### PR TITLE
Add list_categories tool with seed index data

### DIFF
--- a/data/index.json
+++ b/data/index.json
@@ -1,0 +1,94 @@
+{
+  "offers": [
+    {
+      "vendor": "Vercel",
+      "category": "Cloud Hosting",
+      "description": "Free tier for frontend deployments with serverless functions",
+      "tier": "Hobby",
+      "url": "https://vercel.com/pricing",
+      "tags": ["hosting", "serverless", "frontend", "jamstack"],
+      "verifiedDate": "2026-02-18"
+    },
+    {
+      "vendor": "PlanetScale",
+      "category": "Databases",
+      "description": "Serverless MySQL with generous free tier — 1 database, 1B row reads/mo",
+      "tier": "Hobby",
+      "url": "https://planetscale.com/pricing",
+      "tags": ["database", "mysql", "serverless"],
+      "verifiedDate": "2026-02-18"
+    },
+    {
+      "vendor": "Supabase",
+      "category": "Databases",
+      "description": "Open source Firebase alternative with free tier — Postgres, Auth, Storage, Realtime",
+      "tier": "Free",
+      "url": "https://supabase.com/pricing",
+      "tags": ["database", "postgres", "auth", "storage", "realtime", "baas"],
+      "verifiedDate": "2026-02-18"
+    },
+    {
+      "vendor": "GitHub Actions",
+      "category": "CI/CD",
+      "description": "Free CI/CD for public repos, 2000 min/mo for private repos",
+      "tier": "Free",
+      "url": "https://github.com/pricing",
+      "tags": ["ci", "cd", "automation", "github"],
+      "verifiedDate": "2026-02-18"
+    },
+    {
+      "vendor": "Sentry",
+      "category": "Monitoring",
+      "description": "Error tracking and performance monitoring — 5K errors free/mo",
+      "tier": "Developer",
+      "url": "https://sentry.io/pricing/",
+      "tags": ["monitoring", "errors", "performance", "observability"],
+      "verifiedDate": "2026-02-18"
+    },
+    {
+      "vendor": "Clerk",
+      "category": "Auth",
+      "description": "Drop-in auth with 10K monthly active users free",
+      "tier": "Free",
+      "url": "https://clerk.com/pricing",
+      "tags": ["auth", "authentication", "identity", "users"],
+      "verifiedDate": "2026-02-18"
+    },
+    {
+      "vendor": "Resend",
+      "category": "Email",
+      "description": "Developer-first email API — 3K emails/mo free",
+      "tier": "Free",
+      "url": "https://resend.com/pricing",
+      "tags": ["email", "api", "transactional"],
+      "verifiedDate": "2026-02-18"
+    },
+    {
+      "vendor": "Render",
+      "category": "Cloud Hosting",
+      "description": "Free tier for static sites and web services with auto-deploy from Git",
+      "tier": "Free",
+      "url": "https://render.com/pricing",
+      "tags": ["hosting", "paas", "deployment", "docker"],
+      "verifiedDate": "2026-02-18"
+    },
+    {
+      "vendor": "Neon",
+      "category": "Databases",
+      "description": "Serverless Postgres with branching — free tier includes 0.5 GB storage",
+      "tier": "Free",
+      "url": "https://neon.tech/pricing",
+      "tags": ["database", "postgres", "serverless", "branching"],
+      "verifiedDate": "2026-02-18"
+    },
+    {
+      "vendor": "Cloudflare Workers",
+      "category": "Cloud Hosting",
+      "description": "Edge compute with 100K requests/day free",
+      "tier": "Free",
+      "url": "https://developers.cloudflare.com/workers/platform/pricing/",
+      "tags": ["edge", "serverless", "hosting", "workers"],
+      "verifiedDate": "2026-02-18"
+    }
+  ]
+}

--- a/src/data.ts
+++ b/src/data.ts
@@ -1,0 +1,34 @@
+import fs from "node:fs";
+import path from "node:path";
+import type { Offer, OfferIndex } from "./types.js";
+
+const INDEX_PATH = path.join(__dirname, "..", "data", "index.json");
+
+let cachedOffers: Offer[] | null = null;
+
+export function loadOffers(): Offer[] {
+  if (cachedOffers) return cachedOffers;
+
+  if (!fs.existsSync(INDEX_PATH)) {
+    cachedOffers = [];
+    return cachedOffers;
+  }
+
+  const raw = fs.readFileSync(INDEX_PATH, "utf-8");
+  const data: OfferIndex = JSON.parse(raw);
+  cachedOffers = data.offers ?? [];
+  return cachedOffers;
+}
+
+export function getCategories(): { name: string; count: number }[] {
+  const offers = loadOffers();
+  const categoryMap = new Map<string, number>();
+
+  for (const offer of offers) {
+    categoryMap.set(offer.category, (categoryMap.get(offer.category) ?? 0) + 1);
+  }
+
+  return Array.from(categoryMap.entries())
+    .map(([name, count]) => ({ name, count }))
+    .sort((a, b) => a.name.localeCompare(b.name));
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,10 +1,30 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { getCategories } from "./data.js";
 
 const server = new McpServer({
   name: "agentdeals",
   version: "0.1.0",
 });
+
+server.registerTool(
+  "list_categories",
+  {
+    description:
+      "List available categories of developer tool offers (cloud hosting, databases, CI/CD, etc.)",
+  },
+  async () => {
+    const categories = getCategories();
+    return {
+      content: [
+        {
+          type: "text" as const,
+          text: JSON.stringify(categories, null, 2),
+        },
+      ],
+    };
+  }
+);
 
 async function main() {
   const transport = new StdioServerTransport();

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,13 @@
+export interface Offer {
+  vendor: string;
+  category: string;
+  description: string;
+  tier: string;
+  url: string;
+  tags: string[];
+  verifiedDate: string;
+}
+
+export interface OfferIndex {
+  offers: Offer[];
+}

--- a/test/categories.test.ts
+++ b/test/categories.test.ts
@@ -1,0 +1,101 @@
+import { describe, it } from "node:test";
+import assert from "node:assert";
+import { spawn } from "node:child_process";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+function sendMcpMessages(
+  serverProcess: ReturnType<typeof spawn>,
+  messages: object[]
+): Promise<object[]> {
+  return new Promise((resolve, reject) => {
+    const timeout = setTimeout(() => reject(new Error("Timeout")), 5000);
+    const responses: object[] = [];
+    let buffer = "";
+    const expectedResponses = messages.filter(
+      (m: any) => m.id !== undefined
+    ).length;
+
+    const onData = (data: Buffer) => {
+      buffer += data.toString();
+      const lines = buffer.split("\n");
+      buffer = lines.pop() ?? "";
+      for (const line of lines) {
+        if (line.trim()) {
+          try {
+            responses.push(JSON.parse(line.trim()));
+            if (responses.length >= expectedResponses) {
+              clearTimeout(timeout);
+              serverProcess.stdout!.off("data", onData);
+              resolve(responses);
+            }
+          } catch {
+            // not valid JSON yet
+          }
+        }
+      }
+    };
+
+    serverProcess.stdout!.on("data", onData);
+    for (const msg of messages) {
+      serverProcess.stdin!.write(JSON.stringify(msg) + "\n");
+    }
+  });
+}
+
+describe("list_categories tool", () => {
+  it("returns categories from index data", async () => {
+    const serverPath = path.join(__dirname, "..", "dist", "index.js");
+    const proc = spawn("node", [serverPath], {
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+
+    try {
+      const responses = (await sendMcpMessages(proc, [
+        {
+          jsonrpc: "2.0",
+          id: 1,
+          method: "initialize",
+          params: {
+            protocolVersion: "2024-11-05",
+            capabilities: {},
+            clientInfo: { name: "test-client", version: "1.0.0" },
+          },
+        },
+        { jsonrpc: "2.0", method: "notifications/initialized" },
+        {
+          jsonrpc: "2.0",
+          id: 2,
+          method: "tools/call",
+          params: { name: "list_categories", arguments: {} },
+        },
+      ])) as any[];
+
+      const toolResponse = responses.find((r: any) => r.id === 2) as any;
+      assert.ok(toolResponse.result);
+      assert.ok(toolResponse.result.content);
+      assert.strictEqual(toolResponse.result.content.length, 1);
+      assert.strictEqual(toolResponse.result.content[0].type, "text");
+
+      const categories = JSON.parse(toolResponse.result.content[0].text);
+      assert.ok(Array.isArray(categories));
+      assert.ok(categories.length > 0);
+
+      // Each category should have name and count
+      for (const cat of categories) {
+        assert.ok(typeof cat.name === "string");
+        assert.ok(typeof cat.count === "number");
+        assert.ok(cat.count > 0);
+      }
+
+      // Verify categories are sorted alphabetically
+      const names = categories.map((c: any) => c.name);
+      const sorted = [...names].sort();
+      assert.deepStrictEqual(names, sorted);
+    } finally {
+      proc.kill();
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- Added `list_categories` MCP tool that returns categories derived from index data
- Created seed data (`data/index.json`) with 10 real vendor offers across 6 categories
- Added data loading module (`src/data.ts`) and TypeScript types (`src/types.ts`)
- Categories are sorted alphabetically with offer counts
- Works with empty index (returns empty list)

Closes #2

## Test plan
- [x] `npm run build` compiles cleanly
- [x] `list_categories` returns all categories from index data
- [x] Categories include name and count fields
- [x] Categories are sorted alphabetically
- [x] `npm test` passes (2 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)