### PR TITLE
Prepare for MCP registry submission

### DIFF
--- a/data/index.json
+++ b/data/index.json
@@ -10,15 +10,6 @@
       "verifiedDate": "2026-02-18"
     },
     {
-      "vendor": "PlanetScale",
-      "category": "Databases",
-      "description": "Serverless MySQL with generous free tier — 1 database, 1B row reads/mo",
-      "tier": "Hobby",
-      "url": "https://planetscale.com/pricing",
-      "tags": ["database", "mysql", "serverless"],
-      "verifiedDate": "2026-02-18"
-    },
-    {
       "vendor": "Supabase",
       "category": "Databases",
       "description": "Open source Firebase alternative with free tier — Postgres, Auth, Storage, Realtime",
@@ -48,7 +39,7 @@
     {
       "vendor": "Clerk",
       "category": "Auth",
-      "description": "Drop-in auth with 10K monthly active users free",
+      "description": "Drop-in auth with 50K monthly active users free, unlimited apps",
       "tier": "Free",
       "url": "https://clerk.com/pricing",
       "tags": ["auth", "authentication", "identity", "users"],
@@ -75,7 +66,7 @@
     {
       "vendor": "Neon",
       "category": "Databases",
-      "description": "Serverless Postgres with branching — free tier includes 0.5 GB storage",
+      "description": "Serverless Postgres with branching — free tier includes 100 CU-hours/month, 0.5 GB storage",
       "tier": "Free",
       "url": "https://neon.tech/pricing",
       "tags": ["database", "postgres", "serverless", "branching"],

--- a/glama.json
+++ b/glama.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://glama.ai/mcp/schemas/server.json",
+  "maintainers": ["robhunter"]
+}

--- a/package.json
+++ b/package.json
@@ -4,6 +4,28 @@
   "description": "MCP server aggregating developer tool deals, free tiers, and startup programs",
   "type": "module",
   "main": "dist/index.js",
+  "bin": {
+    "agentdeals": "dist/index.js"
+  },
+  "keywords": [
+    "mcp",
+    "developer-tools",
+    "deals",
+    "free-tier",
+    "startup-programs",
+    "model-context-protocol"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/robhunter/agentdeals"
+  },
+  "license": "MIT",
+  "author": "Rob Hunter",
+  "mcpName": "io.github.robhunter/agentdeals",
+  "files": [
+    "dist",
+    "data"
+  ],
   "scripts": {
     "build": "tsc",
     "start": "node dist/index.js",

--- a/server.json
+++ b/server.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.robhunter/agentdeals",
+  "description": "MCP server aggregating developer infrastructure deals, free tiers, and startup programs",
+  "version": "0.1.0",
+  "repository": {
+    "url": "https://github.com/robhunter/agentdeals",
+    "source": "github"
+  },
+  "packages": [
+    {
+      "registryType": "npm",
+      "registryBaseUrl": "https://registry.npmjs.org",
+      "identifier": "agentdeals",
+      "version": "0.1.0",
+      "transport": { "type": "stdio" }
+    }
+  ],
+  "remotes": [
+    {
+      "transportType": "streamableHttp",
+      "url": "https://agentdeals-production.up.railway.app/mcp"
+    }
+  ]
+}

--- a/smithery.yaml
+++ b/smithery.yaml
@@ -1,0 +1,8 @@
+startCommand:
+  type: stdio
+  configSchema:
+    type: object
+    properties: {}
+  commandFunction:
+    |-
+    (config) => ({ command: 'node', args: ['dist/index.js'], env: {} })

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
+#!/usr/bin/env node
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { createServer } from "./server.js";
 


### PR DESCRIPTION
## Summary

- Removed stale PlanetScale entry (no free tier since April 2024)
- Updated Clerk entry to reflect 50K MAUs free (Feb 2026 expansion)
- Updated Neon entry to reflect improved free tier (100 CU-hours/month)
- Added npm publishing fields to package.json: `bin`, `keywords`, `repository`, `license`, `author`, `mcpName`, `files`
- Added shebang to `src/index.ts` for the `bin` entry point
- Created `server.json` manifest for official MCP registry (with npm package and streamable-http remote)
- Created `glama.json` for Glama.ai auto-indexing
- Created `smithery.yaml` for Smithery registry

## Remaining manual step

npm publish requires authentication. Run `npm publish` after merging to publish the package — this is required before submitting to the official MCP registry via `mcp-publisher publish`.

## Test plan

- [x] All 13 existing tests pass
- [x] Build succeeds with no errors
- [x] PlanetScale entry removed from `data/index.json`
- [x] `server.json` schema matches official MCP registry spec
- [x] `package.json` has `mcpName` field for registry verification

Refs #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)