### PR TITLE
Fix multi-session HTTP transport

### DIFF
--- a/src/serve.ts
+++ b/src/serve.ts
@@ -5,32 +5,92 @@ import { createServer } from "./server.js";
 
 const PORT = parseInt(process.env.PORT ?? "3000", 10);
 
-const mcpServer = createServer();
+// Map of session ID → transport for multi-session support
+const sessions = new Map<string, StreamableHTTPServerTransport>();
 
-const transport = new StreamableHTTPServerTransport({
-  sessionIdGenerator: () => randomUUID(),
-});
+function isInitializeRequest(body: unknown): boolean {
+  if (Array.isArray(body)) {
+    return body.some((msg) => msg?.method === "initialize");
+  }
+  return (body as { method?: string })?.method === "initialize";
+}
 
 const httpServer = createHttpServer(async (req, res) => {
   const url = new URL(req.url ?? "/", `http://localhost:${PORT}`);
 
   if (url.pathname === "/mcp") {
-    // For POST requests, parse the JSON body
     if (req.method === "POST") {
       let body = "";
       for await (const chunk of req) {
         body += chunk;
       }
+
+      let parsedBody: unknown;
       try {
-        const parsedBody = JSON.parse(body);
-        await transport.handleRequest(req, res, parsedBody);
+        parsedBody = JSON.parse(body);
       } catch {
         res.writeHead(400, { "Content-Type": "application/json" });
         res.end(JSON.stringify({ error: "Invalid JSON body" }));
+        return;
+      }
+
+      const sessionId = req.headers["mcp-session-id"] as string | undefined;
+
+      if (sessionId && sessions.has(sessionId)) {
+        // Existing session — route to its transport
+        const transport = sessions.get(sessionId)!;
+        await transport.handleRequest(req, res, parsedBody);
+      } else if (!sessionId && isInitializeRequest(parsedBody)) {
+        // New session — create transport + server
+        const transport = new StreamableHTTPServerTransport({
+          sessionIdGenerator: () => randomUUID(),
+          onsessioninitialized: (sid) => {
+            sessions.set(sid, transport);
+          },
+        });
+
+        transport.onclose = () => {
+          const sid = transport.sessionId;
+          if (sid) {
+            sessions.delete(sid);
+          }
+        };
+
+        const mcpServer = createServer();
+        await mcpServer.connect(transport);
+        await transport.handleRequest(req, res, parsedBody);
+      } else {
+        // Invalid: has session ID but unknown, or missing session ID on non-init request
+        res.writeHead(400, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({
+          jsonrpc: "2.0",
+          error: { code: -32600, message: "Bad Request: No valid session. Send an initialize request first." },
+          id: null,
+        }));
+      }
+    } else if (req.method === "GET") {
+      // SSE stream — route to existing session
+      const sessionId = req.headers["mcp-session-id"] as string | undefined;
+      if (sessionId && sessions.has(sessionId)) {
+        await sessions.get(sessionId)!.handleRequest(req, res);
+      } else {
+        res.writeHead(400, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({ error: "Invalid or missing session ID" }));
+      }
+    } else if (req.method === "DELETE") {
+      // Session termination
+      const sessionId = req.headers["mcp-session-id"] as string | undefined;
+      if (sessionId && sessions.has(sessionId)) {
+        const transport = sessions.get(sessionId)!;
+        await transport.handleRequest(req, res);
+        sessions.delete(sessionId);
+      } else {
+        res.writeHead(404, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({ error: "Session not found" }));
       }
     } else {
-      // GET (SSE) and DELETE (session termination)
-      await transport.handleRequest(req, res);
+      res.writeHead(405, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ error: "Method not allowed" }));
     }
   } else if (url.pathname === "/health") {
     res.writeHead(200, { "Content-Type": "application/json" });
@@ -41,14 +101,6 @@ const httpServer = createHttpServer(async (req, res) => {
   }
 });
 
-async function main() {
-  await mcpServer.connect(transport);
-  httpServer.listen(PORT, () => {
-    console.error(`agentdeals MCP server running on http://localhost:${PORT}/mcp`);
-  });
-}
-
-main().catch((error) => {
-  console.error("Server error:", error);
-  process.exit(1);
+httpServer.listen(PORT, () => {
+  console.error(`agentdeals MCP server running on http://localhost:${PORT}/mcp`);
 });


### PR DESCRIPTION
## Summary

- Rewrites `serve.ts` to create a new `Server` + `StreamableHTTPServerTransport` per session instead of sharing one global instance
- Routes requests to the correct session by `Mcp-Session-Id` header
- Cleans up sessions on `DELETE /mcp` and transport close
- Adds test verifying two concurrent clients can initialize and make tool calls independently

## Technical details

The previous implementation created a single `mcpServer` and `transport` at startup, then called `mcpServer.connect(transport)` once. This meant only one MCP client could initialize — subsequent clients got "Server already initialized".

The fix follows the MCP SDK's recommended pattern: each `initialize` request creates a fresh transport + server pair, stored in a `Map<string, Transport>` by session ID. Subsequent requests with that session ID are routed to the existing transport.

## Test plan

- [x] All 14 tests pass (13 existing + 1 new concurrent session test)
- [x] E2E verified: two `curl` clients both get different session IDs and successful initialize responses
- [x] Health endpoint still works without session

Refs #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)