### PR TITLE
Add public README with connection instructions

### DIFF
--- a/AGENT_README.md
+++ b/AGENT_README.md
@@ -62,4 +62,4 @@ Endpoints:
 
 ## Current Status
 
-MCP server is functional with stdio and HTTP transports. 13 passing tests. Issues #7 and #8 complete.
+MCP server is functional with stdio and HTTP transports. 31 vendor entries across 11 categories. 14 passing tests. Multi-session HTTP support. Registry manifests in place (server.json, glama.json, smithery.yaml).

--- a/README.md
+++ b/README.md
@@ -1,0 +1,117 @@
+# AgentDeals
+
+An MCP server that aggregates free tiers, startup credits, and developer tool deals — so your AI agent (or you) can find the best infrastructure offers without leaving the workflow.
+
+AgentDeals indexes real, verified pricing data from 31 developer infrastructure vendors across 11 categories. Connect any MCP-compatible client and search deals by keyword or category.
+
+## Quick Start — Remote (Recommended)
+
+AgentDeals is hosted and ready to use. Add it to your MCP client config:
+
+**Claude Desktop** (`claude_desktop_config.json`):
+```json
+{
+  "mcpServers": {
+    "agentdeals": {
+      "url": "https://agentdeals-production.up.railway.app/mcp"
+    }
+  }
+}
+```
+
+**Any MCP client** — point to:
+```
+https://agentdeals-production.up.railway.app/mcp
+```
+
+## Quick Start — Local (stdio)
+
+```bash
+git clone https://github.com/robhunter/agentdeals.git
+cd agentdeals
+npm install && npm run build
+npm start
+```
+
+Once published to npm, you'll be able to run:
+```bash
+npx agentdeals
+```
+
+## Available Tools
+
+| Tool | Description |
+|------|-------------|
+| `search_offers` | Search deals by keyword, category, or vendor name. Returns matching offers with pricing details and URLs. |
+| `list_categories` | List all available deal categories (Cloud Hosting, Databases, CI/CD, etc.). |
+
+### search_offers
+
+**Parameters:**
+- `query` (string, optional) — Keyword to search vendor names, descriptions, and tags
+- `category` (string, optional) — Filter to a specific category
+
+### list_categories
+
+No parameters. Returns all categories with offer counts.
+
+## Example
+
+**Request:** Search for free database offers
+```json
+{
+  "method": "tools/call",
+  "params": {
+    "name": "search_offers",
+    "arguments": {
+      "query": "database",
+      "category": "Databases"
+    }
+  }
+}
+```
+
+**Response:**
+```json
+[
+  {
+    "vendor": "Neon",
+    "category": "Databases",
+    "description": "Serverless Postgres with 0.5 GiB storage, 100 CU-hours/month compute on free tier",
+    "tier": "Free",
+    "url": "https://neon.com/pricing",
+    "tags": ["database", "postgres", "serverless"]
+  },
+  {
+    "vendor": "MongoDB Atlas",
+    "category": "Databases",
+    "description": "512 MB shared cluster (M0) free forever, supports replica sets",
+    "tier": "Free",
+    "url": "https://www.mongodb.com/pricing",
+    "tags": ["database", "nosql", "document", "mongodb"]
+  }
+]
+```
+
+## Categories
+
+Auth, CI/CD, Cloud Hosting, Cloud IaaS, Databases, Email, Messaging, Monitoring, Search, Storage, Web Scraping
+
+## Stats
+
+- **31** vendor offers across **11** categories
+- Data verified as of 2026-02-24
+
+## Development
+
+```bash
+npm install          # Install dependencies
+npm run build        # Compile TypeScript
+npm test             # Run tests (14 passing)
+npm run serve        # Run HTTP server (port 3000)
+npm start            # Run stdio server
+```
+
+## License
+
+MIT


### PR DESCRIPTION
## Summary
- Creates `README.md` at repo root with project description, remote/local quick start, available tools, usage example, categories, and stats
- Updates `AGENT_README.md` current status to reflect 31 vendors, 11 categories, 14 tests, multi-session HTTP, and registry manifests

Refs #17

## Test plan
- [x] All 14 existing tests pass
- [x] README includes remote connection URL (`https://agentdeals-production.up.railway.app/mcp`)
- [x] README includes local setup instructions (git clone path)
- [x] README lists both tools with descriptions
- [x] README includes realistic usage example with request/response
- [x] AGENT_README.md status updated