### PR TITLE
Add staleness detection and pricing change monitor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ dist/
 .env.*
 *.log
 .DS_Store
+data/pricing-hashes.json

--- a/package.json
+++ b/package.json
@@ -32,7 +32,9 @@
     "serve": "node dist/serve.js",
     "dev": "ts-node src/index.ts",
     "test": "node --test --test-concurrency 1 test/**/*.test.ts",
-    "lint": "tsc --noEmit"
+    "lint": "tsc --noEmit",
+    "check:staleness": "node scripts/check-staleness.js",
+    "check:pricing": "node scripts/check-pricing-changes.js"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.0.0"

--- a/scripts/check-pricing-changes.js
+++ b/scripts/check-pricing-changes.js
@@ -1,0 +1,155 @@
+#!/usr/bin/env node
+
+import { readFileSync, writeFileSync, existsSync } from "node:fs";
+import { createHash } from "node:crypto";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const HASHES_PATH = resolve(__dirname, "..", "data", "pricing-hashes.json");
+const INDEX_PATH = resolve(__dirname, "..", "data", "index.json");
+const FETCH_TIMEOUT_MS = 15000;
+
+function extractTextContent(html) {
+  // Extract visible text content only — far more stable than hashing full HTML.
+  // Dynamic elements (nonces, hydration data, build hashes, session tokens)
+  // live in tags/attributes, not visible text.
+  let cleaned = html;
+  // Remove entire head section (meta tags, scripts, styles, link tags)
+  cleaned = cleaned.replace(/<head[\s\S]*?<\/head>/gi, "");
+  // Remove script and style tags
+  cleaned = cleaned.replace(/<script[\s\S]*?<\/script>/gi, "");
+  cleaned = cleaned.replace(/<style[\s\S]*?<\/style>/gi, "");
+  // Remove SVG content (icon hashes change)
+  cleaned = cleaned.replace(/<svg[\s\S]*?<\/svg>/gi, "");
+  // Remove all HTML tags, keeping text content
+  cleaned = cleaned.replace(/<[^>]+>/g, " ");
+  // Decode common HTML entities
+  cleaned = cleaned.replace(/&amp;/g, "&").replace(/&lt;/g, "<").replace(/&gt;/g, ">")
+    .replace(/&quot;/g, '"').replace(/&#39;/g, "'").replace(/&nbsp;/g, " ");
+  // Remove remaining HTML entities
+  cleaned = cleaned.replace(/&#?\w+;/g, " ");
+  // Remove hex strings (build hashes, trace IDs) — 8+ hex chars
+  cleaned = cleaned.replace(/\b[0-9a-f]{8,}\b/gi, "");
+  // Remove UUIDs
+  cleaned = cleaned.replace(/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/gi, "");
+  // Remove ISO timestamps and date-time strings
+  cleaned = cleaned.replace(/\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}[^\s]*/g, "");
+  // Remove Unix timestamps (10-13 digits)
+  cleaned = cleaned.replace(/\b\d{10,13}\b/g, "");
+  // Normalize whitespace
+  cleaned = cleaned.replace(/\s+/g, " ").trim();
+  return cleaned;
+}
+
+function hashContent(content) {
+  return createHash("sha256").update(content).digest("hex");
+}
+
+async function fetchPage(url) {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+  try {
+    const res = await fetch(url, {
+      signal: controller.signal,
+      headers: {
+        "User-Agent": "AgentDeals-PricingMonitor/1.0",
+        Accept: "text/html",
+      },
+      redirect: "follow",
+    });
+    if (!res.ok) {
+      throw new Error(`HTTP ${res.status}`);
+    }
+    return await res.text();
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+async function main() {
+  let data;
+  try {
+    data = JSON.parse(readFileSync(INDEX_PATH, "utf-8"));
+  } catch (err) {
+    console.error(`Failed to read index: ${err.message}`);
+    process.exit(2);
+  }
+
+  const offers = data.offers || [];
+  const missingUrl = offers.filter((o) => !o.url);
+  if (missingUrl.length > 0) {
+    console.error(`Warning: ${missingUrl.length} entries missing url field:`);
+    for (const o of missingUrl) {
+      console.error(`  - ${o.vendor}`);
+    }
+  }
+
+  // Load existing hashes
+  let previousHashes = {};
+  const isBaseline = !existsSync(HASHES_PATH);
+  if (!isBaseline) {
+    try {
+      previousHashes = JSON.parse(readFileSync(HASHES_PATH, "utf-8"));
+    } catch {
+      console.error("Warning: Could not parse existing hashes file, treating as baseline run.");
+    }
+  }
+
+  const currentHashes = {};
+  const changed = [];
+  const errors = [];
+
+  console.log(`Checking ${offers.length} vendor pricing pages...\n`);
+
+  for (const offer of offers) {
+    if (!offer.url) continue;
+
+    process.stdout.write(`  ${offer.vendor}... `);
+    try {
+      const html = await fetchPage(offer.url);
+      const cleaned = extractTextContent(html);
+      const hash = hashContent(cleaned);
+      currentHashes[offer.vendor] = { url: offer.url, hash, checkedAt: new Date().toISOString() };
+
+      if (!isBaseline && previousHashes[offer.vendor] && previousHashes[offer.vendor].hash !== hash) {
+        changed.push({ vendor: offer.vendor, url: offer.url });
+        console.log("CHANGED");
+      } else {
+        console.log("ok");
+      }
+    } catch (err) {
+      const reason = err.name === "AbortError" ? "timeout" : err.message;
+      errors.push({ vendor: offer.vendor, url: offer.url, error: reason });
+      currentHashes[offer.vendor] = previousHashes[offer.vendor] || { url: offer.url, hash: null, error: reason };
+      console.log(`ERROR (${reason})`);
+    }
+  }
+
+  // Write updated hashes
+  writeFileSync(HASHES_PATH, JSON.stringify(currentHashes, null, 2) + "\n");
+
+  console.log("");
+  if (isBaseline) {
+    console.log(`Baseline created: ${Object.keys(currentHashes).length} vendors hashed.`);
+    console.log(`Hashes saved to ${HASHES_PATH}`);
+  } else if (changed.length === 0) {
+    console.log("No pricing page changes detected.");
+  } else {
+    console.log(`${changed.length} pricing page(s) changed:\n`);
+    for (const c of changed) {
+      console.log(`  ${c.vendor} — ${c.url}`);
+    }
+  }
+
+  if (errors.length > 0) {
+    console.log(`\n${errors.length} error(s):\n`);
+    for (const e of errors) {
+      console.log(`  ${e.vendor} — ${e.error} (${e.url})`);
+    }
+  }
+
+  process.exit(changed.length > 0 ? 1 : 0);
+}
+
+main();

--- a/scripts/check-staleness.js
+++ b/scripts/check-staleness.js
@@ -1,0 +1,66 @@
+#!/usr/bin/env node
+
+import { readFileSync } from "node:fs";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const DEFAULT_THRESHOLD_DAYS = 30;
+
+export function findStaleEntries(offers, thresholdDays, now = new Date()) {
+  const stale = [];
+  for (const offer of offers) {
+    if (!offer.verifiedDate) {
+      stale.push({ vendor: offer.vendor, category: offer.category, daysSince: Infinity });
+      continue;
+    }
+    const verified = new Date(offer.verifiedDate);
+    const diffMs = now.getTime() - verified.getTime();
+    const diffDays = Math.floor(diffMs / (1000 * 60 * 60 * 24));
+    if (diffDays > thresholdDays) {
+      stale.push({ vendor: offer.vendor, category: offer.category, daysSince: diffDays });
+    }
+  }
+  return stale.sort((a, b) => b.daysSince - a.daysSince);
+}
+
+function main() {
+  const thresholdArg = process.argv[2];
+  const thresholdDays = thresholdArg ? parseInt(thresholdArg, 10) : DEFAULT_THRESHOLD_DAYS;
+
+  if (isNaN(thresholdDays) || thresholdDays < 0) {
+    console.error(`Invalid threshold: ${thresholdArg}. Must be a non-negative integer.`);
+    process.exit(2);
+  }
+
+  const indexPath = resolve(__dirname, "..", "data", "index.json");
+  let data;
+  try {
+    data = JSON.parse(readFileSync(indexPath, "utf-8"));
+  } catch (err) {
+    console.error(`Failed to read index: ${err.message}`);
+    process.exit(2);
+  }
+
+  const offers = data.offers || [];
+  const stale = findStaleEntries(offers, thresholdDays);
+
+  if (stale.length === 0) {
+    console.log(`All ${offers.length} entries verified within ${thresholdDays} days.`);
+    process.exit(0);
+  }
+
+  console.log(`Found ${stale.length} stale entries (threshold: ${thresholdDays} days):\n`);
+  for (const entry of stale) {
+    const days = entry.daysSince === Infinity ? "never verified" : `${entry.daysSince} days ago`;
+    console.log(`  ${entry.vendor} (${entry.category}) — ${days}`);
+  }
+
+  process.exit(1);
+}
+
+// Only run main when executed directly (not imported)
+const isMainModule = process.argv[1] && resolve(process.argv[1]) === resolve(fileURLToPath(import.meta.url));
+if (isMainModule) {
+  main();
+}

--- a/test/staleness.test.ts
+++ b/test/staleness.test.ts
@@ -1,0 +1,73 @@
+import { describe, it } from "node:test";
+import assert from "node:assert";
+
+// Import the exported function from the JS script
+const { findStaleEntries } = await import("../scripts/check-staleness.js");
+
+describe("staleness detection", () => {
+  const now = new Date("2026-03-15T00:00:00Z");
+
+  it("returns empty array when all entries are fresh", () => {
+    const offers = [
+      { vendor: "Vercel", category: "Cloud Hosting", verifiedDate: "2026-03-10" },
+      { vendor: "Render", category: "Cloud Hosting", verifiedDate: "2026-03-01" },
+    ];
+    const stale = findStaleEntries(offers, 30, now);
+    assert.strictEqual(stale.length, 0);
+  });
+
+  it("identifies entries older than threshold", () => {
+    const offers = [
+      { vendor: "Fresh", category: "Hosting", verifiedDate: "2026-03-10" },
+      { vendor: "Stale", category: "Databases", verifiedDate: "2026-01-01" },
+      { vendor: "VeryStale", category: "CI/CD", verifiedDate: "2025-12-01" },
+    ];
+    const stale = findStaleEntries(offers, 30, now);
+    assert.strictEqual(stale.length, 2);
+    assert.strictEqual(stale[0].vendor, "VeryStale");
+    assert.strictEqual(stale[1].vendor, "Stale");
+  });
+
+  it("handles missing verifiedDate as infinitely stale", () => {
+    const offers = [
+      { vendor: "NoDate", category: "Auth" },
+    ];
+    const stale = findStaleEntries(offers, 30, now);
+    assert.strictEqual(stale.length, 1);
+    assert.strictEqual(stale[0].vendor, "NoDate");
+    assert.strictEqual(stale[0].daysSince, Infinity);
+  });
+
+  it("respects configurable threshold", () => {
+    const offers = [
+      { vendor: "A", category: "Hosting", verifiedDate: "2026-03-10" },
+      { vendor: "B", category: "Hosting", verifiedDate: "2026-03-14" },
+    ];
+    // With threshold 2, entries older than 2 days from March 15 are stale
+    // A is 5 days old (stale), B is 1 day old (fresh)
+    const stale = findStaleEntries(offers, 2, now);
+    assert.strictEqual(stale.length, 1);
+    assert.strictEqual(stale[0].vendor, "A");
+    assert.strictEqual(stale[0].daysSince, 5);
+  });
+
+  it("returns entries sorted by staleness descending", () => {
+    const offers = [
+      { vendor: "MedStale", category: "A", verifiedDate: "2026-02-01" },
+      { vendor: "MostStale", category: "B", verifiedDate: "2025-12-01" },
+      { vendor: "LeastStale", category: "C", verifiedDate: "2026-02-10" },
+    ];
+    const stale = findStaleEntries(offers, 30, now);
+    assert.strictEqual(stale[0].vendor, "MostStale");
+    assert.strictEqual(stale[1].vendor, "MedStale");
+    assert.strictEqual(stale[2].vendor, "LeastStale");
+  });
+
+  it("includes correct daysSince calculation", () => {
+    const offers = [
+      { vendor: "Test", category: "X", verifiedDate: "2026-02-13" },
+    ];
+    const stale = findStaleEntries(offers, 0, now);
+    assert.strictEqual(stale[0].daysSince, 30);
+  });
+});


### PR DESCRIPTION
## Summary
- **Staleness detection** (`npm run check:staleness`): scans `data/index.json` for entries with `verifiedDate` older than a configurable threshold (default 30 days). Exits 0 if all fresh, 1 if stale entries found. Accepts optional threshold argument: `npm run check:staleness -- 7`
- **Pricing page change monitor** (`npm run check:pricing`): fetches all vendor pricing pages, extracts text content (stripping HTML, scripts, dynamic elements), hashes it, and compares against a stored baseline. First run creates the baseline; subsequent runs detect changes. Handles network errors gracefully (timeout, HTTP errors).
- 6 new tests for staleness date math, thresholds, sorting, and edge cases
- `data/pricing-hashes.json` gitignored (local state, not committed)
- All 31 entries confirmed to have `url` field

Refs #19

## Test plan
- [x] All 20 tests pass (14 existing + 6 new staleness tests)
- [x] `npm run check:staleness` correctly reports all entries fresh (threshold 30 days)
- [x] `npm run check:staleness -- 0` correctly identifies stale entries and exits 1
- [x] `npm run check:pricing` creates baseline on first run (31 vendors hashed)
- [x] `npm run check:pricing` second run detects no false changes for 30/31 vendors (Render has inherently dynamic text content)
- [x] Both scripts handle errors gracefully
- [x] `data/pricing-hashes.json` is gitignored