### PR TITLE
Fix server.json for MCP registry validation

### DIFF
--- a/server.json
+++ b/server.json
@@ -7,18 +7,9 @@
     "url": "https://github.com/robhunter/agentdeals",
     "source": "github"
   },
-  "packages": [
-    {
-      "registryType": "npm",
-      "registryBaseUrl": "https://registry.npmjs.org",
-      "identifier": "agentdeals",
-      "version": "0.1.0",
-      "transport": { "type": "stdio" }
-    }
-  ],
   "remotes": [
     {
-      "transportType": "streamableHttp",
+      "type": "streamable-http",
       "url": "https://agentdeals-production.up.railway.app/mcp"
     }
   ]


### PR DESCRIPTION
## Summary

- Fixed `remotes` array: `transportType` → `type`, `streamableHttp` → `streamable-http`
- Removed `packages` section (not published on npm, not needed for registry submission)
- Passes `mcp-publisher validate`
- All 21 tests pass

Refs #28