### PR TITLE
Add /.well-known/glama.json route for registry claim

### DIFF
--- a/src/serve.ts
+++ b/src/serve.ts
@@ -125,6 +125,14 @@ const httpServer = createHttpServer(async (req, res) => {
   } else if (url.pathname === "/health") {
     res.writeHead(200, { "Content-Type": "application/json" });
     res.end(JSON.stringify({ status: "ok", sessions: sessions.size }));
+  } else if (url.pathname === "/.well-known/glama.json") {
+    res.writeHead(200, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({
+      "$schema": "https://glama.ai/mcp/schemas/connector.json",
+      "maintainers": [
+        { "email": "rob@robbobobbo.com" }
+      ]
+    }));
   } else {
     res.writeHead(404, { "Content-Type": "application/json" });
     res.end(JSON.stringify({ error: "Not found" }));

--- a/test/http.test.ts
+++ b/test/http.test.ts
@@ -273,6 +273,19 @@ describe("HTTP transport", () => {
     assert.ok(offers.length > 0);
   });
 
+  it("serves /.well-known/glama.json", async () => {
+    proc = await startHttpServer();
+
+    const response = await fetch(`http://localhost:${PORT}/.well-known/glama.json`);
+    assert.strictEqual(response.status, 200);
+    assert.strictEqual(response.headers.get("content-type"), "application/json");
+    const body = await response.json() as any;
+    assert.strictEqual(body["$schema"], "https://glama.ai/mcp/schemas/connector.json");
+    assert.ok(Array.isArray(body.maintainers));
+    assert.strictEqual(body.maintainers.length, 1);
+    assert.strictEqual(body.maintainers[0].email, "rob@robbobobbo.com");
+  });
+
   it("returns 404 for unknown paths", async () => {
     proc = await startHttpServer();
 


### PR DESCRIPTION
## Summary
- Adds `GET /.well-known/glama.json` route to the HTTP server, returning the Glama registry ownership verification payload (`$schema` + maintainer email)
- Adds test verifying the endpoint returns correct status, content-type, and JSON body
- 22 tests passing (was 22 — new test replaces none, net +1 from 21 before rebuild)

**Note for Rob:** The email is `rob@robbobobbo.com` as suggested in the issue. Please confirm this matches your Glama account — update if different.

## Test plan
- [x] `GET /.well-known/glama.json` returns 200 with correct JSON
- [x] Response Content-Type is `application/json`
- [x] Existing routes (`/health`, `/mcp`) still work
- [x] All 22 tests pass

Refs #32

🤖 Generated with [Claude Code](https://claude.com/claude-code)