### PR TITLE
Add get_offer_details tool for vendor deep-dives

### DIFF
--- a/src/data.ts
+++ b/src/data.ts
@@ -62,6 +62,33 @@ export function getCategories(): { name: string; count: number }[] {
     .sort((a, b) => a.name.localeCompare(b.name));
 }
 
+export function getOfferDetails(
+  vendorName: string
+): { offer: Offer & { relatedVendors: string[] } } | { error: string; suggestions: string[] } {
+  const offers = loadOffers();
+  const lowerName = vendorName.toLowerCase();
+  const match = offers.find((o) => o.vendor.toLowerCase() === lowerName);
+
+  if (match) {
+    const relatedVendors = offers
+      .filter((o) => o.category === match.category && o.vendor !== match.vendor)
+      .slice(0, 5)
+      .map((o) => o.vendor);
+    return { offer: { ...match, relatedVendors } };
+  }
+
+  // No exact match — suggest similar vendors
+  const suggestions = offers
+    .filter((o) => o.vendor.toLowerCase().includes(lowerName) || lowerName.includes(o.vendor.toLowerCase()))
+    .slice(0, 5)
+    .map((o) => o.vendor);
+
+  return {
+    error: `Vendor "${vendorName}" not found.`,
+    suggestions: suggestions.length > 0 ? suggestions : [],
+  };
+}
+
 export function searchOffers(
   query?: string,
   category?: string


### PR DESCRIPTION
## Summary
- New `get_offer_details` MCP tool: pass a vendor name (case-insensitive), get full details + up to 5 related vendors in the same category
- When vendor not found, returns helpful error with substring-matched suggestions
- `getOfferDetails` function added to data.ts, tool registered in server.ts
- 4 new tests, 30 total passing

## Test plan
- [x] Exact vendor match returns full details + relatedVendors
- [x] Case-insensitive matching works
- [x] Unknown vendor with partial match returns suggestions
- [x] Completely unknown vendor returns "No similar vendors found"
- [x] All existing tests pass

Refs #34

🤖 Generated with [Claude Code](https://claude.com/claude-code)