### PR TITLE
Add sorting options to search_offers

### DIFF
--- a/src/data.ts
+++ b/src/data.ts
@@ -92,7 +92,8 @@ export function getOfferDetails(
 export function searchOffers(
   query?: string,
   category?: string,
-  eligibilityType?: string
+  eligibilityType?: string,
+  sort?: string
 ): Offer[] {
   let results = loadOffers();
 
@@ -123,6 +124,18 @@ export function searchOffers(
         .toLowerCase();
       return terms.every((term) => searchable.includes(term));
     });
+  }
+
+  if (sort === "vendor") {
+    results = [...results].sort((a, b) => a.vendor.localeCompare(b.vendor));
+  } else if (sort === "category") {
+    results = [...results].sort((a, b) =>
+      a.category.localeCompare(b.category) || a.vendor.localeCompare(b.vendor)
+    );
+  } else if (sort === "newest") {
+    results = [...results].sort((a, b) =>
+      b.verifiedDate.localeCompare(a.verifiedDate)
+    );
   }
 
   return results;

--- a/src/server.ts
+++ b/src/server.ts
@@ -49,13 +49,14 @@ export function createServer(): McpServer {
         query: z.string().optional().describe("Keyword to search for in vendor names, descriptions, and tags"),
         category: z.string().optional().describe("Filter results to a specific category (e.g. 'Databases', 'Cloud Hosting')"),
         eligibility_type: z.enum(["public", "accelerator", "oss", "student", "fintech", "geographic", "enterprise"]).optional().describe("Filter by eligibility type: public, accelerator, oss, student, fintech, geographic, enterprise"),
+        sort: z.enum(["vendor", "category", "newest"]).optional().describe("Sort results: vendor (alphabetical by vendor name), category (by category then vendor), newest (most recently verified first)"),
         limit: z.number().optional().describe("Maximum results to return (default: all results, or 20 when offset is provided)"),
         offset: z.number().optional().describe("Number of results to skip (default: 0)"),
       },
     },
-    async ({ query, category, eligibility_type, limit, offset }) => {
+    async ({ query, category, eligibility_type, sort, limit, offset }) => {
       try {
-        const allResults = searchOffers(query, category, eligibility_type);
+        const allResults = searchOffers(query, category, eligibility_type, sort);
         const total = allResults.length;
         const usePagination = limit !== undefined || offset !== undefined;
         const effectiveOffset = offset ?? 0;


### PR DESCRIPTION
## Summary

- Adds optional `sort` parameter to `search_offers` with three options: `vendor` (A-Z by name), `category` (by category then vendor within), `newest` (most recently verified first)
- Sorting applies after all filters (query, category, eligibility_type) and before pagination (limit/offset)
- Omitting `sort` preserves current index order (backwards compatible)
- 5 new tests covering each sort option, index order preservation, and pagination interaction

Refs #39

## Test plan

- [x] `npm run build` compiles cleanly
- [x] `npm test` — 41/41 tests pass
- [x] All existing tests continue to pass unchanged
- [x] Sorting works correctly with pagination (verified via test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)