### PR TITLE
Fix Glama maintainer email for registry claim

### DIFF
--- a/src/serve.ts
+++ b/src/serve.ts
@@ -130,7 +130,7 @@ const httpServer = createHttpServer(async (req, res) => {
     res.end(JSON.stringify({
       "$schema": "https://glama.ai/mcp/schemas/connector.json",
       "maintainers": [
-        { "email": "rob@robbobobbo.com" }
+        { "email": "rob.v.hunter@gmail.com" }
       ]
     }));
   } else {


### PR DESCRIPTION
## Summary
- Changed `/.well-known/glama.json` maintainer email from `rob@robbobobbo.com` to `rob.v.hunter@gmail.com`
- Logo file (`assets/logo-400.png`) already committed to repo in prior commit

## Test plan
- [x] All 49 existing tests pass
- [x] Email fix verified in source

Refs #44