### PR TITLE
Add HTML landing page at root URL

### DIFF
--- a/test/http.test.ts
+++ b/test/http.test.ts
@@ -287,6 +287,20 @@ describe("HTTP transport", () => {
     assert.strictEqual(body.maintainers[0].email, "rob.v.hunter@gmail.com");
   });
 
+  it("serves landing page at root URL", async () => {
+    proc = await startHttpServer();
+
+    const response = await fetch(`http://localhost:${PORT}/`);
+    assert.strictEqual(response.status, 200);
+    assert.ok(response.headers.get("content-type")?.includes("text/html"));
+    const html = await response.text();
+    assert.ok(html.includes("AgentDeals"));
+    assert.ok(html.includes("search_offers"));
+    assert.ok(html.includes("list_categories"));
+    assert.ok(html.includes("get_offer_details"));
+    assert.ok(html.includes("get_deal_changes"));
+  });
+
   it("returns 404 for unknown paths", async () => {
     proc = await startHttpServer();
 


### PR DESCRIPTION
## Summary

- Serves a self-contained, dark-themed HTML landing page at `GET /`
- Stats bar shows live counts from data files (202 offers, 38 categories, 4 tools, 19 tracked changes)
- Sections: hero, stats, "What is this?", tools list, connection instructions (MCP config snippet), and registry links
- Mobile-responsive, no external dependencies (pure inline HTML/CSS)
- All existing endpoints (`/mcp`, `/health`, `/.well-known/glama.json`) unaffected
- New test verifying landing page serves HTML with correct content

Refs #54

## Test plan

- [x] `GET /` returns 200 with `Content-Type: text/html`
- [x] Page contains project name, description, stats, all 4 tool names, and connection instructions
- [x] All existing endpoints still work (health, glama, mcp, 404 for unknown paths)
- [x] 50 tests passing (was 49)
- [x] E2E verified: started server, curled `/`, confirmed HTML with correct stats

🤖 Generated with [Claude Code](https://claude.com/claude-code)