### PR TITLE
Update Neon and Vercel offers, add Cloudflare startup program

### DIFF
--- a/data/deal_changes.json
+++ b/data/deal_changes.json
@@ -227,6 +227,30 @@
       "source_url": "https://sentry.io/pricing/",
       "category": "Monitoring",
       "alternatives": ["Datadog", "New Relic", "BetterStack"]
+    },
+    {
+      "vendor": "Neon",
+      "change_type": "pricing_restructured",
+      "date": "2026-01-15",
+      "summary": "Moved to fully usage-based pricing model post-Databricks acquisition — free tier storage now per-project, projects increased 10→100, branches capped at 10 per project, Neon Auth added",
+      "previous_state": "Free tier: 0.5 GB total storage, 191.9 compute hours, 10 projects, unlimited branches",
+      "current_state": "Free tier: 0.5 GB per project (up to 5 GB across 100 projects), 100 CU-hours/month per project, 10 branches/project, Neon Auth 60K MAU, auto-scaling up to 2 CU, scale-to-zero",
+      "impact": "medium",
+      "source_url": "https://neon.com/pricing",
+      "category": "Databases",
+      "alternatives": ["Supabase", "CockroachDB", "Turso"]
+    },
+    {
+      "vendor": "Vercel",
+      "change_type": "pricing_restructured",
+      "date": "2026-01-01",
+      "summary": "Pro plan moved to credit-based model ($20/mo credit pool), Hobby plan metrics renamed and restructured — bandwidth→Fast Data Transfer, serverless split into Active CPU + Provisioned Memory, Blob Storage and Image Transformations added",
+      "previous_state": "Hobby: 100 GB bandwidth, 100 GB-hours serverless. Pro: fixed per-resource allocations",
+      "current_state": "Hobby: 100 GB/mo Fast Data Transfer, 4 hrs Active CPU, 360 GB-hrs Provisioned Memory, 1M edge requests, 1 GB Blob Storage, 5K image transformations. Pro: $20/mo credit pool across all resources, SAML SSO and HIPAA included",
+      "impact": "medium",
+      "source_url": "https://vercel.com/pricing",
+      "category": "Cloud Hosting",
+      "alternatives": ["Netlify", "Cloudflare Pages", "Render"]
     }
   ]
 }

--- a/data/index.json
+++ b/data/index.json
@@ -3,7 +3,7 @@
     {
       "vendor": "Vercel",
       "category": "Cloud Hosting",
-      "description": "Free tier for frontend deployments with serverless functions",
+      "description": "Hobby plan with 100 GB/month Fast Data Transfer, 1M function invocations, 4 hrs Active CPU, 360 GB-hrs Provisioned Memory, 1M edge requests, 1 GB Blob Storage, 5K image transformations/month",
       "tier": "Hobby",
       "url": "https://vercel.com/pricing",
       "tags": [
@@ -12,7 +12,7 @@
         "frontend",
         "jamstack"
       ],
-      "verifiedDate": "2026-02-23"
+      "verifiedDate": "2026-02-26"
     },
     {
       "vendor": "Render",
@@ -243,7 +243,7 @@
     {
       "vendor": "Neon",
       "category": "Databases",
-      "description": "Serverless Postgres with branching — free tier includes 100 CU-hours/month, 0.5 GB storage",
+      "description": "Serverless Postgres with branching — free tier includes 100 CU-hours/month per project, 0.5 GB storage per project, up to 100 projects, 10 branches per project, Neon Auth (60K MAU), auto-scaling up to 2 CU, scale-to-zero",
       "tier": "Free",
       "url": "https://neon.com/pricing",
       "tags": [
@@ -252,7 +252,7 @@
         "serverless",
         "branching"
       ],
-      "verifiedDate": "2026-02-24"
+      "verifiedDate": "2026-02-26"
     },
     {
       "vendor": "MongoDB Atlas",
@@ -3048,6 +3048,34 @@
           "Not existing IBM Cloud paying customer"
         ],
         "program": "IBM Cloud for Startups"
+      }
+    },
+    {
+      "vendor": "Cloudflare",
+      "category": "Startup Programs",
+      "description": "Up to $250K in Cloudflare credits across 4 tiers: Bootstrapped ($5K), Up-and-Coming ($25K), Seed-Funded ($100K), High Growth ($250K). Covers Workers, R2, Workers AI, Stream, Durable Objects, and more. Credits expire within 1 year. Max $10K toward R2/Cache Reserve, up to $50K for Workers AI",
+      "tier": "Startup Program",
+      "url": "https://www.cloudflare.com/forstartups/",
+      "tags": [
+        "cloud",
+        "startup credits",
+        "edge",
+        "workers",
+        "cloudflare",
+        "infrastructure"
+      ],
+      "verifiedDate": "2026-02-26",
+      "eligibility": {
+        "type": "accelerator",
+        "conditions": [
+          "Software-based product",
+          "Founded within 5 years",
+          "Bootstrapped: valid matching email",
+          "Up-and-Coming: funding up to $1M, active LinkedIn",
+          "Seed-Funded: $1M-$5M raised, approved VC/accelerator partner",
+          "High Growth: Tier 1 VC/accelerator, or mission-critical AI app, or Workers Launchpad participant"
+        ],
+        "program": "Cloudflare for Startups"
       }
     },
     {

--- a/test/deal-changes.test.ts
+++ b/test/deal-changes.test.ts
@@ -89,7 +89,7 @@ describe("get_deal_changes tool", () => {
 
       assert.ok(Array.isArray(body.changes));
       assert.strictEqual(body.total, body.changes.length);
-      assert.strictEqual(body.total, 19);
+      assert.strictEqual(body.total, 21);
     } finally {
       proc.kill();
     }


### PR DESCRIPTION
## Summary

- Updated **Neon** offer to reflect post-Databricks usage-based pricing: storage now per-project, projects increased 10→100, branches capped at 10, Neon Auth added (60K MAU), auto-scaling up to 2 CU
- Updated **Vercel** Hobby plan with current metric names: bandwidth→Fast Data Transfer, serverless split into Active CPU + Provisioned Memory, Blob Storage (1 GB) and Image Transformations (5K/mo) added
- Added **Cloudflare for Startups** conditional entry: up to $250K across 4 tiers (Bootstrapped $5K, Up-and-Coming $25K, Seed-Funded $100K, High Growth $250K)
- Added `deal_changes` entries for both Neon (restructured) and Vercel (restructured)
- Updated deal_changes test count (19 → 21)

All pricing verified against current vendor pages. 50 tests passing.

Refs #56