### PR TITLE
Track deal changes: Atlassian DC, Docker, DigitalOcean Hatch, Google Startups

### DIFF
--- a/data/deal_changes.json
+++ b/data/deal_changes.json
@@ -251,6 +251,54 @@
       "source_url": "https://vercel.com/pricing",
       "category": "Cloud Hosting",
       "alternatives": ["Netlify", "Cloudflare Pages", "Render"]
+    },
+    {
+      "vendor": "Atlassian",
+      "change_type": "pricing_restructured",
+      "date": "2026-02-17",
+      "summary": "Data Center pricing increased 15-40% across Jira, Confluence, and JSM. New DC licenses end March 30 — cloud mandatory for new customers",
+      "previous_state": "Standard Data Center pricing with Advantaged/legacy discounts",
+      "current_state": "15% standard list increase, 18-40% for legacy Advantaged pricing tiers. No new DC licenses after March 30, 2026. Full DC end-of-life March 2029",
+      "impact": "high",
+      "source_url": "https://www.atlassian.com/licensing/future-pricing",
+      "category": "Developer Tools",
+      "alternatives": ["Linear", "Jira Cloud", "Shortcut"]
+    },
+    {
+      "vendor": "Docker Hub",
+      "change_type": "pricing_restructured",
+      "date": "2024-12-10",
+      "summary": "Docker Pro +80% ($5→$9/mo), Team +67% ($9→$15/mo). Free tier: Build Cloud minutes removed, Scout repos cut 3→1, private repos limited to 1 with 2GB storage",
+      "previous_state": "Pro $5/user/month, Team $9/user/month. Free tier included Build Cloud minutes, 3 Scout repos",
+      "current_state": "Pro $9/user/month, Team $15/user/month. Free: 1 private repo (2GB), 1 Scout repo, no Build Cloud minutes, 40 pulls/hour",
+      "impact": "high",
+      "source_url": "https://www.docker.com/blog/november-2024-updated-plans-announcement/",
+      "category": "Container Registry",
+      "alternatives": ["GitHub Container Registry", "Quay.io", "Podman"]
+    },
+    {
+      "vendor": "DigitalOcean",
+      "change_type": "limits_increased",
+      "date": "2025-01-22",
+      "summary": "Hatch startup program expanded to up to $100K compute credits plus up to 3 months free H100 GPU access for AI/ML startups",
+      "previous_state": "Standard Hatch startup credits program",
+      "current_state": "Up to $100K compute credits (12 months, excludes GPU). Separate GPU benefit: discounted H100 at ~$1.90/hr (vs $3.39 standard) plus up to 3 months free GPU access",
+      "impact": "medium",
+      "source_url": "https://investors.digitalocean.com/news/news-details/2025/DigitalOcean-Announces-New-Benefits-for-Hatch-Startup-Program/default.aspx",
+      "category": "Cloud IaaS",
+      "alternatives": ["AWS Activate", "Google Cloud for Startups", "Azure for Startups"]
+    },
+    {
+      "vendor": "Google Cloud",
+      "change_type": "limits_increased",
+      "date": "2026-01-01",
+      "summary": "Google for Startups Cloud Program now offers up to $350K GCP credits for AI-first startups, plus $10K Anthropic (Claude) partner credits via Model Garden",
+      "previous_state": "Up to $200K GCP credits for standard startups",
+      "current_state": "Scale AI Tier: up to $350K GCP credits ($250K year 1, $100K year 2). Standard: $200K. Partner credits: $10K Anthropic/Claude via Model Garden, Fireworks AI, MongoDB Atlas, CockroachDB, 1yr free GitLab Ultimate",
+      "impact": "high",
+      "source_url": "https://cloud.google.com/startup/ai",
+      "category": "Cloud IaaS",
+      "alternatives": ["AWS Activate", "Azure for Startups", "DigitalOcean Hatch"]
     }
   ]
 }

--- a/test/deal-changes.test.ts
+++ b/test/deal-changes.test.ts
@@ -78,7 +78,7 @@ describe("get_deal_changes tool", () => {
           method: "tools/call",
           params: {
             name: "get_deal_changes",
-            arguments: { since: "2025-01-01" },
+            arguments: { since: "2024-01-01" },
           },
         },
       ])) as any[];
@@ -89,7 +89,7 @@ describe("get_deal_changes tool", () => {
 
       assert.ok(Array.isArray(body.changes));
       assert.strictEqual(body.total, body.changes.length);
-      assert.strictEqual(body.total, 21);
+      assert.strictEqual(body.total, 25);
     } finally {
       proc.kill();
     }


### PR DESCRIPTION
## Summary

Refs #62

- Added 4 new deal change entries to `data/deal_changes.json`, bringing total from 21 to 25
- **Atlassian Data Center**: 15-40% price increase (Feb 17, 2026), DC end-of-life timeline through March 2029
- **Docker Hub**: Pro +80%, Team +67% pricing restructure, free tier reductions (effective Dec 10, 2024 — corrected from issue's "2025-12-01")
- **DigitalOcean Hatch**: Expanded to $100K compute credits + separate H100 GPU benefit (clarified: compute credits do not cover GPU Droplets)
- **Google for Startups Cloud Program**: Expanded to $350K for AI-first startups, $10K Anthropic/Claude partner credits via Model Garden
- Updated test `since` date from 2025-01-01 to 2024-01-01 to include Docker entry (pre-2025)
- All 50 tests pass

### Research corrections
- Docker effective date: 2024-12-10 (not 2025-12-01 as in issue)
- DigitalOcean: $100K compute credits and GPU pricing are separate benefits (not combined)

## Test plan

- [x] All 50 existing tests pass
- [x] Deal changes total count updated 21 → 25
- [x] All 4 entries have required fields (vendor, change_type, date, summary, previous_state, current_state, impact, source_url, category, alternatives)
- [x] Entries verified via web research against vendor announcements