### PR TITLE
Add OG meta tags and meta description to landing page

### DIFF
--- a/src/serve.ts
+++ b/src/serve.ts
@@ -82,6 +82,16 @@ function buildLandingPage(): string {
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>AgentDeals — Developer Infrastructure Deals via MCP</title>
+<meta name="description" content="Free MCP server aggregating ${stats.offers}+ developer infrastructure deals — free tiers, startup credits, and pricing changes across ${stats.categories} categories. Search from any AI agent or browse directly.">
+<meta property="og:title" content="AgentDeals — Developer Infrastructure Deals via MCP">
+<meta property="og:description" content="Free tiers are disappearing. Track ${stats.offers}+ developer deals, startup credits, and pricing changes across ${stats.categories} categories. Browse directly or query via MCP.">
+<meta property="og:type" content="website">
+<meta property="og:url" content="https://agentdeals-production.up.railway.app">
+<meta property="og:image" content="https://raw.githubusercontent.com/robhunter/agentdeals/main/assets/logo-400.png">
+<meta name="twitter:card" content="summary">
+<meta name="twitter:title" content="AgentDeals — Developer Infrastructure Deals via MCP">
+<meta name="twitter:description" content="Track ${stats.offers}+ developer deals, free tiers, startup credits, and pricing changes. Browse directly or query via MCP.">
+<meta name="twitter:image" content="https://raw.githubusercontent.com/robhunter/agentdeals/main/assets/logo-400.png">
 <style>
 *{margin:0;padding:0;box-sizing:border-box}
 body{font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Helvetica,Arial,sans-serif;background:#0d1117;color:#c9d1d9;line-height:1.6}


### PR DESCRIPTION
## Summary
- Added `<meta name="description">` with dynamic offer/category counts
- Added Open Graph tags (`og:title`, `og:description`, `og:type`, `og:url`, `og:image`)
- Added Twitter Card tags (`twitter:card`, `twitter:title`, `twitter:description`, `twitter:image`)
- All meta tags placed in `<head>` before `<style>` block
- Uses dynamic stats (252 offers, 38 categories) from loaded data
- OG image points to existing `assets/logo-400.png` via GitHub raw URL

Refs #72

## Test plan
- [x] All 53 existing tests pass
- [x] E2E verified: meta tags render correctly with dynamic values in served HTML
- [x] Landing page renders correctly (no visual changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)