### PR TITLE
Fix Postman data for March 2026 free tier change

### DIFF
--- a/data/deal_changes.json
+++ b/data/deal_changes.json
@@ -158,14 +158,14 @@
     },
     {
       "vendor": "Postman",
-      "change_type": "free_tier_removed",
+      "change_type": "downgrade",
       "date": "2026-03-01",
-      "summary": "Free team collaboration removed — free plan restricted to single user only",
-      "previous_state": "Free plan supported multiple users in shared workspaces with collection sharing",
-      "current_state": "Free plan = 1 user only. Teams require Basic ($14/user/mo) or higher",
+      "summary": "Free team collaboration removed — free plan restricted to single user only. No shared workspaces or collections on free tier",
+      "previous_state": "Free plan supported up to 3 users in shared workspaces with collection sharing and 25 monitoring calls/month",
+      "current_state": "Free plan = 1 user only. Teams require Basic ($14/user/mo) or higher. Solo plan available for individual paid features",
       "impact": "high",
       "source_url": "https://www.postman.com/pricing/",
-      "category": "Developer Tools",
+      "category": "Testing",
       "alternatives": ["Bruno", "Insomnia", "Hoppscotch", "Apidog"]
     },
     {

--- a/data/index.json
+++ b/data/index.json
@@ -2131,7 +2131,7 @@
     {
       "vendor": "Postman",
       "category": "Testing",
-      "description": "Free for individuals — unlimited collections, API testing, mock servers. Teams: up to 3 users, 25 monitoring calls/month",
+      "description": "Free for 1 user only — collections, API testing, mock servers. Team collaboration removed March 2026. Teams require Basic plan ($14/user/mo) or higher",
       "tier": "Free",
       "url": "https://www.postman.com/pricing/",
       "tags": [
@@ -2140,7 +2140,7 @@
         "api-development",
         "mock-servers"
       ],
-      "verifiedDate": "2026-02-25"
+      "verifiedDate": "2026-03-01"
     },
     {
       "vendor": "Directus",


### PR DESCRIPTION
## Summary

Updates Postman entry to reflect the March 1, 2026 free tier change. The free plan is now single-user only — team collaboration has been removed.

**Changes:**
- **Offer entry**: Description updated from "Teams: up to 3 users" to "Free for 1 user only" with note about March 2026 removal
- **Deal change**: Fixed `change_type` from `free_tier_removed` to `downgrade` (free tier still exists, just reduced), added specific previous_state details, corrected category to `Testing`
- `verifiedDate` updated to `2026-03-01`

**Why PM is making this change:** The Coder has been inactive for 4+ days (last PR: #81, Feb 27). This is a product data accuracy fix, not a code change. Stale Postman data is a launch blocker — our core differentiator is verified, current data.

All 53 tests pass.

Closes #83