### PR TITLE
Add lightweight server-side telemetry

### DIFF
--- a/src/serve.ts
+++ b/src/serve.ts
@@ -6,6 +6,7 @@ import { dirname, join } from "node:path";
 import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
 import { createServer } from "./server.js";
 import { loadOffers, getCategories, searchOffers, loadDealChanges } from "./data.js";
+import { recordApiHit, recordSessionConnect, recordSessionDisconnect, recordLandingPageView, getStats } from "./stats.js";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -42,6 +43,7 @@ setInterval(() => {
       console.error(`Cleaned up idle session ${sid} after ${idleMinutes}m`);
       entry.transport.close?.();
       sessions.delete(sid);
+      recordSessionDisconnect();
     }
   }
 }, CLEANUP_INTERVAL_MS).unref();
@@ -374,6 +376,7 @@ const httpServer = createHttpServer(async (req, res) => {
           sessionIdGenerator: () => randomUUID(),
           onsessioninitialized: (sid) => {
             sessions.set(sid, { transport, lastActivity: Date.now() });
+            recordSessionConnect();
           },
         });
 
@@ -381,6 +384,7 @@ const httpServer = createHttpServer(async (req, res) => {
           const sid = transport.sessionId;
           if (sid) {
             sessions.delete(sid);
+            recordSessionDisconnect();
           }
         };
 
@@ -413,6 +417,7 @@ const httpServer = createHttpServer(async (req, res) => {
         const { transport } = sessions.get(sessionId)!;
         await transport.handleRequest(req, res);
         sessions.delete(sessionId);
+        recordSessionDisconnect();
       } else {
         res.writeHead(404, { "Content-Type": "application/json" });
         res.end(JSON.stringify({ error: "Session not found" }));
@@ -430,7 +435,7 @@ const httpServer = createHttpServer(async (req, res) => {
     res.end(faviconBuffer);
   } else if (url.pathname === "/health") {
     res.writeHead(200, { "Content-Type": "application/json" });
-    res.end(JSON.stringify({ status: "ok", sessions: sessions.size }));
+    res.end(JSON.stringify({ status: "ok", sessions: sessions.size, stats: getStats() }));
   } else if (url.pathname === "/.well-known/glama.json") {
     res.writeHead(200, { "Content-Type": "application/json" });
     res.end(JSON.stringify({
@@ -440,6 +445,7 @@ const httpServer = createHttpServer(async (req, res) => {
       ]
     }));
   } else if (url.pathname === "/api/offers" && req.method === "GET") {
+    recordApiHit("/api/offers");
     const q = url.searchParams.get("q") || undefined;
     const category = url.searchParams.get("category") || undefined;
     const limit = parseInt(url.searchParams.get("limit") ?? "20", 10);
@@ -450,10 +456,12 @@ const httpServer = createHttpServer(async (req, res) => {
     res.writeHead(200, { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" });
     res.end(JSON.stringify({ offers: paged, total }));
   } else if (url.pathname === "/api/categories" && req.method === "GET") {
+    recordApiHit("/api/categories");
     const cats = getCategories();
     res.writeHead(200, { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" });
     res.end(JSON.stringify({ categories: cats }));
   } else if (url.pathname === "/") {
+    recordLandingPageView();
     res.writeHead(200, { "Content-Type": "text/html; charset=utf-8" });
     res.end(landingPageHtml);
   } else {

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,6 +1,7 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import { getCategories, getDealChanges, getOfferDetails, searchOffers } from "./data.js";
+import { recordToolCall } from "./stats.js";
 
 export function createServer(): McpServer {
   const server = new McpServer({
@@ -16,6 +17,7 @@ export function createServer(): McpServer {
     },
     async () => {
       try {
+        recordToolCall("list_categories");
         const categories = getCategories();
         return {
           content: [
@@ -56,6 +58,7 @@ export function createServer(): McpServer {
     },
     async ({ query, category, eligibility_type, sort, limit, offset }) => {
       try {
+        recordToolCall("search_offers");
         const allResults = searchOffers(query, category, eligibility_type, sort);
         const total = allResults.length;
         const usePagination = limit !== undefined || offset !== undefined;
@@ -96,6 +99,7 @@ export function createServer(): McpServer {
     },
     async ({ vendor }) => {
       try {
+        recordToolCall("get_offer_details");
         const result = getOfferDetails(vendor);
         if ("error" in result) {
           const msg = result.suggestions.length > 0
@@ -142,6 +146,7 @@ export function createServer(): McpServer {
     },
     async ({ since, change_type, vendor }) => {
       try {
+        recordToolCall("get_deal_changes");
         const result = getDealChanges(since, change_type, vendor);
         return {
           content: [

--- a/src/stats.ts
+++ b/src/stats.ts
@@ -1,0 +1,68 @@
+// In-memory telemetry counters. Resets on server restart (v1).
+// No PII collected — only aggregate counts and tool-level metrics.
+
+const startedAt = Date.now();
+
+const toolCalls: Record<string, number> = {
+  search_offers: 0,
+  list_categories: 0,
+  get_offer_details: 0,
+  get_deal_changes: 0,
+};
+
+const apiHits: Record<string, number> = {
+  "/api/offers": 0,
+  "/api/categories": 0,
+};
+
+let totalSessions = 0;
+let totalDisconnects = 0;
+let landingPageViews = 0;
+
+export function recordToolCall(tool: string): void {
+  if (tool in toolCalls) {
+    toolCalls[tool]++;
+  }
+}
+
+export function recordApiHit(endpoint: string): void {
+  if (endpoint in apiHits) {
+    apiHits[endpoint]++;
+  }
+}
+
+export function recordSessionConnect(): void {
+  totalSessions++;
+}
+
+export function recordSessionDisconnect(): void {
+  totalDisconnects++;
+}
+
+export function recordLandingPageView(): void {
+  landingPageViews++;
+}
+
+export function getStats(): {
+  uptime_seconds: number;
+  total_tool_calls: number;
+  tool_calls: Record<string, number>;
+  total_api_hits: number;
+  api_hits: Record<string, number>;
+  total_sessions: number;
+  total_disconnects: number;
+  landing_page_views: number;
+} {
+  const totalToolCalls = Object.values(toolCalls).reduce((a, b) => a + b, 0);
+  const totalApiHits = Object.values(apiHits).reduce((a, b) => a + b, 0);
+  return {
+    uptime_seconds: Math.round((Date.now() - startedAt) / 1000),
+    total_tool_calls: totalToolCalls,
+    tool_calls: { ...toolCalls },
+    total_api_hits: totalApiHits,
+    api_hits: { ...apiHits },
+    total_sessions: totalSessions,
+    total_disconnects: totalDisconnects,
+    landing_page_views: landingPageViews,
+  };
+}

--- a/test/http.test.ts
+++ b/test/http.test.ts
@@ -374,6 +374,14 @@ describe("HTTP transport", () => {
     const body0 = await health0.json() as any;
     assert.strictEqual(body0.status, "ok");
     assert.strictEqual(body0.sessions, 0);
+    assert.ok(body0.stats);
+    assert.ok(typeof body0.stats.uptime_seconds === "number");
+    assert.ok(typeof body0.stats.total_tool_calls === "number");
+    assert.ok(typeof body0.stats.total_api_hits === "number");
+    assert.ok(typeof body0.stats.total_sessions === "number");
+    assert.ok(typeof body0.stats.landing_page_views === "number");
+    assert.ok(body0.stats.tool_calls);
+    assert.ok(body0.stats.api_hits);
 
     // Create a session
     await mcpRequest("/mcp", {
@@ -408,5 +416,38 @@ describe("HTTP transport", () => {
     const health2 = await fetch(`http://localhost:${PORT}/health`);
     const body2 = await health2.json() as any;
     assert.strictEqual(body2.sessions, 2);
+
+    // Stats should show 2 sessions connected
+    assert.ok(body2.stats.total_sessions >= 2);
+  });
+
+  it("tracks API hit and landing page stats", async () => {
+    proc = await startHttpServer();
+
+    // Record initial stats
+    const h0 = await fetch(`http://localhost:${PORT}/health`);
+    const s0 = (await h0.json() as any).stats;
+    const initialApiOffers = s0.api_hits["/api/offers"];
+    const initialApiCats = s0.api_hits["/api/categories"];
+    const initialPageViews = s0.landing_page_views;
+
+    // Hit /api/offers twice
+    await fetch(`http://localhost:${PORT}/api/offers?limit=1`);
+    await fetch(`http://localhost:${PORT}/api/offers?q=test&limit=1`);
+
+    // Hit /api/categories once
+    await fetch(`http://localhost:${PORT}/api/categories`);
+
+    // Hit landing page once
+    await fetch(`http://localhost:${PORT}/`);
+
+    // Check stats incremented
+    const h1 = await fetch(`http://localhost:${PORT}/health`);
+    const s1 = (await h1.json() as any).stats;
+
+    assert.strictEqual(s1.api_hits["/api/offers"], initialApiOffers + 2);
+    assert.strictEqual(s1.api_hits["/api/categories"], initialApiCats + 1);
+    assert.strictEqual(s1.landing_page_views, initialPageViews + 1);
+    assert.strictEqual(s1.total_api_hits, s0.total_api_hits + 3);
   });
 });


### PR DESCRIPTION
## Summary

- New `src/stats.ts` module with in-memory counters (resets on restart, v1)
- Tracks MCP tool calls per tool name, REST API hits per endpoint, session connect/disconnect events, and landing page views
- Extended `/health` endpoint with full stats object
- No PII collected — only aggregate counts and tool-level metrics

**Example `/health` response:**
```json
{
  "status": "ok",
  "sessions": 2,
  "stats": {
    "uptime_seconds": 3600,
    "total_tool_calls": 142,
    "tool_calls": { "search_offers": 89, "list_categories": 31, "get_offer_details": 15, "get_deal_changes": 7 },
    "total_api_hits": 56,
    "api_hits": { "/api/offers": 43, "/api/categories": 13 },
    "total_sessions": 23,
    "total_disconnects": 21,
    "landing_page_views": 89
  }
}
```

Refs #89

## Test plan

- [x] All 54 tests pass (53 existing + 1 new)
- [x] New test verifies API hit and landing page view counters increment correctly
- [x] Existing health endpoint test extended to verify stats structure

🤖 Generated with [Claude Code](https://claude.com/claude-code)