### PR TITLE
Redesign landing page: warm dark editorial theme

### DIFF
--- a/src/serve.ts
+++ b/src/serve.ts
@@ -92,150 +92,241 @@ function buildLandingPage(): string {
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<title>AgentDeals — Developer Infrastructure Deals via MCP</title>
-<meta name="description" content="Free MCP server aggregating ${stats.offers}+ developer infrastructure deals — free tiers, startup credits, and pricing changes across ${stats.categories} categories. Search from any AI agent or browse directly.">
-<meta property="og:title" content="AgentDeals — Developer Infrastructure Deals via MCP">
-<meta property="og:description" content="Free tiers are disappearing. Track ${stats.offers}+ developer deals, startup credits, and pricing changes across ${stats.categories} categories. Browse directly or query via MCP.">
+<title>AgentDeals — Pricing Context for AI Agents</title>
+<meta name="description" content="${stats.offers}+ developer infrastructure deals across ${stats.categories} categories. Give your AI agent pricing context for better vendor recommendations, or browse deals directly.">
+<meta property="og:title" content="AgentDeals — Pricing Context for AI Agents">
+<meta property="og:description" content="Your AI recommends tools from memory. Memory doesn't include pricing. ${stats.offers}+ deals across ${stats.categories} categories.">
 <meta property="og:type" content="website">
 <meta property="og:url" content="https://agentdeals-production.up.railway.app">
 <meta property="og:image" content="https://raw.githubusercontent.com/robhunter/agentdeals/main/assets/logo-400.png">
 <meta name="twitter:card" content="summary">
-<meta name="twitter:title" content="AgentDeals — Developer Infrastructure Deals via MCP">
-<meta name="twitter:description" content="Track ${stats.offers}+ developer deals, free tiers, startup credits, and pricing changes. Browse directly or query via MCP.">
+<meta name="twitter:title" content="AgentDeals — Pricing Context for AI Agents">
+<meta name="twitter:description" content="Your AI recommends tools from memory. Memory doesn't include pricing. ${stats.offers}+ deals across ${stats.categories} categories.">
 <meta name="twitter:image" content="https://raw.githubusercontent.com/robhunter/agentdeals/main/assets/logo-400.png">
 <link rel="icon" type="image/png" href="/favicon.png">
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=DM+Serif+Display&family=Inter:wght@400;500;600&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
 <style>
 *{margin:0;padding:0;box-sizing:border-box}
-body{font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Helvetica,Arial,sans-serif;background:#0d1117;color:#c9d1d9;line-height:1.6}
-a{color:#58a6ff;text-decoration:none}
-a:hover{text-decoration:underline}
-.container{max-width:800px;margin:0 auto;padding:2rem 1.5rem}
-.hero{text-align:center;padding:3rem 0 2rem}
-.hero h1{font-size:2.5rem;color:#f0f6fc;margin-bottom:.5rem}
-.hero p{font-size:1.15rem;color:#8b949e;max-width:540px;margin:0 auto}
-.hero .hero-lead{font-size:1.4rem;color:#f85149;font-weight:600;margin-bottom:.4rem}
-.browse-btn{display:inline-block;margin-top:1.2rem;padding:.6rem 1.5rem;background:#1f6feb;color:#fff;border-radius:6px;font-size:1rem;font-weight:500;transition:background .15s}
-.browse-btn:hover{background:#388bfd;text-decoration:none}
-.browse-link{color:#58a6ff}
-.stats{display:flex;justify-content:center;gap:2rem;flex-wrap:wrap;padding:1.5rem 0;border-top:1px solid #21262d;border-bottom:1px solid #21262d;margin:1.5rem 0}
-.stat{text-align:center}
-.stat .num{font-size:1.75rem;font-weight:700;color:#f0f6fc}
-.stat .label{font-size:.8rem;color:#8b949e;text-transform:uppercase;letter-spacing:.05em}
-section{margin:2rem 0}
-section h2{font-size:1.3rem;color:#f0f6fc;margin-bottom:.75rem;border-bottom:1px solid #21262d;padding-bottom:.4rem}
-section p{color:#8b949e;margin-bottom:.75rem}
-.tools{list-style:none}
-.tools li{padding:.6rem 0;border-bottom:1px solid #161b22}
-.tools li:last-child{border-bottom:none}
-.tool-name{font-weight:600;color:#f0f6fc;font-family:SFMono-Regular,Consolas,"Liberation Mono",Menlo,monospace;font-size:.9rem}
-.tool-desc{color:#8b949e;font-size:.9rem}
-pre{background:#161b22;border:1px solid #30363d;border-radius:6px;padding:1rem;overflow-x:auto;font-size:.85rem;color:#c9d1d9;line-height:1.5}
-code{font-family:SFMono-Regular,Consolas,"Liberation Mono",Menlo,monospace}
-.links{display:flex;gap:1.5rem;flex-wrap:wrap;margin-top:.5rem}
-.link-btn{display:inline-block;padding:.5rem 1rem;border:1px solid #30363d;border-radius:6px;color:#c9d1d9;font-size:.9rem;transition:border-color .15s}
-.link-btn:hover{border-color:#58a6ff;text-decoration:none}
-.change-entry{padding:.75rem 0;border-bottom:1px solid #161b22}
+:root{
+  --bg:#14120b;--bg-elevated:#1c1a12;--bg-card:rgba(28,26,18,0.6);
+  --border:#2a2720;--border-hover:#c8a44e;
+  --text:#e8e0cc;--text-muted:#9e9685;--text-dim:#6b6356;
+  --accent:#c8a44e;--accent-hover:#dbb85e;--accent-glow:rgba(200,164,78,0.15);
+  --serif:'DM Serif Display',Georgia,'Times New Roman',serif;
+  --sans:'Inter',-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;
+  --mono:'JetBrains Mono',SFMono-Regular,Consolas,monospace;
+}
+body{font-family:var(--sans);background:var(--bg);color:var(--text);line-height:1.6;position:relative}
+body::before{content:'';position:fixed;inset:0;background:url("data:image/svg+xml,%3Csvg viewBox='0 0 256 256' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)' opacity='0.03'/%3E%3C/svg%3E");pointer-events:none;z-index:0}
+a{color:var(--accent);text-decoration:none}
+a:hover{color:var(--accent-hover);text-decoration:underline}
+.container{max-width:960px;margin:0 auto;padding:0 1.5rem;position:relative;z-index:1}
+
+/* Hero */
+.hero{text-align:center;padding:5rem 0 3rem}
+.hero-label{display:inline-block;font-family:var(--mono);font-size:.75rem;font-weight:500;color:var(--accent);text-transform:uppercase;letter-spacing:.15em;border:1px solid var(--border);border-radius:20px;padding:.35rem 1rem;margin-bottom:1.5rem;background:var(--accent-glow)}
+.hero h1{font-family:var(--serif);font-size:3.5rem;color:var(--text);line-height:1.1;margin-bottom:1rem;letter-spacing:-.02em}
+.hero h1 em{font-style:italic;color:var(--accent)}
+.hero-sub{font-size:1.15rem;color:var(--text-muted);max-width:520px;margin:0 auto 2rem;line-height:1.7}
+.hero-actions{display:flex;justify-content:center;gap:1rem;flex-wrap:wrap}
+.btn-primary{display:inline-flex;align-items:center;gap:.5rem;padding:.75rem 1.75rem;background:var(--accent);color:var(--bg);border-radius:8px;font-size:.95rem;font-weight:600;transition:all .2s;border:none;cursor:pointer}
+.btn-primary:hover{background:var(--accent-hover);text-decoration:none;transform:translateY(-1px);box-shadow:0 4px 20px rgba(200,164,78,0.3)}
+.btn-secondary{display:inline-flex;align-items:center;gap:.5rem;padding:.75rem 1.75rem;background:transparent;color:var(--text);border-radius:8px;font-size:.95rem;font-weight:500;transition:all .2s;border:1px solid var(--border)}
+.btn-secondary:hover{border-color:var(--accent);color:var(--accent);text-decoration:none}
+
+/* Stats bar */
+.stats-bar{display:grid;grid-template-columns:repeat(3,1fr);border:1px solid var(--border);border-radius:12px;overflow:hidden;margin:0 auto 4rem;max-width:640px;background:var(--bg-card);backdrop-filter:blur(12px)}
+.stat-item{text-align:center;padding:1.25rem 1rem;position:relative}
+.stat-item+.stat-item::before{content:'';position:absolute;left:0;top:20%;height:60%;width:1px;background:var(--border)}
+.stat-num{font-family:var(--mono);font-size:1.75rem;font-weight:500;color:var(--text);letter-spacing:-.02em}
+.stat-label{font-size:.75rem;color:var(--text-dim);text-transform:uppercase;letter-spacing:.1em;margin-top:.15rem}
+
+/* Section divider */
+.divider{width:100%;height:1px;background:var(--border);margin:0}
+.wavy-divider{width:100%;overflow:hidden;line-height:0;margin:0}
+.wavy-divider svg{display:block;width:100%;height:40px}
+
+/* Sections */
+.section{padding:4rem 0}
+.section-label{font-family:var(--mono);font-size:.7rem;font-weight:500;color:var(--accent);text-transform:uppercase;letter-spacing:.2em;margin-bottom:.75rem}
+.section h2{font-family:var(--serif);font-size:2rem;color:var(--text);margin-bottom:1rem;letter-spacing:-.01em}
+.section p{color:var(--text-muted);margin-bottom:1rem;max-width:600px}
+
+/* Problem / solution */
+.problem-text{font-family:var(--serif);font-size:1.35rem;color:var(--text-muted);line-height:1.6;max-width:600px;margin-bottom:1rem}
+.problem-text strong{color:var(--text)}
+
+/* How it works cards */
+.how-grid{display:grid;grid-template-columns:repeat(3,1fr);gap:1rem;margin-top:2rem}
+.how-card{background:var(--bg-card);backdrop-filter:blur(12px);border:1px solid var(--border);border-radius:12px;padding:1.5rem;transition:border-color .2s}
+.how-card:hover{border-color:var(--accent)}
+.how-card-icon{font-family:var(--mono);font-size:.75rem;color:var(--accent);background:var(--accent-glow);display:inline-block;padding:.3rem .7rem;border-radius:6px;margin-bottom:.75rem;border:1px solid rgba(200,164,78,0.2)}
+.how-card h3{font-family:var(--serif);font-size:1.1rem;color:var(--text);margin-bottom:.5rem}
+.how-card p{font-size:.9rem;color:var(--text-muted);margin-bottom:.75rem}
+.how-card pre{background:var(--bg);border:1px solid var(--border);border-radius:8px;padding:.75rem;font-size:.75rem;color:var(--text-muted);line-height:1.5;overflow-x:auto}
+.how-card code{font-family:var(--mono);font-size:.75rem}
+
+/* Changes */
+.change-entry{padding:.75rem 0;border-bottom:1px solid rgba(42,39,32,0.6)}
 .change-entry:last-child{border-bottom:none}
-.change-header{display:flex;align-items:center;gap:.5rem;flex-wrap:wrap;margin-bottom:.25rem}
-.change-badge{display:inline-block;padding:.15rem .5rem;border-radius:10px;font-size:.7rem;font-weight:600;color:#fff;text-transform:uppercase;letter-spacing:.03em}
-.change-vendor{font-weight:600;color:#f0f6fc;font-size:.9rem}
-.change-date{color:#484f58;font-size:.8rem;margin-left:auto}
-.change-summary{color:#8b949e;font-size:.85rem}
-footer{text-align:center;color:#484f58;font-size:.8rem;padding:2rem 0 1rem;border-top:1px solid #21262d;margin-top:2rem}
-.browse-controls{margin-bottom:1rem}
-.search-input{width:100%;padding:.6rem .8rem;background:#161b22;border:1px solid #30363d;border-radius:6px;color:#c9d1d9;font-size:.9rem;outline:none}
-.search-input:focus{border-color:#58a6ff}
-.search-input::placeholder{color:#484f58}
-.category-pills{display:flex;flex-wrap:wrap;gap:.4rem;margin-top:.6rem}
-.cat-pill{display:inline-block;padding:.2rem .6rem;border-radius:10px;font-size:.75rem;font-weight:500;background:#21262d;color:#8b949e;border:1px solid #30363d;cursor:pointer;transition:all .15s}
-.cat-pill:hover{border-color:#58a6ff;color:#c9d1d9}
-.cat-pill.active{background:#1f6feb;border-color:#1f6feb;color:#fff}
-.deal-cards{display:grid;gap:.75rem;margin-top:.75rem}
-.deal-card{background:#161b22;border:1px solid #21262d;border-radius:6px;padding:.75rem 1rem;cursor:pointer;transition:border-color .15s}
-.deal-card:hover{border-color:#58a6ff}
-.deal-card a.deal-link{display:flex;align-items:center;gap:.3rem;margin-top:.4rem;font-size:.8rem;color:#58a6ff;text-decoration:none}
+.change-header{display:flex;align-items:center;gap:.5rem;flex-wrap:wrap;margin-bottom:.2rem}
+.change-badge{display:inline-block;padding:.15rem .5rem;border-radius:10px;font-size:.65rem;font-weight:600;color:#fff;text-transform:uppercase;letter-spacing:.04em;font-family:var(--mono)}
+.change-vendor{font-weight:600;color:var(--text);font-size:.9rem}
+.change-date{font-family:var(--mono);color:var(--text-dim);font-size:.75rem;margin-left:auto}
+.change-summary{color:var(--text-muted);font-size:.85rem}
+
+/* Browse */
+.browse-controls{margin-bottom:1.25rem}
+.search-input{width:100%;padding:.75rem 1rem;background:var(--bg-elevated);border:1px solid var(--border);border-radius:10px;color:var(--text);font-family:var(--sans);font-size:.9rem;outline:none;transition:border-color .2s}
+.search-input:focus{border-color:var(--accent);box-shadow:0 0 0 3px var(--accent-glow)}
+.search-input::placeholder{color:var(--text-dim)}
+.category-pills{display:flex;flex-wrap:wrap;gap:.4rem;margin-top:.75rem}
+.cat-pill{display:inline-block;padding:.25rem .7rem;border-radius:20px;font-size:.75rem;font-weight:500;background:transparent;color:var(--text-muted);border:1px solid var(--border);cursor:pointer;transition:all .2s;font-family:var(--sans)}
+.cat-pill:hover{border-color:var(--accent);color:var(--text)}
+.cat-pill.active{background:var(--accent);border-color:var(--accent);color:var(--bg);font-weight:600}
+.deal-cards{display:grid;gap:.75rem;margin-top:1rem}
+.deal-card{background:var(--bg-card);backdrop-filter:blur(12px);border:1px solid var(--border);border-radius:10px;padding:1rem 1.25rem;cursor:pointer;transition:all .2s}
+.deal-card:hover{border-color:var(--accent);transform:translateY(-1px);box-shadow:0 4px 16px rgba(0,0,0,0.3)}
+.deal-card a.deal-link{display:inline-flex;align-items:center;gap:.3rem;margin-top:.5rem;font-size:.8rem;font-family:var(--mono);color:var(--accent);text-decoration:none}
 .deal-card a.deal-link:hover{text-decoration:underline}
-.deal-card-header{display:flex;align-items:center;gap:.5rem;flex-wrap:wrap;margin-bottom:.25rem}
-.deal-vendor{font-weight:600;color:#f0f6fc;font-size:.9rem}
-.deal-cat{display:inline-block;padding:.1rem .45rem;border-radius:8px;font-size:.65rem;font-weight:500;background:#21262d;color:#8b949e;border:1px solid #30363d}
-.deal-tier{font-size:.75rem;color:#58a6ff;margin-left:auto}
-.deal-desc{color:#8b949e;font-size:.83rem}
-.show-more{display:block;width:100%;padding:.5rem;margin-top:.75rem;background:transparent;border:1px solid #30363d;border-radius:6px;color:#58a6ff;font-size:.85rem;cursor:pointer;transition:border-color .15s}
-.show-more:hover{border-color:#58a6ff}
-.browse-status{color:#484f58;font-size:.8rem;margin-top:.5rem}
-@media(max-width:600px){.hero h1{font-size:1.75rem}.stats{gap:1rem}.stat .num{font-size:1.3rem}pre{font-size:.75rem}}
+.deal-card-header{display:flex;align-items:center;gap:.5rem;flex-wrap:wrap;margin-bottom:.3rem}
+.deal-vendor{font-weight:600;color:var(--text);font-size:.95rem}
+.deal-cat{display:inline-block;padding:.15rem .5rem;border-radius:8px;font-size:.65rem;font-weight:500;background:var(--accent-glow);color:var(--accent);border:1px solid rgba(200,164,78,0.2)}
+.deal-tier{font-family:var(--mono);font-size:.75rem;color:var(--accent);margin-left:auto}
+.deal-desc{color:var(--text-muted);font-size:.85rem;line-height:1.5}
+.show-more{display:block;width:100%;padding:.65rem;margin-top:1rem;background:transparent;border:1px solid var(--border);border-radius:10px;color:var(--accent);font-size:.85rem;font-family:var(--sans);font-weight:500;cursor:pointer;transition:all .2s}
+.show-more:hover{border-color:var(--accent);background:var(--accent-glow)}
+.browse-status{color:var(--text-dim);font-size:.8rem;margin-top:.5rem;font-family:var(--mono)}
+
+/* Connect */
+.connect-block{background:var(--bg-card);backdrop-filter:blur(12px);border:1px solid var(--border);border-radius:12px;padding:1.5rem;margin-top:1.5rem}
+.connect-block pre{background:var(--bg);border:1px solid var(--border);border-radius:8px;padding:1rem;overflow-x:auto;font-size:.8rem;color:var(--text-muted);line-height:1.5;margin-top:.75rem}
+.connect-block code{font-family:var(--mono)}
+
+/* Badges row */
+.badges{display:flex;gap:1rem;flex-wrap:wrap;margin-top:1.5rem}
+.badge{display:inline-flex;align-items:center;gap:.5rem;padding:.5rem 1rem;border:1px solid var(--border);border-radius:10px;color:var(--text-muted);font-size:.85rem;transition:all .2s}
+.badge:hover{border-color:var(--accent);color:var(--text);text-decoration:none}
+.badge-dot{width:6px;height:6px;border-radius:50%;background:var(--accent)}
+
+/* Footer */
+footer{text-align:center;color:var(--text-dim);font-size:.8rem;padding:3rem 0 2rem;border-top:1px solid var(--border);margin-top:3rem}
+footer a{color:var(--text-muted)}
+
+/* Responsive */
+@media(max-width:768px){
+  .hero{padding:3rem 0 2rem}
+  .hero h1{font-size:2.25rem}
+  .hero-sub{font-size:1rem}
+  .stats-bar{grid-template-columns:repeat(3,1fr);max-width:100%}
+  .stat-num{font-size:1.3rem}
+  .how-grid{grid-template-columns:1fr}
+  .section{padding:2.5rem 0}
+  .section h2{font-size:1.5rem}
+  .problem-text{font-size:1.1rem}
+  .connect-block pre{font-size:.7rem}
+}
 </style>
 </head>
 <body>
 <div class="container">
+
   <div class="hero">
-    <h1>AgentDeals</h1>
-    <p class="hero-lead">Free tiers are disappearing.</p>
-    <p>Track ${stats.offers}+ developer deals, startup credits, and pricing changes across ${stats.categories} categories. Query from any MCP client &mdash; or <a href="#browse" class="browse-link">browse below</a>.</p>
-    <a href="#browse" class="browse-btn">Browse Deals &darr;</a>
+    <div class="hero-label">MCP Server</div>
+    <h1>Deals for <em>agents.</em></h1>
+    <p class="hero-sub">Your AI recommends tools from memory. Memory doesn't include pricing. AgentDeals gives agents the context to make better infrastructure recommendations.</p>
+    <div class="hero-actions">
+      <a href="#browse" class="btn-primary">Browse ${stats.offers.toLocaleString()}+ deals</a>
+      <a href="#connect" class="btn-secondary">Connect via MCP</a>
+    </div>
   </div>
 
-  <div class="stats">
-    <div class="stat"><div class="num">${stats.offers}</div><div class="label">Offers</div></div>
-    <div class="stat"><div class="num">${stats.categories}</div><div class="label">Categories</div></div>
-    <div class="stat"><div class="num">${stats.tools}</div><div class="label">MCP Tools</div></div>
-    <div class="stat"><div class="num">${stats.dealChanges}</div><div class="label">Tracked Changes</div></div>
+  <div class="stats-bar">
+    <div class="stat-item"><div class="stat-num">${stats.offers.toLocaleString()}</div><div class="stat-label">Deals</div></div>
+    <div class="stat-item"><div class="stat-num">${stats.categories}</div><div class="stat-label">Categories</div></div>
+    <div class="stat-item"><div class="stat-num">${stats.dealChanges}</div><div class="stat-label">Changes Tracked</div></div>
   </div>
 
-  <section>
-    <h2>What is this?</h2>
-    <p>AgentDeals is a remote MCP server that indexes free tiers, startup programs, and promotional offers from developer infrastructure companies. AI coding agents and developers can query it to find relevant deals for their projects.</p>
-    <p>Whether you're looking for a free database, CI/CD minutes, cloud hosting credits, or startup accelerator perks — AgentDeals aggregates them in one place, accessible via any MCP-compatible client.</p>
-  </section>
+  <div class="wavy-divider"><svg viewBox="0 0 1200 40" preserveAspectRatio="none"><path d="M0,20 Q150,0 300,20 T600,20 T900,20 T1200,20 V40 H0 Z" fill="none" stroke="rgba(42,39,32,0.8)" stroke-width="1"/></svg></div>
 
-  <section>
-    <h2>Tools</h2>
-    <ul class="tools">
-      <li><span class="tool-name">search_offers</span><br><span class="tool-desc">Search deals by keyword, category, or vendor. Supports pagination, sorting, and eligibility filtering.</span></li>
-      <li><span class="tool-name">list_categories</span><br><span class="tool-desc">List all deal categories with offer counts.</span></li>
-      <li><span class="tool-name">get_offer_details</span><br><span class="tool-desc">Get full details for a specific vendor, including related vendors in the same category.</span></li>
-      <li><span class="tool-name">get_deal_changes</span><br><span class="tool-desc">Track recent pricing and free tier changes — removals, reductions, increases, and restructures.</span></li>
-    </ul>
-  </section>
+  <div class="section">
+    <div class="section-label">The Problem</div>
+    <p class="problem-text">When Claude Code recommends Railway, it doesn't know <strong>Render has a better free tier</strong>. When it suggests Supabase, it doesn't know <strong>your YC batch gets $100K in AWS credits</strong>.</p>
+    <p class="problem-text">AgentDeals gives your agent <strong>pricing context</strong> &mdash; free tiers, startup credits, and deal changes across ${stats.categories} categories of developer infrastructure.</p>
+  </div>
 
-  <section>
-    <h2>Recent Pricing Changes</h2>
-    <p>Tracked by our <code>get_deal_changes</code> tool — no other deals aggregator monitors these.</p>
+  <div class="divider"></div>
+
+  <div class="section">
+    <div class="section-label">How It Works</div>
+    <h2>Three ways to access</h2>
+    <div class="how-grid">
+      <div class="how-card">
+        <div class="how-card-icon">01</div>
+        <h3>Browse</h3>
+        <p>Search and filter ${stats.offers.toLocaleString()}+ deals directly on this page. No setup required.</p>
+      </div>
+      <div class="how-card">
+        <div class="how-card-icon">02</div>
+        <h3>REST API</h3>
+        <p>Query deals programmatically with search, filtering, and pagination.</p>
+        <pre><code>GET /api/offers?q=database</code></pre>
+      </div>
+      <div class="how-card">
+        <div class="how-card-icon">03</div>
+        <h3>MCP</h3>
+        <p>Connect any MCP client. One line of config.</p>
+        <pre><code>"url": "https://agentdeals-production.up.railway.app/mcp"</code></pre>
+      </div>
+    </div>
+  </div>
+
+  <div class="divider"></div>
+
+  <div class="section">
+    <div class="section-label">Deal Tracker</div>
+    <h2>Recent pricing changes</h2>
+    <p>Free tiers get removed. Limits change. We track it so your agent doesn't recommend dead deals.</p>
 ${buildChangesHtml()}
-  </section>
+  </div>
 
-  <section id="browse">
-    <h2>Browse Deals</h2>
+  <div class="divider"></div>
+
+  <div class="section" id="browse">
+    <div class="section-label">Explore</div>
+    <h2>Browse deals</h2>
     <div class="browse-controls">
-      <input type="text" class="search-input" id="deal-search" placeholder="Search ${stats.offers}+ deals...">
+      <input type="text" class="search-input" id="deal-search" placeholder="Search ${stats.offers.toLocaleString()}+ deals &mdash; try &ldquo;database&rdquo; or &ldquo;hosting&rdquo;">
       <div class="category-pills" id="cat-pills"></div>
     </div>
     <div class="deal-cards" id="deal-cards"></div>
     <button class="show-more" id="show-more" style="display:none">Show more</button>
     <div class="browse-status" id="browse-status"></div>
-  </section>
+  </div>
 
-  <section>
-    <h2>Connect</h2>
-    <p>Add AgentDeals to your MCP client. For Claude Desktop or Cursor, add this to your MCP config:</p>
-    <pre><code>{
+  <div class="divider"></div>
+
+  <div class="section" id="connect">
+    <div class="section-label">Get Started</div>
+    <h2>Connect your agent</h2>
+    <p>Add AgentDeals to Claude Desktop, Cursor, or any MCP client:</p>
+    <div class="connect-block">
+      <pre><code>{
   "mcpServers": {
     "agentdeals": {
       "url": "https://agentdeals-production.up.railway.app/mcp"
     }
   }
 }</code></pre>
-    <p>Or connect directly via the streamable-http endpoint at <code>/mcp</code>.</p>
-  </section>
-
-  <section>
-    <h2>Links</h2>
-    <div class="links">
-      <a class="link-btn" href="https://github.com/robhunter/agentdeals">GitHub</a>
-      <a class="link-btn" href="https://registry.modelcontextprotocol.io/v0.1/servers/io.github.robhunter%2Fagentdeals/versions">MCP Registry</a>
-      <a class="link-btn" href="https://glama.ai/mcp/connectors/io.github.robhunter/agentdeals">Glama Connector</a>
     </div>
-  </section>
+    <div class="badges">
+      <a class="badge" href="https://github.com/robhunter/agentdeals"><span class="badge-dot"></span>GitHub</a>
+      <a class="badge" href="https://registry.modelcontextprotocol.io/v0.1/servers/io.github.robhunter%2Fagentdeals/versions"><span class="badge-dot"></span>MCP Registry</a>
+      <a class="badge" href="https://glama.ai/mcp/connectors/io.github.robhunter/agentdeals"><span class="badge-dot"></span>Glama</a>
+    </div>
+  </div>
 
   <footer>AgentDeals &mdash; open source, built for agents</footer>
 </div>
@@ -261,8 +352,12 @@ ${buildChangesHtml()}
       var o=offers[i];
       var tierLabel=o.eligibility?o.eligibility.type:'free tier';
       var dataUrl=o.url?' data-url="'+escHtml(o.url)+'"':'';
-      html+='<div class="deal-card"'+dataUrl+'><div class="deal-card-header"><span class="deal-vendor">'+escHtml(o.vendor)+'</span><span class="deal-cat">'+escHtml(o.category)+'</span><span class="deal-tier">'+escHtml(tierLabel)+'</span></div><div class="deal-desc">'+escHtml(o.description)+'</div>';
-      if(o.url){html+='<a class="deal-link" href="'+escHtml(o.url)+'" target="_blank" rel="noopener">View Deal &rarr;</a>';}
+      html+='<div class="deal-card"'+dataUrl+'>'
+        +'<div class="deal-card-header"><span class="deal-vendor">'+escHtml(o.vendor)+'</span>'
+        +'<span class="deal-cat">'+escHtml(o.category)+'</span>'
+        +'<span class="deal-tier">'+escHtml(tierLabel)+'</span></div>'
+        +'<div class="deal-desc">'+escHtml(o.description)+'</div>';
+      if(o.url){html+='<a class="deal-link" href="'+escHtml(o.url)+'" target="_blank" rel="noopener">View deal &#8594;</a>';}
       html+='</div>';
     }
     if(append){cardsEl.innerHTML+=html;}else{cardsEl.innerHTML=html;}

--- a/test/http.test.ts
+++ b/test/http.test.ts
@@ -295,13 +295,11 @@ describe("HTTP transport", () => {
     assert.ok(response.headers.get("content-type")?.includes("text/html"));
     const html = await response.text();
     assert.ok(html.includes("AgentDeals"));
-    assert.ok(html.includes("search_offers"));
-    assert.ok(html.includes("list_categories"));
-    assert.ok(html.includes("get_offer_details"));
-    assert.ok(html.includes("get_deal_changes"));
-    assert.ok(html.includes("Browse Deals"), "Landing page should have Browse Deals section");
+    assert.ok(html.includes("Deals for"), "Landing page should have updated hero");
+    assert.ok(html.includes("Browse deals"), "Landing page should have Browse deals section");
     assert.ok(html.includes("deal-search"), "Landing page should have search input");
     assert.ok(html.includes("/api/offers"), "Landing page should fetch from /api/offers");
+    assert.ok(html.includes("DM Serif Display"), "Landing page should use serif display font");
   });
 
   it("GET /api/offers returns offers with pagination", async () => {


### PR DESCRIPTION
## Summary

Refs #98

Complete landing page redesign per Rob's feedback. Replaces the cold GitHub-dark prototype look with a warm dark editorial design.

**Design changes:**
- **New value prop**: "Deals for agents." hero with problem/solution narrative ("Your AI recommends tools from memory. Memory doesn't include pricing.")
- **Warm dark palette**: `#14120b` base with gold accent (`#c8a44e`) replacing cold GitHub navy
- **Typography**: DM Serif Display (headlines), Inter (body), JetBrains Mono (data/stats)
- **Glassmorphic cards** with backdrop-blur for deal cards and how-it-works section
- **Editorial layout**: Section labels in monospace, wavy SVG divider, subtle noise texture overlay
- **"How it works" grid**: Three cards showing Browse / REST API / MCP access paths
- **Stats bar**: Monospace numbers for deals, categories, and changes tracked (removed "MCP Tools" stat per issue guidance)

**What's preserved:**
- All existing deal browser functionality (search, category pills, pagination, clickable cards)
- All REST API routes (`/api/offers`, `/api/categories`, `/health`)
- Full MCP functionality
- Mobile-responsive layout (768px breakpoint)

**What changed:**
- Updated OG/meta tags with new value prop messaging
- Updated test assertions to match new page content

## Test plan

- [x] All 54 tests pass
- [x] Build succeeds
- [x] E2E: Landing page serves correctly at `/`
- [x] E2E: MCP initialize works over HTTP
- [x] E2E: `/api/offers` and `/api/categories` return correct data
- [x] E2E: `/health` endpoint returns stats

🤖 Generated with [Claude Code](https://claude.com/claude-code)