### PR TITLE
Add automated pricing page monitor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ dist/
 *.log
 .DS_Store
 data/pricing-hashes.json
+data/pricing-changes.jsonl
 data/free-for-dev-new.json
 data/startup-deals-new.json
 .cache/

--- a/data/watchlist.json
+++ b/data/watchlist.json
@@ -1,0 +1,25 @@
+{
+  "description": "Vendors monitored for pricing page changes. interval: daily (high-churn) or weekly (stable).",
+  "vendors": [
+    { "vendor": "Vercel", "url": "https://vercel.com/pricing", "interval": "daily" },
+    { "vendor": "Render", "url": "https://render.com/pricing", "interval": "daily" },
+    { "vendor": "Supabase", "url": "https://supabase.com/pricing", "interval": "daily" },
+    { "vendor": "Neon", "url": "https://neon.com/pricing", "interval": "daily" },
+    { "vendor": "Railway", "url": "https://railway.com/pricing", "interval": "daily" },
+    { "vendor": "Netlify", "url": "https://www.netlify.com/pricing/", "interval": "daily" },
+    { "vendor": "Cloudflare Workers", "url": "https://developers.cloudflare.com/workers/platform/pricing/", "interval": "daily" },
+    { "vendor": "DigitalOcean", "url": "https://www.digitalocean.com/pricing", "interval": "daily" },
+    { "vendor": "MongoDB Atlas", "url": "https://www.mongodb.com/pricing", "interval": "daily" },
+    { "vendor": "Firebase", "url": "https://firebase.google.com/pricing", "interval": "daily" },
+    { "vendor": "GitHub Actions", "url": "https://docs.github.com/en/billing/managing-billing-for-github-actions/about-billing-for-github-actions", "interval": "weekly" },
+    { "vendor": "Auth0", "url": "https://auth0.com/pricing", "interval": "daily" },
+    { "vendor": "Postman", "url": "https://www.postman.com/pricing/", "interval": "weekly" },
+    { "vendor": "AWS", "url": "https://aws.amazon.com/free/", "interval": "weekly" },
+    { "vendor": "HCP Terraform", "url": "https://www.hashicorp.com/products/terraform/pricing", "interval": "weekly" },
+    { "vendor": "Sentry", "url": "https://sentry.io/pricing/", "interval": "daily" },
+    { "vendor": "Heroku", "url": "https://www.heroku.com/pricing", "interval": "weekly" },
+    { "vendor": "Cloudflare R2", "url": "https://developers.cloudflare.com/r2/pricing/", "interval": "weekly" },
+    { "vendor": "Twilio SendGrid", "url": "https://sendgrid.com/en-us/pricing", "interval": "weekly" },
+    { "vendor": "Algolia", "url": "https://www.algolia.com/pricing/", "interval": "weekly" }
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "lint": "tsc --noEmit",
     "check:staleness": "node scripts/check-staleness.js",
     "check:pricing": "node scripts/check-pricing-changes.js",
+    "monitor:pricing": "node scripts/monitor-pricing.js",
     "ingest:free-for-dev": "node scripts/parse-free-for-dev.ts",
     "ingest:startup-deals": "node scripts/ingest-startup-deals.ts"
   },

--- a/scripts/monitor-pricing.js
+++ b/scripts/monitor-pricing.js
@@ -1,0 +1,209 @@
+#!/usr/bin/env node
+
+/**
+ * Automated pricing page monitor for high-churn vendors.
+ *
+ * Reads data/watchlist.json, fetches pricing pages in parallel,
+ * compares content hashes against stored baselines, and logs
+ * detected changes to data/pricing-changes.jsonl.
+ *
+ * Usage:
+ *   npm run monitor:pricing              # check all vendors due today
+ *   npm run monitor:pricing -- --init    # create baseline (first run)
+ *   npm run monitor:pricing -- --all     # check all vendors regardless of interval
+ *   npm run monitor:pricing -- --vendor "Vercel"  # check a specific vendor
+ *
+ * Add new vendors by editing data/watchlist.json.
+ */
+
+import { readFileSync, writeFileSync, appendFileSync, existsSync } from "node:fs";
+import { createHash } from "node:crypto";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const WATCHLIST_PATH = resolve(__dirname, "..", "data", "watchlist.json");
+const HASHES_PATH = resolve(__dirname, "..", "data", "pricing-hashes.json");
+const CHANGES_PATH = resolve(__dirname, "..", "data", "pricing-changes.jsonl");
+const CONCURRENCY = 10;
+const FETCH_TIMEOUT_MS = 15000;
+
+export function extractTextContent(html) {
+  let cleaned = html;
+  cleaned = cleaned.replace(/<head[\s\S]*?<\/head>/gi, "");
+  cleaned = cleaned.replace(/<script[\s\S]*?<\/script>/gi, "");
+  cleaned = cleaned.replace(/<style[\s\S]*?<\/style>/gi, "");
+  cleaned = cleaned.replace(/<svg[\s\S]*?<\/svg>/gi, "");
+  cleaned = cleaned.replace(/<[^>]+>/g, " ");
+  cleaned = cleaned.replace(/&amp;/g, "&").replace(/&lt;/g, "<").replace(/&gt;/g, ">")
+    .replace(/&quot;/g, '"').replace(/&#39;/g, "'").replace(/&nbsp;/g, " ");
+  cleaned = cleaned.replace(/&#?\w+;/g, " ");
+  cleaned = cleaned.replace(/\b[0-9a-f]{8,}\b/gi, "");
+  cleaned = cleaned.replace(/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/gi, "");
+  cleaned = cleaned.replace(/\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}[^\s]*/g, "");
+  cleaned = cleaned.replace(/\b\d{10,13}\b/g, "");
+  cleaned = cleaned.replace(/\s+/g, " ").trim();
+  return cleaned;
+}
+
+function hashContent(content) {
+  return createHash("sha256").update(content).digest("hex");
+}
+
+async function fetchPage(url) {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+  try {
+    const res = await fetch(url, {
+      signal: controller.signal,
+      headers: {
+        "User-Agent": "AgentDeals-PricingMonitor/1.0",
+        Accept: "text/html",
+      },
+      redirect: "follow",
+    });
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    return await res.text();
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+export function isDueForCheck(entry, lastCheck, now = new Date()) {
+  if (!lastCheck) return true;
+  const lastDate = new Date(lastCheck);
+  const diffMs = now.getTime() - lastDate.getTime();
+  const diffHours = diffMs / (1000 * 60 * 60);
+  return entry.interval === "daily" ? diffHours >= 24 : diffHours >= 168;
+}
+
+async function checkBatch(entries, hashes, isInit) {
+  const results = { changed: [], unchanged: [], errors: [] };
+
+  await Promise.all(entries.map(async (entry) => {
+    try {
+      const html = await fetchPage(entry.url);
+      const text = extractTextContent(html);
+      const hash = hashContent(text);
+      const now = new Date().toISOString();
+      const prev = hashes[entry.vendor];
+
+      if (!isInit && prev && prev.hash && prev.hash !== hash) {
+        results.changed.push({ vendor: entry.vendor, url: entry.url, oldHash: prev.hash, newHash: hash });
+      } else {
+        results.unchanged.push(entry.vendor);
+      }
+
+      hashes[entry.vendor] = { url: entry.url, hash, checkedAt: now };
+    } catch (err) {
+      const reason = err.name === "AbortError" ? "timeout" : err.message;
+      results.errors.push({ vendor: entry.vendor, url: entry.url, error: reason });
+    }
+  }));
+
+  return results;
+}
+
+function logChange(change) {
+  const entry = {
+    ts: new Date().toISOString(),
+    vendor: change.vendor,
+    url: change.url,
+    type: "pricing_page_changed",
+    oldHash: change.oldHash,
+    newHash: change.newHash,
+  };
+  appendFileSync(CHANGES_PATH, JSON.stringify(entry) + "\n");
+}
+
+async function main() {
+  const args = process.argv.slice(2);
+  const isInit = args.includes("--init");
+  const checkAll = args.includes("--all");
+  const vendorIdx = args.indexOf("--vendor");
+  const specificVendor = vendorIdx !== -1 ? args[vendorIdx + 1] : null;
+
+  let watchlist;
+  try {
+    watchlist = JSON.parse(readFileSync(WATCHLIST_PATH, "utf-8"));
+  } catch (err) {
+    console.error(`Failed to read watchlist: ${err.message}`);
+    process.exit(2);
+  }
+
+  let hashes = {};
+  if (!isInit && existsSync(HASHES_PATH)) {
+    try {
+      hashes = JSON.parse(readFileSync(HASHES_PATH, "utf-8"));
+    } catch {
+      console.error("Warning: Could not parse hashes file, treating as init run.");
+    }
+  }
+
+  let vendors = watchlist.vendors;
+  if (specificVendor) {
+    vendors = vendors.filter((v) => v.vendor === specificVendor);
+    if (vendors.length === 0) {
+      console.error(`Vendor "${specificVendor}" not found in watchlist.`);
+      process.exit(2);
+    }
+  } else if (!checkAll && !isInit) {
+    const now = new Date();
+    vendors = vendors.filter((v) => isDueForCheck(v, hashes[v.vendor]?.checkedAt, now));
+  }
+
+  if (vendors.length === 0) {
+    console.log("No vendors due for check. Use --all to force check all vendors.");
+    process.exit(0);
+  }
+
+  console.log(`${isInit ? "Initializing baseline for" : "Checking"} ${vendors.length} vendor pricing pages...\n`);
+
+  const allChanged = [];
+  const allErrors = [];
+  let unchangedCount = 0;
+
+  // Process in batches for concurrency control
+  for (let i = 0; i < vendors.length; i += CONCURRENCY) {
+    const batch = vendors.slice(i, i + CONCURRENCY);
+    const results = await checkBatch(batch, hashes, isInit);
+    allChanged.push(...results.changed);
+    allErrors.push(...results.errors);
+    unchangedCount += results.unchanged.length;
+
+    // Log each change immediately
+    for (const c of results.changed) {
+      logChange(c);
+    }
+  }
+
+  // Save updated hashes
+  writeFileSync(HASHES_PATH, JSON.stringify(hashes, null, 2) + "\n");
+
+  // Summary
+  if (isInit) {
+    console.log(`Baseline created: ${Object.keys(hashes).length} vendors hashed.`);
+  } else if (allChanged.length === 0) {
+    console.log(`No pricing page changes detected (${unchangedCount} checked).`);
+  } else {
+    console.log(`${allChanged.length} pricing page(s) changed:\n`);
+    for (const c of allChanged) {
+      console.log(`  ${c.vendor} — ${c.url}`);
+    }
+    console.log(`\nChanges logged to ${CHANGES_PATH}`);
+  }
+
+  if (allErrors.length > 0) {
+    console.log(`\n${allErrors.length} error(s):\n`);
+    for (const e of allErrors) {
+      console.log(`  ${e.vendor} — ${e.error} (${e.url})`);
+    }
+  }
+
+  process.exit(allChanged.length > 0 ? 1 : 0);
+}
+
+const isMainModule = process.argv[1] && resolve(process.argv[1]) === resolve(fileURLToPath(import.meta.url));
+if (isMainModule) {
+  main();
+}

--- a/test/monitor.test.ts
+++ b/test/monitor.test.ts
@@ -1,0 +1,78 @@
+import { describe, it } from "node:test";
+import assert from "node:assert";
+
+const { extractTextContent, isDueForCheck } = await import("../scripts/monitor-pricing.js");
+
+describe("pricing monitor", () => {
+  describe("extractTextContent", () => {
+    it("strips HTML tags and returns visible text", () => {
+      const html = "<html><body><h1>Pricing</h1><p>Free tier: 100 requests/day</p></body></html>";
+      const text = extractTextContent(html);
+      assert.ok(text.includes("Pricing"));
+      assert.ok(text.includes("Free tier: 100 requests/day"));
+      assert.ok(!text.includes("<h1>"));
+    });
+
+    it("removes head, script, style, and SVG content", () => {
+      const html = `
+        <html>
+          <head><title>Page</title><script>var x=1;</script></head>
+          <body>
+            <script>console.log('hi');</script>
+            <style>.red{color:red}</style>
+            <svg><path d="M0 0"/></svg>
+            <p>Visible content</p>
+          </body>
+        </html>`;
+      const text = extractTextContent(html);
+      assert.ok(text.includes("Visible content"));
+      assert.ok(!text.includes("console.log"));
+      assert.ok(!text.includes(".red"));
+      assert.ok(!text.includes("M0 0"));
+    });
+
+    it("removes hex hashes and UUIDs for stability", () => {
+      const html = "<body><p>Build abcdef1234567890</p><p>ID: 550e8400-e29b-41d4-a716-446655440000</p><p>Price: $10/mo</p></body>";
+      const text = extractTextContent(html);
+      assert.ok(text.includes("Price: $10/mo"));
+      assert.ok(!text.includes("abcdef1234567890"));
+      assert.ok(!text.includes("550e8400"));
+    });
+
+    it("removes ISO timestamps and Unix timestamps", () => {
+      const html = "<body><p>Updated 2026-03-01T12:00:00Z</p><p>ts=1709308800000</p><p>$5/month</p></body>";
+      const text = extractTextContent(html);
+      assert.ok(text.includes("$5/month"));
+      assert.ok(!text.includes("2026-03-01T12:00"));
+    });
+  });
+
+  describe("isDueForCheck", () => {
+    const now = new Date("2026-03-03T12:00:00Z");
+
+    it("returns true when no previous check exists", () => {
+      assert.strictEqual(isDueForCheck({ interval: "daily" }, null, now), true);
+      assert.strictEqual(isDueForCheck({ interval: "weekly" }, undefined, now), true);
+    });
+
+    it("returns true for daily vendors checked >24h ago", () => {
+      const lastCheck = "2026-03-02T10:00:00Z"; // 26 hours ago
+      assert.strictEqual(isDueForCheck({ interval: "daily" }, lastCheck, now), true);
+    });
+
+    it("returns false for daily vendors checked <24h ago", () => {
+      const lastCheck = "2026-03-03T10:00:00Z"; // 2 hours ago
+      assert.strictEqual(isDueForCheck({ interval: "daily" }, lastCheck, now), false);
+    });
+
+    it("returns true for weekly vendors checked >168h ago", () => {
+      const lastCheck = "2026-02-24T10:00:00Z"; // 8 days ago
+      assert.strictEqual(isDueForCheck({ interval: "weekly" }, lastCheck, now), true);
+    });
+
+    it("returns false for weekly vendors checked <168h ago", () => {
+      const lastCheck = "2026-03-01T12:00:00Z"; // 2 days ago
+      assert.strictEqual(isDueForCheck({ interval: "weekly" }, lastCheck, now), false);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `scripts/monitor-pricing.js` — automated pricing page monitor that fetches top 20 high-churn vendor pricing pages in parallel, compares content hashes against baselines, and logs detected changes to `data/pricing-changes.jsonl`
- Adds `data/watchlist.json` — curated list of 20 monitored vendors (Vercel, Supabase, Neon, Railway, Cloudflare, Render, Netlify, etc.) with daily/weekly check intervals
- Supports `--init` (create baseline), `--all` (force check all), `--vendor "Name"` (check specific vendor)
- 9 new tests for text extraction and scheduling logic (63 total, was 54)

## How to use

```bash
npm run monitor:pricing -- --init     # First run: create baseline hashes
npm run monitor:pricing               # Check vendors due today
npm run monitor:pricing -- --all      # Force-check all vendors
npm run monitor:pricing -- --vendor "Vercel"  # Check specific vendor
```

To add a new vendor, edit `data/watchlist.json` and add an entry with `vendor`, `url`, and `interval` ("daily" or "weekly").

## Test plan

- [x] All 63 tests pass (9 new monitor tests)
- [x] `--init` creates baseline for 19/20 vendors (1 rate-limited, transient)
- [x] Follow-up `--all` run detects 0 false positives
- [x] `isDueForCheck` correctly handles daily (24h) and weekly (168h) intervals

Refs #90