### PR TITLE
Add Upstash Redis persistence for telemetry

### DIFF
--- a/src/serve.ts
+++ b/src/serve.ts
@@ -62,9 +62,9 @@ setInterval(() => {
   }
 }, CLEANUP_INTERVAL_MS).unref();
 
-// Load cumulative telemetry from disk (survives deploys)
+// Load cumulative telemetry from Redis or disk (survives deploys)
 const telemetryFile = join(__dirname, "..", "data", "telemetry.json");
-loadTelemetry(telemetryFile);
+await loadTelemetry(telemetryFile);
 
 // Build landing page HTML at startup with real stats
 const offers = loadOffers();
@@ -617,14 +617,14 @@ httpServer.listen(PORT, () => {
   console.error(`agentdeals MCP server running on http://localhost:${PORT}/mcp`);
 });
 
-// Flush telemetry to disk every 5 minutes
+// Flush telemetry every 5 minutes
 const FLUSH_INTERVAL_MS = 5 * 60 * 1000;
 setInterval(() => flushTelemetry(), FLUSH_INTERVAL_MS).unref();
 
 // Flush on graceful shutdown
-function onShutdown() {
-  flushTelemetry();
+async function onShutdown() {
+  await flushTelemetry();
   process.exit(0);
 }
-process.on("SIGTERM", onShutdown);
-process.on("SIGINT", onShutdown);
+process.on("SIGTERM", () => onShutdown());
+process.on("SIGINT", () => onShutdown());

--- a/src/stats.ts
+++ b/src/stats.ts
@@ -1,5 +1,6 @@
-// In-memory telemetry counters with file-based persistence.
-// Cumulative stats survive deploys via data/telemetry.json.
+// In-memory telemetry counters with persistent storage.
+// Cumulative stats survive deploys via Upstash Redis (preferred) or data/telemetry.json (fallback).
+// Set UPSTASH_REDIS_REST_URL and UPSTASH_REDIS_REST_TOKEN env vars to enable Redis persistence.
 // No PII collected — only aggregate counts and tool-level metrics.
 
 import { readFileSync, writeFileSync, mkdirSync } from "node:fs";
@@ -26,7 +27,7 @@ let landingPageViews = 0;
 let sessionsToday = 0;
 let sessionsTodayDate = new Date().toISOString().slice(0, 10);
 
-// Cumulative stats loaded from disk
+// Cumulative stats loaded from external storage
 let cumulative = {
   sessions: 0,
   tool_calls: 0,
@@ -38,29 +39,76 @@ let cumulative = {
 
 let telemetryPath = "";
 
-export function loadTelemetry(filePath: string): void {
-  telemetryPath = filePath;
-  try {
-    const raw = readFileSync(filePath, "utf-8");
-    const data = JSON.parse(raw);
-    cumulative.sessions = data.cumulative_sessions ?? 0;
-    cumulative.tool_calls = data.cumulative_tool_calls ?? 0;
-    cumulative.api_hits = data.cumulative_api_hits ?? 0;
-    cumulative.landing_views = data.cumulative_landing_views ?? 0;
-    cumulative.first_session_at = data.first_session_at ?? "";
-    cumulative.last_deploy_at = data.last_deploy_at ?? "";
-  } catch {
-    // No file yet or corrupt — start fresh
-  }
-  // Record this deploy
-  cumulative.last_deploy_at = serverStartedISO;
+// Upstash Redis REST API support (zero dependencies)
+const REDIS_KEY = "agentdeals:telemetry";
+
+export function useRedis(): boolean {
+  return !!(process.env.UPSTASH_REDIS_REST_URL && process.env.UPSTASH_REDIS_REST_TOKEN);
 }
 
-export function flushTelemetry(): void {
-  if (!telemetryPath) return;
+interface TelemetryData {
+  cumulative_sessions: number;
+  cumulative_tool_calls: number;
+  cumulative_api_hits: number;
+  cumulative_landing_views: number;
+  first_session_at: string;
+  last_deploy_at: string;
+}
+
+async function redisGet(): Promise<TelemetryData | null> {
+  const url = process.env.UPSTASH_REDIS_REST_URL!;
+  const token = process.env.UPSTASH_REDIS_REST_TOKEN!;
+  try {
+    const res = await fetch(url, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${token}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(["GET", REDIS_KEY]),
+    });
+    const json = (await res.json()) as { result?: string | null };
+    if (json.result) {
+      return JSON.parse(json.result) as TelemetryData;
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+async function redisSet(data: TelemetryData): Promise<boolean> {
+  const url = process.env.UPSTASH_REDIS_REST_URL!;
+  const token = process.env.UPSTASH_REDIS_REST_TOKEN!;
+  try {
+    const res = await fetch(url, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${token}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(["SET", REDIS_KEY, JSON.stringify(data)]),
+    });
+    const json = (await res.json()) as { result?: string };
+    return json.result === "OK";
+  } catch {
+    return false;
+  }
+}
+
+function parseTelemetryData(data: Record<string, unknown>): void {
+  cumulative.sessions = (data.cumulative_sessions as number) ?? 0;
+  cumulative.tool_calls = (data.cumulative_tool_calls as number) ?? 0;
+  cumulative.api_hits = (data.cumulative_api_hits as number) ?? 0;
+  cumulative.landing_views = (data.cumulative_landing_views as number) ?? 0;
+  cumulative.first_session_at = (data.first_session_at as string) ?? "";
+  cumulative.last_deploy_at = (data.last_deploy_at as string) ?? "";
+}
+
+function buildTelemetryData(): TelemetryData {
   const totalToolCalls = Object.values(toolCalls).reduce((a, b) => a + b, 0);
   const totalApiHits = Object.values(apiHits).reduce((a, b) => a + b, 0);
-  const data = {
+  return {
     cumulative_sessions: cumulative.sessions + totalSessions,
     cumulative_tool_calls: cumulative.tool_calls + totalToolCalls,
     cumulative_api_hits: cumulative.api_hits + totalApiHits,
@@ -68,12 +116,63 @@ export function flushTelemetry(): void {
     first_session_at: cumulative.first_session_at || (totalSessions > 0 ? serverStartedISO : ""),
     last_deploy_at: cumulative.last_deploy_at,
   };
+}
+
+export async function loadTelemetry(filePath: string): Promise<void> {
+  telemetryPath = filePath;
+
+  // Try Redis first if configured
+  if (useRedis()) {
+    const data = await redisGet();
+    if (data) {
+      parseTelemetryData(data as unknown as Record<string, unknown>);
+      cumulative.last_deploy_at = serverStartedISO;
+      return;
+    }
+  }
+
+  // Fall back to file
+  try {
+    const raw = readFileSync(filePath, "utf-8");
+    const data = JSON.parse(raw);
+    parseTelemetryData(data);
+  } catch {
+    // No file yet or corrupt — start fresh
+  }
+  cumulative.last_deploy_at = serverStartedISO;
+}
+
+export async function flushTelemetry(): Promise<void> {
+  if (!telemetryPath) return;
+  const data = buildTelemetryData();
+
+  // Write to Redis if configured
+  if (useRedis()) {
+    await redisSet(data);
+  }
+
+  // Always write to file as backup
   try {
     mkdirSync(dirname(telemetryPath), { recursive: true });
     writeFileSync(telemetryPath, JSON.stringify(data, null, 2) + "\n");
   } catch {
     // Best effort — don't crash the server
   }
+}
+
+export function resetCounters(): void {
+  totalSessions = 0;
+  totalDisconnects = 0;
+  landingPageViews = 0;
+  sessionsToday = 0;
+  for (const key of Object.keys(toolCalls)) toolCalls[key] = 0;
+  for (const key of Object.keys(apiHits)) apiHits[key] = 0;
+  cumulative.sessions = 0;
+  cumulative.tool_calls = 0;
+  cumulative.api_hits = 0;
+  cumulative.landing_views = 0;
+  cumulative.first_session_at = "";
+  cumulative.last_deploy_at = "";
 }
 
 export function recordToolCall(tool: string): void {

--- a/test/telemetry.test.ts
+++ b/test/telemetry.test.ts
@@ -1,4 +1,4 @@
-import { describe, it } from "node:test";
+import { describe, it, beforeEach, afterEach } from "node:test";
 import assert from "node:assert";
 import { writeFileSync, readFileSync, mkdirSync, rmSync } from "node:fs";
 import { join } from "node:path";
@@ -12,13 +12,15 @@ const {
   recordApiHit,
   recordLandingPageView,
   getStats,
+  useRedis,
+  resetCounters,
 } = await import("../src/stats.ts");
 
 describe("telemetry persistence", () => {
   const tmpDir = join(tmpdir(), `telemetry-test-${randomUUID()}`);
   const telemetryFile = join(tmpDir, "telemetry.json");
 
-  it("loads seed data and accumulates across simulated restart", () => {
+  it("loads seed data and accumulates across simulated restart", async () => {
     // Simulate pre-existing telemetry from a previous deploy
     mkdirSync(tmpDir, { recursive: true });
     const seed = {
@@ -32,7 +34,7 @@ describe("telemetry persistence", () => {
     writeFileSync(telemetryFile, JSON.stringify(seed));
 
     // Load telemetry (simulates server startup)
-    loadTelemetry(telemetryFile);
+    await loadTelemetry(telemetryFile);
 
     // Before any activity, cumulative should reflect seed values
     const stats0 = getStats();
@@ -65,7 +67,7 @@ describe("telemetry persistence", () => {
     assert.strictEqual(stats1.cumulative_landing_views, 88); // 87 + 1
 
     // Flush to disk
-    flushTelemetry();
+    await flushTelemetry();
 
     // Verify file contents
     const persisted = JSON.parse(readFileSync(telemetryFile, "utf-8"));
@@ -80,13 +82,164 @@ describe("telemetry persistence", () => {
     rmSync(tmpDir, { recursive: true, force: true });
   });
 
-  it("initializes cleanly when no telemetry file exists", () => {
+  it("initializes cleanly when no telemetry file exists", async () => {
     const missingFile = join(tmpDir, "nonexistent", "telemetry.json");
     // Should not throw
-    loadTelemetry(missingFile);
+    await loadTelemetry(missingFile);
 
     const stats = getStats();
     assert.ok(typeof stats.cumulative_sessions === "number");
     assert.ok(typeof stats.last_deploy_at === "string");
+  });
+});
+
+describe("redis telemetry", () => {
+  beforeEach(() => {
+    resetCounters();
+  });
+
+  it("useRedis returns false when env vars not set", () => {
+    delete process.env.UPSTASH_REDIS_REST_URL;
+    delete process.env.UPSTASH_REDIS_REST_TOKEN;
+    assert.strictEqual(useRedis(), false);
+  });
+
+  it("useRedis returns true when both env vars are set", () => {
+    process.env.UPSTASH_REDIS_REST_URL = "https://fake-redis.upstash.io";
+    process.env.UPSTASH_REDIS_REST_TOKEN = "fake-token";
+    assert.strictEqual(useRedis(), true);
+    delete process.env.UPSTASH_REDIS_REST_URL;
+    delete process.env.UPSTASH_REDIS_REST_TOKEN;
+  });
+
+  it("useRedis returns false when only URL is set", () => {
+    process.env.UPSTASH_REDIS_REST_URL = "https://fake-redis.upstash.io";
+    delete process.env.UPSTASH_REDIS_REST_TOKEN;
+    assert.strictEqual(useRedis(), false);
+    delete process.env.UPSTASH_REDIS_REST_URL;
+  });
+
+  it("loads from redis when configured and data exists", async () => {
+    const tmpDir2 = join(tmpdir(), `telemetry-redis-${randomUUID()}`);
+    const telemetryFile2 = join(tmpDir2, "telemetry.json");
+
+    const redisData = {
+      cumulative_sessions: 200,
+      cumulative_tool_calls: 500,
+      cumulative_api_hits: 300,
+      cumulative_landing_views: 100,
+      first_session_at: "2026-01-01T00:00:00.000Z",
+      last_deploy_at: "2026-03-03T00:00:00.000Z",
+    };
+
+    // Mock fetch to simulate Upstash REST API
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = async (_url: string | URL | Request, _init?: RequestInit) => {
+      const body = JSON.parse(_init?.body as string);
+      if (body[0] === "GET") {
+        return new Response(JSON.stringify({ result: JSON.stringify(redisData) }));
+      }
+      if (body[0] === "SET") {
+        return new Response(JSON.stringify({ result: "OK" }));
+      }
+      return new Response(JSON.stringify({ result: null }));
+    };
+
+    process.env.UPSTASH_REDIS_REST_URL = "https://fake-redis.upstash.io";
+    process.env.UPSTASH_REDIS_REST_TOKEN = "fake-token";
+
+    await loadTelemetry(telemetryFile2);
+
+    const stats = getStats();
+    assert.strictEqual(stats.cumulative_sessions, 200);
+    assert.strictEqual(stats.cumulative_tool_calls, 500);
+    assert.strictEqual(stats.first_session_at, "2026-01-01T00:00:00.000Z");
+
+    // Restore
+    globalThis.fetch = originalFetch;
+    delete process.env.UPSTASH_REDIS_REST_URL;
+    delete process.env.UPSTASH_REDIS_REST_TOKEN;
+    rmSync(tmpDir2, { recursive: true, force: true });
+  });
+
+  it("flushes to both redis and file when redis configured", async () => {
+    const tmpDir3 = join(tmpdir(), `telemetry-flush-${randomUUID()}`);
+    const telemetryFile3 = join(tmpDir3, "telemetry.json");
+    mkdirSync(tmpDir3, { recursive: true });
+
+    let redisSaved: string | null = null;
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = async (_url: string | URL | Request, _init?: RequestInit) => {
+      const body = JSON.parse(_init?.body as string);
+      if (body[0] === "GET") {
+        return new Response(JSON.stringify({ result: null }));
+      }
+      if (body[0] === "SET") {
+        redisSaved = body[2];
+        return new Response(JSON.stringify({ result: "OK" }));
+      }
+      return new Response(JSON.stringify({ result: null }));
+    };
+
+    process.env.UPSTASH_REDIS_REST_URL = "https://fake-redis.upstash.io";
+    process.env.UPSTASH_REDIS_REST_TOKEN = "fake-token";
+
+    await loadTelemetry(telemetryFile3);
+    await flushTelemetry();
+
+    // Verify Redis received the data
+    assert.ok(redisSaved, "Redis SET should have been called");
+    const redisData = JSON.parse(redisSaved);
+    assert.ok(typeof redisData.cumulative_sessions === "number");
+    assert.ok(redisData.last_deploy_at);
+
+    // Verify file also written
+    const fileData = JSON.parse(readFileSync(telemetryFile3, "utf-8"));
+    assert.ok(typeof fileData.cumulative_sessions === "number");
+
+    // Restore
+    globalThis.fetch = originalFetch;
+    delete process.env.UPSTASH_REDIS_REST_URL;
+    delete process.env.UPSTASH_REDIS_REST_TOKEN;
+    rmSync(tmpDir3, { recursive: true, force: true });
+  });
+
+  it("falls back to file when redis GET fails", async () => {
+    const tmpDir4 = join(tmpdir(), `telemetry-fallback-${randomUUID()}`);
+    const telemetryFile4 = join(tmpDir4, "telemetry.json");
+    mkdirSync(tmpDir4, { recursive: true });
+
+    // Write file-based seed data
+    const seed = {
+      cumulative_sessions: 42,
+      cumulative_tool_calls: 100,
+      cumulative_api_hits: 50,
+      cumulative_landing_views: 25,
+      first_session_at: "2026-02-01T00:00:00.000Z",
+      last_deploy_at: "2026-03-01T00:00:00.000Z",
+    };
+    writeFileSync(telemetryFile4, JSON.stringify(seed));
+
+    // Mock fetch to simulate failure
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = async () => {
+      throw new Error("Network error");
+    };
+
+    process.env.UPSTASH_REDIS_REST_URL = "https://fake-redis.upstash.io";
+    process.env.UPSTASH_REDIS_REST_TOKEN = "fake-token";
+
+    await loadTelemetry(telemetryFile4);
+
+    const stats = getStats();
+    // Should have loaded from file despite Redis failure
+    assert.strictEqual(stats.cumulative_sessions, 42);
+    assert.strictEqual(stats.first_session_at, "2026-02-01T00:00:00.000Z");
+
+    // Restore
+    globalThis.fetch = originalFetch;
+    delete process.env.UPSTASH_REDIS_REST_URL;
+    delete process.env.UPSTASH_REDIS_REST_TOKEN;
+    rmSync(tmpDir4, { recursive: true, force: true });
   });
 });


### PR DESCRIPTION
## Summary

- Adds Upstash Redis REST API support for persisting telemetry stats across Railway deploys
- Uses native `fetch()` — zero new npm dependencies
- Reads `UPSTASH_REDIS_REST_URL` and `UPSTASH_REDIS_REST_TOKEN` env vars at runtime
- Falls back gracefully to file-based persistence when Redis not configured
- Both `loadTelemetry()` and `flushTelemetry()` are now async
- 6 new tests covering Redis load, flush, fallback, and env var detection (75 total, all passing)

## Setup Required

To enable Redis persistence on Railway:
1. Create a free Upstash Redis database at https://upstash.com
2. Add `UPSTASH_REDIS_REST_URL` and `UPSTASH_REDIS_REST_TOKEN` as env vars in Railway
3. Deploy — cumulative stats will now survive across deploys

No code changes needed after env vars are set. The free Upstash tier (10K commands/day) is more than sufficient for telemetry flushes every 5 minutes.

## Test plan

- [x] All 75 tests pass (`npm test`)
- [x] Build succeeds (`npm run build`)
- [x] Server starts cleanly without Redis env vars (file fallback works)
- [x] Redis load tested with mocked fetch (returns correct cumulative data)
- [x] Redis flush tested — writes to both Redis and file
- [x] Redis failure tested — graceful fallback to file-based persistence
- [ ] Production: set Upstash env vars and verify cumulative stats survive a deploy

Refs #107

🤖 Generated with [Claude Code](https://claude.com/claude-code)