### PR TITLE
Add Dockerfile and .dockerignore for Glama listing

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,10 @@
+node_modules
+dist
+.env
+.env.*
+*.log
+.DS_Store
+.cache
+.git
+test
+scripts

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,26 @@
+FROM node:20-slim AS build
+
+WORKDIR /app
+
+COPY package.json package-lock.json ./
+RUN npm ci
+
+COPY tsconfig.json ./
+COPY src/ src/
+
+RUN npx tsc
+
+FROM node:20-slim
+
+WORKDIR /app
+
+COPY package.json package-lock.json ./
+RUN npm ci --omit=dev
+
+COPY --from=build /app/dist/ dist/
+COPY data/ data/
+COPY assets/ assets/
+
+EXPOSE 3000
+
+CMD ["node", "dist/serve.js"]


### PR DESCRIPTION
## Summary
- Multi-stage Dockerfile: build stage compiles TypeScript, production stage uses node:20-slim with only runtime deps
- .dockerignore excludes node_modules, dist, test, scripts, .env, .git
- Image runs the HTTP server (`node dist/serve.js`) on port 3000

Refs #114