### PR TITLE
Add HCP Terraform free tier EOL (March 31, 2026)

### DIFF
--- a/data/deal_changes.json
+++ b/data/deal_changes.json
@@ -795,6 +795,23 @@
         "env0",
         "Scalr"
       ]
+    },
+    {
+      "vendor": "HCP Terraform",
+      "change_type": "pricing_restructured",
+      "date": "2026-03-31",
+      "summary": "HashiCorp legacy free plan for HCP Terraform ends March 31, 2026. All legacy free plan users auto-migrated to enhanced free tier with different limits: 500 managed resources (previously unlimited for small teams), unlimited users, 1 concurrent run, SSO, and policy as code (Sentinel + OPA)",
+      "previous_state": "Legacy free plan with basic Terraform Cloud features",
+      "current_state": "Enhanced free tier: 500 managed resources, unlimited users, 1 concurrent run, SSO, policy as code (Sentinel + OPA). Auto-migration from legacy plan",
+      "impact": "high",
+      "source_url": "https://www.hashicorp.com/products/terraform/pricing",
+      "category": "Infrastructure",
+      "alternatives": [
+        "Spacelift",
+        "env0",
+        "Scalr",
+        "Terragrunt Scale"
+      ]
     }
   ]
 }

--- a/data/index.json
+++ b/data/index.json
@@ -2472,17 +2472,18 @@
     {
       "vendor": "HCP Terraform",
       "category": "Infrastructure",
-      "description": "HashiCorp managed Terraform — 500 managed resources, unlimited users, SSO, policy as code (Sentinel + OPA), 1 concurrent run. Enhanced free tier replaces legacy plan (sunset March 2026)",
-      "tier": "Free",
+      "description": "HashiCorp managed Terraform — enhanced free tier (replacing legacy plan EOL March 31, 2026): 500 managed resources, unlimited users, SSO, policy as code (Sentinel + OPA), 1 concurrent run. Legacy free plan users auto-migrated to enhanced tier",
+      "tier": "Free (Enhanced)",
       "url": "https://www.hashicorp.com/products/terraform/pricing",
       "tags": [
         "infrastructure",
         "iac",
         "terraform",
         "hashicorp",
-        "free tier"
+        "free tier",
+        "deal-change"
       ],
-      "verifiedDate": "2026-02-26"
+      "verifiedDate": "2026-03-10"
     },
     {
       "vendor": "Orama",

--- a/test/deal-changes.test.ts
+++ b/test/deal-changes.test.ts
@@ -89,7 +89,7 @@ describe("get_deal_changes tool", () => {
 
       assert.ok(Array.isArray(body.changes));
       assert.strictEqual(body.total, body.changes.length);
-      assert.strictEqual(body.total, 50);
+      assert.strictEqual(body.total, 51);
     } finally {
       proc.kill();
     }


### PR DESCRIPTION
## Summary
- Updated HCP Terraform entry with enhanced free tier details (500 managed resources, unlimited users, 1 concurrent run, SSO, policy as code)
- Added deal_change entry documenting legacy free plan EOL on March 31, 2026 and auto-migration to enhanced tier
- Updated test assertion for new deal_changes count (51)

Refs #124

## Test plan
- [x] All 79 tests pass
- [x] Data validation passes (1506 offers, 51 deal changes)