### PR TITLE
Add vendor pricing updates: X/Twitter, Gemini, Bright Data

### DIFF
--- a/data/deal_changes.json
+++ b/data/deal_changes.json
@@ -93,12 +93,12 @@
       "vendor": "Google Gemini",
       "change_type": "limits_reduced",
       "date": "2025-12-15",
-      "summary": "Free tier rate limits reduced 50-80%, Gemini 2.0 Flash deprecated",
-      "previous_state": "Higher rate limits on free tier, Gemini 2.0 Flash available",
-      "current_state": "Reduced rate limits, 2.0 Flash retiring March 31 2026, 3.x paid-only, 2.5 series free tier preserved",
-      "impact": "medium",
-      "source_url": "https://ai.google.dev/pricing",
-      "category": "AI/ML APIs",
+      "summary": "Google quietly slashed Gemini API free tier rate limits by 50-80% in late 2025. Gemini 2.5 Flash went from ~250 requests/day to 20-50. Pro model free tier removed entirely. A Google PM admitted generous limits were only supposed to be available for a single weekend",
+      "previous_state": "Pro model available on free tier, Flash ~250 RPD, Flash-Lite generous limits",
+      "current_state": "Pro free tier removed. Flash reduced to 10 RPM (~20-50 RPD). Flash-Lite 15 RPM. 50-80% reduction across the board. Gemini 2.0 Flash retiring March 2026",
+      "impact": "high",
+      "source_url": "https://ai.google.dev/gemini-api/docs/pricing",
+      "category": "AI / ML",
       "alternatives": [
         "OpenRouter",
         "Groq",
@@ -811,6 +811,21 @@
         "env0",
         "Scalr",
         "Terragrunt Scale"
+      ]
+    },
+    {
+      "vendor": "X (Twitter)",
+      "change_type": "free_tier_removed",
+      "date": "2026-02-01",
+      "summary": "X/Twitter API eliminated free tier in February 2026, replacing it with a pay-per-use credit model. Active free-tier users receive a $0 voucher. 'For-good' utility apps remain free. Basic fixed tier remains at $200/month",
+      "previous_state": "Free tier: ~500 posts/month read, 1,500 tweets/month write, no search, ~1 request per 15 minutes",
+      "current_state": "No free tier. Pay-per-use credit model replaces free access. $0 voucher for existing free-tier users. For-good utility apps exempted",
+      "impact": "high",
+      "source_url": "https://developer.x.com/en/portal/products",
+      "category": "API Gateway",
+      "alternatives": [
+        "Bluesky AT Protocol",
+        "Mastodon API"
       ]
     }
   ]

--- a/data/index.json
+++ b/data/index.json
@@ -939,9 +939,9 @@
       "verifiedDate": "2026-02-24"
     },
     {
-      "vendor": "Bright Data",
+      "vendor": "Bright Data MCP Server",
       "category": "Web Scraping",
-      "description": "Web MCP Server — 5K requests/month free for search and scrape-to-markdown via MCP",
+      "description": "MCP-native web scraping infrastructure — 5,000 requests/month free tier. Search, scrape-to-markdown, and structured data extraction via MCP protocol. Notable as an early MCP-native developer tool with a free tier",
       "tier": "Free",
       "url": "https://brightdata.com/products/web-scraper",
       "tags": [
@@ -950,9 +950,10 @@
         "data",
         "web",
         "api",
-        "free tier"
+        "free tier",
+        "mcp-server"
       ],
-      "verifiedDate": "2026-02-23"
+      "verifiedDate": "2026-03-10"
     },
     {
       "vendor": "Firecrawl",
@@ -1352,8 +1353,8 @@
     {
       "vendor": "Google Gemini API",
       "category": "AI / ML",
-      "description": "Free access to Gemini 2.5 Pro (5 RPM, ~25 RPD), Flash (10 RPM), Flash-Lite (15 RPM). 1M token context. Rate limits reduced 50-80% in Dec 2025. Gemini 2.0 models retiring March 3, 2026",
-      "tier": "Free",
+      "description": "Free tier significantly curtailed in late 2025. Pro model free tier removed entirely. Flash free tier rate limits reduced 50-80% (from ~250 RPD to 20-50 RPD). Current free limits: Flash (10 RPM), Flash-Lite (15 RPM). 1M token context. Google PM admitted generous limits 'were only supposed to be available for a single weekend'",
+      "tier": "Free (Reduced)",
       "url": "https://ai.google.dev/gemini-api/docs/pricing",
       "tags": [
         "ai",
@@ -1364,7 +1365,7 @@
         "free tier",
         "deal-change"
       ],
-      "verifiedDate": "2026-03-02"
+      "verifiedDate": "2026-03-10"
     },
     {
       "vendor": "Mistral AI",
@@ -4000,17 +4001,18 @@
     {
       "vendor": "X (Twitter)",
       "category": "API Gateway",
-      "description": "Social media API — Free tier extremely limited: ~500 posts/month read, 1,500 tweets/month write, no search functionality, ~1 request per 15 minutes for reading. Basic tier starts at $200/month. Pay-per-use model introduced February 2026 alongside fixed tiers",
-      "tier": "Free",
+      "description": "Social media API — free tier eliminated February 2026, replaced with pay-per-use credit model. Active free-tier users receive $0 voucher. 'For-good' utility apps remain free. Basic fixed tier starts at $200/month. Pay-per-use credits available as alternative to fixed tiers",
+      "tier": "Pay-per-use (no free tier)",
       "url": "https://developer.x.com/en/portal/products",
       "tags": [
         "social-media",
         "api",
         "twitter",
         "data",
-        "social"
+        "social",
+        "deal-change"
       ],
-      "verifiedDate": "2026-03-02"
+      "verifiedDate": "2026-03-10"
     },
     {
       "vendor": "Grafana k6 Cloud",

--- a/test/deal-changes.test.ts
+++ b/test/deal-changes.test.ts
@@ -89,7 +89,7 @@ describe("get_deal_changes tool", () => {
 
       assert.ok(Array.isArray(body.changes));
       assert.strictEqual(body.total, body.changes.length);
-      assert.strictEqual(body.total, 51);
+      assert.strictEqual(body.total, 52);
     } finally {
       proc.kill();
     }


### PR DESCRIPTION
## Summary
- **X/Twitter (#121):** Updated entry to reflect free tier elimination (Feb 2026), pay-per-use credit model, for-good exemption. Added deal_change entry.
- **Google Gemini API (#122):** Updated entry with Pro free tier removal and Flash 50-80% rate limit reductions. Enhanced existing deal_change with specific details.
- **Bright Data MCP Server (#123):** Updated entry with MCP-native positioning and 5K requests/month free tier details.

Refs #121, #122, #123

## Test plan
- [x] All 79 tests pass
- [x] Data validation passes (1506 offers, 52 deal changes)