### PR TITLE
Update Postman and GitHub Actions deal-change data

### DIFF
--- a/data/index.json
+++ b/data/index.json
@@ -453,9 +453,10 @@
         "ci",
         "cd",
         "automation",
-        "github"
+        "github",
+        "deal-change"
       ],
-      "verifiedDate": "2026-03-02"
+      "verifiedDate": "2026-03-10"
     },
     {
       "vendor": "GitLab CI",
@@ -2140,9 +2141,10 @@
         "testing",
         "api-testing",
         "api-development",
-        "mock-servers"
+        "mock-servers",
+        "deal-change"
       ],
-      "verifiedDate": "2026-03-01"
+      "verifiedDate": "2026-03-10"
     },
     {
       "vendor": "Directus",


### PR DESCRIPTION
## Summary

- Updated verifiedDate to 2026-03-10 for both Postman and GitHub Actions index entries
- Added `deal-change` tag to both entries per issue specification
- Both entries already had accurate descriptions and deal changes logged from prior cycles

**Existing data confirmed:**
- Postman: free plan single-user restriction (March 2026), deal change logged as "downgrade" with high impact, alternatives listed (Bruno, Insomnia, Hoppscotch, Apidog)
- GitHub Actions: self-hosted runner $0.002/min charge (March 2026) + hosted runner 39% price reduction, deal changes logged with medium impact

All 84 tests pass. 1,507 offers, 52 deal changes.

Refs #131