### PR TITLE
Add AI coding tools: Devin, Bolt.new, Lovable, Claude

### DIFF
--- a/data/index.json
+++ b/data/index.json
@@ -21119,6 +21119,66 @@
         "api"
       ],
       "verifiedDate": "2026-03-04"
+    },
+    {
+      "vendor": "Devin",
+      "category": "AI Coding",
+      "description": "Autonomous AI software engineer by Cognition Labs — handles code migrations, framework upgrades, prototypes, integrations, bug fixes. Core plan is pay-as-you-go at $2.25/ACU starting from $20. Team plan $500/mo (250 credits). Devin Review (PR review) is free during early release. Open-source maintainers with 100+ forks can apply for $500 in free credits.",
+      "tier": "Free Credits",
+      "url": "https://devin.ai/pricing",
+      "tags": [
+        "ai",
+        "coding",
+        "autonomous",
+        "code generation",
+        "developer tools"
+      ],
+      "verifiedDate": "2026-03-10"
+    },
+    {
+      "vendor": "Bolt.new",
+      "category": "AI Coding",
+      "description": "AI app builder by StackBlitz — generates frontend, backend, and database code in a live runtime environment. Free tier: 1M tokens/month (300K daily cap), unlimited databases, public + private projects, native hosting with Bolt branding, 10MB file upload limit. Paid plans from $20/mo for higher token limits.",
+      "tier": "Free",
+      "url": "https://bolt.new/pricing",
+      "tags": [
+        "ai",
+        "coding",
+        "app builder",
+        "full-stack",
+        "developer tools"
+      ],
+      "verifiedDate": "2026-03-10"
+    },
+    {
+      "vendor": "Lovable",
+      "category": "AI Coding",
+      "description": "AI app builder (formerly GPT Engineer) — generates full-stack apps from natural language. Free tier: 5 daily credits (up to 30/month), public and private projects, cloud hosting on lovable.app, Lovable branding badge. Pro $25/mo (100 credits + 5 daily). Business $50/mo.",
+      "tier": "Free",
+      "url": "https://lovable.dev/pricing",
+      "tags": [
+        "ai",
+        "coding",
+        "app builder",
+        "no-code",
+        "developer tools"
+      ],
+      "verifiedDate": "2026-03-10"
+    },
+    {
+      "vendor": "Claude",
+      "category": "AI Coding",
+      "description": "AI assistant by Anthropic for coding, analysis, and writing. Free tier: Claude.ai access with Projects (up to 5), Artifacts, and limited Sonnet usage — no API key required. Claude Code CLI available for Pro subscribers. Pro $20/mo, Team $25/seat/month, Max $125/mo.",
+      "tier": "Free",
+      "url": "https://claude.ai",
+      "tags": [
+        "ai",
+        "coding",
+        "llm",
+        "code generation",
+        "developer tools"
+      ],
+      "verifiedDate": "2026-03-10"
     }
   ]
 }

--- a/scripts/validate-data.ts
+++ b/scripts/validate-data.ts
@@ -9,6 +9,7 @@ const ROOT = resolve(__dirname, "..");
 
 const VALID_CATEGORIES = [
   "AI / ML",
+  "AI Coding",
   "API Development",
   "API Gateway",
   "Analytics",


### PR DESCRIPTION
Refs #133

## Summary
- Added 4 new entries in a new **AI Coding** category: Devin, Bolt.new, Lovable, Claude
- Added "AI Coding" to valid categories in validate-data.ts
- Verified pricing pages for all 4 tools — corrected several inaccuracies from the issue:
  - **Devin:** No genuine free plan — classified as "Free Credits" (free PR review during early release, OSS credits program). $20 is a pay-as-you-go minimum, not a subscription.
  - **Lovable:** Free plan includes private projects (not public-only as stated in issue)
  - **Claude:** Team plan is $25/seat/month (not $30/mo as stated in issue)
  - **Bolt.new:** Free tier details confirmed accurate
- 1,511 total offers. 53 categories. 84 tests passing. Validation clean.

## Test plan
- [x] `npm run validate` passes (1,511 offers, 52 deal changes)
- [x] All 84 tests pass
- [x] E2E verified via MCP stdio transport
- [x] New entries searchable by vendor name and category