### PR TITLE
Add REST API parity: /api/changes and /api/details/:vendor

### DIFF
--- a/src/serve.ts
+++ b/src/serve.ts
@@ -5,7 +5,7 @@ import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
 import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
 import { createServer } from "./server.js";
-import { loadOffers, getCategories, getNewOffers, searchOffers, loadDealChanges } from "./data.js";
+import { loadOffers, getCategories, getNewOffers, searchOffers, loadDealChanges, getDealChanges, getOfferDetails } from "./data.js";
 import { recordApiHit, recordSessionConnect, recordSessionDisconnect, recordLandingPageView, getStats, getConnectionStats, loadTelemetry, flushTelemetry } from "./stats.js";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -289,8 +289,12 @@ footer a{color:var(--text-muted)}
       <div class="how-card">
         <div class="how-card-icon">02</div>
         <h3>REST API</h3>
-        <p>Query deals programmatically with search, filtering, and pagination.</p>
-        <pre><code>GET /api/offers?q=database</code></pre>
+        <p>Query deals programmatically. 5 endpoints with search, filtering, and pagination.</p>
+        <pre><code>GET /api/offers?q=database
+GET /api/categories
+GET /api/new?days=7
+GET /api/changes?since=2025-01-01
+GET /api/details/Supabase</code></pre>
       </div>
       <div class="how-card">
         <div class="how-card-icon">03</div>
@@ -609,6 +613,37 @@ const httpServer = createHttpServer(async (req, res) => {
     const cats = getCategories();
     res.writeHead(200, { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" });
     res.end(JSON.stringify({ categories: cats }));
+  } else if (url.pathname === "/api/changes" && req.method === "GET") {
+    recordApiHit("/api/changes");
+    const since = url.searchParams.get("since") || undefined;
+    const type = url.searchParams.get("type") || undefined;
+    const vendorFilter = url.searchParams.get("vendor") || undefined;
+    // Validate since is a valid date if provided
+    if (since && !/^\d{4}-\d{2}-\d{2}/.test(since)) {
+      res.writeHead(400, { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" });
+      res.end(JSON.stringify({ error: "Invalid 'since' parameter. Expected ISO date string (YYYY-MM-DD)." }));
+      return;
+    }
+    const result = getDealChanges(since, type, vendorFilter);
+    res.writeHead(200, { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" });
+    res.end(JSON.stringify(result));
+  } else if (url.pathname.startsWith("/api/details/") && req.method === "GET") {
+    recordApiHit("/api/details");
+    const vendorParam = decodeURIComponent(url.pathname.slice("/api/details/".length));
+    if (!vendorParam) {
+      res.writeHead(400, { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" });
+      res.end(JSON.stringify({ error: "Vendor name is required." }));
+      return;
+    }
+    const includeAlternatives = url.searchParams.get("alternatives") === "true";
+    const detailResult = getOfferDetails(vendorParam, includeAlternatives);
+    if ("error" in detailResult) {
+      res.writeHead(404, { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" });
+      res.end(JSON.stringify({ error: detailResult.error, suggestions: detailResult.suggestions }));
+      return;
+    }
+    res.writeHead(200, { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" });
+    res.end(JSON.stringify({ offer: detailResult.offer, ...(includeAlternatives ? { alternatives: detailResult.offer.alternatives } : {}) }));
   } else if (url.pathname === "/") {
     recordLandingPageView();
     res.writeHead(200, { "Content-Type": "text/html; charset=utf-8" });

--- a/test/http.test.ts
+++ b/test/http.test.ts
@@ -522,6 +522,108 @@ describe("HTTP transport", () => {
     assert.strictEqual(body.sessions, 1);
   });
 
+  it("GET /api/changes returns deal changes", async () => {
+    proc = await startHttpServer();
+
+    const response = await fetch(`http://localhost:${PORT}/api/changes`);
+    assert.strictEqual(response.status, 200);
+    assert.strictEqual(response.headers.get("content-type"), "application/json");
+    const body = await response.json() as any;
+    assert.ok(Array.isArray(body.changes));
+    assert.ok(typeof body.total === "number");
+    assert.strictEqual(body.changes.length, body.total);
+  });
+
+  it("GET /api/changes filters by since, type, and vendor", async () => {
+    proc = await startHttpServer();
+
+    // Get all changes (use a very old date to get everything)
+    const allResp = await fetch(`http://localhost:${PORT}/api/changes?since=2020-01-01`);
+    const allBody = await allResp.json() as any;
+    assert.ok(allBody.total > 0, "Should have deal changes with since=2020-01-01");
+
+    // Filter by type
+    const typeResp = await fetch(`http://localhost:${PORT}/api/changes?since=2020-01-01&type=free_tier_removed`);
+    const typeBody = await typeResp.json() as any;
+    for (const c of typeBody.changes) {
+      assert.strictEqual(c.change_type, "free_tier_removed");
+    }
+
+    // Filter by vendor
+    const vendorResp = await fetch(`http://localhost:${PORT}/api/changes?since=2020-01-01&vendor=Google`);
+    const vendorBody = await vendorResp.json() as any;
+    for (const c of vendorBody.changes) {
+      assert.ok(c.vendor.toLowerCase().includes("google"));
+    }
+  });
+
+  it("GET /api/changes returns 400 for invalid since param", async () => {
+    proc = await startHttpServer();
+
+    const response = await fetch(`http://localhost:${PORT}/api/changes?since=not-a-date`);
+    assert.strictEqual(response.status, 400);
+    const body = await response.json() as any;
+    assert.ok(body.error.includes("Invalid"));
+  });
+
+  it("GET /api/details/:vendor returns offer details", async () => {
+    proc = await startHttpServer();
+
+    // Get a known vendor from /api/offers
+    const offersResp = await fetch(`http://localhost:${PORT}/api/offers?limit=1`);
+    const offersBody = await offersResp.json() as any;
+    const vendorName = offersBody.offers[0].vendor;
+
+    const response = await fetch(`http://localhost:${PORT}/api/details/${encodeURIComponent(vendorName)}`);
+    assert.strictEqual(response.status, 200);
+    const body = await response.json() as any;
+    assert.ok(body.offer);
+    assert.strictEqual(body.offer.vendor, vendorName);
+    assert.ok(!body.alternatives, "Should not include alternatives by default");
+  });
+
+  it("GET /api/details/:vendor?alternatives=true includes alternatives", async () => {
+    proc = await startHttpServer();
+
+    // Get a known vendor
+    const offersResp = await fetch(`http://localhost:${PORT}/api/offers?limit=1`);
+    const offersBody = await offersResp.json() as any;
+    const vendorName = offersBody.offers[0].vendor;
+
+    const response = await fetch(`http://localhost:${PORT}/api/details/${encodeURIComponent(vendorName)}?alternatives=true`);
+    assert.strictEqual(response.status, 200);
+    const body = await response.json() as any;
+    assert.ok(body.offer);
+    assert.ok(Array.isArray(body.alternatives));
+    assert.ok(body.alternatives.length <= 5);
+  });
+
+  it("GET /api/details/:vendor returns 404 for unknown vendor", async () => {
+    proc = await startHttpServer();
+
+    const response = await fetch(`http://localhost:${PORT}/api/details/${encodeURIComponent("NonExistentVendor12345")}`);
+    assert.strictEqual(response.status, 404);
+    const body = await response.json() as any;
+    assert.ok(body.error.includes("not found"));
+  });
+
+  it("GET /api/details/:vendor is case-insensitive", async () => {
+    proc = await startHttpServer();
+
+    // Get a known vendor
+    const offersResp = await fetch(`http://localhost:${PORT}/api/offers?limit=1`);
+    const offersBody = await offersResp.json() as any;
+    const vendorName = offersBody.offers[0].vendor;
+
+    // Request with different casing
+    const lowerName = vendorName.toLowerCase();
+    const response = await fetch(`http://localhost:${PORT}/api/details/${encodeURIComponent(lowerName)}`);
+    assert.strictEqual(response.status, 200);
+    const body = await response.json() as any;
+    assert.ok(body.offer);
+    assert.strictEqual(body.offer.vendor, vendorName);
+  });
+
   it("logs session_close on explicit DELETE", async () => {
     proc = await startHttpServer();
 


### PR DESCRIPTION
## Summary

- Adds `GET /api/changes` endpoint — REST equivalent of `get_deal_changes` MCP tool, with `since`, `type`, and `vendor` query params
- Adds `GET /api/details/:vendor` endpoint — REST equivalent of `get_offer_details` MCP tool, with `alternatives` query param for up to 5 same-category alternatives
- Both endpoints return proper error responses (400 for bad params, 404 for not found) and increment API hit counters
- Landing page API section updated to document all 5 REST endpoints
- 7 new tests (91 total)

Refs #135

## Test plan

- [x] All 91 tests pass (`npm test`)
- [x] E2E verified: `/api/changes?since=2024-01-01` returns 52 changes
- [x] E2E verified: `/api/details/Supabase` returns offer details
- [x] E2E verified: `/api/details/Supabase?alternatives=true` returns 5 alternatives
- [x] E2E verified: unknown vendor returns 404, bad date returns 400
- [x] Case-insensitive vendor matching confirmed

🤖 Generated with [Claude Code](https://claude.com/claude-code)