### PR TITLE
Add request-level query logging to Redis

### DIFF
--- a/src/openapi.ts
+++ b/src/openapi.ts
@@ -202,6 +202,45 @@ export const openapiSpec = {
         }
       }
     },
+    "/api/query-log": {
+      get: {
+        summary: "Recent request log",
+        description: "Returns recent request-level log entries for both MCP tool calls and REST API hits. Stored in Redis, capped at 1000 entries.",
+        parameters: [
+          { name: "limit", in: "query", description: "Number of entries to return (1-200)", schema: { type: "integer", default: 50 } }
+        ],
+        responses: {
+          "200": {
+            description: "Recent request log entries",
+            content: {
+              "application/json": {
+                schema: {
+                  type: "object",
+                  properties: {
+                    entries: {
+                      type: "array",
+                      items: {
+                        type: "object",
+                        properties: {
+                          ts: { type: "string", format: "date-time" },
+                          type: { type: "string", enum: ["mcp", "api"] },
+                          endpoint: { type: "string" },
+                          params: { type: "object" },
+                          user_agent: { type: "string" },
+                          result_count: { type: "integer" },
+                          session_id: { type: "string" }
+                        }
+                      }
+                    },
+                    count: { type: "integer" }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/stats": {
       get: {
         summary: "Service statistics",

--- a/src/serve.ts
+++ b/src/serve.ts
@@ -6,7 +6,7 @@ import { dirname, join } from "node:path";
 import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
 import { createServer } from "./server.js";
 import { loadOffers, getCategories, getNewOffers, searchOffers, loadDealChanges, getDealChanges, getOfferDetails } from "./data.js";
-import { recordApiHit, recordSessionConnect, recordSessionDisconnect, recordLandingPageView, getStats, getConnectionStats, loadTelemetry, flushTelemetry } from "./stats.js";
+import { recordApiHit, recordSessionConnect, recordSessionDisconnect, recordLandingPageView, getStats, getConnectionStats, loadTelemetry, flushTelemetry, logRequest, getRequestLog } from "./stats.js";
 import { openapiSpec } from "./openapi.js";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -290,12 +290,13 @@ footer a{color:var(--text-muted)}
       <div class="how-card">
         <div class="how-card-icon">02</div>
         <h3>REST API</h3>
-        <p>Query deals programmatically. 6 endpoints with search, filtering, and pagination.</p>
+        <p>Query deals programmatically. 7 endpoints with search, filtering, and pagination.</p>
         <pre><code>GET /api/offers?q=database
 GET /api/categories
 GET /api/new?days=7
 GET /api/changes?since=2025-01-01
 GET /api/details/Supabase
+GET /api/query-log?limit=50
 GET /api/openapi.json</code></pre>
       </div>
       <div class="how-card">
@@ -526,7 +527,7 @@ const httpServer = createHttpServer(async (req, res) => {
           }
         };
 
-        const mcpServer = createServer();
+        const mcpServer = createServer(() => transport.sessionId);
         await mcpServer.connect(transport);
         await transport.handleRequest(req, res, parsedBody);
       } else {
@@ -590,8 +591,14 @@ const httpServer = createHttpServer(async (req, res) => {
         { "email": "robvhunter@gmail.com" }
       ]
     }));
+  } else if (url.pathname === "/api/query-log" && req.method === "GET") {
+    const limit = Math.min(Math.max(parseInt(url.searchParams.get("limit") ?? "50", 10) || 50, 1), 200);
+    const entries = await getRequestLog(limit);
+    res.writeHead(200, { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" });
+    res.end(JSON.stringify({ entries, count: entries.length }));
   } else if (url.pathname === "/api/openapi.json" && req.method === "GET") {
     recordApiHit("/api/openapi.json");
+    logRequest({ ts: new Date().toISOString(), type: "api", endpoint: "/api/openapi.json", params: {}, user_agent: req.headers["user-agent"] ?? "unknown", result_count: 1 });
     res.writeHead(200, { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" });
     res.end(JSON.stringify(openapiSpec));
   } else if (url.pathname === "/api/stats" && req.method === "GET") {
@@ -606,17 +613,20 @@ const httpServer = createHttpServer(async (req, res) => {
     const results = searchOffers(q, category);
     const total = results.length;
     const paged = results.slice(offset, offset + limit);
+    logRequest({ ts: new Date().toISOString(), type: "api", endpoint: "/api/offers", params: { q, category, limit, offset }, user_agent: req.headers["user-agent"] ?? "unknown", result_count: paged.length });
     res.writeHead(200, { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" });
     res.end(JSON.stringify({ offers: paged, total }));
   } else if (url.pathname === "/api/new" && req.method === "GET") {
     recordApiHit("/api/new");
     const days = parseInt(url.searchParams.get("days") ?? "7", 10);
     const result = getNewOffers(days);
+    logRequest({ ts: new Date().toISOString(), type: "api", endpoint: "/api/new", params: { days }, user_agent: req.headers["user-agent"] ?? "unknown", result_count: result.offers.length });
     res.writeHead(200, { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" });
     res.end(JSON.stringify(result));
   } else if (url.pathname === "/api/categories" && req.method === "GET") {
     recordApiHit("/api/categories");
     const cats = getCategories();
+    logRequest({ ts: new Date().toISOString(), type: "api", endpoint: "/api/categories", params: {}, user_agent: req.headers["user-agent"] ?? "unknown", result_count: cats.length });
     res.writeHead(200, { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" });
     res.end(JSON.stringify({ categories: cats }));
   } else if (url.pathname === "/api/changes" && req.method === "GET") {
@@ -631,6 +641,7 @@ const httpServer = createHttpServer(async (req, res) => {
       return;
     }
     const result = getDealChanges(since, type, vendorFilter);
+    logRequest({ ts: new Date().toISOString(), type: "api", endpoint: "/api/changes", params: { since, type, vendor: vendorFilter }, user_agent: req.headers["user-agent"] ?? "unknown", result_count: result.changes.length });
     res.writeHead(200, { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" });
     res.end(JSON.stringify(result));
   } else if (url.pathname.startsWith("/api/details/") && req.method === "GET") {
@@ -644,10 +655,12 @@ const httpServer = createHttpServer(async (req, res) => {
     const includeAlternatives = url.searchParams.get("alternatives") === "true";
     const detailResult = getOfferDetails(vendorParam, includeAlternatives);
     if ("error" in detailResult) {
+      logRequest({ ts: new Date().toISOString(), type: "api", endpoint: "/api/details", params: { vendor: vendorParam, alternatives: includeAlternatives }, user_agent: req.headers["user-agent"] ?? "unknown", result_count: 0 });
       res.writeHead(404, { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" });
       res.end(JSON.stringify({ error: detailResult.error, suggestions: detailResult.suggestions }));
       return;
     }
+    logRequest({ ts: new Date().toISOString(), type: "api", endpoint: "/api/details", params: { vendor: vendorParam, alternatives: includeAlternatives }, user_agent: req.headers["user-agent"] ?? "unknown", result_count: 1 });
     res.writeHead(200, { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" });
     res.end(JSON.stringify({ offer: detailResult.offer, ...(includeAlternatives ? { alternatives: detailResult.offer.alternatives } : {}) }));
   } else if (url.pathname === "/") {

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,9 +1,9 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import { getCategories, getDealChanges, getNewOffers, getOfferDetails, searchOffers } from "./data.js";
-import { recordToolCall } from "./stats.js";
+import { recordToolCall, logRequest } from "./stats.js";
 
-export function createServer(): McpServer {
+export function createServer(getSessionId?: () => string | undefined): McpServer {
   const server = new McpServer({
     name: "agentdeals",
     version: "0.1.0",
@@ -20,6 +20,7 @@ export function createServer(): McpServer {
       try {
         recordToolCall("list_categories");
         const categories = getCategories();
+        logRequest({ ts: new Date().toISOString(), type: "mcp", endpoint: "list_categories", params: {}, result_count: categories.length, session_id: getSessionId?.() });
         return {
           content: [
             {
@@ -66,6 +67,7 @@ export function createServer(): McpServer {
         const effectiveOffset = offset ?? 0;
         const effectiveLimit = limit ?? (usePagination ? 20 : total);
         const results = allResults.slice(effectiveOffset, effectiveOffset + effectiveLimit);
+        logRequest({ ts: new Date().toISOString(), type: "mcp", endpoint: "search_offers", params: { query, category, eligibility_type, sort, limit: effectiveLimit, offset: effectiveOffset }, result_count: results.length, session_id: getSessionId?.() });
         return {
           content: [
             {
@@ -107,11 +109,13 @@ export function createServer(): McpServer {
           const msg = result.suggestions.length > 0
             ? `${result.error} Did you mean: ${result.suggestions.join(", ")}?`
             : `${result.error} No similar vendors found.`;
+          logRequest({ ts: new Date().toISOString(), type: "mcp", endpoint: "get_offer_details", params: { vendor, include_alternatives }, result_count: 0, session_id: getSessionId?.() });
           return {
             isError: true,
             content: [{ type: "text" as const, text: msg }],
           };
         }
+        logRequest({ ts: new Date().toISOString(), type: "mcp", endpoint: "get_offer_details", params: { vendor, include_alternatives }, result_count: 1, session_id: getSessionId?.() });
         return {
           content: [
             {
@@ -148,6 +152,7 @@ export function createServer(): McpServer {
       try {
         recordToolCall("get_new_offers");
         const result = getNewOffers(days ?? 7);
+        logRequest({ ts: new Date().toISOString(), type: "mcp", endpoint: "get_new_offers", params: { days: days ?? 7 }, result_count: result.offers.length, session_id: getSessionId?.() });
         return {
           content: [
             {
@@ -186,6 +191,7 @@ export function createServer(): McpServer {
       try {
         recordToolCall("get_deal_changes");
         const result = getDealChanges(since, change_type, vendor);
+        logRequest({ ts: new Date().toISOString(), type: "mcp", endpoint: "get_deal_changes", params: { since, change_type, vendor }, result_count: result.changes.length, session_id: getSessionId?.() });
         return {
           content: [
             {

--- a/src/stats.ts
+++ b/src/stats.ts
@@ -14,6 +14,7 @@ const toolCalls: Record<string, number> = {
   list_categories: 0,
   get_offer_details: 0,
   get_deal_changes: 0,
+  get_new_offers: 0,
 };
 
 const apiHits: Record<string, number> = {
@@ -94,6 +95,86 @@ async function redisSet(data: TelemetryData): Promise<boolean> {
   } catch {
     return false;
   }
+}
+
+// Request-level logging to Upstash Redis
+const REQUEST_LOG_KEY = "agentdeals:request_log";
+const REQUEST_LOG_MAX = 1000;
+
+export interface RequestLogEntry {
+  ts: string;
+  type: "mcp" | "api";
+  endpoint: string;
+  params: Record<string, unknown>;
+  user_agent?: string;
+  result_count: number;
+  session_id?: string;
+}
+
+async function redisLpush(key: string, value: string): Promise<boolean> {
+  if (!useRedis()) return false;
+  const url = process.env.UPSTASH_REDIS_REST_URL!;
+  const token = process.env.UPSTASH_REDIS_REST_TOKEN!;
+  try {
+    const res = await fetch(url, {
+      method: "POST",
+      headers: { Authorization: `Bearer ${token}`, "Content-Type": "application/json" },
+      body: JSON.stringify(["LPUSH", key, value]),
+    });
+    const json = (await res.json()) as { result?: number };
+    return typeof json.result === "number";
+  } catch {
+    return false;
+  }
+}
+
+async function redisLtrim(key: string, start: number, stop: number): Promise<boolean> {
+  if (!useRedis()) return false;
+  const url = process.env.UPSTASH_REDIS_REST_URL!;
+  const token = process.env.UPSTASH_REDIS_REST_TOKEN!;
+  try {
+    await fetch(url, {
+      method: "POST",
+      headers: { Authorization: `Bearer ${token}`, "Content-Type": "application/json" },
+      body: JSON.stringify(["LTRIM", key, start, stop]),
+    });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function redisLrange(key: string, start: number, stop: number): Promise<string[]> {
+  if (!useRedis()) return [];
+  const url = process.env.UPSTASH_REDIS_REST_URL!;
+  const token = process.env.UPSTASH_REDIS_REST_TOKEN!;
+  try {
+    const res = await fetch(url, {
+      method: "POST",
+      headers: { Authorization: `Bearer ${token}`, "Content-Type": "application/json" },
+      body: JSON.stringify(["LRANGE", key, start, stop]),
+    });
+    const json = (await res.json()) as { result?: string[] };
+    return json.result ?? [];
+  } catch {
+    return [];
+  }
+}
+
+export async function logRequest(entry: RequestLogEntry): Promise<void> {
+  const pushed = await redisLpush(REQUEST_LOG_KEY, JSON.stringify(entry));
+  if (pushed) {
+    // Cap list at REQUEST_LOG_MAX entries
+    await redisLtrim(REQUEST_LOG_KEY, 0, REQUEST_LOG_MAX - 1);
+  }
+}
+
+export async function getRequestLog(limit = 50): Promise<RequestLogEntry[]> {
+  const raw = await redisLrange(REQUEST_LOG_KEY, 0, limit - 1);
+  return raw.map((s) => {
+    try { return JSON.parse(s) as RequestLogEntry; }
+    catch { return null; }
+  }).filter((e): e is RequestLogEntry => e !== null);
 }
 
 function parseTelemetryData(data: Record<string, unknown>): void {

--- a/test/http.test.ts
+++ b/test/http.test.ts
@@ -704,7 +704,8 @@ describe("HTTP transport", () => {
     assert.ok(body.paths["/api/changes"]);
     assert.ok(body.paths["/api/details/{vendor}"]);
     assert.ok(body.paths["/api/stats"]);
-    assert.strictEqual(Object.keys(body.paths).length, 6);
+    assert.ok(body.paths["/api/query-log"]);
+    assert.strictEqual(Object.keys(body.paths).length, 7);
     assert.ok(body.components.schemas.Offer);
     assert.ok(body.components.schemas.DealChange);
     assert.ok(body.components.schemas.Eligibility);

--- a/test/query-log.test.ts
+++ b/test/query-log.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, afterEach } from "node:test";
+import assert from "node:assert";
+import { spawn, type ChildProcess } from "node:child_process";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const PORT = 3459; // Unique port to avoid conflicts
+
+function startHttpServer(): Promise<ChildProcess> {
+  return new Promise((resolve, reject) => {
+    const serverPath = path.join(__dirname, "..", "dist", "serve.js");
+    const proc = spawn("node", [serverPath], {
+      stdio: ["pipe", "pipe", "pipe"],
+      env: { ...process.env, PORT: String(PORT) },
+    });
+
+    const timeout = setTimeout(() => {
+      proc.kill();
+      reject(new Error("Server startup timeout"));
+    }, 5000);
+
+    proc.stderr!.on("data", (data: Buffer) => {
+      if (data.toString().includes("running on http")) {
+        clearTimeout(timeout);
+        resolve(proc);
+      }
+    });
+
+    proc.on("error", (err) => {
+      clearTimeout(timeout);
+      reject(err);
+    });
+  });
+}
+
+describe("query-log endpoint", () => {
+  let proc: ChildProcess | null = null;
+
+  afterEach(() => {
+    if (proc) {
+      proc.kill();
+      proc = null;
+    }
+  });
+
+  it("GET /api/query-log returns entries array and count", async () => {
+    proc = await startHttpServer();
+
+    const response = await fetch(`http://localhost:${PORT}/api/query-log`);
+    assert.strictEqual(response.status, 200);
+    assert.strictEqual(response.headers.get("content-type"), "application/json");
+    assert.strictEqual(response.headers.get("access-control-allow-origin"), "*");
+    const body = await response.json() as any;
+    assert.ok(Array.isArray(body.entries));
+    assert.ok(typeof body.count === "number");
+    assert.strictEqual(body.entries.length, body.count);
+  });
+
+  it("GET /api/query-log accepts limit parameter", async () => {
+    proc = await startHttpServer();
+
+    const response = await fetch(`http://localhost:${PORT}/api/query-log?limit=5`);
+    assert.strictEqual(response.status, 200);
+    const body = await response.json() as any;
+    assert.ok(Array.isArray(body.entries));
+    // limit is capped at 200
+    assert.ok(body.count <= 5);
+  });
+
+  it("GET /api/query-log clamps limit to 1-200 range", async () => {
+    proc = await startHttpServer();
+
+    // Negative limit should be clamped to 1
+    const resp1 = await fetch(`http://localhost:${PORT}/api/query-log?limit=-10`);
+    assert.strictEqual(resp1.status, 200);
+
+    // Large limit should be clamped to 200
+    const resp2 = await fetch(`http://localhost:${PORT}/api/query-log?limit=999`);
+    assert.strictEqual(resp2.status, 200);
+  });
+});
+
+describe("request log entry format", () => {
+  it("logRequest and getRequestLog handle entries correctly", async () => {
+    // Import the functions directly for unit testing
+    const { logRequest, getRequestLog } = await import("../dist/stats.js");
+
+    // Without Redis configured, logRequest is a no-op and getRequestLog returns empty
+    // This validates the functions exist and have correct signatures
+    const entry = {
+      ts: new Date().toISOString(),
+      type: "api" as const,
+      endpoint: "/api/offers",
+      params: { q: "database" },
+      user_agent: "test-agent",
+      result_count: 10,
+    };
+
+    // Should not throw
+    await logRequest(entry);
+
+    // Without Redis, returns empty array
+    const log = await getRequestLog(10);
+    assert.ok(Array.isArray(log));
+  });
+});
+
+describe("get_new_offers counter fix", () => {
+  it("toolCalls includes get_new_offers counter", async () => {
+    const { getStats, recordToolCall } = await import("../dist/stats.js");
+
+    recordToolCall("get_new_offers");
+    const stats = getStats();
+    assert.ok("get_new_offers" in stats.tool_calls, "toolCalls should include get_new_offers");
+    assert.ok(stats.tool_calls.get_new_offers >= 1, "get_new_offers counter should increment");
+  });
+});


### PR DESCRIPTION
## Summary
- Logs individual MCP tool calls and REST API hits to Upstash Redis (`agentdeals:request_log` list, capped at 1000 entries)
- Each entry captures: timestamp, type (mcp/api), endpoint, params, user_agent (REST only), result_count, session_id (MCP only)
- New `GET /api/query-log?limit=50` endpoint to retrieve recent entries
- Fixes bug: `get_new_offers` was missing from the `toolCalls` aggregate counter
- OpenAPI spec updated (7 endpoints total)
- 5 new tests, 97 total passing

## Test plan
- [x] All 97 tests pass (92 existing + 5 new)
- [x] E2E: `/api/query-log` returns `{entries: [], count: 0}` without Redis
- [x] E2E: MCP initialize + tool call flow works with session ID passthrough
- [x] E2E: `get_new_offers` now appears in `/health` stats `tool_calls` keys
- [x] Build clean (tsc, no errors)

Refs #139

🤖 Generated with [Claude Code](https://claude.com/claude-code)