### PR TITLE
Add get_stack_recommendation MCP tool and REST endpoint

### DIFF
--- a/src/openapi.ts
+++ b/src/openapi.ts
@@ -202,6 +202,55 @@ export const openapiSpec = {
         }
       }
     },
+    "/api/stack": {
+      get: {
+        summary: "Get free-tier stack recommendation",
+        description: "Returns a curated infrastructure stack recommendation based on your project type. Covers hosting, database, auth, and more — all free tier.",
+        parameters: [
+          { name: "use_case", in: "query", required: true, description: "What you're building (e.g., 'Next.js SaaS app', 'API backend', 'static blog')", schema: { type: "string" }, example: "Next.js SaaS app" },
+          { name: "requirements", in: "query", description: "Comma-separated infrastructure needs (e.g., 'database,auth,email')", schema: { type: "string" }, example: "database,auth,email" }
+        ],
+        responses: {
+          "200": {
+            description: "Stack recommendation",
+            content: {
+              "application/json": {
+                schema: {
+                  type: "object",
+                  properties: {
+                    use_case: { type: "string" },
+                    stack: {
+                      type: "array",
+                      items: {
+                        type: "object",
+                        properties: {
+                          role: { type: "string" },
+                          vendor: { type: "string" },
+                          tier: { type: "string" },
+                          description: { type: "string" },
+                          url: { type: "string", format: "uri" }
+                        }
+                      }
+                    },
+                    total_monthly_cost: { type: "string" },
+                    limitations: { type: "array", items: { type: "string" } },
+                    upgrade_path: { type: "string" }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            description: "Missing use_case parameter",
+            content: {
+              "application/json": {
+                schema: { type: "object", properties: { error: { type: "string" } } }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/query-log": {
       get: {
         summary: "Recent request log",

--- a/src/serve.ts
+++ b/src/serve.ts
@@ -6,6 +6,7 @@ import { dirname, join } from "node:path";
 import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
 import { createServer } from "./server.js";
 import { loadOffers, getCategories, getNewOffers, searchOffers, loadDealChanges, getDealChanges, getOfferDetails } from "./data.js";
+import { getStackRecommendation } from "./stacks.js";
 import { recordApiHit, recordSessionConnect, recordSessionDisconnect, recordLandingPageView, getStats, getConnectionStats, loadTelemetry, flushTelemetry, logRequest, getRequestLog } from "./stats.js";
 import { openapiSpec } from "./openapi.js";
 
@@ -290,12 +291,13 @@ footer a{color:var(--text-muted)}
       <div class="how-card">
         <div class="how-card-icon">02</div>
         <h3>REST API</h3>
-        <p>Query deals programmatically. 7 endpoints with search, filtering, and pagination.</p>
+        <p>Query deals programmatically. 8 endpoints with search, filtering, and stack recommendations.</p>
         <pre><code>GET /api/offers?q=database
 GET /api/categories
 GET /api/new?days=7
 GET /api/changes?since=2025-01-01
 GET /api/details/Supabase
+GET /api/stack?use_case=SaaS+app
 GET /api/query-log?limit=50
 GET /api/openapi.json</code></pre>
       </div>
@@ -591,6 +593,20 @@ const httpServer = createHttpServer(async (req, res) => {
         { "email": "robvhunter@gmail.com" }
       ]
     }));
+  } else if (url.pathname === "/api/stack" && req.method === "GET") {
+    recordApiHit("/api/stack");
+    const useCase = url.searchParams.get("use_case") || url.searchParams.get("q") || "";
+    if (!useCase) {
+      res.writeHead(400, { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" });
+      res.end(JSON.stringify({ error: "use_case parameter is required (e.g., ?use_case=Next.js+SaaS+app)" }));
+      return;
+    }
+    const requirementsParam = url.searchParams.get("requirements");
+    const requirements = requirementsParam ? requirementsParam.split(",").map(r => r.trim()).filter(Boolean) : undefined;
+    const result = getStackRecommendation(useCase, requirements);
+    logRequest({ ts: new Date().toISOString(), type: "api", endpoint: "/api/stack", params: { use_case: useCase, requirements }, user_agent: req.headers["user-agent"] ?? "unknown", result_count: result.stack.length });
+    res.writeHead(200, { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" });
+    res.end(JSON.stringify(result));
   } else if (url.pathname === "/api/query-log" && req.method === "GET") {
     const limit = Math.min(Math.max(parseInt(url.searchParams.get("limit") ?? "50", 10) || 50, 1), 200);
     const entries = await getRequestLog(limit);

--- a/src/server.ts
+++ b/src/server.ts
@@ -2,6 +2,7 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import { getCategories, getDealChanges, getNewOffers, getOfferDetails, searchOffers } from "./data.js";
 import { recordToolCall, logRequest } from "./stats.js";
+import { getStackRecommendation } from "./stacks.js";
 
 export function createServer(getSessionId?: () => string | undefined): McpServer {
   const server = new McpServer({
@@ -208,6 +209,44 @@ export function createServer(getSessionId?: () => string | undefined): McpServer
             {
               type: "text" as const,
               text: `Error getting deal changes: ${err instanceof Error ? err.message : String(err)}`,
+            },
+          ],
+        };
+      }
+    }
+  );
+
+  server.registerTool(
+    "get_stack_recommendation",
+    {
+      description:
+        "Get a complete free-tier infrastructure stack recommendation for your project. Instead of searching category by category, describe what you're building and get a curated stack with hosting, database, auth, and more — all free tier. Covers SaaS apps, API backends, static sites, mobile apps, AI/ML projects, e-commerce, and DevOps.",
+      inputSchema: {
+        use_case: z.string().describe("What you're building (e.g., 'Next.js SaaS app', 'Python API backend', 'static blog', 'mobile app', 'AI chatbot')"),
+        requirements: z.array(z.string()).optional().describe("Specific infrastructure needs to include (e.g., ['database', 'auth', 'email', 'monitoring']). Overrides template defaults when provided."),
+      },
+    },
+    async ({ use_case, requirements }) => {
+      try {
+        recordToolCall("get_stack_recommendation");
+        const result = getStackRecommendation(use_case, requirements);
+        logRequest({ ts: new Date().toISOString(), type: "mcp", endpoint: "get_stack_recommendation", params: { use_case, requirements }, result_count: result.stack.length, session_id: getSessionId?.() });
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: JSON.stringify(result, null, 2),
+            },
+          ],
+        };
+      } catch (err) {
+        console.error("get_stack_recommendation error:", err);
+        return {
+          isError: true,
+          content: [
+            {
+              type: "text" as const,
+              text: `Error getting stack recommendation: ${err instanceof Error ? err.message : String(err)}`,
             },
           ],
         };

--- a/src/stacks.ts
+++ b/src/stacks.ts
@@ -1,0 +1,244 @@
+import { searchOffers } from "./data.js";
+import type { Offer } from "./types.js";
+
+export interface StackComponent {
+  role: string;
+  vendor: string;
+  tier: string;
+  description: string;
+  url: string;
+}
+
+export interface StackRecommendation {
+  use_case: string;
+  stack: StackComponent[];
+  total_monthly_cost: string;
+  limitations: string[];
+  upgrade_path: string;
+}
+
+interface StackTemplate {
+  keywords: string[];
+  roles: { role: string; category: string; preferredVendors?: string[] }[];
+  upgrade_path: string;
+}
+
+const TEMPLATES: StackTemplate[] = [
+  {
+    keywords: ["saas", "web app", "webapp", "next.js", "nextjs", "react app", "full-stack", "fullstack"],
+    roles: [
+      { role: "Hosting", category: "Cloud Hosting", preferredVendors: ["Vercel", "Netlify", "Railway"] },
+      { role: "Database", category: "Databases", preferredVendors: ["Supabase", "Neon", "PlanetScale"] },
+      { role: "Auth", category: "Auth", preferredVendors: ["Clerk", "Auth0", "Supabase"] },
+      { role: "Email", category: "Email", preferredVendors: ["Resend", "SendGrid", "Mailgun"] },
+    ],
+    upgrade_path: "Vercel Pro ($20/mo) + Supabase Pro ($25/mo) for production workloads",
+  },
+  {
+    keywords: ["api", "backend", "server", "express", "fastapi", "python api", "node api", "rest api"],
+    roles: [
+      { role: "Hosting", category: "Cloud Hosting", preferredVendors: ["Railway", "Render", "Fly.io"] },
+      { role: "Database", category: "Databases", preferredVendors: ["Supabase", "Neon", "CockroachDB"] },
+      { role: "Monitoring", category: "Monitoring", preferredVendors: ["Grafana Cloud", "Betterstack", "Checkly"] },
+      { role: "Logging", category: "Logging", preferredVendors: ["Betterstack", "Logflare", "Axiom"] },
+    ],
+    upgrade_path: "Railway Starter ($5/mo) + managed database for production traffic",
+  },
+  {
+    keywords: ["static", "blog", "landing page", "portfolio", "docs", "documentation", "jamstack"],
+    roles: [
+      { role: "Hosting", category: "CDN", preferredVendors: ["Cloudflare Pages", "Netlify", "Vercel"] },
+      { role: "DNS", category: "DNS & Domain Management", preferredVendors: ["Cloudflare", "Namecheap"] },
+      { role: "CI/CD", category: "CI/CD", preferredVendors: ["GitHub Actions", "Cloudflare Pages", "Netlify"] },
+    ],
+    upgrade_path: "Most static hosting free tiers are generous enough for production",
+  },
+  {
+    keywords: ["mobile", "ios", "android", "react native", "flutter", "mobile app"],
+    roles: [
+      { role: "Backend", category: "Cloud Hosting", preferredVendors: ["Supabase", "Firebase", "Railway"] },
+      { role: "Database", category: "Databases", preferredVendors: ["Supabase", "Firebase", "MongoDB Atlas"] },
+      { role: "Auth", category: "Auth", preferredVendors: ["Firebase", "Supabase", "Auth0"] },
+      { role: "Push Notifications", category: "Communication", preferredVendors: ["Firebase", "OneSignal"] },
+    ],
+    upgrade_path: "Firebase Blaze (pay-as-you-go) or Supabase Pro ($25/mo) for production",
+  },
+  {
+    keywords: ["ai", "ml", "machine learning", "llm", "chatbot", "ai app", "ai agent"],
+    roles: [
+      { role: "AI/ML", category: "AI / ML", preferredVendors: ["OpenAI", "Google Gemini API", "Anthropic", "Groq"] },
+      { role: "Hosting", category: "Cloud Hosting", preferredVendors: ["Railway", "Render", "Fly.io"] },
+      { role: "Database", category: "Databases", preferredVendors: ["Supabase", "Neon", "Upstash"] },
+    ],
+    upgrade_path: "AI API costs scale with usage; budget $20-50/mo for moderate LLM traffic",
+  },
+  {
+    keywords: ["ecommerce", "e-commerce", "store", "shop", "marketplace"],
+    roles: [
+      { role: "Hosting", category: "Cloud Hosting", preferredVendors: ["Vercel", "Netlify", "Railway"] },
+      { role: "Database", category: "Databases", preferredVendors: ["Supabase", "PlanetScale", "Neon"] },
+      { role: "Payments", category: "Payments", preferredVendors: ["Stripe", "LemonSqueezy"] },
+      { role: "Auth", category: "Auth", preferredVendors: ["Clerk", "Auth0", "Supabase"] },
+      { role: "Email", category: "Email", preferredVendors: ["Resend", "SendGrid"] },
+    ],
+    upgrade_path: "Stripe fees are per-transaction (2.9% + $0.30); hosting/DB ~$45/mo for production",
+  },
+  {
+    keywords: ["devops", "infrastructure", "platform", "internal tool"],
+    roles: [
+      { role: "CI/CD", category: "CI/CD", preferredVendors: ["GitHub Actions", "GitLab CI", "CircleCI"] },
+      { role: "Container Registry", category: "Container Registry", preferredVendors: ["GitHub Container Registry", "Docker Hub"] },
+      { role: "Monitoring", category: "Monitoring", preferredVendors: ["Grafana Cloud", "Betterstack", "UptimeRobot"] },
+      { role: "Error Tracking", category: "Error Tracking", preferredVendors: ["Sentry", "GlitchTip"] },
+    ],
+    upgrade_path: "GitHub Team ($4/user/mo) + Grafana Cloud Pro for larger teams",
+  },
+];
+
+const ROLE_TO_CATEGORY: Record<string, string> = {
+  hosting: "Cloud Hosting",
+  database: "Databases",
+  db: "Databases",
+  auth: "Auth",
+  authentication: "Auth",
+  email: "Email",
+  cdn: "CDN",
+  "ci/cd": "CI/CD",
+  cicd: "CI/CD",
+  ci: "CI/CD",
+  monitoring: "Monitoring",
+  logging: "Logging",
+  search: "Search",
+  storage: "Storage",
+  analytics: "Analytics",
+  payments: "Payments",
+  "error tracking": "Error Tracking",
+  security: "Security",
+  "feature flags": "Feature Flags",
+  testing: "Testing",
+  "ai/ml": "AI / ML",
+  ai: "AI / ML",
+  ml: "AI / ML",
+  dns: "DNS & Domain Management",
+  cms: "Headless CMS",
+  messaging: "Messaging",
+  push: "Communication",
+};
+
+function findBestOffer(category: string, preferredVendors?: string[]): Offer | null {
+  const offers = searchOffers(undefined, category);
+  // Only consider public/free offers
+  const publicOffers = offers.filter(
+    (o) => o.tier === "Free" || o.tier === "Hobby" || o.tier === "Open Source" || o.tier === "Free Credits"
+  );
+  if (publicOffers.length === 0) return offers[0] ?? null;
+
+  // Try preferred vendors first
+  if (preferredVendors) {
+    for (const vendor of preferredVendors) {
+      const match = publicOffers.find(
+        (o) => o.vendor.toLowerCase() === vendor.toLowerCase()
+      );
+      if (match) return match;
+    }
+  }
+
+  // Fall back to first public free-tier offer
+  return publicOffers[0];
+}
+
+function matchTemplate(useCase: string): StackTemplate | null {
+  const lower = useCase.toLowerCase();
+  let bestMatch: StackTemplate | null = null;
+  let bestScore = 0;
+
+  for (const template of TEMPLATES) {
+    let score = 0;
+    for (const keyword of template.keywords) {
+      if (lower.includes(keyword)) {
+        score += keyword.length; // Longer keyword matches are more specific
+      }
+    }
+    if (score > bestScore) {
+      bestScore = score;
+      bestMatch = template;
+    }
+  }
+
+  return bestMatch;
+}
+
+function buildLimitations(stack: StackComponent[]): string[] {
+  const limitations: string[] = [];
+  for (const component of stack) {
+    // Extract key limitations from description
+    const desc = component.description.toLowerCase();
+    if (desc.includes("hobby") || desc.includes("non-commercial")) {
+      limitations.push(`${component.vendor} free tier may restrict commercial use`);
+    }
+    if (desc.includes("pause") || desc.includes("sleep") || desc.includes("inactive")) {
+      limitations.push(`${component.vendor} may pause after inactivity`);
+    }
+  }
+  if (limitations.length === 0) {
+    limitations.push("Free tiers have usage limits — check vendor pricing pages for details");
+  }
+  return limitations;
+}
+
+export function getStackRecommendation(
+  useCase: string,
+  requirements?: string[]
+): StackRecommendation {
+  let roles: { role: string; category: string; preferredVendors?: string[] }[];
+  let upgradePath: string;
+
+  if (requirements && requirements.length > 0) {
+    // User-specified requirements override template
+    roles = requirements.map((req) => {
+      const lower = req.toLowerCase();
+      const category = ROLE_TO_CATEGORY[lower] ?? req;
+      return { role: req.charAt(0).toUpperCase() + req.slice(1), category };
+    });
+    upgradePath = "Check individual vendor pricing pages for upgrade options";
+  } else {
+    const template = matchTemplate(useCase);
+    if (template) {
+      roles = template.roles;
+      upgradePath = template.upgrade_path;
+    } else {
+      // Fallback: common categories
+      roles = [
+        { role: "Hosting", category: "Cloud Hosting" },
+        { role: "Database", category: "Databases" },
+        { role: "Auth", category: "Auth" },
+        { role: "CI/CD", category: "CI/CD" },
+      ];
+      upgradePath = "Check individual vendor pricing pages for upgrade options";
+    }
+  }
+
+  const stack: StackComponent[] = [];
+  for (const { role, category, preferredVendors } of roles) {
+    const offer = findBestOffer(category, preferredVendors);
+    if (offer) {
+      stack.push({
+        role,
+        vendor: offer.vendor,
+        tier: offer.tier,
+        description: offer.description.length > 200 ? offer.description.slice(0, 197) + "..." : offer.description,
+        url: offer.url,
+      });
+    }
+  }
+
+  const limitations = buildLimitations(stack);
+
+  return {
+    use_case: useCase,
+    stack,
+    total_monthly_cost: "$0",
+    limitations,
+    upgrade_path: upgradePath,
+  };
+}

--- a/src/stats.ts
+++ b/src/stats.ts
@@ -15,11 +15,13 @@ const toolCalls: Record<string, number> = {
   get_offer_details: 0,
   get_deal_changes: 0,
   get_new_offers: 0,
+  get_stack_recommendation: 0,
 };
 
 const apiHits: Record<string, number> = {
   "/api/offers": 0,
   "/api/categories": 0,
+  "/api/stack": 0,
 };
 
 let totalSessions = 0;

--- a/test/http.test.ts
+++ b/test/http.test.ts
@@ -705,7 +705,8 @@ describe("HTTP transport", () => {
     assert.ok(body.paths["/api/details/{vendor}"]);
     assert.ok(body.paths["/api/stats"]);
     assert.ok(body.paths["/api/query-log"]);
-    assert.strictEqual(Object.keys(body.paths).length, 7);
+    assert.ok(body.paths["/api/stack"]);
+    assert.strictEqual(Object.keys(body.paths).length, 8);
     assert.ok(body.components.schemas.Offer);
     assert.ok(body.components.schemas.DealChange);
     assert.ok(body.components.schemas.Eligibility);

--- a/test/stacks.test.ts
+++ b/test/stacks.test.ts
@@ -1,0 +1,141 @@
+import { describe, it, afterEach } from "node:test";
+import assert from "node:assert";
+import { spawn, type ChildProcess } from "node:child_process";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+describe("stack recommendation logic", () => {
+  it("returns stack for SaaS use case", async () => {
+    const { getStackRecommendation } = await import("../dist/stacks.js");
+    const result = getStackRecommendation("Next.js SaaS app");
+    assert.strictEqual(result.use_case, "Next.js SaaS app");
+    assert.ok(result.stack.length >= 3, "SaaS stack should have at least 3 components");
+    assert.strictEqual(result.total_monthly_cost, "$0");
+    assert.ok(Array.isArray(result.limitations));
+    assert.ok(typeof result.upgrade_path === "string");
+
+    // Check stack components have required fields
+    for (const component of result.stack) {
+      assert.ok(component.role, "Should have role");
+      assert.ok(component.vendor, "Should have vendor");
+      assert.ok(component.tier, "Should have tier");
+      assert.ok(component.description, "Should have description");
+      assert.ok(component.url, "Should have url");
+    }
+
+    // Should include hosting and database roles
+    const roles = result.stack.map((c: any) => c.role);
+    assert.ok(roles.includes("Hosting"), "SaaS stack should include Hosting");
+    assert.ok(roles.includes("Database"), "SaaS stack should include Database");
+  });
+
+  it("returns stack for API backend use case", async () => {
+    const { getStackRecommendation } = await import("../dist/stacks.js");
+    const result = getStackRecommendation("Python API backend");
+    assert.ok(result.stack.length >= 3);
+    const roles = result.stack.map((c: any) => c.role);
+    assert.ok(roles.includes("Hosting"));
+    assert.ok(roles.includes("Database"));
+  });
+
+  it("returns stack for static site use case", async () => {
+    const { getStackRecommendation } = await import("../dist/stacks.js");
+    const result = getStackRecommendation("static blog");
+    assert.ok(result.stack.length >= 2);
+  });
+
+  it("returns stack for mobile app use case", async () => {
+    const { getStackRecommendation } = await import("../dist/stacks.js");
+    const result = getStackRecommendation("React Native mobile app");
+    assert.ok(result.stack.length >= 3);
+  });
+
+  it("returns stack for AI/ML use case", async () => {
+    const { getStackRecommendation } = await import("../dist/stacks.js");
+    const result = getStackRecommendation("AI chatbot");
+    assert.ok(result.stack.length >= 2);
+    const roles = result.stack.map((c: any) => c.role);
+    assert.ok(roles.includes("AI/ML"), "AI stack should include AI/ML role");
+  });
+
+  it("requirements override template defaults", async () => {
+    const { getStackRecommendation } = await import("../dist/stacks.js");
+    const result = getStackRecommendation("my project", ["database", "monitoring", "search"]);
+    assert.strictEqual(result.stack.length, 3);
+    const roles = result.stack.map((c: any) => c.role.toLowerCase());
+    assert.ok(roles.includes("database"));
+    assert.ok(roles.includes("monitoring"));
+    assert.ok(roles.includes("search"));
+  });
+
+  it("falls back gracefully for unknown use case", async () => {
+    const { getStackRecommendation } = await import("../dist/stacks.js");
+    const result = getStackRecommendation("quantum teleporter management system");
+    // Should return fallback stack with common categories
+    assert.ok(result.stack.length >= 3);
+    assert.strictEqual(result.total_monthly_cost, "$0");
+  });
+
+  it("description is capped at 200 characters", async () => {
+    const { getStackRecommendation } = await import("../dist/stacks.js");
+    const result = getStackRecommendation("Next.js SaaS app");
+    for (const component of result.stack) {
+      assert.ok(component.description.length <= 200, `Description for ${component.vendor} exceeds 200 chars`);
+    }
+  });
+});
+
+describe("stack REST endpoint", () => {
+  const PORT = 3461;
+  let proc: ChildProcess | null = null;
+
+  function startHttpServer(): Promise<ChildProcess> {
+    return new Promise((resolve, reject) => {
+      const serverPath = path.join(__dirname, "..", "dist", "serve.js");
+      const p = spawn("node", [serverPath], {
+        stdio: ["pipe", "pipe", "pipe"],
+        env: { ...process.env, PORT: String(PORT) },
+      });
+      const timeout = setTimeout(() => { p.kill(); reject(new Error("Server startup timeout")); }, 5000);
+      p.stderr!.on("data", (data: Buffer) => {
+        if (data.toString().includes("running on http")) { clearTimeout(timeout); resolve(p); }
+      });
+      p.on("error", (err) => { clearTimeout(timeout); reject(err); });
+    });
+  }
+
+  afterEach(() => {
+    if (proc) { proc.kill(); proc = null; }
+  });
+
+  it("GET /api/stack returns stack recommendation", async () => {
+    proc = await startHttpServer();
+    const response = await fetch(`http://localhost:${PORT}/api/stack?use_case=SaaS+web+app`);
+    assert.strictEqual(response.status, 200);
+    assert.strictEqual(response.headers.get("access-control-allow-origin"), "*");
+    const body = await response.json() as any;
+    assert.ok(Array.isArray(body.stack));
+    assert.ok(body.stack.length >= 3);
+    assert.strictEqual(body.total_monthly_cost, "$0");
+    assert.ok(Array.isArray(body.limitations));
+    assert.ok(typeof body.upgrade_path === "string");
+  });
+
+  it("GET /api/stack returns 400 without use_case", async () => {
+    proc = await startHttpServer();
+    const response = await fetch(`http://localhost:${PORT}/api/stack`);
+    assert.strictEqual(response.status, 400);
+    const body = await response.json() as any;
+    assert.ok(body.error.includes("use_case"));
+  });
+
+  it("GET /api/stack accepts requirements parameter", async () => {
+    proc = await startHttpServer();
+    const response = await fetch(`http://localhost:${PORT}/api/stack?use_case=my+app&requirements=database,auth,monitoring`);
+    assert.strictEqual(response.status, 200);
+    const body = await response.json() as any;
+    assert.strictEqual(body.stack.length, 3);
+  });
+});


### PR DESCRIPTION
## Summary
- New `get_stack_recommendation` MCP tool: describe your project, get a curated free-tier infrastructure stack in a single call
- 7 stack templates covering common use cases (SaaS, API backend, static site, mobile, AI/ML, e-commerce, DevOps)
- Optional `requirements` parameter to override template defaults with specific needs
- Graceful fallback for unknown use cases (returns top offers per common category)
- New `GET /api/stack?use_case=...&requirements=...` REST endpoint
- OpenAPI spec updated (8 endpoints total)
- 11 new tests, 108 total passing

## Test plan
- [x] All 108 tests pass (97 existing + 11 new)
- [x] E2E: `/api/stack?use_case=Next.js+SaaS+app` returns 4-component stack (Vercel, Supabase, Clerk, Resend)
- [x] E2E: MCP tool call via HTTP transport returns valid stack response
- [x] E2E: `/api/stack` without use_case returns 400
- [x] Template matching: SaaS, API, static, mobile, AI/ML all return appropriate stacks
- [x] Requirements override: custom requirements produce matching stack
- [x] Unknown use case fallback works
- [x] Build clean (tsc, no errors)

Refs #140

🤖 Generated with [Claude Code](https://claude.com/claude-code)