### PR TITLE
Fix /api/stats to return Redis-persisted cumulative metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,7 +186,9 @@ Response:
 ```json
 {
   "activeSessions": 1,
-  "totalSessionsAllTime": 47,
+  "totalSessionsAllTime": 628,
+  "totalApiHitsAllTime": 516,
+  "totalToolCallsAllTime": 281,
   "sessionsToday": 3,
   "serverStarted": "2026-03-01T00:00:00.000Z"
 }

--- a/src/openapi.ts
+++ b/src/openapi.ts
@@ -293,7 +293,7 @@ export const openapiSpec = {
     "/api/stats": {
       get: {
         summary: "Service statistics",
-        description: "Returns aggregate service statistics including uptime, total offers, categories, and usage counts.",
+        description: "Returns connection and usage statistics. Session and usage counts persist across deploys via Redis.",
         responses: {
           "200": {
             description: "Service statistics",
@@ -302,14 +302,12 @@ export const openapiSpec = {
                 schema: {
                   type: "object",
                   properties: {
-                    uptime_seconds: { type: "number" },
-                    total_offers: { type: "integer" },
-                    total_categories: { type: "integer" },
-                    total_deal_changes: { type: "integer" },
-                    sessions: { type: "integer" },
-                    tool_calls: { type: "object" },
-                    api_hits: { type: "object" },
-                    landing_page_views: { type: "integer" }
+                    activeSessions: { type: "integer", description: "Currently connected MCP sessions" },
+                    totalSessionsAllTime: { type: "integer", description: "Cumulative sessions across all deploys (persisted in Redis)" },
+                    totalApiHitsAllTime: { type: "integer", description: "Cumulative REST API hits across all deploys (persisted in Redis)" },
+                    totalToolCallsAllTime: { type: "integer", description: "Cumulative MCP tool calls across all deploys (persisted in Redis)" },
+                    sessionsToday: { type: "integer", description: "Sessions since midnight UTC (resets daily)" },
+                    serverStarted: { type: "string", format: "date-time", description: "ISO timestamp of current server start" }
                   }
                 }
               }

--- a/src/stats.ts
+++ b/src/stats.ts
@@ -330,6 +330,8 @@ export function getStats(): {
 export function getConnectionStats(activeSessions: number): {
   activeSessions: number;
   totalSessionsAllTime: number;
+  totalApiHitsAllTime: number;
+  totalToolCallsAllTime: number;
   sessionsToday: number;
   serverStarted: string;
 } {
@@ -338,9 +340,13 @@ export function getConnectionStats(activeSessions: number): {
     sessionsToday = 0;
     sessionsTodayDate = today;
   }
+  const totalToolCalls = Object.values(toolCalls).reduce((a, b) => a + b, 0);
+  const totalApiHits = Object.values(apiHits).reduce((a, b) => a + b, 0);
   return {
     activeSessions,
-    totalSessionsAllTime: totalSessions,
+    totalSessionsAllTime: cumulative.sessions + totalSessions,
+    totalApiHitsAllTime: cumulative.api_hits + totalApiHits,
+    totalToolCallsAllTime: cumulative.tool_calls + totalToolCalls,
     sessionsToday,
     serverStarted: serverStartedISO,
   };

--- a/test/http.test.ts
+++ b/test/http.test.ts
@@ -459,6 +459,8 @@ describe("HTTP transport", () => {
     const stats0 = await resp0.json() as any;
     assert.strictEqual(stats0.activeSessions, 0);
     assert.ok(typeof stats0.totalSessionsAllTime === "number");
+    assert.ok(typeof stats0.totalApiHitsAllTime === "number");
+    assert.ok(typeof stats0.totalToolCallsAllTime === "number");
     assert.ok(typeof stats0.sessionsToday === "number");
     assert.ok(typeof stats0.serverStarted === "string");
     // serverStarted should be a valid ISO timestamp


### PR DESCRIPTION
## Summary

- `getConnectionStats()` was returning in-memory `totalSessions` counter which reset to zero on every deploy
- Now returns `cumulative.sessions + totalSessions` — the Redis-backed all-time value
- Added `totalApiHitsAllTime` and `totalToolCallsAllTime` to the `/api/stats` response
- Updated OpenAPI spec to document the corrected schema
- Updated README example response

No new Redis code needed — the persistence infrastructure already existed from PR #111. This was purely a bug in which counter `getConnectionStats()` returned.

## Test plan

- [x] All 108 tests pass
- [x] `GET /api/stats` test updated to verify new fields
- [x] `sessionsToday` and `activeSessions` remain in-memory (as expected)

Refs #145

🤖 Generated with [Claude Code](https://claude.com/claude-code)