### PR TITLE
Log MCP client info on session creation

### DIFF
--- a/src/openapi.ts
+++ b/src/openapi.ts
@@ -307,7 +307,8 @@ export const openapiSpec = {
                     totalApiHitsAllTime: { type: "integer", description: "Cumulative REST API hits across all deploys (persisted in Redis)" },
                     totalToolCallsAllTime: { type: "integer", description: "Cumulative MCP tool calls across all deploys (persisted in Redis)" },
                     sessionsToday: { type: "integer", description: "Sessions since midnight UTC (resets daily)" },
-                    serverStarted: { type: "string", format: "date-time", description: "ISO timestamp of current server start" }
+                    serverStarted: { type: "string", format: "date-time", description: "ISO timestamp of current server start" },
+                    clients: { type: "object", additionalProperties: { type: "integer" }, description: "Cumulative session counts per MCP client name (e.g. claude-desktop, cursor)" }
                   }
                 }
               }

--- a/src/serve.ts
+++ b/src/serve.ts
@@ -20,10 +20,16 @@ const faviconBuffer = readFileSync(join(__dirname, "..", "assets", "logo-400.png
 const SESSION_IDLE_TIMEOUT_MS = 15 * 60 * 1000; // 15 minutes
 const CLEANUP_INTERVAL_MS = 60 * 1000; // 60 seconds
 
+interface ClientInfo {
+  name: string;
+  version: string;
+}
+
 interface SessionEntry {
   transport: StreamableHTTPServerTransport;
   lastActivity: number;
   createdAt: number;
+  clientInfo?: ClientInfo;
 }
 
 // Map of session ID → transport + last activity for multi-session support
@@ -466,6 +472,18 @@ function isInitializeRequest(body: unknown): boolean {
   return (body as { method?: string })?.method === "initialize";
 }
 
+function extractClientInfo(body: unknown): ClientInfo | undefined {
+  const msg = Array.isArray(body)
+    ? body.find((m) => m?.method === "initialize")
+    : body;
+  const params = (msg as { params?: { clientInfo?: { name?: string; version?: string } } })?.params;
+  const info = params?.clientInfo;
+  if (info?.name) {
+    return { name: info.name, version: info.version ?? "unknown" };
+  }
+  return undefined;
+}
+
 const httpServer = createHttpServer(async (req, res) => {
   const url = new URL(req.url ?? "/", `http://localhost:${PORT}`);
 
@@ -496,19 +514,30 @@ const httpServer = createHttpServer(async (req, res) => {
         // New session — create transport + server
         const ip = getClientIp(req);
         const userAgent = req.headers["user-agent"] ?? "unknown";
+        const clientInfo = extractClientInfo(parsedBody);
         const transport = new StreamableHTTPServerTransport({
           sessionIdGenerator: () => randomUUID(),
           onsessioninitialized: (sid) => {
             const now = Date.now();
-            sessions.set(sid, { transport, lastActivity: now, createdAt: now });
-            recordSessionConnect();
+            sessions.set(sid, { transport, lastActivity: now, createdAt: now, clientInfo });
+            recordSessionConnect(clientInfo?.name);
             console.log(JSON.stringify({
               event: "session_open",
               ts: new Date(now).toISOString(),
               sessionId: sid,
               ip,
               userAgent,
+              clientInfo,
             }));
+            logRequest({
+              ts: new Date(now).toISOString(),
+              type: "session_connect",
+              endpoint: "initialize",
+              params: {},
+              result_count: 0,
+              session_id: sid,
+              client_info: clientInfo,
+            });
           },
         });
 

--- a/src/stats.ts
+++ b/src/stats.ts
@@ -38,6 +38,7 @@ let cumulative = {
   landing_views: 0,
   first_session_at: "",
   last_deploy_at: "",
+  clients: {} as Record<string, number>,
 };
 
 let telemetryPath = "";
@@ -56,6 +57,7 @@ interface TelemetryData {
   cumulative_landing_views: number;
   first_session_at: string;
   last_deploy_at: string;
+  cumulative_clients?: Record<string, number>;
 }
 
 async function redisGet(): Promise<TelemetryData | null> {
@@ -105,12 +107,13 @@ const REQUEST_LOG_MAX = 1000;
 
 export interface RequestLogEntry {
   ts: string;
-  type: "mcp" | "api";
+  type: "mcp" | "api" | "session_connect";
   endpoint: string;
   params: Record<string, unknown>;
   user_agent?: string;
   result_count: number;
   session_id?: string;
+  client_info?: { name: string; version: string };
 }
 
 async function redisLpush(key: string, value: string): Promise<boolean> {
@@ -186,11 +189,20 @@ function parseTelemetryData(data: Record<string, unknown>): void {
   cumulative.landing_views = (data.cumulative_landing_views as number) ?? 0;
   cumulative.first_session_at = (data.first_session_at as string) ?? "";
   cumulative.last_deploy_at = (data.last_deploy_at as string) ?? "";
+  cumulative.clients = (data.cumulative_clients as Record<string, number>) ?? {};
 }
+
+// In-memory client counts for this deployment
+const sessionClients: Record<string, number> = {};
 
 function buildTelemetryData(): TelemetryData {
   const totalToolCalls = Object.values(toolCalls).reduce((a, b) => a + b, 0);
   const totalApiHits = Object.values(apiHits).reduce((a, b) => a + b, 0);
+  // Merge cumulative + current deployment client counts
+  const mergedClients: Record<string, number> = { ...cumulative.clients };
+  for (const [name, count] of Object.entries(sessionClients)) {
+    mergedClients[name] = (mergedClients[name] ?? 0) + count;
+  }
   return {
     cumulative_sessions: cumulative.sessions + totalSessions,
     cumulative_tool_calls: cumulative.tool_calls + totalToolCalls,
@@ -198,6 +210,7 @@ function buildTelemetryData(): TelemetryData {
     cumulative_landing_views: cumulative.landing_views + landingPageViews,
     first_session_at: cumulative.first_session_at || (totalSessions > 0 ? serverStartedISO : ""),
     last_deploy_at: cumulative.last_deploy_at,
+    cumulative_clients: mergedClients,
   };
 }
 
@@ -250,12 +263,14 @@ export function resetCounters(): void {
   sessionsToday = 0;
   for (const key of Object.keys(toolCalls)) toolCalls[key] = 0;
   for (const key of Object.keys(apiHits)) apiHits[key] = 0;
+  for (const key of Object.keys(sessionClients)) delete sessionClients[key];
   cumulative.sessions = 0;
   cumulative.tool_calls = 0;
   cumulative.api_hits = 0;
   cumulative.landing_views = 0;
   cumulative.first_session_at = "";
   cumulative.last_deploy_at = "";
+  cumulative.clients = {};
 }
 
 export function recordToolCall(tool: string): void {
@@ -270,7 +285,7 @@ export function recordApiHit(endpoint: string): void {
   }
 }
 
-export function recordSessionConnect(): void {
+export function recordSessionConnect(clientName?: string): void {
   totalSessions++;
   if (!cumulative.first_session_at) {
     cumulative.first_session_at = new Date().toISOString();
@@ -281,6 +296,8 @@ export function recordSessionConnect(): void {
     sessionsTodayDate = today;
   }
   sessionsToday++;
+  const name = clientName || "unknown";
+  sessionClients[name] = (sessionClients[name] ?? 0) + 1;
 }
 
 export function recordSessionDisconnect(): void {
@@ -334,6 +351,7 @@ export function getConnectionStats(activeSessions: number): {
   totalToolCallsAllTime: number;
   sessionsToday: number;
   serverStarted: string;
+  clients: Record<string, number>;
 } {
   const today = new Date().toISOString().slice(0, 10);
   if (today !== sessionsTodayDate) {
@@ -342,6 +360,11 @@ export function getConnectionStats(activeSessions: number): {
   }
   const totalToolCalls = Object.values(toolCalls).reduce((a, b) => a + b, 0);
   const totalApiHits = Object.values(apiHits).reduce((a, b) => a + b, 0);
+  // Merge cumulative + current deployment client counts
+  const mergedClients: Record<string, number> = { ...cumulative.clients };
+  for (const [name, count] of Object.entries(sessionClients)) {
+    mergedClients[name] = (mergedClients[name] ?? 0) + count;
+  }
   return {
     activeSessions,
     totalSessionsAllTime: cumulative.sessions + totalSessions,
@@ -349,5 +372,6 @@ export function getConnectionStats(activeSessions: number): {
     totalToolCallsAllTime: cumulative.tool_calls + totalToolCalls,
     sessionsToday,
     serverStarted: serverStartedISO,
+    clients: mergedClients,
   };
 }

--- a/test/http.test.ts
+++ b/test/http.test.ts
@@ -486,6 +486,57 @@ describe("HTTP transport", () => {
     assert.strictEqual(stats1.activeSessions, 1);
     assert.strictEqual(stats1.totalSessionsAllTime, initialAllTime + 1);
     assert.strictEqual(stats1.sessionsToday, initialToday + 1);
+    // Should include clients breakdown with the client name from initialize
+    assert.ok(typeof stats1.clients === "object");
+    assert.ok(stats1.clients["stats-test"] >= 1, "clients should include stats-test");
+  });
+
+  it("GET /api/stats tracks client info from MCP initialize", async () => {
+    proc = await startHttpServer();
+
+    // Get initial client counts
+    const resp0 = await fetch(`http://localhost:${PORT}/api/stats`);
+    const stats0 = await resp0.json() as any;
+    const initialClaude = stats0.clients?.["claude-desktop"] ?? 0;
+    const initialCursor = stats0.clients?.["cursor"] ?? 0;
+
+    // Create two sessions with different clients
+    await mcpRequest("/mcp", {
+      jsonrpc: "2.0",
+      id: 1,
+      method: "initialize",
+      params: {
+        protocolVersion: "2024-11-05",
+        capabilities: {},
+        clientInfo: { name: "claude-desktop", version: "1.2.0" },
+      },
+    });
+    await mcpRequest("/mcp", {
+      jsonrpc: "2.0",
+      id: 1,
+      method: "initialize",
+      params: {
+        protocolVersion: "2024-11-05",
+        capabilities: {},
+        clientInfo: { name: "cursor", version: "0.45.0" },
+      },
+    });
+    await mcpRequest("/mcp", {
+      jsonrpc: "2.0",
+      id: 1,
+      method: "initialize",
+      params: {
+        protocolVersion: "2024-11-05",
+        capabilities: {},
+        clientInfo: { name: "claude-desktop", version: "1.2.0" },
+      },
+    });
+
+    const resp = await fetch(`http://localhost:${PORT}/api/stats`);
+    const stats = await resp.json() as any;
+    assert.ok(typeof stats.clients === "object");
+    assert.strictEqual(stats.clients["claude-desktop"], initialClaude + 2);
+    assert.strictEqual(stats.clients["cursor"], initialCursor + 1);
   });
 
   it("logs session_open to stdout on session creation", async () => {


### PR DESCRIPTION
## Summary
- Extracts `client_info` (name + version) from MCP `initialize` requests
- Logs `session_connect` entries to Redis request log with client info
- Tracks cumulative client counts persisted via Redis telemetry
- Exposes `clients` breakdown in `/api/stats` (e.g., `{"claude-desktop": 5, "cursor": 2}`)
- Adds client info to `session_open` console log events
- Updates OpenAPI spec with new `clients` field

## Test plan
- [x] 109 tests pass (1 new test for client info tracking)
- [x] E2E verified: initialize with `clientInfo`, check `/api/stats` shows correct counts
- [x] Cumulative client counts persist across deploys via Redis
- [x] Build succeeds

Refs #147

🤖 Generated with [Claude Code](https://claude.com/claude-code)