### PR TITLE
Add MCP prompt templates for tool discovery

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -254,5 +254,88 @@ export function createServer(getSessionId?: () => string | undefined): McpServer
     }
   );
 
+  // --- Prompt Templates ---
+
+  server.registerPrompt(
+    "find-free-alternative",
+    {
+      description: "Find free alternatives to a specific vendor. Returns the vendor's current deal plus up to 5 alternatives in the same category.",
+      argsSchema: {
+        vendor: z.string().describe("The vendor name to find alternatives for (e.g. 'Heroku', 'Firebase', 'Auth0')"),
+      },
+    },
+    async ({ vendor }) => ({
+      messages: [
+        {
+          role: "user" as const,
+          content: {
+            type: "text" as const,
+            text: `Find free alternatives to ${vendor}. Use the get_offer_details tool with vendor="${vendor}" and include_alternatives=true to get the vendor's current deal and up to 5 alternatives in the same category.`,
+          },
+        },
+      ],
+    })
+  );
+
+  server.registerPrompt(
+    "recommend-stack",
+    {
+      description: "Get a recommended free-tier infrastructure stack for a project. Returns hosting, database, auth, and more — all free tier.",
+      argsSchema: {
+        project_description: z.string().describe("What you're building (e.g. 'Next.js SaaS app', 'Python API backend', 'mobile app')"),
+      },
+    },
+    async ({ project_description }) => ({
+      messages: [
+        {
+          role: "user" as const,
+          content: {
+            type: "text" as const,
+            text: `Recommend a free infrastructure stack for: ${project_description}. Use the get_stack_recommendation tool with use_case="${project_description}" to get a curated stack of free-tier services covering hosting, database, auth, and more.`,
+          },
+        },
+      ],
+    })
+  );
+
+  server.registerPrompt(
+    "check-pricing-changes",
+    {
+      description: "Check what developer tool pricing has changed recently. Shows free tier removals, limit changes, and new free tiers.",
+    },
+    async () => ({
+      messages: [
+        {
+          role: "user" as const,
+          content: {
+            type: "text" as const,
+            text: "What developer tool pricing has changed recently? Use the get_deal_changes tool to see recent free tier removals, limit reductions, limit increases, new free tiers, and pricing restructures.",
+          },
+        },
+      ],
+    })
+  );
+
+  server.registerPrompt(
+    "search-deals",
+    {
+      description: "Search for free tiers and deals in a specific category. Browse database, hosting, auth, CI/CD, and 48 more categories.",
+      argsSchema: {
+        category: z.string().describe("Category to search (e.g. 'Databases', 'Cloud Hosting', 'Auth', 'CI/CD', 'Monitoring')"),
+      },
+    },
+    async ({ category }) => ({
+      messages: [
+        {
+          role: "user" as const,
+          content: {
+            type: "text" as const,
+            text: `Find free tiers for ${category}. Use the search_offers tool with category="${category}" to see all available free tiers, credits, and discounts in this category.`,
+          },
+        },
+      ],
+    })
+  );
+
   return server;
 }

--- a/test/http.test.ts
+++ b/test/http.test.ts
@@ -764,4 +764,107 @@ describe("HTTP transport", () => {
     assert.ok(body.components.schemas.DealChange);
     assert.ok(body.components.schemas.Eligibility);
   });
+
+  it("prompts/list returns all 4 prompt templates", async () => {
+    proc = await startHttpServer();
+
+    // Initialize session
+    const initResp = await mcpRequest("/mcp", {
+      jsonrpc: "2.0",
+      id: 1,
+      method: "initialize",
+      params: {
+        protocolVersion: "2024-11-05",
+        capabilities: {},
+        clientInfo: { name: "prompt-test", version: "1.0.0" },
+      },
+    });
+    const sessionId = initResp.headers.get("mcp-session-id");
+    assert.ok(sessionId);
+
+    // Send initialized notification
+    await mcpRequest("/mcp", {
+      jsonrpc: "2.0",
+      method: "notifications/initialized",
+    }, sessionId);
+
+    // List prompts
+    const listResp = await mcpRequest("/mcp", {
+      jsonrpc: "2.0",
+      id: 2,
+      method: "prompts/list",
+    }, sessionId);
+
+    const data = parseSSEData(listResp.text);
+    const result = data.find((d: any) => d.id === 2);
+    assert.ok(result, "Should get prompts/list response");
+    const prompts = result.result.prompts;
+    assert.strictEqual(prompts.length, 4);
+
+    const names = prompts.map((p: any) => p.name).sort();
+    assert.deepStrictEqual(names, [
+      "check-pricing-changes",
+      "find-free-alternative",
+      "recommend-stack",
+      "search-deals",
+    ]);
+
+    // Each prompt should have a description
+    for (const p of prompts) {
+      assert.ok(p.description, `Prompt ${p.name} should have a description`);
+    }
+
+    // find-free-alternative should have vendor argument
+    const findAlt = prompts.find((p: any) => p.name === "find-free-alternative");
+    assert.ok(findAlt.arguments?.some((a: any) => a.name === "vendor"));
+
+    // check-pricing-changes should have no required arguments
+    const checkChanges = prompts.find((p: any) => p.name === "check-pricing-changes");
+    assert.ok(!checkChanges.arguments || checkChanges.arguments.length === 0);
+  });
+
+  it("prompts/get returns structured message for find-free-alternative", async () => {
+    proc = await startHttpServer();
+
+    // Initialize session
+    const initResp = await mcpRequest("/mcp", {
+      jsonrpc: "2.0",
+      id: 1,
+      method: "initialize",
+      params: {
+        protocolVersion: "2024-11-05",
+        capabilities: {},
+        clientInfo: { name: "prompt-test", version: "1.0.0" },
+      },
+    });
+    const sessionId = initResp.headers.get("mcp-session-id");
+    assert.ok(sessionId);
+
+    // Send initialized notification
+    await mcpRequest("/mcp", {
+      jsonrpc: "2.0",
+      method: "notifications/initialized",
+    }, sessionId);
+
+    // Get prompt
+    const getResp = await mcpRequest("/mcp", {
+      jsonrpc: "2.0",
+      id: 3,
+      method: "prompts/get",
+      params: {
+        name: "find-free-alternative",
+        arguments: { vendor: "Heroku" },
+      },
+    }, sessionId);
+
+    const data = parseSSEData(getResp.text);
+    const result = data.find((d: any) => d.id === 3);
+    assert.ok(result, "Should get prompts/get response");
+    assert.ok(result.result.messages);
+    assert.strictEqual(result.result.messages.length, 1);
+    const msg = result.result.messages[0];
+    assert.strictEqual(msg.role, "user");
+    assert.ok(msg.content.text.includes("Heroku"));
+    assert.ok(msg.content.text.includes("get_offer_details"));
+  });
 });


### PR DESCRIPTION
## Summary
- Registers 4 MCP prompt templates via `server.registerPrompt()`
- **find-free-alternative**: "Find free alternatives to {vendor}" — guides agent to `get_offer_details` with `include_alternatives: true`
- **recommend-stack**: "Recommend a free stack for {project_description}" — guides to `get_stack_recommendation`
- **check-pricing-changes**: "What pricing has changed recently?" — guides to `get_deal_changes`
- **search-deals**: "Find free tiers for {category}" — guides to `search_offers`
- Each prompt has a description, argument schema, and returns structured messages referencing the appropriate tool

## Test plan
- [x] 111 tests pass (2 new: prompts/list returns all 4, prompts/get returns correct message)
- [x] Build succeeds
- [x] Verified prompt listing and invocation via MCP protocol

Refs #148

🤖 Generated with [Claude Code](https://claude.com/claude-code)