### PR TITLE
Add estimate_costs tool for infrastructure budget planning

### DIFF
--- a/src/costs.ts
+++ b/src/costs.ts
@@ -1,0 +1,208 @@
+import { loadOffers, loadDealChanges, searchOffers } from "./data.js";
+import type { Offer, DealChange } from "./types.js";
+
+export interface ServiceCostEstimate {
+  vendor: string;
+  current_tier: string;
+  free_tier_limits: string;
+  estimated_monthly_cost: string;
+  free_alternative?: { vendor: string; tier: string; description: string };
+  recent_changes?: string[];
+}
+
+export interface CostEstimateResult {
+  services: ServiceCostEstimate[];
+  total_estimated_cost: string;
+  savings_available: string;
+  warnings: string[];
+  scale: string;
+}
+
+type Scale = "hobby" | "startup" | "growth";
+
+const SCALE_DESCRIPTIONS: Record<Scale, string> = {
+  hobby: "Within free tier limits — side projects and prototyping",
+  startup: "Likely exceeding some free tiers — early-stage product with real users",
+  growth: "Exceeding most free tiers — established product with significant usage",
+};
+
+// Scale multipliers for rough cost estimation
+// hobby = free, startup = $5-50/service, growth = $25-200/service
+const SCALE_COST_RANGES: Record<Scale, { min: number; max: number }> = {
+  hobby: { min: 0, max: 0 },
+  startup: { min: 5, max: 50 },
+  growth: { min: 25, max: 200 },
+};
+
+function extractFreeTierLimits(offer: Offer): string {
+  // Extract the most useful part of the description (up to 200 chars)
+  const desc = offer.description;
+  if (desc.length <= 200) return desc;
+  return desc.slice(0, 197) + "...";
+}
+
+function findFreeAlternative(offer: Offer): { vendor: string; tier: string; description: string } | undefined {
+  const offers = searchOffers(undefined, offer.category);
+  const alternative = offers.find(
+    (o) =>
+      o.vendor.toLowerCase() !== offer.vendor.toLowerCase() &&
+      (o.tier === "Free" || o.tier === "Hobby" || o.tier === "Open Source")
+  );
+  if (!alternative) return undefined;
+  return {
+    vendor: alternative.vendor,
+    tier: alternative.tier,
+    description: alternative.description.length > 150
+      ? alternative.description.slice(0, 147) + "..."
+      : alternative.description,
+  };
+}
+
+function getRecentChanges(vendorName: string): string[] {
+  const changes = loadDealChanges();
+  const sixMonthsAgo = new Date(Date.now() - 180 * 24 * 60 * 60 * 1000)
+    .toISOString()
+    .slice(0, 10);
+  return changes
+    .filter(
+      (c) =>
+        c.vendor.toLowerCase() === vendorName.toLowerCase() &&
+        c.date >= sixMonthsAgo
+    )
+    .map((c) => `${c.date}: ${c.summary}`);
+}
+
+function generateWarnings(
+  services: ServiceCostEstimate[],
+  scale: Scale,
+  offers: Map<string, Offer>
+): string[] {
+  const warnings: string[] = [];
+
+  for (const svc of services) {
+    const offer = offers.get(svc.vendor.toLowerCase());
+    if (!offer) continue;
+
+    const desc = offer.description.toLowerCase();
+
+    // Warn about tight free tier limits at startup/growth scale
+    if (scale !== "hobby") {
+      if (desc.includes("1,000") || desc.includes("1000 ")) {
+        warnings.push(
+          `${svc.vendor} free tier has low request/usage limits — likely exceeded at ${scale} scale`
+        );
+      }
+      if (desc.includes("10k mau") || desc.includes("10,000 mau") || desc.includes("10000 mau")) {
+        warnings.push(
+          `${svc.vendor} free tier limited to 10K MAU — you'll hit this at ${scale} scale`
+        );
+      }
+      if (desc.includes("500 mb") || desc.includes("512 mb") || desc.includes("0.5 gi")) {
+        warnings.push(
+          `${svc.vendor} storage is under 1 GB on free tier — plan for upgrades at ${scale} scale`
+        );
+      }
+    }
+
+    // Warn about recent pricing changes
+    if (svc.recent_changes && svc.recent_changes.length > 0) {
+      warnings.push(
+        `${svc.vendor} has had recent pricing changes — review current terms`
+      );
+    }
+  }
+
+  return warnings;
+}
+
+export function estimateCosts(
+  vendorNames: string[],
+  scale: Scale = "hobby"
+): CostEstimateResult {
+  const allOffers = loadOffers();
+  const matchedOffers = new Map<string, Offer>();
+  const services: ServiceCostEstimate[] = [];
+  const unknownVendors: string[] = [];
+
+  for (const name of vendorNames) {
+    const lowerName = name.toLowerCase();
+    const offer = allOffers.find((o) => o.vendor.toLowerCase() === lowerName);
+    if (!offer) {
+      unknownVendors.push(name);
+      services.push({
+        vendor: name,
+        current_tier: "Unknown",
+        free_tier_limits: "Vendor not found in our index",
+        estimated_monthly_cost: "N/A",
+      });
+      continue;
+    }
+
+    matchedOffers.set(lowerName, offer);
+
+    const recentChanges = getRecentChanges(offer.vendor);
+    const costRange = SCALE_COST_RANGES[scale];
+    let estimatedCost: string;
+    if (scale === "hobby") {
+      estimatedCost = "$0 (within free tier)";
+    } else {
+      estimatedCost = `$${costRange.min}-${costRange.max}/mo (estimated at ${scale} scale)`;
+    }
+
+    const svc: ServiceCostEstimate = {
+      vendor: offer.vendor,
+      current_tier: offer.tier,
+      free_tier_limits: extractFreeTierLimits(offer),
+      estimated_monthly_cost: estimatedCost,
+    };
+
+    // Only suggest alternatives for paid tiers or when scaling past free
+    if (scale !== "hobby" || offer.tier !== "Free") {
+      const alt = findFreeAlternative(offer);
+      if (alt) svc.free_alternative = alt;
+    }
+
+    if (recentChanges.length > 0) {
+      svc.recent_changes = recentChanges;
+    }
+
+    services.push(svc);
+  }
+
+  const warnings = generateWarnings(services, scale, matchedOffers);
+  if (unknownVendors.length > 0) {
+    warnings.unshift(
+      `Unknown vendor(s): ${unknownVendors.join(", ")} — not in our index`
+    );
+  }
+
+  // Calculate totals
+  let totalEstimated: string;
+  let savingsAvailable: string;
+  const knownCount = services.length - unknownVendors.length;
+
+  if (scale === "hobby") {
+    totalEstimated = "$0/mo (all within free tiers)";
+    savingsAvailable = "$0 — already on free tiers";
+  } else {
+    const range = SCALE_COST_RANGES[scale];
+    const totalMin = range.min * knownCount;
+    const totalMax = range.max * knownCount;
+    totalEstimated = `$${totalMin}-${totalMax}/mo (estimated for ${knownCount} services at ${scale} scale)`;
+
+    const alternativesCount = services.filter((s) => s.free_alternative).length;
+    if (alternativesCount > 0) {
+      savingsAvailable = `${alternativesCount} service(s) have free alternatives — switching could save $${range.min * alternativesCount}-${range.max * alternativesCount}/mo`;
+    } else {
+      savingsAvailable = "No free alternatives identified";
+    }
+  }
+
+  return {
+    services,
+    total_estimated_cost: totalEstimated,
+    savings_available: savingsAvailable,
+    warnings,
+    scale: `${scale} — ${SCALE_DESCRIPTIONS[scale]}`,
+  };
+}

--- a/src/serve.ts
+++ b/src/serve.ts
@@ -7,6 +7,7 @@ import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/
 import { createServer } from "./server.js";
 import { loadOffers, getCategories, getNewOffers, searchOffers, loadDealChanges, getDealChanges, getOfferDetails } from "./data.js";
 import { getStackRecommendation } from "./stacks.js";
+import { estimateCosts } from "./costs.js";
 import { recordApiHit, recordSessionConnect, recordSessionDisconnect, recordLandingPageView, getStats, getConnectionStats, loadTelemetry, flushTelemetry, logRequest, getRequestLog } from "./stats.js";
 import { openapiSpec } from "./openapi.js";
 
@@ -634,6 +635,25 @@ const httpServer = createHttpServer(async (req, res) => {
     const requirements = requirementsParam ? requirementsParam.split(",").map(r => r.trim()).filter(Boolean) : undefined;
     const result = getStackRecommendation(useCase, requirements);
     logRequest({ ts: new Date().toISOString(), type: "api", endpoint: "/api/stack", params: { use_case: useCase, requirements }, user_agent: req.headers["user-agent"] ?? "unknown", result_count: result.stack.length });
+    res.writeHead(200, { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" });
+    res.end(JSON.stringify(result));
+  } else if (url.pathname === "/api/costs" && req.method === "GET") {
+    recordApiHit("/api/costs");
+    const servicesParam = url.searchParams.get("services");
+    if (!servicesParam) {
+      res.writeHead(400, { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" });
+      res.end(JSON.stringify({ error: "services parameter is required (e.g., ?services=Vercel,Supabase,Clerk)" }));
+      return;
+    }
+    const services = servicesParam.split(",").map(s => s.trim()).filter(Boolean);
+    const scale = (url.searchParams.get("scale") ?? "hobby") as "hobby" | "startup" | "growth";
+    if (!["hobby", "startup", "growth"].includes(scale)) {
+      res.writeHead(400, { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" });
+      res.end(JSON.stringify({ error: "Invalid scale. Must be: hobby, startup, or growth" }));
+      return;
+    }
+    const result = estimateCosts(services, scale);
+    logRequest({ ts: new Date().toISOString(), type: "api", endpoint: "/api/costs", params: { services, scale }, user_agent: req.headers["user-agent"] ?? "unknown", result_count: result.services.length });
     res.writeHead(200, { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" });
     res.end(JSON.stringify(result));
   } else if (url.pathname === "/api/query-log" && req.method === "GET") {

--- a/src/server.ts
+++ b/src/server.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 import { getCategories, getDealChanges, getNewOffers, getOfferDetails, searchOffers } from "./data.js";
 import { recordToolCall, logRequest } from "./stats.js";
 import { getStackRecommendation } from "./stacks.js";
+import { estimateCosts } from "./costs.js";
 
 export function createServer(getSessionId?: () => string | undefined): McpServer {
   const server = new McpServer({
@@ -247,6 +248,44 @@ export function createServer(getSessionId?: () => string | undefined): McpServer
             {
               type: "text" as const,
               text: `Error getting stack recommendation: ${err instanceof Error ? err.message : String(err)}`,
+            },
+          ],
+        };
+      }
+    }
+  );
+
+  server.registerTool(
+    "estimate_costs",
+    {
+      description:
+        "Estimate infrastructure costs for your current stack at different scales. Pass the vendor names you're using (e.g. Vercel, Supabase, Clerk) and a scale (hobby/startup/growth) to get per-service cost analysis, free tier limits, free alternatives, and warnings about recent pricing changes. Use during project planning, code reviews, or deployment setup.",
+      inputSchema: {
+        services: z.array(z.string()).describe("Vendor names to analyze (e.g. ['Vercel', 'Supabase', 'Clerk'])"),
+        scale: z.enum(["hobby", "startup", "growth"]).optional().describe("Scale: hobby (free tiers), startup (some paid), growth (mostly paid). Default: hobby"),
+      },
+    },
+    async ({ services, scale }) => {
+      try {
+        recordToolCall("estimate_costs");
+        const result = estimateCosts(services, scale ?? "hobby");
+        logRequest({ ts: new Date().toISOString(), type: "mcp", endpoint: "estimate_costs", params: { services, scale: scale ?? "hobby" }, result_count: result.services.length, session_id: getSessionId?.() });
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: JSON.stringify(result, null, 2),
+            },
+          ],
+        };
+      } catch (err) {
+        console.error("estimate_costs error:", err);
+        return {
+          isError: true,
+          content: [
+            {
+              type: "text" as const,
+              text: `Error estimating costs: ${err instanceof Error ? err.message : String(err)}`,
             },
           ],
         };

--- a/test/costs.test.ts
+++ b/test/costs.test.ts
@@ -1,0 +1,192 @@
+import { describe, it, afterEach } from "node:test";
+import assert from "node:assert";
+import { spawn, type ChildProcess } from "node:child_process";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+describe("estimate_costs logic", () => {
+  it("returns cost estimate for a single known vendor", async () => {
+    const { estimateCosts } = await import("../dist/costs.js");
+    const result = estimateCosts(["Vercel"]);
+    assert.strictEqual(result.services.length, 1);
+    assert.strictEqual(result.services[0].vendor, "Vercel");
+    assert.ok(result.services[0].current_tier, "Should have current_tier");
+    assert.ok(result.services[0].free_tier_limits, "Should have free_tier_limits");
+    assert.ok(result.services[0].estimated_monthly_cost.includes("$0"), "Hobby scale should be $0");
+    assert.strictEqual(result.scale.split(" — ")[0], "hobby");
+  });
+
+  it("returns cost estimates for multiple vendors", async () => {
+    const { estimateCosts } = await import("../dist/costs.js");
+    const result = estimateCosts(["Vercel", "Supabase", "Clerk"]);
+    assert.strictEqual(result.services.length, 3);
+    const vendors = result.services.map(s => s.vendor);
+    assert.ok(vendors.includes("Vercel"));
+    assert.ok(vendors.includes("Supabase"));
+    assert.ok(vendors.includes("Clerk"));
+  });
+
+  it("handles unknown vendors gracefully", async () => {
+    const { estimateCosts } = await import("../dist/costs.js");
+    const result = estimateCosts(["Vercel", "NonExistentVendor123"]);
+    assert.strictEqual(result.services.length, 2);
+    const unknown = result.services.find(s => s.vendor === "NonExistentVendor123");
+    assert.ok(unknown);
+    assert.strictEqual(unknown.current_tier, "Unknown");
+    assert.ok(unknown.free_tier_limits.includes("not found"));
+    assert.ok(result.warnings.some(w => w.includes("NonExistentVendor123")));
+  });
+
+  it("startup scale returns non-zero cost estimates", async () => {
+    const { estimateCosts } = await import("../dist/costs.js");
+    const result = estimateCosts(["Vercel", "Supabase"], "startup");
+    assert.ok(result.scale.includes("startup"));
+    for (const svc of result.services) {
+      if (svc.current_tier !== "Unknown") {
+        assert.ok(svc.estimated_monthly_cost.includes("startup"), `${svc.vendor} should mention startup scale`);
+      }
+    }
+    assert.ok(!result.total_estimated_cost.includes("$0/mo"));
+  });
+
+  it("growth scale returns higher cost estimates", async () => {
+    const { estimateCosts } = await import("../dist/costs.js");
+    const result = estimateCosts(["Vercel"], "growth");
+    assert.ok(result.scale.includes("growth"));
+    assert.ok(result.services[0].estimated_monthly_cost.includes("growth"));
+  });
+
+  it("suggests free alternatives at startup/growth scale", async () => {
+    const { estimateCosts } = await import("../dist/costs.js");
+    const result = estimateCosts(["Vercel", "Supabase"], "startup");
+    // At least one service should have a free alternative suggestion
+    const withAlternatives = result.services.filter(s => s.free_alternative);
+    // Not guaranteed, but highly likely given our index size
+    assert.ok(result.savings_available, "Should have savings_available field");
+  });
+
+  it("returns warnings array", async () => {
+    const { estimateCosts } = await import("../dist/costs.js");
+    const result = estimateCosts(["Vercel", "Supabase"], "startup");
+    assert.ok(Array.isArray(result.warnings));
+  });
+});
+
+describe("estimate_costs MCP tool via stdio", () => {
+  let proc: ChildProcess | null = null;
+
+  afterEach(() => {
+    if (proc) { proc.kill(); proc = null; }
+  });
+
+  it("responds to estimate_costs tool call", async () => {
+    const serverPath = path.join(__dirname, "..", "dist", "index.js");
+    proc = spawn("node", [serverPath], { stdio: ["pipe", "pipe", "pipe"] });
+
+    const initMsg = JSON.stringify({
+      jsonrpc: "2.0",
+      id: 1,
+      method: "initialize",
+      params: { protocolVersion: "2024-11-05", capabilities: {}, clientInfo: { name: "test", version: "1.0" } },
+    });
+
+    const initedMsg = JSON.stringify({
+      jsonrpc: "2.0",
+      method: "notifications/initialized",
+    });
+
+    const toolCall = JSON.stringify({
+      jsonrpc: "2.0",
+      id: 2,
+      method: "tools/call",
+      params: {
+        name: "estimate_costs",
+        arguments: { services: ["Vercel", "Supabase"], scale: "startup" },
+      },
+    });
+
+    const response = await new Promise<string>((resolve, reject) => {
+      let data = "";
+      let responseCount = 0;
+      const timeout = setTimeout(() => reject(new Error("Timeout")), 10000);
+      proc!.stdout!.on("data", (chunk: Buffer) => {
+        data += chunk.toString();
+        // Count complete JSON responses
+        const lines = data.split("\n").filter(Boolean);
+        if (lines.length >= 2) {
+          clearTimeout(timeout);
+          resolve(lines[1]); // Second response is the tool call result
+        }
+      });
+      proc!.stdin!.write(initMsg + "\n");
+      proc!.stdin!.write(initedMsg + "\n");
+      proc!.stdin!.write(toolCall + "\n");
+    });
+
+    const parsed = JSON.parse(response);
+    assert.strictEqual(parsed.id, 2);
+    assert.ok(parsed.result);
+    const content = JSON.parse(parsed.result.content[0].text);
+    assert.strictEqual(content.services.length, 2);
+    assert.ok(content.total_estimated_cost);
+    assert.ok(content.savings_available);
+    assert.ok(Array.isArray(content.warnings));
+    assert.ok(content.scale.includes("startup"));
+  });
+});
+
+describe("estimate_costs REST endpoint", () => {
+  const PORT = 3462;
+  let proc: ChildProcess | null = null;
+
+  function startHttpServer(): Promise<ChildProcess> {
+    return new Promise((resolve, reject) => {
+      const serverPath = path.join(__dirname, "..", "dist", "serve.js");
+      const p = spawn("node", [serverPath], {
+        stdio: ["pipe", "pipe", "pipe"],
+        env: { ...process.env, PORT: String(PORT) },
+      });
+      const timeout = setTimeout(() => { p.kill(); reject(new Error("Server startup timeout")); }, 5000);
+      p.stderr!.on("data", (data: Buffer) => {
+        if (data.toString().includes("running on http")) { clearTimeout(timeout); resolve(p); }
+      });
+      p.on("error", (err) => { clearTimeout(timeout); reject(err); });
+    });
+  }
+
+  afterEach(() => {
+    if (proc) { proc.kill(); proc = null; }
+  });
+
+  it("GET /api/costs returns cost estimates", async () => {
+    proc = await startHttpServer();
+    const response = await fetch(`http://localhost:${PORT}/api/costs?services=Vercel,Supabase&scale=startup`);
+    assert.strictEqual(response.status, 200);
+    assert.strictEqual(response.headers.get("access-control-allow-origin"), "*");
+    const body = await response.json() as any;
+    assert.strictEqual(body.services.length, 2);
+    assert.ok(body.total_estimated_cost);
+    assert.ok(body.savings_available);
+    assert.ok(Array.isArray(body.warnings));
+    assert.ok(body.scale.includes("startup"));
+  });
+
+  it("GET /api/costs returns 400 without services parameter", async () => {
+    proc = await startHttpServer();
+    const response = await fetch(`http://localhost:${PORT}/api/costs`);
+    assert.strictEqual(response.status, 400);
+    const body = await response.json() as any;
+    assert.ok(body.error.includes("services"));
+  });
+
+  it("GET /api/costs defaults to hobby scale", async () => {
+    proc = await startHttpServer();
+    const response = await fetch(`http://localhost:${PORT}/api/costs?services=Vercel`);
+    assert.strictEqual(response.status, 200);
+    const body = await response.json() as any;
+    assert.ok(body.scale.includes("hobby"));
+    assert.ok(body.services[0].estimated_monthly_cost.includes("$0"));
+  });
+});


### PR DESCRIPTION
## Summary
- New `estimate_costs` MCP tool (7th tool): pass vendor names + scale (hobby/startup/growth) to get per-service cost analysis
- Each service shows: current tier, free tier limits, estimated monthly cost at scale, free alternative from same category, and recent pricing changes from deal_changes
- Warnings for tight free tier limits and recent pricing shifts
- REST endpoint: `GET /api/costs?services=Vercel,Supabase,Clerk&scale=startup`
- 11 new tests (122 total): unit tests for logic, MCP stdio E2E, REST endpoint

## Example
```
estimate_costs(["Vercel", "Supabase", "Clerk"], "startup")
→ Per-service breakdown with $5-50/mo ranges
→ Free alternatives: Render, Neon, Auth0
→ Warnings about Vercel and Supabase recent pricing changes
→ Total: $15-150/mo estimated
```

Refs #152