### PR TITLE
Fix change_type enum to match actual data

### DIFF
--- a/data/deal_changes.json
+++ b/data/deal_changes.json
@@ -213,7 +213,7 @@
     },
     {
       "vendor": "Postman",
-      "change_type": "downgrade",
+      "change_type": "limits_reduced",
       "date": "2026-03-01",
       "summary": "Free team collaboration removed — free plan restricted to single user only. No shared workspaces or collections on free tier",
       "previous_state": "Free plan supported up to 3 users in shared workspaces with collection sharing and 25 monitoring calls/month",
@@ -648,7 +648,7 @@
     },
     {
       "vendor": "OpenAI",
-      "change_type": "free_tier_reduced",
+      "change_type": "limits_reduced",
       "date": "2025-06-01",
       "summary": "Free trial credits ($5-$18 for new accounts) completely discontinued. Free tier now limited to GPT-3.5 Turbo at 3 RPM with no credits. All advanced models (GPT-4, DALL-E, Whisper) require paid access",
       "previous_state": "$5-$18 in free trial credits for new accounts, 3-month expiry, access to all models",
@@ -732,7 +732,7 @@
     },
     {
       "vendor": "Fauna",
-      "change_type": "removed",
+      "change_type": "product_deprecated",
       "date": "2025-05-30",
       "summary": "Fauna shut down entirely on May 30, 2025. The serverless document database ceased all operations. Over 80,000 development teams affected",
       "previous_state": "Free tier: 100K read ops/day, 50K write ops/day, 500K compute ops/day, 5 GB storage. Consumption-based pricing above free limits",
@@ -765,7 +765,7 @@
     },
     {
       "vendor": "Google",
-      "change_type": "pricing_restructure",
+      "change_type": "pricing_restructured",
       "date": "2026-03-30",
       "summary": "Google Developer Program annual subscription ending March 30. Replaced by Google AI Pro ($10/mo) and AI Ultra ($100/mo) tiers with bundled cloud credits and AI model access.",
       "previous_state": "Google Developer Program: annual subscription with standalone cloud credits, developer tools access, and learning resources",

--- a/src/openapi.ts
+++ b/src/openapi.ts
@@ -121,7 +121,7 @@ export const openapiSpec = {
         description: "Returns tracked pricing and tier changes across vendors. Filter by date, change type, or vendor.",
         parameters: [
           { name: "since", in: "query", description: "Filter changes after this date (YYYY-MM-DD)", schema: { type: "string", format: "date" }, example: "2025-01-01" },
-          { name: "type", in: "query", description: "Filter by change type", schema: { type: "string", enum: ["free_tier_removed", "limits_reduced", "limits_increased", "new_free_tier", "pricing_restructured"] } },
+          { name: "type", in: "query", description: "Filter by change type", schema: { type: "string", enum: ["free_tier_removed", "limits_reduced", "limits_increased", "new_free_tier", "pricing_restructured", "open_source_killed", "pricing_model_change", "startup_program_expanded", "pricing_postponed", "product_deprecated"] } },
           { name: "vendor", in: "query", description: "Filter by vendor name", schema: { type: "string" } }
         ],
         responses: {
@@ -348,7 +348,7 @@ export const openapiSpec = {
         type: "object",
         properties: {
           vendor: { type: "string" },
-          change_type: { type: "string", enum: ["free_tier_removed", "limits_reduced", "limits_increased", "new_free_tier", "pricing_restructured"] },
+          change_type: { type: "string", enum: ["free_tier_removed", "limits_reduced", "limits_increased", "new_free_tier", "pricing_restructured", "open_source_killed", "pricing_model_change", "startup_program_expanded", "pricing_postponed", "product_deprecated"] },
           date: { type: "string", format: "date" },
           summary: { type: "string" },
           previous_state: { type: "string" },

--- a/src/server.ts
+++ b/src/server.ts
@@ -185,7 +185,7 @@ export function createServer(getSessionId?: () => string | undefined): McpServer
         "Check which developer tools recently changed their pricing or free tiers. Tracks removals, limit reductions, limit increases, new free tiers, and restructures. Use when advising on vendor lock-in risk or staying current on pricing shifts.",
       inputSchema: {
         since: z.string().optional().describe("ISO date string (YYYY-MM-DD). Only return changes on or after this date. Default: 30 days ago"),
-        change_type: z.enum(["free_tier_removed", "limits_reduced", "limits_increased", "new_free_tier", "pricing_restructured"]).optional().describe("Filter by type of change"),
+        change_type: z.enum(["free_tier_removed", "limits_reduced", "limits_increased", "new_free_tier", "pricing_restructured", "open_source_killed", "pricing_model_change", "startup_program_expanded", "pricing_postponed", "product_deprecated"]).optional().describe("Filter by type of change"),
         vendor: z.string().optional().describe("Filter by vendor name (case-insensitive partial match)"),
       },
     },

--- a/src/types.ts
+++ b/src/types.ts
@@ -21,7 +21,7 @@ export interface OfferIndex {
 
 export interface DealChange {
   vendor: string;
-  change_type: "free_tier_removed" | "limits_reduced" | "limits_increased" | "new_free_tier" | "pricing_restructured";
+  change_type: "free_tier_removed" | "limits_reduced" | "limits_increased" | "new_free_tier" | "pricing_restructured" | "open_source_killed" | "pricing_model_change" | "startup_program_expanded" | "pricing_postponed" | "product_deprecated";
   date: string;
   summary: string;
   previous_state: string;

--- a/test/deal-changes.test.ts
+++ b/test/deal-changes.test.ts
@@ -2,6 +2,7 @@ import { describe, it } from "node:test";
 import assert from "node:assert";
 import { spawn } from "node:child_process";
 import path from "node:path";
+import fs from "node:fs";
 import { fileURLToPath } from "node:url";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -295,6 +296,26 @@ describe("get_deal_changes tool", () => {
       }
     } finally {
       proc.kill();
+    }
+  });
+
+  it("every change_type in data matches the tool enum", async () => {
+    const VALID_CHANGE_TYPES = new Set([
+      "free_tier_removed", "limits_reduced", "limits_increased",
+      "new_free_tier", "pricing_restructured", "open_source_killed",
+      "pricing_model_change", "startup_program_expanded",
+      "pricing_postponed", "product_deprecated",
+    ]);
+
+    const dataPath = path.join(__dirname, "..", "data", "deal_changes.json");
+    const data = JSON.parse(fs.readFileSync(dataPath, "utf8"));
+    const dataTypes = new Set(data.changes.map((c: any) => c.change_type));
+
+    for (const type of dataTypes) {
+      assert.ok(
+        VALID_CHANGE_TYPES.has(type as string),
+        `Data contains change_type "${type}" not in tool enum. Valid: ${[...VALID_CHANGE_TYPES].join(", ")}`
+      );
     }
   });
 });


### PR DESCRIPTION
## Summary

- Normalized 4 near-duplicate `change_type` values in `deal_changes.json` (`downgrade` → `limits_reduced`, `free_tier_reduced` → `limits_reduced`, `pricing_restructure` → `pricing_restructured`, `removed` → `product_deprecated`)
- Expanded the `change_type` enum from 5 to 10 values across MCP tool schema, OpenAPI spec, and TypeScript types to include all distinct values in the data
- Added test verifying every `change_type` in the data file exists in the tool enum

Refs #155

## Test plan

- [x] All 123 tests pass (122 existing + 1 new enum validation test)
- [x] Build clean
- [x] Verified data has exactly 10 distinct change_types matching the enum

🤖 Generated with [Claude Code](https://claude.com/claude-code)