### PR TITLE
Add category-aware relevance ranking to search

### DIFF
--- a/src/data.ts
+++ b/src/data.ts
@@ -97,6 +97,44 @@ export function getOfferDetails(
   };
 }
 
+function scoreOffer(offer: Offer, terms: string[]): number {
+  let score = 0;
+  const vendorLower = offer.vendor.toLowerCase();
+  const categoryLower = offer.category.toLowerCase();
+  const tagsLower = offer.tags.map((t) => t.toLowerCase());
+  const descLower = offer.description.toLowerCase();
+
+  for (const term of terms) {
+    // Vendor name match (highest weight)
+    if (vendorLower === term) {
+      score += 100; // exact vendor name match
+    } else if (vendorLower.includes(term)) {
+      score += 50; // partial vendor name match
+    }
+
+    // Category name match (high weight)
+    if (categoryLower === term) {
+      score += 80;
+    } else if (categoryLower.includes(term)) {
+      score += 40;
+    }
+
+    // Tag match (medium weight)
+    if (tagsLower.some((tag) => tag === term)) {
+      score += 30; // exact tag match
+    } else if (tagsLower.some((tag) => tag.includes(term))) {
+      score += 15; // partial tag match
+    }
+
+    // Description match (lowest weight)
+    if (descLower.includes(term)) {
+      score += 5;
+    }
+  }
+
+  return score;
+}
+
 export function searchOffers(
   query?: string,
   category?: string,
@@ -132,6 +170,15 @@ export function searchOffers(
         .toLowerCase();
       return terms.every((term) => searchable.includes(term));
     });
+
+    // Rank by relevance when no explicit sort requested
+    if (!sort) {
+      const scores = new Map<Offer, number>();
+      for (const offer of results) {
+        scores.set(offer, scoreOffer(offer, terms));
+      }
+      results = [...results].sort((a, b) => scores.get(b)! - scores.get(a)!);
+    }
   }
 
   if (sort === "vendor") {

--- a/test/search.test.ts
+++ b/test/search.test.ts
@@ -620,6 +620,122 @@ describe("search sorting", () => {
   });
 });
 
+describe("search relevance ranking", () => {
+  it("ranks database-category vendors first when searching 'database'", async () => {
+    const proc = startServer();
+    try {
+      const responses = (await sendMcpMessages(proc, [
+        ...INIT_MESSAGES,
+        {
+          jsonrpc: "2.0",
+          id: 2,
+          method: "tools/call",
+          params: { name: "search_offers", arguments: { query: "database" } },
+        },
+      ])) as any[];
+
+      const result = responses.find((r: any) => r.id === 2) as any;
+      const body = JSON.parse(result.result.content[0].text);
+      const top5 = body.results.slice(0, 5);
+
+      // All top 5 should be in the Databases category
+      for (const offer of top5) {
+        assert.strictEqual(
+          offer.category,
+          "Databases",
+          `Expected ${offer.vendor} to be in Databases, got ${offer.category}`
+        );
+      }
+    } finally {
+      proc.kill();
+    }
+  });
+
+  it("ranks Cloud Hosting vendors first when searching 'hosting'", async () => {
+    const proc = startServer();
+    try {
+      const responses = (await sendMcpMessages(proc, [
+        ...INIT_MESSAGES,
+        {
+          jsonrpc: "2.0",
+          id: 2,
+          method: "tools/call",
+          params: { name: "search_offers", arguments: { query: "hosting" } },
+        },
+      ])) as any[];
+
+      const result = responses.find((r: any) => r.id === 2) as any;
+      const body = JSON.parse(result.result.content[0].text);
+      const top5 = body.results.slice(0, 5);
+
+      for (const offer of top5) {
+        assert.strictEqual(
+          offer.category,
+          "Cloud Hosting",
+          `Expected ${offer.vendor} to be in Cloud Hosting, got ${offer.category}`
+        );
+      }
+    } finally {
+      proc.kill();
+    }
+  });
+
+  it("ranks vendor name match first when searching by vendor name", async () => {
+    const proc = startServer();
+    try {
+      const responses = (await sendMcpMessages(proc, [
+        ...INIT_MESSAGES,
+        {
+          jsonrpc: "2.0",
+          id: 2,
+          method: "tools/call",
+          params: { name: "search_offers", arguments: { query: "supabase" } },
+        },
+      ])) as any[];
+
+      const result = responses.find((r: any) => r.id === 2) as any;
+      const body = JSON.parse(result.result.content[0].text);
+
+      assert.ok(body.results.length >= 1);
+      assert.strictEqual(body.results[0].vendor, "Supabase");
+    } finally {
+      proc.kill();
+    }
+  });
+
+  it("explicit sort overrides relevance ranking", async () => {
+    const proc = startServer();
+    try {
+      const responses = (await sendMcpMessages(proc, [
+        ...INIT_MESSAGES,
+        {
+          jsonrpc: "2.0",
+          id: 2,
+          method: "tools/call",
+          params: {
+            name: "search_offers",
+            arguments: { query: "database", sort: "vendor" },
+          },
+        },
+      ])) as any[];
+
+      const result = responses.find((r: any) => r.id === 2) as any;
+      const body = JSON.parse(result.result.content[0].text);
+      const vendors = body.results.map((o: any) => o.vendor);
+
+      // Should be sorted alphabetically, not by relevance
+      for (let i = 1; i < vendors.length; i++) {
+        assert.ok(
+          vendors[i - 1].localeCompare(vendors[i]) <= 0,
+          `${vendors[i - 1]} should come before ${vendors[i]}`
+        );
+      }
+    } finally {
+      proc.kill();
+    }
+  });
+});
+
 describe("get_offer_details with eligibility", () => {
   it("includes eligibility in response for conditional deals", async () => {
     const proc = startServer();


### PR DESCRIPTION
## Summary
- Adds relevance scoring to `searchOffers` when a query is provided and no explicit sort is specified
- Scores weight vendor name matches (100/50 pts), category name matches (80/40 pts), tag matches (30/15 pts), and description matches (5 pts)
- Explicit sort parameters (`vendor`, `category`, `newest`) override relevance ranking

## Results
- "database" → top 5 are all Databases-category vendors (Turso, Convex, Nhost, Nile, Redis Cloud)
- "hosting" → top 5 are all Cloud Hosting vendors
- "supabase" → Supabase is the first result

## Test plan
- [x] 4 new tests covering ranking behavior (database, hosting, vendor name, sort override)
- [x] All 127 tests pass (123 existing + 4 new)

Refs #157