### PR TITLE
Add compare_services MCP tool for vendor comparison

### DIFF
--- a/src/data.ts
+++ b/src/data.ts
@@ -277,3 +277,61 @@ export function getDealChanges(
 
   return { changes: results, total: results.length };
 }
+
+function findVendor(offers: Offer[], name: string): { offer: Offer | null; suggestions: string[] } {
+  const lower = name.toLowerCase();
+  const exact = offers.find((o) => o.vendor.toLowerCase() === lower);
+  if (exact) return { offer: exact, suggestions: [] };
+
+  // Fuzzy: substring match
+  const fuzzy = offers.filter(
+    (o) => o.vendor.toLowerCase().includes(lower) || lower.includes(o.vendor.toLowerCase())
+  );
+  if (fuzzy.length === 1) return { offer: fuzzy[0], suggestions: [] };
+
+  return { offer: null, suggestions: fuzzy.slice(0, 5).map((o) => o.vendor) };
+}
+
+export interface ComparisonResult {
+  vendor_a: Offer & { deal_changes: DealChange[] };
+  vendor_b: Offer & { deal_changes: DealChange[] };
+  shared_categories: boolean;
+  category_overlap: string[];
+}
+
+export function compareServices(
+  vendorA: string,
+  vendorB: string
+): { comparison: ComparisonResult } | { error: string; suggestions_a?: string[]; suggestions_b?: string[] } {
+  const offers = loadOffers();
+
+  const matchA = findVendor(offers, vendorA);
+  const matchB = findVendor(offers, vendorB);
+
+  if (!matchA.offer || !matchB.offer) {
+    return {
+      error: [
+        !matchA.offer ? `Vendor "${vendorA}" not found.${matchA.suggestions.length > 0 ? ` Did you mean: ${matchA.suggestions.join(", ")}?` : ""}` : null,
+        !matchB.offer ? `Vendor "${vendorB}" not found.${matchB.suggestions.length > 0 ? ` Did you mean: ${matchB.suggestions.join(", ")}?` : ""}` : null,
+      ].filter(Boolean).join(" "),
+      ...(matchA.suggestions.length > 0 ? { suggestions_a: matchA.suggestions } : {}),
+      ...(matchB.suggestions.length > 0 ? { suggestions_b: matchB.suggestions } : {}),
+    };
+  }
+
+  const changes = loadDealChanges();
+  const changesA = changes.filter((c) => c.vendor.toLowerCase() === matchA.offer!.vendor.toLowerCase());
+  const changesB = changes.filter((c) => c.vendor.toLowerCase() === matchB.offer!.vendor.toLowerCase());
+
+  const sharedCategories = matchA.offer.category === matchB.offer.category;
+  const categoryOverlap = sharedCategories ? [matchA.offer.category] : [];
+
+  return {
+    comparison: {
+      vendor_a: { ...matchA.offer, deal_changes: changesA },
+      vendor_b: { ...matchB.offer, deal_changes: changesB },
+      shared_categories: sharedCategories,
+      category_overlap: categoryOverlap,
+    },
+  };
+}

--- a/src/openapi.ts
+++ b/src/openapi.ts
@@ -202,6 +202,57 @@ export const openapiSpec = {
         }
       }
     },
+    "/api/compare": {
+      get: {
+        summary: "Compare two vendors side by side",
+        description: "Returns a structured comparison of two developer tool vendors including free tier details, pricing, and recent deal changes.",
+        parameters: [
+          { name: "a", in: "query", required: true, description: "First vendor name (case-insensitive, fuzzy match supported)", schema: { type: "string" }, example: "Supabase" },
+          { name: "b", in: "query", required: true, description: "Second vendor name (case-insensitive, fuzzy match supported)", schema: { type: "string" }, example: "Neon" }
+        ],
+        responses: {
+          "200": {
+            description: "Side-by-side vendor comparison",
+            content: {
+              "application/json": {
+                schema: {
+                  type: "object",
+                  properties: {
+                    vendor_a: { $ref: "#/components/schemas/Offer" },
+                    vendor_b: { $ref: "#/components/schemas/Offer" },
+                    shared_categories: { type: "boolean" },
+                    category_overlap: { type: "array", items: { type: "string" } }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            description: "Missing required parameters",
+            content: {
+              "application/json": {
+                schema: { type: "object", properties: { error: { type: "string" } } }
+              }
+            }
+          },
+          "404": {
+            description: "One or both vendors not found",
+            content: {
+              "application/json": {
+                schema: {
+                  type: "object",
+                  properties: {
+                    error: { type: "string" },
+                    suggestions_a: { type: "array", items: { type: "string" } },
+                    suggestions_b: { type: "array", items: { type: "string" } }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/stack": {
       get: {
         summary: "Get free-tier stack recommendation",

--- a/src/serve.ts
+++ b/src/serve.ts
@@ -5,7 +5,7 @@ import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
 import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
 import { createServer } from "./server.js";
-import { loadOffers, getCategories, getNewOffers, searchOffers, loadDealChanges, getDealChanges, getOfferDetails } from "./data.js";
+import { loadOffers, getCategories, getNewOffers, searchOffers, loadDealChanges, getDealChanges, getOfferDetails, compareServices } from "./data.js";
 import { getStackRecommendation } from "./stacks.js";
 import { estimateCosts } from "./costs.js";
 import { recordApiHit, recordSessionConnect, recordSessionDisconnect, recordLandingPageView, getStats, getConnectionStats, loadTelemetry, flushTelemetry, logRequest, getRequestLog } from "./stats.js";
@@ -681,6 +681,25 @@ const httpServer = createHttpServer(async (req, res) => {
     logRequest({ ts: new Date().toISOString(), type: "api", endpoint: "/api/offers", params: { q, category, limit, offset }, user_agent: req.headers["user-agent"] ?? "unknown", result_count: paged.length });
     res.writeHead(200, { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" });
     res.end(JSON.stringify({ offers: paged, total }));
+  } else if (url.pathname === "/api/compare" && req.method === "GET") {
+    recordApiHit("/api/compare");
+    const a = url.searchParams.get("a") || "";
+    const b = url.searchParams.get("b") || "";
+    if (!a || !b) {
+      res.writeHead(400, { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" });
+      res.end(JSON.stringify({ error: "Both 'a' and 'b' query parameters are required." }));
+      return;
+    }
+    const result = compareServices(a, b);
+    if ("error" in result) {
+      logRequest({ ts: new Date().toISOString(), type: "api", endpoint: "/api/compare", params: { a, b }, user_agent: req.headers["user-agent"] ?? "unknown", result_count: 0 });
+      res.writeHead(404, { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" });
+      res.end(JSON.stringify(result));
+      return;
+    }
+    logRequest({ ts: new Date().toISOString(), type: "api", endpoint: "/api/compare", params: { a, b }, user_agent: req.headers["user-agent"] ?? "unknown", result_count: 2 });
+    res.writeHead(200, { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" });
+    res.end(JSON.stringify(result.comparison));
   } else if (url.pathname === "/api/new" && req.method === "GET") {
     recordApiHit("/api/new");
     const days = parseInt(url.searchParams.get("days") ?? "7", 10);

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,6 +1,6 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
-import { getCategories, getDealChanges, getNewOffers, getOfferDetails, searchOffers } from "./data.js";
+import { getCategories, getDealChanges, getNewOffers, getOfferDetails, searchOffers, compareServices } from "./data.js";
 import { recordToolCall, logRequest } from "./stats.js";
 import { getStackRecommendation } from "./stacks.js";
 import { estimateCosts } from "./costs.js";
@@ -286,6 +286,51 @@ export function createServer(getSessionId?: () => string | undefined): McpServer
             {
               type: "text" as const,
               text: `Error estimating costs: ${err instanceof Error ? err.message : String(err)}`,
+            },
+          ],
+        };
+      }
+    }
+  );
+
+  server.registerTool(
+    "compare_services",
+    {
+      description:
+        "Compare two developer tool vendors side by side. Returns free tier limits, pricing tiers, key differentiators, and recent deal changes for both. Use when deciding between two options (e.g., Supabase vs Neon, Vercel vs Netlify).",
+      inputSchema: {
+        vendor_a: z.string().describe("First vendor name (case-insensitive, fuzzy match supported)"),
+        vendor_b: z.string().describe("Second vendor name (case-insensitive, fuzzy match supported)"),
+      },
+    },
+    async ({ vendor_a, vendor_b }) => {
+      try {
+        recordToolCall("compare_services");
+        const result = compareServices(vendor_a, vendor_b);
+        if ("error" in result) {
+          logRequest({ ts: new Date().toISOString(), type: "mcp", endpoint: "compare_services", params: { vendor_a, vendor_b }, result_count: 0, session_id: getSessionId?.() });
+          return {
+            isError: true,
+            content: [{ type: "text" as const, text: result.error }],
+          };
+        }
+        logRequest({ ts: new Date().toISOString(), type: "mcp", endpoint: "compare_services", params: { vendor_a, vendor_b }, result_count: 2, session_id: getSessionId?.() });
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: JSON.stringify(result.comparison, null, 2),
+            },
+          ],
+        };
+      } catch (err) {
+        console.error("compare_services error:", err);
+        return {
+          isError: true,
+          content: [
+            {
+              type: "text" as const,
+              text: `Error comparing services: ${err instanceof Error ? err.message : String(err)}`,
             },
           ],
         };

--- a/test/http.test.ts
+++ b/test/http.test.ts
@@ -759,7 +759,8 @@ describe("HTTP transport", () => {
     assert.ok(body.paths["/api/stats"]);
     assert.ok(body.paths["/api/query-log"]);
     assert.ok(body.paths["/api/stack"]);
-    assert.strictEqual(Object.keys(body.paths).length, 8);
+    assert.ok(body.paths["/api/compare"]);
+    assert.strictEqual(Object.keys(body.paths).length, 9);
     assert.ok(body.components.schemas.Offer);
     assert.ok(body.components.schemas.DealChange);
     assert.ok(body.components.schemas.Eligibility);

--- a/test/search.test.ts
+++ b/test/search.test.ts
@@ -975,3 +975,153 @@ describe("get_offer_details include_alternatives", () => {
     }
   });
 });
+
+describe("compare_services tool", () => {
+  it("compares two vendors in the same category", async () => {
+    const proc = startServer();
+    try {
+      const responses = (await sendMcpMessages(proc, [
+        ...INIT_MESSAGES,
+        {
+          jsonrpc: "2.0",
+          id: 2,
+          method: "tools/call",
+          params: { name: "compare_services", arguments: { vendor_a: "Supabase", vendor_b: "Neon" } },
+        },
+      ])) as any[];
+
+      const result = responses.find((r: any) => r.id === 2) as any;
+      assert.ok(!result.result.isError);
+      const comparison = JSON.parse(result.result.content[0].text);
+
+      assert.strictEqual(comparison.vendor_a.vendor, "Supabase");
+      assert.strictEqual(comparison.vendor_b.vendor, "Neon");
+      assert.strictEqual(comparison.shared_categories, true);
+      assert.deepStrictEqual(comparison.category_overlap, ["Databases"]);
+      assert.ok(typeof comparison.vendor_a.description === "string");
+      assert.ok(typeof comparison.vendor_b.description === "string");
+      assert.ok(Array.isArray(comparison.vendor_a.deal_changes));
+      assert.ok(Array.isArray(comparison.vendor_b.deal_changes));
+    } finally {
+      proc.kill();
+    }
+  });
+
+  it("compares two vendors in different categories", async () => {
+    const proc = startServer();
+    try {
+      const responses = (await sendMcpMessages(proc, [
+        ...INIT_MESSAGES,
+        {
+          jsonrpc: "2.0",
+          id: 2,
+          method: "tools/call",
+          params: { name: "compare_services", arguments: { vendor_a: "Vercel", vendor_b: "Supabase" } },
+        },
+      ])) as any[];
+
+      const result = responses.find((r: any) => r.id === 2) as any;
+      assert.ok(!result.result.isError);
+      const comparison = JSON.parse(result.result.content[0].text);
+
+      assert.strictEqual(comparison.shared_categories, false);
+      assert.deepStrictEqual(comparison.category_overlap, []);
+    } finally {
+      proc.kill();
+    }
+  });
+
+  it("handles fuzzy vendor name matching", async () => {
+    const proc = startServer();
+    try {
+      const responses = (await sendMcpMessages(proc, [
+        ...INIT_MESSAGES,
+        {
+          jsonrpc: "2.0",
+          id: 2,
+          method: "tools/call",
+          params: { name: "compare_services", arguments: { vendor_a: "supabase", vendor_b: "neon" } },
+        },
+      ])) as any[];
+
+      const result = responses.find((r: any) => r.id === 2) as any;
+      assert.ok(!result.result.isError);
+      const comparison = JSON.parse(result.result.content[0].text);
+      assert.strictEqual(comparison.vendor_a.vendor, "Supabase");
+      assert.strictEqual(comparison.vendor_b.vendor, "Neon");
+    } finally {
+      proc.kill();
+    }
+  });
+
+  it("returns error with suggestions when vendor not found", async () => {
+    const proc = startServer();
+    try {
+      const responses = (await sendMcpMessages(proc, [
+        ...INIT_MESSAGES,
+        {
+          jsonrpc: "2.0",
+          id: 2,
+          method: "tools/call",
+          params: { name: "compare_services", arguments: { vendor_a: "cloud", vendor_b: "Neon" } },
+        },
+      ])) as any[];
+
+      const result = responses.find((r: any) => r.id === 2) as any;
+      assert.ok(result.result.isError);
+      const text = result.result.content[0].text;
+      assert.ok(text.includes("not found"));
+      assert.ok(text.includes("Did you mean"));
+    } finally {
+      proc.kill();
+    }
+  });
+
+  it("returns error when both vendors not found", async () => {
+    const proc = startServer();
+    try {
+      const responses = (await sendMcpMessages(proc, [
+        ...INIT_MESSAGES,
+        {
+          jsonrpc: "2.0",
+          id: 2,
+          method: "tools/call",
+          params: { name: "compare_services", arguments: { vendor_a: "zzzzz", vendor_b: "yyyyy" } },
+        },
+      ])) as any[];
+
+      const result = responses.find((r: any) => r.id === 2) as any;
+      assert.ok(result.result.isError);
+      const text = result.result.content[0].text;
+      // Both should be mentioned as not found
+      assert.ok(text.includes("zzzzz"));
+      assert.ok(text.includes("yyyyy"));
+    } finally {
+      proc.kill();
+    }
+  });
+
+  it("works when comparing same vendor", async () => {
+    const proc = startServer();
+    try {
+      const responses = (await sendMcpMessages(proc, [
+        ...INIT_MESSAGES,
+        {
+          jsonrpc: "2.0",
+          id: 2,
+          method: "tools/call",
+          params: { name: "compare_services", arguments: { vendor_a: "Vercel", vendor_b: "Vercel" } },
+        },
+      ])) as any[];
+
+      const result = responses.find((r: any) => r.id === 2) as any;
+      assert.ok(!result.result.isError);
+      const comparison = JSON.parse(result.result.content[0].text);
+      assert.strictEqual(comparison.vendor_a.vendor, "Vercel");
+      assert.strictEqual(comparison.vendor_b.vendor, "Vercel");
+      assert.strictEqual(comparison.shared_categories, true);
+    } finally {
+      proc.kill();
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- New `compare_services` MCP tool and `/api/compare` REST endpoint for side-by-side vendor comparison
- Accepts two vendor names with case-insensitive fuzzy matching
- Returns structured comparison: free tier details, deal changes, category overlap
- Helpful error messages with vendor suggestions when not found
- OpenAPI spec updated with new endpoint

## Test plan
- [x] 6 new tests: same-category comparison, cross-category, fuzzy matching, vendor not found, both not found, same vendor
- [x] All 133 tests pass (127 existing + 6 new)
- [x] Verified via direct function call: `compareServices('supabase', 'neon')` returns correct data

Refs #158