### PR TITLE
Fix 14 failing tests: forward search params and fix test infra

### DIFF
--- a/src/api-client.ts
+++ b/src/api-client.ts
@@ -48,12 +48,16 @@ export async function fetchCategories(): Promise<unknown> {
 export async function fetchOffers(params: {
   q?: string;
   category?: string;
+  eligibility_type?: string;
+  sort?: string;
   limit?: number;
   offset?: number;
 }): Promise<unknown> {
   const p: Record<string, string> = {};
   if (params.q) p.q = params.q;
   if (params.category) p.category = params.category;
+  if (params.eligibility_type) p.eligibility_type = params.eligibility_type;
+  if (params.sort) p.sort = params.sort;
   if (params.limit !== undefined) p.limit = String(params.limit);
   if (params.offset !== undefined) p.offset = String(params.offset);
   return apiFetch("/api/offers", p);

--- a/src/serve.ts
+++ b/src/serve.ts
@@ -673,9 +673,11 @@ const httpServer = createHttpServer(async (req, res) => {
     recordApiHit("/api/offers");
     const q = url.searchParams.get("q") || undefined;
     const category = url.searchParams.get("category") || undefined;
+    const eligibilityType = url.searchParams.get("eligibility_type") || undefined;
+    const sort = url.searchParams.get("sort") || undefined;
     const limit = parseInt(url.searchParams.get("limit") ?? "20", 10);
     const offset = parseInt(url.searchParams.get("offset") ?? "0", 10);
-    const results = searchOffers(q, category);
+    const results = searchOffers(q, category, eligibilityType, sort);
     const total = results.length;
     const paged = results.slice(offset, offset + limit);
     logRequest({ ts: new Date().toISOString(), type: "api", endpoint: "/api/offers", params: { q, category, limit, offset }, user_agent: req.headers["user-agent"] ?? "unknown", result_count: paged.length });

--- a/src/server-remote.ts
+++ b/src/server-remote.ts
@@ -69,12 +69,12 @@ export function createServer(): McpServer {
         offset: z.number().optional().describe("Number of results to skip (default: 0)"),
       },
     },
-    async ({ query, category, limit, offset }) => {
+    async ({ query, category, eligibility_type, sort, limit, offset }) => {
       try {
         const usePagination = limit !== undefined || offset !== undefined;
         const effectiveOffset = offset ?? 0;
         const effectiveLimit = limit ?? (usePagination ? 20 : 10000);
-        const data = await fetchOffers({ q: query, category, limit: effectiveLimit, offset: effectiveOffset }) as { offers: unknown[]; total: number };
+        const data = await fetchOffers({ q: query, category, eligibility_type, sort, limit: effectiveLimit, offset: effectiveOffset }) as { offers: unknown[]; total: number };
         return mcpText({ results: data.offers, total: data.total, limit: effectiveLimit, offset: effectiveOffset });
       } catch (err) {
         return mcpError(`Error searching offers: ${err instanceof Error ? err.message : String(err)}`);

--- a/test/error-handling.test.ts
+++ b/test/error-handling.test.ts
@@ -1,20 +1,17 @@
-import { describe, it, beforeEach, afterEach } from "node:test";
+import { describe, it } from "node:test";
 import assert from "node:assert";
-import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { spawn } from "node:child_process";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
-const INDEX_PATH = path.join(__dirname, "..", "data", "index.json");
-const BACKUP_PATH = path.join(__dirname, "..", "data", "index.json.bak");
 
 function sendMcpMessages(
   serverProcess: ReturnType<typeof spawn>,
   messages: object[]
 ): Promise<object[]> {
   return new Promise((resolve, reject) => {
-    const timeout = setTimeout(() => reject(new Error("Timeout")), 5000);
+    const timeout = setTimeout(() => reject(new Error("Timeout")), 10000);
     const responses: object[] = [];
     let buffer = "";
     const expectedResponses = messages.filter(
@@ -62,35 +59,23 @@ const INIT_MESSAGES = [
   { jsonrpc: "2.0", method: "notifications/initialized" },
 ];
 
-function startServer() {
+function startServerWithBadApi() {
   const serverPath = path.join(__dirname, "..", "dist", "index.js");
   return spawn("node", [serverPath], {
     stdio: ["pipe", "pipe", "pipe"],
+    env: {
+      ...process.env,
+      AGENTDEALS_API_URL: "http://127.0.0.1:19999",
+    },
   });
 }
 
-// These tests modify the data index file. Each test backs up the file,
-// modifies it, starts a fresh server, tests, then restores the backup.
-// Tests within this describe block run serially (Node test runner default
-// for tests within a single describe) and each test manages its own
-// backup/restore to avoid interfering with concurrent test files.
+// These tests verify the stdio server handles API errors gracefully
+// by pointing it at a non-existent API endpoint.
 
 describe("error handling", () => {
-  beforeEach(() => {
-    // Back up the original index
-    fs.copyFileSync(INDEX_PATH, BACKUP_PATH);
-  });
-
-  afterEach(() => {
-    // Restore the original index
-    fs.copyFileSync(BACKUP_PATH, INDEX_PATH);
-    fs.unlinkSync(BACKUP_PATH);
-  });
-
-  it("handles malformed JSON in index file gracefully", async () => {
-    fs.writeFileSync(INDEX_PATH, "{ not valid json !!!", "utf-8");
-
-    const proc = startServer();
+  it("returns error for list_categories when API is unreachable", async () => {
+    const proc = startServerWithBadApi();
     try {
       const responses = (await sendMcpMessages(proc, [
         ...INIT_MESSAGES,
@@ -104,18 +89,16 @@ describe("error handling", () => {
 
       const result = responses.find((r: any) => r.id === 2) as any;
       assert.ok(result.result, "Should return a result, not crash");
-      const categories = JSON.parse(result.result.content[0].text);
-      assert.ok(Array.isArray(categories));
-      assert.strictEqual(categories.length, 0, "Should return empty categories for malformed JSON");
+      assert.strictEqual(result.result.isError, true, "Should indicate an error");
+      const text = result.result.content[0].text;
+      assert.ok(text.includes("unreachable") || text.includes("Error"), "Error message should mention API issue");
     } finally {
       proc.kill();
     }
   });
 
-  it("handles missing offers array in index file gracefully", async () => {
-    fs.writeFileSync(INDEX_PATH, JSON.stringify({ notOffers: [] }), "utf-8");
-
-    const proc = startServer();
+  it("returns error for search_offers when API is unreachable", async () => {
+    const proc = startServerWithBadApi();
     try {
       const responses = (await sendMcpMessages(proc, [
         ...INIT_MESSAGES,
@@ -129,19 +112,16 @@ describe("error handling", () => {
 
       const result = responses.find((r: any) => r.id === 2) as any;
       assert.ok(result.result, "Should return a result, not crash");
-      const body = JSON.parse(result.result.content[0].text);
-      assert.ok(Array.isArray(body.results));
-      assert.strictEqual(body.results.length, 0, "Should return empty offers for missing offers array");
-      assert.strictEqual(body.total, 0);
+      assert.strictEqual(result.result.isError, true, "Should indicate an error");
+      const text = result.result.content[0].text;
+      assert.ok(text.includes("unreachable") || text.includes("Error"), "Error message should mention API issue");
     } finally {
       proc.kill();
     }
   });
 
-  it("list_categories returns empty array when index has no offers", async () => {
-    fs.writeFileSync(INDEX_PATH, JSON.stringify({ offers: [] }), "utf-8");
-
-    const proc = startServer();
+  it("returns error for get_offer_details when API is unreachable", async () => {
+    const proc = startServerWithBadApi();
     try {
       const responses = (await sendMcpMessages(proc, [
         ...INIT_MESSAGES,
@@ -149,15 +129,15 @@ describe("error handling", () => {
           jsonrpc: "2.0",
           id: 2,
           method: "tools/call",
-          params: { name: "list_categories", arguments: {} },
+          params: { name: "get_offer_details", arguments: { vendor: "Vercel" } },
         },
       ])) as any[];
 
       const result = responses.find((r: any) => r.id === 2) as any;
       assert.ok(result.result, "Should return a result, not crash");
-      const categories = JSON.parse(result.result.content[0].text);
-      assert.ok(Array.isArray(categories));
-      assert.strictEqual(categories.length, 0, "Should return empty categories for empty offers");
+      assert.strictEqual(result.result.isError, true, "Should indicate an error");
+      const text = result.result.content[0].text;
+      assert.ok(text.includes("unreachable") || text.includes("Error"), "Error message should mention API issue");
     } finally {
       proc.kill();
     }

--- a/test/query-log.test.ts
+++ b/test/query-log.test.ts
@@ -1,52 +1,44 @@
-import { describe, it, afterEach } from "node:test";
+import { describe, it, after } from "node:test";
 import assert from "node:assert";
 import { spawn, type ChildProcess } from "node:child_process";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
-const PORT = 3459; // Unique port to avoid conflicts
+const PORT = 13592; // Unique port to avoid conflicts
 
-function startHttpServer(): Promise<ChildProcess> {
-  return new Promise((resolve, reject) => {
-    const serverPath = path.join(__dirname, "..", "dist", "serve.js");
-    const proc = spawn("node", [serverPath], {
-      stdio: ["pipe", "pipe", "pipe"],
-      env: { ...process.env, PORT: String(PORT) },
-    });
+// Start a single HTTP server for all query-log tests
+const serverPath = path.join(__dirname, "..", "dist", "serve.js");
+const proc: ChildProcess = spawn("node", [serverPath], {
+  stdio: ["pipe", "pipe", "pipe"],
+  env: { ...process.env, PORT: String(PORT) },
+});
 
-    const timeout = setTimeout(() => {
-      proc.kill();
-      reject(new Error("Server startup timeout"));
-    }, 5000);
+await new Promise<void>((resolve, reject) => {
+  const timeout = setTimeout(() => {
+    proc.kill();
+    reject(new Error("Server startup timeout"));
+  }, 5000);
 
-    proc.stderr!.on("data", (data: Buffer) => {
-      if (data.toString().includes("running on http")) {
-        clearTimeout(timeout);
-        resolve(proc);
-      }
-    });
-
-    proc.on("error", (err) => {
+  proc.stderr!.on("data", (data: Buffer) => {
+    if (data.toString().includes("running on")) {
       clearTimeout(timeout);
-      reject(err);
-    });
-  });
-}
-
-describe("query-log endpoint", () => {
-  let proc: ChildProcess | null = null;
-
-  afterEach(() => {
-    if (proc) {
-      proc.kill();
-      proc = null;
+      resolve();
     }
   });
 
-  it("GET /api/query-log returns entries array and count", async () => {
-    proc = await startHttpServer();
+  proc.on("error", (err) => {
+    clearTimeout(timeout);
+    reject(err);
+  });
+});
 
+after(() => {
+  proc.kill();
+});
+
+describe("query-log endpoint", () => {
+  it("GET /api/query-log returns entries array and count", async () => {
     const response = await fetch(`http://localhost:${PORT}/api/query-log`);
     assert.strictEqual(response.status, 200);
     assert.strictEqual(response.headers.get("content-type"), "application/json");
@@ -58,8 +50,6 @@ describe("query-log endpoint", () => {
   });
 
   it("GET /api/query-log accepts limit parameter", async () => {
-    proc = await startHttpServer();
-
     const response = await fetch(`http://localhost:${PORT}/api/query-log?limit=5`);
     assert.strictEqual(response.status, 200);
     const body = await response.json() as any;
@@ -69,8 +59,6 @@ describe("query-log endpoint", () => {
   });
 
   it("GET /api/query-log clamps limit to 1-200 range", async () => {
-    proc = await startHttpServer();
-
     // Negative limit should be clamped to 1
     const resp1 = await fetch(`http://localhost:${PORT}/api/query-log?limit=-10`);
     assert.strictEqual(resp1.status, 200);

--- a/test/search.test.ts
+++ b/test/search.test.ts
@@ -1,10 +1,38 @@
-import { describe, it } from "node:test";
+import { describe, it, after } from "node:test";
 import assert from "node:assert";
-import { spawn } from "node:child_process";
+import { spawn, type ChildProcess } from "node:child_process";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+// Start a local HTTP server so stdio MCP tests hit local data (not production API)
+const LOCAL_API_PORT = 13590;
+const LOCAL_API_URL = `http://localhost:${LOCAL_API_PORT}`;
+
+const httpServerPath = path.join(__dirname, "..", "dist", "serve.js");
+const httpServer: ChildProcess = spawn("node", [httpServerPath], {
+  env: { ...process.env, PORT: String(LOCAL_API_PORT) },
+  stdio: ["pipe", "pipe", "pipe"],
+});
+
+await new Promise<void>((resolve, reject) => {
+  const timeout = setTimeout(() => reject(new Error("HTTP server start timeout")), 5000);
+  httpServer.stderr!.on("data", (chunk: Buffer) => {
+    if (chunk.toString().includes("running on")) {
+      clearTimeout(timeout);
+      resolve();
+    }
+  });
+  httpServer.on("error", (err) => {
+    clearTimeout(timeout);
+    reject(err);
+  });
+});
+
+after(() => {
+  httpServer.kill();
+});
 
 function sendMcpMessages(
   serverProcess: ReturnType<typeof spawn>,
@@ -63,6 +91,7 @@ function startServer() {
   const serverPath = path.join(__dirname, "..", "dist", "index.js");
   return spawn("node", [serverPath], {
     stdio: ["pipe", "pipe", "pipe"],
+    env: { ...process.env, AGENTDEALS_API_URL: LOCAL_API_URL },
   });
 }
 


### PR DESCRIPTION
## Summary
- Forward `eligibility_type` and `sort` query params through the full REST API → API client → stdio MCP chain (fixes 8 test failures)
- Rewrite error-handling tests for remote server architecture — test API-unreachable errors instead of local file corruption (fixes 3 test failures)
- Fix query-log tests: share single HTTP server instance per describe block, use unique port to avoid EADDRINUSE (fixes 3 test failures)
- Update search tests to run against local HTTP server instead of production Railway API

## Test plan
- [x] All 139 tests pass (was 128/139)
- [x] eligibility_type filtering works via MCP stdio
- [x] sort param works via MCP stdio
- [x] Error handling returns graceful MCP errors when API unreachable
- [x] Query-log tests no longer timeout

Refs #162

🤖 Generated with [Claude Code](https://claude.com/claude-code)