### PR TITLE
Add check_vendor_risk tool — pricing stability scores (#165)

### DIFF
--- a/src/api-client.ts
+++ b/src/api-client.ts
@@ -102,3 +102,7 @@ export async function fetchCosts(services: string[], scale?: string): Promise<un
 export async function fetchCompare(vendorA: string, vendorB: string): Promise<unknown> {
   return apiFetch("/api/compare", { a: vendorA, b: vendorB });
 }
+
+export async function fetchVendorRisk(vendor: string): Promise<unknown> {
+  return apiFetch(`/api/vendor-risk/${encodeURIComponent(vendor)}`);
+}

--- a/src/data.ts
+++ b/src/data.ts
@@ -299,6 +299,120 @@ export interface ComparisonResult {
   category_overlap: string[];
 }
 
+export interface VendorRiskResult {
+  vendor: string;
+  category: string;
+  risk_level: "stable" | "caution" | "risky";
+  free_tier_longevity_days: number;
+  changes: DealChange[];
+  alternatives: Array<{ vendor: string; category: string; tier: string; risk_level: "stable" | "caution" | "risky" }>;
+  summary: string;
+}
+
+const NEGATIVE_CHANGE_TYPES = new Set([
+  "free_tier_removed",
+  "open_source_killed",
+  "limits_reduced",
+  "pricing_restructured",
+  "product_deprecated",
+]);
+
+const RISKY_CHANGE_TYPES = new Set(["free_tier_removed", "open_source_killed"]);
+
+function vendorRiskLevel(vendorChanges: DealChange[]): "stable" | "caution" | "risky" {
+  const twelveMonthsAgo = new Date(Date.now() - 365 * 24 * 60 * 60 * 1000)
+    .toISOString()
+    .slice(0, 10);
+
+  for (const c of vendorChanges) {
+    if (RISKY_CHANGE_TYPES.has(c.change_type) && c.date >= twelveMonthsAgo) {
+      return "risky";
+    }
+  }
+
+  for (const c of vendorChanges) {
+    if (c.change_type === "limits_reduced" || c.change_type === "pricing_restructured") {
+      return "caution";
+    }
+  }
+
+  return "stable";
+}
+
+export function checkVendorRisk(
+  vendorName: string
+): { result: VendorRiskResult } | { error: string; suggestions?: string[] } {
+  const offers = loadOffers();
+  const match = findVendor(offers, vendorName);
+
+  if (!match.offer) {
+    return {
+      error: `Vendor "${vendorName}" not found.${match.suggestions.length > 0 ? ` Did you mean: ${match.suggestions.join(", ")}?` : ""}`,
+      ...(match.suggestions.length > 0 ? { suggestions: match.suggestions } : {}),
+    };
+  }
+
+  const offer = match.offer;
+  const allChanges = loadDealChanges();
+  const vendorChanges = allChanges
+    .filter((c) => c.vendor.toLowerCase() === offer.vendor.toLowerCase())
+    .sort((a, b) => b.date.localeCompare(a.date));
+
+  const riskLevel = vendorRiskLevel(vendorChanges);
+
+  // Free tier longevity: days since verifiedDate with no negative changes after it
+  const verifiedDate = new Date(offer.verifiedDate);
+  const lastNegativeChange = vendorChanges.find((c) => NEGATIVE_CHANGE_TYPES.has(c.change_type));
+  const longevityStart = lastNegativeChange
+    ? new Date(Math.max(new Date(lastNegativeChange.date).getTime(), verifiedDate.getTime()))
+    : verifiedDate;
+  const longevityDays = Math.max(
+    0,
+    Math.floor((Date.now() - longevityStart.getTime()) / (24 * 60 * 60 * 1000))
+  );
+
+  // Find up to 3 more-stable alternatives in same category
+  const sameCategoryOffers = offers.filter(
+    (o) => o.category === offer.category && o.vendor !== offer.vendor
+  );
+  const alternativesWithRisk = sameCategoryOffers.map((o) => {
+    const oChanges = allChanges.filter((c) => c.vendor.toLowerCase() === o.vendor.toLowerCase());
+    return {
+      vendor: o.vendor,
+      category: o.category,
+      tier: o.tier,
+      risk_level: vendorRiskLevel(oChanges),
+    };
+  });
+  // Prefer stable > caution > risky, then alphabetical
+  const riskOrder = { stable: 0, caution: 1, risky: 2 };
+  const alternatives = alternativesWithRisk
+    .sort((a, b) => riskOrder[a.risk_level] - riskOrder[b.risk_level] || a.vendor.localeCompare(b.vendor))
+    .slice(0, 3);
+
+  // Build summary
+  let summary: string;
+  if (riskLevel === "risky") {
+    summary = `${offer.vendor} is high risk — has had a free tier removal or open source license change in the last 12 months. Consider alternatives.`;
+  } else if (riskLevel === "caution") {
+    summary = `${offer.vendor} has had pricing changes (limit reductions or restructuring). Monitor for further changes.`;
+  } else {
+    summary = `${offer.vendor} has a stable pricing history with no negative changes recorded. Free tier verified for ${longevityDays} days.`;
+  }
+
+  return {
+    result: {
+      vendor: offer.vendor,
+      category: offer.category,
+      risk_level: riskLevel,
+      free_tier_longevity_days: longevityDays,
+      changes: vendorChanges,
+      alternatives,
+      summary,
+    },
+  };
+}
+
 export function compareServices(
   vendorA: string,
   vendorB: string

--- a/src/openapi.ts
+++ b/src/openapi.ts
@@ -253,6 +253,61 @@ export const openapiSpec = {
         }
       }
     },
+    "/api/vendor-risk/{vendor}": {
+      get: {
+        summary: "Check vendor pricing stability and risk",
+        description: "Before depending on a vendor's free tier, check if their pricing is stable. Returns risk level (stable/caution/risky), pricing change history, free tier longevity, and more-stable alternatives.",
+        parameters: [
+          { name: "vendor", in: "path", required: true, description: "Vendor name (case-insensitive, fuzzy match supported)", schema: { type: "string" }, example: "Vercel" }
+        ],
+        responses: {
+          "200": {
+            description: "Vendor risk assessment",
+            content: {
+              "application/json": {
+                schema: {
+                  type: "object",
+                  properties: {
+                    vendor: { type: "string" },
+                    category: { type: "string" },
+                    risk_level: { type: "string", enum: ["stable", "caution", "risky"] },
+                    free_tier_longevity_days: { type: "number" },
+                    changes: { type: "array", items: { $ref: "#/components/schemas/DealChange" } },
+                    alternatives: {
+                      type: "array",
+                      items: {
+                        type: "object",
+                        properties: {
+                          vendor: { type: "string" },
+                          category: { type: "string" },
+                          tier: { type: "string" },
+                          risk_level: { type: "string", enum: ["stable", "caution", "risky"] }
+                        }
+                      }
+                    },
+                    summary: { type: "string" }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            description: "Vendor not found",
+            content: {
+              "application/json": {
+                schema: {
+                  type: "object",
+                  properties: {
+                    error: { type: "string" },
+                    suggestions: { type: "array", items: { type: "string" } }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/stack": {
       get: {
         summary: "Get free-tier stack recommendation",

--- a/src/serve.ts
+++ b/src/serve.ts
@@ -5,7 +5,7 @@ import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
 import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
 import { createServer } from "./server.js";
-import { loadOffers, getCategories, getNewOffers, searchOffers, loadDealChanges, getDealChanges, getOfferDetails, compareServices } from "./data.js";
+import { loadOffers, getCategories, getNewOffers, searchOffers, loadDealChanges, getDealChanges, getOfferDetails, compareServices, checkVendorRisk } from "./data.js";
 import { getStackRecommendation } from "./stacks.js";
 import { estimateCosts } from "./costs.js";
 import { recordApiHit, recordSessionConnect, recordSessionDisconnect, recordLandingPageView, getStats, getConnectionStats, loadTelemetry, flushTelemetry, logRequest, getRequestLog } from "./stats.js";
@@ -730,6 +730,24 @@ const httpServer = createHttpServer(async (req, res) => {
     logRequest({ ts: new Date().toISOString(), type: "api", endpoint: "/api/changes", params: { since, type, vendor: vendorFilter }, user_agent: req.headers["user-agent"] ?? "unknown", result_count: result.changes.length });
     res.writeHead(200, { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" });
     res.end(JSON.stringify(result));
+  } else if (url.pathname.startsWith("/api/vendor-risk/") && req.method === "GET") {
+    recordApiHit("/api/vendor-risk");
+    const vendorParam = decodeURIComponent(url.pathname.slice("/api/vendor-risk/".length));
+    if (!vendorParam) {
+      res.writeHead(400, { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" });
+      res.end(JSON.stringify({ error: "Vendor name is required." }));
+      return;
+    }
+    const riskResult = checkVendorRisk(vendorParam);
+    if ("error" in riskResult) {
+      logRequest({ ts: new Date().toISOString(), type: "api", endpoint: "/api/vendor-risk", params: { vendor: vendorParam }, user_agent: req.headers["user-agent"] ?? "unknown", result_count: 0 });
+      res.writeHead(404, { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" });
+      res.end(JSON.stringify({ error: riskResult.error, ...(riskResult.suggestions ? { suggestions: riskResult.suggestions } : {}) }));
+      return;
+    }
+    logRequest({ ts: new Date().toISOString(), type: "api", endpoint: "/api/vendor-risk", params: { vendor: vendorParam }, user_agent: req.headers["user-agent"] ?? "unknown", result_count: 1 });
+    res.writeHead(200, { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" });
+    res.end(JSON.stringify(riskResult.result));
   } else if (url.pathname.startsWith("/api/details/") && req.method === "GET") {
     recordApiHit("/api/details");
     const vendorParam = decodeURIComponent(url.pathname.slice("/api/details/".length));

--- a/src/server-remote.ts
+++ b/src/server-remote.ts
@@ -9,6 +9,7 @@ import {
   fetchStackRecommendation,
   fetchCosts,
   fetchCompare,
+  fetchVendorRisk,
 } from "./api-client.js";
 
 function mcpError(msg: string) {
@@ -227,6 +228,33 @@ export function createServer(): McpServer {
           }
         }
         return mcpError(`Error comparing services: ${errMsg}`);
+      }
+    }
+  );
+
+  server.registerTool(
+    "check_vendor_risk",
+    {
+      description:
+        "Before depending on a vendor's free tier, check if their pricing is stable. Returns risk level (stable/caution/risky), pricing change history, free tier longevity, and more-stable alternatives. We track 52+ real pricing changes — use this to avoid vendors that have broken trust.",
+      inputSchema: {
+        vendor: z.string().describe("Vendor name to check (case-insensitive, fuzzy match supported)"),
+      },
+    },
+    async ({ vendor }) => {
+      try {
+        const data = await fetchVendorRisk(vendor);
+        return mcpText(data);
+      } catch (err) {
+        const errMsg = err instanceof Error ? err.message : String(err);
+        const match = errMsg.match(/API error \(404\): (.+)/);
+        if (match) {
+          const parsed = tryParseJson(match[1]);
+          if (parsed && typeof parsed === "object" && parsed !== null && "error" in parsed) {
+            return mcpError((parsed as { error: string }).error);
+          }
+        }
+        return mcpError(`Error checking vendor risk: ${errMsg}`);
       }
     }
   );

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,6 +1,6 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
-import { getCategories, getDealChanges, getNewOffers, getOfferDetails, searchOffers, compareServices } from "./data.js";
+import { getCategories, getDealChanges, getNewOffers, getOfferDetails, searchOffers, compareServices, checkVendorRisk } from "./data.js";
 import { recordToolCall, logRequest } from "./stats.js";
 import { getStackRecommendation } from "./stacks.js";
 import { estimateCosts } from "./costs.js";
@@ -331,6 +331,50 @@ export function createServer(getSessionId?: () => string | undefined): McpServer
             {
               type: "text" as const,
               text: `Error comparing services: ${err instanceof Error ? err.message : String(err)}`,
+            },
+          ],
+        };
+      }
+    }
+  );
+
+  server.registerTool(
+    "check_vendor_risk",
+    {
+      description:
+        "Before depending on a vendor's free tier, check if their pricing is stable. Returns risk level (stable/caution/risky), pricing change history, free tier longevity, and more-stable alternatives. We track 52+ real pricing changes — use this to avoid vendors that have broken trust.",
+      inputSchema: {
+        vendor: z.string().describe("Vendor name to check (case-insensitive, fuzzy match supported)"),
+      },
+    },
+    async ({ vendor }) => {
+      try {
+        recordToolCall("check_vendor_risk");
+        const result = checkVendorRisk(vendor);
+        if ("error" in result) {
+          logRequest({ ts: new Date().toISOString(), type: "mcp", endpoint: "check_vendor_risk", params: { vendor }, result_count: 0, session_id: getSessionId?.() });
+          return {
+            isError: true,
+            content: [{ type: "text" as const, text: result.error }],
+          };
+        }
+        logRequest({ ts: new Date().toISOString(), type: "mcp", endpoint: "check_vendor_risk", params: { vendor }, result_count: 1, session_id: getSessionId?.() });
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: JSON.stringify(result.result, null, 2),
+            },
+          ],
+        };
+      } catch (err) {
+        console.error("check_vendor_risk error:", err);
+        return {
+          isError: true,
+          content: [
+            {
+              type: "text" as const,
+              text: `Error checking vendor risk: ${err instanceof Error ? err.message : String(err)}`,
             },
           ],
         };

--- a/test/http.test.ts
+++ b/test/http.test.ts
@@ -760,7 +760,8 @@ describe("HTTP transport", () => {
     assert.ok(body.paths["/api/query-log"]);
     assert.ok(body.paths["/api/stack"]);
     assert.ok(body.paths["/api/compare"]);
-    assert.strictEqual(Object.keys(body.paths).length, 9);
+    assert.ok(body.paths["/api/vendor-risk/{vendor}"]);
+    assert.strictEqual(Object.keys(body.paths).length, 10);
     assert.ok(body.components.schemas.Offer);
     assert.ok(body.components.schemas.DealChange);
     assert.ok(body.components.schemas.Eligibility);

--- a/test/vendor-risk.test.ts
+++ b/test/vendor-risk.test.ts
@@ -1,0 +1,187 @@
+import { describe, it, afterEach } from "node:test";
+import assert from "node:assert";
+import { spawn, type ChildProcess } from "node:child_process";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+describe("checkVendorRisk logic", () => {
+  it("returns stable risk for vendor with no changes", async () => {
+    const { checkVendorRisk } = await import("../dist/data.js");
+    const result = checkVendorRisk("Vercel");
+    assert.ok(!("error" in result), "Should not return error for known vendor");
+    assert.strictEqual(result.result.vendor, "Vercel");
+    assert.ok(["stable", "caution", "risky"].includes(result.result.risk_level));
+    assert.ok(typeof result.result.free_tier_longevity_days === "number");
+    assert.ok(Array.isArray(result.result.changes));
+    assert.ok(Array.isArray(result.result.alternatives));
+    assert.ok(result.result.alternatives.length <= 3);
+    assert.ok(result.result.summary.length > 0);
+    assert.ok(result.result.category.length > 0);
+  });
+
+  it("returns caution for vendor with pricing_restructured", async () => {
+    const { checkVendorRisk } = await import("../dist/data.js");
+    // Vercel has pricing_restructured change
+    const result = checkVendorRisk("Vercel");
+    assert.ok(!("error" in result), "Vercel should be found");
+    assert.strictEqual(result.result.risk_level, "caution", "Vercel should be caution due to pricing_restructured");
+    assert.ok(result.result.changes.length > 0, "Should have recorded changes");
+    assert.ok(result.result.changes.some(c => c.change_type === "pricing_restructured"), "Should have pricing_restructured change");
+  });
+
+  it("returns caution for vendor with limits_reduced", async () => {
+    const { checkVendorRisk } = await import("../dist/data.js");
+    // Supabase has limits_reduced change
+    const result = checkVendorRisk("Supabase");
+    assert.ok(!("error" in result), "Supabase should be found");
+    assert.strictEqual(result.result.risk_level, "caution", "Supabase should be caution due to limits_reduced");
+    assert.ok(result.result.changes.length > 0, "Should have recorded changes");
+  });
+
+  it("returns error with suggestions for unknown vendor", async () => {
+    const { checkVendorRisk } = await import("../dist/data.js");
+    const result = checkVendorRisk("NonExistentVendor123");
+    assert.ok("error" in result, "Should return error for unknown vendor");
+    assert.ok(result.error.includes("not found"));
+  });
+
+  it("returns fuzzy match suggestions for partial vendor name", async () => {
+    const { checkVendorRisk } = await import("../dist/data.js");
+    // "Cloud" should fuzzy match multiple vendors
+    const result = checkVendorRisk("Cloud");
+    // Could either fuzzy-match a single vendor or return suggestions
+    if ("error" in result) {
+      assert.ok(result.suggestions && result.suggestions.length > 0, "Should have suggestions");
+    }
+  });
+
+  it("alternatives are sorted by risk level", async () => {
+    const { checkVendorRisk } = await import("../dist/data.js");
+    const result = checkVendorRisk("Vercel");
+    assert.ok(!("error" in result));
+    const riskOrder: Record<string, number> = { stable: 0, caution: 1, risky: 2 };
+    for (let i = 1; i < result.result.alternatives.length; i++) {
+      assert.ok(
+        riskOrder[result.result.alternatives[i].risk_level] >= riskOrder[result.result.alternatives[i - 1].risk_level],
+        "Alternatives should be sorted by risk level (stable first)"
+      );
+    }
+  });
+
+  it("alternatives include risk_level field", async () => {
+    const { checkVendorRisk } = await import("../dist/data.js");
+    const result = checkVendorRisk("Supabase");
+    assert.ok(!("error" in result));
+    for (const alt of result.result.alternatives) {
+      assert.ok(["stable", "caution", "risky"].includes(alt.risk_level), `Alternative ${alt.vendor} should have valid risk_level`);
+      assert.ok(alt.vendor);
+      assert.ok(alt.category);
+      assert.ok(alt.tier);
+    }
+  });
+});
+
+describe("check_vendor_risk MCP tool via stdio", () => {
+  let proc: ChildProcess | null = null;
+
+  afterEach(() => {
+    if (proc) { proc.kill(); proc = null; }
+  });
+
+  it("check_vendor_risk is listed in tools/list", async () => {
+    const serverPath = path.join(__dirname, "..", "dist", "index.js");
+    proc = spawn("node", [serverPath], { stdio: ["pipe", "pipe", "pipe"] });
+
+    const initMsg = JSON.stringify({
+      jsonrpc: "2.0",
+      id: 1,
+      method: "initialize",
+      params: { protocolVersion: "2024-11-05", capabilities: {}, clientInfo: { name: "test", version: "1.0" } },
+    });
+
+    const initedMsg = JSON.stringify({
+      jsonrpc: "2.0",
+      method: "notifications/initialized",
+    });
+
+    const listTools = JSON.stringify({
+      jsonrpc: "2.0",
+      id: 2,
+      method: "tools/list",
+    });
+
+    const response = await new Promise<string>((resolve, reject) => {
+      let data = "";
+      const timeout = setTimeout(() => reject(new Error("Timeout")), 10000);
+      proc!.stdout!.on("data", (chunk: Buffer) => {
+        data += chunk.toString();
+        const lines = data.split("\n").filter(Boolean);
+        if (lines.length >= 2) {
+          clearTimeout(timeout);
+          resolve(lines[1]);
+        }
+      });
+      proc!.stdin!.write(initMsg + "\n");
+      proc!.stdin!.write(initedMsg + "\n");
+      proc!.stdin!.write(listTools + "\n");
+    });
+
+    const parsed = JSON.parse(response);
+    assert.strictEqual(parsed.id, 2);
+    assert.ok(parsed.result);
+    const tools = parsed.result.tools;
+    assert.ok(Array.isArray(tools));
+    const riskTool = tools.find((t: any) => t.name === "check_vendor_risk");
+    assert.ok(riskTool, "check_vendor_risk should be in tools list");
+    assert.ok(riskTool.description.includes("risk"), "Description should mention risk");
+    assert.ok(riskTool.inputSchema.properties.vendor, "Should have vendor input parameter");
+  });
+});
+
+describe("check_vendor_risk REST endpoint", () => {
+  const PORT = 3463;
+  let proc: ChildProcess | null = null;
+
+  function startHttpServer(): Promise<ChildProcess> {
+    return new Promise((resolve, reject) => {
+      const serverPath = path.join(__dirname, "..", "dist", "serve.js");
+      const p = spawn("node", [serverPath], {
+        stdio: ["pipe", "pipe", "pipe"],
+        env: { ...process.env, PORT: String(PORT) },
+      });
+      const timeout = setTimeout(() => { p.kill(); reject(new Error("Server startup timeout")); }, 5000);
+      p.stderr!.on("data", (data: Buffer) => {
+        if (data.toString().includes("running on http")) { clearTimeout(timeout); resolve(p); }
+      });
+      p.on("error", (err) => { clearTimeout(timeout); reject(err); });
+    });
+  }
+
+  afterEach(() => {
+    if (proc) { proc.kill(); proc = null; }
+  });
+
+  it("GET /api/vendor-risk/:vendor returns risk assessment", async () => {
+    proc = await startHttpServer();
+    const response = await fetch(`http://localhost:${PORT}/api/vendor-risk/Vercel`);
+    assert.strictEqual(response.status, 200);
+    assert.strictEqual(response.headers.get("access-control-allow-origin"), "*");
+    const body = await response.json() as any;
+    assert.ok(body.vendor);
+    assert.ok(body.risk_level);
+    assert.ok(typeof body.free_tier_longevity_days === "number");
+    assert.ok(Array.isArray(body.changes));
+    assert.ok(Array.isArray(body.alternatives));
+    assert.ok(body.summary);
+  });
+
+  it("GET /api/vendor-risk/:vendor returns 404 for unknown vendor", async () => {
+    proc = await startHttpServer();
+    const response = await fetch(`http://localhost:${PORT}/api/vendor-risk/NonExistentVendor123`);
+    assert.strictEqual(response.status, 404);
+    const body = await response.json() as any;
+    assert.ok(body.error.includes("not found"));
+  });
+});


### PR DESCRIPTION
## Summary

- New `check_vendor_risk` MCP tool that returns pricing stability assessment for any vendor
- Risk levels: `stable` (no negative changes), `caution` (limits reduced or pricing restructured), `risky` (free tier removed or open source killed in last 12 months)
- Returns free tier longevity (days since verified with no negative changes), full change history, and up to 3 more-stable alternatives sorted by risk level
- REST endpoint: `GET /api/vendor-risk/:vendor` with fuzzy matching and suggestions
- Registered in both local server (`server.ts`) and stdio remote proxy (`server-remote.ts`)
- OpenAPI spec updated with new endpoint

## Test plan

- [x] 7 unit tests for risk calculation logic (stable, caution via pricing_restructured, caution via limits_reduced, unknown vendor, fuzzy match, alternatives sorting, alternative fields)
- [x] 1 stdio test verifying tool appears in tools/list
- [x] 2 REST endpoint tests (200 for known vendor, 404 for unknown)
- [x] All 149 tests pass (10 new)

Refs #165

🤖 Generated with [Claude Code](https://claude.com/claude-code)