### PR TITLE
Add audit_stack tool — infrastructure savings and risk analysis (#166)

### DIFF
--- a/src/api-client.ts
+++ b/src/api-client.ts
@@ -106,3 +106,7 @@ export async function fetchCompare(vendorA: string, vendorB: string): Promise<un
 export async function fetchVendorRisk(vendor: string): Promise<unknown> {
   return apiFetch(`/api/vendor-risk/${encodeURIComponent(vendor)}`);
 }
+
+export async function fetchAuditStack(services: string[]): Promise<unknown> {
+  return apiFetch("/api/audit-stack", { services: services.join(",") });
+}

--- a/src/data.ts
+++ b/src/data.ts
@@ -413,6 +413,137 @@ export function checkVendorRisk(
   };
 }
 
+// Common infrastructure categories for gap detection
+const CORE_CATEGORIES = [
+  "Databases", "Cloud Hosting", "Monitoring", "Logging", "CI/CD",
+  "Auth", "Email", "Search", "Feature Flags",
+];
+
+export interface AuditServiceResult {
+  vendor: string;
+  status: "found" | "not_found";
+  category?: string;
+  tier?: string;
+  risk_level?: "stable" | "caution" | "risky";
+  recent_changes?: DealChange[];
+  cheaper_alternative?: { vendor: string; tier: string; category: string };
+  suggestions?: string[];
+}
+
+export interface AuditGap {
+  category: string;
+  recommendation: { vendor: string; tier: string; description: string };
+}
+
+export interface AuditResult {
+  services_analyzed: number;
+  risks_found: number;
+  savings_opportunities: number;
+  gaps: AuditGap[];
+  services: AuditServiceResult[];
+  recommendations: string[];
+}
+
+export function auditStack(serviceNames: string[]): AuditResult {
+  const offers = loadOffers();
+  const allChanges = loadDealChanges();
+  const services: AuditServiceResult[] = [];
+  const coveredCategories = new Set<string>();
+  let risksFound = 0;
+  let savingsOpportunities = 0;
+  const recommendations: string[] = [];
+
+  for (const name of serviceNames) {
+    const match = findVendor(offers, name);
+
+    if (!match.offer) {
+      services.push({
+        vendor: name,
+        status: "not_found",
+        ...(match.suggestions.length > 0 ? { suggestions: match.suggestions } : {}),
+      });
+      continue;
+    }
+
+    const offer = match.offer;
+    coveredCategories.add(offer.category);
+
+    const vendorChanges = allChanges
+      .filter((c) => c.vendor.toLowerCase() === offer.vendor.toLowerCase())
+      .sort((a, b) => b.date.localeCompare(a.date));
+
+    const riskLevel = vendorRiskLevel(vendorChanges);
+    if (riskLevel !== "stable") risksFound++;
+
+    // Find a cheaper/free alternative in same category
+    let cheaperAlternative: AuditServiceResult["cheaper_alternative"];
+    const sameCat = offers.filter(
+      (o) => o.category === offer.category && o.vendor !== offer.vendor && o.tier.toLowerCase().includes("free")
+    );
+    if (sameCat.length > 0) {
+      // Pick one with stable risk
+      const stableAlt = sameCat.find((o) => {
+        const oChanges = allChanges.filter((c) => c.vendor.toLowerCase() === o.vendor.toLowerCase());
+        return vendorRiskLevel(oChanges) === "stable";
+      });
+      const alt = stableAlt || sameCat[0];
+      cheaperAlternative = { vendor: alt.vendor, tier: alt.tier, category: alt.category };
+      savingsOpportunities++;
+    }
+
+    const svc: AuditServiceResult = {
+      vendor: offer.vendor,
+      status: "found",
+      category: offer.category,
+      tier: offer.tier,
+      risk_level: riskLevel,
+      ...(vendorChanges.length > 0 ? { recent_changes: vendorChanges } : {}),
+      ...(cheaperAlternative ? { cheaper_alternative: cheaperAlternative } : {}),
+    };
+
+    if (riskLevel === "risky") {
+      recommendations.push(`⚠️ ${offer.vendor} is high risk — consider switching to ${cheaperAlternative?.vendor || "an alternative"}.`);
+    } else if (riskLevel === "caution") {
+      recommendations.push(`Monitor ${offer.vendor} — recent pricing changes detected.`);
+    }
+
+    services.push(svc);
+  }
+
+  // Gap detection
+  const gaps: AuditGap[] = [];
+  for (const cat of CORE_CATEGORIES) {
+    if (!coveredCategories.has(cat)) {
+      const topFree = offers
+        .filter((o) => o.category === cat && o.tier.toLowerCase().includes("free"))
+        .slice(0, 1);
+      if (topFree.length > 0) {
+        gaps.push({
+          category: cat,
+          recommendation: {
+            vendor: topFree[0].vendor,
+            tier: topFree[0].tier,
+            description: topFree[0].description,
+          },
+        });
+      }
+    }
+  }
+
+  if (gaps.length > 0) {
+    recommendations.push(`Missing coverage in ${gaps.length} common categories: ${gaps.map((g) => g.category).join(", ")}.`);
+  }
+
+  return {
+    services_analyzed: serviceNames.length,
+    risks_found: risksFound,
+    savings_opportunities: savingsOpportunities,
+    gaps,
+    services,
+    recommendations,
+  };
+}
+
 export function compareServices(
   vendorA: string,
   vendorB: string

--- a/src/openapi.ts
+++ b/src/openapi.ts
@@ -253,6 +253,43 @@ export const openapiSpec = {
         }
       }
     },
+    "/api/audit-stack": {
+      get: {
+        summary: "Audit your infrastructure stack",
+        description: "Analyze your current services for pricing risks, cost savings, and missing capabilities. Returns per-service risk assessment, cheaper alternatives, and gap analysis.",
+        parameters: [
+          { name: "services", in: "query", required: true, description: "Comma-separated vendor names (e.g. 'Vercel,Supabase,Clerk')", schema: { type: "string" }, example: "Vercel,Supabase,Clerk" }
+        ],
+        responses: {
+          "200": {
+            description: "Stack audit results",
+            content: {
+              "application/json": {
+                schema: {
+                  type: "object",
+                  properties: {
+                    services_analyzed: { type: "number" },
+                    risks_found: { type: "number" },
+                    savings_opportunities: { type: "number" },
+                    gaps: { type: "array", items: { type: "object" } },
+                    services: { type: "array", items: { type: "object" } },
+                    recommendations: { type: "array", items: { type: "string" } }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            description: "Missing services parameter",
+            content: {
+              "application/json": {
+                schema: { type: "object", properties: { error: { type: "string" } } }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/vendor-risk/{vendor}": {
       get: {
         summary: "Check vendor pricing stability and risk",

--- a/src/serve.ts
+++ b/src/serve.ts
@@ -5,7 +5,7 @@ import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
 import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
 import { createServer } from "./server.js";
-import { loadOffers, getCategories, getNewOffers, searchOffers, loadDealChanges, getDealChanges, getOfferDetails, compareServices, checkVendorRisk } from "./data.js";
+import { loadOffers, getCategories, getNewOffers, searchOffers, loadDealChanges, getDealChanges, getOfferDetails, compareServices, checkVendorRisk, auditStack } from "./data.js";
 import { getStackRecommendation } from "./stacks.js";
 import { estimateCosts } from "./costs.js";
 import { recordApiHit, recordSessionConnect, recordSessionDisconnect, recordLandingPageView, getStats, getConnectionStats, loadTelemetry, flushTelemetry, logRequest, getRequestLog } from "./stats.js";
@@ -730,6 +730,24 @@ const httpServer = createHttpServer(async (req, res) => {
     logRequest({ ts: new Date().toISOString(), type: "api", endpoint: "/api/changes", params: { since, type, vendor: vendorFilter }, user_agent: req.headers["user-agent"] ?? "unknown", result_count: result.changes.length });
     res.writeHead(200, { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" });
     res.end(JSON.stringify(result));
+  } else if (url.pathname === "/api/audit-stack" && req.method === "GET") {
+    recordApiHit("/api/audit-stack");
+    const servicesParam = url.searchParams.get("services");
+    if (!servicesParam) {
+      res.writeHead(400, { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" });
+      res.end(JSON.stringify({ error: "Missing required 'services' parameter. Provide comma-separated vendor names." }));
+      return;
+    }
+    const servicesList = servicesParam.split(",").map((s) => s.trim()).filter(Boolean);
+    if (servicesList.length === 0) {
+      res.writeHead(400, { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" });
+      res.end(JSON.stringify({ error: "At least one service name is required." }));
+      return;
+    }
+    const auditResult = auditStack(servicesList);
+    logRequest({ ts: new Date().toISOString(), type: "api", endpoint: "/api/audit-stack", params: { services: servicesList }, user_agent: req.headers["user-agent"] ?? "unknown", result_count: auditResult.services_analyzed });
+    res.writeHead(200, { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" });
+    res.end(JSON.stringify(auditResult));
   } else if (url.pathname.startsWith("/api/vendor-risk/") && req.method === "GET") {
     recordApiHit("/api/vendor-risk");
     const vendorParam = decodeURIComponent(url.pathname.slice("/api/vendor-risk/".length));

--- a/src/server-remote.ts
+++ b/src/server-remote.ts
@@ -10,6 +10,7 @@ import {
   fetchCosts,
   fetchCompare,
   fetchVendorRisk,
+  fetchAuditStack,
 } from "./api-client.js";
 
 function mcpError(msg: string) {
@@ -255,6 +256,25 @@ export function createServer(): McpServer {
           }
         }
         return mcpError(`Error checking vendor risk: ${errMsg}`);
+      }
+    }
+  );
+
+  server.registerTool(
+    "audit_stack",
+    {
+      description:
+        "Audit your current infrastructure stack for cost savings, pricing risks, and missing capabilities. Pass the services you use today. Returns per-service risk assessment, cheaper alternatives, gap analysis for common categories (databases, hosting, CI/CD, auth, monitoring, logging, email, search, feature flags), and actionable recommendations.",
+      inputSchema: {
+        services: z.array(z.string()).describe("Vendor/service names you currently use (e.g. ['Vercel', 'Supabase', 'Clerk', 'Datadog'])"),
+      },
+    },
+    async ({ services }) => {
+      try {
+        const data = await fetchAuditStack(services);
+        return mcpText(data);
+      } catch (err) {
+        return mcpError(`Error auditing stack: ${err instanceof Error ? err.message : String(err)}`);
       }
     }
   );

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,6 +1,6 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
-import { getCategories, getDealChanges, getNewOffers, getOfferDetails, searchOffers, compareServices, checkVendorRisk } from "./data.js";
+import { getCategories, getDealChanges, getNewOffers, getOfferDetails, searchOffers, compareServices, checkVendorRisk, auditStack } from "./data.js";
 import { recordToolCall, logRequest } from "./stats.js";
 import { getStackRecommendation } from "./stacks.js";
 import { estimateCosts } from "./costs.js";
@@ -375,6 +375,43 @@ export function createServer(getSessionId?: () => string | undefined): McpServer
             {
               type: "text" as const,
               text: `Error checking vendor risk: ${err instanceof Error ? err.message : String(err)}`,
+            },
+          ],
+        };
+      }
+    }
+  );
+
+  server.registerTool(
+    "audit_stack",
+    {
+      description:
+        "Audit your current infrastructure stack for cost savings, pricing risks, and missing capabilities. Pass the services you use today. Returns per-service risk assessment, cheaper alternatives, gap analysis for common categories (databases, hosting, CI/CD, auth, monitoring, logging, email, search, feature flags), and actionable recommendations.",
+      inputSchema: {
+        services: z.array(z.string()).describe("Vendor/service names you currently use (e.g. ['Vercel', 'Supabase', 'Clerk', 'Datadog'])"),
+      },
+    },
+    async ({ services }) => {
+      try {
+        recordToolCall("audit_stack");
+        const result = auditStack(services);
+        logRequest({ ts: new Date().toISOString(), type: "mcp", endpoint: "audit_stack", params: { services }, result_count: result.services_analyzed, session_id: getSessionId?.() });
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: JSON.stringify(result, null, 2),
+            },
+          ],
+        };
+      } catch (err) {
+        console.error("audit_stack error:", err);
+        return {
+          isError: true,
+          content: [
+            {
+              type: "text" as const,
+              text: `Error auditing stack: ${err instanceof Error ? err.message : String(err)}`,
             },
           ],
         };

--- a/test/audit-stack.test.ts
+++ b/test/audit-stack.test.ts
@@ -1,0 +1,180 @@
+import { describe, it, afterEach } from "node:test";
+import assert from "node:assert";
+import { spawn, type ChildProcess } from "node:child_process";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+describe("auditStack logic", () => {
+  it("analyzes known vendors and returns structured result", async () => {
+    const { auditStack } = await import("../dist/data.js");
+    const result = auditStack(["Vercel", "Supabase"]);
+    assert.strictEqual(result.services_analyzed, 2);
+    assert.ok(Array.isArray(result.services));
+    assert.strictEqual(result.services.length, 2);
+    assert.ok(Array.isArray(result.gaps));
+    assert.ok(Array.isArray(result.recommendations));
+    assert.ok(typeof result.risks_found === "number");
+    assert.ok(typeof result.savings_opportunities === "number");
+
+    for (const svc of result.services) {
+      assert.strictEqual(svc.status, "found");
+      assert.ok(svc.category);
+      assert.ok(svc.risk_level);
+    }
+  });
+
+  it("handles unknown vendors gracefully", async () => {
+    const { auditStack } = await import("../dist/data.js");
+    const result = auditStack(["Vercel", "NonExistentVendor123"]);
+    assert.strictEqual(result.services_analyzed, 2);
+    const unknown = result.services.find(s => s.vendor === "NonExistentVendor123");
+    assert.ok(unknown);
+    assert.strictEqual(unknown.status, "not_found");
+  });
+
+  it("detects gaps in infrastructure coverage", async () => {
+    const { auditStack } = await import("../dist/data.js");
+    // Only providing a hosting vendor — should detect gaps in databases, auth, etc.
+    const result = auditStack(["Vercel"]);
+    assert.ok(result.gaps.length > 0, "Should detect missing categories");
+    for (const gap of result.gaps) {
+      assert.ok(gap.category);
+      assert.ok(gap.recommendation.vendor);
+      assert.ok(gap.recommendation.tier);
+    }
+  });
+
+  it("detects risk from deal changes", async () => {
+    const { auditStack } = await import("../dist/data.js");
+    // Vercel has pricing_restructured, Supabase has limits_reduced — both are caution
+    const result = auditStack(["Vercel", "Supabase"]);
+    assert.ok(result.risks_found >= 2, `Should find at least 2 risks, got ${result.risks_found}`);
+    const vercel = result.services.find(s => s.vendor === "Vercel");
+    assert.ok(vercel);
+    assert.strictEqual(vercel.risk_level, "caution");
+  });
+
+  it("includes recommendations for risky/caution vendors", async () => {
+    const { auditStack } = await import("../dist/data.js");
+    const result = auditStack(["Vercel", "Supabase"]);
+    assert.ok(result.recommendations.length > 0, "Should have recommendations");
+  });
+
+  it("finds cheaper alternatives", async () => {
+    const { auditStack } = await import("../dist/data.js");
+    const result = auditStack(["Vercel", "Supabase", "Clerk"]);
+    const withAlternatives = result.services.filter(s => s.cheaper_alternative);
+    assert.ok(withAlternatives.length > 0, "Should find at least one cheaper alternative");
+  });
+
+  it("handles empty services array edge case", async () => {
+    const { auditStack } = await import("../dist/data.js");
+    const result = auditStack([]);
+    assert.strictEqual(result.services_analyzed, 0);
+    assert.strictEqual(result.services.length, 0);
+    assert.ok(result.gaps.length > 0, "All categories should be gaps with no services");
+  });
+});
+
+describe("audit_stack MCP tool via stdio", () => {
+  let proc: ChildProcess | null = null;
+
+  afterEach(() => {
+    if (proc) { proc.kill(); proc = null; }
+  });
+
+  it("audit_stack is listed in tools/list", async () => {
+    const serverPath = path.join(__dirname, "..", "dist", "index.js");
+    proc = spawn("node", [serverPath], { stdio: ["pipe", "pipe", "pipe"] });
+
+    const initMsg = JSON.stringify({
+      jsonrpc: "2.0",
+      id: 1,
+      method: "initialize",
+      params: { protocolVersion: "2024-11-05", capabilities: {}, clientInfo: { name: "test", version: "1.0" } },
+    });
+
+    const initedMsg = JSON.stringify({
+      jsonrpc: "2.0",
+      method: "notifications/initialized",
+    });
+
+    const listTools = JSON.stringify({
+      jsonrpc: "2.0",
+      id: 2,
+      method: "tools/list",
+    });
+
+    const response = await new Promise<string>((resolve, reject) => {
+      let data = "";
+      const timeout = setTimeout(() => reject(new Error("Timeout")), 10000);
+      proc!.stdout!.on("data", (chunk: Buffer) => {
+        data += chunk.toString();
+        const lines = data.split("\n").filter(Boolean);
+        if (lines.length >= 2) {
+          clearTimeout(timeout);
+          resolve(lines[1]);
+        }
+      });
+      proc!.stdin!.write(initMsg + "\n");
+      proc!.stdin!.write(initedMsg + "\n");
+      proc!.stdin!.write(listTools + "\n");
+    });
+
+    const parsed = JSON.parse(response);
+    assert.strictEqual(parsed.id, 2);
+    const tools = parsed.result.tools;
+    const auditTool = tools.find((t: any) => t.name === "audit_stack");
+    assert.ok(auditTool, "audit_stack should be in tools list");
+    assert.ok(auditTool.description.includes("Audit"), "Description should mention Audit");
+    assert.ok(auditTool.inputSchema.properties.services, "Should have services input parameter");
+  });
+});
+
+describe("audit_stack REST endpoint", () => {
+  const PORT = 3464;
+  let proc: ChildProcess | null = null;
+
+  function startHttpServer(): Promise<ChildProcess> {
+    return new Promise((resolve, reject) => {
+      const serverPath = path.join(__dirname, "..", "dist", "serve.js");
+      const p = spawn("node", [serverPath], {
+        stdio: ["pipe", "pipe", "pipe"],
+        env: { ...process.env, PORT: String(PORT) },
+      });
+      const timeout = setTimeout(() => { p.kill(); reject(new Error("Server startup timeout")); }, 5000);
+      p.stderr!.on("data", (data: Buffer) => {
+        if (data.toString().includes("running on http")) { clearTimeout(timeout); resolve(p); }
+      });
+      p.on("error", (err) => { clearTimeout(timeout); reject(err); });
+    });
+  }
+
+  afterEach(() => {
+    if (proc) { proc.kill(); proc = null; }
+  });
+
+  it("GET /api/audit-stack returns audit results", async () => {
+    proc = await startHttpServer();
+    const response = await fetch(`http://localhost:${PORT}/api/audit-stack?services=Vercel,Supabase`);
+    assert.strictEqual(response.status, 200);
+    assert.strictEqual(response.headers.get("access-control-allow-origin"), "*");
+    const body = await response.json() as any;
+    assert.strictEqual(body.services_analyzed, 2);
+    assert.ok(Array.isArray(body.services));
+    assert.ok(Array.isArray(body.gaps));
+    assert.ok(Array.isArray(body.recommendations));
+    assert.ok(typeof body.risks_found === "number");
+    assert.ok(typeof body.savings_opportunities === "number");
+  });
+
+  it("GET /api/audit-stack returns 400 without services parameter", async () => {
+    proc = await startHttpServer();
+    const response = await fetch(`http://localhost:${PORT}/api/audit-stack`);
+    assert.strictEqual(response.status, 400);
+    const body = await response.json() as any;
+    assert.ok(body.error.includes("services"));
+  });
+});

--- a/test/http.test.ts
+++ b/test/http.test.ts
@@ -761,7 +761,8 @@ describe("HTTP transport", () => {
     assert.ok(body.paths["/api/stack"]);
     assert.ok(body.paths["/api/compare"]);
     assert.ok(body.paths["/api/vendor-risk/{vendor}"]);
-    assert.strictEqual(Object.keys(body.paths).length, 10);
+    assert.ok(body.paths["/api/audit-stack"]);
+    assert.strictEqual(Object.keys(body.paths).length, 11);
     assert.ok(body.components.schemas.Offer);
     assert.ok(body.components.schemas.DealChange);
     assert.ok(body.components.schemas.Eligibility);


### PR DESCRIPTION
## Summary

- New `audit_stack` MCP tool that takes a list of services and returns comprehensive infrastructure audit
- Per-service analysis: risk level, recent pricing changes, cheaper alternatives in same category
- Gap detection across 9 common infrastructure categories (databases, hosting, CI/CD, auth, monitoring, logging, email, search, feature flags)
- Actionable recommendations for risky vendors and missing categories
- REST endpoint: `GET /api/audit-stack?services=Vercel,Supabase,Clerk`
- Registered in both local server and stdio remote proxy
- OpenAPI spec updated

## Test plan

- [x] 7 unit tests (known vendors, unknown vendors, gap detection, risk detection, recommendations, alternatives, empty input)
- [x] 1 stdio test verifying tool appears in tools/list
- [x] 2 REST endpoint tests (200 with results, 400 missing services)
- [x] All 159 tests pass (10 new)

Refs #166

🤖 Generated with [Claude Code](https://claude.com/claude-code)