### PR TITLE
Add monitor-vendor-changes prompt template

### DIFF
--- a/src/server-remote.ts
+++ b/src/server-remote.ts
@@ -382,5 +382,45 @@ export function createServer(): McpServer {
     })
   );
 
+  server.registerPrompt(
+    "monitor-vendor-changes",
+    {
+      description: "Monitor pricing changes for vendors you depend on. Checks risk levels and recent changes for your watchlist, with a suggested weekly cadence.",
+      argsSchema: {
+        vendors: z.string().describe("Comma-separated list of vendor names to monitor (e.g. 'Vercel,Supabase,Clerk,Neon')"),
+      },
+    },
+    async ({ vendors }) => {
+      const vendorList = vendors.split(",").map((v) => v.trim()).filter(Boolean);
+      const vendorChecks = vendorList.map((v) => `- Use check_vendor_risk with vendor="${v}" to get its risk level, pricing change history, and more-stable alternatives`).join("\n");
+      const vendorFilter = vendorList.map((v) => `- Use get_deal_changes with vendor="${v}" to check for any recent pricing changes`).join("\n");
+      return {
+        messages: [
+          {
+            role: "user" as const,
+            content: {
+              type: "text" as const,
+              text: `Monitor pricing changes for my vendor watchlist: ${vendorList.join(", ")}.
+
+For each vendor, check its pricing stability and recent changes:
+
+${vendorChecks}
+
+${vendorFilter}
+
+After checking all vendors, provide a summary:
+1. **Risk overview**: List each vendor with its risk level (stable/caution/risky)
+2. **Recent changes**: Any pricing changes in the last 30 days
+3. **Action items**: Vendors that need attention — risky vendors, recent negative changes, or expiring deals
+4. **Alternatives**: For any risky vendor, suggest more-stable alternatives
+
+Suggested monitoring cadence: run this check weekly to catch pricing changes early.`,
+            },
+          },
+        ],
+      };
+    }
+  );
+
   return server;
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -540,5 +540,45 @@ export function createServer(getSessionId?: () => string | undefined): McpServer
     })
   );
 
+  server.registerPrompt(
+    "monitor-vendor-changes",
+    {
+      description: "Monitor pricing changes for vendors you depend on. Checks risk levels and recent changes for your watchlist, with a suggested weekly cadence.",
+      argsSchema: {
+        vendors: z.string().describe("Comma-separated list of vendor names to monitor (e.g. 'Vercel,Supabase,Clerk,Neon')"),
+      },
+    },
+    async ({ vendors }) => {
+      const vendorList = vendors.split(",").map((v) => v.trim()).filter(Boolean);
+      const vendorChecks = vendorList.map((v) => `- Use check_vendor_risk with vendor="${v}" to get its risk level, pricing change history, and more-stable alternatives`).join("\n");
+      const vendorFilter = vendorList.map((v) => `- Use get_deal_changes with vendor="${v}" to check for any recent pricing changes`).join("\n");
+      return {
+        messages: [
+          {
+            role: "user" as const,
+            content: {
+              type: "text" as const,
+              text: `Monitor pricing changes for my vendor watchlist: ${vendorList.join(", ")}.
+
+For each vendor, check its pricing stability and recent changes:
+
+${vendorChecks}
+
+${vendorFilter}
+
+After checking all vendors, provide a summary:
+1. **Risk overview**: List each vendor with its risk level (stable/caution/risky)
+2. **Recent changes**: Any pricing changes in the last 30 days
+3. **Action items**: Vendors that need attention — risky vendors, recent negative changes, or expiring deals
+4. **Alternatives**: For any risky vendor, suggest more-stable alternatives
+
+Suggested monitoring cadence: run this check weekly to catch pricing changes early.`,
+            },
+          },
+        ],
+      };
+    }
+  );
+
   return server;
 }

--- a/test/http.test.ts
+++ b/test/http.test.ts
@@ -769,7 +769,7 @@ describe("HTTP transport", () => {
     assert.ok(body.components.schemas.Eligibility);
   });
 
-  it("prompts/list returns all 4 prompt templates", async () => {
+  it("prompts/list returns all 5 prompt templates", async () => {
     proc = await startHttpServer();
 
     // Initialize session
@@ -803,12 +803,13 @@ describe("HTTP transport", () => {
     const result = data.find((d: any) => d.id === 2);
     assert.ok(result, "Should get prompts/list response");
     const prompts = result.result.prompts;
-    assert.strictEqual(prompts.length, 4);
+    assert.strictEqual(prompts.length, 5);
 
     const names = prompts.map((p: any) => p.name).sort();
     assert.deepStrictEqual(names, [
       "check-pricing-changes",
       "find-free-alternative",
+      "monitor-vendor-changes",
       "recommend-stack",
       "search-deals",
     ]);
@@ -825,6 +826,10 @@ describe("HTTP transport", () => {
     // check-pricing-changes should have no required arguments
     const checkChanges = prompts.find((p: any) => p.name === "check-pricing-changes");
     assert.ok(!checkChanges.arguments || checkChanges.arguments.length === 0);
+
+    // monitor-vendor-changes should have vendors argument
+    const monitorVendors = prompts.find((p: any) => p.name === "monitor-vendor-changes");
+    assert.ok(monitorVendors.arguments?.some((a: any) => a.name === "vendors"));
   });
 
   it("prompts/get returns structured message for find-free-alternative", async () => {


### PR DESCRIPTION
## Summary
- New `monitor-vendor-changes` MCP prompt template for proactive vendor pricing monitoring
- Accepts comma-separated vendor list, generates structured prompt orchestrating `check_vendor_risk` + `get_deal_changes` per vendor
- Output guides agent to provide risk overview, recent changes, action items, alternatives, and weekly monitoring cadence
- Registered in both server.ts (local HTTP) and server-remote.ts (stdio proxy)

Refs #171

## Test plan
- [x] Build succeeds
- [x] All 167 tests pass
- [x] Prompt appears in prompts/list (5 total, up from 4)
- [x] Template has `vendors` argument in schema

🤖 Generated with [Claude Code](https://claude.com/claude-code)