### PR TITLE
feat: add get_newest_deals tool and /api/newest endpoint

### DIFF
--- a/src/api-client.ts
+++ b/src/api-client.ts
@@ -111,6 +111,18 @@ export async function fetchAuditStack(services: string[]): Promise<unknown> {
   return apiFetch("/api/audit-stack", { services: services.join(",") });
 }
 
+export async function fetchNewestDeals(params: {
+  since?: string;
+  limit?: number;
+  category?: string;
+}): Promise<unknown> {
+  const p: Record<string, string> = {};
+  if (params.since) p.since = params.since;
+  if (params.limit !== undefined) p.limit = String(params.limit);
+  if (params.category) p.category = params.category;
+  return apiFetch("/api/newest", p);
+}
+
 export async function fetchExpiringDeals(withinDays?: number): Promise<unknown> {
   const p: Record<string, string> = {};
   if (withinDays !== undefined) p.within_days = String(withinDays);

--- a/src/data.ts
+++ b/src/data.ts
@@ -581,6 +581,37 @@ export function compareServices(
   };
 }
 
+export function getNewestDeals(params: {
+  since?: string;
+  limit?: number;
+  category?: string;
+}): { deals: Array<Offer & { days_since_update: number }>; total: number } {
+  const now = new Date();
+  const defaultSince = new Date(now.getTime() - 30 * 24 * 60 * 60 * 1000)
+    .toISOString()
+    .slice(0, 10);
+  const sinceDate = params.since || defaultSince;
+  const limit = Math.min(Math.max(params.limit ?? 20, 1), 50);
+
+  let results = loadOffers().filter((o) => o.verifiedDate >= sinceDate);
+
+  if (params.category) {
+    const lowerCat = params.category.toLowerCase();
+    results = results.filter((o) => o.category.toLowerCase() === lowerCat);
+  }
+
+  results.sort((a, b) => b.verifiedDate.localeCompare(a.verifiedDate));
+
+  const deals = results.slice(0, limit).map((o) => ({
+    ...o,
+    days_since_update: Math.floor(
+      (now.getTime() - new Date(o.verifiedDate).getTime()) / (24 * 60 * 60 * 1000)
+    ),
+  }));
+
+  return { deals, total: deals.length };
+}
+
 export function getExpiringDeals(withinDays: number = 30): { deals: Array<Offer & { days_until_expiry: number }>, total: number } {
   const offers = loadOffers();
   const now = new Date();

--- a/src/openapi.ts
+++ b/src/openapi.ts
@@ -115,6 +115,33 @@ export const openapiSpec = {
         }
       }
     },
+    "/api/newest": {
+      get: {
+        summary: "Newest deals",
+        description: "Returns deals sorted by verified date (newest first) with days_since_update. Use for periodic 'what's new' checks.",
+        parameters: [
+          { name: "since", in: "query", description: "ISO date (YYYY-MM-DD). Only return deals verified after this date. Default: 30 days ago", schema: { type: "string", format: "date" } },
+          { name: "limit", in: "query", description: "Max results (default: 20, max: 50)", schema: { type: "integer", default: 20 } },
+          { name: "category", in: "query", description: "Filter by category name", schema: { type: "string" } }
+        ],
+        responses: {
+          "200": {
+            description: "List of newest deals with days_since_update",
+            content: {
+              "application/json": {
+                schema: {
+                  type: "object",
+                  properties: {
+                    deals: { type: "array", items: { allOf: [{ $ref: "#/components/schemas/Offer" }, { type: "object", properties: { days_since_update: { type: "integer" } } }] } },
+                    total: { type: "integer" }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/changes": {
       get: {
         summary: "Deal and pricing changes",

--- a/src/serve.ts
+++ b/src/serve.ts
@@ -5,7 +5,7 @@ import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
 import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
 import { createServer } from "./server.js";
-import { loadOffers, getCategories, getNewOffers, searchOffers, loadDealChanges, getDealChanges, getOfferDetails, compareServices, checkVendorRisk, auditStack, getExpiringDeals } from "./data.js";
+import { loadOffers, getCategories, getNewOffers, getNewestDeals, searchOffers, loadDealChanges, getDealChanges, getOfferDetails, compareServices, checkVendorRisk, auditStack, getExpiringDeals } from "./data.js";
 import { getStackRecommendation } from "./stacks.js";
 import { estimateCosts } from "./costs.js";
 import { recordApiHit, recordSessionConnect, recordSessionDisconnect, recordLandingPageView, getStats, getConnectionStats, loadTelemetry, flushTelemetry, logRequest, getRequestLog } from "./stats.js";
@@ -763,6 +763,20 @@ const httpServer = createHttpServer(async (req, res) => {
     const days = parseInt(url.searchParams.get("days") ?? "7", 10);
     const result = getNewOffers(days);
     logRequest({ ts: new Date().toISOString(), type: "api", endpoint: "/api/new", params: { days }, user_agent: req.headers["user-agent"] ?? "unknown", result_count: result.offers.length });
+    res.writeHead(200, { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" });
+    res.end(JSON.stringify(result));
+  } else if (url.pathname === "/api/newest" && req.method === "GET") {
+    recordApiHit("/api/newest");
+    const since = url.searchParams.get("since") || undefined;
+    const limit = parseInt(url.searchParams.get("limit") ?? "20", 10) || 20;
+    const category = url.searchParams.get("category") || undefined;
+    if (since && !/^\d{4}-\d{2}-\d{2}/.test(since)) {
+      res.writeHead(400, { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" });
+      res.end(JSON.stringify({ error: "Invalid 'since' parameter. Expected ISO date string (YYYY-MM-DD)." }));
+      return;
+    }
+    const result = getNewestDeals({ since, limit, category });
+    logRequest({ ts: new Date().toISOString(), type: "api", endpoint: "/api/newest", params: { since, limit, category }, user_agent: req.headers["user-agent"] ?? "unknown", result_count: result.total });
     res.writeHead(200, { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" });
     res.end(JSON.stringify(result));
   } else if (url.pathname === "/api/categories" && req.method === "GET") {

--- a/src/server-remote.ts
+++ b/src/server-remote.ts
@@ -12,6 +12,7 @@ import {
   fetchVendorRisk,
   fetchAuditStack,
   fetchExpiringDeals,
+  fetchNewestDeals,
 } from "./api-client.js";
 
 function mcpError(msg: string) {
@@ -140,6 +141,27 @@ export function createServer(): McpServer {
         return mcpText(data);
       } catch (err) {
         return mcpError(`Error getting new offers: ${err instanceof Error ? err.message : String(err)}`);
+      }
+    }
+  );
+
+  server.registerTool(
+    "get_newest_deals",
+    {
+      description:
+        "See what's new in the AgentDeals index. Returns deals sorted by verified date (newest first), with days_since_update for each result. Use for periodic 'what's new' checks — pairs with monitor-vendor-changes prompt for a complete recurring usage loop.",
+      inputSchema: {
+        since: z.string().optional().describe("ISO date string (YYYY-MM-DD). Only return deals verified/added after this date. Default: 30 days ago"),
+        limit: z.number().optional().describe("Max results to return (default: 20, max: 50)"),
+        category: z.string().optional().describe("Filter by category name"),
+      },
+    },
+    async ({ since, limit, category }) => {
+      try {
+        const data = await fetchNewestDeals({ since, limit, category });
+        return mcpText(data);
+      } catch (err) {
+        return mcpError(`Error getting newest deals: ${err instanceof Error ? err.message : String(err)}`);
       }
     }
   );

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,6 +1,6 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
-import { getCategories, getDealChanges, getNewOffers, getOfferDetails, searchOffers, compareServices, checkVendorRisk, auditStack, getExpiringDeals } from "./data.js";
+import { getCategories, getDealChanges, getNewOffers, getNewestDeals, getOfferDetails, searchOffers, compareServices, checkVendorRisk, auditStack, getExpiringDeals } from "./data.js";
 import { recordToolCall, logRequest } from "./stats.js";
 import { getStackRecommendation } from "./stacks.js";
 import { estimateCosts } from "./costs.js";
@@ -171,6 +171,45 @@ export function createServer(getSessionId?: () => string | undefined): McpServer
             {
               type: "text" as const,
               text: `Error getting new offers: ${err instanceof Error ? err.message : String(err)}`,
+            },
+          ],
+        };
+      }
+    }
+  );
+
+  server.registerTool(
+    "get_newest_deals",
+    {
+      description:
+        "See what's new in the AgentDeals index. Returns deals sorted by verified date (newest first), with days_since_update for each result. Use for periodic 'what's new' checks — pairs with monitor-vendor-changes prompt for a complete recurring usage loop.",
+      inputSchema: {
+        since: z.string().optional().describe("ISO date string (YYYY-MM-DD). Only return deals verified/added after this date. Default: 30 days ago"),
+        limit: z.number().optional().describe("Max results to return (default: 20, max: 50)"),
+        category: z.string().optional().describe("Filter by category name"),
+      },
+    },
+    async ({ since, limit, category }) => {
+      try {
+        recordToolCall("get_newest_deals");
+        const result = getNewestDeals({ since, limit, category });
+        logRequest({ ts: new Date().toISOString(), type: "mcp", endpoint: "get_newest_deals", params: { since, limit, category }, result_count: result.total, session_id: getSessionId?.() });
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: JSON.stringify(result, null, 2),
+            },
+          ],
+        };
+      } catch (err) {
+        console.error("get_newest_deals error:", err);
+        return {
+          isError: true,
+          content: [
+            {
+              type: "text" as const,
+              text: `Error getting newest deals: ${err instanceof Error ? err.message : String(err)}`,
             },
           ],
         };

--- a/test/http.test.ts
+++ b/test/http.test.ts
@@ -763,7 +763,8 @@ describe("HTTP transport", () => {
     assert.ok(body.paths["/api/vendor-risk/{vendor}"]);
     assert.ok(body.paths["/api/audit-stack"]);
     assert.ok(body.paths["/api/expiring"]);
-    assert.strictEqual(Object.keys(body.paths).length, 12);
+    assert.ok(body.paths["/api/newest"]);
+    assert.strictEqual(Object.keys(body.paths).length, 13);
     assert.ok(body.components.schemas.Offer);
     assert.ok(body.components.schemas.DealChange);
     assert.ok(body.components.schemas.Eligibility);

--- a/test/newest-deals.test.ts
+++ b/test/newest-deals.test.ts
@@ -1,0 +1,162 @@
+import { describe, it, afterEach } from "node:test";
+import assert from "node:assert";
+import { spawn, type ChildProcess } from "node:child_process";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+describe("getNewestDeals logic", () => {
+  it("returns deals with default params (last 30 days, limit 20)", async () => {
+    const { getNewestDeals } = await import("../dist/data.js");
+    const result = getNewestDeals({});
+    assert.ok(Array.isArray(result.deals), "Should return deals array");
+    assert.ok(typeof result.total === "number", "Should return total count");
+    assert.ok(result.deals.length <= 20, "Default limit should be 20");
+    for (const deal of result.deals) {
+      assert.ok(typeof deal.days_since_update === "number", "Each deal should have days_since_update");
+      assert.ok(deal.days_since_update >= 0, "days_since_update should be non-negative");
+    }
+  });
+
+  it("filters by since date", async () => {
+    const { getNewestDeals } = await import("../dist/data.js");
+    const farPast = "2020-01-01";
+    const resultAll = getNewestDeals({ since: farPast, limit: 50 });
+    const recentOnly = getNewestDeals({ since: "2026-03-01", limit: 50 });
+    assert.ok(resultAll.total >= recentOnly.total, "Broader since should return more or equal results");
+  });
+
+  it("filters by category", async () => {
+    const { getNewestDeals } = await import("../dist/data.js");
+    const result = getNewestDeals({ since: "2020-01-01", limit: 50, category: "Databases" });
+    for (const deal of result.deals) {
+      assert.strictEqual(deal.category, "Databases", "All results should be in Databases category");
+    }
+  });
+
+  it("respects limit parameter", async () => {
+    const { getNewestDeals } = await import("../dist/data.js");
+    const result = getNewestDeals({ since: "2020-01-01", limit: 3 });
+    assert.ok(result.deals.length <= 3, "Should respect limit of 3");
+  });
+
+  it("results are sorted by verifiedDate descending", async () => {
+    const { getNewestDeals } = await import("../dist/data.js");
+    const result = getNewestDeals({ since: "2020-01-01", limit: 50 });
+    for (let i = 1; i < result.deals.length; i++) {
+      assert.ok(
+        result.deals[i].verifiedDate <= result.deals[i - 1].verifiedDate,
+        `Deal at index ${i} should have verifiedDate <= previous`
+      );
+    }
+  });
+
+  it("returns empty when no deals match", async () => {
+    const { getNewestDeals } = await import("../dist/data.js");
+    const result = getNewestDeals({ since: "2099-01-01" });
+    assert.strictEqual(result.total, 0);
+    assert.deepStrictEqual(result.deals, []);
+  });
+});
+
+describe("get_newest_deals MCP tool via stdio", () => {
+  let proc: ChildProcess | null = null;
+
+  afterEach(() => {
+    if (proc) { proc.kill(); proc = null; }
+  });
+
+  it("get_newest_deals is listed in tools/list", async () => {
+    const serverPath = path.join(__dirname, "..", "dist", "index.js");
+    proc = spawn("node", [serverPath], { stdio: ["pipe", "pipe", "pipe"] });
+
+    const initMsg = JSON.stringify({
+      jsonrpc: "2.0",
+      id: 1,
+      method: "initialize",
+      params: { protocolVersion: "2024-11-05", capabilities: {}, clientInfo: { name: "test", version: "1.0" } },
+    });
+
+    const initedMsg = JSON.stringify({
+      jsonrpc: "2.0",
+      method: "notifications/initialized",
+    });
+
+    const listTools = JSON.stringify({
+      jsonrpc: "2.0",
+      id: 2,
+      method: "tools/list",
+    });
+
+    const response = await new Promise<string>((resolve, reject) => {
+      let data = "";
+      const timeout = setTimeout(() => reject(new Error("Timeout")), 10000);
+      proc!.stdout!.on("data", (chunk: Buffer) => {
+        data += chunk.toString();
+        const lines = data.split("\n").filter(Boolean);
+        if (lines.length >= 2) {
+          clearTimeout(timeout);
+          resolve(lines[1]);
+        }
+      });
+      proc!.stdin!.write(initMsg + "\n");
+      proc!.stdin!.write(initedMsg + "\n");
+      proc!.stdin!.write(listTools + "\n");
+    });
+
+    const parsed = JSON.parse(response);
+    assert.strictEqual(parsed.id, 2);
+    const tools = parsed.result.tools;
+    assert.ok(Array.isArray(tools));
+    const newestTool = tools.find((t: any) => t.name === "get_newest_deals");
+    assert.ok(newestTool, "get_newest_deals should be in tools list");
+    assert.ok(newestTool.description.includes("newest") || newestTool.description.includes("new"), "Description should mention newest/new");
+  });
+});
+
+describe("get_newest_deals REST endpoint", () => {
+  const PORT = 3466;
+  let proc: ChildProcess | null = null;
+
+  function startHttpServer(): Promise<ChildProcess> {
+    return new Promise((resolve, reject) => {
+      const serverPath = path.join(__dirname, "..", "dist", "serve.js");
+      const p = spawn("node", [serverPath], {
+        stdio: ["pipe", "pipe", "pipe"],
+        env: { ...process.env, PORT: String(PORT) },
+      });
+      const timeout = setTimeout(() => { p.kill(); reject(new Error("Server startup timeout")); }, 5000);
+      p.stderr!.on("data", (data: Buffer) => {
+        if (data.toString().includes("running on http")) { clearTimeout(timeout); resolve(p); }
+      });
+      p.on("error", (err) => { clearTimeout(timeout); reject(err); });
+    });
+  }
+
+  afterEach(() => {
+    if (proc) { proc.kill(); proc = null; }
+  });
+
+  it("GET /api/newest returns newest deals", async () => {
+    proc = await startHttpServer();
+    const response = await fetch(`http://localhost:${PORT}/api/newest?since=2020-01-01&limit=5`);
+    assert.strictEqual(response.status, 200);
+    assert.strictEqual(response.headers.get("access-control-allow-origin"), "*");
+    const body = await response.json() as any;
+    assert.ok(Array.isArray(body.deals), "Should have deals array");
+    assert.ok(typeof body.total === "number", "Should have total count");
+    assert.ok(body.deals.length <= 5, "Should respect limit");
+    if (body.deals.length > 0) {
+      assert.ok(typeof body.deals[0].days_since_update === "number", "Deals should include days_since_update");
+    }
+  });
+
+  it("GET /api/newest with invalid since returns 400", async () => {
+    proc = await startHttpServer();
+    const response = await fetch(`http://localhost:${PORT}/api/newest?since=not-a-date`);
+    assert.strictEqual(response.status, 400);
+    const body = await response.json() as any;
+    assert.ok(body.error.includes("Invalid"), "Should return error about invalid date");
+  });
+});


### PR DESCRIPTION
Refs #176

Adds `get_newest_deals` MCP tool and `GET /api/newest` REST endpoint for surfacing recently added or updated deals.

**Parameters:**
- `since` (optional, ISO date) — only return deals verified after this date (default: 30 days ago)
- `limit` (optional, number) — max results (default: 20, max: 50)
- `category` (optional, string) — filter by category

**Returns:** deals sorted by `verified_date` descending, each with `days_since_update` computed field.

**Changes:**
- `src/data.ts`: new `getNewestDeals()` function
- `src/server.ts`: registered `get_newest_deals` MCP tool
- `src/serve.ts`: `GET /api/newest` REST endpoint with date validation
- `src/server-remote.ts`: stdio proxy tool registration
- `src/api-client.ts`: `fetchNewestDeals()` client function
- `src/openapi.ts`: OpenAPI spec entry for `/api/newest`
- `test/newest-deals.test.ts`: 8 new tests (logic, stdio, REST)
- `test/http.test.ts`: updated OpenAPI path count assertion (12→13)

176 tests pass (was 167).