### PR TITLE
Enrich search results with risk indicators and change flags

### DIFF
--- a/src/data.ts
+++ b/src/data.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import type { Offer, OfferIndex, DealChange, DealChangesIndex } from "./types.js";
+import type { Offer, EnrichedOffer, OfferIndex, DealChange, DealChangesIndex } from "./types.js";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const INDEX_PATH = path.join(__dirname, "..", "data", "index.json");
@@ -194,6 +194,64 @@ export function searchOffers(
   }
 
   return results;
+}
+
+export function enrichOffers(offers: Offer[]): EnrichedOffer[] {
+  const changes = loadDealChanges();
+  const now = new Date();
+  const ninetyDaysMs = 90 * 24 * 60 * 60 * 1000;
+  const cutoffDate = new Date(now.getTime() - ninetyDaysMs).toISOString().slice(0, 10);
+
+  // Build vendor → changes map (only recent changes within 90 days)
+  const vendorChanges = new Map<string, DealChange[]>();
+  for (const c of changes) {
+    if (c.date >= cutoffDate) {
+      const key = c.vendor.toLowerCase();
+      if (!vendorChanges.has(key)) vendorChanges.set(key, []);
+      vendorChanges.get(key)!.push(c);
+    }
+  }
+
+  // Build vendor → all-time change count for risk_level
+  const vendorAllChanges = new Map<string, number>();
+  for (const c of changes) {
+    const key = c.vendor.toLowerCase();
+    vendorAllChanges.set(key, (vendorAllChanges.get(key) ?? 0) + 1);
+  }
+
+  return offers.map((offer) => {
+    const key = offer.vendor.toLowerCase();
+
+    // recent_change: most recent change within 90 days
+    const recentChanges = vendorChanges.get(key);
+    let recent_change: string | null = null;
+    if (recentChanges && recentChanges.length > 0) {
+      const mostRecent = recentChanges.sort((a, b) => b.date.localeCompare(a.date))[0];
+      recent_change = `${mostRecent.date}: ${mostRecent.summary}`;
+    }
+
+    // expires_soon: flag if expires within 90 days
+    let expires_soon: string | null = null;
+    if (offer.expires_date) {
+      const expiresMs = new Date(offer.expires_date).getTime() - now.getTime();
+      if (expiresMs > 0 && expiresMs <= ninetyDaysMs) {
+        expires_soon = `Expires: ${offer.expires_date}`;
+      }
+    }
+
+    // risk_level: 0 changes = stable, 1 = caution, 2+ = risky
+    const changeCount = vendorAllChanges.get(key) ?? 0;
+    let risk_level: "stable" | "caution" | "risky" | null = null;
+    if (changeCount >= 2) {
+      risk_level = "risky";
+    } else if (changeCount === 1) {
+      risk_level = "caution";
+    } else {
+      risk_level = "stable";
+    }
+
+    return { ...offer, recent_change, expires_soon, risk_level };
+  });
 }
 
 export function getNewOffers(days: number = 7): { offers: Offer[]; total: number } {

--- a/src/serve.ts
+++ b/src/serve.ts
@@ -5,7 +5,7 @@ import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
 import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
 import { createServer } from "./server.js";
-import { loadOffers, getCategories, getNewOffers, getNewestDeals, searchOffers, loadDealChanges, getDealChanges, getOfferDetails, compareServices, checkVendorRisk, auditStack, getExpiringDeals } from "./data.js";
+import { loadOffers, getCategories, getNewOffers, getNewestDeals, searchOffers, enrichOffers, loadDealChanges, getDealChanges, getOfferDetails, compareServices, checkVendorRisk, auditStack, getExpiringDeals } from "./data.js";
 import { getStackRecommendation } from "./stacks.js";
 import { estimateCosts } from "./costs.js";
 import { recordApiHit, recordSessionConnect, recordSessionDisconnect, recordLandingPageView, getStats, getConnectionStats, loadTelemetry, flushTelemetry, logRequest, getRequestLog } from "./stats.js";
@@ -735,7 +735,7 @@ const httpServer = createHttpServer(async (req, res) => {
     const offset = parseInt(url.searchParams.get("offset") ?? "0", 10);
     const results = searchOffers(q, category, eligibilityType, sort);
     const total = results.length;
-    const paged = results.slice(offset, offset + limit);
+    const paged = enrichOffers(results.slice(offset, offset + limit));
     logRequest({ ts: new Date().toISOString(), type: "api", endpoint: "/api/offers", params: { q, category, limit, offset }, user_agent: req.headers["user-agent"] ?? "unknown", result_count: paged.length });
     res.writeHead(200, { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" });
     res.end(JSON.stringify({ offers: paged, total }));

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,6 +1,6 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
-import { getCategories, getDealChanges, getNewOffers, getNewestDeals, getOfferDetails, searchOffers, compareServices, checkVendorRisk, auditStack, getExpiringDeals } from "./data.js";
+import { getCategories, getDealChanges, getNewOffers, getNewestDeals, getOfferDetails, searchOffers, enrichOffers, compareServices, checkVendorRisk, auditStack, getExpiringDeals } from "./data.js";
 import { recordToolCall, logRequest } from "./stats.js";
 import { getStackRecommendation } from "./stacks.js";
 import { estimateCosts } from "./costs.js";
@@ -68,7 +68,8 @@ export function createServer(getSessionId?: () => string | undefined): McpServer
         const usePagination = limit !== undefined || offset !== undefined;
         const effectiveOffset = offset ?? 0;
         const effectiveLimit = limit ?? (usePagination ? 20 : total);
-        const results = allResults.slice(effectiveOffset, effectiveOffset + effectiveLimit);
+        const paged = allResults.slice(effectiveOffset, effectiveOffset + effectiveLimit);
+        const results = enrichOffers(paged);
         logRequest({ ts: new Date().toISOString(), type: "mcp", endpoint: "search_offers", params: { query, category, eligibility_type, sort, limit: effectiveLimit, offset: effectiveOffset }, result_count: results.length, session_id: getSessionId?.() });
         return {
           content: [

--- a/src/types.ts
+++ b/src/types.ts
@@ -16,6 +16,12 @@ export interface Offer {
   expires_date?: string;
 }
 
+export interface EnrichedOffer extends Offer {
+  recent_change: string | null;
+  expires_soon: string | null;
+  risk_level: "stable" | "caution" | "risky" | null;
+}
+
 export interface OfferIndex {
   offers: Offer[];
 }

--- a/test/enrich.test.ts
+++ b/test/enrich.test.ts
@@ -1,0 +1,140 @@
+import { describe, it } from "node:test";
+import assert from "node:assert";
+
+describe("enrichOffers", () => {
+  it("adds risk_level, recent_change, and expires_soon fields to offers", async () => {
+    const { searchOffers, enrichOffers } = await import("../dist/data.js");
+    const results = searchOffers("database");
+    assert.ok(results.length > 0, "Should find database offers");
+
+    const enriched = enrichOffers(results.slice(0, 5));
+    assert.strictEqual(enriched.length, Math.min(5, results.length));
+
+    for (const offer of enriched) {
+      assert.ok("recent_change" in offer, "Should have recent_change field");
+      assert.ok("expires_soon" in offer, "Should have expires_soon field");
+      assert.ok("risk_level" in offer, "Should have risk_level field");
+
+      // risk_level should be one of the valid values or null
+      assert.ok(
+        offer.risk_level === null || ["stable", "caution", "risky"].includes(offer.risk_level),
+        `risk_level should be stable/caution/risky/null, got: ${offer.risk_level}`
+      );
+
+      // recent_change should be string or null
+      assert.ok(
+        offer.recent_change === null || typeof offer.recent_change === "string",
+        "recent_change should be string or null"
+      );
+
+      // expires_soon should be string or null
+      assert.ok(
+        offer.expires_soon === null || typeof offer.expires_soon === "string",
+        "expires_soon should be string or null"
+      );
+    }
+  });
+
+  it("returns stable for vendor with no deal changes", async () => {
+    const { enrichOffers, loadOffers } = await import("../dist/data.js");
+    const offers = loadOffers();
+
+    // Find a vendor with no deal changes — most vendors have none
+    const { loadDealChanges } = await import("../dist/data.js");
+    const changes = loadDealChanges();
+    const changedVendors = new Set(changes.map((c: { vendor: string }) => c.vendor.toLowerCase()));
+
+    const stableOffer = offers.find((o: { vendor: string }) => !changedVendors.has(o.vendor.toLowerCase()));
+    assert.ok(stableOffer, "Should find at least one vendor with no changes");
+
+    const enriched = enrichOffers([stableOffer]);
+    assert.strictEqual(enriched[0].risk_level, "stable");
+    assert.strictEqual(enriched[0].recent_change, null);
+  });
+
+  it("returns caution for vendor with exactly 1 deal change", async () => {
+    const { enrichOffers, loadOffers, loadDealChanges } = await import("../dist/data.js");
+    const changes = loadDealChanges();
+    const offers = loadOffers();
+
+    // Count changes per vendor
+    const counts = new Map<string, number>();
+    for (const c of changes) {
+      const key = c.vendor.toLowerCase();
+      counts.set(key, (counts.get(key) ?? 0) + 1);
+    }
+
+    // Find vendor with exactly 1 change
+    const singleChangeVendor = [...counts.entries()].find(([, count]) => count === 1);
+    if (!singleChangeVendor) return; // Skip if no such vendor
+
+    const offer = offers.find((o: { vendor: string }) => o.vendor.toLowerCase() === singleChangeVendor[0]);
+    if (!offer) return;
+
+    const enriched = enrichOffers([offer]);
+    assert.strictEqual(enriched[0].risk_level, "caution");
+  });
+
+  it("returns risky for vendor with 2+ deal changes", async () => {
+    const { enrichOffers, loadOffers, loadDealChanges } = await import("../dist/data.js");
+    const changes = loadDealChanges();
+    const offers = loadOffers();
+
+    // Count changes per vendor
+    const counts = new Map<string, number>();
+    for (const c of changes) {
+      const key = c.vendor.toLowerCase();
+      counts.set(key, (counts.get(key) ?? 0) + 1);
+    }
+
+    // Find vendor with 2+ changes
+    const multiChangeVendor = [...counts.entries()].find(([, count]) => count >= 2);
+    if (!multiChangeVendor) return; // Skip if no such vendor
+
+    const offer = offers.find((o: { vendor: string }) => o.vendor.toLowerCase() === multiChangeVendor[0]);
+    if (!offer) return;
+
+    const enriched = enrichOffers([offer]);
+    assert.strictEqual(enriched[0].risk_level, "risky");
+  });
+
+  it("preserves original offer fields in enriched result", async () => {
+    const { searchOffers, enrichOffers } = await import("../dist/data.js");
+    const results = searchOffers("vercel");
+    assert.ok(results.length > 0);
+
+    const enriched = enrichOffers([results[0]]);
+    assert.strictEqual(enriched[0].vendor, results[0].vendor);
+    assert.strictEqual(enriched[0].category, results[0].category);
+    assert.strictEqual(enriched[0].description, results[0].description);
+    assert.strictEqual(enriched[0].tier, results[0].tier);
+    assert.strictEqual(enriched[0].url, results[0].url);
+    assert.deepStrictEqual(enriched[0].tags, results[0].tags);
+  });
+
+  it("handles empty offers array", async () => {
+    const { enrichOffers } = await import("../dist/data.js");
+    const enriched = enrichOffers([]);
+    assert.strictEqual(enriched.length, 0);
+  });
+
+  it("recent_change includes date and summary for vendor with changes", async () => {
+    const { enrichOffers, loadOffers, loadDealChanges } = await import("../dist/data.js");
+    const changes = loadDealChanges();
+    const offers = loadOffers();
+
+    if (changes.length === 0) return;
+
+    // Find a vendor that has a recent change (within 90 days)
+    const ninetyDaysAgo = new Date(Date.now() - 90 * 24 * 60 * 60 * 1000).toISOString().slice(0, 10);
+    const recentChange = changes.find((c: { date: string }) => c.date >= ninetyDaysAgo);
+    if (!recentChange) return;
+
+    const offer = offers.find((o: { vendor: string }) => o.vendor.toLowerCase() === recentChange.vendor.toLowerCase());
+    if (!offer) return;
+
+    const enriched = enrichOffers([offer]);
+    assert.ok(enriched[0].recent_change !== null, "Should have recent_change");
+    assert.ok(enriched[0].recent_change!.includes(recentChange.date), "Should include change date");
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `recent_change`, `expires_soon`, and `risk_level` fields to every offer in `search_offers` (MCP) and `/api/offers` (REST) results
- `recent_change` (string|null): most recent deal change summary within 90 days, e.g. "2026-02-01: Project pause policy tightened..."
- `expires_soon` (string|null): flags deals expiring within 90 days, e.g. "Expires: 2026-04-15"
- `risk_level` ("stable"|"caution"|"risky"|null): 0 changes = stable, 1 = caution, 2+ = risky
- All computed in-memory from existing deal_changes data — no performance impact

Example enriched result for Supabase:
```json
{
  "vendor": "Supabase",
  "recent_change": "2026-02-01: Project pause policy tightened — inactive projects now pause after 1 week",
  "expires_soon": null,
  "risk_level": "caution"
}
```

Refs #180

## Test plan

- [x] 7 new enrichment tests (183 total, all passing)
- [x] Tests cover: vendor with changes, vendor without changes, 1 change (caution), 2+ changes (risky), empty array, field preservation, recent_change format
- [x] E2E verified: local HTTP server returns enriched results for `/api/offers?q=supabase`
- [x] MCP stdio clients get enriched results via Railway API after deploy