### PR TITLE
Expand AI Coding category with 2026 pricing data

### DIFF
--- a/data/deal_changes.json
+++ b/data/deal_changes.json
@@ -827,6 +827,42 @@
         "Bluesky AT Protocol",
         "Mastodon API"
       ]
+    },
+    {
+      "vendor": "Cognition Devin",
+      "change_type": "pricing_restructured",
+      "date": "2026-01-15",
+      "summary": "Launched $20/month Core plan with pay-as-you-go ACU pricing, down from previous $500/month-only Team plan",
+      "previous_state": "Team plan only at $500/month (250 credits)",
+      "current_state": "Core plan $20/month (pay-as-you-go at $2.25/ACU), Team plan $500/month remains",
+      "impact": "high",
+      "source_url": "https://devin.ai/pricing",
+      "category": "AI Coding",
+      "alternatives": ["GitHub Copilot", "Cline", "Aider"]
+    },
+    {
+      "vendor": "Cursor",
+      "change_type": "pricing_restructured",
+      "date": "2025-06-01",
+      "summary": "Moved from flat monthly subscription to credit-based pricing model with new $200/month Ultra tier",
+      "previous_state": "Pro plan $20/month with 500 fast requests",
+      "current_state": "Pro plan $20/month (credit-based), Business $40/seat/month, Ultra $200/month (higher credit limits)",
+      "impact": "medium",
+      "source_url": "https://www.cursor.com/pricing",
+      "category": "AI Coding",
+      "alternatives": ["Windsurf", "GitHub Copilot"]
+    },
+    {
+      "vendor": "Augment Code",
+      "change_type": "pricing_restructured",
+      "date": "2025-10-01",
+      "summary": "Shifted from per-seat subscription to credit-based consumption model",
+      "previous_state": "Per-seat monthly subscription",
+      "current_state": "Credit-based consumption model with usage tiers",
+      "impact": "medium",
+      "source_url": "https://www.augmentcode.com/pricing",
+      "category": "AI Coding",
+      "alternatives": ["GitHub Copilot", "Cursor"]
     }
   ]
 }

--- a/data/index.json
+++ b/data/index.json
@@ -21146,7 +21146,7 @@
     {
       "vendor": "Devin",
       "category": "AI Coding",
-      "description": "Autonomous AI software engineer by Cognition Labs — handles code migrations, framework upgrades, prototypes, integrations, bug fixes. Core plan is pay-as-you-go at $2.25/ACU starting from $20. Team plan $500/mo (250 credits). Devin Review (PR review) is free during early release. Open-source maintainers with 100+ forks can apply for $500 in free credits.",
+      "description": "Autonomous AI software engineer by Cognition Labs. Core plan $20/month (pay-as-you-go ACUs at $2.25 each). Team plan $500/mo (250 credits). Devin Review (PR review) is free during early release. Open-source maintainers with 100+ forks can apply for $500 in free credits. Previously $500-only pricing before January 2026 restructuring.",
       "tier": "Free Credits",
       "url": "https://devin.ai/pricing",
       "tags": [
@@ -21156,7 +21156,7 @@
         "code generation",
         "developer tools"
       ],
-      "verifiedDate": "2026-03-10"
+      "verifiedDate": "2026-03-14"
     },
     {
       "vendor": "Bolt.new",
@@ -21202,6 +21202,82 @@
         "developer tools"
       ],
       "verifiedDate": "2026-03-10"
+    },
+    {
+      "vendor": "GitHub Copilot",
+      "category": "AI Coding",
+      "description": "AI coding assistant by GitHub/Microsoft. Free tier: 2,000 code completions/month, 50 chat messages/month (Copilot Chat), access to Claude 3.5 Sonnet and GPT-4o models. Works in VS Code, JetBrains, Neovim, Xcode. Pro plan $10/mo (unlimited completions, 300 premium requests). Pro+ $39/mo. Business $19/seat/mo.",
+      "tier": "Free",
+      "url": "https://github.com/features/copilot",
+      "tags": [
+        "ai",
+        "coding",
+        "code completion",
+        "ide",
+        "developer tools"
+      ],
+      "verifiedDate": "2026-03-14"
+    },
+    {
+      "vendor": "Amazon Q Developer",
+      "category": "AI Coding",
+      "description": "AI coding assistant by AWS. Free tier: inline code suggestions, chat, code transformation, 50 agent invocations/month, /doc and /test commands. Supports VS Code, JetBrains, CLI, and AWS Console. Pro plan $19/user/month (higher limits, admin controls, organizational customization).",
+      "tier": "Free",
+      "url": "https://aws.amazon.com/q/developer/pricing/",
+      "tags": [
+        "ai",
+        "coding",
+        "aws",
+        "code generation",
+        "developer tools"
+      ],
+      "verifiedDate": "2026-03-14"
+    },
+    {
+      "vendor": "Cline",
+      "category": "AI Coding",
+      "description": "Open-source autonomous AI coding agent for VS Code. Fully free — users provide their own API keys (OpenRouter, Anthropic, OpenAI, etc.). Supports file editing, terminal commands, browser interaction. No usage limits beyond API provider costs. MIT licensed.",
+      "tier": "Open Source",
+      "url": "https://github.com/cline/cline",
+      "tags": [
+        "ai",
+        "coding",
+        "autonomous",
+        "open source",
+        "developer tools"
+      ],
+      "verifiedDate": "2026-03-14"
+    },
+    {
+      "vendor": "Aider",
+      "category": "AI Coding",
+      "description": "Open-source AI pair programming CLI tool. Fully free — users provide their own LLM API keys (supports GPT-4o, Claude, Gemini, DeepSeek, Ollama local models). Git-aware editing, multi-file changes, voice coding, in-chat image support. Apache 2.0 licensed.",
+      "tier": "Open Source",
+      "url": "https://aider.chat",
+      "tags": [
+        "ai",
+        "coding",
+        "cli",
+        "pair programming",
+        "open source",
+        "developer tools"
+      ],
+      "verifiedDate": "2026-03-14"
+    },
+    {
+      "vendor": "Windsurf",
+      "category": "AI Coding",
+      "description": "AI-powered IDE by Codeium (formerly Codeium Editor). Free tier: basic Cascade AI flow access, limited premium action credits, code completions, AI chat. Pro plan $15/mo (unlimited flows, more credits). Team and Enterprise tiers available.",
+      "tier": "Free",
+      "url": "https://windsurf.com/pricing",
+      "tags": [
+        "ai",
+        "coding",
+        "ide",
+        "code completion",
+        "developer tools"
+      ],
+      "verifiedDate": "2026-03-14"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Added 5 new AI Coding entries: GitHub Copilot (Free), Amazon Q Developer (Free), Cline (Open Source), Aider (Open Source), Windsurf (Free)
- Updated existing Devin entry to reflect January 2026 $20/mo Core plan restructure
- Added 3 deal_changes: Cognition Devin (pricing_restructured), Cursor (credit-based pricing), Augment Code (credit-based model)
- AI Coding category: 4 → 9 entries. Total offers: 1,516. Deal changes: 52 → 55

## Test plan
- [x] All 183 tests pass
- [x] JSON valid, entries load correctly
- [x] Verified new entries appear in search

Refs #184