### PR TITLE
Add Claude Code plugin for one-click MCP installation

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,11 @@
+{
+  "name": "agentdeals",
+  "description": "Search and compare free tiers, credits, and pricing changes across 1,500+ developer tools. Find deals for databases, hosting, CI/CD, monitoring, and 50+ categories.",
+  "version": "0.2.0",
+  "author": {
+    "name": "Rob Hunter"
+  },
+  "homepage": "https://github.com/robhunter/agentdeals",
+  "repository": "https://github.com/robhunter/agentdeals",
+  "license": "MIT"
+}

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,7 @@
+{
+  "mcpServers": {
+    "agentdeals": {
+      "url": "https://agentdeals-production.up.railway.app/mcp"
+    }
+  }
+}

--- a/README.md
+++ b/README.md
@@ -11,7 +11,17 @@ AgentDeals indexes real, verified pricing data from 1,500+ developer infrastruct
 
 ## Install
 
-### Option A: Claude Desktop Extension (one-click)
+### Option A: Claude Code Plugin (one-click)
+
+Install AgentDeals in Claude Code with a single command:
+
+```bash
+claude plugin install robhunter/agentdeals
+```
+
+This auto-configures the remote MCP server — no local setup needed. All 12 tools, 5 prompt templates, and 2 skills are immediately available.
+
+### Option B: Claude Desktop Extension (one-click)
 
 Install AgentDeals directly in Claude Desktop — no configuration needed:
 
@@ -21,7 +31,7 @@ Install AgentDeals directly in Claude Desktop — no configuration needed:
 
 Or browse for AgentDeals in Claude Desktop under **Settings > Extensions**.
 
-### Option B: npx (local stdio)
+### Option C: npx (local stdio)
 
 No server needed. Runs locally via stdin/stdout:
 
@@ -36,7 +46,7 @@ No server needed. Runs locally via stdin/stdout:
 }
 ```
 
-### Option C: Remote HTTP
+### Option D: Remote HTTP
 
 Connect to the hosted instance — no install required:
 

--- a/skills/check-pricing-changes/SKILL.md
+++ b/skills/check-pricing-changes/SKILL.md
@@ -1,0 +1,21 @@
+---
+name: check-pricing-changes
+description: Check recent developer tool pricing changes, free tier removals, and new deals
+---
+
+When the user asks about pricing changes, vendor risk, or wants to stay updated on developer tool pricing, use the AgentDeals MCP server to check for recent changes.
+
+## Steps
+
+1. Use `get_deal_changes` to retrieve recent pricing changes. Filter by vendor or change_type if the user is specific.
+2. For risk assessment of a specific vendor, use `check_vendor_risk` to see pricing history, change frequency, and risk level.
+3. To audit an entire stack, use `audit_stack` with the list of vendors the user is using.
+4. Use `get_expiring_deals` to find deals or free tiers that are ending soon.
+5. Highlight high-impact changes: free tier removals, significant price increases, and service shutdowns.
+
+## Examples
+
+- "Has anything changed with Heroku pricing?" → `get_deal_changes` filtered to vendor "heroku"
+- "Is Vercel's free tier at risk?" → `check_vendor_risk` for "vercel"
+- "Audit my stack: Supabase, Vercel, Clerk" → `audit_stack` with those vendors
+- "Any deals expiring soon?" → `get_expiring_deals`

--- a/skills/search-deals/SKILL.md
+++ b/skills/search-deals/SKILL.md
@@ -1,0 +1,22 @@
+---
+name: search-deals
+description: Search for free tiers, startup credits, and developer tool deals
+---
+
+When the user asks about pricing, free tiers, cost optimization, or developer tool deals, use the AgentDeals MCP server to search for relevant offers.
+
+## Steps
+
+1. Identify the user's need: Are they looking for a specific vendor, a category of tools, or comparing options?
+2. Use `search_offers` to find matching deals. Filter by category or eligibility if the user specifies constraints (e.g., "startup credits" → eligibility_type: accelerator).
+3. For detailed pricing info on a specific vendor, use `get_offer_details` with `include_alternatives: true` to show comparable options.
+4. If the user wants a full infrastructure stack recommendation, use `get_stack_recommendation` with their use case.
+5. Present results clearly: highlight free tier limits, any recent pricing changes, and expiration dates.
+
+## Examples
+
+- "What free databases are available?" → `search_offers` with query "database" or category "Databases"
+- "Compare Supabase and Firebase" → `compare_services` with vendors ["supabase", "firebase"]
+- "What startup credits can I get?" → `search_offers` with eligibility_type "accelerator"
+- "Best free stack for a SaaS app?" → `get_stack_recommendation` with use_case "saas"
+- "Any recent pricing changes I should know about?" → `get_deal_changes`

--- a/test/deal-changes.test.ts
+++ b/test/deal-changes.test.ts
@@ -90,7 +90,7 @@ describe("get_deal_changes tool", () => {
 
       assert.ok(Array.isArray(body.changes));
       assert.strictEqual(body.total, body.changes.length);
-      assert.strictEqual(body.total, 52);
+      assert.strictEqual(body.total, 55);
     } finally {
       proc.kill();
     }


### PR DESCRIPTION
## Summary

- Added `.claude-plugin/plugin.json` manifest with project metadata
- Added `.mcp.json` configuring the remote streamable-http MCP server endpoint
- Created 2 skills: `search-deals` (find free tiers, compare tools) and `check-pricing-changes` (monitor vendor risk, audit stacks)
- Updated README with Claude Code plugin install instructions (new Option A)
- Fixed deal_changes test count (52 → 55) to match current data

Refs #187

## Test plan

- [x] All 167 tests pass
- [x] Plugin manifest validates as JSON with correct metadata
- [x] `.mcp.json` points to correct Railway production URL
- [x] Skills have proper frontmatter and actionable instructions
- [x] README install section shows plugin install as Option A