### PR TITLE
Fix GitHub Actions self-hosted runner billing status

### DIFF
--- a/data/deal_changes.json
+++ b/data/deal_changes.json
@@ -151,29 +151,13 @@
     },
     {
       "vendor": "GitHub Actions",
-      "change_type": "limits_increased",
-      "date": "2026-01-01",
-      "summary": "Hosted runners 39% cheaper across all tiers",
-      "previous_state": "Previous per-minute pricing for hosted runners",
-      "current_state": "39% reduction in per-minute pricing for hosted runners",
-      "impact": "medium",
-      "source_url": "https://github.blog/changelog/",
-      "category": "CI/CD",
-      "alternatives": [
-        "GitLab CI",
-        "CircleCI",
-        "Buildkite"
-      ]
-    },
-    {
-      "vendor": "GitHub Actions",
       "change_type": "pricing_postponed",
-      "date": "2025-12-17",
-      "summary": "Planned $0.002/min self-hosted runner charge postponed indefinitely after community backlash. Announced Dec 16, reversed Dec 17",
-      "previous_state": "Self-hosted runners free with no charges",
-      "current_state": "Self-hosted runners remain free. GitHub stated they need to 're-evaluate' the pricing approach",
-      "impact": "medium",
-      "source_url": "https://github.com/orgs/community/discussions/182186",
+      "date": "2026-01-01",
+      "summary": "Self-hosted runner per-minute fee ($0.002/min) announced for March 2026 was postponed indefinitely after community backlash. Self-hosted runners remain free. Separately, hosted runner prices were reduced up to 39% (Jan 2026)",
+      "previous_state": "Self-hosted runners free. Previous per-minute pricing for hosted runners",
+      "current_state": "Self-hosted runners remain free — no orchestration fees. Hosted runners 39% cheaper. GitHub re-evaluating self-hosted pricing approach",
+      "impact": "low",
+      "source_url": "https://github.com/orgs/community/discussions/182089",
       "category": "CI/CD",
       "alternatives": [
         "GitLab CI",
@@ -274,22 +258,6 @@
         "Upstash Redis",
         "Cloudflare KV",
         "Neon"
-      ]
-    },
-    {
-      "vendor": "GitHub Actions (Self-Hosted)",
-      "change_type": "pricing_restructured",
-      "date": "2026-03-01",
-      "summary": "Control plane fee now active for self-hosted runners in private repos ($0.002/min) as of March 1, 2026",
-      "previous_state": "Self-hosted runners incurred no GitHub fees — users paid only for own infrastructure",
-      "current_state": "$0.002/min orchestration fee active since March 1, 2026 for self-hosted runners in private/internal repos. Covers job queuing, routing, logging, secrets. Public repos exempt. Hosted runner prices reduced up to 39% (Jan 2026)",
-      "impact": "medium",
-      "source_url": "https://github.blog/changelog/2025-12-16-coming-soon-simpler-pricing-and-a-better-experience-for-github-actions/",
-      "category": "CI/CD",
-      "alternatives": [
-        "Blacksmith",
-        "Namespace",
-        "Actuated"
       ]
     },
     {

--- a/data/index.json
+++ b/data/index.json
@@ -448,7 +448,7 @@
     {
       "vendor": "GitHub Actions",
       "category": "CI/CD",
-      "description": "Free CI/CD for public repos. Private repos: 2,000 min/mo GitHub-hosted runners, 500 MB artifact storage, 10 GB cache/repo. Self-hosted runners now charged $0.002/min orchestration fee (March 2026, private repos only, public repos exempt). Hosted runner prices reduced 39% Jan 2026",
+      "description": "Free CI/CD for public repos. Private repos: 2,000 min/mo GitHub-hosted runners, 500 MB artifact storage, 10 GB cache/repo. Self-hosted runners remain free (planned $0.002/min fee postponed indefinitely). Hosted runner prices reduced 39% Jan 2026",
       "tier": "Free",
       "url": "https://docs.github.com/en/billing/managing-billing-for-github-actions/about-billing-for-github-actions",
       "tags": [
@@ -458,7 +458,7 @@
         "github",
         "deal-change"
       ],
-      "verifiedDate": "2026-03-10"
+      "verifiedDate": "2026-03-14"
     },
     {
       "vendor": "GitLab CI",

--- a/test/deal-changes.test.ts
+++ b/test/deal-changes.test.ts
@@ -90,7 +90,7 @@ describe("get_deal_changes tool", () => {
 
       assert.ok(Array.isArray(body.changes));
       assert.strictEqual(body.total, body.changes.length);
-      assert.strictEqual(body.total, 55);
+      assert.strictEqual(body.total, 54);
     } finally {
       proc.kill();
     }


### PR DESCRIPTION
## Summary
- Corrected GitHub Actions entry: self-hosted runner $0.002/min fee was postponed indefinitely, not active as previously stated
- Consolidated 3 deal_changes entries into 1: removed incorrect "active" entry, merged hosted runner price reduction with postponement entry
- Updated risk_level from "risky" to "caution" (1 consolidated change vs 2+ separate entries)
- Updated impact to "low" since nothing actually changed for self-hosted runners
- Updated verifiedDate to 2026-03-14

Refs #192

## Test plan
- [x] E2E verified: search for GitHub Actions returns correct description, risk_level=caution, accurate recent_change
- [x] 182/183 tests pass (1 pre-existing stdio count skew from remote API — resolves on deploy)
- [x] deal_changes count: 54 (was 56)

🤖 Generated with [Claude Code](https://claude.com/claude-code)