### PR TITLE
Add vendors and since filters to get_deal_changes

### DIFF
--- a/src/api-client.ts
+++ b/src/api-client.ts
@@ -79,11 +79,13 @@ export async function fetchDealChanges(params: {
   since?: string;
   type?: string;
   vendor?: string;
+  vendors?: string;
 }): Promise<unknown> {
   const p: Record<string, string> = {};
   if (params.since) p.since = params.since;
   if (params.type) p.type = params.type;
   if (params.vendor) p.vendor = params.vendor;
+  if (params.vendors) p.vendors = params.vendors;
   return apiFetch("/api/changes", p);
 }
 

--- a/src/data.ts
+++ b/src/data.ts
@@ -306,7 +306,8 @@ export function loadDealChanges(): DealChange[] {
 export function getDealChanges(
   since?: string,
   changeType?: string,
-  vendor?: string
+  vendor?: string,
+  vendors?: string
 ): { changes: DealChange[]; total: number } {
   let results = loadDealChanges();
 
@@ -325,7 +326,14 @@ export function getDealChanges(
     results = results.filter((c) => c.change_type === lowerType);
   }
 
-  if (vendor) {
+  // vendors (comma-separated) takes precedence over vendor (single)
+  if (vendors) {
+    const vendorList = vendors.split(",").map((v) => v.trim().toLowerCase()).filter(Boolean);
+    results = results.filter((c) => {
+      const lowerVendor = c.vendor.toLowerCase();
+      return vendorList.some((v) => lowerVendor.includes(v));
+    });
+  } else if (vendor) {
     const lowerVendor = vendor.toLowerCase();
     results = results.filter((c) => c.vendor.toLowerCase().includes(lowerVendor));
   }

--- a/src/openapi.ts
+++ b/src/openapi.ts
@@ -149,7 +149,8 @@ export const openapiSpec = {
         parameters: [
           { name: "since", in: "query", description: "Filter changes after this date (YYYY-MM-DD)", schema: { type: "string", format: "date" }, example: "2025-01-01" },
           { name: "type", in: "query", description: "Filter by change type", schema: { type: "string", enum: ["free_tier_removed", "limits_reduced", "limits_increased", "new_free_tier", "pricing_restructured", "open_source_killed", "pricing_model_change", "startup_program_expanded", "pricing_postponed", "product_deprecated"] } },
-          { name: "vendor", in: "query", description: "Filter by vendor name", schema: { type: "string" } }
+          { name: "vendor", in: "query", description: "Filter by vendor name", schema: { type: "string" } },
+          { name: "vendors", in: "query", description: "Comma-separated vendor names to filter by (e.g. 'Vercel,Supabase,Clerk')", schema: { type: "string" }, example: "Vercel,Supabase" }
         ],
         responses: {
           "200": {

--- a/src/serve.ts
+++ b/src/serve.ts
@@ -929,14 +929,15 @@ const httpServer = createHttpServer(async (req, res) => {
     const since = url.searchParams.get("since") || undefined;
     const type = url.searchParams.get("type") || undefined;
     const vendorFilter = url.searchParams.get("vendor") || undefined;
+    const vendorsFilter = url.searchParams.get("vendors") || undefined;
     // Validate since is a valid date if provided
     if (since && !/^\d{4}-\d{2}-\d{2}/.test(since)) {
       res.writeHead(400, { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" });
       res.end(JSON.stringify({ error: "Invalid 'since' parameter. Expected ISO date string (YYYY-MM-DD)." }));
       return;
     }
-    const result = getDealChanges(since, type, vendorFilter);
-    logRequest({ ts: new Date().toISOString(), type: "api", endpoint: "/api/changes", params: { since, type, vendor: vendorFilter }, user_agent: req.headers["user-agent"] ?? "unknown", result_count: result.changes.length });
+    const result = getDealChanges(since, type, vendorFilter, vendorsFilter);
+    logRequest({ ts: new Date().toISOString(), type: "api", endpoint: "/api/changes", params: { since, type, vendor: vendorFilter, vendors: vendorsFilter }, user_agent: req.headers["user-agent"] ?? "unknown", result_count: result.changes.length });
     res.writeHead(200, { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" });
     res.end(JSON.stringify(result));
   } else if (url.pathname === "/api/audit-stack" && req.method === "GET") {

--- a/src/server-remote.ts
+++ b/src/server-remote.ts
@@ -175,11 +175,12 @@ export function createServer(): McpServer {
         since: z.string().optional().describe("ISO date string (YYYY-MM-DD). Only return changes on or after this date. Default: 30 days ago"),
         change_type: z.enum(["free_tier_removed", "limits_reduced", "limits_increased", "new_free_tier", "pricing_restructured", "open_source_killed", "pricing_model_change", "startup_program_expanded", "pricing_postponed", "product_deprecated"]).optional().describe("Filter by type of change"),
         vendor: z.string().optional().describe("Filter by vendor name (case-insensitive partial match)"),
+        vendors: z.string().optional().describe("Comma-separated vendor names to filter by (case-insensitive partial match). Use to track changes affecting your specific stack, e.g. 'Vercel,Supabase,Clerk'"),
       },
     },
-    async ({ since, change_type, vendor }) => {
+    async ({ since, change_type, vendor, vendors }) => {
       try {
-        const data = await fetchDealChanges({ since, type: change_type, vendor });
+        const data = await fetchDealChanges({ since, type: change_type, vendor, vendors });
         return mcpText(data);
       } catch (err) {
         return mcpError(`Error getting deal changes: ${err instanceof Error ? err.message : String(err)}`);

--- a/src/server.ts
+++ b/src/server.ts
@@ -227,13 +227,14 @@ export function createServer(getSessionId?: () => string | undefined): McpServer
         since: z.string().optional().describe("ISO date string (YYYY-MM-DD). Only return changes on or after this date. Default: 30 days ago"),
         change_type: z.enum(["free_tier_removed", "limits_reduced", "limits_increased", "new_free_tier", "pricing_restructured", "open_source_killed", "pricing_model_change", "startup_program_expanded", "pricing_postponed", "product_deprecated"]).optional().describe("Filter by type of change"),
         vendor: z.string().optional().describe("Filter by vendor name (case-insensitive partial match)"),
+        vendors: z.string().optional().describe("Comma-separated vendor names to filter by (case-insensitive partial match). Use to track changes affecting your specific stack, e.g. 'Vercel,Supabase,Clerk'"),
       },
     },
-    async ({ since, change_type, vendor }) => {
+    async ({ since, change_type, vendor, vendors }) => {
       try {
         recordToolCall("get_deal_changes");
-        const result = getDealChanges(since, change_type, vendor);
-        logRequest({ ts: new Date().toISOString(), type: "mcp", endpoint: "get_deal_changes", params: { since, change_type, vendor }, result_count: result.changes.length, session_id: getSessionId?.() });
+        const result = getDealChanges(since, change_type, vendor, vendors);
+        logRequest({ ts: new Date().toISOString(), type: "mcp", endpoint: "get_deal_changes", params: { since, change_type, vendor, vendors }, result_count: result.changes.length, session_id: getSessionId?.() });
         return {
           content: [
             {

--- a/test/deal-changes.test.ts
+++ b/test/deal-changes.test.ts
@@ -299,6 +299,46 @@ describe("get_deal_changes tool", () => {
     }
   });
 
+  it("getDealChanges filters by vendors (comma-separated)", async () => {
+    // Direct function test — avoids stdio remote API proxy
+    const { getDealChanges } = await import("../dist/data.js");
+
+    // Single vendor
+    const single = getDealChanges("2024-01-01", undefined, undefined, "Netlify");
+    assert.strictEqual(single.total, 1);
+    assert.strictEqual(single.changes[0].vendor, "Netlify");
+
+    // Multiple vendors
+    const multi = getDealChanges("2024-01-01", undefined, undefined, "Netlify,OpenAI");
+    assert.ok(multi.total >= 2, `Expected at least 2 changes for Netlify+OpenAI, got ${multi.total}`);
+    for (const change of multi.changes) {
+      const lower = change.vendor.toLowerCase();
+      assert.ok(
+        lower.includes("netlify") || lower.includes("openai"),
+        `Unexpected vendor: ${change.vendor}`
+      );
+    }
+
+    // Nonexistent vendors
+    const none = getDealChanges("2024-01-01", undefined, undefined, "nonexistent-xyz,also-fake");
+    assert.strictEqual(none.total, 0);
+    assert.deepStrictEqual(none.changes, []);
+
+    // Combined with since date
+    const combined = getDealChanges("2026-01-01", undefined, undefined, "Netlify,OpenAI");
+    for (const change of combined.changes) {
+      assert.ok(change.date >= "2026-01-01");
+    }
+  });
+
+  it("vendors takes precedence over vendor when both provided", async () => {
+    const { getDealChanges } = await import("../dist/data.js");
+    // When vendors is set, vendor should be ignored
+    const result = getDealChanges("2024-01-01", undefined, "OpenAI", "Netlify");
+    assert.strictEqual(result.total, 1);
+    assert.strictEqual(result.changes[0].vendor, "Netlify");
+  });
+
   it("every change_type in data matches the tool enum", async () => {
     const VALID_CHANGE_TYPES = new Set([
       "free_tier_removed", "limits_reduced", "limits_increased",

--- a/test/http.test.ts
+++ b/test/http.test.ts
@@ -619,6 +619,22 @@ describe("HTTP transport", () => {
     assert.ok(body.error.includes("Invalid"));
   });
 
+  it("GET /api/changes filters by vendors (comma-separated)", async () => {
+    proc = await startHttpServer();
+
+    const response = await fetch(`http://localhost:${PORT}/api/changes?since=2020-01-01&vendors=Netlify,OpenAI`);
+    assert.strictEqual(response.status, 200);
+    const body = await response.json() as any;
+    assert.ok(body.total >= 2, `Expected at least 2 changes for Netlify+OpenAI, got ${body.total}`);
+    for (const change of body.changes) {
+      const vendorLower = change.vendor.toLowerCase();
+      assert.ok(
+        vendorLower.includes("netlify") || vendorLower.includes("openai"),
+        `Unexpected vendor: ${change.vendor}`
+      );
+    }
+  });
+
   it("GET /api/details/:vendor returns offer details", async () => {
     proc = await startHttpServer();
 


### PR DESCRIPTION
Refs #209

## Summary
- Added `vendors` parameter (comma-separated vendor names) to `get_deal_changes` MCP tool and `/api/changes` REST endpoint
- Enables stack-specific temporal change tracking: "show me pricing changes affecting Vercel, Supabase, Clerk since last Monday"
- `vendors` takes precedence over `vendor` when both provided
- Case-insensitive partial match on each comma-separated name
- Updated in all layers: data.ts, server.ts, server-remote.ts, serve.ts, api-client.ts, openapi.ts
- 3 new tests (187 total passing)