### PR TITLE
Dark theme for Swagger UI + complete OpenAPI spec

### DIFF
--- a/src/openapi.ts
+++ b/src/openapi.ts
@@ -500,6 +500,61 @@ export const openapiSpec = {
         }
       }
     },
+    "/api/costs": {
+      get: {
+        summary: "Estimate infrastructure costs",
+        description: "Estimate monthly costs for a stack of services at different scales. Shows free tier limits, when you'd exceed them, and projected costs.",
+        parameters: [
+          { name: "services", in: "query", required: true, description: "Comma-separated list of vendor names", schema: { type: "string" }, example: "Vercel,Supabase,Clerk" },
+          { name: "scale", in: "query", description: "Usage scale tier", schema: { type: "string", enum: ["hobby", "startup", "growth"], default: "hobby" } }
+        ],
+        responses: {
+          "200": {
+            description: "Cost estimates per service and total",
+            content: {
+              "application/json": {
+                schema: {
+                  type: "object",
+                  properties: {
+                    scale: { type: "string", description: "Scale tier used for estimation" },
+                    services: {
+                      type: "array",
+                      items: {
+                        type: "object",
+                        properties: {
+                          vendor: { type: "string" },
+                          free_tier: { type: "string" },
+                          estimated_monthly: { type: "string" },
+                          notes: { type: "string" }
+                        }
+                      }
+                    },
+                    total_estimated_monthly: { type: "string" }
+                  }
+                }
+              }
+            }
+          },
+          "400": { description: "Missing services parameter or invalid scale" }
+        }
+      }
+    },
+    "/api/feed": {
+      get: {
+        summary: "RSS feed of pricing changes",
+        description: "RSS 2.0 feed of developer tool pricing changes. Subscribe in any RSS reader to stay updated on free tier removals, limit changes, and new deals.",
+        responses: {
+          "200": {
+            description: "RSS 2.0 XML feed",
+            content: {
+              "application/rss+xml": {
+                schema: { type: "string", format: "binary" }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/stats": {
       get: {
         summary: "Service statistics",

--- a/src/serve.ts
+++ b/src/serve.ts
@@ -31,11 +31,64 @@ const swaggerDocsHtml = `<!DOCTYPE html>
   <style>
     html { box-sizing: border-box; }
     *, *:before, *:after { box-sizing: inherit; }
-    body { margin: 0; background: #fafafa; }
+    body { margin: 0; background: #14120b; color: #e8e0d0; }
     .topbar { display: none; }
+    /* Dark theme overrides matching landing page */
+    .swagger-ui { background: #14120b; }
+    .swagger-ui .opblock-tag { color: #e8e0d0; border-bottom-color: #2a2520; }
+    .swagger-ui .opblock-tag:hover { background: rgba(200,164,78,0.05); }
+    .swagger-ui .opblock-tag small { color: #a09880; }
+    .swagger-ui .opblock .opblock-summary { border-color: #2a2520; }
+    .swagger-ui .opblock.opblock-get { background: rgba(97,175,254,0.05); border-color: rgba(97,175,254,0.3); }
+    .swagger-ui .opblock.opblock-get .opblock-summary { border-color: rgba(97,175,254,0.3); }
+    .swagger-ui .opblock.opblock-post { background: rgba(73,204,144,0.05); border-color: rgba(73,204,144,0.3); }
+    .swagger-ui .opblock.opblock-post .opblock-summary { border-color: rgba(73,204,144,0.3); }
+    .swagger-ui .opblock .opblock-summary-description { color: #a09880; }
+    .swagger-ui .opblock-body { background: #1a1710; }
+    .swagger-ui .opblock-description-wrapper p,
+    .swagger-ui .opblock-external-docs-wrapper p { color: #c0b8a0; }
+    .swagger-ui table thead tr th { color: #c8a44e; border-bottom-color: #2a2520; }
+    .swagger-ui table tbody tr td { color: #e8e0d0; border-bottom-color: #2a2520; }
+    .swagger-ui .parameter__name { color: #e8e0d0; }
+    .swagger-ui .parameter__type { color: #a09880; }
+    .swagger-ui .parameter__in { color: #a09880; }
+    .swagger-ui .response-col_status { color: #c8a44e; }
+    .swagger-ui .response-col_description { color: #c0b8a0; }
+    .swagger-ui .responses-inner { background: #14120b; }
+    .swagger-ui .model-box { background: #1a1710; }
+    .swagger-ui .model { color: #e8e0d0; }
+    .swagger-ui .model-title { color: #c8a44e; }
+    .swagger-ui section.models { border-color: #2a2520; }
+    .swagger-ui section.models h4 { color: #e8e0d0; border-bottom-color: #2a2520; }
+    .swagger-ui .model-container { background: #1a1710; }
+    .swagger-ui .prop-type { color: #c8a44e; }
+    .swagger-ui .prop-format { color: #a09880; }
+    .swagger-ui .info .title { color: #e8e0d0; }
+    .swagger-ui .info .title small { background: #c8a44e; color: #14120b; }
+    .swagger-ui .info p, .swagger-ui .info li { color: #c0b8a0; }
+    .swagger-ui .info a { color: #c8a44e; }
+    .swagger-ui .scheme-container { background: #1a1710; border-bottom-color: #2a2520; box-shadow: none; }
+    .swagger-ui .scheme-container .schemes > label { color: #a09880; }
+    .swagger-ui select { background: #1a1710; color: #e8e0d0; border-color: #2a2520; }
+    .swagger-ui input[type=text], .swagger-ui textarea { background: #1a1710; color: #e8e0d0; border-color: #2a2520; }
+    .swagger-ui .btn { color: #e8e0d0; border-color: #2a2520; }
+    .swagger-ui .btn.execute { background: #c8a44e; color: #14120b; border-color: #c8a44e; }
+    .swagger-ui .btn.authorize { color: #c8a44e; border-color: #c8a44e; }
+    .swagger-ui .highlight-code { background: #1a1710; }
+    .swagger-ui .highlight-code .microlight { color: #e8e0d0; background: #1a1710; }
+    .swagger-ui .copy-to-clipboard { background: #1a1710; }
+    .swagger-ui .download-contents { color: #c8a44e; }
+    .swagger-ui .opblock-body pre.microlight { background: #1a1710 !important; color: #e8e0d0; border: 1px solid #2a2520; }
+    .swagger-ui .response-control-media-type__accept-message { color: #c8a44e; }
+    .swagger-ui .loading-container .loading::after { color: #c8a44e; }
+    /* Back link */
+    .back-link { display: block; padding: 12px 20px; background: #1a1710; border-bottom: 1px solid #2a2520; font-family: 'Inter', sans-serif; font-size: 14px; }
+    .back-link a { color: #c8a44e; text-decoration: none; }
+    .back-link a:hover { text-decoration: underline; }
   </style>
 </head>
 <body>
+  <div class="back-link"><a href="/">&larr; Back to AgentDeals</a></div>
   <div id="swagger-ui"></div>
   <script src="/api/docs/swagger-ui-bundle.js"></script>
   <script src="/api/docs/swagger-ui-standalone-preset.js"></script>
@@ -44,7 +97,10 @@ const swaggerDocsHtml = `<!DOCTYPE html>
       url: '/api/openapi.json',
       dom_id: '#swagger-ui',
       presets: [SwaggerUIBundle.presets.apis, SwaggerUIStandalonePreset],
-      layout: 'StandaloneLayout'
+      layout: 'StandaloneLayout',
+      deepLinking: true,
+      defaultModelsExpandDepth: 1,
+      syntaxHighlight: { theme: 'monokai' }
     });
   </script>
 </body>


### PR DESCRIPTION
## Summary
- Restyled `/api/docs` Swagger UI with dark theme matching landing page aesthetic (`#14120b` background, `#c8a44e` gold accents, `#e8e0d0` text)
- Added back-link to landing page, deep linking support, and monokai syntax highlighting
- Added 2 missing endpoints to OpenAPI spec: `/api/costs` and `/api/feed` (now 15 total)
- All 190 tests pass

## Acceptance Criteria
- [x] `/api/docs` serves Swagger UI consuming `/api/openapi.json` (already existed)
- [x] All 15 REST endpoints visible and explorable (added 2 missing)
- [x] "Try it out" functionality works for all endpoints
- [x] Dark theme matching existing landing page aesthetic (NEW)
- [x] Link to /api/docs on landing page (already existed)
- [x] Sitemap includes /api/docs (already existed)

Refs #216

🤖 Generated with [Claude Code](https://claude.com/claude-code)