### PR TITLE
Add vendor profile pages (/vendor/:slug)

### DIFF
--- a/src/serve.ts
+++ b/src/serve.ts
@@ -256,6 +256,15 @@ for (const cat of categories) {
   categorySlugMap.set(toSlug(cat.name), cat.name);
 }
 
+// Build vendor slug → name lookup (deduped by slug, first occurrence wins)
+const vendorSlugMap = new Map<string, string>();
+for (const o of offers) {
+  const slug = toSlug(o.vendor);
+  if (slug && !vendorSlugMap.has(slug)) {
+    vendorSlugMap.set(slug, o.vendor);
+  }
+}
+
 function escHtmlServer(s: string): string {
   return s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;");
 }
@@ -270,7 +279,7 @@ function buildCategoryPage(slug: string): string | null {
   const metaDesc = `Compare ${catCount} free ${categoryName.toLowerCase()} tools, free tiers, and developer deals. Verified pricing for ${catOffers.slice(0, 5).map(o => o.vendor).join(", ")}${catCount > 5 ? " and more" : ""}.`;
 
   const offersHtml = catOffers.map((o) => `        <tr>
-          <td style="font-weight:600;color:var(--text);white-space:nowrap"><a href="${escHtmlServer(o.url)}" style="color:var(--text)">${escHtmlServer(o.vendor)}</a></td>
+          <td style="font-weight:600;color:var(--text);white-space:nowrap"><a href="/vendor/${toSlug(o.vendor)}" style="color:var(--text)">${escHtmlServer(o.vendor)}</a></td>
           <td style="font-family:var(--mono);color:var(--accent);white-space:nowrap">${escHtmlServer(o.tier)}</td>
           <td style="color:var(--text-muted)">${escHtmlServer(o.description)}</td>
           <td style="font-family:var(--mono);color:var(--text-dim);white-space:nowrap">${escHtmlServer(o.verifiedDate)}</td>
@@ -989,6 +998,310 @@ function getCurrentWeekKey(): string {
 function getRecentWeekKeys(n: number): string[] {
   const byWeek = getChangesByWeek();
   return Array.from(byWeek.keys()).sort().reverse().slice(0, n);
+}
+
+// --- Vendor profile pages ---
+
+function buildVendorIndexPage(): string {
+  // Group vendors by category
+  const byCategory = new Map<string, Array<{ vendor: string; slug: string; tier: string }>>();
+  const seen = new Set<string>();
+  for (const o of offers) {
+    const slug = toSlug(o.vendor);
+    if (seen.has(slug)) continue;
+    seen.add(slug);
+    if (!byCategory.has(o.category)) byCategory.set(o.category, []);
+    byCategory.get(o.category)!.push({ vendor: o.vendor, slug, tier: o.tier });
+  }
+  // Sort categories and vendors within
+  const sortedCategories = Array.from(byCategory.entries()).sort((a, b) => a[0].localeCompare(b[0]));
+  for (const [, vendors] of sortedCategories) {
+    vendors.sort((a, b) => a.vendor.localeCompare(b.vendor));
+  }
+
+  const totalVendors = vendorSlugMap.size;
+  const title = `All Vendors (${totalVendors}) — AgentDeals`;
+  const metaDesc = `Browse ${totalVendors} developer tool vendors with free tiers. Pricing details, change history, and risk assessment for each vendor.`;
+
+  const categorySections = sortedCategories.map(([cat, vendors]) => `
+      <div class="vendor-category">
+        <h2><a href="/category/${toSlug(cat)}">${escHtmlServer(cat)}</a> <span class="cat-count">(${vendors.length})</span></h2>
+        <div class="vendor-grid">
+${vendors.map(v => `          <a href="/vendor/${v.slug}" class="vendor-card">
+            <span class="vendor-name">${escHtmlServer(v.vendor)}</span>
+            <span class="vendor-tier">${escHtmlServer(v.tier)}</span>
+          </a>`).join("\n")}
+        </div>
+      </div>`).join("\n");
+
+  const jsonLd = {
+    "@context": "https://schema.org",
+    "@type": "CollectionPage",
+    name: "All Vendors",
+    description: metaDesc,
+    numberOfItems: totalVendors,
+    url: "https://agentdeals-production.up.railway.app/vendor",
+  };
+
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>${escHtmlServer(title)}</title>
+<meta name="description" content="${escHtmlServer(metaDesc)}">
+<link rel="canonical" href="https://agentdeals-production.up.railway.app/vendor">
+<meta property="og:title" content="${escHtmlServer(title)}">
+<meta property="og:description" content="${escHtmlServer(metaDesc)}">
+<meta property="og:type" content="website">
+<meta property="og:url" content="https://agentdeals-production.up.railway.app/vendor">
+<link rel="icon" type="image/png" href="/favicon.png">
+<link rel="preconnect" href="https://fonts.googleapis.com"><link rel="preconnect" href="https://fonts.gstatic.com" crossorigin><link href="https://fonts.googleapis.com/css2?family=DM+Serif+Display:ital@0;1&family=Inter:wght@400;500;600&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
+<script type="application/ld+json">${JSON.stringify(jsonLd)}</script>
+<style>
+*{margin:0;padding:0;box-sizing:border-box}
+:root{--bg:#14120b;--bg-elevated:#1c1a12;--bg-card:rgba(28,26,18,0.6);--border:#2a2720;--border-hover:#c8a44e;--text:#e8e0cc;--text-muted:#9e9685;--text-dim:#6b6356;--accent:#c8a44e;--accent-hover:#dbb85e;--accent-glow:rgba(200,164,78,0.15);--serif:'DM Serif Display',Georgia,serif;--sans:'Inter',-apple-system,sans-serif;--mono:'JetBrains Mono',SFMono-Regular,monospace}
+body{font-family:var(--sans);background:var(--bg);color:var(--text);line-height:1.6}
+a{color:var(--accent);text-decoration:none}a:hover{color:var(--accent-hover);text-decoration:underline}
+.container{max-width:960px;margin:0 auto;padding:0 1.5rem}
+.breadcrumb{padding:1.5rem 0 0;font-size:.8rem;color:var(--text-dim)}
+.breadcrumb a{color:var(--text-muted)}
+h1{font-family:var(--serif);font-size:2.25rem;color:var(--text);margin:1rem 0 .5rem;letter-spacing:-.02em}
+.page-meta{color:var(--text-muted);margin-bottom:2rem;font-size:.95rem}
+.vendor-category{margin-bottom:2.5rem}
+.vendor-category h2{font-family:var(--serif);font-size:1.15rem;color:var(--text);margin-bottom:.75rem;padding-bottom:.5rem;border-bottom:1px solid var(--border)}
+.vendor-category h2 a{color:var(--text)}
+.cat-count{color:var(--text-dim);font-weight:400;font-size:.85rem}
+.vendor-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(220px,1fr));gap:.5rem}
+.vendor-card{display:block;padding:.5rem .75rem;border:1px solid var(--border);border-radius:8px;background:var(--bg-card);backdrop-filter:blur(10px);transition:all .2s;text-decoration:none}
+.vendor-card:hover{border-color:var(--accent);background:var(--accent-glow);text-decoration:none}
+.vendor-name{display:block;color:var(--text);font-weight:600;font-size:.85rem}
+.vendor-tier{display:block;color:var(--text-dim);font-family:var(--mono);font-size:.7rem;margin-top:.1rem}
+footer{text-align:center;color:var(--text-dim);font-size:.8rem;padding:3rem 0 2rem;border-top:1px solid var(--border);margin-top:3rem}
+@media(max-width:768px){h1{font-size:1.5rem}.vendor-grid{grid-template-columns:repeat(auto-fill,minmax(160px,1fr))}}
+</style>
+</head>
+<body>
+<div class="container">
+  <div class="breadcrumb"><a href="/">AgentDeals</a> &rsaquo; Vendors</div>
+  <h1>All Vendors</h1>
+  <p class="page-meta">${totalVendors} developer tools with free tiers, organized by category.</p>
+${categorySections}
+  <footer>AgentDeals &mdash; open source, built for agents</footer>
+</div>
+</body>
+</html>`;
+}
+
+function buildVendorPage(slug: string): string | null {
+  const vendorName = vendorSlugMap.get(slug);
+  if (!vendorName) return null;
+
+  // Get all offers for this vendor (some vendors appear in multiple categories)
+  const vendorOffers = offers.filter(o => o.vendor === vendorName);
+  if (vendorOffers.length === 0) return null;
+
+  const primary = vendorOffers[0];
+  const enriched = enrichOffers([primary])[0];
+  const allCategories = [...new Set(vendorOffers.map(o => o.category))];
+
+  // Get deal changes for this vendor
+  const allChanges = loadDealChanges();
+  const vendorChanges = allChanges
+    .filter(c => c.vendor.toLowerCase() === vendorName.toLowerCase())
+    .sort((a, b) => b.date.localeCompare(a.date));
+
+  // Risk assessment
+  const riskColors: Record<string, string> = { stable: "#3fb950", caution: "#d29922", risky: "#f85149" };
+  const riskLevel = enriched.risk_level ?? "stable";
+  const riskColor = riskColors[riskLevel] ?? "#8b949e";
+
+  // Alternatives: other vendors in the same primary category
+  const alternatives = offers
+    .filter(o => o.category === primary.category && o.vendor !== vendorName)
+    .slice(0, 12);
+
+  // Comparison pages featuring this vendor
+  const vendorComparisons = Array.from(comparisonMap.entries())
+    .filter(([, [a, b]]) => a === vendorName || b === vendorName);
+
+  // Title and meta
+  const title = `${vendorName} Free Tier & Pricing — AgentDeals`;
+  const metaDesc = `${vendorName} free tier details: ${primary.tier}. ${primary.description.slice(0, 120)}${primary.description.length > 120 ? "..." : ""} Verified ${primary.verifiedDate}.`;
+
+  // Changes HTML
+  const changesHtml = vendorChanges.length > 0 ? vendorChanges.map(c => {
+    const badge = changeTypeBadge[c.change_type] ?? { label: c.change_type, color: "#8b949e" };
+    return `<div class="change-item">
+        <div class="change-head">
+          <span class="badge" style="background:${badge.color}">${badge.label}</span>
+          <span class="change-date">${c.date}</span>
+          <span class="impact impact-${c.impact}">${c.impact} impact</span>
+        </div>
+        <div class="change-summary">${escHtmlServer(c.summary)}</div>
+        ${c.previous_state && c.current_state ? `<div class="change-detail"><span class="state-label">Before:</span> ${escHtmlServer(c.previous_state)}</div><div class="change-detail"><span class="state-label">After:</span> ${escHtmlServer(c.current_state)}</div>` : ""}
+      </div>`;
+  }).join("\n") : `<p class="no-changes">No recorded pricing changes for ${escHtmlServer(vendorName)}. This is a good sign — stable pricing.</p>`;
+
+  // Alternatives HTML
+  const alternativesHtml = alternatives.length > 0 ? `
+  <div class="section">
+    <h2>Alternatives in ${escHtmlServer(primary.category)}</h2>
+    <div class="alt-grid">
+${alternatives.map(a => `      <a href="/vendor/${toSlug(a.vendor)}" class="alt-card">
+        <span class="alt-name">${escHtmlServer(a.vendor)}</span>
+        <span class="alt-tier">${escHtmlServer(a.tier)}</span>
+      </a>`).join("\n")}
+    </div>
+  </div>` : "";
+
+  // Comparisons HTML
+  const comparisonsHtml = vendorComparisons.length > 0 ? `
+  <div class="section">
+    <h2>Comparisons</h2>
+    <div class="compare-links">
+${vendorComparisons.map(([s, [a, b]]) => `      <a href="/compare/${s}" class="compare-pill">${escHtmlServer(a)} vs ${escHtmlServer(b)}</a>`).join("\n")}
+    </div>
+  </div>` : "";
+
+  // MCP snippet
+  const mcpSnippet = `{
+  "tool": "search_offers",
+  "arguments": {
+    "query": "${vendorName.replace(/"/g, '\\"')}",
+    "limit": 5
+  }
+}`;
+
+  // JSON-LD structured data
+  const jsonLd = {
+    "@context": "https://schema.org",
+    "@type": "WebPage",
+    name: title,
+    description: metaDesc,
+    url: `https://agentdeals-production.up.railway.app/vendor/${slug}`,
+    mainEntity: {
+      "@type": "SoftwareApplication",
+      name: vendorName,
+      description: primary.description,
+      applicationCategory: primary.category,
+      url: primary.url,
+      offers: {
+        "@type": "Offer",
+        price: "0",
+        priceCurrency: "USD",
+        description: primary.tier,
+      },
+    },
+  };
+
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>${escHtmlServer(title)}</title>
+<meta name="description" content="${escHtmlServer(metaDesc)}">
+<link rel="canonical" href="https://agentdeals-production.up.railway.app/vendor/${slug}">
+<meta property="og:title" content="${escHtmlServer(title)}">
+<meta property="og:description" content="${escHtmlServer(metaDesc)}">
+<meta property="og:type" content="website">
+<meta property="og:url" content="https://agentdeals-production.up.railway.app/vendor/${slug}">
+<link rel="icon" type="image/png" href="/favicon.png">
+<link rel="preconnect" href="https://fonts.googleapis.com"><link rel="preconnect" href="https://fonts.gstatic.com" crossorigin><link href="https://fonts.googleapis.com/css2?family=DM+Serif+Display:ital@0;1&family=Inter:wght@400;500;600&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
+<script type="application/ld+json">${JSON.stringify(jsonLd)}</script>
+<style>
+*{margin:0;padding:0;box-sizing:border-box}
+:root{--bg:#14120b;--bg-elevated:#1c1a12;--bg-card:rgba(28,26,18,0.6);--border:#2a2720;--border-hover:#c8a44e;--text:#e8e0cc;--text-muted:#9e9685;--text-dim:#6b6356;--accent:#c8a44e;--accent-hover:#dbb85e;--accent-glow:rgba(200,164,78,0.15);--serif:'DM Serif Display',Georgia,serif;--sans:'Inter',-apple-system,sans-serif;--mono:'JetBrains Mono',SFMono-Regular,monospace}
+body{font-family:var(--sans);background:var(--bg);color:var(--text);line-height:1.6}
+a{color:var(--accent);text-decoration:none}a:hover{color:var(--accent-hover);text-decoration:underline}
+.container{max-width:960px;margin:0 auto;padding:0 1.5rem}
+.breadcrumb{padding:1.5rem 0 0;font-size:.8rem;color:var(--text-dim)}
+.breadcrumb a{color:var(--text-muted)}
+h1{font-family:var(--serif);font-size:2.25rem;color:var(--text);margin:1rem 0 .5rem;letter-spacing:-.02em}
+h1 .risk-badge{font-size:.75rem;font-weight:600;padding:.2rem .6rem;border-radius:12px;vertical-align:middle;margin-left:.5rem}
+.page-meta{color:var(--text-muted);margin-bottom:2rem;font-size:.95rem}
+.detail-grid{display:grid;grid-template-columns:1fr 1fr;gap:1rem;margin-bottom:2rem}
+.detail-card{border:1px solid var(--border);border-radius:12px;padding:1rem 1.25rem;background:var(--bg-card);backdrop-filter:blur(10px)}
+.detail-label{font-family:var(--mono);font-size:.7rem;color:var(--text-dim);text-transform:uppercase;letter-spacing:.1em;margin-bottom:.25rem}
+.detail-value{font-size:.95rem;color:var(--text)}
+.desc-block{margin-bottom:2rem;padding:1rem 1.25rem;background:var(--bg-elevated);border-radius:12px;border-left:3px solid var(--accent)}
+.desc-block h2{font-family:var(--serif);font-size:1.15rem;margin-bottom:.5rem}
+.desc-text{font-size:.9rem;color:var(--text-muted);line-height:1.7}
+.section{margin-bottom:2rem;padding-top:1.5rem;border-top:1px solid var(--border)}
+.section h2{font-family:var(--serif);font-size:1.15rem;color:var(--text);margin-bottom:1rem}
+.change-item{margin-bottom:.75rem;padding:.75rem 1rem;border-left:3px solid var(--border);background:var(--bg-card);border-radius:0 8px 8px 0}
+.change-head{display:flex;align-items:center;gap:.5rem;margin-bottom:.3rem;flex-wrap:wrap}
+.badge{display:inline-block;padding:.1rem .4rem;border-radius:10px;font-size:.65rem;font-weight:600;color:#fff}
+.change-date{font-family:var(--mono);font-size:.75rem;color:var(--text-dim)}
+.impact{font-size:.7rem}.impact-high{color:#f85149}.impact-medium{color:#d29922}.impact-low{color:#8b949e}
+.change-summary{font-size:.85rem;color:var(--text-muted)}
+.change-detail{font-size:.8rem;color:var(--text-dim);margin-top:.25rem}
+.state-label{font-family:var(--mono);font-size:.7rem;color:var(--text-dim)}
+.no-changes{color:var(--text-dim);font-size:.9rem;font-style:italic}
+.alt-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(180px,1fr));gap:.5rem}
+.alt-card{display:block;padding:.5rem .75rem;border:1px solid var(--border);border-radius:8px;background:var(--bg-card);transition:all .2s;text-decoration:none}
+.alt-card:hover{border-color:var(--accent);background:var(--accent-glow);text-decoration:none}
+.alt-name{display:block;color:var(--text);font-weight:600;font-size:.85rem}
+.alt-tier{display:block;color:var(--text-dim);font-family:var(--mono);font-size:.7rem;margin-top:.1rem}
+.compare-links{display:flex;flex-wrap:wrap;gap:.5rem}
+.compare-pill{display:inline-block;padding:.35rem .75rem;border:1px solid var(--border);border-radius:20px;font-size:.8rem;color:var(--text-muted);transition:all .2s}
+.compare-pill:hover{border-color:var(--accent);color:var(--text);text-decoration:none}
+.mcp-section code{display:block;padding:1rem;background:var(--bg-elevated);border-radius:8px;font-family:var(--mono);font-size:.8rem;color:var(--text-muted);white-space:pre;overflow-x:auto;border:1px solid var(--border)}
+.cat-pills{display:flex;flex-wrap:wrap;gap:.3rem;margin-top:.25rem}
+.cat-pill{display:inline-block;padding:.15rem .5rem;border-radius:12px;font-size:.7rem;font-weight:500;background:var(--accent-glow);color:var(--accent);border:1px solid rgba(200,164,78,0.2)}
+footer{text-align:center;color:var(--text-dim);font-size:.8rem;padding:3rem 0 2rem;border-top:1px solid var(--border);margin-top:3rem}
+@media(max-width:768px){h1{font-size:1.5rem}.detail-grid{grid-template-columns:1fr}.alt-grid{grid-template-columns:repeat(auto-fill,minmax(140px,1fr))}}
+</style>
+</head>
+<body>
+<div class="container">
+  <div class="breadcrumb"><a href="/">AgentDeals</a> &rsaquo; <a href="/vendor">Vendors</a> &rsaquo; ${escHtmlServer(vendorName)}</div>
+  <h1>${escHtmlServer(vendorName)} <span class="risk-badge" style="background:${riskColor}20;color:${riskColor};border:1px solid ${riskColor}40">${riskLevel}</span></h1>
+  <p class="page-meta">Free tier details, pricing history, and alternatives. Last updated ${primary.verifiedDate}.</p>
+
+  <div class="detail-grid">
+    <div class="detail-card">
+      <div class="detail-label">Tier</div>
+      <div class="detail-value" style="color:var(--accent)">${escHtmlServer(primary.tier)}</div>
+    </div>
+    <div class="detail-card">
+      <div class="detail-label">Categor${allCategories.length > 1 ? "ies" : "y"}</div>
+      <div class="detail-value">
+        <div class="cat-pills">${allCategories.map(c => `<a href="/category/${toSlug(c)}" class="cat-pill">${escHtmlServer(c)}</a>`).join("")}</div>
+      </div>
+    </div>
+    <div class="detail-card">
+      <div class="detail-label">Pricing Page</div>
+      <div class="detail-value"><a href="${escHtmlServer(primary.url)}" rel="noopener" target="_blank">Visit &rarr;</a></div>
+    </div>
+    <div class="detail-card">
+      <div class="detail-label">Verified</div>
+      <div class="detail-value" style="font-family:var(--mono)">${escHtmlServer(primary.verifiedDate)}</div>
+    </div>
+  </div>
+
+  <div class="desc-block">
+    <h2>Free Tier Details</h2>
+    <p class="desc-text">${escHtmlServer(primary.description)}</p>
+  </div>
+
+  <div class="section">
+    <h2>Pricing Change History (${vendorChanges.length} recorded)</h2>
+    ${changesHtml}
+  </div>
+${alternativesHtml}
+${comparisonsHtml}
+  <div class="section mcp-section">
+    <h2>Query via MCP</h2>
+    <p style="color:var(--text-muted);font-size:.85rem;margin-bottom:.75rem">Look up ${escHtmlServer(vendorName)} programmatically with the AgentDeals MCP server:</p>
+    <code>${escHtmlServer(mcpSnippet)}</code>
+  </div>
+
+  <footer>AgentDeals &mdash; open source, built for agents</footer>
+</div>
+</body>
+</html>`;
 }
 
 function buildLandingPage(): string {
@@ -2103,6 +2416,18 @@ ${Array.from(comparisonMap.keys()).map(s => `  <url>
     <priority>0.7</priority>
   </url>`).join("\n")}
   <url>
+    <loc>https://agentdeals-production.up.railway.app/vendor</loc>
+    <lastmod>${now}</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+${Array.from(vendorSlugMap.keys()).map(s => `  <url>
+    <loc>https://agentdeals-production.up.railway.app/vendor/${s}</loc>
+    <lastmod>${now}</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.6</priority>
+  </url>`).join("\n")}
+  <url>
     <loc>https://agentdeals-production.up.railway.app/digest/archive</loc>
     <lastmod>${now}</lastmod>
     <changefreq>weekly</changefreq>
@@ -2183,6 +2508,23 @@ ${getRecentWeekKeys(4).map(wk => `  <url>
     } else {
       res.writeHead(404, { "Content-Type": "text/html; charset=utf-8" });
       res.end(`<!DOCTYPE html><html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><title>Digest not found — AgentDeals</title><style>body{font-family:-apple-system,sans-serif;background:#14120b;color:#e8e0cc;display:flex;align-items:center;justify-content:center;min-height:100vh;margin:0}a{color:#c8a44e}.box{text-align:center;max-width:480px;padding:2rem}</style></head><body><div class="box"><h1 style="font-size:3rem;margin-bottom:.5rem">404</h1><p>Invalid week format. Use YYYY-wNN (e.g., 2026-w11).</p><p style="margin-top:1rem"><a href="/digest/archive">Browse the digest archive</a></p></div></body></html>`);
+    }
+  } else if (url.pathname === "/vendor" && req.method === "GET") {
+    recordApiHit("/vendor");
+    logRequest({ ts: new Date().toISOString(), type: "api", endpoint: "/vendor", params: {}, user_agent: req.headers["user-agent"] ?? "unknown", result_count: vendorSlugMap.size });
+    res.writeHead(200, { "Content-Type": "text/html; charset=utf-8", "Cache-Control": "public, max-age=3600" });
+    res.end(buildVendorIndexPage());
+  } else if (url.pathname.startsWith("/vendor/") && req.method === "GET") {
+    const slug = url.pathname.slice("/vendor/".length).replace(/\/$/, "");
+    const html = buildVendorPage(slug);
+    if (html) {
+      recordApiHit("/vendor/:slug");
+      logRequest({ ts: new Date().toISOString(), type: "api", endpoint: "/vendor/" + slug, params: {}, user_agent: req.headers["user-agent"] ?? "unknown", result_count: 1 });
+      res.writeHead(200, { "Content-Type": "text/html; charset=utf-8", "Cache-Control": "public, max-age=3600" });
+      res.end(html);
+    } else {
+      res.writeHead(404, { "Content-Type": "text/html; charset=utf-8" });
+      res.end(`<!DOCTYPE html><html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><title>Vendor not found — AgentDeals</title><style>body{font-family:-apple-system,sans-serif;background:#14120b;color:#e8e0cc;display:flex;align-items:center;justify-content:center;min-height:100vh;margin:0}a{color:#c8a44e}.box{text-align:center;max-width:480px;padding:2rem}</style></head><body><div class="box"><h1 style="font-size:3rem;margin-bottom:.5rem">404</h1><p>Vendor "<strong>${escHtmlServer(slug)}</strong>" not found.</p><p style="margin-top:1rem"><a href="/vendor">Browse all ${vendorSlugMap.size} vendors</a></p></div></body></html>`);
     }
   } else {
     res.writeHead(404, { "Content-Type": "application/json" });

--- a/test/http.test.ts
+++ b/test/http.test.ts
@@ -1072,4 +1072,64 @@ describe("HTTP transport", () => {
     const digestCount = (xml.match(/\/digest\//g) || []).length;
     assert.ok(digestCount >= 3, `Expected at least 3 digest URLs in sitemap, got ${digestCount}`);
   });
+
+  it("GET /vendor returns vendor index page", async () => {
+    proc = await startHttpServer();
+
+    const response = await fetch(`http://localhost:${PORT}/vendor`);
+    assert.strictEqual(response.status, 200);
+    assert.ok(response.headers.get("content-type")?.includes("text/html"));
+    const html = await response.text();
+    assert.ok(html.includes("<title>All Vendors"), "Should have vendor index title");
+    assert.ok(html.includes("application/ld+json"), "Should have JSON-LD");
+    assert.ok(html.includes("CollectionPage"), "JSON-LD should use CollectionPage");
+    assert.ok(html.includes("/vendor/"), "Should link to vendor pages");
+    assert.ok(html.includes("canonical"), "Should have canonical link");
+  });
+
+  it("GET /vendor/:slug renders vendor profile page", async () => {
+    proc = await startHttpServer();
+
+    const response = await fetch(`http://localhost:${PORT}/vendor/vercel`);
+    assert.strictEqual(response.status, 200);
+    assert.ok(response.headers.get("content-type")?.includes("text/html"));
+    const html = await response.text();
+    assert.ok(html.includes("Vercel Free Tier"), "Should have vendor-specific title");
+    assert.ok(html.includes("application/ld+json"), "Should have JSON-LD");
+    assert.ok(html.includes("SoftwareApplication"), "JSON-LD should use SoftwareApplication");
+    assert.ok(html.includes("Pricing Change History"), "Should show pricing history section");
+    assert.ok(html.includes("Query via MCP"), "Should show MCP snippet");
+    assert.ok(html.includes("Alternatives in"), "Should show alternatives");
+    assert.ok(html.includes("canonical"), "Should have canonical link");
+    assert.ok(html.includes("risk-badge"), "Should show risk badge");
+  });
+
+  it("GET /vendor/:slug returns 404 for unknown vendor", async () => {
+    proc = await startHttpServer();
+
+    const response = await fetch(`http://localhost:${PORT}/vendor/nonexistent-vendor`);
+    assert.strictEqual(response.status, 404);
+    const html = await response.text();
+    assert.ok(html.includes("404"), "Should show 404");
+    assert.ok(html.includes("nonexistent-vendor"), "Should show the invalid slug");
+    assert.ok(html.includes("/vendor"), "Should link to vendor index");
+  });
+
+  it("sitemap.xml includes vendor pages", async () => {
+    proc = await startHttpServer();
+
+    const response = await fetch(`http://localhost:${PORT}/sitemap.xml`);
+    const xml = await response.text();
+    assert.ok(xml.includes("/vendor/vercel"), "Sitemap should include vendor pages");
+    const vendorCount = (xml.match(/\/vendor\//g) || []).length;
+    assert.ok(vendorCount >= 100, `Expected 100+ vendor URLs in sitemap, got ${vendorCount}`);
+  });
+
+  it("category page links vendors to profile pages", async () => {
+    proc = await startHttpServer();
+
+    const response = await fetch(`http://localhost:${PORT}/category/cloud-hosting`);
+    const html = await response.text();
+    assert.ok(html.includes('href="/vendor/'), "Category page should link vendors to profile pages");
+  });
 });


### PR DESCRIPTION
## Summary

- **1,518 server-rendered vendor profile pages** at `/vendor/{vendor-slug}` showing free tier details, pricing change history, risk assessment, alternatives, comparison links, and MCP query snippet
- **Vendor index page** at `/vendor` listing all vendors grouped by category with links
- **JSON-LD structured data** (SoftwareApplication schema) on each profile page
- **1,519 new sitemap URLs** (1,518 vendors + index) for SEO
- **Category pages** now link vendor names to their profile pages instead of external URLs
- **Styled 404** for unknown vendor slugs
- **5 new tests** (205 total, all passing)

## Test plan

- [x] `npm run build` passes
- [x] `npm test` — 205/205 tests pass
- [x] E2E: `/vendor` returns index with all 1,518 vendors
- [x] E2E: `/vendor/vercel` renders complete profile (risk badge, pricing history, alternatives, comparisons, MCP snippet, JSON-LD)
- [x] E2E: `/vendor/nonexistent` returns 404
- [x] E2E: `/sitemap.xml` includes 1,518+ vendor URLs
- [x] E2E: `/category/cloud-hosting` links vendors to `/vendor/` profile pages

Refs #224

🤖 Generated with [Claude Code](https://claude.com/claude-code)