### PR TITLE
Add rich metadata to glama.json for Glama AAA badge

### DIFF
--- a/glama.json
+++ b/glama.json
@@ -1,4 +1,12 @@
 {
   "$schema": "https://glama.ai/mcp/schemas/server.json",
+  "name": "agentdeals",
+  "description": "Search and compare free tiers, credits, and pricing changes across 1,500+ developer tools. 12 MCP tools for infrastructure decisions, cost estimation, and vendor comparison.",
+  "repository": "https://github.com/robhunter/agentdeals",
+  "license": "MIT",
+  "tools": 12,
+  "prompts": 5,
+  "transport": ["http", "stdio"],
+  "runtime": "node",
   "maintainers": ["robhunter"]
 }


### PR DESCRIPTION
## Summary
- Added name, description, repository, license, tools, prompts, transport, and runtime fields to `glama.json`
- This metadata helps Glama's scanner properly score the server, unblocking the awesome-mcp-servers PR #3003

Refs #234