### PR TITLE
Fix /.well-known/glama.json to serve repo file

### DIFF
--- a/src/serve.ts
+++ b/src/serve.ts
@@ -3192,12 +3192,7 @@ const httpServer = createHttpServer(async (req, res) => {
     res.end(JSON.stringify({ status: "ok", sessions: sessions.size, stats: getStats() }));
   } else if (url.pathname === "/.well-known/glama.json") {
     res.writeHead(200, { "Content-Type": "application/json" });
-    res.end(JSON.stringify({
-      "$schema": "https://glama.ai/mcp/schemas/connector.json",
-      "maintainers": [
-        { "email": "robvhunter@gmail.com" }
-      ]
-    }));
+    res.end(readFileSync(join(__dirname, "..", "glama.json"), "utf-8"));
   } else if (url.pathname === "/api/stack" && req.method === "GET") {
     recordApiHit("/api/stack");
     const useCase = url.searchParams.get("use_case") || url.searchParams.get("q") || "";

--- a/test/http.test.ts
+++ b/test/http.test.ts
@@ -274,17 +274,18 @@ describe("HTTP transport", () => {
     assert.ok(searchBody.results.length > 0);
   });
 
-  it("serves /.well-known/glama.json", async () => {
+  it("serves /.well-known/glama.json from repo file", async () => {
     proc = await startHttpServer();
 
     const response = await fetch(`http://localhost:${PORT}/.well-known/glama.json`);
     assert.strictEqual(response.status, 200);
     assert.strictEqual(response.headers.get("content-type"), "application/json");
     const body = await response.json() as any;
-    assert.strictEqual(body["$schema"], "https://glama.ai/mcp/schemas/connector.json");
-    assert.ok(Array.isArray(body.maintainers));
-    assert.strictEqual(body.maintainers.length, 1);
-    assert.strictEqual(body.maintainers[0].email, "robvhunter@gmail.com");
+    assert.strictEqual(body["$schema"], "https://glama.ai/mcp/schemas/server.json");
+    assert.strictEqual(body.name, "agentdeals");
+    assert.strictEqual(body.license, "MIT");
+    assert.strictEqual(body.tools, 12);
+    assert.ok(Array.isArray(body.transport));
   });
 
   it("serves landing page at root URL", async () => {


### PR DESCRIPTION
## Summary

- Updated `/.well-known/glama.json` endpoint to read and serve the actual `glama.json` file from the repo root instead of returning hardcoded stale data
- Endpoint now returns the `server.json` schema with rich metadata (name, description, tools, license, transport, etc.) instead of the old `connector.json` schema
- Updated test to verify the new response format

## Test plan

- [x] `GET /.well-known/glama.json` returns repo file contents with `server.json` schema
- [x] Response includes name, license, tools count, transport array
- [x] 222/224 tests pass (2 pre-existing timeouts in new-offers.test.ts)

Refs #238