### PR TITLE
Fix /.well-known/glama.json 502 — copy file into Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,7 @@ RUN npm ci --omit=dev
 COPY --from=build /app/dist/ dist/
 COPY data/ data/
 COPY assets/ assets/
+COPY glama.json ./
 
 EXPOSE 3000
 


### PR DESCRIPTION
## Summary
- Add `COPY glama.json ./` to Dockerfile so the `/.well-known/glama.json` endpoint can read the file at runtime
- The route handler (`serve.ts:3534`) uses `readFileSync(join(__dirname, '..', 'glama.json'))` which resolves to `/app/glama.json` in the container — but the file was never copied in

## Test plan
- [x] 225/225 tests pass locally
- [ ] After deploy, verify `curl https://agentdeals.dev/.well-known/glama.json` returns valid JSON with server.json schema

Refs #238