### PR TITLE
Add Atom feed at /feed.xml with vendor profile links

### DIFF
--- a/src/openapi.ts
+++ b/src/openapi.ts
@@ -539,15 +539,15 @@ export const openapiSpec = {
         }
       }
     },
-    "/api/feed": {
+    "/feed.xml": {
       get: {
-        summary: "RSS feed of pricing changes",
-        description: "RSS 2.0 feed of developer tool pricing changes. Subscribe in any RSS reader to stay updated on free tier removals, limit changes, and new deals.",
+        summary: "Atom feed of pricing changes",
+        description: "Atom feed of developer tool pricing changes. Subscribe in any feed reader to stay updated on free tier removals, limit changes, and new deals. Also available at /api/feed.",
         responses: {
           "200": {
-            description: "RSS 2.0 XML feed",
+            description: "Atom XML feed",
             content: {
-              "application/rss+xml": {
+              "application/atom+xml": {
                 schema: { type: "string", format: "binary" }
               }
             }

--- a/src/serve.ts
+++ b/src/serve.ts
@@ -958,7 +958,7 @@ function buildDigestPage(weekKey: string): string | null {
     </div>`;
     }).join("\n    ")}
   </div>`).join("\n")
-    : `<div class="empty-msg"><p>No pricing changes tracked this week.</p><p style="margin-top:.5rem"><a href="/digest/archive">Browse the archive</a> or <a href="/api/feed">subscribe via RSS</a>.</p></div>`;
+    : `<div class="empty-msg"><p>No pricing changes tracked this week.</p><p style="margin-top:.5rem"><a href="/digest/archive">Browse the archive</a> or <a href="/feed.xml">subscribe via RSS</a>.</p></div>`;
 
   // Trending categories
   const catCounts = new Map<string, number>();
@@ -1010,7 +1010,7 @@ function buildDigestPage(weekKey: string): string | null {
 <meta property="og:type" content="article">
 <meta property="og:url" content="https://agentdeals-production.up.railway.app/digest/${weekKey}">
 <link rel="icon" type="image/png" href="/favicon.png">
-<link rel="alternate" type="application/rss+xml" title="AgentDeals — Pricing Changes" href="/api/feed">
+<link rel="alternate" type="application/atom+xml" title="AgentDeals — Pricing Changes" href="/feed.xml">
 <link rel="preconnect" href="https://fonts.googleapis.com"><link rel="preconnect" href="https://fonts.gstatic.com" crossorigin><link href="https://fonts.googleapis.com/css2?family=DM+Serif+Display:ital@0;1&family=Inter:wght@400;500;600&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
 <script type="application/ld+json">${JSON.stringify(jsonLd)}</script>
 <style>${digestCss}</style>
@@ -1027,7 +1027,7 @@ ${trendingHtml}
 
   <div class="rss-cta">
     <p>Get pricing changes delivered automatically</p>
-    <a href="/api/feed">Subscribe via RSS &rarr;</a>
+    <a href="/feed.xml">Subscribe via RSS &rarr;</a>
   </div>
 ${navHtml}
   <footer>AgentDeals &mdash; open source, built for agents</footer>
@@ -1071,7 +1071,7 @@ function buildDigestArchivePage(): string {
 <meta property="og:type" content="website">
 <meta property="og:url" content="https://agentdeals-production.up.railway.app/digest/archive">
 <link rel="icon" type="image/png" href="/favicon.png">
-<link rel="alternate" type="application/rss+xml" title="AgentDeals — Pricing Changes" href="/api/feed">
+<link rel="alternate" type="application/atom+xml" title="AgentDeals — Pricing Changes" href="/feed.xml">
 <link rel="preconnect" href="https://fonts.googleapis.com"><link rel="preconnect" href="https://fonts.gstatic.com" crossorigin><link href="https://fonts.googleapis.com/css2?family=DM+Serif+Display:ital@0;1&family=Inter:wght@400;500;600&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
 <script type="application/ld+json">${JSON.stringify(jsonLd)}</script>
 <style>${digestCss}</style>
@@ -1088,7 +1088,7 @@ function buildDigestArchivePage(): string {
 
   <div class="rss-cta">
     <p>Get pricing changes delivered automatically</p>
-    <a href="/api/feed">Subscribe via RSS &rarr;</a>
+    <a href="/feed.xml">Subscribe via RSS &rarr;</a>
   </div>
 
   <footer>AgentDeals &mdash; open source, built for agents</footer>
@@ -2736,7 +2736,7 @@ function buildLandingPage(): string {
 <meta name="twitter:image" content="https://raw.githubusercontent.com/robhunter/agentdeals/main/assets/logo-400.png">
 <link rel="icon" type="image/png" href="/favicon.png">
 <link rel="canonical" href="https://agentdeals-production.up.railway.app/">
-<link rel="alternate" type="application/rss+xml" title="AgentDeals — Pricing Changes" href="/api/feed">
+<link rel="alternate" type="application/atom+xml" title="AgentDeals — Pricing Changes" href="/feed.xml">
 <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -3738,9 +3738,11 @@ const httpServer = createHttpServer(async (req, res) => {
     const content = readFileSync(filePath);
     res.writeHead(200, { "Content-Type": contentType, "Cache-Control": "public, max-age=86400" });
     res.end(content);
-  } else if (url.pathname === "/api/feed" && req.method === "GET") {
-    recordApiHit("/api/feed");
-    const allChanges = [...dealChanges].sort((a, b) => b.date.localeCompare(a.date));
+  } else if ((url.pathname === "/feed.xml" || url.pathname === "/api/feed") && req.method === "GET") {
+    const feedPath = url.pathname === "/feed.xml" ? "/feed.xml" : "/api/feed";
+    recordApiHit(feedPath);
+    const baseUrl = "https://agentdeals-production.up.railway.app";
+    const allChanges = [...dealChanges].sort((a, b) => b.date.localeCompare(a.date)).slice(0, 50);
     const escXml = (s: string) => s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;").replace(/'/g, "&apos;");
     const changeLabel: Record<string, string> = {
       free_tier_removed: "Free Tier Removed",
@@ -3754,32 +3756,33 @@ const httpServer = createHttpServer(async (req, res) => {
       pricing_postponed: "Pricing Postponed",
       product_deprecated: "Product Deprecated",
     };
-    const items = allChanges.map((c) => {
+    const updatedTs = allChanges.length > 0 ? new Date(allChanges[0].date + "T00:00:00Z").toISOString() : new Date().toISOString();
+    const entries = allChanges.map((c) => {
       const label = changeLabel[c.change_type] ?? c.change_type;
-      return `    <item>
-      <title>${escXml(c.vendor)}: ${escXml(label)}</title>
-      <description>${escXml(c.summary)}</description>
-      <pubDate>${new Date(c.date + "T00:00:00Z").toUTCString()}</pubDate>
-      <link>${escXml(c.source_url)}</link>
-      <category>${escXml(c.change_type)}</category>
-      <guid isPermaLink="false">agentdeals-${escXml(c.vendor.toLowerCase().replace(/\s+/g, "-"))}-${c.date}</guid>
-    </item>`;
+      const vendorSlug = toSlug(c.vendor);
+      const id = `agentdeals-${vendorSlug}-${c.date}`;
+      return `  <entry>
+    <title>${escXml(c.vendor)}: ${escXml(label)}</title>
+    <link href="${baseUrl}/vendor/${vendorSlug}" rel="alternate"/>
+    <id>urn:agentdeals:${escXml(id)}</id>
+    <updated>${new Date(c.date + "T00:00:00Z").toISOString()}</updated>
+    <summary>${escXml(c.summary)}</summary>
+    <category term="${escXml(c.change_type)}" label="${escXml(label)}"/>
+  </entry>`;
     }).join("\n");
-    const rss = `<?xml version="1.0" encoding="UTF-8"?>
-<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
-  <channel>
-    <title>AgentDeals — Developer Tool Pricing Changes</title>
-    <description>Track pricing changes, free tier removals, and deal updates across developer infrastructure tools.</description>
-    <link>https://agentdeals-production.up.railway.app</link>
-    <atom:link href="https://agentdeals-production.up.railway.app/api/feed" rel="self" type="application/rss+xml"/>
-    <language>en-us</language>
-    <lastBuildDate>${new Date().toUTCString()}</lastBuildDate>
-${items}
-  </channel>
-</rss>`;
-    logRequest({ ts: new Date().toISOString(), type: "api", endpoint: "/api/feed", params: {}, user_agent: req.headers["user-agent"] ?? "unknown", result_count: allChanges.length });
-    res.writeHead(200, { "Content-Type": "application/rss+xml; charset=utf-8", "Access-Control-Allow-Origin": "*" });
-    res.end(rss);
+    const atom = `<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <title>AgentDeals — Pricing Changes</title>
+  <subtitle>Track pricing changes, free tier removals, and deal updates across developer infrastructure tools.</subtitle>
+  <link href="${baseUrl}" rel="alternate"/>
+  <link href="${baseUrl}/feed.xml" rel="self" type="application/atom+xml"/>
+  <id>urn:agentdeals:feed</id>
+  <updated>${updatedTs}</updated>
+${entries}
+</feed>`;
+    logRequest({ ts: new Date().toISOString(), type: "api", endpoint: feedPath, params: {}, user_agent: req.headers["user-agent"] ?? "unknown", result_count: allChanges.length });
+    res.writeHead(200, { "Content-Type": "application/atom+xml; charset=utf-8", "Cache-Control": "public, max-age=3600", "Access-Control-Allow-Origin": "*" });
+    res.end(atom);
   } else if (url.pathname === "/robots.txt" && req.method === "GET") {
     const robotsTxt = `User-agent: *\nAllow: /\n\nSitemap: https://agentdeals-production.up.railway.app/sitemap.xml\n`;
     res.writeHead(200, { "Content-Type": "text/plain; charset=utf-8", "Cache-Control": "public, max-age=86400" });
@@ -3801,7 +3804,7 @@ ${items}
     <priority>1.0</priority>
   </url>
   <url>
-    <loc>https://agentdeals-production.up.railway.app/api/feed</loc>
+    <loc>https://agentdeals-production.up.railway.app/feed.xml</loc>
     <lastmod>${now}</lastmod>
     <changefreq>daily</changefreq>
     <priority>0.5</priority>

--- a/test/http.test.ts
+++ b/test/http.test.ts
@@ -799,28 +799,37 @@ describe("HTTP transport", () => {
     assert.ok(body.paths["/api/expiring"]);
     assert.ok(body.paths["/api/newest"]);
     assert.ok(body.paths["/api/costs"]);
-    assert.ok(body.paths["/api/feed"]);
+    assert.ok(body.paths["/feed.xml"]);
     assert.strictEqual(Object.keys(body.paths).length, 15);
     assert.ok(body.components.schemas.Offer);
     assert.ok(body.components.schemas.DealChange);
     assert.ok(body.components.schemas.Eligibility);
   });
 
-  it("GET /api/feed returns valid RSS 2.0 XML", async () => {
+  it("GET /feed.xml returns valid Atom XML", async () => {
+    proc = await startHttpServer();
+
+    const response = await fetch(`http://localhost:${PORT}/feed.xml`);
+    assert.strictEqual(response.status, 200);
+    assert.ok(response.headers.get("content-type")?.includes("application/atom+xml"));
+    const body = await response.text();
+    assert.ok(body.startsWith("<?xml"));
+    assert.ok(body.includes("<feed xmlns="));
+    assert.ok(body.includes("<title>AgentDeals"));
+    assert.ok(body.includes("<entry>"));
+    assert.ok(body.includes("<updated>"));
+    assert.ok(body.includes("/vendor/"));
+    assert.ok(body.includes("<category"));
+  });
+
+  it("GET /api/feed also serves Atom feed", async () => {
     proc = await startHttpServer();
 
     const response = await fetch(`http://localhost:${PORT}/api/feed`);
     assert.strictEqual(response.status, 200);
-    assert.ok(response.headers.get("content-type")?.includes("application/rss+xml"));
+    assert.ok(response.headers.get("content-type")?.includes("application/atom+xml"));
     const body = await response.text();
-    assert.ok(body.startsWith("<?xml"));
-    assert.ok(body.includes("<rss version=\"2.0\""));
-    assert.ok(body.includes("<channel>"));
-    assert.ok(body.includes("<title>AgentDeals"));
-    assert.ok(body.includes("<item>"));
-    assert.ok(body.includes("<pubDate>"));
-    assert.ok(body.includes("<guid"));
-    assert.ok(body.includes("<category>"));
+    assert.ok(body.includes("<feed xmlns="));
   });
 
   it("prompts/list returns all 5 prompt templates", async () => {
@@ -1045,7 +1054,7 @@ describe("HTTP transport", () => {
     assert.ok(html.includes("CollectionPage"), "JSON-LD should use CollectionPage");
     assert.ok(html.includes("/digest/"), "Should link to weekly digests");
     assert.ok(html.includes("canonical"), "Should have canonical link");
-    assert.ok(html.includes("/api/feed"), "Should link to RSS feed");
+    assert.ok(html.includes("/feed.xml"), "Should link to RSS feed");
   });
 
   it("GET /digest/:week renders digest page with changes", async () => {
@@ -1059,7 +1068,7 @@ describe("HTTP transport", () => {
     assert.ok(html.includes("<title>Developer Tool Pricing Changes"), "Should have week title");
     assert.ok(html.includes("application/ld+json"), "Should have JSON-LD");
     assert.ok(html.includes("canonical"), "Should have canonical link");
-    assert.ok(html.includes("/api/feed"), "Should have RSS link");
+    assert.ok(html.includes("/feed.xml"), "Should have RSS link");
   });
 
   it("GET /digest/:week shows empty state for weeks with no changes", async () => {


### PR DESCRIPTION
## Summary
- New `/feed.xml` Atom feed with vendor profile page links, limited to 50 most recent entries
- `/api/feed` kept as alias (both serve Atom XML)
- Updated all `<link rel="alternate">` tags from RSS to Atom format pointing to `/feed.xml`
- Updated sitemap, OpenAPI spec, and RSS CTA links across digest pages
- 1 new test (226 total)

## Test plan
- [x] 226/226 tests pass
- [ ] Verify `/feed.xml` returns valid Atom XML in production
- [ ] Verify feed entries link to `/vendor/<slug>` pages

Refs #242