### PR TITLE
301 redirect non-canonical hostnames to BASE_URL

### DIFF
--- a/src/serve.ts
+++ b/src/serve.ts
@@ -3623,8 +3623,33 @@ function extractClientInfo(body: unknown): ClientInfo | undefined {
   return undefined;
 }
 
+// Parse canonical hostname from BASE_URL for redirect logic
+const canonicalHost = (() => {
+  try { return new URL(BASE_URL).hostname; } catch { return undefined; }
+})();
+
 const httpServer = createHttpServer(async (req, res) => {
   const url = new URL(req.url ?? "/", `http://localhost:${PORT}`);
+
+  // 301 redirect non-canonical hostnames to BASE_URL (SEO canonical domain)
+  if (canonicalHost) {
+    const requestHost = (req.headers.host ?? "").split(":")[0];
+    if (requestHost && requestHost !== canonicalHost) {
+      const skip =
+        url.pathname === "/mcp" ||
+        url.pathname === "/health" ||
+        url.pathname.startsWith("/api/") ||
+        url.pathname.startsWith("/.well-known/") ||
+        url.pathname === "/favicon.png" ||
+        url.pathname === "/favicon.ico";
+      if (!skip) {
+        const target = `${BASE_URL}${url.pathname}${url.search}`;
+        res.writeHead(301, { Location: target });
+        res.end();
+        return;
+      }
+    }
+  }
 
   if (url.pathname === "/mcp") {
     if (req.method === "POST") {

--- a/test/http.test.ts
+++ b/test/http.test.ts
@@ -12,7 +12,7 @@ function startHttpServer(): Promise<ChildProcess> {
     const serverPath = path.join(__dirname, "..", "dist", "serve.js");
     const proc = spawn("node", [serverPath], {
       stdio: ["pipe", "pipe", "pipe"],
-      env: { ...process.env, PORT: String(PORT) },
+      env: { ...process.env, PORT: String(PORT), BASE_URL: `http://localhost:${PORT}` },
     });
 
     const timeout = setTimeout(() => {
@@ -1396,5 +1396,97 @@ describe("HTTP transport", () => {
     assert.ok(html.includes("faq-item"), "Should have visible FAQ items");
     assert.ok(html.includes("best free alternatives to Vercel"), "Should have alternatives FAQ question");
     assert.ok(html.includes("How many free alternatives"), "Should have count FAQ question");
+  });
+});
+
+const REDIRECT_PORT = 3458;
+
+function startRedirectServer(): Promise<ChildProcess> {
+  return new Promise((resolve, reject) => {
+    const serverPath = path.join(__dirname, "..", "dist", "serve.js");
+    const proc = spawn("node", [serverPath], {
+      stdio: ["pipe", "pipe", "pipe"],
+      env: { ...process.env, PORT: String(REDIRECT_PORT), BASE_URL: "https://agentdeals.dev" },
+    });
+
+    const timeout = setTimeout(() => {
+      proc.kill();
+      reject(new Error("Server startup timeout"));
+    }, 5000);
+
+    proc.stderr!.on("data", (data: Buffer) => {
+      if (data.toString().includes("running on http")) {
+        clearTimeout(timeout);
+        resolve(proc);
+      }
+    });
+
+    proc.on("error", (err) => {
+      clearTimeout(timeout);
+      reject(err);
+    });
+  });
+}
+
+describe("301 canonical hostname redirect", () => {
+  let proc: ChildProcess | null = null;
+
+  afterEach(() => {
+    if (proc) {
+      proc.kill();
+      proc = null;
+    }
+  });
+
+  it("redirects HTML pages to canonical domain with 301", async () => {
+    proc = await startRedirectServer();
+    const response = await fetch(`http://localhost:${REDIRECT_PORT}/vendor/supabase?ref=foo`, { redirect: "manual" });
+    assert.strictEqual(response.status, 301);
+    assert.strictEqual(response.headers.get("location"), "https://agentdeals.dev/vendor/supabase?ref=foo");
+  });
+
+  it("redirects landing page to canonical domain", async () => {
+    proc = await startRedirectServer();
+    const response = await fetch(`http://localhost:${REDIRECT_PORT}/`, { redirect: "manual" });
+    assert.strictEqual(response.status, 301);
+    assert.strictEqual(response.headers.get("location"), "https://agentdeals.dev/");
+  });
+
+  it("does NOT redirect /api/* endpoints", async () => {
+    proc = await startRedirectServer();
+    const response = await fetch(`http://localhost:${REDIRECT_PORT}/api/stats`, { redirect: "manual" });
+    assert.strictEqual(response.status, 200);
+  });
+
+  it("does NOT redirect /mcp endpoint", async () => {
+    proc = await startRedirectServer();
+    // GET /mcp without session returns 400, but should NOT be 301
+    const response = await fetch(`http://localhost:${REDIRECT_PORT}/mcp`, { redirect: "manual" });
+    assert.notStrictEqual(response.status, 301, "MCP should not redirect");
+  });
+
+  it("does NOT redirect /health endpoint", async () => {
+    proc = await startRedirectServer();
+    const response = await fetch(`http://localhost:${REDIRECT_PORT}/health`, { redirect: "manual" });
+    assert.strictEqual(response.status, 200);
+  });
+
+  it("does NOT redirect /.well-known/* endpoints", async () => {
+    proc = await startRedirectServer();
+    const response = await fetch(`http://localhost:${REDIRECT_PORT}/.well-known/glama.json`, { redirect: "manual" });
+    assert.notStrictEqual(response.status, 301, ".well-known should not redirect");
+  });
+
+  it("does NOT redirect favicon", async () => {
+    proc = await startRedirectServer();
+    const response = await fetch(`http://localhost:${REDIRECT_PORT}/favicon.png`, { redirect: "manual" });
+    assert.strictEqual(response.status, 200);
+  });
+
+  it("no redirect when BASE_URL matches request host", async () => {
+    // Default server has BASE_URL matching localhost (or not set to external domain)
+    proc = await startHttpServer();
+    const response = await fetch(`http://localhost:${PORT}/`, { redirect: "manual" });
+    assert.strictEqual(response.status, 200);
   });
 });


### PR DESCRIPTION
## Summary
- When `BASE_URL` is set and the incoming request's `Host` header doesn't match the canonical hostname, HTML page requests return a **301 redirect** to `BASE_URL` preserving path and query string
- Excluded from redirects: `/api/*`, `/mcp`, `/health`, `/.well-known/*`, `/favicon.png`, `/favicon.ico`
- When `BASE_URL` is not set or matches the request host, no redirect occurs (backwards compatible)
- 8 new tests covering redirect and non-redirect cases (235 total, all passing)

## Test plan
- [x] HTML pages redirect with 301 (path + query preserved)
- [x] Landing page redirects
- [x] API endpoints NOT redirected
- [x] MCP endpoint NOT redirected
- [x] Health endpoint NOT redirected
- [x] .well-known endpoints NOT redirected
- [x] Favicon NOT redirected
- [x] No redirect when BASE_URL matches request host
- [x] Full test suite passes (235/235)

Refs #256