### PR TITLE
Track GitHub Actions self-hosted runner pricing change

### DIFF
--- a/data/deal_changes.json
+++ b/data/deal_changes.json
@@ -150,6 +150,22 @@
       ]
     },
     {
+      "vendor": "GitHub Actions",
+      "change_type": "pricing_restructured",
+      "date": "2026-03-01",
+      "summary": "Self-hosted runners in private repos now incur $0.002/min cloud platform charge and consume free quota minutes. Previously postponed fee is now active. Hosted runner prices dropped up to 39% (effective Jan 2026). Public repos remain completely free",
+      "previous_state": "Self-hosted runners free in all repos. Hosted runners at previous per-minute pricing",
+      "current_state": "Self-hosted runners $0.002/min in private repos, consume free quota. Hosted runners 39% cheaper. Public repos still free for both runner types",
+      "impact": "high",
+      "source_url": "https://resources.github.com/actions/2026-pricing-changes-for-github-actions/",
+      "category": "CI/CD",
+      "alternatives": [
+        "GitLab CI",
+        "CircleCI",
+        "Buildkite"
+      ]
+    },
+    {
       "vendor": "Bright Data MCP",
       "change_type": "new_free_tier",
       "date": "2025-08-14",

--- a/data/index.json
+++ b/data/index.json
@@ -448,7 +448,7 @@
     {
       "vendor": "GitHub Actions",
       "category": "CI/CD",
-      "description": "Free CI/CD for public repos. Private repos: 2,000 min/mo GitHub-hosted runners, 500 MB artifact storage, 10 GB cache/repo. Self-hosted runners remain free (planned $0.002/min fee postponed indefinitely). Hosted runner prices reduced 39% Jan 2026",
+      "description": "Free CI/CD for public repos. Private repos: 2,000 min/mo GitHub-hosted runners, 500 MB artifact storage, 10 GB cache/repo. Self-hosted runners now $0.002/min in private repos and consume free quota (March 2026). Hosted runner prices reduced 39% (Jan 2026). Public repos free for all runner types",
       "tier": "Free",
       "url": "https://docs.github.com/en/billing/managing-billing-for-github-actions/about-billing-for-github-actions",
       "tags": [
@@ -458,7 +458,7 @@
         "github",
         "deal-change"
       ],
-      "verifiedDate": "2026-03-14"
+      "verifiedDate": "2026-03-15"
     },
     {
       "vendor": "GitLab CI",


### PR DESCRIPTION
## Summary
- Add `pricing_restructured` deal change entry for GitHub Actions (effective 2026-03-01): self-hosted runners now $0.002/min in private repos, consume free quota minutes
- Update GitHub Actions offer description to reflect current pricing state
- Preserves existing `pricing_postponed` entry for historical context
- Public repos remain completely free

## Test plan
- [x] `npm test` — 241 tests pass
- [x] Verified change appears in `loadDealChanges()` results
- [x] Deal change has correct type (`pricing_restructured`), date (`2026-03-01`), and impact (`high`)

Refs #261