### PR TITLE
Add get_weekly_digest MCP tool and /api/digest endpoint

### DIFF
--- a/src/api-client.ts
+++ b/src/api-client.ts
@@ -130,3 +130,7 @@ export async function fetchExpiringDeals(withinDays?: number): Promise<unknown> 
   if (withinDays !== undefined) p.within_days = String(withinDays);
   return apiFetch("/api/expiring", p);
 }
+
+export async function fetchWeeklyDigest(): Promise<unknown> {
+  return apiFetch("/api/digest");
+}

--- a/src/data.ts
+++ b/src/data.ts
@@ -697,3 +697,67 @@ export function getExpiringDeals(withinDays: number = 30): { deals: Array<Offer 
 
   return { deals: expiring, total: expiring.length };
 }
+
+export function getWeeklyDigest(): {
+  week: string;
+  date_range: string;
+  deal_changes: DealChange[];
+  new_offers: { vendor: string; category: string; description: string }[];
+  upcoming_deadlines: { vendor: string; expires_date: string; days_until_expiry: number }[];
+  summary: string;
+} {
+  const now = new Date();
+
+  // Get deal changes — 7-day window, fallback to 30 if <3 changes
+  const sevenDaysAgo = new Date(now.getTime() - 7 * 24 * 60 * 60 * 1000).toISOString().slice(0, 10);
+  const thirtyDaysAgo = new Date(now.getTime() - 30 * 24 * 60 * 60 * 1000).toISOString().slice(0, 10);
+  let changes = getDealChanges(sevenDaysAgo).changes;
+  const usedFallback = changes.length < 3;
+  if (usedFallback) {
+    changes = getDealChanges(thirtyDaysAgo).changes;
+  }
+
+  // New offers added in last 7 days
+  const newOffers = getNewOffers(7).offers.slice(0, 10).map((o) => ({
+    vendor: o.vendor,
+    category: o.category,
+    description: o.description,
+  }));
+
+  // Upcoming deadlines (next 30 days)
+  const deadlines = getExpiringDeals(30).deals.slice(0, 10).map((d) => ({
+    vendor: d.vendor,
+    expires_date: d.expires_date!,
+    days_until_expiry: d.days_until_expiry,
+  }));
+
+  // Week label
+  const weekStart = new Date(now.getTime() - now.getUTCDay() * 86400000 + 86400000); // Monday
+  const weekEnd = new Date(weekStart.getTime() + 6 * 86400000);
+  const fmt = (d: Date) => d.toISOString().slice(0, 10);
+  const week = `${fmt(weekStart)} to ${fmt(weekEnd)}`;
+
+  // Build summary
+  const parts: string[] = [];
+  if (changes.length > 0) {
+    const negative = changes.filter((c) => ["free_tier_removed", "limits_reduced", "open_source_killed", "product_deprecated"].includes(c.change_type));
+    const positive = changes.filter((c) => ["new_free_tier", "limits_increased", "startup_program_expanded"].includes(c.change_type));
+    parts.push(`${changes.length} pricing change${changes.length !== 1 ? "s" : ""} tracked${usedFallback ? " in the past 30 days" : " this week"}`);
+    if (negative.length > 0) parts.push(`${negative.length} negative (${negative.map((c) => c.vendor).join(", ")})`);
+    if (positive.length > 0) parts.push(`${positive.length} positive (${positive.map((c) => c.vendor).join(", ")})`);
+  } else {
+    parts.push("No pricing changes this week");
+  }
+  if (newOffers.length > 0) parts.push(`${newOffers.length} new offer${newOffers.length !== 1 ? "s" : ""} added`);
+  if (deadlines.length > 0) parts.push(`${deadlines.length} deal${deadlines.length !== 1 ? "s" : ""} expiring in the next 30 days`);
+  const summary = parts.join(". ") + ".";
+
+  return {
+    week,
+    date_range: `${fmt(weekStart)} to ${fmt(weekEnd)}`,
+    deal_changes: changes,
+    new_offers: newOffers,
+    upcoming_deadlines: deadlines,
+    summary,
+  };
+}

--- a/src/openapi.ts
+++ b/src/openapi.ts
@@ -412,6 +412,65 @@ export const openapiSpec = {
         }
       }
     },
+    "/api/digest": {
+      get: {
+        summary: "Get weekly pricing digest",
+        description: "Curated weekly summary of developer tool pricing changes, new offers, and upcoming deadlines. Falls back to 30-day window if fewer than 3 changes in the past week.",
+        parameters: [],
+        responses: {
+          "200": {
+            description: "Weekly digest",
+            content: {
+              "application/json": {
+                schema: {
+                  type: "object",
+                  properties: {
+                    week: { type: "string", description: "Week date range" },
+                    date_range: { type: "string", description: "ISO date range" },
+                    deal_changes: {
+                      type: "array",
+                      items: {
+                        type: "object",
+                        properties: {
+                          vendor: { type: "string" },
+                          change_type: { type: "string" },
+                          date: { type: "string", format: "date" },
+                          summary: { type: "string" },
+                          impact: { type: "string", enum: ["high", "medium", "low"] }
+                        }
+                      }
+                    },
+                    new_offers: {
+                      type: "array",
+                      items: {
+                        type: "object",
+                        properties: {
+                          vendor: { type: "string" },
+                          category: { type: "string" },
+                          description: { type: "string" }
+                        }
+                      }
+                    },
+                    upcoming_deadlines: {
+                      type: "array",
+                      items: {
+                        type: "object",
+                        properties: {
+                          vendor: { type: "string" },
+                          expires_date: { type: "string", format: "date" },
+                          days_until_expiry: { type: "integer" }
+                        }
+                      }
+                    },
+                    summary: { type: "string", description: "One-paragraph summary of the week" }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/stack": {
       get: {
         summary: "Get free-tier stack recommendation",

--- a/src/serve.ts
+++ b/src/serve.ts
@@ -5,7 +5,7 @@ import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
 import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
 import { createServer } from "./server.js";
-import { loadOffers, getCategories, getNewOffers, getNewestDeals, searchOffers, enrichOffers, loadDealChanges, getDealChanges, getOfferDetails, compareServices, checkVendorRisk, auditStack, getExpiringDeals } from "./data.js";
+import { loadOffers, getCategories, getNewOffers, getNewestDeals, searchOffers, enrichOffers, loadDealChanges, getDealChanges, getOfferDetails, compareServices, checkVendorRisk, auditStack, getExpiringDeals, getWeeklyDigest } from "./data.js";
 import { getStackRecommendation } from "./stacks.js";
 import { estimateCosts } from "./costs.js";
 import { recordApiHit, recordSessionConnect, recordSessionDisconnect, recordLandingPageView, getStats, getConnectionStats, loadTelemetry, flushTelemetry, logRequest, getRequestLog } from "./stats.js";
@@ -3299,6 +3299,7 @@ GET /api/compare?a=Supabase&amp;b=Neon
 GET /api/vendor-risk/Heroku
 GET /api/audit-stack?services=Vercel,Supabase
 GET /api/expiring?within_days=30
+GET /api/digest
 GET /api/feed
 GET /api/stats
 GET /api/openapi.json
@@ -4039,6 +4040,12 @@ const httpServer = createHttpServer(async (req, res) => {
     logRequest({ ts: new Date().toISOString(), type: "api", endpoint: "/api/expiring", params: { within_days: withinDays }, user_agent: req.headers["user-agent"] ?? "unknown", result_count: result.total });
     res.writeHead(200, { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" });
     res.end(JSON.stringify(result));
+  } else if (url.pathname === "/api/digest" && req.method === "GET") {
+    recordApiHit("/api/digest");
+    const digest = getWeeklyDigest();
+    logRequest({ ts: new Date().toISOString(), type: "api", endpoint: "/api/digest", params: {}, user_agent: req.headers["user-agent"] ?? "unknown", result_count: digest.deal_changes.length });
+    res.writeHead(200, { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" });
+    res.end(JSON.stringify(digest));
   } else if (url.pathname === "/api/docs" && req.method === "GET") {
     recordApiHit("/api/docs");
     res.writeHead(200, { "Content-Type": "text/html; charset=utf-8" });

--- a/src/server-remote.ts
+++ b/src/server-remote.ts
@@ -13,6 +13,7 @@ import {
   fetchAuditStack,
   fetchExpiringDeals,
   fetchNewestDeals,
+  fetchWeeklyDigest,
 } from "./api-client.js";
 
 function mcpError(msg: string) {
@@ -318,6 +319,23 @@ export function createServer(): McpServer {
         return mcpText(data);
       } catch (err) {
         return mcpError(`Error getting expiring deals: ${err instanceof Error ? err.message : String(err)}`);
+      }
+    }
+  );
+
+  server.registerTool(
+    "get_weekly_digest",
+    {
+      description:
+        "Get a curated weekly summary of developer tool pricing changes, new offers, and upcoming deadlines. Use for regular check-ins on what's changed in developer pricing. Falls back to 30-day window if fewer than 3 changes in the past week.",
+      inputSchema: {},
+    },
+    async () => {
+      try {
+        const data = await fetchWeeklyDigest();
+        return mcpText(data);
+      } catch (err) {
+        return mcpError(`Error getting weekly digest: ${err instanceof Error ? err.message : String(err)}`);
       }
     }
   );

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,6 +1,6 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
-import { getCategories, getDealChanges, getNewOffers, getNewestDeals, getOfferDetails, searchOffers, enrichOffers, compareServices, checkVendorRisk, auditStack, getExpiringDeals } from "./data.js";
+import { getCategories, getDealChanges, getNewOffers, getNewestDeals, getOfferDetails, searchOffers, enrichOffers, compareServices, checkVendorRisk, auditStack, getExpiringDeals, getWeeklyDigest } from "./data.js";
 import { recordToolCall, logRequest } from "./stats.js";
 import { getStackRecommendation } from "./stacks.js";
 import { estimateCosts } from "./costs.js";
@@ -491,6 +491,41 @@ export function createServer(getSessionId?: () => string | undefined): McpServer
             {
               type: "text" as const,
               text: `Error getting expiring deals: ${err instanceof Error ? err.message : String(err)}`,
+            },
+          ],
+        };
+      }
+    }
+  );
+
+  server.registerTool(
+    "get_weekly_digest",
+    {
+      description:
+        "Get a curated weekly summary of developer tool pricing changes, new offers, and upcoming deadlines. Use for regular check-ins on what's changed in developer pricing. Falls back to 30-day window if fewer than 3 changes in the past week.",
+      inputSchema: {},
+    },
+    async () => {
+      try {
+        recordToolCall("get_weekly_digest");
+        const digest = getWeeklyDigest();
+        logRequest({ ts: new Date().toISOString(), type: "mcp", endpoint: "get_weekly_digest", params: {}, result_count: digest.deal_changes.length, session_id: getSessionId?.() });
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: JSON.stringify(digest, null, 2),
+            },
+          ],
+        };
+      } catch (err) {
+        console.error("get_weekly_digest error:", err);
+        return {
+          isError: true,
+          content: [
+            {
+              type: "text" as const,
+              text: `Error getting weekly digest: ${err instanceof Error ? err.message : String(err)}`,
             },
           ],
         };

--- a/test/deal-changes.test.ts
+++ b/test/deal-changes.test.ts
@@ -90,7 +90,7 @@ describe("get_deal_changes tool", () => {
 
       assert.ok(Array.isArray(body.changes));
       assert.strictEqual(body.total, body.changes.length);
-      assert.strictEqual(body.total, 53);
+      assert.strictEqual(body.total, 54);
     } finally {
       proc.kill();
     }

--- a/test/http.test.ts
+++ b/test/http.test.ts
@@ -797,10 +797,11 @@ describe("HTTP transport", () => {
     assert.ok(body.paths["/api/vendor-risk/{vendor}"]);
     assert.ok(body.paths["/api/audit-stack"]);
     assert.ok(body.paths["/api/expiring"]);
+    assert.ok(body.paths["/api/digest"]);
     assert.ok(body.paths["/api/newest"]);
     assert.ok(body.paths["/api/costs"]);
     assert.ok(body.paths["/feed.xml"]);
-    assert.strictEqual(Object.keys(body.paths).length, 15);
+    assert.strictEqual(Object.keys(body.paths).length, 16);
     assert.ok(body.components.schemas.Offer);
     assert.ok(body.components.schemas.DealChange);
     assert.ok(body.components.schemas.Eligibility);

--- a/test/weekly-digest.test.ts
+++ b/test/weekly-digest.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, afterEach } from "node:test";
+import assert from "node:assert";
+import { spawn, type ChildProcess } from "node:child_process";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+describe("getWeeklyDigest logic", () => {
+  it("returns a well-formed digest object", async () => {
+    const { getWeeklyDigest } = await import("../dist/data.js");
+    const digest = getWeeklyDigest();
+    assert.ok(digest.week, "should have week field");
+    assert.ok(digest.date_range, "should have date_range field");
+    assert.ok(Array.isArray(digest.deal_changes), "deal_changes should be an array");
+    assert.ok(Array.isArray(digest.new_offers), "new_offers should be an array");
+    assert.ok(Array.isArray(digest.upcoming_deadlines), "upcoming_deadlines should be an array");
+    assert.ok(typeof digest.summary === "string" && digest.summary.length > 0, "summary should be a non-empty string");
+  });
+});
+
+describe("get_weekly_digest REST endpoint", () => {
+  const PORT = 3465;
+  let proc: ChildProcess | null = null;
+
+  function startHttpServer(): Promise<ChildProcess> {
+    return new Promise((resolve, reject) => {
+      const serverPath = path.join(__dirname, "..", "dist", "serve.js");
+      const p = spawn("node", [serverPath], {
+        stdio: ["pipe", "pipe", "pipe"],
+        env: { ...process.env, PORT: String(PORT) },
+      });
+      const timeout = setTimeout(() => { p.kill(); reject(new Error("Server startup timeout")); }, 5000);
+      p.stderr!.on("data", (data: Buffer) => {
+        if (data.toString().includes("running on http")) { clearTimeout(timeout); resolve(p); }
+      });
+      p.on("error", (err) => { clearTimeout(timeout); reject(err); });
+    });
+  }
+
+  afterEach(() => {
+    if (proc) { proc.kill(); proc = null; }
+  });
+
+  it("GET /api/digest returns weekly digest", async () => {
+    proc = await startHttpServer();
+    const res = await fetch(`http://localhost:${PORT}/api/digest`);
+    assert.strictEqual(res.status, 200);
+    assert.strictEqual(res.headers.get("content-type"), "application/json");
+    assert.strictEqual(res.headers.get("access-control-allow-origin"), "*");
+    const body = await res.json() as any;
+    assert.ok(body.week);
+    assert.ok(body.date_range);
+    assert.ok(Array.isArray(body.deal_changes));
+    assert.ok(Array.isArray(body.new_offers));
+    assert.ok(Array.isArray(body.upcoming_deadlines));
+    assert.ok(typeof body.summary === "string");
+  });
+});


### PR DESCRIPTION
## Summary

Refs #265

- New `get_weekly_digest` MCP tool (tool #13) — returns curated weekly summary of deal changes, new offers, and upcoming deadlines with a one-paragraph summary
- Falls back to 30-day window when fewer than 3 changes in the past week
- New `GET /api/digest` REST endpoint (endpoint #16) with OpenAPI documentation
- Registered in both local server (server.ts) and remote API client (server-remote.ts)
- Fixed pre-existing deal change count test (53→54 after GitHub Actions pricing change)

## Test plan

- [x] 243/243 tests passing (2 new: unit test for getWeeklyDigest logic, HTTP test for /api/digest)
- [x] E2E verified: `GET /api/digest` returns well-formed JSON with week, date_range, deal_changes, new_offers, upcoming_deadlines, summary
- [x] E2E verified: `get_weekly_digest` appears in MCP `tools/list` (13 tools total)
- [x] OpenAPI spec updated with /api/digest path definition

🤖 Generated with [Claude Code](https://claude.com/claude-code)