### PR TITLE
Add 10 AI Coding tool comparison pages

### DIFF
--- a/src/serve.ts
+++ b/src/serve.ts
@@ -594,6 +594,17 @@ const COMPARISON_PAIRS: [string, string][] = [
   ["CircleCI", "GitLab CI"],
   // Auth
   ["Auth0", "Clerk"],
+  // AI Coding
+  ["Cursor", "GitHub Copilot"],
+  ["Cursor", "Windsurf"],
+  ["Amazon Q Developer", "GitHub Copilot"],
+  ["Cline", "Aider"],
+  ["Claude Code", "Cursor"],
+  ["Cursor", "Devin"],
+  ["GitHub Copilot", "Windsurf"],
+  ["Augment Code", "Cursor"],
+  ["Bolt.new", "Lovable"],
+  ["Claude Code", "OpenAI Codex"],
   // Cross-category high-interest
   ["Firebase", "Vercel"],
   ["Railway", "Supabase"],


### PR DESCRIPTION
## Summary

Refs #268

- Adds 10 AI Coding comparison matchups to the comparison page infrastructure
- **Must-have pairs:** Cursor vs GitHub Copilot, Cursor vs Windsurf, Amazon Q Developer vs GitHub Copilot, Cline vs Aider, Claude Code vs Cursor, Cursor vs Devin
- **Nice-to-have pairs:** GitHub Copilot vs Windsurf, Augment Code vs Cursor, Bolt.new vs Lovable, Claude Code vs OpenAI Codex
- All 10 pages auto-generated with side-by-side pricing, risk badges, related comparisons, and JSON-LD structured data
- "AI Coding" category section appears on /compare index page
- All new pages included in sitemap.xml
- Proper og:title meta tags (e.g., "Cursor vs GitHub Copilot Free Tier Comparison")
- Reverse URL 301 redirects work (e.g., /compare/github-copilot-vs-cursor → /compare/cursor-vs-github-copilot)
- 243 tests passing, 32 total comparison pages (was 22)

## Test plan

- [x] All 243 tests pass
- [x] E2E verified: compare index page shows AI Coding category
- [x] Individual comparison pages return 200
- [x] OG meta tags present
- [x] Sitemap includes new pages
- [x] Reverse URL 301 redirects work

🤖 Generated with [Claude Code](https://claude.com/claude-code)