### PR TITLE
Add feed URL aliases (/rss, /feed, /atom → /feed.xml)

### DIFF
--- a/src/serve.ts
+++ b/src/serve.ts
@@ -4205,6 +4205,13 @@ const httpServer = createHttpServer(async (req, res) => {
     }
   }
 
+  // Feed URL aliases — redirect common feed paths to canonical /feed.xml
+  if ((url.pathname === "/rss" || url.pathname === "/feed" || url.pathname === "/atom") && req.method === "GET") {
+    res.writeHead(301, { Location: "/feed.xml" });
+    res.end();
+    return;
+  }
+
   // Server-side page view tracking (fire-and-forget, no latency impact)
   // Track HTML page requests only — exclude API, MCP, static assets, health
   const isPagePath = req.method === "GET" && !url.pathname.startsWith("/api/") &&

--- a/test/http.test.ts
+++ b/test/http.test.ts
@@ -834,6 +834,16 @@ describe("HTTP transport", () => {
     assert.ok(body.includes("<feed xmlns="));
   });
 
+  it("GET /rss, /feed, /atom redirect 301 to /feed.xml", async () => {
+    proc = await startHttpServer();
+
+    for (const path of ["/rss", "/feed", "/atom"]) {
+      const response = await fetch(`http://localhost:${PORT}${path}`, { redirect: "manual" });
+      assert.strictEqual(response.status, 301, `${path} should 301`);
+      assert.strictEqual(response.headers.get("location"), "/feed.xml", `${path} should redirect to /feed.xml`);
+    }
+  });
+
   it("prompts/list returns all 5 prompt templates", async () => {
     proc = await startHttpServer();
 


### PR DESCRIPTION
## Summary

- 301 redirect `/rss`, `/feed`, and `/atom` to the canonical `/feed.xml` Atom feed
- Page view data showed visitors hitting these common feed discovery paths and getting 404s
- 1 new test verifying all 3 aliases redirect correctly

Refs #279

## Test plan
- [x] All 259 tests pass (258 existing + 1 new)
- [x] Verified /rss, /feed, /atom all return 301 → /feed.xml
- [x] Verified /feed.xml still serves Atom XML directly