### PR TITLE
Add automated data re-verification pipeline

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "ingest:free-for-dev": "node scripts/parse-free-for-dev.ts",
     "ingest:startup-deals": "node scripts/ingest-startup-deals.ts",
     "recategorize": "node scripts/recategorize.ts",
+    "reverify": "node scripts/reverify.js",
     "validate": "node scripts/validate-data.ts",
     "build:mcpb": "npm run build && npx mcpb pack ."
   },

--- a/scripts/reverify.js
+++ b/scripts/reverify.js
@@ -1,0 +1,184 @@
+#!/usr/bin/env node
+
+/**
+ * Automated data re-verification pipeline.
+ *
+ * Finds stale entries (verifiedDate older than threshold), checks URL
+ * reachability, and bumps verifiedDate for reachable vendors.
+ *
+ * Usage:
+ *   npm run reverify                        # re-verify entries older than 25 days
+ *   npm run reverify -- --threshold 14      # custom threshold
+ *   npm run reverify -- --dry-run           # report only, don't modify data
+ */
+
+import { readFileSync, writeFileSync } from "node:fs";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const INDEX_PATH = resolve(__dirname, "..", "data", "index.json");
+const DEFAULT_THRESHOLD_DAYS = 25;
+const CONCURRENCY = 10;
+const FETCH_TIMEOUT_MS = 15000;
+
+export function findStaleOffers(offers, thresholdDays, now = new Date()) {
+  const stale = [];
+  const fresh = [];
+  for (let i = 0; i < offers.length; i++) {
+    const offer = offers[i];
+    if (!offer.verifiedDate) {
+      stale.push({ index: i, offer });
+      continue;
+    }
+    const verified = new Date(offer.verifiedDate);
+    const diffMs = now.getTime() - verified.getTime();
+    const diffDays = Math.floor(diffMs / (1000 * 60 * 60 * 24));
+    if (diffDays >= thresholdDays) {
+      stale.push({ index: i, offer });
+    } else {
+      fresh.push({ index: i, offer });
+    }
+  }
+  return { stale, freshCount: fresh.length };
+}
+
+async function checkUrl(url) {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+  try {
+    // Try HEAD first (lighter)
+    let res = await fetch(url, {
+      method: "HEAD",
+      signal: controller.signal,
+      headers: {
+        "User-Agent": "AgentDeals-Reverify/1.0",
+        Accept: "text/html",
+      },
+      redirect: "follow",
+    });
+    // Some servers reject HEAD — fall back to GET
+    if (res.status === 405 || res.status === 403) {
+      clearTimeout(timeout);
+      const controller2 = new AbortController();
+      const timeout2 = setTimeout(() => controller2.abort(), FETCH_TIMEOUT_MS);
+      try {
+        res = await fetch(url, {
+          method: "GET",
+          signal: controller2.signal,
+          headers: {
+            "User-Agent": "AgentDeals-Reverify/1.0",
+            Accept: "text/html",
+          },
+          redirect: "follow",
+        });
+      } finally {
+        clearTimeout(timeout2);
+      }
+    }
+    if (!res.ok) {
+      return { reachable: false, error: `HTTP ${res.status}` };
+    }
+    return { reachable: true };
+  } catch (err) {
+    const reason = err.name === "AbortError" ? "timeout" : err.message;
+    return { reachable: false, error: reason };
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+export async function reverifyBatch(entries, today) {
+  const results = { verified: [], flagged: [] };
+
+  await Promise.all(entries.map(async (entry) => {
+    const result = await checkUrl(entry.offer.url);
+    if (result.reachable) {
+      results.verified.push({ index: entry.index, vendor: entry.offer.vendor, category: entry.offer.category });
+    } else {
+      results.flagged.push({
+        index: entry.index,
+        vendor: entry.offer.vendor,
+        url: entry.offer.url,
+        error: result.error,
+      });
+    }
+  }));
+
+  return results;
+}
+
+async function main() {
+  const args = process.argv.slice(2);
+  const dryRun = args.includes("--dry-run");
+
+  const thresholdIdx = args.indexOf("--threshold");
+  const thresholdDays = thresholdIdx !== -1
+    ? parseInt(args[thresholdIdx + 1], 10)
+    : DEFAULT_THRESHOLD_DAYS;
+
+  if (isNaN(thresholdDays) || thresholdDays < 0) {
+    console.error(`Invalid threshold: ${args[thresholdIdx + 1]}. Must be a non-negative integer.`);
+    process.exit(2);
+  }
+
+  let data;
+  try {
+    data = JSON.parse(readFileSync(INDEX_PATH, "utf-8"));
+  } catch (err) {
+    console.error(`Failed to read index: ${err.message}`);
+    process.exit(2);
+  }
+
+  const offers = data.offers || [];
+  const { stale, freshCount } = findStaleOffers(offers, thresholdDays);
+
+  if (stale.length === 0) {
+    console.log(`All ${offers.length} entries verified within ${thresholdDays} days.`);
+    console.log(`Re-verified: 0 | Flagged: 0 | Already fresh: ${freshCount} | Total: ${offers.length}`);
+    process.exit(0);
+  }
+
+  console.log(`Found ${stale.length} stale entries (threshold: ${thresholdDays} days).`);
+  if (dryRun) console.log("(dry-run mode — no changes will be written)\n");
+  else console.log("");
+
+  const today = new Date().toISOString().split("T")[0]; // YYYY-MM-DD
+  let totalVerified = 0;
+  let totalFlagged = 0;
+
+  // Process in batches for concurrency control
+  for (let i = 0; i < stale.length; i += CONCURRENCY) {
+    const batch = stale.slice(i, i + CONCURRENCY);
+    const results = await reverifyBatch(batch, today);
+
+    // Update verifiedDate for reachable entries
+    if (!dryRun) {
+      for (const v of results.verified) {
+        data.offers[v.index].verifiedDate = today;
+      }
+    }
+
+    // Log flagged entries
+    for (const f of results.flagged) {
+      console.log(`  ⚠ ${f.vendor} — ${f.error} (${f.url})`);
+    }
+
+    totalVerified += results.verified.length;
+    totalFlagged += results.flagged.length;
+  }
+
+  // Write updated index
+  if (!dryRun && totalVerified > 0) {
+    writeFileSync(INDEX_PATH, JSON.stringify(data, null, 2) + "\n");
+  }
+
+  console.log(`\nRe-verified: ${totalVerified} | Flagged: ${totalFlagged} | Already fresh: ${freshCount} | Total: ${offers.length}`);
+
+  process.exit(0);
+}
+
+const isMainModule = process.argv[1] && resolve(process.argv[1]) === resolve(fileURLToPath(import.meta.url));
+if (isMainModule) {
+  main();
+}

--- a/test/reverify.test.ts
+++ b/test/reverify.test.ts
@@ -1,0 +1,74 @@
+import { describe, it } from "node:test";
+import assert from "node:assert";
+
+const { findStaleOffers, reverifyBatch } = await import("../scripts/reverify.js");
+
+describe("reverify pipeline", () => {
+  const now = new Date("2026-03-16T00:00:00Z");
+
+  it("skips fresh entries", () => {
+    const offers = [
+      { vendor: "Fresh", category: "Hosting", url: "https://example.com", verifiedDate: "2026-03-10" },
+      { vendor: "AlsoFresh", category: "CI/CD", url: "https://example.com", verifiedDate: "2026-03-15" },
+    ];
+    const { stale, freshCount } = findStaleOffers(offers, 25, now);
+    assert.strictEqual(stale.length, 0);
+    assert.strictEqual(freshCount, 2);
+  });
+
+  it("identifies stale entries beyond threshold", () => {
+    const offers = [
+      { vendor: "Fresh", category: "Hosting", url: "https://example.com", verifiedDate: "2026-03-10" },
+      { vendor: "Stale", category: "Databases", url: "https://example.com", verifiedDate: "2026-02-01" },
+      { vendor: "VeryStale", category: "CI/CD", url: "https://example.com", verifiedDate: "2025-12-01" },
+    ];
+    const { stale, freshCount } = findStaleOffers(offers, 25, now);
+    assert.strictEqual(stale.length, 2);
+    assert.strictEqual(freshCount, 1);
+    assert.strictEqual(stale[0].offer.vendor, "Stale");
+    assert.strictEqual(stale[1].offer.vendor, "VeryStale");
+  });
+
+  it("treats missing verifiedDate as stale", () => {
+    const offers = [
+      { vendor: "NoDate", category: "Auth", url: "https://example.com" },
+    ];
+    const { stale } = findStaleOffers(offers, 25, now);
+    assert.strictEqual(stale.length, 1);
+    assert.strictEqual(stale[0].offer.vendor, "NoDate");
+  });
+
+  it("respects custom threshold parameter", () => {
+    const offers = [
+      { vendor: "A", category: "Hosting", url: "https://example.com", verifiedDate: "2026-03-10" },
+      { vendor: "B", category: "Hosting", url: "https://example.com", verifiedDate: "2026-03-14" },
+    ];
+    // threshold=5: A is 6 days old (stale), B is 2 days old (fresh)
+    const { stale, freshCount } = findStaleOffers(offers, 5, now);
+    assert.strictEqual(stale.length, 1);
+    assert.strictEqual(stale[0].offer.vendor, "A");
+    assert.strictEqual(freshCount, 1);
+  });
+
+  it("preserves original index for data updates", () => {
+    const offers = [
+      { vendor: "Fresh", category: "A", url: "https://example.com", verifiedDate: "2026-03-15" },
+      { vendor: "Stale", category: "B", url: "https://example.com", verifiedDate: "2026-01-01" },
+      { vendor: "AlsoStale", category: "C", url: "https://example.com", verifiedDate: "2026-01-15" },
+    ];
+    const { stale } = findStaleOffers(offers, 25, now);
+    assert.strictEqual(stale[0].index, 1);
+    assert.strictEqual(stale[1].index, 2);
+  });
+
+  it("flags unreachable URLs in batch", async () => {
+    const entries = [
+      { index: 0, offer: { vendor: "Bad", url: "http://localhost:19999/nonexistent", category: "Test" } },
+    ];
+    const results = await reverifyBatch(entries, "2026-03-16");
+    assert.strictEqual(results.flagged.length, 1);
+    assert.strictEqual(results.verified.length, 0);
+    assert.strictEqual(results.flagged[0].vendor, "Bad");
+    assert.ok(results.flagged[0].error);
+  });
+});


### PR DESCRIPTION
## Summary

- New `scripts/reverify.js` finds stale entries (verifiedDate older than threshold), checks URL reachability (HEAD → GET fallback, 15s timeout), and bumps verifiedDate for reachable vendors
- Supports `--threshold <days>` (default 25) and `--dry-run` flags
- Concurrent requests capped at 10 (matching monitor-pricing.js pattern)
- Unreachable URLs flagged with vendor name, URL, and error — not updated
- Summary output: "Re-verified: X | Flagged: Y | Already fresh: Z | Total: N"
- 6 new tests (265 total): fresh skip, stale detection, missing date, threshold param, index preservation, unreachable URL flagging
- npm script: `npm run reverify`

Refs #281