### PR TITLE
Update all URLs from Railway subdomain to agentdeals.dev

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,7 +1,7 @@
 {
   "mcpServers": {
     "agentdeals": {
-      "url": "https://agentdeals-production.up.railway.app/mcp"
+      "url": "https://agentdeals.dev/mcp"
     }
   }
 }

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ An MCP server that aggregates free tiers, startup credits, and developer tool de
 
 AgentDeals indexes real, verified pricing data from 1,500+ developer infrastructure vendors across 53 categories. Available on [npm](https://www.npmjs.com/package/agentdeals) for local use or as a hosted remote server. Connect any MCP-compatible client and search deals by keyword, category, or eligibility.
 
-**Live:** [agentdeals-production.up.railway.app](https://agentdeals-production.up.railway.app)
+**Live:** [agentdeals.dev](https://agentdeals.dev)
 
 ## Install
 
@@ -54,7 +54,7 @@ Connect to the hosted instance — no install required:
 {
   "mcpServers": {
     "agentdeals": {
-      "url": "https://agentdeals-production.up.railway.app/mcp"
+      "url": "https://agentdeals.dev/mcp"
     }
   }
 }
@@ -114,7 +114,7 @@ Add to `claude_desktop_config.json`:
 {
   "mcpServers": {
     "agentdeals": {
-      "url": "https://agentdeals-production.up.railway.app/mcp"
+      "url": "https://agentdeals.dev/mcp"
     }
   }
 }
@@ -145,7 +145,7 @@ Add to `.cursor/mcp.json` in your project or global config:
 {
   "mcpServers": {
     "agentdeals": {
-      "url": "https://agentdeals-production.up.railway.app/mcp"
+      "url": "https://agentdeals.dev/mcp"
     }
   }
 }
@@ -174,7 +174,7 @@ Add to `.vscode/mcp.json` in your workspace:
   "servers": {
     "agentdeals": {
       "type": "http",
-      "url": "https://agentdeals-production.up.railway.app/mcp"
+      "url": "https://agentdeals.dev/mcp"
     }
   }
 }
@@ -202,7 +202,7 @@ Add to `.mcp.json` in your project root:
   "mcpServers": {
     "agentdeals": {
       "type": "url",
-      "url": "https://agentdeals-production.up.railway.app/mcp"
+      "url": "https://agentdeals.dev/mcp"
     }
   }
 }
@@ -216,16 +216,16 @@ AgentDeals also provides a REST API for programmatic access without MCP.
 
 ```bash
 # Search by keyword
-curl "https://agentdeals-production.up.railway.app/api/offers?q=database&limit=5"
+curl "https://agentdeals.dev/api/offers?q=database&limit=5"
 
 # Filter by category
-curl "https://agentdeals-production.up.railway.app/api/offers?category=Databases&limit=10"
+curl "https://agentdeals.dev/api/offers?category=Databases&limit=10"
 
 # Paginate results
-curl "https://agentdeals-production.up.railway.app/api/offers?limit=20&offset=40"
+curl "https://agentdeals.dev/api/offers?limit=20&offset=40"
 
 # Combine search + category
-curl "https://agentdeals-production.up.railway.app/api/offers?q=postgres&category=Databases"
+curl "https://agentdeals.dev/api/offers?q=postgres&category=Databases"
 ```
 
 Response:
@@ -248,7 +248,7 @@ Response:
 ### List categories
 
 ```bash
-curl "https://agentdeals-production.up.railway.app/api/categories"
+curl "https://agentdeals.dev/api/categories"
 ```
 
 Response:
@@ -266,34 +266,34 @@ Response:
 
 ```bash
 # Recently added offers
-curl "https://agentdeals-production.up.railway.app/api/new?days=7"
+curl "https://agentdeals.dev/api/new?days=7"
 
 # Pricing changes
-curl "https://agentdeals-production.up.railway.app/api/changes?since=2025-01-01"
+curl "https://agentdeals.dev/api/changes?since=2025-01-01"
 
 # Vendor details
-curl "https://agentdeals-production.up.railway.app/api/details/Supabase?alternatives=true"
+curl "https://agentdeals.dev/api/details/Supabase?alternatives=true"
 
 # Stack recommendation
-curl "https://agentdeals-production.up.railway.app/api/stack?use_case=saas"
+curl "https://agentdeals.dev/api/stack?use_case=saas"
 
 # Cost estimation
-curl "https://agentdeals-production.up.railway.app/api/costs?services=Vercel,Supabase&scale=startup"
+curl "https://agentdeals.dev/api/costs?services=Vercel,Supabase&scale=startup"
 
 # Compare vendors
-curl "https://agentdeals-production.up.railway.app/api/compare?a=Supabase&b=Neon"
+curl "https://agentdeals.dev/api/compare?a=Supabase&b=Neon"
 
 # Vendor risk check
-curl "https://agentdeals-production.up.railway.app/api/vendor-risk/Heroku"
+curl "https://agentdeals.dev/api/vendor-risk/Heroku"
 
 # Stack audit
-curl "https://agentdeals-production.up.railway.app/api/audit-stack?services=Vercel,Supabase,Clerk"
+curl "https://agentdeals.dev/api/audit-stack?services=Vercel,Supabase,Clerk"
 
 # Server stats
-curl "https://agentdeals-production.up.railway.app/api/stats"
+curl "https://agentdeals.dev/api/stats"
 
 # OpenAPI spec
-curl "https://agentdeals-production.up.railway.app/api/openapi.json"
+curl "https://agentdeals.dev/api/openapi.json"
 ```
 
 ## Available Tools
@@ -422,7 +422,7 @@ npm run serve
 | Variable | Description | Default |
 |----------|-------------|---------|
 | `PORT` | HTTP server port | `3000` |
-| `BASE_URL` | Base URL for canonical links, OG tags, sitemaps, and feeds | `https://agentdeals-production.up.railway.app` |
+| `BASE_URL` | Base URL for canonical links, OG tags, sitemaps, and feeds | `https://agentdeals.dev` |
 | `GOOGLE_SITE_VERIFICATION` | Google Search Console verification code | _(none)_ |
 
 ## Stats

--- a/manifest.json
+++ b/manifest.json
@@ -13,7 +13,7 @@
     "type": "git",
     "url": "https://github.com/robhunter/agentdeals"
   },
-  "homepage": "https://agentdeals-production.up.railway.app",
+  "homepage": "https://agentdeals.dev",
   "icon": "assets/logo-400.png",
   "keywords": [
     "mcp",

--- a/server.json
+++ b/server.json
@@ -10,7 +10,7 @@
   "remotes": [
     {
       "type": "streamable-http",
-      "url": "https://agentdeals-production.up.railway.app/mcp"
+      "url": "https://agentdeals.dev/mcp"
     }
   ]
 }

--- a/src/api-client.ts
+++ b/src/api-client.ts
@@ -1,4 +1,4 @@
-const DEFAULT_BASE_URL = "https://agentdeals-production.up.railway.app";
+const DEFAULT_BASE_URL = "https://agentdeals.dev";
 const TIMEOUT_MS = 10_000;
 
 export function getBaseUrl(): string {

--- a/src/openapi.ts
+++ b/src/openapi.ts
@@ -6,7 +6,7 @@ export const openapiSpec = {
     version: "0.1.0",
     contact: {
       name: "AgentDeals",
-      url: "https://agentdeals-production.up.railway.app"
+      url: "https://agentdeals.dev"
     },
     license: {
       name: "MIT",
@@ -15,7 +15,7 @@ export const openapiSpec = {
   },
   servers: [
     {
-      url: "https://agentdeals-production.up.railway.app",
+      url: "https://agentdeals.dev",
       description: "Production server"
     }
   ],

--- a/src/serve.ts
+++ b/src/serve.ts
@@ -15,7 +15,7 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
 const PORT = parseInt(process.env.PORT ?? "3000", 10);
-const BASE_URL = (process.env.BASE_URL ?? "https://agentdeals-production.up.railway.app").replace(/\/+$/, "");
+const BASE_URL = (process.env.BASE_URL ?? "https://agentdeals.dev").replace(/\/+$/, "");
 
 const GOOGLE_VERIFICATION_META = process.env.GOOGLE_SITE_VERIFICATION
   ? `<meta name="google-site-verification" content="${process.env.GOOGLE_SITE_VERIFICATION}">\n` : "";


### PR DESCRIPTION
Replace all instances of `agentdeals-production.up.railway.app` with `agentdeals.dev` across the codebase.

**Files updated:**
- README.md (25+ references — live URL, MCP config examples, curl examples, BASE_URL default)
- server.json (registry URL)
- manifest.json (homepage URL)
- .mcp.json (default server URL)
- src/serve.ts (fallback BASE_URL)
- src/openapi.ts (OpenAPI spec server URL + contact URL)
- src/api-client.ts (API client default URL)

**Verified:** Zero remaining references to Railway subdomain. All 265 tests pass.

Refs #283