### PR TITLE
Fix stale '12 MCP Tools' on landing page

### DIFF
--- a/src/serve.ts
+++ b/src/serve.ts
@@ -2562,7 +2562,7 @@ ${OG_IMAGE_META}${GOOGLE_VERIFICATION_META}<link rel="icon" type="image/png" hre
   <div class="breadcrumb"><a href="/">AgentDeals</a> &rsaquo; Setup</div>
 
   <h1>Setup Guide</h1>
-  <p class="page-sub">Add AgentDeals to your AI coding assistant. 12 MCP tools for searching deals, comparing vendors, estimating costs, and auditing your stack.</p>
+  <p class="page-sub">Add AgentDeals to your AI coding assistant. 4 MCP tools for searching deals, comparing vendors, planning stacks, and tracking changes.</p>
 
   <div class="quick-start">
     <h3>Quick start</h3>
@@ -3925,7 +3925,7 @@ ${buildRecentChangesSection()}
     </div>
 
     <div class="connect-block" style="margin-top:1.5rem">
-      <h3 style="font-family:var(--serif);font-size:1rem;color:var(--text);margin-bottom:.75rem">12 MCP Tools</h3>
+      <h3 style="font-family:var(--serif);font-size:1rem;color:var(--text);margin-bottom:.75rem">4 MCP Tools</h3>
       <div style="display:grid;gap:.5rem">
         <div style="font-size:.85rem"><code style="font-family:var(--mono);color:var(--accent)">search_deals</code> <span style="color:var(--text-muted)">&mdash; Find free tiers, browse categories, get vendor details with alternatives. Filter by category, eligibility, or keyword.</span></div>
         <div style="font-size:.85rem"><code style="font-family:var(--mono);color:var(--accent)">plan_stack</code> <span style="color:var(--text-muted)">&mdash; Get stack recommendations, cost estimates, or a full infrastructure audit for your project.</span></div>


### PR DESCRIPTION
Refs #289

## Summary
- Updated '12 MCP tools' → '4 MCP tools' in two places on the landing page (setup guide subtitle and tools section heading)
- Updated tool description text to match the 4 consolidated tools (search_deals, plan_stack, compare_vendors, track_changes)
- Verified no other stale tool counts remain in serve.ts

## Test plan
- [x] All 266 tests pass
- [x] Grep confirms no remaining stale MCP tool counts in serve.ts