### PR TITLE
Bump server.json version to 0.2.0

### DIFF
--- a/server.json
+++ b/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.robhunter/agentdeals",
   "description": "MCP server aggregating developer infrastructure deals, free tiers, and startup programs",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "repository": {
     "url": "https://github.com/robhunter/agentdeals",
     "source": "github"


### PR DESCRIPTION
## Summary
- Bumps `server.json` version from `0.1.0` to `0.2.0` to match `package.json`
- Fixes `mcp-publisher publish` error: "cannot publish duplicate version" — v0.1.0 was already published to registry.modelcontextprotocol.io

## Test plan
- [ ] Merge this PR
- [ ] Run `mcp-publisher publish` — should succeed and list AgentDeals on the MCP Community Registry
- [ ] Verify listing at registry.modelcontextprotocol.io

🤖 Generated with [Claude Code](https://claude.com/claude-code)