### PR TITLE
Redirect /api to /api/docs

### DIFF
--- a/src/serve.ts
+++ b/src/serve.ts
@@ -4779,6 +4779,9 @@ const httpServer = createHttpServer(async (req, res) => {
     logRequest({ ts: new Date().toISOString(), type: "api", endpoint: "/api/digest", params: {}, user_agent: req.headers["user-agent"] ?? "unknown", result_count: digest.deal_changes.length });
     res.writeHead(200, { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" });
     res.end(JSON.stringify(digest));
+  } else if (url.pathname === "/api" && req.method === "GET") {
+    res.writeHead(301, { "Location": "/api/docs" });
+    res.end();
   } else if (url.pathname === "/api/docs" && req.method === "GET") {
     recordApiHit("/api/docs");
     res.writeHead(200, { "Content-Type": "text/html; charset=utf-8" });

--- a/test/http.test.ts
+++ b/test/http.test.ts
@@ -808,6 +808,14 @@ describe("HTTP transport", () => {
     assert.ok(body.components.schemas.Eligibility);
   });
 
+  it("GET /api redirects to /api/docs", async () => {
+    proc = await startHttpServer();
+
+    const response = await fetch(`http://localhost:${PORT}/api`, { redirect: "manual" });
+    assert.strictEqual(response.status, 301);
+    assert.strictEqual(response.headers.get("location"), "/api/docs");
+  });
+
   it("GET /feed.xml returns valid Atom XML", async () => {
     proc = await startHttpServer();
 


### PR DESCRIPTION
## Summary
- `GET /api` now returns 301 redirect to `/api/docs` (Swagger UI)
- Previously returned 404 JSON error
- 1 new test (269 total)

Refs #300