### PR TITLE
Add zod as explicit dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,8 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.0.0",
-    "swagger-ui-dist": "^5.32.0"
+    "swagger-ui-dist": "^5.32.0",
+    "zod": "^3.25.0"
   },
   "devDependencies": {
     "@anthropic-ai/mcpb": "^2.1.2",


### PR DESCRIPTION
## Summary
- Adds `zod` as an explicit dependency in `package.json`
- Fixes Glama build failure: `Cannot find module 'zod'`

`zod` is imported directly in `server.ts` and `server-remote.ts` but was only available as a transitive dep via `@modelcontextprotocol/sdk`. This works with npm (hoists transitive deps) but fails with pnpm (strict isolation), which is what Glama's Docker builder uses.

## Test plan
- [ ] Merge and retry Glama build at https://glama.ai/mcp/servers/robhunter/agentdeals/admin/dockerfile
- [ ] Verify build succeeds and release can be created

🤖 Generated with [Claude Code](https://claude.com/claude-code)