### PR TITLE
Fix build:mcpb script package name

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "recategorize": "node scripts/recategorize.ts",
     "reverify": "node scripts/reverify.js",
     "validate": "node scripts/validate-data.ts",
-    "build:mcpb": "npm run build && npx mcpb pack ."
+    "build:mcpb": "npm run build && npx @anthropic-ai/mcpb pack ."
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.0.0",


### PR DESCRIPTION
## Summary
- Updates `build:mcpb` script from `npx mcpb pack .` to `npx @anthropic-ai/mcpb pack .`
- The old `mcpb` package name returns 404 from npm registry

## Test plan
- [ ] Run `npm run build:mcpb` — should produce a `.mcpb` file

🤖 Generated with [Claude Code](https://claude.com/claude-code)