### PR TITLE
Fix package-lock.json sync for zod dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,8 @@
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.0",
-        "swagger-ui-dist": "^5.32.0"
+        "swagger-ui-dist": "^5.32.0",
+        "zod": "^3.25.0"
       },
       "bin": {
         "agentdeals": "dist/index.js"
@@ -44,16 +45,6 @@
       },
       "bin": {
         "mcpb": "dist/cli/cli.js"
-      }
-    },
-    "node_modules/@anthropic-ai/mcpb/node_modules/zod": {
-      "version": "3.25.76",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/@cspotcode/source-map-support": {
@@ -1997,9 +1988,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "4.3.6",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
-      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"


### PR DESCRIPTION
## Summary
- Regenerates `package-lock.json` after `zod` was added to `package.json` in #304
- Fixes Railway deploy failures (`npm ci` requires lockfile in sync)

## Test plan
- [ ] Merge and verify Railway deploy succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)