### PR TITLE
Add /terraform-alternatives page for HCP Terraform March 31 EOL

### DIFF
--- a/data/index.json
+++ b/data/index.json
@@ -2470,7 +2470,8 @@
         "iac",
         "devops",
         "cloud",
-        "free tier"
+        "free tier",
+        "terraform-alternative"
       ],
       "verifiedDate": "2026-02-26"
     },
@@ -2485,7 +2486,8 @@
         "iac",
         "devops",
         "terraform",
-        "free tier"
+        "free tier",
+        "terraform-alternative"
       ],
       "verifiedDate": "2026-02-26"
     },
@@ -5530,7 +5532,8 @@
         "infrastructure",
         "cloud",
         "management",
-        "free-for-dev"
+        "free-for-dev",
+        "terraform-alternative"
       ],
       "verifiedDate": "2026-03-02"
     },
@@ -5572,7 +5575,8 @@
         "infrastructure",
         "cloud",
         "management",
-        "free-for-dev"
+        "free-for-dev",
+        "terraform-alternative"
       ],
       "verifiedDate": "2026-03-02"
     },
@@ -5587,7 +5591,8 @@
         "terraform",
         "gitops",
         "infrastructure",
-        "devops"
+        "devops",
+        "terraform-alternative"
       ],
       "verifiedDate": "2026-03-04"
     },
@@ -8597,7 +8602,8 @@
         "ci",
         "cd",
         "continuous-integration",
-        "free-for-dev"
+        "free-for-dev",
+        "terraform-alternative"
       ],
       "verifiedDate": "2026-03-02"
     },
@@ -8611,7 +8617,8 @@
         "ci",
         "cd",
         "continuous-integration",
-        "free-for-dev"
+        "free-for-dev",
+        "terraform-alternative"
       ],
       "verifiedDate": "2026-03-02"
     },
@@ -20948,7 +20955,8 @@
         "scanning",
         "terraform",
         "kubernetes",
-        "open-source"
+        "open-source",
+        "terraform-alternative"
       ],
       "verifiedDate": "2026-03-03"
     },

--- a/src/serve.ts
+++ b/src/serve.ts
@@ -2364,6 +2364,15 @@ const ALTERNATIVES_PAGES: AlternativesPageConfig[] = [
     tag: "postman-alternative",
     primaryVendor: "Postman",
   },
+  {
+    slug: "terraform-alternatives",
+    title: "HCP Terraform Alternatives — Free IaC Tools After the March 2026 EOL",
+    metaDesc: "HCP Terraform legacy free plan ends March 31, 2026. Compare free alternatives: Spacelift, Terragrunt Scale, Pulumi, Scalr, and more. Verified pricing and free tier details.",
+    contextHtml: `<p>HCP Terraform's legacy free plan reaches <strong>end-of-life on March 31, 2026</strong>. Organizations on the legacy plan will be auto-transitioned to an enhanced free tier — but with a <strong>500 managed resource cap</strong> (previously unlimited for small teams).</p>
+      <p>This isn't a complete shutdown — the new enhanced tier includes SSO, policy as code, and unlimited users. But if the 500-resource limit doesn't fit your workloads, here are free IaC alternatives worth evaluating.</p>`,
+    tag: "terraform-alternative",
+    primaryVendor: "HCP Terraform",
+  },
 ];
 
 const alternativesPageMap = new Map<string, AlternativesPageConfig>();

--- a/test/http.test.ts
+++ b/test/http.test.ts
@@ -1344,6 +1344,21 @@ describe("HTTP transport", () => {
     assert.ok(html.includes("single-user only"), "Should mention the restriction");
   });
 
+  it("GET /terraform-alternatives renders alternatives page", async () => {
+    proc = await startHttpServer();
+
+    const response = await fetch(`http://localhost:${PORT}/terraform-alternatives`);
+    assert.strictEqual(response.status, 200);
+    assert.ok(response.headers.get("content-type")?.includes("text/html"));
+    const html = await response.text();
+    assert.ok(html.includes("HCP Terraform Alternatives"), "Should have Terraform title");
+    assert.ok(html.includes("application/ld+json"), "Should have JSON-LD");
+    assert.ok(html.includes("canonical"), "Should have canonical link");
+    assert.ok(html.includes("global-nav"), "Should have global nav");
+    assert.ok(html.includes("Top Alternatives"), "Should have alternatives section");
+    assert.ok(html.includes("March 31, 2026"), "Should mention the EOL date");
+  });
+
   // --- Search page ---
 
   it("GET /search renders search page with search box", async () => {


### PR DESCRIPTION
## Summary

- Adds `/terraform-alternatives` page targeting HCP Terraform legacy free plan EOL (March 31, 2026)
- Tags 8 IaC alternatives with `terraform-alternative`: Spacelift, Pulumi, Terragrunt Scale, scalr.com, Brainboard, Terramate, Terrateam, Checkov
- Context explains the nuance: not a shutdown, but transition to enhanced free tier with 500 managed resource cap
- Automatically included in sitemap via `ALTERNATIVES_PAGES` array
- 1 new test (272 total, all passing)

## Test plan

- [x] All 272 tests pass
- [x] E2E verified: page renders at `/terraform-alternatives` with correct title, alternatives, and EOL date
- [x] Sitemap includes the new page
- [x] All 8 tagged alternatives appear on the page
- [x] Build succeeds (`npx tsc`)

Refs #315