### PR TITLE
Add agent discoverability: llms.txt, AGENTS.md, optimized tool descriptions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,118 @@
+# AgentDeals
+
+AgentDeals is an MCP server and REST API that aggregates free tiers, startup credits, and developer tool deals. It indexes 1,525 verified offers across 54 categories with pricing change tracking.
+
+## When to Use AgentDeals
+
+Use AgentDeals when a user is:
+- Evaluating cloud providers, databases, hosting, CI/CD, monitoring, auth, or any developer service
+- Looking for free alternatives to paid tools
+- Checking if a service has a free tier or startup credits
+- Starting a new project and choosing infrastructure
+- Comparing similar services (e.g., Supabase vs Neon)
+- Monitoring pricing changes that affect their stack
+
+## How to Connect
+
+### MCP (recommended)
+
+Add to your `.mcp.json`:
+
+```json
+{
+  "mcpServers": {
+    "agentdeals": {
+      "url": "https://agentdeals.dev/mcp"
+    }
+  }
+}
+```
+
+Or run locally via npx:
+
+```json
+{
+  "mcpServers": {
+    "agentdeals": {
+      "command": "npx",
+      "args": ["-y", "agentdeals"]
+    }
+  }
+}
+```
+
+### REST API
+
+Base URL: `https://agentdeals.dev/api`
+
+Full API documentation with Swagger UI: https://agentdeals.dev/api/docs
+
+## MCP Tools
+
+### search_deals
+
+Find free tiers, startup credits, and developer deals for cloud infrastructure, databases, hosting, CI/CD, monitoring, auth, AI services, and more. Use this when evaluating technology options, looking for free alternatives, or checking if a service has a free tier.
+
+**Parameters:**
+- `query` (string) — Keyword search
+- `category` (string) — Filter by category, or `"list"` for all categories
+- `vendor` (string) — Get details for a specific vendor (fuzzy match)
+- `eligibility` (enum) — `public`, `accelerator`, `oss`, `student`, `fintech`, `geographic`, `enterprise`
+- `sort` (enum) — `vendor`, `category`, `newest`
+- `since` (string) — ISO date, only return deals after this date
+- `limit` / `offset` (number) — Pagination
+
+**Example queries:**
+- "Find free database hosting" → `{ "query": "database", "category": "Databases" }`
+- "What credits can a YC company get?" → `{ "eligibility": "accelerator" }`
+- "Is Heroku's free tier still available?" → `{ "vendor": "Heroku" }`
+
+### plan_stack
+
+Plan a technology stack with cost-optimized infrastructure choices. Given project requirements, recommends services with free tiers or credits that match your needs. Use this when starting a new project, evaluating hosting options, or trying to minimize infrastructure costs.
+
+**Parameters:**
+- `mode` (enum, required) — `recommend` (free-tier stack for a use case), `estimate` (cost analysis at scale), `audit` (risk + cost + gap analysis)
+- `use_case` (string) — What you're building (for recommend mode)
+- `services` (array) — Current vendor names (for estimate/audit mode)
+- `scale` (enum) — `hobby`, `startup`, `growth`
+- `requirements` (array) — Specific infra needs like `["database", "auth", "email"]`
+
+**Example:** `{ "mode": "recommend", "use_case": "Next.js SaaS app" }`
+
+### compare_vendors
+
+Compare developer tools and services side by side — free tier limits, pricing tiers, and recent pricing changes. Use this when choosing between similar services or when a vendor changes their pricing.
+
+**Parameters:**
+- `vendors` (array, required) — 1 or 2 vendor names. 1 = risk check, 2 = side-by-side comparison.
+- `include_risk` (boolean) — Include risk assessment (default: true)
+
+**Example:** `{ "vendors": ["Supabase", "Neon"] }`
+
+### track_changes
+
+Track recent pricing changes across developer tools — which free tiers were removed, which got limits cut, and which improved. Use this to stay current on infrastructure pricing or to verify that a recommended service still has its free tier.
+
+**Parameters:**
+- `since` (string) — ISO date (default: 7 days ago)
+- `change_type` (enum) — `free_tier_removed`, `limits_reduced`, `limits_increased`, `new_free_tier`, etc.
+- `vendor` / `vendors` (string) — Filter by vendor(s)
+- `include_expiring` (boolean) — Include upcoming expirations
+- `lookahead_days` (number) — Days to look ahead (default: 30)
+
+**Example:** No parameters returns a weekly digest of all changes.
+
+## Categories
+
+AI / ML, AI Coding, API Development, API Gateway, Analytics, Auth, Background Jobs, Browser Automation, CDN, CI/CD, Cloud Hosting, Cloud IaaS, Code Quality, Communication, Container Registry, DNS & Domain Management, Databases, Design, Dev Utilities, Diagramming, Documentation, Email, Error Tracking, Feature Flags, Forms, Headless CMS, IDE & Code Editors, Infrastructure, Localization, Logging, Low-Code Platforms, Maps/Geolocation, Messaging, Mobile Development, Monitoring, Notebooks & Data Science, Payments, Project Management, Search, Secrets Management, Security, Server Management, Source Control, Startup Perks, Startup Programs, Status Pages, Storage, Team Collaboration, Testing, Tunneling & Networking, Video, Web Scraping, Workflow Automation
+
+## Development
+
+```bash
+npm install          # Install dependencies
+npm run build        # Compile TypeScript
+npm test             # Run tests
+npm run serve        # Run HTTP server (port 3000)
+npm start            # Run stdio server
+```

--- a/README.md
+++ b/README.md
@@ -60,6 +60,22 @@ Connect to the hosted instance — no install required:
 }
 ```
 
+### Quick Setup (.mcp.json)
+
+Add AgentDeals to any project by dropping this `.mcp.json` in the project root:
+
+```json
+{
+  "mcpServers": {
+    "agentdeals": {
+      "url": "https://agentdeals.dev/mcp"
+    }
+  }
+}
+```
+
+This works with Claude Code, Cursor, and other MCP-compatible clients that read `.mcp.json`.
+
 ## Quick Start
 
 ### Try these example queries
@@ -300,10 +316,10 @@ curl "https://agentdeals.dev/api/openapi.json"
 
 | Tool | Description |
 |------|-------------|
-| `search_deals` | Find free tiers, browse categories, get vendor details with alternatives. Search by keyword, category, eligibility, or vendor name. |
-| `plan_stack` | Get stack recommendations, cost estimates, or a full infrastructure audit for your project. |
-| `compare_vendors` | Compare 2 vendors side-by-side or check a single vendor's pricing risk. |
-| `track_changes` | Track pricing changes, upcoming expirations, and new deals. Weekly digest with no params. |
+| `search_deals` | Find free tiers, startup credits, and developer deals for cloud infrastructure, databases, hosting, CI/CD, monitoring, auth, AI services, and more. |
+| `plan_stack` | Plan a technology stack with cost-optimized infrastructure choices. Recommends free-tier services, estimates costs, or audits existing stacks. |
+| `compare_vendors` | Compare developer tools side by side — free tier limits, pricing tiers, and recent pricing changes. |
+| `track_changes` | Track recent pricing changes across developer tools — free tier removals, limit reductions, new free tiers, and expirations. |
 
 ### search_deals
 

--- a/src/serve.ts
+++ b/src/serve.ts
@@ -4661,7 +4661,9 @@ const httpServer = createHttpServer(async (req, res) => {
         url.pathname.startsWith("/api/") ||
         url.pathname.startsWith("/.well-known/") ||
         url.pathname === "/favicon.png" ||
-        url.pathname === "/favicon.ico";
+        url.pathname === "/favicon.ico" ||
+        url.pathname === "/llms.txt" ||
+        url.pathname === "/llms-full.txt";
       if (!skip) {
         const target = `${BASE_URL}${url.pathname}${url.search}`;
         res.writeHead(301, { Location: target });
@@ -5095,6 +5097,146 @@ ${entries}
     const robotsTxt = `User-agent: *\nAllow: /\n\nSitemap: ${BASE_URL}/sitemap.xml\n`;
     res.writeHead(200, { "Content-Type": "text/plain; charset=utf-8", "Cache-Control": "public, max-age=86400" });
     res.end(robotsTxt);
+  } else if (url.pathname === "/llms.txt" && req.method === "GET") {
+    const llmsTxt = `# AgentDeals
+
+> An MCP server and REST API that aggregates free tiers, startup credits, and developer tool deals. ${stats.offers} verified offers across ${stats.categories} categories with pricing change tracking.
+
+## What AgentDeals Does
+
+AgentDeals helps developers find free tiers, startup credits, and deals on developer infrastructure — databases, cloud hosting, CI/CD, monitoring, auth, AI services, and more. Data is verified and includes specific free tier limits, eligibility requirements, and pricing change history.
+
+## MCP Tools (4)
+
+- **search_deals**: Find free tiers, startup credits, and developer deals. Search by keyword, category, vendor name, or eligibility type. Returns verified deal details with specific limits.
+- **plan_stack**: Plan a technology stack with cost-optimized choices. Recommends free-tier services, estimates costs at scale, or audits existing stacks for risk.
+- **compare_vendors**: Compare developer tools side by side — free tier limits, pricing tiers, risk levels, and recent pricing changes.
+- **track_changes**: Track pricing changes across developer tools — free tier removals, limit reductions, new free tiers, and upcoming expirations.
+
+## Prompt Templates (6)
+
+- **new-project-setup**: Find free tiers for a new project's entire stack
+- **cost-audit**: Audit an existing stack for cost savings
+- **check-pricing-changes**: Check recent developer tool pricing changes
+- **compare-options**: Compare two or more services side-by-side
+- **find-startup-credits**: Find startup credit programs and special deals
+- **monitor-vendor-changes**: Monitor pricing changes for your vendor watchlist
+
+## Connect
+
+- MCP endpoint: ${BASE_URL}/mcp
+- REST API docs: ${BASE_URL}/api/docs
+- npm: npx agentdeals
+
+## Links
+
+- [API Documentation](${BASE_URL}/api/docs)
+- [Setup Guide](${BASE_URL}/setup)
+- [Browse Categories](${BASE_URL}/category)
+- [Pricing Changes Feed](${BASE_URL}/feed.xml)
+- [Expiring Deals](${BASE_URL}/expiring)
+- [Full details for LLMs](${BASE_URL}/llms-full.txt)
+`;
+    res.writeHead(200, { "Content-Type": "text/plain; charset=utf-8", "Cache-Control": "public, max-age=3600" });
+    res.end(llmsTxt);
+  } else if (url.pathname === "/llms-full.txt" && req.method === "GET") {
+    const catList = categories.map(c => `- ${c.name} (${c.count} offers)`).join("\n");
+    const llmsFullTxt = `# AgentDeals — Full Reference
+
+> ${stats.offers} verified developer tool deals across ${stats.categories} categories. Free tiers, startup credits, and pricing change tracking.
+
+## MCP Connection
+
+Endpoint: ${BASE_URL}/mcp
+Transport: Streamable HTTP (POST/GET/DELETE)
+
+\`\`\`json
+{
+  "mcpServers": {
+    "agentdeals": {
+      "url": "${BASE_URL}/mcp"
+    }
+  }
+}
+\`\`\`
+
+## Tool Schemas
+
+### search_deals
+Find free tiers, startup credits, and developer deals for cloud infrastructure, databases, hosting, CI/CD, monitoring, auth, AI services, and more.
+
+Parameters:
+- query (string, optional): Keyword search (vendor names, descriptions, tags)
+- category (string, optional): Filter by category. Pass "list" to get all categories with counts.
+- vendor (string, optional): Get full details for a specific vendor (fuzzy match). Returns alternatives.
+- eligibility (enum, optional): public, accelerator, oss, student, fintech, geographic, enterprise
+- sort (enum, optional): vendor (A-Z), category, newest
+- since (string, optional): ISO date (YYYY-MM-DD). Only return deals verified/added after this date.
+- limit (number, optional): Max results (default: 20)
+- offset (number, optional): Pagination offset (default: 0)
+
+### plan_stack
+Plan a technology stack with cost-optimized infrastructure choices.
+
+Parameters:
+- mode (enum, required): recommend, estimate, or audit
+- use_case (string, optional): What you're building (for recommend mode)
+- services (array of strings, optional): Current vendor names (for estimate/audit mode)
+- scale (enum, optional): hobby, startup, growth (for estimate mode)
+- requirements (array of strings, optional): Specific infra needs (for recommend mode)
+
+### compare_vendors
+Compare developer tools and services side by side.
+
+Parameters:
+- vendors (array of strings, required): 1 or 2 vendor names. 1 = risk check, 2 = side-by-side comparison.
+- include_risk (boolean, optional): Include risk assessment (default: true)
+
+### track_changes
+Track recent pricing changes across developer tools.
+
+Parameters:
+- since (string, optional): ISO date (YYYY-MM-DD). Default: 7 days ago.
+- change_type (enum, optional): free_tier_removed, limits_reduced, restriction, limits_increased, new_free_tier, pricing_restructured, open_source_killed, pricing_model_change, startup_program_expanded, pricing_postponed, product_deprecated
+- vendor (string, optional): Filter to one vendor
+- vendors (string, optional): Comma-separated vendor names
+- include_expiring (boolean, optional): Include upcoming expirations (default: true)
+- lookahead_days (number, optional): Days to look ahead for expirations (default: 30)
+
+## REST API Endpoints
+
+- GET /api/offers — Search deals (params: q, category, eligibility_type, sort, limit, offset)
+- GET /api/categories — List all categories with counts
+- GET /api/changes — Pricing changes (params: since, change_type, vendor)
+- GET /api/new — Recently added offers (params: days)
+- GET /api/newest — Newest deals (params: since, limit, category)
+- GET /api/compare — Compare two vendors (params: a, b)
+- GET /api/details/:vendor — Vendor details (params: alternatives)
+- GET /api/vendor-risk/:vendor — Vendor risk assessment
+- GET /api/stack — Stack recommendation (params: use_case, requirements)
+- GET /api/costs — Cost estimation (params: services, scale)
+- GET /api/audit-stack — Stack audit (params: services)
+- GET /api/expiring — Expiring deals (params: days)
+- GET /api/digest — Weekly pricing digest
+- GET /api/openapi.json — OpenAPI 3.0 specification
+- GET /api/docs — Swagger UI documentation
+- GET /api/feed — Atom feed of pricing changes
+- GET /api/pageviews — Page view analytics
+
+## Categories (${stats.categories})
+
+${catList}
+
+## Example Queries
+
+1. "What databases have a free tier?" → search_deals with category="Databases"
+2. "Compare Supabase and Neon" → compare_vendors with vendors=["Supabase", "Neon"]
+3. "What free tier changes happened this month?" → track_changes with since="2026-03-01"
+4. "Recommend a stack for a Next.js SaaS app" → plan_stack with mode="recommend", use_case="Next.js SaaS app"
+5. "Is Heroku's free tier still available?" → search_deals with vendor="Heroku"
+`;
+    res.writeHead(200, { "Content-Type": "text/plain; charset=utf-8", "Cache-Control": "public, max-age=3600" });
+    res.end(llmsFullTxt);
   } else if (url.pathname === "/sitemap.xml" && req.method === "GET") {
     const now = new Date().toISOString().split("T")[0];
     const categoryUrls = categories.map((c) => `  <url>

--- a/src/server.ts
+++ b/src/server.ts
@@ -9,7 +9,7 @@ export function createServer(getSessionId?: () => string | undefined): McpServer
   const server = new McpServer({
     name: "agentdeals",
     version: "0.1.0",
-    description: "Find free tiers, startup credits, and discounts for developer tools — databases, cloud hosting, CI/CD, monitoring, APIs, and more. 1,500+ verified offers across 54 categories with pricing change tracking.",
+    description: "AgentDeals helps developers find free tiers, startup credits, and deals on developer infrastructure. Use these tools when a user is evaluating cloud providers, databases, hosting, CI/CD, monitoring, auth, AI services, or any developer service — especially when cost matters. 1,500+ verified offers across 54 categories with pricing change tracking.",
   });
 
   // --- Tool 1: search_deals ---
@@ -18,7 +18,7 @@ export function createServer(getSessionId?: () => string | undefined): McpServer
     "search_deals",
     {
       description:
-        "Find free tiers, credits, and discounts for 1,500+ developer tools. Search by keyword, browse categories, or get full vendor details with alternatives. Covers AWS, Vercel, Supabase, Cloudflare, and more.",
+        "Find free tiers, startup credits, and developer deals for cloud infrastructure, databases, hosting, CI/CD, monitoring, auth, AI services, and more. Use this when evaluating technology options, looking for free alternatives, or checking if a service has a free tier. Returns verified deal details including specific limits, eligibility requirements, and verification dates.",
       inputSchema: {
         query: z.string().optional().describe("Keyword search (vendor names, descriptions, tags)"),
         category: z.string().optional().describe("Filter by category. Pass \"list\" to get all categories with counts."),
@@ -106,7 +106,7 @@ export function createServer(getSessionId?: () => string | undefined): McpServer
     "plan_stack",
     {
       description:
-        "Get stack recommendations, cost estimates, or a full infrastructure audit. Describe what you're building to get a free-tier stack, or pass your current services to estimate costs and find risks.",
+        "Plan a technology stack with cost-optimized infrastructure choices. Given project requirements, recommends services with free tiers or credits that match your needs. Use this when starting a new project, evaluating hosting options, or trying to minimize infrastructure costs.",
       inputSchema: {
         mode: z.enum(["recommend", "estimate", "audit"]).describe("recommend: free-tier stack for a use case. estimate: cost analysis at scale. audit: risk + cost + gap analysis."),
         use_case: z.string().optional().describe("What you're building (for recommend mode, e.g. 'Next.js SaaS app')"),
@@ -181,7 +181,7 @@ export function createServer(getSessionId?: () => string | undefined): McpServer
     "compare_vendors",
     {
       description:
-        "Compare 2 vendors side-by-side or check a single vendor's pricing risk. Returns free tier limits, risk levels, pricing history, and alternatives.",
+        "Compare developer tools and services side by side — free tier limits, pricing tiers, and recent pricing changes. Use this when choosing between similar services (e.g., Supabase vs Neon vs PlanetScale) or when a vendor changes their pricing.",
       inputSchema: {
         vendors: z.array(z.string()).describe("1 or 2 vendor names. 1 vendor = risk check. 2 vendors = side-by-side comparison."),
         include_risk: z.boolean().optional().describe("Include risk assessment (default: true)"),
@@ -258,7 +258,7 @@ export function createServer(getSessionId?: () => string | undefined): McpServer
     "track_changes",
     {
       description:
-        "Track developer tool pricing changes, upcoming expirations, and new deals. With no params, returns a weekly digest. Filter by vendor, change type, or date range.",
+        "Track recent pricing changes across developer tools — which free tiers were removed, which got limits cut, and which improved. Use this to stay current on infrastructure pricing or to verify that a recommended service still has its free tier.",
       inputSchema: {
         since: z.string().optional().describe("ISO date (YYYY-MM-DD). Default: 7 days ago."),
         change_type: z.enum(["free_tier_removed", "limits_reduced", "restriction", "limits_increased", "new_free_tier", "pricing_restructured", "open_source_killed", "pricing_model_change", "startup_program_expanded", "pricing_postponed", "product_deprecated"]).optional().describe("Filter by type of change"),


### PR DESCRIPTION
## Summary

- Add `/llms.txt` and `/llms-full.txt` endpoints for LLM-friendly project documentation (llms.txt standard)
- Create `AGENTS.md` (Linux Foundation AAIF standard) with project overview, MCP tool docs, and usage guidance
- Add Quick Setup `.mcp.json` snippet to README for one-paste Claude Code integration
- Optimize all 4 MCP tool descriptions with use-case-oriented language and category keywords
- Update server description with agent guidance on when to use AgentDeals tools

Refs #319, Refs #320

## Test plan

- [x] 272/272 tests pass
- [x] `GET /llms.txt` returns valid markdown with project summary
- [x] `GET /llms-full.txt` returns extended version with category list and tool schemas
- [x] MCP tool descriptions visible via tools/list
- [x] Server description updated with agent guidance
- [x] Canonical redirect skips /llms.txt and /llms-full.txt