### PR TITLE
Serve AGENTS.md via HTTP

### DIFF
--- a/src/serve.ts
+++ b/src/serve.ts
@@ -4663,7 +4663,8 @@ const httpServer = createHttpServer(async (req, res) => {
         url.pathname === "/favicon.png" ||
         url.pathname === "/favicon.ico" ||
         url.pathname === "/llms.txt" ||
-        url.pathname === "/llms-full.txt";
+        url.pathname === "/llms-full.txt" ||
+        url.pathname === "/AGENTS.md";
       if (!skip) {
         const target = `${BASE_URL}${url.pathname}${url.search}`;
         res.writeHead(301, { Location: target });
@@ -5237,6 +5238,10 @@ ${catList}
 `;
     res.writeHead(200, { "Content-Type": "text/plain; charset=utf-8", "Cache-Control": "public, max-age=3600" });
     res.end(llmsFullTxt);
+  } else if (url.pathname === "/AGENTS.md" && req.method === "GET") {
+    const agentsMd = readFileSync(join(__dirname, "..", "AGENTS.md"), "utf-8");
+    res.writeHead(200, { "Content-Type": "text/markdown; charset=utf-8", "Cache-Control": "public, max-age=3600" });
+    res.end(agentsMd);
   } else if (url.pathname === "/sitemap.xml" && req.method === "GET") {
     const now = new Date().toISOString().split("T")[0];
     const categoryUrls = categories.map((c) => `  <url>

--- a/test/http.test.ts
+++ b/test/http.test.ts
@@ -288,6 +288,18 @@ describe("HTTP transport", () => {
     assert.ok(Array.isArray(body.transport));
   });
 
+  it("serves /AGENTS.md with text/markdown content type", async () => {
+    proc = await startHttpServer();
+
+    const response = await fetch(`http://localhost:${PORT}/AGENTS.md`);
+    assert.strictEqual(response.status, 200);
+    assert.strictEqual(response.headers.get("content-type"), "text/markdown; charset=utf-8");
+    const body = await response.text();
+    assert.ok(body.includes("# AgentDeals"));
+    assert.ok(body.includes("## MCP Tools"));
+    assert.ok(body.includes("search_deals"));
+  });
+
   it("serves /setup page with client configs and HowTo schema", async () => {
     proc = await startHttpServer();
 


### PR DESCRIPTION
## Summary

- Add `GET /AGENTS.md` route serving the repo's AGENTS.md file with `text/markdown` content type
- Skip canonical domain redirect for `/AGENTS.md` (same treatment as `/llms.txt` and `/llms-full.txt`)
- Add test verifying status, content type, and content

## Test plan

- [x] 273 tests pass (1 new)
- [x] E2E verified: `curl http://localhost:3000/AGENTS.md` returns 200 with correct content type and full AGENTS.md content

Refs #322