### PR TITLE
Fix AGENTS.md crash: add to Docker image + try-catch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,7 @@ COPY --from=build /app/dist/ dist/
 COPY data/ data/
 COPY assets/ assets/
 COPY glama.json ./
+COPY AGENTS.md ./
 
 EXPOSE 3000
 

--- a/src/serve.ts
+++ b/src/serve.ts
@@ -5239,9 +5239,14 @@ ${catList}
     res.writeHead(200, { "Content-Type": "text/plain; charset=utf-8", "Cache-Control": "public, max-age=3600" });
     res.end(llmsFullTxt);
   } else if (url.pathname === "/AGENTS.md" && req.method === "GET") {
-    const agentsMd = readFileSync(join(__dirname, "..", "AGENTS.md"), "utf-8");
-    res.writeHead(200, { "Content-Type": "text/markdown; charset=utf-8", "Cache-Control": "public, max-age=3600" });
-    res.end(agentsMd);
+    try {
+      const agentsMd = readFileSync(join(__dirname, "..", "AGENTS.md"), "utf-8");
+      res.writeHead(200, { "Content-Type": "text/markdown; charset=utf-8", "Cache-Control": "public, max-age=3600" });
+      res.end(agentsMd);
+    } catch {
+      res.writeHead(404, { "Content-Type": "text/plain" });
+      res.end("Not found");
+    }
   } else if (url.pathname === "/sitemap.xml" && req.method === "GET") {
     const now = new Date().toISOString().split("T")[0];
     const categoryUrls = categories.map((c) => `  <url>


### PR DESCRIPTION
## Summary

- AGENTS.md was missing from the Dockerfile COPY instructions, causing `readFileSync` to throw an uncaught exception that crashes the Node.js process in production
- Added `COPY AGENTS.md ./` to Dockerfile
- Wrapped the readFileSync in try-catch so a missing file returns 404 instead of crashing the server

Refs #322

## Test plan

- [x] 105 HTTP tests pass (including AGENTS.md test)
- [x] E2E verified: `GET /AGENTS.md` returns 200 with correct content
- [x] TypeScript builds clean