### PR TITLE
Fix Events structured data validation errors

### DIFF
--- a/src/serve.ts
+++ b/src/serve.ts
@@ -325,11 +325,11 @@ function buildRecentChangesSection(): string {
       "@type": "ListItem",
       position: i + 1,
       item: {
-        "@type": "Event",
-        name: `${c.vendor}: ${(changeTypeBadge[c.change_type] ?? { label: c.change_type }).label}`,
+        "@type": "Article",
+        headline: `${c.vendor}: ${(changeTypeBadge[c.change_type] ?? { label: c.change_type }).label}`,
         description: c.summary,
-        startDate: c.date,
-        location: { "@type": "VirtualLocation", url: `${BASE_URL}/vendor/${c.vendor.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-|-$/g, "")}` },
+        datePublished: c.date,
+        url: `${BASE_URL}/vendor/${c.vendor.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-|-$/g, "")}`,
       },
     })),
   });
@@ -2986,11 +2986,11 @@ ${entriesHtml}
       "@type": "ListItem",
       position: i + 1,
       item: {
-        "@type": "Event",
-        name: `${c.vendor}: ${(changeTypeBadge[c.change_type] ?? { label: c.change_type }).label}`,
+        "@type": "Article",
+        headline: `${c.vendor}: ${(changeTypeBadge[c.change_type] ?? { label: c.change_type }).label}`,
         description: c.summary,
-        startDate: c.date,
-        location: { "@type": "VirtualLocation", url: `${BASE_URL}/vendor/${toSlug(c.vendor)}` },
+        datePublished: c.date,
+        url: `${BASE_URL}/vendor/${toSlug(c.vendor)}`,
       },
     })),
   };
@@ -3183,11 +3183,11 @@ ${entriesHtml}
       "@type": "ListItem",
       position: i + 1,
       item: {
-        "@type": "Event",
-        name: `${c.vendor}: ${(changeTypeBadge[c.change_type] ?? { label: c.change_type }).label}`,
+        "@type": "Article",
+        headline: `${c.vendor}: ${(changeTypeBadge[c.change_type] ?? { label: c.change_type }).label}`,
         description: c.summary,
-        startDate: c.date,
-        location: { "@type": "VirtualLocation", url: `${BASE_URL}/vendor/${toSlug(c.vendor)}` },
+        datePublished: c.date,
+        url: `${BASE_URL}/vendor/${toSlug(c.vendor)}`,
       },
     })),
   };


### PR DESCRIPTION
## Summary
- Replaced `@type: "Event"` with `@type: "Article"` for deal changes in JSON-LD structured data
- Fixed 3 locations: landing page "Recent Pricing Changes", /changes page, /expiring page
- Maps Event fields to Article equivalents: `name`→`headline`, `startDate`→`datePublished`, `location`→`url`

Google Search Console flagged 7 Events structured data issues (1 critical: invalid location type, 6 non-critical: missing Event-required fields). Deal changes are pricing updates, not events — using Article schema eliminates all validation errors.

## Test plan
- [x] 273/273 tests pass
- [x] Zero `@type: "Event"` references remain in serve.ts
- [ ] After deploy, request re-validation in Google Search Console

Refs #325