### PR TITLE
Add /hetzner-alternatives page for April 1 price increase

### DIFF
--- a/data/index.json
+++ b/data/index.json
@@ -24,7 +24,8 @@
         "hosting",
         "paas",
         "deployment",
-        "docker"
+        "docker",
+        "hetzner-alternative"
       ],
       "verifiedDate": "2026-03-18"
     },
@@ -38,7 +39,8 @@
         "edge",
         "serverless",
         "hosting",
-        "workers"
+        "workers",
+        "hetzner-alternative"
       ],
       "verifiedDate": "2026-03-11"
     },
@@ -82,7 +84,8 @@
         "paas",
         "deployment",
         "docker",
-        "low-cost"
+        "low-cost",
+        "hetzner-alternative"
       ],
       "verifiedDate": "2026-03-11"
     },
@@ -97,7 +100,8 @@
         "edge",
         "deployment",
         "docker",
-        "global"
+        "global",
+        "hetzner-alternative"
       ],
       "verifiedDate": "2026-03-11"
     },
@@ -174,7 +178,8 @@
         "iaas",
         "compute",
         "serverless",
-        "free tier"
+        "free tier",
+        "hetzner-alternative"
       ],
       "verifiedDate": "2026-03-14",
       "expires_date": "2027-03-31"
@@ -205,7 +210,8 @@
         "iaas",
         "credits",
         "startup",
-        "free tier"
+        "free tier",
+        "hetzner-alternative"
       ],
       "verifiedDate": "2026-03-14",
       "expires_date": "2026-06-30"
@@ -222,7 +228,8 @@
         "compute",
         "arm",
         "database",
-        "free tier"
+        "free tier",
+        "hetzner-alternative"
       ],
       "verifiedDate": "2026-03-20"
     },
@@ -1875,7 +1882,8 @@
         "credits",
         "startup credits",
         "google cloud",
-        "accelerator"
+        "accelerator",
+        "hetzner-alternative"
       ],
       "verifiedDate": "2026-03-14",
       "eligibility": {
@@ -2420,7 +2428,8 @@
         "iaas",
         "startup-credits",
         "gpu",
-        "compute"
+        "compute",
+        "hetzner-alternative"
       ],
       "verifiedDate": "2026-03-14",
       "eligibility": {

--- a/src/serve.ts
+++ b/src/serve.ts
@@ -2435,6 +2435,15 @@ const ALTERNATIVES_PAGES: AlternativesPageConfig[] = [
     tag: "terraform-alternative",
     primaryVendor: "HCP Terraform",
   },
+  {
+    slug: "hetzner-alternatives",
+    title: "Hetzner Alternatives After April 2026 Price Increase — Budget Cloud Options",
+    metaDesc: "Hetzner is raising dedicated server prices 30-50% on April 1, 2026. Compare free-tier alternatives: DigitalOcean, Oracle Cloud, Render, Railway, Fly.io, Cloudflare Workers, Google Cloud.",
+    contextHtml: `<p><strong>Hetzner</strong> is increasing cloud and dedicated server prices <strong>30-50% on April 1, 2026</strong>, driven by surging DRAM costs (+171% YoY) from AI infrastructure demand. Entry-level cloud servers like the CX23 go from €2.99 to €3.99/mo (+33%). The increase applies to <strong>all regions and all customers</strong> — both new and existing.</p>
+      <p>If you're looking for budget-friendly alternatives with generous free tiers or credits, here are the best options across VPS/cloud providers, managed platforms, and serverless offerings.</p>`,
+    tag: "hetzner-alternative",
+    primaryVendor: "Hetzner",
+  },
 ];
 
 const alternativesPageMap = new Map<string, AlternativesPageConfig>();

--- a/test/http.test.ts
+++ b/test/http.test.ts
@@ -1494,6 +1494,21 @@ describe("HTTP transport", () => {
     assert.ok(html.includes("March 31, 2026"), "Should mention the EOL date");
   });
 
+  it("GET /hetzner-alternatives renders alternatives page", async () => {
+    proc = await startHttpServer();
+
+    const response = await fetch(`http://localhost:${PORT}/hetzner-alternatives`);
+    assert.strictEqual(response.status, 200);
+    assert.ok(response.headers.get("content-type")?.includes("text/html"));
+    const html = await response.text();
+    assert.ok(html.includes("Hetzner Alternatives"), "Should have Hetzner title");
+    assert.ok(html.includes("application/ld+json"), "Should have JSON-LD");
+    assert.ok(html.includes("canonical"), "Should have canonical link");
+    assert.ok(html.includes("global-nav"), "Should have global nav");
+    assert.ok(html.includes("Top Alternatives"), "Should have alternatives section");
+    assert.ok(html.includes("30-50%"), "Should mention the price increase");
+  });
+
   // --- Search page ---
 
   it("GET /search renders search page with search box", async () => {


### PR DESCRIPTION
## Summary
- Dedicated `/hetzner-alternatives` page targeting Hetzner's 30-50% April 1, 2026 price increase (542 HN points)
- 7 vendors tagged as hetzner-alternative: DigitalOcean, Render, Railway, Fly.io, Cloudflare Workers, Oracle Cloud, Google Cloud
- Editorial context about DRAM cost surge, deal change box from existing data, alt cards with risk levels
- Schema.org ItemList JSON-LD, SEO meta tags, OG tags for social sharing
- Auto-included in sitemap.xml and nav via ALTERNATIVES_PAGES config
- 280 tests passing (1 new)

Refs #342

## Test plan
- [x] `/hetzner-alternatives` returns 200
- [x] Page includes all 7 tagged alternatives with free tier details
- [x] JSON-LD ItemList structured data present
- [x] OG meta tags present
- [x] Sitemap includes the page
- [x] Deal change context box shows 30-50% increase details
- [x] 280 tests passing, no regressions