### PR TITLE
Add HCP Terraform alternatives and fix data quality

### DIFF
--- a/data/deal_changes.json
+++ b/data/deal_changes.json
@@ -3,7 +3,7 @@
     {
       "vendor": "Brave Search API",
       "change_type": "free_tier_removed",
-      "date": "2026-02-01",
+      "date": "2026-02-12",
       "summary": "Free plan (5,000 queries/month) replaced with metered billing at $5/1,000 requests. $5 monthly credit provided as offset (~1,000 queries). Credit cards now actively charged with no spending cap",
       "previous_state": "Free plan: 5,000 queries/month, 3 QPS, no credit card required",
       "current_state": "Metered billing at $5/1,000 requests with $5 monthly credit (~1,000 free queries). No free plan. Credit card required, no spending cap",

--- a/data/index.json
+++ b/data/index.json
@@ -2512,9 +2512,10 @@
         "terraform",
         "hashicorp",
         "free tier",
-        "deal-change"
+        "deal-change",
+        "terraform-alternative"
       ],
-      "verifiedDate": "2026-03-10"
+      "verifiedDate": "2026-03-20"
     },
     {
       "vendor": "Orama",
@@ -5623,16 +5624,17 @@
       "verifiedDate": "2026-03-20"
     },
     {
-      "vendor": "scalr.com",
+      "vendor": "Scalr",
       "category": "Infrastructure",
-      "description": "Scalr is a Terraform Automation and COllaboration (TACO) product used to better collaboration and automation on infrastructure and configurations managed by Terraform. Full Terraform CLI support, OPA integration, and a hierarchical configuration model. No SSO tax. All features are included. Use up to 50 runs/month for free.",
+      "description": "Terraform Automation and Collaboration (TACO) platform — full Terraform CLI support, OPA integration, hierarchical configuration model. No SSO tax. All features included. Up to 50 runs/month free",
       "tier": "Free",
-      "url": "https://scalr.com/",
+      "url": "https://www.scalr.com/pricing",
       "tags": [
         "infrastructure",
-        "cloud",
-        "management",
-        "free-for-dev",
+        "iac",
+        "terraform",
+        "devops",
+        "free tier",
         "terraform-alternative"
       ],
       "verifiedDate": "2026-03-20"


### PR DESCRIPTION
Refs #348

## Summary
- All 5 vendors from the issue (Spacelift, Scalr, Terragrunt Scale, Brave Search API, HCP Terraform) already existed in the index with deal_change entries. This PR fixes data quality issues:
  - **Scalr**: Renamed vendor from `scalr.com` → `Scalr`, fixed typo (`COllaboration` → `Collaboration`), updated URL from homepage to pricing page, updated tags to match other IaC entries
  - **HCP Terraform**: Added missing `terraform-alternative` tag so it appears on the alternatives page, bumped verifiedDate from 2026-03-10 to 2026-03-20
  - **Brave Search API**: Corrected deal_change date from 2026-02-01 to 2026-02-12
- 9 terraform alternatives now properly tagged and verified
- 280 tests passing

## Verification
- All pricing data cross-referenced against live vendor pricing pages
- MCP search_deals returns correct vendor names and URLs
- All existing tests pass (280/280)