### PR TITLE
Add trigger examples and response_format to tool descriptions

### DIFF
--- a/src/server-remote.ts
+++ b/src/server-remote.ts
@@ -65,7 +65,7 @@ export function createServer(): McpServer {
     "search_deals",
     {
       description:
-        "Find free tiers, credits, and discounts for 1,500+ developer tools. Search by keyword, browse categories, or get full vendor details with alternatives. Covers AWS, Vercel, Supabase, Cloudflare, and more.",
+        "Find free tiers, credits, and discounts for 1,500+ developer tools. Search by keyword, browse categories, or get full vendor details with alternatives. Covers AWS, Vercel, Supabase, Cloudflare, and more. Call this tool when a user asks: 'Does Supabase have a free tier?', 'What's cheaper than Vercel?', 'Find me a free database'.",
       annotations: {
         readOnlyHint: true,
         destructiveHint: false,
@@ -79,9 +79,10 @@ export function createServer(): McpServer {
         since: z.string().optional().describe("ISO date (YYYY-MM-DD). Only return deals verified/added after this date."),
         limit: z.number().optional().describe("Max results (default: 20)"),
         offset: z.number().optional().describe("Pagination offset (default: 0)"),
+        response_format: z.enum(["concise", "detailed"]).optional().describe("Response detail level. 'concise': vendor name, tier, one-line description, URL only. 'detailed': full response (default)."),
       },
     },
-    async ({ query, category, vendor, eligibility, sort, since, limit, offset }) => {
+    async ({ query, category, vendor, eligibility, sort, since, limit, offset, response_format }) => {
       try {
         // Mode: list categories
         if (category === "list") {
@@ -120,8 +121,18 @@ export function createServer(): McpServer {
           sort,
           limit: effectiveLimit,
           offset: effectiveOffset,
-        }) as { offers: unknown[]; total: number };
-        return mcpText({ results: data.offers, total: data.total, limit: effectiveLimit, offset: effectiveOffset });
+        }) as { offers: Record<string, unknown>[]; total: number };
+
+        // Zero-result suggestion (only when no results match at all, not just paginated past end)
+        if (data.offers.length === 0 && data.total === 0) {
+          const searchTerm = query || category || "";
+          return mcpText({ results: [], total: 0, suggestion: `No matches for '${searchTerm}'. Try searching by category (e.g., 'databases', 'hosting') or browse all categories with search_deals({category: "list"}).` });
+        }
+
+        const outputResults = response_format === "concise"
+          ? data.offers.map((o) => ({ vendor: o.vendor, tier: o.tier, description: o.description, url: o.url }))
+          : data.offers;
+        return mcpText({ results: outputResults, total: data.total, limit: effectiveLimit, offset: effectiveOffset });
       } catch (err) {
         return mcpError(`Error: ${err instanceof Error ? err.message : String(err)}`);
       }
@@ -134,7 +145,7 @@ export function createServer(): McpServer {
     "plan_stack",
     {
       description:
-        "Get stack recommendations, cost estimates, or a full infrastructure audit. Describe what you're building to get a free-tier stack, or pass your current services to estimate costs and find risks.",
+        "Get stack recommendations, cost estimates, or a full infrastructure audit. Describe what you're building to get a free-tier stack, or pass your current services to estimate costs and find risks. Call this tool when a user asks: 'What free tools can I use for a SaaS app?', 'Build me a stack under $50/month'.",
       annotations: {
         readOnlyHint: true,
         destructiveHint: false,
@@ -177,7 +188,7 @@ export function createServer(): McpServer {
     "compare_vendors",
     {
       description:
-        "Compare 2 vendors side-by-side or check a single vendor's pricing risk. Returns free tier limits, risk levels, pricing history, and alternatives.",
+        "Compare 2 vendors side-by-side or check a single vendor's pricing risk. Returns free tier limits, risk levels, pricing history, and alternatives. Call this tool when a user asks: 'Compare Neon vs Supabase', 'Which database has a better free tier?'.",
       annotations: {
         readOnlyHint: true,
         destructiveHint: false,
@@ -235,7 +246,7 @@ export function createServer(): McpServer {
     "track_changes",
     {
       description:
-        "Track developer tool pricing changes, upcoming expirations, and new deals. With no params, returns a weekly digest. Filter by vendor, change type, or date range.",
+        "Track developer tool pricing changes, upcoming expirations, and new deals. With no params, returns a weekly digest. Filter by vendor, change type, or date range. Call this tool when a user asks: 'What developer pricing changed recently?', 'Are any free tiers being removed?'.",
       annotations: {
         readOnlyHint: true,
         destructiveHint: false,
@@ -247,18 +258,23 @@ export function createServer(): McpServer {
         vendors: z.string().optional().describe("Comma-separated vendor names to filter (e.g. 'Vercel,Supabase')"),
         include_expiring: z.boolean().optional().describe("Include upcoming expirations (default: true)"),
         lookahead_days: z.number().optional().describe("Days to look ahead for expirations (default: 30)"),
+        response_format: z.enum(["concise", "detailed"]).optional().describe("Response detail level. 'concise': vendor, change_type, date, summary only. 'detailed': full response (default)."),
       },
     },
-    async ({ since, change_type, vendor, vendors, include_expiring, lookahead_days }) => {
+    async ({ since, change_type, vendor, vendors, include_expiring, lookahead_days, response_format }) => {
       try {
         // No params = weekly digest
         if (!since && !change_type && !vendor && !vendors && include_expiring === undefined) {
-          const data = await fetchWeeklyDigest();
+          const data = await fetchWeeklyDigest() as Record<string, unknown>;
+          if (response_format === "concise" && Array.isArray(data.deal_changes)) {
+            const conciseDigest = { ...data, deal_changes: (data.deal_changes as Record<string, unknown>[]).map((c) => ({ vendor: c.vendor, change_type: c.change_type, date: c.date, summary: c.summary })) };
+            return mcpText(conciseDigest);
+          }
           return mcpText(data);
         }
 
         // Filtered changes
-        const changes = await fetchDealChanges({ since, type: change_type, vendor, vendors });
+        const changes = await fetchDealChanges({ since, type: change_type, vendor, vendors }) as Record<string, unknown>;
         const doExpiring = include_expiring !== false;
         const days = Math.min(Math.max(lookahead_days ?? 30, 1), 365);
 
@@ -266,6 +282,10 @@ export function createServer(): McpServer {
         if (doExpiring) {
           const expiring = await fetchExpiringDeals(days);
           result = { ...(changes as object), expiring_deals: expiring };
+        }
+
+        if (response_format === "concise" && Array.isArray(result.changes)) {
+          result = { ...result, changes: result.changes.map((c: Record<string, unknown>) => ({ vendor: c.vendor, change_type: c.change_type, date: c.date, summary: c.summary })) };
         }
 
         return mcpText(result);

--- a/src/server.ts
+++ b/src/server.ts
@@ -4,6 +4,15 @@ import { getCategories, getDealChanges, getNewOffers, getNewestDeals, getOfferDe
 import { recordToolCall, logRequest } from "./stats.js";
 import { getStackRecommendation } from "./stacks.js";
 import { estimateCosts } from "./costs.js";
+import type { Offer, EnrichedOffer, DealChange } from "./types.js";
+
+function toConciseOffer(offer: Offer | EnrichedOffer) {
+  return { vendor: offer.vendor, tier: offer.tier, description: offer.description, url: offer.url };
+}
+
+function toConciseDealChange(change: DealChange) {
+  return { vendor: change.vendor, change_type: change.change_type, date: change.date, summary: change.summary };
+}
 
 export function createServer(getSessionId?: () => string | undefined): McpServer {
   const server = new McpServer({
@@ -18,7 +27,7 @@ export function createServer(getSessionId?: () => string | undefined): McpServer
     "search_deals",
     {
       description:
-        "Find free tiers, startup credits, and developer deals for cloud infrastructure, databases, hosting, CI/CD, monitoring, auth, AI services, and more. Use this when evaluating technology options, looking for free alternatives, or checking if a service has a free tier. Returns verified deal details including specific limits, eligibility requirements, and verification dates.",
+        "Find free tiers, startup credits, and developer deals for cloud infrastructure, databases, hosting, CI/CD, monitoring, auth, AI services, and more. Use this when evaluating technology options, looking for free alternatives, or checking if a service has a free tier. Returns verified deal details including specific limits, eligibility requirements, and verification dates. Call this tool when a user asks: 'Does Supabase have a free tier?', 'What's cheaper than Vercel?', 'Find me a free database'.",
       annotations: {
         readOnlyHint: true,
         destructiveHint: false,
@@ -32,9 +41,10 @@ export function createServer(getSessionId?: () => string | undefined): McpServer
         since: z.string().optional().describe("ISO date (YYYY-MM-DD). Only return deals verified/added after this date."),
         limit: z.number().optional().describe("Max results (default: 20)"),
         offset: z.number().optional().describe("Pagination offset (default: 0)"),
+        response_format: z.enum(["concise", "detailed"]).optional().describe("Response detail level. 'concise': vendor name, tier, one-line description, URL only. 'detailed': full response (default)."),
       },
     },
-    async ({ query, category, vendor, eligibility, sort, since, limit, offset }) => {
+    async ({ query, category, vendor, eligibility, sort, since, limit, offset, response_format }) => {
       try {
         recordToolCall("search_deals");
 
@@ -90,9 +100,20 @@ export function createServer(getSessionId?: () => string | undefined): McpServer
 
         const paged = filtered.slice(effectiveOffset, effectiveOffset + effectiveLimit);
         const results = enrichOffers(paged);
+        const finalTotal = since ? filtered.length : total;
         logRequest({ ts: new Date().toISOString(), type: "mcp", endpoint: "search_deals", params: { query, category, eligibility, sort, limit: effectiveLimit, offset: effectiveOffset, since }, result_count: results.length, session_id: getSessionId?.() });
+
+        // Zero-result suggestion (only when no results match at all, not just paginated past end)
+        if (results.length === 0 && finalTotal === 0) {
+          const searchTerm = query || category || "";
+          return {
+            content: [{ type: "text" as const, text: JSON.stringify({ results: [], total: 0, suggestion: `No matches for '${searchTerm}'. Try searching by category (e.g., 'databases', 'hosting') or browse all categories with search_deals({category: "list"}).` }, null, 2) }],
+          };
+        }
+
+        const outputResults = response_format === "concise" ? results.map(toConciseOffer) : results;
         return {
-          content: [{ type: "text" as const, text: JSON.stringify({ results, total: since ? filtered.length : total, limit: effectiveLimit, offset: effectiveOffset }, null, 2) }],
+          content: [{ type: "text" as const, text: JSON.stringify({ results: outputResults, total: finalTotal, limit: effectiveLimit, offset: effectiveOffset }, null, 2) }],
         };
       } catch (err) {
         console.error("search_deals error:", err);
@@ -110,7 +131,7 @@ export function createServer(getSessionId?: () => string | undefined): McpServer
     "plan_stack",
     {
       description:
-        "Plan a technology stack with cost-optimized infrastructure choices. Given project requirements, recommends services with free tiers or credits that match your needs. Use this when starting a new project, evaluating hosting options, or trying to minimize infrastructure costs.",
+        "Plan a technology stack with cost-optimized infrastructure choices. Given project requirements, recommends services with free tiers or credits that match your needs. Use this when starting a new project, evaluating hosting options, or trying to minimize infrastructure costs. Call this tool when a user asks: 'What free tools can I use for a SaaS app?', 'Build me a stack under $50/month'.",
       annotations: {
         readOnlyHint: true,
         destructiveHint: false,
@@ -189,7 +210,7 @@ export function createServer(getSessionId?: () => string | undefined): McpServer
     "compare_vendors",
     {
       description:
-        "Compare developer tools and services side by side — free tier limits, pricing tiers, and recent pricing changes. Use this when choosing between similar services (e.g., Supabase vs Neon vs PlanetScale) or when a vendor changes their pricing.",
+        "Compare developer tools and services side by side — free tier limits, pricing tiers, and recent pricing changes. Use this when choosing between similar services (e.g., Supabase vs Neon vs PlanetScale) or when a vendor changes their pricing. Call this tool when a user asks: 'Compare Neon vs Supabase', 'Which database has a better free tier?'.",
       annotations: {
         readOnlyHint: true,
         destructiveHint: false,
@@ -270,7 +291,7 @@ export function createServer(getSessionId?: () => string | undefined): McpServer
     "track_changes",
     {
       description:
-        "Track recent pricing changes across developer tools — which free tiers were removed, which got limits cut, and which improved. Use this to stay current on infrastructure pricing or to verify that a recommended service still has its free tier.",
+        "Track recent pricing changes across developer tools — which free tiers were removed, which got limits cut, and which improved. Use this to stay current on infrastructure pricing or to verify that a recommended service still has its free tier. Call this tool when a user asks: 'What developer pricing changed recently?', 'Are any free tiers being removed?'.",
       annotations: {
         readOnlyHint: true,
         destructiveHint: false,
@@ -282,9 +303,10 @@ export function createServer(getSessionId?: () => string | undefined): McpServer
         vendors: z.string().optional().describe("Comma-separated vendor names to filter (e.g. 'Vercel,Supabase')"),
         include_expiring: z.boolean().optional().describe("Include upcoming expirations (default: true)"),
         lookahead_days: z.number().optional().describe("Days to look ahead for expirations (default: 30)"),
+        response_format: z.enum(["concise", "detailed"]).optional().describe("Response detail level. 'concise': vendor, change_type, date, summary only. 'detailed': full response (default)."),
       },
     },
-    async ({ since, change_type, vendor, vendors, include_expiring, lookahead_days }) => {
+    async ({ since, change_type, vendor, vendors, include_expiring, lookahead_days, response_format }) => {
       try {
         recordToolCall("track_changes");
 
@@ -292,6 +314,12 @@ export function createServer(getSessionId?: () => string | undefined): McpServer
         if (!since && !change_type && !vendor && !vendors && include_expiring === undefined) {
           const digest = getWeeklyDigest();
           logRequest({ ts: new Date().toISOString(), type: "mcp", endpoint: "track_changes", params: {}, result_count: digest.deal_changes.length, session_id: getSessionId?.() });
+          if (response_format === "concise") {
+            const conciseDigest = { ...digest, deal_changes: digest.deal_changes.map(toConciseDealChange) };
+            return {
+              content: [{ type: "text" as const, text: JSON.stringify(conciseDigest, null, 2) }],
+            };
+          }
           return {
             content: [{ type: "text" as const, text: JSON.stringify(digest, null, 2) }],
           };
@@ -306,6 +334,10 @@ export function createServer(getSessionId?: () => string | undefined): McpServer
         if (doExpiring) {
           const expiring = getExpiringDeals(days);
           result = { ...changes, expiring_deals: expiring };
+        }
+
+        if (response_format === "concise") {
+          result = { ...result, changes: result.changes.map(toConciseDealChange) };
         }
 
         logRequest({ ts: new Date().toISOString(), type: "mcp", endpoint: "track_changes", params: { since, change_type, vendor, vendors, include_expiring: doExpiring, lookahead_days: days }, result_count: changes.changes.length, session_id: getSessionId?.() });
@@ -555,7 +587,7 @@ export function getServerCard(baseUrl: string) {
     tools: [
       {
         name: "search_deals",
-        description: "Find free tiers, startup credits, and developer deals for cloud infrastructure, databases, hosting, CI/CD, monitoring, auth, AI services, and more.",
+        description: "Find free tiers, startup credits, and developer deals for cloud infrastructure, databases, hosting, CI/CD, monitoring, auth, AI services, and more. Call this tool when a user asks: 'Does Supabase have a free tier?', 'What's cheaper than Vercel?', 'Find me a free database'.",
         annotations: {
           readOnlyHint: true,
           destructiveHint: false,
@@ -571,12 +603,13 @@ export function getServerCard(baseUrl: string) {
             since: { type: "string", description: "ISO date (YYYY-MM-DD). Only return deals verified/added after this date." },
             limit: { type: "number", description: "Max results (default: 20)" },
             offset: { type: "number", description: "Pagination offset (default: 0)" },
+            response_format: { type: "string", enum: ["concise", "detailed"], description: "Response detail level. 'concise': vendor, tier, description, URL only. 'detailed': full response (default)." },
           },
         },
       },
       {
         name: "plan_stack",
-        description: "Plan a technology stack with cost-optimized infrastructure choices. Recommends services, estimates costs, or audits existing stacks.",
+        description: "Plan a technology stack with cost-optimized infrastructure choices. Recommends services, estimates costs, or audits existing stacks. Call this tool when a user asks: 'What free tools can I use for a SaaS app?', 'Build me a stack under $50/month'.",
         annotations: {
           readOnlyHint: true,
           destructiveHint: false,
@@ -595,7 +628,7 @@ export function getServerCard(baseUrl: string) {
       },
       {
         name: "compare_vendors",
-        description: "Compare developer tools side by side — free tier limits, pricing tiers, and recent pricing changes.",
+        description: "Compare developer tools side by side — free tier limits, pricing tiers, and recent pricing changes. Call this tool when a user asks: 'Compare Neon vs Supabase', 'Which database has a better free tier?'.",
         annotations: {
           readOnlyHint: true,
           destructiveHint: false,
@@ -611,7 +644,7 @@ export function getServerCard(baseUrl: string) {
       },
       {
         name: "track_changes",
-        description: "Track recent pricing changes — free tier removals, limit cuts, and improvements across developer tools.",
+        description: "Track recent pricing changes — free tier removals, limit cuts, and improvements across developer tools. Call this tool when a user asks: 'What developer pricing changed recently?', 'Are any free tiers being removed?'.",
         annotations: {
           readOnlyHint: true,
           destructiveHint: false,
@@ -625,6 +658,7 @@ export function getServerCard(baseUrl: string) {
             vendors: { type: "string", description: "Comma-separated vendor names" },
             include_expiring: { type: "boolean", description: "Include upcoming expirations (default: true)" },
             lookahead_days: { type: "number", description: "Days to look ahead for expirations (default: 30)" },
+            response_format: { type: "string", enum: ["concise", "detailed"], description: "Response detail level. 'concise': vendor, change_type, date, summary only. 'detailed': full response (default)." },
           },
         },
       },

--- a/test/search.test.ts
+++ b/test/search.test.ts
@@ -1179,3 +1179,105 @@ describe("compare_vendors tool", () => {
     }
   });
 });
+
+describe("response_format=concise", () => {
+  it("returns concise output for search_deals", async () => {
+    const proc = startServer();
+    try {
+      const responses = (await sendMcpMessages(proc, [
+        ...INIT_MESSAGES,
+        {
+          jsonrpc: "2.0",
+          id: 2,
+          method: "tools/call",
+          params: {
+            name: "search_deals",
+            arguments: { query: "database", limit: 3, response_format: "concise" },
+          },
+        },
+      ])) as any[];
+
+      const result = responses.find((r: any) => r.id === 2) as any;
+      const body = JSON.parse(result.result.content[0].text);
+      assert.ok(body.results.length > 0);
+      const offer = body.results[0];
+      // Concise: only vendor, tier, description, url
+      assert.ok(typeof offer.vendor === "string");
+      assert.ok(typeof offer.tier === "string");
+      assert.ok(typeof offer.description === "string");
+      assert.ok(typeof offer.url === "string");
+      // Should NOT have enriched fields
+      assert.strictEqual(offer.category, undefined);
+      assert.strictEqual(offer.tags, undefined);
+      assert.strictEqual(offer.risk_level, undefined);
+      assert.strictEqual(offer.days_since_verified, undefined);
+    } finally {
+      proc.kill();
+    }
+  });
+
+  it("returns concise output for track_changes", async () => {
+    const proc = startServer();
+    try {
+      const responses = (await sendMcpMessages(proc, [
+        ...INIT_MESSAGES,
+        {
+          jsonrpc: "2.0",
+          id: 2,
+          method: "tools/call",
+          params: {
+            name: "track_changes",
+            arguments: { since: "2020-01-01", response_format: "concise" },
+          },
+        },
+      ])) as any[];
+
+      const result = responses.find((r: any) => r.id === 2) as any;
+      const body = JSON.parse(result.result.content[0].text);
+      assert.ok(body.changes.length > 0);
+      const change = body.changes[0];
+      // Concise: only vendor, change_type, date, summary
+      assert.ok(typeof change.vendor === "string");
+      assert.ok(typeof change.change_type === "string");
+      assert.ok(typeof change.date === "string");
+      assert.ok(typeof change.summary === "string");
+      // Should NOT have full fields
+      assert.strictEqual(change.previous_state, undefined);
+      assert.strictEqual(change.current_state, undefined);
+      assert.strictEqual(change.impact, undefined);
+      assert.strictEqual(change.source_url, undefined);
+    } finally {
+      proc.kill();
+    }
+  });
+});
+
+describe("zero-result suggestion", () => {
+  it("returns suggestion when search has no matches", async () => {
+    const proc = startServer();
+    try {
+      const responses = (await sendMcpMessages(proc, [
+        ...INIT_MESSAGES,
+        {
+          jsonrpc: "2.0",
+          id: 2,
+          method: "tools/call",
+          params: {
+            name: "search_deals",
+            arguments: { query: "zzzznonexistentquery99999" },
+          },
+        },
+      ])) as any[];
+
+      const result = responses.find((r: any) => r.id === 2) as any;
+      const body = JSON.parse(result.result.content[0].text);
+      assert.strictEqual(body.results.length, 0);
+      assert.strictEqual(body.total, 0);
+      assert.ok(typeof body.suggestion === "string");
+      assert.ok(body.suggestion.includes("No matches"));
+      assert.ok(body.suggestion.includes("category"));
+    } finally {
+      proc.kill();
+    }
+  });
+});


### PR DESCRIPTION
Refs #350

## Changes

1. **Trigger examples** — Added "Call this tool when:" with 2-3 concrete user queries to all 4 MCP tool descriptions (server.ts, server-remote.ts, server card). Research shows this improves LLM task success by ~6 percentage points.

2. **response_format parameter** — Added optional `response_format` enum (`"concise"` | `"detailed"`) to `search_deals` and `track_changes`. Concise mode returns only essential fields (vendor, tier, description, URL for searches; vendor, change_type, date, summary for changes), reducing token consumption.

3. **Zero-result suggestion** — When search_deals returns 0 matches, returns a helpful suggestion message instead of an empty array: `"No matches for 'foo'. Try searching by category (e.g., 'databases', 'hosting') or browse all categories with search_deals({category: \"list\"})."`

## Updated locations

- `src/server.ts` — stdio/local server (tool registrations + server card)
- `src/server-remote.ts` — HTTP/remote server (tool registrations)
- `test/search.test.ts` — 3 new tests

## Tests

- 283 passing (280 existing + 3 new)
- New: concise search output, concise track_changes output, zero-result suggestion
- E2E: server card verified with updated descriptions and response_format params