### PR TITLE
Fix security vulnerabilities flagged by MCP Marketplace

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1771,9 +1771,9 @@
       }
     },
     "node_modules/swagger-ui-dist": {
-      "version": "5.32.0",
-      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-5.32.0.tgz",
-      "integrity": "sha512-nKZB0OuDvacB0s/lC2gbge+RigYvGRGpLLMWMFxaTUwfM+CfndVk9Th2IaTinqXiz6Mn26GK2zriCpv6/+5m3Q==",
+      "version": "5.32.1",
+      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-5.32.1.tgz",
+      "integrity": "sha512-6HQoo7+j8PA2QqP5kgAb9dl1uxUjvR0SAoL/WUp1sTEvm0F6D5npgU2OGCLwl++bIInqGlEUQ2mpuZRZYtyCzQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@scarf/scarf": "=1.4.0"


### PR DESCRIPTION
## Summary

Refs #353

Addresses security issues flagged by MCP Marketplace at https://mcp-marketplace.io.

### Findings

- **Production dependencies: 0 vulnerabilities** (`npm audit --omit=dev` is clean)
- **Dev dependencies: 5 low severity** — all in the `tmp` package chain via `@anthropic-ai/mcpb` → `@inquirer/prompts` → `@inquirer/editor` → `external-editor` → `tmp` (GHSA-52f5-9888-hmc6)
  - No upstream fix available — `tmp` <=0.2.3 covers all released versions
  - `@anthropic-ai/mcpb` is already at latest (2.1.2)
  - This package is a devDependency only (Claude Desktop Extension builder CLI) — not shipped in Docker image
- The MCP Marketplace reported "2 high severity" but npm audit classifies these as low severity (CVSS 2.5). The marketplace likely uses a different vulnerability database or severity mapping.

### Changes

- Updated `swagger-ui-dist` 5.32.0 → 5.32.1 (latest patch)
- 285/286 tests pass (1 pre-existing flaky timeout in stacks.test.ts, unrelated)

### Notes for MCP Marketplace

The 5 low-severity findings are in devDependencies only and do not ship to production. The Docker image is built with `npm install --production` which excludes the entire `@anthropic-ai/mcpb` dependency tree. Production audit is 0 vulnerabilities.