### PR TITLE
Fix flaky api-client test by sharing server across tests

### DIFF
--- a/test/api-client.test.ts
+++ b/test/api-client.test.ts
@@ -1,4 +1,4 @@
-import { describe, it } from "node:test";
+import { describe, it, before, after } from "node:test";
 import assert from "node:assert";
 import { spawn, type ChildProcess } from "node:child_process";
 import path from "node:path";
@@ -15,7 +15,7 @@ async function startHttpServer(port: number): Promise<ChildProcess> {
   });
 
   await new Promise<void>((resolve, reject) => {
-    const timeout = setTimeout(() => reject(new Error("Server start timeout")), 5000);
+    const timeout = setTimeout(() => reject(new Error("Server start timeout")), 10000);
     proc.stderr!.on("data", (chunk: Buffer) => {
       if (chunk.toString().includes("running on")) {
         clearTimeout(timeout);
@@ -33,101 +33,63 @@ async function startHttpServer(port: number): Promise<ChildProcess> {
 
 describe("api-client against local HTTP server", () => {
   const PORT = 13579;
+  let proc: ChildProcess;
+
+  before(async () => {
+    proc = await startHttpServer(PORT);
+    process.env.AGENTDEALS_API_URL = `http://localhost:${PORT}`;
+  });
+
+  after(() => {
+    delete process.env.AGENTDEALS_API_URL;
+    proc?.kill();
+  });
 
   it("fetchCategories returns array of categories", async () => {
-    const proc = await startHttpServer(PORT);
-    try {
-      const { fetchCategories } = await import("../dist/api-client.js");
-      process.env.AGENTDEALS_API_URL = `http://localhost:${PORT}`;
-      try {
-        const categories = await fetchCategories() as { name: string; count: number }[];
-        assert.ok(Array.isArray(categories));
-        assert.ok(categories.length > 0);
-        assert.ok(typeof categories[0].name === "string");
-        assert.ok(typeof categories[0].count === "number");
-      } finally {
-        delete process.env.AGENTDEALS_API_URL;
-      }
-    } finally {
-      proc.kill();
-    }
+    const { fetchCategories } = await import("../dist/api-client.js");
+    const categories = await fetchCategories() as { name: string; count: number }[];
+    assert.ok(Array.isArray(categories));
+    assert.ok(categories.length > 0);
+    assert.ok(typeof categories[0].name === "string");
+    assert.ok(typeof categories[0].count === "number");
   });
 
   it("fetchOffers returns offers with pagination", async () => {
-    const proc = await startHttpServer(PORT);
-    try {
-      const { fetchOffers } = await import("../dist/api-client.js");
-      process.env.AGENTDEALS_API_URL = `http://localhost:${PORT}`;
-      try {
-        const data = await fetchOffers({ q: "database", limit: 5 }) as { offers: unknown[]; total: number };
-        assert.ok(Array.isArray(data.offers));
-        assert.ok(data.offers.length <= 5);
-        assert.ok(typeof data.total === "number");
-      } finally {
-        delete process.env.AGENTDEALS_API_URL;
-      }
-    } finally {
-      proc.kill();
-    }
+    const { fetchOffers } = await import("../dist/api-client.js");
+    const data = await fetchOffers({ q: "database", limit: 5 }) as { offers: unknown[]; total: number };
+    assert.ok(Array.isArray(data.offers));
+    assert.ok(data.offers.length <= 5);
+    assert.ok(typeof data.total === "number");
   });
 
   it("fetchOfferDetails returns offer object", async () => {
-    const proc = await startHttpServer(PORT);
-    try {
-      const { fetchOfferDetails } = await import("../dist/api-client.js");
-      process.env.AGENTDEALS_API_URL = `http://localhost:${PORT}`;
-      try {
-        const data = await fetchOfferDetails("Neon") as { offer: { vendor: string } };
-        assert.ok(data.offer);
-        assert.strictEqual(data.offer.vendor, "Neon");
-      } finally {
-        delete process.env.AGENTDEALS_API_URL;
-      }
-    } finally {
-      proc.kill();
-    }
+    const { fetchOfferDetails } = await import("../dist/api-client.js");
+    const data = await fetchOfferDetails("Neon") as { offer: { vendor: string } };
+    assert.ok(data.offer);
+    assert.strictEqual(data.offer.vendor, "Neon");
   });
 
   it("fetchOfferDetails throws on unknown vendor", async () => {
-    const proc = await startHttpServer(PORT);
-    try {
-      const { fetchOfferDetails } = await import("../dist/api-client.js");
-      process.env.AGENTDEALS_API_URL = `http://localhost:${PORT}`;
-      try {
-        await assert.rejects(
-          () => fetchOfferDetails("zzzznonexistent99999"),
-          (err: Error) => {
-            assert.ok(err.message.includes("404"));
-            return true;
-          }
-        );
-      } finally {
-        delete process.env.AGENTDEALS_API_URL;
+    const { fetchOfferDetails } = await import("../dist/api-client.js");
+    await assert.rejects(
+      () => fetchOfferDetails("zzzznonexistent99999"),
+      (err: Error) => {
+        assert.ok(err.message.includes("404"));
+        return true;
       }
-    } finally {
-      proc.kill();
-    }
+    );
   });
 
   it("fetchCompare returns comparison for two known vendors", async () => {
-    const proc = await startHttpServer(PORT);
-    try {
-      const { fetchCompare } = await import("../dist/api-client.js");
-      process.env.AGENTDEALS_API_URL = `http://localhost:${PORT}`;
-      try {
-        const data = await fetchCompare("Neon", "Supabase") as { vendor_a: { vendor: string }; vendor_b: { vendor: string } };
-        assert.ok(data.vendor_a);
-        assert.ok(data.vendor_b);
-      } finally {
-        delete process.env.AGENTDEALS_API_URL;
-      }
-    } finally {
-      proc.kill();
-    }
+    const { fetchCompare } = await import("../dist/api-client.js");
+    const data = await fetchCompare("Neon", "Supabase") as { vendor_a: { vendor: string }; vendor_b: { vendor: string } };
+    assert.ok(data.vendor_a);
+    assert.ok(data.vendor_b);
   });
 
   it("handles unreachable API with descriptive error", async () => {
     const { fetchCategories } = await import("../dist/api-client.js");
+    const savedUrl = process.env.AGENTDEALS_API_URL;
     process.env.AGENTDEALS_API_URL = "http://localhost:19999";
     try {
       await assert.rejects(
@@ -138,7 +100,7 @@ describe("api-client against local HTTP server", () => {
         }
       );
     } finally {
-      delete process.env.AGENTDEALS_API_URL;
+      process.env.AGENTDEALS_API_URL = savedUrl;
     }
   });
 });


### PR DESCRIPTION
## Summary

- Fixed the intermittent `Server start timeout` failure in `test/api-client.test.ts` that has been a pre-existing flaky test for multiple cycles
- Root cause: each test spawned a separate HTTP server on the same port (13579), causing port contention when the previous test's server hadn't fully released the port
- Fix: use `before`/`after` hooks to start a single shared server for the entire suite
- Also increased startup timeout from 5s to 10s as a safety margin
- Net result: -79/+41 lines (simpler), suite runs in ~0.3s instead of multiple seconds, 290/290 tests pass

## Test plan

- [x] All 6 api-client tests pass consistently
- [x] Full suite: 290/290 pass (0 failures, previously had 1 intermittent failure)
- [x] Unreachable API test correctly restores env var after running