### PR TITLE
Fix structured data: Article → NewsArticle on changes pages

### DIFF
--- a/src/serve.ts
+++ b/src/serve.ts
@@ -3062,11 +3062,12 @@ ${entriesHtml}
       "@type": "ListItem",
       position: i + 1,
       item: {
-        "@type": "Article",
+        "@type": "NewsArticle",
         headline: `${c.vendor}: ${(changeTypeBadge[c.change_type] ?? { label: c.change_type }).label}`,
         description: c.summary,
         datePublished: c.date,
         url: `${BASE_URL}/vendor/${toSlug(c.vendor)}`,
+        publisher: { "@type": "Organization", name: "AgentDeals", url: BASE_URL },
       },
     })),
   };
@@ -3259,11 +3260,12 @@ ${entriesHtml}
       "@type": "ListItem",
       position: i + 1,
       item: {
-        "@type": "Article",
+        "@type": "NewsArticle",
         headline: `${c.vendor}: ${(changeTypeBadge[c.change_type] ?? { label: c.change_type }).label}`,
         description: c.summary,
         datePublished: c.date,
         url: `${BASE_URL}/vendor/${toSlug(c.vendor)}`,
+        publisher: { "@type": "Organization", name: "AgentDeals", url: BASE_URL },
       },
     })),
   };


### PR DESCRIPTION
## Summary

Google Search Console flagged 7 Events structured data issues on agentdeals.dev. Investigation found no explicit Event schema anywhere in the codebase — Google is auto-detecting event-like content (pricing shutdowns, deadline dates) on pages that discuss deal changes.

**Fix:** Changed the JSON-LD `@type` from generic `Article` to `NewsArticle` with `publisher` field on `/changes` and `/expiring` pages. `NewsArticle` is a more specific type that clearly communicates "this is reporting/news about pricing changes" rather than a calendar event.

**Pages affected:**
- `/changes` — deal change timeline (50 items in JSON-LD)
- `/expiring` — upcoming free tier changes (50 items in JSON-LD)

**E2E verified:** NewsArticle type and publisher field present in JSON-LD output on both pages.

**Note:** This is a targeted fix for the 2 pages with Article schema. The other 5 flagged pages (4 timely alternatives + landing page) use SoftwareApplication schema and the misclassification is purely from content analysis — no schema change will help there. Those may require re-validation in Search Console.

Refs Rob's journal note from 2026-03-19 about Google Search Console email.

## Test plan
- [x] 289/290 tests pass (1 pre-existing flaky server startup timeout)
- [x] E2E: `/changes` returns `NewsArticle` type with `publisher` field
- [x] E2E: `/expiring` returns `NewsArticle` type with `publisher` field
- [x] Landing page unaffected (no NewsArticle)
- [ ] After deploy: re-validate affected pages in Google Search Console