### PR TITLE
Enhance server.json for GitHub MCP Registry publish

### DIFF
--- a/server.json
+++ b/server.json
@@ -1,12 +1,21 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.robhunter/agentdeals",
+  "title": "AgentDeals",
   "description": "MCP server aggregating developer infrastructure deals, free tiers, and startup programs",
   "version": "0.2.0",
+  "websiteUrl": "https://agentdeals.dev",
   "repository": {
     "url": "https://github.com/robhunter/agentdeals",
     "source": "github"
   },
+  "icons": [
+    {
+      "src": "https://agentdeals.dev/favicon.png",
+      "size": "400x400",
+      "mediaType": "image/png"
+    }
+  ],
   "remotes": [
     {
       "type": "streamable-http",


### PR DESCRIPTION
## Summary

Enhances `server.json` with metadata fields for GitHub MCP Registry listing:
- Added `title` ("AgentDeals") for display name in registry UIs
- Added `websiteUrl` pointing to https://agentdeals.dev
- Added `icons` array with the 400x400 logo served at `/favicon.png`

The `mcpName` field was already present in `package.json`. Validated with `mcp-publisher validate` ✅

## Manual step required

The `mcp-publisher publish` command requires interactive GitHub OAuth (browser-based device flow). Rob needs to run:

```bash
mcp-publisher login github
mcp-publisher publish
```

Install: `brew install mcp-publisher` (or download binary from https://github.com/modelcontextprotocol/registry/releases)

## Test plan

- [x] `mcp-publisher validate` passes ✅
- [x] 290/290 tests pass
- [ ] Rob runs `mcp-publisher login github` + `mcp-publisher publish`
- [ ] AgentDeals visible at github.com/mcp

Refs #363