### PR TITLE
Data quality: Add Cloudflare free tiers, fix DigitalOcean managed DB claim

### DIFF
--- a/data/deal_changes.json
+++ b/data/deal_changes.json
@@ -962,6 +962,18 @@
       "source_url": "https://www.hashicorp.com/blog/hashicorp-adopts-business-source-license",
       "category": "Infrastructure",
       "alternatives": ["OpenTofu", "Pulumi", "Crossplane"]
+    },
+    {
+      "vendor": "DigitalOcean",
+      "change_type": "restriction",
+      "date": "2026-03-21",
+      "summary": "Managed databases are not part of the free tier. Pricing starts at $15/month. Previous listing incorrectly included '1 basic cluster' as a free tier benefit",
+      "previous_state": "Listed as: Free static sites (up to 3), functions (90K GiB-seconds/mo), and managed databases (1 basic cluster)",
+      "current_state": "Free static sites (up to 3) and functions (90K GiB-seconds/mo). Managed databases start at $15/mo, not free",
+      "impact": "medium",
+      "source_url": "https://www.digitalocean.com/pricing",
+      "category": "Cloud IaaS",
+      "alternatives": ["Neon", "PlanetScale", "Supabase"]
     }
   ]
 }

--- a/data/index.json
+++ b/data/index.json
@@ -32,7 +32,7 @@
     {
       "vendor": "Cloudflare Workers",
       "category": "Cloud Hosting",
-      "description": "Edge compute with 100K requests/day free",
+      "description": "Edge compute with 100K requests/day, 10ms CPU time per invocation. Includes cron triggers, WebSockets, and service bindings",
       "tier": "Free",
       "url": "https://developers.cloudflare.com/workers/platform/pricing/",
       "tags": [
@@ -42,7 +42,7 @@
         "workers",
         "hetzner-alternative"
       ],
-      "verifiedDate": "2026-03-11"
+      "verifiedDate": "2026-03-21"
     },
     {
       "vendor": "Netlify",
@@ -202,7 +202,7 @@
     {
       "vendor": "DigitalOcean",
       "category": "Cloud IaaS",
-      "description": "$200 credit for 60 days for new accounts. Free static sites (up to 3), functions (90K GiB-seconds/mo), and managed databases (1 basic cluster)",
+      "description": "$200 credit for 60 days for new accounts. Free static sites (up to 3) and functions (90K GiB-seconds/mo). Note: managed databases are not included in free tier (start at $15/mo)",
       "tier": "Credits",
       "url": "https://www.digitalocean.com/pricing",
       "tags": [
@@ -213,7 +213,7 @@
         "free tier",
         "hetzner-alternative"
       ],
-      "verifiedDate": "2026-03-14",
+      "verifiedDate": "2026-03-21",
       "expires_date": "2026-06-30"
     },
     {
@@ -890,7 +890,7 @@
     {
       "vendor": "Cloudflare Queues",
       "category": "Messaging",
-      "description": "Message queues on Workers \u2014 10K operations/day free, 24-hour message retention",
+      "description": "Message queues on Workers \u2014 1M operations/month free, 24-hour message retention. Added to free plan late 2025",
       "tier": "Free",
       "url": "https://developers.cloudflare.com/queues/platform/pricing/",
       "tags": [
@@ -900,7 +900,38 @@
         "cloudflare",
         "free tier"
       ],
-      "verifiedDate": "2026-03-14"
+      "verifiedDate": "2026-03-21"
+    },
+    {
+      "vendor": "Cloudflare KV",
+      "category": "Databases",
+      "description": "Key-value store at the edge \u2014 100K reads/day, 1K writes/day, 1 GB storage. Eventually consistent with global replication",
+      "tier": "Free",
+      "url": "https://developers.cloudflare.com/kv/platform/pricing/",
+      "tags": [
+        "key-value",
+        "edge",
+        "serverless",
+        "cloudflare",
+        "free tier"
+      ],
+      "verifiedDate": "2026-03-21"
+    },
+    {
+      "vendor": "Cloudflare Durable Objects",
+      "category": "Cloud Hosting",
+      "description": "Stateful serverless compute \u2014 100K requests/day on free plan. Strongly consistent storage with WebSocket hibernation. SQLite storage included (first 10 GB on paid plan)",
+      "tier": "Free",
+      "url": "https://developers.cloudflare.com/durable-objects/platform/pricing/",
+      "tags": [
+        "serverless",
+        "stateful",
+        "edge",
+        "cloudflare",
+        "websocket",
+        "free tier"
+      ],
+      "verifiedDate": "2026-03-21"
     },
     {
       "vendor": "QStash",

--- a/test/deal-changes.test.ts
+++ b/test/deal-changes.test.ts
@@ -76,7 +76,7 @@ describe("track_changes tool", () => {
 
     assert.ok(Array.isArray(body.changes));
     assert.strictEqual(body.total, body.changes.length);
-    assert.strictEqual(body.total, 62);
+    assert.strictEqual(body.total, 63);
   });
 
   it("filters by date (since)", async () => {


### PR DESCRIPTION
## Summary

- **Cloudflare KV**: Added free tier entry (100K reads/day, 1K writes/day, 1 GB storage)
- **Cloudflare Durable Objects**: Added free tier entry (100K requests/day, WebSocket hibernation)
- **Cloudflare Queues**: Updated from 10K ops/day to 1M ops/month (late 2025 free plan expansion)
- **Cloudflare Workers**: Enhanced description with 10ms CPU time limit
- **DigitalOcean**: Removed incorrect "managed databases (1 basic cluster)" claim — managed DBs start at $15/mo
- **Brave Search API**: Already tracked — entry updated 2026-03-20, deal_change for Feb 2026 free tier removal exists
- Added DigitalOcean deal_change entry for the managed DB correction
- Updated deal_changes test count (62 → 63)

290 tests passing (289 + 1 pre-existing flaky costs.test.ts timeout).

Refs #365