### PR TITLE
Add /freshping-alternatives page for Freshping shutdown

### DIFF
--- a/data/deal_changes.json
+++ b/data/deal_changes.json
@@ -109,7 +109,7 @@
       "vendor": "Supabase",
       "change_type": "limits_reduced",
       "date": "2026-02-01",
-      "summary": "Project pause policy tightened — inactive projects now pause after 1 week",
+      "summary": "Project pause policy tightened \u2014 inactive projects now pause after 1 week",
       "previous_state": "Longer inactivity window before project pause",
       "current_state": "Projects pause after 1 week of inactivity on free tier",
       "impact": "medium",
@@ -125,7 +125,7 @@
       "vendor": "Cloudflare",
       "change_type": "new_free_tier",
       "date": "2026-02-04",
-      "summary": "Queues added to Workers free plan — message queuing now free",
+      "summary": "Queues added to Workers free plan \u2014 message queuing now free",
       "previous_state": "Queues was paid-only",
       "current_state": "Queues included in free Workers plan",
       "impact": "medium",
@@ -139,7 +139,7 @@
       "date": "2026-01-01",
       "summary": "Self-hosted runner per-minute fee ($0.002/min) announced for March 2026 was postponed indefinitely after community backlash. Self-hosted runners remain free. Separately, hosted runner prices were reduced up to 39% (Jan 2026)",
       "previous_state": "Self-hosted runners free. Previous per-minute pricing for hosted runners",
-      "current_state": "Self-hosted runners remain free — no orchestration fees. Hosted runners 39% cheaper. GitHub re-evaluating self-hosted pricing approach",
+      "current_state": "Self-hosted runners remain free \u2014 no orchestration fees. Hosted runners 39% cheaper. GitHub re-evaluating self-hosted pricing approach",
       "impact": "low",
       "source_url": "https://github.com/orgs/community/discussions/182089",
       "category": "CI/CD",
@@ -169,7 +169,7 @@
       "vendor": "Bright Data MCP",
       "change_type": "new_free_tier",
       "date": "2025-08-14",
-      "summary": "Launched free tier for MCP Web Server — 5,000 requests/month for agent developers",
+      "summary": "Launched free tier for MCP Web Server \u2014 5,000 requests/month for agent developers",
       "previous_state": "Paid-only web scraping API",
       "current_state": "5,000 free monthly requests on Rapid mode, includes search_engine and scrape_as_markdown tools, handles JS rendering and CAPTCHAs",
       "impact": "medium",
@@ -184,8 +184,8 @@
       "vendor": "Stripe",
       "change_type": "pricing_restructured",
       "date": "2026-02-01",
-      "summary": "Managed Payments (Merchant of Record) service entering general availability — Stripe handles tax, billing, fraud, and disputes",
-      "previous_state": "Payment processing only — developers handled tax compliance, fraud, and disputes separately",
+      "summary": "Managed Payments (Merchant of Record) service entering general availability \u2014 Stripe handles tax, billing, fraud, and disputes",
+      "previous_state": "Payment processing only \u2014 developers handled tax compliance, fraud, and disputes separately",
       "current_state": "Managed Payments acts as Merchant of Record in 75+ countries, handling sales tax/VAT/GST, fraud prevention, dispute resolution, and transaction-level support",
       "impact": "high",
       "source_url": "https://docs.stripe.com/payments/managed-payments",
@@ -218,7 +218,7 @@
       "change_type": "pricing_restructured",
       "date": "2026-01-01",
       "summary": "Forge platform moved from free to consumption-based billing for compute and storage",
-      "previous_state": "Entirely free — no charges for compute, storage, or KV operations",
+      "previous_state": "Entirely free \u2014 no charges for compute, storage, or KV operations",
       "current_state": "Free monthly allowances per app (100K GB-sec compute, 0.1 GB KVS, 1 GB logs, 1 hr SQL), usage above thresholds billed",
       "impact": "medium",
       "source_url": "https://www.atlassian.com/blog/developer/updates-to-forge-pricing-effective-january-2026",
@@ -232,7 +232,7 @@
       "vendor": "Fly.io",
       "change_type": "pricing_restructured",
       "date": "2026-01-01",
-      "summary": "Volume snapshots now billed — previously free automatic snapshots now cost $0.08/GB-month",
+      "summary": "Volume snapshots now billed \u2014 previously free automatic snapshots now cost $0.08/GB-month",
       "previous_state": "Automatic volume snapshots included at no cost, enabled by default",
       "current_state": "$0.08/GB-month for snapshot storage, first 10 GB free. Snapshots can be disabled to avoid charges",
       "impact": "medium",
@@ -248,7 +248,7 @@
       "vendor": "Cloudflare Durable Objects",
       "change_type": "pricing_restructured",
       "date": "2026-01-07",
-      "summary": "SQLite storage billing began for Durable Objects — previously free during beta",
+      "summary": "SQLite storage billing began for Durable Objects \u2014 previously free during beta",
       "previous_state": "SQLite storage in Durable Objects was free during public beta (compute already billed)",
       "current_state": "Storage charged per GB-hour on Workers Paid plan, first 10 GB included. Free plan users unaffected",
       "impact": "low",
@@ -280,7 +280,7 @@
       "vendor": "Neon",
       "change_type": "pricing_restructured",
       "date": "2026-01-15",
-      "summary": "Moved to fully usage-based pricing model post-Databricks acquisition — free tier storage now per-project, projects increased 10→100, branches capped at 10 per project, Neon Auth added",
+      "summary": "Moved to fully usage-based pricing model post-Databricks acquisition \u2014 free tier storage now per-project, projects increased 10\u2192100, branches capped at 10 per project, Neon Auth added",
       "previous_state": "Free tier: 0.5 GB total storage, 191.9 compute hours, 10 projects, unlimited branches",
       "current_state": "Free tier: 0.5 GB per project (up to 5 GB across 100 projects), 100 CU-hours/month per project, 10 branches/project, Neon Auth 60K MAU, auto-scaling up to 2 CU, scale-to-zero",
       "impact": "medium",
@@ -296,7 +296,7 @@
       "vendor": "Vercel",
       "change_type": "pricing_restructured",
       "date": "2026-01-01",
-      "summary": "Pro plan moved to credit-based model ($20/mo credit pool), Hobby plan metrics renamed and restructured — bandwidth→Fast Data Transfer, serverless split into Active CPU + Provisioned Memory, Blob Storage and Image Transformations added",
+      "summary": "Pro plan moved to credit-based model ($20/mo credit pool), Hobby plan metrics renamed and restructured \u2014 bandwidth\u2192Fast Data Transfer, serverless split into Active CPU + Provisioned Memory, Blob Storage and Image Transformations added",
       "previous_state": "Hobby: 100 GB bandwidth, 100 GB-hours serverless. Pro: fixed per-resource allocations",
       "current_state": "Hobby: 100 GB/mo Fast Data Transfer, 4 hrs Active CPU, 360 GB-hrs Provisioned Memory, 1M edge requests, 1 GB Blob Storage, 5K image transformations. Pro: $20/mo credit pool across all resources, SAML SSO and HIPAA included",
       "impact": "medium",
@@ -312,7 +312,7 @@
       "vendor": "Atlassian",
       "change_type": "pricing_restructured",
       "date": "2026-02-17",
-      "summary": "Data Center pricing increased 15-40% across Jira, Confluence, and JSM. New DC licenses end March 30 — cloud mandatory for new customers",
+      "summary": "Data Center pricing increased 15-40% across Jira, Confluence, and JSM. New DC licenses end March 30 \u2014 cloud mandatory for new customers",
       "previous_state": "Standard Data Center pricing with Advantaged/legacy discounts",
       "current_state": "15% standard list increase, 18-40% for legacy Advantaged pricing tiers. No new DC licenses after March 30, 2026. Full DC end-of-life March 2029",
       "impact": "high",
@@ -328,7 +328,7 @@
       "vendor": "Docker Hub",
       "change_type": "pricing_restructured",
       "date": "2024-12-10",
-      "summary": "Docker Pro +80% ($5→$9/mo), Team +67% ($9→$15/mo). Free tier: Build Cloud minutes removed, Scout repos cut 3→1, private repos limited to 1 with 2GB storage",
+      "summary": "Docker Pro +80% ($5\u2192$9/mo), Team +67% ($9\u2192$15/mo). Free tier: Build Cloud minutes removed, Scout repos cut 3\u21921, private repos limited to 1 with 2GB storage",
       "previous_state": "Pro $5/user/month, Team $9/user/month. Free tier included Build Cloud minutes, 3 Scout repos",
       "current_state": "Pro $9/user/month, Team $15/user/month. Free: 1 private repo (2GB), 1 Scout repo, no Build Cloud minutes, 40 pulls/hour",
       "impact": "high",
@@ -409,7 +409,7 @@
       "date": "2026-08-26",
       "summary": "Assistants API deprecated, full shutdown August 26, 2026. Developers must migrate to Responses API + Conversations API",
       "previous_state": "Assistants API available with code interpreter, file search, function calling, and Threads for conversation management",
-      "current_state": "Deprecated. Full shutdown Aug 26, 2026. Migration required: Assistants → Prompts + Responses API, Threads → Conversations API. No automated migration tool provided",
+      "current_state": "Deprecated. Full shutdown Aug 26, 2026. Migration required: Assistants \u2192 Prompts + Responses API, Threads \u2192 Conversations API. No automated migration tool provided",
       "impact": "high",
       "source_url": "https://community.openai.com/t/assistants-api-beta-deprecation-august-26-2026-sunset/1354666",
       "category": "AI/ML",
@@ -423,8 +423,8 @@
       "vendor": "Hetzner",
       "change_type": "pricing_restructured",
       "date": "2026-04-01",
-      "summary": "Cloud & dedicated server prices increasing 30-50%. Entry-level CX23: €2.99→€3.99/mo (+33%). Applies to new and existing customers. Driven by DRAM (+171% YoY) and NVMe SSD cost surges from AI infrastructure demand",
-      "previous_state": "Lower cloud server pricing across Germany, Finland, US, and Singapore data centers (e.g., CX23 at €2.99/mo)",
+      "summary": "Cloud & dedicated server prices increasing 30-50%. Entry-level CX23: \u20ac2.99\u2192\u20ac3.99/mo (+33%). Applies to new and existing customers. Driven by DRAM (+171% YoY) and NVMe SSD cost surges from AI infrastructure demand",
+      "previous_state": "Lower cloud server pricing across Germany, Finland, US, and Singapore data centers (e.g., CX23 at \u20ac2.99/mo)",
       "current_state": "30-37% increase on cloud servers, up to 50% on select dedicated/storage products. All regions and all customers (new and existing) affected. Announced Feb 23, 2026",
       "impact": "high",
       "source_url": "https://www.hetzner.com/pressroom/statement-price-adjustment/",
@@ -439,7 +439,7 @@
       "vendor": "Anthropic",
       "change_type": "limits_increased",
       "date": "2026-02-05",
-      "summary": "Claude Opus 4.6 API pricing at $5/$25 per MTok (input/output) — 67% below previous Opus 4/4.1 pricing of $15/$75. Frontier AI model at mid-tier prices",
+      "summary": "Claude Opus 4.6 API pricing at $5/$25 per MTok (input/output) \u2014 67% below previous Opus 4/4.1 pricing of $15/$75. Frontier AI model at mid-tier prices",
       "previous_state": "Opus 4/4.1 priced at $15/$75 per million tokens (input/output)",
       "current_state": "Opus 4.6 at $5/$25 per MTok. Extended context (>200K tokens): $10/$37.50. Batch API: $2.50/$12.50. Price reduction began with Opus 4.5 generation",
       "impact": "high",
@@ -737,7 +737,7 @@
       "change_type": "new_free_tier",
       "date": "2025-12-15",
       "summary": "Gruntwork launches free tier for Terragrunt Scale IaC orchestration platform, positioned as HCP Terraform free tier alternative ahead of HashiCorp March 31, 2026 EOL. Includes GitOps, drift detection, and module update automation",
-      "previous_state": "No free tier — Team plan at $500/month",
+      "previous_state": "No free tier \u2014 Team plan at $500/month",
       "current_state": "Free tier with limits matching or exceeding HCP Terraform (500+ managed resources, GitOps, drift detection, Patcher)",
       "impact": "medium",
       "source_url": "https://www.gruntwork.io/blog/announcing-the-terragrunt-scale-free-tier",
@@ -790,7 +790,11 @@
       "impact": "high",
       "source_url": "https://devin.ai/pricing",
       "category": "AI Coding",
-      "alternatives": ["GitHub Copilot", "Cline", "Aider"]
+      "alternatives": [
+        "GitHub Copilot",
+        "Cline",
+        "Aider"
+      ]
     },
     {
       "vendor": "Cursor",
@@ -802,7 +806,10 @@
       "impact": "medium",
       "source_url": "https://www.cursor.com/pricing",
       "category": "AI Coding",
-      "alternatives": ["Windsurf", "GitHub Copilot"]
+      "alternatives": [
+        "Windsurf",
+        "GitHub Copilot"
+      ]
     },
     {
       "vendor": "Augment Code",
@@ -814,13 +821,16 @@
       "impact": "medium",
       "source_url": "https://www.augmentcode.com/pricing",
       "category": "AI Coding",
-      "alternatives": ["GitHub Copilot", "Cursor"]
+      "alternatives": [
+        "GitHub Copilot",
+        "Cursor"
+      ]
     },
     {
       "vendor": "Google Tenor API",
       "change_type": "product_deprecated",
       "date": "2026-06-30",
-      "summary": "Google Tenor public API shutting down June 30, 2026. New API key signups halted January 13, 2026. Only the public GIF search API is affected — Tenor website and app continue operating. Developers must migrate to alternative GIF APIs",
+      "summary": "Google Tenor public API shutting down June 30, 2026. New API key signups halted January 13, 2026. Only the public GIF search API is affected \u2014 Tenor website and app continue operating. Developers must migrate to alternative GIF APIs",
       "previous_state": "Free public API for GIF search, trending GIFs, and autocomplete. No rate limits for reasonable use. Used by messaging apps and social platforms",
       "current_state": "API shutdown June 30, 2026. No new API keys issued since Jan 13, 2026. Existing keys work until shutdown date. No replacement API from Google",
       "impact": "high",
@@ -835,25 +845,33 @@
       "vendor": "Testcontainers Cloud",
       "change_type": "pricing_restructured",
       "date": "2024-06-01",
-      "summary": "Docker acquired AtomicJar (creators of Testcontainers Cloud). Standalone Testcontainers Cloud free tier retired — now bundled into Docker subscriptions. Docker Pro gets 100 min/month, Team 500 min/month, Business 1,500 min/month",
+      "summary": "Docker acquired AtomicJar (creators of Testcontainers Cloud). Standalone Testcontainers Cloud free tier retired \u2014 now bundled into Docker subscriptions. Docker Pro gets 100 min/month, Team 500 min/month, Business 1,500 min/month",
       "previous_state": "Standalone Testcontainers Cloud with independent free tier (100 min/month)",
       "current_state": "Bundled with Docker subscriptions. No standalone free tier. Open-source Testcontainers libraries remain MIT-licensed and fully free",
       "impact": "medium",
       "source_url": "https://testcontainers.com/cloud/",
       "category": "Testing",
-      "alternatives": ["Testcontainers (open-source)", "Docker Desktop", "Podman"]
+      "alternatives": [
+        "Testcontainers (open-source)",
+        "Docker Desktop",
+        "Podman"
+      ]
     },
     {
       "vendor": "Docker Desktop",
       "change_type": "pricing_restructured",
       "date": "2026-01-01",
-      "summary": "Docker Desktop subscription prices increased 67-80% across all tiers. Personal $7→$11, Pro $9→$14, Team $15→$24, Business $24→$35 per user/month. Separate from Docker Hub registry pricing changes",
+      "summary": "Docker Desktop subscription prices increased 67-80% across all tiers. Personal $7\u2192$11, Pro $9\u2192$14, Team $15\u2192$24, Business $24\u2192$35 per user/month. Separate from Docker Hub registry pricing changes",
       "previous_state": "Personal $7/user/month, Pro $9/user/month, Team $15/user/month, Business $24/user/month",
       "current_state": "Personal $11/user/month (+57%), Pro $14/user/month (+56%), Team $24/user/month (+60%), Business $35/user/month (+46%). All tiers affected",
       "impact": "high",
       "source_url": "https://www.docker.com/pricing/",
       "category": "Container Registry",
-      "alternatives": ["Podman Desktop", "Rancher Desktop", "OrbStack"]
+      "alternatives": [
+        "Podman Desktop",
+        "Rancher Desktop",
+        "OrbStack"
+      ]
     },
     {
       "vendor": "Unity DevOps",
@@ -865,7 +883,11 @@
       "impact": "medium",
       "source_url": "https://unity.com/products/devops",
       "category": "Version Control",
-      "alternatives": ["Git LFS", "Perforce", "GitHub"]
+      "alternatives": [
+        "Git LFS",
+        "Perforce",
+        "GitHub"
+      ]
     },
     {
       "vendor": "Anthropic Claude",
@@ -877,7 +899,10 @@
       "impact": "low",
       "source_url": "https://www.anthropic.com/news",
       "category": "AI/ML",
-      "alternatives": ["OpenAI ChatGPT Plus", "Google Gemini Advanced"]
+      "alternatives": [
+        "OpenAI ChatGPT Plus",
+        "Google Gemini Advanced"
+      ]
     },
     {
       "vendor": "Heroku",
@@ -889,19 +914,28 @@
       "impact": "high",
       "source_url": "https://blog.heroku.com/next-chapter",
       "category": "Cloud Hosting",
-      "alternatives": ["Render", "Railway", "Fly.io", "Koyeb"]
+      "alternatives": [
+        "Render",
+        "Railway",
+        "Fly.io",
+        "Koyeb"
+      ]
     },
     {
       "vendor": "GitHub Copilot",
       "change_type": "new_free_tier",
       "date": "2025-12-18",
-      "summary": "GitHub launched Copilot Free tier — AI code completion available to all GitHub users at no cost. 2,000 completions and 50 chat messages per month included",
+      "summary": "GitHub launched Copilot Free tier \u2014 AI code completion available to all GitHub users at no cost. 2,000 completions and 50 chat messages per month included",
       "previous_state": "Paid only: Individual $10/month, Business $19/user/month. Free for verified students, teachers, and OSS maintainers only",
       "current_state": "Free tier: 2,000 code completions/month, 50 chat messages/month. Individual $10/month, Business $19/month, Enterprise $39/month remain for higher limits",
       "impact": "high",
       "source_url": "https://github.blog/news-insights/product-news/github-copilot-in-vscode-free/",
       "category": "AI Coding",
-      "alternatives": ["Cline", "Cody", "Cursor"]
+      "alternatives": [
+        "Cline",
+        "Cody",
+        "Cursor"
+      ]
     },
     {
       "vendor": "Auth0",
@@ -913,7 +947,11 @@
       "impact": "high",
       "source_url": "https://auth0.com/pricing",
       "category": "Authentication",
-      "alternatives": ["Clerk", "Firebase Auth", "Supabase Auth"]
+      "alternatives": [
+        "Clerk",
+        "Firebase Auth",
+        "Supabase Auth"
+      ]
     },
     {
       "vendor": "Railway",
@@ -925,7 +963,11 @@
       "impact": "medium",
       "source_url": "https://railway.com/pricing",
       "category": "Cloud Hosting",
-      "alternatives": ["Render", "Fly.io", "Koyeb"]
+      "alternatives": [
+        "Render",
+        "Fly.io",
+        "Koyeb"
+      ]
     },
     {
       "vendor": "Render",
@@ -937,7 +979,11 @@
       "impact": "low",
       "source_url": "https://render.com/pricing",
       "category": "Cloud Hosting",
-      "alternatives": ["Railway", "Fly.io", "Koyeb"]
+      "alternatives": [
+        "Railway",
+        "Fly.io",
+        "Koyeb"
+      ]
     },
     {
       "vendor": "Redis",
@@ -949,7 +995,12 @@
       "impact": "high",
       "source_url": "https://redis.io/blog/redis-adopts-dual-source-available-licensing/",
       "category": "Databases",
-      "alternatives": ["Valkey", "KeyDB", "DragonflyDB", "Upstash"]
+      "alternatives": [
+        "Valkey",
+        "KeyDB",
+        "DragonflyDB",
+        "Upstash"
+      ]
     },
     {
       "vendor": "HashiCorp",
@@ -961,7 +1012,11 @@
       "impact": "high",
       "source_url": "https://www.hashicorp.com/blog/hashicorp-adopts-business-source-license",
       "category": "Infrastructure",
-      "alternatives": ["OpenTofu", "Pulumi", "Crossplane"]
+      "alternatives": [
+        "OpenTofu",
+        "Pulumi",
+        "Crossplane"
+      ]
     },
     {
       "vendor": "DigitalOcean",
@@ -973,7 +1028,31 @@
       "impact": "medium",
       "source_url": "https://www.digitalocean.com/pricing",
       "category": "Cloud IaaS",
-      "alternatives": ["Neon", "PlanetScale", "Supabase"]
+      "alternatives": [
+        "Neon",
+        "PlanetScale",
+        "Supabase"
+      ]
+    },
+    {
+      "vendor": "Freshping",
+      "change_type": "free_tier_removed",
+      "date": "2026-03-06",
+      "summary": "Freshping shut down entirely. Free accounts disabled March 6, 2026. Paid plans expire at end of term. All data deleted 90 days later (~June 4, 2026). No replacement product offered by Freshworks",
+      "previous_state": "Free plan: 50 monitors, 1-minute check intervals, public status pages, multi-location checks, email/Slack alerts",
+      "current_state": "Service discontinued. No free or paid plan available",
+      "impact": "high",
+      "source_url": "https://www.freshworks.com/freshping/",
+      "category": "Monitoring",
+      "alternatives": [
+        "UptimeRobot",
+        "BetterStack",
+        "Checkly",
+        "StatusCake",
+        "Pulsetic",
+        "Cronitor",
+        "Upptime"
+      ]
     }
   ]
 }

--- a/data/index.json
+++ b/data/index.json
@@ -581,7 +581,8 @@
         "uptime",
         "logging",
         "observability",
-        "status page"
+        "status page",
+        "freshping-alternative"
       ],
       "verifiedDate": "2026-03-14"
     },
@@ -612,7 +613,8 @@
         "synthetic",
         "api",
         "browser",
-        "free tier"
+        "free tier",
+        "freshping-alternative"
       ],
       "verifiedDate": "2026-03-14"
     },
@@ -643,7 +645,8 @@
         "uptime",
         "alerts",
         "status page",
-        "free tier"
+        "free tier",
+        "freshping-alternative"
       ],
       "verifiedDate": "2026-03-14"
     },
@@ -2335,7 +2338,8 @@
         "monitoring",
         "uptime",
         "status-page",
-        "alerting"
+        "alerting",
+        "freshping-alternative"
       ],
       "verifiedDate": "2026-03-14"
     },
@@ -2978,7 +2982,8 @@
         "uptime",
         "monitoring",
         "incidents",
-        "alerts"
+        "alerts",
+        "freshping-alternative"
       ],
       "verifiedDate": "2026-03-20"
     },
@@ -3328,7 +3333,8 @@
         "status page",
         "monitoring",
         "uptime",
-        "open source"
+        "open source",
+        "freshping-alternative"
       ],
       "verifiedDate": "2026-03-20"
     },
@@ -3342,7 +3348,8 @@
         "status page",
         "monitoring",
         "github",
-        "open source"
+        "open source",
+        "freshping-alternative"
       ],
       "verifiedDate": "2026-03-20"
     },
@@ -4331,7 +4338,8 @@
         "monitoring",
         "uptime",
         "status",
-        "alerts"
+        "alerts",
+        "freshping-alternative"
       ],
       "verifiedDate": "2026-03-20"
     },
@@ -4448,7 +4456,8 @@
         "cron",
         "uptime",
         "status-page",
-        "alerts"
+        "alerts",
+        "freshping-alternative"
       ],
       "verifiedDate": "2026-03-20"
     },
@@ -5125,7 +5134,8 @@
         "monitoring",
         "uptime",
         "website",
-        "alerts"
+        "alerts",
+        "freshping-alternative"
       ],
       "verifiedDate": "2026-03-20"
     },
@@ -5140,7 +5150,8 @@
         "uptime",
         "status-page",
         "ssl",
-        "alerts"
+        "alerts",
+        "freshping-alternative"
       ],
       "verifiedDate": "2026-03-20"
     },
@@ -5156,7 +5167,8 @@
         "status-page",
         "api",
         "cron",
-        "ssl"
+        "ssl",
+        "freshping-alternative"
       ],
       "verifiedDate": "2026-03-20"
     },
@@ -5218,7 +5230,8 @@
         "server",
         "uptime",
         "website",
-        "alerts"
+        "alerts",
+        "freshping-alternative"
       ],
       "verifiedDate": "2026-03-20"
     },
@@ -5657,7 +5670,7 @@
     {
       "vendor": "Scalr",
       "category": "Infrastructure",
-      "description": "Terraform Automation and Collaboration (TACO) platform — full Terraform CLI support, OPA integration, hierarchical configuration model. No SSO tax. All features included. Up to 50 runs/month free",
+      "description": "Terraform Automation and Collaboration (TACO) platform \u2014 full Terraform CLI support, OPA integration, hierarchical configuration model. No SSO tax. All features included. Up to 50 runs/month free",
       "tier": "Free",
       "url": "https://www.scalr.com/pricing",
       "tags": [

--- a/src/serve.ts
+++ b/src/serve.ts
@@ -2446,6 +2446,75 @@ const ALTERNATIVES_PAGES: AlternativesPageConfig[] = [
     tag: "hetzner-alternative",
     primaryVendor: "Hetzner",
   },
+  {
+    slug: "freshping-alternatives",
+    title: "Freshping Alternatives — Free Uptime Monitoring Tools for 2026",
+    metaDesc: "Freshping shut down March 6, 2026. Compare free uptime monitoring alternatives: UptimeRobot, Better Stack, Checkly, StatusCake, Pulsetic, Cronitor. Verified pricing.",
+    contextHtml: `<p><strong>Freshping</strong> — Freshworks' free uptime monitoring tool that offered <strong>50 monitors with 1-minute check intervals</strong> and public status pages — <strong>shut down on March 6, 2026</strong>. Free accounts have been disabled, paid plans will expire at end of term, and all data will be deleted 90 days later (~June 4, 2026). Freshworks has not offered a replacement product.</p>
+      <p>If you relied on Freshping for uptime monitoring, here are the best free alternatives — several match or exceed Freshping's 50-monitor free tier.</p>`,
+    tag: "freshping-alternative",
+    primaryVendor: "Freshping",
+    serviceMatrixHtml: `
+  <h2>Free Tier Comparison</h2>
+  <p style="color:var(--text-muted);margin-bottom:1rem">How each alternative's free tier compares to what Freshping offered. Freshping's free plan included 50 monitors, 1-minute intervals, and public status pages.</p>
+  <div style="overflow-x:auto">
+  <table class="compare-table">
+    <thead>
+      <tr>
+        <th>Tool</th>
+        <th>Free Monitors</th>
+        <th>Check Interval</th>
+        <th>Status Pages</th>
+        <th>Alerts</th>
+        <th>Log Retention</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td style="font-weight:600;color:var(--text-dim)">Freshping (discontinued)</td>
+        <td>50</td><td>1 min</td><td>\u2705</td><td>Email, Slack</td>
+        <td>6 months</td>
+      </tr>
+      <tr>
+        <td style="font-weight:600"><a href="/vendor/uptimerobot" style="color:var(--text)">UptimeRobot</a></td>
+        <td>50</td><td>5 min</td><td>\u2705</td><td>Email</td>
+        <td>3 months</td>
+      </tr>
+      <tr>
+        <td style="font-weight:600"><a href="/vendor/better-stack" style="color:var(--text)">Better Stack</a></td>
+        <td>10</td><td>3 min</td><td>\u2705</td><td>Email, Slack</td>
+        <td>3 days</td>
+      </tr>
+      <tr>
+        <td style="font-weight:600"><a href="/vendor/checkly" style="color:var(--text)">Checkly</a></td>
+        <td>10</td><td>10 min</td><td>\u2014</td><td>Email, Slack</td>
+        <td>30 days</td>
+      </tr>
+      <tr>
+        <td style="font-weight:600"><a href="/vendor/statuscake" style="color:var(--text)">StatusCake</a></td>
+        <td>10</td><td>5 min</td><td>\u2014</td><td>Email</td>
+        <td>7 days</td>
+      </tr>
+      <tr>
+        <td style="font-weight:600"><a href="/vendor/pulsetic" style="color:var(--text)">Pulsetic</a></td>
+        <td>10</td><td>5 min</td><td>\u2705</td><td>Email</td>
+        <td>3 months</td>
+      </tr>
+      <tr>
+        <td style="font-weight:600"><a href="/vendor/cronitor" style="color:var(--text)">Cronitor</a></td>
+        <td>5</td><td>5 min</td><td>\u2705</td><td>Email, Slack</td>
+        <td>30 days</td>
+      </tr>
+      <tr>
+        <td style="font-weight:600"><a href="/vendor/upptime" style="color:var(--text)">Upptime</a></td>
+        <td>Unlimited</td><td>5 min</td><td>\u2705</td><td>Email</td>
+        <td>Unlimited</td>
+      </tr>
+    </tbody>
+  </table>
+  </div>
+  <p style="color:var(--text-dim);font-size:.8rem;margin-top:.5rem">\u2705 = included in free tier &nbsp; \u2014 = not included or requires paid plan. UptimeRobot free tier is for personal/non-commercial use only.</p>`,
+  },
 ];
 
 const alternativesPageMap = new Map<string, AlternativesPageConfig>();

--- a/test/deal-changes.test.ts
+++ b/test/deal-changes.test.ts
@@ -76,7 +76,7 @@ describe("track_changes tool", () => {
 
     assert.ok(Array.isArray(body.changes));
     assert.strictEqual(body.total, body.changes.length);
-    assert.strictEqual(body.total, 63);
+    assert.strictEqual(body.total, 64);
   });
 
   it("filters by date (since)", async () => {

--- a/test/http.test.ts
+++ b/test/http.test.ts
@@ -1509,6 +1509,22 @@ describe("HTTP transport", () => {
     assert.ok(html.includes("30-50%"), "Should mention the price increase");
   });
 
+  it("GET /freshping-alternatives renders alternatives page", async () => {
+    proc = await startHttpServer();
+
+    const response = await fetch(`http://localhost:${PORT}/freshping-alternatives`);
+    assert.strictEqual(response.status, 200);
+    assert.ok(response.headers.get("content-type")?.includes("text/html"));
+    const html = await response.text();
+    assert.ok(html.includes("Freshping Alternatives"), "Should have Freshping title");
+    assert.ok(html.includes("application/ld+json"), "Should have JSON-LD");
+    assert.ok(html.includes("canonical"), "Should have canonical link");
+    assert.ok(html.includes("global-nav"), "Should have global nav");
+    assert.ok(html.includes("Top Alternatives"), "Should have alternatives section");
+    assert.ok(html.includes("March 6, 2026"), "Should mention the shutdown date");
+    assert.ok(html.includes("Free Tier Comparison"), "Should have comparison matrix");
+  });
+
   // --- Search page ---
 
   it("GET /search renders search page with search box", async () => {


### PR DESCRIPTION
## Summary

Refs #367

- New `/freshping-alternatives` timely alternatives page — Freshping (Freshworks' free uptime monitoring) shut down March 6, 2026
- 13 tagged alternatives: UptimeRobot, Better Stack, Checkly, StatusCake, Pulsetic, Cronitor, Upptime, OpenStatus, Instatus, OnlineOrNot, Hyperping, Uptimia, 360 Monitoring
- Free tier comparison matrix (monitors count, check interval, status pages, alerts, log retention)
- Freshping deal_change entry (free_tier_removed, high impact)
- Auto-included in sitemap.xml, IndexNow, JSON-LD structured data
- Updated deal_changes test count

## Test plan

- [x] New test: `GET /freshping-alternatives renders alternatives page` — verifies 200, HTML content, JSON-LD, canonical, nav, shutdown date, comparison matrix
- [x] deal-changes test count updated and passing (11/11)
- [x] E2E verified: page renders with 13 vendor cards, comparison matrix, sitemap entry
- [x] Full suite: 290/291 pass (1 pre-existing flaky costs.test.ts timeout)