### PR TITLE
Add /postman-alternatives editorial page with comparison table

### DIFF
--- a/data/index.json
+++ b/data/index.json
@@ -4981,7 +4981,8 @@
         "api-design",
         "documentation",
         "mocking",
-        "developer-tools"
+        "developer-tools",
+        "postman-alternative"
       ],
       "verifiedDate": "2026-03-20"
     },

--- a/src/serve.ts
+++ b/src/serve.ts
@@ -2431,10 +2431,62 @@ const ALTERNATIVES_PAGES: AlternativesPageConfig[] = [
     slug: "postman-alternatives",
     title: "Postman Alternatives — Free API Testing Tools for Teams in 2026",
     metaDesc: "Postman's free plan is now single-user only (March 2026). Compare free alternatives for teams: Bruno, Hoppscotch, Insomnia, Thunder Client, Apidog. Verified pricing.",
-    contextHtml: `<p>Postman's free plan changed in <strong>March 2026</strong>: it is now <strong>single-user only</strong>. Team collaboration features — shared workspaces, collection sharing — are paywalled at $19/user/month.</p>
-      <p>If your team relied on Postman's free tier for API development, here are the best free alternatives with team-friendly features.</p>`,
+    contextHtml: `<p><strong>Postman</strong> changed its free plan on <strong>March 1, 2026</strong>: it is now <strong>single-user only</strong>. Team collaboration features — shared workspaces, collection sharing, and team roles — have been removed from the free tier. The Team plan starts at <strong>$19/user/month</strong>. Previously, up to 3 users could collaborate in shared workspaces for free.</p>
+      <p>This is one of the most impactful free tier removals in 2026 — Postman has millions of developer users. If your team relied on Postman's free plan for API development, here are the best free alternatives with collaboration and team-friendly features.</p>`,
     tag: "postman-alternative",
     primaryVendor: "Postman",
+    serviceMatrixHtml: `
+  <h2>Free Tier Comparison</h2>
+  <p style="color:var(--text-muted);margin-bottom:1rem">How each alternative's free tier compares to what Postman offered. Postman's free plan previously supported 3 users with shared workspaces and collection sharing.</p>
+  <div style="overflow-x:auto">
+  <table class="compare-table">
+    <thead>
+      <tr>
+        <th>Tool</th>
+        <th>Free Users</th>
+        <th>REST</th>
+        <th>GraphQL</th>
+        <th>Team Collab</th>
+        <th>Git-Friendly</th>
+        <th>Self-Hostable</th>
+        <th>License</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td style="font-weight:600;color:var(--text-dim)">Postman (now single-user)</td>
+        <td>1</td><td>\u2705</td><td>\u2705</td><td>\u274c</td><td>\u2014</td><td>\u2014</td>
+        <td style="color:var(--text-dim)">Proprietary</td>
+      </tr>
+      <tr>
+        <td style="font-weight:600"><a href="/vendor/apidog" style="color:var(--text)">Apidog</a></td>
+        <td>4</td><td>\u2705</td><td>\u2705</td><td>\u2705</td><td>\u2014</td><td>\u2014</td>
+        <td>Proprietary</td>
+      </tr>
+      <tr>
+        <td style="font-weight:600"><a href="/vendor/bruno" style="color:var(--text)">Bruno</a></td>
+        <td>Unlimited</td><td>\u2705</td><td>\u2705</td><td>\u2705 (via Git)</td><td>\u2705</td><td>\u2014</td>
+        <td>MIT</td>
+      </tr>
+      <tr>
+        <td style="font-weight:600"><a href="/vendor/hoppscotch" style="color:var(--text)">Hoppscotch</a></td>
+        <td>Unlimited</td><td>\u2705</td><td>\u2705</td><td>\u2705</td><td>\u2014</td><td>\u2705</td>
+        <td>MIT</td>
+      </tr>
+      <tr>
+        <td style="font-weight:600"><a href="/vendor/thunder-client" style="color:var(--text)">Thunder Client</a></td>
+        <td>1</td><td>\u2705</td><td>\u2014</td><td>\u2014</td><td>\u2705</td><td>\u2014</td>
+        <td>Proprietary</td>
+      </tr>
+      <tr>
+        <td style="font-weight:600"><a href="/vendor/insomnia" style="color:var(--text)">Insomnia</a></td>
+        <td>Unlimited</td><td>\u2705</td><td>\u2705</td><td>\u2014</td><td>\u2014</td><td>\u2014</td>
+        <td>MIT</td>
+      </tr>
+    </tbody>
+  </table>
+  </div>
+  <p style="color:var(--text-dim);font-size:.8rem;margin-top:.5rem">\u2705 = supported &nbsp; \u274c = removed from free tier &nbsp; \u2014 = not applicable. Bruno collaboration works via Git (collections stored as files).</p>`,
   },
   {
     slug: "terraform-alternatives",

--- a/test/http.test.ts
+++ b/test/http.test.ts
@@ -1477,6 +1477,8 @@ describe("HTTP transport", () => {
     assert.ok(html.includes("global-nav"), "Should have global nav");
     assert.ok(html.includes("Top Alternatives"), "Should have alternatives section");
     assert.ok(html.includes("single-user only"), "Should mention the restriction");
+    assert.ok(html.includes("March 1, 2026"), "Should mention the date");
+    assert.ok(html.includes("Free Tier Comparison"), "Should have comparison table");
   });
 
   it("GET /terraform-alternatives renders alternatives page", async () => {


### PR DESCRIPTION
## Summary

- Expands the minimal postman-alternatives page config with detailed editorial content about Postman's March 1, 2026 free plan change (single-user only, team features paywalled at $19/user/mo)
- Adds service matrix comparing free tiers across 5 alternatives: Apidog (4 free users), Bruno (unlimited, Git-based), Hoppscotch (unlimited, self-hostable), Thunder Client (VS Code), Insomnia (MIT)
- Tags Apidog with `postman-alternative` (Bruno, Hoppscotch, Thunder Client, Insomnia already tagged)
- Cross-links automatically via `editorialByVendor` map — `/alternative-to/postman` will show CTA linking to the editorial page

## Test plan

- [x] 291/291 tests pass
- [x] Test verifies page returns 200, includes title, JSON-LD, canonical, global nav, alternatives section, "single-user only", "March 1, 2026", "Free Tier Comparison"
- [x] Apidog now appears in tagged alternatives alongside existing 4 tools

Refs #374