### PR TITLE
Add Vera AWS to index and LocalStack alternatives page

### DIFF
--- a/data/index.json
+++ b/data/index.json
@@ -4144,6 +4144,25 @@
       "verifiedDate": "2026-03-21"
     },
     {
+      "vendor": "Vera AWS",
+      "category": "Cloud IaaS",
+      "description": "Open-source local AWS emulator. v0.1 supports 89 resource types including VPCs, EC2 instances, security groups, and EBS volumes — EC2 emulation is unique among LocalStack alternatives. Includes awscli drop-in wrapper and terlocal terraform wrapper. No AWS account or Docker required. Runs entirely on your machine",
+      "tier": "Open Source",
+      "url": "https://github.com/project-vera/vera-aws",
+      "tags": [
+        "aws",
+        "cloud",
+        "testing",
+        "emulator",
+        "local-development",
+        "ec2",
+        "vpc",
+        "open-source",
+        "localstack-alternative"
+      ],
+      "verifiedDate": "2026-03-21"
+    },
+    {
       "vendor": "Brave Search API",
       "category": "Search",
       "description": "$5/month credit (~1,000 queries/mo at $5/1,000 requests). Web search, news, videos, images, LLM context endpoints. 50 req/sec rate limit. Attribution required to keep credit. Credit card required, overages billed with no spending cap. Free tier (5,000 queries/mo) removed Feb 2026",

--- a/src/serve.ts
+++ b/src/serve.ts
@@ -2362,7 +2362,7 @@ const ALTERNATIVES_PAGES: AlternativesPageConfig[] = [
   {
     slug: "localstack-alternatives",
     title: "LocalStack CE Alternatives — Free and Open Source Options for 2026",
-    metaDesc: "LocalStack Community Edition shuts down March 23, 2026. Compare free alternatives: Moto, Testcontainers, MinIO, AWS SAM CLI, DynamoDB Local, ElasticMQ. Service coverage comparison.",
+    metaDesc: "LocalStack Community Edition shuts down March 23, 2026. Compare free alternatives: Vera AWS, Moto, Testcontainers, MinIO, AWS SAM CLI, DynamoDB Local, ElasticMQ. Service coverage comparison.",
     contextHtml: `<p><strong>LocalStack Community Edition</strong> — the open-source AWS cloud emulator that let developers run S3, Lambda, DynamoDB, SQS, and 30+ other AWS services locally — <strong>shuts down on March 23, 2026</strong>. The unified Docker image now requires registration and an auth token. Commercial use requires a paid plan starting at $39/month (Starter) or $89/month (Ultimate).</p>
       <p>Unlike LocalStack, which provided a single all-in-one emulator, the migration path is typically a combination of service-specific tools. Below are the best free and open-source alternatives, organized by which AWS services they replace.</p>`,
     tag: "localstack-alternative",
@@ -2422,10 +2422,15 @@ const ALTERNATIVES_PAGES: AlternativesPageConfig[] = [
         <td>\u2705</td><td>\u2705</td><td>\u2705</td><td>\u2705</td><td>\u2705</td><td>\u2705</td><td>\u2705</td><td>\u2705</td>
         <td>MIT</td>
       </tr>
+      <tr>
+        <td style="font-weight:600"><a href="/vendor/vera-aws" style="color:var(--text)">Vera AWS</a></td>
+        <td>\u2014</td><td>\u2014</td><td>\u2014</td><td>\u2014</td><td>\u2014</td><td>\u2014</td><td>\u2014</td><td>\u2705</td>
+        <td>Open Source</td>
+      </tr>
     </tbody>
   </table>
   </div>
-  <p style="color:var(--text-dim);font-size:.8rem;margin-top:.5rem">\u2705 = supported &nbsp; \u2014 = not applicable. Testcontainers uses LocalStack or other containers under the hood for AWS services.</p>`,
+  <p style="color:var(--text-dim);font-size:.8rem;margin-top:.5rem">\u2705 = supported &nbsp; \u2014 = not applicable. Testcontainers uses LocalStack or other containers under the hood for AWS services. Vera AWS focuses on EC2/VPC infrastructure (89 resource types in v0.1).</p>`,
   },
   {
     slug: "postman-alternatives",

--- a/test/search.test.ts
+++ b/test/search.test.ts
@@ -115,7 +115,8 @@ describe("search_deals tool", () => {
 
       assert.ok(Array.isArray(offers));
       assert.ok(offers.length >= 2);
-      assert.strictEqual(body.total, offers.length);
+      assert.ok(body.total >= offers.length, "total should be >= results (pagination)");
+      assert.ok(offers.length <= 20, "default limit is 20");
       for (const offer of offers) {
         const searchable = [offer.vendor, offer.description, ...offer.tags]
           .join(" ")


### PR DESCRIPTION
Refs #386

## Changes

- **New index entry:** Vera AWS — open-source local AWS emulator with 89 resource types (VPCs, EC2 instances, security groups, EBS volumes). Unique EC2 emulation among LocalStack alternatives. Includes `awscli` drop-in wrapper and `terlocal` terraform wrapper.
- **LocalStack alternatives page:** Added Vera AWS to the service matrix comparison table with EC2 coverage highlighted. Updated meta description and footnote.
- **Search test fix:** `body.total` can exceed `results.length` when total matches > default limit (20). Changed strict equality to `>=` assertion.

## Verification

- 308 tests passing
- E2E: Vera AWS appears on /localstack-alternatives page (8 alternatives total)
- E2E: /vendor/vera-aws returns 200
- E2E: /api/offers?q=vera+aws returns the entry
- 1,545 total offers