### PR TITLE
Fix GitHub Actions deal_change + 5-entry spot-check

### DIFF
--- a/data/deal_changes.json
+++ b/data/deal_changes.json
@@ -150,22 +150,6 @@
       ]
     },
     {
-      "vendor": "GitHub Actions",
-      "change_type": "pricing_restructured",
-      "date": "2026-03-01",
-      "summary": "Self-hosted runners in private repos now incur $0.002/min cloud platform charge and consume free quota minutes. Previously postponed fee is now active. Hosted runner prices dropped up to 39% (effective Jan 2026). Public repos remain completely free",
-      "previous_state": "Self-hosted runners free in all repos. Hosted runners at previous per-minute pricing",
-      "current_state": "Self-hosted runners $0.002/min in private repos, consume free quota. Hosted runners 39% cheaper. Public repos still free for both runner types",
-      "impact": "high",
-      "source_url": "https://resources.github.com/actions/2026-pricing-changes-for-github-actions/",
-      "category": "CI/CD",
-      "alternatives": [
-        "GitLab CI",
-        "CircleCI",
-        "Buildkite"
-      ]
-    },
-    {
       "vendor": "Bright Data MCP",
       "change_type": "new_free_tier",
       "date": "2025-08-14",

--- a/data/index.json
+++ b/data/index.json
@@ -483,7 +483,7 @@
     {
       "vendor": "GitHub Actions",
       "category": "CI/CD",
-      "description": "Free CI/CD for public repos. Private repos: 2,000 min/mo GitHub-hosted runners, 500 MB artifact storage, 10 GB cache/repo. Self-hosted runners now $0.002/min in private repos and consume free quota (March 2026). Hosted runner prices reduced 39% (Jan 2026). Public repos free for all runner types",
+      "description": "Free CI/CD for public repos (unlimited minutes). Private repos: 2,000 min/mo GitHub-hosted runners, 500 MB artifact storage, 10 GB cache/repo. Self-hosted runners remain free — planned $0.002/min fee postponed indefinitely (March 2026). Hosted runner prices reduced 39% (Jan 2026)",
       "tier": "Free",
       "url": "https://docs.github.com/en/billing/managing-billing-for-github-actions/about-billing-for-github-actions",
       "tags": [

--- a/test/deal-changes.test.ts
+++ b/test/deal-changes.test.ts
@@ -76,7 +76,7 @@ describe("track_changes tool", () => {
 
     assert.ok(Array.isArray(body.changes));
     assert.strictEqual(body.total, body.changes.length);
-    assert.strictEqual(body.total, 66);
+    assert.strictEqual(body.total, 65);
   });
 
   it("filters by date (since)", async () => {


### PR DESCRIPTION
## Summary

- **GitHub Actions fix**: Removed incorrect `pricing_restructured` deal_change that claimed self-hosted runner $0.002/min fee was active. GitHub postponed this indefinitely in March 2026 — self-hosted runners remain free. Updated offer description to match.
- **Spot-check**: Verified 5 random entries against live pricing pages — all accurate:
  - datelist.io: 5 bookings/mo, 1 calendar ✓
  - Lunacy: Free desktop design tool ✓
  - Brevo: 300 emails/day ✓
  - xAI: $0.20/$0.50 per M tokens (Grok 4.1 Fast) ✓
  - Zulip: 10K messages, 5 GB storage, self-hostable ✓

**Stats:** 67 deal_changes (-1 incorrect), 309 tests passing

Refs #388