### PR TITLE
Fix data accuracy: Dub.co, Mailjet, Liveblocks (#395)

### DIFF
--- a/data/deal_changes.json
+++ b/data/deal_changes.json
@@ -1073,6 +1073,21 @@
         "Nhost",
         "Convex"
       ]
+    },
+    {
+      "vendor": "Dub.co",
+      "change_type": "limits_reduced",
+      "date": "2026-03-22",
+      "summary": "Free tier link limit reduced 40x from 1,000 links to 25 new links/month. Added 30-day analytics retention limit and 1-user cap",
+      "previous_state": "1,000 links, 1,000 tracked clicks/month, up to 3 custom domains",
+      "current_state": "25 new links/month, 1,000 tracked events/month, 3 custom domains, 1 user, 30-day analytics retention",
+      "impact": "high",
+      "source_url": "https://dub.co/pricing",
+      "category": "Dev Utilities",
+      "alternatives": [
+        "Bitly",
+        "Short.io"
+      ]
     }
   ]
 }

--- a/data/index.json
+++ b/data/index.json
@@ -785,7 +785,7 @@
     {
       "vendor": "Mailjet",
       "category": "Email",
-      "description": "Email API — 6,000 emails/month (200/day limit), 1,500 contacts, email editor and templates",
+      "description": "Email API — 6,000 emails/month (200/day limit), 1,000 contacts, email editor and templates",
       "tier": "Free",
       "url": "https://www.mailjet.com/pricing/",
       "tags": [
@@ -795,7 +795,7 @@
         "marketing",
         "free tier"
       ],
-      "verifiedDate": "2026-03-20"
+      "verifiedDate": "2026-03-22"
     },
     {
       "vendor": "Brevo",
@@ -3276,7 +3276,7 @@
     {
       "vendor": "Dub.co",
       "category": "Dev Utilities",
-      "description": "Open-source link management — 1,000 links, 1,000 tracked clicks/month, up to 3 custom domains, API with native SDKs, analytics. No credit card required",
+      "description": "Open-source link management — 25 new links/month, 1,000 tracked events/month, 3 custom domains, 1 user, 30-day analytics retention, API with native SDKs. No credit card required",
       "tier": "Free",
       "url": "https://dub.co/pricing",
       "tags": [
@@ -3286,7 +3286,7 @@
         "open source",
         "attribution"
       ],
-      "verifiedDate": "2026-03-20"
+      "verifiedDate": "2026-03-22"
     },
     {
       "vendor": "Stytch",
@@ -3308,7 +3308,7 @@
     {
       "vendor": "Liveblocks",
       "category": "Team Collaboration",
-      "description": "Real-time collaboration infrastructure — 100 MAU, 500 monthly active rooms, 8 GB storage. Presence, cursors, comments, notifications, text editor components",
+      "description": "Real-time collaboration infrastructure — 100 MAU, 500 monthly active rooms, 256 MB realtime data + 512 MB file storage. Presence, cursors, comments, notifications, text editor components",
       "tier": "Free",
       "url": "https://liveblocks.io/pricing",
       "tags": [
@@ -3319,7 +3319,7 @@
         "comments",
         "sdk"
       ],
-      "verifiedDate": "2026-03-20"
+      "verifiedDate": "2026-03-22"
     },
     {
       "vendor": "Nango",

--- a/test/deal-changes.test.ts
+++ b/test/deal-changes.test.ts
@@ -76,7 +76,7 @@ describe("track_changes tool", () => {
 
     assert.ok(Array.isArray(body.changes));
     assert.strictEqual(body.total, body.changes.length);
-    assert.strictEqual(body.total, 65);
+    assert.strictEqual(body.total, 66);
   });
 
   it("filters by date (since)", async () => {


### PR DESCRIPTION
## Summary

- **Dub.co** (CRITICAL): Free tier link limit was overstated 40x — corrected from 1,000 links to 25 new links/month. Added 30-day analytics retention, 1-user cap. Added deal_change entry for the reduction.
- **Mailjet**: Contact limit updated from 1,500 to 1,000 (changed Oct 2025).
- **Liveblocks**: Storage corrected from 8 GB to 256 MB realtime data + 512 MB file storage (8 GB was the Pro plan limit).
- All three entries have updated verifiedDate to 2026-03-22.
- 66 deal_changes (+1 Dub.co limits_reduced). 311 tests passing.

Refs #395