### PR TITLE
Fix data accuracy: Neo4j AuraDB, Uploadthing, Kinsta rebrand

### DIFF
--- a/data/deal_changes.json
+++ b/data/deal_changes.json
@@ -1088,6 +1088,37 @@
         "Bitly",
         "Short.io"
       ]
+    },
+    {
+      "vendor": "Uploadthing",
+      "change_type": "free_tier_removed",
+      "date": "2025-01-15",
+      "summary": "Free tier eliminated. Uploadthing moved to usage-based pricing with minimum $25/month plan (250 GB storage). No free tier available",
+      "previous_state": "Free tier: 2 GB storage, 2 GB bandwidth/month",
+      "current_state": "Usage-based pricing only. Minimum $25/month plan with 250 GB storage. No free tier",
+      "impact": "high",
+      "source_url": "https://uploadthing.com/pricing",
+      "category": "Storage",
+      "alternatives": [
+        "Cloudinary",
+        "Vercel Blob",
+        "AWS S3"
+      ]
+    },
+    {
+      "vendor": "Neo4j AuraDB",
+      "change_type": "limits_reduced",
+      "date": "2026-03-22",
+      "summary": "Free tier limits corrected — actual limits are 50,000 nodes and 175,000 relationships, not the previously listed 200,000 nodes and 400,000 relationships (4x overstatement on nodes)",
+      "previous_state": "200,000 nodes, 400,000 relationships (incorrectly listed)",
+      "current_state": "50,000 nodes, 175,000 relationships",
+      "impact": "medium",
+      "source_url": "https://neo4j.com/docs/aura/auradb/getting-started/create-database/",
+      "category": "Databases",
+      "alternatives": [
+        "Dgraph Cloud",
+        "Amazon Neptune"
+      ]
     }
   ]
 }

--- a/data/index.json
+++ b/data/index.json
@@ -889,21 +889,6 @@
       "verifiedDate": "2026-03-14"
     },
     {
-      "vendor": "Uploadthing",
-      "category": "Storage",
-      "description": "File uploads for TypeScript apps — 2 GB storage, 2 GB bandwidth/month free",
-      "tier": "Free",
-      "url": "https://uploadthing.com/pricing",
-      "tags": [
-        "storage",
-        "file uploads",
-        "typescript",
-        "nextjs",
-        "free tier"
-      ],
-      "verifiedDate": "2026-03-14"
-    },
-    {
       "vendor": "CloudAMQP",
       "category": "Messaging",
       "description": "Managed RabbitMQ — 1M messages/month, 20 connections, 100 queues free",
@@ -5136,7 +5121,7 @@
     {
       "vendor": "Neo4j AuraDB",
       "category": "Databases",
-      "description": "Graph database cloud service — free tier: single database, up to 200,000 nodes and 400,000 relationships. Full Cypher query language support. No credit card required",
+      "description": "Graph database cloud service — free tier: single database, up to 50,000 nodes and 175,000 relationships. Full Cypher query language support. No credit card required",
       "tier": "Free",
       "url": "https://neo4j.com/pricing/",
       "tags": [
@@ -5146,7 +5131,7 @@
         "knowledge-graph",
         "cloud"
       ],
-      "verifiedDate": "2026-03-20"
+      "verifiedDate": "2026-03-22"
     },
     {
       "vendor": "InfluxDB Cloud",
@@ -12685,17 +12670,18 @@
       "verifiedDate": "2026-03-20"
     },
     {
-      "vendor": "Kinsta Static Site Hosting",
+      "vendor": "Sevalla (formerly Kinsta)",
       "category": "Cloud Hosting",
-      "description": "Deploy up to 100 static sites for free, custom domains with SSL, 100 GB monthly bandwidth, 260+ Cloudflare CDN locations.",
+      "description": "Deploy up to 100 static sites for free, custom domains with SSL, 100 GB monthly bandwidth, 260+ Cloudflare CDN locations. Rebranded from Kinsta in February 2026.",
       "tier": "Free",
-      "url": "https://kinsta.com/static-site-hosting/",
+      "url": "https://sevalla.com/static-site-hosting/",
       "tags": [
         "hosting",
         "paas",
-        "free-for-dev"
+        "free-for-dev",
+        "kinsta-alternative"
       ],
-      "verifiedDate": "2026-03-20"
+      "verifiedDate": "2026-03-22"
     },
     {
       "vendor": "MDB GO",

--- a/test/deal-changes.test.ts
+++ b/test/deal-changes.test.ts
@@ -76,7 +76,7 @@ describe("track_changes tool", () => {
 
     assert.ok(Array.isArray(body.changes));
     assert.strictEqual(body.total, body.changes.length);
-    assert.strictEqual(body.total, 66);
+    assert.strictEqual(body.total, 68);
   });
 
   it("filters by date (since)", async () => {


### PR DESCRIPTION
## Summary

- **Neo4j AuraDB**: Corrected 4x node overstatement (200K→50K nodes, 400K→175K relationships) per [AuraDB docs](https://neo4j.com/docs/aura/auradb/getting-started/create-database/)
- **Uploadthing**: Removed from index — free tier eliminated Jan 2025, minimum plan now $25/month. Added deal_change entry.
- **Kinsta → Sevalla**: Rebranded vendor name and URL. Free tier limits (100 sites, 100 GB bandwidth) unchanged.
- Added 2 deal_change entries (Uploadthing removal, Neo4j correction). Updated test expectations.

1,545 offers (-1), 70 deal changes (+2), 312 tests passing.

Refs #398