### PR TITLE
Fix data accuracy: Doppler (5→3 users), Chanty (10→5 members)

### DIFF
--- a/data/index.json
+++ b/data/index.json
@@ -1567,7 +1567,7 @@
     {
       "vendor": "Doppler",
       "category": "Secrets Management",
-      "description": "Secrets management — up to 5 team members, unlimited secrets, projects, and environments. CLI, SDKs, and integrations included",
+      "description": "Secrets management — up to 3 users, 10 projects, 4 environments per project. CLI, SDKs, and integrations included",
       "tier": "Free",
       "url": "https://www.doppler.com/pricing",
       "tags": [
@@ -1577,7 +1577,7 @@
         "security",
         "free tier"
       ],
-      "verifiedDate": "2026-03-20"
+      "verifiedDate": "2026-03-22"
     },
     {
       "vendor": "PostHog",
@@ -7368,14 +7368,14 @@
     {
       "vendor": "Chanty.com",
       "category": "Team Collaboration",
-      "description": "Chanty is another alternative to Slack. It has a free forever plan for small teams (up to 10) with unlimited public and private conversations, searchable history, unlimited 1:1 audio calls, unlimited voice messages, ten integrations, and 20 GB storage per team.",
+      "description": "Chanty is another alternative to Slack. It has a free forever plan for small teams (up to 5) with unlimited public and private conversations, searchable history, unlimited 1:1 audio calls, unlimited voice messages, ten integrations, and 20 GB storage per team.",
       "tier": "Free",
       "url": "https://chanty.com/",
       "tags": [
         "developer-tools",
         "free-for-dev"
       ],
-      "verifiedDate": "2026-03-20"
+      "verifiedDate": "2026-03-22"
     },
     {
       "vendor": "DevToolLab",


### PR DESCRIPTION
## Summary

- **Doppler:** Free tier corrected from "up to 5 team members, unlimited secrets, projects, and environments" to "up to 3 users, 10 projects, 4 environments per project" — was overstated by 67% on users and claimed unlimited resources that are capped
- **Chanty:** Free tier corrected from "up to 10" to "up to 5" team members — was overstated by 2x
- Both entries verified against live pricing pages, verifiedDate updated to 2026-03-22

## Test plan

- [x] 312 tests passing
- [x] Data changes verified against source URLs listed in issue

Refs #403