### PR TITLE
Add /auth0-alternatives editorial page

### DIFF
--- a/data/index.json
+++ b/data/index.json
@@ -245,7 +245,8 @@
         "storage",
         "realtime",
         "baas",
-        "firebase-alternative"
+        "firebase-alternative",
+        "auth0-alternative"
       ],
       "verifiedDate": "2026-03-21"
     },
@@ -337,7 +338,8 @@
         "serverless",
         "hosting",
         "analytics",
-        "free tier"
+        "free tier",
+        "auth0-alternative"
       ],
       "verifiedDate": "2026-03-11"
     },
@@ -707,7 +709,8 @@
         "auth",
         "authentication",
         "identity",
-        "users"
+        "users",
+        "auth0-alternative"
       ],
       "verifiedDate": "2026-03-11"
     },
@@ -739,7 +742,8 @@
         "identity",
         "mfa",
         "saml",
-        "free tier"
+        "free tier",
+        "auth0-alternative"
       ],
       "verifiedDate": "2026-03-11"
     },
@@ -755,7 +759,8 @@
         "identity",
         "sso",
         "enterprise",
-        "free tier"
+        "free tier",
+        "auth0-alternative"
       ],
       "verifiedDate": "2026-03-11"
     },
@@ -3306,7 +3311,8 @@
         "oauth",
         "mfa",
         "identity",
-        "fraud prevention"
+        "fraud prevention",
+        "auth0-alternative"
       ],
       "verifiedDate": "2026-03-20"
     },
@@ -3783,9 +3789,27 @@
         "oidc",
         "saml",
         "identity",
-        "open source"
+        "open source",
+        "auth0-alternative"
       ],
       "verifiedDate": "2026-03-20"
+    },
+    {
+      "vendor": "FusionAuth",
+      "category": "Auth",
+      "description": "Full-featured identity platform — community edition: unlimited users, self-hosted free (Apache 2.0). Includes OAuth2/OIDC, SAML, passwordless, MFA, social login, user management, webhooks, themes",
+      "tier": "Community",
+      "url": "https://fusionauth.io/pricing",
+      "tags": [
+        "auth",
+        "authentication",
+        "identity",
+        "sso",
+        "open-source",
+        "self-hosted",
+        "auth0-alternative"
+      ],
+      "verifiedDate": "2026-03-23"
     },
     {
       "vendor": "Cerebras",
@@ -9594,16 +9618,18 @@
     {
       "vendor": "Logto",
       "category": "Auth",
-      "description": "Develop, secure, and manage user identities of your product - for both authentication and authorization. Free for up to 5,000 MAUs with open-source self-hosted option available.",
+      "description": "Open-source identity solution — 50K MAU free (cloud), unlimited self-hosted. OIDC, social login, passwordless, MFA, RBAC, multi-tenancy, webhooks",
       "tier": "Free",
-      "url": "https://logto.io/",
+      "url": "https://logto.io/pricing",
       "tags": [
         "auth",
         "authentication",
         "identity",
-        "free-for-dev"
+        "open-source",
+        "free tier",
+        "auth0-alternative"
       ],
-      "verifiedDate": "2026-03-20"
+      "verifiedDate": "2026-03-23"
     },
     {
       "vendor": "MojoAuth",
@@ -9636,16 +9662,19 @@
     {
       "vendor": "Ory",
       "category": "Auth",
-      "description": "AuthN/AuthZ/OAuth2.0/Zero Trust managed security platform. Forever free developer accounts with all security features, unlimited team members, 200 daily active users, and 25k/mo permission checks.",
+      "description": "Open-source identity infrastructure — Kratos (identity), Hydra (OAuth2/OIDC), Oathkeeper (API gateway), Keto (permissions). Cloud: 25K MAU free. Self-hosted: unlimited, Apache 2.0",
       "tier": "Free",
-      "url": "https://ory.sh/",
+      "url": "https://www.ory.sh/pricing/",
       "tags": [
         "auth",
         "authentication",
         "identity",
-        "free-for-dev"
+        "open-source",
+        "oauth",
+        "free tier",
+        "auth0-alternative"
       ],
-      "verifiedDate": "2026-03-20"
+      "verifiedDate": "2026-03-23"
     },
     {
       "vendor": "Phase Two",

--- a/src/serve.ts
+++ b/src/serve.ts
@@ -3204,6 +3204,125 @@ const ALTERNATIVES_PAGES: AlternativesPageConfig[] = [
   <p style="color:var(--text-dim);font-size:.8rem;margin-top:.5rem">Cloudflare Pages stands out with unlimited bandwidth on the free tier. Netlify switched to a credit-based system in late 2025 — legacy accounts keep 100 GB bandwidth + 300 build minutes. Railway's $5/month includes a $5 credit that covers most hobby projects. Coolify is fully free if you self-host on your own server.</p>`,
   },
   {
+    slug: "auth0-alternatives",
+    title: "Auth0 Alternatives — Best Free Authentication Platforms for 2026",
+    metaDesc: "Auth0 free tier too limited? Compare free authentication alternatives: Clerk, WorkOS, Supabase Auth, Firebase Auth, Logto, FusionAuth, Keycloak, and more. Verified 2026 free tier limits.",
+    contextHtml: `<p><strong>Auth0</strong> is a powerful identity platform, but its pricing is one of the steepest cliffs in developer tools. The free tier gives you <strong>25K MAU</strong> — generous for prototyping. But the moment you outgrow it, you're looking at the Essential plan starting at <strong>$240/month for just 500 external MAU</strong>. That's a jump from $0 to nearly $3,000/year with no middle ground.</p>
+    <p>The pricing pain is compounded by complexity. Auth0's tenant model, rule/action system, and connection limits create billing surprises. Teams regularly discover they need features (SSO, MFA customization, branding removal) that are locked behind higher tiers. "Auth0 alternatives" remains one of the most consistently searched developer queries.</p>
+    <p>The authentication landscape in 2026 offers real competition. Managed platforms (Clerk, WorkOS, Stytch) provide modern DX with generous free tiers. Open-source solutions (Keycloak, FusionAuth, Ory, Logto) give you unlimited users when self-hosted. And BaaS platforms (Supabase, Firebase) include auth as part of a broader free tier. The right choice depends on whether you prioritize DX, cost, or control.</p>`,
+    tag: "auth0-alternative",
+    primaryVendor: "Auth0",
+    hubDesc: "$0 to $240/mo pricing cliff drives alternatives search — 9 free authentication platforms compared",
+    serviceMatrixHtml: `
+  <h2>Free Tier Comparison</h2>
+  <p style="color:var(--text-muted);margin-bottom:1rem">What you actually get for free on each platform. Auth0's 25K MAU free tier is competitive, but the jump to paid is the steepest in the industry.</p>
+  <div style="overflow-x:auto">
+  <table class="compare-table">
+    <thead>
+      <tr>
+        <th>Platform</th>
+        <th>Free MAU</th>
+        <th>SSO</th>
+        <th>MFA</th>
+        <th>Self-Hosted</th>
+        <th>Best For</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td style="font-weight:600;color:var(--text-dim)">Auth0</td>
+        <td>25K</td>
+        <td>Paid</td>
+        <td>Yes</td>
+        <td>No</td>
+        <td style="color:var(--text-dim)">Enterprise identity + rules engine</td>
+      </tr>
+      <tr>
+        <td style="font-weight:600"><a href="/vendor/clerk" style="color:var(--text)">Clerk</a></td>
+        <td>50K</td>
+        <td>Paid</td>
+        <td>Yes</td>
+        <td>No</td>
+        <td>Pre-built UI components + React DX</td>
+      </tr>
+      <tr>
+        <td style="font-weight:600"><a href="/vendor/workos" style="color:var(--text)">WorkOS</a></td>
+        <td>1M</td>
+        <td>Paid</td>
+        <td>Yes</td>
+        <td>No</td>
+        <td>Enterprise SSO + SCIM at scale</td>
+      </tr>
+      <tr>
+        <td style="font-weight:600"><a href="/vendor/supabase" style="color:var(--text)">Supabase Auth</a></td>
+        <td>50K</td>
+        <td>No</td>
+        <td>Yes</td>
+        <td>Yes (OSS)</td>
+        <td>Full BaaS — auth + database + storage</td>
+      </tr>
+      <tr>
+        <td style="font-weight:600"><a href="/vendor/firebase" style="color:var(--text)">Firebase Auth</a></td>
+        <td>50K</td>
+        <td>No</td>
+        <td>Yes</td>
+        <td>No</td>
+        <td>Google ecosystem + mobile SDKs</td>
+      </tr>
+      <tr>
+        <td style="font-weight:600"><a href="/vendor/logto" style="color:var(--text)">Logto</a></td>
+        <td>50K</td>
+        <td>Paid</td>
+        <td>Yes</td>
+        <td>Yes (OSS)</td>
+        <td>Modern OIDC + open-source option</td>
+      </tr>
+      <tr>
+        <td style="font-weight:600"><a href="/vendor/stytch" style="color:var(--text)">Stytch</a></td>
+        <td>10K</td>
+        <td>5 connections</td>
+        <td>Yes</td>
+        <td>No</td>
+        <td>Passwordless + fraud prevention</td>
+      </tr>
+      <tr>
+        <td style="font-weight:600"><a href="/vendor/fusionauth" style="color:var(--text)">FusionAuth</a></td>
+        <td>Unlimited*</td>
+        <td>Yes</td>
+        <td>Yes</td>
+        <td>Yes (Apache 2.0)</td>
+        <td>Full-featured self-hosted — zero cost</td>
+      </tr>
+      <tr>
+        <td style="font-weight:600"><a href="/vendor/keycloak" style="color:var(--text)">Keycloak</a></td>
+        <td>Unlimited*</td>
+        <td>Yes</td>
+        <td>Yes</td>
+        <td>Yes (Apache 2.0)</td>
+        <td>Enterprise IAM — Red Hat backed</td>
+      </tr>
+      <tr>
+        <td style="font-weight:600"><a href="/vendor/ory" style="color:var(--text)">Ory</a></td>
+        <td>25K (cloud)</td>
+        <td>Yes</td>
+        <td>Yes</td>
+        <td>Yes (Apache 2.0)</td>
+        <td>Modular identity — Kratos + Hydra</td>
+      </tr>
+      <tr>
+        <td style="font-weight:600"><a href="/vendor/kinde" style="color:var(--text)">Kinde</a></td>
+        <td>10.5K</td>
+        <td>SAML</td>
+        <td>Yes</td>
+        <td>No</td>
+        <td>Auth + feature flags + billing</td>
+      </tr>
+    </tbody>
+  </table>
+  </div>
+  <p style="color:var(--text-dim);font-size:.8rem;margin-top:.5rem">*FusionAuth and Keycloak are free self-hosted with no user limits. WorkOS leads managed platforms at 1M MAU free (AuthKit). Clerk and Logto both offer 50K MAU. Supabase and Firebase bundle auth into broader BaaS free tiers.</p>`,
+  },
+  {
     slug: "ai-free-tiers",
     title: "Best Free AI APIs and Coding Tools in 2026",
     metaDesc: "Compare free AI APIs, LLM inference, and coding tools — exact rate limits and free tier details for Groq, Cerebras, Mistral, OpenAI, Gemini, Cursor, GitHub Copilot, and 50+ more. Updated March 2026.",

--- a/test/http.test.ts
+++ b/test/http.test.ts
@@ -1634,6 +1634,26 @@ describe("HTTP transport", () => {
     assert.ok(html.includes("Deno Deploy"), "Should include Deno Deploy alternative");
   });
 
+  it("GET /auth0-alternatives renders alternatives page", async () => {
+    proc = await startHttpServer();
+
+    const response = await fetch(`http://localhost:${PORT}/auth0-alternatives`);
+    assert.strictEqual(response.status, 200);
+    assert.ok(response.headers.get("content-type")?.includes("text/html"));
+    const html = await response.text();
+    assert.ok(html.includes("Auth0 Alternatives"), "Should have title");
+    assert.ok(html.includes("application/ld+json"), "Should have JSON-LD");
+    assert.ok(html.includes("canonical"), "Should have canonical link");
+    assert.ok(html.includes("global-nav"), "Should have global nav");
+    assert.ok(html.includes("Top Alternatives"), "Should have alternatives section");
+    assert.ok(html.includes("steepest cliffs"), "Should mention pricing cliff");
+    assert.ok(html.includes("Free Tier Comparison"), "Should have comparison table");
+    assert.ok(html.includes("Clerk"), "Should include Clerk alternative");
+    assert.ok(html.includes("WorkOS"), "Should include WorkOS alternative");
+    assert.ok(html.includes("Keycloak"), "Should include Keycloak alternative");
+    assert.ok(html.includes("FusionAuth"), "Should include FusionAuth alternative");
+  });
+
   it("GET /ai-free-tiers renders AI free tiers editorial page", async () => {
     proc = await startHttpServer();
 
@@ -1674,6 +1694,7 @@ describe("HTTP transport", () => {
     assert.ok(html.includes("/cursor-alternatives"), "Should link to Cursor page");
     assert.ok(html.includes("/datadog-alternatives"), "Should link to Datadog page");
     assert.ok(html.includes("/vercel-alternatives"), "Should link to Vercel page");
+    assert.ok(html.includes("/auth0-alternatives"), "Should link to Auth0 page");
     assert.ok(html.includes("/ai-free-tiers"), "Should link to AI free tiers page");
   });
 


### PR DESCRIPTION
## Summary
- 13th editorial alternatives page — Auth0 authentication alternatives
- 10 alternatives: Clerk, WorkOS, Supabase Auth, Firebase Auth, Logto, Stytch, FusionAuth, Keycloak, Ory, Kinde
- Comparison table with MAU limits, SSO, MFA, self-hosted option
- Context covers Auth0's $0→$240/mo pricing cliff
- Added FusionAuth entry to index (self-hosted, unlimited users, Apache 2.0)
- Updated Logto (50K MAU cloud, OSS) and Ory (Kratos/Hydra/Oathkeeper/Keto, 25K MAU cloud) descriptions
- Tagged 10 vendors with auth0-alternative tag

Refs #426

## Test plan
- [x] 318 tests passing (317 existing + 1 new)
- [x] Page returns 200 at /auth0-alternatives
- [x] All 10 alternatives rendered on page
- [x] JSON-LD structured data present
- [x] In sitemap.xml
- [x] Linked from /alternatives hub page
- [x] Cross-linked from other editorial pages
- [x] RSS feed auto-discovery link present