### PR TITLE
Add DeepSeek API entry to AI/ML category

### DIFF
--- a/data/index.json
+++ b/data/index.json
@@ -22043,6 +22043,23 @@
         "free tier"
       ],
       "verifiedDate": "2026-03-26"
+    },
+    {
+      "vendor": "DeepSeek API",
+      "category": "AI / ML",
+      "description": "Among the cheapest LLM APIs available. DeepSeek V4: $0.30/M input, $0.50/M output (1M context). DeepSeek R1 (reasoning): $0.55/M input, $2.19/M output. Cache hits 90% cheaper. Off-peak discounts up to 75% off. 5M free tokens for new accounts (30-day validity). China-based.",
+      "tier": "Free Credits + Pay-as-you-go",
+      "url": "https://api-docs.deepseek.com/quick_start/pricing",
+      "tags": [
+        "ai",
+        "ml",
+        "llm",
+        "inference",
+        "api",
+        "deepseek",
+        "reasoning"
+      ],
+      "verifiedDate": "2026-03-27"
     }
   ]
 }


### PR DESCRIPTION
## Summary

Adds DeepSeek API as a standalone entry in the AI/ML category:
- DeepSeek V4: $0.30/M input, $0.50/M output (1M context window)
- DeepSeek R1 (reasoning): $0.55/M input, $2.19/M output
- Cache hits 90% cheaper, off-peak discounts up to 75%
- 5M free tokens for new accounts (30-day validity)

**Note:** The other two items in issue #513 already exist in the index:
- Google Gemini Code Assist — already present in IDE & Code Editors category (verified 2026-03-26)
- GitHub Actions — already present in CI/CD category with deal_change for runner price reductions (verified 2026-03-22)

351 tests passing.

Refs #513