### PR TITLE
Fix port conflict in new-offers tests + update path-to-regexp

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1462,9 +1462,9 @@
       }
     },
     "node_modules/path-to-regexp": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.3.0.tgz",
-      "integrity": "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==",
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.0.tgz",
+      "integrity": "sha512-PuseHIvAnz3bjrM2rGJtSgo1zjgxapTLZ7x2pjhzWwlp4SJQgK3f3iZIQwkpEnBaKz6seKBADpM4B4ySkuYypg==",
       "license": "MIT",
       "funding": {
         "type": "opencollective",

--- a/src/serve.ts
+++ b/src/serve.ts
@@ -21299,7 +21299,8 @@ ${Array.from(vendorSlugMap.keys()).map(s => `  <url>
 });
 
 httpServer.listen(PORT, () => {
-  console.error(`agentdeals MCP server running on http://localhost:${PORT}/mcp`);
+  const actualPort = (httpServer.address() as import("net").AddressInfo).port;
+  console.error(`agentdeals MCP server running on http://localhost:${actualPort}/mcp`);
 });
 
 // IndexNow + sitemap ping on startup (fire-and-forget, no impact on server readiness)

--- a/test/new-offers.test.ts
+++ b/test/new-offers.test.ts
@@ -5,7 +5,6 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
-const PORT = 3457;
 
 function sendMcpMessages(
   serverProcess: ReturnType<typeof spawn>,
@@ -163,12 +162,14 @@ describe("search_deals with since param (new offers)", () => {
 describe("GET /api/new REST endpoint", () => {
   let proc: ChildProcess | null = null;
 
+  let serverPort = 0;
+
   function startHttpServer(): Promise<ChildProcess> {
     return new Promise((resolve, reject) => {
       const serverPath = path.join(__dirname, "..", "dist", "serve.js");
       const p = spawn("node", [serverPath], {
         stdio: ["pipe", "pipe", "pipe"],
-        env: { ...process.env, PORT: String(PORT) },
+        env: { ...process.env, PORT: "0" },
       });
 
       const timeout = setTimeout(() => {
@@ -177,7 +178,10 @@ describe("GET /api/new REST endpoint", () => {
       }, 5000);
 
       p.stderr!.on("data", (data: Buffer) => {
-        if (data.toString().includes("running on http")) {
+        const msg = data.toString();
+        const match = msg.match(/running on http:\/\/localhost:(\d+)/);
+        if (match) {
+          serverPort = parseInt(match[1], 10);
           clearTimeout(timeout);
           resolve(p);
         }
@@ -200,7 +204,7 @@ describe("GET /api/new REST endpoint", () => {
   it("returns new offers with default 7-day window", async () => {
     proc = await startHttpServer();
 
-    const response = await fetch(`http://localhost:${PORT}/api/new`);
+    const response = await fetch(`http://localhost:${serverPort}/api/new`);
     assert.strictEqual(response.status, 200);
     assert.strictEqual(response.headers.get("content-type"), "application/json");
     assert.strictEqual(response.headers.get("access-control-allow-origin"), "*");
@@ -214,7 +218,7 @@ describe("GET /api/new REST endpoint", () => {
   it("accepts days query parameter", async () => {
     proc = await startHttpServer();
 
-    const response = await fetch(`http://localhost:${PORT}/api/new?days=30`);
+    const response = await fetch(`http://localhost:${serverPort}/api/new?days=30`);
     assert.strictEqual(response.status, 200);
 
     const body = await response.json() as any;


### PR DESCRIPTION
## Summary

- **Fix flaky test:** new-offers.test.ts used hardcoded port 3457, which caused test failures when a stale server process was still holding the port. Now uses `PORT=0` (OS-assigned random port) and parses the actual port from the server's startup log.
- **Security fix:** Updated path-to-regexp 8.3.0 → 8.4.0 to fix high-severity ReDoS vulnerabilities (GHSA-j3q9-mxjg-w52f, GHSA-27v5-c462-wpq7). Production `npm audit` now shows 0 vulnerabilities.
- **Server improvement:** `serve.ts` now logs the actual listening port from `httpServer.address()` instead of the requested port, which is necessary for PORT=0 support and more accurate in general.

357 tests passing.