### PR TITLE
Fix IndexNow test port conflict

### DIFF
--- a/test/http.test.ts
+++ b/test/http.test.ts
@@ -3224,15 +3224,14 @@ describe("301 canonical hostname redirect", () => {
   });
 });
 
-const INDEXNOW_PORT = 3460;
 const INDEXNOW_TEST_KEY = "test-indexnow-key-abc123";
 
-function startIndexNowServer(): Promise<ChildProcess> {
+function startIndexNowServer(): Promise<{ proc: ChildProcess; port: number }> {
   return new Promise((resolve, reject) => {
     const serverPath = path.join(__dirname, "..", "dist", "serve.js");
     const proc = spawn("node", [serverPath], {
       stdio: ["pipe", "pipe", "pipe"],
-      env: { ...process.env, PORT: String(INDEXNOW_PORT), BASE_URL: `http://localhost:${INDEXNOW_PORT}`, INDEXNOW_KEY: INDEXNOW_TEST_KEY },
+      env: { ...process.env, PORT: "0", BASE_URL: "http://localhost", INDEXNOW_KEY: INDEXNOW_TEST_KEY },
     });
 
     const timeout = setTimeout(() => {
@@ -3241,9 +3240,11 @@ function startIndexNowServer(): Promise<ChildProcess> {
     }, 5000);
 
     proc.stderr!.on("data", (data: Buffer) => {
-      if (data.toString().includes("running on http")) {
+      const msg = data.toString();
+      const match = msg.match(/running on http:\/\/localhost:(\d+)/);
+      if (match) {
         clearTimeout(timeout);
-        resolve(proc);
+        resolve({ proc, port: parseInt(match[1], 10) });
       }
     });
 
@@ -3256,9 +3257,12 @@ function startIndexNowServer(): Promise<ChildProcess> {
 
 describe("IndexNow integration", () => {
   let indexNowProc: ChildProcess | null = null;
+  let indexNowPort: number = 0;
 
   before(async () => {
-    indexNowProc = await startIndexNowServer();
+    const result = await startIndexNowServer();
+    indexNowProc = result.proc;
+    indexNowPort = result.port;
   });
 
   after(() => {
@@ -3269,7 +3273,7 @@ describe("IndexNow integration", () => {
   });
 
   it("serves IndexNow key verification file at /{key}.txt", async () => {
-    const response = await fetch(`http://localhost:${INDEXNOW_PORT}/${INDEXNOW_TEST_KEY}.txt`);
+    const response = await fetch(`http://localhost:${indexNowPort}/${INDEXNOW_TEST_KEY}.txt`);
     assert.strictEqual(response.status, 200);
     assert.strictEqual(response.headers.get("content-type"), "text/plain; charset=utf-8");
     const body = await response.text();
@@ -3277,7 +3281,7 @@ describe("IndexNow integration", () => {
   });
 
   it("returns 404 for incorrect key file path", async () => {
-    const response = await fetch(`http://localhost:${INDEXNOW_PORT}/wrong-key.txt`);
+    const response = await fetch(`http://localhost:${indexNowPort}/wrong-key.txt`);
     assert.strictEqual(response.status, 404);
   });
 


### PR DESCRIPTION
## Summary

Fix flaky IndexNow integration tests by using OS-assigned port (PORT=0) instead of hardcoded port 3460.

- Same pattern applied in PR #529 for new-offers tests
- `startIndexNowServer()` now returns `{ proc, port }` with actual port parsed from server startup log
- Prevents test failures when stale processes hold the hardcoded port

357 tests passing.

Refs #529