### PR TITLE
Fix flaky test timeouts in MCP server spawn tests

### DIFF
--- a/test/audit-stack.test.ts
+++ b/test/audit-stack.test.ts
@@ -144,7 +144,7 @@ describe("audit_stack REST endpoint", () => {
         stdio: ["pipe", "pipe", "pipe"],
         env: { ...process.env, PORT: "0" },
       });
-      const timeout = setTimeout(() => { p.kill(); reject(new Error("Server startup timeout")); }, 5000);
+      const timeout = setTimeout(() => { p.kill(); reject(new Error("Server startup timeout")); }, 10000);
       p.stderr!.on("data", (data: Buffer) => {
         const match = data.toString().match(/running on http:\/\/localhost:(\d+)/);
         if (match) { serverPort = parseInt(match[1], 10); clearTimeout(timeout); resolve(p); }

--- a/test/categories.test.ts
+++ b/test/categories.test.ts
@@ -11,7 +11,7 @@ function sendMcpMessages(
   messages: object[]
 ): Promise<object[]> {
   return new Promise((resolve, reject) => {
-    const timeout = setTimeout(() => reject(new Error("Timeout")), 5000);
+    const timeout = setTimeout(() => reject(new Error("Timeout")), 10000);
     const responses: object[] = [];
     let buffer = "";
     const expectedResponses = messages.filter(

--- a/test/costs.test.ts
+++ b/test/costs.test.ts
@@ -148,7 +148,7 @@ describe("estimate_costs REST endpoint", () => {
         stdio: ["pipe", "pipe", "pipe"],
         env: { ...process.env, PORT: "0" },
       });
-      const timeout = setTimeout(() => { p.kill(); reject(new Error("Server startup timeout")); }, 5000);
+      const timeout = setTimeout(() => { p.kill(); reject(new Error("Server startup timeout")); }, 10000);
       p.stderr!.on("data", (data: Buffer) => {
         const match = data.toString().match(/running on http:\/\/localhost:(\d+)/);
         if (match) { serverPort = parseInt(match[1], 10); clearTimeout(timeout); resolve(p); }

--- a/test/deal-changes.test.ts
+++ b/test/deal-changes.test.ts
@@ -12,7 +12,7 @@ function sendMcpMessages(
   messages: object[]
 ): Promise<object[]> {
   return new Promise((resolve, reject) => {
-    const timeout = setTimeout(() => reject(new Error("Timeout")), 5000);
+    const timeout = setTimeout(() => reject(new Error("Timeout")), 10000);
     const responses: object[] = [];
     let buffer = "";
     const expectedResponses = messages.filter(

--- a/test/expiring-deals.test.ts
+++ b/test/expiring-deals.test.ts
@@ -126,7 +126,7 @@ describe("get_expiring_deals REST endpoint", () => {
         stdio: ["pipe", "pipe", "pipe"],
         env: { ...process.env, PORT: "0" },
       });
-      const timeout = setTimeout(() => { p.kill(); reject(new Error("Server startup timeout")); }, 5000);
+      const timeout = setTimeout(() => { p.kill(); reject(new Error("Server startup timeout")); }, 10000);
       p.stderr!.on("data", (data: Buffer) => {
         const match = data.toString().match(/running on http:\/\/localhost:(\d+)/);
         if (match) { serverPort = parseInt(match[1], 10); clearTimeout(timeout); resolve(p); }

--- a/test/head-requests.test.ts
+++ b/test/head-requests.test.ts
@@ -16,7 +16,7 @@ function startHttpServer(): Promise<ChildProcess> {
       stdio: ["pipe", "pipe", "pipe"],
       env: { ...process.env, PORT: "0", BASE_URL: "http://localhost" },
     });
-    const timeout = setTimeout(() => { p.kill(); reject(new Error("Server startup timeout")); }, 5000);
+    const timeout = setTimeout(() => { p.kill(); reject(new Error("Server startup timeout")); }, 10000);
     p.stderr!.on("data", (data: Buffer) => {
       const match = data.toString().match(/running on http:\/\/localhost:(\d+)/);
       if (match) { serverPort = parseInt(match[1], 10); clearTimeout(timeout); resolve(p); }

--- a/test/new-offers.test.ts
+++ b/test/new-offers.test.ts
@@ -11,7 +11,7 @@ function sendMcpMessages(
   messages: object[]
 ): Promise<object[]> {
   return new Promise((resolve, reject) => {
-    const timeout = setTimeout(() => reject(new Error("Timeout")), 5000);
+    const timeout = setTimeout(() => reject(new Error("Timeout")), 10000);
     const responses: object[] = [];
     let buffer = "";
     const expectedResponses = messages.filter(

--- a/test/newest-deals.test.ts
+++ b/test/newest-deals.test.ts
@@ -126,7 +126,7 @@ describe("get_newest_deals REST endpoint", () => {
         stdio: ["pipe", "pipe", "pipe"],
         env: { ...process.env, PORT: "0" },
       });
-      const timeout = setTimeout(() => { p.kill(); reject(new Error("Server startup timeout")); }, 5000);
+      const timeout = setTimeout(() => { p.kill(); reject(new Error("Server startup timeout")); }, 10000);
       p.stderr!.on("data", (data: Buffer) => {
         const match = data.toString().match(/running on http:\/\/localhost:(\d+)/);
         if (match) { serverPort = parseInt(match[1], 10); clearTimeout(timeout); resolve(p); }

--- a/test/search.test.ts
+++ b/test/search.test.ts
@@ -17,7 +17,7 @@ const httpServer: ChildProcess = spawn("node", [httpServerPath], {
 });
 
 await new Promise<void>((resolve, reject) => {
-  const timeout = setTimeout(() => reject(new Error("HTTP server start timeout")), 5000);
+  const timeout = setTimeout(() => reject(new Error("HTTP server start timeout")), 10000);
   httpServer.stderr!.on("data", (chunk: Buffer) => {
     const match = chunk.toString().match(/running on http:\/\/localhost:(\d+)/);
     if (match) {
@@ -42,7 +42,7 @@ function sendMcpMessages(
   messages: object[]
 ): Promise<object[]> {
   return new Promise((resolve, reject) => {
-    const timeout = setTimeout(() => reject(new Error("Timeout")), 5000);
+    const timeout = setTimeout(() => reject(new Error("Timeout")), 10000);
     const responses: object[] = [];
     let buffer = "";
     const expectedResponses = messages.filter(

--- a/test/server.test.ts
+++ b/test/server.test.ts
@@ -11,7 +11,7 @@ function sendMcpRequest(
   request: object
 ): Promise<object> {
   return new Promise((resolve, reject) => {
-    const timeout = setTimeout(() => reject(new Error("Timeout")), 5000);
+    const timeout = setTimeout(() => reject(new Error("Timeout")), 10000);
     let buffer = "";
 
     const onData = (data: Buffer) => {

--- a/test/stacks.test.ts
+++ b/test/stacks.test.ts
@@ -98,7 +98,7 @@ describe("stack REST endpoint", () => {
         stdio: ["pipe", "pipe", "pipe"],
         env: { ...process.env, PORT: "0" },
       });
-      const timeout = setTimeout(() => { p.kill(); reject(new Error("Server startup timeout")); }, 5000);
+      const timeout = setTimeout(() => { p.kill(); reject(new Error("Server startup timeout")); }, 10000);
       p.stderr!.on("data", (data: Buffer) => {
         const match = data.toString().match(/running on http:\/\/localhost:(\d+)/);
         if (match) { serverPort = parseInt(match[1], 10); clearTimeout(timeout); resolve(p); }

--- a/test/vendor-risk.test.ts
+++ b/test/vendor-risk.test.ts
@@ -151,7 +151,7 @@ describe("check_vendor_risk REST endpoint", () => {
         stdio: ["pipe", "pipe", "pipe"],
         env: { ...process.env, PORT: "0" },
       });
-      const timeout = setTimeout(() => { p.kill(); reject(new Error("Server startup timeout")); }, 5000);
+      const timeout = setTimeout(() => { p.kill(); reject(new Error("Server startup timeout")); }, 10000);
       p.stderr!.on("data", (data: Buffer) => {
         const match = data.toString().match(/running on http:\/\/localhost:(\d+)/);
         if (match) { serverPort = parseInt(match[1], 10); clearTimeout(timeout); resolve(p); }

--- a/test/weekly-digest.test.ts
+++ b/test/weekly-digest.test.ts
@@ -92,7 +92,7 @@ describe("get_weekly_digest REST endpoint", () => {
         stdio: ["pipe", "pipe", "pipe"],
         env: { ...process.env, PORT: "0" },
       });
-      const timeout = setTimeout(() => { p.kill(); reject(new Error("Server startup timeout")); }, 5000);
+      const timeout = setTimeout(() => { p.kill(); reject(new Error("Server startup timeout")); }, 10000);
       p.stderr!.on("data", (data: Buffer) => {
         const match = data.toString().match(/running on http:\/\/localhost:(\d+)/);
         if (match) { serverPort = parseInt(match[1], 10); clearTimeout(timeout); resolve(p); }


### PR DESCRIPTION
## Summary
- Increased MCP server spawn and startup timeouts from 5s to 10s across 13 test files
- The `deal-changes` "filters by date" test was consistently timing out when running the full suite (357 tests spawn multiple server processes concurrently)
- Passes reliably in isolation (324ms) — the timeout was too tight under concurrent load

Refs #353

## Test plan
- [x] All 357 tests pass with the new timeouts
- [x] No test takes more than ~2s individually — the 10s timeout is a safety margin for concurrent execution