### PR TITLE
Update vendor data: Windsurf, Netlify, Unity, Postman

### DIFF
--- a/data/deal_changes.json
+++ b/data/deal_changes.json
@@ -106,6 +106,22 @@
       ]
     },
     {
+      "vendor": "Netlify",
+      "change_type": "restriction",
+      "date": "2026-03-01",
+      "summary": "Every repo committer is now charged as a full Pro seat ($19/mo) when using Netlify CMS or Identity with a private repo. Previously only users who logged into the Netlify dashboard counted as seats",
+      "previous_state": "Only Netlify dashboard users counted as billable seats",
+      "current_state": "All repo committers to connected private repos count as Pro seats ($19/mo each) when using CMS or Identity features",
+      "impact": "high",
+      "source_url": "https://www.netlify.com/pricing/",
+      "category": "Hosting",
+      "alternatives": [
+        "Vercel",
+        "Cloudflare Pages",
+        "GitHub Pages"
+      ]
+    },
+    {
       "vendor": "Supabase",
       "change_type": "limits_reduced",
       "date": "2026-02-01",
@@ -1190,10 +1206,10 @@
     {
       "vendor": "Windsurf",
       "change_type": "pricing_restructured",
-      "date": "2026-03-01",
-      "summary": "Windsurf replaced credits-based free tier with fixed monthly quotas and raised Pro pricing from $15 to $20/month. Free tier went from credits (flexible use) to hard quotas (limited completions + chat messages). Pro plan price increased 33%",
+      "date": "2026-03-19",
+      "summary": "Windsurf replaced credits-based pricing with daily/weekly quotas (Mar 19, 2026). New tiers: Pro $20/mo (was $15), Ultimate $40/mo, Team $200/mo/seat. Free tier changed from flexible credits to hard quotas. Existing Pro subscribers grandfathered at $15/mo",
       "previous_state": "Credits-based system allowing flexible allocation between completions and chat. Pro plan $15/month",
-      "current_state": "Fixed quotas: free tier gets limited completions and chat messages per month. Pro plan $20/month (+33%). Credits replaced by hard limits",
+      "current_state": "Daily/weekly quotas replace credits. Pro $20/mo (existing subs grandfathered at $15), Ultimate $40/mo, Team $200/mo/seat. Free tier gets limited daily completions and chat messages",
       "impact": "medium",
       "source_url": "https://windsurf.com/pricing",
       "category": "AI Coding",

--- a/data/index.json
+++ b/data/index.json
@@ -51,7 +51,7 @@
     {
       "vendor": "Netlify",
       "category": "Cloud Hosting",
-      "description": "300 credits/month (deploys at 15 credits each, bandwidth at 10 credits/GB, compute at 5 credits/GB-hour). Legacy accounts (pre-Sep 2025) keep 100GB bandwidth + 300 build minutes",
+      "description": "300 credits/month (deploys at 15 credits each, bandwidth at 10 credits/GB, compute at 5 credits/GB-hour). Legacy accounts (pre-Sep 2025) keep 100GB bandwidth + 300 build minutes. Gotcha: every repo committer is charged as a full Pro seat ($19/mo) when using Netlify CMS or Identity with a private repo",
       "tier": "Free",
       "url": "https://www.netlify.com/pricing/",
       "tags": [
@@ -60,9 +60,10 @@
         "edge",
         "deployment",
         "jamstack",
-        "vercel-alternative"
+        "vercel-alternative",
+        "deal-change"
       ],
-      "verifiedDate": "2026-03-21"
+      "verifiedDate": "2026-03-31"
     },
     {
       "vendor": "Cloudflare Pages",
@@ -1099,7 +1100,7 @@
     {
       "vendor": "Windsurf",
       "category": "IDE & Code Editors",
-      "description": "AI coding assistant (formerly Codeium) — 25 prompt credits/month, unlimited previews and deploys, all premium models",
+      "description": "AI coding assistant (formerly Codeium). Free tier: daily/weekly quotas for completions and chat (replaced credits Mar 2026). Pro $20/mo, Ultimate $40/mo, Team $200/mo. Existing Pro subscribers grandfathered at $15/mo",
       "tier": "Free",
       "url": "https://windsurf.com/pricing",
       "tags": [
@@ -1107,9 +1108,10 @@
         "ai",
         "code completion",
         "ide",
-        "free tier"
+        "free tier",
+        "deal-change"
       ],
-      "verifiedDate": "2026-03-20"
+      "verifiedDate": "2026-03-31"
     },
     {
       "vendor": "GitHub Copilot",
@@ -2263,7 +2265,7 @@
         "deal-change",
         "postman-alternative"
       ],
-      "verifiedDate": "2026-03-21"
+      "verifiedDate": "2026-03-31"
     },
     {
       "vendor": "Directus",
@@ -4640,7 +4642,7 @@
     {
       "vendor": "Unity DevOps",
       "category": "CI/CD",
-      "description": "Version control + build automation — 25 GB storage, 100 GB egress, no seat charges. Build: 200 Windows + 100 Mac minutes/month. Includes Plastic SCM for version control. Expanded free tier as of March 2026",
+      "description": "Version control + build automation — 25 GB storage (5x increase Mar 2026), 100 GB egress (new Mar 2026), no seat charges (removed Mar 2026). Build: 200 Windows + 100 Mac minutes/month. Includes Plastic SCM for version control. No egress charges through April 2026",
       "tier": "Free",
       "url": "https://unity.com/products/unity-devops",
       "tags": [
@@ -4648,9 +4650,10 @@
         "cd",
         "version-control",
         "build-automation",
-        "game-dev"
+        "game-dev",
+        "deal-change"
       ],
-      "verifiedDate": "2026-03-20"
+      "verifiedDate": "2026-03-31"
     },
     {
       "vendor": "SurrealDB Cloud",
@@ -21621,7 +21624,7 @@
     {
       "vendor": "Windsurf",
       "category": "AI Coding",
-      "description": "AI-powered IDE by Codeium (formerly Codeium Editor). Free tier: basic Cascade AI flow access, limited premium action credits, code completions, AI chat. Pro plan $15/mo (unlimited flows, more credits). Team and Enterprise tiers available.",
+      "description": "AI-powered IDE by Codeium (formerly Codeium Editor). Free tier: daily/weekly quotas for Cascade AI flows, code completions, AI chat (quotas replaced credits Mar 2026). Pro $20/mo (was $15, existing subscribers grandfathered), Ultimate $40/mo, Team $200/mo/seat. All tiers include premium models",
       "tier": "Free",
       "url": "https://windsurf.com/pricing",
       "tags": [
@@ -21630,9 +21633,10 @@
         "ide",
         "code completion",
         "developer tools",
-        "cursor-alternative"
+        "cursor-alternative",
+        "deal-change"
       ],
-      "verifiedDate": "2026-03-14"
+      "verifiedDate": "2026-03-31"
     },
     {
       "vendor": "Augment Code",

--- a/test/deal-changes.test.ts
+++ b/test/deal-changes.test.ts
@@ -76,7 +76,7 @@ describe("track_changes tool", () => {
 
     assert.ok(Array.isArray(body.changes));
     assert.strictEqual(body.total, body.changes.length);
-    assert.strictEqual(body.total, 75);
+    assert.strictEqual(body.total, 76);
   });
 
   it("filters by date (since)", async () => {
@@ -288,7 +288,7 @@ describe("track_changes tool", () => {
 
     // Single vendor
     const single = getDealChanges("2024-01-01", undefined, undefined, "Netlify");
-    assert.strictEqual(single.total, 1);
+    assert.strictEqual(single.total, 2);
     assert.strictEqual(single.changes[0].vendor, "Netlify");
 
     // Multiple vendors
@@ -318,7 +318,7 @@ describe("track_changes tool", () => {
     const { getDealChanges } = await import("../dist/data.js");
     // When vendors is set, vendor should be ignored
     const result = getDealChanges("2024-01-01", undefined, "OpenAI", "Netlify");
-    assert.strictEqual(result.total, 1);
+    assert.strictEqual(result.total, 2);
     assert.strictEqual(result.changes[0].vendor, "Netlify");
   });
 


### PR DESCRIPTION
## Summary

Refs #536

- **Windsurf**: Updated both entries with Mar 19, 2026 quota model (daily/weekly quotas replaced credits). New tier pricing: Pro $20/mo (was $15, existing subs grandfathered), Ultimate $40/mo, Team $200/mo/seat. Updated deal_change with correct date and details
- **Netlify**: Added seat pricing gotcha — every repo committer charged as Pro seat ($19/mo) with CMS/Identity on private repos. New deal_change (restriction, high impact)
- **Unity DevOps**: Enriched description with change dates (5x storage, new egress, removed seat charges) and no-egress-charges promo through April 2026
- **Postman**: Verified date updated to 2026-03-31 (entry already reflected Mar 2026 restrictions from earlier PR)
- **DigitalOcean**: Already covered by PR #537 (issue #535)
- 76 deal changes total. 359 tests passing

## Test plan

- [x] 359/359 tests pass
- [x] Deal changes count updated (74→76: +1 DO price cut from #537, +1 Netlify seat pricing)
- [x] Vendor filter tests updated for 2 Netlify changes