### PR TITLE
Fix GitHub Actions self-hosted runner charge data

### DIFF
--- a/data/deal_changes.json
+++ b/data/deal_changes.json
@@ -166,25 +166,6 @@
       ]
     },
     {
-      "vendor": "GitHub Actions",
-      "change_type": "restriction",
-      "date": "2026-03-01",
-      "summary": "Self-hosted runner usage now costs $0.002/min for private repos. GitHub-hosted runner free tier (2,000 min/mo) unchanged",
-      "previous_state": "Self-hosted runners free for all repos",
-      "current_state": "Self-hosted runners $0.002/min for private repos. GitHub-hosted runner free tier unchanged",
-      "impact": "medium",
-      "source_url": "https://docs.github.com/en/billing/managing-billing-for-github-actions/about-billing-for-github-actions",
-      "category": "CI/CD",
-      "alternatives": [
-        "GitLab CI",
-        "CircleCI",
-        "Buildkite",
-        "Harness CI",
-        "Drone CI",
-        "Google Cloud Build"
-      ]
-    },
-    {
       "vendor": "Bright Data MCP",
       "change_type": "new_free_tier",
       "date": "2025-08-14",

--- a/data/index.json
+++ b/data/index.json
@@ -516,7 +516,7 @@
     {
       "vendor": "GitHub Actions",
       "category": "CI/CD",
-      "description": "Free CI/CD for public repos (unlimited minutes). Private repos: 2,000 min/mo GitHub-hosted runners, 500 MB artifact storage, 10 GB cache/repo. Self-hosted runner usage now costs $0.002/min for private repos (March 2026). GitHub-hosted runner free tier (2,000 min/mo) unchanged. Hosted runner prices reduced 39% (Jan 2026)",
+      "description": "Free CI/CD for public repos (unlimited minutes). Private repos: 2,000 min/mo GitHub-hosted runners, 500 MB artifact storage, 10 GB cache/repo. Self-hosted runners remain free — planned $0.002/min charge was postponed indefinitely after community backlash (March 2026). Hosted runner prices reduced 39% (Jan 2026)",
       "tier": "Free",
       "url": "https://docs.github.com/en/billing/managing-billing-for-github-actions/about-billing-for-github-actions",
       "tags": [
@@ -526,7 +526,7 @@
         "github",
         "deal-change"
       ],
-      "verifiedDate": "2026-03-22"
+      "verifiedDate": "2026-03-31"
     },
     {
       "vendor": "GitLab CI",

--- a/test/deal-changes.test.ts
+++ b/test/deal-changes.test.ts
@@ -76,7 +76,7 @@ describe("track_changes tool", () => {
 
     assert.ok(Array.isArray(body.changes));
     assert.strictEqual(body.total, body.changes.length);
-    assert.strictEqual(body.total, 76);
+    assert.strictEqual(body.total, 75);
   });
 
   it("filters by date (since)", async () => {


### PR DESCRIPTION
## Summary
- Corrected GitHub Actions description: self-hosted runner $0.002/min charge was **postponed indefinitely**, not enacted
- Removed incorrect `restriction` deal_change entry (the `pricing_postponed` entry already correctly describes the situation)
- Updated verified_date to 2026-03-31

Refs #544