### PR TITLE
Update MCP SDK and fix node-forge security vulnerabilities

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.3.1",
       "license": "MIT",
       "dependencies": {
-        "@modelcontextprotocol/sdk": "^1.0.0",
+        "@modelcontextprotocol/sdk": "^1.29.0",
         "swagger-ui-dist": "^5.32.0",
         "zod": "^3.25.0"
       },
@@ -322,9 +322,9 @@
       }
     },
     "node_modules/@modelcontextprotocol/sdk": {
-      "version": "1.27.1",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.27.1.tgz",
-      "integrity": "sha512-sr6GbP+4edBwFndLbM60gf07z0FQ79gaExpnsjMGePXqFcSSb7t6iscpjk9DhFhwd+mTEQrzNafGP8/iGGFYaA==",
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
+      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
       "license": "MIT",
       "dependencies": {
         "@hono/node-server": "^1.19.9",
@@ -1382,9 +1382,9 @@
       }
     },
     "node_modules/node-forge": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.3.tgz",
-      "integrity": "sha512-rLvcdSyRCyouf6jcOIPe/BgwG/d7hKjzMKOas33/pHEr6gbq18IK9zV7DiPvzsz0oBJPme6qr6H6kGZuI9/DZg==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.4.0.tgz",
+      "integrity": "sha512-LarFH0+6VfriEhqMMcLX2F7SwSXeWwnEAJEsYm5QKWchiVYVvJyV9v7UDvUv+w5HO23ZpQTXDv/GxdDdMyOuoQ==",
       "dev": true,
       "license": "(BSD-3-Clause OR GPL-2.0)",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "build:mcpb": "npm run build && npx @anthropic-ai/mcpb pack ."
   },
   "dependencies": {
-    "@modelcontextprotocol/sdk": "^1.0.0",
+    "@modelcontextprotocol/sdk": "^1.29.0",
     "swagger-ui-dist": "^5.32.0",
     "zod": "^3.25.0"
   },


### PR DESCRIPTION
## Summary
- Updated `@modelcontextprotocol/sdk` from 1.27.1 to 1.29.0 (minor version bump)
- Fixed high-severity `node-forge` vulnerabilities via `npm audit fix`:
  - GHSA-2328-f5f3-gj25: basicConstraints bypass in certificate chain verification
  - GHSA-q67f-28xg-22rw: Signature forgery in Ed25519
  - GHSA-5m6q-g25r-mvwx: DoS via infinite loop in BigInteger.modInverse()
  - GHSA-ppp5-5v6c-4jwp: Signature forgery in RSA-PKCS
- Remaining 5 low-severity vulns are in `tmp` package (dev-only dependency via `@anthropic-ai/mcpb`, no fix available upstream)
- Production `npm audit` now shows 0 high/critical vulnerabilities

## Test plan
- [x] `npm run build` — clean TypeScript compilation
- [x] 370 tests passing (no regressions)
- [x] `npm audit` — 0 high/critical vulnerabilities

Refs #353