### PR TITLE
Add MCP Resources for browsable deal data and editorial content

### DIFF
--- a/src/guides.ts
+++ b/src/guides.ts
@@ -1,0 +1,109 @@
+// Editorial guide metadata for MCP resources.
+// This is a lightweight index — the full HTML content lives in serve.ts.
+
+export interface GuideMetadata {
+  slug: string;
+  title: string;
+  description: string;
+  type: "pricing" | "comparison" | "stack" | "alternatives" | "report";
+}
+
+function classifyGuide(slug: string): GuideMetadata["type"] {
+  if (slug.includes("-vs-") || slug.includes("-comparison-")) return "comparison";
+  if (slug.startsWith("free-") && slug.endsWith("-stack")) return "stack";
+  if (slug.includes("pricing") || slug.includes("report") || slug.includes("preview")) return "pricing";
+  if (slug.endsWith("-alternatives") || slug === "ai-free-tiers" || slug === "free-llm-apis" || slug === "api-development-alternatives") return "alternatives";
+  return "report";
+}
+
+// Guide entries: slug, title, one-line description
+const GUIDE_ENTRIES: Array<{ slug: string; title: string; description: string }> = [
+  { slug: "localstack-alternatives", title: "LocalStack CE Alternatives", description: "LocalStack CE shuts down March 23, 2026 — compare 9 free open-source AWS emulators" },
+  { slug: "postman-alternatives", title: "Postman Alternatives", description: "Postman killed free team collaboration March 1, 2026 — 5 free API testing alternatives" },
+  { slug: "terraform-alternatives", title: "HCP Terraform Alternatives", description: "HCP Terraform legacy plan ends March 31, 2026 — free IaC alternatives compared" },
+  { slug: "hetzner-alternatives", title: "Hetzner Alternatives", description: "Hetzner raises prices 30–50% on April 1, 2026 — cloud hosting alternatives with free tiers" },
+  { slug: "freshping-alternatives", title: "Freshping Alternatives", description: "Freshping shut down March 6, 2026 — 13 free uptime monitoring alternatives" },
+  { slug: "heroku-alternatives", title: "Heroku Alternatives", description: "Heroku removed free tier Nov 2022, entered sustaining mode Feb 2026 — 8 free PaaS options" },
+  { slug: "firebase-alternatives", title: "Firebase Alternatives", description: "Firebase Studio shut down March 19, 2026 + Spark forced Blaze migration — 7 BaaS alternatives" },
+  { slug: "github-actions-alternatives", title: "GitHub Actions Alternatives", description: "Self-hosted runner costs introduced March 2026 — 10 free CI/CD alternatives compared" },
+  { slug: "cursor-alternatives", title: "Cursor Alternatives", description: "Cursor credit-based pricing drives alternatives search — 8 free AI coding tools compared" },
+  { slug: "datadog-alternatives", title: "Datadog Alternatives", description: "Unpredictable pricing drives developer search — 12 free monitoring alternatives compared" },
+  { slug: "vercel-alternatives", title: "Vercel Alternatives", description: "Hobby plan limits and $20/seat Pro pricing — 10 free deployment platforms compared" },
+  { slug: "auth0-alternatives", title: "Auth0 Alternatives", description: "$0 to $240/mo pricing cliff — 9 free authentication platforms compared" },
+  { slug: "mongodb-alternatives", title: "MongoDB Alternatives", description: "512 MB free tier + SSPL license — 10 free databases compared" },
+  { slug: "redis-alternatives", title: "Redis Alternatives", description: "BSL license change + 30 MB free tier — 8 open-source and managed alternatives compared" },
+  { slug: "ai-free-tiers", title: "Best Free AI APIs and Coding Tools in 2026", description: "Compare 65 free AI APIs, LLM inference, vector databases, and coding tools" },
+  { slug: "database-alternatives", title: "Database Alternatives", description: "Compare 30+ free databases by type — Postgres, document, key-value, edge, graph, vector, and time-series" },
+  { slug: "hosting-alternatives", title: "Hosting Alternatives", description: "Compare 30+ free hosting options by type — PaaS, static/JAMstack, serverless, containers, VPS" },
+  { slug: "monitoring-alternatives", title: "Monitoring Alternatives", description: "Compare 70+ free monitoring tools by type — APM, uptime, logs, error tracking, and infrastructure" },
+  { slug: "email-service-alternatives", title: "Email Service Alternatives", description: "SendGrid down to 100/day, Mailgun free tier gone — 8 free transactional email alternatives" },
+  { slug: "ci-cd-alternatives", title: "CI/CD Alternatives", description: "35+ free CI/CD tools — build minutes, runners, and pipelines by type" },
+  { slug: "security-alternatives", title: "Security Alternatives", description: "100+ free security tools — SAST/DAST, secret scanning, dependency analysis, container security" },
+  { slug: "storage-alternatives", title: "Storage Alternatives", description: "55+ free cloud storage tools — object storage, media/image CDN, file hosting" },
+  { slug: "testing-alternatives", title: "Testing Alternatives", description: "45+ free testing tools — browser, visual regression, load, E2E, API, and code coverage" },
+  { slug: "analytics-alternatives", title: "Analytics Alternatives", description: "45+ free analytics tools — product analytics, web analytics, event tracking, data infrastructure" },
+  { slug: "ai-ml-alternatives", title: "AI/ML Alternatives", description: "65+ free AI/ML tools — LLM APIs, AI coding assistants, ML platforms, observability" },
+  { slug: "design-alternatives", title: "Design Alternatives", description: "100+ free design tools — UI design, prototyping, components, icons, stock assets" },
+  { slug: "email-alternatives", title: "Email Alternatives", description: "59+ free email tools — transactional APIs, marketing, verification, forwarding" },
+  { slug: "project-management-alternatives", title: "Project Management Alternatives", description: "93+ free PM tools — issue tracking, kanban, team chat, video conferencing, scheduling" },
+  { slug: "ide-code-editors-alternatives", title: "IDE & Code Editor Alternatives", description: "59+ free IDEs and coding tools — desktop editors, cloud IDEs, AI coding assistants" },
+  { slug: "free-llm-apis", title: "Free LLM APIs", description: "25+ free LLM API providers — proprietary model APIs, open-model inference, AI gateways" },
+  { slug: "api-development-alternatives", title: "API Development Alternatives", description: "39+ free API tools — REST/GraphQL clients, mocking, documentation, marketplaces" },
+  { slug: "q1-2026-developer-pricing-report", title: "Q1 2026 Developer Pricing Report", description: "47 verified pricing changes in Q1 2026 — removals, restrictions, price hikes, expansions" },
+  { slug: "hetzner-pricing-2026", title: "Hetzner Pricing 2026", description: "Hetzner April 2026 price increases — before/after tables, impact, alternatives" },
+  { slug: "team-collaboration-alternatives", title: "Team Collaboration Alternatives", description: "60+ free team collaboration tools — chat, video, docs, scheduling, async communication" },
+  { slug: "free-startup-stack", title: "Free Startup Stack", description: "Complete free SaaS infrastructure stack — 10 categories with recommended picks" },
+  { slug: "free-ai-stack", title: "Free AI Stack", description: "Free AI/ML development stack — LLM APIs, vector DB, compute, monitoring, 10 categories" },
+  { slug: "free-devops-stack", title: "Free DevOps Stack", description: "Free DevOps infrastructure stack — CI/CD, monitoring, logging, IaC, 10 categories" },
+  { slug: "free-frontend-stack", title: "Free Frontend Stack", description: "Free frontend/Jamstack development stack — hosting, CMS, auth, analytics, 10 categories" },
+  { slug: "q2-pricing-preview-2026", title: "Q2 2026 Pricing Preview", description: "Forward-looking Q2 pricing preview — upcoming changes, expirations, market trends" },
+  { slug: "google-developer-program-2026", title: "Google Developer Program Premium 2026", description: "Google Developer Program Premium analysis — price comparison, migration guide, alternatives" },
+  { slug: "supabase-vs-firebase", title: "Supabase vs Firebase", description: "Free tier comparison — storage, compute, auth, pricing at scale, decision guide" },
+  { slug: "vercel-vs-netlify", title: "Vercel vs Netlify", description: "Free tier comparison — bandwidth, functions, builds, commercial use, hosting alternatives" },
+  { slug: "neon-vs-supabase", title: "Neon vs Supabase", description: "Free tier comparison — storage, compute, branching, auth, scale-to-zero" },
+  { slug: "railway-vs-render", title: "Railway vs Render", description: "Free tier comparison — usage-based vs fixed pricing, managed databases, sleep behavior" },
+  { slug: "datadog-vs-new-relic", title: "Datadog vs New Relic", description: "Free tier comparison — per-host vs per-GB pricing, APM, logs, synthetics, retention" },
+  { slug: "free-tier-risk", title: "Free Tier Risk Index", description: "38 vendors scored by free tier sustainability risk — methodology and risk factors" },
+  { slug: "hcp-terraform-migration", title: "HCP Terraform Migration Guide", description: "5 migration paths, decision matrix, step-by-step process for HCP Terraform EOL" },
+  { slug: "gemini-api-pricing-2026", title: "Gemini API Pricing 2026", description: "Gemini API pricing analysis — spend caps, rate limit cuts, 8-provider comparison" },
+  { slug: "free-tier-tracker", title: "Free Tier Tracker Q1 2026", description: "Q1 2026 free tier erosion report — 8 removals, 6 expansions, 4 trend patterns" },
+  { slug: "startup-credits", title: "Startup Credits Directory", description: "19 startup credit programs across 3 tiers, $1M+ combined credits, stacking strategy" },
+  { slug: "ai-coding-pricing-2026", title: "AI Coding Tools Pricing 2026", description: "9 AI coding tools compared — Cursor, Copilot, Claude Code, Windsurf, pricing and free tiers" },
+  { slug: "aws-free-tier-2026", title: "AWS Free Tier Guide 2026", description: "29 services, 3 tier types, hidden costs, alternatives — comprehensive AWS free tier guide" },
+  { slug: "gcp-free-tier-2026", title: "GCP Free Tier Guide 2026", description: "31 Always Free products, $300 trial, AI/ML tools, hidden costs — comprehensive GCP guide" },
+  { slug: "azure-free-tier-2026", title: "Azure Free Tier Guide 2026", description: "65+ always-free services, $200 trial, Cosmos DB lifetime tier, Founders Hub $150K" },
+  { slug: "cicd-free-tier-comparison-2026", title: "CI/CD Free Tier Comparison 2026", description: "15+ CI/CD platforms compared — build minutes, runners, parallel jobs, self-hosted options" },
+  { slug: "cloud-free-tier-comparison-2026", title: "Cloud Free Tier Comparison 2026", description: "AWS vs GCP vs Azure vs 5 alternatives — compute, storage, databases, and serverless" },
+  { slug: "database-free-tier-comparison-2026", title: "Database Free Tier Comparison 2026", description: "15+ databases compared — Postgres, MySQL, MongoDB, Redis, vector, and edge databases" },
+  { slug: "hosting-free-tier-comparison-2026", title: "Hosting Free Tier Comparison 2026", description: "PaaS, static, serverless hosting — bandwidth, build minutes, and scaling limits" },
+  { slug: "serverless-free-tier-comparison-2026", title: "Serverless Free Tier Comparison 2026", description: "10+ serverless platforms — invocations, compute, CPU-time vs wall-clock billing" },
+  { slug: "auth-free-tier-comparison-2026", title: "Auth Free Tier Comparison 2026", description: "15+ auth services — MAU limits, overage costs, self-hosted options, growth cost traps" },
+  { slug: "monitoring-free-tier-comparison-2026", title: "Monitoring Free Tier Comparison 2026", description: "20+ monitoring services — data ingest, retention, hosts, alerting, observability costs" },
+  { slug: "email-free-tier-comparison-2026", title: "Email Free Tier Comparison 2026", description: "15+ email services — sending volume, daily caps, webhooks, custom domains" },
+  { slug: "storage-free-tier-comparison-2026", title: "Storage Free Tier Comparison 2026", description: "15+ storage services — capacity, egress, API calls, CDN, and object storage" },
+  { slug: "analytics-free-tier-comparison-2026", title: "Analytics Free Tier Comparison 2026", description: "15+ analytics services — events, sessions, retention, privacy, and self-hosting" },
+  { slug: "testing-free-tier-comparison-2026", title: "Testing Free Tier Comparison 2026", description: "15+ testing tools — browser tests, parallel runs, visual regression, load testing" },
+  { slug: "api-development-free-tier-comparison-2026", title: "API Development Free Tier Comparison 2026", description: "12+ API tools — Postman vs Bruno vs Hoppscotch vs Insomnia, collaboration limits" },
+  { slug: "security-free-tier-comparison-2026", title: "Security Free Tier Comparison 2026", description: "20+ security tools — SAST, SCA, DAST, secrets, container/IaC, SSL/TLS, zero trust" },
+  { slug: "state-of-free-tiers-2026", title: "State of Free Tiers 2026", description: "Data-driven analysis of 1,559 offers across 54 categories — the free tier squeeze, bright spots, cost traps" },
+];
+
+export function getGuideList(): GuideMetadata[] {
+  return GUIDE_ENTRIES.map(e => ({
+    slug: e.slug,
+    title: e.title,
+    description: e.description,
+    type: classifyGuide(e.slug),
+  }));
+}
+
+export function getGuideBySlug(slug: string): GuideMetadata | null {
+  const entry = GUIDE_ENTRIES.find(e => e.slug === slug);
+  if (!entry) return null;
+  return {
+    slug: entry.slug,
+    title: entry.title,
+    description: entry.description,
+    type: classifyGuide(entry.slug),
+  };
+}

--- a/src/server-remote.ts
+++ b/src/server-remote.ts
@@ -1,4 +1,4 @@
-import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { McpServer, ResourceTemplate } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import {
   fetchCategories,
@@ -14,6 +14,7 @@ import {
   fetchNewestDeals,
   fetchWeeklyDigest,
 } from "./api-client.js";
+import { getGuideList, getGuideBySlug } from "./guides.js";
 
 function mcpError(msg: string) {
   return {
@@ -492,6 +493,271 @@ Suggested monitoring cadence: run this check weekly to catch pricing changes ear
           },
         ],
       };
+    }
+  );
+
+  // --- Resources ---
+
+  function toSlug(name: string): string {
+    return name.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/-+$/, "");
+  }
+
+  // Static: all categories
+  server.registerResource(
+    "categories",
+    "agentdeals://categories",
+    {
+      description: "All 54 developer tool categories with offer counts",
+      mimeType: "text/plain",
+    },
+    async () => {
+      const categories = (await fetchCategories()) as Array<{ name: string; count: number }>;
+      const lines = categories.map(c => `- **${c.name}** (${c.count} offers)`);
+      const total = categories.reduce((sum, c) => sum + c.count, 0);
+      const text = `# AgentDeals Categories\n\n${categories.length} categories, ${total} total offers.\n\n${lines.join("\n")}`;
+      return { contents: [{ uri: "agentdeals://categories", text, mimeType: "text/plain" }] };
+    }
+  );
+
+  // Template: category detail
+  server.registerResource(
+    "category",
+    new ResourceTemplate("agentdeals://category/{slug}", {
+      list: async () => {
+        const categories = (await fetchCategories()) as Array<{ name: string; count: number }>;
+        return {
+          resources: categories.map(c => ({
+            uri: `agentdeals://category/${toSlug(c.name)}`,
+            name: c.name,
+            description: `${c.count} offers in ${c.name}`,
+            mimeType: "text/plain",
+          })),
+        };
+      },
+      complete: {
+        slug: async (value) => {
+          const categories = (await fetchCategories()) as Array<{ name: string; count: number }>;
+          return categories.map(c => toSlug(c.name)).filter(s => s.startsWith(value));
+        },
+      },
+    }),
+    {
+      description: "All offers in a specific category",
+      mimeType: "text/plain",
+    },
+    async (_uri, { slug }) => {
+      const data = (await fetchOffers({ category: slug as string, limit: 200 })) as { offers: Array<{ vendor: string; tier: string; description: string; verifiedDate: string; category: string }>; total: number };
+      if (!data.offers || data.offers.length === 0) {
+        return { contents: [{ uri: `agentdeals://category/${slug}`, text: `No category found matching "${slug}".`, mimeType: "text/plain" }] };
+      }
+      const categoryName = data.offers[0].category;
+      const lines = data.offers.map(o => `- **${o.vendor}** — ${o.tier}: ${o.description} (verified ${o.verifiedDate})`);
+      const text = `# ${categoryName}\n\n${data.total} offers.\n\n${lines.join("\n")}`;
+      return { contents: [{ uri: `agentdeals://category/${slug}`, text, mimeType: "text/plain" }] };
+    }
+  );
+
+  // Static: all vendors
+  server.registerResource(
+    "vendors",
+    "agentdeals://vendors",
+    {
+      description: "All vendors with category and tier type",
+      mimeType: "text/plain",
+    },
+    async () => {
+      const data = (await fetchOffers({ limit: 2000 })) as { offers: Array<{ vendor: string; category: string; tier: string }>; total: number };
+      const sorted = data.offers.sort((a, b) => a.vendor.localeCompare(b.vendor));
+      const lines = sorted.map(o => `- **${o.vendor}** | ${o.category} | ${o.tier}`);
+      const text = `# AgentDeals Vendors\n\n${data.total} vendors.\n\n${lines.join("\n")}`;
+      return { contents: [{ uri: "agentdeals://vendors", text, mimeType: "text/plain" }] };
+    }
+  );
+
+  // Template: vendor detail
+  server.registerResource(
+    "vendor",
+    new ResourceTemplate("agentdeals://vendor/{slug}", {
+      list: async () => {
+        const data = (await fetchOffers({ limit: 2000 })) as { offers: Array<{ vendor: string; tier: string }> };
+        return {
+          resources: data.offers.map(o => ({
+            uri: `agentdeals://vendor/${toSlug(o.vendor)}`,
+            name: o.vendor,
+            description: `${o.vendor} — ${o.tier}`,
+            mimeType: "text/plain",
+          })),
+        };
+      },
+      complete: {
+        slug: async (value) => {
+          const data = (await fetchOffers({ limit: 2000 })) as { offers: Array<{ vendor: string }> };
+          return data.offers.map(o => toSlug(o.vendor)).filter(s => s.startsWith(value));
+        },
+      },
+    }),
+    {
+      description: "Full vendor details: free tier limits, pricing, verified date, alternatives, changes",
+      mimeType: "text/plain",
+    },
+    async (_uri, { slug }) => {
+      const data = (await fetchOffers({ limit: 2000 })) as { offers: Array<{ vendor: string; category: string; tier: string; description: string; url: string; verifiedDate: string; tags: string[]; eligibility?: { type: string; conditions: string[] }; expires_date?: string }>; total: number };
+      const match = data.offers.find(o => toSlug(o.vendor) === slug);
+      if (!match) {
+        return { contents: [{ uri: `agentdeals://vendor/${slug}`, text: `No vendor found matching "${slug}".`, mimeType: "text/plain" }] };
+      }
+
+      const changesData = (await fetchDealChanges({ vendor: match.vendor, since: "2020-01-01" })) as { changes: Array<{ date: string; change_type: string; summary: string; previous_state: string; current_state: string }> };
+      const alternatives = data.offers.filter(o => o.category === match.category && o.vendor !== match.vendor).slice(0, 5);
+
+      let text = `# ${match.vendor}\n\n`;
+      text += `**Category:** ${match.category}\n`;
+      text += `**Tier:** ${match.tier}\n`;
+      text += `**Description:** ${match.description}\n`;
+      text += `**Pricing Page:** ${match.url}\n`;
+      text += `**Verified:** ${match.verifiedDate}\n`;
+      if (match.eligibility) {
+        text += `**Eligibility:** ${match.eligibility.type} — ${match.eligibility.conditions.join(", ")}\n`;
+      }
+      if (match.expires_date) {
+        text += `**Expires:** ${match.expires_date}\n`;
+      }
+      text += `**Tags:** ${match.tags.join(", ")}\n`;
+
+      if (changesData.changes.length > 0) {
+        text += `\n## Pricing Changes\n\n`;
+        for (const c of changesData.changes) {
+          text += `- **${c.date}** [${c.change_type}] ${c.summary}\n  Previous: ${c.previous_state}\n  Current: ${c.current_state}\n`;
+        }
+      }
+
+      if (alternatives.length > 0) {
+        text += `\n## Alternatives in ${match.category}\n\n`;
+        for (const a of alternatives) {
+          text += `- **${a.vendor}** — ${a.tier}: ${a.description}\n`;
+        }
+      }
+
+      return { contents: [{ uri: `agentdeals://vendor/${slug}`, text, mimeType: "text/plain" }] };
+    }
+  );
+
+  // Static: all pricing changes
+  server.registerResource(
+    "changes",
+    "agentdeals://changes",
+    {
+      description: "All tracked pricing changes across developer tools",
+      mimeType: "text/plain",
+    },
+    async () => {
+      const data = (await fetchDealChanges({ since: "2020-01-01" })) as { changes: Array<{ date: string; vendor: string; change_type: string; summary: string }> };
+      const lines = data.changes.map(c => `- **${c.date}** | ${c.vendor} | ${c.change_type} | ${c.summary}`);
+      const text = `# AgentDeals Pricing Changes\n\n${data.changes.length} tracked changes.\n\n${lines.join("\n")}`;
+      return { contents: [{ uri: "agentdeals://changes", text, mimeType: "text/plain" }] };
+    }
+  );
+
+  // Static: latest changes
+  server.registerResource(
+    "changes-latest",
+    "agentdeals://changes/latest",
+    {
+      description: "Most recent pricing changes (last 10)",
+      mimeType: "text/plain",
+    },
+    async () => {
+      const data = (await fetchDealChanges({ since: "2020-01-01" })) as { changes: Array<{ date: string; vendor: string; change_type: string; summary: string; previous_state: string; current_state: string }> };
+      const latest = data.changes.slice(0, 10);
+      const lines = latest.map(c =>
+        `- **${c.date}** | ${c.vendor} [${c.change_type}]\n  ${c.summary}\n  Previous: ${c.previous_state}\n  Current: ${c.current_state}`
+      );
+      const text = `# Latest Pricing Changes\n\n${lines.join("\n\n")}`;
+      return { contents: [{ uri: "agentdeals://changes/latest", text, mimeType: "text/plain" }] };
+    }
+  );
+
+  // Static: all editorial guides
+  server.registerResource(
+    "guides",
+    "agentdeals://guides",
+    {
+      description: "All editorial pages — comparisons, stack guides, pricing reports, and alternatives",
+      mimeType: "text/plain",
+    },
+    async () => {
+      const guides = getGuideList();
+      const byType = new Map<string, typeof guides>();
+      for (const g of guides) {
+        if (!byType.has(g.type)) byType.set(g.type, []);
+        byType.get(g.type)!.push(g);
+      }
+      let text = `# AgentDeals Editorial Guides\n\n${guides.length} guides.\n`;
+      for (const [type, items] of byType) {
+        text += `\n## ${type.charAt(0).toUpperCase() + type.slice(1)}\n\n`;
+        for (const g of items) {
+          text += `- **${g.title}** (/${g.slug}) — ${g.description}\n`;
+        }
+      }
+      return { contents: [{ uri: "agentdeals://guides", text, mimeType: "text/plain" }] };
+    }
+  );
+
+  // Template: guide detail
+  server.registerResource(
+    "guide",
+    new ResourceTemplate("agentdeals://guide/{slug}", {
+      list: async () => {
+        const guides = getGuideList();
+        return {
+          resources: guides.map(g => ({
+            uri: `agentdeals://guide/${g.slug}`,
+            name: g.title,
+            description: g.description,
+            mimeType: "text/plain",
+          })),
+        };
+      },
+      complete: {
+        slug: async (value) => {
+          const guides = getGuideList();
+          return guides.map(g => g.slug).filter(s => s.startsWith(value));
+        },
+      },
+    }),
+    {
+      description: "Editorial guide detail — title, description, type, and URL",
+      mimeType: "text/plain",
+    },
+    async (_uri, { slug }) => {
+      const guide = getGuideBySlug(slug as string);
+      if (!guide) {
+        return { contents: [{ uri: `agentdeals://guide/${slug}`, text: `No guide found matching "${slug}".`, mimeType: "text/plain" }] };
+      }
+      let text = `# ${guide.title}\n\n`;
+      text += `**Type:** ${guide.type}\n`;
+      text += `**Description:** ${guide.description}\n`;
+      text += `**URL:** /${guide.slug}\n`;
+
+      // Add related vendor data from changes
+      try {
+        const changesData = (await fetchDealChanges({ since: "2020-01-01" })) as { changes: Array<{ date: string; vendor: string; change_type: string; summary: string }> };
+        const slugLower = guide.slug.toLowerCase();
+        const relatedChanges = changesData.changes.filter(c => {
+          const vendorSlug = c.vendor.toLowerCase().replace(/[^a-z0-9]+/g, "-");
+          return slugLower.includes(vendorSlug) || vendorSlug.includes(slugLower.replace(/-alternatives$/, "").replace(/-vs-.*/, ""));
+        });
+        if (relatedChanges.length > 0) {
+          text += `\n## Related Pricing Changes\n\n`;
+          for (const c of relatedChanges.slice(0, 5)) {
+            text += `- **${c.date}** | ${c.vendor} [${c.change_type}] ${c.summary}\n`;
+          }
+        }
+      } catch {
+        // Changes endpoint not available — skip
+      }
+
+      return { contents: [{ uri: `agentdeals://guide/${slug}`, text, mimeType: "text/plain" }] };
     }
   );
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,9 +1,10 @@
-import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { McpServer, ResourceTemplate } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
-import { getCategories, getDealChanges, getNewOffers, getNewestDeals, getOfferDetails, searchOffers, enrichOffers, compareServices, checkVendorRisk, auditStack, getExpiringDeals, getWeeklyDigest } from "./data.js";
+import { getCategories, getDealChanges, getNewOffers, getNewestDeals, getOfferDetails, searchOffers, enrichOffers, compareServices, checkVendorRisk, auditStack, getExpiringDeals, getWeeklyDigest, loadOffers, loadDealChanges } from "./data.js";
 import { recordToolCall, logRequest } from "./stats.js";
 import { getStackRecommendation } from "./stacks.js";
 import { estimateCosts } from "./costs.js";
+import { getGuideList, getGuideBySlug } from "./guides.js";
 import type { Offer, EnrichedOffer, DealChange } from "./types.js";
 
 function toConciseOffer(offer: Offer | EnrichedOffer) {
@@ -554,6 +555,279 @@ Suggested monitoring cadence: run this check weekly to catch pricing changes ear
     }
   );
 
+  // --- Resources ---
+
+  // Static: all categories with offer counts
+  server.registerResource(
+    "categories",
+    "agentdeals://categories",
+    {
+      description: "All 54 developer tool categories with offer counts",
+      mimeType: "text/plain",
+    },
+    async () => {
+      const categories = getCategories();
+      const lines = categories.map(c => `- **${c.name}** (${c.count} offers)`);
+      const text = `# AgentDeals Categories\n\n${categories.length} categories, ${loadOffers().length} total offers.\n\n${lines.join("\n")}`;
+      return { contents: [{ uri: "agentdeals://categories", text, mimeType: "text/plain" }] };
+    }
+  );
+
+  // Template: category detail
+  server.registerResource(
+    "category",
+    new ResourceTemplate("agentdeals://category/{slug}", {
+      list: async () => {
+        const categories = getCategories();
+        return {
+          resources: categories.map(c => ({
+            uri: `agentdeals://category/${c.name.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/-+$/, "")}`,
+            name: c.name,
+            description: `${c.count} offers in ${c.name}`,
+            mimeType: "text/plain",
+          })),
+        };
+      },
+      complete: {
+        slug: async (value) => {
+          const categories = getCategories();
+          const slugs = categories.map(c => c.name.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/-+$/, ""));
+          return slugs.filter(s => s.startsWith(value));
+        },
+      },
+    }),
+    {
+      description: "All offers in a specific category",
+      mimeType: "text/plain",
+    },
+    async (_uri, { slug }) => {
+      const offers = loadOffers();
+      // Match category by slug (case-insensitive, slug-to-name)
+      const match = offers.filter(o =>
+        o.category.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/-+$/, "") === slug
+      );
+      if (match.length === 0) {
+        return { contents: [{ uri: `agentdeals://category/${slug}`, text: `No category found matching "${slug}".`, mimeType: "text/plain" }] };
+      }
+      const categoryName = match[0].category;
+      const lines = match.map(o => `- **${o.vendor}** — ${o.tier}: ${o.description} (verified ${o.verifiedDate})`);
+      const text = `# ${categoryName}\n\n${match.length} offers.\n\n${lines.join("\n")}`;
+      return { contents: [{ uri: `agentdeals://category/${slug}`, text, mimeType: "text/plain" }] };
+    }
+  );
+
+  // Static: all vendors
+  server.registerResource(
+    "vendors",
+    "agentdeals://vendors",
+    {
+      description: "All vendors with category and tier type",
+      mimeType: "text/plain",
+    },
+    async () => {
+      const offers = loadOffers();
+      const lines = offers
+        .sort((a, b) => a.vendor.localeCompare(b.vendor))
+        .map(o => `- **${o.vendor}** | ${o.category} | ${o.tier}`);
+      const text = `# AgentDeals Vendors\n\n${offers.length} vendors.\n\n${lines.join("\n")}`;
+      return { contents: [{ uri: "agentdeals://vendors", text, mimeType: "text/plain" }] };
+    }
+  );
+
+  // Template: vendor detail
+  server.registerResource(
+    "vendor",
+    new ResourceTemplate("agentdeals://vendor/{slug}", {
+      list: async () => {
+        const offers = loadOffers();
+        return {
+          resources: offers.map(o => ({
+            uri: `agentdeals://vendor/${o.vendor.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/-+$/, "")}`,
+            name: o.vendor,
+            description: `${o.vendor} — ${o.tier}`,
+            mimeType: "text/plain",
+          })),
+        };
+      },
+      complete: {
+        slug: async (value) => {
+          const offers = loadOffers();
+          const slugs = offers.map(o => o.vendor.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/-+$/, ""));
+          return slugs.filter(s => s.startsWith(value));
+        },
+      },
+    }),
+    {
+      description: "Full vendor details: free tier limits, pricing, verified date, alternatives, changes",
+      mimeType: "text/plain",
+    },
+    async (_uri, { slug }) => {
+      const offers = loadOffers();
+      const match = offers.find(o =>
+        o.vendor.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/-+$/, "") === slug
+      );
+      if (!match) {
+        return { contents: [{ uri: `agentdeals://vendor/${slug}`, text: `No vendor found matching "${slug}".`, mimeType: "text/plain" }] };
+      }
+      const changes = loadDealChanges().filter(c => c.vendor.toLowerCase() === match.vendor.toLowerCase());
+      const alternatives = offers
+        .filter(o => o.category === match.category && o.vendor !== match.vendor)
+        .slice(0, 5);
+
+      let text = `# ${match.vendor}\n\n`;
+      text += `**Category:** ${match.category}\n`;
+      text += `**Tier:** ${match.tier}\n`;
+      text += `**Description:** ${match.description}\n`;
+      text += `**Pricing Page:** ${match.url}\n`;
+      text += `**Verified:** ${match.verifiedDate}\n`;
+      if (match.eligibility) {
+        text += `**Eligibility:** ${match.eligibility.type} — ${match.eligibility.conditions.join(", ")}\n`;
+      }
+      if (match.expires_date) {
+        text += `**Expires:** ${match.expires_date}\n`;
+      }
+      text += `**Tags:** ${match.tags.join(", ")}\n`;
+
+      if (changes.length > 0) {
+        text += `\n## Pricing Changes\n\n`;
+        for (const c of changes) {
+          text += `- **${c.date}** [${c.change_type}] ${c.summary}\n  Previous: ${c.previous_state}\n  Current: ${c.current_state}\n`;
+        }
+      }
+
+      if (alternatives.length > 0) {
+        text += `\n## Alternatives in ${match.category}\n\n`;
+        for (const a of alternatives) {
+          text += `- **${a.vendor}** — ${a.tier}: ${a.description}\n`;
+        }
+      }
+
+      return { contents: [{ uri: `agentdeals://vendor/${slug}`, text, mimeType: "text/plain" }] };
+    }
+  );
+
+  // Static: all pricing changes
+  server.registerResource(
+    "changes",
+    "agentdeals://changes",
+    {
+      description: "All tracked pricing changes across developer tools",
+      mimeType: "text/plain",
+    },
+    async () => {
+      const changes = loadDealChanges();
+      const sorted = [...changes].sort((a, b) => b.date.localeCompare(a.date));
+      const lines = sorted.map(c =>
+        `- **${c.date}** | ${c.vendor} | ${c.change_type} | ${c.summary}`
+      );
+      const text = `# AgentDeals Pricing Changes\n\n${changes.length} tracked changes.\n\n${lines.join("\n")}`;
+      return { contents: [{ uri: "agentdeals://changes", text, mimeType: "text/plain" }] };
+    }
+  );
+
+  // Static: latest changes (most recent 10)
+  server.registerResource(
+    "changes-latest",
+    "agentdeals://changes/latest",
+    {
+      description: "Most recent pricing changes (last 10)",
+      mimeType: "text/plain",
+    },
+    async () => {
+      const changes = loadDealChanges();
+      const sorted = [...changes].sort((a, b) => b.date.localeCompare(a.date)).slice(0, 10);
+      const lines = sorted.map(c =>
+        `- **${c.date}** | ${c.vendor} [${c.change_type}]\n  ${c.summary}\n  Previous: ${c.previous_state}\n  Current: ${c.current_state}`
+      );
+      const text = `# Latest Pricing Changes\n\n${lines.join("\n\n")}`;
+      return { contents: [{ uri: "agentdeals://changes/latest", text, mimeType: "text/plain" }] };
+    }
+  );
+
+  // Static: all editorial guides
+  server.registerResource(
+    "guides",
+    "agentdeals://guides",
+    {
+      description: "All editorial pages — comparisons, stack guides, pricing reports, and alternatives",
+      mimeType: "text/plain",
+    },
+    async () => {
+      const guides = getGuideList();
+      const byType = new Map<string, typeof guides>();
+      for (const g of guides) {
+        if (!byType.has(g.type)) byType.set(g.type, []);
+        byType.get(g.type)!.push(g);
+      }
+      let text = `# AgentDeals Editorial Guides\n\n${guides.length} guides.\n`;
+      for (const [type, items] of byType) {
+        text += `\n## ${type.charAt(0).toUpperCase() + type.slice(1)}\n\n`;
+        for (const g of items) {
+          text += `- **${g.title}** (/${g.slug}) — ${g.description}\n`;
+        }
+      }
+      return { contents: [{ uri: "agentdeals://guides", text, mimeType: "text/plain" }] };
+    }
+  );
+
+  // Template: guide detail
+  server.registerResource(
+    "guide",
+    new ResourceTemplate("agentdeals://guide/{slug}", {
+      list: async () => {
+        const guides = getGuideList();
+        return {
+          resources: guides.map(g => ({
+            uri: `agentdeals://guide/${g.slug}`,
+            name: g.title,
+            description: g.description,
+            mimeType: "text/plain",
+          })),
+        };
+      },
+      complete: {
+        slug: async (value) => {
+          const guides = getGuideList();
+          return guides.map(g => g.slug).filter(s => s.startsWith(value));
+        },
+      },
+    }),
+    {
+      description: "Editorial guide detail — title, description, type, and URL",
+      mimeType: "text/plain",
+    },
+    async (_uri, { slug }) => {
+      const guide = getGuideBySlug(slug as string);
+      if (!guide) {
+        return { contents: [{ uri: `agentdeals://guide/${slug}`, text: `No guide found matching "${slug}".`, mimeType: "text/plain" }] };
+      }
+      let text = `# ${guide.title}\n\n`;
+      text += `**Type:** ${guide.type}\n`;
+      text += `**Description:** ${guide.description}\n`;
+      text += `**URL:** /${guide.slug}\n`;
+
+      // Add related vendor data if this is a vendor-specific guide
+      const offers = loadOffers();
+      const changes = loadDealChanges();
+      const slugLower = guide.slug.toLowerCase();
+
+      // Extract vendor names mentioned in the slug for context
+      const relatedChanges = changes.filter(c => {
+        const vendorSlug = c.vendor.toLowerCase().replace(/[^a-z0-9]+/g, "-");
+        return slugLower.includes(vendorSlug) || vendorSlug.includes(slugLower.replace(/-alternatives$/, "").replace(/-vs-.*/, ""));
+      });
+
+      if (relatedChanges.length > 0) {
+        text += `\n## Related Pricing Changes\n\n`;
+        for (const c of relatedChanges.slice(0, 5)) {
+          text += `- **${c.date}** | ${c.vendor} [${c.change_type}] ${c.summary}\n`;
+        }
+      }
+
+      return { contents: [{ uri: `agentdeals://guide/${slug}`, text, mimeType: "text/plain" }] };
+    }
+  );
+
   return server;
 }
 
@@ -580,6 +854,7 @@ export function getServerCard(baseUrl: string) {
     capabilities: {
       tools: { listChanged: false },
       prompts: { listChanged: false },
+      resources: { listChanged: false },
     },
     authentication: {
       required: false,

--- a/test/resources.test.ts
+++ b/test/resources.test.ts
@@ -1,0 +1,277 @@
+import { describe, it, after } from "node:test";
+import assert from "node:assert";
+import { spawn, type ChildProcess } from "node:child_process";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+// Start a local HTTP server so stdio MCP tests hit local data (not production API)
+let LOCAL_API_URL = "";
+
+const httpServerPath = path.join(__dirname, "..", "dist", "serve.js");
+const httpServer: ChildProcess = spawn("node", [httpServerPath], {
+  env: { ...process.env, PORT: "0" },
+  stdio: ["pipe", "pipe", "pipe"],
+});
+
+await new Promise<void>((resolve, reject) => {
+  const timeout = setTimeout(() => reject(new Error("HTTP server start timeout")), 10000);
+  httpServer.stderr!.on("data", (chunk: Buffer) => {
+    const match = chunk.toString().match(/running on http:\/\/localhost:(\d+)/);
+    if (match) {
+      LOCAL_API_URL = `http://localhost:${match[1]}`;
+      clearTimeout(timeout);
+      resolve();
+    }
+  });
+  httpServer.on("error", (err) => {
+    clearTimeout(timeout);
+    reject(err);
+  });
+});
+
+after(() => {
+  httpServer.kill();
+});
+
+function sendMcpMessages(
+  serverProcess: ReturnType<typeof spawn>,
+  messages: object[]
+): Promise<object[]> {
+  return new Promise((resolve, reject) => {
+    const timeout = setTimeout(() => reject(new Error("Timeout")), 15000);
+    const responses: object[] = [];
+    let buffer = "";
+    const expectedResponses = messages.filter(
+      (m: any) => m.id !== undefined
+    ).length;
+
+    const onData = (data: Buffer) => {
+      buffer += data.toString();
+      const lines = buffer.split("\n");
+      buffer = lines.pop() ?? "";
+      for (const line of lines) {
+        if (line.trim()) {
+          try {
+            responses.push(JSON.parse(line.trim()));
+            if (responses.length >= expectedResponses) {
+              clearTimeout(timeout);
+              serverProcess.stdout!.off("data", onData);
+              resolve(responses);
+            }
+          } catch {
+            // not valid JSON yet
+          }
+        }
+      }
+    };
+
+    serverProcess.stdout!.on("data", onData);
+    for (const msg of messages) {
+      serverProcess.stdin!.write(JSON.stringify(msg) + "\n");
+    }
+  });
+}
+
+const INIT_MESSAGES = [
+  {
+    jsonrpc: "2.0",
+    id: 1,
+    method: "initialize",
+    params: {
+      protocolVersion: "2024-11-05",
+      capabilities: {},
+      clientInfo: { name: "test-client", version: "1.0.0" },
+    },
+  },
+  { jsonrpc: "2.0", method: "notifications/initialized" },
+];
+
+function startServer() {
+  const serverPath = path.join(__dirname, "..", "dist", "index.js");
+  return spawn("node", [serverPath], {
+    stdio: ["pipe", "pipe", "pipe"],
+    env: { ...process.env, AGENTDEALS_API_URL: LOCAL_API_URL },
+  });
+}
+
+describe("MCP Resources", () => {
+  it("lists resources including categories, vendors, changes, and guides", async () => {
+    const proc = startServer();
+    try {
+      const responses = (await sendMcpMessages(proc, [
+        ...INIT_MESSAGES,
+        {
+          jsonrpc: "2.0",
+          id: 2,
+          method: "resources/list",
+          params: {},
+        },
+      ])) as any[];
+
+      const listResponse = responses.find((r: any) => r.id === 2) as any;
+      assert.ok(listResponse.result, "resources/list should return a result");
+      assert.ok(Array.isArray(listResponse.result.resources), "result should have resources array");
+
+      const uris = listResponse.result.resources.map((r: any) => r.uri);
+      // Static resources
+      assert.ok(uris.includes("agentdeals://categories"), "should include categories");
+      assert.ok(uris.includes("agentdeals://vendors"), "should include vendors");
+      assert.ok(uris.includes("agentdeals://changes"), "should include changes");
+      assert.ok(uris.includes("agentdeals://changes/latest"), "should include changes/latest");
+      assert.ok(uris.includes("agentdeals://guides"), "should include guides");
+
+      // Template-expanded resources
+      assert.ok(uris.some((u: string) => u.startsWith("agentdeals://category/")), "should include category templates");
+      assert.ok(uris.some((u: string) => u.startsWith("agentdeals://vendor/")), "should include vendor templates");
+      assert.ok(uris.some((u: string) => u.startsWith("agentdeals://guide/")), "should include guide templates");
+
+      // Should have many resources (static + templates)
+      assert.ok(listResponse.result.resources.length > 50, `should have many resources, got ${listResponse.result.resources.length}`);
+    } finally {
+      proc.kill();
+    }
+  });
+
+  it("reads categories resource with all categories listed", async () => {
+    const proc = startServer();
+    try {
+      const responses = (await sendMcpMessages(proc, [
+        ...INIT_MESSAGES,
+        {
+          jsonrpc: "2.0",
+          id: 2,
+          method: "resources/read",
+          params: { uri: "agentdeals://categories" },
+        },
+      ])) as any[];
+
+      const readResponse = responses.find((r: any) => r.id === 2) as any;
+      assert.ok(readResponse.result, "should return a result");
+      assert.ok(Array.isArray(readResponse.result.contents), "should have contents");
+      assert.strictEqual(readResponse.result.contents[0].uri, "agentdeals://categories");
+
+      const text = readResponse.result.contents[0].text;
+      assert.ok(text.includes("# AgentDeals Categories"), "should have heading");
+      assert.ok(text.includes("categories"), "should mention categories");
+      assert.ok(text.includes("Databases"), "should include Databases category");
+    } finally {
+      proc.kill();
+    }
+  });
+
+  it("reads changes resource with tracked changes", async () => {
+    const proc = startServer();
+    try {
+      const responses = (await sendMcpMessages(proc, [
+        ...INIT_MESSAGES,
+        {
+          jsonrpc: "2.0",
+          id: 2,
+          method: "resources/read",
+          params: { uri: "agentdeals://changes" },
+        },
+      ])) as any[];
+
+      const readResponse = responses.find((r: any) => r.id === 2) as any;
+      assert.ok(readResponse.result);
+      const text = readResponse.result.contents[0].text;
+      assert.ok(text.includes("# AgentDeals Pricing Changes"));
+      assert.ok(text.includes("tracked changes"));
+    } finally {
+      proc.kill();
+    }
+  });
+
+  it("reads guides resource listing all editorial pages", async () => {
+    const proc = startServer();
+    try {
+      const responses = (await sendMcpMessages(proc, [
+        ...INIT_MESSAGES,
+        {
+          jsonrpc: "2.0",
+          id: 2,
+          method: "resources/read",
+          params: { uri: "agentdeals://guides" },
+        },
+      ])) as any[];
+
+      const readResponse = responses.find((r: any) => r.id === 2) as any;
+      assert.ok(readResponse.result);
+      const text = readResponse.result.contents[0].text;
+      assert.ok(text.includes("# AgentDeals Editorial Guides"));
+      assert.ok(text.includes("guides"));
+    } finally {
+      proc.kill();
+    }
+  });
+
+  it("reads a specific guide by slug", async () => {
+    const proc = startServer();
+    try {
+      const responses = (await sendMcpMessages(proc, [
+        ...INIT_MESSAGES,
+        {
+          jsonrpc: "2.0",
+          id: 2,
+          method: "resources/read",
+          params: { uri: "agentdeals://guide/supabase-vs-firebase" },
+        },
+      ])) as any[];
+
+      const readResponse = responses.find((r: any) => r.id === 2) as any;
+      assert.ok(readResponse.result);
+      const text = readResponse.result.contents[0].text;
+      assert.ok(text.includes("Supabase vs Firebase"), "should have guide title");
+      assert.ok(text.includes("comparison"), "should show type");
+      assert.ok(text.includes("/supabase-vs-firebase"), "should include URL");
+    } finally {
+      proc.kill();
+    }
+  });
+
+  it("returns not-found message for unknown guide slug", async () => {
+    const proc = startServer();
+    try {
+      const responses = (await sendMcpMessages(proc, [
+        ...INIT_MESSAGES,
+        {
+          jsonrpc: "2.0",
+          id: 2,
+          method: "resources/read",
+          params: { uri: "agentdeals://guide/nonexistent-guide" },
+        },
+      ])) as any[];
+
+      const readResponse = responses.find((r: any) => r.id === 2) as any;
+      assert.ok(readResponse.result);
+      const text = readResponse.result.contents[0].text;
+      assert.ok(text.includes("No guide found"), "should indicate not found");
+    } finally {
+      proc.kill();
+    }
+  });
+
+  it("reads changes/latest resource", async () => {
+    const proc = startServer();
+    try {
+      const responses = (await sendMcpMessages(proc, [
+        ...INIT_MESSAGES,
+        {
+          jsonrpc: "2.0",
+          id: 2,
+          method: "resources/read",
+          params: { uri: "agentdeals://changes/latest" },
+        },
+      ])) as any[];
+
+      const readResponse = responses.find((r: any) => r.id === 2) as any;
+      assert.ok(readResponse.result);
+      const text = readResponse.result.contents[0].text;
+      assert.ok(text.includes("# Latest Pricing Changes"));
+    } finally {
+      proc.kill();
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Adds MCP Resources support, exposing deal data and editorial content as browsable, readable resources. Agents can now explore our dataset natively via `resources/list` and `resources/read` without needing tool calls.

### Resource URIs

| URI Pattern | Type | Description |
|---|---|---|
| `agentdeals://categories` | Static | All 54 categories with offer counts |
| `agentdeals://category/{slug}` | Template | All offers in a specific category |
| `agentdeals://vendors` | Static | All 1,559 vendors with category and tier |
| `agentdeals://vendor/{slug}` | Template | Full vendor detail: limits, pricing changes, alternatives |
| `agentdeals://changes` | Static | All tracked pricing changes |
| `agentdeals://changes/latest` | Static | 10 most recent pricing changes |
| `agentdeals://guides` | Static | All 68 editorial pages by type |
| `agentdeals://guide/{slug}` | Template | Guide detail with related pricing changes |

### Implementation

- Resources registered in both `server.ts` (local/HTTP) and `server-remote.ts` (stdio)
- Template resources include `list` callbacks (for full enumeration) and `complete` callbacks (for slug autocomplete)
- New `guides.ts` module provides lightweight guide metadata index
- Server card updated with `resources` capability
- 1,686 total browsable resources (5 static + 54 categories + 1,559 vendors + 68 guides)
- 7 new tests covering list, read, templates, not-found handling
- 379 total tests passing (372 existing + 7 new)

Refs #570