### PR TITLE
Vendor stability indicators from pricing change history

### DIFF
--- a/src/api-client.ts
+++ b/src/api-client.ts
@@ -50,6 +50,7 @@ export async function fetchOffers(params: {
   category?: string;
   eligibility_type?: string;
   sort?: string;
+  stability?: string;
   limit?: number;
   offset?: number;
 }): Promise<unknown> {
@@ -58,6 +59,7 @@ export async function fetchOffers(params: {
   if (params.category) p.category = params.category;
   if (params.eligibility_type) p.eligibility_type = params.eligibility_type;
   if (params.sort) p.sort = params.sort;
+  if (params.stability) p.stability = params.stability;
   if (params.limit !== undefined) p.limit = String(params.limit);
   if (params.offset !== undefined) p.offset = String(params.offset);
   return apiFetch("/api/offers", p);

--- a/src/data.ts
+++ b/src/data.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import type { Offer, EnrichedOffer, OfferIndex, DealChange, DealChangesIndex } from "./types.js";
+import type { Offer, EnrichedOffer, OfferIndex, DealChange, DealChangesIndex, StabilityClass } from "./types.js";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const INDEX_PATH = path.join(__dirname, "..", "data", "index.json");
@@ -139,7 +139,8 @@ export function searchOffers(
   query?: string,
   category?: string,
   eligibilityType?: string,
-  sort?: string
+  sort?: string,
+  stability?: StabilityClass
 ): Offer[] {
   let results = loadOffers();
 
@@ -154,6 +155,13 @@ export function searchOffers(
     const lowerType = eligibilityType.toLowerCase();
     results = results.filter(
       (o) => o.eligibility?.type.toLowerCase() === lowerType
+    );
+  }
+
+  if (stability) {
+    const stabilityMap = getStabilityMap();
+    results = results.filter(
+      (o) => (stabilityMap.get(o.vendor.toLowerCase()) ?? "stable") === stability
     );
   }
 
@@ -196,6 +204,65 @@ export function searchOffers(
   return results;
 }
 
+const NEGATIVE_STABILITY_TYPES = new Set([
+  "free_tier_removed",
+  "open_source_killed",
+  "limits_reduced",
+  "pricing_restructured",
+  "product_deprecated",
+  "restriction",
+]);
+
+const VOLATILE_TYPES = new Set([
+  "free_tier_removed",
+  "open_source_killed",
+  "product_deprecated",
+]);
+
+const POSITIVE_STABILITY_TYPES = new Set([
+  "limits_increased",
+  "new_free_tier",
+  "startup_program_expanded",
+  "pricing_postponed",
+]);
+
+export function classifyStability(vendorChanges: DealChange[]): StabilityClass {
+  if (vendorChanges.length === 0) return "stable";
+
+  const hasVolatile = vendorChanges.some(c => VOLATILE_TYPES.has(c.change_type));
+  const negativeCount = vendorChanges.filter(c => NEGATIVE_STABILITY_TYPES.has(c.change_type)).length;
+  const positiveCount = vendorChanges.filter(c => POSITIVE_STABILITY_TYPES.has(c.change_type)).length;
+
+  // Volatile: free tier removed, OSS killed, product deprecated, or multiple negative changes
+  if (hasVolatile || negativeCount >= 2) return "volatile";
+
+  // Improving: only positive changes (no negative)
+  if (positiveCount > 0 && negativeCount === 0) return "improving";
+
+  // Watch: one negative change
+  if (negativeCount === 1) return "watch";
+
+  // No negative or positive (e.g. only pricing_model_change) = stable
+  return "stable";
+}
+
+// Build a map of vendor name (lowercase) → stability class from deal_changes
+export function getStabilityMap(): Map<string, StabilityClass> {
+  const changes = loadDealChanges();
+  const vendorChangesMap = new Map<string, DealChange[]>();
+  for (const c of changes) {
+    const key = c.vendor.toLowerCase();
+    if (!vendorChangesMap.has(key)) vendorChangesMap.set(key, []);
+    vendorChangesMap.get(key)!.push(c);
+  }
+
+  const result = new Map<string, StabilityClass>();
+  for (const [vendor, vendorChanges] of vendorChangesMap) {
+    result.set(vendor, classifyStability(vendorChanges));
+  }
+  return result;
+}
+
 export function enrichOffers(offers: Offer[]): EnrichedOffer[] {
   const changes = loadDealChanges();
   const now = new Date();
@@ -217,6 +284,14 @@ export function enrichOffers(offers: Offer[]): EnrichedOffer[] {
   for (const c of changes) {
     const key = c.vendor.toLowerCase();
     vendorAllChanges.set(key, (vendorAllChanges.get(key) ?? 0) + 1);
+  }
+
+  // Build vendor → all changes for stability classification
+  const vendorAllChangesList = new Map<string, DealChange[]>();
+  for (const c of changes) {
+    const key = c.vendor.toLowerCase();
+    if (!vendorAllChangesList.has(key)) vendorAllChangesList.set(key, []);
+    vendorAllChangesList.get(key)!.push(c);
   }
 
   return offers.map((offer) => {
@@ -250,11 +325,14 @@ export function enrichOffers(offers: Offer[]): EnrichedOffer[] {
       risk_level = "stable";
     }
 
+    // stability: derived from change types, not just count
+    const stability = classifyStability(vendorAllChangesList.get(key) ?? []);
+
     const days_since_verified = Math.floor(
       (now.getTime() - new Date(offer.verifiedDate).getTime()) / (24 * 60 * 60 * 1000)
     );
 
-    return { ...offer, recent_change, expires_soon, risk_level, days_since_verified };
+    return { ...offer, recent_change, expires_soon, risk_level, stability, days_since_verified };
   });
 }
 

--- a/src/serve.ts
+++ b/src/serve.ts
@@ -30046,9 +30046,13 @@ const httpServer = createHttpServer(async (req, res) => {
     const category = url.searchParams.get("category") || undefined;
     const eligibilityType = url.searchParams.get("eligibility_type") || undefined;
     const sort = url.searchParams.get("sort") || undefined;
+    const stabilityParam = url.searchParams.get("stability") || undefined;
+    const validStability = stabilityParam && ["stable", "watch", "volatile", "improving"].includes(stabilityParam)
+      ? stabilityParam as import("./types.js").StabilityClass
+      : undefined;
     const limit = parseInt(url.searchParams.get("limit") ?? "20", 10);
     const offset = parseInt(url.searchParams.get("offset") ?? "0", 10);
-    const results = searchOffers(q, category, eligibilityType, sort);
+    const results = searchOffers(q, category, eligibilityType, sort, validStability);
     const total = results.length;
     const paged = enrichOffers(results.slice(offset, offset + limit));
     logRequest({ ts: new Date().toISOString(), type: "api", endpoint: "/api/offers", params: { q, category, limit, offset }, user_agent: req.headers["user-agent"] ?? "unknown", result_count: paged.length });

--- a/src/server-remote.ts
+++ b/src/server-remote.ts
@@ -77,13 +77,14 @@ export function createServer(): McpServer {
         vendor: z.string().optional().describe("Get full details for a specific vendor (fuzzy match). Returns alternatives in the same category."),
         eligibility: z.enum(["public", "accelerator", "oss", "student", "fintech", "geographic", "enterprise"]).optional().describe("Filter by eligibility type"),
         sort: z.enum(["vendor", "category", "newest"]).optional().describe("Sort: vendor (A-Z), category, newest (recently verified first)"),
+        stability: z.enum(["stable", "watch", "volatile", "improving"]).optional().describe("Filter by free tier stability class. stable=no negative changes, watch=one negative change, volatile=free tier removed or multiple negative changes, improving=recent positive changes only."),
         since: z.string().optional().describe("ISO date (YYYY-MM-DD). Only return deals verified/added after this date."),
         limit: z.number().optional().describe("Max results (default: 20)"),
         offset: z.number().optional().describe("Pagination offset (default: 0)"),
         response_format: z.enum(["concise", "detailed"]).optional().describe("Response detail level. 'concise': vendor name, tier, one-line description, URL only. 'detailed': full response (default)."),
       },
     },
-    async ({ query, category, vendor, eligibility, sort, since, limit, offset, response_format }) => {
+    async ({ query, category, vendor, eligibility, sort, stability, since, limit, offset, response_format }) => {
       try {
         // Mode: list categories
         if (category === "list") {
@@ -120,6 +121,7 @@ export function createServer(): McpServer {
           category,
           eligibility_type: eligibility,
           sort,
+          stability,
           limit: effectiveLimit,
           offset: effectiveOffset,
         }) as { offers: Record<string, unknown>[]; total: number };

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,6 +1,6 @@
 import { McpServer, ResourceTemplate } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
-import { getCategories, getDealChanges, getNewOffers, getNewestDeals, getOfferDetails, searchOffers, enrichOffers, compareServices, checkVendorRisk, auditStack, getExpiringDeals, getWeeklyDigest, loadOffers, loadDealChanges } from "./data.js";
+import { getCategories, getDealChanges, getNewOffers, getNewestDeals, getOfferDetails, searchOffers, enrichOffers, compareServices, checkVendorRisk, auditStack, getExpiringDeals, getWeeklyDigest, loadOffers, loadDealChanges, classifyStability, getStabilityMap } from "./data.js";
 import { recordToolCall, logRequest } from "./stats.js";
 import { getStackRecommendation } from "./stacks.js";
 import { estimateCosts } from "./costs.js";
@@ -39,13 +39,14 @@ export function createServer(getSessionId?: () => string | undefined): McpServer
         vendor: z.string().optional().describe("Get full details for a specific vendor (fuzzy match). Returns alternatives in the same category."),
         eligibility: z.enum(["public", "accelerator", "oss", "student", "fintech", "geographic", "enterprise"]).optional().describe("Filter by eligibility type"),
         sort: z.enum(["vendor", "category", "newest"]).optional().describe("Sort: vendor (A-Z), category, newest (recently verified first)"),
+        stability: z.enum(["stable", "watch", "volatile", "improving"]).optional().describe("Filter by free tier stability class. stable=no negative changes, watch=one negative change, volatile=free tier removed or multiple negative changes, improving=recent positive changes only."),
         since: z.string().optional().describe("ISO date (YYYY-MM-DD). Only return deals verified/added after this date."),
         limit: z.number().optional().describe("Max results (default: 20)"),
         offset: z.number().optional().describe("Pagination offset (default: 0)"),
         response_format: z.enum(["concise", "detailed"]).optional().describe("Response detail level. 'concise': vendor name, tier, one-line description, URL only. 'detailed': full response (default)."),
       },
     },
-    async ({ query, category, vendor, eligibility, sort, since, limit, offset, response_format }) => {
+    async ({ query, category, vendor, eligibility, sort, stability, since, limit, offset, response_format }) => {
       try {
         recordToolCall("search_deals");
 
@@ -87,7 +88,7 @@ export function createServer(getSessionId?: () => string | undefined): McpServer
         }
 
         // Mode: search/browse
-        const allResults = searchOffers(query, category, eligibility, sort);
+        const allResults = searchOffers(query, category, eligibility, sort, stability);
         const total = allResults.length;
         const effectiveOffset = offset ?? 0;
         const effectiveLimit = limit ?? 20;
@@ -236,9 +237,14 @@ export function createServer(getSessionId?: () => string | undefined): McpServer
               content: [{ type: "text" as const, text: result.error }],
             };
           }
+          const stabMap = getStabilityMap();
+          const enrichedResult = {
+            ...result.result,
+            stability: stabMap.get(result.result.vendor.toLowerCase()) ?? "stable",
+          };
           logRequest({ ts: new Date().toISOString(), type: "mcp", endpoint: "compare_vendors", params: { vendors }, result_count: 1, session_id: getSessionId?.() });
           return {
-            content: [{ type: "text" as const, text: JSON.stringify(result.result, null, 2) }],
+            content: [{ type: "text" as const, text: JSON.stringify(enrichedResult, null, 2) }],
           };
         }
 
@@ -254,6 +260,17 @@ export function createServer(getSessionId?: () => string | undefined): McpServer
           }
 
           let result: any = comparison.comparison;
+
+          // Add stability indicators
+          const stabMap = getStabilityMap();
+          result = {
+            ...result,
+            stability: {
+              [vendors[0]]: stabMap.get(comparison.comparison.vendor_a.vendor.toLowerCase()) ?? "stable",
+              [vendors[1]]: stabMap.get(comparison.comparison.vendor_b.vendor.toLowerCase()) ?? "stable",
+            },
+          };
+
           if (doRisk) {
             const riskA = checkVendorRisk(vendors[0]);
             const riskB = checkVendorRisk(vendors[1]);
@@ -670,6 +687,7 @@ Suggested monitoring cadence: run this check weekly to catch pricing changes ear
         return { contents: [{ uri: `agentdeals://vendor/${slug}`, text: `No vendor found matching "${slug}".`, mimeType: "text/plain" }] };
       }
       const changes = loadDealChanges().filter(c => c.vendor.toLowerCase() === match.vendor.toLowerCase());
+      const stability = classifyStability(changes);
       const alternatives = offers
         .filter(o => o.category === match.category && o.vendor !== match.vendor)
         .slice(0, 5);
@@ -677,6 +695,7 @@ Suggested monitoring cadence: run this check weekly to catch pricing changes ear
       let text = `# ${match.vendor}\n\n`;
       text += `**Category:** ${match.category}\n`;
       text += `**Tier:** ${match.tier}\n`;
+      text += `**Stability:** ${stability}\n`;
       text += `**Description:** ${match.description}\n`;
       text += `**Pricing Page:** ${match.url}\n`;
       text += `**Verified:** ${match.verifiedDate}\n`;

--- a/src/types.ts
+++ b/src/types.ts
@@ -16,10 +16,13 @@ export interface Offer {
   expires_date?: string;
 }
 
+export type StabilityClass = "stable" | "watch" | "volatile" | "improving";
+
 export interface EnrichedOffer extends Offer {
   recent_change: string | null;
   expires_soon: string | null;
   risk_level: "stable" | "caution" | "risky" | null;
+  stability: StabilityClass;
   days_since_verified: number;
 }
 

--- a/test/stability.test.ts
+++ b/test/stability.test.ts
@@ -1,0 +1,173 @@
+import { describe, it } from "node:test";
+import assert from "node:assert";
+
+describe("classifyStability", () => {
+  it("returns stable for vendor with no changes", async () => {
+    const { classifyStability } = await import("../dist/data.js");
+    assert.strictEqual(classifyStability([]), "stable");
+  });
+
+  it("returns volatile for vendor with free_tier_removed", async () => {
+    const { classifyStability } = await import("../dist/data.js");
+    const changes = [{
+      vendor: "TestVendor",
+      change_type: "free_tier_removed",
+      date: "2026-01-15",
+      summary: "Free tier removed",
+      previous_state: "Free plan available",
+      current_state: "No free plan",
+      impact: "high",
+      source_url: "https://example.com",
+      category: "Databases",
+      alternatives: [],
+    }];
+    assert.strictEqual(classifyStability(changes), "volatile");
+  });
+
+  it("returns volatile for vendor with multiple negative changes", async () => {
+    const { classifyStability } = await import("../dist/data.js");
+    const changes = [
+      {
+        vendor: "TestVendor",
+        change_type: "limits_reduced",
+        date: "2026-01-15",
+        summary: "Limits reduced",
+        previous_state: "100GB",
+        current_state: "10GB",
+        impact: "medium",
+        source_url: "https://example.com",
+        category: "Storage",
+        alternatives: [],
+      },
+      {
+        vendor: "TestVendor",
+        change_type: "restriction",
+        date: "2026-02-15",
+        summary: "New restriction added",
+        previous_state: "No restrictions",
+        current_state: "Requires credit card",
+        impact: "low",
+        source_url: "https://example.com",
+        category: "Storage",
+        alternatives: [],
+      },
+    ];
+    assert.strictEqual(classifyStability(changes), "volatile");
+  });
+
+  it("returns watch for vendor with one negative change", async () => {
+    const { classifyStability } = await import("../dist/data.js");
+    const changes = [{
+      vendor: "TestVendor",
+      change_type: "limits_reduced",
+      date: "2026-01-15",
+      summary: "Storage limits reduced",
+      previous_state: "100GB",
+      current_state: "50GB",
+      impact: "medium",
+      source_url: "https://example.com",
+      category: "Storage",
+      alternatives: [],
+    }];
+    assert.strictEqual(classifyStability(changes), "watch");
+  });
+
+  it("returns improving for vendor with only positive changes", async () => {
+    const { classifyStability } = await import("../dist/data.js");
+    const changes = [
+      {
+        vendor: "TestVendor",
+        change_type: "limits_increased",
+        date: "2026-01-15",
+        summary: "Limits increased",
+        previous_state: "10GB",
+        current_state: "50GB",
+        impact: "medium",
+        source_url: "https://example.com",
+        category: "Storage",
+        alternatives: [],
+      },
+      {
+        vendor: "TestVendor",
+        change_type: "new_free_tier",
+        date: "2026-02-15",
+        summary: "New free tier added",
+        previous_state: "No free tier",
+        current_state: "Free tier available",
+        impact: "high",
+        source_url: "https://example.com",
+        category: "Storage",
+        alternatives: [],
+      },
+    ];
+    assert.strictEqual(classifyStability(changes), "improving");
+  });
+
+  it("returns stable for vendor with only neutral changes", async () => {
+    const { classifyStability } = await import("../dist/data.js");
+    const changes = [{
+      vendor: "TestVendor",
+      change_type: "pricing_model_change",
+      date: "2026-01-15",
+      summary: "Pricing model restructured",
+      previous_state: "Old model",
+      current_state: "New model",
+      impact: "low",
+      source_url: "https://example.com",
+      category: "CI/CD",
+      alternatives: [],
+    }];
+    assert.strictEqual(classifyStability(changes), "stable");
+  });
+});
+
+describe("getStabilityMap", () => {
+  it("returns a Map with stability classes for vendors with changes", async () => {
+    const { getStabilityMap } = await import("../dist/data.js");
+    const map = getStabilityMap();
+    assert.ok(map instanceof Map, "Should return a Map");
+    assert.ok(map.size > 0, "Should have entries for vendors with changes");
+
+    for (const [vendor, stability] of map) {
+      assert.ok(typeof vendor === "string", "Keys should be strings");
+      assert.ok(
+        ["stable", "watch", "volatile", "improving"].includes(stability),
+        `Stability should be valid class, got: ${stability} for ${vendor}`
+      );
+    }
+  });
+});
+
+describe("enrichOffers includes stability", () => {
+  it("adds stability field to enriched offers", async () => {
+    const { searchOffers, enrichOffers } = await import("../dist/data.js");
+    const results = searchOffers("database");
+    assert.ok(results.length > 0);
+
+    const enriched = enrichOffers(results.slice(0, 5));
+    for (const offer of enriched) {
+      assert.ok("stability" in offer, "Should have stability field");
+      assert.ok(
+        ["stable", "watch", "volatile", "improving"].includes(offer.stability),
+        `stability should be valid, got: ${offer.stability}`
+      );
+    }
+  });
+});
+
+describe("searchOffers stability filter", () => {
+  it("filters results by stability class", async () => {
+    const { searchOffers, enrichOffers, getStabilityMap } = await import("../dist/data.js");
+
+    // Get results filtered to stable only
+    const stableResults = searchOffers(undefined, undefined, undefined, undefined, "stable");
+    assert.ok(stableResults.length > 0, "Should find stable vendors");
+
+    // Verify all returned results are actually stable
+    const stabilityMap = getStabilityMap();
+    for (const offer of stableResults) {
+      const stability = stabilityMap.get(offer.vendor.toLowerCase()) ?? "stable";
+      assert.strictEqual(stability, "stable", `${offer.vendor} should be stable`);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `stability` field (`stable`/`watch`/`volatile`/`improving`) to all enriched vendor data, derived automatically from deal_changes.json change types
- New `stability` filter on `search_deals` tool and `/api/offers` REST endpoint
- `compare_vendors` includes stability comparison for both single and two-vendor modes
- MCP vendor resource (`agentdeals://vendor/{slug}`) shows stability indicator
- `classifyStability()` and `getStabilityMap()` utility functions exported from data.ts
- 9 new tests (388 total passing)

## Classification Logic

- **stable**: No negative changes in history (default for vendors not in deal_changes.json)
- **watch**: One negative change (limits_reduced, restriction, pricing_restructured, product_deprecated)
- **volatile**: Free tier removed, OSS killed, product deprecated, or 2+ negative changes
- **improving**: Only positive changes (limits_increased, new_free_tier, startup_program_expanded, pricing_postponed)

## Test plan

- [x] 6 unit tests for classifyStability covering all classification paths
- [x] 1 test for getStabilityMap with real data
- [x] 1 test for enrichOffers stability field
- [x] 1 test for searchOffers stability filter
- [x] All 388 tests passing (379 existing + 9 new)
- [x] E2E: MCP initialize → search_deals with stability filter works

Refs #572