### PR TITLE
Update stale counts in tool descriptions and metadata

### DIFF
--- a/src/guides.ts
+++ b/src/guides.ts
@@ -85,7 +85,7 @@ const GUIDE_ENTRIES: Array<{ slug: string; title: string; description: string }>
   { slug: "testing-free-tier-comparison-2026", title: "Testing Free Tier Comparison 2026", description: "15+ testing tools — browser tests, parallel runs, visual regression, load testing" },
   { slug: "api-development-free-tier-comparison-2026", title: "API Development Free Tier Comparison 2026", description: "12+ API tools — Postman vs Bruno vs Hoppscotch vs Insomnia, collaboration limits" },
   { slug: "security-free-tier-comparison-2026", title: "Security Free Tier Comparison 2026", description: "20+ security tools — SAST, SCA, DAST, secrets, container/IaC, SSL/TLS, zero trust" },
-  { slug: "state-of-free-tiers-2026", title: "State of Free Tiers 2026", description: "Data-driven analysis of 1,559 offers across 54 categories — the free tier squeeze, bright spots, cost traps" },
+  { slug: "state-of-free-tiers-2026", title: "State of Free Tiers 2026", description: "Data-driven analysis of 1,600+ offers across 67 categories — the free tier squeeze, bright spots, cost traps" },
   { slug: "tenor-alternatives", title: "Tenor API Shutdown Migration Guide", description: "Google Tenor API shuts down June 2026 — GIF API alternatives (Klipy, Giphy, Imgur), migration code examples, and platform impact" },
   { slug: "firebase-studio-shutdown", title: "Firebase Studio Shutdown Guide", description: "Firebase Studio shuts down June 2026 — free cloud IDE alternatives with compute, storage, and collaboration limits compared" },
 ];

--- a/src/serve.ts
+++ b/src/serve.ts
@@ -564,7 +564,7 @@ ${offersHtml}
     </div>
   </div>
 
-  ${buildMcpCta("Browse this category from your AI coding assistant. Search 1,500+ deals, compare free tiers, and track pricing changes — directly in your editor.")}
+  ${buildMcpCta("Browse this category from your AI coding assistant. Search 1,600+ deals, compare free tiers, and track pricing changes — directly in your editor.")}
   <footer>AgentDeals &mdash; open source, built for agents | <a href="/privacy">Privacy</a></footer>
 </div>
 <script>${mcpCtaScript()}</script>
@@ -859,7 +859,7 @@ ${tableRows}
     ${otherBestOf}
   </div>
 
-  ${buildMcpCta("Get personalized recommendations from your AI. Search 1,500+ deals, compare free tiers, and track pricing changes — directly in your editor.")}
+  ${buildMcpCta("Get personalized recommendations from your AI. Search 1,600+ deals, compare free tiers, and track pricing changes — directly in your editor.")}
   <footer>AgentDeals &mdash; open source, built for agents | <a href="/privacy">Privacy</a></footer>
 </div>
 <script>${mcpCtaScript()}</script>
@@ -1271,7 +1271,7 @@ ${globalNavCss()}
     </div>
   </div>
 ${relatedHtml}
-  ${buildMcpCta("Compare any two vendors from your AI coding assistant. Search 1,500+ deals, compare free tiers, and track pricing changes — directly in your editor.")}
+  ${buildMcpCta("Compare any two vendors from your AI coding assistant. Search 1,600+ deals, compare free tiers, and track pricing changes — directly in your editor.")}
   <footer>AgentDeals &mdash; open source, built for agents | <a href="/privacy">Privacy</a></footer>
 </div>
 <script>${mcpCtaScript()}</script>
@@ -1938,7 +1938,7 @@ ${comparisonsHtml}
     <code>${escHtmlServer(mcpSnippet)}</code>
   </div>
 ${faqHtml}
-  ${buildMcpCta("Want to compare this vendor in your AI? Search 1,500+ deals, compare free tiers, and track pricing changes — directly in your editor.")}
+  ${buildMcpCta("Want to compare this vendor in your AI? Search 1,600+ deals, compare free tiers, and track pricing changes — directly in your editor.")}
   <footer>AgentDeals &mdash; open source, built for agents | <a href="/privacy">Privacy</a></footer>
 </div>
 <script>${mcpCtaScript()}</script>
@@ -2247,7 +2247,7 @@ ${allAltsHtml}
     ${trendsHtml}
   </div>
 ${altFaqHtml}
-  ${buildMcpCta("Find alternatives from your AI coding assistant. Search 1,500+ deals, compare free tiers, and track pricing changes — directly in your editor.")}
+  ${buildMcpCta("Find alternatives from your AI coding assistant. Search 1,600+ deals, compare free tiers, and track pricing changes — directly in your editor.")}
   <footer>AgentDeals &mdash; open source, built for agents | <a href="/privacy">Privacy</a></footer>
 </div>
 <script>${mcpCtaScript()}</script>
@@ -13108,7 +13108,7 @@ ${mcpCtaCss()}
 
   ${buildMoreAlternativesGuides(slug)}
 
-  ${buildMcpCta("Compare Supabase, Firebase, and 1,500+ other developer tools from your AI assistant. Get free tier data, pricing alerts, and stack recommendations — directly in your editor.")}
+  ${buildMcpCta("Compare Supabase, Firebase, and 1,600+ other developer tools from your AI assistant. Get free tier data, pricing alerts, and stack recommendations — directly in your editor.")}
   <footer>AgentDeals &mdash; open source, built for agents | <a href="/privacy">Privacy</a></footer>
 </div>
 <script>${mcpCtaScript()}</script>
@@ -13436,7 +13436,7 @@ ${mcpCtaCss()}
 
   ${buildMoreAlternativesGuides(slug)}
 
-  ${buildMcpCta("Compare Vercel, Netlify, and 1,500+ other developer tools from your AI assistant. Get free tier data, pricing alerts, and stack recommendations — directly in your editor.")}
+  ${buildMcpCta("Compare Vercel, Netlify, and 1,600+ other developer tools from your AI assistant. Get free tier data, pricing alerts, and stack recommendations — directly in your editor.")}
   <footer>AgentDeals &mdash; open source, built for agents | <a href="/privacy">Privacy</a></footer>
 </div>
 <script>${mcpCtaScript()}</script>
@@ -13764,7 +13764,7 @@ ${mcpCtaCss()}
 
   ${buildMoreAlternativesGuides(slug)}
 
-  ${buildMcpCta("Compare Neon, Supabase, and 1,500+ other developer tools from your AI assistant. Get free tier data, pricing alerts, and stack recommendations — directly in your editor.")}
+  ${buildMcpCta("Compare Neon, Supabase, and 1,600+ other developer tools from your AI assistant. Get free tier data, pricing alerts, and stack recommendations — directly in your editor.")}
   <footer>AgentDeals &mdash; open source, built for agents | <a href="/privacy">Privacy</a></footer>
 </div>
 <script>${mcpCtaScript()}</script>
@@ -13776,7 +13776,7 @@ ${mcpCtaCss()}
 
 function buildRailwayVsRenderPage(): string {
   const title = "Railway vs Render — Free Tier Comparison (2026)";
-  const metaDesc = "Compare Railway and Render free tiers side-by-side. RAM, CPU, databases, Redis, sleep behavior, bandwidth, custom domains — verified data from 1,500+ developer tools. Usage-based flexibility vs predictable billing.";
+  const metaDesc = "Compare Railway and Render free tiers side-by-side. RAM, CPU, databases, Redis, sleep behavior, bandwidth, custom domains — verified data from 1,600+ developer tools. Usage-based flexibility vs predictable billing.";
   const slug = "railway-vs-render";
   const pubDate = "2026-03-26";
 
@@ -14096,7 +14096,7 @@ ${mcpCtaCss()}
 
   ${buildMoreAlternativesGuides(slug)}
 
-  ${buildMcpCta("Compare Railway, Render, and 1,500+ other developer tools from your AI assistant. Get free tier data, pricing alerts, and stack recommendations — directly in your editor.")}
+  ${buildMcpCta("Compare Railway, Render, and 1,600+ other developer tools from your AI assistant. Get free tier data, pricing alerts, and stack recommendations — directly in your editor.")}
   <footer>AgentDeals &mdash; open source, built for agents | <a href="/privacy">Privacy</a></footer>
 </div>
 <script>${mcpCtaScript()}</script>
@@ -14108,7 +14108,7 @@ ${mcpCtaCss()}
 
 function buildDatadogVsNewRelicPage(): string {
   const title = "Datadog vs New Relic — Free Tier Comparison (2026)";
-  const metaDesc = "Compare Datadog and New Relic free tiers side-by-side. Hosts, data ingest, APM, logs, synthetics, retention, alerting — verified data from 1,500+ developer tools. Per-host pricing vs per-GB pricing.";
+  const metaDesc = "Compare Datadog and New Relic free tiers side-by-side. Hosts, data ingest, APM, logs, synthetics, retention, alerting — verified data from 1,600+ developer tools. Per-host pricing vs per-GB pricing.";
   const slug = "datadog-vs-new-relic";
   const pubDate = "2026-03-26";
 
@@ -14423,7 +14423,7 @@ ${mcpCtaCss()}
 
   ${buildMoreAlternativesGuides(slug)}
 
-  ${buildMcpCta("Compare Datadog, New Relic, and 1,500+ other developer tools from your AI assistant. Get free tier data, pricing alerts, and stack recommendations — directly in your editor.")}
+  ${buildMcpCta("Compare Datadog, New Relic, and 1,600+ other developer tools from your AI assistant. Get free tier data, pricing alerts, and stack recommendations — directly in your editor.")}
   <footer>AgentDeals &mdash; open source, built for agents | <a href="/privacy">Privacy</a></footer>
 </div>
 <script>${mcpCtaScript()}</script>
@@ -15579,7 +15579,7 @@ ${mcpCtaCss()}
 
   ${buildMoreAlternativesGuides(slug)}
 
-  ${buildMcpCta("Track free tier risk for 1,500+ developer tools from your AI assistant. Get pricing alerts, risk scores, and migration recommendations — directly in your editor.")}
+  ${buildMcpCta("Track free tier risk for 1,600+ developer tools from your AI assistant. Get pricing alerts, risk scores, and migration recommendations — directly in your editor.")}
   <footer>AgentDeals &mdash; open source, built for agents | <a href="/privacy">Privacy</a></footer>
 </div>
 <script>${mcpCtaScript()}</script>
@@ -15896,7 +15896,7 @@ ${mcpCtaCss()}
     </a>
     <a href="/state-of-free-tiers-2026" class="related-page-link">
       <div class="link-title">State of Free Tiers 2026</div>
-      <div class="link-desc">Comprehensive data-driven report on free tier trends across 1,500+ developer tools</div>
+      <div class="link-desc">Comprehensive data-driven report on free tier trends across 1,600+ developer tools</div>
     </a>
     ${relatedPages.map(p => `<a href="/${p.slug}" class="related-page-link">
       <div class="link-title">${escHtmlServer(p.title.split(" \u2014 ")[0])}</div>
@@ -15906,7 +15906,7 @@ ${mcpCtaCss()}
 
   ${buildMoreAlternativesGuides(slug)}
 
-  ${buildMcpCta("Track vendor stability for 1,500+ developer tools from your AI assistant. Get real-time stability ratings, pricing alerts, and migration recommendations — directly in your editor.")}
+  ${buildMcpCta("Track vendor stability for 1,600+ developer tools from your AI assistant. Get real-time stability ratings, pricing alerts, and migration recommendations — directly in your editor.")}
   <footer>AgentDeals &mdash; open source, built for agents | <a href="/privacy">Privacy</a></footer>
 </div>
 <script>${mcpCtaScript()}</script>
@@ -18038,7 +18038,7 @@ ${mcpCtaCss()}
     ${relatedPages.map(p => `<a href="/${p.slug}" class="related-page-link"><div class="link-title">${escHtmlServer(p.title.split(" — ")[0])}</div><div class="link-desc">${escHtmlServer(p.hubDesc)}</div></a>`).join("\n    ")}
   </div>
 
-  ${buildMcpCta("Track free tier changes across 1,500+ developer tools from your AI assistant. Get pricing alerts, change history, and migration recommendations — directly in your editor.")}
+  ${buildMcpCta("Track free tier changes across 1,600+ developer tools from your AI assistant. Get pricing alerts, change history, and migration recommendations — directly in your editor.")}
   <footer>AgentDeals &mdash; open source, built for agents | <a href="/privacy">Privacy</a></footer>
 </div>
 <script>${mcpCtaScript()}</script>
@@ -29278,7 +29278,7 @@ function buildSetupPage(): string {
   };
 
   const toolExamples: { tool: string; question: string; desc: string }[] = [
-    { tool: "search_deals", question: "Find free database hosting", desc: "Search 1,500+ deals by category, pricing, or keyword" },
+    { tool: "search_deals", question: "Find free database hosting", desc: "Search 1,600+ deals by category, pricing, or keyword" },
     { tool: "compare_vendors", question: "Compare Supabase vs Neon", desc: "Side-by-side comparison of free tiers, risk levels, and limits" },
     { tool: "track_changes", question: "What pricing changes happened this month?", desc: "Track free tier removals, limit changes, and new deals" },
     { tool: "plan_stack", question: "Estimate costs for a SaaS backend", desc: "Stack recommendations, cost estimates, and infrastructure audits" },

--- a/src/server-remote.ts
+++ b/src/server-remote.ts
@@ -57,7 +57,7 @@ export function createServer(): McpServer {
   const server = new McpServer({
     name: "agentdeals",
     version: "0.1.0",
-    description: "Find free tiers, startup credits, and discounts for developer tools — databases, cloud hosting, CI/CD, monitoring, APIs, and more. 1,500+ verified offers across 54 categories with pricing change tracking.",
+    description: "Find free tiers, startup credits, and discounts for developer tools — databases, cloud hosting, CI/CD, monitoring, APIs, and more. 1,600+ verified offers across 67 categories with pricing change tracking.",
   });
 
   // --- Tool 1: search_deals ---
@@ -66,7 +66,7 @@ export function createServer(): McpServer {
     "search_deals",
     {
       description:
-        "Find free tiers, credits, and discounts for 1,500+ developer tools. Search by keyword, browse categories, or get full vendor details with alternatives. Covers AWS, Vercel, Supabase, Cloudflare, and more. Call this tool when a user asks: 'Does Supabase have a free tier?', 'What's cheaper than Vercel?', 'Find me a free database'.",
+        "Find free tiers, credits, and discounts for 1,600+ developer tools. Search by keyword, browse categories, or get full vendor details with alternatives. Covers AWS, Vercel, Supabase, Cloudflare, and more. Call this tool when a user asks: 'Does Supabase have a free tier?', 'What's cheaper than Vercel?', 'Find me a free database'.",
       annotations: {
         readOnlyHint: true,
         destructiveHint: false,

--- a/src/server.ts
+++ b/src/server.ts
@@ -19,7 +19,7 @@ export function createServer(getSessionId?: () => string | undefined): McpServer
   const server = new McpServer({
     name: "agentdeals",
     version: "0.1.0",
-    description: "AgentDeals helps developers find free tiers, startup credits, and deals on developer infrastructure. Use these tools when a user is evaluating cloud providers, databases, hosting, CI/CD, monitoring, auth, AI services, or any developer service — especially when cost matters. 1,500+ verified offers across 54 categories with pricing change tracking.",
+    description: "AgentDeals helps developers find free tiers, startup credits, and deals on developer infrastructure. Use these tools when a user is evaluating cloud providers, databases, hosting, CI/CD, monitoring, auth, AI services, or any developer service — especially when cost matters. 1,600+ verified offers across 67 categories with pricing change tracking.",
   });
 
   // --- Tool 1: search_deals ---
@@ -863,7 +863,7 @@ export function getServerCard(baseUrl: string) {
       title: "AgentDeals",
       version: "0.2.0",
     },
-    description: "Search and compare free tiers, startup credits, and pricing changes across 1,500+ developer tools. 4 intent-based MCP tools for infrastructure decisions, cost estimation, and vendor comparison.",
+    description: "Search and compare free tiers, startup credits, and pricing changes across 1,600+ developer tools. 4 intent-based MCP tools for infrastructure decisions, cost estimation, and vendor comparison.",
     iconUrl: `${baseUrl}/og-image.png`,
     documentationUrl: `${baseUrl}/setup`,
     transport: {


### PR DESCRIPTION
## Summary

- Updated all instances of "1,500+" to "1,600+" across server.ts, server-remote.ts, serve.ts, and guides.ts
- Updated all instances of "54 categories" to "67 categories" 
- Left non-offer-count "1,500+" references intact (Lucide icon counts, pricing data)

Uses rounded "1,600+" for longevity. Actual count is 1,641 offers across 67 categories.

394 tests passing.

Refs #595