### PR TITLE
Add /free-fastapi-stack — FastAPI/Python framework stack guide

### DIFF
--- a/src/guides.ts
+++ b/src/guides.ts
@@ -58,6 +58,7 @@ const GUIDE_ENTRIES: Array<{ slug: string; title: string; description: string }>
   { slug: "free-frontend-stack", title: "Free Frontend Stack", description: "Free frontend/Jamstack development stack — hosting, CMS, auth, analytics, 10 categories" },
   { slug: "free-nextjs-stack", title: "Free Next.js Stack", description: "Free Next.js full-stack infrastructure — hosting, database, auth, storage, email, monitoring, 10 layers" },
   { slug: "free-django-stack", title: "Free Django Stack", description: "Free Django/Python full-stack infrastructure — WSGI hosting, Postgres, Redis, Celery, auth, storage, 10 layers" },
+  { slug: "free-fastapi-stack", title: "Free FastAPI Stack", description: "Free FastAPI/Python full-stack infrastructure — ASGI hosting, async Postgres, Redis, auth, storage, 10 layers" },
   { slug: "q2-pricing-preview-2026", title: "Q2 2026 Pricing Preview", description: "Forward-looking Q2 pricing preview — upcoming changes, expirations, market trends" },
   { slug: "google-developer-program-2026", title: "Google Developer Program Premium 2026", description: "Google Developer Program Premium analysis — price comparison, migration guide, alternatives" },
   { slug: "supabase-vs-firebase", title: "Supabase vs Firebase", description: "Free tier comparison — storage, compute, auth, pricing at scale, decision guide" },

--- a/src/serve.ts
+++ b/src/serve.ts
@@ -3889,6 +3889,15 @@ const ALTERNATIVES_PAGES: AlternativesPageConfig[] = [
     hubDesc: "Complete free Django/Python infrastructure — 10 layers with recommended picks, growth cost analysis, and stability ratings",
   },
   {
+    slug: "free-fastapi-stack",
+    title: "The Complete Free FastAPI/Python Stack for 2026 — $0/Month Full-Stack Infrastructure",
+    metaDesc: "Build a complete FastAPI app on free tiers. 10 infrastructure layers — ASGI hosting, async Postgres, Redis, auth, storage, email, monitoring, CI/CD, background tasks, and API docs. Exact limits, growth costs. Updated April 2026.",
+    contextHtml: "",
+    tag: "fastapi-stack-guide",
+    primaryVendor: "Railway",
+    hubDesc: "Complete free FastAPI/Python infrastructure — 10 layers with recommended picks, growth cost analysis, and stability ratings",
+  },
+  {
     slug: "q2-pricing-preview-2026",
     title: "Q2 2026 Developer Pricing Preview — What's Changing April–June",
     metaDesc: "Upcoming developer tool pricing changes for Q2 2026. Hetzner +30-50%, Google Tenor shutdown, GitHub Actions runner fees, odrive removal, and more. Timeline, impact analysis, and alternatives.",
@@ -12471,6 +12480,482 @@ GitHub → GitHub Actions (CI: pytest + ruff) → Railway (CD: auto-deploy)</div
   ${buildMoreAlternativesGuides(slug)}
 
   ${buildMcpCta("Get personalized Django stack recommendations from your AI assistant. Compare free tiers, check limits, and plan your infrastructure — directly in your editor.")}
+  <footer>AgentDeals &mdash; open source, built for agents | <a href="/privacy">Privacy</a></footer>
+</div>
+<script>${mcpCtaScript()}</script>
+</body>
+</html>`;
+}
+
+// --- Free FastAPI/Python Stack Guide ---
+
+function buildFreeFastapiStackPage(): string {
+  const title = "The Complete Free FastAPI/Python Stack for 2026 — $0/Month Full-Stack Infrastructure";
+  const metaDesc = "Build a complete FastAPI app on free tiers. 10 infrastructure layers — ASGI hosting, async Postgres, Redis, auth, storage, email, monitoring, CI/CD, background tasks, and API docs. Exact limits, growth costs. Updated April 2026.";
+  const slug = "free-fastapi-stack";
+
+  const riskColors: Record<string, string> = { stable: "#3fb950", caution: "#d29922", risky: "#f85149" };
+
+  const stackCategories = [
+    {
+      name: "Hosting & Deployment",
+      icon: "🚀",
+      recommended: { vendor: "Railway", why: "The best free FastAPI hosting in 2026. $5/month free credit covers a FastAPI app with uvicorn ASGI server, auto-deploy from GitHub, and managed add-ons. Nixpacks auto-detects Python projects — just add a Procfile with `web: uvicorn main:app --host 0.0.0.0 --port $PORT`. No sleep timer — your API stays warm for consistent response times." },
+      alternatives: ["Render", "Fly.io", "Koyeb"],
+      outgrow: "When you exceed the $5/month free credit (usually 1-2 services). Render's free tier spins down after 15 minutes of inactivity — cold starts of 30-60 seconds kill API latency. Fly.io gives 3 shared-CPU VMs free with 256 MB RAM, good for lightweight APIs. Koyeb offers 1 nano service free with global edge deployment.",
+      whyNot: "Why not Vercel: Vercel supports FastAPI via serverless functions (Mangum adapter), but loses WebSocket support, background tasks, and startup events — core FastAPI features. Why not Deta Space: Deta shut down Space in 2024. Many FastAPI tutorials still reference it — those guides are outdated.",
+      relatedPage: "/hosting-free-tier-comparison-2026",
+    },
+    {
+      name: "Database",
+      icon: "🗄️",
+      recommended: { vendor: "Neon", why: "Serverless Postgres with native async support. Free tier: 0.5 GiB storage, 190+ compute hours/month, scales to zero. Use with asyncpg for async queries or SQLAlchemy 2.0's async engine. Neon's connection pooler handles FastAPI's concurrent async connections efficiently. Branching lets you test schema changes safely." },
+      alternatives: ["Supabase", "CockroachDB"],
+      outgrow: "When you exceed 0.5 GiB storage. Supabase offers 500 MB Postgres with built-in auth and realtime subscriptions, but pauses after 7 days inactive. CockroachDB's free tier gives 10 GiB storage with distributed Postgres-compatible SQL — good for multi-region APIs.",
+      whyNot: "Why not MongoDB Atlas: FastAPI works with MongoDB (via Motor or Beanie ODM), but most FastAPI tutorials and the ecosystem assume relational data with Pydantic models mapping to SQL tables. Postgres + SQLAlchemy is the mainstream path. Why not SQLite: Most free hosting uses ephemeral filesystems — your database would be wiped on every deploy.",
+      relatedPage: "/database-free-tier-comparison-2026",
+    },
+    {
+      name: "Cache & Redis",
+      icon: "⚡",
+      recommended: { vendor: "Upstash", why: "Serverless Redis with async support. Free tier: 10,000 commands/day, 256 MB storage. FastAPI's async architecture pairs perfectly with Upstash's REST API or the async redis-py client. Use for response caching (fastapi-cache2), rate limiting (slowapi), and session storage. Pay-per-request pricing means you only pay beyond free limits." },
+      alternatives: ["Redis Cloud"],
+      outgrow: "When you exceed 10,000 commands/day. Redis Cloud offers 30 MB free with unlimited commands — better for high-throughput caching. For simple caching without Redis, fastapi-cache2 supports in-memory backends, but these don't persist across deploys.",
+      whyNot: null,
+      relatedPage: null,
+    },
+    {
+      name: "Authentication",
+      icon: "🔐",
+      recommended: { vendor: "Auth0", why: "25,000 MAU free — the most generous managed auth tier. FastAPI has no built-in auth (unlike Django), so you need an external provider or roll your own. Auth0's Python SDK + FastAPI dependency injection pattern works cleanly: create a dependency that validates JWTs, inject it into protected routes. Social login, MFA, and RBAC included on free tier." },
+      alternatives: ["Clerk", "Supabase"],
+      outgrow: "When you exceed 25,000 MAU or need advanced enterprise features. Clerk offers 10,000 MAU free with pre-built UI components (less useful for API-only FastAPI). Supabase Auth gives 50,000 MAU free if you're already using Supabase for your database. For API-only services, rolling your own with python-jose + passlib + OAuth2PasswordBearer is viable but more work.",
+      whyNot: "Why not rolling your own from scratch: FastAPI's security utilities (OAuth2PasswordBearer, HTTPBearer) make it tempting, but you'll end up reimplementing password reset flows, email verification, rate limiting, and session management. Auth0 handles all of this on free tier. Only roll your own for simple API-key auth or internal services.",
+      relatedPage: "/auth-comparison-2026",
+    },
+    {
+      name: "Object Storage",
+      icon: "📦",
+      recommended: { vendor: "Cloudflare R2", why: "Zero egress fees — the standout differentiator. 10 GB storage, 1 million Class A operations, 10 million Class B operations per month. S3-compatible API means boto3 and aioboto3 work directly. FastAPI's UploadFile with async streaming to R2 handles file uploads efficiently without buffering entire files in memory." },
+      alternatives: ["Backblaze B2", "Supabase"],
+      outgrow: "When you exceed 10 GB storage. At scale, R2 saves dramatically vs S3: 1 TB stored + 10 TB egress costs ~$15/month on R2 vs ~$925/month on S3. Backblaze B2 offers 10 GB free with free egress via Cloudflare CDN. Supabase Storage gives 1 GB free with image transformations.",
+      whyNot: "Why not AWS S3: The 5 GB free tier expires after 12 months, then egress costs $0.09/GB. API services returning pre-signed URLs for large files can rack up egress costs quickly — R2 charges $0.",
+      relatedPage: "/storage-comparison-2026",
+    },
+    {
+      name: "Email & Transactional",
+      icon: "✉️",
+      recommended: { vendor: "Resend", why: "Modern developer-first email API. 3,000 emails/month, 100/day on free tier. Clean REST API — call directly with httpx (FastAPI's recommended HTTP client) or the official Python SDK. No framework-specific adapter needed unlike Django. Domain verification, webhook delivery tracking, and React Email templates if you have a frontend." },
+      alternatives: ["Resend", "Brevo"],
+      outgrow: "When you exceed 3,000 emails/month or 100/day. Brevo gives 300 emails/day (9,000/month) with marketing automation. Amazon SES offers 62,000 emails/month free from EC2 at $0.10/1K after — cheapest at scale for high-volume transactional email.",
+      whyNot: "Why not SendGrid: Free tier removed May 2025. Many Python API tutorials still reference SendGrid — those guides are outdated.",
+      relatedPage: "/email-comparison-2026",
+    },
+    {
+      name: "Monitoring & Error Tracking",
+      icon: "🐛",
+      recommended: { vendor: "Sentry", why: "Developer tier: 5,000 errors/month, 10,000 performance transactions, 50 session replays, 1 GB attachments. Official FastAPI integration via sentry-sdk — auto-instruments ASGI middleware, captures unhandled exceptions with full request context (path, query params, headers). Starlette transaction naming gives clean performance traces per endpoint." },
+      alternatives: ["BetterStack", "Grafana Cloud"],
+      outgrow: "When you exceed 5,000 errors/month or need more than 1 team member. BetterStack combines uptime monitoring (10 monitors) with incident management — useful for API health checks. Grafana Cloud offers 10,000 series metrics + 50 GB logs + 50 GB traces — great for full observability beyond error tracking.",
+      whyNot: "Why not Datadog: Free tier has only 1-day metric retention — practically unusable for debugging. Per-host pricing ($15/host/month) gets expensive fast for containerized FastAPI deployments.",
+      relatedPage: "/monitoring-comparison-2026",
+    },
+    {
+      name: "CI/CD",
+      icon: "⚙️",
+      recommended: { vendor: "GitHub Actions", why: "2,000 minutes/month on free tier for public repos (unlimited) and private repos. FastAPI testing integrates naturally — run pytest with httpx.AsyncClient for async endpoint tests. Matrix testing across Python 3.10-3.13 catches compatibility issues. Caching pip dependencies + virtual envs cuts CI time by 50-70%." },
+      alternatives: ["Render"],
+      outgrow: "When you exceed 2,000 minutes/month on private repos. Railway and Render auto-deploy from git with zero CI config — combine with GitHub Actions for tests only.",
+      whyNot: null,
+      relatedPage: "/cicd-free-tier-comparison-2026",
+    },
+    {
+      name: "Background Tasks",
+      icon: "⏱️",
+      recommended: { vendor: "Upstash", why: "FastAPI offers three tiers of background task support. (1) Built-in BackgroundTasks: free, zero dependencies, runs in the same process — perfect for fire-and-forget tasks like sending emails or logging. (2) ARQ + Upstash Redis: async-native task queue built for asyncio — natural fit for FastAPI's async architecture. (3) Celery + Upstash Redis: battle-tested but synchronous — use when you need periodic tasks (Celery Beat) or complex task chains. Upstash's 10,000 commands/day covers moderate task queue usage for both ARQ and Celery." },
+      alternatives: ["Redis Cloud"],
+      outgrow: "When you exceed 10,000 Redis commands/day or need more than a single worker process. Redis Cloud's 30 MB free with unlimited commands is better for high-throughput task queues. For simple use cases, FastAPI's built-in BackgroundTasks requires no external service at all.",
+      whyNot: "Why not Celery as default: Celery is synchronous — it doesn't leverage FastAPI's async runtime. ARQ is async-native and lighter weight. Use Celery only when you need its advanced features (Beat scheduling, canvas chains, result backends). Why not Dramatiq: Similar to Celery but less ecosystem support and fewer production deployments.",
+      relatedPage: null,
+    },
+    {
+      name: "API Documentation",
+      icon: "📖",
+      recommended: { vendor: "FastAPI Built-in", why: "FastAPI's killer feature — automatic OpenAPI (Swagger UI + ReDoc) documentation generated from your type hints and Pydantic models. Zero config, zero cost, always in sync with your code. Access at /docs (Swagger UI) and /redoc (ReDoc). Add response_model, description, tags, and examples to your route decorators for rich, interactive docs that clients can test directly." },
+      alternatives: [],
+      outgrow: "You won't outgrow FastAPI's built-in docs — they scale with your API. For API gateway features (rate limiting, API keys, analytics), Zuplo offers a free tier with 500K requests/month and auto-generated developer portals from your OpenAPI spec.",
+      whyNot: null,
+      relatedPage: null,
+    },
+  ];
+
+  const resolveVendor = (vendorName: string) => {
+    if (vendorName === "FastAPI Built-in") return null;
+    if (vendorName === "Upstash") {
+      const offer = offers.find(o => o.vendor === "Upstash");
+      if (!offer) return null;
+      return enrichOffers([offer])[0];
+    }
+    const offer = offers.find(o => o.vendor === vendorName);
+    if (!offer) return null;
+    return enrichOffers([offer])[0];
+  };
+
+  const stackVendors = stackCategories.flatMap(c => {
+    const v = c.recommended.vendor;
+    return v === "FastAPI Built-in" ? [...c.alternatives] : [v, ...c.alternatives];
+  });
+  const stackChanges = dealChanges.filter(c => stackVendors.some(v => c.vendor.includes(v)));
+
+  const jsonLd = {
+    "@context": "https://schema.org",
+    "@type": "Article",
+    headline: title,
+    description: metaDesc,
+    url: `${BASE_URL}/${slug}`,
+    datePublished: "2026-04-04",
+    dateModified: new Date().toISOString().slice(0, 10),
+    author: { "@type": "Organization", name: "AgentDeals", url: BASE_URL },
+  };
+
+  const faqJsonLd = {
+    "@context": "https://schema.org",
+    "@type": "FAQPage",
+    mainEntity: [
+      {
+        "@type": "Question",
+        name: "Can I host FastAPI for free in 2026?",
+        acceptedAnswer: { "@type": "Answer", text: "Yes. Railway offers a $5/month free credit that covers a small FastAPI app with uvicorn, auto-deploy from GitHub, and no sleep timer. Render has a free tier but spins down after 15 minutes of inactivity (30-60 second cold starts). Fly.io gives 3 shared-CPU VMs free with 256 MB RAM. Koyeb offers 1 nano service free with edge deployment. Avoid Vercel for FastAPI — it requires a serverless adapter and loses WebSocket/background task support." },
+      },
+      {
+        "@type": "Question",
+        name: "What database should I use with FastAPI?",
+        acceptedAnswer: { "@type": "Answer", text: "Neon (serverless Postgres) — 0.5 GiB storage, 190+ compute hours/month, scales to zero. Use with SQLAlchemy 2.0 async engine + asyncpg for async queries, or Tortoise ORM for an async-native alternative. FastAPI has no built-in ORM, so you choose your own — SQLAlchemy is the most popular choice. Supabase (500 MB) is an alternative with built-in auth and realtime." },
+      },
+      {
+        "@type": "Question",
+        name: "Does Vercel support FastAPI?",
+        acceptedAnswer: { "@type": "Answer", text: "Technically yes, via the Mangum adapter that wraps ASGI apps for AWS Lambda-style serverless functions. But you lose WebSocket support, FastAPI's startup/shutdown lifespan events, background tasks, and long-running connections. For API-only services, this may be acceptable. For anything using FastAPI's async features fully, use Railway, Render, or Fly.io instead." },
+      },
+      {
+        "@type": "Question",
+        name: "FastAPI vs Django for free hosting?",
+        acceptedAnswer: { "@type": "Answer", text: "FastAPI is lighter weight and async-native — ideal for APIs, microservices, and AI/ML serving. Django is batteries-included with built-in ORM, admin, auth, and forms — better for full web applications. Both host free on Railway ($5 credit) or Render. FastAPI needs you to choose every component (ORM, auth, admin) separately. Django includes them. If you're building a REST/GraphQL API or serving ML models, FastAPI. If you're building a web app with admin panel and user accounts, Django." },
+      },
+    ],
+  };
+
+  const categorySections = stackCategories.map(cat => {
+    const rec = resolveVendor(cat.recommended.vendor);
+    const altVendors = cat.alternatives.filter(v => v !== cat.recommended.vendor).map(v => resolveVendor(v)).filter(Boolean) as ReturnType<typeof enrichOffers>;
+
+    const recCard = rec ? `
+      <div class="stack-pick">
+        <div class="pick-header">
+          <span class="pick-badge">Recommended</span>
+          <a href="/vendor/${toSlug(rec.vendor)}" class="pick-name">${escHtmlServer(rec.vendor)}</a>
+          <span class="pick-tier">${escHtmlServer(rec.tier)}</span>
+          ${rec.risk_level ? `<span style="display:inline-block;font-size:.65rem;padding:.1rem .4rem;border-radius:10px;background:${riskColors[rec.risk_level]}22;color:${riskColors[rec.risk_level]};font-weight:600">${rec.risk_level}</span>` : ""}
+        </div>
+        <p class="pick-why">${escHtmlServer(cat.recommended.why)}</p>
+        <p class="pick-limits">${escHtmlServer(rec.description.split(". ").slice(0, 2).join(". "))}</p>
+        <div class="pick-links">
+          <a href="/vendor/${toSlug(rec.vendor)}">Full profile</a>
+          <a href="/alternative-to/${toSlug(rec.vendor)}">Alternatives</a>
+          <a href="${escHtmlServer(rec.url)}" target="_blank" rel="noopener">Pricing &nearr;</a>
+        </div>
+      </div>` : cat.recommended.vendor === "FastAPI Built-in" ? `
+      <div class="stack-pick">
+        <div class="pick-header">
+          <span class="pick-badge">Recommended</span>
+          <span class="pick-name">FastAPI Built-in</span>
+          <span class="pick-tier">Free (included)</span>
+          <span style="display:inline-block;font-size:.65rem;padding:.1rem .4rem;border-radius:10px;background:${riskColors.stable}22;color:${riskColors.stable};font-weight:600">stable</span>
+        </div>
+        <p class="pick-why">${escHtmlServer(cat.recommended.why)}</p>
+        <p class="pick-limits">Automatic Swagger UI + ReDoc from type hints. Zero config, zero cost.</p>
+      </div>` : `
+      <div class="stack-pick">
+        <div class="pick-header">
+          <span class="pick-badge">Recommended</span>
+          <span class="pick-name">${escHtmlServer(cat.recommended.vendor)}</span>
+          <span class="pick-tier">Free tier</span>
+        </div>
+        <p class="pick-why">${escHtmlServer(cat.recommended.why)}</p>
+      </div>`;
+
+    const altCards = altVendors.length > 0 ? `
+      <div class="alt-picks">
+        <p class="alt-label">Also consider:</p>
+        ${altVendors.map(a => `<a href="/vendor/${toSlug(a.vendor)}" class="alt-chip">${escHtmlServer(a.vendor)} <span class="chip-tier">${escHtmlServer(a.tier)}</span></a>`).join(" ")}
+      </div>` : "";
+
+    const whyNotBox = cat.whyNot ? `
+      <div class="whynot-box">
+        <strong>⚠️ ${escHtmlServer(cat.whyNot)}</strong>
+      </div>` : "";
+
+    const relatedLink = cat.relatedPage ? `<a href="${cat.relatedPage}" class="related-link">Full comparison guide &rarr;</a>` : "";
+
+    return `
+    <div class="stack-category" id="${toSlug(cat.name)}">
+      <h2><span class="cat-icon">${cat.icon}</span> ${escHtmlServer(cat.name)}</h2>
+      ${recCard}
+      ${altCards}
+      <div class="outgrow-box">
+        <strong>When you'll outgrow it:</strong> ${escHtmlServer(cat.outgrow)}
+      </div>
+      ${whyNotBox}
+      ${relatedLink}
+    </div>`;
+  }).join("\n");
+
+  const stabilityNotes = stackChanges.length > 0 ? `
+  <h2>Stability Notes</h2>
+  <p style="color:var(--text-muted);margin-bottom:1rem;font-size:.9rem">Recent pricing changes affecting vendors in this stack. Based on our tracking of ${dealChanges.length} deal changes across ${offers.length.toLocaleString()}+ developer tools.</p>
+  <div class="stability-list">
+    ${stackChanges.slice(0, 12).map(c => {
+      const typeColors: Record<string, string> = {
+        free_tier_removed: "#f85149", limits_reduced: "#d29922", pricing_restructured: "#d29922",
+        restriction: "#d29922", limits_increased: "#3fb950", new_free_tier: "#3fb950",
+        pricing_postponed: "#3fb950", startup_program_expanded: "#3fb950", product_deprecated: "#f85149",
+      };
+      const color = typeColors[c.change_type] ?? "#94a3b8";
+      return `<div class="stability-item">
+        <span class="stability-badge" style="background:${color}22;color:${color}">${c.change_type.replace(/_/g, " ")}</span>
+        <strong>${escHtmlServer(c.vendor)}</strong>: ${escHtmlServer(c.summary.length > 140 ? c.summary.substring(0, 137) + "..." : c.summary)}
+      </div>`;
+    }).join("\n    ")}
+  </div>
+  <p style="margin-top:1rem;font-size:.85rem"><a href="/changes">View all ${dealChanges.length} pricing changes &rarr;</a></p>` : "";
+
+  const tableRows = stackCategories.map(cat => {
+    const rec = resolveVendor(cat.recommended.vendor);
+    const vendorName = cat.recommended.vendor;
+    const limits = rec ? rec.description.split(". ")[0].substring(0, 80) : vendorName === "FastAPI Built-in" ? "Unlimited — built into FastAPI" : "—";
+    const riskBadge = rec?.risk_level ? `<span style="color:${riskColors[rec.risk_level]}">${rec.risk_level}</span>` : `<span style="color:${riskColors.stable}">stable</span>`;
+    const vendorLink = rec ? `<a href="/vendor/${toSlug(rec.vendor)}" style="color:var(--text);font-weight:600">${escHtmlServer(vendorName)}</a>` : `<span style="font-weight:600">${escHtmlServer(vendorName)}</span>`;
+    return `      <tr>
+        <td style="font-weight:600">${cat.icon} ${escHtmlServer(cat.name)}</td>
+        <td>${vendorLink}</td>
+        <td style="font-family:var(--mono);font-size:.8rem;color:var(--accent)">${escHtmlServer(limits)}</td>
+        <td>${riskBadge}</td>
+      </tr>`;
+  }).join("\n");
+
+  // Growth cost analysis
+  const growthCosts = [
+    { layer: "Database", vendor: "Neon", freeLimit: "0.5 GiB storage", firstPaid: "Launch $19/mo", gets: "10 GiB storage, 300 compute hours, autoscaling", hitFirst: true },
+    { layer: "Hosting", vendor: "Railway", freeLimit: "$5/mo credit", firstPaid: "Hobby $5/mo", gets: "$5 + usage-based, no sleep, more RAM", hitFirst: true },
+    { layer: "Cache/Redis", vendor: "Upstash", freeLimit: "10K cmds/day", firstPaid: "Pay-as-you-go $0.2/100K", gets: "Unlimited commands, 1 GB storage", hitFirst: false },
+    { layer: "Auth", vendor: "Auth0", freeLimit: "25,000 MAU", firstPaid: "Essential $35/mo", gets: "Custom domains, roles, MFA policies", hitFirst: false },
+    { layer: "Email", vendor: "Resend", freeLimit: "3,000 emails/mo", firstPaid: "Pro $20/mo", gets: "50,000 emails/mo, custom domains, analytics", hitFirst: false },
+    { layer: "Storage", vendor: "Cloudflare R2", freeLimit: "10 GB", firstPaid: "$0.015/GB/mo", gets: "Unlimited storage, still zero egress", hitFirst: false },
+    { layer: "Monitoring", vendor: "Sentry", freeLimit: "5,000 errors/mo", firstPaid: "Team $26/mo", gets: "50,000 errors, unlimited members, integrations", hitFirst: false },
+    { layer: "Background Tasks", vendor: "ARQ + Upstash", freeLimit: "10K cmds/day", firstPaid: "Pay-as-you-go $0.2/100K", gets: "Unlimited task dispatches", hitFirst: false },
+    { layer: "API Docs", vendor: "FastAPI Built-in", freeLimit: "Unlimited", firstPaid: "Free forever", gets: "N/A — scales with your API", hitFirst: false },
+    { layer: "CI/CD", vendor: "GitHub Actions", freeLimit: "2,000 min/mo", firstPaid: "Team $4/user/mo", gets: "3,000 min/mo, required reviewers", hitFirst: false },
+  ];
+
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>${escHtmlServer(title)} — AgentDeals</title>
+<meta name="description" content="${escHtmlServer(metaDesc)}">
+<link rel="canonical" href="${BASE_URL}/${slug}">
+<meta property="og:title" content="${escHtmlServer(title)}">
+<meta property="og:description" content="${escHtmlServer(metaDesc)}">
+<meta property="og:type" content="article">
+<meta property="og:url" content="${BASE_URL}/${slug}">
+${OG_IMAGE_META}${GOOGLE_VERIFICATION_META}<link rel="icon" type="image/png" href="/favicon.png">
+<link rel="alternate" type="application/atom+xml" title="AgentDeals — Pricing Changes" href="/feed.xml">
+<link rel="preconnect" href="https://fonts.googleapis.com"><link rel="preconnect" href="https://fonts.gstatic.com" crossorigin><link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
+<script type="application/ld+json">${JSON.stringify(jsonLd)}</script>
+<script type="application/ld+json">${JSON.stringify(faqJsonLd)}</script>
+<style>
+*{margin:0;padding:0;box-sizing:border-box}
+:root{--bg:#0f172a;--bg-elevated:#1e293b;--bg-card:rgba(255,255,255,0.06);--border:#334155;--border-hover:#3b82f6;--text:#f1f5f9;--text-muted:#94a3b8;--text-dim:#64748b;--accent:#3b82f6;--accent-hover:#60a5fa;--accent-glow:rgba(59,130,246,0.15);--serif:'Inter',-apple-system,sans-serif;--sans:'Inter',-apple-system,sans-serif;--mono:'JetBrains Mono',SFMono-Regular,monospace}
+body{font-family:var(--sans);background:var(--bg);color:var(--text);line-height:1.6}
+a{color:var(--accent);text-decoration:none}a:hover{color:var(--accent-hover);text-decoration:underline}
+.container{max-width:960px;margin:0 auto;padding:0 1.5rem}
+.breadcrumb{padding:1.5rem 0 0;font-size:.8rem;color:var(--text-dim)}
+.breadcrumb a{color:var(--text-muted)}
+h1{font-family:var(--serif);font-size:2.25rem;color:var(--text);margin:1rem 0 .5rem;letter-spacing:-.02em}
+h2{font-family:var(--serif);font-size:1.4rem;color:var(--text);margin:2.5rem 0 1rem;letter-spacing:-.01em}
+.context{color:var(--text-muted);margin-bottom:1.5rem;font-size:.95rem;line-height:1.7}
+.context strong{color:var(--text)}
+.cost-banner{background:linear-gradient(135deg,rgba(59,130,246,0.1),rgba(168,85,247,0.1));border:1px solid var(--accent);border-radius:12px;padding:1.5rem;text-align:center;margin:1.5rem 0 2rem}
+.cost-banner .cost-amount{font-size:2.5rem;font-weight:700;color:var(--accent);font-family:var(--mono)}
+.cost-banner .cost-label{color:var(--text-muted);font-size:.9rem;margin-top:.25rem}
+.choose-box{background:rgba(168,85,247,0.08);border:1px solid rgba(168,85,247,0.2);border-radius:12px;padding:1.25rem;margin:1.5rem 0}
+.choose-box h3{color:#a855f7;font-size:1rem;margin-bottom:.5rem}
+.choose-box ul{list-style:none;display:flex;flex-wrap:wrap;gap:.5rem}
+.choose-box li{font-size:.85rem;color:var(--text-muted);padding:.25rem .6rem;background:rgba(168,85,247,0.06);border-radius:8px;border:1px solid rgba(168,85,247,0.1)}
+.builtin-box{background:rgba(63,185,80,0.08);border:1px solid rgba(63,185,80,0.2);border-radius:12px;padding:1.25rem;margin:1.5rem 0}
+.builtin-box h3{color:#3fb950;font-size:1rem;margin-bottom:.5rem}
+.builtin-box ul{list-style:none;display:flex;flex-wrap:wrap;gap:.5rem}
+.builtin-box li{font-size:.85rem;color:var(--text-muted);padding:.25rem .6rem;background:rgba(63,185,80,0.06);border-radius:8px;border:1px solid rgba(63,185,80,0.1)}
+.stack-category{border:1px solid var(--border);border-radius:12px;padding:1.5rem;margin-bottom:1.5rem;background:var(--bg-card)}
+.stack-category h2{margin:0 0 1rem;font-size:1.25rem}
+.cat-icon{margin-right:.5rem}
+.stack-pick{border-left:3px solid var(--accent);padding:1rem 1.25rem;background:rgba(59,130,246,0.05);border-radius:0 8px 8px 0;margin-bottom:1rem}
+.pick-header{display:flex;align-items:center;flex-wrap:wrap;gap:.5rem;margin-bottom:.5rem}
+.pick-badge{font-size:.7rem;font-weight:600;padding:.15rem .5rem;border-radius:10px;background:var(--accent);color:#fff}
+.pick-name{font-size:1.1rem;font-weight:600;color:var(--text)}
+.pick-name:hover{color:var(--accent)}
+.pick-tier{font-family:var(--mono);color:var(--accent);font-size:.8rem;padding:.1rem .5rem;background:var(--accent-glow);border-radius:10px}
+.pick-why{color:var(--text-muted);font-size:.9rem;line-height:1.5;margin-bottom:.5rem}
+.pick-limits{font-family:var(--mono);font-size:.8rem;color:var(--text-dim);line-height:1.5}
+.pick-links{display:flex;flex-wrap:wrap;gap:.75rem;font-size:.8rem;margin-top:.75rem}
+.pick-links a{color:var(--accent)}
+.alt-picks{margin-bottom:1rem}
+.alt-label{color:var(--text-dim);font-size:.8rem;margin-bottom:.5rem}
+.alt-chip{display:inline-block;padding:.3rem .75rem;border:1px solid var(--border);border-radius:20px;font-size:.85rem;color:var(--text);margin:.25rem .25rem .25rem 0;transition:border-color .15s}
+.alt-chip:hover{border-color:var(--accent);text-decoration:none}
+.chip-tier{font-family:var(--mono);font-size:.7rem;color:var(--accent);margin-left:.25rem}
+.outgrow-box{background:rgba(210,153,34,0.08);border:1px solid rgba(210,153,34,0.2);border-radius:8px;padding:.75rem 1rem;font-size:.85rem;color:var(--text-muted);line-height:1.5}
+.outgrow-box strong{color:var(--text)}
+.whynot-box{background:rgba(248,81,73,0.06);border:1px solid rgba(248,81,73,0.15);border-radius:8px;padding:.75rem 1rem;font-size:.85rem;color:var(--text-muted);line-height:1.5;margin-top:.75rem}
+.whynot-box strong{color:var(--text-muted);font-weight:500}
+.related-link{display:block;margin-top:.75rem;font-size:.85rem}
+.compare-table{width:100%;border-collapse:collapse;margin:1rem 0 2rem}
+.compare-table th,.compare-table td{padding:.5rem .75rem;text-align:left;border-bottom:1px solid var(--border);font-size:.85rem}
+.compare-table th{color:var(--text-muted);font-weight:500;font-size:.75rem;text-transform:uppercase;letter-spacing:.05em}
+.compare-table tr:hover{background:var(--accent-glow)}
+.growth-table{width:100%;border-collapse:collapse;margin:1rem 0 2rem}
+.growth-table th,.growth-table td{padding:.5rem .75rem;text-align:left;border-bottom:1px solid var(--border);font-size:.85rem}
+.growth-table th{color:var(--text-muted);font-weight:500;font-size:.75rem;text-transform:uppercase;letter-spacing:.05em}
+.growth-table tr:hover{background:var(--accent-glow)}
+.growth-first{color:#d29922;font-weight:600}
+.stability-list{display:flex;flex-direction:column;gap:.5rem}
+.stability-item{padding:.75rem;border:1px solid var(--border);border-radius:8px;font-size:.85rem;color:var(--text-muted);line-height:1.5;background:var(--bg-card)}
+.stability-item strong{color:var(--text)}
+.stability-badge{display:inline-block;font-size:.65rem;font-weight:600;padding:.1rem .4rem;border-radius:8px;margin-right:.5rem}
+.search-cta{background:var(--bg-card);border:1px solid var(--border);border-radius:8px;padding:1.25rem;margin:2rem 0;text-align:center;font-size:.9rem}
+footer{text-align:center;color:var(--text-dim);font-size:.8rem;padding:3rem 0 2rem;border-top:1px solid var(--border);margin-top:3rem}
+@media(max-width:768px){h1{font-size:1.5rem}.compare-table{font-size:.75rem}.compare-table th,.compare-table td{padding:.4rem .5rem}.growth-table{font-size:.75rem}.growth-table th,.growth-table td{padding:.4rem .5rem}.cost-banner .cost-amount{font-size:2rem}}
+${globalNavCss()}
+${mcpCtaCss()}
+</style>
+</head>
+<body>
+<div class="container">
+  ${buildGlobalNav("alternatives")}
+  <div class="breadcrumb"><a href="/">AgentDeals</a> &rsaquo; <a href="/alternatives">Alternatives</a> &rsaquo; Free FastAPI Stack</div>
+  <h1>The Complete Free FastAPI/Python Stack</h1>
+
+  <div class="context">
+    <p>Everything you need to build and ship a FastAPI app — without spending a dollar. This guide recommends the best free tier for each layer of your FastAPI infrastructure — <strong>10 layers</strong> from ASGI hosting to API documentation — with exact limits pulled from our index of ${offers.length.toLocaleString()}+ verified developer tools.</p>
+    <p>Designed for Python developers building REST APIs, AI/ML serving endpoints, microservices, and async backend services with FastAPI. Each recommendation includes alternatives, a "when you'll outgrow it" guide, "why not X" callouts for popular-but-not-recommended options, and stability notes based on our tracking of ${dealChanges.length} real pricing changes. All limits verified April 2026.</p>
+  </div>
+
+  <div class="cost-banner">
+    <div class="cost-amount">$0<span style="font-size:1rem;color:var(--text-muted)">/month</span></div>
+    <div class="cost-label">Total infrastructure cost for a FastAPI service on free tiers</div>
+  </div>
+
+  <div class="choose-box">
+    <h3>🧩 Choose Your Own Stack — FastAPI's Unbundled Architecture</h3>
+    <p style="font-size:.85rem;color:var(--text-muted);margin-bottom:.75rem">Unlike Django's batteries-included approach, FastAPI gives you a fast async framework and lets you pick every other component. More decisions, but each choice is optimized for your use case. This guide resolves that decision fatigue.</p>
+    <ul>
+      <li>You choose: ORM</li>
+      <li>You choose: Auth</li>
+      <li>You choose: Admin</li>
+      <li>You choose: Email</li>
+      <li>You choose: Task queue</li>
+      <li>You choose: Cache</li>
+      <li>You choose: File storage</li>
+      <li>You choose: Search</li>
+    </ul>
+  </div>
+
+  <div class="builtin-box">
+    <h3>⚡ What FastAPI Gives You for Free</h3>
+    <ul>
+      <li>Async ASGI Server</li>
+      <li>Pydantic Validation</li>
+      <li>OpenAPI Docs (Swagger + ReDoc)</li>
+      <li>Dependency Injection</li>
+      <li>Type-Safe Routing</li>
+      <li>BackgroundTasks</li>
+      <li>WebSocket Support</li>
+      <li>OAuth2 Utilities</li>
+      <li>CORS Middleware</li>
+      <li>Lifespan Events</li>
+    </ul>
+  </div>
+
+  <h2>Stack Overview</h2>
+  <div style="overflow-x:auto">
+  <table class="compare-table">
+    <thead>
+      <tr>
+        <th>Layer</th>
+        <th>Recommended</th>
+        <th>Key Limit</th>
+        <th>Stability</th>
+      </tr>
+    </thead>
+    <tbody>
+${tableRows}
+    </tbody>
+  </table>
+  </div>
+
+${categorySections}
+
+${stabilityNotes}
+
+  <h2>The $20/Month Upgrade — What to Spend First</h2>
+  <p style="color:var(--text-muted);margin-bottom:1rem;font-size:.9rem">When you're ready to spend your first dollar, here's where it matters most. Sorted by which limits you'll likely hit first:</p>
+  <div style="overflow-x:auto">
+  <table class="growth-table">
+    <thead>
+      <tr>
+        <th>Layer</th>
+        <th>Free Limit</th>
+        <th>First Paid Plan</th>
+        <th>What You Get</th>
+      </tr>
+    </thead>
+    <tbody>
+${growthCosts.map(g => `      <tr>
+        <td style="font-weight:600">${escHtmlServer(g.layer)}${g.hitFirst ? ` <span class="growth-first">⬆ hit first</span>` : ""}</td>
+        <td style="font-family:var(--mono);font-size:.8rem;color:var(--text-muted)">${escHtmlServer(g.freeLimit)}</td>
+        <td style="font-family:var(--mono);font-size:.8rem;color:var(--accent)">${escHtmlServer(g.firstPaid)}</td>
+        <td style="font-size:.85rem;color:var(--text-muted)">${escHtmlServer(g.gets)}</td>
+      </tr>`).join("\n")}
+    </tbody>
+  </table>
+  </div>
+  <div style="background:var(--bg-card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;margin:1rem 0">
+    <p style="color:var(--text-muted);font-size:.9rem;line-height:1.7"><strong style="color:var(--text)">The $20/month breakpoint:</strong> Database (Neon Launch $19/mo) is the first upgrade that matters — 10 GiB storage and autoscaling. Hosting stays free longer on Railway's $5 credit if you only run one service. Everything else — auth (25K MAU on Auth0), email (3K/mo), monitoring (5K errors), cache/Redis (10K cmds/day), storage (10 GB R2), API docs (unlimited built-in), CI (2,000 min) — stays free well past your first 1,000 users. FastAPI's lightweight footprint means hosting costs stay lower than Django for the same traffic.</p>
+  </div>
+
+  <h2>Architecture: How It Fits Together</h2>
+  <div style="background:var(--bg-card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;margin:1rem 0">
+    <p style="color:var(--text-muted);font-size:.9rem;line-height:1.7;margin-bottom:1rem">A typical FastAPI service connects these layers:</p>
+    <div style="font-family:var(--mono);font-size:.8rem;color:var(--text-muted);line-height:2;padding:1rem;background:rgba(0,0,0,0.2);border-radius:8px;overflow-x:auto;white-space:pre">Client → Railway (uvicorn + FastAPI ASGI) → Neon (Postgres via asyncpg/SQLAlchemy)
+                                            → Auth0 (JWT validation via dependency injection)
+                                            → Upstash Redis (cache via fastapi-cache2)
+                                            → R2 (file uploads via aioboto3)
+                                            → Resend (transactional emails via httpx)
+                                            → ARQ (async background tasks via Redis)
+                                            → Sentry (error tracking + ASGI performance)
+                                            → FastAPI /docs (auto-generated OpenAPI)
+GitHub → GitHub Actions (CI: pytest + ruff) → Railway (CD: auto-deploy)</div>
+    <p style="color:var(--text-dim);font-size:.8rem;margin-top:1rem">All connections use async HTTPS — no VPCs, no SSH tunnels, no complex networking. Each service is independently replaceable. FastAPI's dependency injection makes swapping providers clean — change the dependency, not the route handlers.</p>
+  </div>
+
+  <div class="search-cta">
+    <p>Need a different framework? See our <a href="/free-django-stack">Free Django Stack</a> for batteries-included Python, <a href="/free-nextjs-stack">Free Next.js Stack</a> for React full-stack, <a href="/free-startup-stack">Free Startup Stack</a> for framework-agnostic infrastructure, <a href="/free-ai-stack">Free AI Stack</a> for ML/AI development (FastAPI is the top choice for ML serving), or <a href="/free-devops-stack">Free DevOps Stack</a> for infrastructure tooling. Or <a href="/search">search</a> our full index of ${offers.length.toLocaleString()}+ developer deals.</p>
+  </div>
+
+  ${buildMoreAlternativesGuides(slug)}
+
+  ${buildMcpCta("Get personalized FastAPI stack recommendations from your AI assistant. Compare free tiers, check limits, and plan your infrastructure — directly in your editor.")}
   <footer>AgentDeals &mdash; open source, built for agents | <a href="/privacy">Privacy</a></footer>
 </div>
 <script>${mcpCtaScript()}</script>
@@ -35798,6 +36283,11 @@ ${Array.from(vendorSlugMap.keys()).map(s => `  <url>
     logRequest({ ts: new Date().toISOString(), type: "api", endpoint: "/free-django-stack", params: {}, user_agent: req.headers["user-agent"] ?? "unknown", result_count: 1 });
     res.writeHead(200, { "Content-Type": "text/html; charset=utf-8", "Cache-Control": "public, max-age=3600" });
     res.end(buildFreeDjangoStackPage());
+  } else if (url.pathname === "/free-fastapi-stack" && isGetOrHead) {
+    recordApiHit("/free-fastapi-stack");
+    logRequest({ ts: new Date().toISOString(), type: "api", endpoint: "/free-fastapi-stack", params: {}, user_agent: req.headers["user-agent"] ?? "unknown", result_count: 1 });
+    res.writeHead(200, { "Content-Type": "text/html; charset=utf-8", "Cache-Control": "public, max-age=3600" });
+    res.end(buildFreeFastapiStackPage());
   } else if (url.pathname === "/supabase-vs-firebase" && isGetOrHead) {
     recordApiHit("/supabase-vs-firebase");
     logRequest({ ts: new Date().toISOString(), type: "api", endpoint: "/supabase-vs-firebase", params: {}, user_agent: req.headers["user-agent"] ?? "unknown", result_count: 1 });

--- a/test/http.test.ts
+++ b/test/http.test.ts
@@ -2373,6 +2373,57 @@ describe("HTTP transport", () => {
     assert.ok(html.includes("/free-nextjs-stack"), "Should cross-link to Next.js stack guide");
   });
 
+  it("GET /free-fastapi-stack renders FastAPI stack guide page", async () => {
+    proc = await startHttpServer();
+
+    const response = await fetch(`http://localhost:${serverPort}/free-fastapi-stack`);
+    assert.strictEqual(response.status, 200);
+    assert.ok(response.headers.get("content-type")?.includes("text/html"));
+    const html = await response.text();
+    assert.ok(html.includes("Complete Free FastAPI"), "Should have title");
+    assert.ok(html.includes("application/ld+json"), "Should have JSON-LD");
+    assert.ok(html.includes('"Article"'), "Should use Article schema");
+    assert.ok(html.includes('"FAQPage"'), "Should have FAQ schema");
+    assert.ok(html.includes("canonical"), "Should have canonical link");
+    assert.ok(html.includes("global-nav"), "Should have global nav");
+    assert.ok(html.includes("$0"), "Should show $0 cost");
+    assert.ok(html.includes("Hosting"), "Should have hosting layer");
+    assert.ok(html.includes("Database"), "Should have database layer");
+    assert.ok(html.includes("Cache"), "Should have cache layer");
+    assert.ok(html.includes("Authentication"), "Should have auth layer");
+    assert.ok(html.includes("Object Storage"), "Should have storage layer");
+    assert.ok(html.includes("Email"), "Should have email layer");
+    assert.ok(html.includes("Monitoring"), "Should have monitoring layer");
+    assert.ok(html.includes("CI/CD"), "Should have CI/CD layer");
+    assert.ok(html.includes("Background Tasks"), "Should have background tasks layer");
+    assert.ok(html.includes("API Documentation"), "Should have API docs layer");
+    assert.ok(html.includes("Railway"), "Should recommend Railway");
+    assert.ok(html.includes("Neon"), "Should recommend Neon");
+    assert.ok(html.includes("Auth0"), "Should recommend Auth0");
+    assert.ok(html.includes("Upstash"), "Should recommend Upstash");
+    assert.ok(html.includes("Cloudflare R2"), "Should recommend R2");
+    assert.ok(html.includes("Resend"), "Should recommend Resend");
+    assert.ok(html.includes("Sentry"), "Should recommend Sentry");
+    assert.ok(html.includes("FastAPI Built-in"), "Should have built-in docs recommendation");
+    assert.ok(html.includes("ARQ"), "Should mention ARQ async task queue");
+    assert.ok(html.includes("uvicorn"), "Should mention uvicorn ASGI server");
+    assert.ok(html.includes("Choose Your Own Stack"), "Should have choose-your-own-stack section");
+    assert.ok(html.includes("What FastAPI Gives You"), "Should have built-in features section");
+    assert.ok(html.includes("outgrow"), "Should have outgrow guidance");
+    assert.ok(html.includes("whynot-box"), "Should have why-not callouts");
+    assert.ok(html.includes("$20/Month Upgrade"), "Should have growth cost section");
+    assert.ok(html.includes("Stack Overview"), "Should have overview table");
+    assert.ok(html.includes("Architecture"), "Should have architecture section");
+    assert.ok(html.includes("Can I host FastAPI for free"), "Should have FAQ content");
+    assert.ok(html.includes("More Alternatives Guides"), "Should have cross-links");
+    assert.ok(html.includes("/hosting-free-tier-comparison-2026"), "Should cross-link to hosting comparison");
+    assert.ok(html.includes("/database-free-tier-comparison-2026"), "Should cross-link to database comparison");
+    assert.ok(html.includes("/auth-comparison-2026"), "Should cross-link to auth comparison");
+    assert.ok(html.includes("/monitoring-comparison-2026"), "Should cross-link to monitoring comparison");
+    assert.ok(html.includes("/free-django-stack"), "Should cross-link to Django stack guide");
+    assert.ok(html.includes("/free-nextjs-stack"), "Should cross-link to Next.js stack guide");
+  });
+
   it("GET /google-developer-program-2026 renders GDP pricing analysis page", async () => {
     proc = await startHttpServer();
 


### PR DESCRIPTION
## Summary

Third framework-specific stack guide. 10 infrastructure layers tailored to FastAPI's async-first, unbundled architecture:

1. **Hosting** — Railway (uvicorn ASGI, no sleep timer)
2. **Database** — Neon (asyncpg, SQLAlchemy 2.0 async)
3. **Cache** — Upstash Redis (fastapi-cache2, async)
4. **Auth** — Auth0 (25K MAU — FastAPI has no built-in auth)
5. **Storage** — Cloudflare R2 (aioboto3, zero egress)
6. **Email** — Resend (httpx REST API)
7. **Monitoring** — Sentry (ASGI middleware integration)
8. **CI/CD** — GitHub Actions (pytest + ruff)
9. **Background Tasks** — ARQ + Upstash (async-native) or Celery
10. **API Docs** — FastAPI built-in (Swagger UI + ReDoc, free)

**FastAPI-specific sections:**
- "Choose Your Own Stack" — unbundled architecture framing
- "What FastAPI Gives You for Free" — built-in features list
- $20/month growth cost analysis (lighter than Django's $24 due to no auth costs)
- Architecture diagram showing async HTTPS connections
- 4 FAQ questions with FAQPage schema
- Why-not callouts (Vercel loses WebSockets, Deta shut down, etc.)

**Technical:** Article + FAQPage JSON-LD, OG meta, sitemap, guides hub, stability notes. 403 tests (1 new).

Refs #615