### PR TITLE
Sitemap lastmod accuracy — per-page update dates

### DIFF
--- a/src/serve.ts
+++ b/src/serve.ts
@@ -361,11 +361,28 @@ for (const cat of categories) {
 }
 
 // Build vendor slug → name lookup (deduped by slug, first occurrence wins)
+// Also build vendor slug → most recent verifiedDate for sitemap lastmod
 const vendorSlugMap = new Map<string, string>();
+const vendorLastmod = new Map<string, string>();
 for (const o of offers) {
   const slug = toSlug(o.vendor);
-  if (slug && !vendorSlugMap.has(slug)) {
+  if (!slug) continue;
+  if (!vendorSlugMap.has(slug)) {
     vendorSlugMap.set(slug, o.vendor);
+  }
+  const prev = vendorLastmod.get(slug);
+  if (!prev || o.verifiedDate > prev) {
+    vendorLastmod.set(slug, o.verifiedDate);
+  }
+}
+
+// Build category slug → most recent verifiedDate for sitemap lastmod
+const categoryLastmod = new Map<string, string>();
+for (const o of offers) {
+  const catSlug = toSlug(o.category);
+  const prev = categoryLastmod.get(catSlug);
+  if (!prev || o.verifiedDate > prev) {
+    categoryLastmod.set(catSlug, o.verifiedDate);
   }
 }
 
@@ -37600,165 +37617,186 @@ ${catList}
     }
   } else if (url.pathname === "/sitemap.xml" && isGetOrHead) {
     const now = new Date().toISOString().split("T")[0];
-    const categoryUrls = categories.map((c) => `  <url>
+    // Most recent verifiedDate across all offers — used for index/hub pages
+    const latestVerified = offers.reduce((max, o) => o.verifiedDate > max ? o.verifiedDate : max, offers[0]?.verifiedDate || now);
+    // Editorial pages use their deploy date (when content was created/last updated)
+    const editorialDate = "2026-04-04";
+    // Comparison pages enrichment deploy date
+    const comparisonDate = "2026-04-04";
+    const categoryUrls = categories.map((c) => {
+      const catLastmod = categoryLastmod.get(toSlug(c.name)) || now;
+      return `  <url>
     <loc>${BASE_URL}/category/${toSlug(c.name)}</loc>
-    <lastmod>${now}</lastmod>
+    <lastmod>${catLastmod}</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
-  </url>`).join("\n");
+  </url>`;
+    }).join("\n");
     const sitemapXml = `<?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>${BASE_URL}/</loc>
-    <lastmod>${now}</lastmod>
+    <lastmod>${latestVerified}</lastmod>
     <changefreq>daily</changefreq>
     <priority>1.0</priority>
   </url>
   <url>
     <loc>${BASE_URL}/feed.xml</loc>
-    <lastmod>${now}</lastmod>
+    <lastmod>${latestVerified}</lastmod>
     <changefreq>daily</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>${BASE_URL}/api/docs</loc>
-    <lastmod>${now}</lastmod>
+    <lastmod>${editorialDate}</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>${BASE_URL}/setup</loc>
-    <lastmod>${now}</lastmod>
+    <lastmod>${editorialDate}</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>${BASE_URL}/privacy</loc>
-    <lastmod>${now}</lastmod>
+    <lastmod>${editorialDate}</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.3</priority>
   </url>
   <url>
     <loc>${BASE_URL}/expiring</loc>
-    <lastmod>${now}</lastmod>
+    <lastmod>${latestVerified}</lastmod>
     <changefreq>daily</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>${BASE_URL}/changes</loc>
-    <lastmod>${now}</lastmod>
+    <lastmod>${latestVerified}</lastmod>
     <changefreq>daily</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>${BASE_URL}/freshness</loc>
-    <lastmod>${now}</lastmod>
+    <lastmod>${latestVerified}</lastmod>
     <changefreq>daily</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>${BASE_URL}/agent-stack</loc>
-    <lastmod>${now}</lastmod>
+    <lastmod>${editorialDate}</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>${BASE_URL}/category</loc>
-    <lastmod>${now}</lastmod>
+    <lastmod>${latestVerified}</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>${BASE_URL}/best</loc>
-    <lastmod>${now}</lastmod>
+    <lastmod>${latestVerified}</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
-${Array.from(bestOfSlugMap.keys()).map(s => `  <url>
+${Array.from(bestOfSlugMap.entries()).map(([s, { categoryName }]) => {
+      const bestLastmod = categoryLastmod.get(toSlug(categoryName)) || now;
+      return `  <url>
     <loc>${BASE_URL}/best/${s}</loc>
-    <lastmod>${now}</lastmod>
+    <lastmod>${bestLastmod}</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
-  </url>`).join("\n")}
+  </url>`;
+    }).join("\n")}
   <url>
     <loc>${BASE_URL}/compare</loc>
-    <lastmod>${now}</lastmod>
+    <lastmod>${comparisonDate}</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
 ${categoryUrls}
 ${Array.from(comparisonMap.keys()).map(s => `  <url>
     <loc>${BASE_URL}/compare/${s}</loc>
-    <lastmod>${now}</lastmod>
+    <lastmod>${comparisonDate}</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>`).join("\n")}
   <url>
     <loc>${BASE_URL}/vendor</loc>
-    <lastmod>${now}</lastmod>
+    <lastmod>${latestVerified}</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
-${Array.from(vendorSlugMap.keys()).map(s => `  <url>
+${Array.from(vendorSlugMap.keys()).map(s => {
+      const vLastmod = vendorLastmod.get(s) || now;
+      return `  <url>
     <loc>${BASE_URL}/vendor/${s}</loc>
-    <lastmod>${now}</lastmod>
+    <lastmod>${vLastmod}</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
-  </url>`).join("\n")}
+  </url>`;
+    }).join("\n")}
   <url>
     <loc>${BASE_URL}/digest/archive</loc>
-    <lastmod>${now}</lastmod>
+    <lastmod>${latestVerified}</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
 ${getRecentWeekKeys(4).map(wk => `  <url>
     <loc>${BASE_URL}/digest/${wk}</loc>
-    <lastmod>${now}</lastmod>
+    <lastmod>${latestVerified}</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>`).join("\n")}
   <url>
     <loc>${BASE_URL}/trends</loc>
-    <lastmod>${now}</lastmod>
+    <lastmod>${latestVerified}</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
-${categories.map(c => `  <url>
+${categories.map(c => {
+      const trendLastmod = categoryLastmod.get(toSlug(c.name)) || now;
+      return `  <url>
     <loc>${BASE_URL}/trends/${toSlug(c.name)}</loc>
-    <lastmod>${now}</lastmod>
+    <lastmod>${trendLastmod}</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
-  </url>`).join("\n")}
+  </url>`;
+    }).join("\n")}
 ${ALTERNATIVES_PAGES.map(p => `  <url>
     <loc>${BASE_URL}/${p.slug}</loc>
-    <lastmod>${now}</lastmod>
+    <lastmod>${editorialDate}</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>`).join("\n")}
   <url>
     <loc>${BASE_URL}/guides</loc>
-    <lastmod>${now}</lastmod>
+    <lastmod>${editorialDate}</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>${BASE_URL}/alternatives</loc>
-    <lastmod>${now}</lastmod>
+    <lastmod>${editorialDate}</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>${BASE_URL}/alternative-to</loc>
-    <lastmod>${now}</lastmod>
+    <lastmod>${latestVerified}</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
-${Array.from(vendorSlugMap.keys()).map(s => `  <url>
+${Array.from(vendorSlugMap.keys()).map(s => {
+      const altLastmod = vendorLastmod.get(s) || now;
+      return `  <url>
     <loc>${BASE_URL}/alternative-to/${s}</loc>
-    <lastmod>${now}</lastmod>
+    <lastmod>${altLastmod}</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
-  </url>`).join("\n")}
+  </url>`;
+    }).join("\n")}
 </urlset>`;
     res.writeHead(200, { "Content-Type": "application/xml; charset=utf-8", "Cache-Control": "public, max-age=3600" });
     res.end(sitemapXml);

--- a/test/http.test.ts
+++ b/test/http.test.ts
@@ -1345,6 +1345,33 @@ describe("HTTP transport", () => {
     assert.ok(altCount >= 100, `Expected 100+ alternative-to URLs in sitemap, got ${altCount}`);
   });
 
+  it("sitemap.xml has varying lastmod dates based on content", async () => {
+    proc = await startHttpServer();
+
+    const response = await fetch(`http://localhost:${serverPort}/sitemap.xml`);
+    const xml = await response.text();
+    // Extract all lastmod dates
+    const lastmods = [...xml.matchAll(/<lastmod>([^<]+)<\/lastmod>/g)].map(m => m[1]);
+    assert.ok(lastmods.length > 100, `Expected 100+ lastmod entries, got ${lastmods.length}`);
+    // Verify not all dates are the same (the whole point of this feature)
+    const uniqueDates = new Set(lastmods);
+    assert.ok(uniqueDates.size > 1, `Expected varying lastmod dates, got ${uniqueDates.size} unique date(s): ${[...uniqueDates].join(", ")}`);
+    // All dates should be valid YYYY-MM-DD format
+    for (const d of lastmods) {
+      assert.match(d, /^\d{4}-\d{2}-\d{2}$/, `Invalid lastmod date format: ${d}`);
+    }
+    // No future dates
+    const today = new Date().toISOString().split("T")[0];
+    for (const d of lastmods) {
+      assert.ok(d <= today, `Lastmod date ${d} is in the future`);
+    }
+    // Vendor pages should use verifiedDate (spot check: /vendor/vercel should not use today's date)
+    const vercelEntry = xml.match(/<url>\s*<loc>[^<]*\/vendor\/vercel<\/loc>\s*<lastmod>([^<]+)<\/lastmod>/);
+    assert.ok(vercelEntry, "Should have vercel vendor entry");
+    // The vercel lastmod should be a verifiedDate, not necessarily today
+    assert.match(vercelEntry![1], /^\d{4}-\d{2}-\d{2}$/, "Vercel lastmod should be valid date");
+  });
+
   // --- Expiring page ---
 
   it("GET /expiring renders expiring deals timeline page", async () => {


### PR DESCRIPTION
## Summary
- Vendor and alternative-to pages use the offer's `verifiedDate` as lastmod
- Category, best-of, and trends pages use the most recent `verifiedDate` in that category
- Editorial/comparison pages use deploy date (2026-04-04)
- Dynamic pages (homepage, changes, expiring, freshness) use the latest `verifiedDate` across all offers
- Adds `vendorLastmod` and `categoryLastmod` maps built at startup from offer data
- 1 new test: verifies lastmod dates vary across URLs, are valid YYYY-MM-DD, and none are in the future

## Impact
- ~1,068 sitemap URLs now have accurate lastmod dates instead of all sharing today's date
- Google can prioritize recrawling pages with actual content changes
- No changes to page content or IndexNow behavior

## Test plan
- [x] All 406 tests pass (405 existing + 1 new)
- [x] Build succeeds
- [x] Sitemap XML is valid with varying lastmod dates

Refs #627