### PR TITLE
Stack-aware change monitoring — personalized pricing alerts

### DIFF
--- a/src/data.ts
+++ b/src/data.ts
@@ -389,7 +389,8 @@ export function getDealChanges(
   since?: string,
   changeType?: string,
   vendor?: string,
-  vendors?: string
+  vendors?: string,
+  categories?: string
 ): { changes: DealChange[]; total: number } {
   let results = loadDealChanges();
 
@@ -420,10 +421,78 @@ export function getDealChanges(
     results = results.filter((c) => c.vendor.toLowerCase().includes(lowerVendor));
   }
 
+  // Category filtering (comma-separated, case-insensitive partial match)
+  if (categories) {
+    const catList = categories.split(",").map((c) => c.trim().toLowerCase()).filter(Boolean);
+    results = results.filter((c) => {
+      const lowerCat = (c.category || "").toLowerCase();
+      return catList.some((cat) => lowerCat.includes(cat));
+    });
+  }
+
   // Sort by date, newest first
   results = [...results].sort((a, b) => b.date.localeCompare(a.date));
 
   return { changes: results, total: results.length };
+}
+
+export interface PersonalizedChanges {
+  your_stack_changes: DealChange[];
+  advisory: DealChange[];
+  summary: {
+    stack_changes_count: number;
+    ecosystem_high_impact_count: number;
+    period_days: number;
+  };
+}
+
+const HIGH_IMPACT_CHANGE_TYPES = new Set([
+  "free_tier_removed", "open_source_killed", "product_deprecated",
+  "limits_reduced", "new_free_tier",
+]);
+
+export function getPersonalizedChanges(
+  since?: string,
+  changeType?: string,
+  vendor?: string,
+  vendors?: string,
+  categories?: string
+): PersonalizedChanges {
+  // Get the user's stack changes
+  const stackResult = getDealChanges(since, changeType, vendor, vendors, categories);
+
+  // Get ALL changes in the same time window (no vendor/category filter)
+  const allResult = getDealChanges(since, changeType);
+
+  // Build a set of vendor names already in the stack results for dedup
+  const stackVendorDates = new Set(
+    stackResult.changes.map((c) => `${c.vendor}|${c.date}|${c.change_type}`)
+  );
+
+  // Advisory: high-impact changes outside the user's filter, top 3
+  const advisory = allResult.changes
+    .filter((c) => c.impact === "high" && HIGH_IMPACT_CHANGE_TYPES.has(c.change_type))
+    .filter((c) => !stackVendorDates.has(`${c.vendor}|${c.date}|${c.change_type}`))
+    .slice(0, 3);
+
+  // Count high-impact ecosystem-wide
+  const ecosystemHighImpact = allResult.changes.filter(
+    (c) => c.impact === "high"
+  ).length;
+
+  // Calculate period in days
+  const sinceDate = since ? new Date(since) : new Date(Date.now() - 30 * 24 * 60 * 60 * 1000);
+  const periodDays = Math.max(1, Math.ceil((Date.now() - sinceDate.getTime()) / (24 * 60 * 60 * 1000)));
+
+  return {
+    your_stack_changes: stackResult.changes,
+    advisory,
+    summary: {
+      stack_changes_count: stackResult.changes.length,
+      ecosystem_high_impact_count: ecosystemHighImpact,
+      period_days: periodDays,
+    },
+  };
 }
 
 function findVendor(offers: Offer[], name: string): { offer: Offer | null; suggestions: string[] } {

--- a/src/mcp-apps.ts
+++ b/src/mcp-apps.ts
@@ -368,9 +368,20 @@ function trackChangesHtml(): string {
   .timeline-reduced::before { background: #fbbf24; }
   .timeline-increased::before, .timeline-new::before { background: #34d399; }
   .timeline-other::before { background: #60a5fa; }
+  .timeline-item.personal { border-left-color: #3b82f6; border-left-width: 3px; }
   .change-date { font-size: 12px; color: #64748b; }
   .change-vendor { font-weight: 600; color: #f1f5f9; }
   .change-summary { font-size: 13px; color: #94a3b8; margin-top: 2px; }
+  .stack-summary { background: linear-gradient(135deg, #1e3a5f 0%, #1e293b 100%); border: 1px solid #3b82f6; border-radius: 8px; padding: 16px; margin-bottom: 16px; }
+  .stack-summary h3 { margin: 0 0 8px; color: #60a5fa; font-size: 15px; }
+  .stack-summary .summary-stats { display: flex; gap: 16px; font-size: 13px; color: #94a3b8; }
+  .stack-summary .summary-stats strong { color: #f1f5f9; }
+  .advisory-section { margin-top: 16px; border-top: 1px solid #334155; padding-top: 12px; }
+  .advisory-section h3 { font-size: 14px; color: #94a3b8; margin: 0 0 8px; cursor: pointer; }
+  .advisory-section h3::before { content: "\\u25B6"; font-size: 10px; margin-right: 6px; display: inline-block; transition: transform 0.2s; }
+  .advisory-section.open h3::before { transform: rotate(90deg); }
+  .advisory-section .advisory-items { display: none; }
+  .advisory-section.open .advisory-items { display: block; }
 </style></head><body>
 <div id="app"><div class="empty">Loading changes...</div></div>
 <script type="module">
@@ -380,7 +391,11 @@ function render(args, data) {
   const el = document.getElementById("app");
   if (!data) { el.innerHTML = '<div class="empty">Loading...</div>'; return; }
 
-  const changes = data.deal_changes || data.changes || [];
+  // Detect personalized vs standard response
+  const isPersonalized = Array.isArray(data.your_stack_changes);
+  const changes = isPersonalized ? data.your_stack_changes : (data.deal_changes || data.changes || []);
+  const advisory = isPersonalized ? (data.advisory || []) : [];
+  const summary = isPersonalized ? data.summary : null;
   const expiring = data.expiring_deals || data.expiring || [];
 
   // Categorize changes
@@ -389,7 +404,7 @@ function render(args, data) {
   const positive = changes.filter(c => c.change_type === "limits_increased" || c.change_type === "new_free_tier" || c.change_type === "startup_program_expanded");
 
   const stats = [
-    { label: "Total Changes", value: changes.length },
+    { label: isPersonalized ? "Your Stack" : "Total Changes", value: changes.length },
     { label: "Removals", value: removals.length },
     { label: "Reductions", value: reductions.length },
     { label: "Improvements", value: positive.length },
@@ -410,28 +425,50 @@ function render(args, data) {
     return "badge-blue";
   };
 
-  // Filter state
-  let activeFilter = "all";
+  function renderTimelineItem(c, isPersonalItem) {
+    return \`
+      <div class="timeline-item \${timelineClass(c.change_type)}\${isPersonalItem ? " personal" : ""}">
+        <div class="change-date">\${esc(c.date)}</div>
+        <div><span class="change-vendor">\${esc(c.vendor)}</span> <span class="badge \${changeBadge(c.change_type)}">\${esc((c.change_type || "").replace(/_/g, " "))}</span></div>
+        <div class="change-summary">\${esc(c.summary)}</div>
+        \${c.previous_state ? \`<div style="margin-top:4px;font-size:12px"><span style="color:#64748b">Before:</span> \${esc(c.previous_state)}</div>\` : ""}
+        \${c.current_state ? \`<div style="font-size:12px"><span style="color:#64748b">After:</span> \${esc(c.current_state)}</div>\` : ""}
+      </div>
+    \`;
+  }
 
   function renderTimeline(filter) {
     const filtered = filter === "all" ? changes :
       filter === "negative" ? [...removals, ...reductions] :
       filter === "positive" ? positive : changes;
     return filtered.length === 0 ? '<div class="empty">No changes match this filter.</div>' :
-      filtered.map(c => \`
-        <div class="timeline-item \${timelineClass(c.change_type)}">
-          <div class="change-date">\${esc(c.date)}</div>
-          <div><span class="change-vendor">\${esc(c.vendor)}</span> <span class="badge \${changeBadge(c.change_type)}">\${esc((c.change_type || "").replace(/_/g, " "))}</span></div>
-          <div class="change-summary">\${esc(c.summary)}</div>
-          \${c.previous_state ? \`<div style="margin-top:4px;font-size:12px"><span style="color:#64748b">Before:</span> \${esc(c.previous_state)}</div>\` : ""}
-          \${c.current_state ? \`<div style="font-size:12px"><span style="color:#64748b">After:</span> \${esc(c.current_state)}</div>\` : ""}
-        </div>
-      \`).join("");
+      filtered.map(c => renderTimelineItem(c, isPersonalized)).join("");
   }
 
+  const stackSummaryHtml = isPersonalized && summary ? \`
+    <div class="stack-summary">
+      <h3>\\ud83d\\udee1\\ufe0f Your Stack</h3>
+      <div class="summary-stats">
+        <span><strong>\${summary.stack_changes_count}</strong> changes affecting your stack</span>
+        <span><strong>\${summary.ecosystem_high_impact_count}</strong> high-impact changes ecosystem-wide</span>
+        <span>Last <strong>\${summary.period_days}</strong> days</span>
+      </div>
+    </div>
+  \` : "";
+
+  const advisoryHtml = advisory.length > 0 ? \`
+    <div class="advisory-section" id="advisory-section">
+      <h3>Also worth knowing (\${advisory.length})</h3>
+      <div class="advisory-items">
+        \${advisory.map(c => renderTimelineItem(c, false)).join("")}
+      </div>
+    </div>
+  \` : "";
+
   el.innerHTML = \`
-    <h2>Pricing Changes</h2>
+    <h2>\${isPersonalized ? "Your Stack Changes" : "Pricing Changes"}</h2>
     <p class="subtitle">\${data.period || "Recent"} developer tool pricing activity</p>
+    \${stackSummaryHtml}
     <div class="stats-row">\${stats.map(s => \`<div class="stat"><div class="stat-value">\${s.value}</div><div class="stat-label">\${s.label}</div></div>\`).join("")}</div>
     <div class="filter-bar">
       <button class="filter-btn active" data-filter="all">All</button>
@@ -439,6 +476,7 @@ function render(args, data) {
       <button class="filter-btn" data-filter="positive">Improvements</button>
     </div>
     <div id="timeline">\${renderTimeline("all")}</div>
+    \${advisoryHtml}
     \${expiring.length > 0 ? \`
       <div class="card" style="margin-top:16px">
         <h3>Expiring Soon</h3>
@@ -456,6 +494,14 @@ function render(args, data) {
       document.getElementById("timeline").innerHTML = renderTimeline(btn.dataset.filter);
     });
   });
+
+  // Wire up advisory toggle
+  const advisoryEl = document.getElementById("advisory-section");
+  if (advisoryEl) {
+    advisoryEl.querySelector("h3").addEventListener("click", () => {
+      advisoryEl.classList.toggle("open");
+    });
+  }
 }
 
 function esc(s) { if (!s) return ""; const d = document.createElement("div"); d.textContent = String(s); return d.innerHTML; }

--- a/src/openapi.ts
+++ b/src/openapi.ts
@@ -145,24 +145,46 @@ export const openapiSpec = {
     "/api/changes": {
       get: {
         summary: "Deal and pricing changes",
-        description: "Returns tracked pricing and tier changes across vendors. Filter by date, change type, or vendor.",
+        description: "Returns tracked pricing and tier changes across vendors. Filter by date, change type, vendor, or category. When vendors or categories are provided, returns personalized results with advisory section for high-impact changes outside your filter.",
         parameters: [
           { name: "since", in: "query", description: "Filter changes after this date (YYYY-MM-DD)", schema: { type: "string", format: "date" }, example: "2025-01-01" },
           { name: "type", in: "query", description: "Filter by change type", schema: { type: "string", enum: ["free_tier_removed", "limits_reduced", "restriction", "limits_increased", "new_free_tier", "pricing_restructured", "open_source_killed", "pricing_model_change", "startup_program_expanded", "pricing_postponed", "product_deprecated"] } },
           { name: "vendor", in: "query", description: "Filter by vendor name", schema: { type: "string" } },
-          { name: "vendors", in: "query", description: "Comma-separated vendor names to filter by (e.g. 'Vercel,Supabase,Clerk')", schema: { type: "string" }, example: "Vercel,Supabase" }
+          { name: "vendors", in: "query", description: "Comma-separated vendor names to filter by (e.g. 'Vercel,Supabase,Clerk'). Triggers personalized response.", schema: { type: "string" }, example: "Vercel,Supabase" },
+          { name: "categories", in: "query", description: "Comma-separated category names to filter by (e.g. 'Database,Cloud Hosting'). Case-insensitive partial match. Triggers personalized response.", schema: { type: "string" }, example: "Database,Hosting" }
         ],
         responses: {
           "200": {
-            description: "List of deal changes",
+            description: "List of deal changes. When vendors or categories are provided, returns personalized response with your_stack_changes, advisory, and summary fields instead of changes/total.",
             content: {
               "application/json": {
                 schema: {
-                  type: "object",
-                  properties: {
-                    changes: { type: "array", items: { $ref: "#/components/schemas/DealChange" } },
-                    total: { type: "integer" }
-                  }
+                  oneOf: [
+                    {
+                      type: "object",
+                      description: "Standard response (no vendor/category filters)",
+                      properties: {
+                        changes: { type: "array", items: { $ref: "#/components/schemas/DealChange" } },
+                        total: { type: "integer" }
+                      }
+                    },
+                    {
+                      type: "object",
+                      description: "Personalized response (vendor/category filters active)",
+                      properties: {
+                        your_stack_changes: { type: "array", items: { $ref: "#/components/schemas/DealChange" } },
+                        advisory: { type: "array", items: { $ref: "#/components/schemas/DealChange" }, description: "Top 3 high-impact changes outside your filter" },
+                        summary: {
+                          type: "object",
+                          properties: {
+                            stack_changes_count: { type: "integer" },
+                            ecosystem_high_impact_count: { type: "integer" },
+                            period_days: { type: "integer" }
+                          }
+                        }
+                      }
+                    }
+                  ]
                 },
                 example: {
                   changes: [{ vendor: "Heroku", change_type: "free_tier_removed", date: "2022-11-28", summary: "Heroku eliminated all free dynos, free Postgres, and free Redis.", previous_state: "Free dyno (550-1000 hrs/mo), free Postgres (10K rows), free Redis (25MB)", current_state: "No free tier. Cheapest plan: $5/mo Eco dyno.", impact: "high", source_url: "https://blog.heroku.com/next-chapter", category: "Cloud Hosting", alternatives: ["Railway", "Render", "Fly.io"] }],

--- a/src/serve.ts
+++ b/src/serve.ts
@@ -5,7 +5,7 @@ import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
 import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
 import { createServer, getServerCard } from "./server.js";
-import { loadOffers, getCategories, getNewOffers, getNewestDeals, searchOffers, enrichOffers, loadDealChanges, getDealChanges, getOfferDetails, compareServices, checkVendorRisk, auditStack, getExpiringDeals, getWeeklyDigest, getFreshnessMetrics, getStabilityMap } from "./data.js";
+import { loadOffers, getCategories, getNewOffers, getNewestDeals, searchOffers, enrichOffers, loadDealChanges, getDealChanges, getPersonalizedChanges, getOfferDetails, compareServices, checkVendorRisk, auditStack, getExpiringDeals, getWeeklyDigest, getFreshnessMetrics, getStabilityMap } from "./data.js";
 import { getStackRecommendation } from "./stacks.js";
 import { estimateCosts } from "./costs.js";
 import { recordApiHit, recordSessionConnect, recordSessionDisconnect, recordLandingPageView, getStats, getConnectionStats, loadTelemetry, flushTelemetry, logRequest, getRequestLog, recordPageView, getPageViews } from "./stats.js";
@@ -39507,16 +39507,26 @@ const httpServer = createHttpServer(async (req, res) => {
     const type = url.searchParams.get("type") || undefined;
     const vendorFilter = url.searchParams.get("vendor") || undefined;
     const vendorsFilter = url.searchParams.get("vendors") || undefined;
+    const categoriesFilter = url.searchParams.get("categories") || undefined;
     // Validate since is a valid date if provided
     if (since && !/^\d{4}-\d{2}-\d{2}/.test(since)) {
       res.writeHead(400, { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" });
       res.end(JSON.stringify({ error: "Invalid 'since' parameter. Expected ISO date string (YYYY-MM-DD)." }));
       return;
     }
-    const result = getDealChanges(since, type, vendorFilter, vendorsFilter);
-    logRequest({ ts: new Date().toISOString(), type: "api", endpoint: "/api/changes", params: { since, type, vendor: vendorFilter, vendors: vendorsFilter }, user_agent: req.headers["user-agent"] ?? "unknown", result_count: result.changes.length });
-    res.writeHead(200, { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" });
-    res.end(JSON.stringify(result));
+    // Personalized mode when vendors or categories filter is active
+    const isPersonalized = !!(vendorsFilter || categoriesFilter);
+    if (isPersonalized) {
+      const result = getPersonalizedChanges(since, type, vendorFilter, vendorsFilter, categoriesFilter);
+      logRequest({ ts: new Date().toISOString(), type: "api", endpoint: "/api/changes", params: { since, type, vendor: vendorFilter, vendors: vendorsFilter, categories: categoriesFilter, personalized: true }, user_agent: req.headers["user-agent"] ?? "unknown", result_count: result.your_stack_changes.length });
+      res.writeHead(200, { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" });
+      res.end(JSON.stringify(result));
+    } else {
+      const result = getDealChanges(since, type, vendorFilter, vendorsFilter, categoriesFilter);
+      logRequest({ ts: new Date().toISOString(), type: "api", endpoint: "/api/changes", params: { since, type, vendor: vendorFilter, vendors: vendorsFilter }, user_agent: req.headers["user-agent"] ?? "unknown", result_count: result.changes.length });
+      res.writeHead(200, { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" });
+      res.end(JSON.stringify(result));
+    }
   } else if (url.pathname === "/api/audit-stack" && isGetOrHead) {
     recordApiHit("/api/audit-stack");
     const servicesParam = url.searchParams.get("services");

--- a/src/server-remote.ts
+++ b/src/server-remote.ts
@@ -263,16 +263,17 @@ export function createServer(): McpServer {
         since: z.string().optional().describe("ISO date (YYYY-MM-DD). Default: 7 days ago."),
         change_type: z.enum(["free_tier_removed", "limits_reduced", "restriction", "limits_increased", "new_free_tier", "pricing_restructured", "open_source_killed", "pricing_model_change", "startup_program_expanded", "pricing_postponed", "product_deprecated"]).optional().describe("Filter by type of change"),
         vendor: z.string().optional().describe("Filter to one vendor (case-insensitive)"),
-        vendors: z.string().optional().describe("Comma-separated vendor names to filter (e.g. 'Vercel,Supabase')"),
+        vendors: z.string().optional().describe("Comma-separated vendor names to filter (e.g. 'Vercel,Supabase'). When provided with categories, returns personalized results with advisory section."),
+        categories: z.string().optional().describe("Comma-separated category names to filter (e.g. 'Database,Cloud Hosting'). Case-insensitive partial match."),
         include_expiring: z.boolean().optional().describe("Include upcoming expirations (default: true)"),
         lookahead_days: z.number().optional().describe("Days to look ahead for expirations (default: 30)"),
         response_format: z.enum(["concise", "detailed"]).optional().describe("Response detail level. 'concise': vendor, change_type, date, summary only. 'detailed': full response (default)."),
       },
     },
-    async ({ since, change_type, vendor, vendors, include_expiring, lookahead_days, response_format }) => {
+    async ({ since, change_type, vendor, vendors, categories, include_expiring, lookahead_days, response_format }) => {
       try {
         // No params = weekly digest
-        if (!since && !change_type && !vendor && !vendors && include_expiring === undefined) {
+        if (!since && !change_type && !vendor && !vendors && !categories && include_expiring === undefined) {
           const data = await fetchWeeklyDigest() as Record<string, unknown>;
           if (response_format === "concise" && Array.isArray(data.deal_changes)) {
             const conciseDigest = { ...data, deal_changes: (data.deal_changes as Record<string, unknown>[]).map((c) => ({ vendor: c.vendor, change_type: c.change_type, date: c.date, summary: c.summary })) };
@@ -281,8 +282,10 @@ export function createServer(): McpServer {
           return mcpText(data);
         }
 
-        // Filtered changes
-        const changes = await fetchDealChanges({ since, type: change_type, vendor, vendors }) as Record<string, unknown>;
+        // Filtered changes — pass categories to API
+        const params: Record<string, string | undefined> = { since, type: change_type, vendor, vendors };
+        if (categories) params.categories = categories;
+        const changes = await fetchDealChanges(params) as Record<string, unknown>;
         const doExpiring = include_expiring !== false;
         const days = Math.min(Math.max(lookahead_days ?? 30, 1), 365);
 
@@ -292,8 +295,18 @@ export function createServer(): McpServer {
           result = { ...(changes as object), expiring_deals: expiring };
         }
 
-        if (response_format === "concise" && Array.isArray(result.changes)) {
-          result = { ...result, changes: result.changes.map((c: Record<string, unknown>) => ({ vendor: c.vendor, change_type: c.change_type, date: c.date, summary: c.summary })) };
+        if (response_format === "concise") {
+          // Handle both personalized and standard response shapes
+          if (Array.isArray(result.changes)) {
+            result = { ...result, changes: result.changes.map((c: Record<string, unknown>) => ({ vendor: c.vendor, change_type: c.change_type, date: c.date, summary: c.summary })) };
+          }
+          if (Array.isArray(result.your_stack_changes)) {
+            result = {
+              ...result,
+              your_stack_changes: result.your_stack_changes.map((c: Record<string, unknown>) => ({ vendor: c.vendor, change_type: c.change_type, date: c.date, summary: c.summary })),
+              advisory: (result.advisory || []).map((c: Record<string, unknown>) => ({ vendor: c.vendor, change_type: c.change_type, date: c.date, summary: c.summary })),
+            };
+          }
         }
 
         return mcpText(result);

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,6 +1,6 @@
 import { McpServer, ResourceTemplate } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
-import { getCategories, getDealChanges, getNewOffers, getNewestDeals, getOfferDetails, searchOffers, enrichOffers, compareServices, checkVendorRisk, auditStack, getExpiringDeals, getWeeklyDigest, loadOffers, loadDealChanges, classifyStability, getStabilityMap } from "./data.js";
+import { getCategories, getDealChanges, getPersonalizedChanges, getNewOffers, getNewestDeals, getOfferDetails, searchOffers, enrichOffers, compareServices, checkVendorRisk, auditStack, getExpiringDeals, getWeeklyDigest, loadOffers, loadDealChanges, classifyStability, getStabilityMap } from "./data.js";
 import { recordToolCall, logRequest } from "./stats.js";
 import { getStackRecommendation } from "./stacks.js";
 import { estimateCosts } from "./costs.js";
@@ -323,18 +323,19 @@ export function createServer(getSessionId?: () => string | undefined): McpServer
         since: z.string().optional().describe("ISO date (YYYY-MM-DD). Default: 7 days ago."),
         change_type: z.enum(["free_tier_removed", "limits_reduced", "restriction", "limits_increased", "new_free_tier", "pricing_restructured", "open_source_killed", "pricing_model_change", "startup_program_expanded", "pricing_postponed", "product_deprecated"]).optional().describe("Filter by type of change"),
         vendor: z.string().optional().describe("Filter to one vendor (case-insensitive)"),
-        vendors: z.string().optional().describe("Comma-separated vendor names to filter (e.g. 'Vercel,Supabase')"),
+        vendors: z.string().optional().describe("Comma-separated vendor names to filter (e.g. 'Vercel,Supabase'). When provided with categories, returns personalized results with advisory section."),
+        categories: z.string().optional().describe("Comma-separated category names to filter (e.g. 'Database,Cloud Hosting'). Case-insensitive partial match."),
         include_expiring: z.boolean().optional().describe("Include upcoming expirations (default: true)"),
         lookahead_days: z.number().optional().describe("Days to look ahead for expirations (default: 30)"),
         response_format: z.enum(["concise", "detailed"]).optional().describe("Response detail level. 'concise': vendor, change_type, date, summary only. 'detailed': full response (default)."),
       },
     },
-    async ({ since, change_type, vendor, vendors, include_expiring, lookahead_days, response_format }) => {
+    async ({ since, change_type, vendor, vendors, categories, include_expiring, lookahead_days, response_format }) => {
       try {
         recordToolCall("track_changes");
 
         // No params = weekly digest
-        if (!since && !change_type && !vendor && !vendors && include_expiring === undefined) {
+        if (!since && !change_type && !vendor && !vendors && !categories && include_expiring === undefined) {
           const digest = getWeeklyDigest();
           logRequest({ ts: new Date().toISOString(), type: "mcp", endpoint: "track_changes", params: {}, result_count: digest.deal_changes.length, session_id: getSessionId?.() });
           if (response_format === "concise") {
@@ -348,10 +349,36 @@ export function createServer(getSessionId?: () => string | undefined): McpServer
           };
         }
 
-        // Filtered changes
-        const changes = getDealChanges(since, change_type, vendor, vendors);
         const doExpiring = include_expiring !== false;
         const days = Math.min(Math.max(lookahead_days ?? 30, 1), 365);
+
+        // Personalized mode: when vendors or categories filter is active
+        const isPersonalized = !!(vendors || categories);
+
+        if (isPersonalized) {
+          const personalized = getPersonalizedChanges(since, change_type, vendor, vendors, categories);
+
+          let result: any = personalized;
+          if (doExpiring) {
+            result = { ...personalized, expiring_deals: getExpiringDeals(days) };
+          }
+
+          if (response_format === "concise") {
+            result = {
+              ...result,
+              your_stack_changes: result.your_stack_changes.map(toConciseDealChange),
+              advisory: result.advisory.map(toConciseDealChange),
+            };
+          }
+
+          logRequest({ ts: new Date().toISOString(), type: "mcp", endpoint: "track_changes", params: { since, change_type, vendor, vendors, categories, include_expiring: doExpiring, lookahead_days: days, personalized: true }, result_count: personalized.your_stack_changes.length, session_id: getSessionId?.() });
+          return {
+            content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }],
+          };
+        }
+
+        // Standard filtered changes (single vendor or change_type only)
+        const changes = getDealChanges(since, change_type, vendor, vendors, categories);
 
         let result: any = changes;
         if (doExpiring) {
@@ -363,7 +390,7 @@ export function createServer(getSessionId?: () => string | undefined): McpServer
           result = { ...result, changes: result.changes.map(toConciseDealChange) };
         }
 
-        logRequest({ ts: new Date().toISOString(), type: "mcp", endpoint: "track_changes", params: { since, change_type, vendor, vendors, include_expiring: doExpiring, lookahead_days: days }, result_count: changes.changes.length, session_id: getSessionId?.() });
+        logRequest({ ts: new Date().toISOString(), type: "mcp", endpoint: "track_changes", params: { since, change_type, vendor, vendors, categories, include_expiring: doExpiring, lookahead_days: days }, result_count: changes.changes.length, session_id: getSessionId?.() });
         return {
           content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }],
         };

--- a/test/deal-changes.test.ts
+++ b/test/deal-changes.test.ts
@@ -322,6 +322,88 @@ describe("track_changes tool", () => {
     assert.strictEqual(result.changes[0].vendor, "Netlify");
   });
 
+  it("getDealChanges filters by categories (comma-separated)", async () => {
+    const { getDealChanges } = await import("../dist/data.js");
+
+    // Single category
+    const db = getDealChanges("2024-01-01", undefined, undefined, undefined, "Database");
+    assert.ok(db.total > 0, "Expected at least 1 database change");
+    for (const change of db.changes) {
+      assert.ok(
+        change.category.toLowerCase().includes("database"),
+        `Unexpected category: ${change.category}`
+      );
+    }
+
+    // Multiple categories
+    const multi = getDealChanges("2024-01-01", undefined, undefined, undefined, "Database,Hosting");
+    assert.ok(multi.total >= db.total, "Multiple categories should return at least as many as single");
+    for (const change of multi.changes) {
+      const lower = change.category.toLowerCase();
+      assert.ok(
+        lower.includes("database") || lower.includes("hosting"),
+        `Unexpected category: ${change.category}`
+      );
+    }
+
+    // Nonexistent category
+    const none = getDealChanges("2024-01-01", undefined, undefined, undefined, "nonexistent-category");
+    assert.strictEqual(none.total, 0);
+    assert.deepStrictEqual(none.changes, []);
+  });
+
+  it("getPersonalizedChanges returns stack changes, advisory, and summary", async () => {
+    const { getPersonalizedChanges } = await import("../dist/data.js");
+
+    const result = getPersonalizedChanges("2024-01-01", undefined, undefined, "Netlify,OpenAI");
+    assert.ok(Array.isArray(result.your_stack_changes), "Expected your_stack_changes array");
+    assert.ok(Array.isArray(result.advisory), "Expected advisory array");
+    assert.ok(result.summary, "Expected summary object");
+    assert.ok(typeof result.summary.stack_changes_count === "number");
+    assert.ok(typeof result.summary.ecosystem_high_impact_count === "number");
+    assert.ok(typeof result.summary.period_days === "number");
+
+    // Stack changes should only contain filtered vendors
+    for (const change of result.your_stack_changes) {
+      const lower = change.vendor.toLowerCase();
+      assert.ok(
+        lower.includes("netlify") || lower.includes("openai"),
+        `Stack change has unexpected vendor: ${change.vendor}`
+      );
+    }
+
+    // Advisory should not contain vendors already in stack
+    const stackVendorDates = new Set(
+      result.your_stack_changes.map((c: any) => `${c.vendor}|${c.date}|${c.change_type}`)
+    );
+    for (const change of result.advisory) {
+      assert.ok(
+        !stackVendorDates.has(`${change.vendor}|${change.date}|${change.change_type}`),
+        `Advisory should not duplicate stack changes`
+      );
+    }
+
+    // Advisory limited to 3
+    assert.ok(result.advisory.length <= 3, `Advisory should be max 3, got ${result.advisory.length}`);
+
+    // Summary counts are consistent
+    assert.strictEqual(result.summary.stack_changes_count, result.your_stack_changes.length);
+  });
+
+  it("getPersonalizedChanges with categories filter", async () => {
+    const { getPersonalizedChanges } = await import("../dist/data.js");
+
+    const result = getPersonalizedChanges("2024-01-01", undefined, undefined, undefined, "Database");
+    assert.ok(Array.isArray(result.your_stack_changes));
+    for (const change of result.your_stack_changes) {
+      assert.ok(
+        change.category.toLowerCase().includes("database"),
+        `Expected database category, got: ${change.category}`
+      );
+    }
+    assert.ok(result.summary.stack_changes_count === result.your_stack_changes.length);
+  });
+
   it("every change_type in data matches the tool enum", async () => {
     const VALID_CHANGE_TYPES = new Set([
       "free_tier_removed", "limits_reduced", "restriction", "limits_increased",

--- a/test/http.test.ts
+++ b/test/http.test.ts
@@ -695,18 +695,40 @@ describe("HTTP transport", () => {
     assert.ok(body.error.includes("Invalid"));
   });
 
-  it("GET /api/changes filters by vendors (comma-separated)", async () => {
+  it("GET /api/changes filters by vendors (comma-separated) — personalized response", async () => {
     proc = await startHttpServer();
 
     const response = await fetch(`http://localhost:${serverPort}/api/changes?since=2020-01-01&vendors=Netlify,OpenAI`);
     assert.strictEqual(response.status, 200);
     const body = await response.json() as any;
-    assert.ok(body.total >= 2, `Expected at least 2 changes for Netlify+OpenAI, got ${body.total}`);
-    for (const change of body.changes) {
+    // Personalized response format
+    assert.ok(Array.isArray(body.your_stack_changes), "Expected your_stack_changes array");
+    assert.ok(Array.isArray(body.advisory), "Expected advisory array");
+    assert.ok(body.summary, "Expected summary object");
+    assert.ok(body.your_stack_changes.length >= 2, `Expected at least 2 stack changes for Netlify+OpenAI, got ${body.your_stack_changes.length}`);
+    for (const change of body.your_stack_changes) {
       const vendorLower = change.vendor.toLowerCase();
       assert.ok(
         vendorLower.includes("netlify") || vendorLower.includes("openai"),
         `Unexpected vendor: ${change.vendor}`
+      );
+    }
+    assert.ok(body.advisory.length <= 3, "Advisory should be max 3");
+  });
+
+  it("GET /api/changes filters by categories — personalized response", async () => {
+    proc = await startHttpServer();
+
+    const response = await fetch(`http://localhost:${serverPort}/api/changes?since=2020-01-01&categories=Database`);
+    assert.strictEqual(response.status, 200);
+    const body = await response.json() as any;
+    assert.ok(Array.isArray(body.your_stack_changes), "Expected your_stack_changes array");
+    assert.ok(Array.isArray(body.advisory), "Expected advisory array");
+    assert.ok(body.summary, "Expected summary object");
+    for (const change of body.your_stack_changes) {
+      assert.ok(
+        change.category.toLowerCase().includes("database"),
+        `Unexpected category: ${change.category}`
       );
     }
   });


### PR DESCRIPTION
## Summary

- `track_changes` now accepts optional `vendors` (comma-separated) and `categories` (comma-separated) parameters for personalized change tracking
- When filters are active, returns three-section response: `your_stack_changes`, `advisory` (top 3 high-impact changes outside filter), and `summary` stats
- When no filters provided, behavior is unchanged (backward compatible)
- REST API `/api/changes` also accepts `vendors` and `categories` query params with same personalized response
- MCP Apps timeline UI shows "Your Stack" summary card, blue-bordered personal changes, and collapsible "Also worth knowing" advisory section when filters active
- OpenAPI spec updated with `categories` parameter and `oneOf` response schema documenting both response formats
- 447 tests passing (4 new: category filtering, personalized changes with vendors, personalized changes with categories, HTTP categories endpoint)

Refs #643