### PR TITLE
Fix .mcpb extension crash from unanchored mcpbignore paths

### DIFF
--- a/.mcpbignore
+++ b/.mcpbignore
@@ -1,12 +1,12 @@
-src/
-test/
-scripts/
-data/
+/src/
+/test/
+/scripts/
+/data/
 *.ts
 tsconfig.json
 tsconfig.*.json
 .gitignore
-.github/
+/.github/
 *.test.*
 *.map
 *.d.ts


### PR DESCRIPTION
## Summary
- Fixes a crash-on-startup bug in the Claude Desktop Extension (.mcpb bundle)
- The `src/` rule in `.mcpbignore` was matching `node_modules/@modelcontextprotocol/ext-apps/dist/src/`, stripping the ext-apps JS files from the bundle
- This caused `ERR_MODULE_NOT_FOUND` when the extension tried to load `mcp-apps.js` → ext-apps
- Fix: anchor `src/`, `test/`, `scripts/`, `data/`, `.github/` patterns with leading `/` so they only match at the project root

Refs #645

## Test plan
- [x] `npx @anthropic-ai/mcpb pack .` produces valid bundle with ext-apps files included (was 1 file, now 8+)
- [x] Unpacked bundle starts successfully via stdio (`initialize` → `tools/list` → `tools/call`)
- [x] All 4 tools, 6 prompts confirmed working from unpacked bundle
- [x] 447 existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)