### PR TITLE
Add agent payment protocol indexing (x402 & MPP)

### DIFF
--- a/data/index.json
+++ b/data/index.json
@@ -12,7 +12,10 @@
         "frontend",
         "jamstack"
       ],
-      "verifiedDate": "2026-03-21"
+      "verifiedDate": "2026-03-21",
+      "payment_protocols": [
+        "x402"
+      ]
     },
     {
       "vendor": "Render",
@@ -46,7 +49,10 @@
         "heroku-alternative",
         "vercel-alternative"
       ],
-      "verifiedDate": "2026-03-22"
+      "verifiedDate": "2026-03-22",
+      "payment_protocols": [
+        "x402"
+      ]
     },
     {
       "vendor": "Netlify",
@@ -78,7 +84,10 @@
         "deployment",
         "vercel-alternative"
       ],
-      "verifiedDate": "2026-04-05"
+      "verifiedDate": "2026-04-05",
+      "payment_protocols": [
+        "x402"
+      ]
     },
     {
       "vendor": "Railway",
@@ -460,7 +469,10 @@
         "free tier",
         "mongodb-alternative"
       ],
-      "verifiedDate": "2026-04-05"
+      "verifiedDate": "2026-04-05",
+      "payment_protocols": [
+        "x402"
+      ]
     },
     {
       "vendor": "Nhost",
@@ -892,7 +904,10 @@
         "cdn",
         "free tier"
       ],
-      "verifiedDate": "2026-03-14"
+      "verifiedDate": "2026-03-14",
+      "payment_protocols": [
+        "x402"
+      ]
     },
     {
       "vendor": "Backblaze B2",
@@ -968,7 +983,10 @@
         "cloudflare",
         "free tier"
       ],
-      "verifiedDate": "2026-03-21"
+      "verifiedDate": "2026-03-21",
+      "payment_protocols": [
+        "x402"
+      ]
     },
     {
       "vendor": "Cloudflare KV",
@@ -983,7 +1001,10 @@
         "cloudflare",
         "free tier"
       ],
-      "verifiedDate": "2026-03-21"
+      "verifiedDate": "2026-03-21",
+      "payment_protocols": [
+        "x402"
+      ]
     },
     {
       "vendor": "Cloudflare Durable Objects",
@@ -999,7 +1020,10 @@
         "websocket",
         "free tier"
       ],
-      "verifiedDate": "2026-03-21"
+      "verifiedDate": "2026-03-21",
+      "payment_protocols": [
+        "x402"
+      ]
     },
     {
       "vendor": "QStash",
@@ -1080,7 +1104,10 @@
         "crawling",
         "free tier"
       ],
-      "verifiedDate": "2026-03-20"
+      "verifiedDate": "2026-03-20",
+      "payment_protocols": [
+        "x402"
+      ]
     },
     {
       "vendor": "Apify",
@@ -1240,7 +1267,10 @@
         "ssl",
         "free tier"
       ],
-      "verifiedDate": "2026-03-14"
+      "verifiedDate": "2026-03-14",
+      "payment_protocols": [
+        "x402"
+      ]
     },
     {
       "vendor": "Hurricane Electric DNS",
@@ -1547,7 +1577,10 @@
         "serverless",
         "free tier"
       ],
-      "verifiedDate": "2026-04-05"
+      "verifiedDate": "2026-04-05",
+      "payment_protocols": [
+        "x402"
+      ]
     },
     {
       "vendor": "PostHog",
@@ -14509,7 +14542,10 @@
         "media",
         "free-for-dev"
       ],
-      "verifiedDate": "2026-03-20"
+      "verifiedDate": "2026-03-20",
+      "payment_protocols": [
+        "x402"
+      ]
     },
     {
       "vendor": "plot.ly",

--- a/src/api-client.ts
+++ b/src/api-client.ts
@@ -51,6 +51,7 @@ export async function fetchOffers(params: {
   eligibility_type?: string;
   sort?: string;
   stability?: string;
+  payment_protocol?: string;
   limit?: number;
   offset?: number;
 }): Promise<unknown> {
@@ -60,6 +61,7 @@ export async function fetchOffers(params: {
   if (params.eligibility_type) p.eligibility_type = params.eligibility_type;
   if (params.sort) p.sort = params.sort;
   if (params.stability) p.stability = params.stability;
+  if (params.payment_protocol) p.payment_protocol = params.payment_protocol;
   if (params.limit !== undefined) p.limit = String(params.limit);
   if (params.offset !== undefined) p.offset = String(params.offset);
   return apiFetch("/api/offers", p);

--- a/src/data.ts
+++ b/src/data.ts
@@ -140,7 +140,8 @@ export function searchOffers(
   category?: string,
   eligibilityType?: string,
   sort?: string,
-  stability?: StabilityClass
+  stability?: StabilityClass,
+  paymentProtocol?: string
 ): Offer[] {
   let results = loadOffers();
 
@@ -162,6 +163,13 @@ export function searchOffers(
     const stabilityMap = getStabilityMap();
     results = results.filter(
       (o) => (stabilityMap.get(o.vendor.toLowerCase()) ?? "stable") === stability
+    );
+  }
+
+  if (paymentProtocol) {
+    const lowerProto = paymentProtocol.toLowerCase();
+    results = results.filter(
+      (o) => o.payment_protocols?.some(p => p.toLowerCase() === lowerProto) ?? false
     );
   }
 

--- a/src/serve.ts
+++ b/src/serve.ts
@@ -5528,6 +5528,15 @@ const ALTERNATIVES_PAGES: AlternativesPageConfig[] = [
     primaryVendor: "AgentDeals",
     hubDesc: "Living tracker of developer tool shutdowns, API sunsets, and deprecation deadlines in 2026 — with migration paths and alternatives",
   },
+  {
+    slug: "agent-payments",
+    title: "Developer Services That Accept Agent Payments (2026) — x402 & MPP Directory",
+    metaDesc: "Directory of developer services accepting autonomous AI agent payments via x402 and Stripe MPP. Firecrawl, Cloudflare, Vercel, Pinata and more. Per-call pricing, free tiers, and integration guides.",
+    contextHtml: "",
+    tag: "agent-payments",
+    primaryVendor: "Cloudflare",
+    hubDesc: "Directory of developer services accepting AI agent payments via x402 and Stripe MPP — per-call pricing, free tiers, and protocol comparison",
+  },
 ];
 
 const alternativesPageMap = new Map<string, AlternativesPageConfig>();
@@ -27973,6 +27982,263 @@ function buildDatabasePricingPage(): string {
     '</body>\n</html>';
 }
 
+// --- Agent Payments page ---
+
+function buildAgentPaymentsPage(): string {
+  const title = "Developer Services That Accept Agent Payments (2026) — x402 & MPP Directory";
+  const metaDesc = "Directory of developer services accepting autonomous AI agent payments via x402 and Stripe MPP. Firecrawl, Cloudflare, Vercel, Pinata and more. Per-call pricing, free tiers, and integration guides.";
+  const slug = "agent-payments";
+  const pubDate = "2026-04-09";
+
+  // Get all offers with payment_protocols
+  const x402Offers = offers.filter(o => o.payment_protocols?.includes("x402"));
+  const mppOffers = offers.filter(o => o.payment_protocols?.includes("mpp"));
+  const allPaymentOffers = offers.filter(o => o.payment_protocols && o.payment_protocols.length > 0);
+
+  // Group x402 offers by category
+  const x402ByCategory = new Map<string, typeof x402Offers>();
+  for (const o of x402Offers) {
+    const cat = o.category;
+    if (!x402ByCategory.has(cat)) x402ByCategory.set(cat, []);
+    x402ByCategory.get(cat)!.push(o);
+  }
+
+  const jsonLd = {
+    "@context": "https://schema.org",
+    "@type": "Article",
+    headline: title,
+    description: metaDesc,
+    url: `${BASE_URL}/${slug}`,
+    datePublished: pubDate,
+    dateModified: new Date().toISOString().slice(0, 10),
+    author: { "@type": "Organization", name: "AgentDeals", url: BASE_URL },
+  };
+
+  const faqItems = [
+    { q: "What is the x402 payment protocol?", a: "x402 is an open HTTP-native payment protocol that uses the HTTP 402 status code to enable machine-to-machine payments. Launched by the x402 Foundation (Linux Foundation) in April 2026 with backing from Stripe, Cloudflare, Shopify, Visa, and Mastercard. It allows AI agents to autonomously pay for API calls without pre-provisioned accounts or API keys." },
+    { q: "Which developer services accept x402 payments?", a: `Currently ${x402Offers.length} developer services indexed on AgentDeals accept x402 payments, including Firecrawl (web scraping), Cloudflare Workers/Pages/D1/R2/KV (cloud infrastructure), Vercel (hosting), and Pinata IPFS (storage). The ecosystem is growing rapidly with 130+ services industry-wide.` },
+    { q: "What is Stripe MPP (Machine-to-Machine Payments)?", a: "MPP (Machine Payments Protocol) is Stripe's framework for agent-to-service payments launched March 2026. It builds on Stripe's existing payment infrastructure to add agent identity, budget controls, and audit trails. MPP uses familiar Stripe APIs, making adoption simpler for services already using Stripe." },
+    { q: "How do AI agents pay for services autonomously?", a: "Agents use payment protocols like x402 or MPP to negotiate and complete payments in real-time. With x402, the agent receives a 402 response with payment requirements, completes the crypto payment, and retries with proof of payment. With MPP, agents use Stripe-managed wallets with configurable spending limits." },
+    { q: "Do x402 services still have free tiers?", a: `Yes. All ${x402Offers.length} x402-enabled services indexed here also offer traditional free tiers. x402 is an additional payment option — it doesn't replace free tier access. Agents can use free tiers first and fall back to x402 when limits are exceeded.` },
+  ];
+
+  const faqJsonLd = {
+    "@context": "https://schema.org",
+    "@type": "FAQPage",
+    mainEntity: faqItems.map(f => ({
+      "@type": "Question",
+      name: f.q,
+      acceptedAnswer: { "@type": "Answer", text: f.a },
+    })),
+  };
+
+  // Build the service table rows
+  const serviceRows = x402Offers.map(o => {
+    const vendorSlug = toSlug(o.vendor);
+    const shortDesc = o.description.split(". ")[0].substring(0, 120);
+    return `<tr>
+      <td><a href="/vendor/${vendorSlug}" class="vendor-link">${escHtmlServer(o.vendor)}</a></td>
+      <td>${escHtmlServer(o.category)}</td>
+      <td class="proto-cell"><span class="proto-badge x402">x402</span></td>
+      <td class="tier-cell">${escHtmlServer(o.tier)}</td>
+      <td class="desc-cell">${escHtmlServer(shortDesc)}</td>
+    </tr>`;
+  }).join("\n");
+
+  // Build category breakdown sections
+  const categorySections = Array.from(x402ByCategory.entries()).sort((a, b) => b[1].length - a[1].length).map(([cat, catOffers]) => {
+    const catSlug = toSlug(cat);
+    const serviceList = catOffers.map(o => {
+      const vendorSlug = toSlug(o.vendor);
+      const shortDesc = o.description.split(". ")[0].substring(0, 100);
+      return `<div class="service-card">
+        <div class="service-header">
+          <a href="/vendor/${vendorSlug}" class="vendor-link">${escHtmlServer(o.vendor)}</a>
+          <span class="proto-badge x402">x402</span>
+        </div>
+        <p class="service-tier">${escHtmlServer(o.tier)}</p>
+        <p class="service-desc">${escHtmlServer(shortDesc)}</p>
+      </div>`;
+    }).join("\n");
+    return `<div class="category-group">
+      <h3><a href="/category/${catSlug}">${escHtmlServer(cat)}</a> <span class="count">${catOffers.length} service${catOffers.length === 1 ? "" : "s"}</span></h3>
+      <div class="service-grid">${serviceList}</div>
+    </div>`;
+  }).join("\n");
+
+  const faqHtml = faqItems.map(f => `<details class="faq-item">
+    <summary>${escHtmlServer(f.q)}</summary>
+    <p>${escHtmlServer(f.a)}</p>
+  </details>`).join("\n");
+
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>${escHtmlServer(title)}</title>
+<meta name="description" content="${escHtmlServer(metaDesc)}">
+<link rel="canonical" href="${BASE_URL}/${slug}">
+<meta property="og:title" content="${escHtmlServer(title)}">
+<meta property="og:description" content="${escHtmlServer(metaDesc)}">
+<meta property="og:type" content="article">
+<meta property="og:url" content="${BASE_URL}/${slug}">
+${OG_IMAGE_META}${GOOGLE_VERIFICATION_META}<link rel="icon" type="image/png" href="/favicon.png">
+<link rel="alternate" type="application/atom+xml" title="AgentDeals — Pricing Changes" href="/feed.xml">
+<link rel="preconnect" href="https://fonts.googleapis.com"><link rel="preconnect" href="https://fonts.gstatic.com" crossorigin><link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
+<script type="application/ld+json">${JSON.stringify(jsonLd)}</script>
+<script type="application/ld+json">${JSON.stringify(faqJsonLd)}</script>
+<style>
+*{margin:0;padding:0;box-sizing:border-box}
+:root{--bg:#0f172a;--bg-elevated:#1e293b;--bg-card:rgba(255,255,255,0.06);--border:#334155;--border-hover:#3b82f6;--text:#f1f5f9;--text-muted:#94a3b8;--text-dim:#64748b;--accent:#3b82f6;--accent-hover:#60a5fa;--accent-glow:rgba(59,130,246,0.15);--purple:#8b5cf6;--purple-glow:rgba(139,92,246,0.15);--green:#10b981;--green-glow:rgba(16,185,129,0.15);--serif:'Inter',-apple-system,sans-serif;--sans:'Inter',-apple-system,sans-serif;--mono:'JetBrains Mono',SFMono-Regular,monospace}
+body{font-family:var(--sans);background:var(--bg);color:var(--text);line-height:1.6}
+a{color:var(--accent);text-decoration:none}a:hover{color:var(--accent-hover);text-decoration:underline}
+.container{max-width:960px;margin:0 auto;padding:0 1.5rem}
+.breadcrumb{padding:1.5rem 0 0;font-size:.8rem;color:var(--text-dim)}
+.breadcrumb a{color:var(--text-muted)}
+h1{font-family:var(--serif);font-size:2rem;color:var(--text);margin:1rem 0 .5rem;letter-spacing:-.02em}
+h2{font-family:var(--serif);font-size:1.3rem;color:var(--text);margin:2rem 0 1rem}
+h3{font-family:var(--serif);font-size:1.1rem;color:var(--text);margin:0}
+.page-intro{color:var(--text-muted);font-size:.95rem;margin-bottom:2rem;max-width:640px}
+.stats-row{display:flex;gap:1rem;margin-bottom:2rem;flex-wrap:wrap}
+.stat-card{background:var(--bg-card);border:1px solid var(--border);border-radius:10px;padding:1rem 1.25rem;flex:1;min-width:140px}
+.stat-value{font-family:var(--mono);font-size:1.5rem;font-weight:700;color:var(--accent)}
+.stat-label{font-size:.8rem;color:var(--text-dim);margin-top:.25rem}
+.proto-section{background:var(--bg-card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;margin-bottom:1.5rem}
+.proto-header{display:flex;align-items:center;gap:.75rem;margin-bottom:.75rem}
+.proto-icon{width:36px;height:36px;border-radius:8px;display:flex;align-items:center;justify-content:center;font-weight:700;font-size:.8rem;font-family:var(--mono)}
+.proto-icon.x402{background:var(--accent-glow);color:var(--accent);border:1px solid rgba(59,130,246,0.3)}
+.proto-icon.mpp{background:var(--purple-glow);color:var(--purple);border:1px solid rgba(139,92,246,0.3)}
+.proto-desc{color:var(--text-muted);font-size:.9rem;line-height:1.5}
+.proto-meta{display:flex;gap:1.5rem;margin-top:.75rem;font-size:.8rem;color:var(--text-dim)}
+table{width:100%;border-collapse:collapse;margin:1.5rem 0}
+th{text-align:left;font-family:var(--mono);font-size:.7rem;color:var(--text-dim);text-transform:uppercase;letter-spacing:.1em;padding:.5rem .75rem;border-bottom:1px solid var(--border)}
+td{padding:.5rem .75rem;font-size:.85rem;color:var(--text-muted);border-bottom:1px solid rgba(51,65,85,0.5)}
+.vendor-link{color:var(--accent);font-weight:500}
+.proto-badge{display:inline-block;padding:.15rem .5rem;border-radius:4px;font-family:var(--mono);font-size:.7rem;font-weight:600}
+.proto-badge.x402{background:var(--accent-glow);color:var(--accent);border:1px solid rgba(59,130,246,0.3)}
+.proto-badge.mpp{background:var(--purple-glow);color:var(--purple);border:1px solid rgba(139,92,246,0.3)}
+.proto-cell{white-space:nowrap}
+.tier-cell{max-width:150px}
+.desc-cell{max-width:200px;color:var(--text-dim);font-size:.8rem}
+.category-group{margin-bottom:1.5rem}
+.category-group h3{display:flex;align-items:center;gap:.5rem;margin-bottom:.75rem}
+.category-group .count{font-size:.75rem;color:var(--text-dim);font-weight:400;font-family:var(--mono)}
+.service-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(280px,1fr));gap:.75rem}
+.service-card{background:var(--bg-card);border:1px solid var(--border);border-radius:8px;padding:1rem;transition:border-color .2s}
+.service-card:hover{border-color:var(--border-hover)}
+.service-header{display:flex;justify-content:space-between;align-items:center;margin-bottom:.5rem}
+.service-tier{font-size:.8rem;color:var(--green);margin-bottom:.25rem}
+.service-desc{font-size:.8rem;color:var(--text-dim)}
+.why-section{background:var(--bg-card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;margin:1.5rem 0}
+.why-section h3{margin-bottom:.75rem}
+.why-list{list-style:none;padding:0}
+.why-list li{padding:.5rem 0;border-bottom:1px solid rgba(51,65,85,0.3);color:var(--text-muted);font-size:.9rem}
+.why-list li:last-child{border-bottom:none}
+.why-list li strong{color:var(--text)}
+.faq-item{border:1px solid var(--border);border-radius:8px;margin-bottom:.5rem;background:var(--bg-card)}
+.faq-item summary{padding:.75rem 1rem;cursor:pointer;font-weight:500;font-size:.9rem;color:var(--text)}
+.faq-item summary:hover{color:var(--accent)}
+.faq-item p{padding:0 1rem .75rem;color:var(--text-muted);font-size:.85rem;line-height:1.6}
+.search-cta{margin:2rem 0;padding:1.25rem;background:var(--bg-card);border:1px solid var(--border);border-radius:10px;text-align:center;color:var(--text-muted);font-size:.9rem}
+.search-cta a{font-weight:500}
+${globalNavCss()}
+.mcp-cta{margin:2rem 0;padding:1.5rem;background:linear-gradient(135deg,var(--accent-glow),var(--purple-glow));border:1px solid var(--border);border-radius:12px}
+.mcp-cta h3{font-size:1rem;margin-bottom:.5rem}
+.mcp-cta .cta-value{color:var(--text-muted);font-size:.85rem;margin-bottom:.75rem}
+.mcp-cta .cta-install{display:flex;align-items:center;gap:.5rem;background:var(--bg);padding:.5rem .75rem;border-radius:8px;font-family:var(--mono);font-size:.8rem;overflow-x:auto}
+.mcp-cta .cta-install code{flex:1;color:var(--text)}
+.mcp-cta .copy-btn{background:var(--accent);color:#fff;border:none;padding:.3rem .6rem;border-radius:4px;cursor:pointer;font-size:.75rem;flex-shrink:0}
+.mcp-cta .copy-btn.copied{background:var(--green)}
+.mcp-cta .cta-links{margin-top:.5rem;font-size:.8rem;color:var(--text-dim)}
+@media(max-width:640px){.stats-row{flex-direction:column}.service-grid{grid-template-columns:1fr}table{font-size:.75rem}.desc-cell{display:none}}
+</style>
+</head>
+<body>
+<div class="container">
+  ${buildGlobalNav("guides")}
+  <div class="breadcrumb"><a href="/">AgentDeals</a> &rsaquo; <a href="/guides">Guides</a> &rsaquo; Agent Payments</div>
+  <h1>Developer Services That Accept Agent Payments</h1>
+  <p class="page-intro">AI agents can now pay for API calls autonomously. This directory tracks which developer services accept payments via x402 (HTTP 402 protocol) and Stripe MPP (Machine Payments Protocol) &mdash; the two leading standards for machine-to-machine payments.</p>
+
+  <div class="stats-row">
+    <div class="stat-card"><div class="stat-value">${allPaymentOffers.length}</div><div class="stat-label">Services indexed</div></div>
+    <div class="stat-card"><div class="stat-value">${x402Offers.length}</div><div class="stat-label">x402 services</div></div>
+    <div class="stat-card"><div class="stat-value">${mppOffers.length}</div><div class="stat-label">MPP services</div></div>
+    <div class="stat-card"><div class="stat-value">${x402ByCategory.size}</div><div class="stat-label">Categories</div></div>
+  </div>
+
+  <h2>Payment Protocols</h2>
+
+  <div class="proto-section">
+    <div class="proto-header">
+      <div class="proto-icon x402">402</div>
+      <div>
+        <h3>x402 &mdash; HTTP Native Agent Payments</h3>
+        <div class="proto-meta"><span>Linux Foundation</span><span>Launched April 2026</span><span>130+ services</span></div>
+      </div>
+    </div>
+    <p class="proto-desc">x402 uses the HTTP 402 &ldquo;Payment Required&rdquo; status code to enable pay-per-call API access. When an agent hits a 402 response, it reads the payment requirements from the response headers, completes the payment (typically via stablecoin on Base), and retries the request with proof of payment. No accounts or API keys needed &mdash; just a wallet. Founded by Coinbase with backing from Stripe, Cloudflare, Shopify, Visa, and Mastercard.</p>
+  </div>
+
+  <div class="proto-section">
+    <div class="proto-header">
+      <div class="proto-icon mpp">MPP</div>
+      <div>
+        <h3>MPP &mdash; Stripe Machine Payments Protocol</h3>
+        <div class="proto-meta"><span>Stripe</span><span>Launched March 2026</span><span>100+ integrations</span></div>
+      </div>
+    </div>
+    <p class="proto-desc">Stripe&rsquo;s Machine Payments Protocol (MPP) extends Stripe&rsquo;s payment infrastructure for agent-to-service transactions. MPP adds agent identity verification, configurable spending limits, budget controls, and full audit trails. Built on familiar Stripe APIs, making adoption straightforward for services already using Stripe for billing. Agents pay with Stripe-managed wallets rather than crypto.</p>
+  </div>
+
+  <h2>x402-Enabled Services</h2>
+  <p style="color:var(--text-muted);font-size:.9rem;margin-bottom:1rem">${x402Offers.length} developer services accepting autonomous agent payments via x402.</p>
+
+  <div style="overflow-x:auto">
+  <table>
+    <thead><tr><th>Service</th><th>Category</th><th>Protocol</th><th>Free Tier</th><th>Details</th></tr></thead>
+    <tbody>
+${serviceRows}
+    </tbody>
+  </table>
+  </div>
+
+  <h2>Services by Category</h2>
+${categorySections}
+
+  <div class="why-section">
+    <h3>Why Agent Payments Matter</h3>
+    <ul class="why-list">
+      <li><strong>No pre-provisioned accounts.</strong> Agents can access any x402-enabled API instantly &mdash; no signup, no API key management, no billing configuration.</li>
+      <li><strong>Pay-per-call economics.</strong> Agents pay only for what they use, at per-request granularity. No monthly minimums or commitment tiers.</li>
+      <li><strong>Autonomous operation.</strong> Agents can discover, negotiate, and pay for services without human intervention &mdash; enabling truly autonomous workflows.</li>
+      <li><strong>Budget controls.</strong> Both x402 (wallet limits) and MPP (Stripe controls) provide guardrails to prevent runaway spending.</li>
+      <li><strong>Free tier fallback.</strong> All services listed here also offer traditional free tiers. Agents can use free tiers first and fall back to paid access when limits are exceeded.</li>
+    </ul>
+  </div>
+
+  <h2>Frequently Asked Questions</h2>
+${faqHtml}
+
+  <div class="search-cta">
+    <p>Filter services by payment protocol: <a href="/api/offers?payment_protocol=x402">/api/offers?payment_protocol=x402</a> &middot; Or use the <code>search_deals</code> MCP tool with <code>payment_protocol: "x402"</code></p>
+  </div>
+
+  ${buildMoreAlternativesGuides(slug)}
+
+  ${buildMcpCta("Search for agent-payment-enabled services, compare pricing, and build autonomous stacks \u2014 directly in your AI editor.")}
+
+  <footer style="text-align:center;padding:2rem 0;color:var(--text-dim);font-size:.8rem;border-top:1px solid var(--border);margin-top:2rem">
+    <p>Data verified ${pubDate}. ${offers.length.toLocaleString()} total offers indexed.</p>
+    <p style="margin-top:.5rem"><a href="/">AgentDeals</a> &middot; <a href="/agent-stack">Agent Stacks</a> &middot; <a href="/guides">Guides</a> &middot; <a href="/changes">Changes</a></p>
+  </footer>
+</div>
+<script>${mcpCtaScript()}</script>
+</body>
+</html>`;
+}
+
 // --- AWS Free Tier 2026 guide page ---
 
 function buildAwsFreeTier2026Page(): string {
@@ -46547,9 +46813,11 @@ const httpServer = createHttpServer(async (req, res) => {
     const validStability = stabilityParam && ["stable", "watch", "volatile", "improving"].includes(stabilityParam)
       ? stabilityParam as import("./types.js").StabilityClass
       : undefined;
+    const paymentProtocol = url.searchParams.get("payment_protocol") || undefined;
+    const validPaymentProtocol = paymentProtocol && ["x402", "mpp"].includes(paymentProtocol) ? paymentProtocol : undefined;
     const limit = parseInt(url.searchParams.get("limit") ?? "20", 10);
     const offset = parseInt(url.searchParams.get("offset") ?? "0", 10);
-    const results = searchOffers(q, category, eligibilityType, sort, validStability);
+    const results = searchOffers(q, category, eligibilityType, sort, validStability, validPaymentProtocol);
     const total = results.length;
     const paged = enrichOffers(results.slice(offset, offset + limit));
     logRequest({ ts: new Date().toISOString(), type: "api", endpoint: "/api/offers", params: { q, category, limit, offset }, user_agent: req.headers["user-agent"] ?? "unknown", result_count: paged.length });
@@ -47632,6 +47900,11 @@ ${Array.from(vendorSlugMap.keys()).map(s => {
     logRequest({ ts: new Date().toISOString(), type: "api", endpoint: "/database-pricing", params: {}, user_agent: req.headers["user-agent"] ?? "unknown", result_count: 1 });
     res.writeHead(200, { "Content-Type": "text/html; charset=utf-8", "Cache-Control": "public, max-age=3600" });
     res.end(buildDatabasePricingPage());
+  } else if (url.pathname === "/agent-payments" && isGetOrHead) {
+    recordApiHit("/agent-payments");
+    logRequest({ ts: new Date().toISOString(), type: "api", endpoint: "/agent-payments", params: {}, user_agent: req.headers["user-agent"] ?? "unknown", result_count: 1 });
+    res.writeHead(200, { "Content-Type": "text/html; charset=utf-8", "Cache-Control": "public, max-age=3600" });
+    res.end(buildAgentPaymentsPage());
   } else if (url.pathname === "/aws-free-tier-2026" && isGetOrHead) {
     recordApiHit("/aws-free-tier-2026");
     logRequest({ ts: new Date().toISOString(), type: "api", endpoint: "/aws-free-tier-2026", params: {}, user_agent: req.headers["user-agent"] ?? "unknown", result_count: 1 });

--- a/src/server-remote.ts
+++ b/src/server-remote.ts
@@ -80,13 +80,14 @@ export function createServer(): McpServer {
         eligibility: z.enum(["public", "accelerator", "oss", "student", "fintech", "geographic", "enterprise"]).optional().describe("Filter by eligibility type"),
         sort: z.enum(["vendor", "category", "newest"]).optional().describe("Sort: vendor (A-Z), category, newest (recently verified first)"),
         stability: z.enum(["stable", "watch", "volatile", "improving"]).optional().describe("Filter by free tier stability class. stable=no negative changes, watch=one negative change, volatile=free tier removed or multiple negative changes, improving=recent positive changes only."),
+        payment_protocol: z.enum(["x402", "mpp"]).optional().describe("Filter by agent payment protocol. x402=HTTP 402 agent payments (Coinbase/Linux Foundation standard), mpp=Stripe Machine-to-Machine Payments."),
         since: z.string().optional().describe("ISO date (YYYY-MM-DD). Only return deals verified/added after this date."),
         limit: z.number().optional().describe("Max results (default: 20)"),
         offset: z.number().optional().describe("Pagination offset (default: 0)"),
         response_format: z.enum(["concise", "detailed"]).optional().describe("Response detail level. 'concise': vendor name, tier, one-line description, URL only. 'detailed': full response (default)."),
       },
     },
-    async ({ query, category, vendor, eligibility, sort, stability, since, limit, offset, response_format }) => {
+    async ({ query, category, vendor, eligibility, sort, stability, payment_protocol, since, limit, offset, response_format }) => {
       try {
         // Mode: list categories
         if (category === "list") {
@@ -124,6 +125,7 @@ export function createServer(): McpServer {
           eligibility_type: eligibility,
           sort,
           stability,
+          payment_protocol,
           limit: effectiveLimit,
           offset: effectiveOffset,
         }) as { offers: Record<string, unknown>[]; total: number };

--- a/src/server.ts
+++ b/src/server.ts
@@ -42,13 +42,14 @@ export function createServer(getSessionId?: () => string | undefined): McpServer
         eligibility: z.enum(["public", "accelerator", "oss", "student", "fintech", "geographic", "enterprise"]).optional().describe("Filter by eligibility type"),
         sort: z.enum(["vendor", "category", "newest"]).optional().describe("Sort: vendor (A-Z), category, newest (recently verified first)"),
         stability: z.enum(["stable", "watch", "volatile", "improving"]).optional().describe("Filter by free tier stability class. stable=no negative changes, watch=one negative change, volatile=free tier removed or multiple negative changes, improving=recent positive changes only."),
+        payment_protocol: z.enum(["x402", "mpp"]).optional().describe("Filter by agent payment protocol. x402=HTTP 402 agent payments (Coinbase/Linux Foundation standard), mpp=Stripe Machine-to-Machine Payments."),
         since: z.string().optional().describe("ISO date (YYYY-MM-DD). Only return deals verified/added after this date."),
         limit: z.number().optional().describe("Max results (default: 20)"),
         offset: z.number().optional().describe("Pagination offset (default: 0)"),
         response_format: z.enum(["concise", "detailed"]).optional().describe("Response detail level. 'concise': vendor name, tier, one-line description, URL only. 'detailed': full response (default)."),
       },
     },
-    async ({ query, category, vendor, eligibility, sort, stability, since, limit, offset, response_format }) => {
+    async ({ query, category, vendor, eligibility, sort, stability, payment_protocol, since, limit, offset, response_format }) => {
       try {
         recordToolCall("search_deals");
 
@@ -90,7 +91,7 @@ export function createServer(getSessionId?: () => string | undefined): McpServer
         }
 
         // Mode: search/browse
-        const allResults = searchOffers(query, category, eligibility, sort, stability);
+        const allResults = searchOffers(query, category, eligibility, sort, stability, payment_protocol);
         const total = allResults.length;
         const effectiveOffset = offset ?? 0;
         const effectiveLimit = limit ?? 20;

--- a/src/types.ts
+++ b/src/types.ts
@@ -14,6 +14,7 @@ export interface Offer {
   verifiedDate: string;
   eligibility?: Eligibility;
   expires_date?: string;
+  payment_protocols?: string[];
 }
 
 export type StabilityClass = "stable" | "watch" | "volatile" | "improving";

--- a/test/payment-protocols.test.ts
+++ b/test/payment-protocols.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, before, after } from "node:test";
+import assert from "node:assert";
+import { spawn, type ChildProcess } from "node:child_process";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+let serverPort = 0;
+
+function startHttpServer(): Promise<ChildProcess> {
+  return new Promise((resolve, reject) => {
+    const serverPath = path.join(__dirname, "..", "dist", "serve.js");
+    const proc = spawn("node", [serverPath], {
+      stdio: ["pipe", "pipe", "pipe"],
+      env: { ...process.env, PORT: "0", BASE_URL: "http://localhost" },
+    });
+
+    const timeout = setTimeout(() => {
+      proc.kill();
+      reject(new Error("Server startup timeout"));
+    }, 5000);
+
+    proc.stderr!.on("data", (data: Buffer) => {
+      const match = data.toString().match(/running on http:\/\/localhost:(\d+)/);
+      if (match) {
+        serverPort = parseInt(match[1], 10);
+        clearTimeout(timeout);
+        resolve(proc);
+      }
+    });
+
+    proc.on("error", (err) => {
+      clearTimeout(timeout);
+      reject(err);
+    });
+  });
+}
+
+describe("payment protocol features", () => {
+  let server: ChildProcess;
+
+  before(async () => {
+    server = await startHttpServer();
+  });
+
+  after(() => {
+    server.kill();
+  });
+
+  it("GET /api/offers?payment_protocol=x402 returns only x402 offers", async () => {
+    const res = await fetch(`http://localhost:${serverPort}/api/offers?payment_protocol=x402&limit=100`);
+    assert.strictEqual(res.status, 200);
+    const data = await res.json() as { offers: { vendor: string; payment_protocols?: string[] }[]; total: number };
+    assert.ok(data.total > 0, "Should have x402 offers");
+    for (const offer of data.offers) {
+      assert.ok(
+        offer.payment_protocols?.includes("x402"),
+        `${offer.vendor} should have x402 in payment_protocols`
+      );
+    }
+  });
+
+  it("GET /api/offers?payment_protocol=mpp returns empty (no MPP vendors yet)", async () => {
+    const res = await fetch(`http://localhost:${serverPort}/api/offers?payment_protocol=mpp&limit=100`);
+    assert.strictEqual(res.status, 200);
+    const data = await res.json() as { offers: unknown[]; total: number };
+    assert.strictEqual(data.total, 0, "No MPP offers expected yet");
+  });
+
+  it("GET /api/offers without payment_protocol returns all offers", async () => {
+    const res = await fetch(`http://localhost:${serverPort}/api/offers?limit=5`);
+    assert.strictEqual(res.status, 200);
+    const data = await res.json() as { offers: unknown[]; total: number };
+    assert.ok(data.total > 12, "Should return more than just x402 offers");
+  });
+
+  it("GET /agent-payments returns 200 with correct content", async () => {
+    const res = await fetch(`http://localhost:${serverPort}/agent-payments`);
+    assert.strictEqual(res.status, 200);
+    const html = await res.text();
+    assert.ok(html.includes("Agent Payments"), "Page should contain title");
+    assert.ok(html.includes("x402"), "Page should mention x402 protocol");
+    assert.ok(html.includes("MPP"), "Page should mention MPP protocol");
+    assert.ok(html.includes("Firecrawl"), "Page should list Firecrawl");
+    assert.ok(html.includes("Cloudflare"), "Page should list Cloudflare");
+    assert.ok(html.includes("application/ld+json"), "Page should have JSON-LD");
+    assert.ok(html.includes("FAQPage"), "Page should have FAQ schema");
+  });
+
+  it("GET /agent-payments is in sitemap", async () => {
+    const res = await fetch(`http://localhost:${serverPort}/sitemap.xml`);
+    const xml = await res.text();
+    assert.ok(xml.includes("/agent-payments"), "Sitemap should include /agent-payments");
+  });
+
+  it("x402 offers include known vendors", async () => {
+    const res = await fetch(`http://localhost:${serverPort}/api/offers?payment_protocol=x402&limit=100`);
+    const data = await res.json() as { offers: { vendor: string }[]; total: number };
+    const vendors = data.offers.map(o => o.vendor);
+    assert.ok(vendors.includes("Firecrawl"), "x402 should include Firecrawl");
+    assert.ok(vendors.includes("Cloudflare Workers"), "x402 should include Cloudflare Workers");
+    assert.ok(vendors.includes("Vercel"), "x402 should include Vercel");
+    assert.ok(vendors.includes("Pinata IPFS"), "x402 should include Pinata IPFS");
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `payment_protocols` optional field to Offer schema (supports `x402` and `mpp` values)
- Enriches 12 verified vendor entries with x402 payment protocol data: Firecrawl, Pinata IPFS, Cloudflare (Workers, Pages, D1, R2, KV, DNS, Workers AI, Queues, Durable Objects), and Vercel
- Adds `payment_protocol` filter parameter to `search_deals` MCP tool and `/api/offers` REST endpoint
- Builds `/agent-payments` content page: protocol explainers (x402 & MPP), service directory table, category breakdown, FAQ with Schema.org markup, dual JSON-LD (Article + FAQPage)
- Page registered in ALTERNATIVES_PAGES for automatic sitemap inclusion and guides index listing
- 6 new tests, 486 total passing

Refs #698