### PR TITLE
Add /auth-pricing redirect to existing auth comparison page

### DIFF
--- a/src/serve.ts
+++ b/src/serve.ts
@@ -46559,8 +46559,8 @@ const httpServer = createHttpServer(async (req, res) => {
     return;
   }
 
-  // Auth comparison alias — redirect old slug to new canonical
-  if (url.pathname === "/auth-free-tier-comparison-2026" && isGetOrHead) {
+  // Auth comparison aliases — redirect old/short slugs to canonical
+  if ((url.pathname === "/auth-free-tier-comparison-2026" || url.pathname === "/auth-pricing" || url.pathname === "/auth-identity-pricing") && isGetOrHead) {
     res.writeHead(301, { Location: "/auth-comparison-2026" });
     res.end();
     return;

--- a/test/http.test.ts
+++ b/test/http.test.ts
@@ -4018,6 +4018,14 @@ describe("HTTP transport", () => {
     assert.ok(response.headers.get("location")?.includes("/auth-comparison-2026"), "Should redirect to new slug");
   });
 
+  it("GET /auth-pricing redirects to /auth-comparison-2026", async () => {
+    proc = await startHttpServer();
+
+    const response = await fetch(`http://localhost:${serverPort}/auth-pricing`, { redirect: "manual" });
+    assert.strictEqual(response.status, 301);
+    assert.ok(response.headers.get("location")?.includes("/auth-comparison-2026"), "Should redirect /auth-pricing to canonical auth comparison");
+  });
+
   it("GET /storage-comparison-2026 renders expanded storage and CDN comparison page", async () => {
     proc = await startHttpServer();
 


### PR DESCRIPTION
## Summary

The comprehensive auth/identity pricing comparison page already exists at `/auth-comparison-2026` (built in a prior cycle). It covers all acceptance criteria from issue #702:

- ✅ 20+ auth services compared in main comparison table
- ✅ Category breakdowns: Managed Auth, BaaS-Integrated, Self-Hosted/OSS, Specialized
- ✅ Best-for verdicts (9 use cases with reasoning)
- ✅ Growth Cost Trap table (pricing at 10K, 25K, 50K, 100K MAU)
- ✅ 7 Hidden Costs and Gotchas sections
- ✅ FAQ schema via `buildComparisonFaq`
- ✅ JSON-LD (Article + FAQPage + BreadcrumbList)
- ✅ Page in sitemap via ALTERNATIVES_PAGES
- ✅ Cross-links to vendor pages, alternatives, and related guides
- ✅ Pricing change timeline with auth-related deal changes

This PR adds 301 redirects from `/auth-pricing` and `/auth-identity-pricing` to the canonical `/auth-comparison-2026` URL, plus a test for the redirect.

487 tests passing (1 new).

Refs #702