### PR TITLE
Add monitoring pricing URL redirects

### DIFF
--- a/src/serve.ts
+++ b/src/serve.ts
@@ -47109,7 +47109,7 @@ const httpServer = createHttpServer(async (req, res) => {
   }
 
   // Monitoring comparison alias — redirect old slug to new canonical
-  if (url.pathname === "/monitoring-free-tier-comparison-2026" && isGetOrHead) {
+  if ((url.pathname === "/monitoring-free-tier-comparison-2026" || url.pathname === "/monitoring-pricing" || url.pathname === "/monitoring-observability-pricing") && isGetOrHead) {
     res.writeHead(301, { Location: "/monitoring-comparison-2026" });
     res.end();
     return;

--- a/test/http.test.ts
+++ b/test/http.test.ts
@@ -4026,6 +4026,22 @@ describe("HTTP transport", () => {
     assert.ok(response.headers.get("location")?.includes("/auth-comparison-2026"), "Should redirect /auth-pricing to canonical auth comparison");
   });
 
+  it("GET /monitoring-pricing redirects to /monitoring-comparison-2026", async () => {
+    proc = await startHttpServer();
+
+    const response = await fetch(`http://localhost:${serverPort}/monitoring-pricing`, { redirect: "manual" });
+    assert.strictEqual(response.status, 301);
+    assert.ok(response.headers.get("location")?.includes("/monitoring-comparison-2026"), "Should redirect /monitoring-pricing to canonical monitoring comparison");
+  });
+
+  it("GET /monitoring-observability-pricing redirects to /monitoring-comparison-2026", async () => {
+    proc = await startHttpServer();
+
+    const response = await fetch(`http://localhost:${serverPort}/monitoring-observability-pricing`, { redirect: "manual" });
+    assert.strictEqual(response.status, 301);
+    assert.ok(response.headers.get("location")?.includes("/monitoring-comparison-2026"), "Should redirect /monitoring-observability-pricing to canonical monitoring comparison");
+  });
+
   it("GET /storage-comparison-2026 renders expanded storage and CDN comparison page", async () => {
     proc = await startHttpServer();
 


### PR DESCRIPTION
## Summary

- Added `/monitoring-pricing` and `/monitoring-observability-pricing` as 301 redirects to the existing `/monitoring-comparison-2026` page
- The existing page already covers all acceptance criteria from issue #705: 25+ services compared, growth cost tables, hidden costs, best-for verdicts, FAQ schema, category breakdowns
- Rather than building a duplicate page, capturing the search intent via redirects
- 490 tests passing (2 new)

Refs #705

## Test plan

- [x] Both redirects return 301 to /monitoring-comparison-2026
- [x] Full test suite passes (490 tests)