### PR TITLE
Add AWS App Runner Migration Guide

### DIFF
--- a/data/deal_changes.json
+++ b/data/deal_changes.json
@@ -1,1408 +1,1429 @@
 {
-  "changes": [
-    {
-      "vendor": "Brave Search API",
-      "change_type": "free_tier_removed",
-      "date": "2026-02-12",
-      "summary": "Free plan (5,000 queries/month) replaced with metered billing at $5/1,000 requests. $5 monthly credit provided as offset (~1,000 queries). Credit cards now actively charged with no spending cap",
-      "previous_state": "Free plan: 5,000 queries/month, 3 QPS, no credit card required",
-      "current_state": "Metered billing at $5/1,000 requests with $5 monthly credit (~1,000 free queries). No free plan. Credit card required, no spending cap",
-      "impact": "high",
-      "source_url": "https://www.implicator.ai/brave-drops-free-search-api-tier-puts-all-developers-on-metered-billing/",
-      "category": "Search",
-      "alternatives": [
-        "SerpAPI",
-        "Google Custom Search"
-      ]
-    },
-    {
-      "vendor": "X API (Twitter)",
-      "change_type": "free_tier_removed",
-      "date": "2026-02-09",
-      "summary": "Free tier replaced with pay-per-use + $10 one-time credit",
-      "previous_state": "Free basic endpoints (Like, Follow, List, etc.)",
-      "current_state": "Pay-per-use pricing, $10 one-time credit for existing users, free plan expired Feb 13",
-      "impact": "high",
-      "source_url": "https://developer.x.com/en",
-      "category": "APIs",
-      "alternatives": [
-        "Bluesky API",
-        "Mastodon API"
-      ]
-    },
-    {
-      "vendor": "Spotify API",
-      "change_type": "limits_reduced",
-      "date": "2026-02-11",
-      "summary": "Premium subscription now required for development mode, test users cut from 25 to 5",
-      "previous_state": "Free developer access to Web API, 25 test users",
-      "current_state": "Spotify Premium subscription required for dev mode, 5 test users max, multiple endpoints deprecated",
-      "impact": "high",
-      "source_url": "https://developer.spotify.com/",
-      "category": "APIs",
-      "alternatives": [
-        "Last.fm API",
-        "MusicBrainz API"
-      ]
-    },
-    {
-      "vendor": "Amazon SP-API",
-      "change_type": "pricing_restructured",
-      "date": "2026-01-31",
-      "summary": "Free access ended after 10+ years, now $1,400/year + per-call fees starting April 30",
-      "previous_state": "Free API access for 10+ years",
-      "current_state": "$1,400/year subscription + per-call fees (effective April 30, 2026)",
-      "impact": "high",
-      "source_url": "https://developer-docs.amazon.com/sp-api/",
-      "category": "APIs",
-      "alternatives": []
-    },
-    {
-      "vendor": "PythonAnywhere",
-      "change_type": "pricing_restructured",
-      "date": "2026-01-15",
-      "summary": "$5 Hacker tier eliminated, features merged into free and higher tiers",
-      "previous_state": "$5/mo Hacker tier with custom domains and more storage",
-      "current_state": "Free tier and $10/mo+ paid tiers only, Hacker tier removed",
-      "impact": "medium",
-      "source_url": "https://www.pythonanywhere.com/pricing/",
-      "category": "Hosting",
-      "alternatives": [
-        "Render",
-        "Railway",
-        "Replit"
-      ]
-    },
-    {
-      "vendor": "Google Gemini",
-      "change_type": "limits_reduced",
-      "date": "2025-12-15",
-      "summary": "Google quietly slashed Gemini API free tier rate limits by 50-80% in late 2025. Gemini 2.5 Flash went from ~250 requests/day to 20-50. Pro model free tier removed entirely. A Google PM admitted generous limits were only supposed to be available for a single weekend",
-      "previous_state": "Pro model available on free tier, Flash ~250 RPD, Flash-Lite generous limits",
-      "current_state": "Pro free tier removed. Flash reduced to 10 RPM (~20-50 RPD). Flash-Lite 15 RPM. 50-80% reduction across the board. Gemini 2.0 Flash retiring March 2026",
-      "impact": "high",
-      "source_url": "https://ai.google.dev/gemini-api/docs/pricing",
-      "category": "AI / ML",
-      "alternatives": [
-        "OpenRouter",
-        "Groq",
-        "Together AI"
-      ]
-    },
-    {
-      "vendor": "Netlify",
-      "change_type": "pricing_restructured",
-      "date": "2025-09-04",
-      "summary": "Restructured to credit-based pricing; sites pause on credit exhaustion",
-      "previous_state": "Traditional tiered pricing with fixed monthly allowances",
-      "current_state": "300 credits/month free, sites pause on exhaustion",
-      "impact": "medium",
-      "source_url": "https://www.netlify.com/pricing/",
-      "category": "Hosting",
-      "alternatives": [
-        "Vercel",
-        "Cloudflare Pages",
-        "GitHub Pages"
-      ]
-    },
-    {
-      "vendor": "Netlify",
-      "change_type": "restriction",
-      "date": "2026-03-01",
-      "summary": "Every repo committer is now charged as a full Pro seat ($19/mo) when using Netlify CMS or Identity with a private repo. Previously only users who logged into the Netlify dashboard counted as seats",
-      "previous_state": "Only Netlify dashboard users counted as billable seats",
-      "current_state": "All repo committers to connected private repos count as Pro seats ($19/mo each) when using CMS or Identity features",
-      "impact": "high",
-      "source_url": "https://www.netlify.com/pricing/",
-      "category": "Hosting",
-      "alternatives": [
-        "Vercel",
-        "Cloudflare Pages",
-        "GitHub Pages"
-      ]
-    },
-    {
-      "vendor": "Supabase",
-      "change_type": "limits_reduced",
-      "date": "2026-02-01",
-      "summary": "Project pause policy tightened \u2014 inactive projects now pause after 1 week",
-      "previous_state": "Longer inactivity window before project pause",
-      "current_state": "Projects pause after 1 week of inactivity on free tier",
-      "impact": "medium",
-      "source_url": "https://supabase.com/pricing",
-      "category": "Databases",
-      "alternatives": [
-        "Neon",
-        "PlanetScale",
-        "CockroachDB"
-      ]
-    },
-    {
-      "vendor": "Cloudflare",
-      "change_type": "new_free_tier",
-      "date": "2026-02-04",
-      "summary": "Queues added to Workers free plan \u2014 message queuing now free",
-      "previous_state": "Queues was paid-only",
-      "current_state": "Queues included in free Workers plan",
-      "impact": "medium",
-      "source_url": "https://developers.cloudflare.com/queues/",
-      "category": "Cloud IaaS",
-      "alternatives": []
-    },
-    {
-      "vendor": "GitHub Actions",
-      "change_type": "pricing_postponed",
-      "date": "2026-01-01",
-      "summary": "Self-hosted runner per-minute fee ($0.002/min) announced for March 2026 was postponed indefinitely after community backlash. Self-hosted runners remain free. Separately, hosted runner prices were reduced up to 39% (Jan 2026)",
-      "previous_state": "Self-hosted runners free. Previous per-minute pricing for hosted runners",
-      "current_state": "Self-hosted runners remain free \u2014 no orchestration fees. Hosted runners 39% cheaper. GitHub re-evaluating self-hosted pricing approach",
-      "impact": "low",
-      "source_url": "https://github.com/orgs/community/discussions/182089",
-      "category": "CI/CD",
-      "alternatives": [
-        "GitLab CI",
-        "CircleCI",
-        "Buildkite"
-      ]
-    },
-    {
-      "vendor": "Bright Data MCP",
-      "change_type": "new_free_tier",
-      "date": "2025-08-14",
-      "summary": "Launched free tier for MCP Web Server \u2014 5,000 requests/month for agent developers",
-      "previous_state": "Paid-only web scraping API",
-      "current_state": "5,000 free monthly requests on Rapid mode, includes search_engine and scrape_as_markdown tools, handles JS rendering and CAPTCHAs",
-      "impact": "medium",
-      "source_url": "https://brightdata.com/pricing/mcp-server",
-      "category": "Web Scraping",
-      "alternatives": [
-        "Firecrawl",
-        "Apify"
-      ]
-    },
-    {
-      "vendor": "Stripe",
-      "change_type": "pricing_restructured",
-      "date": "2026-02-01",
-      "summary": "Managed Payments (Merchant of Record) service entering general availability \u2014 Stripe handles tax, billing, fraud, and disputes",
-      "previous_state": "Payment processing only \u2014 developers handled tax compliance, fraud, and disputes separately",
-      "current_state": "Managed Payments acts as Merchant of Record in 75+ countries, handling sales tax/VAT/GST, fraud prevention, dispute resolution, and transaction-level support",
-      "impact": "high",
-      "source_url": "https://docs.stripe.com/payments/managed-payments",
-      "category": "Payments",
-      "alternatives": [
-        "Paddle",
-        "Lemon Squeezy"
-      ]
-    },
-    {
-      "vendor": "Postman",
-      "change_type": "restriction",
-      "date": "2026-03-01",
-      "summary": "Free plan now single-user only. Team collaboration (shared workspaces, collection sharing) requires paid plan at $19/user/month",
-      "previous_state": "Free plan supported up to 3 users in shared workspaces with collection sharing and 25 monitoring calls/month",
-      "current_state": "Free plan = single user only with unlimited collections, environments, mock servers, basic monitoring. Teams require Team plan ($19/user/mo) or higher",
-      "impact": "high",
-      "source_url": "https://www.postman.com/pricing/",
-      "category": "Testing",
-      "alternatives": [
-        "Bruno",
-        "Insomnia",
-        "Hoppscotch",
-        "Apidog",
-        "Thunder Client"
-      ]
-    },
-    {
-      "vendor": "Atlassian Forge",
-      "change_type": "pricing_restructured",
-      "date": "2026-01-01",
-      "summary": "Forge platform moved from free to consumption-based billing for compute and storage",
-      "previous_state": "Entirely free \u2014 no charges for compute, storage, or KV operations",
-      "current_state": "Free monthly allowances per app (100K GB-sec compute, 0.1 GB KVS, 1 GB logs, 1 hr SQL), usage above thresholds billed",
-      "impact": "medium",
-      "source_url": "https://www.atlassian.com/blog/developer/updates-to-forge-pricing-effective-january-2026",
-      "category": "Developer Tools",
-      "alternatives": [
-        "AWS Lambda",
-        "Self-hosted Connect apps"
-      ]
-    },
-    {
-      "vendor": "Fly.io",
-      "change_type": "pricing_restructured",
-      "date": "2026-01-01",
-      "summary": "Volume snapshots now billed \u2014 previously free automatic snapshots now cost $0.08/GB-month",
-      "previous_state": "Automatic volume snapshots included at no cost, enabled by default",
-      "current_state": "$0.08/GB-month for snapshot storage, first 10 GB free. Snapshots can be disabled to avoid charges",
-      "impact": "medium",
-      "source_url": "https://fly.io/docs/about/pricing/",
-      "category": "Cloud Hosting",
-      "alternatives": [
-        "Render",
-        "Railway",
-        "Koyeb"
-      ]
-    },
-    {
-      "vendor": "Cloudflare Durable Objects",
-      "change_type": "pricing_restructured",
-      "date": "2026-01-07",
-      "summary": "SQLite storage billing began for Durable Objects \u2014 previously free during beta",
-      "previous_state": "SQLite storage in Durable Objects was free during public beta (compute already billed)",
-      "current_state": "Storage charged per GB-hour on Workers Paid plan, first 10 GB included. Free plan users unaffected",
-      "impact": "low",
-      "source_url": "https://developers.cloudflare.com/durable-objects/platform/pricing/",
-      "category": "Cloud IaaS",
-      "alternatives": [
-        "Upstash Redis",
-        "Cloudflare KV",
-        "Neon"
-      ]
-    },
-    {
-      "vendor": "Sentry",
-      "change_type": "pricing_restructured",
-      "date": "2025-08-15",
-      "summary": "Switched from performance units to spans-based metrics for error and performance monitoring",
-      "previous_state": "Performance units pricing model",
-      "current_state": "Spans-based metrics: Developer plan includes 50K errors + 10M spans/month free. Reserved volume pricing replaces on-demand",
-      "impact": "medium",
-      "source_url": "https://sentry.io/pricing/",
-      "category": "Monitoring",
-      "alternatives": [
-        "Datadog",
-        "New Relic",
-        "BetterStack"
-      ]
-    },
-    {
-      "vendor": "Neon",
-      "change_type": "pricing_restructured",
-      "date": "2026-01-15",
-      "summary": "Moved to fully usage-based pricing model post-Databricks acquisition \u2014 free tier storage now per-project, projects increased 10\u2192100, branches capped at 10 per project, Neon Auth added",
-      "previous_state": "Free tier: 0.5 GB total storage, 191.9 compute hours, 10 projects, unlimited branches",
-      "current_state": "Free tier: 0.5 GB per project (up to 5 GB across 100 projects), 100 CU-hours/month per project, 10 branches/project, Neon Auth 60K MAU, auto-scaling up to 2 CU, scale-to-zero",
-      "impact": "medium",
-      "source_url": "https://neon.com/pricing",
-      "category": "Databases",
-      "alternatives": [
-        "Supabase",
-        "CockroachDB",
-        "Turso"
-      ]
-    },
-    {
-      "vendor": "Vercel",
-      "change_type": "pricing_restructured",
-      "date": "2026-01-01",
-      "summary": "Pro plan moved to credit-based model ($20/mo credit pool), Hobby plan metrics renamed and restructured \u2014 bandwidth\u2192Fast Data Transfer, serverless split into Active CPU + Provisioned Memory, Blob Storage and Image Transformations added",
-      "previous_state": "Hobby: 100 GB bandwidth, 100 GB-hours serverless. Pro: fixed per-resource allocations",
-      "current_state": "Hobby: 100 GB/mo Fast Data Transfer, 4 hrs Active CPU, 360 GB-hrs Provisioned Memory, 1M edge requests, 1 GB Blob Storage, 5K image transformations. Pro: $20/mo credit pool across all resources, SAML SSO and HIPAA included",
-      "impact": "medium",
-      "source_url": "https://vercel.com/pricing",
-      "category": "Cloud Hosting",
-      "alternatives": [
-        "Netlify",
-        "Cloudflare Pages",
-        "Render"
-      ]
-    },
-    {
-      "vendor": "Atlassian",
-      "change_type": "pricing_restructured",
-      "date": "2026-02-17",
-      "summary": "Data Center pricing increased 15-40% across Jira, Confluence, and JSM. New DC licenses end March 30 \u2014 cloud mandatory for new customers",
-      "previous_state": "Standard Data Center pricing with Advantaged/legacy discounts",
-      "current_state": "15% standard list increase, 18-40% for legacy Advantaged pricing tiers. No new DC licenses after March 30, 2026. Full DC end-of-life March 2029",
-      "impact": "high",
-      "source_url": "https://www.atlassian.com/licensing/future-pricing",
-      "category": "Developer Tools",
-      "alternatives": [
-        "Linear",
-        "Jira Cloud",
-        "Shortcut"
-      ]
-    },
-    {
-      "vendor": "Docker Hub",
-      "change_type": "pricing_restructured",
-      "date": "2024-12-10",
-      "summary": "Docker Pro +80% ($5\u2192$9/mo), Team +67% ($9\u2192$15/mo). Free tier: Build Cloud minutes removed, Scout repos cut 3\u21921, private repos limited to 1 with 2GB storage",
-      "previous_state": "Pro $5/user/month, Team $9/user/month. Free tier included Build Cloud minutes, 3 Scout repos",
-      "current_state": "Pro $9/user/month, Team $15/user/month. Free: 1 private repo (2GB), 1 Scout repo, no Build Cloud minutes, 40 pulls/hour",
-      "impact": "high",
-      "source_url": "https://www.docker.com/blog/november-2024-updated-plans-announcement/",
-      "category": "Container Registry",
-      "alternatives": [
-        "GitHub Container Registry",
-        "Quay.io",
-        "Podman"
-      ]
-    },
-    {
-      "vendor": "DigitalOcean",
-      "change_type": "limits_increased",
-      "date": "2025-01-22",
-      "summary": "Hatch startup program expanded to up to $100K compute credits plus up to 3 months free H100 GPU access for AI/ML startups",
-      "previous_state": "Standard Hatch startup credits program",
-      "current_state": "Up to $100K compute credits (12 months, excludes GPU). Separate GPU benefit: discounted H100 at ~$1.90/hr (vs $3.39 standard) plus up to 3 months free GPU access",
-      "impact": "medium",
-      "source_url": "https://investors.digitalocean.com/news/news-details/2025/DigitalOcean-Announces-New-Benefits-for-Hatch-Startup-Program/default.aspx",
-      "category": "Cloud IaaS",
-      "alternatives": [
-        "AWS Activate",
-        "Google Cloud for Startups",
-        "Azure for Startups"
-      ]
-    },
-    {
-      "vendor": "Google Cloud",
-      "change_type": "limits_increased",
-      "date": "2026-01-01",
-      "summary": "Google for Startups Cloud Program now offers up to $350K GCP credits for AI-first startups, plus $10K Anthropic (Claude) partner credits via Model Garden",
-      "previous_state": "Up to $200K GCP credits for standard startups",
-      "current_state": "Scale AI Tier: up to $350K GCP credits ($250K year 1, $100K year 2). Standard: $200K. Partner credits: $10K Anthropic/Claude via Model Garden, Fireworks AI, MongoDB Atlas, CockroachDB, 1yr free GitLab Ultimate",
-      "impact": "high",
-      "source_url": "https://cloud.google.com/startup/ai",
-      "category": "Cloud IaaS",
-      "alternatives": [
-        "AWS Activate",
-        "Azure for Startups",
-        "DigitalOcean Hatch"
-      ]
-    },
-    {
-      "vendor": "AWS",
-      "change_type": "pricing_restructured",
-      "date": "2026-01-04",
-      "summary": "EC2 Capacity Blocks for ML GPU prices increased ~15% across regions. p5e.48xlarge went from $34.61 to $39.80/hr (US East) and $43.26 to $49.75/hr (US West N. California)",
-      "previous_state": "p5e.48xlarge at $34.61/hr (US East), $43.26/hr (US West N. California) for Capacity Blocks",
-      "current_state": "p5e.48xlarge at $39.80/hr (US East), $49.75/hr (US West N. California). ~15% increase across most GPU Capacity Block instances",
-      "impact": "medium",
-      "source_url": "https://www.theregister.com/2026/01/05/aws_price_increase/",
-      "category": "Cloud IaaS",
-      "alternatives": [
-        "Google Cloud GPUs",
-        "Azure GPU VMs",
-        "Lambda Cloud"
-      ]
-    },
-    {
-      "vendor": "Google",
-      "change_type": "pricing_restructured",
-      "date": "2026-01-27",
-      "summary": "Google Developer Program Premium merged into Google One AI Pro ($19.99/mo, includes $10 Cloud credits) and AI Ultra ($100 Cloud credits). Developer benefits now bundled into consumer AI subscriptions",
-      "previous_state": "Separate Developer Program Premium subscription ($299/year) with dev tools and perks",
-      "current_state": "Developer benefits folded into AI Pro ($19.99/mo, $10 Cloud credits for Vertex AI/Cloud Run/Gemini API) and AI Ultra ($100 Cloud credits). Developer Program Premium being phased out for @gmail.com accounts",
-      "impact": "medium",
-      "source_url": "https://blog.google/innovation-and-ai/technology/developers-tools/gdp-premium-ai-pro-ultra/",
-      "category": "Developer Tools",
-      "alternatives": [
-        "GitHub Copilot",
-        "JetBrains AI"
-      ]
-    },
-    {
-      "vendor": "OpenAI",
-      "change_type": "free_tier_removed",
-      "date": "2026-08-26",
-      "summary": "Assistants API deprecated, full shutdown August 26, 2026. Developers must migrate to Responses API + Conversations API",
-      "previous_state": "Assistants API available with code interpreter, file search, function calling, and Threads for conversation management",
-      "current_state": "Deprecated. Full shutdown Aug 26, 2026. Migration required: Assistants \u2192 Prompts + Responses API, Threads \u2192 Conversations API. No automated migration tool provided",
-      "impact": "high",
-      "source_url": "https://community.openai.com/t/assistants-api-beta-deprecation-august-26-2026-sunset/1354666",
-      "category": "AI/ML",
-      "alternatives": [
-        "Anthropic Claude API",
-        "Google Gemini API",
-        "Cohere API"
-      ]
-    },
-    {
-      "vendor": "Hetzner",
-      "change_type": "pricing_restructured",
-      "date": "2026-04-01",
-      "summary": "Cloud & dedicated server prices increasing 30-50%. Entry-level CX23: \u20ac2.99\u2192\u20ac3.99/mo (+33%). Applies to new and existing customers. Driven by DRAM (+171% YoY) and NVMe SSD cost surges from AI infrastructure demand",
-      "previous_state": "Lower cloud server pricing across Germany, Finland, US, and Singapore data centers (e.g., CX23 at \u20ac2.99/mo)",
-      "current_state": "30-37% increase on cloud servers, up to 50% on select dedicated/storage products. All regions and all customers (new and existing) affected. Announced Feb 23, 2026",
-      "impact": "high",
-      "source_url": "https://www.hetzner.com/pressroom/statement-price-adjustment/",
-      "category": "Cloud Hosting",
-      "alternatives": [
-        "DigitalOcean",
-        "Vultr",
-        "OVHcloud"
-      ]
-    },
-    {
-      "vendor": "Anthropic",
-      "change_type": "limits_increased",
-      "date": "2026-02-05",
-      "summary": "Claude Opus 4.6 API pricing at $5/$25 per MTok (input/output) \u2014 67% below previous Opus 4/4.1 pricing of $15/$75. Frontier AI model at mid-tier prices",
-      "previous_state": "Opus 4/4.1 priced at $15/$75 per million tokens (input/output)",
-      "current_state": "Opus 4.6 at $5/$25 per MTok. Extended context (>200K tokens): $10/$37.50. Batch API: $2.50/$12.50. Price reduction began with Opus 4.5 generation",
-      "impact": "high",
-      "source_url": "https://docs.anthropic.com/en/docs/about-claude/models",
-      "category": "AI/ML APIs",
-      "alternatives": [
-        "OpenAI GPT-4o",
-        "Google Gemini",
-        "Mistral"
-      ]
-    },
-    {
-      "vendor": "OpenAI",
-      "change_type": "limits_reduced",
-      "date": "2026-02-09",
-      "summary": "Ads launched in ChatGPT Free and Go ($8/mo) tiers. Sponsored units from major brands appear below responses on first prompt. $60 CPM, $200K minimum ad commitment",
-      "previous_state": "Ad-free experience across all ChatGPT tiers including Free",
-      "current_state": "Free and Go tiers show contextual ads (labeled 'sponsored') below responses. Plus/Pro/Business/Enterprise/Education tiers remain ad-free. Users can opt out at cost of reduced daily message limits",
-      "impact": "high",
-      "source_url": "https://openai.com/index/testing-ads-in-chatgpt/",
-      "category": "AI/ML",
-      "alternatives": [
-        "Anthropic Claude",
-        "Google Gemini",
-        "Perplexity"
-      ]
-    },
-    {
-      "vendor": "Google Programmable Search Engine",
-      "change_type": "limits_reduced",
-      "date": "2026-01-22",
-      "summary": "Free full-web search being discontinued. Free tier restricted to max 50 domains per search engine. Migration deadline January 1, 2027",
-      "previous_state": "Free search across the entire web with 10,000 queries/day limit via Custom Search JSON API",
-      "current_state": "Free tier restricted to searching up to 50 specified domains only. Full-web search requires paid Google Cloud Search or Vertex AI Search. Takes effect January 1, 2027",
-      "impact": "high",
-      "source_url": "https://developers.google.com/custom-search",
-      "category": "Search",
-      "alternatives": [
-        "Brave Search API",
-        "SerpAPI",
-        "Bing Web Search API",
-        "Meilisearch"
-      ]
-    },
-    {
-      "vendor": "odrive",
-      "change_type": "free_tier_removed",
-      "date": "2026-03-31",
-      "summary": "odrive free tier discontinued effective March 31, 2026. Previously offered free unified cloud storage sync across multiple providers (Google Drive, Dropbox, S3, etc.)",
-      "previous_state": "Free tier with basic sync across multiple cloud storage providers, file manager interface",
-      "current_state": "Free tier removed. Business plans at $20/user/month (min 5 users) or $200/year org subscription. March 31, 2026 deadline",
-      "impact": "medium",
-      "source_url": "https://www.odrive.com/pricing",
-      "category": "Storage",
-      "alternatives": [
-        "rclone",
-        "Cyberduck",
-        "MultCloud"
-      ]
-    },
-    {
-      "vendor": "MinIO",
-      "change_type": "open_source_killed",
-      "date": "2026-02-12",
-      "summary": "MinIO archived its open-source GitHub repository. All development moved to proprietary MinIO AIStor. No new Docker images, PRs, or contributions accepted. Only case-by-case critical security fixes",
-      "previous_state": "Open-source S3-compatible object storage under AGPL-3.0. Active GitHub repo with community contributions, regular Docker image releases",
-      "current_state": "GitHub repository archived. Development moved to proprietary AIStor product. No new open-source releases. Critical security fixes only on case-by-case basis",
-      "impact": "high",
-      "source_url": "https://linuxiac.com/minio-ends-active-development/",
-      "category": "Storage",
-      "alternatives": [
-        "Ceph",
-        "SeaweedFS",
-        "GarageHQ",
-        "Apache Ozone"
-      ]
-    },
-    {
-      "vendor": "Microsoft Partner Developer Benefits",
-      "change_type": "pricing_restructured",
-      "date": "2026-02-13",
-      "summary": "Per-user monthly Azure credits eliminated, replaced with organization-level bulk Azure credits. Visual Studio license in all benefit tiers now exclusively VS Enterprise IDE",
-      "previous_state": "Per-user monthly Azure credits allocated individually. Mix of Visual Studio Professional and Enterprise licenses across tiers",
-      "current_state": "Organization-level bulk Azure credits (shared pool). All tiers include VS Enterprise IDE only. Per-user monthly credits discontinued",
-      "impact": "medium",
-      "source_url": "https://techcommunity.microsoft.com/discussions/partnerbenefitsforum/new-updates-to-developer-benefits-february-2026/4495536",
-      "category": "Cloud IaaS",
-      "alternatives": [
-        "AWS Partner Network",
-        "Google Cloud Partner Advantage"
-      ]
-    },
-    {
-      "vendor": "Cloudflare Startup Program",
-      "change_type": "startup_program_expanded",
-      "date": "2026-02-01",
-      "summary": "Startup program revamped to 4 tiers with up to $250,000 in credits (previously lower). Tiers: Bootstrapped $5K, Up-and-Coming $25K, Seed-Funded $100K, High Growth $250K. Credits expire within 1 year",
-      "previous_state": "Smaller startup program with fewer tiers and lower credit amounts",
-      "current_state": "4 tiers: $5K, $25K, $100K, $250K credits. Covers Workers, R2, Workers AI, Stream. Caps: $10K for R2/Cache Reserve, $50K for Workers AI. Credits expire within 1 year",
-      "impact": "high",
-      "source_url": "https://blog.cloudflare.com/startup-program-250k-credits/",
-      "category": "Cloud IaaS",
-      "alternatives": [
-        "AWS Activate",
-        "Google for Startups Cloud Program",
-        "Azure for Startups"
-      ]
-    },
-    {
-      "vendor": "Google Gemini 2.0 Flash",
-      "change_type": "product_deprecated",
-      "date": "2026-03-03",
-      "summary": "Gemini 2.0 Flash and 2.0 Flash-Lite models deprecated, scheduled for retirement. Free tier continues with Gemini 2.5 models. Developers on 2.0 must migrate",
-      "previous_state": "Gemini 2.0 Flash and Flash-Lite available as free-tier models with standard rate limits",
-      "current_state": "2.0 Flash and Flash-Lite deprecated. Developers must migrate to Gemini 2.5 Flash or 2.5 Pro. Free tier preserved for 2.5 series",
-      "impact": "medium",
-      "source_url": "https://www.isumsoft.com/internet/gemini-2-flash-deprecation-migration-guide.html",
-      "category": "AI/ML",
-      "alternatives": [
-        "Google Gemini 2.5 Flash",
-        "Google Gemini 2.5 Pro",
-        "OpenRouter",
-        "Groq"
-      ]
-    },
-    {
-      "vendor": "Logz.io",
-      "change_type": "free_tier_removed",
-      "date": "2026-03-02",
-      "summary": "Free Community plan (1 GB/day, 1-day retention, 10 alerts) removed. Only 14-day free trial remains. Consumption-based pricing starts at $0.92/ingested GB/day",
-      "previous_state": "Free Community plan: 1 GB/day ingestion, 1-day retention, 10 alerts, ML-powered anomaly detection",
-      "current_state": "14-day free trial only. Pay-as-go: $0.92/GB/day logs, $0.40/1K metrics/day, $0.16/1M spans/day. No permanent free tier",
-      "impact": "medium",
-      "source_url": "https://logz.io/pricing/",
-      "category": "Logging",
-      "alternatives": [
-        "Grafana Cloud",
-        "BetterStack",
-        "Axiom",
-        "New Relic"
-      ]
-    },
-    {
-      "vendor": "X (Twitter)",
-      "change_type": "pricing_model_change",
-      "date": "2026-02-06",
-      "summary": "Pay-per-use pricing model introduced alongside existing fixed tiers. Legacy free tier users migrated to pay-per-use with $10 voucher. Free tier effectively reduced to proof-of-concept only (~500 posts/month read, no search)",
-      "previous_state": "Fixed tiers: Free (limited), Basic $100/mo, Pro $5,000/mo, Enterprise $42,000/mo",
-      "current_state": "Pay-per-use model added: per-operation billing (read, search, write priced separately). Fixed tiers remain: Free (very limited), Basic $200/mo, Pro $5,000/mo, Enterprise $42,000/mo",
-      "impact": "high",
-      "source_url": "https://devcommunity.x.com/t/announcing-the-launch-of-x-api-pay-per-use-pricing/256476",
-      "category": "API Gateway",
-      "alternatives": [
-        "Bluesky API",
-        "Mastodon API",
-        "Reddit API"
-      ]
-    },
-    {
-      "vendor": "OpenAI",
-      "change_type": "limits_reduced",
-      "date": "2025-06-01",
-      "summary": "Free trial credits ($5-$18 for new accounts) completely discontinued. Free tier now limited to GPT-3.5 Turbo at 3 RPM with no credits. All advanced models (GPT-4, DALL-E, Whisper) require paid access",
-      "previous_state": "$5-$18 in free trial credits for new accounts, 3-month expiry, access to all models",
-      "current_state": "No free credits. Free tier: GPT-3.5 Turbo only, 3 requests/minute. Must add payment method for any other model access",
-      "impact": "high",
-      "source_url": "https://openai.com/api/pricing/",
-      "category": "AI / ML",
-      "alternatives": [
-        "Google Gemini API",
-        "Anthropic Claude API",
-        "Mistral API",
-        "Groq"
-      ]
-    },
-    {
-      "vendor": "Xero Developer API",
-      "change_type": "pricing_model_change",
-      "date": "2026-03-02",
-      "summary": "Xero retiring revenue-share model, moving to 5-tier connection+egress pricing. No more free API access for developers. Costs jumping from ~$0 to $17K+/year for some. Also banning API data use for AI/ML model training",
-      "previous_state": "Revenue-share model with effective free API access for developers building Xero integrations",
-      "current_state": "5-tier usage-based pricing: connection fees + data egress charges. No free tier. Explicit prohibition on using API data for AI/ML training",
-      "impact": "high",
-      "source_url": "https://developer.xero.com/pricing",
-      "category": "API Gateway",
-      "alternatives": [
-        "QuickBooks API",
-        "FreshBooks API",
-        "Wave API"
-      ]
-    },
-    {
-      "vendor": "SendGrid",
-      "change_type": "free_tier_removed",
-      "date": "2025-05-27",
-      "summary": "Perpetual free tier (100 emails/day) eliminated. Replaced with 60-day trial only. Paid plans start at $19.95/month",
-      "previous_state": "Free plan: 100 emails/day forever, no credit card required",
-      "current_state": "60-day trial only (100 emails/day, 100 contacts). Paid plans from $19.95/month after trial",
-      "impact": "high",
-      "source_url": "https://sendgrid.com/en-us/pricing",
-      "category": "Email",
-      "alternatives": [
-        "Resend",
-        "Postmark",
-        "Mailgun",
-        "Amazon SES"
-      ]
-    },
-    {
-      "vendor": "Firebase",
-      "change_type": "limits_reduced",
-      "date": "2026-02-03",
-      "summary": "Cloud Storage removed from Spark (free) plan. Projects on Spark with default appspot.com buckets lose console access and API calls return 402/403 errors. Must upgrade to Blaze (pay-as-you-go) to use Cloud Storage",
-      "previous_state": "Spark plan included Cloud Storage: 5 GB storage, 1 GB/day download, 20K uploads/day, 50K downloads/day",
-      "current_state": "Cloud Storage requires Blaze plan. Blaze provides no-cost quota (1 GiB storage, 10 GB download/month) before charges begin, but credit card required. Other Spark limits unchanged (Firestore, Auth, Functions, Hosting)",
-      "impact": "high",
-      "source_url": "https://firebase.google.com/docs/storage/faqs-storage-changes-announced-sept-2024",
-      "category": "Cloud Storage",
-      "alternatives": [
-        "Supabase Storage",
-        "Cloudflare R2",
-        "AWS S3",
-        "Backblaze B2"
-      ]
-    },
-    {
-      "vendor": "PlanetScale",
-      "change_type": "free_tier_removed",
-      "date": "2024-04-08",
-      "summary": "PlanetScale removed free Hobby plan entirely. All databases on free tier deleted after 30-day grace period. Minimum plan now Scaler at $39/month",
-      "previous_state": "Free Hobby plan: 5 GB storage, 1B row reads/month, 10M row writes/month, 1 production branch, 1 development branch",
-      "current_state": "No free tier. Scaler plan starts at $39/month (25 GB storage). Enterprise custom pricing. Company pivoted to enterprise focus",
-      "impact": "high",
-      "source_url": "https://planetscale.com/blog/planetscale-forever",
-      "category": "Databases",
-      "alternatives": [
-        "Neon",
-        "Turso",
-        "Supabase",
-        "CockroachDB"
-      ]
-    },
-    {
-      "vendor": "Fauna",
-      "change_type": "product_deprecated",
-      "date": "2025-05-30",
-      "summary": "Fauna shut down entirely on May 30, 2025. The serverless document database ceased all operations. Over 80,000 development teams affected",
-      "previous_state": "Free tier: 100K read ops/day, 50K write ops/day, 500K compute ops/day, 5 GB storage. Consumption-based pricing above free limits",
-      "current_state": "Service discontinued. No longer available in any form. All customer data deleted",
-      "impact": "high",
-      "source_url": "https://fauna.com",
-      "category": "Databases",
-      "alternatives": [
-        "Supabase",
-        "MongoDB Atlas",
-        "CockroachDB",
-        "DynamoDB"
-      ]
-    },
-    {
-      "vendor": "LocalStack",
-      "change_type": "free_tier_removed",
-      "date": "2026-03-23",
-      "summary": "LocalStack drops open-source Community Edition. Single unified image requires auth token. Free tier replaced with non-commercial-only tier requiring registration. Commercial use requires paid plan starting at $39/month",
-      "previous_state": "Open-source Community Edition: 30+ emulated AWS services (S3, Lambda, DynamoDB, etc.), no registration required, Docker image freely available",
-      "current_state": "Non-commercial free tier requires registration and auth token. Commercial use starts at $39/month. CI credits system introduced. OSS projects, students, and nonprofits get free access",
-      "impact": "high",
-      "source_url": "https://blog.localstack.cloud/the-road-ahead-for-localstack/",
-      "category": "Testing",
-      "alternatives": [
-        "Moto (open-source AWS mock)",
-        "AWS Free Tier",
-        "Testcontainers"
-      ]
-    },
-    {
-      "vendor": "Google",
-      "change_type": "pricing_restructured",
-      "date": "2026-03-30",
-      "summary": "Google Developer Program annual subscription ending March 30. Replaced by Google AI Pro ($10/mo) and AI Ultra ($100/mo) tiers with bundled cloud credits and AI model access.",
-      "previous_state": "Google Developer Program: annual subscription with standalone cloud credits, developer tools access, and learning resources",
-      "current_state": "Google AI Pro ($10/mo) and AI Ultra ($100/mo) tiers bundle cloud credits with AI model access (Gemini, etc). Developer benefits folded into AI-centric subscriptions",
-      "impact": "high",
-      "source_url": "https://developers.google.com/profile/help/benefits",
-      "category": "Cloud IaaS",
-      "alternatives": [
-        "AWS Activate",
-        "Microsoft for Startups",
-        "Google for Startups Cloud"
-      ],
-      "verified_date": "2026-03-04"
-    },
-    {
-      "vendor": "Terragrunt Scale",
-      "change_type": "new_free_tier",
-      "date": "2025-12-15",
-      "summary": "Gruntwork launches free tier for Terragrunt Scale IaC orchestration platform, positioned as HCP Terraform free tier alternative ahead of HashiCorp March 31, 2026 EOL. Includes GitOps, drift detection, and module update automation",
-      "previous_state": "No free tier \u2014 Team plan at $500/month",
-      "current_state": "Free tier with limits matching or exceeding HCP Terraform (500+ managed resources, GitOps, drift detection, Patcher)",
-      "impact": "medium",
-      "source_url": "https://www.gruntwork.io/blog/announcing-the-terragrunt-scale-free-tier",
-      "category": "Infrastructure",
-      "alternatives": [
-        "Spacelift",
-        "env0",
-        "Scalr"
-      ]
-    },
-    {
-      "vendor": "HCP Terraform",
-      "change_type": "pricing_restructured",
-      "date": "2026-03-31",
-      "summary": "HashiCorp legacy free plan for HCP Terraform ends March 31, 2026. All legacy free plan users auto-migrated to enhanced free tier with different limits: 500 managed resources (previously unlimited for small teams), unlimited users, 1 concurrent run, SSO, and policy as code (Sentinel + OPA)",
-      "previous_state": "Legacy free plan with basic Terraform Cloud features",
-      "current_state": "Enhanced free tier: 500 managed resources, unlimited users, 1 concurrent run, SSO, policy as code (Sentinel + OPA). Auto-migration from legacy plan",
-      "impact": "high",
-      "source_url": "https://www.hashicorp.com/products/terraform/pricing",
-      "category": "Infrastructure",
-      "alternatives": [
-        "Spacelift",
-        "env0",
-        "Scalr",
-        "Terragrunt Scale"
-      ]
-    },
-    {
-      "vendor": "X (Twitter)",
-      "change_type": "free_tier_removed",
-      "date": "2026-02-01",
-      "summary": "X/Twitter API eliminated free tier in February 2026, replacing it with a pay-per-use credit model. Active free-tier users receive a $0 voucher. 'For-good' utility apps remain free. Basic fixed tier remains at $200/month",
-      "previous_state": "Free tier: ~500 posts/month read, 1,500 tweets/month write, no search, ~1 request per 15 minutes",
-      "current_state": "No free tier. Pay-per-use credit model replaces free access. $0 voucher for existing free-tier users. For-good utility apps exempted",
-      "impact": "high",
-      "source_url": "https://developer.x.com/en/portal/products",
-      "category": "API Gateway",
-      "alternatives": [
-        "Bluesky AT Protocol",
-        "Mastodon API"
-      ]
-    },
-    {
-      "vendor": "Cognition Devin",
-      "change_type": "pricing_restructured",
-      "date": "2026-01-15",
-      "summary": "Launched $20/month Core plan with pay-as-you-go ACU pricing, down from previous $500/month-only Team plan",
-      "previous_state": "Team plan only at $500/month (250 credits)",
-      "current_state": "Core plan $20/month (pay-as-you-go at $2.25/ACU), Team plan $500/month remains",
-      "impact": "high",
-      "source_url": "https://devin.ai/pricing",
-      "category": "AI Coding",
-      "alternatives": [
-        "GitHub Copilot",
-        "Cline",
-        "Aider"
-      ]
-    },
-    {
-      "vendor": "Cursor",
-      "change_type": "pricing_restructured",
-      "date": "2025-06-01",
-      "summary": "Moved from flat monthly subscription to credit-based pricing model with new $200/month Ultra tier",
-      "previous_state": "Pro plan $20/month with 500 fast requests",
-      "current_state": "Pro plan $20/month (credit-based), Business $40/seat/month, Ultra $200/month (higher credit limits)",
-      "impact": "medium",
-      "source_url": "https://www.cursor.com/pricing",
-      "category": "AI Coding",
-      "alternatives": [
-        "Windsurf",
-        "GitHub Copilot"
-      ]
-    },
-    {
-      "vendor": "Augment Code",
-      "change_type": "pricing_restructured",
-      "date": "2025-10-01",
-      "summary": "Shifted from per-seat subscription to credit-based consumption model",
-      "previous_state": "Per-seat monthly subscription",
-      "current_state": "Credit-based consumption model with usage tiers",
-      "impact": "medium",
-      "source_url": "https://www.augmentcode.com/pricing",
-      "category": "AI Coding",
-      "alternatives": [
-        "GitHub Copilot",
-        "Cursor"
-      ]
-    },
-    {
-      "vendor": "Google Tenor API",
-      "change_type": "product_deprecated",
-      "date": "2026-06-30",
-      "summary": "Google Tenor public API shutting down June 30, 2026. New API key signups halted January 13, 2026. Only the public GIF search API is affected \u2014 Tenor website and app continue operating. Developers must migrate to alternative GIF APIs",
-      "previous_state": "Free public API for GIF search, trending GIFs, and autocomplete. No rate limits for reasonable use. Used by messaging apps and social platforms",
-      "current_state": "API shutdown June 30, 2026. No new API keys issued since Jan 13, 2026. Existing keys work until shutdown date. No replacement API from Google",
-      "impact": "high",
-      "source_url": "https://developers.google.com/tenor/guides/api-shutdown",
-      "category": "Media",
-      "alternatives": [
-        "Giphy API",
-        "Imgur API"
-      ]
-    },
-    {
-      "vendor": "Testcontainers Cloud",
-      "change_type": "pricing_restructured",
-      "date": "2024-06-01",
-      "summary": "Docker acquired AtomicJar (creators of Testcontainers Cloud). Standalone Testcontainers Cloud free tier retired \u2014 now bundled into Docker subscriptions. Docker Pro gets 100 min/month, Team 500 min/month, Business 1,500 min/month",
-      "previous_state": "Standalone Testcontainers Cloud with independent free tier (100 min/month)",
-      "current_state": "Bundled with Docker subscriptions. No standalone free tier. Open-source Testcontainers libraries remain MIT-licensed and fully free",
-      "impact": "medium",
-      "source_url": "https://testcontainers.com/cloud/",
-      "category": "Testing",
-      "alternatives": [
-        "Testcontainers (open-source)",
-        "Docker Desktop",
-        "Podman"
-      ]
-    },
-    {
-      "vendor": "Docker Desktop",
-      "change_type": "pricing_restructured",
-      "date": "2026-01-01",
-      "summary": "Docker Desktop subscription prices increased 67-80% across all tiers. Personal $7\u2192$11, Pro $9\u2192$14, Team $15\u2192$24, Business $24\u2192$35 per user/month. Separate from Docker Hub registry pricing changes",
-      "previous_state": "Personal $7/user/month, Pro $9/user/month, Team $15/user/month, Business $24/user/month",
-      "current_state": "Personal $11/user/month (+57%), Pro $14/user/month (+56%), Team $24/user/month (+60%), Business $35/user/month (+46%). All tiers affected",
-      "impact": "high",
-      "source_url": "https://www.docker.com/pricing/",
-      "category": "Container Registry",
-      "alternatives": [
-        "Podman Desktop",
-        "Rancher Desktop",
-        "OrbStack"
-      ]
-    },
-    {
-      "vendor": "Unity DevOps",
-      "change_type": "limits_increased",
-      "date": "2026-03-01",
-      "summary": "Free tier significantly expanded: storage 5x increase to 25 GB, 100 GB egress added (new), per-seat charges removed. Unity DevOps (formerly Plastic SCM) now offers generous free version control for game developers",
-      "previous_state": "5 GB storage, no egress allowance, per-seat pricing for teams",
-      "current_state": "25 GB storage (5x increase), 100 GB egress/month (new), per-seat charges removed. Free for individuals and small teams",
-      "impact": "medium",
-      "source_url": "https://unity.com/products/devops",
-      "category": "Version Control",
-      "alternatives": [
-        "Git LFS",
-        "Perforce",
-        "GitHub"
-      ]
-    },
-    {
-      "vendor": "Anthropic Claude",
-      "change_type": "limits_increased",
-      "date": "2026-03-13",
-      "summary": "Temporary usage promotion: double five-hour usage limits during off-peak hours, March 13-27, 2026. Applies to Claude Pro and Team subscribers",
-      "previous_state": "Standard five-hour usage limits for Pro and Team subscribers",
-      "current_state": "2x usage limits during off-peak hours (March 13-27, 2026 only). Temporary promotion to showcase increased capacity",
-      "impact": "low",
-      "source_url": "https://www.anthropic.com/news",
-      "category": "AI/ML",
-      "alternatives": [
-        "OpenAI ChatGPT Plus",
-        "Google Gemini Advanced"
-      ]
-    },
-    {
-      "vendor": "Heroku",
-      "change_type": "free_tier_removed",
-      "date": "2022-11-28",
-      "summary": "Heroku removed all free dynos, free Heroku Postgres, and free Heroku Data for Redis. The iconic PaaS that defined 'free tier' for a generation eliminated free offerings entirely after Salesforce acquisition",
-      "previous_state": "Free dyno: 550 hours/month (1,000 with credit card), free Postgres: 10K rows, free Redis: 25 MB. Dynos slept after 30 min inactivity",
-      "current_state": "No free tier. Mini plan starts at $5/month (Eco dynos $5/month for 1,000 shared hours). Postgres starts at $5/month",
-      "impact": "high",
-      "source_url": "https://blog.heroku.com/next-chapter",
-      "category": "Cloud Hosting",
-      "alternatives": [
-        "Render",
-        "Railway",
-        "Fly.io",
-        "Koyeb"
-      ]
-    },
-    {
-      "vendor": "GitHub Copilot",
-      "change_type": "new_free_tier",
-      "date": "2025-12-18",
-      "summary": "GitHub launched Copilot Free tier \u2014 AI code completion available to all GitHub users at no cost. 2,000 completions and 50 chat messages per month included",
-      "previous_state": "Paid only: Individual $10/month, Business $19/user/month. Free for verified students, teachers, and OSS maintainers only",
-      "current_state": "Free tier: 2,000 code completions/month, 50 chat messages/month. Individual $10/month, Business $19/month, Enterprise $39/month remain for higher limits",
-      "impact": "high",
-      "source_url": "https://github.blog/news-insights/product-news/github-copilot-in-vscode-free/",
-      "category": "AI Coding",
-      "alternatives": [
-        "Cline",
-        "Cody",
-        "Cursor"
-      ]
-    },
-    {
-      "vendor": "Auth0",
-      "change_type": "limits_increased",
-      "date": "2025-11-01",
-      "summary": "Auth0 increased free tier from 7,500 to 25,000 monthly active users. Largest free tier expansion since Okta acquisition. Makes Auth0 competitive with Clerk and Firebase Auth on free tier",
-      "previous_state": "Free tier: 7,500 MAU, unlimited social connections, 2 organizations",
-      "current_state": "Free tier: 25,000 MAU (+233%), unlimited social connections, 5 organizations. Actions, Branding, MFA included",
-      "impact": "high",
-      "source_url": "https://auth0.com/pricing",
-      "category": "Authentication",
-      "alternatives": [
-        "Clerk",
-        "Firebase Auth",
-        "Supabase Auth"
-      ]
-    },
-    {
-      "vendor": "Railway",
-      "change_type": "limits_increased",
-      "date": "2025-10-01",
-      "summary": "Railway expanded free tier following $100M Series B. Trial plan now includes $5 in free credits/month, sufficient for small hobby projects. Removed credit card requirement for trial",
-      "previous_state": "$5 free trial credit one-time, credit card required for Hobby plan",
-      "current_state": "Trial: $5/month in free credits, no credit card needed. Hobby: $5/month + usage. Pro: $20/month per seat",
-      "impact": "medium",
-      "source_url": "https://railway.com/pricing",
-      "category": "Cloud Hosting",
-      "alternatives": [
-        "Render",
-        "Fly.io",
-        "Koyeb"
-      ]
-    },
-    {
-      "vendor": "Render",
-      "change_type": "limits_reduced",
-      "date": "2025-09-01",
-      "summary": "Free web services now spin down after 15 minutes of inactivity (previously 30 minutes). Cold starts take 30-60 seconds. Free tier remains but with faster sleep times",
-      "previous_state": "Free web services slept after 30 minutes of inactivity",
-      "current_state": "Free web services sleep after 15 minutes of inactivity. 750 hours/month free compute unchanged. Cold start 30-60 seconds",
-      "impact": "low",
-      "source_url": "https://render.com/pricing",
-      "category": "Cloud Hosting",
-      "alternatives": [
-        "Railway",
-        "Fly.io",
-        "Koyeb"
-      ]
-    },
-    {
-      "vendor": "Redis",
-      "change_type": "pricing_restructured",
-      "date": "2024-03-20",
-      "summary": "Redis switched from BSD license to dual SSPL/RSALv2 license, effectively ending open-source status. Triggered creation of Valkey fork by Linux Foundation. Redis Cloud pricing unchanged but community trust impacted",
-      "previous_state": "BSD 3-Clause open-source license. Community-driven development. Multiple hosted providers (AWS ElastiCache, etc.)",
-      "current_state": "Dual SSPL + RSALv2 license. Cloud hosting by third parties restricted. Valkey fork (BSD) created by Linux Foundation with AWS, Google, Oracle backing",
-      "impact": "high",
-      "source_url": "https://redis.io/blog/redis-adopts-dual-source-available-licensing/",
-      "category": "Databases",
-      "alternatives": [
-        "Valkey",
-        "KeyDB",
-        "DragonflyDB",
-        "Upstash"
-      ]
-    },
-    {
-      "vendor": "HashiCorp",
-      "change_type": "pricing_restructured",
-      "date": "2023-08-10",
-      "summary": "HashiCorp switched Terraform, Vault, Consul, Nomad, and other products from MPL 2.0 to BSL 1.1 license. Triggered OpenTofu fork under Linux Foundation. IBM acquired HashiCorp for $6.4B in 2024",
-      "previous_state": "Mozilla Public License 2.0 (open-source). Community-driven development with corporate stewardship",
-      "current_state": "Business Source License 1.1. Non-production use free, competitive commercial use restricted. OpenTofu fork (MPL 2.0) maintained by Linux Foundation",
-      "impact": "high",
-      "source_url": "https://www.hashicorp.com/blog/hashicorp-adopts-business-source-license",
-      "category": "Infrastructure",
-      "alternatives": [
-        "OpenTofu",
-        "Pulumi",
-        "Crossplane"
-      ]
-    },
-    {
-      "vendor": "DigitalOcean",
-      "change_type": "limits_increased",
-      "date": "2026-01-01",
-      "summary": "20% price cut on Basic Droplets (cheapest now $4/mo from $5/mo). Per-second billing introduced (minimum 60 seconds or $0.01). Functions free tier increased to 25,000 GiB-seconds/mo",
-      "previous_state": "Basic Droplets from $5/mo, hourly billing, Functions 90K GiB-seconds/mo free",
-      "current_state": "Basic Droplets from $4/mo (1 vCPU, 512 MB, 10 GB SSD). Per-second billing (min 60s/$0.01). Functions 25,000 GiB-seconds/mo free",
-      "impact": "medium",
-      "source_url": "https://www.digitalocean.com/pricing/droplets",
-      "category": "Cloud IaaS",
-      "alternatives": [
-        "Hetzner",
-        "Vultr",
-        "Linode"
-      ]
-    },
-    {
-      "vendor": "DigitalOcean",
-      "change_type": "restriction",
-      "date": "2026-03-21",
-      "summary": "Managed databases are not part of the free tier. Pricing starts at $15/month. Previous listing incorrectly included '1 basic cluster' as a free tier benefit",
-      "previous_state": "Listed as: Free static sites (up to 3), functions (90K GiB-seconds/mo), and managed databases (1 basic cluster)",
-      "current_state": "Free static sites (up to 3) and functions (90K GiB-seconds/mo). Managed databases start at $15/mo, not free",
-      "impact": "medium",
-      "source_url": "https://www.digitalocean.com/pricing",
-      "category": "Cloud IaaS",
-      "alternatives": [
-        "Neon",
-        "PlanetScale",
-        "Supabase"
-      ]
-    },
-    {
-      "vendor": "Freshping",
-      "change_type": "free_tier_removed",
-      "date": "2026-03-06",
-      "summary": "Freshping shut down entirely. Free accounts disabled March 6, 2026. Paid plans expire at end of term. All data deleted 90 days later (~June 4, 2026). No replacement product offered by Freshworks",
-      "previous_state": "Free plan: 50 monitors, 1-minute check intervals, public status pages, multi-location checks, email/Slack alerts",
-      "current_state": "Service discontinued. No free or paid plan available",
-      "impact": "high",
-      "source_url": "https://www.freshworks.com/freshping/",
-      "category": "Monitoring",
-      "alternatives": [
-        "UptimeRobot",
-        "BetterStack",
-        "Checkly",
-        "StatusCake",
-        "Pulsetic",
-        "Cronitor",
-        "Upptime"
-      ]
-    },
-    {
-      "vendor": "Firebase",
-      "change_type": "product_deprecated",
-      "date": "2026-03-19",
-      "summary": "Firebase Studio (formerly Project IDX) shut down March 19, 2026. Cloud IDE and AI code generation features discontinued. Existing projects accessible until March 2027 for migration",
-      "previous_state": "Firebase Studio: cloud IDE with AI code generation, Gemini integration, multi-platform preview",
-      "current_state": "Discontinued. Projects accessible until March 2027 for data export only. Google recommends migrating to other IDEs",
-      "impact": "medium",
-      "source_url": "https://firebase.google.com/docs/studio",
-      "category": "Databases",
-      "alternatives": [
-        "Supabase",
-        "Appwrite Cloud",
-        "PocketBase",
-        "Nhost",
-        "Convex"
-      ]
-    },
-    {
-      "vendor": "Firebase",
-      "change_type": "restriction",
-      "date": "2026-02-01",
-      "summary": "Spark plan projects using legacy *.appspot.com Cloud Storage buckets forced to upgrade to Blaze (pay-as-you-go) plan or lose Cloud Storage access. No billing caps on Blaze plan \u2014 developers risk unexpected charges",
-      "previous_state": "Spark plan: free Cloud Storage with *.appspot.com buckets, no credit card required",
-      "current_state": "Legacy bucket projects must upgrade to Blaze (pay-as-you-go). No hard billing caps. New projects use Firebase Storage buckets on Spark plan",
-      "impact": "high",
-      "source_url": "https://firebase.google.com/docs/storage/web/start",
-      "category": "Databases",
-      "alternatives": [
-        "Supabase",
-        "Appwrite Cloud",
-        "PocketBase",
-        "Nhost",
-        "Convex"
-      ]
-    },
-    {
-      "vendor": "Dub.co",
-      "change_type": "limits_reduced",
-      "date": "2026-03-22",
-      "summary": "Free tier link limit reduced 40x from 1,000 links to 25 new links/month. Added 30-day analytics retention limit and 1-user cap",
-      "previous_state": "1,000 links, 1,000 tracked clicks/month, up to 3 custom domains",
-      "current_state": "25 new links/month, 1,000 tracked events/month, 3 custom domains, 1 user, 30-day analytics retention",
-      "impact": "high",
-      "source_url": "https://dub.co/pricing",
-      "category": "Dev Utilities",
-      "alternatives": [
-        "Bitly",
-        "Short.io"
-      ]
-    },
-    {
-      "vendor": "Uploadthing",
-      "change_type": "free_tier_removed",
-      "date": "2025-01-15",
-      "summary": "Free tier eliminated. Uploadthing moved to usage-based pricing with minimum $25/month plan (250 GB storage). No free tier available",
-      "previous_state": "Free tier: 2 GB storage, 2 GB bandwidth/month",
-      "current_state": "Usage-based pricing only. Minimum $25/month plan with 250 GB storage. No free tier",
-      "impact": "high",
-      "source_url": "https://uploadthing.com/pricing",
-      "category": "Storage",
-      "alternatives": [
-        "Cloudinary",
-        "Vercel Blob",
-        "AWS S3"
-      ]
-    },
-    {
-      "vendor": "Neo4j AuraDB",
-      "change_type": "restriction",
-      "date": "2026-03-22",
-      "summary": "Data correction \u2014 previous entry incorrectly reduced limits to 50K nodes/175K relationships. Actual free tier is 200,000 nodes and 400,000 relationships per Neo4j AuraDB FAQ",
-      "previous_state": "50,000 nodes, 175,000 relationships (incorrectly listed)",
-      "current_state": "200,000 nodes, 400,000 relationships (restored to correct values)",
-      "impact": "low",
-      "source_url": "https://neo4j.com/cloud/platform/aura-graph-database/faq/",
-      "category": "Databases",
-      "alternatives": [
-        "Dgraph Cloud",
-        "Amazon Neptune"
-      ]
-    },
-    {
-      "vendor": "xAI (Grok)",
-      "change_type": "free_tier_removed",
-      "date": "2026-03-19",
-      "summary": "Grok Imagine free image/video generation locked behind SuperGrok subscription ($30/mo). Over 1B generations in first month overwhelmed capacity",
-      "previous_state": "Free image and video generation for all Grok users",
-      "current_state": "Image/video generation requires SuperGrok subscription ($30/month). Text-only Grok remains free with limits",
-      "impact": "medium",
-      "source_url": "https://x.com/xai",
-      "category": "AI / ML",
-      "alternatives": [
-        "DALL-E (credits)",
-        "Stable Diffusion (self-hosted)",
-        "Pollinations.AI"
-      ]
-    },
-    {
-      "vendor": "Google Gemini API",
-      "change_type": "restriction",
-      "date": "2026-04-01",
-      "summary": "Billing-account-level spend caps enforced starting April 1, 2026. When a tier's spend cap is reached, API requests pause until the next billing month. Affects pay-as-you-go developers who may see unexpected request pausing.",
-      "previous_state": "No hard spend caps \u2014 usage billed without automatic pausing",
-      "current_state": "Tier-level spend caps enforced at billing account level. Requests pause when cap is hit until next month",
-      "impact": "medium",
-      "source_url": "https://ai.google.dev/gemini-api/docs/billing",
-      "category": "AI / ML",
-      "alternatives": [
-        "OpenRouter",
-        "Anthropic Claude API",
-        "OpenAI API"
-      ]
-    },
-    {
-      "vendor": "Windsurf",
-      "change_type": "pricing_restructured",
-      "date": "2026-03-19",
-      "summary": "Windsurf replaced credits-based pricing with daily/weekly quotas (Mar 19, 2026). New tiers: Pro $20/mo (was $15), Ultimate $40/mo, Team $200/mo/seat. Free tier changed from flexible credits to hard quotas. Existing Pro subscribers grandfathered at $15/mo",
-      "previous_state": "Credits-based system allowing flexible allocation between completions and chat. Pro plan $15/month",
-      "current_state": "Daily/weekly quotas replace credits. Pro $20/mo (existing subs grandfathered at $15), Ultimate $40/mo, Team $200/mo/seat. Free tier gets limited daily completions and chat messages",
-      "impact": "medium",
-      "source_url": "https://windsurf.com/pricing",
-      "category": "AI Coding",
-      "alternatives": [
-        "Cursor",
-        "GitHub Copilot",
-        "Cline"
-      ]
-    },
-    {
-      "vendor": "Gemini Code Assist",
-      "change_type": "new_free_tier",
-      "date": "2025-12-18",
-      "summary": "Google launched Gemini Code Assist free tier for individual developers. Includes code completions, chat, and multi-file editing powered by Gemini 2.5 Pro. Available in VS Code, JetBrains, and Cloud Shell",
-      "previous_state": "No free tier \u2014 enterprise-only at $19/user/month",
-      "current_state": "Free individual tier with code completions, chat, and multi-file editing. Enterprise tier remains at $19/user/month",
-      "impact": "high",
-      "source_url": "https://cloud.google.com/gemini/docs/codeassist/overview",
-      "category": "AI Coding",
-      "alternatives": [
-        "GitHub Copilot Free",
-        "Cursor",
-        "Cline"
-      ]
-    },
-    {
-      "vendor": "Amazon Aurora PostgreSQL",
-      "change_type": "new_free_tier",
-      "date": "2026-03-25",
-      "summary": "Aurora PostgreSQL Serverless added to AWS Free Tier \u2014 managed PostgreSQL-compatible database now available at no cost with up to 4 ACUs per cluster and 1 GB storage. Part of AWS Free Plan (6 months + credits)",
-      "previous_state": "No free tier \u2014 Aurora was paid-only, starting at ~$0.08/ACU-hour",
-      "current_state": "Free plan with up to 4 ACUs per cluster, 1 GB storage, $100\u2013200 in credits for new accounts",
-      "impact": "high",
-      "source_url": "https://aws.amazon.com/rds/aurora/pricing/",
-      "category": "Databases",
-      "alternatives": [
-        "Neon",
-        "Supabase",
-        "CockroachDB",
-        "PlanetScale"
-      ]
-    },
-    {
-      "vendor": "Amazon Kiro",
-      "change_type": "new_free_tier",
-      "date": "2026-04-07",
-      "summary": "Amazon Kiro AI coding assistant launched GA with tiered credit-based pricing: Free tier (50 credits/month), Pro ($20/month, 1,000 credits), Pro+ ($40/month, 2,000 credits). Credits consumed per AI interaction (specs, code generation, debugging)",
-      "previous_state": "Preview-only access, no public pricing",
-      "current_state": "Free tier: 50 credits/month. Pro: $20/month (1,000 credits). Pro+: $40/month (2,000 credits). GA availability",
-      "impact": "medium",
-      "source_url": "https://kiro.dev/pricing",
-      "category": "AI Coding",
-      "alternatives": [
-        "Cursor",
-        "Windsurf",
-        "GitHub Copilot",
-        "Claude Code"
-      ]
-    },
-    {
-      "vendor": "Replit",
-      "change_type": "pricing_restructured",
-      "date": "2026-04-01",
-      "summary": "Replit Core plan dropped from $25/month to $20/month. New Pro plan added at $100/month with higher credit allocation. Free tier unchanged (limited AI credits, basic compute). Price reduction makes Core more competitive with Cursor Pro ($20/month)",
-      "previous_state": "Free tier + Core plan at $25/month",
-      "current_state": "Free tier + Core plan at $20/month + new Pro plan at $100/month",
-      "impact": "low",
-      "source_url": "https://replit.com/pricing",
-      "category": "Cloud IDE",
-      "alternatives": [
-        "GitHub Codespaces",
-        "Gitpod",
-        "CodeSandbox"
-      ]
-    },
-    {
-      "vendor": "SonarQube Cloud",
-      "change_type": "pricing_restructured",
-      "date": "2026-04-01",
-      "summary": "SonarQube Cloud introduced more granular Team tier pricing with differentiated feature access. Free tier for open-source projects remains. Paid tiers restructured for clearer scaling path from small teams to enterprise",
-      "previous_state": "Free (open source) + Developer + Enterprise tiers",
-      "current_state": "Free (open source) + Team (granular tiers) + Enterprise. More pricing options for mid-size teams",
-      "impact": "low",
-      "source_url": "https://www.sonarsource.com/plans-and-pricing/sonarqube/cloud/",
-      "category": "Code Quality",
-      "alternatives": [
-        "CodeClimate",
-        "Codacy",
-        "DeepSource"
-      ]
-    },
-    {
-      "vendor": "Cursor",
-      "change_type": "new_tier",
-      "date": "2026-04-07",
-      "summary": "Cursor introduced Pro+ tier at $60/month between Pro ($20) and Ultra ($200). Pro+ includes 10x premium model requests vs Pro, priority access, and expanded context window. Expands the pricing ladder from 3 tiers (Free/Pro/Ultra) to 4 (Free/Pro/Pro+/Ultra), filling the $20-$200 gap.",
-      "previous_state": "3-tier pricing: Free (2K completions, 50 slow requests), Pro $20/mo (unlimited completions, 500 fast requests), Ultra $200/mo",
-      "current_state": "4-tier pricing: Free (2K completions, 50 slow requests), Pro $20/mo, Pro+ $60/mo (10x premium requests, priority access, more context), Ultra $200/mo",
-      "impact": "medium",
-      "source_url": "https://www.cursor.com/pricing",
-      "category": "AI Coding",
-      "alternatives": [
-        "GitHub Copilot",
-        "Windsurf",
-        "Cline",
-        "Claude Code"
-      ]
-    },
-    {
-      "vendor": "Google Gemini API",
-      "change_type": "restriction",
-      "date": "2026-04-08",
-      "summary": "Gemini API free tier restricted to Flash and Flash-Lite models only (April 2026). Gemini 2.5 Pro and other Pro models now require a paid billing account. Previously free users could access Pro models with rate limits. Combined with April 1 spend cap enforcement, this significantly narrows what is available at $0.",
-      "previous_state": "Free tier included access to both Flash and Pro models with rate limits. Gemini 2.5 Pro accessible to free users at reduced rates",
-      "current_state": "Free tier restricted to Flash and Flash-Lite models only. Pro models (Gemini 2.5 Pro) require paid billing account. Free users limited to lighter-weight models",
-      "impact": "high",
-      "source_url": "https://ai.google.dev/gemini-api/docs/pricing",
-      "category": "AI / ML",
-      "alternatives": [
-        "OpenRouter",
-        "Groq",
-        "Together AI",
-        "Anthropic Claude API"
-      ]
-    },
-    {
-      "vendor": "OVHcloud",
-      "change_type": "pricing_restructured",
-      "date": "2026-04-01",
-      "summary": "OVHcloud raised prices 9-11% on newer infrastructure (Public Cloud, Bare Metal, VPS 2026 range) effective April 1, 2026. Free tier unchanged. Applies to 2026-range products only \u2014 legacy configurations retain previous pricing.",
-      "previous_state": "Previous pricing on Public Cloud, Bare Metal, and VPS 2026-range products",
-      "current_state": "9-11% price increase on newer infrastructure. Free tier and legacy configurations unaffected",
-      "impact": "medium",
-      "source_url": "https://www.ovhcloud.com/en/pricing/",
-      "category": "Cloud IaaS",
-      "alternatives": [
-        "Hetzner",
-        "DigitalOcean",
-        "Vultr",
-        "Linode"
-      ]
-    },
-    {
-      "vendor": "Amazon SP-API",
-      "change_type": "free_tier_removed",
-      "date": "2026-04-30",
-      "summary": "Amazon Selling Partner API (SP-API) moves to paid access starting April 30, 2026. New base fee of $1,400/year plus per-call fees. Previously free for registered developers. Major impact on Amazon marketplace integrators and third-party seller tools.",
-      "previous_state": "Free API access for registered Amazon developers with standard rate limits",
-      "current_state": "$1,400/year base fee plus per-call fees starting April 30, 2026. No free tier",
-      "impact": "high",
-      "source_url": "https://developer-docs.amazon.com/sp-api/",
-      "category": "E-Commerce",
-      "alternatives": [
-        "Shopify API",
-        "WooCommerce API",
-        "BigCommerce API"
-      ]
-    },
-    {
-      "vendor": "Amazon Kiro",
-      "change_type": "new_free_tier",
-      "date": "2026-04-09",
-      "summary": "Amazon Kiro launched GA with a free tier of 50 interactions/month. Claude-powered IDE focused on spec-driven development. Pro $20/mo (1,000 interactions), Pro+ $40/mo (2,000), Power $200/mo (10,000). Competes directly with Cursor, GitHub Copilot, and Windsurf.",
-      "previous_state": "Preview/beta with limited access",
-      "current_state": "GA with free tier (50 interactions/mo). Four paid tiers: Pro ($20), Pro+ ($40), Power ($200)",
-      "impact": "high",
-      "source_url": "https://kiro.dev/pricing",
-      "category": "AI Coding",
-      "alternatives": [
-        "Cursor",
-        "GitHub Copilot",
-        "Windsurf",
-        "Claude Code"
-      ]
-    },
-    {
-      "vendor": "OpenAI",
-      "change_type": "free_tier_removed",
-      "date": "2026-05-12",
-      "summary": "DALL-E 2 and DALL-E 3 API access discontinued. Developers must migrate to gpt-image-1 (different pricing model, quality tiers changed from standard/hd to low/medium/high) or switch to free alternatives like Pollinations.AI or Lumenfall.ai",
-      "previous_state": "DALL-E 3 API: $0.040-$0.120/image (1024x1024), paid via API credits",
-      "current_state": "DALL-E 2 & 3 API shut down. Replacement: gpt-image-1 at $0.011-$0.167/image with new quality tiers",
-      "impact": "high",
-      "source_url": "https://platform.openai.com/docs/deprecations",
-      "category": "AI / ML",
-      "alternatives": [
-        "gpt-image-1",
-        "Pollinations.AI",
-        "Lumenfall.ai",
-        "Cloudflare Workers AI",
-        "Stability AI",
-        "Replicate"
-      ]
-    },
-    {
-      "vendor": "OpenAI",
-      "change_type": "product_deprecated",
-      "date": "2026-05-07",
-      "summary": "Realtime API beta endpoints deprecated. Developers must remove OpenAI-Beta header, use new client_secrets endpoint, specify session_type, and update event names. GA Realtime API is the direct replacement.",
-      "previous_state": "Realtime API beta: required OpenAI-Beta: realtime=v1 header, single session type, beta event names",
-      "current_state": "Realtime API GA: no beta header, POST /v1/realtime/client_secrets for ephemeral keys, session_type required (speech-to-speech or transcription), updated event names",
-      "impact": "high",
-      "source_url": "https://platform.openai.com/docs/deprecations",
-      "category": "AI / ML",
-      "alternatives": [
-        "OpenAI Realtime API (GA)",
-        "Deepgram",
-        "AssemblyAI",
-        "Azure OpenAI Realtime",
-        "ElevenLabs",
-        "Google Cloud Speech-to-Text"
-      ]
-    }
-  ]
+    "changes": [
+        {
+            "vendor": "Brave Search API",
+            "change_type": "free_tier_removed",
+            "date": "2026-02-12",
+            "summary": "Free plan (5,000 queries/month) replaced with metered billing at $5/1,000 requests. $5 monthly credit provided as offset (~1,000 queries). Credit cards now actively charged with no spending cap",
+            "previous_state": "Free plan: 5,000 queries/month, 3 QPS, no credit card required",
+            "current_state": "Metered billing at $5/1,000 requests with $5 monthly credit (~1,000 free queries). No free plan. Credit card required, no spending cap",
+            "impact": "high",
+            "source_url": "https://www.implicator.ai/brave-drops-free-search-api-tier-puts-all-developers-on-metered-billing/",
+            "category": "Search",
+            "alternatives": [
+                "SerpAPI",
+                "Google Custom Search"
+            ]
+        },
+        {
+            "vendor": "X API (Twitter)",
+            "change_type": "free_tier_removed",
+            "date": "2026-02-09",
+            "summary": "Free tier replaced with pay-per-use + $10 one-time credit",
+            "previous_state": "Free basic endpoints (Like, Follow, List, etc.)",
+            "current_state": "Pay-per-use pricing, $10 one-time credit for existing users, free plan expired Feb 13",
+            "impact": "high",
+            "source_url": "https://developer.x.com/en",
+            "category": "APIs",
+            "alternatives": [
+                "Bluesky API",
+                "Mastodon API"
+            ]
+        },
+        {
+            "vendor": "Spotify API",
+            "change_type": "limits_reduced",
+            "date": "2026-02-11",
+            "summary": "Premium subscription now required for development mode, test users cut from 25 to 5",
+            "previous_state": "Free developer access to Web API, 25 test users",
+            "current_state": "Spotify Premium subscription required for dev mode, 5 test users max, multiple endpoints deprecated",
+            "impact": "high",
+            "source_url": "https://developer.spotify.com/",
+            "category": "APIs",
+            "alternatives": [
+                "Last.fm API",
+                "MusicBrainz API"
+            ]
+        },
+        {
+            "vendor": "Amazon SP-API",
+            "change_type": "pricing_restructured",
+            "date": "2026-01-31",
+            "summary": "Free access ended after 10+ years, now $1,400/year + per-call fees starting April 30",
+            "previous_state": "Free API access for 10+ years",
+            "current_state": "$1,400/year subscription + per-call fees (effective April 30, 2026)",
+            "impact": "high",
+            "source_url": "https://developer-docs.amazon.com/sp-api/",
+            "category": "APIs",
+            "alternatives": []
+        },
+        {
+            "vendor": "PythonAnywhere",
+            "change_type": "pricing_restructured",
+            "date": "2026-01-15",
+            "summary": "$5 Hacker tier eliminated, features merged into free and higher tiers",
+            "previous_state": "$5/mo Hacker tier with custom domains and more storage",
+            "current_state": "Free tier and $10/mo+ paid tiers only, Hacker tier removed",
+            "impact": "medium",
+            "source_url": "https://www.pythonanywhere.com/pricing/",
+            "category": "Hosting",
+            "alternatives": [
+                "Render",
+                "Railway",
+                "Replit"
+            ]
+        },
+        {
+            "vendor": "Google Gemini",
+            "change_type": "limits_reduced",
+            "date": "2025-12-15",
+            "summary": "Google quietly slashed Gemini API free tier rate limits by 50-80% in late 2025. Gemini 2.5 Flash went from ~250 requests/day to 20-50. Pro model free tier removed entirely. A Google PM admitted generous limits were only supposed to be available for a single weekend",
+            "previous_state": "Pro model available on free tier, Flash ~250 RPD, Flash-Lite generous limits",
+            "current_state": "Pro free tier removed. Flash reduced to 10 RPM (~20-50 RPD). Flash-Lite 15 RPM. 50-80% reduction across the board. Gemini 2.0 Flash retiring March 2026",
+            "impact": "high",
+            "source_url": "https://ai.google.dev/gemini-api/docs/pricing",
+            "category": "AI / ML",
+            "alternatives": [
+                "OpenRouter",
+                "Groq",
+                "Together AI"
+            ]
+        },
+        {
+            "vendor": "Netlify",
+            "change_type": "pricing_restructured",
+            "date": "2025-09-04",
+            "summary": "Restructured to credit-based pricing; sites pause on credit exhaustion",
+            "previous_state": "Traditional tiered pricing with fixed monthly allowances",
+            "current_state": "300 credits/month free, sites pause on exhaustion",
+            "impact": "medium",
+            "source_url": "https://www.netlify.com/pricing/",
+            "category": "Hosting",
+            "alternatives": [
+                "Vercel",
+                "Cloudflare Pages",
+                "GitHub Pages"
+            ]
+        },
+        {
+            "vendor": "Netlify",
+            "change_type": "restriction",
+            "date": "2026-03-01",
+            "summary": "Every repo committer is now charged as a full Pro seat ($19/mo) when using Netlify CMS or Identity with a private repo. Previously only users who logged into the Netlify dashboard counted as seats",
+            "previous_state": "Only Netlify dashboard users counted as billable seats",
+            "current_state": "All repo committers to connected private repos count as Pro seats ($19/mo each) when using CMS or Identity features",
+            "impact": "high",
+            "source_url": "https://www.netlify.com/pricing/",
+            "category": "Hosting",
+            "alternatives": [
+                "Vercel",
+                "Cloudflare Pages",
+                "GitHub Pages"
+            ]
+        },
+        {
+            "vendor": "Supabase",
+            "change_type": "limits_reduced",
+            "date": "2026-02-01",
+            "summary": "Project pause policy tightened \u2014 inactive projects now pause after 1 week",
+            "previous_state": "Longer inactivity window before project pause",
+            "current_state": "Projects pause after 1 week of inactivity on free tier",
+            "impact": "medium",
+            "source_url": "https://supabase.com/pricing",
+            "category": "Databases",
+            "alternatives": [
+                "Neon",
+                "PlanetScale",
+                "CockroachDB"
+            ]
+        },
+        {
+            "vendor": "Cloudflare",
+            "change_type": "new_free_tier",
+            "date": "2026-02-04",
+            "summary": "Queues added to Workers free plan \u2014 message queuing now free",
+            "previous_state": "Queues was paid-only",
+            "current_state": "Queues included in free Workers plan",
+            "impact": "medium",
+            "source_url": "https://developers.cloudflare.com/queues/",
+            "category": "Cloud IaaS",
+            "alternatives": []
+        },
+        {
+            "vendor": "GitHub Actions",
+            "change_type": "pricing_postponed",
+            "date": "2026-01-01",
+            "summary": "Self-hosted runner per-minute fee ($0.002/min) announced for March 2026 was postponed indefinitely after community backlash. Self-hosted runners remain free. Separately, hosted runner prices were reduced up to 39% (Jan 2026)",
+            "previous_state": "Self-hosted runners free. Previous per-minute pricing for hosted runners",
+            "current_state": "Self-hosted runners remain free \u2014 no orchestration fees. Hosted runners 39% cheaper. GitHub re-evaluating self-hosted pricing approach",
+            "impact": "low",
+            "source_url": "https://github.com/orgs/community/discussions/182089",
+            "category": "CI/CD",
+            "alternatives": [
+                "GitLab CI",
+                "CircleCI",
+                "Buildkite"
+            ]
+        },
+        {
+            "vendor": "Bright Data MCP",
+            "change_type": "new_free_tier",
+            "date": "2025-08-14",
+            "summary": "Launched free tier for MCP Web Server \u2014 5,000 requests/month for agent developers",
+            "previous_state": "Paid-only web scraping API",
+            "current_state": "5,000 free monthly requests on Rapid mode, includes search_engine and scrape_as_markdown tools, handles JS rendering and CAPTCHAs",
+            "impact": "medium",
+            "source_url": "https://brightdata.com/pricing/mcp-server",
+            "category": "Web Scraping",
+            "alternatives": [
+                "Firecrawl",
+                "Apify"
+            ]
+        },
+        {
+            "vendor": "Stripe",
+            "change_type": "pricing_restructured",
+            "date": "2026-02-01",
+            "summary": "Managed Payments (Merchant of Record) service entering general availability \u2014 Stripe handles tax, billing, fraud, and disputes",
+            "previous_state": "Payment processing only \u2014 developers handled tax compliance, fraud, and disputes separately",
+            "current_state": "Managed Payments acts as Merchant of Record in 75+ countries, handling sales tax/VAT/GST, fraud prevention, dispute resolution, and transaction-level support",
+            "impact": "high",
+            "source_url": "https://docs.stripe.com/payments/managed-payments",
+            "category": "Payments",
+            "alternatives": [
+                "Paddle",
+                "Lemon Squeezy"
+            ]
+        },
+        {
+            "vendor": "Postman",
+            "change_type": "restriction",
+            "date": "2026-03-01",
+            "summary": "Free plan now single-user only. Team collaboration (shared workspaces, collection sharing) requires paid plan at $19/user/month",
+            "previous_state": "Free plan supported up to 3 users in shared workspaces with collection sharing and 25 monitoring calls/month",
+            "current_state": "Free plan = single user only with unlimited collections, environments, mock servers, basic monitoring. Teams require Team plan ($19/user/mo) or higher",
+            "impact": "high",
+            "source_url": "https://www.postman.com/pricing/",
+            "category": "Testing",
+            "alternatives": [
+                "Bruno",
+                "Insomnia",
+                "Hoppscotch",
+                "Apidog",
+                "Thunder Client"
+            ]
+        },
+        {
+            "vendor": "Atlassian Forge",
+            "change_type": "pricing_restructured",
+            "date": "2026-01-01",
+            "summary": "Forge platform moved from free to consumption-based billing for compute and storage",
+            "previous_state": "Entirely free \u2014 no charges for compute, storage, or KV operations",
+            "current_state": "Free monthly allowances per app (100K GB-sec compute, 0.1 GB KVS, 1 GB logs, 1 hr SQL), usage above thresholds billed",
+            "impact": "medium",
+            "source_url": "https://www.atlassian.com/blog/developer/updates-to-forge-pricing-effective-january-2026",
+            "category": "Developer Tools",
+            "alternatives": [
+                "AWS Lambda",
+                "Self-hosted Connect apps"
+            ]
+        },
+        {
+            "vendor": "Fly.io",
+            "change_type": "pricing_restructured",
+            "date": "2026-01-01",
+            "summary": "Volume snapshots now billed \u2014 previously free automatic snapshots now cost $0.08/GB-month",
+            "previous_state": "Automatic volume snapshots included at no cost, enabled by default",
+            "current_state": "$0.08/GB-month for snapshot storage, first 10 GB free. Snapshots can be disabled to avoid charges",
+            "impact": "medium",
+            "source_url": "https://fly.io/docs/about/pricing/",
+            "category": "Cloud Hosting",
+            "alternatives": [
+                "Render",
+                "Railway",
+                "Koyeb"
+            ]
+        },
+        {
+            "vendor": "Cloudflare Durable Objects",
+            "change_type": "pricing_restructured",
+            "date": "2026-01-07",
+            "summary": "SQLite storage billing began for Durable Objects \u2014 previously free during beta",
+            "previous_state": "SQLite storage in Durable Objects was free during public beta (compute already billed)",
+            "current_state": "Storage charged per GB-hour on Workers Paid plan, first 10 GB included. Free plan users unaffected",
+            "impact": "low",
+            "source_url": "https://developers.cloudflare.com/durable-objects/platform/pricing/",
+            "category": "Cloud IaaS",
+            "alternatives": [
+                "Upstash Redis",
+                "Cloudflare KV",
+                "Neon"
+            ]
+        },
+        {
+            "vendor": "Sentry",
+            "change_type": "pricing_restructured",
+            "date": "2025-08-15",
+            "summary": "Switched from performance units to spans-based metrics for error and performance monitoring",
+            "previous_state": "Performance units pricing model",
+            "current_state": "Spans-based metrics: Developer plan includes 50K errors + 10M spans/month free. Reserved volume pricing replaces on-demand",
+            "impact": "medium",
+            "source_url": "https://sentry.io/pricing/",
+            "category": "Monitoring",
+            "alternatives": [
+                "Datadog",
+                "New Relic",
+                "BetterStack"
+            ]
+        },
+        {
+            "vendor": "Neon",
+            "change_type": "pricing_restructured",
+            "date": "2026-01-15",
+            "summary": "Moved to fully usage-based pricing model post-Databricks acquisition \u2014 free tier storage now per-project, projects increased 10\u2192100, branches capped at 10 per project, Neon Auth added",
+            "previous_state": "Free tier: 0.5 GB total storage, 191.9 compute hours, 10 projects, unlimited branches",
+            "current_state": "Free tier: 0.5 GB per project (up to 5 GB across 100 projects), 100 CU-hours/month per project, 10 branches/project, Neon Auth 60K MAU, auto-scaling up to 2 CU, scale-to-zero",
+            "impact": "medium",
+            "source_url": "https://neon.com/pricing",
+            "category": "Databases",
+            "alternatives": [
+                "Supabase",
+                "CockroachDB",
+                "Turso"
+            ]
+        },
+        {
+            "vendor": "Vercel",
+            "change_type": "pricing_restructured",
+            "date": "2026-01-01",
+            "summary": "Pro plan moved to credit-based model ($20/mo credit pool), Hobby plan metrics renamed and restructured \u2014 bandwidth\u2192Fast Data Transfer, serverless split into Active CPU + Provisioned Memory, Blob Storage and Image Transformations added",
+            "previous_state": "Hobby: 100 GB bandwidth, 100 GB-hours serverless. Pro: fixed per-resource allocations",
+            "current_state": "Hobby: 100 GB/mo Fast Data Transfer, 4 hrs Active CPU, 360 GB-hrs Provisioned Memory, 1M edge requests, 1 GB Blob Storage, 5K image transformations. Pro: $20/mo credit pool across all resources, SAML SSO and HIPAA included",
+            "impact": "medium",
+            "source_url": "https://vercel.com/pricing",
+            "category": "Cloud Hosting",
+            "alternatives": [
+                "Netlify",
+                "Cloudflare Pages",
+                "Render"
+            ]
+        },
+        {
+            "vendor": "Atlassian",
+            "change_type": "pricing_restructured",
+            "date": "2026-02-17",
+            "summary": "Data Center pricing increased 15-40% across Jira, Confluence, and JSM. New DC licenses end March 30 \u2014 cloud mandatory for new customers",
+            "previous_state": "Standard Data Center pricing with Advantaged/legacy discounts",
+            "current_state": "15% standard list increase, 18-40% for legacy Advantaged pricing tiers. No new DC licenses after March 30, 2026. Full DC end-of-life March 2029",
+            "impact": "high",
+            "source_url": "https://www.atlassian.com/licensing/future-pricing",
+            "category": "Developer Tools",
+            "alternatives": [
+                "Linear",
+                "Jira Cloud",
+                "Shortcut"
+            ]
+        },
+        {
+            "vendor": "Docker Hub",
+            "change_type": "pricing_restructured",
+            "date": "2024-12-10",
+            "summary": "Docker Pro +80% ($5\u2192$9/mo), Team +67% ($9\u2192$15/mo). Free tier: Build Cloud minutes removed, Scout repos cut 3\u21921, private repos limited to 1 with 2GB storage",
+            "previous_state": "Pro $5/user/month, Team $9/user/month. Free tier included Build Cloud minutes, 3 Scout repos",
+            "current_state": "Pro $9/user/month, Team $15/user/month. Free: 1 private repo (2GB), 1 Scout repo, no Build Cloud minutes, 40 pulls/hour",
+            "impact": "high",
+            "source_url": "https://www.docker.com/blog/november-2024-updated-plans-announcement/",
+            "category": "Container Registry",
+            "alternatives": [
+                "GitHub Container Registry",
+                "Quay.io",
+                "Podman"
+            ]
+        },
+        {
+            "vendor": "DigitalOcean",
+            "change_type": "limits_increased",
+            "date": "2025-01-22",
+            "summary": "Hatch startup program expanded to up to $100K compute credits plus up to 3 months free H100 GPU access for AI/ML startups",
+            "previous_state": "Standard Hatch startup credits program",
+            "current_state": "Up to $100K compute credits (12 months, excludes GPU). Separate GPU benefit: discounted H100 at ~$1.90/hr (vs $3.39 standard) plus up to 3 months free GPU access",
+            "impact": "medium",
+            "source_url": "https://investors.digitalocean.com/news/news-details/2025/DigitalOcean-Announces-New-Benefits-for-Hatch-Startup-Program/default.aspx",
+            "category": "Cloud IaaS",
+            "alternatives": [
+                "AWS Activate",
+                "Google Cloud for Startups",
+                "Azure for Startups"
+            ]
+        },
+        {
+            "vendor": "Google Cloud",
+            "change_type": "limits_increased",
+            "date": "2026-01-01",
+            "summary": "Google for Startups Cloud Program now offers up to $350K GCP credits for AI-first startups, plus $10K Anthropic (Claude) partner credits via Model Garden",
+            "previous_state": "Up to $200K GCP credits for standard startups",
+            "current_state": "Scale AI Tier: up to $350K GCP credits ($250K year 1, $100K year 2). Standard: $200K. Partner credits: $10K Anthropic/Claude via Model Garden, Fireworks AI, MongoDB Atlas, CockroachDB, 1yr free GitLab Ultimate",
+            "impact": "high",
+            "source_url": "https://cloud.google.com/startup/ai",
+            "category": "Cloud IaaS",
+            "alternatives": [
+                "AWS Activate",
+                "Azure for Startups",
+                "DigitalOcean Hatch"
+            ]
+        },
+        {
+            "vendor": "AWS",
+            "change_type": "pricing_restructured",
+            "date": "2026-01-04",
+            "summary": "EC2 Capacity Blocks for ML GPU prices increased ~15% across regions. p5e.48xlarge went from $34.61 to $39.80/hr (US East) and $43.26 to $49.75/hr (US West N. California)",
+            "previous_state": "p5e.48xlarge at $34.61/hr (US East), $43.26/hr (US West N. California) for Capacity Blocks",
+            "current_state": "p5e.48xlarge at $39.80/hr (US East), $49.75/hr (US West N. California). ~15% increase across most GPU Capacity Block instances",
+            "impact": "medium",
+            "source_url": "https://www.theregister.com/2026/01/05/aws_price_increase/",
+            "category": "Cloud IaaS",
+            "alternatives": [
+                "Google Cloud GPUs",
+                "Azure GPU VMs",
+                "Lambda Cloud"
+            ]
+        },
+        {
+            "vendor": "Google",
+            "change_type": "pricing_restructured",
+            "date": "2026-01-27",
+            "summary": "Google Developer Program Premium merged into Google One AI Pro ($19.99/mo, includes $10 Cloud credits) and AI Ultra ($100 Cloud credits). Developer benefits now bundled into consumer AI subscriptions",
+            "previous_state": "Separate Developer Program Premium subscription ($299/year) with dev tools and perks",
+            "current_state": "Developer benefits folded into AI Pro ($19.99/mo, $10 Cloud credits for Vertex AI/Cloud Run/Gemini API) and AI Ultra ($100 Cloud credits). Developer Program Premium being phased out for @gmail.com accounts",
+            "impact": "medium",
+            "source_url": "https://blog.google/innovation-and-ai/technology/developers-tools/gdp-premium-ai-pro-ultra/",
+            "category": "Developer Tools",
+            "alternatives": [
+                "GitHub Copilot",
+                "JetBrains AI"
+            ]
+        },
+        {
+            "vendor": "OpenAI",
+            "change_type": "free_tier_removed",
+            "date": "2026-08-26",
+            "summary": "Assistants API deprecated, full shutdown August 26, 2026. Developers must migrate to Responses API + Conversations API",
+            "previous_state": "Assistants API available with code interpreter, file search, function calling, and Threads for conversation management",
+            "current_state": "Deprecated. Full shutdown Aug 26, 2026. Migration required: Assistants \u2192 Prompts + Responses API, Threads \u2192 Conversations API. No automated migration tool provided",
+            "impact": "high",
+            "source_url": "https://community.openai.com/t/assistants-api-beta-deprecation-august-26-2026-sunset/1354666",
+            "category": "AI/ML",
+            "alternatives": [
+                "Anthropic Claude API",
+                "Google Gemini API",
+                "Cohere API"
+            ]
+        },
+        {
+            "vendor": "Hetzner",
+            "change_type": "pricing_restructured",
+            "date": "2026-04-01",
+            "summary": "Cloud & dedicated server prices increasing 30-50%. Entry-level CX23: \u20ac2.99\u2192\u20ac3.99/mo (+33%). Applies to new and existing customers. Driven by DRAM (+171% YoY) and NVMe SSD cost surges from AI infrastructure demand",
+            "previous_state": "Lower cloud server pricing across Germany, Finland, US, and Singapore data centers (e.g., CX23 at \u20ac2.99/mo)",
+            "current_state": "30-37% increase on cloud servers, up to 50% on select dedicated/storage products. All regions and all customers (new and existing) affected. Announced Feb 23, 2026",
+            "impact": "high",
+            "source_url": "https://www.hetzner.com/pressroom/statement-price-adjustment/",
+            "category": "Cloud Hosting",
+            "alternatives": [
+                "DigitalOcean",
+                "Vultr",
+                "OVHcloud"
+            ]
+        },
+        {
+            "vendor": "Anthropic",
+            "change_type": "limits_increased",
+            "date": "2026-02-05",
+            "summary": "Claude Opus 4.6 API pricing at $5/$25 per MTok (input/output) \u2014 67% below previous Opus 4/4.1 pricing of $15/$75. Frontier AI model at mid-tier prices",
+            "previous_state": "Opus 4/4.1 priced at $15/$75 per million tokens (input/output)",
+            "current_state": "Opus 4.6 at $5/$25 per MTok. Extended context (>200K tokens): $10/$37.50. Batch API: $2.50/$12.50. Price reduction began with Opus 4.5 generation",
+            "impact": "high",
+            "source_url": "https://docs.anthropic.com/en/docs/about-claude/models",
+            "category": "AI/ML APIs",
+            "alternatives": [
+                "OpenAI GPT-4o",
+                "Google Gemini",
+                "Mistral"
+            ]
+        },
+        {
+            "vendor": "OpenAI",
+            "change_type": "limits_reduced",
+            "date": "2026-02-09",
+            "summary": "Ads launched in ChatGPT Free and Go ($8/mo) tiers. Sponsored units from major brands appear below responses on first prompt. $60 CPM, $200K minimum ad commitment",
+            "previous_state": "Ad-free experience across all ChatGPT tiers including Free",
+            "current_state": "Free and Go tiers show contextual ads (labeled 'sponsored') below responses. Plus/Pro/Business/Enterprise/Education tiers remain ad-free. Users can opt out at cost of reduced daily message limits",
+            "impact": "high",
+            "source_url": "https://openai.com/index/testing-ads-in-chatgpt/",
+            "category": "AI/ML",
+            "alternatives": [
+                "Anthropic Claude",
+                "Google Gemini",
+                "Perplexity"
+            ]
+        },
+        {
+            "vendor": "Google Programmable Search Engine",
+            "change_type": "limits_reduced",
+            "date": "2026-01-22",
+            "summary": "Free full-web search being discontinued. Free tier restricted to max 50 domains per search engine. Migration deadline January 1, 2027",
+            "previous_state": "Free search across the entire web with 10,000 queries/day limit via Custom Search JSON API",
+            "current_state": "Free tier restricted to searching up to 50 specified domains only. Full-web search requires paid Google Cloud Search or Vertex AI Search. Takes effect January 1, 2027",
+            "impact": "high",
+            "source_url": "https://developers.google.com/custom-search",
+            "category": "Search",
+            "alternatives": [
+                "Brave Search API",
+                "SerpAPI",
+                "Bing Web Search API",
+                "Meilisearch"
+            ]
+        },
+        {
+            "vendor": "odrive",
+            "change_type": "free_tier_removed",
+            "date": "2026-03-31",
+            "summary": "odrive free tier discontinued effective March 31, 2026. Previously offered free unified cloud storage sync across multiple providers (Google Drive, Dropbox, S3, etc.)",
+            "previous_state": "Free tier with basic sync across multiple cloud storage providers, file manager interface",
+            "current_state": "Free tier removed. Business plans at $20/user/month (min 5 users) or $200/year org subscription. March 31, 2026 deadline",
+            "impact": "medium",
+            "source_url": "https://www.odrive.com/pricing",
+            "category": "Storage",
+            "alternatives": [
+                "rclone",
+                "Cyberduck",
+                "MultCloud"
+            ]
+        },
+        {
+            "vendor": "MinIO",
+            "change_type": "open_source_killed",
+            "date": "2026-02-12",
+            "summary": "MinIO archived its open-source GitHub repository. All development moved to proprietary MinIO AIStor. No new Docker images, PRs, or contributions accepted. Only case-by-case critical security fixes",
+            "previous_state": "Open-source S3-compatible object storage under AGPL-3.0. Active GitHub repo with community contributions, regular Docker image releases",
+            "current_state": "GitHub repository archived. Development moved to proprietary AIStor product. No new open-source releases. Critical security fixes only on case-by-case basis",
+            "impact": "high",
+            "source_url": "https://linuxiac.com/minio-ends-active-development/",
+            "category": "Storage",
+            "alternatives": [
+                "Ceph",
+                "SeaweedFS",
+                "GarageHQ",
+                "Apache Ozone"
+            ]
+        },
+        {
+            "vendor": "Microsoft Partner Developer Benefits",
+            "change_type": "pricing_restructured",
+            "date": "2026-02-13",
+            "summary": "Per-user monthly Azure credits eliminated, replaced with organization-level bulk Azure credits. Visual Studio license in all benefit tiers now exclusively VS Enterprise IDE",
+            "previous_state": "Per-user monthly Azure credits allocated individually. Mix of Visual Studio Professional and Enterprise licenses across tiers",
+            "current_state": "Organization-level bulk Azure credits (shared pool). All tiers include VS Enterprise IDE only. Per-user monthly credits discontinued",
+            "impact": "medium",
+            "source_url": "https://techcommunity.microsoft.com/discussions/partnerbenefitsforum/new-updates-to-developer-benefits-february-2026/4495536",
+            "category": "Cloud IaaS",
+            "alternatives": [
+                "AWS Partner Network",
+                "Google Cloud Partner Advantage"
+            ]
+        },
+        {
+            "vendor": "Cloudflare Startup Program",
+            "change_type": "startup_program_expanded",
+            "date": "2026-02-01",
+            "summary": "Startup program revamped to 4 tiers with up to $250,000 in credits (previously lower). Tiers: Bootstrapped $5K, Up-and-Coming $25K, Seed-Funded $100K, High Growth $250K. Credits expire within 1 year",
+            "previous_state": "Smaller startup program with fewer tiers and lower credit amounts",
+            "current_state": "4 tiers: $5K, $25K, $100K, $250K credits. Covers Workers, R2, Workers AI, Stream. Caps: $10K for R2/Cache Reserve, $50K for Workers AI. Credits expire within 1 year",
+            "impact": "high",
+            "source_url": "https://blog.cloudflare.com/startup-program-250k-credits/",
+            "category": "Cloud IaaS",
+            "alternatives": [
+                "AWS Activate",
+                "Google for Startups Cloud Program",
+                "Azure for Startups"
+            ]
+        },
+        {
+            "vendor": "Google Gemini 2.0 Flash",
+            "change_type": "product_deprecated",
+            "date": "2026-03-03",
+            "summary": "Gemini 2.0 Flash and 2.0 Flash-Lite models deprecated, scheduled for retirement. Free tier continues with Gemini 2.5 models. Developers on 2.0 must migrate",
+            "previous_state": "Gemini 2.0 Flash and Flash-Lite available as free-tier models with standard rate limits",
+            "current_state": "2.0 Flash and Flash-Lite deprecated. Developers must migrate to Gemini 2.5 Flash or 2.5 Pro. Free tier preserved for 2.5 series",
+            "impact": "medium",
+            "source_url": "https://www.isumsoft.com/internet/gemini-2-flash-deprecation-migration-guide.html",
+            "category": "AI/ML",
+            "alternatives": [
+                "Google Gemini 2.5 Flash",
+                "Google Gemini 2.5 Pro",
+                "OpenRouter",
+                "Groq"
+            ]
+        },
+        {
+            "vendor": "Logz.io",
+            "change_type": "free_tier_removed",
+            "date": "2026-03-02",
+            "summary": "Free Community plan (1 GB/day, 1-day retention, 10 alerts) removed. Only 14-day free trial remains. Consumption-based pricing starts at $0.92/ingested GB/day",
+            "previous_state": "Free Community plan: 1 GB/day ingestion, 1-day retention, 10 alerts, ML-powered anomaly detection",
+            "current_state": "14-day free trial only. Pay-as-go: $0.92/GB/day logs, $0.40/1K metrics/day, $0.16/1M spans/day. No permanent free tier",
+            "impact": "medium",
+            "source_url": "https://logz.io/pricing/",
+            "category": "Logging",
+            "alternatives": [
+                "Grafana Cloud",
+                "BetterStack",
+                "Axiom",
+                "New Relic"
+            ]
+        },
+        {
+            "vendor": "X (Twitter)",
+            "change_type": "pricing_model_change",
+            "date": "2026-02-06",
+            "summary": "Pay-per-use pricing model introduced alongside existing fixed tiers. Legacy free tier users migrated to pay-per-use with $10 voucher. Free tier effectively reduced to proof-of-concept only (~500 posts/month read, no search)",
+            "previous_state": "Fixed tiers: Free (limited), Basic $100/mo, Pro $5,000/mo, Enterprise $42,000/mo",
+            "current_state": "Pay-per-use model added: per-operation billing (read, search, write priced separately). Fixed tiers remain: Free (very limited), Basic $200/mo, Pro $5,000/mo, Enterprise $42,000/mo",
+            "impact": "high",
+            "source_url": "https://devcommunity.x.com/t/announcing-the-launch-of-x-api-pay-per-use-pricing/256476",
+            "category": "API Gateway",
+            "alternatives": [
+                "Bluesky API",
+                "Mastodon API",
+                "Reddit API"
+            ]
+        },
+        {
+            "vendor": "OpenAI",
+            "change_type": "limits_reduced",
+            "date": "2025-06-01",
+            "summary": "Free trial credits ($5-$18 for new accounts) completely discontinued. Free tier now limited to GPT-3.5 Turbo at 3 RPM with no credits. All advanced models (GPT-4, DALL-E, Whisper) require paid access",
+            "previous_state": "$5-$18 in free trial credits for new accounts, 3-month expiry, access to all models",
+            "current_state": "No free credits. Free tier: GPT-3.5 Turbo only, 3 requests/minute. Must add payment method for any other model access",
+            "impact": "high",
+            "source_url": "https://openai.com/api/pricing/",
+            "category": "AI / ML",
+            "alternatives": [
+                "Google Gemini API",
+                "Anthropic Claude API",
+                "Mistral API",
+                "Groq"
+            ]
+        },
+        {
+            "vendor": "Xero Developer API",
+            "change_type": "pricing_model_change",
+            "date": "2026-03-02",
+            "summary": "Xero retiring revenue-share model, moving to 5-tier connection+egress pricing. No more free API access for developers. Costs jumping from ~$0 to $17K+/year for some. Also banning API data use for AI/ML model training",
+            "previous_state": "Revenue-share model with effective free API access for developers building Xero integrations",
+            "current_state": "5-tier usage-based pricing: connection fees + data egress charges. No free tier. Explicit prohibition on using API data for AI/ML training",
+            "impact": "high",
+            "source_url": "https://developer.xero.com/pricing",
+            "category": "API Gateway",
+            "alternatives": [
+                "QuickBooks API",
+                "FreshBooks API",
+                "Wave API"
+            ]
+        },
+        {
+            "vendor": "SendGrid",
+            "change_type": "free_tier_removed",
+            "date": "2025-05-27",
+            "summary": "Perpetual free tier (100 emails/day) eliminated. Replaced with 60-day trial only. Paid plans start at $19.95/month",
+            "previous_state": "Free plan: 100 emails/day forever, no credit card required",
+            "current_state": "60-day trial only (100 emails/day, 100 contacts). Paid plans from $19.95/month after trial",
+            "impact": "high",
+            "source_url": "https://sendgrid.com/en-us/pricing",
+            "category": "Email",
+            "alternatives": [
+                "Resend",
+                "Postmark",
+                "Mailgun",
+                "Amazon SES"
+            ]
+        },
+        {
+            "vendor": "Firebase",
+            "change_type": "limits_reduced",
+            "date": "2026-02-03",
+            "summary": "Cloud Storage removed from Spark (free) plan. Projects on Spark with default appspot.com buckets lose console access and API calls return 402/403 errors. Must upgrade to Blaze (pay-as-you-go) to use Cloud Storage",
+            "previous_state": "Spark plan included Cloud Storage: 5 GB storage, 1 GB/day download, 20K uploads/day, 50K downloads/day",
+            "current_state": "Cloud Storage requires Blaze plan. Blaze provides no-cost quota (1 GiB storage, 10 GB download/month) before charges begin, but credit card required. Other Spark limits unchanged (Firestore, Auth, Functions, Hosting)",
+            "impact": "high",
+            "source_url": "https://firebase.google.com/docs/storage/faqs-storage-changes-announced-sept-2024",
+            "category": "Cloud Storage",
+            "alternatives": [
+                "Supabase Storage",
+                "Cloudflare R2",
+                "AWS S3",
+                "Backblaze B2"
+            ]
+        },
+        {
+            "vendor": "PlanetScale",
+            "change_type": "free_tier_removed",
+            "date": "2024-04-08",
+            "summary": "PlanetScale removed free Hobby plan entirely. All databases on free tier deleted after 30-day grace period. Minimum plan now Scaler at $39/month",
+            "previous_state": "Free Hobby plan: 5 GB storage, 1B row reads/month, 10M row writes/month, 1 production branch, 1 development branch",
+            "current_state": "No free tier. Scaler plan starts at $39/month (25 GB storage). Enterprise custom pricing. Company pivoted to enterprise focus",
+            "impact": "high",
+            "source_url": "https://planetscale.com/blog/planetscale-forever",
+            "category": "Databases",
+            "alternatives": [
+                "Neon",
+                "Turso",
+                "Supabase",
+                "CockroachDB"
+            ]
+        },
+        {
+            "vendor": "Fauna",
+            "change_type": "product_deprecated",
+            "date": "2025-05-30",
+            "summary": "Fauna shut down entirely on May 30, 2025. The serverless document database ceased all operations. Over 80,000 development teams affected",
+            "previous_state": "Free tier: 100K read ops/day, 50K write ops/day, 500K compute ops/day, 5 GB storage. Consumption-based pricing above free limits",
+            "current_state": "Service discontinued. No longer available in any form. All customer data deleted",
+            "impact": "high",
+            "source_url": "https://fauna.com",
+            "category": "Databases",
+            "alternatives": [
+                "Supabase",
+                "MongoDB Atlas",
+                "CockroachDB",
+                "DynamoDB"
+            ]
+        },
+        {
+            "vendor": "LocalStack",
+            "change_type": "free_tier_removed",
+            "date": "2026-03-23",
+            "summary": "LocalStack drops open-source Community Edition. Single unified image requires auth token. Free tier replaced with non-commercial-only tier requiring registration. Commercial use requires paid plan starting at $39/month",
+            "previous_state": "Open-source Community Edition: 30+ emulated AWS services (S3, Lambda, DynamoDB, etc.), no registration required, Docker image freely available",
+            "current_state": "Non-commercial free tier requires registration and auth token. Commercial use starts at $39/month. CI credits system introduced. OSS projects, students, and nonprofits get free access",
+            "impact": "high",
+            "source_url": "https://blog.localstack.cloud/the-road-ahead-for-localstack/",
+            "category": "Testing",
+            "alternatives": [
+                "Moto (open-source AWS mock)",
+                "AWS Free Tier",
+                "Testcontainers"
+            ]
+        },
+        {
+            "vendor": "Google",
+            "change_type": "pricing_restructured",
+            "date": "2026-03-30",
+            "summary": "Google Developer Program annual subscription ending March 30. Replaced by Google AI Pro ($10/mo) and AI Ultra ($100/mo) tiers with bundled cloud credits and AI model access.",
+            "previous_state": "Google Developer Program: annual subscription with standalone cloud credits, developer tools access, and learning resources",
+            "current_state": "Google AI Pro ($10/mo) and AI Ultra ($100/mo) tiers bundle cloud credits with AI model access (Gemini, etc). Developer benefits folded into AI-centric subscriptions",
+            "impact": "high",
+            "source_url": "https://developers.google.com/profile/help/benefits",
+            "category": "Cloud IaaS",
+            "alternatives": [
+                "AWS Activate",
+                "Microsoft for Startups",
+                "Google for Startups Cloud"
+            ],
+            "verified_date": "2026-03-04"
+        },
+        {
+            "vendor": "Terragrunt Scale",
+            "change_type": "new_free_tier",
+            "date": "2025-12-15",
+            "summary": "Gruntwork launches free tier for Terragrunt Scale IaC orchestration platform, positioned as HCP Terraform free tier alternative ahead of HashiCorp March 31, 2026 EOL. Includes GitOps, drift detection, and module update automation",
+            "previous_state": "No free tier \u2014 Team plan at $500/month",
+            "current_state": "Free tier with limits matching or exceeding HCP Terraform (500+ managed resources, GitOps, drift detection, Patcher)",
+            "impact": "medium",
+            "source_url": "https://www.gruntwork.io/blog/announcing-the-terragrunt-scale-free-tier",
+            "category": "Infrastructure",
+            "alternatives": [
+                "Spacelift",
+                "env0",
+                "Scalr"
+            ]
+        },
+        {
+            "vendor": "HCP Terraform",
+            "change_type": "pricing_restructured",
+            "date": "2026-03-31",
+            "summary": "HashiCorp legacy free plan for HCP Terraform ends March 31, 2026. All legacy free plan users auto-migrated to enhanced free tier with different limits: 500 managed resources (previously unlimited for small teams), unlimited users, 1 concurrent run, SSO, and policy as code (Sentinel + OPA)",
+            "previous_state": "Legacy free plan with basic Terraform Cloud features",
+            "current_state": "Enhanced free tier: 500 managed resources, unlimited users, 1 concurrent run, SSO, policy as code (Sentinel + OPA). Auto-migration from legacy plan",
+            "impact": "high",
+            "source_url": "https://www.hashicorp.com/products/terraform/pricing",
+            "category": "Infrastructure",
+            "alternatives": [
+                "Spacelift",
+                "env0",
+                "Scalr",
+                "Terragrunt Scale"
+            ]
+        },
+        {
+            "vendor": "X (Twitter)",
+            "change_type": "free_tier_removed",
+            "date": "2026-02-01",
+            "summary": "X/Twitter API eliminated free tier in February 2026, replacing it with a pay-per-use credit model. Active free-tier users receive a $0 voucher. 'For-good' utility apps remain free. Basic fixed tier remains at $200/month",
+            "previous_state": "Free tier: ~500 posts/month read, 1,500 tweets/month write, no search, ~1 request per 15 minutes",
+            "current_state": "No free tier. Pay-per-use credit model replaces free access. $0 voucher for existing free-tier users. For-good utility apps exempted",
+            "impact": "high",
+            "source_url": "https://developer.x.com/en/portal/products",
+            "category": "API Gateway",
+            "alternatives": [
+                "Bluesky AT Protocol",
+                "Mastodon API"
+            ]
+        },
+        {
+            "vendor": "Cognition Devin",
+            "change_type": "pricing_restructured",
+            "date": "2026-01-15",
+            "summary": "Launched $20/month Core plan with pay-as-you-go ACU pricing, down from previous $500/month-only Team plan",
+            "previous_state": "Team plan only at $500/month (250 credits)",
+            "current_state": "Core plan $20/month (pay-as-you-go at $2.25/ACU), Team plan $500/month remains",
+            "impact": "high",
+            "source_url": "https://devin.ai/pricing",
+            "category": "AI Coding",
+            "alternatives": [
+                "GitHub Copilot",
+                "Cline",
+                "Aider"
+            ]
+        },
+        {
+            "vendor": "Cursor",
+            "change_type": "pricing_restructured",
+            "date": "2025-06-01",
+            "summary": "Moved from flat monthly subscription to credit-based pricing model with new $200/month Ultra tier",
+            "previous_state": "Pro plan $20/month with 500 fast requests",
+            "current_state": "Pro plan $20/month (credit-based), Business $40/seat/month, Ultra $200/month (higher credit limits)",
+            "impact": "medium",
+            "source_url": "https://www.cursor.com/pricing",
+            "category": "AI Coding",
+            "alternatives": [
+                "Windsurf",
+                "GitHub Copilot"
+            ]
+        },
+        {
+            "vendor": "Augment Code",
+            "change_type": "pricing_restructured",
+            "date": "2025-10-01",
+            "summary": "Shifted from per-seat subscription to credit-based consumption model",
+            "previous_state": "Per-seat monthly subscription",
+            "current_state": "Credit-based consumption model with usage tiers",
+            "impact": "medium",
+            "source_url": "https://www.augmentcode.com/pricing",
+            "category": "AI Coding",
+            "alternatives": [
+                "GitHub Copilot",
+                "Cursor"
+            ]
+        },
+        {
+            "vendor": "Google Tenor API",
+            "change_type": "product_deprecated",
+            "date": "2026-06-30",
+            "summary": "Google Tenor public API shutting down June 30, 2026. New API key signups halted January 13, 2026. Only the public GIF search API is affected \u2014 Tenor website and app continue operating. Developers must migrate to alternative GIF APIs",
+            "previous_state": "Free public API for GIF search, trending GIFs, and autocomplete. No rate limits for reasonable use. Used by messaging apps and social platforms",
+            "current_state": "API shutdown June 30, 2026. No new API keys issued since Jan 13, 2026. Existing keys work until shutdown date. No replacement API from Google",
+            "impact": "high",
+            "source_url": "https://developers.google.com/tenor/guides/api-shutdown",
+            "category": "Media",
+            "alternatives": [
+                "Giphy API",
+                "Imgur API"
+            ]
+        },
+        {
+            "vendor": "Testcontainers Cloud",
+            "change_type": "pricing_restructured",
+            "date": "2024-06-01",
+            "summary": "Docker acquired AtomicJar (creators of Testcontainers Cloud). Standalone Testcontainers Cloud free tier retired \u2014 now bundled into Docker subscriptions. Docker Pro gets 100 min/month, Team 500 min/month, Business 1,500 min/month",
+            "previous_state": "Standalone Testcontainers Cloud with independent free tier (100 min/month)",
+            "current_state": "Bundled with Docker subscriptions. No standalone free tier. Open-source Testcontainers libraries remain MIT-licensed and fully free",
+            "impact": "medium",
+            "source_url": "https://testcontainers.com/cloud/",
+            "category": "Testing",
+            "alternatives": [
+                "Testcontainers (open-source)",
+                "Docker Desktop",
+                "Podman"
+            ]
+        },
+        {
+            "vendor": "Docker Desktop",
+            "change_type": "pricing_restructured",
+            "date": "2026-01-01",
+            "summary": "Docker Desktop subscription prices increased 67-80% across all tiers. Personal $7\u2192$11, Pro $9\u2192$14, Team $15\u2192$24, Business $24\u2192$35 per user/month. Separate from Docker Hub registry pricing changes",
+            "previous_state": "Personal $7/user/month, Pro $9/user/month, Team $15/user/month, Business $24/user/month",
+            "current_state": "Personal $11/user/month (+57%), Pro $14/user/month (+56%), Team $24/user/month (+60%), Business $35/user/month (+46%). All tiers affected",
+            "impact": "high",
+            "source_url": "https://www.docker.com/pricing/",
+            "category": "Container Registry",
+            "alternatives": [
+                "Podman Desktop",
+                "Rancher Desktop",
+                "OrbStack"
+            ]
+        },
+        {
+            "vendor": "Unity DevOps",
+            "change_type": "limits_increased",
+            "date": "2026-03-01",
+            "summary": "Free tier significantly expanded: storage 5x increase to 25 GB, 100 GB egress added (new), per-seat charges removed. Unity DevOps (formerly Plastic SCM) now offers generous free version control for game developers",
+            "previous_state": "5 GB storage, no egress allowance, per-seat pricing for teams",
+            "current_state": "25 GB storage (5x increase), 100 GB egress/month (new), per-seat charges removed. Free for individuals and small teams",
+            "impact": "medium",
+            "source_url": "https://unity.com/products/devops",
+            "category": "Version Control",
+            "alternatives": [
+                "Git LFS",
+                "Perforce",
+                "GitHub"
+            ]
+        },
+        {
+            "vendor": "Anthropic Claude",
+            "change_type": "limits_increased",
+            "date": "2026-03-13",
+            "summary": "Temporary usage promotion: double five-hour usage limits during off-peak hours, March 13-27, 2026. Applies to Claude Pro and Team subscribers",
+            "previous_state": "Standard five-hour usage limits for Pro and Team subscribers",
+            "current_state": "2x usage limits during off-peak hours (March 13-27, 2026 only). Temporary promotion to showcase increased capacity",
+            "impact": "low",
+            "source_url": "https://www.anthropic.com/news",
+            "category": "AI/ML",
+            "alternatives": [
+                "OpenAI ChatGPT Plus",
+                "Google Gemini Advanced"
+            ]
+        },
+        {
+            "vendor": "Heroku",
+            "change_type": "free_tier_removed",
+            "date": "2022-11-28",
+            "summary": "Heroku removed all free dynos, free Heroku Postgres, and free Heroku Data for Redis. The iconic PaaS that defined 'free tier' for a generation eliminated free offerings entirely after Salesforce acquisition",
+            "previous_state": "Free dyno: 550 hours/month (1,000 with credit card), free Postgres: 10K rows, free Redis: 25 MB. Dynos slept after 30 min inactivity",
+            "current_state": "No free tier. Mini plan starts at $5/month (Eco dynos $5/month for 1,000 shared hours). Postgres starts at $5/month",
+            "impact": "high",
+            "source_url": "https://blog.heroku.com/next-chapter",
+            "category": "Cloud Hosting",
+            "alternatives": [
+                "Render",
+                "Railway",
+                "Fly.io",
+                "Koyeb"
+            ]
+        },
+        {
+            "vendor": "GitHub Copilot",
+            "change_type": "new_free_tier",
+            "date": "2025-12-18",
+            "summary": "GitHub launched Copilot Free tier \u2014 AI code completion available to all GitHub users at no cost. 2,000 completions and 50 chat messages per month included",
+            "previous_state": "Paid only: Individual $10/month, Business $19/user/month. Free for verified students, teachers, and OSS maintainers only",
+            "current_state": "Free tier: 2,000 code completions/month, 50 chat messages/month. Individual $10/month, Business $19/month, Enterprise $39/month remain for higher limits",
+            "impact": "high",
+            "source_url": "https://github.blog/news-insights/product-news/github-copilot-in-vscode-free/",
+            "category": "AI Coding",
+            "alternatives": [
+                "Cline",
+                "Cody",
+                "Cursor"
+            ]
+        },
+        {
+            "vendor": "Auth0",
+            "change_type": "limits_increased",
+            "date": "2025-11-01",
+            "summary": "Auth0 increased free tier from 7,500 to 25,000 monthly active users. Largest free tier expansion since Okta acquisition. Makes Auth0 competitive with Clerk and Firebase Auth on free tier",
+            "previous_state": "Free tier: 7,500 MAU, unlimited social connections, 2 organizations",
+            "current_state": "Free tier: 25,000 MAU (+233%), unlimited social connections, 5 organizations. Actions, Branding, MFA included",
+            "impact": "high",
+            "source_url": "https://auth0.com/pricing",
+            "category": "Authentication",
+            "alternatives": [
+                "Clerk",
+                "Firebase Auth",
+                "Supabase Auth"
+            ]
+        },
+        {
+            "vendor": "Railway",
+            "change_type": "limits_increased",
+            "date": "2025-10-01",
+            "summary": "Railway expanded free tier following $100M Series B. Trial plan now includes $5 in free credits/month, sufficient for small hobby projects. Removed credit card requirement for trial",
+            "previous_state": "$5 free trial credit one-time, credit card required for Hobby plan",
+            "current_state": "Trial: $5/month in free credits, no credit card needed. Hobby: $5/month + usage. Pro: $20/month per seat",
+            "impact": "medium",
+            "source_url": "https://railway.com/pricing",
+            "category": "Cloud Hosting",
+            "alternatives": [
+                "Render",
+                "Fly.io",
+                "Koyeb"
+            ]
+        },
+        {
+            "vendor": "Render",
+            "change_type": "limits_reduced",
+            "date": "2025-09-01",
+            "summary": "Free web services now spin down after 15 minutes of inactivity (previously 30 minutes). Cold starts take 30-60 seconds. Free tier remains but with faster sleep times",
+            "previous_state": "Free web services slept after 30 minutes of inactivity",
+            "current_state": "Free web services sleep after 15 minutes of inactivity. 750 hours/month free compute unchanged. Cold start 30-60 seconds",
+            "impact": "low",
+            "source_url": "https://render.com/pricing",
+            "category": "Cloud Hosting",
+            "alternatives": [
+                "Railway",
+                "Fly.io",
+                "Koyeb"
+            ]
+        },
+        {
+            "vendor": "Redis",
+            "change_type": "pricing_restructured",
+            "date": "2024-03-20",
+            "summary": "Redis switched from BSD license to dual SSPL/RSALv2 license, effectively ending open-source status. Triggered creation of Valkey fork by Linux Foundation. Redis Cloud pricing unchanged but community trust impacted",
+            "previous_state": "BSD 3-Clause open-source license. Community-driven development. Multiple hosted providers (AWS ElastiCache, etc.)",
+            "current_state": "Dual SSPL + RSALv2 license. Cloud hosting by third parties restricted. Valkey fork (BSD) created by Linux Foundation with AWS, Google, Oracle backing",
+            "impact": "high",
+            "source_url": "https://redis.io/blog/redis-adopts-dual-source-available-licensing/",
+            "category": "Databases",
+            "alternatives": [
+                "Valkey",
+                "KeyDB",
+                "DragonflyDB",
+                "Upstash"
+            ]
+        },
+        {
+            "vendor": "HashiCorp",
+            "change_type": "pricing_restructured",
+            "date": "2023-08-10",
+            "summary": "HashiCorp switched Terraform, Vault, Consul, Nomad, and other products from MPL 2.0 to BSL 1.1 license. Triggered OpenTofu fork under Linux Foundation. IBM acquired HashiCorp for $6.4B in 2024",
+            "previous_state": "Mozilla Public License 2.0 (open-source). Community-driven development with corporate stewardship",
+            "current_state": "Business Source License 1.1. Non-production use free, competitive commercial use restricted. OpenTofu fork (MPL 2.0) maintained by Linux Foundation",
+            "impact": "high",
+            "source_url": "https://www.hashicorp.com/blog/hashicorp-adopts-business-source-license",
+            "category": "Infrastructure",
+            "alternatives": [
+                "OpenTofu",
+                "Pulumi",
+                "Crossplane"
+            ]
+        },
+        {
+            "vendor": "DigitalOcean",
+            "change_type": "limits_increased",
+            "date": "2026-01-01",
+            "summary": "20% price cut on Basic Droplets (cheapest now $4/mo from $5/mo). Per-second billing introduced (minimum 60 seconds or $0.01). Functions free tier increased to 25,000 GiB-seconds/mo",
+            "previous_state": "Basic Droplets from $5/mo, hourly billing, Functions 90K GiB-seconds/mo free",
+            "current_state": "Basic Droplets from $4/mo (1 vCPU, 512 MB, 10 GB SSD). Per-second billing (min 60s/$0.01). Functions 25,000 GiB-seconds/mo free",
+            "impact": "medium",
+            "source_url": "https://www.digitalocean.com/pricing/droplets",
+            "category": "Cloud IaaS",
+            "alternatives": [
+                "Hetzner",
+                "Vultr",
+                "Linode"
+            ]
+        },
+        {
+            "vendor": "DigitalOcean",
+            "change_type": "restriction",
+            "date": "2026-03-21",
+            "summary": "Managed databases are not part of the free tier. Pricing starts at $15/month. Previous listing incorrectly included '1 basic cluster' as a free tier benefit",
+            "previous_state": "Listed as: Free static sites (up to 3), functions (90K GiB-seconds/mo), and managed databases (1 basic cluster)",
+            "current_state": "Free static sites (up to 3) and functions (90K GiB-seconds/mo). Managed databases start at $15/mo, not free",
+            "impact": "medium",
+            "source_url": "https://www.digitalocean.com/pricing",
+            "category": "Cloud IaaS",
+            "alternatives": [
+                "Neon",
+                "PlanetScale",
+                "Supabase"
+            ]
+        },
+        {
+            "vendor": "Freshping",
+            "change_type": "free_tier_removed",
+            "date": "2026-03-06",
+            "summary": "Freshping shut down entirely. Free accounts disabled March 6, 2026. Paid plans expire at end of term. All data deleted 90 days later (~June 4, 2026). No replacement product offered by Freshworks",
+            "previous_state": "Free plan: 50 monitors, 1-minute check intervals, public status pages, multi-location checks, email/Slack alerts",
+            "current_state": "Service discontinued. No free or paid plan available",
+            "impact": "high",
+            "source_url": "https://www.freshworks.com/freshping/",
+            "category": "Monitoring",
+            "alternatives": [
+                "UptimeRobot",
+                "BetterStack",
+                "Checkly",
+                "StatusCake",
+                "Pulsetic",
+                "Cronitor",
+                "Upptime"
+            ]
+        },
+        {
+            "vendor": "Firebase",
+            "change_type": "product_deprecated",
+            "date": "2026-03-19",
+            "summary": "Firebase Studio (formerly Project IDX) shut down March 19, 2026. Cloud IDE and AI code generation features discontinued. Existing projects accessible until March 2027 for migration",
+            "previous_state": "Firebase Studio: cloud IDE with AI code generation, Gemini integration, multi-platform preview",
+            "current_state": "Discontinued. Projects accessible until March 2027 for data export only. Google recommends migrating to other IDEs",
+            "impact": "medium",
+            "source_url": "https://firebase.google.com/docs/studio",
+            "category": "Databases",
+            "alternatives": [
+                "Supabase",
+                "Appwrite Cloud",
+                "PocketBase",
+                "Nhost",
+                "Convex"
+            ]
+        },
+        {
+            "vendor": "Firebase",
+            "change_type": "restriction",
+            "date": "2026-02-01",
+            "summary": "Spark plan projects using legacy *.appspot.com Cloud Storage buckets forced to upgrade to Blaze (pay-as-you-go) plan or lose Cloud Storage access. No billing caps on Blaze plan \u2014 developers risk unexpected charges",
+            "previous_state": "Spark plan: free Cloud Storage with *.appspot.com buckets, no credit card required",
+            "current_state": "Legacy bucket projects must upgrade to Blaze (pay-as-you-go). No hard billing caps. New projects use Firebase Storage buckets on Spark plan",
+            "impact": "high",
+            "source_url": "https://firebase.google.com/docs/storage/web/start",
+            "category": "Databases",
+            "alternatives": [
+                "Supabase",
+                "Appwrite Cloud",
+                "PocketBase",
+                "Nhost",
+                "Convex"
+            ]
+        },
+        {
+            "vendor": "Dub.co",
+            "change_type": "limits_reduced",
+            "date": "2026-03-22",
+            "summary": "Free tier link limit reduced 40x from 1,000 links to 25 new links/month. Added 30-day analytics retention limit and 1-user cap",
+            "previous_state": "1,000 links, 1,000 tracked clicks/month, up to 3 custom domains",
+            "current_state": "25 new links/month, 1,000 tracked events/month, 3 custom domains, 1 user, 30-day analytics retention",
+            "impact": "high",
+            "source_url": "https://dub.co/pricing",
+            "category": "Dev Utilities",
+            "alternatives": [
+                "Bitly",
+                "Short.io"
+            ]
+        },
+        {
+            "vendor": "Uploadthing",
+            "change_type": "free_tier_removed",
+            "date": "2025-01-15",
+            "summary": "Free tier eliminated. Uploadthing moved to usage-based pricing with minimum $25/month plan (250 GB storage). No free tier available",
+            "previous_state": "Free tier: 2 GB storage, 2 GB bandwidth/month",
+            "current_state": "Usage-based pricing only. Minimum $25/month plan with 250 GB storage. No free tier",
+            "impact": "high",
+            "source_url": "https://uploadthing.com/pricing",
+            "category": "Storage",
+            "alternatives": [
+                "Cloudinary",
+                "Vercel Blob",
+                "AWS S3"
+            ]
+        },
+        {
+            "vendor": "Neo4j AuraDB",
+            "change_type": "restriction",
+            "date": "2026-03-22",
+            "summary": "Data correction \u2014 previous entry incorrectly reduced limits to 50K nodes/175K relationships. Actual free tier is 200,000 nodes and 400,000 relationships per Neo4j AuraDB FAQ",
+            "previous_state": "50,000 nodes, 175,000 relationships (incorrectly listed)",
+            "current_state": "200,000 nodes, 400,000 relationships (restored to correct values)",
+            "impact": "low",
+            "source_url": "https://neo4j.com/cloud/platform/aura-graph-database/faq/",
+            "category": "Databases",
+            "alternatives": [
+                "Dgraph Cloud",
+                "Amazon Neptune"
+            ]
+        },
+        {
+            "vendor": "xAI (Grok)",
+            "change_type": "free_tier_removed",
+            "date": "2026-03-19",
+            "summary": "Grok Imagine free image/video generation locked behind SuperGrok subscription ($30/mo). Over 1B generations in first month overwhelmed capacity",
+            "previous_state": "Free image and video generation for all Grok users",
+            "current_state": "Image/video generation requires SuperGrok subscription ($30/month). Text-only Grok remains free with limits",
+            "impact": "medium",
+            "source_url": "https://x.com/xai",
+            "category": "AI / ML",
+            "alternatives": [
+                "DALL-E (credits)",
+                "Stable Diffusion (self-hosted)",
+                "Pollinations.AI"
+            ]
+        },
+        {
+            "vendor": "Google Gemini API",
+            "change_type": "restriction",
+            "date": "2026-04-01",
+            "summary": "Billing-account-level spend caps enforced starting April 1, 2026. When a tier's spend cap is reached, API requests pause until the next billing month. Affects pay-as-you-go developers who may see unexpected request pausing.",
+            "previous_state": "No hard spend caps \u2014 usage billed without automatic pausing",
+            "current_state": "Tier-level spend caps enforced at billing account level. Requests pause when cap is hit until next month",
+            "impact": "medium",
+            "source_url": "https://ai.google.dev/gemini-api/docs/billing",
+            "category": "AI / ML",
+            "alternatives": [
+                "OpenRouter",
+                "Anthropic Claude API",
+                "OpenAI API"
+            ]
+        },
+        {
+            "vendor": "Windsurf",
+            "change_type": "pricing_restructured",
+            "date": "2026-03-19",
+            "summary": "Windsurf replaced credits-based pricing with daily/weekly quotas (Mar 19, 2026). New tiers: Pro $20/mo (was $15), Ultimate $40/mo, Team $200/mo/seat. Free tier changed from flexible credits to hard quotas. Existing Pro subscribers grandfathered at $15/mo",
+            "previous_state": "Credits-based system allowing flexible allocation between completions and chat. Pro plan $15/month",
+            "current_state": "Daily/weekly quotas replace credits. Pro $20/mo (existing subs grandfathered at $15), Ultimate $40/mo, Team $200/mo/seat. Free tier gets limited daily completions and chat messages",
+            "impact": "medium",
+            "source_url": "https://windsurf.com/pricing",
+            "category": "AI Coding",
+            "alternatives": [
+                "Cursor",
+                "GitHub Copilot",
+                "Cline"
+            ]
+        },
+        {
+            "vendor": "Gemini Code Assist",
+            "change_type": "new_free_tier",
+            "date": "2025-12-18",
+            "summary": "Google launched Gemini Code Assist free tier for individual developers. Includes code completions, chat, and multi-file editing powered by Gemini 2.5 Pro. Available in VS Code, JetBrains, and Cloud Shell",
+            "previous_state": "No free tier \u2014 enterprise-only at $19/user/month",
+            "current_state": "Free individual tier with code completions, chat, and multi-file editing. Enterprise tier remains at $19/user/month",
+            "impact": "high",
+            "source_url": "https://cloud.google.com/gemini/docs/codeassist/overview",
+            "category": "AI Coding",
+            "alternatives": [
+                "GitHub Copilot Free",
+                "Cursor",
+                "Cline"
+            ]
+        },
+        {
+            "vendor": "Amazon Aurora PostgreSQL",
+            "change_type": "new_free_tier",
+            "date": "2026-03-25",
+            "summary": "Aurora PostgreSQL Serverless added to AWS Free Tier \u2014 managed PostgreSQL-compatible database now available at no cost with up to 4 ACUs per cluster and 1 GB storage. Part of AWS Free Plan (6 months + credits)",
+            "previous_state": "No free tier \u2014 Aurora was paid-only, starting at ~$0.08/ACU-hour",
+            "current_state": "Free plan with up to 4 ACUs per cluster, 1 GB storage, $100\u2013200 in credits for new accounts",
+            "impact": "high",
+            "source_url": "https://aws.amazon.com/rds/aurora/pricing/",
+            "category": "Databases",
+            "alternatives": [
+                "Neon",
+                "Supabase",
+                "CockroachDB",
+                "PlanetScale"
+            ]
+        },
+        {
+            "vendor": "Amazon Kiro",
+            "change_type": "new_free_tier",
+            "date": "2026-04-07",
+            "summary": "Amazon Kiro AI coding assistant launched GA with tiered credit-based pricing: Free tier (50 credits/month), Pro ($20/month, 1,000 credits), Pro+ ($40/month, 2,000 credits). Credits consumed per AI interaction (specs, code generation, debugging)",
+            "previous_state": "Preview-only access, no public pricing",
+            "current_state": "Free tier: 50 credits/month. Pro: $20/month (1,000 credits). Pro+: $40/month (2,000 credits). GA availability",
+            "impact": "medium",
+            "source_url": "https://kiro.dev/pricing",
+            "category": "AI Coding",
+            "alternatives": [
+                "Cursor",
+                "Windsurf",
+                "GitHub Copilot",
+                "Claude Code"
+            ]
+        },
+        {
+            "vendor": "Replit",
+            "change_type": "pricing_restructured",
+            "date": "2026-04-01",
+            "summary": "Replit Core plan dropped from $25/month to $20/month. New Pro plan added at $100/month with higher credit allocation. Free tier unchanged (limited AI credits, basic compute). Price reduction makes Core more competitive with Cursor Pro ($20/month)",
+            "previous_state": "Free tier + Core plan at $25/month",
+            "current_state": "Free tier + Core plan at $20/month + new Pro plan at $100/month",
+            "impact": "low",
+            "source_url": "https://replit.com/pricing",
+            "category": "Cloud IDE",
+            "alternatives": [
+                "GitHub Codespaces",
+                "Gitpod",
+                "CodeSandbox"
+            ]
+        },
+        {
+            "vendor": "SonarQube Cloud",
+            "change_type": "pricing_restructured",
+            "date": "2026-04-01",
+            "summary": "SonarQube Cloud introduced more granular Team tier pricing with differentiated feature access. Free tier for open-source projects remains. Paid tiers restructured for clearer scaling path from small teams to enterprise",
+            "previous_state": "Free (open source) + Developer + Enterprise tiers",
+            "current_state": "Free (open source) + Team (granular tiers) + Enterprise. More pricing options for mid-size teams",
+            "impact": "low",
+            "source_url": "https://www.sonarsource.com/plans-and-pricing/sonarqube/cloud/",
+            "category": "Code Quality",
+            "alternatives": [
+                "CodeClimate",
+                "Codacy",
+                "DeepSource"
+            ]
+        },
+        {
+            "vendor": "Cursor",
+            "change_type": "new_tier",
+            "date": "2026-04-07",
+            "summary": "Cursor introduced Pro+ tier at $60/month between Pro ($20) and Ultra ($200). Pro+ includes 10x premium model requests vs Pro, priority access, and expanded context window. Expands the pricing ladder from 3 tiers (Free/Pro/Ultra) to 4 (Free/Pro/Pro+/Ultra), filling the $20-$200 gap.",
+            "previous_state": "3-tier pricing: Free (2K completions, 50 slow requests), Pro $20/mo (unlimited completions, 500 fast requests), Ultra $200/mo",
+            "current_state": "4-tier pricing: Free (2K completions, 50 slow requests), Pro $20/mo, Pro+ $60/mo (10x premium requests, priority access, more context), Ultra $200/mo",
+            "impact": "medium",
+            "source_url": "https://www.cursor.com/pricing",
+            "category": "AI Coding",
+            "alternatives": [
+                "GitHub Copilot",
+                "Windsurf",
+                "Cline",
+                "Claude Code"
+            ]
+        },
+        {
+            "vendor": "Google Gemini API",
+            "change_type": "restriction",
+            "date": "2026-04-08",
+            "summary": "Gemini API free tier restricted to Flash and Flash-Lite models only (April 2026). Gemini 2.5 Pro and other Pro models now require a paid billing account. Previously free users could access Pro models with rate limits. Combined with April 1 spend cap enforcement, this significantly narrows what is available at $0.",
+            "previous_state": "Free tier included access to both Flash and Pro models with rate limits. Gemini 2.5 Pro accessible to free users at reduced rates",
+            "current_state": "Free tier restricted to Flash and Flash-Lite models only. Pro models (Gemini 2.5 Pro) require paid billing account. Free users limited to lighter-weight models",
+            "impact": "high",
+            "source_url": "https://ai.google.dev/gemini-api/docs/pricing",
+            "category": "AI / ML",
+            "alternatives": [
+                "OpenRouter",
+                "Groq",
+                "Together AI",
+                "Anthropic Claude API"
+            ]
+        },
+        {
+            "vendor": "OVHcloud",
+            "change_type": "pricing_restructured",
+            "date": "2026-04-01",
+            "summary": "OVHcloud raised prices 9-11% on newer infrastructure (Public Cloud, Bare Metal, VPS 2026 range) effective April 1, 2026. Free tier unchanged. Applies to 2026-range products only \u2014 legacy configurations retain previous pricing.",
+            "previous_state": "Previous pricing on Public Cloud, Bare Metal, and VPS 2026-range products",
+            "current_state": "9-11% price increase on newer infrastructure. Free tier and legacy configurations unaffected",
+            "impact": "medium",
+            "source_url": "https://www.ovhcloud.com/en/pricing/",
+            "category": "Cloud IaaS",
+            "alternatives": [
+                "Hetzner",
+                "DigitalOcean",
+                "Vultr",
+                "Linode"
+            ]
+        },
+        {
+            "vendor": "Amazon SP-API",
+            "change_type": "free_tier_removed",
+            "date": "2026-04-30",
+            "summary": "Amazon Selling Partner API (SP-API) moves to paid access starting April 30, 2026. New base fee of $1,400/year plus per-call fees. Previously free for registered developers. Major impact on Amazon marketplace integrators and third-party seller tools.",
+            "previous_state": "Free API access for registered Amazon developers with standard rate limits",
+            "current_state": "$1,400/year base fee plus per-call fees starting April 30, 2026. No free tier",
+            "impact": "high",
+            "source_url": "https://developer-docs.amazon.com/sp-api/",
+            "category": "E-Commerce",
+            "alternatives": [
+                "Shopify API",
+                "WooCommerce API",
+                "BigCommerce API"
+            ]
+        },
+        {
+            "vendor": "Amazon Kiro",
+            "change_type": "new_free_tier",
+            "date": "2026-04-09",
+            "summary": "Amazon Kiro launched GA with a free tier of 50 interactions/month. Claude-powered IDE focused on spec-driven development. Pro $20/mo (1,000 interactions), Pro+ $40/mo (2,000), Power $200/mo (10,000). Competes directly with Cursor, GitHub Copilot, and Windsurf.",
+            "previous_state": "Preview/beta with limited access",
+            "current_state": "GA with free tier (50 interactions/mo). Four paid tiers: Pro ($20), Pro+ ($40), Power ($200)",
+            "impact": "high",
+            "source_url": "https://kiro.dev/pricing",
+            "category": "AI Coding",
+            "alternatives": [
+                "Cursor",
+                "GitHub Copilot",
+                "Windsurf",
+                "Claude Code"
+            ]
+        },
+        {
+            "vendor": "OpenAI",
+            "change_type": "free_tier_removed",
+            "date": "2026-05-12",
+            "summary": "DALL-E 2 and DALL-E 3 API access discontinued. Developers must migrate to gpt-image-1 (different pricing model, quality tiers changed from standard/hd to low/medium/high) or switch to free alternatives like Pollinations.AI or Lumenfall.ai",
+            "previous_state": "DALL-E 3 API: $0.040-$0.120/image (1024x1024), paid via API credits",
+            "current_state": "DALL-E 2 & 3 API shut down. Replacement: gpt-image-1 at $0.011-$0.167/image with new quality tiers",
+            "impact": "high",
+            "source_url": "https://platform.openai.com/docs/deprecations",
+            "category": "AI / ML",
+            "alternatives": [
+                "gpt-image-1",
+                "Pollinations.AI",
+                "Lumenfall.ai",
+                "Cloudflare Workers AI",
+                "Stability AI",
+                "Replicate"
+            ]
+        },
+        {
+            "vendor": "OpenAI",
+            "change_type": "product_deprecated",
+            "date": "2026-05-07",
+            "summary": "Realtime API beta endpoints deprecated. Developers must remove OpenAI-Beta header, use new client_secrets endpoint, specify session_type, and update event names. GA Realtime API is the direct replacement.",
+            "previous_state": "Realtime API beta: required OpenAI-Beta: realtime=v1 header, single session type, beta event names",
+            "current_state": "Realtime API GA: no beta header, POST /v1/realtime/client_secrets for ephemeral keys, session_type required (speech-to-speech or transcription), updated event names",
+            "impact": "high",
+            "source_url": "https://platform.openai.com/docs/deprecations",
+            "category": "AI / ML",
+            "alternatives": [
+                "OpenAI Realtime API (GA)",
+                "Deepgram",
+                "AssemblyAI",
+                "Azure OpenAI Realtime",
+                "ElevenLabs",
+                "Google Cloud Speech-to-Text"
+            ]
+        },
+        {
+            "vendor": "AWS",
+            "change_type": "product_deprecated",
+            "date": "2026-04-30",
+            "summary": "AWS App Runner closed to new customers. Service enters maintenance mode with no new features. AWS recommends migrating to Amazon ECS Express Mode for simplified container deployment.",
+            "previous_state": "App Runner: fully available to all customers, source code and container image deployment, automatic scaling, managed HTTPS",
+            "current_state": "App Runner: closed to new customers April 30, maintenance mode only, existing services continue but no new features planned",
+            "impact": "high",
+            "source_url": "https://docs.aws.amazon.com/apprunner/latest/dg/apprunner-availability-change.html",
+            "category": "Cloud Hosting",
+            "alternatives": [
+                "Amazon ECS Express Mode",
+                "AWS Fargate",
+                "Google Cloud Run",
+                "Azure Container Apps",
+                "Railway",
+                "Render",
+                "Fly.io",
+                "DigitalOcean App Platform"
+            ]
+        }
+    ]
 }

--- a/src/guides.ts
+++ b/src/guides.ts
@@ -108,6 +108,7 @@ const GUIDE_ENTRIES: Array<{ slug: string; title: string; description: string }>
   { slug: "guides/vercel-ai-sdk", title: "Using AgentDeals with Vercel AI SDK", description: "Vercel AI SDK MCP integration guide — experimental_createMCPClient() setup, React/Next.js code examples" },
   { slug: "dall-e-shutdown", title: "DALL-E API Shutdown Migration Guide", description: "OpenAI DALL-E 2 & 3 API shuts down May 12, 2026 — migration to gpt-image-1, free alternatives (Pollinations.AI, Lumenfall.ai, Cloudflare Workers AI), code examples, pricing comparison" },
   { slug: "openai-realtime-migration", title: "OpenAI Realtime API Beta Migration Guide", description: "OpenAI Realtime API beta deprecated May 7, 2026 — migration to GA API, alternative real-time audio services (Deepgram, AssemblyAI, ElevenLabs, Azure OpenAI, Google Cloud Speech-to-Text), code examples, pricing" },
+  { slug: "aws-app-runner-migration", title: "AWS App Runner Migration Guide", description: "AWS App Runner closed to new customers April 30, 2026 — migration to ECS Express Mode, Google Cloud Run, Railway, Render, Fly.io, Azure Container Apps, DigitalOcean App Platform with pricing comparison" },
 ];
 
 export function getGuideList(): GuideMetadata[] {

--- a/src/serve.ts
+++ b/src/serve.ts
@@ -5555,6 +5555,15 @@ const ALTERNATIVES_PAGES: AlternativesPageConfig[] = [
     primaryVendor: "OpenAI",
     hubDesc: "OpenAI Realtime API beta deprecated May 7, 2026 — migration guide to GA API and real-time audio alternatives with code examples and pricing",
   },
+  {
+    slug: "aws-app-runner-migration",
+    title: "AWS App Runner Migration Guide: Alternatives with Free Tiers & Pricing (2026)",
+    metaDesc: "AWS App Runner closes to new customers April 30, 2026. Migrate to ECS Express Mode, Google Cloud Run, Railway, Render, Fly.io, or Azure Container Apps. Free tier comparison, pricing, and migration paths.",
+    contextHtml: "",
+    tag: "app-runner-shutdown",
+    primaryVendor: "AWS",
+    hubDesc: "AWS App Runner closed to new customers April 30, 2026 — migration guide to ECS Express Mode and container deployment alternatives with pricing comparison",
+  },
 ];
 
 const alternativesPageMap = new Map<string, AlternativesPageConfig>();
@@ -23937,6 +23946,17 @@ function buildShutdownTrackerPage(): string {
 
   const shutdowns: ShutdownEntry[] = [
     {
+      service: "AWS App Runner (New Customers)",
+      vendorSlug: "aws",
+      what: "App Runner closed to new customers — existing users can continue, but no new features. AWS recommends ECS Express Mode.",
+      deadline: "2026-04-30",
+      impact: "Cannot create new App Runner services. Existing services continue but service is in maintenance mode.",
+      whoAffected: "Developers looking to deploy new containerized web apps on App Runner, existing users planning long-term",
+      migrationPath: "Migrate to ECS Express Mode (AWS recommended), Google Cloud Run, Railway, Render, or Fly.io",
+      migrationLink: "/aws-app-runner-migration",
+      status: "active",
+    },
+    {
       service: "HubSpot Contact Lists API v1",
       vendorSlug: "hubspot",
       what: "Legacy Contact Lists API v1 sunset \u2014 replaced by Lists API v3",
@@ -28915,6 +28935,583 @@ function buildOpenAIRealtimeMigrationPage(): string {
   };
 
   return '<!DOCTYPE html>\n<html lang="en">\n<head>\n<meta charset="utf-8">\n<meta name="viewport" content="width=device-width,initial-scale=1">\n<title>' + escHtmlServer(title) + ' \u2014 AgentDeals</title>\n<meta name="description" content="' + escHtmlServer(metaDesc) + '">\n<link rel="canonical" href="' + BASE_URL + '/' + slug + '">\n<meta property="og:title" content="' + escHtmlServer(title) + '">\n<meta property="og:description" content="' + escHtmlServer(metaDesc) + '">\n<meta property="og:type" content="article">\n<meta property="og:url" content="' + BASE_URL + '/' + slug + '">\n<meta property="article:published_time" content="' + pubDate + '">\n<meta name="keywords" content="openai realtime api, realtime api beta shutdown, realtime api migration, real-time audio api, speech-to-text api, deepgram alternative, assemblyai, elevenlabs, voice ai api 2026">\n' + OG_IMAGE_META + GOOGLE_VERIFICATION_META + '<link rel="icon" type="image/png" href="/favicon.png">\n<link rel="alternate" type="application/atom+xml" title="AgentDeals \u2014 Pricing Changes" href="/feed.xml">\n<link rel="preconnect" href="https://fonts.googleapis.com"><link rel="preconnect" href="https://fonts.gstatic.com" crossorigin><link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">\n<script type="application/ld+json">' + JSON.stringify(jsonLd) + '</script>\n<script type="application/ld+json">' + JSON.stringify(faqJsonLd) + '</script>\n<script type="application/ld+json">' + JSON.stringify(breadcrumbJsonLd) + '</script>\n<style>\n*{margin:0;padding:0;box-sizing:border-box}\n:root{--bg:#0f172a;--bg-elevated:#1e293b;--bg-card:rgba(255,255,255,0.06);--border:#334155;--border-hover:#3b82f6;--text:#f1f5f9;--text-muted:#94a3b8;--text-dim:#64748b;--accent:#3b82f6;--accent-hover:#60a5fa;--accent-glow:rgba(59,130,246,0.15);--serif:\'Inter\',-apple-system,sans-serif;--sans:\'Inter\',-apple-system,sans-serif;--mono:\'JetBrains Mono\',SFMono-Regular,monospace}\nbody{font-family:var(--sans);background:var(--bg);color:var(--text);line-height:1.6}\na{color:var(--accent);text-decoration:none}a:hover{color:var(--accent-hover);text-decoration:underline}\n.container{max-width:960px;margin:0 auto;padding:0 1.5rem}\n.breadcrumb{padding:1.5rem 0 0;font-size:.8rem;color:var(--text-dim)}\n.breadcrumb a{color:var(--text-muted)}\nh1{font-family:var(--serif);font-size:2.25rem;color:var(--text);margin:1rem 0 .5rem;letter-spacing:-.02em}\nh2{font-family:var(--serif);font-size:1.4rem;color:var(--text);margin:2.5rem 0 1rem;letter-spacing:-.01em}\nh3{font-family:var(--serif);font-size:1.1rem;color:var(--text);margin:1.5rem 0 .5rem}\n.pub-date{color:var(--text-dim);font-size:.85rem;margin-bottom:1.5rem}\n.deadline-banner{background:linear-gradient(135deg,rgba(248,81,73,0.15),rgba(210,153,34,0.1));border:1px solid #f85149;border-radius:12px;padding:1.5rem;margin:1.5rem 0;text-align:center}\n.deadline-days{font-size:2.5rem;font-weight:700;font-family:var(--mono);color:#f85149}\n.deadline-label{font-size:.9rem;color:var(--text-muted);margin-top:.25rem}\n.deadline-date{font-size:.85rem;color:var(--text-dim);margin-top:.5rem}\n.summary-stats{display:grid;grid-template-columns:repeat(auto-fit,minmax(140px,1fr));gap:1rem;margin:1.5rem 0 2rem}\n.stat-card{background:var(--bg-card);border:1px solid var(--border);border-radius:8px;padding:1rem;text-align:center}\n.stat-number{font-size:1.8rem;font-weight:700;font-family:var(--mono);color:var(--accent)}\n.stat-number.red{color:#f85149}\n.stat-number.green{color:#3fb950}\n.stat-label{font-size:.8rem;color:var(--text-muted);margin-top:.25rem}\n.executive-summary{background:var(--bg-card);border:1px solid var(--border);border-radius:8px;padding:1.5rem;margin:1.5rem 0;line-height:1.8}\n.executive-summary p{color:var(--text-muted);margin-bottom:.75rem;font-size:.95rem}\n.executive-summary p:last-child{margin-bottom:0}\n.executive-summary strong{color:var(--text)}\n.section-intro{color:var(--text-muted);font-size:.95rem;margin-bottom:1.25rem;line-height:1.7}\n.pricing-table{width:100%;border-collapse:collapse;margin:1rem 0 2rem;font-size:.85rem}\n.pricing-table th{text-align:left;padding:.75rem .5rem;border-bottom:2px solid var(--border);color:var(--text-muted);font-weight:600;font-size:.75rem;text-transform:uppercase;letter-spacing:.05em}\n.pricing-table td{padding:.6rem .5rem;border-bottom:1px solid var(--border)}\n.pricing-table tr:hover{background:var(--accent-glow)}\n.diff-card{padding:1.25rem;border:1px solid var(--border);border-left:3px solid var(--accent);border-radius:8px;background:var(--bg-card);margin-bottom:.75rem}\n.diff-card h3{margin:0 0 .5rem;font-size:1rem}\n.diff-desc{color:var(--text-muted);font-size:.9rem;line-height:1.6}\n.context-box{background:var(--bg-card);border:1px solid var(--border);border-radius:8px;padding:1.25rem;margin:1rem 0;font-size:.9rem;color:var(--text-muted);line-height:1.7}\n.context-box strong{color:var(--text)}\n.decision-tree{display:grid;gap:1rem;margin:1.5rem 0}\n.decision-path{padding:1.25rem;border:1px solid var(--border);border-radius:8px;background:var(--bg-card);transition:border-color .15s}\n.decision-path:hover{border-color:var(--accent)}\n.decision-path h3{margin:0 0 .5rem;font-size:1rem;color:var(--accent)}\n.decision-path p{color:var(--text-muted);font-size:.9rem;margin-bottom:.5rem}\n.decision-path .best-for{font-size:.8rem;color:var(--text-dim);font-style:italic}\n.verdict-box{background:linear-gradient(135deg,rgba(59,130,246,0.1),rgba(139,92,246,0.1));border:1px solid var(--accent);border-radius:12px;padding:1.5rem;margin:1.5rem 0}\n.verdict-box h3{color:var(--accent);margin:0 0 .75rem;font-size:1.1rem}\n.verdict-item{margin-bottom:.75rem;padding-left:1rem;border-left:2px solid var(--border)}\n.verdict-item strong{color:var(--text)}\n.verdict-item p{color:var(--text-muted);font-size:.9rem;margin:.25rem 0 0}\n.methodology{background:var(--bg-card);border:1px solid var(--border);border-radius:8px;padding:1.25rem;margin:2rem 0;font-size:.9rem;color:var(--text-muted);line-height:1.7}\n.methodology strong{color:var(--text)}\n.related-pages{display:flex;flex-direction:column;gap:.5rem;margin:1rem 0}\n.related-page-link{padding:.75rem 1rem;border:1px solid var(--border);border-radius:8px;background:var(--bg-card);text-decoration:none;transition:border-color .15s}\n.related-page-link:hover{border-color:var(--accent);text-decoration:none}\n.related-page-link .link-title{color:var(--accent);font-weight:600;font-size:.95rem}\n.related-page-link .link-desc{color:var(--text-muted);font-size:.8rem;margin-top:.25rem}\n.toc{background:var(--bg-card);border:1px solid var(--border);border-radius:8px;padding:1.25rem;margin:1.5rem 0}\n.toc h3{margin:0 0 .5rem;font-size:.9rem;color:var(--text-muted)}\n.toc ol{padding-left:1.25rem;margin:0}\n.toc li{margin-bottom:.35rem;font-size:.9rem}\n.toc a{color:var(--accent)}\n.code-block{background:#0d1117;border:1px solid var(--border);border-radius:8px;padding:1.25rem;margin:1rem 0;overflow-x:auto;font-family:var(--mono);font-size:.8rem;line-height:1.5;color:#c9d1d9}\n.code-block .comment{color:#8b949e}\n.code-block .keyword{color:#ff7b72}\n.code-block .string{color:#a5d6ff}\n.code-block .highlight{color:#ffa657}\n.faq-section{margin:2rem 0}\n.faq-item{border:1px solid var(--border);border-radius:8px;margin-bottom:.75rem;overflow:hidden}\n.faq-question{padding:1rem 1.25rem;background:var(--bg-card);cursor:pointer;font-weight:600;font-size:.95rem;display:flex;justify-content:space-between;align-items:center}\n.faq-question:hover{background:var(--accent-glow)}\n.faq-answer{padding:0 1.25rem 1rem;color:var(--text-muted);font-size:.9rem;line-height:1.7}\nfooter{text-align:center;color:var(--text-dim);font-size:.8rem;padding:3rem 0 2rem;border-top:1px solid var(--border);margin-top:3rem}\nfooter a{color:var(--accent)}\n@media(max-width:768px){h1{font-size:1.6rem}.summary-stats{grid-template-columns:1fr 1fr}.pricing-table{font-size:.75rem}.pricing-table td,.pricing-table th{padding:.4rem .25rem}.deadline-days{font-size:1.8rem}}\n' + globalNavCss() + '\n' + mcpCtaCss() + '\n</style>\n</head>\n<body>\n<div class="container">\n  ' + buildGlobalNav("alternatives") + '\n  <div class="breadcrumb"><a href="/">AgentDeals</a> &rsaquo; <a href="/alternatives">Guides</a> &rsaquo; Realtime API Migration Guide</div>\n  <h1>OpenAI Realtime API Beta Shutdown: Migration Guide &amp; Real-Time Audio Alternatives</h1>\n  <p class="pub-date">Published ' + pubDate + ' &middot; Data verified from our index of ' + offers.length.toLocaleString() + ' developer tools &middot; ' + relevantChanges.length + ' OpenAI pricing change' + (relevantChanges.length !== 1 ? "s" : "") + ' tracked</p>\n\n  <div class="deadline-banner">\n    <div class="deadline-days">' + daysLeft + ' days</div>\n    <div class="deadline-label">until Realtime API beta shutdown</div>\n    <div class="deadline-date">May 7, 2026 &middot; <span style="color:' + stabilityColor + ';font-weight:600">OpenAI stability: ' + openaiStability.toUpperCase() + '</span></div>\n  </div>\n\n  <div class="summary-stats">\n    <div class="stat-card"><div class="stat-number red">' + daysLeft + '</div><div class="stat-label">Days Remaining</div></div>\n    <div class="stat-card"><div class="stat-number">' + providers.length + '</div><div class="stat-label">Alternatives Compared</div></div>\n    <div class="stat-card"><div class="stat-number green">' + freeProviderCount + '</div><div class="stat-label">With Free Tiers</div></div>\n    <div class="stat-card"><div class="stat-number">4</div><div class="stat-label">Breaking Changes</div></div>\n  </div>\n\n  <div class="executive-summary">\n    <p><strong>What\'s happening:</strong> OpenAI is deprecating the Realtime API <strong>beta</strong> on <strong>May 7, 2026</strong>. The beta endpoints (which required the <code style="font-family:var(--mono);background:rgba(255,255,255,0.1);padding:.1rem .3rem;border-radius:3px">OpenAI-Beta: realtime=v1</code> header) will stop working. The GA (stable) Realtime API is the replacement.</p>\n    <p><strong>Easiest migration:</strong> <strong>Remove the beta header, update session creation to use client_secrets, and add session_type.</strong> If you are already using the OpenAI SDK, the changes are minimal. The GA API uses the same WebSocket protocol with updated event names.</p>\n    <p><strong>Alternatives exist:</strong> If you are reconsidering OpenAI for real-time audio, <strong>Deepgram</strong> ($200 free credit, $0.0043/min), <strong>AssemblyAI</strong> (free tier), and <strong>Google Cloud Speech-to-Text</strong> (60 min/month free) offer real-time transcription at lower per-minute costs.</p>\n  </div>\n\n  <div class="toc">\n    <h3>Jump to section</h3>\n    <ol>\n      <li><a href="#breaking-changes">Breaking Changes</a></li>\n      <li><a href="#comparison-table">Alternative Comparison Table</a></li>\n      <li><a href="#pricing">Pricing Comparison</a></li>\n      <li><a href="#migration-paths">Migration Paths</a></li>\n      <li><a href="#code-migration">Code Migration Examples</a></li>\n      <li><a href="#faq">FAQ</a></li>\n      <li><a href="#openai-timeline">OpenAI Change Timeline</a></li>\n      <li><a href="#recommendations">Recommendations</a></li>\n      <li><a href="#methodology">Methodology</a></li>\n    </ol>\n  </div>\n\n  <h2 id="breaking-changes">Breaking Changes: Beta to GA</h2>\n  <p class="section-intro">Four key changes required when migrating from the Realtime API beta to the stable GA release.</p>\n\n  <div class="diff-card">\n    <h3>1. Remove the Beta Header</h3>\n    <div class="diff-desc">The <code style="font-family:var(--mono);background:rgba(255,255,255,0.1);padding:.1rem .3rem;border-radius:3px">OpenAI-Beta: realtime=v1</code> header is no longer needed. The GA Realtime API is the default. Remove this header from all requests.</div>\n  </div>\n  <div class="diff-card">\n    <h3>2. New Ephemeral Key Endpoint</h3>\n    <div class="diff-desc">Use <code style="font-family:var(--mono);background:rgba(255,255,255,0.1);padding:.1rem .3rem;border-radius:3px">POST /v1/realtime/client_secrets</code> to generate ephemeral keys for client-side WebSocket connections. This replaces the beta session creation flow.</div>\n  </div>\n  <div class="diff-card">\n    <h3>3. Required session_type Parameter</h3>\n    <div class="diff-desc">You must now specify <code style="font-family:var(--mono);background:rgba(255,255,255,0.1);padding:.1rem .3rem;border-radius:3px">session_type</code> when creating sessions: <strong>"speech-to-speech"</strong> for bidirectional voice conversations or <strong>"transcription"</strong> for audio-to-text. The beta used a single session type for both.</div>\n  </div>\n  <div class="diff-card">\n    <h3>4. Updated Event Names and Payloads</h3>\n    <div class="diff-desc">Some WebSocket event names and payload structures have been updated in the GA release. Review the <a href="https://platform.openai.com/docs/guides/realtime" style="color:var(--accent)">official documentation</a> for the updated event reference.</div>\n  </div>\n\n  <h2 id="comparison-table">Real-Time Audio API Alternatives</h2>\n  <p class="section-intro">All ' + providers.length + ' alternatives compared. Migration effort rated from the perspective of an OpenAI Realtime API integration.</p>\n\n  <div style="overflow-x:auto">\n  <table class="pricing-table">\n    <thead>\n      <tr>\n        <th>Provider</th>\n        <th>Free Tier</th>\n        <th>Pricing</th>\n        <th>Capability</th>\n        <th>Latency</th>\n        <th>Migration</th>\n      </tr>\n    </thead>\n    <tbody>\n        ' + providerTableRows + '\n    </tbody>\n  </table>\n  </div>\n\n  <div class="context-box">\n    <strong>OpenAI vs alternatives:</strong> OpenAI Realtime API is unique in offering <strong>speech-to-speech</strong> (bidirectional voice conversations with an AI model). Most alternatives focus on either speech-to-text (Deepgram, AssemblyAI, Google) or text-to-speech (ElevenLabs). If you need full voice conversation capability, OpenAI GA or Azure OpenAI are your primary options.\n  </div>\n\n  <h2 id="pricing">Pricing Comparison</h2>\n  <p class="section-intro">Per-minute costs across all providers. OpenAI Realtime beta pricing shown for reference.</p>\n\n  <div style="overflow-x:auto">\n  <table class="pricing-table">\n    <thead>\n      <tr>\n        <th>Provider</th>\n        <th>Free Tier</th>\n        <th>Per-Minute Cost</th>\n        <th>Features</th>\n      </tr>\n    </thead>\n    <tbody>\n        ' + pricingTableRows + '\n    </tbody>\n  </table>\n  </div>\n\n  <div class="context-box">\n    <strong>Cost comparison:</strong> OpenAI Realtime API is significantly more expensive per minute than speech-to-text alternatives because it includes AI model inference (GPT-4o) in the pipeline. If you only need transcription, <strong>Deepgram at $0.0043/min</strong> is roughly 14x cheaper than OpenAI\'s audio input rate. However, for full speech-to-speech with AI reasoning, OpenAI remains the most integrated option.\n  </div>\n\n  <h2 id="migration-paths">Migration Paths</h2>\n  <p class="section-intro">Three paths depending on your use case. The right choice depends on whether you need speech-to-speech, transcription only, or voice synthesis.</p>\n\n  <div class="decision-tree">\n    <div class="decision-path" style="border-left:3px solid #3fb950">\n      <h3>Path 1: Stay with OpenAI (Beta to GA)</h3>\n      <p>The easiest migration. Remove the beta header, update session creation to use <code style="font-family:var(--mono);background:rgba(255,255,255,0.1);padding:.1rem .3rem;border-radius:3px">/v1/realtime/client_secrets</code>, add <code style="font-family:var(--mono);background:rgba(255,255,255,0.1);padding:.1rem .3rem;border-radius:3px">session_type</code>, and update any changed event names. Same SDK, same pricing, same capabilities.</p>\n      <p class="best-for">Best for: Existing OpenAI Realtime users who need speech-to-speech and want minimal code changes</p>\n    </div>\n    <div class="decision-path" style="border-left:3px solid var(--accent)">\n      <h3>Path 2: Transcription-Only (Deepgram, AssemblyAI, Google)</h3>\n      <p>If you only need speech-to-text, dedicated transcription services offer better per-minute pricing and often lower latency. Deepgram Nova-2 leads on accuracy and speed. AssemblyAI adds AI-powered analysis via LeMUR. Google offers the widest language support (125+).</p>\n      <p class="best-for">Best for: Applications that process audio input but generate text responses, transcription services, meeting recorders</p>\n    </div>\n    <div class="decision-path" style="border-left:3px solid #8b5cf6">\n      <h3>Path 3: Voice Synthesis (ElevenLabs)</h3>\n      <p>If your use case is generating spoken audio from text, ElevenLabs offers the lowest latency (~75ms) and highest quality voice synthesis with voice cloning capabilities. 10K characters/month free to start.</p>\n      <p class="best-for">Best for: Voice assistants, audiobook generation, voice cloning, accessibility features</p>\n    </div>\n  </div>\n\n  <h2 id="code-migration">Code Migration Examples</h2>\n\n  <h3>Python: Beta to GA Migration</h3>\n  <p class="section-intro">Key changes to your server-side session creation:</p>\n\n  <div class="code-block">\n<span class="comment"># Before: Beta session creation</span>\n<span class="keyword">import</span> openai\n\nclient = openai.OpenAI()\nresponse = client.chat.completions.create(\n    model=<span class="string">"gpt-4o-realtime-preview"</span>,\n    <span class="comment"># Beta required OpenAI-Beta header (set automatically by SDK)</span>\n    extra_headers={<span class="string">"OpenAI-Beta"</span>: <span class="string">"realtime=v1"</span>},\n)\n\n<span class="comment"># After: GA session creation with client_secrets</span>\n<span class="keyword">import</span> openai\n\nclient = openai.OpenAI()\n<span class="comment"># Create ephemeral key for client-side WebSocket</span>\nresponse = client.post(\n    <span class="string">"/v1/realtime/client_secrets"</span>,\n    body={\n        <span class="string">"model"</span>: <span class="string">"gpt-4o-realtime"</span>,\n        <span class="string">"session_type"</span>: <span class="string">"speech-to-speech"</span>,  <span class="comment"># NEW: required</span>\n    },\n)\nephemeral_key = response[<span class="string">"client_secret"</span>][<span class="string">"value"</span>]\n  </div>\n\n  <h3>Node.js: Beta to GA Migration</h3>\n  <p class="section-intro">Same pattern \u2014 update session creation and remove beta header:</p>\n\n  <div class="code-block">\n<span class="comment">// Before: Beta WebSocket connection</span>\n<span class="keyword">const</span> ws = <span class="keyword">new</span> WebSocket(\n  <span class="string">"wss://api.openai.com/v1/realtime?model=gpt-4o-realtime-preview"</span>,\n  {\n    headers: {\n      <span class="string">"Authorization"</span>: <span class="string">"Bearer "</span> + apiKey,\n      <span class="string">"OpenAI-Beta"</span>: <span class="string">"realtime=v1"</span>,  <span class="comment">// REMOVE this</span>\n    },\n  }\n);\n\n<span class="comment">// After: GA \u2014 get ephemeral key, then connect</span>\n<span class="keyword">const</span> resp = <span class="keyword">await</span> fetch(<span class="string">"https://api.openai.com/v1/realtime/client_secrets"</span>, {\n  method: <span class="string">"POST"</span>,\n  headers: {\n    <span class="string">"Authorization"</span>: <span class="string">"Bearer "</span> + apiKey,\n    <span class="string">"Content-Type"</span>: <span class="string">"application/json"</span>,\n  },\n  body: JSON.stringify({\n    model: <span class="string">"gpt-4o-realtime"</span>,\n    session_type: <span class="string">"speech-to-speech"</span>,  <span class="comment">// NEW: required</span>\n  }),\n});\n<span class="keyword">const</span> { client_secret } = <span class="keyword">await</span> resp.json();\n<span class="keyword">const</span> ws = <span class="keyword">new</span> WebSocket(\n  <span class="string">"wss://api.openai.com/v1/realtime?model=gpt-4o-realtime"</span>,\n  { headers: { <span class="string">"Authorization"</span>: <span class="string">"Bearer "</span> + client_secret.value } }\n);\n  </div>\n\n  <h3>Alternative: Deepgram Real-Time Transcription</h3>\n  <p class="section-intro">For speech-to-text only, Deepgram offers a simpler WebSocket API with lower per-minute costs:</p>\n\n  <div class="code-block">\n<span class="comment">// Deepgram real-time transcription (Node.js)</span>\n<span class="keyword">const</span> { createClient, LiveTranscriptionEvents } = require(<span class="string">"@deepgram/sdk"</span>);\n\n<span class="keyword">const</span> deepgram = createClient(<span class="string">"YOUR_DEEPGRAM_API_KEY"</span>);\n<span class="keyword">const</span> connection = deepgram.listen.live({\n  model: <span class="string">"nova-2"</span>,\n  language: <span class="string">"en"</span>,\n  smart_format: <span class="highlight">true</span>,\n});\n\nconnection.on(LiveTranscriptionEvents.Transcript, (data) =&gt; {\n  <span class="keyword">const</span> transcript = data.channel.alternatives[<span class="highlight">0</span>].transcript;\n  console.log(<span class="string">"Transcript:"</span>, transcript);\n});\n\n<span class="comment">// Send audio data to connection.send(audioBuffer)</span>\n  </div>\n\n  <div class="context-box">\n    <strong>session_type options:</strong> The GA Realtime API requires specifying <code style="font-family:var(--mono);background:rgba(255,255,255,0.1);padding:.1rem .3rem;border-radius:3px">"speech-to-speech"</code> for bidirectional voice conversations (the model speaks back) or <code style="font-family:var(--mono);background:rgba(255,255,255,0.1);padding:.1rem .3rem;border-radius:3px">"transcription"</code> for audio-to-text only. The beta handled both in a single session type, so you need to choose which mode your application uses.\n  </div>\n\n  <h2 id="faq">Frequently Asked Questions</h2>\n\n  <div class="faq-section">\n    ' + faqs.map(f => '<div class="faq-item">\n      <div class="faq-question">' + escHtmlServer(f.q) + '<span style="color:var(--text-dim)">\u25BC</span></div>\n      <div class="faq-answer">' + escHtmlServer(f.a) + '</div>\n    </div>').join("\n    ") + '\n  </div>\n\n  ' + (relevantChanges.length > 0 ? '<h2 id="openai-timeline">OpenAI Change Timeline</h2>\n  <p class="section-intro">Changes tracked in our <a href="/changes">deal changes database</a>:</p>\n\n  <div style="overflow-x:auto">\n  <table class="pricing-table">\n    <thead>\n      <tr>\n        <th>Date</th>\n        <th>Change</th>\n        <th>Impact</th>\n      </tr>\n    </thead>\n    <tbody>\n        ' + changeTimelineRows + '\n    </tbody>\n  </table>\n  </div>' : '<h2 id="openai-timeline">OpenAI Change Timeline</h2>\n  <p class="section-intro">Check our <a href="/changes">deal changes database</a> for the latest OpenAI updates.</p>') + '\n\n  <h2 id="recommendations">Recommendations</h2>\n\n  <div class="verdict-box">\n    <h3>Best Alternative for Each Use Case</h3>\n    <div class="verdict-item">\n      <strong>Fastest migration (recommended for most):</strong>\n      <p>OpenAI Realtime API GA \u2014 same SDK, same pricing. Remove the beta header, update session creation, add session_type. If it worked in beta, it will work in GA with minimal changes.</p>\n    </div>\n    <div class="verdict-item">\n      <strong>Best for transcription:</strong>\n      <p>Deepgram Nova-2 \u2014 $200 free credit, $0.0043/min (14x cheaper than OpenAI audio input). Industry-leading accuracy and very low latency (~100ms). Supports 30+ languages.</p>\n    </div>\n    <div class="verdict-item">\n      <strong>Best for transcription + AI analysis:</strong>\n      <p>AssemblyAI \u2014 real-time transcription plus LeMUR for summarization, sentiment analysis, and Q&amp;A on transcribed content. Free tier available.</p>\n    </div>\n    <div class="verdict-item">\n      <strong>Best for enterprise:</strong>\n      <p>Azure OpenAI Realtime \u2014 same API as OpenAI with Azure compliance, data residency, and enterprise support. $200 credit for new accounts.</p>\n    </div>\n    <div class="verdict-item">\n      <strong>Best for voice synthesis:</strong>\n      <p>ElevenLabs \u2014 ultra-low latency (~75ms) text-to-speech with voice cloning. 10K characters/month free. Best quality synthetic voices on the market.</p>\n    </div>\n    <div class="verdict-item">\n      <strong>Best for multi-language:</strong>\n      <p>Google Cloud Speech-to-Text \u2014 125+ languages and variants, 60 min/month free. Best choice if you need broad language coverage.</p>\n    </div>\n  </div>\n\n  <h2 id="methodology">Methodology</h2>\n\n  <div class="methodology">\n    <p><strong>How we track this data:</strong> AgentDeals monitors free tier changes across ' + offers.length.toLocaleString() + ' developer tools in ' + categories.length + ' categories. The Realtime API beta deprecation is tracked in our <a href="/shutdowns">shutdown tracker</a> and <a href="/stability">stability dashboard</a>.</p>\n    <p><strong>Migration recommendations:</strong> Based on API documentation review, SDK compatibility analysis, and community reports. Pricing data verified against official provider pricing pages as of ' + pubDate + '. Free tier availability confirmed via official documentation.</p>\n    <p>For real-time data, use our <a href="/stability">stability dashboard</a>, <a href="/feed.xml">Atom feed</a>, or <a href="/setup">MCP server</a>. Full dataset available via <a href="/api/offers">REST API</a>.</p>\n  </div>\n\n  <h2>Related Guides</h2>\n  <div class="related-pages">\n    ' + relatedPages.map(p => '<a href="/' + p.slug + '" class="related-page-link">\n      <div class="link-title">' + escHtmlServer(p.title.split(" \u2014 ")[0]) + '</div>\n      <div class="link-desc">' + escHtmlServer(p.hubDesc) + '</div>\n    </a>').join("\n    ") + '\n  </div>\n\n  ' + buildMoreAlternativesGuides(slug) + '\n\n  ' + buildMcpCta("Track real-time API shutdowns and compare developer tool free tiers from your AI assistant. Get stability ratings, migration alerts, and pricing comparisons \u2014 directly in your editor.") + '\n  <footer>AgentDeals &mdash; open source, built for agents | <a href="/privacy">Privacy</a></footer>\n</div>\n<script>' + mcpCtaScript() + '</script>\n</body>\n</html>';
+}
+
+// --- AWS App Runner Migration Guide page ---
+
+function buildAppRunnerMigrationPage(): string {
+  const title = "AWS App Runner Migration Guide: Alternatives with Free Tiers & Pricing (2026)";
+  const metaDesc = "AWS App Runner closes to new customers April 30, 2026. Migrate to ECS Express Mode, Google Cloud Run, Railway, Render, Fly.io, or Azure Container Apps. Free tier comparison, pricing, and migration paths.";
+  const slug = "aws-app-runner-migration";
+  const pubDate = "2026-04-10";
+
+  const stabilityMap = getStabilityMap();
+
+  // AWS deal changes
+  const awsChanges = dealChanges.filter(c =>
+    c.vendor === "AWS" || c.vendor === "Amazon AWS" || c.summary.toLowerCase().includes("app runner")
+  ).sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime());
+
+  interface ContainerProvider {
+    name: string;
+    slug: string;
+    freeTier: string;
+    startingPrice: string;
+    pricingModel: string;
+    sourceCodeDeploy: string;
+    autoScaling: string;
+    migrationEffort: string;
+    bestFor: string;
+  }
+
+  const providers: ContainerProvider[] = [
+    { name: "Amazon ECS Express Mode", slug: "aws", freeTier: "AWS Free Tier (750 hrs t2.micro/mo, 12 months)", startingPrice: "~$0.01/hr (Fargate)", pricingModel: "Per-hour (Fargate vCPU + memory)", sourceCodeDeploy: "No — container images only", autoScaling: "Yes (Service Auto Scaling)", migrationEffort: "Moderate — different API, same AWS ecosystem", bestFor: "Existing AWS users (official recommendation)" },
+    { name: "AWS Fargate", slug: "aws", freeTier: "AWS Free Tier (limited)", startingPrice: "$0.04048/vCPU-hr + $0.004445/GB-hr", pricingModel: "Per-second (vCPU + memory)", sourceCodeDeploy: "No — container images only", autoScaling: "Yes (ECS Service Auto Scaling)", migrationEffort: "Moderate — different API, same ECR", bestFor: "Serverless containers on AWS" },
+    { name: "Elastic Beanstalk", slug: "aws", freeTier: "No EB fee (pay for underlying resources)", startingPrice: "EC2 pricing (t2.micro free 12 mo)", pricingModel: "Per-hour (underlying EC2/RDS)", sourceCodeDeploy: "Yes — source code + Dockerfiles", autoScaling: "Yes (EC2 Auto Scaling)", migrationEffort: "Low — supports source code deploy like App Runner", bestFor: "Source code deploy with full AWS control" },
+    { name: "Google Cloud Run", slug: "google-cloud-run", freeTier: "2M requests/mo, 360K vCPU-sec, 180K GiB-sec free", startingPrice: "$0.00002400/vCPU-sec", pricingModel: "Per-request + per-second (scale to zero)", sourceCodeDeploy: "Yes — source code via buildpacks", autoScaling: "Yes (scale to zero)", migrationEffort: "Moderate — different cloud, similar DX", bestFor: "Pay-per-request with generous free tier" },
+    { name: "Azure Container Apps", slug: "azure", freeTier: "180K vCPU-sec, 360K GiB-sec/mo free", startingPrice: "$0.000024/vCPU-sec", pricingModel: "Per-second (consumption) or dedicated", sourceCodeDeploy: "Yes — source code via buildpacks", autoScaling: "Yes (KEDA-based, scale to zero)", migrationEffort: "Moderate — different cloud, similar concepts", bestFor: "Azure ecosystem, event-driven scaling" },
+    { name: "Railway", slug: "railway", freeTier: "$5/mo free credit (trial)", startingPrice: "$5/mo + usage ($0.000463/vCPU-min)", pricingModel: "Per-minute (vCPU + memory) + subscription", sourceCodeDeploy: "Yes — GitHub/GitLab auto-deploy", autoScaling: "Yes (horizontal + vertical)", migrationEffort: "Low — push to deploy, minimal config", bestFor: "Developer experience, fast deployment" },
+    { name: "Render", slug: "render", freeTier: "Free tier (750 hrs/mo, sleeps after inactivity)", startingPrice: "$7/mo (Starter)", pricingModel: "Per-service fixed monthly", sourceCodeDeploy: "Yes — GitHub auto-deploy", autoScaling: "Yes (paid plans)", migrationEffort: "Low — similar DX to App Runner", bestFor: "Simple web services, closest App Runner experience" },
+    { name: "Fly.io", slug: "fly-io", freeTier: "3 shared-cpu-1x VMs, 160GB bandwidth free", startingPrice: "$1.94/mo (shared-cpu-1x)", pricingModel: "Per-VM + bandwidth", sourceCodeDeploy: "Yes — Dockerfiles + buildpacks", autoScaling: "Yes (scale to zero, multi-region)", migrationEffort: "Low-Moderate — CLI-driven, different paradigm", bestFor: "Multi-region, edge deployment" },
+    { name: "DigitalOcean App Platform", slug: "digitalocean", freeTier: "3 static sites free, starter apps $5/mo", startingPrice: "$5/mo (Basic)", pricingModel: "Fixed monthly per app", sourceCodeDeploy: "Yes — GitHub/GitLab auto-deploy", autoScaling: "Yes (Pro+ plans)", migrationEffort: "Low — similar source code deploy model", bestFor: "Simple apps, predictable pricing" },
+    { name: "Northflank", slug: "northflank", freeTier: "Free tier (2 services, 0.2 vCPU, 512MB RAM)", startingPrice: "$10/mo (Developer)", pricingModel: "Per-service + resource usage", sourceCodeDeploy: "Yes — buildpacks + Dockerfiles", autoScaling: "Yes", migrationEffort: "Low — designed as PaaS, similar concepts", bestFor: "Full PaaS with CI/CD built-in" },
+  ];
+
+  const awsStability = stabilityMap.get("aws") ?? "stable";
+  const stabilityColor = awsStability === "volatile" ? "#f85149" : awsStability === "watch" ? "#d29922" : awsStability === "improving" ? "#3fb950" : "var(--text-muted)";
+
+  // Calculate days until deadline
+  const deadlineDate = new Date("2026-04-30");
+  const today = new Date();
+  const daysLeft = Math.max(0, Math.ceil((deadlineDate.getTime() - today.getTime()) / (1000 * 60 * 60 * 24)));
+
+  const freeProviderCount = providers.filter(p => p.freeTier.toLowerCase().includes("free")).length;
+
+  const providerTableRows = providers.map(p => {
+    const freeColor = p.freeTier.toLowerCase().includes("free") ? "#3fb950" : "var(--accent)";
+    const effortColor = p.migrationEffort.startsWith("Low") ? "#3fb950" : p.migrationEffort.startsWith("Moderate") ? "#d29922" : "#f85149";
+    const vendorLink = p.slug ? `<a href="/vendor/${escHtmlServer(p.slug)}" style="color:var(--text)">${escHtmlServer(p.name)}</a>` : escHtmlServer(p.name);
+    return `<tr>
+      <td style="font-weight:600">${vendorLink}</td>
+      <td style="font-family:var(--mono);font-size:.8rem;color:${freeColor}">${escHtmlServer(p.freeTier)}</td>
+      <td style="font-family:var(--mono);font-size:.8rem">${escHtmlServer(p.startingPrice)}</td>
+      <td style="font-size:.8rem">${escHtmlServer(p.pricingModel)}</td>
+      <td style="font-size:.8rem">${p.sourceCodeDeploy.startsWith("Yes") ? '<span style="color:#3fb950">Yes</span>' : '<span style="color:#f85149">No</span>'}</td>
+      <td><span style="color:${effortColor};font-size:.8rem;font-weight:600">${escHtmlServer(p.migrationEffort.split(" — ")[0])}</span></td>
+    </tr>`;
+  }).join("\n        ");
+
+  const pricingComparisonRows = [
+    { name: "App Runner (closing)", free: "None for new customers", monthly: "From $5/mo (1 vCPU, 2GB)", scaling: "Per-request auto-scaling", color: "#f85149" },
+    { name: "ECS Express Mode (Fargate)", free: "AWS Free Tier (limited)", monthly: "~$30/mo (0.5 vCPU, 1GB 24/7)", scaling: "Per-second, service auto-scaling", color: "var(--accent)" },
+    { name: "Google Cloud Run", free: "2M req + 360K vCPU-sec/mo", monthly: "Pay-per-use (scale to zero)", scaling: "Per-request, scale to zero", color: "#3fb950" },
+    { name: "Azure Container Apps", free: "180K vCPU-sec/mo", monthly: "Pay-per-use (scale to zero)", scaling: "Per-second, KEDA events", color: "#3fb950" },
+    { name: "Railway", free: "$5/mo credit (trial)", monthly: "From $5/mo + usage", scaling: "Per-minute, horizontal", color: "#d29922" },
+    { name: "Render", free: "750 hrs/mo (sleeps)", monthly: "From $7/mo (Starter)", scaling: "Fixed + auto-scaling (paid)", color: "#3fb950" },
+    { name: "Fly.io", free: "3 shared VMs free", monthly: "From $1.94/mo per VM", scaling: "Per-VM, multi-region", color: "#3fb950" },
+    { name: "DigitalOcean App Platform", free: "Static sites free", monthly: "From $5/mo (Basic)", scaling: "Fixed monthly per app", color: "#d29922" },
+  ].map(r => `<tr>
+      <td style="font-weight:600">${escHtmlServer(r.name)}</td>
+      <td style="font-family:var(--mono);font-size:.8rem;color:${r.color}">${escHtmlServer(r.free)}</td>
+      <td style="font-family:var(--mono);font-size:.8rem">${escHtmlServer(r.monthly)}</td>
+      <td style="font-size:.8rem">${escHtmlServer(r.scaling)}</td>
+    </tr>`).join("\n        ");
+
+  const changeTimelineRows = awsChanges.slice(0, 10).map(c => {
+    const dateStr = new Date(c.date).toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" });
+    const impactColor = c.impact === "high" ? "#f85149" : c.impact === "medium" ? "#d29922" : "#3fb950";
+    return `<tr>
+      <td style="font-family:var(--mono);font-size:.8rem;white-space:nowrap">${escHtmlServer(dateStr)}</td>
+      <td style="font-size:.85rem">${escHtmlServer(c.summary)}</td>
+      <td><span style="color:${impactColor};font-size:.8rem;font-weight:600">${escHtmlServer(c.impact?.toUpperCase() ?? "N/A")}</span></td>
+    </tr>`;
+  }).join("\n        ");
+
+  // Related editorial pages
+  const relatedPages = ALTERNATIVES_PAGES.filter(p =>
+    ["shutdowns", "aws-free-tier-2026", "cloud-comparison-2026", "free-tier-risk", "state-of-free-tiers"].includes(p.slug)
+  );
+
+  // FAQ data
+  const faqs = [
+    { q: "When does AWS App Runner shut down?", a: "AWS App Runner stops accepting new customers on April 30, 2026. Existing customers can continue using the service, but it has entered maintenance mode with no new features planned. AWS has not announced a final shutdown date for existing services, but recommends migrating to Amazon ECS Express Mode." },
+    { q: "What is ECS Express Mode and how does it replace App Runner?", a: "ECS Express Mode is AWS's recommended migration path. It simplifies Amazon ECS by providing a streamlined container deployment experience similar to App Runner — easier configuration, managed networking, and automatic scaling — while giving you access to the full ECS ecosystem. The main difference is that ECS Express Mode only supports container images (no source code deploy), so you'll need to build your container first." },
+    { q: "Can I still use App Runner if I'm already a customer?", a: "Yes. Existing App Runner services will continue to run after April 30, 2026. You can update existing services and deploy new versions. However, the service is in maintenance mode — no new features will be added, and AWS strongly recommends planning a migration." },
+    { q: "What are the best free alternatives to App Runner?", a: "Google Cloud Run offers the most generous free tier (2 million requests/month, 360K vCPU-seconds, scale to zero). Fly.io provides 3 free shared VMs. Render has a free tier with 750 hours/month (services sleep after inactivity). Azure Container Apps offers 180K vCPU-seconds/month free. For AWS-native options, Elastic Beanstalk has no management fee — you only pay for underlying resources." },
+    { q: "Which alternative supports source code deployment like App Runner?", a: "App Runner's source code deployment (push code, AWS builds the container) is available on: Google Cloud Run (Cloud Build + buildpacks), Railway (GitHub auto-deploy), Render (GitHub auto-deploy), Fly.io (Dockerfiles + buildpacks), DigitalOcean App Platform (GitHub/GitLab auto-deploy), Azure Container Apps (source code via buildpacks), Elastic Beanstalk (source bundles + Dockerfiles), and Northflank (buildpacks + Dockerfiles). ECS Express Mode does NOT support source code deploy — you must provide a container image." },
+  ];
+
+  // JSON-LD — Article
+  const jsonLd = {
+    "@context": "https://schema.org",
+    "@type": "Article",
+    headline: title,
+    description: metaDesc,
+    datePublished: pubDate,
+    dateModified: new Date().toISOString().split("T")[0],
+    author: { "@type": "Organization", name: "AgentDeals", url: BASE_URL },
+    publisher: { "@type": "Organization", name: "AgentDeals", url: BASE_URL },
+    mainEntityOfPage: { "@type": "WebPage", "@id": `${BASE_URL}/${slug}` },
+    about: providers.map(p => ({ "@type": "SoftwareApplication", name: p.name })),
+  };
+
+  // JSON-LD — FAQPage
+  const faqJsonLd = {
+    "@context": "https://schema.org",
+    "@type": "FAQPage",
+    mainEntity: faqs.map(f => ({
+      "@type": "Question",
+      name: f.q,
+      acceptedAnswer: { "@type": "Answer", text: f.a },
+    })),
+  };
+
+  // JSON-LD — BreadcrumbList
+  const breadcrumbJsonLd = {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    itemListElement: [
+      { "@type": "ListItem", position: 1, name: "AgentDeals", item: BASE_URL },
+      { "@type": "ListItem", position: 2, name: "Guides", item: `${BASE_URL}/alternatives` },
+      { "@type": "ListItem", position: 3, name: "App Runner Migration Guide", item: `${BASE_URL}/${slug}` },
+    ],
+  };
+
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>${escHtmlServer(title)} — AgentDeals</title>
+<meta name="description" content="${escHtmlServer(metaDesc)}">
+<link rel="canonical" href="${BASE_URL}/${slug}">
+<meta property="og:title" content="${escHtmlServer(title)}">
+<meta property="og:description" content="${escHtmlServer(metaDesc)}">
+<meta property="og:type" content="article">
+<meta property="og:url" content="${BASE_URL}/${slug}">
+<meta property="article:published_time" content="${pubDate}">
+<meta name="keywords" content="aws app runner shutdown, app runner alternative, app runner migration, ecs express mode, google cloud run, railway, render, fly.io, container deployment free tier, aws app runner replacement 2026">
+${OG_IMAGE_META}${GOOGLE_VERIFICATION_META}<link rel="icon" type="image/png" href="/favicon.png">
+<link rel="alternate" type="application/atom+xml" title="AgentDeals — Pricing Changes" href="/feed.xml">
+<link rel="preconnect" href="https://fonts.googleapis.com"><link rel="preconnect" href="https://fonts.gstatic.com" crossorigin><link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
+<script type="application/ld+json">${JSON.stringify(jsonLd)}</script>
+<script type="application/ld+json">${JSON.stringify(faqJsonLd)}</script>
+<script type="application/ld+json">${JSON.stringify(breadcrumbJsonLd)}</script>
+<style>
+*{margin:0;padding:0;box-sizing:border-box}
+:root{--bg:#0f172a;--bg-elevated:#1e293b;--bg-card:rgba(255,255,255,0.06);--border:#334155;--border-hover:#3b82f6;--text:#f1f5f9;--text-muted:#94a3b8;--text-dim:#64748b;--accent:#3b82f6;--accent-hover:#60a5fa;--accent-glow:rgba(59,130,246,0.15);--serif:'Inter',-apple-system,sans-serif;--sans:'Inter',-apple-system,sans-serif;--mono:'JetBrains Mono',SFMono-Regular,monospace}
+body{font-family:var(--sans);background:var(--bg);color:var(--text);line-height:1.6}
+a{color:var(--accent);text-decoration:none}a:hover{color:var(--accent-hover);text-decoration:underline}
+.container{max-width:960px;margin:0 auto;padding:0 1.5rem}
+.breadcrumb{padding:1.5rem 0 0;font-size:.8rem;color:var(--text-dim)}
+.breadcrumb a{color:var(--text-muted)}
+h1{font-family:var(--serif);font-size:2.25rem;color:var(--text);margin:1rem 0 .5rem;letter-spacing:-.02em}
+h2{font-family:var(--serif);font-size:1.4rem;color:var(--text);margin:2.5rem 0 1rem;letter-spacing:-.01em}
+h3{font-family:var(--serif);font-size:1.1rem;color:var(--text);margin:1.5rem 0 .5rem}
+.pub-date{color:var(--text-dim);font-size:.85rem;margin-bottom:1.5rem}
+.deadline-banner{background:linear-gradient(135deg,rgba(248,81,73,0.15),rgba(210,153,34,0.1));border:1px solid #f85149;border-radius:12px;padding:1.5rem;margin:1.5rem 0;text-align:center}
+.deadline-days{font-size:2.5rem;font-weight:700;font-family:var(--mono);color:#f85149}
+.deadline-label{font-size:.9rem;color:var(--text-muted);margin-top:.25rem}
+.deadline-date{font-size:.85rem;color:var(--text-dim);margin-top:.5rem}
+.summary-stats{display:grid;grid-template-columns:repeat(auto-fit,minmax(140px,1fr));gap:1rem;margin:1.5rem 0 2rem}
+.stat-card{background:var(--bg-card);border:1px solid var(--border);border-radius:8px;padding:1rem;text-align:center}
+.stat-number{font-size:1.8rem;font-weight:700;font-family:var(--mono);color:var(--accent)}
+.stat-number.red{color:#f85149}
+.stat-number.green{color:#3fb950}
+.stat-label{font-size:.8rem;color:var(--text-muted);margin-top:.25rem}
+.executive-summary{background:var(--bg-card);border:1px solid var(--border);border-radius:8px;padding:1.5rem;margin:1.5rem 0;line-height:1.8}
+.executive-summary p{color:var(--text-muted);margin-bottom:.75rem;font-size:.95rem}
+.executive-summary p:last-child{margin-bottom:0}
+.executive-summary strong{color:var(--text)}
+.section-intro{color:var(--text-muted);font-size:.95rem;margin-bottom:1.25rem;line-height:1.7}
+.pricing-table{width:100%;border-collapse:collapse;margin:1rem 0 2rem;font-size:.85rem}
+.pricing-table th{text-align:left;padding:.75rem .5rem;border-bottom:2px solid var(--border);color:var(--text-muted);font-weight:600;font-size:.75rem;text-transform:uppercase;letter-spacing:.05em}
+.pricing-table td{padding:.6rem .5rem;border-bottom:1px solid var(--border)}
+.pricing-table tr:hover{background:var(--accent-glow)}
+.diff-card{padding:1.25rem;border:1px solid var(--border);border-left:3px solid var(--accent);border-radius:8px;background:var(--bg-card);margin-bottom:.75rem}
+.diff-card h3{margin:0 0 .5rem;font-size:1rem}
+.diff-desc{color:var(--text-muted);font-size:.9rem;line-height:1.6}
+.context-box{background:var(--bg-card);border:1px solid var(--border);border-radius:8px;padding:1.25rem;margin:1rem 0;font-size:.9rem;color:var(--text-muted);line-height:1.7}
+.context-box strong{color:var(--text)}
+.decision-tree{display:grid;gap:1rem;margin:1.5rem 0}
+.decision-path{padding:1.25rem;border:1px solid var(--border);border-radius:8px;background:var(--bg-card);transition:border-color .15s}
+.decision-path:hover{border-color:var(--accent)}
+.decision-path h3{margin:0 0 .5rem;font-size:1rem;color:var(--accent)}
+.decision-path p{color:var(--text-muted);font-size:.9rem;margin-bottom:.5rem}
+.decision-path .best-for{font-size:.8rem;color:var(--text-dim);font-style:italic}
+.verdict-box{background:linear-gradient(135deg,rgba(59,130,246,0.1),rgba(139,92,246,0.1));border:1px solid var(--accent);border-radius:12px;padding:1.5rem;margin:1.5rem 0}
+.verdict-box h3{color:var(--accent);margin:0 0 .75rem;font-size:1.1rem}
+.verdict-item{margin-bottom:.75rem;padding-left:1rem;border-left:2px solid var(--border)}
+.verdict-item strong{color:var(--text)}
+.verdict-item p{color:var(--text-muted);font-size:.9rem;margin:.25rem 0 0}
+.methodology{background:var(--bg-card);border:1px solid var(--border);border-radius:8px;padding:1.25rem;margin:2rem 0;font-size:.9rem;color:var(--text-muted);line-height:1.7}
+.methodology strong{color:var(--text)}
+.related-pages{display:flex;flex-direction:column;gap:.5rem;margin:1rem 0}
+.related-page-link{padding:.75rem 1rem;border:1px solid var(--border);border-radius:8px;background:var(--bg-card);text-decoration:none;transition:border-color .15s}
+.related-page-link:hover{border-color:var(--accent);text-decoration:none}
+.related-page-link .link-title{color:var(--accent);font-weight:600;font-size:.95rem}
+.related-page-link .link-desc{color:var(--text-muted);font-size:.8rem;margin-top:.25rem}
+.toc{background:var(--bg-card);border:1px solid var(--border);border-radius:8px;padding:1.25rem;margin:1.5rem 0}
+.toc h3{margin:0 0 .5rem;font-size:.9rem;color:var(--text-muted)}
+.toc ol{padding-left:1.25rem;margin:0}
+.toc li{margin-bottom:.35rem;font-size:.9rem}
+.toc a{color:var(--accent)}
+.code-block{background:#0d1117;border:1px solid var(--border);border-radius:8px;padding:1.25rem;margin:1rem 0;overflow-x:auto;font-family:var(--mono);font-size:.8rem;line-height:1.5;color:#c9d1d9}
+.code-block .comment{color:#8b949e}
+.code-block .keyword{color:#ff7b72}
+.code-block .string{color:#a5d6ff}
+.code-block .highlight{color:#ffa657}
+.faq-section{margin:2rem 0}
+.faq-item{border:1px solid var(--border);border-radius:8px;margin-bottom:.75rem;overflow:hidden}
+.faq-question{padding:1rem 1.25rem;background:var(--bg-card);cursor:pointer;font-weight:600;font-size:.95rem;display:flex;justify-content:space-between;align-items:center}
+.faq-question:hover{background:var(--accent-glow)}
+.faq-answer{padding:0 1.25rem 1rem;color:var(--text-muted);font-size:.9rem;line-height:1.7}
+footer{text-align:center;color:var(--text-dim);font-size:.8rem;padding:3rem 0 2rem;border-top:1px solid var(--border);margin-top:3rem}
+footer a{color:var(--accent)}
+@media(max-width:768px){h1{font-size:1.6rem}.summary-stats{grid-template-columns:1fr 1fr}.pricing-table{font-size:.75rem}.pricing-table td,.pricing-table th{padding:.4rem .25rem}.deadline-days{font-size:1.8rem}}
+${globalNavCss()}
+${mcpCtaCss()}
+</style>
+</head>
+<body>
+<div class="container">
+  ${buildGlobalNav("alternatives")}
+  <div class="breadcrumb"><a href="/">AgentDeals</a> &rsaquo; <a href="/alternatives">Guides</a> &rsaquo; App Runner Migration Guide</div>
+  <h1>AWS App Runner Migration Guide: Alternatives with Free Tiers &amp; Pricing</h1>
+  <p class="pub-date">Published ${pubDate} &middot; Data verified from our index of ${offers.length.toLocaleString()} developer tools &middot; ${awsChanges.length} AWS pricing change${awsChanges.length !== 1 ? "s" : ""} tracked</p>
+
+  <div class="deadline-banner">
+    <div class="deadline-days">${daysLeft} days</div>
+    <div class="deadline-label">until App Runner closes to new customers</div>
+    <div class="deadline-date">April 30, 2026 &middot; <span style="color:${stabilityColor};font-weight:600">AWS stability: ${awsStability.toUpperCase()}</span></div>
+  </div>
+
+  <div class="summary-stats">
+    <div class="stat-card"><div class="stat-number red">${daysLeft}</div><div class="stat-label">Days Remaining</div></div>
+    <div class="stat-card"><div class="stat-number">${providers.length}</div><div class="stat-label">Alternatives Compared</div></div>
+    <div class="stat-card"><div class="stat-number green">${freeProviderCount}</div><div class="stat-label">With Free Tiers</div></div>
+    <div class="stat-card"><div class="stat-number">3</div><div class="stat-label">Migration Paths</div></div>
+  </div>
+
+  <div class="executive-summary">
+    <p><strong>What&rsquo;s happening:</strong> AWS App Runner will <strong>stop accepting new customers on April 30, 2026</strong>. The service has entered maintenance mode with no new features planned. Existing services continue to run, but AWS officially recommends migrating to <strong>Amazon ECS Express Mode</strong>.</p>
+    <p><strong>AWS&rsquo;s recommendation:</strong> <strong>ECS Express Mode</strong> provides a simplified ECS experience designed to replace App Runner. It supports auto-scaling, managed networking, and integration with ECR. The key difference: ECS Express Mode requires container images — it does not support App Runner&rsquo;s source code deployment.</p>
+    <p><strong>Free alternatives exist:</strong> If you want to leave AWS, <strong>Google Cloud Run</strong> (2M requests/mo free, scale to zero), <strong>Fly.io</strong> (3 free VMs), and <strong>Render</strong> (free tier with 750 hrs/mo) all offer container deployment with free tiers and source code deployment support.</p>
+  </div>
+
+  <div class="toc">
+    <h3>Jump to section</h3>
+    <ol>
+      <li><a href="#timeline">Deprecation Timeline</a></li>
+      <li><a href="#comparison-table">Alternative Comparison Table</a></li>
+      <li><a href="#pricing">Pricing Comparison</a></li>
+      <li><a href="#migration-paths">Migration Paths</a></li>
+      <li><a href="#migration-considerations">Migration Considerations</a></li>
+      <li><a href="#code-migration">Migration Examples</a></li>
+      <li><a href="#faq">FAQ</a></li>
+      <li><a href="#aws-timeline">AWS Change Timeline</a></li>
+      <li><a href="#recommendations">Recommendations</a></li>
+      <li><a href="#methodology">Methodology</a></li>
+    </ol>
+  </div>
+
+  <h2 id="timeline">Deprecation Timeline</h2>
+  <p class="section-intro">Key dates for the App Runner deprecation. Existing services continue, but plan your migration.</p>
+
+  <div style="overflow-x:auto">
+  <table class="pricing-table">
+    <thead>
+      <tr>
+        <th>Date</th>
+        <th>Event</th>
+        <th>Impact</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td style="font-family:var(--mono);font-size:.8rem;white-space:nowrap">Apr 2026</td>
+        <td style="font-size:.85rem">AWS announces App Runner will stop accepting new customers. Service enters maintenance mode. ECS Express Mode recommended as replacement.</td>
+        <td><span style="color:#f85149;font-size:.8rem;font-weight:600">HIGH</span></td>
+      </tr>
+      <tr>
+        <td style="font-family:var(--mono);font-size:.8rem;white-space:nowrap">Apr 30, 2026</td>
+        <td style="font-size:.85rem"><strong>New customer cutoff.</strong> No new App Runner services can be created by new accounts. Existing customers can continue deploying.</td>
+        <td><span style="color:#f85149;font-size:.8rem;font-weight:600">HIGH</span></td>
+      </tr>
+      <tr>
+        <td style="font-family:var(--mono);font-size:.8rem;white-space:nowrap">Post-cutoff</td>
+        <td style="font-size:.85rem">Existing services continue to run. Updates and deployments allowed for current customers. No new features will be added to App Runner.</td>
+        <td><span style="color:#d29922;font-size:.8rem;font-weight:600">MEDIUM</span></td>
+      </tr>
+      <tr>
+        <td style="font-family:var(--mono);font-size:.8rem;white-space:nowrap">TBD</td>
+        <td style="font-size:.85rem">AWS has not announced a final shutdown date for existing services. However, maintenance mode typically precedes full deprecation. Plan migration proactively.</td>
+        <td><span style="color:var(--text-dim);font-size:.8rem;font-weight:600">INFO</span></td>
+      </tr>
+    </tbody>
+  </table>
+  </div>
+
+  <div class="context-box">
+    <strong>What&rsquo;s NOT affected (yet):</strong> Existing App Runner services continue to run after April 30. You can still deploy updates and new versions to existing services. The key concern is long-term viability — with no new features and maintenance mode status, App Runner&rsquo;s future is limited. Plan your migration timeline accordingly.
+  </div>
+
+  <h2 id="comparison-table">Container Deployment Alternatives</h2>
+  <p class="section-intro">All ${providers.length} alternatives compared. Migration effort rated from the perspective of an App Runner integration.</p>
+
+  <div style="overflow-x:auto">
+  <table class="pricing-table">
+    <thead>
+      <tr>
+        <th>Provider</th>
+        <th>Free Tier</th>
+        <th>Starting Price</th>
+        <th>Pricing Model</th>
+        <th>Source Deploy</th>
+        <th>Migration</th>
+      </tr>
+    </thead>
+    <tbody>
+        ${providerTableRows}
+    </tbody>
+  </table>
+  </div>
+
+  <div class="context-box">
+    <strong>Source code deploy matters:</strong> One of App Runner&rsquo;s key features was deploying directly from source code (GitHub) without building a Docker image. ECS Express Mode does <strong>not</strong> support this — you must provide a container image. If source code deployment is important to your workflow, consider Railway, Render, Google Cloud Run, or DigitalOcean App Platform, all of which support auto-deploy from GitHub.
+  </div>
+
+  <h2 id="pricing">Pricing Comparison</h2>
+  <p class="section-intro">Monthly cost comparison across alternatives. App Runner pricing shown for reference.</p>
+
+  <div style="overflow-x:auto">
+  <table class="pricing-table">
+    <thead>
+      <tr>
+        <th>Provider</th>
+        <th>Free Tier</th>
+        <th>Typical Monthly Cost</th>
+        <th>Scaling Model</th>
+      </tr>
+    </thead>
+    <tbody>
+        ${pricingComparisonRows}
+    </tbody>
+  </table>
+  </div>
+
+  <div class="context-box">
+    <strong>Scale-to-zero advantage:</strong> Google Cloud Run and Azure Container Apps can scale to zero — you pay nothing when there&rsquo;s no traffic. App Runner supported auto-scaling but not true scale-to-zero (minimum provisioned instances were always billed). This makes Cloud Run and Container Apps significantly cheaper for low-traffic or intermittent workloads.
+  </div>
+
+  <h2 id="migration-paths">Migration Paths</h2>
+  <p class="section-intro">Three paths depending on your cloud strategy. The right choice depends on whether you want to stay on AWS, go multi-cloud, or use a developer PaaS.</p>
+
+  <div class="decision-tree">
+    <div class="decision-path" style="border-left:3px solid #3fb950">
+      <h3>Path 1: Stay on AWS (ECS Express Mode)</h3>
+      <p>AWS&rsquo;s official recommendation. ECS Express Mode simplifies container deployment on ECS with managed networking and auto-scaling. Your ECR images, IAM roles, VPC config, and CloudWatch logs continue to work. The main change: you must containerize your app if you used App Runner&rsquo;s source code deployment — ECS Express Mode requires container images.</p>
+      <p class="best-for">Best for: Teams invested in AWS ecosystem, using ECR, IAM, and other AWS services</p>
+    </div>
+    <div class="decision-path" style="border-left:3px solid var(--accent)">
+      <h3>Path 2: Multi-Cloud PaaS (Cloud Run, Container Apps)</h3>
+      <p>Google Cloud Run and Azure Container Apps offer the closest experience to App Runner — fully managed, auto-scaling, and pay-per-use with generous free tiers. Both support source code deployment and scale-to-zero, which App Runner didn&rsquo;t offer. Cloud Run&rsquo;s 2M free requests/month makes it the strongest free tier option.</p>
+      <p class="best-for">Best for: Cost-sensitive workloads, intermittent traffic, multi-cloud strategy</p>
+    </div>
+    <div class="decision-path" style="border-left:3px solid #8b5cf6">
+      <h3>Path 3: Developer PaaS (Railway, Render, Fly.io)</h3>
+      <p>Developer-focused platforms with the simplest deployment experience. Push to GitHub, get a running service. Railway and Render offer the closest DX to App Runner&rsquo;s source code deploy. Fly.io excels at multi-region deployment. All have free tiers or trial credits to get started.</p>
+      <p class="best-for">Best for: Fast deployment, great DX, small teams, side projects</p>
+    </div>
+  </div>
+
+  <h2 id="migration-considerations">Migration Considerations</h2>
+  <p class="section-intro">Key differences to evaluate when choosing your migration target.</p>
+
+  <div class="diff-card">
+    <h3>Source Code vs. Container Image Deployment</h3>
+    <div class="diff-desc">App Runner supported both source code (auto-built by AWS) and container image deployment. <strong>ECS Express Mode only supports container images.</strong> If your team doesn&rsquo;t maintain Dockerfiles, consider adding a build step (GitHub Actions, AWS CodeBuild) or choose a platform that builds from source (Cloud Run, Railway, Render).</div>
+  </div>
+  <div class="diff-card">
+    <h3>Custom Domain Migration</h3>
+    <div class="diff-desc">Custom domains configured in App Runner need to be reconfigured on your new platform. Update DNS records (CNAME or A records) to point to your new provider. Most platforms provide managed TLS certificates via Let&rsquo;s Encrypt. Plan for a brief DNS propagation period.</div>
+  </div>
+  <div class="diff-card">
+    <h3>Auto-Scaling Differences</h3>
+    <div class="diff-desc">App Runner scaled based on concurrent requests. ECS Express Mode uses ECS Service Auto Scaling (CPU/memory-based). Cloud Run and Container Apps support request-based scaling AND scale-to-zero. Railway and Render offer auto-scaling on paid plans. Consider your scaling triggers when migrating.</div>
+  </div>
+  <div class="diff-card">
+    <h3>Cold Start Behavior</h3>
+    <div class="diff-desc">App Runner had configurable provisioned concurrency to minimize cold starts. On Cloud Run and Container Apps, cold starts occur when scaling from zero. Fly.io keeps VMs warm by default. Railway and Render keep services running continuously on paid plans. Factor cold start requirements into your decision.</div>
+  </div>
+  <div class="diff-card">
+    <h3>VPC and Networking</h3>
+    <div class="diff-desc">If your App Runner service connected to VPC resources (RDS, ElastiCache), staying on AWS (ECS Express Mode or Fargate) preserves those network connections. Moving to another cloud requires exposing those resources publicly or setting up VPN/peering — a significant migration consideration for data-heavy applications.</div>
+  </div>
+
+  <h2 id="code-migration">Migration Examples</h2>
+
+  <h3>App Runner to ECS Express Mode (AWS CLI)</h3>
+  <p class="section-intro">If your App Runner service uses ECR, the ECS migration is straightforward:</p>
+
+  <div class="code-block">
+<span class="comment"># Step 1: Get your current App Runner image URI</span>
+aws apprunner describe-service \\
+  --service-arn <span class="string">arn:aws:apprunner:us-east-1:123456789:service/my-app</span> \\
+  --query <span class="string">"Service.SourceConfiguration.ImageRepository.ImageIdentifier"</span>
+
+<span class="comment"># Step 2: Create ECS cluster (Express Mode simplifies this)</span>
+aws ecs create-cluster --cluster-name <span class="string">my-app-cluster</span>
+
+<span class="comment"># Step 3: Register task definition</span>
+aws ecs register-task-definition \\
+  --family <span class="string">my-app</span> \\
+  --requires-compatibilities <span class="highlight">FARGATE</span> \\
+  --network-mode <span class="string">awsvpc</span> \\
+  --cpu <span class="string">"256"</span> \\
+  --memory <span class="string">"512"</span> \\
+  --container-definitions <span class="string">'[{"name":"my-app","image":"YOUR_ECR_IMAGE","portMappings":[{"containerPort":8080}]}]'</span>
+
+<span class="comment"># Step 4: Create service with auto-scaling</span>
+aws ecs create-service \\
+  --cluster <span class="string">my-app-cluster</span> \\
+  --service-name <span class="string">my-app-service</span> \\
+  --task-definition <span class="string">my-app</span> \\
+  --desired-count <span class="highlight">1</span> \\
+  --launch-type <span class="highlight">FARGATE</span>
+  </div>
+
+  <h3>App Runner to Google Cloud Run</h3>
+  <p class="section-intro">Deploy from source code or container image with a single command:</p>
+
+  <div class="code-block">
+<span class="comment"># Deploy from source code (like App Runner source deploy)</span>
+gcloud run deploy <span class="string">my-app</span> \\
+  --source <span class="string">.</span> \\
+  --region <span class="string">us-central1</span> \\
+  --allow-unauthenticated
+
+<span class="comment"># Or deploy from container image</span>
+gcloud run deploy <span class="string">my-app</span> \\
+  --image <span class="string">gcr.io/my-project/my-app:latest</span> \\
+  --region <span class="string">us-central1</span> \\
+  --allow-unauthenticated \\
+  --min-instances <span class="highlight">0</span> \\
+  --max-instances <span class="highlight">10</span>
+  </div>
+
+  <h3>App Runner to Railway</h3>
+  <p class="section-intro">The simplest migration — connect your GitHub repo and deploy:</p>
+
+  <div class="code-block">
+<span class="comment"># Install Railway CLI</span>
+npm install -g @railway/cli
+
+<span class="comment"># Login and initialize</span>
+railway login
+railway init
+
+<span class="comment"># Deploy from current directory</span>
+railway up
+
+<span class="comment"># Or connect GitHub repo for auto-deploy</span>
+<span class="comment"># (done via Railway dashboard — push to main = auto deploy)</span>
+  </div>
+
+  <div class="context-box">
+    <strong>Dockerfile optional:</strong> Railway, Render, and Google Cloud Run all support deploying without a Dockerfile — they auto-detect your language and build accordingly using buildpacks (Nixpacks on Railway, Heroku buildpacks on Render, Google Cloud buildpacks on Cloud Run). This matches App Runner&rsquo;s source code deployment experience.
+  </div>
+
+  <h2 id="faq">Frequently Asked Questions</h2>
+
+  <div class="faq-section">
+    ${faqs.map(f => `<div class="faq-item">
+      <div class="faq-question">${escHtmlServer(f.q)}<span style="color:var(--text-dim)">\u25BC</span></div>
+      <div class="faq-answer">${escHtmlServer(f.a)}</div>
+    </div>`).join("\n    ")}
+  </div>
+
+  ${awsChanges.length > 0 ? `<h2 id="aws-timeline">AWS Change Timeline</h2>
+  <p class="section-intro">Changes tracked in our <a href="/changes">deal changes database</a>:</p>
+
+  <div style="overflow-x:auto">
+  <table class="pricing-table">
+    <thead>
+      <tr>
+        <th>Date</th>
+        <th>Change</th>
+        <th>Impact</th>
+      </tr>
+    </thead>
+    <tbody>
+        ${changeTimelineRows}
+    </tbody>
+  </table>
+  </div>` : `<h2 id="aws-timeline">AWS Change Timeline</h2>
+  <p class="section-intro">Check our <a href="/changes">deal changes database</a> for the latest AWS updates.</p>`}
+
+  <h2 id="recommendations">Recommendations</h2>
+
+  <div class="verdict-box">
+    <h3>Best Alternative for Each Use Case</h3>
+    <div class="verdict-item">
+      <strong>Staying on AWS (recommended for AWS-heavy stacks):</strong>
+      <p>ECS Express Mode — AWS&rsquo;s official replacement. Keeps your ECR images, IAM roles, VPC connections, and CloudWatch monitoring. Requires container images (no source code deploy).</p>
+    </div>
+    <div class="verdict-item">
+      <strong>Best free tier:</strong>
+      <p>Google Cloud Run — 2M requests/month, 360K vCPU-seconds, scale to zero. The most generous free tier for container workloads. Source code deployment supported via buildpacks.</p>
+    </div>
+    <div class="verdict-item">
+      <strong>Closest App Runner experience:</strong>
+      <p>Render — similar DX with GitHub auto-deploy, managed TLS, and simple dashboard. Free tier available (750 hrs/mo, services sleep after inactivity). Paid plans start at $7/mo.</p>
+    </div>
+    <div class="verdict-item">
+      <strong>Best developer experience:</strong>
+      <p>Railway — push to deploy with zero config. $5/mo free trial credit. Auto-detects language and builds without Dockerfiles. Closest to App Runner&rsquo;s simplicity.</p>
+    </div>
+    <div class="verdict-item">
+      <strong>Multi-region deployment:</strong>
+      <p>Fly.io — deploy to multiple regions with a single config. 3 free shared VMs. Scale to zero supported. Ideal for latency-sensitive applications serving global users.</p>
+    </div>
+    <div class="verdict-item">
+      <strong>Full PaaS with CI/CD:</strong>
+      <p>Northflank — built-in CI/CD pipelines, buildpacks, preview environments. Free tier with 2 services. Good for teams that want a complete platform, not just deployment.</p>
+    </div>
+    <div class="verdict-item">
+      <strong>Event-driven scaling:</strong>
+      <p>Azure Container Apps — KEDA-based auto-scaling that responds to events (queues, HTTP, custom metrics). 180K vCPU-seconds/month free. Best for event-driven architectures.</p>
+    </div>
+    <div class="verdict-item">
+      <strong>AWS source code deploy replacement:</strong>
+      <p>Elastic Beanstalk — if you need to stay on AWS with source code deployment, Beanstalk supports source bundles and Dockerfiles. No management fee — pay only for underlying EC2/RDS resources.</p>
+    </div>
+  </div>
+
+  <h2 id="methodology">Methodology</h2>
+
+  <div class="methodology">
+    <p><strong>How we track this data:</strong> AgentDeals monitors free tier changes across ${offers.length.toLocaleString()} developer tools in ${categories.length} categories. The App Runner deprecation is tracked in our <a href="/shutdowns">shutdown tracker</a> and <a href="/stability">stability dashboard</a>.</p>
+    <p><strong>Migration recommendations:</strong> Based on official AWS documentation, provider pricing pages, and community migration reports. Free tier availability confirmed against official documentation as of ${pubDate}. Pricing data verified across all ${providers.length} alternatives.</p>
+    <p>For real-time data, use our <a href="/stability">stability dashboard</a>, <a href="/feed.xml">Atom feed</a>, or <a href="/setup">MCP server</a>. Full dataset available via <a href="/api/offers">REST API</a>.</p>
+  </div>
+
+  <h2>Related Guides</h2>
+  <div class="related-pages">
+    ${relatedPages.map(p => `<a href="/${p.slug}" class="related-page-link">
+      <div class="link-title">${escHtmlServer(p.title.split(" — ")[0])}</div>
+      <div class="link-desc">${escHtmlServer(p.hubDesc)}</div>
+    </a>`).join("\n    ")}
+  </div>
+
+  ${buildMoreAlternativesGuides(slug)}
+
+  ${buildMcpCta("Track cloud service deprecations and compare container deployment free tiers from your AI assistant. Get stability ratings, migration alerts, and pricing comparisons — directly in your editor.")}
+  <footer>AgentDeals &mdash; open source, built for agents | <a href="/privacy">Privacy</a></footer>
+</div>
+<script>${mcpCtaScript()}</script>
+</body>
+</html>`;
 }
 
 // --- AWS Free Tier 2026 guide page ---
@@ -47881,7 +48478,7 @@ ${catList}
     // Most recent verifiedDate across all offers — used for index/hub pages
     const latestVerified = offers.reduce((max, o) => o.verifiedDate > max ? o.verifiedDate : max, offers[0]?.verifiedDate || now);
     // Editorial pages use their deploy date (when content was created/last updated)
-    const editorialDate = "2026-04-08";
+    const editorialDate = "2026-04-10";
     // Comparison pages enrichment deploy date
     const comparisonDate = "2026-04-04";
     const categoryUrls = categories.map((c) => {
@@ -48593,6 +49190,11 @@ ${Array.from(vendorSlugMap.keys()).map(s => {
     logRequest({ ts: new Date().toISOString(), type: "api", endpoint: "/openai-realtime-migration", params: {}, user_agent: req.headers["user-agent"] ?? "unknown", result_count: 1 });
     res.writeHead(200, { "Content-Type": "text/html; charset=utf-8", "Cache-Control": "public, max-age=3600" });
     res.end(buildOpenAIRealtimeMigrationPage());
+  } else if (url.pathname === "/aws-app-runner-migration" && isGetOrHead) {
+    recordApiHit("/aws-app-runner-migration");
+    logRequest({ ts: new Date().toISOString(), type: "api", endpoint: "/aws-app-runner-migration", params: {}, user_agent: req.headers["user-agent"] ?? "unknown", result_count: 1 });
+    res.writeHead(200, { "Content-Type": "text/html; charset=utf-8", "Cache-Control": "public, max-age=3600" });
+    res.end(buildAppRunnerMigrationPage());
   } else if (url.pathname === "/aws-free-tier-2026" && isGetOrHead) {
     recordApiHit("/aws-free-tier-2026");
     logRequest({ ts: new Date().toISOString(), type: "api", endpoint: "/aws-free-tier-2026", params: {}, user_agent: req.headers["user-agent"] ?? "unknown", result_count: 1 });

--- a/test/deal-changes.test.ts
+++ b/test/deal-changes.test.ts
@@ -76,7 +76,7 @@ describe("track_changes tool", () => {
 
     assert.ok(Array.isArray(body.changes));
     assert.strictEqual(body.total, body.changes.length);
-    assert.strictEqual(body.total, 85);
+    assert.strictEqual(body.total, 86);
   });
 
   it("filters by date (since)", async () => {

--- a/test/http.test.ts
+++ b/test/http.test.ts
@@ -5018,6 +5018,39 @@ describe("shutdown tracker page", () => {
     assert.ok(html.includes("/shutdowns"), "Should cross-link to shutdowns tracker");
   });
 
+  it("GET /aws-app-runner-migration renders App Runner migration guide", async () => {
+    proc = await startHttpServer();
+
+    const response = await fetch(`http://localhost:${serverPort}/aws-app-runner-migration`);
+    assert.strictEqual(response.status, 200);
+    assert.ok(response.headers.get("content-type")?.includes("text/html"));
+    const html = await response.text();
+    assert.ok(html.includes("App Runner"), "Should have App Runner in title");
+    assert.ok(html.includes("application/ld+json"), "Should have JSON-LD");
+    assert.ok(html.includes('"Article"'), "Should use Article schema");
+    assert.ok(html.includes('"FAQPage"'), "Should have FAQPage schema");
+    assert.ok(html.includes("canonical"), "Should have canonical link");
+    assert.ok(html.includes("global-nav"), "Should have global nav");
+    assert.ok(html.includes("April 30, 2026"), "Should show deadline date");
+    assert.ok(html.includes("days"), "Should show days remaining");
+    assert.ok(html.includes("ECS Express Mode"), "Should list ECS Express Mode");
+    assert.ok(html.includes("Google Cloud Run"), "Should list Cloud Run");
+    assert.ok(html.includes("Railway"), "Should list Railway");
+    assert.ok(html.includes("Render"), "Should list Render");
+    assert.ok(html.includes("Fly.io"), "Should list Fly.io");
+    assert.ok(html.includes("Azure Container Apps"), "Should list Azure Container Apps");
+    assert.ok(html.includes("DigitalOcean"), "Should list DigitalOcean");
+    assert.ok(html.includes("Source"), "Should discuss source code deployment");
+    assert.ok(html.includes("Custom Domain"), "Should discuss custom domain migration");
+    assert.ok(html.includes("Auto-Scaling"), "Should discuss auto-scaling differences");
+    assert.ok(html.includes("Migration"), "Should have migration section");
+    assert.ok(html.includes("Pricing"), "Should have pricing comparison");
+    assert.ok(html.includes("Recommendations"), "Should have recommendations");
+    assert.ok(html.includes("Methodology"), "Should have methodology section");
+    assert.ok(html.includes("/vendor/"), "Should have vendor detail links");
+    assert.ok(html.includes("/shutdowns"), "Should cross-link to shutdowns tracker");
+  });
+
   it("GET /tenor-alternatives renders Tenor API shutdown guide", async () => {
     proc = await startHttpServer();
 


### PR DESCRIPTION
## Summary

- Comprehensive migration guide at `/aws-app-runner-migration` for AWS App Runner closing to new customers April 30, 2026
- Compares 10 container deployment alternatives with free tier limits, pricing models, and migration effort ratings
- 3 migration paths (Stay on AWS, Multi-cloud PaaS, Developer PaaS), 5 migration considerations, code examples
- 5-question FAQ with JSON-LD structured data (Article + FAQPage + BreadcrumbList)
- Deal change entry added (88 total), shutdowns tracker entry with migration link
- 492 tests passing (1 new)

Refs #711

## Test plan

- [x] `npm run build` passes
- [x] 492 tests pass (1 new for the page)
- [x] E2E verified: page returns 200, correct title, JSON-LD, all 10 alternatives present
- [x] Shutdowns page shows App Runner entry with migration link
- [x] Deal changes count updated in test (85 → 86)