### PR TITLE
Add referral code schema, rendering, and disclosure page

### DIFF
--- a/data/index.json
+++ b/data/index.json
@@ -106,7 +106,20 @@
         "heroku-alternative",
         "vercel-alternative"
       ],
-      "verifiedDate": "2026-04-02"
+      "verifiedDate": "2026-04-02",
+      "referral": {
+        "code": "PLACEHOLDER",
+        "url": "https://railway.app?referralCode=PLACEHOLDER",
+        "referee_value": "$20 in Railway credits",
+        "referrer_value": "15% commission on first 12 months",
+        "type": "dual-sided",
+        "source": "curated",
+        "submitted_by": null,
+        "terms_url": "https://railway.com/affiliate-program",
+        "verified_date": "2026-04-11",
+        "restrictions": [],
+        "phase1_eligible": true
+      }
     },
     {
       "vendor": "Fly.io",

--- a/src/data.ts
+++ b/src/data.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import type { Offer, EnrichedOffer, OfferIndex, DealChange, DealChangesIndex, StabilityClass } from "./types.js";
+import type { Offer, EnrichedOffer, OfferIndex, DealChange, DealChangesIndex, StabilityClass, Referral } from "./types.js";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const INDEX_PATH = path.join(__dirname, "..", "data", "index.json");
@@ -80,9 +80,9 @@ export function getOfferDetails(
     const relatedVendors = sameCategoryOffers.map((o) => o.vendor);
     const result: Offer & { relatedVendors: string[]; alternatives?: Offer[] } = { ...match, relatedVendors };
     if (includeAlternatives) {
-      result.alternatives = sameCategoryOffers;
+      result.alternatives = sameCategoryOffers.map(o => stripReferrerValue(o));
     }
-    return { offer: result };
+    return { offer: stripReferrerValue(result) };
   }
 
   // No exact match — suggest similar vendors
@@ -340,7 +340,8 @@ export function enrichOffers(offers: Offer[]): EnrichedOffer[] {
       (now.getTime() - new Date(offer.verifiedDate).getTime()) / (24 * 60 * 60 * 1000)
     );
 
-    return { ...offer, recent_change, expires_soon, risk_level, stability, days_since_verified };
+    const enriched = { ...offer, recent_change, expires_soon, risk_level, stability, days_since_verified };
+    return stripReferrerValue(enriched);
   });
 }
 
@@ -352,7 +353,8 @@ export function getNewOffers(days: number = 7): { offers: Offer[]; total: number
   const offers = loadOffers();
   const results = offers
     .filter((o) => o.verifiedDate >= cutoff)
-    .sort((a, b) => b.verifiedDate.localeCompare(a.verifiedDate));
+    .sort((a, b) => b.verifiedDate.localeCompare(a.verifiedDate))
+    .map(o => stripReferrerValue(o));
   return { offers: results, total: results.length };
 }
 
@@ -798,8 +800,8 @@ export function compareServices(
 
   return {
     comparison: {
-      vendor_a: { ...matchA.offer, deal_changes: changesA },
-      vendor_b: { ...matchB.offer, deal_changes: changesB },
+      vendor_a: stripReferrerValue({ ...matchA.offer, deal_changes: changesA }),
+      vendor_b: stripReferrerValue({ ...matchB.offer, deal_changes: changesB }),
       shared_categories: sharedCategories,
       category_overlap: categoryOverlap,
     },
@@ -827,7 +829,7 @@ export function getNewestDeals(params: {
 
   results.sort((a, b) => b.verifiedDate.localeCompare(a.verifiedDate));
 
-  const deals = results.slice(0, limit).map((o) => ({
+  const deals = results.slice(0, limit).map((o) => stripReferrerValue({
     ...o,
     days_since_update: Math.floor(
       (now.getTime() - new Date(o.verifiedDate).getTime()) / (24 * 60 * 60 * 1000)
@@ -1015,4 +1017,39 @@ export function getWeeklyDigest(): {
     upcoming_deadlines: deadlines,
     summary,
   };
+}
+
+const VALID_REFERRAL_TYPES = new Set(["dual-sided", "referrer-only", "referee-only"]);
+const VALID_REFERRAL_SOURCES = new Set(["curated", "sovrn", "agent-submitted"]);
+
+export function validateReferral(referral: Referral, vendor: string): string[] {
+  const errors: string[] = [];
+  if (!referral.url || !/^https?:\/\/.+/.test(referral.url)) {
+    errors.push(`${vendor}: referral.url must be a valid URL`);
+  }
+  if (!VALID_REFERRAL_TYPES.has(referral.type)) {
+    errors.push(`${vendor}: referral.type must be one of: dual-sided, referrer-only, referee-only`);
+  }
+  if (!VALID_REFERRAL_SOURCES.has(referral.source)) {
+    errors.push(`${vendor}: referral.source must be one of: curated, sovrn, agent-submitted`);
+  }
+  if ((referral.type === "dual-sided" || referral.type === "referee-only") && !referral.referee_value) {
+    errors.push(`${vendor}: referral.referee_value is required for ${referral.type} type`);
+  }
+  if (!referral.verified_date || !/^\d{4}-\d{2}-\d{2}$/.test(referral.verified_date)) {
+    errors.push(`${vendor}: referral.verified_date must be a valid ISO date (YYYY-MM-DD)`);
+  } else {
+    const verifiedMs = new Date(referral.verified_date).getTime();
+    const ninetyDaysMs = 90 * 24 * 60 * 60 * 1000;
+    if (Date.now() - verifiedMs > ninetyDaysMs) {
+      errors.push(`${vendor}: referral.verified_date is older than 90 days`);
+    }
+  }
+  return errors;
+}
+
+export function stripReferrerValue<T extends { referral?: Referral }>(offer: T): T {
+  if (!offer.referral) return offer;
+  const { referrer_value, ...publicReferral } = offer.referral;
+  return { ...offer, referral: publicReferral as Referral };
 }

--- a/src/serve.ts
+++ b/src/serve.ts
@@ -1686,6 +1686,7 @@ ${globalNavCss()}
       <div class="detail-row"><span class="detail-label">Verified</span><span class="detail-value">${escHtmlServer(a.verifiedDate)}</span></div>
       <div class="detail-row"><span class="detail-label">Changes</span><span class="detail-value">${a.deal_changes.length} recorded</span></div>
       <div class="desc-block">${escHtmlServer(a.description)}</div>
+      ${a.referral ? `<div style="margin-top:.75rem;padding:.5rem .75rem;border:1px solid #3fb95040;border-left:3px solid #3fb950;border-radius:0 6px 6px 0;background:#3fb95010;font-size:.8rem">\ud83d\udd17 <a href="${escHtmlServer(a.referral.url)}" rel="noopener sponsored" target="_blank">Referral link</a>: ${escHtmlServer(a.referral.referee_value)} <a href="/disclosure" style="font-size:.7rem;color:var(--text-dim)">(disclosure)</a></div>` : ""}
     </div>
     <div class="vendor-col">
       <h2><a href="${escHtmlServer(b.url)}">${escHtmlServer(b.vendor)}</a> ${riskBadge(riskB.risk_level)}</h2>
@@ -1694,6 +1695,7 @@ ${globalNavCss()}
       <div class="detail-row"><span class="detail-label">Verified</span><span class="detail-value">${escHtmlServer(b.verifiedDate)}</span></div>
       <div class="detail-row"><span class="detail-label">Changes</span><span class="detail-value">${b.deal_changes.length} recorded</span></div>
       <div class="desc-block">${escHtmlServer(b.description)}</div>
+      ${b.referral ? `<div style="margin-top:.75rem;padding:.5rem .75rem;border:1px solid #3fb95040;border-left:3px solid #3fb950;border-radius:0 6px 6px 0;background:#3fb95010;font-size:.8rem">\ud83d\udd17 <a href="${escHtmlServer(b.referral.url)}" rel="noopener sponsored" target="_blank">Referral link</a>: ${escHtmlServer(b.referral.referee_value)} <a href="/disclosure" style="font-size:.7rem;color:var(--text-dim)">(disclosure)</a></div>` : ""}
     </div>
   </div>
 
@@ -2882,6 +2884,13 @@ ${enrichedAlts.map(a => {
     </div>`;
   })() : "";
 
+  // Referral callout
+  const referralCalloutHtml = primary.referral ? `
+  <div class="referral-callout" style="margin:1rem 0;padding:.75rem 1rem;border:1px solid #3fb95040;border-left:3px solid #3fb950;border-radius:0 8px 8px 0;background:#3fb95010">
+    <span style="font-size:.9rem">\ud83d\udd17 <strong>Sign up bonus:</strong> <a href="${escHtmlServer(primary.referral.url)}" rel="noopener sponsored" target="_blank">Use our referral link</a> to get ${escHtmlServer(primary.referral.referee_value)}</span>
+    <span style="display:block;font-size:.75rem;margin-top:.25rem;color:var(--text-muted)"><a href="/disclosure" style="color:var(--text-muted)">Affiliate disclosure</a></span>
+  </div>` : "";
+
   // Alternatives HTML
   const alternativesHtml = alternatives.length > 0 ? `
   <div class="section">
@@ -3121,6 +3130,7 @@ ${mcpCtaCss()}
 ${quickVerdictHtml}
 ${categoryContextHtml}
 ${changeNoticeHtml}
+${referralCalloutHtml}
 
   <div class="detail-grid">
     <div class="detail-card">
@@ -47149,6 +47159,106 @@ ${bundleHtml}
 
 // --- Privacy policy page ---
 
+function buildDisclosurePage(): string {
+  const title = "Affiliate Disclosure — AgentDeals";
+  const metaDesc = "AgentDeals affiliate disclosure. How we use referral links, what you get, and how our recommendations work.";
+
+  const jsonLd = {
+    "@context": "https://schema.org",
+    "@type": "WebPage",
+    name: title,
+    description: metaDesc,
+    url: `${BASE_URL}/disclosure`,
+    dateModified: new Date().toISOString().slice(0, 10),
+    publisher: { "@type": "Organization", name: "AgentDeals", url: BASE_URL },
+  };
+
+  // Find all offers with referral data
+  const referralOffers = offers.filter(o => o.referral);
+
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>${escHtmlServer(title)}</title>
+<meta name="description" content="${escHtmlServer(metaDesc)}">
+<link rel="canonical" href="${BASE_URL}/disclosure">
+<meta property="og:title" content="${escHtmlServer(title)}">
+<meta property="og:description" content="${escHtmlServer(metaDesc)}">
+<meta property="og:type" content="website">
+<meta property="og:url" content="${BASE_URL}/disclosure">
+${OG_IMAGE_META}${GOOGLE_VERIFICATION_META}<link rel="icon" type="image/png" href="/favicon.png">
+<link rel="alternate" type="application/atom+xml" title="AgentDeals — Pricing Changes" href="/feed.xml">
+<link rel="preconnect" href="https://fonts.googleapis.com"><link rel="preconnect" href="https://fonts.gstatic.com" crossorigin><link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
+<script type="application/ld+json">${JSON.stringify(jsonLd)}</script>
+<style>
+*{margin:0;padding:0;box-sizing:border-box}
+:root{--bg:#0f172a;--bg-elevated:#1e293b;--bg-card:rgba(255,255,255,0.06);--border:#334155;--border-hover:#3b82f6;--text:#f1f5f9;--text-muted:#94a3b8;--text-dim:#64748b;--accent:#3b82f6;--accent-hover:#60a5fa;--accent-glow:rgba(59,130,246,0.15);--serif:'Inter',-apple-system,sans-serif;--sans:'Inter',-apple-system,sans-serif;--mono:'JetBrains Mono',SFMono-Regular,monospace}
+body{font-family:var(--sans);background:var(--bg);color:var(--text);line-height:1.6}
+a{color:var(--accent);text-decoration:none}a:hover{color:var(--accent-hover);text-decoration:underline}
+.container{max-width:720px;margin:0 auto;padding:0 1.5rem}
+.breadcrumb{padding:1.5rem 0 0;font-size:.8rem;color:var(--text-dim)}
+.breadcrumb a{color:var(--text-muted)}
+h1{font-family:var(--serif);font-size:2.25rem;color:var(--text);margin:1rem 0 .5rem;letter-spacing:-.02em}
+h2{font-family:var(--serif);font-size:1.2rem;color:var(--text);margin:2rem 0 .75rem}
+.page-intro{color:var(--text-muted);font-size:.95rem;margin-bottom:2rem;max-width:640px}
+.section{border:1px solid var(--border);border-radius:12px;background:var(--bg-card);padding:1.25rem 1.5rem;margin-bottom:1rem}
+.section p,.section ul{color:var(--text-muted);font-size:.9rem;margin-bottom:.5rem}
+.section ul{margin-left:1.25rem}
+.section li{margin-bottom:.35rem}
+.section p:last-child,.section ul:last-child{margin-bottom:0}
+.updated{color:var(--text-dim);font-size:.8rem;font-style:italic;margin-top:2rem}
+footer{text-align:center;color:var(--text-dim);font-size:.8rem;padding:3rem 0 2rem;border-top:1px solid var(--border);margin-top:3rem}
+footer a{color:var(--text-muted)}
+@media(max-width:768px){h1{font-size:1.5rem}.section{padding:1rem}}
+${globalNavCss()}
+</style>
+</head>
+<body>
+<div class="container">
+  ${buildGlobalNav("home")}
+  <div class="breadcrumb"><a href="/">AgentDeals</a> &rsaquo; Affiliate Disclosure</div>
+  <h1>Affiliate Disclosure</h1>
+  <p class="page-intro">Transparency about how AgentDeals uses referral links and earns revenue.</p>
+
+  <div class="section">
+    <h2>Material Connection Statement</h2>
+    <p>AgentDeals may financially benefit when you use referral links on this site. We only feature referral codes where you, the user, also receive value (sign-up credits, discounts, or extended trials). Our recommendations are based on product quality, not affiliate status.</p>
+  </div>
+
+  <div class="section">
+    <h2>How Referral Links Work</h2>
+    <ul>
+      <li>Some vendor listings include referral links marked with a \ud83d\udd17 icon</li>
+      <li>When you sign up through a referral link, you receive a bonus (credits, discount, or extended trial)</li>
+      <li>AgentDeals may also receive a commission or credit from the vendor</li>
+      <li>Referral links are clearly labeled and always optional &mdash; the regular pricing page link is always available</li>
+    </ul>
+  </div>
+
+  <div class="section">
+    <h2>What Doesn't Change</h2>
+    <ul>
+      <li>Our data is the same whether or not a vendor has a referral program</li>
+      <li>Pricing change tracking, risk assessments, and stability ratings are objective and unaffected</li>
+      <li>Vendors without referral programs are not ranked lower or excluded</li>
+      <li>We track ${offers.length.toLocaleString()} vendor offers &mdash; only ${referralOffers.length} currently have referral links</li>
+    </ul>
+  </div>
+
+  <div class="section">
+    <h2>Current Referral Partners</h2>
+    ${referralOffers.length > 0 ? `<ul>${referralOffers.map(o => `<li><a href="/vendor/${toSlug(o.vendor)}">${escHtmlServer(o.vendor)}</a>: ${escHtmlServer(o.referral!.referee_value)}${o.referral!.terms_url ? ` (<a href="${escHtmlServer(o.referral!.terms_url)}" rel="noopener" target="_blank">program terms</a>)` : ""}</li>`).join("")}</ul>` : `<p>No referral partners at this time.</p>`}
+  </div>
+
+  <p class="updated">Last updated: ${new Date().toISOString().split("T")[0]}</p>
+  <footer>AgentDeals &mdash; open source, built for agents | <a href="/privacy">Privacy</a></footer>
+</div>
+</body>
+</html>`;
+}
+
 function buildPrivacyPage(): string {
   const title = "Privacy Policy — AgentDeals";
   const metaDesc = "AgentDeals privacy policy. We are a read-only data server — no accounts, no cookies, no personal data collected.";
@@ -49353,6 +49463,12 @@ ${catList}
     <priority>0.3</priority>
   </url>
   <url>
+    <loc>${BASE_URL}/disclosure</loc>
+    <lastmod>${editorialDate}</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.4</priority>
+  </url>
+  <url>
     <loc>${BASE_URL}/expiring</loc>
     <lastmod>${latestVerified}</lastmod>
     <changefreq>daily</changefreq>
@@ -49701,6 +49817,11 @@ ${Array.from(vendorSlugMap.keys()).map(s => {
     logRequest({ ts: new Date().toISOString(), type: "api", endpoint: "/setup", params: {}, user_agent: req.headers["user-agent"] ?? "unknown", result_count: 1 });
     res.writeHead(200, { "Content-Type": "text/html; charset=utf-8", "Cache-Control": "public, max-age=3600" });
     res.end(buildSetupPage());
+  } else if (url.pathname === "/disclosure" && isGetOrHead) {
+    recordApiHit("/disclosure");
+    logRequest({ ts: new Date().toISOString(), type: "api", endpoint: "/disclosure", params: {}, user_agent: req.headers["user-agent"] ?? "unknown", result_count: 1 });
+    res.writeHead(200, { "Content-Type": "text/html; charset=utf-8", "Cache-Control": "public, max-age=3600" });
+    res.end(buildDisclosurePage());
   } else if (url.pathname === "/privacy" && isGetOrHead) {
     recordApiHit("/privacy");
     logRequest({ ts: new Date().toISOString(), type: "api", endpoint: "/privacy", params: {}, user_agent: req.headers["user-agent"] ?? "unknown", result_count: 1 });

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,6 +4,20 @@ export interface Eligibility {
   program?: string;
 }
 
+export interface Referral {
+  code?: string;
+  url: string;
+  referee_value: string;
+  referrer_value?: string;
+  type: "dual-sided" | "referrer-only" | "referee-only";
+  source: "curated" | "sovrn" | "agent-submitted";
+  submitted_by?: string | null;
+  terms_url?: string;
+  verified_date: string;
+  restrictions?: string[];
+  phase1_eligible: boolean;
+}
+
 export interface Offer {
   vendor: string;
   category: string;
@@ -15,6 +29,7 @@ export interface Offer {
   eligibility?: Eligibility;
   expires_date?: string;
   payment_protocols?: string[];
+  referral?: Referral;
 }
 
 export type StabilityClass = "stable" | "watch" | "volatile" | "improving";

--- a/test/referral.test.ts
+++ b/test/referral.test.ts
@@ -1,0 +1,224 @@
+import { describe, it, before, after } from "node:test";
+import assert from "node:assert";
+import { spawn, type ChildProcess } from "node:child_process";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+// Unit tests for validateReferral and stripReferrerValue
+const { validateReferral, stripReferrerValue } = await import("../dist/data.js");
+
+function makeReferral(overrides: Record<string, unknown> = {}) {
+  return {
+    code: "TEST",
+    url: "https://example.com?ref=TEST",
+    referee_value: "$20 in credits",
+    referrer_value: "15% commission",
+    type: "dual-sided" as const,
+    source: "curated" as const,
+    submitted_by: null,
+    terms_url: "https://example.com/terms",
+    verified_date: new Date().toISOString().slice(0, 10),
+    restrictions: [],
+    phase1_eligible: true,
+    ...overrides,
+  };
+}
+
+describe("validateReferral", () => {
+  it("valid referral passes with no errors", () => {
+    const errors = validateReferral(makeReferral(), "TestVendor");
+    assert.strictEqual(errors.length, 0);
+  });
+
+  it("rejects invalid URL", () => {
+    const errors = validateReferral(makeReferral({ url: "not-a-url" }), "TestVendor");
+    assert.ok(errors.some(e => e.includes("valid URL")));
+  });
+
+  it("rejects empty URL", () => {
+    const errors = validateReferral(makeReferral({ url: "" }), "TestVendor");
+    assert.ok(errors.some(e => e.includes("valid URL")));
+  });
+
+  it("rejects invalid type", () => {
+    const errors = validateReferral(makeReferral({ type: "invalid" }), "TestVendor");
+    assert.ok(errors.some(e => e.includes("type must be one of")));
+  });
+
+  it("rejects invalid source", () => {
+    const errors = validateReferral(makeReferral({ source: "unknown" }), "TestVendor");
+    assert.ok(errors.some(e => e.includes("source must be one of")));
+  });
+
+  it("requires referee_value for dual-sided type", () => {
+    const errors = validateReferral(makeReferral({ type: "dual-sided", referee_value: "" }), "TestVendor");
+    assert.ok(errors.some(e => e.includes("referee_value is required")));
+  });
+
+  it("requires referee_value for referee-only type", () => {
+    const errors = validateReferral(makeReferral({ type: "referee-only", referee_value: "" }), "TestVendor");
+    assert.ok(errors.some(e => e.includes("referee_value is required")));
+  });
+
+  it("does not require referee_value for referrer-only type", () => {
+    const errors = validateReferral(makeReferral({ type: "referrer-only", referee_value: "" }), "TestVendor");
+    assert.ok(!errors.some(e => e.includes("referee_value is required")));
+  });
+
+  it("rejects invalid verified_date format", () => {
+    const errors = validateReferral(makeReferral({ verified_date: "Jan 1 2026" }), "TestVendor");
+    assert.ok(errors.some(e => e.includes("valid ISO date")));
+  });
+
+  it("rejects verified_date older than 90 days", () => {
+    const oldDate = new Date(Date.now() - 91 * 24 * 60 * 60 * 1000).toISOString().slice(0, 10);
+    const errors = validateReferral(makeReferral({ verified_date: oldDate }), "TestVendor");
+    assert.ok(errors.some(e => e.includes("older than 90 days")));
+  });
+
+  it("accepts verified_date within 90 days", () => {
+    const recentDate = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000).toISOString().slice(0, 10);
+    const errors = validateReferral(makeReferral({ verified_date: recentDate }), "TestVendor");
+    assert.strictEqual(errors.length, 0);
+  });
+
+  it("accepts all valid source types", () => {
+    for (const source of ["curated", "sovrn", "agent-submitted"]) {
+      const errors = validateReferral(makeReferral({ source }), "TestVendor");
+      assert.strictEqual(errors.length, 0, `source "${source}" should be valid`);
+    }
+  });
+});
+
+describe("stripReferrerValue", () => {
+  it("removes referrer_value from offer with referral", () => {
+    const offer = {
+      vendor: "Test",
+      category: "Cloud",
+      referral: makeReferral(),
+    };
+    const stripped = stripReferrerValue(offer);
+    assert.ok(!("referrer_value" in stripped.referral!));
+    assert.strictEqual(stripped.referral!.referee_value, "$20 in credits");
+    assert.strictEqual(stripped.referral!.url, "https://example.com?ref=TEST");
+  });
+
+  it("returns offer unchanged when no referral", () => {
+    const offer = { vendor: "Test", category: "Cloud" };
+    const stripped = stripReferrerValue(offer);
+    assert.deepStrictEqual(stripped, offer);
+  });
+
+  it("preserves all other referral fields", () => {
+    const referral = makeReferral();
+    const offer = { vendor: "Test", referral };
+    const stripped = stripReferrerValue(offer);
+    assert.strictEqual(stripped.referral!.code, "TEST");
+    assert.strictEqual(stripped.referral!.type, "dual-sided");
+    assert.strictEqual(stripped.referral!.source, "curated");
+    assert.strictEqual(stripped.referral!.phase1_eligible, true);
+    assert.strictEqual(stripped.referral!.terms_url, "https://example.com/terms");
+  });
+});
+
+// HTTP server tests for referral endpoints
+let serverPort = 0;
+let serverProc: ChildProcess | null = null;
+
+function startServer(): Promise<ChildProcess> {
+  return new Promise((resolve, reject) => {
+    const serverPath = path.join(__dirname, "..", "dist", "serve.js");
+    const proc = spawn("node", [serverPath], {
+      stdio: ["pipe", "pipe", "pipe"],
+      env: { ...process.env, PORT: "0", BASE_URL: "http://localhost" },
+    });
+
+    const timeout = setTimeout(() => {
+      proc.kill();
+      reject(new Error("Server startup timeout"));
+    }, 5000);
+
+    proc.stderr!.on("data", (data: Buffer) => {
+      const match = data.toString().match(/running on http:\/\/localhost:(\d+)/);
+      if (match) {
+        serverPort = parseInt(match[1], 10);
+        clearTimeout(timeout);
+        resolve(proc);
+      }
+    });
+
+    proc.on("error", (err) => {
+      clearTimeout(timeout);
+      reject(err);
+    });
+  });
+}
+
+describe("referral HTTP endpoints", () => {
+  before(async () => {
+    serverProc = await startServer();
+  });
+
+  after(() => {
+    serverProc?.kill();
+  });
+
+  it("GET /disclosure returns 200 with disclosure content", async () => {
+    const res = await fetch(`http://localhost:${serverPort}/disclosure`);
+    assert.strictEqual(res.status, 200);
+    const html = await res.text();
+    assert.ok(html.includes("Affiliate Disclosure"));
+    assert.ok(html.includes("Material Connection Statement"));
+    assert.ok(html.includes("AgentDeals may financially benefit"));
+  });
+
+  it("/disclosure page lists current referral partners", async () => {
+    const res = await fetch(`http://localhost:${serverPort}/disclosure`);
+    const html = await res.text();
+    assert.ok(html.includes("Current Referral Partners"));
+    assert.ok(html.includes("Railway"));
+  });
+
+  it("GET /api/offers includes referral data for Railway", async () => {
+    const res = await fetch(`http://localhost:${serverPort}/api/offers?q=Railway&limit=5`);
+    assert.strictEqual(res.status, 200);
+    const data = await res.json();
+    const railway = data.offers.find((o: any) => o.vendor === "Railway");
+    assert.ok(railway, "Railway should be in results");
+    assert.ok(railway.referral, "Railway should have referral data");
+    assert.ok(railway.referral.url, "referral should have url");
+    assert.ok(railway.referral.referee_value, "referral should have referee_value");
+    assert.ok(!("referrer_value" in railway.referral), "referrer_value should be stripped from API");
+  });
+
+  it("GET /api/offers omits referral for vendors without it", async () => {
+    const res = await fetch(`http://localhost:${serverPort}/api/offers?q=Vercel&limit=5`);
+    const data = await res.json();
+    const vercel = data.offers.find((o: any) => o.vendor === "Vercel");
+    assert.ok(vercel, "Vercel should be in results");
+    assert.ok(!vercel.referral, "Vercel should not have referral data");
+  });
+
+  it("GET /vendor/railway shows referral callout", async () => {
+    const res = await fetch(`http://localhost:${serverPort}/vendor/railway`);
+    assert.strictEqual(res.status, 200);
+    const html = await res.text();
+    assert.ok(html.includes("referral-callout") || html.includes("Sign up bonus"), "Vendor page should show referral callout");
+    assert.ok(html.includes("/disclosure"), "Should link to disclosure page");
+  });
+
+  it("GET /vendor/vercel does not show referral callout", async () => {
+    const res = await fetch(`http://localhost:${serverPort}/vendor/vercel`);
+    assert.strictEqual(res.status, 200);
+    const html = await res.text();
+    assert.ok(!html.includes("referral-callout"), "Vendor page without referral should not show callout");
+  });
+
+  it("GET /sitemap.xml includes /disclosure", async () => {
+    const res = await fetch(`http://localhost:${serverPort}/sitemap.xml`);
+    const xml = await res.text();
+    assert.ok(xml.includes("/disclosure"), "Sitemap should include disclosure page");
+  });
+});


### PR DESCRIPTION
## Summary

Phase 1 referral platform: adds optional `referral` object to offer entries, surfaces referral links on vendor/comparison pages, strips internal `referrer_value` from all public outputs, and creates a `/disclosure` page.

- **Schema:** `Referral` interface with code, url, referee_value, type, source, verified_date, restrictions, phase1_eligible
- **Data:** Railway seeded with placeholder referral data
- **Validation:** URL format, type/source enums, referee_value required for dual-sided/referee-only, verified_date within 90 days
- **Privacy:** `referrer_value` stripped from enrichOffers, getOfferDetails, compareServices, getNewOffers, getNewestDeals — never exposed via MCP, REST API, or content pages
- **UI:** Referral callout with disclosure link on vendor pages and comparison pages
- **Disclosure page:** `/disclosure` with material connection statement, how referral links work, current partners list
- **Tests:** 22 new tests covering validation, stripping, HTTP endpoints, content rendering. 518 total passing.

Refs #723

## Test plan

- [x] `validateReferral` unit tests (12 cases: valid, invalid URL, invalid type/source, date freshness)
- [x] `stripReferrerValue` unit tests (3 cases: with referral, without, field preservation)
- [x] HTTP endpoint tests: /disclosure page, /api/offers referral data, vendor page callout, sitemap
- [x] 518 tests passing, 0 failures
- [x] E2E verification: server started, disclosure page renders, Railway vendor page shows callout, Vercel page does not, API returns referral without referrer_value