### PR TITLE
Referral attribution: track which agent surfaced a referral code

### DIFF
--- a/data/referral_requests.json
+++ b/data/referral_requests.json
@@ -1,0 +1,1 @@
+{"referral_requests":[]}

--- a/src/data.ts
+++ b/src/data.ts
@@ -1053,3 +1053,16 @@ export function stripReferrerValue<T extends { referral?: Referral }>(offer: T):
   const { referrer_value, ...publicReferral } = offer.referral;
   return { ...offer, referral: publicReferral as Referral };
 }
+
+/**
+ * Get the referral data for a specific vendor (with referrer_value stripped).
+ * Returns null if the vendor has no referral or vendor not found.
+ */
+export function getVendorReferral(vendorName: string): { vendor: string; referral: Omit<Referral, "referrer_value"> } | null {
+  const offers = loadOffers();
+  const lowerName = vendorName.toLowerCase();
+  const match = offers.find(o => o.vendor.toLowerCase() === lowerName);
+  if (!match || !match.referral) return null;
+  const { referrer_value, ...publicReferral } = match.referral;
+  return { vendor: match.vendor, referral: publicReferral };
+}

--- a/src/referral-requests.ts
+++ b/src/referral-requests.ts
@@ -1,0 +1,128 @@
+import fs from "node:fs";
+import path from "node:path";
+import { randomBytes } from "node:crypto";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REQUESTS_PATH = path.join(__dirname, "..", "data", "referral_requests.json");
+
+export interface ReferralRequest {
+  id: string;
+  agent_id: string;
+  vendor: string;
+  referral_code: string;
+  referral_url: string;
+  requested_at: string;
+  conversion_id: string | null;
+}
+
+let cachedRequests: ReferralRequest[] | null = null;
+
+function loadRequests(): ReferralRequest[] {
+  if (cachedRequests) return cachedRequests;
+
+  if (!fs.existsSync(REQUESTS_PATH)) {
+    cachedRequests = [];
+    return cachedRequests;
+  }
+
+  try {
+    const raw = fs.readFileSync(REQUESTS_PATH, "utf-8");
+    const data = JSON.parse(raw) as { referral_requests?: ReferralRequest[] };
+    cachedRequests = Array.isArray(data.referral_requests) ? data.referral_requests : [];
+  } catch {
+    cachedRequests = [];
+  }
+  return cachedRequests;
+}
+
+function saveRequests(requests: ReferralRequest[]): void {
+  fs.writeFileSync(REQUESTS_PATH, JSON.stringify({ referral_requests: requests }, null, 2), "utf-8");
+  cachedRequests = requests;
+}
+
+export function resetReferralRequestsCache(): void {
+  cachedRequests = null;
+}
+
+function generateRequestId(): string {
+  return `rr_${randomBytes(16).toString("hex")}`;
+}
+
+/**
+ * Log a referral request from an authenticated agent.
+ */
+export function logReferralRequest(opts: {
+  agent_id: string;
+  vendor: string;
+  referral_code: string;
+  referral_url: string;
+}): ReferralRequest {
+  const requests = loadRequests();
+  const request: ReferralRequest = {
+    id: generateRequestId(),
+    agent_id: opts.agent_id,
+    vendor: opts.vendor,
+    referral_code: opts.referral_code,
+    referral_url: opts.referral_url,
+    requested_at: new Date().toISOString(),
+    conversion_id: null,
+  };
+  requests.push(request);
+  saveRequests(requests);
+  return request;
+}
+
+/**
+ * Last-touch attribution: find the most recent agent that requested a referral
+ * code for the given vendor within the lookback window.
+ * Returns the agent_id or null if no match.
+ */
+export function attributeConversion(
+  vendor: string,
+  conversionDate: Date,
+  lookbackDays: number = 90
+): string | null {
+  const requests = loadRequests();
+  const cutoff = new Date(conversionDate.getTime() - lookbackDays * 24 * 60 * 60 * 1000);
+  const vendorLower = vendor.toLowerCase();
+
+  // Filter to matching vendor within lookback window
+  const eligible = requests.filter(r => {
+    if (r.vendor.toLowerCase() !== vendorLower) return false;
+    const requestedAt = new Date(r.requested_at);
+    return requestedAt >= cutoff && requestedAt <= conversionDate;
+  });
+
+  if (eligible.length === 0) return null;
+
+  // Last-touch: most recent request wins
+  eligible.sort((a, b) => new Date(b.requested_at).getTime() - new Date(a.requested_at).getTime());
+  return eligible[0].agent_id;
+}
+
+/**
+ * Get all referral requests for a specific agent.
+ */
+export function getRequestsByAgent(agentId: string): ReferralRequest[] {
+  return loadRequests().filter(r => r.agent_id === agentId);
+}
+
+/**
+ * Get a referral request by ID.
+ */
+export function getRequestById(id: string): ReferralRequest | null {
+  return loadRequests().find(r => r.id === id) ?? null;
+}
+
+/**
+ * Mark a referral request as converted by setting the conversion_id.
+ */
+export function markConversion(requestId: string, conversionId: string): boolean {
+  const requests = loadRequests();
+  const request = requests.find(r => r.id === requestId);
+  if (!request) return false;
+  request.conversion_id = conversionId;
+  saveRequests(requests);
+  return true;
+}

--- a/src/serve.ts
+++ b/src/serve.ts
@@ -5,12 +5,13 @@ import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
 import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
 import { createServer, getServerCard } from "./server.js";
-import { loadOffers, getCategories, getNewOffers, getNewestDeals, searchOffers, enrichOffers, loadDealChanges, getDealChanges, getPersonalizedChanges, getOfferDetails, compareServices, checkVendorRisk, auditStack, getExpiringDeals, getWeeklyDigest, getFreshnessMetrics, getStabilityMap } from "./data.js";
+import { loadOffers, getCategories, getNewOffers, getNewestDeals, searchOffers, enrichOffers, loadDealChanges, getDealChanges, getPersonalizedChanges, getOfferDetails, compareServices, checkVendorRisk, auditStack, getExpiringDeals, getWeeklyDigest, getFreshnessMetrics, getStabilityMap, getVendorReferral } from "./data.js";
 import { getStackRecommendation } from "./stacks.js";
 import { estimateCosts } from "./costs.js";
 import { recordApiHit, recordSessionConnect, recordSessionDisconnect, recordLandingPageView, getStats, getConnectionStats, loadTelemetry, flushTelemetry, logRequest, getRequestLog, recordPageView, getPageViews } from "./stats.js";
 import { openapiSpec } from "./openapi.js";
 import { registerAgent, authenticateRequest, validateVestauthUrl, hashApiKey } from "./agents.js";
+import { logReferralRequest } from "./referral-requests.js";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -50491,6 +50492,46 @@ ${Array.from(vendorSlugMap.keys()).map(s => {
       registered_at: agent.registered_at,
       vestauth_public_key_url: agent.vestauth_public_key_url,
       x402_address: agent.x402_address,
+    }));
+
+  // --- Referral Attribution API ---
+
+  } else if (url.pathname.startsWith("/api/referral/") && isGetOrHead) {
+    const vendor = decodeURIComponent(url.pathname.slice("/api/referral/".length));
+    if (!vendor) {
+      res.writeHead(400, { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" });
+      res.end(JSON.stringify({ error: "Vendor name is required: GET /api/referral/:vendor" }));
+      return;
+    }
+
+    const referralData = getVendorReferral(vendor);
+    if (!referralData) {
+      res.writeHead(404, { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" });
+      res.end(JSON.stringify({ error: `No referral found for vendor "${vendor}"` }));
+      return;
+    }
+
+    // If authenticated, log the attribution request
+    const agent = await authenticateRequest(req as any);
+    if (agent) {
+      logReferralRequest({
+        agent_id: agent.id,
+        vendor: referralData.vendor,
+        referral_code: referralData.referral.code ?? "",
+        referral_url: referralData.referral.url,
+      });
+    }
+
+    recordApiHit("/api/referral/:vendor");
+    logRequest({ ts: new Date().toISOString(), type: "api", endpoint: `/api/referral/${vendor}`, params: { authenticated: !!agent }, user_agent: req.headers["user-agent"] ?? "unknown", result_count: 1 });
+    res.writeHead(200, { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" });
+    res.end(JSON.stringify({
+      vendor: referralData.vendor,
+      referral_code: referralData.referral.code ?? null,
+      referral_url: referralData.referral.url,
+      referee_value: referralData.referral.referee_value,
+      type: referralData.referral.type,
+      attributed: !!agent,
     }));
 
   } else {

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,8 +1,9 @@
 import { McpServer, ResourceTemplate } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
-import { getCategories, getDealChanges, getPersonalizedChanges, getNewOffers, getNewestDeals, getOfferDetails, searchOffers, enrichOffers, compareServices, checkVendorRisk, auditStack, getExpiringDeals, getWeeklyDigest, loadOffers, loadDealChanges, classifyStability, getStabilityMap } from "./data.js";
+import { getCategories, getDealChanges, getPersonalizedChanges, getNewOffers, getNewestDeals, getOfferDetails, searchOffers, enrichOffers, compareServices, checkVendorRisk, auditStack, getExpiringDeals, getWeeklyDigest, loadOffers, loadDealChanges, classifyStability, getStabilityMap, getVendorReferral } from "./data.js";
 import { recordToolCall, logRequest } from "./stats.js";
-import { registerAgent, validateVestauthUrl } from "./agents.js";
+import { registerAgent, validateVestauthUrl, getAgentByApiKeyHash, hashApiKey } from "./agents.js";
+import { logReferralRequest } from "./referral-requests.js";
 import { getStackRecommendation } from "./stacks.js";
 import { estimateCosts } from "./costs.js";
 import { getGuideList, getGuideBySlug } from "./guides.js";
@@ -932,6 +933,73 @@ Suggested monitoring cadence: run this check weekly to catch pricing changes ear
         }
 
         logRequest({ ts: new Date().toISOString(), type: "mcp", endpoint: "register_agent", params: { name }, result_count: 1, session_id: getSessionId?.() });
+
+        return {
+          content: [{ type: "text" as const, text: JSON.stringify(response, null, 2) }],
+        };
+      } catch (err: any) {
+        return {
+          isError: true,
+          content: [{ type: "text" as const, text: err.message }],
+        };
+      }
+    }
+  );
+
+  // --- Tool 6: get_referral_code ---
+
+  server.registerTool(
+    "get_referral_code",
+    {
+      description:
+        "Get the referral code and URL for a specific vendor. If you are an authenticated agent (registered via register_agent), the request is logged for attribution — when a conversion occurs, you'll be credited. Unauthenticated calls still return the code but without attribution tracking.",
+      annotations: {
+        readOnlyHint: true,
+        destructiveHint: false,
+      },
+      inputSchema: {
+        vendor: z.string().describe("Vendor name to get the referral code for (e.g. 'Railway')"),
+        api_key: z.string().optional().describe("Your API key from register_agent, for attribution tracking. Optional — unauthenticated calls still return the code."),
+      },
+    },
+    async ({ vendor, api_key }) => {
+      try {
+        recordToolCall("get_referral_code");
+
+        const referralData = getVendorReferral(vendor);
+        if (!referralData) {
+          return {
+            isError: true,
+            content: [{ type: "text" as const, text: `No referral found for vendor "${vendor}"` }],
+          };
+        }
+
+        // If API key provided, authenticate and log attribution
+        let attributed = false;
+        if (api_key) {
+          const hash = hashApiKey(api_key);
+          const agent = getAgentByApiKeyHash(hash);
+          if (agent) {
+            logReferralRequest({
+              agent_id: agent.id,
+              vendor: referralData.vendor,
+              referral_code: referralData.referral.code ?? "",
+              referral_url: referralData.referral.url,
+            });
+            attributed = true;
+          }
+        }
+
+        const response = {
+          vendor: referralData.vendor,
+          referral_code: referralData.referral.code ?? null,
+          referral_url: referralData.referral.url,
+          referee_value: referralData.referral.referee_value,
+          type: referralData.referral.type,
+          attributed,
+        };
+
+        logRequest({ ts: new Date().toISOString(), type: "mcp", endpoint: "get_referral_code", params: { vendor, attributed }, result_count: 1, session_id: getSessionId?.() });
 
         return {
           content: [{ type: "text" as const, text: JSON.stringify(response, null, 2) }],

--- a/test/referral-attribution.test.ts
+++ b/test/referral-attribution.test.ts
@@ -1,0 +1,314 @@
+import { describe, it, before, after, beforeEach } from "node:test";
+import assert from "node:assert";
+import { spawn, type ChildProcess } from "node:child_process";
+import path from "node:path";
+import fs from "node:fs";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REQUESTS_PATH = path.join(__dirname, "..", "data", "referral_requests.json");
+const AGENTS_PATH = path.join(__dirname, "..", "data", "agents.json");
+
+// Unit tests for referral-requests module
+const { logReferralRequest, attributeConversion, getRequestsByAgent, getRequestById, markConversion, resetReferralRequestsCache } = await import("../dist/referral-requests.js");
+const { registerAgent, resetAgentsCache } = await import("../dist/agents.js");
+
+function resetRequestsFile() {
+  fs.writeFileSync(REQUESTS_PATH, JSON.stringify({ referral_requests: [] }), "utf-8");
+  resetReferralRequestsCache();
+}
+
+function resetAgentsFile() {
+  fs.writeFileSync(AGENTS_PATH, JSON.stringify({ agents: [] }), "utf-8");
+  resetAgentsCache();
+}
+
+describe("Referral Request Logging", () => {
+  beforeEach(() => {
+    resetRequestsFile();
+  });
+
+  after(() => {
+    resetRequestsFile();
+  });
+
+  it("logs a referral request with all fields", () => {
+    const req = logReferralRequest({
+      agent_id: "agent_abc123",
+      vendor: "Railway",
+      referral_code: "PLACEHOLDER",
+      referral_url: "https://railway.app?referralCode=PLACEHOLDER",
+    });
+    assert.ok(req.id.startsWith("rr_"));
+    assert.strictEqual(req.agent_id, "agent_abc123");
+    assert.strictEqual(req.vendor, "Railway");
+    assert.strictEqual(req.referral_code, "PLACEHOLDER");
+    assert.strictEqual(req.referral_url, "https://railway.app?referralCode=PLACEHOLDER");
+    assert.ok(req.requested_at);
+    assert.strictEqual(req.conversion_id, null);
+  });
+
+  it("persists requests to disk", () => {
+    logReferralRequest({
+      agent_id: "agent_abc123",
+      vendor: "Railway",
+      referral_code: "PLACEHOLDER",
+      referral_url: "https://railway.app?referralCode=PLACEHOLDER",
+    });
+    resetReferralRequestsCache();
+    const raw = JSON.parse(fs.readFileSync(REQUESTS_PATH, "utf-8"));
+    assert.strictEqual(raw.referral_requests.length, 1);
+    assert.strictEqual(raw.referral_requests[0].vendor, "Railway");
+  });
+
+  it("generates unique request IDs", () => {
+    const r1 = logReferralRequest({ agent_id: "a1", vendor: "V1", referral_code: "C1", referral_url: "http://u1" });
+    const r2 = logReferralRequest({ agent_id: "a2", vendor: "V2", referral_code: "C2", referral_url: "http://u2" });
+    assert.notStrictEqual(r1.id, r2.id);
+  });
+});
+
+describe("Attribution Logic", () => {
+  beforeEach(() => {
+    resetRequestsFile();
+  });
+
+  after(() => {
+    resetRequestsFile();
+  });
+
+  it("attributes to the single matching agent", () => {
+    const now = new Date();
+    // Log a request 1 day ago
+    const req = logReferralRequest({ agent_id: "agent_1", vendor: "Railway", referral_code: "C1", referral_url: "http://u1" });
+    // Override timestamp to 1 day ago
+    const data = JSON.parse(fs.readFileSync(REQUESTS_PATH, "utf-8"));
+    data.referral_requests[0].requested_at = new Date(now.getTime() - 24 * 60 * 60 * 1000).toISOString();
+    fs.writeFileSync(REQUESTS_PATH, JSON.stringify(data), "utf-8");
+    resetReferralRequestsCache();
+
+    const result = attributeConversion("Railway", now);
+    assert.strictEqual(result, "agent_1");
+  });
+
+  it("last-touch wins: attributes to the most recent requester", () => {
+    const now = new Date();
+    const data = { referral_requests: [
+      { id: "rr_old", agent_id: "agent_first", vendor: "Railway", referral_code: "C1", referral_url: "http://u1", requested_at: new Date(now.getTime() - 48 * 60 * 60 * 1000).toISOString(), conversion_id: null },
+      { id: "rr_new", agent_id: "agent_second", vendor: "Railway", referral_code: "C1", referral_url: "http://u1", requested_at: new Date(now.getTime() - 12 * 60 * 60 * 1000).toISOString(), conversion_id: null },
+    ]};
+    fs.writeFileSync(REQUESTS_PATH, JSON.stringify(data), "utf-8");
+    resetReferralRequestsCache();
+
+    const result = attributeConversion("Railway", now);
+    assert.strictEqual(result, "agent_second");
+  });
+
+  it("returns null when no requests exist for the vendor", () => {
+    const result = attributeConversion("NonExistent", new Date());
+    assert.strictEqual(result, null);
+  });
+
+  it("returns null when requests are outside the lookback window", () => {
+    const now = new Date();
+    const data = { referral_requests: [
+      { id: "rr_1", agent_id: "agent_old", vendor: "Railway", referral_code: "C1", referral_url: "http://u1", requested_at: new Date(now.getTime() - 100 * 24 * 60 * 60 * 1000).toISOString(), conversion_id: null },
+    ]};
+    fs.writeFileSync(REQUESTS_PATH, JSON.stringify(data), "utf-8");
+    resetReferralRequestsCache();
+
+    const result = attributeConversion("Railway", now, 90);
+    assert.strictEqual(result, null);
+  });
+
+  it("respects custom lookback window", () => {
+    const now = new Date();
+    const data = { referral_requests: [
+      { id: "rr_1", agent_id: "agent_1", vendor: "Railway", referral_code: "C1", referral_url: "http://u1", requested_at: new Date(now.getTime() - 5 * 24 * 60 * 60 * 1000).toISOString(), conversion_id: null },
+    ]};
+    fs.writeFileSync(REQUESTS_PATH, JSON.stringify(data), "utf-8");
+    resetReferralRequestsCache();
+
+    // Within 7-day window
+    assert.strictEqual(attributeConversion("Railway", now, 7), "agent_1");
+    // Outside 3-day window
+    assert.strictEqual(attributeConversion("Railway", now, 3), null);
+  });
+
+  it("vendor matching is case-insensitive", () => {
+    const now = new Date();
+    logReferralRequest({ agent_id: "agent_1", vendor: "Railway", referral_code: "C1", referral_url: "http://u1" });
+    const result = attributeConversion("railway", now);
+    assert.strictEqual(result, "agent_1");
+  });
+
+  it("does not attribute requests after the conversion date", () => {
+    const now = new Date();
+    const conversionDate = new Date(now.getTime() - 24 * 60 * 60 * 1000);
+    // Request is after conversion date
+    const data = { referral_requests: [
+      { id: "rr_1", agent_id: "agent_future", vendor: "Railway", referral_code: "C1", referral_url: "http://u1", requested_at: now.toISOString(), conversion_id: null },
+    ]};
+    fs.writeFileSync(REQUESTS_PATH, JSON.stringify(data), "utf-8");
+    resetReferralRequestsCache();
+
+    const result = attributeConversion("Railway", conversionDate);
+    assert.strictEqual(result, null);
+  });
+});
+
+describe("Request Lookups", () => {
+  beforeEach(() => {
+    resetRequestsFile();
+  });
+
+  after(() => {
+    resetRequestsFile();
+  });
+
+  it("gets requests by agent ID", () => {
+    logReferralRequest({ agent_id: "agent_a", vendor: "V1", referral_code: "C1", referral_url: "http://u1" });
+    logReferralRequest({ agent_id: "agent_b", vendor: "V2", referral_code: "C2", referral_url: "http://u2" });
+    logReferralRequest({ agent_id: "agent_a", vendor: "V3", referral_code: "C3", referral_url: "http://u3" });
+
+    const agentARequests = getRequestsByAgent("agent_a");
+    assert.strictEqual(agentARequests.length, 2);
+    assert.ok(agentARequests.every((r: any) => r.agent_id === "agent_a"));
+  });
+
+  it("gets request by ID", () => {
+    const req = logReferralRequest({ agent_id: "agent_a", vendor: "V1", referral_code: "C1", referral_url: "http://u1" });
+    const found = getRequestById(req.id);
+    assert.ok(found);
+    assert.strictEqual(found.vendor, "V1");
+  });
+
+  it("returns null for nonexistent request ID", () => {
+    const found = getRequestById("rr_nonexistent");
+    assert.strictEqual(found, null);
+  });
+});
+
+describe("Conversion Marking", () => {
+  beforeEach(() => {
+    resetRequestsFile();
+  });
+
+  after(() => {
+    resetRequestsFile();
+  });
+
+  it("marks a request as converted", () => {
+    const req = logReferralRequest({ agent_id: "agent_a", vendor: "V1", referral_code: "C1", referral_url: "http://u1" });
+    const result = markConversion(req.id, "conv_123");
+    assert.strictEqual(result, true);
+
+    resetReferralRequestsCache();
+    const updated = getRequestById(req.id);
+    assert.strictEqual(updated!.conversion_id, "conv_123");
+  });
+
+  it("returns false for nonexistent request", () => {
+    const result = markConversion("rr_nonexistent", "conv_123");
+    assert.strictEqual(result, false);
+  });
+});
+
+// --- HTTP endpoint tests ---
+
+let serverPort = 0;
+
+function startHttpServer(): Promise<ChildProcess> {
+  return new Promise((resolve, reject) => {
+    const serverPath = path.join(__dirname, "..", "dist", "serve.js");
+    const proc = spawn("node", [serverPath], {
+      stdio: ["pipe", "pipe", "pipe"],
+      env: { ...process.env, PORT: "0", BASE_URL: "http://localhost" },
+    });
+
+    const timeout = setTimeout(() => {
+      proc.kill();
+      reject(new Error("Server startup timeout"));
+    }, 10000);
+
+    proc.stderr!.on("data", (data: Buffer) => {
+      const match = data.toString().match(/running on http:\/\/localhost:(\d+)/);
+      if (match) {
+        serverPort = parseInt(match[1], 10);
+        clearTimeout(timeout);
+        resolve(proc);
+      }
+    });
+
+    proc.on("error", (err) => {
+      clearTimeout(timeout);
+      reject(err);
+    });
+  });
+}
+
+describe("GET /api/referral/:vendor", () => {
+  let serverProc: ChildProcess;
+
+  before(async () => {
+    resetRequestsFile();
+    resetAgentsFile();
+    serverProc = await startHttpServer();
+  });
+
+  after(() => {
+    serverProc.kill();
+    resetRequestsFile();
+    resetAgentsFile();
+  });
+
+  it("returns referral code for vendor with referral", async () => {
+    const res = await fetch(`http://localhost:${serverPort}/api/referral/Railway`);
+    assert.strictEqual(res.status, 200);
+    const data = await res.json() as any;
+    assert.strictEqual(data.vendor, "Railway");
+    assert.ok(data.referral_url);
+    assert.ok(data.referee_value);
+    assert.strictEqual(data.attributed, false);
+  });
+
+  it("returns 404 for vendor without referral", async () => {
+    const res = await fetch(`http://localhost:${serverPort}/api/referral/NonExistentVendor`);
+    assert.strictEqual(res.status, 404);
+    const data = await res.json() as any;
+    assert.ok(data.error.includes("No referral found"));
+  });
+
+  it("logs attribution for authenticated caller", async () => {
+    // Register an agent
+    const regRes = await fetch(`http://localhost:${serverPort}/api/agents/register`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ name: "ReferralTestBot" }),
+    });
+    const regData = await regRes.json() as any;
+
+    // Request referral with auth
+    const res = await fetch(`http://localhost:${serverPort}/api/referral/Railway`, {
+      headers: { Authorization: `Bearer ${regData.api_key}` },
+    });
+    assert.strictEqual(res.status, 200);
+    const data = await res.json() as any;
+    assert.strictEqual(data.attributed, true);
+    assert.strictEqual(data.vendor, "Railway");
+
+    // Verify the request was logged
+    resetReferralRequestsCache();
+    const raw = JSON.parse(fs.readFileSync(REQUESTS_PATH, "utf-8"));
+    const agentRequests = raw.referral_requests.filter((r: any) => r.vendor === "Railway");
+    assert.ok(agentRequests.length > 0);
+  });
+
+  it("unauthenticated caller still gets the code (no error)", async () => {
+    const res = await fetch(`http://localhost:${serverPort}/api/referral/Railway`);
+    assert.strictEqual(res.status, 200);
+    const data = await res.json() as any;
+    assert.strictEqual(data.attributed, false);
+    assert.ok(data.referral_url);
+  });
+});


### PR DESCRIPTION
## Summary

Adds the referral attribution layer for Phase 2 (issue #726). When an authenticated agent requests a referral code, the request is logged with the agent's ID. When a conversion later occurs, last-touch attribution matches it to the most recent requesting agent within a 90-day window.

### What's included

- **`src/referral-requests.ts`** — data layer: `logReferralRequest`, `attributeConversion` (last-touch), `getRequestsByAgent`, `markConversion`
- **`GET /api/referral/:vendor`** — returns referral code/URL for a vendor; if the caller is authenticated (Bearer token), logs an attribution request
- **`get_referral_code` MCP tool** — accepts optional `api_key` for attribution tracking; unauthenticated callers still get the code
- **`getVendorReferral`** in data.ts — fetches referral data for a vendor with `referrer_value` stripped
- **`data/referral_requests.json`** — JSON file storage following existing project patterns
- **19 new tests** covering attribution logic (single agent, multi-agent tie-break, lookback window, case-insensitive matching), request CRUD, and HTTP endpoints

### Key decisions

- **Last-touch attribution**: most recent agent request within the lookback window wins. Multi-touch deferred to Phase 3.
- **Unauthenticated callers still get the code** — no 401, just no attribution logging. This preserves Phase 1 behavior.
- **JSON file storage** following existing project patterns (agents.json, index.json).

Refs #726