### PR TITLE
feat: Referral code submission API with trust tiers

### DIFF
--- a/src/agents.ts
+++ b/src/agents.ts
@@ -92,6 +92,7 @@ export function registerAgent(opts: {
     api_key_hash: apiKeyHash,
     vestauth_public_key_url: opts.vestauth_public_key_url ?? null,
     x402_address: null,
+    trust_tier: "new",
     status: "active",
     registered_at: new Date().toISOString(),
   };
@@ -208,6 +209,20 @@ export function updateAgentX402Address(agentId: string, x402Address: string | nu
     throw new Error(`Agent not found: ${agentId}`);
   }
   agent.x402_address = x402Address;
+  saveAgents(agents);
+  return agent;
+}
+
+/**
+ * Update an agent's trust tier. Called after conversion confirmation or clawback events.
+ */
+export function updateAgentTrustTier(agentId: string, newTier: "new" | "verified" | "trusted"): Agent {
+  const agents = loadAgents();
+  const agent = agents.find(a => a.id === agentId);
+  if (!agent) {
+    throw new Error(`Agent not found: ${agentId}`);
+  }
+  agent.trust_tier = newTier;
   saveAgents(agents);
   return agent;
 }

--- a/src/ledger.ts
+++ b/src/ledger.ts
@@ -3,6 +3,8 @@ import path from "node:path";
 import { randomBytes } from "node:crypto";
 import { fileURLToPath } from "node:url";
 import { attributeConversion, markConversion, getRequestsByAgent } from "./referral-requests.js";
+import { updateAgentTrustTier } from "./agents.js";
+import { calculateTrustTier } from "./referral-codes.js";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const LEDGER_PATH = path.join(__dirname, "..", "data", "ledger_entries.json");
@@ -277,6 +279,17 @@ export function confirmEligibleEntries(asOfDate?: Date): string[] {
   if (confirmed.length > 0) {
     saveLedger(ledger);
     saveBalances(loadBalances());
+
+    // Recalculate trust tiers for affected agents
+    const affectedAgents = new Set<string>();
+    for (const entryId of confirmed) {
+      const entry = ledger.find(e => e.id === entryId);
+      if (entry?.agent_id) affectedAgents.add(entry.agent_id);
+    }
+    for (const agentId of affectedAgents) {
+      const newTier = calculateTrustTier(agentId, ledger);
+      updateAgentTrustTier(agentId, newTier);
+    }
   }
 
   return confirmed;
@@ -322,6 +335,13 @@ export function clawbackEntry(entryId: string, reason?: string): boolean {
 
   saveLedger(ledger);
   saveBalances(loadBalances());
+
+  // Recalculate trust tier for affected agent
+  if (entry.agent_id) {
+    const newTier = calculateTrustTier(entry.agent_id, ledger);
+    updateAgentTrustTier(entry.agent_id, newTier);
+  }
+
   return true;
 }
 

--- a/src/referral-codes.ts
+++ b/src/referral-codes.ts
@@ -1,0 +1,374 @@
+import fs from "node:fs";
+import path from "node:path";
+import { randomBytes } from "node:crypto";
+import { fileURLToPath } from "node:url";
+import { getAgentById } from "./agents.js";
+import { loadOffers } from "./data.js";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const CODES_PATH = path.join(__dirname, "..", "data", "referral_codes.json");
+
+export type CodeStatus = "pending" | "active" | "expired" | "revoked";
+export type TrustTier = "new" | "verified" | "trusted";
+
+export interface SubmittedReferralCode {
+  id: string;
+  vendor: string;
+  code: string;
+  referral_url: string;
+  description: string;
+  commission_rate: number | null;
+  expiry: string | null;
+  submitted_by: string;
+  source: "agent-submitted";
+  status: CodeStatus;
+  trust_tier_at_submission: TrustTier;
+  impressions: number;
+  clicks: number;
+  conversions: number;
+  submitted_at: string;
+  updated_at: string;
+}
+
+let cachedCodes: SubmittedReferralCode[] | null = null;
+
+function loadCodes(): SubmittedReferralCode[] {
+  if (cachedCodes) return cachedCodes;
+
+  if (!fs.existsSync(CODES_PATH)) {
+    cachedCodes = [];
+    return cachedCodes;
+  }
+
+  try {
+    const raw = fs.readFileSync(CODES_PATH, "utf-8");
+    const data = JSON.parse(raw) as { referral_codes?: SubmittedReferralCode[] };
+    cachedCodes = Array.isArray(data.referral_codes) ? data.referral_codes : [];
+  } catch {
+    cachedCodes = [];
+  }
+  return cachedCodes;
+}
+
+function saveCodes(codes: SubmittedReferralCode[]): void {
+  fs.writeFileSync(CODES_PATH, JSON.stringify({ referral_codes: codes }, null, 2), "utf-8");
+  cachedCodes = codes;
+}
+
+export function resetReferralCodesCache(): void {
+  cachedCodes = null;
+}
+
+function generateCodeId(): string {
+  return `code_${randomBytes(12).toString("hex")}`;
+}
+
+// --- Trust tier calculation ---
+
+/**
+ * Calculate an agent's trust tier based on their conversion/clawback history.
+ * - new: default (just registered)
+ * - verified: 3+ successful conversions, 0 clawbacks
+ * - trusted: 20+ conversions, <5% clawback rate
+ */
+export function calculateTrustTier(agentId: string, ledgerEntries: { event_type: string; agent_id: string | null; status: string }[]): TrustTier {
+  const agentEntries = ledgerEntries.filter(e => e.agent_id === agentId);
+  const conversions = agentEntries.filter(e => e.event_type === "conversion" && e.status !== "clawed_back");
+  const clawbacks = agentEntries.filter(e => e.event_type === "clawback");
+
+  const conversionCount = conversions.length;
+  const clawbackCount = clawbacks.length;
+
+  if (conversionCount >= 20) {
+    const totalEvents = conversionCount + clawbackCount;
+    const clawbackRate = totalEvents > 0 ? clawbackCount / totalEvents : 0;
+    if (clawbackRate < 0.05) return "trusted";
+  }
+
+  if (conversionCount >= 3 && clawbackCount === 0) return "verified";
+
+  return "new";
+}
+
+// --- Rate limiting ---
+
+const DAILY_LIMITS: Record<TrustTier, number> = {
+  new: 10,
+  verified: 10,
+  trusted: 50,
+};
+
+export function getDailySubmissionCount(agentId: string): number {
+  const codes = loadCodes();
+  const todayStart = new Date();
+  todayStart.setHours(0, 0, 0, 0);
+  const todayStr = todayStart.toISOString();
+
+  return codes.filter(c =>
+    c.submitted_by === agentId && c.submitted_at >= todayStr
+  ).length;
+}
+
+export function getDailyLimit(tier: TrustTier): number {
+  return DAILY_LIMITS[tier];
+}
+
+// --- Validation ---
+
+function validateVendorExists(vendor: string): boolean {
+  const offers = loadOffers();
+  return offers.some(o => o.vendor.toLowerCase() === vendor.toLowerCase());
+}
+
+function isValidUrl(url: string): boolean {
+  try {
+    new URL(url);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+// --- Core operations ---
+
+export interface SubmitCodeOpts {
+  vendor: string;
+  code: string;
+  referral_url: string;
+  description: string;
+  commission_rate?: number;
+  expiry?: string;
+  agent_id: string;
+  trust_tier: TrustTier;
+}
+
+export function submitReferralCode(opts: SubmitCodeOpts): SubmittedReferralCode {
+  // Validate vendor exists
+  if (!validateVendorExists(opts.vendor)) {
+    throw new Error(`Vendor "${opts.vendor}" not found in the offers index`);
+  }
+
+  // Validate code
+  if (!opts.code || opts.code.length > 100) {
+    throw new Error("code must be a non-empty string, max 100 characters");
+  }
+
+  // Validate URL
+  if (!isValidUrl(opts.referral_url)) {
+    throw new Error("referral_url must be a valid URL");
+  }
+
+  // Validate agent is active
+  const agent = getAgentById(opts.agent_id);
+  if (!agent || agent.status !== "active") {
+    throw new Error("Agent must be active to submit referral codes");
+  }
+
+  // Check one active code per vendor per agent
+  const codes = loadCodes();
+  const existingActive = codes.find(c =>
+    c.submitted_by === opts.agent_id &&
+    c.vendor.toLowerCase() === opts.vendor.toLowerCase() &&
+    (c.status === "active" || c.status === "pending")
+  );
+  if (existingActive) {
+    throw new Error(`You already have an active/pending code for "${opts.vendor}". Revoke it first to submit a new one.`);
+  }
+
+  // Rate limit check
+  const dailyCount = getDailySubmissionCount(opts.agent_id);
+  const dailyLimit = getDailyLimit(opts.trust_tier);
+  if (dailyCount >= dailyLimit) {
+    throw new Error(`Daily submission limit reached (${dailyLimit}/day for ${opts.trust_tier} tier). Try again tomorrow.`);
+  }
+
+  // Validate expiry if provided
+  if (opts.expiry) {
+    const expiryDate = new Date(opts.expiry);
+    if (isNaN(expiryDate.getTime())) {
+      throw new Error("expiry must be a valid ISO date string");
+    }
+    if (expiryDate <= new Date()) {
+      throw new Error("expiry must be in the future");
+    }
+  }
+
+  // Determine initial status based on trust tier
+  const status: CodeStatus = opts.trust_tier === "new" ? "pending" : "active";
+
+  const now = new Date().toISOString();
+  const entry: SubmittedReferralCode = {
+    id: generateCodeId(),
+    vendor: opts.vendor,
+    code: opts.code,
+    referral_url: opts.referral_url,
+    description: opts.description || "",
+    commission_rate: opts.commission_rate ?? null,
+    expiry: opts.expiry ?? null,
+    submitted_by: opts.agent_id,
+    source: "agent-submitted",
+    status,
+    trust_tier_at_submission: opts.trust_tier,
+    impressions: 0,
+    clicks: 0,
+    conversions: 0,
+    submitted_at: now,
+    updated_at: now,
+  };
+
+  codes.push(entry);
+  saveCodes(codes);
+  return entry;
+}
+
+/**
+ * Get all codes submitted by a specific agent.
+ */
+export function getCodesByAgent(agentId: string): SubmittedReferralCode[] {
+  return loadCodes().filter(c => c.submitted_by === agentId);
+}
+
+/**
+ * Get a submitted code by ID.
+ */
+export function getCodeById(id: string): SubmittedReferralCode | null {
+  return loadCodes().find(c => c.id === id) ?? null;
+}
+
+/**
+ * Update a submitted code. Only the owner can update.
+ * Returns the updated code or throws.
+ */
+export function updateCode(id: string, agentId: string, updates: {
+  code?: string;
+  referral_url?: string;
+  description?: string;
+  commission_rate?: number;
+  expiry?: string | null;
+}): SubmittedReferralCode {
+  const codes = loadCodes();
+  const entry = codes.find(c => c.id === id);
+
+  if (!entry) {
+    throw new Error("Code not found");
+  }
+
+  if (entry.submitted_by !== agentId) {
+    throw new Error("You can only update your own codes");
+  }
+
+  if (entry.status === "revoked") {
+    throw new Error("Cannot update a revoked code");
+  }
+
+  if (updates.code !== undefined) {
+    if (!updates.code || updates.code.length > 100) {
+      throw new Error("code must be a non-empty string, max 100 characters");
+    }
+    entry.code = updates.code;
+  }
+
+  if (updates.referral_url !== undefined) {
+    if (!isValidUrl(updates.referral_url)) {
+      throw new Error("referral_url must be a valid URL");
+    }
+    entry.referral_url = updates.referral_url;
+  }
+
+  if (updates.description !== undefined) {
+    entry.description = updates.description;
+  }
+
+  if (updates.commission_rate !== undefined) {
+    entry.commission_rate = updates.commission_rate;
+  }
+
+  if (updates.expiry !== undefined) {
+    if (updates.expiry !== null) {
+      const expiryDate = new Date(updates.expiry);
+      if (isNaN(expiryDate.getTime())) {
+        throw new Error("expiry must be a valid ISO date string");
+      }
+    }
+    entry.expiry = updates.expiry;
+  }
+
+  entry.updated_at = new Date().toISOString();
+  saveCodes(codes);
+  return entry;
+}
+
+/**
+ * Soft-delete (revoke) a submitted code. Only the owner can revoke.
+ */
+export function revokeCode(id: string, agentId: string): SubmittedReferralCode {
+  const codes = loadCodes();
+  const entry = codes.find(c => c.id === id);
+
+  if (!entry) {
+    throw new Error("Code not found");
+  }
+
+  if (entry.submitted_by !== agentId) {
+    throw new Error("You can only revoke your own codes");
+  }
+
+  if (entry.status === "revoked") {
+    throw new Error("Code is already revoked");
+  }
+
+  entry.status = "revoked";
+  entry.updated_at = new Date().toISOString();
+  saveCodes(codes);
+  return entry;
+}
+
+/**
+ * Get all active agent-submitted codes for a specific vendor.
+ * Used by search results to include alongside curated codes.
+ */
+export function getActiveCodesForVendor(vendorName: string): SubmittedReferralCode[] {
+  const codes = loadCodes();
+  const lowerName = vendorName.toLowerCase();
+
+  // Check and expire any codes past their expiry date
+  const now = new Date();
+  let changed = false;
+  for (const code of codes) {
+    if (code.status === "active" && code.expiry) {
+      const expiryDate = new Date(code.expiry);
+      if (expiryDate <= now) {
+        code.status = "expired";
+        code.updated_at = now.toISOString();
+        changed = true;
+      }
+    }
+  }
+  if (changed) saveCodes(codes);
+
+  return codes.filter(c =>
+    c.vendor.toLowerCase() === lowerName && c.status === "active"
+  );
+}
+
+/**
+ * Get all active agent-submitted codes (for search result integration).
+ */
+export function getAllActiveCodes(): SubmittedReferralCode[] {
+  const codes = loadCodes();
+  const now = new Date();
+  let changed = false;
+  for (const code of codes) {
+    if (code.status === "active" && code.expiry) {
+      const expiryDate = new Date(code.expiry);
+      if (expiryDate <= now) {
+        code.status = "expired";
+        code.updated_at = now.toISOString();
+        changed = true;
+      }
+    }
+  }
+  if (changed) saveCodes(codes);
+
+  return codes.filter(c => c.status === "active");
+}

--- a/src/serve.ts
+++ b/src/serve.ts
@@ -14,6 +14,7 @@ import { registerAgent, authenticateRequest, validateVestauthUrl, hashApiKey, up
 import { logReferralRequest } from "./referral-requests.js";
 import { recordConversion, confirmEligibleEntries, clawbackEntry, getAgentBalance, getAgentLedgerEntries, recordPayout, MINIMUM_PAYOUT_AMOUNT } from "./ledger.js";
 import { validateX402Address, executeTransfer, generateCorrelationId } from "./x402.js";
+import { submitReferralCode, getCodesByAgent, getCodeById, updateCode, revokeCode, calculateTrustTier, getDailySubmissionCount, getDailyLimit, getActiveCodesForVendor } from "./referral-codes.js";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -49039,9 +49040,24 @@ const httpServer = createHttpServer(async (req, res) => {
     const results = searchOffers(q, category, eligibilityType, sort, validStability, validPaymentProtocol);
     const total = results.length;
     const paged = enrichOffers(results.slice(offset, offset + limit));
+    // Append agent-submitted referral codes for each vendor (curated codes shown first via offer.referral)
+    const offersWithAgentCodes = paged.map(offer => {
+      const agentCodes = getActiveCodesForVendor(offer.vendor);
+      if (agentCodes.length === 0) return offer;
+      return {
+        ...offer,
+        agent_referral_codes: agentCodes.map(c => ({
+          code: c.code,
+          referral_url: c.referral_url,
+          description: c.description,
+          source: c.source,
+          submitted_by: c.submitted_by,
+        })),
+      };
+    });
     logRequest({ ts: new Date().toISOString(), type: "api", endpoint: "/api/offers", params: { q, category, limit, offset }, user_agent: req.headers["user-agent"] ?? "unknown", result_count: paged.length });
     res.writeHead(200, { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" });
-    res.end(JSON.stringify({ offers: paged, total }));
+    res.end(JSON.stringify({ offers: offersWithAgentCodes, total }));
   } else if (url.pathname === "/api/compare" && isGetOrHead) {
     recordApiHit("/api/compare");
     const a = url.searchParams.get("a") || "";
@@ -50491,6 +50507,7 @@ ${Array.from(vendorSlugMap.keys()).map(s => {
       id: agent.id,
       name: agent.name,
       status: agent.status,
+      trust_tier: agent.trust_tier ?? "new",
       registered_at: agent.registered_at,
       vestauth_public_key_url: agent.vestauth_public_key_url,
       x402_address: agent.x402_address,
@@ -50806,6 +50823,162 @@ ${Array.from(vendorSlugMap.keys()).map(s => {
       logRequest({ ts: new Date().toISOString(), type: "api", endpoint: `/api/agents/${agentId}/payout`, params: { correlation_id: correlationId, status: "error" }, user_agent: req.headers["user-agent"] ?? "unknown", result_count: 0 });
       res.writeHead(500, { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" });
       res.end(JSON.stringify({ error: err.message, correlation_id: correlationId }));
+    }
+
+  // --- POST /api/referral-codes: Submit a referral code ---
+  } else if (url.pathname === "/api/referral-codes" && req.method === "POST") {
+    const agent = await authenticateRequest(req as any);
+    if (!agent) {
+      res.writeHead(401, { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" });
+      res.end(JSON.stringify({ error: "Authentication required. Include Authorization: Bearer <api-key> header." }));
+      return;
+    }
+
+    let body = "";
+    for await (const chunk of req) {
+      body += chunk;
+    }
+    let parsed: any;
+    try {
+      parsed = JSON.parse(body);
+    } catch {
+      res.writeHead(400, { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" });
+      res.end(JSON.stringify({ error: "Invalid JSON body" }));
+      return;
+    }
+
+    if (!parsed.vendor || typeof parsed.vendor !== "string") {
+      res.writeHead(400, { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" });
+      res.end(JSON.stringify({ error: "vendor is required and must be a string" }));
+      return;
+    }
+    if (!parsed.code || typeof parsed.code !== "string") {
+      res.writeHead(400, { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" });
+      res.end(JSON.stringify({ error: "code is required and must be a string" }));
+      return;
+    }
+    if (!parsed.referral_url || typeof parsed.referral_url !== "string") {
+      res.writeHead(400, { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" });
+      res.end(JSON.stringify({ error: "referral_url is required and must be a string" }));
+      return;
+    }
+
+    try {
+      // Calculate current trust tier from ledger
+      const ledgerEntries = getAgentLedgerEntries(agent.id);
+      const trustTier = calculateTrustTier(agent.id, ledgerEntries);
+
+      const code = submitReferralCode({
+        vendor: parsed.vendor,
+        code: parsed.code,
+        referral_url: parsed.referral_url,
+        description: parsed.description ?? "",
+        commission_rate: parsed.commission_rate,
+        expiry: parsed.expiry,
+        agent_id: agent.id,
+        trust_tier: trustTier,
+      });
+
+      recordApiHit("/api/referral-codes");
+      logRequest({ ts: new Date().toISOString(), type: "api", endpoint: "POST /api/referral-codes", params: { vendor: parsed.vendor, status: code.status }, user_agent: req.headers["user-agent"] ?? "unknown", result_count: 1 });
+      res.writeHead(201, { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" });
+      res.end(JSON.stringify(code));
+    } catch (err: any) {
+      const status = err.message.includes("limit reached") ? 429 : 400;
+      res.writeHead(status, { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" });
+      res.end(JSON.stringify({ error: err.message }));
+    }
+
+  // --- GET /api/referral-codes/mine: List my submitted codes ---
+  } else if (url.pathname === "/api/referral-codes/mine" && isGetOrHead) {
+    const agent = await authenticateRequest(req as any);
+    if (!agent) {
+      res.writeHead(401, { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" });
+      res.end(JSON.stringify({ error: "Authentication required. Include Authorization: Bearer <api-key> header." }));
+      return;
+    }
+
+    const codes = getCodesByAgent(agent.id);
+    const dailyCount = getDailySubmissionCount(agent.id);
+    const ledgerEntries = getAgentLedgerEntries(agent.id);
+    const trustTier = calculateTrustTier(agent.id, ledgerEntries);
+    const dailyLimit = getDailyLimit(trustTier);
+
+    recordApiHit("/api/referral-codes/mine");
+    logRequest({ ts: new Date().toISOString(), type: "api", endpoint: "GET /api/referral-codes/mine", params: { agent_id: agent.id }, user_agent: req.headers["user-agent"] ?? "unknown", result_count: codes.length });
+    res.writeHead(200, { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" });
+    res.end(JSON.stringify({
+      codes,
+      trust_tier: trustTier,
+      daily_submissions: dailyCount,
+      daily_limit: dailyLimit,
+    }));
+
+  // --- PUT /api/referral-codes/:id: Update a code ---
+  } else if (url.pathname.match(/^\/api\/referral-codes\/[^/]+$/) && req.method === "PUT") {
+    const codeId = decodeURIComponent(url.pathname.split("/").pop()!);
+
+    const agent = await authenticateRequest(req as any);
+    if (!agent) {
+      res.writeHead(401, { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" });
+      res.end(JSON.stringify({ error: "Authentication required. Include Authorization: Bearer <api-key> header." }));
+      return;
+    }
+
+    let body = "";
+    for await (const chunk of req) {
+      body += chunk;
+    }
+    let parsed: any;
+    try {
+      parsed = JSON.parse(body);
+    } catch {
+      res.writeHead(400, { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" });
+      res.end(JSON.stringify({ error: "Invalid JSON body" }));
+      return;
+    }
+
+    try {
+      const updated = updateCode(codeId, agent.id, {
+        code: parsed.code,
+        referral_url: parsed.referral_url,
+        description: parsed.description,
+        commission_rate: parsed.commission_rate,
+        expiry: parsed.expiry,
+      });
+
+      recordApiHit("/api/referral-codes/:id");
+      logRequest({ ts: new Date().toISOString(), type: "api", endpoint: `PUT /api/referral-codes/${codeId}`, params: {}, user_agent: req.headers["user-agent"] ?? "unknown", result_count: 1 });
+      res.writeHead(200, { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" });
+      res.end(JSON.stringify(updated));
+    } catch (err: any) {
+      const status = err.message.includes("not found") ? 404 : err.message.includes("only update your own") ? 403 : 400;
+      res.writeHead(status, { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" });
+      res.end(JSON.stringify({ error: err.message }));
+    }
+
+  // --- DELETE /api/referral-codes/:id: Revoke a code ---
+  } else if (url.pathname.match(/^\/api\/referral-codes\/[^/]+$/) && req.method === "DELETE") {
+    const codeId = decodeURIComponent(url.pathname.split("/").pop()!);
+
+    const agent = await authenticateRequest(req as any);
+    if (!agent) {
+      res.writeHead(401, { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" });
+      res.end(JSON.stringify({ error: "Authentication required. Include Authorization: Bearer <api-key> header." }));
+      return;
+    }
+
+    try {
+      const revoked = revokeCode(codeId, agent.id);
+
+      recordApiHit("/api/referral-codes/:id");
+      logRequest({ ts: new Date().toISOString(), type: "api", endpoint: `DELETE /api/referral-codes/${codeId}`, params: {}, user_agent: req.headers["user-agent"] ?? "unknown", result_count: 1 });
+      res.writeHead(200, { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" });
+      res.end(JSON.stringify(revoked));
+    } catch (err: any) {
+      const status = err.message.includes("not found") ? 404 : err.message.includes("only revoke your own") ? 403 : 400;
+      res.writeHead(status, { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" });
+      res.end(JSON.stringify({ error: err.message }));
     }
 
   } else {

--- a/src/server.ts
+++ b/src/server.ts
@@ -4,7 +4,8 @@ import { getCategories, getDealChanges, getPersonalizedChanges, getNewOffers, ge
 import { recordToolCall, logRequest } from "./stats.js";
 import { registerAgent, validateVestauthUrl, getAgentByApiKeyHash, hashApiKey, updateAgentX402Address } from "./agents.js";
 import { logReferralRequest } from "./referral-requests.js";
-import { getAgentBalance, recordPayout, MINIMUM_PAYOUT_AMOUNT } from "./ledger.js";
+import { getAgentBalance, getAgentLedgerEntries, recordPayout, MINIMUM_PAYOUT_AMOUNT } from "./ledger.js";
+import { submitReferralCode, getCodesByAgent, calculateTrustTier, getDailySubmissionCount, getDailyLimit, getActiveCodesForVendor } from "./referral-codes.js";
 import { validateX402Address, executeTransfer, generateCorrelationId } from "./x402.js";
 import { getStackRecommendation } from "./stacks.js";
 import { estimateCosts } from "./costs.js";
@@ -120,7 +121,21 @@ export function createServer(getSessionId?: () => string | undefined): McpServer
           };
         }
 
-        const outputResults = response_format === "concise" ? results.map(toConciseOffer) : results;
+        // Append agent-submitted referral codes for each vendor
+        const resultsWithAgentCodes = results.map(offer => {
+          const agentCodes = getActiveCodesForVendor(offer.vendor);
+          if (agentCodes.length === 0) return offer;
+          return {
+            ...offer,
+            agent_referral_codes: agentCodes.map(c => ({
+              code: c.code,
+              referral_url: c.referral_url,
+              description: c.description,
+              source: c.source,
+            })),
+          };
+        });
+        const outputResults = response_format === "concise" ? resultsWithAgentCodes.map(toConciseOffer) : resultsWithAgentCodes;
         return {
           content: [{ type: "text" as const, text: JSON.stringify({ results: outputResults, total: finalTotal, limit: effectiveLimit, offset: effectiveOffset }, null, 2) }],
         };
@@ -1149,6 +1164,129 @@ Suggested monitoring cadence: run this check weekly to catch pricing changes ear
               chain: transferResult.chain ?? null,
               correlation_id: correlationId,
             },
+          }, null, 2) }],
+        };
+      } catch (err: any) {
+        return {
+          isError: true,
+          content: [{ type: "text" as const, text: err.message }],
+        };
+      }
+    }
+  );
+
+  // --- Tool 9: submit_referral_code ---
+  server.registerTool(
+    "submit_referral_code",
+    {
+      description:
+        "Submit your own referral code for a vendor in the AgentDeals index. Requires authentication via API key (from register_agent). New agents' codes are pending review; verified/trusted agents' codes are auto-approved.",
+      annotations: {
+        readOnlyHint: false,
+        destructiveHint: false,
+      },
+      inputSchema: {
+        vendor: z.string().describe("Vendor name (must exist in the AgentDeals index)"),
+        code: z.string().max(100).describe("The referral code (max 100 chars)"),
+        referral_url: z.string().url().describe("The referral URL"),
+        description: z.string().optional().describe("Description of the referral offer"),
+        commission_rate: z.number().min(0).max(1).optional().describe("Commission rate as a decimal (e.g. 0.15 for 15%)"),
+        expiry: z.string().optional().describe("Expiry date in ISO format (optional)"),
+        api_key: z.string().describe("Your API key from register_agent."),
+      },
+    },
+    async ({ vendor, code, referral_url, description, commission_rate, expiry, api_key }) => {
+      try {
+        recordToolCall("submit_referral_code");
+
+        const hash = hashApiKey(api_key);
+        const agent = getAgentByApiKeyHash(hash);
+        if (!agent) {
+          return {
+            isError: true,
+            content: [{ type: "text" as const, text: "Invalid API key. Register first with register_agent." }],
+          };
+        }
+
+        const ledgerEntries = getAgentLedgerEntries(agent.id);
+        const trustTier = calculateTrustTier(agent.id, ledgerEntries);
+
+        const submitted = submitReferralCode({
+          vendor,
+          code,
+          referral_url,
+          description: description ?? "",
+          commission_rate,
+          expiry,
+          agent_id: agent.id,
+          trust_tier: trustTier,
+        });
+
+        logRequest({ ts: new Date().toISOString(), type: "mcp", endpoint: "submit_referral_code", params: { vendor, status: submitted.status }, result_count: 1, session_id: getSessionId?.() });
+
+        return {
+          content: [{ type: "text" as const, text: JSON.stringify({
+            success: true,
+            code: submitted,
+            trust_tier: trustTier,
+            message: submitted.status === "pending"
+              ? "Code submitted and pending review (new agent tier). It will be visible in search results once approved."
+              : "Code submitted and active. It is now visible in search results.",
+          }, null, 2) }],
+        };
+      } catch (err: any) {
+        return {
+          isError: true,
+          content: [{ type: "text" as const, text: err.message }],
+        };
+      }
+    }
+  );
+
+  // --- Tool 10: my_referral_codes ---
+  server.registerTool(
+    "my_referral_codes",
+    {
+      description:
+        "List your submitted referral codes with performance stats (impressions, clicks, conversions). Requires authentication via API key (from register_agent).",
+      annotations: {
+        readOnlyHint: true,
+        destructiveHint: false,
+      },
+      inputSchema: {
+        api_key: z.string().describe("Your API key from register_agent."),
+      },
+    },
+    async ({ api_key }) => {
+      try {
+        recordToolCall("my_referral_codes");
+
+        const hash = hashApiKey(api_key);
+        const agent = getAgentByApiKeyHash(hash);
+        if (!agent) {
+          return {
+            isError: true,
+            content: [{ type: "text" as const, text: "Invalid API key. Register first with register_agent." }],
+          };
+        }
+
+        const codes = getCodesByAgent(agent.id);
+        const ledgerEntries = getAgentLedgerEntries(agent.id);
+        const trustTier = calculateTrustTier(agent.id, ledgerEntries);
+        const dailyCount = getDailySubmissionCount(agent.id);
+        const dailyLimit = getDailyLimit(trustTier);
+
+        logRequest({ ts: new Date().toISOString(), type: "mcp", endpoint: "my_referral_codes", params: { agent_id: agent.id, count: codes.length }, result_count: codes.length, session_id: getSessionId?.() });
+
+        return {
+          content: [{ type: "text" as const, text: JSON.stringify({
+            codes,
+            trust_tier: trustTier,
+            daily_submissions: dailyCount,
+            daily_limit: dailyLimit,
+            total_codes: codes.length,
+            active_codes: codes.filter(c => c.status === "active").length,
+            pending_codes: codes.filter(c => c.status === "pending").length,
           }, null, 2) }],
         };
       } catch (err: any) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -69,6 +69,7 @@ export interface Agent {
   api_key_hash: string;
   vestauth_public_key_url: string | null;
   x402_address: string | null;
+  trust_tier: "new" | "verified" | "trusted";
   status: "active" | "suspended";
   registered_at: string;
 }

--- a/test/referral-codes.test.ts
+++ b/test/referral-codes.test.ts
@@ -1,0 +1,628 @@
+import { describe, it, before, after, beforeEach } from "node:test";
+import assert from "node:assert";
+import path from "node:path";
+import fs from "node:fs";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const CODES_PATH = path.join(__dirname, "..", "data", "referral_codes.json");
+const AGENTS_PATH = path.join(__dirname, "..", "data", "agents.json");
+
+const {
+  submitReferralCode,
+  getCodesByAgent,
+  getCodeById,
+  updateCode,
+  revokeCode,
+  getActiveCodesForVendor,
+  getAllActiveCodes,
+  calculateTrustTier,
+  getDailySubmissionCount,
+  getDailyLimit,
+  resetReferralCodesCache,
+} = await import("../dist/referral-codes.js");
+
+const { registerAgent, resetAgentsCache } = await import("../dist/agents.js");
+
+function resetFiles() {
+  fs.writeFileSync(CODES_PATH, JSON.stringify({ referral_codes: [] }), "utf-8");
+  resetReferralCodesCache();
+  fs.writeFileSync(AGENTS_PATH, JSON.stringify({ agents: [] }), "utf-8");
+  resetAgentsCache();
+}
+
+function createTestAgent(name = "TestBot"): { agent: any; api_key: string } {
+  return registerAgent({ name });
+}
+
+describe("Referral Code Submission", () => {
+  beforeEach(() => {
+    resetFiles();
+  });
+
+  after(() => {
+    resetFiles();
+  });
+
+  it("submits a referral code for an existing vendor", () => {
+    const { agent } = createTestAgent();
+    const code = submitReferralCode({
+      vendor: "Railway",
+      code: "MYAGENT-RAILWAY",
+      referral_url: "https://railway.app?ref=myagent",
+      description: "Railway hosting referral",
+      agent_id: agent.id,
+      trust_tier: "new",
+    });
+
+    assert.ok(code.id.startsWith("code_"));
+    assert.strictEqual(code.vendor, "Railway");
+    assert.strictEqual(code.code, "MYAGENT-RAILWAY");
+    assert.strictEqual(code.referral_url, "https://railway.app?ref=myagent");
+    assert.strictEqual(code.source, "agent-submitted");
+    assert.strictEqual(code.status, "pending"); // new tier = pending
+    assert.strictEqual(code.trust_tier_at_submission, "new");
+    assert.strictEqual(code.impressions, 0);
+    assert.strictEqual(code.clicks, 0);
+    assert.strictEqual(code.conversions, 0);
+  });
+
+  it("verified agents get auto-approved codes", () => {
+    const { agent } = createTestAgent();
+    const code = submitReferralCode({
+      vendor: "Railway",
+      code: "VERIFIED-CODE",
+      referral_url: "https://railway.app?ref=verified",
+      description: "Auto-approved",
+      agent_id: agent.id,
+      trust_tier: "verified",
+    });
+
+    assert.strictEqual(code.status, "active");
+    assert.strictEqual(code.trust_tier_at_submission, "verified");
+  });
+
+  it("trusted agents get auto-approved codes", () => {
+    const { agent } = createTestAgent();
+    const code = submitReferralCode({
+      vendor: "Railway",
+      code: "TRUSTED-CODE",
+      referral_url: "https://railway.app?ref=trusted",
+      description: "Auto-approved trusted",
+      agent_id: agent.id,
+      trust_tier: "trusted",
+    });
+
+    assert.strictEqual(code.status, "active");
+  });
+
+  it("rejects submission for non-existent vendor", () => {
+    const { agent } = createTestAgent();
+    assert.throws(
+      () => submitReferralCode({
+        vendor: "NonExistentVendor99",
+        code: "CODE",
+        referral_url: "https://example.com",
+        description: "",
+        agent_id: agent.id,
+        trust_tier: "new",
+      }),
+      /not found in the offers index/
+    );
+  });
+
+  it("rejects code longer than 100 characters", () => {
+    const { agent } = createTestAgent();
+    assert.throws(
+      () => submitReferralCode({
+        vendor: "Railway",
+        code: "A".repeat(101),
+        referral_url: "https://railway.app",
+        description: "",
+        agent_id: agent.id,
+        trust_tier: "new",
+      }),
+      /max 100 characters/
+    );
+  });
+
+  it("rejects empty code", () => {
+    const { agent } = createTestAgent();
+    assert.throws(
+      () => submitReferralCode({
+        vendor: "Railway",
+        code: "",
+        referral_url: "https://railway.app",
+        description: "",
+        agent_id: agent.id,
+        trust_tier: "new",
+      }),
+      /non-empty string/
+    );
+  });
+
+  it("rejects invalid referral URL", () => {
+    const { agent } = createTestAgent();
+    assert.throws(
+      () => submitReferralCode({
+        vendor: "Railway",
+        code: "CODE",
+        referral_url: "not-a-url",
+        description: "",
+        agent_id: agent.id,
+        trust_tier: "new",
+      }),
+      /valid URL/
+    );
+  });
+
+  it("enforces one active code per vendor per agent", () => {
+    const { agent } = createTestAgent();
+    submitReferralCode({
+      vendor: "Railway",
+      code: "CODE1",
+      referral_url: "https://railway.app?ref=1",
+      description: "",
+      agent_id: agent.id,
+      trust_tier: "verified",
+    });
+
+    assert.throws(
+      () => submitReferralCode({
+        vendor: "Railway",
+        code: "CODE2",
+        referral_url: "https://railway.app?ref=2",
+        description: "",
+        agent_id: agent.id,
+        trust_tier: "verified",
+      }),
+      /already have an active/
+    );
+  });
+
+  it("allows different agents to submit codes for same vendor", () => {
+    const { agent: agent1 } = createTestAgent("Bot1");
+    const { agent: agent2 } = createTestAgent("Bot2");
+
+    const code1 = submitReferralCode({
+      vendor: "Railway",
+      code: "BOT1-CODE",
+      referral_url: "https://railway.app?ref=bot1",
+      description: "",
+      agent_id: agent1.id,
+      trust_tier: "verified",
+    });
+
+    const code2 = submitReferralCode({
+      vendor: "Railway",
+      code: "BOT2-CODE",
+      referral_url: "https://railway.app?ref=bot2",
+      description: "",
+      agent_id: agent2.id,
+      trust_tier: "verified",
+    });
+
+    assert.ok(code1.id !== code2.id);
+    assert.strictEqual(code1.status, "active");
+    assert.strictEqual(code2.status, "active");
+  });
+
+  it("allows resubmission after revoking", () => {
+    const { agent } = createTestAgent();
+    const code1 = submitReferralCode({
+      vendor: "Railway",
+      code: "CODE1",
+      referral_url: "https://railway.app?ref=1",
+      description: "",
+      agent_id: agent.id,
+      trust_tier: "verified",
+    });
+
+    revokeCode(code1.id, agent.id);
+
+    const code2 = submitReferralCode({
+      vendor: "Railway",
+      code: "CODE2",
+      referral_url: "https://railway.app?ref=2",
+      description: "",
+      agent_id: agent.id,
+      trust_tier: "verified",
+    });
+
+    assert.strictEqual(code2.status, "active");
+  });
+
+  it("handles optional commission_rate and expiry", () => {
+    const { agent } = createTestAgent();
+    const code = submitReferralCode({
+      vendor: "Railway",
+      code: "CODE",
+      referral_url: "https://railway.app?ref=test",
+      description: "With extras",
+      commission_rate: 0.15,
+      expiry: "2027-12-31T00:00:00Z",
+      agent_id: agent.id,
+      trust_tier: "new",
+    });
+
+    assert.strictEqual(code.commission_rate, 0.15);
+    assert.strictEqual(code.expiry, "2027-12-31T00:00:00Z");
+  });
+});
+
+describe("Code Retrieval", () => {
+  beforeEach(() => {
+    resetFiles();
+  });
+
+  after(() => {
+    resetFiles();
+  });
+
+  it("getCodesByAgent returns all codes for an agent", () => {
+    const { agent } = createTestAgent();
+    submitReferralCode({
+      vendor: "Railway",
+      code: "CODE1",
+      referral_url: "https://railway.app?ref=1",
+      description: "",
+      agent_id: agent.id,
+      trust_tier: "verified",
+    });
+    submitReferralCode({
+      vendor: "Render",
+      code: "CODE2",
+      referral_url: "https://render.com?ref=1",
+      description: "",
+      agent_id: agent.id,
+      trust_tier: "verified",
+    });
+
+    const codes = getCodesByAgent(agent.id);
+    assert.strictEqual(codes.length, 2);
+  });
+
+  it("getCodeById returns the correct code", () => {
+    const { agent } = createTestAgent();
+    const submitted = submitReferralCode({
+      vendor: "Railway",
+      code: "CODE1",
+      referral_url: "https://railway.app?ref=1",
+      description: "",
+      agent_id: agent.id,
+      trust_tier: "new",
+    });
+
+    const found = getCodeById(submitted.id);
+    assert.ok(found);
+    assert.strictEqual(found.id, submitted.id);
+  });
+
+  it("getCodeById returns null for non-existent ID", () => {
+    assert.strictEqual(getCodeById("code_nonexistent"), null);
+  });
+});
+
+describe("Code Update", () => {
+  beforeEach(() => {
+    resetFiles();
+  });
+
+  after(() => {
+    resetFiles();
+  });
+
+  it("updates code fields", () => {
+    const { agent } = createTestAgent();
+    const code = submitReferralCode({
+      vendor: "Railway",
+      code: "OLD-CODE",
+      referral_url: "https://railway.app?ref=old",
+      description: "Old desc",
+      agent_id: agent.id,
+      trust_tier: "verified",
+    });
+
+    const updated = updateCode(code.id, agent.id, {
+      code: "NEW-CODE",
+      referral_url: "https://railway.app?ref=new",
+      description: "New desc",
+      commission_rate: 0.2,
+    });
+
+    assert.strictEqual(updated.code, "NEW-CODE");
+    assert.strictEqual(updated.referral_url, "https://railway.app?ref=new");
+    assert.strictEqual(updated.description, "New desc");
+    assert.strictEqual(updated.commission_rate, 0.2);
+  });
+
+  it("rejects update from non-owner", () => {
+    const { agent: agent1 } = createTestAgent("Bot1");
+    const { agent: agent2 } = createTestAgent("Bot2");
+
+    const code = submitReferralCode({
+      vendor: "Railway",
+      code: "CODE",
+      referral_url: "https://railway.app?ref=1",
+      description: "",
+      agent_id: agent1.id,
+      trust_tier: "verified",
+    });
+
+    assert.throws(
+      () => updateCode(code.id, agent2.id, { code: "STOLEN" }),
+      /only update your own/
+    );
+  });
+
+  it("rejects update of revoked code", () => {
+    const { agent } = createTestAgent();
+    const code = submitReferralCode({
+      vendor: "Railway",
+      code: "CODE",
+      referral_url: "https://railway.app?ref=1",
+      description: "",
+      agent_id: agent.id,
+      trust_tier: "verified",
+    });
+
+    revokeCode(code.id, agent.id);
+
+    assert.throws(
+      () => updateCode(code.id, agent.id, { code: "NEW" }),
+      /Cannot update a revoked/
+    );
+  });
+});
+
+describe("Code Revocation", () => {
+  beforeEach(() => {
+    resetFiles();
+  });
+
+  after(() => {
+    resetFiles();
+  });
+
+  it("soft-deletes a code", () => {
+    const { agent } = createTestAgent();
+    const code = submitReferralCode({
+      vendor: "Railway",
+      code: "CODE",
+      referral_url: "https://railway.app?ref=1",
+      description: "",
+      agent_id: agent.id,
+      trust_tier: "verified",
+    });
+
+    const revoked = revokeCode(code.id, agent.id);
+    assert.strictEqual(revoked.status, "revoked");
+  });
+
+  it("rejects revocation from non-owner", () => {
+    const { agent: agent1 } = createTestAgent("Bot1");
+    const { agent: agent2 } = createTestAgent("Bot2");
+
+    const code = submitReferralCode({
+      vendor: "Railway",
+      code: "CODE",
+      referral_url: "https://railway.app?ref=1",
+      description: "",
+      agent_id: agent1.id,
+      trust_tier: "verified",
+    });
+
+    assert.throws(
+      () => revokeCode(code.id, agent2.id),
+      /only revoke your own/
+    );
+  });
+
+  it("rejects double revocation", () => {
+    const { agent } = createTestAgent();
+    const code = submitReferralCode({
+      vendor: "Railway",
+      code: "CODE",
+      referral_url: "https://railway.app?ref=1",
+      description: "",
+      agent_id: agent.id,
+      trust_tier: "verified",
+    });
+
+    revokeCode(code.id, agent.id);
+    assert.throws(
+      () => revokeCode(code.id, agent.id),
+      /already revoked/
+    );
+  });
+});
+
+describe("Active Codes for Vendor", () => {
+  beforeEach(() => {
+    resetFiles();
+  });
+
+  after(() => {
+    resetFiles();
+  });
+
+  it("returns only active codes for a vendor", () => {
+    const { agent: agent1 } = createTestAgent("Bot1");
+    const { agent: agent2 } = createTestAgent("Bot2");
+
+    // Active code
+    submitReferralCode({
+      vendor: "Railway",
+      code: "ACTIVE-CODE",
+      referral_url: "https://railway.app?ref=active",
+      description: "",
+      agent_id: agent1.id,
+      trust_tier: "verified",
+    });
+
+    // Pending code (not returned)
+    submitReferralCode({
+      vendor: "Railway",
+      code: "PENDING-CODE",
+      referral_url: "https://railway.app?ref=pending",
+      description: "",
+      agent_id: agent2.id,
+      trust_tier: "new",
+    });
+
+    const active = getActiveCodesForVendor("Railway");
+    assert.strictEqual(active.length, 1);
+    assert.strictEqual(active[0].code, "ACTIVE-CODE");
+  });
+
+  it("case-insensitive vendor lookup", () => {
+    const { agent } = createTestAgent();
+    submitReferralCode({
+      vendor: "Railway",
+      code: "CODE",
+      referral_url: "https://railway.app?ref=1",
+      description: "",
+      agent_id: agent.id,
+      trust_tier: "verified",
+    });
+
+    const codes = getActiveCodesForVendor("railway");
+    assert.strictEqual(codes.length, 1);
+  });
+
+  it("expires codes past their expiry date", () => {
+    const { agent } = createTestAgent();
+    // Manually create a code with past expiry
+    const codesPath = path.join(__dirname, "..", "data", "referral_codes.json");
+    const data = JSON.parse(fs.readFileSync(codesPath, "utf-8"));
+    data.referral_codes.push({
+      id: "code_expired_test",
+      vendor: "Railway",
+      code: "EXPIRED",
+      referral_url: "https://railway.app?ref=expired",
+      description: "",
+      commission_rate: null,
+      expiry: "2020-01-01T00:00:00Z",
+      submitted_by: agent.id,
+      source: "agent-submitted",
+      status: "active",
+      trust_tier_at_submission: "verified",
+      impressions: 0,
+      clicks: 0,
+      conversions: 0,
+      submitted_at: "2020-01-01T00:00:00Z",
+      updated_at: "2020-01-01T00:00:00Z",
+    });
+    fs.writeFileSync(codesPath, JSON.stringify(data, null, 2), "utf-8");
+    resetReferralCodesCache();
+
+    const codes = getActiveCodesForVendor("Railway");
+    assert.strictEqual(codes.length, 0);
+  });
+});
+
+describe("Trust Tier Calculation", () => {
+  it("returns 'new' with no ledger entries", () => {
+    assert.strictEqual(calculateTrustTier("agent_1", []), "new");
+  });
+
+  it("returns 'new' with fewer than 3 conversions", () => {
+    const entries = [
+      { event_type: "conversion", agent_id: "agent_1", status: "confirmed" },
+      { event_type: "conversion", agent_id: "agent_1", status: "confirmed" },
+    ];
+    assert.strictEqual(calculateTrustTier("agent_1", entries), "new");
+  });
+
+  it("returns 'verified' with 3+ conversions and 0 clawbacks", () => {
+    const entries = [
+      { event_type: "conversion", agent_id: "agent_1", status: "confirmed" },
+      { event_type: "conversion", agent_id: "agent_1", status: "confirmed" },
+      { event_type: "conversion", agent_id: "agent_1", status: "confirmed" },
+    ];
+    assert.strictEqual(calculateTrustTier("agent_1", entries), "verified");
+  });
+
+  it("returns 'new' with 3+ conversions but clawbacks", () => {
+    const entries = [
+      { event_type: "conversion", agent_id: "agent_1", status: "confirmed" },
+      { event_type: "conversion", agent_id: "agent_1", status: "confirmed" },
+      { event_type: "conversion", agent_id: "agent_1", status: "confirmed" },
+      { event_type: "clawback", agent_id: "agent_1", status: "clawed_back" },
+    ];
+    assert.strictEqual(calculateTrustTier("agent_1", entries), "new");
+  });
+
+  it("returns 'trusted' with 20+ conversions and <5% clawback rate", () => {
+    const entries: any[] = [];
+    for (let i = 0; i < 21; i++) {
+      entries.push({ event_type: "conversion", agent_id: "agent_1", status: "confirmed" });
+    }
+    assert.strictEqual(calculateTrustTier("agent_1", entries), "trusted");
+  });
+
+  it("returns 'verified' with 20+ conversions but >=5% clawback rate", () => {
+    const entries: any[] = [];
+    for (let i = 0; i < 20; i++) {
+      entries.push({ event_type: "conversion", agent_id: "agent_1", status: "confirmed" });
+    }
+    // 2 clawbacks out of 22 = ~9% clawback rate
+    entries.push({ event_type: "clawback", agent_id: "agent_1", status: "clawed_back" });
+    entries.push({ event_type: "clawback", agent_id: "agent_1", status: "clawed_back" });
+    assert.strictEqual(calculateTrustTier("agent_1", entries), "new");
+  });
+
+  it("ignores entries from other agents", () => {
+    const entries = [
+      { event_type: "conversion", agent_id: "agent_1", status: "confirmed" },
+      { event_type: "conversion", agent_id: "agent_2", status: "confirmed" },
+      { event_type: "conversion", agent_id: "agent_2", status: "confirmed" },
+      { event_type: "conversion", agent_id: "agent_2", status: "confirmed" },
+    ];
+    assert.strictEqual(calculateTrustTier("agent_1", entries), "new");
+    assert.strictEqual(calculateTrustTier("agent_2", entries), "verified");
+  });
+
+  it("excludes clawed_back conversions from count", () => {
+    const entries = [
+      { event_type: "conversion", agent_id: "agent_1", status: "confirmed" },
+      { event_type: "conversion", agent_id: "agent_1", status: "confirmed" },
+      { event_type: "conversion", agent_id: "agent_1", status: "clawed_back" },
+    ];
+    // 2 non-clawed-back conversions, 0 clawback events
+    assert.strictEqual(calculateTrustTier("agent_1", entries), "new");
+  });
+});
+
+describe("Rate Limiting", () => {
+  beforeEach(() => {
+    resetFiles();
+  });
+
+  after(() => {
+    resetFiles();
+  });
+
+  it("getDailyLimit returns correct limits per tier", () => {
+    assert.strictEqual(getDailyLimit("new"), 10);
+    assert.strictEqual(getDailyLimit("verified"), 10);
+    assert.strictEqual(getDailyLimit("trusted"), 50);
+  });
+
+  it("getDailySubmissionCount tracks today's submissions", () => {
+    const { agent } = createTestAgent();
+
+    assert.strictEqual(getDailySubmissionCount(agent.id), 0);
+
+    submitReferralCode({
+      vendor: "Railway",
+      code: "CODE1",
+      referral_url: "https://railway.app?ref=1",
+      description: "",
+      agent_id: agent.id,
+      trust_tier: "verified",
+    });
+
+    assert.strictEqual(getDailySubmissionCount(agent.id), 1);
+  });
+});


### PR DESCRIPTION
## Summary

- Implements Phase 3 Part 1: agent-submitted referral codes with trust-based review pipeline
- New data layer (`src/referral-codes.ts`) with submission, update, revocation, and expiry management
- REST API: `POST /api/referral-codes`, `GET /api/referral-codes/mine`, `PUT /api/referral-codes/:id`, `DELETE /api/referral-codes/:id`
- MCP tools: `submit_referral_code` and `my_referral_codes`
- Trust tiers (`new`/`verified`/`trusted`) added to Agent type, auto-recalculated on conversion confirmation and clawback events
- Rate limiting: 10 submissions/day for new/verified agents, 50/day for trusted
- One active code per vendor per agent enforced
- Active agent-submitted codes appear in search results alongside curated codes (curated shown first)
- 33 new tests covering all acceptance criteria; 637 total tests passing

Refs #733

## Test plan

- [x] Unit tests: 33 new tests covering submission, validation, trust tiers, rate limits, update, revocation, expiry
- [x] Full test suite: 637 tests passing (604 existing + 33 new)
- [x] E2E verified: register agent → submit code → get codes → update code → revoke code
- [x] Auth rejection verified (401 for missing/bad auth)
- [x] Trust tier shows in agent profile response