### PR TITLE
Code ranking algorithm + agent leaderboard

### DIFF
--- a/src/ledger.ts
+++ b/src/ledger.ts
@@ -3,16 +3,21 @@ import path from "node:path";
 import { randomBytes } from "node:crypto";
 import { fileURLToPath } from "node:url";
 import { attributeConversion, markConversion, getRequestsByAgent } from "./referral-requests.js";
-import { updateAgentTrustTier } from "./agents.js";
-import { calculateTrustTier } from "./referral-codes.js";
+import { updateAgentTrustTier, getAgentById } from "./agents.js";
+import { calculateTrustTier, getCodesByAgent } from "./referral-codes.js";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const LEDGER_PATH = path.join(__dirname, "..", "data", "ledger_entries.json");
 const BALANCES_PATH = path.join(__dirname, "..", "data", "agent_balances.json");
 const CLAWBACK_CONFIG_PATH = path.join(__dirname, "..", "data", "vendor_clawback.json");
 
-// Revenue split: 70% to agent, 30% to AgentDeals
-const AGENT_SHARE_RATE = 0.7;
+// Revenue splits
+// Standard (curated codes): 70% to surfacing agent, 30% to AgentDeals
+const STANDARD_AGENT_SHARE_RATE = 0.7;
+// Agent-submitted codes — same agent submitted and surfaced: 80% agent, 20% platform
+const SINGLE_AGENT_SHARE_RATE = 0.8;
+// Agent-submitted codes — different agents: 40% submitter, 40% surfer, 20% platform
+const DUAL_AGENT_SHARE_RATE = 0.4;
 
 export type EventType = "conversion" | "confirmation" | "clawback" | "payout";
 export type LedgerStatus = "pending" | "confirmed" | "paid_out" | "clawed_back";
@@ -20,11 +25,13 @@ export type LedgerStatus = "pending" | "confirmed" | "paid_out" | "clawed_back";
 export interface LedgerEntry {
   id: string;
   agent_id: string | null;
+  submitter_id?: string | null;
   vendor: string;
   referral_code: string;
   event_type: EventType;
   commission_amount: number;
   agent_share: number;
+  submitter_share?: number;
   status: LedgerStatus;
   conversion_date: string;
   clawback_window_ends: string;
@@ -161,14 +168,20 @@ function roundCents(n: number): number {
 // --- Core operations ---
 
 /**
- * Record a new conversion. Looks up attribution, creates a ledger entry with
- * status "pending", and updates the agent's pending balance.
+ * Record a new conversion. Looks up attribution, creates ledger entries with
+ * status "pending", and updates agent balances.
+ *
+ * When submitter_id is provided (agent-submitted code):
+ * - Same agent submitted AND surfaced: 80% agent / 20% platform
+ * - Different agents: 40% submitter / 40% surfer / 20% platform
+ * When no submitter_id (curated code): 70% surfer / 30% platform
  */
 export function recordConversion(opts: {
   vendor: string;
   referral_code: string;
   commission_amount: number;
   conversion_date?: string;
+  submitter_id?: string | null;
   metadata?: Record<string, unknown>;
 }): LedgerEntry {
   const conversionDate = opts.conversion_date
@@ -176,22 +189,46 @@ export function recordConversion(opts: {
     : new Date();
   const conversionDateStr = conversionDate.toISOString().split("T")[0];
 
-  // Look up attribution
-  const agentId = attributeConversion(opts.vendor, conversionDate);
+  // Look up attribution (surfacing agent)
+  const surfacingAgentId = attributeConversion(opts.vendor, conversionDate);
+  const submitterId = opts.submitter_id ?? null;
 
-  const agentShare = roundCents(opts.commission_amount * AGENT_SHARE_RATE);
   const clawbackDays = getClawbackDays(opts.vendor);
   const clawbackEnd = new Date(conversionDate);
   clawbackEnd.setDate(clawbackEnd.getDate() + clawbackDays);
 
+  // Calculate shares based on agent-submitted vs curated
+  let surferShare = 0;
+  let submitterShare = 0;
+  const commission = roundCents(opts.commission_amount);
+
+  if (submitterId && surfacingAgentId) {
+    if (submitterId === surfacingAgentId) {
+      // Same agent submitted and surfaced: 80/20
+      surferShare = roundCents(commission * SINGLE_AGENT_SHARE_RATE);
+    } else {
+      // Different agents: 40/40/20
+      surferShare = roundCents(commission * DUAL_AGENT_SHARE_RATE);
+      submitterShare = roundCents(commission * DUAL_AGENT_SHARE_RATE);
+    }
+  } else if (submitterId && !surfacingAgentId) {
+    // Agent submitted code but no surfacing attribution — submitter gets 40%
+    submitterShare = roundCents(commission * DUAL_AGENT_SHARE_RATE);
+  } else if (surfacingAgentId) {
+    // Curated code with surfacing agent: 70/30
+    surferShare = roundCents(commission * STANDARD_AGENT_SHARE_RATE);
+  }
+
   const entry: LedgerEntry = {
     id: generateLedgerId(),
-    agent_id: agentId,
+    agent_id: surfacingAgentId,
+    submitter_id: submitterId,
     vendor: opts.vendor,
     referral_code: opts.referral_code,
     event_type: "conversion",
-    commission_amount: roundCents(opts.commission_amount),
-    agent_share: agentId ? agentShare : 0,
+    commission_amount: commission,
+    agent_share: surferShare,
+    submitter_share: submitterShare,
     status: "pending",
     conversion_date: conversionDateStr,
     clawback_window_ends: clawbackEnd.toISOString().split("T")[0],
@@ -206,15 +243,15 @@ export function recordConversion(opts: {
   ledger.push(entry);
   saveLedger(ledger);
 
-  // Update agent balance if attributed
-  if (agentId) {
-    const balance = getOrCreateBalance(agentId);
-    balance.pending_balance = roundCents(balance.pending_balance + agentShare);
+  // Update surfacing agent balance
+  if (surfacingAgentId && surferShare > 0) {
+    const balance = getOrCreateBalance(surfacingAgentId);
+    balance.pending_balance = roundCents(balance.pending_balance + surferShare);
     balance.updated_at = new Date().toISOString();
     saveBalances(loadBalances());
 
     // Mark the referral request as converted
-    const requests = getRequestsByAgent(agentId);
+    const requests = getRequestsByAgent(surfacingAgentId);
     const vendorLower = opts.vendor.toLowerCase();
     const matchingRequest = requests
       .filter(r => r.vendor.toLowerCase() === vendorLower && !r.conversion_id)
@@ -222,6 +259,14 @@ export function recordConversion(opts: {
     if (matchingRequest) {
       markConversion(matchingRequest.id, entry.id);
     }
+  }
+
+  // Update submitter balance if different from surfer
+  if (submitterId && submitterShare > 0 && submitterId !== surfacingAgentId) {
+    const submitterBalance = getOrCreateBalance(submitterId);
+    submitterBalance.pending_balance = roundCents(submitterBalance.pending_balance + submitterShare);
+    submitterBalance.updated_at = new Date().toISOString();
+    saveBalances(loadBalances());
   }
 
   return entry;
@@ -246,11 +291,13 @@ export function confirmEligibleEntries(asOfDate?: Date): string[] {
     const confirmEntry: LedgerEntry = {
       id: generateLedgerId(),
       agent_id: entry.agent_id,
+      submitter_id: entry.submitter_id,
       vendor: entry.vendor,
       referral_code: entry.referral_code,
       event_type: "confirmation",
       commission_amount: entry.commission_amount,
       agent_share: entry.agent_share,
+      submitter_share: entry.submitter_share,
       status: "confirmed",
       conversion_date: entry.conversion_date,
       clawback_window_ends: entry.clawback_window_ends,
@@ -266,13 +313,23 @@ export function confirmEligibleEntries(asOfDate?: Date): string[] {
     entry.confirmed_at = new Date().toISOString();
     confirmed.push(entry.id);
 
-    // Update balance
-    if (entry.agent_id) {
+    // Update surfacing agent balance
+    if (entry.agent_id && entry.agent_share > 0) {
       const balance = getOrCreateBalance(entry.agent_id);
       balance.pending_balance = roundCents(balance.pending_balance - entry.agent_share);
       balance.confirmed_balance = roundCents(balance.confirmed_balance + entry.agent_share);
       balance.total_earned = roundCents(balance.total_earned + entry.agent_share);
       balance.updated_at = new Date().toISOString();
+    }
+
+    // Update submitter balance if different from surfer
+    const submitterShare = entry.submitter_share ?? 0;
+    if (entry.submitter_id && submitterShare > 0 && entry.submitter_id !== entry.agent_id) {
+      const submitterBalance = getOrCreateBalance(entry.submitter_id);
+      submitterBalance.pending_balance = roundCents(submitterBalance.pending_balance - submitterShare);
+      submitterBalance.confirmed_balance = roundCents(submitterBalance.confirmed_balance + submitterShare);
+      submitterBalance.total_earned = roundCents(submitterBalance.total_earned + submitterShare);
+      submitterBalance.updated_at = new Date().toISOString();
     }
   }
 
@@ -308,11 +365,13 @@ export function clawbackEntry(entryId: string, reason?: string): boolean {
   const clawbackEvent: LedgerEntry = {
     id: generateLedgerId(),
     agent_id: entry.agent_id,
+    submitter_id: entry.submitter_id,
     vendor: entry.vendor,
     referral_code: entry.referral_code,
     event_type: "clawback",
     commission_amount: entry.commission_amount,
     agent_share: entry.agent_share,
+    submitter_share: entry.submitter_share,
     status: "clawed_back",
     conversion_date: entry.conversion_date,
     clawback_window_ends: entry.clawback_window_ends,
@@ -326,11 +385,19 @@ export function clawbackEntry(entryId: string, reason?: string): boolean {
   // Update original entry
   entry.status = "clawed_back";
 
-  // Update balance
-  if (entry.agent_id) {
+  // Update surfacing agent balance
+  if (entry.agent_id && entry.agent_share > 0) {
     const balance = getOrCreateBalance(entry.agent_id);
     balance.pending_balance = roundCents(balance.pending_balance - entry.agent_share);
     balance.updated_at = new Date().toISOString();
+  }
+
+  // Update submitter balance if different from surfer
+  const submitterShare = entry.submitter_share ?? 0;
+  if (entry.submitter_id && submitterShare > 0 && entry.submitter_id !== entry.agent_id) {
+    const submitterBalance = getOrCreateBalance(entry.submitter_id);
+    submitterBalance.pending_balance = roundCents(submitterBalance.pending_balance - submitterShare);
+    submitterBalance.updated_at = new Date().toISOString();
   }
 
   saveLedger(ledger);
@@ -436,4 +503,69 @@ export function getLedgerEntry(id: string): LedgerEntry | null {
  */
 export function getAllConversions(): LedgerEntry[] {
   return loadLedger().filter(e => e.event_type === "conversion");
+}
+
+// --- Leaderboard ---
+
+export interface LeaderboardEntry {
+  agent_id: string;
+  agent_name: string;
+  trust_tier: string;
+  total_conversions: number;
+  active_codes: number;
+  total_earnings: number;
+}
+
+/**
+ * Get the agent leaderboard ranked by total conversions.
+ * Public endpoint — no auth required.
+ */
+export function getLeaderboard(opts?: { limit?: number; offset?: number }): { entries: LeaderboardEntry[]; total: number } {
+  const limit = Math.min(opts?.limit ?? 10, 50);
+  const offset = opts?.offset ?? 0;
+
+  const ledger = loadLedger();
+  const balances = loadBalances();
+
+  // Collect per-agent conversion counts from ledger
+  const agentConversions = new Map<string, number>();
+  for (const entry of ledger) {
+    if (entry.event_type === "conversion" && entry.agent_id && entry.status !== "clawed_back") {
+      agentConversions.set(entry.agent_id, (agentConversions.get(entry.agent_id) ?? 0) + 1);
+    }
+    // Also count submitter contributions
+    if (entry.event_type === "conversion" && entry.submitter_id && entry.submitter_id !== entry.agent_id && entry.status !== "clawed_back") {
+      agentConversions.set(entry.submitter_id, (agentConversions.get(entry.submitter_id) ?? 0) + 1);
+    }
+  }
+
+  // Build leaderboard from agents that have at least one conversion
+  const entries: LeaderboardEntry[] = [];
+  for (const [agentId, conversions] of agentConversions) {
+    const agent = getAgentById(agentId);
+    if (!agent) continue;
+
+    const agentCodes = getCodesByAgent(agentId);
+    const activeCodes = agentCodes.filter(c => c.status === "active").length;
+
+    const balance = balances.find(b => b.agent_id === agentId);
+    const totalEarnings = balance ? balance.total_earned + balance.pending_balance + balance.confirmed_balance : 0;
+
+    entries.push({
+      agent_id: agentId,
+      agent_name: agent.name,
+      trust_tier: agent.trust_tier,
+      total_conversions: conversions,
+      active_codes: activeCodes,
+      total_earnings: roundCents(totalEarnings),
+    });
+  }
+
+  // Sort by total conversions descending
+  entries.sort((a, b) => b.total_conversions - a.total_conversions);
+
+  return {
+    entries: entries.slice(offset, offset + limit),
+    total: entries.length,
+  };
 }

--- a/src/referral-codes.ts
+++ b/src/referral-codes.ts
@@ -372,3 +372,100 @@ export function getAllActiveCodes(): SubmittedReferralCode[] {
 
   return codes.filter(c => c.status === "active");
 }
+
+// --- Code Ranking Algorithm ---
+
+const TRUST_WEIGHTS: Record<TrustTier, number> = {
+  new: 1.0,
+  verified: 1.5,
+  trusted: 2.0,
+};
+
+const COLD_START_IMPRESSIONS = 50;
+const RECENCY_DECAY_RATE = 0.05; // 5% per week
+const RECENCY_FLOOR = 0.5;
+const MIN_IMPRESSIONS_FOR_RATE = 10;
+
+/**
+ * Calculate the ranking score for a submitted code.
+ * score = trust_weight × conversion_rate × recency_factor
+ */
+export function calculateCodeScore(code: SubmittedReferralCode, now?: Date): number {
+  const currentDate = now ?? new Date();
+  const trustWeight = TRUST_WEIGHTS[code.trust_tier_at_submission] ?? 1.0;
+
+  // Conversion rate (min 10 impressions before rate kicks in)
+  let conversionRate: number;
+  if (code.impressions < MIN_IMPRESSIONS_FOR_RATE) {
+    conversionRate = 0.5; // default rate for new codes
+  } else {
+    conversionRate = code.conversions / code.impressions;
+  }
+
+  // Recency factor: 1.0 for first 7 days, decaying 5% per week after, floor 0.5
+  const submittedAt = new Date(code.submitted_at);
+  const daysSinceSubmission = Math.max(0, (currentDate.getTime() - submittedAt.getTime()) / (1000 * 60 * 60 * 24));
+  let recencyFactor: number;
+  if (daysSinceSubmission <= 7) {
+    recencyFactor = 1.0;
+  } else {
+    const weeksAfterFirst = (daysSinceSubmission - 7) / 7;
+    recencyFactor = Math.max(RECENCY_FLOOR, 1.0 - weeksAfterFirst * RECENCY_DECAY_RATE);
+  }
+
+  return trustWeight * conversionRate * recencyFactor;
+}
+
+/**
+ * Check if a code is in its cold start trial period (< 50 impressions).
+ */
+export function isInColdStart(code: SubmittedReferralCode): boolean {
+  return code.impressions < COLD_START_IMPRESSIONS;
+}
+
+/**
+ * Get ranked active codes for a vendor. Codes in cold start get equal
+ * distribution; codes past cold start are ranked by score descending.
+ * Returns all active codes sorted: cold start codes first (round-robin
+ * by fewest impressions), then performance-ranked codes.
+ */
+export function getRankedCodesForVendor(vendorName: string, now?: Date): SubmittedReferralCode[] {
+  const activeCodes = getActiveCodesForVendor(vendorName);
+  if (activeCodes.length === 0) return [];
+
+  const coldStart = activeCodes.filter(c => isInColdStart(c));
+  const ranked = activeCodes.filter(c => !isInColdStart(c));
+
+  // Cold start: sort by fewest impressions (equal distribution)
+  coldStart.sort((a, b) => a.impressions - b.impressions);
+
+  // Performance-ranked: sort by score descending
+  ranked.sort((a, b) => calculateCodeScore(b, now) - calculateCodeScore(a, now));
+
+  // Cold start codes are interleaved alongside ranked codes
+  return [...coldStart, ...ranked];
+}
+
+/**
+ * Record an impression for a code (increments the counter).
+ */
+export function recordImpression(codeId: string): void {
+  const codes = loadCodes();
+  const code = codes.find(c => c.id === codeId);
+  if (code) {
+    code.impressions += 1;
+    saveCodes(codes);
+  }
+}
+
+/**
+ * Record a conversion for a submitted code.
+ */
+export function recordCodeConversion(codeId: string): void {
+  const codes = loadCodes();
+  const code = codes.find(c => c.id === codeId);
+  if (code) {
+    code.conversions += 1;
+    saveCodes(codes);
+  }
+}

--- a/src/serve.ts
+++ b/src/serve.ts
@@ -12,9 +12,9 @@ import { recordApiHit, recordSessionConnect, recordSessionDisconnect, recordLand
 import { openapiSpec } from "./openapi.js";
 import { registerAgent, authenticateRequest, validateVestauthUrl, hashApiKey, updateAgentX402Address, getAgentById } from "./agents.js";
 import { logReferralRequest } from "./referral-requests.js";
-import { recordConversion, confirmEligibleEntries, clawbackEntry, getAgentBalance, getAgentLedgerEntries, recordPayout, MINIMUM_PAYOUT_AMOUNT } from "./ledger.js";
+import { recordConversion, confirmEligibleEntries, clawbackEntry, getAgentBalance, getAgentLedgerEntries, recordPayout, MINIMUM_PAYOUT_AMOUNT, getLeaderboard } from "./ledger.js";
 import { validateX402Address, executeTransfer, generateCorrelationId } from "./x402.js";
-import { submitReferralCode, getCodesByAgent, getCodeById, updateCode, revokeCode, calculateTrustTier, getDailySubmissionCount, getDailyLimit, getActiveCodesForVendor } from "./referral-codes.js";
+import { submitReferralCode, getCodesByAgent, getCodeById, updateCode, revokeCode, calculateTrustTier, getDailySubmissionCount, getDailyLimit, getRankedCodesForVendor, calculateCodeScore } from "./referral-codes.js";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -47253,6 +47253,17 @@ ${globalNavCss()}
   </div>
 
   <div class="section">
+    <h2>Agent-Submitted Referral Codes</h2>
+    <p>Some referral codes on AgentDeals are submitted by community agents &mdash; autonomous software agents registered in our marketplace. These codes are:</p>
+    <ul>
+      <li>Ranked by performance (conversion rate) and trust tier</li>
+      <li>Subject to a trust system: new agents' codes are reviewed before activation; verified and trusted agents get auto-approved codes</li>
+      <li>Labeled with their source so you can see whether a code is curated by AgentDeals or submitted by a community agent</li>
+      <li>Revenue from agent-submitted codes is split between the submitting agent, the surfacing agent, and the platform</li>
+    </ul>
+  </div>
+
+  <div class="section">
     <h2>Current Referral Partners</h2>
     ${referralOffers.length > 0 ? `<ul>${referralOffers.map(o => `<li><a href="/vendor/${toSlug(o.vendor)}">${escHtmlServer(o.vendor)}</a>: ${escHtmlServer(o.referral!.referee_value)}${o.referral!.terms_url ? ` (<a href="${escHtmlServer(o.referral!.terms_url)}" rel="noopener" target="_blank">program terms</a>)` : ""}</li>`).join("")}</ul>` : `<p>No referral partners at this time.</p>`}
   </div>
@@ -49040,9 +49051,9 @@ const httpServer = createHttpServer(async (req, res) => {
     const results = searchOffers(q, category, eligibilityType, sort, validStability, validPaymentProtocol);
     const total = results.length;
     const paged = enrichOffers(results.slice(offset, offset + limit));
-    // Append agent-submitted referral codes for each vendor (curated codes shown first via offer.referral)
+    // Append ranked agent-submitted referral codes for each vendor (curated codes shown first via offer.referral)
     const offersWithAgentCodes = paged.map(offer => {
-      const agentCodes = getActiveCodesForVendor(offer.vendor);
+      const agentCodes = getRankedCodesForVendor(offer.vendor);
       if (agentCodes.length === 0) return offer;
       return {
         ...offer,
@@ -49052,6 +49063,7 @@ const httpServer = createHttpServer(async (req, res) => {
           description: c.description,
           source: c.source,
           submitted_by: c.submitted_by,
+          score: Math.round(calculateCodeScore(c) * 1000) / 1000,
         })),
       };
     });
@@ -50980,6 +50992,23 @@ ${Array.from(vendorSlugMap.keys()).map(s => {
       res.writeHead(status, { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" });
       res.end(JSON.stringify({ error: err.message }));
     }
+
+  // --- GET /api/leaderboard: Agent leaderboard ---
+  } else if (url.pathname === "/api/leaderboard" && isGetOrHead) {
+    const limit = Math.min(parseInt(url.searchParams.get("limit") ?? "10", 10), 50);
+    const offset = Math.max(parseInt(url.searchParams.get("offset") ?? "0", 10), 0);
+
+    const result = getLeaderboard({ limit, offset });
+
+    recordApiHit("/api/leaderboard");
+    logRequest({ ts: new Date().toISOString(), type: "api", endpoint: "/api/leaderboard", params: { limit, offset }, user_agent: req.headers["user-agent"] ?? "unknown", result_count: result.entries.length });
+    res.writeHead(200, { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*", "Cache-Control": "public, max-age=60" });
+    res.end(JSON.stringify({
+      leaderboard: result.entries,
+      total: result.total,
+      limit,
+      offset,
+    }));
 
   } else {
     res.writeHead(404, { "Content-Type": "application/json" });

--- a/src/server.ts
+++ b/src/server.ts
@@ -4,8 +4,8 @@ import { getCategories, getDealChanges, getPersonalizedChanges, getNewOffers, ge
 import { recordToolCall, logRequest } from "./stats.js";
 import { registerAgent, validateVestauthUrl, getAgentByApiKeyHash, hashApiKey, updateAgentX402Address } from "./agents.js";
 import { logReferralRequest } from "./referral-requests.js";
-import { getAgentBalance, getAgentLedgerEntries, recordPayout, MINIMUM_PAYOUT_AMOUNT } from "./ledger.js";
-import { submitReferralCode, getCodesByAgent, calculateTrustTier, getDailySubmissionCount, getDailyLimit, getActiveCodesForVendor } from "./referral-codes.js";
+import { getAgentBalance, getAgentLedgerEntries, recordPayout, MINIMUM_PAYOUT_AMOUNT, getLeaderboard } from "./ledger.js";
+import { submitReferralCode, getCodesByAgent, calculateTrustTier, getDailySubmissionCount, getDailyLimit, getRankedCodesForVendor, calculateCodeScore } from "./referral-codes.js";
 import { validateX402Address, executeTransfer, generateCorrelationId } from "./x402.js";
 import { getStackRecommendation } from "./stacks.js";
 import { estimateCosts } from "./costs.js";
@@ -121,9 +121,9 @@ export function createServer(getSessionId?: () => string | undefined): McpServer
           };
         }
 
-        // Append agent-submitted referral codes for each vendor
+        // Append ranked agent-submitted referral codes for each vendor
         const resultsWithAgentCodes = results.map(offer => {
-          const agentCodes = getActiveCodesForVendor(offer.vendor);
+          const agentCodes = getRankedCodesForVendor(offer.vendor);
           if (agentCodes.length === 0) return offer;
           return {
             ...offer,
@@ -132,6 +132,7 @@ export function createServer(getSessionId?: () => string | undefined): McpServer
               referral_url: c.referral_url,
               description: c.description,
               source: c.source,
+              score: Math.round(calculateCodeScore(c) * 1000) / 1000,
             })),
           };
         });
@@ -1287,6 +1288,46 @@ Suggested monitoring cadence: run this check weekly to catch pricing changes ear
             total_codes: codes.length,
             active_codes: codes.filter(c => c.status === "active").length,
             pending_codes: codes.filter(c => c.status === "pending").length,
+          }, null, 2) }],
+        };
+      } catch (err: any) {
+        return {
+          isError: true,
+          content: [{ type: "text" as const, text: err.message }],
+        };
+      }
+    }
+  );
+
+  // --- Tool 11: leaderboard ---
+
+  server.registerTool(
+    "leaderboard",
+    {
+      description:
+        "Get the agent leaderboard showing top-performing agents ranked by total conversions. Shows agent name, trust tier, conversion count, active referral codes, and total earnings. Use this to see which agents are most active in the referral marketplace.",
+      annotations: {
+        readOnlyHint: true,
+        destructiveHint: false,
+      },
+      inputSchema: {
+        limit: z.number().min(1).max(50).optional().describe("Number of entries to return (default 10, max 50)"),
+        offset: z.number().min(0).optional().describe("Offset for pagination (default 0)"),
+      },
+    },
+    async ({ limit, offset }) => {
+      try {
+        recordToolCall("leaderboard");
+        const result = getLeaderboard({ limit, offset });
+
+        logRequest({ ts: new Date().toISOString(), type: "mcp", endpoint: "leaderboard", params: { limit, offset }, result_count: result.entries.length, session_id: getSessionId?.() });
+
+        return {
+          content: [{ type: "text" as const, text: JSON.stringify({
+            leaderboard: result.entries,
+            total: result.total,
+            limit: limit ?? 10,
+            offset: offset ?? 0,
           }, null, 2) }],
         };
       } catch (err: any) {

--- a/test/ranking-leaderboard.test.ts
+++ b/test/ranking-leaderboard.test.ts
@@ -1,0 +1,492 @@
+import { describe, it, before, after, beforeEach } from "node:test";
+import assert from "node:assert";
+import path from "node:path";
+import fs from "node:fs";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const CODES_PATH = path.join(__dirname, "..", "data", "referral_codes.json");
+const AGENTS_PATH = path.join(__dirname, "..", "data", "agents.json");
+const LEDGER_PATH = path.join(__dirname, "..", "data", "ledger_entries.json");
+const BALANCES_PATH = path.join(__dirname, "..", "data", "agent_balances.json");
+const REQUESTS_PATH = path.join(__dirname, "..", "data", "referral_requests.json");
+
+const {
+  submitReferralCode,
+  getCodesByAgent,
+  getActiveCodesForVendor,
+  getRankedCodesForVendor,
+  calculateCodeScore,
+  isInColdStart,
+  recordImpression,
+  recordCodeConversion,
+  resetReferralCodesCache,
+} = await import("../dist/referral-codes.js");
+
+const { registerAgent, resetAgentsCache, updateAgentTrustTier } = await import("../dist/agents.js");
+const { recordConversion, getAgentBalance, getLeaderboard, clawbackEntry, resetLedgerCache } = await import("../dist/ledger.js");
+const { resetReferralRequestsCache, logReferralRequest } = await import("../dist/referral-requests.js");
+
+let origCodes: string | null = null;
+let origAgents: string | null = null;
+let origLedger: string | null = null;
+let origBalances: string | null = null;
+let origRequests: string | null = null;
+
+function saveOriginals() {
+  origCodes = fs.existsSync(CODES_PATH) ? fs.readFileSync(CODES_PATH, "utf-8") : null;
+  origAgents = fs.existsSync(AGENTS_PATH) ? fs.readFileSync(AGENTS_PATH, "utf-8") : null;
+  origLedger = fs.existsSync(LEDGER_PATH) ? fs.readFileSync(LEDGER_PATH, "utf-8") : null;
+  origBalances = fs.existsSync(BALANCES_PATH) ? fs.readFileSync(BALANCES_PATH, "utf-8") : null;
+  origRequests = fs.existsSync(REQUESTS_PATH) ? fs.readFileSync(REQUESTS_PATH, "utf-8") : null;
+}
+
+function restoreOriginals() {
+  if (origCodes !== null) fs.writeFileSync(CODES_PATH, origCodes, "utf-8");
+  else if (fs.existsSync(CODES_PATH)) fs.unlinkSync(CODES_PATH);
+  if (origAgents !== null) fs.writeFileSync(AGENTS_PATH, origAgents, "utf-8");
+  else if (fs.existsSync(AGENTS_PATH)) fs.unlinkSync(AGENTS_PATH);
+  if (origLedger !== null) fs.writeFileSync(LEDGER_PATH, origLedger, "utf-8");
+  else if (fs.existsSync(LEDGER_PATH)) fs.unlinkSync(LEDGER_PATH);
+  if (origBalances !== null) fs.writeFileSync(BALANCES_PATH, origBalances, "utf-8");
+  else if (fs.existsSync(BALANCES_PATH)) fs.unlinkSync(BALANCES_PATH);
+  if (origRequests !== null) fs.writeFileSync(REQUESTS_PATH, origRequests, "utf-8");
+  else if (fs.existsSync(REQUESTS_PATH)) fs.unlinkSync(REQUESTS_PATH);
+  resetReferralCodesCache();
+  resetAgentsCache();
+  resetLedgerCache();
+  resetReferralRequestsCache();
+}
+
+function resetFiles() {
+  fs.writeFileSync(CODES_PATH, JSON.stringify({ referral_codes: [] }), "utf-8");
+  fs.writeFileSync(AGENTS_PATH, JSON.stringify({ agents: [] }), "utf-8");
+  fs.writeFileSync(LEDGER_PATH, JSON.stringify({ ledger_entries: [] }), "utf-8");
+  fs.writeFileSync(BALANCES_PATH, JSON.stringify({ agent_balances: [] }), "utf-8");
+  fs.writeFileSync(REQUESTS_PATH, JSON.stringify({ referral_requests: [] }), "utf-8");
+  resetReferralCodesCache();
+  resetAgentsCache();
+  resetLedgerCache();
+  resetReferralRequestsCache();
+}
+
+function createTestAgent(name: string): { agent: any; api_key: string } {
+  return registerAgent({ name });
+}
+
+describe("Code Ranking Algorithm", () => {
+  before(() => saveOriginals());
+  after(() => restoreOriginals());
+  beforeEach(() => resetFiles());
+
+  it("calculates score with trust_weight × conversion_rate × recency_factor", () => {
+    const { agent } = createTestAgent("RankBot");
+    const code = submitReferralCode({
+      vendor: "Railway",
+      code: "RANK1",
+      referral_url: "https://railway.app?ref=rank1",
+      description: "Test",
+      agent_id: agent.id,
+      trust_tier: "verified",
+    });
+
+    // New code with < 10 impressions uses default 0.5 conversion rate
+    // trust_weight=1.5 (verified), conversion_rate=0.5 (default), recency=1.0 (new)
+    const score = calculateCodeScore(code);
+    assert.strictEqual(score, 1.5 * 0.5 * 1.0);
+  });
+
+  it("uses actual conversion rate after 10+ impressions", () => {
+    const { agent } = createTestAgent("RateBot");
+    const code = submitReferralCode({
+      vendor: "Railway",
+      code: "RATE1",
+      referral_url: "https://railway.app?ref=rate1",
+      description: "Test",
+      agent_id: agent.id,
+      trust_tier: "new",
+    });
+
+    // Simulate 20 impressions, 4 conversions => 20% rate
+    for (let i = 0; i < 20; i++) recordImpression(code.id);
+    for (let i = 0; i < 4; i++) recordCodeConversion(code.id);
+
+    const updatedCodes = getCodesByAgent(agent.id);
+    const updatedCode = updatedCodes.find((c: any) => c.id === code.id);
+    const score = calculateCodeScore(updatedCode);
+    // trust_weight=1.0 (new), conversion_rate=4/20=0.2, recency=1.0
+    assert.strictEqual(score, 1.0 * 0.2 * 1.0);
+  });
+
+  it("applies recency decay after 7 days", () => {
+    const { agent } = createTestAgent("RecencyBot");
+    const code = submitReferralCode({
+      vendor: "Railway",
+      code: "OLD1",
+      referral_url: "https://railway.app?ref=old1",
+      description: "Test",
+      agent_id: agent.id,
+      trust_tier: "trusted",
+    });
+
+    // Score at day 7 (still 1.0)
+    const day7 = new Date(new Date(code.submitted_at).getTime() + 7 * 24 * 60 * 60 * 1000);
+    const score7 = calculateCodeScore(code, day7);
+    assert.strictEqual(score7, 2.0 * 0.5 * 1.0);
+
+    // Score at day 14 (1 week past first 7 days => 0.95)
+    const day14 = new Date(new Date(code.submitted_at).getTime() + 14 * 24 * 60 * 60 * 1000);
+    const score14 = calculateCodeScore(code, day14);
+    const expected14 = 2.0 * 0.5 * 0.95;
+    assert.ok(Math.abs(score14 - expected14) < 0.001);
+
+    // Score after many weeks — floor at 0.5
+    const day200 = new Date(new Date(code.submitted_at).getTime() + 200 * 24 * 60 * 60 * 1000);
+    const score200 = calculateCodeScore(code, day200);
+    const expected200 = 2.0 * 0.5 * 0.5;
+    assert.strictEqual(score200, expected200);
+  });
+
+  it("identifies cold start codes (< 50 impressions)", () => {
+    const { agent } = createTestAgent("ColdBot");
+    const code = submitReferralCode({
+      vendor: "Railway",
+      code: "COLD1",
+      referral_url: "https://railway.app?ref=cold1",
+      description: "Test",
+      agent_id: agent.id,
+      trust_tier: "new",
+    });
+
+    assert.strictEqual(isInColdStart(code), true);
+
+    // Add 50 impressions
+    for (let i = 0; i < 50; i++) recordImpression(code.id);
+    const updatedCodes = getCodesByAgent(agent.id);
+    const updatedCode = updatedCodes.find((c: any) => c.id === code.id);
+    assert.strictEqual(isInColdStart(updatedCode), false);
+  });
+
+  it("ranks codes by score descending after cold start", () => {
+    const { agent: a1 } = createTestAgent("HighBot");
+    updateAgentTrustTier(a1.id, "trusted");
+    const { agent: a2 } = createTestAgent("LowBot");
+
+    // High-performing trusted agent
+    const code1 = submitReferralCode({
+      vendor: "Railway",
+      code: "HIGH1",
+      referral_url: "https://railway.app?ref=high1",
+      description: "High performer",
+      agent_id: a1.id,
+      trust_tier: "trusted",
+    });
+    // Push past cold start with good conversion rate
+    for (let i = 0; i < 50; i++) recordImpression(code1.id);
+    for (let i = 0; i < 10; i++) recordCodeConversion(code1.id);
+
+    // Low-performing verified agent
+    updateAgentTrustTier(a2.id, "verified");
+    const code2 = submitReferralCode({
+      vendor: "Railway",
+      code: "LOW1",
+      referral_url: "https://railway.app?ref=low1",
+      description: "Low performer",
+      agent_id: a2.id,
+      trust_tier: "verified",
+    });
+    for (let i = 0; i < 50; i++) recordImpression(code2.id);
+    for (let i = 0; i < 1; i++) recordCodeConversion(code2.id);
+
+    const ranked = getRankedCodesForVendor("Railway");
+    assert.strictEqual(ranked.length, 2);
+    // High performer should be first
+    assert.strictEqual(ranked[0].code, "HIGH1");
+    assert.strictEqual(ranked[1].code, "LOW1");
+  });
+
+  it("cold start codes appear before performance-ranked codes", () => {
+    const { agent: a1 } = createTestAgent("EstBot");
+    updateAgentTrustTier(a1.id, "trusted");
+    const { agent: a2 } = createTestAgent("NewBot");
+
+    // Established code past cold start
+    const code1 = submitReferralCode({
+      vendor: "Railway",
+      code: "EST1",
+      referral_url: "https://railway.app?ref=est1",
+      description: "Established",
+      agent_id: a1.id,
+      trust_tier: "trusted",
+    });
+    for (let i = 0; i < 50; i++) recordImpression(code1.id);
+
+    // New code in cold start (verified so it's active)
+    updateAgentTrustTier(a2.id, "verified");
+    const code2 = submitReferralCode({
+      vendor: "Railway",
+      code: "NEW1",
+      referral_url: "https://railway.app?ref=new1",
+      description: "Cold start",
+      agent_id: a2.id,
+      trust_tier: "verified",
+    });
+
+    const ranked = getRankedCodesForVendor("Railway");
+    assert.strictEqual(ranked.length, 2);
+    // Cold start code first
+    assert.strictEqual(ranked[0].code, "NEW1");
+    assert.strictEqual(ranked[1].code, "EST1");
+  });
+
+  it("records impressions and conversions", () => {
+    const { agent } = createTestAgent("ImprBot");
+    const code = submitReferralCode({
+      vendor: "Railway",
+      code: "IMPR1",
+      referral_url: "https://railway.app?ref=impr1",
+      description: "Test",
+      agent_id: agent.id,
+      trust_tier: "new",
+    });
+
+    assert.strictEqual(code.impressions, 0);
+    assert.strictEqual(code.conversions, 0);
+
+    recordImpression(code.id);
+    recordImpression(code.id);
+    recordCodeConversion(code.id);
+
+    const codes = getCodesByAgent(agent.id);
+    const updated = codes.find((c: any) => c.id === code.id);
+    assert.strictEqual(updated.impressions, 2);
+    assert.strictEqual(updated.conversions, 1);
+  });
+});
+
+describe("Dual-Agent Revenue Split", () => {
+  before(() => saveOriginals());
+  after(() => restoreOriginals());
+  beforeEach(() => resetFiles());
+
+  it("applies 80/20 split when same agent submitted and surfaced", () => {
+    const { agent } = createTestAgent("SameBot");
+    // Log a referral request so attribution finds this agent
+    logReferralRequest({ vendor: "Railway", agent_id: agent.id });
+
+    const entry = recordConversion({
+      vendor: "Railway",
+      referral_code: "SAME1",
+      commission_amount: 100,
+      submitter_id: agent.id,
+    });
+
+    // Same agent: 80% to agent, 20% platform
+    assert.strictEqual(entry.agent_share, 80);
+    assert.strictEqual(entry.submitter_share, 0); // no separate submitter share since same agent
+    assert.strictEqual(entry.agent_id, agent.id);
+    assert.strictEqual(entry.submitter_id, agent.id);
+
+    const balance = getAgentBalance(agent.id);
+    assert.strictEqual(balance.pending_balance, 80);
+  });
+
+  it("applies 40/40/20 split when different agents", () => {
+    const { agent: submitter } = createTestAgent("SubmitBot");
+    const { agent: surfer } = createTestAgent("SurfBot");
+
+    // Log a referral request for the surfacing agent
+    logReferralRequest({ vendor: "Railway", agent_id: surfer.id });
+
+    const entry = recordConversion({
+      vendor: "Railway",
+      referral_code: "DUAL1",
+      commission_amount: 100,
+      submitter_id: submitter.id,
+    });
+
+    // Different agents: 40% surfer, 40% submitter, 20% platform
+    assert.strictEqual(entry.agent_share, 40);
+    assert.strictEqual(entry.submitter_share, 40);
+    assert.strictEqual(entry.agent_id, surfer.id);
+    assert.strictEqual(entry.submitter_id, submitter.id);
+
+    const surferBalance = getAgentBalance(surfer.id);
+    assert.strictEqual(surferBalance.pending_balance, 40);
+
+    const submitterBalance = getAgentBalance(submitter.id);
+    assert.strictEqual(submitterBalance.pending_balance, 40);
+  });
+
+  it("applies standard 70/30 split for curated codes (no submitter)", () => {
+    const { agent } = createTestAgent("CuratedBot");
+    logReferralRequest({ vendor: "Railway", agent_id: agent.id });
+
+    const entry = recordConversion({
+      vendor: "Railway",
+      referral_code: "CURATED1",
+      commission_amount: 100,
+    });
+
+    // Curated: 70% to surfer, 30% platform
+    assert.strictEqual(entry.agent_share, 70);
+    assert.strictEqual(entry.submitter_share, 0);
+
+    const balance = getAgentBalance(agent.id);
+    assert.strictEqual(balance.pending_balance, 70);
+  });
+
+  it("gives submitter 40% when no surfacing agent exists", () => {
+    const { agent: submitter } = createTestAgent("LoneSubmitter");
+
+    const entry = recordConversion({
+      vendor: "Railway",
+      referral_code: "LONE1",
+      commission_amount: 100,
+      submitter_id: submitter.id,
+    });
+
+    assert.strictEqual(entry.agent_id, null);
+    assert.strictEqual(entry.agent_share, 0);
+    assert.strictEqual(entry.submitter_share, 40);
+
+    const balance = getAgentBalance(submitter.id);
+    assert.strictEqual(balance.pending_balance, 40);
+  });
+});
+
+describe("Agent Leaderboard", () => {
+  before(() => saveOriginals());
+  after(() => restoreOriginals());
+  beforeEach(() => resetFiles());
+
+  it("returns agents ranked by total conversions", () => {
+    const { agent: a1 } = createTestAgent("TopAgent");
+    const { agent: a2 } = createTestAgent("MidAgent");
+
+    // a1 gets 3 conversions via referral requests
+    for (let i = 0; i < 3; i++) {
+      logReferralRequest({ vendor: "Railway", agent_id: a1.id });
+      recordConversion({ vendor: "Railway", referral_code: "TOP", commission_amount: 50 });
+    }
+
+    // a2 gets 1 conversion
+    logReferralRequest({ vendor: "Vercel", agent_id: a2.id });
+    recordConversion({ vendor: "Vercel", referral_code: "MID", commission_amount: 30 });
+
+    const result = getLeaderboard();
+    assert.strictEqual(result.entries.length, 2);
+    assert.strictEqual(result.entries[0].agent_name, "TopAgent");
+    assert.strictEqual(result.entries[0].total_conversions, 3);
+    assert.strictEqual(result.entries[1].agent_name, "MidAgent");
+    assert.strictEqual(result.entries[1].total_conversions, 1);
+  });
+
+  it("respects pagination (limit and offset)", () => {
+    const { agent: a1 } = createTestAgent("First");
+    const { agent: a2 } = createTestAgent("Second");
+    const { agent: a3 } = createTestAgent("Third");
+
+    logReferralRequest({ vendor: "Railway", agent_id: a1.id });
+    recordConversion({ vendor: "Railway", referral_code: "A", commission_amount: 50 });
+    recordConversion({ vendor: "Railway", referral_code: "A", commission_amount: 50 });
+    recordConversion({ vendor: "Railway", referral_code: "A", commission_amount: 50 });
+
+    logReferralRequest({ vendor: "Vercel", agent_id: a2.id });
+    recordConversion({ vendor: "Vercel", referral_code: "B", commission_amount: 30 });
+    recordConversion({ vendor: "Vercel", referral_code: "B", commission_amount: 30 });
+
+    logReferralRequest({ vendor: "Render", agent_id: a3.id });
+    recordConversion({ vendor: "Render", referral_code: "C", commission_amount: 20 });
+
+    const page1 = getLeaderboard({ limit: 2, offset: 0 });
+    assert.strictEqual(page1.entries.length, 2);
+    assert.strictEqual(page1.total, 3);
+    assert.strictEqual(page1.entries[0].agent_name, "First");
+
+    const page2 = getLeaderboard({ limit: 2, offset: 2 });
+    assert.strictEqual(page2.entries.length, 1);
+    assert.strictEqual(page2.entries[0].agent_name, "Third");
+  });
+
+  it("caps limit at 50", () => {
+    const result = getLeaderboard({ limit: 100 });
+    // Should not error, just cap
+    assert.ok(result);
+  });
+
+  it("returns empty leaderboard when no conversions exist", () => {
+    const result = getLeaderboard();
+    assert.strictEqual(result.entries.length, 0);
+    assert.strictEqual(result.total, 0);
+  });
+
+  it("includes active_codes count and earnings", () => {
+    const { agent } = createTestAgent("EarnBot");
+
+    // Submit a code
+    submitReferralCode({
+      vendor: "Railway",
+      code: "EARN1",
+      referral_url: "https://railway.app?ref=earn1",
+      description: "Earnings test",
+      agent_id: agent.id,
+      trust_tier: "verified",
+    });
+
+    // Record conversions
+    logReferralRequest({ vendor: "Railway", agent_id: agent.id });
+    recordConversion({ vendor: "Railway", referral_code: "EARN1", commission_amount: 100 });
+
+    const result = getLeaderboard();
+    assert.strictEqual(result.entries.length, 1);
+    assert.strictEqual(result.entries[0].active_codes, 1);
+    assert.ok(result.entries[0].total_earnings > 0);
+  });
+
+  it("excludes clawed-back conversions from count", () => {
+    const { agent } = createTestAgent("ClawBot");
+    logReferralRequest({ vendor: "Railway", agent_id: agent.id });
+
+    const entry = recordConversion({ vendor: "Railway", referral_code: "CLAW", commission_amount: 50 });
+
+    // Clawback that entry
+    clawbackEntry(entry.id);
+
+    // Record one more valid conversion
+    recordConversion({ vendor: "Railway", referral_code: "VALID", commission_amount: 50 });
+
+    const result = getLeaderboard();
+    // Clawed back one shouldn't count
+    assert.strictEqual(result.entries[0].total_conversions, 1);
+  });
+});
+
+describe("Leaderboard includes submitter conversions", () => {
+  before(() => saveOriginals());
+  after(() => restoreOriginals());
+  beforeEach(() => resetFiles());
+
+  it("counts submitter contributions in leaderboard", () => {
+    const { agent: submitter } = createTestAgent("CodeSubmitter");
+    const { agent: surfer } = createTestAgent("CodeSurfer");
+
+    logReferralRequest({ vendor: "Railway", agent_id: surfer.id });
+    recordConversion({
+      vendor: "Railway",
+      referral_code: "DUAL",
+      commission_amount: 100,
+      submitter_id: submitter.id,
+    });
+
+    const result = getLeaderboard();
+    // Both agents should appear
+    assert.strictEqual(result.total, 2);
+    const submitterEntry = result.entries.find((e: any) => e.agent_name === "CodeSubmitter");
+    const surferEntry = result.entries.find((e: any) => e.agent_name === "CodeSurfer");
+    assert.ok(submitterEntry);
+    assert.ok(surferEntry);
+    assert.strictEqual(submitterEntry.total_conversions, 1);
+    assert.strictEqual(surferEntry.total_conversions, 1);
+  });
+});


### PR DESCRIPTION
## Summary

Refs #735

- **Ranking algorithm**: `score = trust_weight × conversion_rate × recency_factor` with trust weights (new=1.0, verified=1.5, trusted=2.0), min 10 impressions before rate kicks in, recency decay of 5%/week after 7 days (floor 0.5)
- **Cold start**: New codes get 50-impression trial period with equal distribution (sorted by fewest impressions); after 50 impressions, performance-based ranking takes over
- **Leaderboard**: `GET /api/leaderboard` (public, paginated, default 10, max 50) + `leaderboard` MCP tool. Returns agent name, trust tier, total conversions, active codes, total earnings
- **Dual-agent revenue split**: Same agent submitted AND surfaced = 80/20; different agents = 40/40/20 (submitter/surfer/platform); curated codes = 70/30 (unchanged)
- **Disclosure page**: New section explaining agent-submitted codes, ranking, trust tiers, and revenue splits
- **Impression/conversion tracking**: `recordImpression()` and `recordCodeConversion()` functions for submitted code stats

### Files changed
- `src/referral-codes.ts`: ranking algorithm, cold start, impression/conversion tracking, `getRankedCodesForVendor()`
- `src/ledger.ts`: dual-agent splits (`submitter_id`, `submitter_share`), `getLeaderboard()`
- `src/server.ts`: MCP leaderboard tool, ranked code output in search
- `src/serve.ts`: HTTP leaderboard endpoint, ranked codes in search, disclosure page update
- `test/ranking-leaderboard.test.ts`: 18 new tests

### Stats
- 18 new tests, 677 total passing (was 637)
- All acceptance criteria met