### PR TITLE
Replace PLACEHOLDER referral codes with real Railway + Proton links

### DIFF
--- a/data/index.json
+++ b/data/index.json
@@ -108,8 +108,8 @@
       ],
       "verifiedDate": "2026-04-02",
       "referral": {
-        "code": "PLACEHOLDER",
-        "url": "https://railway.app?referralCode=PLACEHOLDER",
+        "code": "7RZL9q",
+        "url": "https://railway.com?referralCode=7RZL9q",
         "referee_value": "$20 in Railway credits",
         "referrer_value": "15% commission on first 12 months",
         "type": "dual-sided",
@@ -11484,7 +11484,16 @@
         "email",
         "free-for-dev"
       ],
-      "verifiedDate": "2026-03-20"
+      "verifiedDate": "2026-03-20",
+      "referral": {
+        "url": "https://pr.tn/ref/60QXGJSB",
+        "type": "referral_link",
+        "source": "curated",
+        "submitted_by": null,
+        "verified_date": "2026-04-12",
+        "restrictions": [],
+        "phase1_eligible": true
+      }
     },
     {
       "vendor": "Sendpulse",

--- a/test/referral-attribution.test.ts
+++ b/test/referral-attribution.test.ts
@@ -36,14 +36,14 @@ describe("Referral Request Logging", () => {
     const req = logReferralRequest({
       agent_id: "agent_abc123",
       vendor: "Railway",
-      referral_code: "PLACEHOLDER",
-      referral_url: "https://railway.app?referralCode=PLACEHOLDER",
+      referral_code: "7RZL9q",
+      referral_url: "https://railway.com?referralCode=7RZL9q",
     });
     assert.ok(req.id.startsWith("rr_"));
     assert.strictEqual(req.agent_id, "agent_abc123");
     assert.strictEqual(req.vendor, "Railway");
-    assert.strictEqual(req.referral_code, "PLACEHOLDER");
-    assert.strictEqual(req.referral_url, "https://railway.app?referralCode=PLACEHOLDER");
+    assert.strictEqual(req.referral_code, "7RZL9q");
+    assert.strictEqual(req.referral_url, "https://railway.com?referralCode=7RZL9q");
     assert.ok(req.requested_at);
     assert.strictEqual(req.conversion_id, null);
   });
@@ -52,8 +52,8 @@ describe("Referral Request Logging", () => {
     logReferralRequest({
       agent_id: "agent_abc123",
       vendor: "Railway",
-      referral_code: "PLACEHOLDER",
-      referral_url: "https://railway.app?referralCode=PLACEHOLDER",
+      referral_code: "7RZL9q",
+      referral_url: "https://railway.com?referralCode=7RZL9q",
     });
     resetReferralRequestsCache();
     const raw = JSON.parse(fs.readFileSync(REQUESTS_PATH, "utf-8"));


### PR DESCRIPTION
## Summary
- Railway referral code updated from `PLACEHOLDER` to `7RZL9q`, domain corrected from `railway.app` to `railway.com`
- Proton Mail referral link added: `https://pr.tn/ref/60QXGJSB`
- Test assertions updated with real codes

## Verification
- Data validation passes (1644 offers)
- Referral attribution tests pass (19/19)
- E2E verified: `/api/referral/Railway` returns `7RZL9q`, `/api/referral/Proton Mail` returns the `pr.tn` link

Refs #739