### PR TITLE
Add referral program directory page and vendor metadata

### DIFF
--- a/data/index.json
+++ b/data/index.json
@@ -119,6 +119,13 @@
         "verified_date": "2026-04-11",
         "restrictions": [],
         "phase1_eligible": true
+      },
+      "referral_program": {
+        "available": true,
+        "referrer_benefit": "15% commission (first 12 months)",
+        "referee_benefit": "$20 in credits",
+        "program_url": "https://railway.com/affiliate-program",
+        "type": "self-service"
       }
     },
     {
@@ -246,6 +253,13 @@
         "static_sites": "3 apps, 1 GiB outbound/mo each",
         "functions": "25,000 GiB-seconds/mo",
         "droplets_from": "$4/mo (1 vCPU, 512 MB, 10 GB SSD)"
+      },
+      "referral_program": {
+        "available": true,
+        "referrer_benefit": "$25 credit",
+        "referee_benefit": "$200 credit (60 days)",
+        "program_url": "https://www.digitalocean.com/referral-program",
+        "type": "self-service"
       }
     },
     {
@@ -299,7 +313,14 @@
         "mongodb-alternative",
         "vector-database"
       ],
-      "verifiedDate": "2026-03-21"
+      "verifiedDate": "2026-03-21",
+      "referral_program": {
+        "available": true,
+        "referrer_benefit": "$20 cash per referral",
+        "referee_benefit": "Free tier access",
+        "program_url": "https://neon.tech/docs/introduction/referral-program",
+        "type": "self-service"
+      }
     },
     {
       "vendor": "MongoDB Atlas",
@@ -842,7 +863,14 @@
         "free tier",
         "email-service-alternative"
       ],
-      "verifiedDate": "2026-04-12"
+      "verifiedDate": "2026-04-12",
+      "referral_program": {
+        "available": true,
+        "referrer_benefit": "20% recurring commission (12 months)",
+        "referee_benefit": "Standard pricing",
+        "program_url": "https://postmarkapp.com/partner-program",
+        "type": "affiliate-network"
+      }
     },
     {
       "vendor": "Mailchimp",
@@ -890,7 +918,14 @@
         "free tier",
         "email-service-alternative"
       ],
-      "verifiedDate": "2026-04-12"
+      "verifiedDate": "2026-04-12",
+      "referral_program": {
+        "available": true,
+        "referrer_benefit": "~$5 per free signup, ~$100 per paid signup",
+        "referee_benefit": "Standard pricing",
+        "program_url": "https://www.brevo.com/partners/",
+        "type": "affiliate-network"
+      }
     },
     {
       "vendor": "Algolia",
@@ -938,7 +973,14 @@
         "backup",
         "free tier"
       ],
-      "verifiedDate": "2026-04-12"
+      "verifiedDate": "2026-04-12",
+      "referral_program": {
+        "available": true,
+        "referrer_benefit": "1 free month per referral",
+        "referee_benefit": "1 free month",
+        "program_url": "https://www.backblaze.com/cloud-storage/refer-a-friend",
+        "type": "self-service"
+      }
     },
     {
       "vendor": "Tigris",
@@ -1268,7 +1310,14 @@
         "budget",
         "eu"
       ],
-      "verifiedDate": "2026-04-12"
+      "verifiedDate": "2026-04-12",
+      "referral_program": {
+        "available": true,
+        "referrer_benefit": "€10 credit",
+        "referee_benefit": "€20 credit",
+        "program_url": "https://www.hetzner.com/tell-a-friend",
+        "type": "self-service"
+      }
     },
     {
       "vendor": "Cloudflare DNS",
@@ -2595,7 +2644,14 @@
         ],
         "program": "DigitalOcean Hatch"
       },
-      "expires_date": "2026-06-30"
+      "expires_date": "2026-06-30",
+      "referral_program": {
+        "available": true,
+        "referrer_benefit": "$25 credit",
+        "referee_benefit": "$200 credit (60 days)",
+        "program_url": "https://www.digitalocean.com/referral-program",
+        "type": "self-service"
+      }
     },
     {
       "vendor": "Atlassian",
@@ -7810,7 +7866,14 @@
         "developer-tools",
         "free-for-dev"
       ],
-      "verifiedDate": "2026-04-12"
+      "verifiedDate": "2026-04-12",
+      "referral_program": {
+        "available": true,
+        "referrer_benefit": "Free months of service",
+        "referee_benefit": "Free months of service",
+        "program_url": "https://proton.me/support/referral-program",
+        "type": "self-service"
+      }
     },
     {
       "vendor": "Pullflow",
@@ -11356,6 +11419,13 @@
         "verified_date": "2026-04-12",
         "restrictions": [],
         "phase1_eligible": true
+      },
+      "referral_program": {
+        "available": true,
+        "referrer_benefit": "Free months of service",
+        "referee_benefit": "Free months of service",
+        "program_url": "https://proton.me/support/referral-program",
+        "type": "self-service"
       }
     },
     {
@@ -14392,7 +14462,14 @@
         "media",
         "free-for-dev"
       ],
-      "verifiedDate": "2026-04-12"
+      "verifiedDate": "2026-04-12",
+      "referral_program": {
+        "available": true,
+        "referrer_benefit": "Free months of service",
+        "referee_benefit": "Free months of service",
+        "program_url": "https://proton.me/support/referral-program",
+        "type": "self-service"
+      }
     },
     {
       "vendor": "QRME.SH",
@@ -20388,7 +20465,14 @@
         "anycast",
         "dnssec"
       ],
-      "verifiedDate": "2026-04-13"
+      "verifiedDate": "2026-04-13",
+      "referral_program": {
+        "available": true,
+        "referrer_benefit": "Up to $100 cash per referral",
+        "referee_benefit": "$100 credit",
+        "program_url": "https://www.vultr.com/docs/vultr-referral-program/",
+        "type": "self-service"
+      }
     },
     {
       "vendor": "Hetzner DNS",
@@ -21582,7 +21666,14 @@
         "consumer",
         "free-tier"
       ],
-      "verifiedDate": "2026-04-02"
+      "verifiedDate": "2026-04-02",
+      "referral_program": {
+        "available": true,
+        "referrer_benefit": "Free months of service",
+        "referee_benefit": "Free months of service",
+        "program_url": "https://proton.me/support/referral-program",
+        "type": "self-service"
+      }
     },
     {
       "vendor": "Apple Passwords",
@@ -21972,7 +22063,14 @@
         "consumer",
         "free-tier"
       ],
-      "verifiedDate": "2026-04-02"
+      "verifiedDate": "2026-04-02",
+      "referral_program": {
+        "available": true,
+        "referrer_benefit": "Free months of service",
+        "referee_benefit": "Free months of service",
+        "program_url": "https://proton.me/support/referral-program",
+        "type": "self-service"
+      }
     },
     {
       "vendor": "Windscribe",
@@ -22119,7 +22217,14 @@
         "consumer",
         "free-tier"
       ],
-      "verifiedDate": "2026-04-02"
+      "verifiedDate": "2026-04-02",
+      "referral_program": {
+        "available": true,
+        "referrer_benefit": "Free months of service",
+        "referee_benefit": "Free months of service",
+        "program_url": "https://proton.me/support/referral-program",
+        "type": "self-service"
+      }
     },
     {
       "vendor": "Tutanota",

--- a/src/serve.ts
+++ b/src/serve.ts
@@ -2900,6 +2900,21 @@ ${enrichedAlts.map(a => {
     <span style="display:block;font-size:.75rem;margin-top:.25rem;color:var(--text-muted)"><a href="/disclosure" style="color:var(--text-muted)">Affiliate disclosure</a></span>
   </div>` : "";
 
+  // Referral program section (shown when vendor has a program, whether or not we have a code)
+  const referralProgramHtml = primary.referral_program?.available ? `
+  <div class="section" style="margin-top:1.5rem">
+    <h2>Referral Program</h2>
+    <div style="border:1px solid var(--border);border-radius:8px;padding:1rem;background:var(--bg-card)">
+      <div style="display:grid;grid-template-columns:1fr 1fr;gap:.75rem;margin-bottom:.75rem">
+        <div><span style="font-size:.7rem;text-transform:uppercase;letter-spacing:.08em;color:var(--text-dim);font-family:var(--mono)">You Earn</span><div style="font-size:.9rem;color:var(--text);margin-top:.25rem">${escHtmlServer(primary.referral_program.referrer_benefit)}</div></div>
+        <div><span style="font-size:.7rem;text-transform:uppercase;letter-spacing:.08em;color:var(--text-dim);font-family:var(--mono)">They Get</span><div style="font-size:.9rem;color:var(--text);margin-top:.25rem">${escHtmlServer(primary.referral_program.referee_benefit)}</div></div>
+      </div>
+      <div style="display:flex;gap:.75rem;flex-wrap:wrap;font-size:.85rem">
+        <a href="${escHtmlServer(primary.referral_program.program_url)}" rel="noopener" target="_blank">View program details &rarr;</a>${!primary.referral ? `<span style="color:var(--text-dim)">&middot;</span><a href="/marketplace">Submit your referral code</a>` : ""}
+      </div>
+    </div>
+  </div>` : "";
+
   // Alternatives HTML
   const alternativesHtml = alternatives.length > 0 ? `
   <div class="section">
@@ -3176,6 +3191,7 @@ ${growthPathHtml}
   </div>
 ${alternativesHtml}
 ${comparisonsHtml}
+${referralProgramHtml}
 ${internalLinksHtml}
   <div class="section mcp-section">
     <h2>Query via MCP</h2>
@@ -47190,6 +47206,212 @@ ${bundleHtml}
 </html>`;
 }
 
+// --- Referral Programs directory page ---
+
+function buildReferralProgramsPage(): string {
+  // Collect unique vendors with referral_program metadata
+  const seen = new Set<string>();
+  const programVendors: { vendor: string; category: string; referrer_benefit: string; referee_benefit: string; program_url: string; type: string; hasCode: boolean; referralUrl?: string; refereeValue?: string }[] = [];
+  for (const o of offers) {
+    if (o.referral_program?.available && !seen.has(o.vendor)) {
+      seen.add(o.vendor);
+      programVendors.push({
+        vendor: o.vendor,
+        category: o.category,
+        referrer_benefit: o.referral_program.referrer_benefit,
+        referee_benefit: o.referral_program.referee_benefit,
+        program_url: o.referral_program.program_url,
+        type: o.referral_program.type,
+        hasCode: !!o.referral,
+        referralUrl: o.referral?.url,
+        refereeValue: o.referral?.referee_value,
+      });
+    }
+  }
+  // Sort: vendors with our codes first, then alphabetical
+  programVendors.sort((a, b) => {
+    if (a.hasCode !== b.hasCode) return a.hasCode ? -1 : 1;
+    return a.vendor.localeCompare(b.vendor);
+  });
+
+  const withCodes = programVendors.filter(v => v.hasCode).length;
+  const withoutCodes = programVendors.length - withCodes;
+
+  const title = "Developer Tool Referral Programs — AgentDeals";
+  const metaDesc = `${programVendors.length} developer tools with self-service referral programs. Earn credits and commissions by referring other developers to cloud, email, database, and infrastructure tools.`;
+
+  const jsonLd = {
+    "@context": "https://schema.org",
+    "@type": "ItemList",
+    name: title,
+    description: metaDesc,
+    numberOfItems: programVendors.length,
+    url: `${BASE_URL}/referral-programs`,
+    itemListElement: programVendors.map((v, i) => ({
+      "@type": "ListItem",
+      position: i + 1,
+      item: {
+        "@type": "Product",
+        name: `${v.vendor} Referral Program`,
+        description: `Refer developers to ${v.vendor}. You get: ${v.referrer_benefit}. They get: ${v.referee_benefit}.`,
+        url: `${BASE_URL}/vendor/${toSlug(v.vendor)}`,
+      },
+    })),
+  };
+
+  const faqLd = {
+    "@context": "https://schema.org",
+    "@type": "FAQPage",
+    mainEntity: [
+      {
+        "@type": "Question",
+        name: "Which developer tools have referral programs?",
+        acceptedAnswer: { "@type": "Answer", text: `We track ${programVendors.length} developer tools with active referral programs, including ${programVendors.slice(0, 5).map(v => v.vendor).join(", ")}, and more. These programs let you earn credits, cash, or commissions by referring other developers.` },
+      },
+      {
+        "@type": "Question",
+        name: "How do I earn money from developer tool referrals?",
+        acceptedAnswer: { "@type": "Answer", text: "Sign up for a vendor's referral program, get your referral link, and share it. When someone signs up through your link, you earn the referrer benefit (credits, cash, or commission). You can also submit your referral codes to our marketplace for broader distribution." },
+      },
+    ],
+  };
+
+  const tableRows = programVendors.map(v => {
+    const vendorSlug = toSlug(v.vendor);
+    const statusHtml = v.hasCode
+      ? `<a href="${escHtmlServer(v.referralUrl!)}" rel="noopener sponsored" target="_blank" class="status-badge status-active">Use our code</a>`
+      : `<a href="/marketplace" class="status-badge status-submit">Submit a code</a>`;
+    const typeLabel = v.type === "self-service" ? "Self-service" : v.type === "affiliate-network" ? "Affiliate network" : "Application";
+    return `      <tr>
+        <td><a href="/vendor/${vendorSlug}" class="vendor-link">${escHtmlServer(v.vendor)}</a></td>
+        <td class="cat-cell">${escHtmlServer(v.category)}</td>
+        <td class="benefit-cell">${escHtmlServer(v.referee_benefit)}</td>
+        <td class="benefit-cell">${escHtmlServer(v.referrer_benefit)}</td>
+        <td class="type-cell">${typeLabel}</td>
+        <td class="status-cell">${statusHtml}</td>
+      </tr>`;
+  }).join("\n");
+
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>${escHtmlServer(title)}</title>
+<meta name="description" content="${escHtmlServer(metaDesc)}">
+<link rel="canonical" href="${BASE_URL}/referral-programs">
+<meta property="og:title" content="${escHtmlServer(title)}">
+<meta property="og:description" content="${escHtmlServer(metaDesc)}">
+<meta property="og:type" content="website">
+<meta property="og:url" content="${BASE_URL}/referral-programs">
+${OG_IMAGE_META}${GOOGLE_VERIFICATION_META}<link rel="icon" type="image/png" href="/favicon.png">
+<link rel="preconnect" href="https://fonts.googleapis.com"><link rel="preconnect" href="https://fonts.gstatic.com" crossorigin><link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
+<script type="application/ld+json">${JSON.stringify(jsonLd)}</script>
+<script type="application/ld+json">${JSON.stringify(faqLd)}</script>
+<style>
+*{margin:0;padding:0;box-sizing:border-box}
+:root{--bg:#0f172a;--bg-elevated:#1e293b;--bg-card:rgba(255,255,255,0.06);--border:#334155;--border-hover:#3b82f6;--text:#f1f5f9;--text-muted:#94a3b8;--text-dim:#64748b;--accent:#3b82f6;--accent-hover:#60a5fa;--accent-glow:rgba(59,130,246,0.15);--green:#3fb950;--green-glow:rgba(63,185,80,0.15);--serif:'Inter',-apple-system,sans-serif;--sans:'Inter',-apple-system,sans-serif;--mono:'JetBrains Mono',SFMono-Regular,monospace}
+body{font-family:var(--sans);background:var(--bg);color:var(--text);line-height:1.6}
+a{color:var(--accent);text-decoration:none}a:hover{color:var(--accent-hover);text-decoration:underline}
+.container{max-width:1100px;margin:0 auto;padding:0 1.5rem}
+.breadcrumb{padding:1.5rem 0 0;font-size:.8rem;color:var(--text-dim)}
+.breadcrumb a{color:var(--text-muted)}
+h1{font-family:var(--serif);font-size:2.25rem;color:var(--text);margin:1rem 0 .5rem;letter-spacing:-.02em}
+.page-intro{color:var(--text-muted);font-size:.95rem;margin-bottom:1.5rem;max-width:720px;line-height:1.7}
+.stats-bar{display:flex;gap:1rem;flex-wrap:wrap;margin-bottom:2rem}
+.stat-card{flex:1;min-width:120px;padding:.75rem 1rem;border:1px solid var(--border);border-radius:8px;background:var(--bg-card);text-align:center}
+.stat-value{font-family:var(--serif);font-size:1.5rem;color:var(--text)}
+.stat-label{font-family:var(--mono);font-size:.65rem;color:var(--text-dim);text-transform:uppercase;letter-spacing:.1em}
+.programs-table{width:100%;border-collapse:collapse;margin-bottom:2rem}
+.programs-table th{text-align:left;padding:.6rem .75rem;font-size:.7rem;text-transform:uppercase;letter-spacing:.08em;color:var(--text-dim);border-bottom:2px solid var(--border);font-family:var(--mono)}
+.programs-table td{padding:.6rem .75rem;border-bottom:1px solid var(--border);font-size:.85rem;vertical-align:middle}
+.programs-table tr:hover{background:var(--bg-card)}
+.vendor-link{color:var(--text);font-weight:600}.vendor-link:hover{color:var(--accent)}
+.cat-cell{color:var(--text-muted);font-size:.8rem}
+.benefit-cell{font-size:.8rem;color:var(--text-muted)}
+.type-cell{font-size:.75rem;color:var(--text-dim);font-family:var(--mono)}
+.status-cell{text-align:center}
+.status-badge{display:inline-block;padding:.2rem .6rem;border-radius:10px;font-size:.7rem;font-weight:600;text-decoration:none}
+.status-active{background:var(--green-glow);color:var(--green);border:1px solid rgba(63,185,80,0.3)}
+.status-active:hover{text-decoration:none;border-color:var(--green)}
+.status-submit{background:var(--accent-glow);color:var(--accent);border:1px solid rgba(59,130,246,0.3)}
+.status-submit:hover{text-decoration:none;border-color:var(--accent)}
+.disclosure{font-size:.8rem;color:var(--text-dim);margin-bottom:2rem;padding:.75rem 1rem;border:1px solid var(--border);border-radius:8px;background:var(--bg-card)}
+.disclosure a{color:var(--text-muted)}
+.faq-section{margin-top:2rem}
+.faq-section h2{font-family:var(--serif);font-size:1.2rem;margin-bottom:1rem}
+.faq-item{margin-bottom:1.25rem}
+.faq-item h3{font-size:.9rem;color:var(--text);margin-bottom:.25rem}
+.faq-item p{font-size:.85rem;color:var(--text-muted);line-height:1.6}
+footer{text-align:center;color:var(--text-dim);font-size:.8rem;padding:3rem 0 2rem;border-top:1px solid var(--border);margin-top:3rem}
+@media(max-width:768px){h1{font-size:1.5rem}.stats-bar{flex-direction:column}.programs-table{display:block;overflow-x:auto}.type-cell{display:none}}
+${globalNavCss()}
+${mcpCtaCss()}
+</style>
+</head>
+<body>
+<div class="container">
+  ${buildGlobalNav("marketplace")}
+  <div class="breadcrumb"><a href="/">AgentDeals</a> &rsaquo; Referral Programs</div>
+  <h1>Developer Tool Referral Programs</h1>
+  <p class="page-intro">${programVendors.length} developer tools with active referral programs. Earn credits, cash, and commissions by referring other developers to infrastructure, email, database, and cloud tools.</p>
+
+  <div class="stats-bar">
+    <div class="stat-card">
+      <div class="stat-value">${programVendors.length}</div>
+      <div class="stat-label">Programs Tracked</div>
+    </div>
+    <div class="stat-card">
+      <div class="stat-value">${withCodes}</div>
+      <div class="stat-label">Our Codes Active</div>
+    </div>
+    <div class="stat-card">
+      <div class="stat-value">${withoutCodes}</div>
+      <div class="stat-label">Accepting Submissions</div>
+    </div>
+  </div>
+
+  <div class="disclosure"><a href="/disclosure">Affiliate disclosure</a>: Links marked "Use our code" are referral links. We may earn a commission at no cost to you.</div>
+
+  <table class="programs-table">
+    <thead>
+      <tr>
+        <th>Vendor</th>
+        <th>Category</th>
+        <th>What You Get</th>
+        <th>What They Get</th>
+        <th>Type</th>
+        <th>Status</th>
+      </tr>
+    </thead>
+    <tbody>
+${tableRows}
+    </tbody>
+  </table>
+
+  <div class="faq-section">
+    <h2>Frequently Asked Questions</h2>
+    <div class="faq-item">
+      <h3>Which developer tools have referral programs?</h3>
+      <p>We track ${programVendors.length} developer tools with active referral programs, including ${programVendors.slice(0, 5).map(v => escHtmlServer(v.vendor)).join(", ")}, and more. These programs let you earn credits, cash, or commissions by referring other developers.</p>
+    </div>
+    <div class="faq-item">
+      <h3>How do I earn money from developer tool referrals?</h3>
+      <p>Sign up for a vendor's referral program, get your referral link, and share it. When someone signs up through your link, you earn the referrer benefit (credits, cash, or commission). You can also <a href="/marketplace">submit your referral codes</a> to our marketplace for broader distribution.</p>
+    </div>
+    <div class="faq-item">
+      <h3>What does "Submit a code" mean?</h3>
+      <p>For vendors where we don't yet have a referral code, you can submit yours through our <a href="/marketplace">agent marketplace</a>. Your code gets ranked by trust tier and conversion performance, and you earn revenue share when it converts.</p>
+    </div>
+  </div>
+
+  ${buildMcpCta("Search referral programs and compare vendor free tiers directly in your AI coding assistant.")}
+  <footer>AgentDeals &mdash; open source, built for agents | <a href="/privacy">Privacy</a></footer>
+</div>
+</body>
+</html>`;
+}
+
 // --- Marketplace onboarding page (public) ---
 
 function buildMarketplacePage(): string {
@@ -49881,6 +50103,12 @@ ${catList}
     <priority>0.7</priority>
   </url>
   <url>
+    <loc>${BASE_URL}/referral-programs</loc>
+    <lastmod>${latestVerified}</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
     <loc>${BASE_URL}/expiring</loc>
     <lastmod>${latestVerified}</lastmod>
     <changefreq>daily</changefreq>
@@ -50234,6 +50462,12 @@ ${Array.from(vendorSlugMap.keys()).map(s => {
     logRequest({ ts: new Date().toISOString(), type: "api", endpoint: "/marketplace", params: {}, user_agent: req.headers["user-agent"] ?? "unknown", result_count: 1 });
     res.writeHead(200, { "Content-Type": "text/html; charset=utf-8", "Cache-Control": "public, max-age=3600" });
     res.end(buildMarketplacePage());
+
+  } else if (url.pathname === "/referral-programs" && isGetOrHead) {
+    recordApiHit("/referral-programs");
+    logRequest({ ts: new Date().toISOString(), type: "api", endpoint: "/referral-programs", params: {}, user_agent: req.headers["user-agent"] ?? "unknown", result_count: 1 });
+    res.writeHead(200, { "Content-Type": "text/html; charset=utf-8", "Cache-Control": "public, max-age=3600" });
+    res.end(buildReferralProgramsPage());
 
   } else if (url.pathname === "/agents/dashboard" && isGetOrHead) {
     const apiKey = url.searchParams.get("key") ?? "";

--- a/src/types.ts
+++ b/src/types.ts
@@ -18,6 +18,14 @@ export interface Referral {
   phase1_eligible: boolean;
 }
 
+export interface ReferralProgram {
+  available: boolean;
+  referrer_benefit: string;
+  referee_benefit: string;
+  program_url: string;
+  type: "self-service" | "application" | "affiliate-network";
+}
+
 export interface Offer {
   vendor: string;
   category: string;
@@ -30,6 +38,7 @@ export interface Offer {
   expires_date?: string;
   payment_protocols?: string[];
   referral?: Referral;
+  referral_program?: ReferralProgram;
 }
 
 export type StabilityClass = "stable" | "watch" | "volatile" | "improving";

--- a/test/referral-programs.test.ts
+++ b/test/referral-programs.test.ts
@@ -1,0 +1,159 @@
+import { describe, it, before, after } from "node:test";
+import assert from "node:assert";
+import { spawn, type ChildProcess } from "node:child_process";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+// Unit tests for referral_program metadata in data
+const { loadOffers } = await import("../dist/data.js");
+const offers = loadOffers();
+
+describe("referral_program metadata", () => {
+  it("at least 10 vendors have referral_program metadata", () => {
+    const seen = new Set<string>();
+    for (const o of offers) {
+      if (o.referral_program?.available) seen.add(o.vendor);
+    }
+    assert.ok(seen.size >= 10, `Expected at least 10 unique vendors with referral_program, got ${seen.size}`);
+  });
+
+  it("referral_program entries have required fields", () => {
+    for (const o of offers) {
+      if (!o.referral_program) continue;
+      assert.ok(typeof o.referral_program.available === "boolean", `${o.vendor}: available must be boolean`);
+      assert.ok(typeof o.referral_program.referrer_benefit === "string" && o.referral_program.referrer_benefit.length > 0, `${o.vendor}: referrer_benefit required`);
+      assert.ok(typeof o.referral_program.referee_benefit === "string" && o.referral_program.referee_benefit.length > 0, `${o.vendor}: referee_benefit required`);
+      assert.ok(typeof o.referral_program.program_url === "string" && o.referral_program.program_url.startsWith("http"), `${o.vendor}: program_url must be valid URL`);
+      assert.ok(["self-service", "application", "affiliate-network"].includes(o.referral_program.type), `${o.vendor}: type must be valid`);
+    }
+  });
+
+  it("Railway has both referral code and referral_program", () => {
+    const railway = offers.find((o: any) => o.vendor === "Railway");
+    assert.ok(railway, "Railway should exist");
+    assert.ok(railway.referral, "Railway should have referral code");
+    assert.ok(railway.referral_program?.available, "Railway should have referral_program");
+  });
+
+  it("DigitalOcean has referral_program but no referral code", () => {
+    const digitalOcean = offers.find((o: any) => o.vendor === "DigitalOcean");
+    assert.ok(digitalOcean, "DigitalOcean should exist");
+    assert.ok(!digitalOcean.referral, "DigitalOcean should not have referral code");
+    assert.ok(digitalOcean.referral_program?.available, "DigitalOcean should have referral_program");
+  });
+
+  it("Vercel has neither referral code nor referral_program", () => {
+    const vercel = offers.find((o: any) => o.vendor === "Vercel");
+    assert.ok(vercel, "Vercel should exist");
+    assert.ok(!vercel.referral, "Vercel should not have referral code");
+    assert.ok(!vercel.referral_program, "Vercel should not have referral_program");
+  });
+});
+
+// HTTP server tests
+let serverPort = 0;
+let serverProc: ChildProcess | null = null;
+
+function startServer(): Promise<ChildProcess> {
+  return new Promise((resolve, reject) => {
+    const serverPath = path.join(__dirname, "..", "dist", "serve.js");
+    const proc = spawn("node", [serverPath], {
+      stdio: ["pipe", "pipe", "pipe"],
+      env: { ...process.env, PORT: "0", BASE_URL: "http://localhost" },
+    });
+
+    const timeout = setTimeout(() => {
+      proc.kill();
+      reject(new Error("Server startup timeout"));
+    }, 10000);
+
+    proc.stderr!.on("data", (data: Buffer) => {
+      const match = data.toString().match(/running on http:\/\/localhost:(\d+)/);
+      if (match) {
+        serverPort = parseInt(match[1], 10);
+        clearTimeout(timeout);
+        resolve(proc);
+      }
+    });
+
+    proc.on("error", (err) => {
+      clearTimeout(timeout);
+      reject(err);
+    });
+  });
+}
+
+describe("referral-programs page", () => {
+  before(async () => {
+    serverProc = await startServer();
+  });
+
+  after(() => {
+    serverProc?.kill();
+  });
+
+  it("GET /referral-programs returns 200", async () => {
+    const res = await fetch(`http://localhost:${serverPort}/referral-programs`);
+    assert.strictEqual(res.status, 200);
+  });
+
+  it("/referral-programs lists vendors with programs", async () => {
+    const res = await fetch(`http://localhost:${serverPort}/referral-programs`);
+    const html = await res.text();
+    assert.ok(html.includes("DigitalOcean"), "Should list DigitalOcean");
+    assert.ok(html.includes("Railway"), "Should list Railway");
+    assert.ok(html.includes("Hetzner"), "Should list Hetzner");
+    assert.ok(html.includes("Neon"), "Should list Neon");
+  });
+
+  it("/referral-programs shows 'Use our code' for vendors with codes", async () => {
+    const res = await fetch(`http://localhost:${serverPort}/referral-programs`);
+    const html = await res.text();
+    assert.ok(html.includes("Use our code"), "Should show 'Use our code' badge");
+  });
+
+  it("/referral-programs shows 'Submit a code' for vendors without codes", async () => {
+    const res = await fetch(`http://localhost:${serverPort}/referral-programs`);
+    const html = await res.text();
+    assert.ok(html.includes("Submit a code"), "Should show 'Submit a code' badge");
+  });
+
+  it("/referral-programs includes affiliate disclosure", async () => {
+    const res = await fetch(`http://localhost:${serverPort}/referral-programs`);
+    const html = await res.text();
+    assert.ok(html.includes("/disclosure"), "Should link to disclosure page");
+    assert.ok(html.includes("Affiliate disclosure"), "Should mention affiliate disclosure");
+  });
+
+  it("/referral-programs has JSON-LD schema", async () => {
+    const res = await fetch(`http://localhost:${serverPort}/referral-programs`);
+    const html = await res.text();
+    assert.ok(html.includes("application/ld+json"), "Should have JSON-LD");
+    assert.ok(html.includes("ItemList"), "Should have ItemList schema");
+    assert.ok(html.includes("FAQPage"), "Should have FAQ schema");
+  });
+
+  it("/vendor/digitalocean shows referral program section", async () => {
+    const res = await fetch(`http://localhost:${serverPort}/vendor/digitalocean`);
+    assert.strictEqual(res.status, 200);
+    const html = await res.text();
+    assert.ok(html.includes("Referral Program"), "Should show Referral Program section");
+    assert.ok(html.includes("$25 credit"), "Should show referrer benefit");
+    assert.ok(html.includes("Submit your referral code"), "Should show submit CTA for vendor without our code");
+  });
+
+  it("/vendor/vercel does not show referral program section", async () => {
+    const res = await fetch(`http://localhost:${serverPort}/vendor/vercel`);
+    assert.strictEqual(res.status, 200);
+    const html = await res.text();
+    assert.ok(!html.includes("Referral Program</h2>"), "Vercel should not show referral program section");
+  });
+
+  it("/sitemap.xml includes /referral-programs", async () => {
+    const res = await fetch(`http://localhost:${serverPort}/sitemap.xml`);
+    const xml = await res.text();
+    assert.ok(xml.includes("/referral-programs"), "Sitemap should include referral-programs page");
+  });
+});


### PR DESCRIPTION
## Summary

- Added `referral_program` metadata to 12 unique vendors (15 index entries) with active self-service referral programs
- Built `/referral-programs` directory page listing all vendors with programs, with "Use our code" / "Submit a code" CTAs
- Enhanced vendor detail pages with "Referral Program" section showing benefits and program links
- Added to sitemap, includes JSON-LD and FAQ schema for SEO

## Vendors with referral_program metadata

| Vendor | Category | Has Our Code |
|--------|----------|-------------|
| Railway | Cloud Hosting | Yes |
| Proton Mail | Email | Yes |
| DigitalOcean | Cloud IaaS | No |
| Hetzner | Infrastructure | No |
| Neon | Databases | No |
| Postmark | Email | No |
| Brevo | Email | No |
| Backblaze B2 | Storage | No |
| Vultr DNS | DNS | No |
| Proton Pass | Security / Password Managers | No |
| Proton Drive | Storage | No |
| Proton VPN | VPN & Privacy | No |

## Test plan

- [x] 14 new tests pass (694 total, 0 failures)
- [x] `/referral-programs` returns 200 with all vendors listed
- [x] "Use our code" shown for Railway/Proton, "Submit a code" for rest
- [x] `/vendor/digitalocean` shows Referral Program section with benefits
- [x] `/vendor/vercel` (no program) renders without referral section
- [x] JSON-LD and FAQ schema included
- [x] Sitemap includes `/referral-programs`
- [x] Affiliate disclosure linked

Refs #749