### PR TITLE
Kiro credits model, Claude Code policy changes, Kiro startup program

### DIFF
--- a/data/deal_changes.json
+++ b/data/deal_changes.json
@@ -1286,7 +1286,7 @@
       "vendor": "Amazon Kiro",
       "change_type": "new_free_tier",
       "date": "2026-04-07",
-      "summary": "Amazon Kiro AI coding assistant launched GA with tiered credit-based pricing: Free tier (50 credits/month), Pro ($20/month, 1,000 credits), Pro+ ($40/month, 2,000 credits). Credits consumed per AI interaction (specs, code generation, debugging)",
+      "summary": "Amazon Kiro AI coding assistant launched GA with tiered credit-based pricing: Free tier (50 credits/month), Pro ($20/month, 1,000 credits), Pro+ ($40/month, 2,000 credits). Credits metered to 0.01 increments, model-dependent rates.",
       "previous_state": "Preview-only access, no public pricing",
       "current_state": "Free tier: 50 credits/month. Pro: $20/month (1,000 credits). Pro+: $40/month (2,000 credits). GA availability",
       "impact": "medium",
@@ -1402,9 +1402,9 @@
       "vendor": "Amazon Kiro",
       "change_type": "new_free_tier",
       "date": "2026-04-09",
-      "summary": "Amazon Kiro launched GA with a free tier of 50 interactions/month. Claude-powered IDE focused on spec-driven development. Pro $20/mo (1,000 interactions), Pro+ $40/mo (2,000), Power $200/mo (10,000). Competes directly with Cursor, GitHub Copilot, and Windsurf.",
+      "summary": "Amazon Kiro launched GA with a free tier of 50 credits/month. Claude-powered IDE focused on spec-driven development. Pro $20/mo (1,000 credits), Pro+ $40/mo (2,000), Power $200/mo (10,000). Credits metered to 0.01 increments, model-dependent rates. $0.04 overage per credit. Enterprise tier available.",
       "previous_state": "Preview/beta with limited access",
-      "current_state": "GA with free tier (50 interactions/mo). Four paid tiers: Pro ($20), Pro+ ($40), Power ($200)",
+      "current_state": "GA with free tier (50 credits/mo). Four paid tiers: Pro ($20), Pro+ ($40), Power ($200). Enterprise: custom pricing",
       "impact": "high",
       "source_url": "https://kiro.dev/pricing",
       "category": "AI Coding",
@@ -3495,6 +3495,56 @@
       "source_url": "",
       "category": "Workflow Automation",
       "alternatives": []
+    },
+    {
+      "vendor": "Claude Code",
+      "change_type": "pricing_restructured",
+      "date": "2026-04-04",
+      "summary": "Three material policy changes: (1) Third-party tool restrictions — external tools like OpenClaw now billed separately on pay-as-you-go, can no longer apply standard usage limits. (2) Extra usage option — all paid plans (Pro, Max 5x, Max 20x) have pay-as-you-go overage at standard API rates. (3) Peak-hour throttling (acknowledged March 31) — 5-hour session limits reduced during weekdays 5 AM–11 AM Pacific.",
+      "previous_state": "Flat subscription pricing with included usage limits. Third-party tools shared standard limits. No overage option.",
+      "current_state": "Subscription + pay-as-you-go overage. Third-party tools billed separately. Peak-hour throttling during weekday mornings.",
+      "impact": "high",
+      "source_url": "https://docs.anthropic.com/en/docs/claude-code/overview",
+      "category": "AI Coding",
+      "alternatives": [
+        "Cursor",
+        "GitHub Copilot",
+        "Amazon Kiro",
+        "Windsurf"
+      ]
+    },
+    {
+      "vendor": "Amazon Kiro",
+      "change_type": "pricing_restructured",
+      "date": "2026-04-13",
+      "summary": "Kiro pricing model clarified: uses credits (not interactions). Credits metered to 0.01 increments, model-dependent rates (Sonnet 4 costs 1.3x more than Auto). $0.04/credit overage (disabled by default). 500 bonus credits for new users (30 days). Enterprise tier with SAML/SCIM SSO. GovCloud ~20% premium, no free tier in GovCloud.",
+      "previous_state": "GA pricing listed as interaction-based",
+      "current_state": "Credit-based pricing with 0.01 granularity. Enterprise tier. GovCloud availability at premium.",
+      "impact": "medium",
+      "source_url": "https://kiro.dev/pricing",
+      "category": "AI Coding",
+      "alternatives": [
+        "Cursor",
+        "GitHub Copilot",
+        "Windsurf",
+        "Claude Code"
+      ]
+    },
+    {
+      "vendor": "Amazon Kiro (AWS Startups)",
+      "change_type": "new_free_tier",
+      "date": "2026-04-13",
+      "summary": "AWS Startups offers up to 1 year of free Kiro Pro+ (worth $480/year). Three tiers: Starter (up to 2 users), Growth (up to 50 users), Scale (up to 100 users). Eligible: early-stage to Series B companies.",
+      "previous_state": "No startup program for Kiro",
+      "current_state": "Up to 1 year free Kiro Pro+ via AWS Startups, up to 100 users",
+      "impact": "medium",
+      "source_url": "https://aws.amazon.com/startups/",
+      "category": "Startup Programs",
+      "alternatives": [
+        "GitHub Copilot",
+        "Cursor",
+        "Windsurf"
+      ]
     }
   ]
 }

--- a/data/index.json
+++ b/data/index.json
@@ -3325,6 +3325,32 @@
       "expires_date": "2026-08-31"
     },
     {
+      "vendor": "Amazon Kiro (AWS Startups)",
+      "category": "Startup Programs",
+      "description": "Up to 1 year of free Kiro Pro+ (worth $480/year) through AWS Startups program. Three tiers: Starter (up to 2 users), Growth (up to 50 users), Scale (up to 100 users). Eligible: early-stage to Series B companies. Application via AWS Startups portal.",
+      "tier": "Startup Program",
+      "url": "https://aws.amazon.com/startups/",
+      "tags": [
+        "ai",
+        "coding",
+        "ide",
+        "startup credits",
+        "aws",
+        "kiro"
+      ],
+      "verifiedDate": "2026-04-13",
+      "eligibility": {
+        "type": "startup",
+        "conditions": [
+          "Early-stage to Series B company",
+          "Starter tier: up to 2 users",
+          "Growth tier: up to 50 users",
+          "Scale tier: up to 100 users"
+        ],
+        "program": "AWS Startups — Kiro Pro+"
+      }
+    },
+    {
       "vendor": "Healthchecks.io",
       "category": "Monitoring",
       "description": "Cron job and scheduled task monitoring — 20 monitors, 100 log entries per job, email/webhook/Slack/Telegram alerts, API access. Also free for open-source projects (Business plan)",
@@ -20588,7 +20614,7 @@
     {
       "vendor": "Claude Code",
       "category": "AI Coding",
-      "description": "Agentic coding tool by Anthropic — terminal-based AI coding agent that reads/writes files, runs commands, and manages git workflows. Available to Claude Pro ($20/mo), Team ($25/seat/mo), and Max ($100-200/mo) subscribers. Uses Claude Sonnet/Opus models. Also available via Anthropic API with usage-based pricing. Free tier via Claude.ai (limited Sonnet usage, Projects, Artifacts).",
+      "description": "Agentic coding tool by Anthropic — terminal-based AI coding agent that reads/writes files, runs commands, and manages git workflows. Available to Claude Pro ($20/mo), Team ($25/seat/mo), and Max ($100-200/mo) subscribers. Uses Claude Sonnet/Opus models. Also available via Anthropic API with usage-based pricing. Free tier via Claude.ai (limited Sonnet usage, Projects, Artifacts). April 2026 changes: (1) Third-party tool restrictions — external tools like OpenClaw now billed separately on pay-as-you-go basis, can no longer apply standard usage limits. (2) Extra usage option — all paid plans (Pro, Max 5x, Max 20x) now have pay-as-you-go overage at standard API rates beyond included usage. (3) Peak-hour throttling — 5-hour session limits reduced during weekdays 5 AM–11 AM Pacific.",
       "tier": "Paid",
       "url": "https://docs.anthropic.com/en/docs/claude-code/overview",
       "tags": [
@@ -20600,7 +20626,7 @@
         "developer tools",
         "cursor-alternative"
       ],
-      "verifiedDate": "2026-04-12"
+      "verifiedDate": "2026-04-13"
     },
     {
       "vendor": "GitHub Copilot",
@@ -22391,7 +22417,7 @@
     {
       "vendor": "Amazon Kiro",
       "category": "AI Coding",
-      "description": "Claude-powered AI IDE by Amazon (GA launch). Free tier: 50 interactions/month. Pro $20/month (1,000 interactions). Pro+ $40/month (2,000 interactions). Power $200/month (10,000 interactions). Built on Claude, focuses on spec-driven development with automated requirements, design docs, and test generation.",
+      "description": "Claude-powered AI IDE by Amazon (GA launch). Free tier: 50 credits/month. Pro $20/month (1,000 credits). Pro+ $40/month (2,000 credits). Power $200/month (10,000 credits). Credits metered to 0.01 increments — different models consume at different rates (Sonnet 4 costs 1.3x more than Auto mode). $0.04 overage per additional credit (disabled by default, must enable in Settings). 500 bonus credits for new users (valid 30 days). Unused monthly credits do NOT roll over. Enterprise tier: custom pricing with SAML/SCIM SSO, usage analytics, organizational management. GovCloud pricing ~20% higher; Free tier unavailable in GovCloud. Built on Claude, focuses on spec-driven development with automated requirements, design docs, and test generation.",
       "tier": "Free",
       "url": "https://kiro.dev/pricing",
       "tags": [
@@ -22402,7 +22428,7 @@
         "cursor-alternative",
         "free tier"
       ],
-      "verifiedDate": "2026-04-09"
+      "verifiedDate": "2026-04-13"
     }
   ]
 }

--- a/src/serve.ts
+++ b/src/serve.ts
@@ -25498,8 +25498,8 @@ function buildAiCodingPricing2026Page(): string {
       pro: "API usage",
       power: "$100\u2013200/mo (Max)",
       teams: "$25/seat (Team)",
-      model: "Usage-based API",
-      freeDetails: "Terminal-based agentic coding tool. Available via Claude Pro ($20/mo), Team ($25/seat), and Max ($100\u2013200/mo) subscriptions with included usage. Also available via Anthropic API with pay-per-token pricing. Most powerful for autonomous multi-file tasks.",
+      model: "Usage-based + overage",
+      freeDetails: "Terminal-based agentic coding tool. Available via Claude Pro ($20/mo), Team ($25/seat), and Max ($100\u2013200/mo) subscriptions. All paid plans now have pay-as-you-go overage at API rates. April 2026: third-party tools billed separately, peak-hour throttling weekdays 5\u201311 AM PT.",
     },
     {
       name: "Augment Code",
@@ -25875,16 +25875,16 @@ function buildAiCodingToolsPricingPage(): string {
       name: "Amazon Kiro",
       slug: "amazon-kiro",
       category: "ide",
-      free: "50 interactions/mo",
+      free: "50 credits/mo",
       pro: "$20/mo",
       power: "$40/mo (Pro+) / $200/mo (Power)",
-      teams: "\u2014",
+      teams: "Enterprise (custom)",
       model: "Credit-based",
-      freeDetails: "Claude-powered IDE by Amazon focused on spec-driven development. Free tier: 50 interactions/month. Automated requirements, design docs, and test generation. Pro: 1,000 interactions, Pro+: 2,000, Power: 10,000. Newest entrant in the IDE space (GA April 2026).",
+      freeDetails: "Claude-powered IDE by Amazon focused on spec-driven development. Free tier: 50 credits/month. Pro: 1,000 credits, Pro+: 2,000, Power: 10,000. Credits metered to 0.01 increments — Sonnet 4 costs 1.3x more than Auto mode. $0.04/credit overage (disabled by default). 500 bonus credits for new users (30 days). Enterprise tier with SAML/SCIM SSO. GovCloud ~20% premium.",
       freeType: "limited",
       monthlyCostSolo: "$0\u201320",
-      monthlyCostTeam5: "\u2014",
-      hiddenCosts: "Interaction-based pricing means complex tasks (spec generation, multi-file edits) consume credits faster than simple completions. No team plan yet. Power tier at $200/mo needed for heavy use.",
+      monthlyCostTeam5: "Enterprise (custom)",
+      hiddenCosts: "Credit-based pricing means model choice affects cost — Sonnet 4 consumes 1.3x more credits than Auto mode. Complex tasks (spec generation, multi-file edits) burn credits faster. Unused credits don't roll over. $0.04/credit overage if enabled. GovCloud ~20% higher, no free tier. Power tier at $200/mo needed for heavy use.",
     },
     {
       name: "GitHub Copilot",
@@ -25940,12 +25940,12 @@ function buildAiCodingToolsPricingPage(): string {
       pro: "$20/mo (Pro)",
       power: "$100\u2013200/mo (Max)",
       teams: "$25/seat",
-      model: "Usage-based / subscription",
-      freeDetails: "Terminal-based agentic coding tool. Available via Claude Pro ($20/mo), Team ($25/seat), and Max ($100\u2013200/mo) subscriptions with included usage. Also available via Anthropic API with pay-per-token pricing. Most powerful for autonomous multi-file tasks.",
+      model: "Usage-based / subscription + overage",
+      freeDetails: "Terminal-based agentic coding tool. Available via Claude Pro ($20/mo), Team ($25/seat), and Max ($100\u2013200/mo) subscriptions. All paid plans now have pay-as-you-go overage at standard API rates. April 2026: third-party tools (e.g. OpenClaw) billed separately. Peak-hour throttling weekdays 5\u201311 AM PT.",
       freeType: "none",
-      monthlyCostSolo: "$20\u2013200",
-      monthlyCostTeam5: "$125",
-      hiddenCosts: "Pro subscription includes limited usage \u2014 heavy users need Max ($100\u2013200/mo). API usage billed per token: Opus ~$15/M input, $75/M output.",
+      monthlyCostSolo: "$20\u2013200+",
+      monthlyCostTeam5: "$125+",
+      hiddenCosts: "April 2026 policy changes: (1) Third-party tools now billed separately — can't use standard limits. (2) Pay-as-you-go overage on all plans at API rates (Opus ~$15/M input, $75/M output). (3) Peak-hour throttling reduces 5-hour session limits weekdays 5\u201311 AM Pacific. Heavy users may see unexpected overage charges.",
     },
     {
       name: "Gemini CLI",
@@ -26209,7 +26209,7 @@ function buildAiCodingToolsPricingPage(): string {
 
   // FAQ structured data
   const faqEntries = [
-    { q: "What is the best free AI coding tool in 2026?", a: "Gemini Code Assist offers the most generous free tier with 6,000 completions/day (180,000/month) and 240 chat messages/day. For open-source alternatives, Cline and Aider are fully free with BYO API keys. Gemini CLI offers 1,000 free requests/day. Amazon Kiro offers 50 free interactions/month — limited, but enough to try spec-driven development." },
+    { q: "What is the best free AI coding tool in 2026?", a: "Gemini Code Assist offers the most generous free tier with 6,000 completions/day (180,000/month) and 240 chat messages/day. For open-source alternatives, Cline and Aider are fully free with BYO API keys. Gemini CLI offers 1,000 free requests/day. Amazon Kiro offers 50 free credits/month — limited, but enough to try spec-driven development." },
     { q: "How much does Cursor cost vs Windsurf?", a: "Both now charge identical prices: $20/month Pro, $200/month Power (Ultra/Max), and $40/seat for teams. Windsurf raised its Pro price from $15 to $20 in March 2026. The main difference is feature set, not price." },
     { q: "Is GitHub Copilot still the cheapest AI coding tool?", a: "Yes, GitHub Copilot Pro at $10/month is the cheapest paid AI coding subscription. It also offers a free tier with 2,000 completions/month and 50 premium requests/month. Pro includes 300 premium requests. Overage costs $0.04/request. Note: advanced reasoning models (Claude Opus 4, o3) consume 5x\u201320x premium requests per interaction." },
     { q: "What are the hidden costs of BYO-key AI coding tools?", a: "Tools like Cline and Aider are free to install but require API keys. Typical costs: $5-50/month for moderate use with Claude Sonnet or GPT-4o. Heavy agentic usage (Cline with Opus) can reach $50-100/month in API costs alone." },
@@ -26217,7 +26217,7 @@ function buildAiCodingToolsPricingPage(): string {
     { q: "Are AI app builders like Bolt.new and Lovable worth it?", a: "For prototyping and MVPs, yes. Bolt.new offers 1M free tokens/month and Lovable gives 5 daily credits. Both generate full-stack apps from natural language. They are not designed for production-grade software development." },
     { q: "What is Google Antigravity?", a: "Google Antigravity is an agent-first IDE powered by Gemini 3, announced November 2025. It is 100% free during public preview with built-in browser automation and multi-agent orchestration. Pricing has not been announced yet." },
     { q: "How do cloud coding agents (Codex, Devin) differ from IDE tools?", a: "Cloud agents run code in sandboxed environments and work autonomously — they can execute tests, create branches, and open PRs. IDE tools assist while you code. Cloud agents are better for delegated tasks; IDE tools are better for interactive development." },
-    { q: "What is Amazon Kiro and how does it compare to Cursor?", a: "Amazon Kiro is a Claude-powered IDE that launched GA in April 2026. It focuses on spec-driven development — automated requirements, design docs, and test generation. Free tier: 50 interactions/month. Pro: $20/month (1,000 interactions), matching Cursor's price. The key difference is Kiro's spec-first workflow vs Cursor's chat-first approach. Kiro has no team plan yet." },
+    { q: "What is Amazon Kiro and how does it compare to Cursor?", a: "Amazon Kiro is a Claude-powered IDE that launched GA in April 2026. It focuses on spec-driven development — automated requirements, design docs, and test generation. Free tier: 50 credits/month. Pro: $20/month (1,000 credits), matching Cursor's price. Credits are metered to 0.01 increments with model-dependent rates (Sonnet 4 costs 1.3x more). $0.04/credit overage available. Enterprise tier with SAML/SCIM SSO for larger teams." },
   ];
 
   const faqJsonLd = {

--- a/test/deal-changes.test.ts
+++ b/test/deal-changes.test.ts
@@ -76,7 +76,7 @@ describe("track_changes tool", () => {
 
     assert.ok(Array.isArray(body.changes));
     assert.strictEqual(body.total, body.changes.length);
-    assert.strictEqual(body.total, 254);
+    assert.strictEqual(body.total, 257);
   });
 
   it("filters by date (since)", async () => {


### PR DESCRIPTION
## Summary

- **Kiro:** Replace "interactions" with "credits" throughout. Add overage ($0.04/credit), 500 bonus credits for new users, Enterprise tier (SAML/SCIM SSO), GovCloud notes (~20% premium, no free tier)
- **Claude Code:** Track three April 2026 policy changes: (1) third-party tool restrictions, (2) pay-as-you-go overage on all plans, (3) peak-hour throttling weekdays 5–11 AM PT
- **Kiro Startup Program:** New conditional deal via AWS Startups — up to 1 year free Kiro Pro+ (worth $480/yr), 3 tiers up to 100 users
- Updated /ai-coding-tools-pricing comparison page, FAQ entries, and deal_changes

## Files changed

- `data/index.json` — Kiro credits, Claude Code policy updates, new startup program entry
- `data/deal_changes.json` — 3 new entries + fix old Kiro entry terminology
- `src/serve.ts` — Comparison page updates for both tools
- `test/deal-changes.test.ts` — Updated deal count (254→257)

## Test plan

- [x] 710 tests passing
- [x] /ai-coding-tools-pricing renders correctly with Kiro credits and Claude Code policy changes
- [x] Deal changes timeline shows Claude Code HIGH impact entry
- [x] Kiro FAQ updated with credits terminology

Refs #764