### PR TITLE
Referral programs directory page + data enrichment

### DIFF
--- a/data/index.json
+++ b/data/index.json
@@ -15,7 +15,16 @@
       "verifiedDate": "2026-04-10",
       "payment_protocols": [
         "x402"
-      ]
+      ],
+      "referral_program": {
+        "available": true,
+        "referrer_benefit": "$5/lead + 30% recurring (6 months)",
+        "referee_benefit": "Standard plan pricing",
+        "program_url": "https://partners.dub.co/v0",
+        "type": "affiliate-network",
+        "commission_type": "recurring",
+        "notes": "v0 affiliate program via Dub. Ambassador program also available with credits and swag."
+      }
     },
     {
       "vendor": "Render",
@@ -32,7 +41,15 @@
         "heroku-alternative",
         "vercel-alternative"
       ],
-      "verifiedDate": "2026-04-14"
+      "verifiedDate": "2026-04-14",
+      "referral_program": {
+        "available": false,
+        "referrer_benefit": "N/A",
+        "referee_benefit": "N/A",
+        "program_url": "https://render.com",
+        "type": "closed",
+        "notes": "No referral program. Feature requested by community but not launched."
+      }
     },
     {
       "vendor": "Cloudflare Workers",
@@ -52,7 +69,15 @@
       "verifiedDate": "2026-04-14",
       "payment_protocols": [
         "x402"
-      ]
+      ],
+      "referral_program": {
+        "available": false,
+        "referrer_benefit": "N/A",
+        "referee_benefit": "N/A",
+        "program_url": "https://www.cloudflare.com/partners/",
+        "type": "partner",
+        "notes": "Channel partner program (PowerUP) for resellers/MSPs only. No individual referral program."
+      }
     },
     {
       "vendor": "Netlify",
@@ -69,7 +94,16 @@
         "vercel-alternative",
         "deal-change"
       ],
-      "verifiedDate": "2026-03-31"
+      "verifiedDate": "2026-03-31",
+      "referral_program": {
+        "available": true,
+        "referrer_benefit": "Up to 20% revenue share",
+        "referee_benefit": "Standard pricing",
+        "program_url": "https://www.netlify.com/partners/",
+        "type": "partner",
+        "commission_type": "recurring",
+        "notes": "PartnerStack-powered. Tiers: Ecosystem (education/influence) and Certified (deeper delivery)."
+      }
     },
     {
       "vendor": "Cloudflare Pages",
@@ -87,7 +121,15 @@
       "verifiedDate": "2026-04-05",
       "payment_protocols": [
         "x402"
-      ]
+      ],
+      "referral_program": {
+        "available": false,
+        "referrer_benefit": "N/A",
+        "referee_benefit": "N/A",
+        "program_url": "https://www.cloudflare.com/partners/",
+        "type": "partner",
+        "notes": "Channel partner program only. No individual referral program."
+      }
     },
     {
       "vendor": "Railway",
@@ -125,13 +167,15 @@
         "referrer_benefit": "15% commission (first 12 months)",
         "referee_benefit": "$20 in credits",
         "program_url": "https://railway.com/affiliate-program",
-        "type": "self-service"
+        "type": "self-service",
+        "commission_type": "recurring",
+        "notes": "First 12 months of referred user spend."
       }
     },
     {
       "vendor": "Fly.io",
       "category": "Cloud Hosting",
-      "description": "Global app hosting \u2014 free trial for new accounts (2 hours runtime OR 7 days, whichever comes first). Legacy free tier (3 shared VMs) for pre-2025 accounts",
+      "description": "Global app hosting — free trial for new accounts (2 hours runtime OR 7 days, whichever comes first). Legacy free tier (3 shared VMs) for pre-2025 accounts",
       "tier": "Trial",
       "url": "https://fly.io/pricing",
       "tags": [
@@ -144,12 +188,20 @@
         "heroku-alternative",
         "vercel-alternative"
       ],
-      "verifiedDate": "2026-04-05"
+      "verifiedDate": "2026-04-05",
+      "referral_program": {
+        "available": false,
+        "referrer_benefit": "N/A",
+        "referee_benefit": "N/A",
+        "program_url": "https://fly.io",
+        "type": "closed",
+        "notes": "Confirmed no affiliate program. Extensions partner program exists for service integrations."
+      }
     },
     {
       "vendor": "Deno Deploy",
       "category": "Cloud Hosting",
-      "description": "Edge runtime \u2014 1M requests/month, 100 GB egress, 1 GiB KV storage, 450K KV reads/month, 15 hours CPU time/month",
+      "description": "Edge runtime — 1M requests/month, 100 GB egress, 1 GiB KV storage, 450K KV reads/month, 15 hours CPU time/month",
       "tier": "Free",
       "url": "https://deno.com/deploy/pricing",
       "tags": [
@@ -167,7 +219,7 @@
     {
       "vendor": "Val Town",
       "category": "Cloud Hosting",
-      "description": "Serverless scripting platform \u2014 100K runs/day, 1 minute wall clock per run, unlimited public vals, MCP integration",
+      "description": "Serverless scripting platform — 100K runs/day, 1 minute wall clock per run, unlimited public vals, MCP integration",
       "tier": "Free",
       "url": "https://www.val.town/pricing",
       "tags": [
@@ -233,7 +285,7 @@
     {
       "vendor": "DigitalOcean",
       "category": "Cloud IaaS",
-      "description": "$200 credit for 60 days for new accounts. Basic Droplets from $4/mo (1 vCPU, 512 MB RAM, 10 GB SSD \u2014 20% price cut Jan 2026). Per-second billing (min 60s or $0.01). App Platform: 3 free static sites (1 GiB outbound/mo each). Functions: 25,000 GiB-seconds/mo free. Spaces: 250 GB + 1 TB transfer for $5/mo. Managed databases start at $15/mo (not free). No perpetual free compute tier",
+      "description": "$200 credit for 60 days for new accounts. Basic Droplets from $4/mo (1 vCPU, 512 MB RAM, 10 GB SSD — 20% price cut Jan 2026). Per-second billing (min 60s or $0.01). App Platform: 3 free static sites (1 GiB outbound/mo each). Functions: 25,000 GiB-seconds/mo free. Spaces: 250 GB + 1 TB transfer for $5/mo. Managed databases start at $15/mo (not free). No perpetual free compute tier",
       "tier": "Credits",
       "url": "https://www.digitalocean.com/pricing",
       "tags": [
@@ -259,7 +311,9 @@
         "referrer_benefit": "$25 credit",
         "referee_benefit": "$200 credit (60 days)",
         "program_url": "https://www.digitalocean.com/referral-program",
-        "type": "self-service"
+        "type": "self-service",
+        "commission_type": "credits",
+        "notes": "Both referrer and referee receive credits."
       }
     },
     {
@@ -282,7 +336,7 @@
     {
       "vendor": "Supabase",
       "category": "Databases",
-      "description": "Open source Firebase alternative \u2014 500 MB Postgres database, 50K monthly active users, 1 GB file storage, 5 GB bandwidth (uncached egress across all services: Storage, Auth, Functions, Database, Realtime) + 5 GB CDN cached egress, 500K edge function invocations, 200 concurrent realtime connections, 2 free projects. Includes Auth, Storage, Realtime, and Edge Functions",
+      "description": "Open source Firebase alternative — 500 MB Postgres database, 50K monthly active users, 1 GB file storage, 5 GB bandwidth (uncached egress across all services: Storage, Auth, Functions, Database, Realtime) + 5 GB CDN cached egress, 500K edge function invocations, 200 concurrent realtime connections, 2 free projects. Includes Auth, Storage, Realtime, and Edge Functions",
       "tier": "Free",
       "url": "https://supabase.com/pricing",
       "tags": [
@@ -297,12 +351,20 @@
         "mongodb-alternative",
         "vector-database"
       ],
-      "verifiedDate": "2026-04-02"
+      "verifiedDate": "2026-04-02",
+      "referral_program": {
+        "available": false,
+        "referrer_benefit": "N/A",
+        "referee_benefit": "N/A",
+        "program_url": "https://supabase.com/partners",
+        "type": "closed",
+        "notes": "No referral/affiliate program. Partner program for integrations only. SupaSquad advocate program exists."
+      }
     },
     {
       "vendor": "Neon",
       "category": "Databases",
-      "description": "Serverless Postgres with branching \u2014 free tier includes 100 CU-hours/month per project, 0.5 GB storage per project, up to 100 projects, 10 branches per project, Neon Auth (60K MAU), auto-scaling up to 2 CU, scale-to-zero",
+      "description": "Serverless Postgres with branching — free tier includes 100 CU-hours/month per project, 0.5 GB storage per project, up to 100 projects, 10 branches per project, Neon Auth (60K MAU), auto-scaling up to 2 CU, scale-to-zero",
       "tier": "Free",
       "url": "https://neon.com/pricing",
       "tags": [
@@ -319,7 +381,9 @@
         "referrer_benefit": "$20 cash per referral",
         "referee_benefit": "Free tier access",
         "program_url": "https://neon.tech/docs/introduction/referral-program",
-        "type": "self-service"
+        "type": "self-service",
+        "commission_type": "one-time",
+        "notes": "$20 cash per qualified referral."
       }
     },
     {
@@ -336,12 +400,21 @@
         "free tier",
         "vector-database"
       ],
-      "verifiedDate": "2026-04-05"
+      "verifiedDate": "2026-04-05",
+      "referral_program": {
+        "available": true,
+        "referrer_benefit": "$100 Amazon gift card per referral",
+        "referee_benefit": "Atlas free tier",
+        "program_url": "https://www.mongodb.com/referral-program",
+        "type": "self-service",
+        "commission_type": "one-time",
+        "notes": "Referee must run M10+ cluster for 30+ days. Not valid for existing MongoDB users."
+      }
     },
     {
       "vendor": "CockroachDB",
       "category": "Databases",
-      "description": "Free serverless distributed SQL \u2014 50M Request Units + 10 GiB storage/month, scales to zero",
+      "description": "Free serverless distributed SQL — 50M Request Units + 10 GiB storage/month, scales to zero",
       "tier": "Basic",
       "url": "https://www.cockroachlabs.com/pricing/",
       "tags": [
@@ -357,7 +430,7 @@
     {
       "vendor": "Turso",
       "category": "Databases",
-      "description": "Edge SQLite \u2014 100 databases, 5 GB storage, 500M rows read/month, 10M rows written/month free",
+      "description": "Edge SQLite — 100 databases, 5 GB storage, 500M rows read/month, 10M rows written/month free",
       "tier": "Free",
       "url": "https://turso.tech/pricing",
       "tags": [
@@ -373,7 +446,7 @@
     {
       "vendor": "Upstash",
       "category": "Databases",
-      "description": "Serverless Redis \u2014 500K commands/month (256MB data). Vector: 10K vectors free. QStash: 1,000 messages/day free",
+      "description": "Serverless Redis — 500K commands/month (256MB data). Vector: 10K vectors free. QStash: 1,000 messages/day free",
       "tier": "Free",
       "url": "https://upstash.com/pricing",
       "tags": [
@@ -390,7 +463,7 @@
     {
       "vendor": "Firebase",
       "category": "Databases",
-      "description": "Full BaaS \u2014 Auth (50K MAU), Firestore (1 GiB storage, 50K reads/day), Cloud Functions (2M invocations/month), Hosting, Analytics, Crashlytics all free",
+      "description": "Full BaaS — Auth (50K MAU), Firestore (1 GiB storage, 50K reads/day), Cloud Functions (2M invocations/month), Hosting, Analytics, Crashlytics all free",
       "tier": "Spark",
       "url": "https://firebase.google.com/pricing",
       "tags": [
@@ -409,7 +482,7 @@
     {
       "vendor": "Databricks (Lakeflow Connect)",
       "category": "Databases",
-      "description": "Azure Databricks Lakeflow Connect \u2014 managed data ingestion. Free tier: 100 DBUs/day per workspace (~100M records/day). Supports 40+ data sources including SQL Server, PostgreSQL, MySQL, Salesforce, Sharepoint, Google Sheets. Serverless compute included",
+      "description": "Azure Databricks Lakeflow Connect — managed data ingestion. Free tier: 100 DBUs/day per workspace (~100M records/day). Supports 40+ data sources including SQL Server, PostgreSQL, MySQL, Salesforce, Sharepoint, Google Sheets. Serverless compute included",
       "tier": "Free",
       "url": "https://learn.microsoft.com/en-us/azure/databricks/connect/",
       "tags": [
@@ -424,7 +497,7 @@
     {
       "vendor": "Convex",
       "category": "Databases",
-      "description": "Reactive backend \u2014 1M function calls/month, 0.5 GB database + vector storage, 1 GB file storage, real-time sync",
+      "description": "Reactive backend — 1M function calls/month, 0.5 GB database + vector storage, 1 GB file storage, real-time sync",
       "tier": "Free",
       "url": "https://www.convex.dev/plans",
       "tags": [
@@ -442,7 +515,7 @@
     {
       "vendor": "Appwrite Cloud",
       "category": "Databases",
-      "description": "Open-source BaaS \u2014 75K MAU, 2 GB storage, 750K function executions/month, 5 GB bandwidth. Projects pause after 1 week of inactivity",
+      "description": "Open-source BaaS — 75K MAU, 2 GB storage, 750K function executions/month, 5 GB bandwidth. Projects pause after 1 week of inactivity",
       "tier": "Free",
       "url": "https://appwrite.io/pricing",
       "tags": [
@@ -461,7 +534,7 @@
     {
       "vendor": "Aiven",
       "category": "Databases",
-      "description": "Managed PostgreSQL, MySQL, or Valkey (Redis-compatible) \u2014 1 CPU, 1 GB RAM, 1 GB disk per service. No time limit",
+      "description": "Managed PostgreSQL, MySQL, or Valkey (Redis-compatible) — 1 CPU, 1 GB RAM, 1 GB disk per service. No time limit",
       "tier": "Free",
       "url": "https://aiven.io/pricing",
       "tags": [
@@ -478,7 +551,7 @@
     {
       "vendor": "Xata",
       "category": "Databases",
-      "description": "Serverless Postgres with branching \u2014 15 GB storage, 75 req/s, 10 branches, daily backups. No cold starts or inactivity pausing",
+      "description": "Serverless Postgres with branching — 15 GB storage, 75 req/s, 10 branches, daily backups. No cold starts or inactivity pausing",
       "tier": "Free",
       "url": "https://xata.io/pricing",
       "tags": [
@@ -494,7 +567,7 @@
     {
       "vendor": "Cloudflare D1",
       "category": "Databases",
-      "description": "SQLite at the edge \u2014 5M rows read/day, 100K rows written/day, 5 GB total storage. Resets daily at midnight UTC",
+      "description": "SQLite at the edge — 5M rows read/day, 100K rows written/day, 5 GB total storage. Resets daily at midnight UTC",
       "tier": "Free",
       "url": "https://developers.cloudflare.com/d1/platform/pricing/",
       "tags": [
@@ -509,12 +582,20 @@
       "verifiedDate": "2026-04-05",
       "payment_protocols": [
         "x402"
-      ]
+      ],
+      "referral_program": {
+        "available": false,
+        "referrer_benefit": "N/A",
+        "referee_benefit": "N/A",
+        "program_url": "https://www.cloudflare.com/partners/",
+        "type": "partner",
+        "notes": "Channel partner program only. No individual referral program."
+      }
     },
     {
       "vendor": "Nhost",
       "category": "Databases",
-      "description": "Open-source Firebase alternative with Postgres + Hasura GraphQL \u2014 1 GB database, 5 GB storage, 5 GB bandwidth free",
+      "description": "Open-source Firebase alternative with Postgres + Hasura GraphQL — 1 GB database, 5 GB storage, 5 GB bandwidth free",
       "tier": "Free",
       "url": "https://nhost.io/pricing",
       "tags": [
@@ -531,7 +612,7 @@
     {
       "vendor": "PocketBase",
       "category": "Databases",
-      "description": "Open-source backend in a single Go binary \u2014 SQLite database, real-time subscriptions, built-in auth (email, OAuth2), file storage (S3-compatible), REST API. Completely free and self-hosted, no vendor lock-in. Single executable, no dependencies",
+      "description": "Open-source backend in a single Go binary — SQLite database, real-time subscriptions, built-in auth (email, OAuth2), file storage (S3-compatible), REST API. Completely free and self-hosted, no vendor lock-in. Single executable, no dependencies",
       "tier": "Free",
       "url": "https://pocketbase.io/docs/",
       "tags": [
@@ -550,7 +631,7 @@
     {
       "vendor": "Hasura Cloud",
       "category": "Databases",
-      "description": "Instant GraphQL and REST APIs on your data \u2014 1 GB data passthrough/month, 60 req/min free",
+      "description": "Instant GraphQL and REST APIs on your data — 1 GB data passthrough/month, 60 req/min free",
       "tier": "Free",
       "url": "https://hasura.io/pricing",
       "tags": [
@@ -566,7 +647,7 @@
     {
       "vendor": "GitHub Actions",
       "category": "CI/CD",
-      "description": "Free CI/CD for public repos (unlimited minutes). Private repos: 2,000 min/mo GitHub-hosted runners, 500 MB artifact storage, 10 GB cache/repo. Self-hosted runners remain free \u2014 planned $0.002/min charge was postponed indefinitely after community backlash (March 2026). Hosted runner prices reduced 39% (Jan 2026)",
+      "description": "Free CI/CD for public repos (unlimited minutes). Private repos: 2,000 min/mo GitHub-hosted runners, 500 MB artifact storage, 10 GB cache/repo. Self-hosted runners remain free — planned $0.002/min charge was postponed indefinitely after community backlash (March 2026). Hosted runner prices reduced 39% (Jan 2026)",
       "tier": "Free",
       "url": "https://docs.github.com/en/billing/managing-billing-for-github-actions/about-billing-for-github-actions",
       "tags": [
@@ -576,7 +657,15 @@
         "github",
         "deal-change"
       ],
-      "verifiedDate": "2026-03-31"
+      "verifiedDate": "2026-03-31",
+      "referral_program": {
+        "available": false,
+        "referrer_benefit": "N/A",
+        "referee_benefit": "N/A",
+        "program_url": "https://github.com/partners",
+        "type": "closed",
+        "notes": "No individual referral program."
+      }
     },
     {
       "vendor": "GitLab CI",
@@ -592,7 +681,15 @@
         "free tier",
         "github-actions-alternative"
       ],
-      "verifiedDate": "2026-04-05"
+      "verifiedDate": "2026-04-05",
+      "referral_program": {
+        "available": false,
+        "referrer_benefit": "N/A",
+        "referee_benefit": "N/A",
+        "program_url": "https://about.gitlab.com/partners/program/",
+        "type": "partner",
+        "notes": "Channel partner program for resellers. No individual referral program."
+      }
     },
     {
       "vendor": "CircleCI",
@@ -628,7 +725,7 @@
     {
       "vendor": "Bitbucket Pipelines",
       "category": "CI/CD",
-      "description": "CI/CD built into Bitbucket \u2014 50 build minutes/month, 1 GB Git LFS, 5 users on free plan",
+      "description": "CI/CD built into Bitbucket — 50 build minutes/month, 1 GB Git LFS, 5 users on free plan",
       "tier": "Free",
       "url": "https://bitbucket.org/product/features/pipelines",
       "tags": [
@@ -654,7 +751,15 @@
         "observability",
         "datadog-alternative"
       ],
-      "verifiedDate": "2026-04-14"
+      "verifiedDate": "2026-04-14",
+      "referral_program": {
+        "available": false,
+        "referrer_benefit": "N/A",
+        "referee_benefit": "N/A",
+        "program_url": "https://sentry.io",
+        "type": "closed",
+        "notes": "No affiliate/referral program for Sentry.io error monitoring. Sponsored account program available for open source."
+      }
     },
     {
       "vendor": "Datadog",
@@ -668,7 +773,15 @@
         "observability",
         "apm"
       ],
-      "verifiedDate": "2026-04-14"
+      "verifiedDate": "2026-04-14",
+      "referral_program": {
+        "available": false,
+        "referrer_benefit": "N/A",
+        "referee_benefit": "N/A",
+        "program_url": "https://www.datadoghq.com/partner/network/",
+        "type": "partner",
+        "notes": "Partner Network for resellers and system integrators. No individual referral program."
+      }
     },
     {
       "vendor": "Grafana Cloud",
@@ -707,7 +820,7 @@
     {
       "vendor": "Axiom",
       "category": "Monitoring",
-      "description": "Observability platform \u2014 500 GB ingest/month, 25 GB storage, 30-day retention, 2 datasets, 1 user, 10 GB-hrs/mo query compute, 256 fields/dataset, 3 monitors, Email/Discord notifiers only",
+      "description": "Observability platform — 500 GB ingest/month, 25 GB storage, 30-day retention, 2 datasets, 1 user, 10 GB-hrs/mo query compute, 256 fields/dataset, 3 monitors, Email/Discord notifiers only",
       "tier": "Personal",
       "url": "https://axiom.co/pricing",
       "tags": [
@@ -723,7 +836,7 @@
     {
       "vendor": "Checkly",
       "category": "Testing",
-      "description": "Synthetic monitoring \u2014 10 uptime monitors, 1K browser check runs, 10K API check runs/month, 6 locations",
+      "description": "Synthetic monitoring — 10 uptime monitors, 1K browser check runs, 10K API check runs/month, 6 locations",
       "tier": "Hobby",
       "url": "https://www.checklyhq.com/pricing/",
       "tags": [
@@ -740,7 +853,7 @@
     {
       "vendor": "New Relic",
       "category": "Monitoring",
-      "description": "Full observability platform \u2014 100 GB data ingest/month, 1 full platform user, unlimited basic users, 500 synthetic checks, 8+ days retention",
+      "description": "Full observability platform — 100 GB data ingest/month, 1 full platform user, unlimited basic users, 500 synthetic checks, 8+ days retention",
       "tier": "Free",
       "url": "https://newrelic.com/pricing",
       "tags": [
@@ -752,7 +865,15 @@
         "free tier",
         "datadog-alternative"
       ],
-      "verifiedDate": "2026-04-14"
+      "verifiedDate": "2026-04-14",
+      "referral_program": {
+        "available": false,
+        "referrer_benefit": "N/A",
+        "referee_benefit": "N/A",
+        "program_url": "https://newrelic.com/solutions/partners",
+        "type": "partner",
+        "notes": "Partner program exists. Legacy affiliate program (2008-2010) appears discontinued."
+      }
     },
     {
       "vendor": "UptimeRobot",
@@ -789,7 +910,7 @@
     {
       "vendor": "Auth0",
       "category": "Auth",
-      "description": "Identity platform \u2014 25K MAU (B2C), unlimited logins, social + database connections, Universal Login. No credit card required",
+      "description": "Identity platform — 25K MAU (B2C), unlimited logins, social + database connections, Universal Login. No credit card required",
       "tier": "Free",
       "url": "https://auth0.com/pricing",
       "tags": [
@@ -800,7 +921,15 @@
         "sso",
         "free tier"
       ],
-      "verifiedDate": "2026-04-05"
+      "verifiedDate": "2026-04-05",
+      "referral_program": {
+        "available": false,
+        "referrer_benefit": "N/A",
+        "referee_benefit": "N/A",
+        "program_url": "https://auth0.com/partners",
+        "type": "partner",
+        "notes": "Part of Okta. Enterprise referral via Okta partner program only ($100 charity donation per qualified referral)."
+      }
     },
     {
       "vendor": "Kinde",
@@ -822,7 +951,7 @@
     {
       "vendor": "WorkOS",
       "category": "Auth",
-      "description": "AuthKit with up to 1M MAU free for user management \u2014 email/password, social login, MFA. Enterprise SSO/SCIM priced separately",
+      "description": "AuthKit with up to 1M MAU free for user management — email/password, social login, MFA. Enterprise SSO/SCIM priced separately",
       "tier": "Free",
       "url": "https://workos.com/pricing",
       "tags": [
@@ -839,7 +968,7 @@
     {
       "vendor": "Resend",
       "category": "Email",
-      "description": "Developer-first email API \u2014 3K emails/mo free",
+      "description": "Developer-first email API — 3K emails/mo free",
       "tier": "Free",
       "url": "https://resend.com/pricing",
       "tags": [
@@ -853,7 +982,7 @@
     {
       "vendor": "Postmark",
       "category": "Email",
-      "description": "Transactional email API \u2014 100 emails/month free, never expires, no credit card required",
+      "description": "Transactional email API — 100 emails/month free, never expires, no credit card required",
       "tier": "Free",
       "url": "https://postmarkapp.com/pricing",
       "tags": [
@@ -869,13 +998,14 @@
         "referrer_benefit": "20% recurring commission (12 months)",
         "referee_benefit": "Standard pricing",
         "program_url": "https://postmarkapp.com/partner-program",
-        "type": "affiliate-network"
+        "type": "affiliate-network",
+        "commission_type": "one-time"
       }
     },
     {
       "vendor": "Mailchimp",
       "category": "Email",
-      "description": "Email marketing \u2014 250 contacts, 500 sends/month, marketing CRM, forms and landing pages included",
+      "description": "Email marketing — 250 contacts, 500 sends/month, marketing CRM, forms and landing pages included",
       "tier": "Free",
       "url": "https://mailchimp.com/pricing/",
       "tags": [
@@ -891,7 +1021,7 @@
     {
       "vendor": "Mailjet",
       "category": "Email",
-      "description": "Email API \u2014 6,000 emails/month (200/day limit), 1,000 contacts, email editor and templates",
+      "description": "Email API — 6,000 emails/month (200/day limit), 1,000 contacts, email editor and templates",
       "tier": "Free",
       "url": "https://www.mailjet.com/pricing/",
       "tags": [
@@ -924,13 +1054,14 @@
         "referrer_benefit": "~$5 per free signup, ~$100 per paid signup",
         "referee_benefit": "Standard pricing",
         "program_url": "https://www.brevo.com/partners/",
-        "type": "affiliate-network"
+        "type": "affiliate-network",
+        "commission_type": "one-time"
       }
     },
     {
       "vendor": "Algolia",
       "category": "Search",
-      "description": "Search-as-a-service \u2014 10K search requests/month, 1M records, AI recommendations included",
+      "description": "Search-as-a-service — 10K search requests/month, 1M records, AI recommendations included",
       "tier": "Build",
       "url": "https://www.algolia.com/pricing",
       "tags": [
@@ -945,7 +1076,7 @@
     {
       "vendor": "Cloudflare R2",
       "category": "Storage",
-      "description": "Object storage with zero egress fees \u2014 10 GB storage, 1M writes, 10M reads/month free",
+      "description": "Object storage with zero egress fees — 10 GB storage, 1M writes, 10M reads/month free",
       "tier": "Free",
       "url": "https://developers.cloudflare.com/r2/pricing/",
       "tags": [
@@ -958,12 +1089,20 @@
       "verifiedDate": "2026-04-12",
       "payment_protocols": [
         "x402"
-      ]
+      ],
+      "referral_program": {
+        "available": false,
+        "referrer_benefit": "N/A",
+        "referee_benefit": "N/A",
+        "program_url": "https://www.cloudflare.com/partners/",
+        "type": "partner",
+        "notes": "Channel partner program only. No individual referral program."
+      }
     },
     {
       "vendor": "Backblaze B2",
       "category": "Storage",
-      "description": "Object storage \u2014 first 10 GB always free, free egress via Cloudflare/CDN partners",
+      "description": "Object storage — first 10 GB always free, free egress via Cloudflare/CDN partners",
       "tier": "Free Allowance",
       "url": "https://www.backblaze.com/cloud-storage/pricing",
       "tags": [
@@ -979,13 +1118,14 @@
         "referrer_benefit": "1 free month per referral",
         "referee_benefit": "1 free month",
         "program_url": "https://www.backblaze.com/cloud-storage/refer-a-friend",
-        "type": "self-service"
+        "type": "self-service",
+        "commission_type": "one-time"
       }
     },
     {
       "vendor": "Tigris",
       "category": "Storage",
-      "description": "S3-compatible object storage \u2014 5 GB free, 10K writes + 100K reads/month, zero egress fees",
+      "description": "S3-compatible object storage — 5 GB free, 10K writes + 100K reads/month, zero egress fees",
       "tier": "Free",
       "url": "https://www.tigrisdata.com/pricing/",
       "tags": [
@@ -1000,7 +1140,7 @@
     {
       "vendor": "Cloudinary",
       "category": "Storage",
-      "description": "Media management \u2014 25 credits/month (1 credit = 1 GB storage OR 1 GB bandwidth OR 1K transformations), up to 3 users",
+      "description": "Media management — 25 credits/month (1 credit = 1 GB storage OR 1 GB bandwidth OR 1K transformations), up to 3 users",
       "tier": "Free",
       "url": "https://cloudinary.com/pricing",
       "tags": [
@@ -1016,7 +1156,7 @@
     {
       "vendor": "CloudAMQP",
       "category": "Messaging",
-      "description": "Managed RabbitMQ \u2014 1M messages/month, 20 connections, 100 queues free",
+      "description": "Managed RabbitMQ — 1M messages/month, 20 connections, 100 queues free",
       "tier": "Little Lemur",
       "url": "https://www.cloudamqp.com/plans.html",
       "tags": [
@@ -1031,7 +1171,7 @@
     {
       "vendor": "Cloudflare Queues",
       "category": "Messaging",
-      "description": "Message queues on Workers \u2014 1M operations/month free, 24-hour message retention. Added to free plan late 2025",
+      "description": "Message queues on Workers — 1M operations/month free, 24-hour message retention. Added to free plan late 2025",
       "tier": "Free",
       "url": "https://developers.cloudflare.com/queues/platform/pricing/",
       "tags": [
@@ -1044,12 +1184,20 @@
       "verifiedDate": "2026-04-14",
       "payment_protocols": [
         "x402"
-      ]
+      ],
+      "referral_program": {
+        "available": false,
+        "referrer_benefit": "N/A",
+        "referee_benefit": "N/A",
+        "program_url": "https://www.cloudflare.com/partners/",
+        "type": "partner",
+        "notes": "Channel partner program only. No individual referral program."
+      }
     },
     {
       "vendor": "Cloudflare KV",
       "category": "Databases",
-      "description": "Key-value store at the edge \u2014 100K reads/day, 1K writes/day, 1 GB storage. Eventually consistent with global replication",
+      "description": "Key-value store at the edge — 100K reads/day, 1K writes/day, 1 GB storage. Eventually consistent with global replication",
       "tier": "Free",
       "url": "https://developers.cloudflare.com/kv/platform/pricing/",
       "tags": [
@@ -1062,12 +1210,20 @@
       "verifiedDate": "2026-04-14",
       "payment_protocols": [
         "x402"
-      ]
+      ],
+      "referral_program": {
+        "available": false,
+        "referrer_benefit": "N/A",
+        "referee_benefit": "N/A",
+        "program_url": "https://www.cloudflare.com/partners/",
+        "type": "partner",
+        "notes": "Channel partner program only. No individual referral program."
+      }
     },
     {
       "vendor": "Cloudflare Durable Objects",
       "category": "Cloud Hosting",
-      "description": "Stateful serverless compute \u2014 100K requests/day on free plan. Strongly consistent storage with WebSocket hibernation. SQLite storage included (first 10 GB on paid plan)",
+      "description": "Stateful serverless compute — 100K requests/day on free plan. Strongly consistent storage with WebSocket hibernation. SQLite storage included (first 10 GB on paid plan)",
       "tier": "Free",
       "url": "https://developers.cloudflare.com/durable-objects/platform/pricing/",
       "tags": [
@@ -1081,12 +1237,20 @@
       "verifiedDate": "2026-04-14",
       "payment_protocols": [
         "x402"
-      ]
+      ],
+      "referral_program": {
+        "available": false,
+        "referrer_benefit": "N/A",
+        "referee_benefit": "N/A",
+        "program_url": "https://www.cloudflare.com/partners/",
+        "type": "partner",
+        "notes": "Channel partner program only. No individual referral program."
+      }
     },
     {
       "vendor": "QStash",
       "category": "Messaging",
-      "description": "Serverless message queue by Upstash \u2014 1,000 messages/day, 10 active schedules, 7-day max delay, retries free",
+      "description": "Serverless message queue by Upstash — 1,000 messages/day, 10 active schedules, 7-day max delay, retries free",
       "tier": "Free",
       "url": "https://upstash.com/pricing/qstash",
       "tags": [
@@ -1101,7 +1265,7 @@
     {
       "vendor": "Pusher",
       "category": "Messaging",
-      "description": "Real-time messaging \u2014 200K messages/day, 100 concurrent connections free",
+      "description": "Real-time messaging — 200K messages/day, 100 concurrent connections free",
       "tier": "Sandbox",
       "url": "https://pusher.com/channels/pricing",
       "tags": [
@@ -1116,7 +1280,7 @@
     {
       "vendor": "Ably",
       "category": "Messaging",
-      "description": "Real-time infrastructure \u2014 6M messages/month, 200 concurrent connections, 200 channels, pub/sub + chat + spaces",
+      "description": "Real-time infrastructure — 6M messages/month, 200 concurrent connections, 200 channels, pub/sub + chat + spaces",
       "tier": "Free",
       "url": "https://ably.com/pricing",
       "tags": [
@@ -1132,7 +1296,7 @@
     {
       "vendor": "Bright Data MCP Server",
       "category": "Web Scraping",
-      "description": "MCP-native web data provider \u2014 5,000 requests/month free in Rapid mode. Two MCP tools: search_engine (search results) and scrape_as_markdown (web page fetching). Handles JS-rendered pages and CAPTCHAs. First MCP-native web data provider with a free tier.",
+      "description": "MCP-native web data provider — 5,000 requests/month free in Rapid mode. Two MCP tools: search_engine (search results) and scrape_as_markdown (web page fetching). Handles JS-rendered pages and CAPTCHAs. First MCP-native web data provider with a free tier.",
       "tier": "Free",
       "url": "https://brightdata.com/pricing/mcp-server",
       "tags": [
@@ -1151,7 +1315,7 @@
     {
       "vendor": "Firecrawl",
       "category": "Web Scraping",
-      "description": "Web scraping API \u2014 500 credits (up to 500 pages), 2 concurrent requests, no credit card required",
+      "description": "Web scraping API — 500 credits (up to 500 pages), 2 concurrent requests, no credit card required",
       "tier": "Free",
       "url": "https://www.firecrawl.dev/pricing",
       "tags": [
@@ -1170,7 +1334,7 @@
     {
       "vendor": "Apify",
       "category": "Web Scraping",
-      "description": "Web scraping and automation \u2014 $5 platform credits/month (renews), 25 concurrent Actor runs, 7-day data retention",
+      "description": "Web scraping and automation — $5 platform credits/month (renews), 25 concurrent Actor runs, 7-day data retention",
       "tier": "Free",
       "url": "https://apify.com/pricing",
       "tags": [
@@ -1202,7 +1366,7 @@
     {
       "vendor": "GitHub Copilot",
       "category": "IDE & Code Editors",
-      "description": "AI code assistant \u2014 2,000 completions/month, 50 premium requests/month, works in VS Code/JetBrains/GitHub.com. Premium requests use advanced models (Claude Opus 4, o3); overage $0.04/request. Students get dedicated Copilot Student plan (Mar 2026) \u2014 premium models available via Auto mode only, no manual model selection for GPT-5.4/Claude Opus/Sonnet. OSS maintainers get Pro free",
+      "description": "AI code assistant — 2,000 completions/month, 50 premium requests/month, works in VS Code/JetBrains/GitHub.com. Premium requests use advanced models (Claude Opus 4, o3); overage $0.04/request. Students get dedicated Copilot Student plan (Mar 2026) — premium models available via Auto mode only, no manual model selection for GPT-5.4/Claude Opus/Sonnet. OSS maintainers get Pro free",
       "tier": "Free",
       "url": "https://github.com/features/copilot/plans",
       "tags": [
@@ -1213,7 +1377,15 @@
         "free tier",
         "deal-change"
       ],
-      "verifiedDate": "2026-04-13"
+      "verifiedDate": "2026-04-13",
+      "referral_program": {
+        "available": false,
+        "referrer_benefit": "N/A",
+        "referee_benefit": "N/A",
+        "program_url": "https://github.com/partners",
+        "type": "closed",
+        "notes": "No individual referral program. Education partner program for student developer pack."
+      }
     },
     {
       "vendor": "Cursor",
@@ -1229,12 +1401,20 @@
         "free tier",
         "deal-change"
       ],
-      "verifiedDate": "2026-04-13"
+      "verifiedDate": "2026-04-13",
+      "referral_program": {
+        "available": false,
+        "referrer_benefit": "N/A",
+        "referee_benefit": "N/A",
+        "program_url": "https://cursor.com",
+        "type": "closed",
+        "notes": "No referral or affiliate program. Community has requested it but not available."
+      }
     },
     {
       "vendor": "Linear",
       "category": "Project Management",
-      "description": "Project management for dev teams \u2014 250 active issues (unlimited archived), unlimited members, 2 teams, AI agents, API",
+      "description": "Project management for dev teams — 250 active issues (unlimited archived), unlimited members, 2 teams, AI agents, API",
       "tier": "Free",
       "url": "https://linear.app/pricing",
       "tags": [
@@ -1249,7 +1429,7 @@
     {
       "vendor": "Snyk",
       "category": "Security",
-      "description": "Developer security \u2014 200 open-source SCA tests/month, 100 SAST (Snyk Code) tests/month, 100 container tests/month, 300 IaC tests/month. Unlimited contributing developers. Code and dependency scanning across all products.",
+      "description": "Developer security — 200 open-source SCA tests/month, 100 SAST (Snyk Code) tests/month, 100 container tests/month, 300 IaC tests/month. Unlimited contributing developers. Code and dependency scanning across all products.",
       "tier": "Free",
       "url": "https://snyk.io/plans/",
       "tags": [
@@ -1268,7 +1448,7 @@
     {
       "vendor": "Fingerprint",
       "category": "Security",
-      "description": "Device identification and fraud prevention \u2014 1,000 API calls/month free. Browser fingerprinting, bot detection, and account fraud prevention. Useful for auth flows, anti-fraud, and bot detection in apps.",
+      "description": "Device identification and fraud prevention — 1,000 API calls/month free. Browser fingerprinting, bot detection, and account fraud prevention. Useful for auth flows, anti-fraud, and bot detection in apps.",
       "tier": "Free",
       "url": "https://fingerprint.com/pricing/",
       "tags": [
@@ -1285,7 +1465,7 @@
     {
       "vendor": "SonarCloud",
       "category": "Security",
-      "description": "Code quality and security analysis \u2014 free and unlimited for open-source projects, 15+ languages, CI/CD integration",
+      "description": "Code quality and security analysis — free and unlimited for open-source projects, 15+ languages, CI/CD integration",
       "tier": "Free",
       "url": "https://www.sonarsource.com/products/sonarcloud/pricing/",
       "tags": [
@@ -1300,7 +1480,7 @@
     {
       "vendor": "Hetzner",
       "category": "Infrastructure",
-      "description": "Budget cloud VMs from \u20ac3.99/month (2 vCPU, 4 GB RAM, 40 GB SSD). No free tier but exceptionally competitive pricing with 20 TB traffic included",
+      "description": "Budget cloud VMs from €3.99/month (2 vCPU, 4 GB RAM, 40 GB SSD). No free tier but exceptionally competitive pricing with 20 TB traffic included",
       "tier": "Budget",
       "url": "https://www.hetzner.com/cloud/",
       "tags": [
@@ -1314,16 +1494,18 @@
       "verifiedDate": "2026-04-12",
       "referral_program": {
         "available": true,
-        "referrer_benefit": "\u20ac10 credit",
-        "referee_benefit": "\u20ac20 credit",
+        "referrer_benefit": "€10 credit",
+        "referee_benefit": "€20 credit",
         "program_url": "https://www.hetzner.com/tell-a-friend",
-        "type": "self-service"
+        "type": "self-service",
+        "commission_type": "credits",
+        "notes": "Hetzner credits for both parties."
       }
     },
     {
       "vendor": "Cloudflare DNS",
       "category": "DNS & Domain Management",
-      "description": "Free authoritative DNS hosting \u2014 unlimited zones and queries, 1,000 records/zone, DDoS protection, free SSL/TLS",
+      "description": "Free authoritative DNS hosting — unlimited zones and queries, 1,000 records/zone, DDoS protection, free SSL/TLS",
       "tier": "Free",
       "url": "https://www.cloudflare.com/plans/free/",
       "tags": [
@@ -1336,12 +1518,20 @@
       "verifiedDate": "2026-04-12",
       "payment_protocols": [
         "x402"
-      ]
+      ],
+      "referral_program": {
+        "available": false,
+        "referrer_benefit": "N/A",
+        "referee_benefit": "N/A",
+        "program_url": "https://www.cloudflare.com/partners/",
+        "type": "partner",
+        "notes": "Channel partner program only. No individual referral program."
+      }
     },
     {
       "vendor": "Hurricane Electric DNS",
       "category": "DNS & Domain Management",
-      "description": "Free DNS hosting \u2014 up to 50 domains, primary and secondary DNS, dynamic DNS, IPv6 support, geographically distributed nameservers",
+      "description": "Free DNS hosting — up to 50 domains, primary and secondary DNS, dynamic DNS, IPv6 support, geographically distributed nameservers",
       "tier": "Free",
       "url": "https://dns.he.net/",
       "tags": [
@@ -1356,7 +1546,7 @@
     {
       "vendor": "deSEC",
       "category": "DNS & Domain Management",
-      "description": "Open-source DNS with automatic DNSSEC \u2014 free forever, run by a non-profit. REST API, dynamic DNS, rate-limited to 300 changes/domain/day",
+      "description": "Open-source DNS with automatic DNSSEC — free forever, run by a non-profit. REST API, dynamic DNS, rate-limited to 300 changes/domain/day",
       "tier": "Free",
       "url": "https://desec.io/",
       "tags": [
@@ -1371,7 +1561,7 @@
     {
       "vendor": "Fastly",
       "category": "CDN",
-      "description": "Edge cloud \u2014 free developer account with 100 GB bandwidth, 1M requests/month, 5 GB object storage, image optimizer, WebSockets, DDoS protection",
+      "description": "Edge cloud — free developer account with 100 GB bandwidth, 1M requests/month, 5 GB object storage, image optimizer, WebSockets, DDoS protection",
       "tier": "Free Developer",
       "url": "https://www.fastly.com/pricing",
       "tags": [
@@ -1381,12 +1571,20 @@
         "compute",
         "free tier"
       ],
-      "verifiedDate": "2026-04-05"
+      "verifiedDate": "2026-04-05",
+      "referral_program": {
+        "available": false,
+        "referrer_benefit": "N/A",
+        "referee_benefit": "N/A",
+        "program_url": "https://www.fastly.com/channel-partner-program",
+        "type": "partner",
+        "notes": "Channel partner program for agencies and consultants. No self-service referral program."
+      }
     },
     {
       "vendor": "jsDelivr",
       "category": "CDN",
-      "description": "Free CDN for open-source \u2014 unlimited bandwidth and requests, serves npm packages and GitHub repos, multi-provider redundancy",
+      "description": "Free CDN for open-source — unlimited bandwidth and requests, serves npm packages and GitHub repos, multi-provider redundancy",
       "tier": "Free",
       "url": "https://www.jsdelivr.com/",
       "tags": [
@@ -1401,7 +1599,7 @@
     {
       "vendor": "LaunchDarkly",
       "category": "Feature Flags",
-      "description": "Feature management \u2014 unlimited seats and flags, 1K client MAU, 1 project, 3 environments, A/B testing, 5K session replays/month",
+      "description": "Feature management — unlimited seats and flags, 1K client MAU, 1 project, 3 environments, A/B testing, 5K session replays/month",
       "tier": "Developer",
       "url": "https://launchdarkly.com/pricing/",
       "tags": [
@@ -1416,7 +1614,7 @@
     {
       "vendor": "Flagsmith",
       "category": "Feature Flags",
-      "description": "Feature flags and remote config \u2014 50K API requests/month, unlimited flags/environments/identities, A/B testing, 1 user",
+      "description": "Feature flags and remote config — 50K API requests/month, unlimited flags/environments/identities, A/B testing, 1 user",
       "tier": "Free",
       "url": "https://www.flagsmith.com/pricing",
       "tags": [
@@ -1430,7 +1628,7 @@
     {
       "vendor": "Harness Feature Flags",
       "category": "Feature Flags",
-      "description": "Feature flags (formerly Split.io) \u2014 2 developers, 25K client MAU, unlimited flags and environments, CI/CD pipelines for rollout",
+      "description": "Feature flags (formerly Split.io) — 2 developers, 25K client MAU, unlimited flags and environments, CI/CD pipelines for rollout",
       "tier": "Free",
       "url": "https://www.harness.io/pricing",
       "tags": [
@@ -1445,7 +1643,7 @@
     {
       "vendor": "Logz.io",
       "category": "Logging",
-      "description": "ELK-based log management \u2014 14-day free trial only. No permanent free tier. Consumption-based pricing starts at $0.92/ingested GB/day. Community plan removed",
+      "description": "ELK-based log management — 14-day free trial only. No permanent free tier. Consumption-based pricing starts at $0.92/ingested GB/day. Community plan removed",
       "tier": "Trial",
       "url": "https://logz.io/pricing/",
       "tags": [
@@ -1460,7 +1658,7 @@
     {
       "vendor": "Papertrail",
       "category": "Logging",
-      "description": "Cloud log management by SolarWinds \u2014 100 MB/month, 48-hour searchable logs, 7-day archive, unlimited sources, real-time tail",
+      "description": "Cloud log management by SolarWinds — 100 MB/month, 48-hour searchable logs, 7-day archive, unlimited sources, real-time tail",
       "tier": "Free",
       "url": "https://www.papertrail.com/plans/",
       "tags": [
@@ -1475,7 +1673,7 @@
     {
       "vendor": "Stripe",
       "category": "Payments",
-      "description": "Payment processing \u2014 no monthly fees, 2.9% + $0.30 per transaction. Full API, dashboard, and test mode free. Pay only when processing live payments",
+      "description": "Payment processing — no monthly fees, 2.9% + $0.30 per transaction. Full API, dashboard, and test mode free. Pay only when processing live payments",
       "tier": "Pay-as-you-go",
       "url": "https://stripe.com/pricing",
       "tags": [
@@ -1488,12 +1686,20 @@
       "verifiedDate": "2026-04-12",
       "payment_protocols": [
         "mpp"
-      ]
+      ],
+      "referral_program": {
+        "available": false,
+        "referrer_benefit": "N/A",
+        "referee_benefit": "N/A",
+        "program_url": "https://stripe.partners",
+        "type": "partner",
+        "notes": "Partner ecosystem but no individual referral/affiliate program. Integration partners only."
+      }
     },
     {
       "vendor": "LemonSqueezy",
       "category": "Payments",
-      "description": "Merchant of record \u2014 no monthly fees, 5% + $0.50 per transaction. Handles sales tax/VAT globally, license keys, fraud protection",
+      "description": "Merchant of record — no monthly fees, 5% + $0.50 per transaction. Handles sales tax/VAT globally, license keys, fraud protection",
       "tier": "Pay-as-you-go",
       "url": "https://www.lemonsqueezy.com/pricing",
       "tags": [
@@ -1508,7 +1714,7 @@
     {
       "vendor": "Contentful",
       "category": "Headless CMS",
-      "description": "Headless CMS \u2014 10K records, 100K API calls/month, 10 users, 25 content types, 2 environments. Personal/non-commercial use",
+      "description": "Headless CMS — 10K records, 100K API calls/month, 10 users, 25 content types, 2 environments. Personal/non-commercial use",
       "tier": "Free",
       "url": "https://www.contentful.com/pricing/",
       "tags": [
@@ -1523,7 +1729,7 @@
     {
       "vendor": "Sanity",
       "category": "Headless CMS",
-      "description": "Structured content platform \u2014 10K documents, 1M CDN requests/month, 100 GB assets, 20 users, GROQ query language. No time limit",
+      "description": "Structured content platform — 10K documents, 1M CDN requests/month, 100 GB assets, 20 users, GROQ query language. No time limit",
       "tier": "Free",
       "url": "https://www.sanity.io/pricing",
       "tags": [
@@ -1539,7 +1745,7 @@
     {
       "vendor": "Hygraph",
       "category": "Headless CMS",
-      "description": "GraphQL headless CMS \u2014 1K content entries, 500K API calls/month, 3 seats, 20 models, unlimited asset storage",
+      "description": "GraphQL headless CMS — 1K content entries, 500K API calls/month, 3 seats, 20 models, unlimited asset storage",
       "tier": "Hobby",
       "url": "https://hygraph.com/pricing",
       "tags": [
@@ -1554,7 +1760,7 @@
     {
       "vendor": "Hugging Face",
       "category": "AI / ML",
-      "description": "ML model hub \u2014 $0.10/month free inference credits, 200+ models via Inference Providers, unlimited model hosting on Hub",
+      "description": "ML model hub — $0.10/month free inference credits, 200+ models via Inference Providers, unlimited model hosting on Hub",
       "tier": "Free",
       "url": "https://huggingface.co/docs/inference-providers/pricing",
       "tags": [
@@ -1565,12 +1771,20 @@
         "open-source",
         "free tier"
       ],
-      "verifiedDate": "2026-04-14"
+      "verifiedDate": "2026-04-14",
+      "referral_program": {
+        "available": false,
+        "referrer_benefit": "N/A",
+        "referee_benefit": "N/A",
+        "program_url": "https://huggingface.co",
+        "type": "closed",
+        "notes": "No referral or affiliate program. Fellowship program exists for community advocates."
+      }
     },
     {
       "vendor": "Groq",
       "category": "AI / ML",
-      "description": "Ultra-fast LLM inference on LPU hardware \u2014 free tier: 30 RPM, 100K-500K tokens/day depending on model. Supports Llama 4 Scout 17B, Llama 3.3 70B, Qwen3 32B, Whisper, and more. No credit card required",
+      "description": "Ultra-fast LLM inference on LPU hardware — free tier: 30 RPM, 100K-500K tokens/day depending on model. Supports Llama 4 Scout 17B, Llama 3.3 70B, Qwen3 32B, Whisper, and more. No credit card required",
       "tier": "Free",
       "url": "https://groq.com/pricing",
       "tags": [
@@ -1586,7 +1800,7 @@
     {
       "vendor": "Google Gemini API",
       "category": "AI / ML",
-      "description": "Free tier restricted to Flash models only (April 2026). Pro models (Gemini 2.5 Pro) require paid billing account. Free limits: Flash (10 RPM), Flash-Lite (15 RPM). 1M token context. Mandatory spend caps enforced since April 1, 2026 \u2014 API requests pause when cap is hit. Previously free Pro access removed entirely.",
+      "description": "Free tier restricted to Flash models only (April 2026). Pro models (Gemini 2.5 Pro) require paid billing account. Free limits: Flash (10 RPM), Flash-Lite (15 RPM). 1M token context. Mandatory spend caps enforced since April 1, 2026 — API requests pause when cap is hit. Previously free Pro access removed entirely.",
       "tier": "Free (Reduced)",
       "url": "https://ai.google.dev/gemini-api/docs/pricing",
       "tags": [
@@ -1603,7 +1817,7 @@
     {
       "vendor": "Mistral AI",
       "category": "AI / ML",
-      "description": "Access to all Mistral models including Large, Codestral, Pixtral \u2014 2 RPM, 1B tokens/month. No credit card required",
+      "description": "Access to all Mistral models including Large, Codestral, Pixtral — 2 RPM, 1B tokens/month. No credit card required",
       "tier": "Experiment",
       "url": "https://mistral.ai/pricing",
       "tags": [
@@ -1619,7 +1833,7 @@
     {
       "vendor": "OpenRouter",
       "category": "AI / ML",
-      "description": "AI model router \u2014 ~30 free models (DeepSeek R1, Llama 3.3, Qwen3, Gemma 3), OpenAI-compatible API, ~20 RPM per model",
+      "description": "AI model router — ~30 free models (DeepSeek R1, Llama 3.3, Qwen3, Gemma 3), OpenAI-compatible API, ~20 RPM per model",
       "tier": "Free",
       "url": "https://openrouter.ai/pricing",
       "tags": [
@@ -1635,7 +1849,7 @@
     {
       "vendor": "Cloudflare Workers AI",
       "category": "AI / ML",
-      "description": "AI inference at the edge \u2014 10,000 neurons/day free across text generation, image classification, translation, speech-to-text models",
+      "description": "AI inference at the edge — 10,000 neurons/day free across text generation, image classification, translation, speech-to-text models",
       "tier": "Free",
       "url": "https://developers.cloudflare.com/workers-ai/platform/pricing/",
       "tags": [
@@ -1649,12 +1863,20 @@
       "verifiedDate": "2026-04-05",
       "payment_protocols": [
         "x402"
-      ]
+      ],
+      "referral_program": {
+        "available": false,
+        "referrer_benefit": "N/A",
+        "referee_benefit": "N/A",
+        "program_url": "https://www.cloudflare.com/partners/",
+        "type": "partner",
+        "notes": "Channel partner program only. No individual referral program."
+      }
     },
     {
       "vendor": "PostHog",
       "category": "Analytics",
-      "description": "Product analytics \u2014 1M events/month, 5K session replays, 1M feature flag requests, 100K error events, A/B testing. No credit card required",
+      "description": "Product analytics — 1M events/month, 5K session replays, 1M feature flag requests, 100K error events, A/B testing. No credit card required",
       "tier": "Free",
       "url": "https://posthog.com/pricing",
       "tags": [
@@ -1671,7 +1893,7 @@
     {
       "vendor": "Amplitude",
       "category": "Analytics",
-      "description": "Product analytics \u2014 50K MTU, 10M events, 1K session replays/month, unlimited feature flags, 1-year retention, unlimited team members",
+      "description": "Product analytics — 50K MTU, 10M events, 1K session replays/month, unlimited feature flags, 1-year retention, unlimited team members",
       "tier": "Starter",
       "url": "https://amplitude.com/pricing",
       "tags": [
@@ -1686,7 +1908,7 @@
     {
       "vendor": "Mixpanel",
       "category": "Analytics",
-      "description": "Product analytics \u2014 1M events/month, 10K session replays, funnels/retention/flows, unlimited seats. Pauses tracking when limit reached",
+      "description": "Product analytics — 1M events/month, 10K session replays, funnels/retention/flows, unlimited seats. Pauses tracking when limit reached",
       "tier": "Free",
       "url": "https://mixpanel.com/pricing/",
       "tags": [
@@ -1701,7 +1923,7 @@
     {
       "vendor": "Inngest",
       "category": "Background Jobs",
-      "description": "Serverless workflow orchestration \u2014 50K function executions/month, 100K events, 5 concurrent steps, 3 users, unlimited environments",
+      "description": "Serverless workflow orchestration — 50K function executions/month, 100K events, 5 concurrent steps, 3 users, unlimited environments",
       "tier": "Hobby",
       "url": "https://www.inngest.com/pricing",
       "tags": [
@@ -1716,7 +1938,7 @@
     {
       "vendor": "Trigger.dev",
       "category": "Background Jobs",
-      "description": "Background jobs platform \u2014 $5 free monthly compute, 20 concurrent runs, unlimited tasks, 5 team members, 10 schedules, 1 day log retention, community support",
+      "description": "Background jobs platform — $5 free monthly compute, 20 concurrent runs, unlimited tasks, 5 team members, 10 schedules, 1 day log retention, community support",
       "tier": "Free",
       "url": "https://trigger.dev/pricing",
       "tags": [
@@ -1731,7 +1953,7 @@
     {
       "vendor": "Momento",
       "category": "Databases",
-      "description": "Serverless cache and pub/sub \u2014 5 GB data transfer/month free, sub-millisecond latency, no infrastructure to manage",
+      "description": "Serverless cache and pub/sub — 5 GB data transfer/month free, sub-millisecond latency, no infrastructure to manage",
       "tier": "Free",
       "url": "https://www.gomomento.com/pricing",
       "tags": [
@@ -1747,7 +1969,7 @@
     {
       "vendor": "Doppler",
       "category": "Secrets Management",
-      "description": "Secrets management \u2014 up to 3 users, 10 projects, 4 environments per project. CLI, SDKs, and integrations included",
+      "description": "Secrets management — up to 3 users, 10 projects, 4 environments per project. CLI, SDKs, and integrations included",
       "tier": "Free",
       "url": "https://www.doppler.com/pricing",
       "tags": [
@@ -1762,7 +1984,7 @@
     {
       "vendor": "PostHog",
       "category": "Startup Programs",
-      "description": "$50,000/year in credits for Y Combinator companies \u2014 auto-renews annually. Covers product analytics, session replay, feature flags, and experimentation. Must have raised less than $25M",
+      "description": "$50,000/year in credits for Y Combinator companies — auto-renews annually. Covers product analytics, session replay, feature flags, and experimentation. Must have raised less than $25M",
       "tier": "YC Deal",
       "url": "https://posthog.com/pricing",
       "tags": [
@@ -1811,7 +2033,7 @@
     {
       "vendor": "Amplitude",
       "category": "Startup Programs",
-      "description": "1 year free Growth plan \u2014 200K MTUs or 100M events/month. All Growth features including Behavioral Cohorts, Pathfinder, experimentation, and predictive audiences. 96%+ approval rate",
+      "description": "1 year free Growth plan — 200K MTUs or 100M events/month. All Growth features including Behavioral Cohorts, Pathfinder, experimentation, and predictive audiences. 96%+ approval rate",
       "tier": "Startup Scholarship",
       "url": "https://amplitude.com/startups",
       "tags": [
@@ -1878,12 +2100,20 @@
           "Project meets Open Source Definition"
         ],
         "program": "JetBrains Open Source Licenses"
+      },
+      "referral_program": {
+        "available": false,
+        "referrer_benefit": "N/A",
+        "referee_benefit": "N/A",
+        "program_url": "https://www.jetbrains.com/company/partners/",
+        "type": "closed",
+        "notes": "No public affiliate program. Content Creators Program provides product access for promotion. Reseller partnerships available."
       }
     },
     {
       "vendor": "1Password",
       "category": "Security",
-      "description": "Free Teams account for open source projects \u2014 includes full platform access (Mac, Windows, iOS, Android, Linux, browser), SSH key management, Git commit signing, and secrets management. Non-expiring membership",
+      "description": "Free Teams account for open source projects — includes full platform access (Mac, Windows, iOS, Android, Linux, browser), SSH key management, Git commit signing, and secrets management. Non-expiring membership",
       "tier": "OSS Teams",
       "url": "https://github.com/1Password/1password-teams-open-source",
       "tags": [
@@ -1908,7 +2138,7 @@
     {
       "vendor": "Sentry",
       "category": "Startup Programs",
-      "description": "Free sponsored plan with Business features \u2014 5M errors, 1B spans, 5,000 GB logs, 100K replays, 500 cron monitors, 25 uptime monitors, 3K continuous profile hours. No term limit",
+      "description": "Free sponsored plan with Business features — 5M errors, 1B spans, 5,000 GB logs, 100K replays, 500 cron monitors, 25 uptime monitors, 3K continuous profile hours. No term limit",
       "tier": "OSS Sponsored",
       "url": "https://sentry.io/for/open-source/",
       "tags": [
@@ -1927,12 +2157,20 @@
           "Project released under a permissive open source license (e.g. Apache, MIT)"
         ],
         "program": "Sentry for Open Source"
+      },
+      "referral_program": {
+        "available": false,
+        "referrer_benefit": "N/A",
+        "referee_benefit": "N/A",
+        "program_url": "https://sentry.io",
+        "type": "closed",
+        "notes": "No affiliate/referral program for Sentry.io error monitoring. Sponsored account program available for open source."
       }
     },
     {
       "vendor": "Brex",
       "category": "Startup Programs",
-      "description": "$350,000+ in aggregate partner perks for Brex cardholders \u2014 includes $5K AWS credits, $2.5K OpenAI credits, $200K Google Cloud, 20 free GitHub Enterprise seats, 6mo free Notion, $500 Anthropic credits, and 30+ more partner discounts",
+      "description": "$350,000+ in aggregate partner perks for Brex cardholders — includes $5K AWS credits, $2.5K OpenAI credits, $200K Google Cloud, 20 free GitHub Enterprise seats, 6mo free Notion, $500 Anthropic credits, and 30+ more partner discounts",
       "tier": "Partner Perks",
       "url": "https://www.brex.com/solutions/startups",
       "tags": [
@@ -2005,7 +2243,7 @@
     {
       "vendor": "Stripe Atlas",
       "category": "Startup Programs",
-      "description": "$50,000+ in founder perks \u2014 $5K AWS credits, $5K DigitalOcean credits, 1yr GitHub, $2.5K Stripe processing credits, plus Notion, Slack, Zendesk, Intercom, and more",
+      "description": "$50,000+ in founder perks — $5K AWS credits, $5K DigitalOcean credits, 1yr GitHub, $2.5K Stripe processing credits, plus Notion, Slack, Zendesk, Intercom, and more",
       "tier": "Founder Perks",
       "url": "https://stripe.com/atlas",
       "tags": [
@@ -2024,7 +2262,15 @@
         ],
         "program": "Stripe Atlas Founder Perks"
       },
-      "expires_date": "2026-06-30"
+      "expires_date": "2026-06-30",
+      "referral_program": {
+        "available": false,
+        "referrer_benefit": "N/A",
+        "referee_benefit": "N/A",
+        "program_url": "https://stripe.partners",
+        "type": "partner",
+        "notes": "Partner ecosystem for integrations. No individual referral program."
+      }
     },
     {
       "vendor": "SVB (Silicon Valley Bank)",
@@ -2072,6 +2318,14 @@
           "Valid student ID or enrollment verification"
         ],
         "program": "GitHub Student Developer Pack"
+      },
+      "referral_program": {
+        "available": false,
+        "referrer_benefit": "N/A",
+        "referee_benefit": "N/A",
+        "program_url": "https://github.com/partners",
+        "type": "closed",
+        "notes": "No individual referral/affiliate program. Education partner program for student developer pack."
       }
     },
     {
@@ -2117,7 +2371,7 @@
     {
       "vendor": "Statically",
       "category": "CDN",
-      "description": "Free CDN for open source projects \u2014 serves files from GitHub, GitLab, Bitbucket repos and npm packages. ~20-30 MB file size limit",
+      "description": "Free CDN for open source projects — serves files from GitHub, GitLab, Bitbucket repos and npm packages. ~20-30 MB file size limit",
       "tier": "Free",
       "url": "https://statically.io/",
       "tags": [
@@ -2161,7 +2415,7 @@
     {
       "vendor": "Polar",
       "category": "Payments",
-      "description": "Merchant of record \u2014 no monthly fee, 4% + $0.40 per transaction (includes Stripe fees). +1.5% for international cards, +0.5% for subscriptions",
+      "description": "Merchant of record — no monthly fee, 4% + $0.40 per transaction (includes Stripe fees). +1.5% for international cards, +0.5% for subscriptions",
       "tier": "Pay-as-you-go",
       "url": "https://polar.sh/",
       "tags": [
@@ -2175,7 +2429,7 @@
     {
       "vendor": "Paddle",
       "category": "Payments",
-      "description": "Merchant of record \u2014 no monthly fee, 5% + $0.50 per transaction. All-in-one: payments, tax compliance, fraud protection, buyer support",
+      "description": "Merchant of record — no monthly fee, 5% + $0.50 per transaction. All-in-one: payments, tax compliance, fraud protection, buyer support",
       "tier": "Standard",
       "url": "https://www.paddle.com/pricing",
       "tags": [
@@ -2227,7 +2481,15 @@
         "self-hosted",
         "cloud"
       ],
-      "verifiedDate": "2026-04-05"
+      "verifiedDate": "2026-04-05",
+      "referral_program": {
+        "available": false,
+        "referrer_benefit": "N/A",
+        "referee_benefit": "N/A",
+        "program_url": "https://www.hashicorp.com/en/partners/become-a-partner",
+        "type": "partner",
+        "notes": "Technology and SI partner programs. No individual referral program."
+      }
     },
     {
       "vendor": "GrowthBook",
@@ -2288,7 +2550,7 @@
     {
       "vendor": "Hookdeck",
       "category": "API Gateway",
-      "description": "Event gateway \u2014 10K events/month, 100K discarded requests, 3-day retention, 5 events/sec throughput. SOC2 compliant",
+      "description": "Event gateway — 10K events/month, 100K discarded requests, 3-day retention, 5 events/sec throughput. SOC2 compliant",
       "tier": "Developer",
       "url": "https://hookdeck.com/pricing",
       "tags": [
@@ -2302,7 +2564,7 @@
     {
       "vendor": "Unkey",
       "category": "API Gateway",
-      "description": "API key management \u2014 1K keys, 150K verifications/month, 7-day logs, 30-day audit logs. Unlimited APIs. Ratelimiting included",
+      "description": "API key management — 1K keys, 150K verifications/month, 7-day logs, 30-day audit logs. Unlimited APIs. Ratelimiting included",
       "tier": "Free",
       "url": "https://www.unkey.com/pricing",
       "tags": [
@@ -2325,7 +2587,15 @@
         "packages",
         "github"
       ],
-      "verifiedDate": "2026-04-12"
+      "verifiedDate": "2026-04-12",
+      "referral_program": {
+        "available": false,
+        "referrer_benefit": "N/A",
+        "referee_benefit": "N/A",
+        "program_url": "https://github.com/partners",
+        "type": "closed",
+        "notes": "No individual referral program."
+      }
     },
     {
       "vendor": "Docker Hub",
@@ -2358,7 +2628,7 @@
     {
       "vendor": "Postman",
       "category": "Testing",
-      "description": "Free for single user only (since March 2026). Unlimited collections, environments, mock servers, basic monitoring. Team collaboration (shared workspaces, collection sharing) removed \u2014 requires Team plan ($19/user/mo). Postman-alternative tag: see Bruno, Hoppscotch, Insomnia, Thunder Client",
+      "description": "Free for single user only (since March 2026). Unlimited collections, environments, mock servers, basic monitoring. Team collaboration (shared workspaces, collection sharing) removed — requires Team plan ($19/user/mo). Postman-alternative tag: see Bruno, Hoppscotch, Insomnia, Thunder Client",
       "tier": "Free",
       "url": "https://www.postman.com/pricing/",
       "tags": [
@@ -2374,7 +2644,7 @@
     {
       "vendor": "Directus",
       "category": "Headless CMS",
-      "description": "Self-hosted free (BSL license, free for <$5M revenue). Cloud free tier discontinued Nov 2025 \u2014 Cloud starts at $15/mo",
+      "description": "Self-hosted free (BSL license, free for <$5M revenue). Cloud free tier discontinued Nov 2025 — Cloud starts at $15/mo",
       "tier": "Self-Hosted",
       "url": "https://directus.io/pricing",
       "tags": [
@@ -2417,7 +2687,7 @@
     {
       "vendor": "Tinybird",
       "category": "Analytics",
-      "description": "Real-time analytics data platform \u2014 10 GB storage, 10 QPS max, 0.25 vCPUs compute. Shared infrastructure, community support",
+      "description": "Real-time analytics data platform — 10 GB storage, 10 QPS max, 0.25 vCPUs compute. Shared infrastructure, community support",
       "tier": "Free",
       "url": "https://www.tinybird.co/pricing",
       "tags": [
@@ -2432,7 +2702,7 @@
     {
       "vendor": "Novu",
       "category": "Messaging",
-      "description": "Notification infrastructure \u2014 10K workflow runs/month, 20 workflows, 2 environments, 3 team members. All channels: email, in-app, SMS, chat, push",
+      "description": "Notification infrastructure — 10K workflow runs/month, 20 workflows, 2 environments, 3 team members. All channels: email, in-app, SMS, chat, push",
       "tier": "Free",
       "url": "https://novu.co/pricing",
       "tags": [
@@ -2446,7 +2716,7 @@
     {
       "vendor": "Svix",
       "category": "Messaging",
-      "description": "Webhook delivery \u2014 50K messages/month, 50 msg/sec throughput, 30-day payload retention, 3 team members. 99.9% SLA",
+      "description": "Webhook delivery — 50K messages/month, 50 msg/sec throughput, 30-day payload retention, 3 team members. 99.9% SLA",
       "tier": "Free",
       "url": "https://www.svix.com/pricing/",
       "tags": [
@@ -2460,7 +2730,7 @@
     {
       "vendor": "Crisp",
       "category": "Messaging",
-      "description": "Customer messaging platform \u2014 2 seats, 100 contacts, unlimited conversations. Website chat widget, shared inbox, desktop/mobile apps",
+      "description": "Customer messaging platform — 2 seats, 100 contacts, unlimited conversations. Website chat widget, shared inbox, desktop/mobile apps",
       "tier": "Free",
       "url": "https://crisp.chat/en/pricing/",
       "tags": [
@@ -2474,7 +2744,7 @@
     {
       "vendor": "Mintlify",
       "category": "API Development",
-      "description": "Developer documentation platform \u2014 custom domain, web editor, API playground, custom components, LLM optimizations. For individuals",
+      "description": "Developer documentation platform — custom domain, web editor, API playground, custom components, LLM optimizations. For individuals",
       "tier": "Hobby",
       "url": "https://mintlify.com/pricing",
       "tags": [
@@ -2488,7 +2758,7 @@
     {
       "vendor": "GitHub Pages",
       "category": "Cloud Hosting",
-      "description": "Static site hosting \u2014 1 GB published site size, 100 GB bandwidth/month, 10 builds/hour. Included with all GitHub accounts",
+      "description": "Static site hosting — 1 GB published site size, 100 GB bandwidth/month, 10 builds/hour. Included with all GitHub accounts",
       "tier": "Free",
       "url": "https://docs.github.com/en/pages",
       "tags": [
@@ -2497,12 +2767,20 @@
         "github",
         "jekyll"
       ],
-      "verifiedDate": "2026-04-05"
+      "verifiedDate": "2026-04-05",
+      "referral_program": {
+        "available": false,
+        "referrer_benefit": "N/A",
+        "referee_benefit": "N/A",
+        "program_url": "https://github.com/partners",
+        "type": "closed",
+        "notes": "No individual referral program."
+      }
     },
     {
       "vendor": "Pulsetic",
       "category": "Monitoring",
-      "description": "Uptime monitoring \u2014 10 monitors (HTTP/heartbeat/API), 5-minute check interval, 3 regions, 3-month history, 3 status pages",
+      "description": "Uptime monitoring — 10 monitors (HTTP/heartbeat/API), 5-minute check interval, 3 regions, 3-month history, 3 status pages",
       "tier": "Free",
       "url": "https://pulsetic.com/pricing/",
       "tags": [
@@ -2517,7 +2795,7 @@
     {
       "vendor": "Nile",
       "category": "Databases",
-      "description": "Postgres for multi-tenant apps \u2014 1 GB storage, 50M serverless query tokens, 500 max connections. Unlimited databases and tenant DBs. Always-on (no cold starts)",
+      "description": "Postgres for multi-tenant apps — 1 GB storage, 50M serverless query tokens, 500 max connections. Unlimited databases and tenant DBs. Always-on (no cold starts)",
       "tier": "Free",
       "url": "https://www.thenile.dev/pricing",
       "tags": [
@@ -2531,7 +2809,7 @@
     {
       "vendor": "Cron-job.org",
       "category": "Background Jobs",
-      "description": "Free cron job scheduling \u2014 unlimited jobs (fair use), 60-second minimum interval, 30-second execution timeout. Auto-disables after 25+ consecutive failures",
+      "description": "Free cron job scheduling — unlimited jobs (fair use), 60-second minimum interval, 30-second execution timeout. Auto-disables after 25+ consecutive failures",
       "tier": "Free",
       "url": "https://cron-job.org/en/",
       "tags": [
@@ -2545,7 +2823,7 @@
     {
       "vendor": "OneSignal",
       "category": "Messaging",
-      "description": "Push notification platform \u2014 unlimited mobile push, up to 10K web push subscribers, 100 emails/day. Multi-platform: iOS, Android, web",
+      "description": "Push notification platform — unlimited mobile push, up to 10K web push subscribers, 100 emails/day. Multi-platform: iOS, Android, web",
       "tier": "Free",
       "url": "https://onesignal.com/pricing",
       "tags": [
@@ -2559,7 +2837,7 @@
     {
       "vendor": "n8n",
       "category": "Background Jobs",
-      "description": "Workflow automation \u2014 self-hosted free (Sustainable Use License). 400+ integrations, visual workflow builder. Cloud free plan removed; all Cloud plans require payment (14-day free trial available). Unlimited active workflows on all paid plans",
+      "description": "Workflow automation — self-hosted free (Sustainable Use License). 400+ integrations, visual workflow builder. Cloud free plan removed; all Cloud plans require payment (14-day free trial available). Unlimited active workflows on all paid plans",
       "tier": "Self-Hosted",
       "url": "https://n8n.io/pricing/",
       "tags": [
@@ -2573,7 +2851,7 @@
     {
       "vendor": "Retool",
       "category": "Low-Code Platforms",
-      "description": "Internal tools builder \u2014 free for up to 5 users, unlimited apps. Drag-and-drop UI, 100+ integrations, custom components",
+      "description": "Internal tools builder — free for up to 5 users, unlimited apps. Drag-and-drop UI, 100+ integrations, custom components",
       "tier": "Free",
       "url": "https://retool.com/pricing",
       "tags": [
@@ -2587,7 +2865,7 @@
     {
       "vendor": "MinIO",
       "category": "Storage",
-      "description": "S3-compatible object storage \u2014 self-hosted free (GNU AGPL v3). High performance, Kubernetes-native. No usage limits when self-hosted. Primary alternative for LocalStack S3 emulation",
+      "description": "S3-compatible object storage — self-hosted free (GNU AGPL v3). High performance, Kubernetes-native. No usage limits when self-hosted. Primary alternative for LocalStack S3 emulation",
       "tier": "Open Source",
       "url": "https://min.io/pricing",
       "tags": [
@@ -2603,7 +2881,7 @@
     {
       "vendor": "Backblaze",
       "category": "Storage",
-      "description": "Flamethrower Startup Program \u2014 up to $100K in B2 Cloud Storage credits. For founders and small teams building data-heavy products (AI/ML, media, gaming, SaaS). Launched Feb 2026",
+      "description": "Flamethrower Startup Program — up to $100K in B2 Cloud Storage credits. For founders and small teams building data-heavy products (AI/ML, media, gaming, SaaS). Launched Feb 2026",
       "tier": "Flamethrower",
       "url": "https://www.backblaze.com/contact-sales/startup",
       "tags": [
@@ -2626,7 +2904,7 @@
     {
       "vendor": "DigitalOcean",
       "category": "Startup Programs",
-      "description": "Hatch startup program \u2014 up to $100K compute credits over 12 months. GPU Droplets at $1.90/GPU/hour for 12 months (H100 excluded from credits). 15 months Standard support. Partner perks from Cloudflare, Stripe, Retool, HubSpot. Must have raised $10M or less",
+      "description": "Hatch startup program — up to $100K compute credits over 12 months. GPU Droplets at $1.90/GPU/hour for 12 months (H100 excluded from credits). 15 months Standard support. Partner perks from Cloudflare, Stripe, Retool, HubSpot. Must have raised $10M or less",
       "tier": "Hatch",
       "url": "https://www.digitalocean.com/startups",
       "tags": [
@@ -2654,13 +2932,15 @@
         "referrer_benefit": "$25 credit",
         "referee_benefit": "$200 credit (60 days)",
         "program_url": "https://www.digitalocean.com/referral-program",
-        "type": "self-service"
+        "type": "self-service",
+        "commission_type": "credits",
+        "notes": "Both referrer and referee receive credits."
       }
     },
     {
       "vendor": "Atlassian",
       "category": "Project Management",
-      "description": "50 seats free for 12 months \u2014 Jira Premium, Confluence Premium, Loom Business + AI, Jira Product Discovery, Compass, Bitbucket Premium. Dedicated CSM and onboarding",
+      "description": "50 seats free for 12 months — Jira Premium, Confluence Premium, Loom Business + AI, Jira Product Discovery, Compass, Bitbucket Premium. Dedicated CSM and onboarding",
       "tier": "Startup Program",
       "url": "https://www.atlassian.com/software/startups",
       "tags": [
@@ -2684,7 +2964,7 @@
     {
       "vendor": "Pulumi",
       "category": "Infrastructure",
-      "description": "Infrastructure as Code platform \u2014 free for individuals with 1 user, unlimited projects/stacks/updates, 500 deployment minutes/mo, 25 secrets, 10K secret API calls/mo",
+      "description": "Infrastructure as Code platform — free for individuals with 1 user, unlimited projects/stacks/updates, 500 deployment minutes/mo, 25 secrets, 10K secret API calls/mo",
       "tier": "Individual",
       "url": "https://www.pulumi.com/pricing/",
       "tags": [
@@ -2700,7 +2980,7 @@
     {
       "vendor": "Spacelift",
       "category": "Infrastructure",
-      "description": "IaC orchestration platform \u2014 2 users, 1 API key, 1 public worker, OIDC integration, credential-less cloud provider integration, cost estimation",
+      "description": "IaC orchestration platform — 2 users, 1 API key, 1 public worker, OIDC integration, credential-less cloud provider integration, cost estimation",
       "tier": "Free",
       "url": "https://spacelift.io/pricing",
       "tags": [
@@ -2716,7 +2996,7 @@
     {
       "vendor": "HCP Terraform",
       "category": "Infrastructure",
-      "description": "HashiCorp managed Terraform \u2014 enhanced free tier (replacing legacy plan EOL March 31, 2026): 500 managed resources, unlimited users, SSO, policy as code (Sentinel + OPA), 1 concurrent run. Legacy free plan users auto-migrated to enhanced tier",
+      "description": "HashiCorp managed Terraform — enhanced free tier (replacing legacy plan EOL March 31, 2026): 500 managed resources, unlimited users, SSO, policy as code (Sentinel + OPA), 1 concurrent run. Legacy free plan users auto-migrated to enhanced tier",
       "tier": "Free (Enhanced)",
       "url": "https://www.hashicorp.com/products/terraform/pricing",
       "tags": [
@@ -2733,7 +3013,7 @@
     {
       "vendor": "Orama",
       "category": "Search",
-      "description": "Full-text, vector, and hybrid search engine \u2014 3 indexes, 100K documents/index, unlimited searches, 150 index updates/mo, 60-day analytics retention",
+      "description": "Full-text, vector, and hybrid search engine — 3 indexes, 100K documents/index, unlimited searches, 150 index updates/mo, 60-day analytics retention",
       "tier": "Free",
       "url": "https://orama.com/pricing",
       "tags": [
@@ -2748,7 +3028,7 @@
     {
       "vendor": "Quay.io",
       "category": "Container Registry",
-      "description": "Red Hat container registry \u2014 unlimited public repositories, 100 GB image layer storage soft cap, 1 TB egress soft cap. CI integration, robot accounts, teams, SSL/TLS",
+      "description": "Red Hat container registry — unlimited public repositories, 100 GB image layer storage soft cap, 1 TB egress soft cap. CI integration, robot accounts, teams, SSL/TLS",
       "tier": "Free",
       "url": "https://quay.io/plans/",
       "tags": [
@@ -2763,7 +3043,7 @@
     {
       "vendor": "BrowserStack Percy",
       "category": "Testing",
-      "description": "Visual regression testing \u2014 5,000 screenshots/month, unlimited users and projects, 30-day build history. Note: BrowserStack browser testing is trial-only; only Percy visual testing has a permanent free tier",
+      "description": "Visual regression testing — 5,000 screenshots/month, unlimited users and projects, 30-day build history. Note: BrowserStack browser testing is trial-only; only Percy visual testing has a permanent free tier",
       "tier": "Free",
       "url": "https://percy.io/pricing",
       "tags": [
@@ -2778,7 +3058,7 @@
     {
       "vendor": "Browserless",
       "category": "Browser Automation",
-      "description": "Headless browser API \u2014 1,000 units/mo (1 unit = 30 sec), 2 concurrent browsers, 1-minute max session with reconnects, automatic captcha solving, BrowserQL editor. Supports Chrome, WebKit, Firefox",
+      "description": "Headless browser API — 1,000 units/mo (1 unit = 30 sec), 2 concurrent browsers, 1-minute max session with reconnects, automatic captcha solving, BrowserQL editor. Supports Chrome, WebKit, Firefox",
       "tier": "Free",
       "url": "https://www.browserless.io/pricing",
       "tags": [
@@ -2793,7 +3073,7 @@
     {
       "vendor": "Browserbase",
       "category": "Browser Automation",
-      "description": "Headless browser infrastructure \u2014 1 browser hour/mo, 1 concurrent browser, 15-minute max session, 7-day data retention, 1 project",
+      "description": "Headless browser infrastructure — 1 browser hour/mo, 1 concurrent browser, 15-minute max session, 7-day data retention, 1 project",
       "tier": "Free",
       "url": "https://www.browserbase.com/pricing",
       "tags": [
@@ -2842,7 +3122,7 @@
     {
       "vendor": "Bugsnag",
       "category": "Error Tracking",
-      "description": "Error monitoring \u2014 7,500 events/month and 1M spans/month on free plan, 1 user, unlimited projects, 7-day data retention. 14-day free trial of paid features available. Rebranded as SmartBear Insight Hub",
+      "description": "Error monitoring — 7,500 events/month and 1M spans/month on free plan, 1 user, unlimited projects, 7-day data retention. 14-day free trial of paid features available. Rebranded as SmartBear Insight Hub",
       "tier": "Free",
       "url": "https://www.bugsnag.com/pricing/",
       "tags": [
@@ -2898,7 +3178,7 @@
     {
       "vendor": "Pipedream",
       "category": "Workflow Automation",
-      "description": "Developer-focused workflow automation \u2014 100 credits/month, 3 active workflows, 3 connected accounts. Building/testing workflows in the editor is free",
+      "description": "Developer-focused workflow automation — 100 credits/month, 3 active workflows, 3 connected accounts. Building/testing workflows in the editor is free",
       "tier": "Free",
       "url": "https://pipedream.com/pricing",
       "tags": [
@@ -2913,7 +3193,7 @@
     {
       "vendor": "Make",
       "category": "Workflow Automation",
-      "description": "Visual workflow automation (formerly Integromat) \u2014 1,000 operations/month, 100 MB data transfer/mo, 2 active scenarios, 15-minute minimum interval",
+      "description": "Visual workflow automation (formerly Integromat) — 1,000 operations/month, 100 MB data transfer/mo, 2 active scenarios, 15-minute minimum interval",
       "tier": "Free Forever",
       "url": "https://www.make.com/en/pricing",
       "tags": [
@@ -2928,7 +3208,7 @@
     {
       "vendor": "Zapier",
       "category": "Workflow Automation",
-      "description": "Workflow automation \u2014 100 tasks/month, unlimited Zaps but limited to 2-step only (one trigger + one action), 2,500 table records, 10 form pages",
+      "description": "Workflow automation — 100 tasks/month, unlimited Zaps but limited to 2-step only (one trigger + one action), 2,500 table records, 10 form pages",
       "tier": "Free",
       "url": "https://zapier.com/pricing",
       "tags": [
@@ -2943,7 +3223,7 @@
     {
       "vendor": "GlitchTip",
       "category": "Error Tracking",
-      "description": "Open-source error tracking \u2014 1,000 events/month, unlimited projects and team members, Sentry SDK-compatible. Also includes uptime monitoring. Self-hostable for unlimited",
+      "description": "Open-source error tracking — 1,000 events/month, unlimited projects and team members, Sentry SDK-compatible. Also includes uptime monitoring. Self-hostable for unlimited",
       "tier": "Free",
       "url": "https://glitchtip.com/pricing/",
       "tags": [
@@ -2958,7 +3238,7 @@
     {
       "vendor": "LogRocket",
       "category": "Error Tracking",
-      "description": "Session replay and error tracking \u2014 1,000 sessions/month, 1-month data retention, 3 seats. Includes session replay, console logs, stack traces, network request data",
+      "description": "Session replay and error tracking — 1,000 sessions/month, 1-month data retention, 3 seats. Includes session replay, console logs, stack traces, network request data",
       "tier": "Free Forever",
       "url": "https://logrocket.com/pricing",
       "tags": [
@@ -2973,7 +3253,7 @@
     {
       "vendor": "LiveKit",
       "category": "Communication",
-      "description": "Real-time audio/video and AI agent infrastructure \u2014 5,000 WebRTC minutes/mo, 1,000 agent session minutes/mo, 5 concurrent agent sessions, 100 concurrent connections, 1 free US phone number. Open source",
+      "description": "Real-time audio/video and AI agent infrastructure — 5,000 WebRTC minutes/mo, 1,000 agent session minutes/mo, 5 concurrent agent sessions, 100 concurrent connections, 1 free US phone number. Open source",
       "tier": "Build",
       "url": "https://livekit.io/pricing",
       "tags": [
@@ -2989,7 +3269,7 @@
     {
       "vendor": "ReadMe",
       "category": "Documentation",
-      "description": "API documentation platform \u2014 1 project, 1 API reference, 3 published versions, 5 admins, basic AI features, ReadMe branding. No custom domain",
+      "description": "API documentation platform — 1 project, 1 API reference, 3 published versions, 5 admins, basic AI features, ReadMe branding. No custom domain",
       "tier": "Free",
       "url": "https://readme.com/pricing",
       "tags": [
@@ -3003,7 +3283,7 @@
     {
       "vendor": "GitBook",
       "category": "Documentation",
-      "description": "Documentation platform \u2014 1 user, gitbook.io subdomain, unlimited traffic, public publishing. No custom domain or AI answers on free tier",
+      "description": "Documentation platform — 1 user, gitbook.io subdomain, unlimited traffic, public publishing. No custom domain or AI answers on free tier",
       "tier": "Free",
       "url": "https://www.gitbook.com/pricing",
       "tags": [
@@ -3017,7 +3297,7 @@
     {
       "vendor": "Chromatic",
       "category": "Testing",
-      "description": "Visual regression testing by the Storybook team \u2014 5,000 snapshots/month, Chrome-only, unlimited projects and collaborators, Git and CI integrations, UI version tracking",
+      "description": "Visual regression testing by the Storybook team — 5,000 snapshots/month, Chrome-only, unlimited projects and collaborators, Git and CI integrations, UI version tracking",
       "tier": "Free",
       "url": "https://www.chromatic.com/pricing",
       "tags": [
@@ -3032,7 +3312,7 @@
     {
       "vendor": "Figma",
       "category": "Design",
-      "description": "Collaborative design tool \u2014 3 Figma design files, 3 FigJam files, unlimited drafts, unlimited viewers, 30-day version history, unlimited cloud storage",
+      "description": "Collaborative design tool — 3 Figma design files, 3 FigJam files, unlimited drafts, unlimited viewers, 30-day version history, unlimited cloud storage",
       "tier": "Starter",
       "url": "https://www.figma.com/pricing/",
       "tags": [
@@ -3062,7 +3342,7 @@
     {
       "vendor": "Penpot",
       "category": "Design",
-      "description": "Open-source design platform \u2014 unlimited teams, unlimited designers/developers, unlimited design files, team libraries. Self-hostable (MPL 2.0). Cloud-hosted free tier has ~10 GB storage",
+      "description": "Open-source design platform — unlimited teams, unlimited designers/developers, unlimited design files, team libraries. Self-hostable (MPL 2.0). Cloud-hosted free tier has ~10 GB storage",
       "tier": "Free",
       "url": "https://penpot.app/pricing",
       "tags": [
@@ -3078,7 +3358,7 @@
     {
       "vendor": "GitGuardian",
       "category": "Security",
-      "description": "Secrets detection for up to 25 developers \u2014 420+ secret types, unlimited real-time scanning, 500 historical scan detections, CLI (ggshield) for pre-commit hooks, VSCode extension, 10K API calls/month",
+      "description": "Secrets detection for up to 25 developers — 420+ secret types, unlimited real-time scanning, 500 historical scan detections, CLI (ggshield) for pre-commit hooks, VSCode extension, 10K API calls/month",
       "tier": "Free",
       "url": "https://www.gitguardian.com/pricing",
       "tags": [
@@ -3093,7 +3373,7 @@
     {
       "vendor": "Sendbird",
       "category": "Communication",
-      "description": "Chat SDK \u2014 Developer plan: 1,000 MAU, 20 peak concurrent connections, unlimited messages/month, unlimited storage (6-month retention). All Pro features included (typing indicators, read receipts, push notifications)",
+      "description": "Chat SDK — Developer plan: 1,000 MAU, 20 peak concurrent connections, unlimited messages/month, unlimited storage (6-month retention). All Pro features included (typing indicators, read receipts, push notifications)",
       "tier": "Developer",
       "url": "https://sendbird.com/pricing/chat",
       "tags": [
@@ -3108,7 +3388,7 @@
     {
       "vendor": "Knock",
       "category": "Messaging",
-      "description": "Notification infrastructure \u2014 10,000 notifications/month, 500 guide active users, unlimited workflows/broadcasts/channels/team members. All delivery channels included",
+      "description": "Notification infrastructure — 10,000 notifications/month, 500 guide active users, unlimited workflows/broadcasts/channels/team members. All delivery channels included",
       "tier": "Developer",
       "url": "https://knock.app/pricing",
       "tags": [
@@ -3187,7 +3467,7 @@
     {
       "vendor": "Formbricks",
       "category": "Forms",
-      "description": "Open-source survey platform \u2014 Community Edition (self-hosted): unlimited seats, unlimited surveys, unlimited responses, all question types, advanced logic, custom styling, API access, all SDKs and integrations (MPL 2.0)",
+      "description": "Open-source survey platform — Community Edition (self-hosted): unlimited seats, unlimited surveys, unlimited responses, all question types, advanced logic, custom styling, API access, all SDKs and integrations (MPL 2.0)",
       "tier": "Community",
       "url": "https://formbricks.com/pricing",
       "tags": [
@@ -3219,7 +3499,7 @@
     {
       "vendor": "Lokalise",
       "category": "Localization",
-      "description": "Localization platform \u2014 1 project, 2 target languages, 500K hosted words, 500 translation keys, 10K processed words/year, 2 advanced seats, 1 integration, 1 automation, 1 GB OTA calls",
+      "description": "Localization platform — 1 project, 2 target languages, 500K hosted words, 500 translation keys, 10K processed words/year, 2 advanced seats, 1 integration, 1 automation, 1 GB OTA calls",
       "tier": "Free",
       "url": "https://lokalise.com/pricing/",
       "tags": [
@@ -3234,7 +3514,7 @@
     {
       "vendor": "Cal.com",
       "category": "Team Collaboration",
-      "description": "Open-source scheduling \u2014 unlimited event types, unlimited bookings, unlimited calendar connections, routing forms, workflow automation, payment processing, Cal Video conferencing. 1 user",
+      "description": "Open-source scheduling — unlimited event types, unlimited bookings, unlimited calendar connections, routing forms, workflow automation, payment processing, Cal Video conferencing. 1 user",
       "tier": "Free",
       "url": "https://cal.com/pricing",
       "tags": [
@@ -3249,7 +3529,7 @@
     {
       "vendor": "Tawk.to",
       "category": "Communication",
-      "description": "100% free live chat software \u2014 unlimited agents, unlimited concurrent chats, unlimited message history, unlimited sites, 45+ languages, CRM, ticketing, knowledge base, video/voice chat, screen sharing",
+      "description": "100% free live chat software — unlimited agents, unlimited concurrent chats, unlimited message history, unlimited sites, 45+ languages, CRM, ticketing, knowledge base, video/voice chat, screen sharing",
       "tier": "Free",
       "url": "https://www.tawk.to/pricing/",
       "tags": [
@@ -3265,7 +3545,7 @@
     {
       "vendor": "Uploadcare",
       "category": "Storage",
-      "description": "File uploading API and image CDN \u2014 free tier for small-scale projects with file upload widget, image transformations, adaptive delivery. 100 MB file size limit. Usage resets monthly",
+      "description": "File uploading API and image CDN — free tier for small-scale projects with file upload widget, image transformations, adaptive delivery. 100 MB file size limit. Usage resets monthly",
       "tier": "Free",
       "url": "https://uploadcare.com/pricing/",
       "tags": [
@@ -3355,13 +3635,13 @@
           "Growth tier: up to 50 users",
           "Scale tier: up to 100 users"
         ],
-        "program": "AWS Startups \u2014 Kiro Pro+"
+        "program": "AWS Startups — Kiro Pro+"
       }
     },
     {
       "vendor": "Healthchecks.io",
       "category": "Monitoring",
-      "description": "Cron job and scheduled task monitoring \u2014 20 monitors, 100 log entries per job, email/webhook/Slack/Telegram alerts, API access. Also free for open-source projects (Business plan)",
+      "description": "Cron job and scheduled task monitoring — 20 monitors, 100 log entries per job, email/webhook/Slack/Telegram alerts, API access. Also free for open-source projects (Business plan)",
       "tier": "Free",
       "url": "https://healthchecks.io/pricing/",
       "tags": [
@@ -3377,7 +3657,7 @@
     {
       "vendor": "ImageKit",
       "category": "Storage",
-      "description": "Real-time image and video optimization with CDN \u2014 20 GB bandwidth/month, 20 GB media storage, unlimited image transformations, 1,000 video processing units. No credit card required",
+      "description": "Real-time image and video optimization with CDN — 20 GB bandwidth/month, 20 GB media storage, unlimited image transformations, 1,000 video processing units. No credit card required",
       "tier": "Free",
       "url": "https://imagekit.io/plans/",
       "tags": [
@@ -3393,7 +3673,7 @@
     {
       "vendor": "Expo",
       "category": "Mobile Development",
-      "description": "React Native build and deployment platform \u2014 30 builds/month (up to 15 iOS), 1,000 MAU for EAS Update, 100,000 hosting requests, 1M CPU-ms, 1 GB hosting storage. No credit card required",
+      "description": "React Native build and deployment platform — 30 builds/month (up to 15 iOS), 1,000 MAU for EAS Update, 100,000 hosting requests, 1M CPU-ms, 1 GB hosting storage. No credit card required",
       "tier": "Free",
       "url": "https://expo.dev/pricing",
       "tags": [
@@ -3410,7 +3690,7 @@
     {
       "vendor": "Crowdin",
       "category": "Localization",
-      "description": "Localization management \u2014 free forever for open-source (unlimited projects/translators). Private: 1 project, 60K hosted words, 1 integration, Crowdin AI access. CLI, GitHub integration, REST API",
+      "description": "Localization management — free forever for open-source (unlimited projects/translators). Private: 1 project, 60K hosted words, 1 integration, Crowdin AI access. CLI, GitHub integration, REST API",
       "tier": "Free",
       "url": "https://crowdin.com/pricing",
       "tags": [
@@ -3425,7 +3705,7 @@
     {
       "vendor": "Permit.io",
       "category": "Auth",
-      "description": "Authorization-as-a-service \u2014 1,000 MAU, all authorization models (RBAC/ABAC/ReBAC), unlimited PDPs, no-code UI, GitOps workflows, GitHub/Terraform integration, SDKs and APIs",
+      "description": "Authorization-as-a-service — 1,000 MAU, all authorization models (RBAC/ABAC/ReBAC), unlimited PDPs, no-code UI, GitOps workflows, GitHub/Terraform integration, SDKs and APIs",
       "tier": "Free",
       "url": "https://www.permit.io/pricing",
       "tags": [
@@ -3441,7 +3721,7 @@
     {
       "vendor": "Codecov",
       "category": "Testing",
-      "description": "Code coverage reporting and analytics \u2014 Developer plan free for 1 user with unlimited public and private repos, 250 private uploads/month. Always free and unlimited for open-source. PR comments, status checks, patch coverage, bundle analysis included. Integrates with GitHub, GitLab, Bitbucket CI/CD",
+      "description": "Code coverage reporting and analytics — Developer plan free for 1 user with unlimited public and private repos, 250 private uploads/month. Always free and unlimited for open-source. PR comments, status checks, patch coverage, bundle analysis included. Integrates with GitHub, GitLab, Bitbucket CI/CD",
       "tier": "Developer",
       "url": "https://about.codecov.io/pricing/",
       "tags": [
@@ -3456,7 +3736,7 @@
     {
       "vendor": "Dub.co",
       "category": "Dev Utilities",
-      "description": "Open-source link management \u2014 25 new links/month, 1,000 tracked events/month, 3 custom domains, 1 user, 30-day analytics retention, API with native SDKs. No credit card required",
+      "description": "Open-source link management — 25 new links/month, 1,000 tracked events/month, 3 custom domains, 1 user, 30-day analytics retention, API with native SDKs. No credit card required",
       "tier": "Free",
       "url": "https://dub.co/pricing",
       "tags": [
@@ -3471,7 +3751,7 @@
     {
       "vendor": "Stytch",
       "category": "Auth",
-      "description": "Authentication and fraud prevention \u2014 10,000 MAU, passwordless login, OAuth, MFA, session management, device fingerprinting, 5 SSO/SCIM connections, 1,000 M2M tokens, password breach detection",
+      "description": "Authentication and fraud prevention — 10,000 MAU, passwordless login, OAuth, MFA, session management, device fingerprinting, 5 SSO/SCIM connections, 1,000 M2M tokens, password breach detection",
       "tier": "Free",
       "url": "https://stytch.com/pricing",
       "tags": [
@@ -3489,7 +3769,7 @@
     {
       "vendor": "Liveblocks",
       "category": "Team Collaboration",
-      "description": "Real-time collaboration infrastructure \u2014 unlimited MAU, 500 monthly active rooms, 256 MB realtime data + 512 MB file storage, 3 dashboard seats, 10 projects. Presence, cursors, comments, notifications, text editor components",
+      "description": "Real-time collaboration infrastructure — unlimited MAU, 500 monthly active rooms, 256 MB realtime data + 512 MB file storage, 3 dashboard seats, 10 projects. Presence, cursors, comments, notifications, text editor components",
       "tier": "Free",
       "url": "https://liveblocks.io/pricing",
       "tags": [
@@ -3505,7 +3785,7 @@
     {
       "vendor": "Nango",
       "category": "API Development",
-      "description": "Integration infrastructure for 600+ APIs \u2014 10 connections, unified auth/data syncing/webhook handling, unlimited development/testing time. All API integrations accessible",
+      "description": "Integration infrastructure for 600+ APIs — 10 connections, unified auth/data syncing/webhook handling, unlimited development/testing time. All API integrations accessible",
       "tier": "Free",
       "url": "https://nango.dev/pricing",
       "tags": [
@@ -3967,7 +4247,7 @@
     {
       "vendor": "FusionAuth",
       "category": "Auth",
-      "description": "Full-featured identity platform \u2014 community edition: unlimited users, self-hosted free (Apache 2.0). Includes OAuth2/OIDC, SAML, passwordless, MFA, social login, user management, webhooks, themes",
+      "description": "Full-featured identity platform — community edition: unlimited users, self-hosted free (Apache 2.0). Includes OAuth2/OIDC, SAML, passwordless, MFA, social login, user management, webhooks, themes",
       "tier": "Community",
       "url": "https://fusionauth.io/pricing",
       "tags": [
@@ -4212,7 +4492,7 @@
     {
       "vendor": "Hoppscotch",
       "category": "API Development",
-      "description": "Free OSS (MIT). API development ecosystem \u2014 REST, GraphQL, WebSocket, SSE, Socket.IO, MQTT testing. Real-time collaboration, environments, collections. Web, desktop, and CLI",
+      "description": "Free OSS (MIT). API development ecosystem — REST, GraphQL, WebSocket, SSE, Socket.IO, MQTT testing. Real-time collaboration, environments, collections. Web, desktop, and CLI",
       "tier": "Free OSS",
       "url": "https://hoppscotch.io/",
       "tags": [
@@ -4372,7 +4652,7 @@
     {
       "vendor": "Vera AWS",
       "category": "Cloud IaaS",
-      "description": "Open-source local AWS emulator. v0.1 supports 89 resource types including VPCs, EC2 instances, security groups, and EBS volumes \u2014 EC2 emulation is unique among LocalStack alternatives. Includes awscli drop-in wrapper and terlocal terraform wrapper. No AWS account or Docker required. Runs entirely on your machine",
+      "description": "Open-source local AWS emulator. v0.1 supports 89 resource types including VPCs, EC2 instances, security groups, and EBS volumes — EC2 emulation is unique among LocalStack alternatives. Includes awscli drop-in wrapper and terlocal terraform wrapper. No AWS account or Docker required. Runs entirely on your machine",
       "tier": "Open Source",
       "url": "https://github.com/project-vera/vera-aws",
       "tags": [
@@ -4391,7 +4671,7 @@
     {
       "vendor": "Floci",
       "category": "Cloud IaaS",
-      "description": "Open-source AWS service emulator \u2014 the leading community replacement for LocalStack CE. 20+ AWS services supported with 408/408 SDK tests passing. 90 MB Docker image (vs LocalStack's 1.0 GB), 24ms startup (vs 3.3s). MIT license, no auth token required. v1.0.4 released March 2026",
+      "description": "Open-source AWS service emulator — the leading community replacement for LocalStack CE. 20+ AWS services supported with 408/408 SDK tests passing. 90 MB Docker image (vs LocalStack's 1.0 GB), 24ms startup (vs 3.3s). MIT license, no auth token required. v1.0.4 released March 2026",
       "tier": "Open Source",
       "url": "https://github.com/hectorvent/floci",
       "tags": [
@@ -4423,7 +4703,7 @@
     {
       "vendor": "OpenAI",
       "category": "AI / ML",
-      "description": "AI API platform \u2014 free tier limited to GPT-3.5 Turbo model only, 3 requests/minute rate limit. No free trial credits for new accounts (discontinued mid-2025). Paid tiers use token-based pricing: GPT-4o from $2.50/1M input tokens. Batch processing at 50% discount available",
+      "description": "AI API platform — free tier limited to GPT-3.5 Turbo model only, 3 requests/minute rate limit. No free trial credits for new accounts (discontinued mid-2025). Paid tiers use token-based pricing: GPT-4o from $2.50/1M input tokens. Batch processing at 50% discount available",
       "tier": "Free",
       "url": "https://openai.com/api/pricing/",
       "tags": [
@@ -4438,12 +4718,20 @@
       "verifiedDate": "2026-04-13",
       "payment_protocols": [
         "x402"
-      ]
+      ],
+      "referral_program": {
+        "available": false,
+        "referrer_benefit": "N/A",
+        "referee_benefit": "N/A",
+        "program_url": "https://openai.com/form/partnerintake/",
+        "type": "closed",
+        "notes": "No public affiliate/referral program. Referral features reportedly in development but not launched."
+      }
     },
     {
       "vendor": "X (Twitter)",
       "category": "API Gateway",
-      "description": "Social media API \u2014 free tier eliminated February 2026, replaced with pay-per-use credit model. Active free-tier users receive $0 voucher. 'For-good' utility apps remain free. Basic fixed tier starts at $200/month. Pay-per-use credits available as alternative to fixed tiers",
+      "description": "Social media API — free tier eliminated February 2026, replaced with pay-per-use credit model. Active free-tier users receive $0 voucher. 'For-good' utility apps remain free. Basic fixed tier starts at $200/month. Pay-per-use credits available as alternative to fixed tiers",
       "tier": "Pay-per-use (no free tier)",
       "url": "https://developer.x.com/en/portal/products",
       "tags": [
@@ -4490,7 +4778,7 @@
     {
       "vendor": "Twingate",
       "category": "Security",
-      "description": "Zero trust network access \u2014 Starter plan free forever: 5 users, 10 remote networks. Replace traditional VPNs with identity-based access to internal resources",
+      "description": "Zero trust network access — Starter plan free forever: 5 users, 10 remote networks. Replace traditional VPNs with identity-based access to internal resources",
       "tier": "Free",
       "url": "https://www.twingate.com/pricing",
       "tags": [
@@ -4505,7 +4793,7 @@
     {
       "vendor": "PythonAnywhere",
       "category": "Cloud Hosting",
-      "description": "Python web hosting \u2014 Beginner plan free forever: 1 web app (yourusername.pythonanywhere.com), 512 MB disk, 100 CPU-seconds/day, 2 consoles. Outbound internet access available to whitelisted sites via HTTP(S)",
+      "description": "Python web hosting — Beginner plan free forever: 1 web app (yourusername.pythonanywhere.com), 512 MB disk, 100 CPU-seconds/day, 2 consoles. Outbound internet access available to whitelisted sites via HTTP(S)",
       "tier": "Free",
       "url": "https://www.pythonanywhere.com/pricing/",
       "tags": [
@@ -4519,7 +4807,7 @@
     {
       "vendor": "GitHub Codespaces",
       "category": "IDE & Code Editors",
-      "description": "Cloud development environments \u2014 120 core hours/month (60 hours on 2-core machine) + 15 GB storage free for all GitHub users. Pre-configured dev containers with VS Code in browser",
+      "description": "Cloud development environments — 120 core hours/month (60 hours on 2-core machine) + 15 GB storage free for all GitHub users. Pre-configured dev containers with VS Code in browser",
       "tier": "Free",
       "url": "https://github.com/features/codespaces",
       "tags": [
@@ -4529,12 +4817,20 @@
         "github",
         "containers"
       ],
-      "verifiedDate": "2026-04-12"
+      "verifiedDate": "2026-04-12",
+      "referral_program": {
+        "available": false,
+        "referrer_benefit": "N/A",
+        "referee_benefit": "N/A",
+        "program_url": "https://github.com/partners",
+        "type": "closed",
+        "notes": "No individual referral program."
+      }
     },
     {
       "vendor": "ngrok",
       "category": "Infrastructure",
-      "description": "Tunneling and ingress platform \u2014 3 online endpoints, 1 GB bandwidth, 20K HTTP/S requests/month, 1 dev domain, 5K TCP/TLS connections. Includes $5 one-time usage credit",
+      "description": "Tunneling and ingress platform — 3 online endpoints, 1 GB bandwidth, 20K HTTP/S requests/month, 1 dev domain, 5K TCP/TLS connections. Includes $5 one-time usage credit",
       "tier": "Free",
       "url": "https://ngrok.com/pricing",
       "tags": [
@@ -4548,7 +4844,7 @@
     {
       "vendor": "Tailscale",
       "category": "Security",
-      "description": "Mesh VPN with WireGuard \u2014 6 users, unlimited devices, MagicDNS, exit nodes, subnet routing. Free Personal plan.",
+      "description": "Mesh VPN with WireGuard — 6 users, unlimited devices, MagicDNS, exit nodes, subnet routing. Free Personal plan.",
       "tier": "Personal",
       "url": "https://tailscale.com/pricing",
       "tags": [
@@ -4563,7 +4859,7 @@
     {
       "vendor": "Redis Cloud",
       "category": "Databases",
-      "description": "Managed Redis \u2014 30 MB memory, single database, shared deployment. Best-effort SLA, community support",
+      "description": "Managed Redis — 30 MB memory, single database, shared deployment. Best-effort SLA, community support",
       "tier": "Free",
       "url": "https://redis.io/pricing",
       "tags": [
@@ -4578,7 +4874,7 @@
     {
       "vendor": "Pinecone",
       "category": "AI / ML",
-      "description": "Vector database \u2014 2 GB storage, 2M write units/month, 1M read units/month, 5 indexes, 5M embedding tokens/month. Pinecone Assistant: 100 docs / 1 GB",
+      "description": "Vector database — 2 GB storage, 2M write units/month, 1M read units/month, 5 indexes, 5M embedding tokens/month. Pinecone Assistant: 100 docs / 1 GB",
       "tier": "Starter",
       "url": "https://pinecone.io/pricing",
       "tags": [
@@ -4593,7 +4889,7 @@
     {
       "vendor": "Qdrant",
       "category": "AI / ML",
-      "description": "Vector database \u2014 1 GB free forever cluster, fully managed on AWS/GCP/Azure. Unlimited users, backups included. No credit card required",
+      "description": "Vector database — 1 GB free forever cluster, fully managed on AWS/GCP/Azure. Unlimited users, backups included. No credit card required",
       "tier": "Free Forever",
       "url": "https://qdrant.tech/pricing/",
       "tags": [
@@ -4608,7 +4904,7 @@
     {
       "vendor": "SuperTokens",
       "category": "Auth",
-      "description": "Open source authentication \u2014 cloud: 5K MAUs free. Self-hosted: unlimited. Email/password, social login, passwordless, RBAC, user management dashboard",
+      "description": "Open source authentication — cloud: 5K MAUs free. Self-hosted: unlimited. Email/password, social login, passwordless, RBAC, user management dashboard",
       "tier": "Free",
       "url": "https://supertokens.com/pricing",
       "tags": [
@@ -4622,7 +4918,7 @@
     {
       "vendor": "StatusCake",
       "category": "Monitoring",
-      "description": "Uptime monitoring \u2014 10 monitors, 5-min intervals, 1 page speed monitor, 1 domain monitor, 1 SSL monitor, 75 free SMS credits/month, 15+ alert integrations",
+      "description": "Uptime monitoring — 10 monitors, 5-min intervals, 1 page speed monitor, 1 domain monitor, 1 SSL monitor, 75 free SMS credits/month, 15+ alert integrations",
       "tier": "Free",
       "url": "https://www.statuscake.com/pricing/",
       "tags": [
@@ -4637,7 +4933,7 @@
     {
       "vendor": "PagerDuty",
       "category": "Monitoring",
-      "description": "Incident management \u2014 5 users, 1 on-call schedule, 1 escalation policy, 100 intl phone/SMS notifications/month, 700+ integrations, API access",
+      "description": "Incident management — 5 users, 1 on-call schedule, 1 escalation policy, 100 intl phone/SMS notifications/month, 700+ integrations, API access",
       "tier": "Free",
       "url": "https://www.pagerduty.com/pricing/",
       "tags": [
@@ -4651,7 +4947,7 @@
     {
       "vendor": "imgix",
       "category": "CDN",
-      "description": "Image CDN and optimization \u2014 1,000 origin images, unlimited transformations, full rendering API, Asset Manager included",
+      "description": "Image CDN and optimization — 1,000 origin images, unlimited transformations, full rendering API, Asset Manager included",
       "tier": "Free",
       "url": "https://www.imgix.com/pricing",
       "tags": [
@@ -4665,7 +4961,7 @@
     {
       "vendor": "Lemon Squeezy",
       "category": "Payments",
-      "description": "Merchant of record for digital products \u2014 $0/month, all features included (payments, subscriptions, tax compliance, fraud protection). Revenue: 5% + 50c/transaction. Email marketing: 500 subscribers free",
+      "description": "Merchant of record for digital products — $0/month, all features included (payments, subscriptions, tax compliance, fraud protection). Revenue: 5% + 50c/transaction. Email marketing: 500 subscribers free",
       "tier": "Free",
       "url": "https://www.lemonsqueezy.com/pricing",
       "tags": [
@@ -4679,7 +4975,7 @@
     {
       "vendor": "Airtable",
       "category": "Low-Code Platforms",
-      "description": "Low-code database and app platform \u2014 free tier: unlimited bases, 1,000 records per base, 1 GB attachment space per base, 100 automation runs/month, 5 editor+ collaborators, 500 AI credits/user/month, 14-day revision history",
+      "description": "Low-code database and app platform — free tier: unlimited bases, 1,000 records per base, 1 GB attachment space per base, 100 automation runs/month, 5 editor+ collaborators, 500 AI credits/user/month, 14-day revision history",
       "tier": "Free",
       "url": "https://airtable.com/pricing",
       "tags": [
@@ -4694,7 +4990,7 @@
     {
       "vendor": "Deepgram",
       "category": "AI / ML",
-      "description": "Speech-to-text and text-to-speech API \u2014 $200 free credits on signup (no credit card required), ~43K minutes transcription with Nova model, credits never expire. Access to all model endpoints",
+      "description": "Speech-to-text and text-to-speech API — $200 free credits on signup (no credit card required), ~43K minutes transcription with Nova model, credits never expire. Access to all model endpoints",
       "tier": "Free Credits",
       "url": "https://deepgram.com/pricing",
       "tags": [
@@ -4709,7 +5005,7 @@
     {
       "vendor": "OpenWeatherMap",
       "category": "Maps/Geolocation",
-      "description": "Weather API \u2014 free tier: 1M API calls/month (60/min), current weather, 5-day forecast, air pollution, weather maps (15 layers), geocoding. Student plan includes historical data and extended forecasts at same limits",
+      "description": "Weather API — free tier: 1M API calls/month (60/min), current weather, 5-day forecast, air pollution, weather maps (15 layers), geocoding. Student plan includes historical data and extended forecasts at same limits",
       "tier": "Free",
       "url": "https://openweathermap.org/price",
       "tags": [
@@ -4724,7 +5020,7 @@
     {
       "vendor": "Semgrep",
       "category": "Security",
-      "description": "Static analysis (SAST) and software composition analysis (SCA) \u2014 free tier: 10 contributors, 50 private repos (unlimited public), cross-file analysis with Pro rules, AI-powered triage and remediation, one-click CI/CD deployment",
+      "description": "Static analysis (SAST) and software composition analysis (SCA) — free tier: 10 contributors, 50 private repos (unlimited public), cross-file analysis with Pro rules, AI-powered triage and remediation, one-click CI/CD deployment",
       "tier": "Free",
       "url": "https://semgrep.dev/pricing",
       "tags": [
@@ -4739,7 +5035,7 @@
     {
       "vendor": "Cronitor",
       "category": "Monitoring",
-      "description": "Cron job and uptime monitoring \u2014 free Hacker plan: 5 monitors, 5-minute check frequency, email and Slack alerts, 1 status page (50 subscribers), 12-month data retention, single user",
+      "description": "Cron job and uptime monitoring — free Hacker plan: 5 monitors, 5-minute check frequency, email and Slack alerts, 1 status page (50 subscribers), 12-month data retention, single user",
       "tier": "Hacker",
       "url": "https://cronitor.io/pricing",
       "tags": [
@@ -4755,7 +5051,7 @@
     {
       "vendor": "Semaphore CI",
       "category": "CI/CD",
-      "description": "CI/CD platform \u2014 free cloud plan: $15 credits/month (~2,000 Ubuntu build minutes), 20 concurrent jobs, YAML pipelines, secrets management. Self-hosted available at $0.0025/min. Cloud starts at $0.0075/min for Ubuntu",
+      "description": "CI/CD platform — free cloud plan: $15 credits/month (~2,000 Ubuntu build minutes), 20 concurrent jobs, YAML pipelines, secrets management. Self-hosted available at $0.0025/min. Cloud starts at $0.0075/min for Ubuntu",
       "tier": "Community (Self-hosted)",
       "url": "https://semaphore.io/pricing",
       "tags": [
@@ -4771,7 +5067,7 @@
     {
       "vendor": "Prisma Accelerate",
       "category": "Databases",
-      "description": "Connection pooling and caching for any database \u2014 100,000 operations/month, 10 connection pool limit, auto-scaling. Also available: Prisma Postgres free tier with 500 MB storage and up to 5 databases",
+      "description": "Connection pooling and caching for any database — 100,000 operations/month, 10 connection pool limit, auto-scaling. Also available: Prisma Postgres free tier with 500 MB storage and up to 5 databases",
       "tier": "Free",
       "url": "https://www.prisma.io/pricing",
       "tags": [
@@ -4786,7 +5082,7 @@
     {
       "vendor": "Unity DevOps",
       "category": "CI/CD",
-      "description": "Version control + build automation \u2014 25 GB storage (5x increase Mar 2026), 100 GB egress (new Mar 2026), no seat charges (removed Mar 2026). Build: 200 Windows + 100 Mac minutes/month. Includes Plastic SCM for version control. No egress charges through April 2026",
+      "description": "Version control + build automation — 25 GB storage (5x increase Mar 2026), 100 GB egress (new Mar 2026), no seat charges (removed Mar 2026). Build: 200 Windows + 100 Mac minutes/month. Includes Plastic SCM for version control. No egress charges through April 2026",
       "tier": "Free",
       "url": "https://unity.com/products/unity-devops",
       "tags": [
@@ -4802,7 +5098,7 @@
     {
       "vendor": "SurrealDB Cloud",
       "category": "Databases",
-      "description": "Multi-model cloud database \u2014 1 GB storage, 0.25 vCPU, 512 MB memory free. Supports SQL-like queries, graph relations, document storage, real-time subscriptions. Includes team collaboration and RBAC",
+      "description": "Multi-model cloud database — 1 GB storage, 0.25 vCPU, 512 MB memory free. Supports SQL-like queries, graph relations, document storage, real-time subscriptions. Includes team collaboration and RBAC",
       "tier": "Free",
       "url": "https://surrealdb.com/pricing",
       "tags": [
@@ -4818,7 +5114,7 @@
     {
       "vendor": "Sematext",
       "category": "Monitoring",
-      "description": "Observability platform \u2014 Logs: 500 MB/day ingestion, 7-day retention. Monitoring: 3 hosts, 3 containers/host, 30-min data retention, 1 alert rule. Volume-based pricing, no per-host charges on paid plans",
+      "description": "Observability platform — Logs: 500 MB/day ingestion, 7-day retention. Monitoring: 3 hosts, 3 containers/host, 30-min data retention, 1 alert rule. Volume-based pricing, no per-host charges on paid plans",
       "tier": "Basic (Free)",
       "url": "https://sematext.com/pricing",
       "tags": [
@@ -4834,7 +5130,7 @@
     {
       "vendor": "AbstractAPI",
       "category": "API Development",
-      "description": "Suite of 15 REST APIs (IP geolocation, email validation, screenshots, exchange rates, phone validation, etc.) \u2014 free tier: 1,000 requests/month per API, 1 request/second rate limit. Non-commercial use only on free tier",
+      "description": "Suite of 15 REST APIs (IP geolocation, email validation, screenshots, exchange rates, phone validation, etc.) — free tier: 1,000 requests/month per API, 1 request/second rate limit. Non-commercial use only on free tier",
       "tier": "Free",
       "url": "https://www.abstractapi.com/api",
       "tags": [
@@ -4864,7 +5160,7 @@
     {
       "vendor": "BigDataCloud",
       "category": "Dev Utilities",
-      "description": "IP geolocation and reverse geocoding APIs \u2014 free tier: 10,000 API requests/month across all endpoints. Includes IP geolocation, ASN lookup, network info, and reverse geocoding",
+      "description": "IP geolocation and reverse geocoding APIs — free tier: 10,000 API requests/month across all endpoints. Includes IP geolocation, ASN lookup, network info, and reverse geocoding",
       "tier": "Free",
       "url": "https://www.bigdatacloud.com/pricing",
       "tags": [
@@ -4879,7 +5175,7 @@
     {
       "vendor": "ipapi",
       "category": "Dev Utilities",
-      "description": "IP address geolocation API \u2014 free tier: 100 API requests/month. Includes location, timezone, currency data. No HTTPS on free tier. Paid plans from $12.99/mo for 50K requests",
+      "description": "IP address geolocation API — free tier: 100 API requests/month. Includes location, timezone, currency data. No HTTPS on free tier. Paid plans from $12.99/mo for 50K requests",
       "tier": "Free",
       "url": "https://ipapi.com/pricing",
       "tags": [
@@ -4893,7 +5189,7 @@
     {
       "vendor": "Hunter.io",
       "category": "Dev Utilities",
-      "description": "Email finder and verification API \u2014 free tier: 50 credits/month (searches + verifications), 1 connected email account, 500 recipients per sequence, unlimited team members",
+      "description": "Email finder and verification API — free tier: 50 credits/month (searches + verifications), 1 connected email account, 500 recipients per sequence, unlimited team members",
       "tier": "Free",
       "url": "https://hunter.io/pricing",
       "tags": [
@@ -4908,7 +5204,7 @@
     {
       "vendor": "Geocodio",
       "category": "Maps/Geolocation",
-      "description": "Geocoding and reverse geocoding API for US and Canada \u2014 free tier: 2,500 lookups/day. Includes address parsing, congressional districts, timezone, and census data fields",
+      "description": "Geocoding and reverse geocoding API for US and Canada — free tier: 2,500 lookups/day. Includes address parsing, congressional districts, timezone, and census data fields",
       "tier": "Free",
       "url": "https://www.geocod.io/pricing/",
       "tags": [
@@ -4923,7 +5219,7 @@
     {
       "vendor": "CurrencyFreaks",
       "category": "Dev Utilities",
-      "description": "Currency exchange rate API \u2014 free tier: 1,000 API requests/month, 170+ currencies, daily updated rates. Includes latest rates and historical data endpoints",
+      "description": "Currency exchange rate API — free tier: 1,000 API requests/month, 170+ currencies, daily updated rates. Includes latest rates and historical data endpoints",
       "tier": "Free",
       "url": "https://currencyfreaks.com/pricing.html",
       "tags": [
@@ -4938,7 +5234,7 @@
     {
       "vendor": "MailboxValidator",
       "category": "Dev Utilities",
-      "description": "Email validation and verification API \u2014 free tier: 300 API queries/month with auto-renewal. Bulk validation: 100 queries free (one-time). Validates syntax, domain, mailbox existence",
+      "description": "Email validation and verification API — free tier: 300 API queries/month with auto-renewal. Bulk validation: 100 queries free (one-time). Validates syntax, domain, mailbox existence",
       "tier": "API-FREE",
       "url": "https://www.mailboxvalidator.com/plans",
       "tags": [
@@ -4952,7 +5248,7 @@
     {
       "vendor": "Screenshotlayer",
       "category": "Dev Utilities",
-      "description": "Website screenshot capture API \u2014 free tier: 100 screenshots/month. Supports PNG, JPEG, GIF output. No HTTPS encryption or CDN on free tier. Paid plans from $19.99/mo for 10K captures",
+      "description": "Website screenshot capture API — free tier: 100 screenshots/month. Supports PNG, JPEG, GIF output. No HTTPS encryption or CDN on free tier. Paid plans from $19.99/mo for 10K captures",
       "tier": "Free",
       "url": "https://screenshotlayer.com/pricing",
       "tags": [
@@ -4966,7 +5262,7 @@
     {
       "vendor": "URLscan.io",
       "category": "Security",
-      "description": "URL and website security scanner API \u2014 free tier: 50 private scans/day, 1,000 unlisted scans/day, 5,000 public scans/day, 1,000 search requests/day, 10,000 result requests/day",
+      "description": "URL and website security scanner API — free tier: 50 private scans/day, 1,000 unlisted scans/day, 5,000 public scans/day, 1,000 search requests/day, 10,000 result requests/day",
       "tier": "Free",
       "url": "https://urlscan.io/pricing",
       "tags": [
@@ -4981,7 +5277,7 @@
     {
       "vendor": "VirusTotal",
       "category": "Security",
-      "description": "Malware and URL analysis API (Google) \u2014 free community tier: 500 requests/day, 4 requests/minute. Scan files, URLs, domains, IPs against 70+ antivirus engines. Non-commercial use only",
+      "description": "Malware and URL analysis API (Google) — free community tier: 500 requests/day, 4 requests/minute. Scan files, URLs, domains, IPs against 70+ antivirus engines. Non-commercial use only",
       "tier": "Community (Free)",
       "url": "https://www.virustotal.com",
       "tags": [
@@ -4996,7 +5292,7 @@
     {
       "vendor": "Kaggle",
       "category": "AI / ML",
-      "description": "Data science platform (Google) \u2014 entirely free: 30 hrs/week GPU compute (Tesla T4, 16 GB VRAM), 20 hrs/week TPU, 20 GB working disk per session. Unlimited public notebooks, datasets, and competitions",
+      "description": "Data science platform (Google) — entirely free: 30 hrs/week GPU compute (Tesla T4, 16 GB VRAM), 20 hrs/week TPU, 20 GB working disk per session. Unlimited public notebooks, datasets, and competitions",
       "tier": "Free",
       "url": "https://www.kaggle.com",
       "tags": [
@@ -5012,7 +5308,7 @@
     {
       "vendor": "Roboflow",
       "category": "AI / ML",
-      "description": "Computer vision platform \u2014 Public plan: 250,000 images, 10 projects, 2 users, $60/month free inference credits. Includes AI-assisted labeling, model training, cloud deployment. All data publicly shared",
+      "description": "Computer vision platform — Public plan: 250,000 images, 10 projects, 2 users, $60/month free inference credits. Includes AI-assisted labeling, model training, cloud deployment. All data publicly shared",
       "tier": "Public (Free)",
       "url": "https://roboflow.com/pricing",
       "tags": [
@@ -5027,7 +5323,7 @@
     {
       "vendor": "Scale AI",
       "category": "AI / ML",
-      "description": "Data labeling and AI data platform \u2014 free tier: first 1,000 annotation units and 10,000 images uploaded free. Nucleus free tier for individuals and academia. Pay-as-you-go after free allocation",
+      "description": "Data labeling and AI data platform — free tier: first 1,000 annotation units and 10,000 images uploaded free. Nucleus free tier for individuals and academia. Pay-as-you-go after free allocation",
       "tier": "Free",
       "url": "https://scale.com/pricing",
       "tags": [
@@ -5042,7 +5338,7 @@
     {
       "vendor": "Weaviate",
       "category": "Databases",
-      "description": "Open-source vector database \u2014 self-hosted: free forever with full features (hybrid search, multi-tenancy, compression). Cloud: 14-day free sandbox with full access. Paid cloud from $45/mo (Flex)",
+      "description": "Open-source vector database — self-hosted: free forever with full features (hybrid search, multi-tenancy, compression). Cloud: 14-day free sandbox with full access. Paid cloud from $45/mo (Flex)",
       "tier": "Open Source",
       "url": "https://weaviate.io/pricing",
       "tags": [
@@ -5057,7 +5353,7 @@
     {
       "vendor": "Zilliz Cloud",
       "category": "Databases",
-      "description": "Managed Milvus vector database \u2014 free tier: 5 GB storage, 2.5M vector compute units/month, up to 5 collections. Milvus open-source also free to self-host with no limits",
+      "description": "Managed Milvus vector database — free tier: 5 GB storage, 2.5M vector compute units/month, up to 5 collections. Milvus open-source also free to self-host with no limits",
       "tier": "Free",
       "url": "https://zilliz.com/pricing",
       "tags": [
@@ -5072,7 +5368,7 @@
     {
       "vendor": "LanceDB",
       "category": "Databases",
-      "description": "Embedded vector database \u2014 OSS: fully free, runs locally or in your cloud, no limits. Cloud: $100 in one-time free credits for serverless managed offering. Usage-based pricing after credits",
+      "description": "Embedded vector database — OSS: fully free, runs locally or in your cloud, no limits. Cloud: $100 in one-time free credits for serverless managed offering. Usage-based pricing after credits",
       "tier": "Open Source",
       "url": "https://lancedb.com/pricing/",
       "tags": [
@@ -5088,7 +5384,7 @@
     {
       "vendor": "Upstash Vector",
       "category": "Databases",
-      "description": "Serverless vector database by Upstash \u2014 10K vectors, 1536 dimensions, 150K query units/day free. REST API, no connection management",
+      "description": "Serverless vector database by Upstash — 10K vectors, 1536 dimensions, 150K query units/day free. REST API, no connection management",
       "tier": "Free",
       "url": "https://upstash.com/pricing/vector",
       "tags": [
@@ -5103,7 +5399,7 @@
     {
       "vendor": "Chroma",
       "category": "Databases",
-      "description": "Open-source AI-native embedding database \u2014 self-hosted: fully free with no limits. Chroma Cloud: free tier with 1M embeddings, 1 collection, 10K queries/day. Python and JavaScript SDKs",
+      "description": "Open-source AI-native embedding database — self-hosted: fully free with no limits. Chroma Cloud: free tier with 1M embeddings, 1 collection, 10K queries/day. Python and JavaScript SDKs",
       "tier": "Open Source",
       "url": "https://www.trychroma.com/pricing",
       "tags": [
@@ -5118,7 +5414,7 @@
     {
       "vendor": "Turbopuffer",
       "category": "Databases",
-      "description": "Serverless vector database \u2014 pay-per-use with no minimum. $0.30/M vectors stored/month, $0.04/M vectors queried. No free tier but extremely low entry cost for small workloads",
+      "description": "Serverless vector database — pay-per-use with no minimum. $0.30/M vectors stored/month, $0.04/M vectors queried. No free tier but extremely low entry cost for small workloads",
       "tier": "Pay-as-you-go",
       "url": "https://turbopuffer.com/pricing",
       "tags": [
@@ -5133,7 +5429,7 @@
     {
       "vendor": "AssemblyAI",
       "category": "AI / ML",
-      "description": "Speech-to-text and audio intelligence API \u2014 free: $50 in credits (~185 hours pre-recorded transcription). Up to 5 concurrent streams. Core STT and Audio Intelligence models. Pay-as-you-go at $0.15/hr after",
+      "description": "Speech-to-text and audio intelligence API — free: $50 in credits (~185 hours pre-recorded transcription). Up to 5 concurrent streams. Core STT and Audio Intelligence models. Pay-as-you-go at $0.15/hr after",
       "tier": "Free",
       "url": "https://www.assemblyai.com/pricing",
       "tags": [
@@ -5149,7 +5445,7 @@
     {
       "vendor": "Replicate",
       "category": "AI / ML",
-      "description": "ML model hosting and inference platform \u2014 free runs on curated model collection without billing. Pay-per-second billing by hardware type (CPU/GPU) after free allowance. No credit card required to start",
+      "description": "ML model hosting and inference platform — free runs on curated model collection without billing. Pay-per-second billing by hardware type (CPU/GPU) after free allowance. No credit card required to start",
       "tier": "Free",
       "url": "https://replicate.com/pricing",
       "tags": [
@@ -5159,12 +5455,20 @@
         "inference",
         "gpu"
       ],
-      "verifiedDate": "2026-04-14"
+      "verifiedDate": "2026-04-14",
+      "referral_program": {
+        "available": false,
+        "referrer_benefit": "N/A",
+        "referee_benefit": "N/A",
+        "program_url": "https://replicate.com",
+        "type": "closed",
+        "notes": "No verified referral/affiliate program for the AI inference platform."
+      }
     },
     {
       "vendor": "Baseten",
       "category": "AI / ML",
-      "description": "ML model deployment platform \u2014 $30 in free credits for new accounts. Basic plan is $0/month with pay-as-you-go billing after credits. Per-minute GPU/CPU billing for custom deployments, per-token for Model APIs",
+      "description": "ML model deployment platform — $30 in free credits for new accounts. Basic plan is $0/month with pay-as-you-go billing after credits. Per-minute GPU/CPU billing for custom deployments, per-token for Model APIs",
       "tier": "Basic (Free Credits)",
       "url": "https://www.baseten.co/pricing/",
       "tags": [
@@ -5180,7 +5484,7 @@
     {
       "vendor": "Weights & Biases",
       "category": "AI / ML",
-      "description": "ML experiment tracking and model registry \u2014 free tier: experiment tracking, unlimited projects, 5 GB cloud storage, up to 5 Model seats. Community support. Model registry and dataset versioning included. Non-commercial use only",
+      "description": "ML experiment tracking and model registry — free tier: experiment tracking, unlimited projects, 5 GB cloud storage, up to 5 Model seats. Community support. Model registry and dataset versioning included. Non-commercial use only",
       "tier": "Free",
       "url": "https://wandb.ai/site/pricing/",
       "tags": [
@@ -5195,7 +5499,7 @@
     {
       "vendor": "Comet ML",
       "category": "AI / ML",
-      "description": "ML experiment tracking and LLM evaluation \u2014 free tier: 1 user, 100 GB data storage, experiment tracking and comparison, dataset versioning, model registry, LLM evaluation. Free Pro plan for academics",
+      "description": "ML experiment tracking and LLM evaluation — free tier: 1 user, 100 GB data storage, experiment tracking and comparison, dataset versioning, model registry, LLM evaluation. Free Pro plan for academics",
       "tier": "Free",
       "url": "https://www.comet.com/site/pricing/",
       "tags": [
@@ -5210,7 +5514,7 @@
     {
       "vendor": "Clarifai",
       "category": "AI / ML",
-      "description": "Full-stack AI platform (computer vision, NLP, audio) \u2014 Community tier: 1,000 API calls/month. Access to pre-trained models for image recognition, NLP, and audio. No credit card required",
+      "description": "Full-stack AI platform (computer vision, NLP, audio) — Community tier: 1,000 API calls/month. Access to pre-trained models for image recognition, NLP, and audio. No credit card required",
       "tier": "Community (Free)",
       "url": "https://www.clarifai.com/pricing",
       "tags": [
@@ -5225,7 +5529,7 @@
     {
       "vendor": "Neptune.ai",
       "category": "AI / ML",
-      "description": "ML experiment tracking \u2014 free for individuals/researchers. 200 GB metadata storage, 50 GB file storage, 100K tracking calls/hour, 20 active runs, unlimited archived experiments, Jupyter/Colab integration",
+      "description": "ML experiment tracking — free for individuals/researchers. 200 GB metadata storage, 50 GB file storage, 100K tracking calls/hour, 20 active runs, unlimited archived experiments, Jupyter/Colab integration",
       "tier": "Free (Individual)",
       "url": "https://neptune.ai/pricing",
       "tags": [
@@ -5240,7 +5544,7 @@
     {
       "vendor": "Labelbox",
       "category": "AI / ML",
-      "description": "Data labeling and annotation platform \u2014 free tier: 500 Labelbox Units (LBUs)/month. Image, video, text, and geospatial annotation. Free for qualified educational institutions",
+      "description": "Data labeling and annotation platform — free tier: 500 Labelbox Units (LBUs)/month. Image, video, text, and geospatial annotation. Free for qualified educational institutions",
       "tier": "Free",
       "url": "https://labelbox.com/pricing/",
       "tags": [
@@ -5255,7 +5559,7 @@
     {
       "vendor": "Tyk",
       "category": "API Gateway",
-      "description": "Open-source API gateway \u2014 self-hosted: free forever under MPL-2.0, includes rate limiting, auth, analytics. Cloud: 48-hour free trial only, paid plans usage-based. Dashboard and developer portal included",
+      "description": "Open-source API gateway — self-hosted: free forever under MPL-2.0, includes rate limiting, auth, analytics. Cloud: 48-hour free trial only, paid plans usage-based. Dashboard and developer portal included",
       "tier": "Open Source",
       "url": "https://tyk.io/pricing/",
       "tags": [
@@ -5270,7 +5574,7 @@
     {
       "vendor": "Stoplight",
       "category": "API Development",
-      "description": "API design and documentation platform \u2014 free tier: 1 user, 1 project. Includes OpenAPI visual designer, API editor, interactive docs, API console, code generation, Git sync, automatic SSL",
+      "description": "API design and documentation platform — free tier: 1 user, 1 project. Includes OpenAPI visual designer, API editor, interactive docs, API console, code generation, Git sync, automatic SSL",
       "tier": "Free",
       "url": "https://stoplight.io/pricing",
       "tags": [
@@ -5285,7 +5589,7 @@
     {
       "vendor": "SwaggerHub",
       "category": "API Development",
-      "description": "API design and documentation platform (SmartBear) \u2014 free tier: 1 designer seat for individual/personal use. OpenAPI editor, API mocking, code generation. Limited API definitions on free plan",
+      "description": "API design and documentation platform (SmartBear) — free tier: 1 designer seat for individual/personal use. OpenAPI editor, API mocking, code generation. Limited API definitions on free plan",
       "tier": "Free",
       "url": "https://swagger.io/tools/swaggerhub/pricing/",
       "tags": [
@@ -5300,7 +5604,7 @@
     {
       "vendor": "RapidAPI",
       "category": "API Development",
-      "description": "API marketplace and hub \u2014 free to sign up and browse. Individual APIs set own free tiers (typically 500-1K req/mo). Platform rate limits: 1,000 req/hr, 500K req/mo. No platform fee on free API tiers",
+      "description": "API marketplace and hub — free to sign up and browse. Individual APIs set own free tiers (typically 500-1K req/mo). Platform rate limits: 1,000 req/hr, 500K req/mo. No platform fee on free API tiers",
       "tier": "Free (Basic)",
       "url": "https://rapidapi.com/pricing/",
       "tags": [
@@ -5314,7 +5618,7 @@
     {
       "vendor": "Apidog",
       "category": "API Development",
-      "description": "API design, debugging, testing, and documentation platform \u2014 free tier: up to 4 users, unlimited projects, unlimited APIs, unlimited requests. API mocking included. 7-day change history",
+      "description": "API design, debugging, testing, and documentation platform — free tier: up to 4 users, unlimited projects, unlimited APIs, unlimited requests. API mocking included. 7-day change history",
       "tier": "Free",
       "url": "https://apidog.com/pricing/",
       "tags": [
@@ -5330,7 +5634,7 @@
     {
       "vendor": "Bruno",
       "category": "API Development",
-      "description": "Free OSS (MIT). Git-based offline API client \u2014 REST, GraphQL, collections stored as files in your repo. No cloud, no accounts, no sync. Desktop app for Mac/Linux/Windows. The #1 open-source Postman alternative",
+      "description": "Free OSS (MIT). Git-based offline API client — REST, GraphQL, collections stored as files in your repo. No cloud, no accounts, no sync. Desktop app for Mac/Linux/Windows. The #1 open-source Postman alternative",
       "tier": "Free OSS",
       "url": "https://www.usebruno.com",
       "tags": [
@@ -5361,7 +5665,7 @@
     {
       "vendor": "Gel",
       "category": "Databases",
-      "description": "Graph-relational database (formerly EdgeDB) \u2014 free cloud tier: 1/4 compute unit (0.5 GiB RAM), 1 GB storage. Also fully open-source for self-hosting. No credit card required",
+      "description": "Graph-relational database (formerly EdgeDB) — free cloud tier: 1/4 compute unit (0.5 GiB RAM), 1 GB storage. Also fully open-source for self-hosting. No credit card required",
       "tier": "Free",
       "url": "https://www.geldata.com/pricing",
       "tags": [
@@ -5376,7 +5680,7 @@
     {
       "vendor": "CrateDB",
       "category": "Databases",
-      "description": "Distributed SQL database for time-series and IoT \u2014 free cloud tier (CRFREE): 2 vCPUs, 2 GB RAM, 8 GB storage. One free cluster per org. No credit card required",
+      "description": "Distributed SQL database for time-series and IoT — free cloud tier (CRFREE): 2 vCPUs, 2 GB RAM, 8 GB storage. One free cluster per org. No credit card required",
       "tier": "Free (CRFREE)",
       "url": "https://cratedb.com/pricing",
       "tags": [
@@ -5392,7 +5696,7 @@
     {
       "vendor": "Neo4j AuraDB",
       "category": "Databases",
-      "description": "Graph database cloud service \u2014 free tier: single database, up to 200,000 nodes and 400,000 relationships. Full Cypher query language support. No credit card required",
+      "description": "Graph database cloud service — free tier: single database, up to 200,000 nodes and 400,000 relationships. Full Cypher query language support. No credit card required",
       "tier": "Free",
       "url": "https://neo4j.com/pricing/",
       "tags": [
@@ -5407,7 +5711,7 @@
     {
       "vendor": "InfluxDB Cloud",
       "category": "Databases",
-      "description": "Time-series database \u2014 free tier: 5 MB writes per 5 minutes, up to 10,000 data series, 30-day data retention. Auto-provisioned for new accounts. Ideal for IoT and monitoring workloads",
+      "description": "Time-series database — free tier: 5 MB writes per 5 minutes, up to 10,000 data series, 30-day data retention. Auto-provisioned for new accounts. Ideal for IoT and monitoring workloads",
       "tier": "Free",
       "url": "https://www.influxdata.com/influxdb-pricing/",
       "tags": [
@@ -5422,7 +5726,7 @@
     {
       "vendor": "Apollo GraphOS",
       "category": "API Development",
-      "description": "GraphQL federation and supergraph platform \u2014 forever free: up to 3 users, 1-day data retention, self-hosted router (60 req/min rate limit), community support. No credit card required",
+      "description": "GraphQL federation and supergraph platform — forever free: up to 3 users, 1-day data retention, self-hosted router (60 req/min rate limit), community support. No credit card required",
       "tier": "Free",
       "url": "https://www.apollographql.com/pricing",
       "tags": [
@@ -5437,7 +5741,7 @@
     {
       "vendor": "Hasura",
       "category": "API Development",
-      "description": "Instant GraphQL API engine over any database \u2014 Hasura Cloud free tier: 1 GB data pass-through, 60 requests/min rate limit. Auto-generates GraphQL APIs from Postgres, SQL Server, BigQuery",
+      "description": "Instant GraphQL API engine over any database — Hasura Cloud free tier: 1 GB data pass-through, 60 requests/min rate limit. Auto-generates GraphQL APIs from Postgres, SQL Server, BigQuery",
       "tier": "Cloud Free",
       "url": "https://hasura.io/pricing",
       "tags": [
@@ -5452,7 +5756,7 @@
     {
       "vendor": "Uptimia",
       "category": "Monitoring",
-      "description": "Website uptime monitoring \u2014 free plan: 1 website, 5-minute check interval, basic uptime monitoring, email alerts. No credit card required",
+      "description": "Website uptime monitoring — free plan: 1 website, 5-minute check interval, basic uptime monitoring, email alerts. No credit card required",
       "tier": "Free",
       "url": "https://www.uptimia.com/pricing",
       "tags": [
@@ -5467,7 +5771,7 @@
     {
       "vendor": "OnlineOrNot",
       "category": "Monitoring",
-      "description": "Uptime and status page monitoring \u2014 free plan: 3 monitors (uptime, keyword, heartbeat), 3-minute check interval, 2 team members, 1 status page, SSL monitoring, multi-location checks, email/Slack/Discord alerts",
+      "description": "Uptime and status page monitoring — free plan: 3 monitors (uptime, keyword, heartbeat), 3-minute check interval, 2 team members, 1 status page, SSL monitoring, multi-location checks, email/Slack/Discord alerts",
       "tier": "Free",
       "url": "https://onlineornot.com/pricing",
       "tags": [
@@ -5483,7 +5787,7 @@
     {
       "vendor": "Hyperping",
       "category": "Monitoring",
-      "description": "Uptime and status page monitoring \u2014 free plan: 5 monitors (HTTP/HTTPS, API, ping, SSL, cron), 3-minute check interval, 1 status page with real-time updates and subscriber notifications, email and webhook alerts",
+      "description": "Uptime and status page monitoring — free plan: 5 monitors (HTTP/HTTPS, API, ping, SSL, cron), 3-minute check interval, 1 status page with real-time updates and subscriber notifications, email and webhook alerts",
       "tier": "Free",
       "url": "https://hyperping.com/pricing",
       "tags": [
@@ -5501,7 +5805,7 @@
     {
       "vendor": "incident.io",
       "category": "Monitoring",
-      "description": "Incident management platform \u2014 free Basic plan: up to 5 users, Slack or Microsoft Teams native incident response, single-team on-call scheduling, 1 status page, essential incident automation",
+      "description": "Incident management platform — free Basic plan: up to 5 users, Slack or Microsoft Teams native incident response, single-team on-call scheduling, 1 status page, essential incident automation",
       "tier": "Basic",
       "url": "https://incident.io/pricing",
       "tags": [
@@ -5516,7 +5820,7 @@
     {
       "vendor": "AppSignal",
       "category": "Monitoring",
-      "description": "Application monitoring (APM, errors, logging) \u2014 free plan: 50,000 requests/month, 1 GB logging/month, 5-day data retention, unlimited apps and hosts. Extended free limits for OSS and humanitarian projects",
+      "description": "Application monitoring (APM, errors, logging) — free plan: 50,000 requests/month, 1 GB logging/month, 5-day data retention, unlimited apps and hosts. Extended free limits for OSS and humanitarian projects",
       "tier": "Free",
       "url": "https://www.appsignal.com/plans",
       "tags": [
@@ -5532,7 +5836,7 @@
     {
       "vendor": "Middleware.io",
       "category": "Monitoring",
-      "description": "Full-stack observability platform \u2014 free forever plan: 100 GB/month data (APM, logs, infrastructure, traces, RUM, synthetics, database, serverless), 1,000 RUM sessions/month, 20,000 synthetic checks/month, 14-day data retention, unlimited users",
+      "description": "Full-stack observability platform — free forever plan: 100 GB/month data (APM, logs, infrastructure, traces, RUM, synthetics, database, serverless), 1,000 RUM sessions/month, 20,000 synthetic checks/month, 14-day data retention, unlimited users",
       "tier": "Free",
       "url": "https://middleware.io/pricing/",
       "tags": [
@@ -5550,7 +5854,7 @@
     {
       "vendor": "360 Monitoring",
       "category": "Monitoring",
-      "description": "Server and website monitoring (formerly Nixstats) \u2014 free Lite plan: 1 server monitor, 5 site monitors, 10-minute check interval, 24-hour data retention, email alerts",
+      "description": "Server and website monitoring (formerly Nixstats) — free Lite plan: 1 server monitor, 5 site monitors, 10-minute check interval, 24-hour data retention, email alerts",
       "tier": "Lite",
       "url": "https://360monitoring.com/pricing/",
       "tags": [
@@ -5566,7 +5870,7 @@
     {
       "vendor": "Drone CI",
       "category": "CI/CD",
-      "description": "Container-native CI/CD (now part of Harness) \u2014 free open-source edition (self-hosted): unlimited users and concurrency, YAML pipelines, Docker-based builds. Cloud available free for open-source projects",
+      "description": "Container-native CI/CD (now part of Harness) — free open-source edition (self-hosted): unlimited users and concurrency, YAML pipelines, Docker-based builds. Cloud available free for open-source projects",
       "tier": "Community (Self-hosted)",
       "url": "https://www.drone.io/",
       "tags": [
@@ -5583,7 +5887,7 @@
     {
       "vendor": "Codefresh",
       "category": "CI/CD",
-      "description": "CI/CD and GitOps platform \u2014 free plan: 120 builds/month, 1 concurrent pipeline. Docker-native build engine with built-in Docker registry",
+      "description": "CI/CD and GitOps platform — free plan: 120 builds/month, 1 concurrent pipeline. Docker-native build engine with built-in Docker registry",
       "tier": "Free",
       "url": "https://codefresh.io/pricing/",
       "tags": [
@@ -5600,7 +5904,7 @@
     {
       "vendor": "Bitrise",
       "category": "CI/CD",
-      "description": "Mobile CI/CD platform \u2014 free Hobby plan: 300 credits/month, 1 private app (unlimited public apps), 1 user, 5 concurrent builds, 90-minute build timeout. Supports iOS, Android, Flutter, React Native",
+      "description": "Mobile CI/CD platform — free Hobby plan: 300 credits/month, 1 private app (unlimited public apps), 1 user, 5 concurrent builds, 90-minute build timeout. Supports iOS, Android, Flutter, React Native",
       "tier": "Hobby",
       "url": "https://bitrise.io/pricing",
       "tags": [
@@ -5617,7 +5921,7 @@
     {
       "vendor": "Codemagic",
       "category": "CI/CD",
-      "description": "Mobile CI/CD platform \u2014 free tier (individual accounts): 500 macOS M2 build minutes/month, unlimited apps, 1 parallel build, 30-day build history, 3 GB cache/build. Supports Flutter, iOS, Android, React Native",
+      "description": "Mobile CI/CD platform — free tier (individual accounts): 500 macOS M2 build minutes/month, unlimited apps, 1 parallel build, 30-day build history, 3 GB cache/build. Supports Flutter, iOS, Android, React Native",
       "tier": "Free",
       "url": "https://codemagic.io/pricing/",
       "tags": [
@@ -5634,7 +5938,7 @@
     {
       "vendor": "Appcircle",
       "category": "CI/CD",
-      "description": "Mobile CI/CD and distribution \u2014 free Starter plan: 20 builds/month, 1 concurrent build, 30-minute max build time, unlimited apps, 1,000 CodePush updates/month, 100 testing distribution downloads/month",
+      "description": "Mobile CI/CD and distribution — free Starter plan: 20 builds/month, 1 concurrent build, 30-minute max build time, unlimited apps, 1,000 CodePush updates/month, 100 testing distribution downloads/month",
       "tier": "Starter",
       "url": "https://appcircle.io/pricing",
       "tags": [
@@ -5651,7 +5955,7 @@
     {
       "vendor": "Buddy",
       "category": "CI/CD",
-      "description": "CI/CD pipeline automation \u2014 free plan: 1 user, 1 concurrent pipeline, 300 pipeline GB-minutes/month, 1 GB pipeline cache, unlimited projects. Note: workspace frozen after 60 days of inactivity",
+      "description": "CI/CD pipeline automation — free plan: 1 user, 1 concurrent pipeline, 300 pipeline GB-minutes/month, 1 GB pipeline cache, unlimited projects. Note: workspace frozen after 60 days of inactivity",
       "tier": "Free",
       "url": "https://buddy.works/pricing",
       "tags": [
@@ -5666,7 +5970,7 @@
     {
       "vendor": "Harness CI",
       "category": "CI/CD",
-      "description": "CI/CD platform \u2014 free plan: 2,000 Harness Cloud build credits/month (Linux, macOS, Windows runners), YAML pipelines, secrets management, test intelligence. Requires business email for cloud runners; self-hosted runner alternative available",
+      "description": "CI/CD platform — free plan: 2,000 Harness Cloud build credits/month (Linux, macOS, Windows runners), YAML pipelines, secrets management, test intelligence. Requires business email for cloud runners; self-hosted runner alternative available",
       "tier": "Free",
       "url": "https://www.harness.io/pricing",
       "tags": [
@@ -5696,7 +6000,7 @@
     {
       "vendor": "Zoho",
       "category": "Cloud IaaS",
-      "description": "Suite of 45+ business apps with free tiers \u2014 Zoho Mail (5 users, 5 GB/user), CRM (3 users), Projects (3 users, 2 projects), Invoice (5 customers), Cliq (unlimited users), Forms (3 forms), and more",
+      "description": "Suite of 45+ business apps with free tiers — Zoho Mail (5 users, 5 GB/user), CRM (3 users), Projects (3 users, 2 projects), Invoice (5 customers), Cliq (unlimited users), Forms (3 forms), and more",
       "tier": "Free",
       "url": "https://www.zoho.com",
       "tags": [
@@ -5774,7 +6078,7 @@
     {
       "vendor": "Vault",
       "category": "Cloud IaaS",
-      "description": "Password manager (Zoho) \u2014 unlimited passwords for 1 user, password generator, browser extensions (Chrome/Firefox/Safari/Edge), mobile apps, secure sharing, offline access",
+      "description": "Password manager (Zoho) — unlimited passwords for 1 user, password generator, browser extensions (Chrome/Firefox/Safari/Edge), mobile apps, secure sharing, offline access",
       "tier": "Free",
       "url": "https://zoho.com/vault",
       "tags": [
@@ -5930,7 +6234,7 @@
     {
       "vendor": "DBOS",
       "category": "Workflow Automation",
-      "description": "Durable workflow orchestration platform \u2014 free tier includes 1 Firecracker microVM per app (512 MB RAM, 1 vCPU), scale to zero, 1M service calls/month, 3-day system data retention, Amazon RDS Postgres backend. Open-source DBOS Transact library free forever for TypeScript, Python, Go, Java, Kotlin",
+      "description": "Durable workflow orchestration platform — free tier includes 1 Firecracker microVM per app (512 MB RAM, 1 vCPU), scale to zero, 1M service calls/month, 3-day system data retention, Amazon RDS Postgres backend. Open-source DBOS Transact library free forever for TypeScript, Python, Go, Java, Kotlin",
       "tier": "Free",
       "url": "https://www.dbos.dev/pricing",
       "tags": [
@@ -5960,7 +6264,7 @@
     {
       "vendor": "Cloud 66",
       "category": "Infrastructure",
-      "description": "Free for personal projects (includes one deployment server, one static site), Cloud 66 gives you everything you need to build, deploy, and grow your applications on any cloud without the headache of the \u201cserver stuff.\u201d.",
+      "description": "Free for personal projects (includes one deployment server, one static site), Cloud 66 gives you everything you need to build, deploy, and grow your applications on any cloud without the headache of the “server stuff.”.",
       "tier": "Free",
       "url": "https://www.cloud66.com/",
       "tags": [
@@ -5988,7 +6292,7 @@
     {
       "vendor": "Scalr",
       "category": "Infrastructure",
-      "description": "Terraform Automation and Collaboration (TACO) platform \u2014 unlimited users, workspaces, and managed resources on free tier. Full Terraform CLI support, OPA policy integration, hierarchical configuration, SAML SSO, 5 concurrent runs. Up to 50 runs/month free",
+      "description": "Terraform Automation and Collaboration (TACO) platform — unlimited users, workspaces, and managed resources on free tier. Full Terraform CLI support, OPA policy integration, hierarchical configuration, SAML SSO, 5 concurrent runs. Up to 50 runs/month free",
       "tier": "Free",
       "url": "https://www.scalr.com/pricing",
       "tags": [
@@ -6004,7 +6308,7 @@
     {
       "vendor": "Terragrunt Scale",
       "category": "Infrastructure",
-      "description": "IaC orchestration platform by Gruntwork \u2014 free tier with GitOps from GitHub/GitLab, dependency-ordered plan/apply, drift detection, and module update automation. Limits match or exceed HCP Terraform free tier (500+ managed resources). Positioned as HCP Terraform alternative",
+      "description": "IaC orchestration platform by Gruntwork — free tier with GitOps from GitHub/GitLab, dependency-ordered plan/apply, drift detection, and module update automation. Limits match or exceed HCP Terraform free tier (500+ managed resources). Positioned as HCP Terraform alternative",
       "tier": "Free",
       "url": "https://terragrunt.com/terragrunt-scale",
       "tags": [
@@ -7668,7 +7972,7 @@
     {
       "vendor": "evernote.com",
       "category": "Team Collaboration",
-      "description": "Note-taking \u2014 50 notes, 1 notebook, 20 MB monthly uploads, 1 device sync, 50 attachments, 20 tags, 5 spaces. Web clipper and search included",
+      "description": "Note-taking — 50 notes, 1 notebook, 20 MB monthly uploads, 1 device sync, 50 attachments, 20 tags, 5 spaces. Web clipper and search included",
       "tier": "Free",
       "url": "https://evernote.com/",
       "tags": [
@@ -7704,7 +8008,7 @@
     {
       "vendor": "Fizzy",
       "category": "Project Management",
-      "description": "Kanban-based platform for project management and issue tracking. Create public boards, set up webhooks, use card stamping, and track unlimited users \u2014 free for up to 1000 items.",
+      "description": "Kanban-based platform for project management and issue tracking. Create public boards, set up webhooks, use card stamping, and track unlimited users — free for up to 1000 items.",
       "tier": "Free",
       "url": "https://www.fizzy.do/",
       "tags": [
@@ -7848,7 +8152,7 @@
     {
       "vendor": "Miro",
       "category": "Diagramming",
-      "description": "Collaborative whiteboard \u2014 3 editable boards, unlimited team members, 10 AI credits/month, 5 Talktracks, 160+ app integrations including Zoom, Slack, and Google Drive",
+      "description": "Collaborative whiteboard — 3 editable boards, unlimited team members, 10 AI credits/month, 5 Talktracks, 160+ app integrations including Zoom, Slack, and Google Drive",
       "tier": "Free",
       "url": "https://miro.com/",
       "tags": [
@@ -7909,7 +8213,8 @@
         "referrer_benefit": "Free months of service",
         "referee_benefit": "Free months of service",
         "program_url": "https://proton.me/support/referral-program",
-        "type": "self-service"
+        "type": "self-service",
+        "commission_type": "credits"
       }
     },
     {
@@ -8071,7 +8376,7 @@
     {
       "vendor": "talky.io",
       "category": "Team Collaboration",
-      "description": "Free group video chat. Anonymous. Peer\u2011to\u2011peer. No plugins, signup, or payment required",
+      "description": "Free group video chat. Anonymous. Peer‑to‑peer. No plugins, signup, or payment required",
       "tier": "Free",
       "url": "https://talky.io/",
       "tags": [
@@ -8323,7 +8628,7 @@
     {
       "vendor": "Cosmic",
       "category": "Headless CMS",
-      "description": "Headless CMS \u2014 1 project, 2 users, 1,000 objects, 10K API requests/month (100K cached), 1 GB storage, 1 GB API bandwidth, 3 AI agents, 300K AI tokens/month",
+      "description": "Headless CMS — 1 project, 2 users, 1,000 objects, 10K API requests/month (100K cached), 1 GB storage, 1 GB API bandwidth, 3 AI agents, 300K AI tokens/month",
       "tier": "Free",
       "url": "https://www.cosmicjs.com/",
       "tags": [
@@ -8435,7 +8740,7 @@
     {
       "vendor": "WPJack",
       "category": "Headless CMS",
-      "description": "Set up WordPress on any cloud in less than 5 minutes! The free tier includes 1 server, 2 sites, free SSL certificates, and unlimited cron jobs. No time limits or expirations\u2014your website, your way.",
+      "description": "Set up WordPress on any cloud in less than 5 minutes! The free tier includes 1 server, 2 sites, free SSL certificates, and unlimited cron jobs. No time limits or expirations—your website, your way.",
       "tier": "Free",
       "url": "https://wpjack.com",
       "tags": [
@@ -8533,7 +8838,7 @@
     {
       "vendor": "codacy.com",
       "category": "Code Quality",
-      "description": "Automated code reviews for PHP, Python, Ruby, Java, JavaScript, Scala, CSS, and CoffeeScript \u2014 free for open source. 4 users, 7 repos on free plan. Static analysis, security patterns, duplication detection, code complexity metrics",
+      "description": "Automated code reviews for PHP, Python, Ruby, Java, JavaScript, Scala, CSS, and CoffeeScript — free for open source. 4 users, 7 repos on free plan. Static analysis, security patterns, duplication detection, code complexity metrics",
       "tier": "Free",
       "url": "https://www.codacy.com/",
       "tags": [
@@ -8593,7 +8898,7 @@
     {
       "vendor": "coveralls.io",
       "category": "Code Quality",
-      "description": "Test coverage tracking \u2014 displays coverage reports with line-by-line detail, PR comments, and badge embeds. Free for open source repos with unlimited public repos. Supports 22+ languages",
+      "description": "Test coverage tracking — displays coverage reports with line-by-line detail, PR comments, and badge embeds. Free for open source repos with unlimited public repos. Supports 22+ languages",
       "tier": "Free",
       "url": "https://coveralls.io/",
       "tags": [
@@ -8677,7 +8982,7 @@
     {
       "vendor": "gtmetrix.com",
       "category": "Code Quality",
-      "description": "Website performance testing \u2014 Lighthouse-based reports with Core Web Vitals, waterfall charts, and optimization recommendations. Free plan: 5 monitored URLs, daily checks, 20 on-demand tests/day",
+      "description": "Website performance testing — Lighthouse-based reports with Core Web Vitals, waterfall charts, and optimization recommendations. Free plan: 5 monitored URLs, daily checks, 20 on-demand tests/day",
       "tier": "Free",
       "url": "https://gtmetrix.com/",
       "tags": [
@@ -8877,7 +9182,7 @@
     {
       "vendor": "deployhq.com",
       "category": "CI/CD",
-      "description": "Automated deployment platform \u2014 free plan: 3 projects with unlimited deployments. Git-based workflow with support for FTP/SFTP/SSH deployment targets",
+      "description": "Automated deployment platform — free plan: 3 projects with unlimited deployments. Git-based workflow with support for FTP/SFTP/SSH deployment targets",
       "tier": "Free",
       "url": "https://www.deployhq.com/",
       "tags": [
@@ -8905,7 +9210,7 @@
     {
       "vendor": "Mergify",
       "category": "CI/CD",
-      "description": "workflow automation and merge queue for GitHub \u2014 Free for public GitHub repositories",
+      "description": "workflow automation and merge queue for GitHub — Free for public GitHub repositories",
       "tier": "Free",
       "url": "https://mergify.com",
       "tags": [
@@ -9390,7 +9695,7 @@
     {
       "vendor": "Datree",
       "category": "Security",
-      "description": "Open Source CLI tool to prevent Kubernetes misconfigurations by ensuring that manifests and Helm charts follow best practices as well as your organization\u2019s policies",
+      "description": "Open Source CLI tool to prevent Kubernetes misconfigurations by ensuring that manifests and Helm charts follow best practices as well as your organization’s policies",
       "tier": "Free",
       "url": "https://www.datree.io/",
       "tags": [
@@ -9746,7 +10051,7 @@
     {
       "vendor": "Logto",
       "category": "Auth",
-      "description": "Open-source identity solution \u2014 50K MAU free (cloud), unlimited self-hosted. OIDC, social login, passwordless, MFA, RBAC, multi-tenancy, webhooks",
+      "description": "Open-source identity solution — 50K MAU free (cloud), unlimited self-hosted. OIDC, social login, passwordless, MFA, RBAC, multi-tenancy, webhooks",
       "tier": "Free",
       "url": "https://logto.io/pricing",
       "tags": [
@@ -9776,7 +10081,7 @@
     {
       "vendor": "Okta",
       "category": "Auth",
-      "description": "Developer authentication via Auth0 platform \u2014 25,000 MAU free, social login, passwordless, MFA, SSO. Note: developer.okta.com/signup now routes to Auth0.",
+      "description": "Developer authentication via Auth0 platform — 25,000 MAU free, social login, passwordless, MFA, SSO. Note: developer.okta.com/signup now routes to Auth0.",
       "tier": "Free",
       "url": "https://developer.okta.com/signup/",
       "tags": [
@@ -9790,7 +10095,7 @@
     {
       "vendor": "Ory",
       "category": "Auth",
-      "description": "Open-source identity infrastructure \u2014 Kratos (identity), Hydra (OAuth2/OIDC), Oathkeeper (API gateway), Keto (permissions). Cloud: 25K MAU free. Self-hosted: unlimited, Apache 2.0",
+      "description": "Open-source identity infrastructure — Kratos (identity), Hydra (OAuth2/OIDC), Oathkeeper (API gateway), Keto (permissions). Cloud: 25K MAU free. Self-hosted: unlimited, Apache 2.0",
       "tier": "Free",
       "url": "https://www.ory.sh/pricing/",
       "tags": [
@@ -9821,7 +10126,7 @@
     {
       "vendor": "PropelAuth",
       "category": "Auth",
-      "description": "Authentication for B2B SaaS \u2014 free up to 10,000 MAUs and 10K Transactional Emails (with a watermark branding: \"Powered by PropelAuth\").",
+      "description": "Authentication for B2B SaaS — free up to 10,000 MAUs and 10K Transactional Emails (with a watermark branding: \"Powered by PropelAuth\").",
       "tier": "Free",
       "url": "https://propelauth.com",
       "tags": [
@@ -10161,7 +10466,7 @@
     {
       "vendor": "SMSGate",
       "category": "Messaging",
-      "description": "SMS Gateway for Android\u2122 enables sending and receiving SMS messages through your devices using cloud routing. Completely free cloud service (with recommended notification for usage above 10,000 messages/day to maintain quality for all users).",
+      "description": "SMS Gateway for Android™ enables sending and receiving SMS messages through your devices using cloud routing. Completely free cloud service (with recommended notification for usage above 10,000 messages/day to maintain quality for all users).",
       "tier": "Free",
       "url": "https://sms-gate.app",
       "tags": [
@@ -10551,7 +10856,7 @@
     {
       "vendor": "fivenines.io",
       "category": "Monitoring",
-      "description": "Linux server monitoring with real\u2011time dashboards and alerting \u2014 free forever for up to 5 monitored servers at 60-seconds interval. No credit card required.",
+      "description": "Linux server monitoring with real‑time dashboards and alerting — free forever for up to 5 monitored servers at 60-seconds interval. No credit card required.",
       "tier": "Free",
       "url": "https://fivenines.io/",
       "tags": [
@@ -10564,7 +10869,7 @@
     {
       "vendor": "incidenthub.cloud",
       "category": "Monitoring",
-      "description": "Cloud and SaaS status page aggregator \u2014 5 monitors and 2 notification channels (Slack and Discord) are free forever.",
+      "description": "Cloud and SaaS status page aggregator — 5 monitors and 2 notification channels (Slack and Discord) are free forever.",
       "tier": "Free",
       "url": "https://incidenthub.cloud/",
       "tags": [
@@ -10785,7 +11090,7 @@
     {
       "vendor": "skylight.io",
       "category": "Monitoring",
-      "description": "Application performance monitoring \u2014 free for first 100,000 traces/month.",
+      "description": "Application performance monitoring — free for first 100,000 traces/month.",
       "tier": "Free",
       "url": "https://www.skylight.io/",
       "tags": [
@@ -10837,7 +11142,7 @@
     {
       "vendor": "UptimeObserver.com",
       "category": "Monitoring",
-      "description": "Get 20 uptime monitors with 5-minute intervals and a customizable status page\u2014even for commercial use. Enjoy unlimited, real-time notifications via email and Telegram. No credit card needed to get started.",
+      "description": "Get 20 uptime monitors with 5-minute intervals and a customizable status page—even for commercial use. Enjoy unlimited, real-time notifications via email and Telegram. No credit card needed to get started.",
       "tier": "Free",
       "url": "https://uptimeobserver.com",
       "tags": [
@@ -11462,7 +11767,8 @@
         "referrer_benefit": "Free months of service",
         "referee_benefit": "Free months of service",
         "program_url": "https://proton.me/support/referral-program",
-        "type": "self-service"
+        "type": "self-service",
+        "commission_type": "credits"
       }
     },
     {
@@ -11504,7 +11810,7 @@
     {
       "vendor": "Substack",
       "category": "Email",
-      "description": "Newsletter platform \u2014 unlimited subscribers, unlimited posts, custom domain, podcast hosting, community features, analytics. Free until you enable paid subscriptions (10% platform fee on paid subs)",
+      "description": "Newsletter platform — unlimited subscribers, unlimited posts, custom domain, podcast hosting, community features, analytics. Free until you enable paid subscriptions (10% platform fee on paid subs)",
       "tier": "Free",
       "url": "https://substack.com",
       "tags": [
@@ -11736,7 +12042,7 @@
     {
       "vendor": "Formester.com",
       "category": "Forms",
-      "description": "Share and embed unique-looking forms on your website\u2014no limits on the number of forms created or features restricted by the plan. Get up to 100 submissions every month for free.",
+      "description": "Share and embed unique-looking forms on your website—no limits on the number of forms created or features restricted by the plan. Get up to 100 submissions every month for free.",
       "tier": "Free",
       "url": "https://formester.com",
       "tags": [
@@ -12050,7 +12356,7 @@
     {
       "vendor": "Langtrace",
       "category": "AI / ML",
-      "description": "enables developers to trace, evaluate, manage prompts and datasets, and debug issues related to an LLM application\u2019s performance. It creates open telemetry standard traces for any LLM which helps with observability and works with any observability client. Free plan offers 50K traces/month.",
+      "description": "enables developers to trace, evaluate, manage prompts and datasets, and debug issues related to an LLM application’s performance. It creates open telemetry standard traces for any LLM which helps with observability and works with any observability client. Free plan offers 50K traces/month.",
       "tier": "Free",
       "url": "https://langtrace.ai",
       "tags": [
@@ -12249,7 +12555,16 @@
         "protection",
         "free-for-dev"
       ],
-      "verifiedDate": "2026-04-05"
+      "verifiedDate": "2026-04-05",
+      "referral_program": {
+        "available": true,
+        "referrer_benefit": "20-35% commission depending on product",
+        "referee_benefit": "Standard pricing",
+        "program_url": "https://www.namecheap.com/affiliates/",
+        "type": "affiliate-network",
+        "commission_type": "one-time",
+        "notes": "Domains 20%, hosting 35%, SSL 35%. Powered by Impact. Min payout $10."
+      }
     },
     {
       "vendor": "ovh.ie",
@@ -12384,7 +12699,7 @@
     {
       "vendor": "Clever Cloud",
       "category": "Cloud Hosting",
-      "description": "European PaaS with automated deployments, autoscaling, managed databases, and Git-based workflows. Includes \u20ac20 free credits at signup, a limited DEV plan with free MySQL and PostgreSQL databases, and free allowances for services like Heptapod and FS Buckets.",
+      "description": "European PaaS with automated deployments, autoscaling, managed databases, and Git-based workflows. Includes €20 free credits at signup, a limited DEV plan with free MySQL and PostgreSQL databases, and free allowances for services like Heptapod and FS Buckets.",
       "tier": "Free",
       "url": "https://clever.cloud",
       "tags": [
@@ -12553,7 +12868,7 @@
     {
       "vendor": "Back4App",
       "category": "Cloud Hosting",
-      "description": "Parse-based backend platform \u2014 free tier: 25K API requests/month, 250 MB database, 1 GB file storage, 1 GB transfer, up to 5 apps. REST + GraphQL APIs",
+      "description": "Parse-based backend platform — free tier: 25K API requests/month, 250 MB database, 1 GB file storage, 1 GB transfer, up to 5 apps. REST + GraphQL APIs",
       "tier": "Free",
       "url": "https://www.back4app.com/pricing/backend-as-a-service",
       "tags": [
@@ -12820,7 +13135,7 @@
     {
       "vendor": "Bubble",
       "category": "Cloud Hosting",
-      "description": "Visual no-code web app builder \u2014 free with Bubble branding. Includes responsive design, basic workflows, REST API connector, core plugins, SEO settings, and community support. Hosted on bubbleapps.io subdomain",
+      "description": "Visual no-code web app builder — free with Bubble branding. Includes responsive design, basic workflows, REST API connector, core plugins, SEO settings, and community support. Hosted on bubbleapps.io subdomain",
       "tier": "Free",
       "url": "https://bubble.io/",
       "tags": [
@@ -13141,7 +13456,16 @@
         "domain",
         "free-for-dev"
       ],
-      "verifiedDate": "2026-04-05"
+      "verifiedDate": "2026-04-05",
+      "referral_program": {
+        "available": true,
+        "referrer_benefit": "20-35% commission depending on product",
+        "referee_benefit": "Standard pricing",
+        "program_url": "https://www.namecheap.com/affiliates/",
+        "type": "affiliate-network",
+        "commission_type": "one-time",
+        "notes": "Domains 20%, hosting 35%, SSL 35%. Powered by Impact."
+      }
     },
     {
       "vendor": "nextdns.io",
@@ -13599,7 +13923,7 @@
     {
       "vendor": "asana.com",
       "category": "Project Management",
-      "description": "Project management \u2014 up to 10 users, unlimited tasks, unlimited projects, list/board/calendar views, 100+ integrations, assignees, due dates, comments, mobile apps",
+      "description": "Project management — up to 10 users, unlimited tasks, unlimited projects, list/board/calendar views, 100+ integrations, assignees, due dates, comments, mobile apps",
       "tier": "Free",
       "url": "https://asana.com/",
       "tags": [
@@ -13659,7 +13983,7 @@
     {
       "vendor": "clickup.com",
       "category": "Project Management",
-      "description": "Project management \u2014 unlimited tasks, unlimited members, 60 MB storage, 1 form, kanban boards, sprint management, collaborative docs, calendar view, 24/7 support",
+      "description": "Project management — unlimited tasks, unlimited members, 60 MB storage, 1 form, kanban boards, sprint management, collaborative docs, calendar view, 24/7 support",
       "tier": "Free",
       "url": "https://clickup.com/",
       "tags": [
@@ -13671,7 +13995,7 @@
     {
       "vendor": "Clockify",
       "category": "Project Management",
-      "description": "Time tracker \u2014 unlimited users, unlimited projects, unlimited time tracking. Timesheets, reports, kiosk mode, Pomodoro timer, idle detection, calendar view. Desktop, mobile, and web apps",
+      "description": "Time tracker — unlimited users, unlimited projects, unlimited time tracking. Timesheets, reports, kiosk mode, Pomodoro timer, idle detection, calendar view. Desktop, mobile, and web apps",
       "tier": "Free",
       "url": "https://clockify.me",
       "tags": [
@@ -13803,7 +14127,7 @@
     {
       "vendor": "kan.bn",
       "category": "Project Management",
-      "description": "A powerful, flexible kanban app that helps you organise work, track progress, and deliver results\u2014all in one place. Free plan up to 1 user for unlimited boards, unlimited lists, unlimited cards.",
+      "description": "A powerful, flexible kanban app that helps you organise work, track progress, and deliver results—all in one place. Free plan up to 1 user for unlimited boards, unlimited lists, unlimited cards.",
       "tier": "Free",
       "url": "https://kan.bn/",
       "tags": [
@@ -14019,7 +14343,7 @@
     {
       "vendor": "teamwork.com",
       "category": "Project Management",
-      "description": "Project management \u2014 5 users, 2 projects on free plan. Task lists, milestones, time tracking, file storage, messages, Gantt chart view, board view",
+      "description": "Project management — 5 users, 2 projects on free plan. Task lists, milestones, time tracking, file storage, messages, Gantt chart view, board view",
       "tier": "Free",
       "url": "https://teamwork.com/",
       "tags": [
@@ -14492,7 +14816,7 @@
     {
       "vendor": "podio.com",
       "category": "Storage",
-      "description": "Work management platform \u2014 up to 5 users on free plan, task management, apps, workspaces, basic workflow automations. 1 GB storage. Citrix-backed",
+      "description": "Work management platform — up to 5 users on free plan, task management, apps, workspaces, basic workflow automations. 1 GB storage. Citrix-backed",
       "tier": "Free",
       "url": "https://podio.com/",
       "tags": [
@@ -14519,13 +14843,14 @@
         "referrer_benefit": "Free months of service",
         "referee_benefit": "Free months of service",
         "program_url": "https://proton.me/support/referral-program",
-        "type": "self-service"
+        "type": "self-service",
+        "commission_type": "credits"
       }
     },
     {
       "vendor": "QRME.SH",
       "category": "Storage",
-      "description": "Fast, beautiful bulk QR code generator \u2013 no login, no watermark, no ads. Up to 100 URLs per bulk export.",
+      "description": "Fast, beautiful bulk QR code generator – no login, no watermark, no ads. Up to 100 URLs per bulk export.",
       "tier": "Free",
       "url": "https://qrme.sh",
       "tags": [
@@ -14668,7 +14993,7 @@
     {
       "vendor": "odrive",
       "category": "Storage",
-      "description": "Cloud storage sync and unification platform \u2014 connects Google Drive, Dropbox, S3, OneDrive, and other providers into a single file manager. Free tier being discontinued March 31, 2026",
+      "description": "Cloud storage sync and unification platform — connects Google Drive, Dropbox, S3, OneDrive, and other providers into a single file manager. Free tier being discontinued March 31, 2026",
       "tier": "Free",
       "url": "https://www.odrive.com/",
       "tags": [
@@ -14942,7 +15267,7 @@
     {
       "vendor": "framer.com",
       "category": "Design",
-      "description": "Framer helps you iterate and animate interface ideas for your next app, website, or product\u2014starting with powerful layouts. For anyone validating Framer as a professional prototyping tool: unlimited viewers, up to 2 editors, and up to 3 projects.",
+      "description": "Framer helps you iterate and animate interface ideas for your next app, website, or product—starting with powerful layouts. For anyone validating Framer as a professional prototyping tool: unlimited viewers, up to 2 editors, and up to 3 projects.",
       "tier": "Free",
       "url": "https://www.framer.com/",
       "tags": [
@@ -14994,7 +15319,7 @@
     {
       "vendor": "haikei.app",
       "category": "Design",
-      "description": "Haikei is a web app to generate unique SVG shapes, backgrounds, and patterns \u2013 ready to use with your design tools and workflow.",
+      "description": "Haikei is a web app to generate unique SVG shapes, backgrounds, and patterns – ready to use with your design tools and workflow.",
       "tier": "Free",
       "url": "https://www.haikei.app/",
       "tags": [
@@ -15137,7 +15462,7 @@
     {
       "vendor": "LottieFiles",
       "category": "Design",
-      "description": "The world\u2019s largest online platform for the world\u2019s most miniature animation format for designers, developers, and more. Access Lottie animation tools and plugins for Android, iOS, and Web.",
+      "description": "The world’s largest online platform for the world’s most miniature animation format for designers, developers, and more. Access Lottie animation tools and plugins for Android, iOS, and Web.",
       "tier": "Free",
       "url": "https://lottiefiles.com/",
       "tags": [
@@ -15813,7 +16138,7 @@
     {
       "vendor": "Webflow",
       "category": "Design",
-      "description": "Visual website builder \u2014 2 pages, 20 CMS collections, 50 CMS items, 1 GB bandwidth/month, 50 form submissions (lifetime). Hosted on webflow.io subdomain. AI site builder included",
+      "description": "Visual website builder — 2 pages, 20 CMS collections, 50 CMS items, 1 GB bandwidth/month, 50 form submissions (lifetime). Hosted on webflow.io subdomain. AI site builder included",
       "tier": "Free",
       "url": "https://webflow.com",
       "tags": [
@@ -15852,7 +16177,7 @@
     {
       "vendor": "Zeplin",
       "category": "Design",
-      "description": "Design handoff platform \u2014 1 active project, unlimited members, style guide, component inspection, asset export. Integrates with Figma, Sketch, and Adobe XD",
+      "description": "Design handoff platform — 1 active project, unlimited members, style guide, component inspection, asset export. Integrates with Figma, Sketch, and Adobe XD",
       "tier": "Free",
       "url": "https://zeplin.io/",
       "tags": [
@@ -16191,7 +16516,7 @@
     {
       "vendor": "cocalc.com",
       "category": "Notebooks & Data Science",
-      "description": "Collaborative computation platform (formerly SageMathCloud) \u2014 browser-based Ubuntu with Python, LaTeX, Jupyter, SageMath, R, and Julia pre-installed. 1 project, 1 GB disk, shared CPU",
+      "description": "Collaborative computation platform (formerly SageMathCloud) — browser-based Ubuntu with Python, LaTeX, Jupyter, SageMath, R, and Julia pre-installed. 1 project, 1 GB disk, shared CPU",
       "tier": "Free",
       "url": "https://cocalc.com/",
       "tags": [
@@ -16227,7 +16552,7 @@
     {
       "vendor": "codepen.io",
       "category": "IDE & Code Editors",
-      "description": "Front-end code playground \u2014 unlimited public pens (HTML/CSS/JS), 1 project with 10 files, asset hosting, embedded previews, console, live collaboration. Supports preprocessors (Sass, LESS, TypeScript)",
+      "description": "Front-end code playground — unlimited public pens (HTML/CSS/JS), 1 project with 10 files, asset hosting, embedded previews, console, live collaboration. Supports preprocessors (Sass, LESS, TypeScript)",
       "tier": "Free",
       "url": "https://codepen.io/",
       "tags": [
@@ -16239,7 +16564,7 @@
     {
       "vendor": "codesandbox.io",
       "category": "IDE & Code Editors",
-      "description": "Cloud IDE \u2014 unlimited public sandboxes, 5 private repositories, 40 hrs/month VM credits (4 vCPU, 8 GB RAM). Real-time collaboration, GitHub integration, instant previews",
+      "description": "Cloud IDE — unlimited public sandboxes, 5 private repositories, 40 hrs/month VM credits (4 vCPU, 8 GB RAM). Real-time collaboration, GitHub integration, instant previews",
       "tier": "Free",
       "url": "https://codesandbox.io/",
       "tags": [
@@ -16311,7 +16636,7 @@
     {
       "vendor": "MarsCode",
       "category": "IDE & Code Editors",
-      "description": "Cloud IDE with AI coding assistant \u2014 code completion, debugging, code explanation, unit test generation. 2 GB workspace storage, supports 100+ languages and frameworks",
+      "description": "Cloud IDE with AI coding assistant — code completion, debugging, code explanation, unit test generation. 2 GB workspace storage, supports 100+ languages and frameworks",
       "tier": "Free",
       "url": "https://www.marscode.com/",
       "tags": [
@@ -16383,7 +16708,7 @@
     {
       "vendor": "Replit",
       "category": "IDE & Code Editors",
-      "description": "Cloud IDE with AI code assistant \u2014 10 GiB account storage, multiplayer collaboration, unlimited public Repls. Supports 50+ languages. Built-in hosting, version history, and package management. Core plan $20/month (was $25, now includes up to 5 collaborators), new Pro plan $100/month with Agent modes and up to 15 builders. Teams plan sunset (migrated to Pro). Free tier unchanged (limited AI credits, basic compute)",
+      "description": "Cloud IDE with AI code assistant — 10 GiB account storage, multiplayer collaboration, unlimited public Repls. Supports 50+ languages. Built-in hosting, version history, and package management. Core plan $20/month (was $25, now includes up to 5 collaborators), new Pro plan $100/month with Agent modes and up to 15 builders. Teams plan sunset (migrated to Pro). Free tier unchanged (limited AI credits, basic compute)",
       "tier": "Free",
       "url": "https://replit.com/pricing",
       "tags": [
@@ -16408,7 +16733,7 @@
     {
       "vendor": "stackblitz.com",
       "category": "IDE & Code Editors",
-      "description": "Browser-based IDE with WebContainers \u2014 unlimited public projects and GitHub repos. Runs Node.js natively in the browser with no remote server. Instant environment setup, offline support",
+      "description": "Browser-based IDE with WebContainers — unlimited public projects and GitHub repos. Runs Node.js natively in the browser with no remote server. Instant environment setup, offline support",
       "tier": "Free",
       "url": "https://stackblitz.com/",
       "tags": [
@@ -16456,7 +16781,7 @@
     {
       "vendor": "VSCodium",
       "category": "IDE & Code Editors",
-      "description": "Community-driven, without telemetry/tracking, and freely-licensed binary distribution of Microsoft\u2019s editor VSCode",
+      "description": "Community-driven, without telemetry/tracking, and freely-licensed binary distribution of Microsoft’s editor VSCode",
       "tier": "Free",
       "url": "https://vscodium.com/",
       "tags": [
@@ -16468,7 +16793,7 @@
     {
       "vendor": "wakatime.com",
       "category": "IDE & Code Editors",
-      "description": "Coding activity tracker via editor plugins \u2014 1-week dashboard history, 1 programming goal, weekly email reports, public leaderboard. Supports 60+ IDEs including VS Code, JetBrains, Vim",
+      "description": "Coding activity tracker via editor plugins — 1-week dashboard history, 1 programming goal, weekly email reports, public leaderboard. Supports 60+ IDEs including VS Code, JetBrains, Vim",
       "tier": "Free",
       "url": "https://wakatime.com/",
       "tags": [
@@ -16633,7 +16958,7 @@
     {
       "vendor": "Expensify",
       "category": "Analytics",
-      "description": "Expense management \u2014 unlimited receipt scanning (SmartScan OCR), expense reports, next-day reimbursement, corporate card program. Free for individuals",
+      "description": "Expense management — unlimited receipt scanning (SmartScan OCR), expense reports, next-day reimbursement, corporate card program. Free for individuals",
       "tier": "Free",
       "url": "https://www.expensify.com/",
       "tags": [
@@ -17177,7 +17502,7 @@
     {
       "vendor": "GraphComment",
       "category": "Communication",
-      "description": "GraphComment is a comments platform that helps you build an active community from the website\u2019s audience.",
+      "description": "GraphComment is a comments platform that helps you build an active community from the website’s audience.",
       "tier": "Free",
       "url": "https://graphcomment.com/",
       "tags": [
@@ -17845,7 +18170,7 @@
       "eligibility": {
         "type": "startup",
         "conditions": [
-          "Startup program \u2014 check vendor for eligibility details"
+          "Startup program — check vendor for eligibility details"
         ],
         "program": "Instabug for Startups Startup Program"
       }
@@ -17865,7 +18190,7 @@
       "eligibility": {
         "type": "startup",
         "conditions": [
-          "Startup program \u2014 check vendor for eligibility details"
+          "Startup program — check vendor for eligibility details"
         ],
         "program": "Freshworks for Startups Startup Program"
       },
@@ -17887,7 +18212,7 @@
       "eligibility": {
         "type": "startup",
         "conditions": [
-          "Startup program \u2014 check vendor for eligibility details"
+          "Startup program — check vendor for eligibility details"
         ],
         "program": "Startup with IBM Startup Program"
       },
@@ -17896,7 +18221,7 @@
     {
       "vendor": "Microsoft for Startups",
       "category": "Cloud IaaS",
-      "description": "Get access to a wide range of benefits\u2014from technical resources and free Azure cloud, to selling alongside Microsoft salespeople and partner channel.",
+      "description": "Get access to a wide range of benefits—from technical resources and free Azure cloud, to selling alongside Microsoft salespeople and partner channel.",
       "tier": "Startup Program",
       "url": "https://startups.microsoft.com/en-us/",
       "tags": [
@@ -17909,7 +18234,7 @@
       "eligibility": {
         "type": "startup",
         "conditions": [
-          "Startup program \u2014 check vendor for eligibility details"
+          "Startup program — check vendor for eligibility details"
         ],
         "program": "Microsoft for Startups Startup Program"
       }
@@ -17930,7 +18255,7 @@
       "eligibility": {
         "type": "startup",
         "conditions": [
-          "Startup program \u2014 check vendor for eligibility details"
+          "Startup program — check vendor for eligibility details"
         ],
         "program": "Create@Alibaba Cloud Startup Program"
       }
@@ -17951,7 +18276,7 @@
       "eligibility": {
         "type": "startup",
         "conditions": [
-          "Startup program \u2014 check vendor for eligibility details"
+          "Startup program — check vendor for eligibility details"
         ],
         "program": "Clever Bootstrap Program Startup Program"
       }
@@ -17959,7 +18284,7 @@
     {
       "vendor": "Heroku for Startups Program",
       "category": "Cloud IaaS",
-      "description": "The Heroku for Startups Program provides teams with the resources they need to quickly get started on Heroku\u2014including platform credits, technical support, and networking.",
+      "description": "The Heroku for Startups Program provides teams with the resources they need to quickly get started on Heroku—including platform credits, technical support, and networking.",
       "tier": "Startup Program",
       "url": "https://www.heroku.com/accelerate",
       "tags": [
@@ -17972,11 +18297,19 @@
       "eligibility": {
         "type": "startup",
         "conditions": [
-          "Startup program \u2014 check vendor for eligibility details"
+          "Startup program — check vendor for eligibility details"
         ],
         "program": "Heroku for Startups Program Startup Program"
       },
-      "expires_date": "2026-04-30"
+      "expires_date": "2026-04-30",
+      "referral_program": {
+        "available": false,
+        "referrer_benefit": "N/A",
+        "referee_benefit": "N/A",
+        "program_url": "https://www.heroku.com/partnering/",
+        "type": "partner",
+        "notes": "No affiliate program. Consulting and add-on partner programs exist."
+      }
     },
     {
       "vendor": "Scaleway Startup Program",
@@ -17994,7 +18327,7 @@
       "eligibility": {
         "type": "startup",
         "conditions": [
-          "Startup program \u2014 check vendor for eligibility details"
+          "Startup program — check vendor for eligibility details"
         ],
         "program": "Scaleway Startup Program Startup Program"
       }
@@ -18015,7 +18348,7 @@
       "eligibility": {
         "type": "startup",
         "conditions": [
-          "Startup program \u2014 check vendor for eligibility details"
+          "Startup program — check vendor for eligibility details"
         ],
         "program": "ScaleGrid Startup Program Startup Program"
       }
@@ -18023,7 +18356,7 @@
     {
       "vendor": "Knowlarity for Startups",
       "category": "Communication",
-      "description": "Unicorn dreams? Knowlarity is happy to offer free credits for its communications suite product\u2014SuperReceptionist. Contact them for exclusive benefits.",
+      "description": "Unicorn dreams? Knowlarity is happy to offer free credits for its communications suite product—SuperReceptionist. Contact them for exclusive benefits.",
       "tier": "Startup Program",
       "url": "https://www.knowlarity.com/startups/",
       "tags": [
@@ -18035,7 +18368,7 @@
       "eligibility": {
         "type": "startup",
         "conditions": [
-          "Startup program \u2014 check vendor for eligibility details"
+          "Startup program — check vendor for eligibility details"
         ],
         "program": "Knowlarity for Startups Startup Program"
       }
@@ -18055,15 +18388,24 @@
       "eligibility": {
         "type": "startup",
         "conditions": [
-          "Startup program \u2014 check vendor for eligibility details"
+          "Startup program — check vendor for eligibility details"
         ],
         "program": "Twilio Startups Program Startup Program"
+      },
+      "referral_program": {
+        "available": true,
+        "referrer_benefit": "10% of minimum spend (max $500K)",
+        "referee_benefit": "Partner program resources",
+        "program_url": "https://www.twilio.com/en-us/partners/become-a-partner",
+        "type": "partner",
+        "commission_type": "one-time",
+        "notes": "Enterprise-focused. Order form minimum 12 months, $25K+ ARR required. Top partner tiers only."
       }
     },
     {
       "vendor": "The Intercom Early Stage Program",
       "category": "Communication",
-      "description": "Intercom helps you build customer relationships through conversational, messenger-based experiences across the customer journey. Eligible startups get all of Intercom\u2019s Pro products for a flat rate of $49/mo for up to one year.",
+      "description": "Intercom helps you build customer relationships through conversational, messenger-based experiences across the customer journey. Eligible startups get all of Intercom’s Pro products for a flat rate of $49/mo for up to one year.",
       "tier": "Startup Program",
       "url": "https://www.intercom.com/early-stage",
       "tags": [
@@ -18075,7 +18417,7 @@
       "eligibility": {
         "type": "startup",
         "conditions": [
-          "Startup program \u2014 check vendor for eligibility details"
+          "Startup program — check vendor for eligibility details"
         ],
         "program": "The Intercom Early Stage Program Startup Program"
       }
@@ -18095,7 +18437,7 @@
       "eligibility": {
         "type": "startup",
         "conditions": [
-          "Startup program \u2014 check vendor for eligibility details"
+          "Startup program — check vendor for eligibility details"
         ],
         "program": "The GoSquared Early Stage Plan Startup Program"
       }
@@ -18115,7 +18457,7 @@
       "eligibility": {
         "type": "startup",
         "conditions": [
-          "Startup program \u2014 check vendor for eligibility details"
+          "Startup program — check vendor for eligibility details"
         ],
         "program": "Zendesk for Startups Startup Program"
       }
@@ -18135,7 +18477,7 @@
       "eligibility": {
         "type": "startup",
         "conditions": [
-          "Startup program \u2014 check vendor for eligibility details"
+          "Startup program — check vendor for eligibility details"
         ],
         "program": "Help Scout for Startups Startup Program"
       }
@@ -18155,7 +18497,7 @@
       "eligibility": {
         "type": "startup",
         "conditions": [
-          "Startup program \u2014 check vendor for eligibility details"
+          "Startup program — check vendor for eligibility details"
         ],
         "program": "Drift for Early Stage Startups Startup Program"
       }
@@ -18175,11 +18517,19 @@
       "eligibility": {
         "type": "startup",
         "conditions": [
-          "Startup program \u2014 check vendor for eligibility details"
+          "Startup program — check vendor for eligibility details"
         ],
         "program": "SendGrid Accelerate Startup Program"
       },
-      "expires_date": "2026-05-15"
+      "expires_date": "2026-05-15",
+      "referral_program": {
+        "available": false,
+        "referrer_benefit": "N/A",
+        "referee_benefit": "N/A",
+        "program_url": "https://sendgrid.com/partners/affiliate/",
+        "type": "closed",
+        "notes": "No active affiliate program."
+      }
     },
     {
       "vendor": "Autodesk Fusion 360 for Startups",
@@ -18196,7 +18546,7 @@
       "eligibility": {
         "type": "startup",
         "conditions": [
-          "Startup program \u2014 check vendor for eligibility details"
+          "Startup program — check vendor for eligibility details"
         ],
         "program": "Autodesk Fusion 360 for Startups Startup Program"
       }
@@ -18204,7 +18554,7 @@
     {
       "vendor": "Chargebee Launch Programme",
       "category": "Payments",
-      "description": "Chargebee makes managing subscription billing easier for you. With Chargebee\u2019s Launch Plan, you get your first USD 50k in revenue for free.",
+      "description": "Chargebee makes managing subscription billing easier for you. With Chargebee’s Launch Plan, you get your first USD 50k in revenue for free.",
       "tier": "Startup Program",
       "url": "https://www.chargebee.com/launch/",
       "tags": [
@@ -18217,7 +18567,7 @@
       "eligibility": {
         "type": "startup",
         "conditions": [
-          "Startup program \u2014 check vendor for eligibility details"
+          "Startup program — check vendor for eligibility details"
         ],
         "program": "Chargebee Launch Programme Startup Program"
       }
@@ -18225,7 +18575,7 @@
     {
       "vendor": "HubSpot for Startups",
       "category": "Startup Perks",
-      "description": "Startups using the HubSpot Growth Platform acquire and retain more customers with HubSpot\u2019s software, educational resources, and robust integrations. All at startup-friendly pricing up to 90% off.",
+      "description": "Startups using the HubSpot Growth Platform acquire and retain more customers with HubSpot’s software, educational resources, and robust integrations. All at startup-friendly pricing up to 90% off.",
       "tier": "Startup Program",
       "url": "https://www.hubspot.com/startups",
       "tags": [
@@ -18237,7 +18587,7 @@
       "eligibility": {
         "type": "startup",
         "conditions": [
-          "Startup program \u2014 check vendor for eligibility details"
+          "Startup program — check vendor for eligibility details"
         ],
         "program": "HubSpot for Startups Startup Program"
       },
@@ -18258,7 +18608,7 @@
       "eligibility": {
         "type": "startup",
         "conditions": [
-          "Startup program \u2014 check vendor for eligibility details"
+          "Startup program — check vendor for eligibility details"
         ],
         "program": "Shotstack Startup Program Startup Program"
       },
@@ -18279,7 +18629,7 @@
       "eligibility": {
         "type": "startup",
         "conditions": [
-          "Startup program \u2014 check vendor for eligibility details"
+          "Startup program — check vendor for eligibility details"
         ],
         "program": "Esri Startup Program Startup Program"
       }
@@ -18299,7 +18649,7 @@
       "eligibility": {
         "type": "startup",
         "conditions": [
-          "Startup program \u2014 check vendor for eligibility details"
+          "Startup program — check vendor for eligibility details"
         ],
         "program": "MATLAB and Simulink for Startups Startup Program"
       }
@@ -18319,7 +18669,7 @@
       "eligibility": {
         "type": "startup",
         "conditions": [
-          "Startup program \u2014 check vendor for eligibility details"
+          "Startup program — check vendor for eligibility details"
         ],
         "program": "FeedBear Startup Program"
       }
@@ -18339,7 +18689,7 @@
       "eligibility": {
         "type": "startup",
         "conditions": [
-          "Startup program \u2014 check vendor for eligibility details"
+          "Startup program — check vendor for eligibility details"
         ],
         "program": "Remote for Startups Startup Program"
       }
@@ -18359,7 +18709,7 @@
       "eligibility": {
         "type": "startup",
         "conditions": [
-          "Startup program \u2014 check vendor for eligibility details"
+          "Startup program — check vendor for eligibility details"
         ],
         "program": "Pareto Security Startup Program"
       }
@@ -18367,7 +18717,7 @@
     {
       "vendor": "Achieved",
       "category": "Startup Perks",
-      "description": "6 months free. Access via: First deal free, then 99\u20ac/year or invite friends",
+      "description": "6 months free. Access via: First deal free, then 99€/year or invite friends",
       "tier": "Startup Program",
       "url": "https://www.joinsecret.com/offers",
       "tags": [
@@ -18379,7 +18729,7 @@
       "eligibility": {
         "type": "startup",
         "conditions": [
-          "First deal free, then 99\u20ac/year or invite friends"
+          "First deal free, then 99€/year or invite friends"
         ],
         "program": "Achieved Startup Deal"
       }
@@ -18428,7 +18778,7 @@
     {
       "vendor": "Axonaut",
       "category": "Startup Perks",
-      "description": "3 months free up to 50 users. Access via: First deal free, then 99\u20ac/year or invite friends",
+      "description": "3 months free up to 50 users. Access via: First deal free, then 99€/year or invite friends",
       "tier": "Startup Program",
       "url": "https://www.joinsecret.com/offers",
       "tags": [
@@ -18440,7 +18790,7 @@
       "eligibility": {
         "type": "startup",
         "conditions": [
-          "First deal free, then 99\u20ac/year or invite friends"
+          "First deal free, then 99€/year or invite friends"
         ],
         "program": "Axonaut Startup Deal"
       }
@@ -18448,7 +18798,7 @@
     {
       "vendor": "Azameo",
       "category": "Startup Perks",
-      "description": "\u20ac100 credit. Access via: First deal free, then 99\u20ac/year or invite friends",
+      "description": "€100 credit. Access via: First deal free, then 99€/year or invite friends",
       "tier": "Startup Program",
       "url": "https://www.joinsecret.com/offers",
       "tags": [
@@ -18460,7 +18810,7 @@
       "eligibility": {
         "type": "startup",
         "conditions": [
-          "First deal free, then 99\u20ac/year or invite friends"
+          "First deal free, then 99€/year or invite friends"
         ],
         "program": "Azameo Startup Deal"
       }
@@ -18468,7 +18818,7 @@
     {
       "vendor": "Batch",
       "category": "Startup Perks",
-      "description": "12 months free on Developer plan. Access via: First deal free, then 99\u20ac/year or invite friends",
+      "description": "12 months free on Developer plan. Access via: First deal free, then 99€/year or invite friends",
       "tier": "Startup Program",
       "url": "https://www.joinsecret.com/offers",
       "tags": [
@@ -18480,7 +18830,7 @@
       "eligibility": {
         "type": "startup",
         "conditions": [
-          "First deal free, then 99\u20ac/year or invite friends"
+          "First deal free, then 99€/year or invite friends"
         ],
         "program": "Batch Startup Deal"
       }
@@ -18508,7 +18858,7 @@
     {
       "vendor": "Botnation",
       "category": "Startup Perks",
-      "description": "6 months free on Expert plan, up to 1,000 users/month.. Access via: First deal free, then 99\u20ac/year or invite friends",
+      "description": "6 months free on Expert plan, up to 1,000 users/month.. Access via: First deal free, then 99€/year or invite friends",
       "tier": "Startup Program",
       "url": "https://www.joinsecret.com/offers",
       "tags": [
@@ -18520,7 +18870,7 @@
       "eligibility": {
         "type": "startup",
         "conditions": [
-          "First deal free, then 99\u20ac/year or invite friends"
+          "First deal free, then 99€/year or invite friends"
         ],
         "program": "Botnation Startup Deal"
       }
@@ -18528,7 +18878,7 @@
     {
       "vendor": "CaptainData",
       "category": "Startup Perks",
-      "description": "6 months free on Mercury plan. Access via: First deal free, then 99\u20ac/year or invite friends",
+      "description": "6 months free on Mercury plan. Access via: First deal free, then 99€/year or invite friends",
       "tier": "Startup Program",
       "url": "https://www.joinsecret.com/offers",
       "tags": [
@@ -18540,7 +18890,7 @@
       "eligibility": {
         "type": "startup",
         "conditions": [
-          "First deal free, then 99\u20ac/year or invite friends"
+          "First deal free, then 99€/year or invite friends"
         ],
         "program": "CaptainData Startup Deal"
       }
@@ -18608,7 +18958,7 @@
     {
       "vendor": "CloudImage",
       "category": "Cloud IaaS",
-      "description": "12 months free on Startup plan. Access via: First deal free, then 99\u20ac/year or invite friends",
+      "description": "12 months free on Startup plan. Access via: First deal free, then 99€/year or invite friends",
       "tier": "Startup Program",
       "url": "https://www.joinsecret.com/offers",
       "tags": [
@@ -18621,7 +18971,7 @@
       "eligibility": {
         "type": "startup",
         "conditions": [
-          "First deal free, then 99\u20ac/year or invite friends"
+          "First deal free, then 99€/year or invite friends"
         ],
         "program": "CloudImage Startup Deal"
       }
@@ -18629,7 +18979,7 @@
     {
       "vendor": "Cloudtalk",
       "category": "Cloud IaaS",
-      "description": "6 months free on Expert plan for 5 users. Access via: First deal free, then 99\u20ac/year or invite friends",
+      "description": "6 months free on Expert plan for 5 users. Access via: First deal free, then 99€/year or invite friends",
       "tier": "Startup Program",
       "url": "https://www.joinsecret.com/offers",
       "tags": [
@@ -18642,7 +18992,7 @@
       "eligibility": {
         "type": "startup",
         "conditions": [
-          "First deal free, then 99\u20ac/year or invite friends"
+          "First deal free, then 99€/year or invite friends"
         ],
         "program": "Cloudtalk Startup Deal"
       }
@@ -18650,7 +19000,7 @@
     {
       "vendor": "Cloudways",
       "category": "Cloud IaaS",
-      "description": "30% off for 3 months. Access via: First deal free, then 99\u20ac/year or invite friends",
+      "description": "30% off for 3 months. Access via: First deal free, then 99€/year or invite friends",
       "tier": "Startup Program",
       "url": "https://www.joinsecret.com/offers",
       "tags": [
@@ -18663,7 +19013,7 @@
       "eligibility": {
         "type": "startup",
         "conditions": [
-          "First deal free, then 99\u20ac/year or invite friends"
+          "First deal free, then 99€/year or invite friends"
         ],
         "program": "Cloudways Startup Deal"
       }
@@ -18671,7 +19021,7 @@
     {
       "vendor": "ColdCRM",
       "category": "Communication",
-      "description": "\u20ac40 discount on the \u20ac129/month plan for 6 months. Access via: First deal free, then 99\u20ac/year or invite friends",
+      "description": "€40 discount on the €129/month plan for 6 months. Access via: First deal free, then 99€/year or invite friends",
       "tier": "Startup Program",
       "url": "https://www.joinsecret.com/offers",
       "tags": [
@@ -18683,7 +19033,7 @@
       "eligibility": {
         "type": "startup",
         "conditions": [
-          "First deal free, then 99\u20ac/year or invite friends"
+          "First deal free, then 99€/year or invite friends"
         ],
         "program": "ColdCRM Startup Deal"
       }
@@ -18691,7 +19041,7 @@
     {
       "vendor": "Crowdfire",
       "category": "Startup Perks",
-      "description": "50% off on Premium plan lifetime deal. Access via: First deal free, then 99\u20ac/year or invite friends",
+      "description": "50% off on Premium plan lifetime deal. Access via: First deal free, then 99€/year or invite friends",
       "tier": "Startup Program",
       "url": "https://www.joinsecret.com/offers",
       "tags": [
@@ -18703,7 +19053,7 @@
       "eligibility": {
         "type": "startup",
         "conditions": [
-          "First deal free, then 99\u20ac/year or invite friends"
+          "First deal free, then 99€/year or invite friends"
         ],
         "program": "Crowdfire Startup Deal"
       }
@@ -18711,7 +19061,7 @@
     {
       "vendor": "Dareboost",
       "category": "Startup Perks",
-      "description": "6 months free on Business plan. Access via: First deal free, then 99\u20ac/year or invite friends",
+      "description": "6 months free on Business plan. Access via: First deal free, then 99€/year or invite friends",
       "tier": "Startup Program",
       "url": "https://www.joinsecret.com/offers",
       "tags": [
@@ -18723,7 +19073,7 @@
       "eligibility": {
         "type": "startup",
         "conditions": [
-          "First deal free, then 99\u20ac/year or invite friends"
+          "First deal free, then 99€/year or invite friends"
         ],
         "program": "Dareboost Startup Deal"
       }
@@ -18731,7 +19081,7 @@
     {
       "vendor": "Datananas",
       "category": "Startup Perks",
-      "description": "50% for 6 months on Pro plan. Access via: First deal free, then 99\u20ac/year or invite friends",
+      "description": "50% for 6 months on Pro plan. Access via: First deal free, then 99€/year or invite friends",
       "tier": "Startup Program",
       "url": "https://www.joinsecret.com/offers",
       "tags": [
@@ -18743,7 +19093,7 @@
       "eligibility": {
         "type": "startup",
         "conditions": [
-          "First deal free, then 99\u20ac/year or invite friends"
+          "First deal free, then 99€/year or invite friends"
         ],
         "program": "Datananas Startup Deal"
       }
@@ -18771,7 +19121,7 @@
     {
       "vendor": "E-Goi",
       "category": "Startup Perks",
-      "description": "6 months free on Starter plan (5000 contacts max). Access via: First deal free, then 99\u20ac/year or invite friends",
+      "description": "6 months free on Starter plan (5000 contacts max). Access via: First deal free, then 99€/year or invite friends",
       "tier": "Startup Program",
       "url": "https://www.joinsecret.com/offers",
       "tags": [
@@ -18783,7 +19133,7 @@
       "eligibility": {
         "type": "startup",
         "conditions": [
-          "First deal free, then 99\u20ac/year or invite friends"
+          "First deal free, then 99€/year or invite friends"
         ],
         "program": "E-Goi Startup Deal"
       }
@@ -18812,7 +19162,7 @@
     {
       "vendor": "findmassleads",
       "category": "Startup Perks",
-      "description": "50% off on the annual Pro plan. Access via: First deal free, then 99\u20ac/year or invite friends",
+      "description": "50% off on the annual Pro plan. Access via: First deal free, then 99€/year or invite friends",
       "tier": "Startup Program",
       "url": "https://www.joinsecret.com/offers",
       "tags": [
@@ -18824,7 +19174,7 @@
       "eligibility": {
         "type": "startup",
         "conditions": [
-          "First deal free, then 99\u20ac/year or invite friends"
+          "First deal free, then 99€/year or invite friends"
         ],
         "program": "findmassleads Startup Deal"
       }
@@ -18852,7 +19202,7 @@
     {
       "vendor": "Freebe",
       "category": "Startup Perks",
-      "description": "6 months free. Access via: First deal free, then 99\u20ac/year or invite friends",
+      "description": "6 months free. Access via: First deal free, then 99€/year or invite friends",
       "tier": "Startup Program",
       "url": "https://www.joinsecret.com/offers",
       "tags": [
@@ -18864,7 +19214,7 @@
       "eligibility": {
         "type": "startup",
         "conditions": [
-          "First deal free, then 99\u20ac/year or invite friends"
+          "First deal free, then 99€/year or invite friends"
         ],
         "program": "Freebe Startup Deal"
       }
@@ -18872,7 +19222,7 @@
     {
       "vendor": "Freshchat",
       "category": "Startup Perks",
-      "description": "$250 credit. Access via: First deal free, then 99\u20ac/year or invite friends",
+      "description": "$250 credit. Access via: First deal free, then 99€/year or invite friends",
       "tier": "Startup Program",
       "url": "https://www.joinsecret.com/offers",
       "tags": [
@@ -18884,7 +19234,7 @@
       "eligibility": {
         "type": "startup",
         "conditions": [
-          "First deal free, then 99\u20ac/year or invite friends"
+          "First deal free, then 99€/year or invite friends"
         ],
         "program": "Freshchat Startup Deal"
       }
@@ -18892,7 +19242,7 @@
     {
       "vendor": "Freshdesk",
       "category": "Startup Perks",
-      "description": "$250 credit. Access via: First deal free, then 99\u20ac/year or invite friends",
+      "description": "$250 credit. Access via: First deal free, then 99€/year or invite friends",
       "tier": "Startup Program",
       "url": "https://www.joinsecret.com/offers",
       "tags": [
@@ -18904,7 +19254,7 @@
       "eligibility": {
         "type": "startup",
         "conditions": [
-          "First deal free, then 99\u20ac/year or invite friends"
+          "First deal free, then 99€/year or invite friends"
         ],
         "program": "Freshdesk Startup Deal"
       }
@@ -18912,7 +19262,7 @@
     {
       "vendor": "Freshmarketer",
       "category": "Startup Perks",
-      "description": "$250 credit. Access via: First deal free, then 99\u20ac/year or invite friends",
+      "description": "$250 credit. Access via: First deal free, then 99€/year or invite friends",
       "tier": "Startup Program",
       "url": "https://www.joinsecret.com/offers",
       "tags": [
@@ -18924,7 +19274,7 @@
       "eligibility": {
         "type": "startup",
         "conditions": [
-          "First deal free, then 99\u20ac/year or invite friends"
+          "First deal free, then 99€/year or invite friends"
         ],
         "program": "Freshmarketer Startup Deal"
       }
@@ -18932,7 +19282,7 @@
     {
       "vendor": "Freshsales",
       "category": "Startup Perks",
-      "description": "$250 credit. Access via: First deal free, then 99\u20ac/year or invite friends",
+      "description": "$250 credit. Access via: First deal free, then 99€/year or invite friends",
       "tier": "Startup Program",
       "url": "https://www.joinsecret.com/offers",
       "tags": [
@@ -18944,7 +19294,7 @@
       "eligibility": {
         "type": "startup",
         "conditions": [
-          "First deal free, then 99\u20ac/year or invite friends"
+          "First deal free, then 99€/year or invite friends"
         ],
         "program": "Freshsales Startup Deal"
       }
@@ -18952,7 +19302,7 @@
     {
       "vendor": "Front",
       "category": "Startup Perks",
-      "description": "75% off any Front plan for 12 months. Access via: First deal free, then 99\u20ac/year or invite friends",
+      "description": "75% off any Front plan for 12 months. Access via: First deal free, then 99€/year or invite friends",
       "tier": "Startup Program",
       "url": "https://www.joinsecret.com/offers",
       "tags": [
@@ -18964,7 +19314,7 @@
       "eligibility": {
         "type": "startup",
         "conditions": [
-          "First deal free, then 99\u20ac/year or invite friends"
+          "First deal free, then 99€/year or invite friends"
         ],
         "program": "Front Startup Deal"
       }
@@ -18972,7 +19322,7 @@
     {
       "vendor": "GoCardLess",
       "category": "Startup Perks",
-      "description": "50% off Plus Plan monthly fees for 12 months. Access via: First deal free, then 99\u20ac/year or invite friends",
+      "description": "50% off Plus Plan monthly fees for 12 months. Access via: First deal free, then 99€/year or invite friends",
       "tier": "Startup Program",
       "url": "https://www.joinsecret.com/offers",
       "tags": [
@@ -18984,7 +19334,7 @@
       "eligibility": {
         "type": "startup",
         "conditions": [
-          "First deal free, then 99\u20ac/year or invite friends"
+          "First deal free, then 99€/year or invite friends"
         ],
         "program": "GoCardLess Startup Deal"
       }
@@ -19052,7 +19402,7 @@
     {
       "vendor": "Harvestr",
       "category": "Startup Perks",
-      "description": "6 months free on Starter plan. Access via: First deal free, then 99\u20ac/year or invite friends",
+      "description": "6 months free on Starter plan. Access via: First deal free, then 99€/year or invite friends",
       "tier": "Startup Program",
       "url": "https://www.joinsecret.com/offers",
       "tags": [
@@ -19064,7 +19414,7 @@
       "eligibility": {
         "type": "startup",
         "conditions": [
-          "First deal free, then 99\u20ac/year or invite friends"
+          "First deal free, then 99€/year or invite friends"
         ],
         "program": "Harvestr Startup Deal"
       }
@@ -19112,7 +19462,7 @@
     {
       "vendor": "InVision",
       "category": "Startup Perks",
-      "description": "6 months free on Starter plan. Access via: First deal free, then 99\u20ac/year or invite friends",
+      "description": "6 months free on Starter plan. Access via: First deal free, then 99€/year or invite friends",
       "tier": "Startup Program",
       "url": "https://www.joinsecret.com/offers",
       "tags": [
@@ -19124,7 +19474,7 @@
       "eligibility": {
         "type": "startup",
         "conditions": [
-          "First deal free, then 99\u20ac/year or invite friends"
+          "First deal free, then 99€/year or invite friends"
         ],
         "program": "InVision Startup Deal"
       }
@@ -19132,7 +19482,7 @@
     {
       "vendor": "Kaspr",
       "category": "Startup Perks",
-      "description": "50% off Basic plan for 12 months. Access via: First deal free, then 99\u20ac/year or invite friends",
+      "description": "50% off Basic plan for 12 months. Access via: First deal free, then 99€/year or invite friends",
       "tier": "Startup Program",
       "url": "https://www.joinsecret.com/offers",
       "tags": [
@@ -19144,7 +19494,7 @@
       "eligibility": {
         "type": "startup",
         "conditions": [
-          "First deal free, then 99\u20ac/year or invite friends"
+          "First deal free, then 99€/year or invite friends"
         ],
         "program": "Kaspr Startup Deal"
       }
@@ -19192,7 +19542,7 @@
     {
       "vendor": "La Fabrique Juridique",
       "category": "Startup Perks",
-      "description": "\u20ac200 credit. Access via: First deal free, then 99\u20ac/year or invite friends",
+      "description": "€200 credit. Access via: First deal free, then 99€/year or invite friends",
       "tier": "Startup Program",
       "url": "https://www.joinsecret.com/offers",
       "tags": [
@@ -19204,7 +19554,7 @@
       "eligibility": {
         "type": "startup",
         "conditions": [
-          "First deal free, then 99\u20ac/year or invite friends"
+          "First deal free, then 99€/year or invite friends"
         ],
         "program": "La Fabrique Juridique Startup Deal"
       }
@@ -19212,7 +19562,7 @@
     {
       "vendor": "Legalstart",
       "category": "Startup Perks",
-      "description": "25% discount. Access via: First deal free, then 99\u20ac/year or invite friends",
+      "description": "25% discount. Access via: First deal free, then 99€/year or invite friends",
       "tier": "Startup Program",
       "url": "https://www.joinsecret.com/offers",
       "tags": [
@@ -19224,7 +19574,7 @@
       "eligibility": {
         "type": "startup",
         "conditions": [
-          "First deal free, then 99\u20ac/year or invite friends"
+          "First deal free, then 99€/year or invite friends"
         ],
         "program": "Legalstart Startup Deal"
       }
@@ -19232,7 +19582,7 @@
     {
       "vendor": "Libeo",
       "category": "Startup Perks",
-      "description": "50% off for 6 months on any plan. Access via: First deal free, then 99\u20ac/year or invite friends",
+      "description": "50% off for 6 months on any plan. Access via: First deal free, then 99€/year or invite friends",
       "tier": "Startup Program",
       "url": "https://www.joinsecret.com/offers",
       "tags": [
@@ -19244,7 +19594,7 @@
       "eligibility": {
         "type": "startup",
         "conditions": [
-          "First deal free, then 99\u20ac/year or invite friends"
+          "First deal free, then 99€/year or invite friends"
         ],
         "program": "Libeo Startup Deal"
       }
@@ -19252,7 +19602,7 @@
     {
       "vendor": "Mention",
       "category": "Startup Perks",
-      "description": "6 months free on Solo plan. Access via: First deal free, then 99\u20ac/year or invite friends",
+      "description": "6 months free on Solo plan. Access via: First deal free, then 99€/year or invite friends",
       "tier": "Startup Program",
       "url": "https://www.joinsecret.com/offers",
       "tags": [
@@ -19264,7 +19614,7 @@
       "eligibility": {
         "type": "startup",
         "conditions": [
-          "First deal free, then 99\u20ac/year or invite friends"
+          "First deal free, then 99€/year or invite friends"
         ],
         "program": "Mention Startup Deal"
       }
@@ -19288,6 +19638,15 @@
           "Free for Brex customers"
         ],
         "program": "MongoDB Startup Deal"
+      },
+      "referral_program": {
+        "available": true,
+        "referrer_benefit": "$100 Amazon gift card per referral",
+        "referee_benefit": "Atlas free tier",
+        "program_url": "https://www.mongodb.com/referral-program",
+        "type": "self-service",
+        "commission_type": "one-time",
+        "notes": "Referee must run M10+ cluster for 30+ days."
       }
     },
     {
@@ -19313,7 +19672,7 @@
     {
       "vendor": "noCRM",
       "category": "Communication",
-      "description": "\u20ac250 credit. Access via: First deal free, then 99\u20ac/year or invite friends",
+      "description": "€250 credit. Access via: First deal free, then 99€/year or invite friends",
       "tier": "Startup Program",
       "url": "https://www.joinsecret.com/offers",
       "tags": [
@@ -19325,7 +19684,7 @@
       "eligibility": {
         "type": "startup",
         "conditions": [
-          "First deal free, then 99\u20ac/year or invite friends"
+          "First deal free, then 99€/year or invite friends"
         ],
         "program": "noCRM Startup Deal"
       }
@@ -19333,7 +19692,7 @@
     {
       "vendor": "PayFit",
       "category": "Startup Perks",
-      "description": "50% off for 6 months. Access via: First deal free, then 99\u20ac/year or invite friends",
+      "description": "50% off for 6 months. Access via: First deal free, then 99€/year or invite friends",
       "tier": "Startup Program",
       "url": "https://www.joinsecret.com/offers",
       "tags": [
@@ -19345,7 +19704,7 @@
       "eligibility": {
         "type": "startup",
         "conditions": [
-          "First deal free, then 99\u20ac/year or invite friends"
+          "First deal free, then 99€/year or invite friends"
         ],
         "program": "PayFit Startup Deal"
       }
@@ -19353,7 +19712,7 @@
     {
       "vendor": "Phantom Buster",
       "category": "Startup Perks",
-      "description": "30% off on any plans for 12 months. Access via: First deal free, then 99\u20ac/year or invite friends",
+      "description": "30% off on any plans for 12 months. Access via: First deal free, then 99€/year or invite friends",
       "tier": "Startup Program",
       "url": "https://www.joinsecret.com/offers",
       "tags": [
@@ -19365,7 +19724,7 @@
       "eligibility": {
         "type": "startup",
         "conditions": [
-          "First deal free, then 99\u20ac/year or invite friends"
+          "First deal free, then 99€/year or invite friends"
         ],
         "program": "Phantom Buster Startup Deal"
       }
@@ -19373,7 +19732,7 @@
     {
       "vendor": "Pipedrive",
       "category": "Startup Perks",
-      "description": "First month free, then 30% discount for 6 months. Access via: First deal free, then 99\u20ac/year or invite friends",
+      "description": "First month free, then 30% discount for 6 months. Access via: First deal free, then 99€/year or invite friends",
       "tier": "Startup Program",
       "url": "https://www.joinsecret.com/offers",
       "tags": [
@@ -19385,7 +19744,7 @@
       "eligibility": {
         "type": "startup",
         "conditions": [
-          "First deal free, then 99\u20ac/year or invite friends"
+          "First deal free, then 99€/year or invite friends"
         ],
         "program": "Pipedrive Startup Deal"
       }
@@ -19393,7 +19752,7 @@
     {
       "vendor": "PixelMe",
       "category": "Startup Perks",
-      "description": "50% discount on any plan for 6 months. Access via: First deal free, then 99\u20ac/year or invite friends",
+      "description": "50% discount on any plan for 6 months. Access via: First deal free, then 99€/year or invite friends",
       "tier": "Startup Program",
       "url": "https://www.joinsecret.com/offers",
       "tags": [
@@ -19405,7 +19764,7 @@
       "eligibility": {
         "type": "startup",
         "conditions": [
-          "First deal free, then 99\u20ac/year or invite friends"
+          "First deal free, then 99€/year or invite friends"
         ],
         "program": "PixelMe Startup Deal"
       }
@@ -19433,7 +19792,7 @@
     {
       "vendor": "Prospect.io",
       "category": "Email",
-      "description": "50% on Starter plan for 6 months + 1000 emails credits. Access via: First deal free, then 99\u20ac/year or invite friends",
+      "description": "50% on Starter plan for 6 months + 1000 emails credits. Access via: First deal free, then 99€/year or invite friends",
       "tier": "Startup Program",
       "url": "https://www.joinsecret.com/offers",
       "tags": [
@@ -19445,7 +19804,7 @@
       "eligibility": {
         "type": "startup",
         "conditions": [
-          "First deal free, then 99\u20ac/year or invite friends"
+          "First deal free, then 99€/year or invite friends"
         ],
         "program": "Prospect.io Startup Deal"
       }
@@ -19453,7 +19812,7 @@
     {
       "vendor": "ProspectIn",
       "category": "Startup Perks",
-      "description": "6 months free on Pro plan for 1 user. Access via: First deal free, then 99\u20ac/year or invite friends",
+      "description": "6 months free on Pro plan for 1 user. Access via: First deal free, then 99€/year or invite friends",
       "tier": "Startup Program",
       "url": "https://www.joinsecret.com/offers",
       "tags": [
@@ -19465,7 +19824,7 @@
       "eligibility": {
         "type": "startup",
         "conditions": [
-          "First deal free, then 99\u20ac/year or invite friends"
+          "First deal free, then 99€/year or invite friends"
         ],
         "program": "ProspectIn Startup Deal"
       }
@@ -19473,7 +19832,7 @@
     {
       "vendor": "Publist",
       "category": "Startup Perks",
-      "description": "Personal plan free forever. Access via: First deal free, then 99\u20ac/year or invite friends",
+      "description": "Personal plan free forever. Access via: First deal free, then 99€/year or invite friends",
       "tier": "Startup Program",
       "url": "https://www.joinsecret.com/offers",
       "tags": [
@@ -19485,7 +19844,7 @@
       "eligibility": {
         "type": "startup",
         "conditions": [
-          "First deal free, then 99\u20ac/year or invite friends"
+          "First deal free, then 99€/year or invite friends"
         ],
         "program": "Publist Startup Deal"
       }
@@ -19493,7 +19852,7 @@
     {
       "vendor": "Qonto",
       "category": "Startup Perks",
-      "description": "7 months free on Standard plan. Access via: First deal free, then 99\u20ac/year or invite friends",
+      "description": "7 months free on Standard plan. Access via: First deal free, then 99€/year or invite friends",
       "tier": "Startup Program",
       "url": "https://www.joinsecret.com/offers",
       "tags": [
@@ -19505,7 +19864,7 @@
       "eligibility": {
         "type": "startup",
         "conditions": [
-          "First deal free, then 99\u20ac/year or invite friends"
+          "First deal free, then 99€/year or invite friends"
         ],
         "program": "Qonto Startup Deal"
       }
@@ -19533,7 +19892,7 @@
     {
       "vendor": "Quickbooks",
       "category": "Startup Perks",
-      "description": "50% discount for 6 months on any subscription plan. Access via: First deal free, then 99\u20ac/year or invite friends",
+      "description": "50% discount for 6 months on any subscription plan. Access via: First deal free, then 99€/year or invite friends",
       "tier": "Startup Program",
       "url": "https://www.joinsecret.com/offers",
       "tags": [
@@ -19545,7 +19904,7 @@
       "eligibility": {
         "type": "startup",
         "conditions": [
-          "First deal free, then 99\u20ac/year or invite friends"
+          "First deal free, then 99€/year or invite friends"
         ],
         "program": "Quickbooks Startup Deal"
       }
@@ -19573,7 +19932,7 @@
     {
       "vendor": "Scalingo",
       "category": "Startup Perks",
-      "description": "\u20ac1,000 credit. Access via: First deal free, then 99\u20ac/year or invite friends",
+      "description": "€1,000 credit. Access via: First deal free, then 99€/year or invite friends",
       "tier": "Startup Program",
       "url": "https://www.joinsecret.com/offers",
       "tags": [
@@ -19585,7 +19944,7 @@
       "eligibility": {
         "type": "startup",
         "conditions": [
-          "First deal free, then 99\u20ac/year or invite friends"
+          "First deal free, then 99€/year or invite friends"
         ],
         "program": "Scalingo Startup Deal"
       }
@@ -19613,7 +19972,7 @@
     {
       "vendor": "Scrapingbee",
       "category": "Startup Perks",
-      "description": "30% off on any plan for 12 months. Access via: First deal free, then 99\u20ac/year or invite friends",
+      "description": "30% off on any plan for 12 months. Access via: First deal free, then 99€/year or invite friends",
       "tier": "Startup Program",
       "url": "https://www.joinsecret.com/offers",
       "tags": [
@@ -19625,7 +19984,7 @@
       "eligibility": {
         "type": "startup",
         "conditions": [
-          "First deal free, then 99\u20ac/year or invite friends"
+          "First deal free, then 99€/year or invite friends"
         ],
         "program": "Scrapingbee Startup Deal"
       }
@@ -19633,7 +19992,7 @@
     {
       "vendor": "Seeqle",
       "category": "Startup Perks",
-      "description": "6 months free on Sprint plan. Access via: First deal free, then 99\u20ac/year or invite friends",
+      "description": "6 months free on Sprint plan. Access via: First deal free, then 99€/year or invite friends",
       "tier": "Startup Program",
       "url": "https://www.joinsecret.com/offers",
       "tags": [
@@ -19645,7 +20004,7 @@
       "eligibility": {
         "type": "startup",
         "conditions": [
-          "First deal free, then 99\u20ac/year or invite friends"
+          "First deal free, then 99€/year or invite friends"
         ],
         "program": "Seeqle Startup Deal"
       }
@@ -19653,7 +20012,7 @@
     {
       "vendor": "Sellsy",
       "category": "Startup Perks",
-      "description": "3 months free. Access via: First deal free, then 99\u20ac/year or invite friends",
+      "description": "3 months free. Access via: First deal free, then 99€/year or invite friends",
       "tier": "Startup Program",
       "url": "https://www.joinsecret.com/offers",
       "tags": [
@@ -19665,7 +20024,7 @@
       "eligibility": {
         "type": "startup",
         "conditions": [
-          "First deal free, then 99\u20ac/year or invite friends"
+          "First deal free, then 99€/year or invite friends"
         ],
         "program": "Sellsy Startup Deal"
       }
@@ -19688,12 +20047,20 @@
           "Free for Brex customers"
         ],
         "program": "SendGrid Startup Deal"
+      },
+      "referral_program": {
+        "available": false,
+        "referrer_benefit": "N/A",
+        "referee_benefit": "N/A",
+        "program_url": "https://sendgrid.com/partners/affiliate/",
+        "type": "closed",
+        "notes": "No active affiliate program. Marketplace partner program for integrations only."
       }
     },
     {
       "vendor": "Sendinblue",
       "category": "Startup Perks",
-      "description": "12 months free on the Premium plan. Access via: First deal free, then 99\u20ac/year or invite friends",
+      "description": "12 months free on the Premium plan. Access via: First deal free, then 99€/year or invite friends",
       "tier": "Startup Program",
       "url": "https://www.joinsecret.com/offers",
       "tags": [
@@ -19705,7 +20072,7 @@
       "eligibility": {
         "type": "startup",
         "conditions": [
-          "First deal free, then 99\u20ac/year or invite friends"
+          "First deal free, then 99€/year or invite friends"
         ],
         "program": "Sendinblue Startup Deal"
       }
@@ -19713,7 +20080,7 @@
     {
       "vendor": "Shine",
       "category": "Startup Perks",
-      "description": "6 months free on Premium plan. Access via: First deal free, then 99\u20ac/year or invite friends",
+      "description": "6 months free on Premium plan. Access via: First deal free, then 99€/year or invite friends",
       "tier": "Startup Program",
       "url": "https://www.joinsecret.com/offers",
       "tags": [
@@ -19725,7 +20092,7 @@
       "eligibility": {
         "type": "startup",
         "conditions": [
-          "First deal free, then 99\u20ac/year or invite friends"
+          "First deal free, then 99€/year or invite friends"
         ],
         "program": "Shine Startup Deal"
       }
@@ -19753,7 +20120,7 @@
     {
       "vendor": "Slite",
       "category": "Startup Perks",
-      "description": "6 months free up to 10 users. Access via: First deal free, then 99\u20ac/year or invite friends",
+      "description": "6 months free up to 10 users. Access via: First deal free, then 99€/year or invite friends",
       "tier": "Startup Program",
       "url": "https://www.joinsecret.com/offers",
       "tags": [
@@ -19765,7 +20132,7 @@
       "eligibility": {
         "type": "startup",
         "conditions": [
-          "First deal free, then 99\u20ac/year or invite friends"
+          "First deal free, then 99€/year or invite friends"
         ],
         "program": "Slite Startup Deal"
       }
@@ -19793,7 +20160,7 @@
     {
       "vendor": "Snapcall",
       "category": "Startup Perks",
-      "description": "6 months free on Growth plan. Access via: First deal free, then 99\u20ac/year or invite friends",
+      "description": "6 months free on Growth plan. Access via: First deal free, then 99€/year or invite friends",
       "tier": "Startup Program",
       "url": "https://www.joinsecret.com/offers",
       "tags": [
@@ -19805,7 +20172,7 @@
       "eligibility": {
         "type": "startup",
         "conditions": [
-          "First deal free, then 99\u20ac/year or invite friends"
+          "First deal free, then 99€/year or invite friends"
         ],
         "program": "Snapcall Startup Deal"
       }
@@ -19813,7 +20180,7 @@
     {
       "vendor": "Social Champ",
       "category": "Startup Perks",
-      "description": "50% off for 12 months. Access via: First deal free, then 99\u20ac/year or invite friends",
+      "description": "50% off for 12 months. Access via: First deal free, then 99€/year or invite friends",
       "tier": "Startup Program",
       "url": "https://www.joinsecret.com/offers",
       "tags": [
@@ -19825,7 +20192,7 @@
       "eligibility": {
         "type": "startup",
         "conditions": [
-          "First deal free, then 99\u20ac/year or invite friends"
+          "First deal free, then 99€/year or invite friends"
         ],
         "program": "Social Champ Startup Deal"
       }
@@ -19833,7 +20200,7 @@
     {
       "vendor": "SocialBee",
       "category": "Startup Perks",
-      "description": "6 months free on the Accelerate plan. Access via: First deal free, then 99\u20ac/year or invite friends",
+      "description": "6 months free on the Accelerate plan. Access via: First deal free, then 99€/year or invite friends",
       "tier": "Startup Program",
       "url": "https://www.joinsecret.com/offers",
       "tags": [
@@ -19845,7 +20212,7 @@
       "eligibility": {
         "type": "startup",
         "conditions": [
-          "First deal free, then 99\u20ac/year or invite friends"
+          "First deal free, then 99€/year or invite friends"
         ],
         "program": "SocialBee Startup Deal"
       }
@@ -19873,7 +20240,7 @@
     {
       "vendor": "Squarespace",
       "category": "Startup Perks",
-      "description": "20% off for 12 months on an annual Business Plan. Access via: First deal free, then 99\u20ac/year or invite friends",
+      "description": "20% off for 12 months on an annual Business Plan. Access via: First deal free, then 99€/year or invite friends",
       "tier": "Startup Program",
       "url": "https://www.joinsecret.com/offers",
       "tags": [
@@ -19885,7 +20252,7 @@
       "eligibility": {
         "type": "startup",
         "conditions": [
-          "First deal free, then 99\u20ac/year or invite friends"
+          "First deal free, then 99€/year or invite friends"
         ],
         "program": "Squarespace Startup Deal"
       }
@@ -19913,7 +20280,7 @@
     {
       "vendor": "Themecloud",
       "category": "Cloud IaaS",
-      "description": "6 months free on Pro1 plan. Access via: First deal free, then 99\u20ac/year or invite friends",
+      "description": "6 months free on Pro1 plan. Access via: First deal free, then 99€/year or invite friends",
       "tier": "Startup Program",
       "url": "https://www.joinsecret.com/offers",
       "tags": [
@@ -19926,7 +20293,7 @@
       "eligibility": {
         "type": "startup",
         "conditions": [
-          "First deal free, then 99\u20ac/year or invite friends"
+          "First deal free, then 99€/year or invite friends"
         ],
         "program": "Themecloud Startup Deal"
       }
@@ -19954,7 +20321,7 @@
     {
       "vendor": "Userguiding",
       "category": "Startup Perks",
-      "description": "50% off for 6 months on the Startup plan. Access via: First deal free, then 99\u20ac/year or invite friends",
+      "description": "50% off for 6 months on the Startup plan. Access via: First deal free, then 99€/year or invite friends",
       "tier": "Startup Program",
       "url": "https://www.joinsecret.com/offers",
       "tags": [
@@ -19966,7 +20333,7 @@
       "eligibility": {
         "type": "startup",
         "conditions": [
-          "First deal free, then 99\u20ac/year or invite friends"
+          "First deal free, then 99€/year or invite friends"
         ],
         "program": "Userguiding Startup Deal"
       }
@@ -19974,7 +20341,7 @@
     {
       "vendor": "Weglot",
       "category": "Startup Perks",
-      "description": "12 months free on the Pro plan. Access via: First deal free, then 99\u20ac/year or invite friends",
+      "description": "12 months free on the Pro plan. Access via: First deal free, then 99€/year or invite friends",
       "tier": "Startup Program",
       "url": "https://www.joinsecret.com/offers",
       "tags": [
@@ -19986,7 +20353,7 @@
       "eligibility": {
         "type": "startup",
         "conditions": [
-          "First deal free, then 99\u20ac/year or invite friends"
+          "First deal free, then 99€/year or invite friends"
         ],
         "program": "Weglot Startup Deal"
       }
@@ -20014,7 +20381,7 @@
     {
       "vendor": "Wisepops",
       "category": "Startup Perks",
-      "description": "6 months free on Basic plan. Access via: First deal free, then 99\u20ac/year or invite friends",
+      "description": "6 months free on Basic plan. Access via: First deal free, then 99€/year or invite friends",
       "tier": "Startup Program",
       "url": "https://www.joinsecret.com/offers",
       "tags": [
@@ -20026,7 +20393,7 @@
       "eligibility": {
         "type": "startup",
         "conditions": [
-          "First deal free, then 99\u20ac/year or invite friends"
+          "First deal free, then 99€/year or invite friends"
         ],
         "program": "Wisepops Startup Deal"
       }
@@ -20034,7 +20401,7 @@
     {
       "vendor": "Wizishop",
       "category": "Startup Perks",
-      "description": "3 months free on Pro plan. Access via: First deal free, then 99\u20ac/year or invite friends",
+      "description": "3 months free on Pro plan. Access via: First deal free, then 99€/year or invite friends",
       "tier": "Startup Program",
       "url": "https://www.joinsecret.com/offers",
       "tags": [
@@ -20046,7 +20413,7 @@
       "eligibility": {
         "type": "startup",
         "conditions": [
-          "First deal free, then 99\u20ac/year or invite friends"
+          "First deal free, then 99€/year or invite friends"
         ],
         "program": "Wizishop Startup Deal"
       }
@@ -20054,7 +20421,7 @@
     {
       "vendor": "WP Engine",
       "category": "Startup Perks",
-      "description": "3 months free on annual plans. Access via: First deal free, then 99\u20ac/year or invite friends",
+      "description": "3 months free on annual plans. Access via: First deal free, then 99€/year or invite friends",
       "tier": "Startup Program",
       "url": "https://www.joinsecret.com/offers",
       "tags": [
@@ -20066,7 +20433,7 @@
       "eligibility": {
         "type": "startup",
         "conditions": [
-          "First deal free, then 99\u20ac/year or invite friends"
+          "First deal free, then 99€/year or invite friends"
         ],
         "program": "WP Engine Startup Deal"
       }
@@ -20074,7 +20441,7 @@
     {
       "vendor": "Yousign",
       "category": "Startup Perks",
-      "description": "6 months free on Team plan for 1 user. Access via: First deal free, then 99\u20ac/year or invite friends",
+      "description": "6 months free on Team plan for 1 user. Access via: First deal free, then 99€/year or invite friends",
       "tier": "Startup Program",
       "url": "https://www.joinsecret.com/offers",
       "tags": [
@@ -20086,7 +20453,7 @@
       "eligibility": {
         "type": "startup",
         "conditions": [
-          "First deal free, then 99\u20ac/year or invite friends"
+          "First deal free, then 99€/year or invite friends"
         ],
         "program": "Yousign Startup Deal"
       }
@@ -20522,7 +20889,9 @@
         "referrer_benefit": "Up to $100 cash per referral",
         "referee_benefit": "$100 credit",
         "program_url": "https://www.vultr.com/docs/vultr-referral-program/",
-        "type": "self-service"
+        "type": "self-service",
+        "commission_type": "one-time",
+        "notes": "Referred user must be active 30+ days and spend $35+"
       }
     },
     {
@@ -20540,7 +20909,7 @@
     {
       "vendor": "Vast.ai",
       "category": "AI / ML",
-      "description": "GPU marketplace \u2014 startup program offers $2,500 in free GPU credits. Access to A100s, H200s, and consumer cards. Up to 81% savings vs. major cloud GPU providers. 24/7 priority support during credit period. No long-term contracts",
+      "description": "GPU marketplace — startup program offers $2,500 in free GPU credits. Access to A100s, H200s, and consumer cards. Up to 81% savings vs. major cloud GPU providers. 24/7 priority support during credit period. No long-term contracts",
       "tier": "Startup Program",
       "url": "https://vast.ai/startup",
       "tags": [
@@ -20595,7 +20964,7 @@
     {
       "vendor": "Bolt.new",
       "category": "AI Coding",
-      "description": "AI app builder by StackBlitz \u2014 generates frontend, backend, and database code in a live runtime environment. Free tier: 1M tokens/month (300K daily cap), unlimited databases, public + private projects, native hosting with Bolt branding, 10MB file upload limit. Paid plans from $20/mo for higher token limits.",
+      "description": "AI app builder by StackBlitz — generates frontend, backend, and database code in a live runtime environment. Free tier: 1M tokens/month (300K daily cap), unlimited databases, public + private projects, native hosting with Bolt branding, 10MB file upload limit. Paid plans from $20/mo for higher token limits.",
       "tier": "Free",
       "url": "https://bolt.new/pricing",
       "tags": [
@@ -20610,7 +20979,7 @@
     {
       "vendor": "Lovable",
       "category": "AI Coding",
-      "description": "AI app builder (formerly GPT Engineer) \u2014 generates full-stack apps from natural language. Free tier: 5 daily credits (up to 30/month), public projects only (private projects require paid plan), cloud hosting on lovable.app, Lovable branding badge. Credits consumed at variable rates (simple styling ~0.50, auth setup ~1.20, full landing page ~1.70). Pro $25/mo (100 credits + 5 daily). Business $50/mo.",
+      "description": "AI app builder (formerly GPT Engineer) — generates full-stack apps from natural language. Free tier: 5 daily credits (up to 30/month), public projects only (private projects require paid plan), cloud hosting on lovable.app, Lovable branding badge. Credits consumed at variable rates (simple styling ~0.50, auth setup ~1.20, full landing page ~1.70). Pro $25/mo (100 credits + 5 daily). Business $50/mo.",
       "tier": "Free",
       "url": "https://lovable.dev/pricing",
       "tags": [
@@ -20625,7 +20994,7 @@
     {
       "vendor": "Claude Code",
       "category": "AI Coding",
-      "description": "Agentic coding tool by Anthropic \u2014 terminal-based AI coding agent that reads/writes files, runs commands, and manages git workflows. Available to Claude Pro ($20/mo), Team ($25/seat/mo), and Max ($100-200/mo) subscribers. Uses Claude Sonnet/Opus models. Also available via Anthropic API with usage-based pricing. Free tier via Claude.ai (limited Sonnet usage, Projects, Artifacts). April 2026 changes: (1) Third-party tool restrictions \u2014 external tools like OpenClaw now billed separately on pay-as-you-go basis, can no longer apply standard usage limits. (2) Extra usage option \u2014 all paid plans (Pro, Max 5x, Max 20x) now have pay-as-you-go overage at standard API rates beyond included usage. (3) Peak-hour throttling \u2014 5-hour session limits reduced during weekdays 5 AM\u201311 AM Pacific.",
+      "description": "Agentic coding tool by Anthropic — terminal-based AI coding agent that reads/writes files, runs commands, and manages git workflows. Available to Claude Pro ($20/mo), Team ($25/seat/mo), and Max ($100-200/mo) subscribers. Uses Claude Sonnet/Opus models. Also available via Anthropic API with usage-based pricing. Free tier via Claude.ai (limited Sonnet usage, Projects, Artifacts). April 2026 changes: (1) Third-party tool restrictions — external tools like OpenClaw now billed separately on pay-as-you-go basis, can no longer apply standard usage limits. (2) Extra usage option — all paid plans (Pro, Max 5x, Max 20x) now have pay-as-you-go overage at standard API rates beyond included usage. (3) Peak-hour throttling — 5-hour session limits reduced during weekdays 5 AM–11 AM Pacific.",
       "tier": "Paid",
       "url": "https://docs.anthropic.com/en/docs/claude-code/overview",
       "tags": [
@@ -20654,7 +21023,15 @@
         "cursor-alternative",
         "deal-change"
       ],
-      "verifiedDate": "2026-04-13"
+      "verifiedDate": "2026-04-13",
+      "referral_program": {
+        "available": false,
+        "referrer_benefit": "N/A",
+        "referee_benefit": "N/A",
+        "program_url": "https://github.com/partners",
+        "type": "closed",
+        "notes": "No individual referral program. Education partner program for student developer pack."
+      }
     },
     {
       "vendor": "Amazon Q Developer",
@@ -20675,7 +21052,7 @@
     {
       "vendor": "Cline",
       "category": "AI Coding",
-      "description": "Open-source autonomous AI coding agent for VS Code. Fully free \u2014 users provide their own API keys (OpenRouter, Anthropic, OpenAI, etc.). Supports file editing, terminal commands, browser interaction. No usage limits beyond API provider costs. MIT licensed.",
+      "description": "Open-source autonomous AI coding agent for VS Code. Fully free — users provide their own API keys (OpenRouter, Anthropic, OpenAI, etc.). Supports file editing, terminal commands, browser interaction. No usage limits beyond API provider costs. MIT licensed.",
       "tier": "Open Source",
       "url": "https://github.com/cline/cline",
       "tags": [
@@ -20691,7 +21068,7 @@
     {
       "vendor": "Aider",
       "category": "AI Coding",
-      "description": "Open-source AI pair programming CLI tool. Fully free \u2014 users provide their own LLM API keys (supports GPT-4o, Claude, Gemini, DeepSeek, Ollama local models). Git-aware editing, multi-file changes, voice coding, in-chat image support. Apache 2.0 licensed.",
+      "description": "Open-source AI pair programming CLI tool. Fully free — users provide their own LLM API keys (supports GPT-4o, Claude, Gemini, DeepSeek, Ollama local models). Git-aware editing, multi-file changes, voice coding, in-chat image support. Apache 2.0 licensed.",
       "tier": "Open Source",
       "url": "https://aider.chat",
       "tags": [
@@ -20741,7 +21118,7 @@
     {
       "vendor": "Google Antigravity",
       "category": "AI Coding",
-      "description": "Agent-first IDE by Google, powered by Gemini 3. 100% free during public preview \u2014 no paid tiers yet. Built-in browser automation, multi-agent orchestration, cross-platform (Mac/Windows/Linux). Announced November 2025.",
+      "description": "Agent-first IDE by Google, powered by Gemini 3. 100% free during public preview — no paid tiers yet. Built-in browser automation, multi-agent orchestration, cross-platform (Mac/Windows/Linux). Announced November 2025.",
       "tier": "Free",
       "url": "https://antigravity.google",
       "tags": [
@@ -20775,7 +21152,7 @@
     {
       "vendor": "OpenAI Codex",
       "category": "AI Coding",
-      "description": "Cloud-native coding agent by OpenAI. Included in ChatGPT Plus ($20/mo), Pro ($200/mo), and Business ($20/user/mo, was $30). Pay-as-you-go seats available \u2014 usage billed on token consumption, no rate limits. $100 credits for new Codex-only team members (up to $500/team, limited time). 2M+ weekly users. API via codex-mini at $1.50/1M input, $6/1M output tokens.",
+      "description": "Cloud-native coding agent by OpenAI. Included in ChatGPT Plus ($20/mo), Pro ($200/mo), and Business ($20/user/mo, was $30). Pay-as-you-go seats available — usage billed on token consumption, no rate limits. $100 credits for new Codex-only team members (up to $500/team, limited time). 2M+ weekly users. API via codex-mini at $1.50/1M input, $6/1M output tokens.",
       "tier": "Freemium",
       "url": "https://openai.com/index/introducing-codex/",
       "tags": [
@@ -20786,12 +21163,20 @@
         "openai",
         "developer tools"
       ],
-      "verifiedDate": "2026-04-12"
+      "verifiedDate": "2026-04-12",
+      "referral_program": {
+        "available": false,
+        "referrer_benefit": "N/A",
+        "referee_benefit": "N/A",
+        "program_url": "https://openai.com",
+        "type": "closed",
+        "notes": "No public affiliate/referral program."
+      }
     },
     {
       "vendor": "Google Tenor API",
       "category": "Media",
-      "description": "Free GIF search API. Public API shutting down June 30, 2026 \u2014 no new API keys since Jan 13, 2026. Existing keys work until shutdown. Provided GIF search, trending GIFs, autocomplete, and categories endpoints. No replacement from Google",
+      "description": "Free GIF search API. Public API shutting down June 30, 2026 — no new API keys since Jan 13, 2026. Existing keys work until shutdown. Provided GIF search, trending GIFs, autocomplete, and categories endpoints. No replacement from Google",
       "tier": "Free (Deprecated)",
       "url": "https://developers.google.com/tenor/guides/api-shutdown",
       "tags": [
@@ -20844,7 +21229,16 @@
       "verifiedDate": "2026-04-14",
       "payment_protocols": [
         "x402"
-      ]
+      ],
+      "referral_program": {
+        "available": true,
+        "referrer_benefit": "Referral fee per enterprise deal",
+        "referee_benefit": "Enterprise onboarding support",
+        "program_url": "https://www.anthropic.com/referral",
+        "type": "partner",
+        "commission_type": "one-time",
+        "notes": "Enterprise referral program. Must bring new enterprise customers. Commission negotiated per deal."
+      }
     },
     {
       "vendor": "Google Cloud BigQuery",
@@ -21004,7 +21398,7 @@
     {
       "vendor": "ClickUp",
       "category": "Project Management",
-      "description": "Free Forever plan \u2014 unlimited tasks, unlimited members, collaborative docs, kanban boards, sprint management, calendar view, in-app video recording, 24/7 support. 60MB storage, 1 form.",
+      "description": "Free Forever plan — unlimited tasks, unlimited members, collaborative docs, kanban boards, sprint management, calendar view, in-app video recording, 24/7 support. 60MB storage, 1 form.",
       "tier": "Free",
       "url": "https://clickup.com/pricing",
       "tags": [
@@ -21019,7 +21413,7 @@
     {
       "vendor": "Notion",
       "category": "Team Collaboration",
-      "description": "Free for individuals \u2014 unlimited pages and blocks, 10 guest collaborators, 5MB file uploads, 7-day page history, basic forms, 1 notion.site, Notion Calendar, Notion Mail (Gmail sync), offline access. Team block limits apply on multi-member workspaces.",
+      "description": "Free for individuals — unlimited pages and blocks, 10 guest collaborators, 5MB file uploads, 7-day page history, basic forms, 1 notion.site, Notion Calendar, Notion Mail (Gmail sync), offline access. Team block limits apply on multi-member workspaces.",
       "tier": "Free",
       "url": "https://www.notion.com/pricing",
       "tags": [
@@ -21030,12 +21424,21 @@
         "wiki",
         "free tier"
       ],
-      "verifiedDate": "2026-04-14"
+      "verifiedDate": "2026-04-14",
+      "referral_program": {
+        "available": true,
+        "referrer_benefit": "50% commission on first 12 months",
+        "referee_benefit": "Standard plan pricing",
+        "program_url": "https://www.notion.com/affiliates",
+        "type": "application",
+        "commission_type": "recurring",
+        "notes": "Commission on Plus, Business, or AI Plan upgrades. Paid monthly via PayPal/Stripe."
+      }
     },
     {
       "vendor": "GitHub Models",
       "category": "AI / ML",
-      "description": "Free access to 100+ AI models via GitHub Marketplace \u2014 GPT-4o, Llama, Mistral, Phi, and more. Free tier: 10-15 RPM, 50-150 requests/day depending on model tier. OpenAI-compatible API endpoint",
+      "description": "Free access to 100+ AI models via GitHub Marketplace — GPT-4o, Llama, Mistral, Phi, and more. Free tier: 10-15 RPM, 50-150 requests/day depending on model tier. OpenAI-compatible API endpoint",
       "tier": "Free",
       "url": "https://github.com/marketplace/models",
       "tags": [
@@ -21050,12 +21453,20 @@
       "verifiedDate": "2026-04-14",
       "payment_protocols": [
         "x402"
-      ]
+      ],
+      "referral_program": {
+        "available": false,
+        "referrer_benefit": "N/A",
+        "referee_benefit": "N/A",
+        "program_url": "https://github.com/partners",
+        "type": "closed",
+        "notes": "No individual referral program."
+      }
     },
     {
       "vendor": "NVIDIA NIM",
       "category": "AI / ML",
-      "description": "Free serverless APIs for LLM inference \u2014 access Llama 3.1, Mistral, and NVIDIA models. Free tier: ~40 RPM, 1,000 free API credits. No credit card required for development",
+      "description": "Free serverless APIs for LLM inference — access Llama 3.1, Mistral, and NVIDIA models. Free tier: ~40 RPM, 1,000 free API credits. No credit card required for development",
       "tier": "Free",
       "url": "https://build.nvidia.com",
       "tags": [
@@ -21072,7 +21483,7 @@
     {
       "vendor": "Ollama Cloud",
       "category": "AI / ML",
-      "description": "Cloud-hosted Ollama for running open-source LLMs \u2014 free tier for light usage with 1 concurrent model. Access Llama, Mistral, Gemma, and other open models via API",
+      "description": "Cloud-hosted Ollama for running open-source LLMs — free tier for light usage with 1 concurrent model. Access Llama, Mistral, Gemma, and other open models via API",
       "tier": "Free",
       "url": "https://ollama.com",
       "tags": [
@@ -21089,7 +21500,7 @@
     {
       "vendor": "Google Gemini Code Assist",
       "category": "IDE & Code Editors",
-      "description": "AI coding assistant by Google \u2014 6,000 code completions/day (180,000/month), 240 chat messages/day. Supports VS Code, JetBrains IDEs, Android Studio, Cloud Shell. Requires only a Gmail account, no credit card. 90x more completions than GitHub Copilot free tier",
+      "description": "AI coding assistant by Google — 6,000 code completions/day (180,000/month), 240 chat messages/day. Supports VS Code, JetBrains IDEs, Android Studio, Cloud Shell. Requires only a Gmail account, no credit card. 90x more completions than GitHub Copilot free tier",
       "tier": "Individual (Free)",
       "url": "https://codeassist.google",
       "tags": [
@@ -21122,7 +21533,7 @@
     {
       "vendor": "LLM7.io",
       "category": "AI / ML",
-      "description": "UK-based free LLM inference gateway. Free tier supported by donors \u2014 access to 30+ models including DeepSeek R1, Qwen2.5 Coder, text, image, and speech-to-text models. No published rate limits on free tier.",
+      "description": "UK-based free LLM inference gateway. Free tier supported by donors — access to 30+ models including DeepSeek R1, Qwen2.5 Coder, text, image, and speech-to-text models. No published rate limits on free tier.",
       "tier": "Free",
       "url": "https://llm7.io",
       "tags": [
@@ -21187,7 +21598,7 @@
     {
       "vendor": "Amazon Aurora PostgreSQL",
       "category": "Databases",
-      "description": "Aurora PostgreSQL Serverless on AWS Free Tier \u2014 managed PostgreSQL-compatible database with automatic scaling. Free plan: up to 4 ACUs per cluster, 1 GB storage. New accounts also get $100\u2013200 in AWS credits for 12 months",
+      "description": "Aurora PostgreSQL Serverless on AWS Free Tier — managed PostgreSQL-compatible database with automatic scaling. Free plan: up to 4 ACUs per cluster, 1 GB storage. New accounts also get $100–200 in AWS credits for 12 months",
       "tier": "Free Tier",
       "url": "https://aws.amazon.com/rds/aurora/pricing/",
       "tags": [
@@ -21392,7 +21803,16 @@
         "consumer",
         "free-tier"
       ],
-      "verifiedDate": "2026-04-02"
+      "verifiedDate": "2026-04-02",
+      "referral_program": {
+        "available": true,
+        "referrer_benefit": "50% commission on first 12 months",
+        "referee_benefit": "Standard plan pricing",
+        "program_url": "https://www.notion.com/affiliates",
+        "type": "application",
+        "commission_type": "recurring",
+        "notes": "Commission on Plus, Business, or AI Plan upgrades. Paid monthly via PayPal/Stripe."
+      }
     },
     {
       "vendor": "Todoist",
@@ -21614,7 +22034,7 @@
     {
       "vendor": "OneDrive",
       "category": "Cloud Storage",
-      "description": "5 GB storage. File sharing and collaboration. Office for the web (Word, Excel, PowerPoint \u2014 basic editing). Personal Vault (3 files limit on free). Photo upload. Mobile app.",
+      "description": "5 GB storage. File sharing and collaboration. Office for the web (Word, Excel, PowerPoint — basic editing). Personal Vault (3 files limit on free). Photo upload. Mobile app.",
       "tier": "Free",
       "url": "https://www.microsoft.com/en-us/microsoft-365/onedrive/compare-onedrive-plans",
       "tags": [
@@ -21730,7 +22150,8 @@
         "referrer_benefit": "Free months of service",
         "referee_benefit": "Free months of service",
         "program_url": "https://proton.me/support/referral-program",
-        "type": "self-service"
+        "type": "self-service",
+        "commission_type": "credits"
       }
     },
     {
@@ -22127,7 +22548,8 @@
         "referrer_benefit": "Free months of service",
         "referee_benefit": "Free months of service",
         "program_url": "https://proton.me/support/referral-program",
-        "type": "self-service"
+        "type": "self-service",
+        "commission_type": "credits"
       }
     },
     {
@@ -22158,7 +22580,15 @@
         "consumer",
         "free"
       ],
-      "verifiedDate": "2026-04-02"
+      "verifiedDate": "2026-04-02",
+      "referral_program": {
+        "available": false,
+        "referrer_benefit": "N/A",
+        "referee_benefit": "N/A",
+        "program_url": "https://www.cloudflare.com/partners/",
+        "type": "partner",
+        "notes": "Channel partner program only. No individual referral program."
+      }
     },
     {
       "vendor": "Khan Academy",
@@ -22281,7 +22711,8 @@
         "referrer_benefit": "Free months of service",
         "referee_benefit": "Free months of service",
         "program_url": "https://proton.me/support/referral-program",
-        "type": "self-service"
+        "type": "self-service",
+        "commission_type": "credits"
       }
     },
     {
@@ -22435,7 +22866,7 @@
     {
       "vendor": "Amazon Kiro",
       "category": "AI Coding",
-      "description": "Claude-powered AI IDE by Amazon (GA launch). Free tier: 50 credits/month. Pro $20/month (1,000 credits). Pro+ $40/month (2,000 credits). Power $200/month (10,000 credits). Credits metered to 0.01 increments \u2014 different models consume at different rates (Sonnet 4 costs 1.3x more than Auto mode). $0.04 overage per additional credit (disabled by default, must enable in Settings). 500 bonus credits for new users (valid 30 days). Unused monthly credits do NOT roll over. Enterprise tier: custom pricing with SAML/SCIM SSO, usage analytics, organizational management. GovCloud pricing ~20% higher; Free tier unavailable in GovCloud. Built on Claude, focuses on spec-driven development with automated requirements, design docs, and test generation.",
+      "description": "Claude-powered AI IDE by Amazon (GA launch). Free tier: 50 credits/month. Pro $20/month (1,000 credits). Pro+ $40/month (2,000 credits). Power $200/month (10,000 credits). Credits metered to 0.01 increments — different models consume at different rates (Sonnet 4 costs 1.3x more than Auto mode). $0.04 overage per additional credit (disabled by default, must enable in Settings). 500 bonus credits for new users (valid 30 days). Unused monthly credits do NOT roll over. Enterprise tier: custom pricing with SAML/SCIM SSO, usage analytics, organizational management. GovCloud pricing ~20% higher; Free tier unavailable in GovCloud. Built on Claude, focuses on spec-driven development with automated requirements, design docs, and test generation.",
       "tier": "Free",
       "url": "https://kiro.dev/pricing",
       "tags": [

--- a/src/serve.ts
+++ b/src/serve.ts
@@ -47197,6 +47197,7 @@ function buildDeveloperHubPage(): string {
     { method: "GET", path: "/api/hosting-pricing", desc: "Cloud hosting & PaaS pricing comparison data", params: "type (traditional-paas, edge-serverless, full-featured, static-specialized)" },
     { method: "GET", path: "/api/llm-pricing", desc: "LLM API pricing comparison data", params: "type (frontier, inference, open-source-host, specialized)" },
     { method: "GET", path: "/api/startup-credits", desc: "Startup credits & programs comparison data", params: "type (cloud-infrastructure, fintech-banking, developer-tools, ai-tools)" },
+    { method: "GET", path: "/api/referral-programs", desc: "Developer tools with referral/affiliate programs", params: "category" },
     { method: "GET", path: "/api/expiring", desc: "Get expiring deals", params: "days" },
     { method: "GET", path: "/api/freshness", desc: "Data freshness metrics", params: "" },
     { method: "GET", path: "/api/digest", desc: "Weekly pricing digest", params: "" },
@@ -49046,7 +49047,7 @@ ${bundleHtml}
 function buildReferralProgramsPage(): string {
   // Collect unique vendors with referral_program metadata
   const seen = new Set<string>();
-  const programVendors: { vendor: string; category: string; referrer_benefit: string; referee_benefit: string; program_url: string; type: string; hasCode: boolean; referralUrl?: string; refereeValue?: string }[] = [];
+  const programVendors: { vendor: string; category: string; referrer_benefit: string; referee_benefit: string; program_url: string; type: string; commission_type?: string; hasCode: boolean; referralUrl?: string; refereeValue?: string }[] = [];
   for (const o of offers) {
     if (o.referral_program?.available && !seen.has(o.vendor)) {
       seen.add(o.vendor);
@@ -49057,6 +49058,7 @@ function buildReferralProgramsPage(): string {
         referee_benefit: o.referral_program.referee_benefit,
         program_url: o.referral_program.program_url,
         type: o.referral_program.type,
+        commission_type: o.referral_program.commission_type,
         hasCode: !!o.referral,
         referralUrl: o.referral?.url,
         refereeValue: o.referral?.referee_value,
@@ -49072,8 +49074,20 @@ function buildReferralProgramsPage(): string {
   const withCodes = programVendors.filter(v => v.hasCode).length;
   const withoutCodes = programVendors.length - withCodes;
 
+  // Group by category
+  const categoryGroups = new Map<string, typeof programVendors>();
+  for (const v of programVendors) {
+    const existing = categoryGroups.get(v.category) || [];
+    existing.push(v);
+    categoryGroups.set(v.category, existing);
+  }
+  const sortedCategories = [...categoryGroups.entries()].sort((a, b) => b[1].length - a[1].length);
+  const categoryFilterButtons = sortedCategories.map(([cat]) =>
+    `<button class="filter-btn" data-category="${escHtmlServer(cat)}">${escHtmlServer(cat)}</button>`
+  ).join("\n      ");
+
   const title = "Developer Tool Referral Programs — AgentDeals";
-  const metaDesc = `${programVendors.length} developer tools with self-service referral programs. Earn credits and commissions by referring other developers to cloud, email, database, and infrastructure tools.`;
+  const metaDesc = `${programVendors.length} developer tools with referral programs across ${categoryGroups.size} categories. Earn credits, cash, and commissions by referring other developers to cloud, email, database, and infrastructure tools.`;
 
   const jsonLd = {
     "@context": "https://schema.org",
@@ -49101,29 +49115,38 @@ function buildReferralProgramsPage(): string {
       {
         "@type": "Question",
         name: "Which developer tools have referral programs?",
-        acceptedAnswer: { "@type": "Answer", text: `We track ${programVendors.length} developer tools with active referral programs, including ${programVendors.slice(0, 5).map(v => v.vendor).join(", ")}, and more. These programs let you earn credits, cash, or commissions by referring other developers.` },
+        acceptedAnswer: { "@type": "Answer", text: `We track ${programVendors.length} developer tools with active referral programs across ${categoryGroups.size} categories, including ${programVendors.slice(0, 5).map(v => v.vendor).join(", ")}, and more.` },
       },
       {
         "@type": "Question",
         name: "How do I earn money from developer tool referrals?",
         acceptedAnswer: { "@type": "Answer", text: "Sign up for a vendor's referral program, get your referral link, and share it. When someone signs up through your link, you earn the referrer benefit (credits, cash, or commission). You can also submit your referral codes to our marketplace for broader distribution." },
       },
+      {
+        "@type": "Question",
+        name: "Can AI agents participate in referral programs?",
+        acceptedAnswer: { "@type": "Answer", text: "Yes. Register your AI agent on our marketplace, submit referral codes for vendors with programs, and earn revenue share when your codes convert. Agents are ranked by trust tier and conversion performance." },
+      },
     ],
   };
+
+  const typeLabel = (t: string) => t === "self-service" ? "Self-service" : t === "affiliate-network" ? "Affiliate network" : t === "partner" ? "Partner" : "Application";
+  const commLabel = (c?: string) => c === "recurring" ? "Recurring" : c === "credits" ? "Credits" : c === "one-time" ? "One-time" : "";
 
   const tableRows = programVendors.map(v => {
     const vendorSlug = toSlug(v.vendor);
     const statusHtml = v.hasCode
       ? `<a href="${escHtmlServer(v.referralUrl!)}" rel="noopener sponsored" target="_blank" class="status-badge status-active">Use our code</a>`
       : `<a href="/marketplace" class="status-badge status-submit">Submit a code</a>`;
-    const typeLabel = v.type === "self-service" ? "Self-service" : v.type === "affiliate-network" ? "Affiliate network" : "Application";
-    return `      <tr>
+    const linkHtml = `<a href="${escHtmlServer(v.program_url)}" rel="noopener" target="_blank" class="program-link">View</a>`;
+    return `      <tr data-category="${escHtmlServer(v.category)}">
         <td><a href="/vendor/${vendorSlug}" class="vendor-link">${escHtmlServer(v.vendor)}</a></td>
         <td class="cat-cell">${escHtmlServer(v.category)}</td>
         <td class="benefit-cell">${escHtmlServer(v.referee_benefit)}</td>
         <td class="benefit-cell">${escHtmlServer(v.referrer_benefit)}</td>
-        <td class="type-cell">${typeLabel}</td>
+        <td class="type-cell">${typeLabel(v.type)}</td>
         <td class="status-cell">${statusHtml}</td>
+        <td class="link-cell">${linkHtml}</td>
       </tr>`;
   }).join("\n");
 
@@ -49157,6 +49180,10 @@ h1{font-family:var(--serif);font-size:2.25rem;color:var(--text);margin:1rem 0 .5
 .stat-card{flex:1;min-width:120px;padding:.75rem 1rem;border:1px solid var(--border);border-radius:8px;background:var(--bg-card);text-align:center}
 .stat-value{font-family:var(--serif);font-size:1.5rem;color:var(--text)}
 .stat-label{font-family:var(--mono);font-size:.65rem;color:var(--text-dim);text-transform:uppercase;letter-spacing:.1em}
+.filter-bar{display:flex;gap:.5rem;flex-wrap:wrap;margin-bottom:1.5rem}
+.filter-btn{padding:.3rem .7rem;border:1px solid var(--border);border-radius:6px;background:transparent;color:var(--text-muted);font-size:.75rem;cursor:pointer;font-family:var(--sans);transition:all .15s}
+.filter-btn:hover{border-color:var(--accent);color:var(--accent)}
+.filter-btn.active{background:var(--accent-glow);border-color:var(--accent);color:var(--accent);font-weight:600}
 .programs-table{width:100%;border-collapse:collapse;margin-bottom:2rem}
 .programs-table th{text-align:left;padding:.6rem .75rem;font-size:.7rem;text-transform:uppercase;letter-spacing:.08em;color:var(--text-dim);border-bottom:2px solid var(--border);font-family:var(--mono)}
 .programs-table td{padding:.6rem .75rem;border-bottom:1px solid var(--border);font-size:.85rem;vertical-align:middle}
@@ -49166,6 +49193,8 @@ h1{font-family:var(--serif);font-size:2.25rem;color:var(--text);margin:1rem 0 .5
 .benefit-cell{font-size:.8rem;color:var(--text-muted)}
 .type-cell{font-size:.75rem;color:var(--text-dim);font-family:var(--mono)}
 .status-cell{text-align:center}
+.link-cell{text-align:center}
+.program-link{font-size:.75rem;color:var(--text-dim);text-decoration:underline}
 .status-badge{display:inline-block;padding:.2rem .6rem;border-radius:10px;font-size:.7rem;font-weight:600;text-decoration:none}
 .status-active{background:var(--green-glow);color:var(--green);border:1px solid rgba(63,185,80,0.3)}
 .status-active:hover{text-decoration:none;border-color:var(--green)}
@@ -49173,13 +49202,18 @@ h1{font-family:var(--serif);font-size:2.25rem;color:var(--text);margin:1rem 0 .5
 .status-submit:hover{text-decoration:none;border-color:var(--accent)}
 .disclosure{font-size:.8rem;color:var(--text-dim);margin-bottom:2rem;padding:.75rem 1rem;border:1px solid var(--border);border-radius:8px;background:var(--bg-card)}
 .disclosure a{color:var(--text-muted)}
+.agent-cta{margin:2rem 0;padding:1.5rem;border:1px solid var(--accent);border-radius:12px;background:var(--accent-glow);text-align:center}
+.agent-cta h2{font-family:var(--serif);font-size:1.3rem;margin-bottom:.5rem}
+.agent-cta p{color:var(--text-muted);font-size:.9rem;margin-bottom:1rem;max-width:600px;margin-left:auto;margin-right:auto}
+.agent-cta a.cta-button{display:inline-block;padding:.6rem 1.5rem;background:var(--accent);color:#fff;border-radius:8px;font-weight:600;font-size:.9rem;text-decoration:none}
+.agent-cta a.cta-button:hover{background:var(--accent-hover);text-decoration:none}
 .faq-section{margin-top:2rem}
 .faq-section h2{font-family:var(--serif);font-size:1.2rem;margin-bottom:1rem}
 .faq-item{margin-bottom:1.25rem}
 .faq-item h3{font-size:.9rem;color:var(--text);margin-bottom:.25rem}
 .faq-item p{font-size:.85rem;color:var(--text-muted);line-height:1.6}
 footer{text-align:center;color:var(--text-dim);font-size:.8rem;padding:3rem 0 2rem;border-top:1px solid var(--border);margin-top:3rem}
-@media(max-width:768px){h1{font-size:1.5rem}.stats-bar{flex-direction:column}.programs-table{display:block;overflow-x:auto}.type-cell{display:none}}
+@media(max-width:768px){h1{font-size:1.5rem}.stats-bar{flex-direction:column}.programs-table{display:block;overflow-x:auto}.type-cell,.link-cell{display:none}}
 ${globalNavCss()}
 ${mcpCtaCss()}
 </style>
@@ -49189,12 +49223,16 @@ ${mcpCtaCss()}
   ${buildGlobalNav("marketplace")}
   <div class="breadcrumb"><a href="/">AgentDeals</a> &rsaquo; Referral Programs</div>
   <h1>Developer Tool Referral Programs</h1>
-  <p class="page-intro">${programVendors.length} developer tools with active referral programs. Earn credits, cash, and commissions by referring other developers to infrastructure, email, database, and cloud tools.</p>
+  <p class="page-intro">${programVendors.length} developer tools with active referral programs across ${categoryGroups.size} categories. Earn credits, cash, and commissions by referring other developers to infrastructure, email, database, and cloud tools.</p>
 
   <div class="stats-bar">
     <div class="stat-card">
       <div class="stat-value">${programVendors.length}</div>
       <div class="stat-label">Programs Tracked</div>
+    </div>
+    <div class="stat-card">
+      <div class="stat-value">${categoryGroups.size}</div>
+      <div class="stat-label">Categories</div>
     </div>
     <div class="stat-card">
       <div class="stat-value">${withCodes}</div>
@@ -49208,15 +49246,21 @@ ${mcpCtaCss()}
 
   <div class="disclosure"><a href="/disclosure">Affiliate disclosure</a>: Links marked "Use our code" are referral links. We may earn a commission at no cost to you.</div>
 
+  <div class="filter-bar">
+    <button class="filter-btn active" data-category="all">All</button>
+    ${categoryFilterButtons}
+  </div>
+
   <table class="programs-table">
     <thead>
       <tr>
         <th>Vendor</th>
         <th>Category</th>
-        <th>What You Get</th>
-        <th>What They Get</th>
+        <th>Referee Benefit</th>
+        <th>Referrer Benefit</th>
         <th>Type</th>
         <th>Status</th>
+        <th>Link</th>
       </tr>
     </thead>
     <tbody>
@@ -49224,15 +49268,25 @@ ${tableRows}
     </tbody>
   </table>
 
+  <div class="agent-cta">
+    <h2>Earn Revenue with Your Referral Codes</h2>
+    <p>Register your AI agent or developer account on the AgentDeals marketplace. Submit referral codes for any vendor with a program, and earn revenue share when your codes convert.</p>
+    <a href="/marketplace" class="cta-button">Register on the Marketplace</a>
+  </div>
+
   <div class="faq-section">
     <h2>Frequently Asked Questions</h2>
     <div class="faq-item">
       <h3>Which developer tools have referral programs?</h3>
-      <p>We track ${programVendors.length} developer tools with active referral programs, including ${programVendors.slice(0, 5).map(v => escHtmlServer(v.vendor)).join(", ")}, and more. These programs let you earn credits, cash, or commissions by referring other developers.</p>
+      <p>We track ${programVendors.length} developer tools with active referral programs across ${categoryGroups.size} categories, including ${programVendors.slice(0, 5).map(v => escHtmlServer(v.vendor)).join(", ")}, and more. These programs let you earn credits, cash, or commissions by referring other developers.</p>
     </div>
     <div class="faq-item">
       <h3>How do I earn money from developer tool referrals?</h3>
       <p>Sign up for a vendor's referral program, get your referral link, and share it. When someone signs up through your link, you earn the referrer benefit (credits, cash, or commission). You can also <a href="/marketplace">submit your referral codes</a> to our marketplace for broader distribution.</p>
+    </div>
+    <div class="faq-item">
+      <h3>Can AI agents participate in referral programs?</h3>
+      <p>Yes. Register your AI agent on our <a href="/marketplace">marketplace</a>, submit referral codes for vendors with programs, and earn revenue share when your codes convert. Agents are ranked by trust tier and conversion performance.</p>
     </div>
     <div class="faq-item">
       <h3>What does "Submit a code" mean?</h3>
@@ -49240,9 +49294,23 @@ ${tableRows}
     </div>
   </div>
 
+  <p style="margin-top:1.5rem;font-size:.85rem;color:var(--text-dim);text-align:center">Query this data programmatically via <a href="/api/referral-programs">/api/referral-programs</a> (JSON), our <a href="/setup">MCP tools</a>, or <a href="/developers">REST API</a>.</p>
+
   ${buildMcpCta("Search referral programs and compare vendor free tiers directly in your AI coding assistant.")}
   <footer>AgentDeals &mdash; open source, built for agents | <a href="/privacy">Privacy</a></footer>
 </div>
+<script>
+document.querySelectorAll('.filter-btn').forEach(btn => {
+  btn.addEventListener('click', () => {
+    document.querySelectorAll('.filter-btn').forEach(b => b.classList.remove('active'));
+    btn.classList.add('active');
+    const cat = btn.dataset.category;
+    document.querySelectorAll('.programs-table tbody tr').forEach(row => {
+      row.style.display = (cat === 'all' || row.dataset.category === cat) ? '' : 'none';
+    });
+  });
+});
+</script>
 </body>
 </html>`;
 }
@@ -51793,6 +51861,35 @@ const httpServer = createHttpServer(async (req, res) => {
     logRequest({ ts: new Date().toISOString(), type: "api", endpoint: "/api/startup-credits", params: { type: startupTypeFilter }, user_agent: req.headers["user-agent"] ?? "unknown", result_count: startupPrograms.length });
     res.writeHead(200, { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" });
     res.end(JSON.stringify({ programs: startupPrograms, changes: startupApiChanges, count: startupPrograms.length, categories: Object.keys(startupCategoryMap) }));
+  } else if (url.pathname === "/api/referral-programs" && isGetOrHead) {
+    recordApiHit("/api/referral-programs");
+    const seen = new Set<string>();
+    const refCategoryFilter = url.searchParams.get("category") || undefined;
+    const refPrograms: { vendor: string; category: string; referrer_benefit: string; referee_benefit: string; program_url: string; type: string; commission_type?: string; notes?: string; vendor_page: string }[] = [];
+    for (const o of offers) {
+      if (o.referral_program?.available && !seen.has(o.vendor)) {
+        seen.add(o.vendor);
+        const catNormalized = o.category.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/-+$/, "");
+        if (!refCategoryFilter || catNormalized === refCategoryFilter || o.category === refCategoryFilter) {
+          refPrograms.push({
+            vendor: o.vendor,
+            category: o.category,
+            referrer_benefit: o.referral_program.referrer_benefit,
+            referee_benefit: o.referral_program.referee_benefit,
+            program_url: o.referral_program.program_url,
+            type: o.referral_program.type,
+            commission_type: o.referral_program.commission_type,
+            notes: o.referral_program.notes,
+            vendor_page: "/vendor/" + o.vendor.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/-+$/, ""),
+          });
+        }
+      }
+    }
+    refPrograms.sort((a, b) => a.vendor.localeCompare(b.vendor));
+    const refCategories = [...new Set(refPrograms.map(p => p.category))].sort();
+    logRequest({ ts: new Date().toISOString(), type: "api", endpoint: "/api/referral-programs", params: { category: refCategoryFilter }, user_agent: req.headers["user-agent"] ?? "unknown", result_count: refPrograms.length });
+    res.writeHead(200, { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" });
+    res.end(JSON.stringify({ programs: refPrograms, count: refPrograms.length, categories: refCategories }));
   } else if (url.pathname === "/api/audit-stack" && isGetOrHead) {
     recordApiHit("/api/audit-stack");
     const servicesParam = url.searchParams.get("services");

--- a/src/types.ts
+++ b/src/types.ts
@@ -23,7 +23,9 @@ export interface ReferralProgram {
   referrer_benefit: string;
   referee_benefit: string;
   program_url: string;
-  type: "self-service" | "application" | "affiliate-network";
+  type: "self-service" | "application" | "affiliate-network" | "partner" | "closed";
+  commission_type?: "one-time" | "recurring" | "credits";
+  notes?: string;
 }
 
 export interface Offer {

--- a/test/referral-programs.test.ts
+++ b/test/referral-programs.test.ts
@@ -11,12 +11,12 @@ const { loadOffers } = await import("../dist/data.js");
 const offers = loadOffers();
 
 describe("referral_program metadata", () => {
-  it("at least 10 vendors have referral_program metadata", () => {
+  it("at least 40 vendors have referral_program metadata", () => {
     const seen = new Set<string>();
     for (const o of offers) {
-      if (o.referral_program?.available) seen.add(o.vendor);
+      if (o.referral_program) seen.add(o.vendor);
     }
-    assert.ok(seen.size >= 10, `Expected at least 10 unique vendors with referral_program, got ${seen.size}`);
+    assert.ok(seen.size >= 40, `Expected at least 40 unique vendors with referral_program, got ${seen.size}`);
   });
 
   it("referral_program entries have required fields", () => {
@@ -26,7 +26,7 @@ describe("referral_program metadata", () => {
       assert.ok(typeof o.referral_program.referrer_benefit === "string" && o.referral_program.referrer_benefit.length > 0, `${o.vendor}: referrer_benefit required`);
       assert.ok(typeof o.referral_program.referee_benefit === "string" && o.referral_program.referee_benefit.length > 0, `${o.vendor}: referee_benefit required`);
       assert.ok(typeof o.referral_program.program_url === "string" && o.referral_program.program_url.startsWith("http"), `${o.vendor}: program_url must be valid URL`);
-      assert.ok(["self-service", "application", "affiliate-network"].includes(o.referral_program.type), `${o.vendor}: type must be valid`);
+      assert.ok(["self-service", "application", "affiliate-network", "partner", "closed"].includes(o.referral_program.type), `${o.vendor}: type must be valid`);
     }
   });
 
@@ -44,11 +44,15 @@ describe("referral_program metadata", () => {
     assert.ok(digitalOcean.referral_program?.available, "DigitalOcean should have referral_program");
   });
 
-  it("Vercel has neither referral code nor referral_program", () => {
+  it("Vercel has referral_program (v0 affiliate)", () => {
     const vercel = offers.find((o: any) => o.vendor === "Vercel");
     assert.ok(vercel, "Vercel should exist");
-    assert.ok(!vercel.referral, "Vercel should not have referral code");
-    assert.ok(!vercel.referral_program, "Vercel should not have referral_program");
+    assert.ok(vercel.referral_program?.available, "Vercel should have referral_program");
+  });
+
+  it("vendors without programs have available: false", () => {
+    const unavailable = offers.filter((o: any) => o.referral_program && !o.referral_program.available);
+    assert.ok(unavailable.length >= 5, `Expected at least 5 vendors with available: false, got ${unavailable.length}`);
   });
 });
 
@@ -144,11 +148,60 @@ describe("referral-programs page", () => {
     assert.ok(html.includes("Submit your referral code"), "Should show submit CTA for vendor without our code");
   });
 
-  it("/vendor/vercel does not show referral program section", async () => {
+  it("/vendor/vercel shows referral program section", async () => {
     const res = await fetch(`http://localhost:${serverPort}/vendor/vercel`);
     assert.strictEqual(res.status, 200);
     const html = await res.text();
-    assert.ok(!html.includes("Referral Program</h2>"), "Vercel should not show referral program section");
+    assert.ok(html.includes("Referral Program"), "Vercel should show referral program section");
+  });
+
+  it("/referral-programs has category filter buttons", async () => {
+    const res = await fetch(`http://localhost:${serverPort}/referral-programs`);
+    const html = await res.text();
+    assert.ok(html.includes("filter-btn"), "Should have filter buttons");
+    assert.ok(html.includes('data-category="all"'), "Should have 'All' filter");
+  });
+
+  it("/referral-programs has agent registration CTA", async () => {
+    const res = await fetch(`http://localhost:${serverPort}/referral-programs`);
+    const html = await res.text();
+    assert.ok(html.includes("Register on the Marketplace"), "Should have marketplace CTA");
+    assert.ok(html.includes("Earn Revenue"), "Should have agent CTA heading");
+  });
+
+  it("/referral-programs links to /api/referral-programs", async () => {
+    const res = await fetch(`http://localhost:${serverPort}/referral-programs`);
+    const html = await res.text();
+    assert.ok(html.includes("/api/referral-programs"), "Should link to API endpoint");
+  });
+
+  it("GET /api/referral-programs returns JSON with programs", async () => {
+    const res = await fetch(`http://localhost:${serverPort}/api/referral-programs`);
+    assert.strictEqual(res.status, 200);
+    assert.strictEqual(res.headers.get("content-type"), "application/json");
+    assert.strictEqual(res.headers.get("access-control-allow-origin"), "*");
+    const body = await res.json();
+    assert.ok(Array.isArray(body.programs), "Should have programs array");
+    assert.ok(body.count >= 15, `Should have at least 15 programs, got ${body.count}`);
+    assert.ok(Array.isArray(body.categories), "Should have categories array");
+    assert.ok(body.categories.length >= 3, "Should have at least 3 categories");
+    const first = body.programs[0];
+    assert.ok(first.vendor, "Program should have vendor");
+    assert.ok(first.category, "Program should have category");
+    assert.ok(first.referrer_benefit, "Program should have referrer_benefit");
+    assert.ok(first.referee_benefit, "Program should have referee_benefit");
+    assert.ok(first.program_url, "Program should have program_url");
+    assert.ok(first.type, "Program should have type");
+    assert.ok(first.vendor_page, "Program should have vendor_page");
+  });
+
+  it("GET /api/referral-programs?category=Databases filters by category", async () => {
+    const res = await fetch(`http://localhost:${serverPort}/api/referral-programs?category=Databases`);
+    const body = await res.json();
+    assert.ok(body.programs.length > 0, "Should have database programs");
+    for (const p of body.programs) {
+      assert.strictEqual(p.category, "Databases", `Expected Databases category, got ${p.category}`);
+    }
   });
 
   it("/sitemap.xml includes /referral-programs", async () => {


### PR DESCRIPTION
## Summary

- Enriched 59 unique vendors with `referral_program` data (21 available programs, 38 documented as unavailable)
- Added `commission_type` and `notes` optional fields to the `ReferralProgram` interface
- Created `GET /api/referral-programs` endpoint with `?category=` filtering, CORS headers, and structured JSON response
- Enhanced `/referral-programs` page with client-side category filter buttons, agent registration CTA, program links column, and API link
- 8 new tests added (20 total in referral-programs.test.ts), 787 tests passing across the full suite

## Acceptance criteria

- [x] At least 30 new vendors have `referral_program` data (50+ added, 59 unique vendors total)
- [x] Vendors without programs have `referral_program.available: false` documented (38 vendors)
- [x] `/referral-programs` page renders with all documented programs grouped by category
- [x] `/api/referral-programs` endpoint returns structured referral program data
- [x] Page has JSON-LD structured data (ItemList + FAQPage) and OG meta tags
- [x] Page includes link to agent registration / marketplace
- [x] Tests pass (787/787)

Refs #775