### PR TITLE
Add dedicated tests for x402 and guides modules

### DIFF
--- a/test/guides.test.ts
+++ b/test/guides.test.ts
@@ -1,0 +1,101 @@
+import { describe, it } from "node:test";
+import assert from "node:assert";
+
+describe("guides module", () => {
+  describe("getGuideList", () => {
+    it("returns non-empty array of guides", async () => {
+      const { getGuideList } = await import("../dist/guides.js");
+      const guides = getGuideList();
+      assert.ok(guides.length > 50);
+    });
+
+    it("each guide has required fields", async () => {
+      const { getGuideList } = await import("../dist/guides.js");
+      const guides = getGuideList();
+      for (const guide of guides) {
+        assert.ok(guide.slug, "slug required");
+        assert.ok(guide.title, "title required");
+        assert.ok(guide.description, "description required");
+        assert.ok(["pricing", "comparison", "stack", "alternatives", "report", "integration"].includes(guide.type),
+          "type must be valid: " + guide.type);
+      }
+    });
+
+    it("has no duplicate slugs", async () => {
+      const { getGuideList } = await import("../dist/guides.js");
+      const guides = getGuideList();
+      const slugs = guides.map(g => g.slug);
+      const unique = new Set(slugs);
+      assert.strictEqual(unique.size, slugs.length, "duplicate slugs found");
+    });
+
+    it("classifies comparison guides correctly", async () => {
+      const { getGuideList } = await import("../dist/guides.js");
+      const guides = getGuideList();
+      const vsGuides = guides.filter(g => g.slug.includes("-vs-"));
+      for (const g of vsGuides) {
+        assert.strictEqual(g.type, "comparison", g.slug + " should be comparison type");
+      }
+    });
+
+    it("classifies stack guides correctly", async () => {
+      const { getGuideList } = await import("../dist/guides.js");
+      const guides = getGuideList();
+      const stackGuides = guides.filter(g => g.slug.startsWith("free-") && g.slug.endsWith("-stack"));
+      assert.ok(stackGuides.length >= 5, "should have multiple stack guides");
+      for (const g of stackGuides) {
+        assert.strictEqual(g.type, "stack", g.slug + " should be stack type");
+      }
+    });
+
+    it("classifies integration guides correctly", async () => {
+      const { getGuideList } = await import("../dist/guides.js");
+      const guides = getGuideList();
+      const integrationGuides = guides.filter(g => g.slug.startsWith("guides/"));
+      assert.ok(integrationGuides.length >= 3);
+      for (const g of integrationGuides) {
+        assert.strictEqual(g.type, "integration", g.slug + " should be integration type");
+      }
+    });
+
+    it("classifies alternatives guides correctly", async () => {
+      const { getGuideList } = await import("../dist/guides.js");
+      const guides = getGuideList();
+      const altGuides = guides.filter(g => g.slug.endsWith("-alternatives"));
+      assert.ok(altGuides.length >= 5);
+      for (const g of altGuides) {
+        assert.strictEqual(g.type, "alternatives", g.slug + " should be alternatives type");
+      }
+    });
+  });
+
+  describe("getGuideBySlug", () => {
+    it("returns guide for valid slug", async () => {
+      const { getGuideBySlug } = await import("../dist/guides.js");
+      const guide = getGuideBySlug("ai-free-tiers");
+      assert.ok(guide);
+      assert.strictEqual(guide.slug, "ai-free-tiers");
+      assert.ok(guide.title.length > 0);
+    });
+
+    it("returns null for nonexistent slug", async () => {
+      const { getGuideBySlug } = await import("../dist/guides.js");
+      const guide = getGuideBySlug("nonexistent-guide-xyz");
+      assert.strictEqual(guide, null);
+    });
+
+    it("returns correct type for integration guide", async () => {
+      const { getGuideBySlug } = await import("../dist/guides.js");
+      const guide = getGuideBySlug("guides/langchain");
+      assert.ok(guide);
+      assert.strictEqual(guide.type, "integration");
+    });
+
+    it("returns correct type for comparison guide", async () => {
+      const { getGuideBySlug } = await import("../dist/guides.js");
+      const guide = getGuideBySlug("supabase-vs-firebase");
+      assert.ok(guide);
+      assert.strictEqual(guide.type, "comparison");
+    });
+  });
+});

--- a/test/x402.test.ts
+++ b/test/x402.test.ts
@@ -1,0 +1,131 @@
+import { describe, it, afterEach } from "node:test";
+import assert from "node:assert";
+
+describe("x402 utilities", () => {
+  describe("generateCorrelationId", () => {
+    it("returns a string starting with payout_", async () => {
+      const { generateCorrelationId } = await import("../dist/x402.js");
+      const id = generateCorrelationId();
+      assert.ok(id.startsWith("payout_"));
+    });
+
+    it("generates unique IDs", async () => {
+      const { generateCorrelationId } = await import("../dist/x402.js");
+      const ids = new Set(Array.from({ length: 50 }, () => generateCorrelationId()));
+      assert.strictEqual(ids.size, 50);
+    });
+
+    it("returns 39-char string (payout_ + 32 hex)", async () => {
+      const { generateCorrelationId } = await import("../dist/x402.js");
+      const id = generateCorrelationId();
+      assert.strictEqual(id.length, 7 + 32);
+      assert.match(id, /^payout_[0-9a-f]{32}$/);
+    });
+  });
+
+  describe("validateX402Address", () => {
+    it("accepts valid Ethereum address", async () => {
+      const { validateX402Address } = await import("../dist/x402.js");
+      const result = validateX402Address("0x1234567890abcdef1234567890abcdef12345678");
+      assert.strictEqual(result.valid, true);
+      assert.strictEqual(result.error, undefined);
+    });
+
+    it("accepts valid Ethereum address with mixed case", async () => {
+      const { validateX402Address } = await import("../dist/x402.js");
+      const result = validateX402Address("0xAbCdEf1234567890AbCdEf1234567890AbCdEf12");
+      assert.strictEqual(result.valid, true);
+    });
+
+    it("accepts valid Solana address", async () => {
+      const { validateX402Address } = await import("../dist/x402.js");
+      const result = validateX402Address("7EYnhQoR9YM3N7UoaKRoA44Uy8JeaZV3qyouov87awMs");
+      assert.strictEqual(result.valid, true);
+    });
+
+    it("rejects empty string", async () => {
+      const { validateX402Address } = await import("../dist/x402.js");
+      const result = validateX402Address("");
+      assert.strictEqual(result.valid, false);
+      assert.ok(result.error);
+    });
+
+    it("rejects null-like input", async () => {
+      const { validateX402Address } = await import("../dist/x402.js");
+      const result = validateX402Address(null as unknown as string);
+      assert.strictEqual(result.valid, false);
+    });
+
+    it("rejects Ethereum address with wrong length", async () => {
+      const { validateX402Address } = await import("../dist/x402.js");
+      const result = validateX402Address("0x1234");
+      assert.strictEqual(result.valid, false);
+      assert.ok(result.error?.includes("Invalid address"));
+    });
+
+    it("rejects address with invalid characters", async () => {
+      const { validateX402Address } = await import("../dist/x402.js");
+      const result = validateX402Address("0xGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGG");
+      assert.strictEqual(result.valid, false);
+    });
+
+    it("trims whitespace from address", async () => {
+      const { validateX402Address } = await import("../dist/x402.js");
+      const result = validateX402Address("  0x1234567890abcdef1234567890abcdef12345678  ");
+      assert.strictEqual(result.valid, true);
+    });
+  });
+
+  describe("executeTransfer", () => {
+    afterEach(async () => {
+      const { resetTransferFn } = await import("../dist/x402.js");
+      resetTransferFn();
+    });
+
+    it("default implementation returns not-configured error", async () => {
+      const { executeTransfer, generateCorrelationId } = await import("../dist/x402.js");
+      const result = await executeTransfer({
+        to_address: "0x1234567890abcdef1234567890abcdef12345678",
+        amount: 10,
+        correlation_id: generateCorrelationId(),
+      });
+      assert.strictEqual(result.success, false);
+      assert.ok(result.error?.includes("not yet configured"));
+    });
+
+    it("uses injected transfer function", async () => {
+      const { executeTransfer, setTransferFn } = await import("../dist/x402.js");
+      setTransferFn(async (req) => ({
+        success: true,
+        tx_hash: "0xfake",
+        chain: "base",
+        token: "USDC",
+        correlation_id: req.correlation_id,
+      }));
+      const result = await executeTransfer({
+        to_address: "0xabc",
+        amount: 5,
+        correlation_id: "test_123",
+      });
+      assert.strictEqual(result.success, true);
+      assert.strictEqual(result.tx_hash, "0xfake");
+      assert.strictEqual(result.correlation_id, "test_123");
+    });
+
+    it("resetTransferFn restores default behavior", async () => {
+      const { executeTransfer, setTransferFn, resetTransferFn } = await import("../dist/x402.js");
+      setTransferFn(async (req) => ({
+        success: true,
+        tx_hash: "0xfake",
+        correlation_id: req.correlation_id,
+      }));
+      resetTransferFn();
+      const result = await executeTransfer({
+        to_address: "0xabc",
+        amount: 5,
+        correlation_id: "test_456",
+      });
+      assert.strictEqual(result.success, false);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Adds 25 new unit tests for two previously untested modules:

- **x402.ts** (12 tests): `generateCorrelationId` uniqueness/format, `validateX402Address` for Ethereum/Solana addresses (valid, invalid, edge cases), `executeTransfer` with default and injected implementations
- **guides.ts** (13 tests): `getGuideList` completeness/field validation/uniqueness/classification by type (comparison, stack, integration, alternatives), `getGuideBySlug` lookup and null handling

Test count: 769 → 794.

Refs #353

## Test plan
- [x] All 25 new tests pass
- [x] Full test suite passes (794/794)
- [x] No changes to source code