### PR TITLE
Add unit tests for stats and referral-requests modules

### DIFF
--- a/test/referral-requests.test.ts
+++ b/test/referral-requests.test.ts
@@ -1,0 +1,183 @@
+import { describe, it, beforeEach, afterEach } from "node:test";
+import assert from "node:assert";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REQUESTS_PATH = path.join(__dirname, "..", "data", "referral_requests.json");
+
+const {
+  logReferralRequest,
+  attributeConversion,
+  getRequestsByAgent,
+  getRequestById,
+  markConversion,
+  resetReferralRequestsCache,
+} = await import("../dist/referral-requests.js");
+
+let originalData: string | null = null;
+
+describe("referral-requests", () => {
+  beforeEach(() => {
+    if (fs.existsSync(REQUESTS_PATH)) {
+      originalData = fs.readFileSync(REQUESTS_PATH, "utf-8");
+    } else {
+      originalData = null;
+    }
+    fs.writeFileSync(REQUESTS_PATH, JSON.stringify({ referral_requests: [] }), "utf-8");
+    resetReferralRequestsCache();
+  });
+
+  afterEach(() => {
+    if (originalData !== null) {
+      fs.writeFileSync(REQUESTS_PATH, originalData, "utf-8");
+    }
+    resetReferralRequestsCache();
+  });
+
+  describe("logReferralRequest", () => {
+    it("creates a request with all required fields", () => {
+      const req = logReferralRequest({
+        agent_id: "agent_001",
+        vendor: "Railway",
+        referral_code: "REF123",
+        referral_url: "https://railway.app/ref/REF123",
+      });
+      assert.ok(req.id.startsWith("rr_"));
+      assert.strictEqual(req.agent_id, "agent_001");
+      assert.strictEqual(req.vendor, "Railway");
+      assert.strictEqual(req.referral_code, "REF123");
+      assert.strictEqual(req.referral_url, "https://railway.app/ref/REF123");
+      assert.ok(req.requested_at);
+      assert.strictEqual(req.conversion_id, null);
+    });
+
+    it("generates unique IDs", () => {
+      const req1 = logReferralRequest({
+        agent_id: "agent_001",
+        vendor: "Railway",
+        referral_code: "REF1",
+        referral_url: "https://example.com",
+      });
+      const req2 = logReferralRequest({
+        agent_id: "agent_001",
+        vendor: "Railway",
+        referral_code: "REF2",
+        referral_url: "https://example.com",
+      });
+      assert.notStrictEqual(req1.id, req2.id);
+    });
+
+    it("persists request to file", () => {
+      logReferralRequest({
+        agent_id: "agent_001",
+        vendor: "Vercel",
+        referral_code: "V123",
+        referral_url: "https://vercel.com/ref",
+      });
+      resetReferralRequestsCache();
+      const data = JSON.parse(fs.readFileSync(REQUESTS_PATH, "utf-8"));
+      assert.strictEqual(data.referral_requests.length, 1);
+      assert.strictEqual(data.referral_requests[0].vendor, "Vercel");
+    });
+  });
+
+  describe("getRequestsByAgent", () => {
+    it("returns only requests for the specified agent", () => {
+      logReferralRequest({ agent_id: "agent_A", vendor: "V1", referral_code: "C1", referral_url: "https://a.com" });
+      logReferralRequest({ agent_id: "agent_B", vendor: "V2", referral_code: "C2", referral_url: "https://b.com" });
+      logReferralRequest({ agent_id: "agent_A", vendor: "V3", referral_code: "C3", referral_url: "https://c.com" });
+      const reqs = getRequestsByAgent("agent_A");
+      assert.strictEqual(reqs.length, 2);
+      assert.ok(reqs.every((r: { agent_id: string }) => r.agent_id === "agent_A"));
+    });
+
+    it("returns empty array for unknown agent", () => {
+      const reqs = getRequestsByAgent("nonexistent");
+      assert.strictEqual(reqs.length, 0);
+    });
+  });
+
+  describe("getRequestById", () => {
+    it("finds a request by ID", () => {
+      const created = logReferralRequest({
+        agent_id: "agent_001",
+        vendor: "Railway",
+        referral_code: "R1",
+        referral_url: "https://r.com",
+      });
+      const found = getRequestById(created.id);
+      assert.ok(found);
+      assert.strictEqual(found.id, created.id);
+      assert.strictEqual(found.vendor, "Railway");
+    });
+
+    it("returns null for unknown ID", () => {
+      const result = getRequestById("rr_nonexistent");
+      assert.strictEqual(result, null);
+    });
+  });
+
+  describe("attributeConversion", () => {
+    it("returns agent_id for last-touch attribution", () => {
+      logReferralRequest({ agent_id: "agent_A", vendor: "Railway", referral_code: "A1", referral_url: "https://a.com" });
+      logReferralRequest({ agent_id: "agent_B", vendor: "Railway", referral_code: "B1", referral_url: "https://b.com" });
+      const result = attributeConversion("Railway", new Date());
+      assert.ok(result === "agent_A" || result === "agent_B", "should attribute to one of the agents");
+    });
+
+    it("is case-insensitive on vendor name", () => {
+      logReferralRequest({ agent_id: "agent_A", vendor: "railway", referral_code: "A1", referral_url: "https://a.com" });
+      const result = attributeConversion("Railway", new Date());
+      assert.strictEqual(result, "agent_A");
+    });
+
+    it("returns null when no matching vendor", () => {
+      logReferralRequest({ agent_id: "agent_A", vendor: "Vercel", referral_code: "V1", referral_url: "https://v.com" });
+      const result = attributeConversion("Railway", new Date());
+      assert.strictEqual(result, null);
+    });
+
+    it("returns null when requests are outside lookback window", () => {
+      const req = logReferralRequest({ agent_id: "agent_A", vendor: "Railway", referral_code: "A1", referral_url: "https://a.com" });
+      const futureDate = new Date(Date.now() + 100 * 24 * 60 * 60 * 1000);
+      const result = attributeConversion("Railway", futureDate, 1);
+      assert.strictEqual(result, null);
+    });
+
+    it("returns null when no requests exist", () => {
+      const result = attributeConversion("Railway", new Date());
+      assert.strictEqual(result, null);
+    });
+
+    it("respects custom lookback days", () => {
+      logReferralRequest({ agent_id: "agent_A", vendor: "Railway", referral_code: "A1", referral_url: "https://a.com" });
+      const result = attributeConversion("Railway", new Date(), 90);
+      assert.strictEqual(result, "agent_A");
+    });
+  });
+
+  describe("markConversion", () => {
+    it("marks a request as converted", () => {
+      const req = logReferralRequest({ agent_id: "agent_A", vendor: "Railway", referral_code: "A1", referral_url: "https://a.com" });
+      const result = markConversion(req.id, "conv_123");
+      assert.strictEqual(result, true);
+      const updated = getRequestById(req.id);
+      assert.strictEqual(updated!.conversion_id, "conv_123");
+    });
+
+    it("returns false for unknown request ID", () => {
+      const result = markConversion("rr_nonexistent", "conv_123");
+      assert.strictEqual(result, false);
+    });
+
+    it("persists conversion to file", () => {
+      const req = logReferralRequest({ agent_id: "agent_A", vendor: "V1", referral_code: "C1", referral_url: "https://v.com" });
+      markConversion(req.id, "conv_456");
+      resetReferralRequestsCache();
+      const data = JSON.parse(fs.readFileSync(REQUESTS_PATH, "utf-8"));
+      assert.strictEqual(data.referral_requests[0].conversion_id, "conv_456");
+    });
+  });
+});

--- a/test/stats.test.ts
+++ b/test/stats.test.ts
@@ -1,0 +1,238 @@
+import { describe, it, beforeEach } from "node:test";
+import assert from "node:assert";
+
+const {
+  recordToolCall,
+  recordApiHit,
+  recordSessionConnect,
+  recordSessionDisconnect,
+  recordLandingPageView,
+  recordPageView,
+  getStats,
+  getConnectionStats,
+  getPageViewsToday,
+  resetCounters,
+  useRedis,
+} = await import("../dist/stats.js");
+
+describe("stats", () => {
+  beforeEach(() => {
+    resetCounters();
+  });
+
+  describe("recordToolCall", () => {
+    it("increments known tool counters", () => {
+      recordToolCall("search_deals");
+      recordToolCall("search_deals");
+      recordToolCall("plan_stack");
+      const stats = getStats();
+      assert.strictEqual(stats.tool_calls.search_deals, 2);
+      assert.strictEqual(stats.tool_calls.plan_stack, 1);
+      assert.strictEqual(stats.total_tool_calls, 3);
+    });
+
+    it("ignores unknown tool names", () => {
+      recordToolCall("nonexistent_tool");
+      const stats = getStats();
+      assert.strictEqual(stats.total_tool_calls, 0);
+    });
+  });
+
+  describe("recordApiHit", () => {
+    it("increments known API endpoint counters", () => {
+      recordApiHit("/api/offers");
+      recordApiHit("/api/offers");
+      recordApiHit("/api/categories");
+      const stats = getStats();
+      assert.strictEqual(stats.api_hits["/api/offers"], 2);
+      assert.strictEqual(stats.api_hits["/api/categories"], 1);
+      assert.strictEqual(stats.total_api_hits, 3);
+    });
+
+    it("ignores unknown endpoints", () => {
+      recordApiHit("/api/unknown");
+      const stats = getStats();
+      assert.strictEqual(stats.total_api_hits, 0);
+    });
+  });
+
+  describe("recordSessionConnect", () => {
+    it("increments session counters", () => {
+      recordSessionConnect("claude-desktop");
+      recordSessionConnect("claude-desktop");
+      recordSessionConnect("cursor");
+      const stats = getStats();
+      assert.strictEqual(stats.total_sessions, 3);
+      assert.strictEqual(stats.cumulative_sessions, 3);
+    });
+
+    it("tracks sessions today with daily reset", () => {
+      recordSessionConnect();
+      recordSessionConnect();
+      const connStats = getConnectionStats(1);
+      assert.strictEqual(connStats.sessionsToday, 2);
+    });
+
+    it("defaults to 'unknown' when no client name provided", () => {
+      recordSessionConnect();
+      const connStats = getConnectionStats(0);
+      assert.ok(connStats.clients["unknown"] >= 1);
+    });
+
+    it("tracks client names in connection stats", () => {
+      recordSessionConnect("claude-desktop");
+      recordSessionConnect("cursor");
+      recordSessionConnect("claude-desktop");
+      const connStats = getConnectionStats(0);
+      assert.strictEqual(connStats.clients["claude-desktop"], 2);
+      assert.strictEqual(connStats.clients["cursor"], 1);
+    });
+  });
+
+  describe("recordSessionDisconnect", () => {
+    it("increments disconnect counter", () => {
+      recordSessionDisconnect();
+      recordSessionDisconnect();
+      const stats = getStats();
+      assert.strictEqual(stats.total_disconnects, 2);
+    });
+  });
+
+  describe("recordLandingPageView", () => {
+    it("increments landing page view counter", () => {
+      recordLandingPageView();
+      recordLandingPageView();
+      recordLandingPageView();
+      const stats = getStats();
+      assert.strictEqual(stats.landing_page_views, 3);
+      assert.strictEqual(stats.cumulative_landing_views, 3);
+    });
+  });
+
+  describe("recordPageView", () => {
+    it("increments in-memory page view counter for non-bots", () => {
+      const before = getPageViewsToday();
+      recordPageView("/", "Mozilla/5.0 Chrome/120");
+      recordPageView("/about", "Mozilla/5.0 Firefox/120");
+      assert.strictEqual(getPageViewsToday() - before, 2);
+    });
+
+    it("skips bot user agents", () => {
+      const before = getPageViewsToday();
+      recordPageView("/", "Googlebot/2.1");
+      recordPageView("/", "bingbot/2.0");
+      recordPageView("/", "AhrefsBot/7.0");
+      recordPageView("/", "GPTBot/1.0");
+      recordPageView("/", "ClaudeBot/1.0");
+      assert.strictEqual(getPageViewsToday() - before, 0);
+    });
+
+    it("skips spider and crawler user agents", () => {
+      const before = getPageViewsToday();
+      recordPageView("/", "Mozilla/5.0 (compatible; spider-bot)");
+      recordPageView("/", "SomeCrawler/1.0");
+      assert.strictEqual(getPageViewsToday() - before, 0);
+    });
+  });
+
+  describe("getStats", () => {
+    it("returns all expected fields", () => {
+      const stats = getStats();
+      assert.strictEqual(typeof stats.uptime_seconds, "number");
+      assert.strictEqual(typeof stats.total_tool_calls, "number");
+      assert.ok(typeof stats.tool_calls === "object");
+      assert.strictEqual(typeof stats.total_api_hits, "number");
+      assert.ok(typeof stats.api_hits === "object");
+      assert.strictEqual(typeof stats.total_sessions, "number");
+      assert.strictEqual(typeof stats.total_disconnects, "number");
+      assert.strictEqual(typeof stats.landing_page_views, "number");
+      assert.strictEqual(typeof stats.cumulative_sessions, "number");
+      assert.strictEqual(typeof stats.cumulative_tool_calls, "number");
+      assert.strictEqual(typeof stats.cumulative_api_hits, "number");
+      assert.strictEqual(typeof stats.cumulative_landing_views, "number");
+      assert.strictEqual(typeof stats.page_views_today, "number");
+      assert.strictEqual(typeof stats.first_session_at, "string");
+      assert.strictEqual(typeof stats.last_deploy_at, "string");
+    });
+
+    it("starts with zero counters after reset", () => {
+      const stats = getStats();
+      assert.strictEqual(stats.total_tool_calls, 0);
+      assert.strictEqual(stats.total_api_hits, 0);
+      assert.strictEqual(stats.total_sessions, 0);
+      assert.strictEqual(stats.total_disconnects, 0);
+      assert.strictEqual(stats.landing_page_views, 0);
+    });
+
+    it("returns uptime greater than or equal to zero", () => {
+      const stats = getStats();
+      assert.ok(stats.uptime_seconds >= 0);
+    });
+  });
+
+  describe("getConnectionStats", () => {
+    it("returns activeSessions from argument", () => {
+      const connStats = getConnectionStats(5);
+      assert.strictEqual(connStats.activeSessions, 5);
+    });
+
+    it("includes serverStarted ISO string", () => {
+      const connStats = getConnectionStats(0);
+      assert.ok(connStats.serverStarted);
+      assert.ok(connStats.serverStarted.includes("T"));
+    });
+
+    it("accumulates all-time stats correctly", () => {
+      recordSessionConnect("test");
+      recordToolCall("search_deals");
+      recordApiHit("/api/offers");
+      const connStats = getConnectionStats(1);
+      assert.strictEqual(connStats.totalSessionsAllTime, 1);
+      assert.strictEqual(connStats.totalToolCallsAllTime, 1);
+      assert.strictEqual(connStats.totalApiHitsAllTime, 1);
+    });
+  });
+
+  describe("resetCounters", () => {
+    it("resets all counters to zero", () => {
+      recordToolCall("search_deals");
+      recordApiHit("/api/offers");
+      recordSessionConnect("test");
+      recordSessionDisconnect();
+      recordLandingPageView();
+      resetCounters();
+      const stats = getStats();
+      assert.strictEqual(stats.total_tool_calls, 0);
+      assert.strictEqual(stats.total_api_hits, 0);
+      assert.strictEqual(stats.total_sessions, 0);
+      assert.strictEqual(stats.total_disconnects, 0);
+      assert.strictEqual(stats.landing_page_views, 0);
+      assert.strictEqual(stats.cumulative_sessions, 0);
+    });
+  });
+
+  describe("useRedis", () => {
+    it("returns false when env vars are not set", () => {
+      const originalUrl = process.env.UPSTASH_REDIS_REST_URL;
+      const originalToken = process.env.UPSTASH_REDIS_REST_TOKEN;
+      delete process.env.UPSTASH_REDIS_REST_URL;
+      delete process.env.UPSTASH_REDIS_REST_TOKEN;
+      assert.strictEqual(useRedis(), false);
+      if (originalUrl) process.env.UPSTASH_REDIS_REST_URL = originalUrl;
+      if (originalToken) process.env.UPSTASH_REDIS_REST_TOKEN = originalToken;
+    });
+  });
+
+  describe("getPageViewsToday", () => {
+    it("returns a number", () => {
+      assert.strictEqual(typeof getPageViewsToday(), "number");
+    });
+
+    it("increases when page views are recorded", () => {
+      const before = getPageViewsToday();
+      recordPageView("/test", "Mozilla/5.0");
+      recordPageView("/test2", "Mozilla/5.0");
+      assert.strictEqual(getPageViewsToday() - before, 2);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- **23 new tests** for `src/stats.ts`: tool call recording, API hit tracking, session management, bot filtering, page view counting, counter reset, Redis detection, connection stats
- **16 new tests** for `src/referral-requests.ts`: request creation, unique IDs, file persistence, agent filtering, ID lookup, last-touch attribution, case-insensitive vendor matching, lookback window, conversion marking
- Test count: 806 → 845

No source code changes — test-only PR.

Refs #353