### PR TITLE
MCP tool for agent friendship management

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -7,6 +7,7 @@ import { logReferralRequest } from "./referral-requests.js";
 import { getAgentBalance, getAgentLedgerEntries, recordPayout, MINIMUM_PAYOUT_AMOUNT, getLeaderboard } from "./ledger.js";
 import { submitReferralCode, getCodesByAgent, calculateTrustTier, getDailySubmissionCount, getDailyLimit, getRankedCodesForVendor, calculateCodeScore } from "./referral-codes.js";
 import { validateX402Address, executeTransfer, generateCorrelationId } from "./x402.js";
+import { addFriend, removeFriend, getFriends, getFriendCodesForVendors } from "./friends.js";
 import { getStackRecommendation } from "./stacks.js";
 import { estimateCosts } from "./costs.js";
 import { getGuideList, getGuideBySlug } from "./guides.js";
@@ -1329,6 +1330,66 @@ Suggested monitoring cadence: run this check weekly to catch pricing changes ear
             limit: limit ?? 10,
             offset: offset ?? 0,
           }, null, 2) }],
+        };
+      } catch (err: any) {
+        return {
+          isError: true,
+          content: [{ type: "text" as const, text: err.message }],
+        };
+      }
+    }
+  );
+
+  server.registerTool(
+    "manage_friends",
+    {
+      description:
+        "Manage your agent friendships on AgentDeals. Friends get preferential routing of each other's referral codes — when you request a referral code, your friends' codes are preferred over strangers'. Actions: 'add' (add a friend by agent ID), 'remove' (remove a friend), 'list' (show all your friends), 'codes' (show vendors where your friends have active referral codes). Requires your API key for authentication.",
+      annotations: {
+        readOnlyHint: false,
+        destructiveHint: false,
+      },
+      inputSchema: {
+        api_key: z.string().describe("Your agent API key for authentication"),
+        action: z.enum(["add", "remove", "list", "codes"]).describe("Action to perform: add, remove, list, or codes"),
+        agent_id: z.string().optional().describe("The agent ID of the friend to add or remove (required for add/remove actions)"),
+      },
+    },
+    async ({ api_key, action, agent_id }) => {
+      try {
+        recordToolCall("manage_friends");
+        const hash = hashApiKey(api_key);
+        const agent = getAgentByApiKeyHash(hash);
+        if (!agent) {
+          return { isError: true, content: [{ type: "text" as const, text: "Invalid API key. Register first with register_agent." }] };
+        }
+
+        let result: unknown;
+
+        if (action === "add") {
+          if (!agent_id) {
+            return { isError: true, content: [{ type: "text" as const, text: "agent_id is required for the add action." }] };
+          }
+          const friendship = addFriend(agent.id, agent_id);
+          result = { action: "added", friendship, message: `Added ${agent_id} as a friend. Their referral codes will now be preferred when you request codes.` };
+        } else if (action === "remove") {
+          if (!agent_id) {
+            return { isError: true, content: [{ type: "text" as const, text: "agent_id is required for the remove action." }] };
+          }
+          removeFriend(agent.id, agent_id);
+          result = { action: "removed", agent_id, message: `Removed ${agent_id} from your friends.` };
+        } else if (action === "list") {
+          const friends = getFriends(agent.id);
+          result = { action: "list", friends, total: friends.length };
+        } else {
+          const codes = getFriendCodesForVendors(agent.id);
+          result = { action: "codes", vendors: codes, total_vendors: codes.length };
+        }
+
+        logRequest({ ts: new Date().toISOString(), type: "mcp", endpoint: "manage_friends", params: { action, agent_id }, result_count: 1, session_id: getSessionId?.() });
+
+        return {
+          content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }],
         };
       } catch (err: any) {
         return {

--- a/test/manage-friends-tool.test.ts
+++ b/test/manage-friends-tool.test.ts
@@ -1,0 +1,171 @@
+import { describe, it, afterEach } from "node:test";
+import assert from "node:assert";
+import { spawn, type ChildProcess } from "node:child_process";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+describe("manage_friends MCP tool via HTTP", () => {
+  let serverPort = 0;
+  let proc: ChildProcess | null = null;
+
+  function startHttpServer(): Promise<ChildProcess> {
+    return new Promise((resolve, reject) => {
+      const serverPath = path.join(__dirname, "..", "dist", "serve.js");
+      const p = spawn("node", [serverPath], {
+        stdio: ["pipe", "pipe", "pipe"],
+        env: { ...process.env, PORT: "0" },
+      });
+      const timeout = setTimeout(() => { p.kill(); reject(new Error("Server startup timeout")); }, 10000);
+      p.stderr!.on("data", (data: Buffer) => {
+        const match = data.toString().match(/running on http:\/\/localhost:(\d+)/);
+        if (match) { serverPort = parseInt(match[1], 10); clearTimeout(timeout); resolve(p); }
+      });
+      p.on("error", (err) => { clearTimeout(timeout); reject(err); });
+    });
+  }
+
+  function parseSSE(text: string): any[] {
+    const results: any[] = [];
+    for (const line of text.split("\n")) {
+      if (line.startsWith("data: ")) {
+        try { results.push(JSON.parse(line.slice(6))); } catch {}
+      }
+    }
+    return results;
+  }
+
+  async function mcpCall(sessionId: string | null, msg: object): Promise<{ responses: any[]; sessionId: string | null }> {
+    const headers: Record<string, string> = { "Content-Type": "application/json", "Accept": "application/json, text/event-stream" };
+    if (sessionId) headers["mcp-session-id"] = sessionId;
+    const res = await fetch(`http://localhost:${serverPort}/mcp`, { method: "POST", headers, body: JSON.stringify(msg) });
+    const text = await res.text();
+    const newSessionId = res.headers.get("mcp-session-id") || sessionId;
+    return { responses: parseSSE(text), sessionId: newSessionId };
+  }
+
+  async function initSession(): Promise<string> {
+    const { sessionId } = await mcpCall(null, {
+      jsonrpc: "2.0", id: 1, method: "initialize",
+      params: { protocolVersion: "2025-03-26", capabilities: {}, clientInfo: { name: "test", version: "1.0" } },
+    });
+    await mcpCall(sessionId, { jsonrpc: "2.0", method: "notifications/initialized" });
+    return sessionId!;
+  }
+
+  async function callTool(sessionId: string, id: number, name: string, args: Record<string, unknown>): Promise<any> {
+    const { responses } = await mcpCall(sessionId, {
+      jsonrpc: "2.0", id, method: "tools/call",
+      params: { name, arguments: args },
+    });
+    return responses.find(r => r.id === id)?.result;
+  }
+
+  afterEach(() => { if (proc) { proc.kill(); proc = null; } });
+
+  it("manage_friends tool is listed in tools/list", async () => {
+    proc = await startHttpServer();
+    const sessionId = await initSession();
+    const { responses } = await mcpCall(sessionId, { jsonrpc: "2.0", id: 2, method: "tools/list", params: {} });
+    const toolsResult = responses.find(r => r.result?.tools);
+    assert.ok(toolsResult, "should get tools/list response");
+    const names = toolsResult.result.tools.map((t: any) => t.name);
+    assert.ok(names.includes("manage_friends"), "manage_friends should be listed");
+  });
+
+  it("rejects invalid API key", async () => {
+    proc = await startHttpServer();
+    const sessionId = await initSession();
+    const result = await callTool(sessionId, 2, "manage_friends", { api_key: "bad-key", action: "list" });
+    assert.ok(result.isError, "should be an error");
+    assert.ok(result.content[0].text.includes("Invalid API key"));
+  });
+
+  it("add requires agent_id", async () => {
+    proc = await startHttpServer();
+    const sessionId = await initSession();
+    const regResult = await callTool(sessionId, 2, "register_agent", { name: "TestAdd_" + Date.now() });
+    const apiKey = JSON.parse(regResult.content[0].text).api_key;
+    const result = await callTool(sessionId, 3, "manage_friends", { api_key: apiKey, action: "add" });
+    assert.ok(result.isError);
+    assert.ok(result.content[0].text.includes("agent_id is required"));
+  });
+
+  it("remove requires agent_id", async () => {
+    proc = await startHttpServer();
+    const sessionId = await initSession();
+    const regResult = await callTool(sessionId, 2, "register_agent", { name: "TestRemove_" + Date.now() });
+    const apiKey = JSON.parse(regResult.content[0].text).api_key;
+    const result = await callTool(sessionId, 3, "manage_friends", { api_key: apiKey, action: "remove" });
+    assert.ok(result.isError);
+    assert.ok(result.content[0].text.includes("agent_id is required"));
+  });
+
+  it("list returns empty for new agent", async () => {
+    proc = await startHttpServer();
+    const sessionId = await initSession();
+    const regResult = await callTool(sessionId, 2, "register_agent", { name: "TestList_" + Date.now() });
+    const apiKey = JSON.parse(regResult.content[0].text).api_key;
+    const result = await callTool(sessionId, 3, "manage_friends", { api_key: apiKey, action: "list" });
+    assert.ok(!result.isError);
+    const data = JSON.parse(result.content[0].text);
+    assert.strictEqual(data.action, "list");
+    assert.strictEqual(data.total, 0);
+  });
+
+  it("full lifecycle: add → list → codes → remove", async () => {
+    proc = await startHttpServer();
+    const sessionId = await initSession();
+    const ts = Date.now();
+
+    const reg1 = JSON.parse((await callTool(sessionId, 2, "register_agent", { name: "A1_" + ts })).content[0].text);
+    const reg2 = JSON.parse((await callTool(sessionId, 3, "register_agent", { name: "A2_" + ts })).content[0].text);
+
+    // Add
+    const addResult = await callTool(sessionId, 4, "manage_friends", { api_key: reg1.api_key, action: "add", agent_id: reg2.id });
+    assert.ok(!addResult.isError, "add should succeed");
+    const addData = JSON.parse(addResult.content[0].text);
+    assert.strictEqual(addData.action, "added");
+
+    // List
+    const listData = JSON.parse((await callTool(sessionId, 5, "manage_friends", { api_key: reg1.api_key, action: "list" })).content[0].text);
+    assert.strictEqual(listData.total, 1);
+    assert.strictEqual(listData.friends[0].friend_id, reg2.id);
+
+    // Codes
+    const codesData = JSON.parse((await callTool(sessionId, 6, "manage_friends", { api_key: reg1.api_key, action: "codes" })).content[0].text);
+    assert.strictEqual(codesData.action, "codes");
+    assert.ok(Array.isArray(codesData.vendors));
+
+    // Remove
+    const removeData = JSON.parse((await callTool(sessionId, 7, "manage_friends", { api_key: reg1.api_key, action: "remove", agent_id: reg2.id })).content[0].text);
+    assert.strictEqual(removeData.action, "removed");
+
+    // Verify empty
+    const afterData = JSON.parse((await callTool(sessionId, 8, "manage_friends", { api_key: reg1.api_key, action: "list" })).content[0].text);
+    assert.strictEqual(afterData.total, 0);
+  });
+
+  it("cannot add yourself as friend", async () => {
+    proc = await startHttpServer();
+    const sessionId = await initSession();
+    const reg = JSON.parse((await callTool(sessionId, 2, "register_agent", { name: "Self_" + Date.now() })).content[0].text);
+    const result = await callTool(sessionId, 3, "manage_friends", { api_key: reg.api_key, action: "add", agent_id: reg.id });
+    assert.ok(result.isError);
+    assert.ok(result.content[0].text.includes("Cannot add yourself"));
+  });
+
+  it("duplicate add returns error", async () => {
+    proc = await startHttpServer();
+    const sessionId = await initSession();
+    const ts = Date.now();
+    const reg1 = JSON.parse((await callTool(sessionId, 2, "register_agent", { name: "Dup1_" + ts })).content[0].text);
+    const reg2 = JSON.parse((await callTool(sessionId, 3, "register_agent", { name: "Dup2_" + ts })).content[0].text);
+
+    await callTool(sessionId, 4, "manage_friends", { api_key: reg1.api_key, action: "add", agent_id: reg2.id });
+    const result = await callTool(sessionId, 5, "manage_friends", { api_key: reg1.api_key, action: "add", agent_id: reg2.id });
+    assert.ok(result.isError);
+    assert.ok(result.content[0].text.includes("Already friends"));
+  });
+});


### PR DESCRIPTION
## Summary

Adds `manage_friends` MCP tool completing Phase 4 Part 2 of the social referrals feature. Agents can now manage friendships conversationally within their MCP workflow.

**Actions:**
- `add` — Add a friend by agent ID. Their referral codes get preferential routing.
- `remove` — Remove a friend.
- `list` — Show all friends with profiles.
- `codes` — Show vendors where friends have active referral codes.

All actions require API key authentication. Errors for invalid keys, missing agent_id, self-friending, and duplicate adds are handled gracefully.

## Test plan

- [x] 8 new tests (889 total, 0 failures)
- [x] Tool listed in tools/list response
- [x] Invalid API key rejected
- [x] Add/remove require agent_id parameter
- [x] Full lifecycle: add → list → codes → remove
- [x] Self-friend and duplicate-add error cases
- [x] All tests via HTTP MCP endpoint (SSE transport)

Refs #796