### PR TITLE
Fix RSS/Atom feed validation errors

### DIFF
--- a/src/serve.ts
+++ b/src/serve.ts
@@ -48335,6 +48335,7 @@ function buildPricingChangesFeed(): string {
   <link href="${BASE_URL}/pricing-changes/feed.xml" rel="self" type="application/atom+xml"/>
   <id>urn:agentdeals:pricing-changes-feed</id>
   <updated>${updatedTs}</updated>
+  <author><name>AgentDeals</name></author>
 ${entries}
 </feed>`;
 }
@@ -52397,7 +52398,9 @@ const httpServer = createHttpServer(async (req, res) => {
       const digest = getFormattedWeeklyDigest(w, 50);
       if (digest.top_changes.length === 0) continue;
       const weekUrl = w === 0 ? `${baseUrl}/this-week` : `${baseUrl}/this-week?week=${w}`;
-      const pubDate = new Date(digest.week_ending + "T12:00:00Z").toISOString();
+      const weekEndDate = new Date(digest.week_ending + "T12:00:00Z");
+      const now = new Date();
+      const pubDate = (weekEndDate > now ? new Date(digest.week_of + "T12:00:00Z") : weekEndDate).toISOString();
       const months = ["January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December"];
       const ws = new Date(digest.week_of + "T00:00:00Z");
       const we = new Date(digest.week_ending + "T00:00:00Z");
@@ -52420,6 +52423,7 @@ const httpServer = createHttpServer(async (req, res) => {
   <link href="${baseUrl}/feed.xml" rel="self" type="application/atom+xml"/>
   <id>urn:agentdeals:weekly-digest</id>
   <updated>${updatedTs}</updated>
+  <author><name>AgentDeals</name></author>
 ${weekEntries.join("\n")}
 </feed>`;
     logRequest({ ts: new Date().toISOString(), type: "api", endpoint: feedPath, params: {}, user_agent: req.headers["user-agent"] ?? "unknown", result_count: weekEntries.length });

--- a/test/feed-weekly-digest.test.ts
+++ b/test/feed-weekly-digest.test.ts
@@ -85,6 +85,24 @@ describe("/feed.xml weekly digest feed", () => {
     assert.strictEqual(res.headers.get("access-control-allow-origin"), "*");
   });
 
+  it("feed has author element", async () => {
+    proc = await startHttpServer();
+    const res = await fetch(`http://localhost:${serverPort}/feed.xml`);
+    const xml = await res.text();
+    assert.ok(xml.includes("<author><name>AgentDeals</name></author>"), "Should have author element");
+  });
+
+  it("no entry has a future updated date", async () => {
+    proc = await startHttpServer();
+    const res = await fetch(`http://localhost:${serverPort}/feed.xml`);
+    const xml = await res.text();
+    const now = new Date();
+    const updatedDates = [...xml.matchAll(/<updated>([^<]+)<\/updated>/g)].map(m => new Date(m[1]));
+    for (const d of updatedDates) {
+      assert.ok(d <= now, `Date ${d.toISOString()} should not be in the future`);
+    }
+  });
+
   it("/api/feed returns same content as /feed.xml", async () => {
     proc = await startHttpServer();
     const res = await fetch(`http://localhost:${serverPort}/api/feed`);


### PR DESCRIPTION
## Summary

- Add feed-level `<author><name>AgentDeals</name></author>` to both `/feed.xml` (weekly digest) and `/pricing-changes/feed.xml` (individual changes) — required by Atom spec
- Fix future-dated `<updated>` on current-week entries: use week start date instead of week ending date when the week hasn't ended yet
- 2 new tests: author element presence, no future dates in feed

Refs #805