### PR TITLE
Add per-entry author elements to Atom feeds for W3C compliance

### DIFF
--- a/src/serve.ts
+++ b/src/serve.ts
@@ -48386,6 +48386,7 @@ function buildPricingChangesFeed(): string {
     <link href="${BASE_URL}/pricing-changes#${anchor}" rel="alternate"/>
     <id>urn:agentdeals:${escXml(id)}</id>
     <updated>${new Date(c.date + "T00:00:00Z").toISOString()}</updated>
+    <author><name>AgentDeals</name></author>
     <summary>${escXml(c.summary + stateInfo)}</summary>
     <category term="${escXml(c.change_type)}" label="${escXml(label)}"/>
   </entry>`;
@@ -52486,6 +52487,7 @@ const httpServer = createHttpServer(async (req, res) => {
     <link href="${escXml(weekUrl)}" rel="alternate"/>
     <id>urn:agentdeals:weekly-digest:${digest.week_of}</id>
     <updated>${pubDate}</updated>
+    <author><name>AgentDeals</name></author>
     <summary type="html">${escXml(digest.digest_html)}</summary>
   </entry>`);
     }

--- a/test/http.test.ts
+++ b/test/http.test.ts
@@ -911,6 +911,9 @@ describe("HTTP transport", () => {
     assert.ok(body.includes("<updated>"));
     assert.ok(body.includes("/this-week"));
     assert.ok(body.includes("weekly-digest"));
+    const entryCount = (body.match(/<entry>/g) || []).length;
+    const entryAuthorCount = (body.match(/<entry>[\s\S]*?<author><name>AgentDeals<\/name><\/author>[\s\S]*?<\/entry>/g) || []).length;
+    assert.strictEqual(entryAuthorCount, entryCount, "Every entry should have its own <author> element");
   });
 
   it("GET /api/feed also serves Atom feed", async () => {
@@ -1503,6 +1506,9 @@ describe("HTTP transport", () => {
     assert.ok(xml.includes("<feed xmlns"), "Should be Atom feed");
     assert.ok(xml.includes("/pricing-changes#"), "Should link to pricing changes anchors");
     assert.ok(xml.includes("urn:agentdeals:pricing-changes-feed"), "Should have correct feed ID");
+    const entryCount = (xml.match(/<entry>/g) || []).length;
+    const entryAuthorCount = (xml.match(/<entry>[\s\S]*?<author><name>AgentDeals<\/name><\/author>[\s\S]*?<\/entry>/g) || []).length;
+    assert.strictEqual(entryAuthorCount, entryCount, "Every entry should have its own <author> element");
   });
 
   it("GET /badge/{vendor}.svg returns valid SVG badge", async () => {


### PR DESCRIPTION
## Summary

Refs #810

Adds `<author><name>AgentDeals</name></author>` to each `<entry>` in both Atom feeds (`/feed.xml` and `/pricing-changes/feed.xml`). Redundant per RFC 4287 (feed-level author applies to entries) but the W3C validator at validator.w3.org/feed/ treats missing per-entry author as an error.

## Test plan

- [x] 2 new test assertions verify every entry has its own `<author>` element
- [x] 276 HTTP tests pass, 0 failures
- [x] Existing feed content unchanged