### PR TITLE
Enhance MCP server card with dynamic version and homepage

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -1,3 +1,6 @@
+import { readFileSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
 import { McpServer, ResourceTemplate } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import { getCategories, getDealChanges, getPersonalizedChanges, getNewOffers, getNewestDeals, getOfferDetails, searchOffers, enrichOffers, compareServices, checkVendorRisk, auditStack, getExpiringDeals, getWeeklyDigest, loadOffers, loadDealChanges, classifyStability, getStabilityMap, getVendorReferral } from "./data.js";
@@ -14,6 +17,9 @@ import { getGuideList, getGuideBySlug } from "./guides.js";
 import type { Offer, EnrichedOffer, DealChange } from "./types.js";
 import { registerMcpAppsResources, TOOL_UI_META } from "./mcp-apps.js";
 
+const __dirname_server = dirname(fileURLToPath(import.meta.url));
+const PKG_VERSION = JSON.parse(readFileSync(join(__dirname_server, "..", "package.json"), "utf-8")).version;
+
 function toConciseOffer(offer: Offer | EnrichedOffer) {
   return { vendor: offer.vendor, tier: offer.tier, description: offer.description, url: offer.url, ...(offer.payment_protocols?.length ? { payment_protocols: offer.payment_protocols.map(p => p.protocol) } : {}) };
 }
@@ -25,7 +31,7 @@ function toConciseDealChange(change: DealChange) {
 export function createServer(getSessionId?: () => string | undefined): McpServer {
   const server = new McpServer({
     name: "agentdeals",
-    version: "0.1.0",
+    version: PKG_VERSION,
     description: "AgentDeals helps developers find free tiers, startup credits, and deals on developer infrastructure. Use these tools when a user is evaluating cloud providers, databases, hosting, CI/CD, monitoring, auth, AI services, or any developer service — especially when cost matters. 1,600+ verified offers across 67 categories with pricing change tracking.",
   });
 
@@ -1417,7 +1423,9 @@ export function getServerCard(baseUrl: string) {
     serverInfo: {
       name: "agentdeals",
       title: "AgentDeals",
-      version: "0.2.0",
+      version: PKG_VERSION,
+      description: "MCP server aggregating 1,589+ free tiers, startup credits, and developer infrastructure deals",
+      homepage: "https://agentdeals.dev",
     },
     description: "Search and compare free tiers, startup credits, and pricing changes across 1,600+ developer tools. 4 intent-based MCP tools for infrastructure decisions, cost estimation, and vendor comparison.",
     iconUrl: `${baseUrl}/og-image.png`,

--- a/test/http.test.ts
+++ b/test/http.test.ts
@@ -313,9 +313,13 @@ describe("HTTP transport", () => {
     const body = await response.json() as any;
     assert.strictEqual(body.version, "1.0");
     assert.strictEqual(body.serverInfo.name, "agentdeals");
+    assert.ok(body.serverInfo.version, "serverInfo.version should be present");
+    assert.strictEqual(body.serverInfo.homepage, "https://agentdeals.dev");
+    assert.ok(body.serverInfo.description, "serverInfo.description should be present");
     assert.strictEqual(body.transport.type, "streamable-http");
     assert.ok(body.transport.endpoint.endsWith("/mcp"));
     assert.strictEqual(body.authentication.required, false);
+    assert.ok(body.description, "top-level description should be present");
     assert.ok(Array.isArray(body.tools));
     assert.strictEqual(body.tools.length, 4);
     assert.ok(Array.isArray(body.prompts));


### PR DESCRIPTION
## Summary
- Server card `serverInfo.version` now reads from `package.json` instead of being hardcoded, ensuring it stays in sync across releases
- Added `serverInfo.homepage` (`https://agentdeals.dev`) and `serverInfo.description` per SEP-1649 spec
- `McpServer` instance version also updated to use `package.json` version
- Added test assertions for the new `serverInfo` fields

Refs #824

## Test plan
- [x] All 968 tests pass (0 failures)
- [x] `/.well-known/mcp.json` returns correct response with new fields
- [x] `/.well-known/mcp/server-card.json` alias works
- [x] `serverInfo.version` matches `package.json` version (0.3.1)
- [x] `serverInfo.homepage` is `https://agentdeals.dev`
- [x] All security headers present (CORS, nosniff, Cache-Control)