### PR TITLE
Add IndexNow status endpoint and expand URL coverage

### DIFF
--- a/src/serve.ts
+++ b/src/serve.ts
@@ -30,6 +30,8 @@ const BASE_URL = (process.env.BASE_URL ?? "https://agentdeals.dev").replace(/\/+
 
 const INDEXNOW_KEY = process.env.INDEXNOW_KEY ?? "";
 
+let indexNowLastSubmission: { ts: string; urlCount: number; status: number } | null = null;
+
 const GOOGLE_VERIFICATION_META = process.env.GOOGLE_SITE_VERIFICATION
   ? `<meta name="google-site-verification" content="${process.env.GOOGLE_SITE_VERIFICATION}">\n` : "";
 
@@ -55373,6 +55375,15 @@ ${Array.from(vendorSlugMap.keys()).map(s => {
       offset,
     }));
 
+  } else if (url.pathname === "/api/indexnow/status" && isGetOrHead) {
+    recordApiHit("/api/indexnow/status");
+    const status = {
+      enabled: !!INDEXNOW_KEY,
+      lastSubmission: indexNowLastSubmission,
+    };
+    res.writeHead(200, { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*", "Cache-Control": "public, max-age=60" });
+    res.end(JSON.stringify(status));
+
   } else if (url.pathname === "/api/referral-health" && isGetOrHead) {
     const report = getLastReport();
     if (!report) {
@@ -55541,6 +55552,16 @@ async function pingSearchEngines(): Promise<void> {
   for (const s of comparisonMap.keys()) {
     urlList.push(`${BASE_URL}/compare/${s}`);
   }
+  // Add report pages
+  urlList.push(`${BASE_URL}/reports`);
+  for (const m of getAvailableReportMonths()) {
+    urlList.push(`${BASE_URL}/reports/${m}`);
+  }
+  // Add event pages
+  urlList.push(`${BASE_URL}/events`);
+  for (const e of EVENTS) {
+    urlList.push(`${BASE_URL}/events/${e.slug}`);
+  }
   // Add vendor pages (top by recent changes first, then alphabetical — cap at ~2000 to stay well under 10k limit)
   const changedVendorSlugs = new Set(dealChanges.map((dc: any) => toSlug(dc.vendor)));
   const vendorSlugs = Array.from(vendorSlugMap.keys());
@@ -55585,6 +55606,7 @@ async function pingSearchEngines(): Promise<void> {
       body: JSON.stringify(payload),
       signal: AbortSignal.timeout(15000),
     });
+    indexNowLastSubmission = { ts: new Date().toISOString(), urlCount: urlList.length, status: resp.status };
     console.error(`IndexNow: submitted ${urlList.length} URLs, status ${resp.status}`);
   } catch (err: any) {
     console.error(`IndexNow: failed — ${err.message}`);

--- a/test/http.test.ts
+++ b/test/http.test.ts
@@ -5223,6 +5223,27 @@ describe("IndexNow integration", () => {
     }
   });
 
+  it("GET /api/indexnow/status returns enabled status when key is set", async () => {
+    const response = await fetch(`http://localhost:${indexNowPort}/api/indexnow/status`);
+    assert.strictEqual(response.status, 200);
+    const data = await response.json() as any;
+    assert.strictEqual(data.enabled, true);
+    assert.ok("lastSubmission" in data, "Should include lastSubmission field");
+  });
+
+  it("GET /api/indexnow/status returns disabled when key is not set", async () => {
+    let proc: ChildProcess | null = null;
+    try {
+      proc = await startHttpServer();
+      const response = await fetch(`http://localhost:${serverPort}/api/indexnow/status`);
+      assert.strictEqual(response.status, 200);
+      const data = await response.json() as any;
+      assert.strictEqual(data.enabled, false);
+    } finally {
+      if (proc) proc.kill();
+    }
+  });
+
 });
 
 describe("shutdown tracker page", () => {


### PR DESCRIPTION
## Summary

- Adds `GET /api/indexnow/status` endpoint returning `{ enabled, lastSubmission }` — the last missing acceptance criterion from #814
- Tracks submission timestamp, URL count, and HTTP status after each IndexNow push
- Adds report pages (23 monthly reports) and event pages to the IndexNow URL submission list
- 2 new tests for the status endpoint (enabled + disabled states)

## What was already done (prior cycles)

IndexNow was already fully implemented: key generation, `/{key}.txt` verification file, URL submission on startup, rate-limited batching. Only the status endpoint was missing.

Refs #814

## Test plan

- [x] 975 tests pass (up from 973)
- [x] E2E verified: `GET /api/indexnow/status` returns `{ enabled: false, lastSubmission: null }` when no key set
- [x] E2E verified: endpoint returns `{ enabled: true }` when INDEXNOW_KEY is set (via test suite)
- [x] TypeScript compiles cleanly