### PR TITLE
Add SEP-1960 MCP manifest at /.well-known/mcp

### DIFF
--- a/src/serve.ts
+++ b/src/serve.ts
@@ -52911,6 +52911,39 @@ const httpServer = createHttpServer(async (req, res) => {
       "X-Content-Type-Options": "nosniff",
     });
     res.end(body);
+  } else if (url.pathname === "/.well-known/mcp" && isGetOrHead) {
+    const card = getServerCard(BASE_URL);
+    const manifest = {
+      schema_version: "2025-01-01",
+      name: card.serverInfo.name,
+      description: card.description,
+      version: card.serverInfo.version,
+      transport: [
+        {
+          type: "streamable-http",
+          url: card.transport.endpoint,
+        },
+      ],
+      tools: card.tools.map((t: any) => ({
+        name: t.name,
+        description: t.description,
+        input_schema: t.inputSchema,
+      })),
+      prompts: card.prompts,
+      authentication: { type: "none" },
+      metadata: {
+        homepage: card.serverInfo.homepage,
+        documentation: card.documentationUrl,
+        icon: card.iconUrl,
+      },
+    };
+    res.writeHead(200, {
+      "Content-Type": "application/json",
+      "Cache-Control": "public, max-age=3600",
+      "Access-Control-Allow-Origin": "*",
+      "X-Content-Type-Options": "nosniff",
+    });
+    res.end(JSON.stringify(manifest, null, 2));
   } else if (url.pathname === "/api/stack" && isGetOrHead) {
     recordApiHit("/api/stack");
     const useCase = url.searchParams.get("use_case") || url.searchParams.get("q") || "";

--- a/test/http.test.ts
+++ b/test/http.test.ts
@@ -347,6 +347,36 @@ describe("HTTP transport", () => {
     assert.strictEqual(body.tools.length, 4);
   });
 
+  it("serves /.well-known/mcp manifest per SEP-1960", async () => {
+    proc = await startHttpServer();
+
+    const response = await fetch(`http://localhost:${serverPort}/.well-known/mcp`);
+    assert.strictEqual(response.status, 200);
+    assert.strictEqual(response.headers.get("content-type"), "application/json");
+    assert.strictEqual(response.headers.get("cache-control"), "public, max-age=3600");
+    assert.strictEqual(response.headers.get("access-control-allow-origin"), "*");
+    const body = await response.json() as any;
+    assert.strictEqual(body.schema_version, "2025-01-01");
+    assert.strictEqual(body.name, "agentdeals");
+    assert.ok(body.version, "version should be present");
+    assert.ok(body.description, "description should be present");
+    assert.ok(Array.isArray(body.transport));
+    assert.strictEqual(body.transport[0].type, "streamable-http");
+    assert.ok(body.transport[0].url.endsWith("/mcp"));
+    assert.ok(Array.isArray(body.tools));
+    assert.strictEqual(body.tools.length, 4);
+    const toolNames = body.tools.map((t: any) => t.name);
+    assert.ok(toolNames.includes("search_deals"));
+    assert.ok(toolNames.includes("plan_stack"));
+    for (const tool of body.tools) {
+      assert.ok(tool.input_schema, `${tool.name} should have input_schema`);
+    }
+    assert.ok(Array.isArray(body.prompts));
+    assert.strictEqual(body.authentication.type, "none");
+    assert.ok(body.metadata.homepage, "metadata.homepage should be present");
+    assert.ok(body.metadata.documentation, "metadata.documentation should be present");
+  });
+
   it("serves /setup page with client configs and HowTo schema", async () => {
     proc = await startHttpServer();
 


### PR DESCRIPTION
## Summary

- Adds `GET /.well-known/mcp` endpoint serving MCP manifest per SEP-1960 schema
- Derived from existing SEP-1649 server card data — consistent tool/prompt definitions
- Both discovery endpoints now active: `/.well-known/mcp.json` (SEP-1649) and `/.well-known/mcp` (SEP-1960)
- 1 new test verifying schema, tools, transport, auth, and metadata

Refs #829

## Test plan

- [x] 979 tests pass
- [x] E2E verified: manifest returns valid JSON with all 4 tools, transport config, and metadata
- [x] Headers: Content-Type application/json, CORS *, Cache 1hr
- [x] Both endpoints consistent (same tools, prompts, version)