### PR TITLE
Sitemap index: split into content-type child sitemaps

### DIFF
--- a/src/serve.ts
+++ b/src/serve.ts
@@ -52758,7 +52758,8 @@ const httpServer = createHttpServer(async (req, res) => {
     url.pathname !== "/mcp" && url.pathname !== "/health" &&
     url.pathname !== "/favicon.png" && url.pathname !== "/favicon.ico" &&
     url.pathname !== "/og-image.png" && url.pathname !== "/robots.txt" &&
-    url.pathname !== "/sitemap.xml" && !url.pathname.startsWith("/.well-known/") &&
+    url.pathname !== "/sitemap.xml" && !url.pathname.startsWith("/sitemap-") &&
+    !url.pathname.startsWith("/.well-known/") &&
     url.pathname !== "/feed.xml";
   if (isPagePath) {
     recordPageView(url.pathname, req.headers["user-agent"] ?? "", req.headers["referer"]);
@@ -53670,324 +53671,159 @@ ${catList}
     }
   } else if (url.pathname === "/sitemap.xml" && isGetOrHead) {
     const now = new Date().toISOString().split("T")[0];
-    // Most recent verifiedDate across all offers — used for index/hub pages
     const latestVerified = offers.reduce((max, o) => o.verifiedDate > max ? o.verifiedDate : max, offers[0]?.verifiedDate || now);
-    // Editorial pages use their deploy date (when content was created/last updated)
     const editorialDate = "2026-04-10";
-    // Comparison pages enrichment deploy date
     const comparisonDate = "2026-04-04";
-    const categoryUrls = categories.map((c) => {
-      const catLastmod = categoryLastmod.get(toSlug(c.name)) || now;
-      return `  <url>
-    <loc>${BASE_URL}/category/${toSlug(c.name)}</loc>
-    <lastmod>${catLastmod}</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.8</priority>
-  </url>`;
-    }).join("\n");
-    const sitemapXml = `<?xml version="1.0" encoding="UTF-8"?>
-<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
-  <url>
-    <loc>${BASE_URL}/</loc>
-    <lastmod>${latestVerified}</lastmod>
-    <changefreq>daily</changefreq>
-    <priority>1.0</priority>
-  </url>
-  <url>
-    <loc>${BASE_URL}/feed.xml</loc>
-    <lastmod>${latestVerified}</lastmod>
-    <changefreq>daily</changefreq>
-    <priority>0.5</priority>
-  </url>
-  <url>
-    <loc>${BASE_URL}/api/docs</loc>
-    <lastmod>${editorialDate}</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
-  </url>
-  <url>
-    <loc>${BASE_URL}/setup</loc>
-    <lastmod>${editorialDate}</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.8</priority>
-  </url>
-  <url>
-    <loc>${BASE_URL}/privacy</loc>
-    <lastmod>${editorialDate}</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.3</priority>
-  </url>
-  <url>
-    <loc>${BASE_URL}/disclosure</loc>
-    <lastmod>${editorialDate}</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.4</priority>
-  </url>
-  <url>
-    <loc>${BASE_URL}/marketplace</loc>
-    <lastmod>${editorialDate}</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
-  </url>
-  <url>
-    <loc>${BASE_URL}/referral-programs</loc>
-    <lastmod>${latestVerified}</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
-  </url>
-  <url>
-    <loc>${BASE_URL}/expiring</loc>
-    <lastmod>${latestVerified}</lastmod>
-    <changefreq>daily</changefreq>
-    <priority>0.8</priority>
-  </url>
-  <url>
-    <loc>${BASE_URL}/changes</loc>
-    <lastmod>${latestVerified}</lastmod>
-    <changefreq>daily</changefreq>
-    <priority>0.8</priority>
-  </url>
-  <url>
-    <loc>${BASE_URL}/deadlines</loc>
-    <lastmod>${latestVerified}</lastmod>
-    <changefreq>daily</changefreq>
-    <priority>0.8</priority>
-  </url>
-  <url>
-    <loc>${BASE_URL}/pricing-changes</loc>
-    <lastmod>${latestVerified}</lastmod>
-    <changefreq>daily</changefreq>
-    <priority>0.8</priority>
-  </url>
-  <url>
-    <loc>${BASE_URL}/freshness</loc>
-    <lastmod>${latestVerified}</lastmod>
-    <changefreq>daily</changefreq>
-    <priority>0.7</priority>
-  </url>
-  <url>
-    <loc>${BASE_URL}/events</loc>
-    <lastmod>${editorialDate}</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
-  </url>
-  ${EVENTS.map(e => `<url>
-    <loc>${BASE_URL}/events/${e.slug}</loc>
-    <lastmod>${editorialDate}</lastmod>
-    <changefreq>daily</changefreq>
-    <priority>0.8</priority>
-  </url>`).join("\n  ")}
-  <url>
-    <loc>${BASE_URL}/reports</loc>
-    <lastmod>${now}</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.7</priority>
-  </url>
-  ${getAvailableReportMonths().map(m => {
-    const reportLastmod = m + "-28" <= now ? m + "-28" : now;
-    return `<url>
-    <loc>${BASE_URL}/reports/${m}</loc>
-    <lastmod>${reportLastmod}</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.7</priority>
-  </url>`;
-  }).join("\n  ")}
-  <url>
-    <loc>${BASE_URL}/stacks</loc>
-    <lastmod>${editorialDate}</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.8</priority>
-  </url>
-  ${STACK_TEMPLATES.map(t => `<url>
-    <loc>${BASE_URL}/stacks/${t.slug}</loc>
-    <lastmod>${editorialDate}</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.8</priority>
-  </url>`).join("\n  ")}
-  <url>
-    <loc>${BASE_URL}/estimate</loc>
-    <lastmod>${editorialDate}</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.8</priority>
-  </url>
-  <url>
-    <loc>${BASE_URL}/stack-check</loc>
-    <lastmod>${editorialDate}</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.8</priority>
-  </url>
-  <url>
-    <loc>${BASE_URL}/compare-tool</loc>
-    <lastmod>${editorialDate}</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.8</priority>
-  </url>
-  <url>
-    <loc>${BASE_URL}/budget-builder</loc>
-    <lastmod>${editorialDate}</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.8</priority>
-  </url>
-  <url>
-    <loc>${BASE_URL}/developers</loc>
-    <lastmod>${editorialDate}</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.8</priority>
-  </url>
-  <url>
-    <loc>${BASE_URL}/badges</loc>
-    <lastmod>${editorialDate}</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
-  </url>
-  <url>
-    <loc>${BASE_URL}/embed</loc>
-    <lastmod>${editorialDate}</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
-  </url>
-  <url>
-    <loc>${BASE_URL}/agent-stack</loc>
-    <lastmod>${editorialDate}</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.9</priority>
-  </url>
-  <url>
-    <loc>${BASE_URL}/category</loc>
-    <lastmod>${latestVerified}</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.8</priority>
-  </url>
-  <url>
-    <loc>${BASE_URL}/best</loc>
-    <lastmod>${latestVerified}</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.8</priority>
-  </url>
-${Array.from(bestOfSlugMap.entries()).map(([s, { categoryName }]) => {
-      const bestLastmod = categoryLastmod.get(toSlug(categoryName)) || now;
-      return `  <url>
-    <loc>${BASE_URL}/best/${s}</loc>
-    <lastmod>${bestLastmod}</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.8</priority>
-  </url>`;
-    }).join("\n")}
-  <url>
-    <loc>${BASE_URL}/compare</loc>
-    <lastmod>${comparisonDate}</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.8</priority>
-  </url>
-${categoryUrls}
-${Array.from(comparisonMap.keys()).map(s => `  <url>
-    <loc>${BASE_URL}/compare/${s}</loc>
-    <lastmod>${comparisonDate}</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
-  </url>`).join("\n")}
-  <url>
-    <loc>${BASE_URL}/vendor</loc>
-    <lastmod>${latestVerified}</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.8</priority>
-  </url>
-${Array.from(vendorSlugMap.keys()).map(s => {
-      const vLastmod = vendorLastmod.get(s) || now;
-      return `  <url>
-    <loc>${BASE_URL}/vendor/${s}</loc>
-    <lastmod>${vLastmod}</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.6</priority>
-  </url>`;
-    }).join("\n")}
-  <url>
-    <loc>${BASE_URL}/this-week</loc>
-    <lastmod>${now}</lastmod>
-    <changefreq>daily</changefreq>
-    <priority>0.9</priority>
-  </url>
-  <url>
-    <loc>${BASE_URL}/digest/archive</loc>
-    <lastmod>${latestVerified}</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
-  </url>
-${getRecentWeekKeys(4).map(wk => `  <url>
-    <loc>${BASE_URL}/digest/${wk}</loc>
-    <lastmod>${latestVerified}</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.6</priority>
-  </url>`).join("\n")}
-  <url>
-    <loc>${BASE_URL}/trends</loc>
-    <lastmod>${latestVerified}</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
-  </url>
-${categories.map(c => {
-      const trendLastmod = categoryLastmod.get(toSlug(c.name)) || now;
-      return `  <url>
-    <loc>${BASE_URL}/trends/${toSlug(c.name)}</loc>
-    <lastmod>${trendLastmod}</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
-  </url>`;
-    }).join("\n")}
-${ALTERNATIVES_PAGES.map(p => `  <url>
-    <loc>${BASE_URL}/${p.slug}</loc>
-    <lastmod>${editorialDate}</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.9</priority>
-  </url>`).join("\n")}
-${Array.from(vsPageMap.keys()).map(s => `  <url>
-    <loc>${BASE_URL}/${s}</loc>
-    <lastmod>${editorialDate}</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.8</priority>
-  </url>`).join("\n")}
-  <url>
-    <loc>${BASE_URL}/guides</loc>
-    <lastmod>${editorialDate}</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.9</priority>
-  </url>
-${INTEGRATION_GUIDES.map(g => `  <url>
-    <loc>${BASE_URL}/guides/${g.slug}</loc>
-    <lastmod>${editorialDate}</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.8</priority>
-  </url>`).join("\n")}
-  <url>
-    <loc>${BASE_URL}/alternatives</loc>
-    <lastmod>${editorialDate}</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.9</priority>
-  </url>
-  <url>
-    <loc>${BASE_URL}/x402-services</loc>
-    <lastmod>${editorialDate}</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.8</priority>
-  </url>
-  <url>
-    <loc>${BASE_URL}/alternative-to</loc>
-    <lastmod>${latestVerified}</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
-  </url>
-${Array.from(vendorSlugMap.keys()).map(s => {
-      const altLastmod = vendorLastmod.get(s) || now;
-      return `  <url>
-    <loc>${BASE_URL}/alternative-to/${s}</loc>
-    <lastmod>${altLastmod}</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
-  </url>`;
-    }).join("\n")}
-</urlset>`;
+    const reportMonths = getAvailableReportMonths();
+    const latestReport = reportMonths.length > 0 ? (reportMonths[reportMonths.length - 1] + "-28" <= now ? reportMonths[reportMonths.length - 1] + "-28" : now) : now;
+    const sitemapIndex = '<?xml version="1.0" encoding="UTF-8"?>\n'
+      + '<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n'
+      + '  <sitemap>\n'
+      + '    <loc>' + BASE_URL + '/sitemap-vendors.xml</loc>\n'
+      + '    <lastmod>' + latestVerified + '</lastmod>\n'
+      + '  </sitemap>\n'
+      + '  <sitemap>\n'
+      + '    <loc>' + BASE_URL + '/sitemap-comparisons.xml</loc>\n'
+      + '    <lastmod>' + comparisonDate + '</lastmod>\n'
+      + '  </sitemap>\n'
+      + '  <sitemap>\n'
+      + '    <loc>' + BASE_URL + '/sitemap-pages.xml</loc>\n'
+      + '    <lastmod>' + latestVerified + '</lastmod>\n'
+      + '  </sitemap>\n'
+      + '  <sitemap>\n'
+      + '    <loc>' + BASE_URL + '/sitemap-reports.xml</loc>\n'
+      + '    <lastmod>' + latestReport + '</lastmod>\n'
+      + '  </sitemap>\n'
+      + '  <sitemap>\n'
+      + '    <loc>' + BASE_URL + '/sitemap-misc.xml</loc>\n'
+      + '    <lastmod>' + latestVerified + '</lastmod>\n'
+      + '  </sitemap>\n'
+      + '</sitemapindex>';
     res.writeHead(200, { "Content-Type": "application/xml; charset=utf-8", "Cache-Control": "public, max-age=3600" });
-    res.end(sitemapXml);
+    res.end(sitemapIndex);
+  } else if (url.pathname === "/sitemap-vendors.xml" && isGetOrHead) {
+    const now = new Date().toISOString().split("T")[0];
+    const latestVerified = offers.reduce((max, o) => o.verifiedDate > max ? o.verifiedDate : max, offers[0]?.verifiedDate || now);
+    let xml = '<?xml version="1.0" encoding="UTF-8"?>\n'
+      + '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n'
+      + '  <url>\n    <loc>' + BASE_URL + '/vendor</loc>\n    <lastmod>' + latestVerified + '</lastmod>\n    <changefreq>weekly</changefreq>\n    <priority>0.8</priority>\n  </url>\n';
+    for (const s of vendorSlugMap.keys()) {
+      const vLastmod = vendorLastmod.get(s) || now;
+      xml += '  <url>\n    <loc>' + BASE_URL + '/vendor/' + s + '</loc>\n    <lastmod>' + vLastmod + '</lastmod>\n    <changefreq>weekly</changefreq>\n    <priority>0.6</priority>\n  </url>\n';
+    }
+    xml += '</urlset>';
+    res.writeHead(200, { "Content-Type": "application/xml; charset=utf-8", "Cache-Control": "public, max-age=3600" });
+    res.end(xml);
+  } else if (url.pathname === "/sitemap-comparisons.xml" && isGetOrHead) {
+    const comparisonDate = "2026-04-04";
+    const editorialDate = "2026-04-10";
+    let xml = '<?xml version="1.0" encoding="UTF-8"?>\n'
+      + '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n'
+      + '  <url>\n    <loc>' + BASE_URL + '/compare</loc>\n    <lastmod>' + comparisonDate + '</lastmod>\n    <changefreq>weekly</changefreq>\n    <priority>0.8</priority>\n  </url>\n';
+    for (const s of comparisonMap.keys()) {
+      xml += '  <url>\n    <loc>' + BASE_URL + '/compare/' + s + '</loc>\n    <lastmod>' + comparisonDate + '</lastmod>\n    <changefreq>weekly</changefreq>\n    <priority>0.7</priority>\n  </url>\n';
+    }
+    for (const s of vsPageMap.keys()) {
+      xml += '  <url>\n    <loc>' + BASE_URL + '/' + s + '</loc>\n    <lastmod>' + editorialDate + '</lastmod>\n    <changefreq>weekly</changefreq>\n    <priority>0.8</priority>\n  </url>\n';
+    }
+    xml += '</urlset>';
+    res.writeHead(200, { "Content-Type": "application/xml; charset=utf-8", "Cache-Control": "public, max-age=3600" });
+    res.end(xml);
+  } else if (url.pathname === "/sitemap-pages.xml" && isGetOrHead) {
+    const now = new Date().toISOString().split("T")[0];
+    const latestVerified = offers.reduce((max, o) => o.verifiedDate > max ? o.verifiedDate : max, offers[0]?.verifiedDate || now);
+    const editorialDate = "2026-04-10";
+    let xml = '<?xml version="1.0" encoding="UTF-8"?>\n'
+      + '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n'
+      + '  <url>\n    <loc>' + BASE_URL + '/</loc>\n    <lastmod>' + latestVerified + '</lastmod>\n    <changefreq>daily</changefreq>\n    <priority>1.0</priority>\n  </url>\n'
+      + '  <url>\n    <loc>' + BASE_URL + '/feed.xml</loc>\n    <lastmod>' + latestVerified + '</lastmod>\n    <changefreq>daily</changefreq>\n    <priority>0.5</priority>\n  </url>\n'
+      + '  <url>\n    <loc>' + BASE_URL + '/api/docs</loc>\n    <lastmod>' + editorialDate + '</lastmod>\n    <changefreq>weekly</changefreq>\n    <priority>0.7</priority>\n  </url>\n'
+      + '  <url>\n    <loc>' + BASE_URL + '/setup</loc>\n    <lastmod>' + editorialDate + '</lastmod>\n    <changefreq>weekly</changefreq>\n    <priority>0.8</priority>\n  </url>\n'
+      + '  <url>\n    <loc>' + BASE_URL + '/privacy</loc>\n    <lastmod>' + editorialDate + '</lastmod>\n    <changefreq>monthly</changefreq>\n    <priority>0.3</priority>\n  </url>\n'
+      + '  <url>\n    <loc>' + BASE_URL + '/disclosure</loc>\n    <lastmod>' + editorialDate + '</lastmod>\n    <changefreq>monthly</changefreq>\n    <priority>0.4</priority>\n  </url>\n'
+      + '  <url>\n    <loc>' + BASE_URL + '/marketplace</loc>\n    <lastmod>' + editorialDate + '</lastmod>\n    <changefreq>weekly</changefreq>\n    <priority>0.7</priority>\n  </url>\n'
+      + '  <url>\n    <loc>' + BASE_URL + '/referral-programs</loc>\n    <lastmod>' + latestVerified + '</lastmod>\n    <changefreq>weekly</changefreq>\n    <priority>0.7</priority>\n  </url>\n'
+      + '  <url>\n    <loc>' + BASE_URL + '/expiring</loc>\n    <lastmod>' + latestVerified + '</lastmod>\n    <changefreq>daily</changefreq>\n    <priority>0.8</priority>\n  </url>\n'
+      + '  <url>\n    <loc>' + BASE_URL + '/changes</loc>\n    <lastmod>' + latestVerified + '</lastmod>\n    <changefreq>daily</changefreq>\n    <priority>0.8</priority>\n  </url>\n'
+      + '  <url>\n    <loc>' + BASE_URL + '/deadlines</loc>\n    <lastmod>' + latestVerified + '</lastmod>\n    <changefreq>daily</changefreq>\n    <priority>0.8</priority>\n  </url>\n'
+      + '  <url>\n    <loc>' + BASE_URL + '/pricing-changes</loc>\n    <lastmod>' + latestVerified + '</lastmod>\n    <changefreq>daily</changefreq>\n    <priority>0.8</priority>\n  </url>\n'
+      + '  <url>\n    <loc>' + BASE_URL + '/freshness</loc>\n    <lastmod>' + latestVerified + '</lastmod>\n    <changefreq>daily</changefreq>\n    <priority>0.7</priority>\n  </url>\n'
+      + '  <url>\n    <loc>' + BASE_URL + '/search</loc>\n    <lastmod>' + latestVerified + '</lastmod>\n    <changefreq>weekly</changefreq>\n    <priority>0.7</priority>\n  </url>\n'
+      + '  <url>\n    <loc>' + BASE_URL + '/stacks</loc>\n    <lastmod>' + editorialDate + '</lastmod>\n    <changefreq>weekly</changefreq>\n    <priority>0.8</priority>\n  </url>\n';
+    for (const t of STACK_TEMPLATES) {
+      xml += '  <url>\n    <loc>' + BASE_URL + '/stacks/' + t.slug + '</loc>\n    <lastmod>' + editorialDate + '</lastmod>\n    <changefreq>weekly</changefreq>\n    <priority>0.8</priority>\n  </url>\n';
+    }
+    xml += '  <url>\n    <loc>' + BASE_URL + '/estimate</loc>\n    <lastmod>' + editorialDate + '</lastmod>\n    <changefreq>weekly</changefreq>\n    <priority>0.8</priority>\n  </url>\n'
+      + '  <url>\n    <loc>' + BASE_URL + '/stack-check</loc>\n    <lastmod>' + editorialDate + '</lastmod>\n    <changefreq>weekly</changefreq>\n    <priority>0.8</priority>\n  </url>\n'
+      + '  <url>\n    <loc>' + BASE_URL + '/compare-tool</loc>\n    <lastmod>' + editorialDate + '</lastmod>\n    <changefreq>weekly</changefreq>\n    <priority>0.8</priority>\n  </url>\n'
+      + '  <url>\n    <loc>' + BASE_URL + '/budget-builder</loc>\n    <lastmod>' + editorialDate + '</lastmod>\n    <changefreq>weekly</changefreq>\n    <priority>0.8</priority>\n  </url>\n'
+      + '  <url>\n    <loc>' + BASE_URL + '/developers</loc>\n    <lastmod>' + editorialDate + '</lastmod>\n    <changefreq>weekly</changefreq>\n    <priority>0.8</priority>\n  </url>\n'
+      + '  <url>\n    <loc>' + BASE_URL + '/badges</loc>\n    <lastmod>' + editorialDate + '</lastmod>\n    <changefreq>weekly</changefreq>\n    <priority>0.7</priority>\n  </url>\n'
+      + '  <url>\n    <loc>' + BASE_URL + '/embed</loc>\n    <lastmod>' + editorialDate + '</lastmod>\n    <changefreq>weekly</changefreq>\n    <priority>0.7</priority>\n  </url>\n'
+      + '  <url>\n    <loc>' + BASE_URL + '/agent-stack</loc>\n    <lastmod>' + editorialDate + '</lastmod>\n    <changefreq>weekly</changefreq>\n    <priority>0.9</priority>\n  </url>\n'
+      + '  <url>\n    <loc>' + BASE_URL + '/category</loc>\n    <lastmod>' + latestVerified + '</lastmod>\n    <changefreq>weekly</changefreq>\n    <priority>0.8</priority>\n  </url>\n';
+    for (const c of categories) {
+      const catLastmod = categoryLastmod.get(toSlug(c.name)) || now;
+      xml += '  <url>\n    <loc>' + BASE_URL + '/category/' + toSlug(c.name) + '</loc>\n    <lastmod>' + catLastmod + '</lastmod>\n    <changefreq>weekly</changefreq>\n    <priority>0.8</priority>\n  </url>\n';
+    }
+    xml += '  <url>\n    <loc>' + BASE_URL + '/best</loc>\n    <lastmod>' + latestVerified + '</lastmod>\n    <changefreq>weekly</changefreq>\n    <priority>0.8</priority>\n  </url>\n';
+    for (const [s, { categoryName }] of bestOfSlugMap.entries()) {
+      const bestLastmod = categoryLastmod.get(toSlug(categoryName)) || now;
+      xml += '  <url>\n    <loc>' + BASE_URL + '/best/' + s + '</loc>\n    <lastmod>' + bestLastmod + '</lastmod>\n    <changefreq>weekly</changefreq>\n    <priority>0.8</priority>\n  </url>\n';
+    }
+    xml += '  <url>\n    <loc>' + BASE_URL + '/guides</loc>\n    <lastmod>' + editorialDate + '</lastmod>\n    <changefreq>weekly</changefreq>\n    <priority>0.9</priority>\n  </url>\n';
+    for (const g of INTEGRATION_GUIDES) {
+      xml += '  <url>\n    <loc>' + BASE_URL + '/guides/' + g.slug + '</loc>\n    <lastmod>' + editorialDate + '</lastmod>\n    <changefreq>weekly</changefreq>\n    <priority>0.8</priority>\n  </url>\n';
+    }
+    xml += '  <url>\n    <loc>' + BASE_URL + '/alternatives</loc>\n    <lastmod>' + editorialDate + '</lastmod>\n    <changefreq>weekly</changefreq>\n    <priority>0.9</priority>\n  </url>\n';
+    for (const p of ALTERNATIVES_PAGES) {
+      xml += '  <url>\n    <loc>' + BASE_URL + '/' + p.slug + '</loc>\n    <lastmod>' + editorialDate + '</lastmod>\n    <changefreq>weekly</changefreq>\n    <priority>0.9</priority>\n  </url>\n';
+    }
+    xml += '  <url>\n    <loc>' + BASE_URL + '/x402-services</loc>\n    <lastmod>' + editorialDate + '</lastmod>\n    <changefreq>weekly</changefreq>\n    <priority>0.8</priority>\n  </url>\n'
+      + '  <url>\n    <loc>' + BASE_URL + '/alternative-to</loc>\n    <lastmod>' + latestVerified + '</lastmod>\n    <changefreq>weekly</changefreq>\n    <priority>0.7</priority>\n  </url>\n';
+    for (const s of vendorSlugMap.keys()) {
+      const altLastmod = vendorLastmod.get(s) || now;
+      xml += '  <url>\n    <loc>' + BASE_URL + '/alternative-to/' + s + '</loc>\n    <lastmod>' + altLastmod + '</lastmod>\n    <changefreq>weekly</changefreq>\n    <priority>0.5</priority>\n  </url>\n';
+    }
+    xml += '</urlset>';
+    res.writeHead(200, { "Content-Type": "application/xml; charset=utf-8", "Cache-Control": "public, max-age=3600" });
+    res.end(xml);
+  } else if (url.pathname === "/sitemap-reports.xml" && isGetOrHead) {
+    const now = new Date().toISOString().split("T")[0];
+    const latestVerified = offers.reduce((max, o) => o.verifiedDate > max ? o.verifiedDate : max, offers[0]?.verifiedDate || now);
+    let xml = '<?xml version="1.0" encoding="UTF-8"?>\n'
+      + '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n'
+      + '  <url>\n    <loc>' + BASE_URL + '/this-week</loc>\n    <lastmod>' + now + '</lastmod>\n    <changefreq>daily</changefreq>\n    <priority>0.9</priority>\n  </url>\n'
+      + '  <url>\n    <loc>' + BASE_URL + '/digest/archive</loc>\n    <lastmod>' + latestVerified + '</lastmod>\n    <changefreq>weekly</changefreq>\n    <priority>0.7</priority>\n  </url>\n';
+    for (const wk of getRecentWeekKeys(4)) {
+      xml += '  <url>\n    <loc>' + BASE_URL + '/digest/' + wk + '</loc>\n    <lastmod>' + latestVerified + '</lastmod>\n    <changefreq>weekly</changefreq>\n    <priority>0.6</priority>\n  </url>\n';
+    }
+    xml += '  <url>\n    <loc>' + BASE_URL + '/reports</loc>\n    <lastmod>' + now + '</lastmod>\n    <changefreq>monthly</changefreq>\n    <priority>0.7</priority>\n  </url>\n';
+    for (const m of getAvailableReportMonths()) {
+      const reportLastmod = m + "-28" <= now ? m + "-28" : now;
+      xml += '  <url>\n    <loc>' + BASE_URL + '/reports/' + m + '</loc>\n    <lastmod>' + reportLastmod + '</lastmod>\n    <changefreq>monthly</changefreq>\n    <priority>0.7</priority>\n  </url>\n';
+    }
+    xml += '</urlset>';
+    res.writeHead(200, { "Content-Type": "application/xml; charset=utf-8", "Cache-Control": "public, max-age=3600" });
+    res.end(xml);
+  } else if (url.pathname === "/sitemap-misc.xml" && isGetOrHead) {
+    const now = new Date().toISOString().split("T")[0];
+    const latestVerified = offers.reduce((max, o) => o.verifiedDate > max ? o.verifiedDate : max, offers[0]?.verifiedDate || now);
+    const editorialDate = "2026-04-10";
+    let xml = '<?xml version="1.0" encoding="UTF-8"?>\n'
+      + '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n'
+      + '  <url>\n    <loc>' + BASE_URL + '/trends</loc>\n    <lastmod>' + latestVerified + '</lastmod>\n    <changefreq>weekly</changefreq>\n    <priority>0.7</priority>\n  </url>\n';
+    for (const c of categories) {
+      const trendLastmod = categoryLastmod.get(toSlug(c.name)) || now;
+      xml += '  <url>\n    <loc>' + BASE_URL + '/trends/' + toSlug(c.name) + '</loc>\n    <lastmod>' + trendLastmod + '</lastmod>\n    <changefreq>weekly</changefreq>\n    <priority>0.5</priority>\n  </url>\n';
+    }
+    xml += '  <url>\n    <loc>' + BASE_URL + '/events</loc>\n    <lastmod>' + editorialDate + '</lastmod>\n    <changefreq>weekly</changefreq>\n    <priority>0.7</priority>\n  </url>\n';
+    for (const e of EVENTS) {
+      xml += '  <url>\n    <loc>' + BASE_URL + '/events/' + e.slug + '</loc>\n    <lastmod>' + editorialDate + '</lastmod>\n    <changefreq>daily</changefreq>\n    <priority>0.8</priority>\n  </url>\n';
+    }
+    xml += '</urlset>';
+    res.writeHead(200, { "Content-Type": "application/xml; charset=utf-8", "Cache-Control": "public, max-age=3600" });
+    res.end(xml);
   } else if (url.pathname === "/") {
     recordLandingPageView();
     res.writeHead(200, { "Content-Type": "text/html; charset=utf-8" });

--- a/test/http.test.ts
+++ b/test/http.test.ts
@@ -1116,10 +1116,24 @@ describe("HTTP transport", () => {
     assert.ok(html.includes("nonexistent-category"), "Should show the invalid slug");
   });
 
-  it("sitemap.xml includes category pages and comparison pages", async () => {
+  it("sitemap.xml returns sitemap index with child sitemaps", async () => {
+    proc = await startHttpServer();
+    const response = await fetch(`http://localhost:${serverPort}/sitemap.xml`);
+    assert.strictEqual(response.status, 200);
+    const xml = await response.text();
+    assert.ok(xml.includes("<sitemapindex"), "Should be a sitemap index");
+    assert.ok(xml.includes("/sitemap-vendors.xml"), "Should reference vendors sitemap");
+    assert.ok(xml.includes("/sitemap-comparisons.xml"), "Should reference comparisons sitemap");
+    assert.ok(xml.includes("/sitemap-pages.xml"), "Should reference pages sitemap");
+    assert.ok(xml.includes("/sitemap-reports.xml"), "Should reference reports sitemap");
+    assert.ok(xml.includes("/sitemap-misc.xml"), "Should reference misc sitemap");
+    assert.ok(xml.includes("<lastmod>"), "Should have lastmod dates");
+  });
+
+  it("sitemap-pages.xml includes category pages", async () => {
     proc = await startHttpServer();
 
-    const response = await fetch(`http://localhost:${serverPort}/sitemap.xml`);
+    const response = await fetch(`http://localhost:${serverPort}/sitemap-pages.xml`);
     assert.strictEqual(response.status, 200);
     const xml = await response.text();
     assert.ok(xml.includes("/category/databases"), "Sitemap should include databases category");
@@ -1127,7 +1141,14 @@ describe("HTTP transport", () => {
     // Should have many category entries (54 categories)
     const categoryCount = (xml.match(/\/category\//g) || []).length;
     assert.ok(categoryCount >= 50, `Expected 50+ category URLs in sitemap, got ${categoryCount}`);
-    // Should include comparison pages
+  });
+
+  it("sitemap-comparisons.xml includes comparison pages", async () => {
+    proc = await startHttpServer();
+
+    const response = await fetch(`http://localhost:${serverPort}/sitemap-comparisons.xml`);
+    assert.strictEqual(response.status, 200);
+    const xml = await response.text();
     assert.ok(xml.includes("/compare/netlify-vs-vercel"), "Sitemap should include comparison pages");
     const compareCount = (xml.match(/\/compare\//g) || []).length;
     assert.ok(compareCount >= 200, `Expected 200+ comparison URLs in sitemap, got ${compareCount}`);
@@ -1192,10 +1213,10 @@ describe("HTTP transport", () => {
     assert.ok(count <= 500, `Expected at most 500 comparisons, got ${count}`);
   });
 
-  it("sitemap includes auto-generated comparison pages", async () => {
+  it("sitemap-comparisons.xml includes auto-generated comparison pages", async () => {
     proc = await startHttpServer();
 
-    const response = await fetch(`http://localhost:${serverPort}/sitemap.xml`);
+    const response = await fetch(`http://localhost:${serverPort}/sitemap-comparisons.xml`);
     const xml = await response.text();
     const compareCount = (xml.match(/\/compare\//g) || []).length;
     assert.ok(compareCount >= 200, `Expected 200+ comparison URLs in sitemap, got ${compareCount}`);
@@ -1276,10 +1297,10 @@ describe("HTTP transport", () => {
     assert.ok(html.includes("404"), "Should show 404");
   });
 
-  it("sitemap.xml includes digest pages", async () => {
+  it("sitemap-reports.xml includes digest pages", async () => {
     proc = await startHttpServer();
 
-    const response = await fetch(`http://localhost:${serverPort}/sitemap.xml`);
+    const response = await fetch(`http://localhost:${serverPort}/sitemap-reports.xml`);
     const xml = await response.text();
     assert.ok(xml.includes("/digest/archive"), "Sitemap should include digest archive");
     const digestCount = (xml.match(/\/digest\//g) || []).length;
@@ -1328,10 +1349,10 @@ describe("HTTP transport", () => {
     assert.ok(html.includes("/vendor"), "Should link to vendor index");
   });
 
-  it("sitemap.xml includes vendor pages", async () => {
+  it("sitemap-vendors.xml includes vendor pages", async () => {
     proc = await startHttpServer();
 
-    const response = await fetch(`http://localhost:${serverPort}/sitemap.xml`);
+    const response = await fetch(`http://localhost:${serverPort}/sitemap-vendors.xml`);
     const xml = await response.text();
     assert.ok(xml.includes("/vendor/vercel"), "Sitemap should include vendor pages");
     const vendorCount = (xml.match(/\/vendor\//g) || []).length;
@@ -1446,10 +1467,10 @@ describe("HTTP transport", () => {
     assert.ok(html.includes("/trends"), "Should link to trends index");
   });
 
-  it("sitemap.xml includes trends pages", async () => {
+  it("sitemap-misc.xml includes trends pages", async () => {
     proc = await startHttpServer();
 
-    const response = await fetch(`http://localhost:${serverPort}/sitemap.xml`);
+    const response = await fetch(`http://localhost:${serverPort}/sitemap-misc.xml`);
     const xml = await response.text();
     assert.ok(xml.includes("/trends/cloud-hosting"), "Sitemap should include trends pages");
     const trendsCount = (xml.match(/\/trends\//g) || []).length;
@@ -1492,10 +1513,10 @@ describe("HTTP transport", () => {
     assert.ok(html.includes("/alternative-to"), "Should link to alternatives index");
   });
 
-  it("sitemap.xml includes alternative-to pages", async () => {
+  it("sitemap-pages.xml includes alternative-to pages", async () => {
     proc = await startHttpServer();
 
-    const response = await fetch(`http://localhost:${serverPort}/sitemap.xml`);
+    const response = await fetch(`http://localhost:${serverPort}/sitemap-pages.xml`);
     const xml = await response.text();
     assert.ok(xml.includes("/alternative-to"), "Sitemap should include alternatives index");
     assert.ok(xml.includes("/alternative-to/vercel"), "Sitemap should include vendor alternatives");
@@ -1503,10 +1524,10 @@ describe("HTTP transport", () => {
     assert.ok(altCount >= 100, `Expected 100+ alternative-to URLs in sitemap, got ${altCount}`);
   });
 
-  it("sitemap.xml has varying lastmod dates based on content", async () => {
+  it("sitemap-vendors.xml has varying lastmod dates based on content", async () => {
     proc = await startHttpServer();
 
-    const response = await fetch(`http://localhost:${serverPort}/sitemap.xml`);
+    const response = await fetch(`http://localhost:${serverPort}/sitemap-vendors.xml`);
     const xml = await response.text();
     // Extract all lastmod dates
     const lastmods = [...xml.matchAll(/<lastmod>([^<]+)<\/lastmod>/g)].map(m => m[1]);
@@ -1713,7 +1734,7 @@ describe("HTTP transport", () => {
   it("GET /badges page is in sitemap", async () => {
     proc = await startHttpServer();
 
-    const response = await fetch(`http://localhost:${serverPort}/sitemap.xml`);
+    const response = await fetch(`http://localhost:${serverPort}/sitemap-pages.xml`);
     const xml = await response.text();
     assert.ok(xml.includes("/badges"), "Sitemap should include /badges page");
   });
@@ -1803,7 +1824,7 @@ describe("HTTP transport", () => {
   it("GET /developers page is in sitemap", async () => {
     proc = await startHttpServer();
 
-    const response = await fetch(`http://localhost:${serverPort}/sitemap.xml`);
+    const response = await fetch(`http://localhost:${serverPort}/sitemap-pages.xml`);
     const xml = await response.text();
     assert.ok(xml.includes("/developers"), "Sitemap should include /developers page");
   });
@@ -1837,7 +1858,7 @@ describe("HTTP transport", () => {
   it("GET /estimate page is in sitemap", async () => {
     proc = await startHttpServer();
 
-    const response = await fetch(`http://localhost:${serverPort}/sitemap.xml`);
+    const response = await fetch(`http://localhost:${serverPort}/sitemap-pages.xml`);
     const xml = await response.text();
     assert.ok(xml.includes("/estimate"), "Sitemap should include /estimate page");
   });
@@ -1904,7 +1925,7 @@ describe("HTTP transport", () => {
   it("GET /stacks pages are in sitemap", async () => {
     proc = await startHttpServer();
 
-    const response = await fetch(`http://localhost:${serverPort}/sitemap.xml`);
+    const response = await fetch(`http://localhost:${serverPort}/sitemap-pages.xml`);
     const xml = await response.text();
     assert.ok(xml.includes("/stacks</loc>") || xml.includes("/stacks<"), "Sitemap should include /stacks index");
     assert.ok(xml.includes("/stacks/saas-mvp"), "Sitemap should include saas-mvp template");
@@ -5001,10 +5022,10 @@ describe("best-of pages", () => {
     assert.ok(html.includes("404"), "Should show 404 message");
   });
 
-  it("sitemap.xml includes best-of pages", async () => {
+  it("sitemap-pages.xml includes best-of pages", async () => {
     proc = await startHttpServer();
 
-    const response = await fetch(`http://localhost:${serverPort}/sitemap.xml`);
+    const response = await fetch(`http://localhost:${serverPort}/sitemap-pages.xml`);
     const xml = await response.text();
     assert.ok(xml.includes("/best"), "Sitemap should include best-of index");
     assert.ok(xml.includes("/best/free-databases"), "Sitemap should include best-of detail pages");
@@ -5527,10 +5548,10 @@ describe("shutdown tracker page", () => {
     assert.ok(response.headers.get("location")?.includes("/cockroachdb-vs-mongodb"), "Should redirect to canonical URL");
   });
 
-  it("sitemap.xml includes programmatic VS pages", async () => {
+  it("sitemap-comparisons.xml includes programmatic VS pages", async () => {
     proc = await startHttpServer();
 
-    const response = await fetch(`http://localhost:${serverPort}/sitemap.xml`);
+    const response = await fetch(`http://localhost:${serverPort}/sitemap-comparisons.xml`);
     const xml = await response.text();
     assert.ok(xml.includes("/cockroachdb-vs-mongodb"), "Sitemap should include VS pages");
     assert.ok(xml.includes("/auth0-vs-clerk"), "Sitemap should include VS pages");
@@ -5605,7 +5626,7 @@ describe("shutdown tracker page", () => {
   it("GET /stack-check is in sitemap", async () => {
     proc = await startHttpServer();
 
-    const response = await fetch(`http://localhost:${serverPort}/sitemap.xml`);
+    const response = await fetch(`http://localhost:${serverPort}/sitemap-pages.xml`);
     const xml = await response.text();
     assert.ok(xml.includes("/stack-check"), "Sitemap should include /stack-check page");
   });
@@ -5663,7 +5684,7 @@ describe("shutdown tracker page", () => {
   it("GET /compare-tool is in sitemap", async () => {
     proc = await startHttpServer();
 
-    const response = await fetch(`http://localhost:${serverPort}/sitemap.xml`);
+    const response = await fetch(`http://localhost:${serverPort}/sitemap-pages.xml`);
     const xml = await response.text();
     assert.ok(xml.includes("/compare-tool"), "Sitemap should include /compare-tool page");
   });
@@ -5766,7 +5787,7 @@ describe("shutdown tracker page", () => {
   it("GET /budget-builder is in sitemap", async () => {
     proc = await startHttpServer();
 
-    const response = await fetch(`http://localhost:${serverPort}/sitemap.xml`);
+    const response = await fetch(`http://localhost:${serverPort}/sitemap-pages.xml`);
     const xml = await response.text();
     assert.ok(xml.includes("/budget-builder"), "Sitemap should include /budget-builder page");
   });
@@ -5804,7 +5825,7 @@ describe("shutdown tracker page", () => {
   it("GET /embed is in sitemap", async () => {
     proc = await startHttpServer();
 
-    const response = await fetch(`http://localhost:${serverPort}/sitemap.xml`);
+    const response = await fetch(`http://localhost:${serverPort}/sitemap-pages.xml`);
     const xml = await response.text();
     assert.ok(xml.includes("/embed"), "Sitemap should include /embed page");
   });
@@ -6204,7 +6225,7 @@ describe("startup credits comparison page", () => {
   it("events pages are in sitemap", async () => {
     proc = await startHttpServer();
 
-    const response = await fetch(`http://localhost:${serverPort}/sitemap.xml`);
+    const response = await fetch(`http://localhost:${serverPort}/sitemap-misc.xml`);
     const xml = await response.text();
     assert.ok(xml.includes("/events"), "Sitemap should include /events");
     assert.ok(xml.includes("/events/google-cloud-next-2026"), "Sitemap should include event page");
@@ -6254,7 +6275,7 @@ describe("Monthly pricing reports", () => {
   it("reports pages are in sitemap", async () => {
     proc = await startHttpServer();
 
-    const response = await fetch(`http://localhost:${serverPort}/sitemap.xml`);
+    const response = await fetch(`http://localhost:${serverPort}/sitemap-reports.xml`);
     const xml = await response.text();
     assert.ok(xml.includes("/reports"), "Sitemap should include /reports");
     assert.ok(xml.includes("/reports/2026-04"), "Sitemap should include monthly report page");

--- a/test/marketplace-dashboard.test.ts
+++ b/test/marketplace-dashboard.test.ts
@@ -312,7 +312,7 @@ describe("Marketplace in Sitemap", () => {
   });
 
   it("sitemap includes /marketplace", async () => {
-    const res = await fetch(`http://localhost:${serverPort}/sitemap.xml`);
+    const res = await fetch(`http://localhost:${serverPort}/sitemap-pages.xml`);
     const xml = await res.text();
     assert.ok(xml.includes("/marketplace"));
   });

--- a/test/payment-protocols.test.ts
+++ b/test/payment-protocols.test.ts
@@ -94,7 +94,7 @@ describe("payment protocol features", () => {
   });
 
   it("GET /agent-payments is in sitemap", async () => {
-    const res = await fetch(`http://localhost:${serverPort}/sitemap.xml`);
+    const res = await fetch(`http://localhost:${serverPort}/sitemap-pages.xml`);
     const xml = await res.text();
     assert.ok(xml.includes("/agent-payments"), "Sitemap should include /agent-payments");
   });
@@ -147,7 +147,7 @@ describe("payment protocol features", () => {
   });
 
   it("GET /x402-services is in sitemap", async () => {
-    const res = await fetch(`http://localhost:${serverPort}/sitemap.xml`);
+    const res = await fetch(`http://localhost:${serverPort}/sitemap-pages.xml`);
     const xml = await res.text();
     assert.ok(xml.includes("/x402-services"), "Sitemap should include /x402-services");
   });

--- a/test/referral-programs.test.ts
+++ b/test/referral-programs.test.ts
@@ -204,8 +204,8 @@ describe("referral-programs page", () => {
     }
   });
 
-  it("/sitemap.xml includes /referral-programs", async () => {
-    const res = await fetch(`http://localhost:${serverPort}/sitemap.xml`);
+  it("sitemap-pages.xml includes /referral-programs", async () => {
+    const res = await fetch(`http://localhost:${serverPort}/sitemap-pages.xml`);
     const xml = await res.text();
     assert.ok(xml.includes("/referral-programs"), "Sitemap should include referral-programs page");
   });

--- a/test/referral.test.ts
+++ b/test/referral.test.ts
@@ -216,8 +216,8 @@ describe("referral HTTP endpoints", () => {
     assert.ok(!html.includes("referral-callout"), "Vendor page without referral should not show callout");
   });
 
-  it("GET /sitemap.xml includes /disclosure", async () => {
-    const res = await fetch(`http://localhost:${serverPort}/sitemap.xml`);
+  it("sitemap-pages.xml includes /disclosure", async () => {
+    const res = await fetch(`http://localhost:${serverPort}/sitemap-pages.xml`);
     const xml = await res.text();
     assert.ok(xml.includes("/disclosure"), "Sitemap should include disclosure page");
   });

--- a/test/this-week.test.ts
+++ b/test/this-week.test.ts
@@ -135,9 +135,9 @@ describe("/this-week page", () => {
     assert.ok(html.includes("/this-week"), "Canonical should reference /this-week");
   });
 
-  it("/this-week appears in sitemap.xml", async () => {
+  it("/this-week appears in sitemap-reports.xml", async () => {
     proc = await startHttpServer();
-    const res = await fetch(`http://localhost:${serverPort}/sitemap.xml`, {
+    const res = await fetch(`http://localhost:${serverPort}/sitemap-reports.xml`, {
 
 
     });


### PR DESCRIPTION
## Summary

- Splits monolithic `sitemap.xml` (3,800+ URLs) into a sitemap index with 5 content-type child sitemaps
- `sitemap-vendors.xml`: ~1,572 vendor pages with per-vendor lastmod dates
- `sitemap-comparisons.xml`: ~351 auto-generated comparisons + editorial vs pages
- `sitemap-pages.xml`: core pages, categories, best-of, guides, alternatives, tools
- `sitemap-reports.xml`: monthly reports, weekly digests
- `sitemap-misc.xml`: trends, events
- Each child has accurate `<lastmod>` based on content type (vendor verified dates, editorial deploy dates, etc.)
- `robots.txt` unchanged — still points to `/sitemap.xml`
- Updated all sitemap tests across 6 test files + added sitemap index structure test

959 tests passing, no regressions.

Refs #833