### PR TITLE
Add BreadcrumbList JSON-LD to alternatives pages

### DIFF
--- a/src/serve.ts
+++ b/src/serve.ts
@@ -6251,6 +6251,7 @@ ${OG_IMAGE_META}${GOOGLE_VERIFICATION_META}<link rel="icon" type="image/png" hre
 <link rel="alternate" type="application/atom+xml" title="AgentDeals — Weekly Pricing Digest" href="/feed.xml">
 <link rel="preconnect" href="https://fonts.googleapis.com"><link rel="preconnect" href="https://fonts.gstatic.com" crossorigin><link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
 <script type="application/ld+json">${JSON.stringify(jsonLd)}</script>
+${buildBreadcrumbJsonLd([{ name: "Home", url: BASE_URL + "/" }, { name: "Alternatives", url: BASE_URL + "/alternative-to" }, { name: config.primaryVendor, url: BASE_URL + "/" + slug }])}
 <style>
 *{margin:0;padding:0;box-sizing:border-box}
 :root{--bg:#0f172a;--bg-elevated:#1e293b;--bg-card:rgba(255,255,255,0.06);--border:#334155;--border-hover:#3b82f6;--text:#f1f5f9;--text-muted:#94a3b8;--text-dim:#64748b;--accent:#3b82f6;--accent-hover:#60a5fa;--accent-glow:rgba(59,130,246,0.15);--serif:'Inter',-apple-system,sans-serif;--sans:'Inter',-apple-system,sans-serif;--mono:'JetBrains Mono',SFMono-Regular,monospace}

--- a/test/http.test.ts
+++ b/test/http.test.ts
@@ -4783,6 +4783,17 @@ describe("HTTP transport", () => {
     assert.ok(html.includes("BreadcrumbList"), "Search page should have BreadcrumbList JSON-LD");
   });
 
+  it("alternatives page has BreadcrumbList JSON-LD", async () => {
+    proc = await startHttpServer();
+
+    const response = await fetch(`http://localhost:${serverPort}/heroku-alternatives`);
+    assert.strictEqual(response.status, 200);
+    const html = await response.text();
+    assert.ok(html.includes("BreadcrumbList"), "Alternatives page should have BreadcrumbList JSON-LD");
+    assert.ok(html.includes("Alternatives"), "Breadcrumb should include Alternatives level");
+    assert.ok(html.includes("Heroku"), "Breadcrumb should include vendor name");
+  });
+
   // --- Global navigation ---
 
   it("landing page has global navigation with all section links", async () => {


### PR DESCRIPTION
Adds BreadcrumbList structured data to alternatives pages (e.g. /heroku-alternatives, /vercel-alternatives). These pages already had visual breadcrumbs but were missing the JSON-LD that all other page types emit.

Breadcrumb trail: Home → Alternatives → [Vendor Name]

Uses the existing `buildBreadcrumbJsonLd()` shared helper, consistent with vendor, best-of, comparison, search, events, and report pages.

1 new test verifying BreadcrumbList presence on alternatives pages.

Refs #817