### PR TITLE
Add Build 2026 + I/O 2026 event coverage pages

### DIFF
--- a/src/serve.ts
+++ b/src/serve.ts
@@ -7047,6 +7047,7 @@ interface EventDef {
   vendorFilter: (vendor: string) => boolean;
   description: string;
   expectedAnnouncements: string[];
+  organizer: string;
   confirmedAnnouncements?: { title: string; detail: string }[];
   preEventNote?: string;
 }
@@ -7065,6 +7066,7 @@ const EVENTS: EventDef[] = [
       return lower.includes("google") || lower.includes("firebase") || lower.includes("gcp");
     },
     description: "Track all Google Cloud pricing changes, new free tiers, and developer program updates announced at Google Cloud Next 2026.",
+    organizer: "Google",
     expectedAnnouncements: [
       "Cloud Run cold start improvements and pricing",
       "BigQuery slot pricing updates",
@@ -7083,6 +7085,54 @@ const EVENTS: EventDef[] = [
       { title: "Enhanced tool governance", detail: "New guardrails and governance controls in Vertex AI Agent Builder." },
     ],
     preEventNote: "This page will be updated with final announcements after the event (April 22\u201324, 2026). Information below reflects confirmed and leaked pre-event announcements as of April 15, 2026.",
+  },
+  {
+    slug: "microsoft-build-2026",
+    title: "Microsoft Build 2026 — Developer Pricing Updates & Free Tier Changes",
+    shortTitle: "Microsoft Build 2026",
+    dates: "May 19\u201321, 2026",
+    location: "Seattle",
+    startDate: "2026-05-19",
+    endDate: "2026-05-21",
+    vendorFilter: (v: string) => {
+      const lower = v.toLowerCase();
+      return lower.includes("microsoft") || lower.includes("azure") || lower.includes("github") || lower.includes("copilot") || lower.includes("vs code");
+    },
+    description: "Track all Microsoft and Azure pricing changes, GitHub updates, and Copilot ecosystem announcements at Microsoft Build 2026.",
+    organizer: "Microsoft",
+    expectedAnnouncements: [
+      "Azure AI free tier and pricing changes",
+      "GitHub Copilot pricing and new features",
+      "Azure Functions and App Service pricing updates",
+      "GitHub Codespaces free tier changes",
+      "VS Code and dev tools ecosystem updates",
+      "Microsoft Founders Hub program updates",
+    ],
+    preEventNote: "Dates expected but not yet officially confirmed. This page will be updated as announcements are made. Check back closer to the event.",
+  },
+  {
+    slug: "google-io-2026",
+    title: "Google I/O 2026 — Developer Pricing Updates & Free Tier Changes",
+    shortTitle: "Google I/O 2026",
+    dates: "May 2026 (exact dates TBD)",
+    location: "Mountain View",
+    startDate: "2026-05-01",
+    endDate: "2026-05-31",
+    vendorFilter: (v: string) => {
+      const lower = v.toLowerCase();
+      return lower.includes("google") || lower.includes("firebase") || lower.includes("flutter") || lower.includes("android") || lower.includes("gemini");
+    },
+    description: "Track Firebase free tier changes, Google AI Studio pricing, Flutter/Dart tooling updates, and Android developer program announcements at Google I/O 2026.",
+    organizer: "Google",
+    expectedAnnouncements: [
+      "Firebase free tier and pricing restructuring",
+      "Google AI Studio pricing and model availability",
+      "Gemini consumer API free tier changes",
+      "Flutter and Dart tooling updates",
+      "Android development tool pricing",
+      "Google Play developer program changes",
+    ],
+    preEventNote: "Exact dates not yet announced. This page will be updated as details emerge. Check back for confirmed dates and announcements.",
   },
 ];
 
@@ -7190,7 +7240,7 @@ function buildEventPage(slug: string): string | null {
   const isActive = event.startDate <= today && !isPast;
 
   const title = event.title;
-  const metaDesc = event.description + " " + vendorNames.length + " Google/GCP services tracked with " + eventOffers.length + " current offerings.";
+  const metaDesc = event.description + " " + vendorNames.length + " services tracked with " + eventOffers.length + " current offerings.";
   const eventJsonLd = {
     "@context": "https://schema.org",
     "@type": "Event",
@@ -7205,7 +7255,7 @@ function buildEventPage(slug: string): string | null {
     url: BASE_URL + "/events/" + event.slug,
     organizer: {
       "@type": "Organization",
-      name: "Google",
+      name: event.organizer,
     },
     dateModified: today,
   };
@@ -7387,8 +7437,8 @@ function buildEventPage(slug: string): string | null {
     + updatesHtml + '\n'
     + confirmedHtml + '\n'
     + announcementsHtml + '\n'
-    + '<section class="event-section">\n<h2>Current GCP Free Tier Overview</h2>\n'
-    + '<p class="section-desc">' + eventOffers.length + ' offerings across ' + eventCategories.length + ' categories from ' + vendorNames.length + ' Google/GCP services.</p>\n'
+    + '<section class="event-section">\n<h2>Current Free Tier Overview</h2>\n'
+    + '<p class="section-desc">' + eventOffers.length + ' offerings across ' + eventCategories.length + ' categories from ' + vendorNames.length + ' tracked services.</p>\n'
     + categoryGroups + '\n</section>\n'
     + comparisonsHtml + '\n'
     + watchlistHtml + '\n'

--- a/test/http.test.ts
+++ b/test/http.test.ts
@@ -6226,6 +6226,35 @@ describe("startup credits comparison page", () => {
     assert.ok(html.includes("canonical"), "Should have canonical link");
   });
 
+  it("GET /events/microsoft-build-2026 renders event page", async () => {
+    proc = await startHttpServer();
+
+    const response = await fetch(`http://localhost:${serverPort}/events/microsoft-build-2026`);
+    assert.strictEqual(response.status, 200);
+    const html = await response.text();
+    assert.ok(html.includes("Microsoft Build 2026"), "Should have event title");
+    assert.ok(html.includes("May 19"), "Should show event dates");
+    assert.ok(html.includes("Seattle"), "Should show event location");
+    assert.ok(html.includes('"Event"'), "Should have Event schema");
+    assert.ok(html.includes("BreadcrumbList"), "Should have breadcrumb JSON-LD");
+    assert.ok(html.includes("Microsoft") || html.includes("GitHub"), "Should list Microsoft/GitHub vendors");
+    assert.ok(html.includes("offers-table"), "Should have offers table");
+  });
+
+  it("GET /events/google-io-2026 renders event page", async () => {
+    proc = await startHttpServer();
+
+    const response = await fetch(`http://localhost:${serverPort}/events/google-io-2026`);
+    assert.strictEqual(response.status, 200);
+    const html = await response.text();
+    assert.ok(html.includes("Google I/O 2026"), "Should have event title");
+    assert.ok(html.includes("Mountain View"), "Should show event location");
+    assert.ok(html.includes('"Event"'), "Should have Event schema");
+    assert.ok(html.includes("BreadcrumbList"), "Should have breadcrumb JSON-LD");
+    assert.ok(html.includes("Firebase") || html.includes("Google"), "Should list Google/Firebase vendors");
+    assert.ok(html.includes("offers-table"), "Should have offers table");
+  });
+
   it("GET /events/nonexistent returns 404", async () => {
     proc = await startHttpServer();
 
@@ -6239,7 +6268,9 @@ describe("startup credits comparison page", () => {
     const response = await fetch(`http://localhost:${serverPort}/sitemap-misc.xml`);
     const xml = await response.text();
     assert.ok(xml.includes("/events"), "Sitemap should include /events");
-    assert.ok(xml.includes("/events/google-cloud-next-2026"), "Sitemap should include event page");
+    assert.ok(xml.includes("/events/google-cloud-next-2026"), "Sitemap should include GCP Next event page");
+    assert.ok(xml.includes("/events/microsoft-build-2026"), "Sitemap should include Build event page");
+    assert.ok(xml.includes("/events/google-io-2026"), "Sitemap should include I/O event page");
   });
 });
 


### PR DESCRIPTION
Adds two new developer event coverage pages to the events directory.

**Microsoft Build 2026** (`/events/microsoft-build-2026`)
- May 19-21, Seattle
- 14 tracked vendors (Azure, GitHub, Copilot, VS Code, etc.)
- 6 expected announcements covering Azure AI, Copilot pricing, GitHub tools

**Google I/O 2026** (`/events/google-io-2026`)
- May 2026 (dates TBD), Mountain View
- 35 tracked vendors (Google, Firebase, Gemini, Flutter, Android)
- 6 expected announcements covering Firebase, AI Studio, Flutter/Dart

**Template improvements:**
- Added `organizer` field to EventDef (no longer hardcoded "Google")
- Generalized meta descriptions and section headers

Events index (`/events`) now lists all 3 events. All pages in sitemap. 2 new tests (962 total).

Refs #838