### PR TITLE
Data update: Codex pricing, Kiro verification, Content API sunset

### DIFF
--- a/data/deal_changes.json
+++ b/data/deal_changes.json
@@ -3,12 +3,12 @@
     {
       "vendor": "OpenAI Codex",
       "change_type": "pricing_restructured",
-      "date": "2026-04-01",
-      "summary": "ChatGPT Business price dropped from $30/user/mo to $20/user/mo (annual). Pay-as-you-go seats now available with no fixed fee. $100 credits for new Codex-only team members (up to $500/team, limited time)",
-      "previous_state": "Business plan $30/user/mo, no pay-as-you-go option",
-      "current_state": "Business $20/user/mo (annual), pay-as-you-go seats with usage-based billing, $100 new member credits",
+      "date": "2026-04-03",
+      "summary": "Switched from per-seat subscription to pay-as-you-go token-based pricing. Teams can add Codex-only seats billed on token consumption with no rate limits. ChatGPT Business price cut from $25 to $20/month (annual). $100 credit per new Codex team member (up to $500/team, limited time)",
+      "previous_state": "Per-seat subscription model, Business plan $25/user/mo",
+      "current_state": "Pay-as-you-go token-based pricing, Business $20/user/mo (annual), Codex-only seats with usage-based billing, $100 new member credits",
       "impact": "medium",
-      "source_url": "https://openai.com/index/introducing-codex/",
+      "source_url": "https://openai.com/index/codex-flexible-pricing-for-teams/",
       "category": "AI Coding",
       "alternatives": [
         "GitHub Copilot",
@@ -3657,6 +3657,22 @@
         "DigitalOcean",
         "Vultr",
         "AWS"
+      ]
+    },
+    {
+      "vendor": "Google Content API for Shopping",
+      "change_type": "product_deprecated",
+      "date": "2026-04-15",
+      "summary": "Google Content API for Shopping being sunset August 18, 2026. Replaced by Merchant API, rolling out April 22, 2026. Developers must migrate before the sunset deadline.",
+      "previous_state": "Active API for Google Merchant Center product data management",
+      "current_state": "Deprecated — sunset August 18, 2026. Replacement: Merchant API (available April 22, 2026)",
+      "impact": "high",
+      "source_url": "https://ppc.land/merchant-api-comes-to-google-ads-scripts-april-22-as-content-api-nears-its-end/",
+      "category": "API Development",
+      "alternatives": [
+        "Google Merchant API",
+        "Shopify API",
+        "BigCommerce API"
       ]
     }
   ]

--- a/data/index.json
+++ b/data/index.json
@@ -21280,9 +21280,9 @@
     {
       "vendor": "OpenAI Codex",
       "category": "AI Coding",
-      "description": "Cloud-native coding agent by OpenAI. Included in ChatGPT Plus ($20/mo), Pro ($200/mo), and Business ($20/user/mo, was $30). Pay-as-you-go seats available \u2014 usage billed on token consumption, no rate limits. $100 credits for new Codex-only team members (up to $500/team, limited time). 2M+ weekly users. API via codex-mini at $1.50/1M input, $6/1M output tokens.",
+      "description": "Cloud-native coding agent by OpenAI. Switched to pay-as-you-go token-based pricing (April 2026). Included in ChatGPT Plus ($20/mo), Pro ($200/mo), and Business ($20/user/mo, cut from $25). Teams can add Codex-only seats with no rate limits, billed on token consumption. $100 credit per new Codex team member (up to $500/team, limited time). 2M+ weekly users. API via codex-mini at $1.50/1M input, $6/1M output tokens.",
       "tier": "Freemium",
-      "url": "https://openai.com/index/introducing-codex/",
+      "url": "https://openai.com/index/codex-flexible-pricing-for-teams/",
       "tags": [
         "ai",
         "coding",
@@ -21291,7 +21291,7 @@
         "openai",
         "developer tools"
       ],
-      "verifiedDate": "2026-04-12",
+      "verifiedDate": "2026-04-15",
       "referral_program": {
         "available": false,
         "referrer_benefit": "N/A",
@@ -23098,7 +23098,7 @@
         "cursor-alternative",
         "free tier"
       ],
-      "verifiedDate": "2026-04-13"
+      "verifiedDate": "2026-04-15"
     },
     {
       "vendor": "OVHcloud",
@@ -23358,6 +23358,23 @@
         "google cloud",
         "vertex-ai",
         "rag"
+      ],
+      "verifiedDate": "2026-04-15"
+    },
+    {
+      "vendor": "Google Content API for Shopping",
+      "category": "API Development",
+      "description": "Product data management API for Google Merchant Center. Being sunset August 18, 2026 — replaced by Merchant API (rolling out April 22, 2026). Free to use with a Google Merchant Center account. Provided product listing, inventory management, and order management endpoints. Developers must migrate to Merchant API before the sunset date.",
+      "tier": "Free (Deprecated)",
+      "url": "https://developers.google.com/shopping-content/guides/quickstart",
+      "tags": [
+        "api",
+        "e-commerce",
+        "google",
+        "shopping",
+        "merchant",
+        "deprecated",
+        "product-data"
       ],
       "verifiedDate": "2026-04-15"
     }

--- a/test/deal-changes.test.ts
+++ b/test/deal-changes.test.ts
@@ -76,7 +76,7 @@ describe("track_changes tool", () => {
 
     assert.ok(Array.isArray(body.changes));
     assert.strictEqual(body.total, body.changes.length);
-    assert.strictEqual(body.total, 264);
+    assert.strictEqual(body.total, 265);
   });
 
   it("filters by date (since)", async () => {


### PR DESCRIPTION
## Summary
- OpenAI Codex: corrected deal change date to April 3, updated source URL, clarified $25→$20 pricing cut per PM source
- Amazon Kiro: verified free tier details (50 credits/mo, 500 trial credits), updated verifiedDate
- Google Content API for Shopping: new offer entry (deprecated) and deal change tracking August 18 sunset

Refs #842

## Test plan
- [x] All 962 tests pass
- [x] Validate script passes (category, date format, duplicate checks)
- [x] Deal change count assertion updated