### PR TITLE
Seed platform referral codes with Railway link

### DIFF
--- a/data/platform_codes.json
+++ b/data/platform_codes.json
@@ -1,0 +1,14 @@
+{
+  "platform_codes": [
+    {
+      "vendor": "Railway",
+      "code": "7RZL9q",
+      "referral_url": "https://railway.com?referralCode=7RZL9q",
+      "referrer_benefit": "15% commission (first 12 months)",
+      "referee_benefit": "$20 in credits",
+      "source": "platform",
+      "active": true,
+      "added_at": "2026-04-12"
+    }
+  ]
+}

--- a/src/platform-codes.ts
+++ b/src/platform-codes.ts
@@ -1,0 +1,57 @@
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const PLATFORM_CODES_PATH = path.join(__dirname, "..", "data", "platform_codes.json");
+
+export interface PlatformCode {
+  vendor: string;
+  code: string;
+  referral_url: string;
+  referrer_benefit: string;
+  referee_benefit: string;
+  source: "platform";
+  active: boolean;
+  added_at: string;
+}
+
+let cachedPlatformCodes: PlatformCode[] | null = null;
+
+function loadPlatformCodes(): PlatformCode[] {
+  if (cachedPlatformCodes) return cachedPlatformCodes;
+
+  if (!fs.existsSync(PLATFORM_CODES_PATH)) {
+    cachedPlatformCodes = [];
+    return cachedPlatformCodes;
+  }
+
+  try {
+    const raw = fs.readFileSync(PLATFORM_CODES_PATH, "utf-8");
+    const data = JSON.parse(raw) as { platform_codes?: PlatformCode[] };
+    cachedPlatformCodes = Array.isArray(data.platform_codes) ? data.platform_codes : [];
+  } catch {
+    cachedPlatformCodes = [];
+  }
+  return cachedPlatformCodes;
+}
+
+export function resetPlatformCodesCache(): void {
+  cachedPlatformCodes = null;
+}
+
+/**
+ * Get the active platform code for a vendor, if one exists.
+ */
+export function getPlatformCodeForVendor(vendorName: string): PlatformCode | null {
+  const codes = loadPlatformCodes();
+  const lowerName = vendorName.toLowerCase();
+  return codes.find(c => c.vendor.toLowerCase() === lowerName && c.active) ?? null;
+}
+
+/**
+ * Get all active platform codes.
+ */
+export function getAllPlatformCodes(): PlatformCode[] {
+  return loadPlatformCodes().filter(c => c.active);
+}

--- a/src/serve.ts
+++ b/src/serve.ts
@@ -15,6 +15,7 @@ import { logReferralRequest } from "./referral-requests.js";
 import { recordConversion, confirmEligibleEntries, clawbackEntry, getAgentBalance, getAgentLedgerEntries, recordPayout, MINIMUM_PAYOUT_AMOUNT, getLeaderboard } from "./ledger.js";
 import { validateX402Address, executeTransfer, generateCorrelationId } from "./x402.js";
 import { submitReferralCode, getCodesByAgent, getCodeById, updateCode, revokeCode, calculateTrustTier, getDailySubmissionCount, getDailyLimit, getRankedCodesForVendor, calculateCodeScore } from "./referral-codes.js";
+import { getPlatformCodeForVendor } from "./platform-codes.js";
 import { runHealthCheck, getLastReport, startPeriodicChecks } from "./referral-health.js";
 import { addFriend, removeFriend, getFriends, getFriendCodesForVendors } from "./friends.js";
 import { subscribe as watchlistSubscribe, getSubscription as getWatchlistSubscription, unsubscribe as watchlistUnsubscribe, listSubscriptions as listWatchlistSubscriptions } from "./watchlist.js";
@@ -3303,7 +3304,19 @@ ${enrichedAlts.map(a => {
     </div>`;
   })() : "";
 
-  const referralCalloutHtml = "";
+  // Platform referral code CTA (shown when we have a platform code for this vendor)
+  const platformCode = getPlatformCodeForVendor(vendorName);
+  const referralCalloutHtml = platformCode ? `
+  <div class="section" style="margin-top:1.5rem">
+    <div style="border:2px solid #3fb950;border-radius:12px;padding:1.25rem;background:linear-gradient(135deg,rgba(63,185,80,0.08),rgba(63,185,80,0.02))">
+      <div style="display:flex;align-items:center;gap:.5rem;margin-bottom:.75rem">
+        <span style="font-size:1.25rem">&#127873;</span>
+        <strong style="font-size:1rem;color:var(--text)">Sign up via our referral link and get ${escHtmlServer(platformCode.referee_benefit)}</strong>
+      </div>
+      <a href="${escHtmlServer(platformCode.referral_url)}" rel="noopener sponsored" target="_blank" style="display:inline-block;padding:.6rem 1.25rem;background:#3fb950;color:#fff;border-radius:8px;font-weight:600;font-size:.9rem;text-decoration:none">Get ${escHtmlServer(platformCode.referee_benefit)} &rarr;</a>
+      <p style="margin-top:.75rem;font-size:.75rem;color:var(--text-dim)">We may earn a commission if you sign up through this link. See our <a href="/disclosure">affiliate disclosure</a>.</p>
+    </div>
+  </div>` : "";
 
   // Referral program section (shown when vendor has a program, whether or not we have a code)
   const referralProgramHtml = primary.referral_program?.available ? `
@@ -55198,6 +55211,47 @@ ${catList}
       daily_submissions: dailyCount,
       daily_limit: dailyLimit,
     }));
+
+  // --- GET /api/referral-codes/:vendor: Get best available code for a vendor ---
+  } else if (url.pathname.match(/^\/api\/referral-codes\/[^/]+$/) && isGetOrHead && url.pathname !== "/api/referral-codes/mine") {
+    const vendorParam = decodeURIComponent(url.pathname.split("/").pop()!);
+
+    // Platform codes have highest priority
+    const platformCode = getPlatformCodeForVendor(vendorParam);
+    if (platformCode) {
+      recordApiHit("/api/referral-codes/:vendor");
+      logRequest({ ts: new Date().toISOString(), type: "api", endpoint: `/api/referral-codes/${vendorParam}`, params: { source: "platform" }, user_agent: req.headers["user-agent"] ?? "unknown", result_count: 1 });
+      res.writeHead(200, { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" });
+      res.end(JSON.stringify({
+        vendor: platformCode.vendor,
+        code: platformCode.code,
+        referral_url: platformCode.referral_url,
+        referee_benefit: platformCode.referee_benefit,
+        source: "platform",
+      }));
+      return;
+    }
+
+    // Fall back to agent-submitted codes (ranked by trust/performance)
+    const rankedCodes = getRankedCodesForVendor(vendorParam);
+    if (rankedCodes.length > 0) {
+      const best = rankedCodes[0];
+      recordApiHit("/api/referral-codes/:vendor");
+      logRequest({ ts: new Date().toISOString(), type: "api", endpoint: `/api/referral-codes/${vendorParam}`, params: { source: "agent-submitted" }, user_agent: req.headers["user-agent"] ?? "unknown", result_count: 1 });
+      res.writeHead(200, { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" });
+      res.end(JSON.stringify({
+        vendor: best.vendor,
+        code: best.code,
+        referral_url: best.referral_url,
+        referee_benefit: best.description,
+        source: "agent-submitted",
+      }));
+      return;
+    }
+
+    // No codes available
+    res.writeHead(404, { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" });
+    res.end(JSON.stringify({ error: `No referral codes available for "${vendorParam}"` }));
 
   // --- PUT /api/referral-codes/:id: Update a code ---
   } else if (url.pathname.match(/^\/api\/referral-codes\/[^/]+$/) && req.method === "PUT") {

--- a/test/platform-codes.test.ts
+++ b/test/platform-codes.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, after, beforeEach } from "node:test";
+import assert from "node:assert";
+import path from "node:path";
+import fs from "node:fs";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const PLATFORM_CODES_PATH = path.join(__dirname, "..", "data", "platform_codes.json");
+
+const {
+  getPlatformCodeForVendor,
+  getAllPlatformCodes,
+  resetPlatformCodesCache,
+} = await import("../dist/platform-codes.js");
+
+const originalData = fs.existsSync(PLATFORM_CODES_PATH)
+  ? fs.readFileSync(PLATFORM_CODES_PATH, "utf-8")
+  : "";
+
+after(() => {
+  if (originalData) {
+    fs.writeFileSync(PLATFORM_CODES_PATH, originalData, "utf-8");
+  }
+  resetPlatformCodesCache();
+});
+
+describe("Platform Codes", () => {
+  beforeEach(() => {
+    // Restore original data and reset cache before each test
+    if (originalData) {
+      fs.writeFileSync(PLATFORM_CODES_PATH, originalData, "utf-8");
+    }
+    resetPlatformCodesCache();
+  });
+
+  it("loads platform codes from data file", () => {
+    const codes = getAllPlatformCodes();
+    assert.ok(Array.isArray(codes));
+    assert.ok(codes.length >= 1, "Should have at least 1 platform code (Railway)");
+  });
+
+  it("returns Railway platform code", () => {
+    const code = getPlatformCodeForVendor("Railway");
+    assert.ok(code, "Railway should have a platform code");
+    assert.strictEqual(code.vendor, "Railway");
+    assert.strictEqual(code.code, "7RZL9q");
+    assert.strictEqual(code.source, "platform");
+    assert.ok(code.referral_url.includes("7RZL9q"));
+    assert.strictEqual(code.referee_benefit, "$20 in credits");
+  });
+
+  it("returns null for vendor without platform code", () => {
+    const code = getPlatformCodeForVendor("NonExistentVendor");
+    assert.strictEqual(code, null);
+  });
+
+  it("is case-insensitive for vendor lookup", () => {
+    const code = getPlatformCodeForVendor("railway");
+    assert.ok(code, "Should match case-insensitively");
+    assert.strictEqual(code.vendor, "Railway");
+  });
+
+  it("only returns active codes", () => {
+    const testData = {
+      platform_codes: [
+        {
+          vendor: "TestVendor",
+          code: "TEST123",
+          referral_url: "https://example.com?ref=TEST123",
+          referrer_benefit: "10%",
+          referee_benefit: "$10",
+          source: "platform",
+          active: false,
+          added_at: "2026-04-15",
+        },
+      ],
+    };
+    fs.writeFileSync(PLATFORM_CODES_PATH, JSON.stringify(testData), "utf-8");
+    resetPlatformCodesCache();
+
+    const code = getPlatformCodeForVendor("TestVendor");
+    assert.strictEqual(code, null, "Inactive codes should not be returned");
+
+    const all = getAllPlatformCodes();
+    assert.strictEqual(all.length, 0, "getAllPlatformCodes should only return active codes");
+  });
+
+  it("handles missing data file gracefully", () => {
+    const backup = fs.readFileSync(PLATFORM_CODES_PATH, "utf-8");
+    fs.unlinkSync(PLATFORM_CODES_PATH);
+    resetPlatformCodesCache();
+
+    const codes = getAllPlatformCodes();
+    assert.deepStrictEqual(codes, []);
+
+    const code = getPlatformCodeForVendor("Railway");
+    assert.strictEqual(code, null);
+
+    // Restore
+    fs.writeFileSync(PLATFORM_CODES_PATH, backup, "utf-8");
+    resetPlatformCodesCache();
+  });
+});


### PR DESCRIPTION
## Summary
- New `data/platform_codes.json` with Railway referral code (Rob's code from April 12)
- New `src/platform-codes.ts` module for platform code management
- `GET /api/referral-codes/:vendor` endpoint returns best available code (platform > agent-submitted)
- Railway vendor page shows referral CTA with "$20 in credits" button and affiliate disclosure
- 6 new tests (968 total)

Refs #843

## Test plan
- [x] All 968 tests pass (962 existing + 6 new platform-codes tests)
- [x] API returns Railway platform code with `source: "platform"`
- [x] API returns 404 for vendors without codes
- [x] Vendor page renders referral CTA with correct link and disclosure
- [x] E2E verified via curl against running server