### PR TITLE
Surface referral codes inline in MCP tool responses and REST API

### DIFF
--- a/src/platform-codes.ts
+++ b/src/platform-codes.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import { getRankedCodesForVendor } from "./referral-codes.js";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const PLATFORM_CODES_PATH = path.join(__dirname, "..", "data", "platform_codes.json");
@@ -54,4 +55,48 @@ export function getPlatformCodeForVendor(vendorName: string): PlatformCode | nul
  */
 export function getAllPlatformCodes(): PlatformCode[] {
   return loadPlatformCodes().filter(c => c.active);
+}
+
+/**
+ * Unified referral code shape returned inline on MCP tool responses and REST enrichment.
+ * Matches the GET /api/referral-codes/:vendor response shape so clients can consume both the same way.
+ */
+export interface BestReferralCode {
+  vendor: string;
+  code: string;
+  referral_url: string;
+  referee_benefit: string;
+  source: "platform" | "agent-submitted";
+}
+
+/**
+ * Get the best available referral code for a vendor.
+ * Platform codes take priority over agent-submitted codes.
+ * Returns null (explicit) when no code is available, so callers can distinguish "no code" from "field missing".
+ */
+export function getBestReferralCode(vendorName: string): BestReferralCode | null {
+  const platformCode = getPlatformCodeForVendor(vendorName);
+  if (platformCode) {
+    return {
+      vendor: platformCode.vendor,
+      code: platformCode.code,
+      referral_url: platformCode.referral_url,
+      referee_benefit: platformCode.referee_benefit,
+      source: "platform",
+    };
+  }
+
+  const ranked = getRankedCodesForVendor(vendorName);
+  if (ranked.length > 0) {
+    const best = ranked[0];
+    return {
+      vendor: best.vendor,
+      code: best.code,
+      referral_url: best.referral_url,
+      referee_benefit: best.description,
+      source: "agent-submitted",
+    };
+  }
+
+  return null;
 }

--- a/src/serve.ts
+++ b/src/serve.ts
@@ -15,7 +15,7 @@ import { logReferralRequest } from "./referral-requests.js";
 import { recordConversion, confirmEligibleEntries, clawbackEntry, getAgentBalance, getAgentLedgerEntries, recordPayout, MINIMUM_PAYOUT_AMOUNT, getLeaderboard } from "./ledger.js";
 import { validateX402Address, executeTransfer, generateCorrelationId } from "./x402.js";
 import { submitReferralCode, getCodesByAgent, getCodeById, updateCode, revokeCode, calculateTrustTier, getDailySubmissionCount, getDailyLimit, getRankedCodesForVendor, calculateCodeScore } from "./referral-codes.js";
-import { getPlatformCodeForVendor } from "./platform-codes.js";
+import { getPlatformCodeForVendor, getBestReferralCode } from "./platform-codes.js";
 import { runHealthCheck, getLastReport, startPeriodicChecks } from "./referral-health.js";
 import { addFriend, removeFriend, getFriends, getFriendCodesForVendors } from "./friends.js";
 import { subscribe as watchlistSubscribe, getSubscription as getWatchlistSubscription, unsubscribe as watchlistUnsubscribe, listSubscriptions as listWatchlistSubscriptions } from "./watchlist.js";
@@ -53113,25 +53113,29 @@ const httpServer = createHttpServer(async (req, res) => {
     const results = searchOffers(q, category, eligibilityType, sort, validStability, validPaymentProtocol);
     const total = results.length;
     const paged = enrichOffers(results.slice(offset, offset + limit));
-    // Append ranked agent-submitted referral codes for each vendor (curated codes shown first via offer.referral)
-    const offersWithAgentCodes = paged.map(offer => {
+    // Enrich each offer with: (1) best referral_code (platform > agent-submitted, explicit null if none)
+    // and (2) full ranked agent-submitted codes list for detailed consumers.
+    const offersWithCodes = paged.map(offer => {
       const agentCodes = getRankedCodesForVendor(offer.vendor);
-      if (agentCodes.length === 0) return offer;
-      return {
+      const enriched: typeof offer & { referral_code: ReturnType<typeof getBestReferralCode>; agent_referral_codes?: unknown[] } = {
         ...offer,
-        agent_referral_codes: agentCodes.map(c => ({
+        referral_code: getBestReferralCode(offer.vendor),
+      };
+      if (agentCodes.length > 0) {
+        enriched.agent_referral_codes = agentCodes.map(c => ({
           code: c.code,
           referral_url: c.referral_url,
           description: c.description,
           source: c.source,
           submitted_by: c.submitted_by,
           score: Math.round(calculateCodeScore(c) * 1000) / 1000,
-        })),
-      };
+        }));
+      }
+      return enriched;
     });
     logRequest({ ts: new Date().toISOString(), type: "api", endpoint: "/api/offers", params: { q, category, limit, offset }, user_agent: req.headers["user-agent"] ?? "unknown", result_count: paged.length });
     res.writeHead(200, { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" });
-    res.end(JSON.stringify({ offers: offersWithAgentCodes, total }));
+    res.end(JSON.stringify({ offers: offersWithCodes, total }));
   } else if (url.pathname === "/api/compare" && isGetOrHead) {
     recordApiHit("/api/compare");
     const a = url.searchParams.get("a") || "";
@@ -53149,8 +53153,15 @@ const httpServer = createHttpServer(async (req, res) => {
       return;
     }
     logRequest({ ts: new Date().toISOString(), type: "api", endpoint: "/api/compare", params: { a, b }, user_agent: req.headers["user-agent"] ?? "unknown", result_count: 2 });
+    const comparisonWithCodes = {
+      ...result.comparison,
+      referral_codes: {
+        [result.comparison.vendor_a.vendor]: getBestReferralCode(result.comparison.vendor_a.vendor),
+        [result.comparison.vendor_b.vendor]: getBestReferralCode(result.comparison.vendor_b.vendor),
+      },
+    };
     res.writeHead(200, { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" });
-    res.end(JSON.stringify(result.comparison));
+    res.end(JSON.stringify(comparisonWithCodes));
   } else if (url.pathname === "/api/new" && isGetOrHead) {
     recordApiHit("/api/new");
     const days = parseInt(url.searchParams.get("days") ?? "7", 10);
@@ -53170,8 +53181,12 @@ const httpServer = createHttpServer(async (req, res) => {
     }
     const result = getNewestDeals({ since, limit, category });
     logRequest({ ts: new Date().toISOString(), type: "api", endpoint: "/api/newest", params: { since, limit, category }, user_agent: req.headers["user-agent"] ?? "unknown", result_count: result.total });
+    const dealsWithCodes = {
+      ...result,
+      deals: result.deals.map(o => ({ ...o, referral_code: getBestReferralCode(o.vendor) })),
+    };
     res.writeHead(200, { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" });
-    res.end(JSON.stringify(result));
+    res.end(JSON.stringify(dealsWithCodes));
   } else if (url.pathname === "/api/categories" && isGetOrHead) {
     recordApiHit("/api/categories");
     const cats = getCategories();
@@ -53487,8 +53502,9 @@ const httpServer = createHttpServer(async (req, res) => {
       return;
     }
     logRequest({ ts: new Date().toISOString(), type: "api", endpoint: "/api/vendor-risk", params: { vendor: vendorParam }, user_agent: req.headers["user-agent"] ?? "unknown", result_count: 1 });
+    const riskWithCode = { ...riskResult.result, referral_code: getBestReferralCode(riskResult.result.vendor) };
     res.writeHead(200, { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" });
-    res.end(JSON.stringify(riskResult.result));
+    res.end(JSON.stringify(riskWithCode));
   } else if (url.pathname.startsWith("/api/details/") && isGetOrHead) {
     recordApiHit("/api/details");
     const vendorParam = decodeURIComponent(url.pathname.slice("/api/details/".length));
@@ -53506,8 +53522,9 @@ const httpServer = createHttpServer(async (req, res) => {
       return;
     }
     logRequest({ ts: new Date().toISOString(), type: "api", endpoint: "/api/details", params: { vendor: vendorParam, alternatives: includeAlternatives }, user_agent: req.headers["user-agent"] ?? "unknown", result_count: 1 });
+    const offerWithCode = { ...detailResult.offer, referral_code: getBestReferralCode(detailResult.offer.vendor) };
     res.writeHead(200, { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" });
-    res.end(JSON.stringify({ offer: detailResult.offer, ...(includeAlternatives ? { alternatives: detailResult.offer.alternatives } : {}) }));
+    res.end(JSON.stringify({ offer: offerWithCode, ...(includeAlternatives ? { alternatives: detailResult.offer.alternatives } : {}) }));
   } else if (url.pathname === "/api/expiring" && isGetOrHead) {
     recordApiHit("/api/expiring");
     const withinDays = Math.min(Math.max(parseInt(url.searchParams.get("within_days") ?? "30", 10) || 30, 1), 365);
@@ -55216,35 +55233,17 @@ ${catList}
   } else if (url.pathname.match(/^\/api\/referral-codes\/[^/]+$/) && isGetOrHead && url.pathname !== "/api/referral-codes/mine") {
     const vendorParam = decodeURIComponent(url.pathname.split("/").pop()!);
 
-    // Platform codes have highest priority
-    const platformCode = getPlatformCodeForVendor(vendorParam);
-    if (platformCode) {
+    const best = getBestReferralCode(vendorParam);
+    if (best) {
       recordApiHit("/api/referral-codes/:vendor");
-      logRequest({ ts: new Date().toISOString(), type: "api", endpoint: `/api/referral-codes/${vendorParam}`, params: { source: "platform" }, user_agent: req.headers["user-agent"] ?? "unknown", result_count: 1 });
-      res.writeHead(200, { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" });
-      res.end(JSON.stringify({
-        vendor: platformCode.vendor,
-        code: platformCode.code,
-        referral_url: platformCode.referral_url,
-        referee_benefit: platformCode.referee_benefit,
-        source: "platform",
-      }));
-      return;
-    }
-
-    // Fall back to agent-submitted codes (ranked by trust/performance)
-    const rankedCodes = getRankedCodesForVendor(vendorParam);
-    if (rankedCodes.length > 0) {
-      const best = rankedCodes[0];
-      recordApiHit("/api/referral-codes/:vendor");
-      logRequest({ ts: new Date().toISOString(), type: "api", endpoint: `/api/referral-codes/${vendorParam}`, params: { source: "agent-submitted" }, user_agent: req.headers["user-agent"] ?? "unknown", result_count: 1 });
+      logRequest({ ts: new Date().toISOString(), type: "api", endpoint: `/api/referral-codes/${vendorParam}`, params: { source: best.source }, user_agent: req.headers["user-agent"] ?? "unknown", result_count: 1 });
       res.writeHead(200, { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" });
       res.end(JSON.stringify({
         vendor: best.vendor,
         code: best.code,
         referral_url: best.referral_url,
-        referee_benefit: best.description,
-        source: "agent-submitted",
+        referee_benefit: best.referee_benefit,
+        source: best.source,
       }));
       return;
     }

--- a/src/server.ts
+++ b/src/server.ts
@@ -9,6 +9,7 @@ import { registerAgent, validateVestauthUrl, getAgentByApiKeyHash, hashApiKey, u
 import { logReferralRequest } from "./referral-requests.js";
 import { getAgentBalance, getAgentLedgerEntries, recordPayout, MINIMUM_PAYOUT_AMOUNT, getLeaderboard } from "./ledger.js";
 import { submitReferralCode, getCodesByAgent, calculateTrustTier, getDailySubmissionCount, getDailyLimit, getRankedCodesForVendor, calculateCodeScore } from "./referral-codes.js";
+import { getBestReferralCode } from "./platform-codes.js";
 import { validateX402Address, executeTransfer, generateCorrelationId } from "./x402.js";
 import { addFriend, removeFriend, getFriends, getFriendCodesForVendors } from "./friends.js";
 import { getStackRecommendation } from "./stacks.js";
@@ -88,8 +89,9 @@ export function createServer(getSessionId?: () => string | undefined): McpServer
             };
           }
           logRequest({ ts: new Date().toISOString(), type: "mcp", endpoint: "search_deals", params: { vendor }, result_count: 1, session_id: getSessionId?.() });
+          const offerWithCode = { ...result.offer, referral_code: getBestReferralCode(result.offer.vendor) };
           return {
-            content: [{ type: "text" as const, text: JSON.stringify(result.offer, null, 2) }],
+            content: [{ type: "text" as const, text: JSON.stringify(offerWithCode, null, 2) }],
           };
         }
 
@@ -97,8 +99,12 @@ export function createServer(getSessionId?: () => string | undefined): McpServer
         if (since && !query && !category) {
           const result = getNewestDeals({ since, limit, category: undefined });
           logRequest({ ts: new Date().toISOString(), type: "mcp", endpoint: "search_deals", params: { since, limit }, result_count: result.total, session_id: getSessionId?.() });
+          const enrichedResult = {
+            ...result,
+            deals: result.deals.map(o => ({ ...o, referral_code: getBestReferralCode(o.vendor) })),
+          };
           return {
-            content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }],
+            content: [{ type: "text" as const, text: JSON.stringify(enrichedResult, null, 2) }],
           };
         }
 
@@ -128,22 +134,28 @@ export function createServer(getSessionId?: () => string | undefined): McpServer
           };
         }
 
-        // Append ranked agent-submitted referral codes for each vendor
-        const resultsWithAgentCodes = results.map(offer => {
+        // Enrich each result with: (1) best referral_code (platform > agent-submitted, explicit null when absent)
+        // and (2) full ranked agent-submitted codes list for verbose consumers.
+        const resultsWithCodes = results.map(offer => {
           const agentCodes = getRankedCodesForVendor(offer.vendor);
-          if (agentCodes.length === 0) return offer;
-          return {
+          const enriched: typeof offer & { referral_code: ReturnType<typeof getBestReferralCode>; agent_referral_codes?: unknown[] } = {
             ...offer,
-            agent_referral_codes: agentCodes.map(c => ({
+            referral_code: getBestReferralCode(offer.vendor),
+          };
+          if (agentCodes.length > 0) {
+            enriched.agent_referral_codes = agentCodes.map(c => ({
               code: c.code,
               referral_url: c.referral_url,
               description: c.description,
               source: c.source,
               score: Math.round(calculateCodeScore(c) * 1000) / 1000,
-            })),
-          };
+            }));
+          }
+          return enriched;
         });
-        const outputResults = response_format === "concise" ? resultsWithAgentCodes.map(toConciseOffer) : resultsWithAgentCodes;
+        const outputResults = response_format === "concise"
+          ? resultsWithCodes.map(r => ({ ...toConciseOffer(r), referral_code: r.referral_code }))
+          : resultsWithCodes;
         return {
           content: [{ type: "text" as const, text: JSON.stringify({ results: outputResults, total: finalTotal, limit: effectiveLimit, offset: effectiveOffset }, null, 2) }],
         };
@@ -273,6 +285,7 @@ export function createServer(getSessionId?: () => string | undefined): McpServer
           const enrichedResult = {
             ...result.result,
             stability: stabMap.get(result.result.vendor.toLowerCase()) ?? "stable",
+            referral_code: getBestReferralCode(result.result.vendor),
           };
           logRequest({ ts: new Date().toISOString(), type: "mcp", endpoint: "compare_vendors", params: { vendors }, result_count: 1, session_id: getSessionId?.() });
           return {
@@ -300,6 +313,10 @@ export function createServer(getSessionId?: () => string | undefined): McpServer
             stability: {
               [vendors[0]]: stabMap.get(comparison.comparison.vendor_a.vendor.toLowerCase()) ?? "stable",
               [vendors[1]]: stabMap.get(comparison.comparison.vendor_b.vendor.toLowerCase()) ?? "stable",
+            },
+            referral_codes: {
+              [vendors[0]]: getBestReferralCode(comparison.comparison.vendor_a.vendor),
+              [vendors[1]]: getBestReferralCode(comparison.comparison.vendor_b.vendor),
             },
           };
 

--- a/test/referral-code-enrichment.test.ts
+++ b/test/referral-code-enrichment.test.ts
@@ -1,0 +1,221 @@
+import { describe, it, before, after } from "node:test";
+import assert from "node:assert";
+import { spawn, type ChildProcess } from "node:child_process";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+const { getBestReferralCode } = await import("../dist/platform-codes.js");
+
+describe("getBestReferralCode helper", () => {
+  it("returns a platform code for Railway (seeded platform code)", () => {
+    const code = getBestReferralCode("Railway");
+    assert.ok(code, "Railway should have a referral code");
+    assert.strictEqual(code.source, "platform");
+    assert.strictEqual(code.vendor, "Railway");
+    assert.ok(code.code);
+    assert.ok(code.referral_url);
+    assert.ok(code.referee_benefit);
+  });
+
+  it("is case-insensitive for vendor lookup", () => {
+    const code = getBestReferralCode("railway");
+    assert.ok(code);
+    assert.strictEqual(code.source, "platform");
+  });
+
+  it("returns null for vendors with no codes", () => {
+    const code = getBestReferralCode("NonExistentVendor_ZZZ_42");
+    assert.strictEqual(code, null);
+  });
+
+  it("returned shape has exactly the expected fields", () => {
+    const code = getBestReferralCode("Railway");
+    assert.ok(code);
+    assert.ok("vendor" in code);
+    assert.ok("code" in code);
+    assert.ok("referral_url" in code);
+    assert.ok("referee_benefit" in code);
+    assert.ok("source" in code);
+  });
+});
+
+describe("MCP tools referral_code enrichment (via local REST proxy)", () => {
+  let serverPort = 0;
+  let serverProc: ChildProcess;
+
+  before(async () => {
+    serverProc = await new Promise<ChildProcess>((resolve, reject) => {
+      const serverPath = path.join(__dirname, "..", "dist", "serve.js");
+      const proc = spawn("node", [serverPath], {
+        stdio: ["pipe", "pipe", "pipe"],
+        env: { ...process.env, PORT: "0", BASE_URL: "http://localhost" },
+      });
+      const timeout = setTimeout(() => { proc.kill(); reject(new Error("Server startup timeout")); }, 15000);
+      proc.stderr!.on("data", (data: Buffer) => {
+        const match = data.toString().match(/running on http:\/\/localhost:(\d+)/);
+        if (match) {
+          serverPort = parseInt(match[1], 10);
+          clearTimeout(timeout);
+          resolve(proc);
+        }
+      });
+      proc.on("error", (err) => { clearTimeout(timeout); reject(err); });
+    });
+  });
+
+  after(() => {
+    serverProc?.kill();
+  });
+
+  function sendMcpRequest(proc: ChildProcess, request: object, responseId: number): Promise<any> {
+    return new Promise((resolve, reject) => {
+      const timeout = setTimeout(() => reject(new Error("MCP request timeout")), 15000);
+      let buffer = "";
+      const onData = (data: Buffer) => {
+        buffer += data.toString();
+        const lines = buffer.split("\n");
+        for (let i = 0; i < lines.length - 1; i++) {
+          const line = lines[i].trim();
+          if (!line) continue;
+          try {
+            const parsed = JSON.parse(line);
+            if (parsed.id === responseId) {
+              clearTimeout(timeout);
+              proc.stdout!.off("data", onData);
+              resolve(parsed);
+              return;
+            }
+          } catch {
+            // not valid JSON yet
+          }
+        }
+        buffer = lines[lines.length - 1];
+      };
+      proc.stdout!.on("data", onData);
+      proc.stdin!.write(JSON.stringify(request) + "\n");
+    });
+  }
+
+  async function initAndCall(toolName: string, toolArgs: object): Promise<any> {
+    const serverBin = path.join(__dirname, "..", "dist", "index.js");
+    const proc = spawn("node", [serverBin], {
+      stdio: ["pipe", "pipe", "pipe"],
+      env: { ...process.env, AGENTDEALS_API_URL: `http://localhost:${serverPort}` },
+    });
+    try {
+      await sendMcpRequest(proc, {
+        jsonrpc: "2.0", id: 1, method: "initialize",
+        params: { protocolVersion: "2024-11-05", capabilities: {}, clientInfo: { name: "test", version: "1.0.0" } },
+      }, 1);
+      proc.stdin!.write(JSON.stringify({ jsonrpc: "2.0", method: "notifications/initialized" }) + "\n");
+      const resp = await sendMcpRequest(proc, {
+        jsonrpc: "2.0", id: 2, method: "tools/call",
+        params: { name: toolName, arguments: toolArgs },
+      }, 2);
+      const text = resp.result?.content?.[0]?.text;
+      assert.ok(text, `Expected content text in ${toolName} response`);
+      return JSON.parse(text);
+    } finally {
+      proc.kill();
+    }
+  }
+
+  it("search_deals results include referral_code field on each result", async () => {
+    const body = await initAndCall("search_deals", { limit: 20 });
+    assert.ok(Array.isArray(body.results));
+    for (const result of body.results) {
+      assert.ok("referral_code" in result, `Missing referral_code on result for ${result.vendor}`);
+    }
+  });
+
+  it("search_deals for Railway returns platform referral_code inline", async () => {
+    const body = await initAndCall("search_deals", { query: "Railway", limit: 10 });
+    const railway = body.results.find((r: any) => r.vendor.toLowerCase() === "railway");
+    assert.ok(railway, "Railway result should be present");
+    assert.ok(railway.referral_code, "Railway referral_code should not be null");
+    assert.strictEqual(railway.referral_code.source, "platform");
+    assert.ok(railway.referral_code.code);
+    assert.ok(railway.referral_code.referral_url);
+    assert.ok(railway.referral_code.referee_benefit);
+  });
+
+  it("compare_vendors single-vendor mode includes referral_code for Railway", async () => {
+    const body = await initAndCall("compare_vendors", { vendors: ["Railway"] });
+    assert.ok("referral_code" in body, "Single-vendor response missing referral_code field");
+    assert.ok(body.referral_code, "Railway referral_code should not be null");
+    assert.strictEqual(body.referral_code.source, "platform");
+  });
+
+  it("compare_vendors two-vendor mode includes referral_codes map with explicit null for vendors without codes", async () => {
+    const body = await initAndCall("compare_vendors", { vendors: ["Railway", "Vercel"] });
+    assert.ok(body.referral_codes, "Two-vendor response should have referral_codes map");
+    // The map key uses the canonical vendor name from the store, which may differ in case from user input.
+    const keys = Object.keys(body.referral_codes);
+    const railwayKey = keys.find(k => k.toLowerCase() === "railway");
+    const vercelKey = keys.find(k => k.toLowerCase() === "vercel");
+    assert.ok(railwayKey, "Railway key should be present");
+    assert.ok(vercelKey, "Vercel key should be present (explicit null if no code)");
+    assert.ok(body.referral_codes[railwayKey!]);
+    assert.strictEqual(body.referral_codes[railwayKey!].source, "platform");
+  });
+});
+
+describe("REST /api/offers referral_code enrichment", () => {
+  let serverPort = 0;
+  let serverProc: ChildProcess;
+
+  before(async () => {
+    serverProc = await new Promise<ChildProcess>((resolve, reject) => {
+      const serverPath = path.join(__dirname, "..", "dist", "serve.js");
+      const proc = spawn("node", [serverPath], {
+        stdio: ["pipe", "pipe", "pipe"],
+        env: { ...process.env, PORT: "0", BASE_URL: "http://localhost" },
+      });
+      const timeout = setTimeout(() => { proc.kill(); reject(new Error("Server startup timeout")); }, 15000);
+      proc.stderr!.on("data", (data: Buffer) => {
+        const match = data.toString().match(/running on http:\/\/localhost:(\d+)/);
+        if (match) {
+          serverPort = parseInt(match[1], 10);
+          clearTimeout(timeout);
+          resolve(proc);
+        }
+      });
+      proc.on("error", (err) => { clearTimeout(timeout); reject(err); });
+    });
+  });
+
+  after(() => {
+    serverProc?.kill();
+  });
+
+  it("every offer in /api/offers includes an explicit referral_code field (null when no code)", async () => {
+    const res = await fetch(`http://localhost:${serverPort}/api/offers?limit=20`);
+    assert.strictEqual(res.status, 200);
+    const body = await res.json() as { offers: Array<{ vendor: string; referral_code: unknown }> };
+    assert.ok(body.offers.length > 0, "Should have some offers");
+    for (const offer of body.offers) {
+      assert.ok("referral_code" in offer, `Offer for ${offer.vendor} missing referral_code field`);
+      // either null or matching shape
+      if (offer.referral_code !== null) {
+        const rc = offer.referral_code as Record<string, unknown>;
+        assert.ok(rc.code, "referral_code.code should be present");
+        assert.ok(rc.referral_url, "referral_code.referral_url should be present");
+        assert.ok(rc.referee_benefit, "referral_code.referee_benefit should be present");
+        assert.ok(rc.source === "platform" || rc.source === "agent-submitted", "referral_code.source should be platform or agent-submitted");
+      }
+    }
+  });
+
+  it("Railway offer in /api/offers includes platform referral_code inline", async () => {
+    const res = await fetch(`http://localhost:${serverPort}/api/offers?q=Railway&limit=20`);
+    assert.strictEqual(res.status, 200);
+    const body = await res.json() as { offers: Array<{ vendor: string; referral_code: { source?: string; code?: string } | null }> };
+    const railway = body.offers.find(o => o.vendor.toLowerCase() === "railway");
+    assert.ok(railway, "Railway offer should be present in search");
+    assert.ok(railway.referral_code, "Railway referral_code should not be null");
+    assert.strictEqual(railway.referral_code!.source, "platform");
+    assert.ok(railway.referral_code!.code);
+  });
+});


### PR DESCRIPTION
## Summary

- New `getBestReferralCode()` helper in `platform-codes.ts` that returns the best available code for a vendor (platform tier > agent-submitted), matching the existing `/api/referral-codes/:vendor` response shape.
- `search_deals` MCP tool (both `server.ts` for in-process HTTP MCP and indirectly `server-remote.ts` via the REST proxy) now includes `referral_code` on every result — an object when a code exists, explicit `null` when none, so agents can check without a second API call.
- `compare_vendors` single-vendor mode includes `referral_code`; two-vendor mode includes a `referral_codes` map keyed by canonical vendor name.
- REST API parity: `/api/offers`, `/api/compare`, `/api/vendor-risk/:vendor`, `/api/details/:vendor`, and `/api/newest` all emit `referral_code` inline. Since the stdio MCP (`server-remote.ts`) is a proxy to these endpoints, it picks up the enrichment automatically.
- DRYs up `/api/referral-codes/:vendor` to use the new helper.
- 10 new tests: helper unit tests, REST endpoint tests, and full MCP-over-stdio tests using a local REST server (via `AGENTDEALS_API_URL`).

Performance: `O(1)` platform lookup (in-memory Map), agent-submitted codes already cached.

Refs #846

## Test plan

- [x] `npm test` — all 978 tests pass (+10 new)
- [x] `npm run lint` — TypeScript check clean
- [x] E2E verified via `curl` against `/api/offers`, `/api/compare`, `/api/vendor-risk`, `/api/referral-codes/:vendor` — all return correct shape with platform code for Railway, `null` for Vercel
- [x] E2E verified via MCP stdio `tools/call` for `search_deals` and `compare_vendors` pointing at local REST — Railway returns full referral_code, Vercel returns explicit null

🤖 Generated with [Claude Code](https://claude.com/claude-code)