### PR TITLE
Bump hono to 4.12.14 to resolve moderate audit advisory

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1217,9 +1217,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.12",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.12.tgz",
-      "integrity": "sha512-p1JfQMKaceuCbpJKAPKVqyqviZdS0eUxH9v82oWo1kb9xjQ5wA6iP3FNVAPDFlz5/p7d45lO+BpSk1tuSZMF4Q==",
+      "version": "4.12.14",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.14.tgz",
+      "integrity": "sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"


### PR DESCRIPTION
## Summary

- \`npm audit fix\` bumped hono 4.12.12 → 4.12.14 to clear GHSA-458j-xx4x-4375 (HTML injection via JSX attribute names in SSR)
- We don't use hono JSX SSR, so this is precautionary, but closes the advisory
- Only remaining vulns are low-severity in the dev-only \`tmp\` / \`@anthropic-ai/mcpb\` chain with no upstream fix, as noted in the issue

Refs #847

## Test plan

- [x] \`npm test\` — all 978 tests pass
- [x] \`npm audit\` — 0 moderate or higher vulnerabilities (5 low remain in tmp chain)

🤖 Generated with [Claude Code](https://claude.com/claude-code)