### PR TITLE
Fix /changes count consistency — show all-time and 30-day counts (#850)

### DIFF
--- a/src/serve.ts
+++ b/src/serve.ts
@@ -49406,6 +49406,8 @@ ${entries}
 function buildChangesPage(): string {
   const allChanges = loadDealChanges();
   const today = new Date().toISOString().slice(0, 10);
+  const thirtyDaysAgo = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000).toISOString().slice(0, 10);
+  const last30DaysCount = allChanges.filter(c => c.date >= thirtyDaysAgo).length;
 
   // Sort all changes reverse chronological
   const sorted = [...allChanges].sort((a, b) => b.date.localeCompare(a.date));
@@ -49461,7 +49463,7 @@ ${entriesHtml}
   }).join("\n");
 
   const title = "Deal Change Timeline \u2014 AgentDeals";
-  const metaDesc = `${allChanges.length} developer infrastructure pricing changes tracked. Free tier removals, price increases, product shutdowns, and new deals.`;
+  const metaDesc = `${allChanges.length} developer infrastructure pricing changes tracked since launch \u2014 ${last30DaysCount} in the last 30 days. Free tier removals, price increases, product shutdowns, and new deals.`;
 
   const jsonLd = {
     "@context": "https://schema.org",
@@ -49554,7 +49556,11 @@ ${globalNavCss()}
   <div class="stats-bar">
     <div class="stat-card">
       <div class="stat-value">${allChanges.length}</div>
-      <div class="stat-label">Total Changes</div>
+      <div class="stat-label">Total (All Time)</div>
+    </div>
+    <div class="stat-card">
+      <div class="stat-value">${last30DaysCount}</div>
+      <div class="stat-label">Last 30 Days</div>
     </div>
     <div class="stat-card">
       <div class="stat-value">${upcomingCount}</div>
@@ -53278,9 +53284,10 @@ const httpServer = createHttpServer(async (req, res) => {
       res.end(JSON.stringify(result));
     } else {
       const result = getDealChanges(since, type, vendorFilter, vendorsFilter, categoriesFilter);
+      const allTimeTotal = loadDealChanges().length;
       logRequest({ ts: new Date().toISOString(), type: "api", endpoint: "/api/changes", params: { since, type, vendor: vendorFilter, vendors: vendorsFilter }, user_agent: req.headers["user-agent"] ?? "unknown", result_count: result.changes.length });
       res.writeHead(200, { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" });
-      res.end(JSON.stringify(result));
+      res.end(JSON.stringify({ ...result, all_time_total: allTimeTotal }));
     }
   } else if (url.pathname === "/api/deadlines" && isGetOrHead) {
     recordApiHit("/api/deadlines");

--- a/test/http.test.ts
+++ b/test/http.test.ts
@@ -697,6 +697,19 @@ describe("HTTP transport", () => {
     assert.strictEqual(body.changes.length, body.total);
   });
 
+  it("GET /api/changes includes all_time_total alongside 30-day total", async () => {
+    proc = await startHttpServer();
+
+    const response = await fetch(`http://localhost:${serverPort}/api/changes`);
+    const body = await response.json() as any;
+    assert.ok(typeof body.all_time_total === "number", "Expected all_time_total field");
+    assert.ok(body.all_time_total >= body.total, "all_time_total should be >= 30-day total");
+    // Sanity: all_time_total should match unfiltered history
+    const allResp = await fetch(`http://localhost:${serverPort}/api/changes?since=2000-01-01`);
+    const allBody = await allResp.json() as any;
+    assert.strictEqual(body.all_time_total, allBody.total, "all_time_total should match since=2000 total");
+  });
+
   it("GET /api/changes filters by since, type, and vendor", async () => {
     proc = await startHttpServer();
 
@@ -1625,6 +1638,9 @@ describe("HTTP transport", () => {
     assert.ok(html.includes("global-nav"), "Should have global nav");
     assert.ok(html.includes("feed.xml"), "Should link to RSS feed");
     assert.ok(!html.includes("${BASE_URL}"), "Should not have unresolved BASE_URL");
+    assert.ok(html.includes("Total (All Time)"), "Should show all-time stat label");
+    assert.ok(html.includes("Last 30 Days"), "Should show 30-day stat label");
+    assert.ok(/tracked since launch.*in the last 30 days/.test(html), "Meta description should cite both all-time and 30-day counts");
   });
 
   it("GET /pricing-changes renders pricing changelog page with filters and anchors", async () => {


### PR DESCRIPTION
## Summary

- /changes page now shows both **267 all-time** and **202 in the last 30 days** counts prominently (two stat cards + meta description).
- `/api/changes` (no params) adds `all_time_total` alongside the existing 30-day `total`, so consumers can surface both figures without a second call.
- JSON-LD `ItemList.numberOfItems` unchanged (still all-time). No breaking changes to existing response fields.
- Motivated by the dev.to article published today ("We Tracked 202 Developer Tool Pricing Changes in 2026") whose canonical is `/changes` — readers who click through now see coherent numbers.

## Changes

- `src/serve.ts`:
  - `buildChangesPage()` computes `last30DaysCount` using the same filter as `getDealChanges()` default (202 matches API `total`).
  - Meta description updated to cite both figures.
  - Stats bar: new "Last 30 Days" card; "Total Changes" relabeled "Total (All Time)".
- `src/serve.ts` `/api/changes` handler: unfiltered (non-personalized) response spreads `all_time_total: loadDealChanges().length` alongside `result`.

## Test plan

- [x] All 980 tests pass (1 new: `/api/changes includes all_time_total alongside 30-day total`; 3 new assertions in existing `/changes` render test).
- [x] E2E verified against running server: `/api/changes` returns `total: 202, all_time_total: 267`; `/changes` meta description reads "267 ... tracked since launch — 202 in the last 30 days."

Refs #850