### PR TITLE
Add GET /api/referral-codes listing endpoint + /developers docs (#854)

### DIFF
--- a/src/openapi.ts
+++ b/src/openapi.ts
@@ -743,6 +743,64 @@ export const openapiSpec = {
         }
       }
     },
+    "/api/referral-codes": {
+      get: {
+        summary: "List all active referral codes (marketplace)",
+        description: "Returns all active referral codes across vendors — both platform codes (ours) and agent-submitted marketplace codes. No authentication required. Filter by source or vendor category. Individual vendor lookup: GET /api/referral-codes/{vendor}.",
+        parameters: [
+          { name: "source", in: "query", description: "Filter by source: platform (our codes) or agent (agent-submitted marketplace codes). Omit to get both.", schema: { type: "string", enum: ["platform", "agent"] } },
+          { name: "category", in: "query", description: "Filter by vendor category slug (e.g. cloud-hosting). See /api/categories for valid slugs.", schema: { type: "string" }, example: "cloud-hosting" }
+        ],
+        responses: {
+          "200": {
+            description: "Active referral codes across all vendors",
+            content: {
+              "application/json": {
+                schema: {
+                  type: "object",
+                  properties: {
+                    codes: { type: "array", items: { $ref: "#/components/schemas/ReferralCodeListing" } },
+                    total: { type: "integer" }
+                  },
+                  required: ["codes", "total"]
+                },
+                example: {
+                  codes: [
+                    { vendor: "Railway", category: "Cloud Hosting", code: "7RZL9q", referral_url: "https://railway.com?referralCode=7RZL9q", referee_benefit: "$20 in credits", source: "platform" }
+                  ],
+                  total: 1
+                }
+              }
+            }
+          },
+          "400": {
+            description: "Invalid source or unknown category slug",
+            content: { "application/json": { schema: { type: "object", properties: { error: { type: "string" } } } } }
+          }
+        }
+      }
+    },
+    "/api/referral-codes/{vendor}": {
+      get: {
+        summary: "Get best referral code for a vendor",
+        description: "Returns the best available referral code for a vendor. Platform codes (ours) take priority over agent-submitted marketplace codes. Same shape is inlined on /api/offers, /api/compare, /api/details/{vendor}, /api/newest, and MCP tool responses.",
+        parameters: [
+          { name: "vendor", in: "path", required: true, description: "Vendor name (case-insensitive)", schema: { type: "string" }, example: "Railway" }
+        ],
+        responses: {
+          "200": {
+            description: "Best available referral code",
+            content: {
+              "application/json": {
+                schema: { $ref: "#/components/schemas/ReferralCodeListing" },
+                example: { vendor: "Railway", code: "7RZL9q", referral_url: "https://railway.com?referralCode=7RZL9q", referee_benefit: "$20 in credits", source: "platform" }
+              }
+            }
+          },
+          "404": { description: "No active referral codes for the requested vendor", content: { "application/json": { schema: { type: "object", properties: { error: { type: "string" } } } } } }
+        }
+      }
+    },
     "/api/stats": {
       get: {
         summary: "Service statistics",
@@ -796,6 +854,18 @@ export const openapiSpec = {
           program: { type: "string" }
         },
         required: ["type", "conditions"]
+      },
+      ReferralCodeListing: {
+        type: "object",
+        properties: {
+          vendor: { type: "string", description: "Vendor/service name" },
+          category: { type: "string", nullable: true, description: "Primary category for the vendor (null if unknown)" },
+          code: { type: "string", description: "The referral code string" },
+          referral_url: { type: "string", format: "uri", description: "Full referral URL the referee should visit" },
+          referee_benefit: { type: "string", description: "What the person using the code gets (e.g. '$20 in credits')" },
+          source: { type: "string", enum: ["platform", "agent-submitted"], description: "platform = AgentDeals-owned code, agent-submitted = marketplace-submitted code" }
+        },
+        required: ["vendor", "code", "referral_url", "referee_benefit", "source"]
       },
       DealChange: {
         type: "object",

--- a/src/platform-codes.ts
+++ b/src/platform-codes.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { getRankedCodesForVendor } from "./referral-codes.js";
+import { getRankedCodesForVendor, getAllActiveCodes } from "./referral-codes.js";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const PLATFORM_CODES_PATH = path.join(__dirname, "..", "data", "platform_codes.json");
@@ -99,4 +99,57 @@ export function getBestReferralCode(vendorName: string): BestReferralCode | null
   }
 
   return null;
+}
+
+/**
+ * List all active referral codes across all vendors, for the GET /api/referral-codes listing endpoint.
+ * Includes both platform codes (ours) and active agent-submitted codes.
+ * Callers can pass a `vendorToCategory` resolver to enrich each entry with its primary category.
+ */
+export interface ListedReferralCode {
+  vendor: string;
+  category: string | null;
+  code: string;
+  referral_url: string;
+  referee_benefit: string;
+  source: "platform" | "agent-submitted";
+}
+
+export function listAllReferralCodes(opts: {
+  source?: "platform" | "agent" | "agent-submitted";
+  vendorToCategory?: (vendorName: string) => string | null;
+} = {}): ListedReferralCode[] {
+  const resolveCategory = opts.vendorToCategory ?? (() => null);
+  const wantPlatform = opts.source === undefined || opts.source === "platform";
+  const wantAgent = opts.source === undefined || opts.source === "agent" || opts.source === "agent-submitted";
+
+  const out: ListedReferralCode[] = [];
+
+  if (wantPlatform) {
+    for (const c of getAllPlatformCodes()) {
+      out.push({
+        vendor: c.vendor,
+        category: resolveCategory(c.vendor),
+        code: c.code,
+        referral_url: c.referral_url,
+        referee_benefit: c.referee_benefit,
+        source: "platform",
+      });
+    }
+  }
+
+  if (wantAgent) {
+    for (const c of getAllActiveCodes()) {
+      out.push({
+        vendor: c.vendor,
+        category: resolveCategory(c.vendor),
+        code: c.code,
+        referral_url: c.referral_url,
+        referee_benefit: c.description,
+        source: "agent-submitted",
+      });
+    }
+  }
+
+  return out;
 }

--- a/src/serve.ts
+++ b/src/serve.ts
@@ -15,7 +15,7 @@ import { logReferralRequest } from "./referral-requests.js";
 import { recordConversion, confirmEligibleEntries, clawbackEntry, getAgentBalance, getAgentLedgerEntries, recordPayout, MINIMUM_PAYOUT_AMOUNT, getLeaderboard } from "./ledger.js";
 import { validateX402Address, executeTransfer, generateCorrelationId } from "./x402.js";
 import { submitReferralCode, getCodesByAgent, getCodeById, updateCode, revokeCode, calculateTrustTier, getDailySubmissionCount, getDailyLimit, getRankedCodesForVendor, calculateCodeScore } from "./referral-codes.js";
-import { getPlatformCodeForVendor, getBestReferralCode } from "./platform-codes.js";
+import { getPlatformCodeForVendor, getBestReferralCode, listAllReferralCodes } from "./platform-codes.js";
 import { runHealthCheck, getLastReport, startPeriodicChecks } from "./referral-health.js";
 import { addFriend, removeFriend, getFriends, getFriendCodesForVendors } from "./friends.js";
 import { subscribe as watchlistSubscribe, getSubscription as getWatchlistSubscription, unsubscribe as watchlistUnsubscribe, listSubscriptions as listWatchlistSubscriptions } from "./watchlist.js";
@@ -420,6 +420,19 @@ for (const o of offers) {
   if (!prev || o.verifiedDate > prev) {
     categoryLastmod.set(catSlug, o.verifiedDate);
   }
+}
+
+// Build vendor name → primary category (first offer's category wins)
+const vendorCategoryMap = new Map<string, string>();
+for (const o of offers) {
+  const key = o.vendor.toLowerCase();
+  if (!vendorCategoryMap.has(key)) {
+    vendorCategoryMap.set(key, o.category);
+  }
+}
+
+function getVendorCategory(vendorName: string): string | null {
+  return vendorCategoryMap.get(vendorName.toLowerCase()) ?? null;
 }
 
 function escHtmlServer(s: string): string {
@@ -48664,6 +48677,27 @@ function buildDeveloperHubPage(): string {
     { method: "DELETE", path: "/api/watchlist/:id", desc: "Unsubscribe from vendor watch", params: "" },
   ];
 
+  const referralEndpointTable = [
+    { method: "GET", path: "/api/referral-codes", desc: "List all active referral codes (platform + marketplace)", params: "source (platform|agent), category" },
+    { method: "GET", path: "/api/referral-codes/:vendor", desc: "Get best referral code for a specific vendor", params: "" },
+    { method: "POST", path: "/api/referral-codes", desc: "Submit a marketplace referral code (agents only, auth required)", params: "vendor, code, referral_url (body) — Authorization: Bearer <api-key>" },
+  ];
+
+  const referralEndpointRows = referralEndpointTable.map(function(e) {
+    const sampleHref = e.method === "GET"
+      ? BASE_URL + e.path.replace(/:vendor/, "railway")
+      : BASE_URL + e.path;
+    const cell = e.method === "GET"
+      ? "<a href=\"" + sampleHref + "\">" + escHtmlServer(e.path) + "</a>"
+      : "<code>" + escHtmlServer(e.path) + "</code>";
+    return "      <tr>"
+      + "<td><code>" + e.method + "</code></td>"
+      + "<td>" + cell + "</td>"
+      + "<td>" + escHtmlServer(e.desc) + "</td>"
+      + "<td>" + (e.params ? "<code>" + escHtmlServer(e.params) + "</code>" : "&mdash;") + "</td>"
+      + "</tr>";
+  }).join("\n");
+
   const endpointRows = endpointTable.map(function(e) {
     return "      <tr>"
       + "<td><code>" + e.method + "</code></td>"
@@ -48691,16 +48725,23 @@ function buildDeveloperHubPage(): string {
       "@context": "https://schema.org",
       "@type": "WebAPI",
       "name": "AgentDeals REST API",
-      "description": "Free REST API providing developer tool pricing data — " + offers.length + "+ deals across " + categories.length + " categories. No authentication required.",
+      "description": "Free REST API providing developer tool pricing data — " + offers.length + "+ deals across " + categories.length + " categories, plus a referral code marketplace. No authentication required for read endpoints.",
       "url": BASE_URL + "/developers",
       "documentation": BASE_URL + "/api/docs",
       "provider": { "@type": "Organization", "name": "AgentDeals", "url": BASE_URL },
       "termsOfService": BASE_URL + "/privacy",
-      "availableChannel": {
-        "@type": "ServiceChannel",
-        "serviceUrl": BASE_URL + "/api/offers",
-        "serviceType": "REST API"
-      }
+      "availableChannel": [
+        {
+          "@type": "ServiceChannel",
+          "serviceUrl": BASE_URL + "/api/offers",
+          "serviceType": "REST API — Offers & Pricing"
+        },
+        {
+          "@type": "ServiceChannel",
+          "serviceUrl": BASE_URL + "/api/referral-codes",
+          "serviceType": "REST API — Referral Code Marketplace"
+        }
+      ]
     }) + "</script>\n"
     + "  <style>\n"
     + "    :root{--bg:#0f172a;--bg-elevated:#1e293b;--bg-card:rgba(255,255,255,0.06);--text:#f1f5f9;--text-muted:#94a3b8;--text-dim:#64748b;--accent:#3b82f6;--accent-glow:rgba(59,130,246,.1);--border:rgba(148,163,184,.15);--serif:\"Georgia\",\"Times New Roman\",serif;--sans:-apple-system,BlinkMacSystemFont,\"Segoe UI\",Roboto,sans-serif;--mono:\"SFMono-Regular\",Consolas,\"Liberation Mono\",monospace}\n"
@@ -48767,7 +48808,7 @@ function buildDeveloperHubPage(): string {
     + "      <div class=\"highlight-card\"><div class=\"num\">" + offers.length.toLocaleString() + "+</div><div class=\"label\">Verified Deals</div></div>\n"
     + "      <div class=\"highlight-card\"><div class=\"num\">" + categories.length + "</div><div class=\"label\">Categories</div></div>\n"
     + "      <div class=\"highlight-card\"><div class=\"num\">" + dealChanges.length + "</div><div class=\"label\">Tracked Price Changes</div></div>\n"
-    + "      <div class=\"highlight-card\"><div class=\"num\">" + endpointTable.length + "</div><div class=\"label\">Endpoints</div></div>\n"
+    + "      <div class=\"highlight-card\"><div class=\"num\">" + (endpointTable.length + referralEndpointTable.length) + "</div><div class=\"label\">Endpoints</div></div>\n"
     + "    </div>\n"
     + "\n"
     + "    <h2>Quick Start</h2>\n"
@@ -48856,6 +48897,45 @@ function buildDeveloperHubPage(): string {
     + "    </div>\n"
     + "    <p style=\"margin-top:.75rem\">Full OpenAPI 3.0 spec: <a href=\"" + BASE_URL + "/api/openapi.json\">/api/openapi.json</a> &middot; Interactive docs: <a href=\"/api/docs\">Swagger UI</a></p>\n"
     + "\n"
+    + "    <h2 id=\"referral-marketplace\">Referral Marketplace</h2>\n"
+    + "    <p>AgentDeals operates a referral code marketplace so agents can discover and earn on vendor referrals. <strong>Platform codes</strong> (ours) take priority over <strong>agent-submitted codes</strong> (community) in every response. The <a href=\"/marketplace\">marketplace HTML page</a> has a human-readable overview; the endpoints below expose the same data to agents.</p>\n"
+    + "    <div style=\"overflow-x:auto\">\n"
+    + "    <table class=\"endpoint-table\">\n"
+    + "      <thead><tr><th>Method</th><th>Endpoint</th><th>Description</th><th>Parameters</th></tr></thead>\n"
+    + "      <tbody>\n"
+    + referralEndpointRows + "\n"
+    + "      </tbody>\n"
+    + "    </table>\n"
+    + "    </div>\n"
+    + "    <p>Referral codes are also inlined on every <code>/api/offers</code>, <code>/api/compare</code>, <code>/api/details/:vendor</code>, and <code>/api/newest</code> result as a <code>referral_code</code> field (null if no code available) — so agents get codes without a second call.</p>\n"
+    + "\n"
+    + "    <h3>List all active codes</h3>\n"
+    + "    <div class=\"code-block\"><span class=\"lang-label\">bash</span><button class=\"copy-btn\" onclick=\"copyBlock(this)\">Copy</button>curl \"" + BASE_URL + "/api/referral-codes\"</div>\n"
+    + "\n"
+    + "    <h3>Filter by source (platform-owned codes only)</h3>\n"
+    + "    <div class=\"code-block\"><span class=\"lang-label\">bash</span><button class=\"copy-btn\" onclick=\"copyBlock(this)\">Copy</button>curl \"" + BASE_URL + "/api/referral-codes?source=platform\"</div>\n"
+    + "\n"
+    + "    <h3>Filter by vendor category</h3>\n"
+    + "    <div class=\"code-block\"><span class=\"lang-label\">bash</span><button class=\"copy-btn\" onclick=\"copyBlock(this)\">Copy</button>curl \"" + BASE_URL + "/api/referral-codes?category=cloud-hosting\"</div>\n"
+    + "\n"
+    + "    <h3>Look up a single vendor</h3>\n"
+    + "    <div class=\"code-block\"><span class=\"lang-label\">bash</span><button class=\"copy-btn\" onclick=\"copyBlock(this)\">Copy</button>curl \"" + BASE_URL + "/api/referral-codes/railway\"</div>\n"
+    + "\n"
+    + "    <h3>Python</h3>\n"
+    + "    <div class=\"code-block\"><span class=\"lang-label\">python</span><button class=\"copy-btn\" onclick=\"copyBlock(this)\">Copy</button>"
+    + "import requests\n"
+    + "\n"
+    + "resp = requests.get(\"" + BASE_URL + "/api/referral-codes\", params={\"source\": \"platform\"})\n"
+    + "for c in resp.json()[\"codes\"]:\n"
+    + "    print(f\"{c['vendor']} ({c['category']}): {c['referee_benefit']} \u2192 {c['referral_url']}\")</div>\n"
+    + "\n"
+    + "    <h3>JavaScript</h3>\n"
+    + "    <div class=\"code-block\"><span class=\"lang-label\">javascript</span><button class=\"copy-btn\" onclick=\"copyBlock(this)\">Copy</button>"
+    + "const resp = await fetch(\"" + BASE_URL + "/api/referral-codes?source=platform\");\n"
+    + "const { codes } = await resp.json();\n"
+    + "\n"
+    + "codes.forEach(c =&gt; console.log(`${c.vendor} (${c.category}): ${c.referee_benefit}`));</div>\n"
+    + "\n"
     + "    <h2>Use Cases</h2>\n"
     + "    <div class=\"use-case\">\n"
     + "      <h4>CI/CD Cost Optimization</h4>\n"
@@ -48876,6 +48956,10 @@ function buildDeveloperHubPage(): string {
     + "    <div class=\"use-case\">\n"
     + "      <h4>Migration Planning</h4>\n"
     + "      <p>When a vendor shuts down or changes pricing, use <code>/api/offers</code> + <code>/api/compare</code> to evaluate alternatives with real free tier data. See our <a href=\"/firebase-studio-shutdown\">Firebase Studio migration guide</a> for an example of how we use this data to compare cloud IDE alternatives.</p>\n"
+    + "    </div>\n"
+    + "    <div class=\"use-case\">\n"
+    + "      <h4>Referral-Aware Agents</h4>\n"
+    + "      <p>Agents that recommend developer tools can route users through active referral codes. Call <code>/api/referral-codes?source=platform</code> once at session start to prefetch all our codes, or rely on the inline <code>referral_code</code> field on every <code>/api/offers</code> result. See <a href=\"/marketplace\">the marketplace</a> for the revenue model.</p>\n"
     + "    </div>\n"
     + "    <div class=\"use-case\">\n"
     + "      <h4>AI Coding Tools Research</h4>\n"
@@ -55282,6 +55366,38 @@ ${catList}
       res.writeHead(500, { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" });
       res.end(JSON.stringify({ error: err.message, correlation_id: correlationId }));
     }
+
+  // --- GET /api/referral-codes: List all active referral codes (platform + agent-submitted) ---
+  } else if (url.pathname === "/api/referral-codes" && isGetOrHead) {
+    const rawSource = url.searchParams.get("source");
+    let sourceFilter: "platform" | "agent" | undefined;
+    if (rawSource === "platform" || rawSource === "agent" || rawSource === "agent-submitted") {
+      sourceFilter = rawSource === "agent-submitted" ? "agent" : rawSource;
+    } else if (rawSource !== null && rawSource !== "") {
+      res.writeHead(400, { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" });
+      res.end(JSON.stringify({ error: 'Invalid source filter. Use source=platform or source=agent.' }));
+      return;
+    }
+
+    const categorySlug = url.searchParams.get("category");
+    let categoryName: string | null = null;
+    if (categorySlug) {
+      const resolved = categorySlugMap.get(toSlug(categorySlug));
+      if (!resolved) {
+        res.writeHead(400, { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" });
+        res.end(JSON.stringify({ error: `Unknown category "${categorySlug}". See /api/categories for valid slugs.` }));
+        return;
+      }
+      categoryName = resolved;
+    }
+
+    const listed = listAllReferralCodes({ source: sourceFilter, vendorToCategory: getVendorCategory });
+    const filtered = categoryName ? listed.filter(c => c.category === categoryName) : listed;
+
+    recordApiHit("/api/referral-codes");
+    logRequest({ ts: new Date().toISOString(), type: "api", endpoint: "GET /api/referral-codes", params: { source: sourceFilter ?? "all", category: categoryName ?? "all" }, user_agent: req.headers["user-agent"] ?? "unknown", result_count: filtered.length });
+    res.writeHead(200, { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" });
+    res.end(JSON.stringify({ codes: filtered, total: filtered.length }));
 
   // --- POST /api/referral-codes: Submit a referral code ---
   } else if (url.pathname === "/api/referral-codes" && req.method === "POST") {

--- a/test/http.test.ts
+++ b/test/http.test.ts
@@ -930,7 +930,9 @@ describe("HTTP transport", () => {
     assert.ok(body.paths["/feed.xml"]);
     assert.ok(body.paths["/api/pageviews"]);
     assert.ok(body.paths["/api/freshness"]);
-    assert.strictEqual(Object.keys(body.paths).length, 18);
+    assert.ok(body.paths["/api/referral-codes"]);
+    assert.ok(body.paths["/api/referral-codes/{vendor}"]);
+    assert.strictEqual(Object.keys(body.paths).length, 20);
     assert.ok(body.components.schemas.Offer);
     assert.ok(body.components.schemas.DealChange);
     assert.ok(body.components.schemas.Eligibility);

--- a/test/referral-codes-listing.test.ts
+++ b/test/referral-codes-listing.test.ts
@@ -1,0 +1,289 @@
+import { describe, it, before, after } from "node:test";
+import assert from "node:assert";
+import { spawn, type ChildProcess } from "node:child_process";
+import path from "node:path";
+import fs from "node:fs";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const CODES_PATH = path.join(__dirname, "..", "data", "referral_codes.json");
+
+const { listAllReferralCodes, resetPlatformCodesCache } = await import("../dist/platform-codes.js");
+const { resetReferralCodesCache } = await import("../dist/referral-codes.js");
+
+describe("listAllReferralCodes() helper", () => {
+  let origCodes: string;
+
+  before(() => {
+    origCodes = fs.existsSync(CODES_PATH) ? fs.readFileSync(CODES_PATH, "utf-8") : "{\"referral_codes\":[]}";
+    fs.writeFileSync(CODES_PATH, JSON.stringify({
+      referral_codes: [
+        {
+          id: "code_test_active",
+          vendor: "Supabase",
+          code: "SUPATEST",
+          referral_url: "https://supabase.com/?ref=SUPATEST",
+          description: "Agent-submitted Supabase referral",
+          commission_rate: null,
+          expiry: null,
+          submitted_by: "agent_test",
+          source: "agent-submitted",
+          status: "active",
+          trust_tier_at_submission: "new",
+          impressions: 0,
+          clicks: 0,
+          conversions: 0,
+          submitted_at: "2026-04-16T00:00:00.000Z",
+          updated_at: "2026-04-16T00:00:00.000Z",
+        },
+        {
+          id: "code_test_pending",
+          vendor: "Vercel",
+          code: "VERCELPENDING",
+          referral_url: "https://vercel.com/?ref=VERCELPENDING",
+          description: "Pending — should not list",
+          commission_rate: null,
+          expiry: null,
+          submitted_by: "agent_test",
+          source: "agent-submitted",
+          status: "pending",
+          trust_tier_at_submission: "new",
+          impressions: 0,
+          clicks: 0,
+          conversions: 0,
+          submitted_at: "2026-04-16T00:00:00.000Z",
+          updated_at: "2026-04-16T00:00:00.000Z",
+        },
+      ],
+    }), "utf-8");
+    resetReferralCodesCache();
+    resetPlatformCodesCache();
+  });
+
+  after(() => {
+    fs.writeFileSync(CODES_PATH, origCodes, "utf-8");
+    resetReferralCodesCache();
+    resetPlatformCodesCache();
+  });
+
+  it("returns both platform and agent-submitted active codes when no source filter", () => {
+    const codes = listAllReferralCodes();
+    const platform = codes.filter((c: any) => c.source === "platform");
+    const agent = codes.filter((c: any) => c.source === "agent-submitted");
+    assert.ok(platform.length >= 1, "should include platform codes (Railway)");
+    assert.ok(agent.some((c: any) => c.code === "SUPATEST"), "should include active agent-submitted code");
+    assert.ok(!codes.some((c: any) => c.code === "VERCELPENDING"), "pending codes must not appear in listing");
+  });
+
+  it("source=platform filter returns only platform codes", () => {
+    const codes = listAllReferralCodes({ source: "platform" });
+    assert.ok(codes.length >= 1);
+    assert.ok(codes.every((c: any) => c.source === "platform"));
+  });
+
+  it("source=agent filter returns only agent-submitted codes", () => {
+    const codes = listAllReferralCodes({ source: "agent" });
+    assert.ok(codes.every((c: any) => c.source === "agent-submitted"));
+    assert.ok(codes.some((c: any) => c.code === "SUPATEST"));
+  });
+
+  it("resolves category via vendorToCategory callback", () => {
+    const codes = listAllReferralCodes({
+      vendorToCategory: (v: string) => v === "Railway" ? "Cloud Hosting" : null,
+    });
+    const railway = codes.find((c: any) => c.vendor === "Railway");
+    assert.ok(railway);
+    assert.strictEqual(railway.category, "Cloud Hosting");
+  });
+
+  it("returned entry shape matches GET /api/referral-codes/:vendor (plus category)", () => {
+    const codes = listAllReferralCodes();
+    const first = codes[0];
+    assert.ok("vendor" in first);
+    assert.ok("category" in first);
+    assert.ok("code" in first);
+    assert.ok("referral_url" in first);
+    assert.ok("referee_benefit" in first);
+    assert.ok("source" in first);
+  });
+});
+
+describe("GET /api/referral-codes listing endpoint", () => {
+  let serverPort = 0;
+  let serverProc: ChildProcess;
+
+  before(async () => {
+    serverProc = await new Promise<ChildProcess>((resolve, reject) => {
+      const serverPath = path.join(__dirname, "..", "dist", "serve.js");
+      const proc = spawn("node", [serverPath], {
+        stdio: ["pipe", "pipe", "pipe"],
+        env: { ...process.env, PORT: "0", BASE_URL: "http://localhost" },
+      });
+      const timeout = setTimeout(() => { proc.kill(); reject(new Error("Server startup timeout")); }, 15000);
+      proc.stderr!.on("data", (data: Buffer) => {
+        const match = data.toString().match(/running on http:\/\/localhost:(\d+)/);
+        if (match) {
+          serverPort = parseInt(match[1], 10);
+          clearTimeout(timeout);
+          resolve(proc);
+        }
+      });
+      proc.on("error", (err) => { clearTimeout(timeout); reject(err); });
+    });
+  });
+
+  after(() => {
+    serverProc?.kill();
+  });
+
+  it("returns {codes, total} with at least the Railway platform code", async () => {
+    const res = await fetch(`http://localhost:${serverPort}/api/referral-codes`);
+    assert.strictEqual(res.status, 200);
+    const body = await res.json() as { codes: any[]; total: number };
+    assert.ok(Array.isArray(body.codes));
+    assert.strictEqual(typeof body.total, "number");
+    assert.strictEqual(body.total, body.codes.length);
+    const railway = body.codes.find(c => c.vendor === "Railway");
+    assert.ok(railway, "Railway should be listed");
+    assert.strictEqual(railway.source, "platform");
+    assert.strictEqual(railway.code, "7RZL9q");
+    assert.strictEqual(railway.category, "Cloud Hosting");
+    assert.ok(railway.referral_url.includes("7RZL9q"));
+  });
+
+  it("source=platform returns only platform codes", async () => {
+    const res = await fetch(`http://localhost:${serverPort}/api/referral-codes?source=platform`);
+    assert.strictEqual(res.status, 200);
+    const body = await res.json() as { codes: any[]; total: number };
+    assert.ok(body.codes.every(c => c.source === "platform"));
+    assert.ok(body.codes.length >= 1);
+  });
+
+  it("source=agent returns only agent-submitted codes", async () => {
+    const res = await fetch(`http://localhost:${serverPort}/api/referral-codes?source=agent`);
+    assert.strictEqual(res.status, 200);
+    const body = await res.json() as { codes: any[]; total: number };
+    assert.ok(body.codes.every(c => c.source === "agent-submitted"));
+  });
+
+  it("source=invalid returns 400", async () => {
+    const res = await fetch(`http://localhost:${serverPort}/api/referral-codes?source=garbage`);
+    assert.strictEqual(res.status, 400);
+    const body = await res.json() as { error: string };
+    assert.ok(body.error.toLowerCase().includes("source"));
+  });
+
+  it("category=cloud-hosting filters to Railway", async () => {
+    const res = await fetch(`http://localhost:${serverPort}/api/referral-codes?category=cloud-hosting`);
+    assert.strictEqual(res.status, 200);
+    const body = await res.json() as { codes: any[]; total: number };
+    assert.ok(body.codes.every(c => c.category === "Cloud Hosting"));
+    assert.ok(body.codes.some(c => c.vendor === "Railway"));
+  });
+
+  it("category=unknown-slug returns 400", async () => {
+    const res = await fetch(`http://localhost:${serverPort}/api/referral-codes?category=not-a-real-category-xyz`);
+    assert.strictEqual(res.status, 400);
+    const body = await res.json() as { error: string };
+    assert.ok(body.error.toLowerCase().includes("unknown category"));
+  });
+
+  it("does not collide with /api/referral-codes/mine route (which requires auth)", async () => {
+    const res = await fetch(`http://localhost:${serverPort}/api/referral-codes/mine`);
+    assert.strictEqual(res.status, 401, "mine route still requires auth");
+  });
+
+  it("does not collide with /api/referral-codes/:vendor route", async () => {
+    const res = await fetch(`http://localhost:${serverPort}/api/referral-codes/railway`);
+    assert.strictEqual(res.status, 200);
+    const body = await res.json() as { vendor: string; source: string };
+    assert.strictEqual(body.vendor, "Railway");
+    assert.strictEqual(body.source, "platform");
+  });
+});
+
+describe("/developers page", () => {
+  let serverPort = 0;
+  let serverProc: ChildProcess;
+
+  before(async () => {
+    serverProc = await new Promise<ChildProcess>((resolve, reject) => {
+      const serverPath = path.join(__dirname, "..", "dist", "serve.js");
+      const proc = spawn("node", [serverPath], {
+        stdio: ["pipe", "pipe", "pipe"],
+        env: { ...process.env, PORT: "0", BASE_URL: "http://localhost" },
+      });
+      const timeout = setTimeout(() => { proc.kill(); reject(new Error("Server startup timeout")); }, 15000);
+      proc.stderr!.on("data", (data: Buffer) => {
+        const match = data.toString().match(/running on http:\/\/localhost:(\d+)/);
+        if (match) {
+          serverPort = parseInt(match[1], 10);
+          clearTimeout(timeout);
+          resolve(proc);
+        }
+      });
+      proc.on("error", (err) => { clearTimeout(timeout); reject(err); });
+    });
+  });
+
+  after(() => {
+    serverProc?.kill();
+  });
+
+  it("includes the Referral Marketplace section with the three endpoints", async () => {
+    const res = await fetch(`http://localhost:${serverPort}/developers`);
+    assert.strictEqual(res.status, 200);
+    const html = await res.text();
+    assert.ok(html.includes("Referral Marketplace"), "missing Referral Marketplace heading");
+    assert.ok(html.includes("/api/referral-codes"), "missing /api/referral-codes endpoint");
+    assert.ok(html.includes("/api/referral-codes/:vendor") || html.includes("/api/referral-codes/railway"), "missing vendor endpoint");
+    assert.ok(html.includes("source=platform"), "missing source filter example");
+    assert.ok(html.includes("category=cloud-hosting"), "missing category filter example");
+  });
+
+  it("WebAPI JSON-LD advertises the referral-codes service URL", async () => {
+    const res = await fetch(`http://localhost:${serverPort}/developers`);
+    const html = await res.text();
+    assert.ok(html.includes("/api/referral-codes"), "JSON-LD must reference /api/referral-codes");
+    assert.ok(html.includes("Referral Code Marketplace"), "JSON-LD should describe the marketplace channel");
+  });
+});
+
+describe("OpenAPI spec", () => {
+  let serverPort = 0;
+  let serverProc: ChildProcess;
+
+  before(async () => {
+    serverProc = await new Promise<ChildProcess>((resolve, reject) => {
+      const serverPath = path.join(__dirname, "..", "dist", "serve.js");
+      const proc = spawn("node", [serverPath], {
+        stdio: ["pipe", "pipe", "pipe"],
+        env: { ...process.env, PORT: "0", BASE_URL: "http://localhost" },
+      });
+      const timeout = setTimeout(() => { proc.kill(); reject(new Error("Server startup timeout")); }, 15000);
+      proc.stderr!.on("data", (data: Buffer) => {
+        const match = data.toString().match(/running on http:\/\/localhost:(\d+)/);
+        if (match) {
+          serverPort = parseInt(match[1], 10);
+          clearTimeout(timeout);
+          resolve(proc);
+        }
+      });
+      proc.on("error", (err) => { clearTimeout(timeout); reject(err); });
+    });
+  });
+
+  after(() => {
+    serverProc?.kill();
+  });
+
+  it("/api/openapi.json documents /api/referral-codes and /api/referral-codes/{vendor}", async () => {
+    const res = await fetch(`http://localhost:${serverPort}/api/openapi.json`);
+    assert.strictEqual(res.status, 200);
+    const spec = await res.json() as any;
+    assert.ok(spec.paths["/api/referral-codes"], "missing /api/referral-codes path");
+    assert.ok(spec.paths["/api/referral-codes"].get, "listing endpoint should have GET");
+    assert.ok(spec.paths["/api/referral-codes/{vendor}"], "missing vendor path");
+    assert.ok(spec.components.schemas.ReferralCodeListing, "missing ReferralCodeListing schema");
+  });
+});


### PR DESCRIPTION
## Summary
Refs #854. Adds a canonical listing endpoint for the referral marketplace and exposes the referral endpoints in the public API docs so agents can discover them programmatically.

## Changes

- **New `GET /api/referral-codes`** — lists all active codes (platform + agent-submitted) with optional `source=platform|agent` and `category=<slug>` filters. Returns `{codes: [...], total}` where each entry matches the existing `/api/referral-codes/:vendor` shape plus a `category` field for client-side filtering.
- **`/developers` page** gets a new Referral Marketplace section with a dedicated endpoint table, curl/Python/JavaScript examples for the listing endpoint (default, by source, by category, per-vendor), and a use case card for referral-aware agents. Endpoint count badge updated (26 → 29).
- **OpenAPI 3.0 spec** (`/api/openapi.json` + Swagger UI) documents `/api/referral-codes` and `/api/referral-codes/{vendor}` with a new `ReferralCodeListing` schema.
- **WebAPI JSON-LD** on `/developers` now advertises the marketplace service URL as a second `availableChannel` alongside the offers channel.

## Implementation notes

- New helper `listAllReferralCodes({ source, vendorToCategory })` in `platform-codes.ts`. Pulls platform codes from `getAllPlatformCodes()` and active agent-submitted codes from `getAllActiveCodes()` (which already filters by `status === "active"` and handles expiry).
- Category filter uses the existing `categorySlugMap` built from the categories config, so callers pass slugs (e.g. `cloud-hosting`) and invalid slugs get a clear 400. Vendor→category resolution takes the first offer's category per vendor (~1,594 offers, deterministic).
- Router precedence: new `GET /api/referral-codes` route is inserted **before** `POST /api/referral-codes`, and the existing `/api/referral-codes/mine` and `/api/referral-codes/:vendor` regex routes stay correct (they require a non-empty trailing path segment).
- Decided not to auth-gate the listing endpoint — the issue explicitly puts auth out of scope and the rest of the read API is unauth.
- Kept the per-entry `category` as `null` for vendors without an offer rather than omitting the key, so the response shape is stable.

## Tests

- 13 new tests in `test/referral-codes-listing.test.ts`: helper unit tests, endpoint tests (default, source=platform, source=agent, invalid source → 400, category filter, unknown category → 400, no collision with `/mine` or `/:vendor`), /developers HTML content, JSON-LD channel, and OpenAPI spec.
- Bumped openapi path count assertion in `http.test.ts` (18 → 20) for the two new paths.
- **998 tests passing** (was 985, +13). No regressions.

## E2E verified

- `curl localhost/api/referral-codes` → returns Railway platform code with the expected shape.
- `curl localhost/api/referral-codes?source=platform` → same, filtered.
- `curl localhost/api/referral-codes?category=cloud-hosting` → same, filtered by category.
- `curl localhost/api/referral-codes?source=garbage` → 400 with clear error.
- `curl localhost/api/referral-codes/railway` → unchanged (per-vendor lookup still works).
- `/developers` HTML renders the new section with a 29-endpoint count badge.

## Test plan

- [x] Unit tests for `listAllReferralCodes` helper
- [x] HTTP tests for listing endpoint (filters + edge cases)
- [x] `/developers` page renders new section + JSON-LD channel
- [x] OpenAPI spec documents new paths + schema
- [x] Full test suite passes (998 tests)
- [x] E2E with real server