### PR TITLE
Add marketplace solicitation CTA on dormant vendor pages (#858)

### DIFF
--- a/src/serve.ts
+++ b/src/serve.ts
@@ -3467,6 +3467,19 @@ ${allCompareLinks.join("\n")}
     <p style="margin-top:.75rem;font-size:.8rem"><a href="/developer-hub">Watchlist API docs &rarr;</a></p>
   </div>`;
 
+  // Marketplace solicitation (low-pressure) — shown only when this vendor has no
+  // platform code, no documented program, and no offer-level referral. Converts
+  // dormant vendor pages into acquisition surfaces for code submitters.
+  const hasAnyReferralSurface = !!platformCode || primary.referral_program?.available === true || !!primary.referral;
+  const marketplaceSolicitationHtml = !hasAnyReferralSurface ? `
+  <div class="section marketplace-solicitation">
+    <div style="border:1px dashed var(--border);border-radius:8px;padding:1rem;background:var(--bg-card);opacity:.92">
+      <h3 style="margin:0 0 .5rem;font-size:.95rem;color:var(--text)">Know a referral or partner program for ${escHtmlServer(vendorName)}?</h3>
+      <p style="margin:0 0 .5rem;font-size:.85rem;color:var(--text-muted)">Submit a referral code via the <a href="/marketplace">Agent Marketplace</a> and earn revenue when agents use it (60% commission, paid via x402). Trust tiers and verification protect against abuse.</p>
+      <p style="margin:0;font-size:.75rem;color:var(--text-dim)">See our <a href="/disclosure">affiliate disclosure</a> for commission details.</p>
+    </div>
+  </div>` : "";
+
   // MCP snippet
   const mcpSnippet = `{
   "tool": "search_deals",
@@ -3707,6 +3720,7 @@ ${altPagesHtml}
 ${reportAppearancesHtml}
 ${referralProgramHtml}
 ${watchlistCtaHtml}
+${marketplaceSolicitationHtml}
 ${internalLinksHtml}
   <div class="section mcp-section">
     <h2>Query via MCP</h2>

--- a/test/vendor-marketplace-solicitation.test.ts
+++ b/test/vendor-marketplace-solicitation.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, before, after } from "node:test";
+import assert from "node:assert";
+import { spawn, type ChildProcess } from "node:child_process";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+let serverPort = 0;
+let serverProc: ChildProcess | null = null;
+
+function startServer(): Promise<ChildProcess> {
+  return new Promise((resolve, reject) => {
+    const serverPath = path.join(__dirname, "..", "dist", "serve.js");
+    const proc = spawn("node", [serverPath], {
+      stdio: ["pipe", "pipe", "pipe"],
+      env: { ...process.env, PORT: "0", BASE_URL: "http://localhost" },
+    });
+    const timeout = setTimeout(() => { proc.kill(); reject(new Error("Server startup timeout")); }, 10000);
+    proc.stderr!.on("data", (data: Buffer) => {
+      const match = data.toString().match(/running on http:\/\/localhost:(\d+)/);
+      if (match) {
+        serverPort = parseInt(match[1], 10);
+        clearTimeout(timeout);
+        resolve(proc);
+      }
+    });
+    proc.on("error", (err) => { clearTimeout(timeout); reject(err); });
+  });
+}
+
+describe("vendor marketplace solicitation CTA (#858)", () => {
+  before(async () => { serverProc = await startServer(); });
+  after(() => { serverProc?.kill(); });
+
+  it("vendor with neither program nor code shows the solicitation block", async () => {
+    // Deno Deploy: no referral_program, no referral, no platform code.
+    const res = await fetch(`http://localhost:${serverPort}/vendor/deno-deploy`);
+    assert.strictEqual(res.status, 200);
+    const html = await res.text();
+    assert.ok(html.includes("marketplace-solicitation"), "Solicitation section CSS hook missing");
+    assert.ok(html.includes("Know a referral or partner program for Deno Deploy?"), "Solicitation heading missing");
+    assert.ok(html.includes('href="/marketplace"'), "Should link to /marketplace");
+    assert.ok(html.includes("60% commission"), "Should mention commission split");
+    assert.ok(html.includes("x402"), "Should mention payout rail");
+    // Should NOT show the active program callout for this vendor
+    assert.ok(!html.includes(">Referral Program</h2>"), "Should not show 'Referral Program' h2 (no program available)");
+  });
+
+  it("vendor with platform code (Railway) does NOT show the solicitation block", async () => {
+    const res = await fetch(`http://localhost:${serverPort}/vendor/railway`);
+    assert.strictEqual(res.status, 200);
+    const html = await res.text();
+    assert.ok(!html.includes("marketplace-solicitation"), "Solicitation should be suppressed when a platform code exists");
+    assert.ok(!html.includes("Know a referral or partner program for Railway?"), "Solicitation heading should not appear for Railway");
+    // Existing platform CTA still rendered
+    assert.ok(html.includes("Sign up via our referral link"), "Existing platform CTA should still render");
+  });
+
+  it("vendor with referral_program.available=true (Vercel) does NOT show the solicitation block", async () => {
+    const res = await fetch(`http://localhost:${serverPort}/vendor/vercel`);
+    assert.strictEqual(res.status, 200);
+    const html = await res.text();
+    assert.ok(!html.includes("marketplace-solicitation"), "Solicitation should be suppressed when program is available");
+    assert.ok(!html.includes("Know a referral or partner program for Vercel?"), "Solicitation heading should not appear for Vercel");
+    // Existing program callout still renders
+    assert.ok(html.includes(">Referral Program</h2>"), "Existing 'Referral Program' h2 should still render");
+  });
+
+  it("solicitation block uses muted/secondary styling (dashed border, h3 not h2)", async () => {
+    const res = await fetch(`http://localhost:${serverPort}/vendor/deno-deploy`);
+    const html = await res.text();
+    // Visually distinguishable from active program promo (which uses h2 + solid border)
+    const idx = html.indexOf("marketplace-solicitation");
+    assert.ok(idx > 0, "Section must exist");
+    const slice = html.slice(idx, idx + 800);
+    assert.ok(slice.includes("border:1px dashed"), "Should use a dashed border to look passive");
+    assert.ok(slice.includes("<h3"), "Should use h3 (less prominent than h2)");
+  });
+
+  it("solicitation block links to disclosure page", async () => {
+    const res = await fetch(`http://localhost:${serverPort}/vendor/deno-deploy`);
+    const html = await res.text();
+    const idx = html.indexOf("marketplace-solicitation");
+    const slice = html.slice(idx, idx + 800);
+    assert.ok(slice.includes('href="/disclosure"'), "Should link to disclosure");
+  });
+});


### PR DESCRIPTION
## Summary

Adds a small, low-pressure marketplace solicitation block to vendor pages that have no referral surface today. Converts ~1,439 dormant vendor pages into passive acquisition surfaces for code submitters (per #858 strategic context).

The block renders only when **all** of these are true:
- `platformCode` is null (no platform-owned code for this vendor)
- `referral_program?.available !== true` (no documented program)
- `primary.referral` is falsy (no offer-level referral object)

If any referral surface exists (Railway has a platform code, Vercel has program metadata), the page is unchanged.

## Implementation

- New \`marketplaceSolicitationHtml\` block in \`buildVendorPage()\` (\`src/serve.ts\`).
- Placed in the page render between \`watchlistCtaHtml\` and \`internalLinksHtml\` — sits between "Watch X for Pricing Changes" and "Related Guides", as suggested in the issue.
- Visually distinguished from the active program callout: dashed border + h3 (vs. solid border + h2), muted color and font sizes, opacity 0.92.
- Copy matches the issue spec verbatim (60% commission, paid via x402, trust tiers + verification).
- Links to \`/marketplace\` and \`/disclosure\`.

## Tests

5 new tests in \`test/vendor-marketplace-solicitation.test.ts\`:
1. \`/vendor/deno-deploy\` (no program, no code) → solicitation **shown**, "Referral Program" h2 absent.
2. \`/vendor/railway\` (platform code) → solicitation **suppressed**, existing platform CTA still rendered.
3. \`/vendor/vercel\` (program available) → solicitation **suppressed**, existing program callout still rendered.
4. Solicitation block uses dashed border + h3 (passive styling).
5. Solicitation block links to \`/disclosure\`.

Test count: 1009 → 1014 (+5). No regressions.

## E2E verification

Started a local server (PORT=8766) and hit all three vendor pages:
- \`/vendor/deno-deploy\` → 1 \`marketplace-solicitation\` match. Headline reads "Know a referral or partner program for Deno Deploy?". Screenshot confirms placement and muted styling.
- \`/vendor/railway\` → 0 \`marketplace-solicitation\` matches. Existing "Sign up via our referral link and get \$20 in credits" CTA renders unchanged.
- \`/vendor/vercel\` → 0 \`marketplace-solicitation\` matches. Existing "Referral Program" section renders unchanged.

## Acceptance criteria

- [x] Vendor pages where \`referral_program\` is missing OR \`available !== true\` show the new section.
- [x] Section is visually distinguishable from the active program CTA (dashed border, h3, muted).
- [x] Links to \`/marketplace\`.
- [x] Vendors with \`referral_code\` (Railway) unchanged.
- [x] Vendors with \`referral_program.available = true\` (Vercel) unchanged.
- [x] Spot-checked 3 vendors: Deno Deploy (shown), Railway (existing), Vercel (existing).

Refs #858