### PR TITLE
Add search query analytics to /api/metrics

### DIFF
--- a/src/serve.ts
+++ b/src/serve.ts
@@ -8,7 +8,7 @@ import { createServer, getServerCard } from "./server.js";
 import { loadOffers, getCategories, getNewOffers, getNewestDeals, searchOffers, enrichOffers, loadDealChanges, getDealChanges, getPersonalizedChanges, getOfferDetails, compareServices, checkVendorRisk, auditStack, getExpiringDeals, getWeeklyDigest, getFormattedWeeklyDigest, getFreshnessMetrics, getStabilityMap, getVendorReferral } from "./data.js";
 import { getStackRecommendation } from "./stacks.js";
 import { estimateCosts } from "./costs.js";
-import { recordApiHit, recordSessionConnect, recordSessionDisconnect, recordLandingPageView, getStats, getConnectionStats, loadTelemetry, flushTelemetry, logRequest, getRequestLog, recordPageView, getPageViews, recordReferralListingCall, recordReferralVendorLookup, getReferralMarketplaceStats, getSessionClassification } from "./stats.js";
+import { recordApiHit, recordSessionConnect, recordSessionDisconnect, recordLandingPageView, getStats, getConnectionStats, loadTelemetry, flushTelemetry, logRequest, getRequestLog, recordPageView, getPageViews, recordReferralListingCall, recordReferralVendorLookup, getReferralMarketplaceStats, getSessionClassification, recordSearchQuery, getSearchAnalytics } from "./stats.js";
 import { openapiSpec } from "./openapi.js";
 import { registerAgent, authenticateRequest, validateVestauthUrl, hashApiKey, updateAgentX402Address, getAgentById } from "./agents.js";
 import { logReferralRequest } from "./referral-requests.js";
@@ -53241,6 +53241,7 @@ const httpServer = createHttpServer(async (req, res) => {
       ...getStats(),
       ...getSessionClassification(),
       referral_marketplace: getReferralMarketplaceStats(),
+      search_analytics: getSearchAnalytics(),
     }));
   } else if (url.pathname === "/.well-known/glama.json") {
     res.writeHead(200, { "Content-Type": "application/json" });
@@ -53375,6 +53376,7 @@ const httpServer = createHttpServer(async (req, res) => {
       }
       return enriched;
     });
+    recordSearchQuery(q, total, category);
     logRequest({ ts: new Date().toISOString(), type: "api", endpoint: "/api/offers", params: { q, category, limit, offset }, user_agent: req.headers["user-agent"] ?? "unknown", result_count: paged.length });
     res.writeHead(200, { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" });
     res.end(JSON.stringify({ offers: offersWithCodes, total }));

--- a/src/server.ts
+++ b/src/server.ts
@@ -4,7 +4,7 @@ import { fileURLToPath } from "node:url";
 import { McpServer, ResourceTemplate } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import { getCategories, getDealChanges, getPersonalizedChanges, getNewOffers, getNewestDeals, getOfferDetails, searchOffers, enrichOffers, compareServices, checkVendorRisk, auditStack, getExpiringDeals, getWeeklyDigest, loadOffers, loadDealChanges, classifyStability, getStabilityMap, getVendorReferral } from "./data.js";
-import { recordToolCall, logRequest } from "./stats.js";
+import { recordToolCall, logRequest, recordSearchQuery } from "./stats.js";
 import { registerAgent, validateVestauthUrl, getAgentByApiKeyHash, hashApiKey, updateAgentX402Address } from "./agents.js";
 import { logReferralRequest } from "./referral-requests.js";
 import { getAgentBalance, getAgentLedgerEntries, recordPayout, MINIMUM_PAYOUT_AMOUNT, getLeaderboard } from "./ledger.js";
@@ -124,6 +124,7 @@ export function createServer(getSessionId?: () => string | undefined): McpServer
         const paged = filtered.slice(effectiveOffset, effectiveOffset + effectiveLimit);
         const results = enrichOffers(paged);
         const finalTotal = since ? filtered.length : total;
+        recordSearchQuery(query, finalTotal, category);
         logRequest({ ts: new Date().toISOString(), type: "mcp", endpoint: "search_deals", params: { query, category, eligibility, sort, limit: effectiveLimit, offset: effectiveOffset, since }, result_count: results.length, session_id: getSessionId?.() });
 
         // Zero-result suggestion (only when no results match at all, not just paginated past end)

--- a/src/stats.ts
+++ b/src/stats.ts
@@ -320,6 +320,7 @@ export function resetCounters(): void {
   cumulative.referral_listing_by_source = { platform: 0, agent: 0, null: 0 };
   cumulative.referral_vendor_lookups = 0;
   cumulative.referral_vendor_counts = {};
+  searchQueryLog.length = 0;
 }
 
 export function recordToolCall(tool: string): void {
@@ -720,4 +721,72 @@ export function getPageViewsToday(): number {
     pageViewsTodayDate = today;
   }
   return pageViewsToday;
+}
+
+// --- Search query analytics (in-memory, resets on deploy) ---
+
+interface SearchQueryEntry {
+  query: string;
+  ts: number;
+  resultCount: number;
+  category?: string;
+}
+
+const searchQueryLog: SearchQueryEntry[] = [];
+
+export function recordSearchQuery(query: string | undefined, resultCount: number, category?: string): void {
+  if (!query) return;
+  const normalized = query.trim().toLowerCase();
+  if (!normalized) return;
+  searchQueryLog.push({
+    query: normalized,
+    ts: Date.now(),
+    resultCount,
+    category,
+  });
+}
+
+export function getSearchAnalytics(): {
+  top_queries_7d: { query: string; count: number }[];
+  zero_result_queries_7d: { query: string; count: number }[];
+  queries_by_category_7d: Record<string, number>;
+} {
+  const sevenDaysAgo = Date.now() - 7 * 24 * 60 * 60 * 1000;
+  const recent = searchQueryLog.filter(e => e.ts >= sevenDaysAgo);
+
+  // Top 20 queries by frequency
+  const queryCounts = new Map<string, number>();
+  for (const e of recent) {
+    queryCounts.set(e.query, (queryCounts.get(e.query) ?? 0) + 1);
+  }
+  const topQueries = [...queryCounts.entries()]
+    .map(([query, count]) => ({ query, count }))
+    .sort((a, b) => b.count - a.count)
+    .slice(0, 20);
+
+  // Top 10 zero-result queries
+  const zeroResultCounts = new Map<string, number>();
+  for (const e of recent) {
+    if (e.resultCount === 0) {
+      zeroResultCounts.set(e.query, (zeroResultCounts.get(e.query) ?? 0) + 1);
+    }
+  }
+  const zeroResultQueries = [...zeroResultCounts.entries()]
+    .map(([query, count]) => ({ query, count }))
+    .sort((a, b) => b.count - a.count)
+    .slice(0, 10);
+
+  // Search volume by category (from results that matched a category)
+  const categoryCounts: Record<string, number> = {};
+  for (const e of recent) {
+    if (e.category) {
+      categoryCounts[e.category] = (categoryCounts[e.category] ?? 0) + 1;
+    }
+  }
+
+  return {
+    top_queries_7d: topQueries,
+    zero_result_queries_7d: zeroResultQueries,
+    queries_by_category_7d: categoryCounts,
+  };
 }

--- a/test/search-analytics.test.ts
+++ b/test/search-analytics.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, beforeEach } from "node:test";
+import assert from "node:assert";
+
+const {
+  recordSearchQuery,
+  getSearchAnalytics,
+  resetCounters,
+} = await import("../src/stats.ts");
+
+describe("search analytics", () => {
+  beforeEach(() => {
+    resetCounters();
+  });
+
+  it("returns empty analytics when no queries recorded", () => {
+    const analytics = getSearchAnalytics();
+    assert.deepStrictEqual(analytics.top_queries_7d, []);
+    assert.deepStrictEqual(analytics.zero_result_queries_7d, []);
+    assert.deepStrictEqual(analytics.queries_by_category_7d, {});
+  });
+
+  it("tracks top queries sorted by frequency", () => {
+    recordSearchQuery("redis", 5);
+    recordSearchQuery("redis", 3);
+    recordSearchQuery("redis", 2);
+    recordSearchQuery("postgres", 10);
+    recordSearchQuery("postgres", 8);
+    recordSearchQuery("mongodb", 4);
+    const analytics = getSearchAnalytics();
+    assert.strictEqual(analytics.top_queries_7d.length, 3);
+    assert.strictEqual(analytics.top_queries_7d[0].query, "redis");
+    assert.strictEqual(analytics.top_queries_7d[0].count, 3);
+    assert.strictEqual(analytics.top_queries_7d[1].query, "postgres");
+    assert.strictEqual(analytics.top_queries_7d[1].count, 2);
+    assert.strictEqual(analytics.top_queries_7d[2].query, "mongodb");
+    assert.strictEqual(analytics.top_queries_7d[2].count, 1);
+  });
+
+  it("normalizes queries to lowercase and trimmed", () => {
+    recordSearchQuery("  Redis  ", 5);
+    recordSearchQuery("REDIS", 3);
+    recordSearchQuery("redis", 2);
+    const analytics = getSearchAnalytics();
+    assert.strictEqual(analytics.top_queries_7d.length, 1);
+    assert.strictEqual(analytics.top_queries_7d[0].query, "redis");
+    assert.strictEqual(analytics.top_queries_7d[0].count, 3);
+  });
+
+  it("ignores undefined and empty queries", () => {
+    recordSearchQuery(undefined, 5);
+    recordSearchQuery("", 3);
+    recordSearchQuery("   ", 2);
+    const analytics = getSearchAnalytics();
+    assert.deepStrictEqual(analytics.top_queries_7d, []);
+  });
+
+  it("tracks zero-result queries", () => {
+    recordSearchQuery("graphql hosting", 0);
+    recordSearchQuery("graphql hosting", 0);
+    recordSearchQuery("redis", 5);
+    recordSearchQuery("nonexistent tool", 0);
+    const analytics = getSearchAnalytics();
+    assert.strictEqual(analytics.zero_result_queries_7d.length, 2);
+    assert.strictEqual(analytics.zero_result_queries_7d[0].query, "graphql hosting");
+    assert.strictEqual(analytics.zero_result_queries_7d[0].count, 2);
+    assert.strictEqual(analytics.zero_result_queries_7d[1].query, "nonexistent tool");
+    assert.strictEqual(analytics.zero_result_queries_7d[1].count, 1);
+  });
+
+  it("tracks queries by category", () => {
+    recordSearchQuery("redis", 5, "databases");
+    recordSearchQuery("postgres", 10, "databases");
+    recordSearchQuery("vercel", 3, "hosting");
+    recordSearchQuery("stripe", 2);
+    const analytics = getSearchAnalytics();
+    assert.strictEqual(analytics.queries_by_category_7d["databases"], 2);
+    assert.strictEqual(analytics.queries_by_category_7d["hosting"], 1);
+    assert.strictEqual(analytics.queries_by_category_7d["stripe"], undefined);
+  });
+
+  it("caps top_queries_7d at 20", () => {
+    for (let i = 0; i < 25; i++) {
+      recordSearchQuery(`query${i}`, 1);
+    }
+    const analytics = getSearchAnalytics();
+    assert.strictEqual(analytics.top_queries_7d.length, 20);
+  });
+
+  it("caps zero_result_queries_7d at 10", () => {
+    for (let i = 0; i < 15; i++) {
+      recordSearchQuery(`missing${i}`, 0);
+    }
+    const analytics = getSearchAnalytics();
+    assert.strictEqual(analytics.zero_result_queries_7d.length, 10);
+  });
+
+  it("resetCounters clears search analytics", () => {
+    recordSearchQuery("redis", 5);
+    recordSearchQuery("nothing", 0);
+    resetCounters();
+    const analytics = getSearchAnalytics();
+    assert.deepStrictEqual(analytics.top_queries_7d, []);
+    assert.deepStrictEqual(analytics.zero_result_queries_7d, []);
+    assert.deepStrictEqual(analytics.queries_by_category_7d, {});
+  });
+
+  it("search_analytics appears in expected shape", () => {
+    recordSearchQuery("test", 3, "testing");
+    const analytics = getSearchAnalytics();
+    assert.ok(Array.isArray(analytics.top_queries_7d));
+    assert.ok(Array.isArray(analytics.zero_result_queries_7d));
+    assert.strictEqual(typeof analytics.queries_by_category_7d, "object");
+    assert.ok(!Array.isArray(analytics.queries_by_category_7d));
+  });
+});


### PR DESCRIPTION
## Summary

Adds a `search_analytics` object to the `/api/metrics` response that exposes:
- **top_queries_7d**: Top 20 most frequent search terms (last 7 days)
- **zero_result_queries_7d**: Top 10 searches with zero results (product gap signal)
- **queries_by_category_7d**: Search volume by category

Queries are normalized (lowercase, trimmed) before aggregation. In-memory only — resets on deploy. No per-session or per-client attribution (privacy-safe).

Instrumented in both REST `/api/offers?q=` and MCP `search_deals` tool.

## Test plan

- 10 new unit tests covering: empty state, frequency sorting, normalization, empty/undefined queries, zero-result tracking, category tracking, cap limits (20/10), resetCounters, shape validation
- Full test suite: 1,038 tests passing (up from 1,028)
- E2E verified: started local server, made search queries, confirmed analytics appear correctly in `/api/metrics`

Refs #866