### PR TITLE
Fix Braintrust free tier limits + remove Wolfram entry

### DIFF
--- a/data/category-mapping.json
+++ b/data/category-mapping.json
@@ -154,7 +154,6 @@
   "WeatherXu": "Dev Utilities",
   "WebScraping.AI": "Web Scraping",
   "What The Diff": "Code Quality",
-  "wolfram.com": "AI / ML",
   "wrapapi.com": "Web Scraping",
   "Zenscrape": "Web Scraping",
   "Zipcodebase": "Dev Utilities",

--- a/data/index.json
+++ b/data/index.json
@@ -8084,18 +8084,6 @@
       "verifiedDate": "2026-04-13"
     },
     {
-      "vendor": "wolfram.com",
-      "category": "AI / ML",
-      "description": "Built-in knowledge-based algorithms in the cloud.",
-      "tier": "Free",
-      "url": "https://wolfram.com/language/",
-      "tags": [
-        "developer-tools",
-        "free-for-dev"
-      ],
-      "verifiedDate": "2026-04-05"
-    },
-    {
       "vendor": "wrapapi.com",
       "category": "Web Scraping",
       "description": "Turn any website into a parameterized API. 30k API calls per month.",
@@ -12652,16 +12640,16 @@
     {
       "vendor": "Braintrust",
       "category": "AI / ML",
-      "description": "Evals, prompt playground, and data management for Gen AI. Free plan gives upto 1,000 private eval rows/week.",
+      "description": "Evals, prompt playground, and data management for Gen AI. Starter plan (free): 1 GB processed data/month, 10k scores/month, 14 days data retention. Unlimited users, projects, datasets, playgrounds, and experiments. Overage: $4/GB data, $2.50 per 1k scores.",
       "tier": "Free",
-      "url": "https://www.braintrustdata.com/",
+      "url": "https://www.braintrust.dev/pricing",
       "tags": [
         "ai",
         "ml",
         "generative-ai",
         "free-for-dev"
       ],
-      "verifiedDate": "2026-04-13"
+      "verifiedDate": "2026-04-17"
     },
     {
       "vendor": "Clair",

--- a/src/serve.ts
+++ b/src/serve.ts
@@ -11164,7 +11164,7 @@ ${buildCards(other)}
       <dd><a href="/vendor/github-copilot">GitHub Copilot</a> for IDE-integrated autocomplete (2,000/mo free). <a href="/vendor/cursor">Cursor</a> for an AI-native editor. <a href="/vendor/gemini-cli">Gemini CLI</a> and <a href="/vendor/cline">Cline</a> for free open-source terminal agents (BYOK).</dd>
 
       <dt>Building an AI app and need observability?</dt>
-      <dd><a href="/vendor/langfuse">Langfuse</a> \u2014 open-source LLM tracing, 50K observations/month free. <a href="/vendor/langwatch">LangWatch</a> for monitoring and optimization. <a href="/vendor/braintrust">Braintrust</a> for evals with 1,000 rows/week free.</dd>
+      <dd><a href="/vendor/langfuse">Langfuse</a> \u2014 open-source LLM tracing, 50K observations/month free. <a href="/vendor/langwatch">LangWatch</a> for monitoring and optimization. <a href="/vendor/braintrust">Braintrust</a> for evals with 1 GB/month free.</dd>
 
       <dt>Need free GPU compute for ML training?</dt>
       <dd><a href="/vendor/kaggle">Kaggle</a> \u2014 30 hrs/week GPU (Tesla T4) and 20 hrs/week TPU, completely free. <a href="/vendor/paperspace">Paperspace</a> for free notebooks with basic instances. <a href="/vendor/vast-ai">Vast.ai</a> startup program for $2,500 in GPU credits.</dd>


### PR DESCRIPTION
## Summary

- **Braintrust:** Corrected free tier from wrong "1,000 private eval rows/week" to actual Starter plan limits: 1 GB processed data/month, 10k scores/month, 14 days retention, unlimited users/projects. URL updated from braintrustdata.com → braintrust.dev/pricing.
- **Wolfram:** Removed — entry was vague ("built-in knowledge-based algorithms in the cloud") with no quantifiable free tier. Wolfram Engine is free for pre-production use only (local install), not a cloud free tier.
- Net -1 offer (1,599 → 1,598). 1,042 tests passing.

Refs #872