### PR TITLE
Strip special characters from search queries

### DIFF
--- a/src/data.ts
+++ b/src/data.ts
@@ -136,6 +136,14 @@ function scoreOffer(offer: Offer, terms: string[]): number {
   return score;
 }
 
+/**
+ * Strip special characters from search queries that break matching.
+ * Keeps alphanumeric, hyphens, spaces, dots, and plus signs.
+ */
+export function sanitizeQuery(raw: string): string {
+  return raw.replace(/[^a-zA-Z0-9\s.\-+]/g, "").replace(/\s+/g, " ").trim();
+}
+
 export function searchOffers(
   query?: string,
   category?: string,

--- a/src/serve.ts
+++ b/src/serve.ts
@@ -5,7 +5,7 @@ import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
 import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
 import { createServer, getServerCard } from "./server.js";
-import { loadOffers, getCategories, getNewOffers, getNewestDeals, searchOffers, enrichOffers, loadDealChanges, getDealChanges, getPersonalizedChanges, getOfferDetails, compareServices, checkVendorRisk, auditStack, getExpiringDeals, getWeeklyDigest, getFormattedWeeklyDigest, getFreshnessMetrics, getStabilityMap, getVendorReferral } from "./data.js";
+import { loadOffers, getCategories, getNewOffers, getNewestDeals, searchOffers, enrichOffers, loadDealChanges, getDealChanges, getPersonalizedChanges, getOfferDetails, compareServices, checkVendorRisk, auditStack, getExpiringDeals, getWeeklyDigest, getFormattedWeeklyDigest, getFreshnessMetrics, getStabilityMap, getVendorReferral, sanitizeQuery } from "./data.js";
 import { getStackRecommendation } from "./stacks.js";
 import { estimateCosts } from "./costs.js";
 import { recordApiHit, recordSessionConnect, recordSessionDisconnect, recordLandingPageView, getStats, getConnectionStats, loadTelemetry, flushTelemetry, logRequest, getRequestLog, recordPageView, getPageViews, recordReferralListingCall, recordReferralVendorLookup, getReferralMarketplaceStats, getSessionClassification, recordSearchQuery, getSearchAnalytics } from "./stats.js";
@@ -51593,7 +51593,8 @@ function buildSearchPage(query: string, categoryFilter: string, typeFilter: stri
   let results: ReturnType<typeof enrichOffers> = [];
   let totalResults = 0;
   if (hasFilters) {
-    const raw = searchOffers(query || undefined, categoryFilter || undefined, typeFilter || undefined, sortParam || undefined);
+    const sanitizedSearchQuery = query ? sanitizeQuery(query) : undefined;
+    const raw = searchOffers(sanitizedSearchQuery || undefined, categoryFilter || undefined, typeFilter || undefined, sortParam || undefined);
     totalResults = raw.length;
     const start = (page - 1) * PAGE_SIZE;
     results = enrichOffers(raw.slice(start, start + PAGE_SIZE));
@@ -53353,7 +53354,8 @@ const httpServer = createHttpServer(async (req, res) => {
     const validPaymentProtocol = paymentProtocol && ["x402", "stripe-mpp"].includes(paymentProtocol) ? paymentProtocol : undefined;
     const limit = parseInt(url.searchParams.get("limit") ?? "20", 10);
     const offset = parseInt(url.searchParams.get("offset") ?? "0", 10);
-    const results = searchOffers(q, category, eligibilityType, sort, validStability, validPaymentProtocol);
+    const sanitizedQ = q ? sanitizeQuery(q) : undefined;
+    const results = searchOffers(sanitizedQ || undefined, category, eligibilityType, sort, validStability, validPaymentProtocol);
     const total = results.length;
     const paged = enrichOffers(results.slice(offset, offset + limit));
     // Enrich each offer with: (1) best referral_code (platform > agent-submitted, explicit null if none)

--- a/src/server.ts
+++ b/src/server.ts
@@ -3,7 +3,7 @@ import { join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 import { McpServer, ResourceTemplate } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
-import { getCategories, getDealChanges, getPersonalizedChanges, getNewOffers, getNewestDeals, getOfferDetails, searchOffers, enrichOffers, compareServices, checkVendorRisk, auditStack, getExpiringDeals, getWeeklyDigest, loadOffers, loadDealChanges, classifyStability, getStabilityMap, getVendorReferral } from "./data.js";
+import { getCategories, getDealChanges, getPersonalizedChanges, getNewOffers, getNewestDeals, getOfferDetails, searchOffers, enrichOffers, compareServices, checkVendorRisk, auditStack, getExpiringDeals, getWeeklyDigest, loadOffers, loadDealChanges, classifyStability, getStabilityMap, getVendorReferral, sanitizeQuery } from "./data.js";
 import { recordToolCall, logRequest, recordSearchQuery } from "./stats.js";
 import { registerAgent, validateVestauthUrl, getAgentByApiKeyHash, hashApiKey, updateAgentX402Address } from "./agents.js";
 import { logReferralRequest } from "./referral-requests.js";
@@ -109,7 +109,8 @@ export function createServer(getSessionId?: () => string | undefined): McpServer
         }
 
         // Mode: search/browse
-        const allResults = searchOffers(query, category, eligibility, sort, stability, payment_protocol);
+        const sanitizedQuery = query ? sanitizeQuery(query) : undefined;
+        const allResults = searchOffers(sanitizedQuery || undefined, category, eligibility, sort, stability, payment_protocol);
         const total = allResults.length;
         const effectiveOffset = offset ?? 0;
         const effectiveLimit = limit ?? 20;

--- a/test/sanitize.test.ts
+++ b/test/sanitize.test.ts
@@ -1,0 +1,39 @@
+import { describe, it } from "node:test";
+import assert from "node:assert";
+
+describe("sanitizeQuery", () => {
+  it("strips backticks and other special characters from queries", async () => {
+    const { sanitizeQuery } = await import("../dist/data.js");
+
+    // Backtick (the real user case from analytics)
+    assert.strictEqual(sanitizeQuery("database`"), "database");
+
+    // Quotes, brackets, parentheses, semicolons, pipes
+    assert.strictEqual(sanitizeQuery('database"hosting'), "databasehosting");
+    assert.strictEqual(sanitizeQuery("redis[free]"), "redisfree");
+    assert.strictEqual(sanitizeQuery("postgres(free)"), "postgresfree");
+    assert.strictEqual(sanitizeQuery("test;drop"), "testdrop");
+    assert.strictEqual(sanitizeQuery("a|b"), "ab");
+
+    // Preserves valid characters: hyphens, spaces, dots, plus signs
+    assert.strictEqual(sanitizeQuery("ci-cd tools"), "ci-cd tools");
+    assert.strictEqual(sanitizeQuery("node.js"), "node.js");
+    assert.strictEqual(sanitizeQuery("c++"), "c++");
+
+    // Trims and normalizes whitespace
+    assert.strictEqual(sanitizeQuery("  database  hosting  "), "database hosting");
+
+    // Empty after sanitization
+    assert.strictEqual(sanitizeQuery("```"), "");
+  });
+
+  it("sanitized queries return the same results as clean queries", async () => {
+    const { searchOffers, sanitizeQuery } = await import("../dist/data.js");
+
+    const cleanResults = searchOffers("database");
+    const dirtyResults = searchOffers(sanitizeQuery("database`"));
+
+    assert.ok(cleanResults.length > 0, "database should return results");
+    assert.strictEqual(cleanResults.length, dirtyResults.length, "database` should return same count as database");
+  });
+});


### PR DESCRIPTION
## Summary

Adds `sanitizeQuery()` that strips non-alphanumeric characters (except hyphens, spaces, dots, plus signs) from search queries before matching. Fixes the real user case where `database\`` returned zero results while `database` returns 20.

Applied to all three search entry points:
- REST `/api/offers?q=` endpoint
- MCP `search_deals` tool
- `/search` HTML page

Original unsanitized query is still logged in search analytics per AC #6.

## Changes

- `src/data.ts`: New `sanitizeQuery()` export
- `src/serve.ts`: Sanitize query in `/api/offers` and `/search` handlers
- `src/server.ts`: Sanitize query in MCP `search_deals` tool
- `test/sanitize.test.ts`: 2 tests (character stripping + result equivalence)

## Test plan

- [x] `database\`` returns same results as `database`
- [x] Hyphens, spaces, dots, plus signs preserved (`ci-cd tools`, `node.js`, `c++`)
- [x] Full test suite: 1,044 passing (+2 new)

Refs #874