### PR TITLE
fix: correct Codemagic build history 30→60 days

### DIFF
--- a/data/index.json
+++ b/data/index.json
@@ -6234,7 +6234,7 @@
     {
       "vendor": "Codemagic",
       "category": "CI/CD",
-      "description": "Mobile CI/CD platform — free tier (individual accounts): 500 macOS M2 build minutes/month, unlimited apps, 1 parallel build, 30-day build history, 3 GB cache/build. Supports Flutter, iOS, Android, React Native",
+      "description": "Mobile CI/CD platform — free tier (individual accounts): 500 macOS M2 build minutes/month, unlimited apps, 1 parallel build, 60-day build history, 3 GB cache/build. Supports Flutter, iOS, Android, React Native",
       "tier": "Free",
       "url": "https://codemagic.io/pricing/",
       "tags": [
@@ -6246,7 +6246,7 @@
         "flutter",
         "macos"
       ],
-      "verifiedDate": "2026-04-12"
+      "verifiedDate": "2026-04-17"
     },
     {
       "vendor": "Appcircle",


### PR DESCRIPTION
Refs #880

Codemagic free tier build history retention is 60 days, not 30. Updated description in data/index.json and refreshed verifiedDate to 2026-04-17.

Source: https://codemagic.io/pricing/

1,044 tests passing, no regressions.