### PR TITLE
Email category data corrections

### DIFF
--- a/data/deal_changes.json
+++ b/data/deal_changes.json
@@ -3739,6 +3739,38 @@
         "OpenRouter",
         "Groq"
       ]
+    },
+    {
+      "vendor": "SendGrid Accelerate",
+      "change_type": "free_tier_removed",
+      "date": "2026-04-17",
+      "summary": "SendGrid Accelerate startup program discontinued. sendgrid.com now redirects to twilio.com. Twilio explicitly states they do not offer additional credits to startups at this time.",
+      "previous_state": "12 months of product credit, mentoring, and networking for startups",
+      "current_state": "Program discontinued — no startup credits available",
+      "impact": "negative",
+      "source_url": "https://www.twilio.com/en-us/startups",
+      "category": "Email",
+      "alternatives": [
+        "SendGrid",
+        "Mailgun",
+        "Postmark"
+      ]
+    },
+    {
+      "vendor": "Prospect.io",
+      "change_type": "free_tier_removed",
+      "date": "2026-04-17",
+      "summary": "Prospect.io startup deal via JoinSecret removed. joinsecret.com returns 403 errors and Prospect.io's own pricing page 404s. Product may have been renamed or discontinued.",
+      "previous_state": "50% on Starter plan for 6 months + 1000 email credits via JoinSecret",
+      "current_state": "Product and deal page both inaccessible — removed from index",
+      "impact": "negative",
+      "source_url": "https://www.joinsecret.com/offers",
+      "category": "Email",
+      "alternatives": [
+        "Apollo.io",
+        "Hunter.io",
+        "Lemlist"
+      ]
     }
   ]
 }

--- a/data/index.json
+++ b/data/index.json
@@ -11966,14 +11966,14 @@
     {
       "vendor": "mailchannels.com",
       "category": "Email",
-      "description": "Email API with REST API and SMTP integrations, free for upto 3,000 emails/month.",
+      "description": "Email API with REST API and SMTP integrations. Free: 100 emails/day (~3,000/month), 3 domains, community support.",
       "tier": "Free",
       "url": "https://www.mailchannels.com",
       "tags": [
         "email",
         "free-for-dev"
       ],
-      "verifiedDate": "2026-04-12"
+      "verifiedDate": "2026-04-17"
     },
     {
       "vendor": "UserCheck",
@@ -12139,14 +12139,14 @@
     {
       "vendor": "SimpleLogin",
       "category": "Email",
-      "description": "Open source, self-hostable email alias/forwarding solution. Free 10 Aliases, unlimited bandwidth, unlimited reply/send. Free for educational staff (student, researcher, etc.).",
+      "description": "Open source, self-hostable email alias/forwarding solution. Free 10 aliases, unlimited bandwidth, free replies from aliases. New outbound messages from aliases require Premium. Free for educational staff (student, researcher, etc.).",
       "tier": "Free",
       "url": "https://simplelogin.io/",
       "tags": [
         "email",
         "free-for-dev"
       ],
-      "verifiedDate": "2026-04-12"
+      "verifiedDate": "2026-04-17"
     },
     {
       "vendor": "Substack",
@@ -18870,35 +18870,6 @@
       }
     },
     {
-      "vendor": "SendGrid Accelerate",
-      "category": "Email",
-      "description": "SendGrid Accelerate is a program to help startups succeed. Startups participating in the SendGrid Accelerate program receive 12 months of product credit, access to mentoring, and networking opportunities exclusive to program participants.",
-      "tier": "Startup Program",
-      "url": "https://sendgrid.com/accelerate/",
-      "tags": [
-        "email",
-        "startup-credits",
-        "awesome-startup-credits"
-      ],
-      "verifiedDate": "2026-04-12",
-      "eligibility": {
-        "type": "startup",
-        "conditions": [
-          "Startup program — check vendor for eligibility details"
-        ],
-        "program": "SendGrid Accelerate Startup Program"
-      },
-      "expires_date": "2026-05-15",
-      "referral_program": {
-        "available": false,
-        "referrer_benefit": "N/A",
-        "referee_benefit": "N/A",
-        "program_url": "https://sendgrid.com/partners/affiliate/",
-        "type": "closed",
-        "notes": "No active affiliate program."
-      }
-    },
-    {
       "vendor": "Autodesk Fusion 360 for Startups",
       "category": "Startup Perks",
       "description": "Fusion 360 for startups is eligible for venture-backed, angel-backed or bootstrap startups that are less than three years old, have 10 or fewer employees and generate less than $100,000 USD in gross annual revenue.",
@@ -20154,26 +20125,6 @@
           "Free for Brex customers"
         ],
         "program": "Postscript Startup Deal"
-      }
-    },
-    {
-      "vendor": "Prospect.io",
-      "category": "Email",
-      "description": "50% on Starter plan for 6 months + 1000 emails credits. Access via: First deal free, then 99€/year or invite friends",
-      "tier": "Startup Program",
-      "url": "https://www.joinsecret.com/offers",
-      "tags": [
-        "email",
-        "startup-credits",
-        "startupdeals"
-      ],
-      "verifiedDate": "2026-04-12",
-      "eligibility": {
-        "type": "startup",
-        "conditions": [
-          "First deal free, then 99€/year or invite friends"
-        ],
-        "program": "Prospect.io Startup Deal"
       }
     },
     {

--- a/src/serve.ts
+++ b/src/serve.ts
@@ -11224,7 +11224,7 @@ function buildEmailAlternativesPage(): string {
     ["Proton Mail", "Tuta"].includes(o.vendor)
   );
   const otherEmailTools = enrichedAll.filter(o =>
-    ["Parsio.io", "EmailJS", "Contact.do", "Waitlio", "Prospect.io", "SendGrid", "SendGrid Accelerate"].includes(o.vendor)
+    ["Parsio.io", "EmailJS", "Contact.do", "Waitlio", "SendGrid"].includes(o.vendor)
   );
   const other = enrichedAll.filter(o =>
     !transactionalApis.includes(o) && !marketingNewsletter.includes(o) && !verificationDeliverability.includes(o) && !forwardingAliases.includes(o) && !temporaryTesting.includes(o) && !securePrivacy.includes(o) && !otherEmailTools.includes(o)

--- a/test/deal-changes.test.ts
+++ b/test/deal-changes.test.ts
@@ -76,7 +76,7 @@ describe("track_changes tool", () => {
 
     assert.ok(Array.isArray(body.changes));
     assert.strictEqual(body.total, body.changes.length);
-    assert.strictEqual(body.total, 269);
+    assert.strictEqual(body.total, 271);
   });
 
   it("filters by date (since)", async () => {


### PR DESCRIPTION
## Summary

- **SendGrid Accelerate — REMOVED:** Program discontinued. sendgrid.com redirects to twilio.com, which explicitly states no startup credits available.
- **Prospect.io — REMOVED:** joinsecret.com returns 403 errors, Prospect.io pricing page 404s. Product appears discontinued.
- **SimpleLogin — ENRICHED:** Clarified that free replies from aliases work but new outbound messages require Premium.
- **MailChannels — ENRICHED:** Added daily limit (100 emails/day) and domain cap (3 domains) to description.
- 2 deal_changes entries added for the removals.
- Updated serve.ts email category grouping to remove the two vendors.

1,044 tests passing. E2E verified — removed vendors return 0 results, updated descriptions correct in API.

Refs #888