### PR TITLE
feat: add /impact-verification route (#899)

### DIFF
--- a/src/serve.ts
+++ b/src/serve.ts
@@ -53868,6 +53868,9 @@ ${weekEntries.join("\n")}
     const robotsTxt = `User-agent: *\nAllow: /\n\nSitemap: ${BASE_URL}/sitemap.xml\n`;
     res.writeHead(200, { "Content-Type": "text/plain; charset=utf-8", "Cache-Control": "public, max-age=86400" });
     res.end(robotsTxt);
+  } else if (url.pathname === "/impact-verification" && isGetOrHead) {
+    res.writeHead(200, { "Content-Type": "text/plain; charset=utf-8", "Cache-Control": "public, max-age=3600" });
+    res.end("Impact-Site-Verification: d7d21c9f-c586-4ea0-bf68-0bd9e995c222");
   } else if (url.pathname === "/llms.txt" && isGetOrHead) {
     const llmsTxt = `# AgentDeals
 

--- a/test/http.test.ts
+++ b/test/http.test.ts
@@ -290,6 +290,16 @@ describe("HTTP transport", () => {
     assert.ok(Array.isArray(body.transport));
   });
 
+  it("serves /impact-verification with Impact site ownership string", async () => {
+    proc = await startHttpServer();
+
+    const response = await fetch(`http://localhost:${serverPort}/impact-verification`);
+    assert.strictEqual(response.status, 200);
+    assert.strictEqual(response.headers.get("content-type"), "text/plain; charset=utf-8");
+    const body = await response.text();
+    assert.strictEqual(body, "Impact-Site-Verification: d7d21c9f-c586-4ea0-bf68-0bd9e995c222");
+  });
+
   it("serves /AGENTS.md with text/markdown content type", async () => {
     proc = await startHttpServer();
 


### PR DESCRIPTION
## Summary

Adds a `/impact-verification` route that returns the Impact-Site-Verification string as text/plain. This lets Impact (the affiliate platform) confirm ownership of agentdeals.dev.

## What shipped

- New route `/impact-verification` in `src/serve.ts` (placed alongside `/robots.txt`, `/llms.txt`)
- Returns: `Impact-Site-Verification: d7d21c9f-c586-4ea0-bf68-0bd9e995c222`
- Content-Type: `text/plain; charset=utf-8`
- Cache-Control: `public, max-age=3600`
- 1 new test in `test/http.test.ts` (1,045 tests total, up from 1,044)

## Verification

- Built (`npm run build`) + full test suite passes (1,045/1,045)
- Local E2E: `curl http://localhost:3456/impact-verification` returns the correct string with 200 and `text/plain; charset=utf-8`

Refs #899