### PR TITLE
fix: sitemap-reports includes all digest weeks + accurate lastmod (#894)

### DIFF
--- a/src/serve.ts
+++ b/src/serve.ts
@@ -2962,6 +2962,12 @@ function getRecentWeekKeys(n: number): string[] {
   return Array.from(byWeek.keys()).sort().reverse().slice(0, n);
 }
 
+// Get ALL week keys that have at least 1 deal change (past or future)
+function getAllWeekKeys(): string[] {
+  const byWeek = getChangesByWeek();
+  return Array.from(byWeek.keys()).sort().reverse();
+}
+
 // --- Vendor profile pages ---
 
 function buildVendorIndexPage(): string {
@@ -54028,8 +54034,9 @@ ${catList}
     const latestVerified = offers.reduce((max, o) => o.verifiedDate > max ? o.verifiedDate : max, offers[0]?.verifiedDate || now);
     const editorialDate = "2026-04-10";
     const comparisonDate = "2026-04-04";
-    const reportMonths = getAvailableReportMonths();
-    const latestReport = reportMonths.length > 0 ? (reportMonths[reportMonths.length - 1] + "-28" <= now ? reportMonths[reportMonths.length - 1] + "-28" : now) : now;
+    // /this-week in sitemap-reports uses `now` as lastmod, so the sitemap index
+    // lastmod for reports must be `now` too (Google uses this to decide re-crawl).
+    const latestReport = now;
     const sitemapIndex = '<?xml version="1.0" encoding="UTF-8"?>\n'
       + '<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n'
       + '  <sitemap>\n'
@@ -54150,7 +54157,7 @@ ${catList}
       + '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n'
       + '  <url>\n    <loc>' + BASE_URL + '/this-week</loc>\n    <lastmod>' + now + '</lastmod>\n    <changefreq>daily</changefreq>\n    <priority>0.9</priority>\n  </url>\n'
       + '  <url>\n    <loc>' + BASE_URL + '/digest/archive</loc>\n    <lastmod>' + latestVerified + '</lastmod>\n    <changefreq>weekly</changefreq>\n    <priority>0.7</priority>\n  </url>\n';
-    for (const wk of getRecentWeekKeys(4)) {
+    for (const wk of getAllWeekKeys()) {
       xml += '  <url>\n    <loc>' + BASE_URL + '/digest/' + wk + '</loc>\n    <lastmod>' + latestVerified + '</lastmod>\n    <changefreq>weekly</changefreq>\n    <priority>0.6</priority>\n  </url>\n';
     }
     xml += '  <url>\n    <loc>' + BASE_URL + '/reports</loc>\n    <lastmod>' + now + '</lastmod>\n    <changefreq>monthly</changefreq>\n    <priority>0.7</priority>\n  </url>\n';

--- a/test/http.test.ts
+++ b/test/http.test.ts
@@ -1155,6 +1155,19 @@ describe("HTTP transport", () => {
     assert.ok(xml.includes("<lastmod>"), "Should have lastmod dates");
   });
 
+  it("sitemap.xml reports sitemap lastmod is current (not stale)", async () => {
+    proc = await startHttpServer();
+    const response = await fetch(`http://localhost:${serverPort}/sitemap.xml`);
+    const xml = await response.text();
+    // Extract the reports sitemap block and its lastmod
+    const reportsBlock = xml.match(/<sitemap>\s*<loc>[^<]*sitemap-reports\.xml<\/loc>\s*<lastmod>([^<]+)<\/lastmod>/);
+    assert.ok(reportsBlock, "Should have a sitemap-reports entry with lastmod");
+    const lastmod = reportsBlock![1];
+    const year = parseInt(lastmod.slice(0, 4), 10);
+    const currentYear = new Date().getFullYear();
+    assert.ok(year >= currentYear - 1, `sitemap-reports lastmod year ${year} should be recent (not 2022); got ${lastmod}`);
+  });
+
   it("sitemap-pages.xml includes category pages", async () => {
     proc = await startHttpServer();
 
@@ -1330,6 +1343,25 @@ describe("HTTP transport", () => {
     assert.ok(xml.includes("/digest/archive"), "Sitemap should include digest archive");
     const digestCount = (xml.match(/\/digest\//g) || []).length;
     assert.ok(digestCount >= 3, `Expected at least 3 digest URLs in sitemap, got ${digestCount}`);
+  });
+
+  it("sitemap-reports.xml includes ALL weeks with deal changes (past + future)", async () => {
+    proc = await startHttpServer();
+
+    // /digest/archive is the canonical list of weeks with deal changes.
+    // The sitemap must include every week the archive shows.
+    const archiveRes = await fetch(`http://localhost:${serverPort}/digest/archive`);
+    const archiveHtml = await archiveRes.text();
+    const archiveWeeks = new Set<string>();
+    for (const m of archiveHtml.matchAll(/\/digest\/(\d{4}-w\d{2})/g)) archiveWeeks.add(m[1]);
+
+    const response = await fetch(`http://localhost:${serverPort}/sitemap-reports.xml`);
+    const xml = await response.text();
+    for (const wk of archiveWeeks) {
+      assert.ok(xml.includes(`/digest/${wk}`), `Sitemap should include digest week ${wk}`);
+    }
+    // Sanity: the sitemap should list substantially more than the old 4-week window
+    assert.ok(archiveWeeks.size >= 10, `Expected >=10 archive weeks to meaningfully test; got ${archiveWeeks.size}`);
   });
 
   it("GET /vendor returns vendor index page", async () => {


### PR DESCRIPTION
## Summary

Three bugs were making recent weekly digests (w14, w15, w16, etc.) invisible to Google despite the pages existing and returning 200 OK. Root causes:

1. **Only 4 weeks listed.** `getRecentWeekKeys(4)` sorted all weeks with deal_changes descending (string sort) and took the first 4. Because some deal_changes are dated in the future (w27, w35, w40, w41), those scheduled future weeks consumed every slot and current-period weeks (w1-w16) never appeared in the sitemap.
2. **Stale sitemap-index lastmod** (`2022-11-28` in production). `getAvailableReportMonths()` returns months sorted DESC (newest first at index 0), but the sitemap-index code used `reportMonths[reportMonths.length - 1]`, picking the *oldest* month.
3. The downstream effect of (2): Google's sitemap index uses lastmod to decide re-crawl priority. A 2022 date tells Google "nothing has changed here in 3.5 years," suppressing discovery of our most timely content.

## What shipped

- Added `getAllWeekKeys()` that returns every week with ≥1 deal_change (past + future), keeping `getRecentWeekKeys(n)` in place for any surface that still wants a windowed view.
- Switched `/sitemap-reports.xml` from `getRecentWeekKeys(4)` to `getAllWeekKeys()`.
- Switched the sitemap-index lastmod for the reports sitemap from the month-math fallback to `now`, since `/this-week` (which is inside that sitemap) always has a current lastmod.

## Verification

- Local server: `/sitemap-reports.xml` now lists 40 weeks (up from ~4), matching every week shown on `/digest/archive`.
- `/sitemap.xml` lastmod for sitemap-reports is today's date.
- 2 new tests added:
  - sitemap-reports.xml includes every week that `/digest/archive` lists
  - sitemap.xml's reports lastmod is within the last year
- 1,047 tests passing (up from 1,045). Full suite green.

Refs #894