### PR TITLE
fix: Gemini API — remove 2.5 Pro free tier claim (#896)

### DIFF
--- a/data/index.json
+++ b/data/index.json
@@ -1976,9 +1976,9 @@
     {
       "vendor": "Google Gemini API",
       "category": "AI / ML",
-      "description": "Free tier includes Flash, Flash-Lite, and 2.5 Pro (5 RPM) models. Per-model paid pricing: Gemini 3.1 Pro Preview $2/$12 per MTok (≤200K ctx, doubles above), Gemini 3.0 Flash Preview $0.50/$3, Gemini 3.1 Flash-Lite Preview $0.25/$1.50, Gemini 2.5 Pro $1.25/$10 (≤200K, doubles above), Gemini 2.5 Flash $0.30/$2.50. Free limits: Flash 10 RPM, Flash-Lite 15 RPM, 2.5 Pro 5 RPM. Gemini 2.0 Flash and 2.0 Flash-Lite deprecated June 1, 2026 — migrate to 2.5 Flash or 3.x Flash. All models support Batch/Flex at 50% discount. Mandatory spend caps enforced since April 1, 2026.",
+      "description": "Free tier is Flash-tier only: Gemini 2.5 Flash (10 RPM), Gemini 2.5 Flash-Lite (15 RPM), Gemini 3.0 Flash Preview, Gemini 3.1 Flash-Lite Preview, Gemini Embedding, and Gemma 4. 2.5 Pro and 3.1 Pro Preview are paid-only. Per-model paid pricing: Gemini 3.1 Pro Preview $2/$12 per MTok (≤200K ctx, doubles above), Gemini 3.0 Flash Preview $0.50/$3, Gemini 3.1 Flash-Lite Preview $0.25/$1.50, Gemini 2.5 Pro $1.25/$10 (≤200K, doubles above), Gemini 2.5 Flash $0.30/$2.50. Gemini 2.0 Flash and 2.0 Flash-Lite deprecated June 1, 2026 — migrate to 2.5 Flash or 3.x Flash. All models support Batch/Flex at 50% discount. Mandatory spend caps enforced since April 1, 2026.",
       "tier": "Free (Reduced)",
-      "url": "https://ai.google.dev/gemini-api/docs/pricing",
+      "url": "https://ai.google.dev/pricing",
       "tags": [
         "ai",
         "ml",
@@ -1989,7 +1989,7 @@
         "deal-change",
         "per-model-pricing"
       ],
-      "verifiedDate": "2026-04-17"
+      "verifiedDate": "2026-04-18"
     },
     {
       "vendor": "Mistral AI",


### PR DESCRIPTION
## Summary

Correction to the Gemini API entry: 2.5 Pro (and 3.1 Pro Preview) are paid-only per the current [pricing page](https://ai.google.dev/pricing). Free tier is Flash-tier models only.

## What shipped

- Updated description: free tier explicitly lists the Flash-tier models (2.5 Flash, 2.5 Flash-Lite, 3.0 Flash Preview, 3.1 Flash-Lite Preview, Gemini Embedding, Gemma 4) and calls out that 2.5 Pro / 3.1 Pro Preview are paid-only.
- URL updated to `https://ai.google.dev/pricing` (the canonical pricing page).
- `verifiedDate` bumped to 2026-04-18.

## No new deal_change — already covered

Per operational learning #36 (don't duplicate existing deal_changes):

- `2026-04-08` entry already documents "Gemini API free tier restricted to Flash and Flash-Lite models only" with source URL and alternatives.
- `2026-06-01` entry already documents the Gemini 2.0 Flash / Flash-Lite deprecation.
- `2026-03-03` entry already documents the 2.0 deprecation announcement.

Adding a third entry for the same event would be noise.

## Acceptance Criteria

- [x] Gemini API entry no longer mentions 2.5 Pro free tier
- [x] deal_change entry exists for the free tier removal (2026-04-08 already tracked)
- [x] Description reflects current free-tier models (Flash-tier only)
- [x] Tests pass (1,047/1,047)

## Verification

Local E2E: `curl /api/offers?q=Gemini+API` returns the corrected description.

## Note on prior regression

PR #877 (issue #875) added the "2.5 Pro (5 RPM)" claim to the description — that was based on my reading at the time but conflicts with the current pricing page. This PR reverts that specific claim while keeping the other #877 additions (per-model paid pricing table, spend-cap note).

Refs #896