### PR TITLE
fix: new-tier agent codes are active on submission (#906)

### DIFF
--- a/src/referral-codes.ts
+++ b/src/referral-codes.ts
@@ -193,8 +193,11 @@ export function submitReferralCode(opts: SubmitCodeOpts): SubmittedReferralCode 
     }
   }
 
-  // Determine initial status based on trust tier
-  const status: CodeStatus = opts.trust_tier === "new" ? "pending" : "active";
+  // All agent-submitted codes are active on submission, regardless of trust tier.
+  // Trust tier influences ranking weight (see TRUST_WEIGHTS below), not visibility —
+  // otherwise new-tier agents could never accumulate the conversions needed to
+  // advance past "new" (issue #906).
+  const status: CodeStatus = "active";
 
   const now = new Date().toISOString();
   const entry: SubmittedReferralCode = {

--- a/src/server.ts
+++ b/src/server.ts
@@ -1207,7 +1207,7 @@ Suggested monitoring cadence: run this check weekly to catch pricing changes ear
     "submit_referral_code",
     {
       description:
-        "Submit your own referral code for a vendor in the AgentDeals index. Requires authentication via API key (from register_agent). New agents' codes are pending review; verified/trusted agents' codes are auto-approved.",
+        "Submit your own referral code for a vendor in the AgentDeals index. Requires authentication via API key (from register_agent). Codes are active immediately; trust tier (new/verified/trusted) affects ranking weight, not visibility.",
       annotations: {
         readOnlyHint: false,
         destructiveHint: false,
@@ -1256,9 +1256,7 @@ Suggested monitoring cadence: run this check weekly to catch pricing changes ear
             success: true,
             code: submitted,
             trust_tier: trustTier,
-            message: submitted.status === "pending"
-              ? "Code submitted and pending review (new agent tier). It will be visible in search results once approved."
-              : "Code submitted and active. It is now visible in search results.",
+            message: "Code submitted and active. It is now visible in search results.",
           }, null, 2) }],
         };
       } catch (err: any) {

--- a/test/referral-codes.test.ts
+++ b/test/referral-codes.test.ts
@@ -60,11 +60,32 @@ describe("Referral Code Submission", () => {
     assert.strictEqual(code.code, "MYAGENT-RAILWAY");
     assert.strictEqual(code.referral_url, "https://railway.app?ref=myagent");
     assert.strictEqual(code.source, "agent-submitted");
-    assert.strictEqual(code.status, "pending"); // new tier = pending
+    // Issue #906: all agent-submitted codes are active immediately, regardless of tier.
+    assert.strictEqual(code.status, "active");
     assert.strictEqual(code.trust_tier_at_submission, "new");
     assert.strictEqual(code.impressions, 0);
     assert.strictEqual(code.clicks, 0);
     assert.strictEqual(code.conversions, 0);
+  });
+
+  it("new-tier agents get active codes (issue #906 — no chicken-and-egg)", () => {
+    const { agent } = createTestAgent();
+    const code = submitReferralCode({
+      vendor: "Railway",
+      code: "NEW-AGENT-CODE",
+      referral_url: "https://railway.app?ref=new",
+      description: "New-tier agent code",
+      agent_id: agent.id,
+      trust_tier: "new",
+    });
+
+    assert.strictEqual(code.status, "active");
+    assert.strictEqual(code.trust_tier_at_submission, "new");
+
+    // Code must be visible via the active-codes surface that search uses.
+    const activeCodes = getActiveCodesForVendor("Railway");
+    assert.strictEqual(activeCodes.length, 1);
+    assert.strictEqual(activeCodes[0].code, "NEW-AGENT-CODE");
   });
 
   it("verified agents get auto-approved codes", () => {
@@ -446,7 +467,7 @@ describe("Active Codes for Vendor", () => {
     resetFiles();
   });
 
-  it("returns only active codes for a vendor", () => {
+  it("returns only active codes for a vendor (excludes pending/revoked)", () => {
     const { agent: agent1 } = createTestAgent("Bot1");
     const { agent: agent2 } = createTestAgent("Bot2");
 
@@ -460,15 +481,29 @@ describe("Active Codes for Vendor", () => {
       trust_tier: "verified",
     });
 
-    // Pending code (not returned)
-    submitReferralCode({
+    // Seed a legacy pending code directly (pre-#906 data may still exist in
+    // production files). getActiveCodesForVendor must continue to exclude it.
+    const data = JSON.parse(fs.readFileSync(CODES_PATH, "utf-8"));
+    data.referral_codes.push({
+      id: "code_legacy_pending",
       vendor: "Railway",
-      code: "PENDING-CODE",
+      code: "LEGACY-PENDING",
       referral_url: "https://railway.app?ref=pending",
       description: "",
-      agent_id: agent2.id,
-      trust_tier: "new",
+      commission_rate: null,
+      expiry: null,
+      submitted_by: agent2.id,
+      source: "agent-submitted",
+      status: "pending",
+      trust_tier_at_submission: "new",
+      impressions: 0,
+      clicks: 0,
+      conversions: 0,
+      submitted_at: "2026-04-18T00:00:00.000Z",
+      updated_at: "2026-04-18T00:00:00.000Z",
     });
+    fs.writeFileSync(CODES_PATH, JSON.stringify(data, null, 2), "utf-8");
+    resetReferralCodesCache();
 
     const active = getActiveCodesForVendor("Railway");
     assert.strictEqual(active.length, 1);


### PR DESCRIPTION
## Summary

Refs #906.

New-tier agent codes were set to `status: "pending"` with no approval mechanism — and trust tiers only advance after 3+ conversions, which can only happen via visible codes. The whole Phase 3 marketplace was non-functional for any new agent.

## Changes

- `src/referral-codes.ts` line 197: drop the `trust_tier === "new" ? "pending" : "active"` gate. All agent-submitted codes start `active`. Trust tier still drives ranking weight via the existing `TRUST_WEIGHTS` map (new=1.0, verified=1.5, trusted=2.0).
- `src/server.ts`: update the `submit_referral_code` MCP tool description and the success message to drop the "pending review" language (no such review flow exists).
- Added comment at the mutation point explaining the chicken-and-egg rationale so this doesn't get re-introduced.

## Tests

- Updated `test/referral-codes.test.ts`: the baseline submit-new-tier test now asserts `status === "active"`; added a dedicated regression test (`new-tier agents get active codes (issue #906 — no chicken-and-egg)`) that submits as a new-tier agent and verifies the code appears in `getActiveCodesForVendor()`.
- Updated the `Active Codes for Vendor` exclusion test to seed a legacy pending code directly (since `submitReferralCode` no longer produces them), so `getActiveCodesForVendor`'s exclusion of pending/revoked status is still covered.
- `npm test`: **1,048 passing** (up from 1,047).

## End-to-end verification

Wired a fresh agent + fresh `referral_codes.json`, submitted as the `new` tier, then called `getActiveCodesForVendor("Railway")`:

```
Agent trust tier (no ledger): new
Submitted code status: active
Active codes for Railway: 1 E2E-NEW-TIER
PASS: true
```

## Acceptance criteria

- [x] Agent-submitted codes from any trust tier are discoverable via `GET /api/referral-codes` and vendor-specific lookups
- [x] Trust tier still influences code **ranking** (trusted codes ranked higher), not code **visibility**
- [x] Existing test suite passes
- [x] MCP tool description updated to reflect new behavior (removed "pending review" language)

## Notes

- The `"pending"` status remains in the `CodeStatus` union — legacy entries from before this change (or future admin-moderation flows) still parse correctly.
- `getActiveCodesForVendor` / `getAllActiveCodes` / the public `listAllReferralCodes` listing endpoint already filter on `status === "active"`, so legacy pending rows are naturally excluded from new surfaces.
- `my_referral_codes`'s `pending_codes` counter is kept (it'll return 0 going forward, but surfaces legacy data honestly).