### PR TITLE
fix: Testing data corrections — Applitools Eyes, everystep-automation (#902)

### DIFF
--- a/data/deal_changes.json
+++ b/data/deal_changes.json
@@ -1,6 +1,37 @@
 {
   "changes": [
     {
+      "vendor": "Applitools Eyes",
+      "change_type": "pricing_restructured",
+      "date": "2026-04-18",
+      "summary": "Free tier metric changed from 'checkpoints' to 'Test Units' (50/month) and user cap relaxed from 1 user to unlimited users. AI-powered visual regression detection unchanged.",
+      "previous_state": "Free tier: 1 user, 100 visual checkpoints/month",
+      "current_state": "Free tier: unlimited users, 50 Test Units/month",
+      "impact": "medium",
+      "source_url": "https://applitools.com/platform-pricing/",
+      "category": "Testing",
+      "alternatives": [
+        "BrowserStack Percy",
+        "Chromatic",
+        "Argos"
+      ]
+    },
+    {
+      "vendor": "everystep-automation.com",
+      "change_type": "free_tier_removed",
+      "date": "2026-04-18",
+      "summary": "Reclassified from Free to Trial tier. No permanent free plan exists — product offers a 30-day free trial only, after which paid licenses are required.",
+      "previous_state": "Free tier: records and replays browser steps, free with fewer options",
+      "current_state": "30-day free trial only — no permanent free tier",
+      "impact": "low",
+      "source_url": "https://www.everystep-automation.com/",
+      "category": "Testing",
+      "alternatives": [
+        "Selenium IDE",
+        "Playwright"
+      ]
+    },
+    {
       "vendor": "OpenAI Codex",
       "change_type": "pricing_restructured",
       "date": "2026-04-03",

--- a/data/index.json
+++ b/data/index.json
@@ -9741,15 +9741,15 @@
     {
       "vendor": "everystep-automation.com",
       "category": "Testing",
-      "description": "Records and replays all steps made in a web browser and creates scripts, free with fewer options",
-      "tier": "Free",
+      "description": "Desktop tool that records and replays all steps made in a web browser and creates scripts. 30-day free trial only — no permanent free tier. Paid licenses required after trial.",
+      "tier": "Trial",
       "url": "https://www.everystep-automation.com/",
       "tags": [
         "testing",
         "qa",
-        "free-for-dev"
+        "trial"
       ],
-      "verifiedDate": "2026-04-13"
+      "verifiedDate": "2026-04-18"
     },
     {
       "vendor": "gridlastic.com",
@@ -20893,7 +20893,7 @@
     {
       "vendor": "Applitools Eyes",
       "category": "Testing",
-      "description": "Free visual testing account for 1 user with 100 visual checkpoints per month. AI-powered visual regression detection. No credit card required.",
+      "description": "Free tier: 50 Test Units per month, unlimited users. AI-powered Visual AI testing to detect meaningful visual differences while ignoring acceptable rendering variations. Supports Playwright, Cypress, Selenium, Storybook. No credit card required.",
       "tier": "Free",
       "url": "https://applitools.com/platform-pricing/",
       "tags": [
@@ -20902,7 +20902,7 @@
         "ai",
         "regression"
       ],
-      "verifiedDate": "2026-04-13"
+      "verifiedDate": "2026-04-18"
     },
     {
       "vendor": "Artillery",

--- a/src/serve.ts
+++ b/src/serve.ts
@@ -10157,7 +10157,7 @@ ${buildCards(other)}
       <tr>
         <td style="font-weight:600"><a href="/vendor/applitools-eyes" style="color:var(--text)">Applitools Eyes</a></td>
         <td>Visual</td>
-        <td>100 checkpoints/mo</td>
+        <td>50 Test Units/mo</td>
         <td>No</td>
         <td>AI-powered visual testing</td>
       </tr>
@@ -10211,7 +10211,7 @@ ${buildCards(other)}
       <dd><a href="/vendor/cypress-cloud">Cypress Cloud</a> \u2014 500 test results/month free with parallelization, screenshots, and video recordings. The Cypress framework itself is open-source. <a href="/vendor/checkly">Checkly</a> adds synthetic monitoring on top of Playwright tests.</dd>
 
       <dt>Want to catch visual regressions in CI?</dt>
-      <dd><a href="/vendor/chromatic">Chromatic</a> for Storybook projects (5K snapshots/month). <a href="/vendor/browserstack-percy">BrowserStack Percy</a> for cross-browser visual diffs (5K screenshots/month). <a href="/vendor/applitools-eyes">Applitools Eyes</a> for AI-powered visual comparison (100 checkpoints/month).</dd>
+      <dd><a href="/vendor/chromatic">Chromatic</a> for Storybook projects (5K snapshots/month). <a href="/vendor/browserstack-percy">BrowserStack Percy</a> for cross-browser visual diffs (5K screenshots/month). <a href="/vendor/applitools-eyes">Applitools Eyes</a> for AI-powered visual comparison (50 Test Units/month, unlimited users).</dd>
 
       <dt>Need load testing for your API?</dt>
       <dd><a href="/vendor/grafana-k6-cloud">Grafana k6 Cloud</a> \u2014 500 VUh/month free with the scriptable k6 framework. <a href="/vendor/artillery">Artillery</a>, <a href="/vendor/gatling">Gatling</a>, and <a href="/vendor/locust">Locust</a> are fully open-source alternatives you can self-host.</dd>
@@ -42137,7 +42137,7 @@ ${mcpCtaCss()}
 
   <div class="diff-card">
     <h3>Applitools Eyes</h3>
-    <div class="diff-desc"><strong>Free tier:</strong> 100 visual checkpoints/month, 1 user. AI-powered visual testing that uses Visual AI to detect meaningful visual differences while ignoring acceptable rendering variations. Supports Playwright, Cypress, Selenium, Storybook, and more. The AI approach reduces false positives compared to pixel-based tools. The 100-checkpoint limit is restrictive for production use.</div>
+    <div class="diff-desc"><strong>Free tier:</strong> 50 Test Units/month, unlimited users. AI-powered visual testing that uses Visual AI to detect meaningful visual differences while ignoring acceptable rendering variations. Supports Playwright, Cypress, Selenium, Storybook, and more. The AI approach reduces false positives compared to pixel-based tools. The 50 Test Unit limit is restrictive for production use but the unlimited-users policy is team-friendly.</div>
   </div>
 
   <h2 id="load-performance">Load &amp; Performance Testing</h2>

--- a/test/deal-changes.test.ts
+++ b/test/deal-changes.test.ts
@@ -76,7 +76,7 @@ describe("track_changes tool", () => {
 
     assert.ok(Array.isArray(body.changes));
     assert.strictEqual(body.total, body.changes.length);
-    assert.strictEqual(body.total, 272);
+    assert.strictEqual(body.total, 274);
   });
 
   it("filters by date (since)", async () => {


### PR DESCRIPTION
## Summary

Refs #902.

- **Applitools Eyes** free tier updated to current pricing (50 Test Units/month, unlimited users). The old description referenced "100 checkpoints" and a 1-user cap — both wrong as of the current /platform-pricing/ page.
- **everystep-automation.com** reclassified from Free to Trial. The vendor only offers a 30-day trial; no permanent free plan exists.

## Changes

### data/index.json
- `Applitools Eyes`: new description ("Free tier: 50 Test Units per month, unlimited users…"), verifiedDate bumped to 2026-04-18.
- `everystep-automation.com`: tier `Free → Trial`, description rewritten, tag `free-for-dev → trial`, verifiedDate bumped.

### src/serve.ts
- Testing comparison table row: `100 checkpoints/mo → 50 Test Units/mo`.
- Alternatives guide blurb: `(100 checkpoints/month) → (50 Test Units/month, unlimited users)`.
- Testing hub `diff-card` for Applitools rewritten to match.

### data/deal_changes.json
Two new entries:
- `Applitools Eyes` — `pricing_restructured`, medium impact, dated 2026-04-18.
- `everystep-automation.com` — `free_tier_removed`, low impact, dated 2026-04-18. (Used `free_tier_removed` because `reclassified` isn't in the tool enum — the effect on users is the same.)

### test/deal-changes.test.ts
- Bumped `getDealChanges("2024-01-01")` total from 272 → 274 (two new entries).

## Tests

`npm test` — **1,048 passing**, no regressions.

E2E-verified via `loadOffers()`: the updated `description` and `tier` fields are returned correctly from the offers index.

## Acceptance criteria

- [x] Applitools Eyes updated to reflect current "50 Test Units, unlimited users" free tier
- [x] everystep-automation.com reclassified as Trial-only
- [x] Tests pass