### PR TITLE
Search category data corrections — CommandBar removed, bonsai.io fixed, searchly.com dead (#897)

### DIFF
--- a/data/deal_changes.json
+++ b/data/deal_changes.json
@@ -3818,6 +3818,22 @@
         "SiliconFlow",
         "OpenRouter"
       ]
+    },
+    {
+      "vendor": "searchly.com",
+      "change_type": "product_deprecated",
+      "date": "2026-04-19",
+      "summary": "searchly.com appears to be offline — homepage returns HTTP 502. Service previously offered 2 free indices and 20 MB storage. Removed from index.",
+      "previous_state": "Free 2 indices and 20 MB storage (hosted Elasticsearch)",
+      "current_state": "Site unreachable (HTTP 502), service appears discontinued — removed from index",
+      "impact": "negative",
+      "source_url": "https://searchly.com/",
+      "category": "Search",
+      "alternatives": [
+        "bonsai.io",
+        "Algolia",
+        "Elastic Cloud"
+      ]
     }
   ]
 }

--- a/data/index.json
+++ b/data/index.json
@@ -11652,38 +11652,14 @@
     {
       "vendor": "bonsai.io",
       "category": "Search",
-      "description": "Free 1 GB memory and 1 GB storage",
+      "description": "Free Sandbox plan: 125 MB memory, 125 MB storage, 35K documents. Free forever. Managed Elasticsearch.",
       "tier": "Free",
-      "url": "https://bonsai.io/",
+      "url": "https://bonsai.io/pricing",
       "tags": [
         "search",
         "free-for-dev"
       ],
-      "verifiedDate": "2026-04-13"
-    },
-    {
-      "vendor": "CommandBar",
-      "category": "Search",
-      "description": "Unified Search Bar as-a-service, web-based UI widget/plugin that allows your users to search contents, navigations, features, etc. within your product, which helps discoverability. Free for up to 1,000 Monthly Active Users, unlimited commands.",
-      "tier": "Free",
-      "url": "https://www.commandbar.com/",
-      "tags": [
-        "search",
-        "free-for-dev"
-      ],
-      "verifiedDate": "2026-04-13"
-    },
-    {
-      "vendor": "searchly.com",
-      "category": "Search",
-      "description": "Free 2 indices and 20 MB storage",
-      "tier": "Free",
-      "url": "http://www.searchly.com/",
-      "tags": [
-        "search",
-        "free-for-dev"
-      ],
-      "verifiedDate": "2026-04-13"
+      "verifiedDate": "2026-04-19"
     },
     {
       "vendor": "10minutemail",

--- a/test/deal-changes.test.ts
+++ b/test/deal-changes.test.ts
@@ -76,7 +76,7 @@ describe("track_changes tool", () => {
 
     assert.ok(Array.isArray(body.changes));
     assert.strictEqual(body.total, body.changes.length);
-    assert.strictEqual(body.total, 274);
+    assert.strictEqual(body.total, 275);
   });
 
   it("filters by date (since)", async () => {


### PR DESCRIPTION
## Summary

Three Search-category data corrections per PM spot-check.

- **CommandBar — removed.** Rebranded to Command AI (Amplitude acquisition); commandbar.com redirects to command.ai. No free tier on any plan — demo-required. The existing \`rebranded\` deal_change from 2026-04-13 (pre-filed) already documents this rebrand, so no duplicate entry.
- **bonsai.io — description corrected.** Previous: \"Free 1 GB memory and 1 GB storage\" (8x overstated). Actual Sandbox plan: **125 MB memory, 125 MB storage, 35K documents**. URL updated to /pricing, verifiedDate refreshed.
- **searchly.com — removed.** Homepage returns HTTP 502. Added a \`product_deprecated\` deal_change with alternatives (bonsai.io, Algolia, Elastic Cloud).

## Stats
- 1,592 offers (down 2 from 1,594)
- 275 deal changes (up 1 from 274)
- 1,048 tests passing

## Notes

- Test assertion \`test/deal-changes.test.ts:79\` was pinned at 274 — bumped to 275 to match the new deal_change. Standard maintenance.
- No \`serve.ts\` references to any of these three vendors (grepped src/ — only deal_changes.json had a CommandBar entry).

## Acceptance Criteria
- [x] CommandBar entry removed
- [x] bonsai.io description corrected to 125 MB memory, 125 MB storage, 35K docs
- [x] searchly.com entry removed (and \`product_deprecated\` deal_change logged)
- [x] Tests pass

## Test plan
- [x] \`npm test\` → 1,048/1,048 passing
- [x] \`node -e 'JSON.parse(...)' data/index.json\` and data/deal_changes.json validate clean
- [x] No src/ references to any removed vendor

Refs #897