### PR TITLE
Add: Amazon SP-API entry to API Development (#895)

### DIFF
--- a/data/deal_changes.json
+++ b/data/deal_changes.json
@@ -1,6 +1,18 @@
 {
   "changes": [
     {
+      "vendor": "Amazon SP-API",
+      "change_type": "pricing_restructured",
+      "date": "2025-11-03",
+      "summary": "Amazon announced SP-API would move from free to paid. $1,400/year annual fee for third-party developers (activated 2026-01-31), with per-call fees of $0.40 per 1K GET calls above tier allowance scheduled to begin 2026-04-30. Tiered allowances: Basic (2.5M GET calls/month), Pro ($1K/mo, 25M calls), Plus ($10K/mo, 250M calls), Enterprise (custom). Sellers/vendors using SP-API for their own business remain exempt.",
+      "previous_state": "Free for all developers, 10+ years of free API access",
+      "current_state": "Paid structure announced — $1,400/year + tiered per-call fees for third-party developers, starting 2026-01-31 (annual) and 2026-04-30 (per-call)",
+      "impact": "high",
+      "source_url": "https://developer.amazonservices.com/",
+      "category": "API Development",
+      "alternatives": []
+    },
+    {
       "vendor": "Xata",
       "change_type": "pricing_model_change",
       "date": "2026-04-19",

--- a/data/index.json
+++ b/data/index.json
@@ -6067,6 +6067,23 @@
       "verifiedDate": "2026-04-19"
     },
     {
+      "vendor": "Amazon SP-API",
+      "category": "API Development",
+      "description": "Amazon Selling Partner API for building seller and vendor tools on Amazon. Sellers/vendors using SP-API for their own business remain fully exempt (free). Third-party developers: $1,400/year annual fee active since Jan 31 2026; Basic tier includes 2.5M GET calls/month. Per-call overage fees ($0.40 per 1K GET calls) were scheduled for 2026-04-30 but postponed indefinitely after developer backlash — no new date announced.",
+      "tier": "Exempt / Paid",
+      "url": "https://developer.amazonservices.com/",
+      "tags": [
+        "api",
+        "amazon",
+        "ecommerce",
+        "marketplace",
+        "sp-api",
+        "selling-partner",
+        "developer-tools"
+      ],
+      "verifiedDate": "2026-04-19"
+    },
+    {
       "vendor": "Uptimia",
       "category": "Monitoring",
       "description": "Website uptime monitoring — free plan: 1 website, 5-minute check interval, basic uptime monitoring, email alerts. No credit card required",

--- a/test/deal-changes.test.ts
+++ b/test/deal-changes.test.ts
@@ -76,7 +76,7 @@ describe("track_changes tool", () => {
 
     assert.ok(Array.isArray(body.changes));
     assert.strictEqual(body.total, body.changes.length);
-    assert.strictEqual(body.total, 277);
+    assert.strictEqual(body.total, 278);
   });
 
   it("filters by date (since)", async () => {


### PR DESCRIPTION
Refs #895

## Summary
Adds Amazon SP-API to the index, closing a zero-result search gap. \"amazon sp-api\" has 2 searches in 7 days with 0 results.

**Entry (API Development):**
- `tier: Exempt / Paid` — sellers/vendors using SP-API for their own business are fully exempt; third-party developers pay \$1,400/year annual fee (active since 2026-01-31). Basic tier includes 2.5M GET calls/month. Per-call overage fees of \$0.40/1K GET calls (originally 2026-04-30) are postponed indefinitely.
- Tags: api, amazon, ecommerce, marketplace, sp-api, selling-partner, developer-tools
- Inserted after the Hasura API Development entry for logical proximity.

## Decision: \"tier\" reflects the nuance, not a blanket \"Free\"
The PM's issue framed SP-API as \"currently free for all developers\" because per-call fees are delayed. But the existing deal_change history (2026-01-31 `pricing_restructured`) documents the $1,400/year annual fee *did* activate for third-party developers — only per-call overages are postponed (2026-04-14 `pricing_postponed`). Using the existing data as the source of truth, the third-party developer path is paid; only the seller/vendor self-use path is truly free. I labeled the tier `Exempt / Paid` and spelled out the split in the description rather than calling it uniformly \"Free\".

## Deal change (+1)
- `Amazon SP-API` — `pricing_restructured` on 2025-11-03 — original announcement that introduced the paid structure. Chose `pricing_restructured` over `pricing_postponed` because this event is the announcement itself; the 2026-04-14 `pricing_postponed` entry already covers the per-call delay. Timeline now reads: announcement (Nov 2025) → activation (Jan 2026) → per-call postponement (Apr 2026).

Bumped `test/deal-changes.test.ts:79` total assertion 277 → 278.

## Acceptance criteria
- [x] Amazon SP-API entry exists in `data/index.json` under API Development
- [x] Deal change entry recorded (2025-11-03)
- [x] Searching \"amazon sp-api\" returns the entry — verified via `/api/offers?q=amazon%20sp-api` returns exactly 1 result
- [x] Tests pass (1,048/1,048)

## Test plan
- [x] `npm test` — 1,048 passing
- [x] Rebuilt `dist/`, started server with `BASE_URL=http://localhost:9889`:
  - `/api/offers?q=amazon sp-api` → 1 result, tier `Exempt / Paid`
  - `/vendor/amazon-sp-api` → HTTP 200, renders full description
  - `/api/changes?since=2025-11-01` → 3 SP-API events in chronological timeline