### PR TITLE
Fix Dev Utilities data: ipapi + CurrencyFreaks (issue #913)

### DIFF
--- a/data/index.json
+++ b/data/index.json
@@ -5455,16 +5455,16 @@
     {
       "vendor": "ipapi",
       "category": "Dev Utilities",
-      "description": "IP address geolocation API — free tier: 100 API requests/month. Includes location, timezone, currency data. No HTTPS on free tier. Paid plans from $12.99/mo for 50K requests",
+      "description": "IP address geolocation API — free tier: 1,000 IP lookups/day (~30,000/month). Includes location, timezone, currency data. Designed for testing & development only; not intended for production. Additional heuristic throttling may apply. Paid plans unlock production use.",
       "tier": "Free",
-      "url": "https://ipapi.com/pricing",
+      "url": "https://ipapi.co/#pricing",
       "tags": [
         "api",
         "geolocation",
         "ip-lookup",
         "location"
       ],
-      "verifiedDate": "2026-04-12"
+      "verifiedDate": "2026-04-19"
     },
     {
       "vendor": "Hunter.io",
@@ -5499,7 +5499,7 @@
     {
       "vendor": "CurrencyFreaks",
       "category": "Dev Utilities",
-      "description": "Currency exchange rate API — free tier: 1,000 API requests/month, 170+ currencies, daily updated rates. Includes latest rates and historical data endpoints",
+      "description": "Currency exchange rate API — free tier: 1,000 API requests/month, 170+ response currencies, daily updated rates, USD base currency only (paid plans unlock all base currencies). Includes latest rates and historical data endpoints.",
       "tier": "Free",
       "url": "https://currencyfreaks.com/pricing.html",
       "tags": [
@@ -5509,7 +5509,7 @@
         "finance",
         "forex"
       ],
-      "verifiedDate": "2026-04-12"
+      "verifiedDate": "2026-04-19"
     },
     {
       "vendor": "MailboxValidator",


### PR DESCRIPTION
## Summary

Refs #913 — two data corrections in the Dev Utilities category, both verified against the vendor pricing pages on 2026-04-19.

### 1. ipapi — URL + free tier corrected

- **URL:** `https://ipapi.com/pricing` → `https://ipapi.co/#pricing`. These are two different vendors; our existing description matched ipapi.co (not .com), so the URL was wrong all along.
- **Free tier:** `100 API requests/month` → `1,000 IP lookups/day (~30,000/month)`. Previous figure understated the free tier by ~300x.
- Added the key caveat that ipapi.co calls out explicitly: free tier is for testing & development only, not production, and "additional heuristics" may further throttle calls.
- `verifiedDate` → 2026-04-19.

### 2. CurrencyFreaks — USD-only base currency restriction added

- Free plan: 1,000 requests/month (unchanged, already correct).
- Added missing base-currency restriction: the free tier is **USD base only** — paid plans unlock all base currencies.
- Clarified that "170+ currencies" refers to **response** currencies (what you can convert TO). You can only convert FROM USD on the free plan.
- `verifiedDate` → 2026-04-19.

## Decisions

- **No deal_change entries added.** Both corrections are pure data-accuracy fixes — not vendor-side pricing changes. ipapi.co's 1,000/day and CurrencyFreaks' USD-only base restriction were present on the pricing pages before our last verifiedDate; our entries just had them wrong. deal_changes tracks real changes over time (op-learning #36) — not edits to our own records.
- **No change_type mapping needed** (op-learning #43 doesn't apply here).

## Test plan

- [x] `npm run build` — clean
- [x] `npm test` — 1,048/1,048 passing, no regressions
- [x] E2E via `BASE_URL=http://localhost:PORT node dist/serve.js` (op-learning #46): `GET /api/offers?q=ipapi` and `?q=CurrencyFreaks` both return the updated descriptions with the new `verifiedDate: 2026-04-19`.

## Acceptance criteria

- [x] ipapi entry updated to "1,000 API requests/day" (not 100/month) — spelled out as "1,000 IP lookups/day (~30,000/month)" plus the testing-only caveat.
- [x] CurrencyFreaks entry updated to note USD-only base currency on free tier.
- [x] Both entries have verified_date updated to today.
- [x] Tests pass.