### PR TITLE
Security + Storage data corrections (issue #915)

### DIFF
--- a/data/deal_changes.json
+++ b/data/deal_changes.json
@@ -3874,6 +3874,23 @@
         "Algolia",
         "Elastic Cloud"
       ]
+    },
+    {
+      "vendor": "ImageEngine",
+      "change_type": "free_tier_removed",
+      "date": "2026-04-19",
+      "summary": "ImageEngine's free developer program is no longer on offer. Only access path is a 30-day free trial (no credit card), followed by flat-rate enterprise licensing. Reclassified to Trial tier.",
+      "previous_state": "Free developer account available via imageengine.io/developer-program",
+      "current_state": "30-day free trial only; flat-rate enterprise licensing after trial",
+      "impact": "medium",
+      "source_url": "https://imageengine.io/",
+      "category": "Storage",
+      "alternatives": [
+        "Cloudinary",
+        "ImageKit",
+        "Uploadcare",
+        "imgix"
+      ]
     }
   ]
 }

--- a/data/index.json
+++ b/data/index.json
@@ -8951,14 +8951,14 @@
     {
       "vendor": "Wormhole",
       "category": "Storage",
-      "description": "Share files up to 5GB with end-to-end encryption for up to 24hours. For files larger than 5 GB, it uses peer-to-peer transfer to send your files directly.",
+      "description": "Share files up to 10 GB with end-to-end encryption. Files ≤5 GB are server-stored for 24 hours; files >5 GB use peer-to-peer transfer sent directly between endpoints.",
       "tier": "Free",
       "url": "https://wormhole.app/",
       "tags": [
         "developer-tools",
         "free-for-dev"
       ],
-      "verifiedDate": "2026-04-12"
+      "verifiedDate": "2026-04-19"
     },
     {
       "vendor": "zoom.us",
@@ -10030,14 +10030,14 @@
     {
       "vendor": "Corgea",
       "category": "Security",
-      "description": "Free autonomous security platform that finds, validates and fixes insecure code and packages across +20 languages and frameworks. Free plan includes 1 user and 2 repos.",
+      "description": "Free autonomous security platform that finds, validates and fixes insecure code and packages across +20 languages and frameworks. Free plan includes 10 repos, 10 PR scans/month, and 10 SAST auto fixes. Features: AI SAST, Logic/Auth Scanning, Dependency Scanning, Secrets Detection, Container Scanning, IaC Scanning.",
       "tier": "Free",
-      "url": "https://corgea.com/",
+      "url": "https://corgea.com/pricing/",
       "tags": [
         "security",
         "free-for-dev"
       ],
-      "verifiedDate": "2026-04-12"
+      "verifiedDate": "2026-04-19"
     },
     {
       "vendor": "crypteron.com",
@@ -14986,15 +14986,15 @@
     {
       "vendor": "ImageEngine",
       "category": "Storage",
-      "description": "ImageEngine is an easy to use global image CDN. Sub 60 sec setup. AVIF and JPEGXL support, WordPress-, Magento-, React-, Vue- plugins and more. Claim your free developer account [here](https://imageengine.io/developer-program/).",
-      "tier": "Free",
+      "description": "Global image CDN with sub-60-second setup, AVIF and JPEGXL support, and WordPress/Magento/React/Vue plugins. 30-day free trial only — no credit card required. Flat-rate enterprise licensing after trial; no permanent free developer tier.",
+      "tier": "Trial",
       "url": "https://imageengine.io/",
       "tags": [
         "storage",
         "media",
-        "free-for-dev"
+        "trial"
       ],
-      "verifiedDate": "2026-04-12"
+      "verifiedDate": "2026-04-19"
     },
     {
       "vendor": "ImgBB",
@@ -15177,15 +15177,15 @@
     {
       "vendor": "podio.com",
       "category": "Storage",
-      "description": "Work management platform — up to 5 users on free plan, task management, apps, workspaces, basic workflow automations. 1 GB storage. Citrix-backed",
+      "description": "Work management platform owned by Progress Software — free plan: 5 users, 100 items max across organization, 1,000 API calls daily. Task management, apps, workspaces, basic workflow automations.",
       "tier": "Free",
-      "url": "https://podio.com/",
+      "url": "https://www.progress.com/podio/pricing",
       "tags": [
         "storage",
         "media",
         "free-for-dev"
       ],
-      "verifiedDate": "2026-04-14"
+      "verifiedDate": "2026-04-19"
     },
     {
       "vendor": "Proton Drive",

--- a/test/deal-changes.test.ts
+++ b/test/deal-changes.test.ts
@@ -76,7 +76,7 @@ describe("track_changes tool", () => {
 
     assert.ok(Array.isArray(body.changes));
     assert.strictEqual(body.total, body.changes.length);
-    assert.strictEqual(body.total, 278);
+    assert.strictEqual(body.total, 279);
   });
 
   it("filters by date (since)", async () => {


### PR DESCRIPTION
## Summary

Four data-accuracy fixes flagged by the PM audit (issue #915): 1 Security entry + 3 Storage entries.

- **Corgea** — free plan expanded from "1 user / 2 repos" to 10 repos, 10 PR scans/month, 10 SAST auto fixes. URL → corgea.com/pricing. Feature list refreshed (AI SAST, Logic/Auth, Dependency, Secrets, Container, IaC).
- **ImageEngine** — reclassified Free → Trial. No permanent free developer tier, only a 30-day trial with flat-rate enterprise licensing after. Tags `free-for-dev` → `trial`. Added deal_change `free_tier_removed` (medium impact) since the developer program previously granted a free account.
- **podio.com** — ownership corrected: Citrix divested Podio; Progress Software now owns it. Added missing 100-item organization cap and 1,000 daily-API-call limit. URL → progress.com/podio/pricing.
- **Wormhole** — file size limit corrected 5 GB → 10 GB. Description clarifies that files ≤5 GB are server-stored for 24h and files >5 GB use peer-to-peer transfer.

## Decisions

- **ImageEngine gets a deal_change; the others do not.** ImageEngine's free developer program used to exist (the old URL `imageengine.io/developer-program` was live) and was retired — that's a real vendor-side event worth recording. Corgea/Podio/Wormhole corrections are pure data accuracy fixes (our entries were wrong about values that have likely been unchanged on the vendor side), so per op-learning #36 they don't get deal_change entries.
- **Tier: Trial (not removal) for ImageEngine.** ImageEngine is referenced by name in the `mediaCdn` grouping in `serve.ts`, so removing the entry would require additional edits. Reclassifying to Trial preserves the grouping and follows the precedent set by Logz.io and everystep-automation.com which also carry `tier: Trial`.

## Test plan

- [x] `npm run build` clean
- [x] `npm test` — 1,048 tests passing
- [x] `test/deal-changes.test.ts` total bumped 278 → 279 for new ImageEngine entry
- [x] E2E verified against local `/api/offers` (all four vendors return updated descriptions, tiers, URLs, and tags) and `/api/changes?vendor=ImageEngine` (returns the new free_tier_removed entry)

Refs #915