### PR TITLE
Data corrections: Analytics + Communication (6 vendors)

### DIFF
--- a/data/index.json
+++ b/data/index.json
@@ -8651,14 +8651,14 @@
     {
       "vendor": "ruttl.com",
       "category": "Communication",
-      "description": "The best all-in-one feedback tool to collect digital feedback and review websites, PDFs, and images.",
+      "description": "All-in-one visual feedback tool to collect digital feedback and review websites, PDFs, and images. Free plan: 1 project, 5 pages, 5 users, unlimited guests; integrations with Trello, Slack, Asana, and Jira. Pro begins at $15/user/month.",
       "tier": "Free",
-      "url": "https://ruttl.com/",
+      "url": "https://ruttl.com/pricing/",
       "tags": [
         "developer-tools",
         "free-for-dev"
       ],
-      "verifiedDate": "2026-04-13"
+      "verifiedDate": "2026-04-19"
     },
     {
       "vendor": "Screen Sharing via Browser",
@@ -8687,14 +8687,14 @@
     {
       "vendor": "SiteDots",
       "category": "Communication",
-      "description": "Share feedback for website projects directly on your website, no emulation, canvas or workarounds. Completely functional free tier.",
+      "description": "Share feedback for website projects directly on your website — no emulation, canvas, or workarounds. Free plan: 1 project/domain, 3 users per project, 6 dots per project, unlimited projects you can join. Many integrations listed as \"coming soon\".",
       "tier": "Free",
-      "url": "https://sitedots.com/",
+      "url": "https://sitedots.com/pricing",
       "tags": [
         "developer-tools",
         "free-for-dev"
       ],
-      "verifiedDate": "2026-04-13"
+      "verifiedDate": "2026-04-19"
     },
     {
       "vendor": "Slab",
@@ -14446,14 +14446,14 @@
     {
       "vendor": "Helploom",
       "category": "Communication",
-      "description": "Customer support software that offers a live chat on the free forever plan. Simple, lightweight and beautiful. Setup is a simple copy-paste script. Built by a developer.",
+      "description": "Customer support software with live chat widget, simple copy-paste setup, and Slack integration. Free plan: 30 threads/month, 3 users, live chat widget, limited Help Center. Built by a developer.",
       "tier": "Free",
-      "url": "https://helploom.com",
+      "url": "https://helploom.com/pricing",
       "tags": [
         "developer-tools",
         "free-for-dev"
       ],
-      "verifiedDate": "2026-04-13"
+      "verifiedDate": "2026-04-19"
     },
     {
       "vendor": "Hygger",
@@ -17202,15 +17202,15 @@
     {
       "vendor": "AppFit",
       "category": "Analytics",
-      "description": "AppFit is a comprehensive analytics and product management tool designed to facilitate seamless, cross-platform management of analytics and product updates. Free plan includes 10,000 events per month, product journal and weekly insights.",
+      "description": "Cross-platform product analytics and release management tool. Free plan is manual-entry only — no automated event tracking — with product journal, weekly email insights, and unlimited team members. Automated event tracking (200K events, 12-week history) begins at Starter $9/month.",
       "tier": "Free",
-      "url": "https://appfit.io",
+      "url": "https://appfit.io/product/pricing",
       "tags": [
         "analytics",
         "statistics",
         "free-for-dev"
       ],
-      "verifiedDate": "2026-04-12"
+      "verifiedDate": "2026-04-19"
     },
     {
       "vendor": "Aptabase",
@@ -17254,20 +17254,20 @@
     {
       "vendor": "Fivetran Activations",
       "category": "Analytics",
-      "description": "Reverse ETL platform. Acquired by Fivetran. Now part of Fivetran Activations.",
+      "description": "Reverse ETL platform (formerly Census, acquired by Fivetran). Free plan: 3,500 Monthly Active Rows (MAR) per month for Activations with access to standard-plan features; paid plans (Standard / Enterprise / Business Critical) above the MAR threshold.",
       "tier": "Free",
-      "url": "https://fivetran.com/",
+      "url": "https://www.fivetran.com/pricing",
       "tags": [
         "analytics",
         "statistics",
         "free-for-dev"
       ],
-      "verifiedDate": "2026-04-12"
+      "verifiedDate": "2026-04-19"
     },
     {
       "vendor": "Clicky",
       "category": "Analytics",
-      "description": "Website Analytics Platform. Free Plan for one website with 3000 views analytics.",
+      "description": "Privacy-focused real-time web analytics (GDPR-compliant, no cookies). Free plan: 1 website, 3,000 daily pageviews, 30-day history retention.",
       "tier": "Free",
       "url": "https://clicky.com",
       "tags": [
@@ -17275,7 +17275,7 @@
         "statistics",
         "free-for-dev"
       ],
-      "verifiedDate": "2026-04-12"
+      "verifiedDate": "2026-04-19"
     },
     {
       "vendor": "counter.dev",


### PR DESCRIPTION
## Summary

Resolves PM data audit findings in issue #917. Six entries across Analytics (3) and Communication (3) had missing, misleading, or wrong free-tier limits from the original bulk free-for-dev import. Each correction verified against the vendor's live pricing page before update.

## Changes

**Analytics**
- **AppFit** — free plan is manual-entry journaling only, no automated event tracking. Fixed misleading "10,000 events/month" description. Paid Starter ($9/mo) is where automated tracking + 200K events begins.
- **Clicky** — clarified the ambiguous "3000 views" as "1 website, 3,000 daily pageviews, 30-day retention".
- **Fivetran Activations** — replaced stub description with actual free-plan limit (3,500 Monthly Active Rows per month for reverse ETL).

**Communication**
- **ruttl.com** — added specific limits: 1 project, 5 pages, 5 users, unlimited guests. Pro starts at $15/user/month.
- **SiteDots** — added specific limits: 1 project/domain, 3 users, 6 dots per project. Integration list noted as "coming soon".
- **Helploom** — added specific limits: 30 threads/month, 3 users, live chat widget.

## Decisions

- **No deal_change entries added.** All 6 are pure data-accuracy fixes, not vendor-side pricing changes — the PM's sources show these limits have likely been stable; our data was just wrong. Per op-learning #36, deal_changes tracks real change over time, not edits to our own records.
- **AppFit kept at tier: Free, not reclassified.** There IS a free plan — it's just manual-entry, which the rewritten description now makes explicit. Reclassifying to Trial would misrepresent the vendor's actual offering.
- **URLs updated** to canonical pricing/ pages where the PM cited them (AppFit, Fivetran, ruttl, SiteDots, Helploom).
- **verifiedDate bumped to 2026-04-19** for all 6.

## Test plan
- [x] Tests pass (1,048 / 1,048)
- [x] Build succeeds
- [x] E2E verified via `BASE_URL=http://localhost:9892 node dist/serve.js` — all 6 updated descriptions and verifiedDates served correctly by /api/offers

Refs #917