### PR TITLE
Data corrections: Code Quality + CMS categories (#919)

### DIFF
--- a/data/index.json
+++ b/data/index.json
@@ -9083,16 +9083,16 @@
     {
       "vendor": "Storyblok",
       "category": "Headless CMS",
-      "description": "A Headless CMS for developers and marketers that works with all modern frameworks. The Community (free) tier offers Management API, Visual Editor, ten sources, Custom Field Types, Internationalization (unlimited languages/locales), Asset Manager (up to 2500 assets), Image Optimizing Service, Search Query, Webhook + 250GB Traffic/month included.",
+      "description": "Headless CMS with visual editor for developers and marketers. Free Starter plan: 1 space, 1 user seat (max 2 with +$15/mo add-on), 100K API requests/month, 2 locales, 200 components, 20K stories max, 2,000 assets, 100 GB traffic/month, 25K AI credits/month, 10 datasources, 3 webhooks, 2 preview URLs. No credit card required.",
       "tier": "Free",
-      "url": "https://www.storyblok.com",
+      "url": "https://www.storyblok.com/pricing",
       "tags": [
         "cms",
         "headless",
         "content",
         "free-for-dev"
       ],
-      "verifiedDate": "2026-04-13"
+      "verifiedDate": "2026-04-19"
     },
     {
       "vendor": "TinaCMS",
@@ -9245,14 +9245,14 @@
     {
       "vendor": "coderabbit.ai",
       "category": "Code Quality",
-      "description": "AI-powered code review tool that integrates with GitHub/GitLab. Free tier includes 200 files/hour, 3 reviews per hour, and 50 conversations/hour. Free forever for open source projects.",
+      "description": "AI-powered code review tool for GitHub/GitLab/Bitbucket. Free tier: basic PR summarization and reviews in IDE on unlimited public and private repositories, with a 14-day Pro trial included (no credit card). Paid Pro is $24/user/month billed annually and adds detailed reviews with 5 reviews/hour; Pro Plus adds 10 reviews/hour. Free-for-open-source may still apply but is no longer prominently featured on the pricing page.",
       "tier": "Free",
-      "url": "https://coderabbit.ai",
+      "url": "https://www.coderabbit.ai/pricing",
       "tags": [
         "developer-tools",
         "free-for-dev"
       ],
-      "verifiedDate": "2026-04-13"
+      "verifiedDate": "2026-04-19"
     },
     {
       "vendor": "CodSpeed",
@@ -9308,18 +9308,6 @@
       "description": "Instantly find the differences between two blocks of code. Completely free to use.",
       "tier": "Free",
       "url": "https://difftext.com",
-      "tags": [
-        "developer-tools",
-        "free-for-dev"
-      ],
-      "verifiedDate": "2026-04-13"
-    },
-    {
-      "vendor": "eversql.com",
-      "category": "Code Quality",
-      "description": "EverSQL - The #1 platform for database optimization. Gain critical insights into your database and SQL queries automatically.",
-      "tier": "Free",
-      "url": "https://www.eversql.com/",
       "tags": [
         "developer-tools",
         "free-for-dev"


### PR DESCRIPTION
## Summary

Three vendor data corrections from PM audit (issue #919):

- **CodeRabbit (Code Quality)** — removed unpublished rate limits (200 files/hr, 3 reviews/hr, 50 conversations/hr) no longer on their pricing page; rewrote description to reflect actual free tier: basic PR summarization + IDE reviews on unlimited public and private repos, with a 14-day Pro trial included. Noted $24/user/mo Pro (billed annually) and 5 reviews/hr rate limit. Free-for-open-source caveat preserved. URL → `/pricing`.
- **EverSQL (Code Quality)** — entry removed. Acquired by Aiven in Nov 2023; eversql.com now redirects to aiven.io. The Aiven SQL Query Optimizer tool is explicitly "Free during the Early Availability period" (temporary, not a permanent free tier), so it doesn't qualify for inclusion.
- **Storyblok (Headless CMS)** — Free Starter plan limits corrected per storyblok.com/pricing: 2 locales (was "unlimited"), 2,000 assets (was 2,500), 100K API requests/month (was missing), 1 space, 1 user seat (max 2 with $15/mo add-on), 100 GB traffic/month, 25K AI credits/month, 200 components, 20K stories, 10 datasources, 3 webhooks, 2 preview URLs.

### Deal_changes

No deal_change entries added. Per op-learning #36, deal_changes tracks real vendor-side changes over time, not edits to our own records.
- CodeRabbit: rate limits likely disappeared from their pricing page at some point; that transition predates our tracking window and our record was stale.
- Storyblok: all incorrect limits were wrong-from-origin (bulk free-for-dev import metadata gaps).
- EverSQL: the Aiven acquisition is from Nov 2023, well outside the tracking window; treated as stale-entry cleanup.

## Verification

- `npm test` — 1,048 tests passing, no regressions.
- E2E via `BASE_URL=http://localhost:9893 node dist/serve.js`:
  - `/api/offers?q=coderabbit` returns updated description + `/pricing` URL.
  - `/api/offers?q=storyblok` returns updated description + `/pricing` URL.
  - `/api/offers?q=eversql` returns 0 offers (removed).
- All three PM claims verified against live vendor pricing pages via WebFetch before editing.

## Test plan

- [x] npm test passes (1,048/1,048)
- [x] tsc build passes
- [x] E2E: CodeRabbit description reflects "basic PR summarization + IDE reviews"
- [x] E2E: EverSQL returns zero results
- [x] E2E: Storyblok description shows "2 locales" and "2,000 assets"

Refs #919