### PR TITLE
Data corrections: Design + Project Management categories (#922)

### DIFF
--- a/data/index.json
+++ b/data/index.json
@@ -1555,7 +1555,7 @@
     {
       "vendor": "Linear",
       "category": "Project Management",
-      "description": "Project management for dev teams — 250 active issues (unlimited archived), unlimited members, 2 teams, AI agents, API",
+      "description": "Project management for dev teams — 250 issues, unlimited members, 2 teams, AI agents, API, 10MB file upload limit.",
       "tier": "Free",
       "url": "https://linear.app/pricing",
       "tags": [
@@ -1565,7 +1565,7 @@
         "agile",
         "free tier"
       ],
-      "verifiedDate": "2026-04-12"
+      "verifiedDate": "2026-04-19"
     },
     {
       "vendor": "Snyk",
@@ -3540,7 +3540,7 @@
     {
       "vendor": "Figma",
       "category": "Design",
-      "description": "Collaborative design tool — 3 Figma design files, 3 FigJam files, unlimited drafts, unlimited viewers, 30-day version history, unlimited cloud storage",
+      "description": "Collaborative design tool — free Starter plan with unlimited drafts, unlimited viewers, unlimited cloud storage, 30-day version history, 150 AI credits/day (500/mo). Team projects limited to 3 files.",
       "tier": "Starter",
       "url": "https://www.figma.com/pricing/",
       "tags": [
@@ -3550,7 +3550,7 @@
         "collaboration",
         "free tier"
       ],
-      "verifiedDate": "2026-04-12"
+      "verifiedDate": "2026-04-19"
     },
     {
       "vendor": "Canva",
@@ -8759,14 +8759,14 @@
     {
       "vendor": "Teamcamp",
       "category": "Project Management",
-      "description": "All-in-one project management application for software development companies.",
+      "description": "All-in-one project management — free for up to 10 users, unlimited projects, 250 tasks, 1 GB storage, time tracking, docs, invoicing.",
       "tier": "Free",
-      "url": "https://www.teamcamp.app",
+      "url": "https://www.teamcamp.app/pricing",
       "tags": [
         "developer-tools",
         "free-for-dev"
       ],
-      "verifiedDate": "2026-04-12"
+      "verifiedDate": "2026-04-19"
     },
     {
       "vendor": "Teamplify",
@@ -15473,7 +15473,7 @@
     {
       "vendor": "CodedThemes",
       "category": "Design",
-      "description": "Offers a well-crafted admin dashboard & and UI kits designed to simplify and speed up modern web development.",
+      "description": "Free admin dashboard templates & UI kits for React, Angular, Vue, Bootstrap, Next.js, Django, and more. Premium templates from $49.",
       "tier": "Free",
       "url": "https://codedthemes.com/",
       "tags": [
@@ -15481,7 +15481,7 @@
         "ui",
         "free-for-dev"
       ],
-      "verifiedDate": "2026-04-12"
+      "verifiedDate": "2026-04-19"
     },
     {
       "vendor": "CodeMyUI",

--- a/src/serve.ts
+++ b/src/serve.ts
@@ -11687,7 +11687,7 @@ ${mcpCtaCss()}
   <h1>Best Free Design Tools for Developers</h1>
 
   <div class="context">
-    <p>Design tooling has become remarkably accessible. <strong>Figma</strong> offers a generous free Starter plan with unlimited files. <strong>Penpot</strong> is a fully open-source alternative with no limits on projects or components. And the Tailwind CSS ecosystem has spawned dozens of free UI component libraries \u2014 <strong>ShadcnUI</strong>, <strong>DaisyUI</strong>, and <strong>HyperUI</strong> give you production-ready components without a design tool at all.</p>
+    <p>Design tooling has become remarkably accessible. <strong>Figma</strong> offers a generous free Starter plan with unlimited drafts and 150 AI credits/day. <strong>Penpot</strong> is a fully open-source alternative with no limits on projects or components. And the Tailwind CSS ecosystem has spawned dozens of free UI component libraries \u2014 <strong>ShadcnUI</strong>, <strong>DaisyUI</strong>, and <strong>HyperUI</strong> give you production-ready components without a design tool at all.</p>
     <p>This page compares every free design tool in our index \u2014 <strong>${designOffers.length} tools</strong> across UI editors, prototyping platforms, component libraries, icon sets, stock assets, color tools, and more. Whether you need a Figma alternative or free icons for your next project, we have the comparison with exact free tier limits.</p>
   </div>
 
@@ -11838,7 +11838,7 @@ ${buildCards(other)}
   <div class="decision-guide">
     <dl>
       <dt>Need a full design tool for UI/UX?</dt>
-      <dd><a href="/vendor/figma">Figma</a> \u2014 industry standard, generous free Starter plan with unlimited files. <a href="/vendor/penpot">Penpot</a> \u2014 open-source alternative, self-hostable, no vendor lock-in. <a href="/vendor/lunacy">Lunacy</a> for offline-first design with built-in assets.</dd>
+      <dd><a href="/vendor/figma">Figma</a> \u2014 industry standard, generous free Starter plan with unlimited drafts (team projects limited to 3 files). <a href="/vendor/penpot">Penpot</a> \u2014 open-source alternative, self-hostable, no vendor lock-in. <a href="/vendor/lunacy">Lunacy</a> for offline-first design with built-in assets.</dd>
 
       <dt>Building a website without code?</dt>
       <dd><a href="/vendor/webflow">Webflow</a> \u2014 most powerful visual builder with CMS (2 projects free). <a href="/vendor/framer-com">Framer</a> for polished portfolio sites. <a href="/vendor/plasmic">Plasmic</a> for visual React development with code export.</dd>


### PR DESCRIPTION
## Summary

- **Figma** (Design): rewrote to reflect current Starter plan language — unlimited drafts, unlimited viewers, 30-day version history, 150 AI credits/day (500/mo). Team projects still limited to 3 files.
- **CodedThemes** (Design): rewrote vague stub to specify free admin dashboard templates & UI kits across React, Angular, Vue, Bootstrap, Next.js, Django, etc. Premium templates from \$49.
- **Linear** (Project Management): removed "(unlimited archived)" qualifier (not on pricing page), added 10MB file upload limit.
- **Teamcamp** (Project Management): rewrote marketing stub with actual free tier limits (10 users, unlimited projects, 250 tasks, 1 GB storage, time tracking, docs, invoicing). URL deep-linked to /pricing.
- Updated **design-alternatives hub page copy** ("unlimited files" → "unlimited drafts") so hub marketing doesn't contradict the corrected Figma description.

## Decision: no deal_changes

Per op-learning #36 — all four are pure data-accuracy fixes (bulk-import metadata gaps and stale language), not vendor-side pricing changes. Vendor state hasn't changed recently; our records were wrong from the original import.

## Verification

All four pricing pages WebFetched against the canonical URLs listed in the issue. PM's corrections verified accurate.

E2E verified via `BASE_URL=http://localhost:9894 PORT=9894 node dist/serve.js` (op-learning #46):
- `/api/offers?q=figma&category=Design` → new description with AI credits + 3-file team limit ✓
- `/api/offers?q=linear&category=Project Management` → "250 issues" + 10MB file limit ✓
- `/api/offers?q=teamcamp` → 10 users / unlimited projects / 250 tasks / 1 GB ✓
- `/api/offers?q=codedthemes` → React/Angular/Vue/Bootstrap/Next.js/Django + \$49 premium ✓

All entries bumped to `verifiedDate: 2026-04-19`.

## Test plan

- [x] `npm run build` — clean
- [x] `npm test` — 1,048 passing, 0 failing (no regressions)
- [x] E2E via /api/offers for all 4 vendors
- [x] `git checkout data/agent_friends.json` to drop the known test-contamination diff (see #921)

Refs #922