### PR TITLE
fix: Workflow Automation + Forms data corrections (#924)

### DIFF
--- a/data/deal_changes.json
+++ b/data/deal_changes.json
@@ -3891,6 +3891,22 @@
         "Uploadcare",
         "imgix"
       ]
+    },
+    {
+      "vendor": "DBOS",
+      "change_type": "free_tier_removed",
+      "date": "2026-04-19",
+      "summary": "DBOS Cloud free tier (1 Firecracker microVM per app, 1M service calls/mo) no longer appears on dbos.dev/pricing. Only the open-source DBOS Transact library remains free; managed cloud is paid-only starting at Pro $99/mo. Description updated accordingly; vendor remains in index under the open-source tier.",
+      "previous_state": "Hosted free tier with 1 Firecracker microVM per app (512 MB RAM, 1 vCPU), scale to zero, 1M service calls/mo",
+      "current_state": "Open-source DBOS Transact library free; managed DBOS Cloud paid-only from Pro at $99/mo",
+      "impact": "medium",
+      "source_url": "https://www.dbos.dev/pricing",
+      "category": "Workflow Automation",
+      "alternatives": [
+        "Temporal",
+        "Inngest",
+        "Trigger.dev"
+      ]
     }
   ]
 }

--- a/data/index.json
+++ b/data/index.json
@@ -3421,7 +3421,7 @@
     {
       "vendor": "Make",
       "category": "Workflow Automation",
-      "description": "Visual workflow automation (formerly Integromat) — 1,000 operations/month, 100 MB data transfer/mo, 2 active scenarios, 15-minute minimum interval",
+      "description": "Visual workflow automation (formerly Integromat) — 1,000 credits/month (renamed from operations; each module action counts as one credit), 512 MB data transfer/mo, 2 active scenarios, 15-minute minimum interval between scheduled runs, 5 MB max file size, 5-minute max scenario runtime, 7-day execution log retention",
       "tier": "Free Forever",
       "url": "https://www.make.com/en/pricing",
       "tags": [
@@ -3431,7 +3431,7 @@
         "no-code",
         "free tier"
       ],
-      "verifiedDate": "2026-04-05"
+      "verifiedDate": "2026-04-19"
     },
     {
       "vendor": "Zapier",
@@ -6564,17 +6564,17 @@
     {
       "vendor": "DBOS",
       "category": "Workflow Automation",
-      "description": "Durable workflow orchestration platform — free tier includes 1 Firecracker microVM per app (512 MB RAM, 1 vCPU), scale to zero, 1M service calls/month, 3-day system data retention, Amazon RDS Postgres backend. Open-source DBOS Transact library free forever for TypeScript, Python, Go, Java, Kotlin",
-      "tier": "Free",
+      "description": "Open-source durable workflow orchestration library (DBOS Transact) — free forever for TypeScript, Python, Go, Java, Kotlin. Self-host with PostgreSQL backend; community support via Discord. Managed DBOS Cloud is paid-only (Pro from $99/mo: 3 seats, 5 apps, 1M checkpoints/mo).",
+      "tier": "Free (open-source library; managed cloud is paid-only)",
       "url": "https://www.dbos.dev/pricing",
       "tags": [
         "workflows",
         "orchestration",
-        "serverless",
         "durable-execution",
-        "postgres"
+        "postgres",
+        "open-source"
       ],
-      "verifiedDate": "2026-04-05"
+      "verifiedDate": "2026-04-19"
     },
     {
       "vendor": "Brainboard",
@@ -12317,14 +12317,14 @@
     {
       "vendor": "Feathery",
       "category": "Forms",
-      "description": "Powerful, developer-friendly form builder. Build signup & login, user onboarding, payment flows, complex financial applications, and more. The free plan allows up to 250 submissions/month and five active forms.",
+      "description": "Developer-friendly form builder for signup/login, user onboarding, payment flows, and complex financial applications. Free plan: 500 submissions/mo, 5 active (published) forms, 10 MB file upload limit, standard integrations, forum support. Unlimited fields, pages, conditions, and seats.",
       "tier": "Free",
-      "url": "https://feathery.io",
+      "url": "https://feathery.io/pricing",
       "tags": [
         "forms",
         "free-for-dev"
       ],
-      "verifiedDate": "2026-04-13"
+      "verifiedDate": "2026-04-19"
     },
     {
       "vendor": "feedback.fish",

--- a/test/deal-changes.test.ts
+++ b/test/deal-changes.test.ts
@@ -76,7 +76,7 @@ describe("track_changes tool", () => {
 
     assert.ok(Array.isArray(body.changes));
     assert.strictEqual(body.total, body.changes.length);
-    assert.strictEqual(body.total, 279);
+    assert.strictEqual(body.total, 280);
   });
 
   it("filters by date (since)", async () => {


### PR DESCRIPTION
## Summary

Clears issue #924 — PM audit of Workflow Automation and Forms flagged 3 vendor entries with data errors. All three verified live against the vendor pricing pages before editing.

## Changes

**Make (Workflow Automation)** — Old: "1,000 operations/month, 100 MB data transfer/mo, 2 active scenarios, 15-minute minimum interval". New description restores the actual limits on make.com/en/pricing: 1,000 **credits**/month (renamed from operations — each module action = 1 credit), **512 MB** data transfer/mo (not 100 MB), 2 active scenarios, 15-minute minimum between scheduled runs, **5 MB max file size**, **5-minute max scenario runtime**, **7-day execution log retention**.

**DBOS (Workflow Automation)** — The hosted free tier (1 Firecracker microVM per app, 1M service calls/mo) is no longer on dbos.dev/pricing. The lowest paid tier is Pro at $99/mo. Open-source DBOS Transact library remains free forever. Description rewritten to match current state; tier string updated; **deal_change added** (`free_tier_removed`, medium impact) since this is a material vendor-side reduction, not a bulk-import accuracy issue.

**Feathery (Forms)** — Free-plan submissions bumped 250 → **500/mo** (PM-flagged). Added the 10 MB file upload limit, 5 active (published) forms cap, standard-integrations + forum-support scope, and unlimited fields/pages/conditions/seats. URL deep-linked to /pricing.

## Tests

- 1,048 passing (no regressions)
- deal-changes total assertion updated 279 → 280 to account for the DBOS deal_change

## E2E verified

`BASE_URL=http://localhost:9894 PORT=9894 node dist/serve.js` — hit /api/offers?q=make / q=dbos / q=feathery, confirmed all three entries return the new descriptions with verifiedDate=2026-04-19.

## Deal change rationale

Only DBOS got a deal_change entry. Make's rename (operations→credits) is arguably a vendor-side change, but the 100 MB → 512 MB swing is most likely our original entry being wrong — the free plan has had 512 MB data transfer for years. Feathery's 250 → 500 could be a bump or could be a correction; PM framed it as a correction. Per op-learning #36 (wrong-from-origin bulk-import metadata gaps don't get deal_changes), both skipped.

Refs #924