### PR TITLE
Data corrections: Documentation + Localization (refs #926)

### DIFF
--- a/data/index.json
+++ b/data/index.json
@@ -3497,7 +3497,7 @@
     {
       "vendor": "ReadMe",
       "category": "Documentation",
-      "description": "API documentation platform — 1 project, 1 API reference, 3 published versions, 5 admins, basic AI features, ReadMe branding. No custom domain",
+      "description": "API documentation platform Starter plan — 1 project, 1 API reference, 1 published version, 1 admin seat, 24-hour request log retention, AI Dropdown / LLMs.txt / MCP Server included (Ask AI is a $150/mo add-on), ReadMe branding (cannot remove). No custom domain, no custom CSS/HTML/JS",
       "tier": "Free",
       "url": "https://readme.com/pricing",
       "tags": [
@@ -3506,7 +3506,7 @@
         "developer-portal",
         "free tier"
       ],
-      "verifiedDate": "2026-04-13"
+      "verifiedDate": "2026-04-19"
     },
     {
       "vendor": "GitBook",
@@ -11077,14 +11077,14 @@
     {
       "vendor": "SimpleLocalize",
       "category": "Localization",
-      "description": "Free up to 100 translation keys, unlimited strings, unlimited languages, startup deals",
+      "description": "Free Community plan — 250 translation keys, unlimited strings, 10 languages, 10 projects, 1 team member. Discount plans available for educational institutions, indie developers, and open-source projects (contact sales)",
       "tier": "Free",
-      "url": "https://simplelocalize.io/",
+      "url": "https://simplelocalize.io/pricing",
       "tags": [
         "developer-tools",
         "free-for-dev"
       ],
-      "verifiedDate": "2026-04-13"
+      "verifiedDate": "2026-04-19"
     },
     {
       "vendor": "Texterify",


### PR DESCRIPTION
## Summary

Applies PM-filed data corrections for 2 vendor entries flagged in issue #926.

**ReadMe (Documentation)** — Starter plan had three wrong numbers and missing signal:
- Published versions: 3 → **1**
- Admin seats: 5 → **1**
- AI features clarified: AI Dropdown, LLMs.txt, MCP Server are included; Ask AI is a **$150/mo add-on**
- Added: 24-hour request log retention, no custom domain, no custom CSS/HTML/JS, ReadMe branding (cannot remove)

**SimpleLocalize (Localization)** — Community plan limits were wrong or missing:
- Translation keys: 100 → **250**
- Languages: unlimited → **10**
- Added: 10 projects, 1 team member
- "startup deals" replaced with accurate programs: educational institutions, indie developers, open-source projects
- URL deep-linked to `/pricing`

Both `verifiedDate` bumped to `2026-04-19`.

## Decision: no deal_changes

Both entries look like they have been wrong since bulk-import origin, per op-learning #36. The direction of ReadMe's admin/version counts (5→1, 3→1) is a reduction, but the 2026-04-13 `verifiedDate` on the old entry was clearly a superficial re-touch (the description still had the legacy 3/5 numbers that the pricing page does not surface). SimpleLocalize's 100→250 keys is an increase, but the current page confirms 250 has been the documented Community limit for some time. Recording either as a vendor-side deal_change would add spurious signal.

## Test plan
- [x] `npm run build` clean
- [x] `npm test` → 1,048/1,048 passing
- [x] E2E via `BASE_URL=http://localhost:9894 PORT=9894 node dist/serve.js`:
  - `/api/offers?q=readme&category=Documentation` returns new Starter description, `verifiedDate: 2026-04-19` ✓
  - `/api/offers?q=simplelocalize` returns new Community description, `verifiedDate: 2026-04-19` ✓
- [x] Restored `data/agent_friends.json` per op-learning #48/#49 (bug #921 still priority/low)

Refs #926