### PR TITLE
Clamp weekly digest feed pubDate to now

### DIFF
--- a/src/serve.ts
+++ b/src/serve.ts
@@ -53837,7 +53837,9 @@ const httpServer = createHttpServer(async (req, res) => {
       const weekUrl = w === 0 ? `${baseUrl}/this-week` : `${baseUrl}/this-week?week=${w}`;
       const weekEndDate = new Date(digest.week_ending + "T12:00:00Z");
       const now = new Date();
-      const pubDate = (weekEndDate > now ? new Date(digest.week_of + "T12:00:00Z") : weekEndDate).toISOString();
+      let pubDateObj = weekEndDate > now ? new Date(digest.week_of + "T12:00:00Z") : weekEndDate;
+      if (pubDateObj > now) pubDateObj = now;
+      const pubDate = pubDateObj.toISOString();
       const months = ["January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December"];
       const ws = new Date(digest.week_of + "T00:00:00Z");
       const we = new Date(digest.week_ending + "T00:00:00Z");


### PR DESCRIPTION
## Summary

`/feed.xml` was emitting Atom entries with a `<updated>` timestamp in the future during the UTC-Monday 00:00–12:00 window. The feed generator picks `digest.week_of + 'T12:00:00Z'` for current-week digests, and when the code runs before noon UTC Monday, that timestamp is still in the future. Atom entries must not be published in the future — and `test/feed-weekly-digest.test.ts`'s `no entry has a future updated date` assertion fails in that window.

Fix: clamp the chosen `pubDateObj` to `now` before emitting.

## Change

- `src/serve.ts` (weekly-digest Atom feed assembly): after choosing `pubDateObj`, clamp to `now` if still in the future.

## Verification

- `npm run build` ✓
- `node --test test/feed-weekly-digest.test.ts` — all 9 tests pass (the future-date assertion previously failed on main at this moment).

## Test plan

- [x] Build passes
- [x] feed-weekly-digest test suite passes
- [x] Feed XML still emits reasonable pubDate for past-week digests