### PR TITLE
Data corrections: Notebooks & Data Science + Error Tracking (refs #931)

### DIFF
--- a/data/index.json
+++ b/data/index.json
@@ -7106,14 +7106,14 @@
     {
       "vendor": "Deepnote",
       "category": "Notebooks & Data Science",
-      "description": "A new data science notebook. Jupyter is compatible with real-time collaboration and running in the cloud. The free tier includes unlimited personal projects, unlimited basic machines with 5GB RAM and 2vCPU, and teams with up to 3 editors.",
+      "description": "Data science notebook platform, Jupyter-compatible with real-time collaboration in the cloud. Free plan: up to 3 editors, unlimited viewers, up to 5 projects, unlimited Basic machines (5 GB RAM, 2 vCPU), 7-day revision history, 10 AI completions/month. Basic machines only (no Plus/Performance/GPU), 15-minute inactivity timeout, no premium data warehouse connections (BigQuery, Snowflake, Redshift).",
       "tier": "Free",
-      "url": "https://deepnote.com",
+      "url": "https://deepnote.com/pricing",
       "tags": [
         "developer-tools",
         "free-for-dev"
       ],
-      "verifiedDate": "2026-04-13"
+      "verifiedDate": "2026-04-19"
     },
     {
       "vendor": "DiffJSON",
@@ -7274,14 +7274,14 @@
     {
       "vendor": "Hex",
       "category": "Notebooks & Data Science",
-      "description": "a collaborative data platform for notebooks, data apps, and knowledge libraries. Free community tier with up to five projects.",
+      "description": "Collaborative data platform for notebooks, data apps, and knowledge libraries. Community plan: up to 5 notebooks, up to 5 published apps, Small compute (2 GB RAM, 0.25 CPU), unlimited users, connect any data source, notebook agent trial (limited AI agent access).",
       "tier": "Free",
-      "url": "https://hex.tech/",
+      "url": "https://hex.tech/pricing",
       "tags": [
         "developer-tools",
         "free-for-dev"
       ],
-      "verifiedDate": "2026-04-13"
+      "verifiedDate": "2026-04-19"
     },
     {
       "vendor": "Hook0",
@@ -11592,15 +11592,15 @@
     {
       "vendor": "honeybadger.io",
       "category": "Error Tracking",
-      "description": "Exception, uptime, and cron monitoring. Free for small teams and open-source projects (12,000 errors/month).",
+      "description": "Exception, uptime, and cron monitoring. Developer plan (free): 5,000 errors/month, 1 user, 50 MB/day logging, 1 uptime monitor, 1 status page, 1 dashboard, unlimited projects, 15-day error data retention, 7-day log retention. Intended for low-traffic projects.",
       "tier": "Free",
-      "url": "https://www.honeybadger.io",
+      "url": "https://www.honeybadger.io/plans/",
       "tags": [
         "error-tracking",
         "crash-reporting",
         "free-for-dev"
       ],
-      "verifiedDate": "2026-04-13"
+      "verifiedDate": "2026-04-19"
     },
     {
       "vendor": "Jam",


### PR DESCRIPTION
Refs #931.

Spot-check corrections to three vendor entries flagged by the PM: Hex, Deepnote, and Honeybadger.

## Changes

**Hex (Notebooks & Data Science)** — Old: "up to five projects". New: Community plan with 5 notebooks, 5 published apps, Small compute (2 GB RAM / 0.25 CPU), unlimited users, connect any data source, notebook agent trial (limited AI agent). URL canonicalized to https://hex.tech/pricing.

**Deepnote (Notebooks & Data Science)** — Old: "unlimited personal projects, unlimited basic machines with 5GB RAM and 2vCPU, teams with up to 3 editors". New: Free plan with 3 editors, unlimited viewers, 5 projects, unlimited Basic machines (5 GB RAM / 2 vCPU), 7-day revision history, 10 AI completions/month, Basic-only compute (no Plus/Performance/GPU), 15-minute inactivity timeout, no premium data warehouse connections (BigQuery, Snowflake, Redshift). URL canonicalized to https://deepnote.com/pricing.

**Honeybadger (Error Tracking)** — Old: "12,000 errors/month". New: Developer plan with 5,000 errors/month, 1 user, 50 MB/day logging, 1 uptime monitor, 1 status page, 1 dashboard, unlimited projects, 15-day error data retention, 7-day log retention. Intended for low-traffic projects. URL deep-linked to https://www.honeybadger.io/plans/.

All three verifiedDate bumped to 2026-04-19.

## Deal changes

None added. All three corrections are wrong-from-origin bulk-import metadata fixes per op-learning #36 — the prior numbers don't reflect specific quantified entries that were stable in our records long enough to constitute a vendor-side reduction event. Honeybadger's 12,000 → 5,000 reduction is the only one that's close; the historical free-for-dev reference has carried 12,000 for years, but without visibility into when Honeybadger actually flipped to 5,000, adding a speculative deal_change would pollute the reduction history with a guessed date. If the PM wants to backfill this retroactively, can be done in a follow-up.

## Verification

- 1,048 tests passing (no regressions).
- E2E verified via local dist/serve.js with BASE_URL=http://localhost:9894 (op-learning #46): all three vendors return new descriptions and URLs with verifiedDate 2026-04-19.
- WebFetch of each canonical pricing page confirmed every limit in the new descriptions.

## Acceptance criteria check

- [x] Hex entry updated to Community plan language
- [x] Deepnote entry updated with 3 editors / 5 projects / Basic machine details
- [x] Honeybadger entry updated: 12,000 → 5,000 errors/month, 1 user, 50 MB/day logging
- [x] All three verifiedDate fields updated to 2026-04-19
- [x] Tests pass (1,048)