### PR TITLE
data: ipinfo.io + Foursquare + Orama corrections (issue #933)

### DIFF
--- a/data/index.json
+++ b/data/index.json
@@ -3230,7 +3230,7 @@
     {
       "vendor": "Orama",
       "category": "Search",
-      "description": "Full-text, vector, and hybrid search engine — 3 indexes, 100K documents/index, unlimited searches, 150 index updates/mo, 60-day analytics retention",
+      "description": "Full-text, vector, hybrid, and NLP search engine — Free Base plan: 2 included projects, 500 included docs per project (max 5,000 docs/project), 2 indexes per project, unlimited searches, 500 AI sessions/mo, 60-day analytics retention. No credit card required. Extra projects $5/mo, extra indexes $5/mo per 10",
       "tier": "Free",
       "url": "https://orama.com/pricing",
       "tags": [
@@ -3240,7 +3240,7 @@
         "hybrid",
         "free tier"
       ],
-      "verifiedDate": "2026-04-13"
+      "verifiedDate": "2026-04-19"
     },
     {
       "vendor": "Quay.io",
@@ -4228,7 +4228,7 @@
     {
       "vendor": "ipinfo.io",
       "category": "Maps/Geolocation",
-      "description": "IP geolocation and data API. Free plan: 50,000 requests/month, IP-to-geolocation, ASN, company, carrier, and privacy detection data",
+      "description": "IP geolocation and data API. IPinfo Lite (free plan): unlimited requests, country and continent-level geolocation only (no city/region/postal code), ASN name and domain. Does NOT include company, carrier, or privacy/anonymity detection (paid plans only). Community support.",
       "tier": "Free",
       "url": "https://ipinfo.io/pricing",
       "tags": [
@@ -4237,7 +4237,7 @@
         "api",
         "data"
       ],
-      "verifiedDate": "2026-04-13"
+      "verifiedDate": "2026-04-19"
     },
     {
       "vendor": "Meilisearch",
@@ -16551,15 +16551,15 @@
     {
       "vendor": "Foursquare",
       "category": "Maps/Geolocation",
-      "description": "Location discovery, venue search, and context-aware content from Places API and Pilgrim SDK.",
+      "description": "Location discovery, venue search, and context-aware content. Places API: 10,000 free calls/mo on Pro endpoints ($0.00 CPM), then pay-per-call. New users get $200 in free credits. Spatial Studio Community (always free: 1 GB cloud storage, limited data catalog, public-only map publishing). Spatial Desktop Basic ($0/mo through 2026, includes $1 of agent tokens to preview FSQ Spatial Agent, 5 shared projects, 3 GB cloud storage). Spatial Workbench 30-day free trial (pay only for compute/storage used).",
       "tier": "Free",
-      "url": "https://developer.foursquare.com/",
+      "url": "https://foursquare.com/pricing/",
       "tags": [
         "maps",
         "geolocation",
         "free-for-dev"
       ],
-      "verifiedDate": "2026-04-13"
+      "verifiedDate": "2026-04-19"
     },
     {
       "vendor": "geoapify.com",


### PR DESCRIPTION
## Summary

Corrections for all three vendors flagged in issue #933 (Maps/Geolocation + Search audit). All confirmed via WebFetch against the current pricing pages.

### ipinfo.io (Maps/Geolocation)
- **Old:** "50,000 requests/month, IP-to-geolocation, ASN, company, carrier, and privacy detection data"
- **New:** IPinfo Lite: unlimited requests, country/continent-level only (no city/region/postal), ASN name and domain. Explicit note that company/carrier/privacy detection require paid plans. Community support.
- Source: https://ipinfo.io/pricing

### Foursquare (Maps/Geolocation)
- **Old:** "Location discovery, venue search, and context-aware content from Places API and Pilgrim SDK." — no free tier limits
- **New:** Places API 10K calls/mo on Pro endpoints + $200 new-user credits, Spatial Studio Community (always free, 1 GB cloud storage), Spatial Desktop Basic ($0/mo through 2026, 5 shared projects, 3 GB cloud storage, $1 FSQ Spatial Agent tokens), Spatial Workbench 30-day trial.
- URL updated: `developer.foursquare.com/` → `foursquare.com/pricing/`
- Source: https://foursquare.com/pricing/

### Orama (Search)
- **Old:** "3 indexes, 100K documents/index, unlimited searches, 150 index updates/mo, 60-day analytics retention"
- **New:** Free Base plan: 2 included projects, 500 included docs/project (max 5,000 docs/project), 2 indexes/project, unlimited full-text/vector/hybrid/NLP searches, 500 AI sessions/mo, 60-day analytics. Added extra-capacity pricing signals ($5/mo extra project, $5/mo per 10 extra indexes).
- Source: https://orama.com/pricing

## Deal changes

None. All three corrections are wrong-from-origin bulk-import metadata gaps per op-learning #36 — none reflect a recent vendor-side reduction. Adding deal_changes for them would pollute the reduction history.

## Verification

- All three `verifiedDate` fields bumped to 2026-04-19
- Tests: 1048/1048 passing
- E2E verified via `BASE_URL=http://localhost:9896 PORT=9896 node dist/serve.js` (op-learning #46): `GET /api/offers?q=ipinfo`, `?q=foursquare`, `?q=orama` all return corrected descriptions.

## Acceptance criteria

- [x] ipinfo.io description updated with correct free tier (IPinfo Lite, unlimited requests, country-level only)
- [x] Foursquare description updated with specific limits (10K calls/month, $200 credits, Studio Community)
- [x] Foursquare URL updated to https://foursquare.com/pricing/
- [x] Orama description updated (2 projects, 500 docs/project, 2 indexes/project, 500 AI sessions)
- [x] All three verified_date fields updated
- [x] Tests pass

Refs #933