### PR TITLE
Tunneling & Networking data corrections (Refs #935)

### DIFF
--- a/data/index.json
+++ b/data/index.json
@@ -14133,14 +14133,14 @@
     {
       "vendor": "Hamachi",
       "category": "Tunneling & Networking",
-      "description": "LogMeIn Hamachi is a hosted VPN service that lets you securely extend LAN-like networks to distributed teams with a free plan that allows unlimited networks with up to 5 people",
+      "description": "LogMeIn Hamachi hosted VPN service that securely extends LAN-like networks to distributed teams. Free for up to 5 computers on a single network; paid tiers required for more computers, multiple networks, or unattended/service mode",
       "tier": "Free",
       "url": "https://www.vpn.net/",
       "tags": [
         "developer-tools",
         "free-for-dev"
       ],
-      "verifiedDate": "2026-04-13"
+      "verifiedDate": "2026-04-20"
     },
     {
       "vendor": "localhost.run",
@@ -14169,14 +14169,14 @@
     {
       "vendor": "LocalXpose",
       "category": "Tunneling & Networking",
-      "description": "Reverse proxy that enables you to expose your localhost servers to the internet. The free plan has 15 minutes tunnel lifetime.",
+      "description": "Reverse proxy that exposes your localhost servers to the internet. Free Starter plan: 2 active HTTP/HTTPS tunnels, unique subdomains, SSL/TLS, interstitial warning page on public pageviews. No credit card required; TCP/TLS/UDP tunneling requires Pro.",
       "tier": "Free",
-      "url": "https://localxpose.io",
+      "url": "https://localxpose.io/pricing",
       "tags": [
         "developer-tools",
         "free-for-dev"
       ],
-      "verifiedDate": "2026-04-13"
+      "verifiedDate": "2026-04-20"
     },
     {
       "vendor": "Pinggy",
@@ -14241,14 +14241,14 @@
     {
       "vendor": "ZeroTier",
       "category": "Tunneling & Networking",
-      "description": "FOSS managed virtual Ethernet as a service. Unlimited end-to-end encrypted networks of 25 clients on the free plan. Clients for desktop/mobile/NA; web interface for configuration of custom routing rules and approval of new client nodes on private networks",
+      "description": "FOSS managed virtual Ethernet as a service. Personal (Free Forever) plan: 10 devices, 1 network, 1 admin — intended for personal/hobbyist use, not commercial. Clients for desktop/mobile; web interface for custom routing rules and approval of new client nodes on private networks",
       "tier": "Free",
-      "url": "https://www.zerotier.com",
+      "url": "https://www.zerotier.com/pricing",
       "tags": [
         "developer-tools",
         "free-for-dev"
       ],
-      "verifiedDate": "2026-04-13"
+      "verifiedDate": "2026-04-20"
     },
     {
       "vendor": "acunote.com",


### PR DESCRIPTION
## Summary

Corrects 3 vendor entries in the Tunneling & Networking category per issue #935. All verified against official pricing pages 2026-04-20.

### 1. ZeroTier
- **Before:** "Unlimited end-to-end encrypted networks of 25 clients on the free plan"
- **After:** Personal (Free Forever) plan: **10 devices, 1 network, 1 admin** — intended for personal/hobbyist use, not commercial
- Source: https://www.zerotier.com/pricing

### 2. Hamachi
- **Before:** "free plan that allows unlimited networks with up to 5 people"
- **After:** Free for up to **5 computers on a single network**; paid tiers required for more computers, multiple networks, or unattended/service mode
- Source: https://www.vpn.net/ (URL already correct — PM note about redirect already reflected)

### 3. LocalXpose
- **Before:** "The free plan has 15 minutes tunnel lifetime"
- **After:** Free Starter plan: **2 active HTTP/HTTPS tunnels**, unique subdomains, SSL/TLS, interstitial warning page on public pageviews, no CC required. TCP/TLS/UDP requires Pro.
- Source: https://localxpose.io/pricing

### Notes
- All three `verifiedDate` bumped to 2026-04-20
- ZeroTier and LocalXpose URLs normalized to pricing pages
- **No deal_changes** — all three are wrong-from-origin per op-learning #36
- 1,071 tests passing
- Local E2E verified via `/api/offers?q=<vendor>` for all three

Refs #935

🤖 Generated with [Claude Code](https://claude.com/claude-code)