### PR TITLE
data: Source Control corrections (Codeberg limits, remove projectlocker)

### DIFF
--- a/data/category-mapping.json
+++ b/data/category-mapping.json
@@ -43,7 +43,6 @@
   "heptapod.net": "Source Control",
   "Pagure.io": "Source Control",
   "pijul.com": "Source Control",
-  "projectlocker.com": "Source Control",
   "RocketGit": "Source Control",
   "savannah.gnu.org": "Source Control",
   "savannah.nongnu.org": "Source Control",

--- a/data/index.json
+++ b/data/index.json
@@ -6653,14 +6653,14 @@
     {
       "vendor": "Codeberg",
       "category": "Source Control",
-      "description": "Unlimited public and private Git repos for free and open-source projects (with unlimited collaborators). Powered by [Forgejo](https://forgejo.org/). Static website hosting with [Codeberg Pages](https://codeberg.page/). CI/CD hosting with [Codeberg's CI](https://docs.codeberg.org/ci/). Translating hosting with [Codeberg Translate](https://translate.codeberg.org/). Includes Package and Container hosting, Project management, and Issue Tracking",
+      "description": "Non-profit Git hosting for free and open-source projects. Public and private Git repos, powered by [Forgejo](https://forgejo.org/). Default soft limits per account/org: 100 repositories, 750 MiB Git storage, and 1.5 GiB combined for packages, LFS, and attachments; contributors may store up to 100 MB of private content. Increases are granted on request for valid use-cases via their public requests repository. Includes [Codeberg Pages](https://codeberg.page/) static site hosting, [Codeberg CI](https://docs.codeberg.org/ci/), [Codeberg Translate](https://translate.codeberg.org/), package/container hosting, project management, and issue tracking.",
       "tier": "Free",
       "url": "https://codeberg.org/",
       "tags": [
         "developer-tools",
         "free-for-dev"
       ],
-      "verifiedDate": "2026-04-13"
+      "verifiedDate": "2026-04-20"
     },
     {
       "vendor": "framagit.org",
@@ -6716,18 +6716,6 @@
       "description": "Unlimited free and open source distributed version control system. Its distinctive feature is based on a sound theory of patches, which makes it easy to learn, use, and distribute. Solves many problems of git/hg/svn/darcs.",
       "tier": "Free",
       "url": "https://pijul.com/",
-      "tags": [
-        "developer-tools",
-        "free-for-dev"
-      ],
-      "verifiedDate": "2026-04-13"
-    },
-    {
-      "vendor": "projectlocker.com",
-      "category": "Source Control",
-      "description": "One free private project (Git and Subversion) with 50 MB of space",
-      "tier": "Free",
-      "url": "https://projectlocker.com",
       "tags": [
         "developer-tools",
         "free-for-dev"


### PR DESCRIPTION
## Summary

Issue #938 — Source Control category data corrections (2 vendors).

### Codeberg (updated)
- **Before:** "Unlimited public and private Git repos... unlimited collaborators"
- **After:** Actual default soft limits — 100 repositories, 750 MiB Git storage, 1.5 GiB combined for packages/LFS/attachments, 100 MB private content for contributors. Increases available on request.
- **Source:** [docs.codeberg.org/getting-started/faq](https://docs.codeberg.org/getting-started/faq/)
- `verifiedDate` bumped to 2026-04-20.

### projectlocker.com (removed)
- No free tier. Vendor only advertises paid plans: Venture ($19/mo, 5 users/5GB/5 projects), Equity ($49/mo), IPO ($99/mo), Enterprise. Time-limited free trials only.
- **Source:** [projectlocker.com](https://projectlocker.com)
- Removed from `data/index.json` and `data/category-mapping.json`. Not referenced anywhere else.

### No deal_changes
Both are wrong-from-origin bulk-import metadata issues (op-learning #36), not vendor-side reductions. Codeberg's "unlimited repos/collaborators" line appears to predate our deal_changes window; projectlocker's "50 MB / 1 project" entry has no source in deal history and may never have been accurate.

## Test plan

- [x] WebFetch Codeberg FAQ page — confirmed all 4 corrected numbers (100 repos, 750 MiB, 1.5 GiB, 100 MB)
- [x] WebFetch projectlocker.com — confirmed no free tier
- [x] `npm run build` — clean
- [x] Local E2E via `BASE_URL=http://localhost:9897 PORT=9897 node dist/serve.js`:
  - `GET /api/offers?q=codeberg` → new description, `days_since_verified: 0`, tier still Free
  - `GET /api/offers?q=projectlocker` → `{"offers":[],"total":0}` (entry removed)
- [x] No code references to `projectlocker` outside of `data/` (verified via grep)
- [x] Tests pass when run from clean state (pre-existing flakiness due to test contamination bug #921 is orthogonal and affects main as well — confirmed by comparing clean runs on both branches)

Refs #938