### PR TITLE
Data corrections: CDN (3 vendors) + Payments (1 vendor)

### DIFF
--- a/data/index.json
+++ b/data/index.json
@@ -5218,8 +5218,8 @@
     {
       "vendor": "imgix",
       "category": "CDN",
-      "description": "Image CDN and optimization — 1,000 origin images, unlimited transformations, full rendering API, Asset Manager included",
-      "tier": "Free",
+      "description": "Image CDN and optimization — no permanent free tier. 30-day free trial with 100 credits, no credit card required. Paid plans start at Starter $25/mo (100 credits, 50 GB storage, 100 GB bandwidth); credit system charges 2 credits/GB/month for storage and 1 credit/GB for delivery.",
+      "tier": "Trial",
       "url": "https://www.imgix.com/pricing",
       "tags": [
         "cdn",
@@ -5227,7 +5227,7 @@
         "media",
         "optimization"
       ],
-      "verifiedDate": "2026-04-13"
+      "verifiedDate": "2026-04-20"
     },
     {
       "vendor": "Lemon Squeezy",
@@ -12938,7 +12938,7 @@
     {
       "vendor": "Skypack",
       "category": "CDN",
-      "description": "The 100% Native ES Module JavaScript CDN. Free for 1 million requests per domain per month.",
+      "description": "ESM-native JavaScript CDN serving optimized npm packages directly to the browser with no install or build step (minification, polyfills, compression, caching handled automatically). Free to use for personal and commercial purposes with no stated request limits; custom domains and advanced needs via contact.",
       "tier": "Free",
       "url": "https://www.skypack.dev/",
       "tags": [
@@ -12946,20 +12946,20 @@
         "protection",
         "free-for-dev"
       ],
-      "verifiedDate": "2026-04-13"
+      "verifiedDate": "2026-04-20"
     },
     {
       "vendor": "Stellate",
       "category": "CDN",
-      "description": "Stellate is a blazing-fast, reliable CDN for your GraphQL API and free for two services.",
+      "description": "GraphQL edge CDN. Free plan: up to 100,000 requests/month, unlimited services, unlimited seats, 1-day data retention, fair-use policy. Business plan starts at $249/mo (25M metrics requests, 30-day retention, optional Edge Caching and Rate Limiting add-ons).",
       "tier": "Free",
-      "url": "https://stellate.co/",
+      "url": "https://stellate.co/pricing",
       "tags": [
         "cdn",
         "protection",
         "free-for-dev"
       ],
-      "verifiedDate": "2026-04-13"
+      "verifiedDate": "2026-04-20"
     },
     {
       "vendor": "toranproxy.com",
@@ -17656,15 +17656,15 @@
     {
       "vendor": "Adapty.io",
       "category": "Payments",
-      "description": "One-stop solution with open-source SDK for mobile in-app subscription integration to iOS, Android, React Native, Flutter, Unity, or web app. Free up to $10k monthly revenue.",
+      "description": "One-stop solution with open-source SDK for mobile in-app subscription integration to iOS, Android, React Native, Flutter, Unity, or web app. Free for apps earning under $5,000/month (rolling 30-day revenue); Pro tier charges 1% of monthly revenue above the $5K threshold.",
       "tier": "Free",
-      "url": "https://adapty.io/",
+      "url": "https://adapty.io/pricing/",
       "tags": [
         "payments",
         "billing",
         "free-for-dev"
       ],
-      "verifiedDate": "2026-04-13"
+      "verifiedDate": "2026-04-20"
     },
     {
       "vendor": "CoinMarketCap",


### PR DESCRIPTION
Refs #940

## Summary

PM spot-check audit reported 40% error rate (4 of 10 CDN+Payments entries). WebFetched each pricing page and applied the corrections below.

## Changes

**imgix** (CDN) — No permanent free tier exists; only a 30-day trial with 100 credits. The prior claim of "1,000 origin images, unlimited transformations" was wrong-from-origin. Tier changed from `Free` to `Trial` (a `free_tier_removed` deal_change already exists from 2026-04-13 that the main entry was contradicting). Description now spells out trial terms (100 credits, no CC) and the Starter $25/mo paid entry point (50 GB storage / 100 GB bandwidth / credit system at 2/GB storage, 1/GB delivery).

**Skypack** (CDN) — The "Free for 1 million requests per domain per month" claim is unverifiable — no such number appears on skypack.dev. Page only says "free to use for personal and commercial purposes, forever" with no stated limits. Description rewritten to describe what the service actually does (ESM-native JS CDN for npm packages, no install/build) with honest language about limits ("no stated request limits"). Tier stays `Free`.

**Stellate** (CDN) — "Free for two services" was wrong. Actual Free plan is **100K requests/month, unlimited services, unlimited seats, 1-day data retention**. Also captured the Business plan entry point ($249/mo, 25M metrics requests, 30-day retention, optional Edge Caching + Rate Limiting) for context. URL deep-linked to `/pricing`.

**Adapty.io** (Payments) — "Free up to \$10k monthly revenue" was a 2x overstatement. Actual free threshold is **\$5,000/month** (rolling 30-day revenue), with 1% on revenue above that. Corrected and URL deep-linked to `/pricing/`.

## No deal_changes

Per operational learning #36, all four corrections are wrong-from-origin bulk-import metadata issues, not vendor-side reductions:
- imgix's "1,000 origin images" predates our deal_changes window (and the existing `free_tier_removed` deal_change from 2026-04-13 already captures the tier shift).
- Skypack's "1M requests" number has no origin source I can find.
- Stellate's "two services" is bulk-import-era boilerplate that never matched vendor reality.
- Adapty's \$10K threshold has been in our index since before deal_changes tracking.

Adding speculative historical deal_changes for any of these would pollute the reduction history.

## Verification

- `npm run build` — clean tsc compile
- `node --test --test-concurrency=1` — **1071/1071 tests passing**, no regressions
- E2E via `/api/offers?q=<vendor>` on localhost:9898: all four entries render with new descriptions and `verifiedDate: 2026-04-20`. imgix correctly appears with `tier: Trial`; the other three remain `tier: Free`.

## Stats

- Offers: 1591 (unchanged — no adds/removes this cycle)
- Deal changes: 280 (unchanged)
- Tests: 1071 passing