### PR TITLE
data: Logging + Web Scraping corrections (Refs #944)

### DIFF
--- a/data/index.json
+++ b/data/index.json
@@ -1804,21 +1804,6 @@
       "verifiedDate": "2026-04-13"
     },
     {
-      "vendor": "Papertrail",
-      "category": "Logging",
-      "description": "Cloud log management by SolarWinds — 100 MB/month, 48-hour searchable logs, 7-day archive, unlimited sources, real-time tail",
-      "tier": "Free",
-      "url": "https://www.papertrail.com/plans/",
-      "tags": [
-        "logging",
-        "syslog",
-        "search",
-        "real-time",
-        "free tier"
-      ],
-      "verifiedDate": "2026-04-13"
-    },
-    {
       "vendor": "Stripe",
       "category": "Payments",
       "description": "Payment processing — no monthly fees, 2.9% + $0.30 per transaction. Full API, dashboard, and test mode free. Pay only when processing live payments",
@@ -7865,26 +7850,26 @@
     {
       "vendor": "ScrapingAnt",
       "category": "Web Scraping",
-      "description": "Headless Chrome scraping API and free checked proxies service. Javascript rendering, premium rotating proxies, CAPTCHAs avoiding. Free 10,000 API credits.",
+      "description": "Headless Chrome scraping API and free checked proxies service. Javascript rendering, premium rotating proxies, CAPTCHA avoidance. Free plan: 10,000 API credits per month (renews monthly), unlimited parallel requests, all core scraping features, no credit card required. See [scrapingant.com](https://scrapingant.com/).",
       "tier": "Free",
       "url": "https://scrapingant.com/",
       "tags": [
         "developer-tools",
         "free-for-dev"
       ],
-      "verifiedDate": "2026-04-13"
+      "verifiedDate": "2026-04-20"
     },
     {
       "vendor": "SerpApi",
       "category": "Web Scraping",
-      "description": "Real-time search engine scraping API. Returns structured JSON results for Google, YouTube, Bing, Baidu, Walmart, and many other machines. The free plan includes 100 successful API calls per month.",
+      "description": "Real-time search engine scraping API. Returns structured JSON results for Google, YouTube, Bing, Baidu, Walmart, and many other engines. Free plan: 250 searches/month, 50 requests/hour throughput limit. Month-to-month, cancel anytime. See [serpapi.com/pricing](https://serpapi.com/pricing).",
       "tier": "Free",
-      "url": "https://serpapi.com/",
+      "url": "https://serpapi.com/pricing",
       "tags": [
         "developer-tools",
         "free-for-dev"
       ],
-      "verifiedDate": "2026-04-13"
+      "verifiedDate": "2026-04-20"
     },
     {
       "vendor": "Simplescraper",
@@ -10889,17 +10874,17 @@
       "verifiedDate": "2026-04-13"
     },
     {
-      "vendor": "logtail.com",
+      "vendor": "Better Stack Logs",
       "category": "Logging",
-      "description": "ClickHouse-based SQL-compatible log management. Free up to 1 GB per month, three days retention.",
+      "description": "ClickHouse-based SQL-compatible log management (formerly Logtail). Free plan: 3 GB/month retained for 3 days, unlimited team members. Full platform access requires a paid Responder license (Nano from $25/mo billed annually, includes 40 GB logs/traces/metrics with 30-day retention). See [betterstack.com/logs/pricing](https://betterstack.com/logs/pricing).",
       "tier": "Free",
-      "url": "https://logtail.com/",
+      "url": "https://betterstack.com/logs/pricing",
       "tags": [
         "logging",
         "log-management",
         "free-for-dev"
       ],
-      "verifiedDate": "2026-04-13"
+      "verifiedDate": "2026-04-20"
     },
     {
       "vendor": "logzab.com",


### PR DESCRIPTION
## Summary

PM-audit data corrections for Logging (2 vendors) + Web Scraping (2 vendors) per issue #944.

### Logging

- **Papertrail — removed.** Vendor's own `recent_change` field (2026-04-13) already stated "No free plan, log observability starts at \$5/GB/month" — the stale `tier: Free` entry contradicted it. Pricing pages return 403 to WebFetch (PM confirmed same). No trial tier visible; removing is the cleanest action, following the projectlocker precedent from PR #941. If a trial does exist, PM can re-add with accurate terms.
- **logtail.com → Better Stack Logs.** Vendor renamed — logtail.com now redirects to betterstack.com. Free tier corrected from 1 GB/month → **3 GB/month retained for 3 days, unlimited team members** (betterstack.com/logs/pricing). Added paid entry-point context (Nano \$25/mo billed annually → 40 GB logs/traces/metrics, 30-day retention) since that's the practical upgrade path.

### Web Scraping

- **SerpApi.** Free plan corrected from 100 → **250 searches/month**. Added the **50-req/hour throughput cap** sub-signal from serpapi.com/pricing — matters for burst workloads. URL deep-linked to /pricing.
- **ScrapingAnt.** Clarified **10,000 credits renews monthly** (previous phrasing "Free 10,000 API credits" implied one-time). Added *unlimited parallel requests* and *no credit card required* signals verified on their pricing page.

### Methodology

No `deal_changes` added. Per op-learning #36, all four are wrong-from-origin bulk-import metadata issues, not vendor-side reductions:
- Papertrail already has a `free_tier_removed` deal_change from 2026-04-13 capturing the tier shift.
- logtail.com's 1 GB figure appears to predate our deal_changes window.
- SerpApi's 100-searches claim is bulk-import-era stale.
- ScrapingAnt's ambiguous "10,000 credits" phrasing is origin-level.

All four `verifiedDate` bumped to 2026-04-20.

### Stats

- **1,590 offers** (−1 for Papertrail removal; previous 1,591)
- 280 deal_changes unchanged
- **1,071 tests passing** on clean `node --test --test-concurrency=1` run
- No regressions

### Verification

E2E verified via BASE_URL=http://localhost:9899 PORT=9899 node dist/serve.js:
- \`/api/offers?q=Papertrail\` → \`{"offers":[],"total":0}\` ✓
- \`/api/offers?q=Better%20Stack%20Logs\` → new description, tier Free, url /logs/pricing ✓
- \`/api/offers?q=SerpApi\` → 250/month + 50/hour + /pricing URL ✓
- \`/api/offers?q=ScrapingAnt\` → renewal-clarified description ✓

Refs #944