### PR TITLE
Communication data corrections: Resend + Mailchimp daily send caps

### DIFF
--- a/data/index.json
+++ b/data/index.json
@@ -1078,7 +1078,7 @@
     {
       "vendor": "Resend",
       "category": "Email",
-      "description": "Developer-first email API — 3K emails/mo free",
+      "description": "Developer-first email API — 3K emails/month free (100/day cap), 1 domain, 1K marketing contacts/month, 5 AI credits, 30-day data retention",
       "tier": "Free",
       "url": "https://resend.com/pricing",
       "tags": [
@@ -1087,7 +1087,7 @@
         "transactional",
         "email-service-alternative"
       ],
-      "verifiedDate": "2026-04-12"
+      "verifiedDate": "2026-04-20"
     },
     {
       "vendor": "Postmark",
@@ -1115,7 +1115,7 @@
     {
       "vendor": "Mailchimp",
       "category": "Email",
-      "description": "Email marketing — 250 contacts, 500 sends/month, marketing CRM, forms and landing pages included",
+      "description": "Email marketing — 250 contacts, 500 sends/month (250/day cap), 1 audience, 1 seat, marketing CRM, forms and landing pages, email support first 30 days",
       "tier": "Free",
       "url": "https://mailchimp.com/pricing/",
       "tags": [
@@ -1126,7 +1126,7 @@
         "free tier",
         "email-service-alternative"
       ],
-      "verifiedDate": "2026-04-12"
+      "verifiedDate": "2026-04-20"
     },
     {
       "vendor": "Mailjet",


### PR DESCRIPTION
## Summary

Refs #946 — Communication category PM spot-check corrections (2 vendors). Both entries had accurate monthly volume but omitted daily caps, which are the binding constraint for burst use cases.

### Changes

- **Resend.** Description updated: "3K emails/month free (100/day cap), 1 domain, 1K marketing contacts/month, 5 AI credits, 30-day data retention". Verified against resend.com/pricing.
- **Mailchimp.** Description updated: "250 contacts, 500 sends/month (250/day cap), 1 audience, 1 seat, marketing CRM, forms and landing pages, email support first 30 days". Verified against mailchimp.com/pricing.

`verifiedDate` bumped to 2026-04-20 on both.

### Decision: no deal_changes

Per op-learning #36, both are wrong-from-origin bulk-import metadata gaps (daily caps omitted from original description), not vendor-side tier reductions. Adding speculative historical reductions would pollute the deal_changes log.

## Test plan

- [x] Description matches vendor pricing page (verified via WebFetch on both resend.com/pricing and mailchimp.com/pricing)
- [x] E2E via local server: `/api/offers?q=Resend` and `/api/offers?q=Mailchimp` render the new descriptions with verifiedDate 2026-04-20
- [x] 1,071 tests pass (`node --test --test-concurrency=1`)