### PR TITLE
Cloudflare Queues free tier: 10K ops/day, not 1M ops/month (#948)

### DIFF
--- a/data/index.json
+++ b/data/index.json
@@ -1287,7 +1287,7 @@
     {
       "vendor": "Cloudflare Queues",
       "category": "Messaging",
-      "description": "Message queues on Workers — 1M operations/month free, 24-hour message retention. Added to free plan late 2025",
+      "description": "Message queues on Workers — 10K operations/day free (~300K/month) on the Workers Free plan, 24-hour message retention (non-configurable). The 1M operations/month allowance applies to the Workers Paid plan ($5/mo), which also unlocks configurable retention up to 14 days",
       "tier": "Free",
       "url": "https://developers.cloudflare.com/queues/platform/pricing/",
       "tags": [
@@ -1297,7 +1297,7 @@
         "cloudflare",
         "free tier"
       ],
-      "verifiedDate": "2026-04-14",
+      "verifiedDate": "2026-04-20",
       "payment_protocols": [
         {
           "protocol": "x402",


### PR DESCRIPTION
Refs #948.

## Summary
- Corrected the Cloudflare Queues entry in Messaging — prior description claimed 1M operations/month free, but that allowance applies only to the Workers Paid plan ($5/mo).
- The Workers Free plan provides **10K operations/day (~300K/month)** with non-configurable 24-hour message retention. Source: https://developers.cloudflare.com/queues/platform/pricing/
- Also resolves an internal contradiction — our Cloudflare Workers (Cloud Hosting) entry already correctly lists "Queues: 10K operations/day" in its bullet of Workers Free perks. The standalone Queues entry was the outlier.
- verifiedDate bumped to 2026-04-20.
- No deal_change added — wrong-from-origin bulk-import metadata per operational learning #36, not a vendor-side reduction.

## Acceptance criteria (from #948)
- [x] Cloudflare Queues description reflects 10K operations/day (not 1M/month)
- [x] No contradiction with Cloudflare Workers entry
- [x] Tests pass (1071/1071 on `node --test --test-concurrency=1`)

## Test plan
- [x] WebFetch verified developers.cloudflare.com/queues/platform/pricing/ — Workers Free plan: 10K ops/day, 24-hour retention; Workers Paid plan: 1M ops/month + configurable retention up to 14 days
- [x] Cross-checked Cloudflare Workers (Cloud Hosting) entry — already lists "Queues: 10K operations/day" → no longer contradictory
- [x] `node --test --test-concurrency=1` → 1071/1071 passing on clean run
- [x] E2E: `/api/offers?q=Cloudflare%20Queues` returns the corrected description with `days_since_verified:0`