### PR TITLE
fix(data): Scalr free tier concurrent runs 5→2 (Refs #952)

### DIFF
--- a/data/index.json
+++ b/data/index.json
@@ -6606,7 +6606,7 @@
     {
       "vendor": "Scalr",
       "category": "Infrastructure",
-      "description": "Terraform Automation and Collaboration (TACO) platform — unlimited users, workspaces, and managed resources on free tier. Full Terraform CLI support, OPA policy integration, hierarchical configuration, SAML SSO, 5 concurrent runs. Up to 50 runs/month free",
+      "description": "Terraform Automation and Collaboration (TACO) platform — unlimited users, workspaces, and managed resources on free tier. Full Terraform CLI support, OPA policy integration, hierarchical configuration, SAML SSO, 2 concurrent runs. Up to 50 runs/month free",
       "tier": "Free",
       "url": "https://www.scalr.com/pricing",
       "tags": [
@@ -6617,7 +6617,7 @@
         "free tier",
         "terraform-alternative"
       ],
-      "verifiedDate": "2026-04-14"
+      "verifiedDate": "2026-04-20"
     },
     {
       "vendor": "Terragrunt Scale",


### PR DESCRIPTION
## Summary
Scalr Free plan allows **2 concurrent runs**, not 5. Verified against https://www.scalr.com/pricing on 2026-04-20.

## Changes
- `data/index.json`: Scalr description `5 concurrent runs` → `2 concurrent runs`
- Bumped `verifiedDate` to `2026-04-20`

Other free-tier specifics remain accurate: up to 50 runs/month, unlimited users/workspaces/managed resources, full Terraform CLI support, OPA policy integration, SAML SSO.

## Decision: no deal_change
Per op-learning #36, this is wrong-from-origin bulk-import metadata (the `5` was never Scalr's actual Free-tier limit), not a vendor-side reduction. Adding a speculative `free_tier_reduced` entry would invent history.

## Verification
- `node --test --test-concurrency=1` → 1,071/1,071 passing
- Local server at `:9903` with `BASE_URL=http://localhost:9903`:
  ```
  /api/offers?q=Scalr → { "vendor":"Scalr", ..., "2 concurrent runs", verifiedDate:"2026-04-20", days_since_verified:0 }
  ```

Refs #952