### PR TITLE
Fix IDE & Code Editors category data (refs #956)

### DIFF
--- a/data/index.json
+++ b/data/index.json
@@ -9157,14 +9157,14 @@
     {
       "vendor": "v0.dev",
       "category": "IDE & Code Editors",
-      "description": "Created by Vercel, v0 generates copy-and-paste friendly React code using shadcn/ui and Tailwind CSS. It uses a credit system, providing 1,200 starting credits and 200 free credits monthly.",
+      "description": "Created by Vercel, v0 generates copy-and-paste friendly React code using shadcn/ui and Tailwind CSS. Free plan: $5 of included monthly credits, 7 messages/day limit. Visual editing with Design Mode, GitHub sync, and deploy to Vercel included. (v0.dev now redirects to v0.app.)",
       "tier": "Free",
-      "url": "https://v0.dev/",
+      "url": "https://v0.app/",
       "tags": [
         "developer-tools",
         "free-for-dev"
       ],
-      "verifiedDate": "2026-04-13"
+      "verifiedDate": "2026-04-20"
     },
     {
       "vendor": "beanstalkapp.com",
@@ -16835,14 +16835,14 @@
     {
       "vendor": "codesandbox.io",
       "category": "IDE & Code Editors",
-      "description": "Cloud IDE — unlimited public sandboxes, 5 private repositories, 40 hrs/month VM credits (4 vCPU, 8 GB RAM). Real-time collaboration, GitHub integration, instant previews",
+      "description": "Cloud IDE — unlimited Browser & VM Sandboxes, 5 members, 40 hrs/month VM credits (up to 4 vCPU, 8 GiB RAM, 20 GB storage per VM). SDK lite capped at 10 concurrent VM Sandboxes, 20 new Sandboxes/hour, 1,000 hourly API requests. Real-time collaboration, GitHub integration, instant previews",
       "tier": "Free",
-      "url": "https://codesandbox.io/",
+      "url": "https://codesandbox.io/pricing",
       "tags": [
         "developer-tools",
         "free-for-dev"
       ],
-      "verifiedDate": "2026-04-14"
+      "verifiedDate": "2026-04-20"
     },
     {
       "vendor": "Components.studio",
@@ -21752,7 +21752,7 @@
     {
       "vendor": "Google Gemini Code Assist",
       "category": "IDE & Code Editors",
-      "description": "AI coding assistant by Google — 6,000 code completions/day (180,000/month), 240 chat messages/day. Now supports Gemini 3.1 Pro and Gemini 3.0 Flash models (Preview) for agent mode, chat, and code generation. Available in VS Code, JetBrains IDEs, Android Studio, Cloud Shell. Requires only a Gmail account, no credit card. 90x more completions than GitHub Copilot free tier",
+      "description": "AI coding assistant by Google — 6,000 code completions/day, 240 chat requests/day, 1,000 Gemini CLI + Agent Mode requests/day (shared pool), powered by Gemini 2.5 on the free Individual tier. Gemini 3 is available to Google AI Ultra subscribers; others can join the waitlist. Available in VS Code, JetBrains IDEs, Android Studio, Cloud Workstations. Requires only a Gmail account, no credit card. 90x more completions than GitHub Copilot free tier",
       "tier": "Individual (Free)",
       "url": "https://codeassist.google",
       "tags": [
@@ -21764,7 +21764,7 @@
         "gemini",
         "free tier"
       ],
-      "verifiedDate": "2026-04-14"
+      "verifiedDate": "2026-04-20"
     },
     {
       "vendor": "LLM7.io",


### PR DESCRIPTION
Refs #956

## Summary

Three data corrections in the IDE & Code Editors category, all verified against live pricing pages 2026-04-20.

### v0.dev
- Prior: "1,200 starting credits and 200 free credits monthly"
- Fix: "$5 of included monthly credits, 7 messages/day limit" per [v0.app/pricing](https://v0.app/pricing)
- URL updated https://v0.dev/ → https://v0.app/ (v0.dev now redirects to v0.app)
- Kept vendor name "v0.dev" (preserves slug-based cross-refs in src/serve.ts; brand still widely known as v0)
- Added Design Mode / GitHub sync / Vercel deploy signals

### codesandbox.io
- Prior: "5 private repositories, 40 hrs/month VM credits (4 vCPU, 8 GB RAM)"
- Fix: "5 members" (team size cap, not repo count) per [codesandbox.io/pricing](https://codesandbox.io/pricing)
- Private Sandboxes are unlimited on Build plan; 5 is the member cap
- Added SDK lite caps (10 concurrent VM Sandboxes, 20 new/hour, 1,000 hourly API requests) and 20 GB per-VM storage

### Google Gemini Code Assist
- Prior: "Now supports Gemini 3.1 Pro and Gemini 3.0 Flash models (Preview)"
- Fix: Removed invented "Gemini 3.1 Pro" model. Per [codeassist.google](https://codeassist.google), free Individual tier gets **Gemini 2.5**; Gemini 3 is rolling out to Google AI Ultra subscribers first (others join waitlist)
- Added 1,000 Gemini CLI + Agent Mode requests/day (shared pool) — new signal from the site
- Chat "messages" → "requests" per current site language

## No deal_changes

Per op-learning #36, all three are wrong-from-origin bulk-import metadata issues, not vendor-side reductions. v0.dev's credit model might be a legit change but the $5/day model is compatible with Vercel's standard usage-credit pricing pattern — adding a speculative free_tier_reduced without a documented transition date would invent history.

## Verification

- `npm run build` — clean
- `node --test --test-concurrency=1 test/**/*.test.ts` → **1,048 tests passing**, 0 failing
- E2E via `BASE_URL=http://localhost:9905 PORT=9905 node dist/serve.js`:
  - `/api/offers?q=v0.dev` → new description present, URL v0.app, verifiedDate:2026-04-20 ✓
  - `/api/offers?q=codesandbox` → "5 members" + SDK lite + 20 GB VM storage present ✓
  - `/api/offers?q=Gemini%20Code%20Assist` → 1,000 CLI+Agent/day + Gemini 2.5 + waitlist language present ✓

## Test plan

- [x] Build succeeds
- [x] All 1,048 tests pass
- [x] E2E /api/offers lookup returns corrected descriptions for all 3 vendors