### PR TITLE
Fix Typeform free plan description: unlimited questions, not 10 fields (#942)

### DIFF
--- a/data/index.json
+++ b/data/index.json
@@ -12469,14 +12469,14 @@
     {
       "vendor": "Typeform.com",
       "category": "Forms",
-      "description": "Include beautifully designed forms on websites. The free plan allows only ten fields per form and 100 monthly responses.",
+      "description": "Include beautifully designed forms on websites. The free plan allows unlimited questions per form and 100 monthly responses.",
       "tier": "Free",
       "url": "https://www.typeform.com/",
       "tags": [
         "forms",
         "free-for-dev"
       ],
-      "verifiedDate": "2026-04-13"
+      "verifiedDate": "2026-04-20"
     },
     {
       "vendor": "Vidhook",


### PR DESCRIPTION
## Summary

Per typeform.com/pricing, Typeform's Free plan allows **unlimited questions per form** (not the previously stated "only ten fields") plus the 100 monthly responses cap which was already correct.

Single-line description correction; verifiedDate bumped 2026-04-13 → 2026-04-20.

## Source

Verified via WebFetch of https://www.typeform.com/pricing/ on 2026-04-20: Free plan lists "unlimited questions per form," 100 responses/month, 1 user/seat, 1 GB file storage, form logic, and integrations.

## No deal_change

Per op-learning #36, this is wrong-from-origin bulk-import metadata (the "10 fields" cap was never Typeform's real Free-tier limit), not a vendor-side reduction. No speculative deal_change added.

## Test plan
- [x] `npm run build` clean
- [x] `node --test --test-concurrency=1 test/**/*.test.ts` — 1,048 pass / 0 fail
- [x] E2E: `/api/offers?q=Typeform` returns corrected description, verifiedDate 2026-04-20, days_since_verified 1

Refs #942