### PR TITLE
Add reverify:rolling for staggered freshness re-verification (Refs #959)

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "ingest:startup-deals": "node scripts/ingest-startup-deals.ts",
     "recategorize": "node scripts/recategorize.ts",
     "reverify": "node scripts/reverify.js",
+    "reverify:rolling": "node scripts/reverify-rolling.js",
     "verify-freshness": "node scripts/verify-freshness.js",
     "validate": "node scripts/validate-data.ts",
     "test:referral-pipeline": "npm run build && node scripts/test-referral-pipeline.ts",

--- a/scripts/reverify-rolling.js
+++ b/scripts/reverify-rolling.js
@@ -1,0 +1,197 @@
+#!/usr/bin/env node
+
+/**
+ * Rolling data re-verification.
+ *
+ * Picks the N oldest-verified entries (regardless of staleness threshold),
+ * checks them, and stamps verifiedDate across a 3-day window so future
+ * re-verifications stay smoothly distributed instead of cliffing on a
+ * single date.
+ *
+ * Usage:
+ *   npm run reverify:rolling                    # 100 oldest, URL-only
+ *   npm run reverify:rolling -- --limit 50      # 50 oldest
+ *   npm run reverify:rolling -- --ai            # Haiku-based verification
+ *   npm run reverify:rolling -- --dry-run       # report only
+ */
+
+import { readFileSync, writeFileSync } from "node:fs";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { reverifyBatch } from "./reverify.js";
+import { fetchPageText, verifyWithHaiku } from "./verify-freshness.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const INDEX_PATH = resolve(__dirname, "..", "data", "index.json");
+const DEFAULT_LIMIT = 100;
+const URL_CONCURRENCY = 10;
+const AI_RATE_LIMIT_MS = 500;
+const STAGGER_WINDOW_DAYS = 3;
+
+export function pickOldestEntries(offers, limit, now = new Date()) {
+  const entries = offers.map((offer, index) => {
+    const ts = offer.verifiedDate
+      ? new Date(offer.verifiedDate).getTime()
+      : 0; // missing date sorts oldest
+    return { index, offer, ts };
+  });
+  entries.sort((a, b) => a.ts - b.ts);
+  const picked = entries.slice(0, limit).map(({ index, offer }) => ({ index, offer }));
+  const remaining = entries.slice(limit);
+  const oldestRemaining = remaining.length > 0
+    ? (remaining[0].offer.verifiedDate || null)
+    : null;
+  return { picked, oldestRemaining };
+}
+
+export function staggeredDate(now, rand = Math.random) {
+  const offsetDays = Math.floor(rand() * STAGGER_WINDOW_DAYS);
+  const d = new Date(now.getTime() - offsetDays * 24 * 60 * 60 * 1000);
+  return d.toISOString().split("T")[0];
+}
+
+function sleep(ms) {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+async function runUrlMode(picked, data, dryRun, now) {
+  let verified = 0;
+  let flagged = 0;
+  for (let i = 0; i < picked.length; i += URL_CONCURRENCY) {
+    const batch = picked.slice(i, i + URL_CONCURRENCY);
+    const results = await reverifyBatch(batch);
+    for (const v of results.verified) {
+      if (!dryRun) {
+        data.offers[v.index].verifiedDate = staggeredDate(now);
+      }
+      verified++;
+    }
+    for (const f of results.flagged) {
+      console.log(`  ⚠ ${f.vendor} — ${f.error} (${f.url})`);
+      flagged++;
+    }
+  }
+  return { verified, flagged, changed: 0, changes: [] };
+}
+
+async function runAiMode(picked, data, dryRun, now) {
+  const Anthropic = (await import("@anthropic-ai/sdk")).default;
+  if (!process.env.ANTHROPIC_API_KEY) {
+    throw new Error("ANTHROPIC_API_KEY required for --ai mode");
+  }
+  const client = new Anthropic();
+
+  let verified = 0;
+  let flagged = 0;
+  let changed = 0;
+  const changes = [];
+
+  for (const entry of picked) {
+    const { offer, index } = entry;
+    const page = await fetchPageText(offer.url);
+    if (!page.ok) {
+      console.log(`  ⚠ ${offer.vendor} — ${page.error} (${offer.url})`);
+      flagged++;
+      await sleep(AI_RATE_LIMIT_MS);
+      continue;
+    }
+    let result;
+    try {
+      result = await verifyWithHaiku(client, offer, page.text);
+    } catch (err) {
+      console.log(`  ⚠ ${offer.vendor} — AI error: ${err.message}`);
+      flagged++;
+      await sleep(AI_RATE_LIMIT_MS);
+      continue;
+    }
+    if (result.status === "confirmed") {
+      if (!dryRun) {
+        data.offers[index].verifiedDate = staggeredDate(now);
+      }
+      verified++;
+    } else if (result.status === "changed") {
+      changed++;
+      changes.push({
+        vendor: offer.vendor,
+        category: offer.category,
+        tier: offer.tier,
+        summary: result.summary,
+      });
+      console.log(`  ⚠ ${offer.vendor} (${offer.category}, ${offer.tier}): ${result.summary}`);
+    } else {
+      flagged++;
+      console.log(`  ⚠ ${offer.vendor} — unclear: ${result.summary || "no detail"}`);
+    }
+    await sleep(AI_RATE_LIMIT_MS);
+  }
+  return { verified, flagged, changed, changes };
+}
+
+async function main() {
+  const args = process.argv.slice(2);
+  const dryRun = args.includes("--dry-run");
+  const useAi = args.includes("--ai");
+
+  const limitIdx = args.indexOf("--limit");
+  const limit = limitIdx !== -1
+    ? parseInt(args[limitIdx + 1], 10)
+    : DEFAULT_LIMIT;
+
+  if (isNaN(limit) || limit < 1) {
+    console.error(`Invalid limit: ${args[limitIdx + 1]}. Must be a positive integer.`);
+    process.exit(2);
+  }
+
+  let data;
+  try {
+    data = JSON.parse(readFileSync(INDEX_PATH, "utf-8"));
+  } catch (err) {
+    console.error(`Failed to read index: ${err.message}`);
+    process.exit(2);
+  }
+
+  const offers = data.offers || [];
+  const now = new Date();
+  const { picked, oldestRemaining } = pickOldestEntries(offers, limit, now);
+
+  console.log(
+    `Rolling re-verification — ${picked.length} oldest entries` +
+      (useAi ? " (Haiku)" : " (URL-only)") +
+      (dryRun ? " (dry-run)" : "")
+  );
+  console.log("");
+
+  if (picked.length === 0) {
+    console.log("No entries to process.");
+    process.exit(0);
+  }
+
+  const result = useAi
+    ? await runAiMode(picked, data, dryRun, now)
+    : await runUrlMode(picked, data, dryRun, now);
+
+  if (!dryRun && result.verified > 0) {
+    writeFileSync(INDEX_PATH, JSON.stringify(data, null, 2) + "\n");
+  }
+
+  console.log("");
+  console.log("── Summary ──");
+  console.log(`Checked: ${picked.length}`);
+  console.log(`Verified (date bumped): ${result.verified}`);
+  if (useAi) console.log(`Changed (PM review needed): ${result.changed}`);
+  console.log(`Flagged (URL/AI failure): ${result.flagged}`);
+  console.log(`Oldest remaining verifiedDate: ${oldestRemaining ?? "n/a"}`);
+  console.log(`Total entries: ${offers.length}`);
+
+  process.exit(0);
+}
+
+const isMainModule =
+  process.argv[1] &&
+  resolve(process.argv[1]) === resolve(fileURLToPath(import.meta.url));
+if (isMainModule) {
+  main().catch((err) => {
+    console.error(`Fatal error: ${err.message}`);
+    process.exit(1);
+  });
+}

--- a/test/reverify-rolling.test.ts
+++ b/test/reverify-rolling.test.ts
@@ -1,0 +1,106 @@
+import { describe, it } from "node:test";
+import assert from "node:assert";
+
+const { pickOldestEntries, staggeredDate } = await import("../scripts/reverify-rolling.js");
+
+describe("rolling re-verification", () => {
+  describe("pickOldestEntries", () => {
+    it("picks the N oldest entries by verifiedDate", () => {
+      const offers = [
+        { vendor: "Newest", verifiedDate: "2026-04-20" },
+        { vendor: "Middle", verifiedDate: "2026-04-10" },
+        { vendor: "Oldest", verifiedDate: "2026-03-01" },
+        { vendor: "Newer", verifiedDate: "2026-04-15" },
+      ];
+      const { picked, oldestRemaining } = pickOldestEntries(offers, 2);
+      assert.strictEqual(picked.length, 2);
+      assert.strictEqual(picked[0].offer.vendor, "Oldest");
+      assert.strictEqual(picked[1].offer.vendor, "Middle");
+      assert.strictEqual(oldestRemaining, "2026-04-15");
+    });
+
+    it("treats missing verifiedDate as oldest", () => {
+      const offers = [
+        { vendor: "Recent", verifiedDate: "2026-04-20" },
+        { vendor: "NoDate" },
+        { vendor: "Old", verifiedDate: "2026-03-01" },
+      ];
+      const { picked } = pickOldestEntries(offers, 2);
+      assert.strictEqual(picked[0].offer.vendor, "NoDate");
+      assert.strictEqual(picked[1].offer.vendor, "Old");
+    });
+
+    it("preserves the original index for in-place updates", () => {
+      const offers = [
+        { vendor: "A", verifiedDate: "2026-04-20" },
+        { vendor: "B", verifiedDate: "2026-03-01" },
+        { vendor: "C", verifiedDate: "2026-04-10" },
+      ];
+      const { picked } = pickOldestEntries(offers, 2);
+      assert.strictEqual(picked[0].index, 1);
+      assert.strictEqual(picked[1].index, 2);
+    });
+
+    it("returns null oldestRemaining when limit covers everything", () => {
+      const offers = [{ vendor: "Only", verifiedDate: "2026-04-20" }];
+      const { picked, oldestRemaining } = pickOldestEntries(offers, 100);
+      assert.strictEqual(picked.length, 1);
+      assert.strictEqual(oldestRemaining, null);
+    });
+
+    it("is idempotent in selection given a fixed input", () => {
+      const offers = [
+        { vendor: "A", verifiedDate: "2026-04-20" },
+        { vendor: "B", verifiedDate: "2026-03-01" },
+        { vendor: "C", verifiedDate: "2026-04-10" },
+      ];
+      const first = pickOldestEntries(offers, 2);
+      const second = pickOldestEntries(offers, 2);
+      assert.deepStrictEqual(
+        first.picked.map((p) => p.offer.vendor),
+        second.picked.map((p) => p.offer.vendor)
+      );
+    });
+  });
+
+  describe("staggeredDate", () => {
+    const now = new Date("2026-04-21T12:00:00Z");
+
+    it("returns today's date when rand picks offset 0", () => {
+      const stamp = staggeredDate(now, () => 0);
+      assert.strictEqual(stamp, "2026-04-21");
+    });
+
+    it("returns yesterday when rand picks offset 1", () => {
+      const stamp = staggeredDate(now, () => 0.4); // floor(0.4*3) = 1
+      assert.strictEqual(stamp, "2026-04-20");
+    });
+
+    it("returns day-before when rand picks offset 2", () => {
+      const stamp = staggeredDate(now, () => 0.8); // floor(0.8*3) = 2
+      assert.strictEqual(stamp, "2026-04-19");
+    });
+
+    it("never produces dates outside the 3-day window", () => {
+      const dates = new Set<string>();
+      for (let i = 0; i < 200; i++) {
+        dates.add(staggeredDate(now));
+      }
+      const allowed = new Set(["2026-04-21", "2026-04-20", "2026-04-19"]);
+      for (const d of dates) {
+        assert.ok(allowed.has(d), `unexpected stamped date ${d}`);
+      }
+    });
+
+    it("distributes across all three days over many samples", () => {
+      const counts: Record<string, number> = {};
+      for (let i = 0; i < 600; i++) {
+        const d = staggeredDate(now);
+        counts[d] = (counts[d] ?? 0) + 1;
+      }
+      assert.ok(counts["2026-04-21"] > 100);
+      assert.ok(counts["2026-04-20"] > 100);
+      assert.ok(counts["2026-04-19"] > 100);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Adds `npm run reverify:rolling` — picks the N oldest entries by `verifiedDate` (default 100, regardless of staleness threshold), checks them, and stamps `verifiedDate` across a 3-day rolling window so future re-verifications stay smoothly distributed instead of cliffing on a single date.

Built on the existing `reverify.js` (URL reachability) and `verify-freshness.js` (Haiku) infrastructure — the new script is an orchestrator, not a reimplementation.

Refs #959

## Why this matters

77% of the index was verified during the April 7-21 sweep. Without intervention, those 1,200+ entries cross the 30-day staleness threshold around May 5-7 simultaneously, recreating the same audit-thread workload that just took ~25 cycles to clear. The rolling mode plus 3-day stagger keeps the freshness distribution flat at near-zero operational cost (~100 URL checks/run, no AI cost unless `--ai` flag passed).

## Acceptance criteria

| Criterion | Status |
|-----------|--------|
| New `npm run reverify:rolling` re-verifies N oldest entries (default 100) | ✓ |
| Staggered date stamping across 3-day window (today / yesterday / day-before, uniform random) | ✓ |
| Report output: checked, verified (bumped), flagged, oldest remaining `verifiedDate`, total | ✓ |
| `--ai` flag uses `verify-freshness.js` Haiku verification (URL-only by default for zero cost) | ✓ |
| Idempotent: running twice safely picks the next-oldest batch | ✓ (selection is purely a sort over current `verifiedDate`) |
| Sorts by `verifiedDate ASC` so oldest gets verified first | ✓ |

## Implementation notes

- `pickOldestEntries(offers, limit)` — sorts by `verifiedDate` ascending (missing date sorts oldest), returns `{picked, oldestRemaining}` for the report. Pure function, exported for testing.
- `staggeredDate(now, rand?)` — uniform random offset over 3 days, returns YYYY-MM-DD. Pure function, `rand` injectable for deterministic tests.
- URL-mode delegates to `reverifyBatch` from `reverify.js` (concurrency 10).
- AI-mode delegates to `fetchPageText` + `verifyWithHaiku` from `verify-freshness.js` (rate-limited 500 ms).
- Argument validation rejects non-positive integers.

## Test plan

- [x] `node --test test/reverify-rolling.test.ts` — 10 new tests pass (oldest-N selection, missing-date handling, index preservation, idempotency, stamp window bounds, stamp distribution).
- [x] `npm test` — full suite 1058/1058 passing (1048 existing + 10 new), no regressions.
- [x] `node scripts/reverify-rolling.js --dry-run --limit 5` against current index: reports `Checked: 5 / Verified: 5 / Flagged: 0 / Oldest remaining: 2026-04-05 / Total: 1586`.
- [x] Argument validation rejects `--limit 0` and `--limit abc` with exit 2.
- [ ] Real (non-dry-run) execution deferred to a future cycle once Rob confirms the staggering policy — no data writes in this PR.