### PR TITLE
Stop friends tests from leaving data/agent_friends.json dirty (Refs #921)

### DIFF
--- a/test/friends.test.ts
+++ b/test/friends.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, after, beforeEach } from "node:test";
+import { describe, it, after, before, beforeEach } from "node:test";
 import assert from "node:assert";
 import path from "node:path";
 import fs from "node:fs";
@@ -49,8 +49,11 @@ function createTestAgent(name: string) {
 }
 
 describe("Agent Friendship Network", () => {
-  beforeEach(() => {
+  before(() => {
     backupFiles();
+  });
+
+  beforeEach(() => {
     resetAll();
   });
 

--- a/test/manage-friends-tool.test.ts
+++ b/test/manage-friends-tool.test.ts
@@ -1,14 +1,34 @@
-import { describe, it, afterEach } from "node:test";
+import { describe, it, before, after, afterEach } from "node:test";
 import assert from "node:assert";
 import { spawn, type ChildProcess } from "node:child_process";
+import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const DATA_DIR = path.join(__dirname, "..", "data");
+const BACKED_UP_FILES = ["agent_friends.json", "agents.json", "referral_codes.json"];
 
 describe("manage_friends MCP tool via HTTP", () => {
   let serverPort = 0;
   let proc: ChildProcess | null = null;
+  const savedContent: Record<string, string | null> = {};
+
+  before(() => {
+    for (const f of BACKED_UP_FILES) {
+      const p = path.join(DATA_DIR, f);
+      savedContent[f] = fs.existsSync(p) ? fs.readFileSync(p, "utf-8") : null;
+    }
+  });
+
+  after(() => {
+    for (const f of BACKED_UP_FILES) {
+      const p = path.join(DATA_DIR, f);
+      const original = savedContent[f];
+      if (original !== null) fs.writeFileSync(p, original, "utf-8");
+      else if (fs.existsSync(p)) fs.unlinkSync(p);
+    }
+  });
 
   function startHttpServer(): Promise<ChildProcess> {
     return new Promise((resolve, reject) => {


### PR DESCRIPTION
## Summary

Fixes the recurring \`data/agent_friends.json\` modification noted across many recent cycles (PRs #916, #918, #920 etc — every cycle had to \`git checkout data/agent_friends.json\` before staging).

Refs #921

## Root causes (two)

1. **\`test/friends.test.ts\`** called \`backupFiles()\` in \`beforeEach\` instead of \`before()\`. \`savedFriends\` got reassigned every test, so \`after()\` restored from the *second-to-last* test's state — not the original. Issue #921 caught this one.
2. **\`test/manage-friends-tool.test.ts\`** spawned the HTTP server (which writes to real data files) with no backup/restore at all. The \"duplicate add returns error\" case adds a friendship and never removes it, leaking directly into \`data/agent_friends.json\`. Caught while verifying the #921 fix — the friends.test.ts patch alone left data dirty.

## Fix

- friends.test.ts: move \`backupFiles()\` into \`before()\`; keep \`resetAll()\` in \`beforeEach\`.
- manage-friends-tool.test.ts: add \`before\`/\`after\` that snapshots and restores the three data files (\`agent_friends.json\`, \`agents.json\`, \`referral_codes.json\`).

## Test plan

- [x] \`npm test\` — 1058/1058 passing, no regressions.
- [x] After \`npm test\`, \`git status\` shows no \`data/\` modifications (only the test-file edits remain).
- [x] No other test file uses \`backupFiles()\` (confirmed via grep).