### PR TITLE
CI: daily rolling re-verification workflow (#964)

### DIFF
--- a/.github/workflows/reverify.yml
+++ b/.github/workflows/reverify.yml
@@ -1,0 +1,58 @@
+name: Daily rolling re-verification
+
+on:
+  schedule:
+    - cron: "0 6 * * *"
+  workflow_dispatch:
+    inputs:
+      limit:
+        description: "Number of oldest entries to re-verify"
+        required: false
+        default: "75"
+
+permissions:
+  contents: write
+
+concurrency:
+  group: reverify-rolling
+  cancel-in-progress: false
+
+jobs:
+  reverify:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run rolling re-verification
+        id: reverify
+        run: |
+          set -o pipefail
+          LIMIT="${{ github.event.inputs.limit || '75' }}"
+          node scripts/reverify-rolling.js --limit "$LIMIT" | tee /tmp/reverify.log
+          VERIFIED=$(grep -oE '^Verified \(date bumped\): [0-9]+' /tmp/reverify.log | grep -oE '[0-9]+$' || echo 0)
+          FLAGGED=$(grep -oE '^Flagged \(URL/AI failure\): [0-9]+' /tmp/reverify.log | grep -oE '[0-9]+$' || echo 0)
+          echo "verified=$VERIFIED" >> "$GITHUB_OUTPUT"
+          echo "flagged=$FLAGGED" >> "$GITHUB_OUTPUT"
+
+      - name: Commit and push if changed
+        env:
+          VERIFIED: ${{ steps.reverify.outputs.verified }}
+          FLAGGED: ${{ steps.reverify.outputs.flagged }}
+        run: |
+          if git diff --quiet -- data/index.json; then
+            echo "No changes to data/index.json — skipping commit."
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add data/index.json
+          git commit -m "data(auto): rolling re-verification — ${VERIFIED} verified, ${FLAGGED} flagged"
+          git push origin HEAD:main


### PR DESCRIPTION
## Summary
Adds a GitHub Actions workflow that automates the rolling re-verification script shipped in PR #962. Runs daily at 06:00 UTC, picks the 75 oldest entries, re-checks URLs, stamps them across a 3-day rolling window, and commits+pushes the updated \`data/index.json\`.

## Why
With 1,586 entries and a 30-day staleness threshold, ~53 entries/day is the theoretical minimum to maintain smooth freshness distribution. 75/day gives a full sweep every ~21 days — comfortable margin that absorbs temporary URL failures. Without automation, someone must remember to run \`npm run reverify:rolling\` each cycle; this removes that dependency.

## Acceptance criteria mapping
- [x] **New workflow file** \`.github/workflows/reverify.yml\` — present
- [x] **Schedule** \`cron: '0 6 * * *'\` — present
- [x] **Steps**: checkout → setup-node@v4 (cached npm) → \`npm ci\` → \`node scripts/reverify-rolling.js --limit 75\` → conditional commit → push to main
- [x] **Commit message format** \`data(auto): rolling re-verification — N verified, M flagged\` — extracted via grep from the script's summary output
- [x] **No-op safety** — \`git diff --quiet -- data/index.json\` short-circuits with exit 0 when nothing changed
- [x] **Manual trigger** \`workflow_dispatch\` with configurable \`limit\` input (default 75) for on-demand runs
- [x] **Permissions** \`contents: write\` using default \`GITHUB_TOKEN\`, no extra secrets

Also added: \`concurrency: { group: reverify-rolling, cancel-in-progress: false }\` to serialize if a manual run overlaps a scheduled one.

## Implementation notes
- \`npm ci\` chosen over \`npm install\` — matches the cached setup-node flow, and \`package-lock.json\` is committed. Consistent, faster, deterministic.
- Grep extraction of verified/flagged counts uses two-stage \`grep -oE\` against the script's \`── Summary ──\` block. Validated locally against real script output.
- Action pushes to \`main\` via \`git push origin HEAD:main\`. Railway auto-deploys on push, so refreshed dates go live the same day.
- URL-only mode (no \`--ai\` flag) keeps cost at \$0. AI verification can be added later if the flagged rate grows meaningful.

## Test plan
- [x] Smoke-tested \`node scripts/reverify-rolling.js --dry-run --limit 3\` locally — summary lines parsed correctly by the workflow's grep extraction (\`verified=0 flagged=3\` output matched expected)
- [x] Full test suite: 1,058 passing (\`node --test --test-concurrency=1 test/**/*.test.ts\`), no regressions
- [x] YAML parse-validated
- [ ] First scheduled run will fire at 06:00 UTC tomorrow; can also be triggered manually via workflow_dispatch from the Actions tab to verify end-to-end before waiting
- [ ] Watch the first run — confirm the commit lands on \`main\` with the expected message, and that Railway picks it up

Refs #964