### PR TITLE
Data: GitHub Copilot April 20 signup pause + consolidation (Refs #967)

### DIFF
--- a/data/deal_changes.json
+++ b/data/deal_changes.json
@@ -3939,6 +3939,41 @@
         "Cloudflare Pages",
         "Railway"
       ]
+    },
+    {
+      "vendor": "GitHub Copilot",
+      "change_type": "restriction",
+      "date": "2026-04-10",
+      "summary": "GitHub paused new Copilot Pro trials due to abuse. Existing trials continue through their term. New users could still sign up for Pro directly (paid) until the broader April 20 signup pause closed that path too.",
+      "previous_state": "Copilot Pro offered a 30-day free trial to any new user",
+      "current_state": "Copilot Pro trials paused indefinitely; direct Pro signup also paused as of 2026-04-20",
+      "impact": "medium",
+      "source_url": "https://github.blog/changelog/2026-04-10-pausing-new-github-copilot-pro-trials/",
+      "category": "AI Coding",
+      "alternatives": [
+        "Cursor",
+        "Windsurf",
+        "Gemini Code Assist",
+        "Claude Code"
+      ]
+    },
+    {
+      "vendor": "GitHub Copilot",
+      "change_type": "restriction",
+      "date": "2026-04-20",
+      "summary": "GitHub paused new signups for Copilot Pro, Pro+, and Copilot Student plans citing infrastructure strain from agentic AI workflows (long-running, parallelized sessions overwhelming capacity). Existing users are unaffected. Free tier signups remain open. Same announcement also removed Claude Opus from Pro (now Pro+ only) and tightened usage limits on individual plans.",
+      "previous_state": "Pro ($10/mo), Pro+ ($39/mo), and Copilot Student plans accepting new signups. Claude Opus available on Pro. Standard individual-plan usage limits.",
+      "current_state": "Pro/Pro+/Student new signups paused. Claude Opus Pro+ only. Individual-plan usage limits tightened. Free tier unaffected.",
+      "impact": "high",
+      "source_url": "https://github.blog/changelog/2026-04-20-changes-to-github-copilot-plans-for-individuals/",
+      "category": "AI Coding",
+      "alternatives": [
+        "Cursor",
+        "Windsurf",
+        "Gemini Code Assist",
+        "Claude Code",
+        "Cline"
+      ]
     }
   ]
 }

--- a/data/index.json
+++ b/data/index.json
@@ -1505,30 +1505,6 @@
       "verifiedDate": "2026-04-13"
     },
     {
-      "vendor": "GitHub Copilot",
-      "category": "IDE & Code Editors",
-      "description": "AI code assistant — 2,000 completions/month, 50 premium requests/month, works in VS Code/JetBrains/GitHub.com. Premium requests use advanced models (Claude Opus 4, o3); overage $0.04/request. Students get dedicated Copilot Student plan (Mar 2026) — premium models available via Auto mode only, no manual model selection for GPT-5.4/Claude Opus/Sonnet. OSS maintainers get Pro free",
-      "tier": "Free",
-      "url": "https://github.com/features/copilot/plans",
-      "tags": [
-        "developer tools",
-        "ai",
-        "code completion",
-        "ide",
-        "free tier",
-        "deal-change"
-      ],
-      "verifiedDate": "2026-04-13",
-      "referral_program": {
-        "available": false,
-        "referrer_benefit": "N/A",
-        "referee_benefit": "N/A",
-        "program_url": "https://github.com/partners",
-        "type": "closed",
-        "notes": "No individual referral program. Education partner program for student developer pack."
-      }
-    },
-    {
       "vendor": "Cursor",
       "category": "AI Coding",
       "description": "AI-powered code editor built on VS Code. 6-plan structure: Free (2,000 completions/month, 50 slow premium requests), Hobby $10/month (lighter paid tier), Pro $20/month (unlimited completions, 500 fast premium requests), Pro+ $60/month (10x premium requests vs Pro, priority access, more context), Business $40/seat/month, Ultra $200/month (highest credit limits for power users). Credit-based pricing model since June 2025.",
@@ -2492,7 +2468,7 @@
     {
       "vendor": "GitHub",
       "category": "Source Control",
-      "description": "Free access to GitHub Pro, JetBrains, Namecheap domain, and 100+ developer tools for verified students. Includes GitHub Copilot, Codespaces, and Actions minutes",
+      "description": "Free access to GitHub Pro, JetBrains, Namecheap domain, and 100+ developer tools for verified students. Includes GitHub Copilot (new Copilot Student signups paused 2026-04-20 due to infrastructure strain — existing students unaffected), Codespaces, and Actions minutes",
       "tier": "Student Pack",
       "url": "https://education.github.com/pack",
       "tags": [
@@ -21242,7 +21218,7 @@
     {
       "vendor": "GitHub Copilot",
       "category": "AI Coding",
-      "description": "AI coding assistant by GitHub/Microsoft. Free tier: 2,000 code completions/month, 50 premium requests/month. Pro $10/mo (unlimited completions, 300 premium requests). Pro+ $39/mo (1,500 premium requests, all models incl. Claude Opus 4, o3). Business $19/seat/mo (300/user). Enterprise $39/seat/mo (1,000/user). Overage $0.04/premium request. Model multipliers: advanced reasoning 5x-20x per interaction. Student plan (Mar 2026): premium models only via Auto mode, no manual selection.",
+      "description": "AI coding assistant by GitHub/Microsoft. Works in VS Code/JetBrains/GitHub.com. Free tier: 2,000 completions/month, 50 premium requests/month. Pro $10/mo (unlimited completions, 300 premium requests). Pro+ $39/mo (1,500 premium requests, all advanced models incl. Claude Opus). Business $19/seat/mo (300/user). Enterprise $39/seat/mo (1,000/user). Overage $0.04/premium request. Model multipliers: advanced reasoning 5x-20x per interaction. **April 20, 2026: GitHub paused new signups for Pro, Pro+, and Copilot Student plans citing infrastructure strain from agentic AI workflows (long-running, parallelized sessions overwhelming capacity); Free tier signups remain open.** Pro trials paused April 10, 2026 (abuse). Claude Opus removed from Pro (now Pro+ only); individual-plan usage limits tightened. Copilot Student: existing students unaffected; premium models via Auto mode only (no manual selection). OSS maintainers get Pro free (when signups reopen).",
       "tier": "Free",
       "url": "https://github.com/features/copilot",
       "tags": [
@@ -21252,9 +21228,10 @@
         "ide",
         "developer tools",
         "cursor-alternative",
-        "deal-change"
+        "deal-change",
+        "signup-paused"
       ],
-      "verifiedDate": "2026-04-13",
+      "verifiedDate": "2026-04-21",
       "referral_program": {
         "available": false,
         "referrer_benefit": "N/A",

--- a/test/deal-changes.test.ts
+++ b/test/deal-changes.test.ts
@@ -76,7 +76,7 @@ describe("track_changes tool", () => {
 
     assert.ok(Array.isArray(body.changes));
     assert.strictEqual(body.total, body.changes.length);
-    assert.strictEqual(body.total, 282);
+    assert.strictEqual(body.total, 284);
   });
 
   it("filters by date (since)", async () => {


### PR DESCRIPTION
## Summary

Updates the GitHub Copilot entry to reflect the April 20, 2026 plan changes announced in the GitHub changelog. This is a major pricing/availability event — signup pauses are rare and signal infrastructure stress, exactly the kind of change developers need to know about.

**Refs #967.**

### What changed on GitHub's side (April 20)

- **Pro, Pro+, and Copilot Student new signups paused** indefinitely due to infrastructure strain from agentic AI workflows (long-running, parallelized sessions overwhelming capacity). Existing users unaffected. Free tier signups remain open.
- **Claude Opus removed from Pro** (now Pro+ only).
- **Individual-plan usage limits tightened**.
- Separately, **Pro trials were paused April 10** due to abuse.

### What this PR does

- **Consolidates the two duplicate GitHub Copilot entries** (previously IDE & Code Editors + AI Coding) into a single comprehensive entry in AI Coding. Keeps full tier detail (Free / Pro / Pro+ / Business / Enterprise) and adds the April 20 news. This closes the "2 Copilot entries" acceptance item.
- **Adds deal_change**: \`2026-04-20 restriction\` (impact: high) — covers signup pause + Opus shift + limit tightening.
- **Adds deal_change**: \`2026-04-10 restriction\` (impact: medium) — covers the Pro trial pause.
- **Updates the GitHub Student Pack entry** to note that new Copilot Student signups are paused (existing students unaffected).
- **Bumps test assertion** \`body.total\` 282→284 to match the two new deal_changes.

Note on the count: the test filters \`since='2024-01-01'\` which excludes 2 pre-2024 entries (Heroku 2022-11-28, HashiCorp 2023-08-10), so the asserted total is 284, not the raw 286.

### Schema note re: acceptance criteria

Issue #967 asked for \`risk_level: risky\` and \`stability: volatile\` fields. Those fields do not exist on any offer in the current schema (confirmed via field enumeration across all 1,585 offers). I added a \`signup-paused\` tag instead so the state surfaces in tag-based filtering. If the PM wants risk_level/stability promoted to first-class offer fields, that's a separate schema change worth its own issue.

### Sources

- https://github.blog/changelog/2026-04-20-changes-to-github-copilot-plans-for-individuals/
- https://github.blog/changelog/2026-04-10-pausing-new-github-copilot-pro-trials/
- https://www.theregister.com/2026/04/20/microsofts_github_grounds_copilot_account/

### Stats

- **1,585 offers** (−1, duplicate IDE & Code Editors Copilot entry removed).
- **286 deal_changes** (+2).
- **1,058 tests passing** on clean \`node --test --test-concurrency=1 test/**/*.test.ts\`.

## Test plan

- [x] \`npm run build\` clean
- [x] \`npm test\` — 1,058 tests passing
- [x] E2E via \`BASE_URL=http://localhost:9933 PORT=9933 node dist/serve.js\`:
  - [x] \`GET /api/offers?q=GitHub+Copilot\` returns exactly 1 Copilot vendor entry (AI Coding, verifiedDate 2026-04-21)
  - [x] \`GET /vendor/github-copilot\` renders signup-pause content and "April 20" markers
  - [x] \`GET /api/changes?vendor=GitHub+Copilot&since=2026-04-01\` returns 2 entries (April 10 + April 20), newest-first, correct impacts (high/medium)
  - [x] GitHub Student Pack entry shows "new Copilot Student signups paused 2026-04-20 — existing students unaffected"