### PR TITLE
Persistent per-endpoint API analytics in telemetry.json (Refs #965)

### DIFF
--- a/src/serve.ts
+++ b/src/serve.ts
@@ -8,7 +8,7 @@ import { createServer, getServerCard } from "./server.js";
 import { loadOffers, getCategories, getNewOffers, getNewestDeals, searchOffers, enrichOffers, loadDealChanges, getDealChanges, getPersonalizedChanges, getOfferDetails, compareServices, checkVendorRisk, auditStack, getExpiringDeals, getWeeklyDigest, getFormattedWeeklyDigest, getFreshnessMetrics, getStabilityMap, getVendorReferral, sanitizeQuery } from "./data.js";
 import { getStackRecommendation } from "./stacks.js";
 import { estimateCosts } from "./costs.js";
-import { recordApiHit, recordSessionConnect, recordSessionDisconnect, recordLandingPageView, getStats, getConnectionStats, loadTelemetry, flushTelemetry, logRequest, getRequestLog, recordPageView, getPageViews, recordReferralListingCall, recordReferralVendorLookup, getReferralMarketplaceStats, getSessionClassification, recordSearchQuery, getSearchAnalytics } from "./stats.js";
+import { recordApiHit, recordSessionConnect, recordSessionDisconnect, recordLandingPageView, getStats, getConnectionStats, loadTelemetry, flushTelemetry, logRequest, getRequestLog, recordPageView, getPageViews, recordReferralListingCall, recordReferralVendorLookup, getReferralMarketplaceStats, getSessionClassification, recordSearchQuery, getSearchAnalytics, getApiHitsByEndpoint } from "./stats.js";
 import { openapiSpec } from "./openapi.js";
 import { registerAgent, authenticateRequest, validateVestauthUrl, hashApiKey, updateAgentX402Address, getAgentById } from "./agents.js";
 import { logReferralRequest } from "./referral-requests.js";
@@ -53229,12 +53229,15 @@ const httpServer = createHttpServer(async (req, res) => {
     res.end(JSON.stringify({ status: "ok", sessions: sessions.size, stats: getStats() }));
   } else if (url.pathname === "/api/metrics" && isGetOrHead) {
     recordApiHit("/api/metrics");
+    const searchAnalytics = getSearchAnalytics();
     res.writeHead(200, { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" });
     res.end(JSON.stringify({
       ...getStats(),
       ...getSessionClassification(),
       referral_marketplace: getReferralMarketplaceStats(),
-      search_analytics: getSearchAnalytics(),
+      search_analytics: searchAnalytics,
+      api_hits_by_endpoint: getApiHitsByEndpoint(),
+      top_search_queries_7d: searchAnalytics.top_queries_7d,
     }));
   } else if (url.pathname === "/.well-known/glama.json") {
     res.writeHead(200, { "Content-Type": "application/json" });

--- a/src/stats.ts
+++ b/src/stats.ts
@@ -16,12 +16,9 @@ const toolCalls: Record<string, number> = {
   track_changes: 0,
 };
 
-const apiHits: Record<string, number> = {
-  "/api/offers": 0,
-  "/api/categories": 0,
-  "/api/stack": 0,
-  "/api/metrics": 0,
-};
+// Per-endpoint hit counts for the current deployment. Accumulates dynamically — any endpoint passed
+// to recordApiHit is counted. Cardinality is bounded by route definitions (~150 endpoints).
+const apiHits: Record<string, number> = {};
 
 let totalSessions = 0;
 let totalDisconnects = 0;
@@ -42,6 +39,7 @@ let cumulative = {
   referral_listing_by_source: { platform: 0, agent: 0, null: 0 } as Record<"platform" | "agent" | "null", number>,
   referral_vendor_lookups: 0,
   referral_vendor_counts: {} as Record<string, number>,
+  api_hits_by_endpoint: {} as Record<string, number>,
 };
 
 // Current-deployment referral marketplace counters
@@ -63,6 +61,16 @@ export function useRedis(): boolean {
   return !!(process.env.UPSTASH_REDIS_REST_URL && process.env.UPSTASH_REDIS_REST_TOKEN);
 }
 
+export interface SearchQueryEntry {
+  query: string;
+  category?: string;
+  results_count: number;
+  timestamp: string;
+}
+
+const SEARCH_QUERY_RING_MAX = 1000;
+const searchQueryLog: SearchQueryEntry[] = [];
+
 interface TelemetryData {
   cumulative_sessions: number;
   cumulative_tool_calls: number;
@@ -75,6 +83,8 @@ interface TelemetryData {
   cumulative_referral_listing_by_source?: Record<"platform" | "agent" | "null", number>;
   cumulative_referral_vendor_lookups?: number;
   cumulative_referral_vendor_counts?: Record<string, number>;
+  cumulative_api_hits_by_endpoint?: Record<string, number>;
+  cumulative_search_queries?: SearchQueryEntry[];
 }
 
 async function redisGet(): Promise<TelemetryData | null> {
@@ -216,6 +226,28 @@ function parseTelemetryData(data: Record<string, unknown>): void {
   };
   cumulative.referral_vendor_lookups = (data.cumulative_referral_vendor_lookups as number) ?? 0;
   cumulative.referral_vendor_counts = (data.cumulative_referral_vendor_counts as Record<string, number>) ?? {};
+  cumulative.api_hits_by_endpoint = (data.cumulative_api_hits_by_endpoint as Record<string, number>) ?? {};
+
+  // Hydrate the search-query ring buffer from persisted entries. Skip malformed records
+  // rather than rejecting the whole load — telemetry.json may have been hand-edited.
+  searchQueryLog.length = 0;
+  const persistedQueries = (data.cumulative_search_queries as unknown[]) ?? [];
+  if (Array.isArray(persistedQueries)) {
+    for (const entry of persistedQueries) {
+      if (
+        entry &&
+        typeof entry === "object" &&
+        typeof (entry as SearchQueryEntry).query === "string" &&
+        typeof (entry as SearchQueryEntry).results_count === "number" &&
+        typeof (entry as SearchQueryEntry).timestamp === "string"
+      ) {
+        searchQueryLog.push(entry as SearchQueryEntry);
+      }
+    }
+    if (searchQueryLog.length > SEARCH_QUERY_RING_MAX) {
+      searchQueryLog.splice(0, searchQueryLog.length - SEARCH_QUERY_RING_MAX);
+    }
+  }
 }
 
 // In-memory client counts for this deployment
@@ -234,6 +266,11 @@ function buildTelemetryData(): TelemetryData {
   for (const [vendor, count] of Object.entries(referralVendorCounts)) {
     mergedVendorCounts[vendor] = (mergedVendorCounts[vendor] ?? 0) + count;
   }
+  // Merge per-endpoint api hits (cumulative + current deployment)
+  const mergedApiHitsByEndpoint: Record<string, number> = { ...cumulative.api_hits_by_endpoint };
+  for (const [endpoint, count] of Object.entries(apiHits)) {
+    mergedApiHitsByEndpoint[endpoint] = (mergedApiHitsByEndpoint[endpoint] ?? 0) + count;
+  }
   return {
     cumulative_sessions: cumulative.sessions + totalSessions,
     cumulative_tool_calls: cumulative.tool_calls + totalToolCalls,
@@ -250,6 +287,8 @@ function buildTelemetryData(): TelemetryData {
     },
     cumulative_referral_vendor_lookups: cumulative.referral_vendor_lookups + referralVendorLookups,
     cumulative_referral_vendor_counts: mergedVendorCounts,
+    cumulative_api_hits_by_endpoint: mergedApiHitsByEndpoint,
+    cumulative_search_queries: searchQueryLog.slice(-SEARCH_QUERY_RING_MAX),
   };
 }
 
@@ -301,7 +340,7 @@ export function resetCounters(): void {
   landingPageViews = 0;
   sessionsToday = 0;
   for (const key of Object.keys(toolCalls)) toolCalls[key] = 0;
-  for (const key of Object.keys(apiHits)) apiHits[key] = 0;
+  for (const key of Object.keys(apiHits)) delete apiHits[key];
   for (const key of Object.keys(sessionClients)) delete sessionClients[key];
   cumulative.sessions = 0;
   cumulative.tool_calls = 0;
@@ -320,6 +359,7 @@ export function resetCounters(): void {
   cumulative.referral_listing_by_source = { platform: 0, agent: 0, null: 0 };
   cumulative.referral_vendor_lookups = 0;
   cumulative.referral_vendor_counts = {};
+  cumulative.api_hits_by_endpoint = {};
   searchQueryLog.length = 0;
 }
 
@@ -330,9 +370,8 @@ export function recordToolCall(tool: string): void {
 }
 
 export function recordApiHit(endpoint: string): void {
-  if (endpoint in apiHits) {
-    apiHits[endpoint]++;
-  }
+  if (!endpoint) return;
+  apiHits[endpoint] = (apiHits[endpoint] ?? 0) + 1;
 }
 
 export function recordSessionConnect(clientName?: string): void {
@@ -723,27 +762,24 @@ export function getPageViewsToday(): number {
   return pageViewsToday;
 }
 
-// --- Search query analytics (in-memory, resets on deploy) ---
-
-interface SearchQueryEntry {
-  query: string;
-  ts: number;
-  resultCount: number;
-  category?: string;
-}
-
-const searchQueryLog: SearchQueryEntry[] = [];
+// --- Search query analytics ---
+// Persisted as a ring buffer (last SEARCH_QUERY_RING_MAX entries) on telemetry.json,
+// so /api/metrics analytics survive deploys.
 
 export function recordSearchQuery(query: string | undefined, resultCount: number, category?: string): void {
   if (!query) return;
   const normalized = query.trim().toLowerCase();
   if (!normalized) return;
-  searchQueryLog.push({
+  const entry: SearchQueryEntry = {
     query: normalized,
-    ts: Date.now(),
-    resultCount,
-    category,
-  });
+    timestamp: new Date().toISOString(),
+    results_count: resultCount,
+  };
+  if (category) entry.category = category;
+  searchQueryLog.push(entry);
+  if (searchQueryLog.length > SEARCH_QUERY_RING_MAX) {
+    searchQueryLog.splice(0, searchQueryLog.length - SEARCH_QUERY_RING_MAX);
+  }
 }
 
 export function getSearchAnalytics(): {
@@ -752,7 +788,10 @@ export function getSearchAnalytics(): {
   queries_by_category_7d: Record<string, number>;
 } {
   const sevenDaysAgo = Date.now() - 7 * 24 * 60 * 60 * 1000;
-  const recent = searchQueryLog.filter(e => e.ts >= sevenDaysAgo);
+  const recent = searchQueryLog.filter(e => {
+    const t = new Date(e.timestamp).getTime();
+    return Number.isFinite(t) && t >= sevenDaysAgo;
+  });
 
   // Top 20 queries by frequency
   const queryCounts = new Map<string, number>();
@@ -767,7 +806,7 @@ export function getSearchAnalytics(): {
   // Top 10 zero-result queries
   const zeroResultCounts = new Map<string, number>();
   for (const e of recent) {
-    if (e.resultCount === 0) {
+    if (e.results_count === 0) {
       zeroResultCounts.set(e.query, (zeroResultCounts.get(e.query) ?? 0) + 1);
     }
   }
@@ -789,4 +828,14 @@ export function getSearchAnalytics(): {
     zero_result_queries_7d: zeroResultQueries,
     queries_by_category_7d: categoryCounts,
   };
+}
+
+// Cumulative per-endpoint API hits (deploy-surviving). Merges persisted counts with
+// the current deployment's in-memory counters.
+export function getApiHitsByEndpoint(): Record<string, number> {
+  const merged: Record<string, number> = { ...cumulative.api_hits_by_endpoint };
+  for (const [endpoint, count] of Object.entries(apiHits)) {
+    merged[endpoint] = (merged[endpoint] ?? 0) + count;
+  }
+  return merged;
 }

--- a/test/api-analytics-persistence.test.ts
+++ b/test/api-analytics-persistence.test.ts
@@ -1,0 +1,245 @@
+import { describe, it, beforeEach } from "node:test";
+import assert from "node:assert";
+import { writeFileSync, readFileSync, mkdirSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { randomUUID } from "node:crypto";
+
+const {
+  loadTelemetry,
+  flushTelemetry,
+  recordApiHit,
+  recordSearchQuery,
+  getApiHitsByEndpoint,
+  getSearchAnalytics,
+  resetCounters,
+} = await import("../src/stats.ts");
+
+describe("per-endpoint API analytics persistence (#965)", () => {
+  beforeEach(() => {
+    resetCounters();
+  });
+
+  it("persists cumulative_api_hits_by_endpoint across simulated restart", async () => {
+    const tmpDir = join(tmpdir(), `api-hits-${randomUUID()}`);
+    const telemetryFile = join(tmpDir, "telemetry.json");
+    mkdirSync(tmpDir, { recursive: true });
+
+    // Seed file with prior cumulative hits
+    const seed = {
+      cumulative_sessions: 0,
+      cumulative_tool_calls: 0,
+      cumulative_api_hits: 50,
+      cumulative_landing_views: 0,
+      first_session_at: "",
+      last_deploy_at: "",
+      cumulative_api_hits_by_endpoint: {
+        "/api/offers": 30,
+        "/api/changes": 20,
+      },
+    };
+    writeFileSync(telemetryFile, JSON.stringify(seed));
+
+    await loadTelemetry(telemetryFile);
+
+    // Before any activity, cumulative breakdown reflects seed
+    const before = getApiHitsByEndpoint();
+    assert.strictEqual(before["/api/offers"], 30);
+    assert.strictEqual(before["/api/changes"], 20);
+
+    // Simulate this-deploy traffic
+    recordApiHit("/api/offers");
+    recordApiHit("/api/offers");
+    recordApiHit("/api/categories");
+
+    const after = getApiHitsByEndpoint();
+    assert.strictEqual(after["/api/offers"], 32, "merges seed (30) + current (2)");
+    assert.strictEqual(after["/api/changes"], 20, "preserves seed-only endpoints");
+    assert.strictEqual(after["/api/categories"], 1, "adds new endpoints not in seed");
+
+    await flushTelemetry();
+
+    const persisted = JSON.parse(readFileSync(telemetryFile, "utf-8"));
+    assert.strictEqual(persisted.cumulative_api_hits_by_endpoint["/api/offers"], 32);
+    assert.strictEqual(persisted.cumulative_api_hits_by_endpoint["/api/changes"], 20);
+    assert.strictEqual(persisted.cumulative_api_hits_by_endpoint["/api/categories"], 1);
+
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("loads cleanly when telemetry file lacks cumulative_api_hits_by_endpoint (backward compat)", async () => {
+    const tmpDir = join(tmpdir(), `api-hits-back-${randomUUID()}`);
+    const telemetryFile = join(tmpDir, "telemetry.json");
+    mkdirSync(tmpDir, { recursive: true });
+
+    // Pre-#965 telemetry shape (no api_hits_by_endpoint, no search_queries)
+    const oldShape = {
+      cumulative_sessions: 100,
+      cumulative_tool_calls: 50,
+      cumulative_api_hits: 200,
+      cumulative_landing_views: 25,
+      first_session_at: "2026-03-01T00:00:00.000Z",
+      last_deploy_at: "2026-03-01T00:00:00.000Z",
+    };
+    writeFileSync(telemetryFile, JSON.stringify(oldShape));
+
+    await loadTelemetry(telemetryFile);
+
+    // No throws, breakdown starts empty
+    const breakdown = getApiHitsByEndpoint();
+    assert.deepStrictEqual(breakdown, {});
+
+    // Recording works after backward-compat load
+    recordApiHit("/api/offers");
+    const breakdown2 = getApiHitsByEndpoint();
+    assert.strictEqual(breakdown2["/api/offers"], 1);
+
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+});
+
+describe("search query ring buffer persistence (#965)", () => {
+  beforeEach(() => {
+    resetCounters();
+  });
+
+  it("persists cumulative_search_queries across simulated restart", async () => {
+    const tmpDir = join(tmpdir(), `search-ring-${randomUUID()}`);
+    const telemetryFile = join(tmpDir, "telemetry.json");
+    mkdirSync(tmpDir, { recursive: true });
+
+    // Seed file with prior queries (recent timestamps so they fall within 7d window)
+    const recentISO = new Date(Date.now() - 60_000).toISOString();
+    const seed = {
+      cumulative_sessions: 0,
+      cumulative_tool_calls: 0,
+      cumulative_api_hits: 0,
+      cumulative_landing_views: 0,
+      first_session_at: "",
+      last_deploy_at: "",
+      cumulative_search_queries: [
+        { query: "redis", timestamp: recentISO, results_count: 5, category: "databases" },
+        { query: "redis", timestamp: recentISO, results_count: 5, category: "databases" },
+        { query: "missing-thing", timestamp: recentISO, results_count: 0 },
+      ],
+    };
+    writeFileSync(telemetryFile, JSON.stringify(seed));
+
+    await loadTelemetry(telemetryFile);
+
+    // Hydrated entries appear in analytics immediately (no need to re-record)
+    const analytics = getSearchAnalytics();
+    const redisEntry = analytics.top_queries_7d.find((q) => q.query === "redis");
+    assert.ok(redisEntry, "redis should appear in top queries");
+    assert.strictEqual(redisEntry!.count, 2);
+    assert.strictEqual(analytics.zero_result_queries_7d.length, 1);
+    assert.strictEqual(analytics.zero_result_queries_7d[0].query, "missing-thing");
+    assert.strictEqual(analytics.queries_by_category_7d["databases"], 2);
+
+    // Add a new query this deploy, flush, and verify it joined the persisted ring
+    recordSearchQuery("postgres", 8, "databases");
+    await flushTelemetry();
+
+    const persisted = JSON.parse(readFileSync(telemetryFile, "utf-8"));
+    assert.ok(Array.isArray(persisted.cumulative_search_queries));
+    assert.strictEqual(persisted.cumulative_search_queries.length, 4);
+    const lastEntry = persisted.cumulative_search_queries[3];
+    assert.strictEqual(lastEntry.query, "postgres");
+    assert.strictEqual(lastEntry.results_count, 8);
+    assert.strictEqual(lastEntry.category, "databases");
+    assert.ok(typeof lastEntry.timestamp === "string");
+    assert.ok(!Number.isNaN(new Date(lastEntry.timestamp).getTime()));
+
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("caps the ring buffer at 1000 entries and evicts oldest", async () => {
+    // Push 1100 entries, expect last 1000 to remain
+    for (let i = 0; i < 1100; i++) {
+      recordSearchQuery(`q${i}`, 1);
+    }
+
+    const tmpDir = join(tmpdir(), `search-ring-cap-${randomUUID()}`);
+    const telemetryFile = join(tmpDir, "telemetry.json");
+    mkdirSync(tmpDir, { recursive: true });
+
+    await loadTelemetry(telemetryFile);
+    // loadTelemetry without a prior file resets buffer; re-push to test cap
+    for (let i = 0; i < 1100; i++) {
+      recordSearchQuery(`q${i}`, 1);
+    }
+    await flushTelemetry();
+
+    const persisted = JSON.parse(readFileSync(telemetryFile, "utf-8"));
+    assert.strictEqual(persisted.cumulative_search_queries.length, 1000);
+    // Oldest 100 evicted — first persisted should be q100
+    assert.strictEqual(persisted.cumulative_search_queries[0].query, "q100");
+    assert.strictEqual(persisted.cumulative_search_queries[999].query, "q1099");
+
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("ignores malformed persisted entries on load (defensive)", async () => {
+    const tmpDir = join(tmpdir(), `search-ring-malformed-${randomUUID()}`);
+    const telemetryFile = join(tmpDir, "telemetry.json");
+    mkdirSync(tmpDir, { recursive: true });
+
+    const recentISO = new Date(Date.now() - 60_000).toISOString();
+    const seed = {
+      cumulative_sessions: 0,
+      cumulative_tool_calls: 0,
+      cumulative_api_hits: 0,
+      cumulative_landing_views: 0,
+      first_session_at: "",
+      last_deploy_at: "",
+      cumulative_search_queries: [
+        { query: "valid", timestamp: recentISO, results_count: 1 },
+        { query: "missing-timestamp", results_count: 1 },
+        { timestamp: recentISO, results_count: 1 },
+        null,
+        "garbage",
+        { query: "valid2", timestamp: recentISO, results_count: 0 },
+      ],
+    };
+    writeFileSync(telemetryFile, JSON.stringify(seed));
+
+    await loadTelemetry(telemetryFile);
+
+    const analytics = getSearchAnalytics();
+    const queries = new Set(analytics.top_queries_7d.map((q) => q.query));
+    assert.ok(queries.has("valid"));
+    assert.ok(queries.has("valid2"));
+    assert.ok(!queries.has("missing-timestamp"));
+
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("backward compat: telemetry.json without cumulative_search_queries loads cleanly", async () => {
+    const tmpDir = join(tmpdir(), `search-ring-back-${randomUUID()}`);
+    const telemetryFile = join(tmpDir, "telemetry.json");
+    mkdirSync(tmpDir, { recursive: true });
+
+    const oldShape = {
+      cumulative_sessions: 1,
+      cumulative_tool_calls: 1,
+      cumulative_api_hits: 1,
+      cumulative_landing_views: 1,
+      first_session_at: "2026-03-01T00:00:00.000Z",
+      last_deploy_at: "2026-03-01T00:00:00.000Z",
+    };
+    writeFileSync(telemetryFile, JSON.stringify(oldShape));
+
+    await loadTelemetry(telemetryFile);
+
+    const analytics = getSearchAnalytics();
+    assert.deepStrictEqual(analytics.top_queries_7d, []);
+
+    // After load, recording new queries works
+    recordSearchQuery("vercel", 3, "hosting");
+    const analytics2 = getSearchAnalytics();
+    assert.strictEqual(analytics2.top_queries_7d.length, 1);
+    assert.strictEqual(analytics2.top_queries_7d[0].query, "vercel");
+
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+});

--- a/test/http.test.ts
+++ b/test/http.test.ts
@@ -545,8 +545,8 @@ describe("HTTP transport", () => {
     // Record initial stats
     const h0 = await fetch(`http://localhost:${serverPort}/health`);
     const s0 = (await h0.json() as any).stats;
-    const initialApiOffers = s0.api_hits["/api/offers"];
-    const initialApiCats = s0.api_hits["/api/categories"];
+    const initialApiOffers = s0.api_hits["/api/offers"] ?? 0;
+    const initialApiCats = s0.api_hits["/api/categories"] ?? 0;
     const initialPageViews = s0.landing_page_views;
 
     // Hit /api/offers twice

--- a/test/stats.test.ts
+++ b/test/stats.test.ts
@@ -39,18 +39,20 @@ describe("stats", () => {
   });
 
   describe("recordApiHit", () => {
-    it("increments known API endpoint counters", () => {
+    it("increments per-endpoint counters dynamically", () => {
       recordApiHit("/api/offers");
       recordApiHit("/api/offers");
       recordApiHit("/api/categories");
+      recordApiHit("/api/changes");
       const stats = getStats();
       assert.strictEqual(stats.api_hits["/api/offers"], 2);
       assert.strictEqual(stats.api_hits["/api/categories"], 1);
-      assert.strictEqual(stats.total_api_hits, 3);
+      assert.strictEqual(stats.api_hits["/api/changes"], 1);
+      assert.strictEqual(stats.total_api_hits, 4);
     });
 
-    it("ignores unknown endpoints", () => {
-      recordApiHit("/api/unknown");
+    it("ignores empty endpoint strings", () => {
+      recordApiHit("");
       const stats = getStats();
       assert.strictEqual(stats.total_api_hits, 0);
     });


### PR DESCRIPTION
Refs #965

## Summary

Persists per-endpoint API hit counts and a 1,000-entry search-query ring buffer to `data/telemetry.json` so `/api/metrics` analytics survive deploys. Also fixes a latent bug where `recordApiHit` was silently no-op'ing for 100+ endpoints.

## Changes

**`src/stats.ts`**
- `apiHits` switches from a 4-endpoint hardcoded record to a dynamic `Record<string, number>`. `recordApiHit(endpoint)` now accumulates any endpoint string. Cardinality bounded by route definitions (~150 endpoints).
- New cumulative state: `cumulative.api_hits_by_endpoint`. Merged into telemetry write via `buildTelemetryData`. Loaded via `parseTelemetryData` with `{}` default for backward compat.
- `SearchQueryEntry` shape changed to AC-compliant `{query, category?, results_count, timestamp}` (ISO string). The buffer is now persisted (`cumulative_search_queries` on telemetry.json), capped at `SEARCH_QUERY_RING_MAX = 1000`, oldest evicted on overflow.
- New exported helper: `getApiHitsByEndpoint()` — merges seed + current deploy.
- Defensive load: malformed search-query entries are skipped (telemetry.json may be hand-edited) rather than rejecting the whole hydrate.
- `resetCounters` clears the new state.

**`src/serve.ts`**
- `/api/metrics` response gains two top-level fields:
  - `api_hits_by_endpoint` — cumulative breakdown across deploys
  - `top_search_queries_7d` — convenience field, same shape as `search_analytics.top_queries_7d`, exposed at the top level per the AC.
- Existing `api_hits` (per-deploy) and `search_analytics` (full breakdown) shapes preserved.

**Tests**
- `test/api-analytics-persistence.test.ts` (new, 6 cases): persistence round-trip, backward-compat load, ring-buffer cap + eviction, malformed-entry skip.
- `test/stats.test.ts`: `recordApiHit` now-known-as-dynamic test (was "ignores unknown endpoints", which is no longer the contract).
- `test/http.test.ts`: `initialApiOffers` defaults to `0` since dynamic counters start undefined.

## Acceptance Criteria

| AC | Status |
|---|---|
| 1. `cumulative_api_hits_by_endpoint` on telemetry.json | done — line in `buildTelemetryData` |
| 2. `cumulative_search_queries` ring buffer (1,000 entries, oldest evicted) | done — `recordSearchQuery` cap + eviction; persisted via `flushTelemetry` |
| 3. Persist on existing schedule | done — uses existing `flushTelemetry` (5-min interval + on SIGTERM/SIGINT) |
| 4. Expose `api_hits_by_endpoint` + `top_search_queries_7d` in `/api/metrics` | done |
| 5. Backward compatible | done — both fields default to empty when absent; tested explicitly |

## End-to-end verification

1. Backed up `data/telemetry.json` to `/tmp/telemetry-backup-pre.json`.
2. Started server on port 9934, hit `/api/offers?q=mongodb&limit=1`, `/api/changes`, `/api/categories`, plus a couple `/api/metrics` self-hits.
3. `/api/metrics` returned the new fields:
   ```json
   "api_hits_by_endpoint": {"/api/offers": 3, "/api/categories": 2, "/api/changes": 3, "/api/metrics": 2},
   "top_search_queries_7d": [{"query": "mongodb", "count": 1}, ...]
   ```
4. Sent SIGTERM → server flushed and exited cleanly in 2s.
5. `data/telemetry.json` showed the new fields persisted with the expected counts and search entries:
   ```json
   "cumulative_api_hits_by_endpoint": {"/api/offers": 3, "/api/categories": 2, "/api/changes": 3, "/api/metrics": 2},
   "cumulative_search_queries": [..., {"query":"mongodb","timestamp":"2026-04-21T15:13:34.482Z","results_count":19}]
   ```
6. Restored backup. Repo is clean.

## Test plan
- [x] `node --test --test-concurrency=1` — **1,064 tests passing** (1,058 + 6 new)
- [x] `npm run build` — clean tsc
- [x] End-to-end: real HTTP server, exercise endpoints, SIGTERM → inspect persisted file
- [x] Backward compat: explicit unit test loads pre-#965 telemetry shape and verifies clean init