### PR TITLE
Add risk_level and stability indicators to MCP tool responses (Refs #969)

### DIFF
--- a/src/data.ts
+++ b/src/data.ts
@@ -555,7 +555,7 @@ const NEGATIVE_CHANGE_TYPES = new Set([
 
 const RISKY_CHANGE_TYPES = new Set(["free_tier_removed", "open_source_killed"]);
 
-function vendorRiskLevel(vendorChanges: DealChange[]): "stable" | "caution" | "risky" {
+export function vendorRiskLevel(vendorChanges: DealChange[]): "stable" | "caution" | "risky" {
   const twelveMonthsAgo = new Date(Date.now() - 365 * 24 * 60 * 60 * 1000)
     .toISOString()
     .slice(0, 10);

--- a/src/server.ts
+++ b/src/server.ts
@@ -22,7 +22,12 @@ const __dirname_server = dirname(fileURLToPath(import.meta.url));
 const PKG_VERSION = JSON.parse(readFileSync(join(__dirname_server, "..", "package.json"), "utf-8")).version;
 
 function toConciseOffer(offer: Offer | EnrichedOffer) {
-  return { vendor: offer.vendor, tier: offer.tier, description: offer.description, url: offer.url, ...(offer.payment_protocols?.length ? { payment_protocols: offer.payment_protocols.map(p => p.protocol) } : {}) };
+  const base = { vendor: offer.vendor, tier: offer.tier, description: offer.description, url: offer.url, ...(offer.payment_protocols?.length ? { payment_protocols: offer.payment_protocols.map(p => p.protocol) } : {}) };
+  const enriched = offer as Partial<EnrichedOffer>;
+  if (enriched.risk_level !== undefined) {
+    return { ...base, risk_level: enriched.risk_level, stability: enriched.stability };
+  }
+  return base;
 }
 
 function toConciseDealChange(change: DealChange) {
@@ -308,13 +313,19 @@ export function createServer(getSessionId?: () => string | undefined): McpServer
 
           let result: any = comparison.comparison;
 
-          // Add stability indicators
+          // Add stability + risk_level indicators (always included, regardless of include_risk detail toggle)
           const stabMap = getStabilityMap();
+          const riskA = checkVendorRisk(vendors[0]);
+          const riskB = checkVendorRisk(vendors[1]);
           result = {
             ...result,
             stability: {
               [vendors[0]]: stabMap.get(comparison.comparison.vendor_a.vendor.toLowerCase()) ?? "stable",
               [vendors[1]]: stabMap.get(comparison.comparison.vendor_b.vendor.toLowerCase()) ?? "stable",
+            },
+            risk_level: {
+              [vendors[0]]: "result" in riskA ? riskA.result.risk_level : "stable",
+              [vendors[1]]: "result" in riskB ? riskB.result.risk_level : "stable",
             },
             referral_codes: {
               [vendors[0]]: getBestReferralCode(comparison.comparison.vendor_a.vendor),
@@ -323,8 +334,6 @@ export function createServer(getSessionId?: () => string | undefined): McpServer
           };
 
           if (doRisk) {
-            const riskA = checkVendorRisk(vendors[0]);
-            const riskB = checkVendorRisk(vendors[1]);
             result = {
               ...result,
               risk: {

--- a/src/stacks.ts
+++ b/src/stacks.ts
@@ -1,5 +1,5 @@
-import { searchOffers } from "./data.js";
-import type { Offer } from "./types.js";
+import { searchOffers, loadDealChanges, vendorRiskLevel, classifyStability } from "./data.js";
+import type { Offer, StabilityClass, DealChange } from "./types.js";
 
 export interface StackComponent {
   role: string;
@@ -7,6 +7,8 @@ export interface StackComponent {
   tier: string;
   description: string;
   url: string;
+  risk_level: "stable" | "caution" | "risky";
+  stability: StabilityClass;
 }
 
 export interface StackRecommendation {
@@ -15,6 +17,7 @@ export interface StackRecommendation {
   total_monthly_cost: string;
   limitations: string[];
   upgrade_path: string;
+  risk_warnings: string[];
 }
 
 interface StackTemplate {
@@ -218,21 +221,34 @@ export function getStackRecommendation(
     }
   }
 
+  const allChanges = loadDealChanges();
+  const changesByVendor = new Map<string, DealChange[]>();
+  for (const c of allChanges) {
+    const key = c.vendor.toLowerCase();
+    const list = changesByVendor.get(key) ?? [];
+    list.push(c);
+    changesByVendor.set(key, list);
+  }
+
   const stack: StackComponent[] = [];
   for (const { role, category, preferredVendors } of roles) {
     const offer = findBestOffer(category, preferredVendors);
     if (offer) {
+      const vendorChanges = changesByVendor.get(offer.vendor.toLowerCase()) ?? [];
       stack.push({
         role,
         vendor: offer.vendor,
         tier: offer.tier,
         description: offer.description.length > 200 ? offer.description.slice(0, 197) + "..." : offer.description,
         url: offer.url,
+        risk_level: vendorRiskLevel(vendorChanges),
+        stability: classifyStability(vendorChanges),
       });
     }
   }
 
   const limitations = buildLimitations(stack);
+  const risk_warnings = buildRiskWarnings(stack);
 
   return {
     use_case: useCase,
@@ -240,5 +256,20 @@ export function getStackRecommendation(
     total_monthly_cost: "$0",
     limitations,
     upgrade_path: upgradePath,
+    risk_warnings,
   };
+}
+
+function buildRiskWarnings(stack: StackComponent[]): string[] {
+  const warnings: string[] = [];
+  for (const c of stack) {
+    if (c.risk_level === "risky") {
+      warnings.push(`${c.vendor} (${c.role}): high risk — free tier removal or open-source license change in the last 12 months. Consider alternatives.`);
+    } else if (c.stability === "volatile") {
+      warnings.push(`${c.vendor} (${c.role}): volatile — free tier removed or multiple negative pricing changes recorded.`);
+    } else if (c.risk_level === "caution" || c.stability === "watch") {
+      warnings.push(`${c.vendor} (${c.role}): monitor — has had limit reductions or pricing restructuring.`);
+    }
+  }
+  return warnings;
 }

--- a/test/mcp-risk-indicators.test.ts
+++ b/test/mcp-risk-indicators.test.ts
@@ -1,0 +1,144 @@
+import { describe, it, afterEach } from "node:test";
+import assert from "node:assert";
+import { spawn, type ChildProcess } from "node:child_process";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+describe("MCP risk_level/stability indicators (issue #969)", () => {
+  let serverPort = 0;
+  let proc: ChildProcess | null = null;
+
+  function startHttpServer(): Promise<ChildProcess> {
+    return new Promise((resolve, reject) => {
+      const serverPath = path.join(__dirname, "..", "dist", "serve.js");
+      const p = spawn("node", [serverPath], {
+        stdio: ["pipe", "pipe", "pipe"],
+        env: { ...process.env, PORT: "0" },
+      });
+      const timeout = setTimeout(() => { p.kill(); reject(new Error("Server startup timeout")); }, 10000);
+      p.stderr!.on("data", (data: Buffer) => {
+        const match = data.toString().match(/running on http:\/\/localhost:(\d+)/);
+        if (match) { serverPort = parseInt(match[1], 10); clearTimeout(timeout); resolve(p); }
+      });
+      p.on("error", (err) => { clearTimeout(timeout); reject(err); });
+    });
+  }
+
+  function parseSSE(text: string): any[] {
+    const results: any[] = [];
+    for (const line of text.split("\n")) {
+      if (line.startsWith("data: ")) {
+        try { results.push(JSON.parse(line.slice(6))); } catch {}
+      }
+    }
+    return results;
+  }
+
+  async function mcpCall(sessionId: string | null, msg: object): Promise<{ responses: any[]; sessionId: string | null }> {
+    const headers: Record<string, string> = { "Content-Type": "application/json", "Accept": "application/json, text/event-stream" };
+    if (sessionId) headers["mcp-session-id"] = sessionId;
+    const res = await fetch(`http://localhost:${serverPort}/mcp`, { method: "POST", headers, body: JSON.stringify(msg) });
+    const text = await res.text();
+    const newSessionId = res.headers.get("mcp-session-id") || sessionId;
+    return { responses: parseSSE(text), sessionId: newSessionId };
+  }
+
+  async function initSession(): Promise<string> {
+    const { sessionId } = await mcpCall(null, {
+      jsonrpc: "2.0", id: 1, method: "initialize",
+      params: { protocolVersion: "2025-03-26", capabilities: {}, clientInfo: { name: "test", version: "1.0" } },
+    });
+    await mcpCall(sessionId, { jsonrpc: "2.0", method: "notifications/initialized" });
+    return sessionId!;
+  }
+
+  async function callTool(sessionId: string, id: number, name: string, args: Record<string, unknown>): Promise<any> {
+    const { responses } = await mcpCall(sessionId, {
+      jsonrpc: "2.0", id, method: "tools/call",
+      params: { name, arguments: args },
+    });
+    return responses.find(r => r.id === id)?.result;
+  }
+
+  afterEach(() => { if (proc) { proc.kill(); proc = null; } });
+
+  it("search_deals concise mode includes risk_level and stability", async () => {
+    proc = await startHttpServer();
+    const sessionId = await initSession();
+    const result = await callTool(sessionId, 2, "search_deals", {
+      category: "Databases", limit: 3, response_format: "concise",
+    });
+    const body = JSON.parse(result.content[0].text);
+    assert.ok(Array.isArray(body.results) && body.results.length > 0, "should return results");
+    for (const r of body.results) {
+      assert.ok(
+        ["stable", "caution", "risky"].includes(r.risk_level),
+        `concise result for ${r.vendor} should have risk_level, got ${r.risk_level}`
+      );
+      assert.ok(
+        ["stable", "watch", "volatile", "improving"].includes(r.stability),
+        `concise result for ${r.vendor} should have stability, got ${r.stability}`
+      );
+      // Concise mode should still be concise: no full description-free kitchen-sink (no deal_changes array)
+      assert.strictEqual(r.deal_changes, undefined, "concise should not include deal_changes");
+    }
+  });
+
+  it("search_deals detailed mode still includes risk_level and stability (no regression)", async () => {
+    proc = await startHttpServer();
+    const sessionId = await initSession();
+    const result = await callTool(sessionId, 2, "search_deals", {
+      category: "Databases", limit: 3,
+    });
+    const body = JSON.parse(result.content[0].text);
+    assert.ok(Array.isArray(body.results) && body.results.length > 0);
+    for (const r of body.results) {
+      assert.ok(["stable", "caution", "risky"].includes(r.risk_level));
+      assert.ok(["stable", "watch", "volatile", "improving"].includes(r.stability));
+    }
+  });
+
+  it("compare_vendors (two vendors) surfaces risk_level and stability at top level", async () => {
+    proc = await startHttpServer();
+    const sessionId = await initSession();
+    const result = await callTool(sessionId, 2, "compare_vendors", {
+      vendors: ["Supabase", "Neon"],
+    });
+    const body = JSON.parse(result.content[0].text);
+    assert.ok(body.stability, "should have stability object");
+    assert.ok(body.risk_level, "should have risk_level object");
+    assert.ok(
+      ["stable", "caution", "risky"].includes(body.risk_level["Supabase"]),
+      `risk_level.Supabase should be valid, got ${body.risk_level["Supabase"]}`
+    );
+    assert.ok(
+      ["stable", "caution", "risky"].includes(body.risk_level["Neon"]),
+      `risk_level.Neon should be valid, got ${body.risk_level["Neon"]}`
+    );
+    assert.ok(["stable", "watch", "volatile", "improving"].includes(body.stability["Supabase"]));
+    assert.ok(["stable", "watch", "volatile", "improving"].includes(body.stability["Neon"]));
+  });
+
+  it("plan_stack recommend mode returns risk_level/stability per component and risk_warnings", async () => {
+    proc = await startHttpServer();
+    const sessionId = await initSession();
+    const result = await callTool(sessionId, 2, "plan_stack", {
+      mode: "recommend", use_case: "Next.js SaaS app",
+    });
+    const body = JSON.parse(result.content[0].text);
+    assert.ok(Array.isArray(body.stack) && body.stack.length > 0, "should return a stack");
+    for (const c of body.stack) {
+      assert.ok(
+        ["stable", "caution", "risky"].includes(c.risk_level),
+        `component ${c.vendor} should have risk_level, got ${c.risk_level}`
+      );
+      assert.ok(
+        ["stable", "watch", "volatile", "improving"].includes(c.stability),
+        `component ${c.vendor} should have stability, got ${c.stability}`
+      );
+    }
+    assert.ok(Array.isArray(body.risk_warnings), "should have risk_warnings array");
+  });
+});

--- a/test/stacks.test.ts
+++ b/test/stacks.test.ts
@@ -85,6 +85,49 @@ describe("stack recommendation logic", () => {
       assert.ok(component.description.length <= 200, `Description for ${component.vendor} exceeds 200 chars`);
     }
   });
+
+  it("stack components include risk_level and stability fields", async () => {
+    const { getStackRecommendation } = await import("../dist/stacks.js");
+    const result = getStackRecommendation("Next.js SaaS app");
+    assert.ok(result.stack.length > 0);
+    for (const component of result.stack) {
+      assert.ok(
+        ["stable", "caution", "risky"].includes(component.risk_level),
+        `${component.vendor} risk_level should be stable|caution|risky, got ${component.risk_level}`
+      );
+      assert.ok(
+        ["stable", "watch", "volatile", "improving"].includes(component.stability),
+        `${component.vendor} stability should be stable|watch|volatile|improving, got ${component.stability}`
+      );
+    }
+  });
+
+  it("stack includes risk_warnings array", async () => {
+    const { getStackRecommendation } = await import("../dist/stacks.js");
+    const result = getStackRecommendation("Next.js SaaS app");
+    assert.ok(Array.isArray(result.risk_warnings));
+    // Each warning should name the vendor and role
+    for (const w of result.risk_warnings) {
+      assert.ok(typeof w === "string");
+      assert.ok(w.length > 0);
+    }
+  });
+
+  it("risk_warnings surfaced when stack contains non-stable components", async () => {
+    const { getStackRecommendation } = await import("../dist/stacks.js");
+    const result = getStackRecommendation("Next.js SaaS app");
+    const hasRisky = result.stack.some(
+      (c: any) => c.risk_level !== "stable" || c.stability !== "stable"
+    );
+    if (hasRisky) {
+      assert.ok(
+        result.risk_warnings.length > 0,
+        "risk_warnings should not be empty when stack has non-stable components"
+      );
+    } else {
+      assert.strictEqual(result.risk_warnings.length, 0);
+    }
+  });
 });
 
 describe("stack REST endpoint", () => {


### PR DESCRIPTION
Refs #969

## Summary

Surfaces `risk_level` and `stability` indicators through the MCP tools where agents actually consume them, so an agent recommending infrastructure can see that a vendor is volatile (Copilot, Cursor) or risky (OpenAI free tier, X API) before suggesting it.

Scope was narrower than the issue initially implied — REST and MCP detailed mode already include these fields today via `enrichOffers` (confirmed in my corrected comment on #969). The real gaps were three spots where they were stripped or absent:

1. **`search_deals` concise mode** — `toConciseOffer` in `src/server.ts` previously stripped everything except vendor/tier/description/url. Now carries `risk_level` + `stability` through when the input is an `EnrichedOffer`.
2. **`compare_vendors` two-vendor mode** — already had a top-level `stability` object, but `risk_level` only appeared nested inside the `risk` sub-object (gated by `include_risk`). Added a top-level `risk_level` object mirroring `stability` shape, always included.
3. **`plan_stack` recommend mode** — each stack component now carries `risk_level` + `stability`, and the recommendation gains a top-level `risk_warnings: string[]` array that names vendor+role and describes the nature of the risk when non-stable.

## Implementation notes

- Exported `vendorRiskLevel()` from `src/data.ts` so `stacks.ts` can derive per-vendor risk without a full `checkVendorRisk()` round-trip (avoids reloading offers + re-running alternatives search for every stack component).
- Single-vendor `compare_vendors` path was already correct — enrichedResult there already included both `risk_level` (via `result.result.risk_level`) and `stability` (via `stabMap.get`).
- Detailed mode of `search_deals` was already correct (via `enrichOffers`). Added a regression test to lock that in.

## Testing

**1,071 tests passing** on clean `npm test` run (+7 new: 4 MCP tool-level + 3 plan_stack unit-level).

### New tests
- `test/mcp-risk-indicators.test.ts` (4 tests, real HTTP MCP transport):
  - `search_deals` concise mode includes both fields
  - `search_deals` detailed mode still includes both (no regression)
  - `compare_vendors` two-vendor mode surfaces both top-level
  - `plan_stack` recommend mode returns per-component risk + top-level `risk_warnings`
- `test/stacks.test.ts` (3 new tests): component shape, `risk_warnings` array presence, conditional presence when stack has non-stable components

### End-to-end verification
Real MCP server on port 9934, real initialize → tools/call over Streamable HTTP:

```
search_deals(category=AI Coding, response_format=concise, limit=2):
  Cursor: risk_level=risky, stability=volatile
  Devin: risk_level=stable, stability=stable

compare_vendors(vendors=[Cursor, GitHub Copilot]):
  stability: {Cursor: volatile, GitHub Copilot: volatile}
  risk_level: {Cursor: caution, GitHub Copilot: caution}

plan_stack(mode=recommend, use_case="AI chatbot"):
  OpenAI (AI/ML): risky/volatile — warning emitted
  Railway (Hosting): stable/improving — no warning
  Supabase (Database): caution/watch — warning emitted
```

## Test plan
- [x] Unit tests pass (1,071 / 1,071)
- [x] End-to-end MCP verified via real server (initialize + tools/call over Streamable HTTP)
- [x] Concise mode carries both fields
- [x] Detailed mode still carries both fields (no regression)
- [x] plan_stack surfaces warnings for risky/volatile vendors
- [x] compare_vendors surfaces both fields top-level