### PR TITLE
Data: Forms/DNS corrections (#971) + Hyperping update (#973)

### DIFF
--- a/data/deal_changes.json
+++ b/data/deal_changes.json
@@ -1,6 +1,18 @@
 {
   "changes": [
     {
+      "vendor": "Hyperping",
+      "change_type": "pricing_restructured",
+      "date": "2026-04-21",
+      "summary": "Hyperping free plan limits restructured: monitor cap raised from 5 to 20 (HTTP, port, ping, keyword), but the check interval slowed from 3 minutes to 5 minutes. Free plan now also includes 1 seat and 1 server monitoring agent. Trade-off: 4x more endpoints can be monitored, at the cost of slower check granularity.",
+      "previous_state": "Free plan: 5 monitors, 3-minute check interval, 1 status page",
+      "current_state": "Free plan: 20 monitors, 5-minute check interval, 1 basic status page, 1 seat, 1 server monitoring agent",
+      "impact": "medium",
+      "source_url": "https://hyperping.com/pricing",
+      "category": "Monitoring",
+      "alternatives": []
+    },
+    {
       "vendor": "Amazon SP-API",
       "change_type": "pricing_restructured",
       "date": "2025-11-03",

--- a/data/index.json
+++ b/data/index.json
@@ -1623,7 +1623,7 @@
     {
       "vendor": "Cloudflare DNS",
       "category": "DNS & Domain Management",
-      "description": "Free authoritative DNS hosting — unlimited zones and queries, 1,000 records/zone, DDoS protection, free SSL/TLS",
+      "description": "Free authoritative DNS hosting — unlimited zones and queries, DDoS protection, free SSL/TLS. Records-per-zone cap is 200 for zones created on or after 2024-09-01; zones created before that date retain the legacy 1,000-record cap.",
       "tier": "Free",
       "url": "https://www.cloudflare.com/plans/free/",
       "tags": [
@@ -1633,7 +1633,7 @@
         "ssl",
         "free tier"
       ],
-      "verifiedDate": "2026-04-14",
+      "verifiedDate": "2026-04-21",
       "payment_protocols": [
         {
           "protocol": "x402",
@@ -6077,20 +6077,17 @@
     {
       "vendor": "Hyperping",
       "category": "Monitoring",
-      "description": "Uptime and status page monitoring — free plan: 5 monitors (HTTP/HTTPS, API, ping, SSL, cron), 3-minute check interval, 1 status page with real-time updates and subscriber notifications, email and webhook alerts",
+      "description": "Uptime and status page monitoring — free plan: 20 monitors (HTTP, port, ping, keyword), 5-minute check interval, 1 basic status page with real-time updates and subscriber notifications, 1 seat, 1 server monitoring agent, email and webhook alerts",
       "tier": "Free",
       "url": "https://hyperping.com/pricing",
       "tags": [
         "monitoring",
         "uptime",
         "status-page",
-        "api",
-        "cron",
-        "ssl",
         "freshping-alternative",
         "datadog-alternative"
       ],
-      "verifiedDate": "2026-04-12"
+      "verifiedDate": "2026-04-21"
     },
     {
       "vendor": "incident.io",
@@ -12433,14 +12430,14 @@
     {
       "vendor": "Survicate",
       "category": "Forms",
-      "description": "Pull feedback from all sources and send follow-up surveys with one tool. Automatically analyze feedback and extract insights with AI. Free email, website, in-product or mobile surveys, AI survey creator, and 25 monthly responses.",
+      "description": "Email, website, in-product, and mobile surveys with AI survey creator. Free plan: 25 responses/month, up to 1,000 stored responses across all active surveys (300/survey cap), up to 3 collaborators. After the initial 10-day trial, surveys created during trial are disabled. No data export and no premium integrations on Free.",
       "tier": "Free",
-      "url": "https://survicate.com/",
+      "url": "https://survicate.com/pricing/",
       "tags": [
         "forms",
         "free-for-dev"
       ],
-      "verifiedDate": "2026-04-13"
+      "verifiedDate": "2026-04-21"
     },
     {
       "vendor": "Typeform.com",
@@ -13828,7 +13825,7 @@
     {
       "vendor": "DigitalPlat",
       "category": "DNS & Domain Management",
-      "description": "Free subdomains under dpdns.org, us.kg, qzz.io, and xx.kg via nonprofit foundation",
+      "description": "Free subdomains via nonprofit foundation. dpdns.org is the primary service. The us.kg subdomain offering has been suspended due to abuse and is no longer accepting registrations. qzz.io and xx.kg may also be available.",
       "tier": "Free",
       "url": "https://domain.digitalplat.org",
       "tags": [
@@ -13836,7 +13833,7 @@
         "domain",
         "free-for-dev"
       ],
-      "verifiedDate": "2026-04-05"
+      "verifiedDate": "2026-04-21"
     },
     {
       "vendor": "isroot.in",
@@ -21024,12 +21021,12 @@
       "category": "DNS & Domain Management",
       "description": "Free secondary DNS: up to 10 zones and 300,000 queries/month with DNSCurve encryption. Commercial use allowed.",
       "tier": "Free",
-      "url": "https://www.buddyns.com/",
+      "url": "https://www.buddyns.com/services/",
       "tags": [
         "dns",
         "secondary-dns"
       ],
-      "verifiedDate": "2026-04-13"
+      "verifiedDate": "2026-04-21"
     },
     {
       "vendor": "Gcore DNS",

--- a/test/deal-changes.test.ts
+++ b/test/deal-changes.test.ts
@@ -76,7 +76,7 @@ describe("track_changes tool", () => {
 
     assert.ok(Array.isArray(body.changes));
     assert.strictEqual(body.total, body.changes.length);
-    assert.strictEqual(body.total, 284);
+    assert.strictEqual(body.total, 285);
   });
 
   it("filters by date (since)", async () => {


### PR DESCRIPTION
## Summary

Two related PM-filed data correction tickets bundled into one PR — both are pure data fixes in `data/index.json` + one new `data/deal_changes.json` entry.

Refs #971
Refs #973

## Forms (#971)

- **Survicate** — rewrote description with help-article-verified facts (25 responses/mo, 1,000-response storage cap with 300/survey, 3 collaborators, no export, post-trial survey disable). **Skipped two PM-supplied claims** that the cited source does not actually corroborate:
  - "1 active survey at a time" — not present in the help article. The pricing page only lists "Active Surveys: 2" for the **Starter (paid)** plan; the help article doesn't quantify active-survey count for Free.
  - "30-day data retention" — not present in the help article. The pricing page lists "6 Months" retention for Starter (paid). The free plan's retention is not separately documented.
  - The article does enumerate other constraints I did include — those went in.

## DNS & Domain Management (#971)

- **Cloudflare DNS** — `1,000 records/zone` → `200 records/zone` for zones created on or after `2024-09-01 00:00:00 UTC`. Older zones retain the legacy 1,000 cap. Verified at https://developers.cloudflare.com/dns/reference/all-features/ (PM-supplied source confirmed).
- **DigitalPlat** — flagged `us.kg` as suspended due to abuse (DNS does not resolve from this network — `ECONNREFUSED`). `dpdns.org` confirmed as primary (still up, 301-redirects to `domain.digitalplat.org`).
- **BuddyNS** — verified against https://www.buddyns.com/services/ — zone cap **unchanged** at 10 / 300K queries/mo. Only verifiedDate + URL refreshed (URL bumped from `/` to `/services/` since that's the canonical pricing path).

## Monitoring (#973)

- **Hyperping** — `5 monitors / 3-min interval / 1 status page` → `20 monitors / 5-min interval / 1 basic status page / 1 seat / 1 server monitoring agent`. Verified at https://hyperping.com/pricing.
- Tag list trimmed: removed `api`, `cron`, `ssl` — current pricing page only lists "HTTP, port, ping & keyword monitoring" for Free.
- Added `deal_change` (2026-04-21, `pricing_restructured`, impact: medium) documenting the trade-off: 4x more monitors at the cost of slower check granularity.

## Why bundle

Both tickets are PM-filed data corrections, both `priority/medium`, both pure JSON edits in `data/index.json`. Per the `loop` of one-data-correction-PR-per-cycle that's been running, bundling tight similar-scope data tickets keeps PR overhead proportional to substance and avoids pushing two near-empty PRs through CI back-to-back.

## Test plan

- [x] All 1,071 tests pass on `--test-concurrency=1` clean run
- [x] `data/deal-changes.test.ts` `body.total === 285` updated (was 284) to match the +1 Hyperping change after pre-2024 filter
- [x] JSON validity check on both files (1,585 offers unchanged; 287 deal_changes (+1))
- [x] Discrepancies between PM-supplied details and live sources flagged in the Survicate section above and called out on issue #971 itself