### PR TITLE
Add Proton referral code (4 products) + slug-aware vendor lookup (Refs #975)

### DIFF
--- a/data/platform_codes.json
+++ b/data/platform_codes.json
@@ -9,6 +9,46 @@
       "source": "platform",
       "active": true,
       "added_at": "2026-04-12"
+    },
+    {
+      "vendor": "Proton Mail",
+      "code": "60QXGJSB",
+      "referral_url": "https://pr.tn/ref/60QXGJSB",
+      "referrer_benefit": "$20 credit",
+      "referee_benefit": "$20 credit",
+      "source": "platform",
+      "active": true,
+      "added_at": "2026-04-21"
+    },
+    {
+      "vendor": "Proton VPN",
+      "code": "60QXGJSB",
+      "referral_url": "https://pr.tn/ref/60QXGJSB",
+      "referrer_benefit": "$20 credit",
+      "referee_benefit": "$20 credit",
+      "source": "platform",
+      "active": true,
+      "added_at": "2026-04-21"
+    },
+    {
+      "vendor": "Proton Pass",
+      "code": "60QXGJSB",
+      "referral_url": "https://pr.tn/ref/60QXGJSB",
+      "referrer_benefit": "$20 credit",
+      "referee_benefit": "$20 credit",
+      "source": "platform",
+      "active": true,
+      "added_at": "2026-04-21"
+    },
+    {
+      "vendor": "Proton Drive",
+      "code": "60QXGJSB",
+      "referral_url": "https://pr.tn/ref/60QXGJSB",
+      "referrer_benefit": "$20 credit",
+      "referee_benefit": "$20 credit",
+      "source": "platform",
+      "active": true,
+      "added_at": "2026-04-21"
     }
   ]
 }

--- a/src/platform-codes.ts
+++ b/src/platform-codes.ts
@@ -41,13 +41,18 @@ export function resetPlatformCodesCache(): void {
   cachedPlatformCodes = null;
 }
 
+function slugifyVendor(name: string): string {
+  return name.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-|-$/g, "");
+}
+
 /**
  * Get the active platform code for a vendor, if one exists.
+ * Accepts both canonical vendor names ("Proton Mail") and URL slugs ("proton-mail").
  */
 export function getPlatformCodeForVendor(vendorName: string): PlatformCode | null {
   const codes = loadPlatformCodes();
-  const lowerName = vendorName.toLowerCase();
-  return codes.find(c => c.vendor.toLowerCase() === lowerName && c.active) ?? null;
+  const querySlug = slugifyVendor(vendorName);
+  return codes.find(c => slugifyVendor(c.vendor) === querySlug && c.active) ?? null;
 }
 
 /**

--- a/test/platform-codes.test.ts
+++ b/test/platform-codes.test.ts
@@ -60,6 +60,27 @@ describe("Platform Codes", () => {
     assert.strictEqual(code.vendor, "Railway");
   });
 
+  it("matches by URL slug (e.g. 'proton-mail' → 'Proton Mail')", () => {
+    for (const slug of ["proton-mail", "proton-vpn", "proton-pass", "proton-drive"]) {
+      const code = getPlatformCodeForVendor(slug);
+      assert.ok(code, `slug ${slug} should resolve to a platform code`);
+      assert.strictEqual(code.code, "60QXGJSB");
+      assert.strictEqual(code.referral_url, "https://pr.tn/ref/60QXGJSB");
+      assert.strictEqual(code.referee_benefit, "$20 credit");
+      assert.strictEqual(code.source, "platform");
+    }
+  });
+
+  it("returns Proton platform code for all 4 product variants by canonical name", () => {
+    for (const vendor of ["Proton Mail", "Proton VPN", "Proton Pass", "Proton Drive"]) {
+      const code = getPlatformCodeForVendor(vendor);
+      assert.ok(code, `${vendor} should have a platform code`);
+      assert.strictEqual(code.vendor, vendor);
+      assert.strictEqual(code.code, "60QXGJSB");
+      assert.strictEqual(code.referral_url, "https://pr.tn/ref/60QXGJSB");
+    }
+  });
+
   it("only returns active codes", () => {
     const testData = {
       platform_codes: [


### PR DESCRIPTION
Refs #975

## Summary

- Adds 4 entries to `data/platform_codes.json` for Proton Mail, Proton VPN, Proton Pass, and Proton Drive — all sharing the referral link `https://pr.tn/ref/60QXGJSB` ($20 credit to both sides).
- Makes `getPlatformCodeForVendor()` match on URL slug equivalence so `/api/referral-codes/proton-mail` (and `proton-vpn`, `proton-pass`, `proton-drive`) resolve correctly. Previously the case-insensitive exact match only worked for single-word vendors (e.g. `railway` → `Railway`); multi-word vendors with hyphenated slugs were unreachable via the slug form. The change is purely additive (any case-insensitive exact match still passes) — no regression risk.
- Two new unit tests cover both lookup paths for all four Proton variants.

## Acceptance criteria

- [x] Proton referral code added (vendor: each of the 4 products; URL `https://pr.tn/ref/60QXGJSB`; referee `$20 credit`)
- [x] All 4 Proton vendor entries return the referral code via API (verified via `/api/details/Proton%20Mail` showing `referral_code` populated)
- [x] `/api/referral-codes/proton-mail` (and `-vpn`, `-pass`, `-drive`) all return 200 with the code
- [x] Tests pass — 1,073 (+2)

## Schema note

PM-supplied `source: direct` shipped as `source: platform`. The `PlatformCode` interface has `source` as the literal `"platform"`, and `BestReferralCode.source` is `"platform" | "agent-submitted"`. "Direct" appeared to be a colloquial label for "Rob provided this himself" rather than a schema field value. If the marketplace UI needs to distinguish "self-served" vs "partnership" platform codes in the future, that's a follow-up schema change.

## E2E verification

```
$ curl /api/referral-codes/proton-mail
{"vendor":"Proton Mail","code":"60QXGJSB","referral_url":"https://pr.tn/ref/60QXGJSB","referee_benefit":"$20 credit","source":"platform"}
$ curl /api/referral-codes/proton-vpn   → Proton VPN
$ curl /api/referral-codes/proton-pass  → Proton Pass
$ curl /api/referral-codes/proton-drive → Proton Drive
$ curl /api/referral-codes?source=platform | total: 5  (Railway + 4 Proton, each tagged with correct category: Cloud Hosting / Email / VPN & Privacy / Security / Storage)
$ curl /api/details/Proton%20Mail → offer.referral_code = the Proton platform code
$ curl /api/referral-codes/railway → Railway (regression check, still works)
```

## Test plan

- [x] `npm run build` — clean
- [x] `npm test` — 1,073 passing, 0 failing
- [x] Manual curl against running server — all 4 slug endpoints + listing + canonical enrichment + Railway regression