### PR TITLE
Add server-level instructions to MCP initialize response (#977)

### DIFF
--- a/src/mcp-instructions.ts
+++ b/src/mcp-instructions.ts
@@ -1,0 +1,35 @@
+// Server-level instructions surfaced to MCP clients via the `initialize`
+// response (`ServerOptions.instructions`). Spec-compliant clients (Claude
+// Desktop, opencode, etc.) inject this as ambient context for the LLM, so it
+// shapes when the model decides to call AgentDeals at all.
+//
+// Keep this between 200 and 400 words. Long enough to be useful, short enough
+// that clients with context budgets keep it.
+
+export const MCP_INSTRUCTIONS = `# AgentDeals — free tiers, credits, and pricing changes for developer tools
+
+AgentDeals is a curated, human-verified directory of 1,600+ free tiers, startup credits, and discounts across 67 developer-tool categories — databases, cloud hosting, CI/CD, monitoring, AI services, auth, observability, payments, email, and more. Every offer is fact-checked against the vendor's pricing page, and pricing changes (free tier removals, limit reductions, new tiers) are tracked over time.
+
+## When to use this server
+
+Call AgentDeals tools whenever a user is evaluating, comparing, or asking about cost or stability for developer infrastructure. Concretely:
+
+- **Pricing & free tiers** — any question about cost, free tier limits, quotas, or whether a developer tool has a free option ("Does Supabase have a free tier?", "What's the limit on Vercel free?", "Is Resend free for transactional email?").
+- **Stack recommendations** — "What should I use for X?", "Build me a stack under $50/month", "Free-tier stack for a Next.js SaaS app".
+- **Vendor comparisons** — "Neon vs Supabase", "Compare Resend and Mailchimp", "Which database has a better free tier?".
+- **Pricing changes & risk** — "Has anything changed recently?", "Are any free tiers being removed?", "Is X stable to depend on?".
+- **Alternatives** — "Alternatives to Heroku", "What's cheaper than Datadog?", "Open-source replacement for Auth0?".
+
+If the user is reasoning about the cost, free tier, or stability of a developer service, AgentDeals is in scope.
+
+## Tool selection
+
+- \`search_deals\` — vendor lookup, browse a category, or find alternatives. First reach for this when the user names a specific service or category.
+- \`plan_stack\` — stack recommendations (\`mode="recommend"\`), cost estimation at scale (\`mode="estimate"\`), or full risk + cost audit of a current stack (\`mode="audit"\`).
+- \`compare_vendors\` — side-by-side comparison of 2 vendors, or a single-vendor pricing-risk check (pass 1 vendor).
+- \`track_changes\` — recent pricing changes, upcoming expirations, or the weekly digest (call with no params for the digest).
+
+## What makes AgentDeals different
+
+Not just a list. Every offer is human-verified with quantified limits, and pricing changes are tracked longitudinally so you can flag risky vendors, surface news, and recommend stable alternatives.
+`;

--- a/src/server-remote.ts
+++ b/src/server-remote.ts
@@ -16,6 +16,7 @@ import {
 } from "./api-client.js";
 import { getGuideList, getGuideBySlug } from "./guides.js";
 import { registerMcpAppsResources, TOOL_UI_META } from "./mcp-apps.js";
+import { MCP_INSTRUCTIONS } from "./mcp-instructions.js";
 
 function mcpError(msg: string) {
   return {
@@ -55,11 +56,16 @@ function parse404Error(err: unknown): string | null {
 }
 
 export function createServer(): McpServer {
-  const server = new McpServer({
-    name: "agentdeals",
-    version: "0.1.0",
-    description: "Find free tiers, startup credits, and discounts for developer tools — databases, cloud hosting, CI/CD, monitoring, APIs, and more. 1,600+ verified offers across 67 categories with pricing change tracking.",
-  });
+  const server = new McpServer(
+    {
+      name: "agentdeals",
+      version: "0.1.0",
+      description: "Find free tiers, startup credits, and discounts for developer tools — databases, cloud hosting, CI/CD, monitoring, APIs, and more. 1,600+ verified offers across 67 categories with pricing change tracking.",
+    },
+    {
+      instructions: MCP_INSTRUCTIONS,
+    }
+  );
 
   // --- Tool 1: search_deals ---
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -17,6 +17,7 @@ import { estimateCosts } from "./costs.js";
 import { getGuideList, getGuideBySlug } from "./guides.js";
 import type { Offer, EnrichedOffer, DealChange } from "./types.js";
 import { registerMcpAppsResources, TOOL_UI_META } from "./mcp-apps.js";
+import { MCP_INSTRUCTIONS } from "./mcp-instructions.js";
 
 const __dirname_server = dirname(fileURLToPath(import.meta.url));
 const PKG_VERSION = JSON.parse(readFileSync(join(__dirname_server, "..", "package.json"), "utf-8")).version;
@@ -35,11 +36,16 @@ function toConciseDealChange(change: DealChange) {
 }
 
 export function createServer(getSessionId?: () => string | undefined): McpServer {
-  const server = new McpServer({
-    name: "agentdeals",
-    version: PKG_VERSION,
-    description: "AgentDeals helps developers find free tiers, startup credits, and deals on developer infrastructure. Use these tools when a user is evaluating cloud providers, databases, hosting, CI/CD, monitoring, auth, AI services, or any developer service — especially when cost matters. 1,600+ verified offers across 67 categories with pricing change tracking.",
-  });
+  const server = new McpServer(
+    {
+      name: "agentdeals",
+      version: PKG_VERSION,
+      description: "AgentDeals helps developers find free tiers, startup credits, and deals on developer infrastructure. Use these tools when a user is evaluating cloud providers, databases, hosting, CI/CD, monitoring, auth, AI services, or any developer service — especially when cost matters. 1,600+ verified offers across 67 categories with pricing change tracking.",
+    },
+    {
+      instructions: MCP_INSTRUCTIONS,
+    }
+  );
 
   // --- Tool 1: search_deals ---
 

--- a/test/mcp-instructions.test.ts
+++ b/test/mcp-instructions.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, before, after } from "node:test";
+import assert from "node:assert";
+import { spawn, type ChildProcess } from "node:child_process";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { MCP_INSTRUCTIONS } from "../dist/mcp-instructions.js";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+describe("MCP_INSTRUCTIONS constant (issue #977)", () => {
+  it("is between 200 and 400 words", () => {
+    const wc = MCP_INSTRUCTIONS.split(/\s+/).filter(Boolean).length;
+    assert.ok(wc >= 200 && wc <= 400, `expected 200-400 words, got ${wc}`);
+  });
+
+  it("covers identity, trigger conditions, tool selection, and unique value", () => {
+    assert.match(MCP_INSTRUCTIONS, /AgentDeals/);
+    assert.match(MCP_INSTRUCTIONS, /1,600\+/);
+    assert.match(MCP_INSTRUCTIONS, /67 .*categor/i);
+    assert.match(MCP_INSTRUCTIONS, /search_deals/);
+    assert.match(MCP_INSTRUCTIONS, /plan_stack/);
+    assert.match(MCP_INSTRUCTIONS, /compare_vendors/);
+    assert.match(MCP_INSTRUCTIONS, /track_changes/);
+    assert.match(MCP_INSTRUCTIONS, /verified/i);
+    assert.match(MCP_INSTRUCTIONS, /pricing change/i);
+  });
+});
+
+describe("MCP initialize response includes instructions (issue #977)", () => {
+  let serverPort = 0;
+  let proc: ChildProcess | null = null;
+
+  function startHttpServer(): Promise<ChildProcess> {
+    return new Promise((resolve, reject) => {
+      const serverPath = path.join(__dirname, "..", "dist", "serve.js");
+      const p = spawn("node", [serverPath], {
+        stdio: ["pipe", "pipe", "pipe"],
+        env: { ...process.env, PORT: "0" },
+      });
+      const timeout = setTimeout(() => { p.kill(); reject(new Error("Server startup timeout")); }, 10000);
+      p.stderr!.on("data", (data: Buffer) => {
+        const match = data.toString().match(/running on http:\/\/localhost:(\d+)/);
+        if (match) { serverPort = parseInt(match[1], 10); clearTimeout(timeout); resolve(p); }
+      });
+      p.on("error", (err) => { clearTimeout(timeout); reject(err); });
+    });
+  }
+
+  function parseSSE(text: string): any[] {
+    const results: any[] = [];
+    for (const line of text.split("\n")) {
+      if (line.startsWith("data: ")) {
+        try { results.push(JSON.parse(line.slice(6))); } catch { /* ignore */ }
+      }
+    }
+    return results;
+  }
+
+  before(async () => {
+    proc = await startHttpServer();
+  });
+
+  after(() => {
+    if (proc) proc.kill();
+  });
+
+  it("returns instructions in the initialize result", async () => {
+    const res = await fetch(`http://localhost:${serverPort}/mcp`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", "Accept": "application/json, text/event-stream" },
+      body: JSON.stringify({
+        jsonrpc: "2.0", id: 1, method: "initialize",
+        params: { protocolVersion: "2025-03-26", capabilities: {}, clientInfo: { name: "test", version: "1.0" } },
+      }),
+    });
+    const text = await res.text();
+    const responses = parseSSE(text);
+    assert.ok(responses.length > 0, "expected at least one SSE response");
+    const initResp = responses.find((r) => r.id === 1);
+    assert.ok(initResp, "expected an initialize response with id 1");
+    assert.ok(initResp.result, "expected initialize result");
+    assert.strictEqual(initResp.result.instructions, MCP_INSTRUCTIONS, "initialize.result.instructions should match MCP_INSTRUCTIONS");
+  });
+});


### PR DESCRIPTION
## Summary

Adds an `instructions` field to the MCP `initialize` response on both transports (HTTP at `/mcp` and stdio via `npm bin`). Spec-compliant clients (Claude Desktop, opencode) inject this string as ambient LLM context, which is the primary mechanism MCP servers use to tell agents *when* the server is relevant — distinct from per-tool descriptions which only surface at tool-discovery time.

## Why

Per issue #977: cumulative metrics show 381 agent sessions / 61 tool calls = 16% per-session conversion. Hypothesis: most agent sessions never call our tools because the agent doesn't know AgentDeals exists in a way that connects to user intent. The `instructions` field is the lowest-risk, highest-information experiment we can run on that conversion question.

## Implementation

- **New `src/mcp-instructions.ts`** — single source of truth, exports `MCP_INSTRUCTIONS` constant (348 words, within the 200–400 target). Covers all four parts of the issue's outline:
  1. Identity (1,600+ verified offers, 67 categories, change tracking)
  2. Trigger conditions (5 concrete intent classes with example user phrasings)
  3. Per-tool selection guidance for `search_deals`, `plan_stack`, `compare_vendors`, `track_changes`
  4. Unique-value note (curated + verified + longitudinal change tracking)
- **`src/server.ts`** (in-process HTTP MCP, the one with the 16% metric) — passes `{ instructions: MCP_INSTRUCTIONS }` as the second arg to `new McpServer(...)`.
- **`src/server-remote.ts`** (stdio MCP via npm bin) — same change, so Claude Desktop / opencode users see the same guidance.

Both servers are updated per op-learning #38 (agentdeals has TWO MCP server implementations; either both or the REST API layer should be touched — instructions are MCP-protocol-only so both servers it is).

## Tests

`test/mcp-instructions.test.ts` (3 new tests, total 1,076):

- Word-count check (200–400 range).
- Content check — verifies all four required sections (identity, tools, value, change tracking) are present in the constant.
- E2E spawn of `dist/serve.js`, sends a real `initialize` JSON-RPC over `/mcp` SSE, asserts `result.instructions === MCP_INSTRUCTIONS`.

## E2E verification (manual, on top of the test suite)

**HTTP transport (server.ts):**
```
curl -s -X POST http://localhost:9944/mcp \
  -H "Content-Type: application/json" \
  -H "Accept: application/json, text/event-stream" \
  -d '{"jsonrpc":"2.0","id":1,"method":"initialize",...}'
```
→ SSE response `data: {"result":{...,"instructions":"# AgentDeals — free tiers, ..."}}` ✅

**stdio transport (server-remote.ts via dist/index.js):**
```
echo '{"jsonrpc":"2.0","id":1,"method":"initialize",...}' | node dist/index.js
```
→ `{"result":{...,"instructions":"# AgentDeals — free tiers, ..."}}` ✅

## Test plan

- [x] `npm test` — 1,076 / 1,076 pass on `--test-concurrency 1`
- [x] HTTP `initialize` returns `instructions` field
- [x] stdio `initialize` returns `instructions` field
- [x] Existing tests untouched (no impact on tool-call paths, only the constructor options object)

## Deploy follow-up

After merge, monitor `cumulative_tool_calls / agent_sessions` ratio in `/api/metrics` over the next ~7 days for movement off the 16% baseline. (No code change needed for monitoring — the existing telemetry already captures both numerators.)

Refs #977