### PR TITLE
Add MiniMax to vendor index (closes zero-result search gap)

### DIFF
--- a/data/index.json
+++ b/data/index.json
@@ -21824,6 +21824,28 @@
       ]
     },
     {
+      "vendor": "MiniMax",
+      "category": "AI / ML",
+      "description": "Chinese AI lab (稀宇科技, Shanghai) offering multimodal APIs via platform.minimax.io. Pay-as-you-go: MiniMax-M2.7 text $0.3/$1.2 per Mtok (highspeed $0.6/$2.4), prompt-cache read $0.06/Mtok; speech/TTS $60/M chars (standard) or $100/M chars (HD), rapid voice clone $1.50/voice; MiniMax-Hailuo-02/2.3 video $0.10-$0.56/video depending on resolution and duration; image-01 $0.0035/image; Music-2.6 $0.15 per ~5 min with a 2-week free trial. Alternative Token Plan subscriptions from $10/mo (Starter: 1,500 M2.7 requests/5hr) to $150/mo (Ultra-Highspeed: 30K requests/5hr, 5 Hailuo videos/day). No documented permanent API free tier. Also maker of Hailuo AI (consumer video) and Talkie.",
+      "tier": "Pay-as-you-go",
+      "url": "https://platform.minimax.io/docs/guides/pricing-paygo",
+      "tags": [
+        "ai",
+        "ml",
+        "llm",
+        "api",
+        "inference",
+        "video",
+        "speech",
+        "tts",
+        "image-generation",
+        "music",
+        "multimodal",
+        "china"
+      ],
+      "verifiedDate": "2026-04-21"
+    },
+    {
       "vendor": "Amazon Aurora PostgreSQL",
       "category": "Databases",
       "description": "Aurora PostgreSQL Serverless on AWS Free Tier — managed PostgreSQL-compatible database with automatic scaling. Free plan: up to 4 ACUs per cluster, 1 GB storage. New accounts also get $100–200 in AWS credits for 12 months",


### PR DESCRIPTION
Refs #979.

## What

Adds a MiniMax entry to `data/index.json` so the vendor resolves in both search and details endpoints. Closes a signal gap — `minimax` appeared in both `top_search_queries_7d` **and** `zero_result_queries_7d` on prod, meaning someone explicitly searched for it and got zero results (plus no suggestion fallback).

## Entry structure decisions

**One entry, not four.** The issue offered the option of splitting abab/Hailuo/Speech into separate offers. I landed on a single combined entry because: (a) none of the modalities have a materially different free tier to differentiate (there's no permanent free tier on any of them), (b) this matches the existing `Anthropic API` pattern (one entry covers Sonnet/Opus/Haiku rather than three vendor rows), and (c) `relatedVendors` is auto-derived by `data.ts:81` from same-category offers, so a single MiniMax entry already cross-links to Groq/Gemini/Mistral/OpenRouter/Hugging Face automatically — no need to split to get cross-linking.

**Tier "Pay-as-you-go", not "Free".** The issue text says MiniMax "offers a free tier and pay-as-you-go for their APIs", but I could not verify a permanent free tier on any page of `platform.minimax.io` (docs, FAQ, token-plan quickstart, pricing overview, pay-as-you-go page all checked). The only free offerings I could confirm are:
- Music-2.6: 2-week free trial across all Token Plan tiers
- Lyrics Generation: 2-week free trial

Those are trials, not free tiers. Rather than invent unverified free-tier numbers, I shipped as `Pay-as-you-go` mirroring the existing Anthropic API entry pattern. The 2-week Music trial is noted in the description. If Rob or PM has a source showing a permanent free tier I couldn't find, I'll add it in a follow-up.

**Pay-as-you-go rates are comprehensive.** Sourced directly from `platform.minimax.io/docs/guides/pricing-paygo.md`:
- MiniMax-M2.7 text: \$0.3/\$1.2 per Mtok (highspeed \$0.6/\$2.4), prompt-cache read \$0.06/Mtok
- Speech/TTS: \$60/M chars (standard) / \$100/M chars (HD) / rapid voice clone \$1.50/voice
- MiniMax-Hailuo-02/2.3 video: \$0.10–\$0.56/video (resolution + duration dependent)
- image-01: \$0.0035/image
- Music-2.6: \$0.15 per ~5 min (+ 2-week free trial)
- Token Plan subscriptions from \$10/mo to \$150/mo (Ultra-Highspeed)

## Verification

- **Acceptance #1** — `/api/details/minimax` → 200 with full offer payload. `relatedVendors` auto-populated: Hugging Face, Groq, Google Gemini API, Mistral AI, OpenRouter.
- **Acceptance #2** — `/api/offers?q=minimax` → 1 matching offer. HTML `/search?q=minimax` → "1 free developer tools matching minimax".
- **Acceptance #3** — All required fields populated: `tier`, `description` (quantified pricing), `url`, `tags[12]` (ai, ml, llm, api, inference, video, speech, tts, image-generation, music, multimodal, china), `category: "AI / ML"`, `verifiedDate: "2026-04-21"`.
- **Acceptance #4** — `verifiedDate` = 2026-04-21 (the date the pricing page was checked).
- **Acceptance #5** — relatedVendors cross-links derived automatically (see Acceptance #1).

Full `npm test -- --test-concurrency=1` passes 1,076/1,076. Offers count 1,585 → 1,586.

## Test plan
- [x] `npm run build` — tsc clean
- [x] `npm test` — 1076/1076 pass
- [x] E2E via real server on `BASE_URL=http://localhost` port 9955
- [x] `/api/details/minimax`, `/api/details/MiniMax`, `/api/details/Minimax` all resolve
- [x] `/api/offers?q=minimax` returns exactly 1 offer
- [x] `/search?q=minimax` HTML page renders with the expected count

🤖 Generated with [Claude Code](https://claude.com/claude-code)