### PR TITLE
Track /search UI queries in telemetry with bot filtering

### DIFF
--- a/src/serve.ts
+++ b/src/serve.ts
@@ -53373,7 +53373,7 @@ const httpServer = createHttpServer(async (req, res) => {
       }
       return enriched;
     });
-    recordSearchQuery(q, total, category);
+    recordSearchQuery(q, total, category, req.headers["user-agent"]);
     logRequest({ ts: new Date().toISOString(), type: "api", endpoint: "/api/offers", params: { q, category, limit, offset }, user_agent: req.headers["user-agent"] ?? "unknown", result_count: paged.length });
     res.writeHead(200, { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" });
     res.end(JSON.stringify({ offers: offersWithCodes, total }));
@@ -54406,6 +54406,13 @@ ${catList}
     const sortParam = url.searchParams.get("sort") ?? "";
     const page = Math.max(1, parseInt(url.searchParams.get("page") ?? "1", 10) || 1);
     recordApiHit("/search");
+    if (query) {
+      const sanitized = sanitizeQuery(query);
+      if (sanitized) {
+        const total = searchOffers(sanitized, categoryFilter || undefined, typeFilter || undefined, sortParam || undefined).length;
+        recordSearchQuery(query, total, categoryFilter || undefined, req.headers["user-agent"]);
+      }
+    }
     logRequest({ ts: new Date().toISOString(), type: "api", endpoint: "/search", params: { q: query, category: categoryFilter, type: typeFilter, sort: sortParam, page: String(page) }, user_agent: req.headers["user-agent"] ?? "unknown", result_count: 1 });
     res.writeHead(200, { "Content-Type": "text/html; charset=utf-8", "Cache-Control": "public, max-age=300" });
     res.end(buildSearchPage(query, categoryFilter, typeFilter, sortParam, page));

--- a/src/stats.ts
+++ b/src/stats.ts
@@ -766,8 +766,9 @@ export function getPageViewsToday(): number {
 // Persisted as a ring buffer (last SEARCH_QUERY_RING_MAX entries) on telemetry.json,
 // so /api/metrics analytics survive deploys.
 
-export function recordSearchQuery(query: string | undefined, resultCount: number, category?: string): void {
+export function recordSearchQuery(query: string | undefined, resultCount: number, category?: string, userAgent?: string): void {
   if (!query) return;
+  if (userAgent && isBot(userAgent)) return;
   const normalized = query.trim().toLowerCase();
   if (!normalized) return;
   const entry: SearchQueryEntry = {

--- a/test/search-analytics.test.ts
+++ b/test/search-analytics.test.ts
@@ -112,4 +112,20 @@ describe("search analytics", () => {
     assert.strictEqual(typeof analytics.queries_by_category_7d, "object");
     assert.ok(!Array.isArray(analytics.queries_by_category_7d));
   });
+
+  it("skips queries with bot user-agent", () => {
+    recordSearchQuery("redis", 5, undefined, "Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)");
+    recordSearchQuery("postgres", 3, undefined, "SemrushBot/7.0");
+    recordSearchQuery("mongodb", 2, undefined, "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36");
+    const analytics = getSearchAnalytics();
+    assert.strictEqual(analytics.top_queries_7d.length, 1);
+    assert.strictEqual(analytics.top_queries_7d[0].query, "mongodb");
+  });
+
+  it("records queries when user-agent is undefined (e.g. internal tests, direct API callers)", () => {
+    recordSearchQuery("redis", 5);
+    recordSearchQuery("postgres", 3, undefined, undefined);
+    const analytics = getSearchAnalytics();
+    assert.strictEqual(analytics.top_queries_7d.length, 2);
+  });
 });


### PR DESCRIPTION
## Summary

`recordSearchQuery` was only wired to `/api/offers`, which handles 49 cumulative hits. The `/search` HTML page handles **4,660** — roughly 100x more traffic. That meant `top_search_queries_7d` and `zero_result_queries_7d` captured ~1% of actual search activity, and the signal-gap detector (the thing that surfaced MiniMax in #979 and led to PR #980) was flying nearly blind on human/browser-agent traffic.

This PR adds telemetry tracking to the `/search` route and threads the user-agent through `recordSearchQuery` so crawler traffic gets filtered before polluting the zero-result signal.

## Changes

- **`src/stats.ts`** — `recordSearchQuery(query, count, category, userAgent?)` adds an optional 4th arg. When the UA matches the existing `BOT_PATTERNS` regex (Googlebot, Ahrefsbot, Semrush, Bingbot, Claudebot, GPTBot, etc.), the function short-circuits before recording.
- **`src/serve.ts`** — `/search` handler now calls `recordSearchQuery` when `query` is present and survives `sanitizeQuery`. `/api/offers` updated identically; today it's a no-op (API callers rarely have bot UAs) but keeps the contract consistent so no caller is "privileged".
- **`test/search-analytics.test.ts`** — 2 new tests: bot UA filter, undefined-UA passthrough (for internal tests / direct API callers).

## Test plan

- [x] `npm test` — 1,078 tests pass (+2)
- [x] Build passes
- [x] E2E on local server w/ isolated telemetry:
  - Human UA, real vendor query (`railway`) → recorded in `top_queries_7d`, absent from `zero_result_queries_7d` ✅
  - Human UA, non-matching query → recorded in both (correctly classified as zero-result) ✅
  - Googlebot UA → not recorded anywhere ✅
  - Ahrefsbot UA → not recorded anywhere ✅
  - `/search` with no `?q=` → no recording attempt ✅
- [x] `data/telemetry.json` restored after E2E, `git status` clean

## Notes

- No change to `/api/metrics` response schema — existing consumers see the same shape, just a more representative set of queries.
- The 10μs overhead of running `searchOffers` twice (once for telemetry count, once inside `buildSearchPage`) is negligible relative to the page render cost. Chose duplicate-call over a `buildSearchPage` signature refactor to keep the diff small.

Refs #964 (telemetry area), extends PR #970.