### PR TITLE
Consolidate duplicate Windsurf entries into single AI Coding entry

### DIFF
--- a/data/index.json
+++ b/data/index.json
@@ -1489,22 +1489,6 @@
       "verifiedDate": "2026-04-14"
     },
     {
-      "vendor": "Windsurf",
-      "category": "IDE & Code Editors",
-      "description": "AI coding assistant (formerly Codeium). Free tier: limited daily quotas for completions and chat (credit system replaced by quotas Mar 2026). Pro $20/mo, Teams $40/mo, Max $200/mo. SWE-1.5 Fast Agent model. Grandfathered Pro subscribers keep $15/mo indefinitely",
-      "tier": "Free",
-      "url": "https://windsurf.com/pricing",
-      "tags": [
-        "developer tools",
-        "ai",
-        "code completion",
-        "ide",
-        "free tier",
-        "deal-change"
-      ],
-      "verifiedDate": "2026-04-13"
-    },
-    {
       "vendor": "Cursor",
       "category": "AI Coding",
       "description": "AI-powered code editor built on VS Code. 6-plan structure: Free (2,000 completions/month, 50 slow premium requests), Hobby $10/month (lighter paid tier), Pro $20/month (unlimited completions, 500 fast premium requests), Pro+ $60/month (10x premium requests vs Pro, priority access, more context), Business $40/seat/month, Ultra $200/month (highest credit limits for power users). Credit-based pricing model since June 2025.",
@@ -21300,6 +21284,7 @@
         "code completion",
         "developer tools",
         "cursor-alternative",
+        "free tier",
         "deal-change"
       ],
       "verifiedDate": "2026-04-13"


### PR DESCRIPTION
## Summary

The index had two **Windsurf** offers — one in `IDE & Code Editors` and one in `AI Coding` — both describing the same free-tier product with near-identical pricing (Free, Pro \$20/mo, Teams \$40/mo, Max \$200/mo, SWE-1.5 Fast Agent, grandfathered \$15/mo). Same duplicate-category pattern [PR #968](https://github.com/robhunter/agentdeals/pull/968) resolved for GitHub Copilot.

**Impact:**
- `/api/offers?q=windsurf` was returning 2 Windsurf cards (+ Zenable) instead of 1.
- Vendor listed twice in related-vendor cross-links on `/vendor/cursor`, `/vendor/github-copilot`, etc. (auto-derived from same-category peers — the "IDE & Code Editors" Windsurf entry was polluting IDE peers, the "AI Coding" entry was on AI Coding peers).

## How I found this

Idle-time inspection of production `/api/metrics` → `search_analytics.top_queries_7d` surfaced `"windsurf"` as an active query. Pulled `/api/offers?q=windsurf` on prod and saw 2 near-identical results. Same family of fixes as #967 (GitHub Copilot April 20) and #971 (Survicate/Forms).

## Change

- Removed the `IDE & Code Editors` Windsurf entry (less comprehensive description — missing Cascade AI flows, "All tiers include premium models" detail).
- Kept the `AI Coding` entry (more comprehensive, plus Windsurf is primarily an AI-powered IDE).
- Preserved the `"free tier"` tag from the removed entry on the remaining entry for tag parity.

## Category choice

Windsurf is an AI-powered IDE by Codeium. `AI Coding` is the more specific category — that's where Cursor, GitHub Copilot, Amazon Kiro, Augment Code, Claude Code, Gemini CLI, etc. all live. The `IDE & Code Editors` category is for traditional/general-purpose editors without AI as the primary pitch (VS Code, JetBrains, Sublime). Same category choice PR #968 made for GitHub Copilot.

## Counts

- Offers: 1,586 → 1,585 (-1, duplicate removed)
- Tests: 1,078 → 1,078 (no test changes needed; no tests hardcode this count or the category of Windsurf)

## E2E verification (local on :9956)

- `GET /api/offers?q=windsurf` → 2 results: `Windsurf` (AI Coding) + `Zenable` (AI/ML, mentions Windsurf in description). ✅
- `GET /api/details/windsurf` → single offer w/ category `AI Coding`, tags include `free tier`, relatedVendors auto-derived: Cursor, Devin, Bolt.new, Lovable, Claude Code. ✅
- `GET /vendor/windsurf` → `<title>Windsurf Free Tier 2026: Limits, Pricing & What Changed | AgentDeals</title>`. ✅
- `GET /search?q=windsurf` → 1 vendor card linking to `/vendor/windsurf` + 1 for `/vendor/zenable` (no duplicate Windsurf card). ✅
- `git status data/` clean after server run (per op-learning #48). ✅

## Refs

No filed issue — small data-quality improvement surfaced by telemetry-loop inspection during a thin-backlog cycle. Follows the same duplicate-entry consolidation pattern as PR #968.