### PR TITLE
Consolidate Notion duplicate entries (Team Collaboration → Productivity & Notes)

### DIFF
--- a/data/index.json
+++ b/data/index.json
@@ -21607,31 +21607,6 @@
       "verifiedDate": "2026-04-14"
     },
     {
-      "vendor": "Notion",
-      "category": "Team Collaboration",
-      "description": "Free for individuals — unlimited pages and blocks, 10 guest collaborators, 5MB file uploads, 7-day page history, basic forms, 1 notion.site, Notion Calendar, Notion Mail (Gmail sync), offline access. Team block limits apply on multi-member workspaces.",
-      "tier": "Free",
-      "url": "https://www.notion.com/pricing",
-      "tags": [
-        "developer tools",
-        "team collaboration",
-        "docs",
-        "notes",
-        "wiki",
-        "free tier"
-      ],
-      "verifiedDate": "2026-04-14",
-      "referral_program": {
-        "available": true,
-        "referrer_benefit": "50% commission on first 12 months",
-        "referee_benefit": "Standard plan pricing",
-        "program_url": "https://www.notion.com/affiliates",
-        "type": "application",
-        "commission_type": "recurring",
-        "notes": "Commission on Plus, Business, or AI Plan upgrades. Paid monthly via PayPal/Stripe."
-      }
-    },
-    {
       "vendor": "GitHub Models",
       "category": "AI / ML",
       "description": "Free access to 100+ AI models via GitHub Marketplace — GPT-4o, Llama, Mistral, Phi, and more. Free tier: 10-15 RPM, 50-150 requests/day depending on model tier. OpenAI-compatible API endpoint",
@@ -22028,17 +22003,19 @@
     {
       "vendor": "Notion",
       "category": "Productivity & Notes",
-      "description": "Unlimited pages and blocks for individual use. 1 member workspace with up to 10 guests. 5 MB file upload limit per file. 7-day page history. Basic integrations. API access.",
+      "description": "Free for individuals — unlimited pages and blocks, 1 member workspace with up to 10 guest collaborators, 5MB file uploads, 7-day page history, basic forms, 1 notion.site, Notion Calendar, Notion Mail (Gmail sync), offline access, basic integrations, API access. Team block limits apply on multi-member workspaces.",
       "tier": "Free",
-      "url": "https://www.notion.so/pricing",
+      "url": "https://www.notion.com/pricing",
       "tags": [
         "notes",
         "productivity",
+        "docs",
         "wiki",
-        "consumer",
-        "free-tier"
+        "team collaboration",
+        "developer tools",
+        "free tier"
       ],
-      "verifiedDate": "2026-04-17",
+      "verifiedDate": "2026-04-22",
       "referral_program": {
         "available": true,
         "referrer_benefit": "50% commission on first 12 months",


### PR DESCRIPTION
## Summary

Third in the category-duplicate consolidation series after PR #968 (GitHub Copilot) and PR #982 (Windsurf). Notion had two entries (Team Collaboration + Productivity & Notes) describing the same Free Plan with near-identical pricing and an identical referral program. Same product, same price, two categories — consolidating to one entry.

## Why Productivity & Notes

The Notion Free tier is explicitly individual-use ("1 member workspace with up to 10 guests, file uploads 5MB, 7-day page history"). Team-grade limits and the unlimited block allowance only kick in on the Plus/Business tiers. "Productivity & Notes" is the more specific category for the Free tier — the same logic the Windsurf dedup used (kept "AI Coding" over the broader "IDE & Code Editors" because it matched the entry's actual positioning).

## What changed

- Removed Notion entry under Team Collaboration (line 21609-21633 of pre-change index.json).
- Enriched the Productivity & Notes entry with the more comprehensive description from the removed entry: notion.site, Notion Calendar, Notion Mail (Gmail sync), offline access, basic forms — combined with API access from the original Productivity & Notes copy.
- URL updated from `notion.so/pricing` → `notion.com/pricing` (current canonical).
- Tag union: notes, productivity, docs, wiki, team collaboration, developer tools, free tier (dropped "consumer" since Notion is widely used by teams).
- `verifiedDate` bumped to 2026-04-22.

## Verification

- 1,585 → 1,584 offers.
- 1,078 tests pass (unchanged) on `--test-concurrency=1`.
- E2E with local server (`PORT=4977 BASE_URL=http://localhost:4977`):
  - `/api/offers?q=notion` → 1 Notion entry (Productivity & Notes, new combined description, Brex / Ramp also mention Notion in their startup-perks copy).
  - `/api/offers?category=Productivity%20%26%20Notes` → 13 entries, Notion present.
  - `/vendor/notion` → 200, renders new merged description.
  - `/team-collaboration-alternatives` → still surfaces Notion (the page's vendor filter is name-based, not category-based).
  - `/project-management-alternatives` → still surfaces Notion.

## Source of opportunity

Surfaced by the today.md observation logged when shipping #982 — flagged 3 likely-dupes (Notion, Figma, Proton Mail) for future cycles. Doing them one at a time so each gets its own category judgment rather than bundling into a mega-PR.

Refs #982