### PR TITLE
Lint for same-product-multi-category duplicate detection (#984)

### DIFF
--- a/.github/workflows/lint-duplicates.yml
+++ b/.github/workflows/lint-duplicates.yml
@@ -1,0 +1,34 @@
+name: Data lint — duplicates
+
+on:
+  pull_request:
+    paths:
+      - "data/index.json"
+      - "scripts/lint-duplicates.js"
+      - ".github/workflows/lint-duplicates.yml"
+  push:
+    branches: [main]
+    paths:
+      - "data/index.json"
+      - "scripts/lint-duplicates.js"
+      - ".github/workflows/lint-duplicates.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  lint-duplicates:
+    runs-on: ubuntu-latest
+    # Advisory only — the script always exits 0. `continue-on-error` adds an
+    # extra belt so an accidental non-zero exit still does not block merges.
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Run duplicate detection
+        run: |
+          node scripts/lint-duplicates.js | tee -a "$GITHUB_STEP_SUMMARY"

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "test": "node --test --test-concurrency 1 test/**/*.test.ts",
     "lint": "tsc --noEmit",
     "check:staleness": "node scripts/check-staleness.js",
+    "lint:duplicates": "node scripts/lint-duplicates.js",
     "check:pricing": "node scripts/check-pricing-changes.js",
     "monitor:pricing": "node scripts/monitor-pricing.js",
     "ingest:free-for-dev": "node scripts/parse-free-for-dev.ts",

--- a/scripts/lint-duplicates.js
+++ b/scripts/lint-duplicates.js
@@ -1,0 +1,148 @@
+#!/usr/bin/env node
+
+// Detection-only lint for same-product-multi-category duplicates in data/index.json.
+// Advisory output — does not modify data, exits 0. Each flagged candidate requires
+// a human category-judgment call (see PR #983 rationale).
+//
+// Heuristic: same vendor name (exact match, case-insensitive), appearing in ≥2
+// distinct categories, whose tier strings share at least one meaningful token
+// after normalization. Catches e.g. Figma "Starter" vs "Free (Starter)"
+// (shared: "starter") and Proton Pass "Free" vs "Free" (shared: "free"),
+// while leaving Sentry "Developer" vs "OSS Sponsored" (no shared token) alone.
+
+import { readFileSync } from "node:fs";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+const TIER_STOPWORDS = new Set([
+  "plan",
+  "tier",
+  "account",
+  "the",
+  "a",
+  "an",
+  "of",
+  "and",
+  "or",
+  "for",
+]);
+
+// Vendor name pairs to always exclude even if heuristic would match.
+// Empty by default — the current known-legitimate multi-entry cases all use
+// distinct vendor names (e.g. "Amazon Kiro" vs "Amazon Kiro (AWS Startups)")
+// and are therefore naturally excluded by exact-name matching.
+const ALLOWLIST = new Set([]);
+
+export function tierTokens(tier) {
+  if (!tier) return new Set();
+  const normalized = String(tier)
+    .toLowerCase()
+    .replace(/[()[\]{}/,:;.!?]/g, " ");
+  const tokens = normalized
+    .split(/\s+/)
+    .map((t) => t.trim())
+    .filter((t) => t.length >= 2 && !TIER_STOPWORDS.has(t));
+  return new Set(tokens);
+}
+
+export function sharedTierTokens(a, b) {
+  const ta = tierTokens(a);
+  const tb = tierTokens(b);
+  const shared = [];
+  for (const t of ta) if (tb.has(t)) shared.push(t);
+  return shared;
+}
+
+export function findDuplicateCandidates(offers) {
+  const byVendor = new Map();
+  for (const o of offers) {
+    if (!o.vendor) continue;
+    const key = o.vendor.toLowerCase().trim();
+    if (!byVendor.has(key)) byVendor.set(key, []);
+    byVendor.get(key).push(o);
+  }
+
+  const candidates = [];
+  for (const [, entries] of byVendor) {
+    if (entries.length < 2) continue;
+    if (ALLOWLIST.has(entries[0].vendor)) continue;
+
+    // For each pair of entries with the same vendor name, check if they
+    // (a) live in different categories and (b) share a tier token.
+    const categories = new Set(entries.map((e) => e.category));
+    if (categories.size < 2) continue;
+
+    // Compute shared tier tokens across all entries — if ANY pair shares a
+    // token and lives in different categories, flag the vendor.
+    let flagged = false;
+    let sharedTokensUnion = new Set();
+    for (let i = 0; i < entries.length; i++) {
+      for (let j = i + 1; j < entries.length; j++) {
+        if (entries[i].category === entries[j].category) continue;
+        const shared = sharedTierTokens(entries[i].tier, entries[j].tier);
+        if (shared.length > 0) {
+          flagged = true;
+          for (const t of shared) sharedTokensUnion.add(t);
+        }
+      }
+    }
+    if (!flagged) continue;
+
+    candidates.push({
+      vendor: entries[0].vendor,
+      entries: entries.map((e) => ({ category: e.category, tier: e.tier })),
+      sharedTierTokens: [...sharedTokensUnion].sort(),
+    });
+  }
+
+  return candidates.sort((a, b) => a.vendor.localeCompare(b.vendor));
+}
+
+export function formatMarkdown(candidates) {
+  if (candidates.length === 0) {
+    return "## Duplicate candidates\n\nNo same-vendor-same-tier multi-category duplicates detected.\n";
+  }
+  const lines = [];
+  lines.push("## Duplicate candidates");
+  lines.push("");
+  lines.push(
+    `**${candidates.length} candidate${candidates.length === 1 ? "" : "s"}** — same vendor, shared tier token, ≥2 categories. Each requires a human category-judgment call (see PR #983).`,
+  );
+  lines.push("");
+  for (const c of candidates) {
+    lines.push(`### ${c.vendor}`);
+    lines.push(`_Shared tier token(s): ${c.sharedTierTokens.join(", ")}_`);
+    for (const e of c.entries) {
+      lines.push(`- ${e.category} — ${e.tier}`);
+    }
+    lines.push("");
+  }
+  return lines.join("\n");
+}
+
+function main() {
+  const indexPath = resolve(__dirname, "..", "data", "index.json");
+  let data;
+  try {
+    data = JSON.parse(readFileSync(indexPath, "utf-8"));
+  } catch (err) {
+    console.error(`Failed to read data/index.json: ${err.message}`);
+    process.exit(2);
+  }
+
+  const offers = data.offers || [];
+  const candidates = findDuplicateCandidates(offers);
+
+  console.log(formatMarkdown(candidates));
+
+  // Advisory only — always exit 0 so CI does not block merges.
+  process.exit(0);
+}
+
+const isMainModule =
+  process.argv[1] && resolve(process.argv[1]) === resolve(fileURLToPath(import.meta.url));
+if (isMainModule) {
+  main();
+}

--- a/test/lint-duplicates.test.ts
+++ b/test/lint-duplicates.test.ts
@@ -1,0 +1,176 @@
+import { describe, it } from "node:test";
+import assert from "node:assert";
+
+const { findDuplicateCandidates, tierTokens, sharedTierTokens, formatMarkdown } = await import(
+  "../scripts/lint-duplicates.js"
+);
+
+describe("tierTokens", () => {
+  it("lowercases and splits on whitespace", () => {
+    assert.deepStrictEqual([...tierTokens("Free")], ["free"]);
+    assert.deepStrictEqual([...tierTokens("Startup Program")], ["startup", "program"]);
+  });
+
+  it("strips parens and punctuation", () => {
+    assert.deepStrictEqual([...tierTokens("Free (Starter)")].sort(), ["free", "starter"]);
+  });
+
+  it("filters stopwords and short tokens", () => {
+    assert.deepStrictEqual([...tierTokens("Basic Plan")], ["basic"]);
+    assert.deepStrictEqual([...tierTokens("Hobby tier")], ["hobby"]);
+  });
+
+  it("handles empty and missing tiers", () => {
+    assert.deepStrictEqual([...tierTokens("")], []);
+    assert.deepStrictEqual([...tierTokens(undefined)], []);
+    assert.deepStrictEqual([...tierTokens(null)], []);
+  });
+});
+
+describe("sharedTierTokens", () => {
+  it("returns shared tokens across tier strings", () => {
+    assert.deepStrictEqual(sharedTierTokens("Starter", "Free (Starter)"), ["starter"]);
+    assert.deepStrictEqual(sharedTierTokens("Free", "Free"), ["free"]);
+  });
+
+  it("returns empty for disjoint tiers", () => {
+    assert.deepStrictEqual(sharedTierTokens("Developer", "OSS Sponsored"), []);
+    assert.deepStrictEqual(sharedTierTokens("Free", "Student Program"), []);
+    assert.deepStrictEqual(sharedTierTokens("Startup Program", "Free (Basic)"), []);
+    assert.deepStrictEqual(sharedTierTokens("Credits", "Hatch"), []);
+  });
+});
+
+describe("findDuplicateCandidates", () => {
+  it("flags same-vendor same-tier multi-category pairs", () => {
+    const offers = [
+      { vendor: "Proton Mail", category: "Email", tier: "Free" },
+      { vendor: "Proton Mail", category: "Consumer Email", tier: "Free" },
+    ];
+    const result = findDuplicateCandidates(offers);
+    assert.strictEqual(result.length, 1);
+    assert.strictEqual(result[0].vendor, "Proton Mail");
+    assert.deepStrictEqual(result[0].sharedTierTokens, ["free"]);
+    assert.strictEqual(result[0].entries.length, 2);
+  });
+
+  it("flags Figma despite tier-string variation (Starter vs Free (Starter))", () => {
+    const offers = [
+      { vendor: "Figma", category: "Design", tier: "Starter" },
+      { vendor: "Figma", category: "Design & Creative", tier: "Free (Starter)" },
+    ];
+    const result = findDuplicateCandidates(offers);
+    assert.strictEqual(result.length, 1);
+    assert.strictEqual(result[0].vendor, "Figma");
+    assert(result[0].sharedTierTokens.includes("starter"));
+  });
+
+  it("does NOT flag different vendor names (Amazon Kiro dual-entry)", () => {
+    const offers = [
+      { vendor: "Amazon Kiro (AWS Startups)", category: "Startup Programs", tier: "Startup Program" },
+      { vendor: "Amazon Kiro", category: "AI Coding", tier: "Free" },
+    ];
+    const result = findDuplicateCandidates(offers);
+    assert.strictEqual(result.length, 0);
+  });
+
+  it("does NOT flag distinct products under same brand (Proton Mail vs Proton VPN)", () => {
+    const offers = [
+      { vendor: "Proton Mail", category: "Email", tier: "Free" },
+      { vendor: "Proton VPN", category: "VPN", tier: "Free" },
+    ];
+    const result = findDuplicateCandidates(offers);
+    assert.strictEqual(result.length, 0);
+  });
+
+  it("does NOT flag same vendor with different tiers (Sentry, PostHog pattern)", () => {
+    const offers = [
+      { vendor: "Sentry", category: "Monitoring", tier: "Developer" },
+      { vendor: "Sentry", category: "Startup Programs", tier: "OSS Sponsored" },
+      { vendor: "PostHog", category: "Analytics", tier: "Free" },
+      { vendor: "PostHog", category: "Startup Programs", tier: "YC Deal" },
+    ];
+    const result = findDuplicateCandidates(offers);
+    assert.strictEqual(result.length, 0);
+  });
+
+  it("does NOT flag same vendor, same tier, but same single category", () => {
+    const offers = [
+      { vendor: "FooBar", category: "Analytics", tier: "Free" },
+      { vendor: "FooBar", category: "Analytics", tier: "Free" },
+    ];
+    const result = findDuplicateCandidates(offers);
+    assert.strictEqual(result.length, 0);
+  });
+
+  it("handles offers missing vendor or category without throwing", () => {
+    const offers = [
+      { category: "Email", tier: "Free" },
+      { vendor: "Bar", tier: "Free" },
+      { vendor: "Baz" },
+    ];
+    const result = findDuplicateCandidates(offers);
+    assert.strictEqual(result.length, 0);
+  });
+
+  it("returns results sorted alphabetically by vendor", () => {
+    const offers = [
+      { vendor: "Zulu", category: "A", tier: "Free" },
+      { vendor: "Zulu", category: "B", tier: "Free" },
+      { vendor: "Alpha", category: "A", tier: "Free" },
+      { vendor: "Alpha", category: "B", tier: "Free" },
+    ];
+    const result = findDuplicateCandidates(offers);
+    assert.strictEqual(result.length, 2);
+    assert.strictEqual(result[0].vendor, "Alpha");
+    assert.strictEqual(result[1].vendor, "Zulu");
+  });
+});
+
+describe("formatMarkdown", () => {
+  it("produces a friendly message when no candidates", () => {
+    const out = formatMarkdown([]);
+    assert.match(out, /No same-vendor-same-tier multi-category duplicates detected/);
+  });
+
+  it("includes each candidate and tier info", () => {
+    const out = formatMarkdown([
+      {
+        vendor: "Figma",
+        entries: [
+          { category: "Design", tier: "Starter" },
+          { category: "Design & Creative", tier: "Free (Starter)" },
+        ],
+        sharedTierTokens: ["starter"],
+      },
+    ]);
+    assert.match(out, /### Figma/);
+    assert.match(out, /Design — Starter/);
+    assert.match(out, /Design & Creative — Free \(Starter\)/);
+    assert.match(out, /starter/);
+  });
+});
+
+describe("lint-duplicates against current data/index.json", () => {
+  it("detects Figma, Proton Pass, and Proton Mail as candidates", async () => {
+    const { readFileSync } = await import("node:fs");
+    const { resolve } = await import("node:path");
+    const indexPath = resolve(process.cwd(), "data", "index.json");
+    const data = JSON.parse(readFileSync(indexPath, "utf-8"));
+    const result = findDuplicateCandidates(data.offers || []);
+    const vendors = result.map((c) => c.vendor);
+    assert(vendors.includes("Figma"), `expected Figma in ${vendors.join(", ")}`);
+    assert(vendors.includes("Proton Pass"), `expected Proton Pass in ${vendors.join(", ")}`);
+    assert(vendors.includes("Proton Mail"), `expected Proton Mail in ${vendors.join(", ")}`);
+  });
+
+  it("does not flag Amazon Kiro (different vendor names)", async () => {
+    const { readFileSync } = await import("node:fs");
+    const { resolve } = await import("node:path");
+    const indexPath = resolve(process.cwd(), "data", "index.json");
+    const data = JSON.parse(readFileSync(indexPath, "utf-8"));
+    const result = findDuplicateCandidates(data.offers || []);
+    const kiroFlagged = result.some((c) => c.vendor.toLowerCase().includes("kiro"));
+    assert.strictEqual(kiroFlagged, false);
+  });
+});


### PR DESCRIPTION
Refs #984

## Summary

Advisory lint that flags same-product-multi-category duplicates in `data/index.json` — detection only, never modifies data, never blocks the build. Each flagged candidate still requires a human category-judgment call per PR #983's one-at-a-time-consolidation principle.

## Implementation

- **`scripts/lint-duplicates.js`** — scans `data/index.json` and groups offers by lowercased vendor name. For each vendor with ≥2 entries in distinct categories, checks whether any pair shares a *meaningful tier token* after normalization (lowercase, strip parens/punctuation, drop stopwords like "plan"/"tier"/"account"/short tokens). Emits a markdown list of candidates + the shared tier tokens per vendor.
- **`test/lint-duplicates.test.ts`** — 18 tests across five suites: token extraction, shared-token detection, per-offer detection (including Figma edge case, Amazon Kiro negative, Sentry-pattern negative, Proton-brand negative), markdown formatting, and a live assertion against current `data/index.json` that Figma/Proton Pass/Proton Mail are flagged and Amazon Kiro is not.
- **`package.json`** — `npm run lint:duplicates`.
- **`.github/workflows/lint-duplicates.yml`** — runs on PRs and pushes to main that touch `data/index.json` (or the lint itself); pipes output into `$GITHUB_STEP_SUMMARY`. `continue-on-error: true` + script-always-exits-0 = belt-and-suspenders advisory mode.

## Key design decision — loose tier matching

The issue's AC says "same tier, appearing in ≥2 categories" *and* requires Figma to be flagged. But Figma's two entries have tiers `"Starter"` and `"Free (Starter)"` — not string-equal. Solution: tokenize tier strings (strip parens/punct, lowercase, drop stopwords) and flag if any token is shared.

Verification against every multi-entry vendor currently in the index:

| Vendor | Tier A | Tier B | Shared | Flagged? |
|---|---|---|---|---|
| Figma | Starter | Free (Starter) | `starter` | ✅ YES (required) |
| Proton Pass | Free | Free | `free` | ✅ YES (required) |
| Proton Mail | Free | Free | `free` | ✅ YES (required) |
| Airtable | Free | Free | `free` | ✅ YES (bonus) |
| Canva | Free | Free | `free` | ✅ YES (bonus) |
| Telegram | Free | Free | `free` | ✅ YES (bonus — categories "Communication" and "Communication & Messaging") |
| Sentry | Developer | OSS Sponsored | — | ❌ correctly not flagged |
| PostHog | Free | YC Deal | — | ❌ correctly not flagged |
| Amplitude | Starter | Startup Scholarship | — | ❌ correctly not flagged |
| Cloudflare Workers | Free | Student Program | — | ❌ correctly not flagged |
| DigitalOcean | Credits | Hatch | — | ❌ correctly not flagged |
| Zoom | Startup Program | Free (Basic) | — | ❌ correctly not flagged |
| OVHcloud | Free / Credits / Budget | — | — | ❌ correctly not flagged |
| Amazon Kiro | (different vendor names) | | | ❌ correctly not flagged |

## Allowlist

Empty. The Amazon Kiro case has distinct vendor strings (`"Amazon Kiro"` vs `"Amazon Kiro (AWS Startups)"`) and is naturally excluded by exact-name matching. An `ALLOWLIST` Set is in the script for future use, with a comment explaining the current exclusions happen by name divergence.

## Output format

Markdown — renders cleanly in `$GITHUB_STEP_SUMMARY`. Example:

```
## Duplicate candidates

**6 candidates** — same vendor, shared tier token, ≥2 categories. Each requires a human category-judgment call (see PR #983).

### Figma
_Shared tier token(s): starter_
- Design — Starter
- Design & Creative — Free (Starter)
```

## Test results

- `npm test` — 1,096 / 1,096 pass (was 1,078 on main; +18 new in this PR).
- `npm run lint:duplicates` — 6 candidates flagged against current `data/index.json`.
- `git status` clean after all test runs (op-learning #48).

## Non-goals (per AC)

- Auto-fixing. Each consolidation needs a category-judgment call.
- Full schema validation or deeper data-quality checks. Scope is narrow: same-name-multi-category detection.