### PR TITLE
Consolidate Figma duplicate entries into Design

### DIFF
--- a/data/index.json
+++ b/data/index.json
@@ -3485,7 +3485,7 @@
     {
       "vendor": "Figma",
       "category": "Design",
-      "description": "Collaborative design tool — free Starter plan with unlimited drafts, unlimited viewers, unlimited cloud storage, 30-day version history, 150 AI credits/day (500/mo). Team projects limited to 3 files.",
+      "description": "Collaborative design tool — free Starter plan with unlimited personal drafts, unlimited viewers/commenters, unlimited cloud storage, 30-day version history, 150 AI credits/day (500/mo). Team projects limited to 3 Figma design files + 3 FigJam files. No team libraries or branching on free.",
       "tier": "Starter",
       "url": "https://www.figma.com/pricing/",
       "tags": [
@@ -22550,21 +22550,6 @@
         "design",
         "graphics",
         "templates",
-        "consumer",
-        "free-tier"
-      ],
-      "verifiedDate": "2026-04-17"
-    },
-    {
-      "vendor": "Figma",
-      "category": "Design & Creative",
-      "description": "Up to 3 Figma design files and 3 FigJam files. Unlimited personal drafts. Unlimited viewers/commenters. Basic prototyping. No team libraries or branching on free.",
-      "tier": "Free (Starter)",
-      "url": "https://www.figma.com/pricing/",
-      "tags": [
-        "design",
-        "ui-ux",
-        "prototyping",
         "consumer",
         "free-tier"
       ],

--- a/test/lint-duplicates.test.ts
+++ b/test/lint-duplicates.test.ts
@@ -152,14 +152,13 @@ describe("formatMarkdown", () => {
 });
 
 describe("lint-duplicates against current data/index.json", () => {
-  it("detects Figma, Proton Pass, and Proton Mail as candidates", async () => {
+  it("detects Proton Pass and Proton Mail as candidates", async () => {
     const { readFileSync } = await import("node:fs");
     const { resolve } = await import("node:path");
     const indexPath = resolve(process.cwd(), "data", "index.json");
     const data = JSON.parse(readFileSync(indexPath, "utf-8"));
     const result = findDuplicateCandidates(data.offers || []);
     const vendors = result.map((c) => c.vendor);
-    assert(vendors.includes("Figma"), `expected Figma in ${vendors.join(", ")}`);
     assert(vendors.includes("Proton Pass"), `expected Proton Pass in ${vendors.join(", ")}`);
     assert(vendors.includes("Proton Mail"), `expected Proton Mail in ${vendors.join(", ")}`);
   });


### PR DESCRIPTION
## Summary

Fourth in the dedup series surfaced by the `lint:duplicates` advisory (PR #985), after Copilot (#968), Windsurf (#982), and Notion (#983).

Figma had two entries describing the same Starter plan:
- **Design** (96-entry category — primary home for design tools) — `Starter` tier, fresh verifiedDate 2026-04-19, richer description
- **Design & Creative** (8-entry narrower category: Photopea, GIMP, Inkscape, DaVinci Resolve, Krita, Blender, Canva, Figma) — `Free (Starter)`, 2026-04-17

## Decision

**Kept Design, removed Design & Creative.** "Design & Creative" is populated by creative/photo/video/3D/illustration tools — Figma is a UI/product design tool and fits "Design" naturally. Canva remains in both categories (pending — it's the next in the lint list).

Merged FigJam file count and \"no team libraries or branching\" detail from the removed entry into the kept description.

## Verification

- \`npm run lint:duplicates\`: 6 → 5 candidates (Figma dropped out)
- 1,584 → 1,583 offers
- 1,096 tests passing (updated regression fence test in \`test/lint-duplicates.test.ts\` to reflect new baseline)
- E2E via dev server on port 3458:
  - \`/api/details/figma\` → Design / Starter, merged description
  - \`/api/offers?q=figma\` → 1 Figma result (was 2)
  - \`/api/offers?category=Design%20%26%20Creative\` → 7 results, no Figma

Refs #984

🤖 Generated with [Claude Code](https://claude.com/claude-code)