### PR TITLE
dedup: consolidate Telegram entries into Communication & Messaging

### DIFF
--- a/data/category-mapping.json
+++ b/data/category-mapping.json
@@ -212,7 +212,7 @@
   "Teamcamp": "Project Management",
   "Teamhood": "Project Management",
   "Teamplify": "Project Management",
-  "Telegram": "Communication",
+  "Telegram": "Communication & Messaging",
   "Tencent RTC": "Team Collaboration",
   "TimeCamp": "Project Management",
   "tldraw.com": "Diagramming",

--- a/data/index.json
+++ b/data/index.json
@@ -8710,18 +8710,6 @@
       "verifiedDate": "2026-04-12"
     },
     {
-      "vendor": "Telegram",
-      "category": "Communication",
-      "description": "Telegram is for everyone who wants fast, reliable messaging and calls. Business users and small teams may like the large groups, usernames, desktop apps, and powerful file-sharing options.",
-      "tier": "Free",
-      "url": "https://telegram.org/",
-      "tags": [
-        "developer-tools",
-        "free-for-dev"
-      ],
-      "verifiedDate": "2026-04-13"
-    },
-    {
       "vendor": "Tencent RTC",
       "category": "Team Collaboration",
       "description": "Tencent Real-Time Communication (TRTC) offers solutions for group audio/video calls.10,000 free minutes/month for the first year.",
@@ -22515,7 +22503,7 @@
     {
       "vendor": "Telegram",
       "category": "Communication & Messaging",
-      "description": "Fully free core features. Unlimited messages. Groups up to 200,000 members. Channels with unlimited subscribers. 2 GB file upload limit. Cloud-based message sync. Voice/video calls. Bot platform.",
+      "description": "Fully free core features. Unlimited messages. Groups up to 200,000 members. Channels with unlimited subscribers. 2 GB file upload limit. Cloud-based message sync. Voice/video calls. Bot platform. Public @usernames. Desktop, web, and mobile clients.",
       "tier": "Free",
       "url": "https://telegram.org",
       "tags": [

--- a/src/serve.ts
+++ b/src/serve.ts
@@ -13192,7 +13192,7 @@ function buildTeamCollaborationAlternativesPage(): string {
 
   // Group by domain
   const chatMessaging = enrichedAll.filter(o =>
-    ["Slack API", "Discord API", "Rocket.Chat", "Pumble", "Chanty.com", "element.io", "Revolt.chat", "Zulip", "flock.com", "gitter.im", "Keybase", "Braid", "twist.com", "Telegram", "Tawk.to", "Crisp", "Helploom"].includes(o.vendor)
+    ["Slack API", "Discord API", "Rocket.Chat", "Pumble", "Chanty.com", "element.io", "Revolt.chat", "Zulip", "flock.com", "gitter.im", "Keybase", "Braid", "twist.com", "Tawk.to", "Crisp", "Helploom"].includes(o.vendor)
   );
   const videoMeetings = enrichedAll.filter(o =>
     ["meet.jit.si", "zoom.us", "Webex", "Daily.co", "Whereby", "Tencent RTC", "talky.io", "LiveKit", "Mux", "wistia.com", "flat.social", "Duckly", "Screen Sharing via Browser"].includes(o.vendor)


### PR DESCRIPTION
## Summary

Fifth in the dedup series surfaced by \`npm run lint:duplicates\` (PR #985). Two Telegram entries described the same Free tier across overlapping categories (Communication + Communication & Messaging). Consolidated to the Communication & Messaging entry — its 8-entry peer group (Slack, Discord, Zoom, Google Meet, Microsoft Teams, Signal, WhatsApp) is squarely consumer/business messaging, while Communication (24 entries) is a grab-bag of developer APIs, chat widgets, commenting tools, startup programs, and CRMs. Telegram belongs with its peer messaging apps.

## Category judgment

| Category | Population | Sample vendors |
|---|---|---|
| Communication (removed) | 24 | Discord API, Slack API, LiveKit, Sendbird, Tawk.to, Stream, Twilio Startups, Zendesk Startups, noCRM — API/widget/startup-program/CRM mix |
| Communication & Messaging (kept) | 8 | Slack, Discord, Zoom, Google Meet, Microsoft Teams, Signal, Telegram, WhatsApp — pure messaging apps |

Same population-check pattern used in PR #986 (Figma): investigate the peer groups before picking which entry to keep.

## Description merge

Kept the more specific tier details (200k members, 2 GB files, bot platform) and added two factual details from the removed entry that the kept one lacked:
- Public @usernames
- Desktop, web, and mobile clients

Dropped marketing/positioning copy ('fast, reliable', 'Business users and small teams may like').

## Downstream change

\`src/serve.ts:13195\` — the \`/team-collaboration-alternatives\` page's \`chatMessaging\` filter previously listed Telegram in its hardcoded vendor array. Since that page filters only Team Collaboration / Communication / Video categories, the Telegram entry there was now dead code (Telegram's remaining entry is in Communication & Messaging, which isn't in that page's scope). Removed Telegram from the array to avoid leaving confusing dead code.

User-facing effect: Telegram no longer appears on /team-collaboration-alternatives. Consistent with the page's team-chat scope (Slack API, Rocket.Chat, Zulip, Pumble, etc.) — Telegram is consumer messaging, fits better on its natural category page.

## Verification

- \`npm test --test-concurrency=1\`: 1,096 / 1,096 pass
- \`npm run lint:duplicates\`: 4 candidates remaining (Airtable, Canva, Proton Mail, Proton Pass) — Telegram dropped as expected
- E2E on isolated server (\`BASE_URL=http://localhost:9959\` per op-learning #46):
  - /api/details/Telegram → single entry, category 'Communication & Messaging', merged description
  - /api/offers?q=telegram → 1 Telegram result (was 2)
  - /api/offers?category=Communication → 23 (was 24)
  - /api/offers?category=Communication%20%26%20Messaging → 8 including Telegram
  - /vendor/telegram → 200
  - /team-collaboration-alternatives → Telegram absent (expected downstream effect)
- git status data/ clean after server runs (op-learning #48 still holds)

## Context

Surfaced by PR #985's lint:duplicates advisory. Direct response to PR #983's one-PR-per-consolidation principle — each dedup gets its own category-judgment call. Previous cycles: PRs #968 (Copilot), #982 (Windsurf), #983 (Notion), #986 (Figma).

1,583 → 1,582 offers.

Refs no issue (small data-quality improvement, not from a filed ticket).