### PR TITLE
Consolidate Proton Pass duplicate entries into Password Managers

### DIFF
--- a/data/index.json
+++ b/data/index.json
@@ -8498,26 +8498,6 @@
       "verifiedDate": "2026-04-12"
     },
     {
-      "vendor": "Proton Pass",
-      "category": "Security",
-      "description": "Password manager with built-in email aliases, 2FA authenticator, sharing and passkeys. Available on web, browser extension, and mobile app and desktop.",
-      "tier": "Free",
-      "url": "https://proton.me/pass",
-      "tags": [
-        "developer-tools",
-        "free-for-dev"
-      ],
-      "verifiedDate": "2026-04-12",
-      "referral_program": {
-        "available": true,
-        "referrer_benefit": "Free months of service",
-        "referee_benefit": "Free months of service",
-        "program_url": "https://proton.me/support/referral-program",
-        "type": "self-service",
-        "commission_type": "credits"
-      }
-    },
-    {
       "vendor": "Pullflow",
       "category": "Code Quality",
       "description": "Pullflow offers an AI-enhanced platform for code review collaboration across GitHub, Slack, and VS Code.",
@@ -22333,7 +22313,7 @@
     {
       "vendor": "Proton Pass",
       "category": "Password Managers",
-      "description": "Unlimited logins and notes. Unlimited devices. 10 hide-my-email aliases. Integrated 2FA/TOTP. Passkey support. End-to-end encrypted. No credit card storage or unlimited aliases on free.",
+      "description": "Unlimited logins, notes, and devices. 10 hide-my-email aliases. Integrated 2FA/TOTP. Passkey support. Vault sharing. End-to-end encrypted. Web, browser extension, mobile, and desktop apps. No credit card storage or unlimited aliases on free.",
       "tier": "Free",
       "url": "https://proton.me/pass/pricing",
       "tags": [

--- a/src/serve.ts
+++ b/src/serve.ts
@@ -9600,7 +9600,7 @@ function buildSecurityAlternativesPage(): string {
     ["letsencrypt.org", "ssllabs.com", "TestTLS.com", "Internet.nl", "Mozilla Observatory", "CertKit", "DJ Checkup", "Sucuri SiteCheck"].includes(o.vendor)
   );
   const other = enrichedAll.filter(o =>
-    ["1Password", "Proton Pass", "FraudLabs Pro", "LoginLlama", "Have I been pwned?", "CyberChef", "Protectumus", "URLscan.io", "VirusTotal", "RandomKeygen", "Virgil Security", "Cookiefirst", "Iubenda", "Ketch", "Pareto Security"].includes(o.vendor)
+    ["1Password", "FraudLabs Pro", "LoginLlama", "Have I been pwned?", "CyberChef", "Protectumus", "URLscan.io", "VirusTotal", "RandomKeygen", "Virgil Security", "Cookiefirst", "Iubenda", "Ketch", "Pareto Security"].includes(o.vendor)
   );
 
   // Build cards helper

--- a/test/lint-duplicates.test.ts
+++ b/test/lint-duplicates.test.ts
@@ -152,14 +152,13 @@ describe("formatMarkdown", () => {
 });
 
 describe("lint-duplicates against current data/index.json", () => {
-  it("detects Proton Pass and Proton Mail as candidates", async () => {
+  it("detects Proton Mail as a candidate", async () => {
     const { readFileSync } = await import("node:fs");
     const { resolve } = await import("node:path");
     const indexPath = resolve(process.cwd(), "data", "index.json");
     const data = JSON.parse(readFileSync(indexPath, "utf-8"));
     const result = findDuplicateCandidates(data.offers || []);
     const vendors = result.map((c) => c.vendor);
-    assert(vendors.includes("Proton Pass"), `expected Proton Pass in ${vendors.join(", ")}`);
     assert(vendors.includes("Proton Mail"), `expected Proton Mail in ${vendors.join(", ")}`);
   });
 


### PR DESCRIPTION
Flows from PR #985 lint advisory output. Sixth in the dedup series after #968 (Copilot), #982 (Windsurf), #983 (Notion), #986 (Figma), #987 (Telegram).

## The duplicate
Two Proton Pass entries described the same Free plan under different categories:
- **Security** (54-entry broad category) — Snyk, SonarCloud, GitGuardian, Tailscale, etc. A grab-bag of developer-security tools.
- **Password Managers** (6-entry peer group) — Bitwarden, Apple Passwords, KeePassXC, LastPass, NordPass. Canonical home for password managers.

## Category-judgment call
Kept **Password Managers**. Inverts the Figma heuristic (where I kept the 96-entry Design over the 8-entry Design & Creative). Here the 54-entry Security category isn't a broader primary home for Proton Pass — it's a miscategorization. Password Managers is where Proton Pass's peers live, and the entry already has concrete free-tier limits (10 aliases, unlimited logins, etc.).

## Description merge
Pulled platform availability (web, browser extension, mobile, desktop) and vault-sharing from the removed Security entry into the kept description. Final:

> Unlimited logins, notes, and devices. 10 hide-my-email aliases. Integrated 2FA/TOTP. Passkey support. Vault sharing. End-to-end encrypted. Web, browser extension, mobile, and desktop apps. No credit card storage or unlimited aliases on free.

## Downstream cleanup
Per op-learning from #987, ran `grep -n '"Proton Pass"' src/serve.ts` and found one reference in the `/security-alternatives` page's hardcoded `other` bucket. With no Security-category Proton Pass entry, the filter can never match — removed. The page's `securityOffers` query pulls from categories Security / Secrets Management / Auth / Error Tracking, so Password-Managers-category vendors correctly don't appear on the security tools hub. Consistent with the page's developer-security-tools scope (it's about SAST, secrets, auth, container — not consumer password managers).

## Lint regression-fence test
Updated `test/lint-duplicates.test.ts` to drop the Proton Pass assertion (Proton Mail still flagged as expected).

## Stats
- Offers: 1,582 → 1,581
- Tests: 1,096 passing (unchanged)
- Lint candidates: 4 → 3 (Airtable, Canva, Proton Mail remaining)

## Verification
- `npm run lint:duplicates` confirms Proton Pass no longer flagged; 3 candidates remain
- Full `npm test --test-concurrency=1`: 1,096/1,096 passing
- Local E2E: `/security-alternatives` returns HTTP 200 and contains 0 Proton Pass references
- Local E2E: `/api/offers?category=Password%20Managers` returns 6 entries including Proton Pass

Refs #985