### PR TITLE
Resolve fuzzy /vendor/:slug 404s to canonical URLs

### DIFF
--- a/src/serve.ts
+++ b/src/serve.ts
@@ -435,6 +435,59 @@ function getVendorCategory(vendorName: string): string | null {
   return vendorCategoryMap.get(vendorName.toLowerCase()) ?? null;
 }
 
+// Resolve a user-typed vendor slug to its canonical form via substring matching
+// against the known vendor slug map. Returns:
+//   - exact: the slug matches a known vendor — caller should render normally
+//   - redirect: one root match — caller should 301 to the canonical slug
+//   - disambiguate: multiple distinct root matches — caller should render a "did you mean?" page
+//   - none: no match — caller should render 404
+// The "root" filter collapses parent/child slug pairs (e.g. amazon-kiro vs
+// amazon-kiro-aws-startups): a child slug that extends a sibling root is dropped.
+type VendorSlugResolution =
+  | { type: "exact"; slug: string }
+  | { type: "redirect"; slug: string }
+  | { type: "disambiguate"; slugs: string[] }
+  | { type: "none" };
+
+// `needle` is a sub-slug of `haystack` when it appears at slug-segment boundaries
+// (i.e., bounded by "-" or start/end of string). Avoids false matches where the
+// input is embedded mid-segment (e.g., "tally" inside "totally" should NOT match).
+function isSubSlug(needle: string, haystack: string): boolean {
+  if (needle === haystack) return true;
+  if (haystack.startsWith(needle + "-")) return true;
+  if (haystack.endsWith("-" + needle)) return true;
+  return haystack.includes("-" + needle + "-");
+}
+
+function resolveVendorSlug(input: string): VendorSlugResolution {
+  if (!input) return { type: "none" };
+  if (vendorSlugMap.has(input)) return { type: "exact", slug: input };
+  if (input.length < 3) return { type: "none" };
+
+  const allSlugs = [...vendorSlugMap.keys()];
+
+  // Completions: known slugs that contain the input as a sub-slug (short-form lookups like "kiro")
+  const completions = allSlugs.filter(s => s !== input && isSubSlug(input, s));
+  if (completions.length > 0) {
+    // Drop any completion that is a "-"-delimited extension of another completion
+    // (e.g., prefer amazon-kiro over amazon-kiro-aws-startups).
+    const roots = completions.filter(
+      s => !completions.some(other => other !== s && s.startsWith(other + "-"))
+    );
+    if (roots.length === 1) return { type: "redirect", slug: roots[0] };
+    return { type: "disambiguate", slugs: roots.slice(0, 10).sort() };
+  }
+
+  // Generalizations: known slugs that are sub-slugs of the input (extra-specific lookups)
+  const generalizations = allSlugs.filter(s => s !== input && isSubSlug(s, input));
+  if (generalizations.length > 0) {
+    const longest = generalizations.reduce((a, b) => (b.length > a.length ? b : a));
+    return { type: "redirect", slug: longest };
+  }
+
+  return { type: "none" };
+}
+
 function escHtmlServer(s: string): string {
   return s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;");
 }
@@ -54293,12 +54346,23 @@ ${catList}
     res.end(buildVendorIndexPage());
   } else if (url.pathname.startsWith("/vendor/") && isGetOrHead) {
     const slug = url.pathname.slice("/vendor/".length).replace(/\/$/, "");
-    const html = buildVendorPage(slug);
-    if (html) {
+    const resolution = resolveVendorSlug(slug);
+    if (resolution.type === "exact") {
+      const html = buildVendorPage(resolution.slug)!;
       recordApiHit("/vendor/:slug");
       logRequest({ ts: new Date().toISOString(), type: "api", endpoint: "/vendor/" + slug, params: {}, user_agent: req.headers["user-agent"] ?? "unknown", result_count: 1 });
       res.writeHead(200, { "Content-Type": "text/html; charset=utf-8", "Cache-Control": "public, max-age=3600" });
       res.end(html);
+    } else if (resolution.type === "redirect") {
+      res.writeHead(301, { "Location": "/vendor/" + resolution.slug });
+      res.end();
+    } else if (resolution.type === "disambiguate") {
+      const links = resolution.slugs.map(s => {
+        const name = vendorSlugMap.get(s) ?? s;
+        return `<li><a href="/vendor/${encodeURIComponent(s)}">${escHtmlServer(name)}</a></li>`;
+      }).join("");
+      res.writeHead(200, { "Content-Type": "text/html; charset=utf-8" });
+      res.end(`<!DOCTYPE html><html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><title>Did you mean? — AgentDeals</title><style>body{font-family:-apple-system,sans-serif;background:#0f172a;color:#f1f5f9;display:flex;align-items:center;justify-content:center;min-height:100vh;margin:0}a{color:#3b82f6}.box{text-align:center;max-width:480px;padding:2rem}ul{list-style:none;padding:0;margin:1rem 0;text-align:left}li{padding:.4rem 0}</style></head><body><div class="box"><h1 style="font-size:2rem;margin-bottom:.5rem">Did you mean?</h1><p>Multiple vendors match "<strong>${escHtmlServer(slug)}</strong>".</p><ul>${links}</ul><p style="margin-top:1rem"><a href="/vendor">Browse all ${vendorSlugMap.size} vendors</a></p></div></body></html>`);
     } else {
       res.writeHead(404, { "Content-Type": "text/html; charset=utf-8" });
       res.end(`<!DOCTYPE html><html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><title>Vendor not found — AgentDeals</title><style>body{font-family:-apple-system,sans-serif;background:#0f172a;color:#f1f5f9;display:flex;align-items:center;justify-content:center;min-height:100vh;margin:0}a{color:#3b82f6}.box{text-align:center;max-width:480px;padding:2rem}</style></head><body><div class="box"><h1 style="font-size:3rem;margin-bottom:.5rem">404</h1><p>Vendor "<strong>${escHtmlServer(slug)}</strong>" not found.</p><p style="margin-top:1rem"><a href="/vendor">Browse all ${vendorSlugMap.size} vendors</a></p></div></body></html>`);

--- a/test/http.test.ts
+++ b/test/http.test.ts
@@ -1487,6 +1487,56 @@ describe("HTTP transport", () => {
     assert.strictEqual(response.headers.get("location"), "/vendor/vercel");
   });
 
+  // Vendor slug alias resolution (issue #989): substring match against vendorSlugMap
+  // so short-form lookups like /vendor/kiro resolve to the canonical slug instead of 404.
+  it("GET /vendor/kiro 301-redirects to /vendor/amazon-kiro", async () => {
+    proc = await startHttpServer();
+
+    const response = await fetch(`http://localhost:${serverPort}/vendor/kiro`, { redirect: "manual" });
+    assert.strictEqual(response.status, 301);
+    assert.strictEqual(response.headers.get("location"), "/vendor/amazon-kiro");
+  });
+
+  it("GET /vendor/qwen 301-redirects to /vendor/alibaba-cloud-qwen-code", async () => {
+    proc = await startHttpServer();
+
+    const response = await fetch(`http://localhost:${serverPort}/vendor/qwen`, { redirect: "manual" });
+    assert.strictEqual(response.status, 301);
+    assert.strictEqual(response.headers.get("location"), "/vendor/alibaba-cloud-qwen-code");
+  });
+
+  it("GET /vendor/proton renders a disambiguation page listing all Proton products", async () => {
+    proc = await startHttpServer();
+
+    const response = await fetch(`http://localhost:${serverPort}/vendor/proton`, { redirect: "manual" });
+    assert.strictEqual(response.status, 200);
+    const html = await response.text();
+    assert.ok(html.includes("Did you mean?"), "Should show disambiguation heading");
+    assert.ok(html.includes('href="/vendor/proton-mail"'), "Should link to Proton Mail");
+    assert.ok(html.includes('href="/vendor/proton-drive"'), "Should link to Proton Drive");
+    assert.ok(html.includes('href="/vendor/proton-pass"'), "Should link to Proton Pass");
+    assert.ok(html.includes('href="/vendor/proton-vpn"'), "Should link to Proton VPN");
+  });
+
+  it("GET /vendor/totally-bogus-slug-xyz returns 404 with no redirect", async () => {
+    proc = await startHttpServer();
+
+    const response = await fetch(`http://localhost:${serverPort}/vendor/totally-bogus-slug-xyz`, { redirect: "manual" });
+    assert.strictEqual(response.status, 404);
+    const html = await response.text();
+    assert.ok(html.includes("404"), "Should show 404");
+    assert.ok(html.includes("totally-bogus-slug-xyz"), "Should echo the invalid slug");
+  });
+
+  it("GET /vendor/vercel still renders the vendor profile page (no regression)", async () => {
+    proc = await startHttpServer();
+
+    const response = await fetch(`http://localhost:${serverPort}/vendor/vercel`, { redirect: "manual" });
+    assert.strictEqual(response.status, 200);
+    const html = await response.text();
+    assert.ok(html.includes("Vercel"), "Should render Vercel profile page");
+  });
+
   it("GET /trends returns trends index page", async () => {
     proc = await startHttpServer();
 


### PR DESCRIPTION
Refs #989

## Summary

Adds a slug-aware substring resolver to the `/vendor/:slug` handler so short-form lookups (kiro, qwen, proton) resolve to canonical URLs instead of returning a bare 404.

## Behavior

| Request | Response | Notes |
|---|---|---|
| `GET /vendor/kiro` | **301** → `/vendor/amazon-kiro` | Drops the AWS Startups child slug via root-collapse |
| `GET /vendor/qwen` | **301** → `/vendor/alibaba-cloud-qwen-code` | Sole match |
| `GET /vendor/proton` | **200** disambiguation page | Lists Proton Mail/Drive/Pass/VPN as links |
| `GET /vendor/totally-bogus-slug-xyz` | **404** | Unchanged behavior |
| `GET /vendor/vercel` | **200** | Unchanged happy path |

## Algorithm

`resolveVendorSlug(input)` returns one of:
- **exact** — `vendorSlugMap.has(input)` → render normally
- **redirect** — exactly one "root" candidate → 301
- **disambiguate** — multiple root candidates → "Did you mean?" page
- **none** — no candidates → 404

Candidate discovery uses **sub-slug matching** at `-`-segment boundaries. `kiro` matches `amazon-kiro` (suffix-bounded by `-`) but `tally` does NOT match `totally` (mid-segment). This is the bug that the first test pass surfaced — `/vendor/totally-bogus-slug-xyz` was 301-ing because `tally` is a substring of `totally`.

Two candidate buckets:
1. **Completions** (slugs that contain the input) — for short-form lookups like `kiro` → `amazon-kiro`. If multiple completions exist and one is a `-`-prefix of others (parent/child), the children are dropped — that's how `kiro` resolves to `amazon-kiro` (parent) rather than disambiguating against `amazon-kiro-aws-startups` (child).
2. **Generalizations** (slugs contained by the input) — for extra-specific lookups; the longest match wins. Only consulted if no completions exist.

Inputs shorter than 3 chars short-circuit to `none` to avoid noisy fuzzy matching on common short strings.

## AC coverage

| AC | Status | Test |
|----|--------|------|
| 1. `/vendor/kiro` → 301 → `/vendor/amazon-kiro` | ✅ | `GET /vendor/kiro 301-redirects to /vendor/amazon-kiro` |
| 2. `/vendor/qwen` → 301 → `/vendor/alibaba-cloud-qwen-code` | ✅ | `GET /vendor/qwen 301-redirects to /vendor/alibaba-cloud-qwen-code` |
| 3. `/vendor/proton` → 200 disambiguation page | ✅ | `GET /vendor/proton renders a disambiguation page listing all Proton products` |
| 4. `/vendor/totally-bogus-slug-xyz` → 404 | ✅ | `GET /vendor/totally-bogus-slug-xyz returns 404 with no redirect` |
| 5. `/vendor/vercel` → 200 (no regression) | ✅ | `GET /vendor/vercel still renders the vendor profile page (no regression)` + existing `/vendor/:slug renders vendor profile page` test |
| 6. recordApiHit fires once per redirect chain | ✅ | E2E verified: `/api/metrics` `vendor_slug` hits went 102 → 103 after `curl -L /vendor/kiro` (single increment) |
| 7. Test coverage for all cases | ✅ | 5 new tests added |

## E2E verification

```
$ curl -I http://localhost:PORT/vendor/kiro
HTTP/1.1 301 Moved Permanently
Location: /vendor/amazon-kiro

$ curl -I http://localhost:PORT/vendor/qwen
HTTP/1.1 301 Moved Permanently
Location: /vendor/alibaba-cloud-qwen-code

$ curl http://localhost:PORT/vendor/proton | grep "Did you mean"
<h1 ...>Did you mean?</h1>
# Lists Proton Drive, Proton Mail, Proton Pass, Proton VPN as links

$ curl -I http://localhost:PORT/vendor/totally-bogus-slug-xyz
HTTP/1.1 404 Not Found

$ curl -I http://localhost:PORT/vendor/vercel
HTTP/1.1 200 OK
```

Metrics counter sanity check: `vendor_slug` endpoint counter went `102 → 103` after `curl -L /vendor/kiro` (one client request, follows 301 to `/vendor/amazon-kiro`). Single increment confirms no double-count.

## Notes & decisions

- **Disambiguation page does not call `recordApiHit`.** Mirrors current 404 behavior (also doesn't track) — keeps the existing endpoint counter focused on rendered profile pages. If we want disambiguation analytics later, easy follow-up to add a `/vendor/:slug/disambiguation` counter.
- **Disambiguation page chrome.** Same dark-mode minimalist style as the existing 404 page, with an unordered link list. No Cache-Control header (caching ambiguous resolutions is risky as data evolves).
- **Out-of-scope routes** (`/compare/:slug`, `/alternative-to/:slug`, `/best/:slug`, `/trends/:slug`) NOT included in this PR — the issue marked them as suggested follow-up. The `resolveVendorSlug` helper is module-private but easily extractable when a follow-up issue lands. Keeping this PR scoped to the one route the issue specifically called out.
- **Length guard.** Inputs <3 chars short-circuit to `none` to avoid surfacing dozens of matches on inputs like "ai" or "io". `kiro`/`qwen`/`proton` are all ≥4 chars so unaffected.

## Test plan

- [x] `npm test` (1101 tests, +5 new) — all pass on `--test-concurrency=1`
- [x] E2E via local server with `PORT=… BASE_URL=http://localhost:…`
- [x] Verified `/api/metrics` counter increments once per redirect chain

🤖 Generated with [Claude Code](https://claude.com/claude-code)