### PR TITLE
Extend /vendor/:slug alias resolver to /alternative-to/:slug

### DIFF
--- a/src/serve.ts
+++ b/src/serve.ts
@@ -54509,12 +54509,23 @@ ${catList}
     res.end(buildAlternativesIndexPage());
   } else if (url.pathname.startsWith("/alternative-to/") && isGetOrHead) {
     const slug = url.pathname.slice("/alternative-to/".length).replace(/\/$/, "");
-    const html = buildAlternativesPage(slug);
-    if (html) {
+    const resolution = resolveVendorSlug(slug);
+    if (resolution.type === "exact") {
+      const html = buildAlternativesPage(resolution.slug)!;
       recordApiHit("/alternative-to/:slug");
       logRequest({ ts: new Date().toISOString(), type: "api", endpoint: "/alternative-to/" + slug, params: {}, user_agent: req.headers["user-agent"] ?? "unknown", result_count: 1 });
       res.writeHead(200, { "Content-Type": "text/html; charset=utf-8", "Cache-Control": "public, max-age=3600" });
       res.end(html);
+    } else if (resolution.type === "redirect") {
+      res.writeHead(301, { "Location": "/alternative-to/" + resolution.slug });
+      res.end();
+    } else if (resolution.type === "disambiguate") {
+      const links = resolution.slugs.map(s => {
+        const name = vendorSlugMap.get(s) ?? s;
+        return `<li><a href="/alternative-to/${encodeURIComponent(s)}">${escHtmlServer(name)}</a></li>`;
+      }).join("");
+      res.writeHead(200, { "Content-Type": "text/html; charset=utf-8" });
+      res.end(`<!DOCTYPE html><html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><title>Did you mean? — AgentDeals</title><style>body{font-family:-apple-system,sans-serif;background:#0f172a;color:#f1f5f9;display:flex;align-items:center;justify-content:center;min-height:100vh;margin:0}a{color:#3b82f6}.box{text-align:center;max-width:480px;padding:2rem}ul{list-style:none;padding:0;margin:1rem 0;text-align:left}li{padding:.4rem 0}</style></head><body><div class="box"><h1 style="font-size:2rem;margin-bottom:.5rem">Did you mean?</h1><p>Multiple vendors match "<strong>${escHtmlServer(slug)}</strong>".</p><ul>${links}</ul><p style="margin-top:1rem"><a href="/alternative-to">Browse all alternatives</a></p></div></body></html>`);
     } else {
       res.writeHead(404, { "Content-Type": "text/html; charset=utf-8" });
       res.end(`<!DOCTYPE html><html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><title>Vendor not found — AgentDeals</title><style>body{font-family:-apple-system,sans-serif;background:#0f172a;color:#f1f5f9;display:flex;align-items:center;justify-content:center;min-height:100vh;margin:0}a{color:#3b82f6}.box{text-align:center;max-width:480px;padding:2rem}</style></head><body><div class="box"><h1 style="font-size:3rem;margin-bottom:.5rem">404</h1><p>Vendor "<strong>${escHtmlServer(slug)}</strong>" not found.</p><p style="margin-top:1rem"><a href="/alternative-to">Browse all alternatives</a></p></div></body></html>`);

--- a/test/http.test.ts
+++ b/test/http.test.ts
@@ -1620,6 +1620,56 @@ describe("HTTP transport", () => {
     assert.ok(html.includes("/alternative-to"), "Should link to alternatives index");
   });
 
+  // Slug alias resolution on /alternative-to/:slug (issue #991) mirrors /vendor/:slug
+  // behavior from #989/PR #990 — same resolveVendorSlug helper, different route prefix.
+  it("GET /alternative-to/kiro 301-redirects to /alternative-to/amazon-kiro", async () => {
+    proc = await startHttpServer();
+
+    const response = await fetch(`http://localhost:${serverPort}/alternative-to/kiro`, { redirect: "manual" });
+    assert.strictEqual(response.status, 301);
+    assert.strictEqual(response.headers.get("location"), "/alternative-to/amazon-kiro");
+  });
+
+  it("GET /alternative-to/qwen 301-redirects to /alternative-to/alibaba-cloud-qwen-code", async () => {
+    proc = await startHttpServer();
+
+    const response = await fetch(`http://localhost:${serverPort}/alternative-to/qwen`, { redirect: "manual" });
+    assert.strictEqual(response.status, 301);
+    assert.strictEqual(response.headers.get("location"), "/alternative-to/alibaba-cloud-qwen-code");
+  });
+
+  it("GET /alternative-to/proton renders a disambiguation page listing all Proton products", async () => {
+    proc = await startHttpServer();
+
+    const response = await fetch(`http://localhost:${serverPort}/alternative-to/proton`, { redirect: "manual" });
+    assert.strictEqual(response.status, 200);
+    const html = await response.text();
+    assert.ok(html.includes("Did you mean?"), "Should show disambiguation heading");
+    assert.ok(html.includes('href="/alternative-to/proton-mail"'), "Should link to Proton Mail");
+    assert.ok(html.includes('href="/alternative-to/proton-drive"'), "Should link to Proton Drive");
+    assert.ok(html.includes('href="/alternative-to/proton-pass"'), "Should link to Proton Pass");
+    assert.ok(html.includes('href="/alternative-to/proton-vpn"'), "Should link to Proton VPN");
+  });
+
+  it("GET /alternative-to/totally-bogus-slug-xyz returns 404 with no redirect", async () => {
+    proc = await startHttpServer();
+
+    const response = await fetch(`http://localhost:${serverPort}/alternative-to/totally-bogus-slug-xyz`, { redirect: "manual" });
+    assert.strictEqual(response.status, 404);
+    const html = await response.text();
+    assert.ok(html.includes("404"), "Should show 404");
+    assert.ok(html.includes("totally-bogus-slug-xyz"), "Should echo the invalid slug");
+  });
+
+  it("GET /alternative-to/amazon-kiro still renders canonical slug (no regression)", async () => {
+    proc = await startHttpServer();
+
+    const response = await fetch(`http://localhost:${serverPort}/alternative-to/amazon-kiro`, { redirect: "manual" });
+    assert.strictEqual(response.status, 200);
+    const html = await response.text();
+    assert.ok(html.includes("Amazon Kiro"), "Should render Amazon Kiro alternatives page");
+  });
+
   it("sitemap-pages.xml includes alternative-to pages", async () => {
     proc = await startHttpServer();
 


### PR DESCRIPTION
Refs #991

## Summary

- `/alternative-to/:slug` now routes through `resolveVendorSlug()` — the same helper shipped in PR #990 for `/vendor/:slug`. Short/fuzzy slugs (`kiro`, `qwen`, `proton`) resolve to their canonical form instead of bare 404s.
- **No helper extraction needed** — `resolveVendorSlug` and `vendorSlugMap` are already module-level in `src/serve.ts`, so the `/alternative-to/:slug` handler can call them directly. Issue body said "extract to helper module or exported"; in reality reuse is free because both handlers share the same module scope.
- **Disambiguation chrome** mirrors the `/vendor/` styling (same Did-you-mean? page), with links pointing to `/alternative-to/<canonical>` instead of `/vendor/<canonical>` per AC #3.

## Behavior

| Request | Before | After |
|---|---|---|
| `GET /alternative-to/kiro` | 404 | **301 → `/alternative-to/amazon-kiro`** |
| `GET /alternative-to/qwen` | 404 | **301 → `/alternative-to/alibaba-cloud-qwen-code`** |
| `GET /alternative-to/proton` | 404 | **200 disambiguation page** listing Drive/Mail/Pass/VPN |
| `GET /alternative-to/totally-bogus-slug-xyz` | 404 | 404 (unchanged) |
| `GET /alternative-to/amazon-kiro` | 200 | 200 (unchanged — canonical) |

## Acceptance criteria

- [x] 1. `GET /alternative-to/kiro` → 301 → `/alternative-to/amazon-kiro`
- [x] 2. `GET /alternative-to/qwen` → 301 → `/alternative-to/alibaba-cloud-qwen-code`
- [x] 3. `GET /alternative-to/proton` → 200 disambiguation page linking to all 4 Proton products
- [x] 4. `GET /alternative-to/totally-bogus-slug-xyz` → 404 (no regression)
- [x] 5. `GET /alternative-to/amazon-kiro` → 200 (no regression on canonical path)
- [x] 6. `recordApiHit` fires exactly once per redirect chain (verified: `/alternative-to/:slug` counter 31 → 32 after `curl -L kiro`)
- [x] 7. Test coverage mirrors the 5 new tests added in PR #990

## Test plan

- [x] 1,106 tests pass locally (`npm test`, `--test-concurrency=1`) — +5 new in test/http.test.ts
- [x] `npm run lint` (tsc --noEmit) clean
- [x] E2E: all 5 curl scenarios above verified against a local `dist/serve.js` on :8787
- [x] Counter-increment: confirmed `api_hits_by_endpoint["/alternative-to/:slug"]` increments exactly once per `curl -L`