### PR TITLE
Per-client tool-call attribution in /api/stats (Refs #992)

### DIFF
--- a/src/openapi.ts
+++ b/src/openapi.ts
@@ -819,7 +819,8 @@ export const openapiSpec = {
                     totalToolCallsAllTime: { type: "integer", description: "Cumulative MCP tool calls across all deploys (persisted in Redis)" },
                     sessionsToday: { type: "integer", description: "Sessions since midnight UTC (resets daily)" },
                     serverStarted: { type: "string", format: "date-time", description: "ISO timestamp of current server start" },
-                    clients: { type: "object", additionalProperties: { type: "integer" }, description: "Cumulative session counts per MCP client name (e.g. claude-desktop, cursor)" }
+                    clients: { type: "object", additionalProperties: { type: "integer" }, description: "Cumulative session counts per MCP client name (e.g. claude-desktop, cursor)" },
+                    toolCallsByClient: { type: "object", additionalProperties: { type: "integer" }, description: "Cumulative MCP tool-call counts per MCP client name. Missing/empty client IDs bucket to 'unknown'. Values sum to totalToolCallsAllTime (invariant)." }
                   }
                 }
               }

--- a/src/serve.ts
+++ b/src/serve.ts
@@ -53217,7 +53217,13 @@ const httpServer = createHttpServer(async (req, res) => {
           }
         };
 
-        const mcpServer = createServer(() => transport.sessionId);
+        const mcpServer = createServer(
+          () => transport.sessionId,
+          () => {
+            const sid = transport.sessionId;
+            return sid ? sessions.get(sid)?.clientInfo?.name : undefined;
+          },
+        );
         await mcpServer.connect(transport);
         await transport.handleRequest(req, res, parsedBody);
       } else {

--- a/src/server.ts
+++ b/src/server.ts
@@ -35,7 +35,7 @@ function toConciseDealChange(change: DealChange) {
   return { vendor: change.vendor, change_type: change.change_type, date: change.date, summary: change.summary };
 }
 
-export function createServer(getSessionId?: () => string | undefined): McpServer {
+export function createServer(getSessionId?: () => string | undefined, getClientName?: () => string | undefined): McpServer {
   const server = new McpServer(
     {
       name: "agentdeals",
@@ -75,7 +75,7 @@ export function createServer(getSessionId?: () => string | undefined): McpServer
     },
     async ({ query, category, vendor, eligibility, sort, stability, payment_protocol, since, limit, offset, response_format }) => {
       try {
-        recordToolCall("search_deals");
+        recordToolCall("search_deals", getClientName?.());
 
         // Mode: list categories
         if (category === "list") {
@@ -204,7 +204,7 @@ export function createServer(getSessionId?: () => string | undefined): McpServer
     },
     async ({ mode, use_case, services, scale, requirements }) => {
       try {
-        recordToolCall("plan_stack");
+        recordToolCall("plan_stack", getClientName?.());
 
         if (mode === "recommend") {
           if (!use_case) {
@@ -281,7 +281,7 @@ export function createServer(getSessionId?: () => string | undefined): McpServer
     },
     async ({ vendors, include_risk }) => {
       try {
-        recordToolCall("compare_vendors");
+        recordToolCall("compare_vendors", getClientName?.());
         const doRisk = include_risk !== false;
 
         // Single vendor = risk check
@@ -394,7 +394,7 @@ export function createServer(getSessionId?: () => string | undefined): McpServer
     },
     async ({ since, change_type, vendor, vendors, categories, include_expiring, lookahead_days, response_format }) => {
       try {
-        recordToolCall("track_changes");
+        recordToolCall("track_changes", getClientName?.());
 
         // No params = weekly digest
         if (!since && !change_type && !vendor && !vendors && !categories && include_expiring === undefined) {
@@ -959,7 +959,7 @@ Suggested monitoring cadence: run this check weekly to catch pricing changes ear
     },
     async ({ name, vestauth_public_key_url }) => {
       try {
-        recordToolCall("register_agent");
+        recordToolCall("register_agent", getClientName?.());
 
         if (vestauth_public_key_url) {
           const validation = await validateVestauthUrl(vestauth_public_key_url);
@@ -1023,7 +1023,7 @@ Suggested monitoring cadence: run this check weekly to catch pricing changes ear
     },
     async ({ vendor, api_key }) => {
       try {
-        recordToolCall("get_referral_code");
+        recordToolCall("get_referral_code", getClientName?.());
 
         const referralData = getVendorReferral(vendor);
         if (!referralData) {
@@ -1088,7 +1088,7 @@ Suggested monitoring cadence: run this check weekly to catch pricing changes ear
     },
     async ({ api_key }) => {
       try {
-        recordToolCall("check_balance");
+        recordToolCall("check_balance", getClientName?.());
 
         const hash = hashApiKey(api_key);
         const agent = getAgentByApiKeyHash(hash);
@@ -1139,7 +1139,7 @@ Suggested monitoring cadence: run this check weekly to catch pricing changes ear
     },
     async ({ api_key }) => {
       try {
-        recordToolCall("request_payout");
+        recordToolCall("request_payout", getClientName?.());
 
         const hash = hashApiKey(api_key);
         const agent = getAgentByApiKeyHash(hash);
@@ -1239,7 +1239,7 @@ Suggested monitoring cadence: run this check weekly to catch pricing changes ear
     },
     async ({ vendor, code, referral_url, description, commission_rate, expiry, api_key }) => {
       try {
-        recordToolCall("submit_referral_code");
+        recordToolCall("submit_referral_code", getClientName?.());
 
         const hash = hashApiKey(api_key);
         const agent = getAgentByApiKeyHash(hash);
@@ -1299,7 +1299,7 @@ Suggested monitoring cadence: run this check weekly to catch pricing changes ear
     },
     async ({ api_key }) => {
       try {
-        recordToolCall("my_referral_codes");
+        recordToolCall("my_referral_codes", getClientName?.());
 
         const hash = hashApiKey(api_key);
         const agent = getAgentByApiKeyHash(hash);
@@ -1356,7 +1356,7 @@ Suggested monitoring cadence: run this check weekly to catch pricing changes ear
     },
     async ({ limit, offset }) => {
       try {
-        recordToolCall("leaderboard");
+        recordToolCall("leaderboard", getClientName?.());
         const result = getLeaderboard({ limit, offset });
 
         logRequest({ ts: new Date().toISOString(), type: "mcp", endpoint: "leaderboard", params: { limit, offset }, result_count: result.entries.length, session_id: getSessionId?.() });
@@ -1395,7 +1395,7 @@ Suggested monitoring cadence: run this check weekly to catch pricing changes ear
     },
     async ({ api_key, action, agent_id }) => {
       try {
-        recordToolCall("manage_friends");
+        recordToolCall("manage_friends", getClientName?.());
         const hash = hashApiKey(api_key);
         const agent = getAgentByApiKeyHash(hash);
         if (!agent) {

--- a/src/stats.ts
+++ b/src/stats.ts
@@ -16,6 +16,11 @@ const toolCalls: Record<string, number> = {
   track_changes: 0,
 };
 
+// Per-client tool-call counts for the current deployment. Client IDs come from MCP initialize
+// clientInfo.name; missing/empty names bucket to "unknown". Cardinality bounded by distinct MCP
+// client populations seen in practice (<200 in production).
+const toolCallsByClient: Record<string, number> = {};
+
 // Per-endpoint hit counts for the current deployment. Accumulates dynamically — any endpoint passed
 // to recordApiHit is counted. Cardinality is bounded by route definitions (~150 endpoints).
 const apiHits: Record<string, number> = {};
@@ -35,6 +40,7 @@ let cumulative = {
   first_session_at: "",
   last_deploy_at: "",
   clients: {} as Record<string, number>,
+  tool_calls_by_client: {} as Record<string, number>,
   referral_listing_calls: 0,
   referral_listing_by_source: { platform: 0, agent: 0, null: 0 } as Record<"platform" | "agent" | "null", number>,
   referral_vendor_lookups: 0,
@@ -79,6 +85,7 @@ interface TelemetryData {
   first_session_at: string;
   last_deploy_at: string;
   cumulative_clients?: Record<string, number>;
+  cumulative_tool_calls_by_client?: Record<string, number>;
   cumulative_referral_listing_calls?: number;
   cumulative_referral_listing_by_source?: Record<"platform" | "agent" | "null", number>;
   cumulative_referral_vendor_lookups?: number;
@@ -217,6 +224,16 @@ function parseTelemetryData(data: Record<string, unknown>): void {
   cumulative.first_session_at = (data.first_session_at as string) ?? "";
   cumulative.last_deploy_at = (data.last_deploy_at as string) ?? "";
   cumulative.clients = (data.cumulative_clients as Record<string, number>) ?? {};
+  cumulative.tool_calls_by_client = (data.cumulative_tool_calls_by_client as Record<string, number>) ?? {};
+  // One-time backfill: if persisted cumulative_tool_calls is greater than the sum of per-client
+  // buckets (e.g. first load after this feature ships — all prior calls were untracked by client),
+  // attribute the delta to "unknown" so the sum(toolCallsByClient) == totalToolCallsAllTime
+  // invariant holds from this deploy onward.
+  const byClientSum = Object.values(cumulative.tool_calls_by_client).reduce((a, b) => a + b, 0);
+  if (cumulative.tool_calls > byClientSum) {
+    const delta = cumulative.tool_calls - byClientSum;
+    cumulative.tool_calls_by_client.unknown = (cumulative.tool_calls_by_client.unknown ?? 0) + delta;
+  }
   cumulative.referral_listing_calls = (data.cumulative_referral_listing_calls as number) ?? 0;
   const listingBySource = (data.cumulative_referral_listing_by_source as Record<string, number>) ?? {};
   cumulative.referral_listing_by_source = {
@@ -261,6 +278,11 @@ function buildTelemetryData(): TelemetryData {
   for (const [name, count] of Object.entries(sessionClients)) {
     mergedClients[name] = (mergedClients[name] ?? 0) + count;
   }
+  // Merge cumulative + current deployment per-client tool-call counts
+  const mergedToolCallsByClient: Record<string, number> = { ...cumulative.tool_calls_by_client };
+  for (const [name, count] of Object.entries(toolCallsByClient)) {
+    mergedToolCallsByClient[name] = (mergedToolCallsByClient[name] ?? 0) + count;
+  }
   // Merge referral vendor counts (cumulative + current deployment)
   const mergedVendorCounts: Record<string, number> = { ...cumulative.referral_vendor_counts };
   for (const [vendor, count] of Object.entries(referralVendorCounts)) {
@@ -279,6 +301,7 @@ function buildTelemetryData(): TelemetryData {
     first_session_at: cumulative.first_session_at || (totalSessions > 0 ? serverStartedISO : ""),
     last_deploy_at: cumulative.last_deploy_at,
     cumulative_clients: mergedClients,
+    cumulative_tool_calls_by_client: mergedToolCallsByClient,
     cumulative_referral_listing_calls: cumulative.referral_listing_calls + referralListingCalls,
     cumulative_referral_listing_by_source: {
       platform: cumulative.referral_listing_by_source.platform + referralListingBySource.platform,
@@ -342,6 +365,7 @@ export function resetCounters(): void {
   for (const key of Object.keys(toolCalls)) toolCalls[key] = 0;
   for (const key of Object.keys(apiHits)) delete apiHits[key];
   for (const key of Object.keys(sessionClients)) delete sessionClients[key];
+  for (const key of Object.keys(toolCallsByClient)) delete toolCallsByClient[key];
   cumulative.sessions = 0;
   cumulative.tool_calls = 0;
   cumulative.api_hits = 0;
@@ -349,6 +373,7 @@ export function resetCounters(): void {
   cumulative.first_session_at = "";
   cumulative.last_deploy_at = "";
   cumulative.clients = {};
+  cumulative.tool_calls_by_client = {};
   referralListingCalls = 0;
   referralListingBySource.platform = 0;
   referralListingBySource.agent = 0;
@@ -363,9 +388,11 @@ export function resetCounters(): void {
   searchQueryLog.length = 0;
 }
 
-export function recordToolCall(tool: string): void {
+export function recordToolCall(tool: string, clientName?: string): void {
   if (tool in toolCalls) {
     toolCalls[tool]++;
+    const bucket = (clientName && clientName.trim()) || "unknown";
+    toolCallsByClient[bucket] = (toolCallsByClient[bucket] ?? 0) + 1;
   }
 }
 
@@ -547,6 +574,7 @@ export function getConnectionStats(activeSessions: number): {
   sessionsToday: number;
   serverStarted: string;
   clients: Record<string, number>;
+  toolCallsByClient: Record<string, number>;
 } {
   const today = new Date().toISOString().slice(0, 10);
   if (today !== sessionsTodayDate) {
@@ -560,6 +588,10 @@ export function getConnectionStats(activeSessions: number): {
   for (const [name, count] of Object.entries(sessionClients)) {
     mergedClients[name] = (mergedClients[name] ?? 0) + count;
   }
+  const mergedToolCallsByClient: Record<string, number> = { ...cumulative.tool_calls_by_client };
+  for (const [name, count] of Object.entries(toolCallsByClient)) {
+    mergedToolCallsByClient[name] = (mergedToolCallsByClient[name] ?? 0) + count;
+  }
   return {
     activeSessions,
     totalSessionsAllTime: cumulative.sessions + totalSessions,
@@ -568,6 +600,7 @@ export function getConnectionStats(activeSessions: number): {
     sessionsToday,
     serverStarted: serverStartedISO,
     clients: mergedClients,
+    toolCallsByClient: mergedToolCallsByClient,
   };
 }
 

--- a/test/stats.test.ts
+++ b/test/stats.test.ts
@@ -36,6 +36,41 @@ describe("stats", () => {
       const stats = getStats();
       assert.strictEqual(stats.total_tool_calls, 0);
     });
+
+    it("tracks per-client tool-call counts when clientName provided", () => {
+      recordToolCall("search_deals", "opencode");
+      recordToolCall("search_deals", "opencode");
+      recordToolCall("plan_stack", "MintMCP Client");
+      const conn = getConnectionStats(0);
+      assert.strictEqual(conn.toolCallsByClient.opencode, 2);
+      assert.strictEqual(conn.toolCallsByClient["MintMCP Client"], 1);
+    });
+
+    it("buckets missing client names under 'unknown'", () => {
+      recordToolCall("search_deals");
+      recordToolCall("compare_vendors", "");
+      recordToolCall("track_changes", "   ");
+      const conn = getConnectionStats(0);
+      assert.strictEqual(conn.toolCallsByClient.unknown, 3);
+    });
+
+    it("does not increment toolCallsByClient for unknown tool names", () => {
+      recordToolCall("nonexistent_tool", "opencode");
+      const conn = getConnectionStats(0);
+      assert.strictEqual(conn.toolCallsByClient.opencode, undefined);
+    });
+
+    it("sum of toolCallsByClient equals totalToolCallsAllTime (invariant)", () => {
+      recordToolCall("search_deals", "opencode");
+      recordToolCall("search_deals", "cursor");
+      recordToolCall("plan_stack", "opencode");
+      recordToolCall("compare_vendors");
+      recordToolCall("track_changes", "MintMCP Client");
+      const conn = getConnectionStats(0);
+      const sum = Object.values(conn.toolCallsByClient).reduce((a: number, b: number) => a + b, 0);
+      assert.strictEqual(sum, conn.totalToolCallsAllTime);
+      assert.strictEqual(sum, 5);
+    });
   });
 
   describe("recordApiHit", () => {

--- a/test/telemetry.test.ts
+++ b/test/telemetry.test.ts
@@ -91,6 +91,73 @@ describe("telemetry persistence", () => {
     assert.ok(typeof stats.cumulative_sessions === "number");
     assert.ok(typeof stats.last_deploy_at === "string");
   });
+
+  it("persists toolCallsByClient and preserves sum invariant across restart", async () => {
+    const tmpDirTC = join(tmpdir(), `telemetry-tc-${randomUUID()}`);
+    const filePath = join(tmpDirTC, "telemetry.json");
+    mkdirSync(tmpDirTC, { recursive: true });
+
+    resetCounters();
+    await loadTelemetry(filePath);
+
+    // First deploy: two clients rack up calls
+    const { recordToolCall: rec, getConnectionStats: conn } = await import("../src/stats.ts");
+    rec("search_deals", "opencode");
+    rec("search_deals", "opencode");
+    rec("plan_stack", "cursor");
+    rec("compare_vendors");
+    await flushTelemetry();
+
+    // Verify persisted shape
+    const persisted1 = JSON.parse(readFileSync(filePath, "utf-8"));
+    assert.strictEqual(persisted1.cumulative_tool_calls, 4);
+    assert.deepStrictEqual(persisted1.cumulative_tool_calls_by_client, {
+      opencode: 2, cursor: 1, unknown: 1,
+    });
+
+    // Simulate restart: reset in-memory, reload
+    resetCounters();
+    await loadTelemetry(filePath);
+
+    // Sum invariant should hold after reload
+    const c = conn(0);
+    const sum = Object.values(c.toolCallsByClient).reduce((a: number, b: number) => a + b, 0);
+    assert.strictEqual(sum, c.totalToolCallsAllTime);
+    assert.strictEqual(c.toolCallsByClient.opencode, 2);
+    assert.strictEqual(c.toolCallsByClient.cursor, 1);
+    assert.strictEqual(c.toolCallsByClient.unknown, 1);
+
+    rmSync(tmpDirTC, { recursive: true, force: true });
+  });
+
+  it("backfills 'unknown' bucket when cumulative_tool_calls exceeds per-client sum", async () => {
+    const tmpDirBF = join(tmpdir(), `telemetry-backfill-${randomUUID()}`);
+    const filePath = join(tmpDirBF, "telemetry.json");
+    mkdirSync(tmpDirBF, { recursive: true });
+
+    // Simulate pre-#992 telemetry: has tool_calls but no per-client breakdown yet
+    const legacy = {
+      cumulative_sessions: 100,
+      cumulative_tool_calls: 61,
+      cumulative_api_hits: 500,
+      cumulative_landing_views: 50,
+      first_session_at: "2026-03-01T00:00:00.000Z",
+      last_deploy_at: "2026-04-01T00:00:00.000Z",
+    };
+    writeFileSync(filePath, JSON.stringify(legacy));
+
+    resetCounters();
+    await loadTelemetry(filePath);
+
+    // The 61 legacy calls should appear under "unknown"
+    const { getConnectionStats: conn } = await import("../src/stats.ts");
+    const c = conn(0);
+    assert.strictEqual(c.toolCallsByClient.unknown, 61);
+    const sum = Object.values(c.toolCallsByClient).reduce((a: number, b: number) => a + b, 0);
+    assert.strictEqual(sum, c.totalToolCallsAllTime);
+
+    rmSync(tmpDirBF, { recursive: true, force: true });
+  });
 });
 
 describe("redis telemetry", () => {


### PR DESCRIPTION
## Summary

Adds `toolCallsByClient` map to `/api/stats` — per-client attribution of MCP tool calls. Enables analyzing the #977 observation window (closes 2026-04-29) by client, distinguishing real-agent tool usage from scanner/bot noise.

Refs #992.

## Implementation

- `recordToolCall(tool, clientName?)` — increments per-client counter alongside existing per-tool counter. Missing/empty names bucket to `"unknown"`.
- `createServer(getSessionId?, getClientName?)` — second optional accessor so `server.ts` tool handlers can forward the caller's client name to `recordToolCall`. Wired up in `serve.ts` via the existing sessions map (`clientInfo.name` captured at MCP `initialize`).
- Persisted as `cumulative_tool_calls_by_client` on telemetry.json (mirrors existing `cumulative_clients` pattern).
- **Backfill on load**: if `cumulative_tool_calls > sum(cumulative_tool_calls_by_client)` (first deploy after this ships — historical calls untracked), attribute the delta to `"unknown"` so AC #2 (sum invariant) holds from Day 1.

## Acceptance criteria

- [x] 1. `/api/stats` returns new `toolCallsByClient` map alongside `clients`
- [x] 2. Sum invariant: `sum(toolCallsByClient) == totalToolCallsAllTime`
- [x] 3. Counter persists across restarts (same file/Redis pattern)
- [x] 4. Missing/empty client IDs bucket to `"unknown"`
- [x] 5. Existing `/api/stats` fields unchanged (additive)
- [x] 6. Test coverage: unit-increment + sum-invariant integration

## Test plan

- [x] `npm test -- --test-concurrency=1` → 1112/1112 (+6 new tests)
- [x] E2E on `dist/serve.js` with `BASE_URL=http://localhost:4573`:
  - Fresh telemetry with 10 baseline `cumulative_tool_calls` → backfills `toolCallsByClient.unknown = 10` ✓
  - MCP `initialize` with `clientInfo.name = "e2e-verify-992"` + `search_deals` call → `toolCallsByClient.e2e-verify-992 = 1` ✓
  - Two more tool calls → bumps to `3` ✓
  - SIGTERM + restart → persists `{"unknown":10, "e2e-verify-992":3}`, sum invariant still holds ✓
- [x] OpenAPI spec updated (`/api/stats` schema includes `toolCallsByClient`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)