### PR TITLE
Consolidate Proton Mail duplicate entries into Consumer Email

### DIFF
--- a/data/index.json
+++ b/data/index.json
@@ -11939,35 +11939,6 @@
       "verifiedDate": "2026-04-12"
     },
     {
-      "vendor": "Proton Mail",
-      "category": "Email",
-      "description": "Free secure email account service provider with built-in end-to-end encryption. Free 1GB storage.",
-      "tier": "Free",
-      "url": "https://proton.me/mail",
-      "tags": [
-        "email",
-        "free-for-dev"
-      ],
-      "verifiedDate": "2026-04-12",
-      "referral": {
-        "url": "https://pr.tn/ref/60QXGJSB",
-        "type": "referral_link",
-        "source": "curated",
-        "submitted_by": null,
-        "verified_date": "2026-04-12",
-        "restrictions": [],
-        "phase1_eligible": true
-      },
-      "referral_program": {
-        "available": true,
-        "referrer_benefit": "Free months of service",
-        "referee_benefit": "Free months of service",
-        "program_url": "https://proton.me/support/referral-program",
-        "type": "self-service",
-        "commission_type": "credits"
-      }
-    },
-    {
       "vendor": "Sendpulse",
       "category": "Email",
       "description": "500 subscribers/month, 15,000 emails/month free",

--- a/src/serve.ts
+++ b/src/serve.ts
@@ -11278,7 +11278,7 @@ function buildEmailAlternativesPage(): string {
     ["mailsac.com", "10minutemail", "inboxkitten.com", "mailinator.com", "temp-mail.io", "EtherealMail", "debugmail.io", "mailcatcher.me", "Imitate Email", "Inboxes App"].includes(o.vendor)
   );
   const securePrivacy = enrichedAll.filter(o =>
-    ["Proton Mail", "Tuta"].includes(o.vendor)
+    ["Tuta"].includes(o.vendor)
   );
   const otherEmailTools = enrichedAll.filter(o =>
     ["Parsio.io", "EmailJS", "Contact.do", "Waitlio", "SendGrid"].includes(o.vendor)
@@ -11427,7 +11427,7 @@ ${buildCards(forwardingAliases)}
 ${buildCards(temporaryTesting)}
 
   <h2>Secure &amp; Privacy Email</h2>
-  <p style="color:var(--text-muted);margin-bottom:1rem">End-to-end encrypted email providers focused on privacy. Proton Mail and Tuta offer free tiers with full encryption — no ads, no tracking.</p>
+  <p style="color:var(--text-muted);margin-bottom:1rem">End-to-end encrypted email providers focused on privacy. Tuta offers a free tier with full encryption — no ads, no tracking. See also <a href="/vendor/proton-mail">Proton Mail</a> in our <a href="/category/consumer-email">Consumer Email</a> category.</p>
 ${buildCards(securePrivacy)}
 
   <h2>Other Email Tools</h2>

--- a/test/lint-duplicates.test.ts
+++ b/test/lint-duplicates.test.ts
@@ -152,14 +152,14 @@ describe("formatMarkdown", () => {
 });
 
 describe("lint-duplicates against current data/index.json", () => {
-  it("detects Proton Mail as a candidate", async () => {
+  it("detects Airtable as a candidate", async () => {
     const { readFileSync } = await import("node:fs");
     const { resolve } = await import("node:path");
     const indexPath = resolve(process.cwd(), "data", "index.json");
     const data = JSON.parse(readFileSync(indexPath, "utf-8"));
     const result = findDuplicateCandidates(data.offers || []);
     const vendors = result.map((c) => c.vendor);
-    assert(vendors.includes("Proton Mail"), `expected Proton Mail in ${vendors.join(", ")}`);
+    assert(vendors.includes("Airtable"), `expected Airtable in ${vendors.join(", ")}`);
   });
 
   it("does not flag Amazon Kiro (different vendor names)", async () => {


### PR DESCRIPTION
Flows from PR #985 lint advisory output. Seventh in the dedup series after #968 (Copilot), #982 (Windsurf), #983 (Notion), #986 (Figma), #987 (Telegram), #988 (Proton Pass).

## The duplicate

Two Proton Mail entries described the same Free plan in different categories:
- **Email** (54-entry grab-bag of transactional APIs, validators, disposable, forwarding — Resend/Postmark/Mailchimp/SendGrid/Substack/etc.)
- **Consumer Email** (4-entry vendor-specific peer group: Gmail, Outlook.com, Tutanota, Proton Mail)

## Category-judgment call

Kept **Consumer Email**. Same logic as Proton Pass PR #988 — inverts the Figma population heuristic: when the smaller category is vendor-specific (consumer email providers) and the larger is a grab-bag of email-adjacent dev tools, keep the smaller one. Proton Mail's actual peers (Gmail/Outlook/Tutanota) live in Consumer Email.

## No description merge needed

The kept Consumer Email entry already has the more comprehensive description ("1 GB storage. 150 messages/day send limit. 1 email address. End-to-end encrypted. Zero-access encryption. No custom domains, no filters, no auto-reply on free. Swiss privacy jurisdiction.") which fully captures the removed Email entry's narrative ("end-to-end encryption. Free 1GB storage."). Verified date 2026-04-17 vs 2026-04-12, so kept entry is also more recent.

## Net effect on /vendor/proton-mail

Now picks Consumer Email as primary category, so the alternatives section shows Gmail/Outlook.com/Tutanota (true competitors) instead of Resend/Postmark/Mailchimp (transactional APIs). FAQ schema, comparison pills, and h-tags update consistently.

## Referral surface preserved

The platform_codes.json mechanism (PR #976) keys off vendor name with slug-aware lookup, not on the inline `referral` field of the offer entry. /vendor/proton-mail still shows the full referral button. /api/referral-codes/proton-mail still returns the code.

## Downstream cleanup in /email-alternatives

Per op-learning from #987:
- Removed dead `"Proton Mail"` reference from the hardcoded `securePrivacy` filter array (the page filters by Email category, so Consumer-Email Proton Mail can never match — leaves Tuta as the only secure-email card).
- Updated the section's introductory text from "Proton Mail and Tuta offer free tiers" (no longer accurate for the cards below) to mention only Tuta + cross-link to /vendor/proton-mail and /category/consumer-email.
- The decision-guide "Want secure, encrypted email?" entry still hardcodes /vendor/proton-mail and /vendor/tuta links — those stay (they're user-facing recommendations, not dead filters; both URLs resolve).

## Lint regression-fence test

Updated test/lint-duplicates.test.ts to drop the Proton Mail assertion and assert Airtable instead (one of 2 remaining candidates).

## Stats

- Offers: 1,580 → 1,579
- Email category: 55 → 54 entries
- Consumer Email category: 4 entries (unchanged)
- Tests: 1,113 passing (unchanged count, one test reframed)
- Lint candidates: 3 → 2 (Airtable + Canva remain)

## Verification

- `npm run lint:duplicates` confirms Proton Mail no longer flagged
- Full `npm test --test-concurrency=1`: 1,113/1,113 passing
- /vendor/proton-mail returns 200 with Consumer Email FAQ schema and Gmail/Outlook/Tutanota alternatives
- /api/referral-codes/proton-mail returns the platform code unchanged ($20 credit, pr.tn URL)
- /vendor/proton-mail referral button still rendered
- /email-alternatives "Secure & Privacy Email" section now shows only Tuta cards with cross-link to /category/consumer-email
- /category/consumer-email returns 200
- /compare/gmail-vs-proton-mail returns 200

Refs #985