### PR TITLE
Add per-tool tool_call attribution to /api/stats (#998)

### DIFF
--- a/src/openapi.ts
+++ b/src/openapi.ts
@@ -820,7 +820,8 @@ export const openapiSpec = {
                     sessionsToday: { type: "integer", description: "Sessions since midnight UTC (resets daily)" },
                     serverStarted: { type: "string", format: "date-time", description: "ISO timestamp of current server start" },
                     clients: { type: "object", additionalProperties: { type: "integer" }, description: "Cumulative session counts per MCP client name (e.g. claude-desktop, cursor)" },
-                    toolCallsByClient: { type: "object", additionalProperties: { type: "integer" }, description: "Cumulative MCP tool-call counts per MCP client name. Missing/empty client IDs bucket to 'unknown'. Values sum to totalToolCallsAllTime (invariant)." }
+                    toolCallsByClient: { type: "object", additionalProperties: { type: "integer" }, description: "Cumulative MCP tool-call counts per MCP client name. Missing/empty client IDs bucket to 'unknown'. Values sum to totalToolCallsAllTime (invariant)." },
+                    toolCallsByName: { type: "object", additionalProperties: { type: "integer" }, description: "Cumulative MCP tool-call counts per tool name (search_deals, plan_stack, compare_vendors, track_changes, register_agent, get_referral_code, check_balance, request_payout). Pre-feature historical calls bucket to 'unknown'. Values sum to totalToolCallsAllTime (invariant)." }
                   }
                 }
               }

--- a/src/stats.ts
+++ b/src/stats.ts
@@ -14,12 +14,20 @@ const toolCalls: Record<string, number> = {
   plan_stack: 0,
   compare_vendors: 0,
   track_changes: 0,
+  register_agent: 0,
+  get_referral_code: 0,
+  check_balance: 0,
+  request_payout: 0,
 };
 
 // Per-client tool-call counts for the current deployment. Client IDs come from MCP initialize
 // clientInfo.name; missing/empty names bucket to "unknown". Cardinality bounded by distinct MCP
 // client populations seen in practice (<200 in production).
 const toolCallsByClient: Record<string, number> = {};
+
+// Per-tool tool-call counts for the current deployment. Keys are MCP tool names that appear in
+// the `toolCalls` gate above. Cardinality bounded by the tool list itself.
+const toolCallsByName: Record<string, number> = {};
 
 // Per-endpoint hit counts for the current deployment. Accumulates dynamically — any endpoint passed
 // to recordApiHit is counted. Cardinality is bounded by route definitions (~150 endpoints).
@@ -41,6 +49,7 @@ let cumulative = {
   last_deploy_at: "",
   clients: {} as Record<string, number>,
   tool_calls_by_client: {} as Record<string, number>,
+  tool_calls_by_name: {} as Record<string, number>,
   referral_listing_calls: 0,
   referral_listing_by_source: { platform: 0, agent: 0, null: 0 } as Record<"platform" | "agent" | "null", number>,
   referral_vendor_lookups: 0,
@@ -86,6 +95,7 @@ interface TelemetryData {
   last_deploy_at: string;
   cumulative_clients?: Record<string, number>;
   cumulative_tool_calls_by_client?: Record<string, number>;
+  cumulative_tool_calls_by_name?: Record<string, number>;
   cumulative_referral_listing_calls?: number;
   cumulative_referral_listing_by_source?: Record<"platform" | "agent" | "null", number>;
   cumulative_referral_vendor_lookups?: number;
@@ -234,6 +244,14 @@ function parseTelemetryData(data: Record<string, unknown>): void {
     const delta = cumulative.tool_calls - byClientSum;
     cumulative.tool_calls_by_client.unknown = (cumulative.tool_calls_by_client.unknown ?? 0) + delta;
   }
+  cumulative.tool_calls_by_name = (data.cumulative_tool_calls_by_name as Record<string, number>) ?? {};
+  // Same backfill-to-unknown pattern for per-name — preserves the sum invariant
+  // sum(toolCallsByName) == totalToolCallsAllTime from Day 1 of this feature.
+  const byNameSum = Object.values(cumulative.tool_calls_by_name).reduce((a, b) => a + b, 0);
+  if (cumulative.tool_calls > byNameSum) {
+    const delta = cumulative.tool_calls - byNameSum;
+    cumulative.tool_calls_by_name.unknown = (cumulative.tool_calls_by_name.unknown ?? 0) + delta;
+  }
   cumulative.referral_listing_calls = (data.cumulative_referral_listing_calls as number) ?? 0;
   const listingBySource = (data.cumulative_referral_listing_by_source as Record<string, number>) ?? {};
   cumulative.referral_listing_by_source = {
@@ -283,6 +301,11 @@ function buildTelemetryData(): TelemetryData {
   for (const [name, count] of Object.entries(toolCallsByClient)) {
     mergedToolCallsByClient[name] = (mergedToolCallsByClient[name] ?? 0) + count;
   }
+  // Merge cumulative + current deployment per-tool-name tool-call counts
+  const mergedToolCallsByName: Record<string, number> = { ...cumulative.tool_calls_by_name };
+  for (const [tool, count] of Object.entries(toolCallsByName)) {
+    mergedToolCallsByName[tool] = (mergedToolCallsByName[tool] ?? 0) + count;
+  }
   // Merge referral vendor counts (cumulative + current deployment)
   const mergedVendorCounts: Record<string, number> = { ...cumulative.referral_vendor_counts };
   for (const [vendor, count] of Object.entries(referralVendorCounts)) {
@@ -302,6 +325,7 @@ function buildTelemetryData(): TelemetryData {
     last_deploy_at: cumulative.last_deploy_at,
     cumulative_clients: mergedClients,
     cumulative_tool_calls_by_client: mergedToolCallsByClient,
+    cumulative_tool_calls_by_name: mergedToolCallsByName,
     cumulative_referral_listing_calls: cumulative.referral_listing_calls + referralListingCalls,
     cumulative_referral_listing_by_source: {
       platform: cumulative.referral_listing_by_source.platform + referralListingBySource.platform,
@@ -366,6 +390,7 @@ export function resetCounters(): void {
   for (const key of Object.keys(apiHits)) delete apiHits[key];
   for (const key of Object.keys(sessionClients)) delete sessionClients[key];
   for (const key of Object.keys(toolCallsByClient)) delete toolCallsByClient[key];
+  for (const key of Object.keys(toolCallsByName)) delete toolCallsByName[key];
   cumulative.sessions = 0;
   cumulative.tool_calls = 0;
   cumulative.api_hits = 0;
@@ -374,6 +399,7 @@ export function resetCounters(): void {
   cumulative.last_deploy_at = "";
   cumulative.clients = {};
   cumulative.tool_calls_by_client = {};
+  cumulative.tool_calls_by_name = {};
   referralListingCalls = 0;
   referralListingBySource.platform = 0;
   referralListingBySource.agent = 0;
@@ -393,6 +419,7 @@ export function recordToolCall(tool: string, clientName?: string): void {
     toolCalls[tool]++;
     const bucket = (clientName && clientName.trim()) || "unknown";
     toolCallsByClient[bucket] = (toolCallsByClient[bucket] ?? 0) + 1;
+    toolCallsByName[tool] = (toolCallsByName[tool] ?? 0) + 1;
   }
 }
 
@@ -575,6 +602,7 @@ export function getConnectionStats(activeSessions: number): {
   serverStarted: string;
   clients: Record<string, number>;
   toolCallsByClient: Record<string, number>;
+  toolCallsByName: Record<string, number>;
 } {
   const today = new Date().toISOString().slice(0, 10);
   if (today !== sessionsTodayDate) {
@@ -592,6 +620,10 @@ export function getConnectionStats(activeSessions: number): {
   for (const [name, count] of Object.entries(toolCallsByClient)) {
     mergedToolCallsByClient[name] = (mergedToolCallsByClient[name] ?? 0) + count;
   }
+  const mergedToolCallsByName: Record<string, number> = { ...cumulative.tool_calls_by_name };
+  for (const [tool, count] of Object.entries(toolCallsByName)) {
+    mergedToolCallsByName[tool] = (mergedToolCallsByName[tool] ?? 0) + count;
+  }
   return {
     activeSessions,
     totalSessionsAllTime: cumulative.sessions + totalSessions,
@@ -601,6 +633,7 @@ export function getConnectionStats(activeSessions: number): {
     serverStarted: serverStartedISO,
     clients: mergedClients,
     toolCallsByClient: mergedToolCallsByClient,
+    toolCallsByName: mergedToolCallsByName,
   };
 }
 

--- a/test/stats.test.ts
+++ b/test/stats.test.ts
@@ -71,6 +71,50 @@ describe("stats", () => {
       assert.strictEqual(sum, conn.totalToolCallsAllTime);
       assert.strictEqual(sum, 5);
     });
+
+    it("tracks per-tool-name tool-call counts", () => {
+      recordToolCall("search_deals", "opencode");
+      recordToolCall("search_deals", "cursor");
+      recordToolCall("plan_stack", "opencode");
+      recordToolCall("compare_vendors");
+      const conn = getConnectionStats(0);
+      assert.strictEqual(conn.toolCallsByName.search_deals, 2);
+      assert.strictEqual(conn.toolCallsByName.plan_stack, 1);
+      assert.strictEqual(conn.toolCallsByName.compare_vendors, 1);
+    });
+
+    it("does not increment toolCallsByName for unknown tool names", () => {
+      recordToolCall("nonexistent_tool", "opencode");
+      const conn = getConnectionStats(0);
+      assert.strictEqual(conn.toolCallsByName.nonexistent_tool, undefined);
+    });
+
+    it("counts the four PM-expanded tools (register_agent, get_referral_code, check_balance, request_payout)", () => {
+      recordToolCall("register_agent", "claude-code");
+      recordToolCall("get_referral_code", "claude-code");
+      recordToolCall("check_balance", "cursor");
+      recordToolCall("request_payout", "cursor");
+      const conn = getConnectionStats(0);
+      assert.strictEqual(conn.toolCallsByName.register_agent, 1);
+      assert.strictEqual(conn.toolCallsByName.get_referral_code, 1);
+      assert.strictEqual(conn.toolCallsByName.check_balance, 1);
+      assert.strictEqual(conn.toolCallsByName.request_payout, 1);
+      assert.strictEqual(conn.totalToolCallsAllTime, 4);
+    });
+
+    it("sum of toolCallsByName equals totalToolCallsAllTime (invariant)", () => {
+      recordToolCall("search_deals", "opencode");
+      recordToolCall("search_deals", "cursor");
+      recordToolCall("plan_stack");
+      recordToolCall("compare_vendors", "MintMCP Client");
+      recordToolCall("track_changes");
+      recordToolCall("register_agent", "claude-code");
+      recordToolCall("get_referral_code", "claude-code");
+      const conn = getConnectionStats(0);
+      const sum = Object.values(conn.toolCallsByName).reduce((a: number, b: number) => a + b, 0);
+      assert.strictEqual(sum, conn.totalToolCallsAllTime);
+      assert.strictEqual(sum, 7);
+    });
   });
 
   describe("recordApiHit", () => {

--- a/test/telemetry.test.ts
+++ b/test/telemetry.test.ts
@@ -158,6 +158,77 @@ describe("telemetry persistence", () => {
 
     rmSync(tmpDirBF, { recursive: true, force: true });
   });
+
+  it("persists toolCallsByName and preserves sum invariant across restart", async () => {
+    const tmpDirTN = join(tmpdir(), `telemetry-tn-${randomUUID()}`);
+    const filePath = join(tmpDirTN, "telemetry.json");
+    mkdirSync(tmpDirTN, { recursive: true });
+
+    resetCounters();
+    await loadTelemetry(filePath);
+
+    // First deploy: rack up calls across several tools
+    const { recordToolCall: rec, getConnectionStats: conn } = await import("../src/stats.ts");
+    rec("search_deals", "opencode");
+    rec("search_deals", "cursor");
+    rec("plan_stack", "opencode");
+    rec("register_agent", "claude-code");
+    rec("get_referral_code", "claude-code");
+    await flushTelemetry();
+
+    // Verify persisted shape
+    const persisted1 = JSON.parse(readFileSync(filePath, "utf-8"));
+    assert.strictEqual(persisted1.cumulative_tool_calls, 5);
+    assert.deepStrictEqual(persisted1.cumulative_tool_calls_by_name, {
+      search_deals: 2, plan_stack: 1, register_agent: 1, get_referral_code: 1,
+    });
+
+    // Simulate restart: reset in-memory, reload
+    resetCounters();
+    await loadTelemetry(filePath);
+
+    // Sum invariant should hold after reload
+    const c = conn(0);
+    const sum = Object.values(c.toolCallsByName).reduce((a: number, b: number) => a + b, 0);
+    assert.strictEqual(sum, c.totalToolCallsAllTime);
+    assert.strictEqual(c.toolCallsByName.search_deals, 2);
+    assert.strictEqual(c.toolCallsByName.plan_stack, 1);
+    assert.strictEqual(c.toolCallsByName.register_agent, 1);
+    assert.strictEqual(c.toolCallsByName.get_referral_code, 1);
+
+    rmSync(tmpDirTN, { recursive: true, force: true });
+  });
+
+  it("backfills 'unknown' bucket when cumulative_tool_calls exceeds per-name sum (legacy data)", async () => {
+    const tmpDirBF2 = join(tmpdir(), `telemetry-backfill-name-${randomUUID()}`);
+    const filePath = join(tmpDirBF2, "telemetry.json");
+    mkdirSync(tmpDirBF2, { recursive: true });
+
+    // Simulate pre-#998 telemetry: has tool_calls but no per-name breakdown yet.
+    // Represents the real production state at PR #998 deploy: ~62 lifetime calls
+    // across 4 original tools, no per-tool-name map persisted.
+    const legacy = {
+      cumulative_sessions: 100,
+      cumulative_tool_calls: 62,
+      cumulative_api_hits: 500,
+      cumulative_landing_views: 50,
+      first_session_at: "2026-03-01T00:00:00.000Z",
+      last_deploy_at: "2026-04-01T00:00:00.000Z",
+    };
+    writeFileSync(filePath, JSON.stringify(legacy));
+
+    resetCounters();
+    await loadTelemetry(filePath);
+
+    // The 62 legacy calls should appear under "unknown"
+    const { getConnectionStats: conn } = await import("../src/stats.ts");
+    const c = conn(0);
+    assert.strictEqual(c.toolCallsByName.unknown, 62);
+    const sum = Object.values(c.toolCallsByName).reduce((a: number, b: number) => a + b, 0);
+    assert.strictEqual(sum, c.totalToolCallsAllTime);
+
+    rmSync(tmpDirBF2, { recursive: true, force: true });
+  });
 });
 
 describe("redis telemetry", () => {


### PR DESCRIPTION
Refs #998.

## Summary

Mirrors PR #994 pattern to add per-tool-name attribution alongside per-client attribution. New field `toolCallsByName` on `/api/stats` response, persisted to `telemetry.json` via `cumulative_tool_calls_by_name`. 8 tools tracked per PM's AC list.

## Changes

- **`src/stats.ts`** — infrastructure mirroring `toolCallsByClient`:
  - Expanded `toolCalls` gate from 4 tools to 8 (added `register_agent`, `get_referral_code`, `check_balance`, `request_payout`). These 4 tools were previously dropped at the `if (tool in toolCalls)` gate entirely — so the PM's AC key list `register_agent`/`get_referral_code`/`check_balance`/`request_payout` literally required gate expansion.
  - Added `toolCallsByName: Record<string, number>` in-memory state + `cumulative.tool_calls_by_name` persisted state.
  - Added `cumulative_tool_calls_by_name` to `TelemetryData` interface.
  - `parseTelemetryData`: hydrate `cumulative.tool_calls_by_name` and backfill any `cumulative.tool_calls - sum` delta to `unknown` so the sum invariant holds on first load.
  - `buildTelemetryData`: merge in-memory + persisted, emit `cumulative_tool_calls_by_name`.
  - `recordToolCall(tool, clientName)`: increment `toolCallsByName[tool]` alongside `toolCallsByClient[bucket]`.
  - `resetCounters`: clear both in-memory and cumulative.
  - `getConnectionStats`: expose `toolCallsByName` field (serialized directly to `/api/stats`).

- **`src/openapi.ts`** — added `toolCallsByName` to `/api/stats` 200-response schema with description naming all 8 tool keys + `unknown` backfill bucket + sum invariant.

- **`test/stats.test.ts`** — 4 new tests (+4): per-tool-name tracking, unknown-tool non-increment, PM-expanded-4-tools counted, sum invariant for per-name.

- **`test/telemetry.test.ts`** — 2 new tests (+2): persistence + sum-invariant across restart, backfill-to-unknown for legacy data.

Total: **1,119 tests (1,113 + 6)**, full suite passes on `--test-concurrency=1`.

## Acceptance criteria

- [x] `/api/stats` response includes `toolCallsByName` with keys for the 8 tools.
- [x] Sum invariant: `sum(toolCallsByName) == totalToolCallsAllTime`.
- [x] On first production deploy: pre-existing ~62 tool_calls backfill to `toolCallsByName[\"unknown\"]`.
- [x] New tool_calls post-deploy increment the correct per-tool bucket (E2E verified — see below).
- [x] Persistence across Railway restart preserves the map (telemetry persistence test).
- [x] Regression tests added.
- [x] Full test suite passes.

## Scope note — gate expansion affects #994 too

Expanding `toolCalls` from 4→8 is symmetric: `toolCallsByClient` from #994 will also start bucketing the 4 newly-tracked tools (register_agent, get_referral_code, check_balance, request_payout) instead of dropping them. Total `cumulative_tool_calls` will grow slightly faster going forward (4 previously-dropped tools now count). No data is rewritten — this affects future increments only.

The 4 MCP tools still ungated (`submit_referral_code`, `my_referral_codes`, `leaderboard`, `manage_friends`) are out of scope for #998 per the PM's AC listing only 8 tools.

## E2E verification

Local server on port 4574:

```
# Clean start: totalToolCallsAllTime=0, toolCallsByName={}
# Initialize MCP session → initialized notification
# tools/call search_deals → totalToolCallsAllTime=1, toolCallsByName={search_deals:1}, toolCallsByClient={e2e-verify-998:1}
# tools/call register_agent → totalToolCallsAllTime=2, toolCallsByName={search_deals:1, register_agent:1}, toolCallsByClient={e2e-verify-998:2}

# Persistence: sum(toolCallsByName) == totalToolCallsAllTime maintained across restart
```

OpenAPI spec correctly exposes `toolCallsByName` under `/api/stats` 200 response schema.

## Test plan

- [x] `npm test` on `--test-concurrency=1` → 1,119/1,119 pass
- [x] Fresh server E2E: tool call increments per-name bucket
- [x] Restart E2E: persistence preserves `cumulative_tool_calls_by_name`
- [x] Sum invariant verified on both in-memory output and persisted file
- [x] OpenAPI spec exposes field