### PR TITLE
Deduplicate Airtable (keep Productivity & Notes)

### DIFF
--- a/data/category-mapping.json
+++ b/data/category-mapping.json
@@ -21,7 +21,7 @@
   "Gitea": "Source Control",
   "Appsmith": "Low-Code Platforms",
   "GitHub Codespaces": "IDE & Code Editors",
-  "Airtable": "Low-Code Platforms",
+  "Airtable": "Productivity & Notes",
   "AbstractAPI": "API Development",
   "APILayer": "API Development",
   "BigDataCloud": "Dev Utilities",

--- a/data/index.json
+++ b/data/index.json
@@ -5189,20 +5189,6 @@
       "verifiedDate": "2026-04-13"
     },
     {
-      "vendor": "Airtable",
-      "category": "Low-Code Platforms",
-      "description": "Low-code database and app platform — free tier: unlimited bases, 1,000 records per base, 1 GB attachment space per base, up to 5 Editor/Creator collaborators (unlimited read-only, 50 Commenter), 500 AI credits/editor+/month, 1,000 API calls/workspace/month, 2-week revision/snapshot history. No automations, extensions, or record coloring on Free.",
-      "tier": "Free",
-      "url": "https://airtable.com/pricing",
-      "tags": [
-        "database",
-        "low-code",
-        "spreadsheet",
-        "collaboration"
-      ],
-      "verifiedDate": "2026-04-19"
-    },
-    {
       "vendor": "Deepgram",
       "category": "AI / ML",
       "description": "Speech-to-text and text-to-speech API — $200 free credits on signup (no credit card required), ~43K minutes transcription with Nova model, credits never expire. Access to all model endpoints",
@@ -22113,17 +22099,19 @@
     {
       "vendor": "Airtable",
       "category": "Productivity & Notes",
-      "description": "Unlimited bases. Up to 1,000 records per base. 1 GB attachment space per base. Up to 5 Editor/Creator collaborators (unlimited read-only, 50 Commenter). 500 AI credits/editor+/month. 2-week revision history. No automations, extensions, sync, or Gantt/timeline views on Free.",
+      "description": "Database and collaboration platform. Unlimited bases. Up to 1,000 records per base. 1 GB attachment space per base. Up to 5 Editor/Creator collaborators (unlimited read-only, 50 Commenter). 500 AI credits/editor+/month. 1,000 API calls/workspace/month. 2-week revision/snapshot history. No automations, extensions, sync, Gantt/timeline views, or record coloring on Free.",
       "tier": "Free",
       "url": "https://airtable.com/pricing",
       "tags": [
         "database",
         "spreadsheet",
+        "low-code",
         "no-code",
+        "collaboration",
         "consumer",
         "free-tier"
       ],
-      "verifiedDate": "2026-04-19"
+      "verifiedDate": "2026-04-23"
     },
     {
       "vendor": "Google Drive",

--- a/test/lint-duplicates.test.ts
+++ b/test/lint-duplicates.test.ts
@@ -152,14 +152,14 @@ describe("formatMarkdown", () => {
 });
 
 describe("lint-duplicates against current data/index.json", () => {
-  it("detects Airtable as a candidate", async () => {
+  it("detects Canva as a candidate", async () => {
     const { readFileSync } = await import("node:fs");
     const { resolve } = await import("node:path");
     const indexPath = resolve(process.cwd(), "data", "index.json");
     const data = JSON.parse(readFileSync(indexPath, "utf-8"));
     const result = findDuplicateCandidates(data.offers || []);
     const vendors = result.map((c) => c.vendor);
-    assert(vendors.includes("Airtable"), `expected Airtable in ${vendors.join(", ")}`);
+    assert(vendors.includes("Canva"), `expected Canva in ${vendors.join(", ")}`);
   });
 
   it("does not flag Amazon Kiro (different vendor names)", async () => {


### PR DESCRIPTION
## Summary

Eighth in the dedup series flowing from PR #985's `lint:duplicates` advisory. Two Airtable entries (Low-Code Platforms + Productivity & Notes) described the same product on the same free tier. Consolidated to the Productivity & Notes entry.

## Category judgment: keep Productivity & Notes despite smaller population

Low-Code Platforms (16 entries) vs Productivity & Notes (13 entries) is a near-tie — the population-heuristic (Figma PR #986) doesn't cleanly dominate. Applied **peer-group-match** instead:

- **Productivity & Notes peers include Notion and Coda** — Airtable's direct head-to-head competitors in the database-meets-documents product class. Evernote and Obsidian round out the knowledge-work peer group.
- **Low-Code Platforms peers are Retool, Appsmith, BudiBase, Mendix, ToolJet** — developer-focused internal tool builders and data utilities. A poor peer match for Airtable's prosumer/team positioning.
- Pre-PR `/vendor/airtable` alternatives: Retool, Appsmith, Data Fetcher, Export SDK, JSON2Video — weak recommendations for an Airtable user.
- Post-PR `/vendor/airtable` alternatives: Notion, Todoist, Trello, Google Keep, Obsidian — directly relevant.
- Also: Low-Code Platforms has `CATEGORY_HUB` routing to `/design-alternatives`, a poor fallback for Airtable (not a Design tool).

This is distinct from the Figma heuristic (population wins when both categories are legitimate) AND the Proton inversion (keep the smaller when the larger is a grab-bag). Low-Code Platforms isn't a grab-bag — it's a coherent category, just a poorly-matched one for Airtable specifically. Logging this as a third dedup pattern: **peer-group-match** wins when both categories are coherent but one has a distinctly stronger peer match for the vendor.

## Description merge preserves useful details

Kept Productivity entry's description is now:
> Database and collaboration platform. Unlimited bases. Up to 1,000 records per base. 1 GB attachment space per base. Up to 5 Editor/Creator collaborators (unlimited read-only, 50 Commenter). 500 AI credits/editor+/month. 1,000 API calls/workspace/month. 2-week revision/snapshot history. No automations, extensions, sync, Gantt/timeline views, or record coloring on Free.

- Added from Low-Code entry: `1,000 API calls/workspace/month`, `record coloring` exclusion, positioning "Database and collaboration platform".
- Preserved from Productivity entry: `sync, Gantt/timeline views` exclusions.
- Tags merged: `database, spreadsheet, low-code (+), no-code, collaboration (+), consumer, free-tier`.
- `verifiedDate` → `2026-04-23`.

## Historical `category-mapping.json` update

The `recategorize.ts` script uses `data/category-mapping.json` to move "Developer Tools" entries to specific categories. Airtable isn't currently in Developer Tools, so the mapping is inert — but updated to `Productivity & Notes` for historical consistency so any future accidental Developer Tools re-categorization would route Airtable to its new home.

## Downstream cleanup: none required

`grep -rn "Airtable" src/` returns no matches in `serve.ts` — unlike Telegram (PR #987) and Proton Mail (PR #997), Airtable has no hardcoded filter arrays or introductory-text claims in page handlers. Clean dedup.

## Regression fence rotation

`test/lint-duplicates.test.ts:155` asserted Airtable is flagged. Rotated to Canva (the last remaining lint candidate). Test count unchanged (1,119 → 1,119).

## E2E verification

Local server, `BASE_URL=http://localhost:4575`:

- `/api/offers?limit=5000` total: **1,579 → 1,578** ✓
- `/api/offers?category=Low-Code Platforms` total: **16 → 15**, Airtable removed ✓
- `/api/offers?category=Productivity & Notes` total: **13** (Airtable present) ✓
- `/api/details/airtable`: primary = `Productivity & Notes`, `relatedVendors = [Notion, Todoist, Trello, Google Keep, Obsidian]` ✓
- `/vendor/airtable`: 200, breadcrumb → Home > Productivity & Notes > Airtable ✓
- `/category/low-code-platforms`: 200 ✓
- `/category/productivity-notes`: 200 ✓
- `/compare/airtable-vs-notion`: 200 ✓
- `/alternative-to/airtable`: 200 ✓
- `npm run lint:duplicates`: now flags only Canva (Airtable cleared) ✓

## Tests

1,119/1,119 pass, `--test-concurrency=1`, clean run.

## Test plan

- [x] Full test suite passes
- [x] Lint reduces from 2 → 1 candidates (Canva remaining)
- [x] Pre/post comparison of `/vendor/airtable` alternatives shows quality improvement
- [x] All downstream pages (/category, /compare, /alternative-to) still resolve 200
- [x] No hardcoded Airtable dead-code in `src/serve.ts` (grep verified)

Refs PR #985's advisory (no PM-filed issue; idle-time follow-up, consistent with Windsurf #982, Notion #983, Figma #986, Proton Pass #988, Proton Mail #997).

🤖 Generated with [Claude Code](https://claude.com/claude-code)