### PR TITLE
Deduplicate Canva (keep Design)

### DIFF
--- a/data/category-mapping.json
+++ b/data/category-mapping.json
@@ -607,7 +607,7 @@
   "Microsoft Teams": "Communication & Messaging",
   "Signal": "Communication & Messaging",
   "WhatsApp": "Communication & Messaging",
-  "Canva": "Design & Creative",
+  "Canva": "Design",
   "Figma": "Design & Creative",
   "Photopea": "Design & Creative",
   "GIMP": "Design & Creative",

--- a/data/index.json
+++ b/data/index.json
@@ -3500,7 +3500,7 @@
     {
       "vendor": "Canva",
       "category": "Design",
-      "description": "2M+ templates, 1.8M+ free stock photos/graphics/elements, 5 GB cloud storage. Standard exports (PNG, JPG, PDF). 1 basic Brand Kit (3 colors). No custom fonts, no transparent backgrounds",
+      "description": "5 GB cloud storage, 250,000+ free templates, 1 million+ free photos/graphics/elements. Basic photo editing and AI features. Standard exports (PNG, JPG, PDF). No Background Remover, Brand Kit, Magic Resize, custom fonts, or transparent backgrounds on free.",
       "tier": "Free",
       "url": "https://www.canva.com/pricing/",
       "tags": [
@@ -3508,9 +3508,11 @@
         "graphics",
         "templates",
         "image editing",
-        "presentations"
+        "presentations",
+        "consumer",
+        "free-tier"
       ],
-      "verifiedDate": "2026-04-14"
+      "verifiedDate": "2026-04-23"
     },
     {
       "vendor": "Penpot",
@@ -22448,21 +22450,6 @@
         "encrypted",
         "consumer",
         "free"
-      ],
-      "verifiedDate": "2026-04-17"
-    },
-    {
-      "vendor": "Canva",
-      "category": "Design & Creative",
-      "description": "5 GB cloud storage. 250,000+ free templates. 1 million+ free photos/graphics. Basic photo editing and AI features. Download as PNG/JPG/PDF. No Background Remover, Brand Kit, or Magic Resize on free.",
-      "tier": "Free",
-      "url": "https://www.canva.com/pricing/",
-      "tags": [
-        "design",
-        "graphics",
-        "templates",
-        "consumer",
-        "free-tier"
       ],
       "verifiedDate": "2026-04-17"
     },

--- a/test/lint-duplicates.test.ts
+++ b/test/lint-duplicates.test.ts
@@ -152,14 +152,14 @@ describe("formatMarkdown", () => {
 });
 
 describe("lint-duplicates against current data/index.json", () => {
-  it("detects Canva as a candidate", async () => {
+  it("finds no duplicate candidates against the current index", async () => {
     const { readFileSync } = await import("node:fs");
     const { resolve } = await import("node:path");
     const indexPath = resolve(process.cwd(), "data", "index.json");
     const data = JSON.parse(readFileSync(indexPath, "utf-8"));
     const result = findDuplicateCandidates(data.offers || []);
     const vendors = result.map((c) => c.vendor);
-    assert(vendors.includes("Canva"), `expected Canva in ${vendors.join(", ")}`);
+    assert.strictEqual(result.length, 0, `unexpected candidate(s): ${vendors.join(", ")}`);
   });
 
   it("does not flag Amazon Kiro (different vendor names)", async () => {


### PR DESCRIPTION
## Summary

Last remaining candidate from PR #985's `lint:duplicates` advisory. Ninth dedup PR in the series (#968 Copilot, #982 Windsurf, #983 Notion, #986 Figma, #987 Telegram, #988 Proton Pass, #997 Proton Mail, #1000 Airtable).

**Key decision — peer-group-match trumps the grab-bag inversion heuristic here.** Both Design (96, broad grab-bag of design-adjacent tools) and Design & Creative (7, coherent FOSS pro creative apps) are legit category homes for Canva. The Proton inversion heuristic would say keep the smaller coherent category (Design & Creative). But the **alternatives rendered** tells a different story:

| Category | Alternatives surfaced for /vendor/canva | Peer match? |
|---|---|---|
| Design (kept) | Figma, Penpot, Excalidraw, Lunacy, Pixlr | ✓ Strong — Figma is Canva's #1 competitor |
| Design & Creative (retired) | Photopea, GIMP, Inkscape, Krita, DaVinci, Blender | ✗ None are Canva peers — all desktop pro creative apps |

Canva is a prosumer template-based tool, not a desktop creative app. Its peers (Figma) live in Design despite Design being a grab-bag. **Ground truth: which category surfaces the vendor's named competitors beats size/grab-bag signals.**

## Changes

- `data/index.json` — retire Canva/Design & Creative entry. Refresh Canva/Design description with the more recent D&C verification (2026-04-17 → merged into kept entry, verifiedDate→2026-04-23). Preserve Design-specific exclusions (custom fonts, transparent backgrounds) while adding D&C's (Background Remover, Magic Resize). Merge tags: add `consumer`, `free-tier`.
- `data/category-mapping.json` — `"Canva": "Design & Creative"` → `"Design"` (inert today since recategorize.ts only acts on Developer Tools entries, but kept consistent).
- `test/lint-duplicates.test.ts` — rotate regression fence from "detects Canva" to "finds no duplicate candidates against the current index" (clean-state fence for the series).

## Counts

- 1,578 → **1,577 offers**
- Design: 96 (unchanged — Canva already present)
- Design & Creative: 7 → 6
- Tests: **1,119/1,119 pass** (`--test-concurrency=1`, clean run)
- `npm run lint:duplicates`: 1 → **0 candidates**

## Downstream cleanup — none needed

Hardcoded Canva references in `src/serve.ts`:
- Line 11601 (`buildDesignAlternativesPage` filter): still correct (Canva stays in Design).
- Line 11648 (`designChangeVendors` for dealChanges filter): independent of offers category.
- Line 14666 (`Design & Prototyping` recommended stack alternatives): hardcoded editorial reference.

## E2E verified on localhost:4582

- ✅ `/vendor/canva` — 200, breadcrumb `Home > Design > Canva`, alternatives `[Figma, Penpot, Excalidraw, Lunacy, Pixlr]`
- ✅ `/category/design` — 200
- ✅ `/category/design-creative` — 200, zero Canva mentions
- ✅ `/compare/canva-vs-figma` — 200
- ✅ `/alternative-to/canva` — 200
- ✅ `/design-alternatives` — 200 (Canva still in page title/recommendations, which is correct since it stays in Design)
- ✅ `/api/details/canva` — `primary.category=Design`, relatedVendors strong

## Follow-up

**Photopea is a latent dup** with the same Design vs Design & Creative split — but `vendor: "photopea.com"` in Design vs `vendor: "Photopea"` in Design & Creative. The lint's exact-string-match misses it. Filing separately — each dedup needs its own category-judgment PR per the series pattern, and Photopea also needs vendor-name normalization to `"Photopea"`.

Refs #985