### PR TITLE
Consolidate Photopea duplicate entries (keep Design & Creative)

### DIFF
--- a/data/index.json
+++ b/data/index.json
@@ -15836,19 +15836,6 @@
       "verifiedDate": "2026-04-05"
     },
     {
-      "vendor": "photopea.com",
-      "category": "Design",
-      "description": "A Free, Advanced online design editor with Adobe Photoshop UI supporting PSD, XCF & Sketch formats (Adobe Photoshop, Gimp and Sketch App).",
-      "tier": "Free",
-      "url": "https://www.photopea.com",
-      "tags": [
-        "design",
-        "ui",
-        "free-for-dev"
-      ],
-      "verifiedDate": "2026-04-12"
-    },
-    {
       "vendor": "Plasmic",
       "category": "Design",
       "description": "A fast, easy-to-use, robust web design tool and page builder that integrates into your codebase. Build responsive pages or complex components; optionally extend with code; and publish to production sites and apps.",

--- a/src/serve.ts
+++ b/src/serve.ts
@@ -11598,7 +11598,7 @@ function buildDesignAlternativesPage(): string {
 
   // Group by design domain
   const designEditors = enrichedAll.filter(o =>
-    ["Figma", "Canva", "Penpot", "Lunacy", "Pixlr", "photopea.com", "Excalidraw", "vectr.com", "Pixelixe"].includes(o.vendor)
+    ["Figma", "Canva", "Penpot", "Lunacy", "Pixlr", "Excalidraw", "vectr.com", "Pixelixe"].includes(o.vendor)
   );
   const prototyping = enrichedAll.filter(o =>
     ["Webflow", "framer.com", "Proto.io", "Plasmic", "Webstudio", "Quant Ux", "TeleportHQ", "Unicorn Platform", "landen.co", "Grapedrop", "marvelapp.com", "Octopus.do", "Updrafts.app", "walkme.com"].includes(o.vendor)
@@ -11745,7 +11745,7 @@ ${mcpCtaCss()}
   ${changesHtml}
 
   <h2>Design Tools &amp; Editors</h2>
-  <p style="color:var(--text-muted);margin-bottom:1rem">Collaborative design tools, photo editors, and vector editors. From full-featured design platforms like Figma and Penpot to lightweight editors like Photopea and Excalidraw for quick mockups and diagrams.</p>
+  <p style="color:var(--text-muted);margin-bottom:1rem">Collaborative design tools, photo editors, and vector editors. From full-featured design platforms like Figma and Penpot to lightweight editors like Pixlr and Excalidraw for quick mockups and diagrams. <a href="/vendor/photopea">Photopea</a> is a browser-based Photoshop alternative in our <a href="/category/design-creative">Design &amp; Creative</a> category.</p>
 ${buildCards(designEditors)}
 
   <h2>Prototyping &amp; No-Code Builders</h2>


### PR DESCRIPTION
## Summary

Two Photopea entries existed under different vendor-name casings:
- `photopea.com` in Design (sparse — 3 tags, brief description)
- `Photopea` in Design & Creative (rich — 6 tags, detailed description)

PR #985 lint missed this because the detector keys on exact vendor-name match, and the `.com` suffix disambiguated the two strings. Noted as a latent dup in the PR #1001 cycle and shipped here as idle-time work.

## Which to keep?

Applied the unified peer-group-match heuristic (op-learning #72, codified after the Canva dedup in PR #1001): **pick the category that surfaces the vendor's named competitors.**

**`/api/details/photopea` on the kept state — Design & Creative:**

```
relatedVendors: ["GIMP", "Inkscape", "DaVinci Resolve", "Krita", "Blender"]
```

These are Photopea's direct peer group: FOSS/free photo and creative editors. GIMP in particular is the archetypal free Photoshop alternative; Photopea's tagline is "Advanced photo editor, free, online, similar to Photoshop."

**Counterfactual — keeping Design:** the designEditors peer group on `/design-alternatives` is Figma/Canva/Penpot/Lunacy/Pixlr/Excalidraw — primarily UI-design tools with only Pixlr as a browser-photo-editor peer. Weaker match for Photopea.

Unlike Canva (PR #1001, where the larger grab-bag won because the smaller coherent category held the wrong peers), Photopea's closest competitors live in the smaller coherent category. Same rule, different answer — the unified heuristic covers both shapes.

## Collateral cleanup

1. **`/design-alternatives` designEditors filter** — removed `"photopea.com"` from the hardcoded vendor list (dead after the Design-category entry goes away). Follows the PR #987 pattern of cleaning up dead filter arrays as part of the dedup PR.
2. **`/design-alternatives` intro prose** — the text "lightweight editors like Photopea and Excalidraw" described Photopea as lightweight (incorrect — it's a full-featured browser Photoshop) AND would have created a UX mismatch after dedup (Photopea no longer renders in the cards). Rewrote to "like Pixlr and Excalidraw" and appended a cross-link: "Photopea is a browser-based Photoshop alternative in our Design & Creative category." Follows op-learning #70.

## Verification

Local E2E (`BASE_URL=http://localhost:8765`):

- `/vendor/photopea` → 200, category Design & Creative, alternatives GIMP/Inkscape/DaVinci/Krita/Blender
- `/vendor/photopea-com` → 301 → `/vendor/photopea` (PR #990's fuzzy slug resolver handles the old URL)
- `/category/design-creative` → 200
- `/design-alternatives` → 200, Photopea absent from designEditors cards, cross-link present in intro prose
- `/api/details/photopea` relatedVendors = [GIMP, Inkscape, DaVinci Resolve, Krita, Blender]

Tests: 1,119 / 1,119 passing (no test changes needed — PR #985 regression fence `finds no duplicate candidates against the current index` was already passing at 0 and stays at 0 since the lint didn't count Photopea as a duplicate anyway).

## Stats

- Offers: 1,577 → 1,576 (single entry retired)
- Tests: 1,119 (unchanged)
- Lint candidates: 0 → 0 (latent dup, below vendor-name-match threshold)

## Follow-up

Will file a separate issue to normalize vendor names in `scripts/lint-duplicates.js` so future casing/suffix variants (e.g. `"photopea.com"` vs `"Photopea"`, `"github.com"` vs `"GitHub"`) get flagged. Keeping this PR scoped to the dedup itself.

## Series

Tenth in the dedup series: PRs #968 (Copilot), #982 (Windsurf), #983 (Notion), #986 (Figma), #987 (Telegram), #988 (Proton Pass), #997 (Proton Mail), #1000 (Airtable), #1001 (Canva), now this. No PM-filed issue — idle-time continuation after PR #1001 resolved all lint-flagged candidates.