### PR TITLE
Normalize vendor names in lint-duplicates (#1003)

### DIFF
--- a/scripts/lint-duplicates.js
+++ b/scripts/lint-duplicates.js
@@ -4,11 +4,14 @@
 // Advisory output — does not modify data, exits 0. Each flagged candidate requires
 // a human category-judgment call (see PR #983 rationale).
 //
-// Heuristic: same vendor name (exact match, case-insensitive), appearing in ≥2
-// distinct categories, whose tier strings share at least one meaningful token
-// after normalization. Catches e.g. Figma "Starter" vs "Free (Starter)"
-// (shared: "starter") and Proton Pass "Free" vs "Free" (shared: "free"),
-// while leaving Sentry "Developer" vs "OSS Sponsored" (no shared token) alone.
+// Heuristic: same vendor name (normalized — case-insensitive, TLD-suffix-stripped,
+// corp-suffix-stripped), appearing in ≥2 distinct categories, whose tier strings
+// share at least one meaningful token after normalization. Catches e.g. Figma
+// "Starter" vs "Free (Starter)" (shared: "starter"), Proton Pass "Free" vs
+// "Free" (shared: "free"), and Photopea "photopea.com" vs "Photopea" (TLD-suffix
+// variant, same product), while leaving Sentry "Developer" vs "OSS Sponsored"
+// (no shared token) alone and Amazon Kiro "Amazon Kiro" vs "Amazon Kiro (AWS
+// Startups)" (parenthetical suffix preserved, different keys) alone.
 
 import { readFileSync } from "node:fs";
 import { resolve, dirname } from "node:path";
@@ -32,8 +35,27 @@ const TIER_STOPWORDS = new Set([
 // Vendor name pairs to always exclude even if heuristic would match.
 // Empty by default — the current known-legitimate multi-entry cases all use
 // distinct vendor names (e.g. "Amazon Kiro" vs "Amazon Kiro (AWS Startups)")
-// and are therefore naturally excluded by exact-name matching.
+// whose parenthetical suffixes are preserved by normalizeVendor, so they
+// are naturally excluded by the (normalized) key-mismatch.
 const ALLOWLIST = new Set([]);
+
+// Normalize a vendor name for grouping: lowercase, strip common TLD suffixes,
+// strip Inc./LLC/Ltd corporate suffixes, trim. Keeps parenthetical disambiguators
+// intact (e.g. "Amazon Kiro (AWS Startups)" stays distinct from "Amazon Kiro").
+// See op-learning #58: exact matching is sometimes a feature — normalization
+// widens the equivalence class only where the variants are empirically the same
+// product (e.g. "photopea.com" vs "Photopea").
+const TLD_SUFFIX_RE = /\.(com|io|net|org|dev|app|co|ai)$/;
+const CORP_SUFFIX_RE = /\s+(inc\.?|llc|ltd\.?)$/;
+
+export function normalizeVendor(name) {
+  return String(name || "")
+    .toLowerCase()
+    .trim()
+    .replace(TLD_SUFFIX_RE, "")
+    .replace(CORP_SUFFIX_RE, "")
+    .trim();
+}
 
 export function tierTokens(tier) {
   if (!tier) return new Set();
@@ -59,7 +81,7 @@ export function findDuplicateCandidates(offers) {
   const byVendor = new Map();
   for (const o of offers) {
     if (!o.vendor) continue;
-    const key = o.vendor.toLowerCase().trim();
+    const key = normalizeVendor(o.vendor);
     if (!byVendor.has(key)) byVendor.set(key, []);
     byVendor.get(key).push(o);
   }
@@ -90,14 +112,23 @@ export function findDuplicateCandidates(offers) {
     }
     if (!flagged) continue;
 
-    candidates.push({
+    const rawNames = [...new Set(entries.map((e) => e.vendor))].sort();
+    const candidate = {
       vendor: entries[0].vendor,
-      entries: entries.map((e) => ({ category: e.category, tier: e.tier })),
+      entries: entries.map((e) => ({
+        vendor: e.vendor,
+        category: e.category,
+        tier: e.tier,
+      })),
       sharedTierTokens: [...sharedTokensUnion].sort(),
-    });
+    };
+    if (rawNames.length > 1) candidate.vendorNameVariants = rawNames;
+    candidates.push(candidate);
   }
 
-  return candidates.sort((a, b) => a.vendor.localeCompare(b.vendor));
+  return candidates.sort((a, b) =>
+    normalizeVendor(a.vendor).localeCompare(normalizeVendor(b.vendor)),
+  );
 }
 
 export function formatMarkdown(candidates) {
@@ -114,8 +145,13 @@ export function formatMarkdown(candidates) {
   for (const c of candidates) {
     lines.push(`### ${c.vendor}`);
     lines.push(`_Shared tier token(s): ${c.sharedTierTokens.join(", ")}_`);
+    if (c.vendorNameVariants) {
+      const variants = c.vendorNameVariants.map((v) => `"${v}"`).join(", ");
+      lines.push(`_Vendor name variants: ${variants}_`);
+    }
     for (const e of c.entries) {
-      lines.push(`- ${e.category} — ${e.tier}`);
+      const label = c.vendorNameVariants ? `${e.vendor} — ${e.category}` : e.category;
+      lines.push(`- ${label} — ${e.tier}`);
     }
     lines.push("");
   }

--- a/test/lint-duplicates.test.ts
+++ b/test/lint-duplicates.test.ts
@@ -1,9 +1,8 @@
 import { describe, it } from "node:test";
 import assert from "node:assert";
 
-const { findDuplicateCandidates, tierTokens, sharedTierTokens, formatMarkdown } = await import(
-  "../scripts/lint-duplicates.js"
-);
+const { findDuplicateCandidates, tierTokens, sharedTierTokens, formatMarkdown, normalizeVendor } =
+  await import("../scripts/lint-duplicates.js");
 
 describe("tierTokens", () => {
   it("lowercases and splits on whitespace", () => {
@@ -24,6 +23,58 @@ describe("tierTokens", () => {
     assert.deepStrictEqual([...tierTokens("")], []);
     assert.deepStrictEqual([...tierTokens(undefined)], []);
     assert.deepStrictEqual([...tierTokens(null)], []);
+  });
+});
+
+describe("normalizeVendor", () => {
+  it("lowercases and trims", () => {
+    assert.strictEqual(normalizeVendor("  Foo  "), "foo");
+    assert.strictEqual(normalizeVendor("FOO"), "foo");
+  });
+
+  it("strips TLD suffixes", () => {
+    assert.strictEqual(normalizeVendor("photopea.com"), "photopea");
+    assert.strictEqual(normalizeVendor("Cal.com"), "cal");
+    assert.strictEqual(normalizeVendor("trigger.dev"), "trigger");
+    assert.strictEqual(normalizeVendor("Adapty.io"), "adapty");
+    assert.strictEqual(normalizeVendor("Daily.co"), "daily");
+    assert.strictEqual(normalizeVendor("Neptune.ai"), "neptune");
+    assert.strictEqual(normalizeVendor("BinShare.net"), "binshare");
+    assert.strictEqual(normalizeVendor("Cron-job.org"), "cron-job");
+    assert.strictEqual(normalizeVendor("Updrafts.app"), "updrafts");
+  });
+
+  it("does not strip TLD-shaped fragments mid-name", () => {
+    // .com at start or middle is not a TLD suffix
+    assert.strictEqual(normalizeVendor("com Foo"), "com foo");
+    assert.strictEqual(normalizeVendor("Foo.com Bar"), "foo.com bar");
+  });
+
+  it("strips Inc./LLC/Ltd. corporate suffixes", () => {
+    assert.strictEqual(normalizeVendor("Acme Inc."), "acme");
+    assert.strictEqual(normalizeVendor("Acme Inc"), "acme");
+    assert.strictEqual(normalizeVendor("Acme LLC"), "acme");
+    assert.strictEqual(normalizeVendor("Acme Ltd"), "acme");
+    assert.strictEqual(normalizeVendor("Acme Ltd."), "acme");
+  });
+
+  it("preserves parenthetical disambiguators (Amazon Kiro pattern)", () => {
+    assert.notStrictEqual(
+      normalizeVendor("Amazon Kiro"),
+      normalizeVendor("Amazon Kiro (AWS Startups)"),
+    );
+  });
+
+  it("handles empty/null/undefined", () => {
+    assert.strictEqual(normalizeVendor(""), "");
+    assert.strictEqual(normalizeVendor(null), "");
+    assert.strictEqual(normalizeVendor(undefined), "");
+  });
+
+  it("groups TLD variants of the same vendor together", () => {
+    assert.strictEqual(normalizeVendor("Photopea"), normalizeVendor("photopea.com"));
+    assert.strictEqual(normalizeVendor("Evernote"), normalizeVendor("evernote.com"));
+    assert.strictEqual(normalizeVendor("ClickUp"), normalizeVendor("clickup.com"));
   });
 });
 
@@ -72,6 +123,66 @@ describe("findDuplicateCandidates", () => {
     ];
     const result = findDuplicateCandidates(offers);
     assert.strictEqual(result.length, 0);
+  });
+
+  it("flags TLD-suffix variants of the same vendor (Photopea pattern)", () => {
+    const offers = [
+      { vendor: "photopea.com", category: "Design", tier: "Free" },
+      { vendor: "Photopea", category: "Design & Creative", tier: "Free" },
+    ];
+    const result = findDuplicateCandidates(offers);
+    assert.strictEqual(result.length, 1);
+    assert.deepStrictEqual(result[0].vendorNameVariants, ["Photopea", "photopea.com"]);
+    assert.deepStrictEqual(result[0].sharedTierTokens, ["free"]);
+  });
+
+  it("flags case-only variants of the same vendor", () => {
+    const offers = [
+      { vendor: "Trello", category: "Productivity & Notes", tier: "Free" },
+      { vendor: "trello.com", category: "Project Management", tier: "Free" },
+    ];
+    const result = findDuplicateCandidates(offers);
+    assert.strictEqual(result.length, 1);
+    assert(result[0].vendorNameVariants);
+    assert.strictEqual(result[0].vendorNameVariants.length, 2);
+  });
+
+  it("flags Inc./LLC corporate-suffix variants", () => {
+    const offers = [
+      { vendor: "Acme Inc.", category: "Monitoring", tier: "Free" },
+      { vendor: "Acme", category: "Analytics", tier: "Free" },
+    ];
+    const result = findDuplicateCandidates(offers);
+    assert.strictEqual(result.length, 1);
+    assert.deepStrictEqual(result[0].vendorNameVariants, ["Acme", "Acme Inc."]);
+  });
+
+  it("does NOT flag TLD-variants when same category (case-variant in one category)", () => {
+    const offers = [
+      { vendor: "clickup.com", category: "Project Management", tier: "Free" },
+      { vendor: "ClickUp", category: "Project Management", tier: "Free" },
+    ];
+    const result = findDuplicateCandidates(offers);
+    assert.strictEqual(result.length, 0);
+  });
+
+  it("does NOT flag different vendors that share a root word (AWS S3 vs AWS EC2)", () => {
+    const offers = [
+      { vendor: "AWS S3", category: "Storage", tier: "Free" },
+      { vendor: "AWS EC2", category: "Compute", tier: "Free" },
+    ];
+    const result = findDuplicateCandidates(offers);
+    assert.strictEqual(result.length, 0);
+  });
+
+  it("omits vendorNameVariants field when all raw names match", () => {
+    const offers = [
+      { vendor: "Figma", category: "Design", tier: "Starter" },
+      { vendor: "Figma", category: "Design & Creative", tier: "Free (Starter)" },
+    ];
+    const result = findDuplicateCandidates(offers);
+    assert.strictEqual(result.length, 1);
+    assert.strictEqual(result[0].vendorNameVariants, undefined);
   });
 
   it("does NOT flag distinct products under same brand (Proton Mail vs Proton VPN)", () => {
@@ -149,20 +260,63 @@ describe("formatMarkdown", () => {
     assert.match(out, /Design & Creative — Free \(Starter\)/);
     assert.match(out, /starter/);
   });
+
+  it("surfaces vendor name variants when entries use different raw names", () => {
+    const out = formatMarkdown([
+      {
+        vendor: "Photopea",
+        entries: [
+          { vendor: "photopea.com", category: "Design", tier: "Free" },
+          { vendor: "Photopea", category: "Design & Creative", tier: "Free" },
+        ],
+        sharedTierTokens: ["free"],
+        vendorNameVariants: ["Photopea", "photopea.com"],
+      },
+    ]);
+    assert.match(out, /Vendor name variants: "Photopea", "photopea\.com"/);
+    assert.match(out, /photopea\.com — Design — Free/);
+    assert.match(out, /Photopea — Design & Creative — Free/);
+  });
 });
 
 describe("lint-duplicates against current data/index.json", () => {
-  it("finds no duplicate candidates against the current index", async () => {
+  // After PR #1003 added vendor-name normalization (TLD/corp suffix stripping),
+  // 5 latent dups surfaced that the exact-match key missed. Each will be
+  // resolved in a follow-up dedup PR. When the count reaches 0, flip this
+  // assertion to `result.length === 0` (the original form).
+  const EXPECTED_PENDING_VARIANTS = ["evernote", "internxt", "pcloud", "todoist", "trello"];
+
+  it("surfaces only known-pending normalized duplicate candidates", async () => {
     const { readFileSync } = await import("node:fs");
     const { resolve } = await import("node:path");
     const indexPath = resolve(process.cwd(), "data", "index.json");
     const data = JSON.parse(readFileSync(indexPath, "utf-8"));
     const result = findDuplicateCandidates(data.offers || []);
-    const vendors = result.map((c) => c.vendor);
-    assert.strictEqual(result.length, 0, `unexpected candidate(s): ${vendors.join(", ")}`);
+    const normalized = result.map((c) => normalizeVendor(c.vendor)).sort();
+    assert.deepStrictEqual(
+      normalized,
+      EXPECTED_PENDING_VARIANTS,
+      `candidate list drifted from expected — update EXPECTED_PENDING_VARIANTS after resolving in a dedup PR, or investigate if new ones appeared. got: ${normalized.join(", ")}`,
+    );
   });
 
-  it("does not flag Amazon Kiro (different vendor names)", async () => {
+  it("all surfaced candidates are vendor-name variants (not straight dedup gaps)", async () => {
+    const { readFileSync } = await import("node:fs");
+    const { resolve } = await import("node:path");
+    const indexPath = resolve(process.cwd(), "data", "index.json");
+    const data = JSON.parse(readFileSync(indexPath, "utf-8"));
+    const result = findDuplicateCandidates(data.offers || []);
+    // Every pending candidate should have vendorNameVariants set, confirming
+    // the normalization (not the exact-match path) is what surfaced it.
+    for (const c of result) {
+      assert(
+        c.vendorNameVariants && c.vendorNameVariants.length > 1,
+        `${c.vendor} lacks vendorNameVariants — if this is a pure same-name dup, it should have been caught pre-normalization`,
+      );
+    }
+  });
+
+  it("does not flag Amazon Kiro (parenthetical suffix preserved)", async () => {
     const { readFileSync } = await import("node:fs");
     const { resolve } = await import("node:path");
     const indexPath = resolve(process.cwd(), "data", "index.json");


### PR DESCRIPTION
## Summary

Adds `normalizeVendor()` to `scripts/lint-duplicates.js`: lowercases, strips common TLD suffixes (`.com`/`.io`/`.net`/`.org`/`.dev`/`.app`/`.co`/`.ai`) and corporate suffixes (`Inc.`/`LLC`/`Ltd.`). Keys `findDuplicateCandidates` on the normalized name so casing/suffix variants of the same vendor key together.

Refs #1003.

## Why

PR #985 shipped the exact-match lint and drove 6 dedup PRs (#986, #987, #988, #997, #1000, #1001, #1002). PR #1002 found one the lint missed: `photopea.com` (Design) and `Photopea` (Design & Creative) keyed separately because the `.com` suffix disambiguated the two strings, so the lint didn't flag the dup.

This PR closes that gap.

## Results against current data

Running `npm run lint:duplicates` against current `data/index.json` surfaces **5 latent dups** the exact-match path missed. Each is a genuine same-product-multi-category dup where the vendor-name form differs:

- `evernote.com` (Team Collaboration) vs `Evernote` (Productivity & Notes)
- `internxt.com` (Storage) vs `Internxt` (Cloud Storage)
- `pcloud.com` (Storage) vs `pCloud` (Cloud Storage)
- `todoist.com` (Project Management) vs `Todoist` (Productivity & Notes)
- `trello.com` (Project Management) vs `Trello` (Productivity & Notes)

Each will need a follow-up dedup PR (one PR per consolidation, per the principle established by the #968/#982/#983/… series). This PR deliberately does not bundle those consolidations — it ships the detection, so CI surfaces them going forward.

## Amazon Kiro regression

The known-legitimate dual Amazon Kiro entry (`Amazon Kiro` / `Amazon Kiro (AWS Startups)`) continues to not flag. The parenthetical disambiguator is preserved by `normalizeVendor`, so the two keys remain distinct. Confirmed by unit test + integration test against current data.

## Report format

When raw vendor names differ within a candidate, the markdown output now includes a `_Vendor name variants: "Photopea", "photopea.com"_` line and prefixes each entry with its raw name, so reviewers see both forms without needing to grep the data file.

## Test plan

- [x] Unit tests for `normalizeVendor`: TLDs, corp suffixes, case, parentheticals-preserved, empty/null
- [x] Unit tests for `findDuplicateCandidates` with TLD variants (positive), Inc./LLC (positive), same category (negative), Amazon Kiro (regression), distinct products (negative)
- [x] `formatMarkdown` variants-aware output test
- [x] Integration test against current `data/index.json` asserts the exact expected 5 pending candidates (test fails loudly if new ones appear or the set drifts — comment instructs future maintainers to shrink `EXPECTED_PENDING_VARIANTS` after each follow-up dedup PR)
- [x] Full suite: `npm test -- --test-concurrency=1` → 1134/1134 (+15 new)
- [x] `npm run lint:duplicates` produces the expected 5-candidate advisory report

## Related

- PR #985 (lint infrastructure — established advisory-only, Amazon-Kiro-as-allowlist-via-distinct-name)
- PR #1002 (Photopea dedup — surfaced the gap this PR closes)
- Op-learning #58 (exact-match as empty-allowlist mechanism; normalization widens only where variants are empirically the same product)