### PR TITLE
Deduplicate Todoist (keep Productivity & Notes)

### DIFF
--- a/data/category-mapping.json
+++ b/data/category-mapping.json
@@ -352,7 +352,6 @@
   "teleretro.com": "Project Management",
   "Tenzu": "Project Management",
   "titanapps.io": "Project Management",
-  "todoist.com": "Project Management",
   "Toggl": "Project Management",
   "trello.com": "Project Management",
   "Tweek": "Project Management",

--- a/data/index.json
+++ b/data/index.json
@@ -14564,18 +14564,6 @@
       "verifiedDate": "2026-04-12"
     },
     {
-      "vendor": "todoist.com",
-      "category": "Project Management",
-      "description": "Collaborative and individual task management. The free plan has: 5 active projects, five users in the project, file uploading up to 5MB, three filters, and one week of activity history.",
-      "tier": "Free",
-      "url": "https://todoist.com/",
-      "tags": [
-        "developer-tools",
-        "free-for-dev"
-      ],
-      "verifiedDate": "2026-04-12"
-    },
-    {
       "vendor": "Toggl",
       "category": "Project Management",
       "description": "Provides two free productivity tools. [Toggl Track](https://toggl.com/track/) for time management and tracking app with a free plan provides seamless time tracking and reporting designed with freelancers in mind. It has unlimited tracking records, projects, clients, tags, reporting, and more. And [Toggl Plan](https://toggl.com/plan/) for task planning with a free plan for solo developers with unlimited tasks, milestones, and timelines.",
@@ -21927,7 +21915,7 @@
     {
       "vendor": "Todoist",
       "category": "Productivity & Notes",
-      "description": "Up to 5 active projects. Up to 5 collaborators per project. 5 MB file upload limit. Basic priority levels. No reminders, no labels, no filters, no calendar view on free tier.",
+      "description": "Up to 5 active projects. Up to 5 collaborators per project. 5 MB file upload limit. Basic priority levels. No reminders, no labels, no filters, no calendar view on free tier. One week of activity history.",
       "tier": "Free",
       "url": "https://todoist.com/pricing",
       "tags": [
@@ -21937,7 +21925,7 @@
         "consumer",
         "free-tier"
       ],
-      "verifiedDate": "2026-04-17"
+      "verifiedDate": "2026-04-23"
     },
     {
       "vendor": "Trello",

--- a/src/serve.ts
+++ b/src/serve.ts
@@ -11949,7 +11949,7 @@ function buildProjectManagementAlternativesPage(): string {
     ["acunote.com", "Yodiz", "ScrumFast", "MeuScrum", "Teaminal", "Fibo", "easyretro.io", "teleretro.com", "planitpoker.com", "point.poker", "Zube"].includes(o.vendor)
   );
   const timeTracking = enrichedAll.filter(o =>
-    ["Clockify", "TimeCamp", "Toggl", "Pendulums", "Pulse.red", "Quidlo Timesheets", "Teamplify", "taskade.com", "todoist.com", "Tweek"].includes(o.vendor)
+    ["Clockify", "TimeCamp", "Toggl", "Pendulums", "Pulse.red", "Quidlo Timesheets", "Teamplify", "taskade.com", "Tweek"].includes(o.vendor)
   );
   const teamChat = enrichedAll.filter(o =>
     ["Chanty.com", "element.io", "flock.com", "Pumble", "Revolt.chat", "Rocket.Chat", "twist.com", "Zulip", "gitter.im", "Keybase", "Braid"].includes(o.vendor)
@@ -12099,7 +12099,7 @@ ${buildCards(kanbanBoards)}
 ${buildCards(agileScrumRetro)}
 
   <h2>Time Tracking &amp; Task Productivity</h2>
-  <p style="color:var(--text-muted);margin-bottom:1rem">Time trackers and personal productivity tools. Clockify offers unlimited free tracking. Toggl provides a polished interface with reporting. Todoist is a popular task manager with a generous free tier.</p>
+  <p style="color:var(--text-muted);margin-bottom:1rem">Time trackers and personal productivity tools. Clockify offers unlimited free tracking. Toggl provides a polished interface with reporting. Taskade combines task lists with team workspaces. For a dedicated personal task manager, see <a href="/vendor/todoist">Todoist</a> in our Productivity &amp; Notes category.</p>
 ${buildCards(timeTracking)}
 
   <h2>Team Chat &amp; Messaging</h2>

--- a/test/lint-duplicates.test.ts
+++ b/test/lint-duplicates.test.ts
@@ -281,10 +281,10 @@ describe("formatMarkdown", () => {
 
 describe("lint-duplicates against current data/index.json", () => {
   // After PR #1003 added vendor-name normalization (TLD/corp suffix stripping),
-  // 5 latent dups surfaced that the exact-match key missed. Each will be
-  // resolved in a follow-up dedup PR. When the count reaches 0, flip this
-  // assertion to `result.length === 0` (the original form).
-  const EXPECTED_PENDING_VARIANTS = ["evernote", "internxt", "pcloud", "todoist", "trello"];
+  // 5 latent dups surfaced that the exact-match key missed. Each resolved in a
+  // follow-up dedup PR. When the count reaches 0, flip this assertion to
+  // `result.length === 0` (the original form).
+  const EXPECTED_PENDING_VARIANTS = ["evernote", "internxt", "pcloud", "trello"];
 
   it("surfaces only known-pending normalized duplicate candidates", async () => {
     const { readFileSync } = await import("node:fs");


### PR DESCRIPTION
## Summary

Eleventh dedup PR in the series, resolves one of the 5 latent vendor-name variants surfaced by PR #1004's normalized lint (`EXPECTED_PENDING_VARIANTS`). Same-product-multi-category duplicate: `todoist.com` in Project Management + `Todoist` in Productivity & Notes.

- **Retired:** `todoist.com` — Project Management — Free (verified 2026-04-12)
- **Kept:** `Todoist` — Productivity & Notes — Free (verified 2026-04-17 → 2026-04-23)

No filed issue — this is an idle-time follow-up to the known-pending backlog encoded in `EXPECTED_PENDING_VARIANTS` (test/lint-duplicates.test.ts:287). Per the one-PR-per-consolidation principle (op-learnings #59 / #72), each pending variant gets its own PR.

## Category decision — unified peer-group-match heuristic (op-learning #72)

**Rule:** pick the category that surfaces the vendor's named competitors in `/api/details/:slug.relatedVendors`.

| Counterfactual | `relatedVendors` | Verdict |
|---|---|---|
| `/api/details/todoist` (Productivity & Notes) | Notion, Trello, Google Keep, Obsidian, Apple Notes | Todoist's direct consumer-productivity peers |
| `/api/details/todoist.com` (Project Management) | Linear, Atlassian, Fibery, Fibo, Fizzy | team engineering PM tools, not Todoist's peer group |

Todoist is a consumer task manager (like TickTick, Microsoft To Do, Apple Notes — all in Productivity & Notes). Project Management houses team engineering tools (Linear/Asana/Jira-adjacent). Peer-group match is decisive even though Project Management (50 entries) is larger than Productivity & Notes (13). Same unified rule as Canva (PR #1001) and Photopea (PR #1002) — population is a weak signal vs direct-competitor proximity.

## Description merge

The two entries had conflicting free-tier details (retired entry: "three filters"; kept entry: "no filters"). The kept entry's 2026-04-17 verify supersedes 2026-04-12 — trusted the newer. Added the verifiable "One week of activity history" detail from the retired entry since it was missing from the kept description. Bumped `verifiedDate` to 2026-04-23.

## Collateral cleanup (op-learning #75 — two classes exercised)

- **(a) Dead-code filter array** — `src/serve.ts` L11952 (`timeTracking` array on `/project-management-alternatives`): removed `"todoist.com"`. The page filters by Project Management + Team Collaboration categories, so Todoist no longer renders there.
- **(b) Stale descriptive prose** — `src/serve.ts` L12102: rewrote Time Tracking & Task Productivity section intro. The previous prose said "Todoist is a popular task manager with a generous free tier" — stale after Todoist leaves this page. Replaced with a Taskade mention + cross-link to `/vendor/todoist` in Productivity & Notes for discoverability.
- `data/category-mapping.json` — removed `"todoist.com"` entry (inert today since recategorize.ts only acts on Developer Tools; prophylactic hygiene per PR #1001/#1002).

## Test updates

`test/lint-duplicates.test.ts` `EXPECTED_PENDING_VARIANTS`: removed `"todoist"` (5 → 4: evernote, internxt, pcloud, trello remaining). Comment tightened to reflect progress ("Each resolved in a follow-up dedup PR" → pointing at this PR's pattern).

## Verification (local `BASE_URL=http://localhost:3000`)

- `/api/offers` total: 1,576 → 1,575 ✓
- `/api/offers?category=Project Management`: 51 → 50 (Todoist absent) ✓
- `/api/offers?category=Productivity & Notes`: 13 (unchanged, Todoist kept) ✓
- `/api/details/todoist`: category Productivity & Notes, relatedVendors `[Notion, Trello, Google Keep, Obsidian, Apple Notes]` ✓
- `/api/details/todoist.com`: 404 with suggestion `"Todoist"` ✓
- `/api/offers?q=todoist`: 1 result (was 2) ✓
- `/vendor/todoist`: 200, breadcrumb `Home > Productivity & Notes > Todoist` ✓
- `/vendor/todoist-com`: 301 → `/vendor/todoist` (PR #990 fuzzy resolver handles old URL) ✓
- `/alternative-to/todoist`: 200 ✓
- `/category/productivity-notes`: 200 ✓
- `/project-management-alternatives`: 200, 0 Todoist cards, cross-link present in Time Tracking intro prose ✓
- `/search?q=todoist`: 200, 1 result ✓
- `npm run lint:duplicates`: 4 candidates (down from 5) ✓
- **1,134 / 1,134 tests pass on `--test-concurrency=1`**

## Follow-up backlog

Four remaining latent vendor-name variants, each priority/low single-PR:
- `evernote` (Team Collaboration vs Productivity & Notes)
- `internxt` (Storage vs Cloud Storage)
- `pcloud` (Storage vs Cloud Storage)
- `trello` (Project Management vs Productivity & Notes) — expect the same shape as Todoist

## Test plan
- [x] 1,134 tests pass on `--test-concurrency=1`
- [x] `npm run lint:duplicates` surfaces 4 candidates (expected set: evernote/internxt/pcloud/trello)
- [x] `/vendor/todoist`, `/alternative-to/todoist`, `/category/productivity-notes`, `/project-management-alternatives` all 200
- [x] `/vendor/todoist-com` 301 redirects correctly
- [x] `relatedVendors` on `/api/details/todoist` lists Todoist's direct consumer-productivity peers