### PR TITLE
Deduplicate Trello (keep Productivity & Notes)

### DIFF
--- a/data/category-mapping.json
+++ b/data/category-mapping.json
@@ -353,7 +353,6 @@
   "Tenzu": "Project Management",
   "titanapps.io": "Project Management",
   "Toggl": "Project Management",
-  "trello.com": "Project Management",
   "Tweek": "Project Management",
   "Wikifactory": "Project Management",
   "Yodiz": "Project Management",

--- a/data/index.json
+++ b/data/index.json
@@ -14576,18 +14576,6 @@
       "verifiedDate": "2026-04-12"
     },
     {
-      "vendor": "trello.com",
-      "category": "Project Management",
-      "description": "Board-based project management. Unlimited Personal Boards, 10 Team Boards.",
-      "tier": "Free",
-      "url": "https://trello.com/",
-      "tags": [
-        "developer-tools",
-        "free-for-dev"
-      ],
-      "verifiedDate": "2026-04-12"
-    },
-    {
       "vendor": "Tweek",
       "category": "Project Management",
       "description": "Simple Weekly To-Do Calendar & Task Management.",
@@ -21939,7 +21927,7 @@
         "consumer",
         "free-tier"
       ],
-      "verifiedDate": "2026-04-17"
+      "verifiedDate": "2026-04-23"
     },
     {
       "vendor": "Google Keep",

--- a/src/serve.ts
+++ b/src/serve.ts
@@ -11940,7 +11940,7 @@ function buildProjectManagementAlternativesPage(): string {
 
   // Group by domain
   const issueTracking = enrichedAll.filter(o =>
-    ["Linear", "Atlassian", "Plane", "Huly", "Shortcut", "clickup.com", "asana.com", "trello.com", "Basecamp", "taiga.io", "nTask", "freedcamp.com", "bitrix24.com", "teamwork.com", "Backlog", "GForge", "Tenzu", "Crosswork", "Sflow", "Kitemaker.co", "leiga.com", "Teamcamp", "titanapps.io", "Wikifactory", "RightFeature", "zenhub.com", "zenkit.com"].includes(o.vendor)
+    ["Linear", "Atlassian", "Plane", "Huly", "Shortcut", "clickup.com", "asana.com", "Basecamp", "taiga.io", "nTask", "freedcamp.com", "bitrix24.com", "teamwork.com", "Backlog", "GForge", "Tenzu", "Crosswork", "Sflow", "Kitemaker.co", "leiga.com", "Teamcamp", "titanapps.io", "Wikifactory", "RightFeature", "zenhub.com", "zenkit.com"].includes(o.vendor)
   );
   const kanbanBoards = enrichedAll.filter(o =>
     ["gokanban.io", "kan.bn", "kanbanflow.com", "kanbantool.com", "MeisterTask", "Teamhood", "HeySpace", "Fizzy", "Fibery", "Hygger"].includes(o.vendor)
@@ -12160,7 +12160,7 @@ ${buildCards(other)}
         <td>All-in-one PM with chat, docs, and HR built in</td>
       </tr>
       <tr>
-        <td style="font-weight:600"><a href="/vendor/trello-com" style="color:var(--text)">Trello</a></td>
+        <td style="font-weight:600"><a href="/vendor/trello" style="color:var(--text)">Trello</a></td>
         <td>Kanban</td>
         <td>Unlimited cards, 10 boards/workspace</td>
         <td>No</td>
@@ -12237,7 +12237,7 @@ ${buildCards(other)}
       <dd><a href="/vendor/plane">Plane</a> — open-source Jira alternative with cycles and modules. <a href="/vendor/huly">Huly</a> — all-in-one with chat, docs, and HR. <a href="/vendor/taiga-io">Taiga</a> — agile PM with Scrum and Kanban.</dd>
 
       <dt>Need simple visual kanban boards?</dt>
-      <dd><a href="/vendor/trello-com">Trello</a> — 10 boards free with Power-Ups. <a href="/vendor/kanbanflow-com">KanbanFlow</a> — Pomodoro timer built in. <a href="/vendor/meistertask">MeisterTask</a> — visual boards with automations.</dd>
+      <dd><a href="/vendor/trello">Trello</a> — 10 boards free with Power-Ups. <a href="/vendor/kanbanflow-com">KanbanFlow</a> — Pomodoro timer built in. <a href="/vendor/meistertask">MeisterTask</a> — visual boards with automations.</dd>
 
       <dt>Need time tracking for your team?</dt>
       <dd><a href="/vendor/clockify">Clockify</a> — unlimited tracking and users, free forever. <a href="/vendor/toggl">Toggl</a> — polished UI with reports, 5 users free. <a href="/vendor/timecamp">TimeCamp</a> — automatic time tracking.</dd>

--- a/test/lint-duplicates.test.ts
+++ b/test/lint-duplicates.test.ts
@@ -284,7 +284,7 @@ describe("lint-duplicates against current data/index.json", () => {
   // 5 latent dups surfaced that the exact-match key missed. Each resolved in a
   // follow-up dedup PR. When the count reaches 0, flip this assertion to
   // `result.length === 0` (the original form).
-  const EXPECTED_PENDING_VARIANTS = ["evernote", "internxt", "pcloud", "trello"];
+  const EXPECTED_PENDING_VARIANTS = ["evernote", "internxt", "pcloud"];
 
   it("surfaces only known-pending normalized duplicate candidates", async () => {
     const { readFileSync } = await import("node:fs");


### PR DESCRIPTION
## Summary
Twelfth in the agentdeals dedup series, and second of the PR #1004 latent-variant backlog (after Todoist PR #1005). Retires `trello.com` (Project Management); keeps `Trello` (Productivity & Notes).

**Unified peer-group-match heuristic** (op-learning #72) applied. Ran the counterfactual on both slugs and the answer was unambiguous:

- `/api/details/trello` (Productivity & Notes, 13 entries): `relatedVendors = [Notion, Todoist, Google Keep, Obsidian, Apple Notes]` — Trello's direct consumer-kanban/task peers.
- Project Management category members (50 entries): Linear, Atlassian, Fibery, Fibo, Fizzy, Asana, Basecamp, ClickUp, … — a team-engineering cohort, wrong peer group for a consumer kanban tool.

Same shape as Todoist (PR #1005), sixth canonical shape (f) in the heuristic library.

## Description merge
The kept entry's `verifiedDate` is 2026-04-17 (vs 2026-04-12 on the retired) and its description is more detailed (unlimited cards, up to 10 boards per workspace, Unlimited Power-Ups, 10 MB per file attachment, 250 Workspace command runs per month, Unlimited activity log) and more current than the retired entry's "Unlimited Personal Boards, 10 Team Boards" framing (which conflicts with current Trello pricing where all users share a workspace quota). Trust the newer verified entry. Bumped verifiedDate to 2026-04-23.

## Collateral cleanup (op-learning #75)
- `data/category-mapping.json`: removed `"trello.com": "Project Management"` (inert but prophylactic hygiene).
- `src/serve.ts` L11943 `issueTracking` filter array: removed `"trello.com"` (dead code — entry no longer exists).
- `src/serve.ts` L12163 PM table row + L12240 decision-guide link: updated `/vendor/trello-com` → `/vendor/trello` for canonical linking. The PR #990 fuzzy resolver still 301s the old form for any external backlinks.

## Kept intact (intentional)
- `pmChangeVendors` array (L11990) retains `"Trello"` — deal_changes aggregation still surfaces Trello-related pricing changes on the PM alternatives page regardless of category.
- Meta description and `/project-management-alternatives` card for Trello retained — SEO signal for users searching for PM alternatives (Trello is commonly considered a lightweight PM tool even if our taxonomy houses it in Productivity & Notes).

## Verification (local server, BASE_URL=http://localhost:3000)
- `/api/offers` total: 1575 → 1574 ✓
- `/api/offers?category=Project%20Management`: 50 → 49 ✓
- `/api/offers?category=Productivity%20%26%20Notes`: 13 (unchanged, Trello kept) ✓
- `/api/details/trello`: category Productivity & Notes, verifiedDate 2026-04-23, relatedVendors consumer cohort ✓
- `/api/details/trello-com`: 404 with suggestion `"Trello"` ✓
- `/api/offers?q=trello`: 1 Trello result (was 2) + 3 unrelated mentions ✓
- `/vendor/trello`: 200 ✓
- `/vendor/trello-com`: 301 → `/vendor/trello` (PR #990 fuzzy resolver) ✓
- `/project-management-alternatives`: 200, 0 `/vendor/trello-com` references, table row + decision guide link to `/vendor/trello` ✓
- `/alternative-to/trello`, `/category/productivity-notes`, `/search?q=trello`: 200 ✓
- `npm run lint:duplicates`: 3 candidates (was 4) ✓
- 1134/1134 tests pass `--test-concurrency=1`

## Backlog
After this PR, 3 latent dedup candidates remain from PR #1004's normalized lint: evernote (Team Collaboration vs Productivity & Notes), internxt (Storage vs Cloud Storage), pcloud (Storage vs Cloud Storage). EXPECTED_PENDING_VARIANTS regression fence stays active.

## Test plan
- [x] `npm run build && npm test -- --test-concurrency=1` passes (1134/1134)
- [x] `npm run lint:duplicates` shows 3 candidates (evernote, internxt, pcloud)
- [x] Local E2E verification via `BASE_URL=http://localhost:3000 node dist/serve.js`
- [x] `/project-management-alternatives` still renders Trello with canonical `/vendor/trello` links

Refs #1004