### PR TITLE
Deduplicate Evernote (keep Productivity & Notes)

### DIFF
--- a/data/category-mapping.json
+++ b/data/category-mapping.json
@@ -173,7 +173,6 @@
   "DevToolLab": "Dev Utilities",
   "Duckly": "Team Collaboration",
   "element.io": "Team Collaboration",
-  "evernote.com": "Team Collaboration",
   "Fibery": "Project Management",
   "Fibo": "Project Management",
   "Fizzy": "Project Management",

--- a/data/index.json
+++ b/data/index.json
@@ -8258,18 +8258,6 @@
       "verifiedDate": "2026-04-13"
     },
     {
-      "vendor": "evernote.com",
-      "category": "Team Collaboration",
-      "description": "Note-taking — 50 notes, 1 notebook, 20 MB monthly uploads, 1 device sync, 50 attachments, 20 tags, 5 spaces. Web clipper and search included",
-      "tier": "Free",
-      "url": "https://evernote.com/",
-      "tags": [
-        "developer-tools",
-        "free-for-dev"
-      ],
-      "verifiedDate": "2026-04-14"
-    },
-    {
       "vendor": "Fibery",
       "category": "Project Management",
       "description": "Connected workspace platform. Free for up to 10 users, 10 databases, unlimited entities.",
@@ -22036,7 +22024,7 @@
     {
       "vendor": "Evernote",
       "category": "Productivity & Notes",
-      "description": "Up to 50 notes total. 1 notebook. 60 MB monthly upload limit. 25 MB max note size. Single device sync plus web. Basic search. No offline notebooks, PDF annotation, or email forwarding on free.",
+      "description": "Up to 50 notes total. 1 notebook. 60 MB monthly upload limit. 25 MB max note size. Single device sync plus web. Basic search and Web Clipper included. No offline notebooks, PDF annotation, or email forwarding on free.",
       "tier": "Free",
       "url": "https://evernote.com/free",
       "tags": [
@@ -22045,7 +22033,7 @@
         "consumer",
         "free-tier"
       ],
-      "verifiedDate": "2026-04-17"
+      "verifiedDate": "2026-04-23"
     },
     {
       "vendor": "Coda",

--- a/src/serve.ts
+++ b/src/serve.ts
@@ -11958,7 +11958,7 @@ function buildProjectManagementAlternativesPage(): string {
     ["meet.jit.si", "talky.io", "Webex", "zoom.us", "Duckly", "Tencent RTC", "Screen Sharing via Browser", "flat.social"].includes(o.vendor)
   );
   const docsKnowledge = enrichedAll.filter(o =>
-    ["Notion", "Hackmd.io", "Nuclino", "Slab", "cDox", "evernote.com", "BookmarkOS.com", "Raindrop.io", "Linkinize", "Stickies", "Liveblocks", "GitDailies", "Lockitbot"].includes(o.vendor)
+    ["Notion", "Hackmd.io", "Nuclino", "Slab", "cDox", "BookmarkOS.com", "Raindrop.io", "Linkinize", "Stickies", "Liveblocks", "GitDailies", "Lockitbot"].includes(o.vendor)
   );
   const scheduling = enrichedAll.filter(o =>
     ["Cal.com", "Calendly", "cally.com"].includes(o.vendor)
@@ -13249,7 +13249,7 @@ function buildTeamCollaborationAlternativesPage(): string {
     ["meet.jit.si", "zoom.us", "Webex", "Daily.co", "Whereby", "Tencent RTC", "talky.io", "LiveKit", "Mux", "wistia.com", "flat.social", "Duckly", "Screen Sharing via Browser"].includes(o.vendor)
   );
   const docsKnowledge = enrichedAll.filter(o =>
-    ["Notion", "Hackmd.io", "Nuclino", "Slab", "cDox", "evernote.com", "BookmarkOS.com", "Raindrop.io", "Linkinize", "Liveblocks", "GitDailies"].includes(o.vendor)
+    ["Notion", "Hackmd.io", "Nuclino", "Slab", "cDox", "BookmarkOS.com", "Raindrop.io", "Linkinize", "Liveblocks", "GitDailies"].includes(o.vendor)
   );
   const scheduling = enrichedAll.filter(o =>
     ["Cal.com", "Calendly", "cally.com"].includes(o.vendor)

--- a/test/lint-duplicates.test.ts
+++ b/test/lint-duplicates.test.ts
@@ -284,7 +284,7 @@ describe("lint-duplicates against current data/index.json", () => {
   // 5 latent dups surfaced that the exact-match key missed. Each resolved in a
   // follow-up dedup PR. When the count reaches 0, flip this assertion to
   // `result.length === 0` (the original form).
-  const EXPECTED_PENDING_VARIANTS = ["evernote", "internxt", "pcloud"];
+  const EXPECTED_PENDING_VARIANTS = ["internxt", "pcloud"];
 
   it("surfaces only known-pending normalized duplicate candidates", async () => {
     const { readFileSync } = await import("node:fs");


### PR DESCRIPTION
## Summary

Thirteenth PR in the dedup series; third of PR #1004's latent-variant backlog
(after Todoist #1005 and Trello #1006). Resolves the `evernote` candidate from
`npm run lint:duplicates` output.

Two Evernote entries described the same product (free tier with 50 notes, 1
notebook, single-device sync) in different categories. Applied the unified
peer-group-match heuristic (op-learning #72) to pick the keeper.

## Decision

- **Kept:** `Evernote` (Productivity & Notes, 13 entries, verifiedDate bumped to 2026-04-23)
- **Retired:** `evernote.com` (Team Collaboration, 34 → 33 entries, verifiedDate was 2026-04-14)

## Why Productivity & Notes wins

`/api/details/evernote` (Productivity & Notes) relatedVendors:
**Notion, Todoist, Trello, Google Keep, Obsidian** — Evernote's direct named
competitors as a consumer note-taking app.

`/api/details/evernote.com` (Team Collaboration) relatedVendors:
**Cal.com, Liveblocks, BookmarkOS.com, Braid, Calendly** — scheduling and
realtime-collab tools, not Evernote's peer cohort.

Same shape (f) as Todoist (#1005) and Trello (#1006) — the smaller coherent
consumer category beats the larger team-engineering category because the
larger one is a miscategorization. Third instance of this shape; the unified
rule is now well-validated as shape-stable across multiple consumer-tool
miscategorization cases.

## Description

Kept entry is already comprehensive. Merged "Web Clipper" detail from the
retired entry (verifiable, well-known Evernote feature). Did NOT merge the
conflicting upload-limit detail (20 MB retired vs 60 MB kept) — trusted the
more recent verification per pattern.

## Collateral cleanup (op-learning #75 class a)

- `data/category-mapping.json` — removed `"evernote.com": "Team Collaboration"`
- `src/serve.ts:11961` — removed `"evernote.com"` from `/project-management-alternatives` `docsKnowledge` filter
- `src/serve.ts:13252` — removed `"evernote.com"` from `/team-collaboration-alternatives` `docsKnowledge` filter

No prose mentions to update — neither alternatives page had Evernote in
introductory text (unlike Photopea/Todoist which needed class b cleanup).

## Tests

`EXPECTED_PENDING_VARIANTS` regression fence (op-learning #76):
`["evernote","internxt","pcloud"]` → `["internxt","pcloud"]`.

The `normalizeVendor("Evernote") === normalizeVendor("evernote.com")` assertion
is preserved — it tests the normalizer, not the data.

## Verification (local, BASE_URL=http://localhost:3000)

- `/api/offers` total: 1574 → 1573 ✓
- `/api/offers?category=Team Collaboration`: 34 → 33 ✓
- `/api/offers?category=Productivity & Notes`: 13 (unchanged, Evernote kept) ✓
- `/api/details/evernote`: Productivity & Notes, verifiedDate 2026-04-23, expected relatedVendors ✓
- `/api/details/evernote.com`: 404 with suggestion "Evernote" ✓
- `/vendor/evernote`: 200 ✓
- `/vendor/evernote-com`: 301 → `/vendor/evernote` (PR #990 fuzzy resolver) ✓
- `/project-management-alternatives`, `/team-collaboration-alternatives`, `/alternative-to/evernote`, `/category/productivity-notes`: all 200, 0 `evernote.com` refs ✓
- `npm run lint:duplicates`: 2 candidates (was 3) ✓
- 1,134 / 1,134 tests pass on `--test-concurrency=1` ✓

Refs: lint surfaced this in PR #1004 normalization; series #968 → #982 → #983 → #986 → #987 → #988 → #997 → #1000 → #1001 → #1002 → #1005 → #1006.