### PR TITLE
Fuzzy-resolve /api/details and MCP search_deals({vendor}) (#1008)

### DIFF
--- a/src/openapi.ts
+++ b/src/openapi.ts
@@ -207,22 +207,37 @@ export const openapiSpec = {
     "/api/details/{vendor}": {
       get: {
         summary: "Vendor detail with alternatives",
-        description: "Get detailed information about a specific vendor's offer. Optionally includes alternatives in the same category.",
+        description: "Get detailed information about a specific vendor's offer. Optionally includes alternatives in the same category. Accepts canonical vendor names (e.g. \"Supabase\") or short-form slugs (e.g. \"kiro\" → Amazon Kiro, \"proton\" → multi-product disambiguation). Fuzzy matches resolve in-place and return `resolved_from`. Ambiguous inputs return 200 with a `disambiguation` array instead of an `offer`.",
         parameters: [
-          { name: "vendor", in: "path", required: true, description: "Vendor name (URL-encoded)", schema: { type: "string" }, example: "Supabase" },
+          { name: "vendor", in: "path", required: true, description: "Vendor name or short-form slug (URL-encoded)", schema: { type: "string" }, example: "Supabase" },
           { name: "alternatives", in: "query", description: "Include alternative vendors in the same category", schema: { type: "string", enum: ["true", "false"], default: "false" } }
         ],
         responses: {
           "200": {
-            description: "Vendor offer details",
+            description: "Vendor offer details, OR a disambiguation list when the input matches multiple vendors (e.g. \"proton\"). When the input was fuzzy-matched to a canonical vendor, the response includes `resolved_from`.",
             content: {
               "application/json": {
                 schema: {
-                  type: "object",
-                  properties: {
-                    offer: { $ref: "#/components/schemas/Offer" },
-                    alternatives: { type: "array", items: { $ref: "#/components/schemas/Offer" }, description: "Only present when alternatives=true" }
-                  }
+                  oneOf: [
+                    {
+                      type: "object",
+                      description: "Resolved vendor offer",
+                      properties: {
+                        offer: { $ref: "#/components/schemas/Offer" },
+                        alternatives: { type: "array", items: { $ref: "#/components/schemas/Offer" }, description: "Only present when alternatives=true" },
+                        resolved_from: { type: "string", description: "Original input when fuzzy-matched to a canonical vendor (e.g. input \"kiro\" resolves to Amazon Kiro)" }
+                      }
+                    },
+                    {
+                      type: "object",
+                      description: "Disambiguation list when input matches multiple vendors",
+                      required: ["disambiguation", "resolved_from"],
+                      properties: {
+                        disambiguation: { type: "array", items: { type: "object", properties: { slug: { type: "string" }, name: { type: "string" } } } },
+                        resolved_from: { type: "string" }
+                      }
+                    }
+                  ]
                 }
               }
             }
@@ -236,7 +251,7 @@ export const openapiSpec = {
             }
           },
           "404": {
-            description: "Vendor not found",
+            description: "Vendor not found (no exact match AND no fuzzy resolution)",
             content: {
               "application/json": {
                 schema: {

--- a/src/serve.ts
+++ b/src/serve.ts
@@ -19,6 +19,7 @@ import { getPlatformCodeForVendor, getBestReferralCode, listAllReferralCodes } f
 import { runHealthCheck, getLastReport, startPeriodicChecks } from "./referral-health.js";
 import { addFriend, removeFriend, getFriends, getFriendCodesForVendors } from "./friends.js";
 import { subscribe as watchlistSubscribe, getSubscription as getWatchlistSubscription, unsubscribe as watchlistUnsubscribe, listSubscriptions as listWatchlistSubscriptions } from "./watchlist.js";
+import { toSlug, vendorSlugMap, resolveVendorSlug } from "./vendor-slug.js";
 import type { Agent } from "./types.js";
 import type { AgentBalance } from "./ledger.js";
 import type { SubmittedReferralCode } from "./referral-codes.js";
@@ -386,26 +387,18 @@ ${entries}
   </div>`;
 }
 
-function toSlug(name: string): string {
-  return name.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-|-$/g, "");
-}
-
 // Build category slug → name lookup
 const categorySlugMap = new Map<string, string>();
 for (const cat of categories) {
   categorySlugMap.set(toSlug(cat.name), cat.name);
 }
 
-// Build vendor slug → name lookup (deduped by slug, first occurrence wins)
-// Also build vendor slug → most recent verifiedDate for sitemap lastmod
-const vendorSlugMap = new Map<string, string>();
+// Build vendor slug → most recent verifiedDate for sitemap lastmod
+// (vendorSlugMap itself now lives in vendor-slug.ts and is imported above.)
 const vendorLastmod = new Map<string, string>();
 for (const o of offers) {
   const slug = toSlug(o.vendor);
   if (!slug) continue;
-  if (!vendorSlugMap.has(slug)) {
-    vendorSlugMap.set(slug, o.vendor);
-  }
   const prev = vendorLastmod.get(slug);
   if (!prev || o.verifiedDate > prev) {
     vendorLastmod.set(slug, o.verifiedDate);
@@ -433,59 +426,6 @@ for (const o of offers) {
 
 function getVendorCategory(vendorName: string): string | null {
   return vendorCategoryMap.get(vendorName.toLowerCase()) ?? null;
-}
-
-// Resolve a user-typed vendor slug to its canonical form via substring matching
-// against the known vendor slug map. Returns:
-//   - exact: the slug matches a known vendor — caller should render normally
-//   - redirect: one root match — caller should 301 to the canonical slug
-//   - disambiguate: multiple distinct root matches — caller should render a "did you mean?" page
-//   - none: no match — caller should render 404
-// The "root" filter collapses parent/child slug pairs (e.g. amazon-kiro vs
-// amazon-kiro-aws-startups): a child slug that extends a sibling root is dropped.
-type VendorSlugResolution =
-  | { type: "exact"; slug: string }
-  | { type: "redirect"; slug: string }
-  | { type: "disambiguate"; slugs: string[] }
-  | { type: "none" };
-
-// `needle` is a sub-slug of `haystack` when it appears at slug-segment boundaries
-// (i.e., bounded by "-" or start/end of string). Avoids false matches where the
-// input is embedded mid-segment (e.g., "tally" inside "totally" should NOT match).
-function isSubSlug(needle: string, haystack: string): boolean {
-  if (needle === haystack) return true;
-  if (haystack.startsWith(needle + "-")) return true;
-  if (haystack.endsWith("-" + needle)) return true;
-  return haystack.includes("-" + needle + "-");
-}
-
-function resolveVendorSlug(input: string): VendorSlugResolution {
-  if (!input) return { type: "none" };
-  if (vendorSlugMap.has(input)) return { type: "exact", slug: input };
-  if (input.length < 3) return { type: "none" };
-
-  const allSlugs = [...vendorSlugMap.keys()];
-
-  // Completions: known slugs that contain the input as a sub-slug (short-form lookups like "kiro")
-  const completions = allSlugs.filter(s => s !== input && isSubSlug(input, s));
-  if (completions.length > 0) {
-    // Drop any completion that is a "-"-delimited extension of another completion
-    // (e.g., prefer amazon-kiro over amazon-kiro-aws-startups).
-    const roots = completions.filter(
-      s => !completions.some(other => other !== s && s.startsWith(other + "-"))
-    );
-    if (roots.length === 1) return { type: "redirect", slug: roots[0] };
-    return { type: "disambiguate", slugs: roots.slice(0, 10).sort() };
-  }
-
-  // Generalizations: known slugs that are sub-slugs of the input (extra-specific lookups)
-  const generalizations = allSlugs.filter(s => s !== input && isSubSlug(s, input));
-  if (generalizations.length > 0) {
-    const longest = generalizations.reduce((a, b) => (b.length > a.length ? b : a));
-    return { type: "redirect", slug: longest };
-  }
-
-  return { type: "none" };
 }
 
 function escHtmlServer(s: string): string {
@@ -53813,17 +53753,39 @@ const httpServer = createHttpServer(async (req, res) => {
       return;
     }
     const includeAlternatives = url.searchParams.get("alternatives") === "true";
-    const detailResult = getOfferDetails(vendorParam, includeAlternatives);
+    let detailResult = getOfferDetails(vendorParam, includeAlternatives);
+    let resolvedFrom: string | null = null;
+    if ("error" in detailResult) {
+      // Fuzzy-resolve: treat vendorParam as a slug and see if it maps to a
+      // known vendor (e.g. "kiro" → "Amazon Kiro", "amazon-kiro" → exact).
+      const resolution = resolveVendorSlug(toSlug(vendorParam));
+      if (resolution.type === "exact" || resolution.type === "redirect") {
+        const canonicalName = vendorSlugMap.get(resolution.slug);
+        if (canonicalName) {
+          const retry = getOfferDetails(canonicalName, includeAlternatives);
+          if (!("error" in retry)) {
+            detailResult = retry;
+            resolvedFrom = vendorParam;
+          }
+        }
+      } else if (resolution.type === "disambiguate") {
+        const disambiguation = resolution.slugs.map(s => ({ slug: s, name: vendorSlugMap.get(s) ?? s }));
+        logRequest({ ts: new Date().toISOString(), type: "api", endpoint: "/api/details", params: { vendor: vendorParam, alternatives: includeAlternatives, disambiguated: true }, user_agent: req.headers["user-agent"] ?? "unknown", result_count: disambiguation.length });
+        res.writeHead(200, { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" });
+        res.end(JSON.stringify({ disambiguation, resolved_from: vendorParam }));
+        return;
+      }
+    }
     if ("error" in detailResult) {
       logRequest({ ts: new Date().toISOString(), type: "api", endpoint: "/api/details", params: { vendor: vendorParam, alternatives: includeAlternatives }, user_agent: req.headers["user-agent"] ?? "unknown", result_count: 0 });
       res.writeHead(404, { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" });
       res.end(JSON.stringify({ error: detailResult.error, suggestions: detailResult.suggestions }));
       return;
     }
-    logRequest({ ts: new Date().toISOString(), type: "api", endpoint: "/api/details", params: { vendor: vendorParam, alternatives: includeAlternatives }, user_agent: req.headers["user-agent"] ?? "unknown", result_count: 1 });
+    logRequest({ ts: new Date().toISOString(), type: "api", endpoint: "/api/details", params: { vendor: vendorParam, alternatives: includeAlternatives, ...(resolvedFrom ? { resolved_from: resolvedFrom } : {}) }, user_agent: req.headers["user-agent"] ?? "unknown", result_count: 1 });
     const offerWithCode = { ...detailResult.offer, referral_code: getBestReferralCode(detailResult.offer.vendor) };
     res.writeHead(200, { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" });
-    res.end(JSON.stringify({ offer: offerWithCode, ...(includeAlternatives ? { alternatives: detailResult.offer.alternatives } : {}) }));
+    res.end(JSON.stringify({ offer: offerWithCode, ...(includeAlternatives ? { alternatives: detailResult.offer.alternatives } : {}), ...(resolvedFrom ? { resolved_from: resolvedFrom } : {}) }));
   } else if (url.pathname === "/api/expiring" && isGetOrHead) {
     recordApiHit("/api/expiring");
     const withinDays = Math.min(Math.max(parseInt(url.searchParams.get("within_days") ?? "30", 10) || 30, 1), 365);

--- a/src/server-remote.ts
+++ b/src/server-remote.ts
@@ -104,9 +104,25 @@ export function createServer(): McpServer {
         // Mode: vendor details
         if (vendor) {
           try {
-            const data = await fetchOfferDetails(vendor, true) as { offer: Record<string, unknown>; alternatives?: unknown[] };
+            const data = await fetchOfferDetails(vendor, true) as {
+              offer?: Record<string, unknown>;
+              alternatives?: unknown[];
+              disambiguation?: { slug: string; name: string }[];
+              resolved_from?: string;
+            };
+            // Fuzzy-match disambiguation: input matched multiple vendors.
+            // Return isError with a structured vendors list so agents can parse.
+            if (data.disambiguation && data.disambiguation.length > 0) {
+              return mcpError(JSON.stringify({ error: `Vendor "${vendor}" matched multiple vendors. Pick one from 'vendors' and retry.`, vendors: data.disambiguation }, null, 2));
+            }
+            if (!data.offer) {
+              return mcpError(`No vendor details returned for "${vendor}".`);
+            }
             if (data.alternatives && !data.offer.alternatives) {
               data.offer.alternatives = data.alternatives;
+            }
+            if (data.resolved_from) {
+              data.offer.resolved_from = data.resolved_from;
             }
             return mcpText(data.offer);
           } catch (err) {

--- a/src/server.ts
+++ b/src/server.ts
@@ -4,6 +4,7 @@ import { fileURLToPath } from "node:url";
 import { McpServer, ResourceTemplate } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import { getCategories, getDealChanges, getPersonalizedChanges, getNewOffers, getNewestDeals, getOfferDetails, searchOffers, enrichOffers, compareServices, checkVendorRisk, auditStack, getExpiringDeals, getWeeklyDigest, loadOffers, loadDealChanges, classifyStability, getStabilityMap, getVendorReferral, sanitizeQuery } from "./data.js";
+import { toSlug, vendorSlugMap, resolveVendorSlug } from "./vendor-slug.js";
 import { recordToolCall, logRequest, recordSearchQuery } from "./stats.js";
 import { registerAgent, validateVestauthUrl, getAgentByApiKeyHash, hashApiKey, updateAgentX402Address } from "./agents.js";
 import { logReferralRequest } from "./referral-requests.js";
@@ -88,7 +89,30 @@ export function createServer(getSessionId?: () => string | undefined, getClientN
 
         // Mode: vendor details
         if (vendor) {
-          const result = getOfferDetails(vendor, true);
+          let result = getOfferDetails(vendor, true);
+          let resolvedFrom: string | null = null;
+          if ("error" in result) {
+            // Fuzzy-resolve: treat vendor as a slug and see if it maps to a
+            // known vendor (e.g. "kiro" → "Amazon Kiro").
+            const resolution = resolveVendorSlug(toSlug(vendor));
+            if (resolution.type === "exact" || resolution.type === "redirect") {
+              const canonicalName = vendorSlugMap.get(resolution.slug);
+              if (canonicalName) {
+                const retry = getOfferDetails(canonicalName, true);
+                if (!("error" in retry)) {
+                  result = retry;
+                  resolvedFrom = vendor;
+                }
+              }
+            } else if (resolution.type === "disambiguate") {
+              const vendors = resolution.slugs.map(s => ({ slug: s, name: vendorSlugMap.get(s) ?? s }));
+              logRequest({ ts: new Date().toISOString(), type: "mcp", endpoint: "search_deals", params: { vendor, disambiguated: true }, result_count: vendors.length, session_id: getSessionId?.() });
+              return {
+                isError: true,
+                content: [{ type: "text" as const, text: JSON.stringify({ error: `Vendor "${vendor}" matched multiple vendors. Pick one from 'vendors' and retry.`, vendors }, null, 2) }],
+              };
+            }
+          }
           if ("error" in result) {
             const msg = result.suggestions.length > 0
               ? `${result.error} Did you mean: ${result.suggestions.join(", ")}?`
@@ -99,8 +123,9 @@ export function createServer(getSessionId?: () => string | undefined, getClientN
               content: [{ type: "text" as const, text: msg }],
             };
           }
-          logRequest({ ts: new Date().toISOString(), type: "mcp", endpoint: "search_deals", params: { vendor }, result_count: 1, session_id: getSessionId?.() });
-          const offerWithCode = { ...result.offer, referral_code: getBestReferralCode(result.offer.vendor) };
+          logRequest({ ts: new Date().toISOString(), type: "mcp", endpoint: "search_deals", params: { vendor, ...(resolvedFrom ? { resolved_from: resolvedFrom } : {}) }, result_count: 1, session_id: getSessionId?.() });
+          const offerWithCode: Record<string, unknown> = { ...result.offer, referral_code: getBestReferralCode(result.offer.vendor) };
+          if (resolvedFrom) offerWithCode.resolved_from = resolvedFrom;
           return {
             content: [{ type: "text" as const, text: JSON.stringify(offerWithCode, null, 2) }],
           };

--- a/src/vendor-slug.ts
+++ b/src/vendor-slug.ts
@@ -1,0 +1,74 @@
+import { loadOffers } from "./data.js";
+
+export function toSlug(name: string): string {
+  return name.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-|-$/g, "");
+}
+
+function buildVendorSlugMap(): Map<string, string> {
+  const offers = loadOffers();
+  const map = new Map<string, string>();
+  for (const o of offers) {
+    const slug = toSlug(o.vendor);
+    if (!slug) continue;
+    if (!map.has(slug)) map.set(slug, o.vendor);
+  }
+  return map;
+}
+
+// Slug → canonical vendor name. Built once at module load from loadOffers()
+// (cached in data.ts). `serve.ts` and `server.ts` both import this to share
+// the same authoritative lookup without circular deps.
+export const vendorSlugMap: Map<string, string> = buildVendorSlugMap();
+
+// Resolve a user-typed vendor slug to its canonical form via substring matching
+// against the known vendor slug map. Returns:
+//   - exact: the slug matches a known vendor — caller should render normally
+//   - redirect: one root match — caller should 301 to the canonical slug
+//   - disambiguate: multiple distinct root matches — caller should render a "did you mean?" page
+//   - none: no match — caller should render 404
+// The "root" filter collapses parent/child slug pairs (e.g. amazon-kiro vs
+// amazon-kiro-aws-startups): a child slug that extends a sibling root is dropped.
+export type VendorSlugResolution =
+  | { type: "exact"; slug: string }
+  | { type: "redirect"; slug: string }
+  | { type: "disambiguate"; slugs: string[] }
+  | { type: "none" };
+
+// `needle` is a sub-slug of `haystack` when it appears at slug-segment boundaries
+// (i.e., bounded by "-" or start/end of string). Avoids false matches where the
+// input is embedded mid-segment (e.g., "tally" inside "totally" should NOT match).
+export function isSubSlug(needle: string, haystack: string): boolean {
+  if (needle === haystack) return true;
+  if (haystack.startsWith(needle + "-")) return true;
+  if (haystack.endsWith("-" + needle)) return true;
+  return haystack.includes("-" + needle + "-");
+}
+
+export function resolveVendorSlug(input: string): VendorSlugResolution {
+  if (!input) return { type: "none" };
+  if (vendorSlugMap.has(input)) return { type: "exact", slug: input };
+  if (input.length < 3) return { type: "none" };
+
+  const allSlugs = [...vendorSlugMap.keys()];
+
+  // Completions: known slugs that contain the input as a sub-slug (short-form lookups like "kiro")
+  const completions = allSlugs.filter(s => s !== input && isSubSlug(input, s));
+  if (completions.length > 0) {
+    // Drop any completion that is a "-"-delimited extension of another completion
+    // (e.g., prefer amazon-kiro over amazon-kiro-aws-startups).
+    const roots = completions.filter(
+      s => !completions.some(other => other !== s && s.startsWith(other + "-"))
+    );
+    if (roots.length === 1) return { type: "redirect", slug: roots[0] };
+    return { type: "disambiguate", slugs: roots.slice(0, 10).sort() };
+  }
+
+  // Generalizations: known slugs that are sub-slugs of the input (extra-specific lookups)
+  const generalizations = allSlugs.filter(s => s !== input && isSubSlug(s, input));
+  if (generalizations.length > 0) {
+    const longest = generalizations.reduce((a, b) => (b.length > a.length ? b : a));
+    return { type: "redirect", slug: longest };
+  }
+
+  return { type: "none" };
+}

--- a/test/http.test.ts
+++ b/test/http.test.ts
@@ -848,6 +848,41 @@ describe("HTTP transport", () => {
     assert.strictEqual(body.offer.vendor, vendorName);
   });
 
+  it("GET /api/details/:vendor fuzzy-resolves short-form slugs (kiro → Amazon Kiro)", async () => {
+    proc = await startHttpServer();
+
+    const response = await fetch(`http://localhost:${serverPort}/api/details/kiro`);
+    assert.strictEqual(response.status, 200);
+    const body = await response.json() as any;
+    assert.ok(body.offer, "Expected offer object");
+    assert.ok(/kiro/i.test(body.offer.vendor), `Expected vendor name containing 'kiro', got ${body.offer.vendor}`);
+    assert.strictEqual(body.resolved_from, "kiro", "Expected resolved_from field on fuzzy match");
+  });
+
+  it("GET /api/details/:vendor returns disambiguation for multi-product short forms (proton → 4 products)", async () => {
+    proc = await startHttpServer();
+
+    const response = await fetch(`http://localhost:${serverPort}/api/details/proton`);
+    assert.strictEqual(response.status, 200);
+    const body = await response.json() as any;
+    assert.ok(Array.isArray(body.disambiguation), "Expected disambiguation array");
+    assert.ok(body.disambiguation.length >= 2, `Expected at least 2 Proton products, got ${body.disambiguation.length}`);
+    assert.strictEqual(body.resolved_from, "proton");
+    for (const d of body.disambiguation) {
+      assert.ok(typeof d.slug === "string" && typeof d.name === "string", "Each disambiguation entry should have slug + name");
+      assert.ok(d.name.toLowerCase().includes("proton"), `Expected 'proton' in name ${d.name}`);
+    }
+  });
+
+  it("GET /api/details/:vendor still returns 404 for genuine misses", async () => {
+    proc = await startHttpServer();
+
+    const response = await fetch(`http://localhost:${serverPort}/api/details/zzz-not-a-real-vendor-slug-xyz`);
+    assert.strictEqual(response.status, 404);
+    const body = await response.json() as any;
+    assert.ok(body.error.includes("not found"));
+  });
+
   it("logs session_close on explicit DELETE", async () => {
     proc = await startHttpServer();
 

--- a/test/search.test.ts
+++ b/test/search.test.ts
@@ -853,7 +853,7 @@ describe("search_deals vendor details", () => {
     }
   });
 
-  it("returns error with suggestions for unknown vendor", async () => {
+  it("returns disambiguation error for ambiguous short-form (e.g. 'Cloud' matches many vendors)", async () => {
     const proc = startServer();
     try {
       const responses = (await sendMcpMessages(proc, [
@@ -869,8 +869,61 @@ describe("search_deals vendor details", () => {
       const result = responses.find((r: any) => r.id === 2) as any;
       assert.ok(result.result.isError);
       const text = result.result.content[0].text;
-      assert.ok(text.includes("not found"));
-      assert.ok(text.includes("Did you mean"));
+      const parsed = JSON.parse(text);
+      assert.ok(Array.isArray(parsed.vendors), "Expected structured vendors array");
+      assert.ok(parsed.vendors.length >= 2, "Expected multiple matches for 'Cloud'");
+      for (const v of parsed.vendors) {
+        assert.ok(typeof v.slug === "string" && typeof v.name === "string");
+      }
+    } finally {
+      proc.kill();
+    }
+  });
+
+  it("fuzzy-resolves short-form vendor slugs (e.g. 'kiro' → 'Amazon Kiro')", async () => {
+    const proc = startServer();
+    try {
+      const responses = (await sendMcpMessages(proc, [
+        ...INIT_MESSAGES,
+        {
+          jsonrpc: "2.0",
+          id: 2,
+          method: "tools/call",
+          params: { name: "search_deals", arguments: { vendor: "kiro" } },
+        },
+      ])) as any[];
+
+      const result = responses.find((r: any) => r.id === 2) as any;
+      assert.ok(!result.result.isError, "Expected success after fuzzy resolve");
+      const offer = JSON.parse(result.result.content[0].text);
+      assert.ok(/kiro/i.test(offer.vendor), `Expected vendor containing 'kiro', got ${offer.vendor}`);
+      assert.strictEqual(offer.resolved_from, "kiro", "Expected resolved_from: 'kiro' on fuzzy match");
+    } finally {
+      proc.kill();
+    }
+  });
+
+  it("returns structured disambiguation for multi-product short-forms (e.g. 'proton')", async () => {
+    const proc = startServer();
+    try {
+      const responses = (await sendMcpMessages(proc, [
+        ...INIT_MESSAGES,
+        {
+          jsonrpc: "2.0",
+          id: 2,
+          method: "tools/call",
+          params: { name: "search_deals", arguments: { vendor: "proton" } },
+        },
+      ])) as any[];
+
+      const result = responses.find((r: any) => r.id === 2) as any;
+      assert.ok(result.result.isError, "Disambiguation is surfaced as isError so agents know to pick");
+      const parsed = JSON.parse(result.result.content[0].text);
+      assert.ok(Array.isArray(parsed.vendors));
+      assert.ok(parsed.vendors.length >= 2);
+      for (const v of parsed.vendors) {
+        assert.ok(v.name.toLowerCase().includes("proton"), `Expected proton-related name, got ${v.name}`);
+      }
     } finally {
       proc.kill();
     }


### PR DESCRIPTION
Refs #1008.

## Summary

Completes the fuzzy vendor-slug resolver series (#989 → PR #990, #991 → PR #993) by applying the same `resolveVendorSlug` semantics to the two agent-consumed surfaces that still returned 404:

1. `GET /api/details/:vendor` (REST JSON) — on lookup miss, resolve and retry; 200 with `resolved_from` on a fuzzy hit, or 200 with `disambiguation` when the short-form matches multiple vendors.
2. MCP `search_deals({vendor})` (in-process `src/server.ts`) — same pattern; disambiguation returned as `isError: true` with a structured `vendors` array so agents can parse without scraping.

## Changes

- **New module `src/vendor-slug.ts`** — `toSlug`, `vendorSlugMap`, `isSubSlug`, `resolveVendorSlug`, `VendorSlugResolution` moved out of `src/serve.ts` so `src/server.ts` can import them without a serve → server circular dep (AC #3).
- **`src/serve.ts`** — `/api/details/:vendor` handler now falls through to `resolveVendorSlug(toSlug(vendorParam))` on a miss. Exact/redirect → re-call `getOfferDetails(canonicalName)` and add `resolved_from`; disambiguate → respond 200 with `{ disambiguation: [{slug, name}], resolved_from }`; none → existing 404+suggestions.
- **`src/server.ts`** — MCP `search_deals` vendor branch mirrors the same fuzzy-resolve flow. Disambiguation returns `{ error, vendors: [{slug, name}] }` as `isError: true` text.
- **`src/server-remote.ts`** — stdio proxy now detects `disambiguation` in the REST response and surfaces it as an MCP error with the structured vendors list; also passes through `resolved_from` into the offer.
- **`src/openapi.ts`** — 200 response schema is now `oneOf`: resolved-offer (optional `resolved_from`) or disambiguation shape; description clarifies the new short-form behavior.

## Tests

1,139/1,139 pass on `npm test --test-concurrency=1` (was 1,134; +5 new).

- `test/http.test.ts` (+3): fuzzy `/api/details/kiro` → 200 with `resolved_from: "kiro"`; `/api/details/proton` → 200 with `disambiguation` array; `/api/details/zzz-not-real` → 404 regression.
- `test/search.test.ts` (+2, 1 modified): stdio MCP `vendor: "kiro"` → success with `resolved_from`; `vendor: "proton"` → structured `vendors` disambiguation. The existing `vendor: "Cloud"` test previously asserted the legacy `Did you mean` string; updated to assert the new structured `vendors` array.

## E2E verification

Local `BASE_URL=http://localhost:3099`:
- `/api/details/Supabase` → 200, no `resolved_from` (exact name).
- `/api/details/kiro` → 200, `resolved_from: "kiro"`, offer.vendor = `Amazon Kiro`.
- `/api/details/amazon-kiro` → 200, `resolved_from: "amazon-kiro"`, offer.vendor = `Amazon Kiro`.
- `/api/details/proton` → 200, `disambiguation: [proton-drive, proton-mail, proton-pass, proton-vpn]`.
- `/api/details/Cloud` → 200, `disambiguation: [10 entries: appwrite-cloud, google-cloud, ibm-cloud, ...]`.
- `/api/details/zzz-not-a-real-thing` → 404.

MCP (via HTTP `/mcp initialize → tools/call`):
- `search_deals({vendor: "kiro"})` → success, offer includes `resolved_from: "kiro"`.
- `search_deals({vendor: "proton"})` → `isError: true`, content is JSON with `vendors` array.
- `search_deals({vendor: "zzz-not-real"})` → `isError: true`, legacy `not found` message.

## Decision: redirect vs 200-with-resolved_from

AC #1 permitted either a 301 to the canonical URL or 200 with `resolved_from`. Chose 200-with-`resolved_from` because:
- REST clients vary in redirect-following behavior; an in-response field is uniform.
- MCP clients can't easily act on HTTP redirects (they expect JSON content directly).
- Symmetric with the MCP path — same mental model on both surfaces.
- Transparent: agents and downstream telemetry can see the original input.

Documented in openapi.ts spec as the chosen convention.

## Decision: #977 attribution window

Shipping this before the 2026-04-29 close of the #977 MCP-instructions observation window. Per PM guidance in the issue (\"don't slow shipping for analytics purity\"), I'll note the confound when wrapping up #977.

## Files

- `src/vendor-slug.ts` (new, 73 lines)
- `src/serve.ts` (−47 lines local defs, +25 fuzzy handler logic)
- `src/server.ts` (+30 lines)
- `src/server-remote.ts` (+17 lines)
- `src/openapi.ts` (+25 lines / −10)
- `test/http.test.ts` (+35 lines, 3 new tests)
- `test/search.test.ts` (+57 lines, 2 new + 1 modified)

## Test plan

- [x] `npm run build` — clean
- [x] `npm test -- --test-concurrency=1` — 1,139/1,139 pass
- [x] E2E verified on local server for all 6 /api/details cases above
- [x] E2E verified MCP /mcp flow for 3 vendor cases
- [x] `npm run lint:duplicates` — 2 known-pending (internxt/pcloud), no regression