### PR TITLE
Deduplicate Internxt + pCloud (keep Cloud Storage)

### DIFF
--- a/data/index.json
+++ b/data/index.json
@@ -14807,19 +14807,6 @@
       "verifiedDate": "2026-04-12"
     },
     {
-      "vendor": "internxt.com",
-      "category": "Storage",
-      "description": "Internxt Drive is a zero-knowledge file storage service based on absolute privacy and uncompromising security. Sign up and get 10 GB for free, forever!",
-      "tier": "Free",
-      "url": "https://internxt.com",
-      "tags": [
-        "storage",
-        "media",
-        "free-for-dev"
-      ],
-      "verifiedDate": "2026-04-12"
-    },
-    {
       "vendor": "kraken.io",
       "category": "Storage",
       "description": "Image optimization for website performance as a service, free 100 MB testing quota. Paid plans start at $5/mo.",
@@ -14903,19 +14890,6 @@
       "description": "Hosted Package Repositories for YUM, APT, RubyGem and PyPI. Limited free plans and open-source plans are available via request",
       "tier": "Free",
       "url": "https://packagecloud.io/",
-      "tags": [
-        "storage",
-        "media",
-        "free-for-dev"
-      ],
-      "verifiedDate": "2026-04-12"
-    },
-    {
-      "vendor": "pcloud.com",
-      "category": "Storage",
-      "description": "Cloud storage service. Up to 10 GB of free storage",
-      "tier": "Free",
-      "url": "https://www.pcloud.com/",
       "tags": [
         "storage",
         "media",

--- a/src/serve.ts
+++ b/src/serve.ts
@@ -10256,7 +10256,7 @@ function buildStorageAlternativesPage(): string {
     o.category === "CDN" && !mediaCdn.includes(o)
   );
   const fileStorageSync = enrichedAll.filter(o =>
-    ["seafile.com", "odrive", "transfernow", "transloadit.com", "wormhol.org", "Wormhole", "GoFile.io", "file.io", "internxt.com", "icedrive.net", "pcloud.com", "sync.com", "Proton Drive", "degoo.com", "Ente", "borgbase.com", "Dropshare"].includes(o.vendor)
+    ["seafile.com", "odrive", "transfernow", "transloadit.com", "wormhol.org", "Wormhole", "GoFile.io", "file.io", "icedrive.net", "sync.com", "Proton Drive", "degoo.com", "Ente", "borgbase.com", "Dropshare"].includes(o.vendor)
   );
   const other = enrichedAll.filter(o =>
     !objectStorage.includes(o) && !mediaCdn.includes(o) && !cdnDelivery.includes(o) && !fileStorageSync.includes(o)
@@ -10525,7 +10525,7 @@ ${buildCards(other)}
       <dd><a href="/vendor/minio">MinIO</a> \u2014 high-performance, S3-compatible, open-source. Run it on your own infrastructure with no storage or bandwidth limits. Widely used in on-prem and Kubernetes environments.</dd>
 
       <dt>Need encrypted file sync?</dt>
-      <dd><a href="/vendor/proton-drive">Proton Drive</a> for end-to-end encrypted cloud storage (1 GB free). <a href="/vendor/internxt-com">Internxt</a> and <a href="/vendor/sync-com">Sync.com</a> are privacy-focused alternatives. <a href="/vendor/seafile-com">Seafile</a> is self-hostable.</dd>
+      <dd><a href="/vendor/proton-drive">Proton Drive</a> for end-to-end encrypted cloud storage (1 GB free). <a href="/vendor/internxt">Internxt</a> and <a href="/vendor/sync-com">Sync.com</a> are privacy-focused alternatives. <a href="/vendor/seafile-com">Seafile</a> is self-hostable.</dd>
 
       <dt>Hosting decentralized content?</dt>
       <dd><a href="/vendor/pinata-ipfs">Pinata</a> for IPFS pinning (1 GB free). Ideal for NFT metadata, decentralized apps, and content-addressed storage.</dd>

--- a/test/lint-duplicates.test.ts
+++ b/test/lint-duplicates.test.ts
@@ -280,40 +280,22 @@ describe("formatMarkdown", () => {
 });
 
 describe("lint-duplicates against current data/index.json", () => {
-  // After PR #1003 added vendor-name normalization (TLD/corp suffix stripping),
-  // 5 latent dups surfaced that the exact-match key missed. Each resolved in a
-  // follow-up dedup PR. When the count reaches 0, flip this assertion to
-  // `result.length === 0` (the original form).
-  const EXPECTED_PENDING_VARIANTS = ["internxt", "pcloud"];
-
-  it("surfaces only known-pending normalized duplicate candidates", async () => {
+  // PR #1003 added vendor-name normalization (TLD/corp suffix stripping),
+  // surfacing 5 latent dups. All resolved in follow-up dedup PRs:
+  // todoist (#1005), trello (#1006), evernote (#1007), internxt + pcloud (#1010).
+  // If this ever drifts back >0, either a new miscategorization appeared and
+  // needs a dedup PR, or the list needs to flip back to the inventory form.
+  it("surfaces zero normalized duplicate candidates", async () => {
     const { readFileSync } = await import("node:fs");
     const { resolve } = await import("node:path");
     const indexPath = resolve(process.cwd(), "data", "index.json");
     const data = JSON.parse(readFileSync(indexPath, "utf-8"));
     const result = findDuplicateCandidates(data.offers || []);
-    const normalized = result.map((c) => normalizeVendor(c.vendor)).sort();
-    assert.deepStrictEqual(
-      normalized,
-      EXPECTED_PENDING_VARIANTS,
-      `candidate list drifted from expected — update EXPECTED_PENDING_VARIANTS after resolving in a dedup PR, or investigate if new ones appeared. got: ${normalized.join(", ")}`,
+    assert.strictEqual(
+      result.length,
+      0,
+      `expected zero candidates, got ${result.length}: ${result.map((c) => c.vendor).join(", ")}`,
     );
-  });
-
-  it("all surfaced candidates are vendor-name variants (not straight dedup gaps)", async () => {
-    const { readFileSync } = await import("node:fs");
-    const { resolve } = await import("node:path");
-    const indexPath = resolve(process.cwd(), "data", "index.json");
-    const data = JSON.parse(readFileSync(indexPath, "utf-8"));
-    const result = findDuplicateCandidates(data.offers || []);
-    // Every pending candidate should have vendorNameVariants set, confirming
-    // the normalization (not the exact-match path) is what surfaced it.
-    for (const c of result) {
-      assert(
-        c.vendorNameVariants && c.vendorNameVariants.length > 1,
-        `${c.vendor} lacks vendorNameVariants — if this is a pure same-name dup, it should have been caught pre-normalization`,
-      );
-    }
   });
 
   it("does not flag Amazon Kiro (parenthetical suffix preserved)", async () => {


### PR DESCRIPTION
## Summary

- Dedup Internxt and pCloud, bundled in one PR — both were Storage vs Cloud Storage with identical shape (e) resolution. Retired `internxt.com` + `pcloud.com` (Storage); kept `Internxt` + `pCloud` (Cloud Storage).
- Collateral: remove 2 dead strings from `/storage-alternatives` fileStorageSync filter array; canonicalize `/vendor/internxt-com` prose link to `/vendor/internxt` (avoid 301 hop).
- Closes out PR #1004's latent-variant backlog (todoist #1005, trello #1006, evernote #1007, internxt+pcloud here). Lint test flips `EXPECTED_PENDING_VARIANTS` → `result.length === 0`.

## Why bundled

Both vendors resolve via the same shape (e) reasoning with identical relatedVendors — Internxt/pCloud (Cloud Storage) peer with Google Drive/iCloud/OneDrive/MEGA/Flickr, while internxt.com/pcloud.com (Storage) peer with Cloudflare R2/Backblaze B2/Tigris/Cloudinary/MinIO (developer object storage — wrong cohort for consumer cloud drive). One PR handles both cleanly; splitting would be churn.

## Shape analysis

This is shape (e) Photopea — smaller coherent category beats larger grab-bag. Storage (53 entries) is a grab-bag mixing object storage, image CDNs, file sharing, QR tools, JSON hosts. Cloud Storage (9 entries) is a tight consumer-cloud-drive cohort. Not a new "7th shape" despite the category-name similarity — the populations reveal them as semantically distinct.

## Verification

- `npm test -- --test-concurrency=1`: **1,138/1,138 pass**
- `npm run lint:duplicates`: "No same-vendor-same-tier multi-category duplicates detected."
- `/api/details/internxt` → Cloud Storage, relatedVendors = Google Drive/Google Photos/iCloud/OneDrive/Flickr ✓
- `/api/details/internxt.com` → auto-resolves via PR #1009 fuzzy resolver to Internxt (resolved_from: "internxt.com") ✓
- `/api/details/pcloud` + `/api/details/pcloud.com` → same pattern ✓
- Total offers: 1,573 → 1,571 ✓
- Storage: 53 → 51 ✓ | Cloud Storage: 9 (unchanged) ✓
- `/vendor/internxt`, `/vendor/pcloud`: HTTP 200 ✓
- `/vendor/internxt-com`, `/vendor/pcloud-com`: HTTP 301 ✓
- `/storage-alternatives`: HTTP 200, no `/vendor/internxt-com` link, no `internxt.com`/`pcloud.com` strings ✓

## Test plan

- [x] Full test suite passes
- [x] Lint surfaces zero candidates
- [x] E2E curl all four `/api/details/...` paths
- [x] Verified prose link update on `/storage-alternatives`