### PR TITLE
docs: refresh AGENT_README Current Status (8 days stale)

### DIFF
--- a/AGENT_README.md
+++ b/AGENT_README.md
@@ -6,7 +6,7 @@ A remote MCP server that aggregates publicly available discounts, free tiers, st
 
 ## Success Criteria
 
-- Working MCP server responding to `search_deals`, `plan_stack`, `compare_vendors`, and `track_changes` tools
+- Working MCP server responding to 4 discovery tools (`search_deals`, `plan_stack`, `compare_vendors`, `track_changes`) and 7 marketplace/referral tools (`register_agent`, `get_referral_code`, `check_balance`, `request_payout`, `submit_referral_code`, `my_referral_codes`, `leaderboard`)
 - Index of real vendor offers with verified data
 - Deployed and accessible (ngrok for dev, hosted service for launch)
 - Registered on MCP registries
@@ -63,14 +63,15 @@ Endpoints:
 
 ## Current Status
 
-_As of 2026-04-16. Counts come from `data/index.json`, `data/deal_changes.json`, `src/openapi.ts`, and `npm test` — rerun to verify before quoting._
+_As of 2026-04-24. Counts come from `data/index.json`, `data/deal_changes.json`, `src/openapi.ts`, and `npm test` — rerun to verify before quoting._
 
-MCP server is functional with stdio and HTTP transports. 4 intent-based tools (search_deals, plan_stack, compare_vendors, track_changes) + 6 prompt templates. **1,594 offers** across **67 categories** with eligibility schema (accelerator, oss, fintech, student types). **267 tracked pricing changes**. **20 documented REST endpoints** (see `src/openapi.ts` / `/api/openapi.json` / Swagger UI at `/api/docs`). **1,028 passing tests**. Multi-session HTTP support with idle timeout cleanup and structured connection logging. Deployed on Railway. Listed on Official MCP Registry and Glama. Registry manifests in place (server.json, glama.json, smithery.yaml). MCP server card (SEP-1649) at `/.well-known/mcp.json`; MCP manifest (SEP-1960) at `/.well-known/mcp`.
+MCP server is functional with stdio and HTTP transports. 11 MCP tools (4 discovery + 7 marketplace/referral) + 6 prompt templates. **1,571 offers** across **66 categories** with eligibility schema (accelerator, oss, fintech, student types). **287 tracked pricing changes**. **20 documented REST endpoints** (see `src/openapi.ts` / `/api/openapi.json` / Swagger UI at `/api/docs`). **1,160 passing tests**. Multi-session HTTP support with idle timeout cleanup and structured connection logging. Deployed on Railway. Listed on Official MCP Registry and Glama. Registry manifests in place (server.json, glama.json, smithery.yaml). MCP server card (SEP-1649) at `/.well-known/mcp.json`; MCP manifest (SEP-1960) at `/.well-known/mcp`. Server-level `instructions` advertised on the `initialize` response (both HTTP and stdio transports).
 
 **Major surfaces shipped beyond the core MCP tools:**
-- **Referral marketplace** — platform codes seeded, `GET /api/referral-codes` listing + per-vendor lookup, inline `referral_code` enrichment on MCP tool responses and REST payloads, passive solicitation CTA on ~1,439 dormant vendor pages.
+- **Referral marketplace** — platform codes seeded (5 active), `GET /api/referral-codes` listing + per-vendor lookup, inline `referral_code` enrichment on MCP tool responses and REST payloads, passive solicitation CTA on ~1,549 dormant vendor pages.
+- **Fuzzy vendor-slug resolver** — short-form inputs (`kiro`, `proton`, `qwen`) resolve to canonical vendor across `/vendor/:slug`, `/alternative-to/:slug`, `/api/details/:vendor`, and MCP `search_deals({vendor})`. Exact/redirect matches return the offer with `resolved_from`; ambiguous inputs return structured disambiguation.
 - **Vendor watchlist API** with HMAC-signed webhook notifications on pricing/deal changes.
-- **Auto-generated SEO pages** — ~349 head-to-head comparison pages across 67 categories, 23 monthly pricing-intelligence report pages, 5 content-type sitemaps.
+- **Auto-generated SEO pages** — ~369 head-to-head comparison pages across 66 categories, 23 monthly pricing-intelligence report pages, 5 content-type sitemaps.
 - **Event coverage** — GCP Next 2026, Microsoft Build 2026, Google I/O 2026 with confirmed announcements.
 - **Weekly pricing digest** — `/this-week` page, API, and RSS/Atom feeds.
-- **Operations** — staleness detection, pricing-change monitor, bulk ingestion scripts, IndexNow integration with status endpoint, referral health checks, `/api/metrics` for marketplace + session-classification telemetry (agent vs. crawler).
+- **Operations** — staleness detection, pricing-change monitor, bulk ingestion scripts, IndexNow integration with status endpoint, referral health checks, `/api/metrics` for marketplace + session-classification telemetry (agent vs. crawler), `/api/stats` with per-client and per-tool-name tool_call attribution, daily automated re-verification, `npm run lint:duplicates` CI lint for multi-category duplicate detection.


### PR DESCRIPTION
## Context

AGENT_README.md's `Current Status` section is 8 days stale (stamp was 2026-04-16). Several numbers have moved materially and the tool count was substantially underreporting — the README claimed 4 MCP tools but `src/server.ts` has 11 (4 discovery + 7 marketplace/referral).

All numbers refreshed against the current tree.

## Changes

### Numeric refreshes
- Offers: 1,594 → **1,571** (dedup series closed out in PR #1010, ~23 offers retired)
- Categories: 67 → **66** (Media category retired in PR #996)
- Tracked pricing changes: 267 → **287** (+20)
- Tests: 1,028 → **1,160** (+132; confirmed via `npm test --test-concurrency=1`)
- Comparison pages: ~349 → **~369** (counted from `/sitemap-comparisons.xml` on local server)
- Dormant vendor pages: ~1,439 → **~1,549** (computed from `data/index.json`: 1,571 total − 22 with any referral surface; matches platform_codes.json 5 active + ~17 with offer-level referral or referral_program.available)

### Correctness fixes
- **Tool count:** 4 → **11**. README previously listed only the 4 discovery tools (`search_deals`, `plan_stack`, `compare_vendors`, `track_changes`); adds the 7 marketplace/referral tools that have been shipping since Phase 3 (`register_agent`, `get_referral_code`, `check_balance`, `request_payout`, `submit_referral_code`, `my_referral_codes`, `leaderboard`). This was a significant underreport for anyone reading the README to understand surface area.

### Surface additions (feature mentions)
- Server-level `instructions` on `initialize` response (PR #978)
- Fuzzy vendor-slug resolver on `/vendor/:slug`, `/alternative-to/:slug`, `/api/details/:vendor`, and MCP `search_deals({vendor})` (PRs #990, #993, #1009)
- `/api/stats` per-client + per-tool-name tool_call attribution (PRs #994, #999)
- Daily automated re-verification (PR #966)
- `npm run lint:duplicates` CI lint for multi-category duplicate detection (PR #985)

### Unchanged
- Tech stack, conventions, commands, HTTP transport section, 20 documented REST endpoints, 6 prompt templates, deploy on Railway, SEP-1649/SEP-1960 well-known surfaces.

## Verification
- Offers/categories: `python3 data/index.json` parse
- Deal changes: `python3 data/deal_changes.json` parse
- Tests: `npm test --test-concurrency=1` → 1,160/1,160 pass
- API paths: `/api/openapi.json` served locally → 20 paths
- Comparison pages: `/sitemap-comparisons.xml` served locally → 369 URLs
- Dormant pages: computed from index.json against platform_codes.json + `referral_program.available === true` + offer-level `referral` field
- Tool count: `grep -E '// --- Tool [0-9]+:' src/server.ts` → 11 tools

Docs-only PR. No source changes, no test changes.

Refs #1012 (self-filed tracking issue if needed).

🤖 Idle-time improvement per CLAUDE.md priority #8.