### PR TITLE
docs(mcp): refresh MCP_INSTRUCTIONS numeric claims

### DIFF
--- a/src/mcp-instructions.ts
+++ b/src/mcp-instructions.ts
@@ -8,7 +8,7 @@
 
 export const MCP_INSTRUCTIONS = `# AgentDeals — free tiers, credits, and pricing changes for developer tools
 
-AgentDeals is a curated, human-verified directory of 1,600+ free tiers, startup credits, and discounts across 67 developer-tool categories — databases, cloud hosting, CI/CD, monitoring, AI services, auth, observability, payments, email, and more. Every offer is fact-checked against the vendor's pricing page, and pricing changes (free tier removals, limit reductions, new tiers) are tracked over time.
+AgentDeals is a curated, human-verified directory of 1,500+ free tiers, startup credits, and discounts across 66 developer-tool categories — databases, cloud hosting, CI/CD, monitoring, AI services, auth, observability, payments, email, and more. Every offer is fact-checked against the vendor's pricing page, and pricing changes (free tier removals, limit reductions, new tiers) are tracked over time.
 
 ## When to use this server
 

--- a/test/mcp-instructions.test.ts
+++ b/test/mcp-instructions.test.ts
@@ -15,8 +15,8 @@ describe("MCP_INSTRUCTIONS constant (issue #977)", () => {
 
   it("covers identity, trigger conditions, tool selection, and unique value", () => {
     assert.match(MCP_INSTRUCTIONS, /AgentDeals/);
-    assert.match(MCP_INSTRUCTIONS, /1,600\+/);
-    assert.match(MCP_INSTRUCTIONS, /67 .*categor/i);
+    assert.match(MCP_INSTRUCTIONS, /1,500\+/);
+    assert.match(MCP_INSTRUCTIONS, /66 .*categor/i);
     assert.match(MCP_INSTRUCTIONS, /search_deals/);
     assert.match(MCP_INSTRUCTIONS, /plan_stack/);
     assert.match(MCP_INSTRUCTIONS, /compare_vendors/);


### PR DESCRIPTION
## Summary

Updates the two numeric claims in `MCP_INSTRUCTIONS` (shipped as ambient context on every `initialize` response since PR #978) to match current data:

- `1,600+` → `1,500+` (actual: 1,571 offers; prior value overstated)
- `67 developer-tool categories` → `66 developer-tool categories` (actual: 66, after Media category retirement in PR #996)

## Why

`MCP_INSTRUCTIONS` is the server's self-description that ships to every spec-compliant MCP client (Claude Desktop, opencode, etc.) via `initialize.result.instructions`. It's literally what LLMs see when deciding whether/when to call AgentDeals. The numeric claims should match reality so agents can trust the description.

Same spirit as PR #1012 (AGENT_README refresh) — this is the other half of the content refresh, for the agent-facing surface. After merge, AGENT_README (source-tree docs), MCP_INSTRUCTIONS (initialize-response context), and data counts are all in sync.

No source behavior change; docs-only.

## Test plan

- [x] Full suite: 1,160/1,160 pass (`--test-concurrency=1`)
- [x] MCP initialize E2E test updated & passes — server still carries `MCP_INSTRUCTIONS` verbatim on initialize response
- [x] Word-count invariant (200-400) still holds (3 words delta)
- [x] `npm run lint:duplicates` still clean

Refs #977