### PR TITLE
chore: npm audit fix + verify-freshness test time-stability

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -970,12 +970,12 @@
       }
     },
     "node_modules/express-rate-limit": {
-      "version": "8.3.1",
-      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.3.1.tgz",
-      "integrity": "sha512-D1dKN+cmyPWuvB+G2SREQDzPY1agpBIcTa9sJxOPMCNeH3gwzhqJRDWCXW3gg0y//+LQ/8j52JbMROWyrKdMdw==",
+      "version": "8.5.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.1.tgz",
+      "integrity": "sha512-5O6KYmyJEpuPJV5hNTXKbAHWRqrzyu+OI3vUnSd2kXFubIVpG7ezpgxQy76Zo5GQZtrQBg86hF+CM/NX+cioiQ==",
       "license": "MIT",
       "dependencies": {
-        "ip-address": "10.1.0"
+        "ip-address": "^10.2.0"
       },
       "engines": {
         "node": ">= 16"
@@ -1022,9 +1022,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "funding": [
         {
           "type": "github",
@@ -1217,9 +1217,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.14",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.14.tgz",
-      "integrity": "sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w==",
+      "version": "4.12.18",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.18.tgz",
+      "integrity": "sha512-RWzP96k/yv0PQfyXnWjs6zot20TqfpfsNXhOnev8d1InAxubW93L11/oNUc3tQqn2G0bSdAOBpX+2uDFHV7kdQ==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
@@ -1278,9 +1278,9 @@
       "license": "ISC"
     },
     "node_modules/ip-address": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
-      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"

--- a/scripts/verify-freshness.js
+++ b/scripts/verify-freshness.js
@@ -155,10 +155,10 @@ function sleep(ms) {
 
 // ── Main ─────────────────────────────────────────────────────────────────────
 
-export async function verifyFreshness({ thresholdDays, dryRun, limit, indexPath }) {
+export async function verifyFreshness({ thresholdDays, dryRun, limit, indexPath, now = new Date() }) {
   const data = JSON.parse(readFileSync(indexPath || INDEX_PATH, "utf-8"));
   const offers = data.offers || [];
-  const { stale, freshCount } = findStaleOffers(offers, thresholdDays);
+  const { stale, freshCount } = findStaleOffers(offers, thresholdDays, now);
 
   if (stale.length === 0) {
     return {
@@ -186,7 +186,7 @@ export async function verifyFreshness({ thresholdDays, dryRun, limit, indexPath 
     }
     return client;
   }
-  const today = new Date().toISOString().split("T")[0];
+  const today = now.toISOString().split("T")[0];
 
   let verified = 0;
   let changed = 0;

--- a/test/verify-freshness.test.ts
+++ b/test/verify-freshness.test.ts
@@ -179,12 +179,12 @@ describe("verify-freshness", () => {
     it("reports all fresh when no stale entries", async () => {
       const data = {
         offers: [
-          { vendor: "Fresh", category: "Hosting", url: "https://example.com", verifiedDate: "2026-04-01", tier: "Free", description: "Free plan" },
+          { vendor: "Fresh", category: "Hosting", url: "https://example.com", verifiedDate: "2026-03-10", tier: "Free", description: "Free plan" },
         ],
       };
       writeFileSync(indexPath, JSON.stringify(data));
 
-      const result = await verifyFreshness({ thresholdDays: 25, dryRun: true, indexPath });
+      const result = await verifyFreshness({ thresholdDays: 25, dryRun: true, indexPath, now });
       assert.strictEqual(result.verified, 0);
       assert.strictEqual(result.alreadyFresh, 1);
     });
@@ -198,7 +198,7 @@ describe("verify-freshness", () => {
       writeFileSync(indexPath, JSON.stringify(data));
       const before = readFileSync(indexPath, "utf-8");
 
-      await verifyFreshness({ thresholdDays: 25, dryRun: true, indexPath });
+      await verifyFreshness({ thresholdDays: 25, dryRun: true, indexPath, now });
       const after = readFileSync(indexPath, "utf-8");
       assert.strictEqual(before, after);
     });
@@ -214,7 +214,7 @@ describe("verify-freshness", () => {
       }));
       writeFileSync(indexPath, JSON.stringify({ offers }));
 
-      const result = await verifyFreshness({ thresholdDays: 25, dryRun: true, limit: 3, indexPath });
+      const result = await verifyFreshness({ thresholdDays: 25, dryRun: true, limit: 3, indexPath, now });
       // Should attempt at most 3, skip the rest
       assert.strictEqual(result.skipped, 7);
       assert.ok(result.failed <= 3);


### PR DESCRIPTION
## Summary

Resolves 5 production vulnerabilities flagged by `npm audit` and fixes a pre-existing date-stale test.

### Security fixes (via `npm audit fix`, no --force)

| Package | Before | After | Severity | CVE class |
|---|---|---|---|---|
| `fast-uri` | 3.1.0 | 3.1.2 | **HIGH** | path traversal, host confusion |
| `hono` | 4.12.14 | 4.12.18 | moderate (5x) | bodyLimit bypass, JSX/JWT/cache |
| `ip-address` | 10.1.0 | 10.2.0 | moderate | XSS in HTML-emitting methods |
| `express-rate-limit` | 8.3.1 | 8.5.1 | (pulls fixed `ip-address`) | — |

Production `npm audit`: **5 vulns (1 HIGH + 4 moderate) → 1 moderate**.

The remaining moderate is `@anthropic-ai/sdk` (GHSA-p7fg-763f-g4gf, Local Filesystem Memory Tool file permissions). Not exploitable in this codebase — the SDK is only imported by `scripts/verify-freshness.js` + `scripts/reverify-rolling.js` which call `client.messages.create()` and never touch the memory tool. Fixing requires breaking-change upgrade to 0.95.2 — tracked separately.

The 5 remaining low-severity advisories are all in the `tmp` chain via `@anthropic-ai/mcpb` (dev dependency only, no upstream fix, ongoing per prior PM comments on this issue).

### Test fix

`test/verify-freshness.test.ts:179` ("reports all fresh when no stale entries") was failing on main — pre-existing flake unrelated to this PR's deps. The test had a hardcoded `verifiedDate: "2026-04-01"` and called `verifyFreshness()` without controlling `now`, so it broke once system time passed the 25-day threshold (today 2026-05-12 is 41 days past).

Fix: threaded a `now = new Date()` default into `verifyFreshness()` matching the existing pattern in `findStaleOffers()`. The three integration tests now pass the suite-scoped `now` fixture (`new Date("2026-03-16T00:00:00Z")`) explicitly, so they're time-stable.

## Test plan

- [x] `npm run build` — clean tsc
- [x] `npm test` — 1160/1160 pass (was 1159/1160 on main)
- [x] `npm audit --omit=dev` — 1 moderate (down from 5; remaining is non-exploitable @anthropic-ai/sdk)

Refs #353