### PR TITLE
security: npm audit fix (hono, qs) + harden flaky weekly-digest feed test

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1217,9 +1217,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.18",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.18.tgz",
-      "integrity": "sha512-RWzP96k/yv0PQfyXnWjs6zot20TqfpfsNXhOnev8d1InAxubW93L11/oNUc3tQqn2G0bSdAOBpX+2uDFHV7kdQ==",
+      "version": "4.12.25",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.25.tgz",
+      "integrity": "sha512-2NFaIyNVgJmBs/ecmtGzlmluTFs5cHEWGTdu0t1HBwYzoGXOL5nUQBRMXsXWla5i4KkG//QMzVP88m1+I3fdAQ==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
@@ -1577,9 +1577,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.15.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.0.tgz",
-      "integrity": "sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==",
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"

--- a/test/feed-weekly-digest.test.ts
+++ b/test/feed-weekly-digest.test.ts
@@ -71,12 +71,25 @@ describe("/feed.xml weekly digest feed", () => {
     assert.ok(xml.includes("Week of"), "Entry titles should start with 'Week of'");
   });
 
-  it("entries link to correct /this-week URLs", async () => {
+  it("entries link to correctly-formatted /this-week URLs", async () => {
     proc = await startHttpServer();
     const res = await fetch(`http://localhost:${serverPort}/feed.xml`);
     const xml = await res.text();
-    assert.ok(xml.includes('/this-week"'), "Current week should link to /this-week");
-    assert.ok(xml.includes("/this-week?week=1"), "Previous week should link to /this-week?week=1");
+    // Each weekly-digest entry links to its /this-week page: the current week
+    // (w=0) to the bare /this-week, prior weeks (w>=1) to /this-week?week=N.
+    // Weeks with no tracked pricing changes are omitted from the feed, so which
+    // specific weeks appear is data-dependent (the current week is often empty
+    // early on). Assert the URL format of whatever entries exist rather than
+    // assuming a particular week is always present.
+    const hrefs = [...xml.matchAll(/<link href="([^"]*\/this-week[^"]*)" rel="alternate"\/>/g)].map((m) => m[1]);
+    assert.ok(hrefs.length > 0, "Should have at least one /this-week entry link");
+    for (const href of hrefs) {
+      assert.match(
+        href,
+        /^https?:\/\/[^/"]+\/this-week(\?week=[1-9][0-9]*)?$/,
+        `this-week link should be bare /this-week or /this-week?week=N, got: ${href}`,
+      );
+    }
   });
 
   it("CORS header is set", async () => {


### PR DESCRIPTION
## Summary

Routine security re-audit of production dependencies (first since the cycle-119 fix, ~34 days ago) surfaced 3 moderate advisories. This PR resolves the two that apply to the deployed HTTP server, plus a pre-existing flaky test that was red on `main`.

Refs #353.

## Security fixes (`npm audit fix`, non-breaking)

| Package | Before | After | Why it matters |
|---|---|---|---|
| `hono` | 4.12.18 | 4.12.25 | 4 advisories in the **public HTTP-serving path** — IPv6 IP-restriction bypass, Set-Cookie injection via cookie helper, JWT middleware accepting non-Bearer schemes, `app.mount` prefix routing. Transitive via `@modelcontextprotocol/sdk` (+ `@hono/node-server`). |
| `qs` | 6.15.0 | 6.15.2 | Remotely-triggerable DoS in `qs.stringify`. Transitive via `@modelcontextprotocol/sdk` → `express` → `body-parser`. |

Both are within-major transitive bumps — **`package.json` is untouched**, only `package-lock.json` changes.

## Deferred: `@anthropic-ai/sdk` advisory (does not apply)

The third finding — `@anthropic-ai/sdk` GHSA-p7fg-763f-g4gf, *Insecure Default File Permissions in Local Filesystem Memory Tool* — is **not exploitable here**. agentdeals imports the SDK only in two offline data-verification scripts (`verify-freshness.js`, `reverify-rolling.js`), and only for `new Anthropic()` + `client.messages.create()` text calls — it never uses the Local Filesystem Memory Tool. Its only fix is a breaking major bump (0.82 → 0.104) that `reverify-rolling.js` (the live rolling-reverification job) depends on, and I can't make live billed API calls from the sandbox to verify it. Deferred rather than ship an unverifiable breaking change for a non-applicable vuln. Recommend bumping to ≥0.92 (lowest non-vulnerable) once the two reverify scripts can be exercised against the live API.

Production audit after this PR: 1 moderate remaining (the deferred, non-applicable SDK one).

## Test fix: flaky `feed-weekly-digest.test.ts`

`test/feed-weekly-digest.test.ts` → "entries link to correct /this-week URLs" was failing **on `main`** (independent of the dependency bump — verified by checking out `main`). The `/feed.xml` builder omits weeks with zero tracked pricing changes (`serve.ts:53858`), so the current week is frequently absent early on. The test wrongly asserted the current week always links to the bare `/this-week`. Rewrote it to assert the **URL-format contract** (each entry link is bare `/this-week` or `/this-week?week=N`) of whatever entries exist — deterministic regardless of which weeks have data.

## Verification

- `npm run build` — clean (tsc exit 0)
- `npm test` — **1160/1160 pass** (was 1159/1160 on `main` due to the flaky feed test)
- MCP transport E2E covered by `test/http.test.ts`: real `initialize` → `mcp-session-id` → `tools/call` (`search_deals`) handshake over the **upgraded hono** HTTP transport — passes.
- agentdeals.dev/health: `status:ok`, HTTP 200 (checked this cycle).