### PR TITLE
Bump @anthropic-ai/sdk 0.82.0 → 0.104.2 (clears GHSA-p7fg-763f-g4gf)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.3.1",
       "license": "MIT",
       "dependencies": {
-        "@anthropic-ai/sdk": "^0.82.0",
+        "@anthropic-ai/sdk": "^0.104.2",
         "@modelcontextprotocol/ext-apps": "^1.5.0",
         "@modelcontextprotocol/sdk": "^1.29.0",
         "swagger-ui-dist": "^5.32.0",
@@ -50,12 +50,13 @@
       }
     },
     "node_modules/@anthropic-ai/sdk": {
-      "version": "0.82.0",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.82.0.tgz",
-      "integrity": "sha512-xdHTjL1GlUlDugHq/I47qdOKp/ROPvuHl7ROJCgUQigbvPu7asf9KcAcU1EqdrP2LuVhEKaTs7Z+ShpZDRzHdQ==",
+      "version": "0.104.2",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.104.2.tgz",
+      "integrity": "sha512-s1wEVDAtEwkS7Ajgep6PZKJLFqybRkmD3Byz+iVVsSpbDY0gjROXE9aOft6V3PMqynn3NTcycV5whga9tCzmKA==",
       "license": "MIT",
       "dependencies": {
-        "json-schema-to-ts": "^3.1.1"
+        "json-schema-to-ts": "^3.1.1",
+        "standardwebhooks": "^1.0.0"
       },
       "bin": {
         "anthropic-ai-sdk": "bin/cli"
@@ -424,6 +425,12 @@
       "integrity": "sha512-xxeapPiUXdZAE3che6f3xogoJPeZgig6omHEy1rIY5WVsB3H2BHNnZH+gHG6x91SCWyQCzWGsuL2Hh3ClO5/qQ==",
       "hasInstallScript": true,
       "license": "Apache-2.0"
+    },
+    "node_modules/@stablelib/base64": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/base64/-/base64-1.0.1.tgz",
+      "integrity": "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==",
+      "license": "MIT"
     },
     "node_modules/@tsconfig/node10": {
       "version": "1.0.12",
@@ -1020,6 +1027,12 @@
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "license": "MIT"
+    },
+    "node_modules/fast-sha256": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fast-sha256/-/fast-sha256-1.3.0.tgz",
+      "integrity": "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==",
+      "license": "Unlicense"
     },
     "node_modules/fast-uri": {
       "version": "3.1.2",
@@ -1801,6 +1814,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/standardwebhooks": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/standardwebhooks/-/standardwebhooks-1.0.0.tgz",
+      "integrity": "sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==",
+      "license": "MIT",
+      "dependencies": {
+        "@stablelib/base64": "^1.0.0",
+        "fast-sha256": "^1.3.0"
       }
     },
     "node_modules/statuses": {

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "build:mcpb": "npm run build && npx @anthropic-ai/mcpb pack ."
   },
   "dependencies": {
-    "@anthropic-ai/sdk": "^0.82.0",
+    "@anthropic-ai/sdk": "^0.104.2",
     "@modelcontextprotocol/ext-apps": "^1.5.0",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "swagger-ui-dist": "^5.32.0",


### PR DESCRIPTION
## What

Bumps `@anthropic-ai/sdk` from 0.82.0 to 0.104.2 (latest), clearing the last open **production** `npm audit` advisory.

## Why

`npm audit --omit=dev` flagged one moderate advisory:
- **GHSA-p7fg-763f-g4gf** — *Insecure Default File Permissions in the SDK's Local Filesystem Memory Tool* (CWE-732). Vulnerable `>=0.79.0 <0.91.1`; firstPatched **0.91.1**.

This is the advisory tracked on #353 as *"@anthropic-ai/sdk Local Filesystem Memory Tool — feature not used in our code; needs --force breaking upgrade tracked separately."* This PR is that upgrade.

**Applicability:** the advisory's vulnerable code path was never reachable here — agentdeals does **not** use the memory tool. The SDK is used only in two operator-run scripts (`scripts/reverify-rolling.js`, `scripts/verify-freshness.js`, npm scripts `reverify:rolling` / `verify-freshness`) via `new Anthropic()` + `client.messages.create({ model, max_tokens, messages })` + `response.content[0].text` — and not in the deployed web runtime (`src/`). But the SDK is still on the run-surface the security rotation covers, and clearing it removes audit noise that could mask a future real advisory.

## Version choice

Bumped to **latest (0.104.2)** rather than the minimal patched 0.91.1: the API surface the scripts use (constructor, `messages.create`, `content[0].text`) is stable across the entire 0.82→0.104 range, so the larger version span adds no real risk, and latest avoids leaving a security-sensitive dep one patch above the advisory floor.

## Verification

- **Production `npm audit --omit=dev`: 1 moderate → 0 vulnerabilities.**
- Real SDK API surface under 0.104.2: `new Anthropic()` constructs, `client.messages.create` is a function (matches both scripts' usage).
- `node --check` passes on both scripts.
- Full test suite: **1160/1160 pass** (unchanged from baseline — both script modules import the new SDK cleanly; the mocked `messages.create` tests confirm the `content[0].text` response shape still matches).
- `tsc --noEmit`: clean.
- `package.json` diff is the single version bump; the lockfile adds only the SDK's own webhook-helper transitive deps (`standardwebhooks` / `fast-sha256` / `@stablelib/base64`), all clean.

## Out of scope (noted for tracking)

The **full** audit (dev+prod) now shows a newly-published HIGH on `tmp@0.0.33` (GHSA-ph9p-34f9-6g65, path traversal). This is **pre-existing and unchanged by this PR** (empty lockfile diff for `tmp`) and **dev-only** — a deeply-nested transitive dep of the build-time bundler (`@anthropic-ai/mcpb` → `@inquirer/prompts` → `external-editor` → `tmp`), absent from the production runtime. Out of the deployed-surface rotation's scope; fixing it would need a risky `overrides`/mcpb bump that could break the interactive `mcpb pack` editor prompt. Flagging for a separate decision.

Refs #353