### PR TITLE
Clear dev-only HIGH (tmp path traversal) via overrides → tmp 0.2.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1516,16 +1516,6 @@
         "wrappy": "1"
       }
     },
-    "node_modules/os-tmpdir": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-      "integrity": "sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/parseurl": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
@@ -1873,16 +1863,13 @@
       }
     },
     "node_modules/tmp": {
-      "version": "0.0.33",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
-      "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.7.tgz",
+      "integrity": "sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "os-tmpdir": "~1.0.2"
-      },
       "engines": {
-        "node": ">=0.6.0"
+        "node": ">=14.14"
       }
     },
     "node_modules/toidentifier": {

--- a/package.json
+++ b/package.json
@@ -60,6 +60,9 @@
     "ts-node": "^10.9.0",
     "typescript": "^5.7.0"
   },
+  "overrides": {
+    "tmp": "^0.2.7"
+  },
   "engines": {
     "node": ">=20.0.0"
   }


### PR DESCRIPTION
## What

Adds an `overrides` entry forcing `tmp` to `^0.2.7`, clearing the last open advisories in agentdeals' full `npm audit` — **1 HIGH + 4 transitive lows**, all in the dev-only build-tool chain.

```
@anthropic-ai/mcpb (devDep, build:mcpb)
  → @inquirer/prompts → @inquirer/editor → external-editor@3.1.0 → tmp@0.0.33
```

## Why now

`tmp <=0.2.5` is vulnerable to:
- **GHSA-ph9p-34f9-6g65** — Path Traversal via unsanitized prefix/postfix (**HIGH**, newly published)
- GHSA-52f5-9888-hmc6 — arbitrary symlink dir write (low)

This was flagged in the [#353 PR #1016 comment](https://github.com/robhunter/agentdeals/issues/353) (2026-06-17) as *"Remaining… flagging for a separate decision."* Every prior "accept the dev-only risk" decision on #353 was premised on **no upstream fix being available**. That premise has changed: `tmp@0.2.6`/`0.2.7` are now published with the fix. They aren't reachable automatically because `external-editor` pins `tmp@^0.0.33` (exactly 0.0.33 under semver caret) — hence npm's "No fix available" — but an `overrides` force reaches them.

## Why it's safe

- **Production is unaffected.** `tmp` has zero production consumers — production `npm audit --omit=dev` was already 0 and stays 0. The override only touches the dev-only `build:mcpb` packaging tool (not in CI).
- **The cross-major bump (0.0.33 → 0.2.7) doesn't break the build tool.** `external-editor` only invokes `tmp`'s file-creation API when an interactive inquirer *editor* prompt opens — which the non-interactive `mcpb pack` flow never triggers. `tmp`'s top-level API surface is unchanged across the bump, so module load is unaffected.

## Verification

| Check | Before | After |
|---|---|---|
| full `npm audit` | 5 (4 low + 1 HIGH) | **0** |
| `npm audit --omit=dev` (production) | 0 | 0 (unchanged) |
| `npm run build:mcpb` | packs OK (tmp 0.0.33) | **packs OK (tmp 0.2.7)** |
| `tsc --noEmit` | clean | clean |
| `npm test` | 1160/1160 | **1160/1160** |

Empirically tested the `build:mcpb` path both before and after the override to confirm the "risky transitive bump" doesn't materialize in our usage.

Refs #353