### PR TITLE
Telemetry: never persist zeros over stored history after a failed load (#1018)

### DIFF
--- a/src/stats.ts
+++ b/src/stats.ts
@@ -221,17 +221,6 @@ export function resetTelemetryHealth(): void {
   for (const k of Object.keys(lastLoggedAt)) delete lastLoggedAt[k];
 }
 
-async function redisGet(): Promise<TelemetryData | null> {
-  const res = await redisCommand<string | null>(["GET", REDIS_KEY]);
-  if (!res.ok || !res.result) return null;
-  try {
-    return JSON.parse(res.result) as TelemetryData;
-  } catch (err) {
-    recordRedisFailure("GET", false, `unparseable telemetry blob: ${err instanceof Error ? err.message : String(err)}`);
-    return null;
-  }
-}
-
 async function redisSet(data: TelemetryData): Promise<boolean> {
   const res = await redisCommand<string>(["SET", REDIS_KEY, JSON.stringify(data)]);
   return res.ok && res.result === "OK";
@@ -409,17 +398,34 @@ function buildTelemetryData(): TelemetryData {
   };
 }
 
+// True when Redis is configured but the boot-time load could not be read. In that state
+// the in-memory `cumulative` totals are NOT the real historical totals — they are zeros —
+// so flushing them to Redis would destroy the stored history. See flushTelemetry.
+let telemetryLoadFailed = false;
+
+export function telemetryLoadDidFail(): boolean {
+  return telemetryLoadFailed;
+}
+
 export async function loadTelemetry(filePath: string): Promise<void> {
   telemetryPath = filePath;
 
   // Try Redis first if configured
   if (useRedis()) {
-    const data = await redisGet();
-    if (data) {
-      parseTelemetryData(data as unknown as Record<string, unknown>);
-      cumulative.last_deploy_at = serverStartedISO;
-      return;
+    const res = await redisCommand<string | null>(["GET", REDIS_KEY]);
+    if (res.ok && res.result) {
+      try {
+        parseTelemetryData(JSON.parse(res.result) as unknown as Record<string, unknown>);
+        cumulative.last_deploy_at = serverStartedISO;
+        telemetryLoadFailed = false;
+        return;
+      } catch {
+        // Corrupt blob — fall through to the file backup rather than trusting it.
+      }
     }
+    // A failed read is not an empty database. Starting from zero here and then writing
+    // those zeros back is how a transient outage turns into permanent data loss.
+    if (!res.ok) telemetryLoadFailed = true;
   }
 
   // Fall back to file
@@ -435,10 +441,31 @@ export async function loadTelemetry(filePath: string): Promise<void> {
 
 export async function flushTelemetry(): Promise<void> {
   if (!telemetryPath) return;
+
+  // If the boot-time load failed, our cumulative totals started at zero and writing them
+  // back would clobber the stored history. Retry the read first: once storage recovers we
+  // re-hydrate and resume persisting. Until then, file-only.
+  if (useRedis() && telemetryLoadFailed) {
+    const res = await redisCommand<string | null>(["GET", REDIS_KEY]);
+    if (res.ok) {
+      if (res.result) {
+        try {
+          parseTelemetryData(JSON.parse(res.result) as unknown as Record<string, unknown>);
+        } catch {
+          // Corrupt blob — treat as recovered-but-empty rather than blocking forever.
+        }
+      }
+      telemetryLoadFailed = false;
+      console.error("[telemetry] storage recovered — resuming persistence");
+    } else {
+      logRedisFailure("SET", `skipping persist: boot load failed (${res.error})`);
+    }
+  }
+
   const data = buildTelemetryData();
 
   // Write to Redis if configured
-  if (useRedis()) {
+  if (useRedis() && !telemetryLoadFailed) {
     await redisSet(data);
   }
 
@@ -452,6 +479,7 @@ export async function flushTelemetry(): Promise<void> {
 }
 
 export function resetCounters(): void {
+  telemetryLoadFailed = false;
   totalSessions = 0;
   totalDisconnects = 0;
   landingPageViews = 0;

--- a/test/stats-telemetry.test.ts
+++ b/test/stats-telemetry.test.ts
@@ -18,6 +18,9 @@ const {
   UNMATCHED_PAGE_KEY,
   logRequest,
   resetCounters,
+  loadTelemetry,
+  flushTelemetry,
+  telemetryLoadDidFail,
 } = await import("../dist/stats.js");
 
 type Call = { cmd: string; args: unknown[] };
@@ -208,6 +211,49 @@ describe("telemetry storage layer (#1018)", () => {
       assert.strictEqual(empty.available, true, "a genuinely empty log is available, just empty");
       assert.strictEqual(empty.error, null);
       assert.deepStrictEqual(empty.entries, []);
+    });
+  });
+
+  describe("a failed load must not clobber stored history", () => {
+    it("refuses to persist zeros after the boot-time read failed", async () => {
+      responder = () => ({ error: "ERR max requests limit exceeded. Limit: 500000, Usage: 500000" });
+      await loadTelemetry("/tmp/agentdeals-telemetry-test.json");
+      assert.strictEqual(telemetryLoadDidFail(), true, "an errored GET is not an empty database");
+
+      calls = [];
+      await flushTelemetry();
+      assert.strictEqual(callsFor("SET").length, 0, "flushing zeros over real history is data loss");
+    });
+
+    it("resumes persisting once storage recovers", async () => {
+      responder = () => ({ error: "ERR max requests limit exceeded" });
+      await loadTelemetry("/tmp/agentdeals-telemetry-test.json");
+      assert.strictEqual(telemetryLoadDidFail(), true);
+
+      // Storage comes back with the real historical totals.
+      responder = (cmd) => {
+        if (cmd === "GET") return { result: JSON.stringify({ cumulative_api_hits: 282802, cumulative_sessions: 24955 }) };
+        return { result: "OK" };
+      };
+      calls = [];
+      await flushTelemetry();
+      assert.strictEqual(telemetryLoadDidFail(), false, "a successful re-read clears the block");
+      assert.strictEqual(callsFor("SET").length, 1, "persistence should resume");
+
+      const written = JSON.parse(String(callsFor("SET")[0].args[1]));
+      assert.strictEqual(written.cumulative_api_hits, 282802, "history must be re-hydrated, not overwritten with zeros");
+    });
+
+    it("persists normally when the boot-time read succeeds", async () => {
+      responder = (cmd) => {
+        if (cmd === "GET") return { result: JSON.stringify({ cumulative_api_hits: 100 }) };
+        return { result: "OK" };
+      };
+      await loadTelemetry("/tmp/agentdeals-telemetry-test.json");
+      assert.strictEqual(telemetryLoadDidFail(), false);
+      calls = [];
+      await flushTelemetry();
+      assert.strictEqual(callsFor("SET").length, 1);
     });
   });
 


### PR DESCRIPTION
Follow-up to #1021. That PR made storage failures visible; deploying it immediately surfaced the confirmed root cause **and** a live data-loss hazard.

## Confirmed root cause of #1018

Straight from the deployed instrumentation, `/api/pageviews` → `storage.last_write_error`:

```
ERR max requests limit exceeded. Limit: 500000, Usage: 500000
```

The Upstash plan's command quota is fully exhausted. **This is neither of the two candidates in the issue** — not a data-size ceiling, not an oversized `MGET`. It is the request quota, which is why `INCR`/`LPUSH` and some reads fail while cached/in-memory paths look healthy.

The unbounded keyspace was still the *driver*: a TTL-less key per raw request path meant `getPageViews()` fanned out `SCAN` + `MGET` across a junk keyspace on every call, on top of 3 `INCR`s per page view and 2 commands per logged request. That is what burned 500,000 commands. #1021 removes the amplification; **it cannot restore service, because the quota is spent.** That needs a plan decision — flagged for Rob.

## The hazard this PR fixes

With the quota exhausted, the boot-time `GET` fails. `loadTelemetry` treated a failed read exactly like "no data yet" and started from zero. Production right now:

```
cumulative_api_hits:  89        (was 282,802)
cumulative_sessions:  1         (was 24,955)
```

Those zeros are in memory, and `flushTelemetry` writes them back on every flush. The moment the quota resets, the first successful `SET` would overwrite the real history with them — a transient outage becoming permanent loss of every historical counter, including the vendor-level traffic history #1018 is about.

It is the same defect class as the unavailable-as-zero bug, applied to the data that matters most.

## Change

- `loadTelemetry` distinguishes a **failed** read from an **empty** one and sets a flag. A corrupt blob falls through to the file backup instead of being trusted.
- `flushTelemetry` skips the Redis write while that flag is set, and retries the read on each flush. When storage recovers, the re-read **re-hydrates the real totals first**, then persistence resumes — so recovery is automatic and nothing is overwritten.
- The file backup is written throughout, unchanged.

## Verification

`tsc --noEmit` clean · **1179/1179** tests pass (3 new, hermetic).

Tests cover: a failed load blocks the `SET`; recovery re-hydrates `cumulative_api_hits: 282802` from storage rather than writing zeros over it; a healthy load persists normally.

Bite-verified — restoring the pre-fix `if (useRedis())` flush condition fails the guard test.

Refs #1018
