### PR TITLE
Telemetry: buffer and flush so command volume fits a fixed budget (#1023)

### DIFF
--- a/src/serve.ts
+++ b/src/serve.ts
@@ -8,7 +8,7 @@ import { createServer, getServerCard } from "./server.js";
 import { loadOffers, getCategories, getNewOffers, getNewestDeals, searchOffers, enrichOffers, loadDealChanges, getDealChanges, getPersonalizedChanges, getOfferDetails, compareServices, checkVendorRisk, auditStack, getExpiringDeals, getWeeklyDigest, getFormattedWeeklyDigest, getFreshnessMetrics, getStabilityMap, getVendorReferral, sanitizeQuery } from "./data.js";
 import { getStackRecommendation } from "./stacks.js";
 import { estimateCosts } from "./costs.js";
-import { recordApiHit, recordSessionConnect, recordSessionDisconnect, recordLandingPageView, getStats, getConnectionStats, loadTelemetry, flushTelemetry, logRequest, getRequestLog, getRequestLogResult, getTelemetryHealth, recordPageView, getPageViews, recordReferralListingCall, recordReferralVendorLookup, getReferralMarketplaceStats, getSessionClassification, recordSearchQuery, getSearchAnalytics, getApiHitsByEndpoint } from "./stats.js";
+import { recordApiHit, recordSessionConnect, recordSessionDisconnect, recordLandingPageView, getStats, getConnectionStats, loadTelemetry, flushTelemetry, flushPending, FLUSH_INTERVAL_SECONDS, logRequest, getRequestLog, getRequestLogResult, getTelemetryHealth, recordPageView, getPageViews, recordReferralListingCall, recordReferralVendorLookup, getReferralMarketplaceStats, getSessionClassification, recordSearchQuery, getSearchAnalytics, getApiHitsByEndpoint } from "./stats.js";
 import { openapiSpec } from "./openapi.js";
 import { registerAgent, authenticateRequest, validateVestauthUrl, hashApiKey, updateAgentX402Address, getAgentById } from "./agents.js";
 import { logReferralRequest } from "./referral-requests.js";
@@ -56034,9 +56034,26 @@ if (!BASE_URL.includes("localhost")) {
 const FLUSH_INTERVAL_MS = 5 * 60 * 1000;
 setInterval(() => flushTelemetry(), FLUSH_INTERVAL_MS).unref();
 
-// Flush on graceful shutdown
+// Page-view counters and the request log are buffered in memory and written as aggregated
+// batches on this interval, so Redis command volume is O(flush intervals) rather than
+// O(requests served) (#1023).
+setInterval(() => {
+  flushPending().catch((err) => console.error(`[telemetry] flush failed: ${err?.message ?? err}`));
+}, FLUSH_INTERVAL_SECONDS * 1000).unref();
+
+// Flush on graceful shutdown. Buffered counters go first: they exist only in memory, so
+// a missed flush here is the one interval of data this design accepts losing on an
+// *unclean* exit and should never lose on a clean one.
+let shuttingDown = false;
 async function onShutdown() {
-  await flushTelemetry();
+  if (shuttingDown) return;
+  shuttingDown = true;
+  try {
+    await flushPending();
+    await flushTelemetry();
+  } catch (err: any) {
+    console.error(`[telemetry] shutdown flush failed: ${err?.message ?? err}`);
+  }
   process.exit(0);
 }
 process.on("SIGTERM", () => onShutdown());

--- a/src/stats.ts
+++ b/src/stats.ts
@@ -131,6 +131,32 @@ const redisHealth = {
   readFailures: 0,
 };
 
+// --- Command budget accounting (#1023) ---
+// Upstash bills per command, not per HTTP request, and the plan ceiling is a hard stop:
+// past it every command is rejected. The 2026-08-07 outage was this ceiling being reached,
+// so the number of commands we spend is itself a thing that has to be measured.
+const DEFAULT_MONTHLY_COMMAND_BUDGET = 300_000;
+const MONTHLY_COMMAND_BUDGET =
+  Number(process.env.TELEMETRY_COMMAND_BUDGET) > 0
+    ? Number(process.env.TELEMETRY_COMMAND_BUDGET)
+    : DEFAULT_MONTHLY_COMMAND_BUDGET;
+
+// Projecting a daily rate from a few seconds of uptime produces nonsense. Divide by at
+// least this much elapsed time so a freshly-booted process under-reports rather than
+// reporting a wild extrapolation.
+const RATE_ESTIMATE_FLOOR_SECONDS = 300;
+
+let commandsIssued = 0;
+
+// Upstash's phrasing for a spent quota has varied ("max requests limit exceeded",
+// "max daily request limit exceeded"). Matching it lets the endpoint say *which* failure
+// mode we are in, which is the difference between "upgrade the plan" and "fix the code".
+const QUOTA_ERROR_PATTERN = /max (?:requests|daily request|commands?)\s+limit exceeded|quota/i;
+
+function isQuotaError(error: string | null): boolean {
+  return typeof error === "string" && QUOTA_ERROR_PATTERN.test(error);
+}
+
 // Throttle stderr so a hard outage can't turn into a log flood (one line per command
 // class per minute is enough to see the actual Upstash error in the platform logs).
 const lastLoggedAt: Record<string, number> = {};
@@ -159,6 +185,10 @@ async function redisCommand<T>(cmd: (string | number)[]): Promise<RedisResult<T>
   if (!useRedis()) return { ok: false, error: "redis-not-configured" };
   const command = String(cmd[0]).toUpperCase();
   const isWrite = WRITE_COMMANDS.has(command);
+  // Counted on attempt, not on success: a command rejected for quota has already been
+  // charged against the quota, so counting only successes would under-report the spend
+  // exactly when it matters most.
+  commandsIssued++;
   const url = process.env.UPSTASH_REDIS_REST_URL!;
   const token = process.env.UPSTASH_REDIS_REST_TOKEN!;
   try {
@@ -195,9 +225,30 @@ export interface TelemetryHealth {
   last_read_error_at: string | null;
   write_failures: number;
   read_failures: number;
+  /** True when the last write failure was the plan's command ceiling rather than a bug. */
+  quota_exhausted: boolean;
+  /** What this process has actually spent, and what that projects to (#1023). */
+  commands_since_boot: number;
+  uptime_seconds: number;
+  estimated_commands_per_day: number;
+  estimated_commands_per_month: number;
+  monthly_command_budget: number;
+  over_budget: boolean;
+  /** Work sitting in memory waiting for the next flush. */
+  pending_page_view_keys: number;
+  pending_request_log_entries: number;
+  /** Request-log entries dropped because a single interval overflowed the batch cap. */
+  request_log_dropped: number;
+  last_flush_at: string | null;
+  flush_interval_seconds: number;
 }
 
 export function getTelemetryHealth(): TelemetryHealth {
+  const uptimeSeconds = Math.round((Date.now() - startedAt) / 1000);
+  const perDay = Math.round(
+    (commandsIssued / Math.max(uptimeSeconds, RATE_ESTIMATE_FLOOR_SECONDS)) * 86_400,
+  );
+  const perMonth = perDay * 30;
   return {
     configured: useRedis(),
     last_write_at: redisHealth.lastWriteAt,
@@ -207,6 +258,18 @@ export function getTelemetryHealth(): TelemetryHealth {
     last_read_error_at: redisHealth.lastReadErrorAt,
     write_failures: redisHealth.writeFailures,
     read_failures: redisHealth.readFailures,
+    quota_exhausted: isQuotaError(redisHealth.lastWriteError) || isQuotaError(redisHealth.lastReadError),
+    commands_since_boot: commandsIssued,
+    uptime_seconds: uptimeSeconds,
+    estimated_commands_per_day: perDay,
+    estimated_commands_per_month: perMonth,
+    monthly_command_budget: MONTHLY_COMMAND_BUDGET,
+    over_budget: perMonth > MONTHLY_COMMAND_BUDGET,
+    pending_page_view_keys: countPendingPageViewKeys(),
+    pending_request_log_entries: requestLogPending.length,
+    request_log_dropped: requestLogDropped,
+    last_flush_at: lastFlushAt,
+    flush_interval_seconds: FLUSH_INTERVAL_SECONDS,
   };
 }
 
@@ -218,6 +281,7 @@ export function resetTelemetryHealth(): void {
   redisHealth.lastReadErrorAt = null;
   redisHealth.writeFailures = 0;
   redisHealth.readFailures = 0;
+  commandsIssued = 0;
   for (const k of Object.keys(lastLoggedAt)) delete lastLoggedAt[k];
 }
 
@@ -241,44 +305,114 @@ export interface RequestLogEntry {
   client_info?: { name: string; version: string };
 }
 
-async function redisLpush(key: string, value: string): Promise<boolean> {
-  const res = await redisCommand<number>(["LPUSH", key, value]);
-  return res.ok && typeof res.result === "number";
-}
+// At most this many entries go out in one flush. A single variadic LPUSH is one command
+// regardless of how many values it carries, so the cap exists to bound the request body,
+// not the command count. Overflow is counted and surfaced rather than dropped silently.
+const REQUEST_LOG_FLUSH_MAX = 250;
 
-async function redisLtrim(key: string, start: number, stop: number): Promise<boolean> {
-  const res = await redisCommand<string>(["LTRIM", key, start, stop]);
-  return res.ok;
-}
+// Let the stored list run this far past its cap before spending a command to trim it.
+const REQUEST_LOG_TRIM_THRESHOLD = Math.floor(REQUEST_LOG_MAX * 1.2);
+
+// Newest-first mirror of the stored list: hydrated once at boot, then kept in step with
+// everything this process pushes. Reads are served from here, so /api/query-log costs
+// zero Redis commands no matter how often it is polled (#1023).
+let requestLogMirror: RequestLogEntry[] = [];
+let requestLogPending: RequestLogEntry[] = [];
+let requestLogDropped = 0;
+let requestLogHydrated = false;
 
 async function redisLrange(key: string, start: number, stop: number): Promise<RedisResult<string[]>> {
   const res = await redisCommand<string[]>(["LRANGE", key, start, stop]);
   if (!res.ok) return res;
-  return { ok: true, result: res.result ?? [] };
+  if (res.result === null || res.result === undefined) return { ok: true, result: [] };
+  // A non-array here means the key is not a list (or the response is not what we asked
+  // for). Report it as a read failure rather than letting an unexpected shape throw its
+  // way out of the boot path — same reasoning as the MGET length check.
+  if (!Array.isArray(res.result)) {
+    const error = `LRANGE returned ${typeof res.result}, expected a list`;
+    recordRedisFailure("LRANGE", false, error);
+    return { ok: false, error };
+  }
+  return { ok: true, result: res.result };
 }
 
-export async function logRequest(entry: RequestLogEntry): Promise<void> {
-  const pushed = await redisLpush(REQUEST_LOG_KEY, JSON.stringify(entry));
-  if (pushed) {
-    // Cap list at REQUEST_LOG_MAX entries
-    await redisLtrim(REQUEST_LOG_KEY, 0, REQUEST_LOG_MAX - 1);
+// Buffered: one LPUSH per flush interval instead of LPUSH+LTRIM per request. The old
+// path cost 2 Redis commands for every logged HTTP request, which is what made command
+// volume O(requests served) and put steady-state spend over the plan ceiling (#1023).
+export function logRequest(entry: RequestLogEntry): void {
+  requestLogMirror.unshift(entry);
+  if (requestLogMirror.length > REQUEST_LOG_MAX) requestLogMirror.length = REQUEST_LOG_MAX;
+
+  if (!useRedis()) return;
+  requestLogPending.push(entry);
+  if (requestLogPending.length > REQUEST_LOG_FLUSH_MAX) {
+    const overflow = requestLogPending.length - REQUEST_LOG_FLUSH_MAX;
+    requestLogDropped += overflow;
+    requestLogPending.splice(0, overflow);
+  }
+}
+
+function parseLogEntry(raw: string): RequestLogEntry | null {
+  try { return JSON.parse(raw) as RequestLogEntry; }
+  catch { return null; }
+}
+
+async function loadRequestLog(): Promise<void> {
+  if (!useRedis()) return;
+  const res = await redisLrange(REQUEST_LOG_KEY, 0, REQUEST_LOG_MAX - 1);
+  if (!res.ok) return; // stays unhydrated — reads report unavailable rather than empty
+  const stored = res.result
+    .map(parseLogEntry)
+    .filter((e): e is RequestLogEntry => e !== null);
+  // Anything logged while the read was in flight is newer than everything stored.
+  requestLogMirror = [...requestLogMirror, ...stored].slice(0, REQUEST_LOG_MAX);
+  requestLogHydrated = true;
+}
+
+async function flushRequestLog(): Promise<void> {
+  if (!useRedis() || requestLogPending.length === 0) return;
+  const batch = requestLogPending;
+  requestLogPending = [];
+
+  // LPUSH is variadic: the whole batch is a single command. Values are pushed left-to-right,
+  // so the chronologically-last entry ends up at index 0 — the newest-first ordering readers
+  // already expect.
+  const push = await redisCommand<number>([
+    "LPUSH",
+    REQUEST_LOG_KEY,
+    ...batch.map((e) => JSON.stringify(e)),
+  ]);
+  if (!push.ok) {
+    // Keep the batch for the next attempt rather than losing it, bounded the same way.
+    requestLogPending = [...batch, ...requestLogPending].slice(-REQUEST_LOG_FLUSH_MAX);
+    return;
+  }
+  // LPUSH returns the new length, so the trim can wait until the list has actually
+  // outgrown its cap by a margin. Trimming on every flush would cost as many commands as
+  // the push itself to remove a handful of entries nothing reads (readers ask for ≤200).
+  if (typeof push.result === "number" && push.result > REQUEST_LOG_TRIM_THRESHOLD) {
+    await redisCommand<string>(["LTRIM", REQUEST_LOG_KEY, 0, REQUEST_LOG_MAX - 1]);
   }
 }
 
 // Returns the log alongside an explicit `available` flag. An unreachable Redis
 // previously produced an empty array indistinguishable from "no traffic yet" (#1018).
+// Served from the in-memory mirror; `available` is false until the boot-time read of the
+// stored list has succeeded, so an unread log is still never reported as an empty one.
 export async function getRequestLogResult(limit = 50): Promise<{
   entries: RequestLogEntry[];
   available: boolean;
   error: string | null;
 }> {
-  const res = await redisLrange(REQUEST_LOG_KEY, 0, limit - 1);
-  if (!res.ok) return { entries: [], available: false, error: res.error };
-  const entries = res.result.map((s) => {
-    try { return JSON.parse(s) as RequestLogEntry; }
-    catch { return null; }
-  }).filter((e): e is RequestLogEntry => e !== null);
-  return { entries, available: true, error: null };
+  if (!useRedis()) return { entries: [], available: false, error: "redis-not-configured" };
+  if (!requestLogHydrated) {
+    return {
+      entries: [],
+      available: false,
+      error: redisHealth.lastReadError ?? "request log not loaded",
+    };
+  }
+  return { entries: requestLogMirror.slice(0, limit), available: true, error: null };
 }
 
 export async function getRequestLog(limit = 50): Promise<RequestLogEntry[]> {
@@ -410,6 +544,12 @@ export function telemetryLoadDidFail(): boolean {
 export async function loadTelemetry(filePath: string): Promise<void> {
   telemetryPath = filePath;
 
+  // Page views and the request log are stored separately and hydrate here so the whole
+  // boot-time read is one place. Both fail closed: an unread store stays unloaded and is
+  // retried on the next flush rather than being treated as empty (#1018/#1022).
+  await loadPageViews();
+  await loadRequestLog();
+
   // Try Redis first if configured
   if (useRedis()) {
     const res = await redisCommand<string | null>(["GET", REDIS_KEY]);
@@ -510,6 +650,23 @@ export function resetCounters(): void {
   cumulative.referral_vendor_counts = {};
   cumulative.api_hits_by_endpoint = {};
   searchQueryLog.length = 0;
+  resetTelemetryBuffers();
+}
+
+// Clears the buffered write paths and their loaded-from-storage state. Separate from
+// resetCounters so a test can put the process back in its just-booted, nothing-loaded
+// condition without touching the cumulative counters.
+export function resetTelemetryBuffers(): void {
+  pageViewSnapshot = emptySnapshot();
+  pendingPageViews = emptySnapshot();
+  pageViewsLoaded = false;
+  pageViewsRereadPending = false;
+  legacyMigrationDone = false;
+  requestLogMirror = [];
+  requestLogPending = [];
+  requestLogDropped = 0;
+  requestLogHydrated = false;
+  lastFlushAt = null;
 }
 
 export function recordToolCall(tool: string, clientName?: string): void {
@@ -747,24 +904,170 @@ function isBot(userAgent: string): boolean {
 let pageViewsToday = 0;
 let pageViewsTodayDate = new Date().toISOString().slice(0, 10);
 
-// Daily page-view and referrer keys expire after DAILY_KEY_TTL_SECONDS. Without a TTL,
-// every distinct path ever requested became a permanent key (#1018).
-const DAILY_KEY_TTL_SECONDS = 35 * 24 * 60 * 60;
-
 // Upstash rejects oversized requests, and a rejected MGET used to read back as a page of
-// zeros. Chunking keeps each command small enough to succeed.
+// zeros. Chunking keeps each command small enough to succeed. Only the one-time migration
+// off the legacy key space still reads this way.
 const MGET_CHUNK_SIZE = 100;
 
-// INCR returns the post-increment value, so a result of 1 means we just created the key —
-// the only moment an EXPIRE is needed. Setting it on every hit would double command volume
-// and keep pushing the expiry out, which for a daily key is exactly wrong.
-async function redisIncrWithTtl(key: string, ttlSeconds?: number): Promise<boolean> {
-  const res = await redisCommand<number>(["INCR", key]);
-  if (!res.ok || typeof res.result !== "number") return false;
-  if (ttlSeconds !== undefined && res.result === 1) {
-    await redisCommand<number>(["EXPIRE", key, ttlSeconds]);
+// --- Page-view storage (#1023) ---
+//
+// Counters used to live one Redis key per (day, path): 3-4 INCRs per page view on write,
+// and a SCAN + MGET fan-out per /api/pageviews call on read. That makes command volume
+// O(requests served) on both sides, which is what exhausted the plan's command quota.
+//
+// They now live in a single JSON snapshot key. Writes accumulate in memory and the whole
+// snapshot is rewritten once per flush interval, so:
+//   * write cost is O(flush intervals), not O(page views) — 2 commands per flush, and
+//     zero when nothing changed;
+//   * read cost is zero — /api/pageviews serves the in-memory snapshot merged with the
+//     un-flushed deltas, so there is no fan-out to cache and no SCAN at all;
+//   * retention is enforced in code (no TTL command, no EXPIRE per key), and the key
+//     space cannot grow without bound because the maps are capped.
+const PAGE_VIEWS_KEY = "agentdeals:pageviews";
+const PAGE_VIEW_DAY_RETENTION = 7;
+const MAX_PAGE_KEYS_PER_DAY = 300;
+const MAX_ALL_TIME_PAGE_KEYS = 300;
+
+// A Referer header is attacker-controlled, so the referrer map is the one part of this
+// key space a stranger can grow. Capping it is what keeps command *payload* — and, before
+// this change, command *count* — from scaling with hostile traffic.
+const MAX_REFERRER_DOMAINS_PER_DAY = 100;
+export const OTHER_REFERRER_KEY = "__other__";
+
+const DAY_TOTAL_KEY = "total";
+
+interface PageViewSnapshot {
+  /** date -> path -> count, including the DAY_TOTAL_KEY pseudo-path. */
+  days: Record<string, Record<string, number>>;
+  /** date -> referrer domain -> count. */
+  referrers: Record<string, Record<string, number>>;
+  /** path -> count, never pruned by date. */
+  all_time: Record<string, number>;
+  updated_at: string;
+}
+
+function emptySnapshot(): PageViewSnapshot {
+  return { days: {}, referrers: {}, all_time: {}, updated_at: "" };
+}
+
+/** Last state known to be stored. */
+let pageViewSnapshot = emptySnapshot();
+/** Increments not yet persisted. Same shape so merging is a plain deep add. */
+let pendingPageViews = emptySnapshot();
+/** False until we have a trustworthy base to add deltas to — see flushPageViews. */
+let pageViewsLoaded = false;
+/** Set by a successful load; consumed by the first flush after it. */
+let pageViewsRereadPending = false;
+
+function bump(map: Record<string, number>, key: string, delta: number): void {
+  map[key] = (map[key] ?? 0) + delta;
+}
+
+// Adds to `map`, folding into `overflowKey` once the key space is full. `known` is a
+// second map (the persisted side) consulted so a key already in the snapshot is not
+// treated as new. Counts are never dropped, only relabelled.
+function bumpBounded(
+  map: Record<string, number>,
+  key: string,
+  delta: number,
+  cap: number,
+  overflowKey: string,
+  known?: Record<string, number>,
+): void {
+  if (key !== overflowKey && !(key in map) && !(known && key in known)) {
+    const size = known
+      ? new Set([...Object.keys(map), ...Object.keys(known)]).size
+      : Object.keys(map).length;
+    if (size >= cap) key = overflowKey;
   }
-  return true;
+  bump(map, key, delta);
+}
+
+function countPendingPageViewKeys(): number {
+  let n = Object.keys(pendingPageViews.all_time).length;
+  for (const day of Object.values(pendingPageViews.days)) n += Object.keys(day).length;
+  for (const day of Object.values(pendingPageViews.referrers)) n += Object.keys(day).length;
+  return n;
+}
+
+function hasPendingPageViews(): boolean {
+  return countPendingPageViewKeys() > 0;
+}
+
+function mergeSnapshot(base: PageViewSnapshot, delta: PageViewSnapshot): PageViewSnapshot {
+  const out: PageViewSnapshot = {
+    days: {},
+    referrers: {},
+    all_time: { ...base.all_time },
+    updated_at: base.updated_at,
+  };
+  for (const [date, map] of Object.entries(base.days)) out.days[date] = { ...map };
+  for (const [date, map] of Object.entries(base.referrers)) out.referrers[date] = { ...map };
+
+  for (const [date, map] of Object.entries(delta.days)) {
+    const target = (out.days[date] ??= {});
+    for (const [key, count] of Object.entries(map)) {
+      if (key === DAY_TOTAL_KEY) bump(target, key, count);
+      else bumpBounded(target, key, count, MAX_PAGE_KEYS_PER_DAY, UNMATCHED_PAGE_KEY);
+    }
+  }
+  for (const [date, map] of Object.entries(delta.referrers)) {
+    const target = (out.referrers[date] ??= {});
+    for (const [key, count] of Object.entries(map)) {
+      bumpBounded(target, key, count, MAX_REFERRER_DOMAINS_PER_DAY, OTHER_REFERRER_KEY);
+    }
+  }
+  for (const [key, count] of Object.entries(delta.all_time)) {
+    bumpBounded(out.all_time, key, count, MAX_ALL_TIME_PAGE_KEYS, UNMATCHED_PAGE_KEY);
+  }
+  return out;
+}
+
+// Retention is applied here rather than by Redis TTLs — one fewer command per key, and it
+// works for a snapshot that has no per-key expiry to hang a TTL on. Overflowing all-time
+// paths fold into __unmatched__ so the total stays exact.
+function pruneSnapshot(snapshot: PageViewSnapshot): void {
+  for (const field of ["days", "referrers"] as const) {
+    const dates = Object.keys(snapshot[field]).sort().reverse();
+    for (const date of dates.slice(PAGE_VIEW_DAY_RETENTION)) delete snapshot[field][date];
+  }
+  const entries = Object.entries(snapshot.all_time);
+  if (entries.length > MAX_ALL_TIME_PAGE_KEYS) {
+    entries.sort((a, b) => b[1] - a[1]);
+    const kept = Object.fromEntries(entries.slice(0, MAX_ALL_TIME_PAGE_KEYS));
+    const folded = entries.slice(MAX_ALL_TIME_PAGE_KEYS).reduce((sum, [, v]) => sum + v, 0);
+    snapshot.all_time = kept;
+    if (folded > 0) bump(snapshot.all_time, UNMATCHED_PAGE_KEY, folded);
+  }
+}
+
+function numericMap(raw: unknown): Record<string, number> {
+  const out: Record<string, number> = {};
+  if (!raw || typeof raw !== "object") return out;
+  for (const [k, v] of Object.entries(raw as Record<string, unknown>)) {
+    if (typeof v === "number" && Number.isFinite(v)) out[k] = v;
+  }
+  return out;
+}
+
+function numericMapOfMaps(raw: unknown): Record<string, Record<string, number>> {
+  const out: Record<string, Record<string, number>> = {};
+  if (!raw || typeof raw !== "object") return out;
+  for (const [k, v] of Object.entries(raw as Record<string, unknown>)) out[k] = numericMap(v);
+  return out;
+}
+
+// The snapshot may have been written by an older build or hand-edited; take what parses
+// and ignore the rest rather than rejecting the whole blob.
+function normalizeSnapshot(raw: unknown): PageViewSnapshot {
+  const snapshot = emptySnapshot();
+  if (!raw || typeof raw !== "object") return snapshot;
+  const obj = raw as Record<string, unknown>;
+  snapshot.days = numericMapOfMaps(obj.days);
+  snapshot.referrers = numericMapOfMaps(obj.referrers);
+  snapshot.all_time = numericMap(obj.all_time);
+  snapshot.updated_at = typeof obj.updated_at === "string" ? obj.updated_at : "";
+  return snapshot;
 }
 
 async function redisMget(keys: string[]): Promise<RedisResult<(string | null)[]>> {
@@ -873,25 +1176,196 @@ export function recordPageView(path: string, userAgent: string, referer?: string
   const served = statusCode === undefined || statusCode < 400;
   const key = served ? normalizePagePath(path) : UNMATCHED_PAGE_KEY;
 
-  // Fire-and-forget — don't await
-  const dailyPath = `pv:${today}:${key}`;
-  const dailyTotal = `pv:${today}:total`;
-  const allTimePath = `pv:all:${key}`;
-  redisIncrWithTtl(dailyPath, DAILY_KEY_TTL_SECONDS).catch(() => {});
-  redisIncrWithTtl(dailyTotal, DAILY_KEY_TTL_SECONDS).catch(() => {});
-  // All-time counters persist, but only over the normalized key space.
-  redisIncrWithTtl(allTimePath).catch(() => {});
+  // Pure in-memory accounting — no Redis command on the request path at all. The deltas
+  // go out aggregated on the next flush (#1023).
+  const day = (pendingPageViews.days[today] ??= {});
+  bumpBounded(day, key, 1, MAX_PAGE_KEYS_PER_DAY, UNMATCHED_PAGE_KEY, pageViewSnapshot.days[today]);
+  bump(day, DAY_TOTAL_KEY, 1);
+  bumpBounded(pendingPageViews.all_time, key, 1, MAX_ALL_TIME_PAGE_KEYS, UNMATCHED_PAGE_KEY, pageViewSnapshot.all_time);
 
-  // Track referrer domain
   if (referer) {
     try {
       const refUrl = new URL(referer);
       const domain = refUrl.hostname.replace(/^www\./, "");
-      redisIncrWithTtl(`ref:${today}:${domain}`, DAILY_KEY_TTL_SECONDS).catch(() => {});
+      const refDay = (pendingPageViews.referrers[today] ??= {});
+      bumpBounded(
+        refDay,
+        domain,
+        1,
+        MAX_REFERRER_DOMAINS_PER_DAY,
+        OTHER_REFERRER_KEY,
+        pageViewSnapshot.referrers[today],
+      );
     } catch {
       // Invalid referrer URL — skip
     }
   }
+}
+
+// --- Page-view load / migration / flush ---
+
+let legacyMigrationDone = false;
+
+// One-time move off the per-key layout. The all-time counters are real history (the
+// partnership conversation is about exactly these numbers), so they are read across and
+// folded into the snapshot rather than abandoned. Legacy keys are left in place: the
+// dailies carry TTLs and expire themselves, and pv:all:* becomes inert once we stop
+// reading it. Returns false if any read failed — a partial migration would silently
+// under-count history, so we retry on the next flush instead of persisting it.
+async function migrateLegacyPageViews(): Promise<PageViewSnapshot | null> {
+  const today = new Date().toISOString().slice(0, 10);
+  const yesterday = new Date(Date.now() - 86400000).toISOString().slice(0, 10);
+  const snapshot = emptySnapshot();
+
+  const sources: { pattern: string; apply: (suffix: string, value: number) => void }[] = [
+    {
+      pattern: "pv:all:",
+      apply: (suffix, value) => bump(snapshot.all_time, suffix, value),
+    },
+    {
+      pattern: `pv:${today}:`,
+      apply: (suffix, value) => bump((snapshot.days[today] ??= {}), suffix, value),
+    },
+    {
+      pattern: `pv:${yesterday}:`,
+      apply: (suffix, value) => bump((snapshot.days[yesterday] ??= {}), suffix, value),
+    },
+    {
+      pattern: `ref:${today}:`,
+      apply: (suffix, value) => bump((snapshot.referrers[today] ??= {}), suffix, value),
+    },
+  ];
+
+  for (const { pattern, apply } of sources) {
+    const scan = await redisScan(`${pattern}*`);
+    if (!scan.ok) return null;
+    if (scan.result.length === 0) continue;
+    const { values, missing } = await redisGetMulti(scan.result);
+    if (missing.length > 0) return null;
+    for (const key of scan.result) apply(key.slice(pattern.length), values.get(key) ?? 0);
+  }
+
+  // pv:all:* never had a total key; the day maps did, and it is carried across as-is.
+  pruneSnapshot(snapshot);
+  return snapshot;
+}
+
+async function loadPageViews(): Promise<void> {
+  if (!useRedis()) return;
+  const res = await redisCommand<string | null>(["GET", PAGE_VIEWS_KEY]);
+  if (!res.ok) return; // a failed read is not an empty database — stay unloaded (#1022)
+
+  if (res.result) {
+    try {
+      pageViewSnapshot = normalizeSnapshot(JSON.parse(res.result));
+      pageViewsLoaded = true;
+      pageViewsRereadPending = true;
+      legacyMigrationDone = true;
+      return;
+    } catch {
+      // Corrupt blob — fall through and rebuild from the legacy key space.
+    }
+  }
+
+  if (!legacyMigrationDone) {
+    const migrated = await migrateLegacyPageViews();
+    if (!migrated) return; // could not read the legacy keys — retry rather than zero them
+    pageViewSnapshot = migrated;
+    legacyMigrationDone = true;
+  }
+  pageViewsLoaded = true;
+  pageViewsRereadPending = true;
+}
+
+async function flushPageViews(): Promise<void> {
+  if (!useRedis()) return;
+
+  if (!pageViewsLoaded) {
+    // Same guard as flushTelemetry: until we have read the stored history, writing our
+    // in-memory view over it would turn an outage into permanent loss (#1022). Deltas keep
+    // accumulating in memory — the key space is capped, so that is bounded.
+    await loadPageViews();
+    if (!pageViewsLoaded) {
+      logRedisFailure("SET", "skipping page-view persist: snapshot not loaded");
+      return;
+    }
+  }
+
+  if (!hasPendingPageViews()) return;
+
+  // One best-effort re-read on the first flush after boot. During a deploy the outgoing
+  // instance flushes on SIGTERM, which can land *after* our boot read; merging into that
+  // stale base would drop its final batch. After this we are the only writer, so the
+  // in-memory snapshot is exactly what we last stored and re-reading every flush would
+  // just spend a command to learn what we already know.
+  if (pageViewsRereadPending) {
+    pageViewsRereadPending = false;
+    const read = await redisCommand<string | null>(["GET", PAGE_VIEWS_KEY]);
+    if (read.ok && read.result) {
+      try { pageViewSnapshot = normalizeSnapshot(JSON.parse(read.result)); }
+      catch { /* corrupt — keep the last known-good local copy */ }
+    }
+  }
+
+  // Take the buffer before the round trip, not after. Requests keep arriving during the
+  // SET, and clearing `pendingPageViews` on the far side of the await would discard every
+  // view recorded in that window — they are not in `merged`, so nothing would ever store
+  // them. Anything counted from here on lands in the next batch.
+  const batch = pendingPageViews;
+  pendingPageViews = emptySnapshot();
+
+  const merged = mergeSnapshot(pageViewSnapshot, batch);
+  pruneSnapshot(merged);
+  merged.updated_at = new Date().toISOString();
+
+  const write = await redisCommand<string>(["SET", PAGE_VIEWS_KEY, JSON.stringify(merged)]);
+  if (!write.ok) {
+    // Put the batch back, on top of whatever arrived while the write was failing.
+    pendingPageViews = mergeSnapshot(batch, pendingPageViews);
+    return;
+  }
+
+  pageViewSnapshot = merged;
+}
+
+// How often serve.ts calls flushPending(). Exposed on the health block so the reported
+// command-rate projection can be reasoned about without reading the source.
+//
+// This value divides straight into Redis command spend — halving it doubles the bill —
+// so the env override is floored rather than trusted. It also sets how much counter data
+// an unclean restart can lose; 60s is the balance point between the two.
+const DEFAULT_FLUSH_INTERVAL_SECONDS = 60;
+const MIN_FLUSH_INTERVAL_SECONDS = 5;
+export const FLUSH_INTERVAL_SECONDS = Number(process.env.TELEMETRY_FLUSH_INTERVAL_SECONDS) > 0
+  ? Math.max(MIN_FLUSH_INTERVAL_SECONDS, Number(process.env.TELEMETRY_FLUSH_INTERVAL_SECONDS))
+  : DEFAULT_FLUSH_INTERVAL_SECONDS;
+
+let lastFlushAt: string | null = null;
+
+async function runFlush(): Promise<void> {
+  try {
+    if (!requestLogHydrated) await loadRequestLog();
+    await flushPageViews();
+    await flushRequestLog();
+    lastFlushAt = new Date().toISOString();
+  } catch (err) {
+    // A flush must never reject: it runs unattended on a timer and on the shutdown path.
+    logRedisFailure("FLUSH", err instanceof Error ? err.message : String(err));
+  }
+}
+
+// Serialises flushes. If a write stalls past the interval the next timer tick would
+// otherwise run concurrently, and the second run would clear `pendingPageViews` including
+// anything recorded after the first run built its merge — deltas dropped without ever
+// being stored. Chaining also means the shutdown flush queues behind an in-flight one
+// rather than being skipped, which a plain re-entrancy flag would get wrong.
+let flushChain: Promise<void> = Promise.resolve();
+
+// Pushes everything buffered on the request path. Called on a timer and on SIGTERM.
+export function flushPending(): Promise<void> {
+  if (!useRedis()) return Promise.resolve();
+  flushChain = flushChain.then(runFlush, runFlush);
+  return flushChain;
 }
 
 export interface PageViewPeriod {
@@ -914,38 +1388,32 @@ export interface PageViewsReport {
 
 const UNAVAILABLE_PERIOD: PageViewPeriod = { total: null, top_pages: [], partial: true };
 
-// Collects one `pv:<scope>:*` period. A read failure yields total: null rather than 0 —
-// presenting an unreadable counter as a measured zero is what produced a "top pages" list
-// in which every entry had 0 views (#1018 Defect B).
-async function collectPeriod(prefix: string): Promise<{ period: PageViewPeriod; error: string | null }> {
-  const scan = await redisScan(`${prefix}*`);
-  if (!scan.ok) return { period: { ...UNAVAILABLE_PERIOD }, error: scan.error };
+const TOP_PAGES_LIMIT = 20;
 
-  const keys = scan.result;
-  const totalKey = `${prefix}total`;
-  const { values, missing } = await redisGetMulti(keys);
-  const missingSet = new Set(missing);
-
-  const pages = keys
-    .filter(k => k !== totalKey && !missingSet.has(k))
-    .map(k => ({ path: k.replace(prefix, ""), views: values.get(k) ?? 0 }))
+function topPages(map: Record<string, number>): { path: string; views: number }[] {
+  return Object.entries(map)
+    .filter(([path]) => path !== DAY_TOTAL_KEY)
+    .map(([path, views]) => ({ path, views }))
     .sort((a, b) => b.views - a.views)
-    .slice(0, 20);
-
-  // `pv:all:*` has no explicit total key, so fall back to summing what we could read.
-  // A sum over a partially-readable key set is not a measurement — report null instead.
-  let total: number | null;
-  if (keys.includes(totalKey)) {
-    total = missingSet.has(totalKey) ? null : (values.get(totalKey) ?? 0);
-  } else if (missing.length > 0) {
-    total = null;
-  } else {
-    total = [...values.entries()].reduce((sum, [k, v]) => (k === totalKey ? sum : sum + v), 0);
-  }
-
-  return { period: { total, top_pages: pages, partial: missing.length > 0 }, error: null };
+    .slice(0, TOP_PAGES_LIMIT);
 }
 
+// A day map carries its own total. An absent day is a measured zero, not an unknown —
+// we hold the whole snapshot, so "we have no record of that day" is a real answer.
+function dayPeriod(map: Record<string, number> | undefined): PageViewPeriod {
+  if (!map) return { total: 0, top_pages: [], partial: false };
+  return { total: map[DAY_TOTAL_KEY] ?? 0, top_pages: topPages(map), partial: false };
+}
+
+function allTimePeriod(map: Record<string, number>): PageViewPeriod {
+  const total = Object.entries(map).reduce((sum, [k, v]) => (k === DAY_TOTAL_KEY ? sum : sum + v), 0);
+  return { total, top_pages: topPages(map), partial: false };
+}
+
+// Serves the in-memory snapshot plus everything not yet flushed. Costs zero Redis
+// commands: the SCAN + MGET fan-out this used to run per caller is gone entirely, which
+// is stronger than caching it (#1023). Numbers include un-flushed deltas, so a page view
+// is visible here immediately rather than after the next flush.
 export async function getPageViews(): Promise<PageViewsReport> {
   const today = new Date().toISOString().slice(0, 10);
   const yesterday = new Date(Date.now() - 86400000).toISOString().slice(0, 10);
@@ -965,32 +1433,30 @@ export async function getPageViews(): Promise<PageViewsReport> {
     };
   }
 
-  const todayResult = await collectPeriod(`pv:${today}:`);
-  const yesterdayResult = await collectPeriod(`pv:${yesterday}:`);
-  const allTimeResult = await collectPeriod("pv:all:");
-
-  // Get today's referrers
-  const refScan = await redisScan(`ref:${today}:*`);
-  const referrers: Record<string, number> = {};
-  if (refScan.ok) {
-    const { values, missing } = await redisGetMulti(refScan.result);
-    const missingSet = new Set(missing);
-    for (const k of refScan.result) {
-      if (missingSet.has(k)) continue;
-      referrers[k.replace(`ref:${today}:`, "")] = values.get(k) ?? 0;
-    }
+  if (!pageViewsLoaded) {
+    // We never got a trustworthy base. The deltas since boot are real but they are not
+    // the totals, and reporting a partial count as the total is the Defect B mistake.
+    return {
+      today: { ...UNAVAILABLE_PERIOD },
+      yesterday: { ...UNAVAILABLE_PERIOD },
+      all_time: { ...UNAVAILABLE_PERIOD },
+      referrers_today: {},
+      available: false,
+      error: redisHealth.lastReadError ?? "page-view snapshot not loaded",
+      storage,
+    };
   }
 
-  const error = todayResult.error ?? yesterdayResult.error ?? allTimeResult.error ?? (refScan.ok ? null : refScan.error);
+  const view = mergeSnapshot(pageViewSnapshot, pendingPageViews);
 
   return {
-    today: todayResult.period,
-    yesterday: yesterdayResult.period,
-    all_time: allTimeResult.period,
-    referrers_today: referrers,
-    available: error === null,
-    error,
-    storage: getTelemetryHealth(),
+    today: dayPeriod(view.days[today]),
+    yesterday: dayPeriod(view.days[yesterday]),
+    all_time: allTimePeriod(view.all_time),
+    referrers_today: { ...(view.referrers[today] ?? {}) },
+    available: true,
+    error: null,
+    storage,
   };
 }
 

--- a/test/stats-telemetry.test.ts
+++ b/test/stats-telemetry.test.ts
@@ -1,9 +1,13 @@
-// Telemetry storage-layer tests (#1018).
+// Telemetry storage-layer tests (#1018, #1023).
 //
 // These are hermetic: Upstash is stubbed at `globalThis.fetch`, so every case runs
 // offline and deterministically. The behaviour under test is specifically what the
 // old code could not express — the difference between "this counter is zero" and
 // "we could not read this counter".
+//
+// Page-view counters no longer live one Redis key per (day, path); they are buffered in
+// memory and persisted as a single JSON snapshot on a flush interval (#1023), so the
+// assertions here look at what a flush *writes* rather than at per-request INCRs.
 
 import { describe, it, beforeEach, afterEach } from "node:test";
 import assert from "node:assert";
@@ -20,6 +24,7 @@ const {
   resetCounters,
   loadTelemetry,
   flushTelemetry,
+  flushPending,
   telemetryLoadDidFail,
 } = await import("../dist/stats.js");
 
@@ -29,6 +34,10 @@ const realFetch = globalThis.fetch;
 let calls: Call[] = [];
 /** Maps a Redis command name to the JSON body Upstash should answer with. */
 let responder: (cmd: string, args: unknown[]) => unknown = () => ({ result: 1 });
+
+const PAGE_VIEWS_KEY = "agentdeals:pageviews";
+const TELEMETRY_KEY = "agentdeals:telemetry";
+const TMP_TELEMETRY = "/tmp/agentdeals-telemetry-test.json";
 
 function installFetchStub(): void {
   globalThis.fetch = (async (_url: string, init: { body: string }) => {
@@ -49,10 +58,26 @@ function callsFor(cmd: string): Call[] {
   return calls.filter(c => c.cmd === cmd);
 }
 
-/** Lets fire-and-forget INCRs inside recordPageView settle before asserting. */
-async function drain(): Promise<void> {
-  await new Promise(resolve => setImmediate(resolve));
-  await new Promise(resolve => setImmediate(resolve));
+/** The SET that persisted the page-view snapshot, parsed. */
+function writtenSnapshot(): any {
+  const set = callsFor("SET").find(c => String(c.args[0]) === PAGE_VIEWS_KEY);
+  assert.ok(set, `no SET of ${PAGE_VIEWS_KEY}; SETs: ${callsFor("SET").map(c => c.args[0]).join(", ")}`);
+  return JSON.parse(String(set!.args[1]));
+}
+
+/** An empty-but-healthy store: every read succeeds and returns nothing. */
+const emptyStore = (cmd: string): unknown => {
+  if (cmd === "GET") return { result: null };
+  if (cmd === "SCAN") return { result: ["0", []] };
+  if (cmd === "LRANGE" || cmd === "MGET") return { result: [] };
+  return { result: "OK" };
+};
+
+/** Boots the module against a store, leaving it in the loaded state a live server has. */
+async function boot(store: (cmd: string, args: unknown[]) => unknown = emptyStore): Promise<void> {
+  responder = store;
+  await loadTelemetry(TMP_TELEMETRY);
+  calls = [];
 }
 
 describe("telemetry storage layer (#1018)", () => {
@@ -110,65 +135,78 @@ describe("telemetry storage layer (#1018)", () => {
 
   describe("recordPageView key space", () => {
     it("writes the normalized route pattern, never the raw path", async () => {
+      await boot();
       recordPageView("/vendor/hetzner", "Mozilla/5.0", undefined, 200);
-      await drain();
-      const keys = callsFor("INCR").map(c => String(c.args[0]));
-      assert.ok(keys.some(k => k.endsWith(":/vendor/:slug")), `expected a /vendor/:slug key, got ${keys.join(", ")}`);
-      assert.ok(!keys.some(k => k.includes("hetzner")), "raw slug must not reach Redis");
+      await flushPending();
+
+      const snapshot = writtenSnapshot();
+      assert.ok(snapshot.all_time["/vendor/:slug"] >= 1, "expected a /vendor/:slug counter");
+      assert.ok(!JSON.stringify(snapshot).includes("hetzner"), "raw slug must not reach Redis");
     });
 
     it("buckets a 404 to __unmatched__ even when the path looks like a page", async () => {
+      await boot();
       recordPageView("/wp-login", "Mozilla/5.0", undefined, 404);
-      await drain();
-      const keys = callsFor("INCR").map(c => String(c.args[0]));
-      assert.ok(keys.some(k => k.endsWith(`:${UNMATCHED_PAGE_KEY}`)), `expected __unmatched__, got ${keys.join(", ")}`);
-      assert.ok(!keys.some(k => k.includes("wp-login")), "a path we 404 must not mint its own key");
+      await flushPending();
+
+      const snapshot = writtenSnapshot();
+      assert.ok(snapshot.all_time[UNMATCHED_PAGE_KEY] >= 1, "expected __unmatched__");
+      assert.ok(!JSON.stringify(snapshot).includes("wp-login"), "a path we 404 must not mint its own key");
     });
 
-    it("sets a TTL on a daily key the first time it is created", async () => {
-      responder = cmd => (cmd === "INCR" ? { result: 1 } : { result: 1 });
+    it("keeps the day-scoped total alongside the per-path counters", async () => {
+      await boot();
+      recordPageView("/", "Mozilla/5.0", undefined, 200);
       recordPageView("/estimate", "Mozilla/5.0", undefined, 200);
-      await drain();
-      const expired = callsFor("EXPIRE").map(c => String(c.args[0]));
-      assert.ok(expired.some(k => k.startsWith("pv:20")), "daily key should be given a TTL on creation");
-      assert.ok(!expired.some(k => k.startsWith("pv:all:")), "all-time counters must not expire");
-    });
+      await flushPending();
 
-    it("does not re-arm the TTL on subsequent hits", async () => {
-      responder = cmd => (cmd === "INCR" ? { result: 7 } : { result: 1 });
-      recordPageView("/estimate", "Mozilla/5.0", undefined, 200);
-      await drain();
-      assert.strictEqual(callsFor("EXPIRE").length, 0, "EXPIRE on every hit would keep pushing the expiry out");
+      const today = new Date().toISOString().slice(0, 10);
+      const day = writtenSnapshot().days[today];
+      assert.strictEqual(day.total, 2);
+      assert.strictEqual(day["/"], 1);
+      assert.strictEqual(day["/estimate"], 1);
     });
   });
 
   describe("read failures are not reported as zeros (Defect B)", () => {
-    it("reports total: null and partial: true when MGET fails", async () => {
-      responder = (cmd) => {
-        if (cmd === "SCAN") return { result: ["0", ["pv:all:/", "pv:all:/estimate"]] };
-        if (cmd === "MGET") return { error: "ERR max request size exceeded" };
-        return { result: 1 };
-      };
-      const report = await getPageViews();
-      assert.strictEqual(report.all_time.total, null, "an unreadable counter must not read back as 0");
-      assert.strictEqual(report.all_time.partial, true);
-      assert.deepStrictEqual(report.all_time.top_pages, [], "must not publish a top-pages list of fake zeros");
-    });
+    it("marks the report unavailable when the snapshot could not be read", async () => {
+      responder = () => ({ error: "ERR unavailable" });
+      await loadTelemetry(TMP_TELEMETRY);
 
-    it("marks the report unavailable when SCAN itself fails", async () => {
-      responder = (cmd) => (cmd === "SCAN" ? { error: "ERR unavailable" } : { result: 1 });
       const report = await getPageViews();
       assert.strictEqual(report.available, false);
       assert.match(String(report.error), /unavailable/);
-      assert.strictEqual(report.today.total, null);
+      assert.strictEqual(report.today.total, null, "an unreadable counter must not read back as 0");
+      assert.strictEqual(report.all_time.total, null);
+      assert.deepStrictEqual(report.all_time.top_pages, [], "must not publish a top-pages list of fake zeros");
+      assert.strictEqual(report.all_time.partial, true);
+    });
+
+    it("marks the report unavailable when the legacy migration scan fails", async () => {
+      // The snapshot key is genuinely absent, but the legacy key space is unreadable —
+      // seeding an empty snapshot here would erase real history on the next flush.
+      responder = (cmd) => {
+        if (cmd === "GET") return { result: null };
+        if (cmd === "SCAN") return { error: "ERR unavailable" };
+        return { result: "OK" };
+      };
+      await loadTelemetry(TMP_TELEMETRY);
+
+      const report = await getPageViews();
+      assert.strictEqual(report.available, false);
+
+      calls = [];
+      recordPageView("/", "Mozilla/5.0", undefined, 200);
+      await flushPending();
+      assert.strictEqual(
+        callsFor("SET").filter(c => String(c.args[0]) === PAGE_VIEWS_KEY).length,
+        0,
+        "must not persist a snapshot built on an unread history",
+      );
     });
 
     it("still reports a genuine zero as zero", async () => {
-      responder = (cmd) => {
-        if (cmd === "SCAN") return { result: ["0", []] };
-        if (cmd === "MGET") return { result: [] };
-        return { result: 1 };
-      };
+      await boot();
       const report = await getPageViews();
       assert.strictEqual(report.available, true);
       assert.strictEqual(report.all_time.total, 0, "an empty keyspace is a real measurement of zero");
@@ -178,35 +216,45 @@ describe("telemetry storage layer (#1018)", () => {
 
   describe("write-path failure is surfaced (Defect A)", () => {
     it("records the Upstash error instead of swallowing it", async () => {
+      await boot();
+      resetTelemetryHealth();
       responder = () => ({ error: "ERR max daily request limit exceeded" });
+
       recordPageView("/estimate", "Mozilla/5.0", undefined, 200);
-      await drain();
+      await flushPending();
+
       const health = getTelemetryHealth();
-      assert.ok(health.write_failures > 0, "a rejected INCR must be counted");
+      assert.ok(health.write_failures > 0, "a rejected write must be counted");
       assert.match(String(health.last_write_error), /max daily request limit/);
       assert.ok(health.last_write_error_at, "the failure needs a timestamp");
       assert.strictEqual(health.last_write_at, null, "a failed write must not look like a successful one");
+      assert.strictEqual(health.quota_exhausted, true, "a spent quota is not an ordinary write error");
     });
 
     it("advances last_write_at only on a successful write", async () => {
-      await logRequest({ ts: new Date().toISOString(), type: "api", endpoint: "/api/test", params: {}, result_count: 0 });
-      const ok = getTelemetryHealth();
-      assert.ok(ok.last_write_at, "a successful LPUSH should stamp last_write_at");
+      await boot();
+      resetTelemetryHealth();
+      logRequest({ ts: new Date().toISOString(), type: "api", endpoint: "/api/test", params: {}, result_count: 0 });
+      await flushPending();
+      assert.ok(getTelemetryHealth().last_write_at, "a successful LPUSH should stamp last_write_at");
 
       resetTelemetryHealth();
       responder = () => ({ error: "ERR quota" });
-      await logRequest({ ts: new Date().toISOString(), type: "api", endpoint: "/api/test", params: {}, result_count: 0 });
+      logRequest({ ts: new Date().toISOString(), type: "api", endpoint: "/api/test", params: {}, result_count: 0 });
+      await flushPending();
       assert.strictEqual(getTelemetryHealth().last_write_at, null);
       assert.ok(getTelemetryHealth().write_failures > 0);
     });
 
     it("distinguishes an unreadable request log from an empty one", async () => {
       responder = () => ({ error: "ERR unavailable" });
+      await loadTelemetry(TMP_TELEMETRY);
       const failed = await getRequestLogResult(10);
       assert.strictEqual(failed.available, false);
       assert.match(String(failed.error), /unavailable/);
 
-      responder = () => ({ result: [] });
+      resetCounters();
+      await boot();
       const empty = await getRequestLogResult(10);
       assert.strictEqual(empty.available, true, "a genuinely empty log is available, just empty");
       assert.strictEqual(empty.error, null);
@@ -217,17 +265,21 @@ describe("telemetry storage layer (#1018)", () => {
   describe("a failed load must not clobber stored history", () => {
     it("refuses to persist zeros after the boot-time read failed", async () => {
       responder = () => ({ error: "ERR max requests limit exceeded. Limit: 500000, Usage: 500000" });
-      await loadTelemetry("/tmp/agentdeals-telemetry-test.json");
+      await loadTelemetry(TMP_TELEMETRY);
       assert.strictEqual(telemetryLoadDidFail(), true, "an errored GET is not an empty database");
 
       calls = [];
       await flushTelemetry();
-      assert.strictEqual(callsFor("SET").length, 0, "flushing zeros over real history is data loss");
+      assert.strictEqual(
+        callsFor("SET").filter(c => String(c.args[0]) === TELEMETRY_KEY).length,
+        0,
+        "flushing zeros over real history is data loss",
+      );
     });
 
     it("resumes persisting once storage recovers", async () => {
       responder = () => ({ error: "ERR max requests limit exceeded" });
-      await loadTelemetry("/tmp/agentdeals-telemetry-test.json");
+      await loadTelemetry(TMP_TELEMETRY);
       assert.strictEqual(telemetryLoadDidFail(), true);
 
       // Storage comes back with the real historical totals.
@@ -238,39 +290,48 @@ describe("telemetry storage layer (#1018)", () => {
       calls = [];
       await flushTelemetry();
       assert.strictEqual(telemetryLoadDidFail(), false, "a successful re-read clears the block");
-      assert.strictEqual(callsFor("SET").length, 1, "persistence should resume");
 
-      const written = JSON.parse(String(callsFor("SET")[0].args[1]));
+      const sets = callsFor("SET").filter(c => String(c.args[0]) === TELEMETRY_KEY);
+      assert.strictEqual(sets.length, 1, "persistence should resume");
+      const written = JSON.parse(String(sets[0].args[1]));
       assert.strictEqual(written.cumulative_api_hits, 282802, "history must be re-hydrated, not overwritten with zeros");
     });
 
     it("persists normally when the boot-time read succeeds", async () => {
-      responder = (cmd) => {
-        if (cmd === "GET") return { result: JSON.stringify({ cumulative_api_hits: 100 }) };
-        return { result: "OK" };
+      responder = (cmd, args) => {
+        if (cmd === "GET" && String(args[0]) === TELEMETRY_KEY) {
+          return { result: JSON.stringify({ cumulative_api_hits: 100 }) };
+        }
+        return emptyStore(cmd);
       };
-      await loadTelemetry("/tmp/agentdeals-telemetry-test.json");
+      await loadTelemetry(TMP_TELEMETRY);
       assert.strictEqual(telemetryLoadDidFail(), false);
       calls = [];
       await flushTelemetry();
-      assert.strictEqual(callsFor("SET").length, 1);
+      assert.strictEqual(callsFor("SET").filter(c => String(c.args[0]) === TELEMETRY_KEY).length, 1);
     });
   });
 
   describe("MGET chunking", () => {
     it("never sends more than 100 keys in one command", async () => {
+      // Only the one-time migration off the legacy key space still reads this way.
       const keys = Array.from({ length: 250 }, (_, i) => `pv:all:/page-${i}`);
       responder = (cmd, args) => {
-        if (cmd === "SCAN") return { result: ["0", keys] };
+        if (cmd === "GET") return { result: null };
+        if (cmd === "SCAN") return { result: ["0", String(args[2]) === "pv:all:*" ? keys : []] };
         if (cmd === "MGET") return { result: args.map(() => "1") };
-        return { result: 1 };
+        if (cmd === "LRANGE") return { result: [] };
+        return { result: "OK" };
       };
-      const report = await getPageViews();
+      await loadTelemetry(TMP_TELEMETRY);
+
       const mgets = callsFor("MGET");
       assert.ok(mgets.length >= 3, `expected 250 keys to be chunked, got ${mgets.length} call(s)`);
       for (const call of mgets) {
         assert.ok(call.args.length <= 100, `chunk of ${call.args.length} exceeds the 100-key cap`);
       }
+
+      const report = await getPageViews();
       assert.strictEqual(report.all_time.total, 250, "chunking must not lose counts");
     });
   });

--- a/test/telemetry-command-budget.test.ts
+++ b/test/telemetry-command-budget.test.ts
@@ -1,0 +1,548 @@
+// Telemetry write-path budget tests (#1023).
+//
+// The 2026-08-07 outage was not bad luck: with one Redis command per HTTP request,
+// steady-state command volume sat over the plan's 500,000/month ceiling, so the write
+// path died and stayed dead. These tests lock the property that fixed it — Redis command
+// volume is a function of *flush intervals*, not of requests served.
+//
+// Hermetic: Upstash is replaced by an in-process fake that actually stores values, so the
+// assertions can check both the command count and the data that ends up persisted.
+
+import { describe, it, beforeEach, afterEach } from "node:test";
+import assert from "node:assert";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { randomUUID } from "node:crypto";
+
+const {
+  recordPageView,
+  getPageViews,
+  getRequestLogResult,
+  getTelemetryHealth,
+  resetTelemetryHealth,
+  resetTelemetryBuffers,
+  resetCounters,
+  loadTelemetry,
+  flushPending,
+  logRequest,
+  UNMATCHED_PAGE_KEY,
+  OTHER_REFERRER_KEY,
+  FLUSH_INTERVAL_SECONDS,
+} = await import("../dist/stats.js");
+
+const PAGE_VIEWS_KEY = "agentdeals:pageviews";
+const REQUEST_LOG_KEY = "agentdeals:request_log";
+const REQUEST_LOG_MAX = 1000;
+const REQUEST_LOG_FLUSH_MAX = 250;
+
+type Call = { cmd: string; args: unknown[] };
+
+/** Minimal stateful Upstash stand-in: enough of the command set to run the write path. */
+class FakeUpstash {
+  values = new Map<string, string>();
+  lists = new Map<string, string[]>();
+  calls: Call[] = [];
+  /** When set, commands answer with this error in a 200 body, as Upstash does. */
+  failWith: string | null = null;
+  /** Restricts `failWith` to these commands, so a read can fail while writes still work. */
+  failOnly: Set<string> | null = null;
+  /** Runs while a command is in flight — lets a test act inside the await window. */
+  onCommand: ((cmd: string, args: unknown[]) => void) | null = null;
+
+  reset(): void {
+    this.calls = [];
+    this.failWith = null;
+    this.failOnly = null;
+  }
+
+  shouldFail(cmd: string): boolean {
+    return this.failWith !== null && (this.failOnly === null || this.failOnly.has(cmd));
+  }
+
+  commandCount(cmd?: string): number {
+    return cmd ? this.calls.filter(c => c.cmd === cmd).length : this.calls.length;
+  }
+
+  callsFor(cmd: string): Call[] {
+    return this.calls.filter(c => c.cmd === cmd);
+  }
+
+  exec(cmd: string, args: unknown[]): unknown {
+    switch (cmd) {
+      case "GET": {
+        const v = this.values.get(String(args[0]));
+        return { result: v === undefined ? null : v };
+      }
+      case "SET":
+        this.values.set(String(args[0]), String(args[1]));
+        return { result: "OK" };
+      case "DEL":
+        this.values.delete(String(args[0]));
+        return { result: 1 };
+      case "MGET":
+        return { result: args.map(k => this.values.get(String(k)) ?? null) };
+      case "SCAN": {
+        const pattern = String(args[2]);
+        const prefix = pattern.endsWith("*") ? pattern.slice(0, -1) : pattern;
+        const keys = [...this.values.keys()].filter(k => k.startsWith(prefix));
+        return { result: ["0", keys] };
+      }
+      case "LPUSH": {
+        const key = String(args[0]);
+        const list = this.lists.get(key) ?? [];
+        for (const v of args.slice(1)) list.unshift(String(v));
+        this.lists.set(key, list);
+        return { result: list.length };
+      }
+      case "LTRIM": {
+        const key = String(args[0]);
+        const list = this.lists.get(key) ?? [];
+        this.lists.set(key, list.slice(Number(args[1]), Number(args[2]) + 1));
+        return { result: "OK" };
+      }
+      case "LRANGE": {
+        const list = this.lists.get(String(args[0])) ?? [];
+        return { result: list.slice(Number(args[1]), Number(args[2]) + 1) };
+      }
+      default:
+        return { result: 1 };
+    }
+  }
+}
+
+const realFetch = globalThis.fetch;
+let redis: FakeUpstash;
+let telemetryFile: string;
+
+function installFetchStub(): void {
+  globalThis.fetch = (async (_url: string, init: { body: string }) => {
+    const parsed = JSON.parse(init.body) as unknown[];
+    const cmd = String(parsed[0]).toUpperCase();
+    const args = parsed.slice(1);
+    redis.calls.push({ cmd, args });
+    redis.onCommand?.(cmd, args);
+    const body = redis.shouldFail(cmd) ? { error: redis.failWith } : redis.exec(cmd, args);
+    return { ok: true, status: 200, json: async () => body };
+  }) as unknown as typeof fetch;
+}
+
+/** Boots the module against the fake and clears the call log, as a live server would be. */
+async function boot(): Promise<void> {
+  await loadTelemetry(telemetryFile);
+  redis.reset();
+  resetTelemetryHealth();
+}
+
+function pageView(path: string, referer?: string): void {
+  recordPageView(path, "Mozilla/5.0 (Macintosh) Chrome/120", referer, 200);
+}
+
+function entry(n: number) {
+  return {
+    ts: new Date(Date.UTC(2026, 7, 25, 0, 0, n % 60)).toISOString(),
+    type: "api" as const,
+    endpoint: `/api/offers`,
+    params: { n },
+    user_agent: "test",
+    result_count: n,
+  };
+}
+
+function storedSnapshot(): any {
+  const raw = redis.values.get(PAGE_VIEWS_KEY);
+  assert.ok(raw, "expected a persisted page-view snapshot");
+  return JSON.parse(raw!);
+}
+
+const today = () => new Date().toISOString().slice(0, 10);
+
+describe("telemetry command budget (#1023)", () => {
+  beforeEach(async () => {
+    process.env.UPSTASH_REDIS_REST_URL = "https://stub.upstash.invalid";
+    process.env.UPSTASH_REDIS_REST_TOKEN = "stub-token";
+    redis = new FakeUpstash();
+    telemetryFile = join(tmpdir(), `telemetry-budget-${randomUUID()}.json`);
+    resetCounters();
+    resetTelemetryHealth();
+    installFetchStub();
+  });
+
+  afterEach(() => {
+    globalThis.fetch = realFetch;
+    delete process.env.UPSTASH_REDIS_REST_URL;
+    delete process.env.UPSTASH_REDIS_REST_TOKEN;
+  });
+
+  describe("the request path spends no commands", () => {
+    it("records 500 page views and 500 logged requests without touching Redis", async () => {
+      await boot();
+
+      for (let i = 0; i < 500; i++) {
+        pageView(i % 2 === 0 ? "/" : "/vendor/some-vendor");
+        logRequest(entry(i));
+      }
+
+      assert.strictEqual(
+        redis.commandCount(),
+        0,
+        `1000 events issued ${redis.commandCount()} commands; the old path would have issued ~2500`,
+      );
+      assert.strictEqual(getTelemetryHealth().commands_since_boot, 0);
+    });
+
+    it("serves reads from memory — no fan-out, cached or otherwise", async () => {
+      await boot();
+      pageView("/");
+      logRequest(entry(1));
+      await flushPending();
+      redis.reset();
+
+      for (let i = 0; i < 50; i++) {
+        await getPageViews();
+        await getRequestLogResult(50);
+      }
+
+      assert.strictEqual(redis.commandCount(), 0, "the SCAN/MGET fan-out must not run per caller");
+    });
+  });
+
+  describe("command volume is a function of flushes, not of traffic", () => {
+    it("costs the same whether the interval carried 10 events or 10,000", async () => {
+      await boot();
+      // Warm-up: the first flush after boot also spends its one-shot deploy-race re-read,
+      // so steady state is what the two measured intervals below have to agree on.
+      pageView("/");
+      await flushPending();
+
+      redis.reset();
+      for (let i = 0; i < 10; i++) { pageView("/"); logRequest(entry(i)); }
+      await flushPending();
+      const small = redis.commandCount();
+
+      // Second interval, three orders of magnitude more traffic.
+      redis.reset();
+      for (let i = 0; i < 10_000; i++) { pageView("/"); logRequest(entry(i)); }
+      await flushPending();
+      const large = redis.commandCount();
+
+      assert.strictEqual(
+        large,
+        small,
+        `1000x the traffic cost ${large} commands vs ${small} — volume must not scale with requests`,
+      );
+      assert.ok(small <= 4, `a flush should cost a handful of commands, got ${small}: ${redis.calls.map(c => c.cmd).join(",")}`);
+    });
+
+    it("aggregates a path's hits into one counter write, not one per hit", async () => {
+      await boot();
+      for (let i = 0; i < 250; i++) pageView("/");
+      await flushPending();
+
+      const sets = redis.callsFor("SET").filter(c => String(c.args[0]) === PAGE_VIEWS_KEY);
+      assert.strictEqual(sets.length, 1, "one snapshot write per interval");
+      assert.strictEqual(redis.commandCount("INCR"), 0, "per-event INCR is the pattern that blew the quota");
+
+      const snapshot = storedSnapshot();
+      assert.strictEqual(snapshot.days[today()]["/"], 250, "aggregation must not lose counts");
+      assert.strictEqual(snapshot.days[today()].total, 250);
+      assert.strictEqual(snapshot.all_time["/"], 250);
+    });
+
+    it("does not drop views recorded while the snapshot write is in flight", async () => {
+      await boot();
+      pageView("/");
+      // Requests keep arriving during the round trip. This one is not in the batch being
+      // written, so clearing the buffer after the await would lose it permanently.
+      redis.onCommand = (cmd) => {
+        if (cmd === "SET") { redis.onCommand = null; pageView("/"); }
+      };
+
+      await flushPending();
+      await flushPending();
+
+      assert.strictEqual(storedSnapshot().days[today()].total, 2, "a view mid-write must survive to the next batch");
+    });
+
+    it("spends nothing on a flush with nothing buffered", async () => {
+      await boot();
+      await flushPending();
+      await flushPending();
+      assert.strictEqual(redis.commandCount(), 0, "an idle server should be free");
+    });
+
+    it("stays inside the monthly budget when every interval is busy", async () => {
+      await boot();
+      // Cost of one fully-loaded interval: page views AND request-log entries pending.
+      for (let i = 0; i < 100; i++) { pageView("/"); logRequest(entry(i)); }
+      await flushPending();
+      const perFlush = redis.commandCount();
+
+      const flushesPerMonth = (30 * 24 * 60 * 60) / FLUSH_INTERVAL_SECONDS;
+      const projected = perFlush * flushesPerMonth;
+      const budget = getTelemetryHealth().monthly_command_budget;
+      assert.ok(
+        projected <= budget,
+        `${perFlush} commands/flush projects to ${projected}/month, over the ${budget} budget`,
+      );
+    });
+  });
+
+  describe("request log batching", () => {
+    it("sends one LPUSH carrying the whole interval, not one per entry", async () => {
+      await boot();
+      for (let i = 0; i < 60; i++) logRequest(entry(i));
+      await flushPending();
+
+      const pushes = redis.callsFor("LPUSH");
+      assert.strictEqual(pushes.length, 1, `expected a single batched LPUSH, got ${pushes.length}`);
+      assert.strictEqual(pushes[0].args.length - 1, 60, "all 60 entries belong in the one command");
+    });
+
+    it("keeps newest-first ordering through the batch", async () => {
+      await boot();
+      for (let i = 0; i < 5; i++) logRequest(entry(i));
+      await flushPending();
+
+      const stored = (redis.lists.get(REQUEST_LOG_KEY) ?? []).map(s => JSON.parse(s));
+      assert.strictEqual(stored[0].params.n, 4, "the newest entry must be at index 0");
+      assert.strictEqual(stored[4].params.n, 0);
+
+      const read = await getRequestLogResult(5);
+      assert.strictEqual(read.entries[0].params.n, 4, "readers see newest-first too");
+    });
+
+    it("trims lazily instead of paying a command every flush", async () => {
+      await boot();
+      redis.lists.set(REQUEST_LOG_KEY, Array.from({ length: REQUEST_LOG_MAX }, (_, i) => JSON.stringify(entry(i))));
+
+      logRequest(entry(1));
+      await flushPending();
+      assert.strictEqual(redis.commandCount("LTRIM"), 0, "one entry over the cap is not worth a command");
+
+      for (let i = 0; i < 250; i++) logRequest(entry(i));
+      await flushPending();
+      assert.strictEqual(redis.commandCount("LTRIM"), 1, "the list must still be bounded");
+      assert.strictEqual((redis.lists.get(REQUEST_LOG_KEY) ?? []).length, REQUEST_LOG_MAX);
+    });
+
+    it("counts entries dropped by an overflowing interval rather than hiding them", async () => {
+      await boot();
+      for (let i = 0; i < REQUEST_LOG_FLUSH_MAX + 40; i++) logRequest(entry(i));
+
+      const health = getTelemetryHealth();
+      assert.strictEqual(health.pending_request_log_entries, REQUEST_LOG_FLUSH_MAX);
+      assert.strictEqual(health.request_log_dropped, 40, "a silent cap reads as full coverage when it is not");
+    });
+
+    it("keeps the batch for a retry when the push fails", async () => {
+      await boot();
+      for (let i = 0; i < 10; i++) logRequest(entry(i));
+      redis.failWith = "ERR max requests limit exceeded. Limit: 500000, Usage: 500000";
+      await flushPending();
+      assert.strictEqual(getTelemetryHealth().pending_request_log_entries, 10, "a failed flush must not eat the batch");
+
+      redis.failWith = null;
+      await flushPending();
+      assert.strictEqual((redis.lists.get(REQUEST_LOG_KEY) ?? []).length, 10, "the retry delivers them");
+    });
+  });
+
+  describe("flush on shutdown and across restarts", () => {
+    it("persists buffered counters when the shutdown flush runs", async () => {
+      await boot();
+      pageView("/");
+      pageView("/estimate");
+      logRequest(entry(1));
+
+      // What serve.ts does on SIGTERM.
+      await flushPending();
+
+      assert.strictEqual(storedSnapshot().days[today()].total, 2);
+      assert.strictEqual((redis.lists.get(REQUEST_LOG_KEY) ?? []).length, 1);
+    });
+
+    it("loses at most the un-flushed interval on an unclean restart, never the history", async () => {
+      await boot();
+      for (let i = 0; i < 30; i++) pageView("/");
+      await flushPending();
+      for (let i = 0; i < 7; i++) pageView("/"); // buffered, never flushed
+
+      // Unclean exit: the process dies with deltas still in memory.
+      resetTelemetryBuffers();
+      await loadTelemetry(telemetryFile);
+
+      const report = await getPageViews();
+      assert.strictEqual(report.available, true);
+      assert.strictEqual(report.today.total, 30, "the flushed history survives; only the open interval is lost");
+      assert.strictEqual(report.all_time.total, 30);
+    });
+
+    it("does not overwrite stored history when the boot read fails", async () => {
+      await boot();
+      for (let i = 0; i < 40; i++) pageView("/");
+      await flushPending();
+      const before = redis.values.get(PAGE_VIEWS_KEY);
+
+      // Restart into an outage.
+      resetTelemetryBuffers();
+      redis.failWith = "ERR max requests limit exceeded. Limit: 500000, Usage: 500000";
+      await loadTelemetry(telemetryFile);
+      for (let i = 0; i < 5; i++) pageView("/");
+      await flushPending();
+
+      assert.strictEqual(redis.values.get(PAGE_VIEWS_KEY), before, "history must be untouched while unread");
+      const blind = await getPageViews();
+      assert.strictEqual(blind.available, false, "and we must say so rather than report 5");
+
+      // Storage recovers: the base is re-read and the buffered deltas land on top of it.
+      redis.failWith = null;
+      await flushPending();
+      const report = await getPageViews();
+      assert.strictEqual(report.available, true);
+      assert.strictEqual(report.today.total, 45, "40 stored + 5 buffered through the outage");
+    });
+
+    it("refuses to persist when only the read failed and writes still work", async () => {
+      // The dangerous shape: a transient read error leaves us with an empty in-memory
+      // view while SET keeps succeeding, so a blind flush would replace real history with
+      // whatever this process has seen since boot.
+      await boot();
+      for (let i = 0; i < 40; i++) pageView("/");
+      await flushPending();
+      const stored = redis.values.get(PAGE_VIEWS_KEY);
+
+      resetTelemetryBuffers();
+      redis.failWith = "ERR connection reset";
+      redis.failOnly = new Set(["GET"]);
+      await loadTelemetry(telemetryFile);
+      for (let i = 0; i < 5; i++) pageView("/");
+      await flushPending();
+
+      assert.strictEqual(redis.values.get(PAGE_VIEWS_KEY), stored, "5 must never be written over 40");
+    });
+
+    it("keeps deltas pending when the snapshot write itself fails", async () => {
+      await boot();
+      pageView("/");
+      redis.failWith = "ERR max requests limit exceeded";
+      await flushPending();
+      assert.ok(getTelemetryHealth().pending_page_view_keys > 0, "a failed SET must not clear the buffer");
+
+      redis.failWith = null;
+      await flushPending();
+      assert.strictEqual(storedSnapshot().days[today()].total, 1);
+    });
+  });
+
+  describe("migration off the legacy per-key layout", () => {
+    it("carries the all-time history into the snapshot", async () => {
+      redis.values.set("pv:all:/", "8000");
+      redis.values.set("pv:all:/vendor/:slug", "2675");
+      redis.values.set(`pv:${today()}:/`, "70");
+      redis.values.set(`pv:${today()}:total`, "89");
+      redis.values.set(`ref:${today()}:news.ycombinator.com`, "12");
+
+      await loadTelemetry(telemetryFile);
+      const report = await getPageViews();
+
+      assert.strictEqual(report.all_time.total, 10_675, "the numbers the partnership conversation is about");
+      assert.strictEqual(report.today.total, 89);
+      assert.strictEqual(report.referrers_today["news.ycombinator.com"], 12);
+    });
+
+    it("runs once — a later boot reads the snapshot and leaves the legacy keys alone", async () => {
+      redis.values.set("pv:all:/", "500");
+      await loadTelemetry(telemetryFile);
+      pageView("/");
+      await flushPending();
+
+      resetTelemetryBuffers();
+      redis.reset();
+      await loadTelemetry(telemetryFile);
+
+      assert.strictEqual(redis.commandCount("SCAN"), 0, "the legacy key space must not be re-scanned every boot");
+      assert.strictEqual((await getPageViews()).all_time.total, 501);
+    });
+  });
+
+  describe("the key space cannot be grown by traffic", () => {
+    it("folds a referrer flood into one bucket", async () => {
+      await boot();
+      for (let i = 0; i < 400; i++) pageView("/", `https://spam-${i}.example.com/x`);
+      await flushPending();
+
+      const referrers = storedSnapshot().referrers[today()];
+      const keys = Object.keys(referrers);
+      assert.ok(keys.length <= 101, `referrer key space grew to ${keys.length} under a flood`);
+      assert.ok(referrers[OTHER_REFERRER_KEY] > 0, "the overflow has to go somewhere countable");
+      assert.strictEqual(
+        Object.values(referrers).reduce((a: number, b) => a + (b as number), 0),
+        400,
+        "folding must not lose hits",
+      );
+    });
+
+    it("folds overflowing all-time paths into __unmatched__ without losing the total", async () => {
+      for (let i = 0; i < 400; i++) redis.values.set(`pv:all:/page-${i}`, "3");
+      await loadTelemetry(telemetryFile);
+
+      const report = await getPageViews();
+      assert.strictEqual(report.all_time.total, 1200, "the total is preserved exactly");
+      const snapshot = (await getPageViews()).all_time.top_pages;
+      assert.ok(snapshot.length <= 20);
+      // 400 paths capped to 300 named + one fold bucket.
+      pageView("/");
+      await flushPending();
+      const keys = Object.keys(storedSnapshot().all_time);
+      assert.ok(keys.length <= 302, `all-time key space grew to ${keys.length}`);
+      assert.ok(keys.includes(UNMATCHED_PAGE_KEY));
+    });
+
+    it("prunes day buckets to the retention window", async () => {
+      const stored = { days: {} as Record<string, Record<string, number>>, referrers: {}, all_time: {}, updated_at: "" };
+      for (let i = 0; i < 20; i++) {
+        const date = new Date(Date.now() - i * 86400000).toISOString().slice(0, 10);
+        stored.days[date] = { total: 1, "/": 1 };
+      }
+      redis.values.set(PAGE_VIEWS_KEY, JSON.stringify(stored));
+
+      await loadTelemetry(telemetryFile);
+      pageView("/");
+      await flushPending();
+
+      assert.ok(Object.keys(storedSnapshot().days).length <= 7, "retention is enforced without a TTL command");
+    });
+  });
+
+  describe("budget instrumentation", () => {
+    it("reports what has been spent and what it projects to", async () => {
+      await boot();
+      pageView("/");
+      logRequest(entry(1));
+      await flushPending();
+
+      const health = getTelemetryHealth();
+      assert.strictEqual(health.commands_since_boot, redis.commandCount(), "the count must match reality");
+      assert.ok(health.commands_since_boot > 0);
+      assert.strictEqual(health.estimated_commands_per_month, health.estimated_commands_per_day * 30);
+      assert.strictEqual(health.over_budget, health.estimated_commands_per_month > health.monthly_command_budget);
+      assert.strictEqual(health.flush_interval_seconds, FLUSH_INTERVAL_SECONDS);
+      assert.ok(health.last_flush_at, "a completed flush should be visible");
+    });
+
+    it("names a spent quota rather than lumping it in with other write errors", async () => {
+      await boot();
+      pageView("/");
+      redis.failWith = "ERR max requests limit exceeded. Limit: 500000, Usage: 500000";
+      await flushPending();
+      assert.strictEqual(getTelemetryHealth().quota_exhausted, true);
+
+      resetTelemetryHealth();
+      redis.failWith = "WRONGTYPE Operation against a key holding the wrong kind of value";
+      await flushPending();
+      const health = getTelemetryHealth();
+      assert.ok(health.write_failures > 0, "still a failure");
+      assert.strictEqual(health.quota_exhausted, false, "but not a billing problem");
+    });
+  });
+});


### PR DESCRIPTION
Refs #1023

Makes the telemetry write path fit a fixed command budget by buffering in memory and flushing aggregated batches, and removes the read fan-out entirely.

## Why the old design could not fit any plan

Command volume was `O(requests served)` on both sides:

| Event | Commands |
|---|---|
| Logged request (`logRequest`) | `LPUSH` + `LTRIM` = 2 |
| Non-bot page view | 3 × `INCR` + `EXPIRE` on creation + 1 `INCR` per referrer |
| `/api/pageviews` read | `SCAN` (paged) + chunked `MGET`, **per caller**, uncached |
| `flushTelemetry` | `SET` per 5 min |

Measured on production this morning: the stored request log held 200 entries spanning `04:21:37.662Z → 05:04:11.918Z`, i.e. **4.67 logged requests/min**. At 2 commands each that is **~404,000 commands/month from the request log alone**, before page views and before a single `/api/pageviews` call. The 500,000/month ceiling was never going to hold.

## What changed

**Page views** move from one Redis key per `(day, path)` to a single JSON snapshot key (`agentdeals:pageviews`). Counters accumulate in a process-local map and the snapshot is rewritten once per flush. Retention (7 days) and key caps are enforced in code, so there is no `EXPIRE` command and no per-key TTL to manage.

**The legacy key space is migrated across once at boot** — `pv:all:*`, today's and yesterday's `pv:<date>:*`, and `ref:<today>:*` are read and folded into the snapshot, so the all-time history is preserved rather than abandoned. If any of those reads fails the migration is retried on the next flush instead of persisting a partial view. Legacy keys are left in place, inert, per the prior on #1018.

**The request log** batches an entire interval into one variadic `LPUSH`. `LTRIM` only runs once the stored list has run past its cap by a margin, rather than every flush.

**Reads cost nothing.** `/api/pageviews` serves the in-memory snapshot merged with the un-flushed deltas, and `/api/query-log` serves an in-memory mirror hydrated once at boot. This is stronger than the requested cache: the `SCAN`/`MGET` fan-out is not cached, it is gone — the only remaining `SCAN` is the one-time migration. Because the read merges pending deltas, a page view is visible on the endpoint *immediately*, not after the next flush.

`flushPending()` runs on a 60s timer and on `SIGTERM`, and is serialised so a stalled write cannot overlap the next tick.

## Arithmetic

60s flush → **43,200 flushes/month**.

| Item | Per flush | Per month |
|---|---|---|
| Page-view snapshot `SET` (only when a view was recorded) | 1 | 43,200 |
| Request-log `LPUSH` (whole interval, one command) | 1 | 43,200 |
| Request-log `LTRIM` (only past 1,200 stored entries) | ~0.02 at 4.7/min | ~1,000 |
| Telemetry blob `SET` (unchanged, 5 min) | — | 8,640 |
| Boot: snapshot `GET`, log `LRANGE`, telemetry `GET`, one re-read | 4 / deploy | ~400 |
| `/api/pageviews` + `/api/query-log` | 0 | **0** |
| **Total** | | **≈ 96,400** |

**≈ 96,400 commands/month** — 32% of the 300,000 budget, 19% of the 500,000 ceiling.

**Scaling factor: `O(1)` in requests served — a 10× traffic increase adds 0 commands.** Only the `LPUSH` payload grows (capped at 250 entries/flush) and `LTRIM` fires more often, which tops out at one per flush. So the ceiling at *any* traffic level is `3 × 43,200 + 8,640 + 400 ≈ **138,400/month**`. A test asserts this directly: an interval carrying 10 events and one carrying 10,000 cost the identical 2 commands.

## Budget instrumentation

`/api/pageviews` → `storage` (and `/api/query-log`) now carries:

```
commands_since_boot, uptime_seconds,
estimated_commands_per_day, estimated_commands_per_month,
monthly_command_budget, over_budget,
quota_exhausted, pending_page_view_keys, pending_request_log_entries,
request_log_dropped, last_flush_at, flush_interval_seconds
```

`quota_exhausted` matches the Upstash quota phrasing specifically, so "upgrade the plan" is distinguishable from "fix the code" without reading the raw error. `request_log_dropped` counts entries an overflowing interval shed, so the batch cap is never a silent truncation. Budget and interval are env-overridable (`TELEMETRY_COMMAND_BUDGET`, `TELEMETRY_FLUSH_INTERVAL_SECONDS`, floored at 5s since it divides straight into spend).

## Data-loss protections

The #1022 guard now covers page views too: if the snapshot read failed we never write, deltas keep buffering (the key space is capped, so that is bounded), and the read is retried each flush until it recovers. A test covers the dangerous shape specifically — **read fails while writes still succeed**, where a blind flush would replace real history with whatever this process has seen since boot.

Two bugs found and fixed while reviewing this work, both bite-verified:
- the pending buffer was cleared *after* the `SET` round trip, so any page view arriving during the write was discarded — it was neither in the batch being written nor in the buffer afterwards. The buffer is now taken before the await, and restored on failure.
- `redisLrange` called `.map` on whatever came back, so an unexpected response shape threw out of the boot path instead of being recorded as a read failure.

## Acceptance criteria

- [x] ≤ 300,000 commands/month at current traffic, arithmetic above — **≈96,400 projected, ≈138,400 ceiling at any traffic**
- [x] Sub-linear scaling, factor stated — **O(1); 10× traffic adds 0 commands**
- [x] Reads served without per-caller fan-out — **fan-out removed, not cached; 0 commands**
- [x] Buffered counters flushed on `SIGTERM` — verified against a real server with the timer set to 600s
- [x] A mid-interval restart loses at most one interval and never zeroes stored history
- [x] `storage` exposes commands since boot and estimated commands/day
- [x] `last_write_error` distinguishes a spent quota from other failure modes
- [x] Tests cover buffered writes, shutdown flush, and the read path

## On the storage layer

You asked whether moving off Upstash is the better answer. **My recommendation is no, and I would not spend the migration.** The reason to consider it was a per-command quota that this design no longer strains: steady state is ~2 commands per minute and flat in traffic, i.e. 19% of the *free* ceiling with no growth path that changes that. Standing up a Railway-hosted Redis or Postgres would add an always-on service to operate and back up in exchange for removing a constraint that is no longer binding. Happy to revisit if the shape of what we store changes — the moment we want per-event rows rather than counters (which is roughly what #1024's beacon implies), the calculus is different.

**Separately, and worth knowing: the quota has reset.** Production writes started succeeding again around 04:00Z today — `last_write_at` is now ahead of `last_write_error_at`, page views are recording under the normalized key space, and `cumulative_api_hits` re-hydrated to 278,456 rather than staying at 89, so the #1022 guard did its job. The gap from 282,802 is the delta that accumulated in memory after 2026-08-07 and was never persisted; it was never in Redis to be restored.

## Verification

- `tsc --noEmit` clean; **1202/1202 tests** (23 new)
- every new test bite-verified against **12 separate mutations** (per-event `LPUSH`, persist-without-a-loaded-base, silent log drop, unbounded referrers, no retention, `INCR` on the request path, migration dropping all-time history, losing deltas on a failed `SET`, no command accounting, quota not distinguished, unserialised flushes, clearing the buffer after the await) — each one turned the relevant test red
- **real `dist/serve.js` against a fake Upstash speaking the REST protocol**, seeded with the legacy key layout:
  - 60 concurrent requests → **0 Redis commands**
  - one flush window → exactly `SET` + `LPUSH(20 entries)`; an idle window → 0 commands
  - 10 × `/api/pageviews` + 10 × `/api/query-log` → **0 commands**
  - migration carried `pv:all:*` (10,675) and `pv:<today>:total` (89) into the snapshot; a second boot cost 3 commands with **no `SCAN`**, confirming it runs once
  - `SIGTERM` with the flush timer at 600s persisted the buffered counters
  - a 404 (`/pricing`) bucketed to `__unmatched__`, and a scanner path (`/$(pwd)/.env`) did not mint a key
- MCP `initialize` → `tools/call` re-verified
