### PR TITLE
Search analytics: separate catalog gaps from caller-applied filters (#1018 Defect C)

### DIFF
--- a/src/serve.ts
+++ b/src/serve.ts
@@ -53381,7 +53381,16 @@ const httpServer = createHttpServer(async (req, res) => {
       }
       return enriched;
     });
-    recordSearchQuery(q, total, category, req.headers["user-agent"]);
+    // `total` is post-filter. For the catalog-gap signal we need what the query alone
+    // matches, and only when a filter was actually applied (#1018 Defect C).
+    const offersFiltered = Boolean(category || eligibilityType || validStability || validPaymentProtocol);
+    recordSearchQuery(q, total, {
+      category,
+      userAgent: req.headers["user-agent"],
+      source: "api",
+      filtered: offersFiltered,
+      unfilteredCount: offersFiltered && sanitizedQ ? searchOffers(sanitizedQ).length : total,
+    });
     logRequest({ ts: new Date().toISOString(), type: "api", endpoint: "/api/offers", params: { q, category, limit, offset }, user_agent: req.headers["user-agent"] ?? "unknown", result_count: paged.length });
     res.writeHead(200, { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" });
     res.end(JSON.stringify({ offers: offersWithCodes, total }));
@@ -54451,7 +54460,14 @@ ${catList}
       const sanitized = sanitizeQuery(query);
       if (sanitized) {
         const total = searchOffers(sanitized, categoryFilter || undefined, typeFilter || undefined, sortParam || undefined).length;
-        recordSearchQuery(query, total, categoryFilter || undefined, req.headers["user-agent"]);
+        const searchFiltered = Boolean(categoryFilter || typeFilter);
+        recordSearchQuery(query, total, {
+          category: categoryFilter || undefined,
+          userAgent: req.headers["user-agent"],
+          source: "web",
+          filtered: searchFiltered,
+          unfilteredCount: searchFiltered ? searchOffers(sanitized).length : total,
+        });
       }
     }
     logRequest({ ts: new Date().toISOString(), type: "api", endpoint: "/search", params: { q: query, category: categoryFilter, type: typeFilter, sort: sortParam, page: String(page) }, user_agent: req.headers["user-agent"] ?? "unknown", result_count: 1 });

--- a/src/server.ts
+++ b/src/server.ts
@@ -161,7 +161,18 @@ export function createServer(getSessionId?: () => string | undefined, getClientN
         const paged = filtered.slice(effectiveOffset, effectiveOffset + effectiveLimit);
         const results = enrichOffers(paged);
         const finalTotal = since ? filtered.length : total;
-        recordSearchQuery(query, finalTotal, category);
+        // `finalTotal` is what this caller got after its own category / eligibility /
+        // stability / payment-protocol / since filters. Recording only that made a
+        // filtered-to-zero MCP call look identical to a query the catalog has nothing
+        // for — and this is the highest-volume search path, so it dominated the
+        // zero-result list that catalog priorities are read off (#1018 Defect C).
+        const searchFiltered = Boolean(category || eligibility || stability || payment_protocol || since);
+        recordSearchQuery(query, finalTotal, {
+          category,
+          source: "mcp",
+          filtered: searchFiltered,
+          unfilteredCount: searchFiltered && sanitizedQuery ? searchOffers(sanitizedQuery).length : finalTotal,
+        });
         logRequest({ ts: new Date().toISOString(), type: "mcp", endpoint: "search_deals", params: { query, category, eligibility, sort, limit: effectiveLimit, offset: effectiveOffset, since }, result_count: results.length, session_id: getSessionId?.() });
 
         // Zero-result suggestion (only when no results match at all, not just paginated past end)

--- a/src/stats.ts
+++ b/src/stats.ts
@@ -76,10 +76,25 @@ export function useRedis(): boolean {
   return !!(process.env.UPSTASH_REDIS_REST_URL && process.env.UPSTASH_REDIS_REST_TOKEN);
 }
 
+/** Where a recorded search came from. Automated MCP traffic and human web traffic are
+ *  very different signals for catalog decisions, and only `source` can tell them apart. */
+export type SearchSource = "web" | "api" | "mcp";
+
 export interface SearchQueryEntry {
   query: string;
   category?: string;
+  /** What the caller actually got back, after their own filters. */
   results_count: number;
+  /**
+   * What the query alone matches against the whole catalog, ignoring category,
+   * eligibility, stability and payment-protocol filters. This — not `results_count` —
+   * is the catalog-coverage signal: a search filtered down to nothing is not a gap in
+   * what we cover (#1018 Defect C). Absent on entries recorded before this shipped.
+   */
+  unfiltered_count?: number;
+  /** True when the caller supplied any filter beyond the query itself. */
+  filtered?: boolean;
+  source?: SearchSource;
   timestamp: string;
 }
 
@@ -469,7 +484,12 @@ function parseTelemetryData(data: Record<string, unknown>): void {
         typeof (entry as SearchQueryEntry).results_count === "number" &&
         typeof (entry as SearchQueryEntry).timestamp === "string"
       ) {
-        searchQueryLog.push(entry as SearchQueryEntry);
+        const parsed = { ...(entry as SearchQueryEntry) };
+        // A malformed unfiltered_count must not silently drive the catalog-gap list.
+        if (typeof parsed.unfiltered_count !== "number" || !Number.isFinite(parsed.unfiltered_count)) {
+          delete parsed.unfiltered_count;
+        }
+        searchQueryLog.push(parsed);
       }
     }
     if (searchQueryLog.length > SEARCH_QUERY_RING_MAX) {
@@ -1473,26 +1493,68 @@ export function getPageViewsToday(): number {
 // Persisted as a ring buffer (last SEARCH_QUERY_RING_MAX entries) on telemetry.json,
 // so /api/metrics analytics survive deploys.
 
-export function recordSearchQuery(query: string | undefined, resultCount: number, category?: string, userAgent?: string): void {
+export interface SearchQueryContext {
+  category?: string;
+  userAgent?: string;
+  source?: SearchSource;
+  /**
+   * Results for the query alone against the whole catalog. Callers that applied a filter
+   * must supply this; without it a search narrowed to nothing by the caller's own
+   * category/eligibility/stability/payment filter is indistinguishable from a query we
+   * genuinely have no offers for, which is what made `zero_result_queries_7d` unusable
+   * for catalog decisions (#1018 Defect C).
+   */
+  unfilteredCount?: number;
+  filtered?: boolean;
+}
+
+export function recordSearchQuery(
+  query: string | undefined,
+  resultCount: number,
+  context: SearchQueryContext = {},
+): void {
   if (!query) return;
-  if (userAgent && isBot(userAgent)) return;
+  if (context.userAgent && isBot(context.userAgent)) return;
   const normalized = query.trim().toLowerCase();
   if (!normalized) return;
+  const filtered = context.filtered ?? false;
   const entry: SearchQueryEntry = {
     query: normalized,
     timestamp: new Date().toISOString(),
     results_count: resultCount,
+    // With no filters applied the two counts are the same measurement by definition, so
+    // callers only have to do the extra work when they actually narrowed the search.
+    unfiltered_count: filtered ? (context.unfilteredCount ?? resultCount) : resultCount,
   };
-  if (category) entry.category = category;
+  if (filtered) entry.filtered = true;
+  if (context.category) entry.category = context.category;
+  if (context.source) entry.source = context.source;
   searchQueryLog.push(entry);
   if (searchQueryLog.length > SEARCH_QUERY_RING_MAX) {
     searchQueryLog.splice(0, searchQueryLog.length - SEARCH_QUERY_RING_MAX);
   }
 }
 
+function rank(counts: Map<string, number>, limit: number): { query: string; count: number }[] {
+  return [...counts.entries()]
+    .map(([query, count]) => ({ query, count }))
+    .sort((a, b) => b.count - a.count || a.query.localeCompare(b.query))
+    .slice(0, limit);
+}
+
+// An entry counts as a catalog gap only if the query alone matched nothing. Entries
+// recorded before `unfiltered_count` existed fall back to `results_count`, which is the
+// old (over-reporting) behaviour — correct for the unfiltered majority, and the only
+// honest reading of a record that never captured the distinction.
+function catalogMatchCount(entry: SearchQueryEntry): number {
+  return entry.unfiltered_count ?? entry.results_count;
+}
+
 export function getSearchAnalytics(): {
   top_queries_7d: { query: string; count: number }[];
   zero_result_queries_7d: { query: string; count: number }[];
+  filtered_to_zero_queries_7d: { query: string; count: number }[];
+  queries_by_source_7d: Record<string, number>;
   queries_by_category_7d: Record<string, number>;
 } {
   const sevenDaysAgo = Date.now() - 7 * 24 * 60 * 60 * 1000;
@@ -1501,39 +1563,35 @@ export function getSearchAnalytics(): {
     return Number.isFinite(t) && t >= sevenDaysAgo;
   });
 
-  // Top 20 queries by frequency
   const queryCounts = new Map<string, number>();
+  // Genuine gaps: the catalog has nothing for this query at all.
+  const zeroResultCounts = new Map<string, number>();
+  // The caller's own filters removed everything. Worth seeing — it says the filter
+  // combination is too narrow — but it is not a signal to go add offers.
+  const filteredToZeroCounts = new Map<string, number>();
+  const sourceCounts: Record<string, number> = {};
+  const categoryCounts: Record<string, number> = {};
+
   for (const e of recent) {
     queryCounts.set(e.query, (queryCounts.get(e.query) ?? 0) + 1);
-  }
-  const topQueries = [...queryCounts.entries()]
-    .map(([query, count]) => ({ query, count }))
-    .sort((a, b) => b.count - a.count)
-    .slice(0, 20);
 
-  // Top 10 zero-result queries
-  const zeroResultCounts = new Map<string, number>();
-  for (const e of recent) {
-    if (e.results_count === 0) {
+    if (catalogMatchCount(e) === 0) {
       zeroResultCounts.set(e.query, (zeroResultCounts.get(e.query) ?? 0) + 1);
+    } else if (e.results_count === 0) {
+      filteredToZeroCounts.set(e.query, (filteredToZeroCounts.get(e.query) ?? 0) + 1);
     }
-  }
-  const zeroResultQueries = [...zeroResultCounts.entries()]
-    .map(([query, count]) => ({ query, count }))
-    .sort((a, b) => b.count - a.count)
-    .slice(0, 10);
 
-  // Search volume by category (from results that matched a category)
-  const categoryCounts: Record<string, number> = {};
-  for (const e of recent) {
-    if (e.category) {
-      categoryCounts[e.category] = (categoryCounts[e.category] ?? 0) + 1;
-    }
+    const source = e.source ?? "unknown";
+    sourceCounts[source] = (sourceCounts[source] ?? 0) + 1;
+
+    if (e.category) categoryCounts[e.category] = (categoryCounts[e.category] ?? 0) + 1;
   }
 
   return {
-    top_queries_7d: topQueries,
-    zero_result_queries_7d: zeroResultQueries,
+    top_queries_7d: rank(queryCounts, 20),
+    zero_result_queries_7d: rank(zeroResultCounts, 10),
+    filtered_to_zero_queries_7d: rank(filteredToZeroCounts, 10),
+    queries_by_source_7d: sourceCounts,
     queries_by_category_7d: categoryCounts,
   };
 }

--- a/test/api-analytics-persistence.test.ts
+++ b/test/api-analytics-persistence.test.ts
@@ -137,7 +137,7 @@ describe("search query ring buffer persistence (#965)", () => {
     assert.strictEqual(analytics.queries_by_category_7d["databases"], 2);
 
     // Add a new query this deploy, flush, and verify it joined the persisted ring
-    recordSearchQuery("postgres", 8, "databases");
+    recordSearchQuery("postgres", 8, { category: "databases" });
     await flushTelemetry();
 
     const persisted = JSON.parse(readFileSync(telemetryFile, "utf-8"));
@@ -235,7 +235,7 @@ describe("search query ring buffer persistence (#965)", () => {
     assert.deepStrictEqual(analytics.top_queries_7d, []);
 
     // After load, recording new queries works
-    recordSearchQuery("vercel", 3, "hosting");
+    recordSearchQuery("vercel", 3, { category: "hosting" });
     const analytics2 = getSearchAnalytics();
     assert.strictEqual(analytics2.top_queries_7d.length, 1);
     assert.strictEqual(analytics2.top_queries_7d[0].query, "vercel");

--- a/test/search-analytics.test.ts
+++ b/test/search-analytics.test.ts
@@ -68,9 +68,9 @@ describe("search analytics", () => {
   });
 
   it("tracks queries by category", () => {
-    recordSearchQuery("redis", 5, "databases");
-    recordSearchQuery("postgres", 10, "databases");
-    recordSearchQuery("vercel", 3, "hosting");
+    recordSearchQuery("redis", 5, { category: "databases" });
+    recordSearchQuery("postgres", 10, { category: "databases" });
+    recordSearchQuery("vercel", 3, { category: "hosting" });
     recordSearchQuery("stripe", 2);
     const analytics = getSearchAnalytics();
     assert.strictEqual(analytics.queries_by_category_7d["databases"], 2);
@@ -105,7 +105,7 @@ describe("search analytics", () => {
   });
 
   it("search_analytics appears in expected shape", () => {
-    recordSearchQuery("test", 3, "testing");
+    recordSearchQuery("test", 3, { category: "testing" });
     const analytics = getSearchAnalytics();
     assert.ok(Array.isArray(analytics.top_queries_7d));
     assert.ok(Array.isArray(analytics.zero_result_queries_7d));
@@ -114,9 +114,9 @@ describe("search analytics", () => {
   });
 
   it("skips queries with bot user-agent", () => {
-    recordSearchQuery("redis", 5, undefined, "Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)");
-    recordSearchQuery("postgres", 3, undefined, "SemrushBot/7.0");
-    recordSearchQuery("mongodb", 2, undefined, "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36");
+    recordSearchQuery("redis", 5, { userAgent: "Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)" });
+    recordSearchQuery("postgres", 3, { userAgent: "SemrushBot/7.0" });
+    recordSearchQuery("mongodb", 2, { userAgent: "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36" });
     const analytics = getSearchAnalytics();
     assert.strictEqual(analytics.top_queries_7d.length, 1);
     assert.strictEqual(analytics.top_queries_7d[0].query, "mongodb");
@@ -124,8 +124,64 @@ describe("search analytics", () => {
 
   it("records queries when user-agent is undefined (e.g. internal tests, direct API callers)", () => {
     recordSearchQuery("redis", 5);
-    recordSearchQuery("postgres", 3, undefined, undefined);
+    recordSearchQuery("postgres", 3, {});
     const analytics = getSearchAnalytics();
     assert.strictEqual(analytics.top_queries_7d.length, 2);
+  });
+
+  // #1018 Defect C. zero_result_queries_7d is read as "queries the catalog has nothing
+  // for" and drives what we go add. Counting a search the *caller* narrowed to nothing
+  // put queries we cover perfectly well at the top of that list.
+  describe("catalog gaps vs caller filters", () => {
+    it("does not call a search a gap when the caller's own filter emptied it", () => {
+      // "auth0 alternative" matches 10 offers; the caller's stability filter removed them.
+      recordSearchQuery("auth0 alternative", 0, { filtered: true, unfilteredCount: 10, source: "mcp" });
+      const analytics = getSearchAnalytics();
+      assert.deepStrictEqual(analytics.zero_result_queries_7d, [], "we cover this query — it is not a gap");
+      assert.deepStrictEqual(analytics.filtered_to_zero_queries_7d, [{ query: "auth0 alternative", count: 1 }]);
+    });
+
+    it("still reports a query the catalog genuinely has nothing for", () => {
+      recordSearchQuery("atlantis", 0, { filtered: true, unfilteredCount: 0, source: "mcp" });
+      recordSearchQuery("atlantis", 0, { source: "web" });
+      const analytics = getSearchAnalytics();
+      assert.deepStrictEqual(analytics.zero_result_queries_7d, [{ query: "atlantis", count: 2 }]);
+      assert.deepStrictEqual(analytics.filtered_to_zero_queries_7d, []);
+    });
+
+    it("separates the two on the same report", () => {
+      for (let i = 0; i < 5; i++) recordSearchQuery("terramate", 0, { filtered: true, unfilteredCount: 1 });
+      for (let i = 0; i < 3; i++) recordSearchQuery("atlantis", 0, { unfilteredCount: 0 });
+      const analytics = getSearchAnalytics();
+      assert.deepStrictEqual(analytics.zero_result_queries_7d, [{ query: "atlantis", count: 3 }]);
+      assert.deepStrictEqual(analytics.filtered_to_zero_queries_7d, [{ query: "terramate", count: 5 }]);
+    });
+
+    it("treats an unfiltered search as its own catalog measurement", () => {
+      recordSearchQuery("storage", 193, { source: "web" });
+      recordSearchQuery("nothing-we-have", 0, { source: "web" });
+      const analytics = getSearchAnalytics();
+      assert.deepStrictEqual(analytics.zero_result_queries_7d, [{ query: "nothing-we-have", count: 1 }]);
+      assert.deepStrictEqual(analytics.filtered_to_zero_queries_7d, []);
+    });
+
+    it("falls back to results_count for entries recorded before this existed", () => {
+      // A pre-#1018-C ring entry carries no unfiltered_count. Reading it as a gap is the
+      // old behaviour, and the only honest reading of a record that never captured the
+      // distinction.
+      recordSearchQuery("legacy-zero", 0);
+      assert.deepStrictEqual(getSearchAnalytics().zero_result_queries_7d, [{ query: "legacy-zero", count: 1 }]);
+    });
+
+    it("attributes queries to the surface they came from", () => {
+      recordSearchQuery("redis", 5, { source: "mcp" });
+      recordSearchQuery("redis", 5, { source: "mcp" });
+      recordSearchQuery("redis", 5, { source: "web" });
+      recordSearchQuery("redis", 5, { source: "api" });
+      recordSearchQuery("redis", 5);
+      assert.deepStrictEqual(getSearchAnalytics().queries_by_source_7d, {
+        mcp: 2, web: 1, api: 1, unknown: 1,
+      });
+    });
   });
 });

--- a/test/search-recording-wiring.test.ts
+++ b/test/search-recording-wiring.test.ts
@@ -1,0 +1,190 @@
+// Locks the wiring between the search endpoints and the analytics ring (#1018 Defect C).
+//
+// The unit tests in search-analytics.test.ts prove `getSearchAnalytics` classifies an
+// entry correctly once it carries `unfiltered_count`. They cannot prove a call site
+// actually supplies it — a handler that forgets keeps producing entries that look like
+// catalog gaps, which is the bug. So this runs the real server and reads the real
+// /api/metrics.
+
+import { describe, it, after, before } from "node:test";
+import assert from "node:assert";
+import { spawn, type ChildProcess } from "node:child_process";
+import { existsSync, renameSync, rmSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const serverPath = path.join(__dirname, "..", "dist", "serve.js");
+const telemetryPath = path.join(__dirname, "..", "data", "telemetry.json");
+const telemetryBackup = `${telemetryPath}.wiring-test-backup`;
+
+let port = 0;
+let proc: ChildProcess;
+let movedAside = false;
+
+// A query with no offers behind it, unique per run.
+const GAP_QUERY = `wiring-gap-${process.pid}`;
+// A query the catalog does cover, paired with a filter that removes everything.
+const COVERED_QUERY = "database";
+
+before(async () => {
+  // The server hydrates data/telemetry.json at boot. That file is gitignored local
+  // detritus which accumulates across test runs, and the analytics lists are truncated to
+  // a top-N — so leftover entries can push this test's queries off the list it asserts
+  // on. Boot against an empty ring and put the file back afterwards.
+  if (existsSync(telemetryPath)) {
+    renameSync(telemetryPath, telemetryBackup);
+    movedAside = true;
+  }
+
+  proc = spawn("node", [serverPath], {
+    stdio: ["pipe", "pipe", "pipe"],
+    env: { ...process.env, PORT: "0" },
+  });
+  await new Promise<void>((resolve, reject) => {
+    const timeout = setTimeout(() => { proc.kill(); reject(new Error("server start timeout")); }, 20000);
+    proc.stderr!.on("data", (data: Buffer) => {
+      const match = data.toString().match(/running on http:\/\/localhost:(\d+)/);
+      if (match) { port = parseInt(match[1], 10); clearTimeout(timeout); resolve(); }
+    });
+    proc.on("error", (err) => { clearTimeout(timeout); reject(err); });
+  });
+});
+
+after(() => {
+  // SIGKILL rather than SIGTERM: the graceful path flushes this run's ring to
+  // data/telemetry.json, which would land on top of the file we are about to restore.
+  proc?.kill("SIGKILL");
+  if (movedAside) renameSync(telemetryBackup, telemetryPath);
+  else if (existsSync(telemetryPath)) rmSync(telemetryPath);
+});
+
+async function get(pathname: string): Promise<any> {
+  const res = await fetch(`http://localhost:${port}${pathname}`);
+  assert.strictEqual(res.status, 200, `${pathname} -> ${res.status}`);
+  return res.json();
+}
+
+async function analytics(): Promise<any> {
+  return (await get("/api/metrics")).search_analytics;
+}
+
+function countFor(list: { query: string; count: number }[], query: string): number {
+  return list.find(e => e.query === query.toLowerCase())?.count ?? 0;
+}
+
+// The server hydrates data/telemetry.json at boot, so the ring may already contain
+// entries for common queries — including pre-#1018-C ones that legitimately read as gaps
+// under the documented fallback. Assert on the change this request makes, not on the
+// absolute state.
+describe("search recording wiring (#1018 Defect C)", () => {
+  it("a filter that empties a covered query is not recorded as a catalog gap", async () => {
+    const covered = await get(`/api/offers?q=${COVERED_QUERY}&limit=1`);
+    assert.ok(covered.total > 0, `${COVERED_QUERY} should match offers; got ${covered.total}`);
+
+    const before = await analytics();
+    const filtered = await get(`/api/offers?q=${COVERED_QUERY}&stability=volatile&payment_protocol=x402&limit=1`);
+    assert.strictEqual(filtered.total, 0, "this filter combination should empty the result set");
+    const after = await analytics();
+
+    assert.strictEqual(
+      countFor(after.zero_result_queries_7d, COVERED_QUERY) - countFor(before.zero_result_queries_7d, COVERED_QUERY),
+      0,
+      "a query we cover must never be added to the gap list because the caller narrowed it",
+    );
+    assert.strictEqual(
+      countFor(after.filtered_to_zero_queries_7d, COVERED_QUERY) - countFor(before.filtered_to_zero_queries_7d, COVERED_QUERY),
+      1,
+      "it belongs on the filtered-to-zero list instead",
+    );
+  });
+
+  it("a query the catalog genuinely has nothing for is still recorded as a gap", async () => {
+    const before = await analytics();
+    const res = await get(`/api/offers?q=${GAP_QUERY}&limit=1`);
+    assert.strictEqual(res.total, 0);
+    const after = await analytics();
+
+    assert.strictEqual(
+      countFor(after.zero_result_queries_7d, GAP_QUERY) - countFor(before.zero_result_queries_7d, GAP_QUERY),
+      1,
+      "a real gap must survive the fix",
+    );
+  });
+
+  it("attributes recorded queries to the surface they arrived on", async () => {
+    await get(`/api/offers?q=${COVERED_QUERY}&limit=1`);
+    const a = await analytics();
+    assert.ok(a.queries_by_source_7d.api > 0, "/api/offers should report source=api");
+  });
+
+  // The MCP tool is the highest-volume search path and the one that skips bot filtering,
+  // so a filtered-to-zero call here is what dominated the gap list.
+  it("applies the same rule to the MCP search_deals tool", async () => {
+    const sessionId = await mcpInitialize();
+
+    const before = await analytics();
+    const filtered = await mcpSearch(sessionId, { query: COVERED_QUERY, payment_protocol: "x402", stability: "volatile" });
+    assert.strictEqual(filtered.total, 0, "this filter combination should empty the result set");
+    const mid = await analytics();
+
+    assert.strictEqual(
+      countFor(mid.zero_result_queries_7d, COVERED_QUERY) - countFor(before.zero_result_queries_7d, COVERED_QUERY),
+      0,
+      "an MCP call filtered to zero is not a catalog gap",
+    );
+    assert.strictEqual(
+      countFor(mid.filtered_to_zero_queries_7d, COVERED_QUERY) - countFor(before.filtered_to_zero_queries_7d, COVERED_QUERY),
+      1,
+    );
+
+    const mcpGap = `${GAP_QUERY}-mcp`;
+    const gap = await mcpSearch(sessionId, { query: mcpGap });
+    assert.strictEqual(gap.total, 0);
+    const after = await analytics();
+    assert.strictEqual(
+      countFor(after.zero_result_queries_7d, mcpGap) - countFor(mid.zero_result_queries_7d, mcpGap),
+      1,
+      "an unfiltered MCP search with no matches is still a gap",
+    );
+    assert.ok(after.queries_by_source_7d.mcp > 0, "MCP searches should report source=mcp");
+  });
+});
+
+/** Upstream returns SSE frames; the payload is the last `data:` line. */
+function parseSse(body: string): any {
+  const lines = body.split("\n").filter(l => l.startsWith("data:"));
+  assert.ok(lines.length > 0, `no SSE data frame in: ${body.slice(0, 200)}`);
+  return JSON.parse(lines[lines.length - 1].slice("data:".length).trim());
+}
+
+async function mcpInitialize(): Promise<string> {
+  const res = await fetch(`http://localhost:${port}/mcp`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json", Accept: "application/json, text/event-stream" },
+    body: JSON.stringify({
+      jsonrpc: "2.0", id: 1, method: "initialize",
+      params: { protocolVersion: "2024-11-05", capabilities: {}, clientInfo: { name: "wiring-test", version: "1.0" } },
+    }),
+  });
+  assert.strictEqual(res.status, 200);
+  await res.text();
+  const sessionId = res.headers.get("mcp-session-id");
+  assert.ok(sessionId, "initialize should return a session id");
+  return sessionId!;
+}
+
+async function mcpSearch(sessionId: string, args: Record<string, unknown>): Promise<any> {
+  const res = await fetch(`http://localhost:${port}/mcp`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Accept: "application/json, text/event-stream",
+      "Mcp-Session-Id": sessionId,
+    },
+    body: JSON.stringify({ jsonrpc: "2.0", id: 2, method: "tools/call", params: { name: "search_deals", arguments: args } }),
+  });
+  assert.strictEqual(res.status, 200);
+  const payload = parseSse(await res.text());
+  return JSON.parse(payload.result.content[0].text);
+}


### PR DESCRIPTION
Refs #1018

Fixes Defect C: `zero_result_queries_7d` was counting searches the *caller* narrowed to nothing as if the catalog had nothing to offer.

## Root cause

All three recording sites passed the **post-filter** count into `recordSearchQuery`:

| Call site | What it recorded |
|---|---|
| `/api/offers` (`serve.ts`) | `searchOffers(q, category, eligibility_type, sort, stability, payment_protocol).length` |
| `/search` (`serve.ts`) | `searchOffers(q, category, type, sort).length` |
| MCP `search_deals` (`server.ts:164`) | `searchOffers(q, category, eligibility, sort, stability, payment_protocol).length`, or the `since`-filtered length |

So `results_count` answered "what did this caller get", while `zero_result_queries_7d` was being read as "what does the catalog not cover". Those are the same number only when no filter was applied. Verified live against the six queries in the issue — with `payment_protocol=x402` applied:

| query | catalog matches | with the filter | old recording | now |
|---|---|---|---|---|
| `auth0 alternative` | 10 | 1 | — | neither list ✓ |
| `terramate` | 1 | 0 | **counted as a gap** | `filtered_to_zero` ✓ |
| `datadog alternative` | 13 | 0 | **counted as a gap** | `filtered_to_zero` ✓ |
| `opentofu` | 1 | 0 | **counted as a gap** | `filtered_to_zero` ✓ |
| `storage` | 193 | 13 | — | neither list ✓ |
| `atlantis` | 0 | 0 | counted as a gap | `zero_result` ✓ (genuine) |

Three of the six flipped. The unfiltered counts above match the issue's table exactly (10 / 1 / 13 / 1 / 193 / 0), which is a useful independent check that search itself is behaving.

This is worst on the MCP path, as flagged in the earlier comment: it is the highest-volume search surface, it is the only one that passes no user-agent (so it skips bot filtering entirely), and it accepts the most filters. A registry probe calling `search_deals({query, stability})` was manufacturing catalog gaps.

## The fix

`SearchQueryEntry` gains `unfiltered_count` — what the query alone matches against the whole catalog — and the gap list keys off **that**, not `results_count`. A caller-emptied search moves to a new `filtered_to_zero_queries_7d` list rather than vanishing: "this filter combination is too narrow" is worth seeing, it is just not a signal to go add offers.

`recordSearchQuery` now takes a context object instead of trailing positionals, and entries record `source` (`web` | `api` | `mcp`), reported as `queries_by_source_7d`. That separates automated MCP traffic from human web traffic on the same list, which is directly useful for catalog decisions and is a down payment on #1019.

The extra `searchOffers` lookup only runs when a filter was actually applied — with no filters the two counts are the same measurement by definition.

**Backward compatibility:** entries persisted before this shipped have no `unfiltered_count` and fall back to `results_count` — the old, over-reporting behaviour. That is deliberate: it is the only honest reading of a record that never captured the distinction. A malformed persisted `unfiltered_count` is dropped on hydration rather than being allowed to drive the gap list.

## Verification

- `tsc --noEmit` clean; **1212/1212 tests** (10 new)
- new unit tests bite-verified against 3 mutations (gap list reverting to `results_count`, `source` not recorded, `unfilteredCount` dropped on write) — each turned the relevant test red
- a new **wiring test** boots the real `dist/serve.js` and reads the real `/api/metrics`, because unit tests cannot prove a call site actually supplies the count. It covers both `/api/offers` and the MCP `search_deals` tool over HTTP, and both are bite-verified: forcing either call site to pass the filtered count turns exactly that test red
- assertions are delta-based, and the test boots against an isolated ring — `data/telemetry.json` is gitignored local detritus that accumulates across runs, and the analytics lists are top-N truncated, so leftovers could otherwise crowd the assertions out. The file is moved aside and restored
- verified end to end against a real server for all six issue queries, plus MCP `initialize` → `tools/call` for both a filtered-to-zero search and an unfiltered one

## What I cannot answer yet

You asked to have the corrected zero-result list recorded on #1018 when this lands. **I cannot produce it from current data, and I would rather say so than hand you a list built on two samples.** The production ring currently holds 2 entries (`postgres`, `atlantis`) — the historical entries are outside the 7-day window, so the 809-record ring I reported yesterday no longer contributes. The corrected list needs about a week of traffic recorded under this build. `atlantis` remains the one entry I trust, and it is confirmed a genuine gap by both the live check and the new classification.

One consequence worth knowing: I could not retro-diagnose why the two lists were previously *identical* — that required the historical entries, which have now aged out. The mechanism above fully explains a gap list contaminated with covered queries; whether every single historical entry had `results_count: 0` for this reason or partly for another (your `loadOffers()`-was-empty hypothesis) is no longer decidable from the data. What is verifiable is that the current build classifies all six sample queries correctly.
