### PR TITLE
Shared selection module: /best/* stops ranking by the alphabet (#1025)

### DIFF
--- a/src/ranking.ts
+++ b/src/ranking.ts
@@ -1,0 +1,550 @@
+/**
+ * Shared selection module — the single ranking authority for every surface
+ * that presents vendors as a recommendation.
+ *
+ * Design (approved on issue #1025):
+ *
+ *   Everything starts at zero and can only be DEMOTED. There is no bonus for
+ *   anything, so there is no signal a vendor can acquire, lobby for, or buy —
+ *   there is nothing to add.
+ *
+ * Consequences of that rule, all deliberate:
+ *
+ *   - Every input is a property of the vendor's own offer or of a change we
+ *     recorded about it. Nothing derived from our editorial copy is an input.
+ *     `description.length` in particular is not read here and must never be:
+ *     it is a 22%-of-range placement lever that measures us, not them.
+ *   - Weights are integers, so the tie band is exactly zero. One offer can
+ *     only rank below another if we can name at least one specific recorded
+ *     fact about it that the other does not have.
+ *   - Because almost nothing separates a healthy free tier from another
+ *     healthy free tier, large ties are the normal case, not an edge case.
+ *     Ties are broken by a permutation seeded on the UTC date and the query
+ *     key alone — never on anything vendor-controlled or vendor-identifying —
+ *     and the seed is published so a third party can recompute the order.
+ *
+ * This module is pure: no filesystem, no network, no clock unless you pass
+ * one in. It imports only `node:crypto` and erased types, so it can be loaded
+ * directly from `src/` by a test runner using type stripping.
+ */
+
+import { createHash } from "node:crypto";
+import type { DealChange, Offer } from "./types.js";
+
+/** Stable URL where the criteria below are published in full. */
+export const CRITERIA_PATH = "/criteria";
+
+/** The policy sentence, kept here so every surface quotes the same words. */
+export const DEMOTE_ONLY_POLICY =
+  "Rankings start every offer at zero and can only demote. There is no signal a vendor can acquire, lobby for, or buy — there is nothing to add.";
+
+/** What we do not model, stated wherever we return a recommendation. */
+export const NOT_MODELLED_NOTICE =
+  "We rank on offer terms, verification recency and recorded adverse changes. We do NOT model technical fit between a product and a role — the caller must apply that.";
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+const STALE_VERIFICATION_DAYS = 90;
+const VERIFICATION_LAPSED_DAYS = 180;
+const EXPIRING_SOON_DAYS = 90;
+const ADVERSE_CHANGE_WINDOW_DAYS = 365;
+
+// --- Tier classification -----------------------------------------------------
+
+export type TierClass = "free" | "time_limited" | "not_free";
+
+/**
+ * Tier strings are free text: 88 distinct values across 1,571 offers, 61 of
+ * them singletons. The previous code gated on a hand-typed allowlist
+ * (`Free | Hobby | Open Source | Free Credits`) which silently hid 290 offers
+ * — including all 13 `Always Free`, all 30 `Free OSS` and all 4 `Free Forever`.
+ *
+ * This is the inverse: a documented classification in which anything we have
+ * not written down a reason to exclude stays IN. A new tier string can never
+ * be silently dropped; the worst it can do is be treated as an ordinary free
+ * offer until someone classifies it.
+ */
+export const NOT_FREE_TIER_RULES: { pattern: RegExp; note: string }[] = [
+  { pattern: /^paid$/i, note: "no free offer at all" },
+  { pattern: /^freemium$/i, note: "paid product with a trial-shaped entry point, not a stated free tier" },
+  { pattern: /^pay[-\s]?as[-\s]?you[-\s]?go$/i, note: "usage-billed from the first request" },
+  { pattern: /^pay[-\s]?per[-\s]?use\b/i, note: "usage-billed from the first request" },
+  { pattern: /^conditional$/i, note: "availability is not stated in terms we can check" },
+  { pattern: /^exempt\s*\/\s*paid$/i, note: "free only by case-by-case exemption" },
+];
+
+export const TIME_LIMITED_TIER_RULES: { pattern: RegExp; note: string }[] = [
+  { pattern: /credit/i, note: "a credit grant that runs out" },
+  { pattern: /\btrial\b/i, note: "a trial that expires" },
+  { pattern: /scholarship/i, note: "a scholarship award, not an ongoing tier" },
+  { pattern: /\bbeta\b|preview|sandbox/i, note: "a beta/preview/sandbox allowance that may end without notice" },
+];
+
+/**
+ * Classify a tier string. Order matters: a tier that names a credit grant is
+ * time-limited even when it also mentions pay-as-you-go pricing afterwards
+ * (`Free Credits + Pay-as-you-go`), because the free part is the credits.
+ */
+export function classifyTier(tier: string): { class: TierClass; note: string } {
+  for (const rule of TIME_LIMITED_TIER_RULES) {
+    if (rule.pattern.test(tier)) return { class: "time_limited", note: rule.note };
+  }
+  for (const rule of NOT_FREE_TIER_RULES) {
+    if (rule.pattern.test(tier)) return { class: "not_free", note: rule.note };
+  }
+  return { class: "free", note: "an ongoing free tier" };
+}
+
+// --- Gates -------------------------------------------------------------------
+
+export type GateCode =
+  | "eligibility_restricted"
+  | "not_a_free_offer"
+  | "offer_expired"
+  | "verification_lapsed";
+
+export interface Gate {
+  code: GateCode;
+  reason: string;
+}
+
+export const GATE_TABLE: { code: GateCode; description: string }[] = [
+  {
+    code: "eligibility_restricted",
+    description:
+      "The offer is not generally available — it requires accelerator, student, open-source, startup or similar qualification. Such offers appear on the category page, not on a ranked recommendation surface.",
+  },
+  {
+    code: "not_a_free_offer",
+    description:
+      "The stated tier is not a free offer (see the tier classification below).",
+  },
+  {
+    code: "offer_expired",
+    description: "The offer's own stated expiry date has already passed.",
+  },
+  {
+    code: "verification_lapsed",
+    description:
+      `We have not been able to confirm the offer for more than ${VERIFICATION_LAPSED_DAYS} days. This is a floor, not a filter: no offer currently trips it.`,
+  },
+];
+
+// --- Demerits ----------------------------------------------------------------
+
+export type DemeritCode =
+  | "free_tier_withdrawn"
+  | "time_limited_offer"
+  | "stale_verification"
+  | "expiring_soon";
+
+export interface Demerit {
+  code: DemeritCode;
+  points: number;
+  /** Human-readable, and true: states the recorded fact behind the demotion. */
+  reason: string;
+  /** Date of the recorded fact, where one exists. */
+  date?: string;
+  /** True when the demerit describes a limit of ours rather than a fact about the vendor. */
+  about_us?: boolean;
+}
+
+export const DEMERIT_TABLE: { code: DemeritCode; points: number; trigger: string }[] = [
+  {
+    code: "free_tier_withdrawn",
+    points: 3,
+    trigger:
+      `A recorded free-tier removal, open-source licence change or product deprecation within the last ${ADVERSE_CHANGE_WINDOW_DAYS} days.`,
+  },
+  {
+    code: "time_limited_offer",
+    points: 2,
+    trigger:
+      "The stated tier is a credit grant, trial, scholarship, beta, preview or sandbox allowance — the free part runs out.",
+  },
+  {
+    code: "stale_verification",
+    points: 1,
+    trigger:
+      `We have not confirmed the offer against the vendor's own pricing page for more than ${STALE_VERIFICATION_DAYS} days. This measures our confidence, not the vendor.`,
+  },
+  {
+    code: "expiring_soon",
+    points: 1,
+    trigger: `The offer's own stated expiry date falls within ${EXPIRING_SOON_DAYS} days.`,
+  },
+];
+
+const WITHDRAWAL_CHANGE_TYPES: Partial<Record<DealChange["change_type"], string>> = {
+  free_tier_removed: "free tier removal",
+  open_source_killed: "open-source licence change",
+  product_deprecated: "product deprecation",
+};
+
+// --- Disclosures (recorded, but never move rank) ------------------------------
+
+export type DisclosureCode = "limits_reduced" | "pricing_restructured" | "restriction";
+
+export interface Disclosure {
+  code: DisclosureCode;
+  date: string;
+  summary: string;
+}
+
+const DISCLOSURE_CHANGE_TYPES = new Set<string>([
+  "limits_reduced",
+  "pricing_restructured",
+  "restriction",
+]);
+
+/**
+ * Why these are shown but not scored: `deal_changes` covers 246 of 1,563
+ * vendors (15.7%), but 51% of the vendors anyone has heard of. Ranking on
+ * recorded instability demotes prominent vendors 3.2x more often than
+ * obscure ones, which would replace an arbitrary ranking with a biased one.
+ * Our not having recorded a limit reduction about a competitor is not
+ * evidence that none happened.
+ */
+export const DISCLOSURE_RATIONALE =
+  "A recorded limit reduction, pricing restructure or new restriction is shown on every surface where the offer appears, with its date and summary — but it does not move rank. We have change records for only 16% of vendors, and disproportionately for well-known ones, so ranking on them would demote the vendors we happen to watch most closely.";
+
+// --- Verification ledger (populated by issue #1020) --------------------------
+
+/**
+ * What the re-verification job knows about an offer it could not confirm.
+ *
+ * Nothing writes this yet: the rolling re-verifier prints failures to stdout
+ * and keeps no record, so today we cannot honestly distinguish "not yet
+ * re-checked" from "re-checked repeatedly and failed". Until #1020 records it,
+ * `stale_verification` states the one thing that is true in both cases — that
+ * we have not been able to confirm the offer since a given date.
+ */
+export interface VerificationFailure {
+  vendor: string;
+  url: string;
+  consecutive_failures: number;
+  last_success: string | null;
+  last_attempt: string;
+  last_error: string;
+}
+
+export type VerificationLedger = Map<string, VerificationFailure>;
+
+// --- Results -----------------------------------------------------------------
+
+export interface RankedEntry<T> {
+  offer: T;
+  demerits: Demerit[];
+  demerit_total: number;
+  disclosures: Disclosure[];
+}
+
+export interface ExcludedEntry<T> {
+  offer: T;
+  gate: Gate;
+}
+
+export interface TieBreak {
+  /** UTC date the order was derived for. */
+  date: string;
+  /** Derived only from the request. Never from the candidate set. */
+  query_key: string;
+  /** sha256(`${date}|${query_key}|p${demerit_total}`), full hex. */
+  seed: string;
+  /** How many offers tie at the top with zero demerits. */
+  tie_count: number;
+  algorithm: string;
+}
+
+export interface RankingResult<T> {
+  /** Every eligible offer, best band first, order rotated within each band. */
+  ranked: RankedEntry<T>[];
+  /** The zero-demerit band — the offers we can stand behind without caveat. */
+  qualified: RankedEntry<T>[];
+  /** Everything with at least one demerit, fewest demerits first. */
+  demoted: RankedEntry<T>[];
+  /** Offers a gate removed, with the gate that removed them. */
+  excluded: ExcludedEntry<T>[];
+  tie_break: TieBreak;
+  criteria_path: string;
+}
+
+export const TIE_BREAK_ALGORITHM =
+  "seed = sha256(utc_date + '|' + query_key + '|p' + demerit_total); order = Fisher-Yates over the tied set driven by mulberry32(first 4 bytes of seed). No vendor name, slug, id, index or offer field is an input.";
+
+// --- Seeded permutation ------------------------------------------------------
+
+export function tieBreakSeed(date: string, queryKey: string, band: number): string {
+  return createHash("sha256").update(`${date}|${queryKey}|p${band}`).digest("hex");
+}
+
+function mulberry32(a: number): () => number {
+  return function () {
+    a |= 0;
+    a = (a + 0x6d2b79f5) | 0;
+    let t = Math.imul(a ^ (a >>> 15), 1 | a);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+/**
+ * Fisher-Yates over `items`, driven only by `seedHex`.
+ *
+ * The permutation is chosen from all n! orderings by the seed alone and then
+ * applied to the incoming list, so an offer's output position is uniform
+ * regardless of what it is called or where it sits in the file. There is
+ * nothing here to grind against.
+ */
+export function seededShuffle<T>(items: T[], seedHex: string): T[] {
+  const out = items.slice();
+  const rng = mulberry32(parseInt(seedHex.slice(0, 8), 16) >>> 0);
+  for (let i = out.length - 1; i > 0; i--) {
+    const j = Math.floor(rng() * (i + 1));
+    const tmp = out[i];
+    out[i] = out[j];
+    out[j] = tmp;
+  }
+  return out;
+}
+
+/** Today in UTC, as YYYY-MM-DD. */
+export function utcDate(now: Date = new Date()): string {
+  return now.toISOString().slice(0, 10);
+}
+
+// --- Ranking -----------------------------------------------------------------
+
+export interface RankOptions {
+  /** Derived only from the request, e.g. `best-of:Databases`. */
+  queryKey: string;
+  /** All recorded deal changes. Passed in so this module stays pure. */
+  changes: DealChange[];
+  /** UTC date to rank for. Defaults to today. */
+  date?: string;
+  /** Failed re-verification attempts, keyed by lowercased vendor. #1020. */
+  verificationLedger?: VerificationLedger;
+}
+
+function daysBetween(fromIso: string, toIso: string): number {
+  const from = Date.parse(fromIso);
+  const to = Date.parse(toIso);
+  if (Number.isNaN(from) || Number.isNaN(to)) return 0;
+  return Math.floor((to - from) / DAY_MS);
+}
+
+function shiftDays(dateIso: string, days: number): string {
+  return new Date(Date.parse(dateIso) + days * DAY_MS).toISOString().slice(0, 10);
+}
+
+/** The gate an offer trips, or null if it is eligible for a ranked surface. */
+export function gateFor(offer: Offer, date: string): Gate | null {
+  if (offer.eligibility) {
+    const program = offer.eligibility.program ? ` (${offer.eligibility.program})` : "";
+    return {
+      code: "eligibility_restricted",
+      reason: `Restricted to ${offer.eligibility.type}${program} applicants — not generally available.`,
+    };
+  }
+  const tierClass = classifyTier(offer.tier);
+  if (tierClass.class === "not_free") {
+    return {
+      code: "not_a_free_offer",
+      reason: `Tier "${offer.tier}" is ${tierClass.note}.`,
+    };
+  }
+  if (offer.expires_date && offer.expires_date < date) {
+    return { code: "offer_expired", reason: `Offer expired on ${offer.expires_date}.` };
+  }
+  if (offer.verifiedDate && daysBetween(offer.verifiedDate, date) > VERIFICATION_LAPSED_DAYS) {
+    return {
+      code: "verification_lapsed",
+      reason: `We have not been able to confirm this offer since ${offer.verifiedDate} — more than ${VERIFICATION_LAPSED_DAYS} days.`,
+    };
+  }
+  return null;
+}
+
+function staleVerificationDemerit(
+  offer: Offer,
+  date: string,
+  ledger?: VerificationLedger,
+): Demerit | null {
+  if (!offer.verifiedDate) return null;
+  const age = daysBetween(offer.verifiedDate, date);
+  if (age <= STALE_VERIFICATION_DAYS) return null;
+
+  const failure = ledger?.get(offer.vendor.toLowerCase());
+  if (failure && failure.consecutive_failures > 0) {
+    const attempts = failure.consecutive_failures === 1 ? "attempt" : "attempts";
+    const since = failure.last_success
+      ? `last confirmed ${failure.last_success}`
+      : "never confirmed since it was indexed";
+    return {
+      code: "stale_verification",
+      points: 1,
+      about_us: true,
+      date: failure.last_attempt,
+      reason:
+        `We cannot confirm this offer: ${failure.consecutive_failures} consecutive re-check ${attempts} have failed ` +
+        `(most recently ${failure.last_attempt} — ${failure.last_error}), ${since}. ` +
+        `This is our inability to verify, not a change by the vendor.`,
+    };
+  }
+
+  return {
+    code: "stale_verification",
+    points: 1,
+    about_us: true,
+    date: offer.verifiedDate,
+    reason:
+      `We have not confirmed this offer against the vendor's pricing page since ${offer.verifiedDate} (${age} days). ` +
+      `This is our confidence in the record, not a change by the vendor.`,
+  };
+}
+
+export function evaluate<T extends Offer>(
+  offer: T,
+  opts: { date: string; changesForVendor: DealChange[]; verificationLedger?: VerificationLedger },
+): RankedEntry<T> {
+  const { date, changesForVendor, verificationLedger } = opts;
+  const demerits: Demerit[] = [];
+  const disclosures: Disclosure[] = [];
+
+  const adverseCutoff = shiftDays(date, -ADVERSE_CHANGE_WINDOW_DAYS);
+
+  let withdrawal: { change: DealChange; label: string } | null = null;
+  for (const change of changesForVendor) {
+    if (change.date < adverseCutoff) continue;
+    const label = WITHDRAWAL_CHANGE_TYPES[change.change_type];
+    if (label) {
+      if (!withdrawal || change.date > withdrawal.change.date) withdrawal = { change, label };
+      continue;
+    }
+    if (DISCLOSURE_CHANGE_TYPES.has(change.change_type)) {
+      disclosures.push({
+        code: change.change_type as DisclosureCode,
+        date: change.date,
+        summary: change.summary,
+      });
+    }
+  }
+  disclosures.sort((a, b) => b.date.localeCompare(a.date));
+
+  if (withdrawal) {
+    demerits.push({
+      code: "free_tier_withdrawn",
+      points: 3,
+      date: withdrawal.change.date,
+      reason: `Recorded ${withdrawal.label} on ${withdrawal.change.date}: ${withdrawal.change.summary}`,
+    });
+  }
+
+  const tierClass = classifyTier(offer.tier);
+  if (tierClass.class === "time_limited") {
+    demerits.push({
+      code: "time_limited_offer",
+      points: 2,
+      reason: `Tier "${offer.tier}" is ${tierClass.note}, not an ongoing free tier.`,
+    });
+  }
+
+  const stale = staleVerificationDemerit(offer, date, verificationLedger);
+  if (stale) demerits.push(stale);
+
+  if (offer.expires_date && offer.expires_date >= date) {
+    const daysLeft = daysBetween(date, offer.expires_date);
+    if (daysLeft <= EXPIRING_SOON_DAYS) {
+      demerits.push({
+        code: "expiring_soon",
+        points: 1,
+        date: offer.expires_date,
+        reason: `The vendor states this offer expires on ${offer.expires_date} (${daysLeft} days).`,
+      });
+    }
+  }
+
+  const demerit_total = demerits.reduce((sum, d) => sum + d.points, 0);
+  return { offer, demerits, demerit_total, disclosures };
+}
+
+export function changesByVendor(changes: DealChange[]): Map<string, DealChange[]> {
+  const map = new Map<string, DealChange[]>();
+  for (const change of changes) {
+    const key = change.vendor.toLowerCase();
+    const list = map.get(key);
+    if (list) list.push(change);
+    else map.set(key, [change]);
+  }
+  return map;
+}
+
+/**
+ * Rank a candidate set. Gates first, then demerits, then a per-band
+ * permutation seeded on the date and the query key.
+ */
+export function rankOffers<T extends Offer>(candidates: T[], opts: RankOptions): RankingResult<T> {
+  const date = opts.date ?? utcDate();
+  const byVendor = changesByVendor(opts.changes);
+
+  const excluded: ExcludedEntry<T>[] = [];
+  const entries: RankedEntry<T>[] = [];
+  for (const offer of candidates) {
+    const gate = gateFor(offer, date);
+    if (gate) {
+      excluded.push({ offer, gate });
+      continue;
+    }
+    entries.push(
+      evaluate(offer, {
+        date,
+        changesForVendor: byVendor.get(offer.vendor.toLowerCase()) ?? [],
+        verificationLedger: opts.verificationLedger,
+      }),
+    );
+  }
+
+  // Group into integer bands. The band is part of the seed so each band gets
+  // its own permutation, and a demoted offer cannot inherit a top-band slot.
+  const bands = new Map<number, RankedEntry<T>[]>();
+  for (const entry of entries) {
+    const list = bands.get(entry.demerit_total);
+    if (list) list.push(entry);
+    else bands.set(entry.demerit_total, [entry]);
+  }
+
+  const ranked: RankedEntry<T>[] = [];
+  for (const band of [...bands.keys()].sort((a, b) => a - b)) {
+    const seed = tieBreakSeed(date, opts.queryKey, band);
+    ranked.push(...seededShuffle(bands.get(band)!, seed));
+  }
+
+  const qualified = ranked.filter((e) => e.demerit_total === 0);
+  const demoted = ranked.filter((e) => e.demerit_total > 0);
+
+  return {
+    ranked,
+    qualified,
+    demoted,
+    excluded,
+    tie_break: {
+      date,
+      query_key: opts.queryKey,
+      seed: tieBreakSeed(date, opts.queryKey, 0),
+      tie_count: qualified.length,
+      algorithm: TIE_BREAK_ALGORITHM,
+    },
+    criteria_path: CRITERIA_PATH,
+  };
+}
+
+/**
+ * Order an inventory listing — a list that is not a recommendation but should
+ * still not be ordered by the alphabet or by our commercial interest in it.
+ *
+ * Date-free by design where the caller passes no date: which pages exist is a
+ * URL-stability question, and rotating that daily would churn the site for a
+ * crawler with no benefit to a reader.
+ */
+export function rotateListing<T>(items: T[], queryKey: string, date?: string): T[] {
+  return seededShuffle(items, tieBreakSeed(date ?? "", queryKey, 0));
+}

--- a/src/serve.ts
+++ b/src/serve.ts
@@ -21,6 +21,8 @@ import { runHealthCheck, getLastReport, startPeriodicChecks } from "./referral-h
 import { addFriend, removeFriend, getFriends, getFriendCodesForVendors } from "./friends.js";
 import { subscribe as watchlistSubscribe, getSubscription as getWatchlistSubscription, unsubscribe as watchlistUnsubscribe, listSubscriptions as listWatchlistSubscriptions } from "./watchlist.js";
 import { toSlug, vendorSlugMap, resolveVendorSlug } from "./vendor-slug.js";
+import { rankOffers, rotateListing, utcDate, CRITERIA_PATH, DEMOTE_ONLY_POLICY, DISCLOSURE_RATIONALE, TIE_BREAK_ALGORITHM, GATE_TABLE, DEMERIT_TABLE, NOT_FREE_TIER_RULES, TIME_LIMITED_TIER_RULES } from "./ranking.js";
+import type { RankedEntry, RankingResult } from "./ranking.js";
 import type { Agent } from "./types.js";
 import type { AgentBalance } from "./ledger.js";
 import type { SubmittedReferralCode } from "./referral-codes.js";
@@ -602,7 +604,7 @@ function generateShieldBadge(leftText: string, rightText: string, color: string,
     + '\n</svg>';
 }
 
-type NavSection = "search" | "categories" | "best" | "trends" | "alternatives" | "guides" | "compare" | "compare-tool" | "digest" | "this-week" | "changes" | "deadlines" | "report" | "reports" | "expiring" | "freshness" | "agent-stack" | "api" | "developers" | "setup" | "home" | "badges" | "estimate" | "stacks" | "stack-check" | "budget-builder" | "embed" | "marketplace" | "dashboard";
+type NavSection = "search" | "categories" | "best" | "trends" | "alternatives" | "guides" | "compare" | "compare-tool" | "digest" | "this-week" | "changes" | "deadlines" | "report" | "reports" | "expiring" | "freshness" | "criteria" | "agent-stack" | "api" | "developers" | "setup" | "home" | "badges" | "estimate" | "stacks" | "stack-check" | "budget-builder" | "embed" | "marketplace" | "dashboard";
 
 function buildBreadcrumbJsonLd(items: { name: string; url: string }[]): string {
   const jsonLd = {
@@ -670,6 +672,7 @@ function buildGlobalNav(active: NavSection): string {
       { href: "/state-of-free-tiers", label: "Report", section: "report" },
       { href: "/reports", label: "Monthly Reports", section: "reports" },
       { href: "/freshness", label: "Freshness", section: "freshness" },
+      { href: CRITERIA_PATH, label: "How We Rank", section: "criteria" },
     ]},
     { label: "Developers", items: [
       { href: "/developers", label: "API", section: "developers" },
@@ -1222,38 +1225,32 @@ ${globalNavCss()}
 
 // Minimum category size to generate a best-of page
 const BEST_OF_MIN_VENDORS = 5;
-const BEST_OF_PICK_COUNT = 8;
 
-// Score vendors for curation: higher = better pick for a "best free" list
-function scoreBestOfVendor(offer: ReturnType<typeof enrichOffers>[number]): number {
-  let score = 0;
-  // Stable pricing (no negative changes) is the strongest signal
-  if (offer.risk_level === "stable") score += 2;
-  else if (offer.risk_level === "caution") score += 1;
-  // Richer description = more useful free tier info
-  if (offer.description.length > 80) score += 1;
-  else if (offer.description.length > 40) score += 0.5;
-  // Recently verified = trustworthy data
-  const thirtyDaysAgo = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000).toISOString().slice(0, 10);
-  if (offer.verifiedDate >= thirtyDaysAgo) score += 1;
-  // Not expiring soon
-  if (!offer.expires_soon) score += 0.5;
-  return score;
-}
-
-// Build best-of slug map at startup
-const bestOfSlugMap = new Map<string, { categoryName: string; picks: ReturnType<typeof enrichOffers> }>();
+/**
+ * Which /best/ pages exist is fixed at startup so the URL set is stable for a
+ * crawler. WHAT is on them, and in what order, is resolved per request through
+ * the shared ranking module (src/ranking.ts) — there is no per-surface scorer
+ * here any more, and no truncation to a "top N": the page shows every offer
+ * that clears the gates, because 44 of 57 categories have more offers tied at
+ * zero demerits than any top-N could hold.
+ */
+const bestOfSlugMap = new Map<string, { categoryName: string }>();
 for (const cat of categories) {
   const catOffers = offers.filter((o) => o.category === cat.name && !o.eligibility);
   if (catOffers.length < BEST_OF_MIN_VENDORS) continue;
-  const enriched = enrichOffers(catOffers);
-  const scored = enriched
-    .map((o) => ({ offer: o, score: scoreBestOfVendor(o) }))
-    .sort((a, b) => b.score - a.score || a.offer.vendor.localeCompare(b.offer.vendor))
-    .slice(0, BEST_OF_PICK_COUNT)
-    .map((s) => s.offer);
-  const slug = `free-${toSlug(cat.name)}`;
-  bestOfSlugMap.set(slug, { categoryName: cat.name, picks: scored });
+  bestOfSlugMap.set(`free-${toSlug(cat.name)}`, { categoryName: cat.name });
+}
+
+type EnrichedOfferRow = ReturnType<typeof enrichOffers>[number];
+
+/** Rank a category's offers for today. Every ranked surface goes through here. */
+function rankCategory(categoryName: string, date = utcDate()): RankingResult<EnrichedOfferRow> {
+  const catOffers = enrichOffers(offers.filter((o) => o.category === categoryName));
+  return rankOffers(catOffers, {
+    queryKey: `best-of:${categoryName}`,
+    changes: dealChanges,
+    date,
+  });
 }
 
 function buildBestOfMiniReview(offer: ReturnType<typeof enrichOffers>[number]): string {
@@ -1269,19 +1266,45 @@ function buildBestOfMiniReview(offer: ReturnType<typeof enrichOffers>[number]): 
   return `${escHtmlServer(offer.description)}${bestForText}${caveat}`;
 }
 
+/** Recorded facts that are shown wherever the offer appears but never move rank. */
+function renderDisclosures(entry: RankedEntry<EnrichedOfferRow>): string {
+  if (entry.disclosures.length === 0) return "";
+  const items = entry.disclosures.map((d) =>
+    `<li><span style="font-family:var(--mono);color:var(--text-dim)">${escHtmlServer(d.date)}</span> &mdash; <strong>${escHtmlServer(d.code.replace(/_/g, " "))}</strong>: ${escHtmlServer(d.summary)}</li>`
+  ).join("");
+  return `<div class="best-disclosure"><span class="best-disclosure-label">Recorded, but does not affect rank:</span><ul>${items}</ul></div>`;
+}
+
+/** Each demerit names the specific recorded fact that caused the demotion. */
+function renderDemerits(entry: RankedEntry<EnrichedOfferRow>): string {
+  if (entry.demerits.length === 0) return "";
+  const items = entry.demerits.map((d) =>
+    `<li><span class="demerit-code">&minus;${d.points} ${escHtmlServer(d.code)}</span> ${escHtmlServer(d.reason)}${d.about_us ? ` <em style="color:var(--text-dim)">(a limit of ours, not a change by the vendor)</em>` : ""}</li>`
+  ).join("");
+  return `<ul class="demerit-list">${items}</ul>`;
+}
+
 function buildBestOfPage(slug: string): string | null {
   const entry = bestOfSlugMap.get(slug);
   if (!entry) return null;
-  const { categoryName, picks } = entry;
+  const { categoryName } = entry;
+  const ranking = rankCategory(categoryName);
+  const qualified = ranking.qualified;
+  const demoted = ranking.demoted;
+  const tie = ranking.tie_break;
   const year = new Date().getFullYear();
-  const pickCount = picks.length;
-  const title = `${pickCount} Best Free ${categoryName} Tools (${year}) — AgentDeals`;
-  const metaDesc = `Curated list of the ${pickCount} best free ${categoryName.toLowerCase()} tools for developers in ${year}. Featuring ${picks.slice(0, 3).map(o => o.vendor).join(", ")}${pickCount > 3 ? " and more" : ""}. Verified pricing, stability ratings, and side-by-side comparison.`;
+  const pickCount = qualified.length;
+  const title = `Best Free ${categoryName} Tools (${year}) — AgentDeals`;
+  const metaDesc = `Every free ${categoryName.toLowerCase()} tier that clears our bar in ${year}: ${pickCount} offers meet the criteria and ${demoted.length} are demoted with a named reason. Verified pricing, recorded changes, and a published ranking method.`;
 
   const riskColors: Record<string, string> = { stable: "#3fb950", caution: "#d29922", risky: "#f85149" };
 
-  // Mini-review cards
-  const reviewsHtml = picks.map((o, i) => {
+  const tiePara = pickCount > 1
+    ? `<strong>${pickCount} offers meet our criteria for this category and none is distinguishable from the others under any signal we record.</strong> They are listed in an order that rotates daily; <a href="${CRITERIA_PATH}">here is how that order is derived</a>. There is no top slot here to sell.`
+    : `<strong>${pickCount} offer meets our criteria for this category.</strong> <a href="${CRITERIA_PATH}">Here is how we decide</a>.`;
+
+  const renderCard = (e: RankedEntry<EnrichedOfferRow>, i: number, demotedCard: boolean) => {
+    const o = e.offer;
     const riskBadge = o.risk_level ? `<span style="display:inline-block;font-size:.7rem;padding:.15rem .5rem;border-radius:10px;background:${riskColors[o.risk_level]}22;color:${riskColors[o.risk_level]};font-weight:600;margin-left:.5rem">${o.risk_level}</span>` : "";
     const review = buildBestOfMiniReview(o);
     const relatedCompareLinks = Array.from(comparisonMap.entries())
@@ -1289,8 +1312,8 @@ function buildBestOfPage(slug: string): string | null {
       .slice(0, 2)
       .map(([cs]) => `<a href="/compare/${cs}" style="font-size:.75rem;color:var(--accent)">Compare</a>`)
       .join(" ");
-    return `      <div class="best-pick">
-        <div class="best-pick-rank">${i + 1}</div>
+    return `      <div class="best-pick${demotedCard ? " best-pick-demoted" : ""}">
+        <div class="best-pick-rank">${demotedCard ? `&minus;${e.demerit_total}` : i + 1}</div>
         <div class="best-pick-content">
           <div class="best-pick-header">
             <a href="/vendor/${toSlug(o.vendor)}" class="best-pick-name">${escHtmlServer(o.vendor)}</a>
@@ -1298,6 +1321,8 @@ function buildBestOfPage(slug: string): string | null {
           </div>
           <div class="best-pick-tier">${escHtmlServer(o.tier)}</div>
           <p class="best-pick-review">${review}</p>
+          ${renderDemerits(e)}
+          ${renderDisclosures(e)}
           <div class="best-pick-links">
             <a href="/vendor/${toSlug(o.vendor)}">Full profile</a>
             <a href="/alternative-to/${toSlug(o.vendor)}">Alternatives</a>
@@ -1306,16 +1331,24 @@ function buildBestOfPage(slug: string): string | null {
           </div>
         </div>
       </div>`;
-  }).join("\n");
+  };
+
+  const reviewsHtml = qualified.map((e, i) => renderCard(e, i, false)).join("\n");
+  const demotedHtml = demoted.length === 0
+    ? `      <p style="color:var(--text-muted);font-size:.9rem">Nothing in this category is demoted today &mdash; we hold no disqualifying record against any of these offers.</p>`
+    : demoted.map((e, i) => renderCard(e, i, true)).join("\n");
 
   // Comparison table
-  const tableRows = picks.map((o) => `        <tr>
+  const tableRows = qualified.map((e) => {
+    const o = e.offer;
+    return `        <tr>
           <td style="font-weight:600"><a href="/vendor/${toSlug(o.vendor)}" style="color:var(--text)">${escHtmlServer(o.vendor)}</a></td>
           <td style="font-family:var(--mono);color:var(--accent)">${escHtmlServer(o.tier)}</td>
           <td style="color:var(--text-muted);max-width:300px">${escHtmlServer(o.description.slice(0, 120))}${o.description.length > 120 ? "..." : ""}</td>
           <td><span style="color:${riskColors[o.risk_level ?? "stable"]}">${o.risk_level ?? "stable"}</span></td>
           <td style="font-family:var(--mono);color:var(--text-dim)">${escHtmlServer(o.verifiedDate)}</td>
-        </tr>`).join("\n");
+        </tr>`;
+  }).join("\n");
 
   // JSON-LD structured data (ItemList)
   const jsonLd = {
@@ -1324,16 +1357,16 @@ function buildBestOfPage(slug: string): string | null {
     name: `Best Free ${categoryName} Tools`,
     description: metaDesc,
     numberOfItems: pickCount,
-    itemListElement: picks.map((o, i) => ({
+    itemListElement: qualified.map((e, i) => ({
       "@type": "ListItem",
       position: i + 1,
       item: {
         "@type": "SoftwareApplication",
-        name: o.vendor,
-        description: o.description,
+        name: e.offer.vendor,
+        description: e.offer.description,
         applicationCategory: categoryName,
-        offers: { "@type": "Offer", price: "0", priceCurrency: "USD", description: o.tier },
-        url: o.url,
+        offers: { "@type": "Offer", price: "0", priceCurrency: "USD", description: e.offer.tier },
+        url: e.offer.url,
       },
     })),
   };
@@ -1341,7 +1374,7 @@ function buildBestOfPage(slug: string): string | null {
   // Other best-of pages for cross-linking
   const otherBestOf = Array.from(bestOfSlugMap.entries())
     .filter(([s]) => s !== slug)
-    .sort((a, b) => b[1].picks.length - a[1].picks.length)
+    .sort((a, b) => offers.filter(o => o.category === b[1].categoryName).length - offers.filter(o => o.category === a[1].categoryName).length)
     .slice(0, 10)
     .map(([s, v]) => `<a href="/best/${s}" style="display:inline-block;padding:.25rem .7rem;border-radius:20px;font-size:.75rem;color:var(--text-muted);border:1px solid var(--border);text-decoration:none;transition:all .2s">${escHtmlServer(v.categoryName)}</a>`)
     .join("\n        ");
@@ -1394,8 +1427,22 @@ h2{font-family:var(--serif);font-size:1.4rem;color:var(--text);margin:2.5rem 0 1
 .compare-table tr:hover{background:var(--accent-glow)}
 .other-best{display:flex;flex-wrap:wrap;gap:.5rem;margin:1rem 0 2rem}
 .other-best a:hover{border-color:var(--accent);color:var(--text);text-decoration:none}
+.tie-note{background:var(--accent-glow);border:1px solid var(--accent);border-radius:8px;padding:1rem 1.25rem;margin-bottom:1.5rem;font-size:.9rem;color:var(--text-muted)}
+.tie-note strong{color:var(--text)}
+.best-pick-demoted{opacity:.85;border-style:dashed}
+.best-pick-demoted .best-pick-rank{color:#d29922;font-family:var(--mono);font-size:1.1rem}
+.demerit-list{list-style:none;margin:.5rem 0;padding:0;font-size:.8rem;color:var(--text-muted)}
+.demerit-list li{padding:.35rem 0 .35rem .75rem;border-left:2px solid #d29922;margin-bottom:.3rem}
+.demerit-code{font-family:var(--mono);color:#d29922;font-weight:600;margin-right:.4rem}
+.best-disclosure{margin:.5rem 0;font-size:.78rem;color:var(--text-dim)}
+.best-disclosure-label{text-transform:uppercase;letter-spacing:.04em;font-size:.68rem}
+.best-disclosure ul{margin:.25rem 0 0 1rem}
+.audit-block{background:var(--bg-card);border:1px solid var(--border);border-radius:8px;padding:1rem 1.25rem;margin:2rem 0;font-size:.8rem;color:var(--text-muted)}
+.audit-block dl{display:grid;grid-template-columns:auto 1fr;gap:.25rem .75rem;margin:.5rem 0 0}
+.audit-block dt{color:var(--text-dim)}
+.audit-block dd{font-family:var(--mono);color:var(--text);word-break:break-all}
 footer{text-align:center;color:var(--text-dim);font-size:.8rem;padding:3rem 0 2rem;border-top:1px solid var(--border);margin-top:3rem}
-@media(max-width:768px){h1{font-size:1.5rem}.best-pick{flex-direction:column;gap:.5rem}.best-pick-rank{text-align:left}.compare-table{font-size:.75rem}.compare-table th,.compare-table td{padding:.4rem .5rem}}
+@media(max-width:768px){h1{font-size:1.5rem}.best-pick{flex-direction:column;gap:.5rem}.best-pick-rank{text-align:left}.compare-table{font-size:.75rem}.compare-table th,.compare-table td{padding:.4rem .5rem}.audit-block dl{grid-template-columns:1fr}}
 ${globalNavCss()}
 ${mcpCtaCss()}
 </style>
@@ -1404,14 +1451,30 @@ ${mcpCtaCss()}
 <div class="container">
   ${buildGlobalNav("best")}
   <div class="breadcrumb"><a href="/">AgentDeals</a> &rsaquo; <a href="/best">Best Of</a> &rsaquo; ${escHtmlServer(categoryName)}</div>
-  <h1>${pickCount} Best Free ${escHtmlServer(categoryName)} Tools</h1>
-  <p class="page-meta">Curated from ${offers.filter(o => o.category === categoryName).length} verified free tiers. Updated ${new Date().toISOString().split("T")[0]}.</p>
+  <h1>Best Free ${escHtmlServer(categoryName)} Tools</h1>
+  <p class="page-meta">Every free ${escHtmlServer(categoryName.toLowerCase())} tier that clears our bar today. Updated ${tie.date}.</p>
+
+  <div class="tie-note">${tiePara}</div>
 
   <div class="trust-note">
-    <strong>Why trust this data?</strong> Every free tier is verified against the vendor's pricing page with dates tracked. We monitor ${dealChanges.length} pricing changes and flag vendors that have reduced or removed free tiers. <a href="/category/${toSlug(categoryName)}">See all ${offers.filter(o => o.category === categoryName).length} ${categoryName.toLowerCase()} offers &rarr;</a>
+    <strong>Why trust this data?</strong> Every free tier is verified against the vendor's pricing page with dates tracked. We monitor ${dealChanges.length} pricing changes and flag vendors that have reduced or removed free tiers. ${escHtmlServer(DEMOTE_ONLY_POLICY)} <a href="/category/${toSlug(categoryName)}">See all ${offers.filter(o => o.category === categoryName).length} ${categoryName.toLowerCase()} offers &rarr;</a>
   </div>
 
 ${reviewsHtml}
+
+  <h2>Demoted &mdash; and exactly why</h2>
+  <p class="page-meta" style="margin-bottom:1rem">These offers are in this category but rank below the list above. Each one names the recorded fact behind it. ${escHtmlServer(DISCLOSURE_RATIONALE)}</p>
+${demotedHtml}
+
+  <div class="audit-block">
+    <strong style="color:var(--text)">Recompute today's order yourself.</strong> The order above is a permutation seeded only on the UTC date and the query key &mdash; no vendor name, slug, id or offer field is an input. <a href="${CRITERIA_PATH}">The algorithm is published</a>, so anyone can reproduce this page's order without asking us.
+    <dl>
+      <dt>date</dt><dd>${escHtmlServer(tie.date)}</dd>
+      <dt>query_key</dt><dd>${escHtmlServer(tie.query_key)}</dd>
+      <dt>seed</dt><dd>${escHtmlServer(tie.seed)}</dd>
+      <dt>tie_count</dt><dd>${tie.tie_count}</dd>
+    </dl>
+  </div>
 
   <h2>Quick Comparison</h2>
   <table class="compare-table">
@@ -1446,7 +1509,7 @@ function buildBestOfIndexPage(): string {
   const year = new Date().getFullYear();
   const bestOfCount = bestOfSlugMap.size;
   const title = `Best Free Developer Tools (${year}) — AgentDeals`;
-  const metaDesc = `Curated "best of" lists for ${bestOfCount} developer tool categories. Top free tiers ranked by generosity, pricing stability, and data quality.`;
+  const metaDesc = `Every free tier that clears our bar, across ${bestOfCount} developer tool categories. Offers are never promoted — only demoted, on a named recorded fact. The method is published.`;
 
   const sortedEntries = Array.from(bestOfSlugMap.entries())
     .sort((a, b) => {
@@ -1457,11 +1520,12 @@ function buildBestOfIndexPage(): string {
 
   const cardsHtml = sortedEntries.map(([slug, entry]) => {
     const totalInCat = offers.filter(o => o.category === entry.categoryName).length;
-    const topVendors = entry.picks.slice(0, 3).map(o => o.vendor).join(", ");
+    const ranking = rankCategory(entry.categoryName);
+    const topVendors = ranking.qualified.slice(0, 3).map(e => e.offer.vendor).join(", ");
     return `
       <a href="/best/${slug}" class="best-index-card">
         <span class="best-index-name">${escHtmlServer(entry.categoryName)}</span>
-        <span class="best-index-picks">${entry.picks.length} top picks from ${totalInCat}</span>
+        <span class="best-index-picks">${ranking.qualified.length} qualify of ${totalInCat}</span>
         <span class="best-index-vendors">${escHtmlServer(topVendors)}</span>
       </a>`;
   }).join("");
@@ -1517,10 +1581,158 @@ ${globalNavCss()}
   ${buildGlobalNav("best")}
   <div class="breadcrumb"><a href="/">AgentDeals</a> &rsaquo; Best Of</div>
   <h1>Best Free Developer Tools</h1>
-  <p class="page-meta">${bestOfCount} curated "best of" lists. Top free tiers ranked by generosity, pricing stability, and verified data.</p>
+  <p class="page-meta">${bestOfCount} categories. Every free tier that clears our bar, with the demoted ones listed underneath and the reason named. <a href="${CRITERIA_PATH}">How we rank &rarr;</a></p>
 
   <div class="best-index-grid">${cardsHtml}
   </div>
+
+  <footer>AgentDeals &mdash; open source, built for agents | <a href="/privacy">Privacy</a> | <a href="/press">Press</a> | <a href="/disclosure">Affiliate Disclosure</a></footer>
+</div>
+</body>
+</html>`;
+}
+
+// --- Ranking criteria page ---
+
+/**
+ * The published method. Every claim on this page is generated from the same
+ * constants the ranking itself uses, so the page cannot drift from the code.
+ */
+function buildCriteriaPage(): string {
+  const date = utcDate();
+
+  // Measured live rather than asserted, so the numbers on the page are today's.
+  let pagesWithUniqueTop = 0;
+  let tieSum = 0;
+  let pageCount = 0;
+  for (const [, { categoryName }] of bestOfSlugMap) {
+    const r = rankCategory(categoryName, date);
+    pageCount++;
+    tieSum += r.tie_break.tie_count;
+    if (r.tie_break.tie_count === 1) pagesWithUniqueTop++;
+  }
+  const meanTie = pageCount > 0 ? (tieSum / pageCount).toFixed(1) : "0";
+
+  const title = "How AgentDeals ranks — published criteria — AgentDeals";
+  const metaDesc = "Our ranking method in full: the gates, the demerits and their weights, the tie-break seed, and the reason there is no top slot to sell. Recompute any ranked page yourself.";
+
+  const gateRows = GATE_TABLE.map(g => `<tr><td><code>${escHtmlServer(g.code)}</code></td><td>${escHtmlServer(g.description)}</td></tr>`).join("\n");
+  const demeritRows = DEMERIT_TABLE.map(d => `<tr><td><code>${escHtmlServer(d.code)}</code></td><td style="text-align:center;font-family:var(--mono)">&minus;${d.points}</td><td>${escHtmlServer(d.trigger)}</td></tr>`).join("\n");
+  const notFreeRows = NOT_FREE_TIER_RULES.map(r => `<tr><td><code>${escHtmlServer(String(r.pattern))}</code></td><td>${escHtmlServer(r.note)}</td></tr>`).join("\n");
+  const timeLimitedRows = TIME_LIMITED_TIER_RULES.map(r => `<tr><td><code>${escHtmlServer(String(r.pattern))}</code></td><td>${escHtmlServer(r.note)}</td></tr>`).join("\n");
+
+  const jsonLd = {
+    "@context": "https://schema.org",
+    "@type": "WebPage",
+    name: "AgentDeals ranking criteria",
+    description: metaDesc,
+    url: `${BASE_URL}${CRITERIA_PATH}`,
+  };
+
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>${escHtmlServer(title)}</title>
+<meta name="description" content="${escHtmlServer(metaDesc)}">
+<link rel="canonical" href="${BASE_URL}${CRITERIA_PATH}">
+<meta property="og:title" content="${escHtmlServer(title)}">
+<meta property="og:description" content="${escHtmlServer(metaDesc)}">
+<meta property="og:type" content="website">
+<meta property="og:url" content="${BASE_URL}${CRITERIA_PATH}">
+${OG_IMAGE_META}${GOOGLE_VERIFICATION_META}<link rel="icon" type="image/png" href="/favicon.png">
+<link rel="preconnect" href="https://fonts.googleapis.com"><link rel="preconnect" href="https://fonts.gstatic.com" crossorigin><link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
+<script type="application/ld+json">${JSON.stringify(jsonLd)}</script>
+${buildBreadcrumbJsonLd([{ name: "Home", url: BASE_URL + "/" }, { name: "Ranking criteria", url: BASE_URL + CRITERIA_PATH }])}
+<style>
+*{margin:0;padding:0;box-sizing:border-box}
+:root{--bg:#0f172a;--bg-elevated:#1e293b;--bg-card:rgba(255,255,255,0.06);--border:#334155;--text:#f1f5f9;--text-muted:#94a3b8;--text-dim:#64748b;--accent:#3b82f6;--accent-hover:#60a5fa;--accent-glow:rgba(59,130,246,0.15);--sans:'Inter',-apple-system,sans-serif;--mono:'JetBrains Mono',SFMono-Regular,monospace}
+body{font-family:var(--sans);background:var(--bg);color:var(--text);line-height:1.65}
+a{color:var(--accent);text-decoration:none}a:hover{color:var(--accent-hover);text-decoration:underline}
+.container{max-width:820px;margin:0 auto;padding:0 1.5rem}
+.breadcrumb{padding:1.5rem 0 0;font-size:.8rem;color:var(--text-dim)}
+.breadcrumb a{color:var(--text-muted)}
+h1{font-size:2.1rem;margin:1rem 0 .5rem;letter-spacing:-.02em}
+h2{font-size:1.3rem;margin:2.5rem 0 .75rem;letter-spacing:-.01em}
+h3{font-size:1rem;margin:1.5rem 0 .5rem;color:var(--text-muted)}
+p{margin:.75rem 0;color:var(--text-muted)}
+ul,ol{margin:.75rem 0 .75rem 1.5rem;color:var(--text-muted)}
+li{margin:.35rem 0}
+code{font-family:var(--mono);font-size:.85em;color:var(--accent)}
+pre{background:var(--bg-elevated);border:1px solid var(--border);border-radius:8px;padding:1rem;overflow-x:auto;font-family:var(--mono);font-size:.8rem;color:var(--text);margin:1rem 0}
+.lede{font-size:1.05rem;color:var(--text);border-left:3px solid var(--accent);padding-left:1rem;margin:1.5rem 0}
+table{width:100%;border-collapse:collapse;margin:1rem 0;font-size:.85rem}
+th,td{padding:.5rem .7rem;text-align:left;border-bottom:1px solid var(--border);vertical-align:top}
+th{color:var(--text-muted);font-weight:500;font-size:.72rem;text-transform:uppercase;letter-spacing:.05em}
+td{color:var(--text-muted)}
+.callout{background:var(--bg-card);border:1px solid var(--border);border-radius:8px;padding:1rem 1.25rem;margin:1.5rem 0}
+.callout strong{color:var(--text)}
+footer{text-align:center;color:var(--text-dim);font-size:.8rem;padding:3rem 0 2rem;border-top:1px solid var(--border);margin-top:3rem}
+@media(max-width:768px){h1{font-size:1.5rem}table{font-size:.75rem}th,td{padding:.4rem .45rem}}
+${globalNavCss()}
+</style>
+</head>
+<body>
+<div class="container">
+  ${buildGlobalNav("criteria")}
+  <div class="breadcrumb"><a href="/">AgentDeals</a> &rsaquo; Ranking criteria</div>
+  <h1>How we rank &mdash; in full</h1>
+  <p class="lede">${escHtmlServer(DEMOTE_ONLY_POLICY)}</p>
+
+  <p>The <a href="/best">best-of pages</a> resolve through one shared module. There is no second scorer, no per-page ordering, no vendor allowlist, pin, boost or override anywhere in the selection path. Nothing derived from our own editorial copy is an input: an offer cannot rank higher because we wrote more words about it. <em>The <code>/api/stack</code> endpoint and the <code>plan_stack</code> MCP tool are being moved onto this same module; until that lands they still use a hand-written template and should not be read as ranked output.</em></p>
+
+  <h2>1. Gates &mdash; what is excluded, and why</h2>
+  <p>A gate removes an offer from ranked surfaces entirely. It still appears on its category page and its vendor page; it is simply not something we would put in front of you as a recommendation.</p>
+  <table><thead><tr><th>Gate</th><th>Meaning</th></tr></thead><tbody>
+${gateRows}
+  </tbody></table>
+
+  <h3>Tier classification</h3>
+  <p>Tier names are free text: ${new Set(offers.map(o => o.tier)).size} distinct values across ${offers.length} offers. We classify them by published rule rather than by an allowlist, so a tier we have not seen before is never silently dropped &mdash; the worst it can do is be treated as an ordinary free tier until someone classifies it.</p>
+  <p><strong style="color:var(--text)">Not a free offer</strong> (gated out entirely):</p>
+  <table><thead><tr><th>Rule</th><th>Reason</th></tr></thead><tbody>
+${notFreeRows}
+  </tbody></table>
+  <p><strong style="color:var(--text)">Time-limited</strong> (kept, but demoted &mdash; the free part runs out):</p>
+  <table><thead><tr><th>Rule</th><th>Reason</th></tr></thead><tbody>
+${timeLimitedRows}
+  </tbody></table>
+
+  <h2>2. Demerits &mdash; the only thing that moves rank</h2>
+  <p>Every eligible offer starts at zero. Points are only ever subtracted, and every point traces to a specific recorded fact with a date, shown on the page next to the offer it demoted.</p>
+  <table><thead><tr><th>Demerit</th><th>Points</th><th>Trigger</th></tr></thead><tbody>
+${demeritRows}
+  </tbody></table>
+  <p>Weights are integers, so the tie band is exactly zero &mdash; no epsilon, no float noise pretending to be signal. The property that buys: <strong style="color:var(--text)">one offer can only rank below another if we can name at least one specific recorded fact about it that the other does not have.</strong></p>
+
+  <h3>What we record but deliberately do not rank on</h3>
+  <p>${escHtmlServer(DISCLOSURE_RATIONALE)}</p>
+
+  <h3>One demerit measures us, not the vendor</h3>
+  <p><code>stale_verification</code> means we have not been able to confirm the offer recently. That is material &mdash; you should know when we cannot vouch for a record &mdash; but it is a statement about our confidence, and it is labelled as such wherever it appears. It is never presented as something the vendor did.</p>
+
+  <h2>3. Ties, and why there is no top slot to sell</h2>
+  <div class="callout">
+    <strong>Zero of ${pageCount} categories have a unique number one.</strong> Under every criterion we currently record, there is no single best free database, no best free AI/ML tool, no best free anything. On average ${meanTie} offers tie at the top of a category.
+  </div>
+  <p>We think that is the honest answer and a better thing to publish than a manufactured winner. It is also the strongest form of &ldquo;our recommendations are not for sale&rdquo;: there is no top slot, so there is nothing to buy. A vendor cannot improve its position by talking to us &mdash; only by improving its offer, or by us being able to verify it.</p>
+
+  <h3>The tie-break</h3>
+  <p>Tied offers are ordered by a permutation seeded on the UTC date and the query key, and nothing else. No vendor name, slug, id, index or offer field is an input, so an offer's position is uniform regardless of what it is called or where it sits in our file. The order rotates daily; the membership of the list does not.</p>
+  <pre>${escHtmlServer(TIE_BREAK_ALGORITHM)}</pre>
+  <p>Every ranked page publishes the <code>date</code>, <code>query_key</code>, <code>seed</code> and <code>tie_count</code> it used, and the JSON APIs return the same block. <strong style="color:var(--text)">You can recompute today's order yourself and check it against what we served, without asking us.</strong> That is the point: not for sale should be auditable, not merely asserted.</p>
+
+  <h2>4. What we do not model</h2>
+  <p>We rank on offer terms, verification recency and recorded adverse changes. <strong style="color:var(--text)">We do not model technical fit</strong> &mdash; whether a particular product suits a particular role in your architecture. A vector database and a relational database sit in the same category here. If you are asking us which of two products fits your app, we are the wrong source; if you are asking whose free tier we could confirm this week and whose was withdrawn in March, that is exactly what this is for.</p>
+
+  <h2>5. Surfaces that are listings, not rankings</h2>
+  <p>Not every list on this site is a recommendation. Where a page is an inventory &mdash; every referral programme we know of, every comparison pair we generate &mdash; it is labelled as such and ordered by the same unbiased permutation rather than by the alphabet or by our commercial interest. Where we hold a referral link and may earn a commission, that is stated on the section itself, not only in a footnote. See our <a href="/disclosure">affiliate disclosure</a>.</p>
+
+  <h2>6. If we have this wrong</h2>
+  <p>Every demotion names a dated, recorded fact. If a fact is wrong or out of date, it is correctable: the record behind it is shown on the vendor's page with its source. Correcting it changes the ranking automatically, because the ranking has no other input. There is no editorial override to appeal to &mdash; deliberately, because an override is the thing that would be sold.</p>
+
+  <p style="font-size:.8rem;color:var(--text-dim);margin-top:2rem">This page is generated from the same constants the ranking uses, so it cannot drift from the code. Last computed ${escHtmlServer(date)}.</p>
 
   <footer>AgentDeals &mdash; open source, built for agents | <a href="/privacy">Privacy</a> | <a href="/press">Press</a> | <a href="/disclosure">Affiliate Disclosure</a></footer>
 </div>
@@ -1578,7 +1790,23 @@ function comparisonSlug(a: string, b: string): string {
   return `${toSlug(a)}-vs-${toSlug(b)}`;
 }
 
-// Auto-generate comparison pairs from categories with 3+ vendors
+/**
+ * Auto-generate comparison pairs from categories with 3+ vendors.
+ *
+ * This used to score vendors on `changeCount * 3 + description.length / 50`,
+ * which meant the length of the copy WE wrote decided which vendors got an
+ * indexed SEO page at all — a placement lever on 25 vendor slots across 20 of
+ * 57 categories, pullable with no code change and no audit trail. The other
+ * term was no better: `deal_changes` covers 16% of vendors and 51% of the
+ * well-known ones, so leaving it as the sole driver would have selected on
+ * how closely we happen to watch a vendor.
+ *
+ * A comparison page is an inventory surface, not a recommendation, so it does
+ * not need the demerit model — it needs no lever at all. Which vendors get one
+ * is a single unbiased draw per category, seeded on the category name alone.
+ * It is deliberately date-free: rotating which URLs exist would churn the site
+ * daily for a crawler with no benefit to a reader.
+ */
 function generateCategoryPairs(): [string, string][] {
   const catVendors = new Map<string, string[]>();
   for (const o of offers) {
@@ -1587,24 +1815,14 @@ function generateCategoryPairs(): [string, string][] {
     if (!arr.includes(o.vendor)) arr.push(o.vendor);
   }
 
-  const changeCount = new Map<string, number>();
-  for (const c of dealChanges) {
-    changeCount.set(c.vendor, (changeCount.get(c.vendor) ?? 0) + 1);
-  }
-
   const pairs: [string, string][] = [];
-  for (const [, vendors] of catVendors) {
+  for (const [category, vendors] of catVendors) {
     if (vendors.length < 3) continue;
-    const scored = vendors.map(v => {
-      const offer = offers.find(o => o.vendor === v)!;
-      return { name: v, score: (changeCount.get(v) ?? 0) * 3 + offer.description.length / 50 };
-    }).sort((a, b) => b.score - a.score);
-
-    const topN = scored.slice(0, 4);
+    const topN = rotateListing(vendors, `compare-pairs:${category}`).slice(0, 4);
     let catPairCount = 0;
     for (let i = 0; i < topN.length && catPairCount < 5; i++) {
       for (let j = i + 1; j < topN.length && catPairCount < 5; j++) {
-        const [a, b] = [topN[i].name, topN[j].name].sort() as [string, string];
+        const [a, b] = [topN[i], topN[j]].sort() as [string, string];
         pairs.push([a, b]);
         catPairCount++;
       }
@@ -1723,8 +1941,31 @@ ${categorySections}
 </html>`;
 }
 
+/**
+ * Resolve a `x-vs-y` slug to a vendor pair.
+ *
+ * `comparisonMap` decides which comparisons we LINK and put in the sitemap.
+ * It does not decide which ones exist: any pair of vendors we hold offers for
+ * renders, so changing the generated set never 404s a URL that was already
+ * indexed. A vendor slug can itself contain "-vs-" in principle, so every
+ * split point is tried.
+ */
+function resolveComparisonSlug(slug: string): [string, string] | null {
+  const mapped = comparisonMap.get(slug);
+  if (mapped) return mapped;
+  let from = 0;
+  for (;;) {
+    const at = slug.indexOf("-vs-", from);
+    if (at === -1) return null;
+    const a = vendorSlugMap.get(slug.slice(0, at));
+    const b = vendorSlugMap.get(slug.slice(at + 4));
+    if (a && b && a !== b) return [a, b];
+    from = at + 1;
+  }
+}
+
 function buildComparisonPage(slug: string): string | null {
-  const pair = comparisonMap.get(slug);
+  const pair = resolveComparisonSlug(slug);
   if (!pair) return null;
 
   const [vendorA, vendorB] = pair;
@@ -54183,6 +54424,7 @@ ${catList}
       + '  <url>\n    <loc>' + BASE_URL + '/deadlines</loc>\n    <lastmod>' + latestVerified + '</lastmod>\n    <changefreq>daily</changefreq>\n    <priority>0.8</priority>\n  </url>\n'
       + '  <url>\n    <loc>' + BASE_URL + '/pricing-changes</loc>\n    <lastmod>' + latestVerified + '</lastmod>\n    <changefreq>daily</changefreq>\n    <priority>0.8</priority>\n  </url>\n'
       + '  <url>\n    <loc>' + BASE_URL + '/freshness</loc>\n    <lastmod>' + latestVerified + '</lastmod>\n    <changefreq>daily</changefreq>\n    <priority>0.7</priority>\n  </url>\n'
+      + '  <url>\n    <loc>' + BASE_URL + CRITERIA_PATH + '</loc>\n    <lastmod>' + latestVerified + '</lastmod>\n    <changefreq>weekly</changefreq>\n    <priority>0.8</priority>\n  </url>\n'
       + '  <url>\n    <loc>' + BASE_URL + '/search</loc>\n    <lastmod>' + latestVerified + '</lastmod>\n    <changefreq>weekly</changefreq>\n    <priority>0.7</priority>\n  </url>\n'
       + '  <url>\n    <loc>' + BASE_URL + '/stacks</loc>\n    <lastmod>' + editorialDate + '</lastmod>\n    <changefreq>weekly</changefreq>\n    <priority>0.8</priority>\n  </url>\n';
     for (const t of STACK_TEMPLATES) {
@@ -54315,6 +54557,17 @@ ${catList}
           return;
         }
       }
+      // Not a generated pair, but both vendors are known: send the reader to
+      // the canonical (alphabetical) URL so the two orderings never both 200.
+      const resolved = resolveComparisonSlug(slug);
+      if (resolved) {
+        const canonical = comparisonSlug(...(resolved.slice().sort() as [string, string]));
+        if (canonical !== slug) {
+          res.writeHead(301, { Location: `/compare/${canonical}` });
+          res.end();
+          return;
+        }
+      }
     }
     const html = buildComparisonPage(slug);
     if (html) {
@@ -54417,6 +54670,11 @@ ${catList}
     logRequest({ ts: new Date().toISOString(), type: "api", endpoint: "/freshness", params: {}, user_agent: req.headers["user-agent"] ?? "unknown", result_count: 1 });
     res.writeHead(200, { "Content-Type": "text/html; charset=utf-8", "Cache-Control": "public, max-age=3600" });
     res.end(buildFreshnessPage());
+  } else if (url.pathname === CRITERIA_PATH && isGetOrHead) {
+    recordApiHit(CRITERIA_PATH);
+    logRequest({ ts: new Date().toISOString(), type: "api", endpoint: CRITERIA_PATH, params: {}, user_agent: req.headers["user-agent"] ?? "unknown", result_count: 1 });
+    res.writeHead(200, { "Content-Type": "text/html; charset=utf-8", "Cache-Control": "public, max-age=3600" });
+    res.end(buildCriteriaPage());
   } else if (url.pathname === "/setup" && isGetOrHead) {
     recordApiHit("/setup");
     logRequest({ ts: new Date().toISOString(), type: "api", endpoint: "/setup", params: {}, user_agent: req.headers["user-agent"] ?? "unknown", result_count: 1 });

--- a/test/best-of-ranking.test.ts
+++ b/test/best-of-ranking.test.ts
@@ -1,0 +1,208 @@
+// The rendered half of #1025: what a reader and a crawler actually see once
+// selection goes through the shared module.
+//
+// The assertions worth having here are the ones a unit test cannot make: that
+// the tie is disclosed above the list rather than hidden by a top-8 cut, that
+// a demoted vendor is still on the page with its reason attached, and that the
+// seed we publish is the seed we used.
+
+import { describe, it, before, after } from "node:test";
+import assert from "node:assert";
+import { spawn, type ChildProcess } from "node:child_process";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { createHash } from "node:crypto";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+let serverPort = 0;
+let proc: ChildProcess | null = null;
+
+function startHttpServer(): Promise<ChildProcess> {
+  return new Promise((resolve, reject) => {
+    const serverPath = path.join(__dirname, "..", "dist", "serve.js");
+    const child = spawn("node", [serverPath], {
+      stdio: ["pipe", "pipe", "pipe"],
+      env: { ...process.env, PORT: "0", BASE_URL: "http://localhost" },
+    });
+    const timeout = setTimeout(() => {
+      child.kill();
+      reject(new Error("Server startup timeout"));
+    }, 15000);
+    child.stderr!.on("data", (data: Buffer) => {
+      const match = data.toString().match(/running on http:\/\/localhost:(\d+)/);
+      if (match) {
+        serverPort = parseInt(match[1], 10);
+        clearTimeout(timeout);
+        resolve(child);
+      }
+    });
+    child.on("error", (err) => { clearTimeout(timeout); reject(err); });
+  });
+}
+
+const get = async (p: string) => {
+  const res = await fetch(`http://localhost:${serverPort}${p}`, { redirect: "manual" });
+  return { status: res.status, location: res.headers.get("location"), html: await res.text() };
+};
+
+before(async () => { proc = await startHttpServer(); });
+after(() => { if (proc) proc.kill(); });
+
+describe("/best/:slug shows the whole qualified band", () => {
+  it("lists every offer that clears the gates, not a top 8", async () => {
+    const { status, html } = await get("/best/free-databases");
+    assert.strictEqual(status, 200);
+    const cards = (html.match(/class="best-pick"/g) ?? []).length;
+    assert.ok(cards > 8, `expected the full band, got ${cards} cards`);
+  });
+
+  it("states the tie in plain language, above the list", async () => {
+    const { html } = await get("/best/free-databases");
+    const tieNote = html.indexOf("offers meet our criteria for this category");
+    const firstCard = html.indexOf('class="best-pick"');
+    assert.ok(tieNote > -1, "the tie must be stated");
+    assert.ok(tieNote < firstCard, "the tie must be stated above the list, not below it");
+    assert.match(html, /none is distinguishable from the others under any signal we record/);
+    assert.match(html, /rotates daily/);
+  });
+
+  it("keeps a title that matches what people search for", async () => {
+    const { html } = await get("/best/free-databases");
+    assert.match(html, /<title>Best Free Databases Tools \(\d{4}\) — AgentDeals<\/title>/);
+    assert.match(html, /<h1>Best Free Databases Tools<\/h1>/);
+  });
+
+  it("keeps demoted vendors on the page with the reason named", async () => {
+    const { html } = await get("/best/free-databases");
+    assert.match(html, /Demoted &mdash; and exactly why/);
+    assert.ok(html.includes("Firebase"), "Firebase withdrew a free tier and should still be listed, below the band");
+    assert.match(html, /free_tier_withdrawn/);
+    assert.match(html, /Recorded product deprecation on \d{4}-\d{2}-\d{2}/);
+  });
+
+  it("discloses a recorded change without letting it move rank", async () => {
+    const { html } = await get("/best/free-databases");
+    assert.match(html, /Recorded, but does not affect rank/);
+    // Supabase's Feb limit reduction is disclosed; it is still in the top band.
+    const demotedAt = html.indexOf("Demoted &mdash; and exactly why");
+    const supabaseAt = html.indexOf(">Supabase<");
+    assert.ok(supabaseAt > -1 && supabaseAt < demotedAt, "Supabase should be in the qualified band");
+  });
+
+  it("publishes the seed it used, and the seed is the real one", async () => {
+    const { html } = await get("/best/free-databases");
+    const date = html.match(/<dt>date<\/dt><dd>(\d{4}-\d{2}-\d{2})<\/dd>/)?.[1];
+    const queryKey = html.match(/<dt>query_key<\/dt><dd>([^<]+)<\/dd>/)?.[1];
+    const seed = html.match(/<dt>seed<\/dt><dd>([0-9a-f]{64})<\/dd>/)?.[1];
+    const tieCount = html.match(/<dt>tie_count<\/dt><dd>(\d+)<\/dd>/)?.[1];
+    assert.ok(date && queryKey && seed && tieCount, "the audit block must publish all four fields");
+    assert.strictEqual(queryKey, "best-of:Databases");
+    const recomputed = createHash("sha256").update(`${date}|${queryKey}|p0`).digest("hex");
+    assert.strictEqual(seed, recomputed, "a third party must be able to recompute the published seed");
+    const cards = (html.match(/class="best-pick"/g) ?? []).length;
+    assert.strictEqual(Number(tieCount), cards, "tie_count must equal the number of qualified entries shown");
+  });
+
+  it("links the published criteria from the page", async () => {
+    const { html } = await get("/best/free-databases");
+    assert.ok(html.includes('href="/criteria"'), "must link to the criteria page");
+  });
+
+  it("keeps the structured data consistent with what is rendered", async () => {
+    const { html } = await get("/best/free-databases");
+    const jsonLd = JSON.parse(html.match(/<script type="application\/ld\+json">(\{"@context":"https:\/\/schema\.org","@type":"ItemList".*?)<\/script>/s)![1]);
+    const cards = (html.match(/class="best-pick"/g) ?? []).length;
+    assert.strictEqual(jsonLd.numberOfItems, cards);
+    assert.strictEqual(jsonLd.itemListElement.length, cards);
+  });
+});
+
+describe("/best/:slug is not a mirror of /category/:slug", () => {
+  // The PM's kill condition: if the gates make no difference, the page is
+  // duplicate content on 57 URLs and should not exist.
+  it("the gates remove offers the category page shows", async () => {
+    const best = await get("/best/free-ai-ml");
+    const category = await get("/category/ai-ml");
+    assert.strictEqual(best.status, 200);
+    assert.strictEqual(category.status, 200);
+    const bestVendors = new Set([...best.html.matchAll(/class="best-pick-name">([^<]+)</g)].map((m) => m[1]));
+    assert.ok(bestVendors.size > 0);
+    // Eligibility-restricted and non-free tiers are in the category and not here.
+    const index = JSON.parse(readFileSync(path.join(__dirname, "..", "data", "index.json"), "utf8"));
+    const gatedOut = index.offers.filter((o: { category: string; eligibility?: unknown }) => o.category === "AI / ML" && o.eligibility);
+    assert.ok(gatedOut.length > 0, "fixture assumption: AI/ML has eligibility-gated offers");
+    for (const o of gatedOut) {
+      assert.ok(!bestVendors.has(o.vendor), `${o.vendor} is eligibility-restricted and must not be on a best-of page`);
+    }
+  });
+});
+
+describe("/criteria publishes the method", () => {
+  it("returns the policy sentence verbatim", async () => {
+    const { status, html } = await get("/criteria");
+    assert.strictEqual(status, 200);
+    assert.match(html, /There is no signal a vendor can acquire, lobby for, or buy — there is nothing to add/);
+  });
+
+  it("publishes the demerit table with its weights", async () => {
+    const { html } = await get("/criteria");
+    for (const code of ["free_tier_withdrawn", "time_limited_offer", "stale_verification", "expiring_soon"]) {
+      assert.ok(html.includes(code), `${code} must be published`);
+    }
+    assert.match(html, /&minus;3/);
+    assert.match(html, /&minus;2/);
+  });
+
+  it("publishes the tie-break algorithm in enough detail to reproduce", async () => {
+    const { html } = await get("/criteria");
+    assert.match(html, /seed = sha256\(utc_date \+ .{1,8}\|.{1,8} \+ query_key \+ .{1,8}\|p.{1,8} \+ demerit_total\)/);
+    assert.match(html, /Fisher-Yates/);
+    assert.match(html, /mulberry32/);
+    assert.match(html, /No vendor name, slug, id, index or offer field is an input/);
+  });
+
+  it("publishes the finding rather than hiding it", async () => {
+    const { html } = await get("/criteria");
+    assert.match(html, /Zero of \d+ categories have a unique number one/);
+  });
+
+  it("says what we do not model", async () => {
+    const { html } = await get("/criteria");
+    assert.match(html, /We do not model technical fit/);
+  });
+
+  it("is in the sitemap and reachable from the nav", async () => {
+    const { html: sitemap } = await get("/sitemap-pages.xml");
+    assert.ok(sitemap.includes("/criteria"), "criteria page must be in the sitemap");
+    const { html: best } = await get("/best");
+    assert.ok(best.includes('href="/criteria"'), "criteria must be linked from the best-of index");
+  });
+
+  it("has a canonical URL and structured data", async () => {
+    const { html } = await get("/criteria");
+    assert.match(html, /<link rel="canonical" href="[^"]*\/criteria">/);
+    assert.ok(html.includes("BreadcrumbList"));
+  });
+});
+
+describe("comparison pages survive the change of pair selection", () => {
+  it("a pair we no longer generate still resolves rather than 404ing", async () => {
+    // Vendors that exist but are not in the generated set: the URL may have
+    // been indexed under the old description.length selection.
+    const { status, html } = await get("/compare/supabase-vs-neon");
+    assert.ok(status === 200 || status === 301, `expected the page to resolve, got ${status}`);
+    if (status === 200) assert.ok(html.includes("Supabase") && html.includes("Neon"));
+  });
+
+  it("the non-canonical ordering 301s rather than serving duplicate content", async () => {
+    const { status, location } = await get("/compare/xata-vs-nile");
+    assert.strictEqual(status, 301);
+    assert.strictEqual(location, "/compare/nile-vs-xata");
+  });
+
+  it("an unknown vendor still 404s", async () => {
+    const { status } = await get("/compare/definitelynotavendor-vs-alsonotavendor");
+    assert.strictEqual(status, 404);
+  });
+});

--- a/test/ranking.test.ts
+++ b/test/ranking.test.ts
@@ -1,0 +1,481 @@
+// The shared selection module (#1025).
+//
+// This is the trust surface: it decides what we put in front of an agent as a
+// recommendation, and the product claim is that the answer is not for sale.
+// So the tests that matter most are the ones that would catch a thumb on the
+// scale — an input derived from our own copy, a vendor name reachable from the
+// scoring path, a tie-break that quietly favours whoever sorts first.
+
+import { describe, it } from "node:test";
+import assert from "node:assert";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const {
+  rankOffers,
+  rotateListing,
+  evaluate,
+  gateFor,
+  classifyTier,
+  seededShuffle,
+  tieBreakSeed,
+  utcDate,
+  DEMERIT_TABLE,
+  GATE_TABLE,
+} = await import("../src/ranking.ts");
+
+type Offer = import("../src/types.ts").Offer;
+type DealChange = import("../src/types.ts").DealChange;
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REPO = join(__dirname, "..");
+const index = JSON.parse(readFileSync(join(REPO, "data", "index.json"), "utf8")) as { offers: Offer[] };
+const dealChanges = (JSON.parse(readFileSync(join(REPO, "data", "deal_changes.json"), "utf8")) as { changes: DealChange[] }).changes;
+
+const TODAY = "2026-08-25";
+
+function offer(over: Partial<Offer> = {}): Offer {
+  return {
+    vendor: "Acme",
+    category: "Databases",
+    description: "A free tier.",
+    tier: "Free",
+    url: "https://example.com/pricing",
+    tags: [],
+    verifiedDate: "2026-08-20",
+    ...over,
+  };
+}
+
+function change(over: Partial<DealChange> = {}): DealChange {
+  return {
+    vendor: "Acme",
+    change_type: "limits_reduced",
+    date: "2026-06-01",
+    summary: "Halved the row limit.",
+    previous_state: "10k rows",
+    current_state: "5k rows",
+    impact: "medium",
+    source_url: "https://example.com/blog",
+    category: "Databases",
+    alternatives: [],
+    ...over,
+  };
+}
+
+function vendorsOf(entries: { offer: Offer }[]): string[] {
+  return entries.map((e) => e.offer.vendor);
+}
+
+describe("tier classification", () => {
+  it("classifies every tier string in the live index", () => {
+    const unclassified = new Set<string>();
+    for (const o of index.offers) {
+      const c = classifyTier(o.tier);
+      if (!["free", "time_limited", "not_free"].includes(c.class)) unclassified.add(o.tier);
+    }
+    assert.strictEqual(unclassified.size, 0, `unclassified tiers: ${[...unclassified].join(", ")}`);
+  });
+
+  it("stops hiding the 290 offers the old hand-typed allowlist dropped", () => {
+    // findBestOffer() gated on {Free, Hobby, Open Source, Free Credits}. Every
+    // tier below was invisible to plan_stack purely because nobody typed it.
+    for (const tier of ["Always Free", "Free OSS", "Free Forever", "Free Tier", "Free (Basic)", "Community", "Personal", "Developer", "Starter"]) {
+      assert.strictEqual(classifyTier(tier).class, "free", `${tier} should be an ordinary free tier`);
+    }
+  });
+
+  it("reads a credit grant as time-limited even when pay-as-you-go follows it", () => {
+    assert.strictEqual(classifyTier("Free Credits + Pay-as-you-go").class, "time_limited");
+    assert.strictEqual(classifyTier("Free ($30/mo credits)").class, "time_limited");
+    assert.strictEqual(classifyTier("Trial Key").class, "time_limited");
+    assert.strictEqual(classifyTier("Experimental Preview").class, "time_limited");
+  });
+
+  it("excludes tiers that are not a free offer at all", () => {
+    for (const tier of ["Paid", "Freemium", "Pay-as-you-go", "Pay-per-use", "Pay-per-use (no free tier)", "Conditional", "Exempt / Paid"]) {
+      assert.strictEqual(classifyTier(tier).class, "not_free", `${tier} should be gated out`);
+    }
+  });
+
+  it("treats an unrecognised tier as free rather than silently dropping it", () => {
+    assert.strictEqual(classifyTier("Whatever The Vendor Calls It").class, "free");
+  });
+
+  it("classification of the live index matches the counts published on /criteria", () => {
+    const counts = { free: 0, time_limited: 0, not_free: 0 };
+    for (const o of index.offers) counts[classifyTier(o.tier).class]++;
+    assert.strictEqual(counts.not_free, 19);
+    assert.strictEqual(counts.time_limited, 23);
+    assert.strictEqual(counts.free, index.offers.length - 42);
+  });
+});
+
+describe("gates", () => {
+  it("excludes offers that are not generally available", () => {
+    const g = gateFor(offer({ eligibility: { type: "student", conditions: ["enrolled"] } }), TODAY);
+    assert.strictEqual(g?.code, "eligibility_restricted");
+  });
+
+  it("excludes an offer whose stated expiry has passed", () => {
+    const g = gateFor(offer({ expires_date: "2026-08-24" }), TODAY);
+    assert.strictEqual(g?.code, "offer_expired");
+  });
+
+  it("excludes an offer we have not confirmed in 180 days", () => {
+    const g = gateFor(offer({ verifiedDate: "2026-01-01" }), TODAY);
+    assert.strictEqual(g?.code, "verification_lapsed");
+  });
+
+  it("lets a healthy free offer through", () => {
+    assert.strictEqual(gateFor(offer(), TODAY), null);
+  });
+
+  it("every gate code is documented on the criteria page table", () => {
+    const documented = new Set(GATE_TABLE.map((g) => g.code));
+    for (const code of ["eligibility_restricted", "not_a_free_offer", "offer_expired", "verification_lapsed"]) {
+      assert.ok(documented.has(code as never), `${code} must be documented`);
+    }
+  });
+});
+
+describe("demerits", () => {
+  it("a stale record loses to a freshly verified one", () => {
+    const fresh = offer({ vendor: "Fresh", verifiedDate: "2026-08-20" });
+    const stale = offer({ vendor: "Stale", verifiedDate: "2026-04-01" });
+    const r = rankOffers([stale, fresh], { queryKey: "t", changes: [], date: TODAY });
+    assert.deepStrictEqual(vendorsOf(r.ranked), ["Fresh", "Stale"]);
+    assert.strictEqual(r.qualified.length, 1);
+    assert.strictEqual(r.demoted[0].demerits[0].code, "stale_verification");
+  });
+
+  it("a withdrawn free tier loses to one with no such record", () => {
+    const clean = offer({ vendor: "Clean" });
+    const withdrawn = offer({ vendor: "Withdrawn" });
+    const r = rankOffers([withdrawn, clean], {
+      queryKey: "t",
+      changes: [change({ vendor: "Withdrawn", change_type: "free_tier_removed", date: "2026-03-19", summary: "Free tier removed." })],
+      date: TODAY,
+    });
+    assert.deepStrictEqual(vendorsOf(r.ranked), ["Clean", "Withdrawn"]);
+    assert.strictEqual(r.demoted[0].demerit_total, 3);
+    assert.match(r.demoted[0].demerits[0].reason, /2026-03-19/);
+  });
+
+  it("an adverse change older than 12 months no longer demotes", () => {
+    const e = evaluate(offer(), {
+      date: TODAY,
+      changesForVendor: [change({ change_type: "free_tier_removed", date: "2025-01-01" })],
+    });
+    assert.strictEqual(e.demerit_total, 0);
+  });
+
+  it("a credit grant is demoted as time-limited", () => {
+    const e = evaluate(offer({ tier: "Free Credits" }), { date: TODAY, changesForVendor: [] });
+    assert.strictEqual(e.demerit_total, 2);
+    assert.strictEqual(e.demerits[0].code, "time_limited_offer");
+  });
+
+  it("demerits stack, and the total is an integer", () => {
+    const e = evaluate(offer({ tier: "Trial", verifiedDate: "2026-04-01" }), {
+      date: TODAY,
+      changesForVendor: [change({ change_type: "product_deprecated", date: "2026-05-01" })],
+    });
+    assert.strictEqual(e.demerit_total, 6);
+    assert.ok(Number.isInteger(e.demerit_total));
+  });
+
+  it("every published demerit weight is a positive integer, so the tie band is exactly zero", () => {
+    for (const d of DEMERIT_TABLE) {
+      assert.ok(Number.isInteger(d.points) && d.points > 0, `${d.code} weight must be a positive integer`);
+    }
+  });
+
+  it("ordering changes when the underlying data changes", () => {
+    const a = offer({ vendor: "A" });
+    const b = offer({ vendor: "B" });
+    const before = rankOffers([a, b], { queryKey: "t", changes: [], date: TODAY });
+    assert.strictEqual(before.qualified.length, 2);
+    const after = rankOffers([a, b], {
+      queryKey: "t",
+      changes: [change({ vendor: "A", change_type: "open_source_killed", date: "2026-07-01" })],
+      date: TODAY,
+    });
+    assert.deepStrictEqual(vendorsOf(after.qualified), ["B"]);
+    assert.deepStrictEqual(vendorsOf(after.demoted), ["A"]);
+  });
+});
+
+describe("recorded changes that must not move rank", () => {
+  for (const change_type of ["limits_reduced", "pricing_restructured", "restriction"] as const) {
+    it(`${change_type} is disclosed but costs nothing`, () => {
+      const e = evaluate(offer(), { date: TODAY, changesForVendor: [change({ change_type })] });
+      assert.strictEqual(e.demerit_total, 0, `${change_type} must not demote`);
+      assert.strictEqual(e.disclosures.length, 1);
+      assert.strictEqual(e.disclosures[0].code, change_type);
+      assert.strictEqual(e.disclosures[0].date, "2026-06-01");
+    });
+  }
+
+  it("Supabase and Neon stay in the top band despite their recorded changes", () => {
+    // The coverage-bias case: both have exactly one recorded negative change,
+    // which under a stability-scoring model put them 37th and 40th of 42.
+    const dbs = index.offers.filter((o) => o.category === "Databases");
+    const r = rankOffers(dbs, { queryKey: "best-of:Databases", changes: dealChanges, date: TODAY });
+    for (const vendor of ["Supabase", "Neon"]) {
+      const entry = r.qualified.find((e) => e.offer.vendor === vendor);
+      assert.ok(entry, `${vendor} should be in the qualified band`);
+      assert.strictEqual(entry.demerit_total, 0);
+      assert.ok(entry.disclosures.length > 0, `${vendor}'s recorded change should still be disclosed`);
+    }
+  });
+});
+
+describe("stale_verification says something true about who is at fault", () => {
+  it("without a failure record it states only that we could not confirm it", () => {
+    const e = evaluate(offer({ verifiedDate: "2026-04-01" }), { date: TODAY, changesForVendor: [] });
+    const d = e.demerits[0];
+    assert.strictEqual(d.code, "stale_verification");
+    assert.strictEqual(d.about_us, true);
+    assert.match(d.reason, /have not confirmed/);
+    assert.match(d.reason, /not a change by the vendor/);
+  });
+
+  it("with a failure record it states the attempt count and the last success", () => {
+    const ledger = new Map([
+      ["acme", { vendor: "Acme", url: "https://example.com", consecutive_failures: 14, last_success: "2026-03-01", last_attempt: "2026-08-24", last_error: "HTTP 403" }],
+    ]);
+    const r = rankOffers([offer({ verifiedDate: "2026-04-01" })], {
+      queryKey: "t",
+      changes: [],
+      date: TODAY,
+      verificationLedger: ledger,
+    });
+    const d = r.demoted[0].demerits[0];
+    assert.match(d.reason, /14 consecutive re-check attempts have failed/);
+    assert.match(d.reason, /last confirmed 2026-03-01/);
+    assert.match(d.reason, /HTTP 403/);
+    assert.match(d.reason, /our inability to verify, not a change by the vendor/);
+    assert.strictEqual(d.about_us, true);
+  });
+
+  it("the demerit is worth the same either way — the wording changes, not the rank", () => {
+    const withoutLedger = evaluate(offer({ verifiedDate: "2026-04-01" }), { date: TODAY, changesForVendor: [] });
+    const withLedger = evaluate(offer({ verifiedDate: "2026-04-01" }), {
+      date: TODAY,
+      changesForVendor: [],
+      verificationLedger: new Map([["acme", { vendor: "Acme", url: "u", consecutive_failures: 3, last_success: null, last_attempt: "2026-08-24", last_error: "timeout" }]]),
+    });
+    assert.strictEqual(withoutLedger.demerit_total, withLedger.demerit_total);
+  });
+});
+
+describe("tie-break", () => {
+  const tied = Array.from({ length: 41 }, (_, i) => offer({ vendor: `V${i}` }));
+
+  it("is deterministic for the same day and query", () => {
+    const a = rankOffers(tied, { queryKey: "best-of:Databases", changes: [], date: TODAY });
+    const b = rankOffers(tied, { queryKey: "best-of:Databases", changes: [], date: TODAY });
+    assert.deepStrictEqual(vendorsOf(a.ranked), vendorsOf(b.ranked));
+  });
+
+  it("rotates the next day", () => {
+    const a = rankOffers(tied, { queryKey: "best-of:Databases", changes: [], date: "2026-08-25" });
+    const b = rankOffers(tied, { queryKey: "best-of:Databases", changes: [], date: "2026-08-26" });
+    assert.notDeepStrictEqual(vendorsOf(a.ranked), vendorsOf(b.ranked));
+  });
+
+  it("differs by query key on the same day", () => {
+    const a = rankOffers(tied, { queryKey: "best-of:Databases", changes: [], date: TODAY });
+    const b = rankOffers(tied, { queryKey: "best-of:Auth", changes: [], date: TODAY });
+    assert.notDeepStrictEqual(vendorsOf(a.ranked), vendorsOf(b.ranked));
+  });
+
+  it("depends on nothing the vendor controls — rename every vendor, same permutation", () => {
+    const renamed = tied.map((o, i) => ({ ...o, vendor: `zzz-${100 - i}` }));
+    const a = rankOffers(tied, { queryKey: "k", changes: [], date: TODAY });
+    const b = rankOffers(renamed, { queryKey: "k", changes: [], date: TODAY });
+    // Same input positions land in the same output positions regardless of name.
+    const posA = vendorsOf(a.ranked).map((v) => tied.findIndex((o) => o.vendor === v));
+    const posB = vendorsOf(b.ranked).map((v) => renamed.findIndex((o) => o.vendor === v));
+    assert.deepStrictEqual(posA, posB);
+  });
+
+  it("is not sensitive to our editorial copy", () => {
+    const wordy = tied.map((o) => ({ ...o, description: "x".repeat(500) }));
+    const a = rankOffers(tied, { queryKey: "k", changes: [], date: TODAY });
+    const b = rankOffers(wordy, { queryKey: "k", changes: [], date: TODAY });
+    const posA = vendorsOf(a.ranked).map((v) => tied.findIndex((o) => o.vendor === v));
+    const posB = vendorsOf(b.ranked).map((v) => wordy.findIndex((o) => o.vendor === v));
+    assert.deepStrictEqual(posA, posB);
+  });
+
+  it("gives every member of a tie the top slot about equally often", () => {
+    // 3,650 consecutive dates over a 41-way tie. Expected 89.0 first places
+    // each; chi-square must clear the 99% critical value for df=40 (63.7).
+    const N = 41;
+    const DAYS = 3650;
+    const items = Array.from({ length: N }, (_, i) => i);
+    const first = new Array(N).fill(0);
+    const positionSum = new Array(N).fill(0);
+    const base = Date.UTC(2026, 0, 1);
+    for (let d = 0; d < DAYS; d++) {
+      const date = new Date(base + d * 86400000).toISOString().slice(0, 10);
+      const order = seededShuffle(items, tieBreakSeed(date, "best-of:Databases", 0));
+      first[order[0]]++;
+      order.forEach((item, pos) => { positionSum[item] += pos; });
+    }
+    const expected = DAYS / N;
+    const chi2 = first.reduce((s, o) => s + (o - expected) ** 2 / expected, 0);
+    assert.ok(chi2 < 63.7, `chi-square ${chi2.toFixed(1)} suggests a non-uniform tie-break`);
+
+    // And no residual file-order bias: first and last incoming index should sit
+    // at the middle of the distribution over time, like everyone else.
+    const meanPos = positionSum.map((s) => s / DAYS);
+    const centre = (N - 1) / 2;
+    for (const idx of [0, N - 1]) {
+      assert.ok(Math.abs(meanPos[idx] - centre) < 1, `incoming index ${idx} has a positional bias`);
+    }
+  });
+
+  it("publishes a seed anyone can recompute", () => {
+    const r = rankOffers(tied, { queryKey: "best-of:Databases", changes: [], date: TODAY });
+    assert.strictEqual(r.tie_break.seed, tieBreakSeed(TODAY, "best-of:Databases", 0));
+    assert.match(r.tie_break.seed, /^[0-9a-f]{64}$/);
+    assert.strictEqual(r.tie_break.tie_count, 41);
+    assert.strictEqual(r.tie_break.date, TODAY);
+  });
+
+  it("a demoted offer can never inherit a top-band slot", () => {
+    const candidates = [
+      ...Array.from({ length: 20 }, (_, i) => offer({ vendor: `Clean${i}` })),
+      offer({ vendor: "Stale", verifiedDate: "2026-04-01" }),
+    ];
+    // Dates chosen so "Stale" is past 90 days but not yet past the 180-day gate.
+    for (const date of ["2026-07-05", "2026-08-25", "2026-09-01", "2026-09-25"]) {
+      const r = rankOffers(candidates, { queryKey: "k", changes: [], date });
+      assert.strictEqual(r.ranked.length, 21, `${date}: nothing should be gated out`);
+      assert.strictEqual(r.ranked[r.ranked.length - 1].offer.vendor, "Stale", `${date}: demoted entry must sort last`);
+    }
+  });
+
+  it("rotateListing is stable across days — URL sets must not churn", () => {
+    const vendors = Array.from({ length: 10 }, (_, i) => `V${i}`);
+    // Pinned to the date-free seed: which /compare/ pages exist must not depend
+    // on when the process happened to boot, or the site churns 300+ URLs a day.
+    assert.deepStrictEqual(
+      rotateListing(vendors, "compare-pairs:Databases"),
+      seededShuffle(vendors, tieBreakSeed("", "compare-pairs:Databases", 0)),
+    );
+    assert.notDeepStrictEqual(rotateListing(vendors, "compare-pairs:Databases"), rotateListing(vendors, "compare-pairs:Auth"));
+    assert.deepStrictEqual(rotateListing(vendors, "k"), rotateListing(vendors, "k", undefined));
+  });
+});
+
+describe("no thumb on the scale", () => {
+  const source = readFileSync(join(REPO, "src", "ranking.ts"), "utf8");
+
+  // Comments in this module exist precisely to explain which levers were
+  // removed and why, so they name the banned things. The assertions below are
+  // about executable code.
+  const stripComments = (src: string) =>
+    src.split("\n").filter((l) => !/^\s*(\*|\/\/|\/\*|\*\/)/.test(l)).join("\n");
+  const code = stripComments(source);
+
+  it("no vendor name from the index appears anywhere in the selection module", () => {
+    const vendors = [...new Set(index.offers.map((o) => o.vendor))].filter((v) => v.length >= 4);
+    const hits = vendors.filter((v) => new RegExp(`\\b${v.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}\\b`).test(source));
+    assert.deepStrictEqual(hits, [], `vendor names must not be reachable from scoring: ${hits.join(", ")}`);
+  });
+
+  it("no override, boost, pin or allowlist mechanism exists in the module", () => {
+    for (const forbidden of [/\bboost\b/i, /\bpin(ned)?\b/i, /allowlist/i, /whitelist/i, /\boverride\b/i, /preferredVendors/i]) {
+      assert.ok(!forbidden.test(code), `selection module must not contain ${forbidden}`);
+    }
+  });
+
+  it("our own editorial copy is not read by the scoring path", () => {
+    assert.ok(!/\.description\b/.test(code), "offer.description must never be a scoring input");
+  });
+
+  it("the per-surface scorer scoreBestOfVendor is gone, not left alongside", () => {
+    const serve = stripComments(readFileSync(join(REPO, "src", "serve.ts"), "utf8"));
+    assert.ok(!/scoreBestOfVendor/.test(serve), "scoreBestOfVendor must not exist");
+    assert.ok(!/description\.length\s*\/\s*50/.test(serve), "the comparison-page description.length lever must be gone");
+  });
+});
+
+describe("the live index, ranked", () => {
+  it("no category has a unique number one — the finding we publish", () => {
+    const categories = [...new Set(index.offers.map((o) => o.category))];
+    let pages = 0;
+    let uniqueTop = 0;
+    for (const cat of categories) {
+      const eligible = index.offers.filter((o) => o.category === cat && !o.eligibility);
+      if (eligible.length < 5) continue;
+      pages++;
+      const r = rankOffers(index.offers.filter((o) => o.category === cat), {
+        queryKey: `best-of:${cat}`,
+        changes: dealChanges,
+        date: TODAY,
+      });
+      if (r.tie_break.tie_count === 1) uniqueTop++;
+    }
+    assert.strictEqual(pages, 57);
+    assert.strictEqual(uniqueTop, 0);
+  });
+
+  it("Databases: Firebase is the only demotion, on a named recorded fact", () => {
+    const r = rankOffers(index.offers.filter((o) => o.category === "Databases"), {
+      queryKey: "best-of:Databases",
+      changes: dealChanges,
+      date: TODAY,
+    });
+    assert.strictEqual(r.qualified.length, 41);
+    assert.deepStrictEqual(vendorsOf(r.demoted), ["Firebase"]);
+    assert.strictEqual(r.demoted[0].demerits[0].code, "free_tier_withdrawn");
+    assert.strictEqual(r.excluded.length, 3);
+  });
+
+  it("AI/ML: the vendors whose free tier is really a credit grant are demoted", () => {
+    const r = rankOffers(index.offers.filter((o) => o.category === "AI / ML"), {
+      queryKey: "best-of:AI / ML",
+      changes: dealChanges,
+      date: TODAY,
+    });
+    const demoted = new Map(r.demoted.map((e) => [e.offer.vendor, e]));
+    for (const vendor of ["OpenAI", "Google Gemini API", "Clarifai", "xAI"]) {
+      assert.ok(demoted.get(vendor)?.demerits.some((d) => d.code === "free_tier_withdrawn"), `${vendor} withdrew a free tier and must be demoted`);
+    }
+    for (const vendor of ["Cohere", "Together AI", "Fireworks AI", "Modal", "DeepSeek API"]) {
+      assert.ok(demoted.get(vendor)?.demerits.some((d) => d.code === "time_limited_offer"), `${vendor} offers credits, not a free tier`);
+    }
+    assert.strictEqual(r.qualified.length, 47);
+  });
+
+  it("every demotion on every page names a specific recorded fact", () => {
+    const categories = [...new Set(index.offers.map((o) => o.category))];
+    for (const cat of categories) {
+      const r = rankOffers(index.offers.filter((o) => o.category === cat), {
+        queryKey: `best-of:${cat}`,
+        changes: dealChanges,
+        date: TODAY,
+      });
+      for (const entry of r.demoted) {
+        assert.ok(entry.demerits.length > 0, `${entry.offer.vendor} demoted with no reason`);
+        for (const d of entry.demerits) {
+          assert.ok(d.reason.length > 20, `${entry.offer.vendor}/${d.code} has no stated reason`);
+          assert.ok(d.points > 0);
+        }
+      }
+    }
+  });
+});
+
+describe("dates", () => {
+  it("utcDate is UTC, not local", () => {
+    assert.strictEqual(utcDate(new Date("2026-08-25T23:59:59Z")), "2026-08-25");
+    assert.strictEqual(utcDate(new Date("2026-08-26T00:00:01Z")), "2026-08-26");
+  });
+});


### PR DESCRIPTION
Refs #1025 — part 1 of 2. This is the shared module plus `/best/*` plus the published criteria, in the order you asked for. `plan_stack`, the referral-programs split and the remaining recommendation surfaces follow in part 2; the enumeration you asked for is at the bottom and it found three surfaces neither of us had listed.

## What ships

**`src/ranking.ts` — one module, pure, no filesystem or clock unless you pass one in.** Gates → demerits → per-band seeded permutation. Everything approved on the issue is implemented as specified: the gate list, the demerit table and its weights, disclosure-only change types, the zero-width tie band, and the seed/permutation design.

**`scoreBestOfVendor` is deleted, not left alongside.** A test asserts the identifier no longer exists in `src/serve.ts`.

**`description.length` is gone from both places it appeared** — the best-of scorer and the comparison-page generator. A test asserts `description` is not reachable from executable code in the selection module, and that mutating our copy does not move any offer's position.

**`/criteria`** publishes the method in full, generated from the same constants the ranking uses so the page cannot drift from the code. Your sentence is the lede: *"There is no signal a vendor can acquire, lobby for, or buy — there is nothing to add."* The tie-break algorithm, the demerit weights, the tier classification rules and the "zero of 57 categories have a unique #1" finding are all on it. Linked from every `/best/` page, in the sitemap, and in the nav.

**Every ranked page publishes `date`, `query_key`, `seed` and `tie_count`.** A test recomputes the seed independently with `crypto.createHash("sha256")` and asserts it matches what the page served — i.e. the audit works from outside.

## What actually changed on the pages

`/best/free-databases`, live from this build:

| | Before | After |
|---|---|---|
| Order | strict alphabetical | 41-way tie at zero demerits, rotated daily |
| Entries shown | 8 | 41 qualified + 1 demoted |
| Supabase | 36th, absent from the page | in the top band, its Feb limit reduction disclosed |
| Neon | 29th, absent | in the top band |
| Demoted | — | Firebase, `free_tier_withdrawn`, product deprecation 2026-03-19 |

`/best/free-ai-ml`: 47 qualified, 16 demoted — four vendors that withdrew a free tier (OpenAI, Google Gemini API, Clarifai, xAI) and nine whose "free tier" is a credit grant. All thirteen were presented among the eight best on that page yesterday.

Across all 57 pages: mean tie at the top rises from 11.1 to 23.3, and **zero categories have a unique number one**.

## Three things you need to decide on

### 1. Your `/best/X` ≈ `/category/X` kill condition trips — on 21 of 57 pages

You asked to be told if it tripped on any page. Measured across all 57:

- **21 pages have nothing gated and nothing demoted.** The offer set is identical to the category page; the only differences are the rotated order and the tie disclosure. Full list: Auth (29), Web Scraping (23), Feature Flags (9), Container Registry (9), Low-Code Platforms (15), Documentation (6), Maps/Geolocation (20), Forms (29), Localization (14), Team Collaboration (33), Mobile Development (9), Notebooks & Data Science (10), Diagramming (10), Tunneling & Networking (16), Code Quality (20), Streaming & Media (12), Cloud Storage (9), Password Managers (6), Communication & Messaging (8), Design & Creative (6), Fitness & Health (5).
- **36 pages differentiate**: 61 offers gated out and 63 demoted in total.

I have shipped all 57 rather than pre-emptively killing 21, because the call is yours and because the set is not stable — a category acquires a demotion the first time a vendor withdraws a tier or a record goes stale, and the 21 shrinks on its own. But on today's data those 21 URLs are duplicate content with a different sort order, and I would not argue if you want them gone.

### 2. Comparison-page selection: 264 of 321 auto-generated URLs change

Removing `description.length` from `generateCategoryPairs` had to change which pairs exist, and leaving `changeCount * 3` as the sole driver would have been worse — that is the 15.7%-coverage signal deciding who gets an SEO page. So pair selection is now one unbiased draw per category, seeded on the category name and deliberately **date-free**: rotating which URLs exist would churn the site nightly for a crawler.

That still moves 264 of 321 generated pairs. **I mitigated it rather than accepting the loss:** `/compare/:slug` now resolves any pair of known vendors, not only generated ones, and 301s the non-canonical ordering to the alphabetical one. So no previously-indexed comparison URL 404s — the generated set now only decides what we *link and sitemap*, not what exists. Three tests cover it.

Flagging one thing you did not ask about: `COMPARISON_PAIRS` is still a hand-typed list of 30-odd vendor names deciding who gets a comparison page. I left it — a comparison is not a recommendation, and those pairs track real search demand — but by your own "a list someone typed is fiat with better manners" test it deserves a verdict from you rather than from me.

### 3. `stale_verification`'s two-way reason is not derivable yet — as you suspected

You asked the reason to distinguish "not yet re-checked" from "re-check attempted and failed", with the failure count and last success date. **Nothing records that today.** `scripts/reverify-rolling.js` prints failures to stdout and keeps no per-vendor record; the commit messages carry only counts ("28 verified, 47 flagged"). So neither variant can be stated truthfully about a given offer right now.

Rather than pick the flattering one, the demerit currently states the thing that is true in both cases — *"We have not confirmed this offer against the vendor's pricing page since 2026-04-01 (146 days). This is our confidence in the record, not a change by the vendor."* — and carries `about_us: true`, which the page renders as *"(a limit of ours, not a change by the vendor)"*.

The failed-check variant is written, tested and wired to an optional `VerificationLedger` the module accepts as input. #1020 populates it and the wording upgrades automatically to *"14 consecutive re-check attempts have failed (most recently 2026-08-24 — HTTP 403), last confirmed 2026-03-01. This is our inability to verify, not a change by the vendor."* A test asserts both variants and that the two are worth the same points — the wording changes, never the rank. **This is the concrete shape of what #1020 must record**, so it is defined rather than left to be discovered.

## The `localeCompare` / file-order enumeration

You asked for every user-facing vendor list with a one-line verdict. I checked all of them rather than generalising. **Three of these are recommendation surfaces neither of us had listed**, and one of them is on the highest-traffic page on the site:

| Location | What it orders | Verdict |
|---|---|---|
| `serve.ts:1227` best-of scorer | 57 `/best/` pages | **Recommendation** — fixed in this PR |
| `serve.ts:1596` comparison pairs | which `/compare/` pages exist | **Was a lever** — fixed in this PR |
| **`serve.ts:3441`** `/vendor/:slug` alternatives | `offers.filter(...).slice(0, 12)` — **pure file order**, truncated | **Recommendation — not previously listed.** `/vendor/:slug` is 28% of page views. Part 2. |
| **`serve.ts:4006`** `/alternative-to/:slug` | risk bucket, then file order within bucket | **Recommendation — not previously listed.** The risk bucket is the coverage-biased signal we just removed from ranking. Part 2. |
| **`data.ts:626`** `checkVendorRisk()` alternatives | risk bucket then alphabetical, `.slice(0, 3)` | **Recommendation — not previously listed.** Feeds MCP and `/api/vendor-risk`. Part 2. |
| `serve.ts:50865` referral programs page | our codes first, then alphabetical | **Monetized sort** — split and labelled in part 2, per your decision |
| `serve.ts:53995` `/api/referral-programs` | alphabetical | **Inventory listing (API twin of the above)** — part 2 |
| `serve.ts:3221` `/vendor` directory | alphabetical within category, complete | **Inventory listing** — navigational, not truncated. Leave. |
| `serve.ts:48463` `/badges` | alphabetical, complete | **Inventory listing.** Leave. |
| `server.ts:777`, `server-remote.ts:614` | MCP `agentdeals://vendors`, complete | **Inventory listing.** Leave. |
| `data.ts:210/213` `searchOffers(sort:)` | caller asked for A→Z | **Neither** — the caller's own sort. Leave. |
| `data.ts:66` `getCategories()` | category names | **Neither** — not a vendor list. Leave. |
| `serve.ts:4082` risk leaderboard | recorded instability, descending | **Neither** — a disclosure ranking. Inverting it would be nonsense. Leave. |

`plan_stack`'s `publicOffers[0]` file-order fallback is the remaining one and is part 2 by your sequencing.

## Verification

- `tsc` clean. **1,323/1,323 tests pass** (62 new).
- **Every new test bite-verified against 9 mutations**, each of which fails the suite: reintroducing `description.length` as an input, seeding the tie-break on the vendor name, letting `limits_reduced` demote, restoring the hand-typed tier allowlist, dropping the eligibility gate, rewording `stale_verification` to blame the vendor, inverting the band order, making the listing rotation date-dependent, and widening the adverse-change window to forever.
- Tie-break uniformity is measured, not asserted: 3,650 consecutive dates over a 41-member tie, chi-square 36.7 against a 63.7 critical value (df=40), first and last incoming index both averaging position 20.0 of 40.
- Beyond unit tests: ran the real `dist/serve.js` and checked `/criteria` (200), `/best/free-databases` (200, 41 cards, seed recomputed independently and matched), `/best/free-ai-ml` demotions, the `/compare/` fallback and its 301, and MCP `initialize` → `tools/call` end to end.
- Visually verified both new pages with shot-scraper rather than trusting the HTML.

## Not in this PR, deliberately

`plan_stack` / `/api/stack`, the three alternatives surfaces above, the referral-programs split, and the `llms.txt` / tool-description links to `/criteria`. The criteria page says so explicitly rather than claiming a coverage it does not yet have: *"The `/api/stack` endpoint and the `plan_stack` MCP tool are being moved onto this same module; until that lands they still use a hand-written template and should not be read as ranked output."* That line comes out in part 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)