### PR TITLE
plan_stack stops naming a winner; every ranked surface now shares one module (#1025)

### DIFF
--- a/src/data.ts
+++ b/src/data.ts
@@ -3,6 +3,7 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 import type { Offer, EnrichedOffer, OfferIndex, DealChange, DealChangesIndex, StabilityClass, Referral } from "./types.js";
 import { isUrlSuspended } from "./referral-health.js";
+import { rankForListing } from "./ranking.js";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const INDEX_PATH = path.join(__dirname, "..", "data", "index.json");
@@ -75,9 +76,13 @@ export function getOfferDetails(
   const match = offers.find((o) => o.vendor.toLowerCase() === lowerName);
 
   if (match) {
-    const sameCategoryOffers = offers
-      .filter((o) => o.category === match.category && o.vendor !== match.vendor)
-      .slice(0, 5);
+    // Related vendors and alternatives are a recommendation, so they resolve
+    // through the shared selection module (#1025) rather than `.slice(0, 5)`
+    // over data/index.json order.
+    const sameCategoryOffers = rankForListing(
+      offers.filter((o) => o.category === match.category && o.vendor !== match.vendor),
+      { queryKey: `related:${match.category}:${match.vendor}`, changes: loadDealChanges() },
+    ).entries.slice(0, 5).map((e) => e.offer);
     const relatedVendors = sameCategoryOffers.map((o) => o.vendor);
     const result: Offer & { relatedVendors: string[]; alternatives?: Offer[] } = { ...match, relatedVendors };
     if (includeAlternatives) {
@@ -541,7 +546,7 @@ export interface VendorRiskResult {
   risk_level: "stable" | "caution" | "risky";
   free_tier_longevity_days: number;
   changes: DealChange[];
-  alternatives: Array<{ vendor: string; category: string; tier: string; risk_level: "stable" | "caution" | "risky" }>;
+  alternatives: Array<{ vendor: string; category: string; tier: string; risk_level: "stable" | "caution" | "risky"; demerits: Array<{ code: string; points: number; reason: string }> }>;
   summary: string;
 }
 
@@ -607,24 +612,20 @@ export function checkVendorRisk(
     Math.floor((Date.now() - longevityStart.getTime()) / (24 * 60 * 60 * 1000))
   );
 
-  // Find up to 3 more-stable alternatives in same category
-  const sameCategoryOffers = offers.filter(
-    (o) => o.category === offer.category && o.vendor !== offer.vendor
-  );
-  const alternativesWithRisk = sameCategoryOffers.map((o) => {
-    const oChanges = allChanges.filter((c) => c.vendor.toLowerCase() === o.vendor.toLowerCase());
-    return {
-      vendor: o.vendor,
-      category: o.category,
-      tier: o.tier,
-      risk_level: vendorRiskLevel(oChanges),
-    };
-  });
-  // Prefer stable > caution > risky, then alphabetical
-  const riskOrder = { stable: 0, caution: 1, risky: 2 };
-  const alternatives = alternativesWithRisk
-    .sort((a, b) => riskOrder[a.risk_level] - riskOrder[b.risk_level] || a.vendor.localeCompare(b.vendor))
-    .slice(0, 3);
+  // Up to 3 alternatives in the same category. This is a recommendation, so it
+  // resolves through the shared selection module (#1025) rather than the old
+  // "risk bucket, then alphabetical" sort — which ranked on the count of
+  // changes we happen to have recorded and broke ties with the alphabet.
+  const alternatives = rankForListing(
+    offers.filter((o) => o.category === offer.category && o.vendor !== offer.vendor),
+    { queryKey: `vendor-risk-alternatives:${offer.vendor}`, changes: allChanges },
+  ).entries.slice(0, 3).map((e) => ({
+    vendor: e.offer.vendor,
+    category: e.offer.category,
+    tier: e.offer.tier,
+    risk_level: vendorRiskLevel(allChanges.filter((c) => c.vendor.toLowerCase() === e.offer.vendor.toLowerCase())),
+    demerits: e.demerits.map((d) => ({ code: d.code, points: d.points, reason: d.reason })),
+  }));
 
   // Build summary
   let summary: string;

--- a/src/openapi.ts
+++ b/src/openapi.ts
@@ -575,15 +575,15 @@ export const openapiSpec = {
     },
     "/api/stack": {
       get: {
-        summary: "Get free-tier stack recommendation",
-        description: "Returns a curated infrastructure stack recommendation based on your project type. Covers hosting, database, auth, and more — all free tier.",
+        summary: "Get free-tier stack candidates per role",
+        description: "For each role in your project type (hosting, database, auth, …) returns the set of free-tier offers whose terms we can stand behind today — deliberately not a single pick, because under every signal we record dozens of them tie. Each candidate carries its demerits, with the recorded fact and date behind each, plus any recorded changes we disclose but do not rank on. This endpoint does NOT model technical fit between a product and a role; the caller must apply that. The method is published at /criteria, and every role returns the tie_break seed so its order can be recomputed independently.",
         parameters: [
           { name: "use_case", in: "query", required: true, description: "What you're building (e.g., 'Next.js SaaS app', 'API backend', 'static blog')", schema: { type: "string" }, example: "Next.js SaaS app" },
           { name: "requirements", in: "query", description: "Comma-separated infrastructure needs (e.g., 'database,auth,email')", schema: { type: "string" }, example: "database,auth,email" }
         ],
         responses: {
           "200": {
-            description: "Stack recommendation",
+            description: "Candidate sets per role, with the evidence behind each",
             content: {
               "application/json": {
                 schema: {
@@ -596,13 +596,33 @@ export const openapiSpec = {
                         type: "object",
                         properties: {
                           role: { type: "string" },
-                          vendor: { type: "string" },
-                          tier: { type: "string" },
-                          description: { type: "string" },
-                          url: { type: "string", format: "uri" }
+                          category: { type: "string" },
+                          candidates: {
+                            type: "array",
+                            description: "The rotated tied set for this role, capped at 8. Not ordered by merit — every member is indistinguishable under our criteria.",
+                            items: {
+                              type: "object",
+                              properties: {
+                                vendor: { type: "string" },
+                                tier: { type: "string" },
+                                description: { type: "string" },
+                                url: { type: "string", format: "uri" },
+                                verified_date: { type: "string", format: "date" },
+                                demerits: { type: "array", description: "Empty when we hold nothing against the offer.", items: { type: "object", properties: { code: { type: "string" }, points: { type: "integer" }, reason: { type: "string" }, date: { type: "string" }, about_us: { type: "boolean", description: "True when the demerit describes a limit of ours rather than a fact about the vendor." } } } },
+                                disclosures: { type: "array", description: "Recorded changes shown but never ranked on.", items: { type: "object", properties: { code: { type: "string" }, date: { type: "string" }, summary: { type: "string" } } } }
+                              }
+                            }
+                          },
+                          tie_count: { type: "integer", description: "How many offers tie at zero demerits in this role." },
+                          eligible_count: { type: "integer" },
+                          demoted_count: { type: "integer" },
+                          excluded_count: { type: "integer" },
+                          reason: { type: "string" },
+                          tie_break: { type: "object", properties: { date: { type: "string" }, query_key: { type: "string" }, seed: { type: "string" }, tie_count: { type: "integer" }, algorithm: { type: "string" } } }
                         }
                       }
                     },
+                    method: { type: "object", properties: { policy: { type: "string" }, not_modelled: { type: "string" }, criteria_url: { type: "string" } } },
                     total_monthly_cost: { type: "string" },
                     limitations: { type: "array", items: { type: "string" } },
                     upgrade_path: { type: "string" }

--- a/src/ranking.ts
+++ b/src/ranking.ts
@@ -548,3 +548,49 @@ export function rankOffers<T extends Offer>(candidates: T[], opts: RankOptions):
 export function rotateListing<T>(items: T[], queryKey: string, date?: string): T[] {
   return seededShuffle(items, tieBreakSeed(date ?? "", queryKey, 0));
 }
+
+export interface ListedEntry<T> extends RankedEntry<T> {
+  /** Set when a gate applies. The entry is listed last, with the gate stated. */
+  gate?: Gate;
+}
+
+export interface ListingResult<T> {
+  entries: ListedEntry<T>[];
+  qualified_count: number;
+  demoted_count: number;
+  gated_count: number;
+  tie_break: TieBreak;
+}
+
+/**
+ * Rank a "what else could fill this need" list, e.g. the alternatives on a
+ * vendor page.
+ *
+ * Same ranking, one difference: a gated offer is moved to the end with its
+ * gate stated rather than removed. A `/best/` page claims *every free X that
+ * clears our bar*, so an offer that does not clear the bar has no business on
+ * it. An alternatives list claims *the other things in this category*, and
+ * dropping them silently would empty 91 of these pages — every vendor whose
+ * category peers are all eligibility-restricted, which is most of the startup
+ * and fintech programmes. Listing them with "requires accelerator/student
+ * qualification" attached tells the reader more than hiding them does.
+ */
+export function rankForListing<T extends Offer>(candidates: T[], opts: RankOptions): ListingResult<T> {
+  const date = opts.date ?? utcDate();
+  const result = rankOffers(candidates, { ...opts, date });
+  // One band past the worst demerit total, so the gated tail gets its own
+  // permutation and can never be interleaved with rankable offers.
+  const gatedBand = result.ranked.reduce((max, e) => Math.max(max, e.demerit_total), 0) + 1;
+  const gatedTail: ListedEntry<T>[] = seededShuffle(
+    result.excluded,
+    tieBreakSeed(date, opts.queryKey, gatedBand),
+  ).map((e) => ({ offer: e.offer, demerits: [], demerit_total: gatedBand, disclosures: [], gate: e.gate }));
+
+  return {
+    entries: [...result.ranked, ...gatedTail],
+    qualified_count: result.qualified.length,
+    demoted_count: result.demoted.length,
+    gated_count: result.excluded.length,
+    tie_break: result.tie_break,
+  };
+}

--- a/src/serve.ts
+++ b/src/serve.ts
@@ -21,7 +21,7 @@ import { runHealthCheck, getLastReport, startPeriodicChecks } from "./referral-h
 import { addFriend, removeFriend, getFriends, getFriendCodesForVendors } from "./friends.js";
 import { subscribe as watchlistSubscribe, getSubscription as getWatchlistSubscription, unsubscribe as watchlistUnsubscribe, listSubscriptions as listWatchlistSubscriptions } from "./watchlist.js";
 import { toSlug, vendorSlugMap, resolveVendorSlug } from "./vendor-slug.js";
-import { rankOffers, rotateListing, utcDate, CRITERIA_PATH, DEMOTE_ONLY_POLICY, DISCLOSURE_RATIONALE, TIE_BREAK_ALGORITHM, GATE_TABLE, DEMERIT_TABLE, NOT_FREE_TIER_RULES, TIME_LIMITED_TIER_RULES } from "./ranking.js";
+import { rankOffers, rankForListing, rotateListing, utcDate, CRITERIA_PATH, DEMOTE_ONLY_POLICY, DISCLOSURE_RATIONALE, TIE_BREAK_ALGORITHM, GATE_TABLE, DEMERIT_TABLE, NOT_FREE_TIER_RULES, TIME_LIMITED_TIER_RULES } from "./ranking.js";
 import type { RankedEntry, RankingResult } from "./ranking.js";
 import type { Agent } from "./types.js";
 import type { AgentBalance } from "./ledger.js";
@@ -1680,7 +1680,7 @@ ${globalNavCss()}
   <h1>How we rank &mdash; in full</h1>
   <p class="lede">${escHtmlServer(DEMOTE_ONLY_POLICY)}</p>
 
-  <p>The <a href="/best">best-of pages</a> resolve through one shared module. There is no second scorer, no per-page ordering, no vendor allowlist, pin, boost or override anywhere in the selection path. Nothing derived from our own editorial copy is an input: an offer cannot rank higher because we wrote more words about it. <em>The <code>/api/stack</code> endpoint and the <code>plan_stack</code> MCP tool are being moved onto this same module; until that lands they still use a hand-written template and should not be read as ranked output.</em></p>
+  <p>Every surface that presents vendors as a recommendation &mdash; the <a href="/best">best-of pages</a>, the alternatives on every vendor page, the <code>/api/stack</code> endpoint and the <code>plan_stack</code> MCP tool &mdash; resolves through one shared module. There is no second scorer, no per-page ordering, no vendor allowlist, pin, boost or override anywhere in the selection path. Nothing derived from our own editorial copy is an input: an offer cannot rank higher because we wrote more words about it.</p>
 
   <h2>1. Gates &mdash; what is excluded, and why</h2>
   <p>A gate removes an offer from ranked surfaces entirely. It still appears on its category page and its vendor page; it is simply not something we would put in front of you as a recommendation.</p>
@@ -3438,9 +3438,14 @@ function buildVendorPage(slug: string): string | null {
   const stability = enriched.stability ?? "stable";
 
   // Alternatives: other vendors in the same primary category
-  const alternatives = offers
-    .filter(o => o.category === primary.category && o.vendor !== vendorName)
-    .slice(0, 12);
+  // "Alternatives to X" is a recommendation, so it goes through the shared
+  // module. It used to be `.slice(0, 12)` over raw file order — whoever was
+  // typed into data/index.json first won, on the single highest-traffic page
+  // type on the site.
+  const alternatives = rankForListing(
+    offers.filter(o => o.category === primary.category && o.vendor !== vendorName),
+    { queryKey: `alternatives:${primary.category}:${vendorName}`, changes: dealChanges },
+  ).entries.slice(0, 12).map(e => e.offer);
 
   // Comparison pages featuring this vendor
   const vendorComparisons = Array.from(comparisonMap.entries())
@@ -4010,10 +4015,16 @@ function buildAlternativesPage(slug: string): string | null {
       dedupedAlts.push(a);
     }
   }
-  // Enrich and sort by stability (stable first, then caution, then risky)
-  const enrichedAlts = enrichOffers(dedupedAlts);
-  const riskOrder: Record<string, number> = { stable: 0, caution: 1, risky: 2 };
-  enrichedAlts.sort((a, b) => (riskOrder[a.risk_level ?? "stable"] ?? 3) - (riskOrder[b.risk_level ?? "stable"] ?? 3));
+  // Order through the shared module. This used to sort by the derived
+  // risk_level bucket — the count-of-recorded-changes signal that demotes
+  // prominent vendors 3.2x more often than obscure ones — with file order
+  // deciding everything inside a bucket.
+  const altRanking = rankForListing(enrichOffers(dedupedAlts), {
+    queryKey: `alternative-to:${vendorName}`,
+    changes: dealChanges,
+  });
+  const enrichedAlts = altRanking.entries.map(e => e.offer);
+  const altDemerits = new Map(altRanking.entries.map(e => [e.offer.vendor, e]));
 
   // Deal-change-driven alternatives (editorially curated)
   const curatedAltNames = new Set<string>();
@@ -4082,6 +4093,8 @@ function buildAlternativesPage(slug: string): string | null {
           <a href="/vendor/${aSlug}" class="action-link">Profile</a>
           ${hasComparison ? `<a href="/compare/${compSlug}" class="action-link">Compare</a>` : ""}
         </div>
+        ${(altDemerits.get(a.vendor)?.demerits ?? []).map(d => `<div class="alt-demerit"><strong>&minus;${d.points} ${escHtmlServer(d.code)}</strong> ${escHtmlServer(d.reason)}</div>`).join("")}
+        ${altDemerits.get(a.vendor)?.gate ? `<div class="alt-demerit"><strong>${escHtmlServer(altDemerits.get(a.vendor)!.gate!.code)}</strong> ${escHtmlServer(altDemerits.get(a.vendor)!.gate!.reason)}</div>` : ""}
         ${a.referral ? `<div class="alt-referral"><span>\ud83d\udd17 <a href="${escHtmlServer(a.referral.url)}" rel="noopener sponsored" target="_blank">${escHtmlServer(a.referral.referee_value ?? "Save with our referral link")}</a></span> <a href="/disclosure" class="alt-referral-disc">(disclosure)</a></div>` : ""}
       </div>`;
   }
@@ -4100,7 +4113,7 @@ ${curatedAlts.map(a => altCard(a, true)).join("\n")}
   const allAltsHtml = enrichedAlts.length > 0 ? `
   <div class="section">
     <h2>All Free Alternatives (${enrichedAlts.length})</h2>
-    <p class="section-note">Sorted by stability &mdash; most stable first.</p>
+    <p class="section-note">${altRanking.qualified_count} of these carry no recorded demerit and are indistinguishable under every signal we hold; their order rotates daily. ${altRanking.demoted_count} are demoted with the reason named, and ${altRanking.gated_count} are listed last because they are not generally available or are not a free offer. <a href="${CRITERIA_PATH}">How we rank</a>.</p>
     <div class="alt-list">
 ${enrichedAlts.map(a => altCard(a, false)).join("\n")}
     </div>
@@ -4240,6 +4253,8 @@ h3{font-family:var(--serif);font-size:1rem;color:var(--text);margin-bottom:.5rem
 .alt-referral a{color:#3fb950}
 .alt-referral a:hover{color:#6fdd8b}
 .alt-referral-disc{font-size:.7rem;color:var(--text-dim)!important}
+.alt-demerit{grid-column:1/-1;font-size:.75rem;color:var(--text-muted);padding:.3rem 0 .1rem .6rem;border-left:2px solid #d29922;margin-top:.35rem}
+.alt-demerit strong{font-family:var(--mono);color:#d29922}
 .action-pill{display:inline-block;padding:.35rem .75rem;border:1px solid var(--border);border-radius:20px;font-size:.8rem;color:var(--text-muted);transition:all .2s}
 .action-pill:hover{border-color:var(--accent);color:var(--text);text-decoration:none}
 .no-changes{color:var(--text-dim);font-size:.9rem;font-style:italic}
@@ -50859,14 +50874,25 @@ function buildReferralProgramsPage(): string {
       });
     }
   }
-  // Sort: vendors with our codes first, then alphabetical
-  programVendors.sort((a, b) => {
-    if (a.hasCode !== b.hasCode) return a.hasCode ? -1 : 1;
-    return a.vendor.localeCompare(b.vendor);
-  });
+  /**
+   * This page used to be one list sorted "vendors we hold a referral code for
+   * first, then alphabetical" — so the page about referral programmes was
+   * ordered by our commercial interest in them, silently.
+   *
+   * Separation plus labelling beats hidden ordering. We do have commercial
+   * relationships; they just don't get to be invisible. Within each section the
+   * order comes from the shared unbiased rotation rather than the alphabet,
+   * which is the bias we are removing everywhere else. This is an inventory
+   * listing, not a quality ranking, so it does not go through the demerit
+   * model — that would be a category error.
+   */
+  const paidSection = rotateListing(programVendors.filter(v => v.hasCode), "referral-programs:with-code");
+  const unpaidSection = rotateListing(programVendors.filter(v => !v.hasCode), "referral-programs:without-code");
+  programVendors.length = 0;
+  programVendors.push(...paidSection, ...unpaidSection);
 
-  const withCodes = programVendors.filter(v => v.hasCode).length;
-  const withoutCodes = programVendors.length - withCodes;
+  const withCodes = paidSection.length;
+  const withoutCodes = unpaidSection.length;
 
   // Group by category
   const categoryGroups = new Map<string, typeof programVendors>();
@@ -50927,7 +50953,7 @@ function buildReferralProgramsPage(): string {
   const typeLabel = (t: string) => t === "self-service" ? "Self-service" : t === "affiliate-network" ? "Affiliate network" : t === "partner" ? "Partner" : "Application";
   const commLabel = (c?: string) => c === "recurring" ? "Recurring" : c === "credits" ? "Credits" : c === "one-time" ? "One-time" : "";
 
-  const tableRows = programVendors.map(v => {
+  const renderRows = (list: typeof programVendors) => list.map(v => {
     const vendorSlug = toSlug(v.vendor);
     const statusHtml = v.hasCode
       ? `<a href="${escHtmlServer(v.referralUrl!)}" rel="noopener sponsored" target="_blank" class="status-badge status-active">Use our code</a>`
@@ -50943,6 +50969,19 @@ function buildReferralProgramsPage(): string {
         <td class="link-cell">${linkHtml}</td>
       </tr>`;
   }).join("\n");
+  const paidRows = renderRows(paidSection);
+  const unpaidRows = renderRows(unpaidSection);
+  const tableHead = `    <thead>
+      <tr>
+        <th>Vendor</th>
+        <th>Category</th>
+        <th>Referee Benefit</th>
+        <th>Referrer Benefit</th>
+        <th>Type</th>
+        <th>Status</th>
+        <th>Link</th>
+      </tr>
+    </thead>`;
 
   return `<!DOCTYPE html>
 <html lang="en">
@@ -50995,6 +51034,8 @@ h1{font-family:var(--serif);font-size:2.25rem;color:var(--text);margin:1rem 0 .5
 .status-submit{background:var(--accent-glow);color:var(--accent);border:1px solid rgba(59,130,246,0.3)}
 .status-submit:hover{text-decoration:none;border-color:var(--accent)}
 .disclosure{font-size:.8rem;color:var(--text-dim);margin-bottom:2rem;padding:.75rem 1rem;border:1px solid var(--border);border-radius:8px;background:var(--bg-card)}
+.section-heading{font-size:1.15rem;color:var(--text);margin:2.5rem 0 .35rem;letter-spacing:-.01em}
+.section-note{color:var(--text-muted);font-size:.85rem;margin-bottom:1rem}
 .disclosure a{color:var(--text-muted)}
 .agent-cta{margin:2rem 0;padding:1.5rem;border:1px solid var(--accent);border-radius:12px;background:var(--accent-glow);text-align:center}
 .agent-cta h2{font-family:var(--serif);font-size:1.3rem;margin-bottom:.5rem}
@@ -51045,20 +51086,21 @@ ${mcpCtaCss()}
     ${categoryFilterButtons}
   </div>
 
+  <h2 class="section-heading">Programs we have a referral link for &mdash; we may earn a commission</h2>
+  <p class="section-note">${withCodes} of ${programVendors.length}. If you sign up through the &ldquo;Use our code&rdquo; link we may be paid for it. See our <a href="/disclosure">affiliate disclosure</a>. Within this section the order is the same unbiased daily rotation we use everywhere else &mdash; not by how much any of them pays us. <a href="${CRITERIA_PATH}">How we order lists</a>.</p>
   <table class="programs-table">
-    <thead>
-      <tr>
-        <th>Vendor</th>
-        <th>Category</th>
-        <th>Referee Benefit</th>
-        <th>Referrer Benefit</th>
-        <th>Type</th>
-        <th>Status</th>
-        <th>Link</th>
-      </tr>
-    </thead>
+${tableHead}
     <tbody>
-${tableRows}
+${paidRows}
+    </tbody>
+  </table>
+
+  <h2 class="section-heading">Programs we don&rsquo;t have a referral link for</h2>
+  <p class="section-note">${withoutCodes} of ${programVendors.length}. We earn nothing from these. They are here because the programme exists, not because of any relationship with us.</p>
+  <table class="programs-table">
+${tableHead}
+    <tbody>
+${unpaidRows}
     </tbody>
   </table>
 
@@ -53155,15 +53197,26 @@ function copyConfig(btn){
         var html='<div class="sb-stack">';
         for(var i=0;i<data.stack.length;i++){
           var s=data.stack[i];
-          var vendorSlug=s.vendor.toLowerCase().replace(/[^a-z0-9]+/g,'-').replace(/^-|-$/g,'');
+          var cands=s.candidates||[];
+          var links='';
+          for(var k=0;k<cands.length;k++){
+            var c=cands[k];
+            var vendorSlug=c.vendor.toLowerCase().replace(/[^a-z0-9]+/g,'-').replace(/^-|-$/g,'');
+            var flag=(c.demerits&&c.demerits.length>0)?' <span style="color:#d29922;font-size:.7rem">&minus;'+c.demerits.length+'</span>':'';
+            links+=(k>0?', ':'')+'<a href="/vendor/'+escHtml(vendorSlug)+'">'+escHtml(c.vendor)+'</a>'+flag;
+          }
+          var tieText=s.tie_count>cands.length
+            ? cands.length+' of '+s.tie_count+' equally-qualified options, rotated daily'
+            : cands.length+' option'+(cands.length===1?'':'s');
           html+='<div class="sb-item">'
             +'<span class="sb-role">'+escHtml(s.role)+'</span>'
             +'<div class="sb-detail">'
-            +'<div class="sb-vendor"><a href="/vendor/'+escHtml(vendorSlug)+'">'+escHtml(s.vendor)+'</a> <span style="color:var(--text-dim);font-size:.8rem">'+escHtml(s.tier)+'</span></div>'
-            +'<div class="sb-desc">'+escHtml(s.description)+'</div>'
+            +'<div class="sb-vendor">'+links+'</div>'
+            +'<div class="sb-desc">'+escHtml(tieText)+'</div>'
             +'</div></div>';
         }
         html+='</div>';
+        html+='<p style="color:var(--text-dim);font-size:.78rem;margin-top:.75rem">We rank on offer terms, verification recency and recorded changes &mdash; not on which product fits your architecture. <a href="/criteria">How we rank</a>.</p>';
         if(data.limitations&&data.limitations.length>0){
           html+='<div class="sb-meta"><div class="sb-meta-row"><span class="sb-meta-label">Monthly cost</span><span class="sb-meta-value">'+escHtml(data.total_monthly_cost)+'</span></div>';
           html+='<ul class="sb-limits">';
@@ -53992,7 +54045,11 @@ const httpServer = createHttpServer(async (req, res) => {
         }
       }
     }
-    refPrograms.sort((a, b) => a.vendor.localeCompare(b.vendor));
+    // Inventory listing, ordered by the shared unbiased rotation rather than
+    // the alphabet — the same treatment as the rendered /referral-programs page.
+    const refOrdered = rotateListing(refPrograms, "referral-programs:api");
+    refPrograms.length = 0;
+    refPrograms.push(...refOrdered);
     const refCategories = [...new Set(refPrograms.map(p => p.category))].sort();
     logRequest({ ts: new Date().toISOString(), type: "api", endpoint: "/api/referral-programs", params: { category: refCategoryFilter }, user_agent: req.headers["user-agent"] ?? "unknown", result_count: refPrograms.length });
     res.writeHead(200, { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" });
@@ -54200,10 +54257,14 @@ ${weekEntries.join("\n")}
 
 AgentDeals helps developers find free tiers, startup credits, and deals on developer infrastructure — databases, cloud hosting, CI/CD, monitoring, auth, AI services, and more. Data is verified and includes specific free tier limits, eligibility requirements, and pricing change history.
 
+## How ranking works — read this before trusting an order
+
+Recommendations are not for sale. Every ranked surface resolves through one module in which offers start at zero and can only be demoted, on a specific recorded fact with a date. There is no signal a vendor can acquire, lobby for or buy. Because almost nothing separates one healthy free tier from another, large ties are the normal case — 0 of 57 categories has a unique number one — and tied offers are ordered by a permutation seeded on the UTC date and the query key alone. Every ranked response publishes that seed so you can recompute the order yourself. We do NOT model technical fit between a product and a role; apply that yourself. Full method: ${BASE_URL}${CRITERIA_PATH}
+
 ## MCP Tools (4)
 
 - **search_deals**: Find free tiers, startup credits, and developer deals. Search by keyword, category, vendor name, or eligibility type. Returns verified deal details with specific limits.
-- **plan_stack**: Plan a technology stack with cost-optimized choices. Recommends free-tier services, estimates costs at scale, or audits existing stacks for risk.
+- **plan_stack**: Plan a technology stack with cost-optimized choices. Per role, returns the set of free-tier offers whose terms we can stand behind today — not a single pick — with the recorded facts behind any demotion. Does not model technical fit; the caller applies that. Also estimates costs at scale and audits existing stacks for risk.
 - **compare_vendors**: Compare developer tools side by side — free tier limits, pricing tiers, risk levels, and recent pricing changes.
 - **track_changes**: Track pricing changes across developer tools — free tier removals, limit reductions, new free tiers, and upcoming expirations.
 
@@ -54225,6 +54286,7 @@ AgentDeals helps developers find free tiers, startup credits, and deals on devel
 
 ## Links
 
+- [How we rank — published criteria](${BASE_URL}${CRITERIA_PATH})
 - [REST API Developer Hub](${BASE_URL}/developers)
 - [API Documentation (Swagger)](${BASE_URL}/api/docs)
 - [Setup Guide](${BASE_URL}/setup)

--- a/src/server.ts
+++ b/src/server.ts
@@ -224,7 +224,7 @@ export function createServer(getSessionId?: () => string | undefined, getClientN
     "plan_stack",
     {
       description:
-        "Plan a technology stack with cost-optimized infrastructure choices. Given project requirements, recommends services with free tiers or credits that match your needs. Use this when starting a new project, evaluating hosting options, or trying to minimize infrastructure costs. Call this tool when a user asks: 'What free tools can I use for a SaaS app?', 'Build me a stack under $50/month'.",
+        "Plan a technology stack with cost-optimized infrastructure choices. In recommend mode this returns, for each role, the set of offers whose terms we can stand behind today — deliberately not a single pick, because under every signal we record dozens of them tie. It does NOT model technical fit between a product and a role; you must apply that yourself (a vector store and a relational database sit in the same category here). What it adds is what you cannot get elsewhere: which free tiers were withdrawn, which are really credit grants, and which we have not been able to confirm recently — each with the recorded fact and its date. Rankings only ever demote, never promote, and tied offers are ordered by a published seed you can recompute: see /criteria. Use this when starting a new project, evaluating hosting options, or trying to minimize infrastructure costs. Call this tool when a user asks: 'What free tools can I use for a SaaS app?', 'Build me a stack under $50/month'.",
       annotations: {
         readOnlyHint: true,
         destructiveHint: false,

--- a/src/stacks.ts
+++ b/src/stacks.ts
@@ -1,100 +1,160 @@
 import { searchOffers, loadDealChanges, vendorRiskLevel, classifyStability } from "./data.js";
+import { rankOffers, utcDate, CRITERIA_PATH, DEMOTE_ONLY_POLICY, NOT_MODELLED_NOTICE } from "./ranking.js";
+import type { Demerit, Disclosure, TieBreak } from "./ranking.js";
 import type { Offer, StabilityClass, DealChange } from "./types.js";
 
-export interface StackComponent {
-  role: string;
+/**
+ * plan_stack no longer answers "what should I use".
+ *
+ * It used to: a hand-written TEMPLATES table listed preferred vendors per role
+ * and `findBestOffer()` returned the first one present in the catalog, so
+ * Supabase won every database slot in every template because someone typed it
+ * first. The fallback when no preferred vendor matched was `publicOffers[0]` —
+ * index order in the JSON file.
+ *
+ * Deleting the preference list on its own made the answer worse, not better:
+ * scored purely on offer terms, a Next.js SaaS app got Chroma (a vector store)
+ * as its database and Integrately (an automation tool) as its hosting. The
+ * templates were carrying real technical fit that our category taxonomy cannot
+ * express, and no amount of ranking recovers it.
+ *
+ * So the question changed instead. Our caller is a language model that already
+ * knows Chroma is a vector store; that knowledge is free and abundant and we
+ * add nothing by supplying it. What it cannot get anywhere else is that a given
+ * free tier was withdrawn in March, or that nobody has been able to confirm
+ * this one for 142 days. This tool now answers: *of the things that can fill
+ * this role, which ones have terms we can stand behind today, and what exactly
+ * is wrong with the rest.* The caller applies fit; we apply terms.
+ */
+
+export interface StackCandidate {
   vendor: string;
   tier: string;
   description: string;
   url: string;
+  verified_date: string;
   risk_level: "stable" | "caution" | "risky";
   stability: StabilityClass;
+  /** Empty for a candidate we hold nothing against. */
+  demerits: Demerit[];
+  /** Recorded facts shown wherever the offer appears; they never move rank. */
+  disclosures: Disclosure[];
+}
+
+export interface StackRole {
+  role: string;
+  category: string;
+  /** The rotated tied set, capped. Deliberately not a single pick. */
+  candidates: StackCandidate[];
+  /** How many offers tie at zero demerits — the size of the band we drew from. */
+  tie_count: number;
+  eligible_count: number;
+  demoted_count: number;
+  excluded_count: number;
+  /** Why these, in words, with the numbers behind it. */
+  reason: string;
+  tie_break: TieBreak;
 }
 
 export interface StackRecommendation {
   use_case: string;
-  stack: StackComponent[];
+  stack: StackRole[];
   total_monthly_cost: string;
   limitations: string[];
   upgrade_path: string;
   risk_warnings: string[];
+  method: {
+    policy: string;
+    not_modelled: string;
+    criteria_url: string;
+  };
 }
+
+/** How many of a tied band to return per role. A page size, not a ranking. */
+const CANDIDATES_PER_ROLE = 8;
 
 interface StackTemplate {
   keywords: string[];
-  roles: { role: string; category: string; preferredVendors?: string[] }[];
+  roles: { role: string; category: string }[];
   upgrade_path: string;
 }
 
+/**
+ * Templates define roles and the category each role draws from. They no longer
+ * name winners: `preferredVendors` is deleted rather than repointed, because
+ * retyping the fiat is not the fix. The upgrade-path strings lost their vendor
+ * names for the same reason — they were naming the same hardcoded winners in
+ * prose.
+ */
 const TEMPLATES: StackTemplate[] = [
   {
     keywords: ["saas", "web app", "webapp", "next.js", "nextjs", "react app", "full-stack", "fullstack"],
     roles: [
-      { role: "Hosting", category: "Cloud Hosting", preferredVendors: ["Vercel", "Netlify", "Railway"] },
-      { role: "Database", category: "Databases", preferredVendors: ["Supabase", "Neon", "PlanetScale"] },
-      { role: "Auth", category: "Auth", preferredVendors: ["Clerk", "Auth0", "Supabase"] },
-      { role: "Email", category: "Email", preferredVendors: ["Resend", "SendGrid", "Mailgun"] },
+      { role: "Hosting", category: "Cloud Hosting" },
+      { role: "Database", category: "Databases" },
+      { role: "Auth", category: "Auth" },
+      { role: "Email", category: "Email" },
     ],
-    upgrade_path: "Vercel Pro ($20/mo) + Supabase Pro ($25/mo) for production workloads",
+    upgrade_path: "Paid hosting and a managed database typically start around $20-25/mo each for production workloads",
   },
   {
     keywords: ["api", "backend", "server", "express", "fastapi", "python api", "node api", "rest api"],
     roles: [
-      { role: "Hosting", category: "Cloud Hosting", preferredVendors: ["Railway", "Render", "Fly.io"] },
-      { role: "Database", category: "Databases", preferredVendors: ["Supabase", "Neon", "CockroachDB"] },
-      { role: "Monitoring", category: "Monitoring", preferredVendors: ["Grafana Cloud", "Betterstack", "Checkly"] },
-      { role: "Logging", category: "Logging", preferredVendors: ["Betterstack", "Logflare", "Axiom"] },
+      { role: "Hosting", category: "Cloud Hosting" },
+      { role: "Database", category: "Databases" },
+      { role: "Monitoring", category: "Monitoring" },
+      { role: "Logging", category: "Logging" },
     ],
-    upgrade_path: "Railway Starter ($5/mo) + managed database for production traffic",
+    upgrade_path: "Expect roughly $5-20/mo for hosting plus a managed database once you outgrow a free tier",
   },
   {
     keywords: ["static", "blog", "landing page", "portfolio", "docs", "documentation", "jamstack"],
     roles: [
-      { role: "Hosting", category: "CDN", preferredVendors: ["Cloudflare Pages", "Netlify", "Vercel"] },
-      { role: "DNS", category: "DNS & Domain Management", preferredVendors: ["Cloudflare", "Namecheap"] },
-      { role: "CI/CD", category: "CI/CD", preferredVendors: ["GitHub Actions", "Cloudflare Pages", "Netlify"] },
+      { role: "Hosting", category: "CDN" },
+      { role: "DNS", category: "DNS & Domain Management" },
+      { role: "CI/CD", category: "CI/CD" },
     ],
     upgrade_path: "Most static hosting free tiers are generous enough for production",
   },
   {
     keywords: ["mobile", "ios", "android", "react native", "flutter", "mobile app"],
     roles: [
-      { role: "Backend", category: "Cloud Hosting", preferredVendors: ["Supabase", "Firebase", "Railway"] },
-      { role: "Database", category: "Databases", preferredVendors: ["Supabase", "Firebase", "MongoDB Atlas"] },
-      { role: "Auth", category: "Auth", preferredVendors: ["Firebase", "Supabase", "Auth0"] },
-      { role: "Push Notifications", category: "Communication", preferredVendors: ["Firebase", "OneSignal"] },
+      { role: "Backend", category: "Cloud Hosting" },
+      { role: "Database", category: "Databases" },
+      { role: "Auth", category: "Auth" },
+      { role: "Push Notifications", category: "Communication" },
     ],
-    upgrade_path: "Firebase Blaze (pay-as-you-go) or Supabase Pro ($25/mo) for production",
+    upgrade_path: "Backend-as-a-service paid tiers generally start around $25/mo for production",
   },
   {
     keywords: ["ai", "ml", "machine learning", "llm", "chatbot", "ai app", "ai agent"],
     roles: [
-      { role: "AI/ML", category: "AI / ML", preferredVendors: ["OpenAI", "Google Gemini API", "Anthropic", "Groq"] },
-      { role: "Hosting", category: "Cloud Hosting", preferredVendors: ["Railway", "Render", "Fly.io"] },
-      { role: "Database", category: "Databases", preferredVendors: ["Supabase", "Neon", "Upstash"] },
+      { role: "AI/ML", category: "AI / ML" },
+      { role: "Hosting", category: "Cloud Hosting" },
+      { role: "Database", category: "Databases" },
     ],
     upgrade_path: "AI API costs scale with usage; budget $20-50/mo for moderate LLM traffic",
   },
   {
     keywords: ["ecommerce", "e-commerce", "store", "shop", "marketplace"],
     roles: [
-      { role: "Hosting", category: "Cloud Hosting", preferredVendors: ["Vercel", "Netlify", "Railway"] },
-      { role: "Database", category: "Databases", preferredVendors: ["Supabase", "PlanetScale", "Neon"] },
-      { role: "Payments", category: "Payments", preferredVendors: ["Stripe", "LemonSqueezy"] },
-      { role: "Auth", category: "Auth", preferredVendors: ["Clerk", "Auth0", "Supabase"] },
-      { role: "Email", category: "Email", preferredVendors: ["Resend", "SendGrid"] },
+      { role: "Hosting", category: "Cloud Hosting" },
+      { role: "Database", category: "Databases" },
+      { role: "Payments", category: "Payments" },
+      { role: "Auth", category: "Auth" },
+      { role: "Email", category: "Email" },
     ],
-    upgrade_path: "Stripe fees are per-transaction (2.9% + $0.30); hosting/DB ~$45/mo for production",
+    upgrade_path: "Payment processing is per-transaction; hosting and a database run about $45/mo for production",
   },
   {
     keywords: ["devops", "infrastructure", "platform", "internal tool"],
     roles: [
-      { role: "CI/CD", category: "CI/CD", preferredVendors: ["GitHub Actions", "GitLab CI", "CircleCI"] },
-      { role: "Container Registry", category: "Container Registry", preferredVendors: ["GitHub Container Registry", "Docker Hub"] },
-      { role: "Monitoring", category: "Monitoring", preferredVendors: ["Grafana Cloud", "Betterstack", "UptimeRobot"] },
-      { role: "Error Tracking", category: "Error Tracking", preferredVendors: ["Sentry", "GlitchTip"] },
+      { role: "CI/CD", category: "CI/CD" },
+      { role: "Container Registry", category: "Container Registry" },
+      { role: "Monitoring", category: "Monitoring" },
+      { role: "Error Tracking", category: "Error Tracking" },
     ],
-    upgrade_path: "GitHub Team ($4/user/mo) + Grafana Cloud Pro for larger teams",
+    upgrade_path: "Per-seat pricing dominates here once a team grows past the free seat count",
   },
 ];
 
@@ -128,28 +188,6 @@ const ROLE_TO_CATEGORY: Record<string, string> = {
   push: "Communication",
 };
 
-function findBestOffer(category: string, preferredVendors?: string[]): Offer | null {
-  const offers = searchOffers(undefined, category);
-  // Only consider public/free offers
-  const publicOffers = offers.filter(
-    (o) => o.tier === "Free" || o.tier === "Hobby" || o.tier === "Open Source" || o.tier === "Free Credits"
-  );
-  if (publicOffers.length === 0) return offers[0] ?? null;
-
-  // Try preferred vendors first
-  if (preferredVendors) {
-    for (const vendor of preferredVendors) {
-      const match = publicOffers.find(
-        (o) => o.vendor.toLowerCase() === vendor.toLowerCase()
-      );
-      if (match) return match;
-    }
-  }
-
-  // Fall back to first public free-tier offer
-  return publicOffers[0];
-}
-
 function matchTemplate(useCase: string): StackTemplate | null {
   const lower = useCase.toLowerCase();
   let bestMatch: StackTemplate | null = null;
@@ -171,34 +209,74 @@ function matchTemplate(useCase: string): StackTemplate | null {
   return bestMatch;
 }
 
-function buildLimitations(stack: StackComponent[]): string[] {
-  const limitations: string[] = [];
-  for (const component of stack) {
-    // Extract key limitations from description
-    const desc = component.description.toLowerCase();
-    if (desc.includes("hobby") || desc.includes("non-commercial")) {
-      limitations.push(`${component.vendor} free tier may restrict commercial use`);
-    }
-    if (desc.includes("pause") || desc.includes("sleep") || desc.includes("inactive")) {
-      limitations.push(`${component.vendor} may pause after inactivity`);
+function buildLimitations(roles: StackRole[]): string[] {
+  const limitations = new Set<string>();
+  for (const role of roles) {
+    for (const c of role.candidates) {
+      const desc = c.description.toLowerCase();
+      if (desc.includes("hobby") || desc.includes("non-commercial")) {
+        limitations.add(`${c.vendor} free tier may restrict commercial use`);
+      }
+      if (desc.includes("pause") || desc.includes("sleep") || desc.includes("inactive")) {
+        limitations.add(`${c.vendor} may pause after inactivity`);
+      }
     }
   }
-  if (limitations.length === 0) {
-    limitations.push("Free tiers have usage limits — check vendor pricing pages for details");
+  if (limitations.size === 0) {
+    limitations.add("Free tiers have usage limits — check vendor pricing pages for details");
   }
-  return limitations;
+  return [...limitations];
+}
+
+/**
+ * Warnings describe the candidates we are actually showing, and each cites the
+ * recorded fact behind it rather than a derived risk bucket.
+ */
+function buildRiskWarnings(roles: StackRole[]): string[] {
+  const warnings: string[] = [];
+  for (const role of roles) {
+    for (const c of role.candidates) {
+      for (const d of c.demerits) {
+        warnings.push(`${c.vendor} (${role.role}): ${d.reason}`);
+      }
+      for (const disclosure of c.disclosures) {
+        warnings.push(`${c.vendor} (${role.role}): ${disclosure.date} — ${disclosure.summary} (recorded; does not affect rank)`);
+      }
+    }
+  }
+  return warnings;
+}
+
+function toCandidate(
+  offer: Offer,
+  demerits: Demerit[],
+  disclosures: Disclosure[],
+  vendorChanges: DealChange[],
+): StackCandidate {
+  return {
+    vendor: offer.vendor,
+    tier: offer.tier,
+    description: offer.description.length > 200 ? offer.description.slice(0, 197) + "..." : offer.description,
+    url: offer.url,
+    verified_date: offer.verifiedDate,
+    risk_level: vendorRiskLevel(vendorChanges),
+    stability: classifyStability(vendorChanges),
+    demerits,
+    disclosures,
+  };
 }
 
 export function getStackRecommendation(
   useCase: string,
-  requirements?: string[]
+  requirements?: string[],
+  date: string = utcDate(),
 ): StackRecommendation {
-  let roles: { role: string; category: string; preferredVendors?: string[] }[];
+  let roleSpecs: { role: string; category: string }[];
   let upgradePath: string;
 
   if (requirements && requirements.length > 0) {
-    // User-specified requirements override template
-    roles = requirements.map((req) => {
+    // User-specified requirements override the template
+    roleSpecs = requirements.map((req) => {
       const lower = req.toLowerCase();
       const category = ROLE_TO_CATEGORY[lower] ?? req;
       return { role: req.charAt(0).toUpperCase() + req.slice(1), category };
@@ -207,11 +285,11 @@ export function getStackRecommendation(
   } else {
     const template = matchTemplate(useCase);
     if (template) {
-      roles = template.roles;
+      roleSpecs = template.roles;
       upgradePath = template.upgrade_path;
     } else {
       // Fallback: common categories
-      roles = [
+      roleSpecs = [
         { role: "Hosting", category: "Cloud Hosting" },
         { role: "Database", category: "Databases" },
         { role: "Auth", category: "Auth" },
@@ -230,46 +308,55 @@ export function getStackRecommendation(
     changesByVendor.set(key, list);
   }
 
-  const stack: StackComponent[] = [];
-  for (const { role, category, preferredVendors } of roles) {
-    const offer = findBestOffer(category, preferredVendors);
-    if (offer) {
-      const vendorChanges = changesByVendor.get(offer.vendor.toLowerCase()) ?? [];
-      stack.push({
-        role,
-        vendor: offer.vendor,
-        tier: offer.tier,
-        description: offer.description.length > 200 ? offer.description.slice(0, 197) + "..." : offer.description,
-        url: offer.url,
-        risk_level: vendorRiskLevel(vendorChanges),
-        stability: classifyStability(vendorChanges),
-      });
-    }
-  }
+  const stack: StackRole[] = [];
+  for (const { role, category } of roleSpecs) {
+    const categoryOffers = searchOffers(undefined, category);
+    if (categoryOffers.length === 0) continue;
 
-  const limitations = buildLimitations(stack);
-  const risk_warnings = buildRiskWarnings(stack);
+    const ranking = rankOffers(categoryOffers, {
+      queryKey: `stack:${useCase}:${role}`,
+      changes: allChanges,
+      date,
+    });
+
+    // Draw from the best band available. If nothing is unblemished we still
+    // answer, with the demerits attached rather than hidden.
+    const shown = ranking.ranked.slice(0, CANDIDATES_PER_ROLE);
+    if (shown.length === 0) continue;
+
+    const candidates = shown.map((e) =>
+      toCandidate(e.offer, e.demerits, e.disclosures, changesByVendor.get(e.offer.vendor.toLowerCase()) ?? []),
+    );
+
+    const tieCount = ranking.qualified.length;
+    const reason = tieCount > 0
+      ? `${tieCount} of ${ranking.ranked.length} ${category} offers carry no recorded demerit and are indistinguishable under every signal we hold; ${candidates.length} shown, in an order seeded on ${date} and the query key. ${ranking.demoted.length} demoted with a named reason, ${ranking.excluded.length} excluded by the gates.`
+      : `No ${category} offer is free of recorded demerits today. Showing the least demoted, each with its reason attached. ${ranking.excluded.length} excluded by the gates.`;
+
+    stack.push({
+      role,
+      category,
+      candidates,
+      tie_count: tieCount,
+      eligible_count: ranking.ranked.length,
+      demoted_count: ranking.demoted.length,
+      excluded_count: ranking.excluded.length,
+      reason,
+      tie_break: ranking.tie_break,
+    });
+  }
 
   return {
     use_case: useCase,
     stack,
     total_monthly_cost: "$0",
-    limitations,
+    limitations: buildLimitations(stack),
     upgrade_path: upgradePath,
-    risk_warnings,
+    risk_warnings: buildRiskWarnings(stack),
+    method: {
+      policy: DEMOTE_ONLY_POLICY,
+      not_modelled: NOT_MODELLED_NOTICE,
+      criteria_url: CRITERIA_PATH,
+    },
   };
-}
-
-function buildRiskWarnings(stack: StackComponent[]): string[] {
-  const warnings: string[] = [];
-  for (const c of stack) {
-    if (c.risk_level === "risky") {
-      warnings.push(`${c.vendor} (${c.role}): high risk — free tier removal or open-source license change in the last 12 months. Consider alternatives.`);
-    } else if (c.stability === "volatile") {
-      warnings.push(`${c.vendor} (${c.role}): volatile — free tier removed or multiple negative pricing changes recorded.`);
-    } else if (c.risk_level === "caution" || c.stability === "watch") {
-      warnings.push(`${c.vendor} (${c.role}): monitor — has had limit reductions or pricing restructuring.`);
-    }
-  }
-  return warnings;
 }

--- a/test/mcp-risk-indicators.test.ts
+++ b/test/mcp-risk-indicators.test.ts
@@ -129,15 +129,19 @@ describe("MCP risk_level/stability indicators (issue #969)", () => {
     });
     const body = JSON.parse(result.content[0].text);
     assert.ok(Array.isArray(body.stack) && body.stack.length > 0, "should return a stack");
-    for (const c of body.stack) {
-      assert.ok(
-        ["stable", "caution", "risky"].includes(c.risk_level),
-        `component ${c.vendor} should have risk_level, got ${c.risk_level}`
-      );
-      assert.ok(
-        ["stable", "watch", "volatile", "improving"].includes(c.stability),
-        `component ${c.vendor} should have stability, got ${c.stability}`
-      );
+    // #1025: a role now carries a candidate set rather than one winning vendor.
+    for (const role of body.stack) {
+      assert.ok(Array.isArray(role.candidates) && role.candidates.length > 0, `${role.role} should have candidates`);
+      for (const c of role.candidates) {
+        assert.ok(
+          ["stable", "caution", "risky"].includes(c.risk_level),
+          `candidate ${c.vendor} should have risk_level, got ${c.risk_level}`
+        );
+        assert.ok(
+          ["stable", "watch", "volatile", "improving"].includes(c.stability),
+          `candidate ${c.vendor} should have stability, got ${c.stability}`
+        );
+      }
     }
     assert.ok(Array.isArray(body.risk_warnings), "should have risk_warnings array");
   });

--- a/test/ranked-surfaces.test.ts
+++ b/test/ranked-surfaces.test.ts
@@ -1,0 +1,226 @@
+// #1025 part 2: the surfaces that were still resolving order by file order,
+// by a risk bucket, or by our commercial interest.
+//
+// The enumeration behind this file matters more than any single assertion:
+// three of these were recommendation surfaces nobody had listed, and one of
+// them (`/vendor/:slug` alternatives) sits on the highest-traffic page type on
+// the site while being decided by nothing but the order of data/index.json.
+
+import { describe, it, before, after } from "node:test";
+import assert from "node:assert";
+import { spawn, type ChildProcess } from "node:child_process";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO = path.join(__dirname, "..");
+let serverPort = 0;
+let proc: ChildProcess | null = null;
+
+function startHttpServer(): Promise<ChildProcess> {
+  return new Promise((resolve, reject) => {
+    const child = spawn("node", [path.join(REPO, "dist", "serve.js")], {
+      stdio: ["pipe", "pipe", "pipe"],
+      env: { ...process.env, PORT: "0", BASE_URL: "http://localhost" },
+    });
+    const timeout = setTimeout(() => { child.kill(); reject(new Error("Server startup timeout")); }, 15000);
+    child.stderr!.on("data", (data: Buffer) => {
+      const m = data.toString().match(/running on http:\/\/localhost:(\d+)/);
+      if (m) { serverPort = parseInt(m[1], 10); clearTimeout(timeout); resolve(child); }
+    });
+    child.on("error", (err) => { clearTimeout(timeout); reject(err); });
+  });
+}
+
+const get = async (p: string) => {
+  const res = await fetch(`http://localhost:${serverPort}${p}`);
+  return { status: res.status, text: await res.text() };
+};
+
+before(async () => { proc = await startHttpServer(); });
+after(() => { if (proc) proc.kill(); });
+
+const stripComments = (src: string) =>
+  src.split("\n").filter((l) => !/^\s*(\*|\/\/|\/\*|\*\/)/.test(l)).join("\n");
+
+describe("the templates no longer name winners", () => {
+  const stacks = stripComments(readFileSync(path.join(REPO, "src", "stacks.ts"), "utf8"));
+
+  it("preferredVendors is deleted, not repointed", () => {
+    assert.ok(!/preferredVendors/.test(stacks), "retyping the fiat is not the fix");
+  });
+
+  it("the publicOffers[0] file-order fallback is gone", () => {
+    assert.ok(!/publicOffers/.test(stacks), "index order must not decide a recommendation");
+    assert.ok(!/findBestOffer/.test(stacks), "the single-winner selector must be gone");
+  });
+
+  it("no vendor name from the index survives in the selection path", () => {
+    const index = JSON.parse(readFileSync(path.join(REPO, "data", "index.json"), "utf8")) as { offers: { vendor: string }[] };
+    const vendors = [...new Set(index.offers.map((o) => o.vendor))].filter((v) => v.length >= 4);
+    const hits = vendors.filter((v) => new RegExp(`\\b${v.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}\\b`).test(stacks));
+    assert.deepStrictEqual(hits, [], `vendor names still reachable from stack selection: ${hits.join(", ")}`);
+  });
+});
+
+describe("/vendor/:slug alternatives", () => {
+  it("are not served in data/index.json order", async () => {
+    const index = JSON.parse(readFileSync(path.join(REPO, "data", "index.json"), "utf8")) as { offers: { vendor: string; category: string }[] };
+    const { status, text } = await get("/vendor/supabase");
+    assert.strictEqual(status, 200);
+    const shown = [...text.matchAll(/\/vendor\/([a-z0-9-]+)"[^>]*class="alt-vendor-name"/g)].map((m) => m[1]);
+    const fileOrder = index.offers
+      .filter((o) => o.category === "Databases" && o.vendor !== "Supabase")
+      .map((o) => o.vendor.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-|-$/g, ""));
+    if (shown.length >= 3) {
+      assert.notDeepStrictEqual(shown, fileOrder.slice(0, shown.length), "alternatives are still in raw file order");
+    }
+  });
+});
+
+describe("/alternative-to/:slug", () => {
+  it("names the recorded fact behind every demotion", async () => {
+    const { status, text } = await get("/alternative-to/openai");
+    assert.strictEqual(status, 200);
+    assert.match(text, /<strong>&minus;3 free_tier_withdrawn<\/strong> Recorded [a-z ]+ on \d{4}-\d{2}-\d{2}/, "a withdrawn free tier must name the change and its date");
+    assert.match(text, /<strong>&minus;2 time_limited_offer<\/strong> Tier &quot;[^&]+&quot; is a credit grant/, "a credit grant must say so");
+    assert.match(text, /<strong>&minus;1 stale_verification<\/strong>[^<]*not a change by the vendor/, "our own verification gap must be labelled as ours");
+    assert.match(text, /How we rank/);
+  });
+
+  it("no longer claims to be sorted by stability", async () => {
+    const { text } = await get("/alternative-to/vercel");
+    assert.ok(!text.includes("Sorted by stability"), "that copy described the ordering we removed");
+    assert.match(text, /carry no recorded demerit/);
+  });
+
+  it("puts every unblemished alternative above every demoted one, and is not alphabetical", async () => {
+    const { text } = await get("/alternative-to/vercel");
+    const list = text.slice(text.indexOf("All Free Alternatives"));
+    const cards = list.split('<div class="alt-row').slice(1);
+    assert.ok(cards.length >= 10, `expected a full alternatives list, got ${cards.length}`);
+
+    const demeritAt = cards.findIndex((c) => c.includes("alt-demerit"));
+    if (demeritAt > -1) {
+      const cleanAfter = cards.slice(demeritAt).filter((c) => !c.includes("alt-demerit"));
+      assert.strictEqual(cleanAfter.length, 0, "an offer we hold nothing against was ranked below a demoted one");
+    }
+
+    const vendors = cards.map((c) => c.match(/class="alt-vendor-name">([^<]+)</)?.[1] ?? "");
+    assert.notDeepStrictEqual(vendors, [...vendors].sort((a, b) => a.localeCompare(b)), "alternatives are still alphabetical");
+  });
+
+  it("does not empty out a page whose category peers are all eligibility-gated", async () => {
+    // 91 /alternative-to pages would have gone to zero alternatives if the
+    // gates removed offers here the way they do on a /best/ page.
+    const { status, text } = await get("/alternative-to/brex");
+    assert.strictEqual(status, 200);
+    const shown = (text.match(/class="alt-vendor-name"/g) ?? []).length;
+    assert.ok(shown > 0, "a gated category must still list its peers, labelled");
+    assert.match(text, /eligibility_restricted/, "the gate must be stated on the entries it applies to");
+  });
+});
+
+describe("/api/vendor-risk alternatives", () => {
+  it("carry the evidence behind them", async () => {
+    const { status, text } = await get("/api/vendor-risk/openai");
+    assert.strictEqual(status, 200);
+    const body = JSON.parse(text);
+    assert.ok(Array.isArray(body.alternatives));
+    for (const a of body.alternatives) {
+      assert.ok(Array.isArray(a.demerits), `${a.vendor} must carry its demerits`);
+    }
+  });
+});
+
+describe("/referral-programs stops being ordered by our own money", () => {
+  it("splits into two explicitly headed sections", async () => {
+    const { status, text } = await get("/referral-programs");
+    assert.strictEqual(status, 200);
+    const paid = text.indexOf("Programs we have a referral link for");
+    const unpaid = text.indexOf("Programs we don");
+    assert.ok(paid > -1, "the paid section must be headed as such");
+    assert.ok(unpaid > paid, "the unpaid section must follow it, separately headed");
+    assert.match(text, /we may earn a commission/);
+  });
+
+  it("puts the disclosure on the section header, not only per item", async () => {
+    const { text } = await get("/referral-programs");
+    const paid = text.indexOf("Programs we have a referral link for");
+    const unpaid = text.indexOf("Programs we don");
+    const sectionNote = text.slice(paid, unpaid);
+    assert.match(sectionNote, /href="\/disclosure"/, "the paid section header must carry the disclosure link");
+  });
+
+  it("is no longer one list with the paying vendors silently on top", async () => {
+    const { text } = await get("/referral-programs");
+    const tables = text.split("<table class=\"programs-table\">").length - 1;
+    assert.strictEqual(tables, 2, "expected exactly two tables, one per section");
+    // Every "Use our code" link must be inside the first table.
+    const secondTableAt = text.indexOf("<table class=\"programs-table\">", text.indexOf("<table class=\"programs-table\">") + 1);
+    const paidLinksAfterSplit = text.slice(secondTableAt).match(/status-active/g) ?? [];
+    assert.strictEqual(paidLinksAfterSplit.length, 0, "a monetized link leaked into the unpaid section");
+  });
+
+  it("orders within a section by rotation, not the alphabet", async () => {
+    const { text } = await get("/referral-programs");
+    // Only one vendor currently has one of our codes, so the observable
+    // section is the unpaid one — the second table.
+    const secondBodyAt = text.indexOf("<tbody>", text.indexOf("</tbody>"));
+    const secondTable = text.slice(secondBodyAt, text.indexOf("</tbody>", secondBodyAt));
+    const vendors = [...secondTable.matchAll(/class="vendor-link">([^<]+)</g)].map((m) => m[1]);
+    assert.ok(vendors.length >= 4, `expected several unpaid programmes, got ${vendors.length}`);
+    assert.notDeepStrictEqual(vendors, [...vendors].sort((a, b) => a.localeCompare(b)), "still alphabetical inside the section");
+
+    // Pinned to the rotation the module actually produces over the source
+    // order, so reintroducing any other sort fails here.
+    const { rotateListing } = await import("../src/ranking.ts");
+    const index = JSON.parse(readFileSync(path.join(REPO, "data", "index.json"), "utf8")) as {
+      offers: { vendor: string; referral?: unknown; referral_program?: { available?: boolean } }[];
+    };
+    const seen = new Set<string>();
+    const sourceOrder: string[] = [];
+    for (const o of index.offers) {
+      if (o.referral_program?.available && !seen.has(o.vendor)) {
+        seen.add(o.vendor);
+        if (!o.referral) sourceOrder.push(o.vendor);
+      }
+    }
+    assert.deepStrictEqual(vendors, rotateListing(sourceOrder, "referral-programs:without-code"));
+  });
+});
+
+describe("the criteria are discoverable by an agent that never renders HTML", () => {
+  it("llms.txt states the ranking policy and links the method", async () => {
+    const { status, text } = await get("/llms.txt");
+    assert.strictEqual(status, 200);
+    assert.match(text, /Recommendations are not for sale/);
+    assert.match(text, /can only be demoted/);
+    assert.match(text, /do NOT model technical fit/i);
+    assert.match(text, /\/criteria/);
+  });
+
+  it("the plan_stack tool description says what it now returns", async () => {
+    const { text } = await get("/llms.txt");
+    assert.match(text, /not a single pick/);
+  });
+
+  it("/api/stack carries the method with every response", async () => {
+    const { status, text } = await get("/api/stack?use_case=Next.js+SaaS+app");
+    assert.strictEqual(status, 200);
+    const body = JSON.parse(text);
+    assert.strictEqual(body.method.criteria_url, "/criteria");
+    assert.match(body.method.not_modelled, /do NOT model technical fit/i);
+    for (const role of body.stack) {
+      assert.ok(role.candidates.length > 0);
+      assert.match(role.tie_break.seed, /^[0-9a-f]{64}$/);
+    }
+  });
+
+  it("/criteria no longer carries the interim caveat now that plan_stack has moved", async () => {
+    const { text } = await get("/criteria");
+    assert.ok(!text.includes("are being moved onto this same module"), "the caveat must come out with the work");
+    assert.match(text, /the <code>\/api\/stack<\/code> endpoint and the <code>plan_stack<\/code> MCP tool/);
+  });
+});

--- a/test/stacks.test.ts
+++ b/test/stacks.test.ts
@@ -16,13 +16,16 @@ describe("stack recommendation logic", () => {
     assert.ok(Array.isArray(result.limitations));
     assert.ok(typeof result.upgrade_path === "string");
 
-    // Check stack components have required fields
-    for (const component of result.stack) {
-      assert.ok(component.role, "Should have role");
-      assert.ok(component.vendor, "Should have vendor");
-      assert.ok(component.tier, "Should have tier");
-      assert.ok(component.description, "Should have description");
-      assert.ok(component.url, "Should have url");
+    // Check roles and their candidates have required fields
+    for (const role of result.stack) {
+      assert.ok(role.role, "Should have role");
+      assert.ok(role.candidates.length > 0, "Should have candidates");
+      for (const c of role.candidates) {
+        assert.ok(c.vendor, "Should have vendor");
+        assert.ok(c.tier, "Should have tier");
+        assert.ok(c.description, "Should have description");
+        assert.ok(c.url, "Should have url");
+      }
     }
 
     // Should include hosting and database roles
@@ -81,24 +84,28 @@ describe("stack recommendation logic", () => {
   it("description is capped at 200 characters", async () => {
     const { getStackRecommendation } = await import("../dist/stacks.js");
     const result = getStackRecommendation("Next.js SaaS app");
-    for (const component of result.stack) {
-      assert.ok(component.description.length <= 200, `Description for ${component.vendor} exceeds 200 chars`);
+    for (const role of result.stack) {
+      for (const c of role.candidates) {
+        assert.ok(c.description.length <= 200, `Description for ${c.vendor} exceeds 200 chars`);
+      }
     }
   });
 
-  it("stack components include risk_level and stability fields", async () => {
+  it("candidates include risk_level and stability fields", async () => {
     const { getStackRecommendation } = await import("../dist/stacks.js");
     const result = getStackRecommendation("Next.js SaaS app");
     assert.ok(result.stack.length > 0);
-    for (const component of result.stack) {
-      assert.ok(
-        ["stable", "caution", "risky"].includes(component.risk_level),
-        `${component.vendor} risk_level should be stable|caution|risky, got ${component.risk_level}`
-      );
-      assert.ok(
-        ["stable", "watch", "volatile", "improving"].includes(component.stability),
-        `${component.vendor} stability should be stable|watch|volatile|improving, got ${component.stability}`
-      );
+    for (const role of result.stack) {
+      for (const c of role.candidates) {
+        assert.ok(
+          ["stable", "caution", "risky"].includes(c.risk_level),
+          `${c.vendor} risk_level should be stable|caution|risky, got ${c.risk_level}`
+        );
+        assert.ok(
+          ["stable", "watch", "volatile", "improving"].includes(c.stability),
+          `${c.vendor} stability should be stable|watch|volatile|improving, got ${c.stability}`
+        );
+      }
     }
   });
 
@@ -113,19 +120,93 @@ describe("stack recommendation logic", () => {
     }
   });
 
-  it("risk_warnings surfaced when stack contains non-stable components", async () => {
+  it("every risk warning names a candidate we are actually showing", async () => {
     const { getStackRecommendation } = await import("../dist/stacks.js");
     const result = getStackRecommendation("Next.js SaaS app");
-    const hasRisky = result.stack.some(
-      (c: any) => c.risk_level !== "stable" || c.stability !== "stable"
-    );
-    if (hasRisky) {
-      assert.ok(
-        result.risk_warnings.length > 0,
-        "risk_warnings should not be empty when stack has non-stable components"
-      );
-    } else {
-      assert.strictEqual(result.risk_warnings.length, 0);
+    const shown = new Set(result.stack.flatMap((r: any) => r.candidates.map((c: any) => `${c.vendor} (${r.role})`)));
+    for (const w of result.risk_warnings) {
+      const prefix = w.slice(0, w.indexOf("):") + 1);
+      assert.ok(shown.has(prefix), `warning references ${prefix}, which is not in the returned candidate set`);
+    }
+  });
+});
+
+// #1025: plan_stack stops naming one winner per role. The old behaviour put
+// Supabase in every database slot of every template because it was typed first
+// in `preferredVendors`; the fallback was `publicOffers[0]`, index order in the
+// JSON file. Both are gone.
+describe("plan_stack does not name a winner", () => {
+  it("returns a candidate set per role, not a single vendor", async () => {
+    const { getStackRecommendation } = await import("../dist/stacks.js");
+    const result = getStackRecommendation("Next.js SaaS app");
+    for (const role of result.stack) {
+      assert.ok(Array.isArray(role.candidates), `${role.role} must return candidates`);
+      assert.ok(role.candidates.length > 1, `${role.role} returned ${role.candidates.length} candidate — that is a pick, not a set`);
+      assert.strictEqual((role as any).vendor, undefined, "a role must not carry a single winning vendor");
+    }
+  });
+
+  it("no vendor occupies the same slot across every template", async () => {
+    const { getStackRecommendation } = await import("../dist/stacks.js");
+    const firsts = ["Next.js SaaS app", "AI agent backend", "side project with database"].map((useCase) => {
+      const db = getStackRecommendation(useCase).stack.find((r: any) => r.role === "Database");
+      return db?.candidates[0]?.vendor;
+    });
+    assert.ok(firsts.every(Boolean), "each use case should return a database role");
+    assert.notStrictEqual(new Set(firsts).size, 1, `the same vendor led every template: ${firsts[0]}`);
+  });
+
+  it("discloses the size of the tie it drew from, and the seed", async () => {
+    const { getStackRecommendation } = await import("../dist/stacks.js");
+    const result = getStackRecommendation("Next.js SaaS app");
+    for (const role of result.stack) {
+      assert.ok(role.tie_count >= role.candidates.length || role.tie_count === 0, `${role.role} shows more candidates than tie_count claims`);
+      assert.match(role.tie_break.seed, /^[0-9a-f]{64}$/);
+      assert.strictEqual(role.tie_break.query_key, `stack:Next.js SaaS app:${role.role}`);
+      assert.ok(role.reason.length > 40, `${role.role} must explain itself`);
+    }
+  });
+
+  it("states plainly that we do not model technical fit", async () => {
+    const { getStackRecommendation } = await import("../dist/stacks.js");
+    const result = getStackRecommendation("Next.js SaaS app");
+    assert.match(result.method.not_modelled, /do NOT model technical fit/i);
+    assert.match(result.method.policy, /nothing to add/);
+    assert.strictEqual(result.method.criteria_url, "/criteria");
+  });
+
+  it("the tier gate replaces the hand-typed allowlist — Always Free is reachable again", async () => {
+    const { getStackRecommendation } = await import("../dist/stacks.js");
+    const seen = new Set<string>();
+    for (const useCase of ["Next.js SaaS app", "AI agent backend", "static blog", "devops platform", "ecommerce store"]) {
+      for (const role of getStackRecommendation(useCase).stack) {
+        for (const c of role.candidates) seen.add(c.tier);
+      }
+    }
+    // `findBestOffer()` gated on {Free, Hobby, Open Source, Free Credits}, so no
+    // offer outside that set could ever appear. Any tier outside it proves the
+    // allowlist is gone.
+    const outsideOldAllowlist = [...seen].filter((t) => !["Free", "Hobby", "Open Source", "Free Credits"].includes(t));
+    assert.ok(outsideOldAllowlist.length > 0, "no tier outside the old allowlist appeared — the gate may not have changed");
+  });
+
+  it("rotates day to day but is stable within a day", async () => {
+    const { getStackRecommendation } = await import("../dist/stacks.js");
+    const a = getStackRecommendation("Next.js SaaS app", undefined, "2026-08-25");
+    const b = getStackRecommendation("Next.js SaaS app", undefined, "2026-08-25");
+    const c = getStackRecommendation("Next.js SaaS app", undefined, "2026-08-26");
+    const names = (r: any) => r.stack.map((role: any) => role.candidates.map((x: any) => x.vendor).join(","));
+    assert.deepStrictEqual(names(a), names(b));
+    assert.notDeepStrictEqual(names(a), names(c));
+  });
+
+  it("a demoted candidate is never shown above one with no demerits", async () => {
+    const { getStackRecommendation } = await import("../dist/stacks.js");
+    for (const useCase of ["Next.js SaaS app", "AI chatbot", "ecommerce store"]) {
+      for (const role of getStackRecommendation(useCase).stack) {
+        const totals = role.candidates.map((c: any) => c.demerits.reduce((s: number, d: any) => s + d.points, 0));
+        assert.deepStrictEqual(totals, [...totals].sort((x, y) => x - y), `${useCase}/${role.role} is out of band order`);
+      }
     }
   });
 });
@@ -165,6 +246,8 @@ describe("stack REST endpoint", () => {
     assert.strictEqual(body.total_monthly_cost, "$0");
     assert.ok(Array.isArray(body.limitations));
     assert.ok(typeof body.upgrade_path === "string");
+    assert.ok(Array.isArray(body.stack[0].candidates));
+    assert.strictEqual(body.method.criteria_url, "/criteria");
   });
 
   it("GET /api/stack returns 400 without use_case", async () => {


### PR DESCRIPTION
Refs #1025 — part 2 of 2, following #1030. This lands the `plan_stack` interim exactly as you decided it, the referral-programs split, and the three recommendation surfaces the enumeration turned up that neither of us had listed.

## `plan_stack` — no winner, per your decision

`TEMPLATES.preferredVendors` is **deleted, not repointed**. `findBestOffer()` and the `publicOffers[0]` index-order fallback are gone. The hand-typed tier allowlist is gone with them — a test proves it by asserting some tier *outside* `{Free, Hobby, Open Source, Free Credits}` now appears in output, which was impossible before.

Live, from this build (`2026-08-25`, `use_case=Next.js SaaS app`):

| Role | Before | After |
|---|---|---|
| Hosting | Vercel | 8 of **57** tied — bismuth.cloud, Cloudflare Pages, Apply.build, Alwaysdata, readthedocs.org, Northflank, Cloudflare Durable Objects, tilda.cc |
| Database | **Supabase** (every template, always) | 8 of **41** tied — Chroma, Aiven, Databricks, Momento, filess.io, Hasura Cloud, Convex, Nile |
| Auth | Clerk | 8 of **29** tied |
| Email | Resend | 8 of **52** tied |

Each role carries `tie_count`, `eligible_count`, `demoted_count`, `excluded_count`, a `reason` in words, and its `tie_break` seed. The response carries a `method` block with the policy sentence, the criteria URL, and the not-modelled notice — implementing your requirement verbatim:

> *"We rank on offer terms, verification recency and recorded adverse changes. We do NOT model technical fit between a product and a role — the caller must apply that."*

Chroma is still in the database candidate set, and that is the design working rather than failing: it is one of 41 equals in a list whose own text says we do not model fit, instead of being presented as *the* database for a SaaS app. Your framing is what made this shippable — the caller already knows Chroma is a vector store, and it cannot get "this free tier was withdrawn in March" anywhere else.

## Three recommendation surfaces the enumeration found

These were in my part-1 table and are fixed here. None was in the issue.

| Surface | Was | Now |
|---|---|---|
| `/vendor/:slug` alternatives | `.slice(0, 12)` over **raw file order** — 28% of page views | shared module |
| `/alternative-to/:slug` | risk_level bucket, then file order inside the bucket | shared module, each demotion named on the card |
| `checkVendorRisk()` (MCP + `/api/vendor-risk`) | risk bucket then alphabetical, `.slice(0, 3)` | shared module, demerits returned with each alternative |
| `getOfferDetails()` related vendors | `.slice(0, 5)` over file order | shared module |

The risk-bucket sort deserves a note: it ranked on the count of changes we happen to have recorded, which is the 15.7%-coverage / 3.2x-prominence-bias signal we removed from `/best/*` for exactly this reason. It was still deciding the alternatives on every vendor page.

**One design decision I want visible.** These use a new `rankForListing()` that differs from `rankOffers()` in one way: a gated offer is moved to the end **with its gate stated** rather than removed. I measured before choosing: applying `/best/`-style gating here would have emptied **91 `/alternative-to/` pages** — every vendor whose category peers are all eligibility-restricted, which is most of the startup and fintech programmes. A `/best/` page claims *every free X that clears our bar*, so an offer that does not clear it has no business on it; an alternatives page claims *the other things in this category*, and telling the reader "requires accelerator qualification" is more useful than hiding it. Different claim, different treatment, both stated on `/criteria`.

## Referral programmes: separated and labelled, per your decision

Two explicitly headed sections, disclosure on the section header rather than only per item, shared rotation inside each instead of `localeCompare`. A test asserts no monetized link can appear in the unpaid section.

**One number worth having:** only **1 of 21** programmes currently has one of our codes (Railway). So the old "our codes first" sort was moving exactly one row to the top. That does not change the verdict — a page ordered by our commercial interest is a page ordered by our commercial interest, and it scales the moment we hold more codes — but I would rather you have the real magnitude than infer a bigger one.

## Discoverability, so an agent that never renders HTML gets the same story

- `llms.txt` gains a **"How ranking works — read this before trusting an order"** section: the policy, "0 of 57 categories has a unique number one", the not-modelled caveat, and the `/criteria` link.
- The `plan_stack` MCP tool description and the OpenAPI schema for `/api/stack` describe what the tool now returns, including the candidate/demerit/tie_break shape.
- `/criteria` drops the interim caveat from #1030 and now truthfully claims every ranked surface.

## Breaking change, deliberate

`/api/stack` and MCP `plan_stack` recommend mode change shape: `stack[]` entries go from `{role, vendor, tier, description, url, risk_level, stability}` to `{role, category, candidates[], tie_count, …, reason, tie_break}`. That is the point of the issue — the old shape could only express a single winner. Updated with it: the landing-page stack builder (now renders the candidate set with the tie count and the not-modelled line), the OpenAPI schema, `test/stacks.test.ts`, and the #969 MCP risk-indicator test.

`risk_warnings` survives but is now derived from the candidates actually returned, and each warning cites the recorded fact rather than a derived bucket. A test asserts every warning names a candidate that is genuinely in the response.

## Verification

- `tsc` clean, **1347/1347 tests** (17 new).
- **Bite-verified against 8 mutations**, each failing the suite: naming one winner per role again, restoring the alphabetical section order on the referral page, dropping the gated tail, blanking the `method` block, stripping the demerit reasons from the alternatives cards, alphabetising the alternatives after ranking, inverting the band order, and removing the policy line from `llms.txt`.
- Two mutations initially did **not** bite and the tests were strengthened until they did: the referral-order test was reading the 1-row paid section, and the alternatives test asserted a CSS class that the gate rendering also emits. Both now pin against the real expected output.
- Beyond unit tests: `/api/stack` driven against the real `dist/serve.js`, MCP `initialize` → `tools/call` on `plan_stack` end to end, and the referral page plus the landing-page stack builder verified visually rather than from the HTML.

## Still outstanding from part 1, both yours to call

1. **21 of 57 `/best/X` pages have nothing gated and nothing demoted**, so their offer set is identical to `/category/X`. Full list in #1030. Your stated kill condition.
2. **`COMPARISON_PAIRS`** is still a hand-typed list of vendor names deciding who gets a `/compare/` page. Not a ranking, so I left it — but it is a typed list of vendor names in a page-generation path, and you should rule on it rather than me.

And `stale_verification`'s failed-check variant is written and tested but inert until #1020 records the attempts — the shape it needs to record is specified in #1030.

🤖 Generated with [Claude Code](https://claude.com/claude-code)