### PR TITLE
404s are not page views: split requests by outcome, repair the junk keyspace (#1029)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,16 +67,29 @@ HTTP request to a client class and publish the result at `/api/traffic`:
 per-family counts inside `ai_agent`, the top route patterns per class, and a `web_vs_mcp`
 block comparing web hits to MCP tool calls over the same window.
 
-Two deliberate choices worth knowing about:
+Three deliberate choices worth knowing about:
 
 - **`sdk_client` is not folded into `ai_agent`.** `undici` and `python-httpx` traffic may
   be an agent or may be a scraper; counting it as an agent would overclaim.
 - **Bot traffic is counted, not dropped.** The separate `/api/pageviews` figure remains
   human-shaped traffic only, so that number did not change meaning.
+- **A request that did not resolve to a page is not a hit.** Requests are split by
+  outcome: served (2xx) is what `hits_total`, `by_class` and the page-view total count;
+  `not_found_*` (4xx/5xx) and `redirect_*` (3xx) are reported next to them and never
+  inside them. A redirect is excluded because the request that follows it is the hit, and
+  counting both would double it.
+
+Every window states its own denominator: `days` is the window it is labelled with,
+`data_days_available` is how much of that we hold data for, and `coverage` says so in
+words. `/api/pageviews` carries `all_time_trustworthy_from`, the date its all-time series
+became comparable.
 
 **No PII.** We store the class and a bounded family label from a fixed table — never a
-user agent, never an IP address, never a full request path outside a fixed route-pattern
-key space.
+user agent, never an IP address. Request paths are stored as a fixed route-pattern key
+space, with one exception: `not_found_sample` on `/api/traffic` keeps the last 50
+non-resolving request paths, sanitized to printable ASCII and truncated to 80 characters,
+so that a vulnerability scan can be told apart from a broken integration. Those paths are
+never used to construct a storage key.
 
 ## MCP Tools
 

--- a/scripts/e2e-1029.mjs
+++ b/scripts/e2e-1029.mjs
@@ -1,0 +1,273 @@
+// End-to-end verification for #1029 against production-shaped stored data.
+//
+// Unit + wiring tests cover the logic and the hooks. This covers the thing neither can:
+// booting the real dist/serve.js against a stored snapshot with the actual shape
+// production holds today — junk all-time keys, a legacy day whose total counted its 404s,
+// and class counters recorded before the outcome split — then driving real traffic
+// through it and reading the real endpoints.
+//
+// Usage: node scripts/e2e-1029.mjs
+
+import { createServer } from "node:http";
+import { spawn } from "node:child_process";
+
+const store = new Map();
+const lists = new Map();
+const commands = [];
+
+// --- Fake Upstash -----------------------------------------------------------------
+const upstash = createServer((req, res) => {
+  let body = "";
+  req.on("data", c => (body += c));
+  req.on("end", () => {
+    const args = JSON.parse(body || "[]");
+    const cmd = String(args[0]).toUpperCase();
+    commands.push(cmd);
+    let result;
+    switch (cmd) {
+      case "GET": result = store.get(String(args[1])) ?? null; break;
+      case "SET": store.set(String(args[1]), String(args[2])); result = "OK"; break;
+      case "MGET": result = args.slice(1).map(k => store.get(String(k)) ?? null); break;
+      case "SCAN": {
+        const pattern = String(args[3] ?? "*");
+        const prefix = pattern.endsWith("*") ? pattern.slice(0, -1) : pattern;
+        result = ["0", [...store.keys()].filter(k => k.startsWith(prefix))];
+        break;
+      }
+      case "LPUSH": {
+        const key = String(args[1]);
+        const list = lists.get(key) ?? [];
+        for (const v of args.slice(2)) list.unshift(String(v));
+        lists.set(key, list);
+        result = list.length;
+        break;
+      }
+      case "LTRIM": {
+        const key = String(args[1]);
+        lists.set(key, (lists.get(key) ?? []).slice(Number(args[2]), Number(args[3]) + 1));
+        result = "OK";
+        break;
+      }
+      case "LRANGE":
+        result = (lists.get(String(args[1])) ?? []).slice(Number(args[2]), Number(args[3]) + 1);
+        break;
+      default: result = 1;
+    }
+    res.writeHead(200, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ result }));
+  });
+});
+
+const today = new Date().toISOString().slice(0, 10);
+
+// The exact junk keys the PM quoted from the live all_time.top_pages, plus the real
+// shape of today's counters: a day total that counted its own 404s, and class counters
+// with the 404s already inside them.
+const SEEDED = {
+  days: {
+    [today]: {
+      total: 3862,
+      "/": 49,
+      "/vendor/:slug": 199,
+      "/category/:slug": 123,
+      "/best/:slug": 94,
+      __unmatched__: 3013,
+    },
+  },
+  referrers: {},
+  all_time: {
+    "/": 9701,
+    "/vendor/:slug": 400,
+    __unmatched__: 3866,
+    "/%2f%2eenv": 31,
+    "/%2eenv": 28,
+    "/%2fbackend%2f%2eenv": 28,
+    "/%2egit/%63onfig": 27,
+    "/%2f%2eaws%2fcredentials": 27,
+    "/$(pwd)/.env": 9,
+    "/$(pwd)/.env.local": 9,
+    "/$(pwd)/.git/config": 9,
+    "/$(pwd)/*.auto.tfvars": 9,
+  },
+  updated_at: new Date().toISOString(),
+  classes: { [today]: { sdk_client: 3361, browser: 279, seo_crawler: 883, internal: 68 } },
+  class_routes: { [today]: { "sdk_client|__unmatched__": 3065, "browser|/vendor/:slug": 66 } },
+  families: {},
+  mcp: { [today]: 2 },
+};
+
+const BROWSER = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36";
+const SCANNER = "python-httpx/0.27.0";
+const AGENT = "Mozilla/5.0 (compatible; ChatGPT-User/1.0; +https://openai.com/bot)";
+
+const fail = [];
+function check(label, actual, expected) {
+  const ok = JSON.stringify(actual) === JSON.stringify(expected);
+  console.log(`${ok ? "  ok  " : "  FAIL"}  ${label}: ${JSON.stringify(actual)}${ok ? "" : ` (expected ${JSON.stringify(expected)})`}`);
+  if (!ok) fail.push(label);
+}
+
+await new Promise(r => upstash.listen(0, r));
+const upstashPort = upstash.address().port;
+store.set("agentdeals:pageviews", JSON.stringify(SEEDED));
+
+const proc = spawn("node", ["dist/serve.js"], {
+  stdio: ["pipe", "pipe", "pipe"],
+  env: {
+    ...process.env,
+    PORT: "0",
+    BASE_URL: "http://localhost",
+    UPSTASH_REDIS_REST_URL: `http://127.0.0.1:${upstashPort}`,
+    UPSTASH_REDIS_REST_TOKEN: "fake",
+    TELEMETRY_FLUSH_INTERVAL_SECONDS: "5",
+  },
+});
+let stderr = "";
+proc.stderr.on("data", d => { stderr += d.toString(); });
+const port = await new Promise((resolve, reject) => {
+  const t = setTimeout(() => reject(new Error(`server start timeout\n${stderr}`)), 30000);
+  proc.stderr.on("data", d => {
+    const m = d.toString().match(/running on http:\/\/localhost:(\d+)/);
+    if (m) { clearTimeout(t); resolve(Number(m[1])); }
+  });
+});
+
+const hit = async (p, ua) => {
+  const res = await fetch(`http://localhost:${port}${p}`, { headers: { "user-agent": ua }, redirect: "manual" });
+  await res.arrayBuffer();
+  return res.status;
+};
+const observe = async p => (await fetch(`http://localhost:${port}${p}`, {
+  headers: { "user-agent": "agentdeals-internal/1.0 (coder e2e)" },
+})).json();
+
+console.log("\n=== 1. the repair, on the stored snapshot ===");
+const pv0 = await observe("/api/pageviews");
+check("all_time.total excludes the junk and the legacy bucket", pv0.all_time.total, 9701 + 400);
+check("all_time.not_found holds the repaired junk", pv0.all_time.not_found, 31 + 28 + 28 + 27 + 27 + 9 + 9 + 9 + 9);
+check("all_time.unclassified_legacy holds the un-splittable bucket", pv0.all_time.unclassified_legacy, 3866);
+check("no junk path survives in top_pages",
+  pv0.all_time.top_pages.filter(p => /%|\$/.test(p.path)).length, 0);
+check("today.total is the named pages, not the inflated counter", pv0.today.total, 49 + 199 + 123 + 94);
+// The seeded day lists 4 named pages against a stored total of 3,862 — deliberately
+// partial, as a legacy day whose smaller keys have expired would be. So the unnameable
+// remainder is larger than the __unmatched__ bucket alone, and the report says so rather
+// than dropping the difference. What must hold is that the arithmetic closes.
+check("today.unclassified_legacy carries everything unnameable", pv0.today.unclassified_legacy, 3862 - 465);
+check("and the arithmetic closes against the old total",
+  pv0.today.total + pv0.today.unclassified_legacy, 3862);
+check("trustworthy_from is stamped", pv0.all_time_trustworthy_from, today);
+
+console.log("\n=== 2. real traffic, real statuses ===");
+const before = await observe("/api/traffic");
+const cmdsBefore = commands.length;
+for (let i = 0; i < 40; i++) await hit(`/wp-admin-${i}/setup.php`, SCANNER);
+for (let i = 0; i < 5; i++) await hit("/vendor/neon", BROWSER);
+await hit("/vendor/neon", AGENT);
+check("a scanned path 404s", await hit("/zzz-e2e-probe", SCANNER), 404);
+check("a plural vendor path 301s", await hit("/vendors/neon", BROWSER), 301);
+
+const after = await observe("/api/traffic");
+check("40+1 scanner 404s counted apart",
+  after.since_boot_not_found - before.since_boot_not_found, 41);
+check("none of them counted as a page the scanner read",
+  after.since_boot_by_class.sdk_client - before.since_boot_by_class.sdk_client, 0);
+check("the browser's 5 page views counted",
+  after.since_boot_by_class.browser - before.since_boot_by_class.browser, 5);
+check("the redirect counted apart from both",
+  after.since_boot_redirects - before.since_boot_redirects, 1);
+check("the AI agent hit counted", after.since_boot_by_class.ai_agent - before.since_boot_by_class.ai_agent, 1);
+
+console.log("\n=== 3. the sample makes the excluded traffic attributable ===");
+const sample = after.not_found_sample;
+check("sample is bounded", sample.length <= 50, true);
+check("newest first", sample[0].path, "/zzz-e2e-probe");
+check("carries the client class", sample[0].client_class, "sdk_client");
+check("carries the status", sample[0].status, 404);
+console.log(`  sample head: ${JSON.stringify(sample.slice(0, 3))}`);
+
+console.log("\n=== 4. the window states its own denominator ===");
+check("today is complete", after.today.coverage.split(";")[0], "complete");
+check("30d says how thin it is", after.last_30d.coverage.split(";")[0].startsWith("partial — 1 of 30 days"), true);
+check("and names the pre-split day", after.today.pre_split_dates, [today]);
+console.log(`  coverage(30d): ${after.last_30d.coverage}`);
+
+console.log("\n=== 5. the command budget still binds ===");
+const cmdsForTraffic = commands.length - cmdsBefore;
+console.log(`  ${cmdsForTraffic} Redis commands for 48 requests + 2 observability reads`);
+check("no command on the request path", cmdsForTraffic <= 1, true);
+
+console.log("\n=== 6. one flush writes one snapshot, repaired ===");
+const flushBefore = commands.length;
+await new Promise(r => setTimeout(r, 6500));
+const flushCmds = commands.slice(flushBefore);
+console.log(`  flush spent: ${JSON.stringify(flushCmds)}`);
+check("exactly one SET for the snapshot", flushCmds.filter(c => c === "SET").length, 1);
+check("no SCAN", flushCmds.includes("SCAN"), false);
+
+const stored = JSON.parse(store.get("agentdeals:pageviews"));
+check("the junk is gone from storage", Object.keys(stored.all_time).some(k => /%|\$/.test(k)), false);
+check("stored not_found key holds the repaired hits", stored.all_time.__not_found__ >= 177, true);
+check("the sample persisted", stored.not_found_sample.length > 0, true);
+check("trustworthy_from persisted", stored.all_time_trustworthy_from, today);
+check("outcome_split_from persisted", stored.outcome_split_from, today);
+check("snapshot size stays sane", JSON.stringify(stored).length < 400_000, true);
+console.log(`  stored snapshot: ${(JSON.stringify(stored).length / 1024).toFixed(1)}KB`);
+
+console.log("\n=== 7. MCP still works, and lands on the MCP side ===");
+let mcpSession;
+const mcp = async payload => {
+  const headers = { "Content-Type": "application/json", Accept: "application/json, text/event-stream" };
+  if (mcpSession) headers["mcp-session-id"] = mcpSession;
+  const res = await fetch(`http://localhost:${port}/mcp`, {
+    method: "POST", headers, body: JSON.stringify(payload),
+  });
+  const sid = res.headers.get("mcp-session-id");
+  if (sid) mcpSession = sid;
+  return res.text();
+};
+const init = await mcp({ jsonrpc: "2.0", id: 1, method: "initialize", params: { protocolVersion: "2024-11-05", capabilities: {}, clientInfo: { name: "coder-e2e", version: "1" } } });
+check("initialize answers", init.includes("serverInfo"), true);
+await mcp({ jsonrpc: "2.0", method: "notifications/initialized" });
+const call = await mcp({ jsonrpc: "2.0", id: 2, method: "tools/call", params: { name: "search_deals", arguments: { query: "postgres" } } });
+check("tools/call answers", call.includes("result") && !call.includes('"error"'), true);
+if (!call.includes("result")) console.log(`  tools/call raw: ${call.slice(0, 400)}`);
+
+console.log("\n=== 8. the search window says how thin it is ===");
+const metrics = await observe("/api/metrics");
+console.log(`  window_7d: ${JSON.stringify(metrics.search_analytics.window_7d)}`);
+check("search window is disclosed", typeof metrics.search_analytics.window_7d.coverage, "string");
+check("page_views_today excludes the 404s", metrics.page_views_today, 5);
+
+console.log("\n=== 9. idempotence: a second boot must not re-repair ===");
+proc.kill("SIGTERM");
+await new Promise(r => setTimeout(r, 1500));
+const storedAfterShutdown = JSON.parse(store.get("agentdeals:pageviews"));
+const proc2 = spawn("node", ["dist/serve.js"], {
+  stdio: ["pipe", "pipe", "pipe"],
+  env: {
+    ...process.env, PORT: "0", BASE_URL: "http://localhost",
+    UPSTASH_REDIS_REST_URL: `http://127.0.0.1:${upstashPort}`,
+    UPSTASH_REDIS_REST_TOKEN: "fake", TELEMETRY_FLUSH_INTERVAL_SECONDS: "5",
+  },
+});
+const port2 = await new Promise((resolve, reject) => {
+  const t = setTimeout(() => reject(new Error("second boot timeout")), 30000);
+  proc2.stderr.on("data", d => {
+    const m = d.toString().match(/running on http:\/\/localhost:(\d+)/);
+    if (m) { clearTimeout(t); resolve(Number(m[1])); }
+  });
+});
+const pv2 = await (await fetch(`http://localhost:${port2}/api/pageviews`, {
+  headers: { "user-agent": "agentdeals-internal/1.0 (coder e2e)" },
+})).json();
+check("all-time total unchanged on reboot", pv2.all_time.total, JSON.parse(JSON.stringify(
+  Object.entries(storedAfterShutdown.all_time)
+    .filter(([k]) => !["total", "__not_found__", "__redirect__", "__unmatched__"].includes(k))
+    .reduce((s, [, v]) => s + v, 0))));
+check("trustworthy_from not reset to a later date", pv2.all_time_trustworthy_from, today);
+proc2.kill("SIGKILL");
+
+upstash.close();
+console.log(`\n${fail.length === 0 ? "ALL CHECKS PASSED" : `FAILURES: ${fail.join(", ")}`}`);
+process.exit(fail.length === 0 ? 0 : 1);

--- a/src/stats.ts
+++ b/src/stats.ts
@@ -688,6 +688,12 @@ export function resetTelemetryBuffers(): void {
   requestLogHydrated = false;
   lastFlushAt = null;
   trafficSinceBoot = {};
+  notFoundSinceBoot = 0;
+  redirectsSinceBoot = 0;
+  // The process-local page-view tally is part of "just booted" too. Without this a test
+  // that reads getStats().page_views_today inherits every view the previous one recorded.
+  pageViewsToday = 0;
+  pageViewsTodayDate = new Date().toISOString().slice(0, 10);
 }
 
 export function recordToolCall(tool: string, clientName?: string): void {
@@ -962,6 +968,71 @@ export const OTHER_REFERRER_KEY = "__other__";
 
 const DAY_TOTAL_KEY = "total";
 
+// --- Request outcome (#1029) ---
+//
+// A request that does not resolve to a page is not a page view. Before this, a 404 was
+// bucketed to __unmatched__ *inside* the day map and counted toward the day total, so 84%
+// of a day's recorded page views were a scanner walking paths we do not serve — and the
+// same requests inflated every client class's hit count on /api/traffic.
+//
+// Three outcomes, counted apart, because collapsing them loses a distinction we quote:
+//   served    (2xx) — we returned content. This is the page view.
+//   redirect  (3xx) — the URL resolves, to somewhere else. Counting it as a page view
+//                     double-counts: the client then fetches the target and that is a
+//                     second request. Visible, never in the total.
+//   not_found (4xx/5xx) — did not resolve. Visible, never in the total.
+export type RequestOutcome = "served" | "redirect" | "not_found";
+
+/**
+ * Classify a served status code. `undefined` means the caller did not record a status
+ * (an internal call, or a test recording an intent rather than a response) and is treated
+ * as served — the same reading the pre-#1029 code gave it.
+ */
+export function requestOutcome(statusCode?: number): RequestOutcome {
+  if (statusCode === undefined) return "served";
+  if (statusCode >= 400) return "not_found";
+  if (statusCode >= 300) return "redirect";
+  return "served";
+}
+
+/** Counts *about* a day, stored alongside the paths in the same map. Never a page path. */
+export const NOT_FOUND_KEY = "__not_found__";
+export const REDIRECT_KEY = "__redirect__";
+
+/**
+ * Where a *served* page view goes when we cannot name its path — either the day's key
+ * space is full, or the path is one we answered but cannot normalize.
+ *
+ * It exists because `__unmatched__` used to mean both "we served this and cannot name it"
+ * and "this is not a page at all", and the two have to be separated to exclude one from
+ * the total without dropping the other. Everything under this key is a request we
+ * answered with a page, so it counts.
+ */
+export const OVERFLOW_PAGE_KEY = "__other_pages__";
+
+/**
+ * What `normalizePagePath`/`normalizeRoutePath` return for a path that is not a route we
+ * serve. Declared here rather than next to them because PSEUDO_DAY_KEYS below needs it at
+ * module-evaluation time.
+ */
+export const UNMATCHED_PAGE_KEY = "__unmatched__";
+
+/**
+ * Keys inside a day/all-time map that are not page paths and are never in `total`.
+ *
+ * `__unmatched__` is in here as a *legacy* bucket: the pre-#1029 build wrote 404s there
+ * and had no other use for it that mattered at scale, but it recorded no status code, so
+ * its contents cannot be split now. It is reported as `unclassified_legacy` — excluded
+ * from the total because it is overwhelmingly non-resolving traffic, and named for what
+ * we actually know rather than asserted to be entirely 404s. Nothing writes it any more.
+ */
+const PSEUDO_DAY_KEYS = new Set<string>([DAY_TOTAL_KEY, NOT_FOUND_KEY, REDIRECT_KEY, UNMATCHED_PAGE_KEY]);
+
+/** Where a non-served outcome is tallied inside a day/all-time path map. */
+function outcomeKey(outcome: Exclude<RequestOutcome, "served">): string {
+  return outcome === "redirect" ? REDIRECT_KEY : NOT_FOUND_KEY;
+}
+
 // --- Client-class traffic attribution (#1019) ---
 //
 // These counters ride inside the page-view snapshot rather than in keys of their own.
@@ -1006,15 +1077,51 @@ const CLASS_ROUTE_SEP = "|";
 /** Overflow bucket for the per-day family map. Matches UNKNOWN_FAMILY in client-class.ts. */
 const UNKNOWN_FAMILY_KEY = "unknown";
 
+/**
+ * One remembered non-resolving request (#1029). The `__unmatched__` bucket answers "how
+ * many" and nothing else, which is not enough to tell a vulnerability scanner from a
+ * search engine walking our URLs wrong — two facts that lead to opposite decisions.
+ *
+ * The path is sanitized and truncated on the way in. It is never used to construct a key
+ * (that is what bounded the key space in the first place) and carries no PII.
+ */
+export interface NotFoundSample {
+  ts: string;
+  client_class: string;
+  status: number;
+  path: string;
+}
+
+/** How many recent non-resolving requests to remember. Rides in the existing snapshot. */
+const NOT_FOUND_SAMPLE_MAX = 50;
+const NOT_FOUND_SAMPLE_PATH_MAX = 80;
+
+/**
+ * Reduce an attacker-controlled path to something safe to store and to render. Strips
+ * everything outside printable ASCII plus the characters that could close out of a
+ * markup or shell context, then truncates.
+ */
+export function sanitizeSamplePath(raw: unknown): string {
+  const clean = String(raw ?? "")
+    .replace(/[^\x20-\x7e]/g, "")
+    .replace(/[<>"'`&\\]/g, "");
+  return clean.length > NOT_FOUND_SAMPLE_PATH_MAX
+    ? `${clean.slice(0, NOT_FOUND_SAMPLE_PATH_MAX)}...`
+    : clean;
+}
+
 interface PageViewSnapshot {
-  /** date -> path -> count, including the DAY_TOTAL_KEY pseudo-path. Humans only. */
+  /** date -> path -> count, including the pseudo-keys in PSEUDO_DAY_KEYS. Humans only. */
   days: Record<string, Record<string, number>>;
   /** date -> referrer domain -> count. */
   referrers: Record<string, Record<string, number>>;
-  /** path -> count, never pruned by date. */
+  /** path -> count, never pruned by date. Carries the same pseudo-keys as a day map. */
   all_time: Record<string, number>;
   updated_at: string;
-  /** date -> client class -> hits. Every classified request, bots included (#1019). */
+  /**
+   * date -> client class -> hits we *served* (2xx). Bots included (#1019); requests that
+   * redirected or did not resolve are in `redirects`/`not_found` and never here (#1029).
+   */
   classes: Record<string, Record<string, number>>;
   /** date -> `${class}|${route}` -> hits. Flattened so the 2-level helpers still apply. */
   class_routes: Record<string, Record<string, number>>;
@@ -1022,6 +1129,29 @@ interface PageViewSnapshot {
   families: Record<string, Record<string, number>>;
   /** date -> MCP tool calls, so web_vs_mcp compares the same window on both sides. */
   mcp: Record<string, number>;
+  /** date -> client class -> requests that did not resolve to a page (4xx/5xx) (#1029). */
+  not_found: Record<string, Record<string, number>>;
+  /** date -> client class -> 3xx. Apart, so a redirect and its target are not two hits. */
+  redirects: Record<string, Record<string, number>>;
+  /** Rolling sample of recent non-resolving requests, oldest first (#1029). */
+  not_found_sample: NotFoundSample[];
+  /**
+   * Date the all-time counters were repaired onto the normalized key space (#1029).
+   * Counts carried across from before it were collected by a build that treated a 404 as
+   * a page view, so the series is only quotable from this date on.
+   */
+  all_time_trustworthy_from: string;
+  /**
+   * Date from which `classes` counts served requests only (#1029).
+   *
+   * The page-view maps repair themselves — the total is recomputed from the page keys —
+   * but `classes` holds one number per class per day with the 404s already added in, and
+   * the obvious way to back them out (subtract that class's `__unmatched__` route count)
+   * is not safe: that bucket also absorbs route-key overflow and served-but-unnormalized
+   * routes, neither of which I can bound to zero by inspection. So the day the split
+   * landed is disclosed rather than guessed at, and any window reaching before it says so.
+   */
+  outcome_split_from: string;
 }
 
 function emptySnapshot(): PageViewSnapshot {
@@ -1034,6 +1164,11 @@ function emptySnapshot(): PageViewSnapshot {
     class_routes: {},
     families: {},
     mcp: {},
+    not_found: {},
+    redirects: {},
+    not_found_sample: [],
+    all_time_trustworthy_from: "",
+    outcome_split_from: "",
   };
 }
 
@@ -1049,6 +1184,26 @@ let pageViewsRereadPending = false;
 // Process-local tally, kept even with no storage configured so a dev run and the test
 // suite can still see classification happening. Not a substitute for the snapshot.
 let trafficSinceBoot: Record<string, number> = {};
+/** Non-served outcomes since boot. Kept apart from trafficSinceBoot for the same reason
+ * they are kept apart in the snapshot: `by_class` counts requests we served (#1029). */
+let notFoundSinceBoot = 0;
+let redirectsSinceBoot = 0;
+
+// Newest last, matching the snapshot's ordering so a merge is a plain concatenation.
+function recordNotFoundSample(client_class: string, path: string, status: number): void {
+  pendingPageViews.not_found_sample.push({
+    ts: new Date().toISOString(),
+    client_class,
+    status,
+    path: sanitizeSamplePath(path),
+  });
+  if (pendingPageViews.not_found_sample.length > NOT_FOUND_SAMPLE_MAX) {
+    pendingPageViews.not_found_sample.splice(
+      0,
+      pendingPageViews.not_found_sample.length - NOT_FOUND_SAMPLE_MAX,
+    );
+  }
+}
 
 function bump(map: Record<string, number>, key: string, delta: number): void {
   map[key] = (map[key] ?? 0) + delta;
@@ -1081,6 +1236,12 @@ function countPendingPageViewKeys(): number {
   for (const day of Object.values(pendingPageViews.classes)) n += Object.keys(day).length;
   for (const day of Object.values(pendingPageViews.class_routes)) n += Object.keys(day).length;
   for (const day of Object.values(pendingPageViews.families)) n += Object.keys(day).length;
+  for (const day of Object.values(pendingPageViews.not_found)) n += Object.keys(day).length;
+  for (const day of Object.values(pendingPageViews.redirects)) n += Object.keys(day).length;
+  // Samples on their own must also make the flush worth running: a burst of 404s from a
+  // class already counted today adds no new counter key, and without this the sample
+  // would sit in memory until some other traffic happened to trigger a write.
+  n += pendingPageViews.not_found_sample.length;
   return n;
 }
 
@@ -1098,18 +1259,28 @@ function mergeSnapshot(base: PageViewSnapshot, delta: PageViewSnapshot): PageVie
     class_routes: {},
     families: {},
     mcp: { ...base.mcp },
+    not_found: {},
+    redirects: {},
+    // Oldest first, capped — the delta is newer than the base by construction.
+    not_found_sample: [...base.not_found_sample, ...delta.not_found_sample].slice(-NOT_FOUND_SAMPLE_MAX),
+    all_time_trustworthy_from: base.all_time_trustworthy_from || delta.all_time_trustworthy_from,
+    outcome_split_from: base.outcome_split_from || delta.outcome_split_from,
   };
   for (const [date, map] of Object.entries(base.days)) out.days[date] = { ...map };
   for (const [date, map] of Object.entries(base.referrers)) out.referrers[date] = { ...map };
   for (const [date, map] of Object.entries(base.classes)) out.classes[date] = { ...map };
   for (const [date, map] of Object.entries(base.class_routes)) out.class_routes[date] = { ...map };
   for (const [date, map] of Object.entries(base.families)) out.families[date] = { ...map };
+  for (const [date, map] of Object.entries(base.not_found)) out.not_found[date] = { ...map };
+  for (const [date, map] of Object.entries(base.redirects)) out.redirects[date] = { ...map };
 
   for (const [date, map] of Object.entries(delta.days)) {
     const target = (out.days[date] ??= {});
     for (const [key, count] of Object.entries(map)) {
-      if (key === DAY_TOTAL_KEY) bump(target, key, count);
-      else bumpBounded(target, key, count, MAX_PAGE_KEYS_PER_DAY, UNMATCHED_PAGE_KEY);
+      // Pseudo-keys are counts about the day, not paths: they must never be folded into
+      // the overflow bucket, and they must never consume a slot in the path key space.
+      if (PSEUDO_DAY_KEYS.has(key)) bump(target, key, count);
+      else bumpBounded(target, key, count, MAX_PAGE_KEYS_PER_DAY, OVERFLOW_PAGE_KEY);
     }
   }
   for (const [date, map] of Object.entries(delta.referrers)) {
@@ -1119,7 +1290,16 @@ function mergeSnapshot(base: PageViewSnapshot, delta: PageViewSnapshot): PageVie
     }
   }
   for (const [key, count] of Object.entries(delta.all_time)) {
-    bumpBounded(out.all_time, key, count, MAX_ALL_TIME_PAGE_KEYS, UNMATCHED_PAGE_KEY);
+    if (PSEUDO_DAY_KEYS.has(key)) bump(out.all_time, key, count);
+    else bumpBounded(out.all_time, key, count, MAX_ALL_TIME_PAGE_KEYS, OVERFLOW_PAGE_KEY);
+  }
+  // Both are keyed by the fixed class enum, so they need no cap for the same reason
+  // `classes` needs none.
+  for (const field of ["not_found", "redirects"] as const) {
+    for (const [date, map] of Object.entries(delta[field])) {
+      const target = (out[field][date] ??= {});
+      for (const [key, count] of Object.entries(map)) bump(target, key, count);
+    }
   }
   // The class map is keyed by a fixed 8-value enum, so it needs no cap — an unbounded
   // key here would mean the classifier returned something it cannot return.
@@ -1148,7 +1328,7 @@ function mergeSnapshot(base: PageViewSnapshot, delta: PageViewSnapshot): PageVie
 // move hits between classes on a busy day, which is the one number we quote.
 function classRouteOverflowKey(key: string): string {
   const cls = key.split(CLASS_ROUTE_SEP)[0];
-  return `${cls}${CLASS_ROUTE_SEP}${UNMATCHED_PAGE_KEY}`;
+  return `${cls}${CLASS_ROUTE_SEP}${OVERFLOW_PAGE_KEY}`;
 }
 
 // Retention is applied here rather than by Redis TTLs — one fewer command per key, and it
@@ -1160,21 +1340,89 @@ function pruneSnapshot(snapshot: PageViewSnapshot): void {
     for (const date of dates.slice(PAGE_VIEW_DAY_RETENTION)) delete snapshot[field][date];
   }
   // Class totals and MCP call counts are narrow enough to keep for the 30-day window
-  // the web_vs_mcp comparison reports over.
-  for (const date of Object.keys(snapshot.classes).sort().reverse().slice(CLASS_DAY_RETENTION)) {
-    delete snapshot.classes[date];
+  // the web_vs_mcp comparison reports over. The outcome counters are the same shape (a
+  // fixed enum per date) and answer questions over the same window.
+  for (const field of ["classes", "mcp", "not_found", "redirects"] as const) {
+    for (const date of Object.keys(snapshot[field]).sort().reverse().slice(CLASS_DAY_RETENTION)) {
+      delete snapshot[field][date];
+    }
   }
-  for (const date of Object.keys(snapshot.mcp).sort().reverse().slice(CLASS_DAY_RETENTION)) {
-    delete snapshot.mcp[date];
-  }
-  const entries = Object.entries(snapshot.all_time);
+  // The sample is deliberately NOT capped here. Two places already bound it: the recorder
+  // (in-memory growth between flushes) and the merge (base + delta, which is both what a
+  // reader sees and what the next flush writes). A third copy of the same rule is a line
+  // no test can bite, which makes it a line nobody can safely change later.
+  //
+  // Pseudo-keys are held out of the cap: they are counts about the whole series, they
+  // cannot grow the key space, and folding one into __unmatched__ would move a
+  // deliberately-excluded number back into the reported total.
+  const pseudo = Object.entries(snapshot.all_time).filter(([k]) => PSEUDO_DAY_KEYS.has(k));
+  const entries = Object.entries(snapshot.all_time).filter(([k]) => !PSEUDO_DAY_KEYS.has(k));
   if (entries.length > MAX_ALL_TIME_PAGE_KEYS) {
     entries.sort((a, b) => b[1] - a[1]);
-    const kept = Object.fromEntries(entries.slice(0, MAX_ALL_TIME_PAGE_KEYS));
+    const kept = Object.fromEntries([...entries.slice(0, MAX_ALL_TIME_PAGE_KEYS), ...pseudo]);
     const folded = entries.slice(MAX_ALL_TIME_PAGE_KEYS).reduce((sum, [, v]) => sum + v, 0);
     snapshot.all_time = kept;
-    if (folded > 0) bump(snapshot.all_time, UNMATCHED_PAGE_KEY, folded);
+    if (folded > 0) bump(snapshot.all_time, OVERFLOW_PAGE_KEY, folded);
   }
+}
+
+/**
+ * One-time repair of the pre-#1021 all-time key space (#1029).
+ *
+ * Before path normalization existed, `recordPageView` used the raw pathname, so every
+ * string a scanner put in a request line became a permanent counter: `/$(pwd)/.env`,
+ * `/%2f%2eenv`, `/%2egit/%63onfig`. #1023's migration carried those counts faithfully
+ * into the snapshot, which is where they still are — `all_time.top_pages` serves them.
+ *
+ * They were never page views, they were scans, so their counts move to the not-found
+ * bucket rather than being deleted: the arithmetic stays exact and the scan volume stays
+ * visible, which is the whole shape of this issue.
+ *
+ * This much is provable: a key that fails normalization is one we cannot have answered
+ * with a page, because the router has no route of that shape.
+ *
+ * What this deliberately does NOT touch:
+ *   `__unmatched__` — already collapsed, and the build that wrote it recorded no status
+ *     code, so it cannot be split into 404s and served-but-unnamed. It is reported as
+ *     `unclassified_legacy`: outside the total, named for what we actually know.
+ *   a 404 on a slug-shaped path — `/wp-login`, `/telescope` — normalizes to itself and is
+ *     indistinguishable from a real page in a counter that never recorded a status.
+ * That residue is why the payload carries `trustworthy_from` rather than a claim that the
+ * all-time series is now clean.
+ *
+ * Idempotent: after the first pass there is nothing left that fails normalization.
+ */
+function repairAllTimeKeys(snapshot: PageViewSnapshot): { keys: number; hits: number } {
+  let keys = 0;
+  let hits = 0;
+  for (const [key, count] of Object.entries(snapshot.all_time)) {
+    if (PSEUDO_DAY_KEYS.has(key) || key === OVERFLOW_PAGE_KEY) continue;
+    if (normalizePagePath(key) === key) continue;
+    delete snapshot.all_time[key];
+    bump(snapshot.all_time, NOT_FOUND_KEY, count);
+    keys++;
+    hits += count;
+  }
+  return { keys, hits };
+}
+
+/** Repair + stamp, applied wherever a stored snapshot is adopted as the base. */
+function adoptSnapshot(snapshot: PageViewSnapshot): PageViewSnapshot {
+  const repaired = repairAllTimeKeys(snapshot);
+  if (repaired.keys > 0) {
+    console.error(
+      `[telemetry] #1029 all-time repair: moved ${repaired.keys} non-route keys ` +
+        `(${repaired.hits} hits) into ${NOT_FOUND_KEY}`,
+    );
+  }
+  // Repair, then prune — never the other way round. The prune's overflow bucket means
+  // "a page we served but cannot name", so anything folded into it before the repair has
+  // run is permanently mislabelled as served.
+  pruneSnapshot(snapshot);
+  const today = new Date().toISOString().slice(0, 10);
+  if (!snapshot.all_time_trustworthy_from) snapshot.all_time_trustworthy_from = today;
+  if (!snapshot.outcome_split_from) snapshot.outcome_split_from = today;
+  return snapshot;
 }
 
 function numericMap(raw: unknown): Record<string, number> {
@@ -1209,7 +1457,39 @@ function normalizeSnapshot(raw: unknown): PageViewSnapshot {
   snapshot.class_routes = numericMapOfMaps(obj.class_routes);
   snapshot.families = numericMapOfMaps(obj.families);
   snapshot.mcp = numericMap(obj.mcp);
+  // Absent on a snapshot written before #1029. An empty map reads as "that build did not
+  // separate outcomes", which is true — the not-found hits it recorded are inside
+  // `classes` and `days`, and `trustworthy_from` is what says so.
+  snapshot.not_found = numericMapOfMaps(obj.not_found);
+  snapshot.redirects = numericMapOfMaps(obj.redirects);
+  snapshot.not_found_sample = notFoundSamples(obj.not_found_sample);
+  snapshot.all_time_trustworthy_from =
+    typeof obj.all_time_trustworthy_from === "string" ? obj.all_time_trustworthy_from : "";
+  snapshot.outcome_split_from =
+    typeof obj.outcome_split_from === "string" ? obj.outcome_split_from : "";
   return snapshot;
+}
+
+// Re-validates on the way back in: the blob is stored data, and the path field is the one
+// piece of it that originated in a request line.
+function notFoundSamples(raw: unknown): NotFoundSample[] {
+  if (!Array.isArray(raw)) return [];
+  const out: NotFoundSample[] = [];
+  // Not re-capped here: the merge bounds what any reader sees and what the next flush
+  // writes back, so an oversized stored blob is reported at the cap and rewritten at the
+  // cap. What this loop is for is the per-entry validation below — the path is the one
+  // field in the snapshot that originated in a request line.
+  for (const entry of raw) {
+    if (!entry || typeof entry !== "object") continue;
+    const e = entry as Record<string, unknown>;
+    out.push({
+      ts: typeof e.ts === "string" ? e.ts : "",
+      client_class: typeof e.client_class === "string" ? e.client_class : "unknown",
+      status: typeof e.status === "number" && Number.isFinite(e.status) ? e.status : 0,
+      path: sanitizeSamplePath(e.path),
+    });
+  }
+  return out;
 }
 
 async function redisMget(keys: string[]): Promise<RedisResult<(string | null)[]>> {
@@ -1280,9 +1560,6 @@ const DYNAMIC_PAGE_PREFIXES = [
   "/best/",
 ] as const;
 
-// Every page view that is not a route we actually serve collapses into this one key.
-export const UNMATCHED_PAGE_KEY = "__unmatched__";
-
 // Maps a raw request path onto a bounded key space. Before this, `recordPageView` used the
 // raw pathname, so any string an attacker put in a request line became a permanent Redis
 // key — the live keyspace contained entries like `/$(pwd)/.env` (#1018).
@@ -1341,12 +1618,26 @@ export function recordTraffic(
 ): void {
   const { client_class, family } = classification;
   const today = new Date().toISOString().slice(0, 10);
+  const outcome = requestOutcome(statusCode);
+
+  // A client that only ever 404s is not a client that read 3,000 pages, so the outcome
+  // decides which counter moves — not just which route key it lands under (#1029).
+  if (outcome !== "served") {
+    if (outcome === "not_found") {
+      notFoundSinceBoot++;
+      recordNotFoundSample(client_class, path, statusCode ?? 0);
+    } else {
+      redirectsSinceBoot++;
+    }
+    if (!useRedis()) return;
+    bump((pendingPageViews[outcome === "redirect" ? "redirects" : "not_found"][today] ??= {}), client_class, 1);
+    return;
+  }
 
   trafficSinceBoot[client_class] = (trafficSinceBoot[client_class] ?? 0) + 1;
   if (!useRedis()) return;
 
-  const served = statusCode === undefined || statusCode < 400;
-  const route = served ? normalizeRoutePath(path) : UNMATCHED_PAGE_KEY;
+  const route = normalizeRoutePath(path);
 
   bump((pendingPageViews.classes[today] ??= {}), client_class, 1);
   bumpBounded(
@@ -1354,7 +1645,7 @@ export function recordTraffic(
     `${client_class}${CLASS_ROUTE_SEP}${route}`,
     1,
     MAX_CLASS_ROUTE_KEYS_PER_DAY,
-    `${client_class}${CLASS_ROUTE_SEP}${UNMATCHED_PAGE_KEY}`,
+    `${client_class}${CLASS_ROUTE_SEP}${OVERFLOW_PAGE_KEY}`,
     pageViewSnapshot.class_routes[today],
   );
   // Per-family detail is only kept for the class it is asked about. Every other class
@@ -1382,19 +1673,33 @@ export function recordPageView(path: string, userAgent: string, referer?: string
     pageViewsToday = 0;
     pageViewsTodayDate = today;
   }
-  pageViewsToday++;
+  const outcome = requestOutcome(statusCode);
+  if (outcome === "served") pageViewsToday++;
 
   if (!useRedis()) return;
 
-  const served = statusCode === undefined || statusCode < 400;
-  const key = served ? normalizePagePath(path) : UNMATCHED_PAGE_KEY;
+  // Requests that did not resolve to a page are counted, under their own name, and are
+  // not part of the day total. They also earn no referrer credit and no path key — the
+  // path is not one of ours (#1029).
+  if (outcome !== "served") {
+    const day = (pendingPageViews.days[today] ??= {});
+    bump(day, outcomeKey(outcome), 1);
+    bump(pendingPageViews.all_time, outcomeKey(outcome), 1);
+    return;
+  }
+
+  // A path we answered but cannot name goes to the served-overflow bucket, never to
+  // __unmatched__ — that key now means "recorded before we counted outcomes" and is
+  // reported outside the total, so a served hit landing there would vanish from it.
+  const normalized = normalizePagePath(path);
+  const key = normalized === UNMATCHED_PAGE_KEY ? OVERFLOW_PAGE_KEY : normalized;
 
   // Pure in-memory accounting — no Redis command on the request path at all. The deltas
   // go out aggregated on the next flush (#1023).
   const day = (pendingPageViews.days[today] ??= {});
-  bumpBounded(day, key, 1, MAX_PAGE_KEYS_PER_DAY, UNMATCHED_PAGE_KEY, pageViewSnapshot.days[today]);
+  bumpBounded(day, key, 1, MAX_PAGE_KEYS_PER_DAY, OVERFLOW_PAGE_KEY, pageViewSnapshot.days[today]);
   bump(day, DAY_TOTAL_KEY, 1);
-  bumpBounded(pendingPageViews.all_time, key, 1, MAX_ALL_TIME_PAGE_KEYS, UNMATCHED_PAGE_KEY, pageViewSnapshot.all_time);
+  bumpBounded(pendingPageViews.all_time, key, 1, MAX_ALL_TIME_PAGE_KEYS, OVERFLOW_PAGE_KEY, pageViewSnapshot.all_time);
 
   if (referer) {
     try {
@@ -1459,7 +1764,9 @@ async function migrateLegacyPageViews(): Promise<PageViewSnapshot | null> {
   }
 
   // pv:all:* never had a total key; the day maps did, and it is carried across as-is.
-  pruneSnapshot(snapshot);
+  // Deliberately NOT pruned here: pruning folds overflowing keys into the served-overflow
+  // bucket, and doing that before the repair has classified them would relabel junk keys
+  // as pages we served. adoptSnapshot repairs first, then prunes.
   return snapshot;
 }
 
@@ -1470,7 +1777,7 @@ async function loadPageViews(): Promise<void> {
 
   if (res.result) {
     try {
-      pageViewSnapshot = normalizeSnapshot(JSON.parse(res.result));
+      pageViewSnapshot = adoptSnapshot(normalizeSnapshot(JSON.parse(res.result)));
       pageViewsLoaded = true;
       pageViewsRereadPending = true;
       legacyMigrationDone = true;
@@ -1483,7 +1790,9 @@ async function loadPageViews(): Promise<void> {
   if (!legacyMigrationDone) {
     const migrated = await migrateLegacyPageViews();
     if (!migrated) return; // could not read the legacy keys — retry rather than zero them
-    pageViewSnapshot = migrated;
+    // Repaired on the way in: the legacy key space is precisely where the junk keys came
+    // from, so a rebuild from it must not re-create what the repair removed.
+    pageViewSnapshot = adoptSnapshot(migrated);
     legacyMigrationDone = true;
   }
   pageViewsLoaded = true;
@@ -1515,7 +1824,7 @@ async function flushPageViews(): Promise<void> {
     pageViewsRereadPending = false;
     const read = await redisCommand<string | null>(["GET", PAGE_VIEWS_KEY]);
     if (read.ok && read.result) {
-      try { pageViewSnapshot = normalizeSnapshot(JSON.parse(read.result)); }
+      try { pageViewSnapshot = adoptSnapshot(normalizeSnapshot(JSON.parse(read.result))); }
       catch { /* corrupt — keep the last known-good local copy */ }
     }
   }
@@ -1582,10 +1891,21 @@ export function flushPending(): Promise<void> {
 }
 
 export interface PageViewPeriod {
+  /** Pages we served (2xx). Excludes redirects and non-resolving requests (#1029). */
   total: number | null;
   top_pages: { path: string; views: number }[];
   /** True when at least one key in this period could not be read. */
   partial: boolean;
+  /** Requests that resolved to no page (4xx/5xx). Counted, never inside `total`. */
+  not_found: number;
+  /** 3xx. Counted apart so a redirect and the request that follows it are not two views. */
+  redirects: number;
+  /**
+   * Hits the pre-#1029 build collapsed into `__unmatched__` before it recorded a status
+   * code. Overwhelmingly 404s, but it did not record enough to prove that, so they are
+   * excluded from `total` and reported under a name that claims only what we know.
+   */
+  unclassified_legacy: number;
 }
 
 export interface PageViewsReport {
@@ -1593,34 +1913,83 @@ export interface PageViewsReport {
   yesterday: PageViewPeriod;
   all_time: PageViewPeriod;
   referrers_today: Record<string, number>;
+  /**
+   * Date from which `all_time` was collected under the current counting rules. Counts
+   * before it came from a build that treated a 404 as a page view and minted a permanent
+   * key per scanned path; they are retained, repaired where that was possible, and are
+   * not quotable.
+   */
+  all_time_trustworthy_from: string | null;
+  /** What each figure includes and excludes. Meant to be read next to the numbers. */
+  notes: string[];
   /** False when the storage layer could not be read at all — the numbers are not measurements. */
   available: boolean;
   error: string | null;
   storage: TelemetryHealth;
 }
 
-const UNAVAILABLE_PERIOD: PageViewPeriod = { total: null, top_pages: [], partial: true };
+const UNAVAILABLE_PERIOD: PageViewPeriod = {
+  total: null,
+  top_pages: [],
+  partial: true,
+  not_found: 0,
+  redirects: 0,
+  unclassified_legacy: 0,
+};
+
+const PAGE_VIEW_NOTES = [
+  "`total` counts requests we answered with a page (2xx), by a non-bot client, over the stated period. It excludes bots, redirects, non-resolving requests, API routes, /mcp and static assets.",
+  "`not_found` counts requests that resolved to no page (4xx/5xx). Before #1029 these were inside `total` and were 84% of it on the day the defect was found.",
+  "`redirects` counts 3xx answers to page requests. A redirect is followed, and the request that follows it is the page view — counting both would double it. Redirects issued before the page-view hook (non-canonical hostnames, /vendors/*) are counted on /api/traffic instead, so that figure is the larger of the two.",
+  "`top_pages` lists normalized route patterns, not raw paths, and is truncated to the top 20 — the entries do not sum to `total`.",
+  "`all_time` has no retention and spans the pre-#1029 counting rules; read `all_time_trustworthy_from` before quoting it. Daily figures are retained for 7 days.",
+];
 
 const TOP_PAGES_LIMIT = 20;
 
 function topPages(map: Record<string, number>): { path: string; views: number }[] {
   return Object.entries(map)
-    .filter(([path]) => path !== DAY_TOTAL_KEY)
+    .filter(([path]) => !PSEUDO_DAY_KEYS.has(path))
     .map(([path, views]) => ({ path, views }))
     .sort((a, b) => b.views - a.views)
     .slice(0, TOP_PAGES_LIMIT);
 }
 
-// A day map carries its own total. An absent day is a measured zero, not an unknown —
-// we hold the whole snapshot, so "we have no record of that day" is a real answer.
+/**
+ * `total` is the sum of the page keys, not the stored `total` counter.
+ *
+ * They agree for anything recorded after #1029 — one served view bumps exactly one page
+ * key and the counter — but they disagree for a day recorded before it, because that
+ * build bumped the counter for 404s too. Summing the page keys counts only what we can
+ * name as a page, which is the right answer for both eras and needs no retroactive
+ * rewrite of stored history to get there.
+ */
+function periodFrom(map: Record<string, number>): PageViewPeriod {
+  const total = Object.entries(map).reduce((sum, [k, v]) => (PSEUDO_DAY_KEYS.has(k) ? sum : sum + v), 0);
+  // Whatever the old counter counted that we cannot name as a page: the collapsed
+  // __unmatched__ bucket, plus any excess the stored total carries over the page keys
+  // (a legacy day whose per-path keys expired out from under its total). Taking the
+  // larger keeps the arithmetic closed instead of quietly dropping the difference.
+  const stored = map[DAY_TOTAL_KEY] ?? 0;
+  const unclassified = Math.max(map[UNMATCHED_PAGE_KEY] ?? 0, stored - total);
+  return {
+    total,
+    top_pages: topPages(map),
+    partial: false,
+    not_found: map[NOT_FOUND_KEY] ?? 0,
+    redirects: map[REDIRECT_KEY] ?? 0,
+    unclassified_legacy: Math.max(0, unclassified),
+  };
+}
+
+// An absent day is a measured zero, not an unknown — we hold the whole snapshot, so
+// "we have no record of that day" is a real answer.
 function dayPeriod(map: Record<string, number> | undefined): PageViewPeriod {
-  if (!map) return { total: 0, top_pages: [], partial: false };
-  return { total: map[DAY_TOTAL_KEY] ?? 0, top_pages: topPages(map), partial: false };
+  return periodFrom(map ?? {});
 }
 
 function allTimePeriod(map: Record<string, number>): PageViewPeriod {
-  const total = Object.entries(map).reduce((sum, [k, v]) => (k === DAY_TOTAL_KEY ? sum : sum + v), 0);
-  return { total, top_pages: topPages(map), partial: false };
+  return periodFrom(map);
 }
 
 // Serves the in-memory snapshot plus everything not yet flushed. Costs zero Redis
@@ -1636,10 +2005,12 @@ export async function getPageViews(): Promise<PageViewsReport> {
     // No storage configured: today's in-memory counter is a real measurement, the
     // historical periods are simply not available here.
     return {
-      today: { total: pageViewsToday, top_pages: [], partial: false },
+      today: { total: pageViewsToday, top_pages: [], partial: false, not_found: notFoundSinceBoot, redirects: redirectsSinceBoot, unclassified_legacy: 0 },
       yesterday: { ...UNAVAILABLE_PERIOD },
       all_time: { ...UNAVAILABLE_PERIOD },
       referrers_today: {},
+      all_time_trustworthy_from: null,
+      notes: PAGE_VIEW_NOTES,
       available: false,
       error: "redis-not-configured",
       storage,
@@ -1654,6 +2025,8 @@ export async function getPageViews(): Promise<PageViewsReport> {
       yesterday: { ...UNAVAILABLE_PERIOD },
       all_time: { ...UNAVAILABLE_PERIOD },
       referrers_today: {},
+      all_time_trustworthy_from: null,
+      notes: PAGE_VIEW_NOTES,
       available: false,
       error: redisHealth.lastReadError ?? "page-view snapshot not loaded",
       storage,
@@ -1667,6 +2040,8 @@ export async function getPageViews(): Promise<PageViewsReport> {
     yesterday: dayPeriod(view.days[yesterday]),
     all_time: allTimePeriod(view.all_time),
     referrers_today: { ...(view.referrers[today] ?? {}) },
+    all_time_trustworthy_from: view.all_time_trustworthy_from || null,
+    notes: PAGE_VIEW_NOTES,
     available: true,
     error: null,
     storage,
@@ -1695,13 +2070,33 @@ export interface TrafficWindow {
    * them, and silently.
    */
   detail_days: number;
-  /** Every classified request in the window, `internal` included. */
+  /**
+   * How many days of the window we actually hold data for. A keyspace rebuilt this
+   * morning makes `last_30d` arithmetically correct and presentationally a lie; this is
+   * the field that says so, and `coverage` says it in words.
+   */
+  data_days_available: number;
+  /** "complete", or a sentence naming how much of the window is backed by data. */
+  coverage: string;
+  /** Every request in the window we answered with content (2xx), `internal` included. */
   hits_total: number;
   /** `hits_total` minus `internal`. This is the number to quote. */
   hits_excluding_internal: number;
   by_class: Record<string, number>;
   ai_agent_by_family: Record<string, number>;
   top_routes_by_class: Record<string, { route: string; hits: number }[]>;
+  /** Requests that resolved to no page. Never inside `hits_total` (#1029). */
+  not_found_total: number;
+  not_found_by_class: Record<string, number>;
+  /** 3xx. Also outside `hits_total` — the request that follows the redirect is the hit. */
+  redirect_total: number;
+  redirects_by_class: Record<string, number>;
+  /**
+   * Empty once the whole window post-dates the outcome split (#1029). While it is not,
+   * the listed dates were recorded by a build that counted non-resolving requests inside
+   * `by_class`, so `hits_total` for this window is high by however many those were.
+   */
+  pre_split_dates: string[];
 }
 
 export interface WebVsMcp {
@@ -1725,7 +2120,15 @@ export interface TrafficReport {
   /** False when the storage layer could not be read — the numbers are not measurements. */
   available: boolean;
   error: string | null;
+  /** Served requests only, matching `by_class`. */
   since_boot_by_class: Record<string, number>;
+  since_boot_not_found: number;
+  since_boot_redirects: number;
+  /**
+   * The last few non-resolving requests, newest first. Enough to tell a vulnerability
+   * scanner from a broken integration, which the count alone cannot (#1029).
+   */
+  not_found_sample: NotFoundSample[];
   notes: string[];
   storage: TelemetryHealth;
 }
@@ -1747,12 +2150,54 @@ function emptyWindow(days: number): TrafficWindow {
     from: dates[dates.length - 1],
     to: dates[0],
     detail_days: Math.min(days, PAGE_VIEW_DAY_RETENTION),
+    data_days_available: 0,
+    coverage: coverageNote(days, 0),
     hits_total: 0,
     hits_excluding_internal: 0,
     by_class: {},
     ai_agent_by_family: {},
     top_routes_by_class: {},
+    not_found_total: 0,
+    not_found_by_class: {},
+    redirect_total: 0,
+    redirects_by_class: {},
+    pre_split_dates: [],
   };
+}
+
+/**
+ * Earliest date we hold any record for, across every dated map. Derived rather than
+ * stored so that a keyspace rebuild moves it forward on its own — the failure mode of a
+ * stored "collecting since" date is that it survives the reset it was supposed to warn
+ * about. A genuinely silent first day understates coverage by one, which errs the safe
+ * way.
+ */
+function earliestRecordedDate(view: PageViewSnapshot): string | null {
+  let earliest: string | null = null;
+  const dated = [view.classes, view.days, view.not_found, view.redirects, view.referrers];
+  for (const map of dated) {
+    for (const date of Object.keys(map)) {
+      if (Object.keys(map[date] ?? {}).length === 0) continue;
+      if (earliest === null || date < earliest) earliest = date;
+    }
+  }
+  for (const date of Object.keys(view.mcp)) {
+    if (earliest === null || date < earliest) earliest = date;
+  }
+  return earliest;
+}
+
+function coverageNote(days: number, available: number, earliest?: string | null): string {
+  if (available >= days) return "complete";
+  const since = earliest ? ` (earliest record ${earliest})` : "";
+  return `partial — ${available} of ${days} day${days === 1 ? "" : "s"} of data available${since}`;
+}
+
+function daysBetweenInclusive(from: string, to: string): number {
+  const a = Date.parse(`${from}T00:00:00Z`);
+  const b = Date.parse(`${to}T00:00:00Z`);
+  if (!Number.isFinite(a) || !Number.isFinite(b) || b < a) return 0;
+  return Math.round((b - a) / 86400000) + 1;
 }
 
 function buildWindow(view: PageViewSnapshot, days: number): TrafficWindow {
@@ -1760,11 +2205,38 @@ function buildWindow(view: PageViewSnapshot, days: number): TrafficWindow {
   const window = emptyWindow(days);
   const routeTotals: Record<string, Record<string, number>> = {};
 
+  const earliest = earliestRecordedDate(view);
+  // Clamped by construction: the span runs from the later of (earliest record, window
+  // start) to the window end, which cannot exceed the window.
+  window.data_days_available = earliest
+    ? daysBetweenInclusive(earliest > window.from ? earliest : window.from, window.to)
+    : 0;
+  window.coverage = coverageNote(days, window.data_days_available, earliest);
+
+  // The split landed mid-day, so its own date is mixed and counts as pre-split.
+  const split = view.outcome_split_from;
+  if (split) {
+    window.pre_split_dates = dates.filter(d => d <= split && view.classes[d]).sort();
+    if (window.pre_split_dates.length > 0) {
+      window.coverage +=
+        `; hits_total still includes non-resolving requests on ${window.pre_split_dates.join(", ")}, ` +
+        `recorded before the outcome split on ${split}`;
+    }
+  }
+
   for (const date of dates) {
     for (const [cls, count] of Object.entries(view.classes[date] ?? {})) {
       window.by_class[cls] = (window.by_class[cls] ?? 0) + count;
       window.hits_total += count;
       if (cls !== "internal") window.hits_excluding_internal += count;
+    }
+    for (const [cls, count] of Object.entries(view.not_found[date] ?? {})) {
+      window.not_found_by_class[cls] = (window.not_found_by_class[cls] ?? 0) + count;
+      window.not_found_total += count;
+    }
+    for (const [cls, count] of Object.entries(view.redirects[date] ?? {})) {
+      window.redirects_by_class[cls] = (window.redirects_by_class[cls] ?? 0) + count;
+      window.redirect_total += count;
     }
     for (const [family, count] of Object.entries(view.families[date] ?? {})) {
       window.ai_agent_by_family[family] = (window.ai_agent_by_family[family] ?? 0) + count;
@@ -1781,7 +2253,11 @@ function buildWindow(view: PageViewSnapshot, days: number): TrafficWindow {
 
   // Classes we never saw still appear, at zero — an absent key would read as "unknown"
   // when what we mean is "measured, and it was none".
-  for (const cls of TRAFFIC_CLASSES) window.by_class[cls] ??= 0;
+  for (const cls of TRAFFIC_CLASSES) {
+    window.by_class[cls] ??= 0;
+    window.not_found_by_class[cls] ??= 0;
+    window.redirects_by_class[cls] ??= 0;
+  }
 
   for (const [cls, routes] of Object.entries(routeTotals)) {
     window.top_routes_by_class[cls] = Object.entries(routes)
@@ -1819,6 +2295,9 @@ const TRAFFIC_NOTES = [
   "No PII. Only the class and a bounded family label from a fixed table are stored; user agents and IPs are never persisted.",
   "Attribution starts from the deploy that introduced it — windows longer than that are short by however much history predates it, not wrong.",
   "Class totals are retained for 30 days; the per-family and per-route breakdowns only for 7. Each window states its own detail_days rather than presenting 7 days of detail as 30.",
+  "hits_total, hits_excluding_internal, by_class and top_routes_by_class count requests we answered with content (2xx). Requests that did not resolve are in not_found_*, and 3xx answers are in redirect_* — a client that only ever 404s is not a client that read our pages (#1029).",
+  "not_found carries no route breakdown: an unmatched path has no route by definition. not_found_sample carries the actual paths, sanitized and truncated, for the last 50.",
+  "Each window states data_days_available alongside days. Where they differ the window is arithmetically correct and shorter than its label — read coverage before quoting it.",
 ];
 
 /**
@@ -1843,6 +2322,13 @@ export function getTrafficReport(): TrafficReport {
     available: false,
     error,
     since_boot_by_class,
+    since_boot_not_found: notFoundSinceBoot,
+    since_boot_redirects: redirectsSinceBoot,
+    // The buffered sample is a real observation of this process, exactly like the
+    // since-boot tallies beside it. Returning [] here would report the count of a thing
+    // while hiding the thing itself, on the code path — no storage, or storage we could
+    // not read — where an operator most needs to see what is hitting the server.
+    not_found_sample: [...pendingPageViews.not_found_sample].reverse(),
     notes: TRAFFIC_NOTES,
     storage,
   });
@@ -1869,6 +2355,9 @@ export function getTrafficReport(): TrafficReport {
     available: true,
     error: null,
     since_boot_by_class,
+    since_boot_not_found: notFoundSinceBoot,
+    since_boot_redirects: redirectsSinceBoot,
+    not_found_sample: [...view.not_found_sample].reverse(),
     notes: TRAFFIC_NOTES,
     storage,
   };
@@ -1935,18 +2424,58 @@ function catalogMatchCount(entry: SearchQueryEntry): number {
   return entry.unfiltered_count ?? entry.results_count;
 }
 
+/**
+ * How much of the nominal 7-day window these lists are actually backed by (#1029).
+ *
+ * The log is a ring of the last SEARCH_QUERY_RING_MAX entries, so a `_7d` list can be
+ * two hours of a busy morning wearing a week's label — which is exactly what happened
+ * after the #1023 repair reset it, and is why the corrected zero-result list could not be
+ * delivered on #1018. The window states its own denominator rather than relying on the
+ * reader to remember.
+ */
+export interface SearchWindowCoverage {
+  days: number;
+  data_days_available: number;
+  coverage: string;
+  entries: number;
+  oldest_entry: string | null;
+  /** True when the ring is full, so the window is bounded by entry count, not by time. */
+  ring_saturated: boolean;
+}
+
 export function getSearchAnalytics(): {
   top_queries_7d: { query: string; count: number }[];
   zero_result_queries_7d: { query: string; count: number }[];
   filtered_to_zero_queries_7d: { query: string; count: number }[];
   queries_by_source_7d: Record<string, number>;
   queries_by_category_7d: Record<string, number>;
+  window_7d: SearchWindowCoverage;
 } {
   const sevenDaysAgo = Date.now() - 7 * 24 * 60 * 60 * 1000;
   const recent = searchQueryLog.filter(e => {
     const t = new Date(e.timestamp).getTime();
     return Number.isFinite(t) && t >= sevenDaysAgo;
   });
+
+  const timestamps = recent
+    .map(e => new Date(e.timestamp).getTime())
+    .filter(t => Number.isFinite(t));
+  const oldest = timestamps.length > 0 ? Math.min(...timestamps) : null;
+  // Round up: a partial day of data is a day the window is backed by, and rounding down
+  // would report 0 for everything short of 24 hours.
+  const spanDays = oldest === null ? 0 : Math.min(7, Math.ceil((Date.now() - oldest) / 86400000)) || 1;
+  const window_7d: SearchWindowCoverage = {
+    days: 7,
+    data_days_available: spanDays,
+    coverage: coverageNote(
+      7,
+      spanDays,
+      oldest === null ? null : new Date(oldest).toISOString().slice(0, 10),
+    ),
+    entries: recent.length,
+    oldest_entry: oldest === null ? null : new Date(oldest).toISOString(),
+    ring_saturated: searchQueryLog.length >= SEARCH_QUERY_RING_MAX,
+  };
 
   const queryCounts = new Map<string, number>();
   // Genuine gaps: the catalog has nothing for this query at all.
@@ -1978,6 +2507,7 @@ export function getSearchAnalytics(): {
     filtered_to_zero_queries_7d: rank(filteredToZeroCounts, 10),
     queries_by_source_7d: sourceCounts,
     queries_by_category_7d: categoryCounts,
+    window_7d,
   };
 }
 

--- a/test/not-found-accounting.test.ts
+++ b/test/not-found-accounting.test.ts
@@ -1,0 +1,771 @@
+// A request that does not resolve to a page is not a page view (#1029).
+//
+// The defect these lock: 84% of the page views we recorded on 2026-08-25 were a scanner
+// walking paths we do not serve, and the same requests inflated every client class's hit
+// count on /api/traffic. Both figures were about to be quoted to an external partner.
+//
+// The properties under test are the ones that make the numbers quotable:
+//   - a non-resolving request is counted, under its own name, outside every total
+//   - a redirect is counted apart from both, because the request that follows it is the
+//     page view and counting both would double it
+//   - the excluded traffic stays *attributable* — bounded sample, client class, path —
+//     because "scanner" and "broken integration" lead to opposite decisions
+//   - none of it spends a Redis command (#1023's budget still binds)
+//   - the pre-#1021 junk key space is repaired, and what could not be repaired says so
+//
+// Hermetic: Upstash is replaced by an in-process fake that actually stores values.
+
+import { describe, it, beforeEach, afterEach } from "node:test";
+import assert from "node:assert";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { randomUUID } from "node:crypto";
+
+const {
+  recordTraffic: recordTrafficRaw,
+  recordPageView,
+  recordSearchQuery,
+  getSearchAnalytics,
+  getTrafficReport,
+  getPageViews,
+  getStats,
+  resetTelemetryHealth,
+  getTelemetryHealth,
+  resetTelemetryBuffers,
+  resetCounters,
+  loadTelemetry,
+  flushPending,
+  requestOutcome,
+  sanitizeSamplePath,
+  normalizePagePath,
+  UNMATCHED_PAGE_KEY,
+  OVERFLOW_PAGE_KEY,
+  NOT_FOUND_KEY,
+  REDIRECT_KEY,
+} = await import("../dist/stats.js");
+const { classifyRequest } = await import("../dist/client-class.js");
+
+function recordTraffic(path: string, ua: string | undefined, status?: number): void {
+  recordTrafficRaw(classifyRequest(path, ua), path, status);
+}
+
+const PAGE_VIEWS_KEY = "agentdeals:pageviews";
+
+const UA = {
+  chrome: "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36",
+  curl: "curl/8.5.0",
+  googlebot: "Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)",
+  chatgpt: "Mozilla/5.0 (compatible; ChatGPT-User/1.0; +https://openai.com/bot)",
+};
+
+type Call = { cmd: string; args: unknown[] };
+
+class FakeUpstash {
+  values = new Map<string, string>();
+  lists = new Map<string, string[]>();
+  calls: Call[] = [];
+  failWith: string | null = null;
+
+  reset(): void {
+    this.calls = [];
+    this.failWith = null;
+  }
+  commandCount(cmd?: string): number {
+    return cmd ? this.calls.filter(c => c.cmd === cmd).length : this.calls.length;
+  }
+  exec(cmd: string, args: unknown[]): unknown {
+    switch (cmd) {
+      case "GET": {
+        const v = this.values.get(String(args[0]));
+        return { result: v === undefined ? null : v };
+      }
+      case "SET":
+        this.values.set(String(args[0]), String(args[1]));
+        return { result: "OK" };
+      case "MGET":
+        return { result: args.map(k => this.values.get(String(k)) ?? null) };
+      case "SCAN": {
+        const pattern = String(args[2]);
+        const prefix = pattern.endsWith("*") ? pattern.slice(0, -1) : pattern;
+        return { result: ["0", [...this.values.keys()].filter(k => k.startsWith(prefix))] };
+      }
+      case "LPUSH": {
+        const key = String(args[0]);
+        const list = this.lists.get(key) ?? [];
+        for (const v of args.slice(1)) list.unshift(String(v));
+        this.lists.set(key, list);
+        return { result: list.length };
+      }
+      case "LRANGE": {
+        const list = this.lists.get(String(args[0])) ?? [];
+        return { result: list.slice(Number(args[1]), Number(args[2]) + 1) };
+      }
+      default:
+        return { result: 1 };
+    }
+  }
+}
+
+const realFetch = globalThis.fetch;
+let redis: FakeUpstash;
+let telemetryFile: string;
+
+function installFetchStub(): void {
+  globalThis.fetch = (async (_url: string, init: { body: string }) => {
+    const parsed = JSON.parse(init.body) as unknown[];
+    const cmd = String(parsed[0]).toUpperCase();
+    const args = parsed.slice(1);
+    redis.calls.push({ cmd, args });
+    const body = redis.failWith ? { error: redis.failWith } : redis.exec(cmd, args);
+    return { ok: true, status: 200, json: async () => body };
+  }) as unknown as typeof fetch;
+}
+
+async function boot(): Promise<void> {
+  await loadTelemetry(telemetryFile);
+  redis.reset();
+  resetTelemetryHealth();
+}
+
+function storedSnapshot(): any {
+  const raw = redis.values.get(PAGE_VIEWS_KEY);
+  assert.ok(raw, "expected a persisted snapshot");
+  return JSON.parse(raw!);
+}
+
+const today = () => new Date().toISOString().slice(0, 10);
+const daysAgo = (n: number) => new Date(Date.now() - n * 86400000).toISOString().slice(0, 10);
+
+describe("404s are not page views (#1029)", () => {
+  beforeEach(async () => {
+    process.env.UPSTASH_REDIS_REST_URL = "https://stub.upstash.invalid";
+    process.env.UPSTASH_REDIS_REST_TOKEN = "stub-token";
+    redis = new FakeUpstash();
+    telemetryFile = join(tmpdir(), `not-found-${randomUUID()}.json`);
+    resetCounters();
+    resetTelemetryBuffers();
+    resetTelemetryHealth();
+    installFetchStub();
+  });
+
+  afterEach(() => {
+    globalThis.fetch = realFetch;
+    delete process.env.UPSTASH_REDIS_REST_URL;
+    delete process.env.UPSTASH_REDIS_REST_TOKEN;
+  });
+
+  describe("outcome classification", () => {
+    it("splits 2xx from 3xx from 4xx/5xx", () => {
+      assert.equal(requestOutcome(200), "served");
+      assert.equal(requestOutcome(204), "served");
+      assert.equal(requestOutcome(299), "served");
+      assert.equal(requestOutcome(301), "redirect");
+      assert.equal(requestOutcome(302), "redirect");
+      assert.equal(requestOutcome(304), "redirect");
+      assert.equal(requestOutcome(404), "not_found");
+      assert.equal(requestOutcome(410), "not_found");
+      assert.equal(requestOutcome(500), "not_found");
+      // A caller that recorded no status is recording an intent, not a response. It gets
+      // the pre-#1029 reading rather than being silently reclassified as a failure.
+      assert.equal(requestOutcome(undefined), "served");
+    });
+  });
+
+  describe("the excluded traffic is out of every total we would quote", () => {
+    it("reproduces the reported shape: a scan burst leaves the headline figures alone", async () => {
+      await boot();
+      // 100 scanner 404s against 12 real page views, roughly the ratio production showed.
+      for (let i = 0; i < 100; i++) {
+        recordPageView(`/wp-admin-${i}`, UA.chrome, undefined, 404);
+        recordTraffic(`/wp-admin-${i}`, UA.curl, 404);
+      }
+      for (let i = 0; i < 12; i++) {
+        recordPageView("/vendor/neon", UA.chrome, undefined, 200);
+        recordTraffic("/vendor/neon", UA.chrome, 200);
+      }
+      await flushPending();
+
+      const pv = await getPageViews();
+      assert.equal(pv.today.total, 12, "the page-view headline counts pages we served");
+      assert.equal(pv.today.not_found, 100, "and the scan volume is still visible");
+      assert.equal(pv.all_time.total, 12);
+      assert.equal(pv.all_time.not_found, 100);
+
+      const traffic = getTrafficReport().today;
+      assert.equal(traffic.hits_total, 12);
+      assert.equal(traffic.hits_excluding_internal, 12);
+      assert.equal(traffic.not_found_total, 100);
+      assert.equal(traffic.by_class.sdk_client, 0, "a client that only 404s read nothing");
+      assert.equal(traffic.not_found_by_class.sdk_client, 100);
+      assert.equal(traffic.web_vs_mcp ?? undefined, undefined);
+    });
+
+    it("keeps web_vs_mcp clean, since that is the number going to a partner", async () => {
+      await boot();
+      for (let i = 0; i < 50; i++) recordTraffic(`/probe-${i}`, UA.curl, 404);
+      recordTraffic("/vendor/neon", UA.chatgpt, 200);
+
+      const web = getTrafficReport().web_vs_mcp.today;
+      assert.equal(web.web_hits, 1, "50 failed probes are not 50 web hits");
+      assert.equal(web.ai_agent_hits, 1);
+    });
+
+    it("does not let a 404 reach the in-memory page-view counter either", async () => {
+      await boot();
+      recordPageView("/nope", UA.chrome, undefined, 404);
+      recordPageView("/", UA.chrome, undefined, 200);
+      // getStats().page_views_today is a second surface on the same number, on /api/metrics.
+      assert.equal(getStats().page_views_today, 1);
+    });
+
+    it("counts a redirect apart from both, so it is neither a view nor a failure", async () => {
+      await boot();
+      recordPageView("/compare/b-vs-a", UA.chrome, undefined, 301);
+      recordTraffic("/compare/b-vs-a", UA.chrome, 301);
+      recordPageView("/compare/a-vs-b", UA.chrome, undefined, 200);
+      recordTraffic("/compare/a-vs-b", UA.chrome, 200);
+      await flushPending();
+
+      const pv = await getPageViews();
+      assert.equal(pv.today.total, 1, "the 301 and the request that follows it are one view");
+      assert.equal(pv.today.redirects, 1);
+      assert.equal(pv.today.not_found, 0);
+
+      const traffic = getTrafficReport().today;
+      assert.equal(traffic.hits_total, 1);
+      assert.equal(traffic.redirect_total, 1);
+      assert.equal(traffic.not_found_total, 0);
+      assert.equal(traffic.redirects_by_class.browser, 1);
+      assert.equal(storedSnapshot().days[today()][REDIRECT_KEY], 1);
+      // ...and it must not show up as a route the class read, or the breakdown would
+      // disagree with the total it sits next to.
+      const routes = (traffic.top_routes_by_class.browser ?? []).map((r: any) => r.route);
+      assert.deepEqual(routes, ["/compare/:slug"], `a redirect leaked into the route list: ${routes}`);
+      assert.equal(
+        (storedSnapshot().class_routes[today()] ?? {})["browser|/compare/:slug"],
+        1,
+        "exactly one route hit, from the 200 — not two",
+      );
+    });
+
+    it("earns no referrer credit for a page it did not serve", async () => {
+      await boot();
+      recordPageView("/gone", UA.chrome, "https://news.ycombinator.com/item?id=1", 404);
+      await flushPending();
+      const pv = await getPageViews();
+      assert.deepEqual(pv.referrers_today, {}, "a 404 is not a referral to a page");
+    });
+  });
+
+  describe("the excluded traffic stays attributable", () => {
+    it("remembers the last 50 non-resolving requests with class, status and path", async () => {
+      await boot();
+      recordTraffic("/wp-login.php", UA.curl, 404);
+      recordTraffic("/vendor/neon", UA.chrome, 200);
+      recordTraffic("/vendors/neon", UA.chrome, 301);
+      recordTraffic("/broken", UA.googlebot, 500);
+
+      const sample = getTrafficReport().not_found_sample;
+      // A served page is not a failure, and neither is a redirect — the sample exists to
+      // characterise traffic we could not answer, so anything else in it is noise.
+      assert.equal(sample.length, 2, "only non-resolving requests are sampled");
+      assert.ok(!sample.some((s: any) => s.path === "/vendor/neon"), "a served page is not sampled");
+      assert.ok(!sample.some((s: any) => s.path === "/vendors/neon"), "a redirect is not sampled");
+      // Newest first: an operator reading this wants the most recent burst at the top.
+      assert.equal(sample[0].path, "/broken");
+      assert.equal(sample[0].status, 500);
+      assert.equal(sample[0].client_class, "search_crawler");
+      assert.equal(sample[1].path, "/wp-login.php");
+      assert.equal(sample[1].client_class, "sdk_client");
+      assert.ok(Date.parse(sample[0].ts) > 0, "each sample is timestamped");
+    });
+
+    it("bounds the sample so a sustained scan cannot grow the snapshot", async () => {
+      await boot();
+      for (let i = 0; i < 5000; i++) recordTraffic(`/scan-${i}`, UA.curl, 404);
+      await flushPending();
+
+      assert.equal(storedSnapshot().not_found_sample.length, 50, "the ring is capped");
+      const sample = getTrafficReport().not_found_sample;
+      assert.equal(sample.length, 50);
+      assert.equal(sample[0].path, "/scan-4999", "and it keeps the newest, not the oldest");
+    });
+
+    it("bounds it in memory too, between flushes", async () => {
+      await boot();
+      for (let i = 0; i < 5000; i++) recordTraffic(`/scan-${i}`, UA.curl, 404);
+      // Nothing has been flushed, so the snapshot cannot show the buffer. A scan running
+      // faster than the flush interval must not accumulate one object per request in
+      // memory — the pending-work counter is where that would show.
+      const pending = getTelemetryHealth().pending_page_view_keys;
+      assert.ok(pending <= 60, `pending page-view work grew to ${pending} for 5,000 scanned paths`);
+    });
+
+    it("stays capped on the read path, where nothing has been pruned", async () => {
+      await boot();
+      for (let i = 0; i < 40; i++) recordTraffic(`/stored-${i}`, UA.curl, 404);
+      await flushPending();
+      // These are in the pending delta, not the snapshot. A read merges the two, and the
+      // merge is the only thing standing between 50 stored + 50 buffered and a 100-entry
+      // answer from a field documented as holding the last 50.
+      for (let i = 0; i < 40; i++) recordTraffic(`/buffered-${i}`, UA.curl, 404);
+
+      const sample = getTrafficReport().not_found_sample;
+      assert.equal(sample.length, 50, "the read path must not exceed the documented cap");
+      assert.equal(sample[0].path, "/buffered-39", "and it is the newest 50");
+    });
+
+    it("stays capped across flushes, not just within one", async () => {
+      await boot();
+      for (let i = 0; i < 40; i++) recordTraffic(`/first-${i}`, UA.curl, 404);
+      await flushPending();
+      for (let i = 0; i < 40; i++) recordTraffic(`/second-${i}`, UA.curl, 404);
+      await flushPending();
+
+      const stored = storedSnapshot().not_found_sample;
+      assert.equal(stored.length, 50, "two 40-entry batches must not persist as 80");
+      assert.equal(stored[stored.length - 1].path, "/second-39", "the newest survives");
+      assert.ok(
+        !stored.some((s: any) => s.path === "/first-0"),
+        "and the oldest is the one dropped",
+      );
+    });
+
+    it("counts non-resolving and redirected requests apart since boot", async () => {
+      await boot();
+      recordTraffic("/gone", UA.curl, 404);
+      recordTraffic("/gone-too", UA.curl, 410);
+      recordTraffic("/moved", UA.chrome, 301);
+      recordTraffic("/vendor/neon", UA.chatgpt, 200);
+
+      const report = getTrafficReport();
+      assert.equal(report.since_boot_not_found, 2);
+      assert.equal(report.since_boot_redirects, 1);
+      assert.equal(report.since_boot_by_class.ai_agent, 1);
+      assert.equal(report.since_boot_by_class.sdk_client, 0, "since_boot_by_class is served-only too");
+    });
+
+    it("sanitizes and truncates the path, and never uses it as a key", async () => {
+      await boot();
+      const hostile = `/$(pwd)/<script>alert('x')</script>/${"a".repeat(200)}`;
+      recordTraffic(hostile, UA.curl, 404);
+      await flushPending();
+
+      const snapshot = storedSnapshot();
+      const sample = snapshot.not_found_sample[0];
+      assert.ok(sample.path.length <= 83, `path not truncated: ${sample.path.length}`);
+      assert.ok(!/[<>"'`&\\]/.test(sample.path), `unescaped markup survived: ${sample.path}`);
+      // The bounded key space is what #1018 bought; a sample must not spend it back.
+      for (const map of [snapshot.days[today()] ?? {}, snapshot.all_time, snapshot.class_routes[today()] ?? {}]) {
+        for (const key of Object.keys(map)) {
+          assert.ok(!key.includes("script"), `sample path leaked into a key: ${key}`);
+          assert.ok(!key.includes("pwd"), `sample path leaked into a key: ${key}`);
+        }
+      }
+    });
+
+    it("reports and rewrites an oversized stored sample at the cap", async () => {
+      await boot();
+      recordTraffic("/probe", UA.curl, 404);
+      await flushPending();
+
+      // A blob written by a future build, a hand edit, or a bug: whatever it claims, a
+      // reader must see the documented 50 and the next flush must store 50.
+      const raw = JSON.parse(redis.values.get(PAGE_VIEWS_KEY)!);
+      raw.not_found_sample = Array.from({ length: 500 }, (_, i) => ({
+        ts: new Date().toISOString(),
+        client_class: "sdk_client",
+        status: 404,
+        path: `/stale-${i}`,
+      }));
+      redis.values.set(PAGE_VIEWS_KEY, JSON.stringify(raw));
+      resetTelemetryBuffers();
+      await boot();
+
+      assert.equal(getTrafficReport().not_found_sample.length, 50, "a reader sees the cap");
+      recordTraffic("/probe-2", UA.curl, 404);
+      await flushPending();
+      assert.equal(storedSnapshot().not_found_sample.length, 50, "and the oversized blob does not persist");
+    });
+
+    it("survives a round trip through storage with the path re-sanitized", async () => {
+      await boot();
+      recordTraffic("/probe", UA.curl, 404);
+      await flushPending();
+
+      // Simulate a hand-edited or older blob: the stored path is the one field that
+      // originated in a request line, so it is re-validated on the way back in.
+      const raw = JSON.parse(redis.values.get(PAGE_VIEWS_KEY)!);
+      raw.not_found_sample.push({ ts: "x", client_class: "browser", status: 404, path: "/<img onerror=1>" });
+      redis.values.set(PAGE_VIEWS_KEY, JSON.stringify(raw));
+      resetTelemetryBuffers();
+      await boot();
+
+      const sample = getTrafficReport().not_found_sample;
+      assert.ok(!sample.some((s: any) => /[<>]/.test(s.path)), "markup must not survive a reload");
+    });
+
+    it("aggregates by client class so the shape is visible without the sample", async () => {
+      await boot();
+      for (let i = 0; i < 30; i++) recordTraffic(`/scan-${i}`, UA.curl, 404);
+      for (let i = 0; i < 3; i++) recordTraffic(`/typo-${i}`, UA.chrome, 404);
+      recordTraffic("/gone", UA.googlebot, 404);
+
+      const window = getTrafficReport().today;
+      assert.equal(window.not_found_by_class.sdk_client, 30);
+      assert.equal(window.not_found_by_class.browser, 3);
+      assert.equal(window.not_found_by_class.search_crawler, 1);
+      assert.equal(window.not_found_total, 34);
+      // Classes with none are zero-filled, so an absent key never reads as "unknown".
+      assert.equal(window.not_found_by_class.ai_agent, 0);
+    });
+  });
+
+  describe("it costs nothing (#1023's budget still binds)", () => {
+    it("spends zero commands on the request path, whatever the scan volume", async () => {
+      await boot();
+      for (let i = 0; i < 2000; i++) {
+        recordTraffic(`/scan-${i}`, UA.curl, 404);
+        recordPageView(`/scan-${i}`, UA.chrome, undefined, 404);
+      }
+      assert.equal(redis.commandCount(), 0, `2000 scanned paths issued ${redis.commandCount()} commands`);
+    });
+
+    it("adds no command to a flush: the counters and the sample ride in the same SET", async () => {
+      await boot();
+      recordPageView("/", UA.chrome, undefined, 200);
+      await flushPending();
+      redis.reset();
+
+      for (let i = 0; i < 500; i++) recordTraffic(`/scan-${i}`, UA.curl, 404);
+      await flushPending();
+      assert.equal(redis.commandCount("SET"), 1, "one snapshot write, as before #1029");
+      assert.equal(redis.commandCount("SCAN"), 0);
+      assert.equal(redis.commandCount("MGET"), 0);
+      assert.equal(redis.commandCount("INCR"), 0);
+    });
+
+    it("serves the sample and the counters from memory — reads stay free", async () => {
+      await boot();
+      recordTraffic("/scan", UA.curl, 404);
+      await flushPending();
+      redis.reset();
+      for (let i = 0; i < 25; i++) {
+        getTrafficReport();
+        await getPageViews();
+      }
+      assert.equal(redis.commandCount(), 0);
+    });
+  });
+
+  describe("the pre-#1021 junk key space", () => {
+    // The keys the PM quoted from the live all_time.top_pages, verbatim.
+    const JUNK = [
+      "/%2f%2eenv",
+      "/%2eenv",
+      "/%2fbackend%2f%2eenv",
+      "/%2egit/%63onfig",
+      "/%2f%2eaws%2fcredentials",
+      "/$(pwd)/.env",
+      "/$(pwd)/.git/config",
+    ];
+
+    it("moves keys that are not routes we serve into the not-found bucket", async () => {
+      for (const key of JUNK) redis.values.set(`pv:all:${key}`, "9");
+      redis.values.set("pv:all:/", "500");
+      redis.values.set("pv:all:/vendor/:slug", "300");
+      await loadTelemetry(telemetryFile);
+
+      const pv = await getPageViews();
+      assert.equal(pv.all_time.total, 800, "only routes we serve are page views");
+      assert.equal(pv.all_time.not_found, JUNK.length * 9, "and the scan volume is preserved, not deleted");
+      const paths = pv.all_time.top_pages.map((p: any) => p.path);
+      for (const key of JUNK) assert.ok(!paths.includes(key), `${key} still served in top_pages`);
+      assert.ok(paths.includes("/") && paths.includes("/vendor/:slug"));
+    });
+
+    it("is idempotent, and does not re-import the junk on a later boot", async () => {
+      for (const key of JUNK) redis.values.set(`pv:all:${key}`, "9");
+      redis.values.set("pv:all:/", "500");
+      await loadTelemetry(telemetryFile);
+      recordPageView("/", UA.chrome, undefined, 200);
+      await flushPending();
+
+      const first = (await getPageViews()).all_time;
+      resetTelemetryBuffers();
+      await loadTelemetry(telemetryFile);
+      const second = (await getPageViews()).all_time;
+
+      assert.equal(second.total, first.total, "a second pass must not move anything again");
+      assert.equal(second.not_found, first.not_found);
+      assert.ok(!JSON.stringify(storedSnapshot().all_time).includes("pwd"));
+    });
+
+    it("holds the pseudo-keys out of the path cap so they cannot be folded away", async () => {
+      // 400 junk keys: more than the 300-key all-time cap, so the fold runs too.
+      for (let i = 0; i < 400; i++) redis.values.set(`pv:all:/%2e${i}%2fenv`, "2");
+      await loadTelemetry(telemetryFile);
+
+      const pv = await getPageViews();
+      assert.equal(pv.all_time.total, 0, "none of these was ever a page we served");
+      assert.equal(pv.all_time.not_found, 800, "and every hit is accounted for");
+    });
+
+    it("keeps the excluded counters out of the path cap, so a full key space cannot re-absorb them", async () => {
+      // Saturate all-time with real pages, then record traffic of every outcome. If the
+      // excluded counters were treated as ordinary path keys they would fold into the
+      // served-overflow bucket once the cap was reached — silently moving scan traffic
+      // back inside the number we quote.
+      for (let i = 0; i < 320; i++) redis.values.set(`pv:all:/page-${i}`, "1");
+      await boot();
+      for (let i = 0; i < 25; i++) recordPageView(`/scan-${i}`, UA.chrome, undefined, 404);
+      recordPageView("/moved", UA.chrome, undefined, 301);
+      recordPageView("/", UA.chrome, undefined, 200);
+      await flushPending();
+
+      const all = (await getPageViews()).all_time;
+      assert.equal(all.not_found, 25, "not-found must not be folded into a page bucket");
+      assert.equal(all.redirects, 1);
+      const stored = storedSnapshot().all_time;
+      assert.equal(stored[NOT_FOUND_KEY], 25, "and it is stored under its own key, not the overflow one");
+      assert.ok(!all.top_pages.some((p: any) => p.path === NOT_FOUND_KEY));
+    });
+
+    it("does the same for a day map, whose cap is reached first on a busy day", async () => {
+      await boot();
+      // 320 distinct served pages saturates the 300-key day cap, so the fold is running.
+      for (let i = 0; i < 320; i++) recordPageView(`/page-${i}`, UA.chrome, undefined, 200);
+      for (let i = 0; i < 25; i++) recordPageView(`/scan-${i}`, UA.chrome, undefined, 404);
+      recordPageView("/moved", UA.chrome, undefined, 301);
+      await flushPending();
+
+      const day = storedSnapshot().days[today()];
+      assert.equal(day[NOT_FOUND_KEY], 25, "the day's not-found counter must not be folded away");
+      assert.equal(day[REDIRECT_KEY], 1);
+      assert.equal(day.total, 320, "and the total is still the served pages only");
+
+      const pv = (await getPageViews()).today;
+      assert.equal(pv.total, 320);
+      assert.equal(pv.not_found, 25);
+      assert.equal(pv.redirects, 1);
+    });
+
+    it("names the boundary it cannot repair rather than claiming the series is clean", async () => {
+      redis.values.set("pv:all:/", "500");
+      await loadTelemetry(telemetryFile);
+      const pv = await getPageViews();
+      assert.equal(pv.all_time_trustworthy_from, today());
+      assert.ok(pv.notes.some((n: string) => n.includes("all_time_trustworthy_from")));
+    });
+
+    it("keeps the stamped date across a restart rather than resetting it to today", async () => {
+      redis.values.set("pv:all:/", "500");
+      await loadTelemetry(telemetryFile);
+      recordPageView("/", UA.chrome, undefined, 200);
+      await flushPending();
+
+      const raw = JSON.parse(redis.values.get(PAGE_VIEWS_KEY)!);
+      raw.all_time_trustworthy_from = "2026-01-01";
+      redis.values.set(PAGE_VIEWS_KEY, JSON.stringify(raw));
+      resetTelemetryBuffers();
+      await loadTelemetry(telemetryFile);
+
+      assert.equal((await getPageViews()).all_time_trustworthy_from, "2026-01-01");
+    });
+
+    it("reports what the old counter could not name instead of dropping it", async () => {
+      // A legacy day: the stored total counted the 404s, the page keys did not.
+      redis.values.set(`pv:${today()}:/`, "573");
+      redis.values.set(`pv:${today()}:total`, "3580");
+      redis.values.set(`pv:${today()}:${UNMATCHED_PAGE_KEY}`, "3007");
+      await loadTelemetry(telemetryFile);
+
+      const pv = (await getPageViews()).today;
+      assert.equal(pv.total, 573, "the figure the PM measured by hand");
+      assert.equal(pv.unclassified_legacy, 3007);
+      assert.equal(pv.total + pv.unclassified_legacy, 3580, "and the arithmetic closes");
+      assert.ok(!pv.top_pages.some((p: any) => p.path === UNMATCHED_PAGE_KEY));
+    });
+  });
+
+  describe("nothing writes the legacy bucket any more", () => {
+    it("sends a served page we cannot name to the overflow bucket, not __unmatched__", async () => {
+      await boot();
+      // Normalization rejects this path, but we answered it with a page.
+      const odd = "/Weird_Path!!";
+      assert.equal(normalizePagePath(odd), UNMATCHED_PAGE_KEY, "precondition: it does not normalize");
+      recordPageView(odd, UA.chrome, undefined, 200);
+      await flushPending();
+
+      const day = storedSnapshot().days[today()];
+      assert.equal(day[OVERFLOW_PAGE_KEY], 1, "a page we served belongs in the total");
+      assert.equal(day[UNMATCHED_PAGE_KEY], undefined);
+      assert.equal((await getPageViews()).today.total, 1);
+    });
+
+    it("never writes __unmatched__ across a mixed traffic day", async () => {
+      await boot();
+      recordPageView("/", UA.chrome, undefined, 200);
+      recordPageView("/gone", UA.chrome, undefined, 404);
+      recordPageView("/moved", UA.chrome, undefined, 301);
+      recordTraffic("/vendor/neon", UA.chatgpt, 200);
+      recordTraffic("/gone", UA.curl, 404);
+      await flushPending();
+
+      const snapshot = storedSnapshot();
+      const written = JSON.stringify({
+        days: snapshot.days,
+        all_time: snapshot.all_time,
+        class_routes: snapshot.class_routes,
+      });
+      assert.ok(!written.includes(UNMATCHED_PAGE_KEY), `${UNMATCHED_PAGE_KEY} was written: ${written}`);
+    });
+  });
+
+  describe("every window states its own denominator", () => {
+    it("says how much of the window is actually backed by data", async () => {
+      await boot();
+      recordTraffic("/vendor/neon", UA.chatgpt, 200);
+      const report = getTrafficReport();
+
+      assert.equal(report.today.data_days_available, 1);
+      assert.equal(report.today.coverage.split(";")[0], "complete");
+      // The failure the PM hit: today, 7d and 30d all read 4,984 because the keyspace was
+      // rebuilt that morning. Arithmetically right, presentationally a month-long claim.
+      assert.equal(report.last_30d.days, 30);
+      assert.equal(report.last_30d.data_days_available, 1);
+      assert.ok(
+        report.last_30d.coverage.startsWith("partial — 1 of 30 days"),
+        `coverage did not warn: ${report.last_30d.coverage}`,
+      );
+      // Assert on the coverage clause itself: the pre-split disclosure appended after
+      // the ";" also contains today's date, and would satisfy a looser check.
+      assert.ok(
+        report.last_30d.coverage.split(";")[0].includes(today()),
+        `coverage clause does not name the earliest record: ${report.last_30d.coverage}`,
+      );
+    });
+
+    it("reports complete once the window is genuinely covered", async () => {
+      for (let i = 0; i < 10; i++) {
+        redis.values.set(`pv:${daysAgo(i)}:/`, "1");
+      }
+      // Only today/yesterday migrate from legacy keys, so seed the snapshot directly.
+      redis.values.set(
+        PAGE_VIEWS_KEY,
+        JSON.stringify({
+          days: {},
+          referrers: {},
+          all_time: {},
+          updated_at: new Date().toISOString(),
+          classes: Object.fromEntries(
+            Array.from({ length: 10 }, (_, i) => [daysAgo(i), { browser: 5 }]),
+          ),
+          class_routes: {},
+          families: {},
+          mcp: {},
+        }),
+      );
+      await boot();
+
+      const report = getTrafficReport();
+      assert.equal(report.today.coverage.split(";")[0], "complete");
+      assert.equal(report.last_7d.data_days_available, 7);
+      assert.equal(report.last_7d.coverage.split(";")[0], "complete");
+      assert.equal(report.last_30d.data_days_available, 10);
+      assert.ok(report.last_30d.coverage.startsWith("partial — 10 of 30 days"));
+    });
+
+    it("discloses days whose class totals predate the outcome split", async () => {
+      await boot();
+      recordTraffic("/vendor/neon", UA.chatgpt, 200);
+      const report = getTrafficReport();
+
+      // The split lands mid-day, so its own date is mixed and is named as such rather
+      // than being quietly presented as clean.
+      assert.deepEqual(report.today.pre_split_dates, [today()]);
+      assert.ok(report.today.coverage.includes("before the outcome split"));
+      assert.ok(report.notes.some((n: string) => n.includes("not_found_*")));
+    });
+
+    it("stops disclosing once every day in the window post-dates the split", async () => {
+      redis.values.set(
+        PAGE_VIEWS_KEY,
+        JSON.stringify({
+          days: {},
+          referrers: {},
+          all_time: {},
+          updated_at: new Date().toISOString(),
+          classes: { [today()]: { browser: 5 } },
+          class_routes: {},
+          families: {},
+          mcp: {},
+          outcome_split_from: daysAgo(3),
+        }),
+      );
+      await boot();
+
+      const window = getTrafficReport().today;
+      assert.deepEqual(window.pre_split_dates, []);
+      assert.ok(!window.coverage.includes("before the outcome split"));
+    });
+
+    it("states the denominator of the page-view figures too", async () => {
+      await boot();
+      const pv = await getPageViews();
+      assert.ok(pv.notes.length > 0);
+      assert.ok(pv.notes.some((n: string) => n.includes("2xx")), "says what is included");
+      assert.ok(pv.notes.some((n: string) => n.includes("excludes bots")), "says what is excluded");
+      assert.ok(pv.notes.some((n: string) => n.includes("7 days")), "says over what window");
+    });
+  });
+
+  describe("the search-analytics window says how thin it is", () => {
+    it("reports a 7-day list backed by an hour of data as partial", () => {
+      resetCounters();
+      recordSearchQuery("postgres", 3, { source: "web" });
+      recordSearchQuery("redis", 0, { source: "mcp" });
+
+      const window = getSearchAnalytics().window_7d;
+      assert.equal(window.days, 7);
+      assert.equal(window.entries, 2);
+      assert.equal(window.data_days_available, 1);
+      assert.ok(
+        window.coverage.startsWith("partial — 1 of 7 days"),
+        `coverage did not warn: ${window.coverage}`,
+      );
+      assert.equal(window.ring_saturated, false);
+      assert.ok(Date.parse(window.oldest_entry) > 0);
+    });
+
+    it("reports an empty ring as zero days rather than as a covered week", () => {
+      resetCounters();
+      const window = getSearchAnalytics().window_7d;
+      assert.equal(window.entries, 0);
+      assert.equal(window.data_days_available, 0);
+      assert.equal(window.oldest_entry, null);
+      assert.ok(window.coverage.startsWith("partial — 0 of 7 days"));
+    });
+  });
+
+  describe("sanitizeSamplePath", () => {
+    it("strips what could break out of a rendering context", () => {
+      assert.equal(sanitizeSamplePath("/<script>x</script>"), "/scriptx/script");
+      assert.equal(sanitizeSamplePath("/a bc"), "/abc");
+      assert.equal(sanitizeSamplePath("/café"), "/caf");
+      assert.equal(sanitizeSamplePath("/back\\slash"), "/backslash");
+    });
+
+    it("truncates rather than storing whatever length the request line had", () => {
+      const out = sanitizeSamplePath(`/${"a".repeat(500)}`);
+      assert.ok(out.length <= 83, `length ${out.length}`);
+      assert.ok(out.endsWith("..."), "and says that it truncated");
+    });
+
+    it("survives a non-string, because the blob is stored data", () => {
+      assert.equal(sanitizeSamplePath(undefined), "");
+      assert.equal(sanitizeSamplePath(null), "");
+      assert.equal(sanitizeSamplePath(42), "42");
+    });
+  });
+});

--- a/test/not-found-wiring.test.ts
+++ b/test/not-found-wiring.test.ts
@@ -1,0 +1,156 @@
+// Locks the wiring between the HTTP server and the outcome split (#1029).
+//
+// not-found-accounting.test.ts proves the counters are right once `recordTraffic` and
+// `recordPageView` are told the status. It cannot prove the server tells them: a handler
+// that returns before the hook is registered, or a hook registered before the status is
+// known, keeps producing the bug this issue is about — a 404 counted as a page view.
+// That is exactly how the page-view hook came to miss every redirect (found in #1019), so
+// this drives the real server over real HTTP.
+
+import { describe, it, after, before } from "node:test";
+import assert from "node:assert";
+import { spawn, type ChildProcess } from "node:child_process";
+import { existsSync, renameSync, rmSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const serverPath = path.join(__dirname, "..", "dist", "serve.js");
+const telemetryPath = path.join(__dirname, "..", "data", "telemetry.json");
+const telemetryBackup = `${telemetryPath}.not-found-wiring-backup`;
+
+let port = 0;
+let proc: ChildProcess;
+let movedAside = false;
+
+before(async () => {
+  // Same isolation as the search wiring test: data/telemetry.json is gitignored local
+  // detritus that any spawned server hydrates.
+  if (existsSync(telemetryPath)) {
+    renameSync(telemetryPath, telemetryBackup);
+    movedAside = true;
+  }
+
+  proc = spawn("node", [serverPath], {
+    stdio: ["pipe", "pipe", "pipe"],
+    // BASE_URL decides the canonical hostname, and a request to localhost that does not
+    // match it 301s before reaching any handler — which would make every case below
+    // assert on the canonical redirect instead of on what it means to.
+    env: { ...process.env, PORT: "0", BASE_URL: "http://localhost" },
+  });
+  await new Promise<void>((resolve, reject) => {
+    const timeout = setTimeout(() => { proc.kill(); reject(new Error("server start timeout")); }, 20000);
+    proc.stderr!.on("data", (data: Buffer) => {
+      const match = data.toString().match(/running on http:\/\/localhost:(\d+)/);
+      if (match) { port = parseInt(match[1], 10); clearTimeout(timeout); resolve(); }
+    });
+    proc.on("error", (err) => { clearTimeout(timeout); reject(err); });
+  });
+});
+
+after(() => {
+  proc?.kill("SIGKILL");
+  if (movedAside) renameSync(telemetryBackup, telemetryPath);
+  else if (existsSync(telemetryPath)) rmSync(telemetryPath);
+});
+
+const BROWSER =
+  "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36";
+
+async function request(pathname: string, redirect: RequestRedirect = "manual"): Promise<number> {
+  const res = await fetch(`http://localhost:${port}${pathname}`, {
+    headers: { "user-agent": BROWSER },
+    redirect,
+  });
+  await res.arrayBuffer();
+  return res.status;
+}
+
+/** Read through the internal marker so the observability call is not itself measured. */
+async function observe(pathname: string): Promise<any> {
+  const res = await fetch(`http://localhost:${port}${pathname}`, {
+    headers: { "user-agent": "agentdeals-internal/1.0 (wiring test)" },
+  });
+  assert.strictEqual(res.status, 200, `${pathname} -> ${res.status}`);
+  return res.json();
+}
+
+describe("404 accounting wiring (#1029)", () => {
+  it("counts a real 404 as not-found and not as traffic", async () => {
+    const before = await observe("/api/traffic");
+    const status = await request(`/zzz-wiring-probe-${process.pid}`);
+    assert.strictEqual(status, 404, "precondition: the probe path must actually 404");
+    const after = await observe("/api/traffic");
+
+    assert.strictEqual(
+      after.since_boot_not_found - before.since_boot_not_found,
+      1,
+      "the 404 must be counted, under its own name",
+    );
+    assert.strictEqual(
+      after.since_boot_by_class.browser - before.since_boot_by_class.browser,
+      0,
+      "and it must not appear as a page this client read",
+    );
+  });
+
+  it("counts a real 200 as traffic", async () => {
+    const before = await observe("/api/traffic");
+    assert.strictEqual(await request("/"), 200);
+    const after = await observe("/api/traffic");
+
+    assert.strictEqual(after.since_boot_by_class.browser - before.since_boot_by_class.browser, 1);
+    assert.strictEqual(after.since_boot_not_found - before.since_boot_not_found, 0);
+  });
+
+  it("counts a real 301 apart from both", async () => {
+    const before = await observe("/api/traffic");
+    // /vendors/<slug> 301s to /vendor/<slug>. This branch returns *above* the page-view
+    // hook, which is why the traffic hook is registered first — a redirect that nothing
+    // records at all is the failure mode here.
+    assert.strictEqual(await request("/vendors/neon"), 301);
+    const after = await observe("/api/traffic");
+
+    assert.strictEqual(after.since_boot_redirects - before.since_boot_redirects, 1);
+    assert.strictEqual(after.since_boot_not_found - before.since_boot_not_found, 0);
+    assert.strictEqual(after.since_boot_by_class.browser - before.since_boot_by_class.browser, 0);
+  });
+
+  it("keeps a real 404 out of page_views_today on /api/metrics", async () => {
+    const before = (await observe("/api/metrics")).page_views_today;
+    await request(`/zzz-wiring-probe-b-${process.pid}`);
+    const mid = (await observe("/api/metrics")).page_views_today;
+    assert.strictEqual(mid - before, 0, "a 404 is not a page view on any surface");
+
+    assert.strictEqual(await request("/estimate"), 200);
+    const after = (await observe("/api/metrics")).page_views_today;
+    assert.strictEqual(after - mid, 1, "and a served page still is");
+  });
+
+  it("samples the real 404 with its path, class and status", async () => {
+    const probe = `/zzz-wiring-sample-${process.pid}`;
+    await request(probe);
+    const sample = (await observe("/api/traffic")).not_found_sample;
+
+    const entry = sample.find((s: any) => s.path === probe);
+    assert.ok(entry, `probe not in the sample: ${JSON.stringify(sample.slice(0, 3))}`);
+    assert.strictEqual(entry.status, 404);
+    assert.strictEqual(entry.client_class, "browser");
+    assert.ok(Date.parse(entry.ts) > 0);
+  });
+
+  it("states the denominator on both reporting endpoints", async () => {
+    const traffic = await observe("/api/traffic");
+    const pageviews = await observe("/api/pageviews");
+
+    for (const w of [traffic.today, traffic.last_7d, traffic.last_30d]) {
+      assert.strictEqual(typeof w.coverage, "string");
+      assert.strictEqual(typeof w.data_days_available, "number");
+      assert.strictEqual(typeof w.not_found_total, "number");
+    }
+    assert.ok(pageviews.notes.length > 0, "/api/pageviews must state what it counts");
+    assert.ok(Array.isArray(traffic.not_found_sample));
+    // Present even with no storage configured — the field must not be conditional on it.
+    assert.ok("all_time_trustworthy_from" in pageviews);
+  });
+});

--- a/test/stats-telemetry.test.ts
+++ b/test/stats-telemetry.test.ts
@@ -20,6 +20,7 @@ const {
   resetTelemetryHealth,
   normalizePagePath,
   UNMATCHED_PAGE_KEY,
+  NOT_FOUND_KEY,
   logRequest,
   resetCounters,
   loadTelemetry,
@@ -144,14 +145,39 @@ describe("telemetry storage layer (#1018)", () => {
       assert.ok(!JSON.stringify(snapshot).includes("hetzner"), "raw slug must not reach Redis");
     });
 
-    it("buckets a 404 to __unmatched__ even when the path looks like a page", async () => {
+    // Contract changed by #1029. It used to be "a 404 buckets to __unmatched__", which
+    // bounded the key space but still counted the request as a page view — 84% of a day's
+    // recorded views on the day that was found. It is now "a 404 is not a page view":
+    // counted, under its own name, outside the total.
+    it("counts a 404 as not-found rather than as a page view, however page-like the path", async () => {
       await boot();
       recordPageView("/wp-login", "Mozilla/5.0", undefined, 404);
+      recordPageView("/estimate", "Mozilla/5.0", undefined, 200);
       await flushPending();
 
       const snapshot = writtenSnapshot();
-      assert.ok(snapshot.all_time[UNMATCHED_PAGE_KEY] >= 1, "expected __unmatched__");
+      const today = new Date().toISOString().slice(0, 10);
+      assert.strictEqual(snapshot.days[today][NOT_FOUND_KEY], 1, "expected a not-found counter");
+      assert.strictEqual(snapshot.all_time[NOT_FOUND_KEY], 1);
+      assert.strictEqual(snapshot.days[today].total, 1, "only the served request is in the total");
+      assert.strictEqual(snapshot.days[today][UNMATCHED_PAGE_KEY], undefined, "nothing writes the legacy bucket");
       assert.ok(!JSON.stringify(snapshot).includes("wp-login"), "a path we 404 must not mint its own key");
+
+      const report = await getPageViews();
+      assert.strictEqual(report.today.total, 1);
+      assert.strictEqual(report.today.not_found, 1);
+    });
+
+    it("counts a 3xx apart from both — the request that follows it is the page view", async () => {
+      await boot();
+      recordPageView("/compare/b-vs-a", "Mozilla/5.0", undefined, 301);
+      recordPageView("/compare/a-vs-b", "Mozilla/5.0", undefined, 200);
+      await flushPending();
+
+      const report = await getPageViews();
+      assert.strictEqual(report.today.total, 1, "the redirect and its target are one page view");
+      assert.strictEqual(report.today.redirects, 1);
+      assert.strictEqual(report.today.not_found, 0, "a redirect is not a not-found");
     });
 
     it("keeps the day-scoped total alongside the per-path counters", async () => {

--- a/test/telemetry-command-budget.test.ts
+++ b/test/telemetry-command-budget.test.ts
@@ -26,6 +26,8 @@ const {
   flushPending,
   logRequest,
   UNMATCHED_PAGE_KEY,
+  OVERFLOW_PAGE_KEY,
+  NOT_FOUND_KEY,
   OTHER_REFERRER_KEY,
   FLUSH_INTERVAL_SECONDS,
 } = await import("../dist/stats.js");
@@ -446,7 +448,12 @@ describe("telemetry command budget (#1023)", () => {
       const report = await getPageViews();
 
       assert.strictEqual(report.all_time.total, 10_675, "the numbers the partnership conversation is about");
-      assert.strictEqual(report.today.total, 89);
+      // The legacy day counter says 89 while its page keys account for 70. That gap is
+      // what the old build counted and could not name — 404s, mostly. #1029 reports the
+      // page keys as the total and the gap under its own name, so nothing is dropped and
+      // nothing unnameable is inside a number anyone would quote.
+      assert.strictEqual(report.today.total, 70);
+      assert.strictEqual(report.today.unclassified_legacy, 19);
       assert.strictEqual(report.referrers_today["news.ycombinator.com"], 12);
     });
 
@@ -482,12 +489,17 @@ describe("telemetry command budget (#1023)", () => {
       );
     });
 
-    it("folds overflowing all-time paths into __unmatched__ without losing the total", async () => {
+    // The fold bucket is __other_pages__, not __unmatched__ (#1029): these are pages we
+    // served and cannot name individually, and they belong in the total. __unmatched__ is
+    // now the legacy bucket for traffic recorded before outcomes were counted, and is
+    // reported outside the total — folding served hits there would delete them from it.
+    it("folds overflowing all-time paths into __other_pages__ without losing the total", async () => {
       for (let i = 0; i < 400; i++) redis.values.set(`pv:all:/page-${i}`, "3");
       await loadTelemetry(telemetryFile);
 
       const report = await getPageViews();
       assert.strictEqual(report.all_time.total, 1200, "the total is preserved exactly");
+      assert.strictEqual(report.all_time.unclassified_legacy, 0, "an overflowing page is not legacy traffic");
       const snapshot = (await getPageViews()).all_time.top_pages;
       assert.ok(snapshot.length <= 20);
       // 400 paths capped to 300 named + one fold bucket.
@@ -495,7 +507,8 @@ describe("telemetry command budget (#1023)", () => {
       await flushPending();
       const keys = Object.keys(storedSnapshot().all_time);
       assert.ok(keys.length <= 302, `all-time key space grew to ${keys.length}`);
-      assert.ok(keys.includes(UNMATCHED_PAGE_KEY));
+      assert.ok(keys.includes(OVERFLOW_PAGE_KEY));
+      assert.ok(!keys.includes(UNMATCHED_PAGE_KEY), "served overflow must not land in the legacy bucket");
     });
 
     it("prunes day buckets to the retention window", async () => {

--- a/test/traffic-attribution.test.ts
+++ b/test/traffic-attribution.test.ts
@@ -28,6 +28,8 @@ const {
   flushPending,
   normalizeRoutePath,
   UNMATCHED_PAGE_KEY,
+  OVERFLOW_PAGE_KEY,
+  NOT_FOUND_KEY,
 } = await import("../dist/stats.js");
 const { classifyRequest, CLIENT_CLASSES } = await import("../dist/client-class.js");
 
@@ -308,7 +310,7 @@ describe("client-class traffic attribution (#1019)", () => {
     // 200 + one bucket per class. Bounded is what matters, and this is the bound.
     assert.ok(keys.length <= 208, `class_routes grew to ${keys.length} keys — cap not enforced`);
     assert.ok(
-      keys.includes(`ai_agent|${UNMATCHED_PAGE_KEY}`) && keys.includes(`search_crawler|${UNMATCHED_PAGE_KEY}`),
+      keys.includes(`ai_agent|${OVERFLOW_PAGE_KEY}`) && keys.includes(`search_crawler|${OVERFLOW_PAGE_KEY}`),
       "overflow folds into a per-class bucket, not a shared one",
     );
     // Nothing is dropped, and nothing moves between classes on a busy day.
@@ -318,15 +320,41 @@ describe("client-class traffic attribution (#1019)", () => {
     assert.equal(sum("search_crawler"), 400);
   });
 
-  it("a 404 does not mint a route key, however well-formed the path looks", async () => {
+  // Contract changed by #1029: a 404 no longer mints a route key *at all*, rather than
+  // minting the shared unmatched one. A client that only ever 404s is not a client that
+  // read our pages, so it must not appear in that class's hit count or route list.
+  it("a 404 is counted apart from served traffic and mints no route key", async () => {
     await boot();
     recordTraffic("/wp-login.php", UA.curl, 404);
     recordTraffic("/vendor/real", UA.curl, 200);
     await flushPending();
 
-    const routes = storedSnapshot().class_routes[today()];
-    assert.equal(routes[`sdk_client|${UNMATCHED_PAGE_KEY}`], 1);
+    const snapshot = storedSnapshot();
+    const routes = snapshot.class_routes[today()];
     assert.equal(routes["sdk_client|/vendor/:slug"], 1);
+    assert.equal(routes[`sdk_client|${UNMATCHED_PAGE_KEY}`], undefined, "no route key for a 404");
+    assert.equal(routes[`sdk_client|${OVERFLOW_PAGE_KEY}`], undefined);
+    assert.equal(snapshot.classes[today()].sdk_client, 1, "only the served request is a hit");
+    assert.equal(snapshot.not_found[today()].sdk_client, 1, "the 404 is counted, under its own name");
+
+    const window = getTrafficReport().today;
+    assert.equal(window.hits_total, 1);
+    assert.equal(window.by_class.sdk_client, 1);
+    assert.equal(window.not_found_total, 1);
+    assert.equal(window.not_found_by_class.sdk_client, 1);
+  });
+
+  it("counts a 3xx apart from both — the redirect and its target are one hit", async () => {
+    await boot();
+    recordTraffic("/vendors/neon", UA.chrome, 301);
+    recordTraffic("/vendor/neon", UA.chrome, 200);
+    await flushPending();
+
+    const window = getTrafficReport().today;
+    assert.equal(window.hits_total, 1, "a redirect plus the request that follows it is one hit");
+    assert.equal(window.redirect_total, 1);
+    assert.equal(window.not_found_total, 0, "a redirect is not a not-found");
+    assert.equal(storedSnapshot().redirects[today()].browser, 1);
   });
 
   it("normalizeRoutePath keeps API routes bounded too", () => {
@@ -410,6 +438,22 @@ describe("window honesty and storage bounds", () => {
       snap.mcp[day(i)] = 999999;
     }
     for (let k = 0; k < 300; k++) snap.all_time[`/some-page-slug-${k}`] = 99999999;
+    // #1029's additions: two class-keyed outcome maps over the same 30 days, and the
+    // bounded not-found sample at its cap with the longest path each entry can hold.
+    snap.not_found = {};
+    snap.redirects = {};
+    for (let i = 0; i < 30; i++) {
+      snap.not_found[day(i)] = Object.fromEntries(CLASSES.map(c => [c, 9999999]));
+      snap.redirects[day(i)] = Object.fromEntries(CLASSES.map(c => [c, 9999999]));
+    }
+    snap.not_found_sample = Array.from({ length: 50 }, () => ({
+      ts: new Date().toISOString(),
+      client_class: "search_crawler",
+      status: 404,
+      path: `/${"a".repeat(80)}...`,
+    }));
+    snap.all_time_trustworthy_from = "2026-08-25";
+    snap.outcome_split_from = "2026-08-25";
 
     const bytes = JSON.stringify(snap).length;
     assert.ok(bytes < 400_000, `worst-case snapshot is ${(bytes / 1024).toFixed(0)}KB`);


### PR DESCRIPTION
Refs #1029

## What changed

A request is now classified by **outcome** and the three outcomes are counted apart:

| outcome | what it is | where it lands |
|---|---|---|
| `served` (2xx) | we answered with a page | `total`, `hits_total`, `hits_excluding_internal`, `by_class`, `top_routes_by_class` |
| `redirect` (3xx) | the URL resolves, elsewhere | `redirects` / `redirect_total` / `redirects_by_class` |
| `not_found` (4xx/5xx) | did not resolve | `not_found` / `not_found_total` / `not_found_by_class` |

Everything outside `served` is **counted, visible, and never inside a number anyone would quote.**

### On the 3xx bucket, which the issue did not ask for

The issue says "non-2xx responses are counted in their own `not_found` counter". Taken literally, a 301 to the canonical hostname would be filed under "not found", which is false in a payload whose whole purpose is to be true. So redirects get their own bucket. The substantive reason to exclude them is separate from the naming: a redirect is followed, and the request that follows it is the page view — counting both double-counts one visit.

It is also now measurable. We could not previously see our own 3xx volume at all, which is part of why this was easy to miss.

## Verified against production-shaped data

`scripts/e2e-1029.mjs` boots the real `dist/serve.js` against a fake Upstash seeded with the shape production holds today — the junk all-time keys **verbatim from your `top_pages` read**, a day whose stored total counted its own 404s, and class counters recorded before the split. All checks pass:

| | before | after |
|---|---|---|
| `all_time.total` | 14,378 | **10,101** (`/` + `/vendor/:slug`) |
| `all_time.not_found` | — | **177** (the repaired junk) |
| `all_time.unclassified_legacy` | inside the total | **3,866** |
| `today.total` | 3,862 | **465** (the named pages) |
| `today.unclassified_legacy` | inside the total | **3,397**, and 465 + 3,397 = 3,862 |

Then 48 real requests (40 scanner 404s, 5 browser page views, 1 AI-agent hit, 1 probe, 1 301) → **0 Redis commands on the request path**; one flush → `GET`, `SET`, `LPUSH`, exactly as before; stored snapshot 5.1 KB. MCP `initialize` → `tools/call` still answers. A second boot re-reads and repairs nothing, and does not re-stamp the date.

## Acceptance criteria

- [x] **Non-2xx excluded from `today.total`, `all_time.total`, `hits_total`, `hits_excluding_internal`.** Also from `page_views_today` on `/api/metrics`, which had the same defect and the issue did not list.
- [x] **`/api/traffic`: unmatched no longer inflates a class's route totals.** A 404 mints no route key at all now, rather than minting the shared unmatched one.
- [x] **Every quotable figure states its own denominator.** `/api/traffic` windows carry `data_days_available` + a `coverage` sentence; `/api/pageviews` gains a `notes` block; `/api/metrics` search analytics gain `window_7d` with the same treatment.
- [x] **Bounded rolling sample**, 50 entries, client class + status + timestamp + path sanitized to printable ASCII and truncated to 80 chars. Never used to construct a key, re-sanitized on the way back out of storage.
- [x] **Aggregated by client class**, zero-filled so an absent class reads as "none" not "unknown".
- [x] **Zero additional Redis commands.** Asserted: 2,000 scanned paths → 0 commands; 500 more between flushes → still exactly 1 `SET`.
- [x] **Junk keyspace purged** — see the caveat below.
- [x] **`trustworthy_from` on the payload.**

## Three things I could not do, or did differently

**1. The junk `pv:all:*` Redis keys still exist. I repaired the snapshot instead, and I think deleting them would be wrong.**

The junk you can see — `/%2f%2eenv`, `/$(pwd)/.env` — is served out of the **snapshot**, because #1023's migration copied it there. That is what this PR repairs, and it is what every API reads. The original `pv:all:*` keys are inert: nothing reads them once a snapshot exists.

I did not add code to `DEL` them, for a reason beyond not having Upstash credentials: the legacy keyspace is the **only** fallback if the snapshot is ever lost or corrupted — `loadPageViews` rebuilds from it. Deleting it to reclaim storage would remove the backup for the exact vendor-level history we need. Your call, but I would leave them.

**2. The `classes` counters for today are still mixed, and I disclosed it rather than repairing it.**

The page-view maps repair themselves, because the total is now recomputed from the page keys. `classes` cannot be: it holds one number per class per day with the 404s already added in. The obvious back-out — subtract that class's `__unmatched__` route count — is *not* safe, because that bucket also absorbs route-key overflow and served-but-unnormalized routes, and I cannot bound either to zero by inspection. Guessing would have been undetectable if wrong.

So `outcome_split_from` is stamped, and any window reaching back past it appends to its own `coverage` string:

> `partial — 1 of 30 days of data available (earliest record 2026-08-25); hits_total still includes non-resolving requests on 2026-08-25, recorded before the outcome split on 2026-08-25`

It clears itself as the mixed days age out.

**3. The portal Health tab does not show these numbers.** You listed it as a place to apply the same treatment. I grepped `agent-portal` — it has no reference to `/api/pageviews` or `/api/traffic`; its Health tab is agent-process health from `logs/health.jsonl`. Nothing to fix there. Say the word if you meant a different surface.

Also, per your correction: **the internal-marker ask is struck.** Nothing was built for it.

## A correction to a public claim

`AGENTS.md` said we store "never a full request path outside a fixed route-pattern key space". The sample stores paths. It is sanitized, truncated and never used as a key, but the old sentence was no longer true, so it now describes the exception explicitly.

## Verification

- `tsc` clean, **1,394/1,394 tests** (47 new across `not-found-accounting.test.ts` and `not-found-wiring.test.ts`)
- **34 mutations bite-verified.** Four did not bite on the first pass and were treated as findings, not formalities:
  - the sample's in-memory cap was invisible to every test — the snapshot could not see it. Locked via the pending-work counter.
  - the merge-side cap was masked by the prune-side cap. Locked with a read-path test where nothing has been pruned.
  - `since_boot_redirects` was asserted nowhere, so a mutation folding redirects into the not-found tally survived.
  - a redirect leaking into `top_routes_by_class` was unasserted.
- **Two bugs found by my own tests, before review:**
  - the prune ran *before* the repair on the migration path, so 100 junk keys were folded into the served-overflow bucket and permanently relabelled as pages we served. Order is now repair-then-prune, with a mutation locking it.
  - `not_found_sample` was hardcoded `[]` on the no-storage/unreadable-storage path while `since_boot_not_found` was reported — publishing the count of a thing while hiding the thing, on exactly the code path where an operator most needs to see what is hitting the server.
- **One layer removed rather than tested.** The sample was capped in four places. Two were genuinely load-bearing, two were unreachable behind the others — no mutation could bite them. I deleted the redundant pair instead of manufacturing tests for them, and locked the *system* property (an oversized stored blob is reported at the cap and rewritten at the cap) rather than any one line.
- Worst-case snapshot: 159.6 KB → **178.5 KB**, against a 400 KB assertion.
