### PR TITLE
A warning label is a claim, and it must name the record behind it (#1038)

### DIFF
--- a/src/data.ts
+++ b/src/data.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import type { Offer, EnrichedOffer, OfferIndex, DealChange, DealChangesIndex, StabilityClass, Referral } from "./types.js";
+import type { Offer, EnrichedOffer, OfferIndex, DealChange, DealChangesIndex, StabilityClass, Referral, RiskCause } from "./types.js";
 import { isUrlSuspended } from "./referral-health.js";
 import { rankForListing } from "./ranking.js";
 
@@ -226,27 +226,54 @@ export function searchOffers(
   return results;
 }
 
-const NEGATIVE_STABILITY_TYPES = new Set([
-  "free_tier_removed",
-  "open_source_killed",
-  "limits_reduced",
-  "pricing_restructured",
-  "product_deprecated",
-  "restriction",
-]);
+/**
+ * Which way a change points for the user. One table, because before #1038
+ * five copies of this idea existed in the codebase and they had drifted:
+ * `classifyStability` counted `pricing_model_change` as neither negative nor
+ * positive (so Xata retiring its SaaS free tier read as `stable`) and left
+ * `new_tier` out of the positive set, while the weekly digest had its own two
+ * lists that disagreed with both.
+ *
+ * Direction is not the same question as risk. RISK_DEMOTION below is stricter:
+ * it decides what we are willing to publish a warning label for. This table
+ * decides what we are willing to *call* negative. The invariant between them —
+ * nothing RISK_DEMOTION demotes may be positive or neutral here — is asserted
+ * in risk-badge.test.ts.
+ */
+export const CHANGE_DIRECTION: Record<DealChange["change_type"], "negative" | "positive" | "neutral"> = {
+  free_tier_removed: "negative",
+  open_source_killed: "negative",
+  product_deprecated: "negative",
+  limits_reduced: "negative",
+  restriction: "negative",
+  pricing_restructured: "negative",
+  pricing_model_change: "negative",
+  limits_increased: "positive",
+  new_free_tier: "positive",
+  new_tier: "positive",
+  startup_program_expanded: "positive",
+  pricing_postponed: "positive",
+  rebranded: "neutral",
+};
 
+const directionSet = (d: "negative" | "positive" | "neutral") =>
+  new Set(Object.entries(CHANGE_DIRECTION).filter(([, v]) => v === d).map(([k]) => k));
+
+export const NEGATIVE_CHANGE_TYPES = directionSet("negative");
+export const POSITIVE_CHANGE_TYPES = directionSet("positive");
+
+/** Severity, not direction: the negatives that end a free tier outright. */
 const VOLATILE_TYPES = new Set([
   "free_tier_removed",
   "open_source_killed",
   "product_deprecated",
 ]);
 
-const POSITIVE_STABILITY_TYPES = new Set([
-  "limits_increased",
-  "new_free_tier",
-  "startup_program_expanded",
-  "pricing_postponed",
-]);
+/** The two the risk scale treats as severe. Exported so no caller inlines them. */
+export const SEVERE_CHANGE_TYPES = new Set(["free_tier_removed", "open_source_killed"]);
+
+const NEGATIVE_STABILITY_TYPES = NEGATIVE_CHANGE_TYPES;
+const POSITIVE_STABILITY_TYPES = POSITIVE_CHANGE_TYPES;
 
 export function classifyStability(vendorChanges: DealChange[]): StabilityClass {
   if (vendorChanges.length === 0) return "stable";
@@ -301,14 +328,7 @@ export function enrichOffers(offers: Offer[]): EnrichedOffer[] {
     }
   }
 
-  // Build vendor → all-time change count for risk_level
-  const vendorAllChanges = new Map<string, number>();
-  for (const c of changes) {
-    const key = c.vendor.toLowerCase();
-    vendorAllChanges.set(key, (vendorAllChanges.get(key) ?? 0) + 1);
-  }
-
-  // Build vendor → all changes for stability classification
+  // Build vendor → all changes for risk assessment and stability classification
   const vendorAllChangesList = new Map<string, DealChange[]>();
   for (const c of changes) {
     const key = c.vendor.toLowerCase();
@@ -336,16 +356,16 @@ export function enrichOffers(offers: Offer[]): EnrichedOffer[] {
       }
     }
 
-    // risk_level: 0 changes = stable, 1 = caution, 2+ = risky
-    const changeCount = vendorAllChanges.get(key) ?? 0;
-    let risk_level: "stable" | "caution" | "risky" | null = null;
-    if (changeCount >= 2) {
-      risk_level = "risky";
-    } else if (changeCount === 1) {
-      risk_level = "caution";
-    } else {
-      risk_level = "stable";
-    }
+    // risk_level: the single definition in vendorRiskAssessment (#1038). It
+    // used to be a count of every change record of every type, which measured
+    // how closely we had watched the vendor rather than anything about the
+    // vendor. The cause travels with the level so no surface can render the
+    // warning without the dated fact behind it.
+    const assessment = vendorRiskAssessment(vendorAllChangesList.get(key) ?? []);
+    const risk_level = assessment.level;
+    const risk_cause = assessment.cause
+      ? { date: assessment.cause.date, change_type: assessment.cause.change_type, summary: assessment.cause.summary }
+      : null;
 
     // stability: derived from change types, not just count
     const stability = classifyStability(vendorAllChangesList.get(key) ?? []);
@@ -354,7 +374,7 @@ export function enrichOffers(offers: Offer[]): EnrichedOffer[] {
       (now.getTime() - new Date(offer.verifiedDate).getTime()) / (24 * 60 * 60 * 1000)
     );
 
-    const enriched = { ...offer, recent_change, expires_soon, risk_level, stability, days_since_verified };
+    const enriched = { ...offer, recent_change, expires_soon, risk_level, risk_cause, stability, days_since_verified };
     return stripReferrerValue(enriched);
   });
 }
@@ -544,40 +564,89 @@ export interface VendorRiskResult {
   vendor: string;
   category: string;
   risk_level: "stable" | "caution" | "risky";
+  /** Never null when risk_level is caution or risky (#1038). */
+  risk_cause: RiskCause | null;
   free_tier_longevity_days: number;
   changes: DealChange[];
-  alternatives: Array<{ vendor: string; category: string; tier: string; risk_level: "stable" | "caution" | "risky"; demerits: Array<{ code: string; points: number; reason: string }> }>;
+  alternatives: Array<{ vendor: string; category: string; tier: string; risk_level: "stable" | "caution" | "risky"; risk_cause: RiskCause | null; demerits: Array<{ code: string; points: number; reason: string }> }>;
   summary: string;
 }
 
-const NEGATIVE_CHANGE_TYPES = new Set([
-  "free_tier_removed",
-  "open_source_killed",
-  "limits_reduced",
-  "pricing_restructured",
-  "product_deprecated",
-]);
+/**
+ * Every change type that appears in data/deal_changes.json, and how far it
+ * demotes the vendor. `null` demotes nothing.
+ *
+ * #1038: the definition the public surfaces used counted change records of
+ * *any* type, all-time. `limits_increased` — a vendor expanding its free tier
+ * — pushed that vendor toward `caution`, and a vendor we had never examined
+ * rendered `stable` because we had written nothing about it. The badge was a
+ * map of our own coverage, so it flagged the companies we watch most closely
+ * and rewarded obscurity.
+ *
+ * The table is exhaustive on purpose. A type left out of it is a silent
+ * decision either way, so `risk-badge.test.ts` asserts it covers every type
+ * present in the data.
+ */
+export const RISK_DEMOTION: Record<DealChange["change_type"], "risky" | "caution" | null> = {
+  // The free tier we list stopped existing.
+  free_tier_removed: "risky",
+  open_source_killed: "risky",
+  // The free tier still exists and is worth less than it was.
+  limits_reduced: "caution",
+  pricing_restructured: "caution",
+  // Neutral or favourable to the user. These can never raise a risk level.
+  limits_increased: null,
+  new_free_tier: null,
+  new_tier: null,
+  startup_program_expanded: null,
+  pricing_postponed: null,
+  rebranded: null, // a naming event, not a pricing one
+  // Negative, but not risk inputs today — see the #1038 PR description. In
+  // short: `product_deprecated` is dominated by unrelated products of large
+  // vendors (an AWS Lambda runtime deprecation says nothing about AWS's free
+  // tier) and `restriction` currently holds at least one correction to our own
+  // data. Both would reintroduce the coverage proxy this issue removed.
+  product_deprecated: null,
+  restriction: null,
+  pricing_model_change: null,
+};
 
-const RISKY_CHANGE_TYPES = new Set(["free_tier_removed", "open_source_killed"]);
+const RISK_RANK: Record<"stable" | "caution" | "risky", number> = { stable: 0, caution: 1, risky: 2 };
+
+export interface VendorRiskAssessment {
+  level: "stable" | "caution" | "risky";
+  /** The record that produced the level. Never null when level !== "stable". */
+  cause: DealChange | null;
+}
+
+/**
+ * The only definition of vendor risk in the codebase.
+ *
+ * Returns the level *and* the dated record that earned it, because no surface
+ * may publish a warning it cannot show the reason for (#1038).
+ */
+export function vendorRiskAssessment(vendorChanges: DealChange[], nowMs: number = Date.now()): VendorRiskAssessment {
+  const twelveMonthsAgo = new Date(nowMs - 365 * 24 * 60 * 60 * 1000).toISOString().slice(0, 10);
+
+  let best: { level: "caution" | "risky"; cause: DealChange } | null = null;
+  for (const c of vendorChanges) {
+    const demotion = RISK_DEMOTION[c.change_type];
+    if (!demotion) continue;
+    // A severe change ages into `caution`, never into `stable`. We still hold
+    // the record, and `stable` is itself a published claim — SendGrid's free
+    // tier removal is 15 months old and calling that vendor stable would be a
+    // false statement we made ourselves.
+    const level = demotion === "risky" && c.date < twelveMonthsAgo ? "caution" : demotion;
+    if (!best || RISK_RANK[level] > RISK_RANK[best.level] || (level === best.level && c.date > best.cause.date)) {
+      best = { level, cause: c };
+    }
+  }
+
+  return best ? { level: best.level, cause: best.cause } : { level: "stable", cause: null };
+}
 
 export function vendorRiskLevel(vendorChanges: DealChange[]): "stable" | "caution" | "risky" {
-  const twelveMonthsAgo = new Date(Date.now() - 365 * 24 * 60 * 60 * 1000)
-    .toISOString()
-    .slice(0, 10);
-
-  for (const c of vendorChanges) {
-    if (RISKY_CHANGE_TYPES.has(c.change_type) && c.date >= twelveMonthsAgo) {
-      return "risky";
-    }
-  }
-
-  for (const c of vendorChanges) {
-    if (c.change_type === "limits_reduced" || c.change_type === "pricing_restructured") {
-      return "caution";
-    }
-  }
-
-  return "stable";
+  return vendorRiskAssessment(vendorChanges).level;
 }
 
 export function checkVendorRisk(
@@ -599,7 +668,8 @@ export function checkVendorRisk(
     .filter((c) => c.vendor.toLowerCase() === offer.vendor.toLowerCase())
     .sort((a, b) => b.date.localeCompare(a.date));
 
-  const riskLevel = vendorRiskLevel(vendorChanges);
+  const assessment = vendorRiskAssessment(vendorChanges);
+  const riskLevel = assessment.level;
 
   // Free tier longevity: days since verifiedDate with no negative changes after it
   const verifiedDate = new Date(offer.verifiedDate);
@@ -623,18 +693,27 @@ export function checkVendorRisk(
     vendor: e.offer.vendor,
     category: e.offer.category,
     tier: e.offer.tier,
-    risk_level: vendorRiskLevel(allChanges.filter((c) => c.vendor.toLowerCase() === e.offer.vendor.toLowerCase())),
+    ...(() => {
+      const a = vendorRiskAssessment(allChanges.filter((c) => c.vendor.toLowerCase() === e.offer.vendor.toLowerCase()));
+      return {
+        risk_level: a.level,
+        risk_cause: a.cause ? { date: a.cause.date, change_type: a.cause.change_type, summary: a.cause.summary } : null,
+      };
+    })(),
     demerits: e.demerits.map((d) => ({ code: d.code, points: d.points, reason: d.reason })),
   }));
 
-  // Build summary
+  // Build summary. Every non-stable summary names the dated record that
+  // produced the level (#1038) — the tool result is a surface like any other,
+  // and a warning without its reason is an assertion.
   let summary: string;
-  if (riskLevel === "risky") {
-    summary = `${offer.vendor} is high risk — has had a free tier removal or open source license change in the last 12 months. Consider alternatives.`;
-  } else if (riskLevel === "caution") {
-    summary = `${offer.vendor} has had pricing changes (limit reductions or restructuring). Monitor for further changes.`;
+  const cause = assessment.cause;
+  if (riskLevel === "risky" && cause) {
+    summary = `${offer.vendor} is high risk — ${cause.date}: ${cause.summary} Consider alternatives.`;
+  } else if (riskLevel === "caution" && cause) {
+    summary = `${offer.vendor} warrants caution — ${cause.date}: ${cause.summary} Monitor for further changes.`;
   } else {
-    summary = `${offer.vendor} has a stable pricing history with no negative changes recorded. Free tier verified for ${longevityDays} days.`;
+    summary = `${offer.vendor} has a stable pricing history with no free tier removal, limit reduction or pricing restructure on record. Free tier verified for ${longevityDays} days.`;
   }
 
   return {
@@ -642,6 +721,7 @@ export function checkVendorRisk(
       vendor: offer.vendor,
       category: offer.category,
       risk_level: riskLevel,
+      risk_cause: cause ? { date: cause.date, change_type: cause.change_type, summary: cause.summary } : null,
       free_tier_longevity_days: longevityDays,
       changes: vendorChanges,
       alternatives,
@@ -1007,8 +1087,8 @@ export function getWeeklyDigest(): {
   // Build summary
   const parts: string[] = [];
   if (changes.length > 0) {
-    const negative = changes.filter((c) => ["free_tier_removed", "limits_reduced", "restriction", "open_source_killed", "product_deprecated"].includes(c.change_type));
-    const positive = changes.filter((c) => ["new_free_tier", "limits_increased", "startup_program_expanded"].includes(c.change_type));
+    const negative = changes.filter((c) => CHANGE_DIRECTION[c.change_type] === "negative");
+    const positive = changes.filter((c) => CHANGE_DIRECTION[c.change_type] === "positive");
     parts.push(`${changes.length} pricing change${changes.length !== 1 ? "s" : ""} tracked${usedFallback ? " in the past 30 days" : " this week"}`);
     if (negative.length > 0) parts.push(`${negative.length} negative (${negative.map((c) => c.vendor).join(", ")})`);
     if (positive.length > 0) parts.push(`${positive.length} positive (${positive.map((c) => c.vendor).join(", ")})`);
@@ -1109,8 +1189,8 @@ export function getFormattedWeeklyDigest(weeksAgo: number = 0, limit: number = 2
   const months = ["January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December"];
   const dateLabel = `${months[weekStart.getUTCMonth()]} ${weekStart.getUTCDate()}\u2013${weekEnd.getUTCDate()}, ${weekStart.getUTCFullYear()}`;
 
-  const negativeTypes = new Set(["free_tier_removed", "limits_reduced", "restriction", "open_source_killed", "product_deprecated"]);
-  const positiveTypes = new Set(["new_free_tier", "limits_increased", "startup_program_expanded"]);
+  const negativeTypes = NEGATIVE_STABILITY_TYPES;
+  const positiveTypes = POSITIVE_STABILITY_TYPES;
 
   const losses = topChanges.filter(c => negativeTypes.has(c.change_type));
   const brightSpots = topChanges.filter(c => positiveTypes.has(c.change_type));

--- a/src/mcp-apps.ts
+++ b/src/mcp-apps.ts
@@ -288,8 +288,13 @@ function render(args, data) {
   // Single vendor risk check
   if (data.risk_level || data.stability) {
     const vendor = data.vendor || (args.vendors && args.vendors[0]) || "Vendor";
-    const risk = data.risk_level || data.stability || "unknown";
-    const riskBadge = risk === "stable" || risk === "low" ? "badge-green" : risk === "watch" || risk === "medium" ? "badge-yellow" : "badge-red";
+    let risk = data.risk_level || data.stability || "unknown";
+    const cause = data.risk_cause || null;
+    // #1038: caution/risky are negative claims about a named company. They
+    // render only alongside the dated record that produced them.
+    const showRisk = risk === "stable" || risk === "low" || risk === "unknown" || !!cause;
+    if (!showRisk) risk = "unknown";
+    const riskBadge = risk === "stable" || risk === "low" ? "badge-green" : risk === "watch" || risk === "medium" ? "badge-yellow" : risk === "unknown" ? "badge-gray" : "badge-red";
     const changes = data.changes || data.recent_changes || [];
     el.innerHTML = \`
       <div class="card">
@@ -297,6 +302,7 @@ function render(args, data) {
           <h2>\${esc(vendor)} Risk Assessment</h2>
           <span class="badge \${riskBadge}">\${esc(risk)}</span>
         </div>
+        \${cause && risk !== "stable" ? \`<p style="margin-top:8px;font-size:13px;color:#94a3b8"><strong>Why \${esc(risk)}:</strong> \${esc(cause.date)} \u2014 \${esc(cause.summary)}</p>\` : ""}
         \${data.summary ? \`<p style="margin-top:8px;font-size:14px">\${esc(data.summary)}</p>\` : ""}
       </div>
       \${changes.length > 0 ? \`

--- a/src/openapi.ts
+++ b/src/openapi.ts
@@ -373,6 +373,7 @@ export const openapiSpec = {
                     vendor: { type: "string" },
                     category: { type: "string" },
                     risk_level: { type: "string", enum: ["stable", "caution", "risky"] },
+                    risk_cause: { type: "object", nullable: true, description: "The single dated record that produced a non-stable risk_level. Never null when risk_level is caution or risky (#1038) — a client that renders the level must be able to render the reason.", properties: { date: { type: "string" }, change_type: { type: "string" }, summary: { type: "string" } } },
                     free_tier_longevity_days: { type: "number" },
                     changes: { type: "array", items: { $ref: "#/components/schemas/DealChange" } },
                     alternatives: {
@@ -383,7 +384,8 @@ export const openapiSpec = {
                           vendor: { type: "string" },
                           category: { type: "string" },
                           tier: { type: "string" },
-                          risk_level: { type: "string", enum: ["stable", "caution", "risky"] }
+                          risk_level: { type: "string", enum: ["stable", "caution", "risky"] },
+                          risk_cause: { type: "object", nullable: true, description: "The single dated record that produced a non-stable risk_level. Never null when risk_level is caution or risky (#1038) — a client that renders the level must be able to render the reason.", properties: { date: { type: "string" }, change_type: { type: "string" }, summary: { type: "string" } } }
                         }
                       }
                     },

--- a/src/serve.ts
+++ b/src/serve.ts
@@ -5,7 +5,7 @@ import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
 import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
 import { createServer, getServerCard } from "./server.js";
-import { loadOffers, getCategories, getNewOffers, getNewestDeals, searchOffers, enrichOffers, loadDealChanges, getDealChanges, getPersonalizedChanges, getOfferDetails, compareServices, checkVendorRisk, auditStack, getExpiringDeals, getWeeklyDigest, getFormattedWeeklyDigest, getFreshnessMetrics, getStabilityMap, getVendorReferral, sanitizeQuery } from "./data.js";
+import { vendorRiskAssessment, NEGATIVE_CHANGE_TYPES, POSITIVE_CHANGE_TYPES, SEVERE_CHANGE_TYPES, loadOffers, getCategories, getNewOffers, getNewestDeals, searchOffers, enrichOffers, loadDealChanges, getDealChanges, getPersonalizedChanges, getOfferDetails, compareServices, checkVendorRisk, auditStack, getExpiringDeals, getWeeklyDigest, getFormattedWeeklyDigest, getFreshnessMetrics, getStabilityMap, getVendorReferral, sanitizeQuery } from "./data.js";
 import { getStackRecommendation } from "./stacks.js";
 import { estimateCosts } from "./costs.js";
 import { classifyRequest } from "./client-class.js";
@@ -25,7 +25,7 @@ import { subscribe as watchlistSubscribe, getSubscription as getWatchlistSubscri
 import { toSlug, vendorSlugMap, resolveVendorSlug } from "./vendor-slug.js";
 import { rankOffers, rankForListing, rotateListing, utcDate, CRITERIA_PATH, DEMOTE_ONLY_POLICY, DISCLOSURE_RATIONALE, TIE_BREAK_ALGORITHM, GATE_TABLE, DEMERIT_TABLE, NOT_FREE_TIER_RULES, TIME_LIMITED_TIER_RULES } from "./ranking.js";
 import type { RankedEntry, RankingResult } from "./ranking.js";
-import type { Agent } from "./types.js";
+import type { Agent, RiskCause } from "./types.js";
 import type { AgentBalance } from "./ledger.js";
 import type { SubmittedReferralCode } from "./referral-codes.js";
 
@@ -267,7 +267,57 @@ const changeTypeBadge: Record<string, { label: string; color: string }> = {
   startup_program_expanded: { label: "expanded", color: "#3fb950" },
   pricing_postponed: { label: "postponed", color: "#58a6ff" },
   product_deprecated: { label: "deprecated", color: "#f85149" },
+  restriction: { label: "restricted", color: "#d29922" },
+  new_tier: { label: "new tier", color: "#58a6ff" },
+  rebranded: { label: "rebranded", color: "#8b949e" },
 };
+
+const RISK_COLORS: Record<string, string> = { stable: "#3fb950", caution: "#d29922", risky: "#f85149" };
+const STABILITY_COLORS: Record<string, string> = { stable: "#3fb950", watch: "#d29922", volatile: "#f85149", improving: "#58a6ff" };
+
+function riskCauseLabel(cause: RiskCause): string {
+  return `${cause.date} ${changeTypeBadge[cause.change_type]?.label ?? cause.change_type.replace(/_/g, " ")}`;
+}
+
+/**
+ * The only way a risk level reaches an HTML surface (#1038).
+ *
+ * `caution` and `risky` are negative factual claims about a named company, so
+ * they render *with* the dated record that produced them, and render nothing
+ * at all without one — a warning a reader cannot check is an assertion. Before
+ * this, `/vendor/railway` carried `caution` in its `<h1>` because Railway had
+ * expanded its free tier, and `/vendor/neon` carried one whose cause was seven
+ * months old and therefore invisible on the page.
+ *
+ * `stable` needs no cause: it is the absence of a claim against the vendor.
+ */
+function riskBadgeHtml(
+  level: string | null | undefined,
+  cause: RiskCause | null | undefined,
+  opts: { compact?: boolean; margin?: boolean } = {},
+): string {
+  if (!level) return "";
+  if (level !== "stable" && !cause) return "";
+  const color = RISK_COLORS[level] ?? "#8b949e";
+  const size = opts.compact ? ".65rem" : ".7rem";
+  const margin = opts.margin === false ? "" : "margin-left:.5rem;";
+  const badge = `<span style="display:inline-block;${margin}font-size:${size};padding:.15rem .5rem;border-radius:10px;background:${color}22;color:${color};font-weight:600">${level}</span>`;
+  if (level === "stable" || !cause) return badge;
+  return `${badge} <span style="font-size:${size};color:var(--text-dim)" title="${escHtmlServer(cause.summary)}">${escHtmlServer(riskCauseLabel(cause))}</span>`;
+}
+
+/** Table-cell form of the same rule: the level, and under it the dated cause. */
+function riskCellHtml(level: string | null | undefined, cause: RiskCause | null | undefined): string {
+  const resolved = level ?? "stable";
+  // A level with no cause is neither publishable as a warning nor rewritable
+  // into "stable" — that would be a positive claim we also cannot back.
+  if (resolved !== "stable" && !cause) return `<span style="color:var(--text-dim)">&mdash;</span>`;
+  const color = RISK_COLORS[resolved] ?? "#8b949e";
+  const causeHtml = resolved !== "stable" && cause
+    ? `<br><span style="font-size:.7rem;color:var(--text-dim)" title="${escHtmlServer(cause.summary)}">${escHtmlServer(riskCauseLabel(cause))}</span>`
+    : "";
+  return `<span style="color:${color}">${resolved}</span>${causeHtml}`;
+}
 
 function buildChangesHtml(): string {
   return recentChanges.map((c) => {
@@ -1265,7 +1315,12 @@ function buildBestOfMiniReview(offer: ReturnType<typeof enrichOffers>[number]): 
   if (desc.includes("student") || desc.includes("education")) bestFor.push("students");
   if (desc.includes("unlimited") || desc.includes("no limit")) bestFor.push("unlimited usage needs");
   const bestForText = bestFor.length > 0 ? ` Best for ${bestFor.join(" and ")}.` : "";
-  const caveat = offer.risk_level === "caution" ? " Note: pricing has changed in the past." : offer.risk_level === "risky" ? " Caution: pricing has changed multiple times." : "";
+  // #1038: this used to say "pricing has changed in the past" / "changed
+  // multiple times" off a count of records of any type, so a vendor that
+  // *raised* its limits got the caveat. It now quotes the record itself.
+  const caveat = offer.risk_level !== "stable" && offer.risk_cause
+    ? ` Note — ${offer.risk_cause.date}: ${escHtmlServer(offer.risk_cause.summary)}`
+    : "";
   return `${escHtmlServer(offer.description)}${bestForText}${caveat}`;
 }
 
@@ -1308,7 +1363,7 @@ function buildBestOfPage(slug: string): string | null {
 
   const renderCard = (e: RankedEntry<EnrichedOfferRow>, i: number, demotedCard: boolean) => {
     const o = e.offer;
-    const riskBadge = o.risk_level ? `<span style="display:inline-block;font-size:.7rem;padding:.15rem .5rem;border-radius:10px;background:${riskColors[o.risk_level]}22;color:${riskColors[o.risk_level]};font-weight:600;margin-left:.5rem">${o.risk_level}</span>` : "";
+    const riskBadge = riskBadgeHtml(o.risk_level, o.risk_cause);
     const review = buildBestOfMiniReview(o);
     const relatedCompareLinks = Array.from(comparisonMap.entries())
       .filter(([, [a, b]]) => a === o.vendor || b === o.vendor)
@@ -1348,7 +1403,7 @@ function buildBestOfPage(slug: string): string | null {
           <td style="font-weight:600"><a href="/vendor/${toSlug(o.vendor)}" style="color:var(--text)">${escHtmlServer(o.vendor)}</a></td>
           <td style="font-family:var(--mono);color:var(--accent)">${escHtmlServer(o.tier)}</td>
           <td style="color:var(--text-muted);max-width:300px">${escHtmlServer(o.description.slice(0, 120))}${o.description.length > 120 ? "..." : ""}</td>
-          <td><span style="color:${riskColors[o.risk_level ?? "stable"]}">${o.risk_level ?? "stable"}</span></td>
+          <td>${riskCellHtml(o.risk_level, o.risk_cause)}</td>
           <td style="font-family:var(--mono);color:var(--text-dim)">${escHtmlServer(o.verifiedDate)}</td>
         </tr>`;
   }).join("\n");
@@ -1715,6 +1770,11 @@ ${demeritRows}
 
   <h3>One demerit measures us, not the vendor</h3>
   <p><code>stale_verification</code> means we have not been able to confirm the offer recently. That is material &mdash; you should know when we cannot vouch for a record &mdash; but it is a statement about our confidence, and it is labelled as such wherever it appears. It is never presented as something the vendor did.</p>
+
+  <h3>The risk label is not a rank, and it is never a count</h3>
+  <p>Vendor pages carry a <code>stable</code> / <code>caution</code> / <code>risky</code> label. <strong style="color:var(--text)">It moves no order on this site</strong> &mdash; the ranking module cannot read it, and flipping every label leaves every listing we publish in the same order.</p>
+  <p>It is decided by the <em>type</em> of a recorded change, never by how many records we hold. A vendor that expanded its free tier, postponed a fee, added a tier or changed its name cannot be labelled <code>caution</code> for any of those. <strong style="color:var(--text)">A <code>caution</code> or <code>risky</code> label always renders together with the single dated record that produced it, on the same page and next to the label. Where we cannot show the reason, we do not show the label.</strong></p>
+  <p>The honest limit: <code>stable</code> means we hold no record of a free tier removal, a limit reduction or a pricing restructure for that vendor. It is a statement about our records, not a clean bill of health &mdash; a vendor we have never had cause to examine reads the same as one with a long clean history. Until August 2026 the label was derived from a count of records of any type, which inverted that: the vendors we watched most closely were the ones it flagged, and several were flagged for good news. That is fixed, and this paragraph is here so the next version of it is checkable.</p>
 
   <h2>3. Ties, and why there is no top slot to sell</h2>
   <div class="callout">
@@ -2146,11 +2206,7 @@ function buildComparisonPage(slug: string): string | null {
   const riskA = enrichOffers([offers.find(o => o.vendor === a.vendor)!])[0];
   const riskB = enrichOffers([offers.find(o => o.vendor === b.vendor)!])[0];
 
-  const riskBadge = (level: string | null) => {
-    const colors: Record<string, string> = { stable: "#3fb950", caution: "#d29922", risky: "#f85149" };
-    const color = colors[level ?? ""] ?? "#8b949e";
-    return `<span style="display:inline-block;padding:.15rem .5rem;border-radius:12px;font-size:.7rem;font-weight:600;background:${color}20;color:${color};border:1px solid ${color}40">${level ?? "unknown"}</span>`;
-  };
+  const riskBadge = (o: { risk_level: string | null; risk_cause: RiskCause | null }) => riskBadgeHtml(o.risk_level, o.risk_cause, { margin: false });
 
   const changesHtml = (changes: typeof a.deal_changes, vendor: string) => {
     if (changes.length === 0) return `<p style="color:var(--text-dim);font-size:.85rem">No recorded pricing changes for ${escHtmlServer(vendor)}.</p>`;
@@ -2182,8 +2238,10 @@ function buildComparisonPage(slug: string): string | null {
   const tierB = b.tier.toLowerCase();
   const hasFreeA = tierA !== "none" && !a.description.toLowerCase().includes("no free tier");
   const hasFreeB = tierB !== "none" && !b.description.toLowerCase().includes("no free tier");
-  const stabilityA = riskA.risk_level ?? "unknown";
-  const stabilityB = riskB.risk_level ?? "unknown";
+  // These are risk levels, not stability classes — two different scales.
+  // They render only when their cause does (#1038).
+  const stabilityA = riskA.risk_cause || riskA.risk_level === "stable" ? riskA.risk_level ?? "unknown" : "unknown";
+  const stabilityB = riskB.risk_cause || riskB.risk_level === "stable" ? riskB.risk_level ?? "unknown" : "unknown";
   const changesCountA = a.deal_changes.length;
   const changesCountB = b.deal_changes.length;
 
@@ -2348,7 +2406,7 @@ ${categoryContextHtml}
 ${verdictHtml}
   <div class="compare-grid">
     <div class="vendor-col">
-      <h2><a href="/vendor/${toSlug(a.vendor)}">${escHtmlServer(a.vendor)}</a> ${riskBadge(riskA.risk_level)}</h2>
+      <h2><a href="/vendor/${toSlug(a.vendor)}">${escHtmlServer(a.vendor)}</a> ${riskBadge(riskA)}</h2>
       <div class="detail-row"><span class="detail-label">Category</span><span class="detail-value">${escHtmlServer(a.category)}</span></div>
       <div class="detail-row"><span class="detail-label">Tier</span><span class="detail-value" style="color:var(--accent)">${escHtmlServer(a.tier)}</span></div>
       <div class="detail-row"><span class="detail-label">Verified</span><span class="detail-value">${escHtmlServer(a.verifiedDate)}</span></div>
@@ -2357,7 +2415,7 @@ ${verdictHtml}
       ${a.referral ? `<div style="margin-top:.75rem;padding:.5rem .75rem;border:1px solid #3fb95040;border-left:3px solid #3fb950;border-radius:0 6px 6px 0;background:#3fb95010;font-size:.8rem">\ud83d\udd17 <a href="${escHtmlServer(a.referral.url)}" rel="noopener sponsored" target="_blank">Referral link</a>: ${escHtmlServer(a.referral.referee_value ?? "Save with our referral link")} <a href="/disclosure" style="font-size:.7rem;color:var(--text-dim)">(disclosure)</a></div>` : ""}
     </div>
     <div class="vendor-col">
-      <h2><a href="/vendor/${toSlug(b.vendor)}">${escHtmlServer(b.vendor)}</a> ${riskBadge(riskB.risk_level)}</h2>
+      <h2><a href="/vendor/${toSlug(b.vendor)}">${escHtmlServer(b.vendor)}</a> ${riskBadge(riskB)}</h2>
       <div class="detail-row"><span class="detail-label">Category</span><span class="detail-value">${escHtmlServer(b.category)}</span></div>
       <div class="detail-row"><span class="detail-label">Tier</span><span class="detail-value" style="color:var(--accent)">${escHtmlServer(b.tier)}</span></div>
       <div class="detail-row"><span class="detail-label">Verified</span><span class="detail-value">${escHtmlServer(b.verifiedDate)}</span></div>
@@ -2678,11 +2736,7 @@ function buildVsPage(slug: string): string | null {
   const riskA = enrichOffers([offers.find(o => o.vendor === a.vendor)!])[0];
   const riskB = enrichOffers([offers.find(o => o.vendor === b.vendor)!])[0];
 
-  const riskBadge = (level: string | null) => {
-    const colors: Record<string, string> = { stable: "#3fb950", caution: "#d29922", risky: "#f85149" };
-    const color = colors[level ?? ""] ?? "#8b949e";
-    return `<span style="display:inline-block;padding:.15rem .5rem;border-radius:12px;font-size:.7rem;font-weight:600;background:${color}20;color:${color};border:1px solid ${color}40">${level ?? "unknown"}</span>`;
-  };
+  const riskBadge = (o: { risk_level: string | null; risk_cause: RiskCause | null }) => riskBadgeHtml(o.risk_level, o.risk_cause, { margin: false });
 
   const stabilityBadge = (stability: string) => {
     const colors: Record<string, string> = { stable: "#3fb950", watch: "#d29922", volatile: "#f85149", improving: "#58a6ff" };
@@ -2849,7 +2903,7 @@ ${globalNavCss()}
   <h2>Side-by-Side Comparison</h2>
   <div class="compare-grid">
     <div class="vendor-col">
-      <h3><a href="/vendor/${toSlug(a.vendor)}">${escHtmlServer(a.vendor)}</a> ${riskBadge(riskA.risk_level)} ${stabilityBadge(riskA.stability ?? "stable")}</h3>
+      <h3><a href="/vendor/${toSlug(a.vendor)}">${escHtmlServer(a.vendor)}</a> ${riskBadge(riskA)} ${stabilityBadge(riskA.stability ?? "stable")}</h3>
       <div class="detail-row"><span class="detail-label">Category</span><span class="detail-value">${escHtmlServer(a.category)}</span></div>
       <div class="detail-row"><span class="detail-label">Tier</span><span class="detail-value" style="color:var(--accent)">${escHtmlServer(a.tier)}</span></div>
       <div class="detail-row"><span class="detail-label">Verified</span><span class="detail-value">${escHtmlServer(a.verifiedDate)}</span></div>
@@ -2858,7 +2912,7 @@ ${globalNavCss()}
       <div class="desc-block">${escHtmlServer(a.description)}</div>
     </div>
     <div class="vendor-col">
-      <h3><a href="/vendor/${toSlug(b.vendor)}">${escHtmlServer(b.vendor)}</a> ${riskBadge(riskB.risk_level)} ${stabilityBadge(riskB.stability ?? "stable")}</h3>
+      <h3><a href="/vendor/${toSlug(b.vendor)}">${escHtmlServer(b.vendor)}</a> ${riskBadge(riskB)} ${stabilityBadge(riskB.stability ?? "stable")}</h3>
       <div class="detail-row"><span class="detail-label">Category</span><span class="detail-value">${escHtmlServer(b.category)}</span></div>
       <div class="detail-row"><span class="detail-label">Tier</span><span class="detail-value" style="color:var(--accent)">${escHtmlServer(b.tier)}</span></div>
       <div class="detail-row"><span class="detail-label">Verified</span><span class="detail-value">${escHtmlServer(b.verifiedDate)}</span></div>
@@ -3601,9 +3655,17 @@ function buildVendorPage(slug: string): string | null {
 
   // Risk assessment
   const riskColors: Record<string, string> = { stable: "#3fb950", caution: "#d29922", risky: "#f85149" };
-  const riskLevel = enriched.risk_level ?? "stable";
+  const riskCause = enriched.risk_cause;
+  // #1038: a level we cannot show the cause for is not publishable in the H1.
+  const riskLevel = enriched.risk_level && (enriched.risk_level === "stable" || riskCause) ? enriched.risk_level : "stable";
   const riskColor = riskColors[riskLevel] ?? "#8b949e";
   const stability = enriched.stability ?? "stable";
+  // The badge sits in the largest text on the page. Its reason sits directly
+  // under it — not only in the history section further down, which for a cause
+  // older than 90 days did not carry it at all (Neon, #1038).
+  const riskCauseLine = riskLevel !== "stable" && riskCause
+    ? `  <p class="risk-cause-line" style="margin:.4rem 0 .6rem;font-size:.9rem;color:var(--text-muted)"><strong style="color:${riskColor}">Why ${riskLevel}:</strong> <span class="risk-cause-date" style="font-family:var(--mono)">${escHtmlServer(riskCause.date)}</span> &mdash; ${escHtmlServer(riskCause.summary)} <a href="#changes" style="white-space:nowrap">Full history &darr;</a></p>`
+    : "";
 
   // Alternatives: other vendors in the same primary category
   // "Alternatives to X" is a recommendation, so it goes through the shared
@@ -3708,11 +3770,11 @@ function buildVendorPage(slug: string): string | null {
           <tr class="current-vendor-row">
             <td><strong>${escHtmlServer(vendorName)}</strong></td>
             <td>${escHtmlServer(primary.tier)}</td>
-            <td><span class="stability-dot" style="background:${riskColor}"></span> ${escHtmlServer(stability)}</td>
+            <td><span class="stability-dot" style="background:${STABILITY_COLORS[stability] ?? "#8b949e"}"></span> ${escHtmlServer(stability)}</td>
           </tr>
 ${enrichedAlts.map(a => {
   const aStability = a.stability ?? "stable";
-  const aColor = riskColors[a.risk_level ?? "stable"] ?? "#8b949e";
+  const aColor = STABILITY_COLORS[aStability] ?? "#8b949e";
   return `          <tr>
             <td><a href="/vendor/${toSlug(a.vendor)}">${escHtmlServer(a.vendor)}</a></td>
             <td>${escHtmlServer(a.tier)}</td>
@@ -3742,7 +3804,14 @@ ${enrichedAlts.map(a => {
 
   // Prominent change notice for vendors with significant changes
   const latestChange = vendorChanges[0];
-  const changeNoticeHtml = latestChange && (latestChange.change_type === "free_tier_removed" || latestChange.change_type === "limits_reduced" || latestChange.change_type === "open_source_killed" || latestChange.change_type === "product_deprecated" || latestChange.change_type === "pricing_restructured") ? (() => {
+  // #1038: this was a seventh inline copy of the change-direction taxonomy, and
+  // it keyed on the *latest* record rather than the one that earned the badge —
+  // so it could show a different record from the one the <h1> is warning about,
+  // or none at all. It reads the shared set, and it stands down when the cause
+  // line above has already published this exact record.
+  const causeAlreadyShown = riskCause !== null && latestChange !== undefined && latestChange !== null
+    && latestChange.date === riskCause.date && latestChange.change_type === riskCause.change_type;
+  const changeNoticeHtml = latestChange && !causeAlreadyShown && NEGATIVE_CHANGE_TYPES.has(latestChange.change_type) ? (() => {
     const badge = changeTypeBadge[latestChange.change_type] ?? { label: latestChange.change_type, color: "#8b949e" };
     const anchor = `${toSlug(latestChange.vendor)}-${latestChange.date}`;
     return `<div class="change-notice" style="margin:1rem 0;padding:.75rem 1rem;border:1px solid ${badge.color}40;border-left:3px solid ${badge.color};border-radius:0 8px 8px 0;background:${badge.color}10">
@@ -3937,11 +4006,17 @@ ${allCompareLinks.join("\n")}
   // FAQ data for vendor pages — expanded to 6-8 questions
   const faqFreeAnswer = `Yes, ${vendorName} offers a free tier: ${primary.tier}. ${primary.description.slice(0, 200)}${primary.description.length > 200 ? "..." : ""}`;
   const faqTierAnswer = `${vendorName}'s free tier is called "${primary.tier}". ${primary.description}`;
+  // #1038: these answers ship inside FAQPage JSON-LD, which is the version of
+  // this page an AI search engine quotes. They used to reach for the *count* of
+  // recorded changes and for `vendorChanges[0]` — the most recent record of any
+  // type — so a vendor could be told it "requires caution" and then handed a
+  // free-tier expansion as the evidence. They now quote the record that
+  // produced the level, and nothing else.
   const faqReliableAnswer = riskLevel === "stable"
-    ? `${vendorName}'s free tier is considered stable. ${vendorChanges.length === 0 ? "There are no recorded pricing changes." : `There ${vendorChanges.length === 1 ? "has been 1 recorded pricing change" : `have been ${vendorChanges.length} recorded pricing changes`}, but the free tier remains available.`}`
+    ? `${vendorName}'s free tier is considered stable: we hold no free tier removal, limit reduction or pricing restructure on record for this vendor.${vendorChanges.length > 0 ? ` We do hold ${vendorChanges.length === 1 ? "1 other recorded change" : `${vendorChanges.length} other recorded changes`} — see the pricing history below.` : ""}`
     : riskLevel === "caution"
-    ? `${vendorName}'s free tier requires caution. There ${vendorChanges.length === 1 ? "has been 1 recorded pricing change" : `have been ${vendorChanges.length} recorded pricing changes`}. ${vendorChanges[0] ? `Most recently: ${vendorChanges[0].summary}` : ""}`
-    : `${vendorName}'s free tier is considered risky. There ${vendorChanges.length === 1 ? "has been 1 significant pricing change" : `have been ${vendorChanges.length} significant pricing changes`}. ${vendorChanges[0] ? `Most recently: ${vendorChanges[0].summary}` : ""} Consider alternatives.`;
+    ? `${vendorName}'s free tier requires caution because of one specific recorded change${riskCause ? `, on ${riskCause.date}: ${riskCause.summary}` : "."}`
+    : `${vendorName}'s free tier is considered risky because of one specific recorded change${riskCause ? `, on ${riskCause.date}: ${riskCause.summary}` : "."} Consider alternatives.`;
   const faqCategoryAnswer = `${vendorName} is categorized under ${allCategories.join(", ")} on AgentDeals.${alternatives.length > 0 ? ` Other vendors in ${primary.category} include ${alternatives.slice(0, 5).map(a => a.vendor).join(", ")}.` : ""}`;
 
   // NEW: Additional FAQ items
@@ -4087,6 +4162,7 @@ ${mcpCtaCss()}
   ${buildGlobalNav("categories")}
   <div class="breadcrumb"><a href="/">AgentDeals</a> &rsaquo; <a href="/vendor">Vendors</a> &rsaquo; ${escHtmlServer(vendorName)}</div>
   <h1>${escHtmlServer(vendorName)} Free Tier ${currentYear} <span class="risk-badge" style="background:${riskColor}20;color:${riskColor};border:1px solid ${riskColor}40">${riskLevel}</span></h1>
+${riskCauseLine}
   <p class="page-meta">Limits, pricing history, and ${alternatives.length} alternatives. Verified ${verifiedMonth}. Last updated ${escHtmlServer(lastUpdated)}.</p>
 ${quickVerdictHtml}
 ${categoryContextHtml}
@@ -4122,7 +4198,7 @@ ${compareTableHtml}
 ${growthPathHtml}
 
   <div class="section">
-    <h2>Pricing Change History (${vendorChanges.length} recorded)</h2>
+    <h2 id="changes">Pricing Change History (${vendorChanges.length} recorded)</h2>
     ${changesHtml}
     <p style="margin-top:.75rem;font-size:.8rem"><a href="/pricing-changes">View all ${dealChanges.length} pricing changes across all vendors &rarr;</a></p>
   </div>
@@ -4166,7 +4242,9 @@ function buildAlternativesPage(slug: string): string | null {
     .sort((a, b) => b.date.localeCompare(a.date));
 
   const riskColors: Record<string, string> = { stable: "#3fb950", caution: "#d29922", risky: "#f85149" };
-  const riskLevel = enriched.risk_level ?? "stable";
+  const riskCause = enriched.risk_cause;
+  // #1038: no publishable cause, no warning.
+  const riskLevel = enriched.risk_level && (enriched.risk_level === "stable" || riskCause) ? enriched.risk_level : "stable";
   const riskColor = riskColors[riskLevel] ?? "#8b949e";
 
   // Get all categories this vendor belongs to
@@ -4216,6 +4294,9 @@ function buildAlternativesPage(slug: string): string | null {
   const situationHtml = (() => {
     const parts: string[] = [];
     parts.push(`<div class="risk-row"><span class="risk-label">Risk Level:</span> <span class="risk-badge-inline" style="background:${riskColor}20;color:${riskColor};border:1px solid ${riskColor}40">${riskLevel}</span></div>`);
+    if (riskLevel !== "stable" && riskCause) {
+      parts.push(`<div class="risk-row"><span class="risk-label">Why:</span> <span class="risk-cause-date" style="font-family:var(--mono)">${escHtmlServer(riskCause.date)}</span> &mdash; ${escHtmlServer(riskCause.summary)}</div>`);
+    }
     parts.push(`<div class="risk-row"><span class="risk-label">Category:</span> ${vendorCategories.map(c => `<a href="/category/${toSlug(c)}" class="cat-pill">${escHtmlServer(c)}</a>`).join(" ")}</div>`);
     parts.push(`<div class="risk-row"><span class="risk-label">Pricing Page:</span> <a href="${escHtmlServer(primary.url)}" rel="noopener" target="_blank">${escHtmlServer(primary.url.replace(/^https?:\/\//, "").slice(0, 50))}${primary.url.replace(/^https?:\/\//, "").length > 50 ? "..." : ""}</a></div>`);
     if (vendorChanges.length > 0) {
@@ -4242,15 +4323,13 @@ function buildAlternativesPage(slug: string): string | null {
   // Build alternative cards
   const vName = vendorName; // narrowed for closure
   function altCard(a: typeof enrichedAlts[0], curated: boolean): string {
-    const aRisk = a.risk_level ?? "stable";
-    const aRiskColor = riskColors[aRisk] ?? "#8b949e";
     const aSlug = toSlug(a.vendor);
     const compSlug = comparisonSlug(vName < a.vendor ? vName : a.vendor, vName < a.vendor ? a.vendor : vName);
     const hasComparison = comparisonMap.has(compSlug);
     return `<div class="alt-row${curated ? " curated" : ""}">
         <div class="alt-info">
           <a href="/vendor/${aSlug}" class="alt-vendor-name">${escHtmlServer(a.vendor)}</a>
-          <span class="risk-badge-sm" style="background:${aRiskColor}20;color:${aRiskColor};border:1px solid ${aRiskColor}40">${aRisk}</span>
+          ${riskBadgeHtml(a.risk_level, a.risk_cause, { compact: true, margin: false })}
           ${curated ? '<span class="curated-badge">recommended</span>' : ""}
         </div>
         <div class="alt-tier">${escHtmlServer(a.tier)}</div>
@@ -4318,13 +4397,16 @@ ${enrichedAlts.map(a => altCard(a, false)).join("\n")}
   // FAQ data for alternative-to pages
   const topStableAlts = enrichedAlts.filter(a => (a.risk_level ?? "stable") === "stable").slice(0, 5);
   const faqBestAltsAnswer = topStableAlts.length > 0
-    ? `The best free alternatives to ${vendorName} include ${topStableAlts.map(a => `${a.vendor} (${a.tier})`).join(", ")}. All have stable pricing with no recent changes.`
+    ? `The best free alternatives to ${vendorName} include ${topStableAlts.map(a => `${a.vendor} (${a.tier})`).join(", ")}. We hold no free tier removal, limit reduction or pricing restructure on record for any of them.`
     : `There are ${enrichedAlts.length} free alternatives to ${vendorName} available. ${enrichedAlts.slice(0, 3).map(a => a.vendor).join(", ")} are among the options.`;
+  // #1038: "flagged due to N recorded pricing changes" then quoting
+  // vendorChanges[0] could hand the reader a limits_increased record as the
+  // reason for a warning. The flag has exactly one cause and this names it.
   const faqFreeTierAnswer = riskLevel === "stable"
-    ? `Yes, ${vendorName} currently offers a free tier (${primary.tier}). ${vendorChanges.length === 0 ? "No pricing changes have been recorded." : `However, there ${vendorChanges.length === 1 ? "has been 1 pricing change" : `have been ${vendorChanges.length} pricing changes`} on record.`}`
+    ? `Yes, ${vendorName} currently offers a free tier (${primary.tier}). ${vendorChanges.length === 0 ? "No pricing changes have been recorded." : `We hold ${vendorChanges.length === 1 ? "1 recorded change" : `${vendorChanges.length} recorded changes`} for this vendor, none of them a free tier removal, limit reduction or pricing restructure.`}`
     : riskLevel === "caution"
-    ? `${vendorName} has a free tier (${primary.tier}), but it's flagged as "caution" due to ${vendorChanges.length} recorded pricing change${vendorChanges.length !== 1 ? "s" : ""}. ${vendorChanges[0] ? vendorChanges[0].summary : ""}`
-    : `${vendorName}'s free tier (${primary.tier}) is considered risky. ${vendorChanges[0] ? vendorChanges[0].summary : ""} Consider migrating to a more stable alternative.`;
+    ? `${vendorName} has a free tier (${primary.tier}), but it's flagged as "caution" because of one specific recorded change${riskCause ? `, on ${riskCause.date}: ${riskCause.summary}` : "."}`
+    : `${vendorName}'s free tier (${primary.tier}) is considered risky because of one specific recorded change${riskCause ? `, on ${riskCause.date}: ${riskCause.summary}` : "."} Consider migrating to a more stable alternative.`;
   const faqCountAnswer = `There are ${enrichedAlts.length} free alternatives to ${vendorName} tracked on AgentDeals across the ${vendorCategories.join(", ")} categor${vendorCategories.length > 1 ? "ies" : "y"}.`;
   const faqChangesAnswer = vendorChanges.length > 0
     ? `Yes, ${vendorName} has ${vendorChanges.length} recorded pricing change${vendorChanges.length !== 1 ? "s" : ""}. The most recent was on ${vendorChanges[0].date}: ${vendorChanges[0].summary}`
@@ -4480,33 +4562,26 @@ function buildAlternativesIndexPage(): string {
 
   // Identify vendors with strongest "look elsewhere" signals
   // Priority: vendors with deal changes indicating negative trends, or risky ratings
-  const vendorSignals = new Map<string, { changes: number; negative: number; riskLevel: string; categories: string[] }>();
+  // #1038: this list used to score `+1 per other change`, so a vendor that
+  // expanded its free tier earned a place on a page headed "Free Alternatives
+  // to Popular Tools" — we recommended leaving a vendor for improving. A
+  // vendor appears here only if it carries a risk level we can name a cause
+  // for, and the row publishes that cause instead of a change count.
+  const vendorSignals = new Map<string, { riskLevel: string; riskCause: RiskCause | null; categories: string[] }>();
 
   for (const o of offers) {
     if (!vendorSignals.has(o.vendor)) {
       const enriched = enrichOffers([o])[0];
-      vendorSignals.set(o.vendor, { changes: 0, negative: 0, riskLevel: enriched.risk_level ?? "stable", categories: [] });
+      vendorSignals.set(o.vendor, { riskLevel: enriched.risk_level ?? "stable", riskCause: enriched.risk_cause, categories: [] });
     }
     const sig = vendorSignals.get(o.vendor)!;
     if (!sig.categories.includes(o.category)) sig.categories.push(o.category);
   }
 
-  for (const c of allChanges) {
-    const sig = vendorSignals.get(c.vendor);
-    if (sig) {
-      sig.changes++;
-      if (["free_tier_removed", "limits_reduced", "restriction", "open_source_killed", "product_deprecated"].includes(c.change_type)) {
-        sig.negative++;
-      }
-    }
-  }
-
-  // Score: risky=3, caution=2, stable=0, +2 per negative change, +1 per other change
-  const scored = Array.from(vendorSignals.entries()).map(([vendor, sig]) => {
-    const riskScore = sig.riskLevel === "risky" ? 3 : sig.riskLevel === "caution" ? 2 : 0;
-    const score = riskScore + sig.negative * 2 + (sig.changes - sig.negative);
-    return { vendor, score, ...sig };
-  }).filter(v => v.score > 0).sort((a, b) => b.score - a.score);
+  const scored = Array.from(vendorSignals.entries())
+    .map(([vendor, sig]) => ({ vendor, score: sig.riskLevel === "risky" ? 2 : sig.riskLevel === "caution" ? 1 : 0, ...sig }))
+    .filter(v => v.score > 0 && v.riskCause !== null)
+    .sort((a, b) => b.score - a.score || (b.riskCause!.date).localeCompare(a.riskCause!.date) || a.vendor.localeCompare(b.vendor));
 
   const riskColors: Record<string, string> = { stable: "#3fb950", caution: "#d29922", risky: "#f85149" };
 
@@ -4514,11 +4589,9 @@ function buildAlternativesIndexPage(): string {
   const metaDesc = `Browse free alternatives to ${scored.length} developer tools. Find stable replacements when vendors raise prices, remove free tiers, or reduce limits.`;
 
   const vendorListHtml = scored.map(v => {
-    const rc = riskColors[v.riskLevel] ?? "#8b949e";
     return `<a href="/alternative-to/${toSlug(v.vendor)}" class="idx-row">
         <span class="idx-vendor">${escHtmlServer(v.vendor)}</span>
-        <span class="risk-badge-sm" style="background:${rc}20;color:${rc};border:1px solid ${rc}40">${v.riskLevel}</span>
-        <span class="idx-changes">${v.changes} change${v.changes !== 1 ? "s" : ""}</span>
+        ${riskBadgeHtml(v.riskLevel, v.riskCause, { compact: true, margin: false })}
         <span class="idx-cats">${v.categories.slice(0, 2).map(c => escHtmlServer(c)).join(", ")}${v.categories.length > 2 ? "..." : ""}</span>
       </a>`;
   }).join("\n");
@@ -6643,7 +6716,7 @@ function buildTimelyAlternativesPage(slug: string): string | null {
 
   // Build alternative cards
   const altCards = enriched.map((o) => {
-    const riskBadge = o.risk_level ? `<span style="display:inline-block;font-size:.7rem;padding:.15rem .5rem;border-radius:10px;background:${riskColors[o.risk_level]}22;color:${riskColors[o.risk_level]};font-weight:600;margin-left:.5rem">${o.risk_level}</span>` : "";
+    const riskBadge = riskBadgeHtml(o.risk_level, o.risk_cause);
     return `      <div class="alt-card">
         <div class="alt-card-header">
           <a href="/vendor/${toSlug(o.vendor)}" class="alt-card-name">${escHtmlServer(o.vendor)}</a>
@@ -6665,7 +6738,7 @@ function buildTimelyAlternativesPage(slug: string): string | null {
   <h2>Other ${escHtmlServer(primaryOffer?.category ?? "")} Tools</h2>
   <p style="color:var(--text-muted);margin-bottom:1rem">More free tools in the same category that may fit your needs.</p>
   ${enrichedCategory.map((o) => {
-    const riskBadge = o.risk_level ? `<span style="display:inline-block;font-size:.7rem;padding:.15rem .5rem;border-radius:10px;background:${riskColors[o.risk_level]}22;color:${riskColors[o.risk_level]};font-weight:600;margin-left:.5rem">${o.risk_level}</span>` : "";
+    const riskBadge = riskBadgeHtml(o.risk_level, o.risk_cause);
     return `      <div class="alt-card" style="border-color:var(--border)">
         <div class="alt-card-header">
           <a href="/vendor/${toSlug(o.vendor)}" class="alt-card-name">${escHtmlServer(o.vendor)}</a>
@@ -6687,7 +6760,7 @@ function buildTimelyAlternativesPage(slug: string): string | null {
           <td style="font-weight:600"><a href="/vendor/${toSlug(o.vendor)}" style="color:var(--text)">${escHtmlServer(o.vendor)}</a></td>
           <td style="font-family:var(--mono);color:var(--accent)">${escHtmlServer(o.tier)}</td>
           <td style="color:var(--text-muted);max-width:300px">${escHtmlServer(o.description.slice(0, 120))}${o.description.length > 120 ? "..." : ""}</td>
-          <td><span style="color:${riskColors[o.risk_level ?? "stable"]}">${o.risk_level ?? "stable"}</span></td>
+          <td>${riskCellHtml(o.risk_level, o.risk_cause)}</td>
         </tr>`).join("\n");
 
   // JSON-LD
@@ -7775,13 +7848,12 @@ function buildEventPage(slug: string): string | null {
     const rows = catOffers.map(o => {
       const vendorSlug = toSlug(o.vendor);
       const riskColors: Record<string, string> = { stable: "#3fb950", caution: "#d29922", risky: "#f85149" };
-      const riskLevel = o.risk_level ?? "stable";
-      const riskColor = riskColors[riskLevel] ?? "#8b949e";
+
       return '<tr>'
         + '<td><a href="/vendor/' + vendorSlug + '">' + escHtmlServer(o.vendor) + '</a></td>'
         + '<td>' + escHtmlServer(o.tier) + '</td>'
         + '<td>' + escHtmlServer(o.description.slice(0, 100)) + (o.description.length > 100 ? "..." : "") + '</td>'
-        + '<td><span class="risk-badge-sm" style="color:' + riskColor + '">' + riskLevel + '</span></td>'
+        + '<td>' + riskCellHtml(o.risk_level, o.risk_cause) + '</td>'
         + '<td>' + o.verifiedDate + '</td>'
         + '</tr>';
     }).join("\n");
@@ -7971,7 +8043,7 @@ function buildReportsIndexPage(): string {
   const monthCards = months.map(m => {
     const [y, mo] = m.split("-");
     const monthChanges = allChanges.filter(c => c.date.startsWith(m));
-    const negative = monthChanges.filter(c => ["free_tier_removed","limits_reduced","restriction","product_deprecated","open_source_killed","pricing_model_change"].includes(c.change_type)).length;
+    const negative = monthChanges.filter(c => NEGATIVE_CHANGE_TYPES.has(c.change_type)).length;
     const positive = monthChanges.filter(c => ["new_free_tier","limits_increased","startup_program_expanded","new_tier"].includes(c.change_type)).length;
     const neutral = monthChanges.length - negative - positive;
     const sentiment = negative > positive ? "bearish" : positive > negative ? "bullish" : "mixed";
@@ -8404,7 +8476,7 @@ function buildAiFreeTiersPage(): string {
 
   // Build alternative cards helper
   const buildCards = (items: ReturnType<typeof enrichOffers>) => items.map(o => {
-    const riskBadge = o.risk_level ? `<span style="display:inline-block;font-size:.7rem;padding:.15rem .5rem;border-radius:10px;background:${riskColors[o.risk_level]}22;color:${riskColors[o.risk_level]};font-weight:600;margin-left:.5rem">${o.risk_level}</span>` : "";
+    const riskBadge = riskBadgeHtml(o.risk_level, o.risk_cause);
     return `<div class="alt-card">
         <div class="alt-card-header">
           <a href="/vendor/${toSlug(o.vendor)}" class="alt-card-name">${escHtmlServer(o.vendor)}</a>
@@ -8670,7 +8742,7 @@ function buildHostingAlternativesPage(): string {
 
   // Build cards helper
   const buildCards = (items: ReturnType<typeof enrichOffers>) => items.map(o => {
-    const riskBadge = o.risk_level ? `<span style="display:inline-block;font-size:.7rem;padding:.15rem .5rem;border-radius:10px;background:${riskColors[o.risk_level]}22;color:${riskColors[o.risk_level]};font-weight:600;margin-left:.5rem">${o.risk_level}</span>` : "";
+    const riskBadge = riskBadgeHtml(o.risk_level, o.risk_cause);
     return `<div class="alt-card">
         <div class="alt-card-header">
           <a href="/vendor/${toSlug(o.vendor)}" class="alt-card-name">${escHtmlServer(o.vendor)}</a>
@@ -9015,7 +9087,7 @@ function buildDatabaseAlternativesPage(): string {
 
   // Build cards helper
   const buildCards = (items: ReturnType<typeof enrichOffers>) => items.map(o => {
-    const riskBadge = o.risk_level ? `<span style="display:inline-block;font-size:.7rem;padding:.15rem .5rem;border-radius:10px;background:${riskColors[o.risk_level]}22;color:${riskColors[o.risk_level]};font-weight:600;margin-left:.5rem">${o.risk_level}</span>` : "";
+    const riskBadge = riskBadgeHtml(o.risk_level, o.risk_cause);
     return `<div class="alt-card">
         <div class="alt-card-header">
           <a href="/vendor/${toSlug(o.vendor)}" class="alt-card-name">${escHtmlServer(o.vendor)}</a>
@@ -9361,7 +9433,7 @@ function buildMonitoringAlternativesPage(): string {
 
   // Build cards helper
   const buildCards = (items: ReturnType<typeof enrichOffers>) => items.map(o => {
-    const riskBadge = o.risk_level ? `<span style="display:inline-block;font-size:.7rem;padding:.15rem .5rem;border-radius:10px;background:${riskColors[o.risk_level]}22;color:${riskColors[o.risk_level]};font-weight:600;margin-left:.5rem">${o.risk_level}</span>` : "";
+    const riskBadge = riskBadgeHtml(o.risk_level, o.risk_cause);
     return `<div class="alt-card">
         <div class="alt-card-header">
           <a href="/vendor/${toSlug(o.vendor)}" class="alt-card-name">${escHtmlServer(o.vendor)}</a>
@@ -9694,7 +9766,7 @@ function buildCiCdAlternativesPage(): string {
 
   // Build cards helper
   const buildCards = (items: ReturnType<typeof enrichOffers>) => items.map(o => {
-    const riskBadge = o.risk_level ? `<span style="display:inline-block;font-size:.7rem;padding:.15rem .5rem;border-radius:10px;background:${riskColors[o.risk_level]}22;color:${riskColors[o.risk_level]};font-weight:600;margin-left:.5rem">${o.risk_level}</span>` : "";
+    const riskBadge = riskBadgeHtml(o.risk_level, o.risk_cause);
     return `<div class="alt-card">
         <div class="alt-card-header">
           <a href="/vendor/${toSlug(o.vendor)}" class="alt-card-name">${escHtmlServer(o.vendor)}</a>
@@ -10023,7 +10095,7 @@ function buildSecurityAlternativesPage(): string {
 
   // Build cards helper
   const buildCards = (items: ReturnType<typeof enrichOffers>) => items.map(o => {
-    const riskBadge = o.risk_level ? `<span style="display:inline-block;font-size:.7rem;padding:.15rem .5rem;border-radius:10px;background:${riskColors[o.risk_level]}22;color:${riskColors[o.risk_level]};font-weight:600;margin-left:.5rem">${o.risk_level}</span>` : "";
+    const riskBadge = riskBadgeHtml(o.risk_level, o.risk_cause);
     return `<div class="alt-card">
         <div class="alt-card-header">
           <a href="/vendor/${toSlug(o.vendor)}" class="alt-card-name">${escHtmlServer(o.vendor)}</a>
@@ -10365,7 +10437,7 @@ function buildTestingAlternativesPage(): string {
 
   // Build cards helper
   const buildCards = (items: ReturnType<typeof enrichOffers>) => items.map(o => {
-    const riskBadge = o.risk_level ? `<span style="display:inline-block;font-size:.7rem;padding:.15rem .5rem;border-radius:10px;background:${riskColors[o.risk_level]}22;color:${riskColors[o.risk_level]};font-weight:600;margin-left:.5rem">${o.risk_level}</span>` : "";
+    const riskBadge = riskBadgeHtml(o.risk_level, o.risk_cause);
     return `<div class="alt-card">
         <div class="alt-card-header">
           <a href="/vendor/${toSlug(o.vendor)}" class="alt-card-name">${escHtmlServer(o.vendor)}</a>
@@ -10691,7 +10763,7 @@ function buildStorageAlternativesPage(): string {
 
   // Build cards helper
   const buildCards = (items: ReturnType<typeof enrichOffers>) => items.map(o => {
-    const riskBadge = o.risk_level ? `<span style="display:inline-block;font-size:.7rem;padding:.15rem .5rem;border-radius:10px;background:${riskColors[o.risk_level]}22;color:${riskColors[o.risk_level]};font-weight:600;margin-left:.5rem">${o.risk_level}</span>` : "";
+    const riskBadge = riskBadgeHtml(o.risk_level, o.risk_cause);
     return `<div class="alt-card">
         <div class="alt-card-header">
           <a href="/vendor/${toSlug(o.vendor)}" class="alt-card-name">${escHtmlServer(o.vendor)}</a>
@@ -11008,7 +11080,7 @@ function buildAnalyticsAlternativesPage(): string {
 
   // Build cards helper
   const buildCards = (items: ReturnType<typeof enrichOffers>) => items.map(o => {
-    const riskBadge = o.risk_level ? `<span style="display:inline-block;font-size:.7rem;padding:.15rem .5rem;border-radius:10px;background:${riskColors[o.risk_level]}22;color:${riskColors[o.risk_level]};font-weight:600;margin-left:.5rem">${o.risk_level}</span>` : "";
+    const riskBadge = riskBadgeHtml(o.risk_level, o.risk_cause);
     return `<div class="alt-card">
         <div class="alt-card-header">
           <a href="/vendor/${toSlug(o.vendor)}" class="alt-card-name">${escHtmlServer(o.vendor)}</a>
@@ -11329,7 +11401,7 @@ function buildAiMlAlternativesPage(): string {
 
   // Build cards helper
   const buildCards = (items: ReturnType<typeof enrichOffers>) => items.map(o => {
-    const riskBadge = o.risk_level ? `<span style="display:inline-block;font-size:.7rem;padding:.15rem .5rem;border-radius:10px;background:${riskColors[o.risk_level]}22;color:${riskColors[o.risk_level]};font-weight:600;margin-left:.5rem">${o.risk_level}</span>` : "";
+    const riskBadge = riskBadgeHtml(o.risk_level, o.risk_cause);
     return `<div class="alt-card">
         <div class="alt-card-header">
           <a href="/vendor/${toSlug(o.vendor)}" class="alt-card-name">${escHtmlServer(o.vendor)}</a>
@@ -11656,7 +11728,7 @@ function buildEmailAlternativesPage(): string {
 
   // Build cards helper
   const buildCards = (items: ReturnType<typeof enrichOffers>) => items.map(o => {
-    const riskBadge = o.risk_level ? `<span style="display:inline-block;font-size:.7rem;padding:.15rem .5rem;border-radius:10px;background:${riskColors[o.risk_level]}22;color:${riskColors[o.risk_level]};font-weight:600;margin-left:.5rem">${o.risk_level}</span>` : "";
+    const riskBadge = riskBadgeHtml(o.risk_level, o.risk_cause);
     return `<div class="alt-card">
         <div class="alt-card-header">
           <a href="/vendor/${toSlug(o.vendor)}" class="alt-card-name">${escHtmlServer(o.vendor)}</a>
@@ -11994,7 +12066,7 @@ function buildDesignAlternativesPage(): string {
 
   // Build cards helper
   const buildCards = (items: ReturnType<typeof enrichOffers>) => items.map(o => {
-    const riskBadge = o.risk_level ? `<span style="display:inline-block;font-size:.7rem;padding:.15rem .5rem;border-radius:10px;background:${riskColors[o.risk_level]}22;color:${riskColors[o.risk_level]};font-weight:600;margin-left:.5rem">${o.risk_level}</span>` : "";
+    const riskBadge = riskBadgeHtml(o.risk_level, o.risk_cause);
     return `<div class="alt-card">
         <div class="alt-card-header">
           <a href="/vendor/${toSlug(o.vendor)}" class="alt-card-name">${escHtmlServer(o.vendor)}</a>
@@ -12336,7 +12408,7 @@ function buildProjectManagementAlternativesPage(): string {
 
   // Build cards helper
   const buildCards = (items: ReturnType<typeof enrichOffers>) => items.map(o => {
-    const riskBadge = o.risk_level ? `<span style="display:inline-block;font-size:.7rem;padding:.15rem .5rem;border-radius:10px;background:${riskColors[o.risk_level]}22;color:${riskColors[o.risk_level]};font-weight:600;margin-left:.5rem">${o.risk_level}</span>` : "";
+    const riskBadge = riskBadgeHtml(o.risk_level, o.risk_cause);
     return `<div class="alt-card">
         <div class="alt-card-header">
           <a href="/vendor/${toSlug(o.vendor)}" class="alt-card-name">${escHtmlServer(o.vendor)}</a>
@@ -12669,7 +12741,7 @@ function buildIdeCodeEditorsAlternativesPage(): string {
 
   // Build cards helper
   const buildCards = (items: ReturnType<typeof enrichOffers>) => items.map(o => {
-    const riskBadge = o.risk_level ? `<span style="display:inline-block;font-size:.7rem;padding:.15rem .5rem;border-radius:10px;background:${riskColors[o.risk_level]}22;color:${riskColors[o.risk_level]};font-weight:600;margin-left:.5rem">${o.risk_level}</span>` : "";
+    const riskBadge = riskBadgeHtml(o.risk_level, o.risk_cause);
     return `<div class="alt-card">
         <div class="alt-card-header">
           <a href="/vendor/${toSlug(o.vendor)}" class="alt-card-name">${escHtmlServer(o.vendor)}</a>
@@ -12983,7 +13055,7 @@ function buildFreeLlmApisPage(): string {
 
   // Build cards helper
   const buildCards = (items: ReturnType<typeof enrichOffers>) => items.map(o => {
-    const riskBadge = o.risk_level ? `<span style="display:inline-block;font-size:.7rem;padding:.15rem .5rem;border-radius:10px;background:${riskColors[o.risk_level]}22;color:${riskColors[o.risk_level]};font-weight:600;margin-left:.5rem">${o.risk_level}</span>` : "";
+    const riskBadge = riskBadgeHtml(o.risk_level, o.risk_cause);
     return `<div class="alt-card">
         <div class="alt-card-header">
           <a href="/vendor/${toSlug(o.vendor)}" class="alt-card-name">${escHtmlServer(o.vendor)}</a>
@@ -13310,7 +13382,7 @@ function buildApiDevelopmentAlternativesPage(): string {
 
   // Build cards helper
   const buildCards = (items: ReturnType<typeof enrichOffers>) => items.map(o => {
-    const riskBadge = o.risk_level ? `<span style="display:inline-block;font-size:.7rem;padding:.15rem .5rem;border-radius:10px;background:${riskColors[o.risk_level]}22;color:${riskColors[o.risk_level]};font-weight:600;margin-left:.5rem">${o.risk_level}</span>` : "";
+    const riskBadge = riskBadgeHtml(o.risk_level, o.risk_cause);
     return `<div class="alt-card">
         <div class="alt-card-header">
           <a href="/vendor/${toSlug(o.vendor)}" class="alt-card-name">${escHtmlServer(o.vendor)}</a>
@@ -13633,7 +13705,7 @@ function buildTeamCollaborationAlternativesPage(): string {
 
   // Build cards helper
   const buildCards = (items: ReturnType<typeof enrichOffers>) => items.map(o => {
-    const riskBadge = o.risk_level ? `<span style="display:inline-block;font-size:.7rem;padding:.15rem .5rem;border-radius:10px;background:${riskColors[o.risk_level]}22;color:${riskColors[o.risk_level]};font-weight:600;margin-left:.5rem">${o.risk_level}</span>` : "";
+    const riskBadge = riskBadgeHtml(o.risk_level, o.risk_cause);
     return `<div class="alt-card">
         <div class="alt-card-header">
           <a href="/vendor/${toSlug(o.vendor)}" class="alt-card-name">${escHtmlServer(o.vendor)}</a>
@@ -14050,7 +14122,7 @@ function buildFreeStartupStackPage(): string {
           <span class="pick-badge">Recommended</span>
           <a href="/vendor/${toSlug(rec.vendor)}" class="pick-name">${escHtmlServer(rec.vendor)}</a>
           <span class="pick-tier">${escHtmlServer(rec.tier)}</span>
-          ${rec.risk_level ? `<span style="display:inline-block;font-size:.65rem;padding:.1rem .4rem;border-radius:10px;background:${riskColors[rec.risk_level]}22;color:${riskColors[rec.risk_level]};font-weight:600">${rec.risk_level}</span>` : ""}
+          ${riskBadgeHtml(rec.risk_level, rec.risk_cause, { compact: true, margin: false })}
         </div>
         <p class="pick-why">${escHtmlServer(cat.recommended.why)}</p>
         <p class="pick-limits">${escHtmlServer(rec.description.split(". ").slice(0, 2).join(". "))}</p>
@@ -14105,7 +14177,7 @@ function buildFreeStartupStackPage(): string {
   const tableRows = stackCategories.map(cat => {
     const rec = resolveVendor(cat.recommended.vendor);
     const limits = rec ? rec.description.split(". ")[0].substring(0, 80) : "—";
-    const riskBadge = rec?.risk_level ? `<span style="color:${riskColors[rec.risk_level]}">${rec.risk_level}</span>` : `<span style="color:${riskColors.stable}">stable</span>`;
+    const riskBadge = rec ? riskCellHtml(rec.risk_level, rec.risk_cause) : riskCellHtml("stable", null);
     return `      <tr>
         <td style="font-weight:600">${cat.icon} ${escHtmlServer(cat.name)}</td>
         <td><a href="/vendor/${toSlug(cat.recommended.vendor)}" style="color:var(--text);font-weight:600">${escHtmlServer(cat.recommended.vendor)}</a></td>
@@ -14367,7 +14439,7 @@ function buildFreeAiStackPage(): string {
           <span class="pick-badge">Recommended</span>
           <a href="/vendor/${toSlug(rec.vendor)}" class="pick-name">${escHtmlServer(rec.vendor)}</a>
           <span class="pick-tier">${escHtmlServer(rec.tier)}</span>
-          ${rec.risk_level ? `<span style="display:inline-block;font-size:.65rem;padding:.1rem .4rem;border-radius:10px;background:${riskColors[rec.risk_level]}22;color:${riskColors[rec.risk_level]};font-weight:600">${rec.risk_level}</span>` : ""}
+          ${riskBadgeHtml(rec.risk_level, rec.risk_cause, { compact: true, margin: false })}
         </div>
         <p class="pick-why">${escHtmlServer(cat.recommended.why)}</p>
         <p class="pick-limits">${escHtmlServer(rec.description.split(". ").slice(0, 2).join(". "))}</p>
@@ -14420,7 +14492,7 @@ function buildFreeAiStackPage(): string {
   const tableRows = stackCategories.map(cat => {
     const rec = resolveVendor(cat.recommended.vendor);
     const limits = rec ? rec.description.split(". ")[0].substring(0, 80) : "—";
-    const riskBadge = rec?.risk_level ? `<span style="color:${riskColors[rec.risk_level]}">${rec.risk_level}</span>` : `<span style="color:${riskColors.stable}">stable</span>`;
+    const riskBadge = rec ? riskCellHtml(rec.risk_level, rec.risk_cause) : riskCellHtml("stable", null);
     return `      <tr>
         <td style="font-weight:600">${cat.icon} ${escHtmlServer(cat.name)}</td>
         <td><a href="/vendor/${toSlug(cat.recommended.vendor)}" style="color:var(--text);font-weight:600">${escHtmlServer(cat.recommended.vendor)}</a></td>
@@ -14720,7 +14792,7 @@ function buildFreeDevopsStackPage(): string {
           <span class="pick-badge">Recommended</span>
           <a href="/vendor/${toSlug(rec.vendor)}" class="pick-name">${escHtmlServer(rec.vendor)}</a>
           <span class="pick-tier">${escHtmlServer(rec.tier)}</span>
-          ${rec.risk_level ? `<span style="display:inline-block;font-size:.65rem;padding:.1rem .4rem;border-radius:10px;background:${riskColors[rec.risk_level]}22;color:${riskColors[rec.risk_level]};font-weight:600">${rec.risk_level}</span>` : ""}
+          ${riskBadgeHtml(rec.risk_level, rec.risk_cause, { compact: true, margin: false })}
         </div>
         <p class="pick-why">${escHtmlServer(cat.recommended.why)}</p>
         <p class="pick-limits">${escHtmlServer(rec.description.split(". ").slice(0, 2).join(". "))}</p>
@@ -14773,7 +14845,7 @@ function buildFreeDevopsStackPage(): string {
   const tableRows = stackCategories.map(cat => {
     const rec = resolveVendor(cat.recommended.vendor);
     const limits = rec ? rec.description.split(". ")[0].substring(0, 80) : "—";
-    const riskBadge = rec?.risk_level ? `<span style="color:${riskColors[rec.risk_level]}">${rec.risk_level}</span>` : `<span style="color:${riskColors.stable}">stable</span>`;
+    const riskBadge = rec ? riskCellHtml(rec.risk_level, rec.risk_cause) : riskCellHtml("stable", null);
     return `      <tr>
         <td style="font-weight:600">${cat.icon} ${escHtmlServer(cat.name)}</td>
         <td><a href="/vendor/${toSlug(cat.recommended.vendor)}" style="color:var(--text);font-weight:600">${escHtmlServer(cat.recommended.vendor)}</a></td>
@@ -15074,7 +15146,7 @@ function buildFreeFrontendStackPage(): string {
           <span class="pick-badge">Recommended</span>
           <a href="/vendor/${toSlug(rec.vendor)}" class="pick-name">${escHtmlServer(rec.vendor)}</a>
           <span class="pick-tier">${escHtmlServer(rec.tier)}</span>
-          ${rec.risk_level ? `<span style="display:inline-block;font-size:.65rem;padding:.1rem .4rem;border-radius:10px;background:${riskColors[rec.risk_level]}22;color:${riskColors[rec.risk_level]};font-weight:600">${rec.risk_level}</span>` : ""}
+          ${riskBadgeHtml(rec.risk_level, rec.risk_cause, { compact: true, margin: false })}
         </div>
         <p class="pick-why">${escHtmlServer(cat.recommended.why)}</p>
         <p class="pick-limits">${escHtmlServer(rec.description.split(". ").slice(0, 2).join(". "))}</p>
@@ -15127,7 +15199,7 @@ function buildFreeFrontendStackPage(): string {
   const tableRows = stackCategories.map(cat => {
     const rec = resolveVendor(cat.recommended.vendor);
     const limits = rec ? rec.description.split(". ")[0].substring(0, 80) : "—";
-    const riskBadge = rec?.risk_level ? `<span style="color:${riskColors[rec.risk_level]}">${rec.risk_level}</span>` : `<span style="color:${riskColors.stable}">stable</span>`;
+    const riskBadge = rec ? riskCellHtml(rec.risk_level, rec.risk_cause) : riskCellHtml("stable", null);
     return `      <tr>
         <td style="font-weight:600">${cat.icon} ${escHtmlServer(cat.name)}</td>
         <td><a href="/vendor/${toSlug(cat.recommended.vendor)}" style="color:var(--text);font-weight:600">${escHtmlServer(cat.recommended.vendor)}</a></td>
@@ -15464,7 +15536,7 @@ function buildFreeNextjsStackPage(): string {
           <span class="pick-badge">Recommended</span>
           <a href="/vendor/${toSlug(rec.vendor)}" class="pick-name">${escHtmlServer(rec.vendor)}</a>
           <span class="pick-tier">${escHtmlServer(rec.tier)}</span>
-          ${rec.risk_level ? `<span style="display:inline-block;font-size:.65rem;padding:.1rem .4rem;border-radius:10px;background:${riskColors[rec.risk_level]}22;color:${riskColors[rec.risk_level]};font-weight:600">${rec.risk_level}</span>` : ""}
+          ${riskBadgeHtml(rec.risk_level, rec.risk_cause, { compact: true, margin: false })}
         </div>
         <p class="pick-why">${escHtmlServer(cat.recommended.why)}</p>
         <p class="pick-limits">${escHtmlServer(rec.description.split(". ").slice(0, 2).join(". "))}</p>
@@ -15523,7 +15595,7 @@ function buildFreeNextjsStackPage(): string {
   const tableRows = stackCategories.map(cat => {
     const rec = resolveVendor(cat.recommended.vendor);
     const limits = rec ? rec.description.split(". ")[0].substring(0, 80) : "—";
-    const riskBadge = rec?.risk_level ? `<span style="color:${riskColors[rec.risk_level]}">${rec.risk_level}</span>` : `<span style="color:${riskColors.stable}">stable</span>`;
+    const riskBadge = rec ? riskCellHtml(rec.risk_level, rec.risk_cause) : riskCellHtml("stable", null);
     return `      <tr>
         <td style="font-weight:600">${cat.icon} ${escHtmlServer(cat.name)}</td>
         <td><a href="/vendor/${toSlug(cat.recommended.vendor)}" style="color:var(--text);font-weight:600">${escHtmlServer(cat.recommended.vendor)}</a></td>
@@ -15884,7 +15956,7 @@ function buildFreeDjangoStackPage(): string {
           <span class="pick-badge">Recommended</span>
           <a href="/vendor/${toSlug(rec.vendor)}" class="pick-name">${escHtmlServer(rec.vendor)}</a>
           <span class="pick-tier">${escHtmlServer(rec.tier)}</span>
-          ${rec.risk_level ? `<span style="display:inline-block;font-size:.65rem;padding:.1rem .4rem;border-radius:10px;background:${riskColors[rec.risk_level]}22;color:${riskColors[rec.risk_level]};font-weight:600">${rec.risk_level}</span>` : ""}
+          ${riskBadgeHtml(rec.risk_level, rec.risk_cause, { compact: true, margin: false })}
         </div>
         <p class="pick-why">${escHtmlServer(cat.recommended.why)}</p>
         <p class="pick-limits">${escHtmlServer(rec.description.split(". ").slice(0, 2).join(". "))}</p>
@@ -15962,7 +16034,7 @@ function buildFreeDjangoStackPage(): string {
     const rec = resolveVendor(cat.recommended.vendor);
     const vendorName = cat.recommended.vendor;
     const limits = rec ? rec.description.split(". ")[0].substring(0, 80) : vendorName === "Django Built-in Auth" ? "Unlimited — included in Django" : "—";
-    const riskBadge = rec?.risk_level ? `<span style="color:${riskColors[rec.risk_level]}">${rec.risk_level}</span>` : `<span style="color:${riskColors.stable}">stable</span>`;
+    const riskBadge = rec ? riskCellHtml(rec.risk_level, rec.risk_cause) : riskCellHtml("stable", null);
     const vendorLink = rec ? `<a href="/vendor/${toSlug(rec.vendor)}" style="color:var(--text);font-weight:600">${escHtmlServer(vendorName)}</a>` : `<span style="font-weight:600">${escHtmlServer(vendorName)}</span>`;
     return `      <tr>
         <td style="font-weight:600">${cat.icon} ${escHtmlServer(cat.name)}</td>
@@ -16343,7 +16415,7 @@ function buildFreeFastapiStackPage(): string {
           <span class="pick-badge">Recommended</span>
           <a href="/vendor/${toSlug(rec.vendor)}" class="pick-name">${escHtmlServer(rec.vendor)}</a>
           <span class="pick-tier">${escHtmlServer(rec.tier)}</span>
-          ${rec.risk_level ? `<span style="display:inline-block;font-size:.65rem;padding:.1rem .4rem;border-radius:10px;background:${riskColors[rec.risk_level]}22;color:${riskColors[rec.risk_level]};font-weight:600">${rec.risk_level}</span>` : ""}
+          ${riskBadgeHtml(rec.risk_level, rec.risk_cause, { compact: true, margin: false })}
         </div>
         <p class="pick-why">${escHtmlServer(cat.recommended.why)}</p>
         <p class="pick-limits">${escHtmlServer(rec.description.split(". ").slice(0, 2).join(". "))}</p>
@@ -16421,7 +16493,7 @@ function buildFreeFastapiStackPage(): string {
     const rec = resolveVendor(cat.recommended.vendor);
     const vendorName = cat.recommended.vendor;
     const limits = rec ? rec.description.split(". ")[0].substring(0, 80) : vendorName === "FastAPI Built-in" ? "Unlimited — built into FastAPI" : "—";
-    const riskBadge = rec?.risk_level ? `<span style="color:${riskColors[rec.risk_level]}">${rec.risk_level}</span>` : `<span style="color:${riskColors.stable}">stable</span>`;
+    const riskBadge = rec ? riskCellHtml(rec.risk_level, rec.risk_cause) : riskCellHtml("stable", null);
     const vendorLink = rec ? `<a href="/vendor/${toSlug(rec.vendor)}" style="color:var(--text);font-weight:600">${escHtmlServer(vendorName)}</a>` : `<span style="font-weight:600">${escHtmlServer(vendorName)}</span>`;
     return `      <tr>
         <td style="font-weight:600">${cat.icon} ${escHtmlServer(cat.name)}</td>
@@ -16819,7 +16891,7 @@ function buildFreeGoStackPage(): string {
           <span class="pick-badge">Recommended</span>
           <a href="/vendor/${toSlug(rec.vendor)}" class="pick-name">${escHtmlServer(rec.vendor)}</a>
           <span class="pick-tier">${escHtmlServer(rec.tier)}</span>
-          ${rec.risk_level ? `<span style="display:inline-block;font-size:.65rem;padding:.1rem .4rem;border-radius:10px;background:${riskColors[rec.risk_level]}22;color:${riskColors[rec.risk_level]};font-weight:600">${rec.risk_level}</span>` : ""}
+          ${riskBadgeHtml(rec.risk_level, rec.risk_cause, { compact: true, margin: false })}
         </div>
         <p class="pick-why">${escHtmlServer(cat.recommended.why)}</p>
         <p class="pick-limits">${escHtmlServer(rec.description.split(". ").slice(0, 2).join(". "))}</p>
@@ -16897,7 +16969,7 @@ function buildFreeGoStackPage(): string {
     const rec = resolveVendor(cat.recommended.vendor);
     const vendorName = cat.recommended.vendor;
     const limits = rec ? rec.description.split(". ")[0].substring(0, 80) : (vendorName === "Go Goroutines" ? "Unlimited — built into Go runtime" : vendorName === "swaggo/swag" ? "Open source — generates from comments" : "—");
-    const riskBadge = rec?.risk_level ? `<span style="color:${riskColors[rec.risk_level]}">${rec.risk_level}</span>` : `<span style="color:${riskColors.stable}">stable</span>`;
+    const riskBadge = rec ? riskCellHtml(rec.risk_level, rec.risk_cause) : riskCellHtml("stable", null);
     const vendorLink = rec ? `<a href="/vendor/${toSlug(rec.vendor)}" style="color:var(--text);font-weight:600">${escHtmlServer(vendorName)}</a>` : `<span style="font-weight:600">${escHtmlServer(vendorName)}</span>`;
     return `      <tr>
         <td style="font-weight:600">${cat.icon} ${escHtmlServer(cat.name)}</td>
@@ -17329,7 +17401,7 @@ function buildFreeSaasStackPage(): string {
           <span class="pick-badge">Recommended</span>
           <a href="/vendor/${toSlug(rec.vendor)}" class="pick-name">${escHtmlServer(rec.vendor)}</a>
           <span class="pick-tier">${escHtmlServer(rec.tier)}</span>
-          ${rec.risk_level ? `<span style="display:inline-block;font-size:.65rem;padding:.1rem .4rem;border-radius:10px;background:${riskColors[rec.risk_level]}22;color:${riskColors[rec.risk_level]};font-weight:600">${rec.risk_level}</span>` : ""}
+          ${riskBadgeHtml(rec.risk_level, rec.risk_cause, { compact: true, margin: false })}
         </div>
         <p class="pick-why">${escHtmlServer(cat.recommended.why)}</p>
         <p class="pick-limits">${escHtmlServer(rec.description.split(". ").slice(0, 2).join(". "))}</p>
@@ -17407,7 +17479,7 @@ function buildFreeSaasStackPage(): string {
     const rec = resolveVendor(cat.recommended.vendor);
     const vendorName = cat.recommended.vendor;
     const limits = rec ? rec.description.split(". ")[0].substring(0, 80) : (vendorName === "Stripe" ? "No monthly fee \u2014 2.9% + 30\u00a2/txn" : "\u2014");
-    const riskBadge = rec?.risk_level ? `<span style="color:${riskColors[rec.risk_level]}">${rec.risk_level}</span>` : `<span style="color:${riskColors.stable}">stable</span>`;
+    const riskBadge = rec ? riskCellHtml(rec.risk_level, rec.risk_cause) : riskCellHtml("stable", null);
     const vendorLink = rec ? `<a href="/vendor/${toSlug(rec.vendor)}" style="color:var(--text);font-weight:600">${escHtmlServer(vendorName)}</a>` : `<span style="font-weight:600">${escHtmlServer(vendorName)}</span>`;
     return `      <tr>
         <td style="font-weight:600">${cat.icon} ${escHtmlServer(cat.name)}</td>
@@ -26211,7 +26283,7 @@ function buildFreeTierTrackerPage(): string {
   const positiveTypes = ["limits_increased", "new_free_tier", "startup_program_expanded", "pricing_postponed"];
 
   // Separate negative and positive
-  const removedOrReduced = q1Changes.filter(c => ["free_tier_removed", "open_source_killed"].includes(c.change_type));
+  const removedOrReduced = q1Changes.filter(c => SEVERE_CHANGE_TYPES.has(c.change_type));
   const limitsReduced = q1Changes.filter(c => ["limits_reduced", "restriction"].includes(c.change_type));
   const restructured = q1Changes.filter(c => ["pricing_restructured", "pricing_model_change", "product_deprecated"].includes(c.change_type));
   const expanded = q1Changes.filter(c => positiveTypes.includes(c.change_type));
@@ -47042,25 +47114,28 @@ function buildStackCheckPage(): string {
   const totalChanges = allChanges.length;
 
   // Build vendor lookup for client-side enrichment
-  const vendorLookup: Record<string, { vendor: string; category: string; description: string; tier: string; slug: string; risk_level: string; stability: string; recent_changes: Array<{ date: string; change_type: string; summary: string; impact: string }> }> = {};
+  // #1038: this page carried its own third definition of risk — an inline
+  // type test over only the 3 most recent records, with no date window. It now
+  // reads the one definition, and ships the cause so the client can render it.
+  const vendorLookup: Record<string, { vendor: string; category: string; description: string; tier: string; slug: string; risk_level: string; risk_cause: RiskCause | null; stability: string; recent_changes: Array<{ date: string; change_type: string; summary: string; impact: string }> }> = {};
   for (const offer of allOffers) {
     const slug = toSlug(offer.vendor);
-    const vendorChanges = allChanges
+    const allVendorChanges = allChanges
       .filter(c => c.vendor.toLowerCase() === offer.vendor.toLowerCase())
-      .sort((a, b) => b.date.localeCompare(a.date))
-      .slice(0, 3);
+      .sort((a, b) => b.date.localeCompare(a.date));
+    const vendorChanges = allVendorChanges.slice(0, 3);
     const stability = stabilityMap.get(slug) || "stable";
-    const riskLevel = vendorChanges.length === 0 ? "stable"
-      : vendorChanges.some(c => ["free_tier_removed", "product_deprecated", "open_source_killed"].includes(c.change_type)) ? "risky"
-      : vendorChanges.some(c => ["limits_reduced", "restriction", "pricing_restructured", "pricing_model_change"].includes(c.change_type)) ? "caution"
-      : "stable";
+    const assessment = vendorRiskAssessment(allVendorChanges);
     vendorLookup[slug] = {
       vendor: offer.vendor,
       category: offer.category,
       description: offer.description,
       tier: offer.tier,
       slug,
-      risk_level: riskLevel,
+      risk_level: assessment.level,
+      risk_cause: assessment.cause
+        ? { date: assessment.cause.date, change_type: assessment.cause.change_type, summary: assessment.cause.summary }
+        : null,
       stability,
       recent_changes: vendorChanges.map(c => ({ date: c.date, change_type: c.change_type, summary: c.summary, impact: c.impact })),
     };
@@ -47415,9 +47490,13 @@ function buildStackCheckPage(): string {
           continue;
         }
         var rl = svc.risk_level || 'stable';
+        var rc = svc.risk_cause || null;
+        // #1038: a warning renders only with its dated cause.
+        if (rl !== 'stable' && !rc) rl = 'stable';
         var slug = toSlug(svc.vendor);
         cardsHtml += '<div class="service-card"><div class="card-header"><span class="card-vendor"><a href="/vendor/' + esc(slug) + '">' + esc(svc.vendor) + '</a></span>';
         cardsHtml += '<div style="display:flex;gap:.5rem;align-items:center"><span class="card-category">' + esc(svc.category) + '</span><span class="risk-badge ' + esc(rl) + '">' + esc(rl) + '</span></div></div>';
+        if (rl !== 'stable' && rc) cardsHtml += '<p class="card-risk-cause"><strong>Why ' + esc(rl) + ':</strong> ' + esc(rc.date) + ' &mdash; ' + esc(rc.summary) + '</p>';
         cardsHtml += '<p class="card-tier">' + esc(svc.tier) + '</p>';
 
         if (svc.recent_changes && svc.recent_changes.length > 0) {
@@ -47760,9 +47839,13 @@ ${globalNavCss()}
       });
   }
 
-  function riskBadge(level) {
+  function riskBadge(level, cause) {
+    // #1038: caution/risky render only with the dated record behind them.
+    if (level !== 'stable' && !cause) return '';
     var cls = level === 'stable' ? 'badge-stable' : level === 'caution' ? 'badge-caution' : 'badge-risky';
-    return '<span class="badge ' + cls + '">' + level + '</span>';
+    var badge = '<span class="badge ' + cls + '">' + level + '</span>';
+    if (level === 'stable') return badge;
+    return badge + ' <span class="risk-cause">' + escHtml(cause.date) + ' &mdash; ' + escHtml(cause.summary) + '</span>';
   }
 
   function changeTypeBadge(type) {
@@ -47773,10 +47856,11 @@ ${globalNavCss()}
   function renderVendorCard(v) {
     var slug = toSlug(v.vendor);
     var risk = v.risk_level || 'stable';
+    var riskCause = v.risk_cause || null;
     var changes = v.deal_changes || v.recent_changes || [];
     var html = '<div class="vendor-card">';
     html += '<h3><a href="/vendor/' + slug + '">' + escHtml(v.vendor) + '</a></h3>';
-    html += '<span class="badge badge-category">' + escHtml(v.category) + '</span> ' + riskBadge(risk);
+    html += '<span class="badge badge-category">' + escHtml(v.category) + '</span> ' + riskBadge(risk, riskCause);
     html += '<div class="vendor-desc">' + escHtml(v.description) + '</div>';
     html += '<div class="vendor-meta">Tier: ' + escHtml(v.tier) + ' &middot; Verified: ' + escHtml(v.verifiedDate || v.verified_date || '') + '</div>';
     html += '<div class="vendor-links">';
@@ -47832,13 +47916,14 @@ ${globalNavCss()}
       description: data.description,
       tier: data.tier,
       risk_level: data.risk_level,
+      risk_cause: data.risk_cause,
       verifiedDate: data.verified_date,
       deal_changes: data.recent_changes || []
     });
     if (data.safer_alternatives && data.safer_alternatives.length > 0) {
       html += '<div style="margin-top:1rem;font-size:.85rem;color:var(--text-muted)"><strong>Alternatives:</strong> ';
       html += data.safer_alternatives.map(function(alt) {
-        return '<a href="/vendor/' + toSlug(alt.vendor) + '">' + escHtml(alt.vendor) + '</a> (' + alt.risk_level + ')';
+        return '<a href="/vendor/' + toSlug(alt.vendor) + '">' + escHtml(alt.vendor) + '</a>' + (alt.risk_level === 'stable' || alt.risk_cause ? ' (' + escHtml(alt.risk_level) + ')' : '');
       }).join(', ');
       html += '</div>';
     }
@@ -48192,15 +48277,18 @@ function buildBudgetBuilderPage(): string {
   const totalChanges = allChanges.length;
 
   // Build per-category vendor data with risk levels for client-side recommendation engine
-  const categoryVendors: Record<string, Array<{ slug: string; name: string; free: string; starter: number; growth: number; scale: number; notes: string; risk_level: string; recent_changes: number }>> = {};
+  // #1038: a fourth definition of risk lived here — its own inline type test,
+  // no date window, on a high/medium/low scale of its own — and unlike the
+  // others it *ranks*: `riskPenalty` below moves a vendor down the client-side
+  // recommender. It reads the one definition now, and the card publishes the
+  // dated cause, so nothing here demotes a vendor for a reason we won't show.
+  const categoryVendors: Record<string, Array<{ slug: string; name: string; free: string; starter: number; growth: number; scale: number; notes: string; risk_level: string; risk_cause: RiskCause | null }>> = {};
   for (const cat of estimatorData) {
     categoryVendors[cat.id] = cat.vendors.map(v => {
       const vendorChanges = allChanges.filter(c => toSlug(c.vendor) === v.slug || c.vendor.toLowerCase() === v.name.toLowerCase());
-      const stability = stabilityMap.get(v.slug) || "stable";
-      const riskLevel = vendorChanges.some(c => ["free_tier_removed", "product_deprecated", "open_source_killed"].includes(c.change_type)) ? "high"
-        : vendorChanges.some(c => ["limits_reduced", "restriction", "pricing_restructured", "pricing_model_change"].includes(c.change_type)) ? "medium"
-        : "low";
-      return { slug: v.slug, name: v.name, free: v.free, starter: v.starter, growth: v.growth, scale: v.scale, notes: v.notes, risk_level: riskLevel, recent_changes: vendorChanges.length };
+      const assessment = vendorRiskAssessment(vendorChanges);
+      return { slug: v.slug, name: v.name, free: v.free, starter: v.starter, growth: v.growth, scale: v.scale, notes: v.notes, risk_level: assessment.level,
+        risk_cause: assessment.cause ? { date: assessment.cause.date, change_type: assessment.cause.change_type, summary: assessment.cause.summary } : null };
     });
   }
 
@@ -48487,7 +48575,7 @@ function buildBudgetBuilderPage(): string {
     + '      // For $0 budget, only consider free tiers\n'
     + '      cost = 0;\n'
     + '    }\n'
-    + '    var riskPenalty = v.risk_level === "high" ? 100 : v.risk_level === "medium" ? 30 : 0;\n'
+    + '    var riskPenalty = v.risk_cause ? (v.risk_level === "risky" ? 100 : v.risk_level === "caution" ? 30 : 0) : 0;\n'
     + '    var score = cost + riskPenalty - (v.free !== "" && cost === 0 ? 50 : 0); // bonus for free tier\n'
     + '    return { vendor: v, cost: cost, score: score };\n'
     + '  });\n'
@@ -48500,7 +48588,7 @@ function buildBudgetBuilderPage(): string {
     + '  var results = document.getElementById("results");\n'
     + '  results.style.display = "block";\n'
     + '  var totalCost = 0;\n'
-    + '  var riskCounts = { low: 0, medium: 0, high: 0 };\n'
+    + '  var riskCounts = { stable: 0, caution: 0, risky: 0 };\n'
     + '  var stackHtml = "";\n'
     + '  var catKeys = Array.from(selectedCategories);\n'
     + '  var paidEquivalent = 0; // Estimate what these services would cost at paid tier\n'
@@ -48510,7 +48598,7 @@ function buildBudgetBuilderPage(): string {
     + '    if (!rec) return;\n'
     + '    var cost = selectedBudget === 0 ? 0 : rec.starter;\n'
     + '    totalCost += cost;\n'
-    + '    riskCounts[rec.risk_level]++;\n'
+    + '    if (riskCounts[rec.risk_level] !== undefined) riskCounts[rec.risk_level]++;\n'
     + '    paidEquivalent += rec.growth > 0 ? rec.growth : rec.starter > 0 ? rec.starter : 25; // estimate paid value\n'
     + '\n'
     + '    // Get alternatives (next 2 vendors)\n'
@@ -48522,7 +48610,8 @@ function buildBudgetBuilderPage(): string {
     + '    stackHtml += \'<span class="stack-card-category">\' + (CATEGORY_LABELS[catId] || catId) + \'</span>\';\n'
     + '    stackHtml += \'<span class="stack-card-cost">\' + (cost === 0 ? "FREE" : "$" + cost + "/mo") + \'</span>\';\n'
     + '    stackHtml += \'</div>\';\n'
-    + '    stackHtml += \'<div class="stack-card-vendor"><a href="/vendor/\' + rec.slug + \'">\' + rec.name + \'</a> <span class="risk-badge \' + rec.risk_level + \'">\' + rec.risk_level + \' risk</span></div>\';\n'
+    + '    stackHtml += \'<div class="stack-card-vendor"><a href="/vendor/\' + rec.slug + \'">\' + rec.name + \'</a>\' + (rec.risk_cause ? \' <span class="risk-badge \' + rec.risk_level + \'">\' + rec.risk_level + \'</span>\' : "") + \'</div>\';\n'
+    + '    if (rec.risk_cause) stackHtml += \'<div class="stack-card-risk-cause">Why \' + rec.risk_level + \': \' + rec.risk_cause.date + \' — \' + rec.risk_cause.summary + \'</div>\';\n'
     + '    stackHtml += \'<div class="stack-card-free">\' + rec.free + \'</div>\';\n'
     + '    if (rec.notes) stackHtml += \'<div style="color:var(--text-dim);font-size:.8rem">\' + rec.notes + \'</div>\';\n'
     + '\n'
@@ -48532,7 +48621,7 @@ function buildBudgetBuilderPage(): string {
     + '      alts.forEach(function(alt) {\n'
     + '        var altCost = selectedBudget === 0 ? 0 : alt.starter;\n'
     + '        stackHtml += \'<div class="alt-row"><a href="/vendor/\' + alt.slug + \'">\' + alt.name + \'</a>\';\n'
-    + '        stackHtml += \'<span>\' + (altCost === 0 ? "FREE" : "$" + altCost + "/mo") + \' · <span class="risk-badge \' + alt.risk_level + \'">\' + alt.risk_level + \'</span></span></div>\';\n'
+    + '        stackHtml += \'<span>\' + (altCost === 0 ? "FREE" : "$" + altCost + "/mo") + (alt.risk_cause ? \' · <span class="risk-badge \' + alt.risk_level + \'" title="\' + alt.risk_cause.date + \': \' + alt.risk_cause.summary + \'">\' + alt.risk_level + \'</span>\' : "") + \'</span></div>\';\n'
     + '      });\n'
     + '      stackHtml += \'</div>\';\n'
     + '    }\n'
@@ -48576,15 +48665,15 @@ function buildBudgetBuilderPage(): string {
     + '  }\n'
     + '\n'
     + '  // Risk summary\n'
-    + '  var total = riskCounts.low + riskCounts.medium + riskCounts.high;\n'
+    + '  var total = riskCounts.stable + riskCounts.caution + riskCounts.risky;\n'
     + '  var riskHtml = \'<h3>Stack Risk Assessment</h3>\';\n'
     + '  riskHtml += \'<div class="risk-meter">\';\n'
-    + '  for (var i = 0; i < riskCounts.low; i++) riskHtml += \'<div class="risk-meter-segment" style="background:var(--green)"></div>\';\n'
-    + '  for (var j = 0; j < riskCounts.medium; j++) riskHtml += \'<div class="risk-meter-segment" style="background:var(--yellow)"></div>\';\n'
-    + '  for (var k = 0; k < riskCounts.high; k++) riskHtml += \'<div class="risk-meter-segment" style="background:var(--red)"></div>\';\n'
+    + '  for (var i = 0; i < riskCounts.stable; i++) riskHtml += \'<div class="risk-meter-segment" style="background:var(--green)"></div>\';\n'
+    + '  for (var j = 0; j < riskCounts.caution; j++) riskHtml += \'<div class="risk-meter-segment" style="background:var(--yellow)"></div>\';\n'
+    + '  for (var k = 0; k < riskCounts.risky; k++) riskHtml += \'<div class="risk-meter-segment" style="background:var(--red)"></div>\';\n'
     + '  riskHtml += \'</div>\';\n'
-    + '  riskHtml += \'<p style="color:var(--text-muted);font-size:.85rem;margin-top:.5rem">\' + riskCounts.low + \' low risk, \' + riskCounts.medium + \' medium risk, \' + riskCounts.high + \' high risk</p>\';\n'
-    + '  if (riskCounts.high > 0) riskHtml += \'<p style="color:var(--red);font-size:.85rem;margin-top:.25rem">&#x26a0; \' + riskCounts.high + \' service(s) have recently restricted or removed their free tier. Consider alternatives.</p>\';\n'
+    + '  riskHtml += \'<p style="color:var(--text-muted);font-size:.85rem;margin-top:.5rem">\' + riskCounts.stable + \' stable, \' + riskCounts.caution + \' caution, \' + riskCounts.risky + \' risky</p>\';\n'
+    + '  if (riskCounts.risky > 0) riskHtml += \'<p style="color:var(--red);font-size:.85rem;margin-top:.25rem">&#x26a0; \' + riskCounts.risky + \' service(s) have removed a free tier or changed an open-source licence in the last 12 months. Consider alternatives.</p>\';\n'
     + '  document.getElementById("risk-summary").innerHTML = riskHtml;\n'
     + '\n'
     + '  // Shareable URL\n'
@@ -52083,12 +52172,11 @@ function buildSearchPage(query: string, categoryFilter: string, typeFilter: stri
 
   // Results HTML
   const resultsHtml = results.map((r, idx) => {
-    const risk = r.risk_level ?? "stable";
-    const rc = riskColors[risk] ?? "#8b949e";
+
     let card = '<a href="/vendor/' + toSlug(r.vendor) + '" class="result-card">'
       + '<div class="result-header">'
       + '<span class="result-vendor">' + escHtmlServer(r.vendor) + '</span>'
-      + '<span class="risk-badge-sm" style="background:' + rc + '20;color:' + rc + ';border:1px solid ' + rc + '40">' + risk + '</span>'
+      + riskBadgeHtml(r.risk_level, r.risk_cause, { compact: true, margin: false })
       + '<span class="result-cat">' + escHtmlServer(r.category) + '</span>'
       + '</div>'
       + '<div class="result-tier">' + escHtmlServer(r.tier) + '</div>'
@@ -52410,7 +52498,7 @@ function buildTrendsPage(slug: string): string | null {
   }
 
   // At-risk vendors (risky or caution)
-  const atRisk = enriched.filter(o => o.risk_level === "risky" || o.risk_level === "caution")
+  const atRisk = enriched.filter(o => (o.risk_level === "risky" || o.risk_level === "caution") && o.risk_cause)
     .sort((a, b) => (a.risk_level === "risky" ? 0 : 1) - (b.risk_level === "risky" ? 0 : 1));
 
   // Stable picks (stable risk, no recent changes)
@@ -52451,11 +52539,9 @@ function buildTrendsPage(slug: string): string | null {
     <h2>At-Risk Vendors</h2>
     <div class="vendor-list">
 ${atRisk.map(o => {
-    const rc = riskColors[o.risk_level ?? ""] ?? "#8b949e";
     return `      <a href="/vendor/${toSlug(o.vendor)}" class="vendor-item">
         <span class="vi-name">${escHtmlServer(o.vendor)}</span>
-        <span class="vi-risk" style="color:${rc}">${o.risk_level}</span>
-        ${o.recent_change ? `<span class="vi-change">${escHtmlServer(o.recent_change)}</span>` : ""}
+        <span class="vi-risk">${riskBadgeHtml(o.risk_level, o.risk_cause, { compact: true, margin: false })}</span>
       </a>`;
   }).join("\n")}
     </div>
@@ -52895,7 +52981,7 @@ ${globalNavCss()}
 
   <div style="text-align:center;margin:-1.5rem auto 2.5rem;max-width:640px">
     <a href="/state-of-free-tiers" style="display:inline-flex;align-items:center;gap:.5rem;padding:.6rem 1.25rem;border:1px solid var(--border);border-radius:8px;background:var(--bg-card);color:var(--text-muted);font-size:.85rem;text-decoration:none;transition:all .2s">
-      <span style="color:#f85149;font-weight:600">${dealChanges.filter(c => ["free_tier_removed","limits_reduced","restriction","open_source_killed","product_deprecated"].includes(c.change_type)).length} negative</span> vs <span style="color:#3fb950;font-weight:600">${dealChanges.filter(c => ["new_free_tier","limits_increased","startup_program_expanded"].includes(c.change_type)).length} positive</span> changes &mdash; <span style="color:var(--accent)">Read the State of Free Tiers Report &rarr;</span>
+      <span style="color:#f85149;font-weight:600">${dealChanges.filter(c => NEGATIVE_CHANGE_TYPES.has(c.change_type)).length} negative</span> vs <span style="color:#3fb950;font-weight:600">${dealChanges.filter(c => POSITIVE_CHANGE_TYPES.has(c.change_type)).length} positive</span> changes &mdash; <span style="color:var(--accent)">Read the State of Free Tiers Report &rarr;</span>
     </a>
   </div>
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -36,7 +36,9 @@ function toConciseOffer(offer: Offer | EnrichedOffer) {
   const base = { vendor: offer.vendor, tier: offer.tier, description: offer.description, url: offer.url, ...(offer.payment_protocols?.length ? { payment_protocols: offer.payment_protocols.map(p => p.protocol) } : {}) };
   const enriched = offer as Partial<EnrichedOffer>;
   if (enriched.risk_level !== undefined) {
-    return { ...base, risk_level: enriched.risk_level, stability: enriched.stability };
+    // risk_cause travels with risk_level everywhere (#1038) — a client that
+    // renders the level has to be able to render the reason for it.
+    return { ...base, risk_level: enriched.risk_level, risk_cause: enriched.risk_cause ?? null, stability: enriched.stability };
   }
   return base;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -53,10 +53,27 @@ export interface Offer {
 
 export type StabilityClass = "stable" | "watch" | "volatile" | "improving";
 
+export type RiskLevel = "stable" | "caution" | "risky";
+
+/**
+ * The one recorded fact that produced a non-stable risk level (#1038).
+ *
+ * A warning a reader cannot check is an assertion, so `caution` and `risky`
+ * travel with the dated record that earned them and every surface that shows
+ * the level shows the cause beside it.
+ */
+export interface RiskCause {
+  date: string;
+  change_type: string;
+  summary: string;
+}
+
 export interface EnrichedOffer extends Offer {
   recent_change: string | null;
   expires_soon: string | null;
-  risk_level: "stable" | "caution" | "risky" | null;
+  risk_level: RiskLevel | null;
+  /** Never null when `risk_level` is `caution` or `risky`. */
+  risk_cause: RiskCause | null;
   stability: StabilityClass;
   days_since_verified: number;
 }
@@ -67,7 +84,7 @@ export interface OfferIndex {
 
 export interface DealChange {
   vendor: string;
-  change_type: "free_tier_removed" | "limits_reduced" | "restriction" | "limits_increased" | "new_free_tier" | "new_tier" | "pricing_restructured" | "open_source_killed" | "pricing_model_change" | "startup_program_expanded" | "pricing_postponed" | "product_deprecated";
+  change_type: "free_tier_removed" | "limits_reduced" | "restriction" | "limits_increased" | "new_free_tier" | "new_tier" | "pricing_restructured" | "open_source_killed" | "pricing_model_change" | "startup_program_expanded" | "pricing_postponed" | "product_deprecated" | "rebranded";
   date: string;
   summary: string;
   previous_state: string;

--- a/test/enrich.test.ts
+++ b/test/enrich.test.ts
@@ -52,50 +52,70 @@ describe("enrichOffers", () => {
     assert.strictEqual(enriched[0].recent_change, null);
   });
 
-  it("returns caution for vendor with exactly 1 deal change", async () => {
+  // #1038: these two tests used to assert the count-based rule directly — "1
+  // change = caution, 2+ = risky". That rule is the defect: it counted records
+  // we happened to have written, so `limits_increased` demoted a vendor and a
+  // vendor we had never examined rendered stable. What replaces them asserts
+  // the property the rule is supposed to have.
+  it("counts nothing — the number of records a vendor has cannot move its risk level", async () => {
     const { enrichOffers, loadOffers, loadDealChanges } = await import("../dist/data.js");
     const changes = loadDealChanges();
     const offers = loadOffers();
 
-    // Count changes per vendor
     const counts = new Map<string, number>();
     for (const c of changes) {
       const key = c.vendor.toLowerCase();
       counts.set(key, (counts.get(key) ?? 0) + 1);
     }
 
-    // Find vendor with exactly 1 change
-    const singleChangeVendor = [...counts.entries()].find(([, count]) => count === 1);
-    if (!singleChangeVendor) return; // Skip if no such vendor
+    // A vendor with several records, none of them demoting, must stay stable.
+    const FAVOURABLE = new Set(["limits_increased", "new_free_tier", "new_tier", "startup_program_expanded", "pricing_postponed", "rebranded"]);
+    const byVendor = new Map<string, { change_type: string }[]>();
+    for (const c of changes) {
+      const key = c.vendor.toLowerCase();
+      if (!byVendor.has(key)) byVendor.set(key, []);
+      byVendor.get(key)!.push(c);
+    }
 
-    const offer = offers.find((o: { vendor: string }) => o.vendor.toLowerCase() === singleChangeVendor[0]);
-    if (!offer) return;
-
-    const enriched = enrichOffers([offer]);
-    assert.strictEqual(enriched[0].risk_level, "caution");
+    let checked = 0;
+    for (const [vendor, vendorChanges] of byVendor) {
+      if (!vendorChanges.every((c) => FAVOURABLE.has(c.change_type))) continue;
+      const offer = offers.find((o: { vendor: string }) => o.vendor.toLowerCase() === vendor);
+      if (!offer) continue;
+      const enriched = enrichOffers([offer])[0];
+      assert.strictEqual(
+        enriched.risk_level,
+        "stable",
+        `${offer.vendor} has ${vendorChanges.length} record(s), all favourable or neutral (${vendorChanges.map((c) => c.change_type).join(", ")}), and must not be warned`,
+      );
+      assert.strictEqual(enriched.risk_cause, null);
+      checked++;
+    }
+    assert.ok(checked > 0, "expected at least one vendor whose whole history is favourable");
   });
 
-  it("returns risky for vendor with 2+ deal changes", async () => {
-    const { enrichOffers, loadOffers, loadDealChanges } = await import("../dist/data.js");
-    const changes = loadDealChanges();
-    const offers = loadOffers();
+  it("a vendor whose only record is limits_increased renders stable", async () => {
+    const { enrichOffers } = await import("../dist/data.js");
+    const offer = {
+      vendor: "Testing Vendor 1038", category: "Databases", tier: "Free", description: "d",
+      url: "https://example.com", verifiedDate: "2026-08-01", tags: [],
+    };
+    // enrichOffers reads the live change file, so assert through the function
+    // that decides, with the record the issue is named for.
+    const { vendorRiskAssessment } = await import("../dist/data.js");
+    const assessment = vendorRiskAssessment([
+      { vendor: "Testing Vendor 1038", change_type: "limits_increased", date: "2026-08-01", summary: "Free tier expanded", previous_state: "", current_state: "", impact: "high", source_url: "", category: "Databases", alternatives: [] },
+    ]);
+    assert.strictEqual(assessment.level, "stable");
+    assert.strictEqual(assessment.cause, null);
+    assert.strictEqual(enrichOffers([offer])[0].risk_level, "stable");
+  });
 
-    // Count changes per vendor
-    const counts = new Map<string, number>();
-    for (const c of changes) {
-      const key = c.vendor.toLowerCase();
-      counts.set(key, (counts.get(key) ?? 0) + 1);
-    }
-
-    // Find vendor with 2+ changes
-    const multiChangeVendor = [...counts.entries()].find(([, count]) => count >= 2);
-    if (!multiChangeVendor) return; // Skip if no such vendor
-
-    const offer = offers.find((o: { vendor: string }) => o.vendor.toLowerCase() === multiChangeVendor[0]);
-    if (!offer) return;
-
-    const enriched = enrichOffers([offer]);
-    assert.strictEqual(enriched[0].risk_level, "risky");
+  it("never publishes a risk level it cannot name a cause for", async () => {
+    const { enrichOffers, loadOffers } = await import("../dist/data.js");
+    const enriched = enrichOffers(loadOffers());
+    const uncaused = enriched.filter((o: { risk_level: string | null; risk_cause: unknown }) => o.risk_level !== "stable" && !o.risk_cause);
+    assert.strictEqual(uncaused.length, 0, `${uncaused.length} offers carry a warning with no cause`);
   });
 
   it("preserves original offer fields in enriched result", async () => {

--- a/test/risk-badge.test.ts
+++ b/test/risk-badge.test.ts
@@ -1,0 +1,274 @@
+// #1038: the risk badge in every vendor page's <h1> counted our own change
+// records, all-time, of any type. Railway rendered `caution` for expanding its
+// free tier; DigitalOcean rendered `risky` above a recorded 20% price cut.
+//
+// Two properties are under test here, and they are different properties:
+//
+//   1. The level is earned. Nothing neutral or favourable to the user can
+//      raise it, and the number of records we happen to hold cannot move it.
+//   2. The level is checkable. `caution` and `risky` are negative factual
+//      claims about a named company, so every surface that publishes one also
+//      publishes the dated record behind it — or publishes nothing.
+//
+// The second is the one that generalises, and it is the one that needs an
+// end-to-end test: the computation can be right while a page still renders a
+// warning a reader cannot check.
+
+import { describe, it, before, after } from "node:test";
+import assert from "node:assert";
+import { spawn, type ChildProcess } from "node:child_process";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO = path.join(__dirname, "..");
+
+let serverPort = 0;
+let proc: ChildProcess | null = null;
+
+function startHttpServer(): Promise<ChildProcess> {
+  return new Promise((resolve, reject) => {
+    const child = spawn("node", [path.join(REPO, "dist", "serve.js")], {
+      stdio: ["pipe", "pipe", "pipe"],
+      env: { ...process.env, PORT: "0", BASE_URL: "http://localhost" },
+    });
+    const timeout = setTimeout(() => { child.kill(); reject(new Error("Server startup timeout")); }, 15000);
+    child.stderr!.on("data", (data: Buffer) => {
+      const m = data.toString().match(/running on http:\/\/localhost:(\d+)/);
+      if (m) { serverPort = parseInt(m[1], 10); clearTimeout(timeout); resolve(child); }
+    });
+    child.on("error", (err) => { clearTimeout(timeout); reject(err); });
+  });
+}
+
+const get = async (p: string) => {
+  const res = await fetch(`http://localhost:${serverPort}${p}`);
+  return { status: res.status, text: await res.text() };
+};
+
+before(async () => { proc = await startHttpServer(); });
+after(() => { if (proc) proc.kill(); });
+
+const toSlug = (v: string) => v.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-|-$/g, "");
+
+type Change = { vendor: string; change_type: string; date: string; summary: string };
+
+function changesByVendor(changes: Change[]): Map<string, Change[]> {
+  const m = new Map<string, Change[]>();
+  for (const c of changes) {
+    const k = c.vendor.toLowerCase();
+    if (!m.has(k)) m.set(k, []);
+    m.get(k)!.push(c);
+  }
+  return m;
+}
+
+describe("#1038 — the level is earned", () => {
+  it("the demotion table names every change type present in the data", async () => {
+    const { RISK_DEMOTION, loadDealChanges } = await import("../dist/data.js");
+    const present = new Set(loadDealChanges().map((c: Change) => c.change_type));
+    const missing = [...present].filter((t) => !(t in RISK_DEMOTION));
+    assert.deepStrictEqual(
+      missing,
+      [],
+      `data/deal_changes.json holds change types the risk table has no entry for: ${missing.join(", ")}. ` +
+      `A type left out of the table demotes nothing by accident rather than by decision — add it explicitly, either way.`,
+    );
+  });
+
+  it("no neutral or favourable change type can raise a risk level", async () => {
+    const { vendorRiskAssessment } = await import("../dist/data.js");
+    // The six the issue names, plus the whole table read back — a type that
+    // moves from null to a demotion has to be a deliberate edit here too.
+    const favourable = ["limits_increased", "new_free_tier", "new_tier", "startup_program_expanded", "pricing_postponed", "rebranded"];
+    for (const change_type of favourable) {
+      const assessment = vendorRiskAssessment([
+        { vendor: "V", change_type, date: "2026-08-01", summary: "s", previous_state: "", current_state: "", impact: "high", source_url: "", category: "c", alternatives: [] },
+      ]);
+      assert.strictEqual(assessment.level, "stable", `${change_type} must not demote`);
+      assert.strictEqual(assessment.cause, null);
+    }
+  });
+
+  it("a vendor whose only history is limits_increased renders stable, live", async () => {
+    // Railway is the issue's headline example: `caution` in its <h1> because
+    // it expanded its free tier after a $100M Series B.
+    const { loadDealChanges } = await import("../dist/data.js");
+    const railway = changesByVendor(loadDealChanges()).get("railway") ?? [];
+    assert.ok(railway.length > 0, "expected Railway to still hold change records");
+    assert.ok(
+      railway.every((c) => c.change_type === "limits_increased"),
+      "this test is anchored on Railway holding only limits_increased; its records have changed, re-anchor it",
+    );
+    const { text } = await get("/vendor/railway");
+    const h1 = text.match(/<h1>[\s\S]*?<\/h1>/)?.[0] ?? "";
+    assert.ok(h1.length > 0, "no <h1> on /vendor/railway");
+    assert.ok(!/caution|risky/.test(h1), `Railway's <h1> still carries a warning: ${h1}`);
+  });
+
+  it("the count of records we hold does not move the level", async () => {
+    const { vendorRiskAssessment } = await import("../dist/data.js");
+    const rec = (change_type: string, date: string) => ({
+      vendor: "V", change_type, date, summary: "s", previous_state: "", current_state: "", impact: "low" as const, source_url: "", category: "c", alternatives: [],
+    });
+    // Ten favourable records is still stable; one demoting record is not.
+    const many = Array.from({ length: 10 }, (_, i) => rec("limits_increased", `2026-0${(i % 9) + 1}-01`));
+    assert.strictEqual(vendorRiskAssessment(many).level, "stable");
+    assert.strictEqual(vendorRiskAssessment([...many, rec("limits_reduced", "2026-08-01")]).level, "caution");
+  });
+
+  it("a severe change ages into caution, never into stable", async () => {
+    const { vendorRiskAssessment } = await import("../dist/data.js");
+    const nowMs = Date.parse("2026-08-25T00:00:00Z");
+    const removed = (date: string) => ({
+      vendor: "V", change_type: "free_tier_removed", date, summary: "s", previous_state: "", current_state: "", impact: "high" as const, source_url: "", category: "c", alternatives: [],
+    });
+    assert.strictEqual(vendorRiskAssessment([removed("2026-06-01")], nowMs).level, "risky");
+    // 15 months old — SendGrid's case. `stable` would be a false statement we
+    // made ourselves: we hold a record of the free tier being removed.
+    assert.strictEqual(vendorRiskAssessment([removed("2025-05-27")], nowMs).level, "caution");
+  });
+
+  it("nothing the risk scale demotes is called positive or neutral by the direction table", async () => {
+    // The two tables answer different questions — direction is what we call a
+    // change, risk is what we publish a warning for — but they may not
+    // contradict each other. Before #1038 five drifted copies of the direction
+    // idea existed and they did.
+    const { RISK_DEMOTION, CHANGE_DIRECTION } = await import("../dist/data.js");
+    for (const [type, demotion] of Object.entries(RISK_DEMOTION)) {
+      if (!demotion) continue;
+      assert.strictEqual(
+        CHANGE_DIRECTION[type as keyof typeof CHANGE_DIRECTION],
+        "negative",
+        `${type} demotes to ${demotion} but the direction table does not call it negative`,
+      );
+    }
+    // And the direction table is exhaustive over the risk table's keys.
+    for (const type of Object.keys(RISK_DEMOTION)) {
+      assert.ok(type in CHANGE_DIRECTION, `${type} has no direction`);
+    }
+  });
+
+  it("there is one definition of risk in src/, not four", () => {
+    // Before this issue there were four: enrichOffers counted records,
+    // vendorRiskLevel read types, and serve.ts carried two more inline — one on
+    // the stack checker and one that *ranked* on the cost estimator.
+    const sources = ["src/data.ts", "src/serve.ts", "src/stacks.ts", "src/mcp-apps.ts"]
+      .map((f) => ({ f, src: readFileSync(path.join(REPO, f), "utf8") }));
+    for (const { f, src } of sources) {
+      const executable = src.split("\n").filter((l) => !/^\s*(\*|\/\/|\/\*|\*\/)/.test(l)).join("\n");
+      // The signature of a hand-rolled definition: a literal list of change
+      // types tested inline to produce a level.
+      const inline = executable.match(/\[\s*"free_tier_removed"[^\]]*\]\s*\.includes\(/g) ?? [];
+      assert.deepStrictEqual(inline, [], `${f} classifies change types inline; risk has one definition and it is vendorRiskAssessment`);
+    }
+  });
+});
+
+describe("#1038 — the level is checkable", () => {
+  it("every offer carrying a warning carries the record that produced it", async () => {
+    const { enrichOffers, loadOffers } = await import("../dist/data.js");
+    const uncaused = enrichOffers(loadOffers())
+      .filter((o: { risk_level: string | null; risk_cause: unknown }) => o.risk_level !== "stable" && !o.risk_cause);
+    assert.strictEqual(uncaused.length, 0);
+  });
+
+  it("the vendor page publishes the dated cause beside the badge in the <h1>", async () => {
+    const { enrichOffers, loadOffers } = await import("../dist/data.js");
+    const warned = enrichOffers(loadOffers())
+      .filter((o: { risk_level: string | null }) => o.risk_level !== "stable")
+      .slice(0, 6);
+    assert.ok(warned.length > 0, "expected at least one warned vendor to test");
+
+    for (const offer of warned) {
+      const { text } = await get(`/vendor/${toSlug(offer.vendor)}`);
+      const h1 = text.match(/<h1>[\s\S]*?<\/h1>/)?.[0] ?? "";
+      assert.ok(new RegExp(offer.risk_level!).test(h1), `${offer.vendor}: expected ${offer.risk_level} in the <h1>`);
+      assert.ok(
+        text.includes(`Why ${offer.risk_level}:`),
+        `${offer.vendor}: <h1> says ${offer.risk_level} and the page never says why`,
+      );
+      assert.ok(
+        text.includes(offer.risk_cause.date),
+        `${offer.vendor}: the cause is dated ${offer.risk_cause.date} and that date is nowhere on the page`,
+      );
+    }
+  });
+
+  it("a cause older than the 90-day recent-change window still renders", async () => {
+    // Neon's cause is dated 2026-01-15. `recent_change` reaches back 90 days,
+    // so before this the page showed a warning and nothing that explained it.
+    const { enrichOffers, loadOffers } = await import("../dist/data.js");
+    const neon = enrichOffers(loadOffers().filter((o: { vendor: string }) => o.vendor === "Neon"))[0];
+    if (!neon || neon.risk_level === "stable") return; // records changed; nothing to assert
+    assert.ok(neon.risk_cause, "Neon carries a warning with no cause");
+    assert.strictEqual(neon.recent_change, null, "this test is anchored on Neon's cause being outside the 90-day window");
+    const { text } = await get("/vendor/neon");
+    assert.ok(text.includes(neon.risk_cause.date), "Neon's cause date is not on the page");
+  });
+
+  it("the alternatives surfaces publish the cause too", async () => {
+    const { enrichOffers, loadOffers } = await import("../dist/data.js");
+    const warned = enrichOffers(loadOffers()).find((o: { risk_level: string | null }) => o.risk_level !== "stable");
+    assert.ok(warned, "expected a warned vendor");
+    const { text } = await get(`/alternative-to/${toSlug(warned.vendor)}`);
+    if (!/Risk Level:/.test(text)) return; // page shape changed
+    assert.ok(text.includes(warned.risk_cause.date), `/alternative-to/${toSlug(warned.vendor)} shows a level with no dated cause`);
+  });
+
+  it("the alternatives index lists nobody it cannot name a reason for", async () => {
+    // This page used to score `+1 per other change`, so a vendor that expanded
+    // its free tier earned a row on a page headed "Free Alternatives to
+    // Popular Tools" — we recommended leaving a vendor for improving.
+    const { text } = await get("/alternative-to");
+    const rows = text.match(/<a href="\/alternative-to\/[^"]+" class="idx-row">[\s\S]*?<\/a>/g) ?? [];
+    assert.ok(rows.length > 0, "no rows on /alternative-to");
+    for (const row of rows) {
+      assert.ok(
+        /\d{4}-\d{2}-\d{2}/.test(row),
+        `a row on /alternative-to carries a level with no dated cause: ${row.replace(/\s+/g, " ").slice(0, 200)}`,
+      );
+    }
+  });
+
+  it("/api/offers ships risk_cause wherever it ships a non-stable risk_level", async () => {
+    const res = await fetch(`http://localhost:${serverPort}/api/offers?limit=200`);
+    const body = await res.json() as { offers?: Array<{ vendor: string; risk_level?: string; risk_cause?: unknown }> };
+    const offers = body.offers ?? [];
+    assert.ok(offers.length > 0, "no offers returned");
+    const bad = offers.filter((o) => o.risk_level && o.risk_level !== "stable" && !o.risk_cause);
+    assert.deepStrictEqual(bad.map((o) => o.vendor), [], "JSON callers got a level they cannot explain to their user");
+  });
+});
+
+describe("#1038 — risk does not rank", () => {
+  it("src/ranking.ts does not read risk_level or stability", () => {
+    const src = readFileSync(path.join(REPO, "src", "ranking.ts"), "utf8");
+    const executable = src.split("\n").filter((l) => !/^\s*(\*|\/\/|\/\*|\*\/)/.test(l)).join("\n");
+    for (const token of ["risk_level", "vendorRiskLevel", "vendorRiskAssessment", "classifyStability", "stability"]) {
+      assert.ok(!executable.includes(token), `src/ranking.ts reads ${token}`);
+    }
+  });
+
+  it("mutating risk_level and stability does not change the order rankForListing returns", async () => {
+    // The stronger form of the same claim: the comment at src/data.ts said the
+    // risk bucket had been removed from one sort, and a comment is not a test.
+    const { rankForListing } = await import("../dist/ranking.js");
+    const { enrichOffers, loadOffers, loadDealChanges } = await import("../dist/data.js");
+    const changes = loadDealChanges();
+    const candidates = enrichOffers(loadOffers().slice(0, 120));
+
+    const order = (offers: unknown[]) =>
+      rankForListing(offers as never, { queryKey: "risk-does-not-rank", changes, date: "2026-08-25" })
+        .entries.map((e: { offer: { vendor: string } }) => e.offer.vendor);
+
+    const baseline = order(candidates);
+    const flipped = order(candidates.map((o: { risk_level: string; stability: string }) => ({
+      ...o,
+      risk_level: o.risk_level === "stable" ? "risky" : "stable",
+      stability: o.stability === "stable" ? "volatile" : "stable",
+    })));
+    assert.deepStrictEqual(flipped, baseline, "the ranking moved when risk_level/stability were flipped — risk is ranking");
+  });
+});

--- a/test/stability.test.ts
+++ b/test/stability.test.ts
@@ -103,21 +103,43 @@ describe("classifyStability", () => {
     assert.strictEqual(classifyStability(changes), "improving");
   });
 
+  // #1038: this used to assert `pricing_model_change` was neutral. All five
+  // records of that type describe a free tier getting worse — Xata retiring
+  // its SaaS free tier, Xero ending free API access, X migrating legacy free
+  // users to pay-per-use — so reading them as neutral rendered Xata `stable`.
+  // `rebranded` is now the only genuinely neutral type: a naming event.
   it("returns stable for vendor with only neutral changes", async () => {
     const { classifyStability } = await import("../dist/data.js");
     const changes = [{
       vendor: "TestVendor",
-      change_type: "pricing_model_change",
+      change_type: "rebranded",
       date: "2026-01-15",
-      summary: "Pricing model restructured",
-      previous_state: "Old model",
-      current_state: "New model",
+      summary: "Rebranded to NewName, URL changed",
+      previous_state: "OldName",
+      current_state: "NewName",
       impact: "low",
       source_url: "https://example.com",
       category: "CI/CD",
       alternatives: [],
     }];
     assert.strictEqual(classifyStability(changes), "stable");
+  });
+
+  it("a pricing model change that retires a free tier is not neutral", async () => {
+    const { classifyStability } = await import("../dist/data.js");
+    const changes = [{
+      vendor: "TestVendor",
+      change_type: "pricing_model_change",
+      date: "2026-04-19",
+      summary: "Pivoted to open source; SaaS free tier retired",
+      previous_state: "Free tier",
+      current_state: "Self-host only",
+      impact: "high",
+      source_url: "https://example.com",
+      category: "Databases",
+      alternatives: [],
+    }];
+    assert.strictEqual(classifyStability(changes), "watch");
   });
 });
 


### PR DESCRIPTION
Refs #1038

## What was wrong

`src/data.ts:339` counted **every change record of every type, all-time**. `limits_increased` pushed a vendor toward `caution`; a vendor we had never examined rendered `stable` because we had written nothing about it. So the badge measured our coverage and rewarded obscurity — the third instance of the defect we removed from `description.length` (#1025) and declined to ship in `stale_verification` (#1020), and the only one that actually shipped, in the `<h1>` of our highest-traffic route.

## Before / after

You asked for the distribution. Across 1,571 offers:

| | risky | caution | stable |
|---|---|---|---|
| before | 20 | 91 | 1460 |
| after | **18** | **63** | **1490** |

**It is not the large drop you expected, and the reason is worth knowing.** `vendorRiskLevel` is windowed to 12 months only on its `risky` branch — its `caution` branch loops over every record regardless of date, so `limits_reduced` (36 records) and `pricing_restructured` (54) still fire at any age. I measured what a 12-month window on that branch would buy: **3 offers.** Not worth the behavioural change, and leaving it unwindowed is what makes `stable` literally true — *we hold no adverse record for this vendor, at any date*. Publishing both numbers and declining to narrow is the same trade as #1024's `denominator_days_available`.

Your four examples, live:

| | before | after |
|---|---|---|
| `/vendor/railway` | `caution` | **`stable`** |
| `/vendor/digitalocean` | `risky` | **`stable`** |
| `/vendor/github-actions` | `caution` | **`stable`** |
| `/vendor/neon` | `caution`, cause invisible | `caution` + `2026-01-15 — Moved to fully usage-based pricing…` under the badge |

## The two properties, which are different properties

**1. The level is earned.** One definition, `vendorRiskAssessment`, decided by an exhaustive `RISK_DEMOTION` table. `limits_increased`, `new_free_tier`, `new_tier`, `startup_program_expanded`, `pricing_postponed` and `rebranded` demote nothing. **A test asserts the table names every change type present in the data** — a type left out of it demotes nothing by accident rather than by decision, and the next type you add will fail that test until someone decides.

**2. The level is checkable.** `caution` and `risky` travel with the dated record that produced them — `risk_cause` on `EnrichedOffer`, in `/api/offers`, in `checkVendorRisk`, in the MCP tool result, in the OpenAPI schema — and **render as nothing at all without one**. Neon is the case that needs this: its cause is seven months old, outside the 90-day `recent_change` window, so the page showed a warning and nothing that explained it.

**Agreed on `rebranded`** — 19 records, a naming event, no risk input in either direction.

## One regression I introduced and then fixed

Switching verbatim to `vendorRiskLevel` moves **SendGrid** from `risky` to `stable`, because its `free_tier_removed` is dated 2025-05-27 and the risky branch is windowed to 12 months. `checkVendorRisk` would then have told an agent *"SendGrid has a stable pricing history with no negative changes recorded"* — about a vendor whose free tier removal we hold on record. **`stable` is a published claim too.** A severe change now ages into `caution`, never into `stable`, so the invariant is clean: `stable` means we hold no adverse record at all. That is the +1 in the caution column (62 → 63).

## There were not two implementations. There were six

You found two. Enumerating every call site found four more, and two of them were client-side:

| where | what it was | ranks? |
|---|---|---|
| `enrichOffers` | count of records | no |
| `vendorRiskLevel` | type-aware | no |
| stack-checker `vendorLookup` | own inline type test, **only the 3 most recent records**, no window | no |
| cost-estimator `categoryVendors` | own inline type test on a `high/medium/low` scale | **yes** |
| vendor-page change notice | own 5-type list, keyed on the *latest* record | no |
| weekly digest ×2 + `classifyStability` ×3 | own negative/positive lists | no |

**The fourth one ranks.** `riskPenalty = high ? 100 : medium ? 30 : 0` moves a vendor down the cost estimator's client-side recommender. It does not touch `rankForListing`, so your AC is satisfied as asked — but I do not think "it isn't the selection module" is the answer you want, so I am flagging it rather than filing it quietly. It reads the one definition now and its card publishes the dated cause, so nothing there demotes a vendor for a reason we won't show. **Whether a risk level should move a recommendation order at all is your call, and I have not made it.**

## Confirming risk does not rank, as a fact and not a comment

You asked for this stated with a test rather than inferred from the comment at `src/data.ts:617`. Two:

- `src/ranking.ts` contains no `risk_level`, `stability`, `vendorRiskLevel` or `classifyStability` in executable code.
- **Flipping `risk_level` and `stability` on every candidate returns the identical order from `rankForListing`.** That is the property; the grep is the cheap corroboration.

## The stability audit — it is not sound, and the fix is one offer

`classifyStability` is type-aware, as you said. But its three type sets were copies of the direction taxonomy and they had **drifted**: `pricing_model_change` was in neither the negative nor the positive set, and `new_tier` was missing from the positive set. All five `pricing_model_change` records describe a free tier getting worse — Xata retiring its SaaS free tier, Xero ending free API access, X migrating legacy free users to pay-per-use. Reading them as neutral rendered **Xata `stable`**.

One `CHANGE_DIRECTION` table now feeds `classifyStability`, both weekly-digest classifications, the free-tier-longevity calculation and the vendor-page change notice. A test asserts nothing `RISK_DEMOTION` demotes is called positive or neutral by it. Effect on the published distribution: `watch` 55 → 56 (Xata). `volatile` 33 and `improving` 17 unchanged.

## Three things I did not do, and why

**1. `product_deprecated` (69 records), `restriction` (10) and `pricing_model_change` (5) are not risk inputs.** Adding the largest change type in the file would have expanded warnings in an issue about removing unearned ones, and `product_deprecated` is dominated by *unrelated products of large vendors* — an AWS Lambda Node 20 runtime deprecation, OpenAI Realtime beta endpoints. That is the coverage proxy again: a big vendor accumulates deprecation records for products that have nothing to do with the free tier we list. **8 live offers are affected**, and 5 of them are `volatile` on the stability scale while `stable` on the risk scale, which is a visible disagreement between two labels on the same page:

`DigitalOcean` ×2, `Google Gemini API`, `Postman`, `Neo4j AuraDB`, `Xata`, `Brackets`, `Google Content API for Shopping`.

Say the word and I will file it. It needs a decision about scoping `product_deprecated` to the offer's own product, not just a set-membership change.

**2. Two records need a data correction, not a code change.**
- **Neo4j AuraDB** `restriction` 2026-03-22 reads *"Data correction — previous entry incorrectly reduced limits to 50K nodes. Actual free tier is 200,000 nodes"*. **That is a correction to our own record, stored as an adverse change against the vendor.** It is your "the signal measures us, not the vendor" in its purest form and no taxonomy can fix it.
- **Stripe** `pricing_restructured` 2026-02-01 is Managed Payments entering GA — a new product, as you noted. It keeps `caution`, but the badge now shows the reader that sentence, so the flag is at least judgeable rather than assertable.

**3. I did not touch the `stable` badge's own requirement to show a cause.** `stable` is the absence of a claim against the vendor, so there is nothing to date. `/criteria` states the honest limit instead: a vendor we have never had cause to examine reads the same as one with a long clean history.

## `/criteria`

New subsection under §2 — the badge moves no order, is never a count, always renders with its dated cause, and what `stable` does and does not mean. It sits beside "One demerit measures us, not the vendor" because it is the same failure mode, and the paragraph names what was wrong until August 2026 so the next version of it is checkable.

## Verified

`npm test`: **1457 pass, 0 fail** (17 new). Live against a real `dist/serve.js`: `/vendor/railway` `stable` with no cause line, `/vendor/neon` `caution` with the date and summary under the badge and the duplicate notice box suppressed, a real MCP `initialize` → `tools/call compare_vendors` returning `risk_cause` in the JSON block and quoting it in `summary` with #1024's signal footer still arriving as its own content block, `/api/offers?limit=400` with zero warned offers lacking a cause, and all 78 `/alternative-to` index rows carrying a dated cause. Vendor pages checked visually with shot-scraper.