### PR TITLE
data: correct Mailtrap free-tier record (independently verified)

### DIFF
--- a/data/index.json
+++ b/data/index.json
@@ -11881,14 +11881,14 @@
     {
       "vendor": "Mailtrap.io",
       "category": "Email",
-      "description": "Email API, SMTP, 4,000 emails/month free for transactional and marketing emails.",
+      "description": "Three separate free products. Email API/SMTP: 4,000 emails/month (150/day cap), 1 domain, 3-day log retention. Email Sandbox (testing): 50 test emails/month, 1 sandbox. Email Marketing: 1,500 emails/month, 500 contacts. 1 user each.",
       "tier": "Free",
       "url": "https://mailtrap.io/",
       "tags": [
         "email",
         "free-for-dev"
       ],
-      "verifiedDate": "2026-07-12"
+      "verifiedDate": "2026-08-25"
     },
     {
       "vendor": "Mutant Mail",


### PR DESCRIPTION
## Why this exists

Mailtrap emailed Rob overnight: *"We've noticed our positioning is slightly outdated and would love to provide an updated copy. In return, we'll gladly provide a link from our blog to help boost your website's SEO."*

I checked their live pricing page before their copy arrived. **They are right, and our record is wrong in a way that would make an agent give a user bad advice.**

| | our record (verified 2026-07-12) | live, 2026-08-25 |
|---|---|---|
| Email API/SMTP | 4,000/mo | 4,000/mo **+ 150/day cap**, 1 domain, 3-day log retention |
| Email Marketing | *folded into the same 4,000* | **1,500/mo, 500 contacts** — a separate product |
| Email Sandbox (testing) | **absent** | 50 test emails/mo, 1 sandbox |

Two concrete harms: we overstate the marketing allowance by **2.7×**, and we omit the Sandbox entirely — which is the product a developer searching "free email testing" actually wants, and the one Mailtrap is best known for.

## What this PR does

One record. Description rewritten to name the three products separately with their real limits, in the style of our August-vintage email records (Resend, Mailjet, Mailchimp already carry daily caps). `verifiedDate` → 2026-08-25.

## What this PR deliberately does not do

**No `deal_changes.json` entry.** Nothing changed at the vendor — our record was wrong and now it isn't. Filing a correction as a change record is the [Neo4j AuraDB 2026-03-22](https://github.com/robhunter/agentdeals/issues/1038) defect in its purest form: that record reads *"Data correction — previous entry incorrectly reduced limits to 50K nodes"* and is stored as an adverse change **against Neo4j**, so our own mistake demotes the vendor we made it about.

Now that #1038 publishes risk causes in the `<h1>`, that defect is user-visible. A vendor who writes in to correct us must not be penalised for it.

## The policy point

No link was accepted, requested, or discussed. **The correction is free and it would have happened anyway** — verifying it took one fetch of a public pricing page.

That has to be the standing rule, for two reasons. `/criteria` says nothing we publish is acquirable; accepting a backlink *as consideration for a content change* would make that false the first time we did it. And separately, Google's spam policy names exchanging links for goods or services as a link scheme — so the offered remedy carries the risk it is offered to cure.

Related: #1020. Mailtrap sat 44 days past its last verification because the re-verifier spends 63% of its capacity re-picking the same 46 permanently-failing records (oldest now **142 days**, up exactly one day since #1020 was filed — i.e. no progress). **A vendor noticed our data was stale before our own re-verifier reached it.** That is the first externally-reported symptom of #1020.