### PR TITLE
Extend the private-context guard to counterparty references

### DIFF
--- a/AGENT_README.md
+++ b/AGENT_README.md
@@ -29,6 +29,12 @@ A remote MCP server that aggregates publicly available discounts, free tiers, st
 - PRs: Squash merge preferred
 - Branches: `<issue-number>-<short-description>`
 - Index data: `data/index.json` — structured vendor offer entries
+- **Do not add code comments in this repo.** This is a public tree; express intent
+  through naming, small functions and test names instead. Existing comments stay —
+  the rule applies to new ones.
+- Comments are not the only published prose: test names, assertion messages and
+  anything under `docs/` ship to every reader too. `test/no-private-context.test.ts`
+  scans all of it. If it fires, fix the text — do not widen the exclusion.
 
 ## Commands
 

--- a/test/no-private-context.test.ts
+++ b/test/no-private-context.test.ts
@@ -4,13 +4,15 @@
 // and they are the easiest place for context to leak, because a comment feels like a note
 // to yourself rather than something published. It is not: it ships.
 //
-// Three things went in this way and had to be taken back out (2026-08-25):
+// Four things went in this way and had to be taken back out (2026-08-25):
 //   - a business identity block (entity name, tax ID, street address) in a docs/ file,
 //     added as a convenience for filling in affiliate registrations
 //   - two comments explaining a retention choice by pointing at a private commercial
 //     conversation, which is context the reader cannot have and we do not want to give
 //   - a scatter of comments and test names attributing a decision to an internal role
 //     rather than stating the reason for it
+//   - a test name saying a published figure was "going to a partner", which named a
+//     counterparty without naming a conversation and so slipped the rule above
 //
 // The last one is the instructive case, because it is also just worse commenting. "X
 // overrode this during review" tells you who to blame; "a 400 here throws away the most
@@ -88,6 +90,16 @@ const RULES: Rule[] = [
     name: "private commercial conversation",
     pattern: /\bpartner(?:ship)?\s+(?:conversation|discussion|talks|call|negotiation)/i,
     why: "pointing a code comment at a private commercial discussion tells a reader it exists and what it is about",
+  },
+  {
+    name: "commercial counterparty as audience",
+    pattern:
+      /\b(?:going|sent|shown|quoted|promised|reported|shared|pitched|due)\s+to\s+(?:an?|the|our)\s+(?:external\s+|prospective\s+|potential\s+|commercial\s+)?(?:partner|investor|acquirer|buyer)\b|\b(?:our|my)\s+(?:external\s+|prospective\s+|potential\s+|commercial\s+)?(?:partner|investor|acquirer|buyer)\b/i,
+    why:
+      "'partner' alone is ordinary product vocabulary here — vendors run partner programs, " +
+      "/disclosure lists referral partners, and type: 'partner' is a schema value. What is " +
+      "banned is a counterparty of ours as the audience for a number or a decision: that is " +
+      "what reveals a commercial relationship and what it turns on",
   },
   {
     name: "internal role attribution",

--- a/test/not-found-accounting.test.ts
+++ b/test/not-found-accounting.test.ts
@@ -200,7 +200,7 @@ describe("404s are not page views (#1029)", () => {
       assert.equal(traffic.web_vs_mcp ?? undefined, undefined);
     });
 
-    it("keeps web_vs_mcp clean, since that is the number going to a partner", async () => {
+    it("keeps web_vs_mcp clean, since that is the number we publish", async () => {
       await boot();
       for (let i = 0; i < 50; i++) recordTraffic(`/probe-${i}`, UA.curl, 404);
       recordTraffic("/vendor/neon", UA.chatgpt, 200);


### PR DESCRIPTION
Follow-up to #1042.

That guard keyed on a *conversation* noun. Prose naming a counterparty as the audience for a number — without naming a conversation — passed it. One line of that shape was still live in a test name after the review; this adds a rule for it and fixes the line.

Scoped so ordinary product vocabulary stays legal. `partner` appears ~26 times in this tree legitimately (vendor partner programs, `Current Referral Partners` on /disclosure, `type: "partner"` in the schema). The rule bans a counterparty of *ours* as the audience for a figure or decision, not the word.

Verified by probe: 4 banned shapes all fire the rule, 6 real product strings from this repo do not.

Also updates `AGENT_README.md`:
- new code comments are not added in this repo
- test names and assertion messages are published prose too — both misses here were in those rather than in comments, which is the reason the guard scans whole files rather than comment syntax

`tsc --noEmit` clean, `npm test` 1465 pass / 0 fail (+1).