### PR TITLE
Stop publishing caller values and session identifiers on /api/query-log

### DIFF
--- a/scripts/e2e-1039.mjs
+++ b/scripts/e2e-1039.mjs
@@ -1,0 +1,274 @@
+import { createServer } from "node:http";
+import { spawn } from "node:child_process";
+import { connect } from "node:net";
+import { readFileSync, writeFileSync, existsSync } from "node:fs";
+
+const store = new Map();
+const lists = new Map();
+
+const upstash = createServer((req, res) => {
+  let body = "";
+  req.on("data", c => (body += c));
+  req.on("end", () => {
+    const args = JSON.parse(body || "[]");
+    const cmd = String(args[0]).toUpperCase();
+    let result;
+    switch (cmd) {
+      case "GET": result = store.get(String(args[1])) ?? null; break;
+      case "SET": store.set(String(args[1]), String(args[2])); result = "OK"; break;
+      case "MGET": result = args.slice(1).map(k => store.get(String(k)) ?? null); break;
+      case "SCAN": {
+        const pattern = String(args[3] ?? "*");
+        const prefix = pattern.endsWith("*") ? pattern.slice(0, -1) : pattern;
+        result = ["0", [...store.keys()].filter(k => k.startsWith(prefix))];
+        break;
+      }
+      case "LPUSH": {
+        const key = String(args[1]);
+        const list = lists.get(key) ?? [];
+        for (const v of args.slice(2)) list.unshift(String(v));
+        lists.set(key, list);
+        result = list.length;
+        break;
+      }
+      case "LTRIM": {
+        const key = String(args[1]);
+        lists.set(key, (lists.get(key) ?? []).slice(Number(args[2]), Number(args[3]) + 1));
+        result = "OK";
+        break;
+      }
+      case "LRANGE":
+        result = (lists.get(String(args[1])) ?? []).slice(Number(args[2]), Number(args[3]) + 1);
+        break;
+      default: result = 1;
+    }
+    res.writeHead(200, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ result }));
+  });
+});
+
+const fail = [];
+function checkTrue(label, cond, detail = "") {
+  console.log(`${cond ? "  ok  " : "  FAIL"}  ${label}${cond || !detail ? "" : ` — ${detail}`}`);
+  if (!cond) fail.push(label);
+}
+function check(label, actual, expected) {
+  const ok = JSON.stringify(actual) === JSON.stringify(expected);
+  console.log(`${ok ? "  ok  " : "  FAIL"}  ${label}: ${JSON.stringify(actual)}${ok ? "" : ` (expected ${JSON.stringify(expected)})`}`);
+  if (!ok) fail.push(label);
+}
+
+const AGENTS_PATH = "data/agents.json";
+const agentsBefore = existsSync(AGENTS_PATH) ? readFileSync(AGENTS_PATH, "utf8") : null;
+function restoreAgentStore() {
+  if (agentsBefore !== null) writeFileSync(AGENTS_PATH, agentsBefore);
+}
+process.on("exit", restoreAgentStore);
+
+const SEARCH_TEXT = "wildebeest-migration-tracker";
+const REGISTRATION_NAME = `quokka-registry-probe-${process.pid}`;
+const CLIENT_NAME = "pangolin-mcp-client";
+
+await new Promise(r => upstash.listen(0, r));
+const upstashUrl = `http://127.0.0.1:${upstash.address().port}`;
+
+const child = spawn("node", ["dist/serve.js"], {
+  stdio: ["pipe", "pipe", "pipe"],
+  env: {
+    ...process.env,
+    PORT: "0",
+    BASE_URL: "http://localhost",
+    UPSTASH_REDIS_REST_URL: upstashUrl,
+    UPSTASH_REDIS_REST_TOKEN: "fake",
+    TELEMETRY_FLUSH_INTERVAL_SECONDS: "5",
+  },
+});
+
+const port = await new Promise((resolve, reject) => {
+  const t = setTimeout(() => { child.kill(); reject(new Error("startup timeout")); }, 20000);
+  child.stderr.on("data", d => {
+    const m = d.toString().match(/running on http:\/\/localhost:(\d+)/);
+    if (m) { clearTimeout(t); resolve(Number(m[1])); }
+  });
+});
+const base = `http://localhost:${port}`;
+const url = p => `${base}${p}`;
+
+function rawRequest(path, userAgent) {
+  return new Promise((resolve, reject) => {
+    const socket = connect(port, "localhost", () => {
+      socket.write(
+        `GET ${path} HTTP/1.1\r\nHost: localhost\r\nUser-Agent: ${userAgent}\r\nConnection: close\r\n\r\n`,
+      );
+    });
+    let response = "";
+    socket.on("data", d => (response += d.toString()));
+    socket.on("end", () => resolve(response));
+    socket.on("error", reject);
+    setTimeout(() => { socket.destroy(); resolve(response); }, 5000);
+  });
+}
+
+console.log(`\nserver on ${base}, storage on ${upstashUrl}\n`);
+
+console.log("1. Drive real traffic through the free-text intakes");
+{
+  const r1 = await fetch(url(`/api/offers?q=${encodeURIComponent(SEARCH_TEXT)}&category=Infrastructure&limit=5`));
+  checkTrue("search with free text accepted", r1.status === 200, String(r1.status));
+
+  const r2 = await fetch(url("/api/agents/register"), {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ name: REGISTRATION_NAME }),
+  });
+  checkTrue(`registration reached its handler (status ${r2.status})`, [200, 201, 400, 403, 409, 503].includes(r2.status), String(r2.status));
+}
+
+console.log("\n2. Open a real MCP session and call a tool");
+let mcpSessionId = null;
+{
+  const mcpHeaders = {
+    "Content-Type": "application/json",
+    "Accept": "application/json, text/event-stream",
+  };
+  const init = await fetch(url("/mcp"), {
+    method: "POST",
+    headers: mcpHeaders,
+    body: JSON.stringify({
+      jsonrpc: "2.0", id: 1, method: "initialize",
+      params: { protocolVersion: "2024-11-05", capabilities: {}, clientInfo: { name: CLIENT_NAME, version: "9.9.9" } },
+    }),
+  });
+  mcpSessionId = init.headers.get("mcp-session-id");
+  await init.text();
+  checkTrue("initialize succeeded", init.status === 200 && !!mcpSessionId, `${init.status} ${mcpSessionId}`);
+
+  await fetch(url("/mcp"), {
+    method: "POST",
+    headers: { ...mcpHeaders, "mcp-session-id": mcpSessionId },
+    body: JSON.stringify({ jsonrpc: "2.0", method: "notifications/initialized" }),
+  });
+
+  for (const query of [SEARCH_TEXT, "postgres"]) {
+    const call = await fetch(url("/mcp"), {
+      method: "POST",
+      headers: { ...mcpHeaders, "mcp-session-id": mcpSessionId },
+      body: JSON.stringify({
+        jsonrpc: "2.0", id: 2, method: "tools/call",
+        params: { name: "search_deals", arguments: { query, limit: 3 } },
+      }),
+    });
+    await call.text();
+    checkTrue(`tool call for ${query.slice(0, 12)} succeeded`, call.status === 200, String(call.status));
+  }
+}
+
+console.log("\n3. What the public endpoint publishes");
+const published = await (await fetch(url("/api/query-log?limit=200"))).json();
+const body = JSON.stringify(published);
+{
+  checkTrue("the log is available", published.available === true, JSON.stringify(published.error));
+  checkTrue("it has entries", published.count > 0, String(published.count));
+
+  checkTrue("the search text is absent", !body.includes(SEARCH_TEXT));
+  checkTrue("the registration name is absent", !body.includes(REGISTRATION_NAME));
+  checkTrue("no entry carries a params object", !body.includes('"params"'));
+  checkTrue("no entry carries a session identifier", !body.includes('"session_id"'));
+  if (mcpSessionId) checkTrue("the live session identifier is absent", !body.includes(mcpSessionId));
+
+  const searchEntry = published.entries.find(e => e.endpoint === "/api/offers");
+  checkTrue("the search entry is present", !!searchEntry);
+  check("its parameter lengths", searchEntry?.param_lengths, {
+    q: SEARCH_TEXT.length, category: "Infrastructure".length, limit: 1, offset: 1,
+  });
+
+  const registerEntry = published.entries.find(e => e.endpoint === "/api/agents/register");
+  if (registerEntry) {
+    check("the registration name is published as a length", registerEntry.param_lengths, { name: REGISTRATION_NAME.length });
+  } else {
+    console.log("  --    registration was not logged on this build; skipping");
+  }
+
+  const sessionEntries = published.entries.filter(e => e.session_index !== undefined);
+  checkTrue("session entries carry an index instead", sessionEntries.length > 0, String(sessionEntries.length));
+  const indexes = new Set(sessionEntries.map(e => e.session_index));
+  checkTrue("every index is a small integer", [...indexes].every(i => Number.isInteger(i) && i >= 1 && i <= sessionEntries.length));
+  checkTrue("the tool calls share one index", indexes.size === 1, `indexes: ${[...indexes].join(",")}`);
+
+  const withClient = published.entries.find(e => e.client_info);
+  checkTrue("the client name is still published", withClient?.client_info?.name === CLIENT_NAME, JSON.stringify(withClient?.client_info));
+}
+
+console.log("\n4. A caller cannot use the log to republish prose on this domain");
+{
+  const longAgent = `evil/1.0 ${"A".repeat(4000)} trailing-contact-details`;
+  await fetch(url("/api/offers?q=probe&limit=1"), { headers: { "User-Agent": longAgent } });
+  const after = await (await fetch(url("/api/query-log?limit=200"))).json();
+  const longEntry = after.entries.find(e => (e.user_agent ?? "").startsWith("evil/1.0"));
+  checkTrue("an oversized user agent was logged", !!longEntry, "entry not found, the checks below would pass vacuously");
+  if (longEntry) {
+    check("it is bounded", longEntry.user_agent.length, 200);
+    checkTrue("its tail was dropped", !longEntry.user_agent.includes("trailing-contact-details"));
+  }
+
+  for (const code of [0, 7, 27, 127]) {
+    const response = await rawRequest("/api/offers?q=probe&limit=1", `evil/1.0 ${String.fromCharCode(code)} tail`);
+    checkTrue(
+      `a user agent carrying control character ${code} is refused at the HTTP layer`,
+      response.startsWith("HTTP/1.1 400"),
+      response.split("\r\n")[0] || "(no response)",
+    );
+  }
+
+  const escape = String.fromCharCode(27);
+  const hostileClient = `evil${escape}[31m${String.fromCharCode(7)}${"B".repeat(900)}`;
+  const init = await fetch(url("/mcp"), {
+    method: "POST",
+    headers: { "Content-Type": "application/json", "Accept": "application/json, text/event-stream" },
+    body: JSON.stringify({
+      jsonrpc: "2.0", id: 1, method: "initialize",
+      params: { protocolVersion: "2024-11-05", capabilities: {}, clientInfo: { name: hostileClient, version: "1.0" } },
+    }),
+  });
+  await init.text();
+  const afterMcp = await (await fetch(url("/api/query-log?limit=200"))).json();
+  const hostileEntry = afterMcp.entries.find(e => (e.client_info?.name ?? "").startsWith("evil"));
+  checkTrue("a hostile client name reached the log through the JSON body", !!hostileEntry, "entry not found, the checks below would pass vacuously");
+  if (hostileEntry) {
+    check("the client name is bounded", hostileEntry.client_info.name.length, 200);
+    checkTrue("the client name carries no control characters", ![...hostileEntry.client_info.name].some(ch => {
+      const c = ch.codePointAt(0) ?? 0;
+      return c < 0x20 || c === 0x7f;
+    }));
+  }
+}
+
+console.log("\n5. Retention is unchanged: the values are still in storage");
+{
+  await new Promise(r => setTimeout(r, 7000));
+  const stored = lists.get("agentdeals:request_log") ?? [];
+  checkTrue("the request log reached storage", stored.length > 0, String(stored.length));
+  const storedBody = stored.join("\n");
+  checkTrue("the search text is retained", storedBody.includes(SEARCH_TEXT));
+  checkTrue("the session identifier is retained", !mcpSessionId || storedBody.includes(mcpSessionId));
+  checkTrue("raw parameter values are retained", storedBody.includes('"params"'));
+}
+
+console.log("\n6. The published schema matches what is served");
+{
+  const spec = await (await fetch(url("/api/openapi.json"))).json();
+  const props = spec.paths["/api/query-log"].get.responses["200"].content["application/json"].schema.properties.entries.items.properties;
+  checkTrue("the schema describes param_lengths", !!props.param_lengths);
+  checkTrue("the schema describes session_index", !!props.session_index);
+  checkTrue("the schema no longer describes session_id", !props.session_id);
+  checkTrue("the schema no longer describes params", !props.params);
+}
+
+child.kill();
+upstash.close();
+
+console.log(`\n${fail.length === 0 ? "PASS" : `FAIL (${fail.length})`}`);
+if (fail.length) {
+  for (const f of fail) console.log(`  - ${f}`);
+  process.exit(1);
+}

--- a/src/openapi.ts
+++ b/src/openapi.ts
@@ -647,7 +647,7 @@ export const openapiSpec = {
     "/api/query-log": {
       get: {
         summary: "Recent request log",
-        description: "Returns recent request-level log entries for both MCP tool calls and REST API hits. Stored in Redis, capped at 1000 entries.",
+        description: "Returns recent request-level log entries for both MCP tool calls and REST API hits. Stored in Redis, capped at 1000 entries. Query parameter values are not published: each entry reports the parameter names it carried and the length of each value. Session identifiers are not published either; entries from one session share a session_index that is assigned within a single response and carries no meaning across responses.",
         parameters: [
           { name: "limit", in: "query", description: "Number of entries to return (1-200)", schema: { type: "integer", default: 50 } }
         ],
@@ -665,12 +665,20 @@ export const openapiSpec = {
                         type: "object",
                         properties: {
                           ts: { type: "string", format: "date-time" },
-                          type: { type: "string", enum: ["mcp", "api"] },
+                          type: { type: "string", enum: ["mcp", "api", "session_connect"] },
                           endpoint: { type: "string" },
-                          params: { type: "object" },
+                          param_lengths: {
+                            type: "object",
+                            description: "Parameter name to the character length of the value that was sent. Values themselves are retained internally and never published.",
+                            additionalProperties: { type: "integer" }
+                          },
                           user_agent: { type: "string" },
                           result_count: { type: "integer" },
-                          session_id: { type: "string" }
+                          session_index: { type: "integer", description: "Groups entries from the same session within this response only." },
+                          client_info: {
+                            type: "object",
+                            properties: { name: { type: "string" }, version: { type: "string" } }
+                          }
                         }
                       }
                     },

--- a/src/serve.ts
+++ b/src/serve.ts
@@ -11,7 +11,7 @@ import { estimateCosts } from "./costs.js";
 import { classifyRequest } from "./client-class.js";
 import { acceptSignal, ackMissing, checkRateLimit, clientAddress, RATE_LIMIT_PER_MINUTE, SIGNAL_ACK_PARAM, SIGNAL_BODY_MAX, SIGNAL_DOC_PATH, SIGNAL_PATH, type SignalInput } from "./signal.js";
 import { agentBlock, CONVERTED_CAVEAT, DEFERENCE, PRIVACY_SCOPE, signalHeaderValue, signalHtmlBlock, signalLlmsSection, SIGNAL_HEADER_NAME } from "./signal-copy.js";
-import { recordApiHit, recordSessionConnect, recordSessionDisconnect, recordLandingPageView, getStats, getConnectionStats, loadTelemetry, flushTelemetry, flushPending, FLUSH_INTERVAL_SECONDS, logRequest, getRequestLog, getRequestLogResult, getTelemetryHealth, recordPageView, getPageViews, recordReferralListingCall, recordReferralVendorLookup, getReferralMarketplaceStats, getSessionClassification, recordSearchQuery, getSearchAnalytics, getApiHitsByEndpoint, recordTraffic, getTrafficReport, getSignalReport, SIGNAL_MIN_SAMPLE, SIGNAL_DENOMINATOR_ROUTES } from "./stats.js";
+import { recordApiHit, recordSessionConnect, recordSessionDisconnect, recordLandingPageView, getStats, getConnectionStats, loadTelemetry, flushTelemetry, flushPending, FLUSH_INTERVAL_SECONDS, logRequest, getPublicRequestLogResult, getTelemetryHealth, recordPageView, getPageViews, recordReferralListingCall, recordReferralVendorLookup, getReferralMarketplaceStats, getSessionClassification, recordSearchQuery, getSearchAnalytics, getApiHitsByEndpoint, recordTraffic, getTrafficReport, getSignalReport, SIGNAL_MIN_SAMPLE, SIGNAL_DENOMINATOR_ROUTES } from "./stats.js";
 import { openapiSpec } from "./openapi.js";
 import { registerAgent, authenticateRequest, validateVestauthUrl, hashApiKey, updateAgentX402Address, getAgentById } from "./agents.js";
 import { logReferralRequest } from "./referral-requests.js";
@@ -54040,7 +54040,7 @@ const httpServer = createHttpServer(async (req, res) => {
     res.end(JSON.stringify(result));
   } else if (url.pathname === "/api/query-log" && isGetOrHead) {
     const limit = Math.min(Math.max(parseInt(url.searchParams.get("limit") ?? "50", 10) || 50, 1), 200);
-    const log = await getRequestLogResult(limit);
+    const log = await getPublicRequestLogResult(limit);
     res.writeHead(200, { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" });
     res.end(JSON.stringify({
       entries: log.entries,

--- a/src/signal-copy.ts
+++ b/src/signal-copy.ts
@@ -19,8 +19,9 @@
 //     exactly the ones we most want to hear from. Every web surface carries the deference
 //     clause; the MCP surfaces do not need it.
 //  4. Scope every privacy sentence to the call in front of it. "Nothing about your user is
-//     recorded" reads as a claim about the site, and /api/query-log publishes raw user
-//     agents and search params, so the site does not currently support that claim.
+//     recorded" reads as a claim about the site, and the site records more than this call
+//     does — search text is retained, and /api/query-log publishes user agents — so the
+//     site does not currently support that claim.
 //  5. `recommended` and `converted` are two counters and never a funnel. An agent almost
 //     never observes a signup, so a ratio between them would say something about agent
 //     observability while looking like it said something about a vendor.

--- a/src/stats.ts
+++ b/src/stats.ts
@@ -434,6 +434,92 @@ export async function getRequestLog(limit = 50): Promise<RequestLogEntry[]> {
   return (await getRequestLogResult(limit)).entries;
 }
 
+export const PUBLISHED_TEXT_MAX = 200;
+
+export interface PublicRequestLogEntry {
+  ts: string;
+  type: RequestLogEntry["type"];
+  endpoint: string;
+  param_lengths: Record<string, number>;
+  user_agent?: string;
+  result_count: number;
+  session_index?: number;
+  client_info?: { name: string; version: string };
+}
+
+function publishedLength(value: unknown): number {
+  if (typeof value === "string") return value.length;
+  try {
+    return JSON.stringify(value)?.length ?? 0;
+  } catch {
+    return 0;
+  }
+}
+
+function lengthsByParamName(params: Record<string, unknown> | undefined): Record<string, number> {
+  const lengths: Record<string, number> = {};
+  if (!params) return lengths;
+  for (const [name, value] of Object.entries(params)) {
+    if (value === undefined) continue;
+    lengths[name] = publishedLength(value);
+  }
+  return lengths;
+}
+
+function boundedText(raw: unknown): string | undefined {
+  if (typeof raw !== "string") return undefined;
+  let printable = "";
+  for (const ch of raw) {
+    const code = ch.codePointAt(0) ?? 0;
+    printable += code < 0x20 || code === 0x7f ? " " : ch;
+  }
+  const bounded = printable.replace(/\s+/g, " ").trim().slice(0, PUBLISHED_TEXT_MAX);
+  return bounded || undefined;
+}
+
+export function toPublicRequestLog(entries: RequestLogEntry[]): PublicRequestLogEntry[] {
+  const indexBySession = new Map<string, number>();
+  return entries.map(entry => {
+    const published: PublicRequestLogEntry = {
+      ts: entry.ts,
+      type: entry.type,
+      endpoint: entry.endpoint,
+      param_lengths: lengthsByParamName(entry.params),
+      result_count: entry.result_count,
+    };
+    const userAgent = boundedText(entry.user_agent);
+    if (userAgent) published.user_agent = userAgent;
+    if (entry.client_info) {
+      published.client_info = {
+        name: boundedText(entry.client_info.name) ?? "unknown",
+        version: boundedText(entry.client_info.version) ?? "unknown",
+      };
+    }
+    if (entry.session_id) {
+      let index = indexBySession.get(entry.session_id);
+      if (index === undefined) {
+        index = indexBySession.size + 1;
+        indexBySession.set(entry.session_id, index);
+      }
+      published.session_index = index;
+    }
+    return published;
+  });
+}
+
+export async function getPublicRequestLogResult(limit = 50): Promise<{
+  entries: PublicRequestLogEntry[];
+  available: boolean;
+  error: string | null;
+}> {
+  const stored = await getRequestLogResult(limit);
+  return {
+    entries: toPublicRequestLog(stored.entries),
+    available: stored.available,
+    error: stored.error,
+  };
+}
+
 function parseTelemetryData(data: Record<string, unknown>): void {
   cumulative.sessions = (data.cumulative_sessions as number) ?? 0;
   cumulative.tool_calls = (data.cumulative_tool_calls as number) ?? 0;

--- a/test/query-log-redaction.test.ts
+++ b/test/query-log-redaction.test.ts
@@ -1,0 +1,184 @@
+import { describe, it } from "node:test";
+import assert from "node:assert";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const REPO = path.join(path.dirname(fileURLToPath(import.meta.url)), "..");
+
+const {
+  toPublicRequestLog,
+  PUBLISHED_TEXT_MAX,
+} = await import("../src/stats.ts");
+
+type RawEntry = Parameters<typeof toPublicRequestLog>[0][number];
+
+function entry(over: Partial<RawEntry> = {}): RawEntry {
+  return {
+    ts: "2026-08-25T21:00:00.000Z",
+    type: "api",
+    endpoint: "/api/offers",
+    params: {},
+    result_count: 1,
+    ...over,
+  } as RawEntry;
+}
+
+describe("parameter values are replaced by their lengths", () => {
+  it("publishes the name and length of a free-text query, never the text", () => {
+    const [published] = toPublicRequestLog([
+      entry({ params: { q: "how do i cancel my subscription", category: "Infrastructure" } }),
+    ]);
+    assert.deepEqual(published.param_lengths, { q: 31, category: 14 });
+    const serialized = JSON.stringify(published);
+    assert.ok(!serialized.includes("cancel"), "query text must not reach the response");
+    assert.ok(!serialized.includes("Infrastructure"), "filter text must not reach the response");
+  });
+
+  it("has no params key at all", () => {
+    const [published] = toPublicRequestLog([entry({ params: { q: "postgres" } })]);
+    assert.ok(!("params" in published));
+  });
+
+  it("does not publish a registration name", () => {
+    const [published] = toPublicRequestLog([
+      entry({ endpoint: "/api/agents/register", params: { name: "ada-lovelace-bot" } }),
+    ]);
+    assert.deepEqual(published.param_lengths, { name: 16 });
+    assert.ok(!JSON.stringify(published).includes("ada-lovelace"));
+  });
+
+  it("measures non-string values without publishing them", () => {
+    const [published] = toPublicRequestLog([
+      entry({ params: { limit: 2000, personalized: true, vendors: ["neon", "supabase"] } }),
+    ]);
+    assert.equal(published.param_lengths.limit, 4);
+    assert.equal(published.param_lengths.personalized, 4);
+    assert.equal(published.param_lengths.vendors, 19);
+    assert.ok(!JSON.stringify(published).includes("neon"));
+  });
+
+  it("omits parameters that were never sent", () => {
+    const [published] = toPublicRequestLog([
+      entry({ params: { q: "redis", category: undefined, sort: undefined } }),
+    ]);
+    assert.deepEqual(Object.keys(published.param_lengths), ["q"]);
+  });
+
+  it("survives a value that cannot be serialized", () => {
+    const cyclic: Record<string, unknown> = {};
+    cyclic.self = cyclic;
+    const [published] = toPublicRequestLog([entry({ params: { odd: cyclic } })]);
+    assert.equal(published.param_lengths.odd, 0);
+  });
+});
+
+describe("session identifiers are not published", () => {
+  it("replaces the identifier with an index", () => {
+    const [published] = toPublicRequestLog([
+      entry({ session_id: "3f1c8a4e-2b7d-4a91-9c33-6de5b0f21a77" }),
+    ]);
+    assert.equal(published.session_index, 1);
+    assert.ok(!("session_id" in published));
+    assert.ok(!JSON.stringify(published).includes("3f1c8a4e"));
+  });
+
+  it("gives entries from one session the same index and different sessions different ones", () => {
+    const published = toPublicRequestLog([
+      entry({ session_id: "session-a" }),
+      entry({ session_id: "session-b" }),
+      entry({ session_id: "session-a" }),
+    ]);
+    assert.equal(published[0].session_index, 1);
+    assert.equal(published[1].session_index, 2);
+    assert.equal(published[2].session_index, 1);
+  });
+
+  it("assigns the index within one response, so it means nothing across responses", () => {
+    const raw = [entry({ session_id: "session-a" }), entry({ session_id: "session-b" })];
+    const wholeWindow = toPublicRequestLog(raw);
+    const laterWindow = toPublicRequestLog(raw.slice(1));
+    assert.equal(wholeWindow[1].session_index, 2);
+    assert.equal(laterWindow[0].session_index, 1);
+  });
+
+  it("leaves the index off entries that carry no session", () => {
+    const [published] = toPublicRequestLog([entry()]);
+    assert.ok(!("session_index" in published));
+  });
+});
+
+describe("caller-supplied text is bounded before it is republished", () => {
+  it("keeps a normal user agent intact", () => {
+    const ua = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36";
+    const [published] = toPublicRequestLog([entry({ user_agent: ua })]);
+    assert.equal(published.user_agent, ua);
+  });
+
+  it("bounds a user agent that is long enough to be prose", () => {
+    const [published] = toPublicRequestLog([entry({ user_agent: "x".repeat(5000) })]);
+    assert.equal(published.user_agent!.length, PUBLISHED_TEXT_MAX);
+  });
+
+  it("strips control characters from a user agent", () => {
+    const escape = String.fromCharCode(27);
+    const nul = String.fromCharCode(0);
+    const del = String.fromCharCode(127);
+    const [published] = toPublicRequestLog([
+      entry({ user_agent: `curl/8.0${escape}[31m${nul}${del}Injected: header` }),
+    ]);
+    const hasControlChar = [...published.user_agent!].some(ch => {
+      const code = ch.codePointAt(0) ?? 0;
+      return code < 0x20 || code === 0x7f;
+    });
+    assert.equal(hasControlChar, false);
+    assert.equal(published.user_agent, "curl/8.0 [31m Injected: header");
+  });
+
+  it("collapses a newline that would otherwise split the value across lines", () => {
+    const [published] = toPublicRequestLog([
+      entry({ user_agent: `curl/8.0${String.fromCharCode(10)}Injected: header` }),
+    ]);
+    assert.equal(published.user_agent, "curl/8.0 Injected: header");
+  });
+
+  it("bounds a client-reported name and version", () => {
+    const [published] = toPublicRequestLog([
+      entry({ client_info: { name: "y".repeat(900), version: "1.0.0" } }),
+    ]);
+    assert.equal(published.client_info!.name.length, PUBLISHED_TEXT_MAX);
+    assert.equal(published.client_info!.version, "1.0.0");
+  });
+
+  it("reports an empty client name as unknown rather than as an empty string", () => {
+    const [published] = toPublicRequestLog([
+      entry({ client_info: { name: "   ", version: "" } }),
+    ]);
+    assert.equal(published.client_info!.name, "unknown");
+    assert.equal(published.client_info!.version, "unknown");
+  });
+});
+
+describe("the raw log is not reachable from the request path", () => {
+  const stripComments = (src: string) =>
+    src.split("\n").filter((l) => !/^\s*(\*|\/\/|\/\*|\*\/)/.test(l)).join("\n");
+
+  it("serve.ts reads the published projection and never the stored entries", () => {
+    const serve = stripComments(readFileSync(path.join(REPO, "src", "serve.ts"), "utf8"));
+    assert.ok(
+      !/getRequestLogResult/.test(serve),
+      "the stored entries must not be reachable from the request path",
+    );
+    assert.ok(!/getRequestLog\b/.test(serve), "the stored entries must not be reachable either way");
+    assert.ok(/getPublicRequestLogResult/.test(serve), "the endpoint must read the projection");
+  });
+
+  it("the projection is what the published schema describes", () => {
+    const openapi = readFileSync(path.join(REPO, "src", "openapi.ts"), "utf8");
+    const spec = openapi.slice(openapi.indexOf('"/api/query-log"'), openapi.indexOf('"/api/costs"'));
+    assert.ok(spec.includes("param_lengths"));
+    assert.ok(spec.includes("session_index"));
+    assert.ok(!/\bsession_id\b/.test(spec));
+    assert.ok(!/params: \{ type: "object" \}/.test(spec));
+  });
+});


### PR DESCRIPTION
Part 1 of #1039. This is the gate for #1043 — the replacement privacy copy says we do not publish session identifiers, registration names or raw query parameter values, and that sentence is false until this ships.

## What changed

Nothing about what we retain. The stored entry is byte-identical; the change is at the publication boundary, so `/api/query-log` serves a projection rather than the stored record.

| field | before | after |
|---|---|---|
| `params` | every value, verbatim | `param_lengths` — the parameter names, and the character length of each value |
| `session_id` | the raw identifier | `session_index` — assigned while building one response |
| `user_agent` | unbounded | bounded to 200 characters, control characters removed |
| `client_info` | unbounded | same, bounded the same way |

`client_info` is otherwise kept as the issue directed — it is software identification and the input to #1035.

## Why lengths rather than an allowlist of safe keys

An allowlist drifts: a parameter added later is published until someone remembers to classify it. Enumerating the call sites found three that an allowlist written from the search parameters would have missed — `/api/agents/register` logs the chosen name, `POST /api/friends` logs an agent identifier, and `/api/details` spreads a computed key into its params. `PATCH /api/agents/me` already logged a boolean rather than the address itself, which is the pattern the rest now follows by construction.

## Why an index rather than a hash

A hash of the session identifier is stable across responses, so it still links a caller's activity over time — the property the issue asks to remove. The index is built while assembling one response and means nothing outside it. A test asserts that: the same session that is index 2 in one window is index 1 in a window that starts later.

## Verification

`npm test` 1484 pass / 0 fail — 1466 before, 18 new. `tsc` clean.

Every guard is mutation-verified. Each of these was applied to the source in turn, and each produced a failing test:

| mutation | tests failed |
|---|---|
| publish raw params instead of lengths | 5 |
| publish the raw session id | 3 |
| stop bounding caller text | 5 |
| stop stripping control characters | 1 |
| stop skipping unsent parameters | 1 |
| index sessions globally instead of per response | 2 |
| `serve.ts` reads the stored entries again | 1 |
| schema still advertises `session_id` | 1 |

The first pass found a real hole: my control-character test used a newline, which the existing whitespace collapse already handles, so the mutation survived. Rewritten against a non-whitespace control character.

`scripts/e2e-1039.mjs` (committed, re-runnable) drives a real `dist/serve.js` against a fake Upstash: a search with distinctive free text, a registration, a real MCP `initialize` → `notifications/initialized` → two `tools/call`. It then checks both directions — the text is absent from the published response **and** still present in the stored list after a flush, which is what makes "retention unchanged" a measured claim rather than an assertion.

Two things the end-to-end run established that I had assumed otherwise:

- Node's HTTP parser rejects any control character in a header value with a 400 before our handler runs, so that path cannot deliver one. The reachable vector is `clientInfo.name`, which arrives in a JSON body — the script sends a hostile one there and checks the published value is bounded and clean.
- The registration path returns 409 before it logs, so an earlier run of the script left a record behind. The script now snapshots and restores `data/agents.json`, which is tracked.

## Not in this PR

Part 2 (per-class search analytics) is unchanged and still open. `/api/traffic`'s "No PII" note still reads as a site-wide claim and is still wrong at that scope — it belongs to #1043's rescope. The stored client-name map key is caller-supplied and unbounded; noted on the issue rather than changed here, because bounding a persisted key space changes what `clients_top` reports.

Refs #1039