### PR TITLE
Check link liveness separately from verification, and stop publishing a green badge over a dead destination

### DIFF
--- a/.github/workflows/liveness.yml
+++ b/.github/workflows/liveness.yml
@@ -1,0 +1,55 @@
+name: Daily link liveness
+
+on:
+  schedule:
+    - cron: "30 5 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: link-liveness
+  cancel-in-progress: false
+
+jobs:
+  liveness:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Check every catalog link
+        id: liveness
+        run: |
+          set -o pipefail
+          node scripts/check-liveness.js --report | tee /tmp/liveness.log
+          UNREACHABLE=$(grep -oE '^Unreachable: [0-9]+' /tmp/liveness.log | grep -oE '[0-9]+$' || echo 0)
+          UNKNOWN=$(grep -oE '^Unknown \(we were refused, no claim published\): [0-9]+' /tmp/liveness.log | grep -oE '[0-9]+$' || echo 0)
+          echo "unreachable=$UNREACHABLE" >> "$GITHUB_OUTPUT"
+          echo "unknown=$UNKNOWN" >> "$GITHUB_OUTPUT"
+
+      - name: Commit and push if changed
+        env:
+          UNREACHABLE: ${{ steps.liveness.outputs.unreachable }}
+          UNKNOWN: ${{ steps.liveness.outputs.unknown }}
+        run: |
+          if git diff --quiet -- data/link_health.json; then
+            echo "No change to data/link_health.json — skipping commit."
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add data/link_health.json
+          git commit -m "data(auto): link liveness — ${UNREACHABLE} unreachable, ${UNKNOWN} could not be checked"
+          git push origin HEAD:main

--- a/data/link_health.json
+++ b/data/link_health.json
@@ -1,0 +1,554 @@
+{
+  "generated_at": "2026-08-25",
+  "links": [
+    {
+      "url": "https://cirrus-ci.org",
+      "checked": "2026-08-25",
+      "outcome": "unknown",
+      "detail": "GET EAI_AGAIN",
+      "terminal": false,
+      "last_reachable": "2026-04-12",
+      "consecutive_unreachable": 0
+    },
+    {
+      "url": "https://cloud.google.com/vertex-ai/docs/agent-builder",
+      "checked": "2026-08-25",
+      "outcome": "unreachable",
+      "detail": "GET 404",
+      "terminal": false,
+      "last_reachable": "2026-04-15",
+      "consecutive_unreachable": 1
+    },
+    {
+      "url": "https://codepen.io/",
+      "checked": "2026-08-25",
+      "outcome": "unknown",
+      "detail": "GET 403",
+      "terminal": false,
+      "last_reachable": "2026-08-18",
+      "consecutive_unreachable": 0
+    },
+    {
+      "url": "https://codesandbox.io/pricing",
+      "checked": "2026-08-25",
+      "outcome": "unknown",
+      "detail": "GET 403",
+      "terminal": false,
+      "last_reachable": "2026-04-20",
+      "consecutive_unreachable": 0
+    },
+    {
+      "url": "https://cstate.netlify.app",
+      "checked": "2026-08-25",
+      "outcome": "unreachable",
+      "detail": "GET 404",
+      "terminal": false,
+      "last_reachable": "2026-05-02",
+      "consecutive_unreachable": 1
+    },
+    {
+      "url": "https://developers.cloudflare.com/workers/runtime-apis/dynamic-workers/",
+      "checked": "2026-08-25",
+      "outcome": "unreachable",
+      "detail": "GET 404",
+      "terminal": false,
+      "last_reachable": "2026-04-14",
+      "consecutive_unreachable": 1
+    },
+    {
+      "url": "https://devin.ai/pricing",
+      "checked": "2026-08-25",
+      "outcome": "unknown",
+      "detail": "GET 429",
+      "terminal": false,
+      "last_reachable": "2026-07-25",
+      "consecutive_unreachable": 0
+    },
+    {
+      "url": "https://domain.digitalplat.org",
+      "checked": "2026-08-25",
+      "outcome": "unknown",
+      "detail": "GET 403",
+      "terminal": false,
+      "last_reachable": "2026-04-21",
+      "consecutive_unreachable": 0
+    },
+    {
+      "url": "https://duckly.com/",
+      "checked": "2026-08-25",
+      "outcome": "unknown",
+      "detail": "GET 503",
+      "terminal": false,
+      "last_reachable": "2026-08-02",
+      "consecutive_unreachable": 0
+    },
+    {
+      "url": "https://evernote.com/free",
+      "checked": "2026-08-25",
+      "outcome": "unreachable",
+      "detail": "GET 404",
+      "terminal": false,
+      "last_reachable": "2026-04-23",
+      "consecutive_unreachable": 1
+    },
+    {
+      "url": "https://freetools.site/",
+      "checked": "2026-08-25",
+      "outcome": "unknown",
+      "detail": "GET 502",
+      "terminal": false,
+      "last_reachable": "2026-07-17",
+      "consecutive_unreachable": 0
+    },
+    {
+      "url": "https://gitgud.io",
+      "checked": "2026-08-25",
+      "outcome": "unknown",
+      "detail": "GET 403",
+      "terminal": false,
+      "last_reachable": "2026-06-12",
+      "consecutive_unreachable": 0
+    },
+    {
+      "url": "https://github.com/ArcadeLabsInc/tollbooth",
+      "checked": "2026-08-25",
+      "outcome": "unreachable",
+      "detail": "GET 404",
+      "terminal": false,
+      "last_reachable": "2026-04-14",
+      "consecutive_unreachable": 1
+    },
+    {
+      "url": "https://gpu-bridge.com",
+      "checked": "2026-08-25",
+      "outcome": "unreachable",
+      "detail": "GET ENOTFOUND",
+      "terminal": false,
+      "last_reachable": "2026-04-14",
+      "consecutive_unreachable": 1
+    },
+    {
+      "url": "https://howuku.com",
+      "checked": "2026-08-25",
+      "outcome": "unknown",
+      "detail": "GET TIMEOUT",
+      "terminal": false,
+      "last_reachable": "2026-07-23",
+      "consecutive_unreachable": 0
+    },
+    {
+      "url": "https://inkscape.org",
+      "checked": "2026-08-25",
+      "outcome": "unknown",
+      "detail": "GET TIMEOUT",
+      "terminal": false,
+      "last_reachable": "2026-07-02",
+      "consecutive_unreachable": 0
+    },
+    {
+      "url": "https://labelbox.com/pricing/",
+      "checked": "2026-08-25",
+      "outcome": "unreachable",
+      "detail": "GET 404",
+      "terminal": false,
+      "last_reachable": "2026-06-09",
+      "consecutive_unreachable": 1
+    },
+    {
+      "url": "https://langtrace.ai",
+      "checked": "2026-08-25",
+      "outcome": "unreachable",
+      "detail": "GET 404",
+      "terminal": false,
+      "last_reachable": "2026-05-07",
+      "consecutive_unreachable": 1
+    },
+    {
+      "url": "https://lottiefiles.com/",
+      "checked": "2026-08-25",
+      "outcome": "unknown",
+      "detail": "GET 403",
+      "terminal": false,
+      "last_reachable": "2026-08-19",
+      "consecutive_unreachable": 0
+    },
+    {
+      "url": "https://mathworks.com/products/startups.html",
+      "checked": "2026-08-25",
+      "outcome": "unknown",
+      "detail": "GET 403",
+      "terminal": false,
+      "last_reachable": "2026-07-24",
+      "consecutive_unreachable": 0
+    },
+    {
+      "url": "https://moss.sh",
+      "checked": "2026-08-25",
+      "outcome": "unknown",
+      "detail": "GET UND_ERR_CONNECT_TIMEOUT",
+      "terminal": false,
+      "last_reachable": "2026-04-13",
+      "consecutive_unreachable": 0
+    },
+    {
+      "url": "https://namae.dev/",
+      "checked": "2026-08-25",
+      "outcome": "unknown",
+      "detail": "GET 429",
+      "terminal": false,
+      "last_reachable": "2026-04-23",
+      "consecutive_unreachable": 0
+    },
+    {
+      "url": "https://nspolygon.com",
+      "checked": "2026-08-25",
+      "outcome": "unreachable",
+      "detail": "GET ENOTFOUND",
+      "terminal": false,
+      "last_reachable": "2026-05-31",
+      "consecutive_unreachable": 1
+    },
+    {
+      "url": "https://one.google.com/ai-premium",
+      "checked": "2026-08-25",
+      "outcome": "unreachable",
+      "detail": "GET 404",
+      "terminal": false,
+      "last_reachable": "2026-04-15",
+      "consecutive_unreachable": 1
+    },
+    {
+      "url": "https://openvps.ai",
+      "checked": "2026-08-25",
+      "outcome": "unknown",
+      "detail": "GET UND_ERR_CONNECT_TIMEOUT",
+      "terminal": false,
+      "last_reachable": "2026-04-14",
+      "consecutive_unreachable": 0
+    },
+    {
+      "url": "https://ramp.com/rewards/aws",
+      "checked": "2026-08-25",
+      "outcome": "unreachable",
+      "detail": "GET 404",
+      "terminal": false,
+      "last_reachable": "2026-08-05",
+      "consecutive_unreachable": 1
+    },
+    {
+      "url": "https://run.claw.cloud",
+      "checked": "2026-08-25",
+      "outcome": "unreachable",
+      "detail": "GET ENOTFOUND",
+      "terminal": false,
+      "last_reachable": "2026-04-24",
+      "consecutive_unreachable": 1
+    },
+    {
+      "url": "https://segment.com/docs/guides/usage-and-billing/discounts-for-startups-npos/",
+      "checked": "2026-08-25",
+      "outcome": "unknown",
+      "detail": "GET 403",
+      "terminal": false,
+      "last_reachable": "2026-04-12",
+      "consecutive_unreachable": 0
+    },
+    {
+      "url": "https://soos.io",
+      "checked": "2026-08-25",
+      "outcome": "unreachable",
+      "detail": "GET 410",
+      "terminal": true,
+      "last_reachable": "2026-05-23",
+      "consecutive_unreachable": 1
+    },
+    {
+      "url": "https://strale.io",
+      "checked": "2026-08-25",
+      "outcome": "unreachable",
+      "detail": "GET 404",
+      "terminal": false,
+      "last_reachable": "2026-04-14",
+      "consecutive_unreachable": 1
+    },
+    {
+      "url": "https://testtls.com",
+      "checked": "2026-08-25",
+      "outcome": "unknown",
+      "detail": "GET 502",
+      "terminal": false,
+      "last_reachable": "2026-07-12",
+      "consecutive_unreachable": 0
+    },
+    {
+      "url": "https://todo.microsoft.com",
+      "checked": "2026-08-25",
+      "outcome": "unreachable",
+      "detail": "GET 404",
+      "terminal": false,
+      "last_reachable": "2026-04-17",
+      "consecutive_unreachable": 1
+    },
+    {
+      "url": "https://voice-clone.org/tools/audio-enhancer",
+      "checked": "2026-08-25",
+      "outcome": "unknown",
+      "detail": "GET UND_ERR_CONNECT_TIMEOUT",
+      "terminal": false,
+      "last_reachable": "2026-06-16",
+      "consecutive_unreachable": 0
+    },
+    {
+      "url": "https://volaryddns.net",
+      "checked": "2026-08-25",
+      "outcome": "unreachable",
+      "detail": "GET ENOTFOUND",
+      "terminal": false,
+      "last_reachable": "2026-07-12",
+      "consecutive_unreachable": 1
+    },
+    {
+      "url": "https://wdrfree.com/free-svg",
+      "checked": "2026-08-25",
+      "outcome": "unreachable",
+      "detail": "GET 404",
+      "terminal": false,
+      "last_reachable": "2026-06-01",
+      "consecutive_unreachable": 1
+    },
+    {
+      "url": "https://windsurf.com/pricing",
+      "checked": "2026-08-25",
+      "outcome": "unknown",
+      "detail": "GET 429",
+      "terminal": false,
+      "last_reachable": "2026-06-25",
+      "consecutive_unreachable": 0
+    },
+    {
+      "url": "https://www.autodesk.in/products/fusion-360/startups",
+      "checked": "2026-08-25",
+      "outcome": "unknown",
+      "detail": "GET 403",
+      "terminal": false,
+      "last_reachable": "2026-07-04",
+      "consecutive_unreachable": 0
+    },
+    {
+      "url": "https://www.bismuth.cloud/",
+      "checked": "2026-08-25",
+      "outcome": "unreachable",
+      "detail": "GET ENOTFOUND",
+      "terminal": false,
+      "last_reachable": "2026-07-08",
+      "consecutive_unreachable": 1
+    },
+    {
+      "url": "https://www.browsercat.com",
+      "checked": "2026-08-25",
+      "outcome": "unknown",
+      "detail": "GET 402",
+      "terminal": false,
+      "last_reachable": "2026-06-10",
+      "consecutive_unreachable": 0
+    },
+    {
+      "url": "https://www.btunnel.in/",
+      "checked": "2026-08-25",
+      "outcome": "unreachable",
+      "detail": "GET ENOTFOUND",
+      "terminal": false,
+      "last_reachable": "2026-06-15",
+      "consecutive_unreachable": 1
+    },
+    {
+      "url": "https://www.clarifai.com/pricing",
+      "checked": "2026-08-25",
+      "outcome": "unreachable",
+      "detail": "GET ENOTFOUND",
+      "terminal": false,
+      "last_reachable": "2026-07-15",
+      "consecutive_unreachable": 1
+    },
+    {
+      "url": "https://www.cmyktopantone.com/",
+      "checked": "2026-08-25",
+      "outcome": "unknown",
+      "detail": "GET 502",
+      "terminal": false,
+      "last_reachable": "2026-04-27",
+      "consecutive_unreachable": 0
+    },
+    {
+      "url": "https://www.contentful.com/pricing/",
+      "checked": "2026-08-25",
+      "outcome": "unknown",
+      "detail": "GET 429",
+      "terminal": false,
+      "last_reachable": "2026-07-25",
+      "consecutive_unreachable": 0
+    },
+    {
+      "url": "https://www.couchbase.com/products/capella/",
+      "checked": "2026-08-25",
+      "outcome": "unknown",
+      "detail": "GET 403",
+      "terminal": false,
+      "last_reachable": "2026-07-15",
+      "consecutive_unreachable": 0
+    },
+    {
+      "url": "https://www.datree.io/",
+      "checked": "2026-08-25",
+      "outcome": "unreachable",
+      "detail": "GET 404",
+      "terminal": false,
+      "last_reachable": "2026-07-10",
+      "consecutive_unreachable": 1
+    },
+    {
+      "url": "https://www.hashicorp.com/products/terraform/pricing",
+      "checked": "2026-08-25",
+      "outcome": "unknown",
+      "detail": "GET 429",
+      "terminal": false,
+      "last_reachable": "2026-04-19",
+      "consecutive_unreachable": 0
+    },
+    {
+      "url": "https://www.hashicorp.com/products/vault/pricing",
+      "checked": "2026-08-25",
+      "outcome": "unknown",
+      "detail": "GET 429",
+      "terminal": false,
+      "last_reachable": "2026-04-05",
+      "consecutive_unreachable": 0
+    },
+    {
+      "url": "https://www.ibm.com/partners/startup",
+      "checked": "2026-08-25",
+      "outcome": "unreachable",
+      "detail": "GET 404",
+      "terminal": false,
+      "last_reachable": "2026-04-05",
+      "consecutive_unreachable": 1
+    },
+    {
+      "url": "https://www.icedrive.net/",
+      "checked": "2026-08-25",
+      "outcome": "unknown",
+      "detail": "GET 403",
+      "terminal": false,
+      "last_reachable": "2026-07-15",
+      "consecutive_unreachable": 0
+    },
+    {
+      "url": "https://www.karbonsites.space",
+      "checked": "2026-08-25",
+      "outcome": "unknown",
+      "detail": "GET 502",
+      "terminal": false,
+      "last_reachable": "2026-08-04",
+      "consecutive_unreachable": 0
+    },
+    {
+      "url": "https://www.knowlarity.com/startups/",
+      "checked": "2026-08-25",
+      "outcome": "unknown",
+      "detail": "GET 502",
+      "terminal": false,
+      "last_reachable": "2026-05-09",
+      "consecutive_unreachable": 0
+    },
+    {
+      "url": "https://www.logo.dev",
+      "checked": "2026-08-25",
+      "outcome": "unknown",
+      "detail": "GET 429",
+      "terminal": false,
+      "last_reachable": "2026-07-20",
+      "consecutive_unreachable": 0
+    },
+    {
+      "url": "https://www.make.com/en/pricing",
+      "checked": "2026-08-25",
+      "outcome": "unknown",
+      "detail": "GET 403",
+      "terminal": false,
+      "last_reachable": "2026-04-19",
+      "consecutive_unreachable": 0
+    },
+    {
+      "url": "https://www.microsoft.com/en-us/microsoft-365/onedrive/compare-onedrive-plans",
+      "checked": "2026-08-25",
+      "outcome": "unknown",
+      "detail": "GET TIMEOUT",
+      "terminal": false,
+      "last_reachable": "2026-08-21",
+      "consecutive_unreachable": 0
+    },
+    {
+      "url": "https://www.microsoft.com/en-us/microsoft-teams/compare-microsoft-teams-options",
+      "checked": "2026-08-25",
+      "outcome": "unknown",
+      "detail": "GET TIMEOUT",
+      "terminal": false,
+      "last_reachable": "2026-08-19",
+      "consecutive_unreachable": 0
+    },
+    {
+      "url": "https://www.namecheap.com/domains/freedns/",
+      "checked": "2026-08-25",
+      "outcome": "unknown",
+      "detail": "GET 403",
+      "terminal": false,
+      "last_reachable": "2026-07-29",
+      "consecutive_unreachable": 0
+    },
+    {
+      "url": "https://www.namecheap.com/supersonic-cdn/#free-plan",
+      "checked": "2026-08-25",
+      "outcome": "unknown",
+      "detail": "GET 403",
+      "terminal": false,
+      "last_reachable": "2026-05-20",
+      "consecutive_unreachable": 0
+    },
+    {
+      "url": "https://www.oracle.com/cloud/free/",
+      "checked": "2026-08-25",
+      "outcome": "unknown",
+      "detail": "GET 403",
+      "terminal": false,
+      "last_reachable": "2026-08-15",
+      "consecutive_unreachable": 0
+    },
+    {
+      "url": "https://www.software.com/code-time",
+      "checked": "2026-08-25",
+      "outcome": "unreachable",
+      "detail": "GET 404",
+      "terminal": false,
+      "last_reachable": "2026-04-13",
+      "consecutive_unreachable": 1
+    },
+    {
+      "url": "https://www.vultr.com/features/advanced-networking/",
+      "checked": "2026-08-25",
+      "outcome": "unknown",
+      "detail": "GET 403",
+      "terminal": false,
+      "last_reachable": "2026-04-13",
+      "consecutive_unreachable": 0
+    },
+    {
+      "url": "https://www.webex.com/",
+      "checked": "2026-08-25",
+      "outcome": "unknown",
+      "detail": "GET 403",
+      "terminal": false,
+      "last_reachable": "2026-08-02",
+      "consecutive_unreachable": 0
+    }
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "test": "node --test --test-concurrency 1 test/**/*.test.ts",
     "lint": "tsc --noEmit",
     "check:staleness": "node scripts/check-staleness.js",
+    "check:liveness": "node scripts/check-liveness.js",
     "lint:duplicates": "node scripts/lint-duplicates.js",
     "check:pricing": "node scripts/check-pricing-changes.js",
     "monitor:pricing": "node scripts/monitor-pricing.js",

--- a/scripts/check-liveness.js
+++ b/scripts/check-liveness.js
@@ -1,0 +1,284 @@
+#!/usr/bin/env node
+
+import { readFileSync, writeFileSync, existsSync } from "node:fs";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  classifyHttpStatus,
+  classifyNetworkError,
+  isTerminalStatus,
+  LINK_GRACE_DAYS,
+} from "../dist/link-health.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const INDEX_PATH = resolve(__dirname, "..", "data", "index.json");
+const HEALTH_PATH = resolve(__dirname, "..", "data", "link_health.json");
+
+const USER_AGENT = "AgentDeals-Liveness/1.0 (+https://agentdeals.dev)";
+const FETCH_TIMEOUT_MS = 15000;
+const HOST_CONCURRENCY = 8;
+const SAME_HOST_DELAY_MS = 1200;
+
+const HELP = `Link liveness — asks whether each catalog URL still resolves, which is a
+separate and much cheaper question than whether its terms are still right.
+Runs over every record on every run, regardless of verifiedDate.
+
+Three outcomes, and the distinction between the last two is the point:
+
+  reachable    2xx or 3xx.
+  unreachable  404, 410, or a hostname that does not resolve. Evidence about
+               the destination. Past a ${LINK_GRACE_DAYS}-day grace window it suppresses the
+               risk badge and the verification date on the vendor page.
+  unknown      403, 429, 5xx, timeouts. Evidence that this checker was
+               refused, which is not evidence about the vendor. Publishes
+               nothing in either direction and changes no page.
+
+Usage:
+  node scripts/check-liveness.js                 check every record
+  node scripts/check-liveness.js --limit 50      first 50 distinct URLs
+  node scripts/check-liveness.js --dry-run       report only, write nothing
+  node scripts/check-liveness.js --report        print the delisting queue
+`;
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+function hostOf(url) {
+  try {
+    return new URL(url).host;
+  } catch {
+    return url;
+  }
+}
+
+async function request(url, method) {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+  try {
+    const res = await fetch(url, {
+      method,
+      signal: controller.signal,
+      redirect: "follow",
+      headers: { "User-Agent": USER_AGENT, Accept: "text/html,*/*" },
+    });
+    return { status: res.status };
+  } catch (err) {
+    const code = err.name === "AbortError" ? "TIMEOUT" : (err.cause?.code ?? err.code ?? "FETCH_FAILED");
+    return { errorCode: code };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+export async function checkLiveness(url) {
+  const head = await request(url, "HEAD");
+
+  if (head.status !== undefined && classifyHttpStatus(head.status) === "reachable") {
+    return { outcome: "reachable", detail: `HEAD ${head.status}`, terminal: false };
+  }
+
+  const get = await request(url, "GET");
+
+  if (get.status !== undefined) {
+    return {
+      outcome: classifyHttpStatus(get.status),
+      detail: `GET ${get.status}`,
+      terminal: isTerminalStatus(get.status),
+    };
+  }
+
+  return {
+    outcome: classifyNetworkError(get.errorCode),
+    detail: `GET ${get.errorCode}`,
+    terminal: false,
+  };
+}
+
+function collectUrls(offers) {
+  const byUrl = new Map();
+  for (const offer of offers) {
+    if (typeof offer.url !== "string" || offer.url.length === 0) continue;
+    const seen = byUrl.get(offer.url);
+    const verified = offer.verifiedDate ?? null;
+    if (!seen) {
+      byUrl.set(offer.url, { url: offer.url, latestVerified: verified, vendors: [offer.vendor] });
+      continue;
+    }
+    if (verified && (!seen.latestVerified || verified > seen.latestVerified)) seen.latestVerified = verified;
+    if (!seen.vendors.includes(offer.vendor)) seen.vendors.push(offer.vendor);
+  }
+  return [...byUrl.values()];
+}
+
+export function nextRecord(target, previous, result, today) {
+  const priorLastReachable = previous?.last_reachable ?? target.latestVerified ?? null;
+  const priorStreak = previous?.consecutive_unreachable ?? 0;
+
+  if (result.outcome === "reachable") {
+    return {
+      url: target.url,
+      checked: today,
+      outcome: "reachable",
+      detail: result.detail,
+      terminal: false,
+      last_reachable: today,
+      consecutive_unreachable: 0,
+    };
+  }
+
+  if (result.outcome === "unreachable") {
+    return {
+      url: target.url,
+      checked: today,
+      outcome: "unreachable",
+      detail: result.detail,
+      terminal: result.terminal,
+      last_reachable: priorLastReachable,
+      consecutive_unreachable: priorStreak + 1,
+    };
+  }
+
+  return {
+    url: target.url,
+    checked: today,
+    outcome: "unknown",
+    detail: result.detail,
+    terminal: previous?.terminal ?? false,
+    last_reachable: priorLastReachable,
+    consecutive_unreachable: priorStreak,
+  };
+}
+
+function loadPrevious() {
+  if (!existsSync(HEALTH_PATH)) return new Map();
+  try {
+    const parsed = JSON.parse(readFileSync(HEALTH_PATH, "utf-8"));
+    return new Map((parsed.links ?? []).map((r) => [r.url, r]));
+  } catch (err) {
+    console.error(`Existing link health index unreadable (${err.message}); starting from empty.`);
+    return new Map();
+  }
+}
+
+async function runHostQueue(targets, previous, today, onRecord) {
+  for (let i = 0; i < targets.length; i++) {
+    if (i > 0) await sleep(SAME_HOST_DELAY_MS);
+    const target = targets[i];
+    const result = await checkLiveness(target.url);
+    onRecord(nextRecord(target, previous.get(target.url), result, today));
+  }
+}
+
+function delistingQueue(records, today) {
+  const nowMs = new Date(today).getTime();
+  return records
+    .filter((r) => r.outcome === "unreachable")
+    .filter((r) => {
+      if (r.terminal) return true;
+      if (!r.last_reachable) return false;
+      const days = Math.floor((nowMs - new Date(r.last_reachable).getTime()) / 86400000);
+      return days >= LINK_GRACE_DAYS;
+    })
+    .sort((a, b) => (a.last_reachable ?? "").localeCompare(b.last_reachable ?? ""));
+}
+
+async function main() {
+  const args = process.argv.slice(2);
+  if (args.includes("--help") || args.includes("-h")) {
+    console.log(HELP);
+    process.exit(0);
+  }
+  const dryRun = args.includes("--dry-run");
+  const report = args.includes("--report");
+  const limitIdx = args.indexOf("--limit");
+  const limit = limitIdx !== -1 ? parseInt(args[limitIdx + 1], 10) : Infinity;
+
+  if (limitIdx !== -1 && (isNaN(limit) || limit < 1)) {
+    console.error(`Invalid limit: ${args[limitIdx + 1]}. Must be a positive integer.`);
+    process.exit(2);
+  }
+
+  let data;
+  try {
+    data = JSON.parse(readFileSync(INDEX_PATH, "utf-8"));
+  } catch (err) {
+    console.error(`Failed to read index: ${err.message}`);
+    process.exit(2);
+  }
+
+  const today = new Date().toISOString().split("T")[0];
+  const previous = loadPrevious();
+  const targets = collectUrls(data.offers ?? []).slice(0, limit);
+  const vendorsByUrl = new Map(targets.map((t) => [t.url, t.vendors]));
+
+  const byHost = new Map();
+  for (const target of targets) {
+    const host = hostOf(target.url);
+    if (!byHost.has(host)) byHost.set(host, []);
+    byHost.get(host).push(target);
+  }
+
+  console.log(`Link liveness — ${targets.length} distinct URLs across ${byHost.size} hosts${dryRun ? " (dry-run)" : ""}`);
+
+  const records = [];
+  const queues = [...byHost.values()];
+  let cursor = 0;
+  const workers = Array.from({ length: Math.min(HOST_CONCURRENCY, queues.length) }, async () => {
+    while (cursor < queues.length) {
+      const queue = queues[cursor++];
+      await runHostQueue(queue, previous, today, (r) => records.push(r));
+    }
+  });
+  await Promise.all(workers);
+
+  for (const record of previous.values()) {
+    if (!vendorsByUrl.has(record.url)) records.push(record);
+  }
+
+  records.sort((a, b) => a.url.localeCompare(b.url));
+
+  const counts = { reachable: 0, unreachable: 0, unknown: 0 };
+  for (const r of records) counts[r.outcome] = (counts[r.outcome] ?? 0) + 1;
+
+  const persisted = records.filter((r) => r.outcome !== "reachable");
+
+  if (!dryRun) {
+    writeFileSync(HEALTH_PATH, JSON.stringify({ generated_at: today, links: persisted }, null, 2) + "\n");
+  }
+
+  const queue = delistingQueue(records, today);
+
+  console.log("");
+  console.log("── Summary ──");
+  console.log(`Reachable:   ${counts.reachable}`);
+  console.log(`Unreachable: ${counts.unreachable}`);
+  console.log(`Unknown (we were refused, no claim published): ${counts.unknown}`);
+  console.log(`Past the ${LINK_GRACE_DAYS}-day grace window or terminal: ${queue.length}`);
+  console.log(`Written to data/link_health.json: ${persisted.length} (a link that answers needs no record)`);
+
+  if (report) {
+    console.log("");
+    console.log("── Delisting queue — confirm by hand, do not automate ──");
+    for (const r of queue) {
+      const vendors = (vendorsByUrl.get(r.url) ?? []).join(", ");
+      console.log(
+        `${r.terminal ? "TERMINAL" : "        "} ${String(r.detail).padEnd(22)} last reachable ${r.last_reachable ?? "never recorded"}  ${vendors} — ${r.url}`
+      );
+    }
+    console.log("");
+    console.log("── Could not check — these publish nothing and are not evidence ──");
+    for (const r of records.filter((x) => x.outcome === "unknown")) {
+      const vendors = (vendorsByUrl.get(r.url) ?? []).join(", ");
+      console.log(`         ${String(r.detail).padEnd(22)} ${vendors} — ${r.url}`);
+    }
+  }
+
+  process.exit(0);
+}
+
+const isMainModule = process.argv[1] && resolve(process.argv[1]) === resolve(fileURLToPath(import.meta.url));
+if (isMainModule) {
+  main().catch((err) => {
+    console.error(`Fatal error: ${err.message}`);
+    process.exit(1);
+  });
+}

--- a/scripts/reverify.js
+++ b/scripts/reverify.js
@@ -58,7 +58,7 @@ async function checkUrl(url) {
       redirect: "follow",
     });
     // Some servers reject HEAD — fall back to GET
-    if (res.status === 405 || res.status === 403) {
+    if (!res.ok) {
       clearTimeout(timeout);
       const controller2 = new AbortController();
       const timeout2 = setTimeout(() => controller2.abort(), FETCH_TIMEOUT_MS);

--- a/src/data.ts
+++ b/src/data.ts
@@ -1,9 +1,10 @@
 import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import type { Offer, EnrichedOffer, OfferIndex, DealChange, DealChangesIndex, StabilityClass, Referral, RiskCause } from "./types.js";
+import type { Offer, EnrichedOffer, OfferIndex, DealChange, DealChangesIndex, StabilityClass, Referral, RiskCause, LinkUnreachable } from "./types.js";
 import { isUrlSuspended } from "./referral-health.js";
 import { rankForListing } from "./ranking.js";
+import { unreachableNoticeForUrl, resetLinkHealthCache } from "./link-health.js";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const INDEX_PATH = path.join(__dirname, "..", "data", "index.json");
@@ -52,6 +53,7 @@ export function loadOffers(): Offer[] {
 export function resetCache(): void {
   cachedOffers = null;
   cachedChanges = null;
+  resetLinkHealthCache();
 }
 
 export function getCategories(): { name: string; count: number }[] {
@@ -362,7 +364,8 @@ export function enrichOffers(offers: Offer[]): EnrichedOffer[] {
     // vendor. The cause travels with the level so no surface can render the
     // warning without the dated fact behind it.
     const assessment = vendorRiskAssessment(vendorAllChangesList.get(key) ?? []);
-    const risk_level = assessment.level;
+    const link_unreachable = unreachableNoticeForUrl(offer.url, now.getTime());
+    const risk_level = link_unreachable && assessment.level === "stable" ? null : assessment.level;
     const risk_cause = assessment.cause
       ? { date: assessment.cause.date, change_type: assessment.cause.change_type, summary: assessment.cause.summary }
       : null;
@@ -374,7 +377,7 @@ export function enrichOffers(offers: Offer[]): EnrichedOffer[] {
       (now.getTime() - new Date(offer.verifiedDate).getTime()) / (24 * 60 * 60 * 1000)
     );
 
-    const enriched = { ...offer, recent_change, expires_soon, risk_level, risk_cause, stability, days_since_verified };
+    const enriched = { ...offer, recent_change, expires_soon, risk_level, risk_cause, stability, days_since_verified, link_unreachable };
     return stripReferrerValue(enriched);
   });
 }
@@ -563,12 +566,13 @@ export interface ComparisonResult {
 export interface VendorRiskResult {
   vendor: string;
   category: string;
-  risk_level: "stable" | "caution" | "risky";
+  risk_level: "stable" | "caution" | "risky" | null;
   /** Never null when risk_level is caution or risky (#1038). */
   risk_cause: RiskCause | null;
+  link_unreachable: LinkUnreachable | null;
   free_tier_longevity_days: number;
   changes: DealChange[];
-  alternatives: Array<{ vendor: string; category: string; tier: string; risk_level: "stable" | "caution" | "risky"; risk_cause: RiskCause | null; demerits: Array<{ code: string; points: number; reason: string }> }>;
+  alternatives: Array<{ vendor: string; category: string; tier: string; risk_level: "stable" | "caution" | "risky" | null; risk_cause: RiskCause | null; link_unreachable: LinkUnreachable | null; demerits: Array<{ code: string; points: number; reason: string }> }>;
   summary: string;
 }
 
@@ -669,6 +673,7 @@ export function checkVendorRisk(
     .sort((a, b) => b.date.localeCompare(a.date));
 
   const assessment = vendorRiskAssessment(vendorChanges);
+  const linkUnreachable = unreachableNoticeForUrl(offer.url);
   const riskLevel = assessment.level;
 
   // Free tier longevity: days since verifiedDate with no negative changes after it
@@ -695,9 +700,11 @@ export function checkVendorRisk(
     tier: e.offer.tier,
     ...(() => {
       const a = vendorRiskAssessment(allChanges.filter((c) => c.vendor.toLowerCase() === e.offer.vendor.toLowerCase()));
+      const unreachable = unreachableNoticeForUrl(e.offer.url);
       return {
-        risk_level: a.level,
+        risk_level: unreachable && a.level === "stable" ? null : a.level,
         risk_cause: a.cause ? { date: a.cause.date, change_type: a.cause.change_type, summary: a.cause.summary } : null,
+        link_unreachable: unreachable,
       };
     })(),
     demerits: e.demerits.map((d) => ({ code: d.code, points: d.points, reason: d.reason })),
@@ -708,10 +715,15 @@ export function checkVendorRisk(
   // and a warning without its reason is an assertion.
   let summary: string;
   const cause = assessment.cause;
+  const unreachableClause = linkUnreachable
+    ? ` Its pricing page has not resolved for us${linkUnreachable.last_reachable ? ` since ${linkUnreachable.last_reachable}` : ""}, so we cannot confirm its current terms.`
+    : "";
   if (riskLevel === "risky" && cause) {
-    summary = `${offer.vendor} is high risk — ${cause.date}: ${cause.summary} Consider alternatives.`;
+    summary = `${offer.vendor} is high risk — ${cause.date}: ${cause.summary} Consider alternatives.${unreachableClause}`;
   } else if (riskLevel === "caution" && cause) {
-    summary = `${offer.vendor} warrants caution — ${cause.date}: ${cause.summary} Monitor for further changes.`;
+    summary = `${offer.vendor} warrants caution — ${cause.date}: ${cause.summary} Monitor for further changes.${unreachableClause}`;
+  } else if (linkUnreachable) {
+    summary = `We hold no free tier removal, limit reduction or pricing restructure on record for ${offer.vendor}.${unreachableClause} Treat that as a statement about our records, not as a stable pricing history.`;
   } else {
     summary = `${offer.vendor} has a stable pricing history with no free tier removal, limit reduction or pricing restructure on record. Free tier verified for ${longevityDays} days.`;
   }
@@ -720,8 +732,9 @@ export function checkVendorRisk(
     result: {
       vendor: offer.vendor,
       category: offer.category,
-      risk_level: riskLevel,
+      risk_level: linkUnreachable && riskLevel === "stable" ? null : riskLevel,
       risk_cause: cause ? { date: cause.date, change_type: cause.change_type, summary: cause.summary } : null,
+      link_unreachable: linkUnreachable,
       free_tier_longevity_days: longevityDays,
       changes: vendorChanges,
       alternatives,

--- a/src/link-health.ts
+++ b/src/link-health.ts
@@ -1,0 +1,118 @@
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import type { LinkUnreachable } from "./types.js";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+function linkHealthPath(): string {
+  return process.env.AGENTDEALS_LINK_HEALTH_PATH || path.join(__dirname, "..", "data", "link_health.json");
+}
+
+export type LivenessOutcome = "reachable" | "unreachable" | "unknown";
+
+export const LINK_GRACE_DAYS = 14;
+
+const STATUS_UNREACHABLE = new Set([404, 410]);
+
+const NETWORK_ERROR_UNREACHABLE = new Set(["ENOTFOUND"]);
+
+export interface LinkCheckRecord {
+  url: string;
+  checked: string;
+  outcome: LivenessOutcome;
+  detail: string;
+  terminal: boolean;
+  last_reachable: string | null;
+  consecutive_unreachable: number;
+}
+
+export interface LinkHealthIndex {
+  generated_at: string;
+  links: LinkCheckRecord[];
+}
+
+export function classifyHttpStatus(status: number): LivenessOutcome {
+  if (status >= 200 && status < 400) return "reachable";
+  if (STATUS_UNREACHABLE.has(status)) return "unreachable";
+  return "unknown";
+}
+
+export function classifyNetworkError(code: string | undefined): LivenessOutcome {
+  if (code && NETWORK_ERROR_UNREACHABLE.has(code)) return "unreachable";
+  return "unknown";
+}
+
+export function isTerminalStatus(status: number): boolean {
+  return status === 410;
+}
+
+let cachedLinkHealth: Map<string, LinkCheckRecord> | null = null;
+
+export function resetLinkHealthCache(): void {
+  cachedLinkHealth = null;
+}
+
+export function loadLinkHealth(): Map<string, LinkCheckRecord> {
+  if (cachedLinkHealth) return cachedLinkHealth;
+
+  const empty = new Map<string, LinkCheckRecord>();
+  const sourcePath = linkHealthPath();
+
+  if (!fs.existsSync(sourcePath)) {
+    cachedLinkHealth = empty;
+    return cachedLinkHealth;
+  }
+
+  let parsed: LinkHealthIndex;
+  try {
+    parsed = JSON.parse(fs.readFileSync(sourcePath, "utf-8"));
+  } catch (err) {
+    console.error(`Link health index unreadable, treating every link as unchecked: ${err}`);
+    cachedLinkHealth = empty;
+    return cachedLinkHealth;
+  }
+
+  if (!parsed || !Array.isArray(parsed.links)) {
+    console.error("Link health index is missing 'links', treating every link as unchecked");
+    cachedLinkHealth = empty;
+    return cachedLinkHealth;
+  }
+
+  const map = new Map<string, LinkCheckRecord>();
+  for (const record of parsed.links) {
+    if (record && typeof record.url === "string") map.set(record.url, record);
+  }
+  cachedLinkHealth = map;
+  return cachedLinkHealth;
+}
+
+export function unreachableNotice(
+  record: LinkCheckRecord | undefined,
+  nowMs: number = Date.now(),
+  graceDays: number = LINK_GRACE_DAYS
+): LinkUnreachable | null {
+  if (!record) return null;
+  if (record.outcome !== "unreachable") return null;
+
+  if (!record.terminal) {
+    if (!record.last_reachable) return null;
+    const elapsedDays = Math.floor(
+      (nowMs - new Date(record.last_reachable).getTime()) / (24 * 60 * 60 * 1000)
+    );
+    if (!Number.isFinite(elapsedDays) || elapsedDays < graceDays) return null;
+  }
+
+  return {
+    last_reachable: record.last_reachable,
+    checked: record.checked,
+    terminal: record.terminal,
+  };
+}
+
+export function unreachableNoticeForUrl(
+  url: string,
+  nowMs: number = Date.now()
+): LinkUnreachable | null {
+  return unreachableNotice(loadLinkHealth().get(url), nowMs);
+}

--- a/src/openapi.ts
+++ b/src/openapi.ts
@@ -372,7 +372,8 @@ export const openapiSpec = {
                   properties: {
                     vendor: { type: "string" },
                     category: { type: "string" },
-                    risk_level: { type: "string", enum: ["stable", "caution", "risky"] },
+                    risk_level: { type: "string", enum: ["stable", "caution", "risky"], nullable: true, description: "Null where the offer's own link is confirmed unreachable (#1046) — we withhold the level rather than publish a favourable one we cannot check." },
+                    link_unreachable: { type: "object", nullable: true, description: "Non-null only where a check reached a conclusion about the destination: a 404 confirmed by a full request, a 410, or a hostname with no address. Being refused (403, 429, 5xx, timeout) is evidence about our checker and never produces one of these.", properties: { last_reachable: { type: "string", format: "date", nullable: true }, checked: { type: "string", format: "date" }, terminal: { type: "boolean" } } },
                     risk_cause: { type: "object", nullable: true, description: "The single dated record that produced a non-stable risk_level. Never null when risk_level is caution or risky (#1038) — a client that renders the level must be able to render the reason.", properties: { date: { type: "string" }, change_type: { type: "string" }, summary: { type: "string" } } },
                     free_tier_longevity_days: { type: "number" },
                     changes: { type: "array", items: { $ref: "#/components/schemas/DealChange" } },
@@ -384,7 +385,8 @@ export const openapiSpec = {
                           vendor: { type: "string" },
                           category: { type: "string" },
                           tier: { type: "string" },
-                          risk_level: { type: "string", enum: ["stable", "caution", "risky"] },
+                          risk_level: { type: "string", enum: ["stable", "caution", "risky"], nullable: true, description: "Null where this alternative's own link is confirmed unreachable (#1046)." },
+                          link_unreachable: { type: "object", nullable: true, properties: { last_reachable: { type: "string", format: "date", nullable: true }, checked: { type: "string", format: "date" }, terminal: { type: "boolean" } } },
                           risk_cause: { type: "object", nullable: true, description: "The single dated record that produced a non-stable risk_level. Never null when risk_level is caution or risky (#1038) — a client that renders the level must be able to render the reason.", properties: { date: { type: "string" }, change_type: { type: "string" }, summary: { type: "string" } } }
                         }
                       }

--- a/src/serve.ts
+++ b/src/serve.ts
@@ -13,6 +13,7 @@ import { acceptSignal, ackMissing, checkRateLimit, clientAddress, RATE_LIMIT_PER
 import { agentBlock, CONVERTED_CAVEAT, DEFERENCE, PRIVACY_SCOPE, signalHeaderValue, signalHtmlBlock, signalLlmsSection, SIGNAL_HEADER_NAME } from "./signal-copy.js";
 import { recordApiHit, recordSessionConnect, recordSessionDisconnect, recordLandingPageView, getStats, getConnectionStats, loadTelemetry, flushTelemetry, flushPending, FLUSH_INTERVAL_SECONDS, logRequest, getPublicRequestLogResult, getTelemetryHealth, recordPageView, getPageViews, recordReferralListingCall, recordReferralVendorLookup, getReferralMarketplaceStats, getSessionClassification, recordSearchQuery, getSearchAnalytics, getApiHitsByEndpoint, recordTraffic, getTrafficReport, getSignalReport, SIGNAL_MIN_SAMPLE, SIGNAL_DENOMINATOR_ROUTES } from "./stats.js";
 import { openapiSpec } from "./openapi.js";
+import { LINK_GRACE_DAYS } from "./link-health.js";
 import { registerAgent, authenticateRequest, validateVestauthUrl, hashApiKey, updateAgentX402Address, getAgentById } from "./agents.js";
 import { logReferralRequest } from "./referral-requests.js";
 import { recordConversion, confirmEligibleEntries, clawbackEntry, getAgentBalance, getAgentLedgerEntries, recordPayout, MINIMUM_PAYOUT_AMOUNT, getLeaderboard } from "./ledger.js";
@@ -25,7 +26,7 @@ import { subscribe as watchlistSubscribe, getSubscription as getWatchlistSubscri
 import { toSlug, vendorSlugMap, resolveVendorSlug } from "./vendor-slug.js";
 import { rankOffers, rankForListing, rotateListing, utcDate, CRITERIA_PATH, DEMOTE_ONLY_POLICY, DISCLOSURE_RATIONALE, TIE_BREAK_ALGORITHM, GATE_TABLE, DEMERIT_TABLE, NOT_FREE_TIER_RULES, TIME_LIMITED_TIER_RULES } from "./ranking.js";
 import type { RankedEntry, RankingResult } from "./ranking.js";
-import type { Agent, RiskCause } from "./types.js";
+import type { Agent, RiskCause, LinkUnreachable } from "./types.js";
 import type { AgentBalance } from "./ledger.js";
 import type { SubmittedReferralCode } from "./referral-codes.js";
 
@@ -306,8 +307,18 @@ function riskBadgeHtml(
   return `${badge} <span style="font-size:${size};color:var(--text-dim)" title="${escHtmlServer(cause.summary)}">${escHtmlServer(riskCauseLabel(cause))}</span>`;
 }
 
+function stabilityCellHtml(stability: string, linkUnreachable: LinkUnreachable | null | undefined): string {
+  if (linkUnreachable) {
+    const since = linkUnreachable.last_reachable ? ` since ${linkUnreachable.last_reachable}` : "";
+    return `<span style="color:var(--text-dim)" title="Link has not resolved${escHtmlServer(since)}">link unreachable</span>`;
+  }
+  const color = STABILITY_COLORS[stability] ?? "#8b949e";
+  return `<span class="stability-dot" style="background:${color}"></span> ${escHtmlServer(stability)}`;
+}
+
 /** Table-cell form of the same rule: the level, and under it the dated cause. */
 function riskCellHtml(level: string | null | undefined, cause: RiskCause | null | undefined): string {
+  if (level === null) return `<span style="color:var(--text-dim)">&mdash;</span>`;
   const resolved = level ?? "stable";
   // A level with no cause is neither publishable as a warning nor rewritable
   // into "stable" — that would be a positive claim we also cannot back.
@@ -1775,6 +1786,11 @@ ${demeritRows}
   <p>Vendor pages carry a <code>stable</code> / <code>caution</code> / <code>risky</code> label. <strong style="color:var(--text)">It moves no order on this site</strong> &mdash; the ranking module cannot read it, and flipping every label leaves every listing we publish in the same order.</p>
   <p>It is decided by the <em>type</em> of a recorded change, never by how many records we hold. A vendor that expanded its free tier, postponed a fee, added a tier or changed its name cannot be labelled <code>caution</code> for any of those. <strong style="color:var(--text)">A <code>caution</code> or <code>risky</code> label always renders together with the single dated record that produced it, on the same page and next to the label. Where we cannot show the reason, we do not show the label.</strong></p>
   <p>The honest limit: <code>stable</code> means we hold no record of a free tier removal, a limit reduction or a pricing restructure for that vendor. It is a statement about our records, not a clean bill of health &mdash; a vendor we have never had cause to examine reads the same as one with a long clean history. Until August 2026 the label was derived from a count of records of any type, which inverted that: the vendors we watched most closely were the ones it flagged, and several were flagged for good news. That is fixed, and this paragraph is here so the next version of it is checkable.</p>
+
+  <h3>What we publish when the link itself stops resolving</h3>
+  <p>Verification asks whether an offer's terms are still right. A separate daily check asks the cheaper question of whether its link still resolves at all, and it runs over every record regardless of how recently that record was verified.</p>
+  <p><strong style="color:var(--text)">Where the link has not resolved for ${LINK_GRACE_DAYS} days, or the server has answered <code>410 Gone</code>, we withhold the <code>stable</code> label and the verification date and publish the date the link was last reachable instead.</strong> A green label and a recent date over a destination that no longer answers is the most confident-looking thing on the page and the least true. A vendor is allowed an outage, which is what the ${LINK_GRACE_DAYS} days are for.</p>
+  <p>The distinction that does the work: <strong style="color:var(--text)">being refused is not evidence about a vendor.</strong> A <code>403</code>, a <code>429</code>, a gateway error or a timeout tells you that our checker was turned away from a datacentre address, and it changes nothing we publish in either direction &mdash; we do not withhold the label, and we do not claim the link is dead. Only an answer about the destination counts: <code>404</code> confirmed by a full request, <code>410</code>, or a hostname with no address. This is the same rule as <code>stale_verification</code> above and the risk label before it, and it keeps arriving because each surface used to implement its own version.</p>
 
   <h2>3. Ties, and why there is no top slot to sell</h2>
   <div class="callout">
@@ -3667,6 +3683,14 @@ function buildVendorPage(slug: string): string | null {
     ? `  <p class="risk-cause-line" style="margin:.4rem 0 .6rem;font-size:.9rem;color:var(--text-muted)"><strong style="color:${riskColor}">Why ${riskLevel}:</strong> <span class="risk-cause-date" style="font-family:var(--mono)">${escHtmlServer(riskCause.date)}</span> &mdash; ${escHtmlServer(riskCause.summary)} <a href="#changes" style="white-space:nowrap">Full history &darr;</a></p>`
     : "";
 
+  const linkUnreachable = enriched.link_unreachable;
+  const h1RiskBadge = enriched.risk_level === null || (linkUnreachable && riskLevel === "stable")
+    ? ""
+    : ` <span class="risk-badge" style="background:${riskColor}20;color:${riskColor};border:1px solid ${riskColor}40">${riskLevel}</span>`;
+  const linkUnreachableLine = linkUnreachable
+    ? `  <p class="link-unreachable-line" style="margin:.4rem 0 .6rem;font-size:.9rem;color:var(--text-muted)"><strong style="color:#f85149">Link unreachable:</strong> ${escHtmlServer(primary.url)} did not resolve on our check of <span class="link-checked-date" style="font-family:var(--mono)">${escHtmlServer(linkUnreachable.checked)}</span>. ${linkUnreachable.last_reachable ? `Last reachable <span class="link-last-reachable" style="font-family:var(--mono)">${escHtmlServer(linkUnreachable.last_reachable)}</span>.` : "We have no date on which it was reachable."}</p>`
+    : "";
+
   // Alternatives: other vendors in the same primary category
   // "Alternatives to X" is a recommendation, so it goes through the shared
   // module. It used to be `.slice(0, 12)` over raw file order — whoever was
@@ -3689,18 +3713,24 @@ function buildVendorPage(slug: string): string | null {
     : `${vendorName} Pricing ${currentYear}: Plans, Costs & Free Alternatives | AgentDeals`;
   const descLimits = primary.description.slice(0, 100).replace(/\.\s.*$/, "");
   const verifiedMonth = (() => { const d = primary.verifiedDate.split("-"); const months = ["January","February","March","April","May","June","July","August","September","October","November","December"]; return `${months[parseInt(d[1],10)-1]} ${d[0]}`; })();
+  const verifiedSentence = enriched.link_unreachable ? "" : ` Verified ${verifiedMonth}.`;
   const metaDesc = hasFree
-    ? `${vendorName} free tier includes ${descLimits}. Verified ${verifiedMonth}. Compare with ${alternatives.length} alternatives in ${primary.category}.`
-    : `${vendorName} pricing details and ${alternatives.length} free alternatives in ${primary.category}. Verified ${verifiedMonth}.`;
+    ? `${vendorName} free tier includes ${descLimits}.${verifiedSentence} Compare with ${alternatives.length} alternatives in ${primary.category}.`
+    : `${vendorName} pricing details and ${alternatives.length} free alternatives in ${primary.category}.${verifiedSentence}`;
 
   // --- NEW: Quick Verdict ---
   const stabilityLabel: Record<string, string> = { stable: "stable", watch: "on our watch list", volatile: "volatile", improving: "improving" };
   const stabilityText = stabilityLabel[stability] || "stable";
   const keyLimit = primary.description.slice(0, 120).replace(/\.\s.*$/, "");
-  const verdictLine2 = vendorChanges.length === 0
+  const unconfirmableSince = linkUnreachable
+    ? (linkUnreachable.last_reachable ? ` since ${linkUnreachable.last_reachable}` : "")
+    : "";
+  const verdictLine2 = linkUnreachable
+    ? `Its pricing page has not resolved for us${unconfirmableSince}, so we cannot confirm these terms today.`
+    : vendorChanges.length === 0
     ? `It's ${stabilityText} — zero pricing changes recorded.`
     : `It's ${stabilityText} — ${vendorChanges.length} pricing change${vendorChanges.length > 1 ? "s" : ""} recorded.`;
-  const verdictLine3 = alternatives.length > 0
+  const verdictLine3 = alternatives.length > 0 && !linkUnreachable
     ? `Best for ${primary.category.toLowerCase()} workloads${alternatives.length >= 5 ? ` — ${alternatives.length} alternatives available` : ""}.`
     : "";
   const quickVerdictHtml = `
@@ -3770,15 +3800,13 @@ function buildVendorPage(slug: string): string | null {
           <tr class="current-vendor-row">
             <td><strong>${escHtmlServer(vendorName)}</strong></td>
             <td>${escHtmlServer(primary.tier)}</td>
-            <td><span class="stability-dot" style="background:${STABILITY_COLORS[stability] ?? "#8b949e"}"></span> ${escHtmlServer(stability)}</td>
+            <td>${stabilityCellHtml(stability, linkUnreachable)}</td>
           </tr>
 ${enrichedAlts.map(a => {
-  const aStability = a.stability ?? "stable";
-  const aColor = STABILITY_COLORS[aStability] ?? "#8b949e";
   return `          <tr>
             <td><a href="/vendor/${toSlug(a.vendor)}">${escHtmlServer(a.vendor)}</a></td>
             <td>${escHtmlServer(a.tier)}</td>
-            <td><span class="stability-dot" style="background:${aColor}"></span> ${escHtmlServer(aStability)}</td>
+            <td>${stabilityCellHtml(a.stability ?? "stable", a.link_unreachable)}</td>
           </tr>`;
 }).join("\n")}
         </tbody>
@@ -4012,7 +4040,9 @@ ${allCompareLinks.join("\n")}
   // type — so a vendor could be told it "requires caution" and then handed a
   // free-tier expansion as the evidence. They now quote the record that
   // produced the level, and nothing else.
-  const faqReliableAnswer = riskLevel === "stable"
+  const faqReliableAnswer = linkUnreachable
+    ? `We cannot say. ${vendorName}'s pricing page has not resolved for us${unconfirmableSince}, so we are not publishing a stability judgement for this vendor until it does.`
+    : riskLevel === "stable"
     ? `${vendorName}'s free tier is considered stable: we hold no free tier removal, limit reduction or pricing restructure on record for this vendor.${vendorChanges.length > 0 ? ` We do hold ${vendorChanges.length === 1 ? "1 other recorded change" : `${vendorChanges.length} other recorded changes`} — see the pricing history below.` : ""}`
     : riskLevel === "caution"
     ? `${vendorName}'s free tier requires caution because of one specific recorded change${riskCause ? `, on ${riskCause.date}: ${riskCause.summary}` : "."}`
@@ -4020,13 +4050,17 @@ ${allCompareLinks.join("\n")}
   const faqCategoryAnswer = `${vendorName} is categorized under ${allCategories.join(", ")} on AgentDeals.${alternatives.length > 0 ? ` Other vendors in ${primary.category} include ${alternatives.slice(0, 5).map(a => a.vendor).join(", ")}.` : ""}`;
 
   // NEW: Additional FAQ items
-  const faqProductionAnswer = hasFree
+  const faqProductionAnswer = linkUnreachable
+    ? `${vendorName}'s pricing page has not resolved for us${unconfirmableSince}. We cannot confirm what its free tier offers today, so we are not recommending it for production or for anything else until we can.`
+    : hasFree
     ? (riskLevel === "stable"
       ? `${vendorName}'s free tier can be suitable for small production workloads and side projects. With ${stabilityText} pricing and ${escHtmlServer(keyLimit)}, it's a reasonable starting point. Monitor your usage against the limits and have an upgrade plan ready.`
       : `${vendorName}'s free tier is usable for prototyping and development, but exercise caution for production workloads given its ${stabilityText} pricing history. Consider alternatives with more stable pricing for critical services.`)
     : `${vendorName} does not offer a free tier for production use. Consider free alternatives in ${primary.category}.`;
   const faqChangedAnswer = vendorChanges.length > 0
     ? `Yes, ${vendorName} has had ${vendorChanges.length} recorded pricing change${vendorChanges.length > 1 ? "s" : ""}. Most recently: ${vendorChanges[0].summary} (${vendorChanges[0].date}).`
+    : linkUnreachable
+    ? `We hold no recorded pricing changes for ${vendorName}, but its pricing page has not resolved for us${unconfirmableSince}, so that is a statement about our records rather than a positive signal.`
     : `No, ${vendorName} has had no recorded pricing changes. This is a positive stability signal.`;
   const faqAlternativesAnswer = alternatives.length > 0
     ? `The top free alternatives to ${vendorName} in ${primary.category} include ${alternatives.slice(0, 5).map(a => `${a.vendor} (${a.tier})`).join(", ")}. See all ${alternatives.length} alternatives above.`
@@ -4161,9 +4195,10 @@ ${mcpCtaCss()}
 <div class="container">
   ${buildGlobalNav("categories")}
   <div class="breadcrumb"><a href="/">AgentDeals</a> &rsaquo; <a href="/vendor">Vendors</a> &rsaquo; ${escHtmlServer(vendorName)}</div>
-  <h1>${escHtmlServer(vendorName)} Free Tier ${currentYear} <span class="risk-badge" style="background:${riskColor}20;color:${riskColor};border:1px solid ${riskColor}40">${riskLevel}</span></h1>
+  <h1>${escHtmlServer(vendorName)} Free Tier ${currentYear}${h1RiskBadge}</h1>
 ${riskCauseLine}
-  <p class="page-meta">Limits, pricing history, and ${alternatives.length} alternatives. Verified ${verifiedMonth}. Last updated ${escHtmlServer(lastUpdated)}.</p>
+${linkUnreachableLine}
+  <p class="page-meta">Limits, pricing history, and ${alternatives.length} alternatives.${verifiedSentence} Last updated ${escHtmlServer(lastUpdated)}.</p>
 ${quickVerdictHtml}
 ${categoryContextHtml}
 ${changeNoticeHtml}
@@ -4185,8 +4220,8 @@ ${referralCalloutHtml}
       <div class="detail-value"><a href="${escHtmlServer(primary.url)}" rel="noopener" target="_blank">Visit &rarr;</a></div>
     </div>
     <div class="detail-card">
-      <div class="detail-label">Verified</div>
-      <div class="detail-value" style="font-family:var(--mono)">${escHtmlServer(primary.verifiedDate)}</div>
+      <div class="detail-label">${linkUnreachable ? "Link last reachable" : "Verified"}</div>
+      <div class="detail-value" style="font-family:var(--mono)">${escHtmlServer(linkUnreachable ? (linkUnreachable.last_reachable ?? "no reachable date on record") : primary.verifiedDate)}</div>
     </div>
   </div>
 
@@ -4335,7 +4370,7 @@ function buildAlternativesPage(slug: string): string | null {
         <div class="alt-tier">${escHtmlServer(a.tier)}</div>
         <div class="alt-meta">
           <span class="alt-category">${escHtmlServer(a.category)}</span>
-          <span class="alt-date">Verified ${a.verifiedDate}</span>
+          <span class="alt-date">${a.link_unreachable ? `Link unreachable${a.link_unreachable.last_reachable ? ` since ${escHtmlServer(a.link_unreachable.last_reachable)}` : ""}` : `Verified ${a.verifiedDate}`}</span>
         </div>
         <div class="alt-actions">
           <a href="/vendor/${aSlug}" class="action-link">Profile</a>
@@ -4395,7 +4430,7 @@ ${enrichedAlts.map(a => altCard(a, false)).join("\n")}
   };
 
   // FAQ data for alternative-to pages
-  const topStableAlts = enrichedAlts.filter(a => (a.risk_level ?? "stable") === "stable").slice(0, 5);
+  const topStableAlts = enrichedAlts.filter(a => a.risk_level === "stable").slice(0, 5);
   const faqBestAltsAnswer = topStableAlts.length > 0
     ? `The best free alternatives to ${vendorName} include ${topStableAlts.map(a => `${a.vendor} (${a.tier})`).join(", ")}. We hold no free tier removal, limit reduction or pricing restructure on record for any of them.`
     : `There are ${enrichedAlts.length} free alternatives to ${vendorName} available. ${enrichedAlts.slice(0, 3).map(a => a.vendor).join(", ")} are among the options.`;

--- a/src/types.ts
+++ b/src/types.ts
@@ -68,6 +68,12 @@ export interface RiskCause {
   summary: string;
 }
 
+export interface LinkUnreachable {
+  last_reachable: string | null;
+  checked: string;
+  terminal: boolean;
+}
+
 export interface EnrichedOffer extends Offer {
   recent_change: string | null;
   expires_soon: string | null;
@@ -76,6 +82,7 @@ export interface EnrichedOffer extends Offer {
   risk_cause: RiskCause | null;
   stability: StabilityClass;
   days_since_verified: number;
+  link_unreachable: LinkUnreachable | null;
 }
 
 export interface OfferIndex {

--- a/test/enrich.test.ts
+++ b/test/enrich.test.ts
@@ -114,8 +114,15 @@ describe("enrichOffers", () => {
   it("never publishes a risk level it cannot name a cause for", async () => {
     const { enrichOffers, loadOffers } = await import("../dist/data.js");
     const enriched = enrichOffers(loadOffers());
-    const uncaused = enriched.filter((o: { risk_level: string | null; risk_cause: unknown }) => o.risk_level !== "stable" && !o.risk_cause);
+    const uncaused = enriched.filter((o: { risk_level: string | null; risk_cause: unknown }) => o.risk_level && o.risk_level !== "stable" && !o.risk_cause);
     assert.strictEqual(uncaused.length, 0, `${uncaused.length} offers carry a warning with no cause`);
+  });
+
+  it("withholds a level only where the link is confirmed unreachable, never for any other reason", async () => {
+    const { enrichOffers, loadOffers } = await import("../dist/data.js");
+    const withheld = enrichOffers(loadOffers()).filter((o: { risk_level: string | null }) => o.risk_level === null);
+    const unexplained = withheld.filter((o: { link_unreachable: unknown }) => !o.link_unreachable);
+    assert.strictEqual(unexplained.length, 0, `${unexplained.length} offers publish no level and no reason for withholding it`);
   });
 
   it("preserves original offer fields in enriched result", async () => {

--- a/test/link-liveness-checker.test.ts
+++ b/test/link-liveness-checker.test.ts
@@ -1,0 +1,130 @@
+import { describe, it, before, after } from "node:test";
+import assert from "node:assert";
+import http from "node:http";
+import type { AddressInfo } from "node:net";
+import { checkLiveness, nextRecord } from "../scripts/check-liveness.js";
+import { reverifyBatch } from "../scripts/reverify.js";
+
+let server: http.Server;
+let base = "";
+
+before(async () => {
+  server = http.createServer((req, res) => {
+    const path = req.url ?? "/";
+    if (path === "/head-404-get-200") {
+      res.writeHead(req.method === "HEAD" ? 404 : 200).end();
+      return;
+    }
+    if (path === "/head-502-get-200") {
+      res.writeHead(req.method === "HEAD" ? 502 : 200).end();
+      return;
+    }
+    if (path === "/gone") {
+      res.writeHead(410).end();
+      return;
+    }
+    if (path === "/missing") {
+      res.writeHead(404).end();
+      return;
+    }
+    if (path === "/refused") {
+      res.writeHead(403).end();
+      return;
+    }
+    if (path === "/rate-limited") {
+      res.writeHead(429).end();
+      return;
+    }
+    res.writeHead(200).end();
+  });
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  base = `http://127.0.0.1:${(server.address() as AddressInfo).port}`;
+});
+
+after(async () => {
+  await new Promise<void>((resolve) => server.close(() => resolve()));
+});
+
+describe("#1046 a non-2xx HEAD is not evidence until GET has been asked", () => {
+  it("calls a host that answers HEAD with 404 and GET with 200 reachable", async () => {
+    const result = await checkLiveness(`${base}/head-404-get-200`);
+    assert.equal(result.outcome, "reachable");
+    assert.equal(result.detail, "GET 200");
+  });
+
+  it("calls a host that answers HEAD with 502 and GET with 200 reachable", async () => {
+    const result = await checkLiveness(`${base}/head-502-get-200`);
+    assert.equal(result.outcome, "reachable");
+  });
+
+  it("reaches the same verdict through the re-verifier, which shares the fallback", async () => {
+    const entries = [
+      { index: 0, offer: { vendor: "Head404", url: `${base}/head-404-get-200`, category: "Test" } },
+      { index: 1, offer: { vendor: "Missing", url: `${base}/missing`, category: "Test" } },
+    ];
+    const results = await reverifyBatch(entries);
+    assert.deepEqual(results.verified.map((v: { vendor: string }) => v.vendor), ["Head404"]);
+    assert.deepEqual(results.flagged.map((f: { vendor: string }) => f.vendor), ["Missing"]);
+  });
+
+  it("confirms a 404 with GET before calling it unreachable", async () => {
+    const result = await checkLiveness(`${base}/missing`);
+    assert.equal(result.outcome, "unreachable");
+    assert.equal(result.detail, "GET 404");
+    assert.equal(result.terminal, false);
+  });
+
+  it("marks a 410 terminal", async () => {
+    const result = await checkLiveness(`${base}/gone`);
+    assert.equal(result.outcome, "unreachable");
+    assert.equal(result.terminal, true);
+  });
+
+  it("records being refused as unknown, not as a dead link", async () => {
+    assert.equal((await checkLiveness(`${base}/refused`)).outcome, "unknown");
+    assert.equal((await checkLiveness(`${base}/rate-limited`)).outcome, "unknown");
+  });
+
+  it("records a hostname that does not resolve as unreachable", async () => {
+    const result = await checkLiveness("https://this-name-does-not-resolve.invalid/pricing");
+    assert.equal(result.outcome, "unreachable");
+    assert.match(result.detail, /ENOTFOUND/);
+  });
+});
+
+describe("#1046 how a check updates a link's history", () => {
+  const target = { url: "https://example.test/pricing", latestVerified: "2026-05-23", vendors: ["Example"] };
+
+  it("seeds last reachable from the record's verification date the first time a link fails", () => {
+    const next = nextRecord(target, undefined, { outcome: "unreachable", detail: "GET 404", terminal: false }, "2026-08-25");
+    assert.equal(next.last_reachable, "2026-05-23");
+    assert.equal(next.consecutive_unreachable, 1);
+  });
+
+  it("advances last reachable to today whenever the link answers", () => {
+    const next = nextRecord(target, undefined, { outcome: "reachable", detail: "HEAD 200", terminal: false }, "2026-08-25");
+    assert.equal(next.last_reachable, "2026-08-25");
+    assert.equal(next.consecutive_unreachable, 0);
+  });
+
+  it("clears a failure streak as soon as the link answers again", () => {
+    const previous = { url: target.url, checked: "2026-08-24", outcome: "unreachable" as const, detail: "GET 404", terminal: false, last_reachable: "2026-05-23", consecutive_unreachable: 9 };
+    const next = nextRecord(target, previous, { outcome: "reachable", detail: "GET 200", terminal: false }, "2026-08-25");
+    assert.equal(next.consecutive_unreachable, 0);
+    assert.equal(next.last_reachable, "2026-08-25");
+  });
+
+  it("leaves the history untouched when we could not check, so being refused never ages a link toward delisting", () => {
+    const previous = { url: target.url, checked: "2026-08-24", outcome: "unreachable" as const, detail: "GET 404", terminal: false, last_reachable: "2026-05-23", consecutive_unreachable: 3 };
+    const next = nextRecord(target, previous, { outcome: "unknown", detail: "GET 403", terminal: false }, "2026-08-25");
+    assert.equal(next.outcome, "unknown");
+    assert.equal(next.consecutive_unreachable, 3);
+    assert.equal(next.last_reachable, "2026-05-23");
+  });
+
+  it("does not let a refusal reset a link that a server has already said is gone", () => {
+    const previous = { url: target.url, checked: "2026-08-24", outcome: "unreachable" as const, detail: "GET 410", terminal: true, last_reachable: "2026-05-23", consecutive_unreachable: 3 };
+    const next = nextRecord(target, previous, { outcome: "unknown", detail: "GET 429", terminal: false }, "2026-08-25");
+    assert.equal(next.terminal, true);
+  });
+});

--- a/test/link-liveness-pages.test.ts
+++ b/test/link-liveness-pages.test.ts
@@ -1,0 +1,192 @@
+import { describe, it, before, after } from "node:test";
+import assert from "node:assert";
+import { spawn, type ChildProcess } from "node:child_process";
+import { readFileSync, writeFileSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO = path.join(__dirname, "..");
+
+type Offer = { vendor: string; url: string; verifiedDate: string };
+
+function slugOf(vendor: string): string {
+  return vendor.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "");
+}
+
+const offers: Offer[] = JSON.parse(readFileSync(path.join(REPO, "data", "index.json"), "utf-8")).offers;
+const changed = new Set<string>(
+  JSON.parse(readFileSync(path.join(REPO, "data", "deal_changes.json"), "utf-8")).changes.map(
+    (c: { vendor: string }) => c.vendor.toLowerCase()
+  )
+);
+
+const rowsPerVendor = new Map<string, number>();
+for (const o of offers) rowsPerVendor.set(o.vendor, (rowsPerVendor.get(o.vendor) ?? 0) + 1);
+
+const unblemished = offers.filter(
+  (o) =>
+    !changed.has(o.vendor.toLowerCase()) &&
+    slugOf(o.vendor).length > 2 &&
+    o.url.startsWith("http") &&
+    rowsPerVendor.get(o.vendor) === 1
+);
+
+const goneVendor = unblemished[0];
+const refusedVendor = unblemished.find((o) => o.url !== goneVendor.url && o.vendor !== goneVendor.vendor)!;
+const controlVendor = unblemished.find(
+  (o) => o.url !== goneVendor.url && o.url !== refusedVendor.url && o.vendor !== goneVendor.vendor && o.vendor !== refusedVendor.vendor
+)!;
+
+let fixtureDir = "";
+let serverPort = 0;
+let proc: ChildProcess | null = null;
+
+function startServer(fixturePath: string): Promise<ChildProcess> {
+  return new Promise((resolve, reject) => {
+    const child = spawn("node", [path.join(REPO, "dist", "serve.js")], {
+      stdio: ["pipe", "pipe", "pipe"],
+      env: { ...process.env, PORT: "0", BASE_URL: "http://localhost", AGENTDEALS_LINK_HEALTH_PATH: fixturePath },
+    });
+    const timeout = setTimeout(() => { child.kill(); reject(new Error("Server startup timeout")); }, 20000);
+    child.stderr!.on("data", (data: Buffer) => {
+      const m = data.toString().match(/running on http:\/\/localhost:(\d+)/);
+      if (m) { serverPort = parseInt(m[1], 10); clearTimeout(timeout); resolve(child); }
+    });
+    child.on("error", (err) => { clearTimeout(timeout); reject(err); });
+  });
+}
+
+const get = async (p: string) => {
+  const res = await fetch(`http://localhost:${serverPort}${p}`);
+  return { status: res.status, body: await res.text() };
+};
+
+before(async () => {
+  assert.ok(goneVendor && refusedVendor && controlVendor, "fixture needs three distinct vendors carrying no change records");
+
+  fixtureDir = mkdtempSync(path.join(tmpdir(), "link-health-"));
+  const fixturePath = path.join(fixtureDir, "link_health.json");
+  writeFileSync(fixturePath, JSON.stringify({
+    generated_at: "2026-08-25",
+    links: [
+      { url: goneVendor.url, checked: "2026-08-25", outcome: "unreachable", detail: "GET 410", terminal: true, last_reachable: "2026-01-04", consecutive_unreachable: 6 },
+      { url: refusedVendor.url, checked: "2026-08-25", outcome: "unknown", detail: "GET 403", terminal: false, last_reachable: "2026-01-04", consecutive_unreachable: 0 },
+    ],
+  }, null, 2));
+
+  proc = await startServer(fixturePath);
+});
+
+after(() => {
+  if (proc) proc.kill();
+  if (fixtureDir) rmSync(fixtureDir, { recursive: true, force: true });
+});
+
+describe("#1046 a vendor page whose link is confirmed unreachable", () => {
+  it("renders, so the assertions below are about a real page", async () => {
+    const res = await get(`/vendor/${slugOf(goneVendor.vendor)}`);
+    assert.equal(res.status, 200, `/vendor/${slugOf(goneVendor.vendor)} must exist for this test to mean anything`);
+    assert.match(res.body, new RegExp(`<h1>[^<]*${goneVendor.vendor.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}`, "i"));
+  });
+
+  it("does not render a stable badge", async () => {
+    const { body } = await get(`/vendor/${slugOf(goneVendor.vendor)}`);
+    const h1 = body.match(/<h1>[\s\S]*?<\/h1>/)![0];
+    assert.doesNotMatch(h1, /risk-badge/, "the h1 must carry no risk badge while the link is confirmed gone");
+  });
+
+  it("does not claim a verification month anywhere on the page or in its meta description", async () => {
+    const { body } = await get(`/vendor/${slugOf(goneVendor.vendor)}`);
+    assert.doesNotMatch(body, /Verified (January|February|March|April|May|June|July|August|September|October|November|December) \d{4}/);
+    assert.doesNotMatch(body, /class="detail-label">Verified</);
+  });
+
+  it("says the true thing instead — the date the link was last reachable", async () => {
+    const { body } = await get(`/vendor/${slugOf(goneVendor.vendor)}`);
+    assert.match(body, /class="link-unreachable-line"/);
+    assert.match(body, /Last reachable <span class="link-last-reachable"[^>]*>2026-01-04<\/span>/);
+    assert.match(body, /class="detail-label">Link last reachable</);
+  });
+
+  it("makes no favourable claim anywhere in its prose, including the FAQ answers an AI search engine quotes", async () => {
+    const { body } = await get(`/vendor/${slugOf(goneVendor.vendor)}`);
+    for (const claim of ["It's stable", "considered stable", "positive stability signal", "reasonable starting point"]) {
+      assert.ok(!body.includes(claim), `the page still says "${claim}" about a vendor whose link does not resolve`);
+    }
+    assert.match(body, /pricing page has not resolved for us since 2026-01-04/);
+  });
+
+  it("shows the comparison table the link state rather than a green stability dot", async () => {
+    const { body } = await get(`/vendor/${slugOf(goneVendor.vendor)}`);
+    const ownRow = body.match(/<tr class="current-vendor-row">[\s\S]*?<\/tr>/)![0];
+    assert.match(ownRow, /link unreachable/);
+    assert.doesNotMatch(ownRow, /stability-dot/);
+  });
+
+  it("withholds the level from the API rather than publishing a green one", async () => {
+    const { body } = await get(`/api/offers?q=${encodeURIComponent(goneVendor.vendor)}&limit=50`);
+    const match = JSON.parse(body).offers.find((o: { url: string }) => o.url === goneVendor.url);
+    assert.ok(match, "the offer must come back from the API for this assertion to have a subject");
+    assert.equal(match.risk_level, null);
+    assert.deepEqual(match.link_unreachable, { last_reachable: "2026-01-04", checked: "2026-08-25", terminal: true });
+  });
+});
+
+describe("#1046 a vendor page whose link we were merely refused", () => {
+  it("is untouched — being refused is evidence about us, not about them", async () => {
+    const { status, body } = await get(`/vendor/${slugOf(refusedVendor.vendor)}`);
+    assert.equal(status, 200);
+    const h1 = body.match(/<h1>[\s\S]*?<\/h1>/)![0];
+    assert.match(h1, /risk-badge[^>]*>stable</);
+    assert.match(body, /class="detail-label">Verified</);
+    assert.doesNotMatch(body, /class="link-unreachable-line"/);
+    assert.doesNotMatch(body, /pricing page has not resolved/);
+    assert.match(body, /<tr class="current-vendor-row">[\s\S]*?stability-dot[\s\S]*?<\/tr>/);
+  });
+
+  it("publishes no link claim in the API in either direction", async () => {
+    const { body } = await get(`/api/offers?q=${encodeURIComponent(refusedVendor.vendor)}&limit=50`);
+    const match = JSON.parse(body).offers.find((o: { url: string }) => o.url === refusedVendor.url);
+    assert.ok(match, "the offer must come back from the API for this assertion to have a subject");
+    assert.equal(match.link_unreachable, null);
+    assert.equal(match.risk_level, "stable");
+  });
+});
+
+describe("#1046 a vendor page we never checked", () => {
+  it("renders exactly as it did before, badge and verification date included", async () => {
+    const { status, body } = await get(`/vendor/${slugOf(controlVendor.vendor)}`);
+    assert.equal(status, 200);
+    const h1 = body.match(/<h1>[\s\S]*?<\/h1>/)![0];
+    assert.match(h1, /risk-badge[^>]*>stable</);
+    assert.match(body, /Verified (January|February|March|April|May|June|July|August|September|October|November|December) \d{4}/);
+    assert.doesNotMatch(body, /class="link-unreachable-line"/);
+  });
+});
+
+describe("#1046 the MCP tool that answers whether a vendor is risky", () => {
+  it("does not tell an agent a vendor has a stable pricing history when we cannot reach its page", async () => {
+    const { checkVendorRisk, resetCache } = await import("../dist/data.js");
+    process.env.AGENTDEALS_LINK_HEALTH_PATH = path.join(fixtureDir, "link_health.json");
+    resetCache();
+    try {
+    const gone = checkVendorRisk(goneVendor.vendor);
+    assert.ok("result" in gone, `checkVendorRisk did not resolve ${goneVendor.vendor}`);
+    assert.equal(gone.result.risk_level, null);
+    assert.equal(gone.result.link_unreachable?.last_reachable, "2026-01-04");
+    assert.ok(!gone.result.summary.includes("has a stable pricing history"), gone.result.summary);
+    assert.match(gone.result.summary, /has not resolved for us since 2026-01-04/);
+
+    const refused = checkVendorRisk(refusedVendor.vendor);
+    assert.ok("result" in refused, `checkVendorRisk did not resolve ${refusedVendor.vendor}`);
+    assert.equal(refused.result.risk_level, "stable");
+    assert.equal(refused.result.link_unreachable, null);
+    assert.match(refused.result.summary, /has a stable pricing history/);
+    } finally {
+      delete process.env.AGENTDEALS_LINK_HEALTH_PATH;
+      resetCache();
+    }
+  });
+});

--- a/test/link-liveness.test.ts
+++ b/test/link-liveness.test.ts
@@ -1,0 +1,110 @@
+import { describe, it } from "node:test";
+import assert from "node:assert";
+import {
+  classifyHttpStatus,
+  classifyNetworkError,
+  isTerminalStatus,
+  unreachableNotice,
+  LINK_GRACE_DAYS,
+  type LinkCheckRecord,
+} from "../src/link-health.ts";
+
+const DAY = 24 * 60 * 60 * 1000;
+const NOW = new Date("2026-08-25T00:00:00Z").getTime();
+
+function record(over: Partial<LinkCheckRecord> = {}): LinkCheckRecord {
+  return {
+    url: "https://example.test/pricing",
+    checked: "2026-08-25",
+    outcome: "unreachable",
+    detail: "GET 404",
+    terminal: false,
+    last_reachable: "2026-05-23",
+    consecutive_unreachable: 4,
+    ...over,
+  };
+}
+
+describe("#1046 outcome classification", () => {
+  it("treats 2xx and 3xx as reachable", () => {
+    for (const status of [200, 201, 204, 301, 302, 307, 308]) {
+      assert.equal(classifyHttpStatus(status), "reachable", `status ${status}`);
+    }
+  });
+
+  it("treats 404 and 410 as evidence about the destination", () => {
+    assert.equal(classifyHttpStatus(404), "unreachable");
+    assert.equal(classifyHttpStatus(410), "unreachable");
+  });
+
+  it("treats every status that means we were refused as unknown, not as a dead link", () => {
+    for (const status of [401, 402, 403, 405, 429, 451, 500, 502, 503, 504]) {
+      assert.equal(
+        classifyHttpStatus(status),
+        "unknown",
+        `status ${status} must not be publishable as evidence about a vendor`
+      );
+    }
+  });
+
+  it("treats a name that does not resolve as unreachable and a temporary resolver failure as unknown", () => {
+    assert.equal(classifyNetworkError("ENOTFOUND"), "unreachable");
+    assert.equal(classifyNetworkError("EAI_AGAIN"), "unknown");
+    assert.equal(classifyNetworkError("UND_ERR_CONNECT_TIMEOUT"), "unknown");
+    assert.equal(classifyNetworkError("ECONNREFUSED"), "unknown");
+    assert.equal(classifyNetworkError("ECONNRESET"), "unknown");
+    assert.equal(classifyNetworkError("TIMEOUT"), "unknown");
+    assert.equal(classifyNetworkError(undefined), "unknown");
+  });
+
+  it("treats 410 alone as terminal", () => {
+    assert.equal(isTerminalStatus(410), true);
+    assert.equal(isTerminalStatus(404), false);
+    assert.equal(isTerminalStatus(403), false);
+  });
+});
+
+describe("#1046 when an unreachable link becomes publishable", () => {
+  it("publishes nothing while the link is still inside its grace window", () => {
+    const justOutOfReach = new Date(NOW - (LINK_GRACE_DAYS - 1) * DAY).toISOString().slice(0, 10);
+    assert.equal(unreachableNotice(record({ last_reachable: justOutOfReach }), NOW), null);
+  });
+
+  it("publishes once the link has been out of reach for the whole grace window", () => {
+    const atTheEdge = new Date(NOW - LINK_GRACE_DAYS * DAY).toISOString().slice(0, 10);
+    const notice = unreachableNotice(record({ last_reachable: atTheEdge }), NOW);
+    assert.ok(notice);
+    assert.equal(notice.last_reachable, atTheEdge);
+    assert.equal(notice.checked, "2026-08-25");
+  });
+
+  it("publishes a 410 immediately, because the server has stated the answer", () => {
+    const yesterday = new Date(NOW - DAY).toISOString().slice(0, 10);
+    const notice = unreachableNotice(
+      record({ terminal: true, detail: "GET 410", last_reachable: yesterday }),
+      NOW
+    );
+    assert.ok(notice);
+    assert.equal(notice.terminal, true);
+  });
+
+  it("publishes nothing for a link we were merely refused, however long it has been refused", () => {
+    const longAgo = new Date(NOW - 400 * DAY).toISOString().slice(0, 10);
+    assert.equal(
+      unreachableNotice(record({ outcome: "unknown", detail: "GET 403", last_reachable: longAgo }), NOW),
+      null
+    );
+  });
+
+  it("publishes nothing for a link that answered on the last check", () => {
+    assert.equal(unreachableNotice(record({ outcome: "reachable", detail: "HEAD 200" }), NOW), null);
+  });
+
+  it("publishes nothing for a URL that has never been checked", () => {
+    assert.equal(unreachableNotice(undefined, NOW), null);
+  });
+
+  it("publishes nothing when we hold no date the link was last reachable and the server has not said gone", () => {
+    assert.equal(unreachableNotice(record({ last_reachable: null }), NOW), null);
+  });
+});

--- a/test/risk-badge.test.ts
+++ b/test/risk-badge.test.ts
@@ -170,14 +170,14 @@ describe("#1038 — the level is checkable", () => {
   it("every offer carrying a warning carries the record that produced it", async () => {
     const { enrichOffers, loadOffers } = await import("../dist/data.js");
     const uncaused = enrichOffers(loadOffers())
-      .filter((o: { risk_level: string | null; risk_cause: unknown }) => o.risk_level !== "stable" && !o.risk_cause);
+      .filter((o: { risk_level: string | null; risk_cause: unknown }) => o.risk_level && o.risk_level !== "stable" && !o.risk_cause);
     assert.strictEqual(uncaused.length, 0);
   });
 
   it("the vendor page publishes the dated cause beside the badge in the <h1>", async () => {
     const { enrichOffers, loadOffers } = await import("../dist/data.js");
     const warned = enrichOffers(loadOffers())
-      .filter((o: { risk_level: string | null }) => o.risk_level !== "stable")
+      .filter((o: { risk_level: string | null }) => o.risk_level && o.risk_level !== "stable")
       .slice(0, 6);
     assert.ok(warned.length > 0, "expected at least one warned vendor to test");
 
@@ -210,7 +210,7 @@ describe("#1038 — the level is checkable", () => {
 
   it("the alternatives surfaces publish the cause too", async () => {
     const { enrichOffers, loadOffers } = await import("../dist/data.js");
-    const warned = enrichOffers(loadOffers()).find((o: { risk_level: string | null }) => o.risk_level !== "stable");
+    const warned = enrichOffers(loadOffers()).find((o: { risk_level: string | null }) => o.risk_level && o.risk_level !== "stable");
     assert.ok(warned, "expected a warned vendor");
     const { text } = await get(`/alternative-to/${toSlug(warned.vendor)}`);
     if (!/Risk Level:/.test(text)) return; // page shape changed


### PR DESCRIPTION
Refs #1046

## What was wrong

`verifiedDate` answers "are the terms still right?". Nothing asked the cheaper, separate question "does this link resolve at all?", so a record could keep a `stable` badge and a verification date over a URL returning `410 Gone`. **23 records** were in that state.

## What this ships

A daily check (`scripts/check-liveness.js`, `.github/workflows/liveness.yml`) runs over **every** record regardless of `verifiedDate` and sorts each result into one of three outcomes:

| outcome | what it is | what it publishes |
|---|---|---|
| `reachable` | 2xx / 3xx | nothing; no record is stored for it |
| `unreachable` | 404 confirmed by a full GET, 410, or a hostname with no address | withholds the level and the verification date past the grace window |
| `unknown` | 403, 429, 5xx, timeouts, temporary resolver failures | **nothing, in either direction** |

The third row is the one that matters and it is the third time this rule has come up — `stale_verification` (#1025) and the risk badge (#1038) were the first two. **Being refused is evidence about our checker, not about the vendor.**

### The rule

Where a link has been unreachable past a **14-day grace window**, or the server has answered `410`, the record **withholds its `stable` level and its verification date** and publishes **the date the link was last reachable** instead.

`caution` and `risky` keep their badges. Those are dated records that remain true and checkable — Clarifai below keeps its `risky` badge and loses its verification date.

The grace window is seeded from `verifiedDate`, which is by definition a date on which a check reached that URL. That is what makes the effect immediate rather than needing three days of counter warm-up.

### One place, so every surface inherits it

The withholding happens once, in `enrichOffers`. `risk_level` becomes `null` — a state the type already allowed — so every consumer that renders a level renders nothing:

- vendor page `<h1>` badge, quick verdict, comparison table row, `Verified` detail card, meta description
- the FAQ answers inside `FAQPage` JSON-LD, which is the version an AI search engine quotes
- `/api/offers`, and the MCP `compare_vendors` result

That last one is the one worth flagging. Before this change it returned:

> `SOOS has a stable pricing history with no free tier removal, limit reduction or pricing restructure on record. Free tier verified for 94 days.`

about a vendor whose site returns `410 Gone`. It now returns:

> `We hold no free tier removal, limit reduction or pricing restructure on record for SOOS. Its pricing page has not resolved for us since 2026-05-23, so we cannot confirm its current terms. Treat that as a statement about our records, not as a stable pricing history.`

### A second defect, fixed in the same pass

`reverify.js` fell back from `HEAD` to `GET` only on `405` and `403`. `www.kaggle.com` answers `HEAD` with **404** and `GET` with **200**; `www.twingate.com` answers `HEAD` with **502** and `GET` with **200**. Both had been in the daily flagged list for **142 days** because of the verb, not the vendor. Any non-2xx `HEAD` now retries with `GET` before it counts as evidence.

## Effect

**23 of 1,571 offers** carry a link notice. 22 have their level withheld; 1 (`Clarifai`) keeps a `risky` badge backed by a dated record.

`data/link_health.json` is seeded from a full run and stores only the links that are **not** reachable — 61 records, since a link that answers needs no record.

## Verification

- `npm test` **1520 pass / 0 fail** (1484 before, 36 new). `tsc` clean.
- **14 mutations** applied to the real source, each rebuilt and re-run; every one produced failures. They cover the classification table, the grace window, the terminal case, the `unknown` bucket in both directions, the HEAD→GET fallback in both scripts, the history transitions, and each of the six rendering surfaces.
- Two independent full runs over all 1,478 distinct URLs returned **identical** counts and identical URL sets (1417 reachable / 23 unreachable / 38 could-not-check).
- Every `ENOTFOUND` cross-checked against the system resolver and against DNS-over-HTTPS before shipping. All seven confirmed: no A, AAAA or CNAME record.
- Real `dist/serve.js` booted; full MCP `initialize` → `notifications/initialized` → `tools/call`; vendor pages, `/api/offers` and `/criteria` checked; page checked visually with shot-scraper, **which is how I found that the quick verdict and the comparison table were still saying "stable" after the h1 badge was already gone**.

## Not in this PR

- **Delisting.** The queue is printed by `--report` and is for human confirmation, per the issue. Nothing is deleted automatically.
- **Corrected URLs.** The set changed under the issue's group B — the check found 6 dead links *inside* 60 days that a stale-record sweep could never see, including `bismuth.cloud`, which is now NXDOMAIN. Full list in an issue comment.
- **Scheduling.** #1020's sibling question. This PR records the outcome class per link so that work has something to schedule on.