### PR TITLE
Stop telling search engines the privacy policy changed today

### DIFF
--- a/src/serve.ts
+++ b/src/serve.ts
@@ -52012,6 +52012,14 @@ ${globalNavCss()}
 </html>`;
 }
 
+const PRIVACY_LAST_UPDATED = "2026-03-20";
+
+function privacyLastUpdatedLabel(): string {
+  const [y, m, d] = PRIVACY_LAST_UPDATED.split("-");
+  const months = ["January","February","March","April","May","June","July","August","September","October","November","December"];
+  return `${months[parseInt(m, 10) - 1]} ${parseInt(d, 10)}, ${y}`;
+}
+
 function buildPrivacyPage(): string {
   const title = "Privacy Policy — AgentDeals";
   const metaDesc = "AgentDeals privacy policy. We are a read-only data server — no accounts, no cookies, no personal data collected.";
@@ -52022,7 +52030,7 @@ function buildPrivacyPage(): string {
     name: title,
     description: metaDesc,
     url: `${BASE_URL}/privacy`,
-    dateModified: new Date().toISOString().slice(0, 10),
+    dateModified: PRIVACY_LAST_UPDATED,
     publisher: { "@type": "Organization", name: "AgentDeals", url: BASE_URL },
   };
 
@@ -52119,7 +52127,7 @@ ${globalNavCss()}
     <p>Questions about this policy? Open an issue on our <a href="https://github.com/robhunter/agentdeals/issues">GitHub repository</a>.</p>
   </div>
 
-  <p class="updated">Last updated: March 20, 2026</p>
+  <p class="updated">Last updated: ${privacyLastUpdatedLabel()}</p>
 
   <footer>AgentDeals &mdash; open source, built for agents | <a href="/privacy">Privacy</a> | <a href="/press">Press</a> | <a href="/disclosure">Affiliate Disclosure</a></footer>
 </div>

--- a/test/privacy-freshness.test.ts
+++ b/test/privacy-freshness.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, before, after } from "node:test";
+import assert from "node:assert";
+import { spawn, type ChildProcess } from "node:child_process";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO = path.join(__dirname, "..");
+
+let serverPort = 0;
+let proc: ChildProcess | null = null;
+
+function startServer(): Promise<ChildProcess> {
+  return new Promise((resolve, reject) => {
+    const child = spawn("node", [path.join(REPO, "dist", "serve.js")], {
+      stdio: ["pipe", "pipe", "pipe"],
+      env: { ...process.env, PORT: "0", BASE_URL: "http://localhost" },
+    });
+    const timeout = setTimeout(() => { child.kill(); reject(new Error("Server startup timeout")); }, 20000);
+    child.stderr!.on("data", (data: Buffer) => {
+      const m = data.toString().match(/running on http:\/\/localhost:(\d+)/);
+      if (m) { serverPort = parseInt(m[1], 10); clearTimeout(timeout); resolve(child); }
+    });
+    child.on("error", (err) => { clearTimeout(timeout); reject(err); });
+  });
+}
+
+const MONTHS = ["January","February","March","April","May","June","July","August","September","October","November","December"];
+
+before(async () => { proc = await startServer(); });
+after(() => { if (proc) proc.kill(); });
+
+describe("#1043 the privacy policy's own freshness claim", () => {
+  it("does not tell a search engine the document changed today", async () => {
+    const body = await (await fetch(`http://localhost:${serverPort}/privacy`)).text();
+
+    const jsonLd = body.match(/<script type="application\/ld\+json">([\s\S]*?)<\/script>/)?.[1];
+    assert.ok(jsonLd, "/privacy must carry JSON-LD for this assertion to have a subject");
+    const { dateModified } = JSON.parse(jsonLd);
+    assert.ok(dateModified, "the JSON-LD must carry a dateModified");
+
+    const today = new Date().toISOString().slice(0, 10);
+    assert.notStrictEqual(
+      dateModified,
+      today,
+      "dateModified equals today, which is what an automatic new Date() produces on a document nobody edited",
+    );
+  });
+
+  it("publishes the same date to a search engine and to a reader", async () => {
+    const body = await (await fetch(`http://localhost:${serverPort}/privacy`)).text();
+
+    const jsonLd = body.match(/<script type="application\/ld\+json">([\s\S]*?)<\/script>/)?.[1];
+    const { dateModified } = JSON.parse(jsonLd!);
+
+    const visible = body.match(/class="updated">Last updated: ([A-Z][a-z]+) (\d{1,2}), (\d{4})</);
+    assert.ok(visible, "/privacy must render a visible last-updated line for this assertion to have a subject");
+
+    const month = String(MONTHS.indexOf(visible[1]) + 1).padStart(2, "0");
+    assert.notStrictEqual(month, "00", `unrecognised month ${visible[1]}`);
+    const rendered = `${visible[3]}-${month}-${visible[2].padStart(2, "0")}`;
+
+    assert.strictEqual(dateModified, rendered, "the structured data and the visible text disagree about when this policy last changed");
+  });
+});


### PR DESCRIPTION
Refs #1043 — Part 3, the `dateModified` checkbox. Independent of the copy you are waiting on Rob for.

## What was wrong

`/privacy`'s JSON-LD emitted `dateModified: new Date().toISOString()`, so it told Google the privacy policy had been modified **today, every day**, while the visible line on the same page read `Last updated: March 20, 2026`. Two claims about the same fact, on the same page, disagreeing — and the machine-readable one was the false one.

## What changed

One constant (`PRIVACY_LAST_UPDATED`) feeds both the JSON-LD and the visible line, so the visible date is now the only place to edit and the structured data cannot drift from it.

## The guard

Two assertions, and the second is the one that matters:

1. `dateModified` is not today's date — catches an automatic `new Date()` returning.
2. **The structured data and the visible text publish the same date.** That is what was actually broken; a stale-but-honest constant in both places would have been fine.

Mutation-verified: reverting `dateModified` to `new Date()` fails both, and drifting the visible line alone fails the second.

## Not in this PR

`/disclosure` renders `Last updated: <today>` in its visible text too. Weaker case — that page does re-render its partner list from live data on every request — but the line still claims an edit that did not happen. Not fixing it inside a PR about `/privacy`; flagging it for the issue.

`npm test` 1522 pass / 0 fail (1520 before, 2 new). `tsc` clean.