### PR TITLE
Membership gates for alternatives: a connection pool and a laptop emulator are not alternatives to a database (#1032 Phase 1)

### DIFF
--- a/data/index.json
+++ b/data/index.json
@@ -752,7 +752,15 @@
         "free tier",
         "firebase-alternative"
       ],
-      "verifiedDate": "2026-08-22"
+      "verifiedDate": "2026-08-22",
+      "product_role": {
+        "deployment_model": "hosted",
+        "is_addon": true,
+        "augments": "a database you already run",
+        "source_url": "https://hasura.io/docs/3.0/connectors/overview/",
+        "source_quote": "We use native data connectors to make your data accessible through a GraphQL API.",
+        "reviewed": "2026-08-25"
+      }
     },
     {
       "vendor": "GitHub Actions",
@@ -3038,7 +3046,14 @@
         "local-dev",
         "localstack-alternative"
       ],
-      "verifiedDate": "2026-08-24"
+      "verifiedDate": "2026-08-24",
+      "product_role": {
+        "deployment_model": "self_hosted",
+        "is_addon": false,
+        "source_url": "https://min.io/pricing",
+        "source_quote": "Purpose-built subscription tiers support no-cost development to mission-critical production.",
+        "reviewed": "2026-08-25"
+      }
     },
     {
       "vendor": "Backblaze",
@@ -4741,7 +4756,14 @@
         "serverless",
         "deal-change"
       ],
-      "verifiedDate": "2026-08-25"
+      "verifiedDate": "2026-08-25",
+      "product_role": {
+        "deployment_model": "local_dev_only",
+        "is_addon": false,
+        "source_url": "https://www.localstack.cloud/",
+        "source_quote": "LocalStack creates secure cloud development and testing sandbox environments so AI agents, software developers, and CI/CD pipelines can build, test, and validate applications before they touch the cloud.",
+        "reviewed": "2026-08-25"
+      }
     },
     {
       "vendor": "Testcontainers",
@@ -4804,7 +4826,14 @@
         "nosql",
         "localstack-alternative"
       ],
-      "verifiedDate": "2026-08-15"
+      "verifiedDate": "2026-08-15",
+      "product_role": {
+        "deployment_model": "local_dev_only",
+        "is_addon": false,
+        "source_url": "https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/DynamoDBLocal.html",
+        "source_quote": "With the downloadable version of Amazon DynamoDB, you can develop and test applications without accessing the DynamoDB web service. Instead, the database is self-contained on your computer.",
+        "reviewed": "2026-08-25"
+      }
     },
     {
       "vendor": "ElasticMQ",
@@ -4820,7 +4849,14 @@
         "local-dev",
         "localstack-alternative"
       ],
-      "verifiedDate": "2026-08-14"
+      "verifiedDate": "2026-08-14",
+      "product_role": {
+        "deployment_model": "self_hosted",
+        "is_addon": false,
+        "source_url": "https://github.com/softwaremill/elasticmq",
+        "source_quote": "In-memory message queue with an Amazon SQS-compatible interface. Runs stand-alone or embedded.",
+        "reviewed": "2026-08-25"
+      }
     },
     {
       "vendor": "CloudDev",
@@ -4840,7 +4876,14 @@
         "api-gateway",
         "localstack-alternative"
       ],
-      "verifiedDate": "2026-08-15"
+      "verifiedDate": "2026-08-15",
+      "product_role": {
+        "deployment_model": "local_dev_only",
+        "is_addon": false,
+        "source_url": "https://github.com/Jeffrin-dev/CloudDev",
+        "source_quote": "Run AWS services locally - open-source alternative to LocalStack. S3, DynamoDB, Lambda, SQS, API Gateway and 38 more services in one command.",
+        "reviewed": "2026-08-25"
+      }
     },
     {
       "vendor": "Vera AWS",
@@ -4859,7 +4902,14 @@
         "open-source",
         "localstack-alternative"
       ],
-      "verifiedDate": "2026-08-14"
+      "verifiedDate": "2026-08-14",
+      "product_role": {
+        "deployment_model": "local_dev_only",
+        "is_addon": false,
+        "source_url": "https://github.com/project-vera/vera",
+        "source_quote": "High-fidelity, anycloud emulators running in your laptop. For DevOps programming, testing, and simulation.",
+        "reviewed": "2026-08-25"
+      }
     },
     {
       "vendor": "Floci",
@@ -4876,7 +4926,14 @@
         "open-source",
         "localstack-alternative"
       ],
-      "verifiedDate": "2026-08-11"
+      "verifiedDate": "2026-08-11",
+      "product_role": {
+        "deployment_model": "local_dev_only",
+        "is_addon": false,
+        "source_url": "https://github.com/floci-io/floci",
+        "source_quote": "Light, fluffy, and always free - The AWS Local Emulator alternative",
+        "reviewed": "2026-08-25"
+      }
     },
     {
       "vendor": "Brave Search API",
@@ -5289,7 +5346,15 @@
         "orm",
         "serverless"
       ],
-      "verifiedDate": "2026-08-22"
+      "verifiedDate": "2026-08-22",
+      "product_role": {
+        "deployment_model": "hosted",
+        "is_addon": true,
+        "augments": "a database you already run",
+        "source_url": "https://www.prisma.io/docs/accelerate",
+        "source_quote": "Prisma Accelerate is a managed connection pool and global cache.",
+        "reviewed": "2026-08-25"
+      }
     },
     {
       "vendor": "Unity DevOps",
@@ -9550,7 +9615,14 @@
         "qa",
         "free-for-dev"
       ],
-      "verifiedDate": "2026-08-05"
+      "verifiedDate": "2026-08-05",
+      "product_role": {
+        "deployment_model": "hosted",
+        "is_addon": false,
+        "source_url": "https://appetize.io",
+        "source_quote": "Cloud emulators for iOS and Android that give every team instant mobile access.",
+        "reviewed": "2026-08-25"
+      }
     },
     {
       "vendor": "Argos",

--- a/scripts/membership-impact.js
+++ b/scripts/membership-impact.js
@@ -1,0 +1,116 @@
+import { loadOffers } from "../dist/data.js";
+import { partitionAlternatives, partitionRoleCandidates, MEMBERSHIP_GATE_RULES } from "../dist/product-role.js";
+
+const HELP = `membership-impact.js — report what the #1032 membership gates remove.
+
+Usage:
+  node scripts/membership-impact.js [--json]
+
+Prints, for every catalogue record classified with a product_role, which
+alternatives lists it is removed from, how many lists shrink, and every
+category whose alternatives list falls below three entries once the gates
+are applied. Reads data/index.json through the built dist/ modules; makes no
+network calls and writes nothing.
+
+  --json   emit the same report as JSON instead of text
+  --help   show this message`;
+
+if (process.argv.includes("--help") || process.argv.includes("-h")) {
+  console.log(HELP);
+  process.exit(0);
+}
+
+const asJson = process.argv.includes("--json");
+const offers = loadOffers();
+
+const classified = offers.filter((o) => o.product_role);
+const gated = classified.filter((o) => o.product_role.deployment_model === "local_dev_only" || o.product_role.is_addon);
+
+const removalsByOffer = new Map();
+const listsAffected = new Map();
+const categoryShrink = [];
+
+const categories = [...new Set(offers.map((o) => o.category))].sort();
+
+for (const category of categories) {
+  const inCategory = offers.filter((o) => o.category === category);
+  let shrunk = 0;
+  let minKept = Infinity;
+  let minSubject = null;
+  for (const subject of inCategory) {
+    const candidates = inCategory.filter((o) => o.vendor !== subject.vendor);
+    const { kept, removed } = partitionAlternatives(candidates, subject);
+    if (removed.length > 0) {
+      shrunk += 1;
+      const key = `${category}`;
+      listsAffected.set(key, (listsAffected.get(key) ?? 0) + 1);
+      for (const r of removed) {
+        const k = `${r.offer.vendor} (${r.offer.category})`;
+        const entry = removalsByOffer.get(k) ?? { gate: r.gate, lists: 0 };
+        entry.lists += 1;
+        removalsByOffer.set(k, entry);
+      }
+    }
+    if (kept.length < minKept) {
+      minKept = kept.length;
+      minSubject = subject.vendor;
+    }
+  }
+  if (shrunk > 0 && minKept < 3) {
+    categoryShrink.push({ category, min_alternatives: minKept, on_page: minSubject, total_in_category: inCategory.length });
+  }
+}
+
+const roleCategories = [...new Set(categories)];
+const roleImpact = [];
+for (const category of roleCategories) {
+  const { removed } = partitionRoleCandidates(offers.filter((o) => o.category === category));
+  if (removed.length > 0) {
+    roleImpact.push({ category, removed: removed.map((r) => `${r.offer.vendor} (${MEMBERSHIP_GATE_RULES[r.gate].label.toLowerCase()})`) });
+  }
+}
+
+const report = {
+  catalogue_size: offers.length,
+  classified: classified.length,
+  gated: gated.length,
+  gated_records: gated.map((o) => ({
+    vendor: o.vendor,
+    category: o.category,
+    deployment_model: o.product_role.deployment_model,
+    is_addon: o.product_role.is_addon,
+    source_url: o.product_role.source_url,
+  })),
+  alternatives_lists_shrunk: [...listsAffected.entries()].map(([category, lists]) => ({ category, lists })),
+  removals: [...removalsByOffer.entries()].map(([offer, v]) => ({ offer, gate: v.gate, lists: v.lists })),
+  categories_below_three: categoryShrink,
+  role_recommendation_impact: roleImpact,
+};
+
+if (asJson) {
+  console.log(JSON.stringify(report, null, 2));
+} else {
+  console.log(`catalogue ${report.catalogue_size} records, ${report.classified} classified, ${report.gated} carrying a gate\n`);
+  console.log("gated records:");
+  for (const g of report.gated_records) {
+    console.log(`  ${g.vendor} (${g.category}) — ${g.deployment_model}${g.is_addon ? ", add-on" : ""}`);
+  }
+  console.log("\nremoved from alternatives lists:");
+  for (const r of report.removals) {
+    console.log(`  ${r.offer} — ${r.gate} — removed from ${r.lists} lists`);
+  }
+  console.log("\nalternatives lists that shrink, by category:");
+  for (const a of report.alternatives_lists_shrunk) {
+    console.log(`  ${a.category}: ${a.lists} lists`);
+  }
+  console.log("\ncategories where an alternatives list falls below 3:");
+  if (report.categories_below_three.length === 0) console.log("  none");
+  for (const c of report.categories_below_three) {
+    console.log(`  ${c.category}: ${c.min_alternatives} on /vendor/${c.on_page} (${c.total_in_category} in category)`);
+  }
+  console.log("\nrole recommendations (/api/stack, plan_stack):");
+  if (report.role_recommendation_impact.length === 0) console.log("  none");
+  for (const r of report.role_recommendation_impact) {
+    console.log(`  ${r.category}: ${r.removed.join(", ")}`);
+  }
+}

--- a/src/data.ts
+++ b/src/data.ts
@@ -5,6 +5,7 @@ import type { Offer, EnrichedOffer, OfferIndex, DealChange, DealChangesIndex, St
 import { isUrlSuspended } from "./referral-health.js";
 import { rankForListing } from "./ranking.js";
 import { unreachableNoticeForUrl, resetLinkHealthCache } from "./link-health.js";
+import { filterAlternatives } from "./product-role.js";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const INDEX_PATH = path.join(__dirname, "..", "data", "index.json");
@@ -82,7 +83,7 @@ export function getOfferDetails(
     // through the shared selection module (#1025) rather than `.slice(0, 5)`
     // over data/index.json order.
     const sameCategoryOffers = rankForListing(
-      offers.filter((o) => o.category === match.category && o.vendor !== match.vendor),
+      filterAlternatives(offers.filter((o) => o.category === match.category && o.vendor !== match.vendor), match),
       { queryKey: `related:${match.category}:${match.vendor}`, changes: loadDealChanges() },
     ).entries.slice(0, 5).map((e) => e.offer);
     const relatedVendors = sameCategoryOffers.map((o) => o.vendor);
@@ -692,7 +693,7 @@ export function checkVendorRisk(
   // "risk bucket, then alphabetical" sort — which ranked on the count of
   // changes we happen to have recorded and broke ties with the alphabet.
   const alternatives = rankForListing(
-    offers.filter((o) => o.category === offer.category && o.vendor !== offer.vendor),
+    filterAlternatives(offers.filter((o) => o.category === offer.category && o.vendor !== offer.vendor), offer),
     { queryKey: `vendor-risk-alternatives:${offer.vendor}`, changes: allChanges },
   ).entries.slice(0, 3).map((e) => ({
     vendor: e.offer.vendor,

--- a/src/product-role.ts
+++ b/src/product-role.ts
@@ -1,0 +1,120 @@
+import type { Offer, ProductRole } from "./types.js";
+
+export type RoleCarrier = { product_role?: ProductRole };
+
+export type MembershipGate = "local_dev_only" | "addon";
+
+export const MEMBERSHIP_GATE_ORDER: MembershipGate[] = ["local_dev_only", "addon"];
+
+export const MEMBERSHIP_GATE_RULES: Record<MembershipGate, { label: string; rule: string }> = {
+  local_dev_only: {
+    label: "Runs only on a developer machine",
+    rule: "The product is a local stand-in for a service you would otherwise run in production. It is not an alternative to the hosted service it stands in for.",
+  },
+  addon: {
+    label: "Extends another product",
+    rule: "The product adds a capability to another product rather than replacing it. It is not an alternative to the thing it augments.",
+  },
+};
+
+export const MEMBERSHIP_GATE_SYMMETRY =
+  "A gate removes an offer from an alternatives list only when the vendor the list is about does not carry the same gate. One local emulator is still an alternative to another; one add-on is still an alternative to another.";
+
+export const MEMBERSHIP_GATE_SCOPE =
+  "These gates decide membership of alternatives, related-vendor, risk and role-recommendation lists. They are not scores, they never change the order of anything, and they never filter a category page, a best-of page or a search result — those are inventory, and the caller asked for the category.";
+
+export const MEMBERSHIP_GATE_CORRECTIONS =
+  "Every gated offer publishes the URL on the vendor's own site that the classification was read from, and the sentence it was read from. A vendor who believes we have read it wrong can point at the same page.";
+
+export function membershipGatesFor(offer: RoleCarrier): Set<MembershipGate> {
+  const gates = new Set<MembershipGate>();
+  const role = offer.product_role;
+  if (!role) return gates;
+  if (role.deployment_model === "local_dev_only") gates.add("local_dev_only");
+  if (role.is_addon) gates.add("addon");
+  return gates;
+}
+
+function gateAgainst(candidate: RoleCarrier, subjectGates: Set<MembershipGate>): MembershipGate | null {
+  const candidateGates = membershipGatesFor(candidate);
+  for (const gate of MEMBERSHIP_GATE_ORDER) {
+    if (candidateGates.has(gate) && !subjectGates.has(gate)) return gate;
+  }
+  return null;
+}
+
+export function alternativeMembershipGate(candidate: RoleCarrier, subject: RoleCarrier): MembershipGate | null {
+  return gateAgainst(candidate, membershipGatesFor(subject));
+}
+
+export function membershipGatesAcross(subjects: RoleCarrier[]): Set<MembershipGate> {
+  const union = new Set<MembershipGate>();
+  for (const subject of subjects) {
+    for (const gate of membershipGatesFor(subject)) union.add(gate);
+  }
+  return union;
+}
+
+export function roleMembershipGate(candidate: RoleCarrier): MembershipGate | null {
+  const gates = membershipGatesFor(candidate);
+  for (const gate of MEMBERSHIP_GATE_ORDER) {
+    if (gates.has(gate)) return gate;
+  }
+  return null;
+}
+
+export interface AlternativesPartition<T extends RoleCarrier> {
+  kept: T[];
+  removed: Array<{ offer: T; gate: MembershipGate }>;
+}
+
+export function partitionAlternativesAcross<T extends RoleCarrier>(candidates: T[], subjects: RoleCarrier[]): AlternativesPartition<T> {
+  const subjectGates = membershipGatesAcross(subjects);
+  const kept: T[] = [];
+  const removed: Array<{ offer: T; gate: MembershipGate }> = [];
+  for (const candidate of candidates) {
+    const gate = gateAgainst(candidate, subjectGates);
+    if (gate) removed.push({ offer: candidate, gate });
+    else kept.push(candidate);
+  }
+  return { kept, removed };
+}
+
+export function partitionAlternatives<T extends RoleCarrier>(candidates: T[], subject: RoleCarrier): AlternativesPartition<T> {
+  return partitionAlternativesAcross(candidates, [subject]);
+}
+
+export function filterAlternatives<T extends RoleCarrier>(candidates: T[], subject: RoleCarrier): T[] {
+  return partitionAlternatives(candidates, subject).kept;
+}
+
+export function partitionRoleCandidates<T extends RoleCarrier>(candidates: T[]): AlternativesPartition<T> {
+  const kept: T[] = [];
+  const removed: Array<{ offer: T; gate: MembershipGate }> = [];
+  for (const candidate of candidates) {
+    const gate = roleMembershipGate(candidate);
+    if (gate) removed.push({ offer: candidate, gate });
+    else kept.push(candidate);
+  }
+  return { kept, removed };
+}
+
+export function deploymentModelLabel(role: ProductRole): string {
+  if (role.deployment_model === "local_dev_only") return "Runs only on a developer machine";
+  if (role.deployment_model === "self_hosted") return "Self-hosted";
+  return "Hosted service";
+}
+
+export function productRoleSentence(offer: Offer): string | null {
+  const role = offer.product_role;
+  if (!role) return null;
+  const parts = [deploymentModelLabel(role)];
+  if (role.is_addon) {
+    parts.push(role.augments ? `extends ${role.augments} rather than replacing one` : "extends another product rather than replacing it");
+  }
+  const gated = membershipGatesFor(offer).size > 0;
+  const consequence = gated
+    ? `${offer.vendor} is listed in ${offer.category} and searchable there, and is left out of alternatives lists for vendors it cannot stand in for.`
+    : `${offer.vendor} is listed everywhere a ${offer.category} offer is listed.`;
+  return `${parts.join(", ")}. ${consequence}`;
+}

--- a/src/serve.ts
+++ b/src/serve.ts
@@ -26,6 +26,7 @@ import { subscribe as watchlistSubscribe, getSubscription as getWatchlistSubscri
 import { toSlug, vendorSlugMap, resolveVendorSlug } from "./vendor-slug.js";
 import { rankOffers, rankForListing, rotateListing, utcDate, CRITERIA_PATH, DEMOTE_ONLY_POLICY, DISCLOSURE_RATIONALE, TIE_BREAK_ALGORITHM, GATE_TABLE, DEMERIT_TABLE, NOT_FREE_TIER_RULES, TIME_LIMITED_TIER_RULES } from "./ranking.js";
 import type { RankedEntry, RankingResult } from "./ranking.js";
+import { partitionAlternatives, partitionAlternativesAcross, productRoleSentence, MEMBERSHIP_GATE_RULES, MEMBERSHIP_GATE_ORDER, MEMBERSHIP_GATE_SYMMETRY, MEMBERSHIP_GATE_SCOPE, MEMBERSHIP_GATE_CORRECTIONS } from "./product-role.js";
 import type { Agent, RiskCause, LinkUnreachable } from "./types.js";
 import type { AgentBalance } from "./ledger.js";
 import type { SubmittedReferralCode } from "./referral-codes.js";
@@ -1690,6 +1691,9 @@ function buildCriteriaPage(): string {
   const demeritRows = DEMERIT_TABLE.map(d => `<tr><td><code>${escHtmlServer(d.code)}</code></td><td style="text-align:center;font-family:var(--mono)">&minus;${d.points}</td><td>${escHtmlServer(d.trigger)}</td></tr>`).join("\n");
   const notFreeRows = NOT_FREE_TIER_RULES.map(r => `<tr><td><code>${escHtmlServer(String(r.pattern))}</code></td><td>${escHtmlServer(r.note)}</td></tr>`).join("\n");
   const timeLimitedRows = TIME_LIMITED_TIER_RULES.map(r => `<tr><td><code>${escHtmlServer(String(r.pattern))}</code></td><td>${escHtmlServer(r.note)}</td></tr>`).join("\n");
+  const membershipGateRows = MEMBERSHIP_GATE_ORDER.map(g => `<tr><td><code>${escHtmlServer(g)}</code> &mdash; ${escHtmlServer(MEMBERSHIP_GATE_RULES[g].label)}</td><td>${escHtmlServer(MEMBERSHIP_GATE_RULES[g].rule)}</td></tr>`).join("\n");
+  const classifiedCount = offers.filter(o => o.product_role).length;
+  const gatedCount = offers.filter(o => o.product_role && (o.product_role.deployment_model === "local_dev_only" || o.product_role.is_addon)).length;
 
   const jsonLd = {
     "@context": "https://schema.org",
@@ -1806,14 +1810,24 @@ ${demeritRows}
   <h2>4. What we do not model</h2>
   <p>We rank on offer terms, verification recency and recorded adverse changes. <strong style="color:var(--text)">We do not model technical fit</strong> &mdash; whether a particular product suits a particular role in your architecture. A vector database and a relational database sit in the same category here. If you are asking us which of two products fits your app, we are the wrong source; if you are asking whose free tier we could confirm this week and whose was withdrawn in March, that is exactly what this is for.</p>
 
-  <h2>5. What agents tell us, and what we do with it</h2>
+  <h2 id="membership">5. Two product properties that decide membership, and never order</h2>
+  <p>Section 4 is about fit and it still stands. This is a different thing: two factual properties of a product, of the same kind as its category and read from the vendor's own words. They answer whether a product <em>could</em> stand in for another at all, not whether it would suit you better.</p>
+  <table><thead><tr><th>Property</th><th>What it means</th></tr></thead><tbody>
+${membershipGateRows}
+  </tbody></table>
+  <p>${escHtmlServer(MEMBERSHIP_GATE_SYMMETRY)}</p>
+  <p>${escHtmlServer(MEMBERSHIP_GATE_SCOPE)}</p>
+  <p><strong style="color:var(--text)">Neither property is available on request.</strong> A vendor cannot ask to be classified, declassified, or exempted, for the same reason there is no top slot to buy. ${escHtmlServer(MEMBERSHIP_GATE_CORRECTIONS)}</p>
+  <p>The honest limit: we have classified ${classifiedCount} of ${offers.length} records, ${gatedCount} of which carry a gate. <strong style="color:var(--text)">A record with no classification has not been reviewed &mdash; it does not mean we have checked and found it hosted.</strong> Absence of the property publishes nothing in either direction and gates nothing, which is the same rule we use for a link we were merely refused.</p>
+
+  <h2>6. What agents tell us, and what we do with it</h2>
   <p>Agents can report which vendor they recommended, at <a href="${SIGNAL_DOC_PATH}"><code>${escHtmlServer(SIGNAL_PATH)}</code></a>. <strong style="color:var(--text)">Those counts never affect any order we publish</strong> &mdash; not now, not behind a flag. A self-reported counter that influenced placement would be a purchasable ranking with extra steps, and the whole reason to trust this index is that there is no such thing.</p>
   <p><strong style="color:var(--text)">And we do not publish per-vendor signal counts, because a visible counter is a signal a vendor could acquire.</strong> Anyone can fire that endpoint without authenticating &mdash; including a vendor, at itself, all day. We publish the aggregate totals on <a href="${SIGNAL_DOC_PATH}">the signal page</a>, including the unflattering ones; we do not publish a table anyone could screenshot as &ldquo;AgentDeals&rsquo; most-recommended vendor&rdquo;.</p>
 
-  <h2>6. Surfaces that are listings, not rankings</h2>
+  <h2>7. Surfaces that are listings, not rankings</h2>
   <p>Not every list on this site is a recommendation. Where a page is an inventory &mdash; every referral programme we know of, every comparison pair we generate &mdash; it is labelled as such and ordered by the same unbiased permutation rather than by the alphabet or by our commercial interest. Where we hold a referral link and may earn a commission, that is stated on the section itself, not only in a footnote. See our <a href="/disclosure">affiliate disclosure</a>.</p>
 
-  <h2>7. If we have this wrong</h2>
+  <h2>8. If we have this wrong</h2>
   <p>Every demotion names a dated, recorded fact. If a fact is wrong or out of date, it is correctable: the record behind it is shown on the vendor's page with its source. Correcting it changes the ranking automatically, because the ranking has no other input. There is no editorial override to appeal to &mdash; deliberately, because an override is the thing that would be sold.</p>
 
   <p style="font-size:.8rem;color:var(--text-dim);margin-top:2rem">This page is generated from the same constants the ranking uses, so it cannot drift from the code. Last computed ${escHtmlServer(date)}.</p>
@@ -3696,8 +3710,19 @@ function buildVendorPage(slug: string): string | null {
   // module. It used to be `.slice(0, 12)` over raw file order — whoever was
   // typed into data/index.json first won, on the single highest-traffic page
   // type on the site.
-  const alternatives = rankForListing(
+  const productRoleLine = (() => {
+    const role = primary.product_role;
+    const sentence = productRoleSentence(primary);
+    if (!role || !sentence) return "";
+    return `  <p class="product-role-line" style="margin:.4rem 0 .6rem;font-size:.9rem;color:var(--text-muted)"><strong>Product role:</strong> ${escHtmlServer(sentence)} We read that from <a href="${escHtmlServer(role.source_url)}" rel="nofollow noopener">${escHtmlServer(role.source_url)}</a> on <span class="product-role-reviewed" style="font-family:var(--mono)">${escHtmlServer(role.reviewed)}</span>, where it says: &ldquo;${escHtmlServer(role.source_quote)}&rdquo; <a href="${CRITERIA_PATH}#membership">How we use this</a>.</p>`;
+  })();
+
+  const alternativesMembership = partitionAlternatives(
     offers.filter(o => o.category === primary.category && o.vendor !== vendorName),
+    primary,
+  );
+  const alternatives = rankForListing(
+    alternativesMembership.kept,
     { queryKey: `alternatives:${primary.category}:${vendorName}`, changes: dealChanges },
   ).entries.slice(0, 12).map(e => e.offer);
 
@@ -3878,6 +3903,8 @@ ${enrichedAlts.map(a => {
   </div>` : "";
 
   // Alternatives HTML
+  const membershipExclusionsHtml = alternativesMembership.removed.length > 0 ? `
+    <p class="alt-excluded" style="margin:.7rem 0 0;font-size:.85rem;color:var(--text-muted)">Left out of this list: ${alternativesMembership.removed.map(r => `<a href="/vendor/${toSlug(r.offer.vendor)}">${escHtmlServer(r.offer.vendor)}</a> (${escHtmlServer(MEMBERSHIP_GATE_RULES[r.gate].label.toLowerCase())})`).join(", ")}. Each is still listed in <a href="/category/${toSlug(primary.category)}">${escHtmlServer(primary.category)}</a>, with the vendor's own words we read that from on its page. <a href="${CRITERIA_PATH}#membership">How we decide this</a>.</p>` : "";
   const alternativesHtml = alternatives.length > 0 ? `
   <div class="section">
     <h2>Alternatives in ${escHtmlServer(primary.category)}</h2>
@@ -3886,7 +3913,7 @@ ${alternatives.map(a => `      <a href="/vendor/${toSlug(a.vendor)}" class="alt-
         <span class="alt-name">${escHtmlServer(a.vendor)}</span>
         <span class="alt-tier">${escHtmlServer(a.tier)}</span>
       </a>`).join("\n")}
-    </div>
+    </div>${membershipExclusionsHtml}
   </div>` : "";
 
   // Comparisons HTML — include both /compare/ pages and root-level VS pages
@@ -4198,6 +4225,7 @@ ${mcpCtaCss()}
   <h1>${escHtmlServer(vendorName)} Free Tier ${currentYear}${h1RiskBadge}</h1>
 ${riskCauseLine}
 ${linkUnreachableLine}
+${productRoleLine}
   <p class="page-meta">Limits, pricing history, and ${alternatives.length} alternatives.${verifiedSentence} Last updated ${escHtmlServer(lastUpdated)}.</p>
 ${quickVerdictHtml}
 ${categoryContextHtml}
@@ -4301,7 +4329,8 @@ function buildAlternativesPage(slug: string): string | null {
   // risk_level bucket — the count-of-recorded-changes signal that demotes
   // prominent vendors 3.2x more often than obscure ones — with file order
   // deciding everything inside a bucket.
-  const altRanking = rankForListing(enrichOffers(dedupedAlts), {
+  const altMembership = partitionAlternativesAcross(dedupedAlts, vendorOffers);
+  const altRanking = rankForListing(enrichOffers(altMembership.kept), {
     queryKey: `alternative-to:${vendorName}`,
     changes: dealChanges,
   });
@@ -4396,7 +4425,8 @@ ${curatedAlts.map(a => altCard(a, true)).join("\n")}
   const allAltsHtml = enrichedAlts.length > 0 ? `
   <div class="section">
     <h2>All Free Alternatives (${enrichedAlts.length})</h2>
-    <p class="section-note">${altRanking.qualified_count} of these carry no recorded demerit and are indistinguishable under every signal we hold; their order rotates daily. ${altRanking.demoted_count} are demoted with the reason named, and ${altRanking.gated_count} are listed last because they are not generally available or are not a free offer. <a href="${CRITERIA_PATH}">How we rank</a>.</p>
+    <p class="section-note">${altRanking.qualified_count} of these carry no recorded demerit and are indistinguishable under every signal we hold; their order rotates daily. ${altRanking.demoted_count} are demoted with the reason named, and ${altRanking.gated_count} are listed last because they are not generally available or are not a free offer. <a href="${CRITERIA_PATH}">How we rank</a>.</p>${altMembership.removed.length > 0 ? `
+    <p class="alt-excluded" style="font-size:.85rem;color:var(--text-muted)">Left out of this list: ${altMembership.removed.map(r => `<a href="/vendor/${toSlug(r.offer.vendor)}">${escHtmlServer(r.offer.vendor)}</a> (${escHtmlServer(MEMBERSHIP_GATE_RULES[r.gate].label.toLowerCase())})`).join(", ")}. Each is still listed in its category, with the vendor's own words we read that from on its page. <a href="${CRITERIA_PATH}#membership">How we decide this</a>.</p>` : ""}
     <div class="alt-list">
 ${enrichedAlts.map(a => altCard(a, false)).join("\n")}
     </div>
@@ -6745,7 +6775,7 @@ function buildTimelyAlternativesPage(slug: string): string | null {
   // Skip category section when we have enough tagged alternatives (6+)
   const primaryOffer = offers.find(o => o.vendor === config.primaryVendor);
   const categoryOffers = taggedOffers.length >= 6 ? [] : (primaryOffer
-    ? offers.filter(o => o.category === primaryOffer.category && o.vendor !== config.primaryVendor && !taggedOffers.some(t => t.vendor === o.vendor))
+    ? partitionAlternatives(offers.filter(o => o.category === primaryOffer.category && o.vendor !== config.primaryVendor && !taggedOffers.some(t => t.vendor === o.vendor)), primaryOffer).kept
     : []);
   const enrichedCategory = enrichOffers(categoryOffers.slice(0, 5));
 

--- a/src/server-remote.ts
+++ b/src/server-remote.ts
@@ -17,6 +17,8 @@ import {
 import { getGuideList, getGuideBySlug } from "./guides.js";
 import { registerMcpAppsResources, TOOL_UI_META } from "./mcp-apps.js";
 import { MCP_INSTRUCTIONS } from "./mcp-instructions.js";
+import { filterAlternatives } from "./product-role.js";
+import type { ProductRole } from "./types.js";
 
 function mcpError(msg: string) {
   return {
@@ -645,14 +647,17 @@ Suggested monitoring cadence: run this check weekly to catch pricing changes ear
       mimeType: "text/plain",
     },
     async (_uri, { slug }) => {
-      const data = (await fetchOffers({ limit: 2000 })) as { offers: Array<{ vendor: string; category: string; tier: string; description: string; url: string; verifiedDate: string; tags: string[]; eligibility?: { type: string; conditions: string[] }; expires_date?: string }>; total: number };
+      const data = (await fetchOffers({ limit: 2000 })) as { offers: Array<{ vendor: string; category: string; tier: string; description: string; url: string; verifiedDate: string; tags: string[]; eligibility?: { type: string; conditions: string[] }; expires_date?: string; product_role?: ProductRole }>; total: number };
       const match = data.offers.find(o => toSlug(o.vendor) === slug);
       if (!match) {
         return { contents: [{ uri: `agentdeals://vendor/${slug}`, text: `No vendor found matching "${slug}".`, mimeType: "text/plain" }] };
       }
 
       const changesData = (await fetchDealChanges({ vendor: match.vendor, since: "2020-01-01" })) as { changes: Array<{ date: string; change_type: string; summary: string; previous_state: string; current_state: string }> };
-      const alternatives = data.offers.filter(o => o.category === match.category && o.vendor !== match.vendor).slice(0, 5);
+      const alternatives = filterAlternatives(
+        data.offers.filter(o => o.category === match.category && o.vendor !== match.vendor),
+        match,
+      ).slice(0, 5);
 
       let text = `# ${match.vendor}\n\n`;
       text += `**Category:** ${match.category}\n`;

--- a/src/server.ts
+++ b/src/server.ts
@@ -17,6 +17,7 @@ import { getStackRecommendation } from "./stacks.js";
 import { estimateCosts } from "./costs.js";
 import { getGuideList, getGuideBySlug } from "./guides.js";
 import type { Offer, EnrichedOffer, DealChange } from "./types.js";
+import { filterAlternatives } from "./product-role.js";
 import { registerMcpAppsResources, TOOL_UI_META } from "./mcp-apps.js";
 import { MCP_INSTRUCTIONS } from "./mcp-instructions.js";
 import { MCP_SIGNAL_FOOTER } from "./signal-copy.js";
@@ -829,9 +830,10 @@ Suggested monitoring cadence: run this check weekly to catch pricing changes ear
       }
       const changes = loadDealChanges().filter(c => c.vendor.toLowerCase() === match.vendor.toLowerCase());
       const stability = classifyStability(changes);
-      const alternatives = offers
-        .filter(o => o.category === match.category && o.vendor !== match.vendor)
-        .slice(0, 5);
+      const alternatives = filterAlternatives(
+        offers.filter(o => o.category === match.category && o.vendor !== match.vendor),
+        match,
+      ).slice(0, 5);
 
       let text = `# ${match.vendor}\n\n`;
       text += `**Category:** ${match.category}\n`;

--- a/src/stacks.ts
+++ b/src/stacks.ts
@@ -2,6 +2,7 @@ import { searchOffers, loadDealChanges, vendorRiskLevel, classifyStability } fro
 import { rankOffers, utcDate, CRITERIA_PATH, DEMOTE_ONLY_POLICY, NOT_MODELLED_NOTICE } from "./ranking.js";
 import type { Demerit, Disclosure, TieBreak } from "./ranking.js";
 import type { Offer, StabilityClass, DealChange } from "./types.js";
+import { partitionRoleCandidates, MEMBERSHIP_GATE_RULES } from "./product-role.js";
 
 /**
  * plan_stack no longer answers "what should I use".
@@ -310,7 +311,8 @@ export function getStackRecommendation(
 
   const stack: StackRole[] = [];
   for (const { role, category } of roleSpecs) {
-    const categoryOffers = searchOffers(undefined, category);
+    const roleMembership = partitionRoleCandidates(searchOffers(undefined, category));
+    const categoryOffers = roleMembership.kept;
     if (categoryOffers.length === 0) continue;
 
     const ranking = rankOffers(categoryOffers, {
@@ -329,9 +331,12 @@ export function getStackRecommendation(
     );
 
     const tieCount = ranking.qualified.length;
-    const reason = tieCount > 0
+    const roleMembershipNote = roleMembership.removed.length > 0
+      ? ` ${roleMembership.removed.map((r) => `${r.offer.vendor} (${MEMBERSHIP_GATE_RULES[r.gate].label.toLowerCase()})`).join(", ")} ${roleMembership.removed.length === 1 ? "is" : "are"} listed in ${category} but cannot fill this role, so ${roleMembership.removed.length === 1 ? "it is" : "they are"} not a candidate here.`
+      : "";
+    const reason = (tieCount > 0
       ? `${tieCount} of ${ranking.ranked.length} ${category} offers carry no recorded demerit and are indistinguishable under every signal we hold; ${candidates.length} shown, in an order seeded on ${date} and the query key. ${ranking.demoted.length} demoted with a named reason, ${ranking.excluded.length} excluded by the gates.`
-      : `No ${category} offer is free of recorded demerits today. Showing the least demoted, each with its reason attached. ${ranking.excluded.length} excluded by the gates.`;
+      : `No ${category} offer is free of recorded demerits today. Showing the least demoted, each with its reason attached. ${ranking.excluded.length} excluded by the gates.`) + roleMembershipNote;
 
     stack.push({
       role,

--- a/src/types.ts
+++ b/src/types.ts
@@ -36,6 +36,17 @@ export interface PaymentProtocol {
   example_cost?: string;
 }
 
+export type DeploymentModel = "hosted" | "self_hosted" | "local_dev_only";
+
+export interface ProductRole {
+  deployment_model: DeploymentModel;
+  is_addon: boolean;
+  augments?: string;
+  source_url: string;
+  source_quote: string;
+  reviewed: string;
+}
+
 export interface Offer {
   vendor: string;
   category: string;
@@ -49,6 +60,7 @@ export interface Offer {
   payment_protocols?: PaymentProtocol[];
   referral?: Referral;
   referral_program?: ReferralProgram;
+  product_role?: ProductRole;
 }
 
 export type StabilityClass = "stable" | "watch" | "volatile" | "improving";

--- a/test/alternatives-membership.test.ts
+++ b/test/alternatives-membership.test.ts
@@ -1,0 +1,332 @@
+import { describe, it, before, after } from "node:test";
+import assert from "node:assert";
+import { spawn, type ChildProcess } from "node:child_process";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import type { Offer } from "../src/types.ts";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO = path.join(__dirname, "..");
+
+const offers: Offer[] = JSON.parse(readFileSync(path.join(REPO, "data", "index.json"), "utf-8")).offers;
+
+const SUBJECT = "Neon";
+const GATED_ADDON = "Prisma Accelerate";
+const GATED_LOCAL = "DynamoDB Local";
+
+function slugOf(vendor: string): string {
+  return vendor.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "");
+}
+
+let serverPort = 0;
+let proc: ChildProcess | null = null;
+
+function startServer(): Promise<ChildProcess> {
+  return new Promise((resolve, reject) => {
+    const child = spawn("node", [path.join(REPO, "dist", "serve.js")], {
+      stdio: ["pipe", "pipe", "pipe"],
+      env: { ...process.env, PORT: "0", BASE_URL: "http://localhost" },
+    });
+    const timeout = setTimeout(() => { child.kill(); reject(new Error("Server startup timeout")); }, 20000);
+    child.stderr!.on("data", (data: Buffer) => {
+      const m = data.toString().match(/running on http:\/\/localhost:(\d+)/);
+      if (m) { serverPort = parseInt(m[1], 10); clearTimeout(timeout); resolve(child); }
+    });
+    child.on("error", (err) => { clearTimeout(timeout); reject(err); });
+  });
+}
+
+const get = async (p: string) => {
+  const res = await fetch(`http://localhost:${serverPort}${p}`);
+  return { status: res.status, body: await res.text() };
+};
+
+function faqAnswers(body: string): string[] {
+  const blocks = body.match(/<script type="application\/ld\+json">([\s\S]*?)<\/script>/g) ?? [];
+  const answers: string[] = [];
+  for (const block of blocks) {
+    const json = block.replace(/^<script type="application\/ld\+json">/, "").replace(/<\/script>$/, "");
+    let parsed: unknown;
+    try { parsed = JSON.parse(json); } catch { continue; }
+    const entries = Array.isArray(parsed) ? parsed : [parsed];
+    for (const entry of entries) {
+      const page = entry as { "@type"?: string; mainEntity?: Array<{ acceptedAnswer?: { text?: string } }> };
+      if (page["@type"] !== "FAQPage" || !Array.isArray(page.mainEntity)) continue;
+      for (const q of page.mainEntity) {
+        if (q.acceptedAnswer?.text) answers.push(q.acceptedAnswer.text);
+      }
+    }
+  }
+  return answers;
+}
+
+function sectionAfter(body: string, heading: string): string {
+  const at = body.indexOf(heading);
+  assert.notEqual(at, -1, `the page must contain a "${heading}" section for this test to mean anything`);
+  const rest = body.slice(at);
+  const end = rest.indexOf("alt-excluded");
+  return end === -1 ? rest.slice(0, 6000) : rest.slice(0, end);
+}
+
+before(async () => {
+  for (const vendor of [SUBJECT, GATED_ADDON, GATED_LOCAL]) {
+    assert.ok(offers.some((o) => o.vendor === vendor), `${vendor} must be in the catalogue for this test to mean anything`);
+  }
+  const addon = offers.find((o) => o.vendor === GATED_ADDON)!;
+  const local = offers.find((o) => o.vendor === GATED_LOCAL)!;
+  assert.equal(addon.product_role?.is_addon, true, `${GATED_ADDON} must be classified as an add-on for this test to mean anything`);
+  assert.equal(local.product_role?.deployment_model, "local_dev_only", `${GATED_LOCAL} must be classified as local-only for this test to mean anything`);
+  proc = await startServer();
+});
+
+after(() => { if (proc) proc.kill(); });
+
+describe("#1032 the vendor page the issue was filed about", () => {
+  it("renders, so the assertions below are about a real page", async () => {
+    const res = await get(`/vendor/${slugOf(SUBJECT)}`);
+    assert.equal(res.status, 200, `/vendor/${slugOf(SUBJECT)} must exist for this test to mean anything`);
+    assert.match(res.body, new RegExp(`<h1>[^<]*${SUBJECT}`, "i"));
+  });
+
+  it("still offers alternatives, so the gates did not empty the list", async () => {
+    const { body } = await get(`/vendor/${slugOf(SUBJECT)}`);
+    const grid = sectionAfter(body, "Alternatives in");
+    const cards = grid.match(/class="alt-name"/g) ?? [];
+    assert.ok(cards.length >= 5, `the alternatives grid must still carry a useful list, found ${cards.length}`);
+  });
+
+  it("does not list a connection pool or a downloadable emulator among them", async () => {
+    const { body } = await get(`/vendor/${slugOf(SUBJECT)}`);
+    const grid = sectionAfter(body, "Alternatives in");
+    assert.ok(!grid.includes(GATED_ADDON), `${GATED_ADDON} is a thing you put in front of ${SUBJECT}, not a replacement for it`);
+    assert.ok(!grid.includes(GATED_LOCAL), `${GATED_LOCAL} cannot serve a production workload and is not a replacement for ${SUBJECT}`);
+  });
+
+  it("says which offers were left out and why, rather than removing them silently", async () => {
+    const { body } = await get(`/vendor/${slugOf(SUBJECT)}`);
+    const notice = body.match(/<p class="alt-excluded"[\s\S]*?<\/p>/);
+    assert.ok(notice, "an offer removed from an alternatives list must be named on the page it was removed from");
+    assert.ok(notice[0].includes(GATED_ADDON), `${GATED_ADDON} must be named in the notice`);
+    assert.ok(notice[0].includes(GATED_LOCAL), `${GATED_LOCAL} must be named in the notice`);
+    assert.match(notice[0], /How we decide this/, "the notice must link to the published rule");
+  });
+
+  it("changes the machine-readable answer, not only the rendered list", async () => {
+    const { body } = await get(`/vendor/${slugOf(SUBJECT)}`);
+    const answers = faqAnswers(body);
+    assert.ok(answers.length > 0, "the vendor page must publish FAQ structured data for this test to mean anything");
+    const alternativesAnswer = answers.find((a) => a.includes("free alternatives to"));
+    assert.ok(alternativesAnswer, "the FAQ must answer what the free alternatives are");
+    assert.ok(!alternativesAnswer.includes(GATED_ADDON), `${GATED_ADDON} must not be quoted as a top free alternative`);
+    assert.ok(!alternativesAnswer.includes(GATED_LOCAL), `${GATED_LOCAL} must not be quoted as a top free alternative`);
+    for (const answer of answers) {
+      assert.ok(!answer.includes(GATED_LOCAL), `no structured answer may present ${GATED_LOCAL} as a ${SUBJECT} option`);
+    }
+  });
+});
+
+describe("#1032 a gated vendor's own page shows the classification and its source", () => {
+  it("publishes the property, the URL it was read from and the sentence", async () => {
+    const { status, body } = await get(`/vendor/${slugOf(GATED_ADDON)}`);
+    assert.equal(status, 200, `/vendor/${slugOf(GATED_ADDON)} must exist for this test to mean anything`);
+    const line = body.match(/<p class="product-role-line"[\s\S]*?<\/p>/);
+    assert.ok(line, "a gated vendor must be able to see how we classified it");
+    const role = offers.find((o) => o.vendor === GATED_ADDON)!.product_role!;
+    assert.ok(line[0].includes(role.source_url), "the classification must cite the page it was read from");
+    assert.ok(line[0].includes(role.source_quote.slice(0, 40)), "the classification must quote the sentence it was read from");
+    assert.ok(line[0].includes(role.reviewed), "the classification must carry the date it was read");
+  });
+
+  it("says the offer is still listed in its category", async () => {
+    const { body } = await get(`/vendor/${slugOf(GATED_LOCAL)}`);
+    const line = body.match(/<p class="product-role-line"[\s\S]*?<\/p>/);
+    assert.ok(line, `${GATED_LOCAL} must publish its classification`);
+    const category = offers.find((o) => o.vendor === GATED_LOCAL)!.category;
+    assert.ok(line[0].includes(category), "the page must say where the offer is still listed");
+  });
+
+  it("publishes nothing for an offer we have not reviewed", async () => {
+    const unreviewed = offers.find((o) => !o.product_role && o.category === "Databases")!;
+    assert.ok(unreviewed, "the catalogue must contain an unreviewed record for this test to mean anything");
+    const { body } = await get(`/vendor/${slugOf(unreviewed.vendor)}`);
+    assert.ok(!body.includes("product-role-line"), "an unreviewed offer must not carry a classification line");
+  });
+});
+
+describe("#1032 inventory surfaces are not filtered", () => {
+  it("keeps gated offers on their category page", async () => {
+    const category = offers.find((o) => o.vendor === GATED_ADDON)!.category;
+    const { status, body } = await get(`/category/${slugOf(category)}`);
+    assert.equal(status, 200, `/category/${slugOf(category)} must exist for this test to mean anything`);
+    assert.ok(body.includes(GATED_ADDON), `${GATED_ADDON} must still be listed in ${category}`);
+    assert.ok(body.includes(GATED_LOCAL), `${GATED_LOCAL} must still be listed in ${category}`);
+  });
+
+  it("keeps gated offers in the JSON catalogue, with the classification attached", async () => {
+    const { status, body } = await get(`/api/offers?category=Databases&limit=200`);
+    assert.equal(status, 200);
+    const parsed = JSON.parse(body) as { offers: Offer[] };
+    const addon = parsed.offers.find((o) => o.vendor === GATED_ADDON);
+    assert.ok(addon, `${GATED_ADDON} must still be returned by the catalogue API`);
+    assert.equal(addon.product_role?.is_addon, true, "the API record must publish the classification");
+    assert.ok(parsed.offers.some((o) => o.vendor === GATED_LOCAL), `${GATED_LOCAL} must still be returned by the catalogue API`);
+  });
+
+  it("keeps gated offers findable by search", async () => {
+    const { status, body } = await get(`/api/offers?q=${encodeURIComponent(GATED_LOCAL)}`);
+    assert.equal(status, 200);
+    const parsed = JSON.parse(body) as { offers: Offer[] };
+    assert.ok(parsed.offers.some((o) => o.vendor === GATED_LOCAL), `a caller who searches for ${GATED_LOCAL} must find it`);
+  });
+});
+
+describe("#1032 every page in an affected category, not only the one in the issue", () => {
+  const gatedByCategory = new Map<string, Offer[]>();
+  for (const o of offers) {
+    if (!o.product_role) continue;
+    if (o.product_role.deployment_model !== "local_dev_only" && !o.product_role.is_addon) continue;
+    gatedByCategory.set(o.category, [...(gatedByCategory.get(o.category) ?? []), o]);
+  }
+
+  it("has categories to sweep, so the assertions below have subjects", () => {
+    assert.ok(gatedByCategory.size > 0, "no category carries a gated record, so the sweep below checks nothing");
+  });
+
+  for (const [category, gatedHere] of gatedByCategory) {
+    it(`shows no gated offer in any ${category} alternatives grid`, async () => {
+      const subjects = offers.filter((o) => o.category === category && !gatedHere.some((g) => g.vendor === o.vendor));
+      assert.ok(subjects.length > 5, `${category} needs enough vendor pages to sweep, found ${subjects.length}`);
+      let gridsChecked = 0;
+      const offenders: string[] = [];
+      for (const subject of subjects) {
+        const { status, body } = await get(`/vendor/${slugOf(subject.vendor)}`);
+        if (status !== 200) continue;
+        const at = body.indexOf("Alternatives in");
+        if (at === -1) continue;
+        const grid = body.slice(at, body.indexOf("alt-excluded", at) === -1 ? at + 6000 : body.indexOf("alt-excluded", at));
+        gridsChecked += 1;
+        for (const gated of gatedHere) {
+          if (grid.includes(gated.vendor)) offenders.push(`${gated.vendor} on /vendor/${slugOf(subject.vendor)}`);
+        }
+      }
+      assert.ok(gridsChecked > 5, `the sweep must actually read grids, read ${gridsChecked}`);
+      assert.deepStrictEqual(offenders, [], `these offers cannot replace the vendor whose page lists them: ${offenders.join("; ")}`);
+    });
+
+    it(`names the gated ${category} offers on every page they were removed from`, async () => {
+      const subject = offers.find((o) => o.category === category && !gatedHere.some((g) => g.vendor === o.vendor))!;
+      const { body } = await get(`/vendor/${slugOf(subject.vendor)}`);
+      const notice = body.match(/<p class="alt-excluded"[\s\S]*?<\/p>/);
+      assert.ok(notice, `/vendor/${slugOf(subject.vendor)} removed offers without naming them`);
+      for (const gated of gatedHere) {
+        assert.ok(notice[0].includes(gated.vendor), `${gated.vendor} must be named on /vendor/${slugOf(subject.vendor)}`);
+      }
+    });
+  }
+});
+
+describe("#1032 the other recommendation surfaces", () => {
+  it("leaves gated offers out of the alternatives page", async () => {
+    const { status, body } = await get(`/alternative-to/${slugOf(SUBJECT)}`);
+    assert.equal(status, 200, `/alternative-to/${slugOf(SUBJECT)} must exist for this test to mean anything`);
+    const headingAt = body.indexOf("All Free Alternatives");
+    assert.notEqual(headingAt, -1, "the full alternatives section must render for this test to mean anything");
+    const listStart = body.indexOf('<div class="alt-list">', headingAt);
+    assert.notEqual(listStart, -1, "the alternatives list must render for this test to mean anything");
+    const list = body.slice(listStart, body.indexOf("</div>\n  </div>", listStart));
+    const rows = list.match(/class="alt-vendor-name"/g) ?? [];
+    assert.ok(rows.length >= 5, `the alternatives list must carry entries for this test to mean anything, found ${rows.length}`);
+    assert.ok(!list.includes(GATED_ADDON), `${GATED_ADDON} must not appear in the alternatives list`);
+    assert.ok(!list.includes(GATED_LOCAL), `${GATED_LOCAL} must not appear in the alternatives list`);
+  });
+
+  it("leaves gated offers out of a role recommendation and says so", async () => {
+    const { status, body } = await get(`/api/stack?use_case=${encodeURIComponent("postgres api backend")}`);
+    assert.equal(status, 200);
+    const parsed = JSON.parse(body) as { stack: Array<{ role: string; category: string; candidates: Array<{ vendor: string }>; reason: string }> };
+    const database = parsed.stack.find((r) => r.category === "Databases");
+    assert.ok(database, "the stack must contain a database role for this test to mean anything");
+    assert.ok(database.candidates.length > 0, "the database role must still return candidates");
+    const vendors = database.candidates.map((c) => c.vendor);
+    assert.ok(!vendors.includes(GATED_ADDON), `${GATED_ADDON} cannot fill a database role`);
+    assert.ok(!vendors.includes(GATED_LOCAL), `${GATED_LOCAL} cannot fill a database role`);
+    assert.ok(database.reason.includes(GATED_ADDON), "the role must say which offers it left out");
+  });
+
+  it("leaves gated offers out of the vendor risk tool's alternatives, on every page in the category", async () => {
+    const category = offers.find((o) => o.vendor === GATED_ADDON)!.category;
+    const subjects = offers.filter((o) => o.category === category && o.vendor !== GATED_ADDON && o.vendor !== GATED_LOCAL);
+    let answered = 0;
+    const offenders: string[] = [];
+    for (const subject of subjects) {
+      const { status, body } = await get(`/api/vendor-risk/${encodeURIComponent(subject.vendor)}`);
+      if (status !== 200) continue;
+      const parsed = JSON.parse(body) as { alternatives?: Array<{ vendor: string }> };
+      if (!parsed.alternatives?.length) continue;
+      answered += 1;
+      for (const gated of [GATED_ADDON, GATED_LOCAL]) {
+        if (parsed.alternatives.some((a) => a.vendor === gated)) offenders.push(`${gated} offered as an alternative to ${subject.vendor}`);
+      }
+    }
+    assert.ok(answered > 10, `the sweep must actually read risk results, read ${answered}`);
+    assert.deepStrictEqual(offenders, [], `these products cannot replace the vendor they are offered against: ${offenders.join("; ")}`);
+  });
+
+  it("leaves gated offers out of the vendor detail tool's related vendors", async () => {
+    const category = offers.find((o) => o.vendor === GATED_ADDON)!.category;
+    const subjects = offers.filter((o) => o.category === category && o.vendor !== GATED_ADDON && o.vendor !== GATED_LOCAL);
+    let answered = 0;
+    const offenders: string[] = [];
+    for (const subject of subjects) {
+      const { status, body } = await get(`/api/details/${encodeURIComponent(subject.vendor)}?alternatives=true`);
+      if (status !== 200) continue;
+      const parsed = JSON.parse(body) as { offer?: { relatedVendors?: string[]; alternatives?: Array<{ vendor: string }> } };
+      const related = parsed.offer?.relatedVendors;
+      if (!related?.length) continue;
+      answered += 1;
+      for (const gated of [GATED_ADDON, GATED_LOCAL]) {
+        if (related.includes(gated)) offenders.push(`${gated} related to ${subject.vendor}`);
+        if (parsed.offer?.alternatives?.some((a) => a.vendor === gated)) offenders.push(`${gated} listed as an alternative to ${subject.vendor}`);
+      }
+    }
+    assert.ok(answered > 10, `the sweep must actually read detail results, read ${answered}`);
+    assert.deepStrictEqual(offenders, [], `these products cannot replace the vendor they are returned against: ${offenders.join("; ")}`);
+  });
+});
+
+describe("#1032 a classification must not contradict what we already publish", () => {
+  const curated = new Set<string>();
+  const changes = JSON.parse(readFileSync(path.join(REPO, "data", "deal_changes.json"), "utf-8")).changes as Array<{ alternatives?: string[] }>;
+  for (const c of changes) {
+    for (const a of c.alternatives ?? []) curated.add(a);
+  }
+
+  it("reads the curated alternatives, so the assertion below has a subject", () => {
+    assert.ok(curated.size > 50, `the change records must name alternatives for this test to mean anything, found ${curated.size}`);
+  });
+
+  it("never gates a vendor our own change records recommend as an alternative", () => {
+    const conflicts = offers
+      .filter((o) => o.product_role && (o.product_role.deployment_model === "local_dev_only" || o.product_role.is_addon))
+      .filter((o) => curated.has(o.vendor))
+      .map((o) => o.vendor);
+    assert.deepStrictEqual(
+      conflicts,
+      [],
+      `we recommend these as alternatives in our own dated records and cannot also hold that they replace nothing: ${conflicts.join(", ")}`
+    );
+  });
+});
+
+describe("#1032 the rule is published", () => {
+  it("explains both properties on the criteria page", async () => {
+    const { status, body } = await get("/criteria");
+    assert.equal(status, 200);
+    assert.ok(body.includes('id="membership"'), "the criteria page must carry the anchor the vendor pages link to");
+    assert.ok(body.includes("local_dev_only"), "the criteria page must name the deployment property");
+    assert.ok(body.includes("addon"), "the criteria page must name the add-on property");
+    assert.match(body, /Neither property is available on request/, "the criteria page must say the classification cannot be requested");
+    assert.match(body, /has not been reviewed/, "the criteria page must say what an unclassified record means");
+  });
+});

--- a/test/product-role.test.ts
+++ b/test/product-role.test.ts
@@ -1,0 +1,297 @@
+import { describe, it } from "node:test";
+import assert from "node:assert";
+import { readFileSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  membershipGatesFor,
+  alternativeMembershipGate,
+  roleMembershipGate,
+  partitionAlternatives,
+  partitionAlternativesAcross,
+  partitionRoleCandidates,
+  filterAlternatives,
+  productRoleSentence,
+  MEMBERSHIP_GATE_ORDER,
+  MEMBERSHIP_GATE_RULES,
+} from "../src/product-role.ts";
+import { rankForListing, rankOffers } from "../src/ranking.ts";
+import type { Offer, ProductRole, DeploymentModel } from "../src/types.ts";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REPO = join(__dirname, "..");
+const index = JSON.parse(readFileSync(join(REPO, "data", "index.json"), "utf8")) as { offers: Offer[] };
+
+const DEPLOYMENT_MODELS: DeploymentModel[] = ["hosted", "self_hosted", "local_dev_only"];
+
+function offer(vendor: string, role?: Partial<ProductRole>): Offer {
+  return {
+    vendor,
+    category: "Databases",
+    description: `${vendor} description`,
+    tier: "Free",
+    url: `https://${vendor.toLowerCase()}.example/pricing`,
+    tags: [],
+    verifiedDate: "2026-08-01",
+    ...(role
+      ? {
+          product_role: {
+            deployment_model: "hosted",
+            is_addon: false,
+            source_url: `https://${vendor.toLowerCase()}.example/docs`,
+            source_quote: "quote",
+            reviewed: "2026-08-25",
+            ...role,
+          } as ProductRole,
+        }
+      : {}),
+  };
+}
+
+const hosted = offer("Hosted");
+const emulator = offer("Emulator", { deployment_model: "local_dev_only" });
+const otherEmulator = offer("OtherEmulator", { deployment_model: "local_dev_only" });
+const addon = offer("Addon", { is_addon: true, augments: "a database you already run" });
+const otherAddon = offer("OtherAddon", { is_addon: true });
+const selfHosted = offer("SelfHosted", { deployment_model: "self_hosted" });
+const unreviewed = offer("Unreviewed");
+
+describe("#1032 which product properties gate membership", () => {
+  it("an unclassified record carries no gate", () => {
+    assert.deepStrictEqual([...membershipGatesFor(unreviewed)], []);
+  });
+
+  it("only local_dev_only gates on deployment model, and self-hosted never does", () => {
+    assert.deepStrictEqual([...membershipGatesFor(emulator)], ["local_dev_only"]);
+    assert.deepStrictEqual([...membershipGatesFor(selfHosted)], []);
+    assert.deepStrictEqual([...membershipGatesFor(hosted)], []);
+  });
+
+  it("an add-on gates whatever it is deployed as", () => {
+    assert.deepStrictEqual([...membershipGatesFor(addon)], ["addon"]);
+    const selfHostedAddon = offer("Both", { deployment_model: "self_hosted", is_addon: true });
+    assert.deepStrictEqual([...membershipGatesFor(selfHostedAddon)], ["addon"]);
+  });
+
+  it("a record can carry both gates", () => {
+    const both = offer("Both", { deployment_model: "local_dev_only", is_addon: true });
+    assert.deepStrictEqual([...membershipGatesFor(both)].sort(), ["addon", "local_dev_only"]);
+  });
+
+  it("every gate in the order table has published wording", () => {
+    for (const gate of MEMBERSHIP_GATE_ORDER) {
+      assert.ok(MEMBERSHIP_GATE_RULES[gate].label.length > 0, `${gate} needs a label`);
+      assert.ok(MEMBERSHIP_GATE_RULES[gate].rule.length > 20, `${gate} needs a rule a reader can check`);
+    }
+    assert.deepStrictEqual(
+      Object.keys(MEMBERSHIP_GATE_RULES).sort(),
+      [...MEMBERSHIP_GATE_ORDER].sort(),
+      "the published table and the applied order must name the same gates"
+    );
+  });
+});
+
+describe("#1032 a gate removes a candidate only where the subject cannot carry it too", () => {
+  it("removes a local-only product from a hosted product's alternatives", () => {
+    assert.equal(alternativeMembershipGate(emulator, hosted), "local_dev_only");
+  });
+
+  it("keeps a local-only product in another local-only product's alternatives", () => {
+    assert.equal(alternativeMembershipGate(emulator, otherEmulator), null);
+  });
+
+  it("removes an add-on from the alternatives of the thing it augments", () => {
+    assert.equal(alternativeMembershipGate(addon, hosted), "addon");
+  });
+
+  it("keeps an add-on in another add-on's alternatives", () => {
+    assert.equal(alternativeMembershipGate(addon, otherAddon), null);
+  });
+
+  it("never removes a candidate that carries no gate", () => {
+    for (const subject of [hosted, emulator, addon, selfHosted, unreviewed]) {
+      assert.equal(alternativeMembershipGate(hosted, subject), null);
+      assert.equal(alternativeMembershipGate(selfHosted, subject), null);
+      assert.equal(alternativeMembershipGate(unreviewed, subject), null);
+    }
+  });
+
+  it("a subject carrying one gate does not inherit the other", () => {
+    assert.equal(alternativeMembershipGate(addon, emulator), "addon");
+    assert.equal(alternativeMembershipGate(emulator, addon), "local_dev_only");
+  });
+
+  it("reports the removed candidates and the gate that removed each", () => {
+    const { kept, removed } = partitionAlternatives([hosted, emulator, addon, selfHosted], hosted);
+    assert.deepStrictEqual(kept.map((o) => o.vendor), ["Hosted", "SelfHosted"]);
+    assert.deepStrictEqual(
+      removed.map((r) => [r.offer.vendor, r.gate]),
+      [["Emulator", "local_dev_only"], ["Addon", "addon"]]
+    );
+  });
+
+  it("filterAlternatives keeps exactly what partitionAlternatives keeps", () => {
+    const candidates = [hosted, emulator, addon, selfHosted, unreviewed];
+    assert.deepStrictEqual(
+      filterAlternatives(candidates, hosted).map((o) => o.vendor),
+      partitionAlternatives(candidates, hosted).kept.map((o) => o.vendor)
+    );
+  });
+
+  it("a vendor listed in several categories keeps a candidate any one of its records could keep", () => {
+    const acrossOne = partitionAlternativesAcross([emulator], [hosted]);
+    assert.deepStrictEqual(acrossOne.removed.map((r) => r.offer.vendor), ["Emulator"]);
+    const acrossBoth = partitionAlternativesAcross([emulator], [hosted, otherEmulator]);
+    assert.deepStrictEqual(acrossBoth.kept.map((o) => o.vendor), ["Emulator"]);
+  });
+});
+
+describe("#1032 a role recommendation has no subject to compare against", () => {
+  it("removes every gated candidate from a role, both gates", () => {
+    const { kept, removed } = partitionRoleCandidates([hosted, emulator, addon, selfHosted, unreviewed]);
+    assert.deepStrictEqual(kept.map((o) => o.vendor), ["Hosted", "SelfHosted", "Unreviewed"]);
+    assert.deepStrictEqual(removed.map((r) => r.gate), ["local_dev_only", "addon"]);
+  });
+
+  it("names a gate for a gated record and nothing for an ungated one", () => {
+    assert.equal(roleMembershipGate(emulator), "local_dev_only");
+    assert.equal(roleMembershipGate(addon), "addon");
+    assert.equal(roleMembershipGate(selfHosted), null);
+    assert.equal(roleMembershipGate(unreviewed), null);
+  });
+});
+
+describe("#1032 neither property can reach scoring or ordering", () => {
+  const rankingSource = readFileSync(join(REPO, "src", "ranking.ts"), "utf8");
+
+  it("the selection module does not mention either property", () => {
+    for (const banned of [/product_role/, /deployment_model/, /is_addon/, /local_dev_only/]) {
+      assert.ok(!banned.test(rankingSource), `the selection module must not read ${banned}`);
+    }
+  });
+
+  it("flipping every classification leaves the order of a listing byte-identical", () => {
+    const candidates = index.offers.filter((o) => o.category === "Databases");
+    assert.ok(candidates.length > 10, "this test needs a category with enough records to order");
+
+    const before = rankForListing(candidates, { queryKey: "order-check", changes: [], date: "2026-08-25" });
+    const flipped = candidates.map((o) => ({
+      ...o,
+      product_role: {
+        deployment_model: (o.product_role?.deployment_model === "local_dev_only" ? "hosted" : "local_dev_only") as DeploymentModel,
+        is_addon: !o.product_role?.is_addon,
+        source_url: "https://example.invalid/docs",
+        source_quote: "flipped for this test",
+        reviewed: "2026-08-25",
+      },
+    }));
+    const after = rankForListing(flipped, { queryKey: "order-check", changes: [], date: "2026-08-25" });
+
+    assert.deepStrictEqual(
+      after.entries.map((e) => e.offer.vendor),
+      before.entries.map((e) => e.offer.vendor),
+      "the classification must not move a single position"
+    );
+    assert.deepStrictEqual(
+      after.entries.map((e) => e.demerit_total),
+      before.entries.map((e) => e.demerit_total),
+      "the classification must not add or remove a single demerit point"
+    );
+  });
+
+  it("a gated offer scores exactly what it scored before it was classified", () => {
+    const subject = index.offers.find((o) => o.vendor === "DynamoDB Local");
+    assert.ok(subject, "DynamoDB Local must be in the catalogue for this test to mean anything");
+    const withoutRole = { ...subject } as Offer;
+    delete withoutRole.product_role;
+    const opts = { queryKey: "score-check", changes: [], date: "2026-08-25" };
+    assert.deepStrictEqual(
+      rankOffers([subject], opts).ranked.map((e) => e.demerit_total),
+      rankOffers([withoutRole], opts).ranked.map((e) => e.demerit_total)
+    );
+  });
+});
+
+describe("#1032 every classification in the catalogue is publishable", () => {
+  const classified = index.offers.filter((o) => o.product_role);
+
+  it("classifies at least one record, so the assertions below have a subject", () => {
+    assert.ok(classified.length > 0, "no record carries a product_role, so nothing below is being checked");
+  });
+
+  it("uses only the three published deployment models", () => {
+    for (const o of classified) {
+      assert.ok(
+        DEPLOYMENT_MODELS.includes(o.product_role!.deployment_model),
+        `${o.vendor} carries an unpublished deployment model: ${o.product_role!.deployment_model}`
+      );
+    }
+  });
+
+  it("carries a source on an outside site and the sentence read from it", () => {
+    for (const o of classified) {
+      const role = o.product_role!;
+      assert.ok(role.source_url.startsWith("https://"), `${o.vendor} needs an https source`);
+      assert.ok(!role.source_url.includes("agentdeals"), `${o.vendor} must cite the vendor, not us`);
+      assert.ok(role.source_quote.trim().length > 20, `${o.vendor} needs the sentence it was read from`);
+      assert.match(role.reviewed, /^\d{4}-\d{2}-\d{2}$/, `${o.vendor} needs the date it was read`);
+    }
+  });
+
+  it("marks an add-on with what it extends", () => {
+    for (const o of classified.filter((x) => x.product_role!.is_addon)) {
+      assert.ok((o.product_role!.augments ?? "").length > 0, `${o.vendor} is gated as an add-on without saying what it extends`);
+    }
+  });
+
+  it("says in one sentence what the classification means for where the offer appears", () => {
+    for (const o of classified) {
+      const sentence = productRoleSentence(o)!;
+      assert.ok(sentence.includes(o.vendor), `${o.vendor}'s published sentence must name it`);
+      assert.ok(sentence.includes(o.category), `${o.vendor}'s published sentence must say where it is still listed`);
+    }
+    assert.equal(productRoleSentence(unreviewed), null, "an unreviewed offer publishes no sentence");
+  });
+});
+
+describe("#1032 what the gates do to the catalogue", () => {
+  const categories = [...new Set(index.offers.map((o) => o.category))];
+
+  it("leaves the two entries the issue names out of the Neon alternatives set", () => {
+    const neon = index.offers.find((o) => o.vendor === "Neon");
+    assert.ok(neon, "Neon must be in the catalogue for this test to mean anything");
+    const kept = filterAlternatives(
+      index.offers.filter((o) => o.category === neon.category && o.vendor !== neon.vendor),
+      neon
+    ).map((o) => o.vendor);
+    assert.ok(kept.length > 0, "the Neon alternatives set must not be empty");
+    assert.ok(!kept.includes("Prisma Accelerate"), "a connection pool is not an alternative to a database");
+    assert.ok(!kept.includes("DynamoDB Local"), "a downloadable emulator is not an alternative to a hosted database");
+  });
+
+  it("does not drop any category's alternatives list below three entries", () => {
+    const thin: string[] = [];
+    for (const category of categories) {
+      const inCategory = index.offers.filter((o) => o.category === category);
+      if (inCategory.length < 4) continue;
+      for (const subject of inCategory) {
+        const kept = filterAlternatives(inCategory.filter((o) => o.vendor !== subject.vendor), subject);
+        if (kept.length < 3) thin.push(`${subject.vendor} (${category}): ${kept.length}`);
+      }
+    }
+    assert.deepStrictEqual(thin, [], `these alternatives lists fall below three entries: ${thin.join("; ")}`);
+  });
+
+  it("leaves reviewed products that are their own category's real thing ungated", () => {
+    const mustStay = ["MinIO", "Bruno", "Insomnia", "Playwright", "LanceDB", "AWS SAM CLI", "Appetize", "ElasticMQ"];
+    for (const vendor of mustStay) {
+      const record = index.offers.find((o) => o.vendor === vendor);
+      assert.ok(record, `${vendor} must be in the catalogue for this test to mean anything`);
+      assert.deepStrictEqual(
+        [...membershipGatesFor(record)],
+        [],
+        `${vendor} runs real workloads and must stay in its category's alternatives lists`
+      );
+    }
+  });
+});


### PR DESCRIPTION
Refs #1032. Phase 1 only — `deployment_model` and `is_addon`. No taxonomy, no subtypes, nothing from Phase 2.

## What is on the page now

`/vendor/neon` lists SurrealDB Cloud, Nhost, Nile, InfluxDB Cloud, SeaTable, skyvia.com, Neo4j AuraDB, Chroma, Google Cloud BigQuery, Upstash, Convex, LanceDB — and under it:

> Left out of this list: Hasura Cloud (extends another product), DynamoDB Local (runs only on a developer machine), Prisma Accelerate (extends another product). Each is still listed in Databases, with the vendor's own words we read that from on its page.

The `FAQPage` answer changed with it, and so did the MCP results. Verified over a real `initialize` → `tools/call`: `plan_stack` returns no gated candidate for the Database role and says which three it left out; `search_deals` related vendors and `compare_vendors` alternatives carry none.

## The rule, and where it differs from the issue

The issue says `local_dev_only` is excluded from alternatives surfaces, full stop. I implemented one thing narrower:

**A gate removes a candidate only where the subject of the list does not carry the same gate.**

The blanket rule deletes the true answer from the pages where it is most needed. `/alternative-to/localstack` would lose Floci, Vera AWS, CloudDev and DynamoDB Local — every actual alternative to LocalStack, all at once — because they are all emulators. One emulator is still an alternative to another; one add-on is still an alternative to another. Everything the issue asks for still holds: Neon carries no gate, so it loses all three.

It is asymmetric in the safe direction. A gated subject keeps ungated candidates, so `/vendor/prisma-accelerate` still lists Neon. That is imperfect and I have left it — the fix is "show other poolers first", which is ordering, and ordering is exactly what this property must not touch. **Flagging it for Phase 2.**

## What the gates remove

7 records carry a gate, out of 10 classified, out of 1,571.

| record | category | gate | source |
|---|---|---|---|
| DynamoDB Local | Databases | `local_dev_only` | AWS: "the database is self-contained on your computer" |
| Prisma Accelerate | Databases | `addon` | Prisma: "a managed connection pool and global cache" |
| Hasura Cloud | Databases | `addon` | Hasura: "native data connectors to make your data accessible through a GraphQL API" |
| LocalStack | Testing | `local_dev_only` | LocalStack: "before they touch the cloud" |
| Floci | Cloud IaaS | `local_dev_only` | "The AWS Local Emulator alternative" |
| Vera AWS | Cloud IaaS | `local_dev_only` | "emulators running in your laptop" |
| CloudDev | Cloud IaaS | `local_dev_only` | "Run AWS services locally" |

Per surface, from `node scripts/membership-impact.js`:

| surface | effect |
|---|---|
| vendor page alternatives | 126 lists shrink — Databases 45, Testing 44, Cloud IaaS 37 |
| `/alternative-to/:slug` | same set, one entry each |
| `getOfferDetails` related vendors | same set |
| `checkVendorRisk` alternatives | same set |
| `/api/stack` role candidates | Databases −3, Cloud IaaS −3, Testing −1 |
| category / best-of / search / `/api/offers` | **unchanged** |

**No category's alternatives list falls below 3.** The worst case is 37 entries. Asserted as a test over every category, not measured once.

Also classified and deliberately **not** gated, because a probe flags them and the answer is no: MinIO (`self_hosted`, runs production), ElasticMQ (`self_hosted`), Appetize (`hosted` — the emulator is the service). Pinned by test alongside Bruno, Insomnia, Playwright, LanceDB and AWS SAM CLI, which deploys as well as running locally.

## Published and contestable

Every gated vendor page carries the property, the URL on the vendor's own site, the sentence read from it, and the date. `/criteria` §5 has the table, the symmetry rule, the scope, and **"Neither property is available on request."**

The honest limit is on the page too: **10 of 1,571 reviewed, and an unclassified record has not been checked** — it does not mean we looked and found it hosted. Absence gates nothing and publishes nothing, the same rule as a link we were merely refused.

## Two things found on the way

**A sixth and seventh alternatives surface the issue does not list.** `agentdeals://vendor/{slug}` in *both* MCP servers builds its own alternatives with `.slice(0, 5)` over `data/index.json` file order. Membership is gated here now. **The ordering is not** — whoever was typed into the file first still wins, in a published MCP resource, which contradicts what `/criteria` claims about every recommendation surface resolving through the shared module. Out of scope for this PR and I would rather you sequence it than have me fold it in.

**The three-value enum does not describe a developer CLI or a desktop client.** AWS SAM CLI, Bruno, Insomnia and Playwright are none of `hosted` / `self_hosted` / `local_dev_only`. I left them unclassified rather than forcing a value, and pinned them by test instead. Worth knowing before Phase 2 puts a taxonomy on top of this.

**And `/api/stack` still answers your example badly.** `postgres api backend` now returns Amazon Aurora PostgreSQL, Zilliz Cloud, Neo4j AuraDB, SeaTable, Chroma, Nhost, Redis Cloud, StackBy. Phase 1 removed the pooler and the emulator; a vector store, a graph database and two spreadsheets are still there. That is the subtype problem and Phase 1 does not touch it.

## Editorial cross-check

A vendor named as an alternative in any of our 287 dated change records cannot be gated as replacing nothing. None of the 7 is named; Supabase is. Asserted as a test — it is the guard that caught the one mutation my hand-written pins missed.

## Verified

- `tsc` clean; **1,574 pass / 0 fail** (1,522 at wake, +52).
- **26 mutations applied to the real source and data, each rebuilt and re-run. All 26 produce failures.** Four survived the first pass and all four were real gaps: the vendor-page assertion was passing on a 12-of-44 slice rather than on the gate, two surfaces had no test at all, and nothing stopped a legitimate database being gated. Fixed by sweeping every vendor page and every risk result in an affected category, and by the cross-check above.
- Real `dist/serve.js` booted; full MCP `initialize` → `notifications/initialized` → `tools/call`.
- Screenshots of `/vendor/neon`, `/vendor/prisma-accelerate` and `/criteria#membership`.
