### PR TITLE
Assert the AI/ML band is a total partition rather than a fixed count

### DIFF
--- a/test/ranking.test.ts
+++ b/test/ranking.test.ts
@@ -439,19 +439,27 @@ describe("the live index, ranked", () => {
   });
 
   it("AI/ML: the vendors whose free tier is really a credit grant are demoted", () => {
-    const r = rankOffers(index.offers.filter((o) => o.category === "AI / ML"), {
+    const offers = index.offers.filter((o) => o.category === "AI / ML");
+    const r = rankOffers(offers, {
       queryKey: "best-of:AI / ML",
       changes: dealChanges,
       date: TODAY,
     });
     const demoted = new Map(r.demoted.map((e) => [e.offer.vendor, e]));
-    for (const vendor of ["OpenAI", "Google Gemini API", "Clarifai", "xAI"]) {
+    const withdrawn = ["OpenAI", "Google Gemini API", "Clarifai", "xAI"];
+    const credits = ["Cohere", "Together AI", "Fireworks AI", "Modal", "DeepSeek API"];
+    for (const vendor of withdrawn) {
       assert.ok(demoted.get(vendor)?.demerits.some((d) => d.code === "free_tier_withdrawn"), `${vendor} withdrew a free tier and must be demoted`);
     }
-    for (const vendor of ["Cohere", "Together AI", "Fireworks AI", "Modal", "DeepSeek API"]) {
+    for (const vendor of credits) {
       assert.ok(demoted.get(vendor)?.demerits.some((d) => d.code === "time_limited_offer"), `${vendor} offers credits, not a free tier`);
     }
-    assert.strictEqual(r.qualified.length, 47);
+    const qualified = vendorsOf(r.qualified);
+    for (const vendor of [...withdrawn, ...credits]) {
+      assert.ok(!qualified.includes(vendor), `${vendor} is demoted and must not also be in the qualified band`);
+    }
+    assert.strictEqual(r.qualified.length + r.demoted.length + r.excluded.length, offers.length);
+    assert.ok(r.qualified.length > 0);
   });
 
   it("every demotion on every page names a specific recorded fact", () => {


### PR DESCRIPTION
`test/ranking.test.ts` pinned `r.qualified.length` to 47 for AI / ML. The daily re-verification job (`4dbdf9a`) refreshed three `verifiedDate` values; **Kaggle** (2026-04-05 → 2026-08-24) came off its stale-verification demotion and rejoined the band, making it 48. Main has been red since that commit.

The catalogue did not change size — AI / ML holds 70 offers before and after. One offer moved demoted → qualified, which is the re-verification loop doing exactly its job.

Bumping 47 → 48 would re-arm the trap on the next refresh, so the census assertion is replaced by two properties that do not drift:

- every offer lands in exactly one of `qualified`, `demoted`, `excluded`
- no vendor named in the test's own `withdrawn`/`credits` lists appears in `qualified`

The second is strictly stronger than the count for what this test is about — it catches a demotion silently failing, which a total could not.

Bite-verified: making `qualified` drop one entry fails this test (and the Databases sibling). Restored, 43/43 green.

Same fixed-count pattern is still present on the Databases case (`qualified.length === 41`, `excluded.length === 3`) and in the compare-pages count. Left alone here because they pass today and this PR is about unblocking main, but they are the same landmine.