### PR TITLE
Write a dated durable copy of each day's analytics (#1056 durability half)

### DIFF
--- a/.github/workflows/analytics-rollup.yml
+++ b/.github/workflows/analytics-rollup.yml
@@ -1,0 +1,63 @@
+name: Daily analytics rollup
+
+on:
+  schedule:
+    - cron: "30 4 * * *"
+  workflow_dispatch:
+    inputs:
+      date:
+        description: "Single YYYY-MM-DD to roll up (blank = every date on offer)"
+        required: false
+        default: ""
+
+permissions:
+  contents: write
+
+concurrency:
+  group: analytics-rollup
+  cancel-in-progress: false
+
+jobs:
+  rollup:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Roll up
+        id: rollup
+        env:
+          SINGLE_DATE: ${{ github.event.inputs.date }}
+        run: |
+          set -o pipefail
+          if [ -n "$SINGLE_DATE" ]; then
+            node scripts/rollup-analytics.js --date "$SINGLE_DATE" | tee /tmp/rollup.log
+          else
+            node scripts/rollup-analytics.js | tee /tmp/rollup.log
+          fi
+          WRITTEN=$(grep -oE '^Rolled up: [0-9]+' /tmp/rollup.log | grep -oE '[0-9]+$' || echo 0)
+          echo "written=$WRITTEN" >> "$GITHUB_OUTPUT"
+
+      - name: Commit and push if changed
+        env:
+          WRITTEN: ${{ steps.rollup.outputs.written }}
+        run: |
+          if [ -z "$(git status --porcelain -- data/analytics)" ]; then
+            echo "No change under data/analytics — skipping commit."
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add data/analytics
+          git commit -m "data(auto): analytics rollup — ${WRITTEN} day(s)"
+          git push origin HEAD:main

--- a/scripts/e2e-1056.mjs
+++ b/scripts/e2e-1056.mjs
@@ -1,0 +1,327 @@
+import { createServer } from "node:http";
+import { spawn } from "node:child_process";
+import { mkdtempSync, rmSync, readFileSync, readdirSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const HELP = `End-to-end check for the durable daily analytics rollup.
+
+Boots the real dist/serve.js against a fake Upstash holding a production-shaped
+snapshot, reads the real endpoint, runs the real collector script against it, and
+restarts the server pointed at the files the collector wrote. Covers the two things
+unit tests cannot: that the endpoint is wired to the stored snapshot, and that a
+process which starts with an empty Redis still reports the history on disk.
+
+Usage: node scripts/e2e-1056.mjs
+`;
+
+if (process.argv.includes("--help") || process.argv.includes("-h")) {
+  console.log(HELP);
+  process.exit(0);
+}
+
+const store = new Map();
+const lists = new Map();
+
+const upstash = createServer((req, res) => {
+  let body = "";
+  req.on("data", c => (body += c));
+  req.on("end", () => {
+    const args = JSON.parse(body || "[]");
+    const cmd = String(args[0]).toUpperCase();
+    let result;
+    switch (cmd) {
+      case "GET": result = store.get(String(args[1])) ?? null; break;
+      case "SET": store.set(String(args[1]), String(args[2])); result = "OK"; break;
+      case "MGET": result = args.slice(1).map(k => store.get(String(k)) ?? null); break;
+      case "SCAN": {
+        const pattern = String(args[3] ?? "*");
+        const prefix = pattern.endsWith("*") ? pattern.slice(0, -1) : pattern;
+        result = ["0", [...store.keys()].filter(k => k.startsWith(prefix))];
+        break;
+      }
+      case "LPUSH": {
+        const key = String(args[1]);
+        const list = lists.get(key) ?? [];
+        for (const v of args.slice(2)) list.unshift(String(v));
+        lists.set(key, list);
+        result = list.length;
+        break;
+      }
+      case "LTRIM": {
+        const key = String(args[1]);
+        lists.set(key, (lists.get(key) ?? []).slice(Number(args[2]), Number(args[3]) + 1));
+        result = "OK";
+        break;
+      }
+      case "LRANGE":
+        result = (lists.get(String(args[1])) ?? []).slice(Number(args[2]), Number(args[3]) + 1);
+        break;
+      default: result = 1;
+    }
+    res.writeHead(200, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ result }));
+  });
+});
+
+const day = n => new Date(Date.now() - n * 86400000).toISOString().slice(0, 10);
+const TODAY = day(0);
+const YESTERDAY = day(1);
+const TWO_DAYS_AGO = day(2);
+
+const SECRET_VENDOR = "neon";
+const SECRET_CALLER_TEXT = "a product nobody here carries";
+const SECRET_RAW_EVENT = "an-event-we-never-listed";
+
+function seededDay(scale) {
+  return {
+    total: 100 * scale + 21,
+    "/vendor/:slug": 60 * scale,
+    "/search": 25 * scale,
+    "/": 15 * scale,
+    __not_found__: 14,
+    __redirect__: 7,
+    __unmatched__: 0,
+  };
+}
+
+const SEEDED = {
+  days: { [TWO_DAYS_AGO]: seededDay(1), [YESTERDAY]: seededDay(2), [TODAY]: seededDay(3) },
+  referrers: { [YESTERDAY]: { "news.ycombinator.com": 9 }, [TODAY]: { "google.com": 31 } },
+  all_time: { total: 0, "/vendor/:slug": 360, "/search": 150 },
+  updated_at: new Date().toISOString(),
+  classes: {
+    [TWO_DAYS_AGO]: { browser: 60, ai_agent: 20, seo_crawler: 20 },
+    [YESTERDAY]: { browser: 120, ai_agent: 40, seo_crawler: 40 },
+    [TODAY]: { browser: 180, ai_agent: 60, seo_crawler: 60 },
+  },
+  class_routes: {
+    [YESTERDAY]: { "ai_agent|/vendor/:slug": 30, "browser|/search": 55 },
+    [TODAY]: { "ai_agent|/vendor/:slug": 45, "browser|/search": 70 },
+  },
+  families: { [YESTERDAY]: { claude: 22, gptbot: 18 }, [TODAY]: { claude: 33, gptbot: 27 } },
+  mcp: { [TWO_DAYS_AGO]: 11, [YESTERDAY]: 22, [TODAY]: 33 },
+  not_found: { [YESTERDAY]: { other_bot: 14 }, [TODAY]: { other_bot: 14 } },
+  redirects: { [YESTERDAY]: { browser: 7 }, [TODAY]: { browser: 7 } },
+  not_found_sample: [],
+  signals: {
+    [YESTERDAY]: {
+      total: 9,
+      "e:recommended": 8,
+      "e:converted": 1,
+      "t:post": 9,
+      "c:ai_agent": 9,
+      "s:/vendor/:slug": 6,
+      "a:a-reporting-agent": 9,
+      [`v:recommended:${SECRET_VENDOR}`]: 5,
+      "v:recommended:supabase": 3,
+      [`v:converted:${SECRET_VENDOR}`]: 1,
+      [`u:${SECRET_CALLER_TEXT}`]: 2,
+      [`x:${SECRET_RAW_EVENT}`]: 1,
+    },
+    [TODAY]: { total: 2, "e:recommended": 2, "t:post": 2, "c:sdk_client": 2 },
+  },
+  signals_all_time: { total: 11, "e:recommended": 10, "e:converted": 1 },
+  signal_notes: [],
+  signals_from: TWO_DAYS_AGO,
+  all_time_trustworthy_from: TWO_DAYS_AGO,
+  outcome_split_from: TWO_DAYS_AGO,
+};
+
+const failures = [];
+function check(label, cond, detail = "") {
+  if (cond) console.log(`  ok    ${label}`);
+  else {
+    console.log(`  FAIL  ${label}${detail ? ` — ${detail}` : ""}`);
+    failures.push(label);
+  }
+}
+
+function startServer(env) {
+  return new Promise((resolve, reject) => {
+    const proc = spawn("node", ["dist/serve.js"], {
+      cwd: process.cwd(),
+      stdio: ["pipe", "pipe", "pipe"],
+      env: { ...process.env, PORT: "0", BASE_URL: "http://localhost", ...env },
+    });
+    const timer = setTimeout(() => {
+      proc.kill("SIGKILL");
+      reject(new Error("server startup timeout"));
+    }, 30000);
+    const onData = buf => {
+      const m = buf.toString().match(/running on http:\/\/localhost:(\d+)/);
+      if (m) {
+        clearTimeout(timer);
+        resolve({ proc, port: Number(m[1]) });
+      }
+    };
+    proc.stdout.on("data", onData);
+    proc.stderr.on("data", onData);
+    proc.on("error", reject);
+  });
+}
+
+async function stop(proc) {
+  proc.kill("SIGTERM");
+  await new Promise(r => {
+    const t = setTimeout(() => {
+      proc.kill("SIGKILL");
+      r();
+    }, 8000);
+    proc.on("exit", () => {
+      clearTimeout(t);
+      r();
+    });
+  });
+}
+
+function runCollector(args) {
+  return new Promise(resolve => {
+    const proc = spawn("node", ["scripts/rollup-analytics.js", ...args], {
+      cwd: process.cwd(),
+      stdio: ["pipe", "pipe", "pipe"],
+      env: process.env,
+    });
+    let out = "";
+    proc.stdout.on("data", d => (out += d.toString()));
+    proc.stderr.on("data", d => (out += d.toString()));
+    proc.on("exit", code => resolve({ code, out }));
+  });
+}
+
+const UA = { "User-Agent": "agentdeals-internal/1.0 (rollup e2e)" };
+
+async function main() {
+  const dir = mkdtempSync(join(tmpdir(), "rollup-e2e-"));
+  await new Promise(r => upstash.listen(0, r));
+  const upstashUrl = `http://127.0.0.1:${upstash.address().port}`;
+  store.set("agentdeals:pageviews", JSON.stringify(SEEDED));
+
+  const redisEnv = {
+    UPSTASH_REDIS_REST_URL: upstashUrl,
+    UPSTASH_REDIS_REST_TOKEN: "e2e-token",
+  };
+
+  console.log("\n1. Endpoint serves the stored day, redacted");
+  let { proc, port } = await startServer({ ...redisEnv, AGENTDEALS_ROLLUP_DIR: dir });
+  const base = `http://127.0.0.1:${port}`;
+
+  const dayRes = await fetch(`${base}/api/analytics/daily?date=${YESTERDAY}`, { headers: UA });
+  const dayBody = await dayRes.json();
+  check("endpoint returns 200", dayRes.status === 200, String(dayRes.status));
+  check("served count comes from the route keys, not the stored total",
+    dayBody.page_views.served === 200, `got ${dayBody.page_views?.served}`);
+  check("not-found stays out of served", dayBody.page_views.not_found === 14);
+  check("redirects stay out of served", dayBody.page_views.redirects === 7);
+  check("every route is carried", Object.keys(dayBody.page_views.by_route).length === 3);
+  check("mcp calls carried", dayBody.mcp_tool_calls === 22);
+  check("classes carried", dayBody.traffic.by_class.browser === 120);
+  check("families carried", dayBody.traffic.ai_agent_families.claude === 22);
+  check("referrers carried", dayBody.referrers["news.ycombinator.com"] === 9);
+  check("signal total carried", dayBody.signals.total === 9);
+  check("signal source carried", dayBody.signals.by_source["/vendor/:slug"] === 6);
+  check("vendor keys counted", dayBody.signals.vendor_key_count === 3);
+  check("vendor detail withheld", dayBody.vendors === null);
+  check("past day marked final", dayBody.complete === true);
+
+  const dayText = JSON.stringify(dayBody);
+  check("no vendor slug in the response", !dayText.includes(SECRET_VENDOR));
+  check("no second vendor slug in the response", !dayText.includes("supabase"));
+  check("no caller-supplied name in the response", !dayText.includes(SECRET_CALLER_TEXT));
+  check("no caller-supplied event in the response", !dayText.includes(SECRET_RAW_EVENT));
+
+  const todayRes = await fetch(`${base}/api/analytics/daily?date=${TODAY}`, { headers: UA });
+  const todayBody = await todayRes.json();
+  check("current day marked incomplete", todayBody.complete === false);
+  check("dates on offer include all three seeded days",
+    [TWO_DAYS_AGO, YESTERDAY, TODAY].every(d => todayBody.dates_available.includes(d)),
+    JSON.stringify(todayBody.dates_available));
+
+  const badRes = await fetch(`${base}/api/analytics/daily?date=nonsense`, { headers: UA });
+  check("a malformed date is refused", badRes.status === 400, String(badRes.status));
+
+  console.log("\n2. Collector writes one file per day");
+  let run = await runCollector(["--base", base, "--dir", dir]);
+  check("collector exits clean", run.code === 0, run.out);
+  const written = readdirSync(dir).sort();
+  check("a file per seeded day", written.length === 3, written.join(","));
+  check("named by date", written.includes(`${YESTERDAY}.json`), written.join(","));
+
+  const storedYesterday = JSON.parse(readFileSync(join(dir, `${YESTERDAY}.json`), "utf-8"));
+  check("stored day keeps the served count", storedYesterday.page_views.served === 200);
+  check("stored day is final", storedYesterday.complete === true);
+  check("stored day drops the live dates list", storedYesterday.dates_available === undefined);
+
+  const allText = written.map(f => readFileSync(join(dir, f), "utf-8")).join("\n");
+  check("no vendor slug reaches disk", !allText.includes(SECRET_VENDOR));
+  check("no caller-supplied name reaches disk", !allText.includes(SECRET_CALLER_TEXT));
+  check("no caller-supplied event reaches disk", !allText.includes(SECRET_RAW_EVENT));
+
+  console.log("\n3. Re-running does not rewrite a day already final");
+  const beforeMtime = readFileSync(join(dir, `${YESTERDAY}.json`), "utf-8");
+  writeFileSync(join(dir, `${TODAY}.json`), readFileSync(join(dir, `${TODAY}.json`), "utf-8"));
+  run = await runCollector(["--base", base, "--dir", dir]);
+  check("second run exits clean", run.code === 0, run.out);
+  check("past days reported already final", /Already final: 2/.test(run.out), run.out);
+  check("the current day is still rewritten", /Rolled up: 1/.test(run.out), run.out);
+  check("a final day is untouched",
+    readFileSync(join(dir, `${YESTERDAY}.json`), "utf-8") === beforeMtime);
+
+  await stop(proc);
+
+  console.log("\n4. A cold start with empty storage still reports the history on disk");
+  store.clear();
+  ({ proc, port } = await startServer({ ...redisEnv, AGENTDEALS_ROLLUP_DIR: dir }));
+  const coldBase = `http://127.0.0.1:${port}`;
+  const signals = await (await fetch(`${coldBase}/api/signals`, { headers: UA })).json();
+  check("signals reports durable rollup coverage", signals.durable_rollup !== null && signals.durable_rollup !== undefined);
+  check("coverage names the first day", signals.durable_rollup?.first_date === TWO_DAYS_AGO,
+    JSON.stringify(signals.durable_rollup));
+  check("coverage names the last day", signals.durable_rollup?.last_date === TODAY);
+  check("coverage names the last complete day", signals.durable_rollup?.last_complete_date === YESTERDAY);
+  check("coverage counts the days", signals.durable_rollup?.days === 3);
+  check("coverage says where the files are", signals.durable_rollup?.path === dir);
+  check("live windows are empty on a cleared store", signals.all_time.total === 0,
+    String(signals.all_time?.total));
+
+  const history = await (await fetch(`${coldBase}/api/analytics/history`, { headers: UA })).json();
+  check("history serves a day per stored file", history.days.length === 3, String(history.days?.length));
+  check("history is ordered oldest first", history.days[0].date === TWO_DAYS_AGO);
+  check("history carries counts Redis no longer holds",
+    history.days.find(d => d.date === YESTERDAY)?.served === 200,
+    JSON.stringify(history.days));
+  check("history carries the class split", history.days.find(d => d.date === YESTERDAY)?.by_class.browser === 120);
+  check("history reports its own coverage", history.coverage.days === 3);
+  const historyText = JSON.stringify(history);
+  check("history leaks no vendor slug", !historyText.includes(SECRET_VENDOR));
+  check("history leaks no caller-supplied name", !historyText.includes(SECRET_CALLER_TEXT));
+  await stop(proc);
+
+  console.log("\n5. Without storage the endpoint refuses rather than reporting zeros");
+  ({ proc, port } = await startServer({ AGENTDEALS_ROLLUP_DIR: dir }));
+  const bareBase = `http://127.0.0.1:${port}`;
+  const bareRes = await fetch(`${bareBase}/api/analytics/daily?date=${YESTERDAY}`, { headers: UA });
+  const bareBody = await bareRes.json();
+  check("endpoint answers 503", bareRes.status === 503, String(bareRes.status));
+  check("endpoint says why", bareBody.error === "redis-not-configured", JSON.stringify(bareBody));
+  check("endpoint does not claim availability", bareBody.available === false);
+
+  const emptyDir = mkdtempSync(join(tmpdir(), "rollup-e2e-empty-"));
+  run = await runCollector(["--base", bareBase, "--dir", emptyDir]);
+  check("collector refuses to write", run.code !== 0, run.out);
+  check("collector wrote nothing", readdirSync(emptyDir).length === 0);
+  rmSync(emptyDir, { recursive: true, force: true });
+  await stop(proc);
+
+  rmSync(dir, { recursive: true, force: true });
+  upstash.close();
+
+  console.log(`\n${failures.length === 0 ? "PASS" : `FAIL (${failures.length})`}`);
+  for (const f of failures) console.log(`  - ${f}`);
+  process.exit(failures.length === 0 ? 0 : 1);
+}
+
+main().catch(err => {
+  console.error(err);
+  process.exit(1);
+});

--- a/scripts/rollup-analytics.js
+++ b/scripts/rollup-analytics.js
@@ -1,0 +1,130 @@
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { parseRollup, writeRollup, ROLLUP_DIR, ROLLUP_DATE_PATTERN } from "../dist/analytics-rollup.js";
+
+const HELP = `Write a dated durable copy of one day of analytics.
+
+Reads the day's aggregate from a running agentdeals instance and commits it to a flat
+file, because the counters it comes from are pruned by date and the container filesystem
+they are served from is rebuilt on every deploy. Files already present are only rewritten
+when the stored copy is incomplete.
+
+Usage: node scripts/rollup-analytics.js [options]
+
+  --base <url>    Instance to read from (default https://agentdeals.dev)
+  --date <date>   Roll up one YYYY-MM-DD instead of every date on offer
+  --dir <path>    Where to write (default ${ROLLUP_DIR})
+  --skip-today    Do not write a partial file for the current UTC date
+  --dry-run       Report what would be written, write nothing
+  --help          This text
+`;
+
+function parseArgs(argv) {
+  const opts = {
+    base: "https://agentdeals.dev",
+    date: null,
+    dir: ROLLUP_DIR,
+    skipToday: false,
+    dryRun: false,
+  };
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === "--help" || arg === "-h") return { help: true };
+    else if (arg === "--base") opts.base = argv[++i];
+    else if (arg === "--date") opts.date = argv[++i];
+    else if (arg === "--dir") opts.dir = argv[++i];
+    else if (arg === "--skip-today") opts.skipToday = true;
+    else if (arg === "--dry-run") opts.dryRun = true;
+    else {
+      console.error(`Unknown argument: ${arg}`);
+      return { help: true, invalid: true };
+    }
+  }
+  return opts;
+}
+
+const USER_AGENT = "agentdeals-internal/1.0 (analytics rollup)";
+
+async function fetchDay(base, date) {
+  const url = `${base.replace(/\/$/, "")}/api/analytics/daily?date=${date}`;
+  const res = await fetch(url, { headers: { "User-Agent": USER_AGENT } });
+  const body = await res.text();
+  if (!res.ok) {
+    throw new Error(`${url} returned ${res.status}: ${body.slice(0, 300)}`);
+  }
+  let parsed;
+  try {
+    parsed = JSON.parse(body);
+  } catch {
+    throw new Error(`${url} returned unparseable JSON`);
+  }
+  return parsed;
+}
+
+function storedIsFinal(dir, date) {
+  const path = join(dir, `${date}.json`);
+  if (!existsSync(path)) return false;
+  try {
+    const stored = parseRollup(JSON.parse(readFileSync(path, "utf-8")));
+    return stored !== null && stored.complete === true;
+  } catch {
+    return false;
+  }
+}
+
+async function main() {
+  const opts = parseArgs(process.argv.slice(2));
+  if (opts.help) {
+    console.log(HELP);
+    process.exit(opts.invalid ? 1 : 0);
+  }
+
+  const today = new Date().toISOString().slice(0, 10);
+
+  if (opts.date && !ROLLUP_DATE_PATTERN.test(opts.date)) {
+    console.error(`--date must be YYYY-MM-DD, got ${opts.date}`);
+    process.exit(1);
+  }
+
+  const probe = await fetchDay(opts.base, opts.date ?? today);
+  const offered = Array.isArray(probe.dates_available) ? probe.dates_available : [];
+  const dates = opts.date
+    ? [opts.date]
+    : offered.filter(d => ROLLUP_DATE_PATTERN.test(d)).filter(d => !(opts.skipToday && d === today));
+
+  if (dates.length === 0) {
+    console.log("No dates on offer — the instance is holding no dated counters.");
+    process.exit(0);
+  }
+
+  let written = 0;
+  let skipped = 0;
+  for (const date of dates) {
+    if (storedIsFinal(opts.dir, date)) {
+      skipped++;
+      continue;
+    }
+    const payload = date === (opts.date ?? today) ? probe : await fetchDay(opts.base, date);
+    const rollup = parseRollup(payload);
+    if (!rollup) {
+      console.error(`${date}: response did not parse as a rollup — refusing to write`);
+      process.exit(1);
+    }
+    const label = rollup.complete ? "final" : "partial";
+    if (opts.dryRun) {
+      console.log(`would write ${join(opts.dir, `${date}.json`)} (${label}, served ${rollup.page_views.served}, signals ${rollup.signals.total})`);
+    } else {
+      const path = writeRollup(opts.dir, rollup);
+      console.log(`wrote ${path} (${label}, served ${rollup.page_views.served}, signals ${rollup.signals.total})`);
+    }
+    written++;
+  }
+
+  console.log(`Rolled up: ${written}`);
+  console.log(`Already final: ${skipped}`);
+}
+
+main().catch(err => {
+  console.error(err instanceof Error ? err.message : String(err));
+  process.exit(1);
+});

--- a/src/analytics-rollup.ts
+++ b/src/analytics-rollup.ts
@@ -1,0 +1,211 @@
+import { readFileSync, writeFileSync, readdirSync, mkdirSync, existsSync } from "node:fs";
+import { join } from "node:path";
+import type { RollupDaySource, DurableRollupCoverage } from "./stats.js";
+
+export const ROLLUP_SCHEMA_VERSION = 1;
+export const ROLLUP_DIR = "data/analytics";
+export const ROLLUP_DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
+
+export const ROLLUP_EXCLUSIONS: readonly string[] = [
+  "per-vendor counts: a durable per-vendor series is a placement metric a vendor could acquire by firing an endpoint at itself, and this artifact is public",
+  "caller-supplied vendor names and event strings: counted here, never transcribed, because a rolling window and a permanent public file are different publications",
+  "reported free-text notes",
+  "request paths that resolved to no page",
+  "anything identifying an individual caller",
+];
+
+export interface RollupSignals {
+  total: number;
+  by_event: Record<string, number>;
+  by_transport: Record<string, number>;
+  by_client_class: Record<string, number>;
+  by_source: Record<string, number>;
+  by_reporting_agent: Record<string, number>;
+  unresolved_vendor_name_count: number;
+  unrecognized_event_count: number;
+  vendor_key_count: number;
+}
+
+export interface RollupPageViews {
+  served: number;
+  not_found: number;
+  redirects: number;
+  unclassified_legacy: number;
+  by_route: Record<string, number>;
+}
+
+export interface RollupTraffic {
+  by_class: Record<string, number>;
+  by_class_route: Record<string, number>;
+  ai_agent_families: Record<string, number>;
+  not_found_by_class: Record<string, number>;
+  redirects_by_class: Record<string, number>;
+}
+
+export interface DailyRollup {
+  schema: number;
+  date: string;
+  generated_at: string;
+  complete: boolean;
+  page_views: RollupPageViews;
+  traffic: RollupTraffic;
+  mcp_tool_calls: number;
+  referrers: Record<string, number>;
+  signals: RollupSignals;
+  vendors: Record<string, number> | null;
+  excluded: readonly string[];
+}
+
+function sortedNumericMap(entries: [string, number][]): Record<string, number> {
+  return Object.fromEntries(entries.sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0])));
+}
+
+function summarizeSignals(signals: RollupDaySource["signals"]): RollupSignals {
+  return {
+    total: signals.total,
+    by_event: sortedNumericMap(Object.entries(signals.by_event)),
+    by_transport: sortedNumericMap(Object.entries(signals.by_transport)),
+    by_client_class: sortedNumericMap(Object.entries(signals.by_client_class)),
+    by_source: sortedNumericMap(Object.entries(signals.by_source)),
+    by_reporting_agent: sortedNumericMap(Object.entries(signals.by_reporting_agent)),
+    unresolved_vendor_name_count: Object.keys(signals.unresolved_vendor_names).length,
+    unrecognized_event_count: Object.keys(signals.unrecognized_events).length,
+    vendor_key_count: Object.keys(signals.by_vendor).length,
+  };
+}
+
+export function buildDailyRollup(source: RollupDaySource, generatedAt: string): DailyRollup {
+  return {
+    schema: ROLLUP_SCHEMA_VERSION,
+    date: source.date,
+    generated_at: generatedAt,
+    complete: source.date < generatedAt.slice(0, 10),
+    page_views: {
+      served: source.page_views.served,
+      not_found: source.page_views.not_found,
+      redirects: source.page_views.redirects,
+      unclassified_legacy: source.page_views.unclassified_legacy,
+      by_route: sortedNumericMap(Object.entries(source.page_views.by_route)),
+    },
+    traffic: {
+      by_class: sortedNumericMap(Object.entries(source.classes)),
+      by_class_route: sortedNumericMap(Object.entries(source.class_routes)),
+      ai_agent_families: sortedNumericMap(Object.entries(source.families)),
+      not_found_by_class: sortedNumericMap(Object.entries(source.not_found)),
+      redirects_by_class: sortedNumericMap(Object.entries(source.redirects)),
+    },
+    mcp_tool_calls: source.mcp_tool_calls,
+    referrers: sortedNumericMap(Object.entries(source.referrers)),
+    signals: summarizeSignals(source.signals),
+    vendors: null,
+    excluded: ROLLUP_EXCLUSIONS,
+  };
+}
+
+function numericMap(raw: unknown): Record<string, number> {
+  if (!raw || typeof raw !== "object") return {};
+  const out: Record<string, number> = {};
+  for (const [key, value] of Object.entries(raw as Record<string, unknown>)) {
+    if (typeof value === "number" && Number.isFinite(value)) out[key] = value;
+  }
+  return out;
+}
+
+function numberAt(raw: Record<string, unknown>, key: string): number {
+  const value = raw[key];
+  return typeof value === "number" && Number.isFinite(value) ? value : 0;
+}
+
+export function parseRollup(raw: unknown): DailyRollup | null {
+  if (!raw || typeof raw !== "object") return null;
+  const obj = raw as Record<string, unknown>;
+  const date = obj.date;
+  if (typeof date !== "string" || !ROLLUP_DATE_PATTERN.test(date)) return null;
+  const pageViews = (obj.page_views ?? {}) as Record<string, unknown>;
+  const traffic = (obj.traffic ?? {}) as Record<string, unknown>;
+  const signals = (obj.signals ?? {}) as Record<string, unknown>;
+  return {
+    schema: numberAt(obj, "schema") || ROLLUP_SCHEMA_VERSION,
+    date,
+    generated_at: typeof obj.generated_at === "string" ? obj.generated_at : "",
+    complete: obj.complete === true,
+    page_views: {
+      served: numberAt(pageViews, "served"),
+      not_found: numberAt(pageViews, "not_found"),
+      redirects: numberAt(pageViews, "redirects"),
+      unclassified_legacy: numberAt(pageViews, "unclassified_legacy"),
+      by_route: numericMap(pageViews.by_route),
+    },
+    traffic: {
+      by_class: numericMap(traffic.by_class),
+      by_class_route: numericMap(traffic.by_class_route),
+      ai_agent_families: numericMap(traffic.ai_agent_families),
+      not_found_by_class: numericMap(traffic.not_found_by_class),
+      redirects_by_class: numericMap(traffic.redirects_by_class),
+    },
+    mcp_tool_calls: numberAt(obj, "mcp_tool_calls"),
+    referrers: numericMap(obj.referrers),
+    signals: {
+      total: numberAt(signals, "total"),
+      by_event: numericMap(signals.by_event),
+      by_transport: numericMap(signals.by_transport),
+      by_client_class: numericMap(signals.by_client_class),
+      by_source: numericMap(signals.by_source),
+      by_reporting_agent: numericMap(signals.by_reporting_agent),
+      unresolved_vendor_name_count: numberAt(signals, "unresolved_vendor_name_count"),
+      unrecognized_event_count: numberAt(signals, "unrecognized_event_count"),
+      vendor_key_count: numberAt(signals, "vendor_key_count"),
+    },
+    vendors: obj.vendors && typeof obj.vendors === "object" ? numericMap(obj.vendors) : null,
+    excluded: Array.isArray(obj.excluded) ? obj.excluded.filter(e => typeof e === "string") : [],
+  };
+}
+
+export function rollupFileName(date: string): string {
+  return `${date}.json`;
+}
+
+export function readRollups(dir: string): DailyRollup[] {
+  if (!existsSync(dir)) return [];
+  const out: DailyRollup[] = [];
+  let names: string[];
+  try {
+    names = readdirSync(dir);
+  } catch {
+    return [];
+  }
+  for (const name of names) {
+    if (!name.endsWith(".json")) continue;
+    if (!ROLLUP_DATE_PATTERN.test(name.slice(0, -5))) continue;
+    try {
+      const parsed = parseRollup(JSON.parse(readFileSync(join(dir, name), "utf-8")));
+      if (parsed) out.push(parsed);
+    } catch {
+      continue;
+    }
+  }
+  return out.sort((a, b) => a.date.localeCompare(b.date));
+}
+
+export function coverageOf(rollups: DailyRollup[], dir: string): DurableRollupCoverage {
+  const dates = rollups.map(r => r.date).sort();
+  const complete = rollups.filter(r => r.complete).map(r => r.date).sort();
+  return {
+    first_date: dates[0] ?? null,
+    last_date: dates[dates.length - 1] ?? null,
+    last_complete_date: complete[complete.length - 1] ?? null,
+    days: dates.length,
+    path: dir,
+  };
+}
+
+export function readRollupCoverage(dir: string = ROLLUP_DIR): DurableRollupCoverage {
+  return coverageOf(readRollups(dir), dir);
+}
+
+export function writeRollup(dir: string, rollup: DailyRollup): string {
+  mkdirSync(dir, { recursive: true });
+  const path = join(dir, rollupFileName(rollup.date));
+  writeFileSync(path, JSON.stringify(rollup, null, 2) + "\n", "utf-8");
+  return path;
+}

--- a/src/client-class.ts
+++ b/src/client-class.ts
@@ -192,6 +192,8 @@ const OBSERVABILITY_PATHS = new Set([
   "/api/query-log",
   "/api/traffic",
   "/api/metrics",
+  "/api/analytics/daily",
+  "/api/analytics/history",
   "/health",
 ]);
 

--- a/src/serve.ts
+++ b/src/serve.ts
@@ -11,7 +11,8 @@ import { estimateCosts } from "./costs.js";
 import { classifyRequest } from "./client-class.js";
 import { acceptSignal, ackMissing, checkRateLimit, clientAddress, RATE_LIMIT_PER_MINUTE, SIGNAL_ACK_PARAM, SIGNAL_BODY_MAX, SIGNAL_DOC_PATH, SIGNAL_PATH, type SignalInput } from "./signal.js";
 import { agentBlock, CONVERTED_CAVEAT, DEFERENCE, PRIVACY_SCOPE, signalHeaderValue, signalHtmlBlock, signalLlmsSection, SIGNAL_HEADER_NAME } from "./signal-copy.js";
-import { recordApiHit, recordSessionConnect, recordSessionDisconnect, recordLandingPageView, getStats, getConnectionStats, loadTelemetry, flushTelemetry, flushPending, FLUSH_INTERVAL_SECONDS, logRequest, getPublicRequestLogResult, getTelemetryHealth, recordPageView, getPageViews, recordReferralListingCall, recordReferralVendorLookup, getReferralMarketplaceStats, getSessionClassification, recordSearchQuery, getSearchAnalytics, getApiHitsByEndpoint, recordTraffic, getTrafficReport, getSignalReport, SIGNAL_MIN_SAMPLE, SIGNAL_DENOMINATOR_ROUTES } from "./stats.js";
+import { recordApiHit, recordSessionConnect, recordSessionDisconnect, recordLandingPageView, getStats, getConnectionStats, loadTelemetry, flushTelemetry, flushPending, FLUSH_INTERVAL_SECONDS, logRequest, getPublicRequestLogResult, getTelemetryHealth, recordPageView, getPageViews, recordReferralListingCall, recordReferralVendorLookup, getReferralMarketplaceStats, getSessionClassification, recordSearchQuery, getSearchAnalytics, getApiHitsByEndpoint, recordTraffic, getTrafficReport, getSignalReport, SIGNAL_MIN_SAMPLE, SIGNAL_DENOMINATOR_ROUTES, getRollupDaySource, getRollupDatesAvailable, setDurableRollupCoverage } from "./stats.js";
+import { buildDailyRollup, readRollups, coverageOf, ROLLUP_DATE_PATTERN } from "./analytics-rollup.js";
 import { openapiSpec } from "./openapi.js";
 import { LINK_GRACE_DAYS } from "./link-health.js";
 import { registerAgent, authenticateRequest, validateVestauthUrl, hashApiKey, updateAgentX402Address, getAgentById } from "./agents.js";
@@ -234,6 +235,24 @@ setInterval(() => {
 // Load cumulative telemetry from Redis or disk (survives deploys)
 const telemetryFile = join(__dirname, "..", "data", "telemetry.json");
 await loadTelemetry(telemetryFile);
+
+const rollupDir = process.env.AGENTDEALS_ROLLUP_DIR ?? join(__dirname, "..", "data", "analytics");
+const durableRollups = readRollups(rollupDir);
+const durableRollupCoverage = coverageOf(durableRollups, rollupDir);
+setDurableRollupCoverage(durableRollupCoverage);
+const durableHistoryBody = JSON.stringify({
+  coverage: durableRollupCoverage,
+  days: durableRollups.map(r => ({
+    date: r.date,
+    complete: r.complete,
+    served: r.page_views.served,
+    not_found: r.page_views.not_found,
+    redirects: r.page_views.redirects,
+    mcp_tool_calls: r.mcp_tool_calls,
+    signals: r.signals.total,
+    by_class: r.traffic.by_class,
+  })),
+});
 
 // Build landing page HTML at startup with real stats
 const offers = loadOffers();
@@ -53768,6 +53787,38 @@ const httpServer = createHttpServer(async (req, res) => {
     // site is built to exclude. A test asserts no per-vendor count reaches this response.
     res.writeHead(200, { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" });
     res.end(JSON.stringify(getSignalReport()));
+    return;
+  }
+
+  if (url.pathname === "/api/analytics/history" && isGetOrHead) {
+    res.writeHead(200, { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" });
+    res.end(durableHistoryBody);
+    return;
+  }
+
+  if (url.pathname === "/api/analytics/daily" && isGetOrHead) {
+    const requested = url.searchParams.get("date") ?? new Date().toISOString().slice(0, 10);
+    if (!ROLLUP_DATE_PATTERN.test(requested)) {
+      res.writeHead(400, { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" });
+      res.end(JSON.stringify({ error: "date must be YYYY-MM-DD" }));
+      return;
+    }
+    const source = getRollupDaySource(requested);
+    if (!source.available) {
+      res.writeHead(503, { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" });
+      res.end(JSON.stringify({
+        error: source.reason,
+        available: false,
+        date: requested,
+        dates_available: getRollupDatesAvailable(),
+      }));
+      return;
+    }
+    res.writeHead(200, { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" });
+    res.end(JSON.stringify({
+      ...buildDailyRollup(source, new Date().toISOString()),
+      dates_available: getRollupDatesAvailable(),
+    }));
     return;
   }
 

--- a/src/stats.ts
+++ b/src/stats.ts
@@ -2554,6 +2554,9 @@ const SIGNAL_FACETS = {
   rawEvent: "x",
   /** Which surface produced the signal — the one thing that says which invitation works. */
   source: "s",
+  event: "e",
+  transport: "t",
+  clientClass: "c",
 } as const;
 const MAX_SIGNAL_KEYS_PER_FACET_PER_DAY = 100;
 const MAX_SIGNAL_ALL_TIME_KEYS_PER_FACET = 300;
@@ -2566,9 +2569,9 @@ const SIGNAL_OVERFLOW = "__other__";
  */
 function buildFixedSignalKeys(): Set<string> {
   const keys = new Set<string>([SIGNAL_TOTAL_KEY]);
-  for (const e of [...SIGNAL_EVENTS, SIGNAL_UNRECOGNIZED_EVENT]) keys.add(`e${SIGNAL_SEP}${e}`);
-  for (const t of SIGNAL_TRANSPORTS) keys.add(`t${SIGNAL_SEP}${t}`);
-  for (const c of TRAFFIC_CLASSES) keys.add(`c${SIGNAL_SEP}${c}`);
+  for (const e of [...SIGNAL_EVENTS, SIGNAL_UNRECOGNIZED_EVENT]) keys.add(`${SIGNAL_FACETS.event}${SIGNAL_SEP}${e}`);
+  for (const t of SIGNAL_TRANSPORTS) keys.add(`${SIGNAL_FACETS.transport}${SIGNAL_SEP}${t}`);
+  for (const c of TRAFFIC_CLASSES) keys.add(`${SIGNAL_FACETS.clientClass}${SIGNAL_SEP}${c}`);
   return keys;
 }
 const FIXED_SIGNAL_KEYS = buildFixedSignalKeys();
@@ -2678,9 +2681,9 @@ export function recordSignal(rec: SignalRecord): void {
 
   const fixed = [
     SIGNAL_TOTAL_KEY,
-    `e${SIGNAL_SEP}${eventKey}`,
-    `t${SIGNAL_SEP}${rec.transport}`,
-    `c${SIGNAL_SEP}${cls}`,
+    `${SIGNAL_FACETS.event}${SIGNAL_SEP}${eventKey}`,
+    `${SIGNAL_FACETS.transport}${SIGNAL_SEP}${rec.transport}`,
+    `${SIGNAL_FACETS.clientClass}${SIGNAL_SEP}${cls}`,
   ];
   const bounded: string[] = [];
   // The per-vendor key carries the event with it: "recommended neon" and "converted neon"
@@ -2818,9 +2821,9 @@ function foldSignals(map: Record<string, number>, window: SignalWindow): void {
     if (sep < 0) continue;
     const facet = key.slice(0, sep);
     const rest = key.slice(sep + 1);
-    if (facet === "e") window.by_event[rest] = (window.by_event[rest] ?? 0) + count;
-    else if (facet === "t") window.by_transport[rest] = (window.by_transport[rest] ?? 0) + count;
-    else if (facet === "c") window.by_client_class[rest] = (window.by_client_class[rest] ?? 0) + count;
+    if (facet === SIGNAL_FACETS.event) window.by_event[rest] = (window.by_event[rest] ?? 0) + count;
+    else if (facet === SIGNAL_FACETS.transport) window.by_transport[rest] = (window.by_transport[rest] ?? 0) + count;
+    else if (facet === SIGNAL_FACETS.clientClass) window.by_client_class[rest] = (window.by_client_class[rest] ?? 0) + count;
     else if (facet === SIGNAL_FACETS.vendor && rest !== SIGNAL_OVERFLOW) {
       // `rest` is `${event}:${slug}` — count the vendor, once, across events.
       const slugAt = rest.indexOf(SIGNAL_SEP);
@@ -2928,6 +2931,7 @@ export interface SignalReport {
   all_time: SignalWindow;
   /** False when storage is not configured: the numbers are this process's, not durable. */
   durable: boolean;
+  durable_rollup: DurableRollupCoverage | null;
   recording_since: string | null;
   since_boot: number;
   notes: string[];
@@ -2947,6 +2951,7 @@ export function getSignalReport(): SignalReport {
     last_30d: buildSignalWindow(view, 30),
     all_time: buildSignalAllTime(view),
     durable: useRedis() && pageViewsLoaded,
+    durable_rollup: getDurableRollupCoverage(),
     recording_since: view.signals_from || null,
     since_boot: signalsSinceBoot,
     notes: SIGNAL_NOTES,
@@ -2981,6 +2986,164 @@ export function getSignalVendorBreakdown(): { event: string; vendor: string; cou
 export function getSignalNotes(): SignalNote[] {
   const view = mergeSnapshot(pageViewSnapshot, pendingPageViews);
   return [...view.signal_notes].reverse();
+}
+
+export interface RollupSignalFacets {
+  total: number;
+  by_event: Record<string, number>;
+  by_transport: Record<string, number>;
+  by_client_class: Record<string, number>;
+  by_source: Record<string, number>;
+  by_reporting_agent: Record<string, number>;
+  by_vendor: Record<string, number>;
+  unresolved_vendor_names: Record<string, number>;
+  unrecognized_events: Record<string, number>;
+}
+
+export interface RollupDayPageViews {
+  served: number;
+  not_found: number;
+  redirects: number;
+  unclassified_legacy: number;
+  by_route: Record<string, number>;
+}
+
+export interface RollupDaySource {
+  date: string;
+  page_views: RollupDayPageViews;
+  referrers: Record<string, number>;
+  classes: Record<string, number>;
+  class_routes: Record<string, number>;
+  families: Record<string, number>;
+  mcp_tool_calls: number;
+  not_found: Record<string, number>;
+  redirects: Record<string, number>;
+  signals: RollupSignalFacets;
+  available: boolean;
+  reason: string | null;
+}
+
+function emptySignalFacets(): RollupSignalFacets {
+  return {
+    total: 0,
+    by_event: {},
+    by_transport: {},
+    by_client_class: {},
+    by_source: {},
+    by_reporting_agent: {},
+    by_vendor: {},
+    unresolved_vendor_names: {},
+    unrecognized_events: {},
+  };
+}
+
+export function splitSignalKeys(map: Record<string, number>): RollupSignalFacets {
+  const out = emptySignalFacets();
+  const target: Record<string, Record<string, number>> = {
+    [SIGNAL_FACETS.event]: out.by_event,
+    [SIGNAL_FACETS.transport]: out.by_transport,
+    [SIGNAL_FACETS.clientClass]: out.by_client_class,
+    [SIGNAL_FACETS.source]: out.by_source,
+    [SIGNAL_FACETS.agent]: out.by_reporting_agent,
+    [SIGNAL_FACETS.vendor]: out.by_vendor,
+    [SIGNAL_FACETS.unresolved]: out.unresolved_vendor_names,
+    [SIGNAL_FACETS.rawEvent]: out.unrecognized_events,
+  };
+  for (const [key, count] of Object.entries(map)) {
+    if (key === SIGNAL_TOTAL_KEY) {
+      out.total += count;
+      continue;
+    }
+    const sep = key.indexOf(SIGNAL_SEP);
+    if (sep < 0) continue;
+    const bucket = target[key.slice(0, sep)];
+    if (!bucket) continue;
+    const rest = key.slice(sep + 1);
+    bucket[rest] = (bucket[rest] ?? 0) + count;
+  }
+  return out;
+}
+
+export function splitDayPageViews(map: Record<string, number>): RollupDayPageViews {
+  const period = periodFrom(map);
+  const by_route: Record<string, number> = {};
+  for (const [key, count] of Object.entries(map)) {
+    if (!PSEUDO_DAY_KEYS.has(key)) by_route[key] = count;
+  }
+  return {
+    served: period.total ?? 0,
+    not_found: period.not_found,
+    redirects: period.redirects,
+    unclassified_legacy: period.unclassified_legacy,
+    by_route,
+  };
+}
+
+export function getRollupDaySource(date: string): RollupDaySource {
+  const empty = {
+    date,
+    page_views: splitDayPageViews({}),
+    referrers: {},
+    classes: {},
+    class_routes: {},
+    families: {},
+    mcp_tool_calls: 0,
+    not_found: {},
+    redirects: {},
+    signals: emptySignalFacets(),
+  };
+  if (!useRedis()) return { ...empty, available: false, reason: "redis-not-configured" };
+  if (!pageViewsLoaded) {
+    return {
+      ...empty,
+      available: false,
+      reason: redisHealth.lastReadError ?? "page-view snapshot not loaded",
+    };
+  }
+  const view = mergeSnapshot(pageViewSnapshot, pendingPageViews);
+  return {
+    date,
+    page_views: splitDayPageViews(view.days[date] ?? {}),
+    referrers: { ...(view.referrers[date] ?? {}) },
+    classes: { ...(view.classes[date] ?? {}) },
+    class_routes: { ...(view.class_routes[date] ?? {}) },
+    families: { ...(view.families[date] ?? {}) },
+    mcp_tool_calls: view.mcp[date] ?? 0,
+    not_found: { ...(view.not_found[date] ?? {}) },
+    redirects: { ...(view.redirects[date] ?? {}) },
+    signals: splitSignalKeys(view.signals[date] ?? {}),
+    available: true,
+    reason: null,
+  };
+}
+
+export function getRollupDatesAvailable(): string[] {
+  if (!useRedis() || !pageViewsLoaded) return [];
+  const view = mergeSnapshot(pageViewSnapshot, pendingPageViews);
+  const dates = new Set<string>();
+  for (const field of ["days", "referrers", "classes", "class_routes", "families", "not_found", "redirects", "signals"] as const) {
+    for (const date of Object.keys(view[field])) dates.add(date);
+  }
+  for (const date of Object.keys(view.mcp)) dates.add(date);
+  return [...dates].sort();
+}
+
+export interface DurableRollupCoverage {
+  first_date: string | null;
+  last_date: string | null;
+  last_complete_date: string | null;
+  days: number;
+  path: string;
+}
+
+let durableRollupCoverage: DurableRollupCoverage | null = null;
+
+export function setDurableRollupCoverage(coverage: DurableRollupCoverage | null): void {
+  durableRollupCoverage = coverage;
+}
+
+export function getDurableRollupCoverage(): DurableRollupCoverage | null {
+  return durableRollupCoverage;
 }
 
 // --- Search query analytics ---

--- a/test/analytics-rollup.test.ts
+++ b/test/analytics-rollup.test.ts
@@ -1,0 +1,245 @@
+import { describe, it } from "node:test";
+import assert from "node:assert";
+import { mkdtempSync, writeFileSync, rmSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  buildDailyRollup,
+  parseRollup,
+  readRollups,
+  readRollupCoverage,
+  coverageOf,
+  writeRollup,
+  ROLLUP_EXCLUSIONS,
+  ROLLUP_SCHEMA_VERSION,
+} from "../src/analytics-rollup.ts";
+import type { RollupDaySource } from "../src/stats.ts";
+
+function sourceFor(date: string, overrides: Partial<RollupDaySource> = {}): RollupDaySource {
+  return {
+    date,
+    page_views: { served: 0, not_found: 0, redirects: 0, unclassified_legacy: 0, by_route: {} },
+    referrers: {},
+    classes: {},
+    class_routes: {},
+    families: {},
+    mcp_tool_calls: 0,
+    not_found: {},
+    redirects: {},
+    signals: {
+      total: 0,
+      by_event: {},
+      by_transport: {},
+      by_client_class: {},
+      by_source: {},
+      by_reporting_agent: {},
+      by_vendor: {},
+      unresolved_vendor_names: {},
+      unrecognized_events: {},
+    },
+    available: true,
+    reason: null,
+    ...overrides,
+  };
+}
+
+const POPULATED = sourceFor("2026-08-20", {
+  page_views: {
+    served: 180,
+    not_found: 17,
+    redirects: 9,
+    unclassified_legacy: 30,
+    by_route: { "/vendor/:slug": 100, "/search": 50, "/": 30 },
+  },
+  referrers: { "news.ycombinator.com": 12, "google.com": 40 },
+  classes: { ai_agent: 30, browser: 120, seo_crawler: 30 },
+  class_routes: { "ai_agent|/vendor/:slug": 25, "browser|/search": 40 },
+  families: { claude: 20, gptbot: 10 },
+  mcp_tool_calls: 77,
+  not_found: { other_bot: 17 },
+  redirects: { browser: 9 },
+  signals: {
+    total: 6,
+    by_event: { recommended: 5, converted: 1 },
+    by_transport: { post: 6 },
+    by_client_class: { ai_agent: 6 },
+    by_source: { "/vendor/:slug": 4 },
+    by_reporting_agent: { "some-agent": 6 },
+    by_vendor: { "recommended:neon": 3, "recommended:supabase": 2, "converted:neon": 1 },
+    unresolved_vendor_names: { "a vendor we do not carry": 2 },
+    unrecognized_events: { "some-unlisted-event": 1 },
+  },
+});
+
+describe("daily analytics rollup", () => {
+  it("keeps served, not-found and redirect counts apart from each other", () => {
+    const rollup = buildDailyRollup(POPULATED, "2026-08-21T04:30:00.000Z");
+    assert.equal(rollup.page_views.served, 180);
+    assert.equal(rollup.page_views.not_found, 17);
+    assert.equal(rollup.page_views.redirects, 9);
+    assert.equal(rollup.page_views.unclassified_legacy, 30);
+  });
+
+  it("carries every route, not only the ones a top-N list would show", () => {
+    const by_route: Record<string, number> = {};
+    for (let i = 0; i < 120; i++) by_route[`/route-${i}`] = 120 - i;
+    const wide = sourceFor("2026-08-20", {
+      page_views: { served: 7260, not_found: 0, redirects: 0, unclassified_legacy: 0, by_route },
+    });
+    const rollup = buildDailyRollup(wide, "2026-08-21T00:00:00.000Z");
+    assert.equal(Object.keys(rollup.page_views.by_route).length, 120);
+  });
+
+  it("summarizes signals by event, transport, class, source and reporting agent", () => {
+    const { signals } = buildDailyRollup(POPULATED, "2026-08-21T04:30:00.000Z");
+    assert.equal(signals.total, 6);
+    assert.deepEqual(signals.by_event, { recommended: 5, converted: 1 });
+    assert.deepEqual(signals.by_transport, { post: 6 });
+    assert.deepEqual(signals.by_client_class, { ai_agent: 6 });
+    assert.deepEqual(signals.by_source, { "/vendor/:slug": 4 });
+    assert.deepEqual(signals.by_reporting_agent, { "some-agent": 6 });
+  });
+
+  it("records how many vendor keys existed without recording which vendors", () => {
+    const rollup = buildDailyRollup(POPULATED, "2026-08-21T04:30:00.000Z");
+    assert.equal(rollup.signals.vendor_key_count, 3);
+    assert.equal(rollup.vendors, null);
+    const serialized = JSON.stringify(rollup);
+    for (const slug of ["neon", "supabase"]) {
+      assert.ok(!serialized.includes(slug), `vendor slug ${slug} must not reach the artifact`);
+    }
+  });
+
+  it("counts caller-supplied strings without transcribing them", () => {
+    const rollup = buildDailyRollup(POPULATED, "2026-08-21T04:30:00.000Z");
+    assert.equal(rollup.signals.unresolved_vendor_name_count, 1);
+    assert.equal(rollup.signals.unrecognized_event_count, 1);
+    const serialized = JSON.stringify(rollup);
+    assert.ok(!serialized.includes("a vendor we do not carry"));
+    assert.ok(!serialized.includes("some-unlisted-event"));
+  });
+
+  it("states what it deliberately leaves out", () => {
+    const rollup = buildDailyRollup(POPULATED, "2026-08-21T04:30:00.000Z");
+    assert.deepEqual(rollup.excluded, ROLLUP_EXCLUSIONS);
+    assert.ok(ROLLUP_EXCLUSIONS.length > 0);
+  });
+
+  it("marks a same-day rollup incomplete and a past day final", () => {
+    const sameDay = buildDailyRollup(sourceFor("2026-08-21"), "2026-08-21T12:00:00.000Z");
+    const pastDay = buildDailyRollup(sourceFor("2026-08-20"), "2026-08-21T00:00:00.000Z");
+    assert.equal(sameDay.complete, false);
+    assert.equal(pastDay.complete, true);
+  });
+
+  it("carries traffic, referrers and MCP calls through unchanged", () => {
+    const rollup = buildDailyRollup(POPULATED, "2026-08-21T04:30:00.000Z");
+    assert.deepEqual(rollup.traffic.by_class, { browser: 120, ai_agent: 30, seo_crawler: 30 });
+    assert.deepEqual(rollup.traffic.ai_agent_families, { claude: 20, gptbot: 10 });
+    assert.deepEqual(rollup.traffic.by_class_route, { "browser|/search": 40, "ai_agent|/vendor/:slug": 25 });
+    assert.deepEqual(rollup.traffic.not_found_by_class, { other_bot: 17 });
+    assert.deepEqual(rollup.traffic.redirects_by_class, { browser: 9 });
+    assert.deepEqual(rollup.referrers, { "google.com": 40, "news.ycombinator.com": 12 });
+    assert.equal(rollup.mcp_tool_calls, 77);
+  });
+
+  it("round-trips through JSON without losing a field", () => {
+    const rollup = buildDailyRollup(POPULATED, "2026-08-21T04:30:00.000Z");
+    const back = parseRollup(JSON.parse(JSON.stringify(rollup)));
+    assert.deepEqual(back, rollup);
+  });
+
+  it("refuses a payload with no usable date", () => {
+    assert.equal(parseRollup(null), null);
+    assert.equal(parseRollup({}), null);
+    assert.equal(parseRollup({ date: "not-a-date" }), null);
+    assert.equal(parseRollup({ date: "2026-8-1" }), null);
+  });
+});
+
+describe("rollup files on disk", () => {
+  function withTempDir(run: (dir: string) => void): void {
+    const dir = mkdtempSync(join(tmpdir(), "rollup-"));
+    try {
+      run(dir);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  }
+
+  it("reads back what it wrote", () => {
+    withTempDir(dir => {
+      const rollup = buildDailyRollup(POPULATED, "2026-08-21T04:30:00.000Z");
+      const path = writeRollup(dir, rollup);
+      assert.ok(path.endsWith("2026-08-20.json"));
+      const [read] = readRollups(dir);
+      assert.deepEqual(read, rollup);
+    });
+  });
+
+  it("reports coverage across the days present, and names the last complete one", () => {
+    withTempDir(dir => {
+      writeRollup(dir, buildDailyRollup(sourceFor("2026-08-18"), "2026-08-21T00:00:00.000Z"));
+      writeRollup(dir, buildDailyRollup(sourceFor("2026-08-19"), "2026-08-21T00:00:00.000Z"));
+      writeRollup(dir, buildDailyRollup(sourceFor("2026-08-21"), "2026-08-21T09:00:00.000Z"));
+      const coverage = readRollupCoverage(dir);
+      assert.equal(coverage.first_date, "2026-08-18");
+      assert.equal(coverage.last_date, "2026-08-21");
+      assert.equal(coverage.last_complete_date, "2026-08-19");
+      assert.equal(coverage.days, 3);
+      assert.equal(coverage.path, dir);
+    });
+  });
+
+  it("skips files that are not dated rollups instead of failing the whole read", () => {
+    withTempDir(dir => {
+      writeRollup(dir, buildDailyRollup(sourceFor("2026-08-18"), "2026-08-21T00:00:00.000Z"));
+      writeFileSync(join(dir, "README.md"), "not a rollup", "utf-8");
+      writeFileSync(join(dir, "notes.json"), "{}", "utf-8");
+      writeFileSync(join(dir, "2026-08-19.json"), "{ broken", "utf-8");
+      const rollups = readRollups(dir);
+      assert.equal(rollups.length, 1);
+      assert.equal(rollups[0].date, "2026-08-18");
+    });
+  });
+
+  it("ignores a stray copy whose body is a valid rollup but whose name is not a date", () => {
+    withTempDir(dir => {
+      const real = buildDailyRollup(sourceFor("2026-08-18"), "2026-08-21T00:00:00.000Z");
+      writeRollup(dir, real);
+      writeFileSync(join(dir, "latest.json"), JSON.stringify(real), "utf-8");
+      writeFileSync(join(dir, "2026-08-18.json.bak"), JSON.stringify(real), "utf-8");
+      const rollups = readRollups(dir);
+      assert.equal(rollups.length, 1);
+      assert.equal(readRollupCoverage(dir).days, 1);
+    });
+  });
+
+  it("reports empty coverage for a directory that does not exist", () => {
+    const coverage = readRollupCoverage(join(tmpdir(), "rollup-absent-directory"));
+    assert.equal(coverage.days, 0);
+    assert.equal(coverage.last_date, null);
+    assert.equal(coverage.last_complete_date, null);
+  });
+
+  it("writes a schema version so a later reader can tell the shape", () => {
+    withTempDir(dir => {
+      writeRollup(dir, buildDailyRollup(POPULATED, "2026-08-21T04:30:00.000Z"));
+      const raw = JSON.parse(readFileSync(join(dir, "2026-08-20.json"), "utf-8"));
+      assert.equal(raw.schema, ROLLUP_SCHEMA_VERSION);
+    });
+  });
+
+  it("computes coverage from the rollups it is given", () => {
+    const coverage = coverageOf(
+      [
+        buildDailyRollup(sourceFor("2026-08-02"), "2026-08-03T00:00:00.000Z"),
+        buildDailyRollup(sourceFor("2026-08-01"), "2026-08-03T00:00:00.000Z"),
+      ],
+      "somewhere",
+    );
+    assert.equal(coverage.first_date, "2026-08-01");
+    assert.equal(coverage.last_date, "2026-08-02");
+    assert.equal(coverage.days, 2);
+  });
+});

--- a/test/client-class.test.ts
+++ b/test/client-class.test.ts
@@ -199,6 +199,13 @@ describe("classifyRequest — internal attribution", () => {
     assert.equal(classifyRequest("/api/query-log?limit=200", UA.curl).client_class, "internal");
   });
 
+  it("the rollup endpoints are internal, so the collector cannot inflate what it records", () => {
+    assert.equal(isObservabilityPath("/api/analytics/daily"), true);
+    assert.equal(isObservabilityPath("/api/analytics/history"), true);
+    assert.equal(classifyRequest("/api/analytics/daily?date=2026-08-20", UA.curl).client_class, "internal");
+    assert.equal(classifyRequest("/api/analytics/history", UA.chrome).client_class, "internal");
+  });
+
   it("a content path is classified on its user agent, not its path", () => {
     assert.equal(classifyRequest("/vendor/neon", UA.chatgptUser).client_class, "ai_agent");
     assert.equal(classifyRequest("/api/offers", UA.chrome).client_class, "browser");

--- a/test/rollup-day-source.test.ts
+++ b/test/rollup-day-source.test.ts
@@ -1,0 +1,93 @@
+import { describe, it } from "node:test";
+import assert from "node:assert";
+import { splitDayPageViews, splitSignalKeys, getRollupDaySource, getRollupDatesAvailable } from "../src/stats.ts";
+
+describe("splitting a stored day into rollup input", () => {
+  it("counts served views from the route keys, never from the stored total", () => {
+    const split = splitDayPageViews({
+      total: 210,
+      "/vendor/:slug": 100,
+      "/search": 50,
+      "/": 30,
+      __not_found__: 17,
+      __redirect__: 9,
+      __unmatched__: 4,
+    });
+    assert.equal(split.served, 180);
+    assert.equal(split.not_found, 17);
+    assert.equal(split.redirects, 9);
+  });
+
+  it("keeps the pseudo keys out of the route map so none is ever read as a page", () => {
+    const split = splitDayPageViews({
+      total: 10,
+      "/": 6,
+      __not_found__: 3,
+      __redirect__: 1,
+      __unmatched__: 2,
+    });
+    assert.deepEqual(Object.keys(split.by_route), ["/"]);
+  });
+
+  it("reports the excess a stored total carries over its surviving route keys", () => {
+    const split = splitDayPageViews({ total: 500, "/": 20, __unmatched__: 5 });
+    assert.equal(split.served, 20);
+    assert.equal(split.unclassified_legacy, 480);
+  });
+
+  it("reads an empty day as measured zero rather than as missing", () => {
+    const split = splitDayPageViews({});
+    assert.equal(split.served, 0);
+    assert.equal(split.not_found, 0);
+    assert.deepEqual(split.by_route, {});
+  });
+
+  it("routes each signal facet to its own bucket", () => {
+    const split = splitSignalKeys({
+      total: 6,
+      "e:recommended": 5,
+      "e:converted": 1,
+      "t:post": 6,
+      "c:ai_agent": 6,
+      "s:/vendor/:slug": 4,
+      "a:some-agent": 6,
+      "v:recommended:neon": 3,
+      "u:a name we do not carry": 2,
+      "x:an unlisted event": 1,
+    });
+    assert.equal(split.total, 6);
+    assert.deepEqual(split.by_event, { recommended: 5, converted: 1 });
+    assert.deepEqual(split.by_transport, { post: 6 });
+    assert.deepEqual(split.by_client_class, { ai_agent: 6 });
+    assert.deepEqual(split.by_source, { "/vendor/:slug": 4 });
+    assert.deepEqual(split.by_reporting_agent, { "some-agent": 6 });
+    assert.deepEqual(split.by_vendor, { "recommended:neon": 3 });
+    assert.deepEqual(split.unresolved_vendor_names, { "a name we do not carry": 2 });
+    assert.deepEqual(split.unrecognized_events, { "an unlisted event": 1 });
+  });
+
+  it("keeps a source key containing the separator intact", () => {
+    const split = splitSignalKeys({ "s:/compare/:slug": 3 });
+    assert.deepEqual(split.by_source, { "/compare/:slug": 3 });
+  });
+
+  it("ignores a facet letter it does not know rather than misfiling it", () => {
+    const split = splitSignalKeys({ "z:something": 9, total: 1 });
+    assert.equal(split.total, 1);
+    for (const bucket of Object.values(split)) {
+      if (typeof bucket === "number") continue;
+      assert.ok(!("something" in bucket));
+    }
+  });
+
+  it("reports a day as unavailable rather than empty when storage is not configured", () => {
+    const source = getRollupDaySource("2026-08-20");
+    assert.equal(source.available, false);
+    assert.equal(source.reason, "redis-not-configured");
+    assert.equal(source.page_views.served, 0);
+  });
+
+  it("offers no dates when there is no snapshot to read them from", () => {
+    assert.deepEqual(getRollupDatesAvailable(), []);
+  });
+});


### PR DESCRIPTION
Refs #1056 — the durability half only, split as you offered ("If you want to split it, ship the dated rollup on its own first"). Outbound tracking and the MCP mention log are not in this PR.

## The AC's storage target is not durable on this deployment

The criterion says the server writes `data/analytics/YYYY-MM-DD.json`. I checked before building:

- `Dockerfile` ends with `COPY data/ data/` into a `node:20-slim` image.
- No volume is mounted and nothing in `src/` reads a volume path.
- The only runtime writers into `data/` today (`agents.json`, `ledger.json`, `referral_codes.json`) already lose their writes on every deploy.

So a file the server writes there survives until the next deploy and no further. Shipping that *plus* `/api/signals` reporting a "last durable rollup" date would publish a durability claim that a deploy silently falsifies — the #1043 shape you flagged on this very issue, and worse than the status quo because it reads as solved.

**Git is what is actually durable for `data/` here**, and it is what `liveness.yml` and `reverify.yml` already use. So the writer moved outside the container.

## What ships

**`.github/workflows/analytics-rollup.yml`** — daily 04:30 UTC, reads one day at a time from production, commits what changed.

**`scripts/rollup-analytics.js`** — the collector.
- **Backfills every date the instance still holds on its first run.** That is the part that matters this week: it captures whatever is left of the 7- and 30-day windows the moment it lands, rather than starting the clock at zero.
- Rewrites the current day each run until it closes; never rewrites a day already marked final.
- Refuses to write when the instance cannot answer. A rollup of zeroes recorded as fact is the failure mode worth designing against, so an unloaded snapshot is a 503 and a non-zero exit, not an empty file.

**`/api/analytics/daily?date=`** — one date's counters, exact, straight off the stored snapshot. Not a difference of two windows.

**`/api/analytics/history`** — the committed files, read once at boot. This is the "a cold start rebuilds from files" criterion: with Redis emptied, the service still answers for every day on disk. Verified by clearing the fake store and restarting.

**`/api/signals`** gains `durable_rollup` — `first_date`, `last_date`, `last_complete_date`, `days`, `path`. Checkable rather than asserted, as asked.

## The control you asked to extend, and where I drew the line

`ROLLUP_EXCLUSIONS` is in the artifact itself, so a reader of any committed file sees what it does not carry:

- **Per-vendor counts.** `vendors` is `null` and only `vendor_key_count` is written. Same reasoning as `getSignalVendorBreakdown()` — a durable per-vendor series is exactly as self-reportable as a live one, and this artifact is public.
- **Caller-supplied vendor names and event strings.** Counted, never transcribed. `/api/signals` already publishes these in a rolling 30-day window; committing them to public git history forever is a different publication and I did not think that was mine to make. `unresolved_vendor_name_count` and `unrecognized_event_count` preserve the shape. **The catalog-gap feed keeps working live; it just does not become permanent.** Say the word and it is a one-line change.
- Reported free text, non-resolving request paths, anything identifying a caller.

Bite-verified, not asserted: setting `vendors` from the vendor map, or transcribing the caller names, each fails the e2e — which greps every written file for a seeded slug and a seeded caller string.

## Per-vendor durability is blocked on something I cannot do

The AC wants per-vendor counts in the rollup. That needs a collector inside the trust boundary, which needs a credential. **`gh secret list` on this repo returns empty — there are no Actions secrets at all**, which is why the existing data jobs only ever use `GITHUB_TOKEN` and public HTTP.

Two ways forward, both Rob's call, neither taken here:
1. Put the Upstash REST credentials in Actions secrets. I did **not** do this and would not without being asked: it is a production datastore credential on a public repo, readable by any workflow and anyone with write access.
2. A token-gated `/api/analytics/daily?detail=vendors`, with the token set in both Railway and Actions.

The rollup format already carries a `vendors` field so either can fill it later without a schema change or a backfill.

## The copy criterion does not apply to this PR

Your 10:07 comment adds `/llms.txt`, `/signal` and `src/signal.ts:4` to the AC. **This PR does not falsify those strings** — it adds no tracking of any kind, only a durable copy of counts we already collect and already publish. "When you leave this site the trail ends" stays true until the redirect ships. That criterion belongs to the outbound half and I have deliberately not pre-emptively edited copy to describe an instrument we do not yet have.

## One thing I got wrong in my own code, found by mutation

The collector deleted `dates_available` from the payload before writing. Removing that line broke nothing: `parseRollup` rebuilds from a fixed key list and had already dropped it. A line no test can bite is a line nobody can safely change later, so I deleted it and mutated the parse boundary instead — which does bite.

A second survivor: my "ignores files that are not dated rollups" test used a file containing `{}`, so it passed because the *body* was rejected, not the *name*. A stray `latest.json` holding a valid rollup would have been read and double-counted in coverage. Now tested with a valid body under a non-date name.

## Also in here

`/api/analytics/*` is added to `OBSERVABILITY_PATHS`. Without it the collector's own daily fetches — up to 30 on a backfill — land in the counters it is recording, which is the one rule this file exists to enforce.

The fixed signal facet letters `e`/`t`/`c` were literals in three places; they are now one definition alongside the others in `SIGNAL_FACETS`.

## Verified

- `tsc` clean, **1601/1601 tests** (34 new), full suite green.
- **`scripts/e2e-1056.mjs`, 53 checks, all passing** — boots real `dist/serve.js` against a fake Upstash seeded with three production-shaped days, reads the real endpoint, runs the real collector as a subprocess, restarts against the written files with storage cleared, and checks the no-storage refusal path.
- **15 mutations against real source; 2 survived the first pass and both were real gaps** (above). The other 13 each fail the check they should.

Not yet run against production — the endpoint ships with this PR. I will run the collector immediately after deploy and report what the first backfill actually captured, since that is the number that says how much history was still recoverable.
