### PR TITLE
Count daily MCP sessions by date so a deploy does not restart the day

### DIFF
--- a/scripts/e2e-1052.mjs
+++ b/scripts/e2e-1052.mjs
@@ -1,0 +1,305 @@
+import { createServer } from "node:http";
+import { spawn } from "node:child_process";
+
+const HELP = `End-to-end check for the durable daily MCP session count (#1052 criterion 0).
+
+Boots the real dist/serve.js against a fake Upstash, opens real MCP sessions over
+streamable HTTP (initialize -> tools/call), restarts the process against the same
+store, and reads /api/stats and /api/traffic across the restart. Covers the thing
+unit tests cannot: that a deploy no longer restarts the day.
+
+Usage: node scripts/e2e-1052.mjs
+`;
+
+if (process.argv.includes("--help") || process.argv.includes("-h")) {
+  console.log(HELP);
+  process.exit(0);
+}
+
+const store = new Map();
+const lists = new Map();
+
+const upstash = createServer((req, res) => {
+  let body = "";
+  req.on("data", c => (body += c));
+  req.on("end", () => {
+    const args = JSON.parse(body || "[]");
+    const cmd = String(args[0]).toUpperCase();
+    let result;
+    switch (cmd) {
+      case "GET": result = store.get(String(args[1])) ?? null; break;
+      case "SET": store.set(String(args[1]), String(args[2])); result = "OK"; break;
+      case "MGET": result = args.slice(1).map(k => store.get(String(k)) ?? null); break;
+      case "SCAN": {
+        const pattern = String(args[3] ?? "*");
+        const prefix = pattern.endsWith("*") ? pattern.slice(0, -1) : pattern;
+        result = ["0", [...store.keys()].filter(k => k.startsWith(prefix))];
+        break;
+      }
+      case "LPUSH": {
+        const key = String(args[1]);
+        const list = lists.get(key) ?? [];
+        for (const v of args.slice(2)) list.unshift(String(v));
+        lists.set(key, list);
+        result = list.length;
+        break;
+      }
+      case "LTRIM": {
+        const key = String(args[1]);
+        lists.set(key, (lists.get(key) ?? []).slice(Number(args[2]), Number(args[3]) + 1));
+        result = "OK";
+        break;
+      }
+      case "LRANGE":
+        result = (lists.get(String(args[1])) ?? []).slice(Number(args[2]), Number(args[3]) + 1);
+        break;
+      default: result = 1;
+    }
+    res.writeHead(200, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ result }));
+  });
+});
+
+const failures = [];
+function check(label, cond, detail = "") {
+  if (cond) console.log(`  ok    ${label}`);
+  else {
+    console.log(`  FAIL  ${label}${detail ? ` — ${detail}` : ""}`);
+    failures.push(label);
+  }
+}
+
+function startServer(env) {
+  return new Promise((resolve, reject) => {
+    const proc = spawn("node", ["dist/serve.js"], {
+      cwd: process.cwd(),
+      stdio: ["pipe", "pipe", "pipe"],
+      env: { ...process.env, PORT: "0", BASE_URL: "http://localhost", ...env },
+    });
+    const timer = setTimeout(() => {
+      proc.kill("SIGKILL");
+      reject(new Error("server startup timeout"));
+    }, 30000);
+    const onData = buf => {
+      const m = buf.toString().match(/running on http:\/\/localhost:(\d+)/);
+      if (m) {
+        clearTimeout(timer);
+        resolve({ proc, port: Number(m[1]) });
+      }
+    };
+    proc.stdout.on("data", onData);
+    proc.stderr.on("data", onData);
+    proc.on("error", reject);
+  });
+}
+
+async function stop(proc) {
+  proc.kill("SIGTERM");
+  await new Promise(r => {
+    const t = setTimeout(() => {
+      proc.kill("SIGKILL");
+      r();
+    }, 8000);
+    proc.on("exit", () => {
+      clearTimeout(t);
+      r();
+    });
+  });
+}
+
+const UA = { "User-Agent": "agentdeals-internal/1.0 (session series e2e)" };
+const MCP_HEADERS = {
+  ...UA,
+  "Content-Type": "application/json",
+  Accept: "application/json, text/event-stream",
+};
+
+function parseMcpBody(text) {
+  if (text.startsWith("event:") || text.includes("\ndata: ")) {
+    const line = text.split("\n").find(l => l.startsWith("data: "));
+    return line ? JSON.parse(line.slice(6)) : null;
+  }
+  return text ? JSON.parse(text) : null;
+}
+
+async function openSession(base, clientName) {
+  const res = await fetch(`${base}/mcp`, {
+    method: "POST",
+    headers: MCP_HEADERS,
+    body: JSON.stringify({
+      jsonrpc: "2.0",
+      id: 1,
+      method: "initialize",
+      params: {
+        protocolVersion: "2024-11-05",
+        capabilities: {},
+        clientInfo: { name: clientName, version: "1.0.0" },
+      },
+    }),
+  });
+  const sid = res.headers.get("mcp-session-id");
+  const body = parseMcpBody(await res.text());
+  return { status: res.status, sid, body };
+}
+
+async function initializeWithRawClientInfo(base, clientInfo) {
+  const res = await fetch(`${base}/mcp`, {
+    method: "POST",
+    headers: MCP_HEADERS,
+    body: JSON.stringify({
+      jsonrpc: "2.0",
+      id: 1,
+      method: "initialize",
+      params: { protocolVersion: "2024-11-05", capabilities: {}, ...clientInfo },
+    }),
+  });
+  const sid = res.headers.get("mcp-session-id");
+  const body = parseMcpBody(await res.text());
+  return { status: res.status, sid, body };
+}
+
+async function callTool(base, sid) {
+  const res = await fetch(`${base}/mcp`, {
+    method: "POST",
+    headers: { ...MCP_HEADERS, "mcp-session-id": sid },
+    body: JSON.stringify({
+      jsonrpc: "2.0",
+      id: 2,
+      method: "tools/call",
+      params: { name: "search_deals", arguments: { query: "postgres" } },
+    }),
+  });
+  return { status: res.status, body: parseMcpBody(await res.text()) };
+}
+
+const today = new Date().toISOString().slice(0, 10);
+
+async function stats(base) {
+  return (await fetch(`${base}/api/stats`, { headers: UA })).json();
+}
+async function traffic(base) {
+  return (await fetch(`${base}/api/traffic`, { headers: UA })).json();
+}
+
+async function main() {
+  await new Promise(r => upstash.listen(0, r));
+  const upstashUrl = `http://127.0.0.1:${upstash.address().port}`;
+  const redisEnv = {
+    UPSTASH_REDIS_REST_URL: upstashUrl,
+    UPSTASH_REDIS_REST_TOKEN: "e2e-token",
+  };
+
+  console.log("\n1. A real MCP session is counted the moment it opens");
+  let { proc, port } = await startServer(redisEnv);
+  let base = `http://127.0.0.1:${port}`;
+
+  const before = (await stats(base)).sessionsToday;
+  check("a fresh store starts the day at zero", before === 0, `got ${before}`);
+
+  const first = await openSession(base, "opencode");
+  check("initialize returns 200", first.status === 200, String(first.status));
+  check("initialize returns a session id", Boolean(first.sid));
+  check("initialize returns a server result", Boolean(first.body?.result?.serverInfo));
+
+  const afterOne = (await stats(base)).sessionsToday;
+  check("the session is counted before any flush", afterOne === 1, `got ${afterOne}`);
+
+  const tool = await callTool(base, first.sid);
+  check("tools/call on that session returns 200", tool.status === 200, String(tool.status));
+  check("tools/call returns content", Boolean(tool.body?.result));
+
+  for (const name of ["claude-code", "glimind-probe", "mcp"]) {
+    const s = await openSession(base, name);
+    check(`initialize succeeds for ${name}`, s.status === 200);
+  }
+
+  for (const [label, raw] of [
+    ["omits clientInfo", {}],
+    ["sends clientInfo with no name", { clientInfo: {} }],
+    ["sends a name with no version", { clientInfo: { name: "mcp" } }],
+  ]) {
+    const r = await initializeWithRawClientInfo(base, raw);
+    check(`a client that ${label} is refused a session`, r.status === 400, String(r.status));
+  }
+  check("a refused initialize is not counted as a session",
+    (await stats(base)).sessionsToday === 4, `got ${(await stats(base)).sessionsToday}`);
+
+  const preRestart = await stats(base);
+  check("all four sessions are on the day", preRestart.sessionsToday === 4,
+    `got ${preRestart.sessionsToday}`);
+
+  const preTraffic = await traffic(base);
+  check("the traffic report dates the series to today",
+    preTraffic.sessions.recording_since === today, String(preTraffic.sessions.recording_since));
+  check("the traffic report agrees with /api/stats",
+    preTraffic.sessions.today === 4, `got ${preTraffic.sessions.today}`);
+  check("the series carries one entry per measured day",
+    JSON.stringify(preTraffic.sessions.daily) === JSON.stringify([{ date: today, sessions: 4 }]),
+    JSON.stringify(preTraffic.sessions.daily));
+  check("the reading rule is published with the series",
+    preTraffic.notes.some(n => n.includes("recording_since")));
+
+  console.log("\n2. The count survives the event that used to reset it");
+  await stop(proc);
+  check("the outgoing process persisted the day", Boolean(store.get("agentdeals:pageviews")));
+  const persisted = JSON.parse(store.get("agentdeals:pageviews") ?? "{}");
+  check("the day is stored under its own date key", persisted.sessions?.[today] === 4,
+    JSON.stringify(persisted.sessions));
+  check("the clients that opened them are stored too",
+    persisted.session_clients?.[today]?.opencode === 1,
+    JSON.stringify(persisted.session_clients?.[today]));
+
+  ({ proc, port } = await startServer(redisEnv));
+  base = `http://127.0.0.1:${port}`;
+
+  const afterRestart = await stats(base);
+  check("a restart does not restart the day", afterRestart.sessionsToday === 4,
+    `got ${afterRestart.sessionsToday}`);
+  check("the restart is a genuinely new process",
+    afterRestart.serverStarted !== preRestart.serverStarted);
+
+  const post = await openSession(base, "codex-mcp-client");
+  check("a post-restart initialize returns 200", post.status === 200);
+  const final = await stats(base);
+  check("a post-restart session adds to the day rather than replacing it",
+    final.sessionsToday === 5, `got ${final.sessionsToday}`);
+
+  const finalTraffic = await traffic(base);
+  check("recording_since holds at the first measured date, not the restart",
+    finalTraffic.sessions.recording_since === today,
+    String(finalTraffic.sessions.recording_since));
+  check("the lifetime total is reported apart from the dated series",
+    finalTraffic.sessions.all_time >= final.sessionsToday,
+    `all_time=${finalTraffic.sessions.all_time} today=${final.sessionsToday}`);
+
+  console.log("\n3. A store written before the series existed reads as unmeasured");
+  await stop(proc);
+  store.set("agentdeals:pageviews", JSON.stringify({
+    days: { [today]: 100 },
+    all_time: {},
+    updated_at: new Date().toISOString(),
+  }));
+  ({ proc, port } = await startServer(redisEnv));
+  base = `http://127.0.0.1:${port}`;
+
+  const legacy = await traffic(base);
+  check("an old snapshot reports no measurement rather than zero sessions",
+    legacy.sessions.recording_since === null, String(legacy.sessions.recording_since));
+  check("an old snapshot carries an empty series",
+    Array.isArray(legacy.sessions.daily) && legacy.sessions.daily.length === 0,
+    JSON.stringify(legacy.sessions.daily));
+  check("an old snapshot still reports the day as zero, not as missing",
+    (await stats(base)).sessionsToday === 0);
+
+  await stop(proc);
+  upstash.close();
+
+  console.log(`\n${failures.length === 0 ? "PASS" : `FAIL (${failures.length})`}`);
+  for (const f of failures) console.log(`  - ${f}`);
+  process.exit(failures.length === 0 ? 0 : 1);
+}
+
+main().catch(err => {
+  console.error(err);
+  process.exit(1);
+});

--- a/src/openapi.ts
+++ b/src/openapi.ts
@@ -864,7 +864,7 @@ export const openapiSpec = {
                     totalSessionsAllTime: { type: "integer", description: "Cumulative sessions across all deploys (persisted in Redis)" },
                     totalApiHitsAllTime: { type: "integer", description: "Cumulative REST API hits across all deploys (persisted in Redis)" },
                     totalToolCallsAllTime: { type: "integer", description: "Cumulative MCP tool calls across all deploys (persisted in Redis)" },
-                    sessionsToday: { type: "integer", description: "Sessions since midnight UTC (resets daily)" },
+                    sessionsToday: { type: "integer", description: "Sessions opened since midnight UTC. Persisted per day, so a deploy does not reset it. Counts only from the date the daily series began — see sessions.recording_since on /api/traffic." },
                     serverStarted: { type: "string", format: "date-time", description: "ISO timestamp of current server start" },
                     clients: { type: "object", additionalProperties: { type: "integer" }, description: "Cumulative session counts per MCP client name (e.g. claude-desktop, cursor)" },
                     toolCallsByClient: { type: "object", additionalProperties: { type: "integer" }, description: "Cumulative MCP tool-call counts per MCP client name. Missing/empty client IDs bucket to 'unknown'. Values sum to totalToolCallsAllTime (invariant)." },

--- a/src/stats.ts
+++ b/src/stats.ts
@@ -817,9 +817,7 @@ export function recordSessionConnect(clientName?: string): void {
     OTHER_SESSION_CLIENT_KEY,
     pageViewSnapshot.session_clients[today],
   );
-  if (!pendingPageViews.sessions_from && !pageViewSnapshot.sessions_from) {
-    pendingPageViews.sessions_from = today;
-  }
+  pendingPageViews.sessions_from = today;
 }
 
 export function getSessionsForDate(date: string): number {
@@ -1186,7 +1184,7 @@ const CLASS_ROUTE_SEP = "|";
 const UNKNOWN_FAMILY_KEY = "unknown";
 
 const SESSION_DAY_RETENTION = 90;
-const MAX_SESSION_CLIENT_KEYS_PER_DAY = 120;
+export const MAX_SESSION_CLIENT_KEYS_PER_DAY = 120;
 export const OTHER_SESSION_CLIENT_KEY = "__other_clients__";
 export const UNNAMED_SESSION_CLIENT_KEY = "unknown";
 

--- a/src/stats.ts
+++ b/src/stats.ts
@@ -36,8 +36,6 @@ const apiHits: Record<string, number> = {};
 let totalSessions = 0;
 let totalDisconnects = 0;
 let landingPageViews = 0;
-let sessionsToday = 0;
-let sessionsTodayDate = new Date().toISOString().slice(0, 10);
 
 // Cumulative stats loaded from external storage
 let cumulative = {
@@ -729,7 +727,6 @@ export function resetCounters(): void {
   totalSessions = 0;
   totalDisconnects = 0;
   landingPageViews = 0;
-  sessionsToday = 0;
   for (const key of Object.keys(toolCalls)) toolCalls[key] = 0;
   for (const key of Object.keys(apiHits)) delete apiHits[key];
   for (const key of Object.keys(sessionClients)) delete sessionClients[key];
@@ -807,14 +804,42 @@ export function recordSessionConnect(clientName?: string): void {
   if (!cumulative.first_session_at) {
     cumulative.first_session_at = new Date().toISOString();
   }
-  const today = new Date().toISOString().slice(0, 10);
-  if (today !== sessionsTodayDate) {
-    sessionsToday = 0;
-    sessionsTodayDate = today;
-  }
-  sessionsToday++;
-  const name = clientName || "unknown";
+  const name = (clientName && clientName.trim()) || UNNAMED_SESSION_CLIENT_KEY;
   sessionClients[name] = (sessionClients[name] ?? 0) + 1;
+
+  const today = new Date().toISOString().slice(0, 10);
+  bump(pendingPageViews.sessions, today, 1);
+  bumpBounded(
+    (pendingPageViews.session_clients[today] ??= {}),
+    name,
+    1,
+    MAX_SESSION_CLIENT_KEYS_PER_DAY,
+    OTHER_SESSION_CLIENT_KEY,
+    pageViewSnapshot.session_clients[today],
+  );
+  if (!pendingPageViews.sessions_from && !pageViewSnapshot.sessions_from) {
+    pendingPageViews.sessions_from = today;
+  }
+}
+
+export function getSessionsForDate(date: string): number {
+  return (pageViewSnapshot.sessions[date] ?? 0) + (pendingPageViews.sessions[date] ?? 0);
+}
+
+export function getSessionSeries(): SessionSeries {
+  const dates = new Set([
+    ...Object.keys(pageViewSnapshot.sessions),
+    ...Object.keys(pendingPageViews.sessions),
+  ]);
+  return {
+    daily: [...dates]
+      .sort()
+      .map(date => ({ date, sessions: getSessionsForDate(date) })),
+    today: getSessionsForDate(new Date().toISOString().slice(0, 10)),
+    recording_since: pageViewSnapshot.sessions_from || pendingPageViews.sessions_from || null,
+    all_time: cumulative.sessions + totalSessions,
+    retention_days: SESSION_DAY_RETENTION,
+  };
 }
 
 export function recordSessionDisconnect(): void {
@@ -979,10 +1004,6 @@ export function getConnectionStats(activeSessions: number): {
   toolCallsByName: Record<string, number>;
 } {
   const today = new Date().toISOString().slice(0, 10);
-  if (today !== sessionsTodayDate) {
-    sessionsToday = 0;
-    sessionsTodayDate = today;
-  }
   const totalToolCalls = Object.values(toolCalls).reduce((a, b) => a + b, 0);
   const totalApiHits = Object.values(apiHits).reduce((a, b) => a + b, 0);
   // Merge cumulative + current deployment client counts
@@ -1003,7 +1024,7 @@ export function getConnectionStats(activeSessions: number): {
     totalSessionsAllTime: cumulative.sessions + totalSessions,
     totalApiHitsAllTime: cumulative.api_hits + totalApiHits,
     totalToolCallsAllTime: cumulative.tool_calls + totalToolCalls,
-    sessionsToday,
+    sessionsToday: getSessionsForDate(today),
     serverStarted: serverStartedISO,
     clients: mergedClients,
     toolCallsByClient: mergedToolCallsByClient,
@@ -1164,6 +1185,11 @@ const CLASS_ROUTE_SEP = "|";
 /** Overflow bucket for the per-day family map. Matches UNKNOWN_FAMILY in client-class.ts. */
 const UNKNOWN_FAMILY_KEY = "unknown";
 
+const SESSION_DAY_RETENTION = 90;
+const MAX_SESSION_CLIENT_KEYS_PER_DAY = 120;
+export const OTHER_SESSION_CLIENT_KEY = "__other_clients__";
+export const UNNAMED_SESSION_CLIENT_KEY = "unknown";
+
 /**
  * One remembered non-resolving request (#1029). The `__unmatched__` bucket answers "how
  * many" and nothing else, which is not enough to tell a vulnerability scanner from a
@@ -1216,6 +1242,9 @@ interface PageViewSnapshot {
   families: Record<string, Record<string, number>>;
   /** date -> MCP tool calls, so web_vs_mcp compares the same window on both sides. */
   mcp: Record<string, number>;
+  sessions: Record<string, number>;
+  session_clients: Record<string, Record<string, number>>;
+  sessions_from: string;
   /** date -> client class -> requests that did not resolve to a page (4xx/5xx) (#1029). */
   not_found: Record<string, Record<string, number>>;
   /** date -> client class -> 3xx. Apart, so a redirect and its target are not two hits. */
@@ -1264,6 +1293,8 @@ function emptySnapshot(): PageViewSnapshot {
     class_routes: {},
     families: {},
     mcp: {},
+    sessions: {},
+    session_clients: {},
     not_found: {},
     redirects: {},
     not_found_sample: [],
@@ -1271,6 +1302,7 @@ function emptySnapshot(): PageViewSnapshot {
     signals_all_time: {},
     signal_notes: [],
     signals_from: "",
+    sessions_from: "",
     all_time_trustworthy_from: "",
     outcome_split_from: "",
   };
@@ -1350,6 +1382,8 @@ function countPendingPageViewKeys(): number {
   // class already counted today adds no new counter key, and without this the sample
   // would sit in memory until some other traffic happened to trigger a write.
   n += pendingPageViews.not_found_sample.length;
+  n += Object.keys(pendingPageViews.sessions).length;
+  for (const day of Object.values(pendingPageViews.session_clients)) n += Object.keys(day).length;
   return n;
 }
 
@@ -1367,6 +1401,8 @@ function mergeSnapshot(base: PageViewSnapshot, delta: PageViewSnapshot): PageVie
     class_routes: {},
     families: {},
     mcp: { ...base.mcp },
+    sessions: { ...base.sessions },
+    session_clients: {},
     not_found: {},
     redirects: {},
     // Oldest first, capped — the delta is newer than the base by construction.
@@ -1375,6 +1411,7 @@ function mergeSnapshot(base: PageViewSnapshot, delta: PageViewSnapshot): PageVie
     signals_all_time: { ...base.signals_all_time },
     signal_notes: [...base.signal_notes, ...delta.signal_notes].slice(-SIGNAL_NOTE_MAX),
     signals_from: base.signals_from || delta.signals_from,
+    sessions_from: base.sessions_from || delta.sessions_from,
     all_time_trustworthy_from: base.all_time_trustworthy_from || delta.all_time_trustworthy_from,
     outcome_split_from: base.outcome_split_from || delta.outcome_split_from,
   };
@@ -1383,6 +1420,7 @@ function mergeSnapshot(base: PageViewSnapshot, delta: PageViewSnapshot): PageVie
   for (const [date, map] of Object.entries(base.classes)) out.classes[date] = { ...map };
   for (const [date, map] of Object.entries(base.class_routes)) out.class_routes[date] = { ...map };
   for (const [date, map] of Object.entries(base.families)) out.families[date] = { ...map };
+  for (const [date, map] of Object.entries(base.session_clients)) out.session_clients[date] = { ...map };
   for (const [date, map] of Object.entries(base.not_found)) out.not_found[date] = { ...map };
   for (const [date, map] of Object.entries(base.redirects)) out.redirects[date] = { ...map };
   for (const [date, map] of Object.entries(base.signals)) out.signals[date] = { ...map };
@@ -1443,6 +1481,13 @@ function mergeSnapshot(base: PageViewSnapshot, delta: PageViewSnapshot): PageVie
     }
   }
   for (const [date, count] of Object.entries(delta.mcp)) bump(out.mcp, date, count);
+  for (const [date, count] of Object.entries(delta.sessions)) bump(out.sessions, date, count);
+  for (const [date, map] of Object.entries(delta.session_clients)) {
+    const target = (out.session_clients[date] ??= {});
+    for (const [key, count] of Object.entries(map)) {
+      bumpBounded(target, key, count, MAX_SESSION_CLIENT_KEYS_PER_DAY, OTHER_SESSION_CLIENT_KEY);
+    }
+  }
   return out;
 }
 
@@ -1467,6 +1512,11 @@ function pruneSnapshot(snapshot: PageViewSnapshot): void {
   // fixed enum per date) and answer questions over the same window.
   for (const field of ["classes", "mcp", "not_found", "redirects", "signals"] as const) {
     for (const date of Object.keys(snapshot[field]).sort().reverse().slice(CLASS_DAY_RETENTION)) {
+      delete snapshot[field][date];
+    }
+  }
+  for (const field of ["sessions", "session_clients"] as const) {
+    for (const date of Object.keys(snapshot[field]).sort().reverse().slice(SESSION_DAY_RETENTION)) {
       delete snapshot[field][date];
     }
   }
@@ -1583,6 +1633,8 @@ function normalizeSnapshot(raw: unknown): PageViewSnapshot {
   snapshot.class_routes = numericMapOfMaps(obj.class_routes);
   snapshot.families = numericMapOfMaps(obj.families);
   snapshot.mcp = numericMap(obj.mcp);
+  snapshot.sessions = numericMap(obj.sessions);
+  snapshot.session_clients = numericMapOfMaps(obj.session_clients);
   // Absent on a snapshot written before #1029. An empty map reads as "that build did not
   // separate outcomes", which is true — the not-found hits it recorded are inside
   // `classes` and `days`, and `trustworthy_from` is what says so.
@@ -1595,6 +1647,7 @@ function normalizeSnapshot(raw: unknown): PageViewSnapshot {
   snapshot.signals_all_time = numericMap(obj.signals_all_time);
   snapshot.signal_notes = signalNotes(obj.signal_notes);
   snapshot.signals_from = typeof obj.signals_from === "string" ? obj.signals_from : "";
+  snapshot.sessions_from = typeof obj.sessions_from === "string" ? obj.sessions_from : "";
   snapshot.all_time_trustworthy_from =
     typeof obj.all_time_trustworthy_from === "string" ? obj.all_time_trustworthy_from : "";
   snapshot.outcome_split_from =
@@ -2283,8 +2336,22 @@ export interface TrafficReport {
    * scanner from a broken integration, which the count alone cannot (#1029).
    */
   not_found_sample: NotFoundSample[];
+  sessions: SessionSeries;
   notes: string[];
   storage: TelemetryHealth;
+}
+
+export interface SessionSeriesDay {
+  date: string;
+  sessions: number;
+}
+
+export interface SessionSeries {
+  daily: SessionSeriesDay[];
+  today: number;
+  recording_since: string | null;
+  all_time: number;
+  retention_days: number;
 }
 
 const TOP_ROUTES_PER_CLASS = 10;
@@ -2452,6 +2519,7 @@ const TRAFFIC_NOTES = [
   "hits_total, hits_excluding_internal, by_class and top_routes_by_class count requests we answered with content (2xx). Requests that did not resolve are in not_found_*, and 3xx answers are in redirect_* — a client that only ever 404s is not a client that read our pages (#1029).",
   "not_found carries no route breakdown: an unmatched path has no route by definition. not_found_sample carries the actual paths, sanitized and truncated, for the last 50.",
   "Each window states data_days_available alongside days. Where they differ the window is arithmetically correct and shorter than its label — read coverage before quoting it.",
+  "sessions.daily counts MCP sessions opened per UTC day and survives a deploy. It starts at sessions.recording_since; there is no measurement before that date, so a chart must start the line there rather than draw zero. sessions.all_time predates the series and cannot be split across dates.",
 ];
 
 /**
@@ -2483,6 +2551,7 @@ export function getTrafficReport(): TrafficReport {
     // while hiding the thing itself, on the code path — no storage, or storage we could
     // not read — where an operator most needs to see what is hitting the server.
     not_found_sample: [...pendingPageViews.not_found_sample].reverse(),
+    sessions: getSessionSeries(),
     notes: TRAFFIC_NOTES,
     storage,
   });
@@ -2512,6 +2581,7 @@ export function getTrafficReport(): TrafficReport {
     since_boot_not_found: notFoundSinceBoot,
     since_boot_redirects: redirectsSinceBoot,
     not_found_sample: [...view.not_found_sample].reverse(),
+    sessions: getSessionSeries(),
     notes: TRAFFIC_NOTES,
     storage,
   };

--- a/test/session-series.test.ts
+++ b/test/session-series.test.ts
@@ -15,8 +15,10 @@ const {
   resetTelemetryHealth,
   loadTelemetry,
   flushPending,
+  getTelemetryHealth,
   OTHER_SESSION_CLIENT_KEY,
   UNNAMED_SESSION_CLIENT_KEY,
+  MAX_SESSION_CLIENT_KEYS_PER_DAY,
 } = await import("../dist/stats.js");
 
 const PAGE_VIEWS_KEY = "agentdeals:pageviews";
@@ -220,7 +222,7 @@ describe("daily MCP session counts (#1052)", () => {
 
     const clients = storedSnapshot().session_clients[today()];
     assert.ok(
-      Object.keys(clients).length <= 121,
+      Object.keys(clients).length <= MAX_SESSION_CLIENT_KEYS_PER_DAY + 1,
       `key space must stay bounded, saw ${Object.keys(clients).length}`,
     );
     assert.ok(clients[OTHER_SESSION_CLIENT_KEY] > 0, "the excess must be folded, not dropped");
@@ -269,6 +271,122 @@ describe("daily MCP session counts (#1052)", () => {
     assert.deepStrictEqual(
       series.daily.map((d: { date: string }) => d.date),
       ["2026-01-01", today()],
+    );
+  });
+
+  it("keeps the stored first-measured date when a later day flushes over it", async () => {
+    redis.values.set(
+      PAGE_VIEWS_KEY,
+      JSON.stringify({
+        days: {},
+        all_time: {},
+        sessions: { "2026-01-01": 5 },
+        sessions_from: "2026-01-01",
+        updated_at: "2026-01-01T00:00:00.000Z",
+      }),
+    );
+    await boot();
+    recordSessionConnect("opencode");
+    await flushPending();
+
+    assert.strictEqual(
+      storedSnapshot().sessions_from,
+      "2026-01-01",
+      "a flush must not move the date the series began",
+    );
+    assert.strictEqual(getSessionSeries().recording_since, "2026-01-01");
+  });
+
+  it("adds the day's clients to the stored ones rather than replacing them", async () => {
+    await boot();
+    recordSessionConnect("opencode");
+    recordSessionConnect("claude-code");
+    await flushPending();
+
+    await redeploy();
+    recordSessionConnect("opencode");
+    recordSessionConnect("codex-mcp-client");
+    await flushPending();
+
+    assert.deepStrictEqual(storedSnapshot().session_clients[today()], {
+      opencode: 2,
+      "claude-code": 1,
+      "codex-mcp-client": 1,
+    });
+    assert.strictEqual(storedSnapshot().sessions[today()], 4);
+  });
+
+  it("holds the stored client key space at the cap across repeated flushes", async () => {
+    await boot();
+    for (let i = 0; i < 400; i++) recordSessionConnect(`first-batch-${i}`);
+    await flushPending();
+    for (let i = 0; i < 400; i++) recordSessionConnect(`second-batch-${i}`);
+    await flushPending();
+
+    const clients = storedSnapshot().session_clients[today()];
+    assert.ok(
+      Object.keys(clients).length <= MAX_SESSION_CLIENT_KEYS_PER_DAY + 1,
+      `key space must stay bounded across flushes, saw ${Object.keys(clients).length}`,
+    );
+    const total = Object.values(clients).reduce((a, b) => (a as number) + (b as number), 0);
+    assert.strictEqual(total, 800, "no session may be lost to the cap");
+    assert.strictEqual(storedSnapshot().sessions[today()], 800);
+  });
+
+  it("caps the merged day when an outgoing instance flushes its own clients after we booted", async () => {
+    await boot();
+    for (let i = 0; i < MAX_SESSION_CLIENT_KEYS_PER_DAY; i++) {
+      recordSessionConnect(`incoming-${i}`);
+    }
+
+    const departing: Record<string, number> = {};
+    for (let i = 0; i < MAX_SESSION_CLIENT_KEYS_PER_DAY; i++) departing[`departing-${i}`] = 1;
+    redis.values.set(
+      PAGE_VIEWS_KEY,
+      JSON.stringify({
+        days: {},
+        all_time: {},
+        sessions: { [today()]: MAX_SESSION_CLIENT_KEYS_PER_DAY },
+        session_clients: { [today()]: departing },
+        sessions_from: today(),
+        updated_at: new Date().toISOString(),
+      }),
+    );
+
+    await flushPending();
+
+    const clients = storedSnapshot().session_clients[today()];
+    assert.ok(
+      Object.keys(clients).length <= MAX_SESSION_CLIENT_KEYS_PER_DAY + 1,
+      `the merge must bound the key space it did not record, saw ${Object.keys(clients).length}`,
+    );
+    const total = Object.values(clients).reduce((a, b) => (a as number) + (b as number), 0);
+    assert.strictEqual(
+      total,
+      MAX_SESSION_CLIENT_KEYS_PER_DAY * 2,
+      "both instances' sessions must survive the merge",
+    );
+    assert.strictEqual(
+      storedSnapshot().sessions[today()],
+      MAX_SESSION_CLIENT_KEYS_PER_DAY * 2,
+      "the day total must include the departing instance's final batch",
+    );
+  });
+
+  it("bounds what an unflushed burst of new client names can hold in memory", async () => {
+    await boot();
+    const before = getTelemetryHealth().pending_page_view_keys;
+    for (let i = 0; i < 5000; i++) recordSessionConnect(`burst-${i}`);
+
+    const growth = getTelemetryHealth().pending_page_view_keys - before;
+    assert.ok(
+      growth <= MAX_SESSION_CLIENT_KEYS_PER_DAY + 2,
+      `an unflushed burst must not grow the buffer per distinct name, grew by ${growth}`,
+    );
+    assert.strictEqual(
+      getConnectionStats(0).sessionsToday,
+      5000,
+      "bounding the buffer must not lose a session from the day",
     );
   });
 

--- a/test/session-series.test.ts
+++ b/test/session-series.test.ts
@@ -1,0 +1,327 @@
+import { describe, it, beforeEach, afterEach } from "node:test";
+import assert from "node:assert";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { randomUUID } from "node:crypto";
+
+const {
+  recordSessionConnect,
+  getConnectionStats,
+  getSessionSeries,
+  getSessionsForDate,
+  getTrafficReport,
+  resetCounters,
+  resetTelemetryBuffers,
+  resetTelemetryHealth,
+  loadTelemetry,
+  flushPending,
+  OTHER_SESSION_CLIENT_KEY,
+  UNNAMED_SESSION_CLIENT_KEY,
+} = await import("../dist/stats.js");
+
+const PAGE_VIEWS_KEY = "agentdeals:pageviews";
+
+type Call = { cmd: string; args: unknown[] };
+
+class FakeUpstash {
+  values = new Map<string, string>();
+  lists = new Map<string, string[]>();
+  calls: Call[] = [];
+
+  reset(): void {
+    this.calls = [];
+  }
+  commandCount(cmd?: string): number {
+    return cmd ? this.calls.filter(c => c.cmd === cmd).length : this.calls.length;
+  }
+  exec(cmd: string, args: unknown[]): unknown {
+    switch (cmd) {
+      case "GET": {
+        const v = this.values.get(String(args[0]));
+        return { result: v === undefined ? null : v };
+      }
+      case "SET":
+        this.values.set(String(args[0]), String(args[1]));
+        return { result: "OK" };
+      case "MGET":
+        return { result: args.map(k => this.values.get(String(k)) ?? null) };
+      case "SCAN":
+        return { result: ["0", []] };
+      case "LPUSH": {
+        const key = String(args[0]);
+        const list = this.lists.get(key) ?? [];
+        for (const v of args.slice(1)) list.unshift(String(v));
+        this.lists.set(key, list);
+        return { result: list.length };
+      }
+      case "LRANGE": {
+        const list = this.lists.get(String(args[0])) ?? [];
+        return { result: list.slice(Number(args[1]), Number(args[2]) + 1) };
+      }
+      default:
+        return { result: 1 };
+    }
+  }
+}
+
+const realFetch = globalThis.fetch;
+let redis: FakeUpstash;
+let telemetryFile: string;
+
+function installFetchStub(): void {
+  globalThis.fetch = (async (_url: string, init: { body: string }) => {
+    const parsed = JSON.parse(init.body) as unknown[];
+    const cmd = String(parsed[0]).toUpperCase();
+    const args = parsed.slice(1);
+    redis.calls.push({ cmd, args });
+    return { ok: true, status: 200, json: async () => redis.exec(cmd, args) };
+  }) as unknown as typeof fetch;
+}
+
+async function boot(): Promise<void> {
+  await loadTelemetry(telemetryFile);
+  redis.reset();
+  resetTelemetryHealth();
+}
+
+async function redeploy(): Promise<void> {
+  resetCounters();
+  resetTelemetryBuffers();
+  await boot();
+}
+
+function storedSnapshot(): Record<string, any> {
+  const raw = redis.values.get(PAGE_VIEWS_KEY);
+  assert.ok(raw, "expected a persisted snapshot");
+  return JSON.parse(raw!);
+}
+
+const today = () => new Date().toISOString().slice(0, 10);
+
+describe("daily MCP session counts (#1052)", () => {
+  beforeEach(async () => {
+    process.env.UPSTASH_REDIS_REST_URL = "https://stub.upstash.invalid";
+    process.env.UPSTASH_REDIS_REST_TOKEN = "stub-token";
+    redis = new FakeUpstash();
+    telemetryFile = join(tmpdir(), `sessions-${randomUUID()}.json`);
+    resetCounters();
+    resetTelemetryBuffers();
+    resetTelemetryHealth();
+    installFetchStub();
+  });
+
+  afterEach(() => {
+    globalThis.fetch = realFetch;
+    delete process.env.UPSTASH_REDIS_REST_URL;
+    delete process.env.UPSTASH_REDIS_REST_TOKEN;
+  });
+
+  it("keeps counting today's sessions across a deploy", async () => {
+    await boot();
+    for (let i = 0; i < 7; i++) recordSessionConnect("opencode");
+    assert.strictEqual(getConnectionStats(0).sessionsToday, 7);
+    await flushPending();
+
+    await redeploy();
+
+    assert.strictEqual(
+      getConnectionStats(0).sessionsToday,
+      7,
+      "a restart must not restart the day",
+    );
+    recordSessionConnect("claude-code");
+    assert.strictEqual(getConnectionStats(0).sessionsToday, 8);
+  });
+
+  it("adds post-deploy sessions to the pre-deploy count rather than replacing them", async () => {
+    await boot();
+    for (let i = 0; i < 4; i++) recordSessionConnect("opencode");
+    await flushPending();
+    await redeploy();
+    for (let i = 0; i < 3; i++) recordSessionConnect("opencode");
+    await flushPending();
+    await redeploy();
+    for (let i = 0; i < 2; i++) recordSessionConnect("opencode");
+
+    assert.strictEqual(getConnectionStats(0).sessionsToday, 9);
+  });
+
+  it("counts a session the moment it happens, before the next flush", async () => {
+    await boot();
+    recordSessionConnect("opencode");
+    assert.strictEqual(
+      getConnectionStats(0).sessionsToday,
+      1,
+      "the un-flushed buffer is part of the answer",
+    );
+  });
+
+  it("attributes each day to its own key so a rollover needs no reset", async () => {
+    await boot();
+    recordSessionConnect("opencode");
+    await flushPending();
+
+    const stored = storedSnapshot();
+    assert.deepStrictEqual(Object.keys(stored.sessions), [today()]);
+    assert.strictEqual(stored.sessions[today()], 1);
+    assert.strictEqual(getSessionsForDate("2020-01-01"), 0);
+  });
+
+  it("makes a session on its own worth a flush", async () => {
+    await boot();
+    recordSessionConnect("opencode");
+    const before = redis.commandCount("SET");
+    await flushPending();
+    assert.ok(
+      redis.commandCount("SET") > before,
+      "an MCP-only interval records no page view; sessions must trigger the write themselves",
+    );
+  });
+
+  it("costs no Redis command per session", async () => {
+    await boot();
+    for (let i = 0; i < 250; i++) recordSessionConnect(`client-${i % 5}`);
+    assert.strictEqual(
+      redis.commandCount(),
+      0,
+      "recording must stay in memory — #1023's write pattern is the reason the snapshot exists",
+    );
+  });
+
+  it("records which clients opened the day's sessions", async () => {
+    await boot();
+    recordSessionConnect("opencode");
+    recordSessionConnect("opencode");
+    recordSessionConnect("glimind-probe");
+    await flushPending();
+
+    assert.deepStrictEqual(storedSnapshot().session_clients[today()], {
+      opencode: 2,
+      "glimind-probe": 1,
+    });
+  });
+
+  it("buckets a session with no client name apart from a named one", async () => {
+    await boot();
+    recordSessionConnect();
+    recordSessionConnect("   ");
+    recordSessionConnect("opencode");
+    await flushPending();
+
+    const clients = storedSnapshot().session_clients[today()];
+    assert.strictEqual(clients[UNNAMED_SESSION_CLIENT_KEY], 2);
+    assert.strictEqual(clients.opencode, 1);
+  });
+
+  it("caps the caller-supplied client key space without losing a session", async () => {
+    await boot();
+    for (let i = 0; i < 400; i++) recordSessionConnect(`attacker-supplied-${i}`);
+    await flushPending();
+
+    const clients = storedSnapshot().session_clients[today()];
+    assert.ok(
+      Object.keys(clients).length <= 121,
+      `key space must stay bounded, saw ${Object.keys(clients).length}`,
+    );
+    assert.ok(clients[OTHER_SESSION_CLIENT_KEY] > 0, "the excess must be folded, not dropped");
+    const total = Object.values(clients).reduce((a, b) => (a as number) + (b as number), 0);
+    assert.strictEqual(total, 400, "every session must still be counted somewhere");
+    assert.strictEqual(getConnectionStats(0).sessionsToday, 400);
+  });
+
+  it("does not carry a client name across from the cap into the next day's budget", async () => {
+    await boot();
+    for (let i = 0; i < 400; i++) recordSessionConnect(`attacker-supplied-${i}`);
+    await flushPending();
+    assert.strictEqual(
+      storedSnapshot().sessions[today()],
+      400,
+      "the per-day total is a single key and is never subject to the client cap",
+    );
+  });
+
+  it("dates the series so a reader cannot plot zero where nothing was measured", async () => {
+    await boot();
+    recordSessionConnect("opencode");
+    await flushPending();
+
+    const series = getSessionSeries();
+    assert.strictEqual(series.recording_since, today());
+    assert.deepStrictEqual(series.daily, [{ date: today(), sessions: 1 }]);
+    assert.strictEqual(series.today, 1);
+  });
+
+  it("keeps recording_since at the first date, not the latest", async () => {
+    await boot();
+    recordSessionConnect("opencode");
+    await flushPending();
+
+    const stored = storedSnapshot();
+    stored.sessions["2026-01-01"] = 5;
+    stored.sessions_from = "2026-01-01";
+    redis.values.set(PAGE_VIEWS_KEY, JSON.stringify(stored));
+
+    await redeploy();
+    recordSessionConnect("opencode");
+
+    const series = getSessionSeries();
+    assert.strictEqual(series.recording_since, "2026-01-01");
+    assert.deepStrictEqual(
+      series.daily.map((d: { date: string }) => d.date),
+      ["2026-01-01", today()],
+    );
+  });
+
+  it("reports the lifetime total separately from the dated series", async () => {
+    await boot();
+    recordSessionConnect("opencode");
+    const series = getSessionSeries();
+    assert.strictEqual(series.all_time, getConnectionStats(0).totalSessionsAllTime);
+    assert.ok(
+      series.retention_days >= 30,
+      "the session series is the narrowest map in the snapshot and is kept longer than the 30-day counters",
+    );
+  });
+
+  it("reads a snapshot written before the series existed as unmeasured, not as zero sessions", async () => {
+    redis.values.set(
+      PAGE_VIEWS_KEY,
+      JSON.stringify({ days: {}, all_time: {}, updated_at: "2026-08-01T00:00:00.000Z" }),
+    );
+    await boot();
+
+    const series = getSessionSeries();
+    assert.strictEqual(series.recording_since, null);
+    assert.deepStrictEqual(series.daily, []);
+  });
+
+  it("publishes the series on the traffic report", async () => {
+    await boot();
+    recordSessionConnect("opencode");
+    await flushPending();
+
+    const report = getTrafficReport();
+    assert.strictEqual(report.sessions.today, 1);
+    assert.strictEqual(report.sessions.recording_since, today());
+    assert.ok(
+      report.notes.some((n: string) => n.includes("recording_since")),
+      "the rule for reading the series must be published with it",
+    );
+  });
+
+  it("still answers from the buffer when storage is unavailable", async () => {
+    delete process.env.UPSTASH_REDIS_REST_URL;
+    delete process.env.UPSTASH_REDIS_REST_TOKEN;
+    resetCounters();
+    resetTelemetryBuffers();
+    recordSessionConnect("opencode");
+
+    const report = getTrafficReport();
+    assert.strictEqual(report.available, false);
+    assert.strictEqual(
+      report.sessions.today,
+      1,
+      "a session this process saw is an observation of this process, exactly like since_boot_by_class",
+    );
+  });
+});


### PR DESCRIPTION
Criterion 0 of #1052, shipped on its own as asked.

## The defect, measured live

`sessionsToday` was a module-level `let` reset only on a UTC date rollover. Nothing restored it on boot, so its real meaning was *"sessions since the later of midnight and the last deploy"* while `openapi.ts` documented it as `Sessions since midnight UTC (resets daily)`.

Read from production at 21:08Z today:

```
sessionsToday   352
serverStarted   2026-08-26T17:45:51Z    (202 min before the read)
```

352 sessions in 202 minutes is 1.74/min. Extrapolated over the 1268 minutes since midnight UTC that is **~2207 against a published 352 — a 6.3x undercount**, worse than the 3.4x on the issue because that sample was taken 39 minutes after a deploy and this one 3.4 hours into a 21-hour day.

## The change

The count moves into the page-view snapshot keyed by date. That removes both halves of the defect at once: the value survives a restart because the snapshot does, and the day rollover becomes a different key rather than an assignment, so no code path has to remember to perform it. It rides in the existing snapshot, so a session still costs zero additional Redis commands.

Also added, because criterion 1 says to start writing the series before the UI exists and the data is perishable:

- `sessions` and `session_clients` per day in the snapshot, 90-day retention.
- `sessions` on `/api/traffic` — `daily`, `today`, `all_time`, `retention_days`, and `recording_since`.
- `recording_since` is the load-bearing field. The series is never zero-filled, and a reader must not extend the line left of that date: there is no measurement there, and drawing zero would assert one. A snapshot written before this change reports `recording_since: null` and an empty series, not a run of zero-session days.
- `session_clients` is capped per day. `clientInfo.name` is caller-supplied and is the second map in the key space a stranger can grow, after `referrers`.

## Two corrections to the issue, from production

**There is no unnamed-client bucket, and there never has been.** The issue reads the `mcp` bucket (12,705 sessions) as *"unnamed — clients that sent no clientInfo"*. Production carries 133 distinct client names and **`unknown` is not among them**. The MCP SDK rejects `initialize` unless `clientInfo` carries both `name` and `version` — I checked all three shapes against a real server, and each returns HTTP 400 before our handler counts anything:

```
clientInfo omitted            HTTP 400
clientInfo: {}                HTTP 400
clientInfo: {name:"mcp"}      HTTP 400   (no version)
```

So `mcp` is not an absence — it is 12,705 sessions from clients sending the literal name `mcp`. The three-way split criterion 2 asks for (`named agent / registry-or-probe / unnamed`) has an empty third category. The real distinction is generic-vs-specific naming, not named-vs-unnamed. The e2e asserts the refusals so the bucket stays structurally empty.

**`sessions_by_type` is wrong by about 10x and is public right now.** `/api/metrics` currently reports:

```
sessions_by_type   agent 16394 · crawler 10891 · total 27285
```

`classifyMcpClient` defaults anything unmatched to `agent`, so that 16,394 includes the 12,705 `mcp` sessions, plus `mcpbeat` (555, an uptime monitor) and `agent-tools.cloud` (633, a catalog) — both of which the issue's own table classifies as not-an-agent. Named coding agents are `opencode` 977 + `claude-code` 328 + `codex-mcp-client` 326 ≈ **1,600 of 27,285, about 6%**, which matches the 5.6% on the issue. We publish 60%.

**This PR does not touch that.** It is criterion 2's problem, it wants the classifier rewritten rather than patched, and Criterion 0 was asked for separately and first. Flagging it here because it is live and because any chart built on `classifyMcpClient` as it stands would draw the same 10x error.

## Verification

- 1684 tests, 0 failures, `tsc` clean. 21 new.
- `scripts/e2e-1052.mjs` — **32 checks, all passing** against real `dist/serve.js`: real `initialize` → `tools/call` over streamable HTTP, a genuine `SIGTERM` + restart against the same store, and the pre-#1052 snapshot shape. Proves the day survives the restart (4 before, 4 after, 5 after one more session) and that `serverStarted` actually changed, so the restart was real.
- **Mutation pass, 15 mutations.** Five survived the first round:
  - Two were my mutations being too narrow — sessions are counted toward the flush threshold on two lines and I removed one; the cap exists at both the recording and merge boundaries and I removed one. Removing both kills the test in each case.
  - Three were real gaps, now closed: nothing pinned `sessions_from` against a merge, nothing asserted the day's client map accumulates rather than replaces, and nothing bounded the buffer in memory. The `sessions_from` invariant had been defended in two places that masked each other, so neither was pinned — collapsed to one definition at the merge boundary and pinned there.
  - The merge-side cap looked unreachable until I found the window it exists for: the first flush after boot re-reads the store to catch the outgoing instance's `SIGTERM` write, so base and delta can each carry a full cap's worth. That case is now a test.
  - One survivor left and I am calling it equivalent rather than fixing it: dropping the `known` argument on the recording-side cap changes only how many already-stored names count against the day's budget. The durable map stays capped at the merge boundary and the buffer stays bounded either way. Every recording-side call site in the file passes `known` and every merge-side one omits it, so the code follows the existing convention.

Refs #1052