### PR TITLE
Count a client as an agent only when we can name it

### DIFF
--- a/src/stats.ts
+++ b/src/stats.ts
@@ -861,16 +861,13 @@ export function recordReferralVendorLookup(vendor: string): void {
   referralVendorCounts[key] = (referralVendorCounts[key] ?? 0) + 1;
 }
 
-// Classify MCP client names as 'agent' (real user-facing agent) or 'crawler'
-// (registry/scanner/health-probe). Case-insensitive substring match on the patterns below.
-// Conservative: unknown or unmatched names default to 'agent' — we'd rather over-count
-// agents than under-count them. Keep the rule list here so we can tune it in one place.
 export const CRAWLER_CLIENT_PATTERNS = [
   "crawler",
   "probe",
   "scanner",
   "validator",
   "inspector",
+  "introspector",
   "scoring",
   "enricher",
   "registry",
@@ -888,29 +885,93 @@ export const CRAWLER_CLIENT_PATTERNS = [
   "yellowmcp",
   "mcpscoringengine",
   "fabrique-noauth-probe",
+  "index",
+  "catalog",
+  "audit",
+  "watch",
+  "uptime",
+  "beat",
+  "grade",
+  "research",
+  "census",
+  "poll",
+  "walker",
+  "scraper",
+  "miner",
+  "extractor",
+  "discovery",
+  "liveness",
+  "readiness",
+  "reputation",
+  "trust",
+  "verifier",
+  "observatory",
+  "smithery",
+  "censys",
+  "spec-check",
+  "tirekick",
+  "sweep",
+  "recon",
 ] as const;
 
-export function classifyMcpClient(name: string): "agent" | "crawler" {
-  const lower = (name || "").toLowerCase();
+export const AGENT_CLIENT_NAMES = [
+  "claude-code",
+  "claude-desktop",
+  "cline",
+  "codex-mcp-client",
+  "continue",
+  "cursor",
+  "goose",
+  "librechat",
+  "lobehub-mcp-client",
+  "metamcp-client",
+  "mcporter",
+  "opencode",
+  "windsurf",
+  "zed",
+] as const;
+
+export const INTERNAL_CLIENT_PREFIX = "agentdeals";
+
+export type McpClientClass = "agent" | "crawler" | "internal" | "unattributed";
+
+export function classifyMcpClient(name: string): McpClientClass {
+  const lower = (name || "").trim().toLowerCase();
+  if (!lower) return "unattributed";
+  if (lower.startsWith(INTERNAL_CLIENT_PREFIX)) return "internal";
+  if ((AGENT_CLIENT_NAMES as readonly string[]).includes(lower)) return "agent";
   for (const pattern of CRAWLER_CLIENT_PATTERNS) {
     if (lower.includes(pattern)) return "crawler";
   }
-  return "agent";
+  return "unattributed";
 }
 
+export const SESSION_CLASSIFICATION_RULE =
+  "agent counts only client names on an explicit allowlist of agent products. crawler counts names matching a registry/scanner/probe/monitor pattern. internal is our own traffic. unattributed is everything else, including the generic name 'mcp' — a name we do not recognise is not evidence of an agent, and no missing crawler pattern can add to the agent count.";
+
 export function getSessionClassification(): {
-  sessions_by_type: { agent: number; crawler: number; total: number };
-  clients_top: { name: string; sessions: number; type: "agent" | "crawler" }[];
+  sessions_by_type: {
+    agent: number;
+    crawler: number;
+    internal: number;
+    unattributed: number;
+    total: number;
+  };
+  clients_top: { name: string; sessions: number; type: McpClientClass }[];
+  classification_rule: string;
 } {
   const mergedClients: Record<string, number> = { ...cumulative.clients };
   for (const [name, count] of Object.entries(sessionClients)) {
     mergedClients[name] = (mergedClients[name] ?? 0) + count;
   }
-  let agentSessions = 0;
-  let crawlerSessions = 0;
+  const byType: Record<McpClientClass, number> = {
+    agent: 0,
+    crawler: 0,
+    internal: 0,
+    unattributed: 0,
+  };
   for (const [name, count] of Object.entries(mergedClients)) {
-    if (classifyMcpClient(name) === "crawler") crawlerSessions += count;
-    else agentSessions += count;
+    byType[classifyMcpClient(name)] += count;
   }
   const clientsTop = Object.entries(mergedClients)
     .map(([name, sessions]) => ({ name, sessions, type: classifyMcpClient(name) }))
@@ -918,11 +979,11 @@ export function getSessionClassification(): {
     .slice(0, 10);
   return {
     sessions_by_type: {
-      agent: agentSessions,
-      crawler: crawlerSessions,
-      total: agentSessions + crawlerSessions,
+      ...byType,
+      total: byType.agent + byType.crawler + byType.internal + byType.unattributed,
     },
     clients_top: clientsTop,
+    classification_rule: SESSION_CLASSIFICATION_RULE,
   };
 }
 

--- a/test/session-classification.test.ts
+++ b/test/session-classification.test.ts
@@ -12,6 +12,7 @@ const {
   recordSessionConnect,
   resetCounters,
   CRAWLER_CLIENT_PATTERNS,
+  AGENT_CLIENT_NAMES,
 } = await import("../src/stats.ts");
 
 describe("classifyMcpClient heuristic", () => {
@@ -46,22 +47,102 @@ describe("classifyMcpClient heuristic", () => {
     assert.strictEqual(classifyMcpClient("MCPSCORINGENGINE"), "crawler");
   });
 
-  it("classifies real-looking agent names as 'agent'", () => {
-    assert.strictEqual(classifyMcpClient("Kai"), "agent");
-    assert.strictEqual(classifyMcpClient("Agent iOS"), "agent");
-    assert.strictEqual(classifyMcpClient("scout"), "agent");
-    assert.strictEqual(classifyMcpClient("axiom"), "agent");
-    assert.strictEqual(classifyMcpClient("openclaw"), "agent");
-    assert.strictEqual(classifyMcpClient("codex-mcp-client"), "agent");
-    assert.strictEqual(classifyMcpClient("lobehub-mcp-client"), "agent");
-    assert.strictEqual(classifyMcpClient("opencode"), "agent");
-    assert.strictEqual(classifyMcpClient("mcp-client"), "agent");
+  it("classifies every allowlisted agent product as 'agent'", () => {
+    for (const name of AGENT_CLIENT_NAMES) {
+      assert.strictEqual(
+        classifyMcpClient(name),
+        "agent",
+        `allowlisted name "${name}" should classify as agent`,
+      );
+    }
   });
 
-  it("defaults to 'agent' for unknown or empty names", () => {
-    assert.strictEqual(classifyMcpClient("unknown"), "agent");
-    assert.strictEqual(classifyMcpClient(""), "agent");
-    assert.strictEqual(classifyMcpClient("SomeBrandNewClient"), "agent");
+  it("counts a name it does not recognise as unattributed rather than as an agent", () => {
+    assert.strictEqual(classifyMcpClient("SomeBrandNewClient"), "unattributed");
+    assert.strictEqual(classifyMcpClient("Kai"), "unattributed");
+    assert.strictEqual(classifyMcpClient("scout"), "unattributed");
+    assert.strictEqual(classifyMcpClient("axiom"), "unattributed");
+    assert.strictEqual(classifyMcpClient("openclaw"), "unattributed");
+  });
+
+  it("counts the generic name every unbranded client sends as unattributed", () => {
+    assert.strictEqual(
+      classifyMcpClient("mcp"),
+      "unattributed",
+      "'mcp' is the largest single bucket in production and is not evidence of an agent",
+    );
+    assert.strictEqual(classifyMcpClient("mcp-client"), "unattributed");
+  });
+
+  it("counts an empty or blank name as unattributed", () => {
+    assert.strictEqual(classifyMcpClient(""), "unattributed");
+    assert.strictEqual(classifyMcpClient("   "), "unattributed");
+  });
+
+  it("counts our own traffic apart from everyone else's", () => {
+    assert.strictEqual(classifyMcpClient("agentdeals-internal"), "internal");
+    assert.strictEqual(classifyMcpClient("agentdeals-monitor"), "internal");
+    assert.strictEqual(
+      classifyMcpClient("mcpmux-dev.agentdeals-mcp-http"),
+      "unattributed",
+      "a third party naming us is not our own traffic",
+    );
+  });
+
+  it("cannot let a missing crawler pattern inflate the agent count", () => {
+    for (const name of ["brand-new-scanner-we-have-not-seen", "totally-unknown", "mcpbeat"]) {
+      assert.notStrictEqual(
+        classifyMcpClient(name),
+        "agent",
+        `"${name}" must not reach the agent bucket without being allowlisted`,
+      );
+    }
+  });
+
+  it("classifies the monitors and catalogues the two-value rule called agents", () => {
+    assert.strictEqual(classifyMcpClient("mcpbeat"), "crawler");
+    assert.strictEqual(classifyMcpClient("Smithery Connect"), "crawler");
+    assert.strictEqual(classifyMcpClient("AgentIndexBot"), "crawler");
+    assert.strictEqual(classifyMcpClient("mcp-indexer"), "crawler");
+    assert.strictEqual(classifyMcpClient("mcp-rugpull-research"), "crawler");
+    assert.strictEqual(classifyMcpClient("mcpindex-trust"), "crawler");
+    assert.strictEqual(
+      classifyMcpClient("Mozilla/5.0 (compatible; CensysInspect/1.1; +https://about.censys.io/)"),
+      "crawler",
+    );
+  });
+
+  it("admits a name to the agent bucket only when it matches the allowlist whole", () => {
+    for (const name of [
+      "opencode-scanner",
+      "fake-cursor-probe",
+      "not-claude-code",
+      "claude-code-registry-crawler",
+      "zed-indexer",
+    ]) {
+      assert.notStrictEqual(
+        classifyMcpClient(name),
+        "agent",
+        `"${name}" merely contains an allowlisted name and must not be counted as one`,
+      );
+    }
+  });
+
+  it("matches the allowlist despite surrounding whitespace and casing", () => {
+    assert.strictEqual(classifyMcpClient("  opencode  "), "agent");
+    assert.strictEqual(classifyMcpClient("OpenCode"), "agent");
+    assert.strictEqual(classifyMcpClient("\tclaude-code\n"), "agent");
+  });
+
+  it("keeps the allowlist and the crawler patterns from contradicting each other", () => {
+    for (const name of AGENT_CLIENT_NAMES) {
+      const matched = CRAWLER_CLIENT_PATTERNS.filter((p: string) => name.includes(p));
+      assert.deepStrictEqual(
+        matched,
+        [],
+        `allowlisted "${name}" also matches crawler pattern(s) ${matched.join(", ")} — one of the two lists is wrong`,
+      );
+    }
   });
 });
 
@@ -78,11 +159,31 @@ describe("getSessionClassification aggregation", () => {
     recordSessionConnect("Kai");
     recordSessionConnect("scout");
     recordSessionConnect("scout");
+    recordSessionConnect("agentdeals-internal");
 
     const c = getSessionClassification();
     assert.strictEqual(c.sessions_by_type.crawler, 3);
-    assert.strictEqual(c.sessions_by_type.agent, 4);
-    assert.strictEqual(c.sessions_by_type.total, 7);
+    assert.strictEqual(c.sessions_by_type.agent, 1, "only the allowlisted opencode is an agent");
+    assert.strictEqual(c.sessions_by_type.unattributed, 3, "Kai and scout are names we cannot place");
+    assert.strictEqual(c.sessions_by_type.internal, 1);
+    assert.strictEqual(c.sessions_by_type.total, 8);
+  });
+
+  it("totals every bucket, so no session escapes the split", () => {
+    for (const name of ["mcpdd", "opencode", "Kai", "agentdeals-monitor", "mcp", ""]) {
+      recordSessionConnect(name);
+    }
+    const t = getSessionClassification().sessions_by_type;
+    assert.strictEqual(t.agent + t.crawler + t.internal + t.unattributed, t.total);
+    assert.strictEqual(t.total, 6);
+  });
+
+  it("publishes the rule it classified by", () => {
+    const c = getSessionClassification();
+    assert.ok(
+      c.classification_rule.includes("allowlist"),
+      "a heuristic split must publish its rule",
+    );
   });
 
   it("returns clients_top sorted descending by sessions, capped at 10", () => {
@@ -104,28 +205,29 @@ describe("getSessionClassification aggregation", () => {
     for (let i = 1; i < c.clients_top.length; i++) {
       assert.ok(c.clients_top[i - 1].sessions >= c.clients_top[i].sessions);
     }
-    // Every entry has a type field
     for (const entry of c.clients_top) {
-      assert.ok(entry.type === "agent" || entry.type === "crawler");
+      assert.ok(["agent", "crawler", "internal", "unattributed"].includes(entry.type));
     }
   });
 
-  it("classifies 'unknown' (missing client name) as agent", () => {
-    // recordSessionConnect(undefined) uses "unknown" as the bucket key
+  it("does not count a session it cannot attribute as an agent", () => {
     recordSessionConnect();
     recordSessionConnect();
     const c = getSessionClassification();
-    assert.strictEqual(c.sessions_by_type.agent, 2);
+    assert.strictEqual(c.sessions_by_type.agent, 0);
     assert.strictEqual(c.sessions_by_type.crawler, 0);
+    assert.strictEqual(c.sessions_by_type.unattributed, 2);
     const unknown = c.clients_top.find(e => e.name === "unknown");
     assert.ok(unknown);
-    assert.strictEqual(unknown.type, "agent");
+    assert.strictEqual(unknown.type, "unattributed");
   });
 
   it("returns empty buckets when no sessions have been recorded", () => {
     const c = getSessionClassification();
     assert.strictEqual(c.sessions_by_type.agent, 0);
     assert.strictEqual(c.sessions_by_type.crawler, 0);
+    assert.strictEqual(c.sessions_by_type.internal, 0);
+    assert.strictEqual(c.sessions_by_type.unattributed, 0);
     assert.strictEqual(c.sessions_by_type.total, 0);
     assert.deepStrictEqual(c.clients_top, []);
   });
@@ -164,14 +266,17 @@ describe("GET /api/metrics — sessions_by_type + clients_top", () => {
     assert.strictEqual(res.status, 200);
     const body = await res.json() as any;
     assert.ok(body.sessions_by_type, "sessions_by_type block missing");
-    assert.strictEqual(typeof body.sessions_by_type.agent, "number");
-    assert.strictEqual(typeof body.sessions_by_type.crawler, "number");
-    assert.strictEqual(typeof body.sessions_by_type.total, "number");
-    // Invariant: agent + crawler === total
+    for (const field of ["agent", "crawler", "internal", "unattributed", "total"]) {
+      assert.strictEqual(typeof body.sessions_by_type[field], "number", `${field} must be a number`);
+    }
     assert.strictEqual(
-      body.sessions_by_type.agent + body.sessions_by_type.crawler,
+      body.sessions_by_type.agent +
+        body.sessions_by_type.crawler +
+        body.sessions_by_type.internal +
+        body.sessions_by_type.unattributed,
       body.sessions_by_type.total,
     );
+    assert.strictEqual(typeof body.classification_rule, "string");
   });
 
   it("returns clients_top as an array where each entry has name, sessions, type", async () => {
@@ -182,7 +287,10 @@ describe("GET /api/metrics — sessions_by_type + clients_top", () => {
     for (const entry of body.clients_top) {
       assert.strictEqual(typeof entry.name, "string");
       assert.strictEqual(typeof entry.sessions, "number");
-      assert.ok(entry.type === "agent" || entry.type === "crawler", `entry.type must be 'agent' or 'crawler', got ${entry.type}`);
+      assert.ok(
+        ["agent", "crawler", "internal", "unattributed"].includes(entry.type),
+        `unexpected entry.type ${entry.type}`,
+      );
     }
     // clients_top sorted descending by sessions
     for (let i = 1; i < body.clients_top.length; i++) {


### PR DESCRIPTION
Criterion 2 of #1052, as far as the classifier goes. The view still has to be built, but it should not be built on this.

## What we were publishing

`/api/metrics`, live before this change:

```
sessions_by_type   agent 16394 · crawler 10891 · total 27285
```

**60% of our MCP sessions were reported as real agents.** `classifyMcpClient` matched a list of crawler patterns and returned `agent` for everything else, so the 16,394 included:

- **12,705 sessions from clients sending the generic name `mcp`** — the single largest bucket on the service, 47% of all sessions
- `mcpbeat` 556 — an uptime monitor; `beat` was not a pattern
- `agent-tools.cloud` 633 — a catalogue; nothing in the name says so
- 29 further names matching no pattern at all

Named agent products are `opencode` 978 + `claude-code` 328 + `codex-mcp-client` 326 ≈ **1,700, about 6%** — which agrees with the 5.6% you computed independently on the issue. We were publishing a 10x overstatement of our own agent adoption.

## The rule

Four buckets, and the direction of the default is the whole point:

| bucket | rule | live |
|---|---|---:|
| `agent` | an explicit allowlist of agent products, matched **whole** | 1,701 (6.2%) |
| `crawler` | the pattern list, extended with the monitor / index / catalogue / audit / research families visible in the live population | 11,924 (43.7%) |
| `internal` | our own traffic | 9 |
| `unattributed` | everything else, including `mcp` | 13,679 (50.1%) |

**A name we cannot place is no longer evidence of an agent.** And because the agent bucket can only be entered via the allowlist, *a missing crawler pattern can never inflate the agent count* — the worst a gap in the pattern list can do is leave a scanner in `unattributed`. That asymmetry is deliberate and there is a test for it.

`getSessionClassification` now returns `classification_rule` next to the counts, per "if the split has to be heuristic, publish the rule".

## Two judgements I want on the record

**The third category you asked for is empty, so I renamed it.** Criterion 2 asks for `named agent / registry-or-probe / unnamed`. There is no unnamed bucket: production carries 133 distinct client names and `unknown` is not among them, because the MCP SDK refuses `initialize` unless `clientInfo` carries both `name` and `version`. `mcp` is not an absence — it is 12,705 clients that sent the literal string `mcp`. So the third bucket is `unattributed` (a name we cannot place) rather than `unnamed`. Overturn it if you want different wording; the counts are the same either way.

**I did not use tool calls to classify, because they do not separate the two things.** It was the obvious objective signal — a catalogue connects and never calls anything — and it is wrong:

```
client               sessions   tool calls
opencode                  978          323
agent-tools.cloud         633            0
claude-code               328            0
codex-mcp-client          326            0
```

`claude-code` and `codex-mcp-client` are unambiguously real coding agents and they call tools exactly as often as the catalogue does: never. Your own criterion 3 is why — the great majority of sessions initialize, read the tool list and disconnect. Had I used this signal I would have demoted two real agents. Worth recording as a fact about the data: `opencode` alone is 323 of 432 all-time tool calls, 75%.

**`agent-tools.cloud` is left in `unattributed`, not `crawler`.** Your table calls it a catalogue and I believe you, but I have not verified it myself and the name does not say so. `unattributed` overstates nothing. Say the word and it goes on an exact-name list.

## Verification

- 1694 tests, 0 failures, `tsc` clean.
- The four tests that asserted the old default are **rewritten to the corrected property, not deleted** — including `defaults to 'agent' for unknown or empty names`, which was a test asserting the defect.
- Real `initialize` against `dist/serve.js` for an allowlisted, a crawler, a generic, an internal and an unrecognised name, then read back off `/api/metrics`.
- **7 mutations, 3 survived the first round, 2 were real gaps:** a substring allowlist would have admitted `fake-cursor-probe` and `claude-code-registry-crawler` as agents, and an untrimmed name missed the allowlist entirely. Both are now tested. The third survivor — consulting crawler patterns before the allowlist — is a genuine equivalent, and the test asserting the two lists never contradict each other is what makes the order not matter.

Refs #1052