### PR TITLE
Record distinct clients per vendor per day, outside git and off the public surface

### DIFF
--- a/scripts/e2e-1052-vendors.mjs
+++ b/scripts/e2e-1052-vendors.mjs
@@ -1,0 +1,258 @@
+import { createServer } from "node:http";
+import { spawn } from "node:child_process";
+
+const HELP = `End-to-end check for the private per-vendor daily series (#1052 Part A).
+
+Boots the real dist/serve.js against a fake Upstash, drives real page requests at
+vendor pages from several client addresses, restarts the process against the same
+store, and asserts three things unit tests cannot: that the series survives a
+deploy, that no public endpoint carries it, and that the export refuses a caller
+without the token.
+
+Usage: node scripts/e2e-1052-vendors.mjs
+`;
+
+if (process.argv.includes("--help") || process.argv.includes("-h")) {
+  console.log(HELP);
+  process.exit(0);
+}
+
+const TOKEN = "e2e-analytics-token-0123456789";
+const store = new Map();
+const lists = new Map();
+
+const upstash = createServer((req, res) => {
+  let body = "";
+  req.on("data", c => (body += c));
+  req.on("end", () => {
+    const args = JSON.parse(body || "[]");
+    const cmd = String(args[0]).toUpperCase();
+    let result;
+    switch (cmd) {
+      case "GET": result = store.get(String(args[1])) ?? null; break;
+      case "SET": store.set(String(args[1]), String(args[2])); result = "OK"; break;
+      case "MGET": result = args.slice(1).map(k => store.get(String(k)) ?? null); break;
+      case "SCAN": {
+        const pattern = String(args[3] ?? "*");
+        const prefix = pattern.endsWith("*") ? pattern.slice(0, -1) : pattern;
+        result = ["0", [...store.keys()].filter(k => k.startsWith(prefix))];
+        break;
+      }
+      case "LPUSH": {
+        const key = String(args[1]);
+        const list = lists.get(key) ?? [];
+        for (const v of args.slice(2)) list.unshift(String(v));
+        lists.set(key, list);
+        result = list.length;
+        break;
+      }
+      case "LTRIM": {
+        const key = String(args[1]);
+        lists.set(key, (lists.get(key) ?? []).slice(Number(args[2]), Number(args[3]) + 1));
+        result = "OK";
+        break;
+      }
+      case "LRANGE":
+        result = (lists.get(String(args[1])) ?? []).slice(Number(args[2]), Number(args[3]) + 1);
+        break;
+      default: result = 1;
+    }
+    res.writeHead(200, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ result }));
+  });
+});
+
+const failures = [];
+function check(label, cond, detail = "") {
+  if (cond) console.log(`  ok    ${label}`);
+  else {
+    console.log(`  FAIL  ${label}${detail ? ` — ${detail}` : ""}`);
+    failures.push(label);
+  }
+}
+
+function startServer(env) {
+  return new Promise((resolve, reject) => {
+    const proc = spawn("node", ["dist/serve.js"], {
+      cwd: process.cwd(),
+      stdio: ["pipe", "pipe", "pipe"],
+      env: { ...process.env, PORT: "0", BASE_URL: "http://localhost", ...env },
+    });
+    const timer = setTimeout(() => {
+      proc.kill("SIGKILL");
+      reject(new Error("server startup timeout"));
+    }, 30000);
+    const onData = buf => {
+      const m = buf.toString().match(/running on http:\/\/localhost:(\d+)/);
+      if (m) {
+        clearTimeout(timer);
+        resolve({ proc, port: Number(m[1]) });
+      }
+    };
+    proc.stdout.on("data", onData);
+    proc.stderr.on("data", onData);
+    proc.on("error", reject);
+  });
+}
+
+async function stop(proc) {
+  proc.kill("SIGTERM");
+  await new Promise(r => {
+    const t = setTimeout(() => {
+      proc.kill("SIGKILL");
+      r();
+    }, 8000);
+    proc.on("exit", () => {
+      clearTimeout(t);
+      r();
+    });
+  });
+}
+
+const BROWSER_UA =
+  "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/128.0 Safari/537.36";
+
+async function visit(base, path, address, ua = BROWSER_UA) {
+  const res = await fetch(`${base}${path}`, {
+    headers: { "User-Agent": ua, "X-Forwarded-For": address },
+  });
+  await res.arrayBuffer();
+  return res.status;
+}
+
+function today() {
+  return new Date().toISOString().slice(0, 10);
+}
+
+function storedDay(date = today()) {
+  const raw = store.get(`vendorseries:${date}`);
+  return raw ? JSON.parse(raw) : null;
+}
+
+async function json(base, path, headers = {}) {
+  const res = await fetch(`${base}${path}`, {
+    headers: { "User-Agent": "agentdeals-internal/1.0 (vendor series e2e)", ...headers },
+  });
+  const text = await res.text();
+  let parsed = null;
+  try {
+    parsed = JSON.parse(text);
+  } catch {}
+  return { status: res.status, body: parsed, text };
+}
+
+const upstashPort = await new Promise(resolve => {
+  upstash.listen(0, "127.0.0.1", () => resolve(upstash.address().port));
+});
+
+const ENV = {
+  UPSTASH_REDIS_REST_URL: `http://127.0.0.1:${upstashPort}`,
+  UPSTASH_REDIS_REST_TOKEN: "fake",
+  TELEMETRY_FLUSH_INTERVAL_SECONDS: "5",
+  VENDOR_SERIES_WRITE_INTERVAL_SECONDS: "1",
+  ANALYTICS_EXPORT_TOKEN: TOKEN,
+};
+
+console.log("\n#1052 Part A — private per-vendor daily series\n");
+
+let first = await startServer(ENV);
+let base = `http://localhost:${first.port}`;
+
+console.log("recording");
+
+for (let i = 0; i < 12; i++) await visit(base, "/vendor/vercel", "203.0.113.10");
+await visit(base, "/vendor/vercel", "203.0.113.11");
+await visit(base, "/vendor/vercel", "203.0.113.12");
+await visit(base, "/vendor/render", "203.0.113.10");
+await visit(base, "/api/details/render", "203.0.113.99");
+const notFoundStatus = await visit(base, "/vendor/definitely-not-a-vendor-xyz", "203.0.113.20");
+await visit(base, "/vendor/vercel", "203.0.113.30", "agentdeals-internal/1.0 (probe)");
+for (const path of ["/", "/shutdowns", "/criteria", "/search?q=postgres", "/api/offers"]) {
+  await visit(base, path, "203.0.113.60");
+}
+
+await stop(first.proc);
+
+let day = storedDay();
+check("the day was written to its own key on shutdown", day !== null);
+check("twelve requests from one address count as one client", day?.counts?.vercel === 3, JSON.stringify(day?.counts));
+check("a second surface for the same vendor counts under one slug", day?.counts?.render === 2, JSON.stringify(day?.counts));
+check("the 404 we served on a vendor path is not counted anywhere", notFoundStatus >= 400 && day?.counts?.__other_vendors__ === undefined, JSON.stringify(day?.counts));
+check("a page that names no vendor is not counted", day?.counts?.__other_vendors__ === undefined && Object.keys(day?.counts ?? {}).length === 2, JSON.stringify(day?.counts));
+check("the internal class is excluded", day?.counts?.vercel === 3);
+check("one process start recorded", day?.process_starts === 1, String(day?.process_starts));
+check("no address appears in the stored record", !JSON.stringify(day).includes("203.0.113"));
+check("the key carries only slugs we publish", Object.keys(day?.counts ?? {}).every(k => k === "__other_vendors__" || /^[a-z0-9][a-z0-9-]*$/.test(k)));
+
+console.log("\nsurviving a deploy");
+
+const second = await startServer(ENV);
+base = `http://localhost:${second.port}`;
+
+await visit(base, "/vendor/vercel", "203.0.113.10");
+await visit(base, "/vendor/fly-io", "203.0.113.40");
+await new Promise(r => setTimeout(r, 7000));
+
+const gauge = await json(base, "/api/traffic");
+check("/api/traffic reports the series is recording", gauge.body?.vendor_series?.recording_date === today());
+check("the published gauge names no vendor", !JSON.stringify(gauge.body.vendor_series).includes("vercel"));
+check("the gauge says the series is not published", gauge.body?.vendor_series?.published === false);
+check("the gauge says the store is configured", gauge.body?.vendor_series?.configured === true);
+
+day = storedDay();
+check("the restarted process adds to the same day", day?.counts?.vercel === 4, JSON.stringify(day?.counts));
+check("process_starts is the upper bound on double counting", day?.process_starts === 2, String(day?.process_starts));
+
+console.log("\nnot served publicly");
+
+const publicSurfaces = ["/api/pageviews", "/api/traffic", "/api/metrics", "/api/analytics/history", "/api/signals", "/health"];
+for (const path of publicSurfaces) {
+  const res = await json(base, path);
+  const carriesSeries = res.text.includes("vendorseries") || /"vercel"\s*:\s*\d/.test(res.text);
+  check(`${path} carries no per-vendor count`, !carriesSeries);
+}
+
+const daily = await json(base, `/api/analytics/daily?date=${today()}`);
+check("/api/analytics/daily keeps vendors null", daily.body?.vendors === null, JSON.stringify(daily.body?.vendors));
+
+console.log("\nexport");
+
+const anon = await json(base, "/api/analytics/vendors");
+check("the export 404s without a token", anon.status === 404, String(anon.status));
+
+const wrong = await json(base, "/api/analytics/vendors", { Authorization: "Bearer wrong-token-wrong-token" });
+check("the export 404s with the wrong token", wrong.status === 404, String(wrong.status));
+
+const authed = await json(base, "/api/analytics/vendors", { Authorization: `Bearer ${TOKEN}` });
+check("the export 200s with the token", authed.status === 200, String(authed.status));
+check("the export returns the day we recorded", authed.body?.days?.[0]?.counts?.vercel === 4, JSON.stringify(authed.body?.days?.[0]?.counts));
+check("the export states the counting rule", (authed.body?.notes ?? []).some(n => n.includes("distinct clients per vendor per day")));
+check("the export states the restart limit", (authed.body?.notes ?? []).some(n => n.includes("process_starts")));
+check("the export defaults to the retention window", authed.body?.requested_days === 90, String(authed.body?.requested_days));
+
+const ranged = await json(base, `/api/analytics/vendors?from=${today()}&to=${today()}`, { Authorization: `Bearer ${TOKEN}` });
+check("a one-day range returns one day", ranged.body?.days?.length === 1, String(ranged.body?.days?.length));
+
+const bad = await json(base, "/api/analytics/vendors?from=yesterday", { Authorization: `Bearer ${TOKEN}` });
+check("a malformed date is rejected", bad.status === 400, String(bad.status));
+
+const head = await fetch(`${base}/api/analytics/vendors`, { method: "HEAD" });
+check("HEAD without a token is also refused", head.status === 404, String(head.status));
+
+await stop(second.proc);
+
+console.log("\nwithout a token configured");
+
+const third = await startServer({ ...ENV, ANALYTICS_EXPORT_TOKEN: "" });
+base = `http://localhost:${third.port}`;
+const unconfigured = await json(base, "/api/analytics/vendors", { Authorization: `Bearer ${TOKEN}` });
+check("the export 404s when no token is configured", unconfigured.status === 404, String(unconfigured.status));
+await visit(base, "/vendor/vercel", "203.0.113.55");
+await new Promise(r => setTimeout(r, 7000));
+check("recording continues with the export closed", storedDay()?.counts?.vercel === 5, JSON.stringify(storedDay()?.counts));
+await stop(third.proc);
+
+upstash.close();
+
+console.log(`\n${failures.length === 0 ? "PASS" : `FAIL — ${failures.length}`}: ${failures.join(", ")}\n`);
+process.exit(failures.length === 0 ? 0 : 1);

--- a/src/client-class.ts
+++ b/src/client-class.ts
@@ -194,6 +194,7 @@ const OBSERVABILITY_PATHS = new Set([
   "/api/metrics",
   "/api/analytics/daily",
   "/api/analytics/history",
+  "/api/analytics/vendors",
   "/api/page-reviews",
   "/health",
 ]);

--- a/src/serve.ts
+++ b/src/serve.ts
@@ -11,8 +11,9 @@ import { estimateCosts } from "./costs.js";
 import { classifyRequest } from "./client-class.js";
 import { acceptSignal, ackMissing, checkRateLimit, clientAddress, RATE_LIMIT_PER_MINUTE, SIGNAL_ACK_PARAM, SIGNAL_BODY_MAX, SIGNAL_DOC_PATH, SIGNAL_PATH, type SignalInput } from "./signal.js";
 import { agentBlock, CONVERTED_CAVEAT, DEFERENCE, PRIVACY_SCOPE, signalHeaderValue, signalHtmlBlock, signalLlmsSection, SIGNAL_HEADER_NAME } from "./signal-copy.js";
-import { recordApiHit, recordSessionConnect, recordSessionDisconnect, recordLandingPageView, getStats, getConnectionStats, loadTelemetry, flushTelemetry, flushPending, FLUSH_INTERVAL_SECONDS, logRequest, getPublicRequestLogResult, getTelemetryHealth, recordPageView, getPageViews, recordReferralListingCall, recordReferralVendorLookup, getReferralMarketplaceStats, getSessionClassification, recordSearchQuery, getSearchAnalytics, getApiHitsByEndpoint, recordTraffic, getTrafficReport, getSignalReport, SIGNAL_MIN_SAMPLE, SIGNAL_DENOMINATOR_ROUTES, getRollupDaySource, getRollupDatesAvailable, setDurableRollupCoverage } from "./stats.js";
+import { recordApiHit, recordSessionConnect, recordSessionDisconnect, recordLandingPageView, getStats, getConnectionStats, loadTelemetry, flushTelemetry, flushPending, FLUSH_INTERVAL_SECONDS, logRequest, getPublicRequestLogResult, getTelemetryHealth, recordPageView, getPageViews, recordReferralListingCall, recordReferralVendorLookup, getReferralMarketplaceStats, getSessionClassification, recordSearchQuery, getSearchAnalytics, getApiHitsByEndpoint, recordTraffic, getTrafficReport, getSignalReport, SIGNAL_MIN_SAMPLE, SIGNAL_DENOMINATOR_ROUTES, getRollupDaySource, getRollupDatesAvailable, setDurableRollupCoverage, redisJsonGet, redisJsonMget, redisJsonSet } from "./stats.js";
 import { buildDailyRollup, readRollups, coverageOf, ROLLUP_DATE_PATTERN } from "./analytics-rollup.js";
+import { configureVendorSeries, recordVendorRequest, flushVendorSeries, readVendorSeries, vendorSeriesGauge, vendorExportAuthorized, isSeriesDate, seriesDateRange, VENDOR_SERIES_PATH, VENDOR_SERIES_RETENTION_DAYS, VENDOR_SERIES_NOTES } from "./vendor-series.js";
 import { openapiSpec } from "./openapi.js";
 import { LINK_GRACE_DAYS } from "./link-health.js";
 import { registerAgent, authenticateRequest, validateVestauthUrl, hashApiKey, updateAgentX402Address, getAgentById } from "./agents.js";
@@ -53725,7 +53726,17 @@ const httpServer = createHttpServer(async (req, res) => {
   // on finish so the served status is known; costs no Redis commands.
   if (isCountableTraffic(url.pathname)) {
     res.on("finish", () => {
-      recordTraffic(classifyRequest(url.pathname, req.headers["user-agent"]), url.pathname, res.statusCode);
+      const classification = classifyRequest(url.pathname, req.headers["user-agent"]);
+      recordTraffic(classification, url.pathname, res.statusCode);
+      if (SINGLE_VENDOR_PREFIXES.some(prefix => url.pathname.startsWith(prefix))) {
+        recordVendorRequest({
+          slug: singleVendorSlug(url.pathname),
+          client_class: classification.client_class,
+          address: clientAddress(req.headers["x-forwarded-for"], req.socket.remoteAddress),
+          status: res.statusCode,
+          date: new Date().toISOString().slice(0, 10),
+        });
+      }
     });
   }
 
@@ -53856,6 +53867,42 @@ const httpServer = createHttpServer(async (req, res) => {
   if (url.pathname === "/api/analytics/history" && isGetOrHead) {
     res.writeHead(200, { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" });
     res.end(durableHistoryBody);
+    return;
+  }
+
+  if (url.pathname === VENDOR_SERIES_PATH && isGetOrHead) {
+    if (!vendorExportAuthorized(req.headers["authorization"])) {
+      res.writeHead(404, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ error: "Not found" }));
+      return;
+    }
+    const today = new Date().toISOString().slice(0, 10);
+    const to = url.searchParams.get("to") ?? today;
+    const defaultFrom = new Date(Date.parse(to) - (VENDOR_SERIES_RETENTION_DAYS - 1) * 86400000)
+      .toISOString().slice(0, 10);
+    const from = url.searchParams.get("from") ?? defaultFrom;
+    if (!isSeriesDate(from) || !isSeriesDate(to)) {
+      res.writeHead(400, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ error: "from and to must be YYYY-MM-DD" }));
+      return;
+    }
+    const dates = seriesDateRange(from, to);
+    const series = await readVendorSeries(dates);
+    if (!series.ok) {
+      res.writeHead(503, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ error: series.error ?? "unavailable", available: false, from, to }));
+      return;
+    }
+    res.writeHead(200, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({
+      available: true,
+      from,
+      to,
+      requested_days: dates.length,
+      days: series.days,
+      gauge: vendorSeriesGauge(),
+      notes: VENDOR_SERIES_NOTES,
+    }, null, 2));
     return;
   }
 
@@ -54254,7 +54301,7 @@ const httpServer = createHttpServer(async (req, res) => {
     // `internal` by path: observing the system is not using it.
     const data = getTrafficReport();
     res.writeHead(200, { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" });
-    res.end(JSON.stringify(data));
+    res.end(JSON.stringify({ ...data, vendor_series: vendorSeriesGauge() }));
   } else if (url.pathname === "/api/offers" && isGetOrHead) {
     recordApiHit("/api/offers");
     const q = url.searchParams.get("q") || undefined;
@@ -56995,6 +57042,16 @@ setInterval(() => {
   flushPending().catch((err) => console.error(`[telemetry] flush failed: ${err?.message ?? err}`));
 }, FLUSH_INTERVAL_SECONDS * 1000).unref();
 
+configureVendorSeries({
+  get: redisJsonGet,
+  mget: redisJsonMget,
+  set: redisJsonSet,
+});
+
+setInterval(() => {
+  flushVendorSeries().catch((err) => console.error(`[vendor-series] flush failed: ${err?.message ?? err}`));
+}, FLUSH_INTERVAL_SECONDS * 1000).unref();
+
 // Flush on graceful shutdown. Buffered counters go first: they exist only in memory, so
 // a missed flush here is the one interval of data this design accepts losing on an
 // *unclean* exit and should never lose on a clean one.
@@ -57004,6 +57061,7 @@ async function onShutdown() {
   shuttingDown = true;
   try {
     await flushPending();
+    await flushVendorSeries(true);
     await flushTelemetry();
   } catch (err: any) {
     console.error(`[telemetry] shutdown flush failed: ${err?.message ?? err}`);

--- a/src/stats.ts
+++ b/src/stats.ts
@@ -1758,6 +1758,44 @@ function signalNotes(raw: unknown): SignalNote[] {
   return out;
 }
 
+export interface JsonReadResult {
+  ok: boolean;
+  value: unknown;
+  error?: string;
+}
+
+export interface JsonWriteResult {
+  ok: boolean;
+  error?: string;
+}
+
+function parseJsonValue(raw: string | null): unknown {
+  if (typeof raw !== "string" || raw.length === 0) return null;
+  try {
+    return JSON.parse(raw);
+  } catch {
+    return null;
+  }
+}
+
+export async function redisJsonGet(key: string): Promise<JsonReadResult> {
+  const res = await redisCommand<string | null>(["GET", key]);
+  if (!res.ok) return { ok: false, value: null, error: res.error };
+  return { ok: true, value: parseJsonValue(res.result ?? null) };
+}
+
+export async function redisJsonMget(keys: string[]): Promise<{ ok: boolean; values: unknown[]; error?: string }> {
+  if (keys.length === 0) return { ok: true, values: [] };
+  const res = await redisMget(keys);
+  if (!res.ok) return { ok: false, values: [], error: res.error };
+  return { ok: true, values: res.result.map(parseJsonValue) };
+}
+
+export async function redisJsonSet(key: string, value: unknown, ttlSeconds: number): Promise<JsonWriteResult> {
+  const res = await redisCommand<string>(["SET", key, JSON.stringify(value), "EX", String(Math.max(1, Math.floor(ttlSeconds)))]);
+  return res.ok ? { ok: true } : { ok: false, error: res.error };
+}
+
 async function redisMget(keys: string[]): Promise<RedisResult<(string | null)[]>> {
   const res = await redisCommand<(string | null)[]>(["MGET", ...keys]);
   if (!res.ok) return res;

--- a/src/vendor-series.ts
+++ b/src/vendor-series.ts
@@ -1,0 +1,437 @@
+import { createHash, randomBytes, timingSafeEqual } from "node:crypto";
+
+export const VENDOR_SERIES_PATH = "/api/analytics/vendors";
+export const MIN_EXPORT_TOKEN_LENGTH = 16;
+
+export function vendorExportAuthorized(header: string | string[] | undefined): boolean {
+  const expected = process.env.ANALYTICS_EXPORT_TOKEN;
+  if (typeof expected !== "string" || expected.length < MIN_EXPORT_TOKEN_LENGTH) return false;
+  const raw = Array.isArray(header) ? header[0] : header;
+  if (typeof raw !== "string") return false;
+  const match = /^Bearer[ \t]+(\S.*)$/i.exec(raw.trim());
+  if (!match) return false;
+  const supplied = Buffer.from(match[1]);
+  const wanted = Buffer.from(expected);
+  return supplied.length === wanted.length && timingSafeEqual(supplied, wanted);
+}
+
+export const VENDOR_SERIES_SCHEMA = 1;
+export const VENDOR_SERIES_KEY_PREFIX = "vendorseries:";
+export const OVERFLOW_VENDOR_KEY = "__other_vendors__";
+export const VENDOR_SERIES_RETENTION_DAYS = 90;
+export const VENDOR_SERIES_TTL_SECONDS = 100 * 86400;
+export const MAX_VENDOR_SLUGS_PER_DAY = 400;
+export const MAX_CLIENTS_PER_VENDOR_PER_DAY = 2000;
+export const MAX_TRACKED_CLIENT_KEYS = 50000;
+const CLIENT_KEY_LENGTH = 12;
+
+export interface VendorDay {
+  schema: number;
+  date: string;
+  counts: Record<string, number>;
+  process_starts: number;
+  slug_overflow: number;
+  capped_slugs: number;
+  dedup_suppressed: number;
+  first_recorded_at: string;
+  updated_at: string;
+}
+
+export function vendorSeriesKey(date: string): string {
+  return `${VENDOR_SERIES_KEY_PREFIX}${date}`;
+}
+
+export function emptyVendorDay(date: string): VendorDay {
+  return {
+    schema: VENDOR_SERIES_SCHEMA,
+    date,
+    counts: {},
+    process_starts: 0,
+    slug_overflow: 0,
+    capped_slugs: 0,
+    dedup_suppressed: 0,
+    first_recorded_at: "",
+    updated_at: "",
+  };
+}
+
+function numericMap(raw: unknown): Record<string, number> {
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) return {};
+  const out: Record<string, number> = {};
+  for (const [key, value] of Object.entries(raw as Record<string, unknown>)) {
+    if (typeof value === "number" && Number.isFinite(value) && value > 0) out[key] = value;
+  }
+  return out;
+}
+
+function numberAt(raw: Record<string, unknown>, key: string): number {
+  const value = raw[key];
+  return typeof value === "number" && Number.isFinite(value) && value > 0 ? value : 0;
+}
+
+function stringAt(raw: Record<string, unknown>, key: string): string {
+  const value = raw[key];
+  return typeof value === "string" ? value : "";
+}
+
+export function parseVendorDay(raw: unknown, date: string): VendorDay {
+  if (!raw || typeof raw !== "object") return emptyVendorDay(date);
+  const obj = raw as Record<string, unknown>;
+  const stored = stringAt(obj, "date");
+  return {
+    schema: numberAt(obj, "schema") || VENDOR_SERIES_SCHEMA,
+    date: stored || date,
+    counts: numericMap(obj.counts),
+    process_starts: numberAt(obj, "process_starts"),
+    slug_overflow: numberAt(obj, "slug_overflow"),
+    capped_slugs: numberAt(obj, "capped_slugs"),
+    dedup_suppressed: numberAt(obj, "dedup_suppressed"),
+    first_recorded_at: stringAt(obj, "first_recorded_at"),
+    updated_at: stringAt(obj, "updated_at"),
+  };
+}
+
+function addBounded(counts: Record<string, number>, slug: string, amount: number): number {
+  if (amount <= 0) return 0;
+  if (counts[slug] !== undefined || slug === OVERFLOW_VENDOR_KEY) {
+    counts[slug] = (counts[slug] ?? 0) + amount;
+    return 0;
+  }
+  if (Object.keys(counts).length >= MAX_VENDOR_SLUGS_PER_DAY) {
+    counts[OVERFLOW_VENDOR_KEY] = (counts[OVERFLOW_VENDOR_KEY] ?? 0) + amount;
+    return amount;
+  }
+  counts[slug] = amount;
+  return 0;
+}
+
+export function mergeVendorDay(base: VendorDay, delta: VendorDay, now: string): VendorDay {
+  const merged = emptyVendorDay(base.date || delta.date);
+  merged.counts = { ...base.counts };
+  let overflowed = 0;
+  for (const [slug, count] of Object.entries(delta.counts)) {
+    overflowed += addBounded(merged.counts, slug, count);
+  }
+  merged.process_starts = base.process_starts + delta.process_starts;
+  merged.slug_overflow = base.slug_overflow + delta.slug_overflow + overflowed;
+  merged.capped_slugs = Math.max(base.capped_slugs, delta.capped_slugs);
+  merged.dedup_suppressed = base.dedup_suppressed + delta.dedup_suppressed;
+  merged.first_recorded_at = base.first_recorded_at || delta.first_recorded_at || now;
+  merged.updated_at = now;
+  return merged;
+}
+
+const CLIENT_SALT = randomBytes(16).toString("hex");
+
+export function clientKey(address: string): string {
+  return createHash("sha256").update(CLIENT_SALT).update(address).digest("hex").slice(0, CLIENT_KEY_LENGTH);
+}
+
+interface RecordingDay {
+  date: string;
+  delta: VendorDay;
+  seen: Map<string, Set<string>>;
+  trackedKeys: number;
+  countedTotal: number;
+  suppressedTotal: number;
+  overflowTotal: number;
+}
+
+let recording: RecordingDay | null = null;
+let lastWriteAt: string | null = null;
+let lastWriteError: string | null = null;
+let writeFailures = 0;
+let daysWritten = 0;
+
+function startDay(date: string): RecordingDay {
+  const delta = emptyVendorDay(date);
+  delta.process_starts = 1;
+  return { date, delta, seen: new Map(), trackedKeys: 0, countedTotal: 0, suppressedTotal: 0, overflowTotal: 0 };
+}
+
+export interface VendorRequest {
+  slug: string | null;
+  client_class: string;
+  address: string;
+  status: number;
+  date: string;
+}
+
+export function recordVendorRequest(input: VendorRequest): void {
+  if (input.client_class === "internal") return;
+  if (!(input.status >= 200 && input.status < 300)) return;
+
+  if (!recording || recording.date !== input.date) {
+    if (recording && hasPendingVendorCounts()) carry({ date: recording.date, delta: recording.delta });
+    recording = startDay(input.date);
+  }
+  const day = recording;
+  const slug = input.slug ?? OVERFLOW_VENDOR_KEY;
+
+  let clients = day.seen.get(slug);
+  if (!clients) {
+    clients = new Set();
+    day.seen.set(slug, clients);
+  }
+
+  const key = clientKey(input.address);
+  if (clients.has(key)) return;
+
+  if (clients.size >= MAX_CLIENTS_PER_VENDOR_PER_DAY) {
+    day.delta.capped_slugs = countCapped(day);
+    day.delta.dedup_suppressed++;
+    day.suppressedTotal++;
+    return;
+  }
+  if (day.trackedKeys >= MAX_TRACKED_CLIENT_KEYS) {
+    day.delta.dedup_suppressed++;
+    day.suppressedTotal++;
+    return;
+  }
+
+  clients.add(key);
+  day.trackedKeys++;
+  day.countedTotal++;
+  const overflowed = addBounded(day.delta.counts, slug, 1);
+  day.delta.slug_overflow += overflowed;
+  day.overflowTotal += overflowed;
+  if (!day.delta.first_recorded_at) day.delta.first_recorded_at = new Date().toISOString();
+}
+
+function countCapped(day: RecordingDay): number {
+  let capped = 0;
+  for (const clients of day.seen.values()) {
+    if (clients.size >= MAX_CLIENTS_PER_VENDOR_PER_DAY) capped++;
+  }
+  return capped;
+}
+
+export function hasPendingVendorCounts(): boolean {
+  if (!recording) return false;
+  const { delta } = recording;
+  return Object.keys(delta.counts).length > 0 || delta.process_starts > 0 || delta.dedup_suppressed > 0;
+}
+
+export interface PendingVendorWrite {
+  date: string;
+  delta: VendorDay;
+}
+
+export const MAX_CARRY_OVER_DAYS = 5;
+const carryOver: PendingVendorWrite[] = [];
+let droppedDays = 0;
+
+function carry(write: PendingVendorWrite): void {
+  const existing = carryOver.find(entry => entry.date === write.date);
+  if (existing) {
+    existing.delta = mergeVendorDay(existing.delta, write.delta, "");
+    existing.delta.updated_at = "";
+    return;
+  }
+  carryOver.push(write);
+  while (carryOver.length > MAX_CARRY_OVER_DAYS) {
+    carryOver.shift();
+    droppedDays++;
+  }
+}
+
+export function takeVendorWrites(): PendingVendorWrite[] {
+  const writes = carryOver.splice(0, carryOver.length);
+  if (recording && hasPendingVendorCounts()) {
+    writes.push({ date: recording.date, delta: recording.delta });
+    recording.delta = emptyVendorDay(recording.date);
+  }
+  return writes;
+}
+
+export function returnVendorWrites(writes: PendingVendorWrite[]): void {
+  for (const write of writes) {
+    if (recording && recording.date === write.date) {
+      recording.delta = mergeVendorDay(write.delta, recording.delta, "");
+      recording.delta.updated_at = "";
+    } else {
+      carry(write);
+    }
+  }
+}
+
+export interface VendorSeriesStore {
+  get(key: string): Promise<{ ok: boolean; value: unknown; error?: string }>;
+  mget(keys: string[]): Promise<{ ok: boolean; values: unknown[]; error?: string }>;
+  set(key: string, value: unknown, ttlSeconds: number): Promise<{ ok: boolean; error?: string }>;
+}
+
+let store: VendorSeriesStore | null = null;
+let lastAttemptMs = 0;
+
+export const DEFAULT_WRITE_INTERVAL_SECONDS = 300;
+export const MIN_WRITE_INTERVAL_SECONDS = 1;
+
+export function vendorWriteIntervalSeconds(): number {
+  const raw = Number(process.env.VENDOR_SERIES_WRITE_INTERVAL_SECONDS);
+  return raw > 0 ? Math.max(MIN_WRITE_INTERVAL_SECONDS, raw) : DEFAULT_WRITE_INTERVAL_SECONDS;
+}
+
+export function configureVendorSeries(next: VendorSeriesStore | null): void {
+  store = next;
+}
+
+export function vendorSeriesConfigured(): boolean {
+  return store !== null;
+}
+
+let flushChain: Promise<number> = Promise.resolve(0);
+
+export function flushVendorSeries(force = false, now = new Date()): Promise<number> {
+  if (!store) return Promise.resolve(0);
+  const run = () => runVendorFlush(force, now);
+  flushChain = flushChain.then(run, run);
+  return flushChain;
+}
+
+async function runVendorFlush(force: boolean, now: Date): Promise<number> {
+  if (!store) return 0;
+  const nowMs = now.getTime();
+  const due = force || carryOver.length > 0 || nowMs - lastAttemptMs >= vendorWriteIntervalSeconds() * 1000;
+  if (!due) return 0;
+
+  const writes = takeVendorWrites();
+  if (writes.length === 0) {
+    lastAttemptMs = nowMs;
+    return 0;
+  }
+  lastAttemptMs = nowMs;
+
+  const stamp = now.toISOString();
+  const failed: PendingVendorWrite[] = [];
+  let written = 0;
+
+  for (const write of writes) {
+    const key = vendorSeriesKey(write.date);
+    const read = await store.get(key);
+    if (!read.ok) {
+      noteVendorWriteFailure(read.error ?? "read-failed");
+      failed.push(write);
+      continue;
+    }
+    const merged = mergeVendorDay(parseVendorDay(read.value, write.date), write.delta, stamp);
+    const result = await store.set(key, merged, VENDOR_SERIES_TTL_SECONDS);
+    if (!result.ok) {
+      noteVendorWriteFailure(result.error ?? "write-failed");
+      failed.push(write);
+      continue;
+    }
+    noteVendorWrite(stamp);
+    written++;
+  }
+
+  if (failed.length > 0) returnVendorWrites(failed);
+  return written;
+}
+
+export async function readVendorSeries(dates: string[]): Promise<{ ok: boolean; days: VendorDay[]; error?: string }> {
+  if (!store) return { ok: false, days: [], error: "not-configured" };
+  if (dates.length === 0) return { ok: true, days: [] };
+  const read = await store.mget(dates.map(vendorSeriesKey));
+  if (!read.ok) return { ok: false, days: [], error: read.error ?? "read-failed" };
+  const days: VendorDay[] = [];
+  for (let i = 0; i < dates.length; i++) {
+    const value = read.values[i];
+    if (value === null || value === undefined) continue;
+    days.push(parseVendorDay(value, dates[i]));
+  }
+  return { ok: true, days };
+}
+
+function noteVendorWrite(at: string): void {
+  lastWriteAt = at;
+  lastWriteError = null;
+  daysWritten++;
+}
+
+function noteVendorWriteFailure(message: string): void {
+  lastWriteError = message;
+  writeFailures++;
+}
+
+export interface VendorSeriesGauge {
+  recording_date: string | null;
+  slugs_today: number;
+  clients_today: number;
+  dedup_tracked: number;
+  dedup_suppressed: number;
+  slug_overflow: number;
+  capped_slugs: number;
+  pending_write: boolean;
+  last_write_at: string | null;
+  last_write_error: string | null;
+  write_failures: number;
+  writes: number;
+  carry_over_days: number;
+  dropped_days: number;
+  configured: boolean;
+  write_interval_seconds: number;
+  retention_days: number;
+  published: boolean;
+}
+
+export function vendorSeriesGauge(): VendorSeriesGauge {
+  return {
+    recording_date: recording?.date ?? null,
+    slugs_today: recording ? recording.seen.size : 0,
+    clients_today: recording?.countedTotal ?? 0,
+    dedup_tracked: recording?.trackedKeys ?? 0,
+    dedup_suppressed: recording?.suppressedTotal ?? 0,
+    slug_overflow: recording?.overflowTotal ?? 0,
+    capped_slugs: recording ? countCapped(recording) : 0,
+    pending_write: hasPendingVendorCounts(),
+    last_write_at: lastWriteAt,
+    last_write_error: lastWriteError,
+    write_failures: writeFailures,
+    writes: daysWritten,
+    carry_over_days: carryOver.length,
+    dropped_days: droppedDays,
+    configured: store !== null,
+    write_interval_seconds: vendorWriteIntervalSeconds(),
+    retention_days: VENDOR_SERIES_RETENTION_DAYS,
+    published: false,
+  };
+}
+
+export function resetVendorSeries(): void {
+  recording = null;
+  lastWriteAt = null;
+  lastWriteError = null;
+  writeFailures = 0;
+  daysWritten = 0;
+  droppedDays = 0;
+  lastAttemptMs = 0;
+  carryOver.length = 0;
+  store = null;
+}
+
+const DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
+
+export function isSeriesDate(value: unknown): value is string {
+  return typeof value === "string" && DATE_PATTERN.test(value) && !Number.isNaN(Date.parse(value));
+}
+
+export function seriesDateRange(from: string, to: string, maxDays = VENDOR_SERIES_RETENTION_DAYS): string[] {
+  const start = Date.parse(from);
+  const end = Date.parse(to);
+  if (Number.isNaN(start) || Number.isNaN(end) || end < start) return [];
+  const out: string[] = [];
+  for (let t = start; t <= end && out.length < maxDays; t += 86400000) {
+    out.push(new Date(t).toISOString().slice(0, 10));
+  }
+  return out;
+}
+
+export const VENDOR_SERIES_NOTES: readonly string[] = [
+  "`counts` is distinct clients per vendor per day, not requests. A client is counted once per vendor per day per server process.",
+  "Deduplication is in-memory and per-process: the salted client hash is generated at startup and never written to storage, so a restart mid-day can count a client a second time. `process_starts` is the upper bound on that multiple.",
+  "Only 2xx responses to paths that name exactly one catalogued vendor are counted. Requests classified `internal` are excluded.",
+  "A slug we do not publish cannot mint a key: unknown slugs land in `__other_vendors__`, and `slug_overflow` counts what the per-day slug cap folded there.",
+  "The client address comes from `x-forwarded-for`, which is caller-supplied, so a caller able to vary it can inflate its own vendor's distinct count. This series must not be used as a placement metric without an independent check.",
+  "This series is never written to the public rollup in `data/analytics/`, which keeps `vendors: null`.",
+];

--- a/test/vendor-series.test.ts
+++ b/test/vendor-series.test.ts
@@ -1,0 +1,467 @@
+import { describe, it, beforeEach } from "node:test";
+import assert from "node:assert";
+
+const {
+  recordVendorRequest,
+  flushVendorSeries,
+  configureVendorSeries,
+  readVendorSeries,
+  resetVendorSeries,
+  vendorSeriesGauge,
+  vendorSeriesKey,
+  parseVendorDay,
+  mergeVendorDay,
+  emptyVendorDay,
+  seriesDateRange,
+  isSeriesDate,
+  takeVendorWrites,
+  OVERFLOW_VENDOR_KEY,
+  MAX_VENDOR_SLUGS_PER_DAY,
+  MAX_CLIENTS_PER_VENDOR_PER_DAY,
+  MAX_TRACKED_CLIENT_KEYS,
+  VENDOR_SERIES_RETENTION_DAYS,
+  VENDOR_SERIES_TTL_SECONDS,
+  VENDOR_SERIES_NOTES,
+  VENDOR_SERIES_PATH,
+  vendorExportAuthorized,
+} = await import("../src/vendor-series.ts");
+
+type StoreCall = { key: string; value: any; ttl: number };
+
+function fakeStore(seed: Record<string, any> = {}) {
+  const data = new Map<string, any>(Object.entries(seed));
+  const writes: StoreCall[] = [];
+  let failRead = false;
+  let failWrite = false;
+  return {
+    data,
+    writes,
+    failRead: (on: boolean) => { failRead = on; },
+    failWrite: (on: boolean) => { failWrite = on; },
+    store: {
+      async get(key: string) {
+        if (failRead) return { ok: false, value: null, error: "read-boom" };
+        return { ok: true, value: data.has(key) ? data.get(key) : null };
+      },
+      async mget(keys: string[]) {
+        if (failRead) return { ok: false, values: [], error: "read-boom" };
+        return { ok: true, values: keys.map(k => (data.has(k) ? data.get(k) : null)) };
+      },
+      async set(key: string, value: any, ttl: number) {
+        if (failWrite) return { ok: false, error: "write-boom" };
+        data.set(key, JSON.parse(JSON.stringify(value)));
+        writes.push({ key, value, ttl });
+        return { ok: true };
+      },
+    },
+  };
+}
+
+const DAY = "2026-08-27";
+
+function hit(overrides: Partial<Parameters<typeof recordVendorRequest>[0]> = {}) {
+  recordVendorRequest({
+    slug: "neon",
+    client_class: "ai_agent",
+    address: "203.0.113.10",
+    status: 200,
+    date: DAY,
+    ...overrides,
+  });
+}
+
+describe("vendor series recording", () => {
+  beforeEach(() => {
+    resetVendorSeries();
+    process.env.VENDOR_SERIES_WRITE_INTERVAL_SECONDS = "1";
+  });
+
+  it("counts one client once however many times it asks for the same vendor", () => {
+    for (let i = 0; i < 50; i++) hit();
+    const writes = takeVendorWrites();
+    assert.deepStrictEqual(writes[0].delta.counts, { neon: 1 });
+  });
+
+  it("counts two addresses on one vendor as two clients", () => {
+    hit({ address: "198.51.100.1" });
+    hit({ address: "198.51.100.2" });
+    assert.deepStrictEqual(takeVendorWrites()[0].delta.counts, { neon: 2 });
+  });
+
+  it("counts one client on two vendors once for each", () => {
+    hit({ slug: "neon" });
+    hit({ slug: "render" });
+    assert.deepStrictEqual(takeVendorWrites()[0].delta.counts, { neon: 1, render: 1 });
+  });
+
+  it("excludes the internal class", () => {
+    hit({ client_class: "internal" });
+    assert.strictEqual(takeVendorWrites().length, 0);
+  });
+
+  it("counts every non-internal class, including bots", () => {
+    const classes = ["ai_agent", "search_crawler", "browser", "sdk_client", "unknown"];
+    classes.forEach((client_class, i) => hit({ client_class, address: `10.0.0.${i}` }));
+    assert.strictEqual(takeVendorWrites()[0].delta.counts.neon, 5);
+  });
+
+  it("counts only responses we served", () => {
+    hit({ status: 404, address: "1.1.1.1" });
+    hit({ status: 301, address: "1.1.1.2" });
+    hit({ status: 500, address: "1.1.1.3" });
+    assert.strictEqual(takeVendorWrites().length, 0);
+  });
+
+  it("folds a slug we do not publish into one overflow key", () => {
+    hit({ slug: null, address: "2.2.2.1" });
+    hit({ slug: null, address: "2.2.2.2" });
+    assert.deepStrictEqual(takeVendorWrites()[0].delta.counts, { [OVERFLOW_VENDOR_KEY]: 2 });
+  });
+
+  it("caps the day's slug keys and folds the excess into the overflow key", () => {
+    for (let i = 0; i < MAX_VENDOR_SLUGS_PER_DAY + 20; i++) {
+      hit({ slug: `vendor-${i}`, address: `10.1.${Math.floor(i / 250)}.${i % 250}` });
+    }
+    const delta = takeVendorWrites()[0].delta;
+    assert.strictEqual(Object.keys(delta.counts).length, MAX_VENDOR_SLUGS_PER_DAY + 1);
+    assert.strictEqual(delta.counts[OVERFLOW_VENDOR_KEY], 20);
+    assert.strictEqual(delta.slug_overflow, 20);
+  });
+
+  it("stops counting rather than over-counting when one vendor exceeds the client cap", () => {
+    for (let i = 0; i < MAX_CLIENTS_PER_VENDOR_PER_DAY + 30; i++) {
+      hit({ address: `10.2.${Math.floor(i / 250)}.${i % 250}` });
+    }
+    const delta = takeVendorWrites()[0].delta;
+    assert.strictEqual(delta.counts.neon, MAX_CLIENTS_PER_VENDOR_PER_DAY);
+    assert.strictEqual(delta.dedup_suppressed, 30);
+    assert.strictEqual(delta.capped_slugs, 1);
+  });
+
+  it("bounds the dedup table so a burst of addresses cannot grow memory without limit", () => {
+    const perVendor = MAX_CLIENTS_PER_VENDOR_PER_DAY;
+    const vendors = Math.ceil(MAX_TRACKED_CLIENT_KEYS / perVendor) + 5;
+    let attempts = 0;
+    for (let v = 0; v < vendors; v++) {
+      for (let c = 0; c < perVendor; c++) {
+        hit({ slug: `vendor-${v}`, address: `10.${v}.${Math.floor(c / 256)}.${c % 256}` });
+        attempts++;
+      }
+    }
+    const gauge = vendorSeriesGauge();
+    assert.strictEqual(gauge.dedup_tracked, MAX_TRACKED_CLIENT_KEYS);
+    assert.strictEqual(gauge.clients_today, MAX_TRACKED_CLIENT_KEYS);
+    assert.strictEqual(gauge.dedup_suppressed, attempts - MAX_TRACKED_CLIENT_KEYS);
+    const counted = Object.values(takeVendorWrites()[0].delta.counts).reduce((a: any, b: any) => a + b, 0);
+    assert.strictEqual(counted, MAX_TRACKED_CLIENT_KEYS);
+  });
+
+  it("carries an unwritten day over when the date rolls", () => {
+    hit({ date: "2026-08-27", address: "3.3.3.1" });
+    hit({ date: "2026-08-28", address: "3.3.3.1" });
+    const writes = takeVendorWrites();
+    assert.deepStrictEqual(writes.map(w => w.date), ["2026-08-27", "2026-08-28"]);
+    assert.deepStrictEqual(writes[0].delta.counts, { neon: 1 });
+    assert.deepStrictEqual(writes[1].delta.counts, { neon: 1 });
+  });
+});
+
+describe("vendor series persistence", () => {
+  beforeEach(() => {
+    resetVendorSeries();
+    process.env.VENDOR_SERIES_WRITE_INTERVAL_SECONDS = "1";
+  });
+
+  it("writes the day under its own key with a retention TTL", async () => {
+    const fake = fakeStore();
+    configureVendorSeries(fake.store);
+    hit();
+    const written = await flushVendorSeries(true, new Date("2026-08-27T10:00:00Z"));
+    assert.strictEqual(written, 1);
+    assert.strictEqual(fake.writes[0].key, vendorSeriesKey(DAY));
+    assert.strictEqual(fake.writes[0].ttl, VENDOR_SERIES_TTL_SECONDS);
+    assert.deepStrictEqual(fake.writes[0].value.counts, { neon: 1 });
+    assert.strictEqual(fake.writes[0].value.process_starts, 1);
+  });
+
+  it("adds to what another process already stored for the day", async () => {
+    const fake = fakeStore({
+      [vendorSeriesKey(DAY)]: { date: DAY, counts: { neon: 40, render: 7 }, process_starts: 2 },
+    });
+    configureVendorSeries(fake.store);
+    hit();
+    hit({ slug: "fly", address: "4.4.4.4" });
+    await flushVendorSeries(true, new Date("2026-08-27T10:00:00Z"));
+    assert.deepStrictEqual(fake.data.get(vendorSeriesKey(DAY)).counts, { neon: 41, render: 7, fly: 1 });
+    assert.strictEqual(fake.data.get(vendorSeriesKey(DAY)).process_starts, 3);
+  });
+
+  it("does not re-add a delta that was already written", async () => {
+    const fake = fakeStore();
+    configureVendorSeries(fake.store);
+    hit();
+    await flushVendorSeries(true, new Date("2026-08-27T10:00:00Z"));
+    await flushVendorSeries(true, new Date("2026-08-27T10:05:00Z"));
+    assert.deepStrictEqual(fake.data.get(vendorSeriesKey(DAY)).counts, { neon: 1 });
+  });
+
+  it("counts a client once across flushes but again after a restart", async () => {
+    const fake = fakeStore();
+    configureVendorSeries(fake.store);
+    hit();
+    await flushVendorSeries(true, new Date("2026-08-27T10:00:00Z"));
+    hit();
+    await flushVendorSeries(true, new Date("2026-08-27T10:05:00Z"));
+    assert.deepStrictEqual(fake.data.get(vendorSeriesKey(DAY)).counts, { neon: 1 });
+
+    resetVendorSeries();
+    configureVendorSeries(fake.store);
+    hit();
+    await flushVendorSeries(true, new Date("2026-08-27T10:10:00Z"));
+    const stored = fake.data.get(vendorSeriesKey(DAY));
+    assert.strictEqual(stored.counts.neon, 2);
+    assert.strictEqual(stored.process_starts, 2);
+  });
+
+  it("keeps the delta when the write fails and loses nothing on the retry", async () => {
+    const fake = fakeStore();
+    configureVendorSeries(fake.store);
+    hit({ address: "5.5.5.1" });
+    hit({ address: "5.5.5.2" });
+    fake.failWrite(true);
+    assert.strictEqual(await flushVendorSeries(true, new Date("2026-08-27T10:00:00Z")), 0);
+    assert.strictEqual(vendorSeriesGauge().write_failures, 1);
+
+    fake.failWrite(false);
+    hit({ address: "5.5.5.3" });
+    await flushVendorSeries(true, new Date("2026-08-27T10:01:00Z"));
+    assert.deepStrictEqual(fake.data.get(vendorSeriesKey(DAY)).counts, { neon: 3 });
+    assert.strictEqual(fake.data.get(vendorSeriesKey(DAY)).process_starts, 1);
+  });
+
+  it("keeps the delta when the read fails", async () => {
+    const fake = fakeStore();
+    configureVendorSeries(fake.store);
+    hit();
+    fake.failRead(true);
+    assert.strictEqual(await flushVendorSeries(true, new Date("2026-08-27T10:00:00Z")), 0);
+    fake.failRead(false);
+    await flushVendorSeries(true, new Date("2026-08-27T10:01:00Z"));
+    assert.deepStrictEqual(fake.data.get(vendorSeriesKey(DAY)).counts, { neon: 1 });
+  });
+
+  it("writes a rolled-over day to its own key", async () => {
+    const fake = fakeStore();
+    configureVendorSeries(fake.store);
+    hit({ date: "2026-08-27" });
+    hit({ date: "2026-08-28" });
+    await flushVendorSeries(true, new Date("2026-08-28T00:01:00Z"));
+    assert.deepStrictEqual(fake.data.get(vendorSeriesKey("2026-08-27")).counts, { neon: 1 });
+    assert.deepStrictEqual(fake.data.get(vendorSeriesKey("2026-08-28")).counts, { neon: 1 });
+  });
+
+  it("waits for the write interval unless forced", async () => {
+    process.env.VENDOR_SERIES_WRITE_INTERVAL_SECONDS = "300";
+    const fake = fakeStore();
+    configureVendorSeries(fake.store);
+    hit();
+    assert.strictEqual(await flushVendorSeries(false, new Date("2026-08-27T10:00:00Z")), 1);
+    hit({ address: "6.6.6.6" });
+    assert.strictEqual(await flushVendorSeries(false, new Date("2026-08-27T10:01:00Z")), 0);
+    assert.strictEqual(await flushVendorSeries(false, new Date("2026-08-27T10:06:00Z")), 1);
+  });
+
+  it("serialises overlapping flushes so neither drops the other's delta", async () => {
+    const fake = fakeStore();
+    let release: () => void = () => {};
+    const gate = new Promise<void>(r => { release = r; });
+    let firstRead = true;
+    const slow = {
+      ...fake.store,
+      async get(key: string) {
+        if (firstRead) {
+          firstRead = false;
+          await gate;
+        }
+        return fake.store.get(key);
+      },
+    };
+    configureVendorSeries(slow);
+    hit({ address: "7.7.7.1" });
+    const a = flushVendorSeries(true, new Date("2026-08-27T10:00:00Z"));
+    hit({ address: "7.7.7.2" });
+    const b = flushVendorSeries(true, new Date("2026-08-27T10:00:01Z"));
+    release();
+    await Promise.all([a, b]);
+    assert.deepStrictEqual(fake.data.get(vendorSeriesKey(DAY)).counts, { neon: 2 });
+  });
+
+  it("writes nothing when no store is configured", async () => {
+    hit();
+    assert.strictEqual(await flushVendorSeries(true, new Date("2026-08-27T10:00:00Z")), 0);
+    assert.strictEqual(vendorSeriesGauge().configured, false);
+  });
+
+  it("persists no client identifier and no address", async () => {
+    const fake = fakeStore();
+    configureVendorSeries(fake.store);
+    hit({ address: "203.0.113.77" });
+    hit({ address: "2001:db8::1", slug: "render" });
+    await flushVendorSeries(true, new Date("2026-08-27T10:00:00Z"));
+    const serialized = JSON.stringify(fake.data.get(vendorSeriesKey(DAY)));
+    assert.ok(!serialized.includes("203.0.113.77"));
+    assert.ok(!serialized.includes("2001:db8"));
+    assert.deepStrictEqual(Object.keys(fake.data.get(vendorSeriesKey(DAY)).counts).sort(), ["neon", "render"]);
+  });
+});
+
+describe("vendor series export", () => {
+  beforeEach(() => {
+    resetVendorSeries();
+    process.env.VENDOR_SERIES_WRITE_INTERVAL_SECONDS = "1";
+  });
+
+  it("returns the days it holds and omits the ones it does not", async () => {
+    const fake = fakeStore({
+      [vendorSeriesKey("2026-08-25")]: { date: "2026-08-25", counts: { neon: 3 } },
+      [vendorSeriesKey("2026-08-27")]: { date: "2026-08-27", counts: { neon: 5 } },
+    });
+    configureVendorSeries(fake.store);
+    const result = await readVendorSeries(["2026-08-25", "2026-08-26", "2026-08-27"]);
+    assert.strictEqual(result.ok, true);
+    assert.deepStrictEqual(result.days.map((d: any) => d.date), ["2026-08-25", "2026-08-27"]);
+  });
+
+  it("reports a read failure rather than an empty series", async () => {
+    const fake = fakeStore();
+    fake.failRead(true);
+    configureVendorSeries(fake.store);
+    const result = await readVendorSeries(["2026-08-25"]);
+    assert.strictEqual(result.ok, false);
+    assert.deepStrictEqual(result.days, []);
+  });
+
+  it("bounds a requested range to the retention window", () => {
+    assert.strictEqual(seriesDateRange("2020-01-01", "2026-08-27").length, VENDOR_SERIES_RETENTION_DAYS);
+    assert.deepStrictEqual(seriesDateRange("2026-08-26", "2026-08-27"), ["2026-08-26", "2026-08-27"]);
+    assert.deepStrictEqual(seriesDateRange("2026-08-27", "2026-08-26"), []);
+  });
+
+  it("accepts only a calendar date", () => {
+    assert.strictEqual(isSeriesDate("2026-08-27"), true);
+    assert.strictEqual(isSeriesDate("2026-13-01"), false);
+    assert.strictEqual(isSeriesDate("yesterday"), false);
+    assert.strictEqual(isSeriesDate(20260827), false);
+  });
+
+  it("says the counting rule, the dedup limit and the spoofing limit next to the numbers", () => {
+    const text = VENDOR_SERIES_NOTES.join(" ");
+    assert.match(text, /distinct clients per vendor per day/);
+    assert.match(text, /process_starts/);
+    assert.match(text, /x-forwarded-for/);
+    assert.match(text, /vendors: null/);
+  });
+});
+
+describe("vendor series export authorization", () => {
+  const TOKEN = "0123456789abcdef0123";
+
+  beforeEach(() => {
+    delete process.env.ANALYTICS_EXPORT_TOKEN;
+  });
+
+  it("refuses every request when no token is configured", () => {
+    for (const header of [undefined, "", "Bearer ", `Bearer ${TOKEN}`]) {
+      assert.strictEqual(vendorExportAuthorized(header), false);
+    }
+  });
+
+  it("refuses a token shorter than the minimum even when it matches", () => {
+    process.env.ANALYTICS_EXPORT_TOKEN = "short";
+    assert.strictEqual(vendorExportAuthorized("Bearer short"), false);
+  });
+
+  it("accepts the configured token and refuses everything else", () => {
+    process.env.ANALYTICS_EXPORT_TOKEN = TOKEN;
+    assert.strictEqual(vendorExportAuthorized(`Bearer ${TOKEN}`), true);
+    assert.strictEqual(vendorExportAuthorized(`bearer ${TOKEN}`), true);
+    assert.strictEqual(vendorExportAuthorized(` Bearer ${TOKEN} `), true);
+    assert.strictEqual(vendorExportAuthorized(`Bearer ${TOKEN}x`), false);
+    assert.strictEqual(vendorExportAuthorized(`Bearer ${TOKEN.slice(0, -1)}`), false);
+    assert.strictEqual(vendorExportAuthorized(TOKEN), false);
+    assert.strictEqual(vendorExportAuthorized(`Basic ${TOKEN}`), false);
+    assert.strictEqual(vendorExportAuthorized(undefined), false);
+  });
+
+  it("reads only the first value when the header arrives more than once", () => {
+    process.env.ANALYTICS_EXPORT_TOKEN = TOKEN;
+    assert.strictEqual(vendorExportAuthorized([`Bearer ${TOKEN}`, "Bearer nope"]), true);
+    assert.strictEqual(vendorExportAuthorized(["Bearer nope", `Bearer ${TOKEN}`]), false);
+  });
+
+  it("keeps the export path in the observability list so its own reads are not counted", async () => {
+    const { isObservabilityPath } = await import("../src/client-class.ts");
+    assert.strictEqual(isObservabilityPath(VENDOR_SERIES_PATH), true);
+    assert.strictEqual(isObservabilityPath(`${VENDOR_SERIES_PATH}?from=2026-08-01`), true);
+  });
+});
+
+describe("the gauge that is published", () => {
+  beforeEach(() => {
+    resetVendorSeries();
+  });
+
+  it("carries counts and never a vendor name", () => {
+    hit({ slug: "neon" });
+    hit({ slug: "planetscale", address: "9.9.9.9" });
+    const serialized = JSON.stringify(vendorSeriesGauge());
+    assert.ok(!serialized.includes("neon"));
+    assert.ok(!serialized.includes("planetscale"));
+    assert.strictEqual(vendorSeriesGauge().slugs_today, 2);
+    assert.strictEqual(vendorSeriesGauge().clients_today, 2);
+    assert.strictEqual(vendorSeriesGauge().published, false);
+  });
+
+  it("keeps reporting what this process counted after a successful write", async () => {
+    const fake = fakeStore();
+    configureVendorSeries(fake.store);
+    hit();
+    await flushVendorSeries(true, new Date("2026-08-27T10:00:00Z"));
+    assert.strictEqual(vendorSeriesGauge().clients_today, 1);
+    assert.strictEqual(vendorSeriesGauge().pending_write, false);
+    assert.strictEqual(vendorSeriesGauge().writes, 1);
+  });
+});
+
+describe("vendor day parsing", () => {
+  it("survives a record written by another build", () => {
+    const parsed = parseVendorDay({ date: "2026-08-27", counts: { neon: "x", render: 4, fly: -1 }, junk: true }, "2026-08-01");
+    assert.deepStrictEqual(parsed.counts, { render: 4 });
+    assert.strictEqual(parsed.date, "2026-08-27");
+  });
+
+  it("returns an empty day for anything that is not an object", () => {
+    for (const raw of [null, undefined, "", 7, "not json"]) {
+      assert.deepStrictEqual(parseVendorDay(raw, DAY).counts, {});
+    }
+  });
+
+  it("sums counts and process starts on merge", () => {
+    const base = { ...emptyVendorDay(DAY), counts: { neon: 2 }, process_starts: 1, dedup_suppressed: 3 };
+    const delta = { ...emptyVendorDay(DAY), counts: { neon: 5, fly: 1 }, process_starts: 1, dedup_suppressed: 2 };
+    const merged = mergeVendorDay(base, delta, "2026-08-27T10:00:00Z");
+    assert.deepStrictEqual(merged.counts, { neon: 7, fly: 1 });
+    assert.strictEqual(merged.process_starts, 2);
+    assert.strictEqual(merged.dedup_suppressed, 5);
+    assert.strictEqual(merged.updated_at, "2026-08-27T10:00:00Z");
+  });
+
+  it("folds a merge past the slug cap into the overflow key", () => {
+    const base = { ...emptyVendorDay(DAY), counts: Object.fromEntries(Array.from({ length: MAX_VENDOR_SLUGS_PER_DAY }, (_, i) => [`v${i}`, 1])) };
+    const delta = { ...emptyVendorDay(DAY), counts: { latecomer: 4 } };
+    const merged = mergeVendorDay(base, delta, "2026-08-27T10:00:00Z");
+    assert.strictEqual(merged.counts.latecomer, undefined);
+    assert.strictEqual(merged.counts[OVERFLOW_VENDOR_KEY], 4);
+    assert.strictEqual(merged.slug_overflow, 4);
+  });
+});


### PR DESCRIPTION
Refs #1052 — Part A. Nothing here is publicly readable and no UI was built, per the direction change.

## What this records

One number per vendor per day: **distinct clients that asked for a page naming that vendor**. It lives in its own Redis key per day (`vendorseries:YYYY-MM-DD`, 100-day TTL), is never written to this repo, and no public endpoint carries it.

The counting rule, as specified:

- **2xx only.** A 404 on `/vendor/wp-admin` is not a vendor page view.
- **`internal` excluded**, which is why my own probes do not appear.
- **One client counted once per vendor per day.** A looping client is 1, not 130 — which is the failure mode that made `rapidapi` fall 130 → 57 in eight hours in your snapshots.
- Any route that names exactly one catalogued vendor counts. That is `singleVendorSlug`, the existing single definition of the concept, so `/vendor/render` and `/api/details/render` land on the same slug. Worth knowing when you compare against your Cloudflare baseline, which is `/vendor/*` only.

## The limitation I could not remove, stated in the payload

**Deduplication is in-memory and per-process.** Telling one client from another needs a salted hash of the network address; the salt is generated at boot and the hashes are never written anywhere, which is the same mechanism the rate limiter has always used and the reason `/privacy`'s "no PII in the counters" is still true.

The cost is that a restart mid-day resets the dedup table, so a client active on both sides of a deploy can be counted twice. I did not hide this: **`process_starts` is written into every day record and is the exact upper bound on the multiple.** A day with `process_starts: 2` can over-count a client at most 2x; typically far less, since most clients make one visit.

The alternative — a salt stable across processes, so hashes could be persisted and matched — makes the stored record a per-caller pseudonymous identifier with a de-anonymisation oracle for anyone holding the salt. That is a privacy-posture change on a site that publishes "no tracking" on five surfaces, and it is not mine to make. Flagged below.

## Keyspace safety, honouring #1018

Three bounds, and **every one of them under-counts rather than over-counts**:

| bound | what it does | what it reports |
|---|---|---|
| catalogue allowlist | only a slug in `data/index.json` gets a key; everything else goes to `__other_vendors__` | — |
| 400 slugs/day | folds the excess into `__other_vendors__` | `slug_overflow` |
| 50,000 tracked clients | stops admitting new clients | `dedup_suppressed` |

A caller cannot mint a key, and cannot reach even the overflow bucket without us answering them with a 200.

## The export is closed

`GET /api/analytics/vendors?from=&to=` returns the series with the counting notes attached. It answers **404 unless `ANALYTICS_EXPORT_TOKEN` is set and the caller presents it** — 404 rather than 401, so it does not announce itself. **The variable is not set in production, so the endpoint is shut.** Recording is the half that cannot be backfilled; opening the read path is a Part B decision about who reads this and how, and I did not want to pre-empt the design doc.

`/api/traffic` gains a `vendor_series` gauge — counts, dates and write health, never a slug — so recording can be confirmed from outside without opening anything.

## What is unchanged

`data/analytics/*.json` keeps `vendors: null`, and `ROLLUP_EXCLUSIONS` still says why. `/api/leaderboard` is untouched.

## Two things to note

**1. The distinct count is caller-influenceable.** The address comes from `x-forwarded-for`, which is caller-supplied. A caller able to vary it can inflate its own vendor's number. This is stated in the export payload, and it is why this must not become a placement metric without an independent check. It is bounded — 2,000 distinct clients per vendor per day, reported as `capped_slugs` when it binds — but not eliminated.

**2. `/privacy` needs one line, and it belongs to #1043.** The bullet "counters do not track individual users or sessions" is already claim 5 of #1043's audit, with replacement copy drafted. Rather than edit it here and collide, the sentence for that draft is on the issue.

## Verification

- **1,732 tests, 0 failures** (38 new), `tsc` clean, **0 new code comments**.
- **`scripts/e2e-1052-vendors.mjs` — 37 checks against real `dist/serve.js`** and a fake Upstash: real page requests from several addresses, a genuine SIGTERM and restart against the same store, and assertions that six public endpoints carry no per-vendor count.
- **Mutation pass: 31 mutations, 31 killed** — but only after three rounds. The three that survived first were real gaps:
  - Nothing bounded the dedup table's memory. `MAX_TRACKED_CLIENT_KEYS` was the only defence and untested; 1,571 slugs x 2,000 clients is 3.1M hashes if it is removed.
  - Nothing asserted that recording is *bounded to vendor paths* — forcing the prefix test to `true` recorded every request on the site into the overflow bucket and every check still passed.
  - My own 404 assertion passed for the wrong reason. It checked that an unknown slug had no key of its own, but an unknown slug was never going to get one — it goes to the overflow bucket. Forcing the status to 200 was invisible to it. Now it asserts the overflow bucket is empty, which kills both.
- Serialised the flush after review, not after a failure: two overlapping flushes would each read the stored day and the second would overwrite the first's delta. `flushPending` chains for this exact reason and I had not copied it. There is now a test that fails without the chain.