### PR TITLE
Apply the alternatives gate symmetry rule in the category sweeps that assert it

### DIFF
--- a/test/alternatives-membership.test.ts
+++ b/test/alternatives-membership.test.ts
@@ -15,6 +15,22 @@ const SUBJECT = "Neon";
 const GATED_ADDON = "Prisma Accelerate";
 const GATED_LOCAL = "DynamoDB Local";
 
+type GateName = "local_dev_only" | "addon";
+
+function gatesOf(vendor: string): Set<GateName> {
+  const gates = new Set<GateName>();
+  const role = offers.find((o) => o.vendor === vendor)?.product_role;
+  if (!role) return gates;
+  if (role.deployment_model === "local_dev_only") gates.add("local_dev_only");
+  if (role.is_addon) gates.add("addon");
+  return gates;
+}
+
+function gateAppliesFor(gated: string, subject: string): boolean {
+  const subjectGates = gatesOf(subject);
+  return [...gatesOf(gated)].some((gate) => !subjectGates.has(gate));
+}
+
 function slugOf(vendor: string): string {
   return vendor.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "");
 }
@@ -258,6 +274,7 @@ describe("#1032 the other recommendation surfaces", () => {
     const category = offers.find((o) => o.vendor === GATED_ADDON)!.category;
     const subjects = offers.filter((o) => o.category === category && o.vendor !== GATED_ADDON && o.vendor !== GATED_LOCAL);
     let answered = 0;
+    let gateChecks = 0;
     const offenders: string[] = [];
     for (const subject of subjects) {
       const { status, body } = await get(`/api/vendor-risk/${encodeURIComponent(subject.vendor)}`);
@@ -266,10 +283,13 @@ describe("#1032 the other recommendation surfaces", () => {
       if (!parsed.alternatives?.length) continue;
       answered += 1;
       for (const gated of [GATED_ADDON, GATED_LOCAL]) {
+        if (!gateAppliesFor(gated, subject.vendor)) continue;
+        gateChecks += 1;
         if (parsed.alternatives.some((a) => a.vendor === gated)) offenders.push(`${gated} offered as an alternative to ${subject.vendor}`);
       }
     }
     assert.ok(answered > 10, `the sweep must actually read risk results, read ${answered}`);
+    assert.ok(gateChecks > 10, `the sweep must actually apply the gate, applied it ${gateChecks} times`);
     assert.deepStrictEqual(offenders, [], `these products cannot replace the vendor they are offered against: ${offenders.join("; ")}`);
   });
 
@@ -277,6 +297,7 @@ describe("#1032 the other recommendation surfaces", () => {
     const category = offers.find((o) => o.vendor === GATED_ADDON)!.category;
     const subjects = offers.filter((o) => o.category === category && o.vendor !== GATED_ADDON && o.vendor !== GATED_LOCAL);
     let answered = 0;
+    let gateChecks = 0;
     const offenders: string[] = [];
     for (const subject of subjects) {
       const { status, body } = await get(`/api/details/${encodeURIComponent(subject.vendor)}?alternatives=true`);
@@ -286,11 +307,14 @@ describe("#1032 the other recommendation surfaces", () => {
       if (!related?.length) continue;
       answered += 1;
       for (const gated of [GATED_ADDON, GATED_LOCAL]) {
+        if (!gateAppliesFor(gated, subject.vendor)) continue;
+        gateChecks += 1;
         if (related.includes(gated)) offenders.push(`${gated} related to ${subject.vendor}`);
         if (parsed.offer?.alternatives?.some((a) => a.vendor === gated)) offenders.push(`${gated} listed as an alternative to ${subject.vendor}`);
       }
     }
     assert.ok(answered > 10, `the sweep must actually read detail results, read ${answered}`);
+    assert.ok(gateChecks > 10, `the sweep must actually apply the gate, applied it ${gateChecks} times`);
     assert.deepStrictEqual(offenders, [], `these products cannot replace the vendor they are returned against: ${offenders.join("; ")}`);
   });
 });


### PR DESCRIPTION
main has been red since #1053 merged. `npm test` exits 1 on `1f9fb46`.

```
test at test/alternatives-membership.test.ts:257:3
✖ leaves gated offers out of the vendor risk tool's alternatives, on every page in the category
  AssertionError: these products cannot replace the vendor they are offered against:
  Prisma Accelerate offered as an alternative to Hasura Cloud
```

## The code is right; the test was

`Hasura Cloud` carries `is_addon: true`, classified in #1053 itself:

```
"is_addon": true, "augments": "a database you already run",
"source_url": "https://hasura.io/docs/3.0/connectors/overview/", "reviewed": "2026-08-25"
```

So does `Prisma Accelerate`. `MEMBERSHIP_GATE_SYMMETRY` is explicit that this pairing is allowed — *"One local emulator is still an alternative to another; one add-on is still an alternative to another."* Offering Prisma Accelerate against Hasura Cloud is the shipped rule working, not a defect.

The two category sweeps excluded exactly two vendors by name from their subject list and then asserted the gate against every remaining subject. That encodes "these are the only gated offers in Databases", which stopped being true in the same PR that wrote the assertion. Both sweeps now derive each subject's gates from its own `product_role` and skip a pair only where the symmetry rule says the gate does not apply.

## Bite-verified

| mutation | result |
|---|---|
| `gateAgainst` returns null (the real chokepoint) | **10 tests fail**, both sweeps among them |
| `gateAppliesFor` returns false (sweep made vacuous) | **2 tests fail** — `applied it 0 times` |
| `alternativeMembershipGate` returns null | survives here, caught by `product-role.test.ts` |

The third one is a finding rather than a gap: `alternativeMembershipGate` has **no production caller**. Every surface goes through `partitionAlternativesAcross` → `gateAgainst`. It is the symmetry rule written a second time, exercised only by its own unit test, and free to drift from the rule that ships. Left for #1032 rather than deleted here.

The `gateChecks > 10` assertions are new. Without them a future classification that gates the whole category would make both sweeps pass by checking nothing.

Full suite: **1732/1732**.

## How this stayed hidden for five merges

I have been running `npm test 2>&1 | tail -N`. A pipeline exits with the status of its last command, so `tail` returned 0 every time and the failure scrolled past above the window. Five PRs merged onto a red main. I am capturing the exit code directly from now on.

Refs #1032