### PR TITLE
Give the change log a writer, a recorded date, and an alarm

### DIFF
--- a/.github/workflows/reverify.yml
+++ b/.github/workflows/reverify.yml
@@ -39,20 +39,27 @@ jobs:
           node scripts/reverify-rolling.js --limit "$LIMIT" | tee /tmp/reverify.log
           VERIFIED=$(grep -oE '^Verified \(date bumped\): [0-9]+' /tmp/reverify.log | grep -oE '[0-9]+$' || echo 0)
           FLAGGED=$(grep -oE '^Flagged \(URL/AI failure\): [0-9]+' /tmp/reverify.log | grep -oE '[0-9]+$' || echo 0)
+          RECORDED=$(grep -oE '^Recorded to data/deal_changes.json: [0-9]+' /tmp/reverify.log | grep -oE '[0-9]+$' || echo 0)
           echo "verified=$VERIFIED" >> "$GITHUB_OUTPUT"
           echo "flagged=$FLAGGED" >> "$GITHUB_OUTPUT"
+          echo "recorded=$RECORDED" >> "$GITHUB_OUTPUT"
 
       - name: Commit and push if changed
         env:
           VERIFIED: ${{ steps.reverify.outputs.verified }}
           FLAGGED: ${{ steps.reverify.outputs.flagged }}
+          RECORDED: ${{ steps.reverify.outputs.recorded }}
         run: |
-          if git diff --quiet -- data/index.json; then
-            echo "No changes to data/index.json — skipping commit."
+          if git diff --quiet -- data/index.json data/deal_changes.json; then
+            echo "No changes to data/index.json or data/deal_changes.json — skipping commit."
             exit 0
           fi
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add data/index.json
-          git commit -m "data(auto): rolling re-verification — ${VERIFIED} verified, ${FLAGGED} flagged"
+          git add data/index.json data/deal_changes.json
+          git commit -m "data(auto): rolling re-verification — ${VERIFIED} verified, ${FLAGGED} flagged, ${RECORDED} changes recorded"
           git push origin HEAD:main
+
+      - name: Fail if the change log has gone stale
+        if: always()
+        run: node scripts/check-change-log-staleness.js

--- a/data/deal_changes.json
+++ b/data/deal_changes.json
@@ -10,7 +10,8 @@
       "impact": "medium",
       "source_url": "https://hyperping.com/pricing",
       "category": "Monitoring",
-      "alternatives": []
+      "alternatives": [],
+      "recorded_date": "2026-04-21"
     },
     {
       "vendor": "Amazon SP-API",
@@ -22,7 +23,8 @@
       "impact": "high",
       "source_url": "https://developer.amazonservices.com/",
       "category": "API Development",
-      "alternatives": []
+      "alternatives": [],
+      "recorded_date": "2026-04-19"
     },
     {
       "vendor": "Xata",
@@ -38,7 +40,8 @@
         "Neon",
         "Supabase",
         "CockroachDB"
-      ]
+      ],
+      "recorded_date": "2026-04-19"
     },
     {
       "vendor": "Hasura Cloud",
@@ -50,7 +53,8 @@
       "impact": "high",
       "source_url": "https://hasura.io/pricing",
       "category": "Databases",
-      "alternatives": []
+      "alternatives": [],
+      "recorded_date": "2026-04-19"
     },
     {
       "vendor": "Applitools Eyes",
@@ -66,7 +70,8 @@
         "BrowserStack Percy",
         "Chromatic",
         "Argos"
-      ]
+      ],
+      "recorded_date": "2026-04-18"
     },
     {
       "vendor": "everystep-automation.com",
@@ -81,7 +86,8 @@
       "alternatives": [
         "Selenium IDE",
         "Playwright"
-      ]
+      ],
+      "recorded_date": "2026-04-18"
     },
     {
       "vendor": "OpenAI Codex",
@@ -97,7 +103,8 @@
         "GitHub Copilot",
         "Claude Code",
         "Devin"
-      ]
+      ],
+      "recorded_date": "2026-04-15"
     },
     {
       "vendor": "GitHub Copilot",
@@ -114,19 +121,21 @@
         "Windsurf",
         "Claude Code",
         "Cline"
-      ]
+      ],
+      "recorded_date": "2026-04-13"
     },
     {
       "vendor": "Windsurf",
       "change_type": "pricing_restructured",
       "date": "2026-04-01",
-      "summary": "Grandfathered Pro pricing ($15/mo) confirmed indefinite \u2014 not expiring end of April as previously noted. Credit system fully replaced by daily/weekly quotas for all plans",
+      "summary": "Grandfathered Pro pricing ($15/mo) confirmed indefinite — not expiring end of April as previously noted. Credit system fully replaced by daily/weekly quotas for all plans",
       "previous_state": "Grandfathered Pro at $15/mo 'through April 2026' (implied expiration)",
       "current_state": "Grandfathered Pro at $15/mo indefinitely. All plans use daily/weekly quota system",
       "impact": "low",
       "source_url": "https://windsurf.com/pricing",
       "category": "AI Coding",
-      "alternatives": []
+      "alternatives": [],
+      "recorded_date": "2026-04-13"
     },
     {
       "vendor": "Brave Search API",
@@ -141,7 +150,8 @@
       "alternatives": [
         "SerpAPI",
         "Google Custom Search"
-      ]
+      ],
+      "recorded_date": "2026-04-15"
     },
     {
       "vendor": "X API (Twitter)",
@@ -156,7 +166,8 @@
       "alternatives": [
         "Bluesky API",
         "Mastodon API"
-      ]
+      ],
+      "recorded_date": "2026-02-25"
     },
     {
       "vendor": "Spotify API",
@@ -171,7 +182,8 @@
       "alternatives": [
         "Last.fm API",
         "MusicBrainz API"
-      ]
+      ],
+      "recorded_date": "2026-02-25"
     },
     {
       "vendor": "Amazon SP-API",
@@ -187,7 +199,8 @@
         "Shopify API",
         "WooCommerce API",
         "BigCommerce API"
-      ]
+      ],
+      "recorded_date": "2026-02-25"
     },
     {
       "vendor": "PythonAnywhere",
@@ -203,7 +216,8 @@
         "Render",
         "Railway",
         "Replit"
-      ]
+      ],
+      "recorded_date": "2026-02-25"
     },
     {
       "vendor": "Google Gemini",
@@ -219,7 +233,8 @@
         "OpenRouter",
         "Groq",
         "Together AI"
-      ]
+      ],
+      "recorded_date": "2026-03-09"
     },
     {
       "vendor": "Netlify",
@@ -235,7 +250,8 @@
         "Vercel",
         "Cloudflare Pages",
         "GitHub Pages"
-      ]
+      ],
+      "recorded_date": "2026-02-25"
     },
     {
       "vendor": "Netlify",
@@ -251,13 +267,14 @@
         "Vercel",
         "Cloudflare Pages",
         "GitHub Pages"
-      ]
+      ],
+      "recorded_date": "2026-03-31"
     },
     {
       "vendor": "Supabase",
       "change_type": "limits_reduced",
       "date": "2026-02-01",
-      "summary": "Project pause policy tightened \u2014 inactive projects now pause after 1 week",
+      "summary": "Project pause policy tightened — inactive projects now pause after 1 week",
       "previous_state": "Longer inactivity window before project pause",
       "current_state": "Projects pause after 1 week of inactivity on free tier",
       "impact": "medium",
@@ -267,19 +284,21 @@
         "Neon",
         "PlanetScale",
         "CockroachDB"
-      ]
+      ],
+      "recorded_date": "2026-02-25"
     },
     {
       "vendor": "Cloudflare",
       "change_type": "new_free_tier",
       "date": "2026-02-04",
-      "summary": "Queues added to Workers free plan \u2014 message queuing now free",
+      "summary": "Queues added to Workers free plan — message queuing now free",
       "previous_state": "Queues was paid-only",
       "current_state": "Queues included in free Workers plan",
       "impact": "medium",
       "source_url": "https://developers.cloudflare.com/queues/",
       "category": "Cloud IaaS",
-      "alternatives": []
+      "alternatives": [],
+      "recorded_date": "2026-02-25"
     },
     {
       "vendor": "GitHub Actions",
@@ -287,7 +306,7 @@
       "date": "2026-01-01",
       "summary": "Self-hosted runner per-minute fee ($0.002/min) announced for March 2026 was postponed indefinitely after community backlash. Self-hosted runners remain free. Separately, hosted runner prices were reduced up to 39% (Jan 2026)",
       "previous_state": "Self-hosted runners free. Previous per-minute pricing for hosted runners",
-      "current_state": "Self-hosted runners remain free \u2014 no orchestration fees. Hosted runners 39% cheaper. GitHub re-evaluating self-hosted pricing approach",
+      "current_state": "Self-hosted runners remain free — no orchestration fees. Hosted runners 39% cheaper. GitHub re-evaluating self-hosted pricing approach",
       "impact": "low",
       "source_url": "https://github.com/orgs/community/discussions/182089",
       "category": "CI/CD",
@@ -295,13 +314,14 @@
         "GitLab CI",
         "CircleCI",
         "Buildkite"
-      ]
+      ],
+      "recorded_date": "2026-03-14"
     },
     {
       "vendor": "Bright Data MCP",
       "change_type": "new_free_tier",
       "date": "2025-08-14",
-      "summary": "Launched free tier for MCP Web Server \u2014 5,000 requests/month for agent developers",
+      "summary": "Launched free tier for MCP Web Server — 5,000 requests/month for agent developers",
       "previous_state": "Paid-only web scraping API",
       "current_state": "5,000 free monthly requests on Rapid mode, includes search_engine and scrape_as_markdown tools, handles JS rendering and CAPTCHAs",
       "impact": "medium",
@@ -310,14 +330,15 @@
       "alternatives": [
         "Firecrawl",
         "Apify"
-      ]
+      ],
+      "recorded_date": "2026-02-25"
     },
     {
       "vendor": "Stripe",
       "change_type": "pricing_restructured",
       "date": "2026-02-01",
-      "summary": "Managed Payments (Merchant of Record) service entering general availability \u2014 Stripe handles tax, billing, fraud, and disputes",
-      "previous_state": "Payment processing only \u2014 developers handled tax compliance, fraud, and disputes separately",
+      "summary": "Managed Payments (Merchant of Record) service entering general availability — Stripe handles tax, billing, fraud, and disputes",
+      "previous_state": "Payment processing only — developers handled tax compliance, fraud, and disputes separately",
       "current_state": "Managed Payments acts as Merchant of Record in 75+ countries, handling sales tax/VAT/GST, fraud prevention, dispute resolution, and transaction-level support",
       "impact": "high",
       "source_url": "https://docs.stripe.com/payments/managed-payments",
@@ -325,7 +346,8 @@
       "alternatives": [
         "Paddle",
         "Lemon Squeezy"
-      ]
+      ],
+      "recorded_date": "2026-02-25"
     },
     {
       "vendor": "Postman",
@@ -343,14 +365,15 @@
         "Hoppscotch",
         "Apidog",
         "Thunder Client"
-      ]
+      ],
+      "recorded_date": "2026-03-17"
     },
     {
       "vendor": "Atlassian Forge",
       "change_type": "pricing_restructured",
       "date": "2026-01-01",
       "summary": "Forge platform moved from free to consumption-based billing for compute and storage",
-      "previous_state": "Entirely free \u2014 no charges for compute, storage, or KV operations",
+      "previous_state": "Entirely free — no charges for compute, storage, or KV operations",
       "current_state": "Free monthly allowances per app (100K GB-sec compute, 0.1 GB KVS, 1 GB logs, 1 hr SQL), usage above thresholds billed",
       "impact": "medium",
       "source_url": "https://www.atlassian.com/blog/developer/updates-to-forge-pricing-effective-january-2026",
@@ -358,13 +381,14 @@
       "alternatives": [
         "AWS Lambda",
         "Self-hosted Connect apps"
-      ]
+      ],
+      "recorded_date": "2026-02-25"
     },
     {
       "vendor": "Fly.io",
       "change_type": "pricing_restructured",
       "date": "2026-01-01",
-      "summary": "Volume snapshots now billed \u2014 previously free automatic snapshots now cost $0.08/GB-month",
+      "summary": "Volume snapshots now billed — previously free automatic snapshots now cost $0.08/GB-month",
       "previous_state": "Automatic volume snapshots included at no cost, enabled by default",
       "current_state": "$0.08/GB-month for snapshot storage, first 10 GB free. Snapshots can be disabled to avoid charges",
       "impact": "medium",
@@ -374,13 +398,14 @@
         "Render",
         "Railway",
         "Koyeb"
-      ]
+      ],
+      "recorded_date": "2026-02-25"
     },
     {
       "vendor": "Cloudflare Durable Objects",
       "change_type": "pricing_restructured",
       "date": "2026-01-07",
-      "summary": "SQLite storage billing began for Durable Objects \u2014 previously free during beta",
+      "summary": "SQLite storage billing began for Durable Objects — previously free during beta",
       "previous_state": "SQLite storage in Durable Objects was free during public beta (compute already billed)",
       "current_state": "Storage charged per GB-hour on Workers Paid plan, first 10 GB included. Free plan users unaffected",
       "impact": "low",
@@ -390,7 +415,8 @@
         "Upstash Redis",
         "Cloudflare KV",
         "Neon"
-      ]
+      ],
+      "recorded_date": "2026-02-25"
     },
     {
       "vendor": "Sentry",
@@ -406,13 +432,14 @@
         "Datadog",
         "New Relic",
         "BetterStack"
-      ]
+      ],
+      "recorded_date": "2026-02-25"
     },
     {
       "vendor": "Neon",
       "change_type": "pricing_restructured",
       "date": "2026-01-15",
-      "summary": "Moved to fully usage-based pricing model post-Databricks acquisition \u2014 free tier storage now per-project, projects increased 10\u2192100, branches capped at 10 per project, Neon Auth added",
+      "summary": "Moved to fully usage-based pricing model post-Databricks acquisition — free tier storage now per-project, projects increased 10→100, branches capped at 10 per project, Neon Auth added",
       "previous_state": "Free tier: 0.5 GB total storage, 191.9 compute hours, 10 projects, unlimited branches",
       "current_state": "Free tier: 0.5 GB per project (up to 5 GB across 100 projects), 100 CU-hours/month per project, 10 branches/project, Neon Auth 60K MAU, auto-scaling up to 2 CU, scale-to-zero",
       "impact": "medium",
@@ -422,13 +449,14 @@
         "Supabase",
         "CockroachDB",
         "Turso"
-      ]
+      ],
+      "recorded_date": "2026-02-26"
     },
     {
       "vendor": "Vercel",
       "change_type": "pricing_restructured",
       "date": "2026-01-01",
-      "summary": "Pro plan moved to credit-based model ($20/mo credit pool), Hobby plan metrics renamed and restructured \u2014 bandwidth\u2192Fast Data Transfer, serverless split into Active CPU + Provisioned Memory, Blob Storage and Image Transformations added",
+      "summary": "Pro plan moved to credit-based model ($20/mo credit pool), Hobby plan metrics renamed and restructured — bandwidth→Fast Data Transfer, serverless split into Active CPU + Provisioned Memory, Blob Storage and Image Transformations added",
       "previous_state": "Hobby: 100 GB bandwidth, 100 GB-hours serverless. Pro: fixed per-resource allocations",
       "current_state": "Hobby: 100 GB/mo Fast Data Transfer, 4 hrs Active CPU, 360 GB-hrs Provisioned Memory, 1M edge requests, 1 GB Blob Storage, 5K image transformations. Pro: $20/mo credit pool across all resources, SAML SSO and HIPAA included",
       "impact": "medium",
@@ -438,13 +466,14 @@
         "Netlify",
         "Cloudflare Pages",
         "Render"
-      ]
+      ],
+      "recorded_date": "2026-02-26"
     },
     {
       "vendor": "Atlassian",
       "change_type": "pricing_restructured",
       "date": "2026-02-17",
-      "summary": "Data Center pricing increased 15-40% across Jira, Confluence, and JSM. New DC licenses end March 30 \u2014 cloud mandatory for new customers",
+      "summary": "Data Center pricing increased 15-40% across Jira, Confluence, and JSM. New DC licenses end March 30 — cloud mandatory for new customers",
       "previous_state": "Standard Data Center pricing with Advantaged/legacy discounts",
       "current_state": "15% standard list increase, 18-40% for legacy Advantaged pricing tiers. No new DC licenses after March 30, 2026. Full DC end-of-life March 2029",
       "impact": "high",
@@ -454,13 +483,14 @@
         "Linear",
         "Jira Cloud",
         "Shortcut"
-      ]
+      ],
+      "recorded_date": "2026-02-26"
     },
     {
       "vendor": "Docker Hub",
       "change_type": "pricing_restructured",
       "date": "2024-12-10",
-      "summary": "Docker Pro +80% ($5\u2192$9/mo), Team +67% ($9\u2192$15/mo). Free tier: Build Cloud minutes removed, Scout repos cut 3\u21921, private repos limited to 1 with 2GB storage",
+      "summary": "Docker Pro +80% ($5→$9/mo), Team +67% ($9→$15/mo). Free tier: Build Cloud minutes removed, Scout repos cut 3→1, private repos limited to 1 with 2GB storage",
       "previous_state": "Pro $5/user/month, Team $9/user/month. Free tier included Build Cloud minutes, 3 Scout repos",
       "current_state": "Pro $9/user/month, Team $15/user/month. Free: 1 private repo (2GB), 1 Scout repo, no Build Cloud minutes, 40 pulls/hour",
       "impact": "high",
@@ -470,7 +500,8 @@
         "GitHub Container Registry",
         "Quay.io",
         "Podman"
-      ]
+      ],
+      "recorded_date": "2026-02-26"
     },
     {
       "vendor": "DigitalOcean",
@@ -486,7 +517,8 @@
         "AWS Activate",
         "Google Cloud for Startups",
         "Azure for Startups"
-      ]
+      ],
+      "recorded_date": "2026-02-26"
     },
     {
       "vendor": "Google Cloud",
@@ -502,7 +534,8 @@
         "AWS Activate",
         "Azure for Startups",
         "DigitalOcean Hatch"
-      ]
+      ],
+      "recorded_date": "2026-02-26"
     },
     {
       "vendor": "AWS",
@@ -518,7 +551,8 @@
         "Google Cloud GPUs",
         "Azure GPU VMs",
         "Lambda Cloud"
-      ]
+      ],
+      "recorded_date": "2026-02-26"
     },
     {
       "vendor": "Google",
@@ -533,7 +567,8 @@
       "alternatives": [
         "GitHub Copilot",
         "JetBrains AI"
-      ]
+      ],
+      "recorded_date": "2026-02-26"
     },
     {
       "vendor": "OpenAI",
@@ -541,7 +576,7 @@
       "date": "2026-08-26",
       "summary": "Assistants API deprecated, full shutdown August 26, 2026. Developers must migrate to Responses API + Conversations API",
       "previous_state": "Assistants API available with code interpreter, file search, function calling, and Threads for conversation management",
-      "current_state": "Deprecated. Full shutdown Aug 26, 2026. Migration required: Assistants \u2192 Prompts + Responses API, Threads \u2192 Conversations API. No automated migration tool provided",
+      "current_state": "Deprecated. Full shutdown Aug 26, 2026. Migration required: Assistants → Prompts + Responses API, Threads → Conversations API. No automated migration tool provided",
       "impact": "high",
       "source_url": "https://community.openai.com/t/assistants-api-beta-deprecation-august-26-2026-sunset/1354666",
       "category": "AI/ML",
@@ -549,14 +584,15 @@
         "Anthropic Claude API",
         "Google Gemini API",
         "Cohere API"
-      ]
+      ],
+      "recorded_date": "2026-02-26"
     },
     {
       "vendor": "Hetzner",
       "change_type": "pricing_restructured",
       "date": "2026-04-01",
-      "summary": "Cloud & dedicated server prices increasing 30-50%. Entry-level CX23: \u20ac2.99\u2192\u20ac3.99/mo (+33%). Applies to new and existing customers. Driven by DRAM (+171% YoY) and NVMe SSD cost surges from AI infrastructure demand",
-      "previous_state": "Lower cloud server pricing across Germany, Finland, US, and Singapore data centers (e.g., CX23 at \u20ac2.99/mo)",
+      "summary": "Cloud & dedicated server prices increasing 30-50%. Entry-level CX23: €2.99→€3.99/mo (+33%). Applies to new and existing customers. Driven by DRAM (+171% YoY) and NVMe SSD cost surges from AI infrastructure demand",
+      "previous_state": "Lower cloud server pricing across Germany, Finland, US, and Singapore data centers (e.g., CX23 at €2.99/mo)",
       "current_state": "30-37% increase on cloud servers, up to 50% on select dedicated/storage products. All regions and all customers (new and existing) affected. Announced Feb 23, 2026",
       "impact": "high",
       "source_url": "https://www.hetzner.com/pressroom/statement-price-adjustment/",
@@ -565,13 +601,14 @@
         "DigitalOcean",
         "Vultr",
         "OVHcloud"
-      ]
+      ],
+      "recorded_date": "2026-02-26"
     },
     {
       "vendor": "Anthropic",
       "change_type": "limits_increased",
       "date": "2026-02-05",
-      "summary": "Claude Opus 4.6 API pricing at $5/$25 per MTok (input/output) \u2014 67% below previous Opus 4/4.1 pricing of $15/$75. Frontier AI model at mid-tier prices",
+      "summary": "Claude Opus 4.6 API pricing at $5/$25 per MTok (input/output) — 67% below previous Opus 4/4.1 pricing of $15/$75. Frontier AI model at mid-tier prices",
       "previous_state": "Opus 4/4.1 priced at $15/$75 per million tokens (input/output)",
       "current_state": "Opus 4.6 at $5/$25 per MTok. Extended context (>200K tokens): $10/$37.50. Batch API: $2.50/$12.50. Price reduction began with Opus 4.5 generation",
       "impact": "high",
@@ -581,7 +618,8 @@
         "OpenAI GPT-4o",
         "Google Gemini",
         "Mistral"
-      ]
+      ],
+      "recorded_date": "2026-02-26"
     },
     {
       "vendor": "OpenAI",
@@ -597,7 +635,8 @@
         "Anthropic Claude",
         "Google Gemini",
         "Perplexity"
-      ]
+      ],
+      "recorded_date": "2026-02-26"
     },
     {
       "vendor": "Google Programmable Search Engine",
@@ -614,7 +653,8 @@
         "SerpAPI",
         "Bing Web Search API",
         "Meilisearch"
-      ]
+      ],
+      "recorded_date": "2026-02-26"
     },
     {
       "vendor": "odrive",
@@ -630,7 +670,8 @@
         "rclone",
         "Cyberduck",
         "MultCloud"
-      ]
+      ],
+      "recorded_date": "2026-02-26"
     },
     {
       "vendor": "MinIO",
@@ -647,7 +688,8 @@
         "SeaweedFS",
         "GarageHQ",
         "Apache Ozone"
-      ]
+      ],
+      "recorded_date": "2026-02-26"
     },
     {
       "vendor": "Microsoft Partner Developer Benefits",
@@ -662,7 +704,8 @@
       "alternatives": [
         "AWS Partner Network",
         "Google Cloud Partner Advantage"
-      ]
+      ],
+      "recorded_date": "2026-02-26"
     },
     {
       "vendor": "Cloudflare Startup Program",
@@ -678,7 +721,8 @@
         "AWS Activate",
         "Google for Startups Cloud Program",
         "Azure for Startups"
-      ]
+      ],
+      "recorded_date": "2026-02-26"
     },
     {
       "vendor": "Google Gemini 2.0 Flash",
@@ -695,7 +739,8 @@
         "Google Gemini 2.5 Pro",
         "OpenRouter",
         "Groq"
-      ]
+      ],
+      "recorded_date": "2026-02-26"
     },
     {
       "vendor": "Logz.io",
@@ -712,7 +757,8 @@
         "BetterStack",
         "Axiom",
         "New Relic"
-      ]
+      ],
+      "recorded_date": "2026-03-02"
     },
     {
       "vendor": "X (Twitter)",
@@ -728,7 +774,8 @@
         "Bluesky API",
         "Mastodon API",
         "Reddit API"
-      ]
+      ],
+      "recorded_date": "2026-03-02"
     },
     {
       "vendor": "OpenAI",
@@ -745,7 +792,8 @@
         "Anthropic Claude API",
         "Mistral API",
         "Groq"
-      ]
+      ],
+      "recorded_date": "2026-03-11"
     },
     {
       "vendor": "Xero Developer API",
@@ -761,7 +809,8 @@
         "QuickBooks API",
         "FreshBooks API",
         "Wave API"
-      ]
+      ],
+      "recorded_date": "2026-03-14"
     },
     {
       "vendor": "SendGrid",
@@ -778,7 +827,8 @@
         "Postmark",
         "Mailgun",
         "Amazon SES"
-      ]
+      ],
+      "recorded_date": "2026-03-02"
     },
     {
       "vendor": "Firebase",
@@ -795,7 +845,8 @@
         "Cloudflare R2",
         "AWS S3",
         "Backblaze B2"
-      ]
+      ],
+      "recorded_date": "2026-03-02"
     },
     {
       "vendor": "PlanetScale",
@@ -812,7 +863,8 @@
         "Turso",
         "Supabase",
         "CockroachDB"
-      ]
+      ],
+      "recorded_date": "2026-03-02"
     },
     {
       "vendor": "Fauna",
@@ -829,7 +881,8 @@
         "MongoDB Atlas",
         "CockroachDB",
         "DynamoDB"
-      ]
+      ],
+      "recorded_date": "2026-03-11"
     },
     {
       "vendor": "LocalStack",
@@ -845,7 +898,8 @@
         "Moto (open-source AWS mock)",
         "AWS Free Tier",
         "Testcontainers"
-      ]
+      ],
+      "recorded_date": "2026-03-02"
     },
     {
       "vendor": "Google",
@@ -862,14 +916,15 @@
         "Microsoft for Startups",
         "Google for Startups Cloud"
       ],
-      "verified_date": "2026-03-04"
+      "verified_date": "2026-03-04",
+      "recorded_date": "2026-03-11"
     },
     {
       "vendor": "Terragrunt Scale",
       "change_type": "new_free_tier",
       "date": "2025-12-15",
       "summary": "Gruntwork launches free tier for Terragrunt Scale IaC orchestration platform, positioned as HCP Terraform free tier alternative ahead of HashiCorp March 31, 2026 EOL. Includes GitOps, drift detection, and module update automation",
-      "previous_state": "No free tier \u2014 Team plan at $500/month",
+      "previous_state": "No free tier — Team plan at $500/month",
       "current_state": "Free tier with limits matching or exceeding HCP Terraform (500+ managed resources, GitOps, drift detection, Patcher)",
       "impact": "medium",
       "source_url": "https://www.gruntwork.io/blog/announcing-the-terragrunt-scale-free-tier",
@@ -878,7 +933,8 @@
         "Spacelift",
         "env0",
         "Scalr"
-      ]
+      ],
+      "recorded_date": "2026-03-04"
     },
     {
       "vendor": "HCP Terraform",
@@ -895,7 +951,8 @@
         "env0",
         "Scalr",
         "Terragrunt Scale"
-      ]
+      ],
+      "recorded_date": "2026-03-09"
     },
     {
       "vendor": "X (Twitter)",
@@ -910,7 +967,8 @@
       "alternatives": [
         "Bluesky AT Protocol",
         "Mastodon API"
-      ]
+      ],
+      "recorded_date": "2026-03-09"
     },
     {
       "vendor": "Cognition Devin",
@@ -926,7 +984,8 @@
         "GitHub Copilot",
         "Cline",
         "Aider"
-      ]
+      ],
+      "recorded_date": "2026-03-13"
     },
     {
       "vendor": "Cursor",
@@ -941,7 +1000,8 @@
       "alternatives": [
         "Windsurf",
         "GitHub Copilot"
-      ]
+      ],
+      "recorded_date": "2026-03-13"
     },
     {
       "vendor": "Augment Code",
@@ -956,13 +1016,14 @@
       "alternatives": [
         "GitHub Copilot",
         "Cursor"
-      ]
+      ],
+      "recorded_date": "2026-03-13"
     },
     {
       "vendor": "Google Tenor API",
       "change_type": "product_deprecated",
       "date": "2026-06-30",
-      "summary": "Google Tenor public API shutting down June 30, 2026. New API key signups halted January 13, 2026. Only the public GIF search API is affected \u2014 Tenor website and app continue operating. Developers must migrate to alternative GIF APIs",
+      "summary": "Google Tenor public API shutting down June 30, 2026. New API key signups halted January 13, 2026. Only the public GIF search API is affected — Tenor website and app continue operating. Developers must migrate to alternative GIF APIs",
       "previous_state": "Free public API for GIF search, trending GIFs, and autocomplete. No rate limits for reasonable use. Used by messaging apps and social platforms",
       "current_state": "API shutdown June 30, 2026. No new API keys issued since Jan 13, 2026. Existing keys work until shutdown date. No replacement API from Google",
       "impact": "high",
@@ -971,13 +1032,14 @@
       "alternatives": [
         "Giphy API",
         "Imgur API"
-      ]
+      ],
+      "recorded_date": "2026-03-14"
     },
     {
       "vendor": "Testcontainers Cloud",
       "change_type": "pricing_restructured",
       "date": "2024-06-01",
-      "summary": "Docker acquired AtomicJar (creators of Testcontainers Cloud). Standalone Testcontainers Cloud free tier retired \u2014 now bundled into Docker subscriptions. Docker Pro gets 100 min/month, Team 500 min/month, Business 1,500 min/month",
+      "summary": "Docker acquired AtomicJar (creators of Testcontainers Cloud). Standalone Testcontainers Cloud free tier retired — now bundled into Docker subscriptions. Docker Pro gets 100 min/month, Team 500 min/month, Business 1,500 min/month",
       "previous_state": "Standalone Testcontainers Cloud with independent free tier (100 min/month)",
       "current_state": "Bundled with Docker subscriptions. No standalone free tier. Open-source Testcontainers libraries remain MIT-licensed and fully free",
       "impact": "medium",
@@ -987,13 +1049,14 @@
         "Testcontainers (open-source)",
         "Docker Desktop",
         "Podman"
-      ]
+      ],
+      "recorded_date": "2026-03-14"
     },
     {
       "vendor": "Docker Desktop",
       "change_type": "pricing_restructured",
       "date": "2026-01-01",
-      "summary": "Docker Desktop subscription prices increased 67-80% across all tiers. Personal $7\u2192$11, Pro $9\u2192$14, Team $15\u2192$24, Business $24\u2192$35 per user/month. Separate from Docker Hub registry pricing changes",
+      "summary": "Docker Desktop subscription prices increased 67-80% across all tiers. Personal $7→$11, Pro $9→$14, Team $15→$24, Business $24→$35 per user/month. Separate from Docker Hub registry pricing changes",
       "previous_state": "Personal $7/user/month, Pro $9/user/month, Team $15/user/month, Business $24/user/month",
       "current_state": "Personal $11/user/month (+57%), Pro $14/user/month (+56%), Team $24/user/month (+60%), Business $35/user/month (+46%). All tiers affected",
       "impact": "high",
@@ -1003,7 +1066,8 @@
         "Podman Desktop",
         "Rancher Desktop",
         "OrbStack"
-      ]
+      ],
+      "recorded_date": "2026-03-15"
     },
     {
       "vendor": "Unity DevOps",
@@ -1019,7 +1083,8 @@
         "Git LFS",
         "Perforce",
         "GitHub"
-      ]
+      ],
+      "recorded_date": "2026-03-15"
     },
     {
       "vendor": "Anthropic Claude",
@@ -1034,7 +1099,8 @@
       "alternatives": [
         "OpenAI ChatGPT Plus",
         "Google Gemini Advanced"
-      ]
+      ],
+      "recorded_date": "2026-03-15"
     },
     {
       "vendor": "Heroku",
@@ -1051,13 +1117,14 @@
         "Railway",
         "Fly.io",
         "Koyeb"
-      ]
+      ],
+      "recorded_date": "2026-03-19"
     },
     {
       "vendor": "GitHub Copilot",
       "change_type": "new_free_tier",
       "date": "2025-12-18",
-      "summary": "GitHub launched Copilot Free tier \u2014 AI code completion available to all GitHub users at no cost. 2,000 completions and 50 chat messages per month included",
+      "summary": "GitHub launched Copilot Free tier — AI code completion available to all GitHub users at no cost. 2,000 completions and 50 chat messages per month included",
       "previous_state": "Paid only: Individual $10/month, Business $19/user/month. Free for verified students, teachers, and OSS maintainers only",
       "current_state": "Free tier: 2,000 code completions/month, 50 chat messages/month. Individual $10/month, Business $19/month, Enterprise $39/month remain for higher limits",
       "impact": "high",
@@ -1067,7 +1134,8 @@
         "Cline",
         "Cody",
         "Cursor"
-      ]
+      ],
+      "recorded_date": "2026-03-19"
     },
     {
       "vendor": "Auth0",
@@ -1083,7 +1151,8 @@
         "Clerk",
         "Firebase Auth",
         "Supabase Auth"
-      ]
+      ],
+      "recorded_date": "2026-03-19"
     },
     {
       "vendor": "Railway",
@@ -1099,7 +1168,8 @@
         "Render",
         "Fly.io",
         "Koyeb"
-      ]
+      ],
+      "recorded_date": "2026-03-19"
     },
     {
       "vendor": "Render",
@@ -1115,7 +1185,8 @@
         "Railway",
         "Fly.io",
         "Koyeb"
-      ]
+      ],
+      "recorded_date": "2026-03-19"
     },
     {
       "vendor": "Redis",
@@ -1132,7 +1203,8 @@
         "KeyDB",
         "DragonflyDB",
         "Upstash"
-      ]
+      ],
+      "recorded_date": "2026-03-19"
     },
     {
       "vendor": "HashiCorp",
@@ -1148,7 +1220,8 @@
         "OpenTofu",
         "Pulumi",
         "Crossplane"
-      ]
+      ],
+      "recorded_date": "2026-03-19"
     },
     {
       "vendor": "DigitalOcean",
@@ -1164,7 +1237,8 @@
         "Hetzner",
         "Vultr",
         "Linode"
-      ]
+      ],
+      "recorded_date": "2026-03-31"
     },
     {
       "vendor": "DigitalOcean",
@@ -1180,7 +1254,8 @@
         "Neon",
         "PlanetScale",
         "Supabase"
-      ]
+      ],
+      "recorded_date": "2026-03-21"
     },
     {
       "vendor": "Freshping",
@@ -1200,7 +1275,8 @@
         "Pulsetic",
         "Cronitor",
         "Upptime"
-      ]
+      ],
+      "recorded_date": "2026-03-21"
     },
     {
       "vendor": "Firebase",
@@ -1218,13 +1294,14 @@
         "PocketBase",
         "Nhost",
         "Convex"
-      ]
+      ],
+      "recorded_date": "2026-03-21"
     },
     {
       "vendor": "Firebase",
       "change_type": "restriction",
       "date": "2026-02-01",
-      "summary": "Spark plan projects using legacy *.appspot.com Cloud Storage buckets forced to upgrade to Blaze (pay-as-you-go) plan or lose Cloud Storage access. No billing caps on Blaze plan \u2014 developers risk unexpected charges",
+      "summary": "Spark plan projects using legacy *.appspot.com Cloud Storage buckets forced to upgrade to Blaze (pay-as-you-go) plan or lose Cloud Storage access. No billing caps on Blaze plan — developers risk unexpected charges",
       "previous_state": "Spark plan: free Cloud Storage with *.appspot.com buckets, no credit card required",
       "current_state": "Legacy bucket projects must upgrade to Blaze (pay-as-you-go). No hard billing caps. New projects use Firebase Storage buckets on Spark plan",
       "impact": "high",
@@ -1236,7 +1313,8 @@
         "PocketBase",
         "Nhost",
         "Convex"
-      ]
+      ],
+      "recorded_date": "2026-03-21"
     },
     {
       "vendor": "Dub.co",
@@ -1251,7 +1329,8 @@
       "alternatives": [
         "Bitly",
         "Short.io"
-      ]
+      ],
+      "recorded_date": "2026-03-22"
     },
     {
       "vendor": "Uploadthing",
@@ -1267,13 +1346,14 @@
         "Cloudinary",
         "Vercel Blob",
         "AWS S3"
-      ]
+      ],
+      "recorded_date": "2026-03-22"
     },
     {
       "vendor": "Neo4j AuraDB",
       "change_type": "restriction",
       "date": "2026-03-22",
-      "summary": "Data correction \u2014 previous entry incorrectly reduced limits to 50K nodes/175K relationships. Actual free tier is 200,000 nodes and 400,000 relationships per Neo4j AuraDB FAQ",
+      "summary": "Data correction — previous entry incorrectly reduced limits to 50K nodes/175K relationships. Actual free tier is 200,000 nodes and 400,000 relationships per Neo4j AuraDB FAQ",
       "previous_state": "50,000 nodes, 175,000 relationships (incorrectly listed)",
       "current_state": "200,000 nodes, 400,000 relationships (restored to correct values)",
       "impact": "low",
@@ -1282,7 +1362,8 @@
       "alternatives": [
         "Dgraph Cloud",
         "Amazon Neptune"
-      ]
+      ],
+      "recorded_date": "2026-03-22"
     },
     {
       "vendor": "xAI (Grok)",
@@ -1298,14 +1379,15 @@
         "DALL-E (credits)",
         "Stable Diffusion (self-hosted)",
         "Pollinations.AI"
-      ]
+      ],
+      "recorded_date": "2026-03-24"
     },
     {
       "vendor": "Google Gemini API",
       "change_type": "restriction",
       "date": "2026-04-01",
       "summary": "Billing-account-level spend caps enforced starting April 1, 2026. When a tier's spend cap is reached, API requests pause until the next billing month. Affects pay-as-you-go developers who may see unexpected request pausing.",
-      "previous_state": "No hard spend caps \u2014 usage billed without automatic pausing",
+      "previous_state": "No hard spend caps — usage billed without automatic pausing",
       "current_state": "Tier-level spend caps enforced at billing account level. Requests pause when cap is hit until next month",
       "impact": "medium",
       "source_url": "https://ai.google.dev/gemini-api/docs/billing",
@@ -1314,7 +1396,8 @@
         "OpenRouter",
         "Anthropic Claude API",
         "OpenAI API"
-      ]
+      ],
+      "recorded_date": "2026-03-26"
     },
     {
       "vendor": "Windsurf",
@@ -1330,14 +1413,15 @@
         "Cursor",
         "GitHub Copilot",
         "Cline"
-      ]
+      ],
+      "recorded_date": "2026-03-31"
     },
     {
       "vendor": "Gemini Code Assist",
       "change_type": "new_free_tier",
       "date": "2025-12-18",
       "summary": "Google launched Gemini Code Assist free tier for individual developers. Includes code completions, chat, and multi-file editing powered by Gemini 2.5 Pro. Available in VS Code, JetBrains, and Cloud Shell",
-      "previous_state": "No free tier \u2014 enterprise-only at $19/user/month",
+      "previous_state": "No free tier — enterprise-only at $19/user/month",
       "current_state": "Free individual tier with code completions, chat, and multi-file editing. Enterprise tier remains at $19/user/month",
       "impact": "high",
       "source_url": "https://cloud.google.com/gemini/docs/codeassist/overview",
@@ -1346,15 +1430,16 @@
         "GitHub Copilot Free",
         "Cursor",
         "Cline"
-      ]
+      ],
+      "recorded_date": "2026-03-27"
     },
     {
       "vendor": "Amazon Aurora PostgreSQL",
       "change_type": "new_free_tier",
       "date": "2026-03-25",
-      "summary": "Aurora PostgreSQL Serverless added to AWS Free Tier \u2014 managed PostgreSQL-compatible database now available at no cost with up to 4 ACUs per cluster and 1 GB storage. Part of AWS Free Plan (6 months + credits)",
-      "previous_state": "No free tier \u2014 Aurora was paid-only, starting at ~$0.08/ACU-hour",
-      "current_state": "Free plan with up to 4 ACUs per cluster, 1 GB storage, $100\u2013200 in credits for new accounts",
+      "summary": "Aurora PostgreSQL Serverless added to AWS Free Tier — managed PostgreSQL-compatible database now available at no cost with up to 4 ACUs per cluster and 1 GB storage. Part of AWS Free Plan (6 months + credits)",
+      "previous_state": "No free tier — Aurora was paid-only, starting at ~$0.08/ACU-hour",
+      "current_state": "Free plan with up to 4 ACUs per cluster, 1 GB storage, $100–200 in credits for new accounts",
       "impact": "high",
       "source_url": "https://aws.amazon.com/rds/aurora/pricing/",
       "category": "Databases",
@@ -1363,7 +1448,8 @@
         "Supabase",
         "CockroachDB",
         "PlanetScale"
-      ]
+      ],
+      "recorded_date": "2026-03-27"
     },
     {
       "vendor": "Amazon Kiro",
@@ -1380,7 +1466,8 @@
         "Windsurf",
         "GitHub Copilot",
         "Claude Code"
-      ]
+      ],
+      "recorded_date": "2026-04-08"
     },
     {
       "vendor": "Replit",
@@ -1396,7 +1483,8 @@
         "GitHub Codespaces",
         "Gitpod",
         "CodeSandbox"
-      ]
+      ],
+      "recorded_date": "2026-04-08"
     },
     {
       "vendor": "SonarQube Cloud",
@@ -1412,7 +1500,8 @@
         "CodeClimate",
         "Codacy",
         "DeepSource"
-      ]
+      ],
+      "recorded_date": "2026-04-08"
     },
     {
       "vendor": "Cursor",
@@ -1429,7 +1518,8 @@
         "Windsurf",
         "Cline",
         "Claude Code"
-      ]
+      ],
+      "recorded_date": "2026-04-08"
     },
     {
       "vendor": "Google Gemini API",
@@ -1446,7 +1536,8 @@
         "Groq",
         "Together AI",
         "Anthropic Claude API"
-      ]
+      ],
+      "recorded_date": "2026-04-08"
     },
     {
       "vendor": "OVHcloud",
@@ -1463,7 +1554,8 @@
         "DigitalOcean",
         "Vultr",
         "Linode"
-      ]
+      ],
+      "recorded_date": "2026-04-09"
     },
     {
       "vendor": "Amazon SP-API",
@@ -1471,7 +1563,7 @@
       "date": "2026-04-14",
       "summary": "Amazon SP-API per-call fees (originally April 30, 2026) postponed indefinitely following widespread developer backlash. The $1,400/year annual fee (started Jan 31) remains in effect, but per-call GET fees ($0.40/1K calls above tier allowance) have no new implementation date. Amazon cited \"additional feedback\" from developer community as reason for delay.",
       "previous_state": "Free API access for registered Amazon developers with standard rate limits",
-      "current_state": "$1,400/year annual fee active (since Jan 31). Per-call fees postponed indefinitely \u2014 no new date announced. Basic/Pro/Plus/Enterprise tiers defined but overage charges not yet enforced. Private apps remain exempt",
+      "current_state": "$1,400/year annual fee active (since Jan 31). Per-call fees postponed indefinitely — no new date announced. Basic/Pro/Plus/Enterprise tiers defined but overage charges not yet enforced. Private apps remain exempt",
       "impact": "high",
       "source_url": "https://developer-docs.amazon.com/sp-api/",
       "category": "E-Commerce",
@@ -1479,7 +1571,8 @@
         "Shopify API",
         "WooCommerce API",
         "BigCommerce API"
-      ]
+      ],
+      "recorded_date": "2026-04-14"
     },
     {
       "vendor": "Amazon Kiro",
@@ -1496,7 +1589,8 @@
         "GitHub Copilot",
         "Windsurf",
         "Claude Code"
-      ]
+      ],
+      "recorded_date": "2026-04-09"
     },
     {
       "vendor": "OpenAI",
@@ -1515,7 +1609,8 @@
         "Cloudflare Workers AI",
         "Stability AI",
         "Replicate"
-      ]
+      ],
+      "recorded_date": "2026-04-10"
     },
     {
       "vendor": "OpenAI",
@@ -1534,7 +1629,8 @@
         "Azure OpenAI Realtime",
         "ElevenLabs",
         "Google Cloud Speech-to-Text"
-      ]
+      ],
+      "recorded_date": "2026-04-10"
     },
     {
       "vendor": "AWS",
@@ -1555,7 +1651,8 @@
         "Render",
         "Fly.io",
         "DigitalOcean App Platform"
-      ]
+      ],
+      "recorded_date": "2026-04-10"
     },
     {
       "vendor": "AWS",
@@ -1572,7 +1669,8 @@
         "Windows client",
         "Mac client",
         "Web client"
-      ]
+      ],
+      "recorded_date": "2026-04-10"
     },
     {
       "vendor": "AWS",
@@ -1586,7 +1684,8 @@
       "category": "Serverless",
       "alternatives": [
         "Node.js 22 Lambda runtime"
-      ]
+      ],
+      "recorded_date": "2026-04-10"
     },
     {
       "vendor": "Google Maps",
@@ -1600,7 +1699,8 @@
       "category": "APIs",
       "alternatives": [
         "Google Maps API key authentication"
-      ]
+      ],
+      "recorded_date": "2026-04-10"
     },
     {
       "vendor": "AWS",
@@ -1614,7 +1714,8 @@
       "category": "Cloud Hosting",
       "alternatives": [
         "Fargate Platform Version 1.4.0+"
-      ]
+      ],
+      "recorded_date": "2026-04-10"
     },
     {
       "vendor": "AWS",
@@ -1630,7 +1731,8 @@
         "Istio",
         "Linkerd",
         "Amazon EKS native service mesh"
-      ]
+      ],
+      "recorded_date": "2026-04-10"
     },
     {
       "vendor": "AWS",
@@ -1646,13 +1748,14 @@
         "AWS CDK",
         "Terraform",
         "Pulumi"
-      ]
+      ],
+      "recorded_date": "2026-04-10"
     },
     {
       "vendor": "Vercel",
       "change_type": "pricing_restructured",
       "date": "2026-02-01",
-      "summary": "New Pro projects now default to Turbo build machines (30 vCPUs, 60GB memory) at $0.126/minute \u2014 9x more expensive than Standard machines ($0.014/min). Pro plan still $20/seat/month with $20 usage credit, but real-world build costs for moderate teams can hit $400+/month. Standard machines still available but must be manually selected.",
+      "summary": "New Pro projects now default to Turbo build machines (30 vCPUs, 60GB memory) at $0.126/minute — 9x more expensive than Standard machines ($0.014/min). Pro plan still $20/seat/month with $20 usage credit, but real-world build costs for moderate teams can hit $400+/month. Standard machines still available but must be manually selected.",
       "previous_state": "Pro plan: Standard build machines at $0.014/min (default). Turbo available as opt-in upgrade",
       "current_state": "Pro plan: Turbo build machines at $0.126/min (default, 30 vCPUs, 60GB RAM). Standard still available via manual opt-out. 9x cost increase for builds if not changed",
       "impact": "medium",
@@ -1663,7 +1766,8 @@
         "Cloudflare Pages",
         "Render",
         "Railway"
-      ]
+      ],
+      "recorded_date": "2026-04-10"
     },
     {
       "vendor": "Augment Code",
@@ -1679,7 +1783,8 @@
         "GitHub Copilot",
         "Cline",
         "Aider"
-      ]
+      ],
+      "recorded_date": "2026-04-12"
     },
     {
       "vendor": "Socket.dev",
@@ -1691,7 +1796,8 @@
       "impact": "low",
       "source_url": "https://socket.dev/pricing",
       "category": "Security",
-      "alternatives": []
+      "alternatives": [],
+      "recorded_date": "2026-04-12"
     },
     {
       "vendor": "LocalStack",
@@ -1703,7 +1809,8 @@
       "impact": "low",
       "source_url": "https://www.localstack.cloud/pricing",
       "category": "Testing",
-      "alternatives": []
+      "alternatives": [],
+      "recorded_date": "2026-04-12"
     },
     {
       "vendor": "Xata Lite",
@@ -1719,7 +1826,8 @@
         "Supabase",
         "PlanetScale",
         "Neon"
-      ]
+      ],
+      "recorded_date": "2026-04-12"
     },
     {
       "vendor": "stathat.com",
@@ -1734,7 +1842,8 @@
       "alternatives": [
         "Prometheus",
         "Grafana Cloud"
-      ]
+      ],
+      "recorded_date": "2026-04-12"
     },
     {
       "vendor": "Prisma Accelerate",
@@ -1746,7 +1855,8 @@
       "impact": "low",
       "source_url": "https://www.prisma.io/pricing",
       "category": "Databases",
-      "alternatives": []
+      "alternatives": [],
+      "recorded_date": "2026-04-12"
     },
     {
       "vendor": "SurrealDB Cloud",
@@ -1758,7 +1868,8 @@
       "impact": "low",
       "source_url": "https://surrealdb.com/pricing",
       "category": "Databases",
-      "alternatives": []
+      "alternatives": [],
+      "recorded_date": "2026-04-12"
     },
     {
       "vendor": "codehooks.io",
@@ -1770,7 +1881,8 @@
       "impact": "medium",
       "source_url": "https://codehooks.io/",
       "category": "Databases",
-      "alternatives": []
+      "alternatives": [],
+      "recorded_date": "2026-04-12"
     },
     {
       "vendor": "SeaTable",
@@ -1782,7 +1894,8 @@
       "impact": "low",
       "source_url": "https://seatable.io/",
       "category": "Databases",
-      "alternatives": []
+      "alternatives": [],
+      "recorded_date": "2026-04-12"
     },
     {
       "vendor": "Phase Two",
@@ -1798,7 +1911,8 @@
         "Keycloak",
         "ZITADEL",
         "SuperTokens"
-      ]
+      ],
+      "recorded_date": "2026-04-12"
     },
     {
       "vendor": "Nx Cloud",
@@ -1810,7 +1924,8 @@
       "impact": "medium",
       "source_url": "https://nx.dev/ci",
       "category": "CI/CD",
-      "alternatives": []
+      "alternatives": [],
+      "recorded_date": "2026-04-12"
     },
     {
       "vendor": "incidenthub.cloud",
@@ -1822,7 +1937,8 @@
       "impact": "medium",
       "source_url": "https://incidenthub.cloud/",
       "category": "Monitoring",
-      "alternatives": []
+      "alternatives": [],
+      "recorded_date": "2026-04-12"
     },
     {
       "vendor": "Servervana",
@@ -1837,7 +1953,8 @@
       "alternatives": [
         "UptimeObserver",
         "Xitoring"
-      ]
+      ],
+      "recorded_date": "2026-04-12"
     },
     {
       "vendor": "economize.cloud",
@@ -1849,7 +1966,8 @@
       "impact": "low",
       "source_url": "https://economize.cloud",
       "category": "Monitoring",
-      "alternatives": []
+      "alternatives": [],
+      "recorded_date": "2026-04-12"
     },
     {
       "vendor": "deployhq.com",
@@ -1861,7 +1979,8 @@
       "impact": "low",
       "source_url": "https://www.deployhq.com/",
       "category": "CI/CD",
-      "alternatives": []
+      "alternatives": [],
+      "recorded_date": "2026-04-12"
     },
     {
       "vendor": "Commerce Layer",
@@ -1873,7 +1992,8 @@
       "impact": "low",
       "source_url": "https://commercelayer.io",
       "category": "Dev Utilities",
-      "alternatives": []
+      "alternatives": [],
+      "recorded_date": "2026-04-12"
     },
     {
       "vendor": "Kiter.app",
@@ -1885,7 +2005,8 @@
       "impact": "low",
       "source_url": "https://www.kiter.app/",
       "category": "Dev Utilities",
-      "alternatives": []
+      "alternatives": [],
+      "recorded_date": "2026-04-12"
     },
     {
       "vendor": "Snap Accelerate",
@@ -1897,7 +2018,8 @@
       "impact": "low",
       "source_url": "https://developers.snapchat.com/accelerate/",
       "category": "Startup Perks",
-      "alternatives": []
+      "alternatives": [],
+      "recorded_date": "2026-04-12"
     },
     {
       "vendor": "ActiveCampaign",
@@ -1909,7 +2031,8 @@
       "impact": "low",
       "source_url": "https://segment.com/industry/startups/",
       "category": "Startup Perks",
-      "alternatives": []
+      "alternatives": [],
+      "recorded_date": "2026-04-12"
     },
     {
       "vendor": "Adjust",
@@ -1921,7 +2044,8 @@
       "impact": "low",
       "source_url": "https://segment.com/industry/startups/",
       "category": "Startup Perks",
-      "alternatives": []
+      "alternatives": [],
+      "recorded_date": "2026-04-12"
     },
     {
       "vendor": "Apptimize",
@@ -1933,7 +2057,8 @@
       "impact": "low",
       "source_url": "https://segment.com/industry/startups/",
       "category": "Startup Perks",
-      "alternatives": []
+      "alternatives": [],
+      "recorded_date": "2026-04-12"
     },
     {
       "vendor": "Attribution App",
@@ -1945,7 +2070,8 @@
       "impact": "low",
       "source_url": "https://segment.com/industry/startups/",
       "category": "Startup Perks",
-      "alternatives": []
+      "alternatives": [],
+      "recorded_date": "2026-04-12"
     },
     {
       "vendor": "Branch",
@@ -1957,7 +2083,8 @@
       "impact": "low",
       "source_url": "https://segment.com/industry/startups/",
       "category": "Startup Perks",
-      "alternatives": []
+      "alternatives": [],
+      "recorded_date": "2026-04-12"
     },
     {
       "vendor": "Chartio",
@@ -1969,7 +2096,8 @@
       "impact": "low",
       "source_url": "https://segment.com/industry/startups/",
       "category": "Startup Perks",
-      "alternatives": []
+      "alternatives": [],
+      "recorded_date": "2026-04-12"
     },
     {
       "vendor": "ClearBrain",
@@ -1981,7 +2109,8 @@
       "impact": "low",
       "source_url": "https://segment.com/industry/startups/",
       "category": "Startup Perks",
-      "alternatives": []
+      "alternatives": [],
+      "recorded_date": "2026-04-12"
     },
     {
       "vendor": "Commando.io",
@@ -1993,7 +2122,8 @@
       "impact": "low",
       "source_url": "https://www.userlike.com/en/blog/startup-deals",
       "category": "Startup Perks",
-      "alternatives": []
+      "alternatives": [],
+      "recorded_date": "2026-04-12"
     },
     {
       "vendor": "CrazyEgg",
@@ -2005,7 +2135,8 @@
       "impact": "low",
       "source_url": "https://www.userlike.com/en/blog/startup-deals",
       "category": "Startup Perks",
-      "alternatives": []
+      "alternatives": [],
+      "recorded_date": "2026-04-12"
     },
     {
       "vendor": "Cyfe",
@@ -2017,7 +2148,8 @@
       "impact": "low",
       "source_url": "https://www.userlike.com/en/blog/startup-deals",
       "category": "Startup Perks",
-      "alternatives": []
+      "alternatives": [],
+      "recorded_date": "2026-04-12"
     },
     {
       "vendor": "Drift",
@@ -2029,7 +2161,8 @@
       "impact": "low",
       "source_url": "https://segment.com/industry/startups/",
       "category": "Startup Perks",
-      "alternatives": []
+      "alternatives": [],
+      "recorded_date": "2026-04-12"
     },
     {
       "vendor": "FullContact",
@@ -2041,7 +2174,8 @@
       "impact": "low",
       "source_url": "https://www.userlike.com/en/blog/startup-deals",
       "category": "Startup Perks",
-      "alternatives": []
+      "alternatives": [],
+      "recorded_date": "2026-04-12"
     },
     {
       "vendor": "Gem",
@@ -2053,7 +2187,8 @@
       "impact": "low",
       "source_url": "https://stripe.com/en-de/corporate-card",
       "category": "Startup Perks",
-      "alternatives": []
+      "alternatives": [],
+      "recorded_date": "2026-04-12"
     },
     {
       "vendor": "Google BigQuery",
@@ -2065,7 +2200,8 @@
       "impact": "low",
       "source_url": "https://segment.com/industry/startups/",
       "category": "Startup Perks",
-      "alternatives": []
+      "alternatives": [],
+      "recorded_date": "2026-04-12"
     },
     {
       "vendor": "Guideline",
@@ -2077,7 +2213,8 @@
       "impact": "low",
       "source_url": "https://stripe.com/en-de/corporate-card",
       "category": "Startup Perks",
-      "alternatives": []
+      "alternatives": [],
+      "recorded_date": "2026-04-12"
     },
     {
       "vendor": "Gusto",
@@ -2089,7 +2226,8 @@
       "impact": "low",
       "source_url": "https://stripe.com/en-de/corporate-card",
       "category": "Startup Perks",
-      "alternatives": []
+      "alternatives": [],
+      "recorded_date": "2026-04-12"
     },
     {
       "vendor": "Kasa",
@@ -2101,7 +2239,8 @@
       "impact": "low",
       "source_url": "https://stripe.com/en-de/corporate-card",
       "category": "Startup Perks",
-      "alternatives": []
+      "alternatives": [],
+      "recorded_date": "2026-04-12"
     },
     {
       "vendor": "Lester Lee",
@@ -2113,7 +2252,8 @@
       "impact": "low",
       "source_url": "https://segment.com/industry/startups/",
       "category": "Startup Perks",
-      "alternatives": []
+      "alternatives": [],
+      "recorded_date": "2026-04-12"
     },
     {
       "vendor": "Looker",
@@ -2125,7 +2265,8 @@
       "impact": "low",
       "source_url": "https://segment.com/industry/startups/",
       "category": "Startup Perks",
-      "alternatives": []
+      "alternatives": [],
+      "recorded_date": "2026-04-12"
     },
     {
       "vendor": "Mode",
@@ -2137,7 +2278,8 @@
       "impact": "low",
       "source_url": "https://segment.com/industry/startups/",
       "category": "Startup Perks",
-      "alternatives": []
+      "alternatives": [],
+      "recorded_date": "2026-04-12"
     },
     {
       "vendor": "MoEngage",
@@ -2149,7 +2291,8 @@
       "impact": "low",
       "source_url": "https://segment.com/industry/startups/",
       "category": "Startup Perks",
-      "alternatives": []
+      "alternatives": [],
+      "recorded_date": "2026-04-12"
     },
     {
       "vendor": "Monday",
@@ -2161,7 +2304,8 @@
       "impact": "low",
       "source_url": "https://www.userlike.com/en/blog/startup-deals",
       "category": "Startup Perks",
-      "alternatives": []
+      "alternatives": [],
+      "recorded_date": "2026-04-12"
     },
     {
       "vendor": "PersistIQ",
@@ -2173,7 +2317,8 @@
       "impact": "low",
       "source_url": "https://segment.com/industry/startups/",
       "category": "Startup Perks",
-      "alternatives": []
+      "alternatives": [],
+      "recorded_date": "2026-04-12"
     },
     {
       "vendor": "Pilot",
@@ -2185,7 +2330,8 @@
       "impact": "low",
       "source_url": "https://stripe.com/en-de/corporate-card",
       "category": "Startup Perks",
-      "alternatives": []
+      "alternatives": [],
+      "recorded_date": "2026-04-12"
     },
     {
       "vendor": "Polymail",
@@ -2197,7 +2343,8 @@
       "impact": "low",
       "source_url": "https://www.userlike.com/en/blog/startup-deals",
       "category": "Startup Perks",
-      "alternatives": []
+      "alternatives": [],
+      "recorded_date": "2026-04-12"
     },
     {
       "vendor": "ProofHub",
@@ -2209,7 +2356,8 @@
       "impact": "low",
       "source_url": "https://www.userlike.com/en/blog/startup-deals",
       "category": "Startup Perks",
-      "alternatives": []
+      "alternatives": [],
+      "recorded_date": "2026-04-12"
     },
     {
       "vendor": "Seekwell",
@@ -2221,7 +2369,8 @@
       "impact": "low",
       "source_url": "https://segment.com/industry/startups/",
       "category": "Startup Perks",
-      "alternatives": []
+      "alternatives": [],
+      "recorded_date": "2026-04-12"
     },
     {
       "vendor": "Shopify",
@@ -2233,7 +2382,8 @@
       "impact": "low",
       "source_url": "https://stripe.com/en-de/corporate-card",
       "category": "Startup Perks",
-      "alternatives": []
+      "alternatives": [],
+      "recorded_date": "2026-04-12"
     },
     {
       "vendor": "Split",
@@ -2245,7 +2395,8 @@
       "impact": "low",
       "source_url": "https://segment.com/industry/startups/",
       "category": "Startup Perks",
-      "alternatives": []
+      "alternatives": [],
+      "recorded_date": "2026-04-12"
     },
     {
       "vendor": "Userlike",
@@ -2257,7 +2408,8 @@
       "impact": "low",
       "source_url": "https://www.userlike.com/en/blog/startup-deals",
       "category": "Startup Perks",
-      "alternatives": []
+      "alternatives": [],
+      "recorded_date": "2026-04-12"
     },
     {
       "vendor": "Vero",
@@ -2269,7 +2421,8 @@
       "impact": "low",
       "source_url": "https://segment.com/industry/startups/",
       "category": "Startup Perks",
-      "alternatives": []
+      "alternatives": [],
+      "recorded_date": "2026-04-12"
     },
     {
       "vendor": "Vervoe",
@@ -2281,7 +2434,8 @@
       "impact": "low",
       "source_url": "https://segment.com/industry/startups/",
       "category": "Startup Perks",
-      "alternatives": []
+      "alternatives": [],
+      "recorded_date": "2026-04-12"
     },
     {
       "vendor": "APITemplate.io",
@@ -2293,7 +2447,8 @@
       "impact": "low",
       "source_url": "https://apitemplate.io",
       "category": "Dev Utilities",
-      "alternatives": []
+      "alternatives": [],
+      "recorded_date": "2026-04-12"
     },
     {
       "vendor": "Conversion Tools",
@@ -2305,7 +2460,8 @@
       "impact": "low",
       "source_url": "https://conversiontools.io/",
       "category": "Dev Utilities",
-      "alternatives": []
+      "alternatives": [],
+      "recorded_date": "2026-04-12"
     },
     {
       "vendor": "CraftMyPDF",
@@ -2317,7 +2473,8 @@
       "impact": "low",
       "source_url": "https://craftmypdf.com",
       "category": "Dev Utilities",
-      "alternatives": []
+      "alternatives": [],
+      "recorded_date": "2026-04-12"
     },
     {
       "vendor": "CurrencyScoop",
@@ -2329,7 +2486,8 @@
       "impact": "low",
       "source_url": "https://currencybeacon.com/",
       "category": "Dev Utilities",
-      "alternatives": []
+      "alternatives": [],
+      "recorded_date": "2026-04-12"
     },
     {
       "vendor": "CustomJS",
@@ -2341,7 +2499,8 @@
       "impact": "low",
       "source_url": "https://customjs.space/",
       "category": "Dev Utilities",
-      "alternatives": []
+      "alternatives": [],
+      "recorded_date": "2026-04-12"
     },
     {
       "vendor": "DiffJSON",
@@ -2353,7 +2512,8 @@
       "impact": "low",
       "source_url": "https://comparejson.com/",
       "category": "Dev Utilities",
-      "alternatives": []
+      "alternatives": [],
+      "recorded_date": "2026-04-12"
     },
     {
       "vendor": "UniRateAPI",
@@ -2365,7 +2525,8 @@
       "impact": "low",
       "source_url": "https://unirateapi.com",
       "category": "Dev Utilities",
-      "alternatives": []
+      "alternatives": [],
+      "recorded_date": "2026-04-12"
     },
     {
       "vendor": "PDFMonkey",
@@ -2377,19 +2538,21 @@
       "impact": "low",
       "source_url": "https://www.pdfmonkey.io/",
       "category": "Dev Utilities",
-      "alternatives": []
+      "alternatives": [],
+      "recorded_date": "2026-04-12"
     },
     {
       "vendor": "redirect.pizza",
       "change_type": "pricing_restructured",
       "date": "2026-04-12",
-      "summary": "Free plan changed: sources reduced 10\u21925 domains, but hits increased 100K\u2192250K requests",
+      "summary": "Free plan changed: sources reduced 10→5 domains, but hits increased 100K→250K requests",
       "previous_state": "10 sources, 100,000 hits/month",
       "current_state": "5 domains, 250,000 requests/month",
       "impact": "low",
       "source_url": "https://redirect.pizza/",
       "category": "Dev Utilities",
-      "alternatives": []
+      "alternatives": [],
+      "recorded_date": "2026-04-12"
     },
     {
       "vendor": "Renamer.ai",
@@ -2401,7 +2564,8 @@
       "impact": "low",
       "source_url": "https://renamer.ai",
       "category": "Dev Utilities",
-      "alternatives": []
+      "alternatives": [],
+      "recorded_date": "2026-04-12"
     },
     {
       "vendor": "FeedBear",
@@ -2413,7 +2577,8 @@
       "impact": "low",
       "source_url": "https://www.feedbear.com/early-stage",
       "category": "Startup Perks",
-      "alternatives": []
+      "alternatives": [],
+      "recorded_date": "2026-04-12"
     },
     {
       "vendor": "Backlight",
@@ -2425,7 +2590,8 @@
       "impact": "low",
       "source_url": "",
       "category": "Design",
-      "alternatives": []
+      "alternatives": [],
+      "recorded_date": "2026-04-12"
     },
     {
       "vendor": "Branition Colors",
@@ -2437,7 +2603,8 @@
       "impact": "low",
       "source_url": "",
       "category": "Design",
-      "alternatives": []
+      "alternatives": [],
+      "recorded_date": "2026-04-12"
     },
     {
       "vendor": "MovingPencils",
@@ -2449,7 +2616,8 @@
       "impact": "low",
       "source_url": "",
       "category": "Design",
-      "alternatives": []
+      "alternatives": [],
+      "recorded_date": "2026-04-12"
     },
     {
       "vendor": "Free For Commercial Use",
@@ -2461,19 +2629,21 @@
       "impact": "low",
       "source_url": "",
       "category": "Design",
-      "alternatives": []
+      "alternatives": [],
+      "recorded_date": "2026-04-12"
     },
     {
       "vendor": "Pixelixe",
       "change_type": "free_tier_removed",
       "date": "2026-04-12",
-      "summary": "No longer free \u2014 paid plans start at $12/mo",
+      "summary": "No longer free — paid plans start at $12/mo",
       "previous_state": "",
-      "current_state": "No longer free \u2014 paid plans start at $12/mo",
+      "current_state": "No longer free — paid plans start at $12/mo",
       "impact": "low",
       "source_url": "",
       "category": "Design",
-      "alternatives": []
+      "alternatives": [],
+      "recorded_date": "2026-04-12"
     },
     {
       "vendor": "WalkMe",
@@ -2485,7 +2655,8 @@
       "impact": "low",
       "source_url": "",
       "category": "Design",
-      "alternatives": []
+      "alternatives": [],
+      "recorded_date": "2026-04-12"
     },
     {
       "vendor": "NextUI",
@@ -2497,7 +2668,8 @@
       "impact": "low",
       "source_url": "",
       "category": "Design",
-      "alternatives": []
+      "alternatives": [],
+      "recorded_date": "2026-04-12"
     },
     {
       "vendor": "Landen",
@@ -2509,7 +2681,8 @@
       "impact": "low",
       "source_url": "",
       "category": "Design",
-      "alternatives": []
+      "alternatives": [],
+      "recorded_date": "2026-04-12"
     },
     {
       "vendor": "Whimsical",
@@ -2521,19 +2694,21 @@
       "impact": "low",
       "source_url": "",
       "category": "Design",
-      "alternatives": []
+      "alternatives": [],
+      "recorded_date": "2026-04-12"
     },
     {
       "vendor": "Contact.do",
       "change_type": "free_tier_removed",
       "date": "2026-04-12",
-      "summary": "No longer free \u2014 $19 lifetime only",
+      "summary": "No longer free — $19 lifetime only",
       "previous_state": "",
-      "current_state": "No longer free \u2014 $19 lifetime only",
+      "current_state": "No longer free — $19 lifetime only",
       "impact": "low",
       "source_url": "",
       "category": "Email",
-      "alternatives": []
+      "alternatives": [],
+      "recorded_date": "2026-04-12"
     },
     {
       "vendor": "MailerLite",
@@ -2545,7 +2720,8 @@
       "impact": "low",
       "source_url": "",
       "category": "Email",
-      "alternatives": []
+      "alternatives": [],
+      "recorded_date": "2026-04-12"
     },
     {
       "vendor": "MailerSend",
@@ -2557,7 +2733,8 @@
       "impact": "low",
       "source_url": "",
       "category": "Email",
-      "alternatives": []
+      "alternatives": [],
+      "recorded_date": "2026-04-12"
     },
     {
       "vendor": "Plunk",
@@ -2569,7 +2746,8 @@
       "impact": "low",
       "source_url": "",
       "category": "Email",
-      "alternatives": []
+      "alternatives": [],
+      "recorded_date": "2026-04-12"
     },
     {
       "vendor": "Maileroo",
@@ -2581,7 +2759,8 @@
       "impact": "low",
       "source_url": "",
       "category": "Email",
-      "alternatives": []
+      "alternatives": [],
+      "recorded_date": "2026-04-12"
     },
     {
       "vendor": "Mailtrap",
@@ -2593,7 +2772,8 @@
       "impact": "low",
       "source_url": "",
       "category": "Email",
-      "alternatives": []
+      "alternatives": [],
+      "recorded_date": "2026-04-12"
     },
     {
       "vendor": "AnonAddy",
@@ -2605,7 +2785,8 @@
       "impact": "low",
       "source_url": "",
       "category": "Email",
-      "alternatives": []
+      "alternatives": [],
+      "recorded_date": "2026-04-12"
     },
     {
       "vendor": "Bump Email",
@@ -2617,19 +2798,21 @@
       "impact": "low",
       "source_url": "",
       "category": "Email",
-      "alternatives": []
+      "alternatives": [],
+      "recorded_date": "2026-04-12"
     },
     {
       "vendor": "Parsio",
       "change_type": "free_tier_removed",
       "date": "2026-04-12",
-      "summary": "No ongoing free tier \u2014 30 trial credits only",
+      "summary": "No ongoing free tier — 30 trial credits only",
       "previous_state": "",
-      "current_state": "No ongoing free tier \u2014 30 trial credits only",
+      "current_state": "No ongoing free tier — 30 trial credits only",
       "impact": "low",
       "source_url": "",
       "category": "Email",
-      "alternatives": []
+      "alternatives": [],
+      "recorded_date": "2026-04-12"
     },
     {
       "vendor": "Maildroppa",
@@ -2641,7 +2824,8 @@
       "impact": "low",
       "source_url": "",
       "category": "Email",
-      "alternatives": []
+      "alternatives": [],
+      "recorded_date": "2026-04-12"
     },
     {
       "vendor": "Kitemaker",
@@ -2653,7 +2837,8 @@
       "impact": "low",
       "source_url": "",
       "category": "Project Management",
-      "alternatives": []
+      "alternatives": [],
+      "recorded_date": "2026-04-12"
     },
     {
       "vendor": "sflow.io",
@@ -2665,43 +2850,47 @@
       "impact": "low",
       "source_url": "",
       "category": "Project Management",
-      "alternatives": []
+      "alternatives": [],
+      "recorded_date": "2026-04-12"
     },
     {
       "vendor": "Quidlo",
       "change_type": "free_tier_removed",
       "date": "2026-04-12",
-      "summary": "No free tier \u2014 30-day trial only",
+      "summary": "No free tier — 30-day trial only",
       "previous_state": "",
-      "current_state": "No free tier \u2014 30-day trial only",
+      "current_state": "No free tier — 30-day trial only",
       "impact": "low",
       "source_url": "",
       "category": "Project Management",
-      "alternatives": []
+      "alternatives": [],
+      "recorded_date": "2026-04-12"
     },
     {
       "vendor": "Teamhood",
       "change_type": "free_tier_removed",
       "date": "2026-04-12",
-      "summary": "No free tier \u2014 14-day trial only",
+      "summary": "No free tier — 14-day trial only",
       "previous_state": "",
-      "current_state": "No free tier \u2014 14-day trial only",
+      "current_state": "No free tier — 14-day trial only",
       "impact": "low",
       "source_url": "",
       "category": "Project Management",
-      "alternatives": []
+      "alternatives": [],
+      "recorded_date": "2026-04-12"
     },
     {
       "vendor": "Zenkit",
       "change_type": "free_tier_removed",
       "date": "2026-04-12",
-      "summary": "No free tier \u2014 trial only, then data export only",
+      "summary": "No free tier — trial only, then data export only",
       "previous_state": "",
-      "current_state": "No free tier \u2014 trial only, then data export only",
+      "current_state": "No free tier — trial only, then data export only",
       "impact": "low",
       "source_url": "",
       "category": "Project Management",
-      "alternatives": []
+      "alternatives": [],
+      "recorded_date": "2026-04-12"
     },
     {
       "vendor": "HeySpace",
@@ -2713,7 +2902,8 @@
       "impact": "low",
       "source_url": "",
       "category": "Project Management",
-      "alternatives": []
+      "alternatives": [],
+      "recorded_date": "2026-04-12"
     },
     {
       "vendor": "Wikifactory",
@@ -2725,7 +2915,8 @@
       "impact": "low",
       "source_url": "",
       "category": "Project Management",
-      "alternatives": []
+      "alternatives": [],
+      "recorded_date": "2026-04-12"
     },
     {
       "vendor": "Teleretro",
@@ -2737,7 +2928,8 @@
       "impact": "low",
       "source_url": "",
       "category": "Project Management",
-      "alternatives": []
+      "alternatives": [],
+      "recorded_date": "2026-04-12"
     },
     {
       "vendor": "MeScrum",
@@ -2749,7 +2941,8 @@
       "impact": "low",
       "source_url": "",
       "category": "Project Management",
-      "alternatives": []
+      "alternatives": [],
+      "recorded_date": "2026-04-12"
     },
     {
       "vendor": "Protectumus",
@@ -2761,19 +2954,21 @@
       "impact": "low",
       "source_url": "",
       "category": "Security",
-      "alternatives": []
+      "alternatives": [],
+      "recorded_date": "2026-04-12"
     },
     {
       "vendor": "HostedScan",
       "change_type": "free_tier_removed",
       "date": "2026-04-12",
-      "summary": "No free tier \u2014 plans start at $49/mo",
+      "summary": "No free tier — plans start at $49/mo",
       "previous_state": "",
-      "current_state": "No free tier \u2014 plans start at $49/mo",
+      "current_state": "No free tier — plans start at $49/mo",
       "impact": "low",
       "source_url": "",
       "category": "Security",
-      "alternatives": []
+      "alternatives": [],
+      "recorded_date": "2026-04-12"
     },
     {
       "vendor": "StackHawk",
@@ -2785,7 +2980,8 @@
       "impact": "low",
       "source_url": "",
       "category": "Security",
-      "alternatives": []
+      "alternatives": [],
+      "recorded_date": "2026-04-12"
     },
     {
       "vendor": "CookieFirst",
@@ -2797,19 +2993,21 @@
       "impact": "low",
       "source_url": "",
       "category": "Security",
-      "alternatives": []
+      "alternatives": [],
+      "recorded_date": "2026-04-12"
     },
     {
       "vendor": "Tailscale",
       "change_type": "limits_increased",
       "date": "2026-04-12",
-      "summary": "Free tier expanded: 3\u21926 users, 100\u2192unlimited devices",
+      "summary": "Free tier expanded: 3→6 users, 100→unlimited devices",
       "previous_state": "",
-      "current_state": "Free tier expanded: 3\u21926 users, 100\u2192unlimited devices",
+      "current_state": "Free tier expanded: 3→6 users, 100→unlimited devices",
       "impact": "low",
       "source_url": "",
       "category": "Security",
-      "alternatives": []
+      "alternatives": [],
+      "recorded_date": "2026-04-12"
     },
     {
       "vendor": "PyUp",
@@ -2821,7 +3019,8 @@
       "impact": "low",
       "source_url": "",
       "category": "Security",
-      "alternatives": []
+      "alternatives": [],
+      "recorded_date": "2026-04-12"
     },
     {
       "vendor": "LibreQR",
@@ -2833,19 +3032,21 @@
       "impact": "low",
       "source_url": "",
       "category": "Storage",
-      "alternatives": []
+      "alternatives": [],
+      "recorded_date": "2026-04-12"
     },
     {
       "vendor": "Redbooth",
       "change_type": "product_deprecated",
       "date": "2026-04-12",
-      "summary": "Not a P2P file syncing service \u2014 mischaracterized (PM tool)",
+      "summary": "Not a P2P file syncing service — mischaracterized (PM tool)",
       "previous_state": "",
-      "current_state": "Not a P2P file syncing service \u2014 mischaracterized (PM tool)",
+      "current_state": "Not a P2P file syncing service — mischaracterized (PM tool)",
       "impact": "low",
       "source_url": "",
       "category": "Storage",
-      "alternatives": []
+      "alternatives": [],
+      "recorded_date": "2026-04-12"
     },
     {
       "vendor": "Kraken.io",
@@ -2857,7 +3058,8 @@
       "impact": "low",
       "source_url": "",
       "category": "Storage",
-      "alternatives": []
+      "alternatives": [],
+      "recorded_date": "2026-04-12"
     },
     {
       "vendor": "Otixo",
@@ -2869,7 +3071,8 @@
       "impact": "low",
       "source_url": "",
       "category": "Storage",
-      "alternatives": []
+      "alternatives": [],
+      "recorded_date": "2026-04-12"
     },
     {
       "vendor": "Userbird",
@@ -2881,7 +3084,8 @@
       "impact": "low",
       "source_url": "",
       "category": "Analytics",
-      "alternatives": []
+      "alternatives": [],
+      "recorded_date": "2026-04-12"
     },
     {
       "vendor": "Seline",
@@ -2893,7 +3097,8 @@
       "impact": "low",
       "source_url": "",
       "category": "Analytics",
-      "alternatives": []
+      "alternatives": [],
+      "recorded_date": "2026-04-12"
     },
     {
       "vendor": "Segment Startups",
@@ -2905,7 +3110,8 @@
       "impact": "low",
       "source_url": "",
       "category": "Analytics",
-      "alternatives": []
+      "alternatives": [],
+      "recorded_date": "2026-04-12"
     },
     {
       "vendor": "Census",
@@ -2917,7 +3123,8 @@
       "impact": "low",
       "source_url": "",
       "category": "Analytics",
-      "alternatives": []
+      "alternatives": [],
+      "recorded_date": "2026-04-12"
     },
     {
       "vendor": "UsabilityHub",
@@ -2929,7 +3136,8 @@
       "impact": "low",
       "source_url": "",
       "category": "Analytics",
-      "alternatives": []
+      "alternatives": [],
+      "recorded_date": "2026-04-12"
     },
     {
       "vendor": "Hotjar",
@@ -2941,19 +3149,21 @@
       "impact": "low",
       "source_url": "",
       "category": "Analytics",
-      "alternatives": []
+      "alternatives": [],
+      "recorded_date": "2026-04-12"
     },
     {
       "vendor": "FullStory",
       "change_type": "limits_increased",
       "date": "2026-04-12",
-      "summary": "Free tier increased from 1,000 to 30,000 sessions/month, retention 1\u219212 months",
+      "summary": "Free tier increased from 1,000 to 30,000 sessions/month, retention 1→12 months",
       "previous_state": "",
-      "current_state": "Free tier increased from 1,000 to 30,000 sessions/month, retention 1\u219212 months",
+      "current_state": "Free tier increased from 1,000 to 30,000 sessions/month, retention 1→12 months",
       "impact": "low",
       "source_url": "",
       "category": "Analytics",
-      "alternatives": []
+      "alternatives": [],
+      "recorded_date": "2026-04-12"
     },
     {
       "vendor": "Smartlook",
@@ -2965,7 +3175,8 @@
       "impact": "low",
       "source_url": "",
       "category": "Analytics",
-      "alternatives": []
+      "alternatives": [],
+      "recorded_date": "2026-04-12"
     },
     {
       "vendor": "UXtweak",
@@ -2977,19 +3188,21 @@
       "impact": "low",
       "source_url": "",
       "category": "Analytics",
-      "alternatives": []
+      "alternatives": [],
+      "recorded_date": "2026-04-12"
     },
     {
       "vendor": "Zoho Subscriptions",
       "change_type": "free_tier_removed",
       "date": "2026-04-13",
-      "summary": "Rebranded to Zoho Billing, free tier discontinued \u2014 paid-only with 14-day trial",
+      "summary": "Rebranded to Zoho Billing, free tier discontinued — paid-only with 14-day trial",
       "previous_state": "",
-      "current_state": "Rebranded to Zoho Billing, free tier discontinued \u2014 paid-only with 14-day trial",
+      "current_state": "Rebranded to Zoho Billing, free tier discontinued — paid-only with 14-day trial",
       "impact": "low",
       "source_url": "",
       "category": "Cloud IaaS",
-      "alternatives": []
+      "alternatives": [],
+      "recorded_date": "2026-04-13"
     },
     {
       "vendor": "API-Ninjas",
@@ -3001,7 +3214,8 @@
       "impact": "low",
       "source_url": "",
       "category": "API Development",
-      "alternatives": []
+      "alternatives": [],
+      "recorded_date": "2026-04-13"
     },
     {
       "vendor": "HeyForm",
@@ -3013,7 +3227,8 @@
       "impact": "low",
       "source_url": "",
       "category": "Forms",
-      "alternatives": []
+      "alternatives": [],
+      "recorded_date": "2026-04-13"
     },
     {
       "vendor": "Codiga",
@@ -3025,19 +3240,21 @@
       "impact": "low",
       "source_url": "",
       "category": "IDE & Code Editors",
-      "alternatives": []
+      "alternatives": [],
+      "recorded_date": "2026-04-13"
     },
     {
       "vendor": "xAI",
       "change_type": "free_tier_removed",
       "date": "2026-04-13",
-      "summary": "$25/month free API credits no longer offered \u2014 Grok API paid-only",
+      "summary": "$25/month free API credits no longer offered — Grok API paid-only",
       "previous_state": "",
-      "current_state": "$25/month free API credits no longer offered \u2014 Grok API paid-only",
+      "current_state": "$25/month free API credits no longer offered — Grok API paid-only",
       "impact": "low",
       "source_url": "",
       "category": "AI / ML",
-      "alternatives": []
+      "alternatives": [],
+      "recorded_date": "2026-04-13"
     },
     {
       "vendor": "Clarifai",
@@ -3049,7 +3266,8 @@
       "impact": "low",
       "source_url": "",
       "category": "AI / ML",
-      "alternatives": []
+      "alternatives": [],
+      "recorded_date": "2026-04-13"
     },
     {
       "vendor": "Typeform",
@@ -3061,7 +3279,8 @@
       "impact": "low",
       "source_url": "",
       "category": "Forms",
-      "alternatives": []
+      "alternatives": [],
+      "recorded_date": "2026-04-13"
     },
     {
       "vendor": "CodeRabbit",
@@ -3073,7 +3292,8 @@
       "impact": "low",
       "source_url": "",
       "category": "Code Quality",
-      "alternatives": []
+      "alternatives": [],
+      "recorded_date": "2026-04-13"
     },
     {
       "vendor": "SwaggerHub",
@@ -3085,7 +3305,8 @@
       "impact": "low",
       "source_url": "",
       "category": "API Development",
-      "alternatives": []
+      "alternatives": [],
+      "recorded_date": "2026-04-13"
     },
     {
       "vendor": "Stickies.app",
@@ -3097,7 +3318,8 @@
       "impact": "low",
       "source_url": "",
       "category": "Team Collaboration",
-      "alternatives": []
+      "alternatives": [],
+      "recorded_date": "2026-04-13"
     },
     {
       "vendor": "Katalon",
@@ -3109,7 +3331,8 @@
       "impact": "low",
       "source_url": "",
       "category": "Testing",
-      "alternatives": []
+      "alternatives": [],
+      "recorded_date": "2026-04-13"
     },
     {
       "vendor": "TestingBot",
@@ -3121,19 +3344,21 @@
       "impact": "low",
       "source_url": "",
       "category": "Testing",
-      "alternatives": []
+      "alternatives": [],
+      "recorded_date": "2026-04-13"
     },
     {
       "vendor": "Knowlarity",
       "change_type": "free_tier_removed",
       "date": "2026-04-13",
-      "summary": "Free startup credits no longer visible, paid from \u20b916,800/year",
+      "summary": "Free startup credits no longer visible, paid from ₹16,800/year",
       "previous_state": "",
-      "current_state": "Free startup credits no longer visible, paid from \u20b916,800/year",
+      "current_state": "Free startup credits no longer visible, paid from ₹16,800/year",
       "impact": "low",
       "source_url": "",
       "category": "Communication",
-      "alternatives": []
+      "alternatives": [],
+      "recorded_date": "2026-04-13"
     },
     {
       "vendor": "microlink.io",
@@ -3145,7 +3370,8 @@
       "impact": "low",
       "source_url": "",
       "category": "Web Scraping",
-      "alternatives": []
+      "alternatives": [],
+      "recorded_date": "2026-04-13"
     },
     {
       "vendor": "Firecrawl",
@@ -3157,7 +3383,8 @@
       "impact": "low",
       "source_url": "",
       "category": "Web Scraping",
-      "alternatives": []
+      "alternatives": [],
+      "recorded_date": "2026-04-13"
     },
     {
       "vendor": "filebase.com",
@@ -3169,7 +3396,8 @@
       "impact": "low",
       "source_url": "",
       "category": "Cloud IaaS",
-      "alternatives": []
+      "alternatives": [],
+      "recorded_date": "2026-04-13"
     },
     {
       "vendor": "Pocket Alert",
@@ -3181,7 +3409,8 @@
       "impact": "low",
       "source_url": "",
       "category": "Messaging",
-      "alternatives": []
+      "alternatives": [],
+      "recorded_date": "2026-04-13"
     },
     {
       "vendor": "Stoplight",
@@ -3193,7 +3422,8 @@
       "impact": "low",
       "source_url": "",
       "category": "API Development",
-      "alternatives": []
+      "alternatives": [],
+      "recorded_date": "2026-04-13"
     },
     {
       "vendor": "Google Maps Platform",
@@ -3205,7 +3435,8 @@
       "impact": "low",
       "source_url": "",
       "category": "Maps/Geolocation",
-      "alternatives": []
+      "alternatives": [],
+      "recorded_date": "2026-04-13"
     },
     {
       "vendor": "PubNub",
@@ -3217,19 +3448,21 @@
       "impact": "low",
       "source_url": "",
       "category": "Messaging",
-      "alternatives": []
+      "alternatives": [],
+      "recorded_date": "2026-04-13"
     },
     {
       "vendor": "Zoho Meeting",
       "change_type": "pricing_restructured",
       "date": "2026-04-13",
-      "summary": "Participants increased 3\u2192100 but 60-minute duration limit added",
+      "summary": "Participants increased 3→100 but 60-minute duration limit added",
       "previous_state": "",
-      "current_state": "Participants increased 3\u2192100 but 60-minute duration limit added",
+      "current_state": "Participants increased 3→100 but 60-minute duration limit added",
       "impact": "low",
       "source_url": "",
       "category": "Cloud IaaS",
-      "alternatives": []
+      "alternatives": [],
+      "recorded_date": "2026-04-13"
     },
     {
       "vendor": "OneSignal",
@@ -3241,7 +3474,8 @@
       "impact": "low",
       "source_url": "",
       "category": "Messaging",
-      "alternatives": []
+      "alternatives": [],
+      "recorded_date": "2026-04-13"
     },
     {
       "vendor": "Stadia Maps",
@@ -3253,7 +3487,8 @@
       "impact": "low",
       "source_url": "",
       "category": "Maps/Geolocation",
-      "alternatives": []
+      "alternatives": [],
+      "recorded_date": "2026-04-13"
     },
     {
       "vendor": "Keywords AI",
@@ -3265,19 +3500,21 @@
       "impact": "low",
       "source_url": "",
       "category": "AI / ML",
-      "alternatives": []
+      "alternatives": [],
+      "recorded_date": "2026-04-13"
     },
     {
       "vendor": "Revolt",
       "change_type": "rebranded",
       "date": "2026-04-13",
-      "summary": "revolt.chat \u2192 stoat.chat",
+      "summary": "revolt.chat → stoat.chat",
       "previous_state": "",
-      "current_state": "revolt.chat \u2192 stoat.chat",
+      "current_state": "revolt.chat → stoat.chat",
       "impact": "low",
       "source_url": "",
       "category": "Team Collaboration",
-      "alternatives": []
+      "alternatives": [],
+      "recorded_date": "2026-04-13"
     },
     {
       "vendor": "GoSquared",
@@ -3289,7 +3526,8 @@
       "impact": "low",
       "source_url": "",
       "category": "Communication",
-      "alternatives": []
+      "alternatives": [],
+      "recorded_date": "2026-04-13"
     },
     {
       "vendor": "Drift",
@@ -3301,7 +3539,8 @@
       "impact": "low",
       "source_url": "",
       "category": "Communication",
-      "alternatives": []
+      "alternatives": [],
+      "recorded_date": "2026-04-13"
     },
     {
       "vendor": "Synadia NGS",
@@ -3313,7 +3552,8 @@
       "impact": "low",
       "source_url": "",
       "category": "Messaging",
-      "alternatives": []
+      "alternatives": [],
+      "recorded_date": "2026-04-13"
     },
     {
       "vendor": "Pingram.io",
@@ -3325,7 +3565,8 @@
       "impact": "low",
       "source_url": "",
       "category": "Messaging",
-      "alternatives": []
+      "alternatives": [],
+      "recorded_date": "2026-04-13"
     },
     {
       "vendor": "LambdaTest",
@@ -3337,7 +3578,8 @@
       "impact": "low",
       "source_url": "",
       "category": "Testing",
-      "alternatives": []
+      "alternatives": [],
+      "recorded_date": "2026-04-13"
     },
     {
       "vendor": "DhiWise",
@@ -3349,7 +3591,8 @@
       "impact": "low",
       "source_url": "",
       "category": "IDE & Code Editors",
-      "alternatives": []
+      "alternatives": [],
+      "recorded_date": "2026-04-13"
     },
     {
       "vendor": "Brackets",
@@ -3361,7 +3604,8 @@
       "impact": "low",
       "source_url": "",
       "category": "IDE & Code Editors",
-      "alternatives": []
+      "alternatives": [],
+      "recorded_date": "2026-04-13"
     },
     {
       "vendor": "Apiary",
@@ -3373,7 +3617,8 @@
       "impact": "low",
       "source_url": "",
       "category": "API Development",
-      "alternatives": []
+      "alternatives": [],
+      "recorded_date": "2026-04-13"
     },
     {
       "vendor": "Stamen Maps",
@@ -3385,19 +3630,21 @@
       "impact": "low",
       "source_url": "",
       "category": "Maps/Geolocation",
-      "alternatives": []
+      "alternatives": [],
+      "recorded_date": "2026-04-13"
     },
     {
       "vendor": "Clever Cloud",
       "change_type": "rebranded",
       "date": "2026-04-13",
-      "summary": "Program renamed to UP, offers up to \u20ac10K credits",
+      "summary": "Program renamed to UP, offers up to €10K credits",
       "previous_state": "",
-      "current_state": "Program renamed to UP, offers up to \u20ac10K credits",
+      "current_state": "Program renamed to UP, offers up to €10K credits",
       "impact": "low",
       "source_url": "",
       "category": "Cloud IaaS",
-      "alternatives": []
+      "alternatives": [],
+      "recorded_date": "2026-04-13"
     },
     {
       "vendor": "Alibaba Cloud Startups",
@@ -3409,7 +3656,8 @@
       "impact": "low",
       "source_url": "",
       "category": "Cloud IaaS",
-      "alternatives": []
+      "alternatives": [],
+      "recorded_date": "2026-04-13"
     },
     {
       "vendor": "Logz.io",
@@ -3421,7 +3669,8 @@
       "impact": "low",
       "source_url": "",
       "category": "Logging",
-      "alternatives": []
+      "alternatives": [],
+      "recorded_date": "2026-04-13"
     },
     {
       "vendor": "Papertrail",
@@ -3433,7 +3682,8 @@
       "impact": "low",
       "source_url": "",
       "category": "Logging",
-      "alternatives": []
+      "alternatives": [],
+      "recorded_date": "2026-04-13"
     },
     {
       "vendor": "LogZab",
@@ -3445,7 +3695,8 @@
       "impact": "low",
       "source_url": "",
       "category": "Logging",
-      "alternatives": []
+      "alternatives": [],
+      "recorded_date": "2026-04-13"
     },
     {
       "vendor": "Elmah.io",
@@ -3457,7 +3708,8 @@
       "impact": "low",
       "source_url": "",
       "category": "Error Tracking",
-      "alternatives": []
+      "alternatives": [],
+      "recorded_date": "2026-04-13"
     },
     {
       "vendor": "Beanstalk",
@@ -3469,7 +3721,8 @@
       "impact": "low",
       "source_url": "",
       "category": "Source Control",
-      "alternatives": []
+      "alternatives": [],
+      "recorded_date": "2026-04-13"
     },
     {
       "vendor": "Storyblok",
@@ -3481,7 +3734,8 @@
       "impact": "low",
       "source_url": "",
       "category": "Headless CMS",
-      "alternatives": []
+      "alternatives": [],
+      "recorded_date": "2026-04-13"
     },
     {
       "vendor": "Imgix",
@@ -3493,7 +3747,8 @@
       "impact": "low",
       "source_url": "",
       "category": "CDN",
-      "alternatives": []
+      "alternatives": [],
+      "recorded_date": "2026-04-13"
     },
     {
       "vendor": "Toran Proxy",
@@ -3505,7 +3760,8 @@
       "impact": "low",
       "source_url": "",
       "category": "CDN",
-      "alternatives": []
+      "alternatives": [],
+      "recorded_date": "2026-04-13"
     },
     {
       "vendor": "Shotstack",
@@ -3517,7 +3773,8 @@
       "impact": "low",
       "source_url": "",
       "category": "Video",
-      "alternatives": []
+      "alternatives": [],
+      "recorded_date": "2026-04-13"
     },
     {
       "vendor": "CommandBar",
@@ -3529,7 +3786,8 @@
       "impact": "low",
       "source_url": "",
       "category": "Search",
-      "alternatives": []
+      "alternatives": [],
+      "recorded_date": "2026-04-13"
     },
     {
       "vendor": "LingoHub",
@@ -3541,7 +3799,8 @@
       "impact": "low",
       "source_url": "",
       "category": "Localization",
-      "alternatives": []
+      "alternatives": [],
+      "recorded_date": "2026-04-13"
     },
     {
       "vendor": "Transifex",
@@ -3553,7 +3812,8 @@
       "impact": "low",
       "source_url": "",
       "category": "Localization",
-      "alternatives": []
+      "alternatives": [],
+      "recorded_date": "2026-04-13"
     },
     {
       "vendor": "RunCloud",
@@ -3565,7 +3825,8 @@
       "impact": "low",
       "source_url": "",
       "category": "Server Management",
-      "alternatives": []
+      "alternatives": [],
+      "recorded_date": "2026-04-13"
     },
     {
       "vendor": "Pipedream",
@@ -3577,13 +3838,14 @@
       "impact": "low",
       "source_url": "",
       "category": "Workflow Automation",
-      "alternatives": []
+      "alternatives": [],
+      "recorded_date": "2026-04-13"
     },
     {
       "vendor": "Claude Code",
       "change_type": "pricing_restructured",
       "date": "2026-04-04",
-      "summary": "Three material policy changes: (1) Third-party tool restrictions \u2014 external tools like OpenClaw now billed separately on pay-as-you-go, can no longer apply standard usage limits. (2) Extra usage option \u2014 all paid plans (Pro, Max 5x, Max 20x) have pay-as-you-go overage at standard API rates. (3) Peak-hour throttling (acknowledged March 31) \u2014 5-hour session limits reduced during weekdays 5 AM\u201311 AM Pacific.",
+      "summary": "Three material policy changes: (1) Third-party tool restrictions — external tools like OpenClaw now billed separately on pay-as-you-go, can no longer apply standard usage limits. (2) Extra usage option — all paid plans (Pro, Max 5x, Max 20x) have pay-as-you-go overage at standard API rates. (3) Peak-hour throttling (acknowledged March 31) — 5-hour session limits reduced during weekdays 5 AM–11 AM Pacific.",
       "previous_state": "Flat subscription pricing with included usage limits. Third-party tools shared standard limits. No overage option.",
       "current_state": "Subscription + pay-as-you-go overage. Third-party tools billed separately. Peak-hour throttling during weekday mornings.",
       "impact": "high",
@@ -3594,7 +3856,8 @@
         "GitHub Copilot",
         "Amazon Kiro",
         "Windsurf"
-      ]
+      ],
+      "recorded_date": "2026-04-13"
     },
     {
       "vendor": "Amazon Kiro",
@@ -3611,7 +3874,8 @@
         "GitHub Copilot",
         "Windsurf",
         "Claude Code"
-      ]
+      ],
+      "recorded_date": "2026-04-13"
     },
     {
       "vendor": "Amazon Kiro (AWS Startups)",
@@ -3627,7 +3891,8 @@
         "GitHub Copilot",
         "Cursor",
         "Windsurf"
-      ]
+      ],
+      "recorded_date": "2026-04-13"
     },
     {
       "vendor": "Windsurf",
@@ -3643,15 +3908,16 @@
         "Cursor",
         "GitHub Copilot",
         "Claude Code"
-      ]
+      ],
+      "recorded_date": "2026-04-13"
     },
     {
       "vendor": "GitHub Copilot",
       "change_type": "restriction",
       "date": "2026-03-12",
-      "summary": "Student plan now managed under dedicated 'GitHub Copilot Student' plan. Premium models (GPT-5.4, Claude Opus, Claude Sonnet) removed from manual self-selection \u2014 still available via Auto mode (system picks the model).",
+      "summary": "Student plan now managed under dedicated 'GitHub Copilot Student' plan. Premium models (GPT-5.4, Claude Opus, Claude Sonnet) removed from manual self-selection — still available via Auto mode (system picks the model).",
       "previous_state": "Students shared Copilot Free quotas with full model self-selection",
-      "current_state": "Dedicated Student plan \u2014 premium models only via Auto mode, no manual model selection",
+      "current_state": "Dedicated Student plan — premium models only via Auto mode, no manual model selection",
       "impact": "medium",
       "source_url": "https://github.com/features/copilot/plans",
       "category": "AI Coding",
@@ -3659,7 +3925,8 @@
         "Cursor",
         "Windsurf",
         "Gemini Code Assist"
-      ]
+      ],
+      "recorded_date": "2026-04-13"
     },
     {
       "vendor": "Cursor",
@@ -3675,7 +3942,8 @@
         "Windsurf",
         "GitHub Copilot",
         "Claude Code"
-      ]
+      ],
+      "recorded_date": "2026-04-13"
     },
     {
       "vendor": "n8n",
@@ -3683,7 +3951,7 @@
       "date": "2026-04-14",
       "summary": "n8n Cloud free plan removed entirely. All Cloud plans now require payment (14-day free trial available). Unlimited active workflows across all paid plans. Self-hosted remains free under Sustainable Use License.",
       "previous_state": "Cloud had a free plan with limited executions",
-      "current_state": "No free Cloud plan. Starter \u20ac24/mo, Pro \u20ac60/mo, Enterprise custom. Self-hosted free (Sustainable Use License)",
+      "current_state": "No free Cloud plan. Starter €24/mo, Pro €60/mo, Enterprise custom. Self-hosted free (Sustainable Use License)",
       "impact": "medium",
       "source_url": "https://n8n.io/pricing/",
       "category": "Background Jobs",
@@ -3692,7 +3960,8 @@
         "Pipedream",
         "Make",
         "Zapier"
-      ]
+      ],
+      "recorded_date": "2026-04-13"
     },
     {
       "vendor": "Microsoft",
@@ -3708,7 +3977,8 @@
         "Amazon WorkSpaces",
         "Azure Virtual Desktop",
         "Citrix DaaS"
-      ]
+      ],
+      "recorded_date": "2026-04-13"
     },
     {
       "vendor": "Microsoft",
@@ -3723,7 +3993,8 @@
       "alternatives": [
         "Google Workspace Enterprise Plus",
         "Zoho Workplace"
-      ]
+      ],
+      "recorded_date": "2026-04-13"
     },
     {
       "vendor": "OVHcloud",
@@ -3740,7 +4011,8 @@
         "DigitalOcean",
         "Vultr",
         "AWS"
-      ]
+      ],
+      "recorded_date": "2026-04-09"
     },
     {
       "vendor": "Google Content API for Shopping",
@@ -3748,7 +4020,7 @@
       "date": "2026-04-15",
       "summary": "Google Content API for Shopping being sunset August 18, 2026. Replaced by Merchant API, rolling out April 22, 2026. Developers must migrate before the sunset deadline.",
       "previous_state": "Active API for Google Merchant Center product data management",
-      "current_state": "Deprecated \u2014 sunset August 18, 2026. Replacement: Merchant API (available April 22, 2026)",
+      "current_state": "Deprecated — sunset August 18, 2026. Replacement: Merchant API (available April 22, 2026)",
       "impact": "high",
       "source_url": "https://ppc.land/merchant-api-comes-to-google-ads-scripts-april-22-as-content-api-nears-its-end/",
       "category": "API Development",
@@ -3756,13 +4028,14 @@
         "Google Merchant API",
         "Shopify API",
         "BigCommerce API"
-      ]
+      ],
+      "recorded_date": "2026-04-15"
     },
     {
       "vendor": "DeepSeek",
       "change_type": "pricing_restructured",
       "date": "2026-04-17",
-      "summary": "DeepSeek V3.2 replaces V4 branding. Pricing dropped: chat model $0.30\u2192$0.28/M input, $0.50\u2192$0.42/M output. Reasoner model pricing unified with chat at $0.28/$0.42 (was $0.55/$2.19). Free token welcome package appears removed.",
+      "summary": "DeepSeek V3.2 replaces V4 branding. Pricing dropped: chat model $0.30→$0.28/M input, $0.50→$0.42/M output. Reasoner model pricing unified with chat at $0.28/$0.42 (was $0.55/$2.19). Free token welcome package appears removed.",
       "previous_state": "DeepSeek V4: $0.30/M input, $0.50/M output. R1: $0.55/M input, $2.19/M output. 5M free tokens for new accounts.",
       "current_state": "DeepSeek V3.2 (chat + reasoner): $0.28/M input, $0.42/M output. Cache hits 90% cheaper. No free token mention on pricing page.",
       "impact": "medium",
@@ -3772,7 +4045,8 @@
         "OpenAI API",
         "Anthropic Claude API",
         "Google Gemini API"
-      ]
+      ],
+      "recorded_date": "2026-04-16"
     },
     {
       "vendor": "Netlify",
@@ -3788,7 +4062,8 @@
         "Vercel",
         "Cloudflare Pages",
         "Railway"
-      ]
+      ],
+      "recorded_date": "2026-04-16"
     },
     {
       "vendor": "Alibaba Cloud Qwen Code",
@@ -3804,7 +4079,8 @@
         "GitHub Copilot",
         "Cursor",
         "Codeium"
-      ]
+      ],
+      "recorded_date": "2026-04-16"
     },
     {
       "vendor": "Google Gemini API",
@@ -3821,7 +4097,8 @@
         "Gemini 3.0 Flash",
         "OpenRouter",
         "Groq"
-      ]
+      ],
+      "recorded_date": "2026-04-17"
     },
     {
       "vendor": "SendGrid Accelerate",
@@ -3837,7 +4114,8 @@
         "SendGrid",
         "Mailgun",
         "Postmark"
-      ]
+      ],
+      "recorded_date": "2026-04-17"
     },
     {
       "vendor": "Prospect.io",
@@ -3853,7 +4131,8 @@
         "Apollo.io",
         "Hunter.io",
         "Lemlist"
-      ]
+      ],
+      "recorded_date": "2026-04-17"
     },
     {
       "vendor": "Kluster AI",
@@ -3869,7 +4148,8 @@
         "Groq",
         "SiliconFlow",
         "OpenRouter"
-      ]
+      ],
+      "recorded_date": "2026-04-17"
     },
     {
       "vendor": "searchly.com",
@@ -3885,7 +4165,8 @@
         "bonsai.io",
         "Algolia",
         "Elastic Cloud"
-      ]
+      ],
+      "recorded_date": "2026-04-19"
     },
     {
       "vendor": "ImageEngine",
@@ -3902,7 +4183,8 @@
         "ImageKit",
         "Uploadcare",
         "imgix"
-      ]
+      ],
+      "recorded_date": "2026-04-19"
     },
     {
       "vendor": "DBOS",
@@ -3918,7 +4200,8 @@
         "Temporal",
         "Inngest",
         "Trigger.dev"
-      ]
+      ],
+      "recorded_date": "2026-04-19"
     },
     {
       "vendor": "X (Twitter)",
@@ -3934,7 +4217,8 @@
         "Bluesky AT Protocol",
         "Mastodon API",
         "Reddit API"
-      ]
+      ],
+      "recorded_date": "2026-04-21"
     },
     {
       "vendor": "Netlify",
@@ -3950,7 +4234,8 @@
         "Vercel",
         "Cloudflare Pages",
         "Railway"
-      ]
+      ],
+      "recorded_date": "2026-04-21"
     },
     {
       "vendor": "GitHub Copilot",
@@ -3967,7 +4252,8 @@
         "Windsurf",
         "Gemini Code Assist",
         "Claude Code"
-      ]
+      ],
+      "recorded_date": "2026-04-21"
     },
     {
       "vendor": "GitHub Copilot",
@@ -3985,7 +4271,8 @@
         "Gemini Code Assist",
         "Claude Code",
         "Cline"
-      ]
+      ],
+      "recorded_date": "2026-04-21"
     },
     {
       "vendor": "Amazon SES",
@@ -4003,7 +4290,8 @@
         "MailerSend",
         "Brevo",
         "Postal"
-      ]
+      ],
+      "recorded_date": "2026-08-26"
     },
     {
       "vendor": "Storj",
@@ -4020,7 +4308,8 @@
         "Backblaze B2",
         "Tigris",
         "MinIO"
-      ]
+      ],
+      "recorded_date": "2026-08-26"
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "check:liveness": "node scripts/check-liveness.js",
     "lint:duplicates": "node scripts/lint-duplicates.js",
     "check:pricing": "node scripts/check-pricing-changes.js",
+    "check:change-log": "node scripts/check-change-log-staleness.js",
     "monitor:pricing": "node scripts/monitor-pricing.js",
     "ingest:free-for-dev": "node scripts/parse-free-for-dev.ts",
     "ingest:startup-deals": "node scripts/ingest-startup-deals.ts",

--- a/scripts/backfill-change-recorded-dates.js
+++ b/scripts/backfill-change-recorded-dates.js
@@ -1,0 +1,124 @@
+#!/usr/bin/env node
+
+import { readFileSync, writeFileSync } from "node:fs";
+import { execFileSync } from "node:child_process";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { changeKey } from "./change-log.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const ROOT = resolve(__dirname, "..");
+const CHANGES_PATH = resolve(ROOT, "data", "deal_changes.json");
+const TRACKED_PATH = "data/deal_changes.json";
+
+function git(args) {
+  return execFileSync("git", args, { cwd: ROOT, encoding: "utf-8", maxBuffer: 64 * 1024 * 1024 });
+}
+
+export function firstSeenDates(commits, readAtCommit) {
+  const firstSeen = new Map();
+  for (const { sha, date } of commits) {
+    let changes;
+    try {
+      changes = readAtCommit(sha);
+    } catch {
+      continue;
+    }
+    for (const change of changes) {
+      const key = changeKey(change);
+      if (!firstSeen.has(key)) firstSeen.set(key, date);
+    }
+  }
+  return firstSeen;
+}
+
+function main() {
+  const dryRun = process.argv.includes("--dry-run");
+
+  const log = git(["log", "--reverse", "--format=%H %cs", "--", TRACKED_PATH]).trim();
+  const commits = log
+    .split("\n")
+    .filter(Boolean)
+    .map((line) => {
+      const [sha, date] = line.split(" ");
+      return { sha, date };
+    });
+
+  const readAtCommit = (sha) => {
+    const raw = git(["show", `${sha}:${TRACKED_PATH}`]);
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed.changes) ? parsed.changes : [];
+  };
+
+  const firstSeen = firstSeenDates(commits, readAtCommit);
+
+  const data = JSON.parse(readFileSync(CHANGES_PATH, "utf-8"));
+  let stamped = 0;
+  let alreadyStamped = 0;
+  let unresolved = 0;
+  const unresolvedVendors = [];
+
+  for (const change of data.changes) {
+    if (change.recorded_date) {
+      alreadyStamped++;
+      continue;
+    }
+    const date = firstSeen.get(changeKey(change));
+    if (!date) {
+      unresolved++;
+      unresolvedVendors.push(`${change.vendor} (${change.change_type}, ${change.date})`);
+      continue;
+    }
+    change.recorded_date = date;
+    stamped++;
+  }
+
+  console.log(`Commits touching ${TRACKED_PATH}: ${commits.length}`);
+  console.log(`Distinct change keys seen across history: ${firstSeen.size}`);
+  console.log(`Entries stamped: ${stamped}`);
+  console.log(`Entries already carrying recorded_date: ${alreadyStamped}`);
+  console.log(`Entries with no commit of origin: ${unresolved}`);
+  for (const vendor of unresolvedVendors) console.log(`  ? ${vendor}`);
+
+  const byMonth = {};
+  for (const change of data.changes) {
+    if (!change.recorded_date) continue;
+    const month = change.recorded_date.slice(0, 7);
+    byMonth[month] = (byMonth[month] ?? 0) + 1;
+  }
+  console.log("");
+  console.log("Entries by month recorded:");
+  for (const month of Object.keys(byMonth).sort()) {
+    console.log(`  ${month}  ${byMonth[month]}`);
+  }
+
+  const recordedDays = [...new Set(data.changes.map((c) => c.recorded_date).filter(Boolean))].sort();
+  let widestGap = 0;
+  let widestGapRange = "";
+  for (let i = 1; i < recordedDays.length; i++) {
+    const gap = Math.round(
+      (Date.parse(recordedDays[i]) - Date.parse(recordedDays[i - 1])) / 86400000
+    );
+    if (gap > widestGap) {
+      widestGap = gap;
+      widestGapRange = `${recordedDays[i - 1]} → ${recordedDays[i]}`;
+    }
+  }
+  console.log("");
+  console.log(`Distinct recording days: ${recordedDays.length}`);
+  console.log(`Widest gap between recording days: ${widestGap} days (${widestGapRange})`);
+
+  if (dryRun) {
+    console.log("");
+    console.log("Dry run — nothing written.");
+    return;
+  }
+
+  writeFileSync(CHANGES_PATH, JSON.stringify(data, null, 2) + "\n");
+  console.log("");
+  console.log(`Wrote ${CHANGES_PATH}`);
+}
+
+const isMainModule =
+  process.argv[1] && resolve(process.argv[1]) === resolve(fileURLToPath(import.meta.url));
+if (isMainModule) main();

--- a/scripts/change-log.js
+++ b/scripts/change-log.js
@@ -1,0 +1,158 @@
+import { readFileSync, writeFileSync } from "node:fs";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+export const CHANGES_PATH =
+  process.env.AGENTDEALS_CHANGES_PATH || resolve(__dirname, "..", "data", "deal_changes.json");
+
+export const DETECTED_BY_AI = "reverify-ai";
+
+export const CHANGE_TYPES = [
+  "free_tier_removed",
+  "limits_reduced",
+  "restriction",
+  "limits_increased",
+  "new_free_tier",
+  "new_tier",
+  "pricing_restructured",
+  "open_source_killed",
+  "pricing_model_change",
+  "startup_program_expanded",
+  "pricing_postponed",
+  "product_deprecated",
+  "rebranded",
+];
+
+const IMPACTS = ["high", "medium", "low"];
+const DEFAULT_IMPACT = "medium";
+const ISO_DATE = /^\d{4}-\d{2}-\d{2}$/;
+const DEFAULT_REPICK_WINDOW_DAYS = 21;
+
+export function changeKey(change) {
+  return [change.vendor, change.change_type, change.date, change.source_url].join("|");
+}
+
+export function isoDay(now) {
+  return new Date(now).toISOString().slice(0, 10);
+}
+
+export function buildChangeEntry(offer, result, options = {}) {
+  const now = options.now ?? new Date();
+  const recordedDate = isoDay(now);
+  const missing = [];
+
+  const changeType = typeof result.change_type === "string" ? result.change_type.trim() : "";
+  if (!CHANGE_TYPES.includes(changeType)) missing.push("change_type");
+
+  const summary = typeof result.summary === "string" ? result.summary.trim() : "";
+  if (!summary) missing.push("summary");
+
+  const currentState = typeof result.current_state === "string" ? result.current_state.trim() : "";
+  if (!currentState) missing.push("current_state");
+
+  if (missing.length > 0) return { entry: null, missing };
+
+  const effectiveDate =
+    typeof result.effective_date === "string" && ISO_DATE.test(result.effective_date.trim())
+      ? result.effective_date.trim()
+      : recordedDate;
+
+  const impact = IMPACTS.includes(result.impact) ? result.impact : DEFAULT_IMPACT;
+
+  return {
+    entry: {
+      vendor: offer.vendor,
+      change_type: changeType,
+      date: effectiveDate,
+      summary,
+      previous_state: offer.description,
+      current_state: currentState,
+      impact,
+      source_url: offer.url,
+      category: offer.category,
+      alternatives: [],
+      detected_by: options.detectedBy ?? DETECTED_BY_AI,
+      recorded_date: recordedDate,
+    },
+    missing: [],
+  };
+}
+
+export function selectNewChanges(existing, candidates, options = {}) {
+  const windowDays = options.windowDays ?? DEFAULT_REPICK_WINDOW_DAYS;
+  const keys = new Set(existing.map(changeKey));
+  const recent = new Map();
+  for (const change of existing) {
+    const stamp = change.recorded_date || change.date;
+    const pair = `${change.vendor}|${change.change_type}`;
+    const previous = recent.get(pair);
+    if (!previous || stamp > previous) recent.set(pair, stamp);
+  }
+
+  const fresh = [];
+  const suppressed = [];
+  for (const candidate of candidates) {
+    const key = changeKey(candidate);
+    if (keys.has(key)) {
+      suppressed.push({ candidate, reason: "already_recorded" });
+      continue;
+    }
+    const pair = `${candidate.vendor}|${candidate.change_type}`;
+    const lastStamp = recent.get(pair);
+    if (lastStamp && daysBetween(lastStamp, candidate.recorded_date) < windowDays) {
+      suppressed.push({ candidate, reason: "recorded_within_repick_window" });
+      continue;
+    }
+    fresh.push(candidate);
+    keys.add(key);
+    recent.set(pair, candidate.recorded_date);
+  }
+  return { fresh, suppressed };
+}
+
+function daysBetween(from, to) {
+  return Math.round((Date.parse(to) - Date.parse(from)) / 86400000);
+}
+
+export function readChangeLog(path = CHANGES_PATH) {
+  const data = JSON.parse(readFileSync(path, "utf-8"));
+  if (!Array.isArray(data.changes)) throw new Error(`${path} has no changes array`);
+  return data;
+}
+
+export function appendChangeEntries(candidates, options = {}) {
+  const path = options.path ?? CHANGES_PATH;
+  const data = readChangeLog(path);
+  const { fresh, suppressed } = selectNewChanges(data.changes, candidates, options);
+  if (fresh.length > 0 && !options.dryRun) {
+    data.changes.push(...fresh);
+    writeFileSync(path, JSON.stringify(data, null, 2) + "\n");
+  }
+  return { appended: fresh, suppressed, total: data.changes.length };
+}
+
+export function changeLogFreshness(changes, now = new Date()) {
+  const today = isoDay(now);
+  const recorded = changes.map((c) => c.recorded_date).filter(Boolean).sort();
+  const detected = changes
+    .filter((c) => c.detected_by)
+    .map((c) => c.recorded_date)
+    .filter(Boolean)
+    .sort();
+  const last = recorded.length > 0 ? recorded[recorded.length - 1] : null;
+  const lastDetected = detected.length > 0 ? detected[detected.length - 1] : null;
+  const thirtyDaysAgo = isoDay(new Date(Date.parse(today) - 30 * 86400000));
+  return {
+    total: changes.length,
+    last_recorded_date: last,
+    days_since_last_recorded: last === null ? null : Math.max(0, daysBetween(last, today)),
+    last_detected_date: lastDetected,
+    days_since_last_detected:
+      lastDetected === null ? null : Math.max(0, daysBetween(lastDetected, today)),
+    recorded_last_30_days: recorded.filter((d) => d >= thirtyDaysAgo).length,
+    machine_detected_total: changes.filter((c) => c.detected_by).length,
+    entries_without_recorded_date: changes.length - recorded.length,
+  };
+}

--- a/scripts/check-change-log-staleness.js
+++ b/scripts/check-change-log-staleness.js
@@ -1,0 +1,64 @@
+#!/usr/bin/env node
+
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { readChangeLog, changeLogFreshness, CHANGES_PATH } from "./change-log.js";
+
+export const DEFAULT_THRESHOLD_DAYS = 14;
+
+export function report(freshness, thresholdDays) {
+  const lines = [];
+  lines.push("── Change-log freshness ──");
+  lines.push(`Total changes recorded: ${freshness.total}`);
+  lines.push(`Last change recorded: ${freshness.last_recorded_date ?? "never"}`);
+  lines.push(`Days since last change recorded: ${freshness.days_since_last_recorded ?? "n/a"}`);
+  lines.push(`Recorded in the last 30 days: ${freshness.recorded_last_30_days}`);
+  lines.push(
+    `Machine-detected entries: ${freshness.machine_detected_total}` +
+      (freshness.last_detected_date
+        ? ` (last ${freshness.last_detected_date}, ${freshness.days_since_last_detected} days ago)`
+        : " (none — no detector has ever written to this log)")
+  );
+  lines.push(`Threshold: ${thresholdDays} days`);
+
+  const days = freshness.days_since_last_recorded;
+  const stale = days === null || days > thresholdDays;
+  if (stale) {
+    lines.push("");
+    lines.push(
+      days === null
+        ? "STALE: no entry carries a recorded_date, so the age of this log cannot be measured."
+        : `STALE: ${days} days since anything was added to the change log, past the ${thresholdDays}-day threshold.`
+    );
+    lines.push(
+      "The daily job runs URL mode, which cannot detect a change. Nothing else writes to this log."
+    );
+  }
+  return { stale, text: lines.join("\n") };
+}
+
+function main() {
+  const args = process.argv.slice(2);
+  const idx = args.indexOf("--threshold");
+  const thresholdDays = idx !== -1 ? parseInt(args[idx + 1], 10) : DEFAULT_THRESHOLD_DAYS;
+  if (isNaN(thresholdDays) || thresholdDays < 1) {
+    console.error(`Invalid threshold: ${args[idx + 1]}. Must be a positive integer.`);
+    process.exit(2);
+  }
+
+  let data;
+  try {
+    data = readChangeLog(CHANGES_PATH);
+  } catch (err) {
+    console.error(`Failed to read change log: ${err.message}`);
+    process.exit(2);
+  }
+
+  const { stale, text } = report(changeLogFreshness(data.changes), thresholdDays);
+  console.log(text);
+  process.exit(stale ? 1 : 0);
+}
+
+const isMainModule =
+  process.argv[1] && resolve(process.argv[1]) === resolve(fileURLToPath(import.meta.url));
+if (isMainModule) main();

--- a/scripts/e2e-1074.mjs
+++ b/scripts/e2e-1074.mjs
@@ -1,0 +1,226 @@
+import { createServer } from "node:http";
+import { spawn } from "node:child_process";
+import { mkdtempSync, rmSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const HELP = `End-to-end check for the change-log writer.
+
+Runs the real reverify-rolling CLI in --ai mode against a stub Anthropic endpoint
+and stub vendor pages, then reads what landed on disk. Covers what unit tests
+cannot: that the CLI itself writes a detected change to the change log, that a
+record whose terms moved keeps its stale verification date, that a second run over
+the same record does not write the entry twice, and that the staleness alarm exits
+non-zero on a log that has stopped growing.
+
+Usage: node scripts/e2e-1074.mjs
+`;
+
+if (process.argv.includes("--help") || process.argv.includes("-h")) {
+  console.log(HELP);
+  process.exit(0);
+}
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const work = mkdtempSync(join(tmpdir(), "e2e-1074-"));
+const indexPath = join(work, "index.json");
+const changesPath = join(work, "deal_changes.json");
+
+let checks = 0;
+let failures = 0;
+function check(label, condition, detail = "") {
+  checks++;
+  if (condition) {
+    console.log(`  ✓ ${label}`);
+  } else {
+    failures++;
+    console.log(`  ✗ ${label}${detail ? ` — ${detail}` : ""}`);
+  }
+}
+
+const PAGE_TEXT = {
+  moved: "Examplebase pricing. The Starter plan is a 14 day trial of 500 MB. After the trial it is 19 dollars per month. Effective 1 August 2026.",
+  same: "Steadybase pricing. The free plan gives 1 GB of storage every month with no time limit and no card required.",
+  vague: "Vaguebase pricing. Plans and limits are listed in the console after you sign in. Contact sales for details.",
+};
+
+const pages = createServer((req, res) => {
+  const key = req.url.replace("/", "");
+  const text = PAGE_TEXT[key];
+  if (!text) {
+    res.writeHead(404, { "Content-Type": "text/html" });
+    res.end("<html><body>not found</body></html>");
+    return;
+  }
+  res.writeHead(200, { "Content-Type": "text/html" });
+  res.end(`<html><head><title>Pricing</title></head><body><main>${text}</main></body></html>`);
+});
+
+const REPLIES = {
+  Examplebase: {
+    status: "changed",
+    summary: "The free 500 MB plan is now a 14-day trial that converts to $19/month",
+    change_type: "free_tier_removed",
+    current_state: "500 MB for 14 days, then $19 per month",
+    impact: "high",
+    effective_date: "2026-08-01",
+  },
+  Steadybase: { status: "confirmed" },
+  Vaguebase: { status: "changed", summary: "something about the plans looks different" },
+};
+
+let modelCalls = 0;
+const anthropic = createServer((req, res) => {
+  let body = "";
+  req.on("data", (c) => (body += c));
+  req.on("end", () => {
+    modelCalls++;
+    const parsed = JSON.parse(body || "{}");
+    const prompt = parsed.messages?.[0]?.content ?? "";
+    const vendor = Object.keys(REPLIES).find((v) => prompt.includes(`Vendor: ${v}`));
+    const reply = REPLIES[vendor] ?? { status: "unclear", summary: "no stub for this vendor" };
+    res.writeHead(200, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({
+      id: "msg_stub",
+      type: "message",
+      role: "assistant",
+      model: parsed.model,
+      content: [{ type: "text", text: JSON.stringify(reply) }],
+      stop_reason: "end_turn",
+      stop_sequence: null,
+      usage: { input_tokens: 100, output_tokens: 60 },
+    }));
+  });
+});
+
+function listen(server) {
+  return new Promise((r) => server.listen(0, "127.0.0.1", () => r(server.address().port)));
+}
+
+function run(script, args, env) {
+  return new Promise((r) => {
+    const child = spawn("node", [join(ROOT, "scripts", script), ...args], {
+      env: { ...process.env, ...env },
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    let out = "";
+    child.stdout.on("data", (d) => (out += d));
+    child.stderr.on("data", (d) => (out += d));
+    child.on("close", (code) => r({ code, out }));
+  });
+}
+
+const pagesPort = await listen(pages);
+const anthropicPort = await listen(anthropic);
+
+const offers = [
+  {
+    vendor: "Examplebase", category: "Databases", tier: "Free",
+    description: "500 MB storage and 2 GB egress per month, free forever",
+    url: `http://127.0.0.1:${pagesPort}/moved`, tags: ["database"], verifiedDate: "2026-01-01",
+  },
+  {
+    vendor: "Steadybase", category: "Databases", tier: "Free",
+    description: "1 GB of storage per month with no time limit",
+    url: `http://127.0.0.1:${pagesPort}/same`, tags: ["database"], verifiedDate: "2026-01-02",
+  },
+  {
+    vendor: "Vaguebase", category: "Databases", tier: "Free",
+    description: "A free plan with unspecified limits",
+    url: `http://127.0.0.1:${pagesPort}/vague`, tags: ["database"], verifiedDate: "2026-01-03",
+  },
+];
+
+writeFileSync(indexPath, JSON.stringify({ offers }, null, 2) + "\n");
+writeFileSync(changesPath, JSON.stringify({ changes: [] }, null, 2) + "\n");
+
+const env = {
+  AGENTDEALS_INDEX_PATH: indexPath,
+  AGENTDEALS_CHANGES_PATH: changesPath,
+  ANTHROPIC_API_KEY: "stub-key-not-a-real-credential",
+  ANTHROPIC_BASE_URL: `http://127.0.0.1:${anthropicPort}`,
+};
+
+console.log("── Run 1: AI mode over three records ──");
+const first = await run("reverify-rolling.js", ["--ai", "--limit", "3"], env);
+console.log(first.out.split("\n").map((l) => `    ${l}`).join("\n"));
+
+check("the CLI exited cleanly", first.code === 0, `exit ${first.code}`);
+check("the stub model was asked about every record", modelCalls === 3, `${modelCalls} calls`);
+
+let log = JSON.parse(readFileSync(changesPath, "utf-8"));
+check("the detected change was written to the log", log.changes.length === 1, `${log.changes.length} entries`);
+
+const written = log.changes[0] ?? {};
+check("the entry names the vendor whose terms moved", written.vendor === "Examplebase", written.vendor);
+check("the entry carries the change type the reading produced", written.change_type === "free_tier_removed", written.change_type);
+check("the entry's current state came from the page, not from our record", written.current_state === "500 MB for 14 days, then $19 per month", written.current_state);
+check("the entry's previous state is what we had published", written.previous_state === offers[0].description, written.previous_state);
+check("the entry is marked as machine-written", written.detected_by === "reverify-ai", written.detected_by);
+check("the entry says when it was recorded", /^\d{4}-\d{2}-\d{2}$/.test(written.recorded_date ?? ""), written.recorded_date);
+check("the entry dates the change from the page", written.date === "2026-08-01", written.date);
+check("the entry cites the page that was read", written.source_url === offers[0].url, written.source_url);
+
+let index = JSON.parse(readFileSync(indexPath, "utf-8"));
+const byVendor = Object.fromEntries(index.offers.map((o) => [o.vendor, o]));
+check("the record whose terms moved keeps its stale verification date", byVendor.Examplebase.verifiedDate === "2026-01-01", byVendor.Examplebase.verifiedDate);
+check("the record the reading confirmed was stamped fresh", byVendor.Steadybase.verifiedDate !== "2026-01-02", byVendor.Steadybase.verifiedDate);
+check("the record we could not classify keeps its stale verification date", byVendor.Vaguebase.verifiedDate === "2026-01-03", byVendor.Vaguebase.verifiedDate);
+check("no entry was written for the detection we could not classify", !log.changes.some((c) => c.vendor === "Vaguebase"));
+check("the run said a detection was dropped rather than dropping it silently", /Vaguebase — change detected but not recordable/.test(first.out));
+check("the run reported what it recorded", /Recorded to data\/deal_changes.json: 1/.test(first.out));
+
+console.log("");
+console.log("── Run 2: the same records come round again ──");
+const second = await run("reverify-rolling.js", ["--ai", "--limit", "3"], env);
+console.log(second.out.split("\n").map((l) => `    ${l}`).join("\n"));
+
+log = JSON.parse(readFileSync(changesPath, "utf-8"));
+check("the second run exited cleanly", second.code === 0, `exit ${second.code}`);
+check("the change was not written a second time", log.changes.length === 1, `${log.changes.length} entries`);
+check("the second run said why it wrote nothing", /not recorded: /.test(second.out));
+
+console.log("");
+console.log("── URL mode over the same records ──");
+const urlRun = await run("reverify-rolling.js", ["--limit", "3"], env);
+log = JSON.parse(readFileSync(changesPath, "utf-8"));
+check("URL mode exited cleanly", urlRun.code === 0, `exit ${urlRun.code}`);
+check("URL mode wrote nothing to the change log", log.changes.length === 1, `${log.changes.length} entries`);
+check("URL mode states that it cannot detect a change", /URL mode compares nothing and cannot report a change/.test(urlRun.out));
+index = JSON.parse(readFileSync(indexPath, "utf-8"));
+const afterUrl = Object.fromEntries(index.offers.map((o) => [o.vendor, o]));
+check("URL mode re-stamps the record whose terms moved, undoing the date AI mode withheld", afterUrl.Examplebase.verifiedDate !== "2026-01-01", afterUrl.Examplebase.verifiedDate);
+console.log("    ^ this check passing is the collision, not the fix: the daily URL job restores a fresh");
+console.log("      verifiedDate on a record a reading found to be wrong. Withholding the stamp only holds");
+console.log("      if the record carries a flag the URL job also respects.");
+
+console.log("");
+console.log("── The staleness alarm ──");
+const fresh = await run("check-change-log-staleness.js", [], { AGENTDEALS_CHANGES_PATH: changesPath });
+check("a log written today passes", fresh.code === 0, `exit ${fresh.code}`);
+check("the alarm reports the machine-written total", /Machine-detected entries: 1/.test(fresh.out), fresh.out.trim());
+
+const stalePath = join(work, "stale_changes.json");
+writeFileSync(stalePath, JSON.stringify({
+  changes: [{ vendor: "Old", change_type: "restriction", date: "2026-04-21", recorded_date: "2026-04-21" }],
+}, null, 2) + "\n");
+const stale = await run("check-change-log-staleness.js", [], { AGENTDEALS_CHANGES_PATH: stalePath });
+check("a log that stopped growing fails the job", stale.code === 1, `exit ${stale.code}`);
+check("the failure names the number that was invisible", /Days since last change recorded: \d+/.test(stale.out));
+check("the failure says the daily job cannot clear it", /URL mode, which cannot detect a change/.test(stale.out));
+
+const unmeasurablePath = join(work, "unmeasurable_changes.json");
+writeFileSync(unmeasurablePath, JSON.stringify({
+  changes: [{ vendor: "Old", change_type: "restriction", date: "2026-04-21" }],
+}, null, 2) + "\n");
+const unmeasurable = await run("check-change-log-staleness.js", [], { AGENTDEALS_CHANGES_PATH: unmeasurablePath });
+check("a log whose age cannot be measured fails the job", unmeasurable.code === 1, `exit ${unmeasurable.code}`);
+
+pages.close();
+anthropic.close();
+rmSync(work, { recursive: true, force: true });
+
+console.log("");
+console.log(`── ${checks - failures}/${checks} checks passed ──`);
+process.exit(failures === 0 ? 0 : 1);

--- a/scripts/mutate-1074.sh
+++ b/scripts/mutate-1074.sh
@@ -1,0 +1,152 @@
+#!/usr/bin/env bash
+set -u
+
+cd "$(dirname "$0")/.." || exit 1
+
+FILES=(scripts/change-log.js scripts/reverify-rolling.js scripts/check-change-log-staleness.js scripts/backfill-change-recorded-dates.js src/data.ts src/serve.ts)
+BACKUP=$(mktemp -d)
+for f in "${FILES[@]}"; do
+  mkdir -p "$BACKUP/$(dirname "$f")"
+  cp "$f" "$BACKUP/$f"
+done
+
+restore() {
+  for f in "${FILES[@]}"; do cp "$BACKUP/$f" "$f"; done
+  npm run build > /dev/null 2>&1
+}
+
+killed=0
+survived=0
+SURVIVORS=()
+
+mutate() {
+  local label="$1"; local file="$2"; local from="$3"; local to="$4"
+  restore
+  if ! grep -qF -- "$from" "$file"; then
+    echo "  SKIP (pattern absent): $label"
+    return
+  fi
+  python3 - "$file" "$from" "$to" <<'PY'
+import sys
+path, frm, to = sys.argv[1], sys.argv[2], sys.argv[3]
+src = open(path).read()
+open(path, "w").write(src.replace(frm, to, 1))
+PY
+  npm run build > /dev/null 2>&1
+  if node --test --test-concurrency 1 test/change-log-writer.test.ts > /tmp/mutate-1074-run.log 2>&1; then
+    survived=$((survived + 1))
+    SURVIVORS+=("$label")
+    echo "  SURVIVED: $label"
+  else
+    killed=$((killed + 1))
+    echo "  killed:   $label"
+  fi
+}
+
+echo "── Mutating the change-log writer ──"
+
+mutate "entry takes previous_state from the page reading instead of our record" \
+  scripts/change-log.js "previous_state: offer.description," "previous_state: currentState,"
+mutate "entry takes current_state from our own record instead of the page" \
+  scripts/change-log.js "current_state: currentState," "current_state: offer.description,"
+mutate "entry is not marked as machine-written" \
+  scripts/change-log.js "detected_by: options.detectedBy ?? DETECTED_BY_AI," "detected_by: undefined,"
+mutate "entry does not say when it was recorded" \
+  scripts/change-log.js "recorded_date: recordedDate," "recorded_date: undefined,"
+mutate "recorded date is used as the change date even when the page gives one" \
+  scripts/change-log.js "? result.effective_date.trim()" "? recordedDate"
+mutate "an unknown change type is written anyway" \
+  scripts/change-log.js "if (!CHANGE_TYPES.includes(changeType)) missing.push(\"change_type\");" "if (false) missing.push(\"change_type\");"
+mutate "a detection with no current state is written anyway" \
+  scripts/change-log.js "if (!currentState) missing.push(\"current_state\");" "if (false) missing.push(\"current_state\");"
+mutate "a detection with no summary is written anyway" \
+  scripts/change-log.js "if (!summary) missing.push(\"summary\");" "if (false) missing.push(\"summary\");"
+mutate "only the first missing field is reported" \
+  scripts/change-log.js "if (missing.length > 0) return { entry: null, missing };" "if (missing.length > 0) return { entry: null, missing: missing.slice(0, 1) };"
+mutate "dedup by exact key is dropped" \
+  scripts/change-log.js "if (keys.has(key)) {" "if (false) {"
+mutate "dedup inside the re-pick window is dropped" \
+  scripts/change-log.js "if (lastStamp && daysBetween(lastStamp, candidate.recorded_date) < windowDays) {" "if (false) {"
+mutate "the re-pick window swallows every later change of the same kind" \
+  scripts/change-log.js "const windowDays = options.windowDays ?? DEFAULT_REPICK_WINDOW_DAYS;" "const windowDays = 100000;"
+mutate "a candidate does not block its own duplicate inside one batch" \
+  scripts/change-log.js "keys.add(key);" "void key;"
+mutate "the exact-key guard is dropped while the window guard stays" \
+  scripts/change-log.js "if (keys.has(key)) {
+      suppressed.push({ candidate, reason: \"already_recorded\" });
+      continue;
+    }" "if (false) {
+      suppressed.push({ candidate, reason: \"already_recorded\" });
+      continue;
+    }"
+mutate "a dry run writes to disk anyway" \
+  scripts/change-log.js "if (fresh.length > 0 && !options.dryRun) {" "if (fresh.length > 0) {"
+mutate "freshness reads the change date instead of the date we recorded it" \
+  scripts/change-log.js "const recorded = changes.map((c) => c.recorded_date).filter(Boolean).sort();" "const recorded = changes.map((c) => c.date).filter(Boolean).sort();"
+mutate "freshness reports the oldest recording instead of the newest" \
+  scripts/change-log.js "const last = recorded.length > 0 ? recorded[recorded.length - 1] : null;" "const last = recorded.length > 0 ? recorded[0] : null;"
+mutate "a log with no recorded dates reports an age of zero" \
+  scripts/change-log.js "days_since_last_recorded: last === null ? null : Math.max(0, daysBetween(last, today))," "days_since_last_recorded: last === null ? 0 : Math.max(0, daysBetween(last, today)),"
+mutate "machine-written entries are counted as hand-written" \
+  scripts/change-log.js "machine_detected_total: changes.filter((c) => c.detected_by).length," "machine_detected_total: 0,"
+
+echo "── Mutating the mode that cannot detect ──"
+mutate "URL mode reports a change" \
+  scripts/reverify-rolling.js "return { verified, flagged, changed: 0, changes: [], recorded: [], suppressed: [], unclassified: [] };" \
+  "return { verified, flagged, changed: 1, changes: [{}], recorded: [{}], suppressed: [], unclassified: [] };"
+mutate "URL mode drops the statement that it cannot detect" \
+  scripts/reverify-rolling.js "lines.push(\"Change detection: not run. URL mode compares nothing and cannot report a change.\");" "lines.push(\"\");"
+mutate "URL mode prints a change count as if it were a measurement" \
+  scripts/reverify-rolling.js "lines.push(\"Change detection: not run. URL mode compares nothing and cannot report a change.\");" "lines.push(\`Changed (PM review needed): \${result.changed}\`);"
+mutate "AI mode stamps a record whose terms it found had moved" \
+  scripts/reverify-rolling.js "} else if (result.status === \"changed\") {" "} else if (result.status === \"changed\" && (data.offers[index].verifiedDate = staggeredDate(now))) {"
+mutate "AI mode does not write what it detected" \
+  scripts/reverify-rolling.js "const { appended, suppressed } = appendFn(changes, {" "const { appended, suppressed } = appendFn([], {"
+mutate "AI mode counts an unclassifiable detection as nothing" \
+  scripts/reverify-rolling.js "unclassified.push({ vendor: offer.vendor, url: offer.url, missing, summary: result.summary });" "void missing;"
+mutate "the re-pick window is switched off" \
+  scripts/reverify-rolling.js "return Math.max(1, Math.ceil(total / batchSize));" "return 0;"
+mutate "the re-pick window ignores how big the catalogue is" \
+  scripts/reverify-rolling.js "return Math.max(1, Math.ceil(total / batchSize));" "return 1;"
+
+echo "── Mutating the alarm ──"
+mutate "the alarm fires one day early" \
+  scripts/check-change-log-staleness.js "const stale = days === null || days > thresholdDays;" "const stale = days === null || days >= thresholdDays;"
+mutate "the alarm never fires" \
+  scripts/check-change-log-staleness.js "const stale = days === null || days > thresholdDays;" "const stale = false;"
+mutate "an unmeasurable age is treated as healthy" \
+  scripts/check-change-log-staleness.js "const stale = days === null || days > thresholdDays;" "const stale = days !== null && days > thresholdDays;"
+mutate "the threshold is loosened past the gap we already had" \
+  scripts/check-change-log-staleness.js "export const DEFAULT_THRESHOLD_DAYS = 14;" "export const DEFAULT_THRESHOLD_DAYS = 200;"
+mutate "the alarm stops saying the daily job cannot clear it" \
+  scripts/check-change-log-staleness.js "\"The daily job runs URL mode, which cannot detect a change. Nothing else writes to this log.\"" "\"\""
+
+echo "── Mutating the backfill ──"
+mutate "the backfill dates an entry from the last commit that held it" \
+  scripts/backfill-change-recorded-dates.js "if (!firstSeen.has(key)) firstSeen.set(key, date);" "firstSeen.set(key, date);"
+
+echo "── Mutating the published surfaces ──"
+mutate "the age is dropped from /api/changes" \
+  src/serve.ts "res.end(JSON.stringify({ ...result, all_time_total: allTimeTotal, change_log_freshness: changeLogFreshness }));" \
+  "res.end(JSON.stringify({ ...result, all_time_total: allTimeTotal }));"
+mutate "the age is dropped from the personalized /api/changes" \
+  src/serve.ts "res.end(JSON.stringify({ ...result, change_log_freshness: changeLogFreshness }));" "res.end(JSON.stringify(result));"
+mutate "the age is dropped from /api/metrics" \
+  src/serve.ts "change_log_freshness: getChangeLogFreshness()," "//"
+mutate "the freshness line is dropped from the change timeline" \
+  src/serve.ts "\${changeLogFreshnessNote()}
+\${monthsHtml}" "\${monthsHtml}"
+mutate "the freshness line is dropped from the expiring page" \
+  src/serve.ts "\${changeLogFreshnessNote()}
+\${totalUpcoming > 0" "\${totalUpcoming > 0"
+mutate "the server disagrees with the writer about the log's age" \
+  src/data.ts "const recorded = changes.map((c) => c.recorded_date).filter((d): d is string => !!d).sort();" \
+  "const recorded = changes.map((c) => c.date).filter((d): d is string => !!d).sort();"
+
+restore
+rm -rf "$BACKUP"
+
+echo ""
+echo "── ${killed} killed, ${survived} survived ──"
+for s in "${SURVIVORS[@]:-}"; do [ -n "$s" ] && echo "  SURVIVOR: $s"; done
+exit 0

--- a/scripts/reverify-rolling.js
+++ b/scripts/reverify-rolling.js
@@ -20,9 +20,11 @@ import { resolve, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 import { reverifyBatch } from "./reverify.js";
 import { fetchPageText, verifyWithHaiku } from "./verify-freshness.js";
+import { buildChangeEntry, appendChangeEntries } from "./change-log.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
-const INDEX_PATH = resolve(__dirname, "..", "data", "index.json");
+const INDEX_PATH =
+  process.env.AGENTDEALS_INDEX_PATH || resolve(__dirname, "..", "data", "index.json");
 const DEFAULT_LIMIT = 100;
 const URL_CONCURRENCY = 10;
 const AI_RATE_LIMIT_MS = 500;
@@ -54,12 +56,12 @@ function sleep(ms) {
   return new Promise((r) => setTimeout(r, ms));
 }
 
-async function runUrlMode(picked, data, dryRun, now) {
+export async function runUrlMode(picked, data, dryRun, now, batchFn = reverifyBatch) {
   let verified = 0;
   let flagged = 0;
   for (let i = 0; i < picked.length; i += URL_CONCURRENCY) {
     const batch = picked.slice(i, i + URL_CONCURRENCY);
-    const results = await reverifyBatch(batch);
+    const results = await batchFn(batch);
     for (const v of results.verified) {
       if (!dryRun) {
         data.offers[v.index].verifiedDate = staggeredDate(now);
@@ -71,37 +73,45 @@ async function runUrlMode(picked, data, dryRun, now) {
       flagged++;
     }
   }
-  return { verified, flagged, changed: 0, changes: [] };
+  return { verified, flagged, changed: 0, changes: [], recorded: [], suppressed: [], unclassified: [] };
 }
 
-async function runAiMode(picked, data, dryRun, now) {
-  const Anthropic = (await import("@anthropic-ai/sdk")).default;
-  if (!process.env.ANTHROPIC_API_KEY) {
-    throw new Error("ANTHROPIC_API_KEY required for --ai mode");
+export async function runAiMode(picked, data, dryRun, now, options = {}) {
+  const fetchFn = options.fetchFn ?? fetchPageText;
+  const appendFn = options.appendFn ?? appendChangeEntries;
+  const rateLimitMs = options.rateLimitMs ?? AI_RATE_LIMIT_MS;
+  let verifyFn = options.verifyFn;
+  if (!verifyFn) {
+    const Anthropic = (await import("@anthropic-ai/sdk")).default;
+    if (!process.env.ANTHROPIC_API_KEY) {
+      throw new Error("ANTHROPIC_API_KEY required for --ai mode");
+    }
+    const client = new Anthropic();
+    verifyFn = (offer, pageText) => verifyWithHaiku(client, offer, pageText);
   }
-  const client = new Anthropic();
 
   let verified = 0;
   let flagged = 0;
   let changed = 0;
   const changes = [];
+  const unclassified = [];
 
   for (const entry of picked) {
     const { offer, index } = entry;
-    const page = await fetchPageText(offer.url);
+    const page = await fetchFn(offer.url);
     if (!page.ok) {
       console.log(`  ⚠ ${offer.vendor} — ${page.error} (${offer.url})`);
       flagged++;
-      await sleep(AI_RATE_LIMIT_MS);
+      await sleep(rateLimitMs);
       continue;
     }
     let result;
     try {
-      result = await verifyWithHaiku(client, offer, page.text);
+      result = await verifyFn(offer, page.text);
     } catch (err) {
       console.log(`  ⚠ ${offer.vendor} — AI error: ${err.message}`);
       flagged++;
-      await sleep(AI_RATE_LIMIT_MS);
+      await sleep(rateLimitMs);
       continue;
     }
     if (result.status === "confirmed") {
@@ -111,20 +121,54 @@ async function runAiMode(picked, data, dryRun, now) {
       verified++;
     } else if (result.status === "changed") {
       changed++;
-      changes.push({
-        vendor: offer.vendor,
-        category: offer.category,
-        tier: offer.tier,
-        summary: result.summary,
-      });
-      console.log(`  ⚠ ${offer.vendor} (${offer.category}, ${offer.tier}): ${result.summary}`);
+      const { entry: change, missing } = buildChangeEntry(offer, result, { now });
+      if (change) {
+        changes.push(change);
+        console.log(`  ⚠ ${offer.vendor} (${offer.category}, ${change.change_type}): ${change.summary}`);
+      } else {
+        unclassified.push({ vendor: offer.vendor, url: offer.url, missing, summary: result.summary });
+        console.log(
+          `  ⚠ ${offer.vendor} — change detected but not recordable, missing ${missing.join(", ")}: ${result.summary || "no detail"}`
+        );
+      }
     } else {
       flagged++;
       console.log(`  ⚠ ${offer.vendor} — unclear: ${result.summary || "no detail"}`);
     }
-    await sleep(AI_RATE_LIMIT_MS);
+    await sleep(rateLimitMs);
   }
-  return { verified, flagged, changed, changes };
+
+  const { appended, suppressed } = appendFn(changes, {
+    dryRun,
+    windowDays: options.windowDays,
+    path: options.changesPath,
+  });
+  for (const { candidate, reason } of suppressed) {
+    console.log(`  – ${candidate.vendor} (${candidate.change_type}) not recorded: ${reason}`);
+  }
+
+  return { verified, flagged, changed, changes, recorded: appended, suppressed, unclassified };
+}
+
+export function repickWindowDays(total, batchSize) {
+  if (!batchSize || batchSize < 1) return 1;
+  return Math.max(1, Math.ceil(total / batchSize));
+}
+
+export function summaryLines(result, { useAi, checked, oldestRemaining, total }) {
+  const lines = ["", "── Summary ──", `Checked: ${checked}`, `Verified (date bumped): ${result.verified}`];
+  if (useAi) {
+    lines.push(`Changed (PM review needed): ${result.changed}`);
+    lines.push(`Recorded to data/deal_changes.json: ${result.recorded.length}`);
+    lines.push(`Already recorded, not written again: ${result.suppressed.length}`);
+    lines.push(`Detected but not recordable: ${result.unclassified.length}`);
+  } else {
+    lines.push("Change detection: not run. URL mode compares nothing and cannot report a change.");
+  }
+  lines.push(`Flagged (URL/AI failure): ${result.flagged}`);
+  lines.push(`Oldest remaining verifiedDate: ${oldestRemaining ?? "n/a"}`);
+  lines.push(`Total entries: ${total}`);
+  return lines;
 }
 
 async function main() {
@@ -167,21 +211,18 @@ async function main() {
   }
 
   const result = useAi
-    ? await runAiMode(picked, data, dryRun, now)
+    ? await runAiMode(picked, data, dryRun, now, {
+        windowDays: repickWindowDays(offers.length, picked.length),
+      })
     : await runUrlMode(picked, data, dryRun, now);
 
   if (!dryRun && result.verified > 0) {
     writeFileSync(INDEX_PATH, JSON.stringify(data, null, 2) + "\n");
   }
 
-  console.log("");
-  console.log("── Summary ──");
-  console.log(`Checked: ${picked.length}`);
-  console.log(`Verified (date bumped): ${result.verified}`);
-  if (useAi) console.log(`Changed (PM review needed): ${result.changed}`);
-  console.log(`Flagged (URL/AI failure): ${result.flagged}`);
-  console.log(`Oldest remaining verifiedDate: ${oldestRemaining ?? "n/a"}`);
-  console.log(`Total entries: ${offers.length}`);
+  for (const line of summaryLines(result, { useAi, checked: picked.length, oldestRemaining, total: offers.length })) {
+    console.log(line);
+  }
 
   process.exit(0);
 }

--- a/scripts/verify-freshness.js
+++ b/scripts/verify-freshness.js
@@ -18,7 +18,9 @@ import { readFileSync, writeFileSync } from "node:fs";
 import { resolve, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 import Anthropic from "@anthropic-ai/sdk";
+import { CHANGE_TYPES } from "./change-log.js";
 
+const CHANGE_TYPE_VALUES = CHANGE_TYPES.join(", ");
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const INDEX_PATH = resolve(__dirname, "..", "data", "index.json");
 const DEFAULT_THRESHOLD_DAYS = 25;
@@ -119,12 +121,17 @@ Compare the stored deal info against the pricing page text. Focus on:
 
 Respond with EXACTLY one of these JSON objects (no other text):
 - If the deal info is still accurate: {"status":"confirmed"}
-- If you found a discrepancy: {"status":"changed","summary":"<brief description of what changed>"}
-- If the page doesn't contain enough info to verify: {"status":"unclear","summary":"<reason>"}`;
+- If the page doesn't contain enough info to verify: {"status":"unclear","summary":"<reason>"}
+- If you found a discrepancy: {"status":"changed","summary":"<what changed>","change_type":"<one of: ${CHANGE_TYPE_VALUES}>","current_state":"<what the page says the terms are now>","impact":"<high|medium|low>","effective_date":"<YYYY-MM-DD, only if the page states when this took effect>"}
+
+Rules for a "changed" response:
+- current_state must describe only what the page text above says. Do not restate the stored deal info and do not infer terms the page does not state.
+- Omit effective_date entirely unless the page gives a date.
+- If you cannot pick a change_type from that list, or cannot state current_state from the page, answer "unclear" instead.`;
 
   const response = await client.messages.create({
     model: HAIKU_MODEL,
-    max_tokens: 200,
+    max_tokens: 400,
     messages: [{ role: "user", content: prompt }],
   });
 

--- a/src/data.ts
+++ b/src/data.ts
@@ -433,6 +433,47 @@ export function loadDealChanges(): DealChange[] {
   return cachedChanges;
 }
 
+export interface ChangeLogFreshness {
+  total: number;
+  last_recorded_date: string | null;
+  days_since_last_recorded: number | null;
+  last_detected_date: string | null;
+  days_since_last_detected: number | null;
+  recorded_last_30_days: number;
+  machine_detected_total: number;
+  entries_without_recorded_date: number;
+}
+
+export function changeLogFreshness(changes: DealChange[], now: Date = new Date()): ChangeLogFreshness {
+  const today = now.toISOString().slice(0, 10);
+  const daysBetween = (from: string, to: string) =>
+    Math.round((Date.parse(to) - Date.parse(from)) / 86400000);
+  const recorded = changes.map((c) => c.recorded_date).filter((d): d is string => !!d).sort();
+  const detected = changes
+    .filter((c) => c.detected_by)
+    .map((c) => c.recorded_date)
+    .filter((d): d is string => !!d)
+    .sort();
+  const last = recorded.length > 0 ? recorded[recorded.length - 1] : null;
+  const lastDetected = detected.length > 0 ? detected[detected.length - 1] : null;
+  const thirtyDaysAgo = new Date(Date.parse(today) - 30 * 86400000).toISOString().slice(0, 10);
+  return {
+    total: changes.length,
+    last_recorded_date: last,
+    days_since_last_recorded: last === null ? null : Math.max(0, daysBetween(last, today)),
+    last_detected_date: lastDetected,
+    days_since_last_detected:
+      lastDetected === null ? null : Math.max(0, daysBetween(lastDetected, today)),
+    recorded_last_30_days: recorded.filter((d) => d >= thirtyDaysAgo).length,
+    machine_detected_total: changes.filter((c) => c.detected_by).length,
+    entries_without_recorded_date: changes.length - recorded.length,
+  };
+}
+
+export function getChangeLogFreshness(now: Date = new Date()): ChangeLogFreshness {
+  return changeLogFreshness(loadDealChanges(), now);
+}
+
 export function getDealChanges(
   since?: string,
   changeType?: string,

--- a/src/serve.ts
+++ b/src/serve.ts
@@ -5,7 +5,7 @@ import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
 import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
 import { createServer, getServerCard } from "./server.js";
-import { vendorRiskAssessment, NEGATIVE_CHANGE_TYPES, POSITIVE_CHANGE_TYPES, SEVERE_CHANGE_TYPES, loadOffers, getCategories, getNewOffers, getNewestDeals, searchOffers, enrichOffers, loadDealChanges, getDealChanges, getPersonalizedChanges, getOfferDetails, compareServices, checkVendorRisk, auditStack, getExpiringDeals, getWeeklyDigest, getFormattedWeeklyDigest, getFreshnessMetrics, getStabilityMap, getVendorReferral, sanitizeQuery } from "./data.js";
+import { vendorRiskAssessment, NEGATIVE_CHANGE_TYPES, POSITIVE_CHANGE_TYPES, SEVERE_CHANGE_TYPES, loadOffers, getCategories, getNewOffers, getNewestDeals, searchOffers, enrichOffers, loadDealChanges, getDealChanges, getPersonalizedChanges, getOfferDetails, compareServices, checkVendorRisk, auditStack, getExpiringDeals, getWeeklyDigest, getFormattedWeeklyDigest, getFreshnessMetrics, getStabilityMap, getVendorReferral, sanitizeQuery, getChangeLogFreshness } from "./data.js";
 import { getStackRecommendation } from "./stacks.js";
 import { estimateCosts } from "./costs.js";
 import { classifyRequest } from "./client-class.js";
@@ -310,6 +310,14 @@ const stats = {
   tools: 4,
   dealChanges: dealChanges.length,
 };
+
+export function changeLogFreshnessNote(now: Date = new Date()): string {
+  const freshness = getChangeLogFreshness(now);
+  if (!freshness.last_recorded_date) return "";
+  const days = freshness.days_since_last_recorded ?? 0;
+  const when = days === 0 ? "today" : days === 1 ? "yesterday" : `${days} days ago`;
+  return `  <p class="log-freshness" style="color:var(--text-dim);font-size:.8rem;margin:-1rem 0 1.5rem">We last added an entry to this log ${when}, on ${freshness.last_recorded_date}. The counts above are changes by the date they took effect, not by the date we recorded them.</p>\n`;
+}
 
 // Prepare recent deal changes for landing page (5 most recent, sorted newest first)
 const recentChanges = [...dealChanges]
@@ -50326,6 +50334,7 @@ ${globalNavCss()}
     </div>
   </div>
 
+${changeLogFreshnessNote()}
 ${monthsHtml}
 
   <div class="mcp-cta">
@@ -50528,6 +50537,7 @@ ${globalNavCss()}
     </div>
   </div>
 
+${changeLogFreshnessNote()}
 ${totalUpcoming > 0 ? upcomingHtml : `  <div class="no-upcoming">No upcoming pricing changes in the next 30 days. Check back soon or <a href="/feed.xml">subscribe via RSS</a>.</div>`}
 
 ${recent.length > 0 ? `  <div class="recent-section">
@@ -54210,6 +54220,7 @@ const httpServer = createHttpServer(async (req, res) => {
       search_analytics: searchAnalytics,
       api_hits_by_endpoint: getApiHitsByEndpoint(),
       top_search_queries_7d: searchAnalytics.top_queries_7d,
+      change_log_freshness: getChangeLogFreshness(),
     }));
   } else if (url.pathname === "/.well-known/glama.json") {
     res.writeHead(200, { "Content-Type": "application/json" });
@@ -54506,17 +54517,18 @@ const httpServer = createHttpServer(async (req, res) => {
     }
     // Personalized mode when vendors or categories filter is active
     const isPersonalized = !!(vendorsFilter || categoriesFilter);
+    const changeLogFreshness = getChangeLogFreshness();
     if (isPersonalized) {
       const result = getPersonalizedChanges(since, type, vendorFilter, vendorsFilter, categoriesFilter);
       logRequest({ ts: new Date().toISOString(), type: "api", endpoint: "/api/changes", params: { since, type, vendor: vendorFilter, vendors: vendorsFilter, categories: categoriesFilter, personalized: true }, user_agent: req.headers["user-agent"] ?? "unknown", result_count: result.your_stack_changes.length });
       res.writeHead(200, { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" });
-      res.end(JSON.stringify(result));
+      res.end(JSON.stringify({ ...result, change_log_freshness: changeLogFreshness }));
     } else {
       const result = getDealChanges(since, type, vendorFilter, vendorsFilter, categoriesFilter);
       const allTimeTotal = loadDealChanges().length;
       logRequest({ ts: new Date().toISOString(), type: "api", endpoint: "/api/changes", params: { since, type, vendor: vendorFilter, vendors: vendorsFilter }, user_agent: req.headers["user-agent"] ?? "unknown", result_count: result.changes.length });
       res.writeHead(200, { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" });
-      res.end(JSON.stringify({ ...result, all_time_total: allTimeTotal }));
+      res.end(JSON.stringify({ ...result, all_time_total: allTimeTotal, change_log_freshness: changeLogFreshness }));
     }
   } else if (url.pathname === "/api/deadlines" && isGetOrHead) {
     recordApiHit("/api/deadlines");

--- a/src/types.ts
+++ b/src/types.ts
@@ -112,6 +112,8 @@ export interface DealChange {
   source_url: string;
   category: string;
   alternatives: string[];
+  detected_by?: string;
+  recorded_date?: string;
 }
 
 export interface DealChangesIndex {

--- a/test/change-log-writer.test.ts
+++ b/test/change-log-writer.test.ts
@@ -1,0 +1,590 @@
+import { describe, it, before, after } from "node:test";
+import assert from "node:assert";
+import { spawn, type ChildProcess } from "node:child_process";
+import { readFileSync, writeFileSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { changeLogFreshness as serverFreshness } from "../dist/data.js";
+
+const {
+  buildChangeEntry,
+  selectNewChanges,
+  appendChangeEntries,
+  changeLogFreshness,
+  changeKey,
+  CHANGE_TYPES,
+  DETECTED_BY_AI,
+} = await import("../scripts/change-log.js");
+
+const { runUrlMode, runAiMode, summaryLines, repickWindowDays } = await import("../scripts/reverify-rolling.js");
+const { firstSeenDates } = await import("../scripts/backfill-change-recorded-dates.js");
+const { report, DEFAULT_THRESHOLD_DAYS } = await import("../scripts/check-change-log-staleness.js");
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO = path.join(__dirname, "..");
+const NOW = new Date("2026-08-27T09:00:00Z");
+
+const OFFER = {
+  vendor: "Examplebase",
+  category: "Databases",
+  tier: "Free",
+  description: "500 MB storage and 2 GB egress per month, free forever",
+  url: "https://examplebase.dev/pricing",
+};
+
+const DETECTION = {
+  status: "changed",
+  summary: "The free plan is now a 14-day trial",
+  change_type: "free_tier_removed",
+  current_state: "500 MB for 14 days, then $19/month",
+  impact: "high",
+  effective_date: "2026-08-01",
+};
+
+function tempLog(changes: unknown[]): string {
+  const dir = mkdtempSync(path.join(tmpdir(), "change-log-"));
+  const file = path.join(dir, "deal_changes.json");
+  writeFileSync(file, JSON.stringify({ changes }, null, 2) + "\n");
+  return file;
+}
+
+describe("change log writer", () => {
+  describe("buildChangeEntry", () => {
+    it("produces every field the stored record shape requires", () => {
+      const { entry } = buildChangeEntry(OFFER, DETECTION, { now: NOW });
+      const required = [
+        "vendor", "change_type", "date", "summary", "previous_state",
+        "current_state", "impact", "source_url", "category", "alternatives",
+      ];
+      for (const field of required) {
+        assert.ok(entry[field] !== undefined && entry[field] !== null, `missing ${field}`);
+      }
+      assert.strictEqual(entry.vendor, OFFER.vendor);
+      assert.strictEqual(entry.category, OFFER.category);
+      assert.strictEqual(entry.source_url, OFFER.url);
+      assert.deepStrictEqual(entry.alternatives, []);
+    });
+
+    it("takes previous_state from the stored record and current_state from the page reading", () => {
+      const { entry } = buildChangeEntry(OFFER, DETECTION, { now: NOW });
+      assert.strictEqual(entry.previous_state, OFFER.description);
+      assert.strictEqual(entry.current_state, DETECTION.current_state);
+      assert.notStrictEqual(entry.current_state, OFFER.description);
+    });
+
+    it("marks the entry as machine-written and stamps when it was recorded", () => {
+      const { entry } = buildChangeEntry(OFFER, DETECTION, { now: NOW });
+      assert.strictEqual(entry.detected_by, DETECTED_BY_AI);
+      assert.strictEqual(entry.recorded_date, "2026-08-27");
+    });
+
+    it("keeps the recorded date separate from the date the terms changed", () => {
+      const { entry } = buildChangeEntry(OFFER, DETECTION, { now: NOW });
+      assert.strictEqual(entry.date, "2026-08-01");
+      assert.strictEqual(entry.recorded_date, "2026-08-27");
+    });
+
+    it("falls back to the recorded date when the page gives no effective date", () => {
+      const { effective_date, ...noDate } = DETECTION;
+      const { entry } = buildChangeEntry(OFFER, noDate, { now: NOW });
+      assert.strictEqual(entry.date, "2026-08-27");
+    });
+
+    it("ignores an effective date that is not an ISO day", () => {
+      const { entry } = buildChangeEntry(OFFER, { ...DETECTION, effective_date: "last summer" }, { now: NOW });
+      assert.strictEqual(entry.date, "2026-08-27");
+    });
+
+    it("writes no entry when the change type is not one we publish", () => {
+      const { entry, missing } = buildChangeEntry(OFFER, { ...DETECTION, change_type: "got_worse" }, { now: NOW });
+      assert.strictEqual(entry, null);
+      assert.deepStrictEqual(missing, ["change_type"]);
+    });
+
+    it("writes no entry when the page reading produced no current state", () => {
+      const { entry, missing } = buildChangeEntry(OFFER, { ...DETECTION, current_state: "  " }, { now: NOW });
+      assert.strictEqual(entry, null);
+      assert.deepStrictEqual(missing, ["current_state"]);
+    });
+
+    it("writes no entry when there is no summary", () => {
+      const { summary, ...noSummary } = DETECTION;
+      const { entry, missing } = buildChangeEntry(OFFER, noSummary, { now: NOW });
+      assert.strictEqual(entry, null);
+      assert.deepStrictEqual(missing, ["summary"]);
+    });
+
+    it("reports every field it needed rather than only the first", () => {
+      const { missing } = buildChangeEntry(OFFER, { status: "changed" }, { now: NOW });
+      assert.deepStrictEqual(missing, ["change_type", "summary", "current_state"]);
+    });
+
+    it("accepts every change type the published catalogue uses", () => {
+      for (const changeType of CHANGE_TYPES) {
+        const { entry } = buildChangeEntry(OFFER, { ...DETECTION, change_type: changeType }, { now: NOW });
+        assert.ok(entry, `${changeType} was rejected`);
+        assert.strictEqual(entry.change_type, changeType);
+      }
+    });
+
+    it("defaults impact rather than inventing one when the model omits it", () => {
+      const { impact, ...noImpact } = DETECTION;
+      const { entry } = buildChangeEntry(OFFER, noImpact, { now: NOW });
+      assert.strictEqual(entry.impact, "medium");
+    });
+  });
+
+  describe("selectNewChanges", () => {
+    const candidate = () => buildChangeEntry(OFFER, DETECTION, { now: NOW }).entry;
+
+    it("records a change nothing in the log already covers", () => {
+      const { fresh, suppressed } = selectNewChanges([], [candidate()]);
+      assert.strictEqual(fresh.length, 1);
+      assert.strictEqual(suppressed.length, 0);
+    });
+
+    it("does not write the same change twice", () => {
+      const existing = candidate();
+      const { fresh, suppressed } = selectNewChanges([existing], [candidate()]);
+      assert.strictEqual(fresh.length, 0);
+      assert.strictEqual(suppressed[0].reason, "already_recorded");
+    });
+
+    it("does not write a second copy when the same record is re-read before the catalogue comes round again", () => {
+      const yesterday = { ...candidate(), recorded_date: "2026-08-26", date: "2026-08-26" };
+      const today = { ...candidate(), recorded_date: "2026-08-27", date: "2026-08-27" };
+      const { fresh, suppressed } = selectNewChanges([yesterday], [today], { windowDays: 21 });
+      assert.strictEqual(fresh.length, 0);
+      assert.strictEqual(suppressed[0].reason, "recorded_within_repick_window");
+    });
+
+    it("records a later change of the same kind once the window has passed", () => {
+      const old = { ...candidate(), recorded_date: "2026-06-01", date: "2026-06-01" };
+      const now = { ...candidate(), recorded_date: "2026-08-27", date: "2026-08-27" };
+      const { fresh } = selectNewChanges([old], [now], { windowDays: 21 });
+      assert.strictEqual(fresh.length, 1);
+    });
+
+    it("suppresses a repeat against a hand-written entry that carries no recorded date", () => {
+      const handWritten = { ...candidate(), date: "2026-08-20" };
+      delete handWritten.recorded_date;
+      delete handWritten.detected_by;
+      const { fresh, suppressed } = selectNewChanges([handWritten], [
+        { ...candidate(), date: "2026-08-27", recorded_date: "2026-08-27" },
+      ], { windowDays: 21 });
+      assert.strictEqual(fresh.length, 0);
+      assert.strictEqual(suppressed[0].reason, "recorded_within_repick_window");
+    });
+
+    it("does not write the same change twice within one batch", () => {
+      const { fresh, suppressed } = selectNewChanges([], [candidate(), candidate()]);
+      assert.strictEqual(fresh.length, 1);
+      assert.strictEqual(suppressed.length, 1);
+    });
+
+    it("keeps changes for different vendors apart", () => {
+      const other = { ...candidate(), vendor: "Otherbase" };
+      const { fresh } = selectNewChanges([candidate()], [other]);
+      assert.strictEqual(fresh.length, 1);
+    });
+
+    it("blocks an exact repeat even with the re-pick window switched off", () => {
+      const { fresh, suppressed } = selectNewChanges([], [candidate(), candidate()], { windowDays: 0 });
+      assert.strictEqual(fresh.length, 1);
+      assert.strictEqual(suppressed[0].reason, "already_recorded");
+    });
+
+    it("blocks an exact repeat against the stored log with the window switched off", () => {
+      const { fresh, suppressed } = selectNewChanges([candidate()], [candidate()], { windowDays: 0 });
+      assert.strictEqual(fresh.length, 0);
+      assert.strictEqual(suppressed[0].reason, "already_recorded");
+    });
+  });
+
+  describe("what the run tells whoever reads the log", () => {
+    const urlResult = { verified: 3, flagged: 1, changed: 0, changes: [], recorded: [], suppressed: [], unclassified: [] };
+    const aiResult = { verified: 1, flagged: 0, changed: 2, changes: [{}], recorded: [{}], suppressed: [{}], unclassified: [{}] };
+    const context = { checked: 4, oldestRemaining: "2026-04-05", total: 1580 };
+
+    it("states that URL mode cannot detect a change rather than printing a count of zero", () => {
+      const lines = summaryLines(urlResult, { ...context, useAi: false });
+      assert.ok(lines.some((l: string) => /URL mode compares nothing and cannot report a change/.test(l)));
+      assert.ok(!lines.some((l: string) => /^Changed/.test(l)), "URL mode printed a change count");
+    });
+
+    it("reports what AI mode wrote, what it withheld and what it could not classify", () => {
+      const lines = summaryLines(aiResult, { ...context, useAi: true });
+      assert.ok(lines.includes("Recorded to data/deal_changes.json: 1"));
+      assert.ok(lines.includes("Already recorded, not written again: 1"));
+      assert.ok(lines.includes("Detected but not recordable: 1"));
+    });
+
+    it("derives the re-pick window from how long the catalogue takes to come round", () => {
+      assert.strictEqual(repickWindowDays(1580, 75), 22);
+      assert.strictEqual(repickWindowDays(150, 75), 2);
+    });
+
+    it("never derives a window that switches the guard off", () => {
+      assert.strictEqual(repickWindowDays(0, 75), 1);
+      assert.strictEqual(repickWindowDays(1580, 0), 1);
+      assert.ok(repickWindowDays(10, 1000) >= 1);
+    });
+  });
+
+  describe("appendChangeEntries", () => {
+    it("adds the entry to the file on disk", () => {
+      const file = tempLog([]);
+      const { entry } = buildChangeEntry(OFFER, DETECTION, { now: NOW });
+      const result = appendChangeEntries([entry], { path: file });
+      assert.strictEqual(result.appended.length, 1);
+      const written = JSON.parse(readFileSync(file, "utf-8"));
+      assert.strictEqual(written.changes.length, 1);
+      assert.strictEqual(written.changes[0].vendor, OFFER.vendor);
+      assert.strictEqual(written.changes[0].detected_by, DETECTED_BY_AI);
+      rmSync(path.dirname(file), { recursive: true, force: true });
+    });
+
+    it("preserves entries that were already in the file", () => {
+      const existing = { ...buildChangeEntry({ ...OFFER, vendor: "Priorbase" }, DETECTION, { now: NOW }).entry };
+      const file = tempLog([existing]);
+      const { entry } = buildChangeEntry(OFFER, DETECTION, { now: NOW });
+      appendChangeEntries([entry], { path: file });
+      const written = JSON.parse(readFileSync(file, "utf-8"));
+      assert.strictEqual(written.changes.length, 2);
+      assert.strictEqual(written.changes[0].vendor, "Priorbase");
+      rmSync(path.dirname(file), { recursive: true, force: true });
+    });
+
+    it("writes nothing on a dry run", () => {
+      const file = tempLog([]);
+      const { entry } = buildChangeEntry(OFFER, DETECTION, { now: NOW });
+      const result = appendChangeEntries([entry], { path: file, dryRun: true });
+      assert.strictEqual(result.appended.length, 1);
+      const written = JSON.parse(readFileSync(file, "utf-8"));
+      assert.strictEqual(written.changes.length, 0);
+      rmSync(path.dirname(file), { recursive: true, force: true });
+    });
+  });
+
+  describe("URL mode reports no change because it compares nothing", () => {
+    const picked = [
+      { index: 0, offer: { ...OFFER, verifiedDate: "2026-01-01" } },
+      { index: 1, offer: { ...OFFER, vendor: "Otherbase", verifiedDate: "2026-01-02" } },
+    ];
+
+    it("returns a change count of zero even when every entry is reachable", async () => {
+      const data = { offers: picked.map((p) => ({ ...p.offer })) };
+      const batchFn = async (batch: any[]) => ({
+        verified: batch.map((b) => ({ index: b.index, vendor: b.offer.vendor })),
+        flagged: [],
+      });
+      const result = await runUrlMode(picked, data, false, NOW, batchFn);
+      assert.strictEqual(result.verified, 2);
+      assert.strictEqual(result.changed, 0);
+      assert.deepStrictEqual(result.changes, []);
+      assert.deepStrictEqual(result.recorded, []);
+    });
+
+    it("returns a change count of zero when every entry fails its fetch", async () => {
+      const data = { offers: picked.map((p) => ({ ...p.offer })) };
+      const batchFn = async (batch: any[]) => ({
+        verified: [],
+        flagged: batch.map((b) => ({ vendor: b.offer.vendor, url: b.offer.url, error: "HTTP 500" })),
+      });
+      const result = await runUrlMode(picked, data, false, NOW, batchFn);
+      assert.strictEqual(result.flagged, 2);
+      assert.strictEqual(result.changed, 0);
+      assert.deepStrictEqual(result.changes, []);
+    });
+
+    it("stamps a fresh verifiedDate on a page that merely answered", async () => {
+      const data = { offers: picked.map((p) => ({ ...p.offer })) };
+      const batchFn = async (batch: any[]) => ({
+        verified: batch.map((b) => ({ index: b.index, vendor: b.offer.vendor })),
+        flagged: [],
+      });
+      await runUrlMode(picked, data, false, NOW, batchFn);
+      assert.notStrictEqual(data.offers[0].verifiedDate, "2026-01-01");
+    });
+  });
+
+  describe("AI mode is the only mode that can write a change", () => {
+    const picked = [{ index: 0, offer: { ...OFFER, verifiedDate: "2026-01-01" } }];
+    const fetchFn = async () => ({ ok: true, text: "500 MB for 14 days, then $19/month" });
+
+    it("writes the detected change to the log", async () => {
+      const file = tempLog([]);
+      const data = { offers: [{ ...OFFER, verifiedDate: "2026-01-01" }] };
+      const result = await runAiMode(picked, data, false, NOW, {
+        fetchFn,
+        verifyFn: async () => DETECTION,
+        rateLimitMs: 0,
+        changesPath: file,
+      });
+      assert.strictEqual(result.changed, 1);
+      assert.strictEqual(result.recorded.length, 1);
+      const written = JSON.parse(readFileSync(file, "utf-8"));
+      assert.strictEqual(written.changes.length, 1);
+      rmSync(path.dirname(file), { recursive: true, force: true });
+    });
+
+    it("leaves a changed record carrying its stale verification date", async () => {
+      const file = tempLog([]);
+      const data = { offers: [{ ...OFFER, verifiedDate: "2026-01-01" }] };
+      await runAiMode(picked, data, false, NOW, {
+        fetchFn,
+        verifyFn: async () => DETECTION,
+        rateLimitMs: 0,
+        changesPath: file,
+      });
+      assert.strictEqual(data.offers[0].verifiedDate, "2026-01-01");
+      rmSync(path.dirname(file), { recursive: true, force: true });
+    });
+
+    it("counts a detection it cannot classify instead of writing a guess", async () => {
+      const file = tempLog([]);
+      const data = { offers: [{ ...OFFER, verifiedDate: "2026-01-01" }] };
+      const result = await runAiMode(picked, data, false, NOW, {
+        fetchFn,
+        verifyFn: async () => ({ status: "changed", summary: "something moved" }),
+        rateLimitMs: 0,
+        changesPath: file,
+      });
+      assert.strictEqual(result.changed, 1);
+      assert.strictEqual(result.recorded.length, 0);
+      assert.strictEqual(result.unclassified.length, 1);
+      const written = JSON.parse(readFileSync(file, "utf-8"));
+      assert.strictEqual(written.changes.length, 0);
+      rmSync(path.dirname(file), { recursive: true, force: true });
+    });
+
+    it("writes nothing when the reading confirms the record", async () => {
+      const file = tempLog([]);
+      const data = { offers: [{ ...OFFER, verifiedDate: "2026-01-01" }] };
+      const result = await runAiMode(picked, data, false, NOW, {
+        fetchFn,
+        verifyFn: async () => ({ status: "confirmed" }),
+        rateLimitMs: 0,
+        changesPath: file,
+      });
+      assert.strictEqual(result.verified, 1);
+      assert.strictEqual(result.recorded.length, 0);
+      assert.ok(
+        ["2026-08-25", "2026-08-26", "2026-08-27"].includes(data.offers[0].verifiedDate),
+        `confirmed record was stamped ${data.offers[0].verifiedDate}`
+      );
+      rmSync(path.dirname(file), { recursive: true, force: true });
+    });
+  });
+});
+
+describe("change log freshness", () => {
+  const changes = [
+    { vendor: "A", change_type: "restriction", date: "2026-01-01", recorded_date: "2026-08-01" },
+    { vendor: "B", change_type: "restriction", date: "2026-02-01", recorded_date: "2026-08-20", detected_by: DETECTED_BY_AI },
+    { vendor: "C", change_type: "restriction", date: "2026-03-01", recorded_date: "2026-06-01" },
+  ];
+
+  it("counts days since anything was added, not days since the newest change date", () => {
+    const freshness = changeLogFreshness(changes, NOW);
+    assert.strictEqual(freshness.last_recorded_date, "2026-08-20");
+    assert.strictEqual(freshness.days_since_last_recorded, 7);
+  });
+
+  it("reports what the detector produced separately from the log as a whole", () => {
+    const freshness = changeLogFreshness(changes, NOW);
+    assert.strictEqual(freshness.machine_detected_total, 1);
+    assert.strictEqual(freshness.last_detected_date, "2026-08-20");
+    assert.strictEqual(freshness.recorded_last_30_days, 2);
+  });
+
+  it("says the age is unmeasurable rather than zero when nothing carries a recorded date", () => {
+    const freshness = changeLogFreshness([{ vendor: "A", change_type: "restriction", date: "2026-01-01" }], NOW);
+    assert.strictEqual(freshness.last_recorded_date, null);
+    assert.strictEqual(freshness.days_since_last_recorded, null);
+    assert.strictEqual(freshness.entries_without_recorded_date, 1);
+  });
+
+  it("agrees with the copy the server publishes from the same entries", () => {
+    assert.deepStrictEqual(changeLogFreshness(changes, NOW), serverFreshness(changes as any, NOW));
+  });
+
+  it("agrees with the server on the published change log", () => {
+    const published = JSON.parse(readFileSync(path.join(REPO, "data", "deal_changes.json"), "utf-8")).changes;
+    assert.deepStrictEqual(changeLogFreshness(published, NOW), serverFreshness(published, NOW));
+  });
+});
+
+describe("the staleness alarm", () => {
+  const freshnessAt = (days: number) => ({
+    total: 289,
+    last_recorded_date: "2026-08-01",
+    days_since_last_recorded: days,
+    last_detected_date: null,
+    days_since_last_detected: null,
+    recorded_last_30_days: 1,
+    machine_detected_total: 0,
+    entries_without_recorded_date: 0,
+  });
+
+  it("stays quiet inside the threshold", () => {
+    assert.strictEqual(report(freshnessAt(DEFAULT_THRESHOLD_DAYS), DEFAULT_THRESHOLD_DAYS).stale, false);
+  });
+
+  it("fires one day past the threshold", () => {
+    assert.strictEqual(report(freshnessAt(DEFAULT_THRESHOLD_DAYS + 1), DEFAULT_THRESHOLD_DAYS).stale, true);
+  });
+
+  it("would have fired long before the gap the log actually had", () => {
+    assert.ok(DEFAULT_THRESHOLD_DAYS < 127);
+    assert.strictEqual(report(freshnessAt(127), DEFAULT_THRESHOLD_DAYS).stale, true);
+  });
+
+  it("fires when the age cannot be measured at all", () => {
+    const unmeasurable = { ...freshnessAt(0), last_recorded_date: null, days_since_last_recorded: null };
+    assert.strictEqual(report(unmeasurable, DEFAULT_THRESHOLD_DAYS).stale, true);
+  });
+
+  it("says the daily job cannot clear the alarm on its own", () => {
+    const { text } = report(freshnessAt(30), DEFAULT_THRESHOLD_DAYS);
+    assert.match(text, /URL mode, which cannot detect a change/);
+  });
+});
+
+describe("recovering when each entry was first written", () => {
+  const entry = (vendor: string) => ({
+    vendor, change_type: "restriction", date: "2026-01-01",
+    source_url: "https://example.com/pricing",
+  });
+
+  it("dates an entry from the commit that introduced it, not the one that last touched it", () => {
+    const commits = [
+      { sha: "a", date: "2026-02-25" },
+      { sha: "b", date: "2026-04-21" },
+      { sha: "c", date: "2026-08-26" },
+    ];
+    const files: Record<string, any[]> = {
+      a: [entry("First")],
+      b: [entry("First"), entry("Second")],
+      c: [entry("First"), entry("Second"), entry("Third")],
+    };
+    const seen = firstSeenDates(commits, (sha: string) => files[sha]);
+    assert.strictEqual(seen.get(changeKey(entry("First"))), "2026-02-25");
+    assert.strictEqual(seen.get(changeKey(entry("Second"))), "2026-04-21");
+    assert.strictEqual(seen.get(changeKey(entry("Third"))), "2026-08-26");
+  });
+
+  it("keeps the original date for an entry that was later edited", () => {
+    const commits = [{ sha: "a", date: "2026-02-25" }, { sha: "b", date: "2026-08-26" }];
+    const files: Record<string, any[]> = {
+      a: [{ ...entry("First"), summary: "as first written" }],
+      b: [{ ...entry("First"), summary: "reworded much later" }],
+    };
+    const seen = firstSeenDates(commits, (sha: string) => files[sha]);
+    assert.strictEqual(seen.get(changeKey(entry("First"))), "2026-02-25");
+  });
+
+  it("skips commits from before the file existed", () => {
+    const commits = [{ sha: "missing", date: "2026-01-01" }, { sha: "a", date: "2026-02-25" }];
+    const seen = firstSeenDates(commits, (sha: string) => {
+      if (sha === "missing") throw new Error("path does not exist in this commit");
+      return [entry("First")];
+    });
+    assert.strictEqual(seen.get(changeKey(entry("First"))), "2026-02-25");
+  });
+});
+
+describe("the published change log", () => {
+  const published = JSON.parse(
+    readFileSync(path.join(REPO, "data", "deal_changes.json"), "utf-8")
+  ).changes;
+
+  it("stamps every entry with the day it was recorded", () => {
+    const missing = published.filter((c: any) => !c.recorded_date);
+    assert.deepStrictEqual(missing.map((c: any) => c.vendor), []);
+  });
+
+  it("uses ISO days for every recorded date", () => {
+    for (const change of published) {
+      assert.match(change.recorded_date, /^\d{4}-\d{2}-\d{2}$/, `${change.vendor} has ${change.recorded_date}`);
+    }
+  });
+
+  it("holds a measurable age", () => {
+    const freshness = changeLogFreshness(published, NOW);
+    assert.strictEqual(freshness.entries_without_recorded_date, 0);
+    assert.ok(typeof freshness.days_since_last_recorded === "number");
+  });
+
+  it("keeps a key that identifies an entry across revisions of the file", () => {
+    const keys = new Set(published.map((c: any) => changeKey(c)));
+    assert.ok(keys.size >= published.length - 1, `${published.length - keys.size} entries share a key`);
+  });
+});
+
+describe("the change log's age reaches the surfaces that publish freshness", () => {
+  let serverPort = 0;
+  let proc: ChildProcess | null = null;
+
+  before(async () => {
+    proc = await new Promise<ChildProcess>((resolve, reject) => {
+      const child = spawn("node", [path.join(REPO, "dist", "serve.js")], {
+        stdio: ["pipe", "pipe", "pipe"],
+        env: { ...process.env, PORT: "0", BASE_URL: "http://localhost" },
+      });
+      const timeout = setTimeout(() => { child.kill(); reject(new Error("Server startup timeout")); }, 30000);
+      child.stderr!.on("data", (data: Buffer) => {
+        const m = data.toString().match(/running on http:\/\/localhost:(\d+)/);
+        if (m) { serverPort = parseInt(m[1], 10); clearTimeout(timeout); resolve(child); }
+      });
+      child.on("error", (err) => { clearTimeout(timeout); reject(err); });
+    });
+  });
+
+  after(() => { if (proc) proc.kill(); });
+
+  it("puts the age on /api/changes", async () => {
+    const res = await fetch(`http://localhost:${serverPort}/api/changes`);
+    assert.strictEqual(res.status, 200);
+    const body = await res.json() as any;
+    assert.ok(body.change_log_freshness, "no change_log_freshness on /api/changes");
+    assert.strictEqual(typeof body.change_log_freshness.days_since_last_recorded, "number");
+    assert.match(body.change_log_freshness.last_recorded_date, /^\d{4}-\d{2}-\d{2}$/);
+  });
+
+  it("reports the age separately from the count of changes", async () => {
+    const res = await fetch(`http://localhost:${serverPort}/api/changes`);
+    const body = await res.json() as any;
+    assert.notStrictEqual(body.change_log_freshness.days_since_last_recorded, body.all_time_total);
+    assert.strictEqual(typeof body.all_time_total, "number");
+    assert.strictEqual(typeof body.change_log_freshness.total, "number");
+  });
+
+  it("puts the age on a personalized /api/changes response too", async () => {
+    const res = await fetch(`http://localhost:${serverPort}/api/changes?vendors=vercel`);
+    assert.strictEqual(res.status, 200);
+    const body = await res.json() as any;
+    assert.ok(body.change_log_freshness, "no change_log_freshness on the personalized response");
+  });
+
+  it("puts the age on /api/metrics", async () => {
+    const res = await fetch(`http://localhost:${serverPort}/api/metrics`);
+    const body = await res.json() as any;
+    assert.ok(body.change_log_freshness, "no change_log_freshness on /api/metrics");
+  });
+
+  it("tells a reader of /changes when the log was last written", async () => {
+    const res = await fetch(`http://localhost:${serverPort}/changes`);
+    const html = await res.text();
+    assert.match(html, /class="log-freshness"/);
+    assert.match(html, /We last added an entry to this log/);
+  });
+
+  it("tells a reader of /expiring when the log was last written", async () => {
+    const res = await fetch(`http://localhost:${serverPort}/expiring`);
+    const html = await res.text();
+    assert.match(html, /class="log-freshness"/);
+    assert.match(html, /We last added an entry to this log/);
+  });
+});


### PR DESCRIPTION
Refs #1074 — Phase 1 only. Phase 2 is untouched and still waiting on the spend decision.

## What was broken

`runAiMode` could return `status: "changed"` with a summary of what moved. That result was printed and handed back to `main()`. Nothing appended it to `data/deal_changes.json`, the workflow's commit step staged `data/index.json` alone, and the daily job ran URL mode, whose change count is the literal `0`. A detection had nowhere to go.

## AC1 — a detected change is written, not printed

`scripts/change-log.js` is new and holds one definition of what a change entry is and when one may be written.

`buildChangeEntry(offer, reading)` produces the full stored shape. `previous_state` is our record — that is what the entry supersedes, by definition. `current_state`, `change_type`, `impact` and the effective date come from the reading of the vendor's page, never from our own prose. `source_url` is the page that was actually read.

**It refuses to write rather than guessing.** If the reading does not yield a `change_type` from our published list, or gives no `current_state`, no entry is built. The detection is counted and named in the run output as `Detected but not recordable, missing <fields>`, and the record does not get a fresh `verifiedDate`. There is no default classification, because a guessed `change_type` is a published claim about a vendor.

`verifyWithHaiku`'s prompt now asks for those fields, lists the exact change types, and tells the model to answer `unclear` rather than invent a classification. `max_tokens` 200 → 400 to fit the extra fields.

**Repeats are suppressed two ways.** A record the model marks `changed` keeps its stale `verifiedDate`, so it stays at the head of the oldest-first queue and is re-read the next day. Without a guard that writes the same entry every day forever. Suppression is by exact key, and by a window derived from how long the catalogue takes to come round again — `ceil(1580/75) = 22` days at the current limit, not a constant. Genuine repeat events outside that window still record. Every suppression is printed with its reason.

## AC2 — machine entries are distinguishable

New entries carry `detected_by: "reverify-ai"`. Hand-written entries have no such field, so the split is readable without reading git history. `/api/changes` reports `machine_detected_total`, currently 0.

## AC3 — days since the log was last written

Every entry now carries `recorded_date`, which is not the same thing as `date`: eleven entries dated after 2026-05-01 were all written on or before 2026-04-21, so the newest `date` in the file says nothing about when we last learned something.

The existing 289 were backfilled from git — `scripts/backfill-change-recorded-dates.js` walks the 86 commits that touched the file and dates each entry from the commit that introduced it. All 289 resolved, none guessed. **It reproduces the number in the issue from the data rather than by hand: widest gap between recording days, 127 (2026-04-21 → 2026-08-26).**

```
2026-02  31    gaps between recording days: median 2, p90 5, max 8 — then 127
2026-03  45
2026-04  211
2026-08    2
```

Published on `/api/changes` (both the plain and the personalized response), `/api/metrics`, and as a line on `/changes` and `/expiring`:

> We last added an entry to this log yesterday, on 2026-08-26. The counts above are changes by the date they took effect, not by the date we recorded them.

That second sentence is there because the `/changes` stat card reads "Last 30 days: 3" while only 2 entries were added in that window — adjacent numbers that mean different things.

`track_changes` over MCP returns the change objects wholesale, so `recorded_date` reaches agents too.

## AC4 — the alarm, and the threshold

`scripts/check-change-log-staleness.js` (`npm run check:change-log`) exits 1 when the log has not grown in **14 days**. It is the last step of the daily workflow, after the commit step, so a red alarm never costs us the day's verification data.

14 because the backfill gives the distribution: while the log was being maintained, the gap between recording days was **median 2, p90 5, widest 8**. 14 is nearly double the widest gap seen in normal operation, so it cannot fire on a quiet fortnight, and it would have fired on **2026-05-05 — 113 days before anyone noticed**.

**This alarm will start failing the daily workflow around 2026-09-09 unless Phase 2 ships, and that is the designed behaviour.** URL mode cannot write to this log. A red daily job is the true statement that nothing is detecting changes, and the failure text says so:

```
STALE: 41 days since anything was added to the change log, past the 14-day threshold.
The daily job runs URL mode, which cannot detect a change. Nothing else writes to this log.
```

It also fails when *no* entry carries a `recorded_date`, so deleting the field cannot read as a healthy zero.

## AC5 — URL mode cannot report a change

`runUrlMode` is exported with an injectable batch function and tested with every entry verified, and again with every entry failed: `changed` is 0 and `changes` is empty in both. Its summary no longer prints a change count at all — it prints `Change detection: not run. URL mode compares nothing and cannot report a change.` A count of zero next to a count of verified records reads as a measurement.

## Two things I could not do, and one collision

**I have no `ANTHROPIC_API_KEY`, so the writer has not run against the real model.** `scripts/e2e-1074.mjs` runs the real CLI in `--ai` mode against a stub Anthropic endpoint and stub vendor pages — 30 checks, covering the append, the withheld stamp, the refusal to classify, the second run not duplicating, URL mode writing nothing, and the alarm's exit codes. That verifies every line of our code on the real path. It does not verify that the model returns the new fields in practice; the first real run must be read, not trusted.

**`data/pricing-hashes.json` and `data/pricing-changes.jsonl` have never existed.** Both are gitignored and `git log --all --diff-filter=A` finds no commit that ever added either. Neither `check:pricing` nor `monitor:pricing` is referenced by any workflow or by the Dockerfile — the only invocation path is a manual `npm run`. Since `data/` is rebuilt from the image on every deploy, nothing they wrote could have survived anywhere.

**The collision, which Phase 1 cannot fix:** AI mode correctly withholds the fresh `verifiedDate` from a record whose terms it found had moved — and the next day's URL-mode run stamps it fresh anyway, because the page returns 200. The e2e asserts this happens today so the behaviour is visible rather than assumed. Withholding the stamp only holds if the record carries a flag the URL job also respects, which is AC8's half of Phase 2.

## Verified

- **1827 tests, 0 failures**, exit code captured directly. 58 new.
- **39 mutations, all killed.** Three survived the first round: two were properties that lived in the untested `main()` — the statement that URL mode cannot detect, and the window derivation — now extracted into `summaryLines()` and `repickWindowDays()` and tested. The third was two dedup guards masking each other, so the exact-key guard is now tested with the window switched off.
- `tsc` clean, `validate-data` clean at 1580 offers / 289 changes.
- The data diff is the new field and nothing else: parsed and compared against `HEAD`, identical once `recorded_date` is stripped.
- Real MCP `initialize` → `tools/call`, and shot-scraper on `/changes` and `/expiring`.
- 0 new code comments in `src/` and `test/`.
