### PR TITLE
Say where a change's date came from, and gate the alarm on the detector

### DIFF
--- a/.github/workflows/reverify.yml
+++ b/.github/workflows/reverify.yml
@@ -12,6 +12,7 @@ on:
 
 permissions:
   contents: write
+  issues: write
 
 concurrency:
   group: reverify-rolling
@@ -60,6 +61,26 @@ jobs:
           git commit -m "data(auto): rolling re-verification — ${VERIFIED} verified, ${FLAGGED} flagged, ${RECORDED} changes recorded"
           git push origin HEAD:main
 
-      - name: Fail if the change log has gone stale
+      - name: Check the change log is still being written to
+        id: staleness
         if: always()
         run: node scripts/check-change-log-staleness.js
+
+      - name: Signal that no change detector is scheduled
+        if: always() && steps.staleness.outputs.open_absence_issue == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          MARKER: reverify-detector-not-scheduled
+        run: |
+          set -euo pipefail
+          EXISTING=$(gh issue list --state open --search "$MARKER in:body" --json number --jq '.[0].number // empty')
+          if [ -n "$EXISTING" ]; then
+            echo "Absence already signalled by issue #$EXISTING — not opening another."
+            exit 0
+          fi
+          node scripts/detector-absence-issue-body.js "$MARKER" > /tmp/absence-issue.md
+          gh issue create \
+            --title "No change detector is scheduled — the daily job cannot notice a pricing change" \
+            --label "priority/high" \
+            --label "type: bug" \
+            --body-file /tmp/absence-issue.md

--- a/data/deal_changes.json
+++ b/data/deal_changes.json
@@ -11,7 +11,8 @@
       "source_url": "https://hyperping.com/pricing",
       "category": "Monitoring",
       "alternatives": [],
-      "recorded_date": "2026-04-21"
+      "recorded_date": "2026-04-21",
+      "date_source": "hand_written"
     },
     {
       "vendor": "Amazon SP-API",
@@ -24,7 +25,8 @@
       "source_url": "https://developer.amazonservices.com/",
       "category": "API Development",
       "alternatives": [],
-      "recorded_date": "2026-04-19"
+      "recorded_date": "2026-04-19",
+      "date_source": "hand_written"
     },
     {
       "vendor": "Xata",
@@ -41,7 +43,8 @@
         "Supabase",
         "CockroachDB"
       ],
-      "recorded_date": "2026-04-19"
+      "recorded_date": "2026-04-19",
+      "date_source": "hand_written"
     },
     {
       "vendor": "Hasura Cloud",
@@ -54,7 +57,8 @@
       "source_url": "https://hasura.io/pricing",
       "category": "Databases",
       "alternatives": [],
-      "recorded_date": "2026-04-19"
+      "recorded_date": "2026-04-19",
+      "date_source": "hand_written"
     },
     {
       "vendor": "Applitools Eyes",
@@ -71,7 +75,8 @@
         "Chromatic",
         "Argos"
       ],
-      "recorded_date": "2026-04-18"
+      "recorded_date": "2026-04-18",
+      "date_source": "hand_written"
     },
     {
       "vendor": "everystep-automation.com",
@@ -87,7 +92,8 @@
         "Selenium IDE",
         "Playwright"
       ],
-      "recorded_date": "2026-04-18"
+      "recorded_date": "2026-04-18",
+      "date_source": "hand_written"
     },
     {
       "vendor": "OpenAI Codex",
@@ -104,7 +110,8 @@
         "Claude Code",
         "Devin"
       ],
-      "recorded_date": "2026-04-15"
+      "recorded_date": "2026-04-15",
+      "date_source": "hand_written"
     },
     {
       "vendor": "GitHub Copilot",
@@ -122,7 +129,8 @@
         "Claude Code",
         "Cline"
       ],
-      "recorded_date": "2026-04-13"
+      "recorded_date": "2026-04-13",
+      "date_source": "hand_written"
     },
     {
       "vendor": "Windsurf",
@@ -135,7 +143,8 @@
       "source_url": "https://windsurf.com/pricing",
       "category": "AI Coding",
       "alternatives": [],
-      "recorded_date": "2026-04-13"
+      "recorded_date": "2026-04-13",
+      "date_source": "hand_written"
     },
     {
       "vendor": "Brave Search API",
@@ -151,7 +160,8 @@
         "SerpAPI",
         "Google Custom Search"
       ],
-      "recorded_date": "2026-04-15"
+      "recorded_date": "2026-04-15",
+      "date_source": "hand_written"
     },
     {
       "vendor": "X API (Twitter)",
@@ -167,7 +177,8 @@
         "Bluesky API",
         "Mastodon API"
       ],
-      "recorded_date": "2026-02-25"
+      "recorded_date": "2026-02-25",
+      "date_source": "hand_written"
     },
     {
       "vendor": "Spotify API",
@@ -183,7 +194,8 @@
         "Last.fm API",
         "MusicBrainz API"
       ],
-      "recorded_date": "2026-02-25"
+      "recorded_date": "2026-02-25",
+      "date_source": "hand_written"
     },
     {
       "vendor": "Amazon SP-API",
@@ -200,7 +212,8 @@
         "WooCommerce API",
         "BigCommerce API"
       ],
-      "recorded_date": "2026-02-25"
+      "recorded_date": "2026-02-25",
+      "date_source": "hand_written"
     },
     {
       "vendor": "PythonAnywhere",
@@ -217,7 +230,8 @@
         "Railway",
         "Replit"
       ],
-      "recorded_date": "2026-02-25"
+      "recorded_date": "2026-02-25",
+      "date_source": "hand_written"
     },
     {
       "vendor": "Google Gemini",
@@ -234,7 +248,8 @@
         "Groq",
         "Together AI"
       ],
-      "recorded_date": "2026-03-09"
+      "recorded_date": "2026-03-09",
+      "date_source": "hand_written"
     },
     {
       "vendor": "Netlify",
@@ -251,7 +266,8 @@
         "Cloudflare Pages",
         "GitHub Pages"
       ],
-      "recorded_date": "2026-02-25"
+      "recorded_date": "2026-02-25",
+      "date_source": "hand_written"
     },
     {
       "vendor": "Netlify",
@@ -268,7 +284,8 @@
         "Cloudflare Pages",
         "GitHub Pages"
       ],
-      "recorded_date": "2026-03-31"
+      "recorded_date": "2026-03-31",
+      "date_source": "hand_written"
     },
     {
       "vendor": "Supabase",
@@ -285,7 +302,8 @@
         "PlanetScale",
         "CockroachDB"
       ],
-      "recorded_date": "2026-02-25"
+      "recorded_date": "2026-02-25",
+      "date_source": "hand_written"
     },
     {
       "vendor": "Cloudflare",
@@ -298,7 +316,8 @@
       "source_url": "https://developers.cloudflare.com/queues/",
       "category": "Cloud IaaS",
       "alternatives": [],
-      "recorded_date": "2026-02-25"
+      "recorded_date": "2026-02-25",
+      "date_source": "hand_written"
     },
     {
       "vendor": "GitHub Actions",
@@ -315,7 +334,8 @@
         "CircleCI",
         "Buildkite"
       ],
-      "recorded_date": "2026-03-14"
+      "recorded_date": "2026-03-14",
+      "date_source": "hand_written"
     },
     {
       "vendor": "Bright Data MCP",
@@ -331,7 +351,8 @@
         "Firecrawl",
         "Apify"
       ],
-      "recorded_date": "2026-02-25"
+      "recorded_date": "2026-02-25",
+      "date_source": "hand_written"
     },
     {
       "vendor": "Stripe",
@@ -347,7 +368,8 @@
         "Paddle",
         "Lemon Squeezy"
       ],
-      "recorded_date": "2026-02-25"
+      "recorded_date": "2026-02-25",
+      "date_source": "hand_written"
     },
     {
       "vendor": "Postman",
@@ -366,7 +388,8 @@
         "Apidog",
         "Thunder Client"
       ],
-      "recorded_date": "2026-03-17"
+      "recorded_date": "2026-03-17",
+      "date_source": "hand_written"
     },
     {
       "vendor": "Atlassian Forge",
@@ -382,7 +405,8 @@
         "AWS Lambda",
         "Self-hosted Connect apps"
       ],
-      "recorded_date": "2026-02-25"
+      "recorded_date": "2026-02-25",
+      "date_source": "hand_written"
     },
     {
       "vendor": "Fly.io",
@@ -399,7 +423,8 @@
         "Railway",
         "Koyeb"
       ],
-      "recorded_date": "2026-02-25"
+      "recorded_date": "2026-02-25",
+      "date_source": "hand_written"
     },
     {
       "vendor": "Cloudflare Durable Objects",
@@ -416,7 +441,8 @@
         "Cloudflare KV",
         "Neon"
       ],
-      "recorded_date": "2026-02-25"
+      "recorded_date": "2026-02-25",
+      "date_source": "hand_written"
     },
     {
       "vendor": "Sentry",
@@ -433,7 +459,8 @@
         "New Relic",
         "BetterStack"
       ],
-      "recorded_date": "2026-02-25"
+      "recorded_date": "2026-02-25",
+      "date_source": "hand_written"
     },
     {
       "vendor": "Neon",
@@ -450,7 +477,8 @@
         "CockroachDB",
         "Turso"
       ],
-      "recorded_date": "2026-02-26"
+      "recorded_date": "2026-02-26",
+      "date_source": "hand_written"
     },
     {
       "vendor": "Vercel",
@@ -467,7 +495,8 @@
         "Cloudflare Pages",
         "Render"
       ],
-      "recorded_date": "2026-02-26"
+      "recorded_date": "2026-02-26",
+      "date_source": "hand_written"
     },
     {
       "vendor": "Atlassian",
@@ -484,7 +513,8 @@
         "Jira Cloud",
         "Shortcut"
       ],
-      "recorded_date": "2026-02-26"
+      "recorded_date": "2026-02-26",
+      "date_source": "hand_written"
     },
     {
       "vendor": "Docker Hub",
@@ -501,7 +531,8 @@
         "Quay.io",
         "Podman"
       ],
-      "recorded_date": "2026-02-26"
+      "recorded_date": "2026-02-26",
+      "date_source": "hand_written"
     },
     {
       "vendor": "DigitalOcean",
@@ -518,7 +549,8 @@
         "Google Cloud for Startups",
         "Azure for Startups"
       ],
-      "recorded_date": "2026-02-26"
+      "recorded_date": "2026-02-26",
+      "date_source": "hand_written"
     },
     {
       "vendor": "Google Cloud",
@@ -535,7 +567,8 @@
         "Azure for Startups",
         "DigitalOcean Hatch"
       ],
-      "recorded_date": "2026-02-26"
+      "recorded_date": "2026-02-26",
+      "date_source": "hand_written"
     },
     {
       "vendor": "AWS",
@@ -552,7 +585,8 @@
         "Azure GPU VMs",
         "Lambda Cloud"
       ],
-      "recorded_date": "2026-02-26"
+      "recorded_date": "2026-02-26",
+      "date_source": "hand_written"
     },
     {
       "vendor": "Google",
@@ -568,7 +602,8 @@
         "GitHub Copilot",
         "JetBrains AI"
       ],
-      "recorded_date": "2026-02-26"
+      "recorded_date": "2026-02-26",
+      "date_source": "hand_written"
     },
     {
       "vendor": "OpenAI",
@@ -585,7 +620,8 @@
         "Google Gemini API",
         "Cohere API"
       ],
-      "recorded_date": "2026-02-26"
+      "recorded_date": "2026-02-26",
+      "date_source": "hand_written"
     },
     {
       "vendor": "Hetzner",
@@ -602,7 +638,8 @@
         "Vultr",
         "OVHcloud"
       ],
-      "recorded_date": "2026-02-26"
+      "recorded_date": "2026-02-26",
+      "date_source": "hand_written"
     },
     {
       "vendor": "Anthropic",
@@ -619,7 +656,8 @@
         "Google Gemini",
         "Mistral"
       ],
-      "recorded_date": "2026-02-26"
+      "recorded_date": "2026-02-26",
+      "date_source": "hand_written"
     },
     {
       "vendor": "OpenAI",
@@ -636,7 +674,8 @@
         "Google Gemini",
         "Perplexity"
       ],
-      "recorded_date": "2026-02-26"
+      "recorded_date": "2026-02-26",
+      "date_source": "hand_written"
     },
     {
       "vendor": "Google Programmable Search Engine",
@@ -654,7 +693,8 @@
         "Bing Web Search API",
         "Meilisearch"
       ],
-      "recorded_date": "2026-02-26"
+      "recorded_date": "2026-02-26",
+      "date_source": "hand_written"
     },
     {
       "vendor": "odrive",
@@ -671,7 +711,8 @@
         "Cyberduck",
         "MultCloud"
       ],
-      "recorded_date": "2026-02-26"
+      "recorded_date": "2026-02-26",
+      "date_source": "hand_written"
     },
     {
       "vendor": "MinIO",
@@ -689,7 +730,8 @@
         "GarageHQ",
         "Apache Ozone"
       ],
-      "recorded_date": "2026-02-26"
+      "recorded_date": "2026-02-26",
+      "date_source": "hand_written"
     },
     {
       "vendor": "Microsoft Partner Developer Benefits",
@@ -705,7 +747,8 @@
         "AWS Partner Network",
         "Google Cloud Partner Advantage"
       ],
-      "recorded_date": "2026-02-26"
+      "recorded_date": "2026-02-26",
+      "date_source": "hand_written"
     },
     {
       "vendor": "Cloudflare Startup Program",
@@ -722,7 +765,8 @@
         "Google for Startups Cloud Program",
         "Azure for Startups"
       ],
-      "recorded_date": "2026-02-26"
+      "recorded_date": "2026-02-26",
+      "date_source": "hand_written"
     },
     {
       "vendor": "Google Gemini 2.0 Flash",
@@ -740,7 +784,8 @@
         "OpenRouter",
         "Groq"
       ],
-      "recorded_date": "2026-02-26"
+      "recorded_date": "2026-02-26",
+      "date_source": "hand_written"
     },
     {
       "vendor": "Logz.io",
@@ -758,7 +803,8 @@
         "Axiom",
         "New Relic"
       ],
-      "recorded_date": "2026-03-02"
+      "recorded_date": "2026-03-02",
+      "date_source": "hand_written"
     },
     {
       "vendor": "X (Twitter)",
@@ -775,7 +821,8 @@
         "Mastodon API",
         "Reddit API"
       ],
-      "recorded_date": "2026-03-02"
+      "recorded_date": "2026-03-02",
+      "date_source": "hand_written"
     },
     {
       "vendor": "OpenAI",
@@ -793,7 +840,8 @@
         "Mistral API",
         "Groq"
       ],
-      "recorded_date": "2026-03-11"
+      "recorded_date": "2026-03-11",
+      "date_source": "hand_written"
     },
     {
       "vendor": "Xero Developer API",
@@ -810,7 +858,8 @@
         "FreshBooks API",
         "Wave API"
       ],
-      "recorded_date": "2026-03-14"
+      "recorded_date": "2026-03-14",
+      "date_source": "hand_written"
     },
     {
       "vendor": "SendGrid",
@@ -828,7 +877,8 @@
         "Mailgun",
         "Amazon SES"
       ],
-      "recorded_date": "2026-03-02"
+      "recorded_date": "2026-03-02",
+      "date_source": "hand_written"
     },
     {
       "vendor": "Firebase",
@@ -846,7 +896,8 @@
         "AWS S3",
         "Backblaze B2"
       ],
-      "recorded_date": "2026-03-02"
+      "recorded_date": "2026-03-02",
+      "date_source": "hand_written"
     },
     {
       "vendor": "PlanetScale",
@@ -864,7 +915,8 @@
         "Supabase",
         "CockroachDB"
       ],
-      "recorded_date": "2026-03-02"
+      "recorded_date": "2026-03-02",
+      "date_source": "hand_written"
     },
     {
       "vendor": "Fauna",
@@ -882,7 +934,8 @@
         "CockroachDB",
         "DynamoDB"
       ],
-      "recorded_date": "2026-03-11"
+      "recorded_date": "2026-03-11",
+      "date_source": "hand_written"
     },
     {
       "vendor": "LocalStack",
@@ -899,7 +952,8 @@
         "AWS Free Tier",
         "Testcontainers"
       ],
-      "recorded_date": "2026-03-02"
+      "recorded_date": "2026-03-02",
+      "date_source": "hand_written"
     },
     {
       "vendor": "Google",
@@ -917,7 +971,8 @@
         "Google for Startups Cloud"
       ],
       "verified_date": "2026-03-04",
-      "recorded_date": "2026-03-11"
+      "recorded_date": "2026-03-11",
+      "date_source": "hand_written"
     },
     {
       "vendor": "Terragrunt Scale",
@@ -934,7 +989,8 @@
         "env0",
         "Scalr"
       ],
-      "recorded_date": "2026-03-04"
+      "recorded_date": "2026-03-04",
+      "date_source": "hand_written"
     },
     {
       "vendor": "HCP Terraform",
@@ -952,7 +1008,8 @@
         "Scalr",
         "Terragrunt Scale"
       ],
-      "recorded_date": "2026-03-09"
+      "recorded_date": "2026-03-09",
+      "date_source": "hand_written"
     },
     {
       "vendor": "X (Twitter)",
@@ -968,7 +1025,8 @@
         "Bluesky AT Protocol",
         "Mastodon API"
       ],
-      "recorded_date": "2026-03-09"
+      "recorded_date": "2026-03-09",
+      "date_source": "hand_written"
     },
     {
       "vendor": "Cognition Devin",
@@ -985,7 +1043,8 @@
         "Cline",
         "Aider"
       ],
-      "recorded_date": "2026-03-13"
+      "recorded_date": "2026-03-13",
+      "date_source": "hand_written"
     },
     {
       "vendor": "Cursor",
@@ -1001,7 +1060,8 @@
         "Windsurf",
         "GitHub Copilot"
       ],
-      "recorded_date": "2026-03-13"
+      "recorded_date": "2026-03-13",
+      "date_source": "hand_written"
     },
     {
       "vendor": "Augment Code",
@@ -1017,7 +1077,8 @@
         "GitHub Copilot",
         "Cursor"
       ],
-      "recorded_date": "2026-03-13"
+      "recorded_date": "2026-03-13",
+      "date_source": "hand_written"
     },
     {
       "vendor": "Google Tenor API",
@@ -1033,7 +1094,8 @@
         "Giphy API",
         "Imgur API"
       ],
-      "recorded_date": "2026-03-14"
+      "recorded_date": "2026-03-14",
+      "date_source": "hand_written"
     },
     {
       "vendor": "Testcontainers Cloud",
@@ -1050,7 +1112,8 @@
         "Docker Desktop",
         "Podman"
       ],
-      "recorded_date": "2026-03-14"
+      "recorded_date": "2026-03-14",
+      "date_source": "hand_written"
     },
     {
       "vendor": "Docker Desktop",
@@ -1067,7 +1130,8 @@
         "Rancher Desktop",
         "OrbStack"
       ],
-      "recorded_date": "2026-03-15"
+      "recorded_date": "2026-03-15",
+      "date_source": "hand_written"
     },
     {
       "vendor": "Unity DevOps",
@@ -1084,7 +1148,8 @@
         "Perforce",
         "GitHub"
       ],
-      "recorded_date": "2026-03-15"
+      "recorded_date": "2026-03-15",
+      "date_source": "hand_written"
     },
     {
       "vendor": "Anthropic Claude",
@@ -1100,7 +1165,8 @@
         "OpenAI ChatGPT Plus",
         "Google Gemini Advanced"
       ],
-      "recorded_date": "2026-03-15"
+      "recorded_date": "2026-03-15",
+      "date_source": "hand_written"
     },
     {
       "vendor": "Heroku",
@@ -1118,7 +1184,8 @@
         "Fly.io",
         "Koyeb"
       ],
-      "recorded_date": "2026-03-19"
+      "recorded_date": "2026-03-19",
+      "date_source": "hand_written"
     },
     {
       "vendor": "GitHub Copilot",
@@ -1135,7 +1202,8 @@
         "Cody",
         "Cursor"
       ],
-      "recorded_date": "2026-03-19"
+      "recorded_date": "2026-03-19",
+      "date_source": "hand_written"
     },
     {
       "vendor": "Auth0",
@@ -1152,7 +1220,8 @@
         "Firebase Auth",
         "Supabase Auth"
       ],
-      "recorded_date": "2026-03-19"
+      "recorded_date": "2026-03-19",
+      "date_source": "hand_written"
     },
     {
       "vendor": "Railway",
@@ -1169,7 +1238,8 @@
         "Fly.io",
         "Koyeb"
       ],
-      "recorded_date": "2026-03-19"
+      "recorded_date": "2026-03-19",
+      "date_source": "hand_written"
     },
     {
       "vendor": "Render",
@@ -1186,7 +1256,8 @@
         "Fly.io",
         "Koyeb"
       ],
-      "recorded_date": "2026-03-19"
+      "recorded_date": "2026-03-19",
+      "date_source": "hand_written"
     },
     {
       "vendor": "Redis",
@@ -1204,7 +1275,8 @@
         "DragonflyDB",
         "Upstash"
       ],
-      "recorded_date": "2026-03-19"
+      "recorded_date": "2026-03-19",
+      "date_source": "hand_written"
     },
     {
       "vendor": "HashiCorp",
@@ -1221,7 +1293,8 @@
         "Pulumi",
         "Crossplane"
       ],
-      "recorded_date": "2026-03-19"
+      "recorded_date": "2026-03-19",
+      "date_source": "hand_written"
     },
     {
       "vendor": "DigitalOcean",
@@ -1238,7 +1311,8 @@
         "Vultr",
         "Linode"
       ],
-      "recorded_date": "2026-03-31"
+      "recorded_date": "2026-03-31",
+      "date_source": "hand_written"
     },
     {
       "vendor": "DigitalOcean",
@@ -1255,7 +1329,8 @@
         "PlanetScale",
         "Supabase"
       ],
-      "recorded_date": "2026-03-21"
+      "recorded_date": "2026-03-21",
+      "date_source": "hand_written"
     },
     {
       "vendor": "Freshping",
@@ -1276,7 +1351,8 @@
         "Cronitor",
         "Upptime"
       ],
-      "recorded_date": "2026-03-21"
+      "recorded_date": "2026-03-21",
+      "date_source": "hand_written"
     },
     {
       "vendor": "Firebase",
@@ -1295,7 +1371,8 @@
         "Nhost",
         "Convex"
       ],
-      "recorded_date": "2026-03-21"
+      "recorded_date": "2026-03-21",
+      "date_source": "hand_written"
     },
     {
       "vendor": "Firebase",
@@ -1314,7 +1391,8 @@
         "Nhost",
         "Convex"
       ],
-      "recorded_date": "2026-03-21"
+      "recorded_date": "2026-03-21",
+      "date_source": "hand_written"
     },
     {
       "vendor": "Dub.co",
@@ -1330,7 +1408,8 @@
         "Bitly",
         "Short.io"
       ],
-      "recorded_date": "2026-03-22"
+      "recorded_date": "2026-03-22",
+      "date_source": "hand_written"
     },
     {
       "vendor": "Uploadthing",
@@ -1347,7 +1426,8 @@
         "Vercel Blob",
         "AWS S3"
       ],
-      "recorded_date": "2026-03-22"
+      "recorded_date": "2026-03-22",
+      "date_source": "hand_written"
     },
     {
       "vendor": "Neo4j AuraDB",
@@ -1363,7 +1443,8 @@
         "Dgraph Cloud",
         "Amazon Neptune"
       ],
-      "recorded_date": "2026-03-22"
+      "recorded_date": "2026-03-22",
+      "date_source": "hand_written"
     },
     {
       "vendor": "xAI (Grok)",
@@ -1380,7 +1461,8 @@
         "Stable Diffusion (self-hosted)",
         "Pollinations.AI"
       ],
-      "recorded_date": "2026-03-24"
+      "recorded_date": "2026-03-24",
+      "date_source": "hand_written"
     },
     {
       "vendor": "Google Gemini API",
@@ -1397,7 +1479,8 @@
         "Anthropic Claude API",
         "OpenAI API"
       ],
-      "recorded_date": "2026-03-26"
+      "recorded_date": "2026-03-26",
+      "date_source": "hand_written"
     },
     {
       "vendor": "Windsurf",
@@ -1414,7 +1497,8 @@
         "GitHub Copilot",
         "Cline"
       ],
-      "recorded_date": "2026-03-31"
+      "recorded_date": "2026-03-31",
+      "date_source": "hand_written"
     },
     {
       "vendor": "Gemini Code Assist",
@@ -1431,7 +1515,8 @@
         "Cursor",
         "Cline"
       ],
-      "recorded_date": "2026-03-27"
+      "recorded_date": "2026-03-27",
+      "date_source": "hand_written"
     },
     {
       "vendor": "Amazon Aurora PostgreSQL",
@@ -1449,7 +1534,8 @@
         "CockroachDB",
         "PlanetScale"
       ],
-      "recorded_date": "2026-03-27"
+      "recorded_date": "2026-03-27",
+      "date_source": "hand_written"
     },
     {
       "vendor": "Amazon Kiro",
@@ -1467,7 +1553,8 @@
         "GitHub Copilot",
         "Claude Code"
       ],
-      "recorded_date": "2026-04-08"
+      "recorded_date": "2026-04-08",
+      "date_source": "hand_written"
     },
     {
       "vendor": "Replit",
@@ -1484,7 +1571,8 @@
         "Gitpod",
         "CodeSandbox"
       ],
-      "recorded_date": "2026-04-08"
+      "recorded_date": "2026-04-08",
+      "date_source": "hand_written"
     },
     {
       "vendor": "SonarQube Cloud",
@@ -1501,7 +1589,8 @@
         "Codacy",
         "DeepSource"
       ],
-      "recorded_date": "2026-04-08"
+      "recorded_date": "2026-04-08",
+      "date_source": "hand_written"
     },
     {
       "vendor": "Cursor",
@@ -1519,7 +1608,8 @@
         "Cline",
         "Claude Code"
       ],
-      "recorded_date": "2026-04-08"
+      "recorded_date": "2026-04-08",
+      "date_source": "hand_written"
     },
     {
       "vendor": "Google Gemini API",
@@ -1537,7 +1627,8 @@
         "Together AI",
         "Anthropic Claude API"
       ],
-      "recorded_date": "2026-04-08"
+      "recorded_date": "2026-04-08",
+      "date_source": "hand_written"
     },
     {
       "vendor": "OVHcloud",
@@ -1555,7 +1646,8 @@
         "Vultr",
         "Linode"
       ],
-      "recorded_date": "2026-04-09"
+      "recorded_date": "2026-04-09",
+      "date_source": "hand_written"
     },
     {
       "vendor": "Amazon SP-API",
@@ -1572,7 +1664,8 @@
         "WooCommerce API",
         "BigCommerce API"
       ],
-      "recorded_date": "2026-04-14"
+      "recorded_date": "2026-04-14",
+      "date_source": "hand_written"
     },
     {
       "vendor": "Amazon Kiro",
@@ -1590,7 +1683,8 @@
         "Windsurf",
         "Claude Code"
       ],
-      "recorded_date": "2026-04-09"
+      "recorded_date": "2026-04-09",
+      "date_source": "hand_written"
     },
     {
       "vendor": "OpenAI",
@@ -1610,7 +1704,8 @@
         "Stability AI",
         "Replicate"
       ],
-      "recorded_date": "2026-04-10"
+      "recorded_date": "2026-04-10",
+      "date_source": "hand_written"
     },
     {
       "vendor": "OpenAI",
@@ -1630,7 +1725,8 @@
         "ElevenLabs",
         "Google Cloud Speech-to-Text"
       ],
-      "recorded_date": "2026-04-10"
+      "recorded_date": "2026-04-10",
+      "date_source": "hand_written"
     },
     {
       "vendor": "AWS",
@@ -1652,7 +1748,8 @@
         "Fly.io",
         "DigitalOcean App Platform"
       ],
-      "recorded_date": "2026-04-10"
+      "recorded_date": "2026-04-10",
+      "date_source": "hand_written"
     },
     {
       "vendor": "AWS",
@@ -1670,7 +1767,8 @@
         "Mac client",
         "Web client"
       ],
-      "recorded_date": "2026-04-10"
+      "recorded_date": "2026-04-10",
+      "date_source": "hand_written"
     },
     {
       "vendor": "AWS",
@@ -1685,7 +1783,8 @@
       "alternatives": [
         "Node.js 22 Lambda runtime"
       ],
-      "recorded_date": "2026-04-10"
+      "recorded_date": "2026-04-10",
+      "date_source": "hand_written"
     },
     {
       "vendor": "Google Maps",
@@ -1700,7 +1799,8 @@
       "alternatives": [
         "Google Maps API key authentication"
       ],
-      "recorded_date": "2026-04-10"
+      "recorded_date": "2026-04-10",
+      "date_source": "hand_written"
     },
     {
       "vendor": "AWS",
@@ -1715,7 +1815,8 @@
       "alternatives": [
         "Fargate Platform Version 1.4.0+"
       ],
-      "recorded_date": "2026-04-10"
+      "recorded_date": "2026-04-10",
+      "date_source": "hand_written"
     },
     {
       "vendor": "AWS",
@@ -1732,7 +1833,8 @@
         "Linkerd",
         "Amazon EKS native service mesh"
       ],
-      "recorded_date": "2026-04-10"
+      "recorded_date": "2026-04-10",
+      "date_source": "hand_written"
     },
     {
       "vendor": "AWS",
@@ -1749,7 +1851,8 @@
         "Terraform",
         "Pulumi"
       ],
-      "recorded_date": "2026-04-10"
+      "recorded_date": "2026-04-10",
+      "date_source": "hand_written"
     },
     {
       "vendor": "Vercel",
@@ -1767,7 +1870,8 @@
         "Render",
         "Railway"
       ],
-      "recorded_date": "2026-04-10"
+      "recorded_date": "2026-04-10",
+      "date_source": "hand_written"
     },
     {
       "vendor": "Augment Code",
@@ -1784,7 +1888,8 @@
         "Cline",
         "Aider"
       ],
-      "recorded_date": "2026-04-12"
+      "recorded_date": "2026-04-12",
+      "date_source": "hand_written"
     },
     {
       "vendor": "Socket.dev",
@@ -1797,7 +1902,8 @@
       "source_url": "https://socket.dev/pricing",
       "category": "Security",
       "alternatives": [],
-      "recorded_date": "2026-04-12"
+      "recorded_date": "2026-04-12",
+      "date_source": "hand_written"
     },
     {
       "vendor": "LocalStack",
@@ -1810,7 +1916,8 @@
       "source_url": "https://www.localstack.cloud/pricing",
       "category": "Testing",
       "alternatives": [],
-      "recorded_date": "2026-04-12"
+      "recorded_date": "2026-04-12",
+      "date_source": "hand_written"
     },
     {
       "vendor": "Xata Lite",
@@ -1827,7 +1934,8 @@
         "PlanetScale",
         "Neon"
       ],
-      "recorded_date": "2026-04-12"
+      "recorded_date": "2026-04-12",
+      "date_source": "hand_written"
     },
     {
       "vendor": "stathat.com",
@@ -1843,7 +1951,8 @@
         "Prometheus",
         "Grafana Cloud"
       ],
-      "recorded_date": "2026-04-12"
+      "recorded_date": "2026-04-12",
+      "date_source": "hand_written"
     },
     {
       "vendor": "Prisma Accelerate",
@@ -1856,7 +1965,8 @@
       "source_url": "https://www.prisma.io/pricing",
       "category": "Databases",
       "alternatives": [],
-      "recorded_date": "2026-04-12"
+      "recorded_date": "2026-04-12",
+      "date_source": "hand_written"
     },
     {
       "vendor": "SurrealDB Cloud",
@@ -1869,7 +1979,8 @@
       "source_url": "https://surrealdb.com/pricing",
       "category": "Databases",
       "alternatives": [],
-      "recorded_date": "2026-04-12"
+      "recorded_date": "2026-04-12",
+      "date_source": "hand_written"
     },
     {
       "vendor": "codehooks.io",
@@ -1882,7 +1993,8 @@
       "source_url": "https://codehooks.io/",
       "category": "Databases",
       "alternatives": [],
-      "recorded_date": "2026-04-12"
+      "recorded_date": "2026-04-12",
+      "date_source": "hand_written"
     },
     {
       "vendor": "SeaTable",
@@ -1895,7 +2007,8 @@
       "source_url": "https://seatable.io/",
       "category": "Databases",
       "alternatives": [],
-      "recorded_date": "2026-04-12"
+      "recorded_date": "2026-04-12",
+      "date_source": "hand_written"
     },
     {
       "vendor": "Phase Two",
@@ -1912,7 +2025,8 @@
         "ZITADEL",
         "SuperTokens"
       ],
-      "recorded_date": "2026-04-12"
+      "recorded_date": "2026-04-12",
+      "date_source": "hand_written"
     },
     {
       "vendor": "Nx Cloud",
@@ -1925,7 +2039,8 @@
       "source_url": "https://nx.dev/ci",
       "category": "CI/CD",
       "alternatives": [],
-      "recorded_date": "2026-04-12"
+      "recorded_date": "2026-04-12",
+      "date_source": "hand_written"
     },
     {
       "vendor": "incidenthub.cloud",
@@ -1938,7 +2053,8 @@
       "source_url": "https://incidenthub.cloud/",
       "category": "Monitoring",
       "alternatives": [],
-      "recorded_date": "2026-04-12"
+      "recorded_date": "2026-04-12",
+      "date_source": "hand_written"
     },
     {
       "vendor": "Servervana",
@@ -1954,7 +2070,8 @@
         "UptimeObserver",
         "Xitoring"
       ],
-      "recorded_date": "2026-04-12"
+      "recorded_date": "2026-04-12",
+      "date_source": "hand_written"
     },
     {
       "vendor": "economize.cloud",
@@ -1967,7 +2084,8 @@
       "source_url": "https://economize.cloud",
       "category": "Monitoring",
       "alternatives": [],
-      "recorded_date": "2026-04-12"
+      "recorded_date": "2026-04-12",
+      "date_source": "hand_written"
     },
     {
       "vendor": "deployhq.com",
@@ -1980,7 +2098,8 @@
       "source_url": "https://www.deployhq.com/",
       "category": "CI/CD",
       "alternatives": [],
-      "recorded_date": "2026-04-12"
+      "recorded_date": "2026-04-12",
+      "date_source": "hand_written"
     },
     {
       "vendor": "Commerce Layer",
@@ -1993,7 +2112,8 @@
       "source_url": "https://commercelayer.io",
       "category": "Dev Utilities",
       "alternatives": [],
-      "recorded_date": "2026-04-12"
+      "recorded_date": "2026-04-12",
+      "date_source": "hand_written"
     },
     {
       "vendor": "Kiter.app",
@@ -2006,7 +2126,8 @@
       "source_url": "https://www.kiter.app/",
       "category": "Dev Utilities",
       "alternatives": [],
-      "recorded_date": "2026-04-12"
+      "recorded_date": "2026-04-12",
+      "date_source": "hand_written"
     },
     {
       "vendor": "Snap Accelerate",
@@ -2019,7 +2140,8 @@
       "source_url": "https://developers.snapchat.com/accelerate/",
       "category": "Startup Perks",
       "alternatives": [],
-      "recorded_date": "2026-04-12"
+      "recorded_date": "2026-04-12",
+      "date_source": "hand_written"
     },
     {
       "vendor": "ActiveCampaign",
@@ -2032,7 +2154,8 @@
       "source_url": "https://segment.com/industry/startups/",
       "category": "Startup Perks",
       "alternatives": [],
-      "recorded_date": "2026-04-12"
+      "recorded_date": "2026-04-12",
+      "date_source": "hand_written"
     },
     {
       "vendor": "Adjust",
@@ -2045,7 +2168,8 @@
       "source_url": "https://segment.com/industry/startups/",
       "category": "Startup Perks",
       "alternatives": [],
-      "recorded_date": "2026-04-12"
+      "recorded_date": "2026-04-12",
+      "date_source": "hand_written"
     },
     {
       "vendor": "Apptimize",
@@ -2058,7 +2182,8 @@
       "source_url": "https://segment.com/industry/startups/",
       "category": "Startup Perks",
       "alternatives": [],
-      "recorded_date": "2026-04-12"
+      "recorded_date": "2026-04-12",
+      "date_source": "hand_written"
     },
     {
       "vendor": "Attribution App",
@@ -2071,7 +2196,8 @@
       "source_url": "https://segment.com/industry/startups/",
       "category": "Startup Perks",
       "alternatives": [],
-      "recorded_date": "2026-04-12"
+      "recorded_date": "2026-04-12",
+      "date_source": "hand_written"
     },
     {
       "vendor": "Branch",
@@ -2084,7 +2210,8 @@
       "source_url": "https://segment.com/industry/startups/",
       "category": "Startup Perks",
       "alternatives": [],
-      "recorded_date": "2026-04-12"
+      "recorded_date": "2026-04-12",
+      "date_source": "hand_written"
     },
     {
       "vendor": "Chartio",
@@ -2097,7 +2224,8 @@
       "source_url": "https://segment.com/industry/startups/",
       "category": "Startup Perks",
       "alternatives": [],
-      "recorded_date": "2026-04-12"
+      "recorded_date": "2026-04-12",
+      "date_source": "hand_written"
     },
     {
       "vendor": "ClearBrain",
@@ -2110,7 +2238,8 @@
       "source_url": "https://segment.com/industry/startups/",
       "category": "Startup Perks",
       "alternatives": [],
-      "recorded_date": "2026-04-12"
+      "recorded_date": "2026-04-12",
+      "date_source": "hand_written"
     },
     {
       "vendor": "Commando.io",
@@ -2123,7 +2252,8 @@
       "source_url": "https://www.userlike.com/en/blog/startup-deals",
       "category": "Startup Perks",
       "alternatives": [],
-      "recorded_date": "2026-04-12"
+      "recorded_date": "2026-04-12",
+      "date_source": "hand_written"
     },
     {
       "vendor": "CrazyEgg",
@@ -2136,7 +2266,8 @@
       "source_url": "https://www.userlike.com/en/blog/startup-deals",
       "category": "Startup Perks",
       "alternatives": [],
-      "recorded_date": "2026-04-12"
+      "recorded_date": "2026-04-12",
+      "date_source": "hand_written"
     },
     {
       "vendor": "Cyfe",
@@ -2149,7 +2280,8 @@
       "source_url": "https://www.userlike.com/en/blog/startup-deals",
       "category": "Startup Perks",
       "alternatives": [],
-      "recorded_date": "2026-04-12"
+      "recorded_date": "2026-04-12",
+      "date_source": "hand_written"
     },
     {
       "vendor": "Drift",
@@ -2162,7 +2294,8 @@
       "source_url": "https://segment.com/industry/startups/",
       "category": "Startup Perks",
       "alternatives": [],
-      "recorded_date": "2026-04-12"
+      "recorded_date": "2026-04-12",
+      "date_source": "hand_written"
     },
     {
       "vendor": "FullContact",
@@ -2175,7 +2308,8 @@
       "source_url": "https://www.userlike.com/en/blog/startup-deals",
       "category": "Startup Perks",
       "alternatives": [],
-      "recorded_date": "2026-04-12"
+      "recorded_date": "2026-04-12",
+      "date_source": "hand_written"
     },
     {
       "vendor": "Gem",
@@ -2188,7 +2322,8 @@
       "source_url": "https://stripe.com/en-de/corporate-card",
       "category": "Startup Perks",
       "alternatives": [],
-      "recorded_date": "2026-04-12"
+      "recorded_date": "2026-04-12",
+      "date_source": "hand_written"
     },
     {
       "vendor": "Google BigQuery",
@@ -2201,7 +2336,8 @@
       "source_url": "https://segment.com/industry/startups/",
       "category": "Startup Perks",
       "alternatives": [],
-      "recorded_date": "2026-04-12"
+      "recorded_date": "2026-04-12",
+      "date_source": "hand_written"
     },
     {
       "vendor": "Guideline",
@@ -2214,7 +2350,8 @@
       "source_url": "https://stripe.com/en-de/corporate-card",
       "category": "Startup Perks",
       "alternatives": [],
-      "recorded_date": "2026-04-12"
+      "recorded_date": "2026-04-12",
+      "date_source": "hand_written"
     },
     {
       "vendor": "Gusto",
@@ -2227,7 +2364,8 @@
       "source_url": "https://stripe.com/en-de/corporate-card",
       "category": "Startup Perks",
       "alternatives": [],
-      "recorded_date": "2026-04-12"
+      "recorded_date": "2026-04-12",
+      "date_source": "hand_written"
     },
     {
       "vendor": "Kasa",
@@ -2240,7 +2378,8 @@
       "source_url": "https://stripe.com/en-de/corporate-card",
       "category": "Startup Perks",
       "alternatives": [],
-      "recorded_date": "2026-04-12"
+      "recorded_date": "2026-04-12",
+      "date_source": "hand_written"
     },
     {
       "vendor": "Lester Lee",
@@ -2253,7 +2392,8 @@
       "source_url": "https://segment.com/industry/startups/",
       "category": "Startup Perks",
       "alternatives": [],
-      "recorded_date": "2026-04-12"
+      "recorded_date": "2026-04-12",
+      "date_source": "hand_written"
     },
     {
       "vendor": "Looker",
@@ -2266,7 +2406,8 @@
       "source_url": "https://segment.com/industry/startups/",
       "category": "Startup Perks",
       "alternatives": [],
-      "recorded_date": "2026-04-12"
+      "recorded_date": "2026-04-12",
+      "date_source": "hand_written"
     },
     {
       "vendor": "Mode",
@@ -2279,7 +2420,8 @@
       "source_url": "https://segment.com/industry/startups/",
       "category": "Startup Perks",
       "alternatives": [],
-      "recorded_date": "2026-04-12"
+      "recorded_date": "2026-04-12",
+      "date_source": "hand_written"
     },
     {
       "vendor": "MoEngage",
@@ -2292,7 +2434,8 @@
       "source_url": "https://segment.com/industry/startups/",
       "category": "Startup Perks",
       "alternatives": [],
-      "recorded_date": "2026-04-12"
+      "recorded_date": "2026-04-12",
+      "date_source": "hand_written"
     },
     {
       "vendor": "Monday",
@@ -2305,7 +2448,8 @@
       "source_url": "https://www.userlike.com/en/blog/startup-deals",
       "category": "Startup Perks",
       "alternatives": [],
-      "recorded_date": "2026-04-12"
+      "recorded_date": "2026-04-12",
+      "date_source": "hand_written"
     },
     {
       "vendor": "PersistIQ",
@@ -2318,7 +2462,8 @@
       "source_url": "https://segment.com/industry/startups/",
       "category": "Startup Perks",
       "alternatives": [],
-      "recorded_date": "2026-04-12"
+      "recorded_date": "2026-04-12",
+      "date_source": "hand_written"
     },
     {
       "vendor": "Pilot",
@@ -2331,7 +2476,8 @@
       "source_url": "https://stripe.com/en-de/corporate-card",
       "category": "Startup Perks",
       "alternatives": [],
-      "recorded_date": "2026-04-12"
+      "recorded_date": "2026-04-12",
+      "date_source": "hand_written"
     },
     {
       "vendor": "Polymail",
@@ -2344,7 +2490,8 @@
       "source_url": "https://www.userlike.com/en/blog/startup-deals",
       "category": "Startup Perks",
       "alternatives": [],
-      "recorded_date": "2026-04-12"
+      "recorded_date": "2026-04-12",
+      "date_source": "hand_written"
     },
     {
       "vendor": "ProofHub",
@@ -2357,7 +2504,8 @@
       "source_url": "https://www.userlike.com/en/blog/startup-deals",
       "category": "Startup Perks",
       "alternatives": [],
-      "recorded_date": "2026-04-12"
+      "recorded_date": "2026-04-12",
+      "date_source": "hand_written"
     },
     {
       "vendor": "Seekwell",
@@ -2370,7 +2518,8 @@
       "source_url": "https://segment.com/industry/startups/",
       "category": "Startup Perks",
       "alternatives": [],
-      "recorded_date": "2026-04-12"
+      "recorded_date": "2026-04-12",
+      "date_source": "hand_written"
     },
     {
       "vendor": "Shopify",
@@ -2383,7 +2532,8 @@
       "source_url": "https://stripe.com/en-de/corporate-card",
       "category": "Startup Perks",
       "alternatives": [],
-      "recorded_date": "2026-04-12"
+      "recorded_date": "2026-04-12",
+      "date_source": "hand_written"
     },
     {
       "vendor": "Split",
@@ -2396,7 +2546,8 @@
       "source_url": "https://segment.com/industry/startups/",
       "category": "Startup Perks",
       "alternatives": [],
-      "recorded_date": "2026-04-12"
+      "recorded_date": "2026-04-12",
+      "date_source": "hand_written"
     },
     {
       "vendor": "Userlike",
@@ -2409,7 +2560,8 @@
       "source_url": "https://www.userlike.com/en/blog/startup-deals",
       "category": "Startup Perks",
       "alternatives": [],
-      "recorded_date": "2026-04-12"
+      "recorded_date": "2026-04-12",
+      "date_source": "hand_written"
     },
     {
       "vendor": "Vero",
@@ -2422,7 +2574,8 @@
       "source_url": "https://segment.com/industry/startups/",
       "category": "Startup Perks",
       "alternatives": [],
-      "recorded_date": "2026-04-12"
+      "recorded_date": "2026-04-12",
+      "date_source": "hand_written"
     },
     {
       "vendor": "Vervoe",
@@ -2435,7 +2588,8 @@
       "source_url": "https://segment.com/industry/startups/",
       "category": "Startup Perks",
       "alternatives": [],
-      "recorded_date": "2026-04-12"
+      "recorded_date": "2026-04-12",
+      "date_source": "hand_written"
     },
     {
       "vendor": "APITemplate.io",
@@ -2448,7 +2602,8 @@
       "source_url": "https://apitemplate.io",
       "category": "Dev Utilities",
       "alternatives": [],
-      "recorded_date": "2026-04-12"
+      "recorded_date": "2026-04-12",
+      "date_source": "hand_written"
     },
     {
       "vendor": "Conversion Tools",
@@ -2461,7 +2616,8 @@
       "source_url": "https://conversiontools.io/",
       "category": "Dev Utilities",
       "alternatives": [],
-      "recorded_date": "2026-04-12"
+      "recorded_date": "2026-04-12",
+      "date_source": "hand_written"
     },
     {
       "vendor": "CraftMyPDF",
@@ -2474,7 +2630,8 @@
       "source_url": "https://craftmypdf.com",
       "category": "Dev Utilities",
       "alternatives": [],
-      "recorded_date": "2026-04-12"
+      "recorded_date": "2026-04-12",
+      "date_source": "hand_written"
     },
     {
       "vendor": "CurrencyScoop",
@@ -2487,7 +2644,8 @@
       "source_url": "https://currencybeacon.com/",
       "category": "Dev Utilities",
       "alternatives": [],
-      "recorded_date": "2026-04-12"
+      "recorded_date": "2026-04-12",
+      "date_source": "hand_written"
     },
     {
       "vendor": "CustomJS",
@@ -2500,7 +2658,8 @@
       "source_url": "https://customjs.space/",
       "category": "Dev Utilities",
       "alternatives": [],
-      "recorded_date": "2026-04-12"
+      "recorded_date": "2026-04-12",
+      "date_source": "hand_written"
     },
     {
       "vendor": "DiffJSON",
@@ -2513,7 +2672,8 @@
       "source_url": "https://comparejson.com/",
       "category": "Dev Utilities",
       "alternatives": [],
-      "recorded_date": "2026-04-12"
+      "recorded_date": "2026-04-12",
+      "date_source": "hand_written"
     },
     {
       "vendor": "UniRateAPI",
@@ -2526,7 +2686,8 @@
       "source_url": "https://unirateapi.com",
       "category": "Dev Utilities",
       "alternatives": [],
-      "recorded_date": "2026-04-12"
+      "recorded_date": "2026-04-12",
+      "date_source": "hand_written"
     },
     {
       "vendor": "PDFMonkey",
@@ -2539,7 +2700,8 @@
       "source_url": "https://www.pdfmonkey.io/",
       "category": "Dev Utilities",
       "alternatives": [],
-      "recorded_date": "2026-04-12"
+      "recorded_date": "2026-04-12",
+      "date_source": "hand_written"
     },
     {
       "vendor": "redirect.pizza",
@@ -2552,7 +2714,8 @@
       "source_url": "https://redirect.pizza/",
       "category": "Dev Utilities",
       "alternatives": [],
-      "recorded_date": "2026-04-12"
+      "recorded_date": "2026-04-12",
+      "date_source": "hand_written"
     },
     {
       "vendor": "Renamer.ai",
@@ -2565,7 +2728,8 @@
       "source_url": "https://renamer.ai",
       "category": "Dev Utilities",
       "alternatives": [],
-      "recorded_date": "2026-04-12"
+      "recorded_date": "2026-04-12",
+      "date_source": "hand_written"
     },
     {
       "vendor": "FeedBear",
@@ -2578,7 +2742,8 @@
       "source_url": "https://www.feedbear.com/early-stage",
       "category": "Startup Perks",
       "alternatives": [],
-      "recorded_date": "2026-04-12"
+      "recorded_date": "2026-04-12",
+      "date_source": "hand_written"
     },
     {
       "vendor": "Backlight",
@@ -2591,7 +2756,8 @@
       "source_url": "",
       "category": "Design",
       "alternatives": [],
-      "recorded_date": "2026-04-12"
+      "recorded_date": "2026-04-12",
+      "date_source": "hand_written"
     },
     {
       "vendor": "Branition Colors",
@@ -2604,7 +2770,8 @@
       "source_url": "",
       "category": "Design",
       "alternatives": [],
-      "recorded_date": "2026-04-12"
+      "recorded_date": "2026-04-12",
+      "date_source": "hand_written"
     },
     {
       "vendor": "MovingPencils",
@@ -2617,7 +2784,8 @@
       "source_url": "",
       "category": "Design",
       "alternatives": [],
-      "recorded_date": "2026-04-12"
+      "recorded_date": "2026-04-12",
+      "date_source": "hand_written"
     },
     {
       "vendor": "Free For Commercial Use",
@@ -2630,7 +2798,8 @@
       "source_url": "",
       "category": "Design",
       "alternatives": [],
-      "recorded_date": "2026-04-12"
+      "recorded_date": "2026-04-12",
+      "date_source": "hand_written"
     },
     {
       "vendor": "Pixelixe",
@@ -2643,7 +2812,8 @@
       "source_url": "",
       "category": "Design",
       "alternatives": [],
-      "recorded_date": "2026-04-12"
+      "recorded_date": "2026-04-12",
+      "date_source": "hand_written"
     },
     {
       "vendor": "WalkMe",
@@ -2656,7 +2826,8 @@
       "source_url": "",
       "category": "Design",
       "alternatives": [],
-      "recorded_date": "2026-04-12"
+      "recorded_date": "2026-04-12",
+      "date_source": "hand_written"
     },
     {
       "vendor": "NextUI",
@@ -2669,7 +2840,8 @@
       "source_url": "",
       "category": "Design",
       "alternatives": [],
-      "recorded_date": "2026-04-12"
+      "recorded_date": "2026-04-12",
+      "date_source": "hand_written"
     },
     {
       "vendor": "Landen",
@@ -2682,7 +2854,8 @@
       "source_url": "",
       "category": "Design",
       "alternatives": [],
-      "recorded_date": "2026-04-12"
+      "recorded_date": "2026-04-12",
+      "date_source": "hand_written"
     },
     {
       "vendor": "Whimsical",
@@ -2695,7 +2868,8 @@
       "source_url": "",
       "category": "Design",
       "alternatives": [],
-      "recorded_date": "2026-04-12"
+      "recorded_date": "2026-04-12",
+      "date_source": "hand_written"
     },
     {
       "vendor": "Contact.do",
@@ -2708,7 +2882,8 @@
       "source_url": "",
       "category": "Email",
       "alternatives": [],
-      "recorded_date": "2026-04-12"
+      "recorded_date": "2026-04-12",
+      "date_source": "hand_written"
     },
     {
       "vendor": "MailerLite",
@@ -2721,7 +2896,8 @@
       "source_url": "",
       "category": "Email",
       "alternatives": [],
-      "recorded_date": "2026-04-12"
+      "recorded_date": "2026-04-12",
+      "date_source": "hand_written"
     },
     {
       "vendor": "MailerSend",
@@ -2734,7 +2910,8 @@
       "source_url": "",
       "category": "Email",
       "alternatives": [],
-      "recorded_date": "2026-04-12"
+      "recorded_date": "2026-04-12",
+      "date_source": "hand_written"
     },
     {
       "vendor": "Plunk",
@@ -2747,7 +2924,8 @@
       "source_url": "",
       "category": "Email",
       "alternatives": [],
-      "recorded_date": "2026-04-12"
+      "recorded_date": "2026-04-12",
+      "date_source": "hand_written"
     },
     {
       "vendor": "Maileroo",
@@ -2760,7 +2938,8 @@
       "source_url": "",
       "category": "Email",
       "alternatives": [],
-      "recorded_date": "2026-04-12"
+      "recorded_date": "2026-04-12",
+      "date_source": "hand_written"
     },
     {
       "vendor": "Mailtrap",
@@ -2773,7 +2952,8 @@
       "source_url": "",
       "category": "Email",
       "alternatives": [],
-      "recorded_date": "2026-04-12"
+      "recorded_date": "2026-04-12",
+      "date_source": "hand_written"
     },
     {
       "vendor": "AnonAddy",
@@ -2786,7 +2966,8 @@
       "source_url": "",
       "category": "Email",
       "alternatives": [],
-      "recorded_date": "2026-04-12"
+      "recorded_date": "2026-04-12",
+      "date_source": "hand_written"
     },
     {
       "vendor": "Bump Email",
@@ -2799,7 +2980,8 @@
       "source_url": "",
       "category": "Email",
       "alternatives": [],
-      "recorded_date": "2026-04-12"
+      "recorded_date": "2026-04-12",
+      "date_source": "hand_written"
     },
     {
       "vendor": "Parsio",
@@ -2812,7 +2994,8 @@
       "source_url": "",
       "category": "Email",
       "alternatives": [],
-      "recorded_date": "2026-04-12"
+      "recorded_date": "2026-04-12",
+      "date_source": "hand_written"
     },
     {
       "vendor": "Maildroppa",
@@ -2825,7 +3008,8 @@
       "source_url": "",
       "category": "Email",
       "alternatives": [],
-      "recorded_date": "2026-04-12"
+      "recorded_date": "2026-04-12",
+      "date_source": "hand_written"
     },
     {
       "vendor": "Kitemaker",
@@ -2838,7 +3022,8 @@
       "source_url": "",
       "category": "Project Management",
       "alternatives": [],
-      "recorded_date": "2026-04-12"
+      "recorded_date": "2026-04-12",
+      "date_source": "hand_written"
     },
     {
       "vendor": "sflow.io",
@@ -2851,7 +3036,8 @@
       "source_url": "",
       "category": "Project Management",
       "alternatives": [],
-      "recorded_date": "2026-04-12"
+      "recorded_date": "2026-04-12",
+      "date_source": "hand_written"
     },
     {
       "vendor": "Quidlo",
@@ -2864,7 +3050,8 @@
       "source_url": "",
       "category": "Project Management",
       "alternatives": [],
-      "recorded_date": "2026-04-12"
+      "recorded_date": "2026-04-12",
+      "date_source": "hand_written"
     },
     {
       "vendor": "Teamhood",
@@ -2877,7 +3064,8 @@
       "source_url": "",
       "category": "Project Management",
       "alternatives": [],
-      "recorded_date": "2026-04-12"
+      "recorded_date": "2026-04-12",
+      "date_source": "hand_written"
     },
     {
       "vendor": "Zenkit",
@@ -2890,7 +3078,8 @@
       "source_url": "",
       "category": "Project Management",
       "alternatives": [],
-      "recorded_date": "2026-04-12"
+      "recorded_date": "2026-04-12",
+      "date_source": "hand_written"
     },
     {
       "vendor": "HeySpace",
@@ -2903,7 +3092,8 @@
       "source_url": "",
       "category": "Project Management",
       "alternatives": [],
-      "recorded_date": "2026-04-12"
+      "recorded_date": "2026-04-12",
+      "date_source": "hand_written"
     },
     {
       "vendor": "Wikifactory",
@@ -2916,7 +3106,8 @@
       "source_url": "",
       "category": "Project Management",
       "alternatives": [],
-      "recorded_date": "2026-04-12"
+      "recorded_date": "2026-04-12",
+      "date_source": "hand_written"
     },
     {
       "vendor": "Teleretro",
@@ -2929,7 +3120,8 @@
       "source_url": "",
       "category": "Project Management",
       "alternatives": [],
-      "recorded_date": "2026-04-12"
+      "recorded_date": "2026-04-12",
+      "date_source": "hand_written"
     },
     {
       "vendor": "MeScrum",
@@ -2942,7 +3134,8 @@
       "source_url": "",
       "category": "Project Management",
       "alternatives": [],
-      "recorded_date": "2026-04-12"
+      "recorded_date": "2026-04-12",
+      "date_source": "hand_written"
     },
     {
       "vendor": "Protectumus",
@@ -2955,7 +3148,8 @@
       "source_url": "",
       "category": "Security",
       "alternatives": [],
-      "recorded_date": "2026-04-12"
+      "recorded_date": "2026-04-12",
+      "date_source": "hand_written"
     },
     {
       "vendor": "HostedScan",
@@ -2968,7 +3162,8 @@
       "source_url": "",
       "category": "Security",
       "alternatives": [],
-      "recorded_date": "2026-04-12"
+      "recorded_date": "2026-04-12",
+      "date_source": "hand_written"
     },
     {
       "vendor": "StackHawk",
@@ -2981,7 +3176,8 @@
       "source_url": "",
       "category": "Security",
       "alternatives": [],
-      "recorded_date": "2026-04-12"
+      "recorded_date": "2026-04-12",
+      "date_source": "hand_written"
     },
     {
       "vendor": "CookieFirst",
@@ -2994,7 +3190,8 @@
       "source_url": "",
       "category": "Security",
       "alternatives": [],
-      "recorded_date": "2026-04-12"
+      "recorded_date": "2026-04-12",
+      "date_source": "hand_written"
     },
     {
       "vendor": "Tailscale",
@@ -3007,7 +3204,8 @@
       "source_url": "",
       "category": "Security",
       "alternatives": [],
-      "recorded_date": "2026-04-12"
+      "recorded_date": "2026-04-12",
+      "date_source": "hand_written"
     },
     {
       "vendor": "PyUp",
@@ -3020,7 +3218,8 @@
       "source_url": "",
       "category": "Security",
       "alternatives": [],
-      "recorded_date": "2026-04-12"
+      "recorded_date": "2026-04-12",
+      "date_source": "hand_written"
     },
     {
       "vendor": "LibreQR",
@@ -3033,7 +3232,8 @@
       "source_url": "",
       "category": "Storage",
       "alternatives": [],
-      "recorded_date": "2026-04-12"
+      "recorded_date": "2026-04-12",
+      "date_source": "hand_written"
     },
     {
       "vendor": "Redbooth",
@@ -3046,7 +3246,8 @@
       "source_url": "",
       "category": "Storage",
       "alternatives": [],
-      "recorded_date": "2026-04-12"
+      "recorded_date": "2026-04-12",
+      "date_source": "hand_written"
     },
     {
       "vendor": "Kraken.io",
@@ -3059,7 +3260,8 @@
       "source_url": "",
       "category": "Storage",
       "alternatives": [],
-      "recorded_date": "2026-04-12"
+      "recorded_date": "2026-04-12",
+      "date_source": "hand_written"
     },
     {
       "vendor": "Otixo",
@@ -3072,7 +3274,8 @@
       "source_url": "",
       "category": "Storage",
       "alternatives": [],
-      "recorded_date": "2026-04-12"
+      "recorded_date": "2026-04-12",
+      "date_source": "hand_written"
     },
     {
       "vendor": "Userbird",
@@ -3085,7 +3288,8 @@
       "source_url": "",
       "category": "Analytics",
       "alternatives": [],
-      "recorded_date": "2026-04-12"
+      "recorded_date": "2026-04-12",
+      "date_source": "hand_written"
     },
     {
       "vendor": "Seline",
@@ -3098,7 +3302,8 @@
       "source_url": "",
       "category": "Analytics",
       "alternatives": [],
-      "recorded_date": "2026-04-12"
+      "recorded_date": "2026-04-12",
+      "date_source": "hand_written"
     },
     {
       "vendor": "Segment Startups",
@@ -3111,7 +3316,8 @@
       "source_url": "",
       "category": "Analytics",
       "alternatives": [],
-      "recorded_date": "2026-04-12"
+      "recorded_date": "2026-04-12",
+      "date_source": "hand_written"
     },
     {
       "vendor": "Census",
@@ -3124,7 +3330,8 @@
       "source_url": "",
       "category": "Analytics",
       "alternatives": [],
-      "recorded_date": "2026-04-12"
+      "recorded_date": "2026-04-12",
+      "date_source": "hand_written"
     },
     {
       "vendor": "UsabilityHub",
@@ -3137,7 +3344,8 @@
       "source_url": "",
       "category": "Analytics",
       "alternatives": [],
-      "recorded_date": "2026-04-12"
+      "recorded_date": "2026-04-12",
+      "date_source": "hand_written"
     },
     {
       "vendor": "Hotjar",
@@ -3150,7 +3358,8 @@
       "source_url": "",
       "category": "Analytics",
       "alternatives": [],
-      "recorded_date": "2026-04-12"
+      "recorded_date": "2026-04-12",
+      "date_source": "hand_written"
     },
     {
       "vendor": "FullStory",
@@ -3163,7 +3372,8 @@
       "source_url": "",
       "category": "Analytics",
       "alternatives": [],
-      "recorded_date": "2026-04-12"
+      "recorded_date": "2026-04-12",
+      "date_source": "hand_written"
     },
     {
       "vendor": "Smartlook",
@@ -3176,7 +3386,8 @@
       "source_url": "",
       "category": "Analytics",
       "alternatives": [],
-      "recorded_date": "2026-04-12"
+      "recorded_date": "2026-04-12",
+      "date_source": "hand_written"
     },
     {
       "vendor": "UXtweak",
@@ -3189,7 +3400,8 @@
       "source_url": "",
       "category": "Analytics",
       "alternatives": [],
-      "recorded_date": "2026-04-12"
+      "recorded_date": "2026-04-12",
+      "date_source": "hand_written"
     },
     {
       "vendor": "Zoho Subscriptions",
@@ -3202,7 +3414,8 @@
       "source_url": "",
       "category": "Cloud IaaS",
       "alternatives": [],
-      "recorded_date": "2026-04-13"
+      "recorded_date": "2026-04-13",
+      "date_source": "hand_written"
     },
     {
       "vendor": "API-Ninjas",
@@ -3215,7 +3428,8 @@
       "source_url": "",
       "category": "API Development",
       "alternatives": [],
-      "recorded_date": "2026-04-13"
+      "recorded_date": "2026-04-13",
+      "date_source": "hand_written"
     },
     {
       "vendor": "HeyForm",
@@ -3228,7 +3442,8 @@
       "source_url": "",
       "category": "Forms",
       "alternatives": [],
-      "recorded_date": "2026-04-13"
+      "recorded_date": "2026-04-13",
+      "date_source": "hand_written"
     },
     {
       "vendor": "Codiga",
@@ -3241,7 +3456,8 @@
       "source_url": "",
       "category": "IDE & Code Editors",
       "alternatives": [],
-      "recorded_date": "2026-04-13"
+      "recorded_date": "2026-04-13",
+      "date_source": "hand_written"
     },
     {
       "vendor": "xAI",
@@ -3254,7 +3470,8 @@
       "source_url": "",
       "category": "AI / ML",
       "alternatives": [],
-      "recorded_date": "2026-04-13"
+      "recorded_date": "2026-04-13",
+      "date_source": "hand_written"
     },
     {
       "vendor": "Clarifai",
@@ -3267,7 +3484,8 @@
       "source_url": "",
       "category": "AI / ML",
       "alternatives": [],
-      "recorded_date": "2026-04-13"
+      "recorded_date": "2026-04-13",
+      "date_source": "hand_written"
     },
     {
       "vendor": "Typeform",
@@ -3280,7 +3498,8 @@
       "source_url": "",
       "category": "Forms",
       "alternatives": [],
-      "recorded_date": "2026-04-13"
+      "recorded_date": "2026-04-13",
+      "date_source": "hand_written"
     },
     {
       "vendor": "CodeRabbit",
@@ -3293,7 +3512,8 @@
       "source_url": "",
       "category": "Code Quality",
       "alternatives": [],
-      "recorded_date": "2026-04-13"
+      "recorded_date": "2026-04-13",
+      "date_source": "hand_written"
     },
     {
       "vendor": "SwaggerHub",
@@ -3306,7 +3526,8 @@
       "source_url": "",
       "category": "API Development",
       "alternatives": [],
-      "recorded_date": "2026-04-13"
+      "recorded_date": "2026-04-13",
+      "date_source": "hand_written"
     },
     {
       "vendor": "Stickies.app",
@@ -3319,7 +3540,8 @@
       "source_url": "",
       "category": "Team Collaboration",
       "alternatives": [],
-      "recorded_date": "2026-04-13"
+      "recorded_date": "2026-04-13",
+      "date_source": "hand_written"
     },
     {
       "vendor": "Katalon",
@@ -3332,7 +3554,8 @@
       "source_url": "",
       "category": "Testing",
       "alternatives": [],
-      "recorded_date": "2026-04-13"
+      "recorded_date": "2026-04-13",
+      "date_source": "hand_written"
     },
     {
       "vendor": "TestingBot",
@@ -3345,7 +3568,8 @@
       "source_url": "",
       "category": "Testing",
       "alternatives": [],
-      "recorded_date": "2026-04-13"
+      "recorded_date": "2026-04-13",
+      "date_source": "hand_written"
     },
     {
       "vendor": "Knowlarity",
@@ -3358,7 +3582,8 @@
       "source_url": "",
       "category": "Communication",
       "alternatives": [],
-      "recorded_date": "2026-04-13"
+      "recorded_date": "2026-04-13",
+      "date_source": "hand_written"
     },
     {
       "vendor": "microlink.io",
@@ -3371,7 +3596,8 @@
       "source_url": "",
       "category": "Web Scraping",
       "alternatives": [],
-      "recorded_date": "2026-04-13"
+      "recorded_date": "2026-04-13",
+      "date_source": "hand_written"
     },
     {
       "vendor": "Firecrawl",
@@ -3384,7 +3610,8 @@
       "source_url": "",
       "category": "Web Scraping",
       "alternatives": [],
-      "recorded_date": "2026-04-13"
+      "recorded_date": "2026-04-13",
+      "date_source": "hand_written"
     },
     {
       "vendor": "filebase.com",
@@ -3397,7 +3624,8 @@
       "source_url": "",
       "category": "Cloud IaaS",
       "alternatives": [],
-      "recorded_date": "2026-04-13"
+      "recorded_date": "2026-04-13",
+      "date_source": "hand_written"
     },
     {
       "vendor": "Pocket Alert",
@@ -3410,7 +3638,8 @@
       "source_url": "",
       "category": "Messaging",
       "alternatives": [],
-      "recorded_date": "2026-04-13"
+      "recorded_date": "2026-04-13",
+      "date_source": "hand_written"
     },
     {
       "vendor": "Stoplight",
@@ -3423,7 +3652,8 @@
       "source_url": "",
       "category": "API Development",
       "alternatives": [],
-      "recorded_date": "2026-04-13"
+      "recorded_date": "2026-04-13",
+      "date_source": "hand_written"
     },
     {
       "vendor": "Google Maps Platform",
@@ -3436,7 +3666,8 @@
       "source_url": "",
       "category": "Maps/Geolocation",
       "alternatives": [],
-      "recorded_date": "2026-04-13"
+      "recorded_date": "2026-04-13",
+      "date_source": "hand_written"
     },
     {
       "vendor": "PubNub",
@@ -3449,7 +3680,8 @@
       "source_url": "",
       "category": "Messaging",
       "alternatives": [],
-      "recorded_date": "2026-04-13"
+      "recorded_date": "2026-04-13",
+      "date_source": "hand_written"
     },
     {
       "vendor": "Zoho Meeting",
@@ -3462,7 +3694,8 @@
       "source_url": "",
       "category": "Cloud IaaS",
       "alternatives": [],
-      "recorded_date": "2026-04-13"
+      "recorded_date": "2026-04-13",
+      "date_source": "hand_written"
     },
     {
       "vendor": "OneSignal",
@@ -3475,7 +3708,8 @@
       "source_url": "",
       "category": "Messaging",
       "alternatives": [],
-      "recorded_date": "2026-04-13"
+      "recorded_date": "2026-04-13",
+      "date_source": "hand_written"
     },
     {
       "vendor": "Stadia Maps",
@@ -3488,7 +3722,8 @@
       "source_url": "",
       "category": "Maps/Geolocation",
       "alternatives": [],
-      "recorded_date": "2026-04-13"
+      "recorded_date": "2026-04-13",
+      "date_source": "hand_written"
     },
     {
       "vendor": "Keywords AI",
@@ -3501,7 +3736,8 @@
       "source_url": "",
       "category": "AI / ML",
       "alternatives": [],
-      "recorded_date": "2026-04-13"
+      "recorded_date": "2026-04-13",
+      "date_source": "hand_written"
     },
     {
       "vendor": "Revolt",
@@ -3514,7 +3750,8 @@
       "source_url": "",
       "category": "Team Collaboration",
       "alternatives": [],
-      "recorded_date": "2026-04-13"
+      "recorded_date": "2026-04-13",
+      "date_source": "hand_written"
     },
     {
       "vendor": "GoSquared",
@@ -3527,7 +3764,8 @@
       "source_url": "",
       "category": "Communication",
       "alternatives": [],
-      "recorded_date": "2026-04-13"
+      "recorded_date": "2026-04-13",
+      "date_source": "hand_written"
     },
     {
       "vendor": "Drift",
@@ -3540,7 +3778,8 @@
       "source_url": "",
       "category": "Communication",
       "alternatives": [],
-      "recorded_date": "2026-04-13"
+      "recorded_date": "2026-04-13",
+      "date_source": "hand_written"
     },
     {
       "vendor": "Synadia NGS",
@@ -3553,7 +3792,8 @@
       "source_url": "",
       "category": "Messaging",
       "alternatives": [],
-      "recorded_date": "2026-04-13"
+      "recorded_date": "2026-04-13",
+      "date_source": "hand_written"
     },
     {
       "vendor": "Pingram.io",
@@ -3566,7 +3806,8 @@
       "source_url": "",
       "category": "Messaging",
       "alternatives": [],
-      "recorded_date": "2026-04-13"
+      "recorded_date": "2026-04-13",
+      "date_source": "hand_written"
     },
     {
       "vendor": "LambdaTest",
@@ -3579,7 +3820,8 @@
       "source_url": "",
       "category": "Testing",
       "alternatives": [],
-      "recorded_date": "2026-04-13"
+      "recorded_date": "2026-04-13",
+      "date_source": "hand_written"
     },
     {
       "vendor": "DhiWise",
@@ -3592,7 +3834,8 @@
       "source_url": "",
       "category": "IDE & Code Editors",
       "alternatives": [],
-      "recorded_date": "2026-04-13"
+      "recorded_date": "2026-04-13",
+      "date_source": "hand_written"
     },
     {
       "vendor": "Brackets",
@@ -3605,7 +3848,8 @@
       "source_url": "",
       "category": "IDE & Code Editors",
       "alternatives": [],
-      "recorded_date": "2026-04-13"
+      "recorded_date": "2026-04-13",
+      "date_source": "hand_written"
     },
     {
       "vendor": "Apiary",
@@ -3618,7 +3862,8 @@
       "source_url": "",
       "category": "API Development",
       "alternatives": [],
-      "recorded_date": "2026-04-13"
+      "recorded_date": "2026-04-13",
+      "date_source": "hand_written"
     },
     {
       "vendor": "Stamen Maps",
@@ -3631,7 +3876,8 @@
       "source_url": "",
       "category": "Maps/Geolocation",
       "alternatives": [],
-      "recorded_date": "2026-04-13"
+      "recorded_date": "2026-04-13",
+      "date_source": "hand_written"
     },
     {
       "vendor": "Clever Cloud",
@@ -3644,7 +3890,8 @@
       "source_url": "",
       "category": "Cloud IaaS",
       "alternatives": [],
-      "recorded_date": "2026-04-13"
+      "recorded_date": "2026-04-13",
+      "date_source": "hand_written"
     },
     {
       "vendor": "Alibaba Cloud Startups",
@@ -3657,7 +3904,8 @@
       "source_url": "",
       "category": "Cloud IaaS",
       "alternatives": [],
-      "recorded_date": "2026-04-13"
+      "recorded_date": "2026-04-13",
+      "date_source": "hand_written"
     },
     {
       "vendor": "Logz.io",
@@ -3670,7 +3918,8 @@
       "source_url": "",
       "category": "Logging",
       "alternatives": [],
-      "recorded_date": "2026-04-13"
+      "recorded_date": "2026-04-13",
+      "date_source": "hand_written"
     },
     {
       "vendor": "Papertrail",
@@ -3683,7 +3932,8 @@
       "source_url": "",
       "category": "Logging",
       "alternatives": [],
-      "recorded_date": "2026-04-13"
+      "recorded_date": "2026-04-13",
+      "date_source": "hand_written"
     },
     {
       "vendor": "LogZab",
@@ -3696,7 +3946,8 @@
       "source_url": "",
       "category": "Logging",
       "alternatives": [],
-      "recorded_date": "2026-04-13"
+      "recorded_date": "2026-04-13",
+      "date_source": "hand_written"
     },
     {
       "vendor": "Elmah.io",
@@ -3709,7 +3960,8 @@
       "source_url": "",
       "category": "Error Tracking",
       "alternatives": [],
-      "recorded_date": "2026-04-13"
+      "recorded_date": "2026-04-13",
+      "date_source": "hand_written"
     },
     {
       "vendor": "Beanstalk",
@@ -3722,7 +3974,8 @@
       "source_url": "",
       "category": "Source Control",
       "alternatives": [],
-      "recorded_date": "2026-04-13"
+      "recorded_date": "2026-04-13",
+      "date_source": "hand_written"
     },
     {
       "vendor": "Storyblok",
@@ -3735,7 +3988,8 @@
       "source_url": "",
       "category": "Headless CMS",
       "alternatives": [],
-      "recorded_date": "2026-04-13"
+      "recorded_date": "2026-04-13",
+      "date_source": "hand_written"
     },
     {
       "vendor": "Imgix",
@@ -3748,7 +4002,8 @@
       "source_url": "",
       "category": "CDN",
       "alternatives": [],
-      "recorded_date": "2026-04-13"
+      "recorded_date": "2026-04-13",
+      "date_source": "hand_written"
     },
     {
       "vendor": "Toran Proxy",
@@ -3761,7 +4016,8 @@
       "source_url": "",
       "category": "CDN",
       "alternatives": [],
-      "recorded_date": "2026-04-13"
+      "recorded_date": "2026-04-13",
+      "date_source": "hand_written"
     },
     {
       "vendor": "Shotstack",
@@ -3774,7 +4030,8 @@
       "source_url": "",
       "category": "Video",
       "alternatives": [],
-      "recorded_date": "2026-04-13"
+      "recorded_date": "2026-04-13",
+      "date_source": "hand_written"
     },
     {
       "vendor": "CommandBar",
@@ -3787,7 +4044,8 @@
       "source_url": "",
       "category": "Search",
       "alternatives": [],
-      "recorded_date": "2026-04-13"
+      "recorded_date": "2026-04-13",
+      "date_source": "hand_written"
     },
     {
       "vendor": "LingoHub",
@@ -3800,7 +4058,8 @@
       "source_url": "",
       "category": "Localization",
       "alternatives": [],
-      "recorded_date": "2026-04-13"
+      "recorded_date": "2026-04-13",
+      "date_source": "hand_written"
     },
     {
       "vendor": "Transifex",
@@ -3813,7 +4072,8 @@
       "source_url": "",
       "category": "Localization",
       "alternatives": [],
-      "recorded_date": "2026-04-13"
+      "recorded_date": "2026-04-13",
+      "date_source": "hand_written"
     },
     {
       "vendor": "RunCloud",
@@ -3826,7 +4086,8 @@
       "source_url": "",
       "category": "Server Management",
       "alternatives": [],
-      "recorded_date": "2026-04-13"
+      "recorded_date": "2026-04-13",
+      "date_source": "hand_written"
     },
     {
       "vendor": "Pipedream",
@@ -3839,7 +4100,8 @@
       "source_url": "",
       "category": "Workflow Automation",
       "alternatives": [],
-      "recorded_date": "2026-04-13"
+      "recorded_date": "2026-04-13",
+      "date_source": "hand_written"
     },
     {
       "vendor": "Claude Code",
@@ -3857,7 +4119,8 @@
         "Amazon Kiro",
         "Windsurf"
       ],
-      "recorded_date": "2026-04-13"
+      "recorded_date": "2026-04-13",
+      "date_source": "hand_written"
     },
     {
       "vendor": "Amazon Kiro",
@@ -3875,7 +4138,8 @@
         "Windsurf",
         "Claude Code"
       ],
-      "recorded_date": "2026-04-13"
+      "recorded_date": "2026-04-13",
+      "date_source": "hand_written"
     },
     {
       "vendor": "Amazon Kiro (AWS Startups)",
@@ -3892,7 +4156,8 @@
         "Cursor",
         "Windsurf"
       ],
-      "recorded_date": "2026-04-13"
+      "recorded_date": "2026-04-13",
+      "date_source": "hand_written"
     },
     {
       "vendor": "Windsurf",
@@ -3909,7 +4174,8 @@
         "GitHub Copilot",
         "Claude Code"
       ],
-      "recorded_date": "2026-04-13"
+      "recorded_date": "2026-04-13",
+      "date_source": "hand_written"
     },
     {
       "vendor": "GitHub Copilot",
@@ -3926,7 +4192,8 @@
         "Windsurf",
         "Gemini Code Assist"
       ],
-      "recorded_date": "2026-04-13"
+      "recorded_date": "2026-04-13",
+      "date_source": "hand_written"
     },
     {
       "vendor": "Cursor",
@@ -3943,7 +4210,8 @@
         "GitHub Copilot",
         "Claude Code"
       ],
-      "recorded_date": "2026-04-13"
+      "recorded_date": "2026-04-13",
+      "date_source": "hand_written"
     },
     {
       "vendor": "n8n",
@@ -3961,7 +4229,8 @@
         "Make",
         "Zapier"
       ],
-      "recorded_date": "2026-04-13"
+      "recorded_date": "2026-04-13",
+      "date_source": "hand_written"
     },
     {
       "vendor": "Microsoft",
@@ -3978,7 +4247,8 @@
         "Azure Virtual Desktop",
         "Citrix DaaS"
       ],
-      "recorded_date": "2026-04-13"
+      "recorded_date": "2026-04-13",
+      "date_source": "hand_written"
     },
     {
       "vendor": "Microsoft",
@@ -3994,7 +4264,8 @@
         "Google Workspace Enterprise Plus",
         "Zoho Workplace"
       ],
-      "recorded_date": "2026-04-13"
+      "recorded_date": "2026-04-13",
+      "date_source": "hand_written"
     },
     {
       "vendor": "OVHcloud",
@@ -4012,7 +4283,8 @@
         "Vultr",
         "AWS"
       ],
-      "recorded_date": "2026-04-09"
+      "recorded_date": "2026-04-09",
+      "date_source": "hand_written"
     },
     {
       "vendor": "Google Content API for Shopping",
@@ -4029,7 +4301,8 @@
         "Shopify API",
         "BigCommerce API"
       ],
-      "recorded_date": "2026-04-15"
+      "recorded_date": "2026-04-15",
+      "date_source": "hand_written"
     },
     {
       "vendor": "DeepSeek",
@@ -4046,7 +4319,8 @@
         "Anthropic Claude API",
         "Google Gemini API"
       ],
-      "recorded_date": "2026-04-16"
+      "recorded_date": "2026-04-16",
+      "date_source": "hand_written"
     },
     {
       "vendor": "Netlify",
@@ -4063,7 +4337,8 @@
         "Cloudflare Pages",
         "Railway"
       ],
-      "recorded_date": "2026-04-16"
+      "recorded_date": "2026-04-16",
+      "date_source": "hand_written"
     },
     {
       "vendor": "Alibaba Cloud Qwen Code",
@@ -4080,7 +4355,8 @@
         "Cursor",
         "Codeium"
       ],
-      "recorded_date": "2026-04-16"
+      "recorded_date": "2026-04-16",
+      "date_source": "hand_written"
     },
     {
       "vendor": "Google Gemini API",
@@ -4098,7 +4374,8 @@
         "OpenRouter",
         "Groq"
       ],
-      "recorded_date": "2026-04-17"
+      "recorded_date": "2026-04-17",
+      "date_source": "hand_written"
     },
     {
       "vendor": "SendGrid Accelerate",
@@ -4115,7 +4392,8 @@
         "Mailgun",
         "Postmark"
       ],
-      "recorded_date": "2026-04-17"
+      "recorded_date": "2026-04-17",
+      "date_source": "hand_written"
     },
     {
       "vendor": "Prospect.io",
@@ -4132,7 +4410,8 @@
         "Hunter.io",
         "Lemlist"
       ],
-      "recorded_date": "2026-04-17"
+      "recorded_date": "2026-04-17",
+      "date_source": "hand_written"
     },
     {
       "vendor": "Kluster AI",
@@ -4149,7 +4428,8 @@
         "SiliconFlow",
         "OpenRouter"
       ],
-      "recorded_date": "2026-04-17"
+      "recorded_date": "2026-04-17",
+      "date_source": "hand_written"
     },
     {
       "vendor": "searchly.com",
@@ -4166,7 +4446,8 @@
         "Algolia",
         "Elastic Cloud"
       ],
-      "recorded_date": "2026-04-19"
+      "recorded_date": "2026-04-19",
+      "date_source": "hand_written"
     },
     {
       "vendor": "ImageEngine",
@@ -4184,7 +4465,8 @@
         "Uploadcare",
         "imgix"
       ],
-      "recorded_date": "2026-04-19"
+      "recorded_date": "2026-04-19",
+      "date_source": "hand_written"
     },
     {
       "vendor": "DBOS",
@@ -4201,7 +4483,8 @@
         "Inngest",
         "Trigger.dev"
       ],
-      "recorded_date": "2026-04-19"
+      "recorded_date": "2026-04-19",
+      "date_source": "hand_written"
     },
     {
       "vendor": "X (Twitter)",
@@ -4218,7 +4501,8 @@
         "Mastodon API",
         "Reddit API"
       ],
-      "recorded_date": "2026-04-21"
+      "recorded_date": "2026-04-21",
+      "date_source": "hand_written"
     },
     {
       "vendor": "Netlify",
@@ -4235,7 +4519,8 @@
         "Cloudflare Pages",
         "Railway"
       ],
-      "recorded_date": "2026-04-21"
+      "recorded_date": "2026-04-21",
+      "date_source": "hand_written"
     },
     {
       "vendor": "GitHub Copilot",
@@ -4253,7 +4538,8 @@
         "Gemini Code Assist",
         "Claude Code"
       ],
-      "recorded_date": "2026-04-21"
+      "recorded_date": "2026-04-21",
+      "date_source": "hand_written"
     },
     {
       "vendor": "GitHub Copilot",
@@ -4272,7 +4558,8 @@
         "Claude Code",
         "Cline"
       ],
-      "recorded_date": "2026-04-21"
+      "recorded_date": "2026-04-21",
+      "date_source": "hand_written"
     },
     {
       "vendor": "Amazon SES",
@@ -4291,7 +4578,8 @@
         "Brevo",
         "Postal"
       ],
-      "recorded_date": "2026-08-26"
+      "recorded_date": "2026-08-26",
+      "date_source": "hand_written"
     },
     {
       "vendor": "Storj",
@@ -4309,7 +4597,8 @@
         "Tigris",
         "MinIO"
       ],
-      "recorded_date": "2026-08-26"
+      "recorded_date": "2026-08-26",
+      "date_source": "hand_written"
     }
   ]
 }

--- a/scripts/backfill-change-date-sources.js
+++ b/scripts/backfill-change-date-sources.js
@@ -1,0 +1,62 @@
+#!/usr/bin/env node
+
+import { readFileSync, writeFileSync } from "node:fs";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { DATE_SOURCE_HAND_WRITTEN, DATE_SOURCES } from "./change-log.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const CHANGES_PATH = resolve(__dirname, "..", "data", "deal_changes.json");
+
+export function planBackfill(changes) {
+  const machineWritten = changes.filter((c) => c.detected_by);
+  const alreadyLabelled = changes.filter((c) => DATE_SOURCES.includes(c.date_source));
+  const toLabel = changes.filter(
+    (c) => !c.detected_by && !DATE_SOURCES.includes(c.date_source)
+  );
+  return { machineWritten, alreadyLabelled, toLabel };
+}
+
+function main() {
+  const dryRun = process.argv.includes("--dry-run");
+  const data = JSON.parse(readFileSync(CHANGES_PATH, "utf-8"));
+  const { machineWritten, alreadyLabelled, toLabel } = planBackfill(data.changes);
+
+  console.log(`Entries: ${data.changes.length}`);
+  console.log(`Already carrying a date_source: ${alreadyLabelled.length}`);
+  console.log(`Machine-written (detected_by set): ${machineWritten.length}`);
+  console.log(`To label ${DATE_SOURCE_HAND_WRITTEN}: ${toLabel.length}`);
+
+  const unlabelledMachine = machineWritten.filter(
+    (c) => !DATE_SOURCES.includes(c.date_source)
+  );
+  if (unlabelledMachine.length > 0) {
+    console.error("");
+    console.error(
+      `Refusing to run: ${unlabelledMachine.length} machine-written entries carry no date_source.`
+    );
+    console.error(
+      "Only the writer knows whether their date came from the vendor's page, so this script cannot label them."
+    );
+    for (const c of unlabelledMachine.slice(0, 5)) {
+      console.error(`  ${c.vendor} | ${c.change_type} | ${c.date}`);
+    }
+    process.exit(2);
+  }
+
+  for (const change of toLabel) change.date_source = DATE_SOURCE_HAND_WRITTEN;
+
+  if (dryRun) {
+    console.log("");
+    console.log("Dry run — nothing written.");
+    return;
+  }
+
+  writeFileSync(CHANGES_PATH, JSON.stringify(data, null, 2) + "\n");
+  console.log("");
+  console.log(`Wrote ${CHANGES_PATH}`);
+}
+
+const isMainModule =
+  process.argv[1] && resolve(process.argv[1]) === resolve(fileURLToPath(import.meta.url));
+if (isMainModule) main();

--- a/scripts/change-log.js
+++ b/scripts/change-log.js
@@ -30,6 +30,22 @@ const DEFAULT_IMPACT = "medium";
 const ISO_DATE = /^\d{4}-\d{2}-\d{2}$/;
 const DEFAULT_REPICK_WINDOW_DAYS = 21;
 
+export const DATE_SOURCE_VENDOR_PAGE = "vendor_page";
+export const DATE_SOURCE_HAND_WRITTEN = "hand_written";
+export const DATE_SOURCE_DISCOVERED = "discovered";
+
+export const DATE_SOURCES = [
+  DATE_SOURCE_VENDOR_PAGE,
+  DATE_SOURCE_HAND_WRITTEN,
+  DATE_SOURCE_DISCOVERED,
+];
+
+export const EVENT_DATED_SOURCES = [DATE_SOURCE_VENDOR_PAGE, DATE_SOURCE_HAND_WRITTEN];
+
+export function isEventDated(change) {
+  return EVENT_DATED_SOURCES.includes(change?.date_source);
+}
+
 export function changeKey(change) {
   return [change.vendor, change.change_type, change.date, change.source_url].join("|");
 }
@@ -54,10 +70,10 @@ export function buildChangeEntry(offer, result, options = {}) {
 
   if (missing.length > 0) return { entry: null, missing };
 
-  const effectiveDate =
+  const statedDate =
     typeof result.effective_date === "string" && ISO_DATE.test(result.effective_date.trim())
       ? result.effective_date.trim()
-      : recordedDate;
+      : null;
 
   const impact = IMPACTS.includes(result.impact) ? result.impact : DEFAULT_IMPACT;
 
@@ -65,7 +81,8 @@ export function buildChangeEntry(offer, result, options = {}) {
     entry: {
       vendor: offer.vendor,
       change_type: changeType,
-      date: effectiveDate,
+      date: statedDate ?? recordedDate,
+      date_source: statedDate ? DATE_SOURCE_VENDOR_PAGE : DATE_SOURCE_DISCOVERED,
       summary,
       previous_state: offer.description,
       current_state: currentState,
@@ -154,5 +171,7 @@ export function changeLogFreshness(changes, now = new Date()) {
     recorded_last_30_days: recorded.filter((d) => d >= thirtyDaysAgo).length,
     machine_detected_total: changes.filter((c) => c.detected_by).length,
     entries_without_recorded_date: changes.length - recorded.length,
+    discovered_date_total: changes.filter((c) => !isEventDated(c)).length,
+    entries_without_date_source: changes.filter((c) => !DATE_SOURCES.includes(c.date_source)).length,
   };
 }

--- a/scripts/check-change-log-staleness.js
+++ b/scripts/check-change-log-staleness.js
@@ -1,12 +1,37 @@
 #!/usr/bin/env node
 
-import { resolve } from "node:path";
+import { appendFileSync, readFileSync } from "node:fs";
+import { resolve, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 import { readChangeLog, changeLogFreshness, CHANGES_PATH } from "./change-log.js";
 
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
 export const DEFAULT_THRESHOLD_DAYS = 14;
 
-export function report(freshness, thresholdDays) {
+export const WORKFLOW_PATH =
+  process.env.AGENTDEALS_REVERIFY_WORKFLOW_PATH ||
+  resolve(__dirname, "..", ".github", "workflows", "reverify.yml");
+
+const INVOCATION = /node\s+scripts\/reverify-rolling\.js[^\n]*/g;
+
+export function detectorSchedule(workflowYaml) {
+  const invocations = workflowYaml.match(INVOCATION) ?? [];
+  if (invocations.length === 0) {
+    return { known: false, scheduled: false, reason: "no reverify-rolling.js invocation found" };
+  }
+  const withAi = invocations.filter((line) => /(^|\s)--ai(\s|$)/.test(line));
+  if (withAi.length > 0 && withAi.length < invocations.length) {
+    return {
+      known: false,
+      scheduled: false,
+      reason: `${withAi.length} of ${invocations.length} invocations pass --ai`,
+    };
+  }
+  return { known: true, scheduled: withAi.length > 0, reason: null };
+}
+
+export function report(freshness, thresholdDays, schedule) {
   const lines = [];
   lines.push("── Change-log freshness ──");
   lines.push(`Total changes recorded: ${freshness.total}`);
@@ -19,22 +44,55 @@ export function report(freshness, thresholdDays) {
         ? ` (last ${freshness.last_detected_date}, ${freshness.days_since_last_detected} days ago)`
         : " (none — no detector has ever written to this log)")
   );
-  lines.push(`Threshold: ${thresholdDays} days`);
+  lines.push(`Entries whose effective date is the day we looked: ${freshness.discovered_date_total}`);
+  lines.push("");
 
-  const days = freshness.days_since_last_recorded;
+  if (!schedule.known) {
+    lines.push(
+      `CANNOT TELL whether the detector is scheduled: ${schedule.reason}. Refusing to guess which alarm applies.`
+    );
+    return { failJob: false, openAbsenceIssue: false, undecidable: true, text: lines.join("\n") };
+  }
+
+  if (!schedule.scheduled) {
+    lines.push(
+      "The daily workflow does not pass --ai, so nothing is scheduled to detect a change."
+    );
+    lines.push(
+      "Elapsed time cannot measure a detector that is switched off, so this step does not fail the run."
+    );
+    lines.push("Signalling the absence as a single open issue instead.");
+    return { failJob: false, openAbsenceIssue: true, undecidable: false, text: lines.join("\n") };
+  }
+
+  const days = freshness.days_since_last_detected;
+  lines.push(`Detector is scheduled (--ai). Threshold: ${thresholdDays} days since last detection.`);
   const stale = days === null || days > thresholdDays;
   if (stale) {
     lines.push("");
     lines.push(
       days === null
-        ? "STALE: no entry carries a recorded_date, so the age of this log cannot be measured."
-        : `STALE: ${days} days since anything was added to the change log, past the ${thresholdDays}-day threshold.`
+        ? "STALE: the detector is scheduled but has never written an entry to this log. This fires from its first scheduled run, because a detector that runs and records nothing is indistinguishable here from one that never ran — only its first detection clears it."
+        : `STALE: ${days} days since the detector last recorded a change, past the ${thresholdDays}-day threshold.`
     );
     lines.push(
-      "The daily job runs URL mode, which cannot detect a change. Nothing else writes to this log."
+      "A hand-written entry does not clear this: the gate reads days_since_last_detected, not days_since_last_recorded."
     );
   }
-  return { stale, text: lines.join("\n") };
+  return { failJob: stale, openAbsenceIssue: false, undecidable: false, text: lines.join("\n") };
+}
+
+function emitOutputs(result, schedule) {
+  const outputPath = process.env.GITHUB_OUTPUT;
+  if (!outputPath) return;
+  appendFileSync(
+    outputPath,
+    [
+      `detector_scheduled=${schedule.known && schedule.scheduled}`,
+      `open_absence_issue=${result.openAbsenceIssue}`,
+      "",
+    ].join("\n")
+  );
 }
 
 function main() {
@@ -54,9 +112,20 @@ function main() {
     process.exit(2);
   }
 
-  const { stale, text } = report(changeLogFreshness(data.changes), thresholdDays);
-  console.log(text);
-  process.exit(stale ? 1 : 0);
+  let workflowYaml;
+  try {
+    workflowYaml = readFileSync(WORKFLOW_PATH, "utf-8");
+  } catch (err) {
+    console.error(`Failed to read ${WORKFLOW_PATH}: ${err.message}`);
+    process.exit(2);
+  }
+
+  const schedule = detectorSchedule(workflowYaml);
+  const result = report(changeLogFreshness(data.changes), thresholdDays, schedule);
+  console.log(result.text);
+  emitOutputs(result, schedule);
+  if (result.undecidable) process.exit(2);
+  process.exit(result.failJob ? 1 : 0);
 }
 
 const isMainModule =

--- a/scripts/detector-absence-issue-body.js
+++ b/scripts/detector-absence-issue-body.js
@@ -1,0 +1,34 @@
+#!/usr/bin/env node
+
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+export function absenceIssueBody(marker) {
+  return [
+    "The daily re-verification workflow does not pass `--ai`, so the only mode that can detect a",
+    "pricing change never runs. URL mode reports a hardcoded zero. Nothing is scheduled to write",
+    "to `data/deal_changes.json`.",
+    "",
+    "This is one durable signal for a condition elapsed time cannot measure. The change log ages",
+    "whether or not anything out there has changed, so a day-counting alarm on it would be red",
+    "every day, and an alarm that is red every day is one nobody reads.",
+    "",
+    "The staleness gate reads `days_since_last_detected` and starts failing the daily run at the",
+    "same commit that adds `--ai` to the workflow. There is no flag to flip separately.",
+    "",
+    "Opened by `.github/workflows/reverify.yml`, which will not open a second one while this is",
+    `open. Marker: ${marker}`,
+    "",
+  ].join("\n");
+}
+
+const isMainModule =
+  process.argv[1] && resolve(process.argv[1]) === resolve(fileURLToPath(import.meta.url));
+if (isMainModule) {
+  const marker = process.argv[2];
+  if (!marker) {
+    console.error("Usage: detector-absence-issue-body.js <marker>");
+    process.exit(2);
+  }
+  process.stdout.write(absenceIssueBody(marker));
+}

--- a/scripts/mutate-1074-ac10-round2.sh
+++ b/scripts/mutate-1074-ac10-round2.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+set -u
+
+cd "$(dirname "$0")/.." || exit 1
+
+FILES=(scripts/change-log.js src/serve.ts)
+BACKUP=$(mktemp -d)
+for f in "${FILES[@]}"; do
+  mkdir -p "$BACKUP/$(dirname "$f")"
+  cp "$f" "$BACKUP/$f"
+done
+
+restore() {
+  for f in "${FILES[@]}"; do cp "$BACKUP/$f" "$f"; done
+  npm run build > /dev/null 2>&1
+}
+
+killed=0
+survived=0
+SURVIVORS=()
+
+mutate() {
+  local label="$1"; local file="$2"; local from="$3"; local to="$4"
+  restore
+  if ! grep -qF -- "$from" "$file"; then
+    echo "  SKIP (pattern absent): $label"
+    return
+  fi
+  python3 - "$file" "$from" "$to" <<'PY'
+import sys
+path, frm, to = sys.argv[1], sys.argv[2], sys.argv[3]
+src = open(path).read()
+open(path, "w").write(src.replace(frm, to, 1))
+PY
+  npm run build > /dev/null 2>&1
+  if node --test --test-concurrency 1 test/change-date-provenance.test.ts test/change-log-writer.test.ts > /tmp/mutate-ac10-r2.log 2>&1; then
+    survived=$((survived + 1))
+    SURVIVORS+=("$label")
+    echo "  SURVIVED: $label"
+  else
+    killed=$((killed + 1))
+    echo "  killed:   $label"
+  fi
+}
+
+echo "── Re-running the four round-one survivors ──"
+
+mutate "the script-side predicate admits a discovery as an event date" \
+  scripts/change-log.js "export const EVENT_DATED_SOURCES = [DATE_SOURCE_VENDOR_PAGE, DATE_SOURCE_HAND_WRITTEN];" \
+  "export const EVENT_DATED_SOURCES = [DATE_SOURCE_VENDOR_PAGE, DATE_SOURCE_HAND_WRITTEN, DATE_SOURCE_DISCOVERED];"
+mutate "/changes groups a discovery into a calendar month" \
+  src/serve.ts "  const sorted = [...eventDated].sort((a, b) => b.date.localeCompare(a.date));
+  const undatedSorted = [...undatedChanges].sort((a, b) => b.date.localeCompare(a.date));
+
+  // Group by month" \
+  "  const sorted = [...allChanges].sort((a, b) => b.date.localeCompare(a.date));
+  const undatedSorted = [...undatedChanges].sort((a, b) => b.date.localeCompare(a.date));
+
+  // Group by month"
+mutate "/changes counts a discovery in Last 30 Days" \
+  src/serve.ts "const last30DaysCount = eventDated.filter(c => c.date >= thirtyDaysAgo).length;" \
+  "const last30DaysCount = allChanges.filter(c => c.date >= thirtyDaysAgo).length;"
+mutate "/expiring counts a discovery as a recent change" \
+  src/serve.ts "const recent = eventDated.filter(c => c.date < today && c.date >= thirtyDaysAgo)" \
+  "const recent = allChanges.filter(c => c.date <= today && c.date >= thirtyDaysAgo)"
+
+echo "── Checks that the new assertions cannot pass for the wrong reason ──"
+mutate "the undated group is rendered but the dated month groups are dropped" \
+  src/serve.ts "\${undatedHtml}
+\${monthsHtml}
+
+  <div class=\"cross-links\">" "\${undatedHtml}
+
+  <div class=\"cross-links\">"
+mutate "/expiring drops the Recently Discovered section" \
+  src/serve.ts "\${recentlyDiscovered.length > 0 ? \`  <div class=\"recent-section\">
+    <h2>Recently Discovered</h2>" "\${false ? \`  <div class=\"recent-section\">
+    <h2>Recently Discovered</h2>"
+
+restore
+rm -rf "$BACKUP"
+
+echo ""
+echo "── ${killed} killed, ${survived} survived ──"
+for s in "${SURVIVORS[@]:-}"; do [ -n "$s" ] && echo "  SURVIVOR: $s"; done
+exit 0

--- a/scripts/mutate-1074-ac10.sh
+++ b/scripts/mutate-1074-ac10.sh
@@ -1,0 +1,234 @@
+#!/usr/bin/env bash
+set -u
+
+cd "$(dirname "$0")/.." || exit 1
+
+FILES=(scripts/change-log.js scripts/check-change-log-staleness.js scripts/backfill-change-date-sources.js scripts/validate-data.ts src/change-dates.ts src/data.ts src/serve.ts src/server.ts)
+BACKUP=$(mktemp -d)
+for f in "${FILES[@]}"; do
+  mkdir -p "$BACKUP/$(dirname "$f")"
+  cp "$f" "$BACKUP/$f"
+done
+
+restore() {
+  for f in "${FILES[@]}"; do cp "$BACKUP/$f" "$f"; done
+  npm run build > /dev/null 2>&1
+}
+
+killed=0
+survived=0
+SURVIVORS=()
+
+mutate() {
+  local label="$1"; local file="$2"; local from="$3"; local to="$4"
+  restore
+  if ! grep -qF -- "$from" "$file"; then
+    echo "  SKIP (pattern absent): $label"
+    return
+  fi
+  python3 - "$file" "$from" "$to" <<'PY'
+import sys
+path, frm, to = sys.argv[1], sys.argv[2], sys.argv[3]
+src = open(path).read()
+open(path, "w").write(src.replace(frm, to, 1))
+PY
+  npm run build > /dev/null 2>&1
+  if node --test --test-concurrency 1 test/change-date-provenance.test.ts test/change-log-writer.test.ts > /tmp/mutate-ac10-run.log 2>&1; then
+    survived=$((survived + 1))
+    SURVIVORS+=("$label")
+    echo "  SURVIVED: $label"
+  else
+    killed=$((killed + 1))
+    echo "  killed:   $label"
+  fi
+}
+
+echo "── Mutating the writer's date provenance ──"
+mutate "a discovery is labelled as if the vendor's page stated the date" \
+  scripts/change-log.js "date_source: statedDate ? DATE_SOURCE_VENDOR_PAGE : DATE_SOURCE_DISCOVERED," \
+  "date_source: DATE_SOURCE_VENDOR_PAGE,"
+mutate "a page-stated date is labelled a discovery" \
+  scripts/change-log.js "date_source: statedDate ? DATE_SOURCE_VENDOR_PAGE : DATE_SOURCE_DISCOVERED," \
+  "date_source: DATE_SOURCE_DISCOVERED,"
+mutate "the writer emits no provenance at all" \
+  scripts/change-log.js "date_source: statedDate ? DATE_SOURCE_VENDOR_PAGE : DATE_SOURCE_DISCOVERED," \
+  "date_source: undefined,"
+mutate "a malformed page-stated date is kept as the effective date" \
+  scripts/change-log.js "typeof result.effective_date === \"string\" && ISO_DATE.test(result.effective_date.trim())" \
+  "typeof result.effective_date === \"string\" && result.effective_date.trim().length > 0"
+mutate "the discovery falls back to a date that is not the run date" \
+  scripts/change-log.js "date: statedDate ?? recordedDate," "date: statedDate ?? \"2026-01-01\","
+
+echo "── Mutating the predicate that decides what may be presented as an event ──"
+mutate "the script-side predicate admits a discovery as an event date" \
+  scripts/change-log.js "export const EVENT_DATED_SOURCES = [DATE_SOURCE_VENDOR_PAGE, DATE_SOURCE_HAND_WRITTEN];" \
+  "export const EVENT_DATED_SOURCES = [DATE_SOURCE_VENDOR_PAGE, DATE_SOURCE_HAND_WRITTEN, DATE_SOURCE_DISCOVERED];"
+mutate "the server predicate admits a discovery as an event date" \
+  src/data.ts "export const EVENT_DATED_SOURCES: ChangeDateSource[] = [\"vendor_page\", \"hand_written\"];" \
+  "export const EVENT_DATED_SOURCES: ChangeDateSource[] = [\"vendor_page\", \"hand_written\", \"discovered\"];"
+mutate "an absent provenance defaults to being an event date" \
+  src/data.ts "return EVENT_DATED_SOURCES.includes(change.date_source as ChangeDateSource);" \
+  "return change.date_source !== \"discovered\";"
+mutate "the partition puts every entry on the dated side" \
+  src/data.ts "for (const change of changes) (isEventDated(change) ? dated : discovered).push(change);" \
+  "for (const change of changes) dated.push(change);"
+mutate "the count of undateable entries is always zero" \
+  src/data.ts "discovered_date_total: changes.filter((c) => !isEventDated(c)).length," \
+  "discovered_date_total: 0,"
+mutate "entries missing a provenance are not counted as missing" \
+  src/data.ts "entries_without_date_source: changes.filter(" "entries_without_date_source: 0 * changes.filter("
+
+echo "── Mutating the rendering helpers ──"
+mutate "the discovery prefix is dropped from the rendered date" \
+  src/change-dates.ts "return isEventDated(c) ? c.date : \`\${DISCOVERED_DATE_PREFIX} \${c.date}\`;" \
+  "return c.date;"
+mutate "a discovery date is published as datePublished in structured data" \
+  src/change-dates.ts "return isEventDated(c) ? { datePublished: c.date } : {};" \
+  "return { datePublished: c.date };"
+mutate "the undated group heading stops naming what is missing" \
+  src/change-dates.ts "return \`Effective date unknown (\${count} \${count === 1 ? \"change\" : \"changes\"})\`;" \
+  "return \"Other changes\";"
+mutate "the undated note stops saying they are excluded from the counts" \
+  src/change-dates.ts "excluded from the monthly groups" "included in the monthly groups"
+
+echo "── Mutating the change timeline ──"
+mutate "/changes groups a discovery into a calendar month" \
+  src/serve.ts "  const sorted = [...eventDated].sort((a, b) => b.date.localeCompare(a.date));
+  const undatedSorted = [...undatedChanges].sort((a, b) => b.date.localeCompare(a.date));
+
+  // Group by month" \
+  "  const sorted = [...allChanges].sort((a, b) => b.date.localeCompare(a.date));
+  const undatedSorted = [...undatedChanges].sort((a, b) => b.date.localeCompare(a.date));
+
+  // Group by month"
+mutate "/changes counts a discovery in Last 30 Days" \
+  src/serve.ts "const last30DaysCount = eventDated.filter(c => c.date >= thirtyDaysAgo).length;" \
+  "const last30DaysCount = allChanges.filter(c => c.date >= thirtyDaysAgo).length;"
+mutate "/changes stops rendering the undated group at all" \
+  src/serve.ts "\${changeLogFreshnessNote()}
+\${undatedHtml}" "\${changeLogFreshnessNote()}"
+mutate "/changes marks a discovery as an upcoming change" \
+  src/serve.ts "    const isUpcoming = dated && c.date >= today;
+    const altHtml = c.alternatives && c.alternatives.length > 0
+      ? \`<div class=\"chg-alts\">" \
+  "    const isUpcoming = c.date >= today;
+    const altHtml = c.alternatives && c.alternatives.length > 0
+      ? \`<div class=\"chg-alts\">"
+mutate "/pricing-changes groups a discovery into a calendar month" \
+  src/serve.ts "  const sorted = [...eventDated].sort((a, b) => b.date.localeCompare(a.date));
+  const undatedSorted = [...undatedChanges].sort((a, b) => b.date.localeCompare(a.date));
+
+  // Group by month
+  const byMonth = new Map<string, typeof sorted>();
+  for (const c of sorted) {
+    const monthKey = c.date.slice(0, 7);
+    if (!byMonth.has(monthKey)) byMonth.set(monthKey, []);
+    byMonth.get(monthKey)!.push(c);
+  }
+
+  const monthNames = [\"January\", \"February\", \"March\", \"April\", \"May\", \"June\", \"July\", \"August\", \"September\", \"October\", \"November\", \"December\"];
+  function formatMonth(key: string): string {
+    const [y, m] = key.split(\"-\");
+    return \`\${monthNames[parseInt(m, 10) - 1]} \${y}\`;
+  }
+
+  // Anchor ID for each change" \
+  "  const sorted = [...allChanges].sort((a, b) => b.date.localeCompare(a.date));
+  const undatedSorted: typeof sorted = [];
+
+  // Group by month
+  const byMonth = new Map<string, typeof sorted>();
+  for (const c of sorted) {
+    const monthKey = c.date.slice(0, 7);
+    if (!byMonth.has(monthKey)) byMonth.set(monthKey, []);
+    byMonth.get(monthKey)!.push(c);
+  }
+
+  const monthNames = [\"January\", \"February\", \"March\", \"April\", \"May\", \"June\", \"July\", \"August\", \"September\", \"October\", \"November\", \"December\"];
+  function formatMonth(key: string): string {
+    const [y, m] = key.split(\"-\");
+    return \`\${monthNames[parseInt(m, 10) - 1]} \${y}\`;
+  }
+
+  // Anchor ID for each change"
+mutate "/expiring treats a discovery as an upcoming deadline" \
+  src/serve.ts "const upcoming = eventDated.filter(c => c.date >= today)" "const upcoming = allChanges.filter(c => c.date >= today)"
+mutate "/expiring counts a discovery as a recent change" \
+  src/serve.ts "const recent = eventDated.filter(c => c.date < today && c.date >= thirtyDaysAgo)" \
+  "const recent = allChanges.filter(c => c.date <= today && c.date >= thirtyDaysAgo)"
+
+echo "── Mutating the monthly reports ──"
+mutate "a discovery opens a month on /reports" \
+  src/serve.ts "for (const c of allChanges) if (isEventDated(c)) months.add(c.date.slice(0, 7));" \
+  "for (const c of allChanges) months.add(c.date.slice(0, 7));"
+mutate "a discovery is counted inside a monthly report" \
+  src/serve.ts "return changes.filter((c) => isEventDated(c) && c.date.startsWith(yearMonthPrefix));" \
+  "return changes.filter((c) => c.date.startsWith(yearMonthPrefix));"
+
+echo "── Mutating what agents are told ──"
+mutate "the MCP digest drops the provenance and hands over a bare date" \
+  src/server.ts "date_source: change.date_source, " ""
+mutate "a discovery is published to agents as an upcoming deadline" \
+  src/data.ts ".filter((c) => isEventDated(c) && c.date >= today && c.date <= thirtyDaysFromNow)" \
+  ".filter((c) => c.date >= today && c.date <= thirtyDaysFromNow)"
+
+echo "── Mutating the alarm's reading of the schedule ──"
+mutate "the schedule always reads as scheduled" \
+  scripts/check-change-log-staleness.js "return { known: true, scheduled: withAi.length > 0, reason: null };" \
+  "return { known: true, scheduled: true, reason: null };"
+mutate "the schedule always reads as not scheduled" \
+  scripts/check-change-log-staleness.js "return { known: true, scheduled: withAi.length > 0, reason: null };" \
+  "return { known: true, scheduled: false, reason: null };"
+mutate "--ai is matched as a substring, so --ai-dry-run counts" \
+  scripts/check-change-log-staleness.js "const withAi = invocations.filter((line) => /(^|\\s)--ai(\\s|\$)/.test(line));" \
+  "const withAi = invocations.filter((line) => line.includes(\"--ai\"));"
+mutate "a missing invocation is read as a decided answer" \
+  scripts/check-change-log-staleness.js "return { known: false, scheduled: false, reason: \"no reverify-rolling.js invocation found\" };" \
+  "return { known: true, scheduled: false, reason: null };"
+mutate "a partially converted workflow is read as decided" \
+  scripts/check-change-log-staleness.js "if (withAi.length > 0 && withAi.length < invocations.length) {" "if (false) {"
+
+echo "── Mutating what the alarm gates on ──"
+mutate "the gate reads the log's age instead of the detector's" \
+  scripts/check-change-log-staleness.js "const days = freshness.days_since_last_detected;" \
+  "const days = freshness.days_since_last_recorded;"
+mutate "the alarm never fails the job" \
+  scripts/check-change-log-staleness.js "return { failJob: stale, openAbsenceIssue: false, undecidable: false, text: lines.join(\"\\n\") };" \
+  "return { failJob: false, openAbsenceIssue: false, undecidable: false, text: lines.join(\"\\n\") };"
+mutate "a scheduled detector that never detected is treated as healthy" \
+  scripts/check-change-log-staleness.js "const stale = days === null || days > thresholdDays;" \
+  "const stale = days !== null && days > thresholdDays;"
+mutate "the alarm fires one day early" \
+  scripts/check-change-log-staleness.js "const stale = days === null || days > thresholdDays;" \
+  "const stale = days === null || days >= thresholdDays;"
+mutate "the threshold is loosened past the gap we already had" \
+  scripts/check-change-log-staleness.js "export const DEFAULT_THRESHOLD_DAYS = 14;" \
+  "export const DEFAULT_THRESHOLD_DAYS = 200;"
+mutate "the unscheduled state fails the daily run instead of signalling once" \
+  scripts/check-change-log-staleness.js "return { failJob: false, openAbsenceIssue: true, undecidable: false, text: lines.join(\"\\n\") };" \
+  "return { failJob: true, openAbsenceIssue: false, undecidable: false, text: lines.join(\"\\n\") };"
+mutate "the absence is never signalled" \
+  scripts/check-change-log-staleness.js "return { failJob: false, openAbsenceIssue: true, undecidable: false, text: lines.join(\"\\n\") };" \
+  "return { failJob: false, openAbsenceIssue: false, undecidable: false, text: lines.join(\"\\n\") };"
+mutate "the alarm stops saying a hand-written entry cannot clear it" \
+  scripts/check-change-log-staleness.js "\"A hand-written entry does not clear this: the gate reads days_since_last_detected, not days_since_last_recorded.\"" \
+  "\"\""
+
+echo "── Mutating the backfill and the data gate ──"
+mutate "the backfill claims a machine-written entry was hand-written" \
+  scripts/backfill-change-date-sources.js "(c) => !c.detected_by && !DATE_SOURCES.includes(c.date_source)" \
+  "(c) => !DATE_SOURCES.includes(c.date_source)"
+mutate "the backfill relabels an entry that already carries a provenance" \
+  scripts/backfill-change-date-sources.js "const alreadyLabelled = changes.filter((c) => DATE_SOURCES.includes(c.date_source));" \
+  "const alreadyLabelled = [];"
+mutate "a published entry may carry no provenance" \
+  scripts/validate-data.ts "  \"alternatives\",
+  \"date_source\"," "  \"alternatives\","
+
+restore
+rm -rf "$BACKUP"
+
+echo ""
+echo "── ${killed} killed, ${survived} survived ──"
+for s in "${SURVIVORS[@]:-}"; do [ -n "$s" ] && echo "  SURVIVOR: $s"; done
+exit 0

--- a/scripts/mutate-1074.sh
+++ b/scripts/mutate-1074.sh
@@ -119,7 +119,7 @@ mutate "an unmeasurable age is treated as healthy" \
 mutate "the threshold is loosened past the gap we already had" \
   scripts/check-change-log-staleness.js "export const DEFAULT_THRESHOLD_DAYS = 14;" "export const DEFAULT_THRESHOLD_DAYS = 200;"
 mutate "the alarm stops saying the daily job cannot clear it" \
-  scripts/check-change-log-staleness.js "\"The daily job runs URL mode, which cannot detect a change. Nothing else writes to this log.\"" "\"\""
+  scripts/check-change-log-staleness.js "\"The daily workflow does not pass --ai, so nothing is scheduled to detect a change.\"" "\"\""
 
 echo "── Mutating the backfill ──"
 mutate "the backfill dates an entry from the last commit that held it" \
@@ -135,7 +135,9 @@ mutate "the age is dropped from /api/metrics" \
   src/serve.ts "change_log_freshness: getChangeLogFreshness()," "//"
 mutate "the freshness line is dropped from the change timeline" \
   src/serve.ts "\${changeLogFreshnessNote()}
-\${monthsHtml}" "\${monthsHtml}"
+\${undatedHtml}
+\${monthsHtml}" "\${undatedHtml}
+\${monthsHtml}"
 mutate "the freshness line is dropped from the expiring page" \
   src/serve.ts "\${changeLogFreshnessNote()}
 \${totalUpcoming > 0" "\${totalUpcoming > 0"

--- a/scripts/validate-data.ts
+++ b/scripts/validate-data.ts
@@ -133,7 +133,10 @@ const REQUIRED_CHANGE_FIELDS = [
   "source_url",
   "category",
   "alternatives",
+  "date_source",
 ];
+
+const VALID_DATE_SOURCES = ["vendor_page", "hand_written", "discovered"];
 
 function validateOffers(offers: Offer[]): ValidationError[] {
   const errors: ValidationError[] = [];
@@ -274,6 +277,16 @@ function validateDealChanges(changes: DealChange[]): ValidationError[] {
         vendor,
         field: "source_url",
         message: `Invalid URL format: ${change.source_url}`,
+      });
+    }
+
+    if (change.date_source && !VALID_DATE_SOURCES.includes(change.date_source)) {
+      errors.push({
+        file: "data/deal_changes.json",
+        index: i,
+        vendor,
+        field: "date_source",
+        message: `Unknown date_source "${change.date_source}". Valid: ${VALID_DATE_SOURCES.join(", ")}`,
       });
     }
   }

--- a/src/change-dates.ts
+++ b/src/change-dates.ts
@@ -1,0 +1,21 @@
+import { isEventDated } from "./data.js";
+import type { DealChange } from "./types.js";
+
+type DatedChange = Pick<DealChange, "date" | "date_source">;
+
+export const DISCOVERED_DATE_PREFIX = "discovered";
+
+export const UNDATED_GROUP_NOTE =
+  "The vendor’s page states these terms but not when they took effect, so we can only tell you when we found them. They are listed by discovery date and are excluded from the monthly groups and the Last 30 Days count above, both of which count changes by the date they took effect.";
+
+export function undatedGroupHeading(count: number): string {
+  return `Effective date unknown (${count} ${count === 1 ? "change" : "changes"})`;
+}
+
+export function changeDateLabel(c: DatedChange): string {
+  return isEventDated(c) ? c.date : `${DISCOVERED_DATE_PREFIX} ${c.date}`;
+}
+
+export function changeDatePublished(c: DatedChange): { datePublished: string } | Record<string, never> {
+  return isEventDated(c) ? { datePublished: c.date } : {};
+}

--- a/src/data.ts
+++ b/src/data.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import type { Offer, EnrichedOffer, OfferIndex, DealChange, DealChangesIndex, StabilityClass, Referral, RiskCause, LinkUnreachable } from "./types.js";
+import type { Offer, EnrichedOffer, OfferIndex, DealChange, DealChangesIndex, ChangeDateSource, StabilityClass, Referral, RiskCause, LinkUnreachable } from "./types.js";
 import { isUrlSuspended } from "./referral-health.js";
 import { rankForListing } from "./ranking.js";
 import { unreachableNoticeForUrl, resetLinkHealthCache } from "./link-health.js";
@@ -9,7 +9,8 @@ import { filterAlternatives } from "./product-role.js";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const INDEX_PATH = path.join(__dirname, "..", "data", "index.json");
-const CHANGES_PATH = path.join(__dirname, "..", "data", "deal_changes.json");
+const CHANGES_PATH =
+  process.env.AGENTDEALS_CHANGES_PATH || path.join(__dirname, "..", "data", "deal_changes.json");
 
 let cachedOffers: Offer[] | null = null;
 let cachedChanges: DealChange[] | null = null;
@@ -433,6 +434,23 @@ export function loadDealChanges(): DealChange[] {
   return cachedChanges;
 }
 
+export const DATE_SOURCES: ChangeDateSource[] = ["vendor_page", "hand_written", "discovered"];
+
+export const EVENT_DATED_SOURCES: ChangeDateSource[] = ["vendor_page", "hand_written"];
+
+export function isEventDated(change: Pick<DealChange, "date_source">): boolean {
+  return EVENT_DATED_SOURCES.includes(change.date_source as ChangeDateSource);
+}
+
+export function partitionByDateProvenance<T extends Pick<DealChange, "date_source">>(
+  changes: T[]
+): { dated: T[]; discovered: T[] } {
+  const dated: T[] = [];
+  const discovered: T[] = [];
+  for (const change of changes) (isEventDated(change) ? dated : discovered).push(change);
+  return { dated, discovered };
+}
+
 export interface ChangeLogFreshness {
   total: number;
   last_recorded_date: string | null;
@@ -442,6 +460,8 @@ export interface ChangeLogFreshness {
   recorded_last_30_days: number;
   machine_detected_total: number;
   entries_without_recorded_date: number;
+  discovered_date_total: number;
+  entries_without_date_source: number;
 }
 
 export function changeLogFreshness(changes: DealChange[], now: Date = new Date()): ChangeLogFreshness {
@@ -467,6 +487,10 @@ export function changeLogFreshness(changes: DealChange[], now: Date = new Date()
     recorded_last_30_days: recorded.filter((d) => d >= thirtyDaysAgo).length,
     machine_detected_total: changes.filter((c) => c.detected_by).length,
     entries_without_recorded_date: changes.length - recorded.length,
+    discovered_date_total: changes.filter((c) => !isEventDated(c)).length,
+    entries_without_date_source: changes.filter(
+      (c) => !DATE_SOURCES.includes(c.date_source as ChangeDateSource)
+    ).length,
   };
 }
 
@@ -1114,7 +1138,7 @@ export function getWeeklyDigest(): {
   // Upcoming deadlines from deal changes with future dates (next 30 days)
   const allChanges = loadDealChanges();
   const changeDeadlines = allChanges
-    .filter((c) => c.date >= today && c.date <= thirtyDaysFromNow)
+    .filter((c) => isEventDated(c) && c.date >= today && c.date <= thirtyDaysFromNow)
     .map((c) => ({
       vendor: c.vendor,
       date: c.date,

--- a/src/openapi.ts
+++ b/src/openapi.ts
@@ -540,7 +540,8 @@ export const openapiSpec = {
                         properties: {
                           vendor: { type: "string" },
                           change_type: { type: "string" },
-                          date: { type: "string", format: "date" },
+                          date: { type: "string", format: "date", description: "When the change took effect, unless date_source is \"discovered\" — then it is the day we found it and the effective date is unknown." },
+                          date_source: { type: "string", enum: ["vendor_page", "hand_written", "discovered"], description: "Where date came from. \"vendor_page\": the vendor's page stated it. \"hand_written\": a person recorded it before this field existed. \"discovered\": the page stated no effective date, so date is the day we read the page — do not present it as the date the vendor changed anything." },
                           summary: { type: "string" },
                           impact: { type: "string", enum: ["high", "medium", "low"] }
                         }

--- a/src/serve.ts
+++ b/src/serve.ts
@@ -5,7 +5,7 @@ import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
 import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
 import { createServer, getServerCard } from "./server.js";
-import { vendorRiskAssessment, NEGATIVE_CHANGE_TYPES, POSITIVE_CHANGE_TYPES, SEVERE_CHANGE_TYPES, loadOffers, getCategories, getNewOffers, getNewestDeals, searchOffers, enrichOffers, loadDealChanges, getDealChanges, getPersonalizedChanges, getOfferDetails, compareServices, checkVendorRisk, auditStack, getExpiringDeals, getWeeklyDigest, getFormattedWeeklyDigest, getFreshnessMetrics, getStabilityMap, getVendorReferral, sanitizeQuery, getChangeLogFreshness } from "./data.js";
+import { vendorRiskAssessment, NEGATIVE_CHANGE_TYPES, POSITIVE_CHANGE_TYPES, SEVERE_CHANGE_TYPES, loadOffers, getCategories, getNewOffers, getNewestDeals, searchOffers, enrichOffers, loadDealChanges, getDealChanges, getPersonalizedChanges, getOfferDetails, compareServices, checkVendorRisk, auditStack, getExpiringDeals, getWeeklyDigest, getFormattedWeeklyDigest, getFreshnessMetrics, getStabilityMap, getVendorReferral, sanitizeQuery, getChangeLogFreshness, isEventDated, partitionByDateProvenance } from "./data.js";
 import { getStackRecommendation } from "./stacks.js";
 import { estimateCosts } from "./costs.js";
 import { classifyRequest } from "./client-class.js";
@@ -30,7 +30,8 @@ import { linkifyVerdictBlocks, overdueReport, pageDateModified, pageFreshness, p
 import { rankOffers, rankForListing, rotateListing, utcDate, CRITERIA_PATH, DEMOTE_ONLY_POLICY, DISCLOSURE_RATIONALE, TIE_BREAK_ALGORITHM, GATE_TABLE, DEMERIT_TABLE, NOT_FREE_TIER_RULES, TIME_LIMITED_TIER_RULES } from "./ranking.js";
 import type { RankedEntry, RankingResult } from "./ranking.js";
 import { partitionAlternatives, partitionAlternativesAcross, productRoleSentence, MEMBERSHIP_GATE_RULES, MEMBERSHIP_GATE_ORDER, MEMBERSHIP_GATE_SYMMETRY, MEMBERSHIP_GATE_SCOPE, MEMBERSHIP_GATE_CORRECTIONS } from "./product-role.js";
-import type { Agent, RiskCause, LinkUnreachable } from "./types.js";
+import type { Agent, DealChange, RiskCause, LinkUnreachable } from "./types.js";
+import { changeDateLabel, changeDatePublished, undatedGroupHeading, DISCOVERED_DATE_PREFIX, UNDATED_GROUP_NOTE } from "./change-dates.js";
 import type { AgentBalance } from "./ledger.js";
 import type { SubmittedReferralCode } from "./referral-codes.js";
 
@@ -411,7 +412,7 @@ function buildChangesHtml(): string {
         <div class="change-header">
           <span class="change-badge" style="background:${badge.color}">${badge.label}</span>
           <span class="change-vendor">${c.vendor}</span>
-          <span class="change-date">${c.date}</span>
+          <span class="change-date">${changeDateLabel(c)}</span>
         </div>
         <div class="change-summary">${c.summary}</div>
       </div>`;
@@ -488,7 +489,7 @@ function buildRecentChangesSection(): string {
         <div class="rc-head">
           <span class="change-badge" style="background:${badge.color}">${badge.label}</span>
           <a href="/vendor/${vendorSlug}" class="rc-vendor">${c.vendor}</a>
-          <span class="rc-date">${c.date}</span>
+          <span class="rc-date">${changeDateLabel(c)}</span>
         </div>
         <div class="rc-summary">${c.summary}</div>
       </div>`;
@@ -507,7 +508,7 @@ function buildRecentChangesSection(): string {
         "@type": "Article",
         headline: `${c.vendor}: ${(changeTypeBadge[c.change_type] ?? { label: c.change_type }).label}`,
         description: c.summary,
-        datePublished: c.date,
+        ...changeDatePublished(c),
         url: `${BASE_URL}/vendor/${c.vendor.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-|-$/g, "")}`,
       },
     })),
@@ -4043,7 +4044,7 @@ ${allCompareLinks.join("\n")}
   // Monthly report appearances
   const reportMonths = getAvailableReportMonths();
   const vendorReportMonths = reportMonths.filter(m => {
-    return dealChanges.some((c: any) => c.vendor.toLowerCase() === vendorName.toLowerCase() && c.date.startsWith(m));
+    return changesEffectiveIn(dealChanges, m).some((c) => c.vendor.toLowerCase() === vendorName.toLowerCase());
   });
   const reportAppearancesHtml = vendorReportMonths.length > 0 ? `
   <div class="section">
@@ -8149,8 +8150,12 @@ function getMonthName(monthNum: number): string {
 function getAvailableReportMonths(): string[] {
   const allChanges = loadDealChanges();
   const months = new Set<string>();
-  for (const c of allChanges) months.add(c.date.slice(0, 7));
+  for (const c of allChanges) if (isEventDated(c)) months.add(c.date.slice(0, 7));
   return [...months].sort().reverse();
+}
+
+function changesEffectiveIn(changes: DealChange[], yearMonthPrefix: string): DealChange[] {
+  return changes.filter((c) => isEventDated(c) && c.date.startsWith(yearMonthPrefix));
 }
 
 function buildReportsIndexPage(): string {
@@ -8180,7 +8185,7 @@ function buildReportsIndexPage(): string {
 
   const monthCards = months.map(m => {
     const [y, mo] = m.split("-");
-    const monthChanges = allChanges.filter(c => c.date.startsWith(m));
+    const monthChanges = changesEffectiveIn(allChanges, m);
     const negative = monthChanges.filter(c => NEGATIVE_CHANGE_TYPES.has(c.change_type)).length;
     const positive = monthChanges.filter(c => ["new_free_tier","limits_increased","startup_program_expanded","new_tier"].includes(c.change_type)).length;
     const neutral = monthChanges.length - negative - positive;
@@ -8250,7 +8255,7 @@ function buildReportsIndexPage(): string {
 
 function buildMonthlyReportPage(yearMonth: string): string | null {
   const allChanges = loadDealChanges();
-  const monthChanges = allChanges.filter(c => c.date.startsWith(yearMonth));
+  const monthChanges = changesEffectiveIn(allChanges, yearMonth);
   if (monthChanges.length === 0) return null;
 
   const [yearStr, moStr] = yearMonth.split("-");
@@ -8282,7 +8287,7 @@ function buildMonthlyReportPage(yearMonth: string): string | null {
 
   // Previous month comparison
   const prevMonth = monthNum === 1 ? (parseInt(yearStr) - 1) + "-12" : yearStr + "-" + String(monthNum - 1).padStart(2, "0");
-  const prevChanges = allChanges.filter(c => c.date.startsWith(prevMonth));
+  const prevChanges = changesEffectiveIn(allChanges, prevMonth);
   const prevNeg = prevChanges.filter(c => negativeTypes.has(c.change_type)).length;
   const prevPos = prevChanges.filter(c => positiveTypes.has(c.change_type)).length;
 
@@ -49682,11 +49687,13 @@ function buildDeveloperHubPage(): string {
 
 function buildPricingChangesPage(): string {
   const allChanges = loadDealChanges();
+  const { dated: eventDated, discovered: undatedChanges } = partitionByDateProvenance(allChanges);
   const today = new Date().toISOString().slice(0, 10);
   const currentYear = new Date().getFullYear();
 
   // Sort all changes reverse chronological
-  const sorted = [...allChanges].sort((a, b) => b.date.localeCompare(a.date));
+  const sorted = [...eventDated].sort((a, b) => b.date.localeCompare(a.date));
+  const undatedSorted = [...undatedChanges].sort((a, b) => b.date.localeCompare(a.date));
 
   // Group by month
   const byMonth = new Map<string, typeof sorted>();
@@ -49726,7 +49733,8 @@ function buildPricingChangesPage(): string {
     const badge = changeTypeBadge[c.change_type] ?? { label: c.change_type, color: "#8b949e" };
     const impactColor = c.impact === "high" ? "#f85149" : c.impact === "medium" ? "#d29922" : "#8b949e";
     const vendorSlug = toSlug(c.vendor);
-    const isUpcoming = c.date >= today;
+    const dated = isEventDated(c);
+    const isUpcoming = dated && c.date >= today;
     const category = filterCategory[c.change_type] ?? "neutral";
     const altHtml = c.alternatives && c.alternatives.length > 0
       ? `<div class="pc-alts"><span class="pc-alts-label">Alternatives:</span> ${c.alternatives.map(a => `<a href="/vendor/${toSlug(a)}">${escHtmlServer(a)}</a>`).join(", ")}</div>`
@@ -49738,10 +49746,10 @@ function buildPricingChangesPage(): string {
         </div>`
       : "";
     const vendorCat = (c.category || "").toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/(^-|-$)/g, "");
-    const changeYear = c.date.slice(0, 4);
-    return `      <div class="pc-entry${isUpcoming ? " pc-upcoming" : ""}" id="${changeAnchor(c)}" data-type="${escHtmlServer(c.change_type)}" data-impact="${escHtmlServer(c.impact)}" data-category="${category}" data-vendor-cat="${vendorCat}" data-year="${changeYear}">
+    const changeYear = dated ? c.date.slice(0, 4) : "";
+    return `      <div class="pc-entry${isUpcoming ? " pc-upcoming" : ""}${dated ? "" : " pc-undated"}" id="${changeAnchor(c)}" data-type="${escHtmlServer(c.change_type)}" data-impact="${escHtmlServer(c.impact)}" data-category="${category}" data-vendor-cat="${vendorCat}" data-year="${changeYear}">
         <div class="pc-left">
-          <div class="pc-date">${c.date}</div>
+          <div class="pc-date">${dated ? c.date : `${DISCOVERED_DATE_PREFIX} ${c.date}`}</div>
           ${isUpcoming ? `<div class="pc-upcoming-badge">upcoming</div>` : ""}
           <a href="#${changeAnchor(c)}" class="pc-anchor" title="Link to this change">#</a>
         </div>
@@ -49834,6 +49842,12 @@ ${altHtml}
 ${entriesHtml}
     </div>`;
   }).join("\n");
+
+  const undatedHtml = undatedSorted.length === 0 ? "" : `    <div class="month-group month-group-undated">
+      <h2 class="month-heading" id="month-undated">${undatedGroupHeading(undatedSorted.length)}</h2>
+      <p class="month-note">${UNDATED_GROUP_NOTE}</p>
+${undatedSorted.map(c => buildChangeEntry(c)).join("\n")}
+    </div>`;
 
   const title = "Developer Tool Pricing Changes \u2014 Free Tier Tracker";
   const metaDesc = `Track ${allChanges.length}+ developer tool pricing changes: free tier removals, limit reductions, price hikes, and new free tiers. Interactive timeline filterable by type, impact, year, and category.`;
@@ -49988,6 +50002,7 @@ h1{font-family:var(--serif);font-size:2.25rem;color:var(--text);margin:1rem 0 .5
 .pc-entry:hover{border-color:var(--accent)}
 .pc-entry:target{border-color:var(--accent);background:var(--accent-glow)}
 .pc-upcoming{border-color:rgba(88,166,255,0.3)}
+.pc-undated{border-style:dashed}
 .pc-left{flex-shrink:0;min-width:100px;text-align:right;position:relative}
 .pc-date{font-family:var(--mono);font-size:.75rem;color:var(--text-muted)}
 .pc-upcoming-badge{font-family:var(--mono);font-size:.65rem;color:#58a6ff;font-weight:600;text-transform:uppercase;letter-spacing:.05em}
@@ -50084,6 +50099,7 @@ ${upcomingChanges.map(c => buildChangeEntry(c)).join("\n")}
 ` : ""}
 ${filterButtonsHtml}
 
+${undatedHtml}
 ${monthsHtml}
 
   <div class="cross-links">
@@ -50163,12 +50179,14 @@ ${entries}
 
 function buildChangesPage(): string {
   const allChanges = loadDealChanges();
+  const { dated: eventDated, discovered: undatedChanges } = partitionByDateProvenance(allChanges);
   const today = new Date().toISOString().slice(0, 10);
   const thirtyDaysAgo = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000).toISOString().slice(0, 10);
-  const last30DaysCount = allChanges.filter(c => c.date >= thirtyDaysAgo).length;
+  const last30DaysCount = eventDated.filter(c => c.date >= thirtyDaysAgo).length;
 
   // Sort all changes reverse chronological
-  const sorted = [...allChanges].sort((a, b) => b.date.localeCompare(a.date));
+  const sorted = [...eventDated].sort((a, b) => b.date.localeCompare(a.date));
+  const undatedSorted = [...undatedChanges].sort((a, b) => b.date.localeCompare(a.date));
 
   // Group by month
   const byMonth = new Map<string, typeof sorted>();
@@ -50188,13 +50206,14 @@ function buildChangesPage(): string {
     const badge = changeTypeBadge[c.change_type] ?? { label: c.change_type, color: "#8b949e" };
     const impactColor = c.impact === "high" ? "#f85149" : c.impact === "medium" ? "#d29922" : "#8b949e";
     const vendorSlug = toSlug(c.vendor);
-    const isUpcoming = c.date >= today;
+    const dated = isEventDated(c);
+    const isUpcoming = dated && c.date >= today;
     const altHtml = c.alternatives && c.alternatives.length > 0
       ? `<div class="chg-alts"><span class="chg-alts-label">Alternatives:</span> ${c.alternatives.map(a => `<a href="/vendor/${toSlug(a)}">${escHtmlServer(a)}</a>`).join(", ")}</div>`
       : "";
-    return `      <div class="chg-entry${isUpcoming ? " chg-upcoming" : ""}">
+    return `      <div class="chg-entry${isUpcoming ? " chg-upcoming" : ""}${dated ? "" : " chg-undated"}">
         <div class="chg-left">
-          <div class="chg-date">${c.date}</div>
+          <div class="chg-date">${dated ? c.date : `${DISCOVERED_DATE_PREFIX} ${c.date}`}</div>
           ${isUpcoming ? `<div class="chg-upcoming-badge">upcoming</div>` : ""}
         </div>
         <div class="chg-right">
@@ -50210,7 +50229,7 @@ ${altHtml}
   }
 
   const upcomingCount = sorted.filter(c => c.date >= today).length;
-  const removedCount = sorted.filter(c => c.change_type === "free_tier_removed" || c.change_type === "open_source_killed" || c.change_type === "product_deprecated").length;
+  const removedCount = allChanges.filter(c => c.change_type === "free_tier_removed" || c.change_type === "open_source_killed" || c.change_type === "product_deprecated").length;
 
   const monthsHtml = Array.from(byMonth.entries()).map(([month, changes]) => {
     const entriesHtml = changes.map(c => buildChangeEntry(c)).join("\n");
@@ -50219,6 +50238,12 @@ ${altHtml}
 ${entriesHtml}
     </div>`;
   }).join("\n");
+
+  const undatedHtml = undatedSorted.length === 0 ? "" : `    <div class="month-group month-group-undated">
+      <h2 class="month-heading">${undatedGroupHeading(undatedSorted.length)}</h2>
+      <p class="month-note">${UNDATED_GROUP_NOTE}</p>
+${undatedSorted.map(c => buildChangeEntry(c)).join("\n")}
+    </div>`;
 
   const title = "Deal Change Timeline \u2014 AgentDeals";
   const metaDesc = `${allChanges.length} developer infrastructure pricing changes tracked since launch \u2014 ${last30DaysCount} in the last 30 days. Free tier removals, price increases, product shutdowns, and new deals.`;
@@ -50278,9 +50303,11 @@ h1{font-family:var(--serif);font-size:2.25rem;color:var(--text);margin:1rem 0 .5
 .stat-label{font-family:var(--mono);font-size:.65rem;color:var(--text-dim);text-transform:uppercase;letter-spacing:.1em}
 .month-group{margin-bottom:2rem}
 .month-heading{font-family:var(--serif);font-size:1.15rem;color:var(--text);margin-bottom:.75rem;padding-bottom:.5rem;border-bottom:1px solid var(--border)}
+.month-note{font-size:.8rem;color:var(--text-muted);margin:-.25rem 0 .75rem;line-height:1.5}
 .chg-entry{display:flex;gap:1rem;padding:.75rem;margin-bottom:.5rem;border:1px solid var(--border);border-radius:8px;background:var(--bg-card);transition:border-color .2s}
 .chg-entry:hover{border-color:var(--accent)}
 .chg-upcoming{border-color:rgba(88,166,255,0.3)}
+.chg-undated{border-style:dashed}
 .chg-left{flex-shrink:0;min-width:100px;text-align:right}
 .chg-date{font-family:var(--mono);font-size:.75rem;color:var(--text-muted)}
 .chg-upcoming-badge{font-family:var(--mono);font-size:.65rem;color:#58a6ff;font-weight:600;text-transform:uppercase;letter-spacing:.05em}
@@ -50332,9 +50359,14 @@ ${globalNavCss()}
       <div class="stat-value">${byMonth.size}</div>
       <div class="stat-label">Months Tracked</div>
     </div>
+${undatedSorted.length === 0 ? "" : `    <div class="stat-card">
+      <div class="stat-value">${undatedSorted.length}</div>
+      <div class="stat-label">Effective Date Unknown</div>
+    </div>`}
   </div>
 
 ${changeLogFreshnessNote()}
+${undatedHtml}
 ${monthsHtml}
 
   <div class="mcp-cta">
@@ -50352,13 +50384,15 @@ ${monthsHtml}
 
 function buildExpiringPage(): string {
   const allChanges = loadDealChanges();
+  const { dated: eventDated, discovered: undatedChanges } = partitionByDateProvenance(allChanges);
   const today = new Date().toISOString().slice(0, 10);
   const todayMs = new Date(today + "T00:00:00Z").getTime();
 
   // Split into upcoming (future) and recent (past 30 days)
   const thirtyDaysAgo = new Date(todayMs - 30 * 86400000).toISOString().slice(0, 10);
-  const upcoming = allChanges.filter(c => c.date >= today).sort((a, b) => a.date.localeCompare(b.date));
-  const recent = allChanges.filter(c => c.date < today && c.date >= thirtyDaysAgo).sort((a, b) => b.date.localeCompare(a.date));
+  const upcoming = eventDated.filter(c => c.date >= today).sort((a, b) => a.date.localeCompare(b.date));
+  const recent = eventDated.filter(c => c.date < today && c.date >= thirtyDaysAgo).sort((a, b) => b.date.localeCompare(a.date));
+  const recentlyDiscovered = undatedChanges.filter(c => c.date >= thirtyDaysAgo).sort((a, b) => b.date.localeCompare(a.date));
 
   // Group upcoming by month
   const upcomingByMonth = new Map<string, typeof upcoming>();
@@ -50388,12 +50422,13 @@ function buildExpiringPage(): string {
     const badge = changeTypeBadge[c.change_type] ?? { label: c.change_type, color: "#8b949e" };
     const impactColor = c.impact === "high" ? "#f85149" : c.impact === "medium" ? "#d29922" : "#8b949e";
     const vendorSlug = toSlug(c.vendor);
-    const countdown = showCountdown ? countdownLabel(c.date) : null;
+    const dated = isEventDated(c);
+    const countdown = showCountdown && dated ? countdownLabel(c.date) : null;
     const urgentClass = countdown?.urgent ? " entry-urgent" : "";
-    return `      <div class="exp-entry${urgentClass}">
+    return `      <div class="exp-entry${urgentClass}${dated ? "" : " exp-undated"}">
         <div class="exp-left">
           ${countdown ? `<div class="exp-countdown${countdown.urgent ? " exp-countdown-urgent" : ""}">${countdown.text}</div>` : ""}
-          <div class="exp-date">${c.date}</div>
+          <div class="exp-date">${dated ? c.date : `${DISCOVERED_DATE_PREFIX} ${c.date}`}</div>
         </div>
         <div class="exp-right">
           <div class="exp-head">
@@ -50502,6 +50537,7 @@ h1{font-family:var(--serif);font-size:2.25rem;color:var(--text);margin:1rem 0 .5
 .recent-toggle:hover{border-color:var(--accent);background:var(--accent-glow)}
 .recent-entries{display:none}
 .recent-entries.show{display:block}
+.exp-undated{border-style:dashed}
 .no-upcoming{color:var(--text-dim);font-style:italic;padding:2rem;text-align:center;border:1px dashed var(--border);border-radius:8px}
 .mcp-cta{margin-top:2.5rem;padding:1.5rem;border:1px solid var(--border);border-radius:12px;background:var(--accent-glow);text-align:center}
 .mcp-cta p{color:var(--text-muted);font-size:.9rem;margin-bottom:.5rem}
@@ -50547,6 +50583,12 @@ ${recent.length > 0 ? `  <div class="recent-section">
     <div class="recent-entries">
 ${recent.map(c => buildEntry(c, false)).join("\n")}
     </div>
+  </div>` : ""}
+
+${recentlyDiscovered.length > 0 ? `  <div class="recent-section">
+    <h2>Recently Discovered</h2>
+    <p class="recent-desc">${recentlyDiscovered.length} ${recentlyDiscovered.length === 1 ? "change" : "changes"} we found in the last 30 days whose effective date the vendor’s page does not state. They are dated by discovery and are not counted as upcoming or as recently changed.</p>
+${recentlyDiscovered.map(c => buildEntry(c, false)).join("\n")}
   </div>` : ""}
 
   <div class="mcp-cta">

--- a/src/server-remote.ts
+++ b/src/server-remote.ts
@@ -302,7 +302,7 @@ export function createServer(): McpServer {
         if (!since && !change_type && !vendor && !vendors && !categories && include_expiring === undefined) {
           const data = await fetchWeeklyDigest() as Record<string, unknown>;
           if (response_format === "concise" && Array.isArray(data.deal_changes)) {
-            const conciseDigest = { ...data, deal_changes: (data.deal_changes as Record<string, unknown>[]).map((c) => ({ vendor: c.vendor, change_type: c.change_type, date: c.date, summary: c.summary })) };
+            const conciseDigest = { ...data, deal_changes: (data.deal_changes as Record<string, unknown>[]).map((c) => ({ vendor: c.vendor, change_type: c.change_type, date: c.date, date_source: c.date_source, summary: c.summary })) };
             return mcpText(conciseDigest);
           }
           return mcpText(data);

--- a/src/server.ts
+++ b/src/server.ts
@@ -45,7 +45,7 @@ function toConciseOffer(offer: Offer | EnrichedOffer) {
 }
 
 function toConciseDealChange(change: DealChange) {
-  return { vendor: change.vendor, change_type: change.change_type, date: change.date, summary: change.summary };
+  return { vendor: change.vendor, change_type: change.change_type, date: change.date, date_source: change.date_source, summary: change.summary };
 }
 
 export function createServer(getSessionId?: () => string | undefined, getClientName?: () => string | undefined): McpServer {

--- a/src/types.ts
+++ b/src/types.ts
@@ -101,6 +101,8 @@ export interface OfferIndex {
   offers: Offer[];
 }
 
+export type ChangeDateSource = "vendor_page" | "hand_written" | "discovered";
+
 export interface DealChange {
   vendor: string;
   change_type: "free_tier_removed" | "limits_reduced" | "restriction" | "limits_increased" | "new_free_tier" | "new_tier" | "pricing_restructured" | "open_source_killed" | "pricing_model_change" | "startup_program_expanded" | "pricing_postponed" | "product_deprecated" | "rebranded";
@@ -114,6 +116,7 @@ export interface DealChange {
   alternatives: string[];
   detected_by?: string;
   recorded_date?: string;
+  date_source?: ChangeDateSource;
 }
 
 export interface DealChangesIndex {

--- a/test/change-date-provenance.test.ts
+++ b/test/change-date-provenance.test.ts
@@ -1,0 +1,435 @@
+import { describe, it, before, after } from "node:test";
+import assert from "node:assert";
+import { spawn, type ChildProcess } from "node:child_process";
+import { readFileSync, writeFileSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  isEventDated,
+  partitionByDateProvenance,
+  changeLogFreshness,
+  DATE_SOURCES,
+  EVENT_DATED_SOURCES,
+} from "../dist/data.js";
+import {
+  changeDateLabel,
+  changeDatePublished,
+  undatedGroupHeading,
+  DISCOVERED_DATE_PREFIX,
+  UNDATED_GROUP_NOTE,
+} from "../dist/change-dates.js";
+
+const { buildChangeEntry } = await import("../scripts/change-log.js");
+const { planBackfill } = await import("../scripts/backfill-change-date-sources.js");
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO = path.join(__dirname, "..");
+
+const TODAY = new Date().toISOString().slice(0, 10);
+const TEN_DAYS_AGO = new Date(Date.parse(TODAY) - 10 * 86400000).toISOString().slice(0, 10);
+const SUBJECT = "Xata";
+const CONTROL = "Hyperping";
+
+const OFFER = {
+  vendor: SUBJECT,
+  category: "Databases",
+  description: "15 GB storage on the free plan.",
+  url: "https://xata.io/pricing",
+};
+
+function fixtureChange(dateSource: string) {
+  return {
+    vendor: SUBJECT,
+    change_type: "limits_reduced",
+    date: TODAY,
+    date_source: dateSource,
+    summary: "Free storage allowance cut.",
+    previous_state: "15 GB storage",
+    current_state: "5 GB storage",
+    impact: "high",
+    source_url: "https://xata.io/pricing",
+    category: "Databases",
+    alternatives: [],
+    detected_by: "reverify-ai",
+    recorded_date: TODAY,
+  };
+}
+
+function controlChange() {
+  return {
+    vendor: CONTROL,
+    change_type: "limits_reduced",
+    date: TEN_DAYS_AGO,
+    date_source: "vendor_page",
+    summary: "Monitor allowance cut.",
+    previous_state: "10 monitors",
+    current_state: "5 monitors",
+    impact: "medium",
+    source_url: "https://hyperping.io/pricing",
+    category: "Monitoring",
+    alternatives: [],
+    recorded_date: TEN_DAYS_AGO,
+  };
+}
+
+describe("what a date_source means", () => {
+  it("treats only an explicitly recorded provenance as an event date", () => {
+    for (const source of EVENT_DATED_SOURCES) {
+      assert.strictEqual(isEventDated({ date_source: source } as any), true, source);
+    }
+    assert.strictEqual(isEventDated({ date_source: "discovered" } as any), false);
+  });
+
+  it("under-claims rather than over-claims when the provenance is absent or unrecognised", () => {
+    assert.strictEqual(isEventDated({} as any), false);
+    assert.strictEqual(isEventDated({ date_source: "" } as any), false);
+    assert.strictEqual(isEventDated({ date_source: "from_somewhere" } as any), false);
+  });
+
+  it("has exactly one value that is not an event date", () => {
+    const notEventDated = DATE_SOURCES.filter((s: string) => !EVENT_DATED_SOURCES.includes(s as any));
+    assert.deepStrictEqual(notEventDated, ["discovered"]);
+  });
+
+  it("splits a mixed log without losing or duplicating an entry", () => {
+    const mixed = [
+      fixtureChange("vendor_page"),
+      fixtureChange("discovered"),
+      fixtureChange("hand_written"),
+      { ...fixtureChange("discovered"), date_source: undefined },
+    ];
+    const { dated, discovered } = partitionByDateProvenance(mixed as any);
+    assert.strictEqual(dated.length, 2);
+    assert.strictEqual(discovered.length, 2);
+    assert.strictEqual(dated.length + discovered.length, mixed.length);
+  });
+});
+
+describe("the writer refuses to pass a sweep date off as an effective date", () => {
+  const NOW = new Date("2026-09-10T06:00:00Z");
+  const result = { change_type: "limits_reduced", summary: "Cut.", current_state: "5 GB" };
+
+  it("records where the date came from when the page states one", () => {
+    const { entry } = buildChangeEntry(OFFER, { ...result, effective_date: "2026-07-01" }, { now: NOW });
+    assert.strictEqual(entry.date, "2026-07-01");
+    assert.strictEqual(entry.date_source, "vendor_page");
+  });
+
+  it("marks the run date as a discovery when the page states none", () => {
+    const { entry } = buildChangeEntry(OFFER, result, { now: NOW });
+    assert.strictEqual(entry.date, "2026-09-10");
+    assert.strictEqual(entry.recorded_date, "2026-09-10");
+    assert.strictEqual(entry.date_source, "discovered");
+  });
+
+  it("marks a malformed page-stated date as a discovery rather than keeping it", () => {
+    for (const bad of ["July 2026", "2026-7-1", "", "   ", "2026-07-01T00:00:00Z"]) {
+      const { entry } = buildChangeEntry(OFFER, { ...result, effective_date: bad }, { now: NOW });
+      assert.strictEqual(entry.date_source, "discovered", `expected discovery for ${JSON.stringify(bad)}`);
+      assert.strictEqual(entry.date, "2026-09-10");
+    }
+  });
+
+  it("never emits a provenance outside the published set", () => {
+    for (const effective_date of ["2026-07-01", undefined]) {
+      const { entry } = buildChangeEntry(OFFER, { ...result, effective_date }, { now: NOW });
+      assert.ok(DATE_SOURCES.includes(entry.date_source), entry.date_source);
+    }
+  });
+});
+
+describe("backfilling the entries written before the field existed", () => {
+  it("labels a hand-written entry and leaves an already-labelled one alone", () => {
+    const changes = [
+      { vendor: "A", date: "2026-01-01" },
+      { vendor: "B", date: "2026-01-01", date_source: "vendor_page" },
+    ];
+    const { toLabel, alreadyLabelled, machineWritten } = planBackfill(changes);
+    assert.deepStrictEqual(toLabel.map((c: any) => c.vendor), ["A"]);
+    assert.deepStrictEqual(alreadyLabelled.map((c: any) => c.vendor), ["B"]);
+    assert.strictEqual(machineWritten.length, 0);
+  });
+
+  it("does not claim a machine-written entry was hand-written", () => {
+    const changes = [{ vendor: "A", date: "2026-01-01", detected_by: "reverify-ai" }];
+    const { toLabel, machineWritten } = planBackfill(changes);
+    assert.strictEqual(toLabel.length, 0);
+    assert.strictEqual(machineWritten.length, 1);
+  });
+
+  it("left every published entry carrying a provenance", () => {
+    const published = JSON.parse(readFileSync(path.join(REPO, "data", "deal_changes.json"), "utf-8")).changes;
+    const freshness = changeLogFreshness(published, new Date());
+    assert.strictEqual(freshness.entries_without_date_source, 0);
+    assert.ok(published.length > 100, `expected the real log, got ${published.length} entries`);
+  });
+
+  it("counts entries whose date is only a discovery", () => {
+    const freshness = changeLogFreshness(
+      [fixtureChange("vendor_page"), fixtureChange("discovered"), fixtureChange("discovered")] as any,
+      new Date()
+    );
+    assert.strictEqual(freshness.discovered_date_total, 2);
+  });
+});
+
+describe("the rendering helpers", () => {
+  it("prefixes a discovery date and leaves an event date bare", () => {
+    assert.strictEqual(changeDateLabel(fixtureChange("vendor_page") as any), TODAY);
+    assert.strictEqual(changeDateLabel(fixtureChange("hand_written") as any), TODAY);
+    assert.strictEqual(
+      changeDateLabel(fixtureChange("discovered") as any),
+      `${DISCOVERED_DATE_PREFIX} ${TODAY}`
+    );
+  });
+
+  it("omits datePublished from structured data rather than publishing a discovery date", () => {
+    assert.deepStrictEqual(changeDatePublished(fixtureChange("vendor_page") as any), { datePublished: TODAY });
+    assert.deepStrictEqual(changeDatePublished(fixtureChange("discovered") as any), {});
+  });
+
+  it("says in the group heading and note that the effective date is what is missing", () => {
+    assert.match(undatedGroupHeading(1), /1 change\b/);
+    assert.match(undatedGroupHeading(3), /3 changes\b/);
+    assert.match(UNDATED_GROUP_NOTE, /not when they took effect/);
+    assert.match(UNDATED_GROUP_NOTE, /excluded from the monthly groups/);
+  });
+});
+
+function countEntriesFor(html: string, prefix: string, vendor: string): number {
+  const link = new RegExp(`class="${prefix}-vendor">${vendor}</a>`, "g");
+  return (html.match(link) ?? []).length;
+}
+
+function regionFrom(html: string, start: string, end?: string): string {
+  const i = html.indexOf(start);
+  if (i === -1) return "";
+  const j = end ? html.indexOf(end, i + start.length) : -1;
+  return j === -1 ? html.slice(i) : html.slice(i, j);
+}
+
+function last30DaysTile(html: string): number {
+  const m = html.match(/<div class="stat-value">(\d+)<\/div>\s*<div class="stat-label">Last 30 Days<\/div>/);
+  assert.ok(m, "could not find the Last 30 Days tile");
+  return parseInt(m![1], 10);
+}
+
+const CHANGE_SURFACES = [
+  "/",
+  "/changes",
+  "/expiring",
+  "/pricing-changes",
+  "/reports",
+  `/reports/${TODAY.slice(0, 7)}`,
+  `/vendor/${SUBJECT.toLowerCase()}`,
+  "/api/changes",
+  "/api/digest",
+];
+
+describe("no surface renders a discovery date as the date the vendor changed something", () => {
+  let tmp: string;
+  let datedPort = 0;
+  let discoveredPort = 0;
+  let datedProc: ChildProcess;
+  let discoveredProc: ChildProcess;
+
+  function start(changesPath: string): Promise<{ proc: ChildProcess; port: number }> {
+    return new Promise((resolve, reject) => {
+      const child = spawn("node", [path.join(REPO, "dist", "serve.js")], {
+        stdio: ["pipe", "pipe", "pipe"],
+        env: {
+          ...process.env,
+          PORT: "0",
+          BASE_URL: "http://localhost:3000",
+          AGENTDEALS_CHANGES_PATH: changesPath,
+        },
+      });
+      const timeout = setTimeout(() => {
+        child.kill();
+        reject(new Error("Server startup timeout"));
+      }, 30000);
+      child.stderr!.on("data", (data: Buffer) => {
+        const m = data.toString().match(/running on http:\/\/localhost:(\d+)/);
+        if (m) {
+          clearTimeout(timeout);
+          resolve({ proc: child, port: parseInt(m[1], 10) });
+        }
+      });
+      child.on("error", (err) => {
+        clearTimeout(timeout);
+        reject(err);
+      });
+    });
+  }
+
+  before(async () => {
+    tmp = mkdtempSync(path.join(tmpdir(), "date-provenance-"));
+    const datedPath = path.join(tmp, "dated.json");
+    const discoveredPath = path.join(tmp, "discovered.json");
+    writeFileSync(datedPath, JSON.stringify({ changes: [controlChange(), fixtureChange("vendor_page")] }, null, 2));
+    writeFileSync(discoveredPath, JSON.stringify({ changes: [controlChange(), fixtureChange("discovered")] }, null, 2));
+    const dated = await start(datedPath);
+    const discovered = await start(discoveredPath);
+    datedProc = dated.proc;
+    datedPort = dated.port;
+    discoveredProc = discovered.proc;
+    discoveredPort = discovered.port;
+  });
+
+  after(() => {
+    if (datedProc) datedProc.kill();
+    if (discoveredProc) discoveredProc.kill();
+    if (tmp) rmSync(tmp, { recursive: true, force: true });
+  });
+
+  async function bodies(route: string) {
+    const [a, b] = await Promise.all([
+      fetch(`http://localhost:${datedPort}${route}`),
+      fetch(`http://localhost:${discoveredPort}${route}`),
+    ]);
+    return { dated: await a.text(), discovered: await b.text(), status: [a.status, b.status] };
+  }
+
+  it("serves the fixture entry on the surfaces under test", async () => {
+    let mentioning = 0;
+    for (const route of CHANGE_SURFACES) {
+      const { dated } = await bodies(route);
+      if (dated.includes(SUBJECT)) mentioning += 1;
+    }
+    assert.ok(
+      mentioning >= 5,
+      `only ${mentioning} of ${CHANGE_SURFACES.length} surfaces rendered the fixture — the sweep below would prove nothing`
+    );
+  });
+
+  it("renders differently when the same entry carries only a discovery date", async () => {
+    const absorbed: string[] = [];
+    for (const route of CHANGE_SURFACES) {
+      const { dated, discovered } = await bodies(route);
+      if (!dated.includes(SUBJECT)) continue;
+      if (dated === discovered) absorbed.push(route);
+    }
+    assert.deepStrictEqual(
+      absorbed,
+      [],
+      `these surfaces show the entry but render a discovery date identically to an effective date: ${absorbed.join(", ")}`
+    );
+  });
+
+  it("keeps the discovery out of every month group and off the upcoming list", async () => {
+    const renderedBadge = /<div class="(chg|pc)-upcoming-badge">/;
+    for (const route of ["/changes", "/pricing-changes"]) {
+      const { dated, discovered } = await bodies(route);
+      assert.ok(
+        renderedBadge.test(dated),
+        `${route} did not mark the dated control as upcoming, so the check below would pass for the wrong reason`
+      );
+      assert.ok(discovered.includes(undatedGroupHeading(1)), `${route} has no undated group`);
+      assert.ok(!renderedBadge.test(discovered), `${route} marked a discovery as upcoming`);
+    }
+  });
+
+  it("never puts the discovery inside a calendar month", async () => {
+    for (const [route, prefix] of [["/changes", "chg"], ["/pricing-changes", "pc"]] as const) {
+      const { dated, discovered } = await bodies(route);
+      const monthsOf = (html: string) => regionFrom(html, '<div class="month-group">');
+      assert.ok(
+        countEntriesFor(monthsOf(discovered), prefix, CONTROL) >= 1,
+        `${route} rendered no dated entry in a month group, so the absence below proves nothing`
+      );
+      assert.strictEqual(
+        countEntriesFor(monthsOf(dated), prefix, SUBJECT) >= 1,
+        true,
+        `${route} should put the dated control in a month group`
+      );
+      assert.strictEqual(
+        countEntriesFor(monthsOf(discovered), prefix, SUBJECT),
+        0,
+        `${route} put a change with no known effective date into a calendar month`
+      );
+    }
+  });
+
+  it("never lists the discovery among changes that recently took effect", async () => {
+    const { dated, discovered } = await bodies("/expiring");
+    const recentOf = (html: string) =>
+      regionFrom(html, "<h2>Recently Changed</h2>", "<h2>Recently Discovered</h2>");
+    assert.ok(
+      countEntriesFor(recentOf(dated), "exp", CONTROL) >= 1,
+      "/expiring listed nothing under Recently Changed, so the absence below proves nothing"
+    );
+    assert.strictEqual(
+      countEntriesFor(recentOf(discovered), "exp", SUBJECT),
+      0,
+      "/expiring listed a change with no known effective date as having recently changed"
+    );
+    assert.ok(
+      discovered.includes("<h2>Recently Discovered</h2>"),
+      "/expiring dropped the discovery instead of listing it separately"
+    );
+  });
+
+  it("leaves the Last 30 Days tile counting only changes that took effect in the window", async () => {
+    const { dated, discovered } = await bodies("/changes");
+    assert.strictEqual(last30DaysTile(dated), 2, "both fixture changes fall inside the window when both are dated");
+    assert.strictEqual(
+      last30DaysTile(discovered),
+      1,
+      "a change with no known effective date was counted as having taken effect in the last 30 days"
+    );
+  });
+
+  it("says on the page how many entries it could not date", async () => {
+    const { dated, discovered } = await bodies("/changes");
+    assert.ok(!dated.includes("Effective Date Unknown"), "the dated control should show no such tile");
+    assert.ok(discovered.includes("Effective Date Unknown"), "/changes hid the undateable count");
+    assert.ok(discovered.includes(UNDATED_GROUP_NOTE), "/changes dropped the note explaining the group");
+  });
+
+  it("keeps the discovery out of the monthly report it would otherwise land in", async () => {
+    const { dated, discovered } = await bodies(`/reports/${TODAY.slice(0, 7)}`);
+    assert.ok(dated.includes(SUBJECT), "the dated control should appear in this month's report");
+    assert.ok(discovered.includes(CONTROL), "the report did not render at all, so the absence below proves nothing");
+    assert.ok(!discovered.includes(SUBJECT), "a change with no known effective date was counted in a monthly report");
+  });
+
+  it("does not publish a discovery date as datePublished in structured data", async () => {
+    for (const route of ["/", "/changes", "/expiring"]) {
+      const { discovered } = await bodies(route);
+      for (const block of discovered.matchAll(/<script type="application\/ld\+json">([\s\S]*?)<\/script>/g)) {
+        const json = JSON.parse(block[1]);
+        const items = JSON.stringify(json);
+        if (!items.includes(SUBJECT)) continue;
+        assert.ok(
+          !new RegExp(`"datePublished":"${TODAY}"`).test(items),
+          `${route} published a discovery date as datePublished`
+        );
+      }
+    }
+  });
+
+  it("hands agents the provenance alongside the date", async () => {
+    const res = await fetch(`http://localhost:${discoveredPort}/api/changes`);
+    const body = (await res.json()) as any;
+    const entry = body.changes.find((c: any) => c.vendor === SUBJECT);
+    assert.ok(entry, "the API dropped the entry");
+    assert.strictEqual(entry.date_source, "discovered");
+  });
+
+  it("counts the discovery separately from changes that took effect in the window", async () => {
+    const datedRes = await (await fetch(`http://localhost:${datedPort}/api/changes`)).json() as any;
+    const discoveredRes = await (await fetch(`http://localhost:${discoveredPort}/api/changes`)).json() as any;
+    assert.strictEqual(datedRes.change_log_freshness.discovered_date_total, 0);
+    assert.strictEqual(discoveredRes.change_log_freshness.discovered_date_total, 1);
+  });
+
+  it("does not turn a discovery into a deadline in the agent digest", async () => {
+    const body = (await (await fetch(`http://localhost:${discoveredPort}/api/digest`)).json()) as any;
+    const deadlines = body.upcoming_deadlines ?? [];
+    assert.ok(
+      !deadlines.some((d: any) => d.vendor === SUBJECT),
+      "a change with no known effective date was published as an upcoming deadline"
+    );
+  });
+});

--- a/test/change-log-writer.test.ts
+++ b/test/change-log-writer.test.ts
@@ -19,7 +19,7 @@ const {
 
 const { runUrlMode, runAiMode, summaryLines, repickWindowDays } = await import("../scripts/reverify-rolling.js");
 const { firstSeenDates } = await import("../scripts/backfill-change-recorded-dates.js");
-const { report, DEFAULT_THRESHOLD_DAYS } = await import("../scripts/check-change-log-staleness.js");
+const { report, DEFAULT_THRESHOLD_DAYS, detectorSchedule, WORKFLOW_PATH } = await import("../scripts/check-change-log-staleness.js");
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const REPO = path.join(__dirname, "..");
@@ -381,10 +381,29 @@ describe("change log writer", () => {
 
 describe("change log freshness", () => {
   const changes = [
-    { vendor: "A", change_type: "restriction", date: "2026-01-01", recorded_date: "2026-08-01" },
-    { vendor: "B", change_type: "restriction", date: "2026-02-01", recorded_date: "2026-08-20", detected_by: DETECTED_BY_AI },
-    { vendor: "C", change_type: "restriction", date: "2026-03-01", recorded_date: "2026-06-01" },
+    { vendor: "A", change_type: "restriction", date: "2026-01-01", recorded_date: "2026-08-01", date_source: "hand_written" },
+    { vendor: "B", change_type: "restriction", date: "2026-02-01", recorded_date: "2026-08-20", detected_by: DETECTED_BY_AI, date_source: "vendor_page" },
+    { vendor: "C", change_type: "restriction", date: "2026-03-01", recorded_date: "2026-06-01", date_source: "discovered" },
   ];
+
+  it("carries every provenance the field can hold, so agreement is not agreement on an empty field", () => {
+    assert.deepStrictEqual(
+      [...new Set(changes.map((c) => c.date_source))].sort(),
+      ["discovered", "hand_written", "vendor_page"]
+    );
+  });
+
+  it("counts an entry whose date is only a discovery", () => {
+    const freshness = changeLogFreshness(changes, NOW);
+    assert.strictEqual(freshness.discovered_date_total, 1);
+    assert.strictEqual(freshness.entries_without_date_source, 0);
+  });
+
+  it("treats an entry with no provenance as one whose date it cannot vouch for", () => {
+    const freshness = changeLogFreshness([{ vendor: "A", change_type: "restriction", date: "2026-01-01" }], NOW);
+    assert.strictEqual(freshness.discovered_date_total, 1);
+    assert.strictEqual(freshness.entries_without_date_source, 1);
+  });
 
   it("counts days since anything was added, not days since the newest change date", () => {
     const freshness = changeLogFreshness(changes, NOW);
@@ -417,39 +436,125 @@ describe("change log freshness", () => {
 });
 
 describe("the staleness alarm", () => {
-  const freshnessAt = (days: number) => ({
+  const freshnessAt = (detectedDaysAgo: number | null, recordedDaysAgo = 1) => ({
     total: 289,
     last_recorded_date: "2026-08-01",
-    days_since_last_recorded: days,
-    last_detected_date: null,
-    days_since_last_detected: null,
+    days_since_last_recorded: recordedDaysAgo,
+    last_detected_date: detectedDaysAgo === null ? null : "2026-08-01",
+    days_since_last_detected: detectedDaysAgo,
     recorded_last_30_days: 1,
-    machine_detected_total: 0,
+    machine_detected_total: detectedDaysAgo === null ? 0 : 1,
     entries_without_recorded_date: 0,
+    discovered_date_total: 0,
+    entries_without_date_source: 0,
   });
 
-  it("stays quiet inside the threshold", () => {
-    assert.strictEqual(report(freshnessAt(DEFAULT_THRESHOLD_DAYS), DEFAULT_THRESHOLD_DAYS).stale, false);
+  const SCHEDULED = { known: true, scheduled: true, reason: null };
+  const NOT_SCHEDULED = { known: true, scheduled: false, reason: null };
+
+  it("stays quiet inside the threshold once the detector is scheduled", () => {
+    const r = report(freshnessAt(DEFAULT_THRESHOLD_DAYS), DEFAULT_THRESHOLD_DAYS, SCHEDULED);
+    assert.strictEqual(r.failJob, false);
   });
 
-  it("fires one day past the threshold", () => {
-    assert.strictEqual(report(freshnessAt(DEFAULT_THRESHOLD_DAYS + 1), DEFAULT_THRESHOLD_DAYS).stale, true);
+  it("fires one day past the threshold once the detector is scheduled", () => {
+    const r = report(freshnessAt(DEFAULT_THRESHOLD_DAYS + 1), DEFAULT_THRESHOLD_DAYS, SCHEDULED);
+    assert.strictEqual(r.failJob, true);
   });
 
   it("would have fired long before the gap the log actually had", () => {
     assert.ok(DEFAULT_THRESHOLD_DAYS < 127);
-    assert.strictEqual(report(freshnessAt(127), DEFAULT_THRESHOLD_DAYS).stale, true);
+    assert.strictEqual(report(freshnessAt(127), DEFAULT_THRESHOLD_DAYS, SCHEDULED).failJob, true);
   });
 
-  it("fires when the age cannot be measured at all", () => {
-    const unmeasurable = { ...freshnessAt(0), last_recorded_date: null, days_since_last_recorded: null };
-    assert.strictEqual(report(unmeasurable, DEFAULT_THRESHOLD_DAYS).stale, true);
+  it("fires when a scheduled detector has never recorded anything", () => {
+    assert.strictEqual(report(freshnessAt(null), DEFAULT_THRESHOLD_DAYS, SCHEDULED).failJob, true);
   });
 
-  it("says the daily job cannot clear the alarm on its own", () => {
-    const { text } = report(freshnessAt(30), DEFAULT_THRESHOLD_DAYS);
-    assert.match(text, /URL mode, which cannot detect a change/);
+  it("cannot be silenced by a hand-written entry", () => {
+    const handWrittenToday = freshnessAt(127, 0);
+    const r = report(handWrittenToday, DEFAULT_THRESHOLD_DAYS, SCHEDULED);
+    assert.strictEqual(r.failJob, true, "a fresh recorded_date must not clear a stale detector");
+    assert.match(r.text, /hand-written entry does not clear this/);
   });
+
+  it("does not fail the daily run while no detector is scheduled", () => {
+    const r = report(freshnessAt(null, 127), DEFAULT_THRESHOLD_DAYS, NOT_SCHEDULED);
+    assert.strictEqual(r.failJob, false, "a day counter cannot measure a detector that is off");
+    assert.strictEqual(r.openAbsenceIssue, true);
+  });
+
+  it("signals the absence exactly once rather than every day", () => {
+    const scheduled = report(freshnessAt(1), DEFAULT_THRESHOLD_DAYS, SCHEDULED);
+    assert.strictEqual(scheduled.openAbsenceIssue, false);
+  });
+
+  it("refuses to pick an alarm when it cannot read the schedule", () => {
+    const undecidable = { known: false, scheduled: false, reason: "no invocation found" };
+    const r = report(freshnessAt(1), DEFAULT_THRESHOLD_DAYS, undecidable);
+    assert.strictEqual(r.undecidable, true);
+    assert.strictEqual(r.failJob, false);
+    assert.strictEqual(r.openAbsenceIssue, false);
+    assert.match(r.text, /Refusing to guess/);
+  });
+});
+
+describe("reading the detector's schedule out of the workflow", () => {
+  const withCommand = (cmd: string) => `jobs:\n  reverify:\n    steps:\n      - run: |\n          ${cmd}\n`;
+
+  it("reads the shipped workflow rather than a flag someone must remember to set", () => {
+    const yaml = readFileSync(WORKFLOW_PATH, "utf-8");
+    const schedule = detectorSchedule(yaml);
+    assert.strictEqual(schedule.known, true);
+    assert.strictEqual(schedule.scheduled, false, "the shipped workflow does not pass --ai yet");
+  });
+
+  it("sees a scheduled detector when the invocation passes --ai", () => {
+    const schedule = detectorSchedule(withCommand('node scripts/reverify-rolling.js --ai --limit "$LIMIT"'));
+    assert.deepStrictEqual({ known: schedule.known, scheduled: schedule.scheduled }, { known: true, scheduled: true });
+  });
+
+  it("does not mistake a longer flag for --ai", () => {
+    const schedule = detectorSchedule(withCommand('node scripts/reverify-rolling.js --ai-dry-run --limit "5"'));
+    assert.strictEqual(schedule.scheduled, false);
+  });
+
+  it("refuses when it cannot find the invocation at all", () => {
+    assert.strictEqual(detectorSchedule("jobs:\n  reverify:\n    steps: []\n").known, false);
+  });
+
+  it("refuses when only some invocations pass --ai", () => {
+    const yaml =
+      withCommand('node scripts/reverify-rolling.js --limit "5"') +
+      withCommand('node scripts/reverify-rolling.js --ai --limit "5"');
+    const schedule = detectorSchedule(yaml);
+    assert.strictEqual(schedule.known, false);
+    assert.match(schedule.reason, /1 of 2/);
+  });
+
+  it("changes meaning at the same commit that changes the behaviour", () => {
+    const off = readFileSync(WORKFLOW_PATH, "utf-8");
+    const on = off.replace("reverify-rolling.js --limit", "reverify-rolling.js --ai --limit");
+    assert.notStrictEqual(on, off, "expected the shipped invocation to be rewritable");
+    const stale = freshnessNeverDetected();
+    assert.strictEqual(report(stale, DEFAULT_THRESHOLD_DAYS, detectorSchedule(off)).failJob, false);
+    assert.strictEqual(report(stale, DEFAULT_THRESHOLD_DAYS, detectorSchedule(on)).failJob, true);
+  });
+
+  function freshnessNeverDetected() {
+    return {
+      total: 289,
+      last_recorded_date: "2026-08-01",
+      days_since_last_recorded: 1,
+      last_detected_date: null,
+      days_since_last_detected: null,
+      recorded_last_30_days: 1,
+      machine_detected_total: 0,
+      entries_without_recorded_date: 0,
+      discovered_date_total: 0,
+      entries_without_date_source: 0,
+    };
+  }
 });
 
 describe("recovering when each entry was first written", () => {


### PR DESCRIPTION
Refs #1074 — AC10, and the alarm ruling from your comment of 06:04Z. Both were the "ships now" half; Phase 2 is untouched and still blocked.

## AC10 — the shape, and why not a null date

You offered `date_source` or a null `date`. I took `date_source`, because nulling `date` fails in two different ways across ~100 read sites: `c.date.slice(0, 7)` throws, which is loud and recoverable, but `c.date >= cutoff` silently evaluates false, which is neither. A mixed loud/silent failure across that many call sites is worse than either alone.

Three values, and **every entry carries one** — the field is never absent, so the rendering rule is total with no default:

- `vendor_page` — the reading found a stated effective date on the vendor's page.
- `discovered` — the page stated none, so `date` is the day we read it.
- `hand_written` — recorded by a person before this field existed.

The 289 existing entries are backfilled `hand_written`, and that is **provable rather than assumed**: none of them carries `detected_by`, so none was machine-written. `scripts/backfill-change-date-sources.js` asserts that precondition and **exits 2 rather than run** if any machine-written entry lacks a provenance, because only the writer knows where its date came from. The data diff is the new field and nothing else — I parsed both files and compared with `date_source` stripped: **0 differences across 289 entries.**

I did not label the legacy entries `vendor_page`. Their dates are real event dates — the AWS Free Tier restructure on 2025-07-16 is not a discovery date — but nobody recorded where they came from, and claiming otherwise would be the same guess this issue exists to stop.

## The direction of the default

`isEventDated` returns true only for an explicit allowlist. An absent or unrecognised `date_source` renders as *discovered*, which under-claims. The other direction publishes a false date, which is the failure AC10 exists to prevent. `validate-data` now requires the field and rejects an unknown value, so the data file cannot drift into the ambiguous state in the first place.

## What changed on the surfaces

A discovery is always stamped with the run date, so it lands in exactly the counts you named — and in two more I found while sweeping:

- **`/changes`, `/pricing-changes`** — excluded from the monthly groups and from **Last 30 Days**; rendered once in an "Effective date unknown (N changes)" group with a note saying what is missing and that they are not in the counts above. A new **Effective Date Unknown** tile carries the number, so nothing vanishes.
- **`/expiring`** — `date >= today` is **true on the day of the sweep**, so every discovery would have rendered with an "upcoming" badge and a countdown. They are now off the upcoming list and off Recently Changed, in a **Recently Discovered** section instead.
- **`/reports`** — a discovery no longer opens a calendar month, and is not counted inside a monthly report.
- **JSON-LD** — `datePublished` is **omitted**, not filled with the discovery date. This is the surface AI search engines actually read, and it was the highest-stakes version of the bug.
- **The weekly digest** — a discovery is no longer published to agents as an upcoming **deadline**. `/api/changes` and the MCP concise payload now carry `date_source` alongside `date`.

**One judgement I made rather than a gap:** the weekly digest's this-week *window* still includes discoveries. A change discovered this week is genuinely news this week even if it is not a change this week, and dropping it would silence the digest on exactly the discoveries agents subscribe for. The payload carries `date_source`, so nothing is hidden. Say the word if you want it excluded.

## The alarm — your ruling, and the one call inside it

`check-change-log-staleness.js` reads whether the shipped workflow passes `--ai`, exactly as you specified — no config flag, so the alarm changes meaning at the same commit that changes the behaviour.

- **Not scheduled (today):** does not fail the run. Emits `open_absence_issue=true`, and the workflow opens **one** issue titled for the absence, guarded by a marker search so it cannot open a second while one is open. It only ever creates; it never closes.
- **Scheduled:** gates `days_since_last_detected` at 14 and fails the job. A fresh `recorded_date` does not clear it — there is a test that asserts a hand-written entry today with a 127-day-stale detector still fails.
- **Undecidable:** if the invocation is missing, or only some invocations pass `--ai`, it exits 2 and refuses to pick an alarm rather than guessing.

**The call:** a scheduled detector that has *never* recorded anything is treated as stale, so the gate goes red from the detector's first scheduled run until its first detection. The alternative — null means healthy — makes a detector that is on but broken invisible, which is the "reads clean because nothing is checked" shape this whole issue is about. The cost is a false alarm for a few days at a moment when someone is watching. The proper fix is a detector-ran marker so "ran and found nothing" is distinguishable from "never ran"; that belongs with Phase 2 and I have said so in the failure message itself rather than leaving it to be discovered.

`days_since_last_recorded` is unchanged and still published. It is the right public freshness number; it just is not the gate.

## Mutation pass: 44, all killed, after two rounds

Four survived round one and **all four were real gaps in the tests, not in the code**:

1. **The script-side predicate could admit a discovery as an event date and nothing failed.** The script/server parity fixture carried no `date_source` at all, so both sides agreed for the wrong reason — this issue's own shape, and the same trap that produced two survivors last cycle. The fixture now carries all three values and asserts it does.
2. **`/changes` could group a discovery into a calendar month** and my sweep still passed, because "the two renders differ" is weaker than "makes no false claim" — the mutated page rendered the entry in a month group *and* the undated group, so it still differed from the control.
3. **`/changes` could count a discovery in Last 30 Days** — nothing asserted the tile's value.
4. **`/expiring` could list a discovery as recently changed** — same shape as (2).

The fix needed a **second fixture entry that is always dated**, because with one undated entry the dated regions are empty and "absent from the month groups" passes trivially. Every new assertion now has a positive control, and I mutated the controls themselves to prove they cannot pass for the wrong reason.

## Verified

- **1866 tests / 0 failures**, exit code captured directly, suite run twice. 39 new.
- **44 mutations, 0 survivors** after round two (`scripts/mutate-1074-ac10.sh`, `-round2.sh`, both committed and re-runnable). Two stale patterns in `mutate-1074.sh` repaired so the previous PR's guarantees still hold.
- **Rendered 17 routes against a `main` worktree and diffed.** On today's data the only HTML differences are three new CSS rules and blank lines from the empty undated group — **no content changed anywhere**, which is what a pre-sweep guard should look like. The only API difference is the new field on entries plus `discovered_date_total` and `entries_without_date_source`.
- **Both alarm branches run for real**, including `GITHUB_OUTPUT` emission: detector off → exit 0, `open_absence_issue=true`; detector on → exit 1, `open_absence_issue=false`.
- **Real MCP `initialize` → `tools/call`** against a server holding three discoveries: every entry in the concise payload carries `date_source`.
- **shot-scraper on `/changes` and `/expiring`** against that fixture — this is what the page looks like after a sweep, and it is the reason I caught the "upcoming" badge.
- `tsc` clean, `validate-data` clean at 1,580 offers / 289 changes, **0 new code comments**, workflow YAML parses with both new steps wired correctly.