### PR TITLE
Refuse to answer an unreadable schedule, and label every discovery date

### DIFF
--- a/scripts/check-change-log-staleness.js
+++ b/scripts/check-change-log-staleness.js
@@ -13,19 +13,108 @@ export const WORKFLOW_PATH =
   process.env.AGENTDEALS_REVERIFY_WORKFLOW_PATH ||
   resolve(__dirname, "..", ".github", "workflows", "reverify.yml");
 
-const INVOCATION = /node\s+scripts\/reverify-rolling\.js[^\n]*/g;
+const INVOCATION = /node\s+scripts\/reverify-rolling\.js([^\n]*)/g;
+
+const COMMAND_SEPARATORS = new Set(["|", ";", "&", ">", "<"]);
+
+export const AI_FLAG = "--ai";
+
+export const DETECTOR_CLI_OPTIONS = {
+  takesValue: ["--limit"],
+  boolean: ["--ai", "--dry-run"],
+};
+
+export function tokenizeArgs(argText) {
+  const tokens = [];
+  let current = null;
+  const flush = () => {
+    if (current) tokens.push(current);
+    current = null;
+  };
+  const add = (text, expands = false) => {
+    if (!current) current = { text: "", expands: false };
+    current.text += text;
+    if (expands) current.expands = true;
+  };
+
+  let i = 0;
+  while (i < argText.length) {
+    const ch = argText[i];
+    if (/\s/.test(ch)) {
+      flush();
+      i += 1;
+    } else if (COMMAND_SEPARATORS.has(ch)) {
+      flush();
+      return tokens;
+    } else if (argText.startsWith("${{", i)) {
+      const end = argText.indexOf("}}", i + 3);
+      const raw = end === -1 ? argText.slice(i) : argText.slice(i, end + 2);
+      add(raw, true);
+      i += raw.length;
+    } else if (ch === "'") {
+      const end = argText.indexOf("'", i + 1);
+      const raw = end === -1 ? argText.slice(i) : argText.slice(i, end + 1);
+      add(raw);
+      i += raw.length;
+    } else if (ch === '"') {
+      let j = i + 1;
+      let raw = '"';
+      let expands = false;
+      while (j < argText.length && argText[j] !== '"') {
+        if (argText[j] === "$") expands = true;
+        raw += argText[j];
+        j += 1;
+      }
+      if (j < argText.length) raw += '"';
+      add(raw, expands);
+      i = j + 1;
+    } else if (ch === "$") {
+      add(ch, true);
+      i += 1;
+    } else {
+      add(ch);
+      i += 1;
+    }
+  }
+  flush();
+  return tokens;
+}
+
+export function flagTokens(argText) {
+  const flags = [];
+  let consumingValue = false;
+  for (const token of tokenizeArgs(argText)) {
+    if (consumingValue) {
+      consumingValue = false;
+      continue;
+    }
+    if (DETECTOR_CLI_OPTIONS.takesValue.includes(token.text)) consumingValue = true;
+    flags.push(token);
+  }
+  return flags;
+}
 
 export function detectorSchedule(workflowYaml) {
-  const invocations = workflowYaml.match(INVOCATION) ?? [];
+  const invocations = [...workflowYaml.matchAll(INVOCATION)].map((m) => flagTokens(m[1]));
   if (invocations.length === 0) {
     return { known: false, scheduled: false, reason: "no reverify-rolling.js invocation found" };
   }
-  const withAi = invocations.filter((line) => /(^|\s)--ai(\s|$)/.test(line));
+  const unresolved = invocations.flat().filter((token) => token.expands);
+  if (unresolved.length > 0) {
+    return {
+      known: false,
+      scheduled: false,
+      reason: `an argument that could be the ${AI_FLAG} flag is not a literal: ${unresolved
+        .map((token) => token.text)
+        .join(", ")}`,
+    };
+  }
+  const withAi = invocations.filter((tokens) => tokens.some((token) => token.text === AI_FLAG));
   if (withAi.length > 0 && withAi.length < invocations.length) {
     return {
       known: false,
       scheduled: false,
-      reason: `${withAi.length} of ${invocations.length} invocations pass --ai`,
+      reason: `${withAi.length} of ${invocations.length} invocations pass ${AI_FLAG}`,
     };
   }
   return { known: true, scheduled: withAi.length > 0, reason: null };

--- a/scripts/mutate-1074-ac11-ac12.sh
+++ b/scripts/mutate-1074-ac11-ac12.sh
@@ -1,0 +1,122 @@
+#!/usr/bin/env bash
+set -uo pipefail
+cd "$(dirname "$0")/.."
+
+PASS=0
+FAIL=0
+
+run_mutation() {
+  local name="$1" file="$2" from="$3" to="$4" tests="$5"
+  cp "$file" "$file.bak"
+  if ! python3 - "$file" "$from" "$to" <<'PY'
+import sys, pathlib
+path, old, new = sys.argv[1], sys.argv[2], sys.argv[3]
+p = pathlib.Path(path)
+s = p.read_text()
+if s.count(old) != 1:
+    print(f"SKIP: pattern found {s.count(old)} times", file=sys.stderr)
+    sys.exit(3)
+p.write_text(s.replace(old, new))
+PY
+  then
+    echo "SKIP  $name (pattern stale)"
+    mv "$file.bak" "$file"
+    FAIL=$((FAIL + 1))
+    return
+  fi
+
+  npm run build > /tmp/mut-build.log 2>&1
+  if [ $? -ne 0 ]; then
+    echo "SKIP  $name (build failed)"
+    mv "$file.bak" "$file"
+    npm run build > /dev/null 2>&1
+    FAIL=$((FAIL + 1))
+    return
+  fi
+
+  node --test $tests > /tmp/mut-test.log 2>&1
+  local status=$?
+  mv "$file.bak" "$file"
+  npm run build > /dev/null 2>&1
+
+  if [ $status -ne 0 ]; then
+    echo "KILLED  $name"
+    PASS=$((PASS + 1))
+  else
+    echo "SURVIVED  $name  <-- $tests did not notice"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+SWEEP="test/discovery-date-surfaces.test.ts"
+STRUCT="test/change-structured-data.test.ts"
+PROV="test/change-date-provenance.test.ts"
+WRITER="test/change-log-writer.test.ts"
+
+run_mutation "risk cause chip renders a bare date" src/serve.ts \
+  'return `${changeDateLabel(cause)} ${changeTypeBadge' \
+  'return `${cause.date} ${changeTypeBadge' "$SWEEP"
+
+run_mutation "structured Event fabricates a start date" src/serve.ts \
+  '    ...changeEventStartDate(c),' '    startDate: c.date,' "$SWEEP"
+
+run_mutation "risk cause prose says the change happened on that day" src/serve.ts \
+  "requires caution because of one specific recorded change\${riskCause ? \`, \${changeDateClause(riskCause)}" \
+  "requires caution because of one specific recorded change\${riskCause ? \`, on \${riskCause.date}" "$SWEEP"
+
+run_mutation "offer metadata dates itself from a discovery" src/serve.ts \
+  '  const lastPricingChange = latestEventDate(vendorChanges);' \
+  '  const lastPricingChange = vendorChanges.length > 0 ? vendorChanges[0].date : null;' "$SWEEP"
+
+run_mutation "the report headline dates itself from a discovery" src/serve.ts \
+  '  const latest = latestEventDate(changes, utcToday());' \
+  '  const latest = changes.length > 0 ? changes.map((c) => c.date).sort().reverse()[0] : null;' "$SWEEP"
+
+run_mutation "changes list drops entries with no effective date" src/serve.ts \
+  '    itemListElement: newestFirst.slice(0, 50).map((c, i) => ({' \
+  '    itemListElement: sorted.slice(0, 50).map((c, i) => ({' "$STRUCT"
+
+run_mutation "changes list appends discoveries after the cap" src/serve.ts \
+  '  const newestFirst = [...allChanges].sort((a, b) => b.date.localeCompare(a.date));' \
+  '  const newestFirst = [...eventDated, ...undatedChanges];' "$STRUCT"
+
+run_mutation "expiring list drops entries with no effective date" src/serve.ts \
+  '    itemListElement: [...upcoming, ...recentlyDiscovered].slice(0, 50).map((c, i) => ({' \
+  '    itemListElement: upcoming.slice(0, 50).map((c, i) => ({' "$STRUCT"
+
+run_mutation "expiring total omits what it could not date" src/serve.ts \
+  '    numberOfItems: totalUpcoming + recent.length + recentlyDiscovered.length,' \
+  '    numberOfItems: totalUpcoming + recent.length,' "$STRUCT"
+
+run_mutation "structured data publishes a discovery date" src/change-dates.ts \
+  'export function changeDatePublished(c: DatedChange): { datePublished: string } | Record<string, never> {
+  return isEventDated(c) ? { datePublished: c.date } : {};
+}' \
+  'export function changeDatePublished(c: DatedChange): { datePublished: string } | Record<string, never> {
+  return { datePublished: c.date };
+}' "$STRUCT $PROV"
+
+run_mutation "the schedule reader answers on an unexpanded argument" scripts/check-change-log-staleness.js \
+  '  const unresolved = invocations.flat().filter((token) => token.expands);' \
+  '  const unresolved = [];' "$WRITER"
+
+run_mutation "an option value is treated as a possible flag" scripts/check-change-log-staleness.js \
+  '    if (DETECTOR_CLI_OPTIONS.takesValue.includes(token.text)) consumingValue = true;' \
+  '    if (false) consumingValue = true;' "$WRITER"
+
+run_mutation "the reader stops honouring quotes around an expansion" scripts/check-change-log-staleness.js \
+  '        if (argText[j] === "$") expands = true;' \
+  '        if (false) expands = true;' "$WRITER"
+
+run_mutation "a declared exemption stops being checked for use" test/discovery-date-surfaces.test.ts \
+  '    name: "a page or dataset modification date",
+    allows: (before) => /"dateModified":"$/.test(before),' \
+  '    name: "a page or dataset modification date",
+    allows: (before) => /"neverEmittedAnywhere":"$/.test(before),' "$SWEEP"
+
+run_mutation "the risk cause is projected without its provenance" src/data.ts \
+  '      ? { date: assessment.cause.date, date_source: assessment.cause.date_source, change_type: assessment.cause.change_type, summary: assessment.cause.summary }' \
+  '      ? { date: assessment.cause.date, change_type: assessment.cause.change_type, summary: assessment.cause.summary }' "$SWEEP"
+
+echo
+echo "killed: $PASS   survived-or-skipped: $FAIL"

--- a/src/change-dates.ts
+++ b/src/change-dates.ts
@@ -1,9 +1,25 @@
-import { isEventDated } from "./data.js";
-import type { DealChange } from "./types.js";
+import type { DealChange, ChangeDateSource } from "./types.js";
 
 type DatedChange = Pick<DealChange, "date" | "date_source">;
 
 export const DISCOVERED_DATE_PREFIX = "discovered";
+
+export const DATE_SOURCES: ChangeDateSource[] = ["vendor_page", "hand_written", "discovered"];
+
+export const EVENT_DATED_SOURCES: ChangeDateSource[] = ["vendor_page", "hand_written"];
+
+export function isEventDated(change: Pick<DealChange, "date_source">): boolean {
+  return EVENT_DATED_SOURCES.includes(change.date_source as ChangeDateSource);
+}
+
+export function partitionByDateProvenance<T extends Pick<DealChange, "date_source">>(
+  changes: T[]
+): { dated: T[]; discovered: T[] } {
+  const dated: T[] = [];
+  const discovered: T[] = [];
+  for (const change of changes) (isEventDated(change) ? dated : discovered).push(change);
+  return { dated, discovered };
+}
 
 export const UNDATED_GROUP_NOTE =
   "The vendor’s page states these terms but not when they took effect, so we can only tell you when we found them. They are listed by discovery date and are excluded from the monthly groups and the Last 30 Days count above, both of which count changes by the date they took effect.";
@@ -16,6 +32,24 @@ export function changeDateLabel(c: DatedChange): string {
   return isEventDated(c) ? c.date : `${DISCOVERED_DATE_PREFIX} ${c.date}`;
 }
 
+export function changeDateClause(c: DatedChange): string {
+  return isEventDated(c) ? `on ${c.date}` : `${DISCOVERED_DATE_PREFIX} ${c.date}`;
+}
+
 export function changeDatePublished(c: DatedChange): { datePublished: string } | Record<string, never> {
   return isEventDated(c) ? { datePublished: c.date } : {};
+}
+
+export function changeEventStartDate(c: DatedChange): { startDate: string } | Record<string, never> {
+  return isEventDated(c) ? { startDate: c.date } : {};
+}
+
+export function latestEventDate(changes: DatedChange[], notAfter?: string): string | null {
+  let latest: string | null = null;
+  for (const c of changes) {
+    if (!c.date || !isEventDated(c)) continue;
+    if (notAfter && c.date > notAfter) continue;
+    if (latest === null || c.date > latest) latest = c.date;
+  }
+  return latest;
 }

--- a/src/data.ts
+++ b/src/data.ts
@@ -6,6 +6,7 @@ import { isUrlSuspended } from "./referral-health.js";
 import { rankForListing } from "./ranking.js";
 import { unreachableNoticeForUrl, resetLinkHealthCache } from "./link-health.js";
 import { filterAlternatives } from "./product-role.js";
+import { DATE_SOURCES, isEventDated, changeDateClause } from "./change-dates.js";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const INDEX_PATH = path.join(__dirname, "..", "data", "index.json");
@@ -369,7 +370,7 @@ export function enrichOffers(offers: Offer[]): EnrichedOffer[] {
     const link_unreachable = unreachableNoticeForUrl(offer.url, now.getTime());
     const risk_level = link_unreachable && assessment.level === "stable" ? null : assessment.level;
     const risk_cause = assessment.cause
-      ? { date: assessment.cause.date, change_type: assessment.cause.change_type, summary: assessment.cause.summary }
+      ? { date: assessment.cause.date, date_source: assessment.cause.date_source, change_type: assessment.cause.change_type, summary: assessment.cause.summary }
       : null;
 
     // stability: derived from change types, not just count
@@ -434,22 +435,8 @@ export function loadDealChanges(): DealChange[] {
   return cachedChanges;
 }
 
-export const DATE_SOURCES: ChangeDateSource[] = ["vendor_page", "hand_written", "discovered"];
-
-export const EVENT_DATED_SOURCES: ChangeDateSource[] = ["vendor_page", "hand_written"];
-
-export function isEventDated(change: Pick<DealChange, "date_source">): boolean {
-  return EVENT_DATED_SOURCES.includes(change.date_source as ChangeDateSource);
-}
-
-export function partitionByDateProvenance<T extends Pick<DealChange, "date_source">>(
-  changes: T[]
-): { dated: T[]; discovered: T[] } {
-  const dated: T[] = [];
-  const discovered: T[] = [];
-  for (const change of changes) (isEventDated(change) ? dated : discovered).push(change);
-  return { dated, discovered };
-}
+export { EVENT_DATED_SOURCES, partitionByDateProvenance } from "./change-dates.js";
+export { DATE_SOURCES, isEventDated };
 
 export interface ChangeLogFreshness {
   total: number;
@@ -769,7 +756,7 @@ export function checkVendorRisk(
       const unreachable = unreachableNoticeForUrl(e.offer.url);
       return {
         risk_level: unreachable && a.level === "stable" ? null : a.level,
-        risk_cause: a.cause ? { date: a.cause.date, change_type: a.cause.change_type, summary: a.cause.summary } : null,
+        risk_cause: a.cause ? { date: a.cause.date, date_source: a.cause.date_source, change_type: a.cause.change_type, summary: a.cause.summary } : null,
         link_unreachable: unreachable,
       };
     })(),
@@ -785,9 +772,9 @@ export function checkVendorRisk(
     ? ` Its pricing page has not resolved for us${linkUnreachable.last_reachable ? ` since ${linkUnreachable.last_reachable}` : ""}, so we cannot confirm its current terms.`
     : "";
   if (riskLevel === "risky" && cause) {
-    summary = `${offer.vendor} is high risk — ${cause.date}: ${cause.summary} Consider alternatives.${unreachableClause}`;
+    summary = `${offer.vendor} is high risk — ${changeDateClause(cause)}: ${cause.summary} Consider alternatives.${unreachableClause}`;
   } else if (riskLevel === "caution" && cause) {
-    summary = `${offer.vendor} warrants caution — ${cause.date}: ${cause.summary} Monitor for further changes.${unreachableClause}`;
+    summary = `${offer.vendor} warrants caution — ${changeDateClause(cause)}: ${cause.summary} Monitor for further changes.${unreachableClause}`;
   } else if (linkUnreachable) {
     summary = `We hold no free tier removal, limit reduction or pricing restructure on record for ${offer.vendor}.${unreachableClause} Treat that as a statement about our records, not as a stable pricing history.`;
   } else {
@@ -799,7 +786,7 @@ export function checkVendorRisk(
       vendor: offer.vendor,
       category: offer.category,
       risk_level: linkUnreachable && riskLevel === "stable" ? null : riskLevel,
-      risk_cause: cause ? { date: cause.date, change_type: cause.change_type, summary: cause.summary } : null,
+      risk_cause: cause ? { date: cause.date, date_source: cause.date_source, change_type: cause.change_type, summary: cause.summary } : null,
       link_unreachable: linkUnreachable,
       free_tier_longevity_days: longevityDays,
       changes: vendorChanges,

--- a/src/ranking.ts
+++ b/src/ranking.ts
@@ -29,7 +29,7 @@
  */
 
 import { createHash } from "node:crypto";
-import type { DealChange, Offer } from "./types.js";
+import type { ChangeDateSource, DealChange, Offer } from "./types.js";
 
 /** Stable URL where the criteria below are published in full. */
 export const CRITERIA_PATH = "/criteria";
@@ -187,6 +187,7 @@ export type DisclosureCode = "limits_reduced" | "pricing_restructured" | "restri
 export interface Disclosure {
   code: DisclosureCode;
   date: string;
+  date_source?: ChangeDateSource;
   summary: string;
 }
 
@@ -424,6 +425,7 @@ export function evaluate<T extends Offer>(
       disclosures.push({
         code: change.change_type as DisclosureCode,
         date: change.date,
+        date_source: change.date_source,
         summary: change.summary,
       });
     }

--- a/src/serve.ts
+++ b/src/serve.ts
@@ -30,8 +30,8 @@ import { linkifyVerdictBlocks, overdueReport, pageDateModified, pageFreshness, p
 import { rankOffers, rankForListing, rotateListing, utcDate, CRITERIA_PATH, DEMOTE_ONLY_POLICY, DISCLOSURE_RATIONALE, TIE_BREAK_ALGORITHM, GATE_TABLE, DEMERIT_TABLE, NOT_FREE_TIER_RULES, TIME_LIMITED_TIER_RULES } from "./ranking.js";
 import type { RankedEntry, RankingResult } from "./ranking.js";
 import { partitionAlternatives, partitionAlternativesAcross, productRoleSentence, MEMBERSHIP_GATE_RULES, MEMBERSHIP_GATE_ORDER, MEMBERSHIP_GATE_SYMMETRY, MEMBERSHIP_GATE_SCOPE, MEMBERSHIP_GATE_CORRECTIONS } from "./product-role.js";
-import type { Agent, DealChange, RiskCause, LinkUnreachable } from "./types.js";
-import { changeDateLabel, changeDatePublished, undatedGroupHeading, DISCOVERED_DATE_PREFIX, UNDATED_GROUP_NOTE } from "./change-dates.js";
+import type { Agent, ChangeDateSource, DealChange, RiskCause, LinkUnreachable } from "./types.js";
+import { changeDateLabel, changeDateClause, changeDatePublished, changeEventStartDate, latestEventDate, undatedGroupHeading, DISCOVERED_DATE_PREFIX, UNDATED_GROUP_NOTE } from "./change-dates.js";
 import type { AgentBalance } from "./ledger.js";
 import type { SubmittedReferralCode } from "./referral-codes.js";
 
@@ -56,8 +56,8 @@ function latestChangeDate(changes: Array<{ date?: string }>, notAfter = utcToday
   return latest;
 }
 
-function dataChangesSegment(changes: Array<{ date?: string }>): string {
-  const latest = latestChangeDate(changes);
+function dataChangesSegment(changes: Array<{ date: string; date_source?: ChangeDateSource }>): string {
+  const latest = latestEventDate(changes, utcToday());
   return latest ? ` Latest tracked change ${latest}.` : "";
 }
 
@@ -352,7 +352,7 @@ const RISK_COLORS: Record<string, string> = { stable: "#3fb950", caution: "#d299
 const STABILITY_COLORS: Record<string, string> = { stable: "#3fb950", watch: "#d29922", volatile: "#f85149", improving: "#58a6ff" };
 
 function riskCauseLabel(cause: RiskCause): string {
-  return `${cause.date} ${changeTypeBadge[cause.change_type]?.label ?? cause.change_type.replace(/_/g, " ")}`;
+  return `${changeDateLabel(cause)} ${changeTypeBadge[cause.change_type]?.label ?? cause.change_type.replace(/_/g, " ")}`;
 }
 
 /**
@@ -1405,7 +1405,7 @@ function buildBestOfMiniReview(offer: ReturnType<typeof enrichOffers>[number]): 
   // multiple times" off a count of records of any type, so a vendor that
   // *raised* its limits got the caveat. It now quotes the record itself.
   const caveat = offer.risk_level !== "stable" && offer.risk_cause
-    ? ` Note — ${offer.risk_cause.date}: ${escHtmlServer(offer.risk_cause.summary)}`
+    ? ` Note — ${changeDateLabel(offer.risk_cause)}: ${escHtmlServer(offer.risk_cause.summary)}`
     : "";
   return `${escHtmlServer(offer.description)}${bestForText}${caveat}`;
 }
@@ -1414,7 +1414,7 @@ function buildBestOfMiniReview(offer: ReturnType<typeof enrichOffers>[number]): 
 function renderDisclosures(entry: RankedEntry<EnrichedOfferRow>): string {
   if (entry.disclosures.length === 0) return "";
   const items = entry.disclosures.map((d) =>
-    `<li><span style="font-family:var(--mono);color:var(--text-dim)">${escHtmlServer(d.date)}</span> &mdash; <strong>${escHtmlServer(d.code.replace(/_/g, " "))}</strong>: ${escHtmlServer(d.summary)}</li>`
+    `<li><span style="font-family:var(--mono);color:var(--text-dim)">${escHtmlServer(changeDateLabel(d))}</span> &mdash; <strong>${escHtmlServer(d.code.replace(/_/g, " "))}</strong>: ${escHtmlServer(d.summary)}</li>`
   ).join("");
   return `<div class="best-disclosure"><span class="best-disclosure-label">Recorded, but does not affect rank:</span><ul>${items}</ul></div>`;
 }
@@ -2319,7 +2319,7 @@ function buildComparisonPage(slug: string): string | null {
       return `<div style="margin-bottom:.75rem;padding:.6rem .75rem;border-left:3px solid ${badge.color};background:var(--bg-card);border-radius:0 6px 6px 0">
         <div style="display:flex;align-items:center;gap:.5rem;margin-bottom:.25rem">
           <span style="display:inline-block;padding:.1rem .4rem;border-radius:10px;font-size:.65rem;font-weight:600;background:${badge.color};color:#fff">${badge.label}</span>
-          <span style="font-family:var(--mono);font-size:.75rem;color:var(--text-dim)">${c.date}</span>
+          <span style="font-family:var(--mono);font-size:.75rem;color:var(--text-dim)">${changeDateLabel(c)}</span>
           <span style="font-size:.7rem;color:${c.impact === "high" ? "#f85149" : c.impact === "medium" ? "#d29922" : "#8b949e"}">${c.impact} impact</span>
         </div>
         <div style="font-size:.85rem;color:var(--text-muted)">${escHtmlServer(c.summary)}</div>
@@ -2856,7 +2856,7 @@ function buildVsPage(slug: string): string | null {
       return `<div style="margin-bottom:.75rem;padding:.6rem .75rem;border-left:3px solid ${badge.color};background:var(--bg-card);border-radius:0 6px 6px 0">
         <div style="display:flex;align-items:center;gap:.5rem;margin-bottom:.25rem">
           <span style="display:inline-block;padding:.1rem .4rem;border-radius:10px;font-size:.65rem;font-weight:600;background:${badge.color};color:#fff">${badge.label}</span>
-          <span style="font-family:var(--mono);font-size:.75rem;color:var(--text-dim)">${c.date}</span>
+          <span style="font-family:var(--mono);font-size:.75rem;color:var(--text-dim)">${changeDateLabel(c)}</span>
           <span style="font-size:.7rem;color:${c.impact === "high" ? "#f85149" : c.impact === "medium" ? "#d29922" : "#8b949e"}">${c.impact} impact</span>
         </div>
         <div style="font-size:.85rem;color:var(--text-muted)">${escHtmlServer(c.summary)}</div>
@@ -3210,7 +3210,7 @@ function buildDigestPage(weekKey: string): string | null {
       <div class="change-header">
         <span class="change-badge" style="background:${badge.color}">${badge.label}</span>
         <span class="change-vendor">${escHtmlServer(c.vendor)}</span>
-        <span class="change-date">${c.date}</span>
+        <span class="change-date">${changeDateLabel(c)}</span>
         <span class="change-cat">${escHtmlServer(c.category)}</span>
       </div>
       <div class="change-summary">${escHtmlServer(c.summary)}</div>
@@ -3768,7 +3768,7 @@ function buildVendorPage(slug: string): string | null {
   // under it — not only in the history section further down, which for a cause
   // older than 90 days did not carry it at all (Neon, #1038).
   const riskCauseLine = riskLevel !== "stable" && riskCause
-    ? `  <p class="risk-cause-line" style="margin:.4rem 0 .6rem;font-size:.9rem;color:var(--text-muted)"><strong style="color:${riskColor}">Why ${riskLevel}:</strong> <span class="risk-cause-date" style="font-family:var(--mono)">${escHtmlServer(riskCause.date)}</span> &mdash; ${escHtmlServer(riskCause.summary)} <a href="#changes" style="white-space:nowrap">Full history &darr;</a></p>`
+    ? `  <p class="risk-cause-line" style="margin:.4rem 0 .6rem;font-size:.9rem;color:var(--text-muted)"><strong style="color:${riskColor}">Why ${riskLevel}:</strong> <span class="risk-cause-date" style="font-family:var(--mono)">${escHtmlServer(changeDateLabel(riskCause))}</span> &mdash; ${escHtmlServer(riskCause.summary)} <a href="#changes" style="white-space:nowrap">Full history &darr;</a></p>`
     : "";
 
   const linkUnreachable = enriched.link_unreachable;
@@ -3921,7 +3921,7 @@ ${enrichedAlts.map(a => {
     return `<div class="change-item">
         <div class="change-head">
           <span class="badge" style="background:${badge.color}">${badge.label}</span>
-          <span class="change-date"><a href="/pricing-changes#${anchor}" style="color:var(--text-dim);text-decoration:none">${c.date}</a></span>
+          <span class="change-date"><a href="/pricing-changes#${anchor}" style="color:var(--text-dim);text-decoration:none">${changeDateLabel(c)}</a></span>
           <span class="impact impact-${c.impact}">${c.impact} impact</span>
         </div>
         <div class="change-summary">${escHtmlServer(c.summary)}</div>
@@ -4059,7 +4059,7 @@ ${allCompareLinks.join("\n")}
   </div>` : "";
 
   // Last updated timestamp
-  const lastPricingChange = vendorChanges.length > 0 ? vendorChanges[0].date : null;
+  const lastPricingChange = latestEventDate(vendorChanges);
   const lastUpdated = lastPricingChange && lastPricingChange > primary.verifiedDate ? lastPricingChange : primary.verifiedDate;
 
   // Watchlist CTA
@@ -4103,7 +4103,7 @@ ${allCompareLinks.join("\n")}
   const pricingEvents = vendorChanges.slice(0, 10).map(c => ({
     "@type": "Event",
     name: `${vendorName} pricing change: ${c.change_type.replace(/_/g, " ")}`,
-    startDate: c.date,
+    ...changeEventStartDate(c),
     description: c.summary,
   }));
   const jsonLd: Record<string, any> = {
@@ -4146,8 +4146,8 @@ ${allCompareLinks.join("\n")}
     : riskLevel === "stable"
     ? `${vendorName}'s free tier is considered stable: we hold no free tier removal, limit reduction or pricing restructure on record for this vendor.${vendorChanges.length > 0 ? ` We do hold ${vendorChanges.length === 1 ? "1 other recorded change" : `${vendorChanges.length} other recorded changes`} — see the pricing history below.` : ""}`
     : riskLevel === "caution"
-    ? `${vendorName}'s free tier requires caution because of one specific recorded change${riskCause ? `, on ${riskCause.date}: ${riskCause.summary}` : "."}`
-    : `${vendorName}'s free tier is considered risky because of one specific recorded change${riskCause ? `, on ${riskCause.date}: ${riskCause.summary}` : "."} Consider alternatives.`;
+    ? `${vendorName}'s free tier requires caution because of one specific recorded change${riskCause ? `, ${changeDateClause(riskCause)}: ${riskCause.summary}` : "."}`
+    : `${vendorName}'s free tier is considered risky because of one specific recorded change${riskCause ? `, ${changeDateClause(riskCause)}: ${riskCause.summary}` : "."} Consider alternatives.`;
   const faqCategoryAnswer = `${vendorName} is categorized under ${allCategories.join(", ")} on AgentDeals.${alternatives.length > 0 ? ` Other vendors in ${primary.category} include ${alternatives.slice(0, 5).map(a => a.vendor).join(", ")}.` : ""}`;
 
   // NEW: Additional FAQ items
@@ -4159,7 +4159,7 @@ ${allCompareLinks.join("\n")}
       : `${vendorName}'s free tier is usable for prototyping and development, but exercise caution for production workloads given its ${stabilityText} pricing history. Consider alternatives with more stable pricing for critical services.`)
     : `${vendorName} does not offer a free tier for production use. Consider free alternatives in ${primary.category}.`;
   const faqChangedAnswer = vendorChanges.length > 0
-    ? `Yes, ${vendorName} has had ${vendorChanges.length} recorded pricing change${vendorChanges.length > 1 ? "s" : ""}. Most recently: ${vendorChanges[0].summary} (${vendorChanges[0].date}).`
+    ? `Yes, ${vendorName} has had ${vendorChanges.length} recorded pricing change${vendorChanges.length > 1 ? "s" : ""}. Most recently: ${vendorChanges[0].summary} (${changeDateLabel(vendorChanges[0])}).`
     : linkUnreachable
     ? `We hold no recorded pricing changes for ${vendorName}, but its pricing page has not resolved for us${unconfirmableSince}, so that is a statement about our records rather than a positive signal.`
     : `No, ${vendorName} has had no recorded pricing changes. This is a positive stability signal.`;
@@ -4433,7 +4433,7 @@ function buildAlternativesPage(slug: string): string | null {
     const parts: string[] = [];
     parts.push(`<div class="risk-row"><span class="risk-label">Risk Level:</span> <span class="risk-badge-inline" style="background:${riskColor}20;color:${riskColor};border:1px solid ${riskColor}40">${riskLevel}</span></div>`);
     if (riskLevel !== "stable" && riskCause) {
-      parts.push(`<div class="risk-row"><span class="risk-label">Why:</span> <span class="risk-cause-date" style="font-family:var(--mono)">${escHtmlServer(riskCause.date)}</span> &mdash; ${escHtmlServer(riskCause.summary)}</div>`);
+      parts.push(`<div class="risk-row"><span class="risk-label">Why:</span> <span class="risk-cause-date" style="font-family:var(--mono)">${escHtmlServer(changeDateLabel(riskCause))}</span> &mdash; ${escHtmlServer(riskCause.summary)}</div>`);
     }
     parts.push(`<div class="risk-row"><span class="risk-label">Category:</span> ${vendorCategories.map(c => `<a href="/category/${toSlug(c)}" class="cat-pill">${escHtmlServer(c)}</a>`).join(" ")}</div>`);
     parts.push(`<div class="risk-row"><span class="risk-label">Pricing Page:</span> <a href="${escHtmlServer(primary.url)}" rel="noopener" target="_blank">${escHtmlServer(primary.url.replace(/^https?:\/\//, "").slice(0, 50))}${primary.url.replace(/^https?:\/\//, "").length > 50 ? "..." : ""}</a></div>`);
@@ -4444,7 +4444,7 @@ function buildAlternativesPage(slug: string): string | null {
         return `<div class="change-item">
           <div class="change-head">
             <span class="badge" style="background:${badge.color}">${badge.label}</span>
-            <span class="change-date">${c.date}</span>
+            <span class="change-date">${changeDateLabel(c)}</span>
             <span class="impact impact-${c.impact}">${c.impact} impact</span>
           </div>
           <div class="change-summary">${escHtmlServer(c.summary)}</div>
@@ -4544,11 +4544,11 @@ ${enrichedAlts.map(a => altCard(a, false)).join("\n")}
   const faqFreeTierAnswer = riskLevel === "stable"
     ? `Yes, ${vendorName} currently offers a free tier (${primary.tier}). ${vendorChanges.length === 0 ? "No pricing changes have been recorded." : `We hold ${vendorChanges.length === 1 ? "1 recorded change" : `${vendorChanges.length} recorded changes`} for this vendor, none of them a free tier removal, limit reduction or pricing restructure.`}`
     : riskLevel === "caution"
-    ? `${vendorName} has a free tier (${primary.tier}), but it's flagged as "caution" because of one specific recorded change${riskCause ? `, on ${riskCause.date}: ${riskCause.summary}` : "."}`
-    : `${vendorName}'s free tier (${primary.tier}) is considered risky because of one specific recorded change${riskCause ? `, on ${riskCause.date}: ${riskCause.summary}` : "."} Consider migrating to a more stable alternative.`;
+    ? `${vendorName} has a free tier (${primary.tier}), but it's flagged as "caution" because of one specific recorded change${riskCause ? `, ${changeDateClause(riskCause)}: ${riskCause.summary}` : "."}`
+    : `${vendorName}'s free tier (${primary.tier}) is considered risky because of one specific recorded change${riskCause ? `, ${changeDateClause(riskCause)}: ${riskCause.summary}` : "."} Consider migrating to a more stable alternative.`;
   const faqCountAnswer = `There are ${enrichedAlts.length} free alternatives to ${vendorName} tracked on AgentDeals across the ${vendorCategories.join(", ")} categor${vendorCategories.length > 1 ? "ies" : "y"}.`;
   const faqChangesAnswer = vendorChanges.length > 0
-    ? `Yes, ${vendorName} has ${vendorChanges.length} recorded pricing change${vendorChanges.length !== 1 ? "s" : ""}. The most recent was on ${vendorChanges[0].date}: ${vendorChanges[0].summary}`
+    ? `Yes, ${vendorName} has ${vendorChanges.length} recorded pricing change${vendorChanges.length !== 1 ? "s" : ""}. The most recent was ${changeDateClause(vendorChanges[0])}: ${vendorChanges[0].summary}`
     : `No, ${vendorName} has no recorded pricing changes on AgentDeals. This indicates stable pricing.`;
 
   const altFaqItems = [
@@ -18270,7 +18270,7 @@ function buildQ1PricingReportPage(): string {
     return "<div class=\"change-card\" style=\"border-left-color:" + impactColor + "\">" +
       "<div class=\"change-header\">" +
         "<a href=\"/vendor/" + vendorSlug + "\" class=\"change-vendor\">" + escHtmlServer(c.vendor) + "</a>" +
-        "<span class=\"change-date\">" + c.date + "</span>" +
+        "<span class=\"change-date\">" + changeDateLabel(c) + "</span>" +
         "<span class=\"change-impact\" style=\"color:" + impactColor + "\">" + c.impact + "</span>" +
       "</div>" +
       "<span class=\"change-type-badge\" style=\"background:" + impactColor + "22;color:" + impactColor + "\">" + typeLabel + "</span>" + editorialLink +
@@ -18704,7 +18704,7 @@ function buildQ2PricingPreview2026Page(): string {
     return `<div class="change-card" style="border-left-color:${impactColor}">
       <div class="change-header">
         <a href="/vendor/${vendorSlug}" class="change-vendor">${escHtmlServer(c.vendor)}</a>
-        <span class="change-date">${c.date}</span>
+        <span class="change-date">${changeDateLabel(c)}</span>
         <span class="change-impact" style="color:${impactColor}">${c.impact}</span>
       </div>
       <span class="change-type-badge" style="background:${impactColor}22;color:${impactColor}">${typeLabel}</span>${editorialLink}
@@ -18849,7 +18849,7 @@ ${mcpCtaCss()}
   ${timelineChanges.map(c => {
     const impactColor = impactColors[c.impact] ?? "#94a3b8";
     return `<div class="timeline-item">
-      <div class="timeline-date">${c.date}</div>
+      <div class="timeline-date">${changeDateLabel(c)}</div>
       <div class="timeline-content">
         <span class="timeline-vendor"><a href="/vendor/${toSlug(c.vendor)}" style="color:var(--text)">${escHtmlServer(c.vendor)}</a></span>
         <span class="timeline-impact" style="background:${impactColor}22;color:${impactColor}">${c.impact}</span>
@@ -23260,7 +23260,7 @@ function buildStabilityDashboardPage(): string {
       <p class="vendor-summary">${escHtmlServer(latestChange?.summary?.substring(0, 200) ?? "")}</p>
       <div class="vendor-meta">
         <span class="change-type">${escHtmlServer(changeTypeLabel)}</span>
-        <span class="change-date">${escHtmlServer(latestChange?.date ?? "")}</span>
+        <span class="change-date">${escHtmlServer(latestChange ? changeDateLabel(latestChange) : "")}</span>
         ${entry.changes.length > 1 ? `<span class="change-count">${entry.changes.length} changes tracked</span>` : ""}
         ${editorialLink ? `<a href="/${editorialLink.slug}" class="alt-link">View alternatives &rarr;</a>` : ""}
       </div>
@@ -45755,7 +45755,7 @@ function buildStateOfFreeTiersPage(): string {
     return `<div style="margin-bottom:.75rem;padding:.75rem 1rem;border-left:3px solid ${badge.color};background:var(--bg-card);border-radius:0 8px 8px 0">
       <div style="display:flex;align-items:center;gap:.5rem;margin-bottom:.3rem;flex-wrap:wrap">
         <span style="display:inline-block;padding:.1rem .5rem;border-radius:10px;font-size:.65rem;font-weight:600;background:${badge.color};color:#fff">${badge.label}</span>
-        <span style="font-family:var(--mono);font-size:.75rem;color:var(--text-dim)">${c.date}</span>
+        <span style="font-family:var(--mono);font-size:.75rem;color:var(--text-dim)">${changeDateLabel(c)}</span>
         <span style="font-size:.7rem;color:${impactColor};font-weight:600">${c.impact} impact</span>
         <a href="/vendor/${toSlug(c.vendor)}" style="font-size:.8rem;font-weight:600;color:var(--text)">${escHtmlServer(c.vendor)}</a>
       </div>
@@ -45769,7 +45769,7 @@ function buildStateOfFreeTiersPage(): string {
     return `<div style="margin-bottom:.75rem;padding:.75rem 1rem;border-left:3px solid ${badge.color};background:var(--bg-card);border-radius:0 8px 8px 0">
       <div style="display:flex;align-items:center;gap:.5rem;margin-bottom:.3rem;flex-wrap:wrap">
         <span style="display:inline-block;padding:.1rem .5rem;border-radius:10px;font-size:.65rem;font-weight:600;background:${badge.color};color:#fff">${badge.label}</span>
-        <span style="font-family:var(--mono);font-size:.75rem;color:var(--text-dim)">${c.date}</span>
+        <span style="font-family:var(--mono);font-size:.75rem;color:var(--text-dim)">${changeDateLabel(c)}</span>
         <a href="/vendor/${toSlug(c.vendor)}" style="font-size:.8rem;font-weight:600;color:var(--text)">${escHtmlServer(c.vendor)}</a>
       </div>
       <div style="font-size:.85rem;color:var(--text-muted);line-height:1.4">${escHtmlServer(c.summary)}</div>
@@ -47277,10 +47277,10 @@ function buildStackCheckPage(): string {
       slug,
       risk_level: assessment.level,
       risk_cause: assessment.cause
-        ? { date: assessment.cause.date, change_type: assessment.cause.change_type, summary: assessment.cause.summary }
+        ? { date: changeDateLabel(assessment.cause), date_source: assessment.cause.date_source, change_type: assessment.cause.change_type, summary: assessment.cause.summary }
         : null,
       stability,
-      recent_changes: vendorChanges.map(c => ({ date: c.date, change_type: c.change_type, summary: c.summary, impact: c.impact })),
+      recent_changes: vendorChanges.map(c => ({ date: changeDateLabel(c), change_type: c.change_type, summary: c.summary, impact: c.impact })),
     };
     // Also add by lowercase vendor name for easy matching
     vendorLookup[offer.vendor.toLowerCase()] = vendorLookup[slug];
@@ -50187,6 +50187,7 @@ function buildChangesPage(): string {
   // Sort all changes reverse chronological
   const sorted = [...eventDated].sort((a, b) => b.date.localeCompare(a.date));
   const undatedSorted = [...undatedChanges].sort((a, b) => b.date.localeCompare(a.date));
+  const newestFirst = [...allChanges].sort((a, b) => b.date.localeCompare(a.date));
 
   // Group by month
   const byMonth = new Map<string, typeof sorted>();
@@ -50255,14 +50256,14 @@ ${undatedSorted.map(c => buildChangeEntry(c)).join("\n")}
     description: metaDesc,
     numberOfItems: allChanges.length,
     url: `${BASE_URL}/changes`,
-    itemListElement: sorted.slice(0, 50).map((c, i) => ({
+    itemListElement: newestFirst.slice(0, 50).map((c, i) => ({
       "@type": "ListItem",
       position: i + 1,
       item: {
         "@type": "NewsArticle",
         headline: `${c.vendor}: ${(changeTypeBadge[c.change_type] ?? { label: c.change_type }).label}`,
         description: c.summary,
-        datePublished: c.date,
+        ...changeDatePublished(c),
         url: `${BASE_URL}/vendor/${toSlug(c.vendor)}`,
         publisher: { "@type": "Organization", name: "AgentDeals", url: BASE_URL },
       },
@@ -50467,16 +50468,16 @@ ${entriesHtml}
     "@type": "ItemList",
     name: title,
     description: metaDesc,
-    numberOfItems: totalUpcoming + recent.length,
+    numberOfItems: totalUpcoming + recent.length + recentlyDiscovered.length,
     url: `${BASE_URL}/expiring`,
-    itemListElement: upcoming.slice(0, 50).map((c, i) => ({
+    itemListElement: [...upcoming, ...recentlyDiscovered].slice(0, 50).map((c, i) => ({
       "@type": "ListItem",
       position: i + 1,
       item: {
         "@type": "NewsArticle",
         headline: `${c.vendor}: ${(changeTypeBadge[c.change_type] ?? { label: c.change_type }).label}`,
         description: c.summary,
-        datePublished: c.date,
+        ...changeDatePublished(c),
         url: `${BASE_URL}/vendor/${toSlug(c.vendor)}`,
         publisher: { "@type": "Organization", name: "AgentDeals", url: BASE_URL },
       },
@@ -52722,7 +52723,7 @@ function buildTrendsPage(slug: string): string | null {
         <div class="timeline-head">
           <span class="badge" style="background:${badge.color}">${badge.label}</span>
           <a href="/vendor/${toSlug(c.vendor)}" class="timeline-vendor">${escHtmlServer(c.vendor)}</a>
-          <span class="timeline-date">${c.date}</span>
+          <span class="timeline-date">${changeDateLabel(c)}</span>
           <span class="impact impact-${c.impact}">${c.impact}</span>
         </div>
         <div class="timeline-summary">${escHtmlServer(c.summary)}</div>

--- a/src/types.ts
+++ b/src/types.ts
@@ -76,6 +76,7 @@ export type RiskLevel = "stable" | "caution" | "risky";
  */
 export interface RiskCause {
   date: string;
+  date_source?: ChangeDateSource;
   change_type: string;
   summary: string;
 }

--- a/test/change-date-provenance.test.ts
+++ b/test/change-date-provenance.test.ts
@@ -209,6 +209,18 @@ function regionFrom(html: string, start: string, end?: string): string {
   return j === -1 ? html.slice(i) : html.slice(i, j);
 }
 
+function structuredItemFor(html: string, vendor: string): { datePublished?: string } | null {
+  for (const block of html.matchAll(/<script type="application\/ld\+json">([\s\S]*?)<\/script>/g)) {
+    const json = JSON.parse(block[1]);
+    if (!Array.isArray(json.itemListElement)) continue;
+    const found = json.itemListElement
+      .map((el: any) => el.item)
+      .find((item: any) => typeof item?.headline === "string" && item.headline.startsWith(`${vendor}:`));
+    if (found) return found;
+  }
+  return null;
+}
+
 function last30DaysTile(html: string): number {
   const m = html.match(/<div class="stat-value">(\d+)<\/div>\s*<div class="stat-label">Last 30 Days<\/div>/);
   assert.ok(m, "could not find the Last 30 Days tile");
@@ -396,16 +408,18 @@ describe("no surface renders a discovery date as the date the vendor changed som
 
   it("does not publish a discovery date as datePublished in structured data", async () => {
     for (const route of ["/", "/changes", "/expiring"]) {
-      const { discovered } = await bodies(route);
-      for (const block of discovered.matchAll(/<script type="application\/ld\+json">([\s\S]*?)<\/script>/g)) {
-        const json = JSON.parse(block[1]);
-        const items = JSON.stringify(json);
-        if (!items.includes(SUBJECT)) continue;
-        assert.ok(
-          !new RegExp(`"datePublished":"${TODAY}"`).test(items),
-          `${route} published a discovery date as datePublished`
-        );
-      }
+      const { dated, discovered } = await bodies(route);
+      assert.strictEqual(
+        structuredItemFor(dated, SUBJECT)?.datePublished,
+        TODAY,
+        `${route} carries no structured item for the entry when its date is an effective date, so the check below proves nothing`
+      );
+      const item = structuredItemFor(discovered, SUBJECT);
+      assert.ok(item, `${route} dropped the entry from its structured data rather than listing it undated`);
+      assert.ok(
+        !("datePublished" in item!),
+        `${route} published a discovery date as datePublished`
+      );
     }
   });
 

--- a/test/change-log-writer.test.ts
+++ b/test/change-log-writer.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, before, after } from "node:test";
 import assert from "node:assert";
-import { spawn, type ChildProcess } from "node:child_process";
+import { spawn, spawnSync, type ChildProcess } from "node:child_process";
 import { readFileSync, writeFileSync, mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
@@ -19,7 +19,7 @@ const {
 
 const { runUrlMode, runAiMode, summaryLines, repickWindowDays } = await import("../scripts/reverify-rolling.js");
 const { firstSeenDates } = await import("../scripts/backfill-change-recorded-dates.js");
-const { report, DEFAULT_THRESHOLD_DAYS, detectorSchedule, WORKFLOW_PATH } = await import("../scripts/check-change-log-staleness.js");
+const { report, DEFAULT_THRESHOLD_DAYS, detectorSchedule, flagTokens, DETECTOR_CLI_OPTIONS, WORKFLOW_PATH } = await import("../scripts/check-change-log-staleness.js");
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const REPO = path.join(__dirname, "..");
@@ -521,6 +521,87 @@ describe("reading the detector's schedule out of the workflow", () => {
 
   it("refuses when it cannot find the invocation at all", () => {
     assert.strictEqual(detectorSchedule("jobs:\n  reverify:\n    steps: []\n").known, false);
+  });
+
+  it("refuses when a shell variable stands where the flag would go", () => {
+    const schedule = detectorSchedule(
+      withCommand('node scripts/reverify-rolling.js --limit "$LIMIT" $AI_FLAG')
+    );
+    assert.strictEqual(schedule.known, false);
+    assert.match(schedule.reason, /\$AI_FLAG/);
+  });
+
+  it("refuses when a workflow expression stands where the flag would go", () => {
+    const schedule = detectorSchedule(
+      withCommand(
+        "node scripts/reverify-rolling.js --limit \"$LIMIT\" ${{ inputs.mode == 'ai' && '--ai' || '' }}"
+      )
+    );
+    assert.strictEqual(schedule.known, false);
+    assert.match(schedule.reason, /inputs\.mode/);
+  });
+
+  it("refuses on a quoted variable standing alone, which expands to one whole argument", () => {
+    const schedule = detectorSchedule(withCommand('node scripts/reverify-rolling.js "$AI_FLAG"'));
+    assert.strictEqual(schedule.known, false);
+    assert.match(schedule.reason, /AI_FLAG/);
+  });
+
+  it("refuses on a braced shell variable in the same position", () => {
+    assert.strictEqual(
+      detectorSchedule(withCommand("node scripts/reverify-rolling.js ${AI_FLAG}")).known,
+      false
+    );
+  });
+
+  it("still answers when the only variable is the value of an option that takes one", () => {
+    const on = detectorSchedule(withCommand('node scripts/reverify-rolling.js --ai --limit "$LIMIT"'));
+    assert.deepStrictEqual({ known: on.known, scheduled: on.scheduled }, { known: true, scheduled: true });
+    const off = detectorSchedule(withCommand('node scripts/reverify-rolling.js --limit "$LIMIT"'));
+    assert.deepStrictEqual({ known: off.known, scheduled: off.scheduled }, { known: true, scheduled: false });
+  });
+
+  it("stops reading at the pipe, so what the log is written to cannot decide this", () => {
+    const schedule = detectorSchedule(
+      withCommand('node scripts/reverify-rolling.js --limit "$LIMIT" | tee "$LOGFILE"')
+    );
+    assert.deepStrictEqual(
+      { known: schedule.known, scheduled: schedule.scheduled },
+      { known: true, scheduled: false }
+    );
+  });
+
+  it("treats an option's value as a value and everything else as a possible flag", () => {
+    assert.deepStrictEqual(
+      flagTokens(' --limit "$LIMIT" --ai').map((t: { text: string }) => t.text),
+      ["--limit", "--ai"]
+    );
+  });
+
+  it("knows the same option grammar the detector itself parses", () => {
+    const source = readFileSync(path.join(REPO, "scripts", "reverify-rolling.js"), "utf-8");
+    const parsed = [
+      ...new Set([...source.matchAll(/args\.(?:includes|indexOf)\("(--[a-z-]+)"\)/g)].map((m) => m[1])),
+    ].sort();
+    const declared = [...DETECTOR_CLI_OPTIONS.takesValue, ...DETECTOR_CLI_OPTIONS.boolean].sort();
+    assert.ok(parsed.length > 0, "found no option literals in the detector, so the comparison proves nothing");
+    assert.deepStrictEqual(parsed, declared);
+  });
+
+  it("exits 2 on a workflow whose schedule it cannot read", () => {
+    const dir = mkdtempSync(path.join(tmpdir(), "detector-schedule-"));
+    try {
+      const workflow = path.join(dir, "reverify.yml");
+      writeFileSync(workflow, withCommand('node scripts/reverify-rolling.js --limit "$LIMIT" $AI_FLAG'));
+      const run = spawnSync("node", [path.join(REPO, "scripts", "check-change-log-staleness.js")], {
+        env: { ...process.env, AGENTDEALS_REVERIFY_WORKFLOW_PATH: workflow },
+        encoding: "utf-8",
+      });
+      assert.strictEqual(run.status, 2, run.stdout + run.stderr);
+      assert.match(run.stdout, /Refusing to guess/);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
   });
 
   it("refuses when only some invocations pass --ai", () => {

--- a/test/change-structured-data.test.ts
+++ b/test/change-structured-data.test.ts
@@ -1,0 +1,171 @@
+import { describe, it, before, after } from "node:test";
+import assert from "node:assert";
+import { spawn, type ChildProcess } from "node:child_process";
+import { writeFileSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO = path.join(__dirname, "..");
+
+const TODAY = new Date().toISOString().slice(0, 10);
+const dayOffset = (days: number) =>
+  new Date(Date.parse(TODAY) + days * 86400000).toISOString().slice(0, 10);
+
+const UPCOMING = "Fauna";
+const UPCOMING_DATE = dayOffset(20);
+const DISCOVERY = "Xata";
+const BACKLOG_SIZE = 60;
+const LIST_CAP = 50;
+const ROUTES = ["/", "/changes", "/expiring"];
+
+function change(vendor: string, date: string, dateSource: string) {
+  return {
+    vendor,
+    change_type: "limits_reduced",
+    date,
+    date_source: dateSource,
+    summary: `${vendor} free allowance cut.`,
+    previous_state: "15 GB storage",
+    current_state: "5 GB storage",
+    impact: "high",
+    source_url: `https://example.com/${vendor.toLowerCase()}/pricing`,
+    category: "Databases",
+    alternatives: [],
+    recorded_date: date,
+  };
+}
+
+function fixtureChanges() {
+  const backlog = Array.from({ length: BACKLOG_SIZE }, (_, i) =>
+    change(`Backlog${String(i).padStart(2, "0")}`, dayOffset(-100 - i), "vendor_page")
+  );
+  return [
+    ...backlog,
+    change(UPCOMING, UPCOMING_DATE, "vendor_page"),
+    { ...change(DISCOVERY, TODAY, "discovered"), detected_by: "reverify-ai" },
+  ];
+}
+
+type Item = { "@type": string; headline?: string; datePublished?: string };
+
+function changeList(html: string, route: string): { numberOfItems: number; items: Item[] } {
+  const lists: { numberOfItems: number; items: Item[] }[] = [];
+  for (const block of html.matchAll(/<script type="application\/ld\+json">([\s\S]*?)<\/script>/g)) {
+    const json = JSON.parse(block[1]);
+    if (json["@type"] !== "ItemList" || !Array.isArray(json.itemListElement)) continue;
+    const items: Item[] = json.itemListElement.map((el: any, i: number) => {
+      assert.strictEqual(el.position, i + 1, `${route} numbered its list positions out of order`);
+      return el.item;
+    });
+    if (!items.every((it) => it["@type"] === "Article" || it["@type"] === "NewsArticle")) continue;
+    lists.push({ numberOfItems: json.numberOfItems, items });
+  }
+  assert.strictEqual(lists.length, 1, `expected exactly one change list in the structured data on ${route}`);
+  return lists[0];
+}
+
+function itemFor(list: { items: Item[] }, vendor: string, route: string): Item {
+  const found = list.items.find((it) => it.headline?.startsWith(`${vendor}:`));
+  assert.ok(found, `${route} left ${vendor} out of its structured data entirely`);
+  return found!;
+}
+
+describe("the machine-readable change lists carry the entries the pages carry", () => {
+  let tmp: string;
+  let proc: ChildProcess;
+  const bodies = new Map<string, string>();
+
+  before(async () => {
+    tmp = mkdtempSync(path.join(tmpdir(), "change-structured-data-"));
+    const changesPath = path.join(tmp, "changes.json");
+    writeFileSync(changesPath, JSON.stringify({ changes: fixtureChanges() }, null, 2));
+    const started = await new Promise<{ proc: ChildProcess; port: number }>((resolve, reject) => {
+      const child = spawn("node", [path.join(REPO, "dist", "serve.js")], {
+        stdio: ["pipe", "pipe", "pipe"],
+        env: {
+          ...process.env,
+          PORT: "0",
+          BASE_URL: "http://localhost:3000",
+          AGENTDEALS_CHANGES_PATH: changesPath,
+        },
+      });
+      const timeout = setTimeout(() => {
+        child.kill();
+        reject(new Error("Server startup timeout"));
+      }, 30000);
+      child.stderr!.on("data", (data: Buffer) => {
+        const m = data.toString().match(/running on http:\/\/localhost:(\d+)/);
+        if (m) {
+          clearTimeout(timeout);
+          resolve({ proc: child, port: parseInt(m[1], 10) });
+        }
+      });
+      child.on("error", (err) => {
+        clearTimeout(timeout);
+        reject(err);
+      });
+    });
+    proc = started.proc;
+    for (const route of ROUTES) {
+      bodies.set(route, await (await fetch(`http://localhost:${started.port}${route}`)).text());
+    }
+  });
+
+  after(() => {
+    if (proc) proc.kill();
+    if (tmp) rmSync(tmp, { recursive: true, force: true });
+  });
+
+  for (const route of ROUTES) {
+    it(`states the effective date of a dated entry on ${route}`, () => {
+      assert.strictEqual(
+        itemFor(changeList(bodies.get(route)!, route), UPCOMING, route).datePublished,
+        UPCOMING_DATE,
+        `${route} dropped the effective date from an entry that has one`
+      );
+    });
+
+    it(`lists an entry whose effective date is unknown on ${route}, without inventing one`, () => {
+      const discovery = itemFor(changeList(bodies.get(route)!, route), DISCOVERY, route);
+      assert.ok(
+        !("datePublished" in discovery),
+        `${route} published the day we looked as the day the terms changed`
+      );
+    });
+  }
+
+  it("counts the entry it could not date in the total it advertises", () => {
+    const list = changeList(bodies.get("/expiring")!, "/expiring");
+    assert.strictEqual(list.items.length, 2);
+    assert.strictEqual(list.numberOfItems, 2);
+  });
+
+  it("does not let a backlog of dated entries crowd a new discovery out of the list", () => {
+    const list = changeList(bodies.get("/changes")!, "/changes");
+    assert.strictEqual(
+      list.items.length,
+      LIST_CAP,
+      "the list is not at its cap, so nothing is being crowded out"
+    );
+    assert.ok(
+      list.items.filter((it) => it.headline?.startsWith("Backlog")).length > 10,
+      "the list holds almost no dated entries, so the presence below proves nothing"
+    );
+    itemFor(list, DISCOVERY, "/changes");
+  });
+
+  it("orders the list by the date each entry carries, newest first", () => {
+    const list = changeList(bodies.get("/changes")!, "/changes");
+    assert.strictEqual(list.items[0].headline?.startsWith(`${UPCOMING}:`), true);
+    assert.strictEqual(list.items[1].headline?.startsWith(`${DISCOVERY}:`), true);
+  });
+
+  it("advertises a total that counts every entry, not only the page of them it shows", () => {
+    assert.strictEqual(
+      changeList(bodies.get("/changes")!, "/changes").numberOfItems,
+      fixtureChanges().length
+    );
+  });
+});

--- a/test/discovery-date-surfaces.test.ts
+++ b/test/discovery-date-surfaces.test.ts
@@ -1,0 +1,246 @@
+import { describe, it, before, after } from "node:test";
+import assert from "node:assert";
+import { spawn, type ChildProcess } from "node:child_process";
+import { writeFileSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO = path.join(__dirname, "..");
+
+const TODAY = new Date().toISOString().slice(0, 10);
+const dayOffset = (days: number) =>
+  new Date(Date.parse(TODAY) + days * 86400000).toISOString().slice(0, 10);
+
+const SUBJECT = "Xata";
+const CONTROL = "Hyperping";
+const CONTROL_DATE = dayOffset(-10);
+const DIGEST_SURFACES = ["/feed.xml", "/api/feed", "/this-week", "/api/digest"];
+
+function change(vendor: string, date: string, dateSource: string) {
+  return {
+    vendor,
+    change_type: "limits_reduced",
+    date,
+    date_source: dateSource,
+    summary: `${vendor} free allowance cut.`,
+    previous_state: "15 GB storage",
+    current_state: "5 GB storage",
+    impact: "high",
+    source_url: `https://example.com/${vendor.toLowerCase()}/pricing`,
+    category: "Databases",
+    alternatives: [],
+    recorded_date: TODAY,
+    ...(dateSource === "discovered" ? { detected_by: "reverify-ai" } : {}),
+  };
+}
+
+const EXEMPT: Array<{ name: string; allows: (before: string, body: string) => boolean }> = [
+  {
+    name: "an identifier built from the vendor and the date, which names an entry rather than dating one",
+    allows: (before) => /(?:\bid="[a-z0-9-]*|href="[^"]*#[a-z0-9-]*)-$|<id>[^<]*$/.test(before),
+  },
+  {
+    name: "an Atom timestamp, which records when we last touched the entry",
+    allows: (before) => /<updated>$/.test(before),
+  },
+  {
+    name: "a page or dataset modification date",
+    allows: (before) => /"dateModified":"$/.test(before),
+  },
+  {
+    name: "a machine payload that hands over the provenance beside the date",
+    allows: (before, body) => /"date":"$/.test(before) && body.includes('"date_source"'),
+  },
+];
+
+function unlabelledDates(body: string, date: string): string[] {
+  const found: string[] = [];
+  let idx = body.indexOf(date);
+  while (idx !== -1) {
+    const before = body.slice(Math.max(0, idx - 80), idx);
+    if (!/discovered[ >"]*$/i.test(before) && !EXEMPT.some((e) => e.allows(before, body))) {
+      found.push(before.slice(-60).replace(/\s+/g, " "));
+    }
+    idx = body.indexOf(date, idx + 1);
+  }
+  return found;
+}
+
+function addedBy(withEntry: string[], without: string[]): string[] {
+  const remaining = [...without];
+  const added: string[] = [];
+  for (const hit of withEntry) {
+    const i = remaining.indexOf(hit);
+    if (i === -1) added.push(hit);
+    else remaining.splice(i, 1);
+  }
+  return added;
+}
+
+function startServer(changesPath: string): Promise<{ proc: ChildProcess; port: number }> {
+  return new Promise((resolve, reject) => {
+    const child = spawn("node", [path.join(REPO, "dist", "serve.js")], {
+      stdio: ["pipe", "pipe", "pipe"],
+      env: {
+        ...process.env,
+        PORT: "0",
+        BASE_URL: "http://localhost:3000",
+        AGENTDEALS_CHANGES_PATH: changesPath,
+      },
+    });
+    const timeout = setTimeout(() => {
+      child.kill();
+      reject(new Error("Server startup timeout"));
+    }, 30000);
+    child.stderr!.on("data", (data: Buffer) => {
+      const m = data.toString().match(/running on http:\/\/localhost:(\d+)/);
+      if (m) {
+        clearTimeout(timeout);
+        resolve({ proc: child, port: parseInt(m[1], 10) });
+      }
+    });
+    child.on("error", (err) => {
+      clearTimeout(timeout);
+      reject(err);
+    });
+  });
+}
+
+describe("no published surface presents a discovery date as the date a vendor changed something", () => {
+  let tmp: string;
+  const servers: ChildProcess[] = [];
+  let routes: string[] = [];
+  let ENTRY_DATE = "";
+  const rendered = new Map<string, { discovered: string; dated: string; absent: string }>();
+
+  before(async () => {
+    tmp = mkdtempSync(path.join(tmpdir(), "discovery-date-surfaces-"));
+    const write = (name: string, changes: unknown[]) => {
+      const p = path.join(tmp, name);
+      writeFileSync(p, JSON.stringify({ changes }));
+      return p;
+    };
+    const control = change(CONTROL, CONTROL_DATE, "vendor_page");
+    const absent = await startServer(write("absent.json", [control]));
+    servers.push(absent.proc);
+
+    const reportingPeriods = new Set<string>();
+    for (const route of DIGEST_SURFACES) {
+      const body = await (await fetch(`http://localhost:${absent.port}${route}`)).text();
+      for (const m of body.matchAll(/\d{4}-\d{2}-\d{2}/g)) reportingPeriods.add(m[0]);
+    }
+    ENTRY_DATE = [0, -1, -2, -3, -4, -5, -6]
+      .map(dayOffset)
+      .find((d) => !reportingPeriods.has(d)) ?? "";
+    assert.ok(ENTRY_DATE, "every candidate date is already a reporting period boundary");
+
+    const discovered = await startServer(
+      write("discovered.json", [control, change(SUBJECT, ENTRY_DATE, "discovered")])
+    );
+    const dated = await startServer(
+      write("dated.json", [control, change(SUBJECT, ENTRY_DATE, "vendor_page")])
+    );
+    servers.push(discovered.proc, dated.proc);
+
+    const index = await (await fetch(`http://localhost:${discovered.port}/sitemap.xml`)).text();
+    const locs: string[] = [];
+    for (const m of index.matchAll(/<loc>([^<]+)<\/loc>/g)) {
+      const childPath = new URL(m[1]).pathname;
+      const xml = await (await fetch(`http://localhost:${discovered.port}${childPath}`)).text();
+      for (const inner of xml.matchAll(/<loc>([^<]+)<\/loc>/g)) locs.push(new URL(inner[1]).pathname);
+    }
+    routes = [
+      ...new Set([
+        ...locs,
+        "/pricing-changes/feed.xml",
+        "/feed.xml",
+        "/api/feed",
+        "/api/changes",
+        "/api/digest",
+        "/api/digest/weekly",
+        `/vendor/${SUBJECT.toLowerCase()}`,
+      ]),
+    ];
+
+    const queue = [...routes];
+    async function worker() {
+      for (;;) {
+        const route = queue.shift();
+        if (!route) return;
+        try {
+          const [a, b, c] = await Promise.all([
+            fetch(`http://localhost:${discovered.port}${route}`),
+            fetch(`http://localhost:${dated.port}${route}`),
+            fetch(`http://localhost:${absent.port}${route}`),
+          ]);
+          if (a.status !== 200 || b.status !== 200 || c.status !== 200) continue;
+          const bodies = { discovered: await a.text(), dated: await b.text(), absent: await c.text() };
+          if (bodies.discovered.includes(SUBJECT)) rendered.set(route, bodies);
+        } catch {
+          continue;
+        }
+      }
+    }
+    await Promise.all(Array.from({ length: 6 }, worker));
+  });
+
+  after(() => {
+    for (const proc of servers) proc.kill();
+    if (tmp) rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it("reaches enough of the site for the sweep below to mean something", () => {
+    assert.ok(routes.length > 1000, `only enumerated ${routes.length} routes from the sitemap`);
+    assert.ok(rendered.size > 40, `only ${rendered.size} routes rendered the entry at all`);
+  });
+
+  it("would see the date if the same entry carried an effective date", () => {
+    const seen = [...rendered].filter(
+      ([, b]) => addedBy(unlabelledDates(b.dated, ENTRY_DATE), unlabelledDates(b.absent, ENTRY_DATE)).length > 0
+    );
+    assert.ok(
+      seen.length > 10,
+      `the sweep attributed a bare date to the entry on only ${seen.length} routes when it was dated, so finding none for a discovery proves nothing`
+    );
+  });
+
+  it("labels every rendering of a date we only know because we looked", () => {
+    const offenders: string[] = [];
+    for (const [route, b] of rendered) {
+      for (const hit of addedBy(unlabelledDates(b.discovered, ENTRY_DATE), unlabelledDates(b.absent, ENTRY_DATE))) {
+        offenders.push(`${route}: ...${hit}`);
+      }
+    }
+    assert.deepStrictEqual(offenders, []);
+  });
+
+  it("does not call an effective date a discovery when the same entry carries one", () => {
+    const mislabelled = [...rendered]
+      .filter(([, b]) => b.dated.includes(`discovered ${ENTRY_DATE}`))
+      .map(([route]) => route);
+    assert.deepStrictEqual(mislabelled, []);
+  });
+
+  it("says discovered somewhere when the entry has no effective date", () => {
+    const labelled = [...rendered].filter(([, b]) => b.discovered.includes(`discovered ${ENTRY_DATE}`));
+    assert.ok(
+      labelled.length > 3,
+      `only ${labelled.length} routes labelled the discovery, so the mislabelling check above proves nothing`
+    );
+  });
+
+  it("keeps every declared exemption in use", () => {
+    const fires = (e: (typeof EXEMPT)[number]) =>
+      [...rendered.values()].some((b) => {
+        let idx = b.discovered.indexOf(ENTRY_DATE);
+        while (idx !== -1) {
+          if (e.allows(b.discovered.slice(Math.max(0, idx - 80), idx), b.discovered)) return true;
+          idx = b.discovered.indexOf(ENTRY_DATE, idx + 1);
+        }
+        return false;
+      });
+    assert.deepStrictEqual(EXEMPT.filter((e) => !fires(e)).map((e) => e.name), []);
+  });
+});


### PR DESCRIPTION
Refs #1074 — AC11 and AC12, plus the sweep that showed the class is wider than either of our lists.

## AC11 — the schedule reader can no longer be wrong instead of undecidable

`detectorSchedule` matched `--ai` against the invocation text. Both of the natural Phase 2 rewrites defeat it silently, and one of them contains the literal `--ai` and still misses because the quotes break the word boundary.

It now **tokenises** the argument text — honouring `'…'`, `"…"` and `${{ … }}` as units, and stopping at the first shell operator — then walks the tokens with **the same option grammar the detector itself parses**. A value consumed by an option that takes one is not a candidate flag; anything else that is not a literal makes the answer unknown, and the script exits 2.

That distinction is what keeps the shipped workflow decidable. Its `--limit "$LIMIT"` is an option's value, so the daily run still reports the detector unscheduled and opens the one marker-guarded issue, exactly as ruled. Treating every `$` as unknowable would have turned that ruling into a job that goes red every day and is therefore read by nobody. All four lines are tests:

| invocation | answer |
|---|---|
| `--limit "$LIMIT"` (shipped) | not scheduled, exit 0 |
| `--limit "$LIMIT" $AI_FLAG` | unknown, exit 2 |
| `--limit "$LIMIT" ${{ inputs.mode == 'ai' && '--ai' \|\| '' }}` | unknown, exit 2 |
| `--ai --limit "$LIMIT"` | scheduled, exit 1 |

A test asserts the declared grammar equals the option literals the detector reads, so the two cannot drift apart. The exit-2 path runs the real CLI.

## AC12 — the lists carry the entries the pages carry

Both timeline lists were built from the dated partition, so an entry with no effective date was absent from the structured data entirely. It now appears with **no `datePublished`**, and a dated entry in the same fixture keeps its own — the positive control.

Ordering matters more than it looks. Appending undated entries after the dated ones would satisfy "present in the list" and still hide every one of them behind a fifty-item cap that a backlog of dated entries fills on its own. The list is ordered by the date each entry carries, and a test with sixty dated entries and one discovery asserts the discovery survives the cap. The advertised total counts it.

## What the sweep found

The issue named two lists. Rendering **every route in the sitemap** against a fixture holding one undated entry found **65 routes** presenting its date as the day a vendor changed something:

- the risk-cause chip (one helper, ~25 routes) and the four prose sentences that quote it
- the structured pricing `Event`, whose `startDate` was the day we looked
- the offer and page metadata derived from the last pricing change, including `priceValidUntil`
- the report headline that names the latest tracked change
- the change chips on the alternatives, trends, stability and quarterly-report pages
- the payload the stack checker hands its own client

All now resolve through the one labelling helper or omit the date. The risk cause carries its provenance so a projection cannot silently lose it.

**Twelve routes remain, and each is a declared exemption** with a test asserting it is still in use: identifiers built from a vendor and a date, feed timestamps recording when we last touched an entry, page and dataset modification dates, and payloads that hand over the provenance beside the date. Naming them beats inferring them from the fact that they render.

## The sweep ships as a build-failing test

It is **differential** — every route is rendered three ways, with the entry dated, undated and absent — so a date the catalogue already publishes for its own reasons cannot be mistaken for a claim about the entry. It picks a fixture date that is not a reporting-period boundary and asserts it found one. It carries two positive controls: the same entry, dated, must produce bare dates on more than ten routes, and the undated one must be labelled on more than three. And it asserts the **mirror** property — an entry that has an effective date must never be labelled a discovery.

3,855 routes in 2.5 seconds.

## Two things the render diff caught that the tests did not

The mirror property is not decoration. Carrying the provenance through the risk cause missed one projection, and **1,389 routes started calling real dated changes discoveries**. The unit tests were green; the diff against `main` was not. That property is now asserted, and its mutation is in the pass.

The second was my own over-application: the free-tier tracker's entries are hand-written editorial facts, not change records, so the label does not apply to them. Reverted.

## Verified

- **1891 tests, 0 failures**, run twice, exit code captured directly. 25 new.
- **15 mutations, all killed** — `scripts/mutate-1074-ac11-ac12.sh`, committed and re-runnable.
- **3,919 routes rendered against `main` and diffed: exactly one differs**, and it is the stack-checker payload gaining the provenance field. On today's data every entry has an effective date, so nothing visible changes until the first sweep — which is what a pre-sweep guard should look like.
- Real MCP `initialize` → `tools/call`; the provenance reaches agents through both the risk cause and the change feed.
- Screenshot of a vendor page rendering an undated entry.
- `tsc` clean, data validation clean at 1,580 offers / 289 changes, 0 new code comments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
