### PR TITLE
Read a quoted flag by what the shell passes, and list every section /expiring counts

### DIFF
--- a/scripts/check-change-log-staleness.js
+++ b/scripts/check-change-log-staleness.js
@@ -31,10 +31,12 @@ export function tokenizeArgs(argText) {
     if (current) tokens.push(current);
     current = null;
   };
-  const add = (text, expands = false) => {
-    if (!current) current = { text: "", expands: false };
+  const add = (text, { expands = false, splittable = false, word = text } = {}) => {
+    if (!current) current = { text: "", word: "", expands: false, splittable: false };
     current.text += text;
+    current.word += word;
     if (expands) current.expands = true;
+    if (splittable) current.splittable = true;
   };
 
   let i = 0;
@@ -49,27 +51,27 @@ export function tokenizeArgs(argText) {
     } else if (argText.startsWith("${{", i)) {
       const end = argText.indexOf("}}", i + 3);
       const raw = end === -1 ? argText.slice(i) : argText.slice(i, end + 2);
-      add(raw, true);
+      add(raw, { expands: true, splittable: true });
       i += raw.length;
     } else if (ch === "'") {
       const end = argText.indexOf("'", i + 1);
       const raw = end === -1 ? argText.slice(i) : argText.slice(i, end + 1);
-      add(raw);
+      add(raw, { word: raw.slice(1, end === -1 ? undefined : -1) });
       i += raw.length;
     } else if (ch === '"') {
       let j = i + 1;
-      let raw = '"';
+      let inner = "";
       let expands = false;
       while (j < argText.length && argText[j] !== '"') {
         if (argText[j] === "$") expands = true;
-        raw += argText[j];
+        inner += argText[j];
         j += 1;
       }
-      if (j < argText.length) raw += '"';
-      add(raw, expands);
+      const closed = j < argText.length;
+      add(closed ? `"${inner}"` : `"${inner}`, { expands, word: inner });
       i = j + 1;
     } else if (ch === "$") {
-      add(ch, true);
+      add(ch, { expands: true, splittable: true });
       i += 1;
     } else {
       add(ch);
@@ -86,9 +88,9 @@ export function flagTokens(argText) {
   for (const token of tokenizeArgs(argText)) {
     if (consumingValue) {
       consumingValue = false;
-      continue;
+      if (token.expands && !token.splittable) continue;
     }
-    if (DETECTOR_CLI_OPTIONS.takesValue.includes(token.text)) consumingValue = true;
+    if (DETECTOR_CLI_OPTIONS.takesValue.includes(token.word)) consumingValue = true;
     flags.push(token);
   }
   return flags;
@@ -109,7 +111,9 @@ export function detectorSchedule(workflowYaml) {
         .join(", ")}`,
     };
   }
-  const withAi = invocations.filter((tokens) => tokens.some((token) => token.text === AI_FLAG));
+  const withAi = invocations.filter((tokens) =>
+    tokens.some((token) => !token.expands && token.word === AI_FLAG)
+  );
   if (withAi.length > 0 && withAi.length < invocations.length) {
     return {
       known: false,

--- a/scripts/mutate-1074-ac13.sh
+++ b/scripts/mutate-1074-ac13.sh
@@ -1,0 +1,134 @@
+#!/usr/bin/env bash
+set -uo pipefail
+cd "$(dirname "$0")/.."
+
+PASS=0
+FAIL=0
+
+run_mutation() {
+  local name="$1" file="$2" from="$3" to="$4" tests="$5"
+  cp "$file" "$file.bak"
+  if ! python3 - "$file" "$from" "$to" <<'PY'
+import sys, pathlib
+path, old, new = sys.argv[1], sys.argv[2], sys.argv[3]
+p = pathlib.Path(path)
+s = p.read_text()
+if s.count(old) != 1:
+    print(f"SKIP: pattern found {s.count(old)} times", file=sys.stderr)
+    sys.exit(3)
+p.write_text(s.replace(old, new))
+PY
+  then
+    echo "SKIP  $name (pattern stale)"
+    mv "$file.bak" "$file"
+    FAIL=$((FAIL + 1))
+    return
+  fi
+
+  node --test $tests > /tmp/mut-ac13.log 2>&1
+  local status=$?
+  mv "$file.bak" "$file"
+
+  if [ $status -ne 0 ]; then
+    echo "KILLED  $name"
+    PASS=$((PASS + 1))
+  else
+    echo "SURVIVED  $name  <-- $tests did not notice"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+run_built_mutation() {
+  local name="$1" file="$2" from="$3" to="$4" tests="$5"
+  cp "$file" "$file.bak"
+  if ! python3 - "$file" "$from" "$to" <<'PY'
+import sys, pathlib
+path, old, new = sys.argv[1], sys.argv[2], sys.argv[3]
+p = pathlib.Path(path)
+s = p.read_text()
+if s.count(old) != 1:
+    print(f"SKIP: pattern found {s.count(old)} times", file=sys.stderr)
+    sys.exit(3)
+p.write_text(s.replace(old, new))
+PY
+  then
+    echo "SKIP  $name (pattern stale)"
+    mv "$file.bak" "$file"
+    FAIL=$((FAIL + 1))
+    return
+  fi
+
+  if ! npm run build > /tmp/mut-ac13-build.log 2>&1; then
+    echo "SKIP  $name (build failed)"
+    mv "$file.bak" "$file"
+    npm run build > /dev/null 2>&1
+    FAIL=$((FAIL + 1))
+    return
+  fi
+
+  node --test $tests > /tmp/mut-ac13.log 2>&1
+  local status=$?
+  mv "$file.bak" "$file"
+  npm run build > /dev/null 2>&1
+
+  if [ $status -ne 0 ]; then
+    echo "KILLED  $name"
+    PASS=$((PASS + 1))
+  else
+    echo "SURVIVED  $name  <-- $tests did not notice"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+DETECTOR="scripts/check-change-log-staleness.js"
+WRITER="test/change-log-writer.test.ts"
+STRUCT="test/change-structured-data.test.ts"
+PROV="test/change-date-provenance.test.ts"
+
+run_mutation "single-quoted token keeps its quotes" "$DETECTOR" \
+  'add(raw, { word: raw.slice(1, end === -1 ? undefined : -1) });' \
+  'add(raw);' "$WRITER"
+
+run_mutation "double-quoted token keeps its quotes" "$DETECTOR" \
+  'add(closed ? `"${inner}"` : `"${inner}`, { expands, word: inner });' \
+  'add(closed ? `"${inner}"` : `"${inner}`, { expands });' "$WRITER"
+
+run_mutation "flag comparison reads the raw text again" "$DETECTOR" \
+  '!token.expands && token.word === AI_FLAG' \
+  'token.text === AI_FLAG' "$WRITER"
+
+run_mutation "option name compared before quote stripping" "$DETECTOR" \
+  'DETECTOR_CLI_OPTIONS.takesValue.includes(token.word)' \
+  'DETECTOR_CLI_OPTIONS.takesValue.includes(token.text)' "$WRITER"
+
+run_mutation "bare shell expansion cannot word-split" "$DETECTOR" \
+  'add(ch, { expands: true, splittable: true });' \
+  'add(ch, { expands: true });' "$WRITER"
+
+run_mutation "workflow expression cannot word-split" "$DETECTOR" \
+  'add(raw, { expands: true, splittable: true });' \
+  'add(raw, { expands: true });' "$WRITER"
+
+run_mutation "value position swallows a splittable token" "$DETECTOR" \
+  'if (token.expands && !token.splittable) continue;' \
+  'continue;' "$WRITER"
+
+run_mutation "value position swallows a literal flag" "$DETECTOR" \
+  'if (token.expands && !token.splittable) continue;' \
+  'if (!token.splittable) continue;' "$WRITER"
+
+run_built_mutation "expiring counts a section it never lists" src/serve.ts \
+  'itemListElement: capListSections([upcoming, recent, recentlyDiscovered], 50)' \
+  'itemListElement: [...upcoming, ...recentlyDiscovered].slice(0, 50)' "$STRUCT"
+
+run_built_mutation "no section is reserved a slot under the cap" src/change-dates.ts \
+  'allotted[i] = 1;' \
+  'allotted[i] = 0;' "$PROV"
+
+run_built_mutation "reserved slots are handed out to the earliest section instead" src/change-dates.ts \
+  'const take = Math.min(budget, sections[i].length - allotted[i]);' \
+  'const take = Math.min(budget, sections[i].length);' "$PROV"
+
+echo
+echo "killed $PASS, survived/skipped $FAIL"
+[ "$FAIL" -eq 0 ]

--- a/src/change-dates.ts
+++ b/src/change-dates.ts
@@ -44,6 +44,22 @@ export function changeEventStartDate(c: DatedChange): { startDate: string } | Re
   return isEventDated(c) ? { startDate: c.date } : {};
 }
 
+export function capListSections<T>(sections: T[][], cap: number): T[] {
+  const allotted = sections.map(() => 0);
+  let budget = cap;
+  for (let i = 0; i < sections.length && budget > 0; i++) {
+    if (sections[i].length === 0) continue;
+    allotted[i] = 1;
+    budget -= 1;
+  }
+  for (let i = 0; i < sections.length && budget > 0; i++) {
+    const take = Math.min(budget, sections[i].length - allotted[i]);
+    allotted[i] += take;
+    budget -= take;
+  }
+  return sections.flatMap((section, i) => section.slice(0, allotted[i]));
+}
+
 export function latestEventDate(changes: DatedChange[], notAfter?: string): string | null {
   let latest: string | null = null;
   for (const c of changes) {

--- a/src/serve.ts
+++ b/src/serve.ts
@@ -31,7 +31,7 @@ import { rankOffers, rankForListing, rotateListing, utcDate, CRITERIA_PATH, DEMO
 import type { RankedEntry, RankingResult } from "./ranking.js";
 import { partitionAlternatives, partitionAlternativesAcross, productRoleSentence, MEMBERSHIP_GATE_RULES, MEMBERSHIP_GATE_ORDER, MEMBERSHIP_GATE_SYMMETRY, MEMBERSHIP_GATE_SCOPE, MEMBERSHIP_GATE_CORRECTIONS } from "./product-role.js";
 import type { Agent, ChangeDateSource, DealChange, RiskCause, LinkUnreachable } from "./types.js";
-import { changeDateLabel, changeDateClause, changeDatePublished, changeEventStartDate, latestEventDate, undatedGroupHeading, DISCOVERED_DATE_PREFIX, UNDATED_GROUP_NOTE } from "./change-dates.js";
+import { changeDateLabel, changeDateClause, changeDatePublished, changeEventStartDate, capListSections, latestEventDate, undatedGroupHeading, DISCOVERED_DATE_PREFIX, UNDATED_GROUP_NOTE } from "./change-dates.js";
 import type { AgentBalance } from "./ledger.js";
 import type { SubmittedReferralCode } from "./referral-codes.js";
 
@@ -50470,7 +50470,7 @@ ${entriesHtml}
     description: metaDesc,
     numberOfItems: totalUpcoming + recent.length + recentlyDiscovered.length,
     url: `${BASE_URL}/expiring`,
-    itemListElement: [...upcoming, ...recentlyDiscovered].slice(0, 50).map((c, i) => ({
+    itemListElement: capListSections([upcoming, recent, recentlyDiscovered], 50).map((c, i) => ({
       "@type": "ListItem",
       position: i + 1,
       item: {

--- a/test/change-date-provenance.test.ts
+++ b/test/change-date-provenance.test.ts
@@ -13,6 +13,7 @@ import {
   EVENT_DATED_SOURCES,
 } from "../dist/data.js";
 import {
+  capListSections,
   changeDateLabel,
   changeDatePublished,
   undatedGroupHeading,
@@ -445,5 +446,32 @@ describe("no surface renders a discovery date as the date the vendor changed som
       !deadlines.some((d: any) => d.vendor === SUBJECT),
       "a change with no known effective date was published as an upcoming deadline"
     );
+  });
+});
+
+describe("capping a list built from several sections", () => {
+  const big = (prefix: string, n: number) => Array.from({ length: n }, (_, i) => `${prefix}${i}`);
+
+  it("keeps every section in the order the page renders them when everything fits", () => {
+    assert.deepStrictEqual(capListSections([["a"], ["b", "c"], ["d"]], 50), ["a", "b", "c", "d"]);
+  });
+
+  it("leaves no non-empty section unrepresented once the cap bites", () => {
+    const capped = capListSections([big("up", 60), big("recent", 40), ["discovery"]], 50);
+    assert.strictEqual(capped.length, 50);
+    assert.ok(capped.includes("recent0"), "a whole section was crowded out of the capped list");
+    assert.ok(capped.includes("discovery"), "the last section was crowded out of the capped list");
+  });
+
+  it("skips empty sections rather than reserving them a slot", () => {
+    assert.deepStrictEqual(capListSections([["a", "b"], [], ["c"]], 2), ["a", "c"]);
+  });
+
+  it("spends the whole cap when the sections fit inside it exactly", () => {
+    assert.deepStrictEqual(capListSections([["a", "b"], ["c", "d"]], 4), ["a", "b", "c", "d"]);
+  });
+
+  it("fills the earlier sections first with whatever the reservations leave", () => {
+    assert.deepStrictEqual(capListSections([big("up", 5), big("recent", 5)], 4), ["up0", "up1", "up2", "recent0"]);
   });
 });

--- a/test/change-log-writer.test.ts
+++ b/test/change-log-writer.test.ts
@@ -561,6 +561,61 @@ describe("reading the detector's schedule out of the workflow", () => {
     assert.deepStrictEqual({ known: off.known, scheduled: off.scheduled }, { known: true, scheduled: false });
   });
 
+  it("reads a quoted flag by what the shell passes, not by the quotes around it", () => {
+    for (const cmd of [
+      "node scripts/reverify-rolling.js --limit 50 '--ai'",
+      'node scripts/reverify-rolling.js --limit 50 "--ai"',
+    ]) {
+      const schedule = detectorSchedule(withCommand(cmd));
+      assert.deepStrictEqual(
+        { known: schedule.known, scheduled: schedule.scheduled },
+        { known: true, scheduled: true },
+        cmd
+      );
+    }
+  });
+
+  it("reads a quoted option name too, so the expansion after it is still a value", () => {
+    const schedule = detectorSchedule(withCommand("node scripts/reverify-rolling.js '--limit' \"$LIMIT\""));
+    assert.deepStrictEqual(
+      { known: schedule.known, scheduled: schedule.scheduled },
+      { known: true, scheduled: false }
+    );
+  });
+
+  it("sees a literal flag standing where a value would go, because the detector scans every argument", () => {
+    const source = readFileSync(path.join(REPO, "scripts", "reverify-rolling.js"), "utf-8");
+    assert.match(
+      source,
+      /args\.includes\("--ai"\)/,
+      "the detector no longer scans every argument for --ai, so this expectation needs rewriting"
+    );
+    const schedule = detectorSchedule(withCommand("node scripts/reverify-rolling.js --limit --ai"));
+    assert.deepStrictEqual(
+      { known: schedule.known, scheduled: schedule.scheduled },
+      { known: true, scheduled: true }
+    );
+  });
+
+  it("refuses on an unquoted expansion in value position, which the shell can split into two arguments", () => {
+    for (const cmd of [
+      "node scripts/reverify-rolling.js --limit $AI_FLAG",
+      "node scripts/reverify-rolling.js --limit ${{ inputs.limit }}",
+    ]) {
+      assert.strictEqual(detectorSchedule(withCommand(cmd)).known, false, cmd);
+    }
+  });
+
+  it("keeps answering for a quoted expansion in value position, which cannot split", () => {
+    const schedule = detectorSchedule(
+      withCommand('node scripts/reverify-rolling.js --limit "${{ inputs.limit }}"')
+    );
+    assert.deepStrictEqual(
+      { known: schedule.known, scheduled: schedule.scheduled },
+      { known: true, scheduled: false }
+    );
+  });
+
   it("stops reading at the pipe, so what the log is written to cannot decide this", () => {
     const schedule = detectorSchedule(
       withCommand('node scripts/reverify-rolling.js --limit "$LIMIT" | tee "$LOGFILE"')
@@ -571,10 +626,18 @@ describe("reading the detector's schedule out of the workflow", () => {
     );
   });
 
-  it("treats an option's value as a value and everything else as a possible flag", () => {
+  it("drops an option's value only when it is an expansion that cannot split", () => {
     assert.deepStrictEqual(
       flagTokens(' --limit "$LIMIT" --ai').map((t: { text: string }) => t.text),
       ["--limit", "--ai"]
+    );
+    assert.deepStrictEqual(
+      flagTokens(" --limit 50 --ai").map((t: { text: string }) => t.text),
+      ["--limit", "50", "--ai"]
+    );
+    assert.deepStrictEqual(
+      flagTokens(" --limit $AI_FLAG").map((t: { text: string }) => t.text),
+      ["--limit", "$AI_FLAG"]
     );
   });
 

--- a/test/change-structured-data.test.ts
+++ b/test/change-structured-data.test.ts
@@ -15,6 +15,8 @@ const dayOffset = (days: number) =>
 
 const UPCOMING = "Fauna";
 const UPCOMING_DATE = dayOffset(20);
+const RECENT = "Neon";
+const RECENT_DATE = dayOffset(-5);
 const DISCOVERY = "Xata";
 const BACKLOG_SIZE = 60;
 const LIST_CAP = 50;
@@ -44,6 +46,7 @@ function fixtureChanges() {
   return [
     ...backlog,
     change(UPCOMING, UPCOMING_DATE, "vendor_page"),
+    change(RECENT, RECENT_DATE, "vendor_page"),
     { ...change(DISCOVERY, TODAY, "discovered"), detected_by: "reverify-ai" },
   ];
 }
@@ -138,8 +141,17 @@ describe("the machine-readable change lists carry the entries the pages carry", 
 
   it("counts the entry it could not date in the total it advertises", () => {
     const list = changeList(bodies.get("/expiring")!, "/expiring");
-    assert.strictEqual(list.items.length, 2);
-    assert.strictEqual(list.numberOfItems, 2);
+    assert.strictEqual(list.items.length, 3);
+    assert.strictEqual(list.numberOfItems, 3);
+  });
+
+  it("gives /expiring's structured data every section its page renders, not only the two it listed", () => {
+    const body = bodies.get("/expiring")!;
+    for (const heading of ["Recently Changed", "Recently Discovered"]) {
+      assert.ok(body.includes(heading), `/expiring did not render its ${heading} section, so the list below proves nothing`);
+    }
+    const list = changeList(body, "/expiring");
+    for (const vendor of [UPCOMING, RECENT, DISCOVERY]) itemFor(list, vendor, "/expiring");
   });
 
   it("does not let a backlog of dated entries crowd a new discovery out of the list", () => {


### PR DESCRIPTION
## AC13 — a quoted literal flag was producing a definite wrong answer

The tokeniser honoured quotes as word boundaries but kept them in the token text, and the comparison was against that text. So `'--ai'` and `"--ai"` both answered **detector off** while the shell was passing `--ai`. That is the one outcome AC11 exists to prevent — not undecidable, wrong — and it fails toward silence, because "off" swaps the staleness gate for the absence marker.

Each token now carries its **shell word** beside its raw text, and the flag comparison reads the word. Same for the option name, so `'--limit' "$LIMIT"` still consumes its value.

### Value position, split three ways

A token in value position is dropped **only when it is an expansion that cannot word-split**:

| shape | value token | treated as | answer |
|---|---|---|---|
| `--limit "$LIMIT"` | quoted expansion | one argument, not a flag | exit 0 |
| `--limit "${{ inputs.limit }}"` | quoted expansion | one argument, not a flag | exit 0 |
| `--limit $AI_FLAG` | unquoted expansion | can split into `50 --ai` | exit 2 |
| `--limit ${{ inputs.limit }}` | unquoted expansion | can split | exit 2 |
| `--limit 50` | literal | candidate flag, is not `--ai` | exit 0 |
| `--limit --ai` | literal | candidate flag, **is** `--ai` | exit 1 |

The last row is not in the acceptance criteria and it is the same class. `reverify-rolling.js` reads `args.includes("--ai")` — position-blind — so a literal `--ai` standing in value position **does** turn the detector on, and the reader was saying off. Keeping a literal in value position as a candidate flag is what makes the reader agree with the parser it is modelling. A test asserts `args.includes("--ai")` is still how the detector reads its own flag, so this expectation cannot outlive the thing it mirrors.

Dropping the redundant `&& !token.expands` from the option-name check came out of the mutation run: an expanding token in flag position already forces `known:false`, so the second guard could never be observed failing.

### Every declared shape, run against the real CLI

```
--limit "$LIMIT"                                           exit=0  does not pass --ai
--limit "$LIMIT" $AI_FLAG                                  exit=2  CANNOT TELL — names $AI_FLAG
--limit "$LIMIT" ${{ inputs.mode == 'ai' && '--ai' || '' }} exit=2  CANNOT TELL — names the expression
--ai --limit "$LIMIT"                                      exit=1  scheduled, STALE fires
--limit 50 '--ai'                                          exit=1  scheduled, STALE fires
--limit 50 "--ai"                                          exit=1  scheduled, STALE fires
--limit $AI_FLAG                                           exit=2  CANNOT TELL — names $AI_FLAG
--limit ${{ inputs.limit }}                                exit=2  CANNOT TELL — names the expression
--limit "${{ inputs.limit }}"                              exit=0  does not pass --ai
'--limit' 50 --ai                                          exit=1  scheduled, STALE fires
'--limit' "$LIMIT"                                         exit=0  does not pass --ai
--limit --ai                                               exit=1  scheduled, STALE fires
```

The four AC11 rows are unchanged, so the shipped workflow still exits 0 and the ruling still holds.

## `/expiring` counted a section it never listed

`numberOfItems` summed upcoming + recent + recentlyDiscovered while `itemListElement` was `[...upcoming, ...recentlyDiscovered]`. On production that was 3 against 2 — the **Recently Changed** section, which is the one place a model reading `/expiring` learns a change already happened.

Listed rather than un-counted, per the recommendation on the issue.

The ordering is the part that needed care, and it is AC12's lesson again: inserting `recent` between the other two pushes discoveries toward a 50-item cap that `upcoming` and `recent` can fill on their own. `capListSections` builds the list in the order the page renders its sections and **reserves one slot for each non-empty section** before filling the rest in order, so no section can be crowded out. It spends the whole cap when the sections fit.

## Verification

- **1902 tests / 0 failures**, exit code captured directly. 11 new.
- **11 mutations, all killed** — `scripts/mutate-1074-ac13.sh`. Two survivors on the first two rounds were both real gaps: the redundant guard above, and a `capListSections` test whose numbers made the arithmetic mutation invisible.
- **3,914 sitemap routes rendered against a `main` worktree and diffed: exactly one differs.** `/expiring`, one line, and the line is the JSON-LD gaining the `OpenAI: removed` entry it was already counting.
- `/expiring` on real data now reports `numberOfItems: 3` against 3 listed items, was 3 against 2.
- `tsc` clean. 0 new code comments.

Refs #1074
