### PR TITLE
AC-A: hold the number of tier-A pages asserting vendor facts from no record

### DIFF
--- a/data/page-reviews.json
+++ b/data/page-reviews.json
@@ -13,7 +13,11 @@
       "badge_subjects_unresolved": [],
       "reviewed_at": null,
       "reviewer": null,
-      "reads_index": true
+      "review_outcome": null,
+      "reads_index": true,
+      "reads_changes": false,
+      "data_source": "catalogue",
+      "data_source_reason": null
     },
     {
       "path": "/agent-stack",
@@ -23,7 +27,11 @@
       "badge_subjects_unresolved": [],
       "reviewed_at": null,
       "reviewer": null,
-      "reads_index": true
+      "review_outcome": null,
+      "reads_index": true,
+      "reads_changes": false,
+      "data_source": "catalogue",
+      "data_source_reason": null
     },
     {
       "path": "/ai-coding-pricing-2026",
@@ -41,7 +49,11 @@
       "badge_subjects_unresolved": [],
       "reviewed_at": null,
       "reviewer": null,
-      "reads_index": false
+      "review_outcome": null,
+      "reads_index": false,
+      "reads_changes": true,
+      "data_source": "unsourced",
+      "data_source_reason": null
     },
     {
       "path": "/ai-coding-tools-pricing",
@@ -64,7 +76,11 @@
       "badge_subjects_unresolved": [],
       "reviewed_at": null,
       "reviewer": null,
-      "reads_index": false
+      "review_outcome": null,
+      "reads_index": false,
+      "reads_changes": true,
+      "data_source": "unsourced",
+      "data_source_reason": null
     },
     {
       "path": "/analytics-free-tier-comparison-2026",
@@ -81,7 +97,11 @@
       "badge_subjects_unresolved": [],
       "reviewed_at": null,
       "reviewer": null,
-      "reads_index": false
+      "review_outcome": null,
+      "reads_index": false,
+      "reads_changes": true,
+      "data_source": "unsourced",
+      "data_source_reason": null
     },
     {
       "path": "/api-development-free-tier-comparison-2026",
@@ -97,7 +117,11 @@
       "badge_subjects_unresolved": [],
       "reviewed_at": null,
       "reviewer": null,
-      "reads_index": false
+      "review_outcome": null,
+      "reads_index": false,
+      "reads_changes": true,
+      "data_source": "unsourced",
+      "data_source_reason": null
     },
     {
       "path": "/auth-comparison-2026",
@@ -119,7 +143,11 @@
       "badge_subjects_unresolved": [],
       "reviewed_at": null,
       "reviewer": null,
-      "reads_index": false
+      "review_outcome": null,
+      "reads_index": false,
+      "reads_changes": true,
+      "data_source": "unsourced",
+      "data_source_reason": null
     },
     {
       "path": "/aws-app-runner-migration",
@@ -137,7 +165,11 @@
       "badge_subjects_unresolved": [],
       "reviewed_at": null,
       "reviewer": null,
-      "reads_index": false
+      "review_outcome": null,
+      "reads_index": false,
+      "reads_changes": true,
+      "data_source": "unsourced",
+      "data_source_reason": null
     },
     {
       "path": "/aws-free-tier-2026",
@@ -153,7 +185,11 @@
       "badge_subjects_unresolved": [],
       "reviewed_at": null,
       "reviewer": null,
-      "reads_index": false
+      "review_outcome": null,
+      "reads_index": false,
+      "reads_changes": true,
+      "data_source": "unsourced",
+      "data_source_reason": null
     },
     {
       "path": "/azure-free-tier-2026",
@@ -166,7 +202,11 @@
       "badge_subjects_unresolved": [],
       "reviewed_at": null,
       "reviewer": null,
-      "reads_index": false
+      "review_outcome": null,
+      "reads_index": false,
+      "reads_changes": true,
+      "data_source": "unsourced",
+      "data_source_reason": null
     },
     {
       "path": "/budget-builder",
@@ -176,7 +216,11 @@
       "badge_subjects_unresolved": [],
       "reviewed_at": null,
       "reviewer": null,
-      "reads_index": false
+      "review_outcome": null,
+      "reads_index": false,
+      "reads_changes": true,
+      "data_source": "editorial",
+      "data_source_reason": "a cost calculator: every figure on it is arithmetic on what the reader typed in"
     },
     {
       "path": "/ci-cd-pricing",
@@ -201,7 +245,11 @@
       "badge_subjects_unresolved": [],
       "reviewed_at": null,
       "reviewer": null,
-      "reads_index": false
+      "review_outcome": null,
+      "reads_index": false,
+      "reads_changes": true,
+      "data_source": "unsourced",
+      "data_source_reason": null
     },
     {
       "path": "/cicd-free-tier-comparison-2026",
@@ -219,7 +267,11 @@
       "badge_subjects_unresolved": [],
       "reviewed_at": null,
       "reviewer": null,
-      "reads_index": false
+      "review_outcome": null,
+      "reads_index": false,
+      "reads_changes": true,
+      "data_source": "unsourced",
+      "data_source_reason": null
     },
     {
       "path": "/cloud-free-tier-comparison-2026",
@@ -234,7 +286,11 @@
       "badge_subjects_unresolved": [],
       "reviewed_at": null,
       "reviewer": null,
-      "reads_index": false
+      "review_outcome": null,
+      "reads_index": false,
+      "reads_changes": true,
+      "data_source": "unsourced",
+      "data_source_reason": null
     },
     {
       "path": "/compare-tool",
@@ -244,7 +300,11 @@
       "badge_subjects_unresolved": [],
       "reviewed_at": null,
       "reviewer": null,
-      "reads_index": false
+      "review_outcome": null,
+      "reads_index": false,
+      "reads_changes": false,
+      "data_source": "editorial",
+      "data_source_reason": "a picker that links to comparison pages and asserts nothing about any vendor itself"
     },
     {
       "path": "/dall-e-shutdown",
@@ -260,7 +320,11 @@
       "badge_subjects_unresolved": [],
       "reviewed_at": null,
       "reviewer": null,
-      "reads_index": false
+      "review_outcome": null,
+      "reads_index": false,
+      "reads_changes": true,
+      "data_source": "unsourced",
+      "data_source_reason": null
     },
     {
       "path": "/database-free-tier-comparison-2026",
@@ -278,7 +342,11 @@
       "badge_subjects_unresolved": [],
       "reviewed_at": null,
       "reviewer": null,
-      "reads_index": false
+      "review_outcome": null,
+      "reads_index": false,
+      "reads_changes": true,
+      "data_source": "unsourced",
+      "data_source_reason": null
     },
     {
       "path": "/database-pricing",
@@ -301,7 +369,11 @@
       "badge_subjects_unresolved": [],
       "reviewed_at": null,
       "reviewer": null,
-      "reads_index": false
+      "review_outcome": null,
+      "reads_index": false,
+      "reads_changes": true,
+      "data_source": "unsourced",
+      "data_source_reason": null
     },
     {
       "path": "/datadog-vs-new-relic",
@@ -315,7 +387,11 @@
       "badge_subjects_unresolved": [],
       "reviewed_at": null,
       "reviewer": null,
-      "reads_index": true
+      "review_outcome": null,
+      "reads_index": true,
+      "reads_changes": false,
+      "data_source": "catalogue",
+      "data_source_reason": null
     },
     {
       "path": "/digitalocean-free-tier-2026",
@@ -331,7 +407,11 @@
       "badge_subjects_unresolved": [],
       "reviewed_at": null,
       "reviewer": null,
-      "reads_index": false
+      "review_outcome": null,
+      "reads_index": false,
+      "reads_changes": true,
+      "data_source": "unsourced",
+      "data_source_reason": null
     },
     {
       "path": "/disclosure",
@@ -341,7 +421,11 @@
       "badge_subjects_unresolved": [],
       "reviewed_at": null,
       "reviewer": null,
-      "reads_index": false
+      "review_outcome": null,
+      "reads_index": false,
+      "reads_changes": false,
+      "data_source": "editorial",
+      "data_source_reason": "states how we are paid and links our policies; names no vendor"
     },
     {
       "path": "/email-comparison-2026",
@@ -358,9 +442,13 @@
         "sendgrid"
       ],
       "badge_subjects_unresolved": [],
-      "reviewed_at": "2026-08-26",
+      "reviewed_at": "2026-08-27",
       "reviewer": "coder",
-      "reads_index": false
+      "review_outcome": "fail",
+      "reads_index": false,
+      "reads_changes": true,
+      "data_source": "unsourced",
+      "data_source_reason": null
     },
     {
       "path": "/firebase-studio-shutdown",
@@ -377,7 +465,11 @@
       "badge_subjects_unresolved": [],
       "reviewed_at": null,
       "reviewer": null,
-      "reads_index": false
+      "review_outcome": null,
+      "reads_index": false,
+      "reads_changes": true,
+      "data_source": "unsourced",
+      "data_source_reason": null
     },
     {
       "path": "/free-ai-stack",
@@ -398,7 +490,11 @@
       "badge_subjects_unresolved": [],
       "reviewed_at": null,
       "reviewer": null,
-      "reads_index": true
+      "review_outcome": null,
+      "reads_index": true,
+      "reads_changes": true,
+      "data_source": "catalogue",
+      "data_source_reason": null
     },
     {
       "path": "/free-devops-stack",
@@ -419,7 +515,11 @@
       "badge_subjects_unresolved": [],
       "reviewed_at": null,
       "reviewer": null,
-      "reads_index": true
+      "review_outcome": null,
+      "reads_index": true,
+      "reads_changes": true,
+      "data_source": "catalogue",
+      "data_source_reason": null
     },
     {
       "path": "/free-django-stack",
@@ -439,7 +539,11 @@
       "badge_subjects_unresolved": [],
       "reviewed_at": null,
       "reviewer": null,
-      "reads_index": true
+      "review_outcome": null,
+      "reads_index": true,
+      "reads_changes": true,
+      "data_source": "catalogue",
+      "data_source_reason": null
     },
     {
       "path": "/free-fastapi-stack",
@@ -458,7 +562,11 @@
       "badge_subjects_unresolved": [],
       "reviewed_at": null,
       "reviewer": null,
-      "reads_index": true
+      "review_outcome": null,
+      "reads_index": true,
+      "reads_changes": true,
+      "data_source": "catalogue",
+      "data_source_reason": null
     },
     {
       "path": "/free-frontend-stack",
@@ -478,7 +586,11 @@
       "badge_subjects_unresolved": [],
       "reviewed_at": null,
       "reviewer": null,
-      "reads_index": true
+      "review_outcome": null,
+      "reads_index": true,
+      "reads_changes": true,
+      "data_source": "catalogue",
+      "data_source_reason": null
     },
     {
       "path": "/free-go-stack",
@@ -497,7 +609,11 @@
       "badge_subjects_unresolved": [],
       "reviewed_at": null,
       "reviewer": null,
-      "reads_index": true
+      "review_outcome": null,
+      "reads_index": true,
+      "reads_changes": true,
+      "data_source": "catalogue",
+      "data_source_reason": null
     },
     {
       "path": "/free-nextjs-stack",
@@ -518,7 +634,11 @@
       "badge_subjects_unresolved": [],
       "reviewed_at": null,
       "reviewer": null,
-      "reads_index": true
+      "review_outcome": null,
+      "reads_index": true,
+      "reads_changes": true,
+      "data_source": "catalogue",
+      "data_source_reason": null
     },
     {
       "path": "/free-saas-stack",
@@ -538,7 +658,11 @@
       "badge_subjects_unresolved": [],
       "reviewed_at": null,
       "reviewer": null,
-      "reads_index": true
+      "review_outcome": null,
+      "reads_index": true,
+      "reads_changes": true,
+      "data_source": "catalogue",
+      "data_source_reason": null
     },
     {
       "path": "/free-startup-stack",
@@ -559,7 +683,11 @@
       "badge_subjects_unresolved": [],
       "reviewed_at": null,
       "reviewer": null,
-      "reads_index": true
+      "review_outcome": null,
+      "reads_index": true,
+      "reads_changes": true,
+      "data_source": "catalogue",
+      "data_source_reason": null
     },
     {
       "path": "/free-tier-risk",
@@ -579,7 +707,11 @@
       "badge_subjects_unresolved": [],
       "reviewed_at": "2026-04-08",
       "reviewer": "content revision",
-      "reads_index": false
+      "review_outcome": null,
+      "reads_index": false,
+      "reads_changes": false,
+      "data_source": "unsourced",
+      "data_source_reason": null
     },
     {
       "path": "/free-tier-tracker",
@@ -603,7 +735,11 @@
       "badge_subjects_unresolved": [],
       "reviewed_at": null,
       "reviewer": null,
-      "reads_index": false
+      "review_outcome": null,
+      "reads_index": false,
+      "reads_changes": true,
+      "data_source": "unsourced",
+      "data_source_reason": null
     },
     {
       "path": "/gcp-free-tier-2026",
@@ -617,7 +753,11 @@
       "badge_subjects_unresolved": [],
       "reviewed_at": null,
       "reviewer": null,
-      "reads_index": false
+      "review_outcome": null,
+      "reads_index": false,
+      "reads_changes": true,
+      "data_source": "unsourced",
+      "data_source_reason": null
     },
     {
       "path": "/gemini-api-pricing-2026",
@@ -630,7 +770,11 @@
       "badge_subjects_unresolved": [],
       "reviewed_at": "2026-04-02",
       "reviewer": "content revision",
-      "reads_index": false
+      "review_outcome": null,
+      "reads_index": false,
+      "reads_changes": true,
+      "data_source": "unsourced",
+      "data_source_reason": null
     },
     {
       "path": "/gemini-api-pricing-changes",
@@ -642,7 +786,11 @@
       "badge_subjects_unresolved": [],
       "reviewed_at": null,
       "reviewer": null,
-      "reads_index": false
+      "review_outcome": null,
+      "reads_index": false,
+      "reads_changes": true,
+      "data_source": "unsourced",
+      "data_source_reason": null
     },
     {
       "path": "/google-developer-program-2026",
@@ -660,7 +808,11 @@
       "badge_subjects_unresolved": [],
       "reviewed_at": null,
       "reviewer": null,
-      "reads_index": false
+      "review_outcome": null,
+      "reads_index": false,
+      "reads_changes": true,
+      "data_source": "unsourced",
+      "data_source_reason": null
     },
     {
       "path": "/hcp-terraform-migration",
@@ -674,7 +826,11 @@
       "badge_subjects_unresolved": [],
       "reviewed_at": null,
       "reviewer": null,
-      "reads_index": true
+      "review_outcome": null,
+      "reads_index": true,
+      "reads_changes": true,
+      "data_source": "catalogue",
+      "data_source_reason": null
     },
     {
       "path": "/hetzner-pricing-2026",
@@ -687,7 +843,11 @@
       "badge_subjects_unresolved": [],
       "reviewed_at": null,
       "reviewer": null,
-      "reads_index": false
+      "review_outcome": null,
+      "reads_index": false,
+      "reads_changes": false,
+      "data_source": "unsourced",
+      "data_source_reason": null
     },
     {
       "path": "/hosting-free-tier-comparison-2026",
@@ -708,7 +868,11 @@
       "badge_subjects_unresolved": [],
       "reviewed_at": null,
       "reviewer": null,
-      "reads_index": false
+      "review_outcome": null,
+      "reads_index": false,
+      "reads_changes": true,
+      "data_source": "unsourced",
+      "data_source_reason": null
     },
     {
       "path": "/hosting-pricing",
@@ -729,7 +893,11 @@
       "badge_subjects_unresolved": [],
       "reviewed_at": null,
       "reviewer": null,
-      "reads_index": false
+      "review_outcome": null,
+      "reads_index": false,
+      "reads_changes": true,
+      "data_source": "unsourced",
+      "data_source_reason": null
     },
     {
       "path": "/llm-api-pricing",
@@ -753,7 +921,11 @@
       "badge_subjects_unresolved": [],
       "reviewed_at": null,
       "reviewer": null,
-      "reads_index": false
+      "review_outcome": null,
+      "reads_index": false,
+      "reads_changes": true,
+      "data_source": "unsourced",
+      "data_source_reason": null
     },
     {
       "path": "/marketplace",
@@ -763,7 +935,11 @@
       "badge_subjects_unresolved": [],
       "reviewed_at": null,
       "reviewer": null,
-      "reads_index": false
+      "review_outcome": null,
+      "reads_index": false,
+      "reads_changes": false,
+      "data_source": "editorial",
+      "data_source_reason": "describes our own referral programme; its tables are our code quotas and revenue splits, not vendor terms"
     },
     {
       "path": "/monitoring-comparison-2026",
@@ -786,7 +962,11 @@
       "badge_subjects_unresolved": [],
       "reviewed_at": null,
       "reviewer": null,
-      "reads_index": false
+      "review_outcome": null,
+      "reads_index": false,
+      "reads_changes": true,
+      "data_source": "unsourced",
+      "data_source_reason": null
     },
     {
       "path": "/neon-vs-supabase",
@@ -803,7 +983,11 @@
       "badge_subjects_unresolved": [],
       "reviewed_at": null,
       "reviewer": null,
-      "reads_index": true
+      "review_outcome": null,
+      "reads_index": true,
+      "reads_changes": true,
+      "data_source": "catalogue",
+      "data_source_reason": null
     },
     {
       "path": "/openai-assistants-alternatives",
@@ -822,7 +1006,11 @@
       "badge_subjects_unresolved": [],
       "reviewed_at": null,
       "reviewer": null,
-      "reads_index": false
+      "review_outcome": null,
+      "reads_index": false,
+      "reads_changes": true,
+      "data_source": "unsourced",
+      "data_source_reason": null
     },
     {
       "path": "/openai-assistants-migration",
@@ -836,7 +1024,11 @@
       "badge_subjects_unresolved": [],
       "reviewed_at": null,
       "reviewer": null,
-      "reads_index": false
+      "review_outcome": null,
+      "reads_index": false,
+      "reads_changes": true,
+      "data_source": "unsourced",
+      "data_source_reason": null
     },
     {
       "path": "/openai-assistants-migration-2026",
@@ -849,7 +1041,11 @@
       "badge_subjects_unresolved": [],
       "reviewed_at": null,
       "reviewer": null,
-      "reads_index": false
+      "review_outcome": null,
+      "reads_index": false,
+      "reads_changes": true,
+      "data_source": "unsourced",
+      "data_source_reason": null
     },
     {
       "path": "/openai-realtime-migration",
@@ -865,7 +1061,11 @@
       "badge_subjects_unresolved": [],
       "reviewed_at": null,
       "reviewer": null,
-      "reads_index": false
+      "review_outcome": null,
+      "reads_index": false,
+      "reads_changes": true,
+      "data_source": "unsourced",
+      "data_source_reason": null
     },
     {
       "path": "/q1-2026-developer-pricing-report",
@@ -877,7 +1077,11 @@
       "badge_subjects_unresolved": [],
       "reviewed_at": null,
       "reviewer": null,
-      "reads_index": false
+      "review_outcome": null,
+      "reads_index": false,
+      "reads_changes": true,
+      "data_source": "unsourced",
+      "data_source_reason": null
     },
     {
       "path": "/q2-pricing-preview-2026",
@@ -893,7 +1097,11 @@
       "badge_subjects_unresolved": [],
       "reviewed_at": null,
       "reviewer": null,
-      "reads_index": false
+      "review_outcome": null,
+      "reads_index": false,
+      "reads_changes": true,
+      "data_source": "unsourced",
+      "data_source_reason": null
     },
     {
       "path": "/railway-vs-render",
@@ -907,7 +1115,11 @@
       "badge_subjects_unresolved": [],
       "reviewed_at": null,
       "reviewer": null,
-      "reads_index": true
+      "review_outcome": null,
+      "reads_index": true,
+      "reads_changes": true,
+      "data_source": "catalogue",
+      "data_source_reason": null
     },
     {
       "path": "/security-free-tier-comparison-2026",
@@ -923,7 +1135,11 @@
       "badge_subjects_unresolved": [],
       "reviewed_at": null,
       "reviewer": null,
-      "reads_index": false
+      "review_outcome": null,
+      "reads_index": false,
+      "reads_changes": true,
+      "data_source": "unsourced",
+      "data_source_reason": null
     },
     {
       "path": "/serverless-free-tier-comparison-2026",
@@ -943,7 +1159,11 @@
       "badge_subjects_unresolved": [],
       "reviewed_at": null,
       "reviewer": null,
-      "reads_index": false
+      "review_outcome": null,
+      "reads_index": false,
+      "reads_changes": true,
+      "data_source": "unsourced",
+      "data_source_reason": null
     },
     {
       "path": "/shutdowns",
@@ -953,7 +1173,11 @@
       "badge_subjects_unresolved": [],
       "reviewed_at": null,
       "reviewer": null,
-      "reads_index": false
+      "review_outcome": null,
+      "reads_index": false,
+      "reads_changes": true,
+      "data_source": "unsourced",
+      "data_source_reason": null
     },
     {
       "path": "/stack-check",
@@ -963,7 +1187,11 @@
       "badge_subjects_unresolved": [],
       "reviewed_at": null,
       "reviewer": null,
-      "reads_index": true
+      "review_outcome": null,
+      "reads_index": true,
+      "reads_changes": true,
+      "data_source": "catalogue",
+      "data_source_reason": null
     },
     {
       "path": "/startup-credits",
@@ -973,7 +1201,11 @@
       "badge_subjects_unresolved": [],
       "reviewed_at": "2026-04-13",
       "reviewer": "content revision",
-      "reads_index": false
+      "review_outcome": null,
+      "reads_index": false,
+      "reads_changes": true,
+      "data_source": "unsourced",
+      "data_source_reason": null
     },
     {
       "path": "/state-of-free-tiers",
@@ -983,7 +1215,11 @@
       "badge_subjects_unresolved": [],
       "reviewed_at": null,
       "reviewer": null,
-      "reads_index": true
+      "review_outcome": null,
+      "reads_index": true,
+      "reads_changes": true,
+      "data_source": "catalogue",
+      "data_source_reason": null
     },
     {
       "path": "/storage-comparison-2026",
@@ -1000,7 +1236,11 @@
       "badge_subjects_unresolved": [],
       "reviewed_at": null,
       "reviewer": null,
-      "reads_index": false
+      "review_outcome": null,
+      "reads_index": false,
+      "reads_changes": true,
+      "data_source": "unsourced",
+      "data_source_reason": null
     },
     {
       "path": "/supabase-vs-firebase",
@@ -1015,7 +1255,11 @@
       "badge_subjects_unresolved": [],
       "reviewed_at": null,
       "reviewer": null,
-      "reads_index": true
+      "review_outcome": null,
+      "reads_index": true,
+      "reads_changes": true,
+      "data_source": "catalogue",
+      "data_source_reason": null
     },
     {
       "path": "/tenor-alternatives",
@@ -1025,7 +1269,11 @@
       "badge_subjects_unresolved": [],
       "reviewed_at": null,
       "reviewer": null,
-      "reads_index": false
+      "review_outcome": null,
+      "reads_index": false,
+      "reads_changes": true,
+      "data_source": "unsourced",
+      "data_source_reason": null
     },
     {
       "path": "/terraform-cloud-free-tier-removed",
@@ -1040,7 +1288,11 @@
       "badge_subjects_unresolved": [],
       "reviewed_at": null,
       "reviewer": null,
-      "reads_index": false
+      "review_outcome": null,
+      "reads_index": false,
+      "reads_changes": false,
+      "data_source": "unsourced",
+      "data_source_reason": null
     },
     {
       "path": "/testing-free-tier-comparison-2026",
@@ -1056,7 +1308,11 @@
       "badge_subjects_unresolved": [],
       "reviewed_at": null,
       "reviewer": null,
-      "reads_index": false
+      "review_outcome": null,
+      "reads_index": false,
+      "reads_changes": true,
+      "data_source": "unsourced",
+      "data_source_reason": null
     },
     {
       "path": "/vector-database-pricing",
@@ -1078,7 +1334,11 @@
       "badge_subjects_unresolved": [],
       "reviewed_at": null,
       "reviewer": null,
-      "reads_index": false
+      "review_outcome": null,
+      "reads_index": false,
+      "reads_changes": true,
+      "data_source": "unsourced",
+      "data_source_reason": null
     },
     {
       "path": "/vercel-vs-netlify",
@@ -1094,7 +1354,11 @@
       "badge_subjects_unresolved": [],
       "reviewed_at": null,
       "reviewer": null,
-      "reads_index": true
+      "review_outcome": null,
+      "reads_index": true,
+      "reads_changes": true,
+      "data_source": "catalogue",
+      "data_source_reason": null
     },
     {
       "path": "/x402-services",
@@ -1104,7 +1368,11 @@
       "badge_subjects_unresolved": [],
       "reviewed_at": null,
       "reviewer": null,
-      "reads_index": true
+      "review_outcome": null,
+      "reads_index": true,
+      "reads_changes": false,
+      "data_source": "catalogue",
+      "data_source_reason": null
     }
   ]
 }

--- a/scripts/mutate-1073-aca.sh
+++ b/scripts/mutate-1073-aca.sh
@@ -1,0 +1,179 @@
+#!/usr/bin/env bash
+set -uo pipefail
+cd "$(dirname "$0")/.."
+
+PASS=0
+FAIL=0
+PROV="test/page-data-provenance.test.ts"
+UNIT="test/page-source-ratchet.test.ts"
+BOTH="$PROV $UNIT"
+
+run_mutation() {
+  local name="$1" file="$2" from="$3" to="$4" tests="${5:-$BOTH}"
+  cp "$file" "$file.bak"
+  if ! python3 - "$file" "$from" "$to" <<'PY'
+import sys, pathlib
+path, old, new = sys.argv[1], sys.argv[2], sys.argv[3]
+p = pathlib.Path(path)
+s = p.read_text()
+if s.count(old) != 1:
+    print(f"SKIP: pattern found {s.count(old)} times", file=sys.stderr)
+    sys.exit(3)
+p.write_text(s.replace(old, new))
+PY
+  then
+    echo "SKIP  $name (pattern stale)"
+    mv "$file.bak" "$file"
+    FAIL=$((FAIL + 1))
+    return
+  fi
+
+  if ! npm run build > /tmp/mut-aca-build.log 2>&1; then
+    echo "SKIP  $name (build failed)"
+    mv "$file.bak" "$file"
+    npm run build > /dev/null 2>&1
+    FAIL=$((FAIL + 1))
+    return
+  fi
+
+  node --test --experimental-strip-types $tests > /tmp/mut-aca.log 2>&1
+  local status=$?
+  mv "$file.bak" "$file"
+  npm run build > /dev/null 2>&1
+
+  if [ $status -ne 0 ]; then
+    echo "KILLED  $name"
+    PASS=$((PASS + 1))
+  else
+    echo "SURVIVED  $name  <-- $tests did not notice"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+run_mutation "no table row ever counts as a published vendor fact" src/page-reviews.ts \
+  'export function vendorFactRows(html: string, slugFor: VendorSlugLookup): VendorFactRow[] {
+  const found: VendorFactRow[] = [];' \
+  'export function vendorFactRows(html: string, slugFor: VendorSlugLookup): VendorFactRow[] {
+  const found: VendorFactRow[] = [];
+  if (html.length > 0) return found;'
+
+run_mutation "a digit in the vendor's own name counts as a fact about it" src/page-reviews.ts \
+  'if (!cells.slice(1).some(cell => /\d/.test(cellText(cell)))) continue;' \
+  'if (!cells.some(cell => /\d/.test(cellText(cell)))) continue;'
+
+run_mutation "the editorial checks run on every page rather than the ones claiming the exemption" src/page-reviews.ts \
+  'if (page.data_source !== "editorial") return violations;' \
+  'if (page.data_source === "editorial") return violations;'
+
+run_mutation "the editorial checks never run" src/page-reviews.ts \
+  'if (page.data_source !== "editorial") return violations;' \
+  'return violations;'
+
+run_mutation "the register may disagree with the change-log perturbation" src/page-reviews.ts \
+  'if (page.reads_changes !== seen.reads_changes) {' \
+  'if (false) {'
+
+run_mutation "the register may disagree with the catalogue perturbation" src/page-reviews.ts \
+  'if (page.reads_index !== seen.reads_index) {' \
+  'if (false) {'
+
+run_mutation "a page may claim the catalogue the perturbation does not move" src/page-reviews.ts \
+  'if (!seen.reads_index && page.data_source === "catalogue") {' \
+  'if (false) {'
+
+run_mutation "a page the perturbation moves may declare any source" src/page-reviews.ts \
+  'if (seen.reads_index && page.data_source !== "catalogue") {' \
+  'if (false) {'
+
+run_mutation "an editorial exemption needs no stated reason" src/page-reviews.ts \
+  'if (page.data_source_reason === null) {
+    violations.push({ path: page.path, problem: "data_source editorial with no stated reason" });' \
+  'if (page.data_source_reason !== null && page.data_source_reason === null) {
+    violations.push({ path: page.path, problem: "data_source editorial with no stated reason" });'
+
+run_mutation "an editorial exemption survives a page full of vendor numbers" src/page-reviews.ts \
+  'if (seen.vendor_fact_rows > 0) {' \
+  'if (false) {'
+
+run_mutation "an editorial exemption survives a page whose verdicts name vendors" src/page-reviews.ts \
+  'if (page.vendors_asserted.length > 0) {
+    violations.push({' \
+  'if (page.vendors_asserted.length < 0) {
+    violations.push({'
+
+run_mutation "an unmeasured register entry passes" src/page-reviews.ts \
+  'if (seen === undefined) {
+      violations.push({ path: page.path, problem: "on the register but not measured" });
+      continue;
+    }' \
+  'if (seen === undefined) {
+      continue;
+    }'
+
+run_mutation "the unsourced budget is a ceiling rather than a count" src/page-reviews.ts \
+  'if (unsourced.length !== tierABudget) {' \
+  'if (unsourced.length > tierABudget) {'
+
+run_mutation "the unsourced budget is not enforced at all" src/page-reviews.ts \
+  'if (unsourced.length !== tierABudget) {' \
+  'if (false) {'
+
+run_mutation "the budget counts tier B as well" src/page-reviews.ts \
+  '.filter(page => page.tier === "A" && page.data_source === "unsourced")' \
+  '.filter(page => page.data_source === "unsourced")'
+
+run_mutation "a register entry with no data source is treated as exempt" src/page-reviews.ts \
+  'data_source: PAGE_DATA_SOURCES.includes(raw.data_source) ? raw.data_source : "unsourced",' \
+  'data_source: PAGE_DATA_SOURCES.includes(raw.data_source) ? raw.data_source : "editorial",'
+
+run_mutation "a whitespace reason is accepted as an exemption argument" src/page-reviews.ts \
+  'typeof raw.data_source_reason === "string" && raw.data_source_reason.trim() ? raw.data_source_reason.trim() : null' \
+  'typeof raw.data_source_reason === "string" ? raw.data_source_reason : null'
+
+run_mutation "an outcome is kept on a page with no review date" src/page-reviews.ts \
+  'review_outcome: reviewedAt !== null && REVIEW_OUTCOMES.includes(raw.review_outcome) ? raw.review_outcome : null,' \
+  'review_outcome: REVIEW_OUTCOMES.includes(raw.review_outcome) ? raw.review_outcome : null,'
+
+run_mutation "the compiled notice never names the date of the last check" src/page-reviews.ts \
+  'if (lastChecked === null) return `Figures compiled ${compiledOn}, not re-checked since`;' \
+  'if (lastChecked === null || lastChecked !== null) return `Figures compiled ${compiledOn}, not re-checked since`;'
+
+run_mutation "a failed review renders as an ordinary one" src/page-reviews.ts \
+  'if (status.review_outcome === "fail") return `${SEPARATOR}Reviewed ${status.reviewed_at}, corrections outstanding`;' \
+  'if (false) return `${SEPARATOR}Reviewed ${status.reviewed_at}, corrections outstanding`;'
+
+run_mutation "every reviewed page says corrections are outstanding" src/page-reviews.ts \
+  'if (status.review_outcome === "fail") return `${SEPARATOR}Reviewed ${status.reviewed_at}, corrections outstanding`;' \
+  'if (status.review_outcome !== "fail") return `${SEPARATOR}Reviewed ${status.reviewed_at}, corrections outstanding`;'
+
+run_mutation "an expired failing review stops saying corrections are outstanding" src/page-reviews.ts \
+  'if (status.review_outcome === "fail") return `${SEPARATOR}Reviewed ${status.reviewed_at}, corrections outstanding`;
+  if (status.state === "expired") return "";' \
+  'if (status.state === "expired") return "";
+  if (status.review_outcome === "fail") return `${SEPARATOR}Reviewed ${status.reviewed_at}, corrections outstanding`;'
+
+run_mutation "the compiled notice trusts a review date the register dates in the future" src/page-reviews.ts \
+  'return compiledNotice(record.published, reviewStatus(record, today).reviewed_at);' \
+  'return compiledNotice(record.published, record.reviewed_at);'
+
+run_mutation "perturbing a store leaves its numbers intact" src/page-reviews.ts \
+  'record[field] = `${PERTURBATION_SENTINEL} ${record[field].replace(/\d/g, "9")}`;' \
+  'record[field] = `${PERTURBATION_SENTINEL} ${record[field]}`;'
+
+run_mutation "perturbing a store reports a count it did not achieve" src/page-reviews.ts \
+  '      touched += 1;
+    }
+  }
+  return touched;' \
+  '      touched += 1;
+    }
+  }
+  return touched + 5000;'
+
+run_mutation "the methodology block goes back to a typed re-check claim" src/serve.ts \
+  '${pageCompiledClause("/email-comparison-2026")}.' \
+  'Compiled ${pubDate}, not re-checked since.'
+
+echo
+echo "killed $PASS, survived/skipped $FAIL"
+[ "$FAIL" -eq 0 ]

--- a/scripts/mutate-1073-acc.sh
+++ b/scripts/mutate-1073-acc.sh
@@ -49,16 +49,16 @@ PY
 }
 
 run_mutation "every page may cite the index" src/page-reviews.ts \
-  'return record.reads_index ? indexCitation(indexSize) : compiledNotice(record.published);' \
-  'return indexCitation(indexSize);'
+  'if (record.reads_index) return indexCitation(indexSize);' \
+  'if (record.reads_index || record.published >= "") return indexCitation(indexSize);'
 
 run_mutation "no page states when it was compiled" src/page-reviews.ts \
-  'return record.reads_index ? indexCitation(indexSize) : compiledNotice(record.published);' \
-  'return record.reads_index ? indexCitation(indexSize) : "";'
+  'return compiledNotice(record.published, reviewStatus(record, today).reviewed_at);' \
+  'return "";'
 
 run_mutation "the compiled notice carries today instead of the compilation date" src/page-reviews.ts \
-  'return record.reads_index ? indexCitation(indexSize) : compiledNotice(record.published);' \
-  'return record.reads_index ? indexCitation(indexSize) : compiledNotice(utcToday());'
+  'return compiledNotice(record.published, reviewStatus(record, today).reviewed_at);' \
+  'return compiledNotice(today, reviewStatus(record, today).reviewed_at);'
 
 run_mutation "a missing register entry defaults to reading the index" src/page-reviews.ts \
   'reads_index: raw.reads_index === true,' \

--- a/scripts/review-page.js
+++ b/scripts/review-page.js
@@ -1,20 +1,27 @@
 import { readFileSync, writeFileSync } from "node:fs";
 import { overdueReport, pageReviewsPath, parsePageReviews } from "../dist/page-reviews.js";
 
-const HELP = `Record that an editorial page was re-read and found correct.
+const HELP = `Record that an editorial page was re-read, and what the reading found.
 
 A review advances the page's freshness date. Nothing else may: a render, a deploy and a
 data refresh all leave it alone, which is the point — the date has to mean a person or a
 model actually read the prose.
 
-A review is refused unless --checked names every vendor the page's verdict blocks commit
-us to. A verdict that awards a badge to a vendor whose record has since moved is the
-failure this guards against, so a review that skipped that vendor is not a review.
+--outcome says what the reading concluded, so the date means a review happened rather
+than a review passed. A page whose review found defects renders "corrections outstanding"
+beside its compilation date until someone fixes them and reviews it again.
 
-Usage: node scripts/review-page.js --path <route> --checked <slug,slug> --reviewer <name> [options]
+A pass is refused unless --checked names every vendor the page's verdict blocks commit
+us to. A verdict that awards a badge to a vendor whose record has since moved is the
+failure this guards against, so a review that skipped that vendor is not a pass. A fail
+carries no such requirement: a reader who finds one wrong number has found the page
+wrong, and making them finish the sweep first is what leaves the defect unrecorded.
+
+Usage: node scripts/review-page.js --path <route> --outcome <pass|fail> --reviewer <name> [options]
        node scripts/review-page.js --list
 
   --path <route>      Page reviewed, e.g. /email-comparison-2026
+  --outcome <verdict> pass or fail
   --checked <slugs>   Comma-separated vendor slugs verified against their current record
   --reviewer <name>   Who or what performed the review
   --date <date>       Review date, YYYY-MM-DD (default: today, UTC)
@@ -25,11 +32,12 @@ Usage: node scripts/review-page.js --path <route> --checked <slug,slug> --review
 `;
 
 function parseArgs(argv) {
-  const opts = { path: null, checked: null, reviewer: null, date: null, list: false, file: pageReviewsPath(), dryRun: false };
+  const opts = { path: null, checked: null, reviewer: null, date: null, outcome: null, list: false, file: pageReviewsPath(), dryRun: false };
   for (let i = 0; i < argv.length; i++) {
     const arg = argv[i];
     if (arg === "--help" || arg === "-h") return { help: true };
     else if (arg === "--path") opts.path = argv[++i];
+    else if (arg === "--outcome") opts.outcome = argv[++i];
     else if (arg === "--checked") opts.checked = argv[++i];
     else if (arg === "--reviewer") opts.reviewer = argv[++i];
     else if (arg === "--date") opts.date = argv[++i];
@@ -70,6 +78,9 @@ if (opts.list) {
 
 if (!opts.path) fail("--path is required");
 if (!opts.reviewer) fail("--reviewer is required — a review has to be attributable");
+if (opts.outcome !== "pass" && opts.outcome !== "fail") {
+  fail("--outcome must be pass or fail — a review date with no verdict cannot say whether the page was found correct");
+}
 
 const record = index.pages.find(p => p.path === opts.path);
 if (!record) fail(`${opts.path} is not on the review register. Run scripts/sync-page-reviews.js if it is a new page.`);
@@ -81,16 +92,18 @@ if (date < record.published) fail(`--date ${date} precedes the page's publicatio
 
 const checked = new Set((opts.checked ?? "").split(",").map(s => s.trim()).filter(Boolean));
 const missing = record.vendors_asserted.filter(slug => !checked.has(slug));
-if (missing.length > 0) {
+if (opts.outcome === "pass" && missing.length > 0) {
   fail(`${opts.path} states a verdict about ${record.vendors_asserted.length} vendors and --checked omits ${missing.length}: ${missing.join(", ")}`);
 }
 const unexpected = [...checked].filter(slug => !record.vendors_asserted.includes(slug));
 
 record.reviewed_at = date;
 record.reviewer = opts.reviewer;
+record.review_outcome = opts.outcome;
 
-console.log(`${opts.path} reviewed ${date} by ${opts.reviewer}`);
-console.log(`  verdict vendors checked: ${record.vendors_asserted.length ? record.vendors_asserted.join(", ") : "(none stated)"}`);
+console.log(`${opts.path} reviewed ${date} by ${opts.reviewer} — ${opts.outcome}`);
+console.log(`  vendors its verdicts commit us to: ${record.vendors_asserted.length ? record.vendors_asserted.join(", ") : "(none stated)"}`);
+if (missing.length > 0) console.log(`  of those, not checked: ${missing.join(", ")}`);
 if (unexpected.length > 0) console.log(`  also checked, not stated in a verdict block: ${unexpected.join(", ")}`);
 if (opts.dryRun) {
   console.log("dry run — nothing written");

--- a/scripts/sync-page-reviews.js
+++ b/scripts/sync-page-reviews.js
@@ -1,9 +1,13 @@
 import { execFileSync } from "node:child_process";
 import { spawn } from "node:child_process";
-import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
-import { deriveTier, parsePageReviews, pageReviewsPath, unresolvedBadgeSubjects, vendorsAssertedIn } from "../dist/page-reviews.js";
+import {
+  CATALOGUE_TEXT_FIELDS, CHANGE_LOG_TEXT_FIELDS, deriveTier, parsePageReviews, pageReviewsPath,
+  perturbTextFields, unresolvedBadgeSubjects, vendorsAssertedIn,
+} from "../dist/page-reviews.js";
 import { assertedVendorSlugs, isNonVendorSubject, namedVendorSlug, vendorSlugMap } from "../dist/vendor-slug.js";
 
 const REPO = join(dirname(fileURLToPath(import.meta.url)), "..");
@@ -14,6 +18,14 @@ Renders every page that carries hand-written prose, derives its review tier from
 whether it states a verdict naming a vendor, and records which vendors that verdict
 commits us to. Review dates already on record are carried over untouched: this
 regenerates what is derived, never what a reviewer asserted.
+
+Which stores a page reads is measured rather than carried over. Each page is rendered
+again against a catalogue and a change log whose text fields have been replaced, and a
+byte-identical render means the page never opened that store.
+
+A page that reads no catalogue record keeps whichever data_source it was given, and a
+page new to the register defaults to "unsourced" — the state that fails the ratchet —
+so a page asserting vendor facts from nowhere has to be argued for rather than slip in.
 
 Publication dates come from the first commit in which the page's route was served,
 which is an event that happened, unlike a hand-typed literal.
@@ -79,11 +91,11 @@ function routeFirstServed(route) {
   }
 }
 
-function startServer() {
+function startServer(env = {}) {
   return new Promise((resolve, reject) => {
     const child = spawn("node", [join(REPO, "dist", "serve.js")], {
       stdio: ["ignore", "ignore", "pipe"],
-      env: { ...process.env, PORT: "0", BASE_URL: "http://localhost", AGENTDEALS_PAGE_REVIEWS_PATH: "/dev/null" },
+      env: { ...process.env, PORT: "0", BASE_URL: "http://localhost", AGENTDEALS_PAGE_REVIEWS_PATH: "/dev/null", ...env },
     });
     const timeout = setTimeout(() => { child.kill(); reject(new Error("server startup timed out")); }, 30000);
     child.stderr.on("data", (buf) => {
@@ -92,6 +104,23 @@ function startServer() {
     });
     child.on("error", (err) => { clearTimeout(timeout); reject(err); });
   });
+}
+
+function writePerturbed(dir, name, key, fields) {
+  const store = JSON.parse(readFileSync(join(REPO, "data", name), "utf-8"));
+  const touched = perturbTextFields(store[key], fields);
+  if (touched < 100) throw new Error(`only ${touched} text fields perturbed in ${name}; a readership measurement against it would prove nothing`);
+  const target = join(dir, name);
+  writeFileSync(target, JSON.stringify(store));
+  return target;
+}
+
+async function render(port, route) {
+  const res = await fetch(`http://localhost:${port}${route}`, {
+    headers: { "user-agent": "agentdeals-internal/1.0 (sync-page-reviews)" },
+  });
+  if (res.status !== 200) throw new Error(`${route} returned ${res.status}`);
+  return res.text();
 }
 
 async function main() {
@@ -107,16 +136,27 @@ async function main() {
   };
   const resolver = { slugsFor: assertedVendorSlugs, isNonVendor: isNonVendorSubject };
 
-  const { child, port } = await startServer();
+  const tmp = mkdtempSync(join(tmpdir(), "sync-page-reviews-"));
+  const perturbedIndex = writePerturbed(tmp, "index.json", "offers", CATALOGUE_TEXT_FIELDS);
+  const perturbedChanges = writePerturbed(tmp, "deal_changes.json", "changes", CHANGE_LOG_TEXT_FIELDS);
+
+  const [real, blindIndex, blindChanges] = await Promise.all([
+    startServer(),
+    startServer({ AGENTDEALS_INDEX_PATH: perturbedIndex }),
+    startServer({ AGENTDEALS_CHANGES_PATH: perturbedChanges }),
+  ]);
   const pages = [];
   const changes = [];
   try {
     for (const route of [...EDITORIAL_PAGES].sort()) {
-      const res = await fetch(`http://localhost:${port}${route}`, { headers: { "user-agent": "agentdeals-internal/1.0 (sync-page-reviews)" } });
-      if (res.status !== 200) throw new Error(`${route} returned ${res.status}`);
-      const html = await res.text();
+      const [html, withoutIndex, withoutChanges] = await Promise.all([
+        render(real.port, route),
+        render(blindIndex.port, route),
+        render(blindChanges.port, route),
+      ]);
       const prior = byPath.get(route);
       const published = prior?.published ?? routeFirstServed(route) ?? new Date().toISOString().slice(0, 10);
+      const readsIndex = html !== withoutIndex;
       const record = {
         path: route,
         published,
@@ -125,10 +165,18 @@ async function main() {
         badge_subjects_unresolved: unresolvedBadgeSubjects(html, resolver).map(b => b.subject),
         reviewed_at: prior?.reviewed_at ?? null,
         reviewer: prior?.reviewer ?? null,
+        review_outcome: prior?.review_outcome ?? null,
+        reads_index: readsIndex,
+        reads_changes: html !== withoutChanges,
+        data_source: readsIndex ? "catalogue" : prior && prior.data_source !== "catalogue" ? prior.data_source : "unsourced",
+        data_source_reason: prior?.data_source_reason ?? null,
       };
-      if (!prior) changes.push(`+ ${route} (published ${published}, tier ${record.tier})`);
+      if (!prior) changes.push(`+ ${route} (published ${published}, tier ${record.tier}, data_source ${record.data_source})`);
       else {
         if (prior.tier !== record.tier) changes.push(`~ ${route} tier ${prior.tier} -> ${record.tier}`);
+        if (prior.reads_index !== record.reads_index) changes.push(`~ ${route} reads_index ${prior.reads_index} -> ${record.reads_index}`);
+        if (prior.reads_changes !== record.reads_changes) changes.push(`~ ${route} reads_changes ${prior.reads_changes} -> ${record.reads_changes}`);
+        if (prior.data_source !== record.data_source) changes.push(`~ ${route} data_source ${prior.data_source} -> ${record.data_source}`);
         const before = prior.vendors_asserted.join(","), after = record.vendors_asserted.join(",");
         if (before !== after) changes.push(`~ ${route} vendors ${prior.vendors_asserted.length} -> ${record.vendors_asserted.length}`);
         const unresolvedBefore = prior.badge_subjects_unresolved.join(","), unresolvedAfter = record.badge_subjects_unresolved.join(",");
@@ -137,7 +185,10 @@ async function main() {
       pages.push(record);
     }
   } finally {
-    child.kill();
+    real.child.kill();
+    blindIndex.child.kill();
+    blindChanges.child.kill();
+    rmSync(tmp, { recursive: true, force: true });
   }
 
   for (const stale of byPath.keys()) {
@@ -147,7 +198,10 @@ async function main() {
   const index = { version: 1, sla_days: { A: 30, B: 90 }, pages };
   const serialized = JSON.stringify(index, null, 2) + "\n";
   const tierA = pages.filter(p => p.tier === "A").length;
+  const unsourcedA = pages.filter(p => p.tier === "A" && p.data_source === "unsourced").length;
   console.log(`${pages.length} pages, ${tierA} tier A, ${pages.length - tierA} tier B`);
+  console.log(`${pages.filter(p => p.reads_index).length} read the catalogue, ${pages.filter(p => p.reads_changes).length} read the change log`);
+  console.log(`${unsourcedA} tier-A pages assert vendor facts and read no catalogue record`);
   for (const line of changes) console.log(line);
   if (opts.dryRun) { console.log("dry run — nothing written"); return; }
   writeFileSync(opts.out, serialized);

--- a/src/page-reviews.ts
+++ b/src/page-reviews.ts
@@ -21,6 +21,22 @@ export const EXPIRY_MULTIPLE = 2;
 
 export type ReviewState = "current" | "overdue" | "expired" | "never_reviewed";
 
+export type ReviewOutcome = "pass" | "fail";
+
+export const REVIEW_OUTCOMES: ReviewOutcome[] = ["pass", "fail"];
+
+export type PageDataSource = "catalogue" | "editorial" | "unsourced";
+
+export const PAGE_DATA_SOURCES: PageDataSource[] = ["catalogue", "editorial", "unsourced"];
+
+export const PAGE_DATA_SOURCE_RULE: Record<PageDataSource, string> = {
+  catalogue: "renders fields from the catalogue, measured by perturbing it",
+  editorial: "asserts no vendor facts of its own, and says why",
+  unsourced: "asserts vendor facts that are literals in the page and reach no record",
+};
+
+export const UNSOURCED_TIER_A_BASELINE = 43;
+
 export interface PageReviewRecord {
   path: string;
   published: string;
@@ -29,7 +45,11 @@ export interface PageReviewRecord {
   badge_subjects_unresolved: string[];
   reviewed_at: string | null;
   reviewer: string | null;
+  review_outcome: ReviewOutcome | null;
   reads_index: boolean;
+  reads_changes: boolean;
+  data_source: PageDataSource;
+  data_source_reason: string | null;
 }
 
 export interface PageReviewIndex {
@@ -48,8 +68,13 @@ export interface ReviewStatus {
   days_since: number;
   days_overdue: number;
   state: ReviewState;
+  review_outcome: ReviewOutcome | null;
   vendors_asserted: string[];
   badge_subjects_unresolved: string[];
+  reads_index: boolean;
+  reads_changes: boolean;
+  data_source: PageDataSource;
+  data_source_reason: string | null;
 }
 
 const DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
@@ -71,15 +96,20 @@ function normalizeRecord(raw: any): PageReviewRecord | null {
   if (!raw || typeof raw.path !== "string" || !raw.path.startsWith("/")) return null;
   if (!isReviewDate(raw.published)) return null;
   const tier: ReviewTier = raw.tier === "A" ? "A" : "B";
+  const reviewedAt = isReviewDate(raw.reviewed_at) ? raw.reviewed_at : null;
   return {
     path: raw.path,
     published: raw.published,
     tier,
     vendors_asserted: Array.isArray(raw.vendors_asserted) ? raw.vendors_asserted.filter((s: unknown) => typeof s === "string") : [],
     badge_subjects_unresolved: Array.isArray(raw.badge_subjects_unresolved) ? raw.badge_subjects_unresolved.filter((s: unknown) => typeof s === "string") : [],
-    reviewed_at: isReviewDate(raw.reviewed_at) ? raw.reviewed_at : null,
+    reviewed_at: reviewedAt,
     reviewer: typeof raw.reviewer === "string" && raw.reviewer ? raw.reviewer : null,
+    review_outcome: reviewedAt !== null && REVIEW_OUTCOMES.includes(raw.review_outcome) ? raw.review_outcome : null,
     reads_index: raw.reads_index === true,
+    reads_changes: raw.reads_changes === true,
+    data_source: PAGE_DATA_SOURCES.includes(raw.data_source) ? raw.data_source : "unsourced",
+    data_source_reason: typeof raw.data_source_reason === "string" && raw.data_source_reason.trim() ? raw.data_source_reason.trim() : null,
   };
 }
 
@@ -150,8 +180,13 @@ export function reviewStatus(record: PageReviewRecord, today: string): ReviewSta
     days_since: daysSince,
     days_overdue: overdue,
     state,
+    review_outcome: reviewedAt === null ? null : record.review_outcome,
     vendors_asserted: record.vendors_asserted,
     badge_subjects_unresolved: record.badge_subjects_unresolved,
+    reads_index: record.reads_index,
+    reads_changes: record.reads_changes,
+    data_source: record.data_source,
+    data_source_reason: record.data_source_reason,
   };
 }
 
@@ -161,6 +196,7 @@ export function freshnessSegmentFor(record: PageReviewRecord | null, today: stri
   if (!record) return "";
   const status = reviewStatus(record, today);
   if (status.state === "never_reviewed") return `${SEPARATOR}Not yet reviewed`;
+  if (status.review_outcome === "fail") return `${SEPARATOR}Reviewed ${status.reviewed_at}, corrections outstanding`;
   if (status.state === "expired") return "";
   return `${SEPARATOR}Reviewed ${status.reviewed_at}`;
 }
@@ -182,17 +218,30 @@ export function indexCitation(indexSize: number): string {
   return `Data verified from our index of ${indexSize.toLocaleString()} developer tools`;
 }
 
-export function compiledNotice(compiledOn: string): string {
-  return `Figures compiled ${compiledOn}, not re-checked since`;
+export function compiledNotice(compiledOn: string, lastChecked: string | null = null): string {
+  if (lastChecked === null) return `Figures compiled ${compiledOn}, not re-checked since`;
+  return `Figures compiled ${compiledOn}, last checked ${lastChecked}`;
 }
 
-export function dataProvenanceFor(record: PageReviewRecord | null, indexSize: number): string {
+export function dataProvenanceFor(record: PageReviewRecord | null, indexSize: number, today: string): string {
   if (!record) return "";
-  return record.reads_index ? indexCitation(indexSize) : compiledNotice(record.published);
+  if (record.reads_index) return indexCitation(indexSize);
+  return compiledNotice(record.published, reviewStatus(record, today).reviewed_at);
 }
 
-export function pageDataProvenance(pagePath: string, indexSize: number): string {
-  return dataProvenanceFor(getPageReview(pagePath), indexSize);
+export function pageDataProvenance(pagePath: string, indexSize: number, today = utcToday()): string {
+  return dataProvenanceFor(getPageReview(pagePath), indexSize, today);
+}
+
+export function compiledClause(record: PageReviewRecord | null, today: string): string {
+  if (!record) return "";
+  const lastChecked = reviewStatus(record, today).reviewed_at;
+  if (lastChecked === null) return `Compiled ${record.published}, not re-checked since`;
+  return `Compiled ${record.published}, last checked ${lastChecked}`;
+}
+
+export function pageCompiledClause(pagePath: string, today = utcToday()): string {
+  return compiledClause(getPageReview(pagePath), today);
 }
 
 export function pageDateModified(pagePath: string, fallbackPublished: string, today = utcToday()): string {
@@ -228,7 +277,10 @@ export interface OverdueReport {
   sla_days: Record<ReviewTier, number>;
   tier_rule: Record<ReviewTier, string>;
   expiry_multiple: number;
+  data_source_rule: Record<PageDataSource, string>;
   totals: { pages: number; current: number; overdue: number; expired: number; never_reviewed: number };
+  data_sources: Record<PageDataSource, number>;
+  unsourced_tier_a: { pages: number; budget: number; paths: string[] };
   pages: ReviewStatus[];
 }
 
@@ -238,12 +290,18 @@ export function overdueReport(today: string, index: PageReviewIndex = loadPageRe
     .sort((a, b) => b.days_overdue - a.days_overdue || a.path.localeCompare(b.path));
   const totals = { pages: pages.length, current: 0, overdue: 0, expired: 0, never_reviewed: 0 };
   for (const p of pages) totals[p.state] += 1;
+  const dataSources: Record<PageDataSource, number> = { catalogue: 0, editorial: 0, unsourced: 0 };
+  for (const p of pages) dataSources[p.data_source] += 1;
+  const unsourced = unsourcedTierAPaths(index.pages);
   return {
     generated_for: today,
     sla_days: { ...SLA_DAYS },
     tier_rule: { ...TIER_RULE },
     expiry_multiple: EXPIRY_MULTIPLE,
+    data_source_rule: { ...PAGE_DATA_SOURCE_RULE },
     totals,
+    data_sources: dataSources,
+    unsourced_tier_a: { pages: unsourced.length, budget: UNSOURCED_TIER_A_BASELINE, paths: unsourced },
     pages,
   };
 }
@@ -446,6 +504,147 @@ export function vendorsAssertedIn(html: string, lookup: VendorLookup): string[] 
 
 export function deriveTier(html: string): ReviewTier {
   return verdictBlocks(html).length > 0 ? "A" : "B";
+}
+
+export const PERTURBATION_SENTINEL = "PMPERTURB";
+export const CATALOGUE_TEXT_FIELDS = ["description", "tier", "notes", "limits"];
+export const CHANGE_LOG_TEXT_FIELDS = ["summary", "previous_state", "current_state"];
+
+export function perturbTextFields(records: any[], fields: string[]): number {
+  let touched = 0;
+  for (const record of records) {
+    if (!record || typeof record !== "object") continue;
+    for (const field of fields) {
+      if (typeof record[field] !== "string") continue;
+      record[field] = `${PERTURBATION_SENTINEL} ${record[field].replace(/\d/g, "9")}`;
+      touched += 1;
+    }
+  }
+  return touched;
+}
+
+const TABLE_ROW = /<tr\b[\s\S]*?<\/tr>/g;
+const ROW_CELL = /<t[dh]\b[^>]*>[\s\S]*?<\/t[dh]>/g;
+const VENDOR_CELL_LINK = /href="\/vendor\/([a-z0-9][a-z0-9-]*)"/;
+
+export interface VendorFactRow {
+  subject: string;
+  slug: string;
+}
+
+function cellText(fragment: string): string {
+  return fragment
+    .replace(/<[^>]*>/g, " ")
+    .replace(/&amp;/g, "&")
+    .replace(/&[a-z]+;/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+export function vendorFactRows(html: string, slugFor: VendorSlugLookup): VendorFactRow[] {
+  const found: VendorFactRow[] = [];
+  for (const row of html.match(TABLE_ROW) ?? []) {
+    const cells = row.match(ROW_CELL) ?? [];
+    const first = cells[0];
+    if (first === undefined) continue;
+    if (!cells.slice(1).some(cell => /\d/.test(cellText(cell)))) continue;
+    const subject = cellText(first);
+    const linked = first.match(VENDOR_CELL_LINK);
+    const slug = linked ? linked[1]! : subject ? slugFor(subject) : null;
+    if (slug) found.push({ subject, slug });
+  }
+  return found;
+}
+
+export interface PageSourceMeasurement {
+  reads_index: boolean;
+  reads_changes: boolean;
+  vendor_fact_rows: number;
+}
+
+export interface PageSourceViolation {
+  path: string;
+  problem: string;
+}
+
+export function unsourcedTierAPaths(pages: PageReviewRecord[]): string[] {
+  return pages
+    .filter(page => page.tier === "A" && page.data_source === "unsourced")
+    .map(page => page.path)
+    .sort();
+}
+
+function declarationViolations(page: PageReviewRecord, seen: PageSourceMeasurement): PageSourceViolation[] {
+  const violations: PageSourceViolation[] = [];
+  if (page.reads_index !== seen.reads_index) {
+    violations.push({
+      path: page.path,
+      problem: `reads_index says ${page.reads_index}, perturbing the catalogue says ${seen.reads_index}`,
+    });
+  }
+  if (page.reads_changes !== seen.reads_changes) {
+    violations.push({
+      path: page.path,
+      problem: `reads_changes says ${page.reads_changes}, perturbing the change log says ${seen.reads_changes}`,
+    });
+  }
+  if (seen.reads_index && page.data_source !== "catalogue") {
+    violations.push({
+      path: page.path,
+      problem: `data_source ${page.data_source} on a page that renders catalogue fields`,
+    });
+  }
+  if (!seen.reads_index && page.data_source === "catalogue") {
+    violations.push({
+      path: page.path,
+      problem: "data_source catalogue on a page the catalogue perturbation leaves byte-identical",
+    });
+  }
+  if (page.data_source !== "editorial") return violations;
+  if (page.data_source_reason === null) {
+    violations.push({ path: page.path, problem: "data_source editorial with no stated reason" });
+  }
+  if (seen.vendor_fact_rows > 0) {
+    violations.push({
+      path: page.path,
+      problem: `data_source editorial on a page with ${seen.vendor_fact_rows} table rows putting a number beside a catalogued vendor`,
+    });
+  }
+  if (page.vendors_asserted.length > 0) {
+    violations.push({
+      path: page.path,
+      problem: `data_source editorial on a page whose verdict blocks assert ${page.vendors_asserted.length} vendors`,
+    });
+  }
+  return violations;
+}
+
+export function pageSourceViolations(
+  pages: PageReviewRecord[],
+  measured: Map<string, PageSourceMeasurement>,
+  tierABudget: number = UNSOURCED_TIER_A_BASELINE
+): PageSourceViolation[] {
+  const violations: PageSourceViolation[] = [];
+  for (const page of pages) {
+    const seen = measured.get(page.path);
+    if (seen === undefined) {
+      violations.push({ path: page.path, problem: "on the register but not measured" });
+      continue;
+    }
+    violations.push(...declarationViolations(page, seen));
+  }
+  const unsourced = unsourcedTierAPaths(pages);
+  if (unsourced.length !== tierABudget) {
+    const direction =
+      unsourced.length > tierABudget
+        ? `${unsourced.length - tierABudget} more than the budget allows, and the budget does not rise`
+        : `${tierABudget - unsourced.length} fewer than the budget; lower UNSOURCED_TIER_A_BASELINE to ${unsourced.length} so the slot cannot be reused`;
+    violations.push({
+      path: "",
+      problem: `${unsourced.length} tier-A pages assert vendor facts and read no catalogue record — ${direction}`,
+    });
+  }
+  return violations;
 }
 
 export function escapeRegExp(value: string): string {

--- a/src/serve.ts
+++ b/src/serve.ts
@@ -26,7 +26,7 @@ import { runHealthCheck, getLastReport, startPeriodicChecks } from "./referral-h
 import { addFriend, removeFriend, getFriends, getFriendCodesForVendors } from "./friends.js";
 import { subscribe as watchlistSubscribe, getSubscription as getWatchlistSubscription, unsubscribe as watchlistUnsubscribe, listSubscriptions as listWatchlistSubscriptions } from "./watchlist.js";
 import { toSlug, vendorSlugMap, resolveVendorSlug, namedVendorSlug } from "./vendor-slug.js";
-import { linkifyVerdictBlocks, overdueReport, pageDataProvenance, pageDateModified, pageFreshness, pageFreshnessSentence, utcToday, verdictsOutdatedBy } from "./page-reviews.js";
+import { linkifyVerdictBlocks, overdueReport, pageCompiledClause, pageDataProvenance, pageDateModified, pageFreshness, pageFreshnessSentence, utcToday, verdictsOutdatedBy } from "./page-reviews.js";
 import { rankOffers, rankForListing, rotateListing, utcDate, CRITERIA_PATH, DEMOTE_ONLY_POLICY, DISCLOSURE_RATIONALE, TIE_BREAK_ALGORITHM, GATE_TABLE, DEMERIT_TABLE, NOT_FREE_TIER_RULES, TIME_LIMITED_TIER_RULES } from "./ranking.js";
 import type { RankedEntry, RankingResult } from "./ranking.js";
 import { partitionAlternatives, partitionAlternativesAcross, productRoleSentence, MEMBERSHIP_GATE_RULES, MEMBERSHIP_GATE_ORDER, MEMBERSHIP_GATE_SYMMETRY, MEMBERSHIP_GATE_SCOPE, MEMBERSHIP_GATE_CORRECTIONS } from "./product-role.js";
@@ -40500,7 +40500,7 @@ ${mcpCtaCss()}
 
   <h2 id="data-source">Data Source</h2>
   <div class="methodology">
-    <strong>How we track this data:</strong> the tables on this page were compiled by hand from vendor pricing pages. They do not come from the catalogue behind our search and MCP tools. Prices and limits are for free tiers only &mdash; paid tier comparisons use publicly available list prices. Compiled ${pubDate}, not re-checked since. <a href="/freshness">Check data freshness</a>.
+    <strong>How we track this data:</strong> the tables on this page were compiled by hand from vendor pricing pages. They do not come from the catalogue behind our search and MCP tools. Prices and limits are for free tiers only &mdash; paid tier comparisons use publicly available list prices. ${pageCompiledClause("/email-comparison-2026")}. <a href="/freshness">Check data freshness</a>.
   </div>
 
 
@@ -42311,7 +42311,7 @@ ${mcpCtaCss()}
 
   <h2 id="data-source">Data Source</h2>
   <div class="methodology">
-    <strong>How we track this data:</strong> the tables on this page were compiled by hand from vendor pricing pages. They do not come from the catalogue behind our search and MCP tools. Prices and limits are for free tiers only &mdash; paid tier comparisons use publicly available list prices. Compiled ${pubDate}, not re-checked since. <a href="/freshness">Check data freshness</a>.
+    <strong>How we track this data:</strong> the tables on this page were compiled by hand from vendor pricing pages. They do not come from the catalogue behind our search and MCP tools. Prices and limits are for free tiers only &mdash; paid tier comparisons use publicly available list prices. ${pageCompiledClause("/storage-comparison-2026")}. <a href="/freshness">Check data freshness</a>.
   </div>
 
 
@@ -42983,7 +42983,7 @@ ${mcpCtaCss()}
 
   <h2 id="data-source">Data Source</h2>
   <div class="methodology">
-    <strong>How we track this data:</strong> the tables on this page were compiled by hand from vendor pricing pages. They do not come from the catalogue behind our search and MCP tools. Prices and limits are for free tiers only &mdash; paid tier comparisons use publicly available list prices. Compiled ${pubDate}, not re-checked since. <a href="/freshness">Check data freshness</a>.
+    <strong>How we track this data:</strong> the tables on this page were compiled by hand from vendor pricing pages. They do not come from the catalogue behind our search and MCP tools. Prices and limits are for free tiers only &mdash; paid tier comparisons use publicly available list prices. ${pageCompiledClause("/testing-free-tier-comparison-2026")}. <a href="/freshness">Check data freshness</a>.
   </div>
 
 
@@ -43669,7 +43669,7 @@ ${mcpCtaCss()}
 
   <h2 id="data-source">Data Source</h2>
   <div class="methodology">
-    <strong>How we track this data:</strong> the tables on this page were compiled by hand from vendor pricing pages. They do not come from the catalogue behind our search and MCP tools. Prices and limits are for free tiers only &mdash; paid tier comparisons use publicly available list prices. Compiled ${pubDate}, not re-checked since. <a href="/freshness">Check data freshness</a>.
+    <strong>How we track this data:</strong> the tables on this page were compiled by hand from vendor pricing pages. They do not come from the catalogue behind our search and MCP tools. Prices and limits are for free tiers only &mdash; paid tier comparisons use publicly available list prices. ${pageCompiledClause("/analytics-free-tier-comparison-2026")}. <a href="/freshness">Check data freshness</a>.
   </div>
 
 
@@ -44269,7 +44269,7 @@ ${mcpCtaCss()}
 
   <h2 id="data-source">Data Source</h2>
   <div class="methodology">
-    <strong>How we track this data:</strong> the tables on this page were compiled by hand from vendor pricing pages. They do not come from the catalogue behind our search and MCP tools. Prices and limits are for free tiers only &mdash; paid tier comparisons use publicly available list prices. Compiled ${pubDate}, not re-checked since. <a href="/freshness">Check data freshness</a>.
+    <strong>How we track this data:</strong> the tables on this page were compiled by hand from vendor pricing pages. They do not come from the catalogue behind our search and MCP tools. Prices and limits are for free tiers only &mdash; paid tier comparisons use publicly available list prices. ${pageCompiledClause("/api-development-free-tier-comparison-2026")}. <a href="/freshness">Check data freshness</a>.
   </div>
 
 
@@ -44990,7 +44990,7 @@ ${mcpCtaCss()}
 
   <h2 id="data-source">Data Source</h2>
   <div class="methodology">
-    <strong>How we track this data:</strong> the tables on this page were compiled by hand from vendor pricing pages. They do not come from the catalogue behind our search and MCP tools. Prices and limits are for free tiers only &mdash; paid tier comparisons use publicly available list prices. Compiled ${pubDate}, not re-checked since. <a href="/freshness">Check data freshness</a>.
+    <strong>How we track this data:</strong> the tables on this page were compiled by hand from vendor pricing pages. They do not come from the catalogue behind our search and MCP tools. Prices and limits are for free tiers only &mdash; paid tier comparisons use publicly available list prices. ${pageCompiledClause("/security-free-tier-comparison-2026")}. <a href="/freshness">Check data freshness</a>.
   </div>
 
 
@@ -45618,7 +45618,7 @@ ${mcpCtaCss()}
 
   <h2 id="data-source">Data Source</h2>
   <div class="methodology">
-    <strong>How we track this data:</strong> the tables on this page were compiled by hand from vendor pricing pages. They do not come from the catalogue behind our search and MCP tools. Prices and limits are for free tiers only &mdash; paid tier comparisons use publicly available list prices. Compiled ${pubDate}, not re-checked since. <a href="/freshness">Check data freshness</a>.
+    <strong>How we track this data:</strong> the tables on this page were compiled by hand from vendor pricing pages. They do not come from the catalogue behind our search and MCP tools. Prices and limits are for free tiers only &mdash; paid tier comparisons use publicly available list prices. ${pageCompiledClause("/hosting-free-tier-comparison-2026")}. <a href="/freshness">Check data freshness</a>.
   </div>
 
 

--- a/test/page-data-provenance.test.ts
+++ b/test/page-data-provenance.test.ts
@@ -5,38 +5,28 @@ import { readFileSync, writeFileSync, mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import {
+  CATALOGUE_TEXT_FIELDS, CHANGE_LOG_TEXT_FIELDS, PAGE_DATA_SOURCES, UNSOURCED_TIER_A_BASELINE,
+  pageSourceViolations, parsePageReviews, perturbTextFields, unsourcedTierAPaths, vendorFactRows,
+  type PageReviewRecord, type PageSourceMeasurement,
+} from "../src/page-reviews.ts";
+import { namedVendorSlug } from "../dist/vendor-slug.js";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const REPO = path.join(__dirname, "..");
 
-const PERTURBED_FIELDS = ["description", "tier", "notes", "limits"];
 const INDEX_CITATION = /our (?:verified )?index of/i;
 const VERIFICATION_CLAIM = /\b(?:verified|cross-referenced) against\b/i;
 const NAMES_A_YEAR = /\b(?:19|20)\d{2}\b/;
-const COMPILED_NOTICE = /Figures compiled (\d{4}-\d{2}-\d{2}), not re-checked since/;
+const COMPILED_NOTICE = /Figures compiled (\d{4}-\d{2}-\d{2}), (?:not re-checked since|last checked (\d{4}-\d{2}-\d{2}))/;
 
-type Registered = { path: string; tier: string; published: string; reads_index: boolean };
-
-function registeredPages(): Registered[] {
-  const raw = JSON.parse(readFileSync(path.join(REPO, "data", "page-reviews.json"), "utf-8"));
-  return raw.pages.map((p: any) => ({
-    path: p.path,
-    tier: p.tier,
-    published: p.published,
-    reads_index: p.reads_index === true,
-  }));
+function registeredPages(): PageReviewRecord[] {
+  return parsePageReviews(readFileSync(path.join(REPO, "data", "page-reviews.json"), "utf-8")).pages;
 }
 
-function perturbIndex(source: string, target: string): number {
-  const data = JSON.parse(readFileSync(source, "utf-8"));
-  let touched = 0;
-  for (const offer of data.offers) {
-    for (const field of PERTURBED_FIELDS) {
-      if (typeof offer[field] !== "string") continue;
-      offer[field] = `PMPERTURB ${offer[field].replace(/\d/g, "9")}`;
-      touched += 1;
-    }
-  }
+function perturbStore(name: string, key: string, fields: string[], target: string): number {
+  const data = JSON.parse(readFileSync(path.join(REPO, "data", name), "utf-8"));
+  const touched = perturbTextFields(data[key], fields);
   writeFileSync(target, JSON.stringify(data));
   return touched;
 }
@@ -80,43 +70,121 @@ describe("a page may only name the source it actually reads", () => {
   let tmp: string;
   let real: { proc: ChildProcess; port: number };
   let perturbed: { proc: ChildProcess; port: number };
+  let changesBlind: { proc: ChildProcess; port: number };
   const pages = registeredPages();
   const bodies = new Map<string, string>();
   const consumesIndex = new Map<string, boolean>();
+  const measured = new Map<string, PageSourceMeasurement>();
 
   before(async () => {
     tmp = mkdtempSync(path.join(tmpdir(), "page-data-provenance-"));
     const perturbedIndex = path.join(tmp, "index.json");
-    const touched = perturbIndex(path.join(REPO, "data", "index.json"), perturbedIndex);
-    assert.ok(touched > 1000, `perturbed only ${touched} fields, so the comparison below proves nothing`);
-    [real, perturbed] = await Promise.all([
+    const perturbedChanges = path.join(tmp, "deal_changes.json");
+    const touchedIndex = perturbStore("index.json", "offers", CATALOGUE_TEXT_FIELDS, perturbedIndex);
+    const touchedChanges = perturbStore("deal_changes.json", "changes", CHANGE_LOG_TEXT_FIELDS, perturbedChanges);
+    assert.ok(touchedIndex > 1000, `perturbed only ${touchedIndex} catalogue fields, so the comparison below proves nothing`);
+    assert.ok(touchedChanges > 100, `perturbed only ${touchedChanges} change-log fields, so the comparison below proves nothing`);
+    [real, perturbed, changesBlind] = await Promise.all([
       startServer({}),
       startServer({ AGENTDEALS_INDEX_PATH: perturbedIndex }),
+      startServer({ AGENTDEALS_CHANGES_PATH: perturbedChanges }),
     ]);
     for (const page of pages) {
-      const [a, b] = await Promise.all([
+      const [a, b, c] = await Promise.all([
         fetch(`http://localhost:${real.port}${page.path}`).then((r) => r.text()),
         fetch(`http://localhost:${perturbed.port}${page.path}`).then((r) => r.text()),
+        fetch(`http://localhost:${changesBlind.port}${page.path}`).then((r) => r.text()),
       ]);
       bodies.set(page.path, a);
       consumesIndex.set(page.path, a !== b);
+      measured.set(page.path, {
+        reads_index: a !== b,
+        reads_changes: a !== c,
+        vendor_fact_rows: vendorFactRows(a, namedVendorSlug).length,
+      });
     }
   });
 
   after(() => {
     real?.proc.kill();
     perturbed?.proc.kill();
+    changesBlind?.proc.kill();
     if (tmp) rmSync(tmp, { recursive: true, force: true });
   });
 
   it("measures readership by perturbing the catalogue, not by trusting the register", () => {
-    const measured = pages.filter((p) => consumesIndex.get(p.path));
-    assert.ok(measured.length > 5, `only ${measured.length} pages responded to the catalogue at all`);
-    assert.ok(measured.length < pages.length, "every page responded, so the measurement cannot distinguish anything");
+    const reading = pages.filter((p) => consumesIndex.get(p.path));
+    assert.ok(reading.length > 5, `only ${reading.length} pages responded to the catalogue at all`);
+    assert.ok(reading.length < pages.length, "every page responded, so the measurement cannot distinguish anything");
     const wrong = pages.filter((p) => p.reads_index !== consumesIndex.get(p.path));
     assert.deepStrictEqual(
       wrong.map((p) => `${p.path} register=${p.reads_index} measured=${consumesIndex.get(p.path)}`),
       []
+    );
+  });
+
+  it("measures the change log separately, because a page blind to the catalogue may still render records", () => {
+    const readingChanges = pages.filter((p) => measured.get(p.path)!.reads_changes);
+    assert.ok(readingChanges.length > 5, `only ${readingChanges.length} pages responded to the change log at all`);
+    assert.ok(readingChanges.length < pages.length, "every page responded, so the measurement cannot distinguish anything");
+    const blindToCatalogue = pages.filter((p) => !p.reads_index);
+    const alsoReadingChanges = blindToCatalogue.filter((p) => measured.get(p.path)!.reads_changes);
+    assert.ok(
+      alsoReadingChanges.length > blindToCatalogue.length / 2,
+      "most pages blind to the catalogue read the change log, so the two measurements must stay distinct"
+    );
+  });
+
+  it("declares a data source for every registered page, and no page may assert one the render denies", () => {
+    assert.deepStrictEqual(
+      pages.filter((p) => !PAGE_DATA_SOURCES.includes(p.data_source)).map((p) => p.path),
+      []
+    );
+    assert.deepStrictEqual(pageSourceViolations(pages, measured).map((v) => `${v.path} ${v.problem}`), []);
+  });
+
+  it("holds the number of tier-A pages that assert vendor facts and read no catalogue record, and cannot admit another", () => {
+    const unsourced = unsourcedTierAPaths(pages);
+    assert.strictEqual(unsourced.length, UNSOURCED_TIER_A_BASELINE);
+    const admitted = [...pages, {
+      ...pages.find((p) => p.tier === "A")!,
+      path: "/a-page-that-does-not-exist",
+      data_source: "unsourced" as const,
+      reads_index: false,
+      reads_changes: false,
+    }];
+    const withOneMore = new Map(measured);
+    withOneMore.set("/a-page-that-does-not-exist", { reads_index: false, reads_changes: false, vendor_fact_rows: 0 });
+    assert.ok(
+      pageSourceViolations(admitted, withOneMore).length > 0,
+      "a forty-fourth unsourced tier-A page passed, so the ratchet allows the number to grow"
+    );
+  });
+
+  it("refuses an editorial exemption on a page that puts a number beside a vendor", () => {
+    const withFalseExemption = pages.map((p) =>
+      p.path === "/storage-comparison-2026"
+        ? { ...p, data_source: "editorial" as const, data_source_reason: "no vendor facts here" }
+        : p
+    );
+    const problems = pageSourceViolations(withFalseExemption, measured, UNSOURCED_TIER_A_BASELINE - 1);
+    assert.ok(
+      problems.some((v) => v.path === "/storage-comparison-2026" && v.problem.includes("table rows")),
+      `the exemption was accepted on a comparison page: ${JSON.stringify(problems)}`
+    );
+  });
+
+  it("counts vendor fact rows on the pages the exemption exists for, so the check is not passing on an empty page", () => {
+    const editorial = pages.filter((p) => p.data_source === "editorial");
+    assert.ok(editorial.length > 0, "no page declares the editorial exemption, so nothing exercises it");
+    for (const page of editorial) {
+      assert.ok(page.data_source_reason, `${page.path} claims the exemption without saying why`);
+      assert.ok(bodies.get(page.path)!.length > 1000, `${page.path} rendered almost nothing, so its zero fact rows prove nothing`);
+    }
+    const measuredRows = pages.filter((p) => measured.get(p.path)!.vendor_fact_rows > 0);
+    assert.ok(
+      measuredRows.length > 20,
+      `only ${measuredRows.length} pages were found to put a number beside a vendor, so the exemption check has almost nothing to refuse`
     );
   });
 
@@ -151,7 +219,7 @@ describe("a page may only name the source it actually reads", () => {
     assert.deepStrictEqual(offenders, []);
   });
 
-  it("tells the reader when the figures were compiled on every page that reads no record", () => {
+  it("tells the reader when the figures were compiled on every page that renders no catalogue field", () => {
     const wrong: string[] = [];
     for (const page of pages) {
       if (page.reads_index || page.tier !== "A") continue;
@@ -162,8 +230,91 @@ describe("a page may only name the source it actually reads", () => {
     assert.deepStrictEqual(wrong, []);
   });
 
+  it("says a reviewed page was checked on the date of the review, rather than never since publication", () => {
+    const wrong: string[] = [];
+    let checked = 0;
+    for (const page of pages) {
+      if (page.reads_index || page.tier !== "A") continue;
+      const found = bodies.get(page.path)!.match(COMPILED_NOTICE)!;
+      const claimed = found[2] ?? null;
+      const expected = page.reviewed_at;
+      if (claimed !== expected) wrong.push(`${page.path}: notice says last checked ${claimed}, register says ${expected}`);
+      if (expected !== null) checked += 1;
+    }
+    assert.deepStrictEqual(wrong, []);
+    assert.ok(checked > 0, "no blind tier-A page carries a review date, so the branch above is never taken");
+  });
+
+  it("makes no re-check claim anywhere on a page that the register contradicts", () => {
+    const offenders: string[] = [];
+    let claiming = 0;
+    for (const page of pages) {
+      const body = bodies.get(page.path)!;
+      const saysNever = /not re-checked since/.test(body);
+      const saysChecked = /last checked (\d{4}-\d{2}-\d{2})/.exec(body);
+      if (saysNever || saysChecked) claiming += 1;
+      if (page.reviewed_at === null && saysChecked) {
+        offenders.push(`${page.path}: claims a check on ${saysChecked[1]} with no review on the register`);
+      }
+      if (page.reviewed_at !== null && saysNever) {
+        offenders.push(`${page.path}: says it was never re-checked, reviewed ${page.reviewed_at}`);
+      }
+    }
+    assert.deepStrictEqual(offenders, []);
+    assert.ok(claiming > 20, `only ${claiming} pages make a re-check claim at all, so the rule has almost nothing to check`);
+  });
+
+  it("says corrections are outstanding wherever a review recorded a failure, and nowhere else", () => {
+    const failing = pages.filter((p) => p.review_outcome === "fail").map((p) => p.path);
+    const saying = pages.filter((p) => /corrections outstanding/.test(bodies.get(p.path)!)).map((p) => p.path);
+    assert.deepStrictEqual(saying.sort(), failing.sort());
+  });
+
   it("does not put the compiled notice on a page that reads the catalogue", () => {
     const wrong = pages.filter((p) => p.reads_index && COMPILED_NOTICE.test(bodies.get(p.path)!));
     assert.deepStrictEqual(wrong.map((p) => p.path), []);
+  });
+});
+
+describe("a review that found defects reaches the reader", () => {
+  const SUBJECT = "/storage-comparison-2026";
+  let tmp: string;
+  let server: { proc: ChildProcess; port: number };
+  const rendered = new Map<string, string>();
+
+  before(async () => {
+    tmp = mkdtempSync(path.join(tmpdir(), "failed-review-"));
+    const register = JSON.parse(readFileSync(path.join(REPO, "data", "page-reviews.json"), "utf-8"));
+    const subject = register.pages.find((p: any) => p.path === SUBJECT);
+    assert.ok(subject, `${SUBJECT} left the register, so this fixture no longer stands for anything`);
+    assert.strictEqual(subject.reviewed_at, null, `${SUBJECT} now carries a real review, so the fixture would not be a change`);
+    subject.reviewed_at = "2026-08-26";
+    subject.reviewer = "fixture";
+    subject.review_outcome = "fail";
+    const registerPath = path.join(tmp, "page-reviews.json");
+    writeFileSync(registerPath, JSON.stringify(register));
+    server = await startServer({ AGENTDEALS_PAGE_REVIEWS_PATH: registerPath });
+    for (const route of [SUBJECT, "/monitoring-comparison-2026"]) {
+      rendered.set(route, await fetch(`http://localhost:${server.port}${route}`).then((r) => r.text()));
+    }
+  });
+
+  after(() => {
+    server?.proc.kill();
+    if (tmp) rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it("says so on the page whose review failed", () => {
+    assert.match(rendered.get(SUBJECT)!, /Reviewed 2026-08-26, corrections outstanding/);
+  });
+
+  it("names the date the figures were last checked, rather than claiming none has happened", () => {
+    assert.match(rendered.get(SUBJECT)!, /Figures compiled 2026-04-03, last checked 2026-08-26/);
+    assert.doesNotMatch(rendered.get(SUBJECT)!, /Figures compiled 2026-04-03, not re-checked since/);
+  });
+
+  it("leaves a page the fixture did not touch saying it was never re-checked", () => {
+    assert.match(rendered.get("/monitoring-comparison-2026")!, /not re-checked since/);
+    assert.doesNotMatch(rendered.get("/monitoring-comparison-2026")!, /corrections outstanding/);
   });
 });

--- a/test/page-source-ratchet.test.ts
+++ b/test/page-source-ratchet.test.ts
@@ -1,0 +1,242 @@
+import { describe, it } from "node:test";
+import assert from "node:assert";
+import {
+  CATALOGUE_TEXT_FIELDS, PERTURBATION_SENTINEL, UNSOURCED_TIER_A_BASELINE,
+  compiledClause, compiledNotice, dataProvenanceFor, freshnessSegmentFor, pageSourceViolations,
+  parsePageReviews, perturbTextFields, unsourcedTierAPaths, vendorFactRows,
+  type PageDataSource, type PageReviewRecord, type PageSourceMeasurement,
+} from "../src/page-reviews.ts";
+
+function page(overrides: Partial<PageReviewRecord> & { path: string }): PageReviewRecord {
+  return {
+    published: "2026-04-03",
+    tier: "A",
+    vendors_asserted: [],
+    badge_subjects_unresolved: [],
+    reviewed_at: null,
+    reviewer: null,
+    review_outcome: null,
+    reads_index: false,
+    reads_changes: false,
+    data_source: "unsourced",
+    data_source_reason: null,
+    ...overrides,
+  };
+}
+
+function seen(overrides: Partial<PageSourceMeasurement> = {}): PageSourceMeasurement {
+  return { reads_index: false, reads_changes: false, vendor_fact_rows: 0, ...overrides };
+}
+
+function filled(count: number, source: PageDataSource = "unsourced"): PageReviewRecord[] {
+  return Array.from({ length: count }, (_, i) => page({ path: `/filler-${i}`, data_source: source }));
+}
+
+function measurementsFor(pages: PageReviewRecord[]): Map<string, PageSourceMeasurement> {
+  return new Map(pages.map(p => [p.path, seen({ reads_index: p.reads_index, reads_changes: p.reads_changes })]));
+}
+
+function problemsFor(pages: PageReviewRecord[], measured = measurementsFor(pages), budget = pages.filter(p => p.tier === "A" && p.data_source === "unsourced").length): string[] {
+  return pageSourceViolations(pages, measured, budget).map(v => `${v.path} ${v.problem}`);
+}
+
+describe("what a page says its figures came from has to survive perturbing the store", () => {
+  it("accepts a register whose every claim the measurement bears out", () => {
+    const pages = [
+      page({ path: "/reads", reads_index: true, data_source: "catalogue" }),
+      page({ path: "/blind" }),
+      page({ path: "/tool", tier: "B", data_source: "editorial", data_source_reason: "a calculator over what the reader typed" }),
+    ];
+    assert.deepStrictEqual(problemsFor(pages), []);
+  });
+
+  it("refuses a page claiming the catalogue that the perturbation leaves byte-identical", () => {
+    const pages = [page({ path: "/claims-too-much", data_source: "catalogue" })];
+    const problems = problemsFor(pages, new Map([["/claims-too-much", seen({ reads_index: false })]]), 0);
+    assert.ok(problems.some(p => p.includes("byte-identical")), problems.join(" | "));
+  });
+
+  it("refuses a page the perturbation moves that declares any source but the catalogue", () => {
+    for (const source of ["unsourced", "editorial"] as PageDataSource[]) {
+      const pages = [page({ path: "/reads", reads_index: true, data_source: source, data_source_reason: "stated" })];
+      const problems = problemsFor(pages, new Map([["/reads", seen({ reads_index: true })]]), 0);
+      assert.ok(problems.some(p => p.includes("renders catalogue fields")), `${source}: ${problems.join(" | ")}`);
+    }
+  });
+
+  it("reports a register entry nothing measured, rather than passing it", () => {
+    const problems = pageSourceViolations([page({ path: "/ghost" })], new Map(), 1).map(v => v.problem);
+    assert.deepStrictEqual(problems, ["on the register but not measured"]);
+  });
+
+  it("holds the register's reads_index and reads_changes to what the two perturbations found", () => {
+    const pages = [page({ path: "/p", reads_index: true, reads_changes: false, data_source: "catalogue" })];
+    const problems = problemsFor(pages, new Map([["/p", seen({ reads_index: true, reads_changes: true })]]), 0);
+    assert.ok(problems.some(p => p.includes("reads_changes says false")), problems.join(" | "));
+    const other = problemsFor(
+      [page({ path: "/p", reads_index: false, reads_changes: true })],
+      new Map([["/p", seen({ reads_index: true, reads_changes: true })]]),
+      0
+    );
+    assert.ok(other.some(p => p.includes("reads_index says false")), other.join(" | "));
+  });
+});
+
+describe("the editorial exemption has to be argued for", () => {
+  it("refuses an exemption with no stated reason", () => {
+    const pages = [page({ path: "/quiet", tier: "B", data_source: "editorial" })];
+    assert.ok(problemsFor(pages).some(p => p.includes("no stated reason")), problemsFor(pages).join(" | "));
+  });
+
+  it("refuses an exemption on a page that puts a number beside a catalogued vendor", () => {
+    const pages = [page({ path: "/table", tier: "B", data_source: "editorial", data_source_reason: "stated" })];
+    const problems = problemsFor(pages, new Map([["/table", seen({ vendor_fact_rows: 12 })]]), 0);
+    assert.ok(problems.some(p => p.includes("12 table rows")), problems.join(" | "));
+  });
+
+  it("refuses an exemption on a page whose verdict blocks name vendors", () => {
+    const pages = [page({ path: "/verdict", tier: "B", data_source: "editorial", data_source_reason: "stated", vendors_asserted: ["neon", "supabase"] })];
+    assert.ok(problemsFor(pages).some(p => p.includes("assert 2 vendors")), problemsFor(pages).join(" | "));
+  });
+});
+
+describe("the number of tier-A pages asserting vendor facts from nowhere only goes down", () => {
+  it("refuses one more than the budget", () => {
+    const pages = filled(4);
+    const problems = problemsFor(pages, measurementsFor(pages), 3);
+    assert.ok(problems.some(p => p.includes("4 tier-A pages") && p.includes("does not rise")), problems.join(" | "));
+  });
+
+  it("refuses a budget left above what the register now holds, so a freed slot cannot be reused", () => {
+    const pages = filled(3);
+    const problems = problemsFor(pages, measurementsFor(pages), 4);
+    assert.ok(problems.some(p => p.includes("lower UNSOURCED_TIER_A_BASELINE to 3")), problems.join(" | "));
+  });
+
+  it("counts only tier A, because the budget is a claim about pages that state a verdict", () => {
+    const pages = [...filled(2), page({ path: "/b-page", tier: "B" })];
+    assert.deepStrictEqual(unsourcedTierAPaths(pages), ["/filler-0", "/filler-1"]);
+  });
+
+  it("is the number the shipped register holds", () => {
+    assert.strictEqual(UNSOURCED_TIER_A_BASELINE, 43);
+  });
+});
+
+describe("a table row counts as a published vendor fact when it names a vendor and a number", () => {
+  const slugFor = (text: string) => (text === "Backblaze B2" ? "backblaze-b2" : null);
+
+  it("counts a row whose first cell names a vendor and whose cells carry a number", () => {
+    const html = "<table><tr><td>Backblaze B2</td><td>10 GB</td></tr></table>";
+    assert.deepStrictEqual(vendorFactRows(html, slugFor), [{ subject: "Backblaze B2", slug: "backblaze-b2" }]);
+  });
+
+  it("ignores a row about a vendor that asserts no number", () => {
+    assert.deepStrictEqual(vendorFactRows("<table><tr><td>Backblaze B2</td><td>Object storage</td></tr></table>", slugFor), []);
+  });
+
+  it("ignores a row of numbers that names no vendor", () => {
+    assert.deepStrictEqual(vendorFactRows("<table><tr><td>Bronze</td><td>10 codes/day</td></tr></table>", slugFor), []);
+  });
+
+  it("ignores a single-cell row, which states no fact about its subject", () => {
+    assert.deepStrictEqual(vendorFactRows("<table><tr><td>Backblaze B2 10 GB</td></tr></table>", slugFor), []);
+  });
+
+  it("does not read a number out of the vendor's own name", () => {
+    const html = "<table><tr><td>Backblaze B2</td><td>Object storage</td><td>Available</td></tr></table>";
+    assert.deepStrictEqual(vendorFactRows(html, slugFor), []);
+  });
+
+  it("reads a vendor from a link when the cell text does not resolve", () => {
+    const html = '<table><tr><td><a href="/vendor/cloudflare-r2">R2</a></td><td>10 GB</td></tr></table>';
+    assert.deepStrictEqual(vendorFactRows(html, () => null), [{ subject: "R2", slug: "cloudflare-r2" }]);
+  });
+
+  it("finds the number in any cell of the row, not only the second", () => {
+    const html = "<table><tr><td>Backblaze B2</td><td>Object storage</td><td>Free egress</td><td>3x stored</td></tr></table>";
+    assert.strictEqual(vendorFactRows(html, slugFor).length, 1);
+  });
+});
+
+describe("perturbing a store", () => {
+  it("replaces the digits and marks the field, so a render that echoes it cannot look unchanged", () => {
+    const records = [{ description: "10 GB free", tier: "free" }];
+    const touched = perturbTextFields(records, CATALOGUE_TEXT_FIELDS);
+    assert.strictEqual(touched, 2);
+    assert.strictEqual(records[0]!.description, `${PERTURBATION_SENTINEL} 99 GB free`);
+  });
+
+  it("leaves a field that is not a string alone, and counts only what it changed", () => {
+    const records = [{ description: null, notes: undefined, limits: 5, tier: "free" }];
+    assert.strictEqual(perturbTextFields(records, CATALOGUE_TEXT_FIELDS), 1);
+    assert.strictEqual(records[0]!.limits, 5);
+  });
+});
+
+describe("a review date means a review happened, and the outcome says what it found", () => {
+  it("keeps an outcome only where a review date supports it", () => {
+    const parsed = parsePageReviews(JSON.stringify({
+      pages: [
+        { path: "/a", published: "2026-04-03", tier: "A", reviewed_at: "2026-08-26", review_outcome: "fail" },
+        { path: "/b", published: "2026-04-03", tier: "A", reviewed_at: null, review_outcome: "pass" },
+        { path: "/c", published: "2026-04-03", tier: "A", reviewed_at: "2026-08-26", review_outcome: "inconclusive" },
+      ],
+    }));
+    assert.deepStrictEqual(parsed.pages.map(p => p.review_outcome), ["fail", null, null]);
+  });
+
+  it("treats a missing data source as the state that fails the ratchet, not as an exemption", () => {
+    const parsed = parsePageReviews(JSON.stringify({
+      pages: [{ path: "/a", published: "2026-04-03", tier: "A" }],
+    }));
+    assert.strictEqual(parsed.pages[0]!.data_source, "unsourced");
+    assert.strictEqual(parsed.pages[0]!.data_source_reason, null);
+  });
+
+  it("drops a reason that is only whitespace, so an exemption cannot be claimed with an empty string", () => {
+    const parsed = parsePageReviews(JSON.stringify({
+      pages: [{ path: "/a", published: "2026-04-03", tier: "B", data_source: "editorial", data_source_reason: "   " }],
+    }));
+    assert.strictEqual(parsed.pages[0]!.data_source_reason, null);
+  });
+
+  it("names the date of the last check instead of claiming none has happened", () => {
+    assert.strictEqual(compiledNotice("2026-04-03"), "Figures compiled 2026-04-03, not re-checked since");
+    assert.strictEqual(compiledNotice("2026-04-03", "2026-08-26"), "Figures compiled 2026-04-03, last checked 2026-08-26");
+  });
+
+  it("says corrections are outstanding on a page whose review failed", () => {
+    const failed = page({ path: "/p", reviewed_at: "2026-08-26", review_outcome: "fail" });
+    assert.strictEqual(freshnessSegmentFor(failed, "2026-08-27"), " &middot; Reviewed 2026-08-26, corrections outstanding");
+  });
+
+  it("keeps saying so once that review is old enough to expire, because the corrections are still outstanding", () => {
+    const failed = page({ path: "/p", reviewed_at: "2026-04-01", review_outcome: "fail" });
+    const passed = page({ path: "/q", reviewed_at: "2026-04-01", review_outcome: "pass" });
+    assert.match(freshnessSegmentFor(failed, "2026-08-27"), /corrections outstanding/);
+    assert.strictEqual(freshnessSegmentFor(passed, "2026-08-27"), "");
+  });
+
+  it("claims no review date it cannot stand behind, on a page reviewed in the future", () => {
+    const ahead = page({ path: "/p", reviewed_at: "2026-09-30", review_outcome: "fail" });
+    assert.strictEqual(freshnessSegmentFor(ahead, "2026-08-27"), " &middot; Not yet reviewed");
+  });
+
+  it("does not name a future review date as the day the figures were last checked", () => {
+    const ahead = page({ path: "/p", published: "2026-04-03", reviewed_at: "2026-09-30", review_outcome: "pass" });
+    assert.strictEqual(dataProvenanceFor(ahead, 1580, "2026-08-27"), "Figures compiled 2026-04-03, not re-checked since");
+    assert.strictEqual(compiledClause(ahead, "2026-08-27"), "Compiled 2026-04-03, not re-checked since");
+  });
+
+  it("names the check on both surfaces once that date has arrived", () => {
+    const checked = page({ path: "/p", published: "2026-04-03", reviewed_at: "2026-08-26", review_outcome: "pass" });
+    assert.strictEqual(dataProvenanceFor(checked, 1580, "2026-08-27"), "Figures compiled 2026-04-03, last checked 2026-08-26");
+    assert.strictEqual(compiledClause(checked, "2026-08-27"), "Compiled 2026-04-03, last checked 2026-08-26");
+  });
+
+  it("cites the catalogue instead of a compilation date on a page that renders catalogue fields", () => {
+    const reading = page({ path: "/p", reads_index: true, data_source: "catalogue", reviewed_at: "2026-08-26", review_outcome: "pass" });
+    assert.strictEqual(dataProvenanceFor(reading, 1580, "2026-08-27"), "Data verified from our index of 1,580 developer tools");
+  });
+});


### PR DESCRIPTION
Refs #1073 — AC-A, plus the `review_outcome` field asked for in the `/monitoring-comparison-2026` review and the byline contradiction noted when AC-C was verified.

## The ratchet

Every register entry declares a `data_source`:

| value | how it is held |
|---|---|
| `catalogue` | measured both ways against the catalogue perturbation — a page cannot claim it or withhold it wrongly |
| `editorial` | needs a written reason, and is refused on any page rendering a table row that puts a number beside a catalogued vendor, or whose verdict blocks name one |
| `unsourced` | the known defect; the tier-A count must equal `UNSOURCED_TIER_A_BASELINE` **exactly** |

Exact equality is what makes it a ratchet in both directions. A forty-fourth page fails. Fixing one also fails until the baseline is lowered in the same change, so a freed slot cannot be quietly reused.

`data_source` absent from an entry parses as `unsourced` — the state that fails — so a new page has to be argued for rather than defaulting into an exemption.

**43 seeded, reproduced independently.** `sync-page-reviews.js` measures the same 43 the perturbation experiment found, with zero register disagreements.

## What the check covers, and what it does not

**It is a claim about the catalogue, not about records in general.** Perturbing `deal_changes.json` as well shows **40 of the 43 blind tier-A pages do read change records** — only `/hetzner-pricing-2026`, `/terraform-cloud-free-tier-removed` and `/free-tier-risk` read nothing at all. So `reads_changes` is now measured and stored alongside `reads_index`, and `unsourced` means *asserts catalogue-class vendor facts that reach no record*, not *reads nothing*.

**The exemption check is necessary, not sufficient.** It refuses `editorial` on 39 of the 43 by table rows and catches `/q1-2026-developer-pricing-report` and `/q2-pricing-preview-2026` through `vendors_asserted`. `/shutdowns` and `/tenor-alternatives` would pass it, so declaring either one editorial would take a false written reason plus lowering the baseline in the same commit. Stated rather than papered over.

**Page granularity cannot see a block-level defect** — a page can read a record for one section and publish frozen prose above it. That is #1081's, not this.

## The exemption has four real occupants

`/budget-builder`, `/compare-tool`, `/disclosure` and `/marketplace`, each with a one-line reason. `/marketplace` is the one that shows why the rule is vendor-scoped rather than digit-scoped: it renders six numeric rows, and every one is our own referral quota or revenue split.

## A bug in the register's own maintenance script

`sync-page-reviews.js` rebuilt each record without `reads_index`. Running it wiped the field from all 67 entries — the 20 pages that cite the catalogue would have started printing "not re-checked since". Proven, not reasoned: regenerating to a temp file gave 0 of 67 entries carrying the field.

It now measures both fields from perturbed copies of both stores, and the file round-trips byte-identically.

## `review_outcome`

`reviewed_at` meant *reviewed and found correct*, so the convention for a failing review was to leave the date off — and a page nobody had read was indistinguishable from one that had failed.

`review-page.js` now requires `--outcome`. A **pass** still has to name every vendor the page's verdicts commit us to. A **fail** does not: making a reader finish the sweep before recording one wrong number is exactly what leaves the defect unrecorded. A failed review renders `Reviewed <date>, corrections outstanding`, and **keeps saying so after the review expires** — expiry means we stop claiming currency, and a page with outstanding corrections is the opposite of current.

## The contradiction, and a second copy of it

`/email-comparison-2026` rendered `Reviewed 2026-08-26 · Figures compiled 2026-04-03, not re-checked since`. The notice took `published` unconditionally and never consulted the review. It now names the date of the last check.

A **hand-typed copy of the same claim** sits in the "How we track this data" block on seven pages — `Compiled ${pubDate}, not re-checked since` — which was already false on `/email-comparison-2026`. It now derives from the register, and a test fails when any page makes a re-check claim the register contradicts. Reverting one site fails that test.

## Recorded as failing, not fixed

`/email-comparison-2026` leads with a stat card reading **`62K — Highest Free Volume (SES from EC2)`**. The same page's verdict says SES "no longer has a free tier — AWS replaced the old 62,000/month-from-EC2 allowance with $200 of Free Tier credits"; its body says "SES has no free tier at all now"; our record, verified today, says "No perpetual free tier".

I marked the page rather than editing the card. Removing it means either dropping a stat card or reassigning a superlative I have not verified, which is content work this issue explicitly defers. The page now tells the reader corrections are outstanding.

## Verified

- **1955 tests / 0 failures**, exit code captured directly, suite run twice. 42 new.
- **26 mutations, all killed**, after three rounds. Round one had two survivors and three that would not compile; the compile failures were a finding — `pageSourceViolations` was restructured so the measurement is non-optional in the rule body and every branch is mutable. One surviving mutation was a real gap (a review dated in the future was trusted by the compilation notice but not by the byline); the other removed a TypeScript guard with no observable behaviour and was dropped.
- **`mutate-1073-acc.sh` repaired and re-run — 5 mutations, all killed**, so the previous criterion's guarantees still hold against the new shape.
- **3,914 sitemap routes rendered against a `main` worktree and diffed.** 5 differ. Four are the intended change; the fifth is `/this-week`, whose only difference is a URL-encoded port in three share links. Every added and removed sentence read individually, and the JSON-LD compared key by key — the sole structured change is `dateModified` moving to the new review date.
- A digit inside a vendor's own name (`Backblaze B2`, `Cloudflare R2`) made its row count as a fact about itself. The number must now be in a cell other than the subject.
- `tsc` clean, `validate-data` clean, **0 new code comments**, screenshot of the changed byline.