### PR TITLE
Carry the page's provenance into the machine-readable copy

### DIFF
--- a/scripts/faq-figure-audit.js
+++ b/scripts/faq-figure-audit.js
@@ -1,0 +1,100 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { spawn } from "node:child_process";
+import { statesVendorFigure } from "../dist/faq-provenance.js";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO = path.join(__dirname, "..");
+
+const PROVENANCE = /Figures compiled \d{4}-\d{2}-\d{2}, (?:not re-checked since|last checked \d{4}-\d{2}-\d{2})/;
+
+function startServer(env = {}) {
+  return new Promise((resolve, reject) => {
+    const child = spawn("node", [path.join(REPO, "dist", "serve.js")], {
+      cwd: REPO,
+      stdio: ["ignore", "ignore", "pipe"],
+      env: { ...process.env, PORT: "0", BASE_URL: "http://localhost:3000", ...env },
+    });
+    const timeout = setTimeout(() => { child.kill(); reject(new Error("timeout")); }, 60000);
+    child.stderr.on("data", (d) => {
+      const m = d.toString().match(/running on http:\/\/localhost:(\d+)/);
+      if (m) { clearTimeout(timeout); resolve({ proc: child, port: parseInt(m[1], 10) }); }
+    });
+    child.on("error", (e) => { clearTimeout(timeout); reject(e); });
+  });
+}
+
+export function faqAnswers(html) {
+  const out = [];
+  const re = /<script type="application\/ld\+json">([\s\S]*?)<\/script>/g;
+  let m;
+  while ((m = re.exec(html)) !== null) {
+    let parsed;
+    try { parsed = JSON.parse(m[1]); } catch { continue; }
+    for (const block of Array.isArray(parsed) ? parsed : [parsed]) {
+      if (!block || block["@type"] !== "FAQPage" || !Array.isArray(block.mainEntity)) continue;
+      for (const q of block.mainEntity) {
+        const text = q?.acceptedAnswer?.text;
+        if (typeof text === "string") out.push({ question: q.name, answer: text });
+      }
+    }
+  }
+  return out;
+}
+
+export function hasProvenance(text) {
+  return PROVENANCE.test(text);
+}
+
+export async function auditRegisterFaqs(env = {}) {
+  const reviews = JSON.parse(readFileSync(path.join(REPO, "data", "page-reviews.json"), "utf-8"));
+  const paths = reviews.pages.map((p) => p.path);
+  const { proc, port } = await startServer(env);
+  const pages = [];
+  try {
+    for (const p of paths) {
+      const res = await fetch(`http://localhost:${port}${p}`);
+      const items = faqAnswers(await res.text());
+      if (items.length > 0) pages.push({ path: p, items });
+    }
+  } finally {
+    proc.kill();
+  }
+  return { register_pages: paths.length, pages };
+}
+
+async function main() {
+  const { register_pages, pages } = await auditRegisterFaqs();
+  let answers = 0, figures = 0, covered = 0, digitsUncovered = 0;
+  const perPage = [];
+  const uncovered = [];
+  for (const { path: p, items } of pages) {
+    answers += items.length;
+    const fig = items.filter((i) => statesVendorFigure(i.answer));
+    const cov = fig.filter((i) => hasProvenance(i.answer));
+    figures += fig.length;
+    covered += cov.length;
+    for (const i of items) {
+      if (!statesVendorFigure(i.answer) && /\d/.test(i.answer)) {
+        digitsUncovered += 1;
+        uncovered.push({ path: p, question: i.question });
+      }
+    }
+    perPage.push({ path: p, answers: items.length, figures: fig.length, covered: cov.length });
+    for (const i of fig) if (!hasProvenance(i.answer)) console.error(`UNCOVERED ${p} :: ${i.question}`);
+  }
+  perPage.sort((a, b) => b.figures - a.figures || a.path.localeCompare(b.path));
+  console.log(JSON.stringify({
+    register_pages,
+    pages_with_faq: pages.length,
+    answers,
+    answers_stating_a_figure: figures,
+    answers_stating_a_figure_with_provenance: covered,
+    answers_with_a_digit_and_no_figure: digitsUncovered,
+    per_page: perPage,
+    digit_but_no_figure: uncovered,
+  }, null, 2));
+}
+
+if (process.argv[1] && process.argv[1].endsWith("faq-figure-audit.js")) await main();

--- a/scripts/mutate-1086.sh
+++ b/scripts/mutate-1086.sh
@@ -1,0 +1,133 @@
+#!/usr/bin/env bash
+set -uo pipefail
+cd "$(dirname "$0")/.."
+
+PASS=0
+FAIL=0
+PROV="test/faq-provenance.test.ts"
+UNIT="test/page-freshness.test.ts"
+BOTH="$PROV $UNIT"
+
+run_mutation() {
+  local name="$1" file="$2" from="$3" to="$4" tests="${5:-$BOTH}"
+  cp "$file" "$file.bak"
+  if ! python3 - "$file" "$from" "$to" <<'PY'
+import sys, pathlib
+path, old, new = sys.argv[1], sys.argv[2], sys.argv[3]
+p = pathlib.Path(path)
+s = p.read_text()
+if s.count(old) != 1:
+    print(f"SKIP: pattern found {s.count(old)} times", file=sys.stderr)
+    sys.exit(3)
+p.write_text(s.replace(old, new))
+PY
+  then
+    echo "SKIP  $name (pattern stale)"
+    mv "$file.bak" "$file"
+    FAIL=$((FAIL + 1))
+    return
+  fi
+
+  if ! npm run build > /tmp/mut-1086-build.log 2>&1; then
+    echo "SKIP  $name (build failed)"
+    mv "$file.bak" "$file"
+    npm run build > /dev/null 2>&1
+    FAIL=$((FAIL + 1))
+    return
+  fi
+
+  node --test --experimental-strip-types $tests > /tmp/mut-1086.log 2>&1
+  local status=$?
+  mv "$file.bak" "$file"
+  npm run build > /dev/null 2>&1
+
+  if [ $status -ne 0 ]; then
+    echo "KILLED  $name"
+    PASS=$((PASS + 1))
+  else
+    echo "SURVIVED  $name  <-- $tests did not notice"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+run_mutation "a review that found defects advances the structured date" src/page-reviews.ts \
+  '  if (status.review_outcome === "fail") return record.published;
+  return status.reviewed_at ?? record.published;' \
+  '  return status.reviewed_at ?? record.published;'
+
+run_mutation "a clean review holds the structured date back too" src/page-reviews.ts \
+  '  if (status.review_outcome === "fail") return record.published;
+  return status.reviewed_at ?? record.published;' \
+  '  return record.published;'
+
+run_mutation "the clause never says corrections are outstanding" src/faq-provenance.ts \
+  'return status.review_outcome === "fail" ? `${notice}; corrections outstanding.` : `${notice}.`;' \
+  'return `${notice}.`;'
+
+run_mutation "every clause says corrections are outstanding" src/faq-provenance.ts \
+  'return status.review_outcome === "fail" ? `${notice}; corrections outstanding.` : `${notice}.`;' \
+  'return `${notice}; corrections outstanding.`;'
+
+run_mutation "the clause forgets the date of the last check" src/faq-provenance.ts \
+  'const notice = compiledNotice(record.published, status.reviewed_at);' \
+  'const notice = compiledNotice(record.published, null);'
+
+run_mutation "no answer carries a clause" src/faq-provenance.ts \
+  'if (!clause || !statesVendorFigure(text)) return text;' \
+  'return text;'
+
+run_mutation "every answer carries a clause" src/faq-provenance.ts \
+  'if (!clause || !statesVendorFigure(text)) return text;' \
+  'if (!clause) return text;'
+
+run_mutation "a page off the register still gets a clause" src/faq-provenance.ts \
+  '  if (!record) return "";
+  const status = reviewStatus(record, today);' \
+  '  if (!record) return "Figures compiled 2026-01-01, not re-checked since.";
+  const status = reviewStatus(record, today);'
+
+run_mutation "the clause is built from a page path nobody passed" src/faq-provenance.ts \
+  'const clause = pageFaqProvenanceClause(pagePath, today);' \
+  'const clause = pageFaqProvenanceClause("/", today);'
+
+run_mutation "a currency amount is not a figure" src/faq-provenance.ts \
+  'if (CURRENCY_AMOUNT.test(answer) || statesQuota(answer)) return true;' \
+  'if (statesQuota(answer)) return true;'
+
+run_mutation "a quota is not a figure" src/faq-provenance.ts \
+  'if (CURRENCY_AMOUNT.test(answer) || statesQuota(answer)) return true;' \
+  'if (CURRENCY_AMOUNT.test(answer)) return true;'
+
+run_mutation "a percentage we state about ourselves counts as a vendor figure" src/faq-provenance.ts \
+  'return PERCENTAGE.test(answer) && !FIRST_PERSON.test(answer);' \
+  'return PERCENTAGE.test(answer);'
+
+run_mutation "a percentage never counts as a figure" src/faq-provenance.ts \
+  'return PERCENTAGE.test(answer) && !FIRST_PERSON.test(answer);' \
+  'return false;'
+
+run_mutation "a count we state about ourselves counts as a vendor figure" src/faq-provenance.ts \
+  'if (!FIRST_PERSON.test(answer.slice(Math.max(0, m.index - OWN_COUNT_WINDOW), m.index))) return true;' \
+  'return true;'
+
+run_mutation "a number inside a product name counts as a figure" src/faq-provenance.ts \
+  '`(?<![\\w-])\\d[\\d,.]*' \
+  '`\\b\\d[\\d,.]*'
+
+run_mutation "markup reaches the structured copy" src/faq-provenance.ts \
+  'return answer.replace(HTML_TAG, "").replace(/\s+/g, " ").trim();' \
+  'return answer.trim();'
+
+run_mutation "the comparison pages recommend a vendor on its stability share" src/serve.ts \
+  '    {
+      q: `How do ${catName.toLowerCase()} free tiers compare on limits?`,' \
+  '    {
+      q: `Are free ${catName.toLowerCase()} services reliable enough for production?`,
+      a: `Most of the ${catName.toLowerCase()} services we track have stable pricing histories. For production use, prioritize providers rated "stable" in our analysis.`,
+    },
+    {
+      q: `How do ${catName.toLowerCase()} free tiers compare on limits?`,'
+
+echo
+echo "killed: $PASS   survived: $FAIL"
+[ "$FAIL" -eq 0 ]

--- a/src/faq-provenance.ts
+++ b/src/faq-provenance.ts
@@ -1,0 +1,85 @@
+import { compiledNotice, getPageReview, reviewStatus, utcToday, type PageReviewRecord } from "./page-reviews.js";
+
+export interface FaqItem {
+  q: string;
+  a: string;
+}
+
+export const FAQ_BASELINE = {
+  answers: 166,
+  stating_a_figure: 77,
+  a_digit_but_no_figure: 39,
+};
+
+const CURRENCY_AMOUNT = /[$€£¢]\s?\d|\d\s?¢|\b\d[\d,.]*\s?(?:USD|EUR|GBP)\b/;
+
+const PERCENTAGE = /\d[\d.]*\s?%/;
+
+const FIRST_PERSON = /\b(?:we|our|ours)\b/i;
+
+export const CONSUMPTION_UNITS = [
+  "GiB", "TiB", "MiB", "KiB", "GB", "TB", "MB", "KB",
+  "seconds", "minutes", "minute", "mins", "min", "hours", "hour", "hrs", "days", "day", "months", "month",
+  "requests", "request", "emails", "email", "errors", "events", "users", "MAU", "seats", "seat", "members",
+  "collaborators", "runs", "run", "records", "record", "replays", "resources", "resource", "builds",
+  "build", "credits", "tokens", "token", "commands", "calls", "invocations", "characters", "messages",
+  "sessions", "rows", "operations", "ops", "projects", "repositories", "repos", "domains", "sites",
+  "containers", "workflows", "jobs", "pipelines", "spans", "logs", "traces", "metrics", "monitors",
+  "checks", "images", "vectors", "environments", "branches", "apps", "concurrency",
+];
+
+const QUOTA_FIGURE = new RegExp(
+  `(?<![\\w-])\\d[\\d,.]*(?:\\s?[-–]\\s?\\d[\\d,.]*)?\\+?[\\s-]?[KMB]?[\\s-]*(?:[a-zA-Z][a-zA-Z-]*[\\s-]+){0,2}(?:${CONSUMPTION_UNITS.join("|")})\\b`,
+  "g",
+);
+
+const OWN_COUNT_WINDOW = 40;
+
+function statesQuota(answer: string): boolean {
+  QUOTA_FIGURE.lastIndex = 0;
+  for (let m = QUOTA_FIGURE.exec(answer); m !== null; m = QUOTA_FIGURE.exec(answer)) {
+    if (!FIRST_PERSON.test(answer.slice(Math.max(0, m.index - OWN_COUNT_WINDOW), m.index))) return true;
+  }
+  return false;
+}
+
+export function statesVendorFigure(answer: string): boolean {
+  if (CURRENCY_AMOUNT.test(answer) || statesQuota(answer)) return true;
+  return PERCENTAGE.test(answer) && !FIRST_PERSON.test(answer);
+}
+
+export function faqProvenanceClause(record: PageReviewRecord | null, today: string): string {
+  if (!record) return "";
+  const status = reviewStatus(record, today);
+  const notice = compiledNotice(record.published, status.reviewed_at);
+  return status.review_outcome === "fail" ? `${notice}; corrections outstanding.` : `${notice}.`;
+}
+
+export function pageFaqProvenanceClause(pagePath: string, today = utcToday()): string {
+  return faqProvenanceClause(getPageReview(pagePath), today);
+}
+
+const HTML_TAG = /<\/?[a-zA-Z][^>]*>/g;
+
+function plainText(answer: string): string {
+  return answer.replace(HTML_TAG, "").replace(/\s+/g, " ").trim();
+}
+
+export function answerWithProvenance(answer: string, clause: string): string {
+  const text = plainText(answer);
+  if (!clause || !statesVendorFigure(text)) return text;
+  return `${text} ${clause}`;
+}
+
+export function faqPageJsonLd(pagePath: string, items: FaqItem[], today = utcToday()): Record<string, unknown> {
+  const clause = pageFaqProvenanceClause(pagePath, today);
+  return {
+    "@context": "https://schema.org",
+    "@type": "FAQPage",
+    mainEntity: items.map(item => ({
+      "@type": "Question",
+      name: item.q,
+      acceptedAnswer: { "@type": "Answer", text: answerWithProvenance(item.a, clause) },
+    })),
+  };
+}

--- a/src/page-reviews.ts
+++ b/src/page-reviews.ts
@@ -244,10 +244,15 @@ export function pageCompiledClause(pagePath: string, today = utcToday()): string
   return compiledClause(getPageReview(pagePath), today);
 }
 
-export function pageDateModified(pagePath: string, fallbackPublished: string, today = utcToday()): string {
-  const record = getPageReview(pagePath);
+export function dateModifiedFor(record: PageReviewRecord | null, fallbackPublished: string, today: string): string {
   if (!record) return fallbackPublished;
-  return reviewStatus(record, today).reviewed_at ?? record.published;
+  const status = reviewStatus(record, today);
+  if (status.review_outcome === "fail") return record.published;
+  return status.reviewed_at ?? record.published;
+}
+
+export function pageDateModified(pagePath: string, fallbackPublished: string, today = utcToday()): string {
+  return dateModifiedFor(getPageReview(pagePath), fallbackPublished, today);
 }
 
 export function pagePublished(pagePath: string, fallbackPublished: string): string {

--- a/src/serve.ts
+++ b/src/serve.ts
@@ -27,6 +27,7 @@ import { addFriend, removeFriend, getFriends, getFriendCodesForVendors } from ".
 import { subscribe as watchlistSubscribe, getSubscription as getWatchlistSubscription, unsubscribe as watchlistUnsubscribe, listSubscriptions as listWatchlistSubscriptions } from "./watchlist.js";
 import { toSlug, vendorSlugMap, resolveVendorSlug, namedVendorSlug } from "./vendor-slug.js";
 import { linkifyVerdictBlocks, overdueReport, pageCompiledClause, pageDataProvenance, pageDateModified, pageFreshness, pageFreshnessSentence, utcToday, verdictsOutdatedBy } from "./page-reviews.js";
+import { faqPageJsonLd, type FaqItem } from "./faq-provenance.js";
 import { rankOffers, rankForListing, rotateListing, utcDate, CRITERIA_PATH, DEMOTE_ONLY_POLICY, DISCLOSURE_RATIONALE, TIE_BREAK_ALGORITHM, GATE_TABLE, DEMERIT_TABLE, NOT_FREE_TIER_RULES, TIME_LIMITED_TIER_RULES } from "./ranking.js";
 import type { RankedEntry, RankingResult } from "./ranking.js";
 import { partitionAlternatives, partitionAlternativesAcross, productRoleSentence, MEMBERSHIP_GATE_RULES, MEMBERSHIP_GATE_ORDER, MEMBERSHIP_GATE_SYMMETRY, MEMBERSHIP_GATE_SCOPE, MEMBERSHIP_GATE_CORRECTIONS } from "./product-role.js";
@@ -1081,24 +1082,12 @@ function buildCategoryPage(slug: string): string | null {
     : "";
 
   // Category FAQ
-  const enrichedOffers = enrichOffers(catOffers);
-  const stableCount = enrichedOffers.filter(o => o.stability === "stable").length;
-  const stablePct = catCount > 0 ? Math.round((stableCount / catCount) * 100) : 0;
   const topAlts = catOffers.slice(0, 5).map(o => escHtmlServer(o.vendor)).join(", ");
-  const productionAnswer = stablePct >= 80
-    ? `Many free ${categoryName.toLowerCase()} tiers are suitable for small production workloads. ${stablePct}% of vendors in this category have stable pricing with no recorded changes. Always monitor your usage against free tier limits and have an upgrade plan.`
-    : stablePct >= 50
-    ? `Some free ${categoryName.toLowerCase()} tiers can work for production, but evaluate stability carefully. ${stablePct}% of vendors have stable pricing. For critical services, prefer vendors with no pricing changes in their history.`
-    : `Free ${categoryName.toLowerCase()} tiers should be used cautiously in production. Only ${stablePct}% of vendors have fully stable pricing. Consider self-hosted options or vendors with strong stability records for critical workloads.`;
 
   const faqItems = [
     {
       q: `What is the best free ${categoryName.toLowerCase()} service?`,
       a: `Based on our data, the most popular free ${categoryName.toLowerCase()} services include ${topAlts}. ${topVendor ? `${escHtmlServer(topVendor.vendor)} offers ${escHtmlServer(keyLimit)} on their ${escHtmlServer(topVendor.tier)} plan.` : ""} The best choice depends on your specific requirements.`,
-    },
-    {
-      q: `Are free ${categoryName.toLowerCase()} tiers good for production?`,
-      a: productionAnswer,
     },
     {
       q: `How many free ${categoryName.toLowerCase()} tools are there?`,
@@ -1107,8 +1096,8 @@ function buildCategoryPage(slug: string): string | null {
     {
       q: `How stable are ${categoryName.toLowerCase()} free tiers?`,
       a: catChangeCount === 0
-        ? `Very stable. No pricing changes have been recorded for any ${categoryName.toLowerCase()} vendor we track. This is one of the most stable categories.`
-        : `${catChangeCount} pricing change${catChangeCount > 1 ? "s have" : " has"} been recorded across ${categoryName.toLowerCase()} vendors. ${stablePct}% of vendors have had no changes at all. Check our <a href="/stability">Stability Dashboard</a> for per-vendor details.`,
+        ? `No pricing changes have been recorded for any ${categoryName.toLowerCase()} vendor we track.`
+        : `${catChangeCount} pricing change${catChangeCount > 1 ? "s have" : " has"} been recorded across ${categoryName.toLowerCase()} vendors. Check our <a href="/stability">Stability Dashboard</a> for per-vendor details.`,
     },
   ];
 
@@ -1121,18 +1110,7 @@ function buildCategoryPage(slug: string): string | null {
   </div>`;
 
   // FAQ JSON-LD
-  const faqJsonLd = {
-    "@context": "https://schema.org",
-    "@type": "FAQPage",
-    mainEntity: faqItems.map(f => ({
-      "@type": "Question",
-      name: f.q,
-      acceptedAnswer: {
-        "@type": "Answer",
-        text: f.a.replace(/<[^>]*>/g, ""),
-      },
-    })),
-  };
+  const faqJsonLd = faqPageJsonLd("/category/" + slug, faqItems);
 
   // JSON-LD structured data (ItemList + FAQPage)
   const jsonLd = {
@@ -2417,15 +2395,7 @@ function buildComparisonPage(slug: string): string | null {
     },
   };
 
-  const faqJsonLd = {
-    "@context": "https://schema.org",
-    "@type": "FAQPage",
-    mainEntity: faqItems.map(item => ({
-      "@type": "Question",
-      name: item.q,
-      acceptedAnswer: { "@type": "Answer", text: item.a },
-    })),
-  };
+  const faqJsonLd = faqPageJsonLd("/" + slug, faqItems);
 
   // Related comparisons (share a vendor with this pair)
   const relatedComparisons = Array.from(comparisonMap.entries())
@@ -2919,15 +2889,7 @@ ${editorialVs.map(p => `      <a href="/${p.slug}" class="related-card">${escHtm
     publisher: { "@type": "Organization", name: "AgentDeals", url: BASE_URL },
   };
 
-  const faqJsonLd = {
-    "@context": "https://schema.org",
-    "@type": "FAQPage",
-    mainEntity: faqItems.map(f => ({
-      "@type": "Question",
-      name: f.q,
-      acceptedAnswer: { "@type": "Answer", text: f.a },
-    })),
-  };
+  const faqJsonLd = faqPageJsonLd("/" + slug, faqItems);
 
   return `<!DOCTYPE html>
 <html lang="en">
@@ -4181,18 +4143,7 @@ ${allCompareLinks.join("\n")}
     { q: `What category is ${vendorName} in?`, a: faqCategoryAnswer },
   ];
 
-  const faqJsonLd = {
-    "@context": "https://schema.org",
-    "@type": "FAQPage",
-    mainEntity: vendorFaqItems.map(item => ({
-      "@type": "Question",
-      name: item.q,
-      acceptedAnswer: {
-        "@type": "Answer",
-        text: item.a,
-      },
-    })),
-  };
+  const faqJsonLd = faqPageJsonLd("/vendor/" + slug, vendorFaqItems);
 
   const faqHtml = `
   <div class="section faq-section">
@@ -4558,18 +4509,7 @@ ${enrichedAlts.map(a => altCard(a, false)).join("\n")}
     { q: `Has ${vendorName} changed their pricing recently?`, a: faqChangesAnswer },
   ];
 
-  const altFaqJsonLd = {
-    "@context": "https://schema.org",
-    "@type": "FAQPage",
-    mainEntity: altFaqItems.map(item => ({
-      "@type": "Question",
-      name: item.q,
-      acceptedAnswer: {
-        "@type": "Answer",
-        text: item.a,
-      },
-    })),
-  };
+  const altFaqJsonLd = faqPageJsonLd("/alternative-to/" + slug, altFaqItems);
 
   const altFaqHtml = `
   <div class="section faq-section">
@@ -15642,32 +15582,12 @@ function buildFreeNextjsStackPage(): string {
     author: { "@type": "Organization", name: "AgentDeals", url: BASE_URL },
   };
 
-  const faqJsonLd = {
-    "@context": "https://schema.org",
-    "@type": "FAQPage",
-    mainEntity: [
-      {
-        "@type": "Question",
-        name: "Is Vercel free for Next.js?",
-        acceptedAnswer: { "@type": "Answer", text: "Yes. Vercel's Hobby plan is free with 100 GB bandwidth, 100 hours serverless function execution, and 6,000 build minutes per month. However, it's limited to non-commercial, personal use. For commercial projects, Vercel Pro starts at $20/month per team member. Alternatives like Railway ($5/month free credit) and Cloudflare Pages (unlimited bandwidth) allow commercial use on free tiers." },
-      },
-      {
-        "@type": "Question",
-        name: "What's the best free database for Next.js?",
-        acceptedAnswer: { "@type": "Answer", text: "Neon (serverless Postgres) is the best fit for Next.js. Its serverless driver works in Vercel Edge Functions, it scales to zero when not in use, and offers 0.5 GiB storage free. Supabase (500 MB, includes auth and realtime) is great if you need a full BaaS. Turso (9 GB, edge SQLite) is ideal for read-heavy apps. PlanetScale removed its free tier in April 2024." },
-      },
-      {
-        "@type": "Question",
-        name: "Can I build a SaaS for free with Next.js?",
-        acceptedAnswer: { "@type": "Answer", text: "Yes — with limits. This guide covers 10 infrastructure layers that cost $0/month total: hosting (Vercel), database (Neon), auth (Clerk 10K MAU), storage (R2), email (Resend 3K/mo), monitoring (Sentry), CI/CD (GitHub Actions), analytics (PostHog 1M events), search (Algolia 10K records), and background jobs (Inngest 25K runs). Most projects can run their entire stack on free tiers until they hit significant traction." },
-      },
-      {
-        "@type": "Question",
-        name: "What's the first thing to spend money on when scaling a Next.js app?",
-        acceptedAnswer: { "@type": "Answer", text: "Database. Neon's 0.5 GiB free storage is the tightest limit in the stack. The Neon Launch plan at $19/month gets you 10 GiB storage, 300 compute hours, and autoscaling. After that, hosting: Vercel Pro at $20/month unlocks commercial use, 1 TB bandwidth, and faster builds. Everything else (auth, email, monitoring, analytics) scales to meaningful traffic on free tiers." },
-      },
-    ],
-  };
+  const faqJsonLd = faqPageJsonLd("/free-nextjs-stack", [
+    { q: "Is Vercel free for Next.js?", a: "Yes. Vercel's Hobby plan is free with 100 GB bandwidth, 100 hours serverless function execution, and 6,000 build minutes per month. However, it's limited to non-commercial, personal use. For commercial projects, Vercel Pro starts at $20/month per team member. Alternatives like Railway ($5/month free credit) and Cloudflare Pages (unlimited bandwidth) allow commercial use on free tiers." },
+    { q: "What's the best free database for Next.js?", a: "Neon (serverless Postgres) is the best fit for Next.js. Its serverless driver works in Vercel Edge Functions, it scales to zero when not in use, and offers 0.5 GiB storage free. Supabase (500 MB, includes auth and realtime) is great if you need a full BaaS. Turso (9 GB, edge SQLite) is ideal for read-heavy apps. PlanetScale removed its free tier in April 2024." },
+    { q: "Can I build a SaaS for free with Next.js?", a: "Yes — with limits. This guide covers 10 infrastructure layers that cost $0/month total: hosting (Vercel), database (Neon), auth (Clerk 10K MAU), storage (R2), email (Resend 3K/mo), monitoring (Sentry), CI/CD (GitHub Actions), analytics (PostHog 1M events), search (Algolia 10K records), and background jobs (Inngest 25K runs). Most projects can run their entire stack on free tiers until they hit significant traction." },
+    { q: "What's the first thing to spend money on when scaling a Next.js app?", a: "Database. Neon's 0.5 GiB free storage is the tightest limit in the stack. The Neon Launch plan at $19/month gets you 10 GiB storage, 300 compute hours, and autoscaling. After that, hosting: Vercel Pro at $20/month unlocks commercial use, 1 TB bandwidth, and faster builds. Everything else (auth, email, monitoring, analytics) scales to meaningful traffic on free tiers." },
+  ]);
 
   const categorySections = stackCategories.map(cat => {
     const rec = resolveVendor(cat.recommended.vendor);
@@ -16062,32 +15982,12 @@ function buildFreeDjangoStackPage(): string {
     author: { "@type": "Organization", name: "AgentDeals", url: BASE_URL },
   };
 
-  const faqJsonLd = {
-    "@context": "https://schema.org",
-    "@type": "FAQPage",
-    mainEntity: [
-      {
-        "@type": "Question",
-        name: "Can I host Django for free in 2026?",
-        acceptedAnswer: { "@type": "Answer", text: "Yes. Railway offers a $5/month free credit that covers a small Django app with Gunicorn, auto-deploy from GitHub, and managed Postgres. Render has a free tier but spins down after 15 minutes of inactivity (30-60 second cold starts). PythonAnywhere offers free WSGI hosting but limits you to one web app with no custom domain. Fly.io gives 3 shared-CPU VMs free with 256 MB RAM." },
-      },
-      {
-        "@type": "Question",
-        name: "What's the best free database for Django?",
-        acceptedAnswer: { "@type": "Answer", text: "Neon (serverless Postgres) — 0.5 GiB storage, 190+ compute hours/month, scales to zero. Django's ORM is built for Postgres, and django.contrib.postgres adds JSONField, ArrayField, full-text search, and range types. Supabase (500 MB) is a good alternative with built-in auth. CockroachDB offers 10 GiB free with distributed Postgres-compatible SQL." },
-      },
-      {
-        "@type": "Question",
-        name: "Does Django need Redis?",
-        acceptedAnswer: { "@type": "Answer", text: "Not strictly, but practically yes for production. Redis powers Django's cache framework (fast page/fragment caching), session storage (faster than database sessions), and Celery (the standard Django task queue for background jobs). Upstash offers 10,000 Redis commands/day free. Without Redis, you can use Django's built-in database cache and in-process task runners, but you'll hit performance ceilings sooner." },
-      },
-      {
-        "@type": "Question",
-        name: "PythonAnywhere vs Railway vs Render for Django?",
-        acceptedAnswer: { "@type": "Answer", text: "Railway is the best overall — $5/month credit, no sleep timer, managed Postgres, and auto-deploy from GitHub. PythonAnywhere is great for learning (free WSGI hosting, built-in console) but limits you to one web app with no custom domain on free tier. Render has a free tier but your app sleeps after 15 minutes, causing 30-60 second cold starts that hurt user experience. For production Django apps, Railway or Fly.io." },
-      },
-    ],
-  };
+  const faqJsonLd = faqPageJsonLd("/free-django-stack", [
+    { q: "Can I host Django for free in 2026?", a: "Yes. Railway offers a $5/month free credit that covers a small Django app with Gunicorn, auto-deploy from GitHub, and managed Postgres. Render has a free tier but spins down after 15 minutes of inactivity (30-60 second cold starts). PythonAnywhere offers free WSGI hosting but limits you to one web app with no custom domain. Fly.io gives 3 shared-CPU VMs free with 256 MB RAM." },
+    { q: "What's the best free database for Django?", a: "Neon (serverless Postgres) — 0.5 GiB storage, 190+ compute hours/month, scales to zero. Django's ORM is built for Postgres, and django.contrib.postgres adds JSONField, ArrayField, full-text search, and range types. Supabase (500 MB) is a good alternative with built-in auth. CockroachDB offers 10 GiB free with distributed Postgres-compatible SQL." },
+    { q: "Does Django need Redis?", a: "Not strictly, but practically yes for production. Redis powers Django's cache framework (fast page/fragment caching), session storage (faster than database sessions), and Celery (the standard Django task queue for background jobs). Upstash offers 10,000 Redis commands/day free. Without Redis, you can use Django's built-in database cache and in-process task runners, but you'll hit performance ceilings sooner." },
+    { q: "PythonAnywhere vs Railway vs Render for Django?", a: "Railway is the best overall — $5/month credit, no sleep timer, managed Postgres, and auto-deploy from GitHub. PythonAnywhere is great for learning (free WSGI hosting, built-in console) but limits you to one web app with no custom domain on free tier. Render has a free tier but your app sleeps after 15 minutes, causing 30-60 second cold starts that hurt user experience. For production Django apps, Railway or Fly.io." },
+  ]);
 
   const categorySections = stackCategories.map(cat => {
     const rec = resolveVendor(cat.recommended.vendor);
@@ -16521,32 +16421,12 @@ function buildFreeFastapiStackPage(): string {
     author: { "@type": "Organization", name: "AgentDeals", url: BASE_URL },
   };
 
-  const faqJsonLd = {
-    "@context": "https://schema.org",
-    "@type": "FAQPage",
-    mainEntity: [
-      {
-        "@type": "Question",
-        name: "Can I host FastAPI for free in 2026?",
-        acceptedAnswer: { "@type": "Answer", text: "Yes. Railway offers a $5/month free credit that covers a small FastAPI app with uvicorn, auto-deploy from GitHub, and no sleep timer. Render has a free tier but spins down after 15 minutes of inactivity (30-60 second cold starts). Fly.io gives 3 shared-CPU VMs free with 256 MB RAM. Koyeb offers 1 nano service free with edge deployment. Avoid Vercel for FastAPI — it requires a serverless adapter and loses WebSocket/background task support." },
-      },
-      {
-        "@type": "Question",
-        name: "What database should I use with FastAPI?",
-        acceptedAnswer: { "@type": "Answer", text: "Neon (serverless Postgres) — 0.5 GiB storage, 190+ compute hours/month, scales to zero. Use with SQLAlchemy 2.0 async engine + asyncpg for async queries, or Tortoise ORM for an async-native alternative. FastAPI has no built-in ORM, so you choose your own — SQLAlchemy is the most popular choice. Supabase (500 MB) is an alternative with built-in auth and realtime." },
-      },
-      {
-        "@type": "Question",
-        name: "Does Vercel support FastAPI?",
-        acceptedAnswer: { "@type": "Answer", text: "Technically yes, via the Mangum adapter that wraps ASGI apps for AWS Lambda-style serverless functions. But you lose WebSocket support, FastAPI's startup/shutdown lifespan events, background tasks, and long-running connections. For API-only services, this may be acceptable. For anything using FastAPI's async features fully, use Railway, Render, or Fly.io instead." },
-      },
-      {
-        "@type": "Question",
-        name: "FastAPI vs Django for free hosting?",
-        acceptedAnswer: { "@type": "Answer", text: "FastAPI is lighter weight and async-native — ideal for APIs, microservices, and AI/ML serving. Django is batteries-included with built-in ORM, admin, auth, and forms — better for full web applications. Both host free on Railway ($5 credit) or Render. FastAPI needs you to choose every component (ORM, auth, admin) separately. Django includes them. If you're building a REST/GraphQL API or serving ML models, FastAPI. If you're building a web app with admin panel and user accounts, Django." },
-      },
-    ],
-  };
+  const faqJsonLd = faqPageJsonLd("/free-fastapi-stack", [
+    { q: "Can I host FastAPI for free in 2026?", a: "Yes. Railway offers a $5/month free credit that covers a small FastAPI app with uvicorn, auto-deploy from GitHub, and no sleep timer. Render has a free tier but spins down after 15 minutes of inactivity (30-60 second cold starts). Fly.io gives 3 shared-CPU VMs free with 256 MB RAM. Koyeb offers 1 nano service free with edge deployment. Avoid Vercel for FastAPI — it requires a serverless adapter and loses WebSocket/background task support." },
+    { q: "What database should I use with FastAPI?", a: "Neon (serverless Postgres) — 0.5 GiB storage, 190+ compute hours/month, scales to zero. Use with SQLAlchemy 2.0 async engine + asyncpg for async queries, or Tortoise ORM for an async-native alternative. FastAPI has no built-in ORM, so you choose your own — SQLAlchemy is the most popular choice. Supabase (500 MB) is an alternative with built-in auth and realtime." },
+    { q: "Does Vercel support FastAPI?", a: "Technically yes, via the Mangum adapter that wraps ASGI apps for AWS Lambda-style serverless functions. But you lose WebSocket support, FastAPI's startup/shutdown lifespan events, background tasks, and long-running connections. For API-only services, this may be acceptable. For anything using FastAPI's async features fully, use Railway, Render, or Fly.io instead." },
+    { q: "FastAPI vs Django for free hosting?", a: "FastAPI is lighter weight and async-native — ideal for APIs, microservices, and AI/ML serving. Django is batteries-included with built-in ORM, admin, auth, and forms — better for full web applications. Both host free on Railway ($5 credit) or Render. FastAPI needs you to choose every component (ORM, auth, admin) separately. Django includes them. If you're building a REST/GraphQL API or serving ML models, FastAPI. If you're building a web app with admin panel and user accounts, Django." },
+  ]);
 
   const categorySections = stackCategories.map(cat => {
     const rec = resolveVendor(cat.recommended.vendor);
@@ -16997,32 +16877,12 @@ function buildFreeGoStackPage(): string {
     author: { "@type": "Organization", name: "AgentDeals", url: BASE_URL },
   };
 
-  const faqJsonLd = {
-    "@context": "https://schema.org",
-    "@type": "FAQPage",
-    mainEntity: [
-      {
-        "@type": "Question",
-        name: "Can I host Go for free in 2026?",
-        acceptedAnswer: { "@type": "Answer", text: "Yes. Railway offers a $5/month free credit that covers a Go binary — Go's tiny memory footprint (~10 MB Docker images from scratch) maximizes the credit. Render has a free tier but spins down after 15 minutes; Go's instant cold starts (~50ms) make this tolerable. Fly.io gives 3 shared-CPU VMs free. Google Cloud Run's free tier (2M requests/month) is excellent for Go — near-instant cold starts and true scale-to-zero." },
-      },
-      {
-        "@type": "Question",
-        name: "What database should I use with Go?",
-        acceptedAnswer: { "@type": "Answer", text: "Neon (serverless Postgres) — 0.5 GiB storage, 190+ compute hours/month. Use with pgx, the fastest Go Postgres driver (pure Go, no CGo). For type-safe SQL without an ORM, use sqlc — it generates Go code from SQL queries at compile time. Go developers typically prefer raw SQL + pgx or sqlc over ORMs like GORM." },
-      },
-      {
-        "@type": "Question",
-        name: "Go vs Node.js for free hosting?",
-        acceptedAnswer: { "@type": "Answer", text: "Go compiles to a single binary with no runtime dependencies — Docker images are 5-15 MB vs 100+ MB for Node.js. This means lower memory usage (more headroom on free tiers), instant cold starts (better for serverless), and simpler deploys (no node_modules, no npm install). Go's goroutines handle concurrency without async/await complexity. Trade-off: Go's ecosystem for web frameworks is smaller, and there's no equivalent to npm's package breadth." },
-      },
-      {
-        "@type": "Question",
-        name: "Do I need a framework for Go web apps?",
-        acceptedAnswer: { "@type": "Answer", text: "No. Go's net/http standard library is production-ready — it powers many of the world's largest services. Add a router (chi or gorilla/mux) for path parameters and middleware chaining. Frameworks like Gin, Echo, and Fiber add convenience (binding, validation, structured logging) but aren't required. The stdlib-first approach means fewer dependencies, smaller binaries, and no framework lock-in." },
-      },
-    ],
-  };
+  const faqJsonLd = faqPageJsonLd("/free-go-stack", [
+    { q: "Can I host Go for free in 2026?", a: "Yes. Railway offers a $5/month free credit that covers a Go binary — Go's tiny memory footprint (~10 MB Docker images from scratch) maximizes the credit. Render has a free tier but spins down after 15 minutes; Go's instant cold starts (~50ms) make this tolerable. Fly.io gives 3 shared-CPU VMs free. Google Cloud Run's free tier (2M requests/month) is excellent for Go — near-instant cold starts and true scale-to-zero." },
+    { q: "What database should I use with Go?", a: "Neon (serverless Postgres) — 0.5 GiB storage, 190+ compute hours/month. Use with pgx, the fastest Go Postgres driver (pure Go, no CGo). For type-safe SQL without an ORM, use sqlc — it generates Go code from SQL queries at compile time. Go developers typically prefer raw SQL + pgx or sqlc over ORMs like GORM." },
+    { q: "Go vs Node.js for free hosting?", a: "Go compiles to a single binary with no runtime dependencies — Docker images are 5-15 MB vs 100+ MB for Node.js. This means lower memory usage (more headroom on free tiers), instant cold starts (better for serverless), and simpler deploys (no node_modules, no npm install). Go's goroutines handle concurrency without async/await complexity. Trade-off: Go's ecosystem for web frameworks is smaller, and there's no equivalent to npm's package breadth." },
+    { q: "Do I need a framework for Go web apps?", a: "No. Go's net/http standard library is production-ready — it powers many of the world's largest services. Add a router (chi or gorilla/mux) for path parameters and middleware chaining. Frameworks like Gin, Echo, and Fiber add convenience (binding, validation, structured logging) but aren't required. The stdlib-first approach means fewer dependencies, smaller binaries, and no framework lock-in." },
+  ]);
 
   const categorySections = stackCategories.map(cat => {
     const rec = resolveVendor(cat.recommended.vendor);
@@ -17479,32 +17339,12 @@ function buildFreeSaasStackPage(): string {
     author: { "@type": "Organization", name: "AgentDeals", url: BASE_URL },
   };
 
-  const faqJsonLd = {
-    "@context": "https://schema.org",
-    "@type": "FAQPage",
-    mainEntity: [
-      {
-        "@type": "Question",
-        name: "What's the cheapest way to launch a SaaS in 2026?",
-        acceptedAnswer: { "@type": "Answer", text: "You can launch a complete SaaS for $0/month using free tiers: Railway or Render (hosting), Neon (Postgres database), Clerk (auth with 50K users free), Stripe (payments \u2014 no monthly fee, only per-transaction), Resend (3K emails/month), Cloudflare R2 (10 GB storage, zero egress), Sentry (error tracking), GitHub Actions (CI/CD), PostHog (1M analytics events), and Inngest (25K background job runs). Total monthly cost at launch: $0. You'll hit your first paid tier around 1,000-5,000 users." },
-      },
-      {
-        "@type": "Question",
-        name: "Can I build a SaaS for free?",
-        acceptedAnswer: { "@type": "Answer", text: "Yes. Every layer of SaaS infrastructure \u2014 hosting, database, authentication, email, storage, monitoring, CI/CD, and analytics \u2014 has a viable free tier in 2026. The only category without a free option is payment processing (Stripe charges 2.9% + 30\u00a2 per transaction but has no monthly fee). Most free tiers support 1,000-5,000 active users before you need to upgrade. The first paid tier is typically database storage \u2014 Neon's Launch plan ($19/month) is usually the first upgrade." },
-      },
-      {
-        "@type": "Question",
-        name: "What's the best free database for SaaS?",
-        acceptedAnswer: { "@type": "Answer", text: "Neon (serverless Postgres) \u2014 0.5 GiB storage, 190+ compute hours/month, scales to zero. Works with every ORM and framework. For bundled BaaS: Supabase gives 500 MB Postgres + auth + storage + realtime (but pauses after 1 week inactive). For distributed SQL: CockroachDB offers 10 GiB free. For edge SQLite: Turso provides 9 GB. Postgres is the default SaaS database \u2014 95% of SaaS apps use it." },
-      },
-      {
-        "@type": "Question",
-        name: "When should I start paying for infrastructure?",
-        acceptedAnswer: { "@type": "Answer", text: "Most SaaS products can run entirely on free tiers through their first 1,000-5,000 users. Database storage (Neon 0.5 GiB) is typically the first limit you'll hit, followed by email volume (Resend 3K/month) and hosting compute. The jump from free to first paid tier is $19-25/month. By the time you need to pay, you should have paying customers. Plan your growth path: at 10K users expect ~$150-300/month total infrastructure, at 100K users ~$1,500-3,000/month." },
-      },
-    ],
-  };
+  const faqJsonLd = faqPageJsonLd("/free-saas-stack", [
+    { q: "What's the cheapest way to launch a SaaS in 2026?", a: "You can launch a complete SaaS for $0/month using free tiers: Railway or Render (hosting), Neon (Postgres database), Clerk (auth with 50K users free), Stripe (payments \u2014 no monthly fee, only per-transaction), Resend (3K emails/month), Cloudflare R2 (10 GB storage, zero egress), Sentry (error tracking), GitHub Actions (CI/CD), PostHog (1M analytics events), and Inngest (25K background job runs). Total monthly cost at launch: $0. You'll hit your first paid tier around 1,000-5,000 users." },
+    { q: "Can I build a SaaS for free?", a: "Yes. Every layer of SaaS infrastructure \u2014 hosting, database, authentication, email, storage, monitoring, CI/CD, and analytics \u2014 has a viable free tier in 2026. The only category without a free option is payment processing (Stripe charges 2.9% + 30\u00a2 per transaction but has no monthly fee). Most free tiers support 1,000-5,000 active users before you need to upgrade. The first paid tier is typically database storage \u2014 Neon's Launch plan ($19/month) is usually the first upgrade." },
+    { q: "What's the best free database for SaaS?", a: "Neon (serverless Postgres) \u2014 0.5 GiB storage, 190+ compute hours/month, scales to zero. Works with every ORM and framework. For bundled BaaS: Supabase gives 500 MB Postgres + auth + storage + realtime (but pauses after 1 week inactive). For distributed SQL: CockroachDB offers 10 GiB free. For edge SQLite: Turso provides 9 GB. Postgres is the default SaaS database \u2014 95% of SaaS apps use it." },
+    { q: "When should I start paying for infrastructure?", a: "Most SaaS products can run entirely on free tiers through their first 1,000-5,000 users. Database storage (Neon 0.5 GiB) is typically the first limit you'll hit, followed by email volume (Resend 3K/month) and hosting compute. The jump from free to first paid tier is $19-25/month. By the time you need to pay, you should have paying customers. Plan your growth path: at 10K users expect ~$150-300/month total infrastructure, at 100K users ~$1,500-3,000/month." },
+  ]);
 
   const categorySections = stackCategories.map(cat => {
     if (cat.isFrameworkSection) {
@@ -21498,15 +21338,7 @@ function buildTerraformCloudFreeTierRemovedPage(): string {
     { q: "Is the Terraform BSL license change related to the free tier removal?", a: "Indirectly. HashiCorp switched Terraform from MPL 2.0 to BSL 1.1 in August 2023, which triggered the OpenTofu fork. The free tier restructuring in March 2026 is part of HashiCorp's broader shift to monetize their ecosystem after the IBM acquisition ($6.4B in 2024). Both changes signal increased commercial pressure on free-tier and open-source users." },
   ];
 
-  const faqJsonLd = {
-    "@context": "https://schema.org",
-    "@type": "FAQPage",
-    mainEntity: faqItems.map(f => ({
-      "@type": "Question",
-      name: f.q,
-      acceptedAnswer: { "@type": "Answer", text: f.a },
-    })),
-  };
+  const faqJsonLd = faqPageJsonLd("/terraform-cloud-free-tier-removed", faqItems);
 
   return '<!DOCTYPE html>\n<html lang="en">\n<head>\n<meta charset="utf-8">\n<meta name="viewport" content="width=device-width,initial-scale=1">\n'
     + '<title>' + escHtmlServer(title) + ' — AgentDeals</title>\n'
@@ -22261,15 +22093,7 @@ function buildGeminiApiPricingChangesPage(): string {
     { q: "Should I migrate away from Gemini API?", a: "It depends on your use case. If you need the 1M token context window, Gemini Flash is still the best free option. For general chat/code tasks at higher volumes, Groq and Cerebras offer better free tiers. For production workloads, evaluate DeepSeek (cheapest) or Anthropic/OpenAI (most established)." },
   ];
 
-  const faqJsonLd = {
-    "@context": "https://schema.org",
-    "@type": "FAQPage",
-    mainEntity: faqItems.map(f => ({
-      "@type": "Question",
-      name: f.q,
-      acceptedAnswer: { "@type": "Answer", text: f.a },
-    })),
-  };
+  const faqJsonLd = faqPageJsonLd("/gemini-api-pricing-changes", faqItems);
 
   return '<!DOCTYPE html>\n<html lang="en">\n<head>\n<meta charset="utf-8">\n<meta name="viewport" content="width=device-width,initial-scale=1">\n'
     + '<title>' + escHtmlServer(title) + ' — AgentDeals</title>\n'
@@ -22788,15 +22612,7 @@ function buildFreeTierRiskPage(): string {
   );
 
   // JSON-LD — Article + FAQPage
-  const faqJsonLd = {
-    "@context": "https://schema.org",
-    "@type": "FAQPage",
-    mainEntity: faqs.map(f => ({
-      "@type": "Question",
-      name: f.q,
-      acceptedAnswer: { "@type": "Answer", text: f.a },
-    })),
-  };
+  const faqJsonLd = faqPageJsonLd("/free-tier-risk", faqs);
   const jsonLd = {
     "@context": "https://schema.org",
     "@type": "Article",
@@ -25652,15 +25468,7 @@ function buildOpenAIAssistantsMigrationPage(): string {
     mainEntityOfPage: { "@type": "WebPage", "@id": BASE_URL + "/" + slug },
   };
 
-  const faqJsonLd = {
-    "@context": "https://schema.org",
-    "@type": "FAQPage",
-    mainEntity: faqEntries.map(f => ({
-      "@type": "Question",
-      name: f.q,
-      acceptedAnswer: { "@type": "Answer", text: f.a },
-    })),
-  };
+  const faqJsonLd = faqPageJsonLd("/openai-assistants-migration", faqEntries);
 
   const breadcrumbJsonLd = {
     "@context": "https://schema.org",
@@ -27032,15 +26840,7 @@ function buildStartupCreditsPage(): string {
     about: programs.map(p => ({ "@type": "SoftwareApplication", name: p.name })),
   };
 
-  const faqJsonLd = {
-    "@context": "https://schema.org",
-    "@type": "FAQPage",
-    mainEntity: faqEntries.map(f => ({
-      "@type": "Question",
-      name: f.q,
-      acceptedAnswer: { "@type": "Answer", text: f.a },
-    })),
-  };
+  const faqJsonLd = faqPageJsonLd("/startup-credits", faqEntries);
 
   const breadcrumbJsonLd = {
     "@context": "https://schema.org",
@@ -28103,15 +27903,7 @@ function buildAiCodingToolsPricingPage(): string {
     { q: "What is Amazon Kiro and how does it compare to Cursor?", a: "Amazon Kiro is a Claude-powered IDE that launched GA in April 2026. It focuses on spec-driven development — automated requirements, design docs, and test generation. Free tier: 50 credits/month. Pro: $20/month (1,000 credits), matching Cursor's price. Credits are metered to 0.01 increments with model-dependent rates (Sonnet 4 costs 1.3x more). $0.04/credit overage available. Enterprise tier with SAML/SCIM SSO for larger teams." },
   ];
 
-  const faqJsonLd = {
-    "@context": "https://schema.org",
-    "@type": "FAQPage",
-    mainEntity: faqEntries.map(f => ({
-      "@type": "Question",
-      name: f.q,
-      acceptedAnswer: { "@type": "Answer", text: f.a },
-    })),
-  };
+  const faqJsonLd = faqPageJsonLd("/ai-coding-tools-pricing", faqEntries);
 
   const breadcrumbJsonLd = {
     "@context": "https://schema.org",
@@ -28888,15 +28680,7 @@ function buildCiCdPricingPage(): string {
     { q: "Which CI/CD tools support Docker and Kubernetes natively?", a: "CircleCI, Codefresh, and Drone CI are container-native — every build step runs in Docker. Google Cloud Build uses containerized build steps. Buildkite supports Docker and Kubernetes agents. GitLab CI has strong Kubernetes integration with Auto DevOps." },
   ];
 
-  const faqJsonLd = {
-    "@context": "https://schema.org",
-    "@type": "FAQPage",
-    mainEntity: faqEntries.map(f => ({
-      "@type": "Question",
-      name: f.q,
-      acceptedAnswer: { "@type": "Answer", text: f.a },
-    })),
-  };
+  const faqJsonLd = faqPageJsonLd("/ci-cd-pricing", faqEntries);
 
   const breadcrumbJsonLd = {
     "@context": "https://schema.org",
@@ -29791,15 +29575,7 @@ function buildDatabasePricingPage(): string {
     { q: "How do I migrate away from a database if pricing changes?", a: "PostgreSQL-compatible databases (Supabase, Neon, CockroachDB, Aurora) offer the easiest migration path — pg_dump works across all of them. MongoDB Atlas data can be exported via mongodump. For serverless databases (Turso, D1, Convex), migration is harder due to proprietary APIs. Choose PostgreSQL-compatible databases to minimize lock-in risk." },
   ];
 
-  const faqJsonLd = {
-    "@context": "https://schema.org",
-    "@type": "FAQPage",
-    mainEntity: faqEntries.map(f => ({
-      "@type": "Question",
-      name: f.q,
-      acceptedAnswer: { "@type": "Answer", text: f.a },
-    })),
-  };
+  const faqJsonLd = faqPageJsonLd("/database-pricing", faqEntries);
 
   const breadcrumbJsonLd = {
     "@context": "https://schema.org",
@@ -30456,15 +30232,7 @@ function buildVectorDatabasePricingPage(): string {
     "about": { "@type": "SoftwareApplication", "applicationCategory": "Vector Database", "name": "Vector Database Pricing Comparison" },
   };
 
-  const faqJsonLd = {
-    "@context": "https://schema.org",
-    "@type": "FAQPage",
-    "mainEntity": faqEntries.map(f => ({
-      "@type": "Question",
-      "name": f.q,
-      "acceptedAnswer": { "@type": "Answer", "text": f.a },
-    })),
-  };
+  const faqJsonLd = faqPageJsonLd("/vector-database-pricing", faqEntries);
 
   const breadcrumbJsonLd = {
     "@context": "https://schema.org",
@@ -31183,15 +30951,7 @@ function buildHostingPricingPage(): string {
     about: services.map(s => ({ "@type": "SoftwareApplication", name: s.name })),
   };
 
-  const faqJsonLd = {
-    "@context": "https://schema.org",
-    "@type": "FAQPage",
-    mainEntity: faqEntries.map(f => ({
-      "@type": "Question",
-      name: f.q,
-      acceptedAnswer: { "@type": "Answer", text: f.a },
-    })),
-  };
+  const faqJsonLd = faqPageJsonLd("/hosting-pricing", faqEntries);
 
   const breadcrumbJsonLd = {
     "@context": "https://schema.org",
@@ -31941,15 +31701,7 @@ function buildLlmApiPricingPage(): string {
     about: providers.map(p => ({ "@type": "SoftwareApplication", name: p.name })),
   };
 
-  const faqJsonLd = {
-    "@context": "https://schema.org",
-    "@type": "FAQPage",
-    mainEntity: faqEntries.map(f => ({
-      "@type": "Question",
-      name: f.q,
-      acceptedAnswer: { "@type": "Answer", text: f.a },
-    })),
-  };
+  const faqJsonLd = faqPageJsonLd("/llm-api-pricing", faqEntries);
 
   const breadcrumbJsonLd = {
     "@context": "https://schema.org",
@@ -32316,15 +32068,7 @@ function buildAgentPaymentsPage(): string {
     { q: "Do x402 services still have free tiers?", a: `Yes. All ${x402Offers.length} x402-enabled services indexed here also offer traditional free tiers. x402 is an additional payment option — it doesn't replace free tier access. Agents can use free tiers first and fall back to x402 when limits are exceeded.` },
   ];
 
-  const faqJsonLd = {
-    "@context": "https://schema.org",
-    "@type": "FAQPage",
-    mainEntity: faqItems.map(f => ({
-      "@type": "Question",
-      name: f.q,
-      acceptedAnswer: { "@type": "Answer", text: f.a },
-    })),
-  };
+  const faqJsonLd = faqPageJsonLd("/agent-payments", faqItems);
 
   // Group MPP offers by category
   const mppByCategory = new Map<string, typeof mppOffers>();
@@ -32614,15 +32358,7 @@ function buildX402ServicesPage(): string {
     { q: "What are the costs of using x402?", a: "Most x402 API calls cost $0.001-$0.01. Base L2 gas fees are typically under $0.001 per transaction. There are no monthly minimums, no commitments, and no signup fees. You only pay for what you use, per-request." },
   ];
 
-  const faqJsonLd = {
-    "@context": "https://schema.org",
-    "@type": "FAQPage",
-    mainEntity: faqItems.map(f => ({
-      "@type": "Question",
-      name: f.q,
-      acceptedAnswer: { "@type": "Answer", text: f.a },
-    })),
-  };
+  const faqJsonLd = faqPageJsonLd("/x402-services", faqItems);
 
   const serviceRows = x402Offers.map(o => {
     const vendorSlug = toSlug(o.vendor);
@@ -32918,15 +32654,7 @@ function buildDallEShutdownPage(): string {
   };
 
   // JSON-LD \u2014 FAQPage
-  const faqJsonLd = {
-    "@context": "https://schema.org",
-    "@type": "FAQPage",
-    mainEntity: faqs.map(f => ({
-      "@type": "Question",
-      name: f.q,
-      acceptedAnswer: { "@type": "Answer", text: f.a },
-    })),
-  };
+  const faqJsonLd = faqPageJsonLd("/dall-e-shutdown", faqs);
 
   // JSON-LD \u2014 BreadcrumbList
   const breadcrumbJsonLd = {
@@ -33439,15 +33167,7 @@ function buildOpenAIRealtimeMigrationPage(): string {
   };
 
   // JSON-LD \u2014 FAQPage
-  const faqJsonLd = {
-    "@context": "https://schema.org",
-    "@type": "FAQPage",
-    mainEntity: faqs.map(f => ({
-      "@type": "Question",
-      name: f.q,
-      acceptedAnswer: { "@type": "Answer", text: f.a },
-    })),
-  };
+  const faqJsonLd = faqPageJsonLd("/openai-realtime-migration", faqs);
 
   // JSON-LD \u2014 BreadcrumbList
   const breadcrumbJsonLd = {
@@ -33582,15 +33302,7 @@ function buildAppRunnerMigrationPage(): string {
   };
 
   // JSON-LD — FAQPage
-  const faqJsonLd = {
-    "@context": "https://schema.org",
-    "@type": "FAQPage",
-    mainEntity: faqs.map(f => ({
-      "@type": "Question",
-      name: f.q,
-      acceptedAnswer: { "@type": "Answer", text: f.a },
-    })),
-  };
+  const faqJsonLd = faqPageJsonLd("/aws-app-runner-migration", faqs);
 
   // JSON-LD — BreadcrumbList
   const breadcrumbJsonLd = {
@@ -35889,21 +35601,18 @@ function buildComparisonRelatedComparisons(slug: string): string {
   </div>`;
 }
 
-function buildComparisonFaq(slug: string, title: string): string {
+export function comparisonFaqItems(slug: string): FaqItem[] {
   const meta = comparisonMetaBySlug.get(slug);
-  if (!meta) return "";
+  if (!meta) return [];
   const catName = meta.categoryName;
   const catOffers = offers.filter(o => {
     const norm = o.category?.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/(^-|-$)/g, "");
     return norm === meta.categorySlug || o.category === catName;
   });
   const count = catOffers.length;
-  const enriched = enrichOffers(catOffers);
-  const stableCount = enriched.filter((o: any) => o.stability === "stable").length;
-  const stablePct = count > 0 ? Math.round((stableCount / count) * 100) : 0;
   const topVendor = catOffers[0]?.vendor || catName;
 
-  const faqs = [
+  return [
     {
       q: `What is the best free ${catName.toLowerCase()} service in 2026?`,
       a: `Based on our comparison of ${count} ${catName.toLowerCase()} services, ${topVendor} stands out for its free tier generosity. However, the best choice depends on your specific requirements — this comparison breaks down limits, scaling costs, and lock-in risk for each provider.`,
@@ -35913,14 +35622,15 @@ function buildComparisonFaq(slug: string, title: string): string {
       a: `Free tier generosity varies by use case. Some providers offer more storage, others more compute or API calls. Our comparison table above shows exact limits side-by-side so you can evaluate based on what matters most for your workload.`,
     },
     {
-      q: `Are free ${catName.toLowerCase()} services reliable enough for production?`,
-      a: `${stablePct}% of the ${count} ${catName.toLowerCase()} services we track have stable pricing histories. For production use, prioritize providers rated "stable" in our analysis and review the hidden costs section to avoid surprises at scale.`,
-    },
-    {
       q: `How do ${catName.toLowerCase()} free tiers compare on limits?`,
       a: `Each provider structures free tier limits differently — some cap storage, others cap requests or compute hours. Our comparison table provides exact numbers for each provider. Check the growth cost analysis section to understand what you'll pay when you exceed free tier limits.`,
     },
   ];
+}
+
+function buildComparisonFaq(slug: string, title: string): string {
+  const faqs = comparisonFaqItems(slug);
+  if (faqs.length === 0) return "";
 
   const faqHtml = faqs.map(f => `<div style="margin-bottom:1.25rem;padding-bottom:1.25rem;border-bottom:1px solid var(--border)">
       <h3 style="margin:0 0 .5rem;font-size:1rem;color:var(--text)">${escHtmlServer(f.q)}</h3>
@@ -35934,49 +35644,9 @@ function buildComparisonFaq(slug: string, title: string): string {
 }
 
 function buildComparisonFaqJsonLd(slug: string): string {
-  const meta = comparisonMetaBySlug.get(slug);
-  if (!meta) return "";
-  const catName = meta.categoryName;
-  const catOffers = offers.filter(o => {
-    const norm = o.category?.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/(^-|-$)/g, "");
-    return norm === meta.categorySlug || o.category === catName;
-  });
-  const count = catOffers.length;
-  const enriched = enrichOffers(catOffers);
-  const stableCount = enriched.filter((o: any) => o.stability === "stable").length;
-  const stablePct = count > 0 ? Math.round((stableCount / count) * 100) : 0;
-  const topVendor = catOffers[0]?.vendor || catName;
-
-  const faqs = [
-    {
-      q: `What is the best free ${catName.toLowerCase()} service in 2026?`,
-      a: `Based on our comparison of ${count} ${catName.toLowerCase()} services, ${topVendor} stands out for its free tier generosity. However, the best choice depends on your specific requirements — this comparison breaks down limits, scaling costs, and lock-in risk for each provider.`,
-    },
-    {
-      q: `Which ${catName.toLowerCase()} free tier is most generous?`,
-      a: `Free tier generosity varies by use case. Some providers offer more storage, others more compute or API calls. Our comparison table above shows exact limits side-by-side so you can evaluate based on what matters most for your workload.`,
-    },
-    {
-      q: `Are free ${catName.toLowerCase()} services reliable enough for production?`,
-      a: `${stablePct}% of the ${count} ${catName.toLowerCase()} services we track have stable pricing histories. For production use, prioritize providers rated "stable" in our analysis and review the hidden costs section to avoid surprises at scale.`,
-    },
-    {
-      q: `How do ${catName.toLowerCase()} free tiers compare on limits?`,
-      a: `Each provider structures free tier limits differently — some cap storage, others cap requests or compute hours. Our comparison table provides exact numbers for each provider. Check the growth cost analysis section to understand what you'll pay when you exceed free tier limits.`,
-    },
-  ];
-
-  const faqJsonLd = {
-    "@context": "https://schema.org",
-    "@type": "FAQPage",
-    mainEntity: faqs.map(f => ({
-      "@type": "Question",
-      name: f.q,
-      acceptedAnswer: { "@type": "Answer", text: f.a },
-    })),
-  };
-
-  return `<script type="application/ld+json">${JSON.stringify(faqJsonLd)}</script>`;
+  const faqs = comparisonFaqItems(slug);
+  if (faqs.length === 0) return "";
+  return `<script type="application/ld+json">${JSON.stringify(faqPageJsonLd("/" + slug, faqs))}</script>`;
 }
 
 function buildComparisonBreadcrumbJsonLd(slug: string, title: string): string {
@@ -47321,15 +46991,7 @@ function buildStackCheckPage(): string {
     { q: "What should I do if my stack scores poorly?", a: "Click the alternatives link on any high-risk service card to find stable replacements. Our risk index tracks which free tiers are expanding vs contracting — prioritize services with a 'stable' or 'improving' stability rating." },
   ];
 
-  const faqJsonLd = {
-    "@context": "https://schema.org",
-    "@type": "FAQPage",
-    "mainEntity": faqItems.map(f => ({
-      "@type": "Question",
-      "name": f.q,
-      "acceptedAnswer": { "@type": "Answer", "text": f.a },
-    })),
-  };
+  const faqJsonLd = faqPageJsonLd("/stack-check", faqItems);
 
   return `<!DOCTYPE html>
 <html lang="en">
@@ -47766,15 +47428,7 @@ function buildCompareToolPage(): string {
     { q: "What if a vendor isn't found?", a: "The tool will show an error with suggestions for similar vendor names. Try searching with a different spelling or check the vendor page for the full list." },
   ];
 
-  const faqJsonLd = {
-    "@context": "https://schema.org",
-    "@type": "FAQPage",
-    "mainEntity": faqItems.map(f => ({
-      "@type": "Question",
-      "name": f.q,
-      "acceptedAnswer": { "@type": "Answer", "text": f.a },
-    })),
-  };
+  const faqJsonLd = faqPageJsonLd("/compare-tool", faqItems);
 
   return `<!DOCTYPE html>
 <html lang="en">
@@ -48473,15 +48127,7 @@ function buildBudgetBuilderPage(): string {
     { q: "How do the risk badges work?", a: "Low risk means the vendor\\'s free tier has been stable with no recent changes. Medium risk means some limits have been reduced recently. High risk means the free tier was removed or significantly restricted — consider alternatives." },
   ];
 
-  const faqJsonLd = {
-    "@context": "https://schema.org",
-    "@type": "FAQPage",
-    "mainEntity": faqItems.map(f => ({
-      "@type": "Question",
-      "name": f.q,
-      "acceptedAnswer": { "@type": "Answer", "text": f.a },
-    })),
-  };
+  const faqJsonLd = faqPageJsonLd("/budget-builder", faqItems);
 
   return '<!DOCTYPE html>\n<html lang="en">\n<head>\n'
     + '  <meta charset="utf-8">\n'
@@ -50928,28 +50574,10 @@ ${altHtml}${guideHtml}
     })),
   };
 
-  const faqJsonLd = {
-    "@context": "https://schema.org",
-    "@type": "FAQPage",
-    mainEntity: [
-      {
-        "@type": "Question",
-        name: "What developer APIs are shutting down in 2026?",
-        acceptedAnswer: {
-          "@type": "Answer",
-          text: `We're tracking ${deadlines.length} upcoming developer tool deadlines including API shutdowns, free tier removals, and pricing changes across cloud infrastructure, databases, CI/CD, monitoring, and more. Major shutdowns include Google Tenor API (June 2026), OpenAI Assistants API (August 2026), and several AWS service deprecations.`,
-        },
-      },
-      {
-        "@type": "Question",
-        name: "Which free tiers are being removed?",
-        acceptedAnswer: {
-          "@type": "Answer",
-          text: `Multiple developer tools are removing or restructuring their free tiers. We track all changes with deadlines, countdown timers, and migration guides so you can plan ahead.`,
-        },
-      },
-    ],
-  };
+  const faqJsonLd = faqPageJsonLd("/deadlines", [
+    { q: "What developer APIs are shutting down in 2026?", a: `We're tracking ${deadlines.length} upcoming developer tool deadlines including API shutdowns, free tier removals, and pricing changes across cloud infrastructure, databases, CI/CD, monitoring, and more. Major shutdowns include Google Tenor API (June 2026), OpenAI Assistants API (August 2026), and several AWS service deprecations.`, },
+    { q: "Which free tiers are being removed?", a: `Multiple developer tools are removing or restructuring their free tiers. We track all changes with deadlines, countdown timers, and migration guides so you can plan ahead.`, },
+  ]);
 
   return `<!DOCTYPE html>
 <html lang="en">
@@ -51370,27 +50998,20 @@ function buildReferralProgramsPage(): string {
     })),
   };
 
-  const faqLd = {
-    "@context": "https://schema.org",
-    "@type": "FAQPage",
-    mainEntity: [
-      {
-        "@type": "Question",
-        name: "Which developer tools have referral programs?",
-        acceptedAnswer: { "@type": "Answer", text: `We track ${programVendors.length} developer tools with active referral programs across ${categoryGroups.size} categories, including ${programVendors.slice(0, 5).map(v => v.vendor).join(", ")}, and more.` },
-      },
-      {
-        "@type": "Question",
-        name: "How do I earn money from developer tool referrals?",
-        acceptedAnswer: { "@type": "Answer", text: "Sign up for a vendor's referral program, get your referral link, and share it. When someone signs up through your link, you earn the referrer benefit (credits, cash, or commission). You can also submit your referral codes to our marketplace for broader distribution." },
-      },
-      {
-        "@type": "Question",
-        name: "Can AI agents participate in referral programs?",
-        acceptedAnswer: { "@type": "Answer", text: "Yes. Register your AI agent on our marketplace, submit referral codes for vendors with programs, and earn revenue share when your codes convert. Agents are ranked by trust tier and conversion performance." },
-      },
-    ],
-  };
+  const faqLd = faqPageJsonLd("/referral-programs", [
+    {
+      q: "Which developer tools have referral programs?",
+      a: `We track ${programVendors.length} developer tools with active referral programs across ${categoryGroups.size} categories, including ${programVendors.slice(0, 5).map(v => v.vendor).join(", ")}, and more.`,
+    },
+    {
+      q: "How do I earn money from developer tool referrals?",
+      a: "Sign up for a vendor's referral program, get your referral link, and share it. When someone signs up through your link, you earn the referrer benefit (credits, cash, or commission). You can also submit your referral codes to our marketplace for broader distribution.",
+    },
+    {
+      q: "Can AI agents participate in referral programs?",
+      a: "Yes. Register your AI agent on our marketplace, submit referral codes for vendors with programs, and earn revenue share when your codes convert. Agents are ranked by trust tier and conversion performance.",
+    },
+  ]);
 
   const typeLabel = (t: string) => t === "self-service" ? "Self-service" : t === "affiliate-network" ? "Affiliate network" : t === "partner" ? "Partner" : "Application";
   const commLabel = (c?: string) => c === "recurring" ? "Recurring" : c === "credits" ? "Credits" : c === "one-time" ? "One-time" : "";

--- a/test/faq-provenance.test.ts
+++ b/test/faq-provenance.test.ts
@@ -1,0 +1,414 @@
+import { describe, it, before, after } from "node:test";
+import assert from "node:assert";
+import { spawn, type ChildProcess } from "node:child_process";
+import { readFileSync, writeFileSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  CATALOGUE_TEXT_FIELDS, CHANGE_LOG_TEXT_FIELDS, compiledNotice, dateModifiedFor, parsePageReviews,
+  perturbTextFields, type PageReviewRecord,
+} from "../src/page-reviews.ts";
+import {
+  FAQ_BASELINE, answerWithProvenance, faqPageJsonLd, faqProvenanceClause, statesVendorFigure,
+} from "../dist/faq-provenance.js";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO = path.join(__dirname, "..");
+const TODAY = "2026-08-27";
+
+const PROVENANCE = /Figures compiled (\d{4}-\d{2}-\d{2}), (?:not re-checked since|last checked (\d{4}-\d{2}-\d{2}))/;
+
+function registeredPages(): PageReviewRecord[] {
+  return parsePageReviews(readFileSync(path.join(REPO, "data", "page-reviews.json"), "utf-8")).pages;
+}
+
+function record(over: Partial<PageReviewRecord> = {}): PageReviewRecord {
+  return {
+    path: "/p", published: "2026-01-01", tier: "A", vendors_asserted: [], badge_subjects_unresolved: [],
+    reviewed_at: null, reviewer: null, review_outcome: null, reads_index: false, reads_changes: false,
+    data_source: "unsourced", data_source_reason: null, ...over,
+  };
+}
+
+function startServer(env: NodeJS.ProcessEnv): Promise<{ proc: ChildProcess; port: number }> {
+  return new Promise((resolve, reject) => {
+    const child = spawn("node", [path.join(REPO, "dist", "serve.js")], {
+      cwd: REPO,
+      stdio: ["ignore", "ignore", "pipe"],
+      env: { ...process.env, PORT: "0", BASE_URL: "http://localhost:3000", ...env },
+    });
+    const timeout = setTimeout(() => { child.kill(); reject(new Error("Server startup timeout")); }, 30000);
+    child.stderr!.on("data", (data: Buffer) => {
+      const m = data.toString().match(/running on http:\/\/localhost:(\d+)/);
+      if (m) { clearTimeout(timeout); resolve({ proc: child, port: parseInt(m[1], 10) }); }
+    });
+    child.on("error", (err) => { clearTimeout(timeout); reject(err); });
+  });
+}
+
+interface Answer { path: string; question: string; text: string }
+
+function faqAnswersIn(pagePath: string, html: string): Answer[] {
+  const out: Answer[] = [];
+  const blocks = html.matchAll(/<script type="application\/ld\+json">([\s\S]*?)<\/script>/g);
+  for (const block of blocks) {
+    let parsed: any;
+    try { parsed = JSON.parse(block[1]); } catch { continue; }
+    for (const entry of Array.isArray(parsed) ? parsed : [parsed]) {
+      if (!entry || entry["@type"] !== "FAQPage" || !Array.isArray(entry.mainEntity)) continue;
+      for (const q of entry.mainEntity) {
+        const text = q?.acceptedAnswer?.text;
+        if (typeof text === "string") out.push({ path: pagePath, question: q.name, text });
+      }
+    }
+  }
+  return out;
+}
+
+function jsonLdBlocks(html: string): any[] {
+  const out: any[] = [];
+  for (const block of html.matchAll(/<script type="application\/ld\+json">([\s\S]*?)<\/script>/g)) {
+    try { out.push(JSON.parse(block[1])); } catch { continue; }
+  }
+  return out;
+}
+
+describe("#1086 a review that found defects does not advance the structured date", () => {
+  it("advances the date when a review found nothing", () => {
+    const passed = record({ published: "2026-04-03", reviewed_at: "2026-08-20", review_outcome: "pass" });
+    assert.strictEqual(dateModifiedFor(passed, "2026-01-01", TODAY), "2026-08-20");
+  });
+
+  it("holds the date at publication when a review found defects", () => {
+    const failed = record({ published: "2026-04-03", reviewed_at: "2026-08-20", review_outcome: "fail" });
+    assert.strictEqual(dateModifiedFor(failed, "2026-01-01", TODAY), "2026-04-03");
+  });
+
+  it("advances the date for a review recorded with no outcome", () => {
+    const older = record({ published: "2026-04-03", reviewed_at: "2026-08-20" });
+    assert.strictEqual(dateModifiedFor(older, "2026-01-01", TODAY), "2026-08-20");
+  });
+
+  it("uses publication for a page nobody has reviewed, and the caller's date for a page off the register", () => {
+    assert.strictEqual(dateModifiedFor(record({ published: "2026-04-03" }), "2026-01-01", TODAY), "2026-04-03");
+    assert.strictEqual(dateModifiedFor(null, "2026-01-01", TODAY), "2026-01-01");
+  });
+
+  it("ignores a review dated after today, in both directions", () => {
+    const ahead = record({ published: "2026-04-03", reviewed_at: "2026-12-01", review_outcome: "fail" });
+    assert.strictEqual(dateModifiedFor(ahead, "2026-01-01", TODAY), "2026-04-03");
+    const aheadPass = record({ published: "2026-04-03", reviewed_at: "2026-12-01", review_outcome: "pass" });
+    assert.strictEqual(dateModifiedFor(aheadPass, "2026-01-01", TODAY), "2026-04-03");
+  });
+});
+
+describe("#1086 the provenance clause an answer carries is derived, not typed", () => {
+  it("names the compile date and the absence of a re-check when nobody has reviewed the page", () => {
+    const clause = faqProvenanceClause(record({ published: "2026-04-13" }), TODAY);
+    assert.strictEqual(clause, "Figures compiled 2026-04-13, not re-checked since.");
+  });
+
+  it("names the date of the last check once a review is on record", () => {
+    const clause = faqProvenanceClause(record({ published: "2026-04-13", reviewed_at: "2026-08-20", review_outcome: "pass" }), TODAY);
+    assert.strictEqual(clause, "Figures compiled 2026-04-13, last checked 2026-08-20.");
+  });
+
+  it("says corrections are outstanding when the review found defects", () => {
+    const clause = faqProvenanceClause(record({ published: "2026-04-03", reviewed_at: "2026-08-27", review_outcome: "fail" }), TODAY);
+    assert.strictEqual(clause, "Figures compiled 2026-04-03, last checked 2026-08-27; corrections outstanding.");
+  });
+
+  it("is the same notice the byline carries", () => {
+    const page = record({ published: "2026-04-13", reviewed_at: "2026-08-20", review_outcome: "pass" });
+    assert.ok(faqProvenanceClause(page, TODAY).startsWith(compiledNotice("2026-04-13", "2026-08-20")));
+  });
+
+  it("says nothing for a page that is not on the register", () => {
+    assert.strictEqual(faqProvenanceClause(null, TODAY), "");
+  });
+});
+
+describe("#1086 which answers state a vendor figure", () => {
+  const stated = [
+    "Vercel Pro starts at $20/month per team member.",
+    "Neon's 0.5 GiB free storage is the tightest limit in the stack.",
+    "The vendor's free Developer tier is 50 replays and 30-day retention.",
+    "Upstash offers 10,000 Redis commands/day free.",
+    "Gemini offers 1,500 free requests/day on the Flash model.",
+    "An enhanced free tier with a 500 managed resource cap and 1 concurrent run.",
+    "If you need the 1M token context window, Flash is still the best free option.",
+    "It is 100% free during public preview.",
+    "UptimeRobot checks on a 5-minute interval.",
+    "Stripe charges 2.9% + 30¢ per transaction.",
+  ];
+
+  const notStated = [
+    "Based on our comparison of 56 email services, Resend stands out for its free tier generosity.",
+    "We currently index 54 developer services with x402 support across 10 categories.",
+    "We weight four factors: pricing history (40%), financial signals (25%), competitive pressure (20%).",
+    "The Assistants API will be fully shut down on August 26, 2026.",
+    "Change the model parameter from dall-e-3 to gpt-image-1 in your images.generate call.",
+    "OpenTofu is a community fork of Terraform under the Linux Foundation with an MPL 2.0 license.",
+    "PostgreSQL-compatible databases offer the easiest migration path.",
+  ];
+
+  for (const text of stated) {
+    it(`treats a figure as stated: ${text.slice(0, 52)}`, () => {
+      assert.ok(statesVendorFigure(text), text);
+    });
+  }
+
+  for (const text of notStated) {
+    it(`treats no figure as stated: ${text.slice(0, 52)}`, () => {
+      assert.ok(!statesVendorFigure(text), text);
+    });
+  }
+});
+
+describe("#1086 the clause is appended only where a figure is stated", () => {
+  const clause = "Figures compiled 2026-04-13, not re-checked since.";
+
+  it("appends to an answer that states a figure", () => {
+    const out = answerWithProvenance("Vercel Pro starts at $20/month.", clause);
+    assert.strictEqual(out, `Vercel Pro starts at $20/month. ${clause}`);
+  });
+
+  it("leaves an answer that states none alone", () => {
+    const out = answerWithProvenance("PostgreSQL offers the easiest migration path.", clause);
+    assert.strictEqual(out, "PostgreSQL offers the easiest migration path.");
+  });
+
+  it("appends nothing when the page is off the register", () => {
+    assert.strictEqual(answerWithProvenance("Vercel Pro starts at $20/month.", ""), "Vercel Pro starts at $20/month.");
+  });
+
+  it("carries no markup into the structured copy", () => {
+    const out = answerWithProvenance('Check our <a href="/stability">Stability Dashboard</a> for 5 GB details.', clause);
+    assert.ok(!out.includes("<"), out);
+    assert.ok(out.includes("Stability Dashboard"), out);
+  });
+
+  it("builds a question for every item it is given", () => {
+    const ld: any = faqPageJsonLd("/not-a-registered-page", [{ q: "A?", a: "B." }, { q: "C?", a: "D." }]);
+    assert.strictEqual(ld["@type"], "FAQPage");
+    assert.deepStrictEqual(ld.mainEntity.map((e: any) => e.name), ["A?", "C?"]);
+    assert.deepStrictEqual(ld.mainEntity.map((e: any) => e.acceptedAnswer.text), ["B.", "D."]);
+  });
+});
+
+describe("#1086 every structured answer that states a vendor figure carries the page's provenance", () => {
+  const pages = registeredPages();
+  let tmp: string;
+  let real: { proc: ChildProcess; port: number };
+  let perturbed: { proc: ChildProcess; port: number };
+  const answers: Answer[] = [];
+  const perturbedAnswers = new Map<string, Answer[]>();
+  const bodies = new Map<string, string>();
+
+  before(async () => {
+    tmp = mkdtempSync(path.join(tmpdir(), "faq-provenance-"));
+    const index = JSON.parse(readFileSync(path.join(REPO, "data", "index.json"), "utf-8"));
+    const touchedIndex = perturbTextFields(index.offers, CATALOGUE_TEXT_FIELDS);
+    for (const offer of index.offers) offer.vendor = `Perturbed ${offer.vendor}`;
+    writeFileSync(path.join(tmp, "index.json"), JSON.stringify(index));
+    const changes = JSON.parse(readFileSync(path.join(REPO, "data", "deal_changes.json"), "utf-8"));
+    const touchedChanges = perturbTextFields(changes.changes, CHANGE_LOG_TEXT_FIELDS);
+    writeFileSync(path.join(tmp, "deal_changes.json"), JSON.stringify(changes));
+    assert.ok(touchedIndex > 1000, `perturbed only ${touchedIndex} catalogue fields, so the comparison below proves nothing`);
+    assert.ok(touchedChanges > 100, `perturbed only ${touchedChanges} change-log fields, so the comparison below proves nothing`);
+
+    [real, perturbed] = await Promise.all([
+      startServer({}),
+      startServer({
+        AGENTDEALS_INDEX_PATH: path.join(tmp, "index.json"),
+        AGENTDEALS_CHANGES_PATH: path.join(tmp, "deal_changes.json"),
+      }),
+    ]);
+    for (const page of pages) {
+      const [a, b] = await Promise.all([
+        fetch(`http://localhost:${real.port}${page.path}`).then((r) => r.text()),
+        fetch(`http://localhost:${perturbed.port}${page.path}`).then((r) => r.text()),
+      ]);
+      bodies.set(page.path, a);
+      answers.push(...faqAnswersIn(page.path, a));
+      perturbedAnswers.set(page.path, faqAnswersIn(page.path, b));
+    }
+  });
+
+  after(() => {
+    real?.proc.kill();
+    perturbed?.proc.kill();
+    if (tmp) rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it("finds structured answers on the register to check", () => {
+    assert.strictEqual(answers.length, FAQ_BASELINE.answers);
+    const withFaq = new Set(answers.map((a) => a.path));
+    assert.ok(withFaq.size > 30, `only ${withFaq.size} registered pages emit a structured FAQ`);
+  });
+
+  it("leaves no answer stating a figure without one", () => {
+    const bare = answers.filter((a) => statesVendorFigure(a.text) && !PROVENANCE.test(a.text));
+    assert.deepStrictEqual(bare.map((a) => `${a.path} :: ${a.question}`), []);
+  });
+
+  it("holds the number of answers stating a figure, so a new one has to be looked at", () => {
+    const stating = answers.filter((a) => statesVendorFigure(a.text));
+    assert.strictEqual(stating.length, FAQ_BASELINE.stating_a_figure);
+  });
+
+  it("holds the number of answers naming a number the rule does not read as a figure", () => {
+    const unread = answers.filter((a) => !statesVendorFigure(a.text) && /\d/.test(a.text));
+    assert.strictEqual(unread.length, FAQ_BASELINE.a_digit_but_no_figure);
+  });
+
+  it("takes the dates in every clause from the register rather than from the answer", () => {
+    const wrong: string[] = [];
+    for (const answer of answers) {
+      const found = PROVENANCE.exec(answer.text);
+      if (!found) continue;
+      const page = pages.find((p) => p.path === answer.path)!;
+      const expected = faqProvenanceClause(page, TODAY);
+      if (!answer.text.endsWith(expected)) wrong.push(`${answer.path} :: ${found[0]} vs ${expected}`);
+    }
+    assert.deepStrictEqual(wrong, []);
+  });
+
+  it("says corrections are outstanding on no page whose review is clean", () => {
+    const failing = new Set(pages.filter((p) => p.review_outcome === "fail").map((p) => p.path));
+    const saying = [...new Set(answers.filter((a) => /corrections outstanding/.test(a.text)).map((a) => a.path))];
+    assert.deepStrictEqual(saying.filter((p) => !failing.has(p)), []);
+  });
+
+  it("holds the structured date of a page whose review found defects at its publication date", () => {
+    for (const page of pages.filter((p) => p.review_outcome === "fail")) {
+      const article = jsonLdBlocks(bodies.get(page.path)!).find((b) => b?.dateModified);
+      assert.ok(article, `${page.path} publishes no structured date`);
+      assert.strictEqual(article.dateModified, page.published, page.path);
+      assert.ok(
+        bodies.get(page.path)!.includes("corrections outstanding"),
+        `${page.path} holds its structured date back without telling a reader why`
+      );
+    }
+  });
+
+  it("only dates an answer whose figures the catalogue cannot move", () => {
+    const moved: string[] = [];
+    let frozen = 0;
+    for (const page of pages) {
+      const before = answers.filter((a) => a.path === page.path);
+      const after = perturbedAnswers.get(page.path) ?? [];
+      for (let i = 0; i < before.length; i++) {
+        if (!PROVENANCE.test(before[i].text)) continue;
+        if (!after[i] || after[i].text !== before[i].text) moved.push(`${page.path} :: ${before[i].question}`);
+        else frozen += 1;
+      }
+    }
+    assert.deepStrictEqual(moved, []);
+    assert.strictEqual(frozen, FAQ_BASELINE.stating_a_figure);
+  });
+
+  it("leaves the answers the catalogue does move without a compile date", () => {
+    const derived: string[] = [];
+    for (const page of pages) {
+      const before = answers.filter((a) => a.path === page.path);
+      const after = perturbedAnswers.get(page.path) ?? [];
+      for (let i = 0; i < before.length; i++) {
+        if (after[i] && after[i].text !== before[i].text) derived.push(`${page.path} :: ${before[i].question}`);
+      }
+    }
+    assert.ok(derived.length > 5, `only ${derived.length} answers responded to the catalogue, so the rule above is nearly vacuous`);
+  });
+
+  it("makes no claim about the stability of a vendor's pricing history", () => {
+    const claims = answers.filter((a) => /stable pricing histor|rated "stable"|have stable pricing|fully stable pricing/.test(a.text));
+    assert.deepStrictEqual(claims.map((a) => `${a.path} :: ${a.question}`), []);
+  });
+});
+
+describe("#1086 recording a failed review changes what the structured copy of the page says", () => {
+  const SUBJECT = "/llm-api-pricing";
+  let tmp: string;
+  let before_: { proc: ChildProcess; port: number };
+  let after_: { proc: ChildProcess; port: number };
+  const rendered = new Map<string, string>();
+
+  before(async () => {
+    tmp = mkdtempSync(path.join(tmpdir(), "faq-failed-review-"));
+    const register = JSON.parse(readFileSync(path.join(REPO, "data", "page-reviews.json"), "utf-8"));
+    const subject = register.pages.find((p: any) => p.path === SUBJECT);
+    assert.ok(subject, `${SUBJECT} left the register, so this fixture no longer stands for anything`);
+    assert.strictEqual(subject.reviewed_at, null, `${SUBJECT} now carries a real review, so the fixture would not be a change`);
+    subject.reviewed_at = "2026-08-27";
+    subject.reviewer = "fixture";
+    subject.review_outcome = "fail";
+    const file = path.join(tmp, "page-reviews.json");
+    writeFileSync(file, JSON.stringify(register));
+    [before_, after_] = await Promise.all([startServer({}), startServer({ AGENTDEALS_PAGE_REVIEWS_PATH: file })]);
+    rendered.set("before", await fetch(`http://localhost:${before_.port}${SUBJECT}`).then((r) => r.text()));
+    rendered.set("after", await fetch(`http://localhost:${after_.port}${SUBJECT}`).then((r) => r.text()));
+  });
+
+  after(() => {
+    before_?.proc.kill();
+    after_?.proc.kill();
+    if (tmp) rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it("has answers that state a figure, so the fixture can show a difference", () => {
+    const stating = faqAnswersIn(SUBJECT, rendered.get("before")!).filter((a) => statesVendorFigure(a.text));
+    assert.ok(stating.length >= 4, `only ${stating.length} answers state a figure`);
+  });
+
+  it("says the figures were never re-checked while no review is on record", () => {
+    for (const answer of faqAnswersIn(SUBJECT, rendered.get("before")!)) {
+      if (!statesVendorFigure(answer.text)) continue;
+      assert.ok(answer.text.endsWith("not re-checked since."), answer.question);
+    }
+  });
+
+  it("says corrections are outstanding in every dated answer once the review records a failure", () => {
+    const dated = faqAnswersIn(SUBJECT, rendered.get("after")!).filter((a) => PROVENANCE.test(a.text));
+    assert.ok(dated.length >= 4, `only ${dated.length} answers carry a date`);
+    for (const answer of dated) {
+      assert.ok(answer.text.endsWith("last checked 2026-08-27; corrections outstanding."), answer.question);
+    }
+  });
+
+  it("leaves the structured date at publication rather than advancing it to the review", () => {
+    const article = jsonLdBlocks(rendered.get("after")!).find((b) => b?.dateModified);
+    assert.ok(article, `${SUBJECT} publishes no structured date`);
+    assert.strictEqual(article.dateModified, "2026-04-13");
+    assert.strictEqual(article.datePublished, "2026-04-13");
+  });
+});
+
+describe("#1086 the stability share is not offered as a production recommendation anywhere", () => {
+  let server: { proc: ChildProcess; port: number };
+
+  before(async () => { server = await startServer({}); });
+  after(() => { server?.proc.kill(); });
+
+  it("keeps it off the category pages that compute it", async () => {
+    for (const route of ["/category/databases", "/category/monitoring", "/category/storage"]) {
+      const html = await fetch(`http://localhost:${server.port}${route}`).then((r) => r.text());
+      for (const answer of faqAnswersIn(route, html)) {
+        assert.ok(
+          !/stable pricing|rated "stable"|suitable for small production/.test(answer.text),
+          `${route} :: ${answer.question}`
+        );
+      }
+    }
+  });
+
+  it("still answers how many changes a category has recorded", async () => {
+    const html = await fetch(`http://localhost:${server.port}/category/databases`).then((r) => r.text());
+    const answers = faqAnswersIn("/category/databases", html);
+    assert.ok(answers.length >= 3, `only ${answers.length} answers on the category page`);
+    assert.ok(
+      answers.some((a) => /pricing change/.test(a.text)),
+      "the category page no longer says how many pricing changes it has recorded"
+    );
+  });
+});

--- a/test/page-data-provenance.test.ts
+++ b/test/page-data-provenance.test.ts
@@ -56,10 +56,14 @@ function startServer(env: NodeJS.ProcessEnv): Promise<{ proc: ChildProcess; port
   });
 }
 
-function visibleSentences(html: string): string[] {
-  const text = html
+function visibleBody(html: string): string {
+  return html
     .replace(/<script[\s\S]*?<\/script>/g, " ")
-    .replace(/<style[\s\S]*?<\/style>/g, " ")
+    .replace(/<style[\s\S]*?<\/style>/g, " ");
+}
+
+function visibleSentences(html: string): string[] {
+  const text = visibleBody(html)
     .replace(/<[^>]+>/g, " ")
     .replace(/&[a-z]+;/g, " ")
     .replace(/\s+/g, " ");
@@ -223,7 +227,7 @@ describe("a page may only name the source it actually reads", () => {
     const wrong: string[] = [];
     for (const page of pages) {
       if (page.reads_index || page.tier !== "A") continue;
-      const found = bodies.get(page.path)!.match(COMPILED_NOTICE);
+      const found = visibleBody(bodies.get(page.path)!).match(COMPILED_NOTICE);
       if (!found) wrong.push(`${page.path}: no compiled notice`);
       else if (found[1] !== page.published) wrong.push(`${page.path}: notice says ${found[1]}, compiled ${page.published}`);
     }
@@ -235,7 +239,7 @@ describe("a page may only name the source it actually reads", () => {
     let checked = 0;
     for (const page of pages) {
       if (page.reads_index || page.tier !== "A") continue;
-      const found = bodies.get(page.path)!.match(COMPILED_NOTICE)!;
+      const found = visibleBody(bodies.get(page.path)!).match(COMPILED_NOTICE)!;
       const claimed = found[2] ?? null;
       const expected = page.reviewed_at;
       if (claimed !== expected) wrong.push(`${page.path}: notice says last checked ${claimed}, register says ${expected}`);
@@ -249,7 +253,7 @@ describe("a page may only name the source it actually reads", () => {
     const offenders: string[] = [];
     let claiming = 0;
     for (const page of pages) {
-      const body = bodies.get(page.path)!;
+      const body = visibleBody(bodies.get(page.path)!);
       const saysNever = /not re-checked since/.test(body);
       const saysChecked = /last checked (\d{4}-\d{2}-\d{2})/.exec(body);
       if (saysNever || saysChecked) claiming += 1;
@@ -266,12 +270,12 @@ describe("a page may only name the source it actually reads", () => {
 
   it("says corrections are outstanding wherever a review recorded a failure, and nowhere else", () => {
     const failing = pages.filter((p) => p.review_outcome === "fail").map((p) => p.path);
-    const saying = pages.filter((p) => /corrections outstanding/.test(bodies.get(p.path)!)).map((p) => p.path);
+    const saying = pages.filter((p) => /corrections outstanding/.test(visibleBody(bodies.get(p.path)!))).map((p) => p.path);
     assert.deepStrictEqual(saying.sort(), failing.sort());
   });
 
   it("does not put the compiled notice on a page that reads the catalogue", () => {
-    const wrong = pages.filter((p) => p.reads_index && COMPILED_NOTICE.test(bodies.get(p.path)!));
+    const wrong = pages.filter((p) => p.reads_index && COMPILED_NOTICE.test(visibleBody(bodies.get(p.path)!)));
     assert.deepStrictEqual(wrong.map((p) => p.path), []);
   });
 });

--- a/test/page-freshness.test.ts
+++ b/test/page-freshness.test.ts
@@ -357,11 +357,21 @@ describe("#1061 what a reader sees instead", () => {
   });
 
   it("dates a page by its review once one is on record", async () => {
-    const reviewed = REGISTRY.pages.find((p: any) => p.reviewed_at !== null);
-    assert.ok(reviewed, "at least one page must carry a review for this assertion to have a subject");
+    const reviewed = REGISTRY.pages.find((p: any) => p.reviewed_at !== null && p.review_outcome !== "fail");
+    assert.ok(reviewed, "at least one page must carry a review that found nothing for this assertion to have a subject");
     const html = await get(reviewed.path);
-    assert.ok(html.includes(`Reviewed ${reviewed.reviewed_at}`), `${reviewed.path} does not render its review date`);
     assert.strictEqual(jsonLdOf(html)?.dateModified, reviewed.reviewed_at);
+  });
+
+  it("does not date a page by a review that found defects", async () => {
+    const failed = REGISTRY.pages.find((p: any) => p.review_outcome === "fail");
+    assert.ok(failed, "no review on the register recorded a failure, so this assertion has no subject");
+    const html = await get(failed.path);
+    assert.ok(
+      html.includes(`Reviewed ${failed.reviewed_at}, corrections outstanding`),
+      `${failed.path} does not tell a reader corrections are outstanding`
+    );
+    assert.strictEqual(jsonLdOf(html)?.dateModified, failed.published);
   });
 
   it("resolves the vendors its headline names to their vendor pages", async () => {


### PR DESCRIPTION
Refs #1086

## AC1 — a failing review does not advance `dateModified`

`pageDateModified` now consults `review_outcome`; a `fail` returns the published date. The decision moved into `dateModifiedFor(record, fallback, today)` so it can be driven from a fixture in both directions rather than only from whatever the register happens to hold.

Verified live on both sides:

| | `main` | this branch |
|---|---|---|
| `/email-comparison-2026` byline | `Reviewed 2026-08-27, corrections outstanding` | unchanged |
| `/email-comparison-2026` JSON-LD `dateModified` | **`2026-08-27`** | **`2026-04-03`** |

It was the only page on the site whose structured date had been advanced by a review, and it is the page whose review found the SES stat card wrong.

The existing assertion `dates a page by its review once one is on record` picked the first reviewed page in the register, which is that one. It now picks a review that found nothing, and a second test takes the failing page — where the byline claim it used to make is the one that actually renders, because the three clean reviews on the register all expired in April.

## AC2 — every structured answer that states a vendor figure carries the page's provenance

**77 of 166 answers** across the 37 registered pages that emit `FAQPage` state a currency amount or a quota figure. Before this change **none** carried a date; now all 77 do, derived from the register:

- no review on record → `Figures compiled 2026-04-13, not re-checked since.`
- reviewed → `... last checked 2026-08-20.`
- `review_outcome: fail` → `... last checked 2026-08-27; corrections outstanding.`

`/llm-api-pricing` renders the first form on all five of its answers, including the one that names Haiku 4.5's price.

**The clause goes in the structured copy only, and that is deliberate.** The HTML answer sits under a byline already carrying the same notice; the JSON-LD answer travels without it. Putting the sentence in the visible prose four times per page would repeat what the byline says a screen above.

### The measurement that decided which clause each answer gets

A page-level `reads_index` does not tell you whether a *block* is catalogue-derived — five `/free-*-stack` pages read the catalogue for their cards and hand-type every FAQ answer. So each answer was measured rather than inherited: render the 67 pages twice, the second time against a catalogue with all 3,160 text fields perturbed and every vendor renamed, and compare answer by answer.

- **77 answers carrying the clause are frozen under the perturbation** — the compile date is the right provenance for every one.
- **12 answers do move** (the comparison pages' "Based on our comparison of N services, X stands out" names a vendor read live) and correctly carry no compile date.

Both directions are asserted, so an answer that becomes catalogue-derived later fails the build rather than silently publishing a compile date for a live figure.

**This measurement caught a defect in the rule itself.** `/email-comparison-2026`'s first answer was getting the clause because "56 **email** services" read as a quota — the category name collided with a unit. A figure is now ignored when `we`/`our` appears in the 40 characters before it, which is the actual distinction: a count of what we track is not a vendor's term.

## AC3 — the stability share is no longer a production recommendation

`stablePct` counts `vendorRiskAssessment` outcomes, and `RISK_DEMOTION` drops `product_deprecated` (69 entries, 24% of the change log) and `restriction` entirely. Removed from both sites that turned it into advice:

- 13 comparison pages: *"92% of the 60 monitoring services we track have stable pricing histories. For production use, prioritize providers rated 'stable'..."* — the whole answer.
- 66 `/category/*` pages: the `productionAnswer` branch, plus `"X% of vendors have had no changes at all"` from the stability answer. The change count it sits beside is counted from the log and stays.

Also dropped `"Very stable... This is one of the most stable categories"` from the zero-change branch — a category with no recorded changes may be one we have not covered, which is the coverage proxy `RISK_DEMOTION`'s own comment describes.

## AC4 — the test, and what stops the rule rotting

`test/faq-provenance.test.ts`, 48 tests. Over the live render of all 67 registered pages:

- no answer stating a figure lacks the clause;
- **the number stating one equals 77 exactly** — not a ceiling, so a new answer with a figure has to be looked at;
- **the number naming a digit the rule does *not* read as a figure equals 39 exactly.** This is what catches the unit list falling behind: a new answer whose figure the detector misses lands in that bucket and moves the count.

A fixture marks `/llm-api-pricing` as failed and asserts its answers change from `not re-checked since` to `corrections outstanding` while its structured date stays at publication — the branch had no real occupant otherwise, because `/email-comparison-2026`'s remaining answers state no figure at all.

## One helper, 31 call sites

Every `FAQPage` block on the site is now built by `faqPageJsonLd(path, items)`. The comparison pages built their answer list **twice** — once in `buildComparisonFaq` for the HTML and once in `buildComparisonFaqJsonLd` for the JSON-LD — so AC3 would otherwise have been two deletions of the same sentence. They share `comparisonFaqItems(slug)` now.

## Verified

- **2004 tests / 0 failures**, exit code captured directly. 49 new.
- **17 mutations, all killed** (`scripts/mutate-1086.sh`).
- **3,914 routes rendered against a `main` worktree and diffed: 100 differ**, and every added and removed sentence was read. 66 category pages and 13 comparison pages lost the production-recommendation answer; 34 registered pages gained clauses. **The 77 appended suffixes are 9 distinct strings, all of the form `Figures compiled <date>, ...`, and they sum to exactly the 77 measured.** No question was added anywhere.
- The route diff caught a regression: stripping tags with `<[^>]*>` ate `<---->` out of a vendor's own catalogue text on `/vendor/webhookrelay-com`. The pattern is tag-shaped now.
- Real MCP `initialize` → `tools/list` → `tools/call`. `tsc` clean, `validate` clean, 0 new code comments.
- Screenshot of `/category/databases` — three questions, no gap where the fourth was.

## Not in scope

`/category/*` and `/alternative-to/*` are not on the register, so their answers carry no clause. The sitemap holds 269 standalone content routes and 202 are unregistered (#1081), so the true count of undated machine-readable price claims is larger than 77 and this change does not reach it.