### PR TITLE
Correct the Azure Assistants API claims on the shutdown pages

### DIFF
--- a/scripts/mutate-1089.sh
+++ b/scripts/mutate-1089.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+set -uo pipefail
+cd "$(dirname "$0")/.."
+
+PASS=0
+FAIL=0
+SUITE="test/azure-assistants-retirement.test.ts"
+
+run_mutation() {
+  local name="$1" file="$2" from="$3" to="$4" tests="${5:-$SUITE}"
+  cp "$file" "$file.bak"
+  if ! python3 - "$file" "$from" "$to" <<'PY'
+import sys, pathlib
+path, old, new = sys.argv[1], sys.argv[2], sys.argv[3]
+p = pathlib.Path(path)
+s = p.read_text()
+if s.count(old) != 1:
+    print(f"SKIP: pattern found {s.count(old)} times", file=sys.stderr)
+    sys.exit(3)
+p.write_text(s.replace(old, new))
+PY
+  then
+    echo "SKIP  $name (pattern stale)"
+    mv "$file.bak" "$file"
+    FAIL=$((FAIL + 1))
+    return
+  fi
+
+  if ! npm run build > /tmp/mut-1089-build.log 2>&1; then
+    echo "SKIP  $name (build failed)"
+    mv "$file.bak" "$file"
+    npm run build > /dev/null 2>&1
+    FAIL=$((FAIL + 1))
+    return
+  fi
+
+  node --test --experimental-strip-types $tests > /tmp/mut-1089.log 2>&1
+  local status=$?
+  mv "$file.bak" "$file"
+  npm run build > /dev/null 2>&1
+
+  if [ $status -ne 0 ]; then
+    echo "KILLED  $name"
+    PASS=$((PASS + 1))
+  else
+    echo "SURVIVED  $name  <-- $tests did not notice"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+run_mutation "the structured FAQ answer goes back to promising Azure kept the API" src/serve.ts \
+  'a: `No. Microsoft retired the Azure OpenAI Assistants API on ${ASSISTANTS_API_SHUTDOWN.date}, the same date OpenAI retired its own. Microsoft'"'"'s documentation states that the Assistants API is retired and directs Azure workloads to ${ASSISTANTS_API_SHUTDOWN.azureSuccessor}, which is generally available; inference-only workloads can use the ${ASSISTANTS_API_SHUTDOWN.azureInferenceApi} instead. Running on Azure does not extend the deadline.`' \
+  'a: "Azure OpenAI has NOT announced deprecation of its Assistants API implementation. Azure may maintain the Assistants API independently of OpenAI'"'"'s decision."'
+
+run_mutation "the free-tier table cell goes back to calling the Azure API live" src/serve.ts \
+  "<td style=\"font-size:.85rem\">' + escHtmlServer(ASSISTANTS_API_SHUTDOWN.azureSuccessor) + ' — Assistants API retired ' + escHtmlServer(ASSISTANTS_API_SHUTDOWN.date) + '</td>" \
+  "<td style=\"font-size:.85rem\">Assistants API (not deprecated)</td>"
+
+run_mutation "the recommendation goes back to hedging the Azure deprecation" src/serve.ts \
+  "Rebuild on ' + escHtmlServer(ASSISTANTS_API_SHUTDOWN.azureSuccessor) + ': Microsoft retired the Azure Assistants API on ' + escHtmlServer(ASSISTANTS_API_SHUTDOWN.date) + ' too, so this path is a change of platform, not a way to keep the old API." \
+  "Assistants API may not be deprecated on Azure."
+
+run_mutation "the cost insight goes back to telling Azure teams to wait" src/serve.ts \
+  "Teams already on Azure face the same deadline: Microsoft retired the Azure OpenAI Assistants API on ' + ASSISTANTS_API_SHUTDOWN.date + ' and directs agents to ' + ASSISTANTS_API_SHUTDOWN.azureSuccessor + '." \
+  "For teams already on Azure, the Assistants API may continue working \\u2014 monitor Azure announcements."
+
+run_mutation "one page is corrected to a different retirement date" src/serve.ts \
+  'Microsoft retired the Azure OpenAI Assistants API on ${ASSISTANTS_API_SHUTDOWN.date} too and directs Azure agents to ${ASSISTANTS_API_SHUTDOWN.azureSuccessor}.' \
+  'Microsoft retired the Azure OpenAI Assistants API on March 31, 2027 too and directs Azure agents to ${ASSISTANTS_API_SHUTDOWN.azureSuccessor}.'
+
+run_mutation "one page stops naming the successor" src/serve.ts \
+  'Move agents to ${ASSISTANTS_API_SHUTDOWN.azureSuccessor}; the ' \
+  'The '
+
+run_mutation "the alternatives page drops its Azure retirement statement" src/serve.ts \
+  'Microsoft retired the Azure OpenAI Assistants API on ${ASSISTANTS_API_SHUTDOWN.date} as well, so an Azure deployment does not extend the deadline. ' \
+  ''
+
+run_mutation "the shared date is edited and one page is not carried with it" src/assistants-shutdown.ts \
+  '  date: "August 26, 2026",' \
+  '  date: "August 27, 2026",'
+
+run_mutation "the survival detector stops looking for the hedged wording" src/assistants-shutdown.ts \
+  '  /may\s+not\s+be\s+deprecated/gi,
+  /may\s+continue\s+(?:working|to\s+work)/gi,
+' \
+  ''
+
+run_mutation "the detector stops requiring the claim to be about this shutdown" src/assistants-shutdown.ts \
+  '      if (!SHUTDOWN_SUBJECT.test(window)) continue;' \
+  '      if (SHUTDOWN_SUBJECT.test(window)) continue;'
+
+echo
+echo "killed: $PASS   survived/skipped: $FAIL"
+[ $FAIL -eq 0 ]

--- a/src/assistants-shutdown.ts
+++ b/src/assistants-shutdown.ts
@@ -1,0 +1,93 @@
+export interface ShutdownFacts {
+  date: string;
+  isoDate: string;
+  openaiSuccessor: string;
+  azureSuccessor: string;
+  azureInferenceApi: string;
+  pages: string[];
+}
+
+export const ASSISTANTS_API_SHUTDOWN: ShutdownFacts = {
+  date: "August 26, 2026",
+  isoDate: "2026-08-26",
+  openaiSuccessor: "Responses API",
+  azureSuccessor: "Microsoft Foundry Agent Service",
+  azureInferenceApi: "Azure OpenAI Responses API",
+  pages: [
+    "/openai-assistants-migration",
+    "/openai-assistants-migration-2026",
+    "/openai-assistants-alternatives",
+  ],
+};
+
+const AZURE_SURVIVAL_PATTERNS: RegExp[] = [
+  /not\s+been\s+deprecated/gi,
+  /not\s+deprecated/gi,
+  /not\s+announced\s+deprecation/gi,
+  /no\s+deprecation\s+announced/gi,
+  /may\s+not\s+be\s+deprecated/gi,
+  /may\s+continue\s+(?:working|to\s+work)/gi,
+  /may\s+maintain\s+(?:it|the\s+Assistants)/gi,
+  /buys?\s+you\s+(?:more\s+)?time/gi,
+  /(?:remains|stays|is\s+still)\s+available\s+on\s+Azure/gi,
+  /Azure\s+is\s+(?:un|not\s+)affected/gi,
+];
+
+const SHUTDOWN_SUBJECT = /Azure|Assistants/i;
+
+const SUBJECT_WINDOW = 200;
+
+const HTML_TAG = /<\/?[a-zA-Z][^>]*>/g;
+
+const AZURE_STATEMENT_WINDOW = 400;
+
+const RETIREMENT_VERB = /retire[ds]?|retirement|shuts?\s?down|sunset/i;
+
+const LONG_DATE = /\b(?:January|February|March|April|May|June|July|August|September|October|November|December)\s+\d{1,2},\s+\d{4}\b/;
+
+export interface AzureRetirementStatement {
+  date: string;
+  namesSuccessor: boolean;
+  sentence: string;
+}
+
+export function plainText(html: string): string {
+  return html
+    .replace(HTML_TAG, " ")
+    .replace(/&mdash;/g, "—")
+    .replace(/&middot;/g, "·")
+    .replace(/&amp;/g, "&")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+export function azureRetirementStatement(html: string): AzureRetirementStatement | null {
+  const text = plainText(html);
+  const azure = /Azure/g;
+  for (let match = azure.exec(text); match !== null; match = azure.exec(text)) {
+    const window = text.slice(match.index, match.index + AZURE_STATEMENT_WINDOW);
+    if (!RETIREMENT_VERB.test(window)) continue;
+    const date = window.match(LONG_DATE);
+    if (!date) continue;
+    const namesSuccessor = window.includes(ASSISTANTS_API_SHUTDOWN.azureSuccessor);
+    if (!namesSuccessor) continue;
+    return { date: date[0], namesSuccessor, sentence: window };
+  }
+  return null;
+}
+
+export function azureSurvivalClaims(text: string): string[] {
+  const found = new Map<number, string>();
+  for (const pattern of AZURE_SURVIVAL_PATTERNS) {
+    pattern.lastIndex = 0;
+    for (let match = pattern.exec(text); match !== null; match = pattern.exec(text)) {
+      const from = Math.max(0, match.index - SUBJECT_WINDOW);
+      const to = Math.min(text.length, match.index + match[0].length + SUBJECT_WINDOW);
+      const window = text.slice(from, to);
+      if (!SHUTDOWN_SUBJECT.test(window)) continue;
+      if (found.has(match.index)) continue;
+      found.set(match.index, window.replace(/\s+/g, " ").trim());
+    }
+  }
+  return [...found.entries()].sort((a, b) => a[0] - b[0]).map(entry => entry[1]);
+}

--- a/src/faq-provenance.ts
+++ b/src/faq-provenance.ts
@@ -8,7 +8,7 @@ export interface FaqItem {
 export const FAQ_BASELINE = {
   answers: 166,
   stating_a_figure: 77,
-  a_digit_but_no_figure: 39,
+  a_digit_but_no_figure: 40,
 };
 
 const CURRENCY_AMOUNT = /[$€£¢]\s?\d|\d\s?¢|\b\d[\d,.]*\s?(?:USD|EUR|GBP)\b/;

--- a/src/serve.ts
+++ b/src/serve.ts
@@ -28,6 +28,7 @@ import { subscribe as watchlistSubscribe, getSubscription as getWatchlistSubscri
 import { toSlug, vendorSlugMap, resolveVendorSlug, namedVendorSlug } from "./vendor-slug.js";
 import { linkifyVerdictBlocks, overdueReport, pageCompiledClause, pageDataProvenance, pageDateModified, pageFreshness, pageFreshnessSentence, utcToday, verdictsOutdatedBy } from "./page-reviews.js";
 import { faqPageJsonLd, type FaqItem } from "./faq-provenance.js";
+import { ASSISTANTS_API_SHUTDOWN } from "./assistants-shutdown.js";
 import { rankOffers, rankForListing, rotateListing, utcDate, CRITERIA_PATH, DEMOTE_ONLY_POLICY, DISCLOSURE_RATIONALE, TIE_BREAK_ALGORITHM, GATE_TABLE, DEMERIT_TABLE, NOT_FREE_TIER_RULES, TIME_LIMITED_TIER_RULES } from "./ranking.js";
 import type { RankedEntry, RankingResult } from "./ranking.js";
 import { partitionAlternatives, partitionAlternativesAcross, productRoleSentence, MEMBERSHIP_GATE_RULES, MEMBERSHIP_GATE_ORDER, MEMBERSHIP_GATE_SYMMETRY, MEMBERSHIP_GATE_SCOPE, MEMBERSHIP_GATE_CORRECTIONS } from "./product-role.js";
@@ -23586,7 +23587,7 @@ ${mcpCtaCss()}
   </div>
 
   <div class="context-box">
-    <strong>Azure OpenAI users:</strong> Azure follows OpenAI\u2019s deprecation timeline. If you\u2019re using Azure OpenAI Assistants API, you\u2019ll also need to migrate by August 26, 2026. The Azure Responses API mirrors OpenAI\u2019s implementation.
+    <strong>Azure OpenAI users:</strong> Azure follows OpenAI\u2019s deprecation timeline. Microsoft retired the Azure OpenAI Assistants API on ${ASSISTANTS_API_SHUTDOWN.date} as well, so an Azure deployment does not extend the deadline. Move agents to ${ASSISTANTS_API_SHUTDOWN.azureSuccessor}; the ${ASSISTANTS_API_SHUTDOWN.azureInferenceApi} mirrors OpenAI\u2019s implementation for inference only.
   </div>
 
   <h2 id="migration-paths">Migration Paths</h2>
@@ -24071,7 +24072,7 @@ ${mcpCtaCss()}
   </div>
   <div class="timeline-event" style="border-bottom:none">
     <div class="timeline-date" style="color:#f85149">Aug 26, 2026</div>
-    <div class="timeline-content"><strong>Full shutdown.</strong> All Assistants, Threads, Runs, and Messages endpoints cease functioning. No grace period announced. Azure OpenAI follows the same timeline.</div>
+    <div class="timeline-content"><strong>Full shutdown.</strong> All Assistants, Threads, Runs, and Messages endpoints cease functioning. No grace period announced. Microsoft retired the Azure OpenAI Assistants API on ${ASSISTANTS_API_SHUTDOWN.date} too and directs Azure agents to ${ASSISTANTS_API_SHUTDOWN.azureSuccessor}.</div>
   </div>
 
   <div class="context-box">
@@ -25314,9 +25315,9 @@ function buildOpenAIAssistantsMigrationPage(): string {
       monthlyCostMid: "$100\u2013300",
       monthlyCostHigh: "$1,000\u20135,000",
       migrationEffort: "Low\u2013Medium",
-      freeOption: "$200 trial credits",
+      freeOption: "$200 Azure credit, 30 days",
       bestFor: "Enterprise users, teams already on Azure, compliance requirements",
-      details: "Same GPT models via Azure. Assistants API on Azure has NOT been deprecated \u2014 Azure may maintain it independently. Enterprise SLAs, data residency, and private endpoints included.",
+      details: `Same GPT models via Azure, but Microsoft retired the Azure OpenAI Assistants API on ${ASSISTANTS_API_SHUTDOWN.date} \u2014 the same date as OpenAI's. Azure workloads move to ${ASSISTANTS_API_SHUTDOWN.azureSuccessor} for agents, or the ${ASSISTANTS_API_SHUTDOWN.azureInferenceApi} for inference only. Enterprise SLAs, data residency, and private endpoints included.`,
     },
     {
       name: "Anthropic Claude API",
@@ -25450,7 +25451,7 @@ function buildOpenAIAssistantsMigrationPage(): string {
   const faqEntries = [
     { q: "When does the OpenAI Assistants API shut down?", a: "The Assistants API will be fully shut down on August 26, 2026. After this date, all Assistants API calls will return errors. OpenAI recommends migrating to the Responses API (for prompts and tool use) and Conversations API (for thread/session management)." },
     { q: "What is the cheapest alternative to the OpenAI Assistants API?", a: "Google Gemini API offers the most generous free tier with 1,500 free requests/day (Flash model). For open-source options, LangChain and CrewAI are free frameworks \u2014 you only pay for the LLM API you choose (or use free local models via Ollama). Anthropic Claude also offers a free tier with rate limits." },
-    { q: "Can I keep using the Assistants API on Azure OpenAI?", a: "Azure OpenAI has NOT announced deprecation of its Assistants API implementation. Azure may maintain the Assistants API independently of OpenAI's decision. However, there is no guarantee \u2014 monitor Azure announcements. If you're on Azure, this may buy you time to plan a more careful migration." },
+    { q: "Can I keep using the Assistants API on Azure OpenAI?", a: `No. Microsoft retired the Azure OpenAI Assistants API on ${ASSISTANTS_API_SHUTDOWN.date}, the same date OpenAI retired its own. Microsoft's documentation states that the Assistants API is retired and directs Azure workloads to ${ASSISTANTS_API_SHUTDOWN.azureSuccessor}, which is generally available; inference-only workloads can use the ${ASSISTANTS_API_SHUTDOWN.azureInferenceApi} instead. Running on Azure does not extend the deadline.` },
     { q: "What replaces Threads in the new Responses API?", a: "OpenAI's Conversations API replaces the Threads functionality from the Assistants API. It provides session management, message history, and context handling. The migration is not automated \u2014 you need to manually update your code to use the new Conversations API endpoints." },
     { q: "How much will migration cost in developer time?", a: "For a small project (single assistant), expect 1\u20132 days of developer time for the Responses API migration. For complex multi-assistant systems, budget 1\u20132 weeks. Switching to a different provider (Anthropic, Gemini, LangChain) adds additional time for API differences and testing. See our cost comparison table for per-path estimates." },
   ];
@@ -25578,7 +25579,7 @@ function buildOpenAIAssistantsMigrationPage(): string {
     '\n' +
     // Executive summary
     '  <div class="executive-summary">\n' +
-    '    <p><strong>What\'s happening:</strong> OpenAI is sunsetting the Assistants API on August 26, 2026. All Assistants, Threads, and associated API calls will stop working. Developers must migrate to the Responses API + Conversations API, switch to Azure OpenAI (which has not announced deprecation), or move to an alternative platform entirely.</p>\n' +
+    '    <p><strong>What\'s happening:</strong> OpenAI is sunsetting the Assistants API on ' + ASSISTANTS_API_SHUTDOWN.date + '. All Assistants, Threads, and associated API calls will stop working. Developers must migrate to the Responses API + Conversations API, or move to an alternative platform entirely. Azure is not a way out: Microsoft retired the Azure OpenAI Assistants API on the same date, ' + ASSISTANTS_API_SHUTDOWN.date + ', and points agentic workloads at ' + ASSISTANTS_API_SHUTDOWN.azureSuccessor + '.</p>\n' +
     '    <p><strong>The cost question:</strong> Migration isn\'t just about code changes \u2014 it\'s about ongoing costs. Staying with OpenAI means the same token pricing but new API patterns. Switching providers can reduce costs 30\u201370% (Gemini\'s free tier) or increase them (Azure\'s enterprise overhead). Open-source frameworks (LangChain, CrewAI) eliminate platform lock-in but require more engineering investment.</p>\n' +
     '    <p><strong>This guide covers:</strong> cost comparison at 3 usage tiers (hobby, production, scale), migration effort estimates, free tier options, and a recommended timeline \u2014 compiled by hand from vendor pricing pages.</p>\n' +
     '  </div>\n' +
@@ -25619,7 +25620,7 @@ function buildOpenAIAssistantsMigrationPage(): string {
     '  </div>\n' +
     '\n' +
     '  <div class="context-box">\n' +
-    '    <strong>Cost insight:</strong> If cost is your primary concern, <a href="/vendor/google-gemini-api">Google Gemini API</a> offers the best free tier (1,500 requests/day on Flash). If migration speed is the priority, the Responses API is the path of least resistance. For teams already on Azure, the Assistants API may continue working \u2014 monitor Azure announcements.\n' +
+    '    <strong>Cost insight:</strong> If cost is your primary concern, <a href="/vendor/google-gemini-api">Google Gemini API</a> offers the best free tier (1,500 requests/day on Flash). If migration speed is the priority, the Responses API is the path of least resistance. Teams already on Azure face the same deadline: Microsoft retired the Azure OpenAI Assistants API on ' + ASSISTANTS_API_SHUTDOWN.date + ' and directs agents to ' + ASSISTANTS_API_SHUTDOWN.azureSuccessor + '.\n' +
     '  </div>\n' +
     '\n' +
     // Section 2: Migration Paths Detailed
@@ -25648,7 +25649,7 @@ function buildOpenAIAssistantsMigrationPage(): string {
     '      <tr><td style="font-weight:600">Anthropic Claude</td><td style="color:#3fb950;font-weight:600">Free tier available</td><td style="font-size:.85rem">Rate-limited</td><td style="font-size:.85rem">Tool use, 200K\u20131M context</td></tr>\n' +
     '      <tr><td style="font-weight:600">LangChain</td><td style="color:#3fb950;font-weight:600">Fully free (MIT)</td><td style="font-size:.85rem">LLM API costs only</td><td style="font-size:.85rem">LangGraph agents, tool calling</td></tr>\n' +
     '      <tr><td style="font-weight:600">CrewAI</td><td style="color:#3fb950;font-weight:600">Fully free (MIT)</td><td style="font-size:.85rem">LLM API costs only</td><td style="font-size:.85rem">Multi-agent orchestration</td></tr>\n' +
-    '      <tr><td style="font-weight:600"><a href="/vendor/azure" style="color:var(--text)">Azure OpenAI</a></td><td style="color:#d29922;font-weight:600">$200 trial credits</td><td style="font-size:.85rem">Credits expire</td><td style="font-size:.85rem">Assistants API (not deprecated)</td></tr>\n' +
+    '      <tr><td style="font-weight:600"><a href="/vendor/azure" style="color:var(--text)">Azure OpenAI</a></td><td style="color:#d29922;font-weight:600">$200 credit, 30 days</td><td style="font-size:.85rem">General Azure trial credit, not an agent entitlement</td><td style="font-size:.85rem">' + escHtmlServer(ASSISTANTS_API_SHUTDOWN.azureSuccessor) + ' — Assistants API retired ' + escHtmlServer(ASSISTANTS_API_SHUTDOWN.date) + '</td></tr>\n' +
     '    </tbody>\n' +
     '  </table>\n' +
     '  </div>\n' +
@@ -25679,7 +25680,7 @@ function buildOpenAIAssistantsMigrationPage(): string {
     '    <h3>Which migration path is right for you?</h3>\n' +
     '    <div class="verdict-item"><strong>Fastest migration:</strong><p>OpenAI Responses API \u2014 same provider, same models, just new API patterns. Minimal code changes.</p></div>\n' +
     '    <div class="verdict-item"><strong>Lowest cost:</strong><p>Google Gemini API \u2014 1,500 free requests/day on Flash, competitive paid pricing. OpenAI-compatible endpoint eases migration.</p></div>\n' +
-    '    <div class="verdict-item"><strong>Enterprise / compliance:</strong><p>Azure OpenAI \u2014 same GPT models, enterprise SLAs, data residency. Assistants API may not be deprecated on Azure.</p></div>\n' +
+    '    <div class="verdict-item"><strong>Enterprise / compliance:</strong><p>Azure OpenAI \u2014 same GPT models, enterprise SLAs, data residency. Rebuild on ' + escHtmlServer(ASSISTANTS_API_SHUTDOWN.azureSuccessor) + ': Microsoft retired the Azure Assistants API on ' + escHtmlServer(ASSISTANTS_API_SHUTDOWN.date) + ' too, so this path is a change of platform, not a way to keep the old API.</p></div>\n' +
     '    <div class="verdict-item"><strong>Best reasoning quality:</strong><p>Anthropic Claude \u2014 Claude 4 Opus for complex tasks. Tool use built in. Prompt caching reduces costs 90% for repeated context.</p></div>\n' +
     '    <div class="verdict-item"><strong>Maximum flexibility:</strong><p>LangChain + BYO LLM \u2014 swap models anytime, no platform lock-in. More work upfront but full control.</p></div>\n' +
     '    <div class="verdict-item"><strong>Multi-agent workflows:</strong><p>CrewAI \u2014 if your Assistants setup used multiple coordinating agents, CrewAI\'s role-based agent model is a natural fit.</p></div>\n' +

--- a/test/azure-assistants-retirement.test.ts
+++ b/test/azure-assistants-retirement.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, before, after } from "node:test";
+import assert from "node:assert";
+import { spawn, type ChildProcess } from "node:child_process";
+import { readFileSync, readdirSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  ASSISTANTS_API_SHUTDOWN, azureRetirementStatement, azureSurvivalClaims, plainText,
+} from "../dist/assistants-shutdown.js";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO = path.join(__dirname, "..");
+
+let serverPort = 0;
+let proc: ChildProcess | null = null;
+
+function startServer(): Promise<ChildProcess> {
+  return new Promise((resolve, reject) => {
+    const child = spawn("node", [path.join(REPO, "dist", "serve.js")], {
+      stdio: ["pipe", "pipe", "pipe"],
+      env: { ...process.env, PORT: "0", BASE_URL: "http://localhost" },
+    });
+    const timeout = setTimeout(() => { child.kill(); reject(new Error("Server startup timeout")); }, 20000);
+    child.stderr!.on("data", (data: Buffer) => {
+      const m = data.toString().match(/running on http:\/\/localhost:(\d+)/);
+      if (m) { serverPort = parseInt(m[1], 10); clearTimeout(timeout); resolve(child); }
+    });
+    child.on("error", (err) => { clearTimeout(timeout); reject(err); });
+  });
+}
+
+const rendered = new Map<string, string>();
+
+before(async () => {
+  proc = await startServer();
+  for (const page of ASSISTANTS_API_SHUTDOWN.pages) {
+    const res = await fetch(`http://localhost:${serverPort}${page}`);
+    assert.strictEqual(res.status, 200, `${page} should render`);
+    rendered.set(page, await res.text());
+  }
+});
+
+after(() => { if (proc) proc.kill(); });
+
+const WITHDRAWN_CLAIMS = [
+  "Same GPT models via Azure. Assistants API on Azure has NOT been deprecated — Azure may maintain it independently.",
+  "Azure OpenAI has NOT announced deprecation of its Assistants API implementation.",
+  "If you're on Azure, this may buy you time to plan a more careful migration.",
+  "Developers must migrate to the Responses API, switch to Azure OpenAI (which has not announced deprecation), or move on.",
+  "For teams already on Azure, the Assistants API may continue working — monitor Azure announcements.",
+  "Azure OpenAI · $200 trial credits · Credits expire · Assistants API (not deprecated)",
+  "Azure OpenAI — same GPT models, enterprise SLAs, data residency. Assistants API may not be deprecated on Azure.",
+];
+
+describe("Azure Assistants API retirement (#1089)", () => {
+  it("Microsoft's published retirement date is pinned independently of the render", () => {
+    assert.strictEqual(ASSISTANTS_API_SHUTDOWN.isoDate, "2026-08-26");
+    assert.strictEqual(ASSISTANTS_API_SHUTDOWN.date, "August 26, 2026");
+    assert.strictEqual(ASSISTANTS_API_SHUTDOWN.azureSuccessor, "Microsoft Foundry Agent Service");
+  });
+
+  it("the detector flags every survival claim this page used to publish", () => {
+    for (const claim of WITHDRAWN_CLAIMS) {
+      assert.notDeepStrictEqual(azureSurvivalClaims(claim), [], `detector missed: ${claim}`);
+    }
+  });
+
+  it("no page claims the Azure Assistants API outlived the shutdown date", () => {
+    for (const [page, html] of rendered) {
+      const claims = azureSurvivalClaims(plainText(html));
+      assert.deepStrictEqual(claims, [], `${page} still tells the reader the Azure Assistants API survived: ${claims.join(" | ")}`);
+    }
+  });
+
+  it("no source string claims the Azure Assistants API outlived the shutdown date", () => {
+    const srcDir = path.join(REPO, "src");
+    const offenders: string[] = [];
+    const patternHome = "assistants-shutdown.ts";
+    for (const file of readdirSync(srcDir).filter(f => f.endsWith(".ts") && f !== patternHome)) {
+      for (const claim of azureSurvivalClaims(readFileSync(path.join(srcDir, file), "utf-8"))) {
+        offenders.push(`src/${file}: ${claim}`);
+      }
+    }
+    assert.deepStrictEqual(offenders, [], `survival claims in source: ${offenders.join(" | ")}`);
+  });
+
+  it("every page covering the shutdown states the Azure retirement date and names the successor", () => {
+    for (const [page, html] of rendered) {
+      const statement = azureRetirementStatement(html);
+      assert.ok(statement, `${page} states no Azure retirement date alongside ${ASSISTANTS_API_SHUTDOWN.azureSuccessor}`);
+      assert.strictEqual(statement.date, ASSISTANTS_API_SHUTDOWN.date, `${page} dates the Azure retirement differently`);
+    }
+  });
+
+  it("the three pages agree on the retirement date and the named successor", () => {
+    const dates = new Set<string>();
+    for (const [page, html] of rendered) {
+      const statement = azureRetirementStatement(html);
+      assert.ok(statement, `${page} carries no Azure retirement statement to compare`);
+      dates.add(statement.date);
+    }
+    assert.strictEqual(rendered.size, 3, "three pages cover this shutdown");
+    assert.deepStrictEqual([...dates], [ASSISTANTS_API_SHUTDOWN.date], "pages disagree on the Azure retirement date");
+  });
+
+  it("the structured FAQ answer about Azure states the retirement", () => {
+    const html = rendered.get("/openai-assistants-migration")!;
+    const blocks = [...html.matchAll(/<script type="application\/ld\+json">(.*?)<\/script>/gs)].map(m => JSON.parse(m[1]));
+    const faq = blocks.find(b => b["@type"] === "FAQPage");
+    assert.ok(faq, "/openai-assistants-migration should publish FAQPage markup");
+    const azureQuestion = faq.mainEntity.find((q: { name: string }) => /Azure/i.test(q.name));
+    assert.ok(azureQuestion, "an FAQ entry should answer the Azure question");
+    const answer: string = azureQuestion.acceptedAnswer.text;
+    assert.deepStrictEqual(azureSurvivalClaims(answer), [], `structured answer still claims survival: ${answer}`);
+    assert.ok(answer.includes(ASSISTANTS_API_SHUTDOWN.date), "structured answer should carry the retirement date");
+    assert.ok(answer.includes(ASSISTANTS_API_SHUTDOWN.azureSuccessor), "structured answer should name the successor");
+  });
+});


### PR DESCRIPTION
Refs #1089

Microsoft retired the Azure OpenAI Assistants API on **2026-08-26**, the same date as OpenAI's. Verified against Microsoft Learn today: the Assistants API concepts page carries "The Assistants API is retired. Use the generally available Microsoft Foundry Agents service", and the successor's own overview is titled "What is Microsoft Foundry Agent Service?".

## AC1 — the Azure claims are corrected

The issue named four. There were **six**. The two extra ones are the two that travel furthest:

| Where | Was |
|---|---|
| Migration path card | "Assistants API on Azure has NOT been deprecated — Azure may maintain it independently." |
| **FAQPage JSON-LD answer** | "Azure OpenAI has NOT announced deprecation… this may buy you time to plan a more careful migration." |
| **Executive summary** | "switch to Azure OpenAI (which has not announced deprecation)" |
| Cost insight | "the Assistants API may continue working — monitor Azure announcements" |
| Free Tier Alternatives row | "Assistants API (not deprecated)" |
| Recommendations, Enterprise | "Assistants API may not be deprecated on Azure." |

The FAQ answer is the one that mattered most: it is structured copy an engine lifts verbatim, and it answered the exact question this reader asks. It now reads:

> No. Microsoft retired the Azure OpenAI Assistants API on August 26, 2026, the same date OpenAI retired its own. Microsoft's documentation states that the Assistants API is retired and directs Azure workloads to Microsoft Foundry Agent Service, which is generally available; inference-only workloads can use the Azure OpenAI Responses API instead. Running on Azure does not extend the deadline.

## AC2 — the Free Tier Alternatives row

Restated rather than removed. `$200 credit, 30 days` is verified against azure.microsoft.com/free ("$200 credit to use on Azure services within 30 days"); the key-limit cell now says it is a general Azure trial credit, not an agent entitlement; the support cell names Foundry Agent Service and the retirement date.

## AC3 — a test asserts no page claims survival

`azureSurvivalClaims()` matches the ten phrasings this defect used, requires the match to sit within 200 characters of Azure or Assistants, and returns the surrounding text so a failure quotes itself. Two tests use it: one over the rendered pages, one over every `src/*.ts` file, so a fourth page acquiring the claim fails the build. A third feeds it the seven withdrawn sentences and asserts it flags each.

## AC4 — the three pages cannot diverge again

`src/assistants-shutdown.ts` holds the date, the agentic successor and the inference-only API. All three pages read it. `azureRetirementStatement()` extracts, from each rendered page, the date stated within 400 characters of an Azure mention that also names the successor; a test asserts all three return the same date and that it equals the record. Editing one page's literal fails the build. The record's own value is pinned against Microsoft's published date in a separate assertion, so silently editing the record fails too.

`/openai-assistants-alternatives` and `/openai-assistants-migration-2026` had the date right but named no successor; both now do.

## Verification

- `npm test` — **2011/2011**, 0 failures.
- `scripts/mutate-1089.sh` — 10 mutations, **10 killed**. Each withdrawn claim put back; one page dated differently; one page stripped of the successor; the shared record edited; the detector narrowed.
- 3,913 routes rendered against a `main` worktree and diffed: **exactly 3 differ**, and every added and removed sentence was read.
- Screenshots of the executive summary, the recommendations box and the free-tier table.

`FAQ_BASELINE.a_digit_but_no_figure` moves 39 → 40. The corrected Azure answer names a retirement date; that is a public event date rather than a compiled quota, so the rule correctly declines to read it as a figure and the answer carries no compile clause. The ratchet did its job — it made me look.

## Not in this PR

- The Gemini `1,500 requests/day` and Anthropic `Claude 4` defects noted on the issue have no acceptance criteria and are not Azure. The Gemini figure sits in a sentence this PR edits and remains unverified.
- The page's countdown reads `0 days until Assistants API shutdown` while the corrected prose is past tense. That is #1064.
- The page stays `review_outcome: fail` and keeps rendering "corrections outstanding" until a review passes. Recording that is the PM's call, not mine.