### PR TITLE
Close the /search facet space to crawlers (#1093)

### DIFF
--- a/scripts/check-search-nofollow.js
+++ b/scripts/check-search-nofollow.js
@@ -1,0 +1,79 @@
+#!/usr/bin/env node
+import { argv, exit } from "node:process";
+
+const base = argv[2] || "http://localhost:3000";
+const UA = "agentdeals-internal/1.0 (search crawl-space check)";
+
+async function get(url) {
+  const res = await fetch(url, { headers: { "User-Agent": UA } });
+  return res.text();
+}
+
+async function sitemapRoutes() {
+  const seen = new Set();
+  const routes = new Set();
+  const todo = [`${base}/sitemap.xml`];
+  while (todo.length) {
+    const sm = todo.pop();
+    if (seen.has(sm)) continue;
+    seen.add(sm);
+    let body;
+    try {
+      body = await get(sm);
+    } catch (err) {
+      console.error(`sitemap unreachable: ${sm} (${err.message})`);
+      continue;
+    }
+    for (const m of body.matchAll(/<loc>(.*?)<\/loc>/g)) {
+      const loc = m[1].replace(/^https?:\/\/[^/]+/, "");
+      if (loc.endsWith(".xml")) todo.push(base + loc);
+      else routes.add(loc);
+    }
+  }
+  return [...routes].sort();
+}
+
+function searchAnchors(html) {
+  return [...html.matchAll(/<a\s[^>]*>/g)]
+    .map(m => m[0])
+    .filter(tag => /href="(?:https?:\/\/[^/"]+)?\/search\?[^"]*"/.test(tag));
+}
+
+function anchorHref(tag) {
+  const m = tag.match(/href="([^"]*)"/);
+  return m ? m[1].replace(/&amp;/g, "&") : "";
+}
+
+const routes = await sitemapRoutes();
+console.log(`routes from sitemap index: ${routes.length}`);
+
+const violations = [];
+const linked = new Set();
+const queue = [...routes];
+const workers = Array.from({ length: 12 }, async () => {
+  while (queue.length) {
+    const route = queue.shift();
+    let html;
+    try {
+      html = await get(base + route);
+    } catch (err) {
+      console.error(`fetch failed: ${route} (${err.message})`);
+      continue;
+    }
+    for (const tag of searchAnchors(html)) {
+      linked.add(anchorHref(tag));
+      if (!/\brel="[^"]*nofollow[^"]*"/.test(tag)) violations.push({ route, tag });
+    }
+  }
+});
+await Promise.all(workers);
+
+console.log(`distinct query-bearing /search URLs linked: ${linked.size}`);
+for (const href of [...linked].sort()) console.log(`  ${href}`);
+
+if (violations.length) {
+  console.log(`\nanchors missing rel="nofollow": ${violations.length}`);
+  for (const v of violations) console.log(`  ${v.route}\n    ${v.tag}`);
+  exit(1);
+}
+console.log(`\nall query-bearing /search anchors carry rel="nofollow"`);

--- a/scripts/mutate-1093.sh
+++ b/scripts/mutate-1093.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+set -uo pipefail
+REPO="$(cd "$(dirname "$0")/.." && pwd)"
+SRC="$REPO/src/serve.ts"
+BACKUP=$(mktemp)
+cp "$SRC" "$BACKUP"
+restore() { cp "$BACKUP" "$SRC"; (cd "$REPO" && npm run build >/dev/null 2>&1); }
+trap restore EXIT
+
+mutate() {
+  FIND="$1" REPLACE="$2" python3 - "$SRC" <<'PY'
+import os, sys
+path = sys.argv[1]
+find, replace = os.environ["FIND"], os.environ["REPLACE"]
+text = open(path, encoding="utf-8").read()
+if find not in text:
+    sys.exit(2)
+open(path, "w", encoding="utf-8").write(text.replace(find, replace, 1))
+PY
+}
+
+run_case() {
+  local name="$1"
+  if ! cmp -s "$SRC" "$BACKUP"; then
+    if (cd "$REPO" && npm run build > /tmp/mut-build.log 2>&1); then
+      if (cd "$REPO" && node --test --test-concurrency 1 test/search-crawl-space.test.ts > /tmp/mut-test.log 2>&1); then
+        echo "SURVIVED: $name"
+      else
+        echo "killed:   $name"
+      fi
+    else
+      echo "SURVIVED (did not compile): $name"
+    fi
+  else
+    echo "NOT APPLIED: $name"
+  fi
+  cp "$BACKUP" "$SRC"
+}
+
+case_run() { mutate "$2" "$3" || true; run_case "$1"; }
+
+case_run "robots.txt drops the search disallow" \
+  'User-agent: *\n${SEARCH_QUERY_DISALLOW}\nAllow: /' \
+  'User-agent: *\nAllow: /'
+
+case_run "robots.txt states the allow before the disallow" \
+  'User-agent: *\n${SEARCH_QUERY_DISALLOW}\nAllow: /' \
+  'User-agent: *\nAllow: /\n${SEARCH_QUERY_DISALLOW}'
+
+case_run "the disallow names a path nothing serves" \
+  'Disallow: /search?' \
+  'Disallow: /nothing-we-serve'
+
+case_run "the search page drops its robots meta" \
+  "+ SEARCH_PAGE_ROBOTS_META + '\\n'
+    " \
+  "+ "
+
+case_run "the search page asks to be indexed" \
+  'content="noindex,follow"' \
+  'content="index,follow"'
+
+case_run "crawlRel never marks a link nofollow" \
+  'return href.startsWith("/search?") ? NOFOLLOW_ATTR : "";' \
+  'return "";'
+
+case_run "crawlRel marks every link nofollow" \
+  'return href.startsWith("/search?") ? NOFOLLOW_ATTR : "";' \
+  'return NOFOLLOW_ATTR;'
+
+case_run "crawlRel does not distinguish the query-bearing space" \
+  'return href.startsWith("/search?")' \
+  'return href.startsWith("/search")'
+
+case_run "searchQueryAnchor drops the rel attribute" \
+  "+ crawlRel(href) + attrs" \
+  "+ attrs"
+
+case_run "one hand-written search link loses its nofollow" \
+  '<a href="/search?q=opentofu" rel="nofollow">' \
+  '<a href="/search?q=opentofu">'
+
+case_run "the sitemap submits the noindex search page" \
+  "BASE_URL + '/stacks</loc>" \
+  "BASE_URL + '/search</loc>"
+
+case_run "the pagination link drops the page number" \
+  'if (overrides.page) params.set("page", overrides.page);' \
+  ''
+
+case_run "the facet pills stop going through the anchor helper" \
+  "return searchQueryAnchor(href, escHtmlServer(t.label), ' class=\"type-filter' + (isActive ? \" active\" : \"\") + '\"');" \
+  "return '<a href=\"' + escHtmlServer(href) + '\" class=\"type-filter' + (isActive ? \" active\" : \"\") + '\">' + escHtmlServer(t.label) + '</a>';"

--- a/src/serve.ts
+++ b/src/serve.ts
@@ -134,6 +134,23 @@ const OG_IMAGE_META = `<meta property="og:image" content="${BASE_URL}/og-image.p
 <meta name="twitter:image" content="${BASE_URL}/og-image.png">
 `;
 
+const SEARCH_QUERY_DISALLOW = "Disallow: /search?";
+const SEARCH_PAGE_ROBOTS_META = '<meta name="robots" content="noindex,follow">';
+const NOFOLLOW_ATTR = ' rel="nofollow"';
+
+function searchQueryHref(params: URLSearchParams | string): string {
+  const qs = typeof params === "string" ? params : params.toString();
+  return "/search" + (qs ? "?" + qs : "");
+}
+
+function crawlRel(href: string): string {
+  return href.startsWith("/search?") ? NOFOLLOW_ATTR : "";
+}
+
+function searchQueryAnchor(href: string, inner: string, attrs = ""): string {
+  return '<a href="' + escHtmlServer(href) + '"' + crawlRel(href) + attrs + '>' + inner + '</a>';
+}
+
 // Swagger UI dist path
 const swaggerUiDistPath = join(__dirname, "..", "node_modules", "swagger-ui-dist");
 
@@ -6961,7 +6978,7 @@ ${tableRows}
 
   <div class="search-cta">
     ${vendorSlugMap.has(toSlug(config.primaryVendor)) ? `<p>Looking for more? <a href="/alternative-to/${toSlug(config.primaryVendor)}">Browse all free alternatives to ${config.primaryVendor} &rarr;</a></p>
-    <p style="margin-top:.5rem;font-size:.85rem;color:var(--text-dim)">Or <a href="/search?q=${encodeURIComponent(config.primaryVendor.toLowerCase() + " alternative")}">search</a> our full index of ${offers.length.toLocaleString()}+ developer deals.</p>` : `<p>Looking for more? <a href="/search?q=${encodeURIComponent(config.primaryVendor.toLowerCase() + " alternative")}">Search all ${config.primaryVendor} alternatives</a> in our index of ${offers.length.toLocaleString()}+ developer deals.</p>`}
+    <p style="margin-top:.5rem;font-size:.85rem;color:var(--text-dim)">Or <a href="/search?q=${encodeURIComponent(config.primaryVendor.toLowerCase() + " alternative")}" rel="nofollow">search</a> our full index of ${offers.length.toLocaleString()}+ developer deals.</p>` : `<p>Looking for more? <a href="/search?q=${encodeURIComponent(config.primaryVendor.toLowerCase() + " alternative")}" rel="nofollow">Search all ${config.primaryVendor} alternatives</a> in our index of ${offers.length.toLocaleString()}+ developer deals.</p>`}
   </div>
 
   ${buildMoreAlternativesGuides(slug)}
@@ -18797,7 +18814,7 @@ function buildGoogleDeveloperProgram2026Page(): string {
   ];
 
   const creditAltRows = creditAlternatives.map(c => `<tr>
-      <td style="font-weight:600"><a href="${c.link}" style="color:var(--text)">${escHtmlServer(c.vendor)}</a></td>
+      <td style="font-weight:600"><a href="${c.link}"${crawlRel(c.link)} style="color:var(--text)">${escHtmlServer(c.vendor)}</a></td>
       <td style="font-family:var(--mono);color:var(--accent);font-size:.85rem">${escHtmlServer(c.credits)}</td>
       <td style="color:var(--text-muted);font-size:.85rem">${escHtmlServer(c.highlight)}</td>
     </tr>`).join("\n        ");
@@ -18813,7 +18830,7 @@ function buildGoogleDeveloperProgram2026Page(): string {
   ];
 
   const llmAltRows = llmAlternatives.map(c => `<tr>
-      <td style="font-weight:600"><a href="${c.link}" style="color:var(--text)">${escHtmlServer(c.vendor)}</a></td>
+      <td style="font-weight:600"><a href="${c.link}"${crawlRel(c.link)} style="color:var(--text)">${escHtmlServer(c.vendor)}</a></td>
       <td style="font-family:var(--mono);color:var(--accent);font-size:.85rem">${escHtmlServer(c.free)}</td>
       <td style="color:var(--text-muted);font-size:.85rem">${escHtmlServer(c.models)}</td>
     </tr>`).join("\n        ");
@@ -18827,7 +18844,7 @@ function buildGoogleDeveloperProgram2026Page(): string {
   ];
 
   const firebaseAltRows = firebaseAlternatives.map(c => `<tr>
-      <td style="font-weight:600"><a href="${c.link}" style="color:var(--text)">${escHtmlServer(c.vendor)}</a></td>
+      <td style="font-weight:600"><a href="${c.link}"${crawlRel(c.link)} style="color:var(--text)">${escHtmlServer(c.vendor)}</a></td>
       <td style="font-family:var(--mono);color:var(--accent);font-size:.85rem">${escHtmlServer(c.free)}</td>
       <td style="color:var(--text-muted);font-size:.85rem">${escHtmlServer(c.highlight)}</td>
     </tr>`).join("\n        ");
@@ -21092,7 +21109,7 @@ ${mcpCtaCss()}
 
   <div class="context-box">
     <strong>Key takeaway:</strong> The enhanced free tier is actually <em>better</em> for teams that need SSO and policy — but the 500 resource cap is the critical constraint. If your Terraform state manages more than 500 resources, you will need a paid plan or an alternative.
-    ${hcpLicense ? `<br><br><strong>License context:</strong> HashiCorp switched from MPL 2.0 to BSL 1.1 in 2023, which restricts competitive commercial use. This triggered the <a href="/search?q=opentofu">OpenTofu</a> fork under the Linux Foundation. IBM acquired HashiCorp for $6.4B in 2024.` : ""}
+    ${hcpLicense ? `<br><br><strong>License context:</strong> HashiCorp switched from MPL 2.0 to BSL 1.1 in 2023, which restricts competitive commercial use. This triggered the <a href="/search?q=opentofu" rel="nofollow">OpenTofu</a> fork under the Linux Foundation. IBM acquired HashiCorp for $6.4B in 2024.` : ""}
   </div>
 
   <h2 id="who-affected">2. Who's Affected</h2>
@@ -21131,7 +21148,7 @@ ${mcpCtaCss()}
       <div><strong style="color:#3fb950">Pros:</strong> ${escHtmlServer(path.pros)}</div>
       <div><strong style="color:#f85149">Cons:</strong> ${escHtmlServer(path.cons)}</div>
     </div>
-    <div style="margin-top:.75rem"><a href="${path.link}" style="font-size:.85rem">View details &rarr;</a></div>
+    <div style="margin-top:.75rem"><a href="${path.link}"${crawlRel(path.link)} style="font-size:.85rem">View details &rarr;</a></div>
   </div>`).join("\n  ")}
 
   <h2 id="decision-matrix">4. Decision Matrix</h2>
@@ -21221,7 +21238,7 @@ ${mcpCtaCss()}
     </div>
     <div class="verdict-item">
       <strong>If you're over 500 resources:</strong>
-      <p><a href="/vendor/scalr">Scalr</a> offers the most generous free tier (unlimited resources, users, and workspaces). <a href="/vendor/spacelift">Spacelift</a> is strong on cloud integration. For zero vendor lock-in, self-host with <a href="/search?q=opentofu">OpenTofu</a>.</p>
+      <p><a href="/vendor/scalr">Scalr</a> offers the most generous free tier (unlimited resources, users, and workspaces). <a href="/vendor/spacelift">Spacelift</a> is strong on cloud integration. For zero vendor lock-in, self-host with <a href="/search?q=opentofu" rel="nofollow">OpenTofu</a>.</p>
     </div>
     <div class="verdict-item">
       <strong>If you're concerned about BSL lock-in:</strong>
@@ -21480,7 +21497,7 @@ function buildTerraformCloudFreeTierRemovedPage(): string {
     + '  </table>\n'
     + '\n'
     + '  <div class="context-box">\n'
-    + '    <strong>Context:</strong> HashiCorp switched Terraform from MPL 2.0 to BSL 1.1 in August 2023, triggering the <a href="/search?q=opentofu">OpenTofu</a> fork under the Linux Foundation. IBM acquired HashiCorp for $6.4B in 2024. The free tier restructuring continues the trend of monetizing the Terraform ecosystem. The enhanced free tier adds SSO and policy features but imposes the 500-resource hard cap that affects growing teams.\n'
+    + '    <strong>Context:</strong> HashiCorp switched Terraform from MPL 2.0 to BSL 1.1 in August 2023, triggering the <a href="/search?q=opentofu" rel="nofollow">OpenTofu</a> fork under the Linux Foundation. IBM acquired HashiCorp for $6.4B in 2024. The free tier restructuring continues the trend of monetizing the Terraform ecosystem. The enhanced free tier adds SSO and policy features but imposes the 500-resource hard cap that affects growing teams.\n'
     + '  </div>\n'
     + '\n'
     // Section 2: Who's Affected
@@ -21552,7 +21569,10 @@ function buildTerraformCloudFreeTierRemovedPage(): string {
       const stability = stabilityMap.get(a.slug) ?? "stable";
       const stabilityColor = stability === "volatile" ? "#f85149" : stability === "watch" ? "#d29922" : stability === "improving" ? "#3fb950" : "#3fb950";
       const stabilityLabel = stability === "volatile" ? "Volatile" : stability === "watch" ? "Watch" : stability === "improving" ? "Improving" : "Stable";
-      return '      <tr><td style="font-weight:600"><a href="/' + (a.slug === "terraform-ce" || a.slug === "atlantis" || a.slug === "env0" || a.slug === "opentofu" ? "search?q=" + encodeURIComponent(a.name) : "vendor/" + a.slug) + '">' + escHtmlServer(a.name) + '</a></td>'
+      const altHref = a.slug === "terraform-ce" || a.slug === "atlantis" || a.slug === "env0" || a.slug === "opentofu"
+        ? searchQueryHref("q=" + encodeURIComponent(a.name))
+        : "/vendor/" + a.slug;
+      return '      <tr><td style="font-weight:600"><a href="' + altHref + '"' + crawlRel(altHref) + '>' + escHtmlServer(a.name) + '</a></td>'
         + '<td>' + escHtmlServer(a.type) + '</td>'
         + '<td style="font-family:var(--mono);font-size:.85rem">' + escHtmlServer(a.freeResources) + '</td>'
         + '<td style="font-family:var(--mono);font-size:.85rem">' + escHtmlServer(a.freeUsers) + '</td>'
@@ -21576,14 +21596,14 @@ function buildTerraformCloudFreeTierRemovedPage(): string {
     + '    <tbody>\n'
     + '      <tr><td style="font-weight:600"><a href="/vendor/hcp-terraform">HCP Terraform</a></td><td class="cost-free">500 resources, unlimited users</td><td>1 concurrent run, 500 cap</td><td>BSL 1.1</td></tr>\n'
     + '      <tr><td style="font-weight:600"><a href="/vendor/scalr">Scalr</a></td><td class="cost-free">Unlimited resources + users</td><td>50 runs/month, 5 environments</td><td>Proprietary</td></tr>\n'
-    + '      <tr><td style="font-weight:600"><a href="/search?q=env0">env0</a></td><td class="cost-free">Unlimited resources, 5 users</td><td>Limited deployments/month</td><td>Proprietary</td></tr>\n'
+    + '      <tr><td style="font-weight:600"><a href="/search?q=env0" rel="nofollow">env0</a></td><td class="cost-free">Unlimited resources, 5 users</td><td>Limited deployments/month</td><td>Proprietary</td></tr>\n'
     + '      <tr><td style="font-weight:600"><a href="/vendor/spacelift">Spacelift</a></td><td class="cost-free">Unlimited resources (1 stack)</td><td>2 users, 1 public worker, 1 stack</td><td>Proprietary</td></tr>\n'
     + '      <tr><td style="font-weight:600"><a href="/vendor/terragrunt-scale">Terragrunt Scale</a></td><td class="cost-free">500+ resources</td><td>Requires Terragrunt adoption</td><td>Proprietary</td></tr>\n'
-    + '      <tr><td style="font-weight:600"><a href="/search?q=terramate">Terramate</a></td><td class="cost-free">2 users, all features</td><td>2 user limit</td><td>Proprietary</td></tr>\n'
-    + '      <tr><td style="font-weight:600"><a href="/search?q=digger">Digger</a></td><td class="cost-free">3 users, PR-driven workflows</td><td>3 user limit</td><td>Apache 2.0</td></tr>\n'
-    + '      <tr><td style="font-weight:600"><a href="/search?q=opentofu">OpenTofu</a></td><td class="cost-free">Unlimited everything</td><td>Self-hosted, manage own state</td><td>MPL 2.0</td></tr>\n'
-    + '      <tr><td style="font-weight:600"><a href="/search?q=atlantis">Atlantis</a></td><td class="cost-free">Unlimited everything</td><td>Self-hosted, no UI</td><td>Apache 2.0</td></tr>\n'
-    + '      <tr><td style="font-weight:600"><a href="/search?q=terraform">Terraform CE</a></td><td class="cost-free">Unlimited, CLI only</td><td>No remote state, no collaboration</td><td>BSL 1.1</td></tr>\n'
+    + '      <tr><td style="font-weight:600"><a href="/search?q=terramate" rel="nofollow">Terramate</a></td><td class="cost-free">2 users, all features</td><td>2 user limit</td><td>Proprietary</td></tr>\n'
+    + '      <tr><td style="font-weight:600"><a href="/search?q=digger" rel="nofollow">Digger</a></td><td class="cost-free">3 users, PR-driven workflows</td><td>3 user limit</td><td>Apache 2.0</td></tr>\n'
+    + '      <tr><td style="font-weight:600"><a href="/search?q=opentofu" rel="nofollow">OpenTofu</a></td><td class="cost-free">Unlimited everything</td><td>Self-hosted, manage own state</td><td>MPL 2.0</td></tr>\n'
+    + '      <tr><td style="font-weight:600"><a href="/search?q=atlantis" rel="nofollow">Atlantis</a></td><td class="cost-free">Unlimited everything</td><td>Self-hosted, no UI</td><td>Apache 2.0</td></tr>\n'
+    + '      <tr><td style="font-weight:600"><a href="/search?q=terraform" rel="nofollow">Terraform CE</a></td><td class="cost-free">Unlimited, CLI only</td><td>No remote state, no collaboration</td><td>BSL 1.1</td></tr>\n'
     + '    </tbody>\n'
     + '  </table>\n'
     + '\n'
@@ -51967,21 +51987,22 @@ function buildSearchPage(query: string, categoryFilter: string, typeFilter: stri
     if (cat) params.set("category", cat);
     if (typ) params.set("type", typ);
     if (srt) params.set("sort", srt);
-    return "/search" + (params.toString() ? "?" + params.toString() : "");
+    if (overrides.page) params.set("page", overrides.page);
+    return searchQueryHref(params);
   }
 
   // Category pills
   const catPillsHtml = categories.map(c => {
     const isActive = categoryFilter.toLowerCase() === c.name.toLowerCase();
     const href = buildFilterUrl({ category: isActive ? "" : c.name });
-    return '<a href="' + escHtmlServer(href) + '" class="cat-filter' + (isActive ? " active" : "") + '">' + escHtmlServer(c.name) + ' <span class="cat-count">' + c.count + '</span></a>';
+    return searchQueryAnchor(href, escHtmlServer(c.name) + ' <span class="cat-count">' + c.count + '</span>', ' class="cat-filter' + (isActive ? " active" : "") + '"');
   }).join("\n");
 
   // Type filter pills
   const typePillsHtml = eligibilityTypes.map(t => {
     const isActive = typeFilter.toLowerCase() === t.value.toLowerCase();
     const href = buildFilterUrl({ type: isActive ? "" : t.value });
-    return '<a href="' + escHtmlServer(href) + '" class="type-filter' + (isActive ? " active" : "") + '">' + escHtmlServer(t.label) + '</a>';
+    return searchQueryAnchor(href, escHtmlServer(t.label), ' class="type-filter' + (isActive ? " active" : "") + '"');
   }).join("\n");
 
   // Sort options
@@ -52030,13 +52051,13 @@ function buildSearchPage(query: string, categoryFilter: string, typeFilter: stri
     emptyStateHtml = '<div class="empty-state">'
       + '<p>No results found' + (hasQuery ? ' for &ldquo;<strong>' + escHtmlServer(query) + '</strong>&rdquo;' : '') + (categoryFilter ? ' in ' + escHtmlServer(categoryFilter) : '') + (typeFilter ? ' (' + escHtmlServer(typeFilter) + ')' : '') + '.</p>'
       + '<p>Try a different search or browse categories above.</p>'
-      + '<div class="suggested">' + suggestedSearches.map(function(s) { return '<a href="/search?q=' + encodeURIComponent(s) + '" class="suggest-pill">' + escHtmlServer(s) + '</a>'; }).join(" ") + '</div>'
+      + '<div class="suggested">' + suggestedSearches.map(function(s) { return searchQueryAnchor(searchQueryHref("q=" + encodeURIComponent(s)), escHtmlServer(s), ' class="suggest-pill"'); }).join(" ") + '</div>'
       + '</div>';
   } else {
     emptyStateHtml = '<div class="empty-state">'
       + '<p>Search ' + offers.length.toLocaleString() + ' free developer tools and services.</p>'
       + '<p class="suggested-label">Popular searches:</p>'
-      + '<div class="suggested">' + suggestedSearches.map(function(s) { return '<a href="/search?q=' + encodeURIComponent(s) + '" class="suggest-pill">' + escHtmlServer(s) + '</a>'; }).join(" ") + '</div>'
+      + '<div class="suggested">' + suggestedSearches.map(function(s) { return searchQueryAnchor(searchQueryHref("q=" + encodeURIComponent(s)), escHtmlServer(s), ' class="suggest-pill"'); }).join(" ") + '</div>'
       + '</div>';
   }
 
@@ -52044,11 +52065,11 @@ function buildSearchPage(query: string, categoryFilter: string, typeFilter: stri
   const paginationHtml = totalPages > 1 ? (() => {
     const links: string[] = [];
     if (page > 1) {
-      links.push('<a href="' + escHtmlServer(buildFilterUrl({})) + '&page=' + (page - 1) + '" class="page-link">&larr; Prev</a>');
+      links.push(searchQueryAnchor(buildFilterUrl({ page: String(page - 1) }), '&larr; Prev', ' class="page-link"'));
     }
     links.push('<span class="page-info">Page ' + page + ' of ' + totalPages + ' (' + totalResults + ' results)</span>');
     if (page < totalPages) {
-      links.push('<a href="' + escHtmlServer(buildFilterUrl({})) + '&page=' + (page + 1) + '" class="page-link">Next &rarr;</a>');
+      links.push(searchQueryAnchor(buildFilterUrl({ page: String(page + 1) }), 'Next &rarr;', ' class="page-link"'));
     }
     return '<div class="pagination">' + links.join("") + '</div>';
   })() : totalResults > 0 ? '<div class="pagination"><span class="page-info">' + totalResults + ' result' + (totalResults !== 1 ? 's' : '') + '</span></div>' : "";
@@ -52069,6 +52090,7 @@ function buildSearchPage(query: string, categoryFilter: string, typeFilter: stri
   return '<!DOCTYPE html>\n<html lang="en">\n<head>\n<meta charset="utf-8">\n<meta name="viewport" content="width=device-width,initial-scale=1">\n'
     + '<title>' + titleText + '</title>\n'
     + '<meta name="description" content="' + escHtmlServer(metaDescText) + '">\n'
+    + SEARCH_PAGE_ROBOTS_META + '\n'
     + '<link rel="canonical" href="' + BASE_URL + '/search">\n'
     + '<meta property="og:title" content="' + titleText + '">\n'
     + '<meta property="og:description" content="' + escHtmlServer(metaDescText) + '">\n'
@@ -54572,7 +54594,7 @@ ${weekEntries.join("\n")}
     res.writeHead(200, { "Content-Type": "text/plain; charset=utf-8", "Cache-Control": "public, max-age=86400" });
     res.end(INDEXNOW_KEY);
   } else if (url.pathname === "/robots.txt" && isGetOrHead) {
-    const robotsTxt = `User-agent: *\nAllow: /\n\nSitemap: ${BASE_URL}/sitemap.xml\n`;
+    const robotsTxt = `User-agent: *\n${SEARCH_QUERY_DISALLOW}\nAllow: /\n\nSitemap: ${BASE_URL}/sitemap.xml\n`;
     res.writeHead(200, { "Content-Type": "text/plain; charset=utf-8", "Cache-Control": "public, max-age=86400" });
     res.end(robotsTxt);
   } else if (url.pathname === "/impact-verification" && isGetOrHead) {
@@ -54818,7 +54840,6 @@ ${catList}
       + '  <url>\n    <loc>' + BASE_URL + '/pricing-changes</loc>\n    <lastmod>' + latestVerified + '</lastmod>\n    <changefreq>daily</changefreq>\n    <priority>0.8</priority>\n  </url>\n'
       + '  <url>\n    <loc>' + BASE_URL + '/freshness</loc>\n    <lastmod>' + latestVerified + '</lastmod>\n    <changefreq>daily</changefreq>\n    <priority>0.7</priority>\n  </url>\n'
       + '  <url>\n    <loc>' + BASE_URL + CRITERIA_PATH + '</loc>\n    <lastmod>' + latestVerified + '</lastmod>\n    <changefreq>weekly</changefreq>\n    <priority>0.8</priority>\n  </url>\n'
-      + '  <url>\n    <loc>' + BASE_URL + '/search</loc>\n    <lastmod>' + latestVerified + '</lastmod>\n    <changefreq>weekly</changefreq>\n    <priority>0.7</priority>\n  </url>\n'
       + '  <url>\n    <loc>' + BASE_URL + '/stacks</loc>\n    <lastmod>' + editorialDate + '</lastmod>\n    <changefreq>weekly</changefreq>\n    <priority>0.8</priority>\n  </url>\n';
     for (const t of STACK_TEMPLATES) {
       xml += '  <url>\n    <loc>' + BASE_URL + '/stacks/' + t.slug + '</loc>\n    <lastmod>' + editorialDate + '</lastmod>\n    <changefreq>weekly</changefreq>\n    <priority>0.8</priority>\n  </url>\n';

--- a/test/search-crawl-space.test.ts
+++ b/test/search-crawl-space.test.ts
@@ -1,0 +1,196 @@
+import { describe, it, before, after } from "node:test";
+import assert from "node:assert";
+import { spawn, ChildProcess } from "node:child_process";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const SERVE_SOURCE = path.join(__dirname, "..", "src", "serve.ts");
+
+let serverPort = 0;
+let proc: ChildProcess | null = null;
+
+function startHttpServer(): Promise<ChildProcess> {
+  return new Promise((resolve, reject) => {
+    const serverPath = path.join(__dirname, "..", "dist", "serve.js");
+    const p = spawn("node", [serverPath], {
+      stdio: ["pipe", "pipe", "pipe"],
+      env: { ...process.env, PORT: "0", BASE_URL: "http://localhost" },
+    });
+    const timeout = setTimeout(() => { p.kill(); reject(new Error("Server startup timeout")); }, 15000);
+    p.stderr!.on("data", (data: Buffer) => {
+      const match = data.toString().match(/running on http:\/\/localhost:(\d+)/);
+      if (match) { serverPort = parseInt(match[1], 10); clearTimeout(timeout); resolve(p); }
+    });
+    p.on("error", (err) => { clearTimeout(timeout); reject(err); });
+  });
+}
+
+async function get(routePath: string, headers: Record<string, string> = {}): Promise<string> {
+  const res = await fetch(`http://localhost:${serverPort}${routePath}`, { headers });
+  return res.text();
+}
+
+function anchors(html: string): string[] {
+  return [...html.matchAll(/<a\s[^>]*>/g)].map((m) => m[0]);
+}
+
+function queryBearingSearchAnchors(html: string): string[] {
+  return anchors(html).filter((tag) => /href="(?:https?:\/\/[^/"]+)?\/search\?/.test(tag));
+}
+
+function bareSearchAnchors(html: string): string[] {
+  return anchors(html).filter((tag) => /href="(?:https?:\/\/[^/"]+)?\/search"/.test(tag));
+}
+
+function hrefOf(tag: string): string {
+  const m = tag.match(/href="([^"]*)"/);
+  return m ? m[1].replace(/&amp;/g, "&") : "";
+}
+
+const SEARCH_VARIANTS = [
+  "/search",
+  "/search?q=vercel",
+  "/search?q=database&page=2",
+  "/search?category=CDN",
+  "/search?type=oss&sort=vendor",
+  "/search?q=vercel&category=CDN&type=public&sort=newest",
+];
+
+const PAGES_LINKING_INTO_SEARCH = [
+  "/terraform-cloud-free-tier-removed",
+  "/hcp-terraform-migration",
+  "/firebase-alternatives",
+  "/postman-alternatives",
+  "/google-developer-program-2026",
+];
+
+describe("search facet space is closed to crawlers", () => {
+  before(async () => { proc = await startHttpServer(); });
+  after(() => { if (proc) { proc.kill(); proc = null; } });
+
+  it("robots.txt disallows the query-bearing search space", async () => {
+    const body = await get("/robots.txt");
+    assert.ok(body.includes("Disallow: /search?"), `robots.txt should disallow the search query space, got:\n${body}`);
+  });
+
+  it("robots.txt states the disallow before the site-wide allow", async () => {
+    const body = await get("/robots.txt");
+    const disallowAt = body.indexOf("Disallow: /search?");
+    const allowAt = body.indexOf("Allow: /");
+    assert.ok(allowAt >= 0, "robots.txt should still allow the rest of the site");
+    assert.ok(disallowAt < allowAt, "a first-match parser must see the disallow before the site-wide allow");
+  });
+
+  it("robots.txt still points at the sitemap index", async () => {
+    const body = await get("/robots.txt");
+    assert.match(body, /^Sitemap: https?:\/\/\S+\/sitemap\.xml$/m);
+  });
+
+  for (const variant of SEARCH_VARIANTS) {
+    it(`${variant} asks not to be indexed`, async () => {
+      const html = await get(variant);
+      assert.ok(
+        html.includes('<meta name="robots" content="noindex,follow">'),
+        `${variant} should carry a noindex,follow robots meta`
+      );
+    });
+  }
+
+  it("the search page is absent from the sitemap it asks not to be indexed in", async () => {
+    const sitemap = await get("/sitemap-pages.xml");
+    const locs = [...sitemap.matchAll(/<loc>(.*?)<\/loc>/g)].map((m) => m[1].replace(/^https?:\/\/[^/]+/, ""));
+    assert.ok(locs.length > 100, `sitemap-pages.xml should still list the site, got ${locs.length} entries`);
+    assert.ok(!locs.includes("/search"), "a noindex page should not be submitted for indexing");
+  });
+
+  for (const variant of SEARCH_VARIANTS) {
+    it(`${variant} marks every link back into the facet space nofollow`, async () => {
+      const html = await get(variant);
+      const found = queryBearingSearchAnchors(html);
+      assert.ok(found.length > 0, `${variant} should publish facet links for a human to click`);
+      const followed = found.filter((tag) => !/\brel="[^"]*nofollow[^"]*"/.test(tag));
+      assert.deepStrictEqual(followed, [], `${variant} publishes crawlable facet links`);
+    });
+  }
+
+  for (const variant of ["/search", "/search?category=CDN"]) {
+    it(`${variant} keeps the unfiltered search address followable`, async () => {
+      const html = await get(variant);
+      const bare = bareSearchAnchors(html);
+      assert.ok(bare.length > 0, `${variant} should still link to the unfiltered search page`);
+      for (const tag of bare) {
+        assert.ok(!/nofollow/.test(tag), `a noindex,follow page needs its own address reachable: ${tag}`);
+      }
+    });
+  }
+
+  it("the next-page link carries the query and lands on later results", async () => {
+    const first = await get("/search?q=database");
+    const next = queryBearingSearchAnchors(first)
+      .filter((tag) => /class="page-link"/.test(tag))
+      .map(hrefOf)
+      .find((href) => href.includes("page=2"));
+    assert.ok(next, "a query with more than one page of results should publish a next-page link");
+    assert.ok(next!.includes("q=database"), `the next-page link should keep the query, got ${next}`);
+    const second = await get(next!);
+    const firstVendors = [...first.matchAll(/class="result-vendor">([^<]+)</g)].map((m) => m[1]);
+    const secondVendors = [...second.matchAll(/class="result-vendor">([^<]+)</g)].map((m) => m[1]);
+    assert.ok(secondVendors.length > 0, "the second page should still render results");
+    assert.deepStrictEqual(firstVendors.filter((v) => secondVendors.includes(v)), [], "the second page should not repeat the first");
+  });
+
+  for (const page of PAGES_LINKING_INTO_SEARCH) {
+    it(`${page} marks its search links nofollow`, async () => {
+      const html = await get(page);
+      const found = queryBearingSearchAnchors(html);
+      assert.ok(found.length > 0, `${page} should still link into search`);
+      const followed = found.filter((tag) => !/\brel="[^"]*nofollow[^"]*"/.test(tag));
+      assert.deepStrictEqual(followed, [], `${page} publishes crawlable search links`);
+    });
+  }
+
+  it("every search link an editorial page publishes still resolves", async () => {
+    const targets = new Set<string>();
+    for (const page of PAGES_LINKING_INTO_SEARCH) {
+      for (const tag of queryBearingSearchAnchors(await get(page))) targets.add(hrefOf(tag));
+    }
+    assert.ok(targets.size > 0, "editorial pages should still link into search");
+    for (const target of targets) {
+      const res = await fetch(`http://localhost:${serverPort}${target}`);
+      assert.strictEqual(res.status, 200, `${target} should still serve a result page`);
+      assert.ok((await res.text()).includes("search-input"), `${target} should still render the search page`);
+    }
+  });
+
+  it("search results do not vary by user agent", async () => {
+    const agents = [
+      "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 Chrome/149.0.0.0 Safari/537.36",
+      "Googlebot/2.1 (+http://www.google.com/bot.html)",
+      "python-httpx/0.28.1",
+      "Mozilla/5.0 (X11; Linux x86_64) Chrome/126.0.0.0 Safari/537.36 (compatible; AionBot/1.0)",
+    ];
+    for (const route of ["/search", "/search?q=database"]) {
+      const bodies = await Promise.all(agents.map((ua) => get(route, { "User-Agent": ua })));
+      const cardCounts = bodies.map((b) => (b.match(/class="result-card"/g) ?? []).length);
+      assert.strictEqual(new Set(cardCounts).size, 1, `${route} returned ${cardCounts.join("/")} results across agents`);
+    }
+    const withResults = await get("/search?q=database");
+    assert.ok((withResults.match(/class="result-card"/g) ?? []).length > 0, "a query with matches should still return them");
+  });
+
+  it("no hand-written search link escapes the nofollow rule", async () => {
+    const source = readFileSync(SERVE_SOURCE, "utf8");
+    const needle = 'href="/search?';
+    const unmarked: string[] = [];
+    let at = source.indexOf(needle);
+    while (at !== -1) {
+      const tagEnd = source.indexOf(">", at);
+      const tail = tagEnd === -1 ? source.slice(at, at + 200) : source.slice(at, tagEnd);
+      if (!tail.includes("nofollow")) unmarked.push(tail.slice(0, 160));
+      at = source.indexOf(needle, at + needle.length);
+    }
+    assert.deepStrictEqual(unmarked, [], "a literal search link must carry rel=\"nofollow\"");
+  });
+});


### PR DESCRIPTION
Refs #1093

`/search` published 81 facet links with no `nofollow`, `robots.txt` carried no `Disallow` of any kind, and the page had no `noindex`. The reachable URL space was unbounded and the route was the majority of everything the site served.

## What changed

- **`robots.txt` states `Disallow: /search?` before the site-wide `Allow: /`.** Bare `/search` stays crawlable on purpose — a crawler has to fetch the page to read the meta below — while every query-bearing variant is out of bounds. The disallow is stated first so a first-match parser reaches it; a longest-match parser gets the same answer either way.
- **Every `/search` variant carries `<meta name="robots" content="noindex,follow">`.** `follow` is deliberate: the page links to `/category`, `/vendor` and `/alternative-to`, which is where the crawl budget should go.
- **Every anchor into a query-bearing `/search?` URL carries `rel="nofollow"`** — the 81 facet, suggestion and pagination anchors on the search page, and the 25 distinct search URLs published across 18 editorial pages.
- **`/search` is no longer listed in `sitemap-pages.xml`.** Not in the acceptance criteria, but a sitemap entry is a request to index and the page now asks not to be; leaving both in place is the contradiction Search Console reports as *Submitted URL marked 'noindex'*.

One definition of the rule: `crawlRel(href)` returns the `nofollow` attribute for a `/search?` href and nothing otherwise, and `searchQueryAnchor` / `searchQueryHref` build the links. Facet URLs including the page number now go through `URLSearchParams`, so the next-page link is `&amp;`-escaped rather than having `&page=` concatenated onto an already-escaped string.

## Serving is unchanged

`/search` and every faceted variant still return 200 with the same results, and nothing is gated on User-Agent. Result counts for `q=database`, `q=hosting`, `q=vercel`, `q=auth`, `q=vercel&category=CDN` and `type=oss&sort=vendor` are identical to production, and identical across a desktop browser UA, Googlebot, `python-httpx/0.28.1`, `AionBot/1.0` and no UA at all.

## Verification

- 2038 tests / 0 failures (2011 before, 27 new). `tsc` clean, `npm run validate` clean, 0 new code comments.
- 13 mutations, all killed (`scripts/mutate-1093.sh`) — including dropping the disallow, stating it after the allow, dropping the robots meta, flipping it to `index`, making `crawlRel` always or never return the attribute, making it stop distinguishing the query-bearing space, un-nofollowing one hand-written link, re-adding `/search` to the sitemap, and dropping the page number from the pagination link.
- 3,917 routes rendered against a `main` worktree and diffed: 23 differ. Every one is explained by exactly the three intended edits — proved by normalising `rel="nofollow"`, the robots meta and the disallow line out of the branch render and re-comparing, which leaves only the sitemap entry and the pagination escaping.
- `scripts/check-search-nofollow.js` walks the sitemap index and fails on any query-bearing `/search?` anchor without `rel="nofollow"`. Clean across all 3,912 routes.
- Real MCP `initialize` → `tools/list` → `tools/call`, and a screenshot of `/search?q=database`.

The render sweep earned its keep: a source-level pass missed four anchors on `/terraform-cloud-free-tier-removed` whose hrefs are built from a vendor's display name rather than a slug. The suite now carries both a render check over the pages that publish these links and a static check that no hand-written `/search?` anchor anywhere in `serve.ts` lacks the attribute.