### PR TITLE
Stop caching robots.txt for a day (#1093)

### DIFF
--- a/src/serve.ts
+++ b/src/serve.ts
@@ -135,6 +135,7 @@ const OG_IMAGE_META = `<meta property="og:image" content="${BASE_URL}/og-image.p
 `;
 
 const SEARCH_QUERY_DISALLOW = "Disallow: /search?";
+const ROBOTS_MAX_AGE_SECONDS = 3600;
 const SEARCH_PAGE_ROBOTS_META = '<meta name="robots" content="noindex,follow">';
 const NOFOLLOW_ATTR = ' rel="nofollow"';
 
@@ -54595,7 +54596,7 @@ ${weekEntries.join("\n")}
     res.end(INDEXNOW_KEY);
   } else if (url.pathname === "/robots.txt" && isGetOrHead) {
     const robotsTxt = `User-agent: *\n${SEARCH_QUERY_DISALLOW}\nAllow: /\n\nSitemap: ${BASE_URL}/sitemap.xml\n`;
-    res.writeHead(200, { "Content-Type": "text/plain; charset=utf-8", "Cache-Control": "public, max-age=86400" });
+    res.writeHead(200, { "Content-Type": "text/plain; charset=utf-8", "Cache-Control": `public, max-age=${ROBOTS_MAX_AGE_SECONDS}` });
     res.end(robotsTxt);
   } else if (url.pathname === "/impact-verification" && isGetOrHead) {
     res.writeHead(200, { "Content-Type": "text/plain; charset=utf-8", "Cache-Control": "public, max-age=3600" });

--- a/test/search-crawl-space.test.ts
+++ b/test/search-crawl-space.test.ts
@@ -88,6 +88,16 @@ describe("search facet space is closed to crawlers", () => {
     assert.match(body, /^Sitemap: https?:\/\/\S+\/sitemap\.xml$/m);
   });
 
+  it("robots.txt is not cacheable for longer than an hour", async () => {
+    const res = await fetch(`http://localhost:${serverPort}/robots.txt`);
+    const maxAge = res.headers.get("cache-control")?.match(/max-age=(\d+)/);
+    assert.ok(maxAge, `robots.txt should still declare a max-age, got ${res.headers.get("cache-control")}`);
+    assert.ok(
+      Number(maxAge![1]) <= 3600,
+      `a rule a crawler cannot see is not in force: an edge cache would serve the previous robots.txt for ${maxAge![1]} seconds`
+    );
+  });
+
   for (const variant of SEARCH_VARIANTS) {
     it(`${variant} asks not to be indexed`, async () => {
       const html = await get(variant);


### PR DESCRIPTION
Refs #1093

Immediately after #1095 deployed, `https://agentdeals.dev/robots.txt` still returned the body with no `Disallow`:

```
cache-control: public, max-age=86400
age: 4776
cf-cache-status: HIT
```

The origin was correct the whole time — a cache-busted request returned the disallow — but a crawler asking for the real URL would have kept getting the permissive copy until **2026-08-28T20:02Z**, nearly a full day after the rule shipped.

A day is the wrong TTL for the one file whose entire purpose is to change what a crawler does next. This lowers it to an hour, with a test that fails if it goes back above that.

This does not evict the copy already at the edge; only a purge does, and that needs a credential this repo does not hold. Noted on the issue so AC-5's window is counted from when the rule is actually visible rather than from the merge.

## Verification

2039 tests / 0 failures (28 in `test/search-crawl-space.test.ts`). Mutating the constant back to 86400 fails the new test with a message naming the number of seconds an edge cache would keep serving the old file. `tsc` clean, 0 new code comments.