### PR TITLE
Move the change detector to an OpenRouter-compatible call and schedule it (#1087)

### DIFF
--- a/.github/workflows/reverify.yml
+++ b/.github/workflows/reverify.yml
@@ -34,10 +34,12 @@ jobs:
 
       - name: Run rolling re-verification
         id: reverify
+        env:
+          OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
         run: |
           set -o pipefail
           LIMIT="${{ github.event.inputs.limit || '75' }}"
-          node scripts/reverify-rolling.js --limit "$LIMIT" | tee /tmp/reverify.log
+          node scripts/reverify-rolling.js --ai --limit "$LIMIT" | tee /tmp/reverify.log
           VERIFIED=$(grep -oE '^Verified \(date bumped\): [0-9]+' /tmp/reverify.log | grep -oE '[0-9]+$' || echo 0)
           FLAGGED=$(grep -oE '^Flagged \(URL/AI failure\): [0-9]+' /tmp/reverify.log | grep -oE '[0-9]+$' || echo 0)
           RECORDED=$(grep -oE '^Recorded to data/deal_changes.json: [0-9]+' /tmp/reverify.log | grep -oE '[0-9]+$' || echo 0)

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
       "version": "0.3.1",
       "license": "MIT",
       "dependencies": {
-        "@anthropic-ai/sdk": "^0.104.2",
         "@modelcontextprotocol/ext-apps": "^1.5.0",
         "@modelcontextprotocol/sdk": "^1.29.0",
         "swagger-ui-dist": "^5.32.0",
@@ -47,36 +46,6 @@
       },
       "bin": {
         "mcpb": "dist/cli/cli.js"
-      }
-    },
-    "node_modules/@anthropic-ai/sdk": {
-      "version": "0.104.2",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.104.2.tgz",
-      "integrity": "sha512-s1wEVDAtEwkS7Ajgep6PZKJLFqybRkmD3Byz+iVVsSpbDY0gjROXE9aOft6V3PMqynn3NTcycV5whga9tCzmKA==",
-      "license": "MIT",
-      "dependencies": {
-        "json-schema-to-ts": "^3.1.1",
-        "standardwebhooks": "^1.0.0"
-      },
-      "bin": {
-        "anthropic-ai-sdk": "bin/cli"
-      },
-      "peerDependencies": {
-        "zod": "^3.25.0 || ^4.0.0"
-      },
-      "peerDependenciesMeta": {
-        "zod": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@babel/runtime": {
-      "version": "7.29.2",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
-      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.9.0"
       }
     },
     "node_modules/@cspotcode/source-map-support": {
@@ -425,12 +394,6 @@
       "integrity": "sha512-xxeapPiUXdZAE3che6f3xogoJPeZgig6omHEy1rIY5WVsB3H2BHNnZH+gHG6x91SCWyQCzWGsuL2Hh3ClO5/qQ==",
       "hasInstallScript": true,
       "license": "Apache-2.0"
-    },
-    "node_modules/@stablelib/base64": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@stablelib/base64/-/base64-1.0.1.tgz",
-      "integrity": "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==",
-      "license": "MIT"
     },
     "node_modules/@tsconfig/node10": {
       "version": "1.0.12",
@@ -1028,12 +991,6 @@
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "license": "MIT"
     },
-    "node_modules/fast-sha256": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/fast-sha256/-/fast-sha256-1.3.0.tgz",
-      "integrity": "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==",
-      "license": "Unlicense"
-    },
     "node_modules/fast-uri": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
@@ -1337,19 +1294,6 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/panva"
-      }
-    },
-    "node_modules/json-schema-to-ts": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
-      "integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.18.3",
-        "ts-algebra": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=16"
       }
     },
     "node_modules/json-schema-traverse": {
@@ -1806,16 +1750,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/standardwebhooks": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/standardwebhooks/-/standardwebhooks-1.0.0.tgz",
-      "integrity": "sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==",
-      "license": "MIT",
-      "dependencies": {
-        "@stablelib/base64": "^1.0.0",
-        "fast-sha256": "^1.3.0"
-      }
-    },
     "node_modules/statuses": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
@@ -1880,12 +1814,6 @@
       "engines": {
         "node": ">=0.6"
       }
-    },
-    "node_modules/ts-algebra": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
-      "integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
-      "license": "MIT"
     },
     "node_modules/ts-node": {
       "version": "10.9.2",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,6 @@
     "build:mcpb": "npm run build && npx @anthropic-ai/mcpb pack ."
   },
   "dependencies": {
-    "@anthropic-ai/sdk": "^0.104.2",
     "@modelcontextprotocol/ext-apps": "^1.5.0",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "swagger-ui-dist": "^5.32.0",

--- a/scripts/e2e-1087.mjs
+++ b/scripts/e2e-1087.mjs
@@ -1,0 +1,102 @@
+#!/usr/bin/env node
+import { createServer } from "node:http";
+import { mkdtempSync, writeFileSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { spawn } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+
+const REPO = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const requests = [];
+
+const server = createServer((req, res) => {
+  let body = "";
+  req.on("data", (c) => (body += c));
+  req.on("end", () => {
+    if (req.url === "/api/v1/chat/completions") {
+      requests.push({ headers: req.headers, body: JSON.parse(body) });
+      const mentionsShrunkTier = requests.length === 1;
+      const answer = mentionsShrunkTier
+        ? '```json\n{"status":"changed","summary":"Free tier cut from 10 GB to 5 GB","change_type":"limits_reduced","current_state":"Free plan includes 5 GB storage","impact":"medium"}\n```'
+        : '{"status":"confirmed"}';
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ choices: [{ message: { content: answer } }] }));
+      return;
+    }
+    if (req.url.startsWith("/pricing")) {
+      res.writeHead(200, { "Content-Type": "text/html" });
+      res.end(
+        "<html><body><h1>Pricing</h1><p>The free plan now includes 5 GB of storage, down from the previous allowance. " +
+          "Paid plans start at $5 per month and add 100 GB. This text exists so the extractor has something to read.</p></body></html>"
+      );
+      return;
+    }
+    res.writeHead(404);
+    res.end();
+  });
+});
+
+await new Promise((r) => server.listen(0, r));
+const port = server.address().port;
+const base = `http://localhost:${port}`;
+
+const dir = mkdtempSync(join(tmpdir(), "e2e-1087-"));
+const indexPath = join(dir, "index.json");
+const changesPath = join(dir, "deal_changes.json");
+writeFileSync(
+  indexPath,
+  JSON.stringify({
+    offers: [
+      { vendor: "StubOne", category: "Cloud Storage", url: `${base}/pricing/one`, tier: "Free", description: "10 GB free storage", verifiedDate: "2025-01-01" },
+      { vendor: "StubTwo", category: "Cloud Storage", url: `${base}/pricing/two`, tier: "Free", description: "5 GB free storage", verifiedDate: "2025-01-02" },
+    ],
+  })
+);
+writeFileSync(changesPath, JSON.stringify({ changes: [] }));
+
+function run(env) {
+  return new Promise((done) => {
+    const p = spawn("node", [join(REPO, "scripts", "reverify-rolling.js"), "--ai", "--limit", "2"], {
+      env: { ...process.env, ...env },
+    });
+    let out = "";
+    p.stdout.on("data", (c) => (out += c));
+    p.stderr.on("data", (c) => (out += c));
+    p.on("close", (code) => done({ code, out }));
+  });
+}
+
+const shared = {
+  AGENTDEALS_INDEX_PATH: indexPath,
+  AGENTDEALS_CHANGES_PATH: changesPath,
+  OPENROUTER_BASE_URL: `${base}/api/v1`,
+};
+
+const noKey = await run({ ...shared, OPENROUTER_API_KEY: "" });
+console.log("── without a key ──");
+console.log(`exit ${noKey.code}`);
+console.log(noKey.out.trim().split("\n").slice(-3).join("\n"));
+console.log(`upstream model requests: ${requests.length}`);
+
+const withKey = await run({ ...shared, OPENROUTER_API_KEY: "stub-key" });
+console.log("");
+console.log("── with a key, against a stub endpoint ──");
+console.log(`exit ${withKey.code}`);
+console.log(withKey.out.trim());
+
+console.log("");
+console.log("── what the detector actually sent ──");
+console.log(`requests: ${requests.length}`);
+for (const r of requests) {
+  console.log(`  authorization: ${r.headers.authorization}`);
+  console.log(`  model: ${r.body.model}  temperature: ${r.body.temperature}  max_tokens: ${r.body.max_tokens}`);
+  console.log(`  prompt mentions the vendor: ${/StubOne|StubTwo/.test(r.body.messages[0].content)}`);
+  console.log(`  prompt carries the page text: ${/5 GB of storage/.test(r.body.messages[0].content)}`);
+}
+
+console.log("");
+console.log("── change log after the run ──");
+console.log(readFileSync(changesPath, "utf-8").trim().slice(0, 700));
+
+server.close();

--- a/scripts/mutate-1087.sh
+++ b/scripts/mutate-1087.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+set -uo pipefail
+REPO="$(cd "$(dirname "$0")/.." && pwd)"
+TARGETS=("$REPO/scripts/verify-freshness.js" "$REPO/scripts/reverify-rolling.js" "$REPO/.github/workflows/reverify.yml")
+BACKUPS=()
+for t in "${TARGETS[@]}"; do b=$(mktemp); cp "$t" "$b"; BACKUPS+=("$b"); done
+restore() { for i in "${!TARGETS[@]}"; do cp "${BACKUPS[$i]}" "${TARGETS[$i]}"; done; }
+trap restore EXIT
+
+TESTS=(test/verify-freshness.test.ts test/change-log-writer.test.ts)
+
+mutate() {
+  FILE="$1" FIND="$2" REPLACE="$3" python3 - <<'PY'
+import os, sys
+path, find, replace = os.environ["FILE"], os.environ["FIND"], os.environ["REPLACE"]
+text = open(path, encoding="utf-8").read()
+if find not in text:
+    sys.exit(2)
+open(path, "w", encoding="utf-8").write(text.replace(find, replace, 1))
+PY
+}
+
+run_case() {
+  local name="$1"
+  local dirty=0
+  for i in "${!TARGETS[@]}"; do cmp -s "${TARGETS[$i]}" "${BACKUPS[$i]}" || dirty=1; done
+  if [ "$dirty" -eq 0 ]; then echo "NOT APPLIED: $name"; return; fi
+  if (cd "$REPO" && node --test --test-concurrency 1 "${TESTS[@]}" > /tmp/mut-1087.log 2>&1); then
+    echo "SURVIVED: $name"
+  else
+    echo "killed:   $name"
+  fi
+  restore
+}
+
+case_run() { mutate "$1" "$2" "$3" || true; run_case "$4"; }
+
+case_run "$REPO/scripts/verify-freshness.js" \
+  '  if (!apiKey) {' \
+  '  if (false) {' \
+  "a missing key no longer stops the run"
+
+case_run "$REPO/scripts/verify-freshness.js" \
+  'export const VERIFIER_MODEL = "google/gemma-3-27b-it";' \
+  'export const VERIFIER_MODEL = "some/other-model";' \
+  "the request names a different model than the constant"
+
+case_run "$REPO/scripts/verify-freshness.js" \
+  '`${baseUrl}/chat/completions`' \
+  '`${baseUrl}/completions`' \
+  "the request goes to the wrong path"
+
+case_run "$REPO/scripts/verify-freshness.js" \
+  'Authorization: `Bearer ${apiKey}`,' \
+  '' \
+  "the request carries no authorization header"
+
+case_run "$REPO/scripts/verify-freshness.js" \
+  '.replace(/^```(?:json)?\s*/i, "").replace(/```$/, "")' \
+  '' \
+  "a fenced code block is no longer unwrapped"
+
+case_run "$REPO/scripts/verify-freshness.js" \
+  'parsed && ["confirmed", "changed", "unclear"].includes(parsed.status) ? parsed : null' \
+  'parsed ?? null' \
+  "any status is accepted"
+
+case_run "$REPO/scripts/verify-freshness.js" \
+  'if (!res.ok) {' \
+  'if (false) {' \
+  "an error status is treated as a successful answer"
+
+case_run "$REPO/scripts/reverify-rolling.js" \
+  '    const client = createVerifierClient();
+    verifyFn = (offer, pageText) => verifyOfferAgainstPage(client, offer, pageText);' \
+  '    verifyFn = (offer, pageText) => verifyOfferAgainstPage(createVerifierClient(), offer, pageText);' \
+  "the client is built per record instead of up front"
+
+case_run "$REPO/.github/workflows/reverify.yml" \
+  'reverify-rolling.js --ai --limit' \
+  'reverify-rolling.js --limit' \
+  "the workflow stops passing --ai"
+
+case_run "$REPO/.github/workflows/reverify.yml" \
+  '          OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
+' \
+  '' \
+  "the workflow passes the flag without the credential"

--- a/scripts/reverify-rolling.js
+++ b/scripts/reverify-rolling.js
@@ -11,7 +11,7 @@
  * Usage:
  *   npm run reverify:rolling                    # 100 oldest, URL-only
  *   npm run reverify:rolling -- --limit 50      # 50 oldest
- *   npm run reverify:rolling -- --ai            # Haiku-based verification
+ *   npm run reverify:rolling -- --ai            # read the vendor's terms and detect changes
  *   npm run reverify:rolling -- --dry-run       # report only
  */
 
@@ -19,7 +19,7 @@ import { readFileSync, writeFileSync } from "node:fs";
 import { resolve, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 import { reverifyBatch } from "./reverify.js";
-import { fetchPageText, verifyWithHaiku } from "./verify-freshness.js";
+import { fetchPageText, verifyOfferAgainstPage, createVerifierClient, VERIFIER_MODEL } from "./verify-freshness.js";
 import { buildChangeEntry, appendChangeEntries } from "./change-log.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -82,12 +82,8 @@ export async function runAiMode(picked, data, dryRun, now, options = {}) {
   const rateLimitMs = options.rateLimitMs ?? AI_RATE_LIMIT_MS;
   let verifyFn = options.verifyFn;
   if (!verifyFn) {
-    const Anthropic = (await import("@anthropic-ai/sdk")).default;
-    if (!process.env.ANTHROPIC_API_KEY) {
-      throw new Error("ANTHROPIC_API_KEY required for --ai mode");
-    }
-    const client = new Anthropic();
-    verifyFn = (offer, pageText) => verifyWithHaiku(client, offer, pageText);
+    const client = createVerifierClient();
+    verifyFn = (offer, pageText) => verifyOfferAgainstPage(client, offer, pageText);
   }
 
   let verified = 0;
@@ -200,7 +196,7 @@ async function main() {
 
   console.log(
     `Rolling re-verification — ${picked.length} oldest entries` +
-      (useAi ? " (Haiku)" : " (URL-only)") +
+      (useAi ? ` (${VERIFIER_MODEL})` : " (URL-only)") +
       (dryRun ? " (dry-run)" : "")
   );
   console.log("");

--- a/scripts/verify-freshness.js
+++ b/scripts/verify-freshness.js
@@ -3,9 +3,9 @@
 /**
  * AI-powered data freshness verification.
  *
- * Finds stale entries, fetches vendor pricing pages, and uses Claude Haiku
- * to verify whether stored deal information is still accurate. Updates
- * verifiedDate for confirmed entries; flags discrepancies for PM review.
+ * Finds stale entries, fetches vendor pricing pages, and asks a model over an
+ * OpenAI-compatible endpoint whether stored deal information is still accurate.
+ * Updates verifiedDate for confirmed entries; flags discrepancies for review.
  *
  * Usage:
  *   npm run verify-freshness                       # verify entries older than 25 days
@@ -17,7 +17,6 @@
 import { readFileSync, writeFileSync } from "node:fs";
 import { resolve, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
-import Anthropic from "@anthropic-ai/sdk";
 import { CHANGE_TYPES } from "./change-log.js";
 
 const CHANGE_TYPE_VALUES = CHANGE_TYPES.join(", ");
@@ -26,8 +25,12 @@ const INDEX_PATH = resolve(__dirname, "..", "data", "index.json");
 const DEFAULT_THRESHOLD_DAYS = 25;
 const FETCH_TIMEOUT_MS = 15_000;
 const RATE_LIMIT_MS = 500; // 2 requests per second
-const MAX_PAGE_TEXT_LENGTH = 12_000; // chars sent to Haiku
-const HAIKU_MODEL = "claude-haiku-4-5-20251001";
+const MAX_PAGE_TEXT_LENGTH = 12_000; // chars of page text sent to the model
+const MAX_RESPONSE_TOKENS = 400;
+
+export const VERIFIER_MODEL = "google/gemma-3-27b-it";
+export const VERIFIER_API_KEY_ENV = "OPENROUTER_API_KEY";
+export const VERIFIER_BASE_URL = "https://openrouter.ai/api/v1";
 
 // ── Helpers ──────────────────────────────────────────────────────────────────
 
@@ -102,7 +105,71 @@ export async function fetchPageText(url) {
   }
 }
 
-export async function verifyWithHaiku(client, offer, pageText) {
+export function createVerifierClient(options = {}) {
+  const apiKey = options.apiKey ?? process.env[VERIFIER_API_KEY_ENV];
+  if (!apiKey) {
+    throw new Error(
+      `${VERIFIER_API_KEY_ENV} is required for --ai mode. Without it nothing can read a vendor's terms, ` +
+        `so the run would report zero changes without having looked. No entry was re-verified and no ` +
+        `verifiedDate was advanced by this run.`
+    );
+  }
+  const baseUrl = (options.baseUrl ?? process.env.OPENROUTER_BASE_URL ?? VERIFIER_BASE_URL).replace(/\/$/, "");
+  const model = options.model ?? VERIFIER_MODEL;
+  const fetchImpl = options.fetchImpl ?? fetch;
+  return {
+    model,
+    baseUrl,
+    async complete(prompt) {
+      const res = await fetchImpl(`${baseUrl}/chat/completions`, {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${apiKey}`,
+          "Content-Type": "application/json",
+          "HTTP-Referer": "https://agentdeals.dev",
+          "X-Title": "AgentDeals re-verification",
+        },
+        body: JSON.stringify({
+          model,
+          max_tokens: MAX_RESPONSE_TOKENS,
+          temperature: 0,
+          messages: [{ role: "user", content: prompt }],
+        }),
+      });
+      if (!res.ok) {
+        const detail = await res.text().catch(() => "");
+        throw new Error(`${model} request failed: HTTP ${res.status}${detail ? ` — ${detail.slice(0, 200)}` : ""}`);
+      }
+      const body = await res.json();
+      const content = body?.choices?.[0]?.message?.content;
+      if (typeof content !== "string") {
+        throw new Error(`${model} returned no message content`);
+      }
+      return content;
+    },
+  };
+}
+
+export function parseVerifierResponse(raw) {
+  const text = typeof raw === "string" ? raw.trim().replace(/^```(?:json)?\s*/i, "").replace(/```$/, "").trim() : "";
+  const accept = (parsed) =>
+    parsed && ["confirmed", "changed", "unclear"].includes(parsed.status) ? parsed : null;
+  try {
+    const parsed = accept(JSON.parse(text));
+    if (parsed) return parsed;
+  } catch {
+    const match = text.match(/\{[^}]+\}/);
+    if (match) {
+      try {
+        const parsed = accept(JSON.parse(match[0]));
+        if (parsed) return parsed;
+      } catch { /* fall through */ }
+    }
+  }
+  return { status: "unclear", summary: "Could not parse AI response" };
+}
+
+export async function verifyOfferAgainstPage(client, offer, pageText) {
   const prompt = `You are verifying whether a vendor's deal/free-tier information is still accurate.
 
 STORED DEAL INFO:
@@ -129,31 +196,7 @@ Rules for a "changed" response:
 - Omit effective_date entirely unless the page gives a date.
 - If you cannot pick a change_type from that list, or cannot state current_state from the page, answer "unclear" instead.`;
 
-  const response = await client.messages.create({
-    model: HAIKU_MODEL,
-    max_tokens: 400,
-    messages: [{ role: "user", content: prompt }],
-  });
-
-  const text = response.content[0]?.text?.trim();
-  try {
-    const parsed = JSON.parse(text);
-    if (["confirmed", "changed", "unclear"].includes(parsed.status)) {
-      return parsed;
-    }
-  } catch {
-    // Try to extract JSON from response
-    const match = text?.match(/\{[^}]+\}/);
-    if (match) {
-      try {
-        const parsed = JSON.parse(match[0]);
-        if (["confirmed", "changed", "unclear"].includes(parsed.status)) {
-          return parsed;
-        }
-      } catch { /* fall through */ }
-    }
-  }
-  return { status: "unclear", summary: "Could not parse AI response" };
+  return parseVerifierResponse(await client.complete(prompt));
 }
 
 function sleep(ms) {
@@ -162,7 +205,7 @@ function sleep(ms) {
 
 // ── Main ─────────────────────────────────────────────────────────────────────
 
-export async function verifyFreshness({ thresholdDays, dryRun, limit, indexPath, now = new Date() }) {
+export async function verifyFreshness({ thresholdDays, dryRun, limit, indexPath, now = new Date(), client: injectedClient }) {
   const data = JSON.parse(readFileSync(indexPath || INDEX_PATH, "utf-8"));
   const offers = data.offers || [];
   const { stale, freshCount } = findStaleOffers(offers, thresholdDays, now);
@@ -183,16 +226,7 @@ export async function verifyFreshness({ thresholdDays, dryRun, limit, indexPath,
   const toVerify = limit ? stale.slice(0, limit) : stale;
   const skipped = stale.length - toVerify.length;
 
-  let client;
-  function getClient() {
-    if (!client) {
-      if (!process.env.ANTHROPIC_API_KEY) {
-        throw new Error("ANTHROPIC_API_KEY environment variable is required");
-      }
-      client = new Anthropic();
-    }
-    return client;
-  }
+  const client = injectedClient ?? createVerifierClient();
   const today = now.toISOString().split("T")[0];
 
   let verified = 0;
@@ -213,10 +247,9 @@ export async function verifyFreshness({ thresholdDays, dryRun, limit, indexPath,
       continue;
     }
 
-    // Verify with Haiku
     let result;
     try {
-      result = await verifyWithHaiku(getClient(), offer, page.text);
+      result = await verifyOfferAgainstPage(client, offer, page.text);
     } catch (err) {
       failed++;
       failures.push({ vendor: offer.vendor, category: offer.category, url: offer.url, error: `AI error: ${err.message}` });

--- a/test/change-log-writer.test.ts
+++ b/test/change-log-writer.test.ts
@@ -20,6 +20,7 @@ const {
 const { runUrlMode, runAiMode, summaryLines, repickWindowDays } = await import("../scripts/reverify-rolling.js");
 const { firstSeenDates } = await import("../scripts/backfill-change-recorded-dates.js");
 const { report, DEFAULT_THRESHOLD_DAYS, detectorSchedule, flagTokens, DETECTOR_CLI_OPTIONS, WORKFLOW_PATH } = await import("../scripts/check-change-log-staleness.js");
+const { VERIFIER_API_KEY_ENV, VERIFIER_MODEL } = await import("../scripts/verify-freshness.js");
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const REPO = path.join(__dirname, "..");
@@ -506,7 +507,16 @@ describe("reading the detector's schedule out of the workflow", () => {
     const yaml = readFileSync(WORKFLOW_PATH, "utf-8");
     const schedule = detectorSchedule(yaml);
     assert.strictEqual(schedule.known, true);
-    assert.strictEqual(schedule.scheduled, false, "the shipped workflow does not pass --ai yet");
+    assert.strictEqual(schedule.scheduled, true, "the shipped workflow passes --ai to the daily run");
+  });
+
+  it("hands the detector the credential the same step needs to use it", () => {
+    const yaml = readFileSync(WORKFLOW_PATH, "utf-8");
+    assert.match(
+      yaml,
+      new RegExp(`${VERIFIER_API_KEY_ENV}: \\$\\{\\{ secrets\\.${VERIFIER_API_KEY_ENV} \\}\\}`),
+      `the step that passes --ai must also receive ${VERIFIER_API_KEY_ENV}`
+    );
   });
 
   it("sees a scheduled detector when the invocation passes --ai", () => {
@@ -677,12 +687,34 @@ describe("reading the detector's schedule out of the workflow", () => {
   });
 
   it("changes meaning at the same commit that changes the behaviour", () => {
-    const off = readFileSync(WORKFLOW_PATH, "utf-8");
-    const on = off.replace("reverify-rolling.js --limit", "reverify-rolling.js --ai --limit");
+    const on = readFileSync(WORKFLOW_PATH, "utf-8");
+    const off = on.replace("reverify-rolling.js --ai --limit", "reverify-rolling.js --limit");
     assert.notStrictEqual(on, off, "expected the shipped invocation to be rewritable");
     const stale = freshnessNeverDetected();
     assert.strictEqual(report(stale, DEFAULT_THRESHOLD_DAYS, detectorSchedule(off)).failJob, false);
     assert.strictEqual(report(stale, DEFAULT_THRESHOLD_DAYS, detectorSchedule(on)).failJob, true);
+  });
+
+  it("refuses to start the detector without the credential, before fetching anything", async () => {
+    const saved = process.env[VERIFIER_API_KEY_ENV];
+    delete process.env[VERIFIER_API_KEY_ENV];
+    let fetched = 0;
+    try {
+      await assert.rejects(
+        () =>
+          runAiMode(
+            [{ index: 0, offer: { vendor: "V", category: "Hosting", url: "http://localhost:19999/x", tier: "Free", description: "d" } }],
+            { offers: [{ vendor: "V" }] },
+            true,
+            NOW,
+            { fetchFn: async () => { fetched += 1; return { ok: true, text: "text" }; } }
+          ),
+        new RegExp(VERIFIER_API_KEY_ENV)
+      );
+    } finally {
+      if (saved !== undefined) process.env[VERIFIER_API_KEY_ENV] = saved;
+    }
+    assert.strictEqual(fetched, 0, "a run that cannot read a vendor's terms should not fetch any");
   });
 
   function freshnessNeverDetected() {

--- a/test/verify-freshness.test.ts
+++ b/test/verify-freshness.test.ts
@@ -4,8 +4,21 @@ import { readFileSync, writeFileSync, mkdtempSync, rmSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 
-const { findStaleOffers, fetchPageText, verifyWithHaiku, verifyFreshness } =
-  await import("../scripts/verify-freshness.js");
+const {
+  findStaleOffers,
+  fetchPageText,
+  verifyOfferAgainstPage,
+  parseVerifierResponse,
+  createVerifierClient,
+  verifyFreshness,
+  VERIFIER_MODEL,
+  VERIFIER_API_KEY_ENV,
+  VERIFIER_BASE_URL,
+} = await import("../scripts/verify-freshness.js");
+
+function stubClient(text: string) {
+  return { model: VERIFIER_MODEL, baseUrl: VERIFIER_BASE_URL, complete: async () => text };
+}
 
 describe("verify-freshness", () => {
   const now = new Date("2026-03-16T00:00:00Z");
@@ -95,71 +108,138 @@ describe("verify-freshness", () => {
     });
   });
 
-  describe("verifyWithHaiku", () => {
+  describe("verifyOfferAgainstPage", () => {
+    const offer = { vendor: "Test", category: "Hosting", tier: "Free", description: "Free hosting" };
+
     it("parses confirmed response", async () => {
-      const mockClient = {
-        messages: {
-          create: async () => ({
-            content: [{ text: '{"status":"confirmed"}' }],
-          }),
-        },
-      };
-      const offer = { vendor: "Test", category: "Hosting", tier: "Free", description: "Free hosting" };
-      const result = await verifyWithHaiku(mockClient, offer, "Free hosting plan available");
+      const result = await verifyOfferAgainstPage(stubClient('{"status":"confirmed"}'), offer, "Free hosting plan available");
       assert.strictEqual(result.status, "confirmed");
     });
 
     it("parses changed response", async () => {
-      const mockClient = {
-        messages: {
-          create: async () => ({
-            content: [{ text: '{"status":"changed","summary":"Free tier removed"}' }],
-          }),
-        },
-      };
-      const offer = { vendor: "Test", category: "Hosting", tier: "Free", description: "Free hosting" };
-      const result = await verifyWithHaiku(mockClient, offer, "Paid plans start at $5/mo");
+      const result = await verifyOfferAgainstPage(
+        stubClient('{"status":"changed","summary":"Free tier removed"}'),
+        offer,
+        "Paid plans start at $5/mo"
+      );
       assert.strictEqual(result.status, "changed");
       assert.strictEqual(result.summary, "Free tier removed");
     });
 
     it("handles unclear response", async () => {
-      const mockClient = {
-        messages: {
-          create: async () => ({
-            content: [{ text: '{"status":"unclear","summary":"Page requires login"}' }],
-          }),
-        },
-      };
-      const offer = { vendor: "Test", category: "Hosting", tier: "Free", description: "Free hosting" };
-      const result = await verifyWithHaiku(mockClient, offer, "Please sign in");
+      const result = await verifyOfferAgainstPage(
+        stubClient('{"status":"unclear","summary":"Page requires login"}'),
+        offer,
+        "Please sign in"
+      );
       assert.strictEqual(result.status, "unclear");
     });
 
-    it("handles malformed AI response gracefully", async () => {
-      const mockClient = {
-        messages: {
-          create: async () => ({
-            content: [{ text: "I think the deal looks correct" }],
-          }),
-        },
-      };
-      const offer = { vendor: "Test", category: "Hosting", tier: "Free", description: "Free hosting" };
-      const result = await verifyWithHaiku(mockClient, offer, "Free hosting");
-      assert.strictEqual(result.status, "unclear");
+    it("sends the stored terms and the page text in the prompt", async () => {
+      let seen = "";
+      const client = { complete: async (prompt: string) => { seen = prompt; return '{"status":"confirmed"}'; } };
+      await verifyOfferAgainstPage(client, offer, "Free hosting plan available");
+      for (const fragment of [offer.vendor, offer.tier, offer.description, "Free hosting plan available"]) {
+        assert.ok(seen.includes(fragment), `prompt should carry ${fragment}`);
+      }
+    });
+  });
+
+  describe("parseVerifierResponse", () => {
+    it("handles malformed AI response gracefully", () => {
+      assert.strictEqual(parseVerifierResponse("I think the deal looks correct").status, "unclear");
     });
 
-    it("extracts JSON from verbose AI response", async () => {
-      const mockClient = {
-        messages: {
-          create: async () => ({
-            content: [{ text: 'The deal is still valid. {"status":"confirmed"}' }],
-          }),
+    it("extracts JSON from verbose AI response", () => {
+      assert.strictEqual(parseVerifierResponse('The deal is still valid. {"status":"confirmed"}').status, "confirmed");
+    });
+
+    it("reads a fenced code block", () => {
+      const result = parseVerifierResponse('```json\n{"status":"changed","summary":"Limit cut"}\n```');
+      assert.strictEqual(result.status, "changed");
+      assert.strictEqual(result.summary, "Limit cut");
+    });
+
+    it("reads a fenced answer whose text contains a closing brace", () => {
+      const result = parseVerifierResponse(
+        '```json\n{"status":"changed","summary":"Template ${quota} removed","change_type":"limits_reduced"}\n```'
+      );
+      assert.strictEqual(result.status, "changed");
+      assert.strictEqual(result.change_type, "limits_reduced");
+    });
+
+    it("refuses a status it does not recognise", () => {
+      assert.strictEqual(parseVerifierResponse('{"status":"probably fine"}').status, "unclear");
+    });
+
+    it("refuses a non-string response", () => {
+      assert.strictEqual(parseVerifierResponse(undefined).status, "unclear");
+    });
+  });
+
+  describe("createVerifierClient", () => {
+    it("refuses to run without a key, naming the variable", () => {
+      const saved = process.env[VERIFIER_API_KEY_ENV];
+      delete process.env[VERIFIER_API_KEY_ENV];
+      try {
+        assert.throws(() => createVerifierClient(), new RegExp(VERIFIER_API_KEY_ENV));
+      } finally {
+        if (saved !== undefined) process.env[VERIFIER_API_KEY_ENV] = saved;
+      }
+    });
+
+    it("posts an OpenAI-shaped chat completion to the configured endpoint", async () => {
+      const calls: any[] = [];
+      const client = createVerifierClient({
+        apiKey: "test-key",
+        baseUrl: "https://openrouter.test/api/v1",
+        fetchImpl: async (url: string, init: any) => {
+          calls.push({ url, init });
+          return {
+            ok: true,
+            json: async () => ({ choices: [{ message: { content: '{"status":"confirmed"}' } }] }),
+          };
         },
-      };
-      const offer = { vendor: "Test", category: "Hosting", tier: "Free", description: "Free hosting" };
-      const result = await verifyWithHaiku(mockClient, offer, "Free hosting plan available");
-      assert.strictEqual(result.status, "confirmed");
+      });
+      const text = await client.complete("does this still hold?");
+      assert.strictEqual(text, '{"status":"confirmed"}');
+      assert.strictEqual(calls.length, 1);
+      assert.strictEqual(calls[0].url, "https://openrouter.test/api/v1/chat/completions");
+      assert.strictEqual(calls[0].init.method, "POST");
+      assert.strictEqual(calls[0].init.headers.Authorization, "Bearer test-key");
+      const body = JSON.parse(calls[0].init.body);
+      assert.strictEqual(body.model, VERIFIER_MODEL);
+      assert.deepStrictEqual(body.messages, [{ role: "user", content: "does this still hold?" }]);
+      assert.strictEqual(body.temperature, 0);
+    });
+
+    it("defaults to the OpenRouter endpoint", () => {
+      assert.strictEqual(createVerifierClient({ apiKey: "test-key" }).baseUrl, VERIFIER_BASE_URL);
+      assert.match(VERIFIER_BASE_URL, /^https:\/\/openrouter\.ai\//);
+    });
+
+    it("asks the model the cost and accuracy were measured on", () => {
+      assert.strictEqual(
+        VERIFIER_MODEL,
+        "google/gemma-3-27b-it",
+        "changing the model changes both the price per record and the answer quality — measure again before moving it"
+      );
+    });
+
+    it("reports the status when the endpoint rejects the request", async () => {
+      const client = createVerifierClient({
+        apiKey: "test-key",
+        fetchImpl: async () => ({ ok: false, status: 401, text: async () => "No auth credentials found" }),
+      });
+      await assert.rejects(() => client.complete("hello"), /401/);
+    });
+
+    it("reports a response carrying no message content", async () => {
+      const client = createVerifierClient({
+        apiKey: "test-key",
+        fetchImpl: async () => ({ ok: true, json: async () => ({ choices: [] }) }),
+      });
+      await assert.rejects(() => client.complete("hello"), /no message content/);
     });
   });
 
@@ -198,7 +278,7 @@ describe("verify-freshness", () => {
       writeFileSync(indexPath, JSON.stringify(data));
       const before = readFileSync(indexPath, "utf-8");
 
-      await verifyFreshness({ thresholdDays: 25, dryRun: true, indexPath, now });
+      await verifyFreshness({ thresholdDays: 25, dryRun: true, indexPath, now, client: stubClient('{"status":"confirmed"}') });
       const after = readFileSync(indexPath, "utf-8");
       assert.strictEqual(before, after);
     });
@@ -214,7 +294,7 @@ describe("verify-freshness", () => {
       }));
       writeFileSync(indexPath, JSON.stringify({ offers }));
 
-      const result = await verifyFreshness({ thresholdDays: 25, dryRun: true, limit: 3, indexPath, now });
+      const result = await verifyFreshness({ thresholdDays: 25, dryRun: true, limit: 3, indexPath, now, client: stubClient('{"status":"confirmed"}') });
       // Should attempt at most 3, skip the rest
       assert.strictEqual(result.skipped, 7);
       assert.ok(result.failed <= 3);


### PR DESCRIPTION
Refs #1087

Parts 1 and 2 of the three you scoped. Part 3 needs no code — the staleness gate reads `days_since_last_detected` and starts failing the moment the workflow passes `--ai`, which is this commit.

## Part 1 — `--ai` no longer goes through the Anthropic SDK

`scripts/verify-freshness.js` now builds an OpenAI-compatible chat completion against `https://openrouter.ai/api/v1/chat/completions` with `OPENROUTER_API_KEY` and model `google/gemma-3-27b-it`. `reverify-rolling.js` uses the same client, so there is one definition rather than two couplings to fix. `@anthropic-ai/sdk` is gone from `dependencies` — nothing else imported it.

Three things fall out of the rewrite that are worth naming:

- **The transport and the parsing are now separate.** `createVerifierClient()` owns the HTTP call; `parseVerifierResponse()` is a pure function. The parser gained a case it needed: this model tends to fence its JSON, and ```` ```json {...} ``` ```` was previously unparseable and would have been recorded as `unclear` on every response.
- **A missing key now fails the run rather than each record.** `verifyFreshness` built its client lazily *inside* the loop, after the page fetch, so an absent key surfaced as a per-record "AI error" in the failures array — 75 quiet failures rather than one loud one. The client is built up front in both entry points now, and a test asserts nothing is fetched when the key is absent.
- **Two existing tests were passing for the wrong reason.** `dry-run does not modify index file` and `respects limit parameter` point their offers at `http://localhost:19999/fake`, so every page fetch failed and the verification path was never reached — which is why they survived a lazily-constructed client. They now take an injected client and exercise the path they are named for.

## Part 2 — the workflow passes the flag and the credential

`.github/workflows/reverify.yml` runs `node scripts/reverify-rolling.js --ai --limit "$LIMIT"` with `OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}` on that step. `detectorSchedule()` reads the shipped file and now reports `{known: true, scheduled: true}`.

## What this does to the nightly run until the secret exists

It fails, on purpose, and it is worth being precise about the cost. The reverify step throws before fetching anything, so **no entry is re-verified and no `verifiedDate` advances** — the ~75 records a night that currently get their date bumped on a URL check will stop. The staleness gate then also fails, because a scheduled detector that has never recorded anything is stale from its first run. The absence-signalling step does not fire, so no duplicate of #1087 is opened.

The error names the variable and the consequence:

```
Fatal error: OPENROUTER_API_KEY is required for --ai mode. Without it nothing can read a
vendor's terms, so the run would report zero changes without having looked. No entry was
re-verified and no verifiedDate was advanced by this run.
```

## Verification

- Full suite green. `tsc` clean, 0 new code comments.
- `scripts/e2e-1087.mjs` runs the real script end to end against a stub OpenRouter endpoint and a stub vendor pricing page, in a temp index and change log. It shows both halves: without a key, exit 1 and **zero** upstream requests; with a key, two requests carrying `Authorization: Bearer …`, `model: google/gemma-3-27b-it`, `temperature: 0`, the vendor's stored terms and the fetched page text in the prompt — and a fenced-JSON `changed` response parsed, classified and written to the change log with `date_source: discovered`.
- `POST https://openrouter.ai/api/v1/chat/completions` from this container returns 401 rather than 404, so the endpoint path is right and egress works. The one thing I cannot verify without the secret is the real model's answer quality, which you measured at 5/5 on the same five hand-verified records.
