### PR TITLE
Keep the MCP notification stream alive across the edge idle timeout (#1098)

### DIFF
--- a/AGENT_README.md
+++ b/AGENT_README.md
@@ -62,7 +62,7 @@ PORT=8080 npm run serve
 
 Endpoints:
 - `POST /mcp` — MCP JSON-RPC requests (requires `Accept: application/json, text/event-stream` header)
-- `GET /mcp` — SSE stream for server-initiated notifications
+- `GET /mcp` — SSE stream for server-initiated notifications. The server writes an SSE comment frame as soon as the stream opens and every 25s after (`MCP_SSE_KEEPALIVE_MS` overrides the interval), so a proxy that closes an idle response does not cut it. A second `GET` on a session that already holds a stream replaces it rather than being refused — a session has one client, so a repeat `GET` is that client reconnecting. A `GET` or `POST` naming a session the server is not holding answers `400` with a JSON-RPC body giving the condition (`unknown_session` or `no_session`) and the recovery (`reinitialize`)
 - `DELETE /mcp` — Session termination
 - `GET /health` — Health check
 - `GET /.well-known/glama.json` — Glama registry ownership verification

--- a/scripts/e2e-1098.mjs
+++ b/scripts/e2e-1098.mjs
@@ -1,0 +1,187 @@
+import { spawn } from "node:child_process";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO = path.join(__dirname, "..");
+
+const UA = "agentdeals-internal/1.0 (issue-1098 stream-lifetime check)";
+const MEASURED_EDGE_STREAM_CUTOFF_MS = 125_000;
+
+function arg(name, fallback) {
+  const index = process.argv.indexOf(`--${name}`);
+  return index === -1 ? fallback : process.argv[index + 1];
+}
+
+const holdSeconds = Number(arg("hold", "330"));
+const remoteUrl = arg("url", null);
+
+const failures = [];
+function check(ok, message) {
+  console.log(`${ok ? "PASS" : "FAIL"}  ${message}`);
+  if (!ok) failures.push(message);
+}
+
+function startLocalServer() {
+  return new Promise((resolve, reject) => {
+    const proc = spawn("node", [path.join(REPO, "dist", "serve.js")], {
+      stdio: ["pipe", "pipe", "pipe"],
+      env: { ...process.env, PORT: "0", BASE_URL: "http://localhost" },
+    });
+    const timeout = setTimeout(() => {
+      proc.kill();
+      reject(new Error("server startup timeout"));
+    }, 30000);
+    proc.stderr.on("data", (data) => {
+      const match = data.toString().match(/running on http:\/\/localhost:(\d+)/);
+      if (match) {
+        clearTimeout(timeout);
+        resolve({ proc, base: `http://localhost:${match[1]}` });
+      }
+    });
+    proc.on("error", (err) => {
+      clearTimeout(timeout);
+      reject(err);
+    });
+  });
+}
+
+async function initSession(base) {
+  const response = await fetch(`${base}/mcp`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json", Accept: "application/json, text/event-stream", "User-Agent": UA },
+    body: JSON.stringify({
+      jsonrpc: "2.0",
+      id: 1,
+      method: "initialize",
+      params: {
+        protocolVersion: "2024-11-05",
+        capabilities: {},
+        clientInfo: { name: "agentdeals-internal", version: "1.0.0" },
+      },
+    }),
+  });
+  await response.text();
+  return { sessionId: response.headers.get("mcp-session-id"), via: response.headers.get("server") ?? "-" };
+}
+
+function openStream(base, sessionId) {
+  return fetch(`${base}/mcp`, {
+    headers: { "Mcp-Session-Id": sessionId, Accept: "text/event-stream", "User-Agent": UA },
+  });
+}
+
+async function main() {
+  let proc = null;
+  let base = remoteUrl;
+  if (!base) {
+    const started = await startLocalServer();
+    proc = started.proc;
+    base = started.base;
+  }
+  console.log(`target ${base}`);
+  console.log(`hold ${holdSeconds}s`);
+
+  const { sessionId, via } = await initSession(base);
+  check(Boolean(sessionId), `initialize returned a session ID (served by ${via})`);
+  if (!sessionId) {
+    proc?.kill();
+    process.exit(1);
+  }
+
+  const stream = await openStream(base, sessionId);
+  check(stream.status === 200, `GET /mcp opened the stream (status ${stream.status})`);
+  if (stream.status !== 200) {
+    console.log(`  body: ${(await stream.text()).slice(0, 400)}`);
+    proc?.kill();
+    process.exit(1);
+  }
+
+  const openedAt = Date.now();
+  const arrivals = [];
+  let ended = false;
+  let endedAt = null;
+  const reader = stream.body.getReader();
+  const pump = (async () => {
+    try {
+      for (;;) {
+        const { done } = await reader.read();
+        if (done) {
+          ended = true;
+          endedAt = Date.now() - openedAt;
+          return;
+        }
+        arrivals.push(Date.now() - openedAt);
+      }
+    } catch (err) {
+      ended = true;
+      endedAt = Date.now() - openedAt;
+      console.log(`  stream read error at ${endedAt}ms: ${err.name}`);
+    }
+  })();
+
+  const deadline = openedAt + holdSeconds * 1000;
+  while (Date.now() < deadline && !ended) {
+    await new Promise((resolve) => setTimeout(resolve, 5000));
+    const elapsed = Math.round((Date.now() - openedAt) / 1000);
+    if (elapsed % 30 === 0 || elapsed % 30 === 1) {
+      console.log(`  ${elapsed}s elapsed, ${arrivals.length} frames, open=${!ended}`);
+    }
+  }
+
+  const heldMs = Date.now() - openedAt;
+  check(!ended, ended ? `stream stayed open (it closed at ${endedAt}ms)` : `stream stayed open for ${heldMs}ms`);
+  check(
+    heldMs > 300_000 || holdSeconds <= 300,
+    `hold exceeded the 300s bar (held ${Math.round(heldMs / 1000)}s)`,
+  );
+
+  const gaps = [];
+  let previous = 0;
+  for (const arrival of arrivals) {
+    gaps.push(arrival - previous);
+    previous = arrival;
+  }
+  const maxGap = gaps.length ? Math.max(...gaps) : heldMs;
+  console.log(`  frames ${arrivals.length}, max gap ${maxGap}ms`);
+  check(
+    maxGap < MEASURED_EDGE_STREAM_CUTOFF_MS,
+    `longest silence on the stream stayed under the measured ${MEASURED_EDGE_STREAM_CUTOFF_MS}ms cutoff (${maxGap}ms)`,
+  );
+
+  const stillUsable = await fetch(`${base}/mcp`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Accept: "application/json, text/event-stream",
+      "Mcp-Session-Id": sessionId,
+      "User-Agent": UA,
+    },
+    body: JSON.stringify([
+      { jsonrpc: "2.0", method: "notifications/initialized" },
+      { jsonrpc: "2.0", id: 2, method: "tools/list" },
+    ]),
+  });
+  const usableBody = await stillUsable.text();
+  check(
+    stillUsable.status === 200 && usableBody.includes("\"tools\""),
+    `session still served tools/list after the hold (status ${stillUsable.status})`,
+  );
+
+  const reconnect = await openStream(base, sessionId);
+  check(reconnect.status === 200, `reconnect while the first stream is open returned ${reconnect.status}`);
+  if (reconnect.status === 200) {
+    await reconnect.body.cancel();
+  } else {
+    console.log(`  body: ${(await reconnect.text()).slice(0, 400)}`);
+  }
+
+  await reader.cancel().catch(() => {});
+  await pump;
+  proc?.kill();
+
+  console.log(failures.length === 0 ? "e2e-1098: all checks passed" : `e2e-1098: ${failures.length} check(s) failed`);
+  process.exit(failures.length === 0 ? 0 : 1);
+}
+
+await main();

--- a/scripts/mutate-1098.sh
+++ b/scripts/mutate-1098.sh
@@ -1,0 +1,162 @@
+#!/usr/bin/env bash
+set -u
+
+REPO="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$REPO" || exit 1
+
+SERVE="src/serve.ts"
+STREAM="src/mcp-stream.ts"
+BACKUP_DIR="$(mktemp -d)"
+cp "$SERVE" "$BACKUP_DIR/serve.ts"
+cp "$STREAM" "$BACKUP_DIR/mcp-stream.ts"
+
+restore() {
+  cp "$BACKUP_DIR/serve.ts" "$SERVE"
+  cp "$BACKUP_DIR/mcp-stream.ts" "$STREAM"
+}
+trap restore EXIT
+
+killed=0
+survived=0
+
+run_mutation() {
+  local name="$1"
+  shift
+  echo "=== $name"
+  restore
+  "$@"
+  if ! npm run build > /tmp/mutate-1098-build.log 2>&1; then
+    echo "    KILLED (does not compile)"
+    killed=$((killed + 1))
+    return
+  fi
+  if timeout 300 node --test --test-concurrency 1 test/mcp-stream.test.ts > /tmp/mutate-1098-test.log 2>&1; then
+    echo "    SURVIVED"
+    survived=$((survived + 1))
+  else
+    echo "    KILLED: $(grep -c '✖' /tmp/mutate-1098-test.log) failing test(s)"
+    grep '✖' /tmp/mutate-1098-test.log | head -4
+    killed=$((killed + 1))
+  fi
+}
+
+m_no_keepalive_write() {
+  python3 - <<'PY'
+p = "src/serve.ts"
+s = open(p).read()
+s = s.replace("""    try {
+      res.write(SSE_KEEPALIVE_FRAME);
+    } catch {
+      releaseStandaloneStream(sessionId, entry, "keepalive_write_failed", res);
+    }
+  }, SSE_KEEPALIVE_INTERVAL_MS);""", """  }, SSE_KEEPALIVE_INTERVAL_MS);""")
+open(p, "w").write(s)
+PY
+}
+
+m_no_prime() {
+  python3 - <<'PY'
+p = "src/serve.ts"
+s = open(p).read()
+s = s.replace("  primeStandaloneStream(res);\n", "")
+open(p, "w").write(s)
+PY
+}
+
+m_no_replace() {
+  python3 - <<'PY'
+p = "src/serve.ts"
+s = open(p).read()
+s = s.replace("""        if (entry.sse) {
+          releaseStandaloneStream(sessionId, entry, "replaced_by_reconnect");
+          await new Promise<void>(resolve => setImmediate(resolve));
+        }
+""", "")
+open(p, "w").write(s)
+PY
+}
+
+m_no_close_release() {
+  python3 - <<'PY'
+p = "src/serve.ts"
+s = open(p).read()
+s = s.replace("""  res.on("close", () => releaseStandaloneStream(sessionId, entry, "client_disconnect", res));\n""", "")
+open(p, "w").write(s)
+PY
+}
+
+m_bare_400_body() {
+  python3 - <<'PY'
+p = "src/serve.ts"
+s = open(p).read()
+s = s.replace("""        res.end(JSON.stringify(sessionRecoveryBody(sessionId ? "unknown_session" : "no_session")));
+      }
+    } else if (req.method === "DELETE") {""", """        res.end(JSON.stringify({ error: "Invalid or missing session ID" }));
+      }
+    } else if (req.method === "DELETE") {""")
+open(p, "w").write(s)
+PY
+}
+
+m_shared_recovery_message() {
+  python3 - <<'PY'
+p = "src/mcp-stream.ts"
+s = open(p).read()
+s = s.replace("""      "No session: this request carried no Mcp-Session-Id header. Send an initialize request to obtain a session ID, then retry with that ID.",""", """      "Unknown session: this server is not holding the session ID you sent, so it cannot serve this request. Send an initialize request to obtain a new session ID, then retry with that ID.",""")
+open(p, "w").write(s)
+PY
+}
+
+m_interval_above_cutoff() {
+  python3 - <<'PY'
+p = "src/mcp-stream.ts"
+s = open(p).read()
+s = s.replace("export const DEFAULT_SSE_KEEPALIVE_MS = 25_000;", "export const DEFAULT_SSE_KEEPALIVE_MS = 130_000;")
+open(p, "w").write(s)
+PY
+}
+
+m_data_frame_not_comment() {
+  python3 - <<'PY'
+p = "src/mcp-stream.ts"
+s = open(p).read()
+s = s.replace('export const SSE_KEEPALIVE_FRAME = ": keepalive\\n\\n";', 'export const SSE_KEEPALIVE_FRAME = "data: keepalive\\n\\n";')
+open(p, "w").write(s)
+PY
+}
+
+m_drop_recovery_field() {
+  python3 - <<'PY'
+p = "src/mcp-stream.ts"
+s = open(p).read()
+s = s.replace('      data: { condition, recovery: "reinitialize" },', '      data: { condition, recovery: "retry" },')
+open(p, "w").write(s)
+PY
+}
+
+m_env_override_ignored() {
+  python3 - <<'PY'
+p = "src/mcp-stream.ts"
+s = open(p).read()
+s = s.replace("""  const raw = env.MCP_SSE_KEEPALIVE_MS;""", """  const raw = undefined as string | undefined;""")
+open(p, "w").write(s)
+PY
+}
+
+run_mutation "keepalive frame is never written" m_no_keepalive_write
+run_mutation "no priming byte when the stream opens" m_no_prime
+run_mutation "reconnect does not replace the held stream" m_no_replace
+run_mutation "slot is not released when the client disconnects" m_no_close_release
+run_mutation "session 400 loses its recovery body" m_bare_400_body
+run_mutation "both session conditions share one message" m_shared_recovery_message
+run_mutation "keepalive interval moves above the measured cutoff" m_interval_above_cutoff
+run_mutation "keepalive becomes a data frame instead of a comment" m_data_frame_not_comment
+run_mutation "recovery field stops saying re-initialize" m_drop_recovery_field
+run_mutation "environment override is ignored" m_env_override_ignored
+
+restore
+npm run build > /dev/null 2>&1
+
+echo
+echo "killed $killed, survived $survived"
+[ "$survived" -eq 0 ]

--- a/src/mcp-stream.ts
+++ b/src/mcp-stream.ts
@@ -1,0 +1,58 @@
+export const SSE_KEEPALIVE_FRAME = ": keepalive\n\n";
+
+export const DEFAULT_SSE_KEEPALIVE_MS = 25_000;
+
+export const MEASURED_EDGE_STREAM_CUTOFF_MS = 125_000;
+
+export function keepaliveIntervalMs(env: Record<string, string | undefined> = process.env): number {
+  const raw = env.MCP_SSE_KEEPALIVE_MS;
+  if (raw === undefined || raw === "") {
+    return DEFAULT_SSE_KEEPALIVE_MS;
+  }
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    return DEFAULT_SSE_KEEPALIVE_MS;
+  }
+  return parsed;
+}
+
+export type SessionRecoveryCondition = "unknown_session" | "no_session";
+
+export interface SessionRecoveryBody {
+  jsonrpc: "2.0";
+  id: null;
+  error: {
+    code: number;
+    message: string;
+    data: {
+      condition: SessionRecoveryCondition;
+      recovery: string;
+    };
+  };
+}
+
+const RECOVERY: Record<SessionRecoveryCondition, { code: number; message: string }> = {
+  unknown_session: {
+    code: -32001,
+    message:
+      "Unknown session: this server is not holding the session ID you sent, so it cannot serve this request. Send an initialize request to obtain a new session ID, then retry with that ID.",
+  },
+  no_session: {
+    code: -32001,
+    message:
+      "No session: this request carried no Mcp-Session-Id header. Send an initialize request to obtain a session ID, then retry with that ID.",
+  },
+};
+
+export function sessionRecoveryBody(condition: SessionRecoveryCondition): SessionRecoveryBody {
+  const spec = RECOVERY[condition];
+  return {
+    jsonrpc: "2.0",
+    id: null,
+    error: {
+      code: spec.code,
+      message: spec.message,
+      data: { condition, recovery: "reinitialize" },
+    },
+  };
+}

--- a/src/serve.ts
+++ b/src/serve.ts
@@ -28,6 +28,7 @@ import { subscribe as watchlistSubscribe, getSubscription as getWatchlistSubscri
 import { toSlug, vendorSlugMap, resolveVendorSlug, namedVendorSlug } from "./vendor-slug.js";
 import { linkifyVerdictBlocks, overdueReport, pageCompiledClause, pageDataProvenance, pageDateModified, pageFreshness, pageFreshnessSentence, utcToday, verdictsOutdatedBy } from "./page-reviews.js";
 import { faqPageJsonLd, type FaqItem } from "./faq-provenance.js";
+import { SSE_KEEPALIVE_FRAME, keepaliveIntervalMs, sessionRecoveryBody } from "./mcp-stream.js";
 import { ASSISTANTS_API_SHUTDOWN } from "./assistants-shutdown.js";
 import { rankOffers, rankForListing, rotateListing, utcDate, CRITERIA_PATH, DEMOTE_ONLY_POLICY, DISCLOSURE_RATIONALE, TIE_BREAK_ALGORITHM, GATE_TABLE, DEMERIT_TABLE, NOT_FREE_TIER_RULES, TIME_LIMITED_TIER_RULES } from "./ranking.js";
 import type { RankedEntry, RankingResult } from "./ranking.js";
@@ -254,15 +255,88 @@ interface ClientInfo {
   version: string;
 }
 
+interface StandaloneStream {
+  res: import("node:http").ServerResponse;
+  timer: NodeJS.Timeout;
+  openedAt: number;
+}
+
 interface SessionEntry {
   transport: StreamableHTTPServerTransport;
   lastActivity: number;
   createdAt: number;
   clientInfo?: ClientInfo;
+  sse?: StandaloneStream;
 }
 
 // Map of session ID → transport + last activity for multi-session support
 const sessions = new Map<string, SessionEntry>();
+
+const SSE_KEEPALIVE_INTERVAL_MS = keepaliveIntervalMs();
+const STREAM_PRIME_POLL_MS = 25;
+const STREAM_PRIME_ATTEMPTS = 40;
+
+function releaseStandaloneStream(
+  sessionId: string,
+  entry: SessionEntry,
+  reason: string,
+  only?: import("node:http").ServerResponse,
+): void {
+  const stream = entry.sse;
+  if (!stream) return;
+  if (only && stream.res !== only) return;
+  clearInterval(stream.timer);
+  entry.sse = undefined;
+  entry.transport.closeStandaloneSSEStream?.();
+  if (!stream.res.writableEnded) {
+    stream.res.end();
+  }
+  console.log(JSON.stringify({
+    event: "stream_close",
+    ts: new Date().toISOString(),
+    sessionId,
+    durationMs: Date.now() - stream.openedAt,
+    reason,
+  }));
+}
+
+function writableEventStream(res: import("node:http").ServerResponse): boolean {
+  if (!res.headersSent || res.writableEnded || res.destroyed) return false;
+  return res.statusCode === 200;
+}
+
+function primeStandaloneStream(res: import("node:http").ServerResponse, attempt = 0): void {
+  if (res.writableEnded || res.destroyed) return;
+  if (writableEventStream(res)) {
+    try {
+      res.write(SSE_KEEPALIVE_FRAME);
+    } catch {
+      return;
+    }
+    return;
+  }
+  if (attempt >= STREAM_PRIME_ATTEMPTS) return;
+  setTimeout(() => primeStandaloneStream(res, attempt + 1), STREAM_PRIME_POLL_MS).unref();
+}
+
+function attachStandaloneStream(
+  sessionId: string,
+  entry: SessionEntry,
+  res: import("node:http").ServerResponse,
+): void {
+  const timer = setInterval(() => {
+    if (!writableEventStream(res)) return;
+    try {
+      res.write(SSE_KEEPALIVE_FRAME);
+    } catch {
+      releaseStandaloneStream(sessionId, entry, "keepalive_write_failed", res);
+    }
+  }, SSE_KEEPALIVE_INTERVAL_MS);
+  timer.unref();
+  entry.sse = { res, timer, openedAt: Date.now() };
+  res.on("close", () => releaseStandaloneStream(sessionId, entry, "client_disconnect", res));
+  primeStandaloneStream(res);
+}
 
 function getClientIp(req: import("node:http").IncomingMessage): string {
   const forwarded = req.headers["x-forwarded-for"];
@@ -292,6 +366,7 @@ setInterval(() => {
         durationMs: now - entry.createdAt,
         reason: "idle_timeout",
       }));
+      releaseStandaloneStream(sid, entry, "session_idle_timeout");
       entry.transport.close?.();
       sessions.delete(sid);
       recordSessionDisconnect();
@@ -53815,6 +53890,7 @@ const httpServer = createHttpServer(async (req, res) => {
           const sid = transport.sessionId;
           if (sid && sessions.has(sid)) {
             const entry = sessions.get(sid)!;
+            releaseStandaloneStream(sid, entry, "session_closed");
             const now = Date.now();
             console.log(JSON.stringify({
               event: "session_close",
@@ -53840,27 +53916,30 @@ const httpServer = createHttpServer(async (req, res) => {
       } else {
         // Invalid: has session ID but unknown, or missing session ID on non-init request
         res.writeHead(400, { "Content-Type": "application/json" });
-        res.end(JSON.stringify({
-          jsonrpc: "2.0",
-          error: { code: -32600, message: "Bad Request: No valid session. Send an initialize request first." },
-          id: null,
-        }));
+        res.end(JSON.stringify(sessionRecoveryBody(sessionId ? "unknown_session" : "no_session")));
       }
     } else if (req.method === "GET") {
       // SSE stream — route to existing session
       const sessionId = req.headers["mcp-session-id"] as string | undefined;
-      if (sessionId && sessions.has(sessionId)) {
+      const entry = sessionId ? sessions.get(sessionId) : undefined;
+      if (sessionId && entry) {
         touchSession(sessionId);
-        await sessions.get(sessionId)!.transport.handleRequest(req, res);
+        if (entry.sse) {
+          releaseStandaloneStream(sessionId, entry, "replaced_by_reconnect");
+          await new Promise<void>(resolve => setImmediate(resolve));
+        }
+        attachStandaloneStream(sessionId, entry, res);
+        await entry.transport.handleRequest(req, res);
       } else {
         res.writeHead(400, { "Content-Type": "application/json" });
-        res.end(JSON.stringify({ error: "Invalid or missing session ID" }));
+        res.end(JSON.stringify(sessionRecoveryBody(sessionId ? "unknown_session" : "no_session")));
       }
     } else if (req.method === "DELETE") {
       // Session termination
       const sessionId = req.headers["mcp-session-id"] as string | undefined;
       if (sessionId && sessions.has(sessionId)) {
         const entry = sessions.get(sessionId)!;
+        releaseStandaloneStream(sessionId, entry, "session_deleted");
         await entry.transport.handleRequest(req, res);
         const now = Date.now();
         console.log(JSON.stringify({

--- a/test/mcp-stream.test.ts
+++ b/test/mcp-stream.test.ts
@@ -1,0 +1,358 @@
+import { describe, it, afterEach } from "node:test";
+import assert from "node:assert";
+import { spawn, type ChildProcess } from "node:child_process";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  DEFAULT_SSE_KEEPALIVE_MS,
+  MEASURED_EDGE_STREAM_CUTOFF_MS,
+  SSE_KEEPALIVE_FRAME,
+  keepaliveIntervalMs,
+  sessionRecoveryBody,
+} from "../dist/mcp-stream.js";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+const KEEPALIVE_MS = 200;
+const HOLD_MS = 3000;
+
+function startServer(keepaliveMs = KEEPALIVE_MS): Promise<{ proc: ChildProcess; port: number; stdout: string[] }> {
+  return new Promise((resolve, reject) => {
+    const serverPath = path.join(__dirname, "..", "dist", "serve.js");
+    const proc = spawn("node", [serverPath], {
+      stdio: ["pipe", "pipe", "pipe"],
+      env: {
+        ...process.env,
+        PORT: "0",
+        BASE_URL: "http://localhost",
+        MCP_SSE_KEEPALIVE_MS: String(keepaliveMs),
+      },
+    });
+    const stdout: string[] = [];
+    proc.stdout!.on("data", (data: Buffer) => {
+      for (const line of data.toString().split("\n")) {
+        if (line.trim()) stdout.push(line);
+      }
+    });
+    const timeout = setTimeout(() => {
+      proc.kill();
+      reject(new Error("Server startup timeout"));
+    }, 20000);
+    proc.stderr!.on("data", (data: Buffer) => {
+      const match = data.toString().match(/running on http:\/\/localhost:(\d+)/);
+      if (match) {
+        clearTimeout(timeout);
+        resolve({ proc, port: parseInt(match[1], 10), stdout });
+      }
+    });
+    proc.on("error", (err) => {
+      clearTimeout(timeout);
+      reject(err);
+    });
+  });
+}
+
+async function initSession(port: number): Promise<string> {
+  const response = await fetch(`http://localhost:${port}/mcp`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json", Accept: "application/json, text/event-stream" },
+    body: JSON.stringify({
+      jsonrpc: "2.0",
+      id: 1,
+      method: "initialize",
+      params: { protocolVersion: "2024-11-05", capabilities: {}, clientInfo: { name: "stream-test", version: "1.0.0" } },
+    }),
+  });
+  await response.text();
+  const sessionId = response.headers.get("mcp-session-id");
+  assert.ok(sessionId, "initialize should return a session ID");
+  return sessionId;
+}
+
+function openStream(port: number, sessionId: string): Promise<Response> {
+  return fetch(`http://localhost:${port}/mcp`, {
+    headers: { "Mcp-Session-Id": sessionId, Accept: "text/event-stream" },
+  });
+}
+
+interface Watcher {
+  chunks: string[];
+  ended: boolean;
+  cancel: () => void;
+}
+
+function watch(response: Response): Watcher {
+  const reader = response.body!.getReader();
+  const decoder = new TextDecoder();
+  const state: Watcher = { chunks: [], ended: false, cancel: () => void reader.cancel().catch(() => {}) };
+  void (async () => {
+    try {
+      for (;;) {
+        const { done, value } = await reader.read();
+        if (done) {
+          state.ended = true;
+          return;
+        }
+        state.chunks.push(decoder.decode(value));
+      }
+    } catch {
+      state.ended = true;
+    }
+  })();
+  return state;
+}
+
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+describe("MCP notification stream keepalive", () => {
+  it("ships a keepalive interval far below the stream cutoff measured at the edge", () => {
+    assert.strictEqual(DEFAULT_SSE_KEEPALIVE_MS, 25_000);
+    assert.strictEqual(MEASURED_EDGE_STREAM_CUTOFF_MS, 125_000);
+    assert.ok(
+      DEFAULT_SSE_KEEPALIVE_MS * 4 <= MEASURED_EDGE_STREAM_CUTOFF_MS,
+      "a stream should carry at least four keepalives inside the window that cut it",
+    );
+  });
+
+  it("keeps a five-minute hold well inside the cutoff at the shipped interval", () => {
+    const holdMs = 300_000;
+    const frames = Math.floor(holdMs / DEFAULT_SSE_KEEPALIVE_MS);
+    assert.ok(frames >= 12, `a 300s hold should carry at least 12 keepalives, carries ${frames}`);
+    assert.ok(DEFAULT_SSE_KEEPALIVE_MS < MEASURED_EDGE_STREAM_CUTOFF_MS);
+  });
+
+  it("reads the interval from the environment and falls back on unusable values", () => {
+    assert.strictEqual(keepaliveIntervalMs({}), DEFAULT_SSE_KEEPALIVE_MS);
+    assert.strictEqual(keepaliveIntervalMs({ MCP_SSE_KEEPALIVE_MS: "" }), DEFAULT_SSE_KEEPALIVE_MS);
+    assert.strictEqual(keepaliveIntervalMs({ MCP_SSE_KEEPALIVE_MS: "1500" }), 1500);
+    assert.strictEqual(keepaliveIntervalMs({ MCP_SSE_KEEPALIVE_MS: "0" }), DEFAULT_SSE_KEEPALIVE_MS);
+    assert.strictEqual(keepaliveIntervalMs({ MCP_SSE_KEEPALIVE_MS: "-5" }), DEFAULT_SSE_KEEPALIVE_MS);
+    assert.strictEqual(keepaliveIntervalMs({ MCP_SSE_KEEPALIVE_MS: "soon" }), DEFAULT_SSE_KEEPALIVE_MS);
+  });
+
+  it("sends a comment frame a conformant client discards rather than a message", () => {
+    assert.ok(SSE_KEEPALIVE_FRAME.startsWith(":"), "an SSE keepalive must be a comment line");
+    assert.ok(SSE_KEEPALIVE_FRAME.endsWith("\n\n"), "an SSE frame must be terminated by a blank line");
+    const dataLines = SSE_KEEPALIVE_FRAME.split("\n").filter((line) => line.startsWith("data:"));
+    assert.deepStrictEqual(dataLines, [], "a keepalive must not carry a data line");
+  });
+
+  it("names the condition and the recovery in every session error body", () => {
+    const unknown = sessionRecoveryBody("unknown_session");
+    assert.strictEqual(unknown.error.data.condition, "unknown_session");
+    assert.strictEqual(unknown.error.data.recovery, "reinitialize");
+    assert.match(unknown.error.message, /session ID you sent/);
+    assert.match(unknown.error.message, /initialize/);
+
+    const missing = sessionRecoveryBody("no_session");
+    assert.strictEqual(missing.error.data.condition, "no_session");
+    assert.strictEqual(missing.error.data.recovery, "reinitialize");
+    assert.match(missing.error.message, /no Mcp-Session-Id header/);
+    assert.match(missing.error.message, /initialize/);
+
+    assert.notStrictEqual(
+      unknown.error.message,
+      missing.error.message,
+      "the two conditions must not share one message",
+    );
+  });
+});
+
+describe("MCP notification stream over HTTP", () => {
+  let proc: ChildProcess | null = null;
+  const watchers: Watcher[] = [];
+
+  afterEach(() => {
+    for (const watcher of watchers.splice(0)) watcher.cancel();
+    if (proc) {
+      proc.kill();
+      proc = null;
+    }
+  });
+
+  it("holds the stream open across many keepalive intervals", async () => {
+    const started = await startServer();
+    proc = started.proc;
+    const sessionId = await initSession(started.port);
+
+    const stream = await openStream(started.port, sessionId);
+    assert.strictEqual(stream.status, 200);
+    assert.match(stream.headers.get("content-type") ?? "", /text\/event-stream/);
+
+    const watcher = watch(stream);
+    watchers.push(watcher);
+    await sleep(HOLD_MS);
+
+    const expected = Math.floor(HOLD_MS / KEEPALIVE_MS / 2);
+    assert.ok(
+      watcher.chunks.length >= expected,
+      `expected at least ${expected} keepalives in ${HOLD_MS}ms, saw ${watcher.chunks.length}`,
+    );
+    assert.strictEqual(watcher.ended, false, "the stream closed while the client was still holding it");
+    for (const chunk of watcher.chunks) {
+      assert.ok(chunk.startsWith(":"), `keepalive chunk was not a comment frame: ${JSON.stringify(chunk)}`);
+    }
+
+  });
+
+  it("puts a byte on the stream at once so a proxy forwards the response instead of holding it", async () => {
+    const slowKeepalive = 4000;
+    const started = await startServer(slowKeepalive);
+    proc = started.proc;
+    const sessionId = await initSession(started.port);
+
+    const openedAt = Date.now();
+    const stream = await openStream(started.port, sessionId);
+    assert.strictEqual(stream.status, 200);
+    const watcher = watch(stream);
+    watchers.push(watcher);
+
+    const waitedFor = 1000;
+    await sleep(waitedFor);
+    assert.ok(
+      watcher.chunks.length >= 1,
+      `no byte reached the client in ${Date.now() - openedAt}ms, so a proxy has nothing to forward until ${slowKeepalive}ms`,
+    );
+    assert.ok(
+      waitedFor < slowKeepalive / 2,
+      "the first byte must arrive well before the first scheduled keepalive or this asserts nothing",
+    );
+  });
+
+  it("releases the stream slot when the client disconnects", async () => {
+    const started = await startServer();
+    proc = started.proc;
+    const sessionId = await initSession(started.port);
+
+    const stream = await openStream(started.port, sessionId);
+    assert.strictEqual(stream.status, 200);
+    const watcher = watch(stream);
+    await sleep(KEEPALIVE_MS * 2);
+    watcher.cancel();
+    await sleep(KEEPALIVE_MS * 3);
+
+    const closes = started.stdout
+      .map((line) => {
+        try {
+          return JSON.parse(line);
+        } catch {
+          return null;
+        }
+      })
+      .filter((event) => event?.event === "stream_close" && event.sessionId === sessionId);
+    assert.ok(closes.length >= 1, "the server did not record the stream closing when the client went away");
+    assert.strictEqual(closes[0].reason, "client_disconnect");
+
+    const reopened = await openStream(started.port, sessionId);
+    assert.strictEqual(reopened.status, 200, "the released slot should accept a fresh stream");
+    const reopenedWatcher = watch(reopened);
+    watchers.push(reopenedWatcher);
+    await sleep(KEEPALIVE_MS * 3);
+    assert.ok(reopenedWatcher.chunks.length > 0, "the fresh stream should carry keepalives");
+  });
+
+  it("accepts a reconnect on a session that still holds a stream instead of answering 409", async () => {
+    const started = await startServer();
+    proc = started.proc;
+    const sessionId = await initSession(started.port);
+
+    const first = await openStream(started.port, sessionId);
+    assert.strictEqual(first.status, 200);
+    const firstWatcher = watch(first);
+    watchers.push(firstWatcher);
+    await sleep(KEEPALIVE_MS * 3);
+    assert.ok(firstWatcher.chunks.length > 0, "the first stream should be live before the reconnect");
+
+    const second = await openStream(started.port, sessionId);
+    assert.strictEqual(second.status, 200, "a reconnect must not be refused");
+    assert.match(second.headers.get("content-type") ?? "", /text\/event-stream/);
+
+    await sleep(KEEPALIVE_MS * 3);
+    assert.strictEqual(firstWatcher.ended, true, "the replaced stream must be closed, not left dangling");
+
+    const secondWatcher = watch(second);
+    watchers.push(secondWatcher);
+    await sleep(KEEPALIVE_MS * 3);
+    assert.ok(secondWatcher.chunks.length > 0, "the replacement stream should carry keepalives");
+
+    const stillUsable = await fetch(`http://localhost:${started.port}/mcp`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Accept: "application/json, text/event-stream",
+        "Mcp-Session-Id": sessionId,
+      },
+      body: JSON.stringify([
+        { jsonrpc: "2.0", method: "notifications/initialized" },
+        { jsonrpc: "2.0", id: 2, method: "tools/list" },
+      ]),
+    });
+    assert.strictEqual(stillUsable.status, 200, "the session must survive the stream replacement");
+    assert.match(await stillUsable.text(), /"tools"/);
+
+  });
+
+  it("tells a client which session condition it hit and that it should re-initialize", async () => {
+    const started = await startServer();
+    proc = started.proc;
+    await initSession(started.port);
+
+    const unknownStream = await fetch(`http://localhost:${started.port}/mcp`, {
+      headers: { "Mcp-Session-Id": "a-session-this-server-never-issued", Accept: "text/event-stream" },
+    });
+    assert.strictEqual(unknownStream.status, 400);
+    const unknownBody = await unknownStream.json() as any;
+    assert.strictEqual(unknownBody.error.data.condition, "unknown_session");
+    assert.strictEqual(unknownBody.error.data.recovery, "reinitialize");
+    assert.match(unknownBody.error.message, /initialize/);
+
+    const noSessionStream = await fetch(`http://localhost:${started.port}/mcp`, {
+      headers: { Accept: "text/event-stream" },
+    });
+    assert.strictEqual(noSessionStream.status, 400);
+    const noSessionBody = await noSessionStream.json() as any;
+    assert.strictEqual(noSessionBody.error.data.condition, "no_session");
+    assert.strictEqual(noSessionBody.error.data.recovery, "reinitialize");
+    assert.match(noSessionBody.error.message, /initialize/);
+
+    const unknownPost = await fetch(`http://localhost:${started.port}/mcp`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Accept: "application/json, text/event-stream",
+        "Mcp-Session-Id": "a-session-this-server-never-issued",
+      },
+      body: JSON.stringify({ jsonrpc: "2.0", id: 3, method: "tools/list" }),
+    });
+    assert.strictEqual(unknownPost.status, 400);
+    const unknownPostBody = await unknownPost.json() as any;
+    assert.strictEqual(unknownPostBody.error.data.condition, "unknown_session");
+    assert.strictEqual(unknownPostBody.error.data.recovery, "reinitialize");
+  });
+
+  it("never answers a stream request with the bare conflict body a client cannot act on", async () => {
+    const started = await startServer();
+    proc = started.proc;
+    const sessionId = await initSession(started.port);
+
+    const bodies: string[] = [];
+    const held: Watcher[] = [];
+    for (let attempt = 0; attempt < 4; attempt++) {
+      const response = await openStream(started.port, sessionId);
+      assert.strictEqual(response.status, 200, `reconnect ${attempt} was refused with ${response.status}`);
+      const heldWatcher = watch(response);
+      held.push(heldWatcher);
+      watchers.push(heldWatcher);
+      await sleep(KEEPALIVE_MS);
+    }
+
+    const conflicted = await fetch(`http://localhost:${started.port}/mcp`, {
+      headers: { "Mcp-Session-Id": "a-session-this-server-never-issued", Accept: "text/event-stream" },
+    });
+    bodies.push(await conflicted.text());
+    for (const body of bodies) {
+      assert.ok(!body.includes("Only one SSE stream"), "a client was handed a conflict it cannot recover from");
+    }
+
+  });
+});


### PR DESCRIPTION
Refs #1098

The standalone `GET /mcp` stream carried no bytes between notifications, and we never send notifications, so it was an idle response — and every proxy in front of it closes an idle response.

## What the cut actually is (AC-5)

Measured 2026-08-27 against the **pre-change** production server, one `initialize` + one `GET /mcp` per path, `curl --max-time 400`, marked `agentdeals-internal/1.0`:

| path | proxies in front | outcome | elapsed |
|---|---|---|---|
| `agentdeals.dev` | Cloudflare → Railway | `502` — `stream reset by client (INTERNAL_ERROR)` | **125.4s** |
| `agentdeals-production.up.railway.app` | Railway only | HTTP/2 `CANCEL` (curl 92) | **300.4s** |

**It is Cloudflare.** 125.4s matches the reported 125s, and the same request with Cloudflare taken out of the path survives to 300.4s. The wording of Railway's 502 is the direct evidence: *its* client is Cloudflare, and it is reporting that Cloudflare reset the stream. Railway then imposes its own ~300s idle ceiling behind it. Both are idle timeouts, so one keepalive cadence clears both.

One thing the issue understates: through Cloudflare the client never received the `200` at all. Cloudflare holds the response headers until the first body byte, and there was never a body byte, so the *only* response a client got was the 502 at 125s.

## What shipped

- **A comment frame when the stream opens, and every 25s after.** `MCP_SSE_KEEPALIVE_MS` overrides the interval for tests. The opening frame is what makes a proxy forward the `200` immediately instead of holding it — without it the client waits a full interval to learn the stream is up, and through Cloudflare it never learned at all.
- **A repeat `GET` replaces the held stream** instead of being refused. A session ID is issued to one client, so a second `GET` on it is that client reconnecting, never a competitor.
- **The slot, the keepalive timer and our record of the stream are released when the response closes** — and when the session is deleted, reaped, or closed by the transport. The release is logged as `stream_close` with a reason.
- **`400` on a session we are not holding carries a JSON-RPC body** naming the condition (`unknown_session` / `no_session`) and the recovery (`reinitialize`), on both the `GET` and `POST` paths. It replaces `{"error":"Invalid or missing session ID"}`, which told a client nothing it could act on.

## Verification

- `npm test` — **2063/2063**, exit 0 (2052 before).
- `scripts/e2e-1098.mjs --hold 330` holds a real stream against a running server for **330.3s**: 14 frames, longest silence **25.03s**, never closed, and the session still served `tools/list` afterwards. It takes `--url` so the same check runs against production.
- `scripts/mutate-1098.sh` — **10 mutations, 10 killed, 0 survived**, including removing the keepalive write, removing the opening frame, removing the replacement, removing the release-on-close, reverting the `400` body, and moving the interval above the measured cutoff.

## Left with the PM

**AC-3's 409 half is met by removing the response, not by rewording it.** Once a repeat `GET` is treated as a reconnect there is no conflict left to report, and a test asserts four back-to-back reconnects on one session all return `200` and that no body carries the SDK's `Only one SSE stream` text. I could not find a conflict that stays reachable under that rule, and an unreachable branch is worse than no branch — but if a `409` should be kept for some case, say so and I will add it.

**AC-4 cannot be answered from here.** It needs 24h of edge log after deploy, and `gh secret list` on this repo returns only `OPENROUTER_API_KEY` — there is no Cloudflare credential, so I have no route to the analytics the 37% baseline came from.

**AC-1 is asserted as "the stream is open and the session still answers", not as a delivered notification.** Nothing in the server emits one today; we advertise `listChanged` on three capabilities and never fire them. That gap is real and separate from this issue.

A session with an open stream and no other traffic is still reaped at the 15-minute idle timeout — a stream is not counted as activity. That is #1054's territory and this PR leaves it alone.
