### PR TITLE
Stop the Atom feed publishing an updated timestamp in the future

### DIFF
--- a/src/change-dates.ts
+++ b/src/change-dates.ts
@@ -60,6 +60,12 @@ export function capListSections<T>(sections: T[][], cap: number): T[] {
   return sections.flatMap((section, i) => section.slice(0, allotted[i]));
 }
 
+export function feedEntryUpdated(day: string, now: Date = new Date()): string {
+  const noon = Date.parse(`${day}T12:00:00Z`);
+  if (Number.isNaN(noon)) return now.toISOString();
+  return new Date(Math.min(noon, now.getTime())).toISOString();
+}
+
 export function latestEventDate(changes: DatedChange[], notAfter?: string): string | null {
   let latest: string | null = null;
   for (const c of changes) {

--- a/src/serve.ts
+++ b/src/serve.ts
@@ -34,7 +34,7 @@ import { rankOffers, rankForListing, rotateListing, utcDate, CRITERIA_PATH, DEMO
 import type { RankedEntry, RankingResult } from "./ranking.js";
 import { partitionAlternatives, partitionAlternativesAcross, productRoleSentence, MEMBERSHIP_GATE_RULES, MEMBERSHIP_GATE_ORDER, MEMBERSHIP_GATE_SYMMETRY, MEMBERSHIP_GATE_SCOPE, MEMBERSHIP_GATE_CORRECTIONS } from "./product-role.js";
 import type { Agent, ChangeDateSource, DealChange, RiskCause, LinkUnreachable } from "./types.js";
-import { changeDateLabel, changeDateClause, changeDatePublished, changeEventStartDate, capListSections, latestEventDate, undatedGroupHeading, DISCOVERED_DATE_PREFIX, UNDATED_GROUP_NOTE } from "./change-dates.js";
+import { changeDateLabel, changeDateClause, changeDatePublished, changeEventStartDate, capListSections, latestEventDate, feedEntryUpdated, undatedGroupHeading, DISCOVERED_DATE_PREFIX, UNDATED_GROUP_NOTE } from "./change-dates.js";
 import type { AgentBalance } from "./ledger.js";
 import type { SubmittedReferralCode } from "./referral-codes.js";
 
@@ -54639,7 +54639,7 @@ const httpServer = createHttpServer(async (req, res) => {
       if (digest.top_changes.length === 0) continue;
       const weekUrl = w === 0 ? `${baseUrl}/this-week` : `${baseUrl}/this-week?week=${w}`;
       const newestChange = latestChangeDate(digest.top_changes) ?? digest.week_of;
-      const pubDate = new Date(newestChange + "T12:00:00Z").toISOString();
+      const pubDate = feedEntryUpdated(newestChange);
       entryUpdates.push(pubDate);
       const months = ["January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December"];
       const ws = new Date(digest.week_of + "T00:00:00Z");

--- a/test/change-date-provenance.test.ts
+++ b/test/change-date-provenance.test.ts
@@ -16,6 +16,7 @@ import {
   capListSections,
   changeDateLabel,
   changeDatePublished,
+  feedEntryUpdated,
   undatedGroupHeading,
   DISCOVERED_DATE_PREFIX,
   UNDATED_GROUP_NOTE,
@@ -473,5 +474,27 @@ describe("capping a list built from several sections", () => {
 
   it("fills the earlier sections first with whatever the reservations leave", () => {
     assert.deepStrictEqual(capListSections([big("up", 5), big("recent", 5)], 4), ["up0", "up1", "up2", "recent0"]);
+  });
+});
+
+describe("feed entry updated timestamps", () => {
+  it("never stamps an entry later than the moment the feed is built", () => {
+    const now = new Date("2026-08-28T01:03:00Z");
+    assert.strictEqual(feedEntryUpdated("2026-08-28", now), "2026-08-28T01:03:00.000Z");
+  });
+
+  it("still stamps noon for a day that is already over", () => {
+    const now = new Date("2026-08-28T01:03:00Z");
+    assert.strictEqual(feedEntryUpdated("2026-08-27", now), "2026-08-27T12:00:00.000Z");
+  });
+
+  it("stamps noon once the day's noon has passed", () => {
+    const now = new Date("2026-08-28T18:00:00Z");
+    assert.strictEqual(feedEntryUpdated("2026-08-28", now), "2026-08-28T12:00:00.000Z");
+  });
+
+  it("falls back to now when the day is not a date", () => {
+    const now = new Date("2026-08-28T01:03:00Z");
+    assert.strictEqual(feedEntryUpdated("not-a-date", now), "2026-08-28T01:03:00.000Z");
   });
 });


### PR DESCRIPTION
`main` is red: `test/feed-weekly-digest.test.ts` → "no entry has a future updated date" fails with `Date 2026-08-28T12:00:00.000Z should not be in the future`.

Each weekly Atom entry was stamped `new Date(newestChange + "T12:00:00Z")`. That was harmless while the newest recorded change was always a past day. The re-verification detector shipped in #1097 now records changes at 00:01Z every morning, so from the run until noon the feed publishes an `<updated>` up to 12 hours ahead of the present — and the feed-level `<updated>`, which reduces over the entry stamps, inherits it. A future `updated` is what an Atom reader sorts and de-duplicates on.

`feedEntryUpdated(day, now)` in `src/change-dates.ts` clamps the noon stamp to `now`, and falls back to `now` for an unparseable day.

Verified against a local server at 01:04:45Z: both entries now carry `2026-08-28T01:04:45.038Z` where they previously carried `2026-08-28T12:00:00.000Z`.

Four unit tests cover both sides of noon, a past day, and the unparseable input. Replacing the clamp with the bare noon stamp fails one of them.

No issue — this is the red-main gate, found on wake.