### PR TITLE
Refuse to record a detected change that describes no change

### DIFF
--- a/.github/workflows/gate-audit.yml
+++ b/.github/workflows/gate-audit.yml
@@ -1,0 +1,54 @@
+name: Change gate audit
+
+on:
+  workflow_dispatch:
+    inputs:
+      on_date:
+        description: "Only audit records recorded on this date (YYYY-MM-DD); blank for all"
+        required: false
+        default: ""
+      confirm:
+        description: "Ask the second-opinion pass as well as the first layer"
+        type: boolean
+        required: false
+        default: true
+
+permissions:
+  contents: read
+
+concurrency:
+  group: gate-audit
+  cancel-in-progress: false
+
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Report what the gate would do
+        env:
+          OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
+        run: |
+          set -o pipefail
+          ARGS=""
+          if [ -n "${{ github.event.inputs.on_date }}" ]; then
+            ARGS="$ARGS --on ${{ github.event.inputs.on_date }}"
+          fi
+          if [ "${{ github.event.inputs.confirm }}" = "true" ]; then
+            ARGS="$ARGS --confirm"
+          fi
+          node scripts/gate-report.js $ARGS | tee /tmp/gate-report.txt
+          {
+            echo '```'
+            cat /tmp/gate-report.txt
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/data/deal_changes.json
+++ b/data/deal_changes.json
@@ -4616,21 +4616,6 @@
       "recorded_date": "2026-08-28"
     },
     {
-      "vendor": "Abby",
-      "change_type": "limits_reduced",
-      "date": "2026-08-28",
-      "date_source": "discovered",
-      "summary": "The free tier now has 1 A/B test instead of 1, and the pricing is now explicitly stated as $12/month per project for the Starter tier (previously just 'scale at a fair price').",
-      "previous_state": "Open-Source feature flags & A/B testing. Configuration as Code & Fully Typed Typescript SDKs. Strong integration with Frameworks such as Next.js & React. Free plan: 1,000 events/month, 3 feature flags/remote configs, 1 A/B test, 5 environments.",
-      "current_state": "Free: 1,000 Events / month, 1 A/B Test, 3 Feature Flags / Remote Configs, 5 Environments. Starter: 1,000 Events / month, 1 A/B Test, 3 Feature Flags / Remote Configs, 5 Environments $12 /mo per Project",
-      "impact": "medium",
-      "source_url": "https://www.tryabby.com",
-      "category": "Feature Flags",
-      "alternatives": [],
-      "detected_by": "reverify-ai",
-      "recorded_date": "2026-08-28"
-    },
-    {
       "vendor": "AppFit",
       "change_type": "limits_reduced",
       "date": "2026-08-28",
@@ -4686,21 +4671,6 @@
       "impact": "high",
       "source_url": "https://www.algolia.com/pricing",
       "category": "Search",
-      "alternatives": [],
-      "detected_by": "reverify-ai",
-      "recorded_date": "2026-08-28"
-    },
-    {
-      "vendor": "Cloudflare DNS",
-      "change_type": "limits_reduced",
-      "date": "2026-08-28",
-      "date_source": "discovered",
-      "summary": "The page confirms a free plan exists, but states a records-per-zone cap of 200 for zones created on or after 2024-09-01, while zones created before that date retain the legacy 1,000-record cap. This matches the stored deal info. However, the page also promotes add-ons that are paid, and the free plan is described as a foundational offering with the option to upgrade.",
-      "previous_state": "Free authoritative DNS hosting — unlimited zones and queries, DDoS protection, free SSL/TLS. Records-per-zone cap is 200 for zones created on or after 2024-09-01; zones created before that date retain the legacy 1,000-record cap.",
-      "current_state": "The free plan offers foundational security and performance. Records-per-zone is capped at 200 for zones created on or after 2024-09-01, and 1,000 for zones created before that date.",
-      "impact": "medium",
-      "source_url": "https://www.cloudflare.com/plans/free/",
-      "category": "DNS & Domain Management",
       "alternatives": [],
       "detected_by": "reverify-ai",
       "recorded_date": "2026-08-28"

--- a/scripts/change-gate.js
+++ b/scripts/change-gate.js
@@ -1,0 +1,204 @@
+export const REJECT_NULL_COMPARISON = "null_comparison";
+export const REJECT_STATES_NO_DIFFERENCE = "states_no_difference";
+export const REJECT_CONFIRMED_UNCHANGED = "confirmed_unchanged";
+
+export const GATE_REASONS = [
+  REJECT_NULL_COMPARISON,
+  REJECT_STATES_NO_DIFFERENCE,
+  REJECT_CONFIRMED_UNCHANGED,
+];
+
+const QUANTITY_CHANGE_TYPES = ["limits_reduced", "limits_increased"];
+
+const COMPARISON_CONNECTIVES = [
+  "instead of",
+  "down from",
+  "up from",
+  "reduced from",
+  "increased from",
+  "rather than",
+  "previously",
+];
+
+const AGREEMENT_PHRASES = [
+  "matches the stored",
+  "matches what we",
+  "matches our stored",
+  "aligns with the stored",
+  "same as the stored",
+  "identical to the stored",
+  "consistent with the stored",
+  "unchanged from the stored",
+  "agrees with the stored",
+  "confirms the stored",
+  "no change from the stored",
+  "no changes from the stored",
+];
+
+const OPERAND_WINDOW = 30;
+const NUMBER = /\d+(?:,\d{3})*(?:\.\d+)?/g;
+
+export function quantities(text) {
+  if (typeof text !== "string") return [];
+  return [...text.matchAll(NUMBER)].map((m) => Number(m[0].replace(/,/g, "")));
+}
+
+function multisetEqual(a, b) {
+  if (a.length !== b.length) return false;
+  const sortNum = (xs) => [...xs].sort((x, y) => x - y);
+  const left = sortNum(a);
+  const right = sortNum(b);
+  return left.every((v, i) => v === right[i]);
+}
+
+function containsAll(haystack, needles) {
+  const pool = [...haystack];
+  for (const n of needles) {
+    const at = pool.indexOf(n);
+    if (at === -1) return false;
+    pool.splice(at, 1);
+  }
+  return true;
+}
+
+export function nullComparisons(summary) {
+  if (typeof summary !== "string") return [];
+  const lower = summary.toLowerCase();
+  const found = [];
+  for (const connective of COMPARISON_CONNECTIVES) {
+    let at = lower.indexOf(connective);
+    while (at !== -1) {
+      const before = summary.slice(Math.max(0, at - OPERAND_WINDOW), at);
+      const after = summary.slice(at + connective.length, at + connective.length + OPERAND_WINDOW);
+      const left = quantities(before).pop();
+      const right = quantities(after).shift();
+      if (left !== undefined && right !== undefined && left === right) {
+        found.push({ connective, value: left });
+      }
+      at = lower.indexOf(connective, at + connective.length);
+    }
+  }
+  return found;
+}
+
+export function assertsAgreement(summary) {
+  if (typeof summary !== "string") return false;
+  const lower = summary.toLowerCase();
+  return AGREEMENT_PHRASES.some((phrase) => lower.includes(phrase));
+}
+
+export function describesChange(entry) {
+  const previous = quantities(entry?.previous_state);
+  const current = quantities(entry?.current_state);
+
+  const nulls = nullComparisons(entry?.summary);
+  if (nulls.length > 0 && containsAll(current, previous)) {
+    return {
+      ok: false,
+      reason: REJECT_NULL_COMPARISON,
+      detail: `summary states "${nulls[0].connective}" between two values of ${nulls[0].value} and no stored quantity is absent from the current state`,
+    };
+  }
+
+  if (
+    QUANTITY_CHANGE_TYPES.includes(entry?.change_type) &&
+    assertsAgreement(entry?.summary) &&
+    multisetEqual(previous, current)
+  ) {
+    return {
+      ok: false,
+      reason: REJECT_STATES_NO_DIFFERENCE,
+      detail: `${entry.change_type} claimed, summary asserts the page matches what we stored, and the two states carry the same quantities`,
+    };
+  }
+
+  return { ok: true };
+}
+
+export function changeConfirmationPrompt(entry) {
+  return `A monitoring job compared a stored description of a vendor's free tier against the vendor's live page and reported a change. Decide whether the report actually describes a change.
+
+STORED DESCRIPTION (what we published before):
+${entry.previous_state}
+
+CURRENT PAGE (what the job read today):
+${entry.current_state}
+
+THE JOB'S REPORT:
+${entry.summary}
+
+Answer "no" if the two descriptions state the same terms in different words, if the report restates the stored description, if the report says the page matches what was stored, or if the only difference is wording, formatting, or detail the stored description never claimed.
+
+Answer "yes" only if a developer relying on the stored description would get something different today.
+
+Respond with EXACTLY one JSON object and no other text:
+{"change":"yes"}
+{"change":"no","reason":"<short reason>"}`;
+}
+
+export function parseConfirmation(raw) {
+  const text =
+    typeof raw === "string"
+      ? raw.trim().replace(/^```(?:json)?\s*/i, "").replace(/```$/, "").trim()
+      : "";
+  const accept = (parsed) =>
+    parsed && (parsed.change === "yes" || parsed.change === "no") ? parsed : null;
+  try {
+    const parsed = accept(JSON.parse(text));
+    if (parsed) return { verdict: parsed.change, reason: parsed.reason ?? null };
+  } catch {
+    const match = text.match(/\{[^}]*\}/);
+    if (match) {
+      try {
+        const parsed = accept(JSON.parse(match[0]));
+        if (parsed) return { verdict: parsed.change, reason: parsed.reason ?? null };
+      } catch { /* fall through */ }
+    }
+  }
+  return { verdict: "unparsed", reason: null };
+}
+
+export async function confirmDescribesChange(client, entry) {
+  return parseConfirmation(await client.complete(changeConfirmationPrompt(entry)));
+}
+
+export async function gateCandidates(candidates, options = {}) {
+  const confirmFn = options.confirmFn;
+  const accepted = [];
+  const rejected = [];
+  const unchecked = [];
+
+  for (const candidate of candidates) {
+    const verdict = describesChange(candidate);
+    if (!verdict.ok) {
+      rejected.push({ candidate, reason: verdict.reason, detail: verdict.detail });
+      continue;
+    }
+    if (!confirmFn) {
+      accepted.push(candidate);
+      continue;
+    }
+    let confirmation;
+    try {
+      confirmation = await confirmFn(candidate);
+    } catch (err) {
+      unchecked.push({ candidate, error: err.message });
+      accepted.push(candidate);
+      continue;
+    }
+    if (confirmation.verdict === "no") {
+      rejected.push({
+        candidate,
+        reason: REJECT_CONFIRMED_UNCHANGED,
+        detail: confirmation.reason || "a second pass judged the report to describe no change",
+      });
+      continue;
+    }
+    if (confirmation.verdict === "unparsed") {
+      unchecked.push({ candidate, error: "second pass returned no usable verdict" });
+    }
+    accepted.push(candidate);
+  }
+
+  return { accepted, rejected, unchecked };
+}

--- a/scripts/e2e-1087.mjs
+++ b/scripts/e2e-1087.mjs
@@ -15,9 +15,14 @@ const server = createServer((req, res) => {
   req.on("data", (c) => (body += c));
   req.on("end", () => {
     if (req.url === "/api/v1/chat/completions") {
-      requests.push({ headers: req.headers, body: JSON.parse(body) });
-      const mentionsShrunkTier = requests.length === 1;
-      const answer = mentionsShrunkTier
+      const parsed = JSON.parse(body);
+      requests.push({ headers: req.headers, body: parsed });
+      const prompt = parsed.messages[0].content;
+      const isSecondOpinion = prompt.includes("THE JOB'S REPORT:");
+      const mentionsShrunkTier = requests.filter((r) => !r.body.messages[0].content.includes("THE JOB'S REPORT:")).length === 1;
+      const answer = isSecondOpinion
+        ? '{"change":"yes"}'
+        : mentionsShrunkTier
         ? '```json\n{"status":"changed","summary":"Free tier cut from 10 GB to 5 GB","change_type":"limits_reduced","current_state":"Free plan includes 5 GB storage","impact":"medium"}\n```'
         : '{"status":"confirmed"}';
       res.writeHead(200, { "Content-Type": "application/json" });

--- a/scripts/e2e-1101.mjs
+++ b/scripts/e2e-1101.mjs
@@ -1,0 +1,127 @@
+#!/usr/bin/env node
+import { createServer } from "node:http";
+import { mkdtempSync, writeFileSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, dirname, resolve } from "node:path";
+import { spawn } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+const REPO = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const requests = [];
+
+const PAGES = {
+  "/pricing/moved":
+    "Free plan: 5 GB storage per month. Paid plans start at $5 per month and add 100 GB. " +
+    "This paragraph exists so the extractor has enough text to read.",
+  "/pricing/reworded":
+    "Free plan: 10 GB storage per month, 3 projects, 1 seat. Starter: 10 GB storage per month, " +
+    "3 projects, 1 seat, $12 per month per project. Text padding so the extractor has enough to read.",
+  "/pricing/restated":
+    "Free plan: 10 GB storage per month across 3 projects. Nothing about these terms has moved. " +
+    "Text padding so the extractor has enough to read.",
+};
+
+const DETECTIONS = {
+  StubMoved:
+    '{"status":"changed","summary":"Free storage is now 5 GB, down from 10 GB","change_type":"limits_reduced","current_state":"Free plan includes 5 GB storage","impact":"high"}',
+  StubReworded:
+    '{"status":"changed","summary":"The free tier now has 3 projects instead of 3, and the Starter tier is now priced at $12 per month per project","change_type":"limits_reduced","current_state":"Free plan: 10 GB storage per month, 3 projects, 1 seat. Starter: 10 GB storage per month, 3 projects, 1 seat, $12 per month per project","impact":"medium"}',
+  StubRestated:
+    '{"status":"changed","summary":"The page states 10 GB across 3 projects, which matches the stored deal info","change_type":"pricing_restructured","current_state":"Free plan: 10 GB storage per month across 3 projects","impact":"medium"}',
+};
+
+function vendorIn(prompt) {
+  return Object.keys(DETECTIONS).find((v) => prompt.includes(v)) ?? null;
+}
+
+const server = createServer((req, res) => {
+  let body = "";
+  req.on("data", (c) => (body += c));
+  req.on("end", () => {
+    if (req.url === "/api/v1/chat/completions") {
+      const parsed = JSON.parse(body);
+      const prompt = parsed.messages[0].content;
+      const isSecondOpinion = prompt.includes("THE JOB'S REPORT:");
+      requests.push({ isSecondOpinion, prompt });
+      let answer;
+      if (isSecondOpinion) {
+        answer = prompt.includes("which matches the stored deal info")
+          ? '{"change":"no","reason":"the report restates the stored terms"}'
+          : '{"change":"yes"}';
+      } else {
+        answer = DETECTIONS[vendorIn(prompt)] ?? '{"status":"confirmed"}';
+      }
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ choices: [{ message: { content: answer } }] }));
+      return;
+    }
+    const page = PAGES[req.url];
+    if (page) {
+      res.writeHead(200, { "Content-Type": "text/html" });
+      res.end(`<html><body><h1>Pricing</h1><p>${page}</p></body></html>`);
+      return;
+    }
+    res.writeHead(404);
+    res.end();
+  });
+});
+
+await new Promise((r) => server.listen(0, r));
+const port = server.address().port;
+const base = `http://localhost:${port}`;
+
+const dir = mkdtempSync(join(tmpdir(), "e2e-1101-"));
+const indexPath = join(dir, "index.json");
+const changesPath = join(dir, "deal_changes.json");
+writeFileSync(
+  indexPath,
+  JSON.stringify({
+    offers: [
+      { vendor: "StubMoved", category: "Cloud Storage", url: `${base}/pricing/moved`, tier: "Free", description: "10 GB free storage per month", verifiedDate: "2025-01-01" },
+      { vendor: "StubReworded", category: "Cloud Storage", url: `${base}/pricing/reworded`, tier: "Free", description: "Free plan: 10 GB storage per month, 3 projects, 1 seat", verifiedDate: "2025-01-02" },
+      { vendor: "StubRestated", category: "Cloud Storage", url: `${base}/pricing/restated`, tier: "Free", description: "Free plan: 10 GB storage per month across 3 projects", verifiedDate: "2025-01-03" },
+    ],
+  })
+);
+writeFileSync(changesPath, JSON.stringify({ changes: [] }));
+
+const run = () =>
+  new Promise((done) => {
+    const p = spawn("node", [join(REPO, "scripts", "reverify-rolling.js"), "--ai", "--limit", "3"], {
+      env: {
+        ...process.env,
+        AGENTDEALS_INDEX_PATH: indexPath,
+        AGENTDEALS_CHANGES_PATH: changesPath,
+        OPENROUTER_BASE_URL: `${base}/api/v1`,
+        OPENROUTER_API_KEY: "stub-key",
+      },
+    });
+    let out = "";
+    p.stdout.on("data", (c) => (out += c));
+    p.stderr.on("data", (c) => (out += c));
+    p.on("close", (code) => done({ code, out }));
+  });
+
+const result = await run();
+console.log("── the run ──");
+console.log(`exit ${result.code}`);
+console.log(result.out.trim());
+
+const detections = requests.filter((r) => !r.isSecondOpinion);
+const secondOpinions = requests.filter((r) => r.isSecondOpinion);
+console.log("");
+console.log("── what reached the model ──");
+console.log(`page readings: ${detections.length}`);
+console.log(`second opinions: ${secondOpinions.length}`);
+for (const v of Object.keys(DETECTIONS)) {
+  const summary = JSON.parse(DETECTIONS[v]).summary;
+  console.log(`  ${v} asked for a second opinion: ${secondOpinions.some((r) => r.prompt.includes(summary))}`);
+}
+
+const written = JSON.parse(readFileSync(changesPath, "utf-8"));
+console.log("");
+console.log("── change log after the run ──");
+console.log(`records: ${written.changes.length}`);
+for (const c of written.changes) console.log(`  ${c.vendor} (${c.change_type}) — ${c.summary}`);
+
+server.close();

--- a/scripts/gate-report.js
+++ b/scripts/gate-report.js
@@ -1,0 +1,87 @@
+#!/usr/bin/env node
+
+/**
+ * Report what the change gate would do to records already in the log.
+ *
+ * Usage:
+ *   node scripts/gate-report.js                        # every machine-detected record, first layer only
+ *   node scripts/gate-report.js --on 2026-08-28        # only records recorded that day
+ *   node scripts/gate-report.js --confirm              # also ask the second-opinion pass
+ */
+
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { readChangeLog, CHANGES_PATH, DETECTED_BY_AI } from "./change-log.js";
+import { gateCandidates, confirmDescribesChange } from "./change-gate.js";
+import { createVerifierClient, VERIFIER_MODEL } from "./verify-freshness.js";
+
+export function machineDetected(changes, onDate) {
+  return changes.filter(
+    (c) => c.detected_by === DETECTED_BY_AI && (!onDate || c.recorded_date === onDate)
+  );
+}
+
+export function reportLines({ candidates, accepted, rejected, unchecked }) {
+  const verdictFor = new Map();
+  for (const c of accepted) verdictFor.set(c, { mark: "keep", note: "" });
+  for (const { candidate, error } of unchecked) {
+    verdictFor.set(candidate, { mark: "keep", note: `no second opinion: ${error}` });
+  }
+  for (const { candidate, reason, detail } of rejected) {
+    verdictFor.set(candidate, { mark: "DROP", note: `${reason} — ${detail}` });
+  }
+  const lines = [];
+  for (const candidate of candidates) {
+    const verdict = verdictFor.get(candidate) ?? { mark: "keep", note: "" };
+    lines.push(
+      `${verdict.mark}  ${candidate.vendor} (${candidate.change_type})${verdict.note ? ` — ${verdict.note}` : ""}`
+    );
+  }
+  lines.push("");
+  lines.push(
+    `Kept: ${candidates.length - rejected.length} | Dropped: ${rejected.length} | Recorded without a second opinion: ${unchecked.length} | Considered: ${candidates.length}`
+  );
+  return lines;
+}
+
+async function main() {
+  const args = process.argv.slice(2);
+  const confirm = args.includes("--confirm");
+  const onIdx = args.indexOf("--on");
+  const onDate = onIdx !== -1 ? args[onIdx + 1] : null;
+
+  const data = readChangeLog(process.env.AGENTDEALS_CHANGES_PATH || CHANGES_PATH);
+  const candidates = machineDetected(data.changes, onDate);
+
+  console.log(
+    `Change gate report — ${candidates.length} machine-detected records` +
+      (onDate ? ` recorded on ${onDate}` : "") +
+      (confirm ? ` (second opinion: ${VERIFIER_MODEL})` : " (first layer only)")
+  );
+  console.log("");
+
+  if (candidates.length === 0) {
+    console.log("Nothing to report.");
+    process.exit(0);
+  }
+
+  let confirmFn = null;
+  if (confirm) {
+    const client = createVerifierClient();
+    confirmFn = (entry) => confirmDescribesChange(client, entry);
+  }
+
+  const result = await gateCandidates(candidates, { confirmFn });
+  for (const line of reportLines({ candidates, ...result })) console.log(line);
+
+  process.exit(0);
+}
+
+const isMainModule =
+  process.argv[1] && resolve(process.argv[1]) === resolve(fileURLToPath(import.meta.url));
+if (isMainModule) {
+  main().catch((err) => {
+    console.error(`Fatal error: ${err.message}`);
+    process.exit(1);
+  });
+}

--- a/scripts/mutate-1101.sh
+++ b/scripts/mutate-1101.sh
@@ -1,0 +1,239 @@
+#!/usr/bin/env bash
+set -u
+
+REPO="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$REPO" || exit 1
+
+GATE="scripts/change-gate.js"
+ROLLING="scripts/reverify-rolling.js"
+BACKUP_DIR="$(mktemp -d)"
+cp "$GATE" "$BACKUP_DIR/change-gate.js"
+cp "$ROLLING" "$BACKUP_DIR/reverify-rolling.js"
+
+restore() {
+  cp "$BACKUP_DIR/change-gate.js" "$GATE"
+  cp "$BACKUP_DIR/reverify-rolling.js" "$ROLLING"
+}
+trap restore EXIT
+
+killed=0
+survived=0
+
+run_mutation() {
+  local name="$1"
+  shift
+  echo "=== $name"
+  restore
+  "$@"
+  if timeout 300 node --test test/change-gate.test.ts > /tmp/mutate-1101-test.log 2>&1; then
+    echo "    SURVIVED"
+    survived=$((survived + 1))
+  else
+    echo "    KILLED: $(grep -c '✖' /tmp/mutate-1101-test.log) failing assertion(s)"
+    grep '✖ ' /tmp/mutate-1101-test.log | head -4
+    killed=$((killed + 1))
+  fi
+}
+
+m_never_rejects() {
+  python3 - <<'PY'
+import re
+p = "scripts/change-gate.js"
+s = open(p).read()
+s = s.replace("export function describesChange(entry) {", "export function describesChange(entry) {\n  return { ok: true };")
+open(p, "w").write(s)
+PY
+}
+
+m_null_comparison_ignored() {
+  python3 - <<'PY'
+p = "scripts/change-gate.js"
+s = open(p).read()
+s = s.replace("if (nulls.length > 0 && containsAll(current, previous)) {", "if (false && nulls.length > 0 && containsAll(current, previous)) {")
+open(p, "w").write(s)
+PY
+}
+
+m_null_comparison_ignores_dropped_quantity() {
+  python3 - <<'PY'
+p = "scripts/change-gate.js"
+s = open(p).read()
+s = s.replace("if (nulls.length > 0 && containsAll(current, previous)) {", "if (nulls.length > 0) {")
+open(p, "w").write(s)
+PY
+}
+
+m_operands_need_not_be_equal() {
+  python3 - <<'PY'
+p = "scripts/change-gate.js"
+s = open(p).read()
+s = s.replace("if (left !== undefined && right !== undefined && left === right) {", "if (left !== undefined && right !== undefined) {")
+open(p, "w").write(s)
+PY
+}
+
+m_operand_window_unbounded() {
+  python3 - <<'PY'
+p = "scripts/change-gate.js"
+s = open(p).read()
+s = s.replace("const OPERAND_WINDOW = 30;", "const OPERAND_WINDOW = 100000;")
+open(p, "w").write(s)
+PY
+}
+
+m_agreement_alone_rejects() {
+  python3 - <<'PY'
+p = "scripts/change-gate.js"
+s = open(p).read()
+s = s.replace(
+  "    QUANTITY_CHANGE_TYPES.includes(entry?.change_type) &&\n    assertsAgreement(entry?.summary) &&\n    multisetEqual(previous, current)",
+  "    assertsAgreement(entry?.summary)")
+open(p, "w").write(s)
+PY
+}
+
+m_agreement_ignores_change_type() {
+  python3 - <<'PY'
+p = "scripts/change-gate.js"
+s = open(p).read()
+s = s.replace("    QUANTITY_CHANGE_TYPES.includes(entry?.change_type) &&\n", "")
+open(p, "w").write(s)
+PY
+}
+
+m_equal_quantities_alone_rejects() {
+  python3 - <<'PY'
+p = "scripts/change-gate.js"
+s = open(p).read()
+s = s.replace("    assertsAgreement(entry?.summary) &&\n", "")
+open(p, "w").write(s)
+PY
+}
+
+m_quantities_ignore_thousands_separator() {
+  python3 - <<'PY'
+p = "scripts/change-gate.js"
+s = open(p).read()
+s = s.replace('const NUMBER = /\\d+(?:,\\d{3})*(?:\\.\\d+)?/g;', 'const NUMBER = /\\d+/g;')
+open(p, "w").write(s)
+PY
+}
+
+m_second_opinion_no_verdict_rejects() {
+  python3 - <<'PY'
+p = "scripts/change-gate.js"
+s = open(p).read()
+s = s.replace('if (confirmation.verdict === "no") {', 'if (confirmation.verdict !== "yes") {')
+open(p, "w").write(s)
+PY
+}
+
+m_second_opinion_error_drops_the_record() {
+  python3 - <<'PY'
+p = "scripts/change-gate.js"
+s = open(p).read()
+s = s.replace(
+  '      unchecked.push({ candidate, error: err.message });\n      accepted.push(candidate);\n      continue;',
+  '      unchecked.push({ candidate, error: err.message });\n      continue;')
+open(p, "w").write(s)
+PY
+}
+
+m_second_opinion_asked_before_the_first_layer() {
+  python3 - <<'PY'
+p = "scripts/change-gate.js"
+s = open(p).read()
+s = s.replace(
+  "    const verdict = describesChange(candidate);\n    if (!verdict.ok) {\n      rejected.push({ candidate, reason: verdict.reason, detail: verdict.detail });\n      continue;\n    }\n    if (!confirmFn) {",
+  "    const verdict = describesChange(candidate);\n    if (!confirmFn) {")
+s = s.replace(
+  "    if (confirmation.verdict === \"no\") {",
+  "    if (!verdict.ok) {\n      rejected.push({ candidate, reason: verdict.reason, detail: verdict.detail });\n      continue;\n    }\n    if (confirmation.verdict === \"no\") {")
+open(p, "w").write(s)
+PY
+}
+
+m_parse_accepts_any_shape() {
+  python3 - <<'PY'
+p = "scripts/change-gate.js"
+s = open(p).read()
+s = s.replace(
+  '    parsed && (parsed.change === "yes" || parsed.change === "no") ? parsed : null;',
+  '    parsed ? { change: parsed.change ?? "yes" } : null;')
+open(p, "w").write(s)
+PY
+}
+
+m_parse_drops_fence_stripping() {
+  python3 - <<'PY'
+p = "scripts/change-gate.js"
+s = open(p).read()
+s = s.replace(
+  '      ? raw.trim().replace(/^```(?:json)?\\s*/i, "").replace(/```$/, "").trim()',
+  '      ? raw.trim()')
+open(p, "w").write(s)
+PY
+}
+
+m_run_writes_the_rejected_candidates() {
+  python3 - <<'PY'
+p = "scripts/reverify-rolling.js"
+s = open(p).read()
+s = s.replace("const { appended, suppressed } = appendFn(accepted, {", "const { appended, suppressed } = appendFn(changes, {")
+open(p, "w").write(s)
+PY
+}
+
+m_summary_hides_the_rejections() {
+  python3 - <<'PY'
+p = "scripts/reverify-rolling.js"
+s = open(p).read()
+s = s.replace('    lines.push(`Rejected (no change described): ${(result.rejected ?? []).length}`);\n', "")
+open(p, "w").write(s)
+PY
+}
+
+m_summary_hides_the_unchecked() {
+  python3 - <<'PY'
+p = "scripts/reverify-rolling.js"
+s = open(p).read()
+s = s.replace('    lines.push(`Recorded without a second opinion: ${(result.unchecked ?? []).length}`);\n', "")
+open(p, "w").write(s)
+PY
+}
+
+m_url_mode_reports_rejections() {
+  python3 - <<'PY'
+p = "scripts/reverify-rolling.js"
+s = open(p).read()
+s = s.replace(
+  '  const lines = ["", "── Summary ──", `Checked: ${checked}`, `Verified (date bumped): ${result.verified}`];\n  if (useAi) {',
+  '  const lines = ["", "── Summary ──", `Checked: ${checked}`, `Verified (date bumped): ${result.verified}`];\n  lines.push(`Rejected (no change described): ${(result.rejected ?? []).length}`);\n  if (useAi) {')
+open(p, "w").write(s)
+PY
+}
+
+run_mutation "the gate never refuses anything" m_never_rejects
+run_mutation "an equal-valued comparison stops being read" m_null_comparison_ignored
+run_mutation "an equal-valued comparison refuses even when a stored figure vanished" m_null_comparison_ignores_dropped_quantity
+run_mutation "any comparison counts, equal-valued or not" m_operands_need_not_be_equal
+run_mutation "the comparison operands may sit anywhere in the summary" m_operand_window_unbounded
+run_mutation "an agreement phrase alone refuses the record" m_agreement_alone_rejects
+run_mutation "an agreement phrase refuses whatever the record claims changed" m_agreement_ignores_change_type
+run_mutation "matching figures alone refuse the record" m_equal_quantities_alone_rejects
+run_mutation "figures are read without their thousands separator" m_quantities_ignore_thousands_separator
+run_mutation "an unreadable second opinion refuses the record" m_second_opinion_no_verdict_rejects
+run_mutation "a second opinion that could not be asked drops the record" m_second_opinion_error_drops_the_record
+run_mutation "the second opinion is spent before the first layer runs" m_second_opinion_asked_before_the_first_layer
+run_mutation "any JSON object counts as a verdict" m_parse_accepts_any_shape
+run_mutation "a fenced verdict is no longer unwrapped" m_parse_drops_fence_stripping
+run_mutation "the run writes every candidate, refused or not" m_run_writes_the_rejected_candidates
+run_mutation "the run summary hides the refusals" m_summary_hides_the_rejections
+run_mutation "the run summary hides the records recorded unchecked" m_summary_hides_the_unchecked
+run_mutation "the mode that detects nothing reports refusals anyway" m_url_mode_reports_rejections
+
+restore
+
+echo
+echo "killed $killed, survived $survived"
+[ "$survived" -eq 0 ]

--- a/scripts/reverify-rolling.js
+++ b/scripts/reverify-rolling.js
@@ -21,6 +21,7 @@ import { fileURLToPath } from "node:url";
 import { reverifyBatch } from "./reverify.js";
 import { fetchPageText, verifyOfferAgainstPage, createVerifierClient, VERIFIER_MODEL } from "./verify-freshness.js";
 import { buildChangeEntry, appendChangeEntries } from "./change-log.js";
+import { gateCandidates, confirmDescribesChange } from "./change-gate.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const INDEX_PATH =
@@ -73,7 +74,7 @@ export async function runUrlMode(picked, data, dryRun, now, batchFn = reverifyBa
       flagged++;
     }
   }
-  return { verified, flagged, changed: 0, changes: [], recorded: [], suppressed: [], unclassified: [] };
+  return { verified, flagged, changed: 0, changes: [], recorded: [], suppressed: [], unclassified: [], rejected: [], unchecked: [] };
 }
 
 export async function runAiMode(picked, data, dryRun, now, options = {}) {
@@ -81,9 +82,11 @@ export async function runAiMode(picked, data, dryRun, now, options = {}) {
   const appendFn = options.appendFn ?? appendChangeEntries;
   const rateLimitMs = options.rateLimitMs ?? AI_RATE_LIMIT_MS;
   let verifyFn = options.verifyFn;
+  let confirmFn = options.confirmFn ?? null;
   if (!verifyFn) {
     const client = createVerifierClient();
     verifyFn = (offer, pageText) => verifyOfferAgainstPage(client, offer, pageText);
+    if (!confirmFn) confirmFn = (entry) => confirmDescribesChange(client, entry);
   }
 
   let verified = 0;
@@ -134,7 +137,15 @@ export async function runAiMode(picked, data, dryRun, now, options = {}) {
     await sleep(rateLimitMs);
   }
 
-  const { appended, suppressed } = appendFn(changes, {
+  const { accepted, rejected, unchecked } = await gateCandidates(changes, { confirmFn });
+  for (const { candidate, reason, detail } of rejected) {
+    console.log(`  ✗ ${candidate.vendor} (${candidate.change_type}) describes no change [${reason}]: ${detail}`);
+  }
+  for (const { candidate, error } of unchecked) {
+    console.log(`  ? ${candidate.vendor} (${candidate.change_type}) recorded without a second opinion: ${error}`);
+  }
+
+  const { appended, suppressed } = appendFn(accepted, {
     dryRun,
     windowDays: options.windowDays,
     path: options.changesPath,
@@ -143,7 +154,7 @@ export async function runAiMode(picked, data, dryRun, now, options = {}) {
     console.log(`  – ${candidate.vendor} (${candidate.change_type}) not recorded: ${reason}`);
   }
 
-  return { verified, flagged, changed, changes, recorded: appended, suppressed, unclassified };
+  return { verified, flagged, changed, changes, recorded: appended, suppressed, unclassified, rejected, unchecked };
 }
 
 export function repickWindowDays(total, batchSize) {
@@ -155,6 +166,8 @@ export function summaryLines(result, { useAi, checked, oldestRemaining, total })
   const lines = ["", "── Summary ──", `Checked: ${checked}`, `Verified (date bumped): ${result.verified}`];
   if (useAi) {
     lines.push(`Changed (PM review needed): ${result.changed}`);
+    lines.push(`Rejected (no change described): ${(result.rejected ?? []).length}`);
+    lines.push(`Recorded without a second opinion: ${(result.unchecked ?? []).length}`);
     lines.push(`Recorded to data/deal_changes.json: ${result.recorded.length}`);
     lines.push(`Already recorded, not written again: ${result.suppressed.length}`);
     lines.push(`Detected but not recordable: ${result.unclassified.length}`);

--- a/test/change-gate.test.ts
+++ b/test/change-gate.test.ts
@@ -1,0 +1,403 @@
+import { describe, it } from "node:test";
+import assert from "node:assert";
+import { readFileSync, writeFileSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+const {
+  describesChange,
+  gateCandidates,
+  nullComparisons,
+  assertsAgreement,
+  quantities,
+  parseConfirmation,
+  changeConfirmationPrompt,
+  REJECT_NULL_COMPARISON,
+  REJECT_STATES_NO_DIFFERENCE,
+  REJECT_CONFIRMED_UNCHANGED,
+} = await import("../scripts/change-gate.js");
+
+const { runAiMode, summaryLines } = await import("../scripts/reverify-rolling.js");
+
+const NOW = new Date("2026-08-28T09:00:00Z");
+
+const SAME_TERMS_EITHER_SIDE = {
+  vendor: "Abby",
+  change_type: "limits_reduced",
+  summary:
+    "The free tier now has 1 A/B test instead of 1, and the pricing is now explicitly stated as $12/month per project for the Starter tier (previously just 'scale at a fair price').",
+  previous_state:
+    "Open-Source feature flags & A/B testing. Configuration as Code & Fully Typed Typescript SDKs. Strong integration with Frameworks such as Next.js & React. Free plan: 1,000 events/month, 3 feature flags/remote configs, 1 A/B test, 5 environments.",
+  current_state:
+    "Free: 1,000 Events / month, 1 A/B Test, 3 Feature Flags / Remote Configs, 5 Environments. Starter: 1,000 Events / month, 1 A/B Test, 3 Feature Flags / Remote Configs, 5 Environments $12 /mo per Project",
+  impact: "medium",
+};
+
+const SUMMARY_SAYS_IT_MATCHES = {
+  vendor: "Cloudflare DNS",
+  change_type: "limits_reduced",
+  summary:
+    "The page confirms a free plan exists, but states a records-per-zone cap of 200 for zones created on or after 2024-09-01, while zones created before that date retain the legacy 1,000-record cap. This matches the stored deal info. However, the page also promotes add-ons that are paid, and the free plan is described as a foundational offering with the option to upgrade.",
+  previous_state:
+    "Free authoritative DNS hosting — unlimited zones and queries, DDoS protection, free SSL/TLS. Records-per-zone cap is 200 for zones created on or after 2024-09-01; zones created before that date retain the legacy 1,000-record cap.",
+  current_state:
+    "The free plan offers foundational security and performance. Records-per-zone is capped at 200 for zones created on or after 2024-09-01, and 1,000 for zones created before that date.",
+  impact: "medium",
+};
+
+const AGREES_ON_ONE_FIGURE_AND_DIFFERS_ON_ANOTHER = {
+  vendor: "Algolia",
+  change_type: "pricing_restructured",
+  summary:
+    "The 'Build' tier is no longer explicitly mentioned. The 'Grow' plan offers 10K search requests/month and 100K records included, which aligns with the stored information, but it's now a paid plan with overage fees. A 'Free' plan is available with 10K search requests/month and 50K records, but it has fewer features.",
+  previous_state:
+    "Search-as-a-service — 10K search requests/month, 1M records, AI recommendations included",
+  current_state:
+    "A 'Free' plan includes 10K search requests/month and 50K records. The 'Grow' plan includes 10K search requests /month and 100K records, with overages at $0.50/1K requests and $0.40/1K records.",
+  impact: "high",
+};
+
+const A_LIMIT_ACTUALLY_MOVED = {
+  vendor: "Deno Deploy",
+  change_type: "limits_reduced",
+  summary:
+    "Egress bandwidth for the free tier is now 20GiB, down from 100 GB. KV storage remains at 1 GiB, but the free tier now includes 1,000,000 KV read units and 500,000 KV write units. CPU time is now 10 hours, down from 15 hours. Revision storage is 10 GiB.",
+  previous_state:
+    "Edge runtime — 1M requests/month, 100 GB egress, 1 GiB KV storage, 450K KV reads/month, 15 hours CPU time/month",
+  current_state:
+    "Free tier includes 1M requests/month, 20GiB egress, 1 GiB KV storage, 1,000,000 KV read units/month, 500,000 KV write units/month, and 10 hr CPU time.",
+  impact: "high",
+};
+
+const A_DAILY_CAP_WAS_HALVED = {
+  vendor: "DB-IP",
+  change_type: "limits_reduced",
+  summary: "The free tier now has a limit of 500 daily requests, down from 1k.",
+  previous_state:
+    "Free IP geolocation API with 1k request per IP per day.lite database under the CC-BY 4.0 License is free too.",
+  current_state: "The Free API is limited to 500 daily requests.",
+  impact: "medium",
+};
+
+const A_RETENTION_WINDOW_SHRANK = {
+  vendor: "Sematext",
+  change_type: "limits_reduced",
+  summary: "The free tier now has a 1-day retention instead of 7, and is priced per host. The original deal had no per-host charges.",
+  previous_state:
+    "Observability platform — Logs: 500 MB/day ingestion, 7-day retention. Monitoring: 3 hosts, 3 containers/host, 30-min data retention, 1 alert rule. Volume-based pricing, no per-host charges on paid plans",
+  current_state: "Basic plan is available per host per month with 1 day retention.",
+  impact: "medium",
+};
+
+const A_FREE_PLAN_BECAME_A_TRIAL = {
+  vendor: "Middleware.io",
+  change_type: "free_tier_removed",
+  summary:
+    "The free tier now offers a 14-day free trial with unlimited data ingestion, instead of a 'free forever' plan with specific limits. The original limits of 100 GB/month data, 1,000 RUM sessions/month, 20,000 synthetic checks/month, and 14-day data retention are no longer offered as a permanent free tier.",
+  previous_state:
+    "Full-stack observability platform — free forever plan: 100 GB/month data (APM, logs, infrastructure, traces, RUM, synthetics, database, serverless), 1,000 RUM sessions/month, 20,000 synthetic checks/month, 14-day data retention, unlimited users",
+  current_state: "We provide 14 days free trial with unlimited data ingestion.",
+  impact: "high",
+};
+
+const THE_CHANGE_WORD_SITS_FAR_FROM_BOTH_FIGURES = {
+  vendor: "Farsplit",
+  change_type: "pricing_model_change",
+  summary:
+    "The free tier still lists 10 GB of storage. Billing is now monthly instead of annual, and the storage allowance of 10 GB is unchanged.",
+  previous_state: "Free tier: 10 GB storage, billed annually",
+  current_state: "Free tier: 10 GB storage, billed monthly",
+  impact: "medium",
+};
+
+const TWO_CAPS_TRADED_PLACES = {
+  vendor: "Swapstore",
+  change_type: "limits_reduced",
+  summary: "Bandwidth is now 10 GB and storage is now 100 GB — the two caps have traded places.",
+  previous_state: "Free tier: 100 GB bandwidth, 10 GB storage",
+  current_state: "Free tier: 10 GB bandwidth, 100 GB storage",
+  impact: "high",
+};
+
+const THE_SAME_CAP_WRITTEN_WITHOUT_ITS_SEPARATOR = {
+  vendor: "Commacount",
+  change_type: "limits_reduced",
+  summary: "The daily cap is now 1000 requests, down from 1,000.",
+  previous_state: "Free API: 1,000 requests per day",
+  current_state: "Free API: 1000 requests per day",
+  impact: "medium",
+};
+
+const RECORDS_THAT_DESCRIBE_A_REAL_CHANGE = [
+  AGREES_ON_ONE_FIGURE_AND_DIFFERS_ON_ANOTHER,
+  A_LIMIT_ACTUALLY_MOVED,
+  A_DAILY_CAP_WAS_HALVED,
+  A_RETENTION_WINDOW_SHRANK,
+  A_FREE_PLAN_BECAME_A_TRIAL,
+  THE_CHANGE_WORD_SITS_FAR_FROM_BOTH_FIGURES,
+  TWO_CAPS_TRADED_PLACES,
+];
+
+function tempLog(changes: unknown[]): string {
+  const dir = mkdtempSync(path.join(tmpdir(), "change-gate-"));
+  const file = path.join(dir, "deal_changes.json");
+  writeFileSync(file, JSON.stringify({ changes }, null, 2) + "\n");
+  return file;
+}
+
+describe("a recorded change must describe a change", () => {
+  describe("both sides of the comparison hold the same value", () => {
+    it("finds the equal pair the summary puts either side of a change word", () => {
+      const found = nullComparisons(SAME_TERMS_EITHER_SIDE.summary);
+      assert.strictEqual(found.length, 1);
+      assert.strictEqual(found[0].value, 1);
+      assert.strictEqual(found[0].connective, "instead of");
+    });
+
+    it("refuses the record whose free tier is unchanged on every figure", () => {
+      const verdict = describesChange(SAME_TERMS_EITHER_SIDE);
+      assert.strictEqual(verdict.ok, false);
+      assert.strictEqual(verdict.reason, REJECT_NULL_COMPARISON);
+    });
+
+    it("keeps a record whose change word separates two different values", () => {
+      assert.deepStrictEqual(nullComparisons(A_DAILY_CAP_WAS_HALVED.summary), []);
+      assert.strictEqual(describesChange(A_DAILY_CAP_WAS_HALVED).ok, true);
+    });
+
+    it("reads no pair across a change word with nothing numeric beside it", () => {
+      assert.deepStrictEqual(nullComparisons(A_FREE_PLAN_BECAME_A_TRIAL.summary), []);
+    });
+
+    it("pairs a change word only with the figures beside it", () => {
+      assert.deepStrictEqual(nullComparisons(THE_CHANGE_WORD_SITS_FAR_FROM_BOTH_FIGURES.summary), []);
+      assert.strictEqual(describesChange(THE_CHANGE_WORD_SITS_FAR_FROM_BOTH_FIGURES).ok, true);
+    });
+
+    it("refuses a cap restated with and without its thousands separator", () => {
+      const verdict = describesChange(THE_SAME_CAP_WRITTEN_WITHOUT_ITS_SEPARATOR);
+      assert.strictEqual(verdict.ok, false, "a cap of 1,000 and a cap of 1000 were read as different figures");
+      assert.strictEqual(verdict.reason, REJECT_NULL_COMPARISON);
+    });
+
+    it("keeps a record where the equal figure sits beside a figure that vanished", () => {
+      const droppedAlongside = {
+        ...SAME_TERMS_EITHER_SIDE,
+        current_state: "Free: 1 A/B Test, 3 Feature Flags, 5 Environments",
+      };
+      assert.deepStrictEqual(nullComparisons(droppedAlongside.summary).length, 1);
+      assert.strictEqual(describesChange(droppedAlongside).ok, true);
+    });
+  });
+
+  describe("the summary says the page agrees with what we stored", () => {
+    it("reads the agreement the summary states outright", () => {
+      assert.strictEqual(assertsAgreement(SUMMARY_SAYS_IT_MATCHES.summary), true);
+    });
+
+    it("refuses a reduced-limits record in which no figure moved", () => {
+      const verdict = describesChange(SUMMARY_SAYS_IT_MATCHES);
+      assert.strictEqual(verdict.ok, false);
+      assert.strictEqual(verdict.reason, REJECT_STATES_NO_DIFFERENCE);
+    });
+
+    it("keeps a record that agrees on one figure and differs on another", () => {
+      assert.strictEqual(assertsAgreement(AGREES_ON_ONE_FIGURE_AND_DIFFERS_ON_ANOTHER.summary), true);
+      assert.strictEqual(describesChange(AGREES_ON_ONE_FIGURE_AND_DIFFERS_ON_ANOTHER).ok, true);
+    });
+
+    it("keeps a reduced-limits record whose caps traded places rather than agreeing", () => {
+      assert.deepStrictEqual(
+        quantities(TWO_CAPS_TRADED_PLACES.previous_state).sort(),
+        quantities(TWO_CAPS_TRADED_PLACES.current_state).sort()
+      );
+      assert.strictEqual(assertsAgreement(TWO_CAPS_TRADED_PLACES.summary), false);
+      assert.strictEqual(describesChange(TWO_CAPS_TRADED_PLACES).ok, true);
+    });
+
+    it("keeps a record whose figures match but whose type is not a claim about figures", () => {
+      const notAQuantityClaim = { ...SUMMARY_SAYS_IT_MATCHES, change_type: "rebranded" };
+      assert.strictEqual(describesChange(notAQuantityClaim).ok, true);
+    });
+
+    it("reads the same figures on both sides of the record it refuses", () => {
+      assert.deepStrictEqual(
+        quantities(SUMMARY_SAYS_IT_MATCHES.previous_state).sort(),
+        quantities(SUMMARY_SAYS_IT_MATCHES.current_state).sort()
+      );
+    });
+  });
+
+  describe("records that describe a real change survive the gate", () => {
+    for (const record of RECORDS_THAT_DESCRIBE_A_REAL_CHANGE) {
+      it(`keeps the ${record.vendor} record`, () => {
+        const verdict = describesChange(record);
+        assert.strictEqual(verdict.ok, true, `${record.vendor} was refused as ${verdict.reason}`);
+      });
+    }
+
+    it("refuses exactly the two records that describe nothing", async () => {
+      const all = [SAME_TERMS_EITHER_SIDE, SUMMARY_SAYS_IT_MATCHES, ...RECORDS_THAT_DESCRIBE_A_REAL_CHANGE];
+      const { accepted, rejected } = await gateCandidates(all);
+      assert.deepStrictEqual(rejected.map((r: any) => r.candidate.vendor), ["Abby", "Cloudflare DNS"]);
+      assert.strictEqual(accepted.length, RECORDS_THAT_DESCRIBE_A_REAL_CHANGE.length);
+    });
+  });
+});
+
+describe("the second opinion on whether a report describes a change", () => {
+  it("asks about the report rather than about the vendor", () => {
+    const prompt = changeConfirmationPrompt(SUMMARY_SAYS_IT_MATCHES);
+    assert.ok(prompt.includes(SUMMARY_SAYS_IT_MATCHES.previous_state));
+    assert.ok(prompt.includes(SUMMARY_SAYS_IT_MATCHES.current_state));
+    assert.ok(prompt.includes(SUMMARY_SAYS_IT_MATCHES.summary));
+  });
+
+  it("reads a bare verdict", () => {
+    assert.deepStrictEqual(parseConfirmation('{"change":"yes"}'), { verdict: "yes", reason: null });
+  });
+
+  it("reads a verdict wrapped in a code fence around an object the loose match cannot read", () => {
+    const fenced = '```json\n{"change":"no","meta":{"k":1},"reason":"same terms"}\n```';
+    assert.deepStrictEqual(parseConfirmation(fenced), { verdict: "no", reason: "same terms" });
+  });
+
+  it("reads a verdict a sentence has been wrapped around", () => {
+    assert.deepStrictEqual(parseConfirmation('Here you go: {"change":"no"} — hope that helps'), {
+      verdict: "no",
+      reason: null,
+    });
+  });
+
+  it("returns no verdict rather than a guess when the answer is prose", () => {
+    assert.strictEqual(parseConfirmation("I think the terms are basically the same").verdict, "unparsed");
+  });
+
+  it("returns no verdict for a shape that answers a different question", () => {
+    assert.strictEqual(parseConfirmation('{"status":"confirmed"}').verdict, "unparsed");
+  });
+
+  it("refuses a record the second opinion calls unchanged", async () => {
+    const { accepted, rejected } = await gateCandidates([A_LIMIT_ACTUALLY_MOVED], {
+      confirmFn: async () => ({ verdict: "no", reason: "the page restates the stored terms" }),
+    });
+    assert.strictEqual(accepted.length, 0);
+    assert.strictEqual(rejected[0].reason, REJECT_CONFIRMED_UNCHANGED);
+    assert.strictEqual(rejected[0].detail, "the page restates the stored terms");
+  });
+
+  it("keeps a record the second opinion calls changed", async () => {
+    const { accepted, rejected, unchecked } = await gateCandidates([A_LIMIT_ACTUALLY_MOVED], {
+      confirmFn: async () => ({ verdict: "yes", reason: null }),
+    });
+    assert.strictEqual(accepted.length, 1);
+    assert.strictEqual(rejected.length, 0);
+    assert.strictEqual(unchecked.length, 0);
+  });
+
+  it("holds a record the second opinion could not be asked about, and says so", async () => {
+    const { accepted, unchecked } = await gateCandidates([A_LIMIT_ACTUALLY_MOVED], {
+      confirmFn: async () => {
+        throw new Error("HTTP 503");
+      },
+    });
+    assert.strictEqual(accepted.length, 1);
+    assert.strictEqual(unchecked.length, 1);
+    assert.strictEqual(unchecked[0].error, "HTTP 503");
+  });
+
+  it("holds a record whose second opinion came back unreadable, and says so", async () => {
+    const { accepted, unchecked } = await gateCandidates([A_LIMIT_ACTUALLY_MOVED], {
+      confirmFn: async () => ({ verdict: "unparsed", reason: null }),
+    });
+    assert.strictEqual(accepted.length, 1);
+    assert.strictEqual(unchecked.length, 1);
+  });
+
+  it("spends no second opinion on a record the first layer already refused", async () => {
+    let asked = 0;
+    await gateCandidates([SAME_TERMS_EITHER_SIDE], {
+      confirmFn: async () => {
+        asked++;
+        return { verdict: "yes", reason: null };
+      },
+    });
+    assert.strictEqual(asked, 0);
+  });
+});
+
+describe("the run does not write a change the gate refused", () => {
+  const offer = {
+    vendor: "Abby",
+    category: "Feature Flags",
+    tier: "Free",
+    description: SAME_TERMS_EITHER_SIDE.previous_state,
+    url: "https://abby.example/pricing",
+    verifiedDate: "2026-01-01",
+  };
+  const picked = [{ index: 0, offer }];
+  const fetchFn = async () => ({ ok: true, text: SAME_TERMS_EITHER_SIDE.current_state });
+  const detection = {
+    status: "changed",
+    summary: SAME_TERMS_EITHER_SIDE.summary,
+    change_type: SAME_TERMS_EITHER_SIDE.change_type,
+    current_state: SAME_TERMS_EITHER_SIDE.current_state,
+    impact: "medium",
+  };
+
+  it("leaves the change log empty", async () => {
+    const file = tempLog([]);
+    const data = { offers: [{ ...offer }] };
+    const result = await runAiMode(picked, data, false, NOW, {
+      fetchFn,
+      verifyFn: async () => detection,
+      rateLimitMs: 0,
+      changesPath: file,
+    });
+    assert.strictEqual(result.changed, 1);
+    assert.strictEqual(result.recorded.length, 0);
+    assert.strictEqual(result.rejected.length, 1);
+    assert.strictEqual(result.rejected[0].reason, REJECT_NULL_COMPARISON);
+    const written = JSON.parse(readFileSync(file, "utf-8"));
+    assert.strictEqual(written.changes.length, 0);
+    rmSync(path.dirname(file), { recursive: true, force: true });
+  });
+
+  it("still writes a change that describes one", async () => {
+    const movedOffer = { ...offer, vendor: "Deno Deploy", description: A_LIMIT_ACTUALLY_MOVED.previous_state };
+    const file = tempLog([]);
+    const data = { offers: [{ ...movedOffer }] };
+    const result = await runAiMode([{ index: 0, offer: movedOffer }], data, false, NOW, {
+      fetchFn,
+      verifyFn: async () => ({
+        status: "changed",
+        summary: A_LIMIT_ACTUALLY_MOVED.summary,
+        change_type: A_LIMIT_ACTUALLY_MOVED.change_type,
+        current_state: A_LIMIT_ACTUALLY_MOVED.current_state,
+        impact: "high",
+      }),
+      rateLimitMs: 0,
+      changesPath: file,
+    });
+    assert.strictEqual(result.recorded.length, 1);
+    assert.strictEqual(result.rejected.length, 0);
+    rmSync(path.dirname(file), { recursive: true, force: true });
+  });
+
+  it("counts the refusals in the run summary", () => {
+    const lines = summaryLines(
+      { verified: 3, flagged: 1, changed: 4, recorded: [{}, {}], suppressed: [], unclassified: [], rejected: [{}, {}], unchecked: [{}] },
+      { useAi: true, checked: 8, oldestRemaining: "2026-01-01", total: 100 }
+    );
+    assert.ok(lines.includes("Rejected (no change described): 2"), lines.join("\n"));
+    assert.ok(lines.includes("Recorded without a second opinion: 1"), lines.join("\n"));
+  });
+
+  it("reports no refusals for a mode that cannot detect a change", () => {
+    const lines = summaryLines(
+      { verified: 3, flagged: 1, changed: 0, recorded: [], suppressed: [], unclassified: [], rejected: [], unchecked: [] },
+      { useAi: false, checked: 4, oldestRemaining: "2026-01-01", total: 100 }
+    );
+    assert.ok(!lines.some((l: string) => l.startsWith("Rejected")), lines.join("\n"));
+  });
+});


### PR DESCRIPTION
Refs #1101

Two of the detector's first 19 records describe no change, and both were public within seven minutes of the run. Nothing between the model's answer and `data/deal_changes.json` asked whether the answer described a change at all.

## The gate

Two layers in `scripts/change-gate.js`, both of which must pass.

**Layer 1 — deterministic, no credential.**

- `null_comparison`: the summary states a change between two *equal* quantities and no stored quantity is missing from the current state. Abby — `1 A/B test instead of 1`.
- `states_no_difference`: a `limits_reduced`/`limits_increased` claim whose summary asserts the page matches what we stored **and** whose two states carry the same figures. Cloudflare DNS — `200`, `2024-09-01` and `1,000` on both sides.

The second rule needs all three conditions because either of the first two alone is too blunt, and the counterexample is in the same batch: Algolia's summary also says "which aligns with the stored information", as a subordinate clause, before naming a records cap that moved from 1M to 50K. A test pins that Algolia survives.

**Layer 2 — one model call per surviving candidate**, asked only whether the report describes a change. A candidate layer 1 already refused is never sent. It **fails open**: an error or an unreadable answer keeps the record and counts it as `Recorded without a second opinion: N`.

## Acceptance criteria

- **AC-1** — the Abby record is refused, and a test feeds it through `runAiMode` and asserts the log stays empty. Layer 1 recognises two specific shapes of "the two states describe the same terms"; layer 2 is what generalises it. Said so on the issue rather than claim more.
- **AC-2** — the Cloudflare DNS record is refused deterministically, and layer 2 covers the same class where the figures differ.
- **AC-3** — `Rejected (no change described): N` in the run summary, plus `Recorded without a second opinion: N` so an unreachable endpoint is visible rather than silent.
- **AC-4** — both records removed. `data/deal_changes.json` 308 → 306, `npm run validate` passes, and `/vendor/cloudflare-dns` and `/vendor/abby` render `Pricing Change History (0 recorded)` locally.
- **AC-5** — reported on the issue: the gate drops exactly those two and keeps the other 17. Nothing else removed. Four records it keeps that I would not defend are named there for you rather than gated unilaterally.

## Verification

`scripts/e2e-1101.mjs` runs the whole path against a stub endpoint: a real change is recorded, a null-comparison record is refused by layer 1 and never reaches the model, and a record only layer 2 can catch is refused by it — 3 page readings, 2 second opinions, 1 record written.

`scripts/gate-report.js` replays the gate over records already in the log. `.github/workflows/gate-audit.yml` runs it with `--confirm` where the credential lives, since `OPENROUTER_API_KEY` cannot be read out of GitHub into my container. The layer-2 verdicts on the 17 will be posted to the issue once this merges.

2103 tests, 0 failures. **18 of 18 mutations killed** (`scripts/mutate-1101.sh`). Three survived the first pass — the operand-adjacency window, the agreement phrase in rule 2, and reading `1,000` as one figure rather than two — and each was a missing fixture rather than a redundant rule.

Blocks #1103, whose AC-2 gates on this.