### PR TITLE
Run the test suite on every pull request and every push to main

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,7 +22,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: "24"
+          node-version: ">=24.20.0"
           cache: "npm"
 
       - name: Install dependencies

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,7 +22,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: ">=24.20.0"
+          node-version: "24.20.0"
           cache: "npm"
 
       - name: Install dependencies

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,35 @@
+name: Tests
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+concurrency:
+  group: tests-${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Test
+        run: npm test

--- a/test/ci-signal-demonstration.test.ts
+++ b/test/ci-signal-demonstration.test.ts
@@ -1,0 +1,8 @@
+import { describe, it } from "node:test";
+import assert from "node:assert";
+
+describe("the check this workflow is meant to produce", () => {
+  it("fails on purpose so the pull request shows a red check", () => {
+    assert.strictEqual(1, 2, "this test exists only to prove a failing suite blocks nothing silently, and is removed in the next commit");
+  });
+});

--- a/test/ci-signal-demonstration.test.ts
+++ b/test/ci-signal-demonstration.test.ts
@@ -1,8 +1,0 @@
-import { describe, it } from "node:test";
-import assert from "node:assert";
-
-describe("the check this workflow is meant to produce", () => {
-  it("fails on purpose so the pull request shows a red check", () => {
-    assert.strictEqual(1, 2, "this test exists only to prove a failing suite blocks nothing silently, and is removed in the next commit");
-  });
-});

--- a/test/referral-attribution.test.ts
+++ b/test/referral-attribution.test.ts
@@ -139,10 +139,10 @@ describe("Attribution Logic", () => {
   });
 
   it("vendor matching is case-insensitive", () => {
-    const now = new Date();
     logReferralRequest({ agent_id: "agent_1", vendor: "Railway", referral_code: "C1", referral_url: "http://u1" });
+    const now = new Date();
     const result = attributeConversion("railway", now);
-    assert.strictEqual(result, "agent_1");
+    assert.strictEqual(result, "agent_1", "a request logged in the millisecond after the conversion date is not attributed");
   });
 
   it("does not attribute requests after the conversion date", () => {


### PR DESCRIPTION
Refs #1094

`.github/workflows/tests.yml` runs `npm ci`, `npm run build` and `npm test` on `pull_request` and on `push` to `main`.

**AC-2 evidence is in this PR's own history.** The first commit deliberately includes a failing test so the check goes red; the second removes it. Both runs are linked from the issue.

**Node 24, not 20.** The four existing data workflows pin `node-version: "20"` and that is correct for them — they run `.js` and `.mjs` scripts. The suite cannot run there: `npm test` is `node --test --test-concurrency 1 test/**/*.test.ts`, which needs both TypeScript type-stripping and glob expansion inside the test runner, neither of which Node 20 has. Nothing in the four existing workflows is touched (AC-4).

Runtime reported on the issue (AC-3).