### PR TITLE
Withhold a stability judgement where we could not read the cited page

### DIFF
--- a/scripts/bare-root-pricing-audit.js
+++ b/scripts/bare-root-pricing-audit.js
@@ -9,9 +9,14 @@
  * established by fetching candidates and looking for price text, not by
  * status code.
  *
+ * The same question is worth asking of any population whose stored URL reads
+ * badly, not only of the bare roots, so --outcome selects the offers by the
+ * verdict their own cited page earned instead.
+ *
  * Usage:
  *   node scripts/bare-root-pricing-audit.js                  # every bare-root offer
  *   node scripts/bare-root-pricing-audit.js --limit 40       # first 40 only
+ *   node scripts/bare-root-pricing-audit.js --outcome unreadable
  *   node scripts/bare-root-pricing-audit.js --out /tmp/x.json
  */
 
@@ -102,12 +107,19 @@ async function main() {
   const limit = limitIdx !== -1 ? parseInt(args[limitIdx + 1], 10) : Infinity;
   const outIdx = args.indexOf("--out");
   const out = outIdx !== -1 ? args[outIdx + 1] : null;
+  const outcomeIdx = args.indexOf("--outcome");
+  const outcome = outcomeIdx !== -1 ? args[outcomeIdx + 1] : null;
 
   const data = JSON.parse(readFileSync(INDEX_PATH, "utf-8"));
-  const offers = (data.offers || []).filter((o) => isBareRoot(o.url));
+  const all = data.offers || [];
+  const offers = outcome
+    ? all.filter((o) => o.source_check?.outcome === outcome)
+    : all.filter((o) => isBareRoot(o.url));
   const subject = offers.slice(0, limit);
 
-  console.log(`Bare-root offers: ${offers.length} of ${(data.offers || []).length}`);
+  console.log(
+    `${outcome ? `Offers whose cited page came back ${outcome}` : "Bare-root offers"}: ${offers.length} of ${all.length}`
+  );
   console.log(`Reading ${subject.length} of them, ${1 + CANDIDATE_PATHS.length} URLs each`);
   console.log("");
 
@@ -126,7 +138,7 @@ async function main() {
   const stats = summarise(audits);
   console.log("");
   console.log("── Summary ──");
-  console.log(`Bare-root offers read: ${stats.total}`);
+  console.log(`Offers read: ${stats.total}`);
   console.log(`Stored root itself carries price text: ${stats.rootPriced}`);
   console.log(`A candidate pricing page carries price text: ${stats.candidatePriced}`);
   console.log(`A candidate pricing page is readable but carries none: ${stats.candidateReadableNoPricing}`);

--- a/scripts/mutate-1109.sh
+++ b/scripts/mutate-1109.sh
@@ -223,7 +223,7 @@ m_empty_history_reads_as_good_news() {
   py <<'PY'
 p = "src/serve.ts"
 s = open(p).read()
-s = s.replace('  }).join("\\n") : sourceDoesNotNameVendor(primary)', '  }).join("\\n") : false')
+s = s.replace('  }).join("\\n") : levelWithheld', '  }).join("\\n") : false')
 open(p, "w").write(s)
 PY
 }
@@ -232,7 +232,7 @@ m_hero_keeps_its_verdict() {
   py <<'PY2'
 p = "src/serve.ts"
 s = open(p).read()
-s = s.replace("    : sourceDoesNotNameVendor(primary)\n    ? `The page we cite for it does not name it, so we cannot confirm these terms today.`\n", "")
+s = s.replace("  const verdictLine2 = levelWithheld", "  const verdictLine2 = false")
 open(p, "w").write(s)
 PY2
 }
@@ -241,7 +241,7 @@ m_table_keeps_its_value() {
   py <<'PY2'
 p = "src/serve.ts"
 s = open(p).read()
-s = s.replace("  if (offer && sourceDoesNotNameVendor(offer)) {", "  if (false) {")
+s = s.replace("  const withheld = offer ? levelWithheldReason(offer, null) : null;", "  const withheld = null;")
 open(p, "w").write(s)
 PY2
 }
@@ -250,7 +250,7 @@ m_faq_keeps_its_answer() {
   py <<'PY2'
 p = "src/serve.ts"
 s = open(p).read()
-s = s.replace("    : sourceDoesNotNameVendor(primary)\n    ? `We cannot say. The page we cite for this offer does not name ${vendorName}, so nothing we have read describes these terms, and we are not publishing a stability judgement for this vendor until that is fixed.`\n", "")
+s = s.replace("  const faqReliableAnswer = levelWithheld", "  const faqReliableAnswer = false")
 open(p, "w").write(s)
 PY2
 }
@@ -259,7 +259,7 @@ m_level_published_anyway() {
   py <<'PY'
 p = "src/source-check.ts"
 s = open(p).read()
-s = s.replace("  return Boolean(linkUnreachable) || sourceDoesNotNameVendor(offer);", "  return Boolean(linkUnreachable);")
+s = s.replace("  return levelWithheldReason(offer, linkUnreachable) !== null;", "  return Boolean(linkUnreachable);")
 open(p, "w").write(s)
 PY
 }
@@ -269,7 +269,7 @@ m_thin_page_also_withholds_the_level() {
 p = "src/source-check.ts"
 s = open(p).read()
 s = s.replace('  return offer.source_check?.outcome === "does_not_name_vendor";',
-              '  return Boolean(offer.source_check) && offer.source_check.outcome !== "ok";')
+              '  return offer.source_check ? offer.source_check.outcome !== "ok" : false;')
 open(p, "w").write(s)
 PY
 }

--- a/scripts/mutate-1113.sh
+++ b/scripts/mutate-1113.sh
@@ -1,0 +1,225 @@
+#!/usr/bin/env bash
+#
+# Mutation testing for the rule that withholds a stability judgement when we
+# could not read the page a record cites.
+#
+# Each mutation breaks one property the change is supposed to hold, rebuilds,
+# and runs the tests that claim to pin it. A surviving mutation means no test
+# is asserting that property. A mutation that changes no file proves nothing
+# and is reported as a survivor rather than silently passing.
+#
+# Usage:
+#   bash scripts/mutate-1113.sh
+#
+set -u
+
+REPO="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$REPO" || exit 1
+
+SOURCE="src/source-check.ts"
+SERVE="src/serve.ts"
+DATA="src/data.ts"
+BACKUP_DIR="$(mktemp -d)"
+cp "$SOURCE" "$BACKUP_DIR/source-check.ts"
+cp "$SERVE" "$BACKUP_DIR/serve.ts"
+cp "$DATA" "$BACKUP_DIR/data.ts"
+
+restore() {
+  cp "$BACKUP_DIR/source-check.ts" "$SOURCE"
+  cp "$BACKUP_DIR/serve.ts" "$SERVE"
+  cp "$BACKUP_DIR/data.ts" "$DATA"
+  npx tsc > /dev/null 2>&1
+}
+trap restore EXIT
+
+killed=0
+survived=0
+TESTS="test/source-check.test.ts test/source-check-pages.test.ts test/enrich.test.ts test/link-liveness-pages.test.ts"
+
+run_mutation() {
+  local name="$1"
+  shift
+  echo "=== $name"
+  restore
+  "$@"
+  local changed=0
+  for f in "$SOURCE" "$SERVE" "$DATA"; do
+    diff -q "$BACKUP_DIR/$(basename "$f")" "$f" > /dev/null || changed=1
+  done
+  if [ "$changed" -eq 0 ]; then
+    echo "    NOT APPLIED: the mutation changed no file, so it proves nothing"
+    survived=$((survived + 1))
+    return
+  fi
+  if ! npx tsc > /tmp/mutate-1113-build.log 2>&1; then
+    echo "    KILLED: does not compile"
+    killed=$((killed + 1))
+    return
+  fi
+  if timeout 600 node --test $TESTS > /tmp/mutate-1113-test.log 2>&1; then
+    echo "    SURVIVED"
+    survived=$((survived + 1))
+  else
+    echo "    KILLED: $(grep -c '✖ ' /tmp/mutate-1113-test.log) failing assertion(s)"
+    grep '✖ ' /tmp/mutate-1113-test.log | head -4
+    killed=$((killed + 1))
+  fi
+}
+
+py() { python3 - "$@"; }
+
+m_unreadable_no_longer_withholds() {
+  py <<'PY'
+p = "src/source-check.ts"
+s = open(p).read()
+s = s.replace('  "does_not_name_vendor",\n  "unreadable",\n];', '  "does_not_name_vendor",\n];')
+open(p, "w").write(s)
+PY
+}
+
+m_thin_page_also_withholds() {
+  py <<'PY'
+p = "src/source-check.ts"
+s = open(p).read()
+s = s.replace('  "does_not_name_vendor",\n  "unreadable",\n];',
+              '  "does_not_name_vendor",\n  "unreadable",\n  "states_no_terms",\n];')
+open(p, "w").write(s)
+PY
+}
+
+m_every_outcome_withholds() {
+  py <<'PY'
+p = "src/source-check.ts"
+s = open(p).read()
+s = s.replace('  if (outcome && LEVEL_WITHHOLDING_OUTCOMES.includes(outcome)) return outcome as LevelWithheldReason;',
+              '  if (outcome) return outcome as LevelWithheldReason;')
+open(p, "w").write(s)
+PY
+}
+
+m_reason_collapses_to_one() {
+  py <<'PY'
+p = "src/source-check.ts"
+s = open(p).read()
+s = s.replace('  if (outcome && LEVEL_WITHHOLDING_OUTCOMES.includes(outcome)) return outcome as LevelWithheldReason;',
+              '  if (outcome && LEVEL_WITHHOLDING_OUTCOMES.includes(outcome)) return "does_not_name_vendor";')
+open(p, "w").write(s)
+PY
+}
+
+m_dead_link_loses_its_precedence() {
+  py <<'PY'
+p = "src/source-check.ts"
+s = open(p).read()
+s = s.replace('  if (linkUnreachable) return "link_unreachable";\n  const outcome = offer.source_check?.outcome;',
+              '  const outcome = offer.source_check?.outcome;')
+s = s.replace('  if (outcome && LEVEL_WITHHOLDING_OUTCOMES.includes(outcome)) return outcome as LevelWithheldReason;\n  return null;',
+              '  if (outcome && LEVEL_WITHHOLDING_OUTCOMES.includes(outcome)) return outcome as LevelWithheldReason;\n  if (linkUnreachable) return "link_unreachable";\n  return null;')
+open(p, "w").write(s)
+PY
+}
+
+m_clause_does_not_distinguish() {
+  py <<'PY'
+p = "src/serve.ts"
+s = open(p).read()
+s = s.replace('  return `we could not read the page we cite for this offer`;',
+              '  return `the page we cite for this offer does not name it`;')
+open(p, "w").write(s)
+PY
+}
+
+m_sentence_does_not_distinguish() {
+  py <<'PY'
+p = "src/serve.ts"
+s = open(p).read()
+s = s.replace('  return `We could not read the page we cite for ${vendorName}.`;',
+              '  return `The page we cite for ${vendorName} does not name it.`;')
+open(p, "w").write(s)
+PY
+}
+
+m_table_keeps_its_value() {
+  py <<'PY'
+p = "src/serve.ts"
+s = open(p).read()
+s = s.replace("  const withheld = offer ? levelWithheldReason(offer, null) : null;", "  const withheld = null;")
+open(p, "w").write(s)
+PY
+}
+
+m_hero_keeps_its_verdict() {
+  py <<'PY'
+p = "src/serve.ts"
+s = open(p).read()
+s = s.replace("  const verdictLine2 = levelWithheld", "  const verdictLine2 = false")
+open(p, "w").write(s)
+PY
+}
+
+m_empty_history_reads_as_good_news() {
+  py <<'PY'
+p = "src/serve.ts"
+s = open(p).read()
+s = s.replace("${escHtmlServer(vendorName)} — but ${escHtmlServer(withheldClause)}, so nothing we have read describes these terms.",
+              "${escHtmlServer(vendorName)}. This is a good sign — stable pricing.")
+open(p, "w").write(s)
+PY
+}
+
+m_faq_keeps_its_answer() {
+  py <<'PY'
+p = "src/serve.ts"
+s = open(p).read()
+s = s.replace("`We cannot say. ${withheldLevelSentence(levelWithheld, vendorName, unconfirmableSince)} Nothing we have read describes these terms, so we are not publishing a stability judgement for this vendor until that is fixed.`",
+              "`${vendorName} is considered stable: we hold no free tier removal on record.`")
+open(p, "w").write(s)
+PY
+}
+
+m_change_answer_keeps_its_positive_signal() {
+  py <<'PY'
+p = "src/serve.ts"
+s = open(p).read()
+s = s.replace("    : levelWithheld\n    ? `We hold no recorded pricing changes for ${vendorName}, but ${withheldClause}, so that is a statement about our records rather than a positive signal.`\n", "")
+open(p, "w").write(s)
+PY
+}
+
+m_tool_result_claims_a_stable_history() {
+  py <<'PY'
+p = "src/data.ts"
+s = open(p).read()
+s = s.replace("  } else if (sourceUnreadable(offer)) {", "  } else if (false) {")
+open(p, "w").write(s)
+PY
+}
+
+m_unreadable_predicate_matches_anything() {
+  py <<'PY'
+p = "src/source-check.ts"
+s = open(p).read()
+s = s.replace('  return offer.source_check?.outcome === "unreadable";',
+              '  return offer.source_check ? offer.source_check.outcome !== "ok" : false;')
+open(p, "w").write(s)
+PY
+}
+
+run_mutation "a page we could not read no longer withholds the level" m_unreadable_no_longer_withholds
+run_mutation "a page stating no terms also withholds the level" m_thin_page_also_withholds
+run_mutation "every non-ok outcome withholds the level" m_every_outcome_withholds
+run_mutation "both withheld reasons report as the same reason" m_reason_collapses_to_one
+run_mutation "a dead link loses its precedence over the page check" m_dead_link_loses_its_precedence
+run_mutation "the withheld clause does not distinguish the reasons" m_clause_does_not_distinguish
+run_mutation "the withheld sentence does not distinguish the reasons" m_sentence_does_not_distinguish
+run_mutation "the comparison table still prints a stability value" m_table_keeps_its_value
+run_mutation "the hero still opens with a stability verdict" m_hero_keeps_its_verdict
+run_mutation "the page still calls an empty history good news" m_empty_history_reads_as_good_news
+run_mutation "the reliability answer still calls it stable" m_faq_keeps_its_answer
+run_mutation "the change answer still reads as a positive signal" m_change_answer_keeps_its_positive_signal
+run_mutation "the tool result still claims a stable history" m_tool_result_claims_a_stable_history
+run_mutation "the unread-page predicate matches any imperfect check" m_unreadable_predicate_matches_anything
+
+echo ""
+echo "killed=$killed survived=$survived"
+[ "$survived" -eq 0 ]

--- a/src/data.ts
+++ b/src/data.ts
@@ -5,7 +5,7 @@ import type { Offer, EnrichedOffer, OfferIndex, DealChange, DealChangesIndex, Ch
 import { isUrlSuspended } from "./referral-health.js";
 import { rankForListing } from "./ranking.js";
 import { unreachableNoticeForUrl, resetLinkHealthCache } from "./link-health.js";
-import { cannotVouchForLevel, sourceDoesNotNameVendor } from "./source-check.js";
+import { cannotVouchForLevel, sourceDoesNotNameVendor, sourceUnreadable } from "./source-check.js";
 import { filterAlternatives } from "./product-role.js";
 import { DATE_SOURCES, isEventDated, changeDateClause } from "./change-dates.js";
 
@@ -784,6 +784,8 @@ export function checkVendorRisk(
     summary = `We hold no free tier removal, limit reduction or pricing restructure on record for ${offer.vendor}.${unreachableClause} Treat that as a statement about our records, not as a stable pricing history.`;
   } else if (sourceDoesNotNameVendor(offer)) {
     summary = `We hold no free tier removal, limit reduction or pricing restructure on record for ${offer.vendor}. The page we cite for it does not name it, so nothing we have read describes this offer. Treat that as a statement about our records, not as a stable pricing history.`;
+  } else if (sourceUnreadable(offer)) {
+    summary = `We hold no free tier removal, limit reduction or pricing restructure on record for ${offer.vendor}. We could not read the page we cite for it, so nothing we have read describes this offer. Treat that as a statement about our records, not as a stable pricing history.`;
   } else {
     summary = `${offer.vendor} has a stable pricing history with no free tier removal, limit reduction or pricing restructure on record. Free tier verified for ${longevityDays} days.`;
   }

--- a/src/serve.ts
+++ b/src/serve.ts
@@ -16,7 +16,7 @@ import { buildDailyRollup, readRollups, coverageOf, ROLLUP_DATE_PATTERN } from "
 import { configureVendorSeries, recordVendorRequest, flushVendorSeries, readVendorSeries, vendorSeriesGauge, vendorExportAuthorized, isSeriesDate, seriesDateRange, VENDOR_SERIES_PATH, VENDOR_SERIES_RETENTION_DAYS, VENDOR_SERIES_NOTES } from "./vendor-series.js";
 import { openapiSpec } from "./openapi.js";
 import { LINK_GRACE_DAYS } from "./link-health.js";
-import { sourceDoesNotNameVendor } from "./source-check.js";
+import { levelWithheldReason, type LevelWithheldReason } from "./source-check.js";
 import { registerAgent, authenticateRequest, validateVestauthUrl, hashApiKey, updateAgentX402Address, getAgentById } from "./agents.js";
 import { logReferralRequest } from "./referral-requests.js";
 import { recordConversion, confirmEligibleEntries, clawbackEntry, getAgentBalance, getAgentLedgerEntries, recordPayout, MINIMUM_PAYOUT_AMOUNT, getLeaderboard } from "./ledger.js";
@@ -478,13 +478,27 @@ function riskBadgeHtml(
   return `${badge} <span style="font-size:${size};color:var(--text-dim)" title="${escHtmlServer(cause.summary)}">${escHtmlServer(riskCauseLabel(cause))}</span>`;
 }
 
+function withheldLevelClause(reason: LevelWithheldReason, since: string): string {
+  if (reason === "link_unreachable") return `its pricing page has not resolved for us${since}`;
+  if (reason === "does_not_name_vendor") return `the page we cite for this offer does not name it`;
+  return `we could not read the page we cite for this offer`;
+}
+
+function withheldLevelSentence(reason: LevelWithheldReason, vendorName: string, since: string): string {
+  if (reason === "link_unreachable") return `${vendorName}'s pricing page has not resolved for us${since}.`;
+  if (reason === "does_not_name_vendor") return `The page we cite for ${vendorName} does not name it.`;
+  return `We could not read the page we cite for ${vendorName}.`;
+}
+
 function stabilityCellHtml(stability: string, linkUnreachable: LinkUnreachable | null | undefined, offer?: Pick<Offer, "source_check">): string {
   if (linkUnreachable) {
     const since = linkUnreachable.last_reachable ? ` since ${linkUnreachable.last_reachable}` : "";
     return `<span style="color:var(--text-dim)" title="Link has not resolved${escHtmlServer(since)}">link unreachable</span>`;
   }
-  if (offer && sourceDoesNotNameVendor(offer)) {
-    return `<span style="color:var(--text-dim)" title="The page we cite for this offer does not name it">source unconfirmed</span>`;
+  const withheld = offer ? levelWithheldReason(offer, null) : null;
+  if (withheld) {
+    const why = withheldLevelClause(withheld, "");
+    return `<span style="color:var(--text-dim)" title="${escHtmlServer(why.charAt(0).toUpperCase() + why.slice(1))}">source unconfirmed</span>`;
   }
   const color = STABILITY_COLORS[stability] ?? "#8b949e";
   return `<span class="stability-dot" style="background:${color}"></span> ${escHtmlServer(stability)}`;
@@ -3884,14 +3898,14 @@ function buildVendorPage(slug: string): string | null {
   const unconfirmableSince = linkUnreachable
     ? (linkUnreachable.last_reachable ? ` since ${linkUnreachable.last_reachable}` : "")
     : "";
-  const verdictLine2 = linkUnreachable
-    ? `Its pricing page has not resolved for us${unconfirmableSince}, so we cannot confirm these terms today.`
-    : sourceDoesNotNameVendor(primary)
-    ? `The page we cite for it does not name it, so we cannot confirm these terms today.`
+  const levelWithheld = levelWithheldReason(primary, linkUnreachable);
+  const withheldClause = levelWithheld ? withheldLevelClause(levelWithheld, unconfirmableSince) : "";
+  const verdictLine2 = levelWithheld
+    ? `${withheldClause.charAt(0).toUpperCase()}${withheldClause.slice(1)}, so we cannot confirm these terms today.`
     : vendorChanges.length === 0
     ? `It's ${stabilityText} — zero pricing changes recorded.`
     : `It's ${stabilityText} — ${vendorChanges.length} pricing change${vendorChanges.length > 1 ? "s" : ""} recorded.`;
-  const verdictLine3 = alternatives.length > 0 && !linkUnreachable && !sourceDoesNotNameVendor(primary)
+  const verdictLine3 = alternatives.length > 0 && !levelWithheld
     ? `Best for ${primary.category.toLowerCase()} workloads${alternatives.length >= 5 ? ` — ${alternatives.length} alternatives available` : ""}.`
     : "";
   const quickVerdictHtml = `
@@ -3989,8 +4003,8 @@ ${enrichedAlts.map(a => {
         <div class="change-summary">${escHtmlServer(c.summary)}</div>
         ${c.previous_state && c.current_state ? `<div class="change-detail"><span class="state-label">Before:</span> ${escHtmlServer(c.previous_state)}</div><div class="change-detail"><span class="state-label">After:</span> ${escHtmlServer(c.current_state)}</div>` : ""}
       </div>`;
-  }).join("\n") : sourceDoesNotNameVendor(primary)
-    ? `<p class="no-changes">No recorded pricing changes for ${escHtmlServer(vendorName)} — but the page we cite for this offer does not name it, so nothing we have read describes these terms. Treat the empty history as a statement about our records, not about this vendor's pricing.</p>`
+  }).join("\n") : levelWithheld
+    ? `<p class="no-changes">No recorded pricing changes for ${escHtmlServer(vendorName)} — but ${escHtmlServer(withheldClause)}, so nothing we have read describes these terms. Treat the empty history as a statement about our records, not about this vendor's pricing.</p>`
     : `<p class="no-changes">No recorded pricing changes for ${escHtmlServer(vendorName)}. This is a good sign — stable pricing.</p>`;
 
   // Prominent change notice for vendors with significant changes
@@ -4205,10 +4219,8 @@ ${allCompareLinks.join("\n")}
   // type — so a vendor could be told it "requires caution" and then handed a
   // free-tier expansion as the evidence. They now quote the record that
   // produced the level, and nothing else.
-  const faqReliableAnswer = linkUnreachable
-    ? `We cannot say. ${vendorName}'s pricing page has not resolved for us${unconfirmableSince}, so we are not publishing a stability judgement for this vendor until it does.`
-    : sourceDoesNotNameVendor(primary)
-    ? `We cannot say. The page we cite for this offer does not name ${vendorName}, so nothing we have read describes these terms, and we are not publishing a stability judgement for this vendor until that is fixed.`
+  const faqReliableAnswer = levelWithheld
+    ? `We cannot say. ${withheldLevelSentence(levelWithheld, vendorName, unconfirmableSince)} Nothing we have read describes these terms, so we are not publishing a stability judgement for this vendor until that is fixed.`
     : riskLevel === "stable"
     ? `${vendorName}'s free tier is considered stable: we hold no free tier removal, limit reduction or pricing restructure on record for this vendor.${vendorChanges.length > 0 ? ` We do hold ${vendorChanges.length === 1 ? "1 other recorded change" : `${vendorChanges.length} other recorded changes`} — see the pricing history below.` : ""}`
     : riskLevel === "caution"
@@ -4217,10 +4229,8 @@ ${allCompareLinks.join("\n")}
   const faqCategoryAnswer = `${vendorName} is categorized under ${allCategories.join(", ")} on AgentDeals.${alternatives.length > 0 ? ` Other vendors in ${primary.category} include ${alternatives.slice(0, 5).map(a => a.vendor).join(", ")}.` : ""}`;
 
   // NEW: Additional FAQ items
-  const faqProductionAnswer = linkUnreachable
-    ? `${vendorName}'s pricing page has not resolved for us${unconfirmableSince}. We cannot confirm what its free tier offers today, so we are not recommending it for production or for anything else until we can.`
-    : sourceDoesNotNameVendor(primary)
-    ? `The page we cite for ${vendorName} does not name it. We cannot confirm what this offer provides today, so we are not recommending it for production or for anything else until we can.`
+  const faqProductionAnswer = levelWithheld
+    ? `${withheldLevelSentence(levelWithheld, vendorName, unconfirmableSince)} We cannot confirm what this offer provides today, so we are not recommending it for production or for anything else until we can.`
     : hasFree
     ? (riskLevel === "stable"
       ? `${vendorName}'s free tier can be suitable for small production workloads and side projects. With ${stabilityText} pricing and ${escHtmlServer(keyLimit)}, it's a reasonable starting point. Monitor your usage against the limits and have an upgrade plan ready.`
@@ -4228,10 +4238,8 @@ ${allCompareLinks.join("\n")}
     : `${vendorName} does not offer a free tier for production use. Consider free alternatives in ${primary.category}.`;
   const faqChangedAnswer = vendorChanges.length > 0
     ? `Yes, ${vendorName} has had ${vendorChanges.length} recorded pricing change${vendorChanges.length > 1 ? "s" : ""}. Most recently: ${vendorChanges[0].summary} (${changeDateLabel(vendorChanges[0])}).`
-    : linkUnreachable
-    ? `We hold no recorded pricing changes for ${vendorName}, but its pricing page has not resolved for us${unconfirmableSince}, so that is a statement about our records rather than a positive signal.`
-    : sourceDoesNotNameVendor(primary)
-    ? `We hold no recorded pricing changes for ${vendorName}, but the page we cite for this offer does not name it, so that is a statement about our records rather than a positive signal.`
+    : levelWithheld
+    ? `We hold no recorded pricing changes for ${vendorName}, but ${withheldClause}, so that is a statement about our records rather than a positive signal.`
     : `No, ${vendorName} has had no recorded pricing changes. This is a positive stability signal.`;
   const faqAlternativesAnswer = alternatives.length > 0
     ? `The top free alternatives to ${vendorName} in ${primary.category} include ${alternatives.slice(0, 5).map(a => `${a.vendor} (${a.tier})`).join(", ")}. See all ${alternatives.length} alternatives above.`

--- a/src/source-check.ts
+++ b/src/source-check.ts
@@ -7,8 +7,19 @@ export const SOURCE_CHECK_OUTCOMES: SourceCheckOutcome[] = [
   "unreadable",
 ];
 
+export type LevelWithheldReason = "link_unreachable" | "does_not_name_vendor" | "unreadable";
+
+export const LEVEL_WITHHOLDING_OUTCOMES: SourceCheckOutcome[] = [
+  "does_not_name_vendor",
+  "unreadable",
+];
+
 export function sourceDoesNotNameVendor(offer: Pick<Offer, "source_check">): boolean {
   return offer.source_check?.outcome === "does_not_name_vendor";
+}
+
+export function sourceUnreadable(offer: Pick<Offer, "source_check">): boolean {
+  return offer.source_check?.outcome === "unreadable";
 }
 
 export function sourceCheckNotice(offer: Pick<Offer, "source_check">): SourceCheck | null {
@@ -17,9 +28,19 @@ export function sourceCheckNotice(offer: Pick<Offer, "source_check">): SourceChe
   return check;
 }
 
+export function levelWithheldReason(
+  offer: Pick<Offer, "source_check">,
+  linkUnreachable: unknown,
+): LevelWithheldReason | null {
+  if (linkUnreachable) return "link_unreachable";
+  const outcome = offer.source_check?.outcome;
+  if (outcome && LEVEL_WITHHOLDING_OUTCOMES.includes(outcome)) return outcome as LevelWithheldReason;
+  return null;
+}
+
 export function cannotVouchForLevel(
   offer: Pick<Offer, "source_check">,
   linkUnreachable: unknown,
 ): boolean {
-  return Boolean(linkUnreachable) || sourceDoesNotNameVendor(offer);
+  return levelWithheldReason(offer, linkUnreachable) !== null;
 }

--- a/test/enrich.test.ts
+++ b/test/enrich.test.ts
@@ -59,6 +59,7 @@ describe("enrichOffers", () => {
   // the property the rule is supposed to have.
   it("counts nothing — the number of records a vendor has cannot move its risk level", async () => {
     const { enrichOffers, loadOffers, loadDealChanges } = await import("../dist/data.js");
+    const { levelWithheldReason } = await import("../dist/source-check.js");
     const changes = loadDealChanges();
     const offers = loadOffers();
 
@@ -83,6 +84,7 @@ describe("enrichOffers", () => {
       const offer = offers.find((o: { vendor: string }) => o.vendor.toLowerCase() === vendor);
       if (!offer) continue;
       const enriched = enrichOffers([offer])[0];
+      if (levelWithheldReason(offer, enriched.link_unreachable)) continue;
       assert.strictEqual(
         enriched.risk_level,
         "stable",
@@ -120,10 +122,10 @@ describe("enrichOffers", () => {
 
   it("withholds a level only against a recorded reason, never for any other", async () => {
     const { enrichOffers, loadOffers } = await import("../dist/data.js");
-    const { sourceDoesNotNameVendor } = await import("../dist/source-check.js");
+    const { levelWithheldReason } = await import("../dist/source-check.js");
     const withheld = enrichOffers(loadOffers()).filter((o: { risk_level: string | null }) => o.risk_level === null);
     const unexplained = withheld.filter(
-      (o: { link_unreachable: unknown }) => !o.link_unreachable && !sourceDoesNotNameVendor(o as never)
+      (o: { link_unreachable: unknown }) => !levelWithheldReason(o as never, o.link_unreachable)
     );
     assert.strictEqual(unexplained.length, 0, `${unexplained.length} offers publish no level and no reason for withholding it`);
   });

--- a/test/source-check-pages.test.ts
+++ b/test/source-check-pages.test.ts
@@ -31,6 +31,28 @@ const SOURCED_FROM_ITS_OWN_PAGE = {
   source_check: { checked: "2026-08-28", outcome: "ok", detail: "text" },
 };
 
+const SOURCED_FROM_A_PAGE_WE_COULD_NOT_READ = {
+  ...SOURCED_FROM_A_MARKETPLACE,
+  vendor: "Shellcorp",
+  url: "https://shellcorp.example/pricing",
+  source_check: {
+    checked: "2026-08-28",
+    outcome: "unreadable",
+    detail: "page content too short (likely JS-rendered SPA)",
+  },
+};
+
+const SOURCED_FROM_A_PAGE_STATING_NO_FIGURES = {
+  ...SOURCED_FROM_A_MARKETPLACE,
+  vendor: "Prosecorp",
+  url: "https://prosecorp.example/pricing",
+  source_check: {
+    checked: "2026-08-28",
+    outcome: "states_no_terms",
+    detail: "no amount, tier or rate",
+  },
+};
+
 let fixtureDir = "";
 let serverPort = 0;
 let proc: ChildProcess | null = null;
@@ -55,12 +77,33 @@ const get = async (p: string) => {
   return { status: res.status, body: await res.text() };
 };
 
+function aboutThisVendor({ body }: { body: string }): string {
+  const verdict = body.match(/<div class="quick-verdict">[\s\S]*?<\/div>/)?.[0];
+  const history = body.match(/<p class="no-changes">[\s\S]*?<\/p>/)?.[0];
+  const answers = body.match(/<div class="faq-a">[\s\S]*?<\/div>/g) ?? [];
+  assert.ok(verdict, "the page must open with a verdict for the assertion to mean anything");
+  assert.ok(history, "the page must carry a change-history paragraph");
+  assert.ok(answers.length >= 3, "the page must carry its own answers");
+  return [verdict, history, ...answers].join("\n");
+}
+
 before(async () => {
   fixtureDir = mkdtempSync(path.join(tmpdir(), "source-check-"));
   const indexPath = path.join(fixtureDir, "index.json");
   writeFileSync(
     indexPath,
-    JSON.stringify({ offers: [SOURCED_FROM_A_MARKETPLACE, SOURCED_FROM_ITS_OWN_PAGE] }, null, 2)
+    JSON.stringify(
+      {
+        offers: [
+          SOURCED_FROM_A_MARKETPLACE,
+          SOURCED_FROM_ITS_OWN_PAGE,
+          SOURCED_FROM_A_PAGE_WE_COULD_NOT_READ,
+          SOURCED_FROM_A_PAGE_STATING_NO_FIGURES,
+        ],
+      },
+      null,
+      2
+    )
   );
   proc = await startServer(indexPath);
 });
@@ -116,6 +159,70 @@ describe("a vendor page whose cited source names somebody else", () => {
 
   it("publishes a stable level for the control", async () => {
     const { body } = await get("/api/offers?q=controlcorp");
+    assert.strictEqual(JSON.parse(body).offers[0].risk_level, "stable");
+  });
+});
+
+describe("a vendor page whose cited source we could not read at all", () => {
+  it("renders, so the assertions below are about a real page", async () => {
+    const res = await get("/vendor/shellcorp");
+    assert.equal(res.status, 200);
+  });
+
+  it("does not read its empty change history as good news", async () => {
+    const { body } = await get("/vendor/shellcorp");
+    assert.doesNotMatch(body, /This is a good sign — stable pricing/);
+    assert.doesNotMatch(body, /This is a positive stability signal/);
+  });
+
+  it("does not open with a stability verdict it cannot back", async () => {
+    const { body } = await get("/vendor/shellcorp");
+    assert.doesNotMatch(body, /It's stable — zero pricing changes recorded/);
+    assert.match(body, /we cannot confirm these terms today/);
+  });
+
+  it("shows no stability value in the comparison table", async () => {
+    const { body } = await get("/vendor/shellcorp");
+    const row = body.match(/<tr class="current-vendor-row">[\s\S]*?<\/tr>/)?.[0] ?? "";
+    assert.ok(row.includes("Shellcorp"), "the row under test must be the vendor's own");
+    assert.match(row, /source unconfirmed/);
+    assert.doesNotMatch(row, /stability-dot/);
+  });
+
+  it("says we could not read the page rather than that it names somebody else", async () => {
+    const own = aboutThisVendor(await get("/vendor/shellcorp"));
+    assert.match(own, /could not read the page we cite/);
+    assert.doesNotMatch(own, /does not name it/);
+  });
+
+  it("publishes no risk level for it through the API", async () => {
+    const { body } = await get("/api/offers?q=shellcorp");
+    const offer = JSON.parse(body).offers[0];
+    assert.strictEqual(offer.risk_level, null);
+    assert.strictEqual(offer.source_check.outcome, "unreadable");
+  });
+});
+
+describe("the two withheld reasons read differently to somebody deciding whether to trust us", () => {
+  it("keeps the unread-page wording off the page whose source names somebody else", async () => {
+    const own = aboutThisVendor(await get("/vendor/fixturecorp"));
+    assert.match(own, /does not name it/);
+    assert.doesNotMatch(own, /could not read the page we cite/);
+  });
+});
+
+describe("a vendor page whose cited source names it but states its terms in prose", () => {
+  it("still publishes a stability judgement", async () => {
+    const { body } = await get("/vendor/prosecorp");
+    assert.match(body, /This is a good sign — stable pricing/);
+    const row = body.match(/<tr class="current-vendor-row">[\s\S]*?<\/tr>/)?.[0] ?? "";
+    assert.ok(row.includes("Prosecorp"), "the row under test must be the vendor's own");
+    assert.doesNotMatch(row, /source unconfirmed/);
+    assert.match(row, /stability-dot/);
+  });
+
+  it("still publishes a level through the API", async () => {
+    const { body } = await get("/api/offers?q=prosecorp");
     assert.strictEqual(JSON.parse(body).offers[0].risk_level, "stable");
   });
 });

--- a/test/source-check.test.ts
+++ b/test/source-check.test.ts
@@ -4,6 +4,7 @@ import {
   SOURCE_CHECK_OUTCOMES,
   sourceDoesNotNameVendor,
   cannotVouchForLevel,
+  levelWithheldReason,
   sourceCheckNotice,
 } from "../dist/source-check.js";
 import { enrichOffers, loadOffers, checkVendorRisk } from "../dist/data.js";
@@ -16,6 +17,12 @@ const CITED_PAGE_NAMES_SOMEBODY_ELSE = {
   detail: "the page never names Cloudways and is not served from its domain",
 };
 
+const CITED_PAGE_COULD_NOT_BE_READ = {
+  checked: "2026-08-28",
+  outcome: "unreadable",
+  detail: "page content too short (likely JS-rendered SPA)",
+};
+
 describe("an offer whose cited page cannot verify it", () => {
   it("uses the same outcome vocabulary as the job that writes it", () => {
     assert.deepStrictEqual([...SOURCE_CHECK_OUTCOMES].sort(), [...WRITTEN_OUTCOMES].sort());
@@ -26,11 +33,29 @@ describe("an offer whose cited page cannot verify it", () => {
     assert.strictEqual(cannotVouchForLevel({}, null), false);
   });
 
+  it("withholds a favourable risk level where we could not read the page at all", () => {
+    assert.strictEqual(cannotVouchForLevel({ source_check: CITED_PAGE_COULD_NOT_BE_READ }, null), true);
+  });
+
   it("does not withhold on an outcome that only says the page was thin", () => {
     const thin = { checked: "2026-08-28", outcome: "states_no_terms", detail: "no amount, tier or rate" };
     assert.strictEqual(sourceDoesNotNameVendor({ source_check: thin }), false);
     assert.strictEqual(cannotVouchForLevel({ source_check: thin }, null), false);
     assert.ok(sourceCheckNotice({ source_check: thin }));
+  });
+
+  it("names which of the reasons is holding the level back", () => {
+    assert.strictEqual(levelWithheldReason({ source_check: CITED_PAGE_NAMES_SOMEBODY_ELSE }, null), "does_not_name_vendor");
+    assert.strictEqual(levelWithheldReason({ source_check: CITED_PAGE_COULD_NOT_BE_READ }, null), "unreadable");
+    assert.strictEqual(levelWithheldReason({}, { checked: "2026-08-28" }), "link_unreachable");
+    assert.strictEqual(levelWithheldReason({}, null), null);
+  });
+
+  it("reports a dead link ahead of anything the page check said about it", () => {
+    assert.strictEqual(
+      levelWithheldReason({ source_check: CITED_PAGE_COULD_NOT_BE_READ }, { checked: "2026-08-28" }),
+      "link_unreachable"
+    );
   });
 
   it("reports nothing to a caller when the page checked out", () => {
@@ -72,6 +97,61 @@ describe("what the enriched record publishes for an unverifiable source", () => 
       assert.strictEqual(result.risk_level, null, `${offer.vendor} still publishes a level`);
       assert.doesNotMatch(result.summary, /has a stable pricing history/);
     }
+  });
+});
+
+describe("what the enriched record publishes for a source we could not read", () => {
+  it("holds every such record back from a stable badge", () => {
+    const offers = loadOffers() as any[];
+    const enriched = enrichOffers(offers) as any[];
+    const unread = enriched.filter(
+      (o) => o.source_check?.outcome === "unreadable" && !o.link_unreachable
+    );
+    assert.ok(unread.length > 0, "no record in the index cites a page we could not read");
+    for (const offer of unread) {
+      assert.notStrictEqual(
+        offer.risk_level,
+        "stable",
+        `${offer.vendor} is badged stable from a page we could not read`
+      );
+    }
+  });
+
+  it("tells a caller we could not read the page instead of claiming a stable history", () => {
+    const vendors = new Set(
+      (loadOffers() as any[])
+        .filter((o) => o.source_check?.outcome === "unreadable")
+        .map((o) => o.vendor)
+    );
+    let said = 0;
+    for (const vendor of vendors) {
+      const { result } = checkVendorRisk(vendor) as any;
+      if (result.risk_level !== null) continue;
+      assert.doesNotMatch(result.summary, /has a stable pricing history/);
+      if (/could not read the page we cite/.test(result.summary)) said++;
+    }
+    assert.ok(said > 0, "no vendor tells a caller the page we cite could not be read");
+  });
+
+  it("does not tell a caller a page we read fine could not be read", () => {
+    const byVendor = new Map<string, any[]>();
+    for (const offer of loadOffers() as any[]) {
+      const key = offer.vendor.toLowerCase();
+      if (!byVendor.has(key)) byVendor.set(key, []);
+      byVendor.get(key)!.push(offer);
+    }
+    let checked = 0;
+    for (const records of byVendor.values()) {
+      if (!records.every((o) => o.source_check?.outcome === "states_no_terms")) continue;
+      const { result } = checkVendorRisk(records[0].vendor) as any;
+      assert.doesNotMatch(
+        result.summary,
+        /could not read the page we cite/,
+        `${records[0].vendor} is told its page was unreadable when it states terms in prose`
+      );
+      if (++checked === 20) break;
+    }
+    assert.ok(checked > 0, "no vendor is sourced only from pages that state no figure we recognise");
   });
 });
 


### PR DESCRIPTION
Refs #1113

#1112 built the mechanism and wired it to one of the two signals it has. `cannotVouchForLevel` was `linkUnreachable || sourceDoesNotNameVendor`, and `unreadable` was in neither term — a page that answers 200 with an empty shell is reachable, so `link_health` never sees it.

## What changed

`levelWithheldReason(offer, linkUnreachable)` returns which of the three reasons holds a level back, or `null`. `cannotVouchForLevel` is now `!== null`, so the API surfaces widen for free.

**AC-1.** Every surface asks the shared predicate instead of testing one signal: the stability cell, the hero verdict, the third verdict line, the change-history paragraph, three FAQ answers (which ship inside `FAQPage` JSON-LD) and the `checkVendorRisk` summary the MCP tool returns.

**AC-3.** The prose distinguishes the two reasons. "The page we cite does not name it" and "we could not read the page we cite" are different statements, and only the second may resolve on its own. Both forms come from one pair of functions rather than nine string literals, so the sentences cannot drift apart the way #1112's hero and API did.

**`states_no_terms` is untouched**, as the issue asked — a vendor stating a free tier in prose our signal counter cannot parse is not evidence the record is wrong. A test pins that carve-out at both the page and the API, so a future widening cannot ship across those 589 records silently.

## AC-4 — measured after the change

| withheld reason | records | renders |
|---|---|---|
| `does_not_name_vendor` | 90 | source unconfirmed |
| `unreadable` | 81 | source unconfirmed |
| link unreachable | 21 | link unreachable |

171 render `source unconfirmed`, exactly the 90 + 81 the issue predicted, so the predicate reached nothing beyond what was intended.

**A defect found by doing AC-1 rather than patching the five sites.** The change-history paragraph had no link-unreachable branch at all, so a vendor whose site is gone and which has no recorded changes read "No recorded pricing changes — this is a good sign, stable pricing". 20 records. Routing it through the shared predicate fixes them.

## AC-5 — the 43 SPA cases

**None of the 43 has a readable pricing page one hop away.** `bare-root-pricing-audit.js` gained an `--outcome` flag so the existing mechanism could be pointed at this population instead of a new one being built; it read all 102 unreadable records against `/pricing`, `/plans` and `/pricing.html`.

| detail | records | readable pricing one hop away |
|---|---|---|
| page content too short (likely JS-rendered SPA) | 43 | **0** |
| HTTP 404 | 15 | 6 |
| HTTP 403 | 14 | 1 |
| fetch failed | 11 | 0 |
| HTTP 429 / 502 / timeout / 402 / 503 / 410 / 401 | 19 | 0 |

So the repoint #1110 proposes does not reach the 43. Whatever fixes them is a different fetch, not a different URL.

Of the 7 candidates that did carry price text I screened each with #1109's naming rule rather than trusting the signal count. `tollbooth` is hosted on `github.com`, so its "pricing page one hop away" is **GitHub's own pricing** — the rule refuses it, the same shared-host false positive as `unpkg.com/pricing` in cycle 200. `Google Vertex AI Agent Engine` resolves to `cloud.google.com/pricing`, accepted only via a host label on an umbrella page, which I would not repoint either. That leaves 4 worth a per-record check, not a bulk repoint.

## Verification

- **2186 / 2186** locally (2171 on main, 15 new).
- **`scripts/mutate-1113.sh` — 14 of 14 killed.** One survived a first pass once I made it compile: widening `sourceUnreadable` to any non-`ok` outcome would have told all 589 `states_no_terms` callers we could not read a page we read fine, and nothing caught it. Three of the fourteen were originally killed by the compiler rather than a test, which proves the type system, not the tests — they were rewritten as mutations that compile before the run counted.
- `mutate-1109.sh` **23/23** after retargeting five mutations whose lines this change moved, `mutate-1107.sh` **17/17**, `mutate-1101.sh` **18/18**.
- `/vendor/kaggle`, `/vendor/coda`, `/vendor/umami`, `/vendor/lottiefiles` on a local server: `source unconfirmed`, no positive stability signal, no "It's stable — zero pricing changes recorded". `/vendor/render` unchanged at `caution`.
- Screenshotted, because #1112 looked correct through the API while the hero contradicted it.
- Real MCP `initialize` → `tools/call` against a local `dist/serve.js`: Kaggle's tool result carries the withheld summary; Render's and Datadog's are unchanged.
- `npm run validate` clean.

## Named, not fixed

The 403 group is intermittent — LottieFiles read fine during the audit and returned 403 to a re-fetch minutes later. An `unreadable` verdict from a 403 or 429 can therefore flip between nightly runs, so a record can move in and out of the withheld state. Withholding on a single failed read errs toward saying less, which is the safe direction, but if that flapping is undesirable the fix is to require N consecutive failed reads. Not in this PR.