### PR TITLE
Withhold the stability verdict when the cited page states no terms, and stop answering "Is X free?" with a bare Yes

### DIFF
--- a/scripts/check-mutation-targets.mjs
+++ b/scripts/check-mutation-targets.mjs
@@ -1,0 +1,97 @@
+/**
+ * Reports mutations in scripts/mutate-*.sh whose target text no longer exists.
+ *
+ * A mutation whose search string has moved applies nothing, and the mutation
+ * script scores it as passing. The scripts themselves catch this only when run,
+ * which costs a rebuild and a test pass per mutation; this reads the target
+ * strings straight out of the scripts and checks them against the files.
+ *
+ * Usage:
+ *   node scripts/check-mutation-targets.mjs            # every mutate-*.sh
+ *   node scripts/check-mutation-targets.mjs 1109 1116  # only those
+ *
+ * Exits non-zero if any mutation has a target that is absent.
+ */
+
+import { readFileSync, readdirSync, existsSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const REPO = path.join(path.dirname(fileURLToPath(import.meta.url)), "..");
+const SCRIPTS = path.join(REPO, "scripts");
+
+const wanted = process.argv.slice(2);
+const scripts = readdirSync(SCRIPTS)
+  .filter((f) => /^mutate-.*\.sh$/.test(f))
+  .filter((f) => wanted.length === 0 || wanted.some((w) => f.includes(w)))
+  .sort();
+
+if (scripts.length === 0) {
+  console.error(`no mutation scripts matched ${wanted.join(", ") || "*"}`);
+  process.exit(2);
+}
+
+const fileCache = new Map();
+const read = (rel) => {
+  if (!fileCache.has(rel)) {
+    const full = path.join(REPO, rel);
+    fileCache.set(rel, existsSync(full) ? readFileSync(full, "utf8") : null);
+  }
+  return fileCache.get(rel);
+};
+
+/** Turn a Python single- or double-quoted literal into the string it denotes. */
+function pythonLiteral(quoted) {
+  const quote = quoted[0];
+  const body = quoted.slice(1, -1);
+  let out = "";
+  for (let i = 0; i < body.length; i++) {
+    if (body[i] !== "\\") { out += body[i]; continue; }
+    const next = body[++i];
+    if (next === "n") out += "\n";
+    else if (next === "t") out += "\t";
+    else if (next === "r") out += "\r";
+    else if (next === "\\") out += "\\";
+    else if (next === quote) out += quote;
+    else out += "\\" + next;
+  }
+  return out;
+}
+
+const MUTATION = /m_(\w+)\(\)\s*\{\s*py <<'(\w+)'\n([\s\S]*?)\n\2\n\}/g;
+const PATH_IN_BODY = /p = "([^"]+)"/g;
+const REPLACE_TARGET = /s\.replace\(\s*('(?:[^'\\]|\\.)*'|"(?:[^"\\]|\\.)*")/g;
+
+let problems = 0;
+let mutationsChecked = 0;
+
+for (const script of scripts) {
+  const source = readFileSync(path.join(SCRIPTS, script), "utf8");
+  const findings = [];
+  for (const [, name, , body] of source.matchAll(MUTATION)) {
+    const paths = [...body.matchAll(PATH_IN_BODY)].map((m) => m[1]);
+    const targets = [...body.matchAll(REPLACE_TARGET)].map((m) => pythonLiteral(m[1]));
+    if (paths.length === 0) continue;
+    mutationsChecked++;
+    for (const rel of paths) {
+      if (read(rel) === null) findings.push([name, `file is missing: ${rel}`]);
+    }
+    for (const target of targets) {
+      if (!paths.some((rel) => (read(rel) ?? "").includes(target))) {
+        findings.push([name, `target absent from ${paths.join(", ")}: ${JSON.stringify(target.slice(0, 100))}`]);
+      }
+    }
+  }
+  if (findings.length > 0) {
+    problems += findings.length;
+    console.log(`${script}`);
+    for (const [name, detail] of findings) console.log(`  m_${name}: ${detail}`);
+  }
+}
+
+console.log(
+  problems === 0
+    ? `${mutationsChecked} mutations across ${scripts.length} script(s) still target code that exists`
+    : `\n${problems} mutation target(s) no longer exist — those mutations apply nothing and score as passing`
+);
+process.exit(problems === 0 ? 0 : 1);

--- a/scripts/e2e-1122.mjs
+++ b/scripts/e2e-1122.mjs
@@ -1,0 +1,280 @@
+/**
+ * Drives every surface #1122 names against a server running the real index.
+ *
+ * Nothing here is stubbed: the server loads data/index.json, and each check
+ * reads the page or the FAQPage structured data a caller would receive.
+ *
+ * Usage: node scripts/e2e-1122.mjs
+ */
+
+import { spawn } from "node:child_process";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { enrichOffers } from "../dist/data.js";
+
+const REPO = path.join(path.dirname(fileURLToPath(import.meta.url)), "..");
+
+const WITHHOLDING_OUTCOMES = ["does_not_name_vendor", "states_no_terms", "unreadable"];
+
+const REASON_TEXT = {
+  does_not_name_vendor: /does not name it/,
+  states_no_terms: /states no terms we can read/,
+  unreadable: /could not read the page we cite/,
+};
+
+const ONE_OF_EACH_OUTCOME = {
+  states_no_terms: "canva",
+  unreadable: "openai",
+  does_not_name_vendor: "cloudways",
+};
+
+const STILL_WITHHELD_FROM_1113 = ["kaggle", "umami", "lottiefiles", "coda", "imageengine"];
+
+const CONFIRMED_SOURCE_CONTROL = "cloudflare-workers";
+
+let port = 0;
+let proc = null;
+let passed = 0;
+const failures = [];
+
+function check(name, fn) {
+  try {
+    fn();
+    passed++;
+    console.log(`  ok   ${name}`);
+  } catch (err) {
+    failures.push(`${name}: ${err.message}`);
+    console.log(`  FAIL ${name}\n       ${err.message}`);
+  }
+}
+
+function assert(condition, message) {
+  if (!condition) throw new Error(message);
+}
+
+function startServer() {
+  return new Promise((resolve, reject) => {
+    const child = spawn("node", [path.join(REPO, "dist", "serve.js")], {
+      stdio: ["pipe", "pipe", "pipe"],
+      env: { ...process.env, PORT: "0", BASE_URL: "http://localhost" },
+    });
+    const timeout = setTimeout(() => { child.kill(); reject(new Error("server startup timeout")); }, 30000);
+    child.stderr.on("data", (buf) => {
+      const m = buf.toString().match(/running on http:\/\/localhost:(\d+)/);
+      if (m) { port = parseInt(m[1], 10); clearTimeout(timeout); resolve(child); }
+    });
+    child.on("error", (err) => { clearTimeout(timeout); reject(err); });
+  });
+}
+
+const get = async (p) => {
+  const res = await fetch(`http://localhost:${port}${p}`);
+  return { status: res.status, body: await res.text() };
+};
+
+function faqAnswers(body) {
+  const page = [...body.matchAll(/<script type="application\/ld\+json">([\s\S]*?)<\/script>/g)]
+    .map((m) => { try { return JSON.parse(m[1]); } catch { return null; } })
+    .find((json) => json && json["@type"] === "FAQPage");
+  if (!page) throw new Error("no FAQPage structured data on the page");
+  return page.mainEntity.map((e) => e.acceptedAnswer.text);
+}
+
+const subjectRow = (body) => body.match(/<tr class="current-vendor-row">[\s\S]*?<\/tr>/)?.[0] ?? "";
+const visibleAnswers = (body) => (body.match(/<div class="faq-a">[\s\S]*?<\/div>/g) ?? []).join("\n");
+
+const toSlug = (s) => s.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-|-$/g, "");
+
+const offers = (() => {
+  const idx = JSON.parse(readFileSync(path.join(REPO, "data", "index.json"), "utf8"));
+  return Array.isArray(idx) ? idx : idx.offers ?? [];
+})();
+
+const primaryBySlug = new Map();
+for (const o of offers) {
+  const slug = toSlug(o.vendor);
+  if (!primaryBySlug.has(slug)) primaryBySlug.set(slug, o);
+}
+
+async function main() {
+  proc = await startServer();
+
+  console.log("\nAC-1 — a page whose source states no terms publishes no stability verdict");
+  {
+    const { status, body } = await get("/vendor/canva");
+    check("/vendor/canva renders", () => assert(status === 200, `status ${status}`));
+    check("no stable badge in the heading", () => {
+      const h1 = body.match(/<h1>[\s\S]*?<\/h1>/)?.[0] ?? "";
+      assert(!/risk-badge/.test(h1), `heading still carries a badge: ${h1}`);
+    });
+    check("no stability dot in its own comparison row", () =>
+      assert(!/stability-dot/.test(subjectRow(body)), "subject row still prints a stability value"));
+    check("the row says the source is unconfirmed", () =>
+      assert(/source unconfirmed/.test(subjectRow(body)), "subject row does not say the source is unconfirmed"));
+    check("the verdict does not read the empty history as stability", () =>
+      assert(!/zero pricing changes recorded/.test(body), "verdict still claims zero recorded changes as a good sign"));
+    check("the change history is not called a good sign", () =>
+      assert(!/This is a good sign — stable pricing/.test(body), "change history still reads as good news"));
+  }
+
+  console.log("\nAC-2 — each outcome names its own reason, and no two read alike");
+  const sentencesSeen = new Map();
+  for (const [outcome, slug] of Object.entries(ONE_OF_EACH_OUTCOME)) {
+    const { body } = await get(`/vendor/${slug}`);
+    const own = [
+      body.match(/<div class="quick-verdict">[\s\S]*?<\/div>/)?.[0] ?? "",
+      body.match(/<p class="no-changes">[\s\S]*?<\/p>/)?.[0] ?? "",
+      visibleAnswers(body),
+    ].join("\n");
+    sentencesSeen.set(outcome, own);
+    check(`/vendor/${slug} (${outcome}) states its own reason`, () =>
+      assert(REASON_TEXT[outcome].test(own), `page does not carry ${REASON_TEXT[outcome]}`));
+    for (const other of WITHHOLDING_OUTCOMES) {
+      if (other === outcome) continue;
+      check(`/vendor/${slug} (${outcome}) does not borrow the ${other} wording`, () =>
+        assert(!REASON_TEXT[other].test(own), `page also reads as ${other}`));
+    }
+  }
+
+  console.log("\nAC-3 — the question an answer engine quotes first carries the caveat");
+  for (const [outcome, slug] of Object.entries(ONE_OF_EACH_OUTCOME)) {
+    const { body } = await get(`/vendor/${slug}`);
+    const [q1, q2] = faqAnswers(body);
+    check(`Q1 for ${slug} does not open with a bare Yes`, () =>
+      assert(!/^Yes, /.test(q1), `Q1 opens: ${q1.slice(0, 80)}`));
+    check(`Q2 for ${slug} does not open with a bare assertion of the terms`, () =>
+      assert(!/^\w[\w .]*'s free tier is called/.test(q2), `Q2 opens: ${q2.slice(0, 80)}`));
+    check(`Q1 for ${slug} carries the reason in its own text`, () =>
+      assert(REASON_TEXT[outcome].test(q1), `Q1 does not name the reason: ${q1.slice(0, 120)}`));
+    check(`Q2 for ${slug} carries the reason in its own text`, () =>
+      assert(REASON_TEXT[outcome].test(q2), `Q2 does not name the reason: ${q2.slice(0, 120)}`));
+    check(`Q1 for ${slug} still shows the stored terms`, () => {
+      const stored = primaryBySlug.get(slug).description.slice(0, 40);
+      assert(q1.includes(stored), `Q1 dropped the stored terms: ${q1.slice(0, 120)}`);
+    });
+    check(`the visible answer for ${slug} matches the structured one`, () => {
+      const visible = visibleAnswers(body);
+      assert(REASON_TEXT[outcome].test(visible), "the rendered FAQ does not carry the reason the JSON-LD does");
+    });
+  }
+
+  console.log("\nPositive control — a record whose source confirms the terms is untouched");
+  {
+    const { body } = await get(`/vendor/${CONFIRMED_SOURCE_CONTROL}`);
+    const [q1, , q3] = faqAnswers(body);
+    check("its heading still carries a stable badge", () => {
+      const h1 = body.match(/<h1>[\s\S]*?<\/h1>/)?.[0] ?? "";
+      assert(/risk-badge/.test(h1) && />stable</.test(h1), `heading lost its badge: ${h1}`);
+    });
+    check("its own row still prints a stability value", () =>
+      assert(/stability-dot/.test(subjectRow(body)), "subject row lost its stability value"));
+    check("Q1 still opens with a bare Yes", () =>
+      assert(/^Yes, /.test(q1), `Q1 opens: ${q1.slice(0, 80)}`));
+    check("Q3 still calls it stable", () =>
+      assert(/considered stable/.test(q3), `Q3 reads: ${q3.slice(0, 80)}`));
+    check("nothing it says about itself carries withholding wording", () => {
+      const own = [
+        body.match(/<h1>[\s\S]*?<\/h1>/)?.[0] ?? "",
+        body.match(/<div class="quick-verdict">[\s\S]*?<\/div>/)?.[0] ?? "",
+        body.match(/<p class="no-changes">[\s\S]*?<\/p>/)?.[0] ?? "",
+        subjectRow(body),
+        faqAnswers(body).join("\n"),
+      ].join("\n");
+      for (const re of Object.values(REASON_TEXT)) {
+        assert(!re.test(own), `a confirmed record says this about itself: ${re}`);
+      }
+    });
+    check("it still reports a withheld alternative's status in that alternative's own row", () => {
+      const rows = body.match(/<table class="mini-compare-table">[\s\S]*?<\/table>/)?.[0] ?? "";
+      assert(rows.length > 0, "the page carries no comparison table");
+      assert(/stability-dot/.test(subjectRow(body)), "the subject lost its own stability value");
+    });
+  }
+
+  console.log("\nNegative control — the pages #1113 fixed still withhold, with their own wording");
+  for (const slug of STILL_WITHHELD_FROM_1113) {
+    const { body } = await get(`/vendor/${slug}`);
+    const outcome = primaryBySlug.get(slug).source_check.outcome;
+    check(`/vendor/${slug} still withholds`, () =>
+      assert(/source unconfirmed/.test(subjectRow(body)) || !/stability-dot/.test(subjectRow(body)),
+        "the page went back to publishing a stability value"));
+    check(`/vendor/${slug} still names ${outcome}`, () =>
+      assert(REASON_TEXT[outcome].test(body), `page no longer names its reason`));
+  }
+
+  console.log("\nThe alternatives page, which re-asserted a level of its own");
+  for (const [outcome, slug] of Object.entries(ONE_OF_EACH_OUTCOME)) {
+    const { body } = await get(`/alternative-to/${slug}`);
+    const riskRow = body.match(/Risk Level:[\s\S]{0,300}?<\/div>/)?.[0] ?? "";
+    check(`/alternative-to/${slug} publishes no stable level`, () => {
+      assert(riskRow.length > 0, "the page carries no risk row");
+      assert(!/>stable</.test(riskRow), `risk row still reads stable: ${riskRow.replace(/<[^>]*>/g, " ")}`);
+    });
+    check(`/alternative-to/${slug} says the source is unconfirmed where no level survives`, () => {
+      const level = enrichOffers([primaryBySlug.get(slug)])[0].risk_level;
+      if (level === null) {
+        assert(/source unconfirmed/.test(riskRow), "risk row does not say the source is unconfirmed");
+      } else {
+        assert(new RegExp(`>${level}<`).test(riskRow),
+          `an adverse level we can name a cause for must still be published, got: ${riskRow.replace(/<[^>]*>/g, " ")}`);
+      }
+    });
+    check(`/alternative-to/${slug} does not read its empty history as stable pricing`, () =>
+      assert(!/This indicates stable pricing/.test(body), "page still reads an empty history as stable pricing"));
+    check(`/alternative-to/${slug} answers "still available" without a bare Yes`, () => {
+      const stillAvailable = faqAnswers(body).find((a) => /free tier/.test(a) && !/best free alternatives/i.test(a));
+      assert(stillAvailable && !/^Yes, /.test(stillAvailable), `answer opens: ${(stillAvailable ?? "").slice(0, 80)}`);
+      assert(REASON_TEXT[outcome].test(stillAvailable), "the answer does not name the reason");
+    });
+  }
+  {
+    const { body } = await get(`/alternative-to/${CONFIRMED_SOURCE_CONTROL}`);
+    const riskRow = body.match(/Risk Level:[\s\S]{0,300}?<\/div>/)?.[0] ?? "";
+    check("the confirmed-source control keeps its stable level there too", () =>
+      assert(/>stable</.test(riskRow), `risk row reads: ${riskRow.replace(/<[^>]*>/g, " ")}`));
+  }
+
+  console.log("\nAC-5 — counting what still renders a stability badge, over every vendor page");
+  {
+    const slugs = [...primaryBySlug.keys()];
+    const dot = {};
+    const bareYes = {};
+    const queue = [...slugs];
+    const worker = async () => {
+      while (queue.length) {
+        const slug = queue.shift();
+        const { body } = await get(`/vendor/${slug}`);
+        const outcome = primaryBySlug.get(slug).source_check?.outcome ?? "(none)";
+        if (/stability-dot/.test(subjectRow(body))) dot[outcome] = (dot[outcome] ?? 0) + 1;
+        if (/^Yes, /.test(faqAnswers(body)[0])) bareYes[outcome] = (bareYes[outcome] ?? 0) + 1;
+      }
+    };
+    await Promise.all(Array.from({ length: 12 }, worker));
+
+    console.log(`  stability badge by outcome: ${JSON.stringify(dot)}`);
+    console.log(`  bare "Yes" by outcome:      ${JSON.stringify(bareYes)}`);
+
+    for (const outcome of WITHHOLDING_OUTCOMES) {
+      check(`no vendor page badges a ${outcome} record`, () =>
+        assert(!dot[outcome], `${dot[outcome]} pages still badge a ${outcome} record`));
+      check(`no vendor page answers a bare Yes for a ${outcome} record`, () =>
+        assert(!bareYes[outcome], `${bareYes[outcome]} pages still answer a bare Yes`));
+    }
+    const okPages = slugs.filter((s) => primaryBySlug.get(s).source_check?.outcome === "ok").length;
+    check("every confirmed-source page still badges and still answers Yes", () => {
+      assert(dot.ok === okPages, `${dot.ok} of ${okPages} confirmed pages badge`);
+      assert(bareYes.ok === okPages, `${bareYes.ok} of ${okPages} confirmed pages answer Yes`);
+    });
+  }
+
+  console.log(`\n${passed} passed, ${failures.length} failed`);
+  for (const f of failures) console.log(`  - ${f}`);
+}
+
+main()
+  .catch((err) => { console.error(err); process.exitCode = 1; })
+  .finally(() => {
+    if (proc) proc.kill();
+    if (failures.length > 0) process.exitCode = 1;
+  });

--- a/scripts/mutate-1109.sh
+++ b/scripts/mutate-1109.sh
@@ -196,7 +196,7 @@ m_verified_date_advances_anyway() {
   py <<'PY'
 p = "scripts/reverify-rolling.js"
 s = open(p).read()
-s = s.replace("  return check.outcome === SOURCE_CHECK_OK;", "  return true;")
+s = s.replace("    const sourceOk = check.outcome === SOURCE_CHECK_OK;", "    const sourceOk = true;")
 open(p, "w").write(s)
 PY
 }

--- a/scripts/mutate-1113.sh
+++ b/scripts/mutate-1113.sh
@@ -72,17 +72,18 @@ m_unreadable_no_longer_withholds() {
   py <<'PY'
 p = "src/source-check.ts"
 s = open(p).read()
-s = s.replace('  "does_not_name_vendor",\n  "unreadable",\n];', '  "does_not_name_vendor",\n];')
+s = s.replace('  "does_not_name_vendor",\n  "states_no_terms",\n  "unreadable",\n];',
+              '  "does_not_name_vendor",\n  "states_no_terms",\n];')
 open(p, "w").write(s)
 PY
 }
 
-m_thin_page_also_withholds() {
+m_thin_page_no_longer_withholds() {
   py <<'PY'
 p = "src/source-check.ts"
 s = open(p).read()
-s = s.replace('  "does_not_name_vendor",\n  "unreadable",\n];',
-              '  "does_not_name_vendor",\n  "unreadable",\n  "states_no_terms",\n];')
+s = s.replace('  "does_not_name_vendor",\n  "states_no_terms",\n  "unreadable",\n];',
+              '  "does_not_name_vendor",\n  "unreadable",\n];')
 open(p, "w").write(s)
 PY
 }
@@ -121,20 +122,20 @@ PY
 
 m_clause_does_not_distinguish() {
   py <<'PY'
-p = "src/serve.ts"
+p = "src/source-check.ts"
 s = open(p).read()
-s = s.replace('  return `we could not read the page we cite for this offer`;',
-              '  return `the page we cite for this offer does not name it`;')
+s = s.replace('  unreadable: () => `we could not read the page we cite for this offer`,',
+              '  unreadable: () => `the page we cite for this offer does not name it`,')
 open(p, "w").write(s)
 PY
 }
 
 m_sentence_does_not_distinguish() {
   py <<'PY'
-p = "src/serve.ts"
+p = "src/source-check.ts"
 s = open(p).read()
-s = s.replace('  return `We could not read the page we cite for ${vendorName}.`;',
-              '  return `The page we cite for ${vendorName} does not name it.`;')
+s = s.replace('  unreadable: (subject) => `We could not read the page we cite for ${subject}.`,',
+              '  unreadable: (subject) => `The page we cite for ${subject} does not name it.`,')
 open(p, "w").write(s)
 PY
 }
@@ -190,23 +191,24 @@ m_tool_result_claims_a_stable_history() {
   py <<'PY'
 p = "src/data.ts"
 s = open(p).read()
-s = s.replace("  } else if (sourceUnreadable(offer)) {", "  } else if (false) {")
+s = s.replace('  } else if (withheldReason) {',
+              '  } else if (withheldReason && withheldReason !== "unreadable") {')
 open(p, "w").write(s)
 PY
 }
 
-m_unreadable_predicate_matches_anything() {
+m_unreadable_reason_matches_any_imperfect_check() {
   py <<'PY'
 p = "src/source-check.ts"
 s = open(p).read()
-s = s.replace('  return offer.source_check?.outcome === "unreadable";',
-              '  return offer.source_check ? offer.source_check.outcome !== "ok" : false;')
+s = s.replace('  if (outcome && LEVEL_WITHHOLDING_OUTCOMES.includes(outcome)) return outcome as LevelWithheldReason;',
+              '  if (outcome && LEVEL_WITHHOLDING_OUTCOMES.includes(outcome)) return "unreadable";')
 open(p, "w").write(s)
 PY
 }
 
 run_mutation "a page we could not read no longer withholds the level" m_unreadable_no_longer_withholds
-run_mutation "a page stating no terms also withholds the level" m_thin_page_also_withholds
+run_mutation "a page stating no terms no longer withholds the level" m_thin_page_no_longer_withholds
 run_mutation "every non-ok outcome withholds the level" m_every_outcome_withholds
 run_mutation "both withheld reasons report as the same reason" m_reason_collapses_to_one
 run_mutation "a dead link loses its precedence over the page check" m_dead_link_loses_its_precedence
@@ -218,7 +220,7 @@ run_mutation "the page still calls an empty history good news" m_empty_history_r
 run_mutation "the reliability answer still calls it stable" m_faq_keeps_its_answer
 run_mutation "the change answer still reads as a positive signal" m_change_answer_keeps_its_positive_signal
 run_mutation "the tool result still claims a stable history" m_tool_result_claims_a_stable_history
-run_mutation "the unread-page predicate matches any imperfect check" m_unreadable_predicate_matches_anything
+run_mutation "the unread-page reason matches any imperfect check" m_unreadable_reason_matches_any_imperfect_check
 
 echo ""
 echo "killed=$killed survived=$survived"

--- a/scripts/mutate-1116.sh
+++ b/scripts/mutate-1116.sh
@@ -229,8 +229,8 @@ m_the_queue_ignores_the_refusal() {
   py <<'PY'
 p = "scripts/reverify-rolling.js"
 s = open(p).read()
-s = s.replace('  const dates = [offer?.verifiedDate, held, refusedOn].filter(Boolean);',
-              '  const dates = [offer?.verifiedDate, held].filter(Boolean);')
+s = s.replace('  const dates = [offer?.verifiedDate, held, refusedOn, verificationRecord?.last_attempt_at].filter(Boolean);',
+              '  const dates = [offer?.verifiedDate, held, verificationRecord?.last_attempt_at].filter(Boolean);')
 open(p, "w").write(s)
 PY
 }

--- a/scripts/mutate-1122.sh
+++ b/scripts/mutate-1122.sh
@@ -1,0 +1,268 @@
+#!/usr/bin/env bash
+#
+# Mutation testing for the rule that a record whose cited page states no terms
+# we can read gets no stability verdict, and for the answers that must not open
+# with a bare "Yes" when we cannot vouch for the terms behind them.
+#
+# Each mutation breaks one property the change is supposed to hold, rebuilds,
+# and runs the tests that claim to pin it. A surviving mutation means no test
+# is asserting that property. A mutation that changes no file proves nothing
+# and is reported as a survivor rather than silently passing.
+#
+# Usage:
+#   bash scripts/mutate-1122.sh
+#
+set -u
+
+REPO="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$REPO" || exit 1
+
+SOURCE="src/source-check.ts"
+SERVE="src/serve.ts"
+DATA="src/data.ts"
+BACKUP_DIR="$(mktemp -d)"
+cp "$SOURCE" "$BACKUP_DIR/source-check.ts"
+cp "$SERVE" "$BACKUP_DIR/serve.ts"
+cp "$DATA" "$BACKUP_DIR/data.ts"
+
+restore() {
+  cp "$BACKUP_DIR/source-check.ts" "$SOURCE"
+  cp "$BACKUP_DIR/serve.ts" "$SERVE"
+  cp "$BACKUP_DIR/data.ts" "$DATA"
+  npx tsc > /dev/null 2>&1
+}
+trap restore EXIT
+
+killed=0
+survived=0
+TESTS="test/source-check.test.ts test/source-check-pages.test.ts test/enrich.test.ts test/link-liveness-pages.test.ts test/vendor-risk.test.ts"
+
+run_mutation() {
+  local name="$1"
+  shift
+  echo "=== $name"
+  restore
+  "$@"
+  local changed=0
+  for f in "$SOURCE" "$SERVE" "$DATA"; do
+    diff -q "$BACKUP_DIR/$(basename "$f")" "$f" > /dev/null || changed=1
+  done
+  if [ "$changed" -eq 0 ]; then
+    echo "    NOT APPLIED: the mutation changed no file, so it proves nothing"
+    survived=$((survived + 1))
+    return
+  fi
+  if ! npx tsc > /tmp/mutate-1122-build.log 2>&1; then
+    echo "    KILLED: does not compile"
+    killed=$((killed + 1))
+    return
+  fi
+  if timeout 900 node --test $TESTS > /tmp/mutate-1122-test.log 2>&1; then
+    echo "    SURVIVED"
+    survived=$((survived + 1))
+  else
+    echo "    KILLED: $(grep -c '✖ ' /tmp/mutate-1122-test.log) failing assertion(s)"
+    grep '✖ ' /tmp/mutate-1122-test.log | head -4
+    killed=$((killed + 1))
+  fi
+}
+
+py() { python3 - "$@"; }
+
+# --- Part A: the outcome that was left out of the withholding list ---
+
+m_no_terms_no_longer_withholds() {
+  py <<'PY'
+p = "src/source-check.ts"
+s = open(p).read()
+s = s.replace('  "does_not_name_vendor",\n  "states_no_terms",\n  "unreadable",\n];',
+              '  "does_not_name_vendor",\n  "unreadable",\n];')
+open(p, "w").write(s)
+PY
+}
+
+m_confirmed_source_withholds_too() {
+  py <<'PY'
+p = "src/source-check.ts"
+s = open(p).read()
+s = s.replace('export const LEVEL_WITHHOLDING_OUTCOMES: SourceCheckOutcome[] = [\n  "does_not_name_vendor",',
+              'export const LEVEL_WITHHOLDING_OUTCOMES: SourceCheckOutcome[] = [\n  "ok",\n  "does_not_name_vendor",')
+open(p, "w").write(s)
+PY
+}
+
+# --- AC-2: three distinct sentences, one per outcome ---
+
+m_no_terms_clause_reads_as_unreadable() {
+  py <<'PY'
+p = "src/source-check.ts"
+s = open(p).read()
+s = s.replace('  states_no_terms: () => `the page we cite for this offer states no terms we can read`,',
+              '  states_no_terms: () => `we could not read the page we cite for this offer`,')
+open(p, "w").write(s)
+PY
+}
+
+m_no_terms_sentence_reads_as_unnamed() {
+  py <<'PY'
+p = "src/source-check.ts"
+s = open(p).read()
+s = s.replace('  states_no_terms: (subject) => `The page we cite for ${subject} states no terms we can read.`,',
+              '  states_no_terms: (subject) => `The page we cite for ${subject} does not name it.`,')
+open(p, "w").write(s)
+PY
+}
+
+m_every_reason_shares_one_sentence() {
+  py <<'PY'
+p = "src/source-check.ts"
+s = open(p).read()
+s = s.replace('export function withheldLevelSentence(\n  reason: LevelWithheldReason,\n  subject: string,\n  since = "",\n): string {\n  return WITHHELD_LEVEL_SENTENCES[reason](subject, since);',
+              'export function withheldLevelSentence(\n  reason: LevelWithheldReason,\n  subject: string,\n  since = "",\n): string {\n  return WITHHELD_LEVEL_SENTENCES.unreadable(subject, since);')
+open(p, "w").write(s)
+PY
+}
+
+# --- Part B: the question an answer engine quotes first ---
+
+m_is_x_free_ignores_the_withholding() {
+  py <<'PY'
+p = "src/serve.ts"
+s = open(p).read()
+s = s.replace('  const faqFreeAnswer = levelWithheld\n', '  const faqFreeAnswer = false\n')
+open(p, "w").write(s)
+PY
+}
+
+m_what_is_x_tier_ignores_the_withholding() {
+  py <<'PY'
+p = "src/serve.ts"
+s = open(p).read()
+s = s.replace('  const faqTierAnswer = levelWithheld\n', '  const faqTierAnswer = false\n')
+open(p, "w").write(s)
+PY
+}
+
+m_answer_drops_the_reason_it_cannot_confirm() {
+  py <<'PY'
+p = "src/serve.ts"
+s = open(p).read()
+s = s.replace('    ? `We cannot confirm that today. ${withheldLevelSentence(levelWithheld, vendorName, unconfirmableSince)} `',
+              '    ? `We cannot confirm that today. `')
+open(p, "w").write(s)
+PY
+}
+
+m_answer_drops_the_unverified_caveat() {
+  py <<'PY'
+p = "src/serve.ts"
+s = open(p).read()
+s = s.replace(' We have not confirmed these terms against the source we cite, so treat them as unverified.`;',
+              '`;')
+open(p, "w").write(s)
+PY
+}
+
+m_answer_drops_the_stored_terms() {
+  py <<'PY'
+p = "src/serve.ts"
+s = open(p).read()
+s = s.replace('Our stored record says ${vendorName} offers a free tier: ${primary.tier}. ${withUnconfirmedTermsCaveat(storedTerms)}',
+              'Our stored record says ${vendorName} offers a free tier.')
+open(p, "w").write(s)
+PY
+}
+
+# --- the alternatives page, which re-asserted a level of its own ---
+
+m_alternatives_page_publishes_the_level_anyway() {
+  py <<'PY'
+p = "src/serve.ts"
+s = open(p).read()
+s = s.replace('    parts.push(\n      enriched.risk_level === null\n', '    parts.push(\n      false\n')
+open(p, "w").write(s)
+PY
+}
+
+m_alternatives_page_answers_yes_anyway() {
+  py <<'PY'
+p = "src/serve.ts"
+s = open(p).read()
+s = s.replace('  const faqFreeTierAnswer = altLevelWithheld\n', '  const faqFreeTierAnswer = false\n')
+open(p, "w").write(s)
+PY
+}
+
+m_alternatives_page_reads_an_empty_history_as_stable() {
+  py <<'PY'
+p = "src/serve.ts"
+s = open(p).read()
+s = s.replace('    : altLevelWithheld\n    ? `We hold no recorded pricing changes for ${vendorName}, but ${altWithheldClause}, so that is a statement about our records rather than a positive signal.`\n',
+              '    : false\n    ? `We hold no recorded pricing changes for ${vendorName}, but ${altWithheldClause}, so that is a statement about our records rather than a positive signal.`\n')
+open(p, "w").write(s)
+PY
+}
+
+m_alternatives_page_names_no_reason() {
+  py <<'PY'
+p = "src/serve.ts"
+s = open(p).read()
+s = s.replace('  const altWithheldSentence = altLevelWithheld\n    ? withheldLevelSentence(altLevelWithheld, vendorName, altUnconfirmableSince)\n    : "";',
+              '  const altWithheldSentence = "";')
+open(p, "w").write(s)
+PY
+}
+
+# --- the tool result, which is a surface like any other ---
+
+m_tool_summary_falls_through_to_a_stable_history() {
+  py <<'PY'
+p = "src/data.ts"
+s = open(p).read()
+s = s.replace('  } else if (withheldReason) {', '  } else if (withheldReason && withheldReason !== "states_no_terms") {')
+open(p, "w").write(s)
+PY
+}
+
+m_tool_summary_names_the_wrong_reason() {
+  py <<'PY'
+p = "src/data.ts"
+s = open(p).read()
+s = s.replace('${withheldLevelSentence(withheldReason, offer.vendor, unreachableSince)}',
+              '${withheldLevelSentence("unreadable", offer.vendor, unreachableSince)}')
+open(p, "w").write(s)
+PY
+}
+
+m_enriched_record_keeps_its_level() {
+  py <<'PY'
+p = "src/data.ts"
+s = open(p).read()
+s = s.replace('      cannotVouchForLevel(offer, link_unreachable) && assessment.level === "stable"\n        ? null\n        : assessment.level;',
+              '      assessment.level;')
+open(p, "w").write(s)
+PY
+}
+
+run_mutation "states_no_terms is dropped from the withholding list"        m_no_terms_no_longer_withholds
+run_mutation "a confirmed source withholds a level too"                    m_confirmed_source_withholds_too
+run_mutation "the states-no-terms clause reads as an unread page"          m_no_terms_clause_reads_as_unreadable
+run_mutation "the states-no-terms sentence reads as an unnamed vendor"     m_no_terms_sentence_reads_as_unnamed
+run_mutation "every reason collapses to one sentence"                      m_every_reason_shares_one_sentence
+run_mutation "'Is X free?' ignores the withholding"                        m_is_x_free_ignores_the_withholding
+run_mutation "'What is X's free tier?' ignores the withholding"            m_what_is_x_tier_ignores_the_withholding
+run_mutation "the answer drops the reason we cannot confirm it"            m_answer_drops_the_reason_it_cannot_confirm
+run_mutation "the answer drops the unverified caveat"                      m_answer_drops_the_unverified_caveat
+run_mutation "the answer drops the stored terms"                           m_answer_drops_the_stored_terms
+run_mutation "the alternatives page publishes a level anyway"              m_alternatives_page_publishes_the_level_anyway
+run_mutation "the alternatives page answers Yes anyway"                    m_alternatives_page_answers_yes_anyway
+run_mutation "the alternatives page reads an empty history as stable"      m_alternatives_page_reads_an_empty_history_as_stable
+run_mutation "the alternatives page names no reason"                       m_alternatives_page_names_no_reason
+run_mutation "the tool summary falls through to a stable history"          m_tool_summary_falls_through_to_a_stable_history
+run_mutation "the tool summary names the wrong reason"                     m_tool_summary_names_the_wrong_reason
+run_mutation "the enriched record keeps its withheld level"                m_enriched_record_keeps_its_level
+
+echo
+echo "killed:   $killed"
+echo "survived: $survived"
+[ "$survived" -eq 0 ]

--- a/src/data.ts
+++ b/src/data.ts
@@ -6,7 +6,7 @@ import { isUrlSuspended } from "./referral-health.js";
 import { rankForListing } from "./ranking.js";
 import { unreachableNoticeForUrl, resetLinkHealthCache } from "./link-health.js";
 import { quarantineSummary, resetVerificationStateCache, type QuarantineSummary } from "./verification-state.js";
-import { cannotVouchForLevel, sourceDoesNotNameVendor, sourceUnreadable } from "./source-check.js";
+import { cannotVouchForLevel, levelWithheldReason, withheldLevelSentence } from "./source-check.js";
 import { filterAlternatives } from "./product-role.js";
 import { DATE_SOURCES, isEventDated, changeDateClause } from "./change-dates.js";
 
@@ -775,19 +775,17 @@ export function checkVendorRisk(
   // and a warning without its reason is an assertion.
   let summary: string;
   const cause = assessment.cause;
+  const unreachableSince = linkUnreachable?.last_reachable ? ` since ${linkUnreachable.last_reachable}` : "";
+  const withheldReason = levelWithheldReason(offer, linkUnreachable);
   const unreachableClause = linkUnreachable
-    ? ` Its pricing page has not resolved for us${linkUnreachable.last_reachable ? ` since ${linkUnreachable.last_reachable}` : ""}, so we cannot confirm its current terms.`
+    ? ` Its pricing page has not resolved for us${unreachableSince}, so we cannot confirm its current terms.`
     : "";
   if (riskLevel === "risky" && cause) {
     summary = `${offer.vendor} is high risk — ${changeDateClause(cause)}: ${cause.summary} Consider alternatives.${unreachableClause}`;
   } else if (riskLevel === "caution" && cause) {
     summary = `${offer.vendor} warrants caution — ${changeDateClause(cause)}: ${cause.summary} Monitor for further changes.${unreachableClause}`;
-  } else if (linkUnreachable) {
-    summary = `We hold no free tier removal, limit reduction or pricing restructure on record for ${offer.vendor}.${unreachableClause} Treat that as a statement about our records, not as a stable pricing history.`;
-  } else if (sourceDoesNotNameVendor(offer)) {
-    summary = `We hold no free tier removal, limit reduction or pricing restructure on record for ${offer.vendor}. The page we cite for it does not name it, so nothing we have read describes this offer. Treat that as a statement about our records, not as a stable pricing history.`;
-  } else if (sourceUnreadable(offer)) {
-    summary = `We hold no free tier removal, limit reduction or pricing restructure on record for ${offer.vendor}. We could not read the page we cite for it, so nothing we have read describes this offer. Treat that as a statement about our records, not as a stable pricing history.`;
+  } else if (withheldReason) {
+    summary = `We hold no free tier removal, limit reduction or pricing restructure on record for ${offer.vendor}. ${withheldLevelSentence(withheldReason, offer.vendor, unreachableSince)} Nothing we have read describes this offer. Treat that as a statement about our records, not as a stable pricing history.`;
   } else {
     summary = `${offer.vendor} has a stable pricing history with no free tier removal, limit reduction or pricing restructure on record. Free tier verified for ${longevityDays} days.`;
   }

--- a/src/serve.ts
+++ b/src/serve.ts
@@ -16,7 +16,7 @@ import { buildDailyRollup, readRollups, coverageOf, ROLLUP_DATE_PATTERN } from "
 import { configureVendorSeries, recordVendorRequest, flushVendorSeries, readVendorSeries, vendorSeriesGauge, vendorExportAuthorized, isSeriesDate, seriesDateRange, VENDOR_SERIES_PATH, VENDOR_SERIES_RETENTION_DAYS, VENDOR_SERIES_NOTES } from "./vendor-series.js";
 import { openapiSpec } from "./openapi.js";
 import { LINK_GRACE_DAYS } from "./link-health.js";
-import { levelWithheldReason, type LevelWithheldReason } from "./source-check.js";
+import { levelWithheldReason, withheldLevelClause, withheldLevelSentence } from "./source-check.js";
 import { registerAgent, authenticateRequest, validateVestauthUrl, hashApiKey, updateAgentX402Address, getAgentById } from "./agents.js";
 import { logReferralRequest } from "./referral-requests.js";
 import { recordConversion, confirmEligibleEntries, clawbackEntry, getAgentBalance, getAgentLedgerEntries, recordPayout, MINIMUM_PAYOUT_AMOUNT, getLeaderboard } from "./ledger.js";
@@ -477,18 +477,6 @@ function riskBadgeHtml(
   const badge = `<span style="display:inline-block;${margin}font-size:${size};padding:.15rem .5rem;border-radius:10px;background:${color}22;color:${color};font-weight:600">${level}</span>`;
   if (level === "stable" || !cause) return badge;
   return `${badge} <span style="font-size:${size};color:var(--text-dim)" title="${escHtmlServer(cause.summary)}">${escHtmlServer(riskCauseLabel(cause))}</span>`;
-}
-
-function withheldLevelClause(reason: LevelWithheldReason, since: string): string {
-  if (reason === "link_unreachable") return `its pricing page has not resolved for us${since}`;
-  if (reason === "does_not_name_vendor") return `the page we cite for this offer does not name it`;
-  return `we could not read the page we cite for this offer`;
-}
-
-function withheldLevelSentence(reason: LevelWithheldReason, vendorName: string, since: string): string {
-  if (reason === "link_unreachable") return `${vendorName}'s pricing page has not resolved for us${since}.`;
-  if (reason === "does_not_name_vendor") return `The page we cite for ${vendorName} does not name it.`;
-  return `We could not read the page we cite for ${vendorName}.`;
 }
 
 function stabilityCellHtml(stability: string, linkUnreachable: LinkUnreachable | null | undefined, offer?: Pick<Offer, "source_check">): string {
@@ -4213,8 +4201,18 @@ ${allCompareLinks.join("\n")}
   }
 
   // FAQ data for vendor pages — expanded to 6-8 questions
-  const faqFreeAnswer = `Yes, ${vendorName} offers a free tier: ${primary.tier}. ${primary.description.slice(0, 200)}${primary.description.length > 200 ? "..." : ""}`;
-  const faqTierAnswer = `${vendorName}'s free tier is called "${primary.tier}". ${primary.description}`;
+  const storedTerms = `${primary.description.slice(0, 200)}${primary.description.length > 200 ? "..." : ""}`;
+  const unconfirmedTermsPreamble = levelWithheld
+    ? `We cannot confirm that today. ${withheldLevelSentence(levelWithheld, vendorName, unconfirmableSince)} `
+    : "";
+  const withUnconfirmedTermsCaveat = (terms: string) =>
+    `${terms}${/[.!?…]$/.test(terms.trim()) ? "" : "."} We have not confirmed these terms against the source we cite, so treat them as unverified.`;
+  const faqFreeAnswer = levelWithheld
+    ? `${unconfirmedTermsPreamble}Our stored record says ${vendorName} offers a free tier: ${primary.tier}. ${withUnconfirmedTermsCaveat(storedTerms)}`
+    : `Yes, ${vendorName} offers a free tier: ${primary.tier}. ${storedTerms}`;
+  const faqTierAnswer = levelWithheld
+    ? `${unconfirmedTermsPreamble}Our stored record calls ${vendorName}'s free tier "${primary.tier}". ${withUnconfirmedTermsCaveat(primary.description)}`
+    : `${vendorName}'s free tier is called "${primary.tier}". ${primary.description}`;
   // #1038: these answers ship inside FAQPage JSON-LD, which is the version of
   // this page an AI search engine quotes. They used to reach for the *count* of
   // recorded changes and for `vendorChanges[0]` — the most recent record of any
@@ -4449,6 +4447,16 @@ function buildAlternativesPage(slug: string): string | null {
 
   const riskColors: Record<string, string> = { stable: "#3fb950", caution: "#d29922", risky: "#f85149" };
   const riskCause = enriched.risk_cause;
+  const altLevelWithheld = levelWithheldReason(primary, enriched.link_unreachable);
+  const altUnconfirmableSince = enriched.link_unreachable?.last_reachable
+    ? ` since ${enriched.link_unreachable.last_reachable}`
+    : "";
+  const altWithheldSentence = altLevelWithheld
+    ? withheldLevelSentence(altLevelWithheld, vendorName, altUnconfirmableSince)
+    : "";
+  const altWithheldClause = altLevelWithheld
+    ? withheldLevelClause(altLevelWithheld, altUnconfirmableSince)
+    : "";
   // #1038: no publishable cause, no warning.
   const riskLevel = enriched.risk_level && (enriched.risk_level === "stable" || riskCause) ? enriched.risk_level : "stable";
   const riskColor = riskColors[riskLevel] ?? "#8b949e";
@@ -4500,7 +4508,14 @@ function buildAlternativesPage(slug: string): string | null {
   // Situation section: why look for alternatives
   const situationHtml = (() => {
     const parts: string[] = [];
-    parts.push(`<div class="risk-row"><span class="risk-label">Risk Level:</span> <span class="risk-badge-inline" style="background:${riskColor}20;color:${riskColor};border:1px solid ${riskColor}40">${riskLevel}</span></div>`);
+    parts.push(
+      enriched.risk_level === null
+        ? `<div class="risk-row"><span class="risk-label">Risk Level:</span> <span class="risk-badge-inline" style="background:#8b949e20;color:var(--text-dim);border:1px solid #8b949e40" title="${escHtmlServer(altWithheldClause.charAt(0).toUpperCase() + altWithheldClause.slice(1))}">source unconfirmed</span></div>`
+        : `<div class="risk-row"><span class="risk-label">Risk Level:</span> <span class="risk-badge-inline" style="background:${riskColor}20;color:${riskColor};border:1px solid ${riskColor}40">${riskLevel}</span></div>`
+    );
+    if (enriched.risk_level === null) {
+      parts.push(`<div class="risk-row"><span class="risk-label">Why:</span> ${escHtmlServer(altWithheldSentence)} We are not publishing a stability judgement for it until that is fixed.</div>`);
+    }
     if (riskLevel !== "stable" && riskCause) {
       parts.push(`<div class="risk-row"><span class="risk-label">Why:</span> <span class="risk-cause-date" style="font-family:var(--mono)">${escHtmlServer(changeDateLabel(riskCause))}</span> &mdash; ${escHtmlServer(riskCause.summary)}</div>`);
     }
@@ -4610,7 +4625,9 @@ ${enrichedAlts.map(a => altCard(a, false)).join("\n")}
   // #1038: "flagged due to N recorded pricing changes" then quoting
   // vendorChanges[0] could hand the reader a limits_increased record as the
   // reason for a warning. The flag has exactly one cause and this names it.
-  const faqFreeTierAnswer = riskLevel === "stable"
+  const faqFreeTierAnswer = altLevelWithheld
+    ? `We cannot confirm that today. ${altWithheldSentence} Our stored record says ${vendorName} offers a free tier (${primary.tier}), but we have not confirmed those terms against the source we cite.`
+    : riskLevel === "stable"
     ? `Yes, ${vendorName} currently offers a free tier (${primary.tier}). ${vendorChanges.length === 0 ? "No pricing changes have been recorded." : `We hold ${vendorChanges.length === 1 ? "1 recorded change" : `${vendorChanges.length} recorded changes`} for this vendor, none of them a free tier removal, limit reduction or pricing restructure.`}`
     : riskLevel === "caution"
     ? `${vendorName} has a free tier (${primary.tier}), but it's flagged as "caution" because of one specific recorded change${riskCause ? `, ${changeDateClause(riskCause)}: ${riskCause.summary}` : "."}`
@@ -4618,6 +4635,8 @@ ${enrichedAlts.map(a => altCard(a, false)).join("\n")}
   const faqCountAnswer = `There are ${enrichedAlts.length} free alternatives to ${vendorName} tracked on AgentDeals across the ${vendorCategories.join(", ")} categor${vendorCategories.length > 1 ? "ies" : "y"}.`;
   const faqChangesAnswer = vendorChanges.length > 0
     ? `Yes, ${vendorName} has ${vendorChanges.length} recorded pricing change${vendorChanges.length !== 1 ? "s" : ""}. The most recent was ${changeDateClause(vendorChanges[0])}: ${vendorChanges[0].summary}`
+    : altLevelWithheld
+    ? `We hold no recorded pricing changes for ${vendorName}, but ${altWithheldClause}, so that is a statement about our records rather than a positive signal.`
     : `No, ${vendorName} has no recorded pricing changes on AgentDeals. This indicates stable pricing.`;
 
   const altFaqItems = [

--- a/src/source-check.ts
+++ b/src/source-check.ts
@@ -7,19 +7,46 @@ export const SOURCE_CHECK_OUTCOMES: SourceCheckOutcome[] = [
   "unreadable",
 ];
 
-export type LevelWithheldReason = "link_unreachable" | "does_not_name_vendor" | "unreadable";
+export type LevelWithheldReason =
+  | "link_unreachable"
+  | "does_not_name_vendor"
+  | "states_no_terms"
+  | "unreadable";
 
 export const LEVEL_WITHHOLDING_OUTCOMES: SourceCheckOutcome[] = [
   "does_not_name_vendor",
+  "states_no_terms",
   "unreadable",
 ];
 
-export function sourceDoesNotNameVendor(offer: Pick<Offer, "source_check">): boolean {
-  return offer.source_check?.outcome === "does_not_name_vendor";
+const WITHHELD_LEVEL_CLAUSES: Record<LevelWithheldReason, (since: string) => string> = {
+  link_unreachable: (since) => `its pricing page has not resolved for us${since}`,
+  does_not_name_vendor: () => `the page we cite for this offer does not name it`,
+  states_no_terms: () => `the page we cite for this offer states no terms we can read`,
+  unreadable: () => `we could not read the page we cite for this offer`,
+};
+
+const WITHHELD_LEVEL_SENTENCES: Record<LevelWithheldReason, (subject: string, since: string) => string> = {
+  link_unreachable: (subject, since) => `${subject}'s pricing page has not resolved for us${since}.`,
+  does_not_name_vendor: (subject) => `The page we cite for ${subject} does not name it.`,
+  states_no_terms: (subject) => `The page we cite for ${subject} states no terms we can read.`,
+  unreadable: (subject) => `We could not read the page we cite for ${subject}.`,
+};
+
+export function withheldLevelClause(reason: LevelWithheldReason, since = ""): string {
+  return WITHHELD_LEVEL_CLAUSES[reason](since);
 }
 
-export function sourceUnreadable(offer: Pick<Offer, "source_check">): boolean {
-  return offer.source_check?.outcome === "unreadable";
+export function withheldLevelSentence(
+  reason: LevelWithheldReason,
+  subject: string,
+  since = "",
+): string {
+  return WITHHELD_LEVEL_SENTENCES[reason](subject, since);
+}
+
+export function sourceDoesNotNameVendor(offer: Pick<Offer, "source_check">): boolean {
+  return offer.source_check?.outcome === "does_not_name_vendor";
 }
 
 export function sourceCheckNotice(offer: Pick<Offer, "source_check">): SourceCheck | null {

--- a/test/source-check-pages.test.ts
+++ b/test/source-check-pages.test.ts
@@ -77,6 +77,14 @@ const get = async (p: string) => {
   return { status: res.status, body: await res.text() };
 };
 
+function faqAnswers(body: string): string[] {
+  const page = [...body.matchAll(/<script type="application\/ld\+json">([\s\S]*?)<\/script>/g)]
+    .map((m) => { try { return JSON.parse(m[1]); } catch { return null; } })
+    .find((json) => json && json["@type"] === "FAQPage");
+  assert.ok(page, "the page must ship FAQPage structured data for the assertion to mean anything");
+  return page.mainEntity.map((entry: { acceptedAnswer: { text: string } }) => entry.acceptedAnswer.text);
+}
+
 function aboutThisVendor({ body }: { body: string }): string {
   const verdict = body.match(/<div class="quick-verdict">[\s\S]*?<\/div>/)?.[0];
   const history = body.match(/<p class="no-changes">[\s\S]*?<\/p>/)?.[0];
@@ -211,18 +219,90 @@ describe("the two withheld reasons read differently to somebody deciding whether
   });
 });
 
-describe("a vendor page whose cited source names it but states its terms in prose", () => {
-  it("still publishes a stability judgement", async () => {
+describe("a vendor page whose cited source names it but states no terms we can read", () => {
+  it("publishes no stability judgement", async () => {
     const { body } = await get("/vendor/prosecorp");
-    assert.match(body, /This is a good sign — stable pricing/);
+    assert.doesNotMatch(body, /This is a good sign — stable pricing/);
+    assert.doesNotMatch(body, /It's stable — zero pricing changes recorded/);
     const row = body.match(/<tr class="current-vendor-row">[\s\S]*?<\/tr>/)?.[0] ?? "";
     assert.ok(row.includes("Prosecorp"), "the row under test must be the vendor's own");
-    assert.doesNotMatch(row, /source unconfirmed/);
-    assert.match(row, /stability-dot/);
+    assert.match(row, /source unconfirmed/);
+    assert.doesNotMatch(row, /stability-dot/);
   });
 
-  it("still publishes a level through the API", async () => {
+  it("publishes no level through the API", async () => {
     const { body } = await get("/api/offers?q=prosecorp");
-    assert.strictEqual(JSON.parse(body).offers[0].risk_level, "stable");
+    const offer = JSON.parse(body).offers[0];
+    assert.strictEqual(offer.risk_level, null);
+    assert.strictEqual(offer.source_check.outcome, "states_no_terms");
   });
+
+  it("says the page states no terms rather than that we could not read it", async () => {
+    const own = aboutThisVendor(await get("/vendor/prosecorp"));
+    assert.match(own, /states no terms we can read/);
+    assert.doesNotMatch(own, /could not read the page we cite/);
+    assert.doesNotMatch(own, /does not name it/);
+  });
+});
+
+describe("the question an answer engine quotes first", () => {
+  const q1 = (body: string) => faqAnswers(body)[0];
+  const q2 = (body: string) => faqAnswers(body)[1];
+
+  it("answers a bare Yes only where the source confirms the terms", async () => {
+    const { body } = await get("/vendor/controlcorp");
+    assert.match(q1(body), /^Yes, Controlcorp offers a free tier/);
+    assert.match(q2(body), /^Controlcorp's free tier is called/);
+  });
+
+  for (const [slug, vendor, reason] of [
+    ["fixturecorp", "Fixturecorp", /does not name it/],
+    ["shellcorp", "Shellcorp", /could not read the page we cite/],
+    ["prosecorp", "Prosecorp", /states no terms we can read/],
+  ] as const) {
+    it(`does not answer Yes for ${vendor}, and carries the reason in the answer itself`, async () => {
+      const { body } = await get(`/vendor/${slug}`);
+      for (const answer of [q1(body), q2(body)]) {
+        assert.doesNotMatch(answer, /^Yes, /);
+        assert.match(answer, reason);
+        assert.match(answer, /treat them as unverified/);
+      }
+    });
+
+    it(`still shows the stored terms for ${vendor} rather than dropping them`, async () => {
+      const { body } = await get(`/vendor/${slug}`);
+      assert.match(q1(body), /30% off for 3 months/);
+    });
+  }
+});
+
+describe("an alternatives page for a vendor whose source we cannot vouch for", () => {
+  it("publishes a stable risk level only where the source confirms the terms", async () => {
+    const { body } = await get("/alternative-to/controlcorp");
+    assert.match(body, /Risk Level:[\s\S]{0,220}>stable</);
+    assert.match(faqAnswers(body)[1], /^Yes, Controlcorp currently offers a free tier/);
+  });
+
+  for (const [slug, vendor, reason] of [
+    ["fixturecorp", "Fixturecorp", /does not name it/],
+    ["shellcorp", "Shellcorp", /could not read the page we cite/],
+    ["prosecorp", "Prosecorp", /states no terms we can read/],
+  ] as const) {
+    it(`does not re-assert a stable risk level for ${vendor}`, async () => {
+      const { body } = await get(`/alternative-to/${slug}`);
+      const riskRow = body.match(/Risk Level:[\s\S]{0,300}?<\/div>/)?.[0] ?? "";
+      assert.ok(riskRow.length > 0, "the page must carry a risk row for the assertion to mean anything");
+      assert.doesNotMatch(riskRow, />stable</);
+      assert.match(riskRow, /source unconfirmed/);
+      assert.match(body, reason);
+    });
+
+    it(`does not read an empty change history for ${vendor} as stable pricing`, async () => {
+      const { body } = await get(`/alternative-to/${slug}`);
+      assert.doesNotMatch(body, /This indicates stable pricing/);
+      const stillAvailable = faqAnswers(body)[1];
+      assert.doesNotMatch(stillAvailable, /^Yes, /);
+      assert.match(stillAvailable, reason);
+    });
+  }
 });

--- a/test/source-check.test.ts
+++ b/test/source-check.test.ts
@@ -2,10 +2,13 @@ import { describe, it } from "node:test";
 import assert from "node:assert";
 import {
   SOURCE_CHECK_OUTCOMES,
+  LEVEL_WITHHOLDING_OUTCOMES,
   sourceDoesNotNameVendor,
   cannotVouchForLevel,
   levelWithheldReason,
   sourceCheckNotice,
+  withheldLevelClause,
+  withheldLevelSentence,
 } from "../dist/source-check.js";
 import { enrichOffers, loadOffers, checkVendorRisk } from "../dist/data.js";
 
@@ -23,6 +26,12 @@ const CITED_PAGE_COULD_NOT_BE_READ = {
   detail: "page content too short (likely JS-rendered SPA)",
 };
 
+const CITED_PAGE_STATES_NO_TERMS = {
+  checked: "2026-08-28",
+  outcome: "states_no_terms",
+  detail: "the page names Canva but states no amount, tier or rate we can read",
+};
+
 describe("an offer whose cited page cannot verify it", () => {
   it("uses the same outcome vocabulary as the job that writes it", () => {
     assert.deepStrictEqual([...SOURCE_CHECK_OUTCOMES].sort(), [...WRITTEN_OUTCOMES].sort());
@@ -37,18 +46,44 @@ describe("an offer whose cited page cannot verify it", () => {
     assert.strictEqual(cannotVouchForLevel({ source_check: CITED_PAGE_COULD_NOT_BE_READ }, null), true);
   });
 
-  it("does not withhold on an outcome that only says the page was thin", () => {
-    const thin = { checked: "2026-08-28", outcome: "states_no_terms", detail: "no amount, tier or rate" };
-    assert.strictEqual(sourceDoesNotNameVendor({ source_check: thin }), false);
-    assert.strictEqual(cannotVouchForLevel({ source_check: thin }, null), false);
-    assert.ok(sourceCheckNotice({ source_check: thin }));
+  it("withholds a favourable risk level where the cited page states no terms we can read", () => {
+    assert.strictEqual(sourceDoesNotNameVendor({ source_check: CITED_PAGE_STATES_NO_TERMS }), false);
+    assert.strictEqual(cannotVouchForLevel({ source_check: CITED_PAGE_STATES_NO_TERMS }, null), true);
+    assert.ok(sourceCheckNotice({ source_check: CITED_PAGE_STATES_NO_TERMS }));
+  });
+
+  it("publishes a level for the one outcome that confirms the terms we cite", () => {
+    assert.strictEqual(
+      cannotVouchForLevel({ source_check: { checked: "2026-08-28", outcome: "ok", detail: "text" } }, null),
+      false
+    );
   });
 
   it("names which of the reasons is holding the level back", () => {
     assert.strictEqual(levelWithheldReason({ source_check: CITED_PAGE_NAMES_SOMEBODY_ELSE }, null), "does_not_name_vendor");
     assert.strictEqual(levelWithheldReason({ source_check: CITED_PAGE_COULD_NOT_BE_READ }, null), "unreadable");
+    assert.strictEqual(levelWithheldReason({ source_check: CITED_PAGE_STATES_NO_TERMS }, null), "states_no_terms");
     assert.strictEqual(levelWithheldReason({}, { checked: "2026-08-28" }), "link_unreachable");
     assert.strictEqual(levelWithheldReason({}, null), null);
+  });
+
+  it("names a reason for every outcome that withholds, so none can fall through", () => {
+    for (const outcome of LEVEL_WITHHOLDING_OUTCOMES) {
+      assert.strictEqual(
+        levelWithheldReason({ source_check: { checked: "2026-08-28", outcome, detail: "d" } }, null),
+        outcome,
+        `${outcome} withholds a level but names no reason for it`
+      );
+    }
+  });
+
+  it("gives every reason its own prose, so no two of them read alike", () => {
+    const reasons = ["link_unreachable", ...LEVEL_WITHHOLDING_OUTCOMES] as const;
+    const clauses = reasons.map((r) => withheldLevelClause(r, ""));
+    const sentences = reasons.map((r) => withheldLevelSentence(r, "Examplebase", ""));
+    for (const text of [...clauses, ...sentences]) assert.ok(text.length > 0);
+    assert.strictEqual(new Set(clauses).size, reasons.length, "two reasons share a clause");
+    assert.strictEqual(new Set(sentences).size, reasons.length, "two reasons share a sentence");
   });
 
   it("reports a dead link ahead of anything the page check said about it", () => {
@@ -152,6 +187,65 @@ describe("what the enriched record publishes for a source we could not read", ()
       if (++checked === 20) break;
     }
     assert.ok(checked > 0, "no vendor is sourced only from pages that state no figure we recognise");
+  });
+});
+
+describe("what the tool tells an agent about a source that states no terms we can read", () => {
+  const vendorsSourcedOnlyFromPagesStatingNoTerms = (): string[] => {
+    const byVendor = new Map<string, any[]>();
+    for (const offer of loadOffers() as any[]) {
+      const key = offer.vendor.toLowerCase();
+      if (!byVendor.has(key)) byVendor.set(key, []);
+      byVendor.get(key)!.push(offer);
+    }
+    return [...byVendor.values()]
+      .filter((records) => records.every((o) => o.source_check?.outcome === "states_no_terms"))
+      .map((records) => records[0].vendor);
+  };
+
+  it("holds every such record back from a stable badge", () => {
+    const enriched = enrichOffers(loadOffers() as any[]) as any[];
+    const statingNoTerms = enriched.filter(
+      (o) => o.source_check?.outcome === "states_no_terms" && !o.link_unreachable
+    );
+    assert.ok(statingNoTerms.length > 0, "no record in the index cites a page that states no terms");
+    for (const offer of statingNoTerms) {
+      assert.notStrictEqual(
+        offer.risk_level,
+        "stable",
+        `${offer.vendor} is badged stable from a page that states no terms we can read`
+      );
+    }
+  });
+
+  it("does not claim a stable pricing history for it", () => {
+    let checked = 0;
+    for (const vendor of vendorsSourcedOnlyFromPagesStatingNoTerms()) {
+      const { result } = checkVendorRisk(vendor) as any;
+      if (result.risk_level !== null) continue;
+      assert.doesNotMatch(
+        result.summary,
+        /has a stable pricing history/,
+        `${vendor} is told it has a stable pricing history from a page that states no terms`
+      );
+      if (++checked === 20) break;
+    }
+    assert.ok(checked > 0, "no vendor is sourced only from pages that state no terms we can read");
+  });
+
+  it("says which reason held the level back rather than leaving it unexplained", () => {
+    let said = 0;
+    for (const vendor of vendorsSourcedOnlyFromPagesStatingNoTerms()) {
+      const { result } = checkVendorRisk(vendor) as any;
+      if (result.risk_level !== null) continue;
+      assert.match(
+        result.summary,
+        /states no terms we can read/,
+        `${vendor} withholds a level without saying why`
+      );
+      if (++said === 20) break;
+    }
+    assert.ok(said > 0, "no vendor tells a caller its cited page states no terms we can read");
   });
 });
 

--- a/test/vendor-risk.test.ts
+++ b/test/vendor-risk.test.ts
@@ -57,25 +57,29 @@ describe("checkVendorRisk logic", () => {
     }
   });
 
-  it("alternatives are sorted by risk level", async () => {
+  it("alternatives are ordered by the demerits the ranking recorded, not by risk label", async () => {
     const { checkVendorRisk } = await import("../dist/data.js");
     const result = checkVendorRisk("Vercel");
     assert.ok(!("error" in result));
-    const riskOrder: Record<string, number> = { stable: 0, caution: 1, risky: 2 };
+    const total = (alt: { demerits: { points: number }[] }) =>
+      alt.demerits.reduce((sum, d) => sum + d.points, 0);
     for (let i = 1; i < result.result.alternatives.length; i++) {
       assert.ok(
-        riskOrder[result.result.alternatives[i].risk_level] >= riskOrder[result.result.alternatives[i - 1].risk_level],
-        "Alternatives should be sorted by risk level (stable first)"
+        total(result.result.alternatives[i]) >= total(result.result.alternatives[i - 1]),
+        `${result.result.alternatives[i].vendor} carries fewer demerits than the entry above it`
       );
     }
   });
 
-  it("alternatives include risk_level field", async () => {
+  it("alternatives carry a risk level we can publish, or null where we cannot vouch for one", async () => {
     const { checkVendorRisk } = await import("../dist/data.js");
     const result = checkVendorRisk("Supabase");
     assert.ok(!("error" in result));
     for (const alt of result.result.alternatives) {
-      assert.ok(["stable", "caution", "risky"].includes(alt.risk_level), `Alternative ${alt.vendor} should have valid risk_level`);
+      assert.ok(
+        ["stable", "caution", "risky", null].includes(alt.risk_level),
+        `Alternative ${alt.vendor} should have valid risk_level`
+      );
       assert.ok(alt.vendor);
       assert.ok(alt.category);
       assert.ok(alt.tier);


### PR DESCRIPTION
Refs #1122

## What was wrong, measured on production before touching anything

`data/index.json` holds 1,580 offers across 1,572 vendor pages. Splitting by the primary offer's `source_check.outcome`: **790 `ok`, 587 `states_no_terms`, 105 `unreadable`, 90 `does_not_name_vendor`.** (The issue's 794/591/105/90 counts offers; a vendor page reads its primary offer, and 1,580 offers collapse to 1,572 slugs.)

Sweeping every `/vendor/*` page on `agentdeals.dev`:

| Surface | Before | After |
|---|---|---|
| stability dot in the vendor's own comparison row | 1,377 (790 `ok` + 587 `states_no_terms`) | **790, all `ok`** |
| "It's stable — zero pricing changes recorded" | 1,197 (630 + 567) | **630, all `ok`** |
| "This is a good sign — stable pricing" | 1,197 (630 + 567) | **630, all `ok`** |
| Q3 "…is considered stable" | 1,245 (673 + 572) | **673, all `ok`** |
| Q1 opening with a bare "Yes," | **1,572 — every page** | **790, all `ok`** |

## Part A — one missing entry in a list

`LEVEL_WITHHOLDING_OUTCOMES` held `does_not_name_vendor` and `unreadable`. `states_no_terms` is the same statement with a different cause — we could not confirm these terms from the page we cite — and it is the largest of the three.

## AC-2 — the reasons could not be told apart, and the shape invited that

`withheldLevelClause`/`withheldLevelSentence` were `if/if/return`, so the last reason was whatever fell through. Adding a fourth reason to that shape silently gives it the `unreadable` wording.

They are now `Record<LevelWithheldReason, …>` in `src/source-check.ts`, so **a new reason cannot compile without prose of its own**, and `serve.ts` and `data.ts` both read them instead of keeping copies. That second half matters: `data.ts` had its own per-outcome `if` chain, which is how the tool result and the page came to say different things.

## Part B — the question an answer engine quotes first

`faqFreeAnswer` and `faqTierAnswer` were unconditional template strings. They now lead with what we cannot confirm and why, keep the stored terms, and close by saying those terms are unverified:

> **Is Canva free?** We cannot confirm that today. The page we cite for Canva states no terms we can read. Our stored record says Canva offers a free tier: Free. 5 GB cloud storage, 250,000+ free templates… We have not confirmed these terms against the source we cite, so treat them as unverified.

## Beyond the ACs: `/alternative-to/*` kept its own copy of the judgement, and it was wrong for all three outcomes

`buildAlternativesPage` reads `enriched.risk_level && … ? … : "stable"` — so a withheld level fell back to **`stable`**. Checked live before the change: `/alternative-to/kaggle` (`unreadable`), `/alternative-to/canva` (`states_no_terms`) and `/alternative-to/cloudways` (`does_not_name_vendor`) all rendered `Risk Level: stable`, "Yes, X currently offers a free tier" and "This indicates stable pricing". #1113 fixed `/vendor/*` and never reached here.

Measured locally, before → after:

| Surface | Before | After |
|---|---|---|
| `Risk Level: stable` | 1,429 (673 `ok` + 756 withheld) | **673, all `ok`** |
| "still available?" answering a bare "Yes," | 1,429 | **673, all `ok`** |
| "This indicates stable pricing" | 1,380 (630 + 750) | **630, all `ok`** |

I included this because AC-1's own example is the claim itself, not the page it was found on: leaving it would mean `/alternative-to/canva` still published `stable` for Canva after the issue closed.

The 756 rather than 782 is deliberate — a record carrying `caution` or `risky` with a dated cause still publishes that level. Withholding suppresses the favourable claim, not an adverse one we can back. `/alternative-to/openai` still reads `risky`.

## AC-5 and the positive control

**790 vendor pages render a stability badge after the change, every one of them `source_check.outcome: ok`.** Zero for the other three outcomes.

The control is exact rather than argued: diffing every page's `<h1>`, quick verdict, change-history paragraph, Q1, Q2 and Q3 before against after — **0 of 790 `ok` pages changed a single character**, and all 782 withheld pages changed.

## Verification

- **2,305/2,305** tests, up from 2,284.
- **`scripts/mutate-1122.sh` — 17/17 killed**, none by the compiler. One real survivor on the first pass: the tool summary could still fall through to "has a stable pricing history" for a `states_no_terms` vendor with nothing asserting otherwise. Three tests now pin it.
- **`scripts/mutate-1113.sh` — 14/14 killed** after retargeting six mutations that this change moved or inverted. Two of them pointed at `serve.ts` functions that now live in `source-check.ts`, and one asserted a behaviour this PR ships.
- **`scripts/e2e-1122.mjs` — 69/69** against a server on the real index: one record of each outcome, the confirmed-source control, the five pages #1113 closed on, the alternatives pages, and a sweep of all 1,572 vendor pages.
- Real MCP `initialize` → `tools/call` over streamable-http, plus `/api/vendor-risk/*` for the summary path.

## Two things to flag

**`test/vendor-risk.test.ts` "alternatives are sorted by risk level" was already failing on `main` before this branch** — I confirmed it by stashing. `rankForListing` orders by demerit total with a date-seeded shuffle inside ties, so the risk-level ordering it asserted is a property the ranking stopped promising in #1025; it passes or fails depending on the day's rotation. It now asserts the demerit ordering the ranking does promise. Its neighbour asserted `risk_level` is always one of three strings, which `null` has been a legitimate value for since #1112 and is now far more common, so that one accepts `null` too.

**No screenshots this time** — the sandbox could not fetch a Chromium build for `shot-scraper`. Verified by reading the rendered visible text of each changed block instead, not only the JSON-LD.
