### PR TITLE
Read the outgrow threshold's period from the clause it appears in

### DIFF
--- a/scripts/e2e-1121.mjs
+++ b/scripts/e2e-1121.mjs
@@ -1,0 +1,261 @@
+/**
+ * Drives the outgrow line on every surface #1121 names, against a server
+ * running the real index.
+ *
+ * Nothing here is stubbed: the server loads data/index.json, and each check
+ * reads the rendered block or the FAQPage structured data a caller receives.
+ *
+ * Usage: node scripts/e2e-1121.mjs
+ */
+
+import { spawn } from "node:child_process";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { levelWithheldReason } from "../dist/source-check.js";
+import { enrichOffers } from "../dist/data.js";
+
+const REPO = path.join(path.dirname(fileURLToPath(import.meta.url)), "..");
+
+const UNDERSTATED = {
+  "embed.ly": "15 requests/sec",
+  "Discord API": "5 messages per 5 seconds per channel",
+  "OpenAI": "3 requests/min",
+  "Gemini CLI": "60 requests/min",
+  "Cerebras": "30 requests/min",
+  "codehooks.io": "60 API calls/min",
+  "SerpApi": "50 requests/hour",
+  "UserCheck": "120 requests/hour",
+  "ampt.dev": "500 invocations/hour",
+  "MiniMax": "7 requests per 5 hours",
+  "Beeceptor": "50 requests/day",
+  "Country-State-City Microservice API": "100 requests/day",
+  "Financial Data": "300 requests/day",
+  "Geolocated.io": "2,000 requests/day",
+  "IP Geolocation": "1,000 requests/day",
+  "microlink.io": "50 requests/day",
+  "Mockfly": "500 requests/day",
+  "Pocket Alert": "50 messages/day",
+  "Imitate Email": "15 emails/day",
+  "podio.com": "1,000 API calls/day",
+};
+
+const NO_PERIOD_STATED = {
+  "Inngest": "100K events",
+  "Authress": "1000 API calls",
+  "Logo.dev": "10,000 API calls",
+  "Pingram.io": "3000 Emails",
+  "phare.io": "100,000 events",
+  "AppFit": "200K events",
+};
+
+const NOT_A_RATE = { "Zulip": "10,000 messages of search history" };
+
+const CONFIRMED_RATE_CONTROL = "cloudflare-workers";
+
+let port = 0;
+let proc = null;
+let passed = 0;
+const failures = [];
+
+function check(name, fn) {
+  try {
+    fn();
+    passed++;
+    console.log(`  ok   ${name}`);
+  } catch (err) {
+    failures.push(`${name}: ${err.message}`);
+    console.log(`  FAIL ${name}\n       ${err.message}`);
+  }
+}
+
+function assert(condition, message) {
+  if (!condition) throw new Error(message);
+}
+
+function startServer() {
+  return new Promise((resolve, reject) => {
+    const child = spawn("node", [path.join(REPO, "dist", "serve.js")], {
+      stdio: ["pipe", "pipe", "pipe"],
+      env: { ...process.env, PORT: "0", BASE_URL: "http://localhost" },
+    });
+    const timeout = setTimeout(() => { child.kill(); reject(new Error("server startup timeout")); }, 30000);
+    child.stderr.on("data", (buf) => {
+      const m = buf.toString().match(/running on http:\/\/localhost:(\d+)/);
+      if (m) { port = parseInt(m[1], 10); clearTimeout(timeout); resolve(child); }
+    });
+    child.on("error", (err) => { clearTimeout(timeout); reject(err); });
+  });
+}
+
+const get = async (p) => {
+  const res = await fetch(`http://localhost:${port}${p}`, { redirect: "manual" });
+  return { status: res.status, body: await res.text() };
+};
+
+const growthBlock = (body) =>
+  body.match(/<div class="section growth-section">[\s\S]*?<\/div>/)?.[0] ?? "";
+
+function outgrowAnswer(body) {
+  const page = [...body.matchAll(/<script type="application\/ld\+json">([\s\S]*?)<\/script>/g)]
+    .map((m) => { try { return JSON.parse(m[1]); } catch { return null; } })
+    .find((json) => json && json["@type"] === "FAQPage");
+  if (!page) throw new Error("no FAQPage structured data on the page");
+  const entry = page.mainEntity.find((e) => /outgrow/i.test(e.name));
+  if (!entry) throw new Error("no outgrow question in the structured data");
+  return entry.acceptedAnswer.text;
+}
+
+const bullets = (body) =>
+  [...growthBlock(body).matchAll(/<li>([\s\S]*?)<\/li>/g)].map((m) => m[1].replace(/<[^>]*>/g, "").trim());
+
+const firstBullet = (body) => bullets(body)[0] ?? "";
+
+const rateBullet = (body) =>
+  bullets(body).find((b) => /^(At|We record) .*(requests|invocations|events|emails|messages|api ?calls)/i.test(b)) ?? "";
+
+const toSlug = (s) => s.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-|-$/g, "");
+
+const offers = JSON.parse(readFileSync(path.join(REPO, "data", "index.json"), "utf8")).offers;
+const primaryByVendor = new Map();
+for (const o of offers) if (!primaryByVendor.has(o.vendor)) primaryByVendor.set(o.vendor, o);
+
+function withheld(vendor) {
+  const offer = primaryByVendor.get(vendor);
+  return levelWithheldReason(offer, enrichOffers([offer])[0].link_unreachable);
+}
+
+async function main() {
+  proc = await startServer();
+
+  console.log("\nAC-1 — every understated rate now states the period its description states");
+  const rendered = [];
+  for (const [vendor, expected] of Object.entries(UNDERSTATED)) {
+    const slug = toSlug(vendor);
+    const { status, body } = await get(`/vendor/${slug}`);
+    check(`/vendor/${slug} renders`, () => assert(status === 200, `status ${status}`));
+    const bullet = rateBullet(body);
+    rendered.push(`| ${vendor} | ${bullet} |`);
+    check(`/vendor/${slug} states ${expected}`, () =>
+      assert(bullet.includes(expected), `first bullet reads: ${bullet}`));
+    if (!withheld(vendor)) {
+      check(`/vendor/${slug} does not say per month`, () =>
+        assert(!/\/mo\b/.test(bullet), `first bullet reads: ${bullet}`));
+    }
+  }
+
+  console.log("\nAC-2 — a description stating no period does not gain one");
+  for (const [vendor, expected] of Object.entries(NO_PERIOD_STATED)) {
+    const slug = toSlug(vendor);
+    const { body } = await get(`/vendor/${slug}`);
+    const bullet = rateBullet(body);
+    rendered.push(`| ${vendor} | ${bullet} |`);
+    check(`/vendor/${slug} states ${expected} with no period`, () =>
+      assert(bullet.includes(expected), `first bullet reads: ${bullet}`));
+    check(`/vendor/${slug} asserts no month`, () =>
+      assert(!/\/mo\b|per month/.test(bullet), `first bullet reads: ${bullet}`));
+  }
+
+  console.log("\nAC-3 — a description naming two periods for one noun does not merge them");
+  {
+    const { body } = await get("/vendor/gemini-cli");
+    const bullet = rateBullet(body);
+    check("/vendor/gemini-cli names the per-minute limit", () =>
+      assert(/60 requests\/min/.test(bullet), `first bullet reads: ${bullet}`));
+    check("/vendor/gemini-cli does not attach the daily period to the per-minute number", () =>
+      assert(!/60 requests\/day/.test(bullet), `first bullet reads: ${bullet}`));
+  }
+
+  console.log("\nAC-4 — a stored depth is not published as a rate");
+  for (const [vendor, expected] of Object.entries(NOT_A_RATE)) {
+    const slug = toSlug(vendor);
+    const { body } = await get(`/vendor/${slug}`);
+    const bullet = rateBullet(body);
+    rendered.push(`| ${vendor} | ${bullet} |`);
+    check(`/vendor/${slug} states ${expected}`, () =>
+      assert(bullet.includes(expected), `first bullet reads: ${bullet}`));
+    check(`/vendor/${slug} does not render it as a monthly allowance`, () =>
+      assert(!/messages\/mo/.test(bullet), `first bullet reads: ${bullet}`));
+  }
+
+  console.log("\nAC-5 — readers and structured data receive the same threshold");
+  for (const vendor of Object.keys(UNDERSTATED)) {
+    const slug = toSlug(vendor);
+    const { body } = await get(`/vendor/${slug}`);
+    const bullet = firstBullet(body);
+    const answer = outgrowAnswer(body);
+    check(`/vendor/${slug} leads its block with the threshold`, () =>
+      assert(bullet === rateBullet(body), `leads with: ${bullet}`));
+    check(`/vendor/${slug} ships one threshold to both surfaces`, () =>
+      assert(answer.startsWith(bullet), `visible: ${bullet}\n       structured: ${answer}`));
+  }
+
+  console.log("\nThe threshold withholds on the same condition the stability verdict does");
+  {
+    const { body } = await get("/vendor/siliconflow");
+    const block = growthBlock(body);
+    check("/vendor/siliconflow stops asserting a threshold as fact", () =>
+      assert(!/At 100 requests\/day, you'll need to upgrade/.test(block), `block reads: ${block}`));
+    check("/vendor/siliconflow keeps the recorded threshold visible", () =>
+      assert(/We record 100 requests\/day as the limit/.test(block), `block reads: ${block}`));
+    check("/vendor/siliconflow names why it cannot confirm it", () =>
+      assert(/states no terms we can read/.test(block), `block reads: ${block}`));
+    check("/vendor/siliconflow carries the caveat into structured data", () =>
+      assert(/we cannot confirm that threshold today/.test(outgrowAnswer(body)),
+        `structured answer: ${outgrowAnswer(body)}`));
+  }
+
+  console.log("\nEvery withheld record stops asserting its threshold, and no confirmed one does");
+  {
+    let withheldPages = 0;
+    let assertedThreshold = 0;
+    let confirmedPages = 0;
+    let confirmedCaveats = 0;
+    for (const [vendor, offer] of primaryByVendor) {
+      const { body } = await get(`/vendor/${toSlug(vendor)}`);
+      const block = growthBlock(body);
+      if (!block) continue;
+      if (withheld(vendor)) {
+        withheldPages++;
+        if (/^At .*you'll need to upgrade\./.test(firstBullet(body))) {
+          assertedThreshold++;
+          console.log(`       still asserting: ${vendor} — ${firstBullet(body)}`);
+        }
+      } else {
+        confirmedPages++;
+        if (/we cannot confirm that threshold today/.test(block)) {
+          confirmedCaveats++;
+          console.log(`       caveat on a confirmed page: ${vendor}`);
+        }
+      }
+      void offer;
+    }
+    check(`no withheld page asserts a threshold (${withheldPages} withheld pages)`, () =>
+      assert(assertedThreshold === 0, `${assertedThreshold} pages still assert one`));
+    check(`no confirmed page gained a caveat (${confirmedPages} confirmed pages)`, () =>
+      assert(confirmedCaveats === 0, `${confirmedCaveats} pages gained one`));
+  }
+
+  console.log("\nPositive control — a description whose period already matched is untouched");
+  {
+    const { body } = await get(`/vendor/${CONFIRMED_RATE_CONTROL}`);
+    check(`/vendor/${CONFIRMED_RATE_CONTROL} still reads 100K requests/day`, () =>
+      assert(/^At 100K requests\/day, you'll need to upgrade\.$/.test(rateBullet(body)),
+        `rate bullet reads: ${rateBullet(body)}`));
+  }
+
+  console.log("\nRendered thresholds\n");
+  console.log("| Vendor | Outgrow line |");
+  console.log("|---|---|");
+  for (const row of rendered) console.log(row);
+
+  console.log(`\n${passed} passed, ${failures.length} failed`);
+  if (failures.length) {
+    for (const f of failures) console.log(`  - ${f}`);
+    process.exitCode = 1;
+  }
+}
+
+main()
+  .catch((err) => { console.error(err); process.exitCode = 1; })
+  .finally(() => { if (proc) proc.kill(); });

--- a/scripts/mutate-1121.sh
+++ b/scripts/mutate-1121.sh
@@ -1,0 +1,265 @@
+#!/usr/bin/env bash
+#
+# Mutation testing for the rule that the "when you'll outgrow it" threshold
+# states the period its own description states, invents none where the
+# description states none, and withholds where the stability verdict does.
+#
+# Each mutation breaks one property the change is supposed to hold, rebuilds,
+# and runs the tests that claim to pin it. A surviving mutation means no test
+# is asserting that property. A mutation that changes no file proves nothing
+# and is reported as a survivor rather than silently passing.
+#
+# Usage:
+#   bash scripts/mutate-1121.sh
+#
+set -u
+
+REPO="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$REPO" || exit 1
+
+LIMITS="src/growth-limits.ts"
+SERVE="src/serve.ts"
+BACKUP_DIR="$(mktemp -d)"
+cp "$LIMITS" "$BACKUP_DIR/growth-limits.ts"
+cp "$SERVE" "$BACKUP_DIR/serve.ts"
+
+restore() {
+  cp "$BACKUP_DIR/growth-limits.ts" "$LIMITS"
+  cp "$BACKUP_DIR/serve.ts" "$SERVE"
+  npx tsc > /dev/null 2>&1
+}
+trap restore EXIT
+
+killed=0
+survived=0
+TESTS="test/growth-limits.test.ts"
+
+run_mutation() {
+  local name="$1"
+  shift
+  echo "=== $name"
+  restore
+  "$@"
+  local changed=0
+  for f in "$LIMITS" "$SERVE"; do
+    diff -q "$BACKUP_DIR/$(basename "$f")" "$f" > /dev/null || changed=1
+  done
+  if [ "$changed" -eq 0 ]; then
+    echo "    NOT APPLIED: the mutation changed no file, so it proves nothing"
+    survived=$((survived + 1))
+    return
+  fi
+  if ! npx tsc > /tmp/mutate-1121-build.log 2>&1; then
+    echo "    KILLED: does not compile"
+    killed=$((killed + 1))
+    return
+  fi
+  if timeout 900 node --test $TESTS > /tmp/mutate-1121-test.log 2>&1; then
+    echo "    SURVIVED"
+    survived=$((survived + 1))
+  else
+    echo "    KILLED: $(grep -c '✖ ' /tmp/mutate-1121-test.log) failing assertion(s)"
+    grep '✖ ' /tmp/mutate-1121-test.log | head -4
+    killed=$((killed + 1))
+  fi
+}
+
+py() { python3 - "$@"; }
+
+# --- The period a description states is the period the page states ---
+
+m_absent_period_defaults_to_a_month() {
+  py <<'PY'
+p = "src/growth-limits.ts"
+s = open(p).read()
+s = s.replace('  return `${quantity} ${noun}`;\n}', '  return `${quantity} ${noun}/mo`;\n}')
+open(p, "w").write(s)
+PY
+}
+
+m_every_period_renders_as_a_month() {
+  py <<'PY'
+p = "src/growth-limits.ts"
+s = open(p).read()
+s = s.replace('  return period.scope ? `${base} per ${period.scope}` : base;',
+              '  return "/mo";')
+open(p, "w").write(s)
+PY
+}
+
+m_minutes_are_read_as_months() {
+  py <<'PY'
+p = "src/growth-limits.ts"
+s = open(p).read()
+s = s.replace('  minute: "min",\n  minutes: "min",', '  minute: "mo",\n  minutes: "mo",')
+open(p, "w").write(s)
+PY
+}
+
+m_seconds_are_read_as_months() {
+  py <<'PY'
+p = "src/growth-limits.ts"
+s = open(p).read()
+s = s.replace('  second: "sec",\n  seconds: "sec",', '  second: "mo",\n  seconds: "mo",')
+open(p, "w").write(s)
+PY
+}
+
+m_hours_are_read_as_days() {
+  py <<'PY'
+p = "src/growth-limits.ts"
+s = open(p).read()
+s = s.replace('  hour: "hour",\n  hours: "hour",', '  hour: "day",\n  hours: "day",')
+open(p, "w").write(s)
+PY
+}
+
+m_a_period_written_as_a_phrase_is_not_read() {
+  py <<'PY'
+p = "src/growth-limits.ts"
+s = open(p).read()
+s = s.replace('  const worded = rest.match(WORDED_PERIOD);', '  const worded = "".match(WORDED_PERIOD);')
+open(p, "w").write(s)
+PY
+}
+
+m_a_period_written_as_an_adverb_is_not_read() {
+  py <<'PY'
+p = "src/growth-limits.ts"
+s = open(p).read()
+s = s.replace('  const adverb = rest.match(ADVERB_PERIOD);', '  const adverb = "".match(ADVERB_PERIOD);')
+open(p, "w").write(s)
+PY
+}
+
+m_the_period_is_read_from_anywhere_in_the_description() {
+  py <<'PY'
+p = "src/growth-limits.ts"
+s = open(p).read()
+s = s.replace('const WORDED_PERIOD = /^(?:\\s+for)?(?:\\s+free)?\\s+(?:per|a|an|every)\\s+(?:(\\d[\\d,]*)\\s*)?([a-z]+)/i;',
+              'const WORDED_PERIOD = /(?:\\s+for)?(?:\\s+free)?\\s+(?:per|a|an|every)\\s+(?:(\\d[\\d,]*)\\s*)?([a-z]+)/i;')
+open(p, "w").write(s)
+PY
+}
+
+m_the_adverb_is_read_from_anywhere_in_the_description() {
+  py <<'PY'
+p = "src/growth-limits.ts"
+s = open(p).read()
+s = s.replace('const ADVERB_PERIOD = /^(?:\\s+for)?(?:\\s+free)?\\s+(hourly|daily|weekly|monthly|yearly|annually)\\b/i;',
+              'const ADVERB_PERIOD = /(?:\\s+for)?(?:\\s+free)?\\s+(hourly|daily|weekly|monthly|yearly|annually)\\b/i;')
+open(p, "w").write(s)
+PY
+}
+
+m_a_multi_unit_window_is_flattened_to_one_unit() {
+  py <<'PY'
+p = "src/growth-limits.ts"
+s = open(p).read()
+s = s.replace('  const base = period.count\n    ? ` per ${period.count} ${PLURAL_UNITS[period.unit]}`\n    : `/${period.unit}`;',
+              '  const base = `/${period.unit}`;')
+open(p, "w").write(s)
+PY
+}
+
+m_any_noun_counts_as_a_unit_of_time() {
+  py <<'PY'
+p = "src/growth-limits.ts"
+s = open(p).read()
+s = s.replace('function timeUnit(word: string | undefined): string | undefined {\n  return word ? TIME_UNITS[word.toLowerCase()] : undefined;',
+              'function timeUnit(word: string | undefined): string | undefined {\n  return word ? TIME_UNITS[word.toLowerCase()] ?? "mo" : undefined;')
+open(p, "w").write(s)
+PY
+}
+
+m_a_stored_depth_is_published_as_a_bare_quantity() {
+  py <<'PY'
+p = "src/growth-limits.ts"
+s = open(p).read()
+s = s.replace('  const qualifier = rest.match(NON_RATE_QUALIFIER);\n  if (qualifier) return `${quantity} ${noun} of ${qualifier[1]}`;', '')
+open(p, "w").write(s)
+PY
+}
+
+m_the_scope_a_rate_is_measured_against_is_dropped() {
+  py <<'PY'
+p = "src/growth-limits.ts"
+s = open(p).read()
+s = s.replace('  return period.scope ? `${base} per ${period.scope}` : base;', '  return base;')
+open(p, "w").write(s)
+PY
+}
+
+# --- The threshold withholds where the stability verdict withholds ---
+
+m_a_withheld_record_asserts_its_threshold() {
+  py <<'PY'
+p = "src/serve.ts"
+s = open(p).read()
+s = s.replace("    growthBullets.push(levelWithheld\n", "    growthBullets.push(false\n")
+open(p, "w").write(s)
+PY
+}
+
+m_a_withheld_threshold_names_no_reason() {
+  py <<'PY'
+p = "src/serve.ts"
+s = open(p).read()
+s = s.replace('      ? `We record ${phrase} as the limit, but ${withheldClause}, so we cannot confirm that threshold today.`',
+              '      ? `We record ${phrase} as the limit, so we cannot confirm that threshold today.`')
+open(p, "w").write(s)
+PY
+}
+
+m_a_withheld_threshold_drops_the_recorded_figure() {
+  py <<'PY'
+p = "src/serve.ts"
+s = open(p).read()
+s = s.replace('      ? `We record ${phrase} as the limit, but ${withheldClause}, so we cannot confirm that threshold today.`',
+              '      ? `We cannot confirm a threshold for this vendor today.`')
+open(p, "w").write(s)
+PY
+}
+
+m_a_confirmed_record_withholds_too() {
+  py <<'PY'
+p = "src/serve.ts"
+s = open(p).read()
+s = s.replace("    growthBullets.push(levelWithheld\n", "    growthBullets.push(true\n")
+open(p, "w").write(s)
+PY
+}
+
+m_structured_data_keeps_its_own_copy_of_the_threshold() {
+  py <<'PY'
+p = "src/serve.ts"
+s = open(p).read()
+s = s.replace('  const faqOutgrowAnswer = growthBullets.length > 0\n    ? `${growthBullets[0].replace(/<[^>]*>/g, "")} When you outgrow',
+              '  const faqOutgrowAnswer = growthBullets.length > 0\n    ? `At ${primary.description} When you outgrow')
+open(p, "w").write(s)
+PY
+}
+
+run_mutation "a description with no period gets a month anyway"          m_absent_period_defaults_to_a_month
+run_mutation "every period renders as a month"                           m_every_period_renders_as_a_month
+run_mutation "minutes are read as months"                                m_minutes_are_read_as_months
+run_mutation "seconds are read as months"                                m_seconds_are_read_as_months
+run_mutation "hours are read as days"                                    m_hours_are_read_as_days
+run_mutation "a period written as a phrase is not read"                  m_a_period_written_as_a_phrase_is_not_read
+run_mutation "a period written as an adverb is not read"                 m_a_period_written_as_an_adverb_is_not_read
+run_mutation "the period may come from any clause"                       m_the_period_is_read_from_anywhere_in_the_description
+run_mutation "the adverb may come from any clause"                       m_the_adverb_is_read_from_anywhere_in_the_description
+run_mutation "a window several units wide is flattened to one"           m_a_multi_unit_window_is_flattened_to_one_unit
+run_mutation "any noun counts as a unit of time"                         m_any_noun_counts_as_a_unit_of_time
+run_mutation "a stored depth is published as a bare quantity"            m_a_stored_depth_is_published_as_a_bare_quantity
+run_mutation "the scope a rate is measured against is dropped"           m_the_scope_a_rate_is_measured_against_is_dropped
+run_mutation "a withheld record asserts its threshold"                   m_a_withheld_record_asserts_its_threshold
+run_mutation "a withheld threshold names no reason"                      m_a_withheld_threshold_names_no_reason
+run_mutation "a withheld threshold drops the recorded figure"            m_a_withheld_threshold_drops_the_recorded_figure
+run_mutation "a confirmed record withholds too"                          m_a_confirmed_record_withholds_too
+run_mutation "structured data keeps its own copy of the threshold"       m_structured_data_keeps_its_own_copy_of_the_threshold
+
+echo
+echo "killed:   $killed"
+echo "survived: $survived"
+[ "$survived" -eq 0 ]

--- a/src/growth-limits.ts
+++ b/src/growth-limits.ts
@@ -1,0 +1,156 @@
+const TIME_UNITS: Record<string, string> = {
+  sec: "sec",
+  secs: "sec",
+  second: "sec",
+  seconds: "sec",
+  min: "min",
+  mins: "min",
+  minute: "min",
+  minutes: "min",
+  hr: "hour",
+  hrs: "hour",
+  hour: "hour",
+  hours: "hour",
+  day: "day",
+  days: "day",
+  wk: "week",
+  week: "week",
+  weeks: "week",
+  mo: "mo",
+  month: "mo",
+  months: "mo",
+  yr: "yr",
+  year: "yr",
+  years: "yr",
+};
+
+const ADVERB_UNITS: Record<string, string> = {
+  hourly: "hour",
+  daily: "day",
+  weekly: "week",
+  monthly: "mo",
+  yearly: "yr",
+  annually: "yr",
+};
+
+const PLURAL_UNITS: Record<string, string> = {
+  sec: "seconds",
+  min: "minutes",
+  hour: "hours",
+  day: "days",
+  week: "weeks",
+  mo: "months",
+  yr: "years",
+};
+
+const SLASH_PERIOD = /^\/(\d[\d,]*)?\s*([a-z]+)(?:\/([a-z]+))?/i;
+const WORDED_PERIOD = /^(?:\s+for)?(?:\s+free)?\s+(?:per|a|an|every)\s+(?:(\d[\d,]*)\s*)?([a-z]+)/i;
+const ADVERB_PERIOD = /^(?:\s+for)?(?:\s+free)?\s+(hourly|daily|weekly|monthly|yearly|annually)\b/i;
+const SCOPE_SUFFIX = /^\s+per\s+([a-z]+)/i;
+const NON_RATE_QUALIFIER = /^\s+of\s+((?!and\b)[a-z]+(?:\s+(?!and\b)[a-z]+){0,2})/i;
+
+export type LimitPeriod = {
+  unit: string;
+  count?: string;
+  scope?: string;
+  length: number;
+};
+
+function timeUnit(word: string | undefined): string | undefined {
+  return word ? TIME_UNITS[word.toLowerCase()] : undefined;
+}
+
+export function readPeriod(rest: string): LimitPeriod | null {
+  const slash = rest.match(SLASH_PERIOD);
+  if (slash) {
+    const direct = timeUnit(slash[2]);
+    if (direct) {
+      return withScope(rest, { unit: direct, count: slash[1], length: slash[0].length });
+    }
+    const scoped = timeUnit(slash[3]);
+    if (scoped) {
+      return { unit: scoped, count: slash[1], scope: slash[2], length: slash[0].length };
+    }
+    return null;
+  }
+
+  const worded = rest.match(WORDED_PERIOD);
+  const wordedUnit = worded ? timeUnit(worded[2]) : undefined;
+  if (worded && wordedUnit) {
+    return withScope(rest, { unit: wordedUnit, count: worded[1], length: worded[0].length });
+  }
+
+  const adverb = rest.match(ADVERB_PERIOD);
+  if (adverb) {
+    return withScope(rest, { unit: ADVERB_UNITS[adverb[1].toLowerCase()], length: adverb[0].length });
+  }
+
+  return null;
+}
+
+function withScope(rest: string, period: LimitPeriod): LimitPeriod {
+  const scope = rest.slice(period.length).match(SCOPE_SUFFIX);
+  if (!scope) return period;
+  return { ...period, scope: scope[1], length: period.length + scope[0].length };
+}
+
+export function renderPeriod(period: LimitPeriod): string {
+  const base = period.count
+    ? ` per ${period.count} ${PLURAL_UNITS[period.unit]}`
+    : `/${period.unit}`;
+  return period.scope ? `${base} per ${period.scope}` : base;
+}
+
+export function readRateLimit(description: string, match: RegExpMatchArray): string {
+  const quantity = match[1];
+  const noun = match[2];
+  const rest = description.slice((match.index ?? 0) + match[0].length);
+  const period = readPeriod(rest);
+  if (period) return `${quantity} ${noun}${renderPeriod(period)}`;
+  const qualifier = rest.match(NON_RATE_QUALIFIER);
+  if (qualifier) return `${quantity} ${noun} of ${qualifier[1]}`;
+  return `${quantity} ${noun}`;
+}
+
+type LimitPattern = {
+  regex: RegExp;
+  unit: string;
+  format: (m: RegExpMatchArray, description: string) => string;
+};
+
+export const LIMIT_PATTERNS: LimitPattern[] = [
+  {
+    regex: /(\d[\d,]*)\s*(gb|gib)\s*(storage|data|disk)/i,
+    unit: "storage",
+    format: (m) => `${m[1]} ${m[2].toUpperCase()} storage`,
+  },
+  {
+    regex: /(\d[\d,]*)\s*(gb|gib)\s*(bandwidth|transfer|egress)/i,
+    unit: "bandwidth",
+    format: (m) => `${m[1]} ${m[2].toUpperCase()} bandwidth`,
+  },
+  {
+    regex: /(\d[\d,]*k?)\s*(mau|monthly active users)/i,
+    unit: "users",
+    format: (m) => `${m[1]} MAU`,
+  },
+  {
+    regex: /(\d[\d,]*k?)\s*(api\s*calls|requests|invocations|events|emails|messages)/i,
+    unit: "requests",
+    format: (m, description) => readRateLimit(description, m),
+  },
+  {
+    regex: /(\d[\d,]*)\s*(projects?|repos?|sites?|apps?|databases?|instances?)/i,
+    unit: "projects",
+    format: (m) => `${m[1]} ${m[2]}`,
+  },
+];
+
+export function growthLimitPhrases(description: string): string[] {
+  const phrases: string[] = [];
+  for (const pattern of LIMIT_PATTERNS) {
+    const m = description.match(pattern.regex);
+    if (m) phrases.push(pattern.format(m, description));
+  }
+  return phrases;
+}

--- a/src/serve.ts
+++ b/src/serve.ts
@@ -17,6 +17,7 @@ import { configureVendorSeries, recordVendorRequest, flushVendorSeries, readVend
 import { openapiSpec } from "./openapi.js";
 import { LINK_GRACE_DAYS } from "./link-health.js";
 import { levelWithheldReason, withheldLevelClause, withheldLevelSentence } from "./source-check.js";
+import { growthLimitPhrases } from "./growth-limits.js";
 import { registerAgent, authenticateRequest, validateVestauthUrl, hashApiKey, updateAgentX402Address, getAgentById } from "./agents.js";
 import { logReferralRequest } from "./referral-requests.js";
 import { recordConversion, confirmEligibleEntries, clawbackEntry, getAgentBalance, getAgentLedgerEntries, recordPayout, MINIMUM_PAYOUT_AMOUNT, getLeaderboard } from "./ledger.js";
@@ -3918,19 +3919,10 @@ function buildVendorPage(slug: string): string | null {
 
   // --- NEW: Growth Path ---
   const growthBullets: string[] = [];
-  const desc = primary.description.toLowerCase();
-  const limitPatterns = [
-    { regex: /(\d[\d,]*)\s*(gb|gib)\s*(storage|data|disk)/i, unit: "storage", format: (m: RegExpMatchArray) => `${m[1]} ${m[2].toUpperCase()} storage` },
-    { regex: /(\d[\d,]*)\s*(gb|gib)\s*(bandwidth|transfer|egress)/i, unit: "bandwidth", format: (m: RegExpMatchArray) => `${m[1]} ${m[2].toUpperCase()} bandwidth` },
-    { regex: /(\d[\d,]*k?)\s*(mau|monthly active users)/i, unit: "users", format: (m: RegExpMatchArray) => `${m[1]} MAU` },
-    { regex: /(\d[\d,]*k?)\s*(api\s*calls|requests|invocations|events|emails|messages)(\/(?:mo|month|day))?/i, unit: "requests", format: (m: RegExpMatchArray) => `${m[1]} ${m[2]}${m[3] || "/mo"}` },
-    { regex: /(\d[\d,]*)\s*(projects?|repos?|sites?|apps?|databases?|instances?)/i, unit: "projects", format: (m: RegExpMatchArray) => `${m[1]} ${m[2]}` },
-  ];
-  for (const pat of limitPatterns) {
-    const m = primary.description.match(pat.regex);
-    if (m) {
-      growthBullets.push(`At ${pat.format(m)}, you'll need to upgrade.`);
-    }
+  for (const phrase of growthLimitPhrases(primary.description)) {
+    growthBullets.push(levelWithheld
+      ? `We record ${phrase} as the limit, but ${withheldClause}, so we cannot confirm that threshold today.`
+      : `At ${phrase}, you'll need to upgrade.`);
   }
   if (growthBullets.length === 0 && hasFree) {
     growthBullets.push(`When your usage exceeds the free tier limits, you'll need to upgrade.`);

--- a/test/growth-limits.test.ts
+++ b/test/growth-limits.test.ts
@@ -1,0 +1,300 @@
+import { describe, it, before, after } from "node:test";
+import assert from "node:assert";
+import { spawn, type ChildProcess } from "node:child_process";
+import { writeFileSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { growthLimitPhrases, readPeriod } from "../dist/growth-limits.js";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO = path.join(__dirname, "..");
+
+const rateLimit = (description: string): string => {
+  const phrases = growthLimitPhrases(description);
+  assert.equal(phrases.length, 1, `expected one limit phrase from: ${description}`);
+  return phrases[0];
+};
+
+describe("the free-tier threshold reads its period from the clause the quantity is in", () => {
+  it("keeps a per-day rate written with a slash", () => {
+    assert.equal(
+      rateLimit("Edge compute with 100K requests/day, 10ms CPU time per invocation"),
+      "100K requests/day"
+    );
+  });
+
+  it("keeps a per-day rate written as a phrase", () => {
+    assert.equal(rateLimit("The free plan allows 300 requests per day."), "300 requests/day");
+  });
+
+  it("keeps a per-day rate written as an article", () => {
+    assert.equal(rateLimit("Free accounts get 15 emails a day forever."), "15 emails/day");
+  });
+
+  it("keeps a per-day rate written as an adverb", () => {
+    assert.equal(
+      rateLimit("Free for one organization, 1,000 API calls daily. Task management, apps, workspaces"),
+      "1,000 API calls/day"
+    );
+  });
+
+  it("keeps a per-hour rate written with a slash", () => {
+    assert.equal(
+      rateLimit("Free tier: 100 searches/month, 50 requests/hour throughput limit."),
+      "50 requests/hour"
+    );
+  });
+
+  it("keeps a per-hour rate written as an adverb, and does not reach past it to a later period", () => {
+    assert.equal(
+      rateLimit("Free tier includes 500 invocations hourly, 2,500 invocations daily and 50,000 monthly"),
+      "500 invocations/hour"
+    );
+  });
+
+  it("keeps a per-minute rate and does not describe it as monthly", () => {
+    const phrase = rateLimit("Free model only, 3 requests/minute rate limit. No free trial credits.");
+    assert.equal(phrase, "3 requests/min");
+    assert.doesNotMatch(phrase, /\/mo\b/);
+  });
+
+  it("keeps a per-minute rate written as a phrase and does not describe it as monthly", () => {
+    const phrase = rateLimit("Serverless backend, 60 API calls per minute, no credit-card signup.");
+    assert.doesNotMatch(phrase, /\/mo\b/);
+    assert.equal(phrase, "60 API calls/min");
+  });
+
+  it("keeps a per-second rate and does not describe it as monthly", () => {
+    const phrase = rateLimit("Free embeds: 5,000/month at 15 requests/second");
+    assert.equal(phrase, "15 requests/sec");
+    assert.doesNotMatch(phrase, /\/mo\b/);
+  });
+
+  it("keeps a per-month rate written as a phrase", () => {
+    assert.equal(
+      rateLimit("2,500 subscribers and 10,000 emails per month free"),
+      "10,000 emails/mo"
+    );
+  });
+
+  it("keeps a per-month rate stated after an intervening free", () => {
+    assert.equal(
+      rateLimit("Observability for LLM apps. Log up to 10,000 requests for free every month."),
+      "10,000 requests/mo"
+    );
+  });
+
+  it("keeps a window that is several units wide rather than rounding it to a month", () => {
+    assert.equal(
+      rateLimit("1,000 contacts, 4,000 emails per 30 days (marketing + transactional)"),
+      "4,000 emails per 30 days"
+    );
+  });
+
+  it("keeps the scope a rate is measured against", () => {
+    assert.equal(
+      rateLimit("Free for up to 5 editors. 1,000 API calls/workspace/month. 2-week revision history"),
+      "1,000 API calls/mo per workspace"
+    );
+  });
+
+  it("keeps both the window and the scope when the source states both", () => {
+    assert.equal(
+      rateLimit("Free forever, with rate limits per registry (e.g., 5 messages per 5 sec per channel). No charges ever"),
+      "5 messages per 5 seconds per channel"
+    );
+  });
+});
+
+describe("a threshold with no stated period does not gain one", () => {
+  it("reports a one-off allowance without a period", () => {
+    const phrase = rateLimit("Company logo API with 44M+ brands. First 10,000 API calls are free.");
+    assert.equal(phrase, "10,000 API calls");
+    assert.doesNotMatch(phrase, /\/mo\b|per /);
+  });
+
+  it("reports a bare quantity in a feature list without a period", () => {
+    const phrase = rateLimit("Free tier includes: 100 SMS and calls, 3000 Emails, Push, Slack, MS Teams");
+    assert.equal(phrase, "3000 Emails");
+    assert.doesNotMatch(phrase, /\/mo\b|per /);
+  });
+
+  it("does not borrow the period from a different quantity in the same sentence", () => {
+    const phrase = rateLimit("Serverless workflow orchestration — 50K function executions/month, 100K events, 5 concurrent steps");
+    assert.equal(phrase, "100K events");
+    assert.doesNotMatch(phrase, /\/mo\b/);
+  });
+
+  it("does not reach past the clause it matched for a period named later in the sentence", () => {
+    const phrase = rateLimit("Free tier includes 100K events, with dedicated support billed per hour.");
+    assert.equal(phrase, "100K events");
+    assert.doesNotMatch(phrase, /\/hour/);
+  });
+
+  it("does not reach past the clause it matched for an adverb named later in the sentence", () => {
+    const phrase = rateLimit("Free tier includes 100K events, with usage reports delivered monthly.");
+    assert.equal(phrase, "100K events");
+    assert.doesNotMatch(phrase, /\/mo\b/);
+  });
+
+  it("does not treat a stored depth as a rate", () => {
+    const phrase = rateLimit("The free plan includes 10,000 messages of search history and File storage up to 5 GB.");
+    assert.equal(phrase, "10,000 messages of search history");
+    assert.doesNotMatch(phrase, /\/mo\b/);
+  });
+});
+
+describe("a description naming two periods for the same noun", () => {
+  it("reports one limit with the period stated beside it", () => {
+    const phrase = rateLimit("Free with a personal account: 60 requests/minute, 1,000 requests/day, 1M token context");
+    assert.equal(phrase, "60 requests/min");
+    assert.doesNotMatch(phrase, /\/day|\/mo\b/);
+  });
+});
+
+describe("reading a period from the text that follows a quantity", () => {
+  it("finds nothing to read when the sentence simply continues", () => {
+    assert.equal(readPeriod(" are free."), null);
+    assert.equal(readPeriod(" for unlimited projects and unlimited status pages."), null);
+    assert.equal(readPeriod(", 12-week history) begins at Starter $9/month."), null);
+  });
+
+  it("does not accept a noun that is not a unit of time", () => {
+    assert.equal(readPeriod("/request"), null);
+    assert.equal(readPeriod(" per seat"), null);
+  });
+});
+
+describe("the other free-tier limits the page reports", () => {
+  it("reports storage, bandwidth, users and projects unchanged by rate parsing", () => {
+    assert.deepEqual(
+      growthLimitPhrases("Free tier: 5 GB storage, 100 GB bandwidth, 50K MAU, 3 projects"),
+      ["5 GB storage", "100 GB bandwidth", "50K MAU", "3 projects"]
+    );
+  });
+});
+
+const A_RATE_WE_CONFIRMED = {
+  vendor: "Controlcorp",
+  category: "Databases",
+  description: "Free tier with 100K requests/day and 5 GB storage",
+  tier: "Free",
+  url: "https://controlcorp.example/pricing",
+  tags: ["databases"],
+  verifiedDate: "2026-08-11",
+  source_check: { checked: "2026-08-28", outcome: "ok", detail: "text" },
+};
+
+const A_PER_MINUTE_RATE_WE_CONFIRMED = {
+  ...A_RATE_WE_CONFIRMED,
+  vendor: "Minutecorp",
+  url: "https://minutecorp.example/pricing",
+  description: "Free model access, 3 requests/minute rate limit. No trial credits.",
+};
+
+const A_RATE_FROM_A_PAGE_STATING_NO_TERMS = {
+  ...A_RATE_WE_CONFIRMED,
+  vendor: "Prosecorp",
+  url: "https://prosecorp.example/pricing",
+  description: "Free inference for open-source models with 100 requests/day limit.",
+  source_check: { checked: "2026-08-28", outcome: "states_no_terms", detail: "no amount, tier or rate" },
+};
+
+let fixtureDir = "";
+let serverPort = 0;
+let proc: ChildProcess | null = null;
+
+function startServer(indexPath: string): Promise<ChildProcess> {
+  return new Promise((resolve, reject) => {
+    const child = spawn("node", [path.join(REPO, "dist", "serve.js")], {
+      stdio: ["pipe", "pipe", "pipe"],
+      env: { ...process.env, PORT: "0", BASE_URL: "http://localhost", AGENTDEALS_INDEX_PATH: indexPath },
+    });
+    const timeout = setTimeout(() => { child.kill(); reject(new Error("Server startup timeout")); }, 20000);
+    child.stderr!.on("data", (data: Buffer) => {
+      const m = data.toString().match(/running on http:\/\/localhost:(\d+)/);
+      if (m) { serverPort = parseInt(m[1], 10); clearTimeout(timeout); resolve(child); }
+    });
+    child.on("error", (err) => { clearTimeout(timeout); reject(err); });
+  });
+}
+
+const get = async (p: string) => {
+  const res = await fetch(`http://localhost:${serverPort}${p}`);
+  return { status: res.status, body: await res.text() };
+};
+
+function growthBlock(body: string): string {
+  const block = body.match(/<div class="section growth-section">[\s\S]*?<\/div>/)?.[0];
+  assert.ok(block, "the page must carry a growth section for the assertion to mean anything");
+  return block;
+}
+
+function outgrowAnswer(body: string): string {
+  const page = [...body.matchAll(/<script type="application\/ld\+json">([\s\S]*?)<\/script>/g)]
+    .map((m) => { try { return JSON.parse(m[1]); } catch { return null; } })
+    .find((json) => json && json["@type"] === "FAQPage");
+  assert.ok(page, "the page must ship FAQPage structured data for the assertion to mean anything");
+  const entry = page.mainEntity.find((e: { name: string }) => /outgrow/i.test(e.name));
+  assert.ok(entry, "the structured data must carry the outgrow question");
+  return entry.acceptedAnswer.text;
+}
+
+before(async () => {
+  fixtureDir = mkdtempSync(path.join(tmpdir(), "growth-limits-"));
+  const indexPath = path.join(fixtureDir, "index.json");
+  writeFileSync(
+    indexPath,
+    JSON.stringify({
+      offers: [A_RATE_WE_CONFIRMED, A_PER_MINUTE_RATE_WE_CONFIRMED, A_RATE_FROM_A_PAGE_STATING_NO_TERMS],
+    }, null, 2)
+  );
+  proc = await startServer(indexPath);
+});
+
+after(() => {
+  if (proc) proc.kill();
+  if (fixtureDir) rmSync(fixtureDir, { recursive: true, force: true });
+});
+
+describe("the outgrow block on a vendor page", () => {
+  it("renders, so the assertions below are about a real page", async () => {
+    const res = await get("/vendor/controlcorp");
+    assert.equal(res.status, 200);
+    assert.match(growthBlock(res.body), /At 100K requests\/day, you'll need to upgrade\./);
+  });
+
+  it("states a per-minute rate as per-minute", async () => {
+    const { body } = await get("/vendor/minutecorp");
+    const block = growthBlock(body);
+    assert.match(block, /At 3 requests\/min, you'll need to upgrade\./);
+    assert.doesNotMatch(block, /\/mo\b/);
+  });
+
+  it("ships the same threshold to readers and to structured data", async () => {
+    const { body } = await get("/vendor/minutecorp");
+    assert.match(growthBlock(body), /At 3 requests\/min, you'll need to upgrade\./);
+    assert.match(outgrowAnswer(body), /^At 3 requests\/min, you'll need to upgrade\./);
+  });
+
+  it("does not state a threshold read off a page that states no terms", async () => {
+    const { body } = await get("/vendor/prosecorp");
+    const block = growthBlock(body);
+    assert.doesNotMatch(block, /At 100 requests\/day, you'll need to upgrade/);
+    assert.match(block, /states no terms we can read/);
+    assert.match(block, /we cannot confirm that threshold today/);
+  });
+
+  it("keeps the recorded threshold visible while saying it is unconfirmed", async () => {
+    const { body } = await get("/vendor/prosecorp");
+    assert.match(growthBlock(body), /We record 100 requests\/day as the limit/);
+  });
+
+  it("withholds the same threshold in structured data as on the page", async () => {
+    const { body } = await get("/vendor/prosecorp");
+    const answer = outgrowAnswer(body);
+    assert.doesNotMatch(answer, /^At 100 requests\/day/);
+    assert.match(answer, /we cannot confirm that threshold today/);
+  });
+});


### PR DESCRIPTION
Refs #1121

`/vendor/openai` said **"At 3 requests/mo, you'll need to upgrade."** against a record that says 3 requests per *minute*. The period group in the rate pattern recognised only `/mo`, `/month` and `/day`; everything else fell to a `|| "/mo"` default, and `/minute` matched the `/mo` inside it, so the sentence rendered a monthly figure while looking like it had read the source. All 20 affected records understated; none overstated.

## What changed

`src/growth-limits.ts` parses the period out of the text **adjacent to the quantity** rather than defaulting one. It reads slash forms (`/day`, `/minute`, `/5hr`), phrases (`per day`, `per 30 days`, `a day`), adverbs (`daily`, `hourly`), a period stated after an intervening `for free`, and the scope a rate is measured against (`/workspace/month`, `per channel`).

Three properties fall out of the parse rather than being special-cased:

- **A description that states no period yields no period.** `"The first 1000 API calls are free"` renders `At 1000 API calls` — the monthly refill it used to claim does not exist.
- **The anchor keeps the number and the period in the same clause.** Gemini CLI's `60 requests/minute, 1,000 requests/day` renders one limit with its own period, and Inngest's `50K function executions/month, 100K events` no longer borrows the `/month` from the neighbouring noun.
- **A quantity qualified by `of …` is reported as the depth it is.** Zulip's `10,000 messages of search history` is not a monthly send allowance.

`serve.ts` keeps one call site, so the visible block and the FAQ `acceptedAnswer` cannot drift apart. The five limit patterns moved into the module with it.

**The threshold now withholds on the same condition the stability verdict does** (requested on the issue). 73 pages stated a threshold read off a page we had read and found no terms on — including `/vendor/siliconflow`, which said it could not confirm the terms and then told the reader what to do at a number that does not appear on the vendor's page. They keep the recorded figure and say it is unconfirmed.

## Verification

**Positive control, exact rather than argued.** Swept the growth block **and** the FAQ answer on all 1,572 vendor pages against `main` and against this branch:

- **1,476 of 1,572 pages are byte-identical.**
- 23 confirmed-source pages changed — every one a period correction.
- 73 withheld pages changed. 73 of 783 asserted a threshold before; **0 after**, and all 73 now carry the caveat.
- **789 confirmed pages, 0 gained a caveat.**
- `/vendor/cloudflare-workers` still reads `At 100K requests/day` — checked as a rendered screenshot, byte-identical to `main`'s.

`scripts/e2e-1121.mjs` — **118 checks, 0 failed**, against a server running the real index: each of the 20 named vendors, the 6 with no stated period, Zulip, the Gemini CLI clause case, the visible-block/JSON-LD match for all 20, and the two whole-index sweeps above.

`scripts/mutate-1121.sh` — **18/18 killed, 0 survivors, none by the compiler.** One mutation survived the first run: dropping the `^` from the period regex, which is the anchor AC-3 depends on. No test caught it because none of my no-period fixtures had a period later in the sentence. Added two, and the mutation now dies.

`npm test` — **2335/2335** (2305 before, 30 added). `node scripts/check-mutation-targets.mjs` — 131 mutations across 21 scripts resolve. Real MCP `initialize` → `tools/call` over the streamable-http transport.

**Looked at the pages**, before and after, rather than only reading their text.
