### PR TITLE
Take a change record's direction from the quantities it compares (#1136)

### DIFF
--- a/data/change_refusals.json
+++ b/data/change_refusals.json
@@ -61,6 +61,30 @@
       "refused_date": "2026-08-29"
     },
     {
+      "vendor": "Aircall",
+      "change_type": "free_tier_removed",
+      "reason": "page_does_not_name_vendor",
+      "detail": "the page read never names Aircall and is not served from its domain, so any terms on it belong to somebody else",
+      "summary": "The rewards page no longer offers 2 months free and instead advertises up to 7x points.",
+      "previous_state": "2 months free. Access via: Free for Brex customers",
+      "current_state": "Earn up to 7x points on purchases and redeem for business-building rewards.",
+      "source_url": "https://brex.com/rewards/",
+      "category": "Startup Perks",
+      "refused_date": "2026-08-29"
+    },
+    {
+      "vendor": "Aiven",
+      "change_type": "limits_reduced",
+      "reason": "measures_no_change",
+      "detail": "limits_reduced claimed, and every quantity the record compares holds the same value once notation and period are normalised — 1 cpu against 1 cpu, 1 GB ram against 1 GB ram, 1 \"previously\" 1",
+      "summary": "The free tier now has limitations on cloud/region selection (cannot select a specific one) and does not include integrations or connection pooling. The free tier also only provides 1GB of total storage. Previously 1GB per service.",
+      "previous_state": "Managed PostgreSQL, MySQL, or Valkey (Redis-compatible) — 1 CPU, 1 GB RAM, 1 GB disk per service. No time limit",
+      "current_state": "Free $0 / month Get building 1 dedicated VM 1 CPU per VM 1 GB RAM per VM 1 GB total storage Cannot select a specific cloud or region No integrations or connection pooling",
+      "source_url": "https://aiven.io/pricing",
+      "category": "Databases",
+      "refused_date": "2026-08-29"
+    },
+    {
       "vendor": "Amazon Kiro (AWS Startups)",
       "change_type": "free_tier_removed",
       "reason": "no_removal_evidence",
@@ -205,6 +229,18 @@
       "refused_date": "2026-08-28"
     },
     {
+      "vendor": "Bugsnag",
+      "change_type": "limits_reduced",
+      "reason": "measures_no_change",
+      "detail": "limits_reduced claimed, and every quantity the record compares holds the same value once notation and period are normalised — 7,500 event/mo against 7.5 event, 1 span/mo against 1 span/mo, 1 user against 1 user",
+      "summary": "The free tier now includes 7.5K events and 1M spans per month, and 1 user. Previously 7,500 events/month and 1M spans/month, 1 user. The free tier is still available. The limits are now tied to the Enterprise plan description.",
+      "previous_state": "Error monitoring — 7,500 events/month and 1M spans/month on free plan, 1 user, unlimited projects, 7-day data retention. 14-day free trial of paid features available. Rebranded as SmartBear Insight Hub",
+      "current_state": "Includes: 1 user Error and performance monitoring 7.5K events and 1M spans per month 50+ platforms 30+ third-party integrations Free plan features, plus: Unlimited users End-to-end diagnostics Basic notifications Select plan features, plus: Automatic error prioritization Stability benchmarks Advanced segmentation Custom notifications SAML single sign-on System Metrics (CPU, Memory, Rendering)",
+      "source_url": "https://www.bugsnag.com/pricing/",
+      "category": "Error Tracking",
+      "refused_date": "2026-08-29"
+    },
+    {
       "vendor": "Cal.com",
       "change_type": "limits_increased",
       "reason": "states_no_difference",
@@ -275,6 +311,18 @@
       "source_url": "https://www.cloudflare.com/plans/free/",
       "category": "DNS & Domain Management",
       "refused_date": "2026-08-28"
+    },
+    {
+      "vendor": "Cloudways",
+      "change_type": "limits_reduced",
+      "reason": "page_does_not_name_vendor",
+      "detail": "the page read never names Cloudways and is not served from its domain, so any terms on it belong to somebody else",
+      "summary": "The offer has been reduced: the page now shows a first deal free, then 99€/year, rather than 30% off for 3 months.",
+      "previous_state": "30% off for 3 months. Access via: First deal free, then 99€/year or invite friends",
+      "current_state": "First deal free, then 99€/year or invite friends.",
+      "source_url": "https://www.joinsecret.com/offers",
+      "category": "Startup Perks",
+      "refused_date": "2026-08-29"
     },
     {
       "vendor": "Codefresh",
@@ -350,6 +398,18 @@
     },
     {
       "vendor": "deployhq.com",
+      "change_type": "limits_reduced",
+      "reason": "measures_no_change",
+      "detail": "limits_reduced claimed, and every quantity the record compares holds the same value once notation and period are normalised — 3 project against 3 project",
+      "summary": "The free tier now offers unlimited deployments. Requires a paid plan starting at $9/month for unlimited projects.",
+      "previous_state": "Automated deployment platform — free plan: 3 projects with unlimited deployments. Git-based workflow with support for FTP/SFTP/SSH deployment targets",
+      "current_state": "Start free with 3 projects and unlimited deployments. Automatic or manual. Unlimited deployments from $9/month.",
+      "source_url": "https://www.deployhq.com/",
+      "category": "CI/CD",
+      "refused_date": "2026-08-29"
+    },
+    {
+      "vendor": "deployhq.com",
       "change_type": "free_tier_removed",
       "reason": "states_no_terms",
       "detail": "every clause of the summary states absence or hedge rather than a term the page carries, so it reports the reading rather than a change",
@@ -371,6 +431,30 @@
       "source_url": "https://www.docker.com/pricing/",
       "category": "Container Registry",
       "refused_date": "2026-08-28"
+    },
+    {
+      "vendor": "Docker Hub",
+      "change_type": "limits_reduced",
+      "reason": "measures_the_opposite",
+      "detail": "limits_reduced claimed, and every quantity that moved between the two states moved the other way — 200 pull per 6 hours against 100 docker/hour",
+      "summary": "The Docker Hub Personal tier now includes 100 Docker Hub pulls/hr instead of 200 pulls per 6-hour window. It also includes 1 Docker Scout-enabled repo.",
+      "previous_state": "1 private repository, unlimited public repositories. 200 pulls per 6-hour window (authenticated). No automated builds on free tier",
+      "current_state": "Docker Personal $0 $0 ... Includes: 100 Docker Hub pulls/hr* 1 private Docker Hub repo 1 Docker Scout-enabled repo*",
+      "source_url": "https://www.docker.com/pricing/",
+      "category": "Container Registry",
+      "refused_date": "2026-08-29"
+    },
+    {
+      "vendor": "Doczilla",
+      "change_type": "limits_increased",
+      "reason": "no_price_signal",
+      "detail": "the page read carries no price signal — no amount, named tier or metered rate in 4163 characters, so it states no terms to have changed",
+      "summary": "The pricing page states there are 'no strict limits' on the number of documents or screenshots, contradicting the stored information of a 250 documents/month limit.",
+      "previous_state": "SaaS API empowering the generation of screenshots or PDFs directly from HTML/CSS/JS code. The free plan allows 250 documents month.",
+      "current_state": "There are no strict limits to the number of documents or screenshots that can be generated.",
+      "source_url": "https://www.doczilla.app/",
+      "category": "Dev Utilities",
+      "refused_date": "2026-08-29"
     },
     {
       "vendor": "duo.com",
@@ -485,12 +569,12 @@
       "change_type": "limits_reduced",
       "reason": "unquantified_limit",
       "detail": "limits_reduced claimed, but the current state names no quantity for anything the stored state measured (2,000 harnes)",
-      "summary": "The free plan now offers a limited set of features and resources compared to the stored information. The original deal of 2,000 build credits/month is no longer explicitly mentioned. The free plan is now focused on individual developers and small teams and doesn't detail the same features (YAML pipelines, secrets management, test intelligence) as previously stated.",
+      "summary": "The free plan now has significantly reduced limits compared to the stored information. The stored info stated 2,000 build credits/month, while the current page details limits for concurrent pipeline executions (up to 60), storage (250GB), and organizations (up to 1).",
       "previous_state": "CI/CD platform — free plan: 2,000 Harness Cloud build credits/month (Linux, macOS, Windows runners), YAML pipelines, secrets management, test intelligence. Requires business email for cloud runners; self-hosted runner alternative available",
-      "current_state": "The free plan is available for individual developers and small teams. It includes up to 60 concurrent pipeline executions, 250GB storage, and up to 5 custom roles. It also includes features like Native Deployment Integration, GitOps, and Self Hosted Runners (up to 60).",
+      "current_state": "Free Plan is available for individual developers and small teams. It includes up to 60 concurrent pipeline executions, 250GB storage, up to 1 organization, up to 500 maximum users, up to 5 custom dashboards, unlimited templates, up to 5 custom roles, and policy as code.",
       "source_url": "https://www.harness.io/pricing",
-      "category": "CI/CD",
-      "refused_date": "2026-08-28"
+      "category": "Dev Utilities",
+      "refused_date": "2026-08-29"
     },
     {
       "vendor": "heap.io",
@@ -527,6 +611,30 @@
       "source_url": "https://www.image-charts.com/",
       "category": "Storage",
       "refused_date": "2026-08-28"
+    },
+    {
+      "vendor": "Imitate Email",
+      "change_type": "limits_increased",
+      "reason": "measures_no_change",
+      "detail": "limits_increased claimed, and every quantity the record compares holds the same value once notation and period are normalised — 15 email/day against 450 test/mo",
+      "summary": "The free tier now offers 450 test emails a month, instead of 15 emails a day.",
+      "previous_state": "Sandbox Email Server for testing email functionality across build/qa and ci/cd. Free accounts get 15 emails a day forever.",
+      "current_state": "Get started with 450 test emails a month, free forever",
+      "source_url": "https://imitate.email",
+      "category": "Email",
+      "refused_date": "2026-08-29"
+    },
+    {
+      "vendor": "incidenthub.cloud",
+      "change_type": "limits_reduced",
+      "reason": "measures_no_change",
+      "detail": "limits_reduced claimed, and every quantity the record compares holds the same value once notation and period are normalised — 5 monitor against 5 monitor",
+      "summary": "The free tier now has no status page.",
+      "previous_state": "Cloud and SaaS status page aggregator — 5 monitors and 2 notification channels (Slack and Discord) are free forever.",
+      "current_state": "We also have a free tier with 5 monitors, Discord and Slack integration, and no status page.",
+      "source_url": "https://incidenthub.cloud/",
+      "category": "Monitoring",
+      "refused_date": "2026-08-29"
     },
     {
       "vendor": "InfluxDB Cloud",
@@ -685,6 +793,18 @@
       "refused_date": "2026-08-28"
     },
     {
+      "vendor": "MantleDB",
+      "change_type": "limits_reduced",
+      "reason": "measures_the_opposite",
+      "detail": "limits_reduced claimed, and every quantity that moved between the two states moved the other way — 72 inactivity against 90 inactivity",
+      "summary": "The free tier now has a limit of 100 entries and 64KB per entry, and unclaimed namespaces are purged after 30 days of inactivity. Claimed namespaces are purged after 90 days of inactivity. Previously a 1MB limit for the free tier and a 72h inactivity scavenger policy.",
+      "previous_state": "Anonymous JSON storage for scripts and tiny apps. No signup required; uses Master AID for updates and Read-Only RID for public fetching. Free tier includes 1 bucket (1MB limit) with a 72h inactivity scavenger policy.",
+      "current_state": "Unclaimed namespaces have a limit of up to 100 entries, 64 KB per entry and are purged after 30 days of no writes. Claimed namespaces have a limit of up to 100 entries, 64 KB per entry and are purged after 90 days of inactivity.",
+      "source_url": "https://mantledb.sh",
+      "category": "Storage",
+      "refused_date": "2026-08-29"
+    },
+    {
       "vendor": "Market Data API",
       "change_type": "limits_reduced",
       "reason": "confirmed_unchanged",
@@ -707,6 +827,18 @@
       "source_url": "https://mdbootstrap.com/",
       "category": "Design",
       "refused_date": "2026-08-28"
+    },
+    {
+      "vendor": "Meeting",
+      "change_type": "limits_reduced",
+      "reason": "measures_the_opposite",
+      "detail": "limits_reduced claimed, and every quantity that moved between the two states moved the other way — 3 meeting against 60 minut, 3 meeting against 100 meeting",
+      "summary": "The free tier now has a 60-minute meeting limit and supports up to 100 participants. Previously unlimited meeting duration with up to 3 meeting participants & 10 Webinar attendees.",
+      "previous_state": "Meetings with upto 3 meeting participants & 10 Webinar attendees.",
+      "current_state": "Free plan offers up to 60 minutes of meetings and 100 meeting participants.",
+      "source_url": "https://zoho.com/meeting",
+      "category": "Cloud IaaS",
+      "refused_date": "2026-08-29"
     },
     {
       "vendor": "Mendix",
@@ -778,6 +910,18 @@
       "current_state": "The Okta Integrator Free Plan is available for building, testing, and managing integrations. It requires first name, last name, work email, and country/region for signup. Access expires after 180 days of inactivity.",
       "source_url": "https://developer.okta.com/signup/",
       "category": "Auth",
+      "refused_date": "2026-08-29"
+    },
+    {
+      "vendor": "OnlineOrNot",
+      "change_type": "limits_reduced",
+      "reason": "measures_no_change",
+      "detail": "limits_reduced claimed, and every quantity the record compares holds the same value once notation and period are normalised — 3 check against 3 check, 2 \"instead of\" 2",
+      "summary": "The free tier now only includes up to 2 users instead of 2 team members. The free tier also no longer includes SSL monitoring, multi-location checks, or Discord alerts.",
+      "previous_state": "Uptime and status page monitoring — free plan: 3 monitors (uptime, keyword, heartbeat), 3-minute check interval, 2 team members, 1 status page, SSL monitoring, multi-location checks, email/Slack/Discord alerts",
+      "current_state": "Hobby (Free) includes up to 2 users, a 3-minute check interval, a limited status page, and basic alerting.",
+      "source_url": "https://onlineornot.com/pricing",
+      "category": "Monitoring",
       "refused_date": "2026-08-29"
     },
     {
@@ -1021,6 +1165,18 @@
       "refused_date": "2026-08-28"
     },
     {
+      "vendor": "snappify",
+      "change_type": "limits_reduced",
+      "reason": "measures_no_change",
+      "detail": "limits_reduced claimed, and every quantity the record compares holds the same value once notation and period are normalised — 3 snap against 3 snap, 3 snap against 3 snap, 5 powered/mo against 5 explanation/mo",
+      "summary": "The free tier now has a watermark on snaps and videos, and limits on snap storage, folder storage, and other features. The free tier also has a limit of 3 snaps at once, and 5 AI explanations per month.",
+      "previous_state": "Enables developers to create stunning visuals. From beautiful code snippets to fully fletched technical presentations. The free plan includes up to 3 snaps at once with unlimited downloads and 5 AI-powered code explanations per month.",
+      "current_state": "The free tier includes 3 snaps at once, 5 AI explanations per month, 100MB image upload limit, 3 snap storage limit, and includes a watermark on videos and snaps.",
+      "source_url": "https://snappify.com",
+      "category": "Dev Utilities",
+      "refused_date": "2026-08-29"
+    },
+    {
       "vendor": "StackBy",
       "change_type": "limits_reduced",
       "reason": "unquantified_limit",
@@ -1105,6 +1261,18 @@
       "refused_date": "2026-08-29"
     },
     {
+      "vendor": "Thunder Client",
+      "change_type": "pricing_model_change",
+      "reason": "no_price_signal",
+      "detail": "the page read carries no price signal — no amount, named tier or metered rate in 1443 characters, so it states no terms to have changed",
+      "summary": "The pricing information has changed. The page no longer explicitly mentions a free tier. It highlights Git Sync for team collaboration, which was previously a premium feature.",
+      "previous_state": "Lightweight REST API client for VS Code. Free tier includes collections, environments, local storage, and request history. No account required for local use. Premium ($10/yr) adds cloud sync and team collaboration",
+      "current_state": "The page describes Thunder Client as a lightweight REST API client with local storage and Git Sync for team collaboration. It does not mention a free or premium tier, or any pricing.",
+      "source_url": "https://www.thunderclient.com",
+      "category": "Dev Utilities",
+      "refused_date": "2026-08-29"
+    },
+    {
       "vendor": "Toggled.dev",
       "change_type": "limits_increased",
       "reason": "confirmed_unchanged",
@@ -1151,6 +1319,18 @@
       "source_url": "https://uptimetoolbox.com/",
       "category": "Monitoring",
       "refused_date": "2026-08-28"
+    },
+    {
+      "vendor": "userforge.com",
+      "change_type": "limits_reduced",
+      "reason": "measures_the_opposite",
+      "detail": "limits_reduced claimed, and every quantity that moved between the two states moved the other way — 3 persona against 5 persona/mo",
+      "summary": "The free tier still exists. The limits have changed. Previously up to 3 personas and 2 collaborators. The current pricing page states 3 personas with portraits & scenes, 3 pages & 5 persona reviews a month, and 1 collaborator.",
+      "previous_state": "Interconnected online personas, user stories and context mapping. Helps keep design and dev in sync free for up to 3 personas and two collaborators.",
+      "current_state": "Free gets you started — you meet your personas and hear their first feedback. ✓ 3 personas with portraits & scenes ✓ 3 pages & 5 persona reviews a month ✓ 10 context sources to ground them ✓ Live share links & clean printing ✓ Bring a collaborator",
+      "source_url": "https://userforge.com/",
+      "category": "Design",
+      "refused_date": "2026-08-29"
     },
     {
       "vendor": "vatcheckapi.com",

--- a/data/deal_changes.json
+++ b/data/deal_changes.json
@@ -4646,21 +4646,6 @@
       "recorded_date": "2026-08-28"
     },
     {
-      "vendor": "Aiven",
-      "change_type": "limits_reduced",
-      "date": "2026-08-28",
-      "date_source": "discovered",
-      "summary": "The free tier now has limitations on cloud/region selection (cannot select a specific one) and does not include integrations or connection pooling. The free tier also only provides 1GB of total storage. Previously 1GB per service.",
-      "previous_state": "Managed PostgreSQL, MySQL, or Valkey (Redis-compatible) — 1 CPU, 1 GB RAM, 1 GB disk per service. No time limit",
-      "current_state": "Free $0 / month Get building 1 dedicated VM 1 CPU per VM 1 GB RAM per VM 1 GB total storage Cannot select a specific cloud or region No integrations or connection pooling",
-      "impact": "medium",
-      "source_url": "https://aiven.io/pricing",
-      "category": "Databases",
-      "alternatives": [],
-      "detected_by": "reverify-ai",
-      "recorded_date": "2026-08-28"
-    },
-    {
       "vendor": "Algolia",
       "change_type": "pricing_restructured",
       "date": "2026-08-28",
@@ -4841,21 +4826,6 @@
       "recorded_date": "2026-08-28"
     },
     {
-      "vendor": "OnlineOrNot",
-      "change_type": "limits_reduced",
-      "date": "2026-08-28",
-      "date_source": "discovered",
-      "summary": "The free tier now only includes up to 2 users instead of 2 team members. The free tier also no longer includes SSL monitoring, multi-location checks, or Discord alerts.",
-      "previous_state": "Uptime and status page monitoring — free plan: 3 monitors (uptime, keyword, heartbeat), 3-minute check interval, 2 team members, 1 status page, SSL monitoring, multi-location checks, email/Slack/Discord alerts",
-      "current_state": "Hobby (Free) includes up to 2 users, a 3-minute check interval, a limited status page, and basic alerting.",
-      "impact": "medium",
-      "source_url": "https://onlineornot.com/pricing",
-      "category": "Monitoring",
-      "alternatives": [],
-      "detected_by": "reverify-ai",
-      "recorded_date": "2026-08-28"
-    },
-    {
       "vendor": "Financial Data",
       "change_type": "free_tier_removed",
       "date": "2026-08-28",
@@ -4866,21 +4836,6 @@
       "impact": "high",
       "source_url": "https://financialdata.net/",
       "category": "Dev Utilities",
-      "alternatives": [],
-      "detected_by": "reverify-ai",
-      "recorded_date": "2026-08-28"
-    },
-    {
-      "vendor": "Docker Hub",
-      "change_type": "limits_reduced",
-      "date": "2026-08-28",
-      "date_source": "discovered",
-      "summary": "The Docker Hub Personal tier now includes 100 Docker Hub pulls/hr instead of 200 pulls per 6-hour window. It also includes 1 Docker Scout-enabled repo.",
-      "previous_state": "1 private repository, unlimited public repositories. 200 pulls per 6-hour window (authenticated). No automated builds on free tier",
-      "current_state": "Docker Personal $0 $0 ... Includes: 100 Docker Hub pulls/hr* 1 private Docker Hub repo 1 Docker Scout-enabled repo*",
-      "impact": "medium",
-      "source_url": "https://www.docker.com/pricing/",
-      "category": "Container Registry",
       "alternatives": [],
       "detected_by": "reverify-ai",
       "recorded_date": "2026-08-28"
@@ -4941,21 +4896,6 @@
       "impact": "medium",
       "source_url": "https://ipwho.org/",
       "category": "Dev Utilities",
-      "alternatives": [],
-      "detected_by": "reverify-ai",
-      "recorded_date": "2026-08-28"
-    },
-    {
-      "vendor": "userforge.com",
-      "change_type": "limits_reduced",
-      "date": "2026-08-28",
-      "date_source": "discovered",
-      "summary": "The free tier still exists. The limits have changed. Previously up to 3 personas and 2 collaborators. The current pricing page states 3 personas with portraits & scenes, 3 pages & 5 persona reviews a month, and 1 collaborator.",
-      "previous_state": "Interconnected online personas, user stories and context mapping. Helps keep design and dev in sync free for up to 3 personas and two collaborators.",
-      "current_state": "Free gets you started — you meet your personas and hear their first feedback. ✓ 3 personas with portraits & scenes ✓ 3 pages & 5 persona reviews a month ✓ 10 context sources to ground them ✓ Live share links & clean printing ✓ Bring a collaborator",
-      "impact": "medium",
-      "source_url": "https://userforge.com/",
-      "category": "Design",
       "alternatives": [],
       "detected_by": "reverify-ai",
       "recorded_date": "2026-08-28"
@@ -5216,21 +5156,6 @@
       "recorded_date": "2026-08-28"
     },
     {
-      "vendor": "deployhq.com",
-      "change_type": "limits_reduced",
-      "date": "2026-08-28",
-      "date_source": "discovered",
-      "summary": "The free tier now offers unlimited deployments. Requires a paid plan starting at $9/month for unlimited projects.",
-      "previous_state": "Automated deployment platform — free plan: 3 projects with unlimited deployments. Git-based workflow with support for FTP/SFTP/SSH deployment targets",
-      "current_state": "Start free with 3 projects and unlimited deployments. Automatic or manual. Unlimited deployments from $9/month.",
-      "impact": "high",
-      "source_url": "https://www.deployhq.com/",
-      "category": "CI/CD",
-      "alternatives": [],
-      "detected_by": "reverify-ai",
-      "recorded_date": "2026-08-28"
-    },
-    {
       "vendor": "Terrateam",
       "change_type": "limits_reduced",
       "date": "2026-08-28",
@@ -5381,21 +5306,6 @@
       "recorded_date": "2026-08-28"
     },
     {
-      "vendor": "incidenthub.cloud",
-      "change_type": "limits_reduced",
-      "date": "2026-08-28",
-      "date_source": "discovered",
-      "summary": "The free tier now has no status page.",
-      "previous_state": "Cloud and SaaS status page aggregator — 5 monitors and 2 notification channels (Slack and Discord) are free forever.",
-      "current_state": "We also have a free tier with 5 monitors, Discord and Slack integration, and no status page.",
-      "impact": "medium",
-      "source_url": "https://incidenthub.cloud/",
-      "category": "Monitoring",
-      "alternatives": [],
-      "detected_by": "reverify-ai",
-      "recorded_date": "2026-08-28"
-    },
-    {
       "vendor": "linkok.com",
       "change_type": "pricing_restructured",
       "date": "2026-08-28",
@@ -5541,21 +5451,6 @@
       "impact": "high",
       "source_url": "https://xitoring.com/",
       "category": "Monitoring",
-      "alternatives": [],
-      "detected_by": "reverify-ai",
-      "recorded_date": "2026-08-28"
-    },
-    {
-      "vendor": "Imitate Email",
-      "change_type": "limits_increased",
-      "date": "2026-08-28",
-      "date_source": "discovered",
-      "summary": "The free tier now offers 450 test emails a month, instead of 15 emails a day.",
-      "previous_state": "Sandbox Email Server for testing email functionality across build/qa and ci/cd. Free accounts get 15 emails a day forever.",
-      "current_state": "Get started with 450 test emails a month, free forever",
-      "impact": "medium",
-      "source_url": "https://imitate.email",
-      "category": "Email",
       "alternatives": [],
       "detected_by": "reverify-ai",
       "recorded_date": "2026-08-28"
@@ -5816,21 +5711,6 @@
       "recorded_date": "2026-08-28"
     },
     {
-      "vendor": "MantleDB",
-      "change_type": "limits_reduced",
-      "date": "2026-08-28",
-      "date_source": "discovered",
-      "summary": "The free tier now has a limit of 100 entries and 64KB per entry, and unclaimed namespaces are purged after 30 days of inactivity. Claimed namespaces are purged after 90 days of inactivity. Previously a 1MB limit for the free tier and a 72h inactivity scavenger policy.",
-      "previous_state": "Anonymous JSON storage for scripts and tiny apps. No signup required; uses Master AID for updates and Read-Only RID for public fetching. Free tier includes 1 bucket (1MB limit) with a 72h inactivity scavenger policy.",
-      "current_state": "Unclaimed namespaces have a limit of up to 100 entries, 64 KB per entry and are purged after 30 days of no writes. Claimed namespaces have a limit of up to 100 entries, 64 KB per entry and are purged after 90 days of inactivity.",
-      "impact": "medium",
-      "source_url": "https://mantledb.sh",
-      "category": "Storage",
-      "alternatives": [],
-      "detected_by": "reverify-ai",
-      "recorded_date": "2026-08-28"
-    },
-    {
       "vendor": "Circum Icons",
       "change_type": "free_tier_removed",
       "date": "2026-08-28",
@@ -5871,21 +5751,6 @@
       "impact": "medium",
       "source_url": "https://icon.horse",
       "category": "Design",
-      "alternatives": [],
-      "detected_by": "reverify-ai",
-      "recorded_date": "2026-08-28"
-    },
-    {
-      "vendor": "Bugsnag",
-      "change_type": "limits_reduced",
-      "date": "2026-08-28",
-      "date_source": "discovered",
-      "summary": "The free tier now includes 7.5K events and 1M spans per month, and 1 user. Previously 7,500 events/month and 1M spans/month, 1 user. The free tier is still available. The limits are now tied to the Enterprise plan description.",
-      "previous_state": "Error monitoring — 7,500 events/month and 1M spans/month on free plan, 1 user, unlimited projects, 7-day data retention. 14-day free trial of paid features available. Rebranded as SmartBear Insight Hub",
-      "current_state": "Includes: 1 user Error and performance monitoring 7.5K events and 1M spans per month 50+ platforms 30+ third-party integrations Free plan features, plus: Unlimited users End-to-end diagnostics Basic notifications Select plan features, plus: Automatic error prioritization Stability benchmarks Advanced segmentation Custom notifications SAML single sign-on System Metrics (CPU, Memory, Rendering)",
-      "impact": "medium",
-      "source_url": "https://www.bugsnag.com/pricing/",
-      "category": "Error Tracking",
       "alternatives": [],
       "detected_by": "reverify-ai",
       "recorded_date": "2026-08-28"
@@ -5946,21 +5811,6 @@
       "impact": "medium",
       "source_url": "https://teleporthq.io/",
       "category": "Design",
-      "alternatives": [],
-      "detected_by": "reverify-ai",
-      "recorded_date": "2026-08-28"
-    },
-    {
-      "vendor": "snappify",
-      "change_type": "limits_reduced",
-      "date": "2026-08-28",
-      "date_source": "discovered",
-      "summary": "The free tier now has a watermark on snaps and videos, and limits on snap storage, folder storage, and other features. The free tier also has a limit of 3 snaps at once, and 5 AI explanations per month.",
-      "previous_state": "Enables developers to create stunning visuals. From beautiful code snippets to fully fletched technical presentations. The free plan includes up to 3 snaps at once with unlimited downloads and 5 AI-powered code explanations per month.",
-      "current_state": "The free tier includes 3 snaps at once, 5 AI explanations per month, 100MB image upload limit, 3 snap storage limit, and includes a watermark on videos and snaps.",
-      "impact": "medium",
-      "source_url": "https://snappify.com",
-      "category": "Dev Utilities",
       "alternatives": [],
       "detected_by": "reverify-ai",
       "recorded_date": "2026-08-28"
@@ -6741,21 +6591,6 @@
       "impact": "high",
       "source_url": "https://www.comet.com/site/pricing/",
       "category": "AI / ML",
-      "alternatives": [],
-      "detected_by": "reverify-ai",
-      "recorded_date": "2026-08-28"
-    },
-    {
-      "vendor": "Meeting",
-      "change_type": "limits_reduced",
-      "date": "2026-08-28",
-      "date_source": "discovered",
-      "summary": "The free tier now has a 60-minute meeting limit and supports up to 100 participants. Previously unlimited meeting duration with up to 3 meeting participants & 10 Webinar attendees.",
-      "previous_state": "Meetings with upto 3 meeting participants & 10 Webinar attendees.",
-      "current_state": "Free plan offers up to 60 minutes of meetings and 100 meeting participants.",
-      "impact": "high",
-      "source_url": "https://zoho.com/meeting",
-      "category": "Cloud IaaS",
       "alternatives": [],
       "detected_by": "reverify-ai",
       "recorded_date": "2026-08-28"

--- a/scripts/change-gate.js
+++ b/scripts/change-gate.js
@@ -1,4 +1,5 @@
 import { pageNamesVendor } from "./vendor-naming.js";
+import { readPeriod, renderPeriod } from "../src/growth-limits.ts";
 
 export const REJECT_NULL_COMPARISON = "null_comparison";
 export const REJECT_STATES_NO_DIFFERENCE = "states_no_difference";
@@ -12,6 +13,8 @@ export const REJECT_REMOVAL_READ_FROM_ROOT = "removal_read_from_root";
 export const REJECT_FREE_TIER_STILL_OFFERED = "free_tier_still_offered";
 export const REJECT_NO_BASELINE = "no_baseline";
 export const REJECT_DANGLING_REFERENCE = "dangling_reference";
+export const REJECT_MEASURES_NO_CHANGE = "measures_no_change";
+export const REJECT_MEASURES_THE_OPPOSITE = "measures_the_opposite";
 
 export const GATE_REASONS = [
   REJECT_NULL_COMPARISON,
@@ -26,6 +29,8 @@ export const GATE_REASONS = [
   REJECT_FREE_TIER_STILL_OFFERED,
   REJECT_NO_BASELINE,
   REJECT_DANGLING_REFERENCE,
+  REJECT_MEASURES_NO_CHANGE,
+  REJECT_MEASURES_THE_OPPOSITE,
 ];
 
 export const FREE_TIER_REMOVED = "free_tier_removed";
@@ -101,6 +106,67 @@ export const BYTE_UNITS = new Map([
 
 const UNIT_AFTER_NUMBER = /^\s?(kib|mib|gib|tib|pib|kb|mb|gb|tb|pb)\b/i;
 
+export const MAGNITUDE_UNITS = new Map([
+  ["k", 1e3],
+  ["m", 1e6],
+  ["bn", 1e9],
+  ["b", 1e9],
+  ["thousand", 1e3],
+  ["million", 1e6],
+  ["billion", 1e9],
+  ["trillion", 1e12],
+]);
+
+const MAGNITUDE_AFTER_NUMBER = /^(?:(bn|k|m|b)|\s(thousand|million|billion|trillion))\b/i;
+
+const DURATION_AFTER_NUMBER =
+  /^[\s-]?(seconds?|secs?|minutes?|mins?|hours?|hrs?|h|days?|weeks?|wks?|months?|years?|yrs?)\b/i;
+
+const PERIOD_SECONDS = new Map([
+  ["sec", 1],
+  ["min", 60],
+  ["hour", 3600],
+  ["day", 86400],
+  ["week", 604800],
+  ["mo", 2592000],
+  ["yr", 31536000],
+]);
+
+const PERIOD_SCAN_WORDS = 4;
+const PERIOD_SCAN_ENDS = /[,;()]/;
+const A_WORD = /[A-Za-z][\w-]*/g;
+const A_FIGURE = /\d/;
+const CLAUSE_ENDS = /[,;.()✓•|]/;
+const A_SCOPE = /\sper\s/i;
+
+function periodAfter(window) {
+  const ends = window.search(PERIOD_SCAN_ENDS);
+  const scan = ends === -1 ? window : window.slice(0, ends);
+  const offsets = [0];
+  const words = new RegExp(A_WORD.source, "g");
+  for (let word = words.exec(scan); word && offsets.length <= PERIOD_SCAN_WORDS; word = words.exec(scan)) {
+    offsets.push(word.index + word[0].length);
+  }
+  for (const at of offsets) {
+    if (A_FIGURE.test(scan.slice(0, at))) break;
+    const rest = scan.slice(at);
+    const period = readPeriod(rest) ?? readPeriod(rest.replace(/^\s+/, ""));
+    if (period) return { period, at, ends: at + period.length };
+  }
+  return null;
+}
+
+export function periodSeconds(period) {
+  const seconds = PERIOD_SECONDS.get(period?.unit ?? "");
+  if (seconds === undefined) return null;
+  const count = Number(String(period.count ?? "1").replace(/,/g, ""));
+  return Number.isFinite(count) && count > 0 ? count * seconds : seconds;
+}
+
+function spanOf(word) {
+  return word ? (PERIOD_SECONDS.get(readPeriod(`/${word}`)?.unit ?? "") ?? null) : null;
+}
+
 export function priceSignals(text) {
   if (typeof text !== "string") return [];
   const found = [];
@@ -121,61 +187,143 @@ function singular(word) {
 
 export const PRICE_ATTRIBUTE = "currency";
 
-export function quantifiedAttributes(text) {
+function wordsIn(trailing) {
+  const words = [];
+  for (const word of trailing.toLowerCase().split(/[^a-z0-9%]+/).filter(Boolean).slice(0, ATTRIBUTE_WORDS)) {
+    const stem = singular(word);
+    if (ATTRIBUTE_STOPWORDS.has(word) || ATTRIBUTE_STOPWORDS.has(stem)) continue;
+    if (A_FIGURE.test(stem.charAt(0))) continue;
+    if (stem.length <= 2 && !BYTE_UNITS.has(stem)) continue;
+    words.push(stem);
+  }
+  return words;
+}
+
+export function readQuantities(text) {
   if (typeof text !== "string") return [];
-  const attributes = [];
+  const read = [];
+  let readThrough = 0;
   for (const match of text.matchAll(NUMBER)) {
     const start = match.index + match[0].length;
-    const trailing = text.slice(start, start + ATTRIBUTE_WINDOW).toLowerCase();
+    const trailing = text.slice(start, start + ATTRIBUTE_WINDOW);
+    const rate = periodAfter(trailing);
+    const beside = trailing.slice(rate?.at === 0 ? rate.ends : 0);
+    const stops = [
+      rate?.at > 0 ? rate.at : -1,
+      beside.search(A_FIGURE),
+      beside.search(CLAUSE_ENDS),
+      beside.search(A_SCOPE),
+    ];
+    const describes = Math.min(...stops.filter((at) => at !== -1), beside.length);
     const words = [];
     if (/[$€£¥₹]\s?$/.test(text.slice(0, match.index))) words.push(PRICE_ATTRIBUTE);
-    for (const word of trailing.split(/[^a-z0-9%]+/).filter(Boolean).slice(0, ATTRIBUTE_WORDS)) {
-      const stem = singular(word);
-      if (ATTRIBUTE_STOPWORDS.has(word) || ATTRIBUTE_STOPWORDS.has(stem)) continue;
-      if (stem.length <= 2) continue;
-      words.push(stem);
-    }
-    const unitMatch = text.slice(start, start + ATTRIBUTE_WINDOW).match(UNIT_AFTER_NUMBER);
+    const named = wordsIn(beside.slice(0, describes));
+    words.push(...(named.length > 0 || rate ? named : wordsIn(trailing)));
+    const unitMatch = trailing.match(UNIT_AFTER_NUMBER);
     const unit = unitMatch ? unitMatch[1].toLowerCase() : null;
-    if (words.length > 0) attributes.push({ value: match[0], words, unit });
+    const magnitudeMatch = unit === null ? trailing.match(MAGNITUDE_AFTER_NUMBER) : null;
+    const magnitude = magnitudeMatch ? (magnitudeMatch[1] ?? magnitudeMatch[2]).toLowerCase() : "";
+    const durationMatch = unit === null && magnitude === "" ? trailing.match(DURATION_AFTER_NUMBER) : null;
+    const scale =
+      BYTE_UNITS.get(unit ?? "") ??
+      MAGNITUDE_UNITS.get(magnitude) ??
+      spanOf(durationMatch ? durationMatch[1] : null) ??
+      1;
+    const period = rate?.period ?? null;
+    read.push({ value: match[0], words, unit, scale, period, spellsAPeriod: match.index < readThrough });
+    if (rate) readThrough = start + rate.ends;
   }
-  return attributes;
+  return read;
+}
+
+export function quantifiedAttributes(text) {
+  return readQuantities(text).filter(({ words, spellsAPeriod }) => words.length > 0 && !spellsAPeriod);
+}
+
+function isAMeasureWord(word) {
+  return !BYTE_UNITS.has(word) && !MAGNITUDE_UNITS.has(word) && !A_FIGURE.test(word.charAt(0));
 }
 
 export function measuredWord(attribute) {
-  return (attribute?.words ?? []).find((word) => !BYTE_UNITS.has(word)) ?? null;
+  return (attribute?.words ?? []).find(isAMeasureWord) ?? null;
 }
 
-export function normalizedMagnitude(attribute) {
-  const scale = BYTE_UNITS.get(attribute?.unit ?? "");
-  if (scale === undefined) return null;
-  const value = Number(String(attribute.value).replace(/,/g, ""));
-  return Number.isFinite(value) ? value * scale : null;
+export function measuredValue(attribute) {
+  const value = Number(String(attribute?.value ?? "").replace(/,/g, ""));
+  if (!Number.isFinite(value)) return null;
+  return value * (attribute?.scale ?? 1);
+}
+
+export function measuresTheSameThing(before, after) {
+  const priced = (attribute) => (attribute?.words ?? []).includes(PRICE_ATTRIBUTE);
+  if (priced(before) !== priced(after)) return false;
+  const left = measuredWord(before);
+  const right = measuredWord(after);
+  if (!left || !right) return false;
+  return after.words.includes(left) || before.words.includes(right);
+}
+
+function sameAmount(from, to) {
+  return Math.abs(from - to) <= 1e-9 * Math.max(Math.abs(from), Math.abs(to), 1);
+}
+
+export function comparedQuantity(before, after) {
+  if (!measuresTheSameThing(before, after)) return null;
+  let from = measuredValue(before);
+  let to = measuredValue(after);
+  if (from === null || to === null) return null;
+  const over = periodSeconds(before?.period);
+  const under = periodSeconds(after?.period);
+  if (over !== null && under !== null) {
+    from /= over;
+    to /= under;
+  }
+  return {
+    attribute: measuredWord(before),
+    previous: renderedQuantity(before),
+    current: renderedQuantity(after),
+    priced: (before.words ?? []).includes(PRICE_ATTRIBUTE),
+    before,
+    after,
+    from,
+    to,
+    direction: sameAmount(from, to) ? "equal" : to > from ? "increase" : "decrease",
+  };
+}
+
+function renderedQuantity(attribute) {
+  const unit = attribute?.unit ? ` ${attribute.unit.toUpperCase()}` : "";
+  const period = attribute?.period ? renderPeriod(attribute.period) : "";
+  return `${attribute?.value}${unit} ${measuredWord(attribute) ?? ""}${period}`.replace(/\s+/g, " ").trim();
+}
+
+function measuresAnAmount(attribute) {
+  return !(attribute?.words ?? []).includes(PRICE_ATTRIBUTE);
+}
+
+export function quantityComparison(entry) {
+  const previous = quantifiedAttributes(entry?.previous_state).filter(measuresAnAmount);
+  const current = quantifiedAttributes(entry?.current_state).filter(measuresAnAmount);
+  const compared = [];
+  const matched = new Set();
+  for (const before of previous) {
+    for (const after of current) {
+      const quantity = comparedQuantity(before, after);
+      if (!quantity) continue;
+      compared.push(quantity);
+      matched.add(before).add(after);
+    }
+  }
+  const unmatched = [...previous, ...current].filter((attribute) => !matched.has(attribute));
+  return { compared, unmatched };
+}
+
+export function comparedQuantities(entry) {
+  return quantityComparison(entry).compared;
 }
 
 export function measuredDifferences(entry) {
-  const previous = quantifiedAttributes(entry?.previous_state);
-  const current = quantifiedAttributes(entry?.current_state);
-  const differences = [];
-  for (const before of previous) {
-    const word = measuredWord(before);
-    const from = normalizedMagnitude(before);
-    if (!word || from === null) continue;
-    for (const after of current) {
-      if (measuredWord(after) !== word) continue;
-      const to = normalizedMagnitude(after);
-      if (to === null || to === from) continue;
-      differences.push({
-        attribute: word,
-        previous: `${before.value} ${before.unit}`,
-        current: `${after.value} ${after.unit}`,
-        from,
-        to,
-        direction: to > from ? "increase" : "decrease",
-      });
-    }
-  }
-  return differences;
+  return comparedQuantities(entry).filter(({ direction }) => direction !== "equal");
 }
 
 export function storedDimensionsAbsentFromPage(entry, pageText) {
@@ -475,11 +623,7 @@ export function statesTheSameFigure(baseline, elsewhere) {
   if (carried.length === 0) return false;
   const already = elsewhere.flatMap((text) => quantifiedAttributes(text));
   return carried.every((figure) =>
-    already.some(
-      (other) =>
-        other.value === figure.value &&
-        figure.words.some((word) => other.words.includes(word) && !BYTE_UNITS.has(word))
-    )
+    already.some((other) => comparedQuantity(figure, other)?.direction === "equal")
   );
 }
 
@@ -533,13 +677,6 @@ export function namesTheDimensionThatChanged(record, summary) {
       before.words.some((word) => after.words.includes(word) && !BYTE_UNITS.has(word))
     )
   );
-}
-
-function comparableMagnitude(attribute) {
-  const scaled = normalizedMagnitude(attribute);
-  if (scaled !== null) return scaled;
-  const value = Number(String(attribute?.value).replace(/,/g, ""));
-  return Number.isFinite(value) ? value : null;
 }
 
 export function summaryFromClauses(clauses) {
@@ -823,7 +960,7 @@ export async function gateCandidates(candidates, options = {}) {
         candidate,
         opinion: confirmation.reason || "a second pass judged the report to describe no change",
         difference,
-        detail: `the two states measure ${difference.attribute} at ${difference.previous} and ${difference.current}, a ${difference.direction} from ${difference.from.toLocaleString("en-US")} to ${difference.to.toLocaleString("en-US")} bytes`,
+        detail: `the two states measure ${difference.attribute} at ${difference.previous} and ${difference.current}, a ${difference.direction} from ${difference.from.toLocaleString("en-US")} to ${difference.to.toLocaleString("en-US")} once notation and period are normalised`,
       });
       accepted.push(candidate);
       continue;
@@ -876,6 +1013,58 @@ function baselineWasDropped(evidence) {
 export function hasABaselineToRestate(record, evidence) {
   if (!DIRECTIONAL_CLAIMS.includes(record?.change_type)) return false;
   return baselineWasDropped(evidence);
+}
+
+const EXPECTED_DIRECTION = {
+  limits_reduced: "decrease",
+  limits_increased: "increase",
+};
+
+export function statesBothSides(summary, quantity) {
+  const stated = quantifiedAttributes(summary);
+  const carries = (attribute) =>
+    stated.some((other) => comparedQuantity(attribute, other)?.direction === "equal");
+  return carries(quantity.before) && carries(quantity.after);
+}
+
+function everyStatedFigureHeldStill(summary, compared, restated) {
+  const held = restated.map(({ value }) => value);
+  return readQuantities(summary)
+    .filter(({ spellsAPeriod }) => !spellsAPeriod)
+    .filter(measuresAnAmount)
+    .every((stated) => {
+      if (held.includes(Number(String(stated.value).replace(/,/g, "")))) return true;
+      if (measuredWord(stated) === null) return false;
+      return compared.some(
+        ({ before, after }) =>
+          comparedQuantity(before, stated)?.direction === "equal" ||
+          comparedQuantity(after, stated)?.direction === "equal"
+      );
+    });
+}
+
+export function measuredAgainstItsClaim(record, published = record?.summary) {
+  const expected = EXPECTED_DIRECTION[record?.change_type];
+  if (!expected) return null;
+  const { compared } = quantityComparison(record);
+  const restated = nullComparisons(published);
+  if (compared.length + restated.length === 0) return null;
+  const moved = compared.filter(({ direction }) => direction !== "equal");
+  if (moved.length === 0) {
+    if (!everyStatedFigureHeldStill(published, compared, restated)) return null;
+    return { reason: REJECT_MEASURES_NO_CHANGE, quantities: compared, restated };
+  }
+  const contradicts = moved.filter(({ direction }) => direction !== expected);
+  if (contradicts.length === moved.length && contradicts.some((q) => statesBothSides(published, q))) {
+    return { reason: REJECT_MEASURES_THE_OPPOSITE, quantities: contradicts, restated };
+  }
+  return null;
+}
+
+function readsAsAList(measured) {
+  const pairs = measured.quantities.map(({ previous, current }) => `${previous} against ${current}`);
+  const stated = measured.restated.map(({ connective, value }) => `${value} "${connective}" ${value}`);
+  return [...pairs, ...stated].slice(0, 3).join(", ");
 }
 
 export function lostTheSubjectOfItsClaim(record, evidence, summary) {
@@ -968,6 +1157,20 @@ export function auditRecord(record, context = {}) {
         `a free tier was recorded as removed on the evidence that the page did not mention it, and the summary states no price, ending or replacement where the free tier was`
       );
     }
+  }
+
+  const measured = measuredAgainstItsClaim(record, rewritten);
+  if (measured?.reason === REJECT_MEASURES_NO_CHANGE) {
+    return refuse(
+      REJECT_MEASURES_NO_CHANGE,
+      `${record.change_type} claimed, and every quantity the record compares holds the same value once notation and period are normalised — ${readsAsAList(measured)}`
+    );
+  }
+  if (measured?.reason === REJECT_MEASURES_THE_OPPOSITE) {
+    return refuse(
+      REJECT_MEASURES_THE_OPPOSITE,
+      `${record.change_type} claimed, and every quantity that moved between the two states moved the other way — ${readsAsAList(measured)}`
+    );
   }
 
   if (lostTheSubjectOfItsClaim(record, evidence, rewritten)) {

--- a/scripts/mutate-1116.sh
+++ b/scripts/mutate-1116.sh
@@ -102,7 +102,7 @@ m_measured_word_takes_the_unit() {
   py <<'PY'
 p = "scripts/change-gate.js"
 s = open(p).read()
-s = s.replace('  return (attribute?.words ?? []).find((word) => !BYTE_UNITS.has(word)) ?? null;',
+s = s.replace('  return (attribute?.words ?? []).find(isAMeasureWord) ?? null;',
               '  return (attribute?.words ?? [])[0] ?? null;')
 open(p, "w").write(s)
 PY
@@ -131,8 +131,8 @@ m_magnitude_ignores_the_unit() {
   py <<'PY'
 p = "scripts/change-gate.js"
 s = open(p).read()
-s = s.replace('  return Number.isFinite(value) ? value * scale : null;',
-              '  return Number.isFinite(value) ? value : null;')
+s = s.replace('  return value * (attribute?.scale ?? 1);',
+              '  return value;')
 open(p, "w").write(s)
 PY
 }
@@ -141,8 +141,7 @@ m_a_figure_without_a_unit_still_measures() {
   py <<'PY'
 p = "scripts/change-gate.js"
 s = open(p).read()
-s = s.replace('  const scale = BYTE_UNITS.get(attribute?.unit ?? "");\n  if (scale === undefined) return null;',
-              '  const scale = BYTE_UNITS.get(attribute?.unit ?? "") ?? 1;')
+s = s.replace('      BYTE_UNITS.get(unit ?? "") ??\n', '')
 open(p, "w").write(s)
 PY
 }
@@ -271,7 +270,7 @@ run_mutation "the unit is read as the thing being measured" m_measured_word_take
 run_mutation "an amount is looked for on the page as the word currency" m_an_amount_is_looked_for_literally
 run_mutation "a gibibyte is scaled as a gigabyte" m_binary_units_scale_like_decimal
 run_mutation "the magnitude ignores the unit written against it" m_magnitude_ignores_the_unit
-run_mutation "a figure with no size unit is measured anyway" m_a_figure_without_a_unit_still_measures
+run_mutation "a size unit does not scale the figure written against it" m_a_figure_without_a_unit_still_measures
 run_mutation "no unit is read out of the text at all" m_no_unit_is_extracted_from_the_text
 run_mutation "the second opinion is never overruled" m_the_second_opinion_is_never_overruled
 run_mutation "the second opinion is always overruled" m_the_second_opinion_is_always_overruled

--- a/scripts/mutate-1121.sh
+++ b/scripts/mutate-1121.sh
@@ -136,8 +136,8 @@ m_the_period_is_read_from_anywhere_in_the_description() {
   py <<'PY'
 p = "src/growth-limits.ts"
 s = open(p).read()
-s = s.replace('const WORDED_PERIOD = /^(?:\\s+for)?(?:\\s+free)?\\s+(?:per|a|an|every)\\s+(?:(\\d[\\d,]*)\\s*)?([a-z]+)/i;',
-              'const WORDED_PERIOD = /(?:\\s+for)?(?:\\s+free)?\\s+(?:per|a|an|every)\\s+(?:(\\d[\\d,]*)\\s*)?([a-z]+)/i;')
+s = s.replace('const WORDED_PERIOD = /^(?:\\s+for)?(?:\\s+free)?\\s+(?:per|a|an|every)\\s+(?:(\\d[\\d,]*)[\\s-]*)?([a-z]+)/i;',
+              'const WORDED_PERIOD = /(?:\\s+for)?(?:\\s+free)?\\s+(?:per|a|an|every)\\s+(?:(\\d[\\d,]*)[\\s-]*)?([a-z]+)/i;')
 open(p, "w").write(s)
 PY
 }

--- a/scripts/mutate-1134-ac11-ac13.sh
+++ b/scripts/mutate-1134-ac11-ac13.sh
@@ -116,7 +116,7 @@ m_two_figures_of_equal_value_are_the_same_figure() {
   py <<'PY'
 p = "scripts/change-gate.js"
 s = open(p).read()
-s = s.replace("        other.value === figure.value &&\n        figure.words.some((word) => other.words.includes(word) && !BYTE_UNITS.has(word))", "        other.value === figure.value")
+s = s.replace('already.some((other) => comparedQuantity(figure, other)?.direction === "equal")', "already.some((other) => measuredValue(figure) === measuredValue(other))")
 open(p, "w").write(s)
 PY
 }

--- a/scripts/mutate-1136.sh
+++ b/scripts/mutate-1136.sh
@@ -1,0 +1,257 @@
+#!/usr/bin/env bash
+set -u
+
+REPO="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$REPO" || exit 1
+
+GATE="scripts/change-gate.js"
+BACKUP_DIR="$(mktemp -d)"
+cp "$GATE" "$BACKUP_DIR/change-gate.js"
+
+restore() {
+  cp "$BACKUP_DIR/change-gate.js" "$GATE"
+}
+trap restore EXIT
+
+killed=0
+survived=0
+TESTS="test/change-summary.test.ts test/change-gate.test.ts"
+
+run_mutation() {
+  local name="$1"
+  shift
+  echo "=== $name"
+  restore
+  "$@"
+  if diff -q "$BACKUP_DIR/change-gate.js" "$GATE" > /dev/null; then
+    echo "    NOT APPLIED: the mutation changed no file, so it proves nothing"
+    survived=$((survived + 1))
+    return
+  fi
+  if timeout 900 npx tsx --test $TESTS > /tmp/mutate-1136-test.log 2>&1; then
+    echo "    SURVIVED"
+    survived=$((survived + 1))
+  else
+    echo "    KILLED: $(grep -c '✖ ' /tmp/mutate-1136-test.log) failing assertion(s)"
+    grep '✖ ' /tmp/mutate-1136-test.log | head -4
+    killed=$((killed + 1))
+  fi
+}
+
+py() { python3 - "$@"; }
+
+m_a_period_is_never_normalised() {
+  py <<'PY'
+p = "scripts/change-gate.js"
+s = open(p).read()
+s = s.replace("  if (over !== null && under !== null) {\n    from /= over;\n    to /= under;\n  }", "")
+open(p, "w").write(s)
+PY
+}
+
+m_a_period_count_counts_for_one() {
+  py <<'PY'
+p = "scripts/change-gate.js"
+s = open(p).read()
+s = s.replace("  return Number.isFinite(count) && count > 0 ? count * seconds : seconds;", "  return seconds;")
+open(p, "w").write(s)
+PY
+}
+
+m_a_magnitude_suffix_is_read_as_a_word() {
+  py <<'PY'
+p = "scripts/change-gate.js"
+s = open(p).read()
+s = s.replace("    const scale =\n      BYTE_UNITS.get(unit ?? \"\") ??\n      MAGNITUDE_UNITS.get(magnitude) ??\n      spanOf(durationMatch ? durationMatch[1] : null) ??\n      1;", "    const scale = BYTE_UNITS.get(unit ?? \"\") ?? 1;")
+open(p, "w").write(s)
+PY
+}
+
+m_a_bare_duration_counts_as_its_own_number() {
+  py <<'PY'
+p = "scripts/change-gate.js"
+s = open(p).read()
+s = s.replace("      spanOf(durationMatch ? durationMatch[1] : null) ??\n", "")
+open(p, "w").write(s)
+PY
+}
+
+m_the_words_run_past_the_next_figure() {
+  py <<'PY'
+p = "scripts/change-gate.js"
+s = open(p).read()
+s = s.replace("      beside.search(A_FIGURE),\n", "")
+open(p, "w").write(s)
+PY
+}
+
+m_the_words_run_past_the_clause() {
+  py <<'PY'
+p = "scripts/change-gate.js"
+s = open(p).read()
+s = s.replace("      beside.search(CLAUSE_ENDS),\n", "")
+open(p, "w").write(s)
+PY
+}
+
+m_the_words_run_past_a_scope() {
+  py <<'PY'
+p = "scripts/change-gate.js"
+s = open(p).read()
+s = s.replace("      beside.search(A_SCOPE),\n", "")
+open(p, "w").write(s)
+PY
+}
+
+m_a_figure_with_no_words_nearby_is_dropped() {
+  py <<'PY'
+p = "scripts/change-gate.js"
+s = open(p).read()
+s = s.replace("    words.push(...(named.length > 0 || rate ? named : wordsIn(trailing)));", "    words.push(...named);")
+open(p, "w").write(s)
+PY
+}
+
+m_a_number_spelling_a_period_is_a_quantity_of_its_own() {
+  py <<'PY'
+p = "scripts/change-gate.js"
+s = open(p).read()
+s = s.replace("  return readQuantities(text).filter(({ words, spellsAPeriod }) => words.length > 0 && !spellsAPeriod);", "  return readQuantities(text).filter(({ words }) => words.length > 0);")
+open(p, "w").write(s)
+PY
+}
+
+m_two_figures_measure_the_same_thing_whatever_they_name() {
+  py <<'PY'
+p = "scripts/change-gate.js"
+s = open(p).read()
+s = s.replace("  return after.words.includes(left) || before.words.includes(right);", "  return true;")
+open(p, "w").write(s)
+PY
+}
+
+m_a_price_is_compared_with_a_count() {
+  py <<'PY'
+p = "scripts/change-gate.js"
+s = open(p).read()
+s = s.replace("  if (priced(before) !== priced(after)) return false;", "")
+open(p, "w").write(s)
+PY
+}
+
+m_a_price_counts_as_a_quantity_the_record_compares() {
+  py <<'PY'
+p = "scripts/change-gate.js"
+s = open(p).read()
+s = s.replace("  const previous = quantifiedAttributes(entry?.previous_state).filter(measuresAnAmount);\n  const current = quantifiedAttributes(entry?.current_state).filter(measuresAnAmount);", "  const previous = quantifiedAttributes(entry?.previous_state);\n  const current = quantifiedAttributes(entry?.current_state);")
+open(p, "w").write(s)
+PY
+}
+
+m_a_record_is_refused_whenever_nothing_moved() {
+  py <<'PY'
+p = "scripts/change-gate.js"
+s = open(p).read()
+s = s.replace("    if (!everyStatedFigureHeldStill(published, compared, restated)) return null;\n", "")
+open(p, "w").write(s)
+PY
+}
+
+m_a_stated_figure_with_no_subject_is_held_still() {
+  py <<'PY'
+p = "scripts/change-gate.js"
+s = open(p).read()
+s = s.replace("      if (measuredWord(stated) === null) return false;", "      if (measuredWord(stated) === null) return true;")
+open(p, "w").write(s)
+PY
+}
+
+m_a_summary_restating_one_figure_never_counts() {
+  py <<'PY'
+p = "scripts/change-gate.js"
+s = open(p).read()
+s = s.replace("  const restated = nullComparisons(published);", "  const restated = [];")
+open(p, "w").write(s)
+PY
+}
+
+m_one_contradicting_figure_is_enough_to_refuse() {
+  py <<'PY'
+p = "scripts/change-gate.js"
+s = open(p).read()
+s = s.replace("  if (contradicts.length === moved.length && contradicts.some((q) => statesBothSides(published, q))) {", "  if (contradicts.length > 0 && contradicts.some((q) => statesBothSides(published, q))) {")
+open(p, "w").write(s)
+PY
+}
+
+m_the_summary_need_not_state_the_figures_that_contradict() {
+  py <<'PY'
+p = "scripts/change-gate.js"
+s = open(p).read()
+s = s.replace("  if (contradicts.length === moved.length && contradicts.some((q) => statesBothSides(published, q))) {", "  if (contradicts.length === moved.length) {")
+open(p, "w").write(s)
+PY
+}
+
+m_the_summary_need_only_state_one_side() {
+  py <<'PY'
+p = "scripts/change-gate.js"
+s = open(p).read()
+s = s.replace("  return carries(quantity.before) && carries(quantity.after);", "  return carries(quantity.before) || carries(quantity.after);")
+open(p, "w").write(s)
+PY
+}
+
+m_an_increase_and_a_reduction_expect_the_same_direction() {
+  py <<'PY'
+p = "scripts/change-gate.js"
+s = open(p).read()
+s = s.replace("  limits_increased: \"increase\",", "  limits_increased: \"decrease\",")
+open(p, "w").write(s)
+PY
+}
+
+m_the_claim_is_judged_on_the_summary_as_written() {
+  py <<'PY'
+p = "scripts/change-gate.js"
+s = open(p).read()
+s = s.replace("  const measured = measuredAgainstItsClaim(record, rewritten);", "  const measured = measuredAgainstItsClaim(record, record?.summary);")
+open(p, "w").write(s)
+PY
+}
+
+m_the_words_are_read_from_in_front_of_the_period() {
+  py <<'PY'
+p = "scripts/change-gate.js"
+s = open(p).read()
+s = s.replace("    const beside = trailing.slice(rate?.at === 0 ? rate.ends : 0);", "    const beside = trailing;")
+open(p, "w").write(s)
+PY
+}
+
+run_mutation "a period is never normalised" m_a_period_is_never_normalised
+run_mutation "a period count counts for one" m_a_period_count_counts_for_one
+run_mutation "a magnitude suffix is read as a word" m_a_magnitude_suffix_is_read_as_a_word
+run_mutation "a bare duration counts as its own number" m_a_bare_duration_counts_as_its_own_number
+run_mutation "the words run past the next figure" m_the_words_run_past_the_next_figure
+run_mutation "the words run past the clause" m_the_words_run_past_the_clause
+run_mutation "the words run past a scope" m_the_words_run_past_a_scope
+run_mutation "a figure with no words nearby is dropped" m_a_figure_with_no_words_nearby_is_dropped
+run_mutation "the words are read from in front of the period" m_the_words_are_read_from_in_front_of_the_period
+run_mutation "a number spelling a period is a quantity of its own" m_a_number_spelling_a_period_is_a_quantity_of_its_own
+run_mutation "two figures measure the same thing whatever they name" m_two_figures_measure_the_same_thing_whatever_they_name
+run_mutation "a price is compared with a count" m_a_price_is_compared_with_a_count
+run_mutation "a price counts as a quantity the record compares" m_a_price_counts_as_a_quantity_the_record_compares
+run_mutation "a record is refused whenever nothing moved" m_a_record_is_refused_whenever_nothing_moved
+run_mutation "a stated figure with no subject is held still" m_a_stated_figure_with_no_subject_is_held_still
+run_mutation "a summary restating one figure never counts" m_a_summary_restating_one_figure_never_counts
+run_mutation "one contradicting figure is enough to refuse" m_one_contradicting_figure_is_enough_to_refuse
+run_mutation "the summary need not state the figures that contradict" m_the_summary_need_not_state_the_figures_that_contradict
+run_mutation "the summary need only state one side" m_the_summary_need_only_state_one_side
+run_mutation "an increase and a reduction expect the same direction" m_an_increase_and_a_reduction_expect_the_same_direction
+run_mutation "the claim is judged on the summary as written" m_the_claim_is_judged_on_the_summary_as_written
+
+restore
+echo
+echo "killed: $killed, survived: $survived"
+[ "$survived" -eq 0 ]

--- a/src/growth-limits.ts
+++ b/src/growth-limits.ts
@@ -44,7 +44,7 @@ const PLURAL_UNITS: Record<string, string> = {
 };
 
 const SLASH_PERIOD = /^\/(\d[\d,]*)?\s*([a-z]+)(?:\/([a-z]+))?/i;
-const WORDED_PERIOD = /^(?:\s+for)?(?:\s+free)?\s+(?:per|a|an|every)\s+(?:(\d[\d,]*)\s*)?([a-z]+)/i;
+const WORDED_PERIOD = /^(?:\s+for)?(?:\s+free)?\s+(?:per|a|an|every)\s+(?:(\d[\d,]*)[\s-]*)?([a-z]+)/i;
 const ADVERB_PERIOD = /^(?:\s+for)?(?:\s+free)?\s+(hourly|daily|weekly|monthly|yearly|annually)\b/i;
 const SCOPE_SUFFIX = /^\s+per\s+([a-z]+)/i;
 const NON_RATE_QUALIFIER = /^\s+of\s+((?!and\b)[a-z]+(?:\s+(?!and\b)[a-z]+){0,2})/i;

--- a/test/change-gate.test.ts
+++ b/test/change-gate.test.ts
@@ -26,7 +26,9 @@ const {
   quantifiedAttributes,
   storedDimensionsAbsentFromPage,
   measuredDifferences,
-  normalizedMagnitude,
+  measuredValue,
+  comparedQuantity,
+  measuredAgainstItsClaim,
   rejectionCounts,
   parseConfirmation,
   changeConfirmationPrompt,
@@ -39,6 +41,8 @@ const {
   REJECT_PAGE_NOT_ABOUT_VENDOR,
   REJECT_UNQUANTIFIED_LIMIT,
   REJECT_CONFIRMED_UNCHANGED,
+  REJECT_MEASURES_NO_CHANGE,
+  REJECT_MEASURES_THE_OPPOSITE,
 } = await import("../scripts/change-gate.js");
 
 const { runAiMode, summaryLines } = await import("../scripts/reverify-rolling.js");
@@ -105,6 +109,14 @@ const A_DAILY_CAP_WAS_HALVED = {
   impact: "medium",
 };
 
+const A_SUPPORT_CHANNEL_CLOSED = {
+  vendor: "Papertrail",
+  change_type: "limits_reduced",
+  summary: "Support on the free plan is now community forums only.",
+  previous_state: "Log aggregation — free plan with email support from the Papertrail team",
+  current_state: "The free plan is supported through the community forum.",
+  impact: "medium",
+};
 const A_RETENTION_WINDOW_SHRANK = {
   vendor: "Sematext",
   change_type: "limits_reduced",
@@ -292,13 +304,13 @@ describe("a recorded change must describe a change", () => {
       assert.strictEqual(verdict.reason, REJECT_NULL_COMPARISON);
     });
 
-    it("keeps a record where the equal figure sits beside a figure that vanished", () => {
+    it("does not read the equal figure as a null comparison where a figure vanished", () => {
       const droppedAlongside = {
         ...SAME_TERMS_EITHER_SIDE,
         current_state: "Free: 1 A/B Test, 3 Feature Flags, 5 Environments",
       };
       assert.deepStrictEqual(nullComparisons(droppedAlongside.summary).length, 1);
-      assert.strictEqual(describesChange(droppedAlongside).ok, true);
+      assert.notStrictEqual(describesChange(droppedAlongside).reason, REJECT_NULL_COMPARISON);
     });
   });
 
@@ -579,44 +591,48 @@ describe("a recorded change must describe a change", () => {
   });
 
   describe("a figure measured in binary units against one measured in decimal", () => {
+    const sized = (value: string, unit: string) => ({
+      value,
+      words: ["x"],
+      unit,
+      scale: BYTE_UNITS.get(unit),
+      period: null,
+    });
+
     it("reads the unit written against the figure", () => {
       const [egress] = quantifiedAttributes("20GiB egress").filter((a: any) => a.unit);
       assert.strictEqual(egress.unit, "gib");
-      assert.strictEqual(normalizedMagnitude(egress), 20 * 1024 ** 3);
+      assert.strictEqual(measuredValue(egress), 20 * 1024 ** 3);
     });
 
     it("scales each binary unit above its decimal namesake", () => {
       for (const [binary, decimal] of [["kib", "kb"], ["mib", "mb"], ["gib", "gb"], ["tib", "tb"]]) {
-        const one = normalizedMagnitude({ value: "1", words: ["x"], unit: binary });
-        const other = normalizedMagnitude({ value: "1", words: ["x"], unit: decimal });
+        const one = measuredValue(sized("1", binary));
+        const other = measuredValue(sized("1", decimal));
         assert.ok(one > other, `${binary} did not exceed ${decimal}`);
       }
     });
 
     it("reads 20 GiB as smaller than 100 GB and 200 GiB as larger", () => {
-      const twenty = normalizedMagnitude({ value: "20", words: ["x"], unit: "gib" });
-      const twoHundred = normalizedMagnitude({ value: "200", words: ["x"], unit: "gib" });
-      const hundred = normalizedMagnitude({ value: "100", words: ["x"], unit: "gb" });
-      assert.ok(twenty < hundred);
-      assert.ok(twoHundred > hundred);
+      assert.strictEqual(comparedQuantity(sized("20", "gib"), sized("100", "gb")).direction, "increase");
+      assert.strictEqual(comparedQuantity(sized("200", "gib"), sized("100", "gb")).direction, "decrease");
     });
 
     it("reads 1 TiB as larger than 1,000 GB and 1 TB as exactly that", () => {
-      const tebibyte = normalizedMagnitude({ value: "1", words: ["x"], unit: "tib" });
-      const terabyte = normalizedMagnitude({ value: "1", words: ["x"], unit: "tb" });
-      const thousand = normalizedMagnitude({ value: "1,000", words: ["x"], unit: "gb" });
-      assert.ok(tebibyte > thousand);
-      assert.strictEqual(terabyte, thousand);
+      assert.strictEqual(comparedQuantity(sized("1", "tib"), sized("1,000", "gb")).direction, "decrease");
+      assert.strictEqual(comparedQuantity(sized("1", "tb"), sized("1,000", "gb")).direction, "equal");
     });
 
-    it("has no magnitude for a figure written without a size unit", () => {
-      assert.strictEqual(normalizedMagnitude({ value: "500", words: ["request"], unit: null }), null);
+    it("reads a figure written without a size unit at its face value", () => {
+      const [requests] = quantifiedAttributes("500 requests");
+      assert.strictEqual(requests.unit, null);
+      assert.strictEqual(measuredValue(requests), 500);
     });
 
     it("measures the egress the two states state in different units", () => {
-      const [difference, ...rest] = measuredDifferences(A_LIMIT_ACTUALLY_MOVED);
-      assert.strictEqual(rest.length, 0);
-      assert.strictEqual(difference.attribute, "egres");
+      const difference = measuredDifferences(A_LIMIT_ACTUALLY_MOVED).find(
+        (d: any) => d.attribute === "egres"
+      );
       assert.strictEqual(difference.direction, "decrease");
       assert.strictEqual(difference.from, 100e9);
       assert.strictEqual(difference.to, 20 * 1024 ** 3);
@@ -636,8 +652,17 @@ describe("a recorded change must describe a change", () => {
       );
     });
 
-    it("measures nothing where only one state carries a size unit", () => {
-      assert.deepStrictEqual(measuredDifferences(A_RETENTION_WINDOW_SHRANK), []);
+    it("reads a retention window shrinking although neither state carries a size unit", () => {
+      const window = measuredDifferences(A_RETENTION_WINDOW_SHRANK).find(
+        (d: any) => d.previous === "7 retention"
+      );
+      assert.strictEqual(window.direction, "decrease");
+      assert.strictEqual(window.from, 7 * 86400);
+      assert.strictEqual(window.to, 86400);
+    });
+
+    it("measures nothing between two states that share no quantified term", () => {
+      assert.deepStrictEqual(measuredDifferences(A_SUPPORT_CHANNEL_CLOSED), []);
     });
 
     it("keeps a record whose figures the second opinion read backwards", async () => {
@@ -654,12 +679,232 @@ describe("a recorded change must describe a change", () => {
     });
 
     it("still refuses a record the second opinion calls unchanged and no figure contradicts", async () => {
-      const { accepted, rejected, overruled } = await gateCandidates([A_RETENTION_WINDOW_SHRANK], {
+      const { accepted, rejected, overruled } = await gateCandidates([A_SUPPORT_CHANNEL_CLOSED], {
         confirmFn: async () => ({ verdict: "no", reason: "the page restates the stored terms" }),
       });
       assert.strictEqual(accepted.length, 0);
       assert.strictEqual(overruled.length, 0);
       assert.strictEqual(rejected[0].reason, REJECT_CONFIRMED_UNCHANGED);
+    });
+  });
+
+  describe("#1136 the direction comes from the quantities, not from the prose", () => {
+    const DOCKER_HUB_REBASED_THE_PERIOD = {
+      vendor: "Docker Hub",
+      change_type: "limits_reduced",
+      summary:
+        "The Docker Hub Personal tier now includes 100 Docker Hub pulls/hr instead of 200 pulls per 6-hour window. It also includes 1 Docker Scout-enabled repo.",
+      previous_state:
+        "1 private repository, unlimited public repositories. 200 pulls per 6-hour window (authenticated). No automated builds on free tier",
+      current_state:
+        "Docker Personal $0 $0 ... Includes: 100 Docker Hub pulls/hr* 1 private Docker Hub repo 1 Docker Scout-enabled repo*",
+      impact: "medium",
+    };
+
+    const A_CAP_APPEARED_BESIDE_A_RISE = {
+      vendor: "Zoho Meeting",
+      change_type: "limits_reduced",
+      summary:
+        "The free tier now has a 60-minute meeting limit and supports up to 100 participants. Previously unlimited meeting duration with up to 3 meeting participants & 10 Webinar attendees.",
+      previous_state: "Meetings with upto 3 meeting participants & 10 Webinar attendees.",
+      current_state: "Free plan offers up to 60 minutes of meetings and 100 meeting participants.",
+      impact: "high",
+    };
+
+    const A_REAL_TENFOLD_CUT = {
+      vendor: "Alibaba Cloud Qwen Code",
+      change_type: "limits_reduced",
+      summary: "The free tier now offers 100 requests/day, down from 1,000 requests/day.",
+      previous_state: "Free tier: 1,000 requests/day with the Qwen Code CLI, no token cap",
+      current_state: "The free tier offers 100 requests/day with the Qwen Code CLI.",
+      impact: "high",
+    };
+
+    it("reads 200 per 6 hours against 100 per hour as a rise", () => {
+      const [pulls] = measuredDifferences(DOCKER_HUB_REBASED_THE_PERIOD);
+      assert.strictEqual(pulls.attribute, "pull");
+      assert.strictEqual(pulls.direction, "increase");
+    });
+
+    it("refuses a reduction whose only compared quantity rose", () => {
+      const verdict = describesChange(DOCKER_HUB_REBASED_THE_PERIOD);
+      assert.strictEqual(verdict.ok, false);
+      assert.strictEqual(verdict.reason, REJECT_MEASURES_THE_OPPOSITE);
+      assert.match(verdict.detail, /200 pull per 6 hours/);
+    });
+
+    it("takes the direction from the matched quantity, not from a cap the page added", () => {
+      assert.strictEqual(
+        measuredAgainstItsClaim(A_CAP_APPEARED_BESIDE_A_RISE).reason,
+        REJECT_MEASURES_THE_OPPOSITE
+      );
+    });
+
+    it("keeps a reduction whose matched quantity really fell", () => {
+      assert.strictEqual(measuredAgainstItsClaim(A_REAL_TENFOLD_CUT), null);
+      assert.strictEqual(describesChange(A_REAL_TENFOLD_CUT).ok, true);
+    });
+
+    it("keeps a record whose contradicting figures the summary never puts to the reader", () => {
+      const buriedInTheStates = {
+        ...A_CAP_APPEARED_BESIDE_A_RISE,
+        summary: "The free tier now has a 60-minute meeting limit.",
+      };
+      assert.strictEqual(measuredAgainstItsClaim(buriedInTheStates), null);
+    });
+
+    it("keeps a record where one figure contradicts the claim and another supports it", () => {
+      const mixed = {
+        ...A_REAL_TENFOLD_CUT,
+        summary: "The free tier now offers 100 requests/day, down from 1,000 requests/day, and 5 seats, up from 2 seats.",
+        previous_state: "Free tier: 1,000 requests/day with the Qwen Code CLI, 2 seats",
+        current_state: "The free tier offers 100 requests/day with the Qwen Code CLI, 5 seats",
+      };
+      const [requests, seats] = measuredDifferences(mixed);
+      assert.strictEqual(requests.direction, "decrease");
+      assert.strictEqual(seats.direction, "increase");
+      assert.strictEqual(measuredAgainstItsClaim(mixed), null);
+    });
+
+    it("reads what a figure measures from past the period written against it", () => {
+      const [minutes] = quantifiedAttributes("10 per 6 hours of build time");
+      assert.deepStrictEqual(minutes.words, ["build", "time"]);
+      assert.strictEqual(minutes.period.unit, "hour");
+    });
+
+    it("does not read a period's own count as a quantity of its own", () => {
+      const [pulls, ...rest] = quantifiedAttributes("200 pulls per 6-hour window");
+      assert.strictEqual(rest.length, 0);
+      assert.strictEqual(pulls.value, "200");
+      assert.strictEqual(pulls.period.count, "6");
+    });
+
+    it("does not compare a price with a count of the same value", () => {
+      const [price] = quantifiedAttributes("$9 per project");
+      const [projects] = quantifiedAttributes("9 projects");
+      assert.strictEqual(comparedQuantity(price, projects), null);
+    });
+
+    it("does not let a paid plan's price decide the direction", () => {
+      const pricedAlongside = {
+        vendor: "deployhq.com",
+        change_type: "limits_reduced",
+        summary: "The free tier still offers 3 projects. Unlimited deployments now start at $9/month.",
+        previous_state: "Free plan: 3 projects with unlimited deployments. Paid plans from $5/month",
+        current_state: "Start free with 3 projects. Unlimited deployments from $9/month.",
+        impact: "high",
+      };
+      assert.strictEqual(
+        measuredAgainstItsClaim(pricedAlongside).reason,
+        REJECT_MEASURES_NO_CHANGE
+      );
+    });
+  });
+
+  describe("#1136 a directional record whose figures did not move", () => {
+    const NOTATION_ONLY = {
+      vendor: "Bugsnag",
+      change_type: "limits_reduced",
+      summary:
+        "The free tier now includes 7.5K events and 1M spans per month, and 1 user. Previously 7,500 events/month and 1M spans/month, 1 user.",
+      previous_state: "Error monitoring — 7,500 events/month and 1M spans/month on free plan, 1 user",
+      current_state: "Includes: 1 user 7.5K events and 1M spans per month 50+ platforms",
+      impact: "medium",
+    };
+
+    const A_RATE_RESTATED_IN_ANOTHER_PERIOD = {
+      vendor: "Imitate Email",
+      change_type: "limits_increased",
+      summary: "The free tier now offers 450 test emails a month, instead of 15 emails a day.",
+      previous_state: "Sandbox email server. Free accounts get 15 emails a day forever.",
+      current_state: "Get started with 450 test emails a month, free forever",
+      impact: "medium",
+    };
+
+    it("reads 7.5K as the same figure as 7,500", () => {
+      assert.strictEqual(measuredAgainstItsClaim(NOTATION_ONLY).reason, REJECT_MEASURES_NO_CHANGE);
+    });
+
+    it("reads 450 a month as the same rate as 15 a day", () => {
+      assert.strictEqual(
+        measuredAgainstItsClaim(A_RATE_RESTATED_IN_ANOTHER_PERIOD).reason,
+        REJECT_MEASURES_NO_CHANGE
+      );
+    });
+
+    it("keeps a record whose summary states a figure that is in neither comparison", () => {
+      const alsoNamesANewCap = {
+        ...NOTATION_ONLY,
+        summary: `${NOTATION_ONLY.summary} The Agent now has a 10 message limit per week.`,
+      };
+      assert.strictEqual(measuredAgainstItsClaim(alsoNamesANewCap), null);
+    });
+
+    it("keeps a record whose equal figures sit beside one that moved", () => {
+      const oneOfThemMoved = {
+        ...NOTATION_ONLY,
+        current_state: "Includes: 1 user 7.5K events and 500K spans per month 50+ platforms",
+      };
+      assert.strictEqual(measuredAgainstItsClaim(oneOfThemMoved), null);
+    });
+
+    it("refuses a record whose only comparison the summary itself states, at the same value", () => {
+      const twoAgainstTwo = {
+        vendor: "OnlineOrNot",
+        change_type: "limits_reduced",
+        summary: "The free tier now only includes up to 2 users instead of 2 team members.",
+        previous_state:
+          "Uptime monitoring — free plan: 3 monitors, 3-minute check interval, 2 team members, 1 status page, SSL monitoring",
+        current_state:
+          "Hobby (Free) includes up to 2 users, a 3-minute check interval, a limited status page, and basic alerting.",
+        impact: "medium",
+      };
+      assert.strictEqual(
+        measuredAgainstItsClaim(twoAgainstTwo).reason,
+        REJECT_MEASURES_NO_CHANGE,
+        "the summary states 2 against 2 and no compared quantity moved"
+      );
+    });
+
+    it("does not read a figure's subject past the clause it sits in", () => {
+      const acrossAComma = quantifiedAttributes(
+        "Hobby (Free) includes up to 2 users, a 3-minute check interval, a limited status page"
+      );
+      const interval = acrossAComma.find((a: any) => a.value === "3");
+      assert.ok(!interval.words.includes("statu"), interval.words.join("/"));
+    });
+
+    it("does not read what a figure is measured per as the thing it measures", () => {
+      const [subscribers] = quantifiedAttributes("Max 10,000 subscribers per send");
+      const [sends] = quantifiedAttributes("10,000 sends a month");
+      assert.deepStrictEqual(subscribers.words, ["subscriber"]);
+      assert.strictEqual(comparedQuantity(subscribers, sends), null);
+    });
+
+    it("keeps a record whose stated figures name nothing our comparison can reach", () => {
+      const ratesWithNoSubject = {
+        vendor: "codehooks.io",
+        change_type: "limits_reduced",
+        summary: "The free tier now has significantly reduced API call limits (1/sec, 500/day). Previously 60/minute.",
+        previous_state: "Serverless backend — free plan: 1 developer, 150 MB database storage",
+        current_state: "The free plan includes 1 Developer, 150 MB Database Storage",
+        impact: "high",
+      };
+      assert.strictEqual(measuredAgainstItsClaim(ratesWithNoSubject), null);
+    });
+
+    it("judges the figures the rewritten summary states, not the ones the gate dropped", () => {
+      const baselineInADroppedClause = {
+        ...NOTATION_ONLY,
+        summary:
+          "The free tier now includes 7.5K events and 1M spans per month, and 1 user. The stored information does not mention the 90-day retention the page states.",
+      };
+      assert.strictEqual(
+        measuredAgainstItsClaim(baselineInADroppedClause),
+        null,
+        "the raw summary states 90, which is in no comparison"
+      );
+      assert.strictEqual(describesChange(baselineInADroppedClause).reason, REJECT_MEASURES_NO_CHANGE);
     });
   });
 
@@ -780,7 +1025,7 @@ describe("the second opinion on whether a report describes a change", () => {
   });
 
   it("refuses a record the second opinion calls unchanged", async () => {
-    const { accepted, rejected } = await gateCandidates([A_DAILY_CAP_WAS_HALVED], {
+    const { accepted, rejected } = await gateCandidates([A_SUPPORT_CHANNEL_CLOSED], {
       confirmFn: async () => ({ verdict: "no", reason: "the page restates the stored terms" }),
     });
     assert.strictEqual(accepted.length, 0);


### PR DESCRIPTION
Refs #1136 — AC-3, AC-7, AC-8, AC-9, and half of AC-4. AC-1, AC-2, AC-5 and AC-6 (reconciling several records from one page-read) are not in this PR.

## The mechanism

`change_type` was decided by the shape of the prose — a cap appearing, a unit rewritten, a figure sitting nearby — and never by comparing the quantities. This adds one reader that answers *is this the same quantity, and which way did it move*, and calls it from the three places AC-9 names: the gate's second-opinion overrule, #1134's restatement guard, and the new refusals.

It normalises what AC-8 asked for and two things I found while measuring:

| | |
|---|---|
| notation | `7.5K` = `7,500`, `10k` = `10,000`, `1.2 billion` = `1,200,000,000` |
| size units | `20GiB` against `100 GB` (already there, now shared) |
| periods | `200 per 6 hours` = `33/hr` — reuses `readPeriod` from #1121 rather than a second parser |
| bare durations | `7-day retention` against `1 day retention`, `30-min` against `1 day` |

Two smaller reading fixes were needed before any of it was trustworthy. A figure's descriptor is now read from the words **beside** it — stopping at the next figure, at the clause boundary, and at a bare `per` — instead of a fixed 60-character window. Before that, `1 private repository` matched `100 Docker Hub pulls/hr` (the window ran 60 characters into the next clause and found "private" there), and `10,000 subscribers per send` matched `10,000 email sends/month`. And a number that spells a period's own count — the `6` in `per 6-hour` — is no longer counted as a quantity of its own.

## The two refusals

**`measures_no_change`** — every quantity the record compares holds the same value, and every figure the *published* summary states is one of them. Judging the rewritten summary rather than the raw one matters: a figure sitting in a clause the gate drops is not a figure the reader is shown.

**`measures_the_opposite`** — every quantity that moved moved against the claim, **and** the summary states both sides of at least one such pair. Without that second condition the rule refused Mercury, whose only comparable figure is a discount going from 30% off to 90% off while the record is about two credit offers that vanished.

## What it does to the log

**11 of 460 refused, 449 byte-identical, 0 rewritten.** Sweep is idempotent.

| | |
|---|---|
| `measures_the_opposite` | Docker Hub, Zoho Meeting, MantleDB, userforge.com |
| `measures_no_change` | Bugsnag, OnlineOrNot, deployhq.com, Imitate Email, Aiven, incidenthub.cloud, snappify |

All five records named in the issue are refused. The five controls survive: **Render** (15 minutes against 30, where 30 also appears in "cold starts take 30-60 seconds"), **Basecamp**, **SweetUptime**, **Alibaba Cloud Qwen Code**, and **Infisical**.

**Two the issue did not name, both from period normalisation.** *Imitate Email* was typed `limits_increased` for `450 test emails a month, instead of 15 emails a day` — 15/day is exactly 450/month. *UniRateAPI* claims a reduction while both states say `200 requests/day`.

## Measuring before shipping

Applied as first written, the rule refused **22 of 145** directional records. Most were the window defect above: Infisical read `3 projects` against `5 identities`, snappify read `3 snaps` against `100MB image upload`. Semgrep matched `10 contributors` to `10 repositories` from the same sentence. Narrowing it to the words beside the figure, then requiring that the published summary state the figures, took it to 11.

## AC-4, and what I could not deliver

`/vendor/docker-hub` no longer publishes the false claim, and its `schema.org/Event` no longer says `limits reduced` — it now reads `pricing restructured`. **The badge is still `caution`**, because the page's remaining record is a real, dated 2024-12-10 restructure ("Docker Pro +80%, Scout repos cut 3→1"). The hero now states that record instead. `/vendor/deployhq-com` emits one Event where it emitted two contradictory ones.

**LaunchDarkly stays refused, but for `no_baseline` rather than the absent reduction AC-7 asks for.** Its published summary states `5k AI runs/mo`, a figure in neither comparison, so the rule keeps it out of `measures_no_change`. The widening that would reach it also refuses **Penpot**, whose free tier really did go from unlimited team members to 8 — both records state a figure that exists only now, and nothing in our data separates a new cap on something previously unbounded from a new allowance. Left as it is; the outcome is right and the reason is not.

**Three refusals are judgement calls, not defects the issue named.** *Aiven* (`1GB total storage. Previously 1GB per service` — same number, real change of scope), *incidenthub.cloud* (`now has no status page`, where the stored terms never mentioned one) and *snappify* (every figure it states is unchanged; the claimed reduction is a watermark). Each is refused by the rule as specified. The trade-off is visible in one test fixture too: a record whose summary compares 1 A/B test against 1 while `1,000 events/month` quietly vanished from the current state is now refused, and the vanished figure is real.

**Refusing adds to #1139.** `/vendor/meeting` and `/vendor/bugsnag` now render *stable — zero pricing changes recorded*. That is better than *caution — limits reduced* for a 33x increase, but it is still a claim about a vendor whose page changed.

## Verified

- 2417/2417 tests, `npx tsx --test` and CI.
- `mutate-1136.sh` **21/21, no survivors** — 8 of the first 20 mutations survived and each was a real gap. `check-mutation-targets.mjs` 206/206 after retargeting five mutations in `mutate-1116.sh`, `mutate-1121.sh` and `mutate-1134-ac11-ac13.sh` whose lines this change moved; those three suites and `mutate-1134.sh` re-run with no survivors.
- `e2e-1121` 118/118, `e2e-1122` 69/69, `e2e-1107`, `e2e-1109`, `e2e-1116`.
- The `growth-limits` regex now allows `per 6-hour`. Swept both sides across all 1,580 offer descriptions: **0 render a different outgrow phrase**, so the change is confined to the gate.
- Real MCP `initialize` → `tools/call`: `track_changes` for Docker Hub returns `total: 0`.
- Screenshots of `/vendor/docker-hub`, `/vendor/meeting` and `/vendor/deployhq-com` against a local server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)