### PR TITLE
Derive the comparison verdict's stability clause from the counts the page prints

### DIFF
--- a/scripts/mutate-1140.sh
+++ b/scripts/mutate-1140.sh
@@ -1,0 +1,256 @@
+#!/usr/bin/env bash
+set -u
+
+REPO="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$REPO" || exit 1
+
+VERDICT="src/comparison-verdict.ts"
+SERVE="src/serve.ts"
+BACKUP_DIR="$(mktemp -d)"
+cp "$VERDICT" "$BACKUP_DIR/comparison-verdict.ts"
+cp "$SERVE" "$BACKUP_DIR/serve.ts"
+
+restore() {
+  cp "$BACKUP_DIR/comparison-verdict.ts" "$VERDICT"
+  cp "$BACKUP_DIR/serve.ts" "$SERVE"
+}
+trap restore EXIT
+
+killed=0
+survived=0
+TESTS="test/comparison-verdict.test.ts"
+
+run_mutation() {
+  local name="$1"
+  shift
+  echo "=== $name"
+  restore
+  "$@"
+  if diff -q "$BACKUP_DIR/comparison-verdict.ts" "$VERDICT" > /dev/null && diff -q "$BACKUP_DIR/serve.ts" "$SERVE" > /dev/null; then
+    echo "    NOT APPLIED: the mutation changed no file, so it proves nothing"
+    survived=$((survived + 1))
+    return
+  fi
+  if ! npm run build > /tmp/mutate-1140-build.log 2>&1; then
+    echo "    KILLED (does not compile)"
+    killed=$((killed + 1))
+    return
+  fi
+  if timeout 300 node --test --test-concurrency 1 $TESTS > /tmp/mutate-1140-test.log 2>&1; then
+    echo "    SURVIVED"
+    survived=$((survived + 1))
+  else
+    echo "    KILLED: $(grep -c '✖ ' /tmp/mutate-1140-test.log) failing assertion(s)"
+    grep '✖ ' /tmp/mutate-1140-test.log | head -4
+    killed=$((killed + 1))
+  fi
+}
+
+py() { python3 - "$@"; }
+
+m_the_count_never_decides() {
+  py <<'PY'
+p = "src/comparison-verdict.ts"
+s = open(p).read()
+s = s.replace("  return stabler.recordedChanges < other.recordedChanges ? stabler : null;", "  return stabler;")
+open(p, "w").write(s)
+PY
+}
+
+m_an_equal_count_still_names_a_winner() {
+  py <<'PY'
+p = "src/comparison-verdict.ts"
+s = open(p).read()
+s = s.replace("  return stabler.recordedChanges < other.recordedChanges ? stabler : null;", "  return stabler.recordedChanges <= other.recordedChanges ? stabler : null;")
+open(p, "w").write(s)
+PY
+}
+
+m_a_withheld_rating_ranks_below_stable() {
+  py <<'PY'
+p = "src/comparison-verdict.ts"
+s = open(p).read()
+s = s.replace("  if (ratingIsWithheld(a) || ratingIsWithheld(b)) return null;\n", "")
+open(p, "w").write(s)
+PY
+}
+
+m_two_sides_of_one_rating_are_ranked() {
+  py <<'PY'
+p = "src/comparison-verdict.ts"
+s = open(p).read()
+s = s.replace("  if (a.rating === b.rating) return null;\n", "")
+open(p, "w").write(s)
+PY
+}
+
+m_a_withheld_rating_is_passed_over_in_silence() {
+  py <<'PY'
+p = "src/comparison-verdict.ts"
+s = open(p).read()
+s = s.replace("    return `${withheld.map(whyWithheld).join(\" \")} We are not comparing the two pricing histories.`;", "    return \"\";")
+open(p, "w").write(s)
+PY
+}
+
+m_the_reader_is_not_told_we_stopped_comparing() {
+  py <<'PY'
+p = "src/comparison-verdict.ts"
+s = open(p).read()
+s = s.replace("    return `${withheld.map(whyWithheld).join(\" \")} We are not comparing the two pricing histories.`;", "    return withheld.map(whyWithheld).join(\" \");")
+open(p, "w").write(s)
+PY
+}
+
+m_only_the_first_withheld_side_is_explained() {
+  py <<'PY'
+p = "src/comparison-verdict.ts"
+s = open(p).read()
+s = s.replace("withheld.map(whyWithheld).join(\" \")", "withheld.slice(0, 1).map(whyWithheld).join(\" \")")
+open(p, "w").write(s)
+PY
+}
+
+m_the_reason_is_never_named() {
+  py <<'PY'
+p = "src/comparison-verdict.ts"
+s = open(p).read()
+s = s.replace("  return side.ratingWithheldBecause\n    ? withheldLevelSentence(side.ratingWithheldBecause, side.vendor, side.unconfirmableSince)\n    : `We are not publishing a stability rating for ${side.vendor}.`;", "  return `We are not publishing a stability rating for ${side.vendor}.`;")
+open(p, "w").write(s)
+PY
+}
+
+m_a_date_is_never_given_for_an_unreachable_page() {
+  py <<'PY'
+p = "src/comparison-verdict.ts"
+s = open(p).read()
+s = s.replace("withheldLevelSentence(side.ratingWithheldBecause, side.vendor, side.unconfirmableSince)", "withheldLevelSentence(side.ratingWithheldBecause, side.vendor, \"\")")
+open(p, "w").write(s)
+PY
+}
+
+m_every_count_is_plural() {
+  py <<'PY'
+p = "src/comparison-verdict.ts"
+s = open(p).read()
+s = s.replace("  return `${count} recorded change${count === 1 ? \"\" : \"s\"}`;", "  return `${count} recorded changes`;")
+open(p, "w").write(s)
+PY
+}
+
+m_the_claim_states_no_counts() {
+  py <<'PY'
+p = "src/comparison-verdict.ts"
+s = open(p).read()
+s = s.replace("  return `${stabler.vendor} has a more stable pricing history (${recordedChangesPhrase(stabler.recordedChanges)} vs ${other.recordedChanges}).`;", "  return `${stabler.vendor} has a more stable pricing history.`;")
+open(p, "w").write(s)
+PY
+}
+
+m_the_claim_states_the_losing_count_first() {
+  py <<'PY'
+p = "src/comparison-verdict.ts"
+s = open(p).read()
+s = s.replace("(${recordedChangesPhrase(stabler.recordedChanges)} vs ${other.recordedChanges})", "(${recordedChangesPhrase(other.recordedChanges)} vs ${stabler.recordedChanges})")
+open(p, "w").write(s)
+PY
+}
+
+m_the_structured_answer_drops_the_clause() {
+  py <<'PY'
+p = "src/comparison-verdict.ts"
+s = open(p).read()
+s = s.replace("  return `${stated(a)} ${stated(b)}${clause ? ` ${clause}` : \"\"}`;", "  return `${stated(a)} ${stated(b)}`;")
+open(p, "w").write(s)
+PY
+}
+
+m_the_structured_answer_publishes_a_withheld_rating() {
+  py <<'PY'
+p = "src/comparison-verdict.ts"
+s = open(p).read()
+s = s.replace("${side.rating ? ` and is rated ${side.rating}` : \"\"}", " and is rated ${side.rating}")
+open(p, "w").write(s)
+PY
+}
+
+m_the_page_never_reads_why_a_rating_was_withheld() {
+  py <<'PY'
+p = "src/serve.ts"
+s = open(p).read()
+s = s.replace("      ratingWithheldBecause: levelWithheldReason(risk, risk.link_unreachable),", "      ratingWithheldBecause: null,")
+open(p, "w").write(s)
+PY
+}
+
+m_the_page_reads_a_withheld_rating_as_stable() {
+  py <<'PY'
+p = "src/serve.ts"
+s = open(p).read()
+s = s.replace("    const rated = risk.risk_cause || risk.risk_level === \"stable\" ? risk.risk_level : null;", "    const rated = \"stable\";")
+open(p, "w").write(s)
+PY
+}
+
+m_the_verdict_drops_the_clause() {
+  py <<'PY'
+p = "src/serve.ts"
+s = open(p).read()
+s = s.replace("  if (stabilityClause) verdictText += ` ${stabilityClause}`;\n", "")
+open(p, "w").write(s)
+PY
+}
+
+m_each_side_counts_the_other_vendors_changes() {
+  py <<'PY'
+p = "src/serve.ts"
+s = open(p).read()
+s = s.replace("  const sideA = comparisonSide(a.vendor, riskA, a.deal_changes.length);\n  const sideB = comparisonSide(b.vendor, riskB, b.deal_changes.length);", "  const sideA = comparisonSide(a.vendor, riskA, b.deal_changes.length);\n  const sideB = comparisonSide(b.vendor, riskB, a.deal_changes.length);")
+open(p, "w").write(s)
+PY
+}
+
+m_a_truncated_list_says_nothing() {
+  py <<'PY'
+p = "src/serve.ts"
+s = open(p).read()
+s = s.replace("    const truncationNote = changes.length > shown.length\n      ? `<p style=\"color:var(--text-dim);font-size:.8rem;margin-top:.5rem\">Showing the ${shown.length} most recent of ${changes.length} recorded changes for ${escHtmlServer(vendor)}.</p>`\n      : \"\";", "    const truncationNote = \"\";")
+open(p, "w").write(s)
+PY
+}
+
+m_a_truncated_list_counts_only_what_it_shows() {
+  py <<'PY'
+p = "src/serve.ts"
+s = open(p).read()
+s = s.replace("Showing the ${shown.length} most recent of ${changes.length} recorded changes", "Showing the ${shown.length} most recent of ${shown.length} recorded changes")
+open(p, "w").write(s)
+PY
+}
+
+run_mutation "the count never decides" m_the_count_never_decides
+run_mutation "an equal count still names a winner" m_an_equal_count_still_names_a_winner
+run_mutation "a withheld rating ranks below stable" m_a_withheld_rating_ranks_below_stable
+run_mutation "two sides of one rating are ranked" m_two_sides_of_one_rating_are_ranked
+run_mutation "a withheld rating is passed over in silence" m_a_withheld_rating_is_passed_over_in_silence
+run_mutation "the reader is not told we stopped comparing" m_the_reader_is_not_told_we_stopped_comparing
+run_mutation "only the first withheld side is explained" m_only_the_first_withheld_side_is_explained
+run_mutation "the reason is never named" m_the_reason_is_never_named
+run_mutation "a date is never given for an unreachable page" m_a_date_is_never_given_for_an_unreachable_page
+run_mutation "every count is plural" m_every_count_is_plural
+run_mutation "the claim states no counts" m_the_claim_states_no_counts
+run_mutation "the claim states the losing count first" m_the_claim_states_the_losing_count_first
+run_mutation "the structured answer drops the clause" m_the_structured_answer_drops_the_clause
+run_mutation "the structured answer publishes a withheld rating" m_the_structured_answer_publishes_a_withheld_rating
+run_mutation "the page never reads why a rating was withheld" m_the_page_never_reads_why_a_rating_was_withheld
+run_mutation "the page reads a withheld rating as stable" m_the_page_reads_a_withheld_rating_as_stable
+run_mutation "the verdict drops the clause" m_the_verdict_drops_the_clause
+run_mutation "each side counts the other vendor's changes" m_each_side_counts_the_other_vendors_changes
+run_mutation "a truncated list says nothing" m_a_truncated_list_says_nothing
+run_mutation "a truncated list counts only what it shows" m_a_truncated_list_counts_only_what_it_shows
+
+restore
+npm run build > /dev/null 2>&1
+echo
+echo "killed: $killed, survived: $survived"
+[ "$survived" -eq 0 ]

--- a/src/comparison-pairs.ts
+++ b/src/comparison-pairs.ts
@@ -1,0 +1,111 @@
+import { loadOffers } from "./data.js";
+import { rotateListing } from "./ranking.js";
+import { toSlug } from "./vendor-slug.js";
+
+export const CURATED_COMPARISON_PAIRS: [string, string][] = [
+  // Cloud Hosting
+  ["Netlify", "Vercel"],
+  ["Railway", "Render"],
+  ["Cloudflare Pages", "Vercel"],
+  ["Netlify", "Render"],
+  ["Cloudflare Pages", "Netlify"],
+  // Databases
+  ["Firebase", "Supabase"],
+  ["Neon", "Supabase"],
+  ["CockroachDB", "Neon"],
+  ["MongoDB", "Supabase"],
+  ["CockroachDB", "MongoDB"],
+  // Monitoring
+  ["Datadog", "Grafana Cloud"],
+  ["Bugsnag", "Sentry"],
+  ["Grafana Cloud", "Sentry"],
+  // CI/CD
+  ["GitHub Actions", "GitLab CI"],
+  ["CircleCI", "GitHub Actions"],
+  ["CircleCI", "GitLab CI"],
+  // Auth
+  ["Auth0", "Clerk"],
+  // AI Coding
+  ["Cursor", "GitHub Copilot"],
+  ["Cursor", "Windsurf"],
+  ["Amazon Q Developer", "GitHub Copilot"],
+  ["Cline", "Aider"],
+  ["Claude Code", "Cursor"],
+  ["Cursor", "Devin"],
+  ["GitHub Copilot", "Windsurf"],
+  ["Augment Code", "Cursor"],
+  ["Bolt.new", "Lovable"],
+  ["Claude Code", "OpenAI Codex"],
+  // Cross-category high-interest
+  ["Firebase", "Vercel"],
+  ["Railway", "Supabase"],
+  ["Netlify", "Railway"],
+  ["Render", "Vercel"],
+  ["Cloudflare Pages", "Render"],
+];
+
+// Build slug for a comparison pair (canonical: alphabetical)
+export function comparisonSlug(a: string, b: string): string {
+  return `${toSlug(a)}-vs-${toSlug(b)}`;
+}
+
+/**
+ * Auto-generate comparison pairs from categories with 3+ vendors.
+ *
+ * This used to score vendors on `changeCount * 3 + description.length / 50`,
+ * which meant the length of the copy WE wrote decided which vendors got an
+ * indexed SEO page at all — a placement lever on 25 vendor slots across 20 of
+ * 57 categories, pullable with no code change and no audit trail. The other
+ * term was no better: `deal_changes` covers 16% of vendors and 51% of the
+ * well-known ones, so leaving it as the sole driver would have selected on
+ * how closely we happen to watch a vendor.
+ *
+ * A comparison page is an inventory surface, not a recommendation, so it does
+ * not need the demerit model — it needs no lever at all. Which vendors get one
+ * is a single unbiased draw per category, seeded on the category name alone.
+ * It is deliberately date-free: rotating which URLs exist would churn the site
+ * daily for a crawler with no benefit to a reader.
+ */
+export function generateCategoryPairs(): [string, string][] {
+  const offers = loadOffers();
+  const catVendors = new Map<string, string[]>();
+  for (const o of offers) {
+    if (!catVendors.has(o.category)) catVendors.set(o.category, []);
+    const arr = catVendors.get(o.category)!;
+    if (!arr.includes(o.vendor)) arr.push(o.vendor);
+  }
+
+  const pairs: [string, string][] = [];
+  for (const [category, vendors] of catVendors) {
+    if (vendors.length < 3) continue;
+    const topN = rotateListing(vendors, `compare-pairs:${category}`).slice(0, 4);
+    let catPairCount = 0;
+    for (let i = 0; i < topN.length && catPairCount < 5; i++) {
+      for (let j = i + 1; j < topN.length && catPairCount < 5; j++) {
+        const [a, b] = [topN[i], topN[j]].sort() as [string, string];
+        pairs.push([a, b]);
+        catPairCount++;
+      }
+    }
+  }
+  return pairs;
+}
+
+export function buildComparisonMap(): Map<string, [string, string]> {
+  const offers = loadOffers();
+  const map = new Map<string, [string, string]>();
+  for (const [a, b] of CURATED_COMPARISON_PAIRS) {
+    const offerA = offers.find(o => o.vendor === a);
+    const offerB = offers.find(o => o.vendor === b);
+    if (offerA && offerB) {
+      map.set(comparisonSlug(a, b), [a, b]);
+    }
+  }
+  for (const [a, b] of generateCategoryPairs()) {
+    const slug = comparisonSlug(a, b);
+    if (!map.has(slug)) {
+      map.set(slug, [a, b]);
+    }
+  }
+  return map;
+}

--- a/src/comparison-verdict.ts
+++ b/src/comparison-verdict.ts
@@ -1,0 +1,52 @@
+import { withheldLevelSentence, type LevelWithheldReason } from "./source-check.js";
+
+export type StabilityRating = "stable" | "caution" | "risky";
+
+export interface ComparisonSide {
+  vendor: string;
+  recordedChanges: number;
+  rating: StabilityRating | null;
+  ratingWithheldBecause: LevelWithheldReason | null;
+  unconfirmableSince: string;
+}
+
+export function ratingIsWithheld(side: ComparisonSide): boolean {
+  return side.rating === null;
+}
+
+export function recordedChangesPhrase(count: number): string {
+  return `${count} recorded change${count === 1 ? "" : "s"}`;
+}
+
+export function moreStableSide(a: ComparisonSide, b: ComparisonSide): ComparisonSide | null {
+  if (ratingIsWithheld(a) || ratingIsWithheld(b)) return null;
+  if (a.rating === b.rating) return null;
+  const stabler = a.rating === "stable" ? a : b.rating === "stable" ? b : null;
+  if (!stabler) return null;
+  const other = stabler === a ? b : a;
+  return stabler.recordedChanges < other.recordedChanges ? stabler : null;
+}
+
+function whyWithheld(side: ComparisonSide): string {
+  return side.ratingWithheldBecause
+    ? withheldLevelSentence(side.ratingWithheldBecause, side.vendor, side.unconfirmableSince)
+    : `We are not publishing a stability rating for ${side.vendor}.`;
+}
+
+export function stabilityVerdictClause(a: ComparisonSide, b: ComparisonSide): string {
+  const withheld = [a, b].filter(ratingIsWithheld);
+  if (withheld.length > 0) {
+    return `${withheld.map(whyWithheld).join(" ")} We are not comparing the two pricing histories.`;
+  }
+  const stabler = moreStableSide(a, b);
+  if (!stabler) return "";
+  const other = stabler === a ? b : a;
+  return `${stabler.vendor} has a more stable pricing history (${recordedChangesPhrase(stabler.recordedChanges)} vs ${other.recordedChanges}).`;
+}
+
+export function stabilityFaqAnswer(a: ComparisonSide, b: ComparisonSide): string {
+  const stated = (side: ComparisonSide) =>
+    `${side.vendor} has ${recordedChangesPhrase(side.recordedChanges)}${side.rating ? ` and is rated ${side.rating}` : ""}.`;
+  const clause = stabilityVerdictClause(a, b);
+  return `${stated(a)} ${stated(b)}${clause ? ` ${clause}` : ""}`;
+}

--- a/src/serve.ts
+++ b/src/serve.ts
@@ -17,6 +17,8 @@ import { configureVendorSeries, recordVendorRequest, flushVendorSeries, readVend
 import { openapiSpec } from "./openapi.js";
 import { LINK_GRACE_DAYS } from "./link-health.js";
 import { levelWithheldReason, withheldLevelClause, withheldLevelSentence } from "./source-check.js";
+import { buildComparisonMap, comparisonSlug } from "./comparison-pairs.js";
+import { stabilityFaqAnswer, stabilityVerdictClause, type ComparisonSide, type StabilityRating } from "./comparison-verdict.js";
 import { growthLimitPhrases } from "./growth-limits.js";
 import { registerAgent, authenticateRequest, validateVestauthUrl, hashApiKey, updateAgentX402Address, getAgentById } from "./agents.js";
 import { logReferralRequest } from "./referral-requests.js";
@@ -2154,110 +2156,7 @@ ${report.notes.map(n => `    <li>${escHtmlServer(n)}</li>`).join("\n")}
 
 // --- Comparison pages ---
 
-// Define comparison pairs: [vendorA, vendorB] — canonical order is alphabetical
-const COMPARISON_PAIRS: [string, string][] = [
-  // Cloud Hosting
-  ["Netlify", "Vercel"],
-  ["Railway", "Render"],
-  ["Cloudflare Pages", "Vercel"],
-  ["Netlify", "Render"],
-  ["Cloudflare Pages", "Netlify"],
-  // Databases
-  ["Firebase", "Supabase"],
-  ["Neon", "Supabase"],
-  ["CockroachDB", "Neon"],
-  ["MongoDB", "Supabase"],
-  ["CockroachDB", "MongoDB"],
-  // Monitoring
-  ["Datadog", "Grafana Cloud"],
-  ["Bugsnag", "Sentry"],
-  ["Grafana Cloud", "Sentry"],
-  // CI/CD
-  ["GitHub Actions", "GitLab CI"],
-  ["CircleCI", "GitHub Actions"],
-  ["CircleCI", "GitLab CI"],
-  // Auth
-  ["Auth0", "Clerk"],
-  // AI Coding
-  ["Cursor", "GitHub Copilot"],
-  ["Cursor", "Windsurf"],
-  ["Amazon Q Developer", "GitHub Copilot"],
-  ["Cline", "Aider"],
-  ["Claude Code", "Cursor"],
-  ["Cursor", "Devin"],
-  ["GitHub Copilot", "Windsurf"],
-  ["Augment Code", "Cursor"],
-  ["Bolt.new", "Lovable"],
-  ["Claude Code", "OpenAI Codex"],
-  // Cross-category high-interest
-  ["Firebase", "Vercel"],
-  ["Railway", "Supabase"],
-  ["Netlify", "Railway"],
-  ["Render", "Vercel"],
-  ["Cloudflare Pages", "Render"],
-];
-
-// Build slug for a comparison pair (canonical: alphabetical)
-function comparisonSlug(a: string, b: string): string {
-  return `${toSlug(a)}-vs-${toSlug(b)}`;
-}
-
-/**
- * Auto-generate comparison pairs from categories with 3+ vendors.
- *
- * This used to score vendors on `changeCount * 3 + description.length / 50`,
- * which meant the length of the copy WE wrote decided which vendors got an
- * indexed SEO page at all — a placement lever on 25 vendor slots across 20 of
- * 57 categories, pullable with no code change and no audit trail. The other
- * term was no better: `deal_changes` covers 16% of vendors and 51% of the
- * well-known ones, so leaving it as the sole driver would have selected on
- * how closely we happen to watch a vendor.
- *
- * A comparison page is an inventory surface, not a recommendation, so it does
- * not need the demerit model — it needs no lever at all. Which vendors get one
- * is a single unbiased draw per category, seeded on the category name alone.
- * It is deliberately date-free: rotating which URLs exist would churn the site
- * daily for a crawler with no benefit to a reader.
- */
-function generateCategoryPairs(): [string, string][] {
-  const catVendors = new Map<string, string[]>();
-  for (const o of offers) {
-    if (!catVendors.has(o.category)) catVendors.set(o.category, []);
-    const arr = catVendors.get(o.category)!;
-    if (!arr.includes(o.vendor)) arr.push(o.vendor);
-  }
-
-  const pairs: [string, string][] = [];
-  for (const [category, vendors] of catVendors) {
-    if (vendors.length < 3) continue;
-    const topN = rotateListing(vendors, `compare-pairs:${category}`).slice(0, 4);
-    let catPairCount = 0;
-    for (let i = 0; i < topN.length && catPairCount < 5; i++) {
-      for (let j = i + 1; j < topN.length && catPairCount < 5; j++) {
-        const [a, b] = [topN[i], topN[j]].sort() as [string, string];
-        pairs.push([a, b]);
-        catPairCount++;
-      }
-    }
-  }
-  return pairs;
-}
-
-// Build lookup maps for comparison pages
-const comparisonMap = new Map<string, [string, string]>();
-for (const [a, b] of COMPARISON_PAIRS) {
-  const offerA = offers.find(o => o.vendor === a);
-  const offerB = offers.find(o => o.vendor === b);
-  if (offerA && offerB) {
-    comparisonMap.set(comparisonSlug(a, b), [a, b]);
-  }
-}
-for (const [a, b] of generateCategoryPairs()) {
-  const slug = comparisonSlug(a, b);
-  if (!comparisonMap.has(slug)) {
-    comparisonMap.set(slug, [a, b]);
-  }
-}
+const comparisonMap = buildComparisonMap();
 
 // Group comparisons by category for the index page
 function getComparisonsByCategory(): Map<string, Array<{ slug: string; a: string; b: string }>> {
@@ -2395,7 +2294,11 @@ function buildComparisonPage(slug: string): string | null {
 
   const changesHtml = (changes: typeof a.deal_changes, vendor: string) => {
     if (changes.length === 0) return `<p style="color:var(--text-dim);font-size:.85rem">No recorded pricing changes for ${escHtmlServer(vendor)}.</p>`;
-    return changes.sort((x, y) => y.date.localeCompare(x.date)).slice(0, 5).map(c => {
+    const shown = changes.sort((x, y) => y.date.localeCompare(x.date)).slice(0, 5);
+    const truncationNote = changes.length > shown.length
+      ? `<p style="color:var(--text-dim);font-size:.8rem;margin-top:.5rem">Showing the ${shown.length} most recent of ${changes.length} recorded changes for ${escHtmlServer(vendor)}.</p>`
+      : "";
+    return shown.map(c => {
       const badge = changeTypeBadge[c.change_type] ?? { label: c.change_type, color: "#8b949e" };
       return `<div style="margin-bottom:.75rem;padding:.6rem .75rem;border-left:3px solid ${badge.color};background:var(--bg-card);border-radius:0 6px 6px 0">
         <div style="display:flex;align-items:center;gap:.5rem;margin-bottom:.25rem">
@@ -2405,7 +2308,7 @@ function buildComparisonPage(slug: string): string | null {
         </div>
         <div style="font-size:.85rem;color:var(--text-muted)">${escHtmlServer(c.summary)}</div>
       </div>`;
-    }).join("\n");
+    }).join("\n") + truncationNote;
   };
 
   // Category context
@@ -2425,10 +2328,23 @@ function buildComparisonPage(slug: string): string | null {
   const hasFreeB = tierB !== "none" && !b.description.toLowerCase().includes("no free tier");
   // These are risk levels, not stability classes — two different scales.
   // They render only when their cause does (#1038).
-  const stabilityA = riskA.risk_cause || riskA.risk_level === "stable" ? riskA.risk_level ?? "unknown" : "unknown";
-  const stabilityB = riskB.risk_cause || riskB.risk_level === "stable" ? riskB.risk_level ?? "unknown" : "unknown";
-  const changesCountA = a.deal_changes.length;
-  const changesCountB = b.deal_changes.length;
+  const comparisonSide = (
+    vendor: string,
+    risk: typeof riskA,
+    recordedChanges: number,
+  ): ComparisonSide => {
+    const rated = risk.risk_cause || risk.risk_level === "stable" ? risk.risk_level : null;
+    return {
+      vendor,
+      recordedChanges,
+      rating: rated as StabilityRating | null,
+      ratingWithheldBecause: levelWithheldReason(risk, risk.link_unreachable),
+      unconfirmableSince: risk.link_unreachable?.last_reachable ? ` since ${risk.link_unreachable.last_reachable}` : "",
+    };
+  };
+  const sideA = comparisonSide(a.vendor, riskA, a.deal_changes.length);
+  const sideB = comparisonSide(b.vendor, riskB, b.deal_changes.length);
+  const stabilityClause = stabilityVerdictClause(sideA, sideB);
 
   let verdictText = "";
   if (hasFreeA && hasFreeB) {
@@ -2440,10 +2356,7 @@ function buildComparisonPage(slug: string): string | null {
   } else {
     verdictText = `Neither ${a.vendor} nor ${b.vendor} currently offers a free tier.`;
   }
-  if (stabilityA !== stabilityB) {
-    const betterVendor = stabilityA === "stable" ? a.vendor : stabilityB === "stable" ? b.vendor : null;
-    if (betterVendor) verdictText += ` ${betterVendor} has a more stable pricing history.`;
-  }
+  if (stabilityClause) verdictText += ` ${stabilityClause}`;
 
   const verdictHtml = `
   <div class="verdict-section">
@@ -2470,7 +2383,7 @@ function buildComparisonPage(slug: string): string | null {
   // FAQ items for JSON-LD
   const faqItems = [
     { q: `Which is cheaper, ${a.vendor} or ${b.vendor}?`, a: hasFreeA && hasFreeB ? `Both offer free tiers. ${a.vendor} provides "${a.tier}" and ${b.vendor} offers "${b.tier}". Compare the specific limits above to determine which fits your usage.` : hasFreeA ? `${a.vendor} offers a free tier ("${a.tier}") while ${b.vendor} does not.` : hasFreeB ? `${b.vendor} offers a free tier ("${b.tier}") while ${a.vendor} does not.` : `Neither currently offers a free tier.` },
-    { q: `Is ${a.vendor} or ${b.vendor} more stable?`, a: `${a.vendor} is rated ${stabilityA} with ${changesCountA} pricing change${changesCountA !== 1 ? "s" : ""} recorded. ${b.vendor} is rated ${stabilityB} with ${changesCountB} change${changesCountB !== 1 ? "s" : ""} recorded.` },
+    { q: `Is ${a.vendor} or ${b.vendor} more stable?`, a: stabilityFaqAnswer(sideA, sideB) },
     { q: `Can I use ${a.vendor} and ${b.vendor} together?`, a: sameCategory ? `While both are in the ${primaryCategory} category, some teams use both for different workloads. Check each vendor's free tier limits to see if they complement your stack.` : `Yes — ${a.vendor} (${a.category}) and ${b.vendor} (${b.category}) serve different purposes and can work well together.` },
   ];
 

--- a/test/comparison-verdict.test.ts
+++ b/test/comparison-verdict.test.ts
@@ -1,0 +1,385 @@
+import { describe, it, before, after } from "node:test";
+import assert from "node:assert";
+import { spawn, type ChildProcess } from "node:child_process";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  moreStableSide,
+  ratingIsWithheld,
+  recordedChangesPhrase,
+  stabilityFaqAnswer,
+  stabilityVerdictClause,
+  type ComparisonSide,
+} from "../dist/comparison-verdict.js";
+import { buildComparisonMap } from "../dist/comparison-pairs.js";
+import { enrichOffers, loadDealChanges, loadOffers } from "../dist/data.js";
+import { levelWithheldReason, type LevelWithheldReason } from "../dist/source-check.js";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO = path.join(__dirname, "..");
+
+const NAMES_A_WINNER = / has a more stable pricing history \((\d+) recorded changes? vs (\d+)\)\.$/;
+
+function side(over: Partial<ComparisonSide> = {}): ComparisonSide {
+  return {
+    vendor: "Vendor A",
+    recordedChanges: 0,
+    rating: "stable",
+    ratingWithheldBecause: null,
+    unconfirmableSince: "",
+    ...over,
+  };
+}
+
+describe("comparison verdict — the stability clause is derived from the counts the page prints", () => {
+  it("names no winner when both sides have the same recorded-change count", () => {
+    const a = side({ vendor: "Alpha", recordedChanges: 0, rating: "stable" });
+    const b = side({ vendor: "Beta", recordedChanges: 0, rating: "caution" });
+    assert.strictEqual(stabilityVerdictClause(a, b), "");
+    assert.strictEqual(moreStableSide(a, b), null);
+  });
+
+  it("names no winner when both sides have the same non-zero count", () => {
+    const a = side({ vendor: "Alpha", recordedChanges: 3, rating: "stable" });
+    const b = side({ vendor: "Beta", recordedChanges: 3, rating: "risky" });
+    assert.strictEqual(stabilityVerdictClause(a, b), "");
+  });
+
+  it("names no winner when the better-rated side has more recorded changes", () => {
+    const a = side({ vendor: "DigitalOcean", recordedChanges: 4, rating: "stable" });
+    const b = side({ vendor: "Sentry", recordedChanges: 1, rating: "caution" });
+    assert.strictEqual(stabilityVerdictClause(a, b), "");
+    assert.strictEqual(stabilityVerdictClause(b, a), "");
+  });
+
+  it("names the better-rated side only when it also has fewer recorded changes, and states both counts", () => {
+    const a = side({ vendor: "Cloudflare Pages", recordedChanges: 0, rating: "stable" });
+    const b = side({ vendor: "Netlify", recordedChanges: 4, rating: "caution" });
+    assert.strictEqual(
+      stabilityVerdictClause(a, b),
+      "Cloudflare Pages has a more stable pricing history (0 recorded changes vs 4).",
+    );
+    assert.strictEqual(stabilityVerdictClause(b, a), stabilityVerdictClause(a, b));
+  });
+
+  it("writes a single recorded change in the singular", () => {
+    assert.strictEqual(recordedChangesPhrase(1), "1 recorded change");
+    assert.strictEqual(recordedChangesPhrase(0), "0 recorded changes");
+    assert.strictEqual(recordedChangesPhrase(4), "4 recorded changes");
+    const clause = stabilityVerdictClause(
+      side({ vendor: "Alpha", recordedChanges: 1, rating: "stable" }),
+      side({ vendor: "Beta", recordedChanges: 5, rating: "risky" }),
+    );
+    assert.strictEqual(clause, "Alpha has a more stable pricing history (1 recorded change vs 5).");
+  });
+
+  it("names no winner between two sides carrying the same rating", () => {
+    const a = side({ vendor: "Alpha", recordedChanges: 1, rating: "caution" });
+    const b = side({ vendor: "Beta", recordedChanges: 4, rating: "caution" });
+    assert.strictEqual(stabilityVerdictClause(a, b), "");
+  });
+
+  it("ranks neither of two sides we both rate stable", () => {
+    const a = side({ vendor: "Alpha", recordedChanges: 0, rating: "stable" });
+    const b = side({ vendor: "Beta", recordedChanges: 4, rating: "stable" });
+    assert.strictEqual(stabilityVerdictClause(a, b), "");
+    assert.strictEqual(moreStableSide(a, b), null);
+  });
+});
+
+describe("comparison verdict — a withheld rating is stated, never resolved", () => {
+  const withheld = (vendor: string, because: LevelWithheldReason, since = "", recordedChanges = 0) =>
+    side({ vendor, recordedChanges, rating: null, ratingWithheldBecause: because, unconfirmableSince: since });
+
+  it("treats a withheld rating as withheld, not as a rank", () => {
+    assert.strictEqual(ratingIsWithheld(withheld("Duolingo", "unreadable")), true);
+    assert.strictEqual(ratingIsWithheld(side({ rating: "risky" })), false);
+  });
+
+  it("names no winner when a side's rating is withheld, even where that side has fewer changes", () => {
+    const evernote = withheld("Evernote", "link_unreachable", " since 2026-04-23");
+    const notion = side({ vendor: "Notion", recordedChanges: 1, rating: "stable" });
+    const clause = stabilityVerdictClause(evernote, notion);
+    assert.match(clause, /^Evernote's pricing page has not resolved for us since 2026-04-23\./);
+    assert.doesNotMatch(clause, NAMES_A_WINNER);
+    assert.strictEqual(moreStableSide(evernote, notion), null);
+  });
+
+  it("names no winner when the side with the withheld rating carries the higher count", () => {
+    const rated = side({ vendor: "Alpha", recordedChanges: 0, rating: "stable" });
+    const unrated = withheld("Beta", "states_no_terms", "", 3);
+    assert.strictEqual(moreStableSide(rated, unrated), null);
+    assert.strictEqual(moreStableSide(unrated, rated), null);
+    assert.doesNotMatch(stabilityVerdictClause(rated, unrated), NAMES_A_WINNER);
+  });
+
+  it("says which page it could not read and that it is not comparing", () => {
+    const clause = stabilityVerdictClause(
+      side({ vendor: "Cloudflare Workers", recordedChanges: 0, rating: "stable" }),
+      withheld("Duolingo", "unreadable"),
+    );
+    assert.strictEqual(
+      clause,
+      "We could not read the page we cite for Duolingo. We are not comparing the two pricing histories.",
+    );
+  });
+
+  it("states a reason for each side when both ratings are withheld", () => {
+    const clause = stabilityVerdictClause(
+      withheld("Cline", "states_no_terms"),
+      withheld("Aider", "does_not_name_vendor"),
+    );
+    assert.match(clause, /The page we cite for Cline states no terms we can read\./);
+    assert.match(clause, /The page we cite for Aider does not name it\./);
+    assert.match(clause, /We are not comparing the two pricing histories\.$/);
+  });
+
+  it("still declines to compare when no reason for the withholding is available", () => {
+    const clause = stabilityVerdictClause(
+      side({ vendor: "Alpha", recordedChanges: 4, rating: "stable" }),
+      side({ vendor: "Beta", recordedChanges: 0, rating: null, ratingWithheldBecause: null }),
+    );
+    assert.match(clause, /We are not publishing a stability rating for Beta\./);
+    assert.doesNotMatch(clause, NAMES_A_WINNER);
+  });
+});
+
+describe("comparison verdict — the prose and the structured data carry the same claim", () => {
+  it("ends the structured answer with the clause the prose prints", () => {
+    const a = side({ vendor: "Bugsnag", recordedChanges: 0, rating: "stable" });
+    const b = side({ vendor: "Sentry", recordedChanges: 1, rating: "caution" });
+    const clause = stabilityVerdictClause(a, b);
+    assert.ok(clause.length > 0);
+    assert.ok(stabilityFaqAnswer(a, b).endsWith(clause));
+  });
+
+  it("carries no claim in the structured answer when the prose drops the clause", () => {
+    const a = side({ vendor: "DigitalOcean", recordedChanges: 4, rating: "stable" });
+    const b = side({ vendor: "Sentry", recordedChanges: 1, rating: "caution" });
+    assert.strictEqual(stabilityVerdictClause(a, b), "");
+    const answer = stabilityFaqAnswer(a, b);
+    assert.doesNotMatch(answer, NAMES_A_WINNER);
+    assert.strictEqual(
+      answer,
+      "DigitalOcean has 4 recorded changes and is rated stable. Sentry has 1 recorded change and is rated caution.",
+    );
+  });
+
+  it("publishes no rating for a side whose rating is withheld", () => {
+    const answer = stabilityFaqAnswer(
+      side({ vendor: "Cloudflare Workers", recordedChanges: 0, rating: "stable" }),
+      side({ vendor: "Duolingo", recordedChanges: 0, rating: null, ratingWithheldBecause: "unreadable" }),
+    );
+    assert.match(answer, /Duolingo has 0 recorded changes\./);
+    assert.doesNotMatch(answer, /Duolingo[^.]*is rated/);
+  });
+});
+
+const offers = loadOffers();
+const changes = loadDealChanges();
+const enriched = new Map<string, ReturnType<typeof enrichOffers>[number]>();
+for (const e of enrichOffers(offers)) if (!enriched.has(e.vendor)) enriched.set(e.vendor, e);
+
+function countFor(vendor: string): number {
+  return changes.filter(c => c.vendor.toLowerCase() === vendor.toLowerCase()).length;
+}
+
+function sideFor(vendor: string): ComparisonSide | null {
+  const e = enriched.get(vendor);
+  if (!e) return null;
+  return {
+    vendor,
+    recordedChanges: countFor(vendor),
+    rating: (e.risk_cause || e.risk_level === "stable" ? e.risk_level : null) as ComparisonSide["rating"],
+    ratingWithheldBecause: levelWithheldReason(e, e.link_unreachable),
+    unconfirmableSince: e.link_unreachable?.last_reachable ? ` since ${e.link_unreachable.last_reachable}` : "",
+  };
+}
+
+function sidesFor(pair: [string, string]): [ComparisonSide, ComparisonSide] | null {
+  const a = sideFor(pair[0]);
+  const b = sideFor(pair[1]);
+  return a && b ? [a, b] : null;
+}
+
+describe("comparison verdict — census over every linked comparison", () => {
+  it("asserts no stability winner that the recorded-change counts do not support", () => {
+    const unsupported: string[] = [];
+    let named = 0;
+    for (const [slug, [va, vb]] of buildComparisonMap()) {
+      const a = sideFor(va);
+      const b = sideFor(vb);
+      assert.ok(a && b, `${slug}: both vendors resolve to an offer`);
+      const clause = stabilityVerdictClause(a, b);
+      const match = clause.match(NAMES_A_WINNER);
+      if (!match) continue;
+      named++;
+      const claim = (s: ComparisonSide) => `${s.vendor} has a more stable pricing history (`;
+      const winner = clause.startsWith(claim(a)) ? a : clause.startsWith(claim(b)) ? b : null;
+      if (!winner) {
+        unsupported.push(`${slug}: winner is not one of the two vendors — ${clause}`);
+        continue;
+      }
+      const loser = winner === a ? b : a;
+      if (winner.recordedChanges >= loser.recordedChanges) {
+        unsupported.push(`${slug}: ${winner.vendor} has ${winner.recordedChanges} recorded, ${loser.vendor} has ${loser.recordedChanges}`);
+      }
+      if (Number(match[1]) !== winner.recordedChanges || Number(match[2]) !== loser.recordedChanges) {
+        unsupported.push(`${slug}: clause states ${match[1]} vs ${match[2]}, records hold ${winner.recordedChanges} vs ${loser.recordedChanges}`);
+      }
+      if (ratingIsWithheld(winner) || ratingIsWithheld(loser)) {
+        unsupported.push(`${slug}: named a winner while a rating is withheld`);
+      }
+    }
+    assert.deepStrictEqual(unsupported, []);
+    assert.ok(named > 0, "at least one comparison still names a supported winner");
+  });
+
+  it("declines to compare on every pair with a withheld rating", () => {
+    const resolved: string[] = [];
+    for (const [slug, [va, vb]] of buildComparisonMap()) {
+      const a = sideFor(va);
+      const b = sideFor(vb);
+      if (!a || !b) continue;
+      if (!ratingIsWithheld(a) && !ratingIsWithheld(b)) continue;
+      const clause = stabilityVerdictClause(a, b);
+      if (!/We are not comparing the two pricing histories\.$/.test(clause)) resolved.push(`${slug}: ${clause}`);
+    }
+    assert.deepStrictEqual(resolved, []);
+  });
+});
+
+describe("comparison verdict — as rendered", () => {
+  let proc: ChildProcess | null = null;
+  let port = 0;
+
+  before(async () => {
+    const started = await new Promise<{ child: ChildProcess; port: number }>((resolve, reject) => {
+      const child = spawn("node", [path.join(REPO, "dist", "serve.js")], {
+        stdio: ["pipe", "pipe", "pipe"],
+        env: { ...process.env, PORT: "0", BASE_URL: "http://localhost" },
+      });
+      const timeout = setTimeout(() => { child.kill(); reject(new Error("Server startup timeout")); }, 30000);
+      child.stderr!.on("data", (data: Buffer) => {
+        const m = data.toString().match(/running on http:\/\/localhost:(\d+)/);
+        if (m) { clearTimeout(timeout); resolve({ child, port: parseInt(m[1], 10) }); }
+      });
+      child.on("error", (err) => { clearTimeout(timeout); reject(err); });
+    });
+    proc = started.child;
+    port = started.port;
+  });
+
+  after(() => { proc?.kill(); });
+
+  const get = async (route: string) => {
+    const res = await fetch(`http://localhost:${port}${route}`, {
+      headers: { "user-agent": "agentdeals-internal/1.0 (comparison-verdict-test)" },
+    });
+    assert.strictEqual(res.status, 200, `${route} responded ${res.status}`);
+    return res.text();
+  };
+
+  const escaped = (s: string) =>
+    s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;");
+
+  const firstSlugWhere = (predicate: (sides: [ComparisonSide, ComparisonSide]) => boolean) => {
+    for (const [slug, pair] of buildComparisonMap()) {
+      const sides = sidesFor(pair);
+      if (sides && predicate(sides)) return { slug, sides };
+    }
+    return null;
+  };
+
+  const renderedVerdict = (html: string) => {
+    const m = html.match(/<div class="verdict-section">\s*<h2>Verdict<\/h2>\s*<p>([\s\S]*?)<\/p>/);
+    assert.ok(m, "the page renders a verdict paragraph");
+    return m[1];
+  };
+
+  const renderedStabilityAnswer = (html: string, sides: [ComparisonSide, ComparisonSide]) => {
+    const blocks = [...html.matchAll(/<script type="application\/ld\+json">([\s\S]*?)<\/script>/g)]
+      .map(m => JSON.parse(m[1]) as Record<string, unknown>);
+    const faq = blocks.find(b => b["@type"] === "FAQPage") as
+      { mainEntity: Array<{ name: string; acceptedAnswer: { text: string } }> } | undefined;
+    assert.ok(faq, "the page emits FAQ structured data");
+    const question = faq.mainEntity.find(q => q.name === `Is ${sides[0].vendor} or ${sides[1].vendor} more stable?`);
+    assert.ok(question, "the structured data answers which of the two is more stable");
+    return question.acceptedAnswer.text;
+  };
+
+  const assertRendersItsClause = async (slug: string, sides: [ComparisonSide, ComparisonSide]) => {
+    const html = await get(`/compare/${slug}`);
+    const clause = stabilityVerdictClause(sides[0], sides[1]);
+    const verdict = renderedVerdict(html);
+    const answer = renderedStabilityAnswer(html, sides);
+    if (clause) {
+      assert.ok(verdict.includes(escaped(clause)), `${slug} verdict does not render "${clause}"`);
+      assert.ok(answer.includes(clause), `${slug} structured data does not carry "${clause}"`);
+    } else {
+      assert.doesNotMatch(verdict, /has a more stable pricing history/, `${slug} verdict names a winner the rule does not`);
+      assert.doesNotMatch(answer, /has a more stable pricing history/, `${slug} structured data names a winner the rule does not`);
+    }
+    return html;
+  };
+
+  it("renders on every linked comparison exactly the clause its own counts support", async () => {
+    const wrong: string[] = [];
+    for (const [slug, pair] of buildComparisonMap()) {
+      const sides = sidesFor(pair);
+      if (!sides) continue;
+      const html = await get(`/compare/${slug}`);
+      const clause = stabilityVerdictClause(sides[0], sides[1]);
+      const verdict = renderedVerdict(html);
+      const answer = renderedStabilityAnswer(html, sides);
+      if (clause && !verdict.includes(escaped(clause))) wrong.push(`${slug}: the verdict does not render "${clause}"`);
+      if (clause && !answer.includes(clause)) wrong.push(`${slug}: the structured data does not carry "${clause}"`);
+      if (!clause && /has a more stable pricing history/.test(verdict)) wrong.push(`${slug}: the verdict names a winner the counts do not support`);
+      if (!clause && /has a more stable pricing history/.test(answer)) wrong.push(`${slug}: the structured data names a winner the counts do not support`);
+      for (const s of sides) {
+        if (s.recordedChanges > 5 && !html.includes(`Showing the 5 most recent of ${s.recordedChanges} recorded changes for ${escaped(s.vendor)}.`)) {
+          wrong.push(`${slug}: lists 5 of ${s.recordedChanges} for ${s.vendor} without saying so`);
+        }
+      }
+    }
+    assert.deepStrictEqual(wrong, []);
+  });
+
+  it("no longer calls the vendor with more recorded changes the more stable of the two", async () => {
+    const pair = buildComparisonMap().get("digitalocean-vs-sentry");
+    assert.ok(pair, "digitalocean-vs-sentry is a linked comparison");
+    const sides = sidesFor(pair)!;
+    const html = await assertRendersItsClause("digitalocean-vs-sentry", sides);
+    const worse = sides[0].recordedChanges > sides[1].recordedChanges ? sides[0] : sides[1];
+    assert.ok(!html.includes(`${worse.vendor} has a more stable pricing history`), `${worse.vendor} has the higher count`);
+  });
+
+  it("says why it is not comparing when a rating is withheld", async () => {
+    const found = firstSlugWhere(([a, b]) => ratingIsWithheld(a) || ratingIsWithheld(b));
+    assert.ok(found, "at least one linked comparison has a withheld rating");
+    const html = await assertRendersItsClause(found.slug, found.sides);
+    assert.match(html, /We are not comparing the two pricing histories/);
+    assert.doesNotMatch(html, /We are not publishing a stability rating for/);
+  });
+
+  it("keeps a supported claim and prints the counts behind it", async () => {
+    const found = firstSlugWhere(sides => NAMES_A_WINNER.test(stabilityVerdictClause(sides[0], sides[1])));
+    assert.ok(found, "at least one linked comparison still names a supported winner");
+    const html = await assertRendersItsClause(found.slug, found.sides);
+    assert.match(html, /has a more stable pricing history \(\d+ recorded changes? vs \d+\)/);
+  });
+
+  it("states how many recorded changes a truncated list is drawn from", async () => {
+    const found = firstSlugWhere(([a, b]) => a.recordedChanges > 5 || b.recordedChanges > 5);
+    assert.ok(found, "at least one linked comparison lists more changes than it can show");
+    const html = await get(`/compare/${found.slug}`);
+    for (const s of found.sides) {
+      if (s.recordedChanges > 5) {
+        assert.ok(
+          html.includes(`Showing the 5 most recent of ${s.recordedChanges} recorded changes for ${escaped(s.vendor)}.`),
+          `${found.slug} does not say how many changes ${s.vendor} has`,
+        );
+      }
+    }
+  });
+});


### PR DESCRIPTION
`/compare/digitalocean-vs-sentry` said *"DigitalOcean has a more stable pricing history."* The same page printed DigitalOcean **4 recorded changes** and Sentry **1**. The clause compared **risk levels** — a different scale, as the comment two lines above it already said — and printed the result as a claim about pricing history. The change counts were computed six lines earlier and never consulted.

## What the clause does now

A winner is named only where the recorded-change counts **and** the risk levels point the same way, and the claim states its arithmetic:

> Cloudflare Pages has a more stable pricing history (0 recorded changes vs 4).

Where either side's level is withheld, the verdict says so and declines to compare, in the wording the vendor pages already use:

> We could not read the page we cite for Duolingo. We are not comparing the two pricing histories.

## The delta over all 353 linked comparisons

| | before | after |
|---|---|---|
| names a stability winner | 177 | **39** |
| states why a rating is withheld | 0 | 211 |
| says nothing | 176 | 103 |

Of the 177 that named a winner: **39 keep it** (the same 39 the issue counts as supported), **122** now state a withheld rating instead, **16** fall silent. **No page names a different winner, and no page that was silent gains a claim** — the change only ever removes a claim or explains its absence. The 211 withheld sentences break down as 122 replacing a claim and 89 added to pages that previously said nothing about stability.

## Why agreement, and not the count alone

AC-1 asks for the clause to be derived from the printed counts. Deriving it from the counts *alone* would name a winner on 68 pages — 29 more than today — and the extras reintroduce the defect on the same page:

- `augment-code-vs-cursor` — Augment Code (3 changes, **risky**) named more stable than Cursor (4, caution)
- `digitalocean-vs-sentry` — Sentry (1, **caution**) named more stable than DigitalOcean (4, stable)
- `highlight-io-vs-logz-io` — Highlight.io named more stable while both are badged **risky**

Each of those pages prints the risk badges next to the verdict. So the rule requires both signals to agree; where they disagree the verdict says nothing and the reader still has both numbers below. This satisfies AC-2 by construction — a named winner always has strictly fewer.

## AC-3: a withheld rating is not a rank

`unknown` was losing to `stable` and handing the win to the vendor we knew *less* about. The reason is now read from `levelWithheldReason`, so the sentence names the actual cause rather than assuming one — `states_no_terms` (218 sides), `unreadable` (36), `does_not_name_vendor` (18), `link_unreachable` (2).

## AC-5: the prose and the structured data

`Is A or B more stable?` in the FAQ JSON-LD is the version an AI search engine quotes. It used to publish `is rated unknown`; it now reports each side's count, omits the rating where it is withheld, and ends with the same clause the prose prints. The census test asserts both surfaces carry the same sentence, parsed separately — a first pass that searched the whole page body let a mutation dropping the clause from the verdict survive on the JSON-LD copy.

## One thing the issue did not name

The change list on a comparison page renders at most five records. A verdict reading `(0 recorded changes vs 6)` sat above a list of five. It now says `Showing the 5 most recent of 6 recorded changes for GitHub Copilot.` — 3 vendor slots in the linked set are affected.

## Structure

`comparisonMap` and the pair generation move to `src/comparison-pairs.ts` so the census can enumerate every linked comparison without a build of `serve.ts`; the clause itself is a pure function in `src/comparison-verdict.ts`. Nothing about which pairs exist changes — `/compare` still lists 353, the comparison sitemap still holds 372 URLs, and the reversed-slug redirect still resolves.

## Verified

- 2440/2440 local, 23 of them new.
- **AC-6 as a rendered census:** the test fetches all 353 linked comparison pages and asserts each renders exactly the clause its own counts support, in both the verdict paragraph and the FAQ structured data, plus the truncation note wherever a list is cut. 1.3s.
- `scripts/mutate-1140.sh` **20/20, no survivors**. Two survived the first pass: the guard against ranking a withheld side was equivalent on my fixture (the withheld side had *fewer* changes, so the count check caught it anyway — the real risk is the other way round, and 6 vendors in the corpus carry a withheld rating with recorded changes), and dropping the clause from the verdict survived because the JSON-LD still carried it.
- `check-mutation-targets.mjs` 226/226 across 25 scripts.
- Real MCP `initialize` → `notifications/initialized` → `tools/call` over HTTP.
- Screenshots of `/compare/digitalocean-vs-sentry`, `/compare/cloudflare-workers-vs-duolingo` and `/compare/cloudflare-pages-vs-netlify` against a local server with `BASE_URL` set to the local origin.

Refs #1140