### PR TITLE
Publish one stability judgement per vendor page (#1143)

### DIFF
--- a/scripts/mutate-1109.sh
+++ b/scripts/mutate-1109.sh
@@ -232,7 +232,7 @@ m_hero_keeps_its_verdict() {
   py <<'PY2'
 p = "src/serve.ts"
 s = open(p).read()
-s = s.replace("  const verdictLine2 = levelWithheld", "  const verdictLine2 = false")
+s = s.replace("    levelWithheld,\n    unconfirmableSince,", "    levelWithheld: null,\n    unconfirmableSince,")
 open(p, "w").write(s)
 PY2
 }

--- a/scripts/mutate-1113.sh
+++ b/scripts/mutate-1113.sh
@@ -153,7 +153,7 @@ m_hero_keeps_its_verdict() {
   py <<'PY'
 p = "src/serve.ts"
 s = open(p).read()
-s = s.replace("  const verdictLine2 = levelWithheld", "  const verdictLine2 = false")
+s = s.replace("    levelWithheld,\n    unconfirmableSince,", "    levelWithheld: null,\n    unconfirmableSince,")
 open(p, "w").write(s)
 PY
 }

--- a/scripts/mutate-1143.sh
+++ b/scripts/mutate-1143.sh
@@ -1,0 +1,298 @@
+#!/usr/bin/env bash
+set -u
+
+REPO="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$REPO" || exit 1
+
+VERDICT="src/vendor-verdict.ts"
+SERVE="src/serve.ts"
+BACKUP_DIR="$(mktemp -d)"
+cp "$VERDICT" "$BACKUP_DIR/vendor-verdict.ts"
+cp "$SERVE" "$BACKUP_DIR/serve.ts"
+
+restore() {
+  cp "$BACKUP_DIR/vendor-verdict.ts" "$VERDICT"
+  cp "$BACKUP_DIR/serve.ts" "$SERVE"
+}
+trap restore EXIT
+
+killed=0
+survived=0
+TESTS="test/vendor-verdict.test.ts"
+
+run_mutation() {
+  local name="$1"
+  shift
+  echo "=== $name"
+  restore
+  "$@"
+  if diff -q "$BACKUP_DIR/vendor-verdict.ts" "$VERDICT" > /dev/null && diff -q "$BACKUP_DIR/serve.ts" "$SERVE" > /dev/null; then
+    echo "    NOT APPLIED: the mutation changed no file, so it proves nothing"
+    survived=$((survived + 1))
+    return
+  fi
+  if ! npm run build > /tmp/mutate-1143-build.log 2>&1; then
+    echo "    KILLED (does not compile)"
+    killed=$((killed + 1))
+    return
+  fi
+  if timeout 300 node --test --test-concurrency 1 $TESTS > /tmp/mutate-1143-test.log 2>&1; then
+    echo "    SURVIVED"
+    survived=$((survived + 1))
+  else
+    echo "    KILLED: $(grep -c '✖ ' /tmp/mutate-1143-test.log) failing assertion(s)"
+    grep '✖ ' /tmp/mutate-1143-test.log | head -4
+    killed=$((killed + 1))
+  fi
+}
+
+py() { python3 - "$@"; }
+
+m_a_level_publishes_without_its_cause() {
+  py <<'PY'
+p = "src/vendor-verdict.ts"
+s = open(p).read()
+s = s.replace('  return level && (level === "stable" || cause) ? level : "stable";', '  return level ?? "stable";')
+open(p, "w").write(s)
+PY
+}
+
+m_every_level_is_rewritten_to_stable() {
+  py <<'PY'
+p = "src/vendor-verdict.ts"
+s = open(p).read()
+s = s.replace('  return level && (level === "stable" || cause) ? level : "stable";', '  return "stable";')
+open(p, "w").write(s)
+PY
+}
+
+m_every_record_counts_as_narrowing() {
+  py <<'PY'
+p = "src/vendor-verdict.ts"
+s = open(p).read()
+s = s.replace('    .filter(c => CHANGE_DIRECTION[c.change_type] === "negative")\n', '')
+open(p, "w").write(s)
+PY
+}
+
+m_the_records_that_helped_count_as_narrowing() {
+  py <<'PY'
+p = "src/vendor-verdict.ts"
+s = open(p).read()
+s = s.replace('CHANGE_DIRECTION[c.change_type] === "negative"', 'CHANGE_DIRECTION[c.change_type] === "positive"')
+open(p, "w").write(s)
+PY
+}
+
+m_the_oldest_narrowing_record_is_called_the_most_recent() {
+  py <<'PY'
+p = "src/vendor-verdict.ts"
+s = open(p).read()
+s = s.replace('    .sort((a, b) => b.date.localeCompare(a.date));', '    .sort((a, b) => a.date.localeCompare(b.date));')
+open(p, "w").write(s)
+PY
+}
+
+m_the_stable_sentence_reports_the_total_instead() {
+  py <<'PY'
+p = "src/vendor-verdict.ts"
+s = open(p).read()
+s = s.replace('  return `${narrowing.length} recorded changes narrowed the terms, the most recent ${changeDateClause(narrowing[0])}.`;',
+              '  return `${total} recorded changes narrowed the terms, the most recent ${changeDateClause(narrowing[0])}.`;')
+open(p, "w").write(s)
+PY
+}
+
+m_a_single_narrowing_record_is_left_unnamed() {
+  py <<'PY'
+p = "src/vendor-verdict.ts"
+s = open(p).read()
+s = s.replace('    return `One recorded ${changeKindNoun(narrowing[0].change_type)} narrowed the terms, ${changeDateClause(narrowing[0])}.`;',
+              '    return `One recorded change narrowed the terms, ${changeDateClause(narrowing[0])}.`;')
+open(p, "w").write(s)
+PY
+}
+
+m_a_stable_rating_never_mentions_the_records_it_holds() {
+  py <<'PY'
+p = "src/vendor-verdict.ts"
+s = open(p).read()
+s = s.replace('  return `We rate it stable — we hold no ${DEMOTING_KINDS_PHRASE} for this vendor. ${narrowingSentence(input.changes)}`;',
+              '  return `We rate it stable — we hold no ${DEMOTING_KINDS_PHRASE} for this vendor.`;')
+open(p, "w").write(s)
+PY
+}
+
+m_a_non_stable_rating_falls_through_to_the_stable_sentence() {
+  py <<'PY'
+p = "src/vendor-verdict.ts"
+s = open(p).read()
+s = s.replace('  if (level !== "stable" && input.cause) {', '  if (level === "stable" && input.cause) {')
+open(p, "w").write(s)
+PY
+}
+
+m_the_cause_is_reported_as_a_count() {
+  py <<'PY'
+p = "src/vendor-verdict.ts"
+s = open(p).read()
+s = s.replace('    return `We rate it ${level} — one recorded ${changeKindNoun(input.cause.change_type)}, ${changeDateClause(input.cause)}.`;',
+              '    return `We rate it ${level} — ${input.changes.length} pricing changes recorded.`;')
+open(p, "w").write(s)
+PY
+}
+
+m_a_cause_we_found_ourselves_is_dated_as_the_day_it_took_effect() {
+  py <<'PY'
+p = "src/vendor-verdict.ts"
+s = open(p).read()
+s = s.replace('${changeDateClause(input.cause)}', 'on ${input.cause.date}')
+s = s.replace('${changeDateClause(narrowing[0])}', 'on ${narrowing[0].date}')
+open(p, "w").write(s)
+PY
+}
+
+m_a_withheld_rating_is_published_as_a_word() {
+  py <<'PY'
+p = "src/vendor-verdict.ts"
+s = open(p).read()
+s = s.replace('  if (input.levelWithheld) return null;\n  return publishedVendorLevel(input.level, input.cause);',
+              '  return publishedVendorLevel(input.level, input.cause);')
+open(p, "w").write(s)
+PY
+}
+
+m_a_restriction_is_named_as_a_limit_reduction() {
+  py <<'PY'
+p = "src/vendor-verdict.ts"
+s = open(p).read()
+s = s.replace('  restriction: "restriction",', '  restriction: "limit reduction",')
+open(p, "w").write(s)
+PY
+}
+
+m_the_one_record_it_holds_is_reported_as_none() {
+  py <<'PY'
+p = "src/vendor-verdict.ts"
+s = open(p).read()
+s = s.replace('      ? `The one change we have recorded did not narrow the terms.`', '      ? `None of the 0 recorded changes narrowed the terms.`')
+open(p, "w").write(s)
+PY
+}
+
+m_the_page_forgets_it_is_withholding_the_rating() {
+  py <<'PY'
+p = "src/serve.ts"
+s = open(p).read()
+s = s.replace("    changes: vendorChanges,\n    levelWithheld,\n    unconfirmableSince,", "    changes: vendorChanges,\n    levelWithheld: null,\n    unconfirmableSince,")
+open(p, "w").write(s)
+PY
+}
+
+m_the_verdict_reads_no_records_at_all() {
+  py <<'PY'
+p = "src/serve.ts"
+s = open(p).read()
+s = s.replace("    cause: riskCause,\n    changes: vendorChanges,", "    cause: riskCause,\n    changes: [],")
+open(p, "w").write(s)
+PY
+}
+
+m_the_badge_renders_the_second_classifier() {
+  py <<'PY'
+p = "src/serve.ts"
+s = open(p).read()
+s = s.replace('border:1px solid ${riskColor}40">${riskLevel}</span>`;',
+              'border:1px solid ${riskColor}40">${enriched.stability ?? "stable"}</span>`;')
+open(p, "w").write(s)
+PY
+}
+
+m_the_comparison_cell_rates_the_vendor_stable_regardless() {
+  py <<'PY'
+p = "src/serve.ts"
+s = open(p).read()
+s = s.replace('<td>${stabilityCellHtml(enriched.risk_level, riskCause, linkUnreachable, primary)}</td>',
+              '<td>${stabilityCellHtml("stable", null, linkUnreachable, primary)}</td>')
+open(p, "w").write(s)
+PY
+}
+
+m_the_comparison_cell_publishes_a_level_with_no_cause() {
+  py <<'PY'
+p = "src/vendor-verdict.ts"
+s = open(p).read()
+s = s.replace('export function publishedVendorLevel(\n  level: PublishedRiskLevel | null,\n  cause: RiskCause | null,\n): PublishedRiskLevel {',
+              'export function publishedVendorLevel(\n  level: PublishedRiskLevel | null,\n  _cause: RiskCause | null,\n): PublishedRiskLevel {')
+s = s.replace('  return level && (level === "stable" || cause) ? level : "stable";', '  return level ?? "stable";')
+open(p, "w").write(s)
+PY
+}
+
+m_the_comparison_cell_loses_its_word() {
+  py <<'PY'
+p = "src/serve.ts"
+s = open(p).read()
+s = s.replace('  return `<span class="stability-dot" style="background:${color}"></span> <span${title}>${escHtmlServer(published)}</span>`;',
+              '  return `<span class="stability-dot" style="background:${color}"></span>`;')
+open(p, "w").write(s)
+PY
+}
+
+m_the_reliability_answer_goes_back_to_a_bare_count() {
+  py <<'PY'
+p = "src/serve.ts"
+s = open(p).read()
+s = s.replace('${vendorChanges.length > 0 ? ` ${narrowingSentence(vendorChanges)} See the pricing history below.` : ""}',
+              '${vendorChanges.length > 0 ? ` We do hold ${vendorChanges.length} other recorded changes — see the pricing history below.` : ""}')
+open(p, "w").write(s)
+PY
+}
+
+m_the_production_answer_names_a_level_of_its_own() {
+  py <<'PY'
+p = "src/serve.ts"
+s = open(p).read()
+s = s.replace("but we rate it ${riskLevel}${riskCause", "but we rate it caution${riskCause")
+open(p, "w").write(s)
+PY
+}
+
+m_the_verdict_line_is_dropped_from_the_page() {
+  py <<'PY'
+p = "src/serve.ts"
+s = open(p).read()
+s = s.replace('  const verdictLine2 = vendorVerdictSentence(verdictInput);', '  const verdictLine2 = "";')
+open(p, "w").write(s)
+PY
+}
+
+run_mutation "a level publishes without its cause" m_a_level_publishes_without_its_cause
+run_mutation "every level is rewritten to stable" m_every_level_is_rewritten_to_stable
+run_mutation "every record counts as narrowing" m_every_record_counts_as_narrowing
+run_mutation "the records that helped count as narrowing" m_the_records_that_helped_count_as_narrowing
+run_mutation "the oldest narrowing record is called the most recent" m_the_oldest_narrowing_record_is_called_the_most_recent
+run_mutation "the stable sentence reports the total instead" m_the_stable_sentence_reports_the_total_instead
+run_mutation "a single narrowing record is left unnamed" m_a_single_narrowing_record_is_left_unnamed
+run_mutation "a stable rating never mentions the records it holds" m_a_stable_rating_never_mentions_the_records_it_holds
+run_mutation "a non-stable rating falls through to the stable sentence" m_a_non_stable_rating_falls_through_to_the_stable_sentence
+run_mutation "the cause is reported as a count" m_the_cause_is_reported_as_a_count
+run_mutation "a cause we found ourselves is dated as the day it took effect" m_a_cause_we_found_ourselves_is_dated_as_the_day_it_took_effect
+run_mutation "a withheld rating is published as a word" m_a_withheld_rating_is_published_as_a_word
+run_mutation "a restriction is named as a limit reduction" m_a_restriction_is_named_as_a_limit_reduction
+run_mutation "the one record it holds is reported as none" m_the_one_record_it_holds_is_reported_as_none
+run_mutation "the page forgets it is withholding the rating" m_the_page_forgets_it_is_withholding_the_rating
+run_mutation "the verdict reads no records at all" m_the_verdict_reads_no_records_at_all
+run_mutation "the badge renders the second classifier" m_the_badge_renders_the_second_classifier
+run_mutation "the comparison cell rates the vendor stable regardless" m_the_comparison_cell_rates_the_vendor_stable_regardless
+run_mutation "the comparison cell publishes a level with no cause" m_the_comparison_cell_publishes_a_level_with_no_cause
+run_mutation "the comparison cell loses its word" m_the_comparison_cell_loses_its_word
+run_mutation "the reliability answer goes back to a bare count" m_the_reliability_answer_goes_back_to_a_bare_count
+run_mutation "the production answer names a level of its own" m_the_production_answer_names_a_level_of_its_own
+run_mutation "the verdict line is dropped from the page" m_the_verdict_line_is_dropped_from_the_page
+
+restore
+npm run build > /dev/null 2>&1
+echo
+echo "killed: $killed, survived: $survived"
+[ "$survived" -eq 0 ]

--- a/src/serve.ts
+++ b/src/serve.ts
@@ -19,6 +19,7 @@ import { LINK_GRACE_DAYS } from "./link-health.js";
 import { levelWithheldReason, withheldLevelClause, withheldLevelSentence } from "./source-check.js";
 import { buildComparisonMap, comparisonSlug } from "./comparison-pairs.js";
 import { stabilityFaqAnswer, stabilityVerdictClause, type ComparisonSide, type StabilityRating } from "./comparison-verdict.js";
+import { publishedVendorLevel, vendorVerdictSentence, narrowingSentence, changeKindNoun, DEMOTING_KINDS_PHRASE, type VendorVerdictInput } from "./vendor-verdict.js";
 import { growthLimitPhrases } from "./growth-limits.js";
 import { registerAgent, authenticateRequest, validateVestauthUrl, hashApiKey, updateAgentX402Address, getAgentById } from "./agents.js";
 import { logReferralRequest } from "./referral-requests.js";
@@ -449,7 +450,6 @@ const changeTypeBadge: Record<string, { label: string; color: string }> = {
 };
 
 const RISK_COLORS: Record<string, string> = { stable: "#3fb950", caution: "#d29922", risky: "#f85149" };
-const STABILITY_COLORS: Record<string, string> = { stable: "#3fb950", watch: "#d29922", volatile: "#f85149", improving: "#58a6ff" };
 
 function riskCauseLabel(cause: RiskCause): string {
   return `${changeDateLabel(cause)} ${changeTypeBadge[cause.change_type]?.label ?? cause.change_type.replace(/_/g, " ")}`;
@@ -482,7 +482,12 @@ function riskBadgeHtml(
   return `${badge} <span style="font-size:${size};color:var(--text-dim)" title="${escHtmlServer(cause.summary)}">${escHtmlServer(riskCauseLabel(cause))}</span>`;
 }
 
-function stabilityCellHtml(stability: string, linkUnreachable: LinkUnreachable | null | undefined, offer?: Pick<Offer, "source_check">): string {
+function stabilityCellHtml(
+  level: "stable" | "caution" | "risky" | null | undefined,
+  cause: RiskCause | null | undefined,
+  linkUnreachable: LinkUnreachable | null | undefined,
+  offer?: Pick<Offer, "source_check">,
+): string {
   if (linkUnreachable) {
     const since = linkUnreachable.last_reachable ? ` since ${linkUnreachable.last_reachable}` : "";
     return `<span style="color:var(--text-dim)" title="Link has not resolved${escHtmlServer(since)}">link unreachable</span>`;
@@ -492,8 +497,10 @@ function stabilityCellHtml(stability: string, linkUnreachable: LinkUnreachable |
     const why = withheldLevelClause(withheld, "");
     return `<span style="color:var(--text-dim)" title="${escHtmlServer(why.charAt(0).toUpperCase() + why.slice(1))}">source unconfirmed</span>`;
   }
-  const color = STABILITY_COLORS[stability] ?? "#8b949e";
-  return `<span class="stability-dot" style="background:${color}"></span> ${escHtmlServer(stability)}`;
+  const published = publishedVendorLevel(level ?? null, cause ?? null);
+  const color = RISK_COLORS[published] ?? "#8b949e";
+  const title = published === "stable" || !cause ? "" : ` title="${escHtmlServer(`${changeDateLabel(cause)} — ${cause.summary}`)}"`;
+  return `<span class="stability-dot" style="background:${color}"></span> <span${title}>${escHtmlServer(published)}</span>`;
 }
 
 /** Table-cell form of the same rule: the level, and under it the dated cause. */
@@ -3739,9 +3746,8 @@ function buildVendorPage(slug: string): string | null {
   const riskColors: Record<string, string> = { stable: "#3fb950", caution: "#d29922", risky: "#f85149" };
   const riskCause = enriched.risk_cause;
   // #1038: a level we cannot show the cause for is not publishable in the H1.
-  const riskLevel = enriched.risk_level && (enriched.risk_level === "stable" || riskCause) ? enriched.risk_level : "stable";
+  const riskLevel = publishedVendorLevel(enriched.risk_level ?? null, riskCause);
   const riskColor = riskColors[riskLevel] ?? "#8b949e";
-  const stability = enriched.stability ?? "stable";
   // The badge sits in the largest text on the page. Its reason sits directly
   // under it — not only in the history section further down, which for a cause
   // older than 90 days did not carry it at all (Neon, #1038).
@@ -3796,19 +3802,20 @@ function buildVendorPage(slug: string): string | null {
     : `${vendorName} pricing details and ${alternatives.length} free alternatives in ${primary.category}.${verifiedSentence}`;
 
   // --- NEW: Quick Verdict ---
-  const stabilityLabel: Record<string, string> = { stable: "stable", watch: "on our watch list", volatile: "volatile", improving: "improving" };
-  const stabilityText = stabilityLabel[stability] || "stable";
   const keyLimit = primary.description.slice(0, 120).replace(/\.\s.*$/, "");
   const unconfirmableSince = linkUnreachable
     ? (linkUnreachable.last_reachable ? ` since ${linkUnreachable.last_reachable}` : "")
     : "";
   const levelWithheld = levelWithheldReason(primary, linkUnreachable);
   const withheldClause = levelWithheld ? withheldLevelClause(levelWithheld, unconfirmableSince) : "";
-  const verdictLine2 = levelWithheld
-    ? `${withheldClause.charAt(0).toUpperCase()}${withheldClause.slice(1)}, so we cannot confirm these terms today.`
-    : vendorChanges.length === 0
-    ? `It's ${stabilityText} — zero pricing changes recorded.`
-    : `It's ${stabilityText} — ${vendorChanges.length} pricing change${vendorChanges.length > 1 ? "s" : ""} recorded.`;
+  const verdictInput: VendorVerdictInput = {
+    level: enriched.risk_level ?? null,
+    cause: riskCause,
+    changes: vendorChanges,
+    levelWithheld,
+    unconfirmableSince,
+  };
+  const verdictLine2 = vendorVerdictSentence(verdictInput);
   const verdictLine3 = alternatives.length > 0 && !levelWithheld
     ? `Best for ${primary.category.toLowerCase()} workloads${alternatives.length >= 5 ? ` — ${alternatives.length} alternatives available` : ""}.`
     : "";
@@ -3870,13 +3877,13 @@ function buildVendorPage(slug: string): string | null {
           <tr class="current-vendor-row">
             <td><strong>${escHtmlServer(vendorName)}</strong></td>
             <td>${escHtmlServer(primary.tier)}</td>
-            <td>${stabilityCellHtml(stability, linkUnreachable, primary)}</td>
+            <td>${stabilityCellHtml(enriched.risk_level, riskCause, linkUnreachable, primary)}</td>
           </tr>
 ${enrichedAlts.map(a => {
   return `          <tr>
             <td><a href="/vendor/${toSlug(a.vendor)}">${escHtmlServer(a.vendor)}</a></td>
             <td>${escHtmlServer(a.tier)}</td>
-            <td>${stabilityCellHtml(a.stability ?? "stable", a.link_unreachable, a)}</td>
+            <td>${stabilityCellHtml(a.risk_level, a.risk_cause, a.link_unreachable, a)}</td>
           </tr>`;
 }).join("\n")}
         </tbody>
@@ -4127,7 +4134,7 @@ ${allCompareLinks.join("\n")}
   const faqReliableAnswer = levelWithheld
     ? `We cannot say. ${withheldLevelSentence(levelWithheld, vendorName, unconfirmableSince)} Nothing we have read describes these terms, so we are not publishing a stability judgement for this vendor until that is fixed.`
     : riskLevel === "stable"
-    ? `${vendorName}'s free tier is considered stable: we hold no free tier removal, limit reduction or pricing restructure on record for this vendor.${vendorChanges.length > 0 ? ` We do hold ${vendorChanges.length === 1 ? "1 other recorded change" : `${vendorChanges.length} other recorded changes`} — see the pricing history below.` : ""}`
+    ? `${vendorName}'s free tier is considered stable: we hold no ${DEMOTING_KINDS_PHRASE} on record for this vendor.${vendorChanges.length > 0 ? ` ${narrowingSentence(vendorChanges)} See the pricing history below.` : ""}`
     : riskLevel === "caution"
     ? `${vendorName}'s free tier requires caution because of one specific recorded change${riskCause ? `, ${changeDateClause(riskCause)}: ${riskCause.summary}` : "."}`
     : `${vendorName}'s free tier is considered risky because of one specific recorded change${riskCause ? `, ${changeDateClause(riskCause)}: ${riskCause.summary}` : "."} Consider alternatives.`;
@@ -4138,8 +4145,8 @@ ${allCompareLinks.join("\n")}
     ? `${withheldLevelSentence(levelWithheld, vendorName, unconfirmableSince)} We cannot confirm what this offer provides today, so we are not recommending it for production or for anything else until we can.`
     : hasFree
     ? (riskLevel === "stable"
-      ? `${vendorName}'s free tier can be suitable for small production workloads and side projects. With ${stabilityText} pricing and ${escHtmlServer(keyLimit)}, it's a reasonable starting point. Monitor your usage against the limits and have an upgrade plan ready.`
-      : `${vendorName}'s free tier is usable for prototyping and development, but exercise caution for production workloads given its ${stabilityText} pricing history. Consider alternatives with more stable pricing for critical services.`)
+      ? `${vendorName}'s free tier can be suitable for small production workloads and side projects. We rate it stable and it offers ${escHtmlServer(keyLimit)}, so it's a reasonable starting point.${vendorChanges.length > 0 ? ` ${narrowingSentence(vendorChanges)}` : ""} Monitor your usage against the limits and have an upgrade plan ready.`
+      : `${vendorName}'s free tier is usable for prototyping and development, but we rate it ${riskLevel}${riskCause ? ` because of one recorded ${changeKindNoun(riskCause.change_type)}, ${changeDateClause(riskCause)}` : ""}. Consider alternatives with more stable pricing for critical services.`)
     : `${vendorName} does not offer a free tier for production use. Consider free alternatives in ${primary.category}.`;
   const faqChangedAnswer = vendorChanges.length > 0
     ? `Yes, ${vendorName} has had ${vendorChanges.length} recorded pricing change${vendorChanges.length > 1 ? "s" : ""}. Most recently: ${vendorChanges[0].summary} (${changeDateLabel(vendorChanges[0])}).`

--- a/src/vendor-verdict.ts
+++ b/src/vendor-verdict.ts
@@ -1,0 +1,87 @@
+import type { DealChange, RiskCause } from "./types.js";
+import { CHANGE_DIRECTION } from "./data.js";
+import { changeDateClause } from "./change-dates.js";
+import { withheldLevelClause, type LevelWithheldReason } from "./source-check.js";
+
+export type PublishedRiskLevel = "stable" | "caution" | "risky";
+
+export const DEMOTING_KINDS_PHRASE = "free tier removal, limit reduction or pricing restructure";
+
+export const CHANGE_KIND_NOUN: Record<DealChange["change_type"], string> = {
+  free_tier_removed: "free tier removal",
+  open_source_killed: "move away from open source",
+  limits_reduced: "limit reduction",
+  pricing_restructured: "pricing restructure",
+  product_deprecated: "product deprecation",
+  restriction: "restriction",
+  pricing_model_change: "pricing model change",
+  limits_increased: "limit increase",
+  new_free_tier: "new free tier",
+  new_tier: "new tier",
+  startup_program_expanded: "startup program expansion",
+  pricing_postponed: "postponed price change",
+  rebranded: "rebrand",
+};
+
+export function changeKindNoun(changeType: string): string {
+  return CHANGE_KIND_NOUN[changeType as DealChange["change_type"]] ?? changeType.replace(/_/g, " ");
+}
+
+export interface VendorVerdictInput {
+  level: PublishedRiskLevel | null;
+  cause: RiskCause | null;
+  changes: Array<Pick<DealChange, "date" | "date_source" | "change_type">>;
+  levelWithheld: LevelWithheldReason | null;
+  unconfirmableSince: string;
+}
+
+export function publishedVendorLevel(
+  level: PublishedRiskLevel | null,
+  cause: RiskCause | null,
+): PublishedRiskLevel {
+  return level && (level === "stable" || cause) ? level : "stable";
+}
+
+function narrowingChanges(
+  changes: VendorVerdictInput["changes"],
+): VendorVerdictInput["changes"] {
+  return changes
+    .filter(c => CHANGE_DIRECTION[c.change_type] === "negative")
+    .slice()
+    .sort((a, b) => b.date.localeCompare(a.date));
+}
+
+export function vendorVerdictWord(input: VendorVerdictInput): PublishedRiskLevel | null {
+  if (input.levelWithheld) return null;
+  return publishedVendorLevel(input.level, input.cause);
+}
+
+export function narrowingSentence(changes: VendorVerdictInput["changes"]): string {
+  const total = changes.length;
+  if (total === 0) return "";
+  const narrowing = narrowingChanges(changes);
+  if (narrowing.length === 0) {
+    return total === 1
+      ? `The one change we have recorded did not narrow the terms.`
+      : `None of the ${total} recorded changes narrowed the terms.`;
+  }
+  if (narrowing.length === 1) {
+    return `One recorded ${changeKindNoun(narrowing[0].change_type)} narrowed the terms, ${changeDateClause(narrowing[0])}.`;
+  }
+  return `${narrowing.length} recorded changes narrowed the terms, the most recent ${changeDateClause(narrowing[0])}.`;
+}
+
+export function vendorVerdictSentence(input: VendorVerdictInput): string {
+  if (input.levelWithheld) {
+    const clause = withheldLevelClause(input.levelWithheld, input.unconfirmableSince);
+    return `${clause.charAt(0).toUpperCase()}${clause.slice(1)}, so we cannot confirm these terms today.`;
+  }
+
+  const level = publishedVendorLevel(input.level, input.cause);
+  if (level !== "stable" && input.cause) {
+    return `We rate it ${level} — one recorded ${changeKindNoun(input.cause.change_type)}, ${changeDateClause(input.cause)}.`;
+  }
+
+  if (input.changes.length === 0) return `It's stable — zero pricing changes recorded.`;
+  return `We rate it stable — we hold no ${DEMOTING_KINDS_PHRASE} for this vendor. ${narrowingSentence(input.changes)}`;
+}

--- a/test/vendor-verdict.test.ts
+++ b/test/vendor-verdict.test.ts
@@ -1,0 +1,389 @@
+import { describe, it, before, after } from "node:test";
+import assert from "node:assert";
+import { spawn, type ChildProcess } from "node:child_process";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  CHANGE_KIND_NOUN,
+  DEMOTING_KINDS_PHRASE,
+  narrowingSentence,
+  publishedVendorLevel,
+  vendorVerdictSentence,
+  vendorVerdictWord,
+  type VendorVerdictInput,
+} from "../dist/vendor-verdict.js";
+import { enrichOffers, loadDealChanges, loadOffers, vendorRiskAssessment, classifyStability } from "../dist/data.js";
+import { vendorSlugMap } from "../dist/vendor-slug.js";
+import { levelWithheldReason } from "../dist/source-check.js";
+import type { DealChange, RiskCause } from "../dist/types.js";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO = path.join(__dirname, "..");
+
+const STABILITY_SCALE_WORDS = /\b(volatile|improving)\b|on our watch list/i;
+const OTHER_SCALE_ON_A_SURFACE_THAT_EMBEDS_SUMMARIES = /\bvolatile\b|on our watch list/i;
+const COUNT_AS_EVIDENCE = /\b\d+ pricing changes? recorded/;
+
+function change(over: Partial<DealChange> = {}): DealChange {
+  return {
+    vendor: "Vendor A",
+    date: "2026-03-01",
+    date_source: "vendor_page",
+    change_type: "limits_reduced",
+    summary: "Free tier storage cut from 10 GB to 1 GB",
+    impact: "medium",
+    category: "Databases",
+    ...over,
+  } as DealChange;
+}
+
+function causeOf(c: DealChange): RiskCause {
+  return { date: c.date, date_source: c.date_source, change_type: c.change_type, summary: c.summary };
+}
+
+function input(over: Partial<VendorVerdictInput> = {}): VendorVerdictInput {
+  return { level: "stable", cause: null, changes: [], levelWithheld: null, unconfirmableSince: "", ...over };
+}
+
+describe("vendor verdict — one rating word, and it carries its cause", () => {
+  it("states the level and the kind of record that earned it, never a count", () => {
+    const c = change({ change_type: "limits_reduced", date: "2026-03-01" });
+    const sentence = vendorVerdictSentence(input({ level: "caution", cause: causeOf(c), changes: [c] }));
+    assert.strictEqual(sentence, "We rate it caution — one recorded limit reduction, on 2026-03-01.");
+    assert.doesNotMatch(sentence, COUNT_AS_EVIDENCE);
+  });
+
+  it("names a free tier removal as the cause of a risky rating", () => {
+    const c = change({ change_type: "free_tier_removed", date: "2026-04-13" });
+    const sentence = vendorVerdictSentence(input({ level: "risky", cause: causeOf(c), changes: [c] }));
+    assert.strictEqual(sentence, "We rate it risky — one recorded free tier removal, on 2026-04-13.");
+  });
+
+  it("dates a cause we found ourselves as discovered, not as the day it took effect", () => {
+    const c = change({ change_type: "limits_reduced", date: "2026-08-28", date_source: "discovered" });
+    const sentence = vendorVerdictSentence(input({ level: "caution", cause: causeOf(c), changes: [c] }));
+    assert.strictEqual(sentence, "We rate it caution — one recorded limit reduction, discovered 2026-08-28.");
+  });
+
+  it("falls back to stable when a level arrives with no record to show for it", () => {
+    assert.strictEqual(publishedVendorLevel("caution", null), "stable");
+    assert.strictEqual(publishedVendorLevel("risky", null), "stable");
+    assert.strictEqual(publishedVendorLevel(null, null), "stable");
+    const c = change();
+    assert.strictEqual(publishedVendorLevel("caution", causeOf(c)), "caution");
+  });
+
+  it("withholds the rating entirely when we cannot read the page we cite", () => {
+    const withheld = input({ level: "stable", levelWithheld: "states_no_terms", changes: [change()] });
+    assert.strictEqual(vendorVerdictWord(withheld), null);
+    assert.strictEqual(
+      vendorVerdictSentence(withheld),
+      "The page we cite for this offer states no terms we can read, so we cannot confirm these terms today.",
+    );
+  });
+
+  it("says a link has not resolved, with the date it last did", () => {
+    const withheld = input({ levelWithheld: "link_unreachable", unconfirmableSince: " since 2026-05-02" });
+    assert.strictEqual(
+      vendorVerdictSentence(withheld),
+      "Its pricing page has not resolved for us since 2026-05-02, so we cannot confirm these terms today.",
+    );
+  });
+});
+
+describe("vendor verdict — a stable rating reports direction, not volume", () => {
+  it("says zero changes are recorded when we hold none", () => {
+    assert.strictEqual(vendorVerdictSentence(input()), "It's stable — zero pricing changes recorded.");
+    assert.strictEqual(narrowingSentence([]), "");
+  });
+
+  it("says the one record it holds did not narrow the terms", () => {
+    const c = change({ change_type: "limits_increased" });
+    const sentence = vendorVerdictSentence(input({ changes: [c] }));
+    assert.ok(sentence.includes(`we hold no ${DEMOTING_KINDS_PHRASE} for this vendor`));
+    assert.ok(sentence.endsWith("The one change we have recorded did not narrow the terms."));
+  });
+
+  it("counts only the records that pointed down, not every record", () => {
+    const changes = [
+      change({ change_type: "limits_increased", date: "2026-01-01" }),
+      change({ change_type: "limits_increased", date: "2025-01-22" }),
+      change({ change_type: "restriction", date: "2026-03-21" }),
+      change({ change_type: "restriction", date: "2026-08-28" }),
+    ];
+    const sentence = vendorVerdictSentence(input({ changes }));
+    assert.ok(sentence.endsWith("2 recorded changes narrowed the terms, the most recent on 2026-08-28."));
+    assert.doesNotMatch(sentence, /4 recorded changes narrowed/);
+    assert.doesNotMatch(sentence, COUNT_AS_EVIDENCE);
+  });
+
+  it("names the single record that narrowed the terms", () => {
+    const changes = [
+      change({ change_type: "limits_increased", date: "2026-01-01" }),
+      change({ change_type: "restriction", date: "2026-03-01" }),
+    ];
+    const sentence = vendorVerdictSentence(input({ changes }));
+    assert.ok(sentence.endsWith("One recorded restriction narrowed the terms, on 2026-03-01."));
+  });
+
+  it("reports that none narrowed the terms when every record points the other way", () => {
+    const changes = [
+      change({ change_type: "limits_increased", date: "2026-01-01" }),
+      change({ change_type: "new_free_tier", date: "2026-02-01" }),
+      change({ change_type: "rebranded", date: "2026-03-01" }),
+    ];
+    assert.strictEqual(narrowingSentence(changes), "None of the 3 recorded changes narrowed the terms.");
+  });
+
+  it("never reaches for the second scale's vocabulary", () => {
+    for (const changes of [[], [change()], [change({ change_type: "limits_increased" })], [change({ change_type: "product_deprecated" })]]) {
+      assert.doesNotMatch(vendorVerdictSentence(input({ changes })), STABILITY_SCALE_WORDS);
+    }
+  });
+});
+
+describe("vendor verdict — the prose table covers the data", () => {
+  it("names every change type present in the change log", () => {
+    const missing = [...new Set(loadDealChanges().map(c => c.change_type))]
+      .filter(t => !(t in CHANGE_KIND_NOUN));
+    assert.deepStrictEqual(missing, [], `change types with no reader-facing noun: ${missing.join(", ")}`);
+  });
+});
+
+interface VendorRow {
+  slug: string;
+  vendor: string;
+  expected: "stable" | "caution" | "risky";
+  withheld: ReturnType<typeof levelWithheldReason>;
+  badgeRendered: boolean;
+  sentence: string;
+  changes: DealChange[];
+}
+
+function vendorRows(): VendorRow[] {
+  const offers = loadOffers();
+  const changes = loadDealChanges();
+  const rows: VendorRow[] = [];
+  for (const [slug, vendor] of vendorSlugMap) {
+    const primary = offers.find(o => o.vendor === vendor);
+    if (!primary) continue;
+    const enriched = enrichOffers([primary])[0];
+    const vendorChanges = changes
+      .filter(c => c.vendor.toLowerCase() === vendor.toLowerCase())
+      .sort((a, b) => b.date.localeCompare(a.date));
+    const withheld = levelWithheldReason(primary, enriched.link_unreachable);
+    const expected = publishedVendorLevel(enriched.risk_level ?? null, enriched.risk_cause ?? null);
+    const unconfirmableSince = enriched.link_unreachable?.last_reachable
+      ? ` since ${enriched.link_unreachable.last_reachable}`
+      : "";
+    rows.push({
+      slug,
+      vendor,
+      expected,
+      withheld,
+      badgeRendered: !(enriched.risk_level === null || (enriched.link_unreachable && expected === "stable")),
+      sentence: vendorVerdictSentence({
+        level: enriched.risk_level ?? null,
+        cause: enriched.risk_cause ?? null,
+        changes: vendorChanges,
+        levelWithheld: withheld,
+        unconfirmableSince,
+      }),
+      changes: vendorChanges,
+    });
+  }
+  return rows;
+}
+
+describe("vendor verdict — corpus invariant, computed offline", () => {
+  it("gives every vendor we hold records for one rating word and no second scale", () => {
+    const wrong: string[] = [];
+    for (const row of vendorRows()) {
+      if (row.changes.length === 0) continue;
+      if (STABILITY_SCALE_WORDS.test(row.sentence)) {
+        wrong.push(`${row.slug}: verdict reaches for a second scale — ${row.sentence}`);
+        continue;
+      }
+      if (row.withheld) {
+        if (/\bWe rate it\b/.test(row.sentence)) wrong.push(`${row.slug}: publishes a rating we are withholding`);
+        continue;
+      }
+      const named = row.sentence.match(/We rate it (stable|caution|risky)\b/)?.[1]
+        ?? (row.sentence.startsWith("It's stable") ? "stable" : null);
+      if (named !== row.expected) {
+        wrong.push(`${row.slug}: badge says ${row.expected}, verdict says ${named ?? "nothing"}`);
+      }
+    }
+    assert.deepStrictEqual(wrong, [], `vendors whose two stability judgements disagree:\n${wrong.join("\n")}`);
+  });
+
+  it("covers vendors the two classifiers rate differently, so the invariant is not vacuous", () => {
+    const changes = loadDealChanges();
+    const byVendor = new Map<string, DealChange[]>();
+    for (const c of changes) {
+      const key = c.vendor.toLowerCase();
+      if (!byVendor.has(key)) byVendor.set(key, []);
+      byVendor.get(key)!.push(c);
+    }
+    const negativeStability = new Set(["watch", "volatile"]);
+    const disagreeing = [...byVendor.entries()].filter(([, vc]) =>
+      vendorRiskAssessment(vc).level === "stable" && negativeStability.has(classifyStability(vc)));
+    assert.ok(
+      disagreeing.length > 0,
+      "the change log holds no vendor the risk scale and the stability enum rate differently",
+    );
+    const routed = vendorRows().filter(r => r.changes.length > 0
+      && vendorRiskAssessment(r.changes).level === "stable"
+      && negativeStability.has(classifyStability(r.changes)));
+    assert.ok(routed.length > 0, "no rendered vendor route sits in that population");
+  });
+});
+
+describe("vendor verdict — as rendered", () => {
+  let proc: ChildProcess | null = null;
+  let port = 0;
+
+  before(async () => {
+    const started = await new Promise<{ child: ChildProcess; port: number }>((resolve, reject) => {
+      const child = spawn("node", [path.join(REPO, "dist", "serve.js")], {
+        stdio: ["pipe", "pipe", "pipe"],
+        env: { ...process.env, PORT: "0", BASE_URL: "http://localhost" },
+      });
+      const timeout = setTimeout(() => { child.kill(); reject(new Error("Server startup timeout")); }, 30000);
+      child.stderr!.on("data", (data: Buffer) => {
+        const m = data.toString().match(/running on http:\/\/localhost:(\d+)/);
+        if (m) { clearTimeout(timeout); resolve({ child, port: parseInt(m[1], 10) }); }
+      });
+      child.on("error", (err) => { clearTimeout(timeout); reject(err); });
+    });
+    proc = started.child;
+    port = started.port;
+  });
+
+  after(() => { proc?.kill(); });
+
+  const get = async (route: string) => {
+    const res = await fetch(`http://localhost:${port}${route}`, {
+      headers: { "user-agent": "agentdeals-internal/1.0 (vendor-verdict-test)" },
+    });
+    assert.strictEqual(res.status, 200, `${route} responded ${res.status}`);
+    return res.text();
+  };
+
+  const badgeWord = (html: string): string | null => {
+    const h1 = html.match(/<h1>[\s\S]*?<\/h1>/)?.[0] ?? "";
+    return h1.match(/<span class="risk-badge"[^>]*>([a-z]+)<\/span>/)?.[1] ?? null;
+  };
+
+  const verdictParagraph = (html: string): string => {
+    const m = html.match(/<div class="quick-verdict">\s*<p>([\s\S]*?)<\/p>/);
+    assert.ok(m, "the page renders a verdict paragraph");
+    return m[1];
+  };
+
+  const comparisonCell = (html: string): { rendered: boolean; word: string | null } => {
+    const row = html.match(/<tr class="current-vendor-row">[\s\S]*?<\/tr>/)?.[0];
+    if (!row) return { rendered: false, word: null };
+    return {
+      rendered: true,
+      word: row.match(/<span class="stability-dot"[^>]*><\/span> <span[^>]*>([a-z]+)<\/span>/)?.[1] ?? null,
+    };
+  };
+
+  const faqAnswers = (html: string, vendor: string): { reliable: string; production: string } => {
+    const blocks = [...html.matchAll(/<script type="application\/ld\+json">([\s\S]*?)<\/script>/g)]
+      .map(m => JSON.parse(m[1]) as Record<string, unknown>);
+    const faq = blocks.find(b => b["@type"] === "FAQPage") as
+      { mainEntity: Array<{ name: string; acceptedAnswer: { text: string } }> } | undefined;
+    assert.ok(faq, `${vendor} emits FAQ structured data`);
+    const find = (name: string) => {
+      const q = faq.mainEntity.find(e => e.name === name);
+      assert.ok(q, `the structured data answers "${name}"`);
+      return q.acceptedAnswer.text;
+    };
+    return {
+      reliable: find(`Is ${vendor}'s free tier reliable?`),
+      production: find(`Is ${vendor}'s free tier good for production?`),
+    };
+  };
+
+  it("renders on every vendor route the one rating its own records support", async () => {
+    const rows = vendorRows();
+    const wrong: string[] = [];
+    let index = 0;
+    const worker = async () => {
+      while (index < rows.length) {
+        const row = rows[index++];
+        const html = await get(`/vendor/${row.slug}`);
+        const badge = badgeWord(html);
+        const verdict = verdictParagraph(html);
+        const cell = comparisonCell(html);
+
+        if (row.badgeRendered && badge !== row.expected) {
+          wrong.push(`${row.slug}: h1 badge is ${badge ?? "absent"}, expected ${row.expected}`);
+        }
+        if (!row.badgeRendered && badge !== null) {
+          wrong.push(`${row.slug}: h1 badge renders ${badge} for a rating we are withholding`);
+        }
+        if (!verdict.includes(row.sentence)) {
+          wrong.push(`${row.slug}: verdict does not render "${row.sentence}"`);
+        }
+        if (STABILITY_SCALE_WORDS.test(verdict)) {
+          wrong.push(`${row.slug}: verdict reaches for a second scale — ${verdict}`);
+        }
+        if (COUNT_AS_EVIDENCE.test(verdict) && row.changes.length > 0) {
+          wrong.push(`${row.slug}: verdict offers a count of changes as its evidence`);
+        }
+        if (cell.rendered && !row.withheld && cell.word !== row.expected) {
+          wrong.push(`${row.slug}: comparison table says ${cell.word ?? "nothing"}, h1 badge says ${row.expected}`);
+        }
+      }
+    };
+    await Promise.all(Array.from({ length: 12 }, worker));
+    assert.deepStrictEqual(wrong.slice(0, 20), [], `vendor routes rendering more than one judgement:\n${wrong.slice(0, 20).join("\n")}`);
+  });
+
+  it("answers both of its own stability questions with the same word", async () => {
+    const rows = vendorRows().filter(r => r.changes.length > 0);
+    const wrong: string[] = [];
+    let index = 0;
+    const worker = async () => {
+      while (index < rows.length) {
+        const row = rows[index++];
+        const html = await get(`/vendor/${row.slug}`);
+        const answers = faqAnswers(html, row.vendor);
+        for (const [name, text] of Object.entries(answers)) {
+          if (OTHER_SCALE_ON_A_SURFACE_THAT_EMBEDS_SUMMARIES.test(text)) {
+            wrong.push(`${row.slug}: the "${name}" answer reaches for a second scale — ${text}`);
+          }
+        }
+        if (!row.withheld && !answers.reliable.includes(row.expected)) {
+          wrong.push(`${row.slug}: the reliability answer does not carry the ${row.expected} rating`);
+        }
+        if (!row.withheld && row.expected === "stable" && !answers.reliable.includes(narrowingSentence(row.changes))) {
+          wrong.push(`${row.slug}: the reliability answer does not say what the records it holds did — ${answers.reliable}`);
+        }
+        const productionRating = answers.production.match(/we rate it (stable|caution|risky)\b/)?.[1];
+        if (productionRating && productionRating !== row.expected) {
+          wrong.push(`${row.slug}: the production answer says ${productionRating}, the badge says ${row.expected}`);
+        }
+      }
+    };
+    await Promise.all(Array.from({ length: 12 }, worker));
+    assert.deepStrictEqual(wrong.slice(0, 20), [], `vendor routes whose FAQ contradicts their badge:\n${wrong.slice(0, 20).join("\n")}`);
+  });
+
+  it("resolves the four routes that rendered a green badge over a negative verdict", async () => {
+    for (const slug of ["digitalocean", "google-gemini-api", "postman", "xata"]) {
+      const row = vendorRows().find(r => r.slug === slug);
+      assert.ok(row, `/vendor/${slug} is a rendered route`);
+      const html = await get(`/vendor/${slug}`);
+      assert.strictEqual(badgeWord(html), row.expected, `/vendor/${slug} badge`);
+      assert.strictEqual(comparisonCell(html).word, row.expected, `/vendor/${slug} comparison cell`);
+      const verdict = verdictParagraph(html);
+      assert.doesNotMatch(verdict, STABILITY_SCALE_WORDS, `/vendor/${slug} verdict`);
+      assert.ok(verdict.includes(row.sentence), `/vendor/${slug} verdict does not render "${row.sentence}"`);
+      assert.match(row.sentence, /narrowed the terms/, `/vendor/${slug} still names the records that pointed down`);
+    }
+  });
+});


### PR DESCRIPTION
Refs #1143

`/vendor/digitalocean` rendered a green `stable` badge in its `<h1>` and, four lines below, *"It's volatile — 4 pricing changes recorded."* Two classifiers, both published as bare one-word judgements in the page's two most prominent positions, on scales that do not share a vocabulary.

## Which definition is now authoritative (AC-6)

**The risk scale**, `vendorRiskAssessment`. It is the one that travels with the dated record that earned it, the badge already used it, and #1038 established that no surface may publish a level it cannot show the reason for. It now drives the `<h1>` badge, the verdict paragraph, the "How X Compares" cell and both stability FAQ answers, all through one resolver (`publishedVendorLevel`) so they cannot drift again.

**`product_deprecated` and `restriction` still do not count toward it**, and this PR makes that decision reader-visible without changing it. I measured the alternative before deciding:

| promote to `caution` | vendors moved | routed | earning record is a correction to our own data |
|---|---|---|---|
| `restriction` | 10 | 10 | **1** — Neo4j AuraDB |
| `product_deprecated` | 64 | 7 | 0 |
| `pricing_model_change` | 9 | 8 | 0 |

Neo4j AuraDB's only record reads *"Data correction — previous entry incorrectly reduced limits to 50K nodes/175K relationships. Actual free tier is 200,000 nodes and 400,000 relationships."* Promoting `restriction` would badge that vendor `caution` because **we** fixed **our** mistake — the coverage proxy #1038 removed. There are only 17 `restriction` records in the whole log, and several of them (Postman's single-user-only free plan, houndci.com's public-repos-only) look like `limits_reduced` typed wrongly. That is a change-typing problem, not a demotion-table problem, so I left the table alone and said so here. Happy to promote it if you'd rather.

## What the verdict says instead

AC-3: the count of changes is not evidence of anything, in either direction, so it is no longer offered as evidence.

- **Non-stable** — `We rate it caution — one recorded pricing restructure, on 2026-02-01.` The kind and the date, not the summary, because `riskCauseLine` renders the summary four lines above it.
- **Stable, no records** — unchanged: `It's stable — zero pricing changes recorded.` (#1139 owns that sentence.)
- **Stable, with records** — `We rate it stable — we hold no free tier removal, limit reduction or pricing restructure for this vendor.` followed by what the records it *does* hold did.

That last clause is the part I would flag. Resolving the contradiction in favour of the risk scale, on its own, would have taken Postman's page from *contradictory* to *uniformly `stable`* over a free plan that went single-user-only in March. Dropping the word is right; dropping the signal is not. So the sentence keeps it:

> Postman's free tier offers Free for single user only (since March 2026). **We rate it stable — we hold no free tier removal, limit reduction or pricing restructure for this vendor. One recorded restriction narrowed the terms, on 2026-03-01.**

> DigitalOcean's free tier offers \$200 credit for 60 days for new accounts. **We rate it stable — we hold no free tier removal, limit reduction or pricing restructure for this vendor. 2 recorded changes narrowed the terms, the most recent discovered 2026-08-28.**

Two of DigitalOcean's four records are `limits_increased`, which is why the old line's `4` was wrong in both directions at once.

## Delta over the whole population

1,572 rendered vendor routes; 251 hold at least one record.

| | routes |
|---|---|
| verdict sentence changes | 218 |
| verdict word changes | 212 |
| **rendered routes whose badge and verdict disagreed in direction** | **22 → 0** |

Word transitions: `watch → caution` 101, `improving → stable` 42, `volatile → risky` 32, `watch → stable` 16, `volatile → caution` 15, `volatile → stable` 6. **No route gains a warning it did not have** — every move is same-severity, less severe, or less positive. All 22 that moved from a negative verdict word to `stable` carry a `narrowed the terms` clause naming the records.

The issue's 82 is over vendor names in the change log; 139 of the 390 vendors with records have no rendered route, so the population that reaches a reader is 24 (22 after excluding two whose rating is withheld). AC-2's four rows are all in it.

| page | before | after (badge = verdict = cell) |
|---|---|---|
| `/vendor/digitalocean` | green `stable` / *volatile* | `stable`, naming 2 narrowing records |
| `/vendor/google-gemini-api` | green `stable` / *volatile* | `stable`, naming 3 |
| `/vendor/postman` | green `stable` / *watch list* | `stable`, naming 1 |
| `/vendor/xata` | green `stable` / *watch list* | `stable`, naming 1 |

## AC-4

`classifyStability` is untouched. `search_deals({stability})` still filters: `volatile` 70, `watch` 133, `improving` 46, checked over a real MCP session.

## Tests (AC-5)

`test/vendor-verdict.test.ts`, 18 tests, 2.5s:

- **Offline corpus invariant.** Every vendor we hold records for gets one rating word, it matches the badge, and none of the four surfaces reaches for the other scale's vocabulary. Computed from `data/deal_changes.json` with no network, exactly as asked. A second test asserts the population the two classifiers rate differently is non-empty, so the invariant cannot pass vacuously.
- **Rendered census over all 1,572 vendor routes** in 1.4s. The badge, the verdict paragraph, the comparison cell and the two FAQ answers are extracted *separately* — the FAQ answers from the `FAQPage` JSON-LD, which is the copy a search engine quotes — and each is compared against the expectation recomputed from the data file, so it cannot rot as records are added.
- The exhaustive `CHANGE_KIND_NOUN` table is asserted to cover every change type present in the data, like `RISK_DEMOTION` and `CHANGE_DIRECTION`.

## Verification

- `npm test` 2458/2458 local (2440 before).
- `scripts/mutate-1143.sh` **23/23, no survivors**. Two survived the first pass and both were a second surface the census did not read on its own terms: a badge resolving the level its own way, and the reliability FAQ answer reverting to a bare count of records while still saying "stable".
- `check-mutation-targets.mjs` 249/249 across 26 scripts. Two mutations in `mutate-1109.sh` and `mutate-1113.sh` targeted the `verdictLine2` expression this PR replaced; retargeted at the new call site and both scripts re-run clean (23/23 and 14/14).
- Real MCP `initialize` → `notifications/initialized` → `tools/call`.
- Screenshots of `/vendor/digitalocean`, `/vendor/postman` and `/vendor/vercel` against a local server with `BASE_URL` set to the local origin.

## Not in scope

`/alternative-to/*` still renders the green accent against a withheld badge — that is #1130, same expression, different surface. The hub and guide pages (`/stability`, the stack guides) still render `getStabilityMap()` words; they carry no competing risk badge, so they do not contradict themselves, but they are the remaining reader-facing users of the second scale.