### PR TITLE
Require a restriction record to establish that something narrowed

### DIFF
--- a/data/change_refusals.json
+++ b/data/change_refusals.json
@@ -397,6 +397,18 @@
       "refused_date": "2026-08-28"
     },
     {
+      "vendor": "debugmail.io",
+      "change_type": "restriction",
+      "reason": "no_terms_to_narrow",
+      "detail": "a restriction was measured against \"Easy to use testing mail server for developers\", a stored description that states no price, named tier or allowance, so there is nothing for the terms to have narrowed from",
+      "summary": "The free tier is now limited to OSS projects. A Silver plan is available for free for OSS projects, but other users have a 2 week trial then $2 per user per month.",
+      "previous_state": "Easy to use testing mail server for developers",
+      "current_state": "We provide a free Silver plan for OSS projects. Contact us here to connect. Plans and pricing We provide a free Silver plan for OSS projects. Contact us here to connect. Free Silver Gold Projects 1 10 Unlimited Team Members 2 20 Unlimited Test Emails per Day Unlimited Unlimited Unlimited Forwarding Emails per Day 1 100 Unlimited Mailbox Storage Limit 10MB per team 1GB per team 5GB per team Forwarding Rules – 1 per project 20 per project IMAP – Soon Soon REST API – Spam Rating – – Soon Mail Client Viewer – – Soon Pricing $0 2 weeks trial period then $2 per user per month $5 per user per month",
+      "source_url": "https://debugmail.io/",
+      "category": "Email",
+      "refused_date": "2026-08-28"
+    },
+    {
       "vendor": "deployhq.com",
       "change_type": "limits_reduced",
       "reason": "measures_no_change",
@@ -529,6 +541,18 @@
       "refused_date": "2026-08-28"
     },
     {
+      "vendor": "Geocodio",
+      "change_type": "restriction",
+      "reason": "measures_no_change",
+      "detail": "a restriction was recorded over quantities that all hold the same value once notation, period and any unit the page defines as equivalent are normalised — 2,500 lookup/day against 2,500 credit/day",
+      "summary": "The free tier now offers 2,500 lookups *daily*. Is limited to US, Canada, and Mexico.",
+      "previous_state": "Geocoding and reverse geocoding API for US and Canada — free tier: 2,500 lookups/day. Includes address parsing, congressional districts, timezone, and census data fields",
+      "current_state": "Pay-as-you-go accounts get the first 2,500 credits per day for free. US, Canada, and Mexico only.",
+      "source_url": "https://www.geocod.io/pricing/",
+      "category": "Maps/Geolocation",
+      "refused_date": "2026-08-28"
+    },
+    {
       "vendor": "GitDailies",
       "change_type": "limits_reduced",
       "reason": "unquantified_limit",
@@ -587,6 +611,18 @@
       "source_url": "https://heap.io",
       "category": "Analytics",
       "refused_date": "2026-08-29"
+    },
+    {
+      "vendor": "houndci.com",
+      "change_type": "restriction",
+      "reason": "no_terms_to_narrow",
+      "detail": "a restriction was measured against \"Comments on GitHub commits about code quality, free for Open Source\", a stored description that states no price, named tier or allowance, so there is nothing for the terms to have narrowed from",
+      "summary": "The free tier is now limited to public repositories. Private repositories require a paid plan.",
+      "previous_state": "Comments on GitHub commits about code quality, free for Open Source",
+      "current_state": "Hound is free for public repos! Private repository plans start at $29/month for up to 50 reviews.",
+      "source_url": "https://houndci.com/",
+      "category": "Code Quality",
+      "refused_date": "2026-08-28"
     },
     {
       "vendor": "Hyperping",
@@ -1261,6 +1297,18 @@
       "refused_date": "2026-08-29"
     },
     {
+      "vendor": "testingbot.com",
+      "change_type": "restriction",
+      "reason": "states_no_narrowing",
+      "detail": "a restriction was recorded by a summary that reports the free tier still standing and names no term that moved",
+      "summary": "The free tier is still offered. The description is less specific. The current page only mentions a 'free plan' and a 'free trial of paid features' without explicitly linking it to open-source projects.",
+      "previous_state": "Selenium Browser and Device Testing, [free for Open Source](https://testingbot.com/open-source)",
+      "current_state": "TestingBot offers a free plan and a free trial of paid features. No credit card is required to start.",
+      "source_url": "https://testingbot.com/",
+      "category": "Testing",
+      "refused_date": "2026-08-28"
+    },
+    {
       "vendor": "Thunder Client",
       "change_type": "pricing_model_change",
       "reason": "no_price_signal",
@@ -1271,6 +1319,18 @@
       "source_url": "https://www.thunderclient.com",
       "category": "Dev Utilities",
       "refused_date": "2026-08-29"
+    },
+    {
+      "vendor": "tickgit.com",
+      "change_type": "restriction",
+      "reason": "no_terms_to_narrow",
+      "detail": "a restriction was measured against \"Surfaces `TODO` comments (and other markers) to identify areas of code worth returning to for improvement.\", a stored description that states no price, named tier or allowance, so there is nothing for the terms to have narrowed from",
+      "summary": "The free tier is now limited to public repositories. Private repositories require a $3/month subscription with a 3-day free trial.",
+      "previous_state": "Surfaces `TODO` comments (and other markers) to identify areas of code worth returning to for improvement.",
+      "current_state": "Free for Public Repositories 🎉 No login required. $3/month for Private Repositories 💵 3 day free trial.",
+      "source_url": "https://www.tickgit.com/",
+      "category": "Code Quality",
+      "refused_date": "2026-08-28"
     },
     {
       "vendor": "Toggled.dev",

--- a/data/deal_changes.json
+++ b/data/deal_changes.json
@@ -1316,7 +1316,7 @@
     },
     {
       "vendor": "DigitalOcean",
-      "change_type": "restriction",
+      "change_type": "record_corrected",
       "date": "2026-03-21",
       "summary": "Managed databases are not part of the free tier. Pricing starts at $15/month. Previous listing incorrectly included '1 basic cluster' as a free tier benefit",
       "previous_state": "Listed as: Free static sites (up to 3), functions (90K GiB-seconds/mo), and managed databases (1 basic cluster)",
@@ -1431,7 +1431,7 @@
     },
     {
       "vendor": "Neo4j AuraDB",
-      "change_type": "restriction",
+      "change_type": "record_corrected",
       "date": "2026-03-22",
       "summary": "Data correction — previous entry incorrectly reduced limits to 50K nodes/175K relationships. Actual free tier is 200,000 nodes and 400,000 relationships per Neo4j AuraDB FAQ",
       "previous_state": "50,000 nodes, 175,000 relationships (incorrectly listed)",
@@ -5381,21 +5381,6 @@
       "recorded_date": "2026-08-28"
     },
     {
-      "vendor": "debugmail.io",
-      "change_type": "restriction",
-      "date": "2026-08-28",
-      "date_source": "discovered",
-      "summary": "The free tier is now limited to OSS projects. A Silver plan is available for free for OSS projects, but other users have a 2 week trial then $2 per user per month.",
-      "previous_state": "Easy to use testing mail server for developers",
-      "current_state": "We provide a free Silver plan for OSS projects. Contact us here to connect. Plans and pricing We provide a free Silver plan for OSS projects. Contact us here to connect. Free Silver Gold Projects 1 10 Unlimited Team Members 2 20 Unlimited Test Emails per Day Unlimited Unlimited Unlimited Forwarding Emails per Day 1 100 Unlimited Mailbox Storage Limit 10MB per team 1GB per team 5GB per team Forwarding Rules – 1 per project 20 per project IMAP – Soon Soon REST API – Spam Rating – – Soon Mail Client Viewer – – Soon Pricing $0 2 weeks trial period then $2 per user per month $5 per user per month",
-      "impact": "high",
-      "source_url": "https://debugmail.io/",
-      "category": "Email",
-      "alternatives": [],
-      "detected_by": "reverify-ai",
-      "recorded_date": "2026-08-28"
-    },
-    {
       "vendor": "DNSExit",
       "change_type": "pricing_restructured",
       "date": "2026-08-28",
@@ -6356,21 +6341,6 @@
       "recorded_date": "2026-08-28"
     },
     {
-      "vendor": "Geocodio",
-      "change_type": "restriction",
-      "date": "2026-08-28",
-      "date_source": "discovered",
-      "summary": "The free tier now offers 2,500 lookups *daily*. Is limited to US, Canada, and Mexico.",
-      "previous_state": "Geocoding and reverse geocoding API for US and Canada — free tier: 2,500 lookups/day. Includes address parsing, congressional districts, timezone, and census data fields",
-      "current_state": "Pay-as-you-go accounts get the first 2,500 credits per day for free. US, Canada, and Mexico only.",
-      "impact": "medium",
-      "source_url": "https://www.geocod.io/pricing/",
-      "category": "Maps/Geolocation",
-      "alternatives": [],
-      "detected_by": "reverify-ai",
-      "recorded_date": "2026-08-28"
-    },
-    {
       "vendor": "Roboflow",
       "change_type": "limits_reduced",
       "date": "2026-08-28",
@@ -6701,21 +6671,6 @@
       "recorded_date": "2026-08-28"
     },
     {
-      "vendor": "houndci.com",
-      "change_type": "restriction",
-      "date": "2026-08-28",
-      "date_source": "discovered",
-      "summary": "The free tier is now limited to public repositories. Private repositories require a paid plan.",
-      "previous_state": "Comments on GitHub commits about code quality, free for Open Source",
-      "current_state": "Hound is free for public repos! Private repository plans start at $29/month for up to 50 reviews.",
-      "impact": "high",
-      "source_url": "https://houndci.com/",
-      "category": "Code Quality",
-      "alternatives": [],
-      "detected_by": "reverify-ai",
-      "recorded_date": "2026-08-28"
-    },
-    {
       "vendor": "Webvizio",
       "change_type": "free_tier_removed",
       "date": "2026-08-28",
@@ -6776,21 +6731,6 @@
       "recorded_date": "2026-08-28"
     },
     {
-      "vendor": "tickgit.com",
-      "change_type": "restriction",
-      "date": "2026-08-28",
-      "date_source": "discovered",
-      "summary": "The free tier is now limited to public repositories. Private repositories require a $3/month subscription with a 3-day free trial.",
-      "previous_state": "Surfaces `TODO` comments (and other markers) to identify areas of code worth returning to for improvement.",
-      "current_state": "Free for Public Repositories 🎉 No login required. $3/month for Private Repositories 💵 3 day free trial.",
-      "impact": "high",
-      "source_url": "https://www.tickgit.com/",
-      "category": "Code Quality",
-      "alternatives": [],
-      "detected_by": "reverify-ai",
-      "recorded_date": "2026-08-28"
-    },
-    {
       "vendor": "BugBug",
       "change_type": "limits_reduced",
       "date": "2026-08-28",
@@ -6800,21 +6740,6 @@
       "current_state": "The Free plan includes: Unlimited local test runs, 15 tests, 4 test suites, 1 user, 1 project, AI Test recorder, Components, Edit & rewind, Screenshots, 7 days of tests history.",
       "impact": "medium",
       "source_url": "https://bugbug.io/",
-      "category": "Testing",
-      "alternatives": [],
-      "detected_by": "reverify-ai",
-      "recorded_date": "2026-08-28"
-    },
-    {
-      "vendor": "testingbot.com",
-      "change_type": "restriction",
-      "date": "2026-08-28",
-      "date_source": "discovered",
-      "summary": "The free tier is still offered. The description is less specific. The current page only mentions a 'free plan' and a 'free trial of paid features' without explicitly linking it to open-source projects.",
-      "previous_state": "Selenium Browser and Device Testing, [free for Open Source](https://testingbot.com/open-source)",
-      "current_state": "TestingBot offers a free plan and a free trial of paid features. No credit card is required to start.",
-      "impact": "medium",
-      "source_url": "https://testingbot.com/",
       "category": "Testing",
       "alternatives": [],
       "detected_by": "reverify-ai",

--- a/scripts/change-gate.js
+++ b/scripts/change-gate.js
@@ -1,4 +1,5 @@
 import { pageNamesVendor } from "./vendor-naming.js";
+import { definedEquivalences } from "./unit-aliases.js";
 import { readPeriod, renderPeriod } from "../src/growth-limits.ts";
 
 export const REJECT_NULL_COMPARISON = "null_comparison";
@@ -15,6 +16,8 @@ export const REJECT_NO_BASELINE = "no_baseline";
 export const REJECT_DANGLING_REFERENCE = "dangling_reference";
 export const REJECT_MEASURES_NO_CHANGE = "measures_no_change";
 export const REJECT_MEASURES_THE_OPPOSITE = "measures_the_opposite";
+export const REJECT_STATES_NO_NARROWING = "states_no_narrowing";
+export const REJECT_NO_TERMS_TO_NARROW = "no_terms_to_narrow";
 
 export const GATE_REASONS = [
   REJECT_NULL_COMPARISON,
@@ -31,13 +34,18 @@ export const GATE_REASONS = [
   REJECT_DANGLING_REFERENCE,
   REJECT_MEASURES_NO_CHANGE,
   REJECT_MEASURES_THE_OPPOSITE,
+  REJECT_STATES_NO_NARROWING,
+  REJECT_NO_TERMS_TO_NARROW,
 ];
 
 export const FREE_TIER_REMOVED = "free_tier_removed";
+export const RESTRICTION = "restriction";
 
 const QUANTITY_CHANGE_TYPES = ["limits_reduced", "limits_increased"];
 
 export const RECLASSIFIED_AS_RESTRUCTURE = "pricing_restructured";
+export const RECLASSIFIED_AS_CORRECTION = "record_corrected";
+export const HAND_WRITTEN = "hand_written";
 
 export const MIN_PRICE_SIGNALS = 1;
 
@@ -254,21 +262,50 @@ export function measuredValue(attribute) {
   return value * (attribute?.scale ?? 1);
 }
 
-export function measuresTheSameThing(before, after) {
+const NO_ALIASES = new Map();
+
+export function unitAliases(pageText) {
+  const index = new Map();
+  const link = (from, to) => {
+    if (!from || !to || from === to) return;
+    if (!index.has(from)) index.set(from, new Set());
+    index.get(from).add(to);
+  };
+  for (const { left, right } of definedEquivalences(pageText)) {
+    const leftWords = wordsIn(left);
+    const rightWords = wordsIn(right);
+    for (const a of leftWords) {
+      for (const b of rightWords) {
+        link(a, b);
+        link(b, a);
+      }
+    }
+  }
+  return index;
+}
+
+function namesTheSameUnit(word, words, aliases) {
+  if (words.includes(word)) return true;
+  const equivalents = aliases.get(word);
+  return equivalents ? words.some((other) => equivalents.has(other)) : false;
+}
+
+export function measuresTheSameThing(before, after, aliases = NO_ALIASES) {
   const priced = (attribute) => (attribute?.words ?? []).includes(PRICE_ATTRIBUTE);
   if (priced(before) !== priced(after)) return false;
   const left = measuredWord(before);
   const right = measuredWord(after);
   if (!left || !right) return false;
-  return after.words.includes(left) || before.words.includes(right);
+  return namesTheSameUnit(left, after.words, aliases) || namesTheSameUnit(right, before.words, aliases);
 }
 
 function sameAmount(from, to) {
   return Math.abs(from - to) <= 1e-9 * Math.max(Math.abs(from), Math.abs(to), 1);
 }
 
-export function comparedQuantity(before, after) {
-  if (!measuresTheSameThing(before, after)) return null;
+export function comparedQuantity(before, after, aliases = NO_ALIASES) {
+  if (!measuresTheSameThing(before, after, aliases)) return null;
+  const aliased = !measuresTheSameThing(before, after, NO_ALIASES);
   let from = measuredValue(before);
   let to = measuredValue(after);
   if (from === null || to === null) return null;
@@ -282,6 +319,7 @@ export function comparedQuantity(before, after) {
     attribute: measuredWord(before),
     previous: renderedQuantity(before),
     current: renderedQuantity(after),
+    aliased,
     priced: (before.words ?? []).includes(PRICE_ATTRIBUTE),
     before,
     after,
@@ -301,14 +339,14 @@ function measuresAnAmount(attribute) {
   return !(attribute?.words ?? []).includes(PRICE_ATTRIBUTE);
 }
 
-export function quantityComparison(entry) {
+export function quantityComparison(entry, aliases = NO_ALIASES) {
   const previous = quantifiedAttributes(entry?.previous_state).filter(measuresAnAmount);
   const current = quantifiedAttributes(entry?.current_state).filter(measuresAnAmount);
   const compared = [];
   const matched = new Set();
   for (const before of previous) {
     for (const after of current) {
-      const quantity = comparedQuantity(before, after);
+      const quantity = comparedQuantity(before, after, aliases);
       if (!quantity) continue;
       compared.push(quantity);
       matched.add(before).add(after);
@@ -729,6 +767,79 @@ export function reportsSomethingStillFree(summary) {
   return FREE_STILL_OFFERED.some((pattern) => pattern.test(withoutTrials));
 }
 
+const ONLY_THE_WORDING_MOVED = [
+  /\b(?:description|wording|phrasing)\s+is\s+(?:now\s+)?less\s+(?:specific|detailed|explicit)\b/i,
+  /\bonly\s+the\s+(?:description|wording|phrasing)\s+(?:has\s+)?changed\b/i,
+  /\b(?:terms?|limits?|allowances?)\s+(?:are|is|remain|remains)\s+(?:the\s+)?(?:same|unchanged)\b/i,
+];
+
+export function reportsNoNarrowing(summary) {
+  if (typeof summary !== "string") return false;
+  const nothingMoved =
+    reportsSomethingStillFree(summary) || ONLY_THE_WORDING_MOVED.some((pattern) => pattern.test(summary));
+  return nothingMoved && summaryEvidence(summary).changed.length === 0;
+}
+
+const OUR_OWN_ENTRY =
+  /\b(?:data\s+correction|(?:the\s+)?(?:previous|prior|original|old)\s+(?:entry|listing|record|description)|our\s+(?:entry|listing|record)|we\s+(?:previously\s+)?(?:listed|recorded|stored))\b/i;
+const STATED_IT_WRONGLY =
+  /\b(?:incorrect(?:ly)?|erroneous(?:ly)?|mistaken(?:ly)?|wrongly|in\s+error|corrected|correction)\b/i;
+
+export function correctsOurOwnRecord(record) {
+  return summaryClauses(record?.summary).some((raw) => {
+    const clause = clauseText(raw);
+    return OUR_OWN_ENTRY.test(clause) && STATED_IT_WRONGLY.test(clause);
+  });
+}
+
+export function baselineIsAStoredDescription(record) {
+  return record?.date_source !== HAND_WRITTEN;
+}
+
+export function restrictionEvidence(record, context = {}) {
+  if (record?.change_type !== RESTRICTION) return { ok: true };
+
+  if (correctsOurOwnRecord(record)) {
+    return {
+      ok: true,
+      reclassifyAs: RECLASSIFIED_AS_CORRECTION,
+      detail: `the summary states that our own earlier entry was wrong, so the record corrects our data rather than reporting terms the vendor narrowed`,
+    };
+  }
+
+  if (reportsNoNarrowing(record?.summary)) {
+    return {
+      ok: false,
+      reason: REJECT_STATES_NO_NARROWING,
+      detail: `a restriction was recorded by a summary that reports the free tier still standing and names no term that moved`,
+    };
+  }
+
+  if (baselineIsAStoredDescription(record) && !statesTerms(record?.previous_state)) {
+    return {
+      ok: false,
+      reason: REJECT_NO_TERMS_TO_NARROW,
+      detail: `a restriction was measured against "${record?.previous_state}", a stored description that states no price, named tier or allowance, so there is nothing for the terms to have narrowed from`,
+    };
+  }
+
+  const { compared, unmatched } = quantityComparison(record, unitAliases(context.pageText));
+  if (
+    unmatched.length === 0 &&
+    compared.some(({ aliased }) => aliased) &&
+    compared.every(({ direction }) => direction === "equal")
+  ) {
+    const held = compared.map(({ previous, current }) => `${previous} against ${current}`).slice(0, 3).join(", ");
+    return {
+      ok: false,
+      reason: REJECT_MEASURES_NO_CHANGE,
+      detail: `a restriction was recorded over quantities that all hold the same value once notation, period and any unit the page defines as equivalent are normalised — ${held}`,
+    };
+  }
+
+  return { ok: true };
+}
+
 export function isDomainRoot(url) {
   try {
     const parsed = new URL(url);
@@ -832,6 +943,12 @@ export function describesChange(entry, context = {}) {
         detail: `${entry.change_type} claimed, but the current state names no quantity for anything the stored state measured (${stored})`,
       };
     }
+  }
+
+  const restriction = restrictionEvidence(entry, context);
+  if (!restriction.ok) return restriction;
+  if (restriction.reclassifyAs) {
+    return { ok: true, reclassifyAs: restriction.reclassifyAs, detail: restriction.detail };
   }
 
   if (refusedByAudit) return refusedByAudit;

--- a/scripts/change-log.js
+++ b/scripts/change-log.js
@@ -23,6 +23,7 @@ export const CHANGE_TYPES = [
   "pricing_postponed",
   "product_deprecated",
   "rebranded",
+  "record_corrected",
 ];
 
 const IMPACTS = ["high", "medium", "low"];

--- a/scripts/e2e-1145.mjs
+++ b/scripts/e2e-1145.mjs
@@ -1,0 +1,52 @@
+import { spawn } from "node:child_process";
+import { writeFileSync } from "node:fs";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const repo = process.argv[2] ?? resolve(__dirname, "..");
+const out = process.argv[3] ?? "/tmp/sweep-1145.json";
+
+const start = () =>
+  new Promise((ok, bad) => {
+    const child = spawn("node", [resolve(repo, "dist", "serve.js")], {
+      stdio: ["pipe", "pipe", "pipe"],
+      env: { ...process.env, PORT: "0", BASE_URL: "http://localhost" },
+    });
+    const timer = setTimeout(() => { child.kill(); bad(new Error("timeout")); }, 30000);
+    child.stderr.on("data", (b) => {
+      const m = b.toString().match(/running on http:\/\/localhost:(\d+)/);
+      if (m) { clearTimeout(timer); ok({ child, port: Number(m[1]) }); }
+    });
+    child.on("error", (e) => { clearTimeout(timer); bad(e); });
+  });
+
+const { child, port } = await start();
+const get = async (route) => {
+  const res = await fetch(`http://localhost:${port}${route}`, { headers: { "user-agent": "agentdeals-internal/1.0 (sweep-1145)" } });
+  if (res.status !== 200) throw new Error(`${route} → ${res.status}`);
+  return res.text();
+};
+
+const sitemap = await get("/sitemap-vendors.xml");
+const slugs = [...sitemap.matchAll(/<loc>[^<]*\/vendor\/([^<]+)<\/loc>/g)].map((m) => m[1]).filter((s) => s !== "vendor");
+
+const rows = {};
+let index = 0;
+const worker = async () => {
+  while (index < slugs.length) {
+    const slug = slugs[index++];
+    let html;
+    try { html = await get(`/vendor/${slug}`); } catch { rows[slug] = { error: true }; continue; }
+    const verdict = html.match(/<div class="quick-verdict">\s*<p>([\s\S]*?)<\/p>/)?.[1] ?? null;
+    const badge = (html.match(/<h1>[\s\S]*?<\/h1>/)?.[0] ?? "").match(/<span class="risk-badge"[^>]*>([a-z]+)<\/span>/)?.[1] ?? null;
+    const banner = html.match(/<strong>Pricing change:<\/strong>([\s\S]*?)<\/span>/)?.[1]?.replace(/\s+/g, " ").trim() ?? null;
+    rows[slug] = { verdict, badge, banner };
+  }
+};
+await Promise.all(Array.from({ length: 12 }, worker));
+
+const changes = await get("/changes");
+writeFileSync(out, JSON.stringify({ slugs: slugs.length, rows, changesLength: changes.length }, null, 1));
+console.log(`${slugs.length} vendor routes → ${out}`);
+child.kill("SIGKILL");

--- a/scripts/mutate-1136.sh
+++ b/scripts/mutate-1136.sh
@@ -125,7 +125,7 @@ m_two_figures_measure_the_same_thing_whatever_they_name() {
   py <<'PY'
 p = "scripts/change-gate.js"
 s = open(p).read()
-s = s.replace("  return after.words.includes(left) || before.words.includes(right);", "  return true;")
+s = s.replace("  return namesTheSameUnit(left, after.words, aliases) || namesTheSameUnit(right, before.words, aliases);", "  return true;")
 open(p, "w").write(s)
 PY
 }

--- a/scripts/mutate-1145.sh
+++ b/scripts/mutate-1145.sh
@@ -1,0 +1,254 @@
+#!/usr/bin/env bash
+set -u
+
+REPO="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$REPO" || exit 1
+
+GATE="scripts/change-gate.js"
+ALIASES="scripts/unit-aliases.js"
+VERDICT="src/vendor-verdict.ts"
+BACKUP_DIR="$(mktemp -d)"
+cp "$GATE" "$BACKUP_DIR/change-gate.js"
+cp "$ALIASES" "$BACKUP_DIR/unit-aliases.js"
+cp "$VERDICT" "$BACKUP_DIR/vendor-verdict.ts"
+
+restore() {
+  cp "$BACKUP_DIR/change-gate.js" "$GATE"
+  cp "$BACKUP_DIR/unit-aliases.js" "$ALIASES"
+  cp "$BACKUP_DIR/vendor-verdict.ts" "$VERDICT"
+}
+trap restore EXIT
+
+killed=0
+survived=0
+TESTS="test/restriction-evidence.test.ts test/vendor-verdict.test.ts"
+
+run_mutation() {
+  local name="$1"
+  shift
+  echo "=== $name"
+  restore
+  "$@"
+  if diff -q "$BACKUP_DIR/change-gate.js" "$GATE" > /dev/null \
+    && diff -q "$BACKUP_DIR/unit-aliases.js" "$ALIASES" > /dev/null \
+    && diff -q "$BACKUP_DIR/vendor-verdict.ts" "$VERDICT" > /dev/null; then
+    echo "    NOT APPLIED: the mutation changed no file, so it proves nothing"
+    survived=$((survived + 1))
+    return
+  fi
+  if ! npm run build > /tmp/mutate-1145-build.log 2>&1; then
+    echo "    KILLED (does not compile)"
+    killed=$((killed + 1))
+    return
+  fi
+  if timeout 300 npx tsx --test $TESTS > /tmp/mutate-1145-test.log 2>&1; then
+    echo "    SURVIVED"
+    survived=$((survived + 1))
+  else
+    echo "    KILLED: $(grep -c '✖ ' /tmp/mutate-1145-test.log) failing assertion(s)"
+    grep '✖ ' /tmp/mutate-1145-test.log | head -4
+    killed=$((killed + 1))
+  fi
+}
+
+py() { python3 - "$@"; }
+
+m_a_summary_never_reports_that_nothing_moved() {
+  py <<'PY'
+p = "scripts/change-gate.js"
+s = open(p).read()
+s = s.replace("  return nothingMoved && summaryEvidence(summary).changed.length === 0;",
+              "  return false;")
+open(p, "w").write(s)
+PY
+}
+
+m_a_free_tier_still_offered_is_enough_on_its_own() {
+  py <<'PY'
+p = "scripts/change-gate.js"
+s = open(p).read()
+s = s.replace("  return nothingMoved && summaryEvidence(summary).changed.length === 0;",
+              "  return nothingMoved;")
+open(p, "w").write(s)
+PY
+}
+
+m_every_baseline_was_written_by_hand() {
+  py <<'PY'
+p = "scripts/change-gate.js"
+s = open(p).read()
+s = s.replace('  return record?.date_source !== HAND_WRITTEN;', '  return false;')
+open(p, "w").write(s)
+PY
+}
+
+m_no_baseline_was_written_by_hand() {
+  py <<'PY'
+p = "scripts/change-gate.js"
+s = open(p).read()
+s = s.replace('  return record?.date_source !== HAND_WRITTEN;', '  return true;')
+open(p, "w").write(s)
+PY
+}
+
+m_quantities_that_held_still_need_no_alias() {
+  py <<'PY'
+p = "scripts/change-gate.js"
+s = open(p).read()
+s = s.replace("    compared.some(({ aliased }) => aliased) &&", "    compared.length > 0 &&")
+open(p, "w").write(s)
+PY
+}
+
+m_the_page_defines_no_units() {
+  py <<'PY'
+p = "scripts/change-gate.js"
+s = open(p).read()
+s = s.replace("  for (const { left, right } of definedEquivalences(pageText)) {",
+              "  for (const { left, right } of []) {")
+open(p, "w").write(s)
+PY
+}
+
+m_an_alias_reaches_only_one_way() {
+  py <<'PY'
+p = "scripts/change-gate.js"
+s = open(p).read()
+s = s.replace("        link(a, b);\n        link(b, a);", "        link(a, b);")
+open(p, "w").write(s)
+PY
+}
+
+m_any_parenthesis_is_an_abbreviation() {
+  py <<'PY'
+p = "scripts/unit-aliases.js"
+s = open(p).read()
+s = s.replace("  return initials === letters ? phrase.join(\" \") : null;", "  return phrase.join(\" \");")
+open(p, "w").write(s)
+PY
+}
+
+m_naming_our_own_entry_is_enough() {
+  py <<'PY'
+p = "scripts/change-gate.js"
+s = open(p).read()
+s = s.replace("    return OUR_OWN_ENTRY.test(clause) && STATED_IT_WRONGLY.test(clause);",
+              "    return OUR_OWN_ENTRY.test(clause);")
+open(p, "w").write(s)
+PY
+}
+
+m_the_two_halves_may_sit_in_different_clauses() {
+  py <<'PY'
+p = "scripts/change-gate.js"
+s = open(p).read()
+s = s.replace("""export function correctsOurOwnRecord(record) {
+  return summaryClauses(record?.summary).some((raw) => {
+    const clause = clauseText(raw);
+    return OUR_OWN_ENTRY.test(clause) && STATED_IT_WRONGLY.test(clause);
+  });
+}""",
+"""export function correctsOurOwnRecord(record) {
+  const summary = record?.summary ?? "";
+  return OUR_OWN_ENTRY.test(summary) && STATED_IT_WRONGLY.test(summary);
+}""")
+open(p, "w").write(s)
+PY
+}
+
+m_the_gate_never_consults_the_restriction_rule() {
+  py <<'PY'
+p = "scripts/change-gate.js"
+s = open(p).read()
+s = s.replace("  const restriction = restrictionEvidence(entry, context);\n  if (!restriction.ok) return restriction;",
+              "  const restriction = restrictionEvidence(entry, context);\n  if (false) return restriction;")
+open(p, "w").write(s)
+PY
+}
+
+m_the_gate_drops_the_reclassification() {
+  py <<'PY'
+p = "scripts/change-gate.js"
+s = open(p).read()
+s = s.replace("""  if (restriction.reclassifyAs) {
+    return { ok: true, reclassifyAs: restriction.reclassifyAs, detail: restriction.detail };
+  }""", "")
+open(p, "w").write(s)
+PY
+}
+
+m_the_rule_judges_every_change_type() {
+  py <<'PY'
+p = "scripts/change-gate.js"
+s = open(p).read()
+s = s.replace("  if (record?.change_type !== RESTRICTION) return { ok: true };", "")
+open(p, "w").write(s)
+PY
+}
+
+m_the_page_it_read_never_reaches_the_rule() {
+  py <<'PY'
+p = "scripts/change-gate.js"
+s = open(p).read()
+s = s.replace("  const { compared, unmatched } = quantityComparison(record, unitAliases(context.pageText));",
+              "  const { compared, unmatched } = quantityComparison(record, unitAliases(undefined));")
+open(p, "w").write(s)
+PY
+}
+
+m_a_repair_counts_as_a_change_the_vendor_made() {
+  py <<'PY'
+p = "src/vendor-verdict.ts"
+s = open(p).read()
+s = s.replace("  const byTheVendor = changes.filter(c => !isACorrectionToOurOwnRecord(c));",
+              "  const byTheVendor = changes;")
+open(p, "w").write(s)
+PY
+}
+
+m_a_page_holding_only_repairs_says_nothing_about_them() {
+  py <<'PY'
+p = "src/vendor-verdict.ts"
+s = open(p).read()
+s = s.replace("""    return corrections.length === 1
+      ? `The one record we hold corrects our own earlier entry rather than reporting a change the vendor made.`
+      : `All ${corrections.length} records we hold correct our own earlier entries rather than reporting changes the vendor made.`;""",
+"""    return corrections.length === 1
+      ? `The one change we have recorded did not narrow the terms.`
+      : `None of the ${corrections.length} recorded changes narrowed the terms.`;""")
+open(p, "w").write(s)
+PY
+}
+
+m_a_repair_is_counted_in_the_total() {
+  py <<'PY'
+p = "src/vendor-verdict.ts"
+s = open(p).read()
+s = s.replace("  const total = byTheVendor.length;", "  const total = changes.length;")
+open(p, "w").write(s)
+PY
+}
+
+run_mutation "a summary never reports that nothing moved" m_a_summary_never_reports_that_nothing_moved
+run_mutation "a free tier still offered is enough on its own" m_a_free_tier_still_offered_is_enough_on_its_own
+run_mutation "every baseline was written by hand" m_every_baseline_was_written_by_hand
+run_mutation "no baseline was written by hand" m_no_baseline_was_written_by_hand
+run_mutation "quantities that held still need no alias" m_quantities_that_held_still_need_no_alias
+run_mutation "the page defines no units" m_the_page_defines_no_units
+run_mutation "an alias reaches only one way" m_an_alias_reaches_only_one_way
+run_mutation "any parenthesis is an abbreviation" m_any_parenthesis_is_an_abbreviation
+run_mutation "naming our own entry is enough" m_naming_our_own_entry_is_enough
+run_mutation "the two halves may sit in different clauses" m_the_two_halves_may_sit_in_different_clauses
+run_mutation "the gate never consults the restriction rule" m_the_gate_never_consults_the_restriction_rule
+run_mutation "the gate drops the reclassification" m_the_gate_drops_the_reclassification
+run_mutation "the rule judges every change type" m_the_rule_judges_every_change_type
+run_mutation "the page it read never reaches the rule" m_the_page_it_read_never_reaches_the_rule
+run_mutation "a repair counts as a change the vendor made" m_a_repair_counts_as_a_change_the_vendor_made
+run_mutation "a page holding only repairs says nothing about them" m_a_page_holding_only_repairs_says_nothing_about_them
+run_mutation "a repair is counted in the total" m_a_repair_is_counted_in_the_total
+
+restore
+npm run build > /dev/null 2>&1
+echo
+echo "killed $killed, survived $survived"
+[ "$survived" -eq 0 ]

--- a/scripts/repair-1145.mjs
+++ b/scripts/repair-1145.mjs
@@ -1,0 +1,62 @@
+import { readFileSync, writeFileSync } from "node:fs";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { restrictionEvidence, RESTRICTION } from "./change-gate.js";
+import { buildRefusalEntry, mergeRefusals, readRefusals, refusalsPath } from "./change-refusals.js";
+import { fetchPageText } from "./verify-freshness.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const CHANGES_PATH = resolve(__dirname, "..", "data", "deal_changes.json");
+
+const apply = process.argv.includes("--apply");
+const offline = process.argv.includes("--offline");
+
+const index = JSON.parse(readFileSync(CHANGES_PATH, "utf-8"));
+const restrictions = index.changes.filter((c) => c.change_type === RESTRICTION);
+
+const pages = new Map();
+if (!offline) {
+  for (const record of restrictions) {
+    if (pages.has(record.source_url)) continue;
+    const read = await fetchPageText(record.source_url);
+    pages.set(record.source_url, read.ok ? read.text : null);
+    console.log(`  read ${record.source_url} → ${read.ok ? `${read.text.length} chars` : read.error}`);
+  }
+}
+
+const reclassified = [];
+const refused = [];
+for (const record of restrictions) {
+  const verdict = restrictionEvidence(record, { pageText: pages.get(record.source_url) ?? undefined });
+  if (verdict.reclassifyAs) reclassified.push({ record, to: verdict.reclassifyAs, detail: verdict.detail });
+  else if (!verdict.ok) refused.push({ record, reason: verdict.reason, detail: verdict.detail });
+}
+
+console.log(`\n${restrictions.length} restriction records`);
+console.log(`  ${reclassified.length} reclassified, ${refused.length} refused, ${restrictions.length - reclassified.length - refused.length} kept\n`);
+for (const { record, to, detail } of reclassified) console.log(`  ${record.vendor} ${record.date} → ${to}\n      ${detail}`);
+for (const { record, reason, detail } of refused) console.log(`  ${record.vendor} ${record.date} → refused (${reason})\n      ${detail}`);
+
+if (!apply) {
+  console.log("\nnothing written — pass --apply");
+  process.exit(0);
+}
+
+const refusedKeys = new Set(refused.map(({ record }) => `${record.vendor}|${record.date}`));
+const reclassifyTo = new Map(reclassified.map(({ record, to }) => [`${record.vendor}|${record.date}`, to]));
+
+index.changes = index.changes
+  .filter((c) => !refusedKeys.has(`${c.vendor}|${c.date}`) || c.change_type !== RESTRICTION)
+  .map((c) => {
+    const to = c.change_type === RESTRICTION ? reclassifyTo.get(`${c.vendor}|${c.date}`) : undefined;
+    return to ? { ...c, change_type: to } : c;
+  });
+writeFileSync(CHANGES_PATH, `${JSON.stringify(index, null, 2)}\n`);
+
+const entries = refused.map(({ record, reason, detail }) =>
+  buildRefusalEntry({ candidate: record, reason, detail }, { now: new Date(`${record.recorded_date ?? record.date}T00:00:00Z`) })
+);
+const path = refusalsPath();
+writeFileSync(path, `${JSON.stringify({ refusals: mergeRefusals(readRefusals(path), entries) }, null, 2)}\n`);
+
+console.log(`\nwrote ${CHANGES_PATH} and ${path}`);

--- a/scripts/unit-aliases.js
+++ b/scripts/unit-aliases.js
@@ -1,0 +1,68 @@
+const EQUATION =
+  /(?:^|[^\w.])1\s+([a-z][a-z\s/-]{0,60}?)\s*(?:=|equals|is\s+equal\s+to)\s*1\s+([a-z][a-z-]*(?:\s+[a-z][a-z-]*){0,3})/gi;
+
+const EXPANSION_THEN_ABBREVIATION =
+  /\b([a-z][a-z-]*(?:\s+[a-z][a-z-]*){1,4})\s*\(\s*([A-Za-z]{2,6})s?\s*\)/g;
+
+const ABBREVIATION_THEN_EXPANSION =
+  /\b([A-Z]{2,6})s?\s*\(\s*([a-z][a-z-]*(?:\s+[a-z][a-z-]*){1,4})\s*\)/g;
+
+export const FORM_EQUATION = "equation";
+export const FORM_ABBREVIATION = "abbreviation";
+
+const CONNECTIVES = new Set(["or", "and", "of", "per", "the", "a", "an", "to", "for"]);
+
+function isAConnective(token) {
+  return CONNECTIVES.has(token.toLowerCase());
+}
+
+function expansionSpelling(expansion, abbreviation) {
+  const letters = abbreviation.toLowerCase();
+  if (letters.length < 2) return null;
+  const tokens = expansion.split(/\s+/).filter(Boolean);
+  let needed = letters.length;
+  let start = tokens.length;
+  while (start > 0 && needed > 0) {
+    start--;
+    if (!isAConnective(tokens[start])) needed--;
+  }
+  if (needed > 0) return null;
+  const phrase = tokens.slice(start);
+  const initials = phrase
+    .filter((token) => !isAConnective(token))
+    .map((token) => token.toLowerCase().charAt(0))
+    .join("");
+  return initials === letters ? phrase.join(" ") : null;
+}
+
+function tidy(phrase) {
+  return phrase.replace(/\s+/g, " ").trim();
+}
+
+function push(into, seen, left, right, form) {
+  const pair = { left: tidy(left), right: tidy(right), form };
+  if (!pair.left || !pair.right) return;
+  const key = `${pair.left}|${pair.right}|${form}`;
+  if (seen.has(key)) return;
+  seen.add(key);
+  into.push(pair);
+}
+
+export function definedEquivalences(pageText) {
+  if (typeof pageText !== "string") return [];
+  const found = [];
+  const seen = new Set();
+
+  for (const match of pageText.matchAll(EQUATION)) {
+    push(found, seen, match[1], match[2], FORM_EQUATION);
+  }
+  for (const match of pageText.matchAll(EXPANSION_THEN_ABBREVIATION)) {
+    const expansion = expansionSpelling(match[1], match[2]);
+    if (expansion) push(found, seen, expansion, match[2], FORM_ABBREVIATION);
+  }
+  for (const match of pageText.matchAll(ABBREVIATION_THEN_EXPANSION)) {
+    const expansion = expansionSpelling(match[2], match[1]);
+    if (expansion) push(found, seen, expansion, match[1], FORM_ABBREVIATION);
+  }
+  return found;
+}

--- a/src/data.ts
+++ b/src/data.ts
@@ -263,7 +263,14 @@ export const CHANGE_DIRECTION: Record<DealChange["change_type"], "negative" | "p
   startup_program_expanded: "positive",
   pricing_postponed: "positive",
   rebranded: "neutral",
+  record_corrected: "neutral",
 };
+
+export const CORRECTION_TO_OUR_OWN_RECORD = "record_corrected";
+
+export function isACorrectionToOurOwnRecord(change: Pick<DealChange, "change_type">): boolean {
+  return change.change_type === CORRECTION_TO_OUR_OWN_RECORD;
+}
 
 const directionSet = (d: "negative" | "positive" | "neutral") =>
   new Set(Object.entries(CHANGE_DIRECTION).filter(([, v]) => v === d).map(([k]) => k));
@@ -665,11 +672,11 @@ export const RISK_DEMOTION: Record<DealChange["change_type"], "risky" | "caution
   startup_program_expanded: null,
   pricing_postponed: null,
   rebranded: null, // a naming event, not a pricing one
+  record_corrected: null, // a repair to our own entry, not an act of the vendor
   // Negative, but not risk inputs today — see the #1038 PR description. In
   // short: `product_deprecated` is dominated by unrelated products of large
   // vendors (an AWS Lambda runtime deprecation says nothing about AWS's free
-  // tier) and `restriction` currently holds at least one correction to our own
-  // data. Both would reintroduce the coverage proxy this issue removed.
+  // tier).
   product_deprecated: null,
   restriction: null,
   pricing_model_change: null,

--- a/src/openapi.ts
+++ b/src/openapi.ts
@@ -148,7 +148,7 @@ export const openapiSpec = {
         description: "Returns tracked pricing and tier changes across vendors. Filter by date, change type, vendor, or category. When vendors or categories are provided, returns personalized results with advisory section for high-impact changes outside your filter.",
         parameters: [
           { name: "since", in: "query", description: "Filter changes after this date (YYYY-MM-DD)", schema: { type: "string", format: "date" }, example: "2025-01-01" },
-          { name: "type", in: "query", description: "Filter by change type", schema: { type: "string", enum: ["free_tier_removed", "limits_reduced", "restriction", "limits_increased", "new_free_tier", "new_tier", "pricing_restructured", "open_source_killed", "pricing_model_change", "startup_program_expanded", "pricing_postponed", "product_deprecated"] } },
+          { name: "type", in: "query", description: "Filter by change type", schema: { type: "string", enum: ["free_tier_removed", "limits_reduced", "restriction", "limits_increased", "new_free_tier", "new_tier", "pricing_restructured", "open_source_killed", "pricing_model_change", "startup_program_expanded", "pricing_postponed", "product_deprecated", "record_corrected"] } },
           { name: "vendor", in: "query", description: "Filter by vendor name", schema: { type: "string" } },
           { name: "vendors", in: "query", description: "Comma-separated vendor names to filter by (e.g. 'Vercel,Supabase,Clerk'). Triggers personalized response.", schema: { type: "string" }, example: "Vercel,Supabase" },
           { name: "categories", in: "query", description: "Comma-separated category names to filter by (e.g. 'Database,Cloud Hosting'). Case-insensitive partial match. Triggers personalized response.", schema: { type: "string" }, example: "Database,Hosting" }
@@ -947,7 +947,7 @@ export const openapiSpec = {
         type: "object",
         properties: {
           vendor: { type: "string" },
-          change_type: { type: "string", enum: ["free_tier_removed", "limits_reduced", "restriction", "limits_increased", "new_free_tier", "new_tier", "pricing_restructured", "open_source_killed", "pricing_model_change", "startup_program_expanded", "pricing_postponed", "product_deprecated", "rebranded"] },
+          change_type: { type: "string", enum: ["free_tier_removed", "limits_reduced", "restriction", "limits_increased", "new_free_tier", "new_tier", "pricing_restructured", "open_source_killed", "pricing_model_change", "startup_program_expanded", "pricing_postponed", "product_deprecated", "rebranded", "record_corrected"] },
           date: { type: "string", format: "date" },
           summary: { type: "string" },
           previous_state: { type: "string" },

--- a/src/server-remote.ts
+++ b/src/server-remote.ts
@@ -287,7 +287,7 @@ export function createServer(): McpServer {
       _meta: TOOL_UI_META.track_changes,
       inputSchema: {
         since: z.string().optional().describe("ISO date (YYYY-MM-DD). Default: 7 days ago."),
-        change_type: z.enum(["free_tier_removed", "limits_reduced", "restriction", "limits_increased", "new_free_tier", "new_tier", "pricing_restructured", "open_source_killed", "pricing_model_change", "startup_program_expanded", "pricing_postponed", "product_deprecated", "rebranded"]).optional().describe("Filter by type of change"),
+        change_type: z.enum(["free_tier_removed", "limits_reduced", "restriction", "limits_increased", "new_free_tier", "new_tier", "pricing_restructured", "open_source_killed", "pricing_model_change", "startup_program_expanded", "pricing_postponed", "product_deprecated", "rebranded", "record_corrected"]).optional().describe("Filter by type of change"),
         vendor: z.string().optional().describe("Filter to one vendor (case-insensitive)"),
         vendors: z.string().optional().describe("Comma-separated vendor names to filter (e.g. 'Vercel,Supabase'). When provided with categories, returns personalized results with advisory section."),
         categories: z.string().optional().describe("Comma-separated category names to filter (e.g. 'Database,Cloud Hosting'). Case-insensitive partial match."),

--- a/src/server.ts
+++ b/src/server.ts
@@ -431,7 +431,7 @@ export function createServer(getSessionId?: () => string | undefined, getClientN
       _meta: TOOL_UI_META.track_changes,
       inputSchema: {
         since: z.string().optional().describe("ISO date (YYYY-MM-DD). Default: 7 days ago."),
-        change_type: z.enum(["free_tier_removed", "limits_reduced", "restriction", "limits_increased", "new_free_tier", "new_tier", "pricing_restructured", "open_source_killed", "pricing_model_change", "startup_program_expanded", "pricing_postponed", "product_deprecated", "rebranded"]).optional().describe("Filter by type of change"),
+        change_type: z.enum(["free_tier_removed", "limits_reduced", "restriction", "limits_increased", "new_free_tier", "new_tier", "pricing_restructured", "open_source_killed", "pricing_model_change", "startup_program_expanded", "pricing_postponed", "product_deprecated", "rebranded", "record_corrected"]).optional().describe("Filter by type of change"),
         vendor: z.string().optional().describe("Filter to one vendor (case-insensitive)"),
         vendors: z.string().optional().describe("Comma-separated vendor names to filter (e.g. 'Vercel,Supabase'). When provided with categories, returns personalized results with advisory section."),
         categories: z.string().optional().describe("Comma-separated category names to filter (e.g. 'Database,Cloud Hosting'). Case-insensitive partial match."),
@@ -1592,7 +1592,7 @@ export function getServerCard(baseUrl: string) {
           type: "object",
           properties: {
             since: { type: "string", description: "ISO date (YYYY-MM-DD). Default: 7 days ago." },
-            change_type: { type: "string", enum: ["free_tier_removed", "limits_reduced", "restriction", "limits_increased", "new_free_tier", "new_tier", "pricing_restructured", "open_source_killed", "pricing_model_change", "startup_program_expanded", "pricing_postponed", "product_deprecated"], description: "Filter by type of change" },
+            change_type: { type: "string", enum: ["free_tier_removed", "limits_reduced", "restriction", "limits_increased", "new_free_tier", "new_tier", "pricing_restructured", "open_source_killed", "pricing_model_change", "startup_program_expanded", "pricing_postponed", "product_deprecated", "record_corrected"], description: "Filter by type of change" },
             vendor: { type: "string", description: "Filter to one vendor" },
             vendors: { type: "string", description: "Comma-separated vendor names" },
             include_expiring: { type: "boolean", description: "Include upcoming expirations (default: true)" },

--- a/src/types.ts
+++ b/src/types.ts
@@ -115,7 +115,7 @@ export type ChangeDateSource = "vendor_page" | "hand_written" | "discovered";
 
 export interface DealChange {
   vendor: string;
-  change_type: "free_tier_removed" | "limits_reduced" | "restriction" | "limits_increased" | "new_free_tier" | "new_tier" | "pricing_restructured" | "open_source_killed" | "pricing_model_change" | "startup_program_expanded" | "pricing_postponed" | "product_deprecated" | "rebranded";
+  change_type: "free_tier_removed" | "limits_reduced" | "restriction" | "limits_increased" | "new_free_tier" | "new_tier" | "pricing_restructured" | "open_source_killed" | "pricing_model_change" | "startup_program_expanded" | "pricing_postponed" | "product_deprecated" | "rebranded" | "record_corrected";
   date: string;
   summary: string;
   previous_state: string;

--- a/src/vendor-verdict.ts
+++ b/src/vendor-verdict.ts
@@ -1,5 +1,5 @@
 import type { DealChange, RiskCause } from "./types.js";
-import { CHANGE_DIRECTION } from "./data.js";
+import { CHANGE_DIRECTION, isACorrectionToOurOwnRecord } from "./data.js";
 import { changeDateClause } from "./change-dates.js";
 import { withheldLevelClause, type LevelWithheldReason } from "./source-check.js";
 
@@ -21,6 +21,7 @@ export const CHANGE_KIND_NOUN: Record<DealChange["change_type"], string> = {
   startup_program_expanded: "startup program expansion",
   pricing_postponed: "postponed price change",
   rebranded: "rebrand",
+  record_corrected: "correction to our own entry",
 };
 
 export function changeKindNoun(changeType: string): string {
@@ -57,9 +58,16 @@ export function vendorVerdictWord(input: VendorVerdictInput): PublishedRiskLevel
 }
 
 export function narrowingSentence(changes: VendorVerdictInput["changes"]): string {
-  const total = changes.length;
-  if (total === 0) return "";
-  const narrowing = narrowingChanges(changes);
+  const corrections = changes.filter(isACorrectionToOurOwnRecord);
+  const byTheVendor = changes.filter(c => !isACorrectionToOurOwnRecord(c));
+  const total = byTheVendor.length;
+  if (total === 0) {
+    if (corrections.length === 0) return "";
+    return corrections.length === 1
+      ? `The one record we hold corrects our own earlier entry rather than reporting a change the vendor made.`
+      : `All ${corrections.length} records we hold correct our own earlier entries rather than reporting changes the vendor made.`;
+  }
+  const narrowing = narrowingChanges(byTheVendor);
   if (narrowing.length === 0) {
     return total === 1
       ? `The one change we have recorded did not narrow the terms.`

--- a/test/deal-changes.test.ts
+++ b/test/deal-changes.test.ts
@@ -415,7 +415,7 @@ describe("track_changes tool", () => {
       "free_tier_removed", "limits_reduced", "restriction", "limits_increased",
       "new_free_tier", "new_tier", "pricing_restructured", "open_source_killed",
       "pricing_model_change", "startup_program_expanded",
-      "pricing_postponed", "product_deprecated", "rebranded",
+      "pricing_postponed", "product_deprecated", "rebranded", "record_corrected",
     ]);
 
     const dataPath = path.join(__dirname, "..", "data", "deal_changes.json");

--- a/test/restriction-evidence.test.ts
+++ b/test/restriction-evidence.test.ts
@@ -1,0 +1,357 @@
+import { describe, it } from "node:test";
+import assert from "node:assert";
+import { readFileSync, mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+process.env.AGENTDEALS_REFUSALS_PATH = path.join(
+  mkdtempSync(path.join(tmpdir(), "refusals-restriction-")),
+  "change_refusals.json"
+);
+
+const {
+  describesChange,
+  restrictionEvidence,
+  correctsOurOwnRecord,
+  reportsNoNarrowing,
+  reportsSomethingStillFree,
+  unitAliases,
+  RECLASSIFIED_AS_CORRECTION,
+  REJECT_STATES_NO_NARROWING,
+  REJECT_NO_TERMS_TO_NARROW,
+  REJECT_MEASURES_NO_CHANGE,
+} = await import("../scripts/change-gate.js");
+
+const { definedEquivalences } = await import("../scripts/unit-aliases.js");
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+const GEOCODIO_PRICING_PAGE =
+  "Geocodio pricing. Pay as you go, no monthly commitment. Annual plans get two months free plus " +
+  "discounts on top-up credits. 1 address or coordinate lookup = 1 credit. Each additional data " +
+  "append = 1 credit. First 2,500 credits used per day are free.";
+
+const TESTINGBOT = {
+  vendor: "testingbot.com",
+  change_type: "restriction",
+  date: "2026-08-28",
+  date_source: "discovered",
+  summary:
+    "The free tier is still offered. The description is less specific. The current page only mentions a " +
+    "'free plan' and a 'free trial of paid features' without explicitly linking it to open-source projects.",
+  previous_state:
+    "Selenium Browser and Device Testing, [free for Open Source](https://testingbot.com/open-source)",
+  current_state:
+    "TestingBot offers a free plan and a free trial of paid features. No credit card is required to start.",
+  impact: "medium",
+  source_url: "https://testingbot.com/",
+};
+
+const DEBUGMAIL = {
+  vendor: "debugmail.io",
+  change_type: "restriction",
+  date: "2026-08-28",
+  date_source: "discovered",
+  summary:
+    "The free tier is now limited to OSS projects. A Silver plan is available for free for OSS projects, " +
+    "but other users have a 2 week trial then $2 per user per month.",
+  previous_state: "Easy to use testing mail server for developers",
+  current_state:
+    "We provide a free Silver plan for OSS projects. Free Silver Gold Projects 1 10 Unlimited Team Members " +
+    "2 20 Unlimited Pricing $0 2 weeks trial period then $2 per user per month $5 per user per month",
+  impact: "high",
+  source_url: "https://debugmail.io/",
+};
+
+const TICKGIT = {
+  vendor: "tickgit.com",
+  change_type: "restriction",
+  date: "2026-08-28",
+  date_source: "discovered",
+  summary:
+    "The free tier is now limited to public repositories. Private repositories require a $3/month " +
+    "subscription with a 3-day free trial.",
+  previous_state:
+    "Surfaces `TODO` comments (and other markers) to identify areas of code worth returning to for improvement.",
+  current_state:
+    "Free for Public Repositories 🎉 No login required. $3/month for Private Repositories 💵 3 day free trial.",
+  impact: "high",
+  source_url: "https://www.tickgit.com/",
+};
+
+const GEOCODIO = {
+  vendor: "Geocodio",
+  change_type: "restriction",
+  date: "2026-08-28",
+  date_source: "discovered",
+  summary: "The free tier now offers 2,500 lookups *daily*. Is limited to US, Canada, and Mexico.",
+  previous_state:
+    "Geocoding and reverse geocoding API for US and Canada — free tier: 2,500 lookups/day. Includes " +
+    "address parsing, congressional districts, timezone, and census data fields",
+  current_state:
+    "Pay-as-you-go accounts get the first 2,500 credits per day for free. US, Canada, and Mexico only.",
+  impact: "medium",
+  source_url: "https://www.geocod.io/pricing/",
+};
+
+const NEO4J = {
+  vendor: "Neo4j AuraDB",
+  change_type: "restriction",
+  date: "2026-03-22",
+  date_source: "hand_written",
+  summary:
+    "Data correction — previous entry incorrectly reduced limits to 50K nodes/175K relationships. Actual " +
+    "free tier is 200,000 nodes and 400,000 relationships per Neo4j AuraDB FAQ",
+  previous_state: "50,000 nodes, 175,000 relationships (incorrectly listed)",
+  current_state: "200,000 nodes, 400,000 relationships (restored to correct values)",
+  impact: "low",
+  source_url: "https://neo4j.com/cloud/platform/aura-graph-database/faq/",
+};
+
+const DIGITALOCEAN_CORRECTION = {
+  vendor: "DigitalOcean",
+  change_type: "restriction",
+  date: "2026-03-21",
+  date_source: "hand_written",
+  summary:
+    "Managed databases are not part of the free tier. Pricing starts at $15/month. Previous listing " +
+    "incorrectly included '1 basic cluster' as a free tier benefit",
+  previous_state:
+    "Listed as: Free static sites (up to 3), functions (90K GiB-seconds/mo), and managed databases (1 basic cluster)",
+  current_state:
+    "Free static sites (up to 3) and functions (90K GiB-seconds/mo). Managed databases start at $15/mo, not free",
+  impact: "medium",
+  source_url: "https://www.digitalocean.com/pricing",
+};
+
+const NETLIFY = {
+  vendor: "Netlify",
+  change_type: "restriction",
+  date: "2026-03-01",
+  date_source: "hand_written",
+  summary:
+    "Every repo committer is now charged as a full Pro seat ($19/mo) when using Netlify CMS or Identity " +
+    "with a private repo. Previously only users who logged into the Netlify dashboard counted as seats",
+  previous_state: "Only Netlify dashboard users counted as billable seats",
+  current_state:
+    "All repo committers to connected private repos count as Pro seats ($19/mo each) when using CMS or Identity features",
+  impact: "high",
+  source_url: "https://www.netlify.com/pricing/",
+};
+
+const PINGMETER = {
+  vendor: "Pingmeter.com",
+  change_type: "restriction",
+  date: "2026-08-28",
+  date_source: "discovered",
+  summary:
+    "The free tier now has restrictions: limited to accounts with 1 category and less than 5 uptime " +
+    "monitors. SMS/voice notification, scheduling and recovery actions are excluded from the free tier.",
+  previous_state:
+    "5 uptime monitors with 10-minute interval. Monitor SSH, HTTP, HTTPS, and any custom TCP ports.",
+  current_state:
+    "Free account is limited to accounts with 1 category and less than 5 uptime monitors. It exclude pro " +
+    "features such as sms/voice notification, scheduling and recovery actions.",
+  impact: "medium",
+  source_url: "https://pingmeter.com/",
+};
+
+describe("a page that defines two names for one unit", () => {
+  it("reads the equation the pricing page writes out", () => {
+    assert.deepStrictEqual(definedEquivalences(GEOCODIO_PRICING_PAGE), [
+      { left: "address or coordinate lookup", right: "credit", form: "equation" },
+    ]);
+  });
+
+  it("reads an abbreviation the page expands", () => {
+    const pairs = definedEquivalences("Billing is per monthly tracked user (MTU). 100 MTUs are included.");
+    assert.deepStrictEqual(pairs, [
+      { left: "monthly tracked user", right: "MTU", form: "abbreviation" },
+    ]);
+  });
+
+  it("reads an expansion the page puts after the abbreviation", () => {
+    const pairs = definedEquivalences("Your plan includes 100 MTU (monthly tracked users) per month.");
+    assert.deepStrictEqual(pairs, [
+      { left: "monthly tracked users", right: "MTU", form: "abbreviation" },
+    ]);
+  });
+
+  it("refuses a parenthesis whose letters the phrase does not spell", () => {
+    assert.deepStrictEqual(definedEquivalences("All prices shown in dollars (USD) per month."), []);
+    assert.deepStrictEqual(definedEquivalences("The free plan (currently) includes 5 seats."), []);
+  });
+
+  it("makes the two words interchangeable in both directions", () => {
+    const aliases = unitAliases(GEOCODIO_PRICING_PAGE);
+    assert.ok(aliases.get("lookup")?.has("credit"), "lookup resolves to credit");
+    assert.ok(aliases.get("credit")?.has("lookup"), "credit resolves to lookup");
+    assert.strictEqual(unitAliases(undefined).size, 0);
+  });
+});
+
+describe("a restriction has to establish that something narrowed", () => {
+  it("refuses a record whose own summary reports the free tier still standing", () => {
+    assert.strictEqual(reportsNoNarrowing(TESTINGBOT.summary), true);
+    const verdict = restrictionEvidence(TESTINGBOT);
+    assert.strictEqual(verdict.ok, false);
+    assert.strictEqual(verdict.reason, REJECT_STATES_NO_NARROWING);
+  });
+
+  it("keeps a record whose summary reports a free tier still open and a term that moved", () => {
+    const stillFreeButSmaller = {
+      ...NETLIFY,
+      vendor: "Somewhere",
+      date_source: "discovered",
+      summary: "The free tier is still offered. Storage on it dropped from 10 GB to 1 GB.",
+      previous_state: "Free plan: 10 GB storage",
+      current_state: "Free plan: 1 GB storage",
+    };
+    assert.strictEqual(reportsSomethingStillFree(stillFreeButSmaller.summary), true);
+    assert.strictEqual(reportsNoNarrowing(stillFreeButSmaller.summary), false);
+    assert.strictEqual(restrictionEvidence(stillFreeButSmaller).ok, true);
+  });
+
+  it("refuses a record measured against a stored description that states no terms", () => {
+    for (const record of [DEBUGMAIL, TICKGIT]) {
+      const verdict = restrictionEvidence(record);
+      assert.strictEqual(verdict.ok, false, `${record.vendor} is refused`);
+      assert.strictEqual(verdict.reason, REJECT_NO_TERMS_TO_NARROW);
+      assert.match(verdict.detail, new RegExp(record.previous_state.slice(0, 24).replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
+    }
+  });
+
+  it("does not second-guess a baseline a person wrote by hand", () => {
+    assert.strictEqual(restrictionEvidence(NETLIFY).ok, true);
+    const asDiscovered = { ...NETLIFY, date_source: "discovered" };
+    assert.strictEqual(restrictionEvidence(asDiscovered).reason, REJECT_NO_TERMS_TO_NARROW);
+  });
+
+  it("refuses a record whose allowance only changed name, on the page's own definition", () => {
+    const verdict = restrictionEvidence(GEOCODIO, { pageText: GEOCODIO_PRICING_PAGE });
+    assert.strictEqual(verdict.ok, false);
+    assert.strictEqual(verdict.reason, REJECT_MEASURES_NO_CHANGE);
+    assert.match(verdict.detail, /2,500 lookup\/day against 2,500 credit\/day/);
+  });
+
+  it("takes the equivalence from the page and not from anywhere else", () => {
+    assert.strictEqual(restrictionEvidence(GEOCODIO).ok, true);
+    assert.strictEqual(restrictionEvidence(GEOCODIO, { pageText: "Geocodio pricing. Credits are billed monthly." }).ok, true);
+  });
+
+  it("leaves a record alone when the two states name one unit and the allowance did move", () => {
+    const halved = {
+      ...GEOCODIO,
+      current_state: "Pay-as-you-go accounts get the first 1,000 credits per day for free.",
+    };
+    assert.strictEqual(restrictionEvidence(halved, { pageText: GEOCODIO_PRICING_PAGE }).ok, true);
+  });
+
+  it("keeps every record the control set holds", () => {
+    for (const record of [NETLIFY, PINGMETER]) {
+      const verdict = restrictionEvidence(record);
+      assert.strictEqual(verdict.ok, true, `${record.vendor} survives`);
+      assert.strictEqual(verdict.reclassifyAs, undefined, `${record.vendor} keeps its type`);
+    }
+  });
+});
+
+describe("a repair to our own entry is not something the vendor did", () => {
+  it("recognises both records that say our earlier entry was wrong", () => {
+    for (const record of [NEO4J, DIGITALOCEAN_CORRECTION]) {
+      assert.strictEqual(correctsOurOwnRecord(record), true, `${record.vendor} corrects our record`);
+      const verdict = restrictionEvidence(record);
+      assert.strictEqual(verdict.ok, true);
+      assert.strictEqual(verdict.reclassifyAs, RECLASSIFIED_AS_CORRECTION);
+    }
+  });
+
+  it("wants the wrongness and our own entry inside one clause", () => {
+    const vendorWasWrong = {
+      ...NETLIFY,
+      summary: "The vendor's page previously stated the wrong price. Seats are now billed per committer.",
+    };
+    assert.strictEqual(correctsOurOwnRecord(vendorWasWrong), false);
+    assert.strictEqual(restrictionEvidence(vendorWasWrong).reclassifyAs, undefined);
+  });
+
+  it("does not reclassify a record that merely mentions a previous listing", () => {
+    const merelyPrevious = {
+      ...NETLIFY,
+      summary: "The previous listing offered 5 seats. The free plan now offers 1 seat.",
+    };
+    assert.strictEqual(correctsOurOwnRecord(merelyPrevious), false);
+  });
+
+  it("does not join our own entry in one sentence to a wrongness in another", () => {
+    const splitAcrossClauses = {
+      ...NETLIFY,
+      summary:
+        "The previous listing offered 5 seats. The vendor has since corrected its own pricing page to show 1 seat.",
+    };
+    assert.match(splitAcrossClauses.summary, /previous listing/);
+    assert.match(splitAcrossClauses.summary, /corrected/);
+    assert.strictEqual(correctsOurOwnRecord(splitAcrossClauses), false);
+    assert.strictEqual(restrictionEvidence(splitAcrossClauses).reclassifyAs, undefined);
+  });
+});
+
+describe("the gate carries the restriction rules", () => {
+  it("refuses through describesChange, not only through the rule", () => {
+    const verdict = describesChange(TESTINGBOT);
+    assert.strictEqual(verdict.ok, false);
+    assert.strictEqual(verdict.reason, REJECT_STATES_NO_NARROWING);
+  });
+
+  it("reclassifies through describesChange", () => {
+    const verdict = describesChange(NEO4J);
+    assert.strictEqual(verdict.ok, true);
+    assert.strictEqual(verdict.reclassifyAs, RECLASSIFIED_AS_CORRECTION);
+  });
+
+  it("hands the page it read to the rule that needs it", () => {
+    const withPage = describesChange(GEOCODIO, { pageText: GEOCODIO_PRICING_PAGE });
+    assert.strictEqual(withPage.ok, false);
+    assert.strictEqual(withPage.reason, REJECT_MEASURES_NO_CHANGE);
+  });
+
+  it("leaves every other change type to the rules that already cover it", () => {
+    const asLimitsReduced = { ...TESTINGBOT, change_type: "limits_reduced" };
+    assert.strictEqual(restrictionEvidence(asLimitsReduced).ok, true);
+  });
+});
+
+describe("every restriction we have stored survives its own rule", () => {
+  const stored = JSON.parse(
+    readFileSync(path.join(__dirname, "..", "data", "deal_changes.json"), "utf-8")
+  ).changes as Array<Record<string, string>>;
+
+  it("holds no restriction record the rule refuses", () => {
+    const failing = stored
+      .filter(c => c.change_type === "restriction")
+      .map(c => ({ record: c, verdict: restrictionEvidence(c) }))
+      .filter(({ verdict }) => !verdict.ok)
+      .map(({ record, verdict }) => `${record.vendor} ${record.date}: ${verdict.reason}`);
+    assert.deepStrictEqual(failing, [], `stored restrictions the rule refuses:\n${failing.join("\n")}`);
+  });
+
+  it("holds no restriction record that corrects our own entry", () => {
+    const mistyped = stored
+      .filter(c => c.change_type === "restriction" && correctsOurOwnRecord(c))
+      .map(c => `${c.vendor} ${c.date}`);
+    assert.deepStrictEqual(mistyped, []);
+  });
+
+  it("still holds the restrictions the control set names", () => {
+    const kept = new Set(stored.filter(c => c.change_type === "restriction").map(c => c.vendor));
+    for (const vendor of ["Firebase", "Postman", "Netlify", "Google Gemini API", "GitHub Copilot"]) {
+      assert.ok(kept.has(vendor), `${vendor} keeps its restriction record`);
+    }
+    assert.strictEqual(stored.filter(c => c.change_type === "record_corrected").length, 2);
+  });
+
+  it("is not vacuous — the population is large enough to have caught the seven", () => {
+    assert.ok(stored.filter(c => c.change_type === "restriction").length >= 10);
+  });
+});

--- a/test/vendor-verdict.test.ts
+++ b/test/vendor-verdict.test.ts
@@ -12,7 +12,7 @@ import {
   vendorVerdictWord,
   type VendorVerdictInput,
 } from "../dist/vendor-verdict.js";
-import { enrichOffers, loadDealChanges, loadOffers, vendorRiskAssessment, classifyStability } from "../dist/data.js";
+import { CHANGE_DIRECTION, enrichOffers, loadDealChanges, loadOffers, vendorRiskAssessment, classifyStability } from "../dist/data.js";
 import { vendorSlugMap } from "../dist/vendor-slug.js";
 import { levelWithheldReason } from "../dist/source-check.js";
 import type { DealChange, RiskCause } from "../dist/types.js";
@@ -23,6 +23,7 @@ const REPO = path.join(__dirname, "..");
 const STABILITY_SCALE_WORDS = /\b(volatile|improving)\b|on our watch list/i;
 const OTHER_SCALE_ON_A_SURFACE_THAT_EMBEDS_SUMMARIES = /\bvolatile\b|on our watch list/i;
 const COUNT_AS_EVIDENCE = /\b\d+ pricing changes? recorded/;
+const CLAIMS_A_NARROWING = /(?:One recorded [^.]*|(?<!None of the )\d+ recorded changes) narrowed the terms/;
 
 function change(over: Partial<DealChange> = {}): DealChange {
   return {
@@ -133,6 +134,43 @@ describe("vendor verdict — a stable rating reports direction, not volume", () 
       change({ change_type: "rebranded", date: "2026-03-01" }),
     ];
     assert.strictEqual(narrowingSentence(changes), "None of the 3 recorded changes narrowed the terms.");
+  });
+
+  it("says what a record that repairs our own entry is, rather than counting it as a change", () => {
+    const changes = [change({ change_type: "record_corrected", date: "2026-03-22" })];
+    assert.strictEqual(
+      narrowingSentence(changes),
+      "The one record we hold corrects our own earlier entry rather than reporting a change the vendor made.",
+    );
+    assert.doesNotMatch(narrowingSentence(changes), /narrowed the terms/);
+    assert.doesNotMatch(vendorVerdictSentence(input({ changes })), /zero pricing changes recorded/);
+  });
+
+  it("says so for every repair when we hold nothing else", () => {
+    const changes = [
+      change({ change_type: "record_corrected", date: "2026-03-22" }),
+      change({ change_type: "record_corrected", date: "2026-03-21" }),
+    ];
+    assert.strictEqual(
+      narrowingSentence(changes),
+      "All 2 records we hold correct our own earlier entries rather than reporting changes the vendor made.",
+    );
+  });
+
+  it("leaves a repair out of both sides of the narrowing count", () => {
+    const changes = [
+      change({ change_type: "limits_increased", date: "2026-01-01" }),
+      change({ change_type: "limits_increased", date: "2025-01-22" }),
+      change({ change_type: "record_corrected", date: "2026-03-21" }),
+      change({ change_type: "restriction", date: "2026-08-28" }),
+    ];
+    assert.strictEqual(
+      narrowingSentence(changes),
+      "One recorded restriction narrowed the terms, on 2026-08-28.",
+    );
+    assert.doesNotMatch(narrowingSentence(changes), /2 recorded changes narrowed/);
+    const noNarrowing = changes.filter(c => c.change_type !== "restriction");
+    assert.strictEqual(narrowingSentence(noNarrowing), "None of the 2 recorded changes narrowed the terms.");
   });
 
   it("never reaches for the second scale's vocabulary", () => {
@@ -371,6 +409,43 @@ describe("vendor verdict — as rendered", () => {
     };
     await Promise.all(Array.from({ length: 12 }, worker));
     assert.deepStrictEqual(wrong.slice(0, 20), [], `vendor routes whose FAQ contradicts their badge:\n${wrong.slice(0, 20).join("\n")}`);
+  });
+
+  it("names a narrowing only where a record of the vendor's own establishes one", async () => {
+    const rows = vendorRows().filter(r => r.changes.length > 0);
+    const wrong: string[] = [];
+    let index = 0;
+    const worker = async () => {
+      while (index < rows.length) {
+        const row = rows[index++];
+        const html = await get(`/vendor/${row.slug}`);
+        const verdict = verdictParagraph(html);
+        const narrowing = row.changes.filter(c => CHANGE_DIRECTION[c.change_type] === "negative");
+        if (CLAIMS_A_NARROWING.test(verdict) && narrowing.length === 0) {
+          wrong.push(`${row.slug}: names a narrowing over ${row.changes.length} record(s), none of which point down`);
+        }
+        if (row.changes.every(c => c.change_type === "record_corrected")) {
+          if (!/corrects? our own earlier entr/.test(verdict)) {
+            wrong.push(`${row.slug}: holds only repairs to our own entries and does not say so — ${verdict}`);
+          }
+          if (CLAIMS_A_NARROWING.test(verdict) || /pricing changes? recorded/.test(verdict)) {
+            wrong.push(`${row.slug}: renders a repair to our own entry as a change the vendor made — ${verdict}`);
+          }
+        }
+      }
+    };
+    await Promise.all(Array.from({ length: 12 }, worker));
+    assert.deepStrictEqual(wrong.slice(0, 20), [], `vendor routes claiming a narrowing they cannot show:\n${wrong.slice(0, 20).join("\n")}`);
+  });
+
+  it("counts one narrowing on the route that carried a repair as a second", async () => {
+    const digitalocean = verdictParagraph(await get("/vendor/digitalocean"));
+    assert.match(digitalocean, /One recorded restriction narrowed the terms/);
+    assert.doesNotMatch(digitalocean, /2 recorded changes narrowed the terms/);
+
+    const neo4j = verdictParagraph(await get("/vendor/neo4j-auradb"));
+    assert.match(neo4j, /The one record we hold corrects our own earlier entry rather than reporting a change the vendor made\./);
+    assert.doesNotMatch(neo4j, /narrowed the terms/);
   });
 
   it("resolves the four routes that rendered a green badge over a negative verdict", async () => {


### PR DESCRIPTION
Refs #1145.

`restriction` is where a change lands when the free tier got worse in a way the detector cannot quantify. Nothing checked that it did. Since #1144 the vendor page names the record — *"One recorded restriction narrowed the terms"* — so **7 of the 17 stored restrictions were making a claim they cannot support, all 7 on production**.

## The rules

Four, each with a named test in the issue, applied both at the gate and over the stored log.

**AC-1 — a summary that reports nothing moved.** `reportsNoNarrowing` fires when the summary says the free tier is still standing (or that only the wording changed) **and** no clause of it states a term that moved. `testingbot.com` published *"One recorded restriction narrowed the terms"* four lines above its own summary reading *"The free tier is still offered. The description is less specific."*

**AC-2 — no baseline to have narrowed from.** A detector-written record's `previous_state` is the offer's stored description; `refusalHolds` already keys on that identity. Where that description states no price, no named tier and no allowance, there is nothing for the terms to have moved from. `debugmail.io`'s baseline was *"Easy to use testing mail server for developers"*.

The rule is scoped to records the detector wrote. A hand-written `previous_state` is a deliberate terms snapshot, and four of the ten genuine restrictions state their terms qualitatively — Netlify's *"Only Netlify dashboard users counted as billable seats"* carries no figure and is a real baseline. `statesTerms` is sufficient, not necessary, so applying it as a refusal to human-written records would have refused four true records. A test asserts both directions on the same fixture.

**AC-3 — one allowance under two names.** New `scripts/unit-aliases.js` reads the equivalences a page declares — `1 X = 1 Y`, and `expansion (ABBR)` in both orders, guarded by whether the phrase's initials actually spell the abbreviation. `measuresTheSameThing` consults them, and a comparison records whether it needed one.

Refusal requires **at least one aliased pair** plus every compared quantity holding still. Without that requirement the rule refuses the Gemini 2026-04-08 record, because `Gemini 2.5 Pro` reads as the quantity `2.5 pro` on both sides — the model-name-as-quantity defect from #1121. The alias requirement is also what the AC asks for: the equivalence has to come from the page.

The repair run fetched `geocod.io/pricing` and found exactly one equivalence on it: `1 address or coordinate lookup = 1 credit`. Under it, `2,500 lookups/day` and `2,500 credits per day` are the same allowance and the record measures no narrowing.

`definedEquivalences` is deliberately standalone and returns phrase pairs rather than a matcher, so the same reader can serve the alias problem elsewhere.

**AC-4 — a repair to our own entry.** New `change_type: record_corrected`, direction neutral, never a risk input. `correctsOurOwnRecord` requires a clause that names our own entry **and** says it was wrong, in the same clause — Neo4j AuraDB's *"previous entry incorrectly reduced limits"*, DigitalOcean's *"Previous listing incorrectly included '1 basic cluster'"*.

`narrowingSentence` takes corrections out of **both** sides of the count, so a page holding only repairs does not fall through to `It's stable — zero pricing changes recorded` either. `/vendor/neo4j-auradb` now reads *"The one record we hold corrects our own earlier entry rather than reporting a change the vendor made."*

## The corpus pass

`scripts/repair-1145.mjs` applies the rules to the stored log, fetching each record's cited page for the alias check. **17 records in: 2 reclassified, 5 refused, 10 kept** — the issue's partition exactly. The refused records keep their full evidence in `data/change_refusals.json`.

## What changed on the site

Every `/vendor/:slug` route in `sitemap-vendors.xml`, dumped on `main` and on this branch:

| | |
|---|---|
| routes | 1,572 |
| byte-identical | **1,565** |
| verdict changed | 7 |
| badge changed | **0** |
| warnings removed | 6 |
| warnings added | **0** |

`/vendor/digitalocean` goes from *"2 recorded changes narrowed the terms"* to *"One recorded restriction narrowed the terms"*. The other six drop a narrowing claim they could not show.

**The cost, stated plainly.** Three of the refused records — houndci, tickgit, debugmail — had a `current_state` naming a real limit on the vendor's own page (*"Hound is free for public repos! Private repository plans start at $29/month"*). Refusing them removes that warning, and those three routes now read `It's stable — zero pricing changes recorded`, which understates what we refused. That sentence is #1139's subject and those three join its population; the evidence is preserved in the refusals file, which is where #1139 reads from. The two remaining refusals — Geocodio and testingbot — are pages where zero recorded changes is simply correct.

## Verification

- **Suite:** 2488 pass, 0 fail (2458 before; 30 new).
- **Mutation:** `scripts/mutate-1145.sh` — **17/17 killed**. Two survivors on the first pass were fixtures agreeing for the wrong reason: the "still free but a term moved" case never triggered `reportsSomethingStillFree` at all, and the "two halves in different clauses" case had no our-own-entry frame anywhere in it. Both fixtures now assert the precondition before the property. A third — replacing `narrowingChanges(byTheVendor)` with `narrowingChanges(changes)` — is equivalent while `record_corrected` maps to neutral, so it was replaced with the denominator mutation, which the census kills on 13 assertions.
- `scripts/check-mutation-targets.mjs`: **266/266** across 27 scripts. `mutate-1136.sh` had a target this branch moved; repointed.
- **Rendered census in CI**, over every vendor route: no route claims a narrowing without a record of the vendor's own that points down, and any route holding only repairs says so and says nothing about pricing changes.
- **Corpus guard in CI**: no stored `restriction` survives that its own rule refuses, and none corrects our own entry.
- **E2E** against a spawned `dist/serve.js` (200s, not 301s): verdicts read as above. Over a real MCP session — `initialize` → `notifications/initialized` → `tools/call` — `track_changes` returns **2** for `record_corrected` (Neo4j, DigitalOcean) and **10** for `restriction`, matching the control set. `/api/changes?type=record_corrected` returns the same 2.
- **Screenshots** of `/vendor/neo4j-auradb` and `/vendor/digitalocean`: the repair page carries a green badge, no warning banner and no narrowing claim; the control keeps both its narrowing clause and its warning.