### PR TITLE
Demote a vendor when the deprecated thing is the product we list (#1147)

### DIFF
--- a/scripts/census-1147.mjs
+++ b/scripts/census-1147.mjs
@@ -1,0 +1,50 @@
+import fs from "node:fs";
+
+const base = process.env.BASE ?? "http://127.0.0.1:8791";
+const out = process.argv[2];
+if (!out) {
+  console.error("usage: BASE=http://127.0.0.1:PORT node scripts/census-1147.mjs <out.json>");
+  process.exit(2);
+}
+
+const offers = JSON.parse(fs.readFileSync(new URL("../data/index.json", import.meta.url), "utf8")).offers;
+const slug = (v) => v.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-|-$/g, "");
+const slugs = [...new Set(offers.map((o) => slug(o.vendor)))].sort();
+
+const capture = (html) => {
+  const h1 = html.match(/<h1>([\s\S]*?)<\/h1>/)?.[1] ?? "";
+  const badge = h1.match(/class="risk-badge"[^>]*>([^<]*)</)?.[1] ?? "";
+  const verdict = html.match(/<div class="quick-verdict">\s*<p>([\s\S]*?)<\/p>/)?.[1] ?? "";
+  const pageMeta = html.match(/<p class="page-meta">([\s\S]*?)<\/p>/)?.[1] ?? "";
+  const metaDesc = html.match(/<meta name="description" content="([^"]*)"/)?.[1] ?? "";
+  const cards = [...html.matchAll(/<div class="detail-label">([\s\S]*?)<\/div>\s*<div class="detail-value"[^>]*>([\s\S]*?)<\/div>/g)]
+    .map((m) => `${m[1].trim()}=${m[2].replace(/<[^>]+>/g, "").trim()}`);
+  const growth = /class="section growth-section"/.test(html);
+  const cause = html.match(/<p class="risk-cause-line"[\s\S]*?<\/p>/)?.[0]?.replace(/<[^>]+>/g, " ").replace(/\s+/g, " ").trim() ?? "";
+  const compareCell = html.match(/<tr class="current-vendor-row">[\s\S]*?<\/tr>/)?.[0]?.replace(/<[^>]+>/g, "|").replace(/\|+/g, "|").trim() ?? "";
+  return {
+    badge,
+    verdict: verdict.replace(/<[^>]+>/g, "").replace(/\s+/g, " ").trim(),
+    pageMeta: pageMeta.replace(/<[^>]+>/g, "").replace(/\s+/g, " ").trim(),
+    metaDesc,
+    cards,
+    growth,
+    cause,
+    compareCell,
+    bytes: html.length,
+  };
+};
+
+const result = {};
+let done = 0;
+for (const s of slugs) {
+  const res = await fetch(`${base}/vendor/${s}`, { redirect: "manual" });
+  if (res.status !== 200) {
+    result[s] = { status: res.status };
+    continue;
+  }
+  result[s] = capture(await res.text());
+  if (++done % 200 === 0) console.error(`  ${done}/${slugs.length}`);
+}
+fs.writeFileSync(out, JSON.stringify(result, null, 1));
+console.error(`captured ${Object.keys(result).length} routes -> ${out}`);

--- a/scripts/mutate-1143.sh
+++ b/scripts/mutate-1143.sh
@@ -136,7 +136,7 @@ m_the_cause_is_reported_as_a_count() {
   py <<'PY'
 p = "src/vendor-verdict.ts"
 s = open(p).read()
-s = s.replace('    return `We rate it ${level} — one recorded ${changeKindNoun(input.cause.change_type)}, ${changeDateClause(input.cause)}.`;',
+s = s.replace('    return `We rate it ${level} — one recorded ${changeKindNoun(input.cause.change_type)}, ${changeDateClause(input.cause)}.${unconfirmed}`;',
               '    return `We rate it ${level} — ${input.changes.length} pricing changes recorded.`;')
 open(p, "w").write(s)
 PY
@@ -156,7 +156,7 @@ m_a_withheld_rating_is_published_as_a_word() {
   py <<'PY'
 p = "src/vendor-verdict.ts"
 s = open(p).read()
-s = s.replace('  if (input.levelWithheld) return null;\n  return publishedVendorLevel(input.level, input.cause);',
+s = s.replace('  if (withholdingDecides(input)) return null;\n  return publishedVendorLevel(input.level, input.cause);',
               '  return publishedVendorLevel(input.level, input.cause);')
 open(p, "w").write(s)
 PY

--- a/scripts/mutate-1147.sh
+++ b/scripts/mutate-1147.sh
@@ -1,0 +1,325 @@
+#!/usr/bin/env bash
+set -u
+
+REPO="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$REPO" || exit 1
+
+DEPRECATION="src/product-deprecation.ts"
+DATA="src/data.ts"
+VERDICT="src/vendor-verdict.ts"
+SERVE="src/serve.ts"
+BACKUP_DIR="$(mktemp -d)"
+cp "$DEPRECATION" "$BACKUP_DIR/product-deprecation.ts"
+cp "$DATA" "$BACKUP_DIR/data.ts"
+cp "$VERDICT" "$BACKUP_DIR/vendor-verdict.ts"
+cp "$SERVE" "$BACKUP_DIR/serve.ts"
+
+restore() {
+  cp "$BACKUP_DIR/product-deprecation.ts" "$DEPRECATION"
+  cp "$BACKUP_DIR/data.ts" "$DATA"
+  cp "$BACKUP_DIR/vendor-verdict.ts" "$VERDICT"
+  cp "$BACKUP_DIR/serve.ts" "$SERVE"
+}
+trap restore EXIT
+
+killed=0
+survived=0
+TESTS="test/product-deprecation.test.ts test/risk-badge.test.ts test/vendor-verdict.test.ts test/mcp-risk-indicators.test.ts"
+
+run_mutation() {
+  local name="$1"
+  shift
+  echo "=== $name"
+  restore
+  "$@"
+  if diff -q "$BACKUP_DIR/product-deprecation.ts" "$DEPRECATION" > /dev/null \
+    && diff -q "$BACKUP_DIR/data.ts" "$DATA" > /dev/null \
+    && diff -q "$BACKUP_DIR/vendor-verdict.ts" "$VERDICT" > /dev/null \
+    && diff -q "$BACKUP_DIR/serve.ts" "$SERVE" > /dev/null; then
+    echo "    NOT APPLIED: the mutation changed no file, so it proves nothing"
+    survived=$((survived + 1))
+    return
+  fi
+  if ! npm run build > /tmp/mutate-1147-build.log 2>&1; then
+    echo "    KILLED (does not compile)"
+    killed=$((killed + 1))
+    return
+  fi
+  if timeout 600 npx tsx --test $TESTS > /tmp/mutate-1147-test.log 2>&1; then
+    echo "    SURVIVED"
+    survived=$((survived + 1))
+  else
+    echo "    KILLED: $(grep -c '✖ ' /tmp/mutate-1147-test.log) failing assertion(s)"
+    grep '✖ ' /tmp/mutate-1147-test.log | head -4
+    killed=$((killed + 1))
+  fi
+}
+
+py() { python3 - "$@"; }
+
+m_every_deprecation_ends_the_listed_product() {
+  py <<'PY'
+p = "src/product-deprecation.ts"
+s = open(p).read()
+s = s.replace("  return productNamedApartFromVendor(reading.subject, change.vendor).length === 0;",
+              "  return true;")
+open(p, "w").write(s)
+PY
+}
+
+m_no_deprecation_ends_the_listed_product() {
+  py <<'PY'
+p = "src/product-deprecation.ts"
+s = open(p).read()
+s = s.replace("  return productNamedApartFromVendor(reading.subject, change.vendor).length === 0;",
+              "  return false;")
+open(p, "w").write(s)
+PY
+}
+
+m_a_generic_noun_is_a_product_name() {
+  py <<'PY'
+p = "src/product-deprecation.ts"
+s = open(p).read()
+s = s.replace("  return words(named).filter(w => !fromVendor.has(w) && !GENERIC_WORDS.has(w));",
+              "  return words(named).filter(w => !fromVendor.has(w));")
+open(p, "w").write(s)
+PY
+}
+
+m_the_vendors_own_name_counts_against_it() {
+  py <<'PY'
+p = "src/product-deprecation.ts"
+s = open(p).read()
+s = s.replace("  return words(named).filter(w => !fromVendor.has(w) && !GENERIC_WORDS.has(w));",
+              "  return words(named).filter(w => !GENERIC_WORDS.has(w));")
+open(p, "w").write(s)
+PY
+}
+
+m_any_trailing_word_that_reads_as_a_tld_is_dropped() {
+  py <<'PY'
+p = "src/product-deprecation.ts"
+s = open(p).read()
+s = s.replace('  const suffix = (vendor ?? "").match(/\\.([a-z]{2,})\\s*$/i)?.[1]?.toLowerCase();\n'
+              '  if (parts.length > 1 && suffix && TLDS.has(suffix) && parts[parts.length - 1] === suffix) parts.pop();',
+              '  if (parts.length > 1 && TLDS.has(parts[parts.length - 1])) parts.pop();')
+open(p, "w").write(s)
+PY
+}
+
+m_a_rename_aside_names_a_second_product() {
+  py <<'PY'
+p = "src/product-deprecation.ts"
+s = open(p).read()
+s = s.replace('  const named = (subject ?? "").replace(RENAME_ASIDE, " ");',
+              '  const named = subject ?? "";')
+open(p, "w").write(s)
+PY
+}
+
+m_the_subject_is_everything_before_the_predicate() {
+  py <<'PY'
+p = "src/product-deprecation.ts"
+s = open(p).read()
+s = s.replace('  for (const sentence of sentences(text ?? "")) {\n'
+              '    const match = sentence.match(PREDICATE);\n'
+              '    if (!match || match.index === undefined) continue;\n'
+              '    return { subject: sentence.slice(0, match.index).trim(), predicate: match[0], sentence };\n'
+              '  }\n'
+              '  return null;',
+              '  const whole = text ?? "";\n'
+              '  const match = whole.match(PREDICATE);\n'
+              '  if (!match || match.index === undefined) return null;\n'
+              '  return { subject: whole.slice(0, match.index).trim(), predicate: match[0], sentence: whole };')
+open(p, "w").write(s)
+PY
+}
+
+m_a_shutdown_of_the_listed_product_only_cautions() {
+  py <<'PY'
+p = "src/data.ts"
+s = open(p).read()
+s = s.replace('    return deprecationEndsTheListedProduct(change) ? "risky" : null;',
+              '    return deprecationEndsTheListedProduct(change) ? "caution" : null;')
+open(p, "w").write(s)
+PY
+}
+
+m_the_demotion_table_is_the_whole_answer() {
+  py <<'PY'
+p = "src/data.ts"
+s = open(p).read()
+s = s.replace('  if (change.change_type === PRODUCT_DEPRECATED) {\n'
+              '    return deprecationEndsTheListedProduct(change) ? "risky" : null;\n'
+              '  }\n'
+              '  return null;',
+              '  return null;')
+open(p, "w").write(s)
+PY
+}
+
+m_every_deprecation_is_severe() {
+  py <<'PY'
+p = "src/data.ts"
+s = open(p).read()
+s = s.replace("  return VOLATILE_TYPES.has(change.change_type) && demotionForChange(change) !== null;",
+              "  return VOLATILE_TYPES.has(change.change_type);")
+open(p, "w").write(s)
+PY
+}
+
+m_two_narrowings_are_volatile_whatever_the_risk_scale_holds() {
+  py <<'PY'
+p = "src/data.ts"
+s = open(p).read()
+s = s.replace("  if (hasVolatile || (negativeCount >= 2 && riskScaleActs)) return \"volatile\";",
+              "  if (hasVolatile || negativeCount >= 2) return \"volatile\";")
+open(p, "w").write(s)
+PY
+}
+
+m_only_a_single_narrowing_is_worth_watching() {
+  py <<'PY'
+p = "src/data.ts"
+s = open(p).read()
+s = s.replace("  if (negativeCount >= 1) return \"watch\";",
+              "  if (negativeCount === 1) return \"watch\";")
+open(p, "w").write(s)
+PY
+}
+
+m_any_date_in_the_record_is_the_shutdown_date() {
+  py <<'PY'
+p = "src/product-deprecation.ts"
+s = open(p).read()
+s = s.replace("    const tail = sentence.slice(match.index + match[0].length);",
+              "    const tail = sentence;")
+open(p, "w").write(s)
+PY
+}
+
+m_the_first_date_stated_is_the_shutdown_date() {
+  py <<'PY'
+p = "src/product-deprecation.ts"
+s = open(p).read()
+s = s.replace("  return dates.sort().pop() ?? null;",
+              "  return dates.sort().shift() ?? null;")
+open(p, "w").write(s)
+PY
+}
+
+m_a_date_belongs_to_any_deprecation_record() {
+  py <<'PY'
+p = "src/product-deprecation.ts"
+s = open(p).read()
+s = s.replace("  if (!deprecationEndsTheListedProduct(change)) return null;\n  const dates = [",
+              "  const dates = [")
+open(p, "w").write(s)
+PY
+}
+
+m_an_announced_shutdown_counts_before_its_date() {
+  py <<'PY'
+p = "src/product-deprecation.ts"
+s = open(p).read()
+s = s.replace("    if (!date || date > today) continue;",
+              "    if (!date) continue;")
+open(p, "w").write(s)
+PY
+}
+
+m_a_discontinued_product_keeps_its_verified_stamp() {
+  py <<'PY'
+p = "src/serve.ts"
+s = open(p).read()
+s = s.replace('  const verifiedSentence = discontinuedOn\n'
+              '    ? ` Discontinued ${discontinuedOn}.`\n'
+              '    : enriched.link_unreachable ? "" : ` Verified ${verifiedMonth}.`;',
+              '  const verifiedSentence = enriched.link_unreachable ? "" : ` Verified ${verifiedMonth}.`;')
+open(p, "w").write(s)
+PY
+}
+
+m_a_discontinued_product_is_still_best_for_a_workload() {
+  py <<'PY'
+p = "src/serve.ts"
+s = open(p).read()
+s = s.replace('  const verdictLine3 = discontinuedOn\n'
+              '    ? `${vendorName} was discontinued on ${discontinuedOn}, so it is not a current option${alternatives.length > 0 ? ` — the ${alternatives.length} alternatives below are replacements` : ""}.`\n'
+              '    : alternatives.length > 0 && !levelWithheld',
+              '  const verdictLine3 = alternatives.length > 0 && !levelWithheld')
+open(p, "w").write(s)
+PY
+}
+
+m_a_reader_can_still_outgrow_a_product_that_has_ended() {
+  py <<'PY'
+p = "src/serve.ts"
+s = open(p).read()
+s = s.replace("  const growthPathHtml = growthBullets.length > 0 && !discontinuedOn ? `",
+              "  const growthPathHtml = growthBullets.length > 0 ? `")
+open(p, "w").write(s)
+PY
+}
+
+m_the_detail_card_still_reads_verified() {
+  py <<'PY'
+p = "src/serve.ts"
+s = open(p).read()
+s = s.replace('<div class="detail-label">${discontinuedOn ? "Discontinued" : linkUnreachable ? "Link last reachable" : "Verified"}</div>',
+              '<div class="detail-label">${linkUnreachable ? "Link last reachable" : "Verified"}</div>')
+open(p, "w").write(s)
+PY
+}
+
+m_withholding_outranks_a_record_we_hold() {
+  py <<'PY'
+p = "src/vendor-verdict.ts"
+s = open(p).read()
+s = s.replace('  return input.levelWithheld !== null && publishedVendorLevel(input.level, input.cause) === "stable";',
+              '  return input.levelWithheld !== null;')
+open(p, "w").write(s)
+PY
+}
+
+m_a_rating_over_a_page_we_cannot_read_says_so_nowhere() {
+  py <<'PY'
+p = "src/vendor-verdict.ts"
+s = open(p).read()
+s = s.replace('    const unconfirmed = input.levelWithheld\n'
+              '      ? ` ${capitalise(withheldLevelClause(input.levelWithheld, input.unconfirmableSince))}, so we cannot confirm the terms above.`\n'
+              '      : "";',
+              '    const unconfirmed = "";')
+open(p, "w").write(s)
+PY
+}
+
+run_mutation "every deprecation ends the listed product" m_every_deprecation_ends_the_listed_product
+run_mutation "no deprecation ends the listed product" m_no_deprecation_ends_the_listed_product
+run_mutation "a generic noun is a product name" m_a_generic_noun_is_a_product_name
+run_mutation "the vendor's own name counts against it" m_the_vendors_own_name_counts_against_it
+run_mutation "any trailing word that reads as a TLD is dropped" m_any_trailing_word_that_reads_as_a_tld_is_dropped
+run_mutation "a rename aside names a second product" m_a_rename_aside_names_a_second_product
+run_mutation "the subject is everything before the predicate" m_the_subject_is_everything_before_the_predicate
+run_mutation "a shutdown of the listed product only cautions" m_a_shutdown_of_the_listed_product_only_cautions
+run_mutation "the demotion table is the whole answer" m_the_demotion_table_is_the_whole_answer
+run_mutation "every deprecation is severe" m_every_deprecation_is_severe
+run_mutation "two narrowings are volatile whatever the risk scale holds" m_two_narrowings_are_volatile_whatever_the_risk_scale_holds
+run_mutation "only a single narrowing is worth watching" m_only_a_single_narrowing_is_worth_watching
+run_mutation "any date in the record is the shutdown date" m_any_date_in_the_record_is_the_shutdown_date
+run_mutation "the first date stated is the shutdown date" m_the_first_date_stated_is_the_shutdown_date
+run_mutation "a date belongs to any deprecation record" m_a_date_belongs_to_any_deprecation_record
+run_mutation "an announced shutdown counts before its date" m_an_announced_shutdown_counts_before_its_date
+run_mutation "a discontinued product keeps its verified stamp" m_a_discontinued_product_keeps_its_verified_stamp
+run_mutation "a discontinued product is still best for a workload" m_a_discontinued_product_is_still_best_for_a_workload
+run_mutation "a reader can still outgrow a product that has ended" m_a_reader_can_still_outgrow_a_product_that_has_ended
+run_mutation "the detail card still reads verified" m_the_detail_card_still_reads_verified
+run_mutation "withholding outranks a record we hold" m_withholding_outranks_a_record_we_hold
+run_mutation "a rating over a page we cannot read says so nowhere" m_a_rating_over_a_page_we_cannot_read_says_so_nowhere
+
+restore
+npm run build > /dev/null 2>&1
+echo
+echo "killed $killed, survived $survived"
+[ "$survived" -eq 0 ]

--- a/src/data.ts
+++ b/src/data.ts
@@ -9,6 +9,7 @@ import { quarantineSummary, resetVerificationStateCache, type QuarantineSummary 
 import { cannotVouchForLevel, levelWithheldReason, withheldLevelSentence } from "./source-check.js";
 import { filterAlternatives } from "./product-role.js";
 import { DATE_SOURCES, isEventDated, changeDateClause } from "./change-dates.js";
+import { PRODUCT_DEPRECATED, deprecationEndsTheListedProduct } from "./product-deprecation.js";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const INDEX_PATH =
@@ -279,11 +280,35 @@ export const NEGATIVE_CHANGE_TYPES = directionSet("negative");
 export const POSITIVE_CHANGE_TYPES = directionSet("positive");
 
 /** Severity, not direction: the negatives that end a free tier outright. */
-const VOLATILE_TYPES = new Set([
+export const VOLATILE_TYPES = new Set([
   "free_tier_removed",
   "open_source_killed",
   "product_deprecated",
 ]);
+
+export const SEVERE_TYPES_WITHOUT_FLAT_DEMOTION: Record<string, string> = {
+  product_deprecated:
+    "Whether a deprecation is severe is a property of the record, not of the type: it demotes when " +
+    "the record says the product we list is the thing going away, and does not when a vendor retires " +
+    "one of its other services. demotionForChange decides per record.",
+};
+
+export function demotionForChange(
+  change: Pick<DealChange, "change_type" | "vendor" | "summary">,
+): "risky" | "caution" | null {
+  const flat = RISK_DEMOTION[change.change_type];
+  if (flat) return flat;
+  if (change.change_type === PRODUCT_DEPRECATED) {
+    return deprecationEndsTheListedProduct(change) ? "risky" : null;
+  }
+  return null;
+}
+
+export function isSevereChange(
+  change: Pick<DealChange, "change_type" | "vendor" | "summary">,
+): boolean {
+  return VOLATILE_TYPES.has(change.change_type) && demotionForChange(change) !== null;
+}
 
 /** The two the risk scale treats as severe. Exported so no caller inlines them. */
 export const SEVERE_CHANGE_TYPES = new Set(["free_tier_removed", "open_source_killed"]);
@@ -294,18 +319,19 @@ const POSITIVE_STABILITY_TYPES = POSITIVE_CHANGE_TYPES;
 export function classifyStability(vendorChanges: DealChange[]): StabilityClass {
   if (vendorChanges.length === 0) return "stable";
 
-  const hasVolatile = vendorChanges.some(c => VOLATILE_TYPES.has(c.change_type));
+  const hasVolatile = vendorChanges.some(isSevereChange);
   const negativeCount = vendorChanges.filter(c => NEGATIVE_STABILITY_TYPES.has(c.change_type)).length;
   const positiveCount = vendorChanges.filter(c => POSITIVE_STABILITY_TYPES.has(c.change_type)).length;
+  const riskScaleActs = vendorChanges.some(c => demotionForChange(c) !== null);
 
-  // Volatile: free tier removed, OSS killed, product deprecated, or multiple negative changes
-  if (hasVolatile || negativeCount >= 2) return "volatile";
+  // Volatile: a severe change, or multiple negative changes the risk scale acts on
+  if (hasVolatile || (negativeCount >= 2 && riskScaleActs)) return "volatile";
 
   // Improving: only positive changes (no negative)
   if (positiveCount > 0 && negativeCount === 0) return "improving";
 
-  // Watch: one negative change
-  if (negativeCount === 1) return "watch";
+  // Watch: at least one negative change
+  if (negativeCount >= 1) return "watch";
 
   // No negative or positive (e.g. only pricing_model_change) = stable
   return "stable";
@@ -701,7 +727,7 @@ export function vendorRiskAssessment(vendorChanges: DealChange[], nowMs: number 
 
   let best: { level: "caution" | "risky"; cause: DealChange } | null = null;
   for (const c of vendorChanges) {
-    const demotion = RISK_DEMOTION[c.change_type];
+    const demotion = demotionForChange(c);
     if (!demotion) continue;
     // A severe change ages into `caution`, never into `stable`. We still hold
     // the record, and `stable` is itself a published claim — SendGrid's free

--- a/src/product-deprecation.ts
+++ b/src/product-deprecation.ts
@@ -1,0 +1,171 @@
+import type { DealChange } from "./types.js";
+
+export const PRODUCT_DEPRECATED = "product_deprecated";
+
+const PREDICATE = new RegExp(
+  [
+    "\\b(?:is|are|was|were)\\s+(?:being\\s+|now\\s+)?(?:shut\\s?down|shutting\\s+down|deprecated|discontinued|sunset|sunsetting|retired|closed)\\b",
+    "\\bwill\\s+(?:be\\s+)?(?:shut\\s?down|shutting\\s+down|deprecated|discontinued|sunset|retired|close)\\b",
+    "\\b(?:shut(?:ting|s)?\\s+down|shutdown)\\b",
+    "\\bbeing\\s+(?:sunset|deprecated|discontinued|retired|phased\\s+out|wound\\s+down)\\b",
+    "\\bdeprecat(?:ed|ion|ing)\\b",
+    "\\bdiscontinu(?:ed|ing|ation)\\b",
+    "\\bsunset(?:ting|s)?\\b",
+    "\\bretir(?:ed|ement|ing)\\b",
+    "\\bphased\\s+out\\b",
+    "\\bwind(?:ing|s)?\\s+down\\b",
+    "\\bend\\s+of\\s+(?:support|availability|life|sale|service)\\b",
+    "\\bclosed\\s+to\\s+new\\s+customers\\b",
+    "\\bno\\s+longer\\s+(?:maintained|supported|available|being\\s+developed)\\b",
+  ].join("|"),
+  "i",
+);
+
+const GENERIC_WORDS = new Set([
+  "the", "a", "an", "this", "that", "these", "those", "its", "their", "our", "his", "her",
+  "and", "or", "of", "for", "to", "in", "on", "at", "by", "with", "from", "as", "than",
+  "is", "are", "was", "were", "be", "been", "being", "will", "would", "has", "have", "had",
+  "it", "they", "we", "you", "all", "both", "now", "still", "also", "only", "then",
+  "service", "services", "platform", "product", "products", "offering", "offerings",
+  "tier", "tiers", "plan", "plans", "company", "business", "tool", "tools",
+  "site", "website", "websites", "software", "free", "paid",
+]);
+
+const TLDS = new Set([
+  "com", "io", "dev", "sh", "ai", "co", "net", "org", "app", "cloud", "xyz", "gg", "so", "tech",
+]);
+
+const RENAME_ASIDE = /\(\s*(?:formerly|previously|forme?rly\s+known\s+as|also\s+known\s+as|f\/k\/a|fka|aka|née|nee|now)\b[^)]*\)/gi;
+
+const MONTHS = [
+  "january", "february", "march", "april", "may", "june",
+  "july", "august", "september", "october", "november", "december",
+];
+
+const MONTH_NAMES = MONTHS.join("|");
+
+const DATE_PATTERNS = [
+  new RegExp(`\\b(${MONTH_NAMES})\\s+(\\d{1,2})(?:st|nd|rd|th)?,?\\s+(\\d{4})\\b`, "gi"),
+  new RegExp(`\\b(\\d{1,2})(?:st|nd|rd|th)?\\s+(${MONTH_NAMES}),?\\s+(\\d{4})\\b`, "gi"),
+  /\b(\d{4})-(\d{2})-(\d{2})\b/g,
+];
+
+function words(text: string): string[] {
+  return (text ?? "").toLowerCase().replace(/[^a-z0-9]+/g, " ").trim().split(/\s+/).filter(Boolean);
+}
+
+export function vendorWords(vendor: string): Set<string> {
+  const parts = words(vendor);
+  const suffix = (vendor ?? "").match(/\.([a-z]{2,})\s*$/i)?.[1]?.toLowerCase();
+  if (parts.length > 1 && suffix && TLDS.has(suffix) && parts[parts.length - 1] === suffix) parts.pop();
+  return new Set(parts);
+}
+
+function sentences(text: string): string[] {
+  return (text ?? "").split(/(?<=[.!?])\s+/).filter(s => s.trim().length > 0);
+}
+
+export interface DeprecationReading {
+  subject: string;
+  predicate: string;
+  sentence: string;
+}
+
+export function readDeprecation(text: string): DeprecationReading | null {
+  for (const sentence of sentences(text ?? "")) {
+    const match = sentence.match(PREDICATE);
+    if (!match || match.index === undefined) continue;
+    return { subject: sentence.slice(0, match.index).trim(), predicate: match[0], sentence };
+  }
+  return null;
+}
+
+export function productNamedApartFromVendor(subject: string, vendor: string): string[] {
+  const fromVendor = vendorWords(vendor);
+  const named = (subject ?? "").replace(RENAME_ASIDE, " ");
+  return words(named).filter(w => !fromVendor.has(w) && !GENERIC_WORDS.has(w));
+}
+
+type DeprecationRecord = Pick<DealChange, "change_type" | "vendor" | "summary">;
+
+const endsTheListedProductCache = new WeakMap<object, boolean>();
+
+function decide(change: DeprecationRecord): boolean {
+  if (change.change_type !== PRODUCT_DEPRECATED) return false;
+  const reading = readDeprecation(change.summary ?? "");
+  if (!reading) return false;
+  return productNamedApartFromVendor(reading.subject, change.vendor).length === 0;
+}
+
+export function deprecationEndsTheListedProduct(change: DeprecationRecord): boolean {
+  const cached = endsTheListedProductCache.get(change as object);
+  if (cached !== undefined) return cached;
+  const decision = decide(change);
+  endsTheListedProductCache.set(change as object, decision);
+  return decision;
+}
+
+function isoFrom(match: RegExpExecArray, pattern: RegExp): string | null {
+  const source = pattern.source;
+  let year: number;
+  let month: number;
+  let day: number;
+  if (source.startsWith("\\b(\\d{4})")) {
+    year = Number(match[1]);
+    month = Number(match[2]);
+    day = Number(match[3]);
+  } else if (source.startsWith("\\b(january")) {
+    year = Number(match[3]);
+    month = MONTHS.indexOf(match[1].toLowerCase()) + 1;
+    day = Number(match[2]);
+  } else {
+    year = Number(match[3]);
+    month = MONTHS.indexOf(match[2].toLowerCase()) + 1;
+    day = Number(match[1]);
+  }
+  if (!year || !month || !day || month > 12 || day > 31) return null;
+  return `${year}-${String(month).padStart(2, "0")}-${String(day).padStart(2, "0")}`;
+}
+
+function datesAfterPredicate(text: string): string[] {
+  const found: string[] = [];
+  for (const sentence of sentences(text ?? "")) {
+    const match = sentence.match(PREDICATE);
+    if (!match || match.index === undefined) continue;
+    const tail = sentence.slice(match.index + match[0].length);
+    for (const pattern of DATE_PATTERNS) {
+      pattern.lastIndex = 0;
+      let hit: RegExpExecArray | null;
+      while ((hit = pattern.exec(tail)) !== null) {
+        const iso = isoFrom(hit, pattern);
+        if (iso) found.push(iso);
+      }
+    }
+  }
+  return found;
+}
+
+export function discontinuationDate(
+  change: Pick<DealChange, "change_type" | "vendor" | "summary" | "current_state">,
+): string | null {
+  if (!deprecationEndsTheListedProduct(change)) return null;
+  const dates = [
+    ...datesAfterPredicate(change.summary ?? ""),
+    ...datesAfterPredicate(change.current_state ?? ""),
+  ];
+  if (dates.length === 0) return null;
+  return dates.sort().pop() ?? null;
+}
+
+export function discontinuedOnOrBefore(
+  changes: Array<Pick<DealChange, "change_type" | "vendor" | "summary" | "current_state">>,
+  today: string,
+): string | null {
+  let latestPast: string | null = null;
+  for (const change of changes) {
+    const date = discontinuationDate(change);
+    if (!date || date > today) continue;
+    if (latestPast === null || date > latestPast) latestPast = date;
+  }
+  return latestPast;
+}

--- a/src/serve.ts
+++ b/src/serve.ts
@@ -35,6 +35,7 @@ import { linkifyVerdictBlocks, overdueReport, pageCompiledClause, pageDataProven
 import { faqPageJsonLd, type FaqItem } from "./faq-provenance.js";
 import { SSE_KEEPALIVE_FRAME, keepaliveIntervalMs, sessionRecoveryBody } from "./mcp-stream.js";
 import { ASSISTANTS_API_SHUTDOWN } from "./assistants-shutdown.js";
+import { discontinuedOnOrBefore } from "./product-deprecation.js";
 import { rankOffers, rankForListing, rotateListing, utcDate, CRITERIA_PATH, DEMOTE_ONLY_POLICY, DISCLOSURE_RATIONALE, TIE_BREAK_ALGORITHM, GATE_TABLE, DEMERIT_TABLE, NOT_FREE_TIER_RULES, TIME_LIMITED_TIER_RULES } from "./ranking.js";
 import type { RankedEntry, RankingResult } from "./ranking.js";
 import { verificationLedger, QUARANTINE_AFTER_FAILURES } from "./verification-state.js";
@@ -3755,6 +3756,8 @@ function buildVendorPage(slug: string): string | null {
     ? `  <p class="risk-cause-line" style="margin:.4rem 0 .6rem;font-size:.9rem;color:var(--text-muted)"><strong style="color:${riskColor}">Why ${riskLevel}:</strong> <span class="risk-cause-date" style="font-family:var(--mono)">${escHtmlServer(changeDateLabel(riskCause))}</span> &mdash; ${escHtmlServer(riskCause.summary)} <a href="#changes" style="white-space:nowrap">Full history &darr;</a></p>`
     : "";
 
+  const discontinuedOn = discontinuedOnOrBefore(vendorChanges, new Date().toISOString().slice(0, 10));
+
   const linkUnreachable = enriched.link_unreachable;
   const h1RiskBadge = enriched.risk_level === null || (linkUnreachable && riskLevel === "stable")
     ? ""
@@ -3796,7 +3799,9 @@ function buildVendorPage(slug: string): string | null {
     : `${vendorName} Pricing ${currentYear}: Plans, Costs & Free Alternatives | AgentDeals`;
   const descLimits = primary.description.slice(0, 100).replace(/\.\s.*$/, "");
   const verifiedMonth = (() => { const d = primary.verifiedDate.split("-"); const months = ["January","February","March","April","May","June","July","August","September","October","November","December"]; return `${months[parseInt(d[1],10)-1]} ${d[0]}`; })();
-  const verifiedSentence = enriched.link_unreachable ? "" : ` Verified ${verifiedMonth}.`;
+  const verifiedSentence = discontinuedOn
+    ? ` Discontinued ${discontinuedOn}.`
+    : enriched.link_unreachable ? "" : ` Verified ${verifiedMonth}.`;
   const metaDesc = hasFree
     ? `${vendorName} free tier includes ${descLimits}.${verifiedSentence} Compare with ${alternatives.length} alternatives in ${primary.category}.`
     : `${vendorName} pricing details and ${alternatives.length} free alternatives in ${primary.category}.${verifiedSentence}`;
@@ -3816,7 +3821,9 @@ function buildVendorPage(slug: string): string | null {
     unconfirmableSince,
   };
   const verdictLine2 = vendorVerdictSentence(verdictInput);
-  const verdictLine3 = alternatives.length > 0 && !levelWithheld
+  const verdictLine3 = discontinuedOn
+    ? `${vendorName} was discontinued on ${discontinuedOn}, so it is not a current option${alternatives.length > 0 ? ` — the ${alternatives.length} alternatives below are replacements` : ""}.`
+    : alternatives.length > 0 && !levelWithheld
     ? `Best for ${primary.category.toLowerCase()} workloads${alternatives.length >= 5 ? ` — ${alternatives.length} alternatives available` : ""}.`
     : "";
   const quickVerdictHtml = `
@@ -3851,7 +3858,7 @@ function buildVendorPage(slug: string): string | null {
     const topAlt = alternatives[0];
     growthBullets.push(`At that point, consider <a href="/vendor/${toSlug(topAlt.vendor)}">${escHtmlServer(topAlt.vendor)}</a> which offers ${escHtmlServer(topAlt.tier)} in the same category.`);
   }
-  const growthPathHtml = growthBullets.length > 0 ? `
+  const growthPathHtml = growthBullets.length > 0 && !discontinuedOn ? `
   <div class="section growth-section">
     <h2>When You'll Outgrow ${escHtmlServer(vendorName)}'s Free Tier</h2>
     <ul class="growth-list">
@@ -4301,8 +4308,8 @@ ${referralCalloutHtml}
       <div class="detail-value"><a href="${escHtmlServer(primary.url)}" rel="noopener" target="_blank">Visit &rarr;</a></div>
     </div>
     <div class="detail-card">
-      <div class="detail-label">${linkUnreachable ? "Link last reachable" : "Verified"}</div>
-      <div class="detail-value" style="font-family:var(--mono)">${escHtmlServer(linkUnreachable ? (linkUnreachable.last_reachable ?? "no reachable date on record") : primary.verifiedDate)}</div>
+      <div class="detail-label">${discontinuedOn ? "Discontinued" : linkUnreachable ? "Link last reachable" : "Verified"}</div>
+      <div class="detail-value" style="font-family:var(--mono)">${escHtmlServer(discontinuedOn ?? (linkUnreachable ? (linkUnreachable.last_reachable ?? "no reachable date on record") : primary.verifiedDate))}</div>
     </div>
   </div>
 

--- a/src/vendor-verdict.ts
+++ b/src/vendor-verdict.ts
@@ -43,6 +43,10 @@ export function publishedVendorLevel(
   return level && (level === "stable" || cause) ? level : "stable";
 }
 
+function capitalise(text: string): string {
+  return `${text.charAt(0).toUpperCase()}${text.slice(1)}`;
+}
+
 function narrowingChanges(
   changes: VendorVerdictInput["changes"],
 ): VendorVerdictInput["changes"] {
@@ -52,8 +56,12 @@ function narrowingChanges(
     .sort((a, b) => b.date.localeCompare(a.date));
 }
 
+export function withholdingDecides(input: VendorVerdictInput): boolean {
+  return input.levelWithheld !== null && publishedVendorLevel(input.level, input.cause) === "stable";
+}
+
 export function vendorVerdictWord(input: VendorVerdictInput): PublishedRiskLevel | null {
-  if (input.levelWithheld) return null;
+  if (withholdingDecides(input)) return null;
   return publishedVendorLevel(input.level, input.cause);
 }
 
@@ -80,14 +88,17 @@ export function narrowingSentence(changes: VendorVerdictInput["changes"]): strin
 }
 
 export function vendorVerdictSentence(input: VendorVerdictInput): string {
-  if (input.levelWithheld) {
-    const clause = withheldLevelClause(input.levelWithheld, input.unconfirmableSince);
+  if (withholdingDecides(input)) {
+    const clause = withheldLevelClause(input.levelWithheld!, input.unconfirmableSince);
     return `${clause.charAt(0).toUpperCase()}${clause.slice(1)}, so we cannot confirm these terms today.`;
   }
 
   const level = publishedVendorLevel(input.level, input.cause);
   if (level !== "stable" && input.cause) {
-    return `We rate it ${level} — one recorded ${changeKindNoun(input.cause.change_type)}, ${changeDateClause(input.cause)}.`;
+    const unconfirmed = input.levelWithheld
+      ? ` ${capitalise(withheldLevelClause(input.levelWithheld, input.unconfirmableSince))}, so we cannot confirm the terms above.`
+      : "";
+    return `We rate it ${level} — one recorded ${changeKindNoun(input.cause.change_type)}, ${changeDateClause(input.cause)}.${unconfirmed}`;
   }
 
   if (input.changes.length === 0) return `It's stable — zero pricing changes recorded.`;

--- a/test/mcp-risk-indicators.test.ts
+++ b/test/mcp-risk-indicators.test.ts
@@ -121,6 +121,32 @@ describe("MCP risk_level/stability indicators (issue #969)", () => {
     assert.ok(["stable", "watch", "volatile", "improving"].includes(body.stability["Neon"]));
   });
 
+  it("search_deals never pairs a stable risk_level with a volatile stability (issue #1147)", async () => {
+    proc = await startHttpServer();
+    const sessionId = await initSession();
+    const result = await callTool(sessionId, 2, "search_deals", {
+      stability: "volatile", limit: 500,
+    });
+    const body = JSON.parse(result.content[0].text);
+    assert.ok(Array.isArray(body.results) && body.results.length > 0, "no volatile offers came back to check");
+    const contradicting = body.results.filter((r: { risk_level: string }) => r.risk_level === "stable");
+    assert.deepStrictEqual(
+      contradicting.map((r: { vendor: string }) => r.vendor),
+      [],
+      "an agent filtering on risk_level would keep these while the same object calls them volatile",
+    );
+  });
+
+  it("search_deals hands a discontinued product a level an agent can filter out (issue #1147)", async () => {
+    proc = await startHttpServer();
+    const sessionId = await initSession();
+    const result = await callTool(sessionId, 2, "search_deals", { query: "Hypertune", limit: 5 });
+    const body = JSON.parse(result.content[0].text);
+    const row = body.results.find((r: { vendor: string }) => r.vendor === "Hypertune");
+    assert.ok(row, "Hypertune is not searchable by name");
+    assert.notStrictEqual(row.risk_level, "stable", "Hypertune is shutting down and search_deals calls it stable");
+  });
+
   it("plan_stack recommend mode returns risk_level/stability per component and risk_warnings", async () => {
     proc = await startHttpServer();
     const sessionId = await initSession();

--- a/test/product-deprecation.test.ts
+++ b/test/product-deprecation.test.ts
@@ -1,0 +1,166 @@
+import { describe, it } from "node:test";
+import assert from "node:assert";
+import {
+  deprecationEndsTheListedProduct,
+  discontinuationDate,
+  discontinuedOnOrBefore,
+  productNamedApartFromVendor,
+  readDeprecation,
+} from "../dist/product-deprecation.js";
+import { loadDealChanges } from "../dist/data.js";
+import type { DealChange } from "../dist/types.js";
+
+function record(over: Partial<DealChange> = {}): DealChange {
+  return {
+    vendor: "Vendor A",
+    date: "2026-08-01",
+    date_source: "vendor_page",
+    change_type: "product_deprecated",
+    summary: "",
+    previous_state: "",
+    current_state: "",
+    impact: "high",
+    source_url: "",
+    category: "Databases",
+    alternatives: [],
+    ...over,
+  } as DealChange;
+}
+
+function storedRecords(vendor: string): DealChange[] {
+  return loadDealChanges().filter(
+    c => c.vendor.toLowerCase() === vendor.toLowerCase() && c.change_type === "product_deprecated",
+  );
+}
+
+function onlyRecord(vendor: string): DealChange {
+  const held = storedRecords(vendor);
+  assert.strictEqual(held.length, 1, `expected exactly one deprecation record for ${vendor}, found ${held.length}`);
+  return held[0];
+}
+
+describe("#1147 — a deprecation demotes when the thing deprecated is the thing we list", () => {
+  it("reads the product we list as the subject of its own shutdown", () => {
+    for (const vendor of ["Hypertune", "smartlook.com", "lost-pixel.com"]) {
+      const held = onlyRecord(vendor);
+      assert.ok(
+        deprecationEndsTheListedProduct(held),
+        `${vendor}: ${held.summary}`,
+      );
+    }
+  });
+
+  it("leaves a vendor alone when the record names one of its other products", () => {
+    const controls = ["Google Gemini API", "MiniMax", "AWS", "Firebase", "OpenAI"];
+    for (const vendor of controls) {
+      const held = storedRecords(vendor);
+      assert.ok(held.length > 0, `${vendor} holds no deprecation record to control on`);
+      for (const c of held) {
+        assert.ok(
+          !deprecationEndsTheListedProduct(c),
+          `${vendor} would be demoted for: ${c.summary}`,
+        );
+      }
+    }
+  });
+
+  it("decides on the record alone — the same sentence flips when the vendor changes", () => {
+    const summary = "Firebase Studio (formerly Project IDX) shut down March 19, 2026.";
+    assert.ok(!deprecationEndsTheListedProduct(record({ vendor: "Firebase", summary })));
+    assert.ok(deprecationEndsTheListedProduct(record({ vendor: "Firebase Studio", summary })));
+  });
+
+  it("matches a vendor recorded as a domain against the name its prose uses", () => {
+    assert.deepStrictEqual(productNamedApartFromVendor("Lost Pixel", "lost-pixel.com"), []);
+    assert.deepStrictEqual(productNamedApartFromVendor("Smartlook", "smartlook.com"), []);
+    assert.deepStrictEqual(productNamedApartFromVendor("Smartlook Analytics", "smartlook.com"), ["analytics"]);
+  });
+
+  it("reads a generic subject as the product itself", () => {
+    assert.ok(deprecationEndsTheListedProduct(record({ vendor: "Xata Lite", summary: "Service has been discontinued." })));
+    assert.ok(deprecationEndsTheListedProduct(record({ vendor: "Anyone", summary: "The free plan is being sunset." })));
+  });
+
+  it("reads a summary that opens on the predicate as the product itself, successor and all", () => {
+    const brackets = onlyRecord("Brackets");
+    assert.strictEqual(readDeprecation(brackets.summary)?.subject, "");
+    assert.ok(deprecationEndsTheListedProduct(brackets), brackets.summary);
+  });
+
+  it("does not let an unrelated preamble stand in for the subject", () => {
+    const summary = "Several discrepancies were found. Acme Cloud is shutting down.";
+    assert.strictEqual(readDeprecation(summary)?.subject, "Acme Cloud");
+    assert.ok(deprecationEndsTheListedProduct(record({ vendor: "Acme Cloud", summary })));
+    assert.ok(!deprecationEndsTheListedProduct(record({ vendor: "Acme", summary: "Several discrepancies were found. Acme Cloud is shutting down." })));
+  });
+
+  it("reads nothing into a record of another type", () => {
+    const summary = "Hypertune is shutting down and no longer accepting new sign ups.";
+    assert.ok(!deprecationEndsTheListedProduct(record({ vendor: "Hypertune", change_type: "limits_reduced", summary })));
+    assert.ok(!deprecationEndsTheListedProduct(record({ vendor: "Hypertune", change_type: "record_corrected", summary })));
+  });
+
+  it("reads no deprecation out of a summary that states none", () => {
+    assert.strictEqual(readDeprecation("Free tier limits raised from 1 GB to 10 GB."), null);
+    assert.ok(!deprecationEndsTheListedProduct(record({ vendor: "Acme", summary: "Free tier limits raised from 1 GB to 10 GB." })));
+  });
+});
+
+describe("#1147 — the date the service stops", () => {
+  it("takes the date the record attaches to the discontinuation", () => {
+    assert.strictEqual(discontinuationDate(onlyRecord("Hypertune")), "2026-08-10");
+  });
+
+  it("ignores a date that sits before the predicate rather than after it", () => {
+    const earlierSentence = record({ vendor: "Acme", summary: "On April 2, 2026 Acme announced a price rise. Acme is shutting down." });
+    assert.strictEqual(discontinuationDate(earlierSentence), null);
+    const sameSentence = record({ vendor: "Acme", summary: "Announced on April 2, 2026, Acme is shutting down." });
+    assert.strictEqual(discontinuationDate(sameSentence), null, "the day it was announced is not the day it stops");
+  });
+
+  it("reads a day-first date as well as a month-first one", () => {
+    const monthFirst = record({ vendor: "Acme", summary: "Acme will be discontinued on August 10, 2026." });
+    const dayFirst = record({ vendor: "Acme", summary: "Acme will be discontinued on 10th August 2026." });
+    assert.strictEqual(discontinuationDate(monthFirst), "2026-08-10");
+    assert.strictEqual(discontinuationDate(dayFirst), "2026-08-10");
+  });
+
+  it("reads past a wind-down date stated ahead of the clause that ends the service", () => {
+    const c = record({
+      vendor: "Acme",
+      summary: "Acme is shutting down.",
+      current_state: "Read-only access runs to December 31, 2027, and the service is discontinued on June 30, 2026.",
+    });
+    assert.strictEqual(discontinuationDate(c), "2026-06-30");
+  });
+
+  it("takes the last date when a record states several", () => {
+    const c = record({
+      vendor: "Acme",
+      summary: "Acme is being sunset from March 1, 2026.",
+      current_state: "Acme is discontinued on September 30, 2027.",
+    });
+    assert.strictEqual(discontinuationDate(c), "2027-09-30");
+  });
+
+  it("gives no date for a vendor whose record names none", () => {
+    assert.strictEqual(discontinuationDate(onlyRecord("lost-pixel.com")), null);
+  });
+
+  it("reports a discontinuation only once its date has passed", () => {
+    const held = [onlyRecord("Hypertune")];
+    assert.strictEqual(discontinuedOnOrBefore(held, "2026-08-29"), "2026-08-10");
+    assert.strictEqual(discontinuedOnOrBefore(held, "2026-08-09"), null);
+  });
+
+  it("does not report a vendor whose free plan outlives the announcement", () => {
+    const held = storedRecords("smartlook.com");
+    assert.strictEqual(discontinuedOnOrBefore(held, "2026-08-29"), null);
+  });
+
+  it("gives no date for a record that does not end the product we list", () => {
+    const c = record({ vendor: "AWS", summary: "AWS Proton end of support on October 7, 2026." });
+    assert.ok(!deprecationEndsTheListedProduct(c));
+    assert.strictEqual(discontinuationDate(c), null);
+  });
+});

--- a/test/risk-badge.test.ts
+++ b/test/risk-badge.test.ts
@@ -242,6 +242,110 @@ describe("#1038 — the level is checkable", () => {
   });
 });
 
+describe("#1147 — a shutdown of the product we list demotes the vendor", () => {
+  it("every severe type either demotes flatly or states why it decides per record", async () => {
+    const { RISK_DEMOTION, VOLATILE_TYPES, SEVERE_TYPES_WITHOUT_FLAT_DEMOTION } = await import("../dist/data.js");
+    const severe = [...VOLATILE_TYPES] as string[];
+    assert.ok(severe.length > 0, "the severity set is empty");
+    for (const type of severe) {
+      if (RISK_DEMOTION[type as keyof typeof RISK_DEMOTION]) continue;
+      const reason = SEVERE_TYPES_WITHOUT_FLAT_DEMOTION[type];
+      assert.ok(
+        typeof reason === "string" && reason.length > 40,
+        `${type} is severe enough for the stability scale and demotes nothing, with no reason a reader of this test can check`,
+      );
+    }
+    for (const type of Object.keys(SEVERE_TYPES_WITHOUT_FLAT_DEMOTION)) {
+      assert.ok(severe.includes(type), `${type} is excused from demoting but is not in the severity set`);
+      assert.strictEqual(
+        RISK_DEMOTION[type as keyof typeof RISK_DEMOTION],
+        null,
+        `${type} demotes flatly, so the excuse recorded for it is stale`,
+      );
+    }
+  });
+
+  it("a vendor whose own product is discontinued cannot publish stable", async () => {
+    const { enrichOffers, loadOffers } = await import("../dist/data.js");
+    const enriched = enrichOffers(loadOffers());
+    for (const vendor of ["Hypertune", "smartlook.com", "lost-pixel.com"]) {
+      const offer = enriched.find((o: { vendor: string }) => o.vendor === vendor);
+      assert.ok(offer, `${vendor} has no offer to rate`);
+      assert.notStrictEqual(offer.risk_level, "stable", `${vendor} still publishes stable`);
+      assert.ok(offer.risk_cause, `${vendor} carries a level with no record behind it`);
+      assert.strictEqual(offer.risk_cause.change_type, "product_deprecated");
+    }
+  });
+
+  it("a vendor that retired one of its other services keeps the level its own record earned", async () => {
+    const { enrichOffers, loadOffers, loadDealChanges } = await import("../dist/data.js");
+    const enriched = enrichOffers(loadOffers());
+    const held = changesByVendor(loadDealChanges() as Change[]);
+    const expected: Record<string, string> = {
+      "Google Gemini API": "stable",
+      "MiniMax": "stable",
+      "AWS": "caution",
+      "Firebase": "caution",
+    };
+    for (const [vendor, level] of Object.entries(expected)) {
+      const offer = enriched.find((o: { vendor: string }) => o.vendor === vendor);
+      assert.ok(offer, `${vendor} has no offer to rate`);
+      assert.ok(
+        (held.get(vendor.toLowerCase()) ?? []).some((c) => c.change_type === "product_deprecated"),
+        `${vendor} holds no deprecation record, so it is not controlling anything`,
+      );
+      assert.strictEqual(offer.risk_level, level, `${vendor} should stay ${level}`);
+      assert.notStrictEqual(
+        offer.risk_cause?.change_type,
+        "product_deprecated",
+        `${vendor} was demoted for retiring one of its other products`,
+      );
+    }
+  });
+
+  it("no offer in the index carries a stable level beside a volatile stability", async () => {
+    const { enrichOffers, loadOffers } = await import("../dist/data.js");
+    const contradicting = enrichOffers(loadOffers())
+      .filter((o: { risk_level: string | null; stability: string }) => o.risk_level === "stable" && o.stability === "volatile")
+      .map((o: { vendor: string }) => o.vendor);
+    assert.deepStrictEqual(contradicting, [], "these offers ship two judgements that cannot both be true");
+  });
+
+  it("keeps a vendor whose narrowings the risk scale does not act on off both ends of the scale", async () => {
+    const { classifyStability } = await import("../dist/data.js");
+    const restriction = (date: string) => ({
+      vendor: "V", change_type: "restriction", date, summary: "Free tier narrowed",
+      previous_state: "", current_state: "", impact: "medium" as const, source_url: "", category: "c", alternatives: [],
+    });
+    const three = [restriction("2026-01-01"), restriction("2026-04-01"), restriction("2026-06-01")];
+    assert.strictEqual(classifyStability(three), "watch");
+    assert.strictEqual(classifyStability([restriction("2026-01-01")]), "watch");
+  });
+
+  it("never calls a vendor stable on a scale where it holds a narrowing", async () => {
+    const { classifyStability, loadDealChanges, NEGATIVE_CHANGE_TYPES } = await import("../dist/data.js");
+    const held = changesByVendor(loadDealChanges() as Change[]);
+    const wrong: string[] = [];
+    for (const [vendor, changes] of held) {
+      const narrowing = changes.filter((c) => NEGATIVE_CHANGE_TYPES.has(c.change_type)).length;
+      if (narrowing > 0 && classifyStability(changes as never) === "stable") {
+        wrong.push(`${vendor} holds ${narrowing} narrowing record(s) and reads stable`);
+      }
+    }
+    assert.deepStrictEqual(wrong, []);
+  });
+
+  it("the volatile population is not empty, so that invariant is not vacuous", async () => {
+    const { enrichOffers, loadOffers } = await import("../dist/data.js");
+    const enriched = enrichOffers(loadOffers());
+    const volatile = enriched.filter((o: { stability: string }) => o.stability === "volatile");
+    assert.ok(volatile.length > 0, "nothing in the index is volatile");
+    for (const offer of volatile) {
+      assert.notStrictEqual(offer.risk_level, "stable", `${offer.vendor} is volatile and rated stable`);
+    }
+  });
+});
+
 describe("#1038 — risk does not rank", () => {
   it("src/ranking.ts does not read risk_level or stability", () => {
     const src = readFileSync(path.join(REPO, "src", "ranking.ts"), "utf8");

--- a/test/vendor-verdict.test.ts
+++ b/test/vendor-verdict.test.ts
@@ -242,14 +242,17 @@ describe("vendor verdict — corpus invariant, computed offline", () => {
         wrong.push(`${row.slug}: verdict reaches for a second scale — ${row.sentence}`);
         continue;
       }
-      if (row.withheld) {
-        if (/\bWe rate it\b/.test(row.sentence)) wrong.push(`${row.slug}: publishes a rating we are withholding`);
+      if (!row.badgeRendered) {
+        if (/\bWe rate it\b/.test(row.sentence)) wrong.push(`${row.slug}: rates a vendor whose badge is withheld`);
         continue;
       }
       const named = row.sentence.match(/We rate it (stable|caution|risky)\b/)?.[1]
         ?? (row.sentence.startsWith("It's stable") ? "stable" : null);
       if (named !== row.expected) {
         wrong.push(`${row.slug}: badge says ${row.expected}, verdict says ${named ?? "nothing"}`);
+      }
+      if (row.withheld && !/cannot confirm the terms above/.test(row.sentence)) {
+        wrong.push(`${row.slug}: rates the vendor without saying we cannot confirm the terms we print`);
       }
     }
     assert.deepStrictEqual(wrong, [], `vendors whose two stability judgements disagree:\n${wrong.join("\n")}`);
@@ -460,5 +463,33 @@ describe("vendor verdict — as rendered", () => {
       assert.ok(verdict.includes(row.sentence), `/vendor/${slug} verdict does not render "${row.sentence}"`);
       assert.match(row.sentence, /narrowed the terms/, `/vendor/${slug} still names the records that pointed down`);
     }
+  });
+
+  it("stops offering a product whose own shutdown date has passed", async () => {
+    const html = await get("/vendor/hypertune");
+    const pageMeta = html.match(/<p class="page-meta">([\s\S]*?)<\/p>/)?.[1] ?? "";
+    assert.match(pageMeta, /Discontinued 2026-08-10/);
+    assert.doesNotMatch(pageMeta, /Verified/, "the subhead still stamps a discontinued product as verified");
+
+    const metaDesc = html.match(/<meta name="description" content="([^"]*)"/)?.[1] ?? "";
+    assert.doesNotMatch(metaDesc, /Verified [A-Z][a-z]+ \d{4}/, "search results still stamp it as verified");
+
+    const verdict = verdictParagraph(html);
+    assert.match(verdict, /discontinued on 2026-08-10, so it is not a current option/);
+    assert.doesNotMatch(verdict, /Best for [a-z ]*workloads/, "the verdict still recommends it for a workload");
+
+    assert.ok(
+      !/class="section growth-section"/.test(html),
+      "the page still tells the reader when they will outgrow a free tier that has ended",
+    );
+    assert.match(html, /<div class="detail-label">Discontinued<\/div>\s*<div class="detail-value"[^>]*>2026-08-10<\/div>/);
+  });
+
+  it("leaves the verified stamp on a product being sunset with no date past", async () => {
+    const html = await get("/vendor/lost-pixel-com");
+    const pageMeta = html.match(/<p class="page-meta">([\s\S]*?)<\/p>/)?.[1] ?? "";
+    assert.match(pageMeta, /Verified [A-Z][a-z]+ \d{4}/);
+    assert.doesNotMatch(pageMeta, /Discontinued/);
+    assert.strictEqual(badgeWord(html), "risky", "a product being sunset is still rated on the record we hold");
   });
 });


### PR DESCRIPTION
Refs #1147.

`/vendor/hypertune` published a green `stable` badge over its own record reading *"Hypertune is shutting down … the service will be discontinued on August 10, 2026"* — nineteen days ago. `/vendor/smartlook-com` and `/vendor/lost-pixel-com` did the same.

## The rule (AC-3)

**A `product_deprecated` record demotes when the subject of the deprecation names nothing apart from the vendor we list.** `src/product-deprecation.ts` finds the first deprecation predicate in the summary, takes the text before it *within that sentence* as the subject, strips the vendor's own words and a small set of generic nouns, and asks whether anything is left.

| Record | Subject read | Left after the vendor's own words | Verdict |
|---|---|---|---|
| Hypertune | `Hypertune` | — | demotes |
| smartlook.com | `Smartlook` | — | demotes |
| lost-pixel.com | `Lost Pixel` | — | demotes |
| Google Gemini API | `Gemini 2.0 Flash and 2.0 Flash-Lite` | `2 0 flash lite` | keeps |
| MiniMax | `Music generation APIs (…)` | `music generation apis …` | keeps |
| AWS ×6 | `AWS Proton`, `AWS App Mesh`, … | `proton`, `app mesh`, … | keeps |
| Firebase | `Firebase Studio (formerly Project IDX)` | `studio project idx` | keeps |
| OpenAI | `Realtime API beta endpoints` | `realtime api beta endpoints` | keeps |

That is the issue's partition exactly, produced by the rule rather than by a vendor list. Two more records qualify that the issue's table lists as `withheld`: **Brackets** (*"No longer maintained by Adobe"*) and **Google Content API for Shopping** (*"being sunset August 18, 2026"*). Both are the listed product ending, so both demote.

AC-2 holds on the controls' own causes: AWS stays `caution` for a January pricing restructure, Firebase for a February limit reduction, and OpenAI stays `risky` for the Assistants API removal — none of them for a deprecation.

## One predicate, both scales (AC-4)

`classifyStability` called every `product_deprecated` record severe, so demoting only on the risk side would have left Gemini and MiniMax `stable`/`volatile`. `isSevereChange` now asks the same per-record question the demotion does, and a count of narrowings can no longer reach `volatile` while the risk scale holds nothing to act on. `stable` beside `volatile`: **5 → 0** across all 1,580 offers, on `/api/offers` and on MCP `search_deals`.

Two offers move on the stability scale — Gemini API and MiniMax, both `volatile → watch`. No offer moves to `stable`; a vendor holding a narrowing record is never stable on that scale, and there is a corpus test for it.

## A past date stops the offer (AC-5)

`discontinuationDate` reads a date stated *after* the predicate in the same sentence, across the summary and `current_state`, and takes the latest. Hypertune gives 2026-08-10; smartlook (free plan to September 2027) and lost-pixel (no date) give nothing, so neither is treated as past. On a route where the date has passed:

- subhead and meta description: `Verified July 2026.` → `Discontinued 2026-08-10.`
- detail card: `Verified 2026-07-05` → `Discontinued 2026-08-10`
- verdict: `Best for feature flags workloads — 8 alternatives available.` → `Hypertune was discontinued on 2026-08-10, so it is not a current option — the 8 alternatives below are replacements.`
- the `When You'll Outgrow Hypertune's Free Tier` section is dropped.

Two routes qualify today: `/vendor/hypertune` and `/vendor/google-content-api-for-shopping`.

## AC-6

`VOLATILE_TYPES` is exported and `SEVERE_TYPES_WITHOUT_FLAT_DEMOTION` states, as data rather than as a comment, why a severe type may map to a null demotion. The test asserts the map covers exactly the severe types with no flat demotion, in both directions, so it cannot rot on either side.

## A withheld rating no longer contradicts its own badge

Demoting Brackets exposed a live defect. `enrichOffers` publishes a demoted `risk_level` even when the source page is unreadable, but `vendorVerdictSentence` withheld unconditionally — so 28 routes already rendered a `caution`/`risky` badge above a paragraph that said only *"we cannot confirm these terms today"*, and my change would have added two more. Withholding now decides only where the level would be `stable`; otherwise the sentence names the level **and** carries the caveat:

> We rate it risky — one recorded move away from open source, on 2026-02-12. The page we cite for this offer states no terms we can read, so we cannot confirm the terms above.

32 verdicts change, every one toward a more severe word, none less. All 785 pages that carried a "cannot confirm" clause still carry one. `test/vendor-verdict.test.ts`'s corpus invariant now keys on whether the badge renders rather than on whether we are withholding, which is a stronger statement of "one rating word per page".

## Verification

- **2,517 tests / 0 failures**, 29 new; `tsc` clean; `validate-data` clean at 1,580 offers / 444 changes.
- **Census over all 1,572 vendor routes**, before and after, capturing the badge, the verdict paragraph, the subhead, the meta description, the detail cards, the growth section, the cause line and the comparison cell: **1,540 byte-length identical**, 32 changed, 5 badges — all toward more severe, none less.
- **Mutation: `scripts/mutate-1147.sh` 22/22, no survivors.** Two retargeted mutations in `mutate-1143.sh` re-run clean at 23/23; `check-mutation-targets.mjs` reports 288/288 across 28 scripts.
- **Real MCP** `initialize` → `notifications/initialized` → `tools/call`: `search_deals({stability:"volatile"})` returns 66 rows and none is rated stable; Hypertune comes back `risky`/`volatile` with its cause; `compare_vendors` agrees.
- Screenshots of the changed pages against a local server with `BASE_URL` set.

## What this does not fix

- `Free Tier Details` on a discontinued page still prints the tier as we last recorded it. The record's before/after is on the same page, and AC-5 named the stamp and the alternatives framing, so I left the description alone rather than widen the change.
- A product being sunset with no stated date (lost-pixel) keeps its `Verified` stamp. It is rated `risky` and its record is quoted, but AC-5 is scoped to a date now past.
- 33 of the 73 `product_deprecated` records are index bookkeeping — dead domains, mischaracterisations, `Removed: source page no longer accessible`. None has a live offer, so none renders a verdict, and the reader does not parse them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)