### PR TITLE
Count a week by what took effect in it, not by what we read that day (#1149)

### DIFF
--- a/scripts/mutate-1149.sh
+++ b/scripts/mutate-1149.sh
@@ -1,0 +1,366 @@
+#!/usr/bin/env bash
+set -u
+
+REPO="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$REPO" || exit 1
+
+DATES="src/change-dates.ts"
+DATA="src/data.ts"
+SERVE="src/serve.ts"
+CORRECTIONS="src/feed-corrections.ts"
+BACKUP_DIR="$(mktemp -d)"
+cp "$DATES" "$BACKUP_DIR/change-dates.ts"
+cp "$DATA" "$BACKUP_DIR/data.ts"
+cp "$SERVE" "$BACKUP_DIR/serve.ts"
+cp "$CORRECTIONS" "$BACKUP_DIR/feed-corrections.ts"
+
+restore() {
+  cp "$BACKUP_DIR/change-dates.ts" "$DATES"
+  cp "$BACKUP_DIR/data.ts" "$DATA"
+  cp "$BACKUP_DIR/serve.ts" "$SERVE"
+  cp "$BACKUP_DIR/feed-corrections.ts" "$CORRECTIONS"
+}
+trap restore EXIT
+
+killed=0
+survived=0
+TESTS="test/weekly-window-provenance.test.ts test/weekly-digest.test.ts test/weekly-digest-formatted.test.ts test/change-date-provenance.test.ts"
+
+run_mutation() {
+  local name="$1"
+  shift
+  echo "=== $name"
+  restore
+  "$@"
+  if diff -q "$BACKUP_DIR/change-dates.ts" "$DATES" > /dev/null \
+    && diff -q "$BACKUP_DIR/data.ts" "$DATA" > /dev/null \
+    && diff -q "$BACKUP_DIR/serve.ts" "$SERVE" > /dev/null \
+    && diff -q "$BACKUP_DIR/feed-corrections.ts" "$CORRECTIONS" > /dev/null; then
+    echo "    NOT APPLIED: the mutation changed no file, so it proves nothing"
+    survived=$((survived + 1))
+    return
+  fi
+  if ! npm run build > /tmp/mutate-1149-build.log 2>&1; then
+    echo "    KILLED (does not compile)"
+    killed=$((killed + 1))
+    return
+  fi
+  if timeout 900 node --test --test-concurrency 1 $TESTS > /tmp/mutate-1149-test.log 2>&1; then
+    echo "    SURVIVED"
+    survived=$((survived + 1))
+  else
+    echo "    KILLED: $(grep -c '✖ ' /tmp/mutate-1149-test.log) failing assertion(s)"
+    grep '✖ ' /tmp/mutate-1149-test.log | head -4
+    killed=$((killed + 1))
+  fi
+}
+
+py() { python3 - "$@"; }
+
+m_a_window_has_no_end() {
+  py <<'PY'
+p = "src/change-dates.ts"
+s = open(p).read()
+s = s.replace('  return date >= window.start && (window.end === undefined || date <= window.end);',
+              '  return date >= window.start;')
+open(p, "w").write(s)
+PY
+}
+
+m_a_window_excludes_its_last_day() {
+  py <<'PY'
+p = "src/change-dates.ts"
+s = open(p).read()
+s = s.replace('  return date >= window.start && (window.end === undefined || date <= window.end);',
+              '  return date >= window.start && (window.end === undefined || date < window.end);')
+open(p, "w").write(s)
+PY
+}
+
+m_a_window_excludes_its_first_day() {
+  py <<'PY'
+p = "src/change-dates.ts"
+s = open(p).read()
+s = s.replace('  return date >= window.start && (window.end === undefined || date <= window.end);',
+              '  return date > window.start && (window.end === undefined || date <= window.end);')
+open(p, "w").write(s)
+PY
+}
+
+m_every_record_in_the_window_is_a_dated_change() {
+  py <<'PY'
+p = "src/change-dates.ts"
+s = open(p).read()
+s = s.replace('  return partitionByDateProvenance(changes.filter((c) => withinWindow(c.date, window)));',
+              '  return { dated: changes.filter((c) => withinWindow(c.date, window)), discovered: [] };')
+open(p, "w").write(s)
+PY
+}
+
+m_the_week_starts_on_the_day_it_is_handed() {
+  py <<'PY'
+p = "src/change-dates.ts"
+s = open(p).read()
+s = s.replace('  const mondayOffset = dayOfWeek === 0 ? -6 : 1 - dayOfWeek;',
+              '  const mondayOffset = 0;')
+open(p, "w").write(s)
+PY
+}
+
+m_sunday_belongs_to_the_week_that_follows_it() {
+  py <<'PY'
+p = "src/change-dates.ts"
+s = open(p).read()
+s = s.replace('  const mondayOffset = dayOfWeek === 0 ? -6 : 1 - dayOfWeek;',
+              '  const mondayOffset = 1 - dayOfWeek;')
+open(p, "w").write(s)
+PY
+}
+
+m_a_discovery_batch_is_described_as_changes() {
+  py <<'PY'
+p = "src/change-dates.ts"
+s = open(p).read()
+s = s.replace('  const pages = `${count} pricing page${count === 1 ? "" : "s"}`;',
+              '  const pages = `${count} pricing change${count === 1 ? "" : "s"}`;')
+open(p, "w").write(s)
+PY
+}
+
+m_the_note_names_the_window_once() {
+  py <<'PY'
+p = "src/change-dates.ts"
+s = open(p).read()
+s = s.replace('so ${subject} dated by discovery and ${verb} not counted as ${object} effect ${when}.`;',
+              'so ${subject} dated by discovery.`;')
+open(p, "w").write(s)
+PY
+}
+
+m_the_first_read_heading_hides_its_count() {
+  py <<'PY'
+p = "src/change-dates.ts"
+s = open(p).read()
+s = s.replace('  return `Pages read for the first time (${count})`;',
+              '  return `Pages read for the first time`;')
+open(p, "w").write(s)
+PY
+}
+
+m_the_weekly_summary_counts_the_discovery_batch() {
+  py <<'PY'
+p = "src/data.ts"
+s = open(p).read()
+s = s.replace('  const { dated: weekChanges, discovered: weekDiscovered } = changesInWindow(allChanges, week);',
+              '  const inWeek = changesInWindow(allChanges, week);\n'
+              '  const weekDiscovered = inWeek.discovered;\n'
+              '  const weekChanges = [...inWeek.dated, ...inWeek.discovered];')
+open(p, "w").write(s)
+PY
+}
+
+m_the_weekly_top_changes_include_the_discovery_batch() {
+  py <<'PY'
+p = "src/data.ts"
+s = open(p).read()
+s = s.replace('  const sorted = [...weekChanges].sort((a, b) => scoreChange(b) - scoreChange(a));\n'
+              '  const topChanges = sorted.slice(0, limit);',
+              '  const sorted = [...weekChanges, ...weekDiscovered].sort((a, b) => scoreChange(b) - scoreChange(a));\n'
+              '  const topChanges = sorted.slice(0, limit);')
+open(p, "w").write(s)
+PY
+}
+
+m_one_change_is_reported_as_changes() {
+  py <<'PY'
+p = "src/data.ts"
+s = open(p).read()
+s = s.replace('    ? `${headlineParts.join(", ")} across ${weekChanges.length} developer tool pricing change${weekChanges.length !== 1 ? "s" : ""}`',
+              '    ? `${headlineParts.join(", ")} across ${weekChanges.length} developer tool pricing changes`')
+open(p, "w").write(s)
+PY
+}
+
+m_a_week_with_no_discovery_batch_still_gets_the_note() {
+  py <<'PY'
+p = "src/data.ts"
+s = open(p).read()
+s = s.replace('  const discoveryNote = weekDiscovered.length > 0 ? discoveryBatchNote(weekDiscovered.length, `during ${dateLabel}`) : "";',
+              '  const discoveryNote = discoveryBatchNote(weekDiscovered.length, `during ${dateLabel}`);')
+open(p, "w").write(s)
+PY
+}
+
+m_the_digest_returns_the_discovery_batch_as_changes() {
+  py <<'PY'
+p = "src/data.ts"
+s = open(p).read()
+s = s.replace('  const changes = [...changesInWindow(allDealChanges, changeWindow).dated].sort((a, b) =>\n'
+              '    b.date.localeCompare(a.date)\n'
+              '  );',
+              '  const inChangeWindow = changesInWindow(allDealChanges, changeWindow);\n'
+              '  const changes = [...inChangeWindow.dated, ...inChangeWindow.discovered].sort((a, b) =>\n'
+              '    b.date.localeCompare(a.date)\n'
+              '  );')
+open(p, "w").write(s)
+PY
+}
+
+m_the_digest_names_the_week_whatever_range_it_returns() {
+  py <<'PY'
+p = "src/data.ts"
+s = open(p).read()
+s = s.replace('    date_range: `${changeWindow.start} to ${changeWindow.end}`,',
+              '    date_range: week,')
+open(p, "w").write(s)
+PY
+}
+
+m_the_digest_window_has_no_upper_bound() {
+  py <<'PY'
+p = "src/data.ts"
+s = open(p).read()
+s = s.replace('  const changeWindow: DateWindow = usedFallback\n'
+              '    ? { start: thirtyDaysAgo, end: today }\n'
+              '    : weekWindow;',
+              '  const changeWindow: DateWindow = usedFallback\n'
+              '    ? { start: thirtyDaysAgo }\n'
+              '    : { start: weekWindow.start };')
+open(p, "w").write(s)
+PY
+}
+
+m_a_deadline_more_than_thirty_days_out_is_dropped() {
+  py <<'PY'
+p = "src/data.ts"
+s = open(p).read()
+s = s.replace('    .filter((c) => isEventDated(c) && c.date >= today)',
+              '    .filter((c) => isEventDated(c) && c.date >= today && c.date <= fmt(new Date(now.getTime() + 30 * 86400000)))')
+open(p, "w").write(s)
+PY
+}
+
+m_the_summary_drops_the_effective_date_qualifier() {
+  py <<'PY'
+p = "src/data.ts"
+s = open(p).read()
+s = s.replace('pricing change${changes.length !== 1 ? "s" : ""} with a known effective date tracked',
+              'pricing change${changes.length !== 1 ? "s" : ""} tracked')
+open(p, "w").write(s)
+PY
+}
+
+m_the_archived_week_counts_every_record_it_holds() {
+  py <<'PY'
+p = "src/serve.ts"
+s = open(p).read()
+s = s.replace('  const { dated: changes, discovered } = partitionByDateProvenance(weekRecords);',
+              '  const changes = weekRecords;\n'
+              '  const { discovered } = partitionByDateProvenance(weekRecords);')
+open(p, "w").write(s)
+PY
+}
+
+m_the_archive_index_counts_every_record_it_holds() {
+  py <<'PY'
+p = "src/serve.ts"
+s = open(p).read()
+s = s.replace('    return `<li><a href="/digest/${key}"><span class="week-label">${dateRange}</span><span class="week-count">${dated.length} change${dated.length !== 1 ? "s" : ""}${firstRead}</span></a></li>`;',
+              '    return `<li><a href="/digest/${key}"><span class="week-label">${dateRange}</span><span class="week-count">${records.length} change${records.length !== 1 ? "s" : ""}</span></a></li>`;')
+open(p, "w").write(s)
+PY
+}
+
+m_this_week_never_shows_what_it_first_read() {
+  py <<'PY'
+p = "src/serve.ts"
+s = open(p).read()
+s = s.replace('  const contentHtml = [changesHtml, firstReadHtml].filter(Boolean).join("\\n");',
+              '  const contentHtml = changesHtml;')
+open(p, "w").write(s)
+PY
+}
+
+m_the_archived_week_never_shows_what_it_first_read() {
+  py <<'PY'
+p = "src/serve.ts"
+s = open(p).read()
+s = s.replace('  const bodyHtml = [changesHtml, firstReadHtml].filter(Boolean).join("\\n");',
+              '  const bodyHtml = changesHtml;')
+open(p, "w").write(s)
+PY
+}
+
+m_the_feed_drops_its_corrections() {
+  py <<'PY'
+p = "src/serve.ts"
+s = open(p).read()
+s = s.replace('${[...corrections, ...weekEntries].join("\\n")}',
+              '${weekEntries.join("\\n")}')
+open(p, "w").write(s)
+PY
+}
+
+m_a_correction_reuses_the_weekly_entry_id() {
+  py <<'PY'
+p = "src/feed-corrections.ts"
+s = open(p).read()
+s = s.replace('    id: "urn:agentdeals:correction:2026-08-29:weekly-digest-2026-08-24",',
+              '    id: "urn:agentdeals:weekly-digest:2026-08-24",')
+open(p, "w").write(s)
+PY
+}
+
+m_a_correction_does_not_quote_what_it_corrects() {
+  py <<'PY'
+p = "src/feed-corrections.ts"
+s = open(p).read()
+s = s.replace('29 pricing restructures across 154 developer tool pricing changes</em>. That count was wrong, and this entry replaces it.</p>"',
+              '29 pricing restructures</em>. That count was wrong, and this entry replaces it.</p>"')
+open(p, "w").write(s)
+PY
+}
+
+m_the_api_calls_every_record_event_dated() {
+  py <<'PY'
+p = "src/serve.ts"
+s = open(p).read()
+s = s.replace('      const { dated, discovered } = partitionByDateProvenance(result.changes);',
+              '      const dated = result.changes;\n'
+              '      const discovered: typeof result.changes = [];')
+open(p, "w").write(s)
+PY
+}
+
+run_mutation "a window has no end" m_a_window_has_no_end
+run_mutation "a window excludes its last day" m_a_window_excludes_its_last_day
+run_mutation "a window excludes its first day" m_a_window_excludes_its_first_day
+run_mutation "every record in the window is a dated change" m_every_record_in_the_window_is_a_dated_change
+run_mutation "the week starts on the day it is handed" m_the_week_starts_on_the_day_it_is_handed
+run_mutation "Sunday belongs to the week that follows it" m_sunday_belongs_to_the_week_that_follows_it
+run_mutation "a discovery batch is described as changes" m_a_discovery_batch_is_described_as_changes
+run_mutation "the note names the window once" m_the_note_names_the_window_once
+run_mutation "the first-read heading hides its count" m_the_first_read_heading_hides_its_count
+run_mutation "the weekly summary counts the discovery batch" m_the_weekly_summary_counts_the_discovery_batch
+run_mutation "the weekly top changes include the discovery batch" m_the_weekly_top_changes_include_the_discovery_batch
+run_mutation "one change is reported as changes" m_one_change_is_reported_as_changes
+run_mutation "a week with no discovery batch still gets the note" m_a_week_with_no_discovery_batch_still_gets_the_note
+run_mutation "the digest returns the discovery batch as changes" m_the_digest_returns_the_discovery_batch_as_changes
+run_mutation "the digest names the week whatever range it returns" m_the_digest_names_the_week_whatever_range_it_returns
+run_mutation "the digest window has no upper bound" m_the_digest_window_has_no_upper_bound
+run_mutation "a deadline more than thirty days out is dropped" m_a_deadline_more_than_thirty_days_out_is_dropped
+run_mutation "the summary drops the effective-date qualifier" m_the_summary_drops_the_effective_date_qualifier
+run_mutation "the archived week counts every record it holds" m_the_archived_week_counts_every_record_it_holds
+run_mutation "the archive index counts every record it holds" m_the_archive_index_counts_every_record_it_holds
+run_mutation "this week never shows what it first read" m_this_week_never_shows_what_it_first_read
+run_mutation "the archived week never shows what it first read" m_the_archived_week_never_shows_what_it_first_read
+run_mutation "the feed drops its corrections" m_the_feed_drops_its_corrections
+run_mutation "a correction reuses the weekly entry id" m_a_correction_reuses_the_weekly_entry_id
+run_mutation "a correction does not quote what it corrects" m_a_correction_does_not_quote_what_it_corrects
+run_mutation "the api calls every record event-dated" m_the_api_calls_every_record_event_dated
+
+restore
+npm run build > /dev/null 2>&1
+echo
+echo "killed: $killed  survived: $survived"
+[ "$survived" -eq 0 ]

--- a/scripts/sweep-1149.mjs
+++ b/scripts/sweep-1149.mjs
@@ -1,0 +1,65 @@
+import { spawn } from "node:child_process";
+import { readFileSync, writeFileSync } from "node:fs";
+import path from "node:path";
+
+const repo = process.argv[2];
+const out = process.argv[3];
+
+function startServer() {
+  return new Promise((resolve, reject) => {
+    const p = spawn("node", [path.join(repo, "dist", "serve.js")], {
+      cwd: repo,
+      stdio: ["pipe", "pipe", "pipe"],
+      env: { ...process.env, PORT: "0", BASE_URL: "http://127.0.0.1" },
+    });
+    const timeout = setTimeout(() => { p.kill("SIGKILL"); reject(new Error("timeout")); }, 30000);
+    p.stderr.on("data", (b) => {
+      const m = b.toString().match(/running on http:\/\/localhost:(\d+)/);
+      if (m) { clearTimeout(timeout); resolve({ proc: p, port: parseInt(m[1], 10) }); }
+    });
+    p.on("error", (e) => { clearTimeout(timeout); reject(e); });
+  });
+}
+
+const changes = JSON.parse(readFileSync(path.join(repo, "data", "deal_changes.json"), "utf8"));
+const arr = Array.isArray(changes) ? changes : changes.changes;
+
+function isoWeek(dstr) {
+  const d = new Date(Date.UTC(...dstr.split("-").map((x, i) => (i === 1 ? +x - 1 : +x))));
+  d.setUTCDate(d.getUTCDate() + 4 - (d.getUTCDay() || 7));
+  const yearStart = new Date(Date.UTC(d.getUTCFullYear(), 0, 1));
+  const week = Math.ceil(((d.getTime() - yearStart.getTime()) / 86400000 + 1) / 7);
+  return `${d.getUTCFullYear()}-w${String(week).padStart(2, "0")}`;
+}
+
+const weekKeys = [...new Set(arr.map((c) => isoWeek(c.date)))].sort();
+
+const paths = [
+  "/this-week",
+  ...Array.from({ length: 10 }, (_, i) => `/this-week?week=${i + 1}`),
+  "/digest/archive",
+  ...weekKeys.map((k) => `/digest/${k}`),
+  "/feed.xml",
+  "/api/digest",
+  "/api/digest/weekly",
+  "/api/digest/weekly?format=markdown",
+  "/api/digest/weekly?weeks_ago=1",
+  "/api/changes",
+  "/api/changes?since=2026-08-22",
+  "/changes",
+  "/pricing-changes",
+  "/expiring",
+];
+
+const { proc, port } = await startServer();
+const result = {};
+for (const p of paths) {
+  const res = await fetch(`http://127.0.0.1:${port}${p}`);
+  const body = await res.text();
+  result[p] = { status: res.status, length: body.length, body };
+}
+proc.kill("SIGKILL");
+writeFileSync(out, JSON.stringify(result));
+console.log(`swept ${paths.length} paths -> ${out}`);
+const bad = Object.entries(result).filter(([, v]) => v.status !== 200);
+if (bad.length) console.log("NON-200:", bad.map(([k, v]) => `${k}=${v.status}`).join(", "));

--- a/src/change-dates.ts
+++ b/src/change-dates.ts
@@ -21,6 +21,44 @@ export function partitionByDateProvenance<T extends Pick<DealChange, "date_sourc
   return { dated, discovered };
 }
 
+export interface DateWindow {
+  start: string;
+  end?: string;
+}
+
+export function isoWeekWindow(date: Date): DateWindow {
+  const dayOfWeek = date.getUTCDay();
+  const mondayOffset = dayOfWeek === 0 ? -6 : 1 - dayOfWeek;
+  const start = new Date(
+    Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate() + mondayOffset)
+  );
+  const end = new Date(start.getTime() + 6 * 86400000);
+  return { start: start.toISOString().slice(0, 10), end: end.toISOString().slice(0, 10) };
+}
+
+export function withinWindow(date: string, window: DateWindow): boolean {
+  return date >= window.start && (window.end === undefined || date <= window.end);
+}
+
+export function changesInWindow<T extends Pick<DealChange, "date" | "date_source">>(
+  changes: T[],
+  window: DateWindow
+): { dated: T[]; discovered: T[] } {
+  return partitionByDateProvenance(changes.filter((c) => withinWindow(c.date, window)));
+}
+
+export function firstReadHeading(count: number): string {
+  return `Pages read for the first time (${count})`;
+}
+
+export function discoveryBatchNote(count: number, when: string): string {
+  const pages = `${count} pricing page${count === 1 ? "" : "s"}`;
+  const subject = count === 1 ? "it is" : "they are";
+  const verb = count === 1 ? "is" : "are";
+  const object = count === 1 ? "a change that took" : "changes that took";
+  return `${pages} read for the first time ${when}. Each records terms that differ from what we had stored, on a page that does not say when they changed — so ${subject} dated by discovery and ${verb} not counted as ${object} effect ${when}.`;
+}
+
 export const UNDATED_GROUP_NOTE =
   "The vendor’s page states these terms but not when they took effect, so we can only tell you when we found them. They are listed by discovery date and are excluded from the monthly groups and the Last 30 Days count above, both of which count changes by the date they took effect.";
 

--- a/src/data.ts
+++ b/src/data.ts
@@ -8,7 +8,7 @@ import { unreachableNoticeForUrl, resetLinkHealthCache } from "./link-health.js"
 import { quarantineSummary, resetVerificationStateCache, type QuarantineSummary } from "./verification-state.js";
 import { cannotVouchForLevel, levelWithheldReason, withheldLevelSentence } from "./source-check.js";
 import { filterAlternatives } from "./product-role.js";
-import { DATE_SOURCES, isEventDated, changeDateClause } from "./change-dates.js";
+import { DATE_SOURCES, isEventDated, changeDateClause, isoWeekWindow, changesInWindow, discoveryBatchNote, firstReadHeading, type DateWindow } from "./change-dates.js";
 import { PRODUCT_DEPRECATED, deprecationEndsTheListedProduct } from "./product-deprecation.js";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -1133,6 +1133,8 @@ export function getWeeklyDigest(): {
   week: string;
   date_range: string;
   deal_changes: DealChange[];
+  discovered_changes: DealChange[];
+  discovery_note: string;
   new_offers: { vendor: string; category: string; description: string }[];
   upcoming_deadlines: { vendor: string; date: string; change_type: string; summary: string }[];
   summary: string;
@@ -1140,16 +1142,22 @@ export function getWeeklyDigest(): {
   const now = new Date();
   const fmt = (d: Date) => d.toISOString().slice(0, 10);
   const today = fmt(now);
-  const thirtyDaysFromNow = fmt(new Date(now.getTime() + 30 * 24 * 60 * 60 * 1000));
 
-  // Get deal changes — 7-day window, fallback to 30 if <3 changes
-  const sevenDaysAgo = new Date(now.getTime() - 7 * 24 * 60 * 60 * 1000).toISOString().slice(0, 10);
+  const allDealChanges = loadDealChanges();
+  const weekWindow = isoWeekWindow(now);
+  const week = `${weekWindow.start} to ${weekWindow.end}`;
+  const inWeek = changesInWindow(allDealChanges, weekWindow);
+
   const thirtyDaysAgo = new Date(now.getTime() - 30 * 24 * 60 * 60 * 1000).toISOString().slice(0, 10);
-  let changes = getDealChanges(sevenDaysAgo).changes;
-  const usedFallback = changes.length < 3;
-  if (usedFallback) {
-    changes = getDealChanges(thirtyDaysAgo).changes;
-  }
+  const usedFallback = inWeek.dated.length < 3;
+  const changeWindow: DateWindow = usedFallback
+    ? { start: thirtyDaysAgo, end: today }
+    : weekWindow;
+  const changes = [...changesInWindow(allDealChanges, changeWindow).dated].sort((a, b) =>
+    b.date.localeCompare(a.date)
+  );
+  const discovered = [...inWeek.discovered].sort((a, b) => b.date.localeCompare(a.date));
+  const discoveryNote = discovered.length > 0 ? discoveryBatchNote(discovered.length, "this week") : "";
 
   // New offers added in last 7 days
   const newOffers = getNewOffers(7).offers.slice(0, 10).map((o) => ({
@@ -1166,10 +1174,8 @@ export function getWeeklyDigest(): {
     summary: `${d.vendor} deal expires`,
   }));
 
-  // Upcoming deadlines from deal changes with future dates (next 30 days)
-  const allChanges = loadDealChanges();
-  const changeDeadlines = allChanges
-    .filter((c) => isEventDated(c) && c.date >= today && c.date <= thirtyDaysFromNow)
+  const changeDeadlines = allDealChanges
+    .filter((c) => isEventDated(c) && c.date >= today)
     .map((c) => ({
       vendor: c.vendor,
       date: c.date,
@@ -1189,30 +1195,28 @@ export function getWeeklyDigest(): {
     })
     .slice(0, 25);
 
-  // Week label
-  const weekStart = new Date(now.getTime() - now.getUTCDay() * 86400000 + 86400000); // Monday
-  const weekEnd = new Date(weekStart.getTime() + 6 * 86400000);
-  const week = `${fmt(weekStart)} to ${fmt(weekEnd)}`;
-
   // Build summary
   const parts: string[] = [];
   if (changes.length > 0) {
     const negative = changes.filter((c) => CHANGE_DIRECTION[c.change_type] === "negative");
     const positive = changes.filter((c) => CHANGE_DIRECTION[c.change_type] === "positive");
-    parts.push(`${changes.length} pricing change${changes.length !== 1 ? "s" : ""} tracked${usedFallback ? " in the past 30 days" : " this week"}`);
+    parts.push(`${changes.length} pricing change${changes.length !== 1 ? "s" : ""} with a known effective date tracked${usedFallback ? " in the past 30 days" : " this week"}`);
     if (negative.length > 0) parts.push(`${negative.length} negative (${negative.map((c) => c.vendor).join(", ")})`);
     if (positive.length > 0) parts.push(`${positive.length} positive (${positive.map((c) => c.vendor).join(", ")})`);
   } else {
-    parts.push("No pricing changes this week");
+    parts.push("No pricing change with a known effective date this week");
   }
+  if (discoveryNote) parts.push(discoveryNote.replace(/\.$/, ""));
   if (newOffers.length > 0) parts.push(`${newOffers.length} new offer${newOffers.length !== 1 ? "s" : ""} added`);
-  if (deadlines.length > 0) parts.push(`${deadlines.length} upcoming deadline${deadlines.length !== 1 ? "s" : ""} in the next 30 days`);
+  if (deadlines.length > 0) parts.push(`${deadlines.length} upcoming deadline${deadlines.length !== 1 ? "s" : ""} through ${deadlines[deadlines.length - 1].date}`);
   const summary = parts.join(". ") + ".";
 
   return {
     week,
-    date_range: `${fmt(weekStart)} to ${fmt(weekEnd)}`,
+    date_range: `${changeWindow.start} to ${changeWindow.end}`,
     deal_changes: changes,
+    discovered_changes: discovered,
+    discovery_note: discoveryNote,
     new_offers: newOffers,
     upcoming_deadlines: deadlines,
     summary,
@@ -1244,6 +1248,8 @@ export interface FormattedWeeklyDigest {
   week_of: string;
   week_ending: string;
   total_changes: number;
+  changes_in_week: number;
+  discovered_in_week: number;
   summary: {
     free_tiers_removed: number;
     new_free_tiers: number;
@@ -1254,6 +1260,8 @@ export interface FormattedWeeklyDigest {
   };
   headline: string;
   top_changes: DealChange[];
+  discovered_changes: DealChange[];
+  discovery_note: string;
   digest_markdown: string;
   digest_html: string;
 }
@@ -1263,18 +1271,16 @@ export function getFormattedWeeklyDigest(weeksAgo: number = 0, limit: number = 2
   const now = new Date();
   const targetDate = new Date(now.getTime() - weeksAgo * 7 * 86400000);
 
-  const dayOfWeek = targetDate.getUTCDay();
-  const mondayOffset = dayOfWeek === 0 ? -6 : 1 - dayOfWeek;
-  const weekStart = new Date(Date.UTC(targetDate.getUTCFullYear(), targetDate.getUTCMonth(), targetDate.getUTCDate() + mondayOffset));
-  const weekEnd = new Date(weekStart.getTime() + 6 * 86400000);
+  const week = isoWeekWindow(targetDate);
+  const weekStartStr = week.start;
+  const weekEndStr = week.end!;
+  const weekStart = new Date(weekStartStr + "T00:00:00Z");
+  const weekEnd = new Date(weekEndStr + "T00:00:00Z");
 
-  const fmt = (d: Date) => d.toISOString().slice(0, 10);
-  const weekStartStr = fmt(weekStart);
-  const weekEndStr = fmt(weekEnd);
-
-  const weekChanges = allChanges.filter(c => c.date >= weekStartStr && c.date <= weekEndStr);
+  const { dated: weekChanges, discovered: weekDiscovered } = changesInWindow(allChanges, week);
   const sorted = [...weekChanges].sort((a, b) => scoreChange(b) - scoreChange(a));
   const topChanges = sorted.slice(0, limit);
+  const discoveredChanges = [...weekDiscovered].sort((a, b) => scoreChange(b) - scoreChange(a)).slice(0, limit);
 
   const summary = {
     free_tiers_removed: weekChanges.filter(c => c.change_type === "free_tier_removed").length,
@@ -1285,6 +1291,10 @@ export function getFormattedWeeklyDigest(weeksAgo: number = 0, limit: number = 2
     pricing_restructured: weekChanges.filter(c => c.change_type === "pricing_restructured").length,
   };
 
+  const months = ["January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December"];
+  const dateLabel = `${months[weekStart.getUTCMonth()]} ${weekStart.getUTCDate()}\u2013${weekEnd.getUTCDate()}, ${weekStart.getUTCFullYear()}`;
+  const discoveryNote = weekDiscovered.length > 0 ? discoveryBatchNote(weekDiscovered.length, `during ${dateLabel}`) : "";
+
   const headlineParts: string[] = [];
   if (summary.free_tiers_removed > 0) headlineParts.push(`${summary.free_tiers_removed} free tier${summary.free_tiers_removed !== 1 ? "s" : ""} removed`);
   if (summary.new_free_tiers > 0) headlineParts.push(`${summary.new_free_tiers} new one${summary.new_free_tiers !== 1 ? "s" : ""} added`);
@@ -1293,11 +1303,8 @@ export function getFormattedWeeklyDigest(weeksAgo: number = 0, limit: number = 2
   if (summary.limits_increased > 0) headlineParts.push(`${summary.limits_increased} limit${summary.limits_increased !== 1 ? "s" : ""} increased`);
   if (summary.pricing_restructured > 0) headlineParts.push(`${summary.pricing_restructured} pricing restructure${summary.pricing_restructured !== 1 ? "s" : ""}`);
   const headline = headlineParts.length > 0
-    ? `${headlineParts.join(", ")} across ${weekChanges.length} developer tool pricing changes`
+    ? `${headlineParts.join(", ")} across ${weekChanges.length} developer tool pricing change${weekChanges.length !== 1 ? "s" : ""}`
     : `${weekChanges.length} developer tool pricing change${weekChanges.length !== 1 ? "s" : ""} tracked this week`;
-
-  const months = ["January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December"];
-  const dateLabel = `${months[weekStart.getUTCMonth()]} ${weekStart.getUTCDate()}\u2013${weekEnd.getUTCDate()}, ${weekStart.getUTCFullYear()}`;
 
   const negativeTypes = NEGATIVE_STABILITY_TYPES;
   const positiveTypes = POSITIVE_STABILITY_TYPES;
@@ -1329,6 +1336,11 @@ export function getFormattedWeeklyDigest(weeksAgo: number = 0, limit: number = 2
   }
   if (topChanges.length === 0) {
     mdSections.push(`No pricing changes tracked this week.`);
+  }
+  if (discoveredChanges.length > 0) {
+    mdSections.push(`## ${firstReadHeading(weekDiscovered.length)}`);
+    mdSections.push(discoveryNote);
+    mdSections.push(discoveredChanges.map(changeToMd).join("\n"));
   }
 
   mdSections.push(`---`);
@@ -1364,6 +1376,11 @@ export function getFormattedWeeklyDigest(weeksAgo: number = 0, limit: number = 2
   if (topChanges.length === 0) {
     htmlSections.push(`<p>No pricing changes tracked this week.</p>`);
   }
+  if (discoveredChanges.length > 0) {
+    htmlSections.push(`<h2>${escHtml(firstReadHeading(weekDiscovered.length))}</h2>`);
+    htmlSections.push(`<p>${escHtml(discoveryNote)}</p>`);
+    htmlSections.push(`<ul>${discoveredChanges.map(changeToHtml).join("")}</ul>`);
+  }
 
   htmlSections.push(`<hr>`);
   htmlSections.push(`<p><a href="https://agentdeals.dev/changes">View all ${allChanges.length} changes</a> | Powered by <a href="https://agentdeals.dev">AgentDeals</a></p>`);
@@ -1374,9 +1391,13 @@ export function getFormattedWeeklyDigest(weeksAgo: number = 0, limit: number = 2
     week_of: weekStartStr,
     week_ending: weekEndStr,
     total_changes: allChanges.length,
+    changes_in_week: weekChanges.length,
+    discovered_in_week: weekDiscovered.length,
     summary,
     headline,
     top_changes: topChanges,
+    discovered_changes: discoveredChanges,
+    discovery_note: discoveryNote,
     digest_markdown: digestMarkdown,
     digest_html: digestHtml,
   };

--- a/src/feed-corrections.ts
+++ b/src/feed-corrections.ts
@@ -1,0 +1,33 @@
+export interface FeedCorrection {
+  id: string;
+  updated: string;
+  title: string;
+  path: string;
+  summaryHtml: string;
+}
+
+export const FEED_CORRECTIONS: FeedCorrection[] = [
+  {
+    id: "urn:agentdeals:correction:2026-08-29:weekly-digest-2026-08-24",
+    updated: "2026-08-29T00:00:00.000Z",
+    title: "Correction: the digest for the week of August 24–30, 2026",
+    path: "/this-week",
+    summaryHtml:
+      "<p>The digest published for the week of August 24–30, 2026 reported <em>24 free tiers removed, 6 new ones added, 3 products deprecated, 53 limits reduced, 23 limits increased, 29 pricing restructures across 154 developer tool pricing changes</em>. That count was wrong, and this entry replaces it.</p>" +
+      "<p>153 of those 154 records came from a single run on 2026-08-28 in which we read those vendors’ pricing pages for the first time. Each one records terms that differ from what we had stored, on a page that does not say when they changed — so the record carries the date we read it, not the date it took effect. Some of what they describe is years old. One change in that week has a known effective date: OpenAI’s removal of the Assistants API free tier, on 2026-08-26.</p>" +
+      "<p>Weekly counts now include only changes with a known effective date. Pages read for the first time are reported separately, under their own heading, and are not counted as changes that took effect in the week we read them.</p>",
+  },
+];
+
+export function correctionEntriesXml(baseUrl: string, escXml: (s: string) => string): string[] {
+  return FEED_CORRECTIONS.map(
+    (c) => `  <entry>
+    <title>${escXml(c.title)}</title>
+    <link href="${escXml(baseUrl + c.path)}" rel="alternate"/>
+    <id>${escXml(c.id)}</id>
+    <updated>${c.updated}</updated>
+    <author><name>AgentDeals</name></author>
+    <summary type="html">${escXml(c.summaryHtml)}</summary>
+  </entry>`
+  );
+}

--- a/src/serve.ts
+++ b/src/serve.ts
@@ -41,7 +41,8 @@ import type { RankedEntry, RankingResult } from "./ranking.js";
 import { verificationLedger, QUARANTINE_AFTER_FAILURES } from "./verification-state.js";
 import { partitionAlternatives, partitionAlternativesAcross, productRoleSentence, MEMBERSHIP_GATE_RULES, MEMBERSHIP_GATE_ORDER, MEMBERSHIP_GATE_SYMMETRY, MEMBERSHIP_GATE_SCOPE, MEMBERSHIP_GATE_CORRECTIONS } from "./product-role.js";
 import type { Agent, ChangeDateSource, DealChange, RiskCause, LinkUnreachable, Offer } from "./types.js";
-import { changeDateLabel, changeDateClause, changeDatePublished, changeEventStartDate, capListSections, latestEventDate, feedEntryUpdated, undatedGroupHeading, DISCOVERED_DATE_PREFIX, UNDATED_GROUP_NOTE } from "./change-dates.js";
+import { changeDateLabel, changeDateClause, changeDatePublished, changeEventStartDate, capListSections, latestEventDate, feedEntryUpdated, undatedGroupHeading, firstReadHeading, discoveryBatchNote, DISCOVERED_DATE_PREFIX, UNDATED_GROUP_NOTE } from "./change-dates.js";
+import { FEED_CORRECTIONS, correctionEntriesXml } from "./feed-corrections.js";
 import type { AgentBalance } from "./ledger.js";
 import type { SubmittedReferralCode } from "./referral-codes.js";
 
@@ -3155,12 +3156,17 @@ function buildDigestPage(weekKey: string): string | null {
   const { year, week } = parsed;
 
   const byWeek = getChangesByWeek();
-  const changes = byWeek.get(weekKey) ?? [];
+  const weekRecords = byWeek.get(weekKey) ?? [];
+  const { dated: changes, discovered } = partitionByDateProvenance(weekRecords);
   const dateRange = formatDateRange(year, week);
+  const discoveryNote = discovered.length > 0 ? discoveryBatchNote(discovered.length, `during ${dateRange}`) : "";
+  const discoveryClause = discovered.length > 0
+    ? ` ${discovered.length} pricing page${discovered.length !== 1 ? "s" : ""} read for the first time, with no effective date of their own.`
+    : "";
   const title = `Developer Tool Pricing Changes: ${dateRange} — AgentDeals`;
   const metaDesc = changes.length > 0
-    ? `${changes.length} pricing changes tracked for developer tools during ${dateRange}. ${changes.filter(c => c.impact === "high").length} high-impact changes.`
-    : `No pricing changes tracked for developer tools during ${dateRange}.`;
+    ? `${changes.length} pricing changes tracked for developer tools during ${dateRange}. ${changes.filter(c => c.impact === "high").length} high-impact changes.${discoveryClause}`
+    : `No pricing changes tracked for developer tools during ${dateRange}.${discoveryClause}`;
 
   // Stats
   const byType = new Map<string, number>();
@@ -3168,14 +3174,20 @@ function buildDigestPage(weekKey: string): string | null {
     byType.set(c.change_type, (byType.get(c.change_type) ?? 0) + 1);
   }
 
+  const discoveryPill = discovered.length > 0
+    ? `\n    <div class="stat-pill"><span style="width:8px;height:8px;border-radius:50%;background:#8b949e;display:inline-block"></span> <strong>${discovered.length}</strong> first read</div>`
+    : "";
   const statsHtml = changes.length > 0 ? `
   <div class="stats-bar">
-    <div class="stat-pill"><strong>${changes.length}</strong> changes</div>
+    <div class="stat-pill"><strong>${changes.length}</strong> change${changes.length !== 1 ? "s" : ""}</div>
     ${Array.from(byType.entries()).map(([type, count]) => {
       const badge = changeTypeBadge[type] ?? { label: type, color: "#8b949e" };
       return `<div class="stat-pill"><span style="width:8px;height:8px;border-radius:50%;background:${badge.color};display:inline-block"></span> <strong>${count}</strong> ${badge.label}</div>`;
-    }).join("\n    ")}
-  </div>` : "";
+    }).join("\n    ")}${discoveryPill}
+  </div>` : (discovered.length > 0 ? `
+  <div class="stats-bar">
+    <div class="stat-pill"><strong>0</strong> changes</div>${discoveryPill}
+  </div>` : "");
 
   // Group by impact
   const byImpact: Record<string, typeof changes> = { high: [], medium: [], low: [] };
@@ -3186,13 +3198,9 @@ function buildDigestPage(weekKey: string): string | null {
   const impactColors = { high: "#f85149", medium: "#d29922", low: "#8b949e" };
   const impactLabels = { high: "High Impact", medium: "Medium Impact", low: "Low Impact" };
 
-  const changesHtml = changes.length > 0
-    ? (["high", "medium", "low"] as const).filter(level => byImpact[level].length > 0).map(level => `
-  <div class="impact-section">
-    <h2><span class="impact-dot" style="background:${impactColors[level]}"></span> ${impactLabels[level]} (${byImpact[level].length})</h2>
-    ${byImpact[level].sort((a, b) => b.date.localeCompare(a.date)).map(c => {
-      const badge = changeTypeBadge[c.change_type] ?? { label: c.change_type, color: "#8b949e" };
-      return `<div class="change-entry" style="border-left-color:${impactColors[level]}">
+  function digestEntry(c: typeof weekRecords[0], borderColor: string): string {
+    const badge = changeTypeBadge[c.change_type] ?? { label: c.change_type, color: "#8b949e" };
+    return `<div class="change-entry" style="border-left-color:${borderColor}">
       <div class="change-header">
         <span class="change-badge" style="background:${badge.color}">${badge.label}</span>
         <span class="change-vendor">${escHtmlServer(c.vendor)}</span>
@@ -3201,9 +3209,24 @@ function buildDigestPage(weekKey: string): string | null {
       </div>
       <div class="change-summary">${escHtmlServer(c.summary)}</div>
     </div>`;
-    }).join("\n    ")}
+  }
+
+  const changesHtml = changes.length > 0
+    ? (["high", "medium", "low"] as const).filter(level => byImpact[level].length > 0).map(level => `
+  <div class="impact-section">
+    <h2><span class="impact-dot" style="background:${impactColors[level]}"></span> ${impactLabels[level]} (${byImpact[level].length})</h2>
+    ${byImpact[level].sort((a, b) => b.date.localeCompare(a.date)).map(c => digestEntry(c, impactColors[level])).join("\n    ")}
   </div>`).join("\n")
     : `<div class="empty-msg"><p>No pricing changes tracked this week.</p><p style="margin-top:.5rem"><a href="/digest/archive">Browse the archive</a> or <a href="/feed.xml">subscribe via RSS</a>.</p></div>`;
+
+  const firstReadHtml = discovered.length > 0 ? `
+  <div class="impact-section">
+    <h2><span class="impact-dot" style="background:#8b949e"></span> ${escHtmlServer(firstReadHeading(discovered.length))}</h2>
+    <p style="font-size:.85rem;color:var(--text-dim);margin-bottom:.75rem">${escHtmlServer(discoveryNote)}</p>
+    ${[...discovered].sort((a, b) => b.date.localeCompare(a.date)).map(c => digestEntry(c, "#8b949e")).join("\n    ")}
+  </div>` : "";
+
+  const bodyHtml = [changesHtml, firstReadHtml].filter(Boolean).join("\n");
 
   // Trending categories
   const catCounts = new Map<string, number>();
@@ -3265,9 +3288,9 @@ ${OG_IMAGE_META}${GOOGLE_VERIFICATION_META}<link rel="icon" type="image/png" hre
   ${buildGlobalNav("digest")}
   <div class="breadcrumb"><a href="/">AgentDeals</a> &rsaquo; <a href="/digest/archive">Digest</a> &rsaquo; ${weekKey}</div>
   <h1>Pricing Changes: ${dateRange}</h1>
-  <p class="page-meta">Week ${week}, ${year}. ${changes.length} change${changes.length !== 1 ? "s" : ""} tracked.</p>
+  <p class="page-meta">Week ${week}, ${year}. ${changes.length} change${changes.length !== 1 ? "s" : ""} tracked.${discoveryClause}</p>
 ${statsHtml}
-${changesHtml}
+${bodyHtml}
 ${trendingHtml}
 
   <div class="rss-cta">
@@ -3288,10 +3311,12 @@ function buildDigestArchivePage(): string {
   const title = "Pricing Change Digest Archive — AgentDeals";
   const metaDesc = `Browse ${weeks.length} weeks of developer tool pricing changes. Free tier removals, limit changes, and new deals tracked weekly.`;
 
-  const listHtml = weeks.map(([key, changes]) => {
+  const listHtml = weeks.map(([key, records]) => {
     const parsed = parseWeekKey(key)!;
     const dateRange = formatDateRange(parsed.year, parsed.week);
-    return `<li><a href="/digest/${key}"><span class="week-label">${dateRange}</span><span class="week-count">${changes.length} change${changes.length !== 1 ? "s" : ""}</span></a></li>`;
+    const { dated, discovered } = partitionByDateProvenance(records);
+    const firstRead = discovered.length > 0 ? ` + ${discovered.length} first read` : "";
+    return `<li><a href="/digest/${key}"><span class="week-label">${dateRange}</span><span class="week-count">${dated.length} change${dated.length !== 1 ? "s" : ""}${firstRead}</span></a></li>`;
   }).join("\n    ");
 
   const jsonLd = {
@@ -3381,13 +3406,35 @@ function buildThisWeekPage(weeksAgo: number): string {
     </section>`;
   }
 
-  const contentHtml = digest.top_changes.length > 0
+  const changesHtml = digest.top_changes.length > 0
     ? [
         renderSection("Biggest Losses", losses, "#f85149"),
         renderSection("Bright Spots", brightSpots, "#3fb950"),
         renderSection("Other Notable Changes", other, "#d29922"),
       ].filter(Boolean).join("\n")
     : `<div class="empty-msg"><p>No pricing changes tracked this week.</p><p style="margin-top:.5rem"><a href="/this-week?week=${weeksAgo + 1}">View previous week</a> or <a href="/feed.xml">subscribe via RSS</a>.</p></div>`;
+
+  const firstReadHtml = digest.discovered_in_week > 0
+    ? `<section class="tw-section tw-first-read">
+      <h2><span class="tw-dot" style="background:#8b949e"></span> ${escHtmlServer(firstReadHeading(digest.discovered_in_week))}</h2>
+      <p style="font-size:.85rem;color:var(--text-dim);margin-bottom:.75rem">${escHtmlServer(digest.discovery_note)}</p>
+      ${digest.discovered_changes.map(c => {
+        const badge = changeTypeBadge[c.change_type] ?? { label: c.change_type, color: "#8b949e" };
+        return `<div class="tw-change" style="border-left-color:#8b949e">
+        <div class="change-header">
+          <span class="change-badge" style="background:${badge.color}">${badge.label}</span>
+          <a href="/vendor/${toSlug(c.vendor)}" class="change-vendor">${escHtmlServer(c.vendor)}</a>
+          <span class="change-cat" style="font-family:var(--mono)">${changeDateLabel(c)}</span>
+          <span class="change-cat">${escHtmlServer(c.category)}</span>
+        </div>
+        <div class="change-summary">${escHtmlServer(c.summary)}</div>
+      </div>`;
+      }).join("\n      ")}
+      ${digest.discovered_in_week > digest.discovered_changes.length ? `<p style="font-size:.85rem;color:var(--text-dim);margin-top:.75rem">Showing ${digest.discovered_changes.length} of ${digest.discovered_in_week}. <a href="/changes">See every page we have read</a>.</p>` : ""}
+    </section>`
+    : "";
+
+  const contentHtml = [changesHtml, firstReadHtml].filter(Boolean).join("\n");
 
   const { summary: s } = digest;
   const summaryPills: string[] = [];
@@ -3397,6 +3444,7 @@ function buildThisWeekPage(weeksAgo: number): string {
   if (s.limits_increased > 0) summaryPills.push(`<span class="tw-pill" style="border-color:#3fb950"><strong>${s.limits_increased}</strong> limit${s.limits_increased !== 1 ? "s" : ""} increased</span>`);
   if (s.products_deprecated > 0) summaryPills.push(`<span class="tw-pill" style="border-color:#f85149"><strong>${s.products_deprecated}</strong> deprecated</span>`);
   if (s.pricing_restructured > 0) summaryPills.push(`<span class="tw-pill" style="border-color:#bc8cff"><strong>${s.pricing_restructured}</strong> restructured</span>`);
+  if (digest.discovered_in_week > 0) summaryPills.push(`<span class="tw-pill" style="border-color:#8b949e"><strong>${digest.discovered_in_week}</strong> pages read for the first time</span>`);
   const summaryBar = summaryPills.length > 0 ? `<div class="tw-summary-bar">${summaryPills.join("")}</div>` : "";
 
   const navHtml = `<div class="tw-nav">
@@ -54294,9 +54342,15 @@ const httpServer = createHttpServer(async (req, res) => {
     } else {
       const result = getDealChanges(since, type, vendorFilter, vendorsFilter, categoriesFilter);
       const allTimeTotal = loadDealChanges().length;
+      const { dated, discovered } = partitionByDateProvenance(result.changes);
+      const dateProvenance = {
+        event_dated: dated.length,
+        discovered: discovered.length,
+        note: discovered.length > 0 ? discoveryBatchNote(discovered.length, "in this window") : "",
+      };
       logRequest({ ts: new Date().toISOString(), type: "api", endpoint: "/api/changes", params: { since, type, vendor: vendorFilter, vendors: vendorsFilter }, user_agent: req.headers["user-agent"] ?? "unknown", result_count: result.changes.length });
       res.writeHead(200, { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" });
-      res.end(JSON.stringify({ ...result, all_time_total: allTimeTotal, change_log_freshness: changeLogFreshness }));
+      res.end(JSON.stringify({ ...result, date_provenance: dateProvenance, all_time_total: allTimeTotal, change_log_freshness: changeLogFreshness }));
     }
   } else if (url.pathname === "/api/deadlines" && isGetOrHead) {
     recordApiHit("/api/deadlines");
@@ -54656,6 +54710,8 @@ const httpServer = createHttpServer(async (req, res) => {
     <summary type="html">${escXml(digest.digest_html)}</summary>
   </entry>`);
     }
+    const corrections = correctionEntriesXml(baseUrl, escXml);
+    for (const c of FEED_CORRECTIONS) entryUpdates.push(c.updated);
     const updatedTs = entryUpdates.length > 0 ? entryUpdates.reduce((a, b) => (b > a ? b : a)) : new Date().toISOString();
     const atom = `<?xml version="1.0" encoding="UTF-8"?>
 <feed xmlns="http://www.w3.org/2005/Atom">
@@ -54666,7 +54722,7 @@ const httpServer = createHttpServer(async (req, res) => {
   <id>urn:agentdeals:weekly-digest</id>
   <updated>${updatedTs}</updated>
   <author><name>AgentDeals</name></author>
-${weekEntries.join("\n")}
+${[...corrections, ...weekEntries].join("\n")}
 </feed>`;
     logRequest({ ts: new Date().toISOString(), type: "api", endpoint: feedPath, params: {}, user_agent: req.headers["user-agent"] ?? "unknown", result_count: weekEntries.length });
     res.writeHead(200, { "Content-Type": "application/atom+xml; charset=utf-8", "Cache-Control": "public, max-age=3600", "Access-Control-Allow-Origin": "*" });

--- a/test/weekly-digest.test.ts
+++ b/test/weekly-digest.test.ts
@@ -23,8 +23,7 @@ describe("getWeeklyDigest logic", () => {
     const allChanges = loadDealChanges() as Array<{ vendor: string; date: string; change_type: string; summary: string }>;
     const now = new Date();
     const today = now.toISOString().slice(0, 10);
-    const thirtyDaysFromNow = new Date(now.getTime() + 30 * 24 * 60 * 60 * 1000).toISOString().slice(0, 10);
-    const futureChanges = allChanges.filter((c) => c.date >= today && c.date <= thirtyDaysFromNow);
+    const futureChanges = allChanges.filter((c) => c.date >= today);
 
     const digest = getWeeklyDigest();
 

--- a/test/weekly-window-provenance.test.ts
+++ b/test/weekly-window-provenance.test.ts
@@ -1,0 +1,355 @@
+import { describe, it, afterEach } from "node:test";
+import assert from "node:assert";
+import { spawn, type ChildProcess } from "node:child_process";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  isoWeekWindow,
+  withinWindow,
+  changesInWindow,
+  discoveryBatchNote,
+  firstReadHeading,
+  partitionByDateProvenance,
+} from "../dist/change-dates.js";
+import { FEED_CORRECTIONS } from "../dist/feed-corrections.js";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO = path.join(__dirname, "..");
+
+const publishedChanges = JSON.parse(
+  readFileSync(path.join(REPO, "data", "deal_changes.json"), "utf-8")
+).changes as Array<{ date: string; date_source: string; change_type: string; vendor: string }>;
+
+function eventDated(c: { date_source?: string }): boolean {
+  return c.date_source === "vendor_page" || c.date_source === "hand_written";
+}
+
+function dated(dateSource: string, date: string) {
+  return { vendor: "Acme", date, date_source: dateSource, change_type: "limits_reduced" };
+}
+
+describe("one definition of the week a digest is about", () => {
+  it("runs Monday to Sunday whichever day of the week it is handed", () => {
+    assert.deepStrictEqual(isoWeekWindow(new Date("2026-08-26T09:00:00Z")), {
+      start: "2026-08-24",
+      end: "2026-08-30",
+    });
+    assert.deepStrictEqual(isoWeekWindow(new Date("2026-08-24T00:00:00Z")), {
+      start: "2026-08-24",
+      end: "2026-08-30",
+    });
+    assert.deepStrictEqual(isoWeekWindow(new Date("2026-08-30T23:59:00Z")), {
+      start: "2026-08-24",
+      end: "2026-08-30",
+    });
+  });
+
+  it("includes both end dates and stays open when no end is given", () => {
+    const week = { start: "2026-08-24", end: "2026-08-30" };
+    assert.strictEqual(withinWindow("2026-08-24", week), true);
+    assert.strictEqual(withinWindow("2026-08-30", week), true);
+    assert.strictEqual(withinWindow("2026-08-23", week), false);
+    assert.strictEqual(withinWindow("2026-08-31", week), false);
+    assert.strictEqual(withinWindow("2099-01-01", { start: "2026-08-24" }), true);
+  });
+
+  it("keeps a record dated outside the window out of both halves", () => {
+    const week = { start: "2026-08-24", end: "2026-08-30" };
+    const { dated: inside, discovered } = changesInWindow(
+      [
+        dated("hand_written", "2026-08-26"),
+        dated("discovered", "2026-08-28"),
+        dated("hand_written", "2026-09-30"),
+        dated("hand_written", "2026-08-20"),
+        dated("discovered", "2026-09-01"),
+      ] as never[],
+      week
+    );
+    assert.deepStrictEqual(inside.map((c: { date: string }) => c.date), ["2026-08-26"]);
+    assert.deepStrictEqual(discovered.map((c: { date: string }) => c.date), ["2026-08-28"]);
+  });
+
+  it("answers the Last 30 Days question with the same call the week uses", () => {
+    const thirtyDaysAgo = new Date(Date.now() - 30 * 86400000).toISOString().slice(0, 10);
+    const viaWindow = changesInWindow(publishedChanges as never[], { start: thirtyDaysAgo }).dated.length;
+    const viaPartition = partitionByDateProvenance(publishedChanges as never[]).dated.filter(
+      (c: { date: string }) => c.date >= thirtyDaysAgo
+    ).length;
+    assert.strictEqual(viaWindow, viaPartition);
+  });
+});
+
+describe("the sentence a discovery batch gets", () => {
+  it("names the window twice and never calls the batch a change", () => {
+    const note = discoveryBatchNote(153, "this week");
+    assert.match(note, /^153 pricing pages read for the first time this week\./);
+    assert.match(note, /not counted as changes that took effect this week\.$/);
+    assert.ok(!/153 (pricing )?changes/.test(note), note);
+  });
+
+  it("reads as one page when there is one", () => {
+    const note = discoveryBatchNote(1, "this week");
+    assert.match(note, /^1 pricing page read for the first time this week\./);
+    assert.match(note, /it is dated by discovery and is not counted as a change that took effect this week\./);
+  });
+
+  it("counts the batch in its own heading", () => {
+    assert.strictEqual(firstReadHeading(153), "Pages read for the first time (153)");
+  });
+});
+
+describe("a weekly digest counts only changes with an effective date", () => {
+  it("puts every discovered record on the discovery side and none in the change count", async () => {
+    const { getFormattedWeeklyDigest } = await import("../dist/data.js");
+    const digest = getFormattedWeeklyDigest(0, 200);
+    const window = { start: digest.week_of, end: digest.week_ending };
+    const expectedDated = publishedChanges.filter((c) => eventDated(c) && withinWindow(c.date, window));
+    const expectedDiscovered = publishedChanges.filter((c) => !eventDated(c) && withinWindow(c.date, window));
+
+    assert.strictEqual(digest.changes_in_week, expectedDated.length);
+    assert.strictEqual(digest.discovered_in_week, expectedDiscovered.length);
+    for (const c of digest.top_changes) assert.ok(eventDated(c), `${c.vendor} ${c.date_source}`);
+    for (const c of digest.discovered_changes) assert.ok(!eventDated(c), `${c.vendor} ${c.date_source}`);
+  });
+
+  it("counts each change type over the dated half only", async () => {
+    const { getFormattedWeeklyDigest } = await import("../dist/data.js");
+    const digest = getFormattedWeeklyDigest(0, 200);
+    const window = { start: digest.week_of, end: digest.week_ending };
+    const inWeek = publishedChanges.filter((c) => eventDated(c) && withinWindow(c.date, window));
+    const count = (t: string) => inWeek.filter((c) => c.change_type === t).length;
+    assert.strictEqual(digest.summary.free_tiers_removed, count("free_tier_removed"));
+    assert.strictEqual(digest.summary.limits_reduced, count("limits_reduced"));
+    assert.strictEqual(digest.summary.new_free_tiers, count("new_free_tier"));
+    assert.strictEqual(digest.summary.limits_increased, count("limits_increased"));
+    assert.strictEqual(digest.summary.products_deprecated, count("product_deprecated"));
+    assert.strictEqual(digest.summary.pricing_restructured, count("pricing_restructured"));
+  });
+
+  it("never states the combined total as a number of changes", async () => {
+    const { getFormattedWeeklyDigest } = await import("../dist/data.js");
+    const digest = getFormattedWeeklyDigest(0, 200);
+    const combined = digest.changes_in_week + digest.discovered_in_week;
+    assert.ok(digest.discovered_in_week > 0, "the corpus should carry a discovery batch to guard against");
+    assert.ok(
+      !digest.headline.includes(`across ${combined} developer tool pricing change`),
+      digest.headline
+    );
+    assert.ok(digest.headline.includes(String(digest.changes_in_week)), digest.headline);
+    assert.ok(!digest.digest_markdown.includes(`> ${combined} developer tool pricing change`));
+  });
+
+  it("agrees with itself on singular and plural", async () => {
+    const { getFormattedWeeklyDigest } = await import("../dist/data.js");
+    for (let weeksAgo = 0; weeksAgo < 40; weeksAgo++) {
+      const digest = getFormattedWeeklyDigest(weeksAgo, 200);
+      if (digest.changes_in_week === 1) {
+        assert.ok(
+          !digest.headline.includes("1 developer tool pricing changes"),
+          `${weeksAgo}: ${digest.headline}`
+        );
+      }
+    }
+  });
+
+  it("gives the discovery batch its own heading and its own sentence", async () => {
+    const { getFormattedWeeklyDigest } = await import("../dist/data.js");
+    const digest = getFormattedWeeklyDigest(0, 200);
+    assert.ok(digest.discovery_note.length > 0);
+    assert.ok(digest.digest_markdown.includes(`## ${firstReadHeading(digest.discovered_in_week)}`));
+    assert.ok(digest.digest_markdown.includes(digest.discovery_note));
+    assert.ok(digest.digest_html.includes(`<h2>${firstReadHeading(digest.discovered_in_week)}</h2>`));
+  });
+
+  it("says nothing about discovery in a week that has none", async () => {
+    const { getFormattedWeeklyDigest } = await import("../dist/data.js");
+    const quiet: number[] = [];
+    for (let weeksAgo = 1; weeksAgo < 60; weeksAgo++) {
+      const digest = getFormattedWeeklyDigest(weeksAgo, 200);
+      if (digest.discovered_in_week !== 0) continue;
+      quiet.push(weeksAgo);
+      assert.strictEqual(digest.discovery_note, "");
+      assert.strictEqual(digest.discovered_changes.length, 0);
+      assert.ok(!digest.digest_markdown.includes("read for the first time"), String(weeksAgo));
+      assert.ok(!digest.digest_html.includes("read for the first time"), String(weeksAgo));
+      assert.strictEqual(Math.min(digest.changes_in_week, 200), digest.top_changes.length);
+    }
+    assert.ok(quiet.length > 20, `expected most archived weeks to carry no discovery batch, got ${quiet.length}`);
+  });
+});
+
+describe("the digest returns only what the window it names contains", () => {
+  it("keeps every returned change inside the range it publishes", async () => {
+    const { getWeeklyDigest } = await import("../dist/data.js");
+    const digest = getWeeklyDigest();
+    const [start, end] = digest.date_range.split(" to ");
+    assert.ok(/^\d{4}-\d{2}-\d{2}$/.test(start) && /^\d{4}-\d{2}-\d{2}$/.test(end), digest.date_range);
+    for (const c of digest.deal_changes) {
+      assert.ok(eventDated(c), `${c.vendor} ${c.date_source}`);
+      assert.ok(withinWindow(c.date, { start, end }), `${c.vendor} ${c.date} outside ${digest.date_range}`);
+    }
+  });
+
+  it("keeps every first-read record inside the week it names", async () => {
+    const { getWeeklyDigest } = await import("../dist/data.js");
+    const digest = getWeeklyDigest();
+    const [start, end] = digest.week.split(" to ");
+    for (const c of digest.discovered_changes) {
+      assert.ok(!eventDated(c), `${c.vendor} ${c.date_source}`);
+      assert.ok(withinWindow(c.date, { start, end }), `${c.vendor} ${c.date} outside ${digest.week}`);
+    }
+  });
+
+  it("routes a future-dated change to the deadlines rather than to the week", async () => {
+    const { getWeeklyDigest } = await import("../dist/data.js");
+    const digest = getWeeklyDigest();
+    const today = new Date().toISOString().slice(0, 10);
+    const future = publishedChanges.filter((c) => eventDated(c) && c.date > today);
+    assert.ok(future.length > 0, "the corpus should carry a future-dated change to place");
+    for (const c of future) {
+      assert.ok(
+        digest.upcoming_deadlines.some((d) => d.vendor === c.vendor && d.date === c.date),
+        `${c.vendor} ${c.date} should be an upcoming deadline`
+      );
+      assert.ok(
+        !digest.deal_changes.some((d) => d.vendor === c.vendor && d.date === c.date && d.date > today),
+        `${c.vendor} ${c.date} should not be reported as a change already tracked`
+      );
+    }
+  });
+
+  it("opens its summary with the number of changes it actually returns", async () => {
+    const { getWeeklyDigest } = await import("../dist/data.js");
+    const digest = getWeeklyDigest();
+    assert.match(digest.summary, new RegExp(`^${digest.deal_changes.length} pricing change`));
+    assert.ok(digest.summary.includes("with a known effective date"), digest.summary);
+    if (digest.discovered_changes.length > 0) {
+      assert.ok(digest.summary.includes("read for the first time this week"), digest.summary);
+    }
+  });
+});
+
+describe("the feed corrects a published week with an entry of its own", () => {
+  it("gives the correction an id no weekly entry can collide with", () => {
+    assert.ok(FEED_CORRECTIONS.length > 0);
+    for (const c of FEED_CORRECTIONS) {
+      assert.ok(c.id.startsWith("urn:agentdeals:correction:"), c.id);
+      assert.ok(!c.id.startsWith("urn:agentdeals:weekly-digest:"), c.id);
+      assert.match(c.updated, /^\d{4}-\d{2}-\d{2}T/);
+      assert.ok(c.summaryHtml.includes("<p>"), c.id);
+    }
+  });
+
+  it("quotes the count it is correcting and names what replaced it", () => {
+    const correction = FEED_CORRECTIONS.find((c) => c.id.includes("weekly-digest-2026-08-24"));
+    assert.ok(correction, "the week of 2026-08-24 should carry a correction");
+    assert.ok(correction!.summaryHtml.includes("154 developer tool pricing changes"), correction!.summaryHtml);
+    assert.ok(correction!.summaryHtml.includes("2026-08-28"), correction!.summaryHtml);
+    assert.ok(correction!.summaryHtml.includes("known effective date"), correction!.summaryHtml);
+  });
+});
+
+describe("every weekly surface reports the same week", () => {
+  let serverPort = 0;
+  let proc: ChildProcess | null = null;
+
+  function startHttpServer(): Promise<ChildProcess> {
+    return new Promise((resolve, reject) => {
+      const serverPath = path.join(REPO, "dist", "serve.js");
+      const p = spawn("node", [serverPath], {
+        stdio: ["pipe", "pipe", "pipe"],
+        env: { ...process.env, PORT: "0", BASE_URL: "http://127.0.0.1" },
+      });
+      const timeout = setTimeout(() => { p.kill("SIGKILL"); reject(new Error("Server startup timeout")); }, 20000);
+      p.stderr!.on("data", (data: Buffer) => {
+        const match = data.toString().match(/running on http:\/\/localhost:(\d+)/);
+        if (match) { serverPort = parseInt(match[1], 10); clearTimeout(timeout); resolve(p); }
+      });
+      p.on("error", (err) => { clearTimeout(timeout); reject(err); });
+    });
+  }
+
+  afterEach(() => {
+    if (proc) { proc.kill("SIGKILL"); proc = null; }
+  });
+
+  it("publishes one count for the week across the page, the API and the feed", async () => {
+    proc = await startHttpServer();
+    const base = `http://127.0.0.1:${serverPort}`;
+    const weekly = await (await fetch(`${base}/api/digest/weekly?limit=200`)).json() as {
+      changes_in_week: number; discovered_in_week: number; headline: string;
+    };
+    const page = await (await fetch(`${base}/this-week`)).text();
+    const feed = await (await fetch(`${base}/feed.xml`)).text();
+
+    const combined = weekly.changes_in_week + weekly.discovered_in_week;
+    assert.ok(weekly.discovered_in_week > 0, "the corpus should carry a discovery batch to guard against");
+    const inflated = `across ${combined} developer tool pricing change`;
+
+    assert.ok(!page.includes(inflated), "/this-week");
+    assert.ok(page.includes(weekly.headline), "/this-week should carry the headline");
+    assert.ok(page.includes(firstReadHeading(weekly.discovered_in_week)), "/this-week");
+
+    const entries = feed.split("<entry>").slice(1);
+    const corrections = entries.filter((e) => e.includes("urn:agentdeals:correction:"));
+    const weeks = entries.filter((e) => !e.includes("urn:agentdeals:correction:"));
+    assert.ok(weeks.length > 0, "/feed.xml should carry weekly entries");
+    for (const entry of weeks) assert.ok(!entry.includes(inflated), "/feed.xml weekly entry");
+    assert.ok(
+      corrections.some((e) => e.includes(inflated)),
+      "a corrected count should survive only inside the entry correcting it"
+    );
+  });
+
+  it("counts the last thirty days on /changes the way the week is counted", async () => {
+    proc = await startHttpServer();
+    const base = `http://127.0.0.1:${serverPort}`;
+    const changesPage = await (await fetch(`${base}/changes`)).text();
+    const thirtyDaysAgo = new Date(Date.now() - 30 * 86400000).toISOString().slice(0, 10);
+    const expected = changesInWindow(publishedChanges as never[], { start: thirtyDaysAgo }).dated.length;
+    const rendered = changesPage.match(/<div class="stat-value">(\d+)<\/div>\s*<div class="stat-label">Last 30 Days<\/div>/);
+    assert.ok(rendered, "/changes should publish a Last 30 Days count");
+    assert.strictEqual(parseInt(rendered![1], 10), expected);
+  });
+
+  it("labels the discovery batch on the archived week that holds it", async () => {
+    proc = await startHttpServer();
+    const base = `http://127.0.0.1:${serverPort}`;
+    const week = await (await fetch(`${base}/digest/2026-w35`)).text();
+    assert.ok(week.includes("Week 35, 2026. 1 change tracked."), "the archived week should count one change");
+    assert.ok(week.includes(firstReadHeading(153)), "the archived week should name its discovery batch");
+    assert.ok(!week.includes("154 changes tracked"), "the archived week should not count the batch as changes");
+  });
+
+  it("separates the two counts in the archive index", async () => {
+    proc = await startHttpServer();
+    const base = `http://127.0.0.1:${serverPort}`;
+    const archive = await (await fetch(`${base}/digest/archive`)).text();
+    assert.ok(archive.includes("1 change + 153 first read"), "the archive should split the week it holds");
+    assert.ok(!archive.includes("154 changes"), "the archive should not count the batch as changes");
+  });
+
+  it("tells an API caller how many of its records carry an effective date", async () => {
+    proc = await startHttpServer();
+    const base = `http://127.0.0.1:${serverPort}`;
+    const body = await (await fetch(`${base}/api/changes?since=2026-08-22`)).json() as {
+      changes: Array<{ date_source: string }>;
+      date_provenance: { event_dated: number; discovered: number; note: string };
+    };
+    const expectedDated = body.changes.filter(eventDated).length;
+    const expectedDiscovered = body.changes.length - expectedDated;
+    assert.ok(expectedDiscovered > 0, "the window should carry a discovery batch to report");
+    assert.strictEqual(body.date_provenance.event_dated, expectedDated);
+    assert.strictEqual(body.date_provenance.discovered, expectedDiscovered);
+    assert.ok(body.date_provenance.note.startsWith(`${expectedDiscovered} pricing pages read`), body.date_provenance.note);
+  });
+
+  it("leaves an archived week with no discovery batch alone", async () => {
+    proc = await startHttpServer();
+    const base = `http://127.0.0.1:${serverPort}`;
+    const week = await (await fetch(`${base}/digest/2026-w34`)).text();
+    assert.ok(week.includes("1 change tracked."), "week 34 should count one change");
+    assert.ok(!week.includes("read for the first time"), "week 34 has no discovery batch to report");
+  });
+});


### PR DESCRIPTION
Refs #1149

`/this-week` was headed **"24 free tiers removed, 6 new ones added, 3 products deprecated, 53 limits reduced, 23 limits increased, 29 pricing restructures across 154 developer tool pricing changes"** for a week in which **one** dated change happened. 153 of the 154 records came from a single scan on 2026-08-28 and carry `date_source: "discovered"` — the vendor's page states the terms and not when they took effect, so the record is dated the day we read it. Some of what they describe is years old. The claim was quantified, dated, attributed to named vendors, and syndicated.

`/changes` already publishes the honest version. This puts the weekly surfaces on the same primitives.

## What the week now contains

| Surface | Before | After |
|---|---|---|
| `/this-week` headline | 24 free tiers removed … across **154** changes | **1 free tier removed across 1 developer tool pricing change** |
| `/this-week` sections | Biggest Losses (43), Bright Spots (6), Other (1) | Biggest Losses (1), **Pages read for the first time (153)** |
| `/digest/2026-w35` | Week 35, 2026. **154 changes tracked.** | Week 35, 2026. **1 change tracked.** 153 pricing pages read for the first time, with no effective date of their own. |
| `/digest/archive` week 35 | 154 changes | **1 change + 153 first read** |
| `/feed.xml` week entry title | … across 154 developer tool pricing changes | … across 1 developer tool pricing change, plus a **correction entry** |
| MCP `track_changes` (no params) | 157 records, 121 negative | 2 dated changes, 153 under `discovered_changes` with a note |
| `/api/changes` | records only | adds `date_provenance` |

## AC-5: one definition, reused

`src/change-dates.ts` gains `isoWeekWindow`, `withinWindow` and `changesInWindow`. `changesInWindow` filters on the window and hands the result straight to the existing `partitionByDateProvenance`, so the weekly window and `/changes`'s Last 30 Days count are the same call with a different window — a test asserts they agree, and a second test reads the rendered Last 30 Days figure off `/changes` and compares it to the primitive.

## AC-4: the digest returns only what the window it names contains

`getWeeklyDigest` selected on `date >= sevenDaysAgo` with **no upper bound** while naming a Monday–Sunday week, so three future-dated records — AWS Proton (2026-10-07), AWS App Mesh (2026-09-30) and Deepgram (2026-09-12) — were returned as changes tracked *this week*. It now selects on the window, and `date_range` names the range `deal_changes` actually covers rather than restating the week when the quiet-week fallback widens it.

**A negative result worth recording:** the AC says those three belong in `upcoming_deadlines`, "where two of them already appear". On `main` only **one** appears. The change-derived deadline list was capped at 30 days and today + 30 is 2026-09-28, so both AWS records fell outside it — after the window fix they would have appeared nowhere at all. `/api/deadlines` already lists every future-dated change with no horizon, so I took that as the spec: the cap is gone and the summary now says "5 upcoming deadlines through 2026-10-07" rather than naming 30 days it no longer means.

## AC-6: the feed corrects rather than restates

The week entries keep their published ids (`urn:agentdeals:weekly-digest:2026-08-24`). A new entry with its own id, `urn:agentdeals:correction:2026-08-29:weekly-digest-2026-08-24`, quotes the headline it corrects, says where the 153 came from, and states the rule that replaced it. A test asserts the corrected count survives **only** inside the entry correcting it — that assertion is what caught my first, blunter version of the check.

## AC-3 negative control, measured

67 paths swept against a `main` worktree, including all 45 archived week pages.

- **25 archived week pages byte-identical.** `/digest/2026-w33` (0 records) among them.
- **19 differ by one character**: `1 changes` → `1 change`. That defect is on `main` today; I fixed it because the count on `/this-week` and `/digest/2026-w35` dropped to 1 and I would otherwise have been publishing it on the two most visible pages. **`/digest/2026-w34` is one of the 19** — its change list, its counts and its structure are unchanged, and I would rather say that than let a control quietly move.
- **1 changes for real**: `/digest/2026-w35`.
- `/changes`, `/pricing-changes` and `/expiring` byte-identical.

## Verification

- **2542/2542** tests pass, including 25 new ones.
- **`mutate-1149.sh`: 26 mutations, 26 killed, 0 survivors.** The first pass had 2 survivors and both were real gaps — nothing covered `/digest/archive`'s per-week count or `/api/changes`'s new provenance block, and each could have reverted to counting the batch as changes while the suite stayed green.
- `check-mutation-targets.mjs`: 314/314 across 29 scripts.
- Real MCP session against the built server: `initialize` → `tools/call track_changes` with no params returns 2 dated changes, 153 under `discovered_changes`, and all five deadlines.
- Screenshots of `/this-week` and `/digest/2026-w35`, looked at rather than parsed — which is how I caught the `1 changes` pill.