### PR TITLE
Count referral partners with the predicate that renders the button (#1154)

### DIFF
--- a/scripts/mutate-1154.sh
+++ b/scripts/mutate-1154.sh
@@ -1,0 +1,230 @@
+#!/usr/bin/env bash
+set -u
+
+REPO="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$REPO" || exit 1
+
+SURFACES="src/referral-surfaces.ts"
+SERVE="src/serve.ts"
+BACKUP_DIR="$(mktemp -d)"
+cp "$SURFACES" "$BACKUP_DIR/referral-surfaces.ts"
+cp "$SERVE" "$BACKUP_DIR/serve.ts"
+
+restore() {
+  cp "$BACKUP_DIR/referral-surfaces.ts" "$SURFACES"
+  cp "$BACKUP_DIR/serve.ts" "$SERVE"
+}
+trap restore EXIT
+
+killed=0
+survived=0
+TESTS="test/referral-disclosure-predicate.test.ts test/referral.test.ts test/referral-programs.test.ts test/ranked-surfaces.test.ts test/vendor-marketplace-solicitation.test.ts"
+
+run_mutation() {
+  local name="$1"
+  shift
+  echo "=== $name"
+  restore
+  "$@"
+  if diff -q "$BACKUP_DIR/referral-surfaces.ts" "$SURFACES" > /dev/null \
+    && diff -q "$BACKUP_DIR/serve.ts" "$SERVE" > /dev/null; then
+    echo "    NOT APPLIED: the mutation changed no file, so it proves nothing"
+    survived=$((survived + 1))
+    return
+  fi
+  if ! npm run build > /tmp/mutate-1154-build.log 2>&1; then
+    echo "    NOT APPLIED: the mutation does not compile, so no test ran"
+    tail -3 /tmp/mutate-1154-build.log
+    survived=$((survived + 1))
+    return
+  fi
+  if timeout 900 node --test --test-concurrency 1 $TESTS > /tmp/mutate-1154-test.log 2>&1; then
+    echo "    SURVIVED"
+    survived=$((survived + 1))
+  else
+    echo "    KILLED: $(grep -c '✖ ' /tmp/mutate-1154-test.log) failing assertion(s)"
+    grep '✖ ' /tmp/mutate-1154-test.log | head -4
+    killed=$((killed + 1))
+  fi
+}
+
+py() { python3 - "$@"; }
+
+m_the_predicate_reads_the_offer_store_only() {
+  py <<'PY'
+p = "src/referral-surfaces.ts"
+s = open(p).read()
+s = s.replace('  const platformCode = getPlatformCodeForVendor(vendorName);',
+              '  const platformCode = getPlatformCodeForVendor("");')
+open(p, "w").write(s)
+PY
+}
+
+m_the_predicate_reads_the_platform_store_only() {
+  py <<'PY'
+p = "src/referral-surfaces.ts"
+s = open(p).read()
+s = s.replace('  if (offerReferral && offer) {',
+              '  if (offerReferral && offer && vendorName !== vendorName) {')
+open(p, "w").write(s)
+PY
+}
+
+m_a_documented_program_counts_as_a_link_of_ours() {
+  py <<'PY'
+p = "src/referral-surfaces.ts"
+s = open(p).read()
+s = s.replace('  return ourReferralLinkFor(vendorName, offer) !== null;',
+              '  return ourReferralLinkFor(vendorName, offer) !== null || offer?.referral_program?.available === true;')
+open(p, "w").write(s)
+PY
+}
+
+m_a_documented_program_is_not_a_referral_surface() {
+  py <<'PY'
+p = "src/referral-surfaces.ts"
+s = open(p).read()
+s = s.replace('  return hasOurReferralLink(vendorName, offer) || documentsVendorReferralProgram(offer);',
+              '  return hasOurReferralLink(vendorName, offer);')
+open(p, "w").write(s)
+PY
+}
+
+m_every_vendor_page_counts_as_already_holding_a_surface() {
+  py <<'PY'
+p = "src/referral-surfaces.ts"
+s = open(p).read()
+s = s.replace('  return hasOurReferralLink(vendorName, offer) || documentsVendorReferralProgram(offer);',
+              '  return vendorName !== "" || documentsVendorReferralProgram(offer);')
+open(p, "w").write(s)
+PY
+}
+
+m_the_listing_drops_the_platform_store() {
+  py <<'PY'
+p = "src/referral-surfaces.ts"
+s = open(p).read()
+s = s.replace('  for (const code of getAllPlatformCodes()) {\n    const slug = toSlug(code.vendor);\n    if (slug && !vendorNameBySlug.has(slug)) vendorNameBySlug.set(slug, code.vendor);\n  }\n', '')
+open(p, "w").write(s)
+PY
+}
+
+m_the_listing_drops_the_offer_store() {
+  py <<'PY'
+p = "src/referral-surfaces.ts"
+s = open(p).read()
+s = s.replace('    if (!offer.referral) continue;\n    const slug = toSlug(offer.vendor);\n    if (slug && !vendorNameBySlug.has(slug)) vendorNameBySlug.set(slug, offer.vendor);',
+              '    if (!offer.referral) continue;')
+open(p, "w").write(s)
+PY
+}
+
+m_the_platform_code_loses_the_program_terms_link() {
+  py <<'PY'
+p = "src/referral-surfaces.ts"
+s = open(p).read()
+s = s.replace('      termsUrl: offerReferral?.terms_url ?? null,\n      source: "platform_code",',
+              '      termsUrl: null,\n      source: "platform_code",')
+open(p, "w").write(s)
+PY
+}
+
+m_a_single_partner_is_counted_in_the_plural() {
+  py <<'PY'
+p = "src/referral-surfaces.ts"
+s = open(p).read()
+s = s.replace('  return count === 1\n    ? "only 1 currently has a referral link of ours"\n    : `only ${count} currently have a referral link of ours`;',
+              '  return `only ${count} currently have a referral link of ours`;')
+open(p, "w").write(s)
+PY
+}
+
+m_the_disclosure_counts_the_offer_store() {
+  py <<'PY'
+p = "src/serve.ts"
+s = open(p).read()
+s = s.replace('  const ourReferralLinks = allOurReferralLinks(offers);',
+              '  const ourReferralLinks = offers.filter(o => o.referral).map(o => ({ vendor: o.vendor, url: o.referral!.url, refereeBenefit: o.referral!.referee_value, termsUrl: o.referral!.terms_url ?? null, source: "offer_referral" as const }));')
+open(p, "w").write(s)
+PY
+}
+
+m_the_disclosure_counts_the_vendors_own_programs_too() {
+  py <<'PY'
+p = "src/serve.ts"
+s = open(p).read()
+s = s.replace('  for (const link of ourReferralLinks) vendorsWithOwnProgram.delete(toSlug(link.vendor));', '')
+open(p, "w").write(s)
+PY
+}
+
+m_the_disclosure_describes_agent_codes_that_do_not_exist() {
+  py <<'PY'
+p = "src/serve.ts"
+s = open(p).read()
+s = s.replace('  const agentSubmittedCodes = listAllReferralCodes({ source: "agent-submitted" });',
+              '  const agentSubmittedCodes = listAllReferralCodes({ source: "platform" });')
+open(p, "w").write(s)
+PY
+}
+
+m_the_directory_splits_on_the_offer_store() {
+  py <<'PY'
+p = "src/serve.ts"
+s = open(p).read()
+s = s.replace('        hasCode: ourLink !== null,', '        hasCode: !!o.referral,')
+open(p, "w").write(s)
+PY
+}
+
+m_the_directory_calls_every_program_unpaid() {
+  py <<'PY'
+p = "src/serve.ts"
+s = open(p).read()
+s = s.replace('        hasCode: ourLink !== null,', '        hasCode: false,')
+open(p, "w").write(s)
+PY
+}
+
+m_the_directory_orders_its_inventory_by_who_pays_us() {
+  py <<'PY'
+p = "src/serve.ts"
+s = open(p).read()
+s = s.replace('  const inventoryOrder = rotateListing([...programVendors], "referral-programs:inventory");',
+              '  const inventoryOrder = [...paidSection, ...unpaidSection];')
+open(p, "w").write(s)
+PY
+}
+
+m_the_vendor_page_solicits_where_it_already_has_a_code() {
+  py <<'PY'
+p = "src/serve.ts"
+s = open(p).read()
+s = s.replace('  const marketplaceSolicitationHtml = !hasAnyReferralSurface(vendorName, primary) ? `',
+              '  const marketplaceSolicitationHtml = !(primary.referral_program?.available === true) ? `')
+open(p, "w").write(s)
+PY
+}
+
+run_mutation "the predicate reads the offer store only" m_the_predicate_reads_the_offer_store_only
+run_mutation "the predicate reads the platform store only" m_the_predicate_reads_the_platform_store_only
+run_mutation "a documented program counts as a link of ours" m_a_documented_program_counts_as_a_link_of_ours
+run_mutation "a documented program is not a referral surface" m_a_documented_program_is_not_a_referral_surface
+run_mutation "every vendor page counts as already holding a surface" m_every_vendor_page_counts_as_already_holding_a_surface
+run_mutation "the listing drops the platform store" m_the_listing_drops_the_platform_store
+run_mutation "the listing drops the offer store" m_the_listing_drops_the_offer_store
+run_mutation "the platform code loses the program terms link" m_the_platform_code_loses_the_program_terms_link
+run_mutation "a single partner is counted in the plural" m_a_single_partner_is_counted_in_the_plural
+run_mutation "the disclosure counts the offer store" m_the_disclosure_counts_the_offer_store
+run_mutation "the disclosure counts the vendors own programs too" m_the_disclosure_counts_the_vendors_own_programs_too
+run_mutation "the disclosure describes agent codes that do not exist" m_the_disclosure_describes_agent_codes_that_do_not_exist
+run_mutation "the directory splits on the offer store" m_the_directory_splits_on_the_offer_store
+run_mutation "the directory calls every program unpaid" m_the_directory_calls_every_program_unpaid
+run_mutation "the directory orders its inventory by who pays us" m_the_directory_orders_its_inventory_by_who_pays_us
+run_mutation "the vendor page solicits where it already has a code" m_the_vendor_page_solicits_where_it_already_has_a_code
+
+restore
+npm run build > /dev/null 2>&1
+echo
+echo "killed: $killed  survived: $survived"
+[ "$survived" -eq 0 ]

--- a/scripts/sweep-1154.mjs
+++ b/scripts/sweep-1154.mjs
@@ -1,0 +1,74 @@
+import { spawn } from "node:child_process";
+import { createHash } from "node:crypto";
+import { readFileSync, writeFileSync } from "node:fs";
+import path from "node:path";
+
+const repo = process.argv[2];
+const out = process.argv[3];
+
+function startServer() {
+  return new Promise((resolve, reject) => {
+    const p = spawn("node", [path.join(repo, "dist", "serve.js")], {
+      cwd: repo,
+      stdio: ["pipe", "pipe", "pipe"],
+      env: { ...process.env, PORT: "0", BASE_URL: "http://127.0.0.1" },
+    });
+    const timeout = setTimeout(() => { p.kill("SIGKILL"); reject(new Error("timeout")); }, 30000);
+    p.stderr.on("data", (b) => {
+      const m = b.toString().match(/running on http:\/\/localhost:(\d+)/);
+      if (m) { clearTimeout(timeout); resolve({ proc: p, port: parseInt(m[1], 10) }); }
+    });
+    p.on("error", (e) => { clearTimeout(timeout); reject(e); });
+  });
+}
+
+const toSlug = (s) => s.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-|-$/g, "");
+const index = JSON.parse(readFileSync(path.join(repo, "data", "index.json"), "utf8"));
+const offers = Array.isArray(index) ? index : index.offers;
+const vendorSlugs = [...new Set(offers.map((o) => toSlug(o.vendor)))].filter(Boolean).sort();
+
+const fullBodyPaths = [
+  "/disclosure",
+  "/referral-programs",
+  "/marketplace",
+  "/api/referral-programs",
+  "/api/referral-codes",
+  "/api/referral-codes?source=platform",
+  "/api/referral-codes?source=agent-submitted",
+  "/privacy",
+  "/press",
+];
+
+const { proc, port } = await startServer();
+const result = { pages: {}, vendors: {} };
+
+for (const p of fullBodyPaths) {
+  const res = await fetch(`http://127.0.0.1:${port}${p}`);
+  const body = await res.text();
+  result.pages[p] = { status: res.status, length: body.length, body };
+}
+
+for (const slug of vendorSlugs) {
+  const res = await fetch(`http://127.0.0.1:${port}/vendor/${slug}`);
+  const body = await res.text();
+  result.vendors[slug] = {
+    status: res.status,
+    length: body.length,
+    sha: createHash("sha256").update(body).digest("hex"),
+    referralBox: body.includes("Sign up via our referral link"),
+    programSection: body.includes("<h2>Referral Program</h2>"),
+    solicitation: body.includes("marketplace-solicitation"),
+  };
+}
+
+proc.kill("SIGKILL");
+writeFileSync(out, JSON.stringify(result));
+
+const renderingReferral = Object.entries(result.vendors).filter(([, v]) => v.referralBox).map(([k]) => k);
+console.log(`swept ${fullBodyPaths.length} pages + ${vendorSlugs.length} vendor pages -> ${out}`);
+console.log(`vendor pages rendering a referral link: ${renderingReferral.length} (${renderingReferral.join(", ")})`);
+console.log(`vendor pages rendering the marketplace solicitation: ${Object.values(result.vendors).filter((v) => v.solicitation).length}`);
+const bad = Object.entries(result.pages).filter(([, v]) => v.status !== 200);
+if (bad.length) console.log("NON-200:", bad.map(([k, v]) => `${k}=${v.status}`).join(", "));
+const badVendors = Object.entries(result.vendors).filter(([, v]) => v.status !== 200);
+if (badVendors.length) console.log(`NON-200 vendor pages: ${badVendors.length}`);

--- a/src/referral-surfaces.ts
+++ b/src/referral-surfaces.ts
@@ -1,0 +1,88 @@
+import { getAllPlatformCodes, getPlatformCodeForVendor } from "./platform-codes.js";
+import { toSlug } from "./vendor-slug.js";
+import type { Offer } from "./types.js";
+
+export type OurReferralLinkSource = "platform_code" | "offer_referral";
+
+export interface OurReferralLink {
+  vendor: string;
+  url: string;
+  refereeBenefit: string;
+  termsUrl: string | null;
+  source: OurReferralLinkSource;
+}
+
+const REFEREE_BENEFIT_FALLBACK = "Referral link available";
+
+export function ourReferralLinkFor(vendorName: string, offer?: Offer | null): OurReferralLink | null {
+  const platformCode = getPlatformCodeForVendor(vendorName);
+  const offerReferral = offer?.referral ?? null;
+
+  if (platformCode) {
+    return {
+      vendor: platformCode.vendor,
+      url: platformCode.referral_url,
+      refereeBenefit: platformCode.referee_benefit,
+      termsUrl: offerReferral?.terms_url ?? null,
+      source: "platform_code",
+    };
+  }
+
+  if (offerReferral && offer) {
+    return {
+      vendor: offer.vendor,
+      url: offerReferral.url,
+      refereeBenefit: offerReferral.referee_value ?? REFEREE_BENEFIT_FALLBACK,
+      termsUrl: offerReferral.terms_url ?? null,
+      source: "offer_referral",
+    };
+  }
+
+  return null;
+}
+
+export function referralLinkCountClause(count: number): string {
+  return count === 1
+    ? "only 1 currently has a referral link of ours"
+    : `only ${count} currently have a referral link of ours`;
+}
+
+export function hasOurReferralLink(vendorName: string, offer?: Offer | null): boolean {
+  return ourReferralLinkFor(vendorName, offer) !== null;
+}
+
+export function documentsVendorReferralProgram(offer?: Offer | null): boolean {
+  return offer?.referral_program?.available === true;
+}
+
+export function hasAnyReferralSurface(vendorName: string, offer?: Offer | null): boolean {
+  return hasOurReferralLink(vendorName, offer) || documentsVendorReferralProgram(offer);
+}
+
+export function allOurReferralLinks(offers: Offer[]): OurReferralLink[] {
+  const offerBySlug = new Map<string, Offer>();
+  for (const offer of offers) {
+    const slug = toSlug(offer.vendor);
+    if (!slug) continue;
+    const held = offerBySlug.get(slug);
+    if (!held || (!held.referral && offer.referral)) offerBySlug.set(slug, offer);
+  }
+
+  const vendorNameBySlug = new Map<string, string>();
+  for (const code of getAllPlatformCodes()) {
+    const slug = toSlug(code.vendor);
+    if (slug && !vendorNameBySlug.has(slug)) vendorNameBySlug.set(slug, code.vendor);
+  }
+  for (const offer of offers) {
+    if (!offer.referral) continue;
+    const slug = toSlug(offer.vendor);
+    if (slug && !vendorNameBySlug.has(slug)) vendorNameBySlug.set(slug, offer.vendor);
+  }
+
+  const links: OurReferralLink[] = [];
+  for (const [slug, vendorName] of vendorNameBySlug) {
+    const link = ourReferralLinkFor(vendorName, offerBySlug.get(slug) ?? null);
+    if (link) links.push(link);
+  }
+  return links;
+}

--- a/src/serve.ts
+++ b/src/serve.ts
@@ -27,6 +27,7 @@ import { recordConversion, confirmEligibleEntries, clawbackEntry, getAgentBalanc
 import { validateX402Address, executeTransfer, generateCorrelationId } from "./x402.js";
 import { submitReferralCode, getCodesByAgent, getCodeById, updateCode, revokeCode, calculateTrustTier, getDailySubmissionCount, getDailyLimit, getRankedCodesForVendor, calculateCodeScore } from "./referral-codes.js";
 import { getPlatformCodeForVendor, getBestReferralCode, listAllReferralCodes } from "./platform-codes.js";
+import { allOurReferralLinks, hasAnyReferralSurface, ourReferralLinkFor, referralLinkCountClause } from "./referral-surfaces.js";
 import { runHealthCheck, getLastReport, startPeriodicChecks } from "./referral-health.js";
 import { addFriend, removeFriend, getFriends, getFriendCodesForVendors } from "./friends.js";
 import { subscribe as watchlistSubscribe, getSubscription as getWatchlistSubscription, unsubscribe as watchlistUnsubscribe, listSubscriptions as listWatchlistSubscriptions } from "./watchlist.js";
@@ -4115,8 +4116,7 @@ ${allCompareLinks.join("\n")}
   // Marketplace solicitation (low-pressure) — shown only when this vendor has no
   // platform code, no documented program, and no offer-level referral. Converts
   // dormant vendor pages into acquisition surfaces for code submitters.
-  const hasAnyReferralSurface = !!platformCode || primary.referral_program?.available === true || !!primary.referral;
-  const marketplaceSolicitationHtml = !hasAnyReferralSurface ? `
+  const marketplaceSolicitationHtml = !hasAnyReferralSurface(vendorName, primary) ? `
   <div class="section marketplace-solicitation">
     <div style="border:1px dashed var(--border);border-radius:8px;padding:1rem;background:var(--bg-card);opacity:.92">
       <h3 style="margin:0 0 .5rem;font-size:.95rem;color:var(--text)">Know a referral or partner program for ${escHtmlServer(vendorName)}?</h3>
@@ -51076,6 +51076,7 @@ function buildReferralProgramsPage(): string {
   for (const o of offers) {
     if (o.referral_program?.available && !seen.has(o.vendor)) {
       seen.add(o.vendor);
+      const ourLink = ourReferralLinkFor(o.vendor, o);
       programVendors.push({
         vendor: o.vendor,
         category: o.category,
@@ -51084,9 +51085,9 @@ function buildReferralProgramsPage(): string {
         program_url: o.referral_program.program_url,
         type: o.referral_program.type,
         commission_type: o.referral_program.commission_type,
-        hasCode: !!o.referral,
-        referralUrl: o.referral?.url,
-        refereeValue: o.referral?.referee_value,
+        hasCode: ourLink !== null,
+        referralUrl: ourLink?.url,
+        refereeValue: ourLink?.refereeBenefit,
       });
     }
   }
@@ -51104,8 +51105,9 @@ function buildReferralProgramsPage(): string {
    */
   const paidSection = rotateListing(programVendors.filter(v => v.hasCode), "referral-programs:with-code");
   const unpaidSection = rotateListing(programVendors.filter(v => !v.hasCode), "referral-programs:without-code");
+  const inventoryOrder = rotateListing([...programVendors], "referral-programs:inventory");
   programVendors.length = 0;
-  programVendors.push(...paidSection, ...unpaidSection);
+  programVendors.push(...inventoryOrder);
 
   const withCodes = paidSection.length;
   const withoutCodes = unpaidSection.length;
@@ -51831,7 +51833,11 @@ function buildDisclosurePage(): string {
   };
 
   // Find all offers with referral data
-  const referralOffers = offers.filter(o => o.referral);
+  const ourReferralLinks = allOurReferralLinks(offers);
+  const vendorsWithOwnProgram = new Set(offers.filter(o => o.referral_program?.available === true).map(o => toSlug(o.vendor)));
+  for (const link of ourReferralLinks) vendorsWithOwnProgram.delete(toSlug(link.vendor));
+  const countClause = referralLinkCountClause(ourReferralLinks.length);
+  const agentSubmittedCodes = listAllReferralCodes({ source: "agent-submitted" });
 
   return `<!DOCTYPE html>
 <html lang="en">
@@ -51900,24 +51906,23 @@ ${globalNavCss()}
       <li>Our data is the same whether or not a vendor has a referral program</li>
       <li>Pricing change tracking, risk assessments, and stability ratings are objective and unaffected</li>
       <li>Vendors without referral programs are not ranked lower or excluded</li>
-      <li>We track ${offers.length.toLocaleString()} vendor offers &mdash; only ${referralOffers.length} currently have referral links</li>
+      <li>We track ${offers.length.toLocaleString()} vendor offers &mdash; ${countClause}</li>
     </ul>
   </div>
-
+${agentSubmittedCodes.length > 0 ? `
   <div class="section">
     <h2>Agent-Submitted Referral Codes</h2>
-    <p>Some referral codes on AgentDeals are submitted by community agents &mdash; autonomous software agents registered in our marketplace. These codes are:</p>
+    <p>${agentSubmittedCodes.length === 1 ? "One referral code on AgentDeals was" : `${agentSubmittedCodes.length} referral codes on AgentDeals were`} submitted by community agents &mdash; autonomous software agents registered in our marketplace. ${agentSubmittedCodes.length === 1 ? "It is" : "They are"}:</p>
     <ul>
       <li>Ranked by performance (conversion rate) and trust tier</li>
       <li>Subject to a trust system: new agents' codes are reviewed before activation; verified and trusted agents get auto-approved codes</li>
       <li>Labeled with their source so you can see whether a code is curated by AgentDeals or submitted by a community agent</li>
-      <li>Revenue from agent-submitted codes is split between the submitting agent, the surfacing agent, and the platform</li>
     </ul>
-  </div>
-
+  </div>` : ""}
   <div class="section">
     <h2>Current Referral Partners</h2>
-    ${referralOffers.length > 0 ? `<ul>${referralOffers.map(o => `<li><a href="/vendor/${toSlug(o.vendor)}">${escHtmlServer(o.vendor)}</a>: ${escHtmlServer(o.referral!.referee_value ?? "Referral link available")}${o.referral!.terms_url ? ` (<a href="${escHtmlServer(o.referral!.terms_url)}" rel="noopener" target="_blank">program terms</a>)` : ""}</li>`).join("")}</ul>` : `<p>No referral partners at this time.</p>`}
+    ${ourReferralLinks.length > 0 ? `<ul>${ourReferralLinks.map(l => `<li><a href="/vendor/${toSlug(l.vendor)}">${escHtmlServer(l.vendor)}</a>: ${escHtmlServer(l.refereeBenefit)}${l.termsUrl ? ` (<a href="${escHtmlServer(l.termsUrl)}" rel="noopener" target="_blank">program terms</a>)` : ""}</li>`).join("")}</ul>` : `<p>No referral partners at this time.</p>`}
+    ${vendorsWithOwnProgram.size > 0 ? `<p>We also document ${vendorsWithOwnProgram.size} ${vendorsWithOwnProgram.size === 1 ? "vendor that runs its own referral program" : "vendors that run their own referral programs"} on <a href="/referral-programs">/referral-programs</a>. We hold no code and earn nothing from ${vendorsWithOwnProgram.size === 1 ? "it" : "those"} &mdash; the program is listed because it exists, not because of any relationship with us.</p>` : ""}
   </div>
 
   <p class="updated">Published 2026-04-11${pageFreshness("/disclosure")}</p>

--- a/test/ranked-surfaces.test.ts
+++ b/test/ranked-surfaces.test.ts
@@ -165,8 +165,8 @@ describe("/referral-programs stops being ordered by our own money", () => {
 
   it("orders within a section by rotation, not the alphabet", async () => {
     const { text } = await get("/referral-programs");
-    // Only one vendor currently has one of our codes, so the observable
-    // section is the unpaid one — the second table.
+    // The unpaid section — the second table — is the larger of the two, and is
+    // the one this pins.
     const secondBodyAt = text.indexOf("<tbody>", text.indexOf("</tbody>"));
     const secondTable = text.slice(secondBodyAt, text.indexOf("</tbody>", secondBodyAt));
     const vendors = [...secondTable.matchAll(/class="vendor-link">([^<]+)</g)].map((m) => m[1]);
@@ -176,6 +176,7 @@ describe("/referral-programs stops being ordered by our own money", () => {
     // Pinned to the rotation the module actually produces over the source
     // order, so reintroducing any other sort fails here.
     const { rotateListing } = await import("../src/ranking.ts");
+    const { hasOurReferralLink } = await import("../dist/referral-surfaces.js");
     const index = JSON.parse(readFileSync(path.join(REPO, "data", "index.json"), "utf8")) as {
       offers: { vendor: string; referral?: unknown; referral_program?: { available?: boolean } }[];
     };
@@ -184,7 +185,7 @@ describe("/referral-programs stops being ordered by our own money", () => {
     for (const o of index.offers) {
       if (o.referral_program?.available && !seen.has(o.vendor)) {
         seen.add(o.vendor);
-        if (!o.referral) sourceOrder.push(o.vendor);
+        if (!hasOurReferralLink(o.vendor, o)) sourceOrder.push(o.vendor);
       }
     }
     assert.deepStrictEqual(vendors, rotateListing(sourceOrder, "referral-programs:without-code"));

--- a/test/referral-disclosure-predicate.test.ts
+++ b/test/referral-disclosure-predicate.test.ts
@@ -1,0 +1,312 @@
+import { describe, it, before, after } from "node:test";
+import assert from "node:assert";
+import fs from "node:fs";
+import { spawn, type ChildProcess } from "node:child_process";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+const { loadOffers } = await import("../dist/data.js");
+const { allOurReferralLinks, ourReferralLinkFor, hasOurReferralLink, hasAnyReferralSurface, documentsVendorReferralProgram, referralLinkCountClause } = await import("../dist/referral-surfaces.js");
+const { getAllPlatformCodes, resetPlatformCodesCache } = await import("../dist/platform-codes.js");
+
+const offers = loadOffers();
+const offerFor = (vendor: string) => offers.find((o: any) => o.vendor === vendor);
+
+const PLATFORM_CODES_PATH = path.join(__dirname, "..", "data", "platform_codes.json");
+
+function startServer(): Promise<{ proc: ChildProcess; port: number }> {
+  return new Promise((resolve, reject) => {
+    const serverPath = path.join(__dirname, "..", "dist", "serve.js");
+    const proc = spawn("node", [serverPath], {
+      stdio: ["pipe", "pipe", "pipe"],
+      env: { ...process.env, PORT: "0", BASE_URL: "http://localhost" },
+    });
+    const timeout = setTimeout(() => {
+      proc.kill();
+      reject(new Error("Server startup timeout"));
+    }, 15000);
+    proc.stderr!.on("data", (data: Buffer) => {
+      const match = data.toString().match(/running on http:\/\/localhost:(\d+)/);
+      if (match) {
+        clearTimeout(timeout);
+        resolve({ proc, port: parseInt(match[1], 10) });
+      }
+    });
+    proc.on("error", (err) => {
+      clearTimeout(timeout);
+      reject(err);
+    });
+  });
+}
+
+function sectionAfter(html: string, heading: string, nextHeading: string): string {
+  const start = html.indexOf(heading);
+  assert.notStrictEqual(start, -1, `expected the page to contain "${heading}"`);
+  const end = nextHeading ? html.indexOf(nextHeading, start + heading.length) : -1;
+  return end === -1 ? html.slice(start) : html.slice(start, end);
+}
+
+describe("one predicate decides whether we hold a referral link for a vendor", () => {
+  it("a vendor held only in the platform code store still counts as one of ours", () => {
+    const link = ourReferralLinkFor("Proton Mail", offerFor("Proton Mail"));
+    assert.ok(link, "Proton Mail is in data/platform_codes.json and should resolve to a referral link");
+    assert.strictEqual(link!.source, "platform_code");
+    assert.ok(link!.url.length > 0);
+  });
+
+  it("a vendor that documents its own program is a referral surface but not a link of ours", () => {
+    const vercel = offerFor("Vercel");
+    assert.ok(vercel, "Vercel should be in the index");
+    assert.ok(documentsVendorReferralProgram(vercel), "Vercel documents its own referral program");
+    assert.strictEqual(ourReferralLinkFor("Vercel", vercel), null, "we hold no code for Vercel");
+    assert.strictEqual(hasAnyReferralSurface("Vercel", vercel), true, "the program section is still a referral surface");
+  });
+
+  it("a vendor with no program and no code of ours has no referral surface at all", () => {
+    const plain = offers.find((o: any) => !o.referral && !o.referral_program?.available && !hasOurReferralLink(o.vendor, o));
+    assert.ok(plain, "expected at least one offer with no referral surface");
+    assert.strictEqual(hasAnyReferralSurface(plain.vendor, plain), false);
+  });
+
+  it("a vendor held in both stores resolves once, keeping the program terms link", () => {
+    const railway = offerFor("Railway");
+    const link = ourReferralLinkFor("Railway", railway);
+    assert.ok(link);
+    assert.strictEqual(link!.source, "platform_code");
+    assert.strictEqual(link!.termsUrl, railway.referral.terms_url);
+    const railwayEntries = allOurReferralLinks(offers).filter((l: any) => l.vendor === "Railway");
+    assert.strictEqual(railwayEntries.length, 1, "Railway is in both stores and should be listed once");
+  });
+
+  it("resolves a vendor whose only referral link sits in the offer index", () => {
+    const offerOnly = {
+      vendor: "Example Storage",
+      referral: { url: "https://example.com/ref/STORAGE", referee_value: "$5 credit", terms_url: "https://example.com/terms" },
+    };
+    const link = ourReferralLinkFor(offerOnly.vendor, offerOnly as any);
+    assert.ok(link, "an offer-level referral is a referral link of ours even with no platform code");
+    assert.strictEqual(link!.source, "offer_referral");
+    assert.strictEqual(link!.refereeBenefit, "$5 credit");
+    assert.strictEqual(link!.termsUrl, "https://example.com/terms");
+  });
+
+  it("lists a vendor held only in the offer index alongside the platform ones", () => {
+    const offerOnly = { vendor: "Example Storage", referral: { url: "https://example.com/ref/STORAGE", referee_value: "$5 credit" } };
+    const links = allOurReferralLinks([...offers, offerOnly] as any);
+    const added = links.filter((l: any) => l.vendor === "Example Storage");
+    assert.strictEqual(added.length, 1, "an offer-level referral should be listed once");
+    assert.strictEqual(links.length, allOurReferralLinks(offers).length + 1);
+  });
+
+  it("counts a single partner in the singular, whatever today's total is", () => {
+    assert.strictEqual(referralLinkCountClause(1), "only 1 currently has a referral link of ours");
+    assert.strictEqual(referralLinkCountClause(0), "only 0 currently have a referral link of ours");
+    assert.strictEqual(referralLinkCountClause(5), "only 5 currently have a referral link of ours");
+  });
+
+  it("every active platform code is one of the links we list", () => {
+    const listed = new Set(allOurReferralLinks(offers).map((l: any) => l.vendor));
+    for (const code of getAllPlatformCodes()) {
+      assert.ok(listed.has(code.vendor), `${code.vendor} has an active platform code and should be listed`);
+    }
+  });
+});
+
+describe("the affiliate disclosure counts what the site renders", () => {
+  let serverProc: ChildProcess | null = null;
+  let port = 0;
+  let html = "";
+
+  before(async () => {
+    const started = await startServer();
+    serverProc = started.proc;
+    port = started.port;
+    html = await (await fetch(`http://localhost:${port}/disclosure`)).text();
+  });
+
+  after(() => {
+    serverProc?.kill();
+  });
+
+  it("names every vendor we hold a referral link for", () => {
+    const partners = sectionAfter(html, "Current Referral Partners", "class=\"updated\"");
+    for (const link of allOurReferralLinks(offers)) {
+      assert.ok(partners.includes(link.vendor), `${link.vendor} has a referral link of ours and should be named as a partner`);
+    }
+  });
+
+  it("states a count equal to the number of links it lists", () => {
+    const expected = allOurReferralLinks(offers).length;
+    const stated = html.match(/only (\d+) currently have a referral link of ours/) ?? html.match(/only (1) currently has a referral link of ours/);
+    assert.ok(stated, "expected the page to state how many vendors have a referral link of ours");
+    assert.strictEqual(parseInt(stated[1], 10), expected);
+  });
+
+  it("agrees with itself on singular and plural", () => {
+    const count = allOurReferralLinks(offers).length;
+    if (count === 1) {
+      assert.ok(html.includes("only 1 currently has a referral link of ours"));
+      assert.ok(!html.includes("only 1 currently have"));
+    } else {
+      assert.ok(html.includes(`only ${count} currently have a referral link of ours`));
+    }
+  });
+
+  it("separates vendors running their own programs from partners of ours", () => {
+    const ours = new Set(allOurReferralLinks(offers).map((l: any) => l.vendor.toLowerCase()));
+    const theirs = new Set(
+      offers.filter((o: any) => o.referral_program?.available === true && !ours.has(o.vendor.toLowerCase())).map((o: any) => o.vendor)
+    );
+    assert.ok(theirs.size > 0, "expected vendors that run their own program without a code of ours");
+    assert.ok(html.includes(`We also document ${theirs.size} vendors that run their own referral programs`));
+    assert.ok(html.includes("We hold no code and earn nothing from those"));
+  });
+
+  it("does not promise a revenue split for agent-submitted codes while none exist", async () => {
+    const listed = await (await fetch(`http://localhost:${port}/api/referral-codes?source=agent-submitted`)).json();
+    assert.strictEqual(listed.total, 0, "this expectation only holds while no agent has a code with us");
+    assert.ok(!html.includes("Agent-Submitted Referral Codes"), "no agent has submitted a code, so the section describes nothing");
+    assert.ok(!html.includes("split between the submitting agent"));
+  });
+
+  it("names exactly the vendors whose pages render a referral link", async () => {
+    for (const link of allOurReferralLinks(offers)) {
+      const slug = link.vendor.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-|-$/g, "");
+      const page = await (await fetch(`http://localhost:${port}/vendor/${slug}`)).text();
+      assert.ok(page.includes("Sign up via our referral link"), `/vendor/${slug} is listed as a partner and should render the referral link`);
+    }
+    const vercel = await (await fetch(`http://localhost:${port}/vendor/vercel`)).text();
+    assert.ok(!vercel.includes("Sign up via our referral link"), "we hold no code for Vercel, so its page must not offer one");
+  });
+});
+
+describe("the referral programs directory labels our commercial relationships", () => {
+  let serverProc: ChildProcess | null = null;
+  let html = "";
+
+  const jsonLdOfType = (type: string) =>
+    [...html.matchAll(/<script type="application\/ld\+json">(.*?)<\/script>/g)]
+      .map((m) => JSON.parse(m[1]))
+      .find((d: any) => d["@type"] === type);
+
+  const inventoryRotation = async () => {
+    const { rotateListing } = await import("../src/ranking.ts");
+    const seen = new Set<string>();
+    const sourceOrder: string[] = [];
+    for (const o of offers) {
+      if (o.referral_program?.available && !seen.has(o.vendor)) {
+        seen.add(o.vendor);
+        sourceOrder.push(o.vendor);
+      }
+    }
+    return rotateListing(sourceOrder, "referral-programs:inventory");
+  };
+
+  before(async () => {
+    const started = await startServer();
+    serverProc = started.proc;
+    html = await (await fetch(`http://localhost:${started.port}/referral-programs`)).text();
+  });
+
+  after(() => {
+    serverProc?.kill();
+  });
+
+  it("puts every vendor we hold a code for in the section that says we may be paid", () => {
+    const paid = sectionAfter(html, "Programs we have a referral link for", "Programs we don");
+    const withProgram = offers.filter((o: any) => o.referral_program?.available === true);
+    for (const offer of withProgram) {
+      if (!hasOurReferralLink(offer.vendor, offer)) continue;
+      assert.ok(paid.includes(`>${offer.vendor}<`), `${offer.vendor} has a referral link of ours and belongs in the paid section`);
+    }
+  });
+
+  it("claims to earn nothing only from vendors we hold no code for", () => {
+    const unpaid = sectionAfter(html, "Programs we don", "agent-cta");
+    assert.ok(unpaid.includes("We earn nothing from these"));
+    for (const offer of offers) {
+      if (!hasOurReferralLink(offer.vendor, offer)) continue;
+      assert.ok(!unpaid.includes(`>${offer.vendor}<`), `${offer.vendor} pays us and must not sit under "We earn nothing from these"`);
+    }
+  });
+
+  it("orders its structured data over the whole inventory, not paid vendors first", async () => {
+    const itemList = jsonLdOfType("ItemList");
+    const listed = itemList.itemListElement.map((e: any) => e.item.name.replace(" Referral Program", ""));
+    assert.deepStrictEqual(listed, await inventoryRotation());
+  });
+
+  it("draws its worked examples from that same order", async () => {
+    const answer = jsonLdOfType("FAQPage").mainEntity[0].acceptedAnswer.text;
+    const expected = (await inventoryRotation()).slice(0, 5);
+    assert.ok(answer.includes(expected.join(", ")), `expected the first five of the inventory order, got: ${answer}`);
+  });
+
+  it("offers our own code rather than a submission form for vendors we hold one for", () => {
+    const paid = sectionAfter(html, "Programs we have a referral link for", "Programs we don");
+    for (const link of allOurReferralLinks(offers)) {
+      const offer = offerFor(link.vendor);
+      if (!offer?.referral_program?.available) continue;
+      assert.ok(paid.includes(link.url), `${link.vendor}'s row should link to the code we hold`);
+    }
+  });
+});
+
+describe("a new row in the platform code store is disclosed on its own", () => {
+  let serverProc: ChildProcess | null = null;
+  let originalFile = "";
+  let html = "";
+  let quietVendorPage = "";
+  const addedVendor = "Example Cloud";
+  const quietVendor = offers.find((o: any) => !hasAnyReferralSurface(o.vendor, o))!.vendor;
+
+  const syntheticRow = (vendor: string) => ({
+    vendor,
+    code: "EXAMPLECODE",
+    referral_url: "https://example.com/ref/EXAMPLECODE",
+    referrer_benefit: "$1 credit",
+    referee_benefit: "$1 credit",
+    source: "platform",
+    active: true,
+    added_at: "2026-08-29",
+  });
+
+  before(async () => {
+    originalFile = fs.readFileSync(PLATFORM_CODES_PATH, "utf-8");
+    const data = JSON.parse(originalFile);
+    data.platform_codes.push(syntheticRow(addedVendor), syntheticRow(quietVendor));
+    fs.writeFileSync(PLATFORM_CODES_PATH, JSON.stringify(data, null, 2), "utf-8");
+    resetPlatformCodesCache();
+    const started = await startServer();
+    serverProc = started.proc;
+    html = await (await fetch(`http://localhost:${started.port}/disclosure`)).text();
+    const slug = quietVendor.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-|-$/g, "");
+    quietVendorPage = await (await fetch(`http://localhost:${started.port}/vendor/${slug}`)).text();
+  });
+
+  after(() => {
+    serverProc?.kill();
+    fs.writeFileSync(PLATFORM_CODES_PATH, originalFile, "utf-8");
+    resetPlatformCodesCache();
+  });
+
+  it("appears as a referral partner without any change to the offer index", () => {
+    const partners = sectionAfter(html, "Current Referral Partners", "class=\"updated\"");
+    assert.ok(partners.includes(addedVendor), "a platform code row alone should name the vendor as a partner");
+    assert.ok(!offers.some((o: any) => o.vendor === addedVendor), "the offer index was not touched");
+  });
+
+  it("is included in the stated count", () => {
+    const withAddedRows = allOurReferralLinks(offers).length;
+    const withoutAddedRows = JSON.parse(originalFile).platform_codes.filter((c: any) => c.active).length;
+    assert.strictEqual(withAddedRows, withoutAddedRows + 2, "the added rows should be the only new links");
+    assert.ok(html.includes(referralLinkCountClause(withAddedRows)));
+  });
+
+  it("turns a page that was asking for a code into one that offers ours", () => {
+    assert.ok(quietVendorPage.includes("Sign up via our referral link"), "the code row alone should render the referral link");
+    assert.ok(!quietVendorPage.includes("marketplace-solicitation"), "a page that now has a code of ours must stop asking for one");
+  });
+});


### PR DESCRIPTION
Refs #1154.

## The defect

`/disclosure` said:

> We track 1,580 vendor offers — only **1** currently have referral links

and listed **Railway** as our only referral partner, while `/vendor/proton-mail`, `/vendor/proton-vpn`, `/vendor/proton-pass` and `/vendor/proton-drive` each rendered a green box reading *"Sign up via our referral link and get $20 credit"* with *"We may earn a commission if you sign up through this link."*

Two stores keyed on vendor, holding different sets: the counter read `offer.referral` in `data/index.json` (1 row), the button reads `data/platform_codes.json` (5 rows).

## A second surface said the opposite of the truth

`/referral-programs` splits into two labelled sections and takes `hasCode` from the same wrong store. The four Proton vendors sat under:

> **Programs we don't have a referral link for** — 20 of 21. **We earn nothing from these.** They are here because the programme exists, not because of any relationship with us.

That page exists because of #1025, which stopped it being ordered by our commercial interest. Denying a commercial relationship is a stronger claim than under-counting one, so it is fixed here too. Verified against production before the change: `proton-mail`, `proton-drive`, `proton-pass` and `proton-vpn` were all in the unpaid table.

## One predicate

`src/referral-surfaces.ts`:

- `ourReferralLinkFor(vendor, offer)` — the union of the two stores that publish a `rel="noopener sponsored"` link and a commission claim. Platform code wins; the offer's `terms_url` is kept when it has one, so Railway does not lose its program-terms link.
- `documentsVendorReferralProgram(offer)` — the vendor runs its own programme. Not a link of ours.
- `hasAnyReferralSurface(vendor, offer)` — the union of both, which is exactly what the vendor page's solicitation gate at `src/serve.ts:4118` already meant.

`/disclosure`, `/referral-programs` and the vendor page now call it (AC-1). Adding a row to `data/platform_codes.json` and nothing else puts the vendor in "Current Referral Partners" and in the count (AC-2) — there is a test that writes such a row, boots a server and reads the page back.

**On AC-1's wording.** The AC names the `hasAnyReferralSurface` union, which includes `referral_program.available`. Taken literally that puts ~21 vendors in "Current Referral Partners" and makes the count 21, contradicting AC-3's 5. It would also assert a commercial relationship with Vercel, Notion, Anthropic API and MongoDB that we do not have — a fresh falsehood on the page whose job is accuracy. So the count is the "link of ours" half, the solicitation gate keeps the full union, and the third component is stated on the page in its own sentence:

> We also document 16 vendors that run their own referral programs on /referral-programs. We hold no code and earn nothing from those — the program is listed because it exists, not because of any relationship with us.

Say the word if you want the count to be the full union instead.

## Two things found while in here

**A count that could be 1 read "only 1 currently have referral links."** It reads that way on production today, and would again the moment #1151 takes the count back to 1. `referralLinkCountClause` is a pure function so the singular branch is tested at 0, 1 and 5 rather than only at today's value.

**The paid/unpaid split fed the structured data.** `programVendors` was rebuilt as paid-then-unpaid and everything downstream read it, so moving four vendors into the paid half made the ItemList and the FAQ answer an AI engine quotes lead with exactly the five vendors that pay us — 1 of the first 5 before, 5 of 5 after. The inventory order is now its own whole-set rotation, pinned by a test that recomputes it from `data/index.json`; the tables keep their two rotations.

## AC-4

`/disclosure` carried an "Agent-Submitted Referral Codes" section ending *"Revenue from agent-submitted codes is split between the submitting agent, the surfacing agent, and the platform."* `data/referral_codes.json` holds zero codes on production and `src/x402.ts` answers *"x402 transfer not yet configured"* on every call, so the split has never happened and cannot. The section is now conditional on there being a code to describe, and the payout sentence is gone. The rest of the marketplace copy is #1150's.

## Verification

- **2564 tests, 0 failures** (22 new). `tsc` clean, `validate-data` clean at 1,580 offers / 444 changes.
- **`scripts/mutate-1154.sh` — 16 mutations, 16 killed, 0 survivors.** Two rounds: the first left three survivors, and each was a real gap — the singular clause was unreachable at today's count, the offer-store half of the listing was masked by Railway also holding a platform code, and the vendor-page call site could not be discriminated because every code-holding vendor also documents a programme. Fixed by extracting the clause, testing `allOurReferralLinks` against a synthetic offer, and adding a second synthetic code row for a vendor with no referral surface at all. `check-mutation-targets.mjs` 330/330 across 30 scripts.
- **AC-3 by rendering.** `scripts/sweep-1154.mjs` swept all 1,572 vendor pages on a `main` worktree and on this branch. **Exactly 5 vendor pages render a referral link** on both, which is the number `/disclosure` now states. The marketplace solicitation count is unchanged at 1,551, so the predicate refactor moved no vendor page.
- **All 1,572 vendor pages byte-identical.** `/disclosure` and `/referral-programs` are the only routes that change; `/marketplace`, `/privacy`, `/press`, `/api/referral-programs` and all three `/api/referral-codes` variants are byte-identical.
- Real MCP `initialize` → `tools/call` against `dist/serve.js`. Screenshots of both changed pages.
- 0 new code comments. `no-private-context` green.

## Not fixed here — the MCP tool reads the wrong store too

`getVendorReferral` in `src/data.ts` reads `offer.referral` only, so on production **today**:

| vendor | `get_referral_code` (MCP) | `/api/referral/:vendor` | `/api/referral-codes/:vendor` | vendor page |
|---|---|---|---|---|
| Railway | code | 200 | 200 | button |
| Proton Mail, VPN, Pass, Drive | `No referral found` | 404 | 200 | button |

Same two-store split, on the surface agents actually call — and it means any new platform code is invisible to `get_referral_code` on arrival, which is the MCP version of what this issue is about. I have not changed it: it alters what an agent is handed rather than what a page says, and #1151 proposes deleting the four Proton entries, so fixing it now could ship codes over MCP days before you remove them. It is about fifteen lines whenever you want it.

`/disclosure` also still renders "Not yet reviewed" — `data/page-reviews.json` has `reviewed_at: null` for it, though this issue records a review. Yours to record.
