### PR TITLE
Render a referral code's own terms, not one program's (#1151)

### DIFF
--- a/data/platform_codes.json
+++ b/data/platform_codes.json
@@ -5,50 +5,12 @@
       "code": "7RZL9q",
       "referral_url": "https://railway.com?referralCode=7RZL9q",
       "referrer_benefit": "15% commission (first 12 months)",
+      "referrer_compensation": "commission",
       "referee_benefit": "$20 in credits",
+      "restrictions": [],
       "source": "platform",
       "active": true,
       "added_at": "2026-04-12"
-    },
-    {
-      "vendor": "Proton Mail",
-      "code": "60QXGJSB",
-      "referral_url": "https://pr.tn/ref/60QXGJSB",
-      "referrer_benefit": "$20 credit",
-      "referee_benefit": "$20 credit",
-      "source": "platform",
-      "active": true,
-      "added_at": "2026-04-21"
-    },
-    {
-      "vendor": "Proton VPN",
-      "code": "60QXGJSB",
-      "referral_url": "https://pr.tn/ref/60QXGJSB",
-      "referrer_benefit": "$20 credit",
-      "referee_benefit": "$20 credit",
-      "source": "platform",
-      "active": true,
-      "added_at": "2026-04-21"
-    },
-    {
-      "vendor": "Proton Pass",
-      "code": "60QXGJSB",
-      "referral_url": "https://pr.tn/ref/60QXGJSB",
-      "referrer_benefit": "$20 credit",
-      "referee_benefit": "$20 credit",
-      "source": "platform",
-      "active": true,
-      "added_at": "2026-04-21"
-    },
-    {
-      "vendor": "Proton Drive",
-      "code": "60QXGJSB",
-      "referral_url": "https://pr.tn/ref/60QXGJSB",
-      "referrer_benefit": "$20 credit",
-      "referee_benefit": "$20 credit",
-      "source": "platform",
-      "active": true,
-      "added_at": "2026-04-21"
     }
   ]
 }

--- a/scripts/mutate-1151.sh
+++ b/scripts/mutate-1151.sh
@@ -1,0 +1,306 @@
+#!/usr/bin/env bash
+set -u
+
+REPO="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$REPO" || exit 1
+
+CODES="src/platform-codes.ts"
+SURFACES="src/referral-surfaces.ts"
+SERVE="src/serve.ts"
+DATA="data/platform_codes.json"
+BACKUP_DIR="$(mktemp -d)"
+cp "$CODES" "$BACKUP_DIR/platform-codes.ts"
+cp "$SURFACES" "$BACKUP_DIR/referral-surfaces.ts"
+cp "$SERVE" "$BACKUP_DIR/serve.ts"
+cp "$DATA" "$BACKUP_DIR/platform_codes.json"
+
+restore() {
+  cp "$BACKUP_DIR/platform-codes.ts" "$CODES"
+  cp "$BACKUP_DIR/referral-surfaces.ts" "$SURFACES"
+  cp "$BACKUP_DIR/serve.ts" "$SERVE"
+  cp "$BACKUP_DIR/platform_codes.json" "$DATA"
+}
+trap restore EXIT
+
+killed=0
+survived=0
+TESTS="test/referral-record-terms.test.ts test/platform-codes.test.ts test/referral-disclosure-predicate.test.ts test/referral-codes-listing.test.ts test/referral-code-enrichment.test.ts test/referral.test.ts"
+
+run_mutation() {
+  local name="$1"
+  shift
+  echo "=== $name"
+  restore
+  "$@"
+  if diff -q "$BACKUP_DIR/platform-codes.ts" "$CODES" > /dev/null \
+    && diff -q "$BACKUP_DIR/referral-surfaces.ts" "$SURFACES" > /dev/null \
+    && diff -q "$BACKUP_DIR/serve.ts" "$SERVE" > /dev/null \
+    && diff -q "$BACKUP_DIR/platform_codes.json" "$DATA" > /dev/null; then
+    echo "    NOT APPLIED: the mutation changed no file, so it proves nothing"
+    survived=$((survived + 1))
+    return
+  fi
+  if ! npm run build > /tmp/mutate-1151-build.log 2>&1; then
+    echo "    NOT APPLIED: the mutation does not compile, so no test ran"
+    tail -3 /tmp/mutate-1151-build.log
+    survived=$((survived + 1))
+    return
+  fi
+  if timeout 900 node --test --test-concurrency 1 $TESTS > /tmp/mutate-1151-test.log 2>&1; then
+    echo "    SURVIVED"
+    survived=$((survived + 1))
+  else
+    echo "    KILLED: $(grep -c '✖ ' /tmp/mutate-1151-test.log) failing assertion(s)"
+    grep '✖ ' /tmp/mutate-1151-test.log | head -4
+    killed=$((killed + 1))
+  fi
+}
+
+py() { python3 - "$@"; }
+
+m_every_arrangement_is_published_as_a_commission() {
+  py <<'PY'
+p = "src/referral-surfaces.ts"
+s = open(p).read()
+s = s.replace('''  if (compensation === "credit") return "We are paid in vendor credit, not cash, if you sign up through this link.";
+  if (compensation === "none") return "We are paid nothing if you sign up through this link.";
+  return "This is a referral link of ours. We have not recorded what it pays us.";''',
+              '  return "We may earn a commission if you sign up through this link.";')
+open(p, "w").write(s)
+PY
+}
+
+m_a_credit_arrangement_is_published_as_a_commission() {
+  py <<'PY'
+p = "src/referral-surfaces.ts"
+s = open(p).read()
+s = s.replace('  if (compensation === "credit") return "We are paid in vendor credit, not cash, if you sign up through this link.";',
+              '  if (compensation === "credit") return "We may earn a commission if you sign up through this link.";')
+open(p, "w").write(s)
+PY
+}
+
+m_an_unstated_arrangement_is_published_as_a_commission() {
+  py <<'PY'
+p = "src/referral-surfaces.ts"
+s = open(p).read()
+s = s.replace('  return "This is a referral link of ours. We have not recorded what it pays us.";',
+              '  return "We may earn a commission if you sign up through this link.";')
+open(p, "w").write(s)
+PY
+}
+
+m_an_arrangement_paying_us_nothing_is_published_as_a_commission() {
+  py <<'PY'
+p = "src/referral-surfaces.ts"
+s = open(p).read()
+s = s.replace('  if (compensation === "none") return "We are paid nothing if you sign up through this link.";',
+              '  if (compensation === "none") return "We may earn a commission if you sign up through this link.";')
+open(p, "w").write(s)
+PY
+}
+
+m_the_cta_ignores_the_recorded_arrangement() {
+  py <<'PY'
+p = "src/serve.ts"
+s = open(p).read()
+s = s.replace('${escHtmlServer(referrerDisclosureSentence(ourLink.compensation))} See our <a href="/disclosure">affiliate disclosure</a>.',
+              'We may earn a commission if you sign up through this link. See our <a href="/disclosure">affiliate disclosure</a>.')
+open(p, "w").write(s)
+PY
+}
+
+m_any_string_is_accepted_as_an_arrangement() {
+  py <<'PY'
+p = "src/platform-codes.ts"
+s = open(p).read()
+s = s.replace('  return REFERRER_COMPENSATIONS.includes(stated as ReferrerCompensation) ? (stated as ReferrerCompensation) : null;',
+              '  return typeof stated === "string" ? (stated as ReferrerCompensation) : null;')
+open(p, "w").write(s)
+PY
+}
+
+m_the_arrangement_is_read_off_the_benefit_wording() {
+  py <<'PY'
+p = "src/platform-codes.ts"
+s = open(p).read()
+s = s.replace('  const stated = (record as { referrer_compensation?: unknown } | null | undefined)?.referrer_compensation;',
+              '  const benefit = (record as { referrer_benefit?: unknown } | null | undefined)?.referrer_benefit;\n  const stated = typeof benefit === "string" && benefit.includes("commission") ? "commission" : (record as { referrer_compensation?: unknown } | null | undefined)?.referrer_compensation;')
+open(p, "w").write(s)
+PY
+}
+
+m_no_record_ever_carries_a_condition() {
+  py <<'PY'
+p = "src/platform-codes.ts"
+s = open(p).read()
+s = s.replace('  if (!Array.isArray(stated)) return [];',
+              '  if (!Array.isArray(stated) || stated.length >= 0) return [];')
+open(p, "w").write(s)
+PY
+}
+
+m_a_blank_condition_is_published_as_a_condition() {
+  py <<'PY'
+p = "src/platform-codes.ts"
+s = open(p).read()
+s = s.replace('  return stated.filter((r): r is string => typeof r === "string" && r.trim().length > 0);',
+              '  return stated as string[];')
+open(p, "w").write(s)
+PY
+}
+
+m_the_cta_drops_the_conditions() {
+  py <<'PY'
+p = "src/serve.ts"
+s = open(p).read()
+s = s.replace('      </div>${ourLink.restrictions.length > 0 ? `\n      <div class="referral-conditions"',
+              '      </div>${ourLink.restrictions.length > 99 ? `\n      <div class="referral-conditions"')
+open(p, "w").write(s)
+PY
+}
+
+m_the_conditions_come_after_the_button() {
+  py <<'PY'
+p = "src/serve.ts"
+s = open(p).read()
+block_start = s.index('      </div>${ourLink.restrictions.length > 0 ? `\n      <div class="referral-conditions"')
+block_end = s.index('` : ""}\n      <a href="${escHtmlServer(ourLink.url)}"', block_start)
+block = s[block_start + len('      </div>'):block_end + len('` : ""}')]
+s = s[:block_start] + '      </div>' + s[block_end + len('` : ""}'):]
+anchor = '</a>\n      <p style="margin-top:.75rem;font-size:.75rem;color:var(--text-dim)">${escHtmlServer(referrerDisclosureSentence('
+s = s.replace(anchor, '</a>' + block + '\n      <p style="margin-top:.75rem;font-size:.75rem;color:var(--text-dim)">${escHtmlServer(referrerDisclosureSentence(')
+open(p, "w").write(s)
+PY
+}
+
+m_the_disclosure_page_drops_the_conditions() {
+  py <<'PY'
+p = "src/serve.ts"
+s = open(p).read()
+s = s.replace('${l.restrictions.length > 0 ? `<ul class="referral-conditions">',
+              '${false ? `<ul class="referral-conditions">')
+open(p, "w").write(s)
+PY
+}
+
+m_the_code_endpoint_drops_the_conditions() {
+  py <<'PY'
+p = "src/serve.ts"
+s = open(p).read()
+s = s.replace('        restrictions: best.restrictions,\n', '')
+open(p, "w").write(s)
+PY
+}
+
+m_the_best_code_reports_no_conditions() {
+  py <<'PY'
+p = "src/platform-codes.ts"
+s = open(p).read()
+s = s.replace('      referee_benefit: platformCode.referee_benefit,\n      restrictions: restrictionsOf(platformCode),',
+              '      referee_benefit: platformCode.referee_benefit,\n      restrictions: [],')
+open(p, "w").write(s)
+PY
+}
+
+m_the_listing_reports_no_conditions() {
+  py <<'PY'
+p = "src/platform-codes.ts"
+s = open(p).read()
+s = s.replace('        referee_benefit: c.referee_benefit,\n        restrictions: restrictionsOf(c),',
+              '        referee_benefit: c.referee_benefit,\n        restrictions: [],')
+open(p, "w").write(s)
+PY
+}
+
+m_a_removed_code_comes_back() {
+  py <<'PY'
+import json
+p = "data/platform_codes.json"
+d = json.load(open(p))
+d["platform_codes"].append({
+    "vendor": "Proton Mail",
+    "code": "60QXGJSB",
+    "referral_url": "https://pr.tn/ref/60QXGJSB",
+    "referrer_benefit": "$20 credit",
+    "referrer_compensation": "credit",
+    "referee_benefit": "$20 credit",
+    "restrictions": [],
+    "source": "platform",
+    "active": True,
+    "added_at": "2026-04-21",
+})
+json.dump(d, open(p, "w"), indent=2)
+PY
+}
+
+m_a_published_code_states_no_arrangement() {
+  py <<'PY'
+import json
+p = "data/platform_codes.json"
+d = json.load(open(p))
+for c in d["platform_codes"]:
+    c.pop("referrer_compensation", None)
+json.dump(d, open(p, "w"), indent=2)
+PY
+}
+
+m_a_published_code_states_no_conditions_field() {
+  py <<'PY'
+import json
+p = "data/platform_codes.json"
+d = json.load(open(p))
+for c in d["platform_codes"]:
+    c.pop("restrictions", None)
+json.dump(d, open(p, "w"), indent=2)
+PY
+}
+
+m_railways_arrangement_is_restated_as_credit() {
+  py <<'PY'
+import json
+p = "data/platform_codes.json"
+d = json.load(open(p))
+for c in d["platform_codes"]:
+    if c["vendor"] == "Railway":
+        c["referrer_compensation"] = "credit"
+json.dump(d, open(p, "w"), indent=2)
+PY
+}
+
+m_the_cta_falls_back_to_the_platform_store_alone() {
+  py <<'PY'
+p = "src/serve.ts"
+s = open(p).read()
+s = s.replace('  const ourLink = ourReferralLinkFor(vendorName, primary);',
+              '  const ourLink = ourReferralLinkFor(vendorName, null);')
+open(p, "w").write(s)
+PY
+}
+
+run_mutation "every arrangement is published as a commission" m_every_arrangement_is_published_as_a_commission
+run_mutation "a credit arrangement is published as a commission" m_a_credit_arrangement_is_published_as_a_commission
+run_mutation "an unstated arrangement is published as a commission" m_an_unstated_arrangement_is_published_as_a_commission
+run_mutation "an arrangement paying us nothing is published as a commission" m_an_arrangement_paying_us_nothing_is_published_as_a_commission
+run_mutation "the CTA ignores the recorded arrangement" m_the_cta_ignores_the_recorded_arrangement
+run_mutation "any string is accepted as an arrangement" m_any_string_is_accepted_as_an_arrangement
+run_mutation "the arrangement is read off the benefit wording" m_the_arrangement_is_read_off_the_benefit_wording
+run_mutation "no record ever carries a condition" m_no_record_ever_carries_a_condition
+run_mutation "a blank condition is published as a condition" m_a_blank_condition_is_published_as_a_condition
+run_mutation "the CTA drops the conditions" m_the_cta_drops_the_conditions
+run_mutation "the conditions come after the button" m_the_conditions_come_after_the_button
+run_mutation "the disclosure page drops the conditions" m_the_disclosure_page_drops_the_conditions
+run_mutation "the code endpoint drops the conditions" m_the_code_endpoint_drops_the_conditions
+run_mutation "the best code reports no conditions" m_the_best_code_reports_no_conditions
+run_mutation "the listing reports no conditions" m_the_listing_reports_no_conditions
+run_mutation "a removed code comes back" m_a_removed_code_comes_back
+run_mutation "a published code states no arrangement" m_a_published_code_states_no_arrangement
+run_mutation "a published code states no conditions field" m_a_published_code_states_no_conditions_field
+run_mutation "Railway's arrangement is restated as credit" m_railways_arrangement_is_restated_as_credit
+run_mutation "the CTA falls back to the platform store alone" m_the_cta_falls_back_to_the_platform_store_alone
+
+restore
+npm run build > /dev/null 2>&1
+echo
+echo "killed=$killed survived=$survived"
+[ "$survived" -eq 0 ]

--- a/src/openapi.ts
+++ b/src/openapi.ts
@@ -840,7 +840,7 @@ export const openapiSpec = {
                 },
                 example: {
                   codes: [
-                    { vendor: "Railway", category: "Cloud Hosting", code: "7RZL9q", referral_url: "https://railway.com?referralCode=7RZL9q", referee_benefit: "$20 in credits", source: "platform" }
+                    { vendor: "Railway", category: "Cloud Hosting", code: "7RZL9q", referral_url: "https://railway.com?referralCode=7RZL9q", referee_benefit: "$20 in credits", restrictions: [], source: "platform" }
                   ],
                   total: 1
                 }
@@ -867,7 +867,7 @@ export const openapiSpec = {
             content: {
               "application/json": {
                 schema: { $ref: "#/components/schemas/ReferralCodeListing" },
-                example: { vendor: "Railway", code: "7RZL9q", referral_url: "https://railway.com?referralCode=7RZL9q", referee_benefit: "$20 in credits", source: "platform" }
+                example: { vendor: "Railway", code: "7RZL9q", referral_url: "https://railway.com?referralCode=7RZL9q", referee_benefit: "$20 in credits", restrictions: [], source: "platform" }
               }
             }
           },
@@ -939,9 +939,10 @@ export const openapiSpec = {
           code: { type: "string", description: "The referral code string" },
           referral_url: { type: "string", format: "uri", description: "Full referral URL the referee should visit" },
           referee_benefit: { type: "string", description: "What the person using the code gets (e.g. '$20 in credits')" },
+          restrictions: { type: "array", items: { type: "string" }, description: "Conditions the referee must meet before the benefit is theirs (e.g. 'A payment method must be linked'). Empty when the record records none. Publish these wherever you publish referee_benefit." },
           source: { type: "string", enum: ["platform", "agent-submitted"], description: "platform = AgentDeals-owned code, agent-submitted = marketplace-submitted code" }
         },
-        required: ["vendor", "code", "referral_url", "referee_benefit", "source"]
+        required: ["vendor", "code", "referral_url", "referee_benefit", "restrictions", "source"]
       },
       DealChange: {
         type: "object",

--- a/src/platform-codes.ts
+++ b/src/platform-codes.ts
@@ -6,15 +6,32 @@ import { getRankedCodesForVendor, getAllActiveCodes } from "./referral-codes.js"
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const PLATFORM_CODES_PATH = path.join(__dirname, "..", "data", "platform_codes.json");
 
+export type ReferrerCompensation = "commission" | "credit" | "none";
+
+const REFERRER_COMPENSATIONS: readonly ReferrerCompensation[] = ["commission", "credit", "none"];
+
 export interface PlatformCode {
   vendor: string;
   code: string;
   referral_url: string;
   referrer_benefit: string;
+  referrer_compensation: ReferrerCompensation;
   referee_benefit: string;
+  restrictions: string[];
   source: "platform";
   active: boolean;
   added_at: string;
+}
+
+export function referrerCompensationOf(record: unknown): ReferrerCompensation | null {
+  const stated = (record as { referrer_compensation?: unknown } | null | undefined)?.referrer_compensation;
+  return REFERRER_COMPENSATIONS.includes(stated as ReferrerCompensation) ? (stated as ReferrerCompensation) : null;
+}
+
+export function restrictionsOf(record: unknown): string[] {
+  const stated = (record as { restrictions?: unknown } | null | undefined)?.restrictions;
+  if (!Array.isArray(stated)) return [];
+  return stated.filter((r): r is string => typeof r === "string" && r.trim().length > 0);
 }
 
 let cachedPlatformCodes: PlatformCode[] | null = null;
@@ -71,6 +88,7 @@ export interface BestReferralCode {
   code: string;
   referral_url: string;
   referee_benefit: string;
+  restrictions: string[];
   source: "platform" | "agent-submitted";
 }
 
@@ -87,6 +105,7 @@ export function getBestReferralCode(vendorName: string): BestReferralCode | null
       code: platformCode.code,
       referral_url: platformCode.referral_url,
       referee_benefit: platformCode.referee_benefit,
+      restrictions: restrictionsOf(platformCode),
       source: "platform",
     };
   }
@@ -99,6 +118,7 @@ export function getBestReferralCode(vendorName: string): BestReferralCode | null
       code: best.code,
       referral_url: best.referral_url,
       referee_benefit: best.description,
+      restrictions: restrictionsOf(best),
       source: "agent-submitted",
     };
   }
@@ -117,6 +137,7 @@ export interface ListedReferralCode {
   code: string;
   referral_url: string;
   referee_benefit: string;
+  restrictions: string[];
   source: "platform" | "agent-submitted";
 }
 
@@ -138,6 +159,7 @@ export function listAllReferralCodes(opts: {
         code: c.code,
         referral_url: c.referral_url,
         referee_benefit: c.referee_benefit,
+        restrictions: restrictionsOf(c),
         source: "platform",
       });
     }
@@ -151,6 +173,7 @@ export function listAllReferralCodes(opts: {
         code: c.code,
         referral_url: c.referral_url,
         referee_benefit: c.description,
+        restrictions: restrictionsOf(c),
         source: "agent-submitted",
       });
     }

--- a/src/referral-surfaces.ts
+++ b/src/referral-surfaces.ts
@@ -1,4 +1,5 @@
-import { getAllPlatformCodes, getPlatformCodeForVendor } from "./platform-codes.js";
+import { getAllPlatformCodes, getPlatformCodeForVendor, referrerCompensationOf, restrictionsOf } from "./platform-codes.js";
+import type { ReferrerCompensation } from "./platform-codes.js";
 import { toSlug } from "./vendor-slug.js";
 import type { Offer } from "./types.js";
 
@@ -8,6 +9,8 @@ export interface OurReferralLink {
   vendor: string;
   url: string;
   refereeBenefit: string;
+  restrictions: string[];
+  compensation: ReferrerCompensation | null;
   termsUrl: string | null;
   source: OurReferralLinkSource;
 }
@@ -23,6 +26,8 @@ export function ourReferralLinkFor(vendorName: string, offer?: Offer | null): Ou
       vendor: platformCode.vendor,
       url: platformCode.referral_url,
       refereeBenefit: platformCode.referee_benefit,
+      restrictions: restrictionsOf(platformCode),
+      compensation: referrerCompensationOf(platformCode),
       termsUrl: offerReferral?.terms_url ?? null,
       source: "platform_code",
     };
@@ -33,12 +38,21 @@ export function ourReferralLinkFor(vendorName: string, offer?: Offer | null): Ou
       vendor: offer.vendor,
       url: offerReferral.url,
       refereeBenefit: offerReferral.referee_value ?? REFEREE_BENEFIT_FALLBACK,
+      restrictions: restrictionsOf(offerReferral),
+      compensation: referrerCompensationOf(offerReferral),
       termsUrl: offerReferral.terms_url ?? null,
       source: "offer_referral",
     };
   }
 
   return null;
+}
+
+export function referrerDisclosureSentence(compensation: ReferrerCompensation | null): string {
+  if (compensation === "commission") return "We may earn a commission if you sign up through this link.";
+  if (compensation === "credit") return "We are paid in vendor credit, not cash, if you sign up through this link.";
+  if (compensation === "none") return "We are paid nothing if you sign up through this link.";
+  return "This is a referral link of ours. We have not recorded what it pays us.";
 }
 
 export function referralLinkCountClause(count: number): string {

--- a/src/serve.ts
+++ b/src/serve.ts
@@ -26,8 +26,8 @@ import { logReferralRequest } from "./referral-requests.js";
 import { recordConversion, confirmEligibleEntries, clawbackEntry, getAgentBalance, getAgentLedgerEntries, recordPayout, MINIMUM_PAYOUT_AMOUNT, getLeaderboard } from "./ledger.js";
 import { validateX402Address, executeTransfer, generateCorrelationId } from "./x402.js";
 import { submitReferralCode, getCodesByAgent, getCodeById, updateCode, revokeCode, calculateTrustTier, getDailySubmissionCount, getDailyLimit, getRankedCodesForVendor, calculateCodeScore } from "./referral-codes.js";
-import { getPlatformCodeForVendor, getBestReferralCode, listAllReferralCodes } from "./platform-codes.js";
-import { allOurReferralLinks, hasAnyReferralSurface, ourReferralLinkFor, referralLinkCountClause } from "./referral-surfaces.js";
+import { getBestReferralCode, listAllReferralCodes } from "./platform-codes.js";
+import { allOurReferralLinks, hasAnyReferralSurface, ourReferralLinkFor, referralLinkCountClause, referrerDisclosureSentence } from "./referral-surfaces.js";
 import { runHealthCheck, getLastReport, startPeriodicChecks } from "./referral-health.js";
 import { addFriend, removeFriend, getFriends, getFriendCodesForVendors } from "./friends.js";
 import { subscribe as watchlistSubscribe, getSubscription as getWatchlistSubscription, unsubscribe as watchlistUnsubscribe, listSubscriptions as listWatchlistSubscriptions } from "./watchlist.js";
@@ -3983,17 +3983,20 @@ ${enrichedAlts.map(a => {
     </div>`;
   })() : "";
 
-  // Platform referral code CTA (shown when we have a platform code for this vendor)
-  const platformCode = getPlatformCodeForVendor(vendorName);
-  const referralCalloutHtml = platformCode ? `
+  const ourLink = ourReferralLinkFor(vendorName, primary);
+  const referralCalloutHtml = ourLink ? `
   <div class="section" style="margin-top:1.5rem">
     <div style="border:2px solid #3fb950;border-radius:12px;padding:1.25rem;background:linear-gradient(135deg,rgba(63,185,80,0.08),rgba(63,185,80,0.02))">
       <div style="display:flex;align-items:center;gap:.5rem;margin-bottom:.75rem">
         <span style="font-size:1.25rem">&#127873;</span>
-        <strong style="font-size:1rem;color:var(--text)">Sign up via our referral link and get ${escHtmlServer(platformCode.referee_benefit)}</strong>
-      </div>
-      <a href="${escHtmlServer(platformCode.referral_url)}" rel="noopener sponsored" target="_blank" style="display:inline-block;padding:.6rem 1.25rem;background:#3fb950;color:#fff;border-radius:8px;font-weight:600;font-size:.9rem;text-decoration:none">Get ${escHtmlServer(platformCode.referee_benefit)} &rarr;</a>
-      <p style="margin-top:.75rem;font-size:.75rem;color:var(--text-dim)">We may earn a commission if you sign up through this link. See our <a href="/disclosure">affiliate disclosure</a>.</p>
+        <strong style="font-size:1rem;color:var(--text)">Sign up via our referral link and get ${escHtmlServer(ourLink.refereeBenefit)}</strong>
+      </div>${ourLink.restrictions.length > 0 ? `
+      <div class="referral-conditions" style="margin:0 0 .9rem;padding:.65rem .85rem;border-left:3px solid #d29922;border-radius:0 6px 6px 0;background:rgba(210,153,34,0.08)">
+        <div style="font-size:.7rem;text-transform:uppercase;letter-spacing:.08em;color:var(--text-dim);font-family:var(--mono);margin-bottom:.35rem">What you have to do to get it</div>
+        <ul style="margin:0;padding-left:1.1rem;font-size:.8rem;color:var(--text);line-height:1.5">${ourLink.restrictions.map(r => `<li>${escHtmlServer(r)}</li>`).join("")}</ul>
+      </div>` : ""}
+      <a href="${escHtmlServer(ourLink.url)}" rel="noopener sponsored" target="_blank" style="display:inline-block;padding:.6rem 1.25rem;background:#3fb950;color:#fff;border-radius:8px;font-weight:600;font-size:.9rem;text-decoration:none">Get ${escHtmlServer(ourLink.refereeBenefit)} &rarr;</a>
+      <p style="margin-top:.75rem;font-size:.75rem;color:var(--text-dim)">${escHtmlServer(referrerDisclosureSentence(ourLink.compensation))} See our <a href="/disclosure">affiliate disclosure</a>.</p>
     </div>
   </div>` : "";
 
@@ -51921,7 +51924,7 @@ ${agentSubmittedCodes.length > 0 ? `
   </div>` : ""}
   <div class="section">
     <h2>Current Referral Partners</h2>
-    ${ourReferralLinks.length > 0 ? `<ul>${ourReferralLinks.map(l => `<li><a href="/vendor/${toSlug(l.vendor)}">${escHtmlServer(l.vendor)}</a>: ${escHtmlServer(l.refereeBenefit)}${l.termsUrl ? ` (<a href="${escHtmlServer(l.termsUrl)}" rel="noopener" target="_blank">program terms</a>)` : ""}</li>`).join("")}</ul>` : `<p>No referral partners at this time.</p>`}
+    ${ourReferralLinks.length > 0 ? `<ul>${ourReferralLinks.map(l => `<li><a href="/vendor/${toSlug(l.vendor)}">${escHtmlServer(l.vendor)}</a>: ${escHtmlServer(l.refereeBenefit)}${l.termsUrl ? ` (<a href="${escHtmlServer(l.termsUrl)}" rel="noopener" target="_blank">program terms</a>)` : ""}${l.restrictions.length > 0 ? `<ul class="referral-conditions">${l.restrictions.map(r => `<li>${escHtmlServer(r)}</li>`).join("")}</ul>` : ""}</li>`).join("")}</ul>` : `<p>No referral partners at this time.</p>`}
     ${vendorsWithOwnProgram.size > 0 ? `<p>We also document ${vendorsWithOwnProgram.size} ${vendorsWithOwnProgram.size === 1 ? "vendor that runs its own referral program" : "vendors that run their own referral programs"} on <a href="/referral-programs">/referral-programs</a>. We hold no code and earn nothing from ${vendorsWithOwnProgram.size === 1 ? "it" : "those"} &mdash; the program is listed because it exists, not because of any relationship with us.</p>` : ""}
   </div>
 
@@ -56449,6 +56452,7 @@ ${catList}
         code: best.code,
         referral_url: best.referral_url,
         referee_benefit: best.referee_benefit,
+        restrictions: best.restrictions,
         source: best.source,
       }));
       return;

--- a/src/types.ts
+++ b/src/types.ts
@@ -9,6 +9,7 @@ export interface Referral {
   url: string;
   referee_value: string;
   referrer_value?: string;
+  referrer_compensation?: "commission" | "credit" | "none";
   type: "dual-sided" | "referrer-only" | "referee-only";
   source: "curated" | "sovrn" | "agent-submitted";
   submitted_by?: string | null;

--- a/test/platform-codes.test.ts
+++ b/test/platform-codes.test.ts
@@ -60,25 +60,20 @@ describe("Platform Codes", () => {
     assert.strictEqual(code.vendor, "Railway");
   });
 
-  it("matches by URL slug (e.g. 'proton-mail' → 'Proton Mail')", () => {
-    for (const slug of ["proton-mail", "proton-vpn", "proton-pass", "proton-drive"]) {
-      const code = getPlatformCodeForVendor(slug);
-      assert.ok(code, `slug ${slug} should resolve to a platform code`);
-      assert.strictEqual(code.code, "60QXGJSB");
-      assert.strictEqual(code.referral_url, "https://pr.tn/ref/60QXGJSB");
-      assert.strictEqual(code.referee_benefit, "$20 credit");
-      assert.strictEqual(code.source, "platform");
-    }
+  it("matches by URL slug (e.g. 'railway' → 'Railway')", () => {
+    const code = getPlatformCodeForVendor("railway");
+    assert.ok(code, "slug railway should resolve to a platform code");
+    assert.strictEqual(code.code, "7RZL9q");
+    assert.strictEqual(code.referral_url, "https://railway.com?referralCode=7RZL9q");
+    assert.strictEqual(code.referee_benefit, "$20 in credits");
+    assert.strictEqual(code.source, "platform");
   });
 
-  it("returns Proton platform code for all 4 product variants by canonical name", () => {
-    for (const vendor of ["Proton Mail", "Proton VPN", "Proton Pass", "Proton Drive"]) {
-      const code = getPlatformCodeForVendor(vendor);
-      assert.ok(code, `${vendor} should have a platform code`);
-      assert.strictEqual(code.vendor, vendor);
-      assert.strictEqual(code.code, "60QXGJSB");
-      assert.strictEqual(code.referral_url, "https://pr.tn/ref/60QXGJSB");
+  it("holds no code for the four Proton products, by name or by slug", () => {
+    for (const vendor of ["Proton Mail", "Proton VPN", "Proton Pass", "Proton Drive", "proton-mail", "proton-vpn", "proton-pass", "proton-drive"]) {
+      assert.strictEqual(getPlatformCodeForVendor(vendor), null, `${vendor} should hold no platform code`);
     }
+    assert.ok(!fs.readFileSync(PLATFORM_CODES_PATH, "utf-8").includes("60QXGJSB"), "the removed code should not be in the store");
   });
 
   it("only returns active codes", () => {

--- a/test/referral-disclosure-predicate.test.ts
+++ b/test/referral-disclosure-predicate.test.ts
@@ -49,11 +49,14 @@ function sectionAfter(html: string, heading: string, nextHeading: string): strin
 }
 
 describe("one predicate decides whether we hold a referral link for a vendor", () => {
-  it("a vendor held only in the platform code store still counts as one of ours", () => {
-    const link = ourReferralLinkFor("Proton Mail", offerFor("Proton Mail"));
-    assert.ok(link, "Proton Mail is in data/platform_codes.json and should resolve to a referral link");
-    assert.strictEqual(link!.source, "platform_code");
-    assert.ok(link!.url.length > 0);
+  it("holds no link for a vendor that is in neither store", () => {
+    for (const vendor of ["Proton Mail", "Proton VPN", "Proton Pass", "Proton Drive"]) {
+      const offer = offerFor(vendor);
+      assert.ok(offer, `${vendor} should be in the index`);
+      assert.strictEqual(ourReferralLinkFor(vendor, offer), null, `we hold no code for ${vendor}`);
+      assert.strictEqual(hasOurReferralLink(vendor, offer), false);
+      assert.strictEqual(hasAnyReferralSurface(vendor, offer), true, "the vendor's own program is still a referral surface");
+    }
   });
 
   it("a vendor that documents its own program is a referral surface but not a link of ours", () => {
@@ -267,7 +270,9 @@ describe("a new row in the platform code store is disclosed on its own", () => {
     code: "EXAMPLECODE",
     referral_url: "https://example.com/ref/EXAMPLECODE",
     referrer_benefit: "$1 credit",
+    referrer_compensation: "credit",
     referee_benefit: "$1 credit",
+    restrictions: [],
     source: "platform",
     active: true,
     added_at: "2026-08-29",

--- a/test/referral-record-terms.test.ts
+++ b/test/referral-record-terms.test.ts
@@ -1,0 +1,361 @@
+import { describe, it, before, after } from "node:test";
+import assert from "node:assert";
+import fs from "node:fs";
+import path from "node:path";
+import { spawn, type ChildProcess } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const PLATFORM_CODES_PATH = path.join(__dirname, "..", "data", "platform_codes.json");
+
+const { referrerDisclosureSentence, ourReferralLinkFor } = await import("../dist/referral-surfaces.js");
+const { getBestReferralCode, listAllReferralCodes, referrerCompensationOf, restrictionsOf, resetPlatformCodesCache } = await import("../dist/platform-codes.js");
+const { getVendorReferral, loadOffers } = await import("../dist/data.js");
+
+const offers = loadOffers();
+const offerFor = (vendor: string) => offers.find((o: any) => o.vendor === vendor);
+
+const PROTON_VENDORS = ["Proton Mail", "Proton VPN", "Proton Pass", "Proton Drive"];
+const PROTON_SLUGS = ["proton-mail", "proton-vpn", "proton-pass", "proton-drive"];
+
+const COMMISSION_SENTENCE = "We may earn a commission if you sign up through this link.";
+
+function startServer(env: Record<string, string> = {}): Promise<{ proc: ChildProcess; port: number }> {
+  return new Promise((resolve, reject) => {
+    const serverPath = path.join(__dirname, "..", "dist", "serve.js");
+    const proc = spawn("node", [serverPath], {
+      stdio: ["pipe", "pipe", "pipe"],
+      env: { ...process.env, PORT: "0", BASE_URL: "http://localhost", ...env },
+    });
+    const timeout = setTimeout(() => {
+      proc.kill();
+      reject(new Error("Server startup timeout"));
+    }, 15000);
+    proc.stderr!.on("data", (data: Buffer) => {
+      const match = data.toString().match(/running on http:\/\/localhost:(\d+)/);
+      if (match) {
+        clearTimeout(timeout);
+        resolve({ proc, port: parseInt(match[1], 10) });
+      }
+    });
+    proc.on("error", (err) => {
+      clearTimeout(timeout);
+      reject(err);
+    });
+  });
+}
+
+describe("every published code states what it pays us and what the reader must do", () => {
+  const store = JSON.parse(fs.readFileSync(PLATFORM_CODES_PATH, "utf-8"));
+
+  it("declares a recognized compensation on every active row", () => {
+    for (const code of store.platform_codes.filter((c: any) => c.active)) {
+      assert.notStrictEqual(
+        referrerCompensationOf(code),
+        null,
+        `${code.vendor} must state referrer_compensation as one of commission, credit or none`
+      );
+    }
+  });
+
+  it("declares a restrictions list on every active row", () => {
+    for (const code of store.platform_codes.filter((c: any) => c.active)) {
+      assert.ok(Array.isArray(code.restrictions), `${code.vendor} must carry a restrictions array, empty if there are none`);
+      assert.deepStrictEqual(restrictionsOf(code), code.restrictions, `${code.vendor}: every restriction must be a non-empty string`);
+    }
+  });
+
+  it("keeps the commission sentence for a record that says commission", () => {
+    assert.strictEqual(referrerDisclosureSentence("commission"), COMMISSION_SENTENCE);
+  });
+
+  it("says credit rather than commission for a record paid in credit", () => {
+    const sentence = referrerDisclosureSentence("credit");
+    assert.ok(sentence.includes("vendor credit, not cash"), sentence);
+    assert.ok(!sentence.includes("commission"), "a credit-only program must not be described as a commission");
+  });
+
+  it("says we are paid nothing for a record that earns us nothing", () => {
+    const sentence = referrerDisclosureSentence("none");
+    assert.ok(sentence.includes("paid nothing"), sentence);
+    assert.ok(!sentence.includes("commission"), sentence);
+  });
+
+  it("claims no payment at all for a record that does not say", () => {
+    const sentence = referrerDisclosureSentence(null);
+    assert.ok(!sentence.includes("commission"), "an unstated arrangement must not be published as a commission");
+    assert.ok(sentence.includes("not recorded"), sentence);
+  });
+
+  it("reads the arrangement off the record rather than off the benefit wording", () => {
+    assert.strictEqual(referrerCompensationOf({ referrer_benefit: "15% commission", referrer_compensation: "credit" }), "credit");
+    assert.strictEqual(referrerCompensationOf({ referrer_benefit: "15% commission" }), null);
+    assert.strictEqual(referrerCompensationOf({ referrer_compensation: "cash" }), null);
+    assert.strictEqual(referrerCompensationOf(null), null);
+  });
+
+  it("drops restrictions that carry no readable text", () => {
+    assert.deepStrictEqual(restrictionsOf({ restrictions: ["A card must be linked", "  ", 7, null] }), ["A card must be linked"]);
+    assert.deepStrictEqual(restrictionsOf({ restrictions: "A card must be linked" }), []);
+    assert.deepStrictEqual(restrictionsOf({}), []);
+  });
+});
+
+describe("the four Proton products offer no code of ours", () => {
+  let serverProc: ChildProcess | null = null;
+  let port = 0;
+
+  before(async () => {
+    const started = await startServer();
+    serverProc = started.proc;
+    port = started.port;
+  });
+
+  after(() => {
+    serverProc?.kill();
+  });
+
+  it("renders no referral banner and no referral button", async () => {
+    for (const slug of PROTON_SLUGS) {
+      const page = await (await fetch(`http://localhost:${port}/vendor/${slug}`)).text();
+      assert.ok(page.includes("<h1"), `/vendor/${slug} should render`);
+      assert.ok(!page.includes("Sign up via our referral link"), `/vendor/${slug} must not offer a referral link`);
+      assert.ok(!page.includes("sponsored"), `/vendor/${slug} must not render a sponsored link`);
+      assert.ok(!page.includes(COMMISSION_SENTENCE), `/vendor/${slug} must not claim a commission`);
+      assert.ok(!page.includes("60QXGJSB"), `/vendor/${slug} must not carry the removed code`);
+    }
+  });
+
+  it("resolves to nothing over MCP and over the code endpoint", async () => {
+    for (const vendor of PROTON_VENDORS) {
+      assert.strictEqual(getVendorReferral(vendor), null, `get_referral_code must find nothing for ${vendor}`);
+      assert.strictEqual(getBestReferralCode(vendor), null, `no code should be offered for ${vendor}`);
+      const res = await fetch(`http://localhost:${port}/api/referral-codes/${encodeURIComponent(vendor)}`);
+      assert.strictEqual(res.status, 404, `/api/referral-codes/${vendor} should report no code`);
+    }
+  });
+
+  it("leaves Railway resolving exactly as before", async () => {
+    const referral = getVendorReferral("Railway");
+    assert.ok(referral, "get_referral_code must still resolve Railway");
+    assert.strictEqual(referral.referral.code, "7RZL9q");
+
+    const best = getBestReferralCode("Railway");
+    assert.strictEqual(best!.code, "7RZL9q");
+    assert.strictEqual(best!.referee_benefit, "$20 in credits");
+    assert.deepStrictEqual(best!.restrictions, []);
+
+    const page = await (await fetch(`http://localhost:${port}/vendor/railway`)).text();
+    assert.ok(page.includes("Sign up via our referral link and get $20 in credits"));
+    assert.ok(page.includes("https://railway.com?referralCode=7RZL9q"));
+    assert.ok(page.includes(COMMISSION_SENTENCE));
+    assert.ok(!page.includes("referral-conditions"), "Railway records no conditions, so none should be rendered");
+  });
+
+  it("carries the restrictions list alongside every benefit the code endpoint publishes", async () => {
+    const listing = await (await fetch(`http://localhost:${port}/api/referral-codes`)).json();
+    assert.ok(listing.codes.length > 0);
+    for (const code of listing.codes) {
+      assert.ok(Array.isArray(code.restrictions), `${code.vendor} should publish a restrictions array beside its benefit`);
+    }
+    for (const code of listAllReferralCodes()) {
+      assert.ok(Array.isArray(code.restrictions));
+    }
+  });
+});
+
+describe("a code whose reward is conditional says so beside the button", () => {
+  let serverProc: ChildProcess | null = null;
+  let originalFile = "";
+  let conditionalPage = "";
+  let creditPage = "";
+  let unpaidPage = "";
+  let silentPage = "";
+  let disclosure = "";
+  let vendorCodeResponse: any = null;
+
+  const CONDITIONS = [
+    "A credit card or PayPal account must be linked before the credit is granted",
+    "Unused credit expires after 30 days",
+  ];
+
+  const quiet = offers.filter((o: any) => !o.referral && !o.referral_program?.available && !ourReferralLinkFor(o.vendor, o));
+  const conditionalVendor = quiet[0].vendor;
+  const creditVendor = quiet[1].vendor;
+  const unpaidVendor = quiet[2].vendor;
+  const silentVendor = quiet[3].vendor;
+
+  const slugOf = (vendor: string) => vendor.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-|-$/g, "");
+
+  before(async () => {
+    originalFile = fs.readFileSync(PLATFORM_CODES_PATH, "utf-8");
+    const data = JSON.parse(originalFile);
+    data.platform_codes.push(
+      {
+        vendor: conditionalVendor,
+        code: "CONDITIONAL",
+        referral_url: "https://example.com/?ref=CONDITIONAL",
+        referrer_benefit: "$100 cash per verified paid signup",
+        referrer_compensation: "commission",
+        referee_benefit: "$300 in credit",
+        restrictions: CONDITIONS,
+        source: "platform",
+        active: true,
+        added_at: "2026-08-29",
+      },
+      {
+        vendor: creditVendor,
+        code: "CREDITONLY",
+        referral_url: "https://example.com/?ref=CREDITONLY",
+        referrer_benefit: "$20 credit",
+        referrer_compensation: "credit",
+        referee_benefit: "$20 credit",
+        restrictions: ["The credit arrives only after a paid plan is held for a month"],
+        source: "platform",
+        active: true,
+        added_at: "2026-08-29",
+      },
+      {
+        vendor: unpaidVendor,
+        code: "NOTHINGFORUS",
+        referral_url: "https://example.com/?ref=NOTHINGFORUS",
+        referrer_benefit: "Nothing",
+        referrer_compensation: "none",
+        referee_benefit: "$10 in credit",
+        restrictions: [],
+        source: "platform",
+        active: true,
+        added_at: "2026-08-29",
+      },
+      {
+        vendor: silentVendor,
+        code: "UNSTATED",
+        referral_url: "https://example.com/?ref=UNSTATED",
+        referrer_benefit: "Unknown",
+        referee_benefit: "$5 in credit",
+        source: "platform",
+        active: true,
+        added_at: "2026-08-29",
+      }
+    );
+    fs.writeFileSync(PLATFORM_CODES_PATH, JSON.stringify(data, null, 2), "utf-8");
+    resetPlatformCodesCache();
+
+    const started = await startServer();
+    serverProc = started.proc;
+    conditionalPage = await (await fetch(`http://localhost:${started.port}/vendor/${slugOf(conditionalVendor)}`)).text();
+    creditPage = await (await fetch(`http://localhost:${started.port}/vendor/${slugOf(creditVendor)}`)).text();
+    unpaidPage = await (await fetch(`http://localhost:${started.port}/vendor/${slugOf(unpaidVendor)}`)).text();
+    silentPage = await (await fetch(`http://localhost:${started.port}/vendor/${slugOf(silentVendor)}`)).text();
+    disclosure = await (await fetch(`http://localhost:${started.port}/disclosure`)).text();
+    vendorCodeResponse = await (await fetch(`http://localhost:${started.port}/api/referral-codes/${encodeURIComponent(conditionalVendor)}`)).json();
+  });
+
+  after(() => {
+    serverProc?.kill();
+    fs.writeFileSync(PLATFORM_CODES_PATH, originalFile, "utf-8");
+    resetPlatformCodesCache();
+  });
+
+  it("prints every condition on the page that offers the reward", () => {
+    assert.ok(conditionalPage.includes("Sign up via our referral link and get $300 in credit"));
+    for (const condition of CONDITIONS) {
+      assert.ok(conditionalPage.includes(condition), `the page should state: ${condition}`);
+    }
+  });
+
+  it("prints them before the reader can click through", () => {
+    const conditionAt = conditionalPage.indexOf(CONDITIONS[0]);
+    const buttonAt = conditionalPage.indexOf("https://example.com/?ref=CONDITIONAL\" rel=\"noopener sponsored\"");
+    assert.ok(conditionAt > -1 && buttonAt > -1);
+    assert.ok(conditionAt < buttonAt, "the conditions must come before the button, not after it");
+  });
+
+  it("repeats them on the disclosure page that lists the partner", () => {
+    for (const condition of CONDITIONS) {
+      assert.ok(disclosure.includes(condition), `/disclosure should state: ${condition}`);
+    }
+  });
+
+  it("describes a credit-only arrangement as credit on the page itself", () => {
+    assert.ok(creditPage.includes("Sign up via our referral link and get $20 credit"));
+    assert.ok(creditPage.includes("vendor credit, not cash"));
+    assert.ok(!creditPage.includes(COMMISSION_SENTENCE), "a program that pays us in credit must not claim a commission");
+    assert.ok(creditPage.includes("The credit arrives only after a paid plan is held for a month"));
+  });
+
+  it("says we are paid nothing when the record says so", () => {
+    assert.ok(unpaidPage.includes("Sign up via our referral link and get $10 in credit"));
+    assert.ok(unpaidPage.includes("paid nothing"));
+    assert.ok(!unpaidPage.includes(COMMISSION_SENTENCE));
+  });
+
+  it("claims nothing for a record that never states the arrangement", () => {
+    assert.ok(silentPage.includes("Sign up via our referral link and get $5 in credit"));
+    assert.ok(!silentPage.includes(COMMISSION_SENTENCE), "an unstated arrangement must not be published as a commission");
+    assert.ok(silentPage.includes("not recorded"));
+    assert.ok(!silentPage.includes("referral-conditions"), "a record with no restrictions field should assert no conditions either way");
+  });
+
+  it("hands the conditions to an agent asking for the code", async () => {
+    const code = getBestReferralCode(conditionalVendor);
+    assert.deepStrictEqual(code!.restrictions, CONDITIONS);
+    const listed = listAllReferralCodes().find((c: any) => c.vendor === conditionalVendor);
+    assert.deepStrictEqual(listed!.restrictions, CONDITIONS);
+  });
+
+  it("serves them on the endpoint that answers for one vendor", () => {
+    assert.strictEqual(vendorCodeResponse.referee_benefit, "$300 in credit");
+    assert.deepStrictEqual(vendorCodeResponse.restrictions, CONDITIONS, "the by-vendor endpoint must publish the conditions beside the benefit");
+  });
+});
+
+describe("a referral link held only in the offer index reaches the page too", () => {
+  let serverProc: ChildProcess | null = null;
+  let page = "";
+  let indexPath = "";
+
+  const quiet = offers.find((o: any) => !o.referral && !o.referral_program?.available && !ourReferralLinkFor(o.vendor, o));
+  const RESTRICTION = "The credit is granted only after the first invoice is paid";
+
+  before(async () => {
+    const seeded = offers.map((o: any) =>
+      o.vendor === quiet.vendor
+        ? {
+            ...o,
+            referral: {
+              url: "https://example.com/?ref=OFFERSTORE",
+              referee_value: "$40 in credits",
+              referrer_value: "Vendor credit only",
+              referrer_compensation: "credit",
+              type: "dual-sided",
+              source: "curated",
+              verified_date: "2026-08-29",
+              restrictions: [RESTRICTION],
+              phase1_eligible: true,
+            },
+          }
+        : o
+    );
+    indexPath = path.join(fs.mkdtempSync(path.join(__dirname, "..", "data", "tmp-offer-store-")), "index.json");
+    fs.writeFileSync(indexPath, JSON.stringify({ offers: seeded }), "utf-8");
+
+    const started = await startServer({ AGENTDEALS_INDEX_PATH: indexPath });
+    serverProc = started.proc;
+    const slug = quiet.vendor.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-|-$/g, "");
+    page = await (await fetch(`http://localhost:${started.port}/vendor/${slug}`)).text();
+  });
+
+  after(() => {
+    serverProc?.kill();
+    fs.rmSync(path.dirname(indexPath), { recursive: true, force: true });
+  });
+
+  it("renders the offer store's link, benefit and conditions", () => {
+    assert.ok(page.includes("Sign up via our referral link and get $40 in credits"), "an offer-level referral should render the CTA");
+    assert.ok(page.includes("https://example.com/?ref=OFFERSTORE"));
+    assert.ok(page.includes(RESTRICTION));
+    assert.ok(page.includes("vendor credit, not cash"));
+    assert.ok(!page.includes(COMMISSION_SENTENCE));
+  });
+});


### PR DESCRIPTION
Refs #1151

One referral banner was rendered for every vendor holding a curated code, and its wording was Railway's. There were only two codes, so four of the five entries had been publishing two false clauses since April.

## What was live

`/vendor/proton-mail`, `/vendor/proton-vpn`, `/vendor/proton-pass` and `/vendor/proton-drive` each rendered:

> **Sign up via our referral link and get $20 credit** — [Get $20 credit →] — We may earn a commission if you sign up through this link.

I read `proton.me/support/referral-program` today to check both clauses against the vendor rather than against the issue:

- *"When you refer a friend, you'll both get a $20 credit reward **when they subscribe to one of these premium Proton plans**: VPN Plus, Mail Plus, Pass Plus, Drive Plus, Proton Unlimited."* The reader we address is on a free-tier index, on a page whose free tier is 1 GB. They get nothing.
- *"Can I exchange my credits for cash? **No.** You can only use your credits on your Proton subscription."* There is no commission.

Both clauses are accurate for Railway and for nothing else we hold.

## The change

**AC-1/AC-2.** The four Proton rows are gone from `data/platform_codes.json`. Railway is the only row, unchanged.

**AC-3.** The banner no longer carries a benefit sentence hardcoded for one program. It reads the record:

- `referrer_compensation` is a new required field — `commission`, `credit` or `none` — and the sentence is chosen from it, not inferred from the benefit string. A record that says `credit` renders *"We are paid in vendor credit, not cash"*; a record that says `none` renders *"We are paid nothing"*; a record that states nothing renders *"we have not recorded what it pays us"* and never the commission claim.
- `restrictions` is a new required field, an array. `[]` is an explicit statement, so a new row cannot be added without answering both questions — a test over the store enforces that.

**AC-4.** A record with restrictions renders them in their own block **between the headline and the button**, so the reader sees the condition before the click rather than behind a policy link. They are repeated on `/disclosure` beside the partner, and carried on `/api/referral-codes` and `/api/referral-codes/:vendor` as `restrictions`, so an agent republishing our benefit string gets the conditions with it. That last part is beyond the wording of AC-4 and I have said so on the issue — an agent that receives `$300 in credit` and nothing else republishes an unconditional claim, which is the defect this AC exists to stop.

**AC-5.** `/vendor/railway` is byte-identical to `main`. Proved by sweep, not by inspection.

**AC-6.** `get_referral_code` resolves Railway and returns nothing for the four Proton vendors; `/api/referral-codes/:vendor` 404s for them and answers 200 for Railway.

**AC-7.** Not done here, on the PM's instruction in the second comment of #1152 — *"that card should go the same way, please handle it here rather than reopening #1151."* What `/referral-programs` says after this change is written out on the issue.

`restrictions` matches the field name already on `Referral` in `src/types.ts`, which has existed unused since the store was written and is rendered nowhere. `ourReferralLinkFor` now maps both stores onto it, so the conditions field has one name wherever it is held.

## The CTA now reads the same predicate as the count

It was keyed on `getPlatformCodeForVendor` while `/disclosure` counted the union of both stores — so a vendor held only in the offer index would have been named a partner on a page that offered no link. That is #1154's defect from the other side. The CTA now calls `ourReferralLinkFor`, which is a **rendering no-op today** (the sweep proves it: 1,568 of 1,572 vendor pages byte-identical) and is covered by a test that seeds a referral into a temporary index via `AGENTDEALS_INDEX_PATH`.

## Verification

- **2,585 tests / 0 failures**, 21 new. `tsc` clean, `validate-data` clean.
- **Rendered sweep over all 1,572 vendor pages plus 9 referral surfaces**, against a `main` worktree: **1,568 byte-identical**; the 4 that change are the four Proton pages, each losing exactly the referral box and nothing else; marketplace solicitation unchanged at 1,551 in both. Vendor pages rendering a referral link: **5 → 1**.
- `/disclosure` and `/referral-programs` track the removal on their own, because #1154 wired them to the shared predicate: *"only 5 currently have"* → *"only 1 currently has"*, and the paid/unpaid split 5/16 → 1/20. No code in this PR touches either sentence.
- `scripts/mutate-1151.sh`: 20 mutations. Includes reverting the hardcoded commission line, publishing a credit arrangement as a commission, publishing an unstated one as a commission, moving the conditions after the button, dropping them from each of the four surfaces, and re-adding a removed code.
- `check-mutation-targets.mjs` clean across every mutation script.
- Real MCP `initialize` → `tools/call` for `get_referral_code`.
- Screenshots of the four Proton pages, `/vendor/railway` and a synthetic conditional record.

## Two things found and not fixed here

Both are on the issue with evidence. Neither is in this PR's scope and both are the PM's to rank.

1. `/hosting-pricing` publishes a hardcoded *"Claim your $20 credit"* sponsored link pointing at `railway.com/affiliate-program` — the page where an affiliate signs up, not our referral URL. The reader gets no credit and we get no attribution. It is gated on `referral_program.available`, so it renders whether or not we hold a code.
2. Railway's `terms_url` (`railway.com/affiliate-program`) does not state the $20 reader benefit we cite it for. That is #1152's "a 200 is three separable claims".
