### PR TITLE
Point the hosting referral at the link we hold, not the program page (#1161)

### DIFF
--- a/scripts/mutate-1161.sh
+++ b/scripts/mutate-1161.sh
@@ -1,0 +1,305 @@
+#!/usr/bin/env bash
+set -u
+
+REPO="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$REPO" || exit 1
+
+ANCHORS="src/referral-anchors.ts"
+SURFACES="src/referral-surfaces.ts"
+SERVE="src/serve.ts"
+BACKUP_DIR="$(mktemp -d)"
+cp "$ANCHORS" "$BACKUP_DIR/referral-anchors.ts"
+cp "$SURFACES" "$BACKUP_DIR/referral-surfaces.ts"
+cp "$SERVE" "$BACKUP_DIR/serve.ts"
+
+restore() {
+  cp "$BACKUP_DIR/referral-anchors.ts" "$ANCHORS"
+  cp "$BACKUP_DIR/referral-surfaces.ts" "$SURFACES"
+  cp "$BACKUP_DIR/serve.ts" "$SERVE"
+}
+trap restore EXIT
+
+killed=0
+survived=0
+TESTS="test/sponsored-link-targets.test.ts test/referral-record-terms.test.ts test/referral-disclosure-predicate.test.ts"
+
+run_mutation() {
+  local name="$1"
+  shift
+  echo "=== $name"
+  restore
+  "$@"
+  if diff -q "$BACKUP_DIR/referral-anchors.ts" "$ANCHORS" > /dev/null \
+    && diff -q "$BACKUP_DIR/referral-surfaces.ts" "$SURFACES" > /dev/null \
+    && diff -q "$BACKUP_DIR/serve.ts" "$SERVE" > /dev/null; then
+    echo "    NOT APPLIED: the mutation changed no file, so it proves nothing"
+    survived=$((survived + 1))
+    return
+  fi
+  if ! npm run build > /tmp/mutate-1161-build.log 2>&1; then
+    echo "    NOT APPLIED: the mutation does not compile, so no test ran"
+    tail -3 /tmp/mutate-1161-build.log
+    survived=$((survived + 1))
+    return
+  fi
+  if timeout 900 node --test --test-concurrency 1 $TESTS > /tmp/mutate-1161-test.log 2>&1; then
+    echo "    SURVIVED"
+    survived=$((survived + 1))
+  else
+    echo "    KILLED: $(grep -c '✖ ' /tmp/mutate-1161-test.log) failing assertion(s)"
+    grep '✖ ' /tmp/mutate-1161-test.log | head -4
+    killed=$((killed + 1))
+  fi
+}
+
+py() { python3 - "$@"; }
+
+m_the_button_points_at_the_vendors_own_program_page() {
+  py <<'PY'
+p = "src/serve.ts"
+s = open(p).read()
+s = s.replace("""'    <p><a href="' + escHtmlServer(hostingReferral.url) + '\"""",
+              """'    <p><a href="' + escHtmlServer(hostingReferral.termsUrl ?? hostingReferral.url) + '\"""")
+open(p, "w").write(s)
+PY
+}
+
+m_the_box_renders_whenever_the_vendor_runs_a_program() {
+  py <<'PY'
+p = "src/serve.ts"
+s = open(p).read()
+s = s.replace('  const hostingReferral = ourReferralLinkFor("Railway", railwayOffer ?? null);',
+              '  const hostingReferral = railwayOffer?.referral_program?.available ? (ourReferralLinkFor("Railway", railwayOffer) ?? { vendor: "Railway", url: railwayOffer.referral_program.program_url, refereeBenefit: "$20 in free credits", restrictions: [], compensation: null, termsUrl: null, source: "offer_referral" as const }) : null;')
+open(p, "w").write(s)
+PY
+}
+
+m_the_button_names_a_hardcoded_benefit() {
+  py <<'PY'
+p = "src/serve.ts"
+s = open(p).read()
+s = s.replace("""'" rel="noopener sponsored" target="_blank">Get ' + escHtmlServer(hostingReferral.refereeBenefit) + ' &rarr;</a>""",
+              """'" rel="noopener sponsored" target="_blank">Get $20 in free credits &rarr;</a>""")
+open(p, "w").write(s)
+PY
+}
+
+m_the_heading_names_a_hardcoded_benefit() {
+  py <<'PY'
+p = "src/serve.ts"
+s = open(p).read()
+s = s.replace("""    '    <h3>\\u{1F680} ' + escHtmlServer(hostingReferral.vendor) + ' \\u2014 ' + escHtmlServer(hostingReferral.refereeBenefit) + ' with our referral</h3>\\n' +""",
+              """    '    <h3>\\u{1F680} Railway \\u2014 $20 in free credits with our referral</h3>\\n' +""")
+open(p, "w").write(s)
+PY
+}
+
+m_the_superlative_returns() {
+  py <<'PY'
+p = "src/serve.ts"
+s = open(p).read()
+s = s.replace("""    '    <p><a href="' + escHtmlServer(hostingReferral.url)""",
+              """    '    <p>Railway is our top pick for side projects and production apps alike. <a href="' + escHtmlServer(hostingReferral.url)""")
+open(p, "w").write(s)
+PY
+}
+
+m_the_unsourced_trial_comparison_returns() {
+  py <<'PY'
+p = "src/serve.ts"
+s = open(p).read()
+s = s.replace("""    '    <p><a href="' + escHtmlServer(hostingReferral.url)""",
+              """    '    <p>4x the standard $5 trial credit). <a href="' + escHtmlServer(hostingReferral.url)""")
+open(p, "w").write(s)
+PY
+}
+
+m_the_box_stops_saying_what_the_link_pays_us() {
+  py <<'PY'
+p = "src/serve.ts"
+s = open(p).read()
+s = s.replace("""    '    <p class="referral-compensation">' + escHtmlServer(referrerDisclosureSentence(hostingReferral.compensation)) + '</p>\\n' +\n    '  </div>\\n'""",
+              """    '  </div>\\n'""")
+open(p, "w").write(s)
+PY
+}
+
+m_the_box_publishes_a_commission_whatever_the_record_says() {
+  py <<'PY'
+p = "src/serve.ts"
+s = open(p).read()
+s = s.replace("""'    <p class="referral-compensation">' + escHtmlServer(referrerDisclosureSentence(hostingReferral.compensation)) + '</p>\\n'""",
+              """'    <p class="referral-compensation">We may earn a commission if you sign up through this link.</p>\\n'""")
+open(p, "w").write(s)
+PY
+}
+
+m_the_conditions_are_never_rendered() {
+  py <<'PY'
+p = "src/serve.ts"
+s = open(p).read()
+s = s.replace("    (hostingReferral.restrictions.length > 0 ?\n", "    (hostingReferral.restrictions.length > 99 ?\n")
+open(p, "w").write(s)
+PY
+}
+
+m_the_conditions_are_stated_after_the_button() {
+  py <<'PY'
+p = "src/serve.ts"
+s = open(p).read()
+conditions = """    (hostingReferral.restrictions.length > 0 ?
+    '    <div class="referral-conditions">\\n' +
+    '      <div class="referral-conditions-heading">' + REFERRAL_CONDITIONS_HEADING + '</div>\\n' +
+    '      <ul>' + hostingReferral.restrictions.map(r => '<li>' + escHtmlServer(r) + '</li>').join("") + '</ul>\\n' +
+    '    </div>\\n'
+    : '') +
+"""
+button = """    '    <p><a href="' + escHtmlServer(hostingReferral.url) + '" rel="noopener sponsored" target="_blank">Get ' + escHtmlServer(hostingReferral.refereeBenefit) + ' &rarr;</a> &middot; <a href="/disclosure" style="color:var(--text-dim);font-size:.8rem">Affiliate disclosure</a></p>\\n' +
+"""
+assert conditions in s and button in s
+s = s.replace(conditions + button, button + conditions)
+open(p, "w").write(s)
+PY
+}
+
+m_the_conditions_lose_their_heading() {
+  py <<'PY'
+p = "src/referral-surfaces.ts"
+s = open(p).read()
+s = s.replace('export const REFERRAL_CONDITIONS_HEADING = "What you have to do to get it";',
+              'export const REFERRAL_CONDITIONS_HEADING = "";')
+open(p, "w").write(s)
+PY
+}
+
+m_the_two_referral_surfaces_word_the_conditions_differently() {
+  py <<'PY'
+p = "src/serve.ts"
+s = open(p).read()
+s = s.replace("""'      <div class="referral-conditions-heading">' + REFERRAL_CONDITIONS_HEADING + '</div>\\n'""",
+              """'      <div class="referral-conditions-heading">Terms</div>\\n'""")
+open(p, "w").write(s)
+PY
+}
+
+m_no_rel_is_read_as_sponsored() {
+  py <<'PY'
+p = "src/referral-anchors.ts"
+s = open(p).read()
+s = s.replace("  return anchor.rel.includes(\"sponsored\");", "  return false;")
+open(p, "w").write(s)
+PY
+}
+
+m_a_rel_that_merely_contains_the_letters_is_read_as_sponsored() {
+  py <<'PY'
+p = "src/referral-anchors.ts"
+s = open(p).read()
+s = s.replace("  return anchor.rel.includes(\"sponsored\");", "  return anchor.rel.join(\" \").includes(\"sponsored\");")
+open(p, "w").write(s)
+PY
+}
+
+m_the_anchor_label_is_never_read() {
+  py <<'PY'
+p = "src/referral-anchors.ts"
+s = open(p).read()
+s = s.replace("      label: plainText(match[2]),", "      label: \"\",")
+open(p, "w").write(s)
+PY
+}
+
+m_the_href_is_never_read() {
+  py <<'PY'
+p = "src/referral-anchors.ts"
+s = open(p).read()
+s = s.replace('      href: attributeOf(match[1], "href"),', '      href: "",')
+open(p, "w").write(s)
+PY
+}
+
+m_nested_markup_swallows_the_label() {
+  py <<'PY'
+p = "src/referral-anchors.ts"
+s = open(p).read()
+s = s.replace('const ANCHOR_TAG = /<a\\s+([^>]*?)>([\\s\\S]*?)<\\/a>/gi;',
+              'const ANCHOR_TAG = /<a\\s+([^>]*?)>([^<]*)<\\/a>/gi;')
+open(p, "w").write(s)
+PY
+}
+
+m_no_label_is_read_as_an_offer() {
+  py <<'PY'
+p = "src/referral-anchors.ts"
+s = open(p).read()
+s = s.replace("  return BENEFIT_VERB.test(text) || BENEFIT_AMOUNT.test(text);", "  return false;")
+open(p, "w").write(s)
+PY
+}
+
+m_every_label_is_read_as_an_offer() {
+  py <<'PY'
+p = "src/referral-anchors.ts"
+s = open(p).read()
+s = s.replace("  return BENEFIT_VERB.test(text) || BENEFIT_AMOUNT.test(text);", "  return text.length > 0;")
+open(p, "w").write(s)
+PY
+}
+
+m_a_stated_amount_is_not_read_as_an_offer() {
+  py <<'PY'
+p = "src/referral-anchors.ts"
+s = open(p).read()
+s = s.replace("  return BENEFIT_VERB.test(text) || BENEFIT_AMOUNT.test(text);", "  return BENEFIT_VERB.test(text);")
+open(p, "w").write(s)
+PY
+}
+
+m_only_a_label_that_is_nothing_but_a_verb_is_read_as_an_offer() {
+  py <<'PY'
+p = "src/referral-anchors.ts"
+s = open(p).read()
+s = s.replace("const BENEFIT_VERB = /^(claim|get|redeem|save|unlock|grab|sign\\s?up|start)\\b/i;",
+              "const BENEFIT_VERB = /^(claim|get|redeem|save|unlock|grab|sign\\s?up|start)$/i;")
+open(p, "w").write(s)
+PY
+}
+
+m_a_verb_anywhere_in_the_label_is_read_as_an_offer() {
+  py <<'PY'
+p = "src/referral-anchors.ts"
+s = open(p).read()
+s = s.replace("const BENEFIT_VERB = /^(claim|get|redeem|save|unlock|grab|sign\\s?up|start)\\b/i;",
+              "const BENEFIT_VERB = /(claim|get|redeem|save|unlock|grab|sign\\s?up|start)\\b/i;")
+open(p, "w").write(s)
+PY
+}
+
+run_mutation "the button points at the vendor's own program page" m_the_button_points_at_the_vendors_own_program_page
+run_mutation "the box renders whenever the vendor runs a program" m_the_box_renders_whenever_the_vendor_runs_a_program
+run_mutation "the button names a hardcoded benefit" m_the_button_names_a_hardcoded_benefit
+run_mutation "the heading names a hardcoded benefit" m_the_heading_names_a_hardcoded_benefit
+run_mutation "the superlative returns" m_the_superlative_returns
+run_mutation "the unsourced trial comparison returns" m_the_unsourced_trial_comparison_returns
+run_mutation "the box stops saying what the link pays us" m_the_box_stops_saying_what_the_link_pays_us
+run_mutation "the box publishes a commission whatever the record says" m_the_box_publishes_a_commission_whatever_the_record_says
+run_mutation "the conditions are never rendered" m_the_conditions_are_never_rendered
+run_mutation "the conditions are stated after the button" m_the_conditions_are_stated_after_the_button
+run_mutation "the conditions lose their heading" m_the_conditions_lose_their_heading
+run_mutation "the two referral surfaces word the conditions differently" m_the_two_referral_surfaces_word_the_conditions_differently
+run_mutation "no rel is read as sponsored" m_no_rel_is_read_as_sponsored
+run_mutation "a rel that merely contains the letters is read as sponsored" m_a_rel_that_merely_contains_the_letters_is_read_as_sponsored
+run_mutation "the anchor label is never read" m_the_anchor_label_is_never_read
+run_mutation "the href is never read" m_the_href_is_never_read
+run_mutation "nested markup swallows the label" m_nested_markup_swallows_the_label
+run_mutation "no label is read as an offer" m_no_label_is_read_as_an_offer
+run_mutation "every label is read as an offer" m_every_label_is_read_as_an_offer
+run_mutation "a stated amount is not read as an offer" m_a_stated_amount_is_not_read_as_an_offer
+run_mutation "only a label that is nothing but a verb is read as an offer" m_only_a_label_that_is_nothing_but_a_verb_is_read_as_an_offer
+run_mutation "a verb anywhere in the label is read as an offer" m_a_verb_anywhere_in_the_label_is_read_as_an_offer
+
+restore
+npm run build > /dev/null 2>&1
+echo
+echo "killed: $killed  survived: $survived"
+[ "$survived" -eq 0 ]

--- a/scripts/sweep-1161.mjs
+++ b/scripts/sweep-1161.mjs
@@ -1,0 +1,87 @@
+import { spawn } from "node:child_process";
+import { createHash } from "node:crypto";
+import { readFileSync, writeFileSync } from "node:fs";
+import path from "node:path";
+
+const repo = process.argv[2];
+const out = process.argv[3];
+const CONCURRENCY = 16;
+
+function startServer() {
+  return new Promise((resolve, reject) => {
+    const p = spawn("node", [path.join(repo, "dist", "serve.js")], {
+      cwd: repo,
+      stdio: ["pipe", "pipe", "pipe"],
+      env: { ...process.env, PORT: "0", BASE_URL: "http://127.0.0.1" },
+    });
+    const timeout = setTimeout(() => { p.kill("SIGKILL"); reject(new Error("timeout")); }, 60000);
+    p.stderr.on("data", (b) => {
+      const m = b.toString().match(/running on http:\/\/localhost:(\d+)/);
+      if (m) { clearTimeout(timeout); resolve({ proc: p, port: parseInt(m[1], 10) }); }
+    });
+    p.on("error", (e) => { clearTimeout(timeout); reject(e); });
+  });
+}
+
+const { sponsoredAnchorsIn } = await import(path.join(repo, "dist", "sponsored-links.js"))
+  .catch(() => ({ sponsoredAnchorsIn: null }));
+
+const ANCHOR_TAG = /<a\s+([^>]*)>([\s\S]*?)<\/a>/gi;
+const fallbackSponsoredAnchorsIn = (html) => {
+  const found = [];
+  for (const m of html.matchAll(ANCHOR_TAG)) {
+    const rel = /rel="([^"]*)"/i.exec(m[1]);
+    if (!rel || !rel[1].split(/\s+/).includes("sponsored")) continue;
+    const href = /href="([^"]*)"/i.exec(m[1]);
+    found.push({ href: href ? href[1] : "", label: m[2].replace(/<[^>]*>/g, "").trim() });
+  }
+  return found;
+};
+const anchorsIn = sponsoredAnchorsIn ?? fallbackSponsoredAnchorsIn;
+
+const { proc, port } = await startServer();
+const base = `http://127.0.0.1:${port}`;
+
+const stripHost = (u) => u.replace(/^https?:\/\/[^/]+/, "");
+const index = await (await fetch(`${base}/sitemap.xml`)).text();
+let paths = [];
+for (const m of index.matchAll(/<loc>([^<]+)<\/loc>/g)) {
+  const xml = await (await fetch(`${base}${stripHost(m[1])}`)).text();
+  paths.push(...[...xml.matchAll(/<loc>([^<]+)<\/loc>/g)].map((l) => stripHost(l[1])));
+}
+paths = [...new Set(paths)].sort();
+
+const extra = ["/", "/disclosure", "/referral-programs", "/marketplace", "/hosting-pricing", "/signal"];
+for (const p of extra) if (!paths.includes(p)) paths.push(p);
+
+const pages = {};
+let cursor = 0;
+async function worker() {
+  while (cursor < paths.length) {
+    const p = paths[cursor++];
+    const res = await fetch(`${base}${p}`);
+    const body = await res.text();
+    pages[p] = {
+      status: res.status,
+      sha: createHash("sha256").update(body).digest("hex"),
+      length: body.length,
+      sponsored: anchorsIn(body),
+    };
+  }
+}
+await Promise.all(Array.from({ length: CONCURRENCY }, worker));
+
+proc.kill("SIGKILL");
+writeFileSync(out, JSON.stringify({ paths, pages }));
+
+const withSponsored = Object.entries(pages).filter(([, v]) => v.sponsored.length > 0);
+const hrefCounts = new Map();
+for (const [, v] of withSponsored) {
+  for (const a of v.sponsored) hrefCounts.set(a.href, (hrefCounts.get(a.href) ?? 0) + 1);
+}
+console.log(`swept ${paths.length} paths -> ${out}`);
+console.log(`pages rendering at least one sponsored link: ${withSponsored.length}`);
+console.log("distinct sponsored hrefs:");
+for (const [href, count] of [...hrefCounts].sort((a, b) => b[1] - a[1])) {
+  console.log(`  ${count.toString().padStart(5)}  ${href}`);
+}

--- a/src/referral-anchors.ts
+++ b/src/referral-anchors.ts
@@ -1,0 +1,43 @@
+export interface RenderedAnchor {
+  href: string;
+  label: string;
+  rel: string[];
+}
+
+const ANCHOR_TAG = /<a\s+([^>]*?)>([\s\S]*?)<\/a>/gi;
+const BENEFIT_VERB = /^(claim|get|redeem|save|unlock|grab|sign\s?up|start)\b/i;
+const BENEFIT_AMOUNT = /[$€£]\s?\d|\b\d+\s*%\s*(off|discount)\b/i;
+
+function attributeOf(tag: string, name: string): string {
+  const match = new RegExp(`\\b${name}="([^"]*)"`, "i").exec(tag);
+  return match ? match[1] : "";
+}
+
+function plainText(html: string): string {
+  return html.replace(/<[^>]*>/g, " ").replace(/&[a-z]+;|&#\d+;/gi, " ").replace(/\s+/g, " ").trim();
+}
+
+export function anchorsIn(html: string): RenderedAnchor[] {
+  const anchors: RenderedAnchor[] = [];
+  for (const match of html.matchAll(ANCHOR_TAG)) {
+    anchors.push({
+      href: attributeOf(match[1], "href"),
+      label: plainText(match[2]),
+      rel: attributeOf(match[1], "rel").split(/\s+/).filter(Boolean),
+    });
+  }
+  return anchors;
+}
+
+export function isSponsored(anchor: RenderedAnchor): boolean {
+  return anchor.rel.includes("sponsored");
+}
+
+export function sponsoredAnchorsIn(html: string): RenderedAnchor[] {
+  return anchorsIn(html).filter(isSponsored);
+}
+
+export function offersAReaderBenefit(label: string): boolean {
+  const text = label.replace(/\s+/g, " ").trim();
+  return BENEFIT_VERB.test(text) || BENEFIT_AMOUNT.test(text);
+}

--- a/src/referral-surfaces.ts
+++ b/src/referral-surfaces.ts
@@ -17,6 +17,8 @@ export interface OurReferralLink {
 
 const REFEREE_BENEFIT_FALLBACK = "Referral link available";
 
+export const REFERRAL_CONDITIONS_HEADING = "What you have to do to get it";
+
 export function ourReferralLinkFor(vendorName: string, offer?: Offer | null): OurReferralLink | null {
   const platformCode = getPlatformCodeForVendor(vendorName);
   const offerReferral = offer?.referral ?? null;

--- a/src/serve.ts
+++ b/src/serve.ts
@@ -27,7 +27,7 @@ import { recordConversion, confirmEligibleEntries, clawbackEntry, getAgentBalanc
 import { validateX402Address, executeTransfer, generateCorrelationId } from "./x402.js";
 import { submitReferralCode, getCodesByAgent, getCodeById, updateCode, revokeCode, calculateTrustTier, getDailySubmissionCount, getDailyLimit, getRankedCodesForVendor, calculateCodeScore } from "./referral-codes.js";
 import { getBestReferralCode, listAllReferralCodes } from "./platform-codes.js";
-import { allOurReferralLinks, hasAnyReferralSurface, ourReferralLinkFor, referralLinkCountClause, referrerDisclosureSentence } from "./referral-surfaces.js";
+import { REFERRAL_CONDITIONS_HEADING, allOurReferralLinks, hasAnyReferralSurface, ourReferralLinkFor, referralLinkCountClause, referrerDisclosureSentence } from "./referral-surfaces.js";
 import { runHealthCheck, getLastReport, startPeriodicChecks } from "./referral-health.js";
 import { addFriend, removeFriend, getFriends, getFriendCodesForVendors } from "./friends.js";
 import { subscribe as watchlistSubscribe, getSubscription as getWatchlistSubscription, unsubscribe as watchlistUnsubscribe, listSubscriptions as listWatchlistSubscriptions } from "./watchlist.js";
@@ -3992,7 +3992,7 @@ ${enrichedAlts.map(a => {
         <strong style="font-size:1rem;color:var(--text)">Sign up via our referral link and get ${escHtmlServer(ourLink.refereeBenefit)}</strong>
       </div>${ourLink.restrictions.length > 0 ? `
       <div class="referral-conditions" style="margin:0 0 .9rem;padding:.65rem .85rem;border-left:3px solid #d29922;border-radius:0 6px 6px 0;background:rgba(210,153,34,0.08)">
-        <div style="font-size:.7rem;text-transform:uppercase;letter-spacing:.08em;color:var(--text-dim);font-family:var(--mono);margin-bottom:.35rem">What you have to do to get it</div>
+        <div style="font-size:.7rem;text-transform:uppercase;letter-spacing:.08em;color:var(--text-dim);font-family:var(--mono);margin-bottom:.35rem">${REFERRAL_CONDITIONS_HEADING}</div>
         <ul style="margin:0;padding-left:1.1rem;font-size:.8rem;color:var(--text);line-height:1.5">${ourLink.restrictions.map(r => `<li>${escHtmlServer(r)}</li>`).join("")}</ul>
       </div>` : ""}
       <a href="${escHtmlServer(ourLink.url)}" rel="noopener sponsored" target="_blank" style="display:inline-block;padding:.6rem 1.25rem;background:#3fb950;color:#fff;border-radius:8px;font-weight:600;font-size:.9rem;text-decoration:none">Get ${escHtmlServer(ourLink.refereeBenefit)} &rarr;</a>
@@ -30987,7 +30987,7 @@ function buildHostingPricingPage(): string {
 
   // Check for Railway referral
   const railwayOffer = offers.find(o => o.vendor === "Railway");
-  const hasRailwayReferral = railwayOffer?.referral_program?.available === true;
+  const hostingReferral = ourReferralLinkFor("Railway", railwayOffer ?? null);
 
   const pricingTableRows = services.map(s => {
     const freeColor = freeTypeColors[s.freeType] || "var(--text-muted)";
@@ -31147,6 +31147,10 @@ function buildHostingPricingPage(): string {
     '.referral-box h3{color:#3fb950;margin:0 0 .5rem;font-size:1rem}\n' +
     '.referral-box p{color:var(--text-muted);font-size:.9rem;margin:0}\n' +
     '.referral-box a{color:#3fb950}\n' +
+    '.referral-conditions{margin:.6rem 0 .75rem;padding:.6rem .8rem;border-left:3px solid #d29922;border-radius:0 6px 6px 0;background:rgba(210,153,34,0.08)}\n' +
+    '.referral-conditions-heading{font-size:.7rem;text-transform:uppercase;letter-spacing:.08em;color:var(--text-dim);font-family:var(--mono);margin-bottom:.35rem}\n' +
+    '.referral-conditions ul{margin:0;padding-left:1.1rem;font-size:.85rem;color:var(--text-muted);line-height:1.5}\n' +
+    '.referral-compensation{margin-top:.6rem !important;font-size:.8rem !important;color:var(--text-dim) !important}\n' +
     '.faq-item{border-bottom:1px solid var(--border);padding:1rem 0}\n' +
     '.faq-item:last-child{border-bottom:none}\n' +
     '.faq-q{font-weight:600;color:var(--text);font-size:.95rem;margin-bottom:.5rem}\n' +
@@ -31176,10 +31180,17 @@ function buildHostingPricingPage(): string {
     '    <p><strong>This guide covers:</strong> pricing tables, category breakdowns, free tier analysis, cost comparison for solo devs and teams, hidden costs, pricing gotchas, and best-for-use-case recommendations \u2014 compiled by hand from vendor pricing pages.</p>\n' +
     '  </div>\n' +
     '\n' +
-    (hasRailwayReferral ? (
+    (hostingReferral ? (
     '  <div class="referral-box">\n' +
-    '    <h3>\u{1F680} Railway \u2014 $20 in free credits with our referral</h3>\n' +
-    '    <p>Get $20 in Railway credits (4x the standard $5 trial credit). Railway is our top pick for side projects and production apps alike. <a href="' + escHtmlServer(railwayOffer?.referral_program?.program_url ?? "/vendor/railway") + '" rel="noopener sponsored">Claim your $20 credit</a> &middot; <a href="/disclosure" style="color:var(--text-dim);font-size:.8rem">Affiliate disclosure</a></p>\n' +
+    '    <h3>\u{1F680} ' + escHtmlServer(hostingReferral.vendor) + ' \u2014 ' + escHtmlServer(hostingReferral.refereeBenefit) + ' with our referral</h3>\n' +
+    (hostingReferral.restrictions.length > 0 ?
+    '    <div class="referral-conditions">\n' +
+    '      <div class="referral-conditions-heading">' + REFERRAL_CONDITIONS_HEADING + '</div>\n' +
+    '      <ul>' + hostingReferral.restrictions.map(r => '<li>' + escHtmlServer(r) + '</li>').join("") + '</ul>\n' +
+    '    </div>\n'
+    : '') +
+    '    <p><a href="' + escHtmlServer(hostingReferral.url) + '" rel="noopener sponsored" target="_blank">Get ' + escHtmlServer(hostingReferral.refereeBenefit) + ' &rarr;</a> &middot; <a href="/disclosure" style="color:var(--text-dim);font-size:.8rem">Affiliate disclosure</a></p>\n' +
+    '    <p class="referral-compensation">' + escHtmlServer(referrerDisclosureSentence(hostingReferral.compensation)) + '</p>\n' +
     '  </div>\n'
     ) : '') +
     '\n' +

--- a/test/sponsored-link-targets.test.ts
+++ b/test/sponsored-link-targets.test.ts
@@ -1,0 +1,276 @@
+import { describe, it, before, after } from "node:test";
+import assert from "node:assert";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { spawn, type ChildProcess } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO = path.join(__dirname, "..");
+const PLATFORM_CODES_PATH = path.join(REPO, "data", "platform_codes.json");
+
+const { anchorsIn, isSponsored, offersAReaderBenefit, sponsoredAnchorsIn } = await import("../dist/referral-anchors.js");
+const { ourReferralLinkFor, allOurReferralLinks, REFERRAL_CONDITIONS_HEADING } = await import("../dist/referral-surfaces.js");
+const { resetPlatformCodesCache } = await import("../dist/platform-codes.js");
+const { loadOffers } = await import("../dist/data.js");
+
+const offers = loadOffers();
+const railwayOffer = offers.find((o: any) => o.vendor === "Railway");
+const RAILWAY_REFERRAL_URL = "https://railway.com?referralCode=7RZL9q";
+const RAILWAY_PROGRAM_URL = "https://railway.com/affiliate-program";
+const COMMISSION_SENTENCE = "We may earn a commission if you sign up through this link.";
+
+function startServer(env: Record<string, string> = {}): Promise<{ proc: ChildProcess; port: number }> {
+  return new Promise((resolve, reject) => {
+    const proc = spawn("node", [path.join(REPO, "dist", "serve.js")], {
+      cwd: REPO,
+      stdio: ["pipe", "pipe", "pipe"],
+      env: { ...process.env, PORT: "0", BASE_URL: "http://127.0.0.1", ...env },
+    });
+    const timeout = setTimeout(() => { proc.kill("SIGKILL"); reject(new Error("Server startup timeout")); }, 30000);
+    proc.stderr!.on("data", (b: Buffer) => {
+      const m = b.toString().match(/running on http:\/\/localhost:(\d+)/);
+      if (m) { clearTimeout(timeout); resolve({ proc, port: parseInt(m[1], 10) }); }
+    });
+    proc.on("error", (e) => { clearTimeout(timeout); reject(e); });
+  });
+}
+
+const stripHost = (u: string) => u.replace(/^https?:\/\/[^/]+/, "");
+
+async function everyPublishedPath(base: string): Promise<string[]> {
+  const index = await (await fetch(`${base}/sitemap.xml`)).text();
+  const paths: string[] = [];
+  for (const m of index.matchAll(/<loc>([^<]+)<\/loc>/g)) {
+    const xml = await (await fetch(`${base}${stripHost(m[1])}`)).text();
+    for (const loc of xml.matchAll(/<loc>([^<]+)<\/loc>/g)) paths.push(stripHost(loc[1]));
+  }
+  for (const extra of ["/", "/hosting-pricing", "/disclosure", "/referral-programs", "/marketplace"]) {
+    if (!paths.includes(extra)) paths.push(extra);
+  }
+  return [...new Set(paths)];
+}
+
+async function fetchAll(base: string, paths: string[], concurrency = 12): Promise<Map<string, string>> {
+  const bodies = new Map<string, string>();
+  let cursor = 0;
+  const worker = async () => {
+    while (cursor < paths.length) {
+      const p = paths[cursor++];
+      bodies.set(p, await (await fetch(`${base}${p}`)).text());
+    }
+  };
+  await Promise.all(Array.from({ length: concurrency }, worker));
+  return bodies;
+}
+
+describe("reading a rendered anchor", () => {
+  it("reports the target and the words the reader clicks", () => {
+    const anchors = anchorsIn('<a href="https://example.com/?ref=X" rel="noopener sponsored" target="_blank">Get $20 in credits &rarr;</a>');
+    assert.strictEqual(anchors.length, 1);
+    assert.strictEqual(anchors[0].href, "https://example.com/?ref=X");
+    assert.strictEqual(anchors[0].label, "Get $20 in credits");
+    assert.ok(isSponsored(anchors[0]));
+  });
+
+  it("does not mistake a rel that merely contains the letters for the sponsored token", () => {
+    assert.ok(!isSponsored(anchorsIn('<a href="/x" rel="nosponsoredlink">y</a>')[0]));
+    assert.ok(isSponsored(anchorsIn('<a href="/x" rel="sponsored">y</a>')[0]));
+  });
+
+  it("reads the label through nested markup", () => {
+    const anchors = anchorsIn('<a href="/x" rel="sponsored"><span>Claim</span> your $20 credit</a>');
+    assert.strictEqual(anchors[0].label, "Claim your $20 credit");
+  });
+
+  it("separates a label that promises the reader something from one that describes a page", () => {
+    for (const label of ["Claim your credits", "Redeem now", "Unlock the free tier", "Sign up free"]) {
+      assert.ok(offersAReaderBenefit(label), `"${label}" opens by telling the reader to take something`);
+    }
+    for (const label of ["View program details", "View", "Read the terms", "Full profile", "How the program works"]) {
+      assert.ok(!offersAReaderBenefit(label), `"${label}" only describes what is on the other end`);
+    }
+  });
+
+  it("reads the instruction the label opens with, not a verb buried in a description", () => {
+    for (const label of ["How to get a referral code", "Read how we get paid", "Where to claim it, explained"]) {
+      assert.ok(!offersAReaderBenefit(label), `"${label}" describes a claim rather than making one`);
+    }
+    assert.ok(offersAReaderBenefit("Get a referral code"), "the same verb in the first position is an instruction");
+  });
+
+  it("treats a stated amount as an offer whatever verb introduces it", () => {
+    for (const label of ["$20 in credits", "20% off your first year", "Referral bonus: $300"]) {
+      assert.ok(offersAReaderBenefit(label), `"${label}" quotes the reader a figure`);
+    }
+    assert.ok(!offersAReaderBenefit("Program details"), "a label with neither a figure nor an instruction is a description");
+  });
+});
+
+describe("every link we mark sponsored is a referral link we hold", () => {
+  let serverProc: ChildProcess | null = null;
+  let bodies = new Map<string, string>();
+  let paths: string[] = [];
+
+  before(async () => {
+    const started = await startServer();
+    serverProc = started.proc;
+    const base = `http://127.0.0.1:${started.port}`;
+    paths = await everyPublishedPath(base);
+    bodies = await fetchAll(base, paths);
+  });
+
+  after(() => { serverProc?.kill("SIGKILL"); });
+
+  it("sweeps the whole published surface rather than a chosen sample", () => {
+    assert.ok(paths.length > 3000, `expected the sitemap to enumerate the site, saw ${paths.length} paths`);
+    const sponsored = [...bodies.values()].flatMap(sponsoredAnchorsIn);
+    assert.ok(sponsored.length > 50, `expected the sweep to find the sponsored links we publish, saw ${sponsored.length}`);
+  });
+
+  it("points every sponsored link at a URL that attributes the signup to us", () => {
+    const ours = new Set(allOurReferralLinks(offers).map((l: any) => l.url));
+    assert.ok(ours.has(RAILWAY_REFERRAL_URL));
+    const strays: string[] = [];
+    for (const [p, body] of bodies) {
+      for (const anchor of sponsoredAnchorsIn(body)) {
+        if (!ours.has(anchor.href)) strays.push(`${p} -> ${anchor.href} ("${anchor.label}")`);
+      }
+    }
+    assert.deepStrictEqual(strays, [], `a sponsored link that is not one of ours pays nobody:\n${strays.join("\n")}`);
+  });
+
+  it("never offers the reader a benefit at a vendor's own program page", () => {
+    const programUrls = new Set(
+      offers.map((o: any) => o.referral_program?.program_url).filter((u: unknown): u is string => typeof u === "string")
+    );
+    assert.ok(programUrls.has(RAILWAY_PROGRAM_URL));
+    const misdirected: string[] = [];
+    for (const [p, body] of bodies) {
+      for (const anchor of anchorsIn(body)) {
+        if (!programUrls.has(anchor.href)) continue;
+        if (isSponsored(anchor) || offersAReaderBenefit(anchor.label)) {
+          misdirected.push(`${p} -> ${anchor.href} ("${anchor.label}")`);
+        }
+      }
+    }
+    assert.deepStrictEqual(misdirected, [], `a program page is where you read about a program, not where a reward is claimed:\n${misdirected.join("\n")}`);
+  });
+});
+
+describe("the hosting comparison offers the code we hold on the terms its record states", () => {
+  let serverProc: ChildProcess | null = null;
+  let page = "";
+
+  before(async () => {
+    const started = await startServer();
+    serverProc = started.proc;
+    page = await (await fetch(`http://127.0.0.1:${started.port}/hosting-pricing`)).text();
+  });
+
+  after(() => { serverProc?.kill("SIGKILL"); });
+
+  it("sends the reader to our referral URL and not to the program page", () => {
+    const sponsored = sponsoredAnchorsIn(page);
+    assert.strictEqual(sponsored.length, 1, "the page offers exactly one referral");
+    assert.strictEqual(sponsored[0].href, RAILWAY_REFERRAL_URL);
+    assert.ok(!page.includes(RAILWAY_PROGRAM_URL), "the affiliate signup page is not an offer to the reader");
+  });
+
+  it("takes the URL, the benefit and the compensation from the same resolver the vendor page uses", () => {
+    const ourLink = ourReferralLinkFor("Railway", railwayOffer);
+    assert.ok(ourLink);
+    assert.strictEqual(sponsoredAnchorsIn(page)[0].href, ourLink.url);
+    assert.ok(page.includes(`Get ${ourLink.refereeBenefit}`), "the button names the benefit the record states");
+    assert.ok(page.includes(`Railway — ${ourLink.refereeBenefit} with our referral`), "the heading names the benefit the record states");
+    assert.ok(page.includes(COMMISSION_SENTENCE), "the page states what the link pays us");
+  });
+
+  it("makes no claim about Railway that no record backs", () => {
+    assert.ok(!page.includes("top pick"), "we publish no ranking that awards a top pick");
+    assert.ok(!page.includes("trial credit)"), "the comparison against a $5 trial credit was sourced from nothing");
+    assert.ok(!page.includes("4x the standard"));
+  });
+});
+
+describe("the hosting referral box answers the record it renders", () => {
+  let serverProc: ChildProcess | null = null;
+  let originalCodes = "";
+  let conditionalPage = "";
+  let noCodePage = "";
+
+  const CONDITIONS = [
+    "The credit is granted only after a payment method is linked",
+    "Unused credit expires after 30 days",
+  ];
+  const CODE_URL = "https://railway.com?referralCode=CURATEDCODE";
+
+  before(async () => {
+    originalCodes = fs.readFileSync(PLATFORM_CODES_PATH, "utf-8");
+    const withConditions = JSON.parse(originalCodes);
+    for (const code of withConditions.platform_codes) {
+      if (code.vendor !== "Railway") continue;
+      code.restrictions = CONDITIONS;
+      code.referral_url = CODE_URL;
+      code.referee_benefit = "$45 in credits";
+      code.referrer_compensation = "credit";
+    }
+    fs.writeFileSync(PLATFORM_CODES_PATH, JSON.stringify(withConditions, null, 2), "utf-8");
+    resetPlatformCodesCache();
+    const conditional = await startServer();
+    conditionalPage = await (await fetch(`http://127.0.0.1:${conditional.port}/hosting-pricing`)).text();
+    conditional.proc.kill("SIGKILL");
+
+    const emptyCodes = JSON.parse(originalCodes);
+    emptyCodes.platform_codes = [];
+    fs.writeFileSync(PLATFORM_CODES_PATH, JSON.stringify(emptyCodes, null, 2), "utf-8");
+    resetPlatformCodesCache();
+
+    const withoutRailwayReferral = offers.map((o: any) => o.vendor === "Railway" ? { ...o, referral: undefined } : o);
+    const indexDir = fs.mkdtempSync(path.join(os.tmpdir(), "hosting-referral-"));
+    const indexPath = path.join(indexDir, "index.json");
+    fs.writeFileSync(indexPath, JSON.stringify({ offers: withoutRailwayReferral }), "utf-8");
+    const started = await startServer({ AGENTDEALS_INDEX_PATH: indexPath });
+    serverProc = started.proc;
+    noCodePage = await (await fetch(`http://127.0.0.1:${started.port}/hosting-pricing`)).text();
+  });
+
+  after(() => {
+    serverProc?.kill("SIGKILL");
+    fs.writeFileSync(PLATFORM_CODES_PATH, originalCodes, "utf-8");
+    resetPlatformCodesCache();
+  });
+
+  it("prefers the curated code over the offer store, as the vendor page does", () => {
+    const sponsored = sponsoredAnchorsIn(conditionalPage);
+    assert.strictEqual(sponsored.length, 1);
+    assert.strictEqual(sponsored[0].href, CODE_URL, "the box must resolve the link the same way every other referral surface does");
+    assert.ok(!conditionalPage.includes(RAILWAY_REFERRAL_URL), "the offer store's URL is not the one we hold for this vendor");
+    assert.ok(conditionalPage.includes("$45 in credits"), "the benefit comes from the record the link came from");
+    assert.ok(!conditionalPage.includes("$20 in credits"), "no part of the box restates a benefit from elsewhere");
+  });
+
+  it("says what this link pays us rather than what the last one did", () => {
+    assert.ok(
+      conditionalPage.includes("We are paid in vendor credit, not cash, if you sign up through this link."),
+      "a code paid in credit must not be disclosed as a commission"
+    );
+    assert.ok(!conditionalPage.includes(COMMISSION_SENTENCE));
+  });
+
+  it("states what a conditional reward costs the reader above the button", () => {
+    assert.ok(conditionalPage.includes(REFERRAL_CONDITIONS_HEADING), "the conditions are introduced as conditions");
+    for (const condition of CONDITIONS) assert.ok(conditionalPage.includes(condition), condition);
+    const heading = conditionalPage.indexOf(REFERRAL_CONDITIONS_HEADING);
+    const button = conditionalPage.indexOf('rel="noopener sponsored"');
+    assert.ok(heading > 0 && heading < button, "a condition stated after the click is stated too late");
+  });
+
+  it("drops the box entirely when we hold no link for the vendor, program or not", () => {
+    assert.ok(noCodePage.includes("Cloud Hosting"), "the rest of the page still renders");
+    assert.ok(!noCodePage.includes('<div class="referral-box">'), "there is nothing to offer");
+    assert.deepStrictEqual(sponsoredAnchorsIn(noCodePage), [], "there is nothing to disclose");
+    assert.ok(!noCodePage.includes("with our referral"));
+  });
+});


### PR DESCRIPTION
Refs #1161.

`/hosting-pricing` rendered a green box headed **"🚀 Railway — $20 in free credits with our referral"** with a button labelled **"Claim your $20 credit"**, `rel="noopener sponsored"`, pointing at `https://railway.com/affiliate-program`.

That page is where an affiliate signs up. It states a 15% referrer commission and no $20 credit, and it carries no referral code — so a reader who clicked it got nothing, and any signup that followed was not attributed to us. Our only revenue-generating referral relationship, promoted on the page dedicated to promoting it, in a form that could pay neither side.

The condition read the right store (`hasRailwayReferral` from the record) and the href read the wrong one. Both stores are correct in isolation; the join between them was not.

## What changed

**The href (AC-1).** `https://railway.com?referralCode=7RZL9q`, from `ourReferralLinkFor`.

**The whole box now renders from that resolver (AC-4)** rather than assembling itself from raw record fields — the URL, the benefit in the heading and on the button, the conditions and the compensation sentence all come from the record the link came from. Two consequences worth naming:

- It is gated on **holding a link**, not on `referral_program.available`. Before this, the box rendered whenever Railway ran a program, whether or not we held a code.
- A code with conditions states them **between the headline and the button**, under the same "What you have to do to get it" heading the vendor page uses — the mechanism from #1151, now reaching this page. The heading is one exported constant so the two surfaces cannot word it differently.

**"Railway is our top pick for side projects and production apps alike" is gone (AC-3),** with no replacement. We publish no ranking that awards a top pick, and this one went to the one vendor we earn from.

**"(4x the standard $5 trial credit)" is gone (AC-6).** It could have been sourced — the Railway record's description says "one-time $5 credit (30-day trial)" — but that is a number parsed out of prose, and the multiplier over it is stated nowhere. AC-6 allows dropping the comparison, so I dropped it rather than add a fragile parse.

**`/hosting-pricing`'s link now comes from `allOurReferralLinks` (AC-5),** which is what a collector under #1157 will enumerate, so this surface is covered by construction rather than by being added to a list.

## AC-2, checked over the render rather than the source

`src/referral-anchors.ts` reads anchors out of rendered HTML — href, label, `rel` tokens — plus `offersAReaderBenefit`, which separates a label that instructs the reader to take something ("Claim your $20 credit") from one that describes what is on the other end ("View program details").

The suite then sweeps **every path in the sitemap (3,916)** and asserts two properties:

1. every anchor marked `sponsored` targets a URL in `allOurReferralLinks` — i.e. a link that attributes the signup to us;
2. no anchor pointing at any `referral_program.program_url` in the index is sponsored or offers the reader a benefit.

Before this change that sweep finds **76 sponsored anchors across 71 pages, 75 at our referral URL and 1 at the affiliate page.** After, all 76 are at the referral URL. The three remaining `program_url` render sites — the vendor page's "View program details", the `/referral-programs` table's "View" under the Program column, and the field on `/api/referral-programs` — are all descriptions of a program and pass. The sweep runs in about 5 seconds.

## Verification

- **2601 tests / 0 failures** (16 new), `tsc --noEmit` clean, `validate-data` clean at 1,580 offers / 444 changes.
- **Sweep of all 3,916 published paths against a `main` worktree: 3,915 byte-identical.** The one that changes is `/hosting-pricing` (+521 bytes). `/vendor/railway` is in the identical set, so pulling the conditions heading into a shared constant is proved to be a no-op rather than assumed to be.
- `scripts/mutate-1161.sh`: **22 mutations, 22 killed, no survivors**, none by the compiler. Two first-pass survivors were real gaps and both are the same shape — a branch today's data cannot reach. Railway's record says `commission`, so hardcoding the commission sentence was an equivalent mutant until a fixture gave the code `referrer_compensation: "credit"`; and every label I had used as a non-offer lacked the verbs entirely, so dropping the `^` anchor from the benefit-verb pattern changed nothing until "How to get a referral code" and "Read how we get paid" were fixtures.
- `check-mutation-targets.mjs` 372/372 across 32 scripts.
- Real MCP `initialize` → `tools/call`: `get_referral_code({vendor: "Railway"})` still returns `7RZL9q` at `railway.com?referralCode=7RZL9q`.
- Screenshots of the box before, after, and carrying a conditional record's three conditions.
- 0 new code comments.
