### PR TITLE
Take a platform credential before writing to the ledger (#1164)

### DIFF
--- a/AGENT_README.md
+++ b/AGENT_README.md
@@ -60,6 +60,14 @@ The HTTP server port defaults to 3000 and can be configured via the `PORT` envir
 PORT=8080 npm run serve
 ```
 
+### Environment
+
+| Variable | Default | Effect |
+|---|---|---|
+| `PORT` | `3000` | HTTP server port |
+| `AGENTDEALS_PLATFORM_SECRET` | unset | The credential for `POST /api/conversions`, `/api/conversions/confirm` and `/api/conversions/clawback`, presented as `Authorization: Bearer <secret>`. **While it is unset every one of those requests is refused with `401`** — a conversion is an assertion about commission paid to us, so an unconfigured deployment must record none rather than record any. |
+| `AGENTDEALS_REGISTER_LIMIT_PER_HOUR` | `5` | Registrations allowed per client per hour on `POST /api/agents/register`. Registration stays open to anyone; the limit bounds how many identities one client can mint, and the developer API page states whatever value is configured. |
+
 Endpoints:
 - `POST /mcp` — MCP JSON-RPC requests (requires `Accept: application/json, text/event-stream` header)
 - `GET /mcp` — SSE stream for server-initiated notifications. The server writes an SSE comment frame as soon as the stream opens and every 25s after (`MCP_SSE_KEEPALIVE_MS` overrides the interval), so a proxy that closes an idle response does not cut it. A second `GET` on a session that already holds a stream replaces it rather than being refused — a session has one client, so a repeat `GET` is that client reconnecting. A `GET` or `POST` naming a session the server is not holding answers `400` with a JSON-RPC body giving the condition (`unknown_session` or `no_session`) and the recovery (`reinitialize`)

--- a/scripts/e2e-1164.mjs
+++ b/scripts/e2e-1164.mjs
@@ -1,0 +1,178 @@
+import { spawn } from "node:child_process";
+import { readFileSync, writeFileSync, existsSync, unlinkSync } from "node:fs";
+import path from "node:path";
+
+const repo = path.resolve(process.argv[2] ?? ".");
+const SECRET = "e2e-1164-platform-secret";
+const dataFiles = ["agents.json", "ledger_entries.json", "agent_balances.json", "referral_requests.json"].map(f =>
+  path.join(repo, "data", f),
+);
+const saved = new Map(dataFiles.map(f => [f, existsSync(f) ? readFileSync(f, "utf8") : null]));
+
+let passed = 0;
+const failures = [];
+function check(name, condition, detail = "") {
+  if (condition) {
+    passed++;
+    console.log(`  ok    ${name}`);
+  } else {
+    failures.push(`${name}${detail ? ` — ${detail}` : ""}`);
+    console.log(`  FAIL  ${name}${detail ? ` — ${detail}` : ""}`);
+  }
+}
+
+function startServer(env) {
+  return new Promise((resolve, reject) => {
+    const proc = spawn("node", [path.join(repo, "dist", "serve.js")], {
+      cwd: repo,
+      stdio: ["pipe", "pipe", "pipe"],
+      env: { ...process.env, PORT: "0", BASE_URL: "http://127.0.0.1", ...env },
+    });
+    const timeout = setTimeout(() => { proc.kill("SIGKILL"); reject(new Error("server startup timeout")); }, 60000);
+    proc.stderr.on("data", b => {
+      const m = b.toString().match(/running on http:\/\/localhost:(\d+)/);
+      if (m) { clearTimeout(timeout); resolve({ proc, port: parseInt(m[1], 10) }); }
+    });
+    proc.on("error", e => { clearTimeout(timeout); reject(e); });
+  });
+}
+
+const post = (base, route, { credential, body } = {}) =>
+  fetch(`${base}${route}`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      ...(credential ? { Authorization: `Bearer ${credential}` } : {}),
+    },
+    body: body === undefined ? undefined : JSON.stringify(body),
+  });
+
+function resetData() {
+  writeFileSync(dataFiles[0], JSON.stringify({ agents: [] }));
+  writeFileSync(dataFiles[1], JSON.stringify({ ledger_entries: [] }));
+  writeFileSync(dataFiles[2], JSON.stringify({ agent_balances: [] }));
+  writeFileSync(dataFiles[3], JSON.stringify({ referral_requests: [] }));
+}
+
+function restoreData() {
+  for (const [f, contents] of saved) {
+    if (contents === null) { if (existsSync(f)) unlinkSync(f); }
+    else writeFileSync(f, contents);
+  }
+}
+
+try {
+  resetData();
+
+  console.log("\nA configured deployment");
+  const configured = await startServer({ AGENTDEALS_PLATFORM_SECRET: SECRET, AGENTDEALS_REGISTER_LIMIT_PER_HOUR: "3" });
+  const base = `http://127.0.0.1:${configured.port}`;
+
+  const reg = await post(base, "/api/agents/register", { body: { name: "E2E1164Bot" } });
+  const agentKey = (await reg.json()).api_key;
+  check("registration is still open to anyone", reg.status === 201, `status ${reg.status}`);
+  check("registration reports its own allowance", reg.headers.get("x-ratelimit-limit") === "3", reg.headers.get("x-ratelimit-limit") ?? "no header");
+
+  for (const [route, body] of [
+    ["/api/conversions", { vendor: "Railway", commission_amount: 100000 }],
+    ["/api/conversions/confirm", undefined],
+    ["/api/conversions/clawback", { entry_id: "le_x" }],
+  ]) {
+    const anon = await post(base, route, { body });
+    check(`${route} refuses an anonymous caller`, anon.status === 401, `status ${anon.status}`);
+    const asAgent = await post(base, route, { credential: agentKey, body });
+    check(`${route} refuses an agent API key`, asAgent.status === 401, `status ${asAgent.status}`);
+    const wrong = await post(base, route, { credential: "wrong-secret", body });
+    check(`${route} refuses a wrong credential`, wrong.status === 401, `status ${wrong.status}`);
+  }
+
+  const ledgerAfterRefusals = JSON.parse(readFileSync(dataFiles[1], "utf8")).ledger_entries;
+  check("nothing was written to the ledger by any refused call", ledgerAfterRefusals.length === 0, `${ledgerAfterRefusals.length} entries`);
+
+  const recorded = await post(base, "/api/conversions", {
+    credential: SECRET,
+    body: { vendor: "Railway", referral_code: "E2E", commission_amount: 12.5, conversion_date: "2026-08-01" },
+  });
+  const entry = await recorded.json();
+  check("a credentialled caller records a conversion", recorded.status === 201 && entry.commission_amount === 12.5, `status ${recorded.status}`);
+
+  const confirmed = await post(base, "/api/conversions/confirm", { credential: SECRET });
+  check("a credentialled caller runs the confirmation sweep", confirmed.status === 200, `status ${confirmed.status}`);
+
+  const clawed = await post(base, "/api/conversions/clawback", { credential: SECRET, body: { entry_id: entry.id } });
+  check("a credentialled caller claws an entry back", clawed.status === 200, `status ${clawed.status}`);
+
+  const tooLarge = await post(base, "/api/conversions", { credential: SECRET, body: { vendor: "Railway", commission_amount: 10001 } });
+  check("an unbounded commission is refused", tooLarge.status === 400, `status ${tooLarge.status}`);
+
+  const unheld = await post(base, "/api/conversions", { credential: SECRET, body: { vendor: "Vercel", commission_amount: 5 } });
+  check("a vendor we hold no link into is refused", unheld.status === 400, `status ${unheld.status}`);
+
+  const second = await post(base, "/api/agents/register", { body: { name: "E2E1164BotTwo" } });
+  const third = await post(base, "/api/agents/register", { body: { name: "E2E1164BotThree" } });
+  const fourth = await post(base, "/api/agents/register", { body: { name: "E2E1164BotFour" } });
+  check("registration admits its allowance", second.status === 201 && third.status === 201, `${second.status}, ${third.status}`);
+  check("registration refuses past its allowance", fourth.status === 429, `status ${fourth.status}`);
+  check("a refused registration says when to retry", Number(fourth.headers.get("retry-after")) > 0, fourth.headers.get("retry-after") ?? "no header");
+
+  const agents = JSON.parse(readFileSync(dataFiles[0], "utf8")).agents.map(a => a.name);
+  check("the refused identity was not created", !agents.includes("E2E1164BotFour"), agents.join(", "));
+
+  const developers = await (await fetch(`${base}/developers`)).text();
+  check("the API page states the limit this server enforces", developers.includes("allows 3 registrations per hour per client"));
+  check("the API page names the headers the endpoint returns", developers.includes("X-RateLimit-Limit"));
+  check("the API page no longer claims the whole API is unlimited", !/no rate limits\.?<\/p>/.test(developers));
+
+  const mcpInit = await fetch(`${base}/mcp`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json", Accept: "application/json, text/event-stream" },
+    body: JSON.stringify({
+      jsonrpc: "2.0", id: 1, method: "initialize",
+      params: { protocolVersion: "2025-06-18", capabilities: {}, clientInfo: { name: "e2e-1164", version: "1.0.0" } },
+    }),
+  });
+  const sessionId = mcpInit.headers.get("mcp-session-id");
+  check("MCP initialize returns a session", mcpInit.status === 200 && !!sessionId, `status ${mcpInit.status}`);
+
+  await fetch(`${base}/mcp`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json", Accept: "application/json, text/event-stream", "Mcp-Session-Id": sessionId },
+    body: JSON.stringify({ jsonrpc: "2.0", method: "notifications/initialized" }),
+  });
+
+  const toolCall = await fetch(`${base}/mcp`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json", Accept: "application/json, text/event-stream", "Mcp-Session-Id": sessionId },
+    body: JSON.stringify({
+      jsonrpc: "2.0", id: 2, method: "tools/call",
+      params: { name: "get_referral_code", arguments: { vendor: "Railway" } },
+    }),
+  });
+  const toolBody = await toolCall.text();
+  check("MCP get_referral_code still resolves Railway", toolCall.status === 200 && toolBody.includes("referralCode=7RZL9q"), `status ${toolCall.status}`);
+
+  configured.proc.kill("SIGKILL");
+
+  console.log("\nAn unconfigured deployment");
+  resetData();
+  const unconfigured = await startServer({ AGENTDEALS_PLATFORM_SECRET: "" });
+  const closedBase = `http://127.0.0.1:${unconfigured.port}`;
+  for (const [route, body] of [
+    ["/api/conversions", { vendor: "Railway", commission_amount: 5 }],
+    ["/api/conversions/confirm", undefined],
+    ["/api/conversions/clawback", { entry_id: "le_x" }],
+  ]) {
+    const anon = await post(closedBase, route, { body });
+    const guessed = await post(closedBase, route, { credential: "", body });
+    check(`${route} is closed rather than open when no secret is set`, anon.status === 401 && guessed.status === 401, `${anon.status}, ${guessed.status}`);
+  }
+  const offers = await (await fetch(`${closedBase}/api/offers?limit=1`)).json();
+  check("the read API is unaffected", offers.total > 1000, `total ${offers.total}`);
+  unconfigured.proc.kill("SIGKILL");
+} finally {
+  restoreData();
+}
+
+console.log(`\n${passed} checks passed, ${failures.length} failed`);
+for (const f of failures) console.log(`  ${f}`);
+process.exit(failures.length === 0 ? 0 : 1);

--- a/scripts/mutate-1164.sh
+++ b/scripts/mutate-1164.sh
@@ -1,0 +1,391 @@
+#!/usr/bin/env bash
+set -u
+
+REPO="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$REPO" || exit 1
+
+AUTH="src/platform-auth.ts"
+LIMIT="src/rate-limit.ts"
+SURFACES="src/referral-surfaces.ts"
+SERVE="src/serve.ts"
+BACKUP_DIR="$(mktemp -d)"
+cp "$AUTH" "$BACKUP_DIR/platform-auth.ts"
+cp "$LIMIT" "$BACKUP_DIR/rate-limit.ts"
+cp "$SURFACES" "$BACKUP_DIR/referral-surfaces.ts"
+cp "$SERVE" "$BACKUP_DIR/serve.ts"
+
+restore() {
+  cp "$BACKUP_DIR/platform-auth.ts" "$AUTH"
+  cp "$BACKUP_DIR/rate-limit.ts" "$LIMIT"
+  cp "$BACKUP_DIR/referral-surfaces.ts" "$SURFACES"
+  cp "$BACKUP_DIR/serve.ts" "$SERVE"
+}
+trap restore EXIT
+
+killed=0
+survived=0
+TESTS="test/conversion-auth.test.ts test/platform-auth.test.ts test/rate-limit.test.ts"
+
+run_mutation() {
+  local name="$1"
+  shift
+  echo "=== $name"
+  restore
+  "$@"
+  if diff -q "$BACKUP_DIR/platform-auth.ts" "$AUTH" > /dev/null \
+    && diff -q "$BACKUP_DIR/rate-limit.ts" "$LIMIT" > /dev/null \
+    && diff -q "$BACKUP_DIR/referral-surfaces.ts" "$SURFACES" > /dev/null \
+    && diff -q "$BACKUP_DIR/serve.ts" "$SERVE" > /dev/null; then
+    echo "    NOT APPLIED: the mutation changed no file, so it proves nothing"
+    survived=$((survived + 1))
+    return
+  fi
+  if ! npm run build > /tmp/mutate-1164-build.log 2>&1; then
+    echo "    NOT APPLIED: the mutation does not compile, so no test ran"
+    tail -3 /tmp/mutate-1164-build.log
+    survived=$((survived + 1))
+    return
+  fi
+  if timeout 900 node --test --test-concurrency 1 $TESTS > /tmp/mutate-1164-test.log 2>&1; then
+    echo "    SURVIVED"
+    survived=$((survived + 1))
+  else
+    echo "    KILLED: $(grep -c '✖ ' /tmp/mutate-1164-test.log) failing assertion(s)"
+    grep '✖ ' /tmp/mutate-1164-test.log | head -4
+    killed=$((killed + 1))
+  fi
+}
+
+py() { python3 - "$@"; }
+
+m_an_unconfigured_secret_admits_every_caller() {
+  py <<'PY'
+p = "src/platform-auth.ts"
+s = open(p).read()
+s = s.replace("  if (!platformSecretConfigured(configured)) return false;",
+              "  if (!platformSecretConfigured(configured)) return true;")
+open(p, "w").write(s)
+PY
+}
+
+m_the_credential_is_compared_by_length() {
+  py <<'PY'
+p = "src/platform-auth.ts"
+s = open(p).read()
+s = s.replace("  return timingSafeEqual(digestOf(presented), digestOf((configured as string).trim()));",
+              "  return presented.length === (configured as string).trim().length;")
+open(p, "w").write(s)
+PY
+}
+
+m_a_prefix_of_the_credential_is_accepted() {
+  py <<'PY'
+p = "src/platform-auth.ts"
+s = open(p).read()
+s = s.replace("  return timingSafeEqual(digestOf(presented), digestOf((configured as string).trim()));",
+              "  return timingSafeEqual(digestOf(presented.slice(0, 4)), digestOf((configured as string).trim().slice(0, 4)));")
+open(p, "w").write(s)
+PY
+}
+
+m_any_authorization_scheme_is_accepted() {
+  py <<'PY'
+p = "src/platform-auth.ts"
+s = open(p).read()
+s = s.replace("  if (!/^bearer /i.test(value)) return null;",
+              "  if (value.length === 0) return null;")
+open(p, "w").write(s)
+PY
+}
+
+m_the_scheme_is_left_on_the_token() {
+  py <<'PY'
+p = "src/platform-auth.ts"
+s = open(p).read()
+s = s.replace("  const token = value.slice(7).trim();",
+              "  const token = value.trim();")
+open(p, "w").write(s)
+PY
+}
+
+m_a_whitespace_secret_counts_as_configured() {
+  py <<'PY'
+p = "src/platform-auth.ts"
+s = open(p).read()
+s = s.replace("  return typeof configured === \"string\" && configured.trim().length > 0;",
+              "  return typeof configured === \"string\" && configured.length > 0;")
+open(p, "w").write(s)
+PY
+}
+
+m_recording_a_conversion_needs_no_credential() {
+  py <<'PY'
+p = "src/serve.ts"
+s = open(p).read()
+s = s.replace("""  } else if (url.pathname === "/api/conversions" && req.method === "POST") {
+    if (!authorizedAsPlatform(req.headers)) {
+      res.writeHead(401, { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" });
+      res.end(JSON.stringify({ error: PLATFORM_CREDENTIAL_REQUIRED }));
+      return;
+    }
+
+""",
+              """  } else if (url.pathname === "/api/conversions" && req.method === "POST") {
+""")
+open(p, "w").write(s)
+PY
+}
+
+m_confirming_the_sweep_needs_no_credential() {
+  py <<'PY'
+p = "src/serve.ts"
+s = open(p).read()
+s = s.replace("""    if (!authorizedAsPlatform(req.headers)) {
+      res.writeHead(401, { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" });
+      res.end(JSON.stringify({ error: PLATFORM_CREDENTIAL_REQUIRED }));
+      return;
+    }
+
+    try {
+      const confirmed = confirmEligibleEntries();""",
+              """    try {
+      const confirmed = confirmEligibleEntries();""")
+open(p, "w").write(s)
+PY
+}
+
+m_clawing_back_needs_no_credential() {
+  py <<'PY'
+p = "src/serve.ts"
+s = open(p).read()
+s = s.replace("""  } else if (url.pathname === "/api/conversions/clawback" && req.method === "POST") {
+    if (!authorizedAsPlatform(req.headers)) {
+      res.writeHead(401, { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" });
+      res.end(JSON.stringify({ error: PLATFORM_CREDENTIAL_REQUIRED }));
+      return;
+    }
+
+""",
+              """  } else if (url.pathname === "/api/conversions/clawback" && req.method === "POST") {
+""")
+open(p, "w").write(s)
+PY
+}
+
+m_an_agent_can_assert_its_own_conversion() {
+  py <<'PY'
+p = "src/serve.ts"
+s = open(p).read()
+s = s.replace("""  } else if (url.pathname === "/api/conversions" && req.method === "POST") {
+    if (!authorizedAsPlatform(req.headers)) {""",
+              """  } else if (url.pathname === "/api/conversions" && req.method === "POST") {
+    if (!(await authenticateRequest(req as any))) {""")
+open(p, "w").write(s)
+PY
+}
+
+m_the_commission_has_no_upper_bound() {
+  py <<'PY'
+p = "src/serve.ts"
+s = open(p).read()
+s = s.replace("""    if (parsed.commission_amount > MAX_COMMISSION_AMOUNT) {
+      res.writeHead(400, { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" });
+      res.end(JSON.stringify({ error: `commission_amount exceeds the maximum recordable commission of $${MAX_COMMISSION_AMOUNT}` }));
+      return;
+    }
+""", "")
+open(p, "w").write(s)
+PY
+}
+
+m_the_upper_bound_refuses_its_own_maximum() {
+  py <<'PY'
+p = "src/serve.ts"
+s = open(p).read()
+s = s.replace("    if (parsed.commission_amount > MAX_COMMISSION_AMOUNT) {",
+              "    if (parsed.commission_amount >= MAX_COMMISSION_AMOUNT) {")
+open(p, "w").write(s)
+PY
+}
+
+m_an_infinite_commission_is_a_number() {
+  py <<'PY'
+p = "src/serve.ts"
+s = open(p).read()
+s = s.replace("    if (!Number.isFinite(parsed.commission_amount) || parsed.commission_amount <= 0) {",
+              "    if (typeof parsed.commission_amount !== \"number\" || parsed.commission_amount <= 0) {")
+open(p, "w").write(s)
+PY
+}
+
+m_any_vendor_can_be_credited() {
+  py <<'PY'
+p = "src/serve.ts"
+s = open(p).read()
+s = s.replace("""    if (!heldReferralLinkForVendor(offers, parsed.vendor)) {
+      res.writeHead(400, { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" });
+      res.end(JSON.stringify({ error: `No referral link of ours for vendor "${parsed.vendor}" — a commission cannot be attributed to a relationship we do not hold` }));
+      return;
+    }
+""", "")
+open(p, "w").write(s)
+PY
+}
+
+m_a_vendor_running_its_own_program_counts_as_a_link_of_ours() {
+  py <<'PY'
+p = "src/serve.ts"
+s = open(p).read()
+s = s.replace("    if (!heldReferralLinkForVendor(offers, parsed.vendor)) {",
+              "    if (!hasAnyReferralSurface(parsed.vendor, offers.find(o => toSlug(o.vendor) === toSlug(parsed.vendor)) ?? null)) {")
+open(p, "w").write(s)
+PY
+}
+
+m_the_held_vendor_must_be_named_exactly() {
+  py <<'PY'
+p = "src/referral-surfaces.ts"
+s = open(p).read()
+s = s.replace("  return allOurReferralLinks(offers).find(link => toSlug(link.vendor) === slug) ?? null;",
+              "  return allOurReferralLinks(offers).find(link => link.vendor === vendorName) ?? null;")
+open(p, "w").write(s)
+PY
+}
+
+m_registration_is_counted_but_never_refused() {
+  py <<'PY'
+p = "src/serve.ts"
+s = open(p).read()
+s = s.replace("    if (!registration.allowed) {",
+              "    if (registration.limit < 0) {")
+open(p, "w").write(s)
+PY
+}
+
+m_the_created_agent_carries_no_ratelimit_headers() {
+  py <<'PY'
+p = "src/serve.ts"
+s = open(p).read()
+s = s.replace("      res.writeHead(201, { \"Content-Type\": \"application/json\", \"Access-Control-Allow-Origin\": \"*\", ...registrationHeaders });",
+              "      res.writeHead(201, { \"Content-Type\": \"application/json\", \"Access-Control-Allow-Origin\": \"*\" });")
+open(p, "w").write(s)
+PY
+}
+
+m_the_limiter_allows_one_fewer_than_its_limit() {
+  py <<'PY'
+p = "src/rate-limit.ts"
+s = open(p).read()
+s = s.replace("        allowed: window.count <= opts.limit,",
+              "        allowed: window.count < opts.limit,")
+open(p, "w").write(s)
+PY
+}
+
+m_the_limiter_allows_one_more_than_its_limit() {
+  py <<'PY'
+p = "src/rate-limit.ts"
+s = open(p).read()
+s = s.replace("        allowed: window.count <= opts.limit,",
+              "        allowed: window.count <= opts.limit + 1,")
+open(p, "w").write(s)
+PY
+}
+
+m_the_window_never_reopens() {
+  py <<'PY'
+p = "src/rate-limit.ts"
+s = open(p).read()
+s = s.replace("      if (!held || now - held.startedAt >= opts.windowMs) {",
+              "      if (!held) {")
+open(p, "w").write(s)
+PY
+}
+
+m_the_key_map_grows_without_bound() {
+  py <<'PY'
+p = "src/rate-limit.ts"
+s = open(p).read()
+s = s.replace("""      while (windows.size > opts.maxKeys) {
+        const oldest = windows.keys().next();
+        if (oldest.done) break;
+        windows.delete(oldest.value);
+      }
+""", "")
+open(p, "w").write(s)
+PY
+}
+
+m_the_remaining_allowance_goes_negative() {
+  py <<'PY'
+p = "src/rate-limit.ts"
+s = open(p).read()
+s = s.replace("        remaining: Math.max(0, opts.limit - window.count),",
+              "        remaining: opts.limit - window.count,")
+open(p, "w").write(s)
+PY
+}
+
+m_a_configured_limit_of_zero_is_honoured() {
+  py <<'PY'
+p = "src/rate-limit.ts"
+s = open(p).read()
+s = s.replace("  return Number.isInteger(parsed) && parsed > 0 ? parsed : REGISTRATION_LIMIT_DEFAULT;",
+              "  return Number.isInteger(parsed) ? parsed : REGISTRATION_LIMIT_DEFAULT;")
+open(p, "w").write(s)
+PY
+}
+
+m_the_api_page_states_a_limit_of_its_own() {
+  py <<'PY'
+p = "src/serve.ts"
+s = open(p).read()
+s = s.replace("allows \" + registrationLimiter.limit + \" registrations per hour per client",
+              "allows \" + 5 + \" registrations per hour per client")
+open(p, "w").write(s)
+PY
+}
+
+m_the_api_page_stops_mentioning_the_limits() {
+  py <<'PY'
+p = "src/serve.ts"
+s = open(p).read()
+start = s.index("    + \"    <p>Two write paths are limited.")
+end = s.index("\n", start) + 1
+s = s[:start] + s[end:]
+open(p, "w").write(s)
+PY
+}
+
+run_mutation "an unconfigured secret admits every caller" m_an_unconfigured_secret_admits_every_caller
+run_mutation "the credential is compared by length" m_the_credential_is_compared_by_length
+run_mutation "a prefix of the credential is accepted" m_a_prefix_of_the_credential_is_accepted
+run_mutation "any authorization scheme is accepted" m_any_authorization_scheme_is_accepted
+run_mutation "the scheme is left on the token" m_the_scheme_is_left_on_the_token
+run_mutation "a whitespace secret counts as configured" m_a_whitespace_secret_counts_as_configured
+run_mutation "recording a conversion needs no credential" m_recording_a_conversion_needs_no_credential
+run_mutation "confirming the sweep needs no credential" m_confirming_the_sweep_needs_no_credential
+run_mutation "clawing back needs no credential" m_clawing_back_needs_no_credential
+run_mutation "an agent can assert its own conversion" m_an_agent_can_assert_its_own_conversion
+run_mutation "the commission has no upper bound" m_the_commission_has_no_upper_bound
+run_mutation "the upper bound refuses its own maximum" m_the_upper_bound_refuses_its_own_maximum
+run_mutation "an infinite commission is a number" m_an_infinite_commission_is_a_number
+run_mutation "any vendor can be credited" m_any_vendor_can_be_credited
+run_mutation "a vendor running its own program counts as a link of ours" m_a_vendor_running_its_own_program_counts_as_a_link_of_ours
+run_mutation "the held vendor must be named exactly" m_the_held_vendor_must_be_named_exactly
+run_mutation "registration is counted but never refused" m_registration_is_counted_but_never_refused
+run_mutation "the created agent carries no ratelimit headers" m_the_created_agent_carries_no_ratelimit_headers
+run_mutation "the limiter allows one fewer than its limit" m_the_limiter_allows_one_fewer_than_its_limit
+run_mutation "the limiter allows one more than its limit" m_the_limiter_allows_one_more_than_its_limit
+run_mutation "the window never reopens" m_the_window_never_reopens
+run_mutation "the key map grows without bound" m_the_key_map_grows_without_bound
+run_mutation "the remaining allowance goes negative" m_the_remaining_allowance_goes_negative
+run_mutation "a configured limit of zero is honoured" m_a_configured_limit_of_zero_is_honoured
+run_mutation "the api page states a limit of its own" m_the_api_page_states_a_limit_of_its_own
+run_mutation "the api page stops mentioning the limits" m_the_api_page_stops_mentioning_the_limits
+
+restore
+npm run build > /dev/null 2>&1
+echo
+echo "killed: $killed  survived: $survived"
+[ "$survived" -eq 0 ]

--- a/src/ledger.ts
+++ b/src/ledger.ts
@@ -19,6 +19,8 @@ const SINGLE_AGENT_SHARE_RATE = 0.8;
 // Agent-submitted codes — different agents: 40% submitter, 40% surfer, 20% platform
 const DUAL_AGENT_SHARE_RATE = 0.4;
 
+export const MAX_COMMISSION_AMOUNT = 10_000;
+
 export type EventType = "conversion" | "confirmation" | "clawback" | "payout";
 export type LedgerStatus = "pending" | "confirmed" | "paid_out" | "clawed_back";
 

--- a/src/platform-auth.ts
+++ b/src/platform-auth.ts
@@ -1,0 +1,38 @@
+import { createHash, timingSafeEqual } from "node:crypto";
+
+export const PLATFORM_SECRET_ENV = "AGENTDEALS_PLATFORM_SECRET";
+
+export const PLATFORM_CREDENTIAL_REQUIRED =
+  "Authentication required. This endpoint records or settles commission paid to AgentDeals and takes the platform credential, not an agent API key.";
+
+type RequestHeaders = Record<string, string | string[] | undefined>;
+
+export function presentedBearerToken(headers: RequestHeaders): string | null {
+  const header = headers["authorization"];
+  const value = Array.isArray(header) ? header[0] : header;
+  if (typeof value !== "string") return null;
+  if (!/^bearer /i.test(value)) return null;
+  const token = value.slice(7).trim();
+  return token.length > 0 ? token : null;
+}
+
+function digestOf(value: string): Buffer {
+  return createHash("sha256").update(value).digest();
+}
+
+export function platformSecretConfigured(configured: string | undefined): boolean {
+  return typeof configured === "string" && configured.trim().length > 0;
+}
+
+export function platformSecretMatches(presented: string | null, configured: string | undefined): boolean {
+  if (!platformSecretConfigured(configured)) return false;
+  if (presented === null) return false;
+  return timingSafeEqual(digestOf(presented), digestOf((configured as string).trim()));
+}
+
+export function authorizedAsPlatform(
+  headers: RequestHeaders,
+  configured: string | undefined = process.env[PLATFORM_SECRET_ENV],
+): boolean {
+  return platformSecretMatches(presentedBearerToken(headers), configured);
+}

--- a/src/rate-limit.ts
+++ b/src/rate-limit.ts
@@ -1,0 +1,92 @@
+import { createHash, randomBytes } from "node:crypto";
+
+const UNPERSISTED_PER_PROCESS_KEY_SALT = randomBytes(16).toString("hex");
+
+export interface RateLimitDecision {
+  allowed: boolean;
+  limit: number;
+  remaining: number;
+  resetSeconds: number;
+}
+
+export interface RateLimiter {
+  limit: number;
+  check(address: string, now?: number): RateLimitDecision;
+  reset(): void;
+}
+
+interface CountedWindow {
+  count: number;
+  startedAt: number;
+}
+
+export function createRateLimiter(opts: { limit: number; windowMs: number; maxKeys: number }): RateLimiter {
+  const windows = new Map<string, CountedWindow>();
+
+  function keyFor(address: string): string {
+    return createHash("sha256").update(UNPERSISTED_PER_PROCESS_KEY_SALT).update(address).digest("hex").slice(0, 16);
+  }
+
+  return {
+    limit: opts.limit,
+
+    check(address: string, now: number = Date.now()): RateLimitDecision {
+      const key = keyFor(address);
+      const held = windows.get(key);
+      let window: CountedWindow;
+      if (!held || now - held.startedAt >= opts.windowMs) {
+        window = { count: 0, startedAt: now };
+      } else {
+        window = held;
+        windows.delete(key);
+      }
+      window.count++;
+      windows.set(key, window);
+
+      while (windows.size > opts.maxKeys) {
+        const oldest = windows.keys().next();
+        if (oldest.done) break;
+        windows.delete(oldest.value);
+      }
+
+      return {
+        allowed: window.count <= opts.limit,
+        limit: opts.limit,
+        remaining: Math.max(0, opts.limit - window.count),
+        resetSeconds: Math.ceil((window.startedAt + opts.windowMs - now) / 1000),
+      };
+    },
+
+    reset(): void {
+      windows.clear();
+    },
+  };
+}
+
+export function rateLimitHeaders(decision: RateLimitDecision): Record<string, string> {
+  return {
+    "X-RateLimit-Limit": String(decision.limit),
+    "X-RateLimit-Remaining": String(decision.remaining),
+    "X-RateLimit-Reset": String(decision.resetSeconds),
+  };
+}
+
+export const REGISTRATION_LIMIT_ENV = "AGENTDEALS_REGISTER_LIMIT_PER_HOUR";
+export const REGISTRATION_LIMIT_DEFAULT = 5;
+export const REGISTRATION_WINDOW_MS = 3_600_000;
+const REGISTRATION_KEYS_MAX = 5000;
+
+export function registrationLimitFrom(raw: string | undefined): number {
+  const parsed = Number(raw);
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : REGISTRATION_LIMIT_DEFAULT;
+}
+
+export function createRegistrationLimiter(
+  raw: string | undefined = process.env[REGISTRATION_LIMIT_ENV],
+): RateLimiter {
+  return createRateLimiter({
+    limit: registrationLimitFrom(raw),
+    windowMs: REGISTRATION_WINDOW_MS,
+    maxKeys: REGISTRATION_KEYS_MAX,
+  });
+}

--- a/src/referral-surfaces.ts
+++ b/src/referral-surfaces.ts
@@ -75,6 +75,12 @@ export function hasAnyReferralSurface(vendorName: string, offer?: Offer | null):
   return hasOurReferralLink(vendorName, offer) || documentsVendorReferralProgram(offer);
 }
 
+export function heldReferralLinkForVendor(offers: Offer[], vendorName: string): OurReferralLink | null {
+  const slug = toSlug(vendorName);
+  if (!slug) return null;
+  return allOurReferralLinks(offers).find(link => toSlug(link.vendor) === slug) ?? null;
+}
+
 export function allOurReferralLinks(offers: Offer[]): OurReferralLink[] {
   const offerBySlug = new Map<string, Offer>();
   for (const offer of offers) {

--- a/src/serve.ts
+++ b/src/serve.ts
@@ -23,11 +23,13 @@ import { publishedVendorLevel, vendorVerdictSentence, narrowingSentence, changeK
 import { growthLimitPhrases } from "./growth-limits.js";
 import { registerAgent, authenticateRequest, validateVestauthUrl, hashApiKey, updateAgentX402Address, getAgentById } from "./agents.js";
 import { logReferralRequest } from "./referral-requests.js";
-import { recordConversion, confirmEligibleEntries, clawbackEntry, getAgentBalance, getAgentLedgerEntries, recordPayout, MINIMUM_PAYOUT_AMOUNT, getLeaderboard } from "./ledger.js";
+import { recordConversion, confirmEligibleEntries, clawbackEntry, getAgentBalance, getAgentLedgerEntries, recordPayout, MAX_COMMISSION_AMOUNT, MINIMUM_PAYOUT_AMOUNT, getLeaderboard } from "./ledger.js";
+import { PLATFORM_CREDENTIAL_REQUIRED, authorizedAsPlatform } from "./platform-auth.js";
+import { createRegistrationLimiter, rateLimitHeaders } from "./rate-limit.js";
 import { validateX402Address, executeTransfer, generateCorrelationId } from "./x402.js";
 import { submitReferralCode, getCodesByAgent, getCodeById, updateCode, revokeCode, calculateTrustTier, getDailySubmissionCount, getDailyLimit, getRankedCodesForVendor, calculateCodeScore } from "./referral-codes.js";
 import { getBestReferralCode, listAllReferralCodes } from "./platform-codes.js";
-import { REFERRAL_CONDITIONS_HEADING, allOurReferralLinks, hasAnyReferralSurface, ourReferralLinkFor, referralLinkCountClause, referrerDisclosureSentence } from "./referral-surfaces.js";
+import { REFERRAL_CONDITIONS_HEADING, allOurReferralLinks, hasAnyReferralSurface, heldReferralLinkForVendor, ourReferralLinkFor, referralLinkCountClause, referrerDisclosureSentence } from "./referral-surfaces.js";
 import { runHealthCheck, getLastReport, startPeriodicChecks } from "./referral-health.js";
 import { addFriend, removeFriend, getFriends, getFriendCodesForVendors } from "./friends.js";
 import { subscribe as watchlistSubscribe, getSubscription as getWatchlistSubscription, unsubscribe as watchlistUnsubscribe, listSubscriptions as listWatchlistSubscriptions } from "./watchlist.js";
@@ -404,6 +406,8 @@ const durableHistoryBody = JSON.stringify({
     by_class: r.traffic.by_class,
   })),
 });
+
+const registrationLimiter = createRegistrationLimiter();
 
 // Build landing page HTML at startup with real stats
 const offers = loadOffers();
@@ -49218,7 +49222,7 @@ function buildDeveloperHubPage(): string {
     + "    " + buildGlobalNav("developers") + "\n"
     + "\n"
     + "    <h1>REST API for Developer Tool Pricing</h1>\n"
-    + "    <p class=\"subtitle\">Free, open, and ready to use. No API key, no rate limits, no signup. Query " + offers.length.toLocaleString() + "+ deals across " + categories.length + " categories with plain HTTP requests.</p>\n"
+    + "    <p class=\"subtitle\">Free, open, and ready to use. No API key, no signup, and no rate limits on the read endpoints. Query " + offers.length.toLocaleString() + "+ deals across " + categories.length + " categories with plain HTTP requests.</p>\n"
     + "\n"
     + "    <div class=\"badge-row\">\n"
     + "      <span class=\"api-badge\"><span class=\"dot\"></span>No Authentication</span>\n"
@@ -49410,7 +49414,8 @@ function buildDeveloperHubPage(): string {
     + "}</div>\n"
     + "\n"
     + "    <h2>Rate Limits</h2>\n"
-    + "    <p>There are currently <strong>no rate limits</strong>. We trust developers to be reasonable. If this changes, we will add an <code>X-RateLimit-*</code> header before enforcing any limits.</p>\n"
+    + "    <p>The read endpoints above have <strong>no rate limits</strong>. We trust developers to be reasonable.</p>\n"
+    + "    <p>Two write paths are limited. <code>POST /api/agents/register</code> allows " + registrationLimiter.limit + " registrations per hour per client and returns <code>X-RateLimit-Limit</code>, <code>X-RateLimit-Remaining</code> and <code>X-RateLimit-Reset</code> on every response. The attribution beacon at <code>" + SIGNAL_PATH + "</code> allows " + RATE_LIMIT_PER_MINUTE + " per minute &mdash; <a href=\"" + SIGNAL_DOC_PATH + "\">its own page</a> covers how that limit is keyed. Over either limit you get a <code>429</code> with <code>Retry-After</code>.</p>\n"
     + "\n"
     + "    " + buildMcpCta("Prefer AI-native access? AgentDeals is also an MCP server — 4 tools that work in Claude, Cursor, Cline, and any MCP-compatible client.") + "\n"
     + "\n"
@@ -55935,6 +55940,22 @@ ${catList}
   // --- Agent Registry API ---
 
   } else if (url.pathname === "/api/agents/register" && req.method === "POST") {
+    const registration = registrationLimiter.check(clientAddress(req.headers["x-forwarded-for"], req.socket.remoteAddress));
+    const registrationHeaders = rateLimitHeaders(registration);
+    if (!registration.allowed) {
+      res.writeHead(429, {
+        "Content-Type": "application/json",
+        "Access-Control-Allow-Origin": "*",
+        "Retry-After": String(registration.resetSeconds),
+        ...registrationHeaders,
+      });
+      res.end(JSON.stringify({
+        error: "Too many registrations from this client. Registration is open to anyone, but rate limited.",
+        retry_after_seconds: registration.resetSeconds,
+      }));
+      return;
+    }
+
     let body = "";
     for await (const chunk of req) {
       body += chunk;
@@ -55943,13 +55964,13 @@ ${catList}
     try {
       parsed = JSON.parse(body);
     } catch {
-      res.writeHead(400, { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" });
+      res.writeHead(400, { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*", ...registrationHeaders });
       res.end(JSON.stringify({ error: "Invalid JSON body" }));
       return;
     }
 
     if (!parsed.name || typeof parsed.name !== "string" || parsed.name.trim().length === 0) {
-      res.writeHead(400, { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" });
+      res.writeHead(400, { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*", ...registrationHeaders });
       res.end(JSON.stringify({ error: "name is required and must be a non-empty string" }));
       return;
     }
@@ -55959,7 +55980,7 @@ ${catList}
       if (parsed.vestauth_public_key_url) {
         const validation = await validateVestauthUrl(parsed.vestauth_public_key_url);
         if (!validation.valid) {
-          res.writeHead(400, { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" });
+          res.writeHead(400, { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*", ...registrationHeaders });
           res.end(JSON.stringify({ error: `Invalid vestauth URL: ${validation.error}` }));
           return;
         }
@@ -55985,11 +56006,11 @@ ${catList}
 
       recordApiHit("/api/agents/register");
       logRequest({ ts: new Date().toISOString(), type: "api", endpoint: "/api/agents/register", params: { name: parsed.name }, user_agent: req.headers["user-agent"] ?? "unknown", result_count: 1 });
-      res.writeHead(201, { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" });
+      res.writeHead(201, { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*", ...registrationHeaders });
       res.end(JSON.stringify(responseBody));
     } catch (err: any) {
       const status = err.message.includes("already exists") ? 409 : 500;
-      res.writeHead(status, { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" });
+      res.writeHead(status, { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*", ...registrationHeaders });
       res.end(JSON.stringify({ error: err.message }));
     }
 
@@ -56056,6 +56077,12 @@ ${catList}
 
   // --- POST /api/conversions: Record a new conversion ---
   } else if (url.pathname === "/api/conversions" && req.method === "POST") {
+    if (!authorizedAsPlatform(req.headers)) {
+      res.writeHead(401, { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" });
+      res.end(JSON.stringify({ error: PLATFORM_CREDENTIAL_REQUIRED }));
+      return;
+    }
+
     let body = "";
     for await (const chunk of req) {
       body += chunk;
@@ -56074,9 +56101,19 @@ ${catList}
       res.end(JSON.stringify({ error: "vendor is required and must be a string" }));
       return;
     }
-    if (typeof parsed.commission_amount !== "number" || parsed.commission_amount <= 0) {
+    if (!Number.isFinite(parsed.commission_amount) || parsed.commission_amount <= 0) {
       res.writeHead(400, { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" });
       res.end(JSON.stringify({ error: "commission_amount is required and must be a positive number" }));
+      return;
+    }
+    if (parsed.commission_amount > MAX_COMMISSION_AMOUNT) {
+      res.writeHead(400, { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" });
+      res.end(JSON.stringify({ error: `commission_amount exceeds the maximum recordable commission of $${MAX_COMMISSION_AMOUNT}` }));
+      return;
+    }
+    if (!heldReferralLinkForVendor(offers, parsed.vendor)) {
+      res.writeHead(400, { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" });
+      res.end(JSON.stringify({ error: `No referral link of ours for vendor "${parsed.vendor}" — a commission cannot be attributed to a relationship we do not hold` }));
       return;
     }
 
@@ -56133,6 +56170,12 @@ ${catList}
 
   // --- POST /api/conversions/confirm: Confirm eligible entries ---
   } else if (url.pathname === "/api/conversions/confirm" && req.method === "POST") {
+    if (!authorizedAsPlatform(req.headers)) {
+      res.writeHead(401, { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" });
+      res.end(JSON.stringify({ error: PLATFORM_CREDENTIAL_REQUIRED }));
+      return;
+    }
+
     try {
       const confirmed = confirmEligibleEntries();
       recordApiHit("/api/conversions/confirm");
@@ -56146,6 +56189,12 @@ ${catList}
 
   // --- POST /api/conversions/clawback: Clawback a pending entry ---
   } else if (url.pathname === "/api/conversions/clawback" && req.method === "POST") {
+    if (!authorizedAsPlatform(req.headers)) {
+      res.writeHead(401, { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" });
+      res.end(JSON.stringify({ error: PLATFORM_CREDENTIAL_REQUIRED }));
+      return;
+    }
+
     let body = "";
     for await (const chunk of req) {
       body += chunk;

--- a/test/agents.test.ts
+++ b/test/agents.test.ts
@@ -189,7 +189,7 @@ function startHttpServer(): Promise<ChildProcess> {
     const serverPath = path.join(__dirname, "..", "dist", "serve.js");
     const proc = spawn("node", [serverPath], {
       stdio: ["pipe", "pipe", "pipe"],
-      env: { ...process.env, PORT: "0", BASE_URL: "http://localhost" },
+      env: { ...process.env, PORT: "0", BASE_URL: "http://localhost", AGENTDEALS_REGISTER_LIMIT_PER_HOUR: "50" },
     });
 
     const timeout = setTimeout(() => {

--- a/test/conversion-auth.test.ts
+++ b/test/conversion-auth.test.ts
@@ -1,0 +1,353 @@
+import { describe, it, before, after } from "node:test";
+import assert from "node:assert";
+import { spawn, type ChildProcess } from "node:child_process";
+import path from "node:path";
+import fs from "node:fs";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const AGENTS_PATH = path.join(__dirname, "..", "data", "agents.json");
+const LEDGER_PATH = path.join(__dirname, "..", "data", "ledger_entries.json");
+const BALANCES_PATH = path.join(__dirname, "..", "data", "agent_balances.json");
+const REQUESTS_PATH = path.join(__dirname, "..", "data", "referral_requests.json");
+
+const PLATFORM_SECRET = "test-platform-secret-1164";
+const HELD_VENDOR = "Railway";
+
+const { MAX_COMMISSION_AMOUNT } = await import("../dist/ledger.js");
+const { resetAgentsCache } = await import("../dist/agents.js");
+const { resetLedgerCache } = await import("../dist/ledger.js");
+
+const managedPaths = [AGENTS_PATH, LEDGER_PATH, BALANCES_PATH, REQUESTS_PATH];
+const emptyContents = new Map<string, string>([
+  [AGENTS_PATH, JSON.stringify({ agents: [] })],
+  [LEDGER_PATH, JSON.stringify({ ledger_entries: [] })],
+  [BALANCES_PATH, JSON.stringify({ agent_balances: [] })],
+  [REQUESTS_PATH, JSON.stringify({ referral_requests: [] })],
+]);
+const originals = new Map<string, string | null>();
+
+function saveOriginals(): void {
+  for (const p of managedPaths) {
+    originals.set(p, fs.existsSync(p) ? fs.readFileSync(p, "utf-8") : null);
+  }
+}
+
+function restoreOriginals(): void {
+  for (const p of managedPaths) {
+    const held = originals.get(p) ?? null;
+    if (held !== null) fs.writeFileSync(p, held, "utf-8");
+    else if (fs.existsSync(p)) fs.unlinkSync(p);
+  }
+  resetAgentsCache();
+  resetLedgerCache();
+}
+
+function emptyTheStores(): void {
+  for (const p of managedPaths) fs.writeFileSync(p, emptyContents.get(p)!, "utf-8");
+  resetAgentsCache();
+  resetLedgerCache();
+}
+
+function ledgerEntryCount(): number {
+  const raw = JSON.parse(fs.readFileSync(LEDGER_PATH, "utf-8")) as { ledger_entries?: unknown[] };
+  return Array.isArray(raw.ledger_entries) ? raw.ledger_entries.length : 0;
+}
+
+function startHttpServer(extraEnv: Record<string, string>): Promise<{ proc: ChildProcess; port: number }> {
+  return new Promise((resolve, reject) => {
+    const serverPath = path.join(__dirname, "..", "dist", "serve.js");
+    const proc = spawn("node", [serverPath], {
+      stdio: ["pipe", "pipe", "pipe"],
+      env: { ...process.env, PORT: "0", BASE_URL: "http://localhost", ...extraEnv },
+    });
+
+    const timeout = setTimeout(() => {
+      proc.kill();
+      reject(new Error("Server startup timeout"));
+    }, 15000);
+
+    proc.stderr!.on("data", (data: Buffer) => {
+      const match = data.toString().match(/running on http:\/\/localhost:(\d+)/);
+      if (match) {
+        clearTimeout(timeout);
+        resolve({ proc, port: parseInt(match[1], 10) });
+      }
+    });
+
+    proc.on("error", (err) => {
+      clearTimeout(timeout);
+      reject(err);
+    });
+  });
+}
+
+describe("Conversion endpoints require the platform credential", () => {
+  let serverProc: ChildProcess;
+  let port = 0;
+  let agentKey = "";
+
+  const post = (route: string, opts: { credential?: string; body?: unknown } = {}) =>
+    fetch(`http://localhost:${port}${route}`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        ...(opts.credential ? { Authorization: `Bearer ${opts.credential}` } : {}),
+      },
+      body: opts.body === undefined ? undefined : JSON.stringify(opts.body),
+    });
+
+  const conversionBody = (over: Record<string, unknown> = {}) => ({
+    vendor: HELD_VENDOR,
+    referral_code: "AUTHTEST",
+    commission_amount: 4.25,
+    conversion_date: "2026-04-13",
+    ...over,
+  });
+
+  before(async () => {
+    saveOriginals();
+    emptyTheStores();
+    const started = await startHttpServer({ AGENTDEALS_PLATFORM_SECRET: PLATFORM_SECRET });
+    serverProc = started.proc;
+    port = started.port;
+
+    const registered = await post("/api/agents/register", { body: { name: "ConversionAuthProbe" } });
+    agentKey = ((await registered.json()) as { api_key: string }).api_key;
+  });
+
+  after(() => {
+    serverProc?.kill();
+    restoreOriginals();
+  });
+
+  const routes: Array<{ route: string; body?: unknown }> = [
+    { route: "/api/conversions", body: { vendor: HELD_VENDOR, commission_amount: 1 } },
+    { route: "/api/conversions/confirm" },
+    { route: "/api/conversions/clawback", body: { entry_id: "le_whatever" } },
+  ];
+
+  for (const { route, body } of routes) {
+    it(`POST ${route} returns 401 with no credential`, async () => {
+      const res = await post(route, { body });
+      assert.strictEqual(res.status, 401);
+      const parsed = (await res.json()) as { error: string };
+      assert.match(parsed.error, /platform credential/);
+    });
+
+    it(`POST ${route} returns 401 with a wrong credential`, async () => {
+      const res = await post(route, { credential: "not-the-secret", body });
+      assert.strictEqual(res.status, 401);
+    });
+
+    it(`POST ${route} returns 401 when presented an agent API key`, async () => {
+      const res = await post(route, { credential: agentKey, body });
+      assert.strictEqual(res.status, 401);
+    });
+  }
+
+  it("writes nothing to the ledger when the caller has no credential", async () => {
+    const before = ledgerEntryCount();
+    const res = await post("/api/conversions", { body: conversionBody({ commission_amount: 999 }) });
+    assert.strictEqual(res.status, 401);
+    assert.strictEqual(ledgerEntryCount(), before);
+  });
+
+  it("records a conversion for a credentialled caller", async () => {
+    const before = ledgerEntryCount();
+    const res = await post("/api/conversions", { credential: PLATFORM_SECRET, body: conversionBody() });
+    assert.strictEqual(res.status, 201);
+    const entry = (await res.json()) as { id: string; vendor: string; commission_amount: number; status: string };
+    assert.ok(entry.id.startsWith("le_"));
+    assert.strictEqual(entry.vendor, HELD_VENDOR);
+    assert.strictEqual(entry.commission_amount, 4.25);
+    assert.strictEqual(entry.status, "pending");
+    assert.strictEqual(ledgerEntryCount(), before + 1);
+  });
+
+  it("runs the confirmation sweep for a credentialled caller", async () => {
+    const res = await post("/api/conversions/confirm", { credential: PLATFORM_SECRET });
+    assert.strictEqual(res.status, 200);
+    const parsed = (await res.json()) as { confirmed_count: number; confirmed_ids: string[] };
+    assert.ok("confirmed_count" in parsed);
+    assert.ok(Array.isArray(parsed.confirmed_ids));
+  });
+
+  it("reaches the clawback lookup for a credentialled caller", async () => {
+    const res = await post("/api/conversions/clawback", {
+      credential: PLATFORM_SECRET,
+      body: { entry_id: "le_does_not_exist" },
+    });
+    assert.strictEqual(res.status, 404);
+  });
+
+  it("rejects a commission above the maximum recordable amount", async () => {
+    const before = ledgerEntryCount();
+    const res = await post("/api/conversions", {
+      credential: PLATFORM_SECRET,
+      body: conversionBody({ commission_amount: MAX_COMMISSION_AMOUNT + 1 }),
+    });
+    assert.strictEqual(res.status, 400);
+    const parsed = (await res.json()) as { error: string };
+    assert.match(parsed.error, /maximum recordable commission/);
+    assert.strictEqual(ledgerEntryCount(), before);
+  });
+
+  it("accepts a commission at the maximum recordable amount", async () => {
+    const res = await post("/api/conversions", {
+      credential: PLATFORM_SECRET,
+      body: conversionBody({ commission_amount: MAX_COMMISSION_AMOUNT }),
+    });
+    assert.strictEqual(res.status, 201);
+  });
+
+  it("reports a commission that is not a finite number as not a number, not as too large", async () => {
+    const notNumbers = [
+      '{"vendor":"Railway","commission_amount":1e400}',
+      '{"vendor":"Railway","commission_amount":-1e400}',
+      '{"vendor":"Railway","commission_amount":"5"}',
+      '{"vendor":"Railway","commission_amount":null}',
+    ];
+    for (const raw of notNumbers) {
+      const res = await fetch(`http://localhost:${port}/api/conversions`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json", Authorization: `Bearer ${PLATFORM_SECRET}` },
+        body: raw,
+      });
+      assert.strictEqual(res.status, 400, `should reject ${raw}`);
+      const parsed = (await res.json()) as { error: string };
+      assert.match(parsed.error, /commission_amount is required and must be a positive number/, `for ${raw}`);
+    }
+  });
+
+  it("rejects a vendor we hold no referral link for", async () => {
+    const before = ledgerEntryCount();
+    const res = await post("/api/conversions", {
+      credential: PLATFORM_SECRET,
+      body: conversionBody({ vendor: "A Vendor We Have Never Heard Of" }),
+    });
+    assert.strictEqual(res.status, 400);
+    const parsed = (await res.json()) as { error: string };
+    assert.match(parsed.error, /No referral link of ours/);
+    assert.strictEqual(ledgerEntryCount(), before);
+  });
+
+  it("rejects a vendor that runs its own programme when we hold no link into it", async () => {
+    const before = ledgerEntryCount();
+    const res = await post("/api/conversions", {
+      credential: PLATFORM_SECRET,
+      body: conversionBody({ vendor: "Vercel" }),
+    });
+    assert.strictEqual(res.status, 400);
+    const parsed = (await res.json()) as { error: string };
+    assert.match(parsed.error, /No referral link of ours/);
+    assert.strictEqual(ledgerEntryCount(), before);
+  });
+
+  it("matches a held vendor by slug as well as by name", async () => {
+    const res = await post("/api/conversions", {
+      credential: PLATFORM_SECRET,
+      body: conversionBody({ vendor: "railway" }),
+    });
+    assert.strictEqual(res.status, 201);
+  });
+});
+
+describe("Conversion endpoints with no platform secret configured", () => {
+  let serverProc: ChildProcess;
+  let port = 0;
+
+  before(async () => {
+    saveOriginals();
+    emptyTheStores();
+    const started = await startHttpServer({ AGENTDEALS_PLATFORM_SECRET: "" });
+    serverProc = started.proc;
+    port = started.port;
+  });
+
+  after(() => {
+    serverProc?.kill();
+    restoreOriginals();
+  });
+
+  it("refuses every caller rather than admitting every caller", async () => {
+    for (const credential of [undefined, "", "guess", "Bearer"]) {
+      const res = await fetch(`http://localhost:${port}/api/conversions`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          ...(credential === undefined ? {} : { Authorization: `Bearer ${credential}` }),
+        },
+        body: JSON.stringify({ vendor: HELD_VENDOR, commission_amount: 1 }),
+      });
+      assert.strictEqual(res.status, 401, `credential ${JSON.stringify(credential)} should not be admitted`);
+    }
+    assert.strictEqual(ledgerEntryCount(), 0);
+  });
+});
+
+describe("Agent registration is open but rate limited", () => {
+  let serverProc: ChildProcess;
+  let port = 0;
+
+  before(async () => {
+    saveOriginals();
+    emptyTheStores();
+    const started = await startHttpServer({ AGENTDEALS_REGISTER_LIMIT_PER_HOUR: "2" });
+    serverProc = started.proc;
+    port = started.port;
+  });
+
+  after(() => {
+    serverProc?.kill();
+    restoreOriginals();
+  });
+
+  const register = (name: string) =>
+    fetch(`http://localhost:${port}/api/agents/register`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ name }),
+    });
+
+  it("admits the allowance, then answers 429 with the headers the API page promises", async () => {
+    const first = await register("RateLimitedBotOne");
+    assert.strictEqual(first.status, 201);
+    assert.strictEqual(first.headers.get("x-ratelimit-limit"), "2");
+    assert.strictEqual(first.headers.get("x-ratelimit-remaining"), "1");
+    assert.ok(Number(first.headers.get("x-ratelimit-reset")) > 0);
+
+    const second = await register("RateLimitedBotTwo");
+    assert.strictEqual(second.status, 201);
+    assert.strictEqual(second.headers.get("x-ratelimit-remaining"), "0");
+
+    const third = await register("RateLimitedBotThree");
+    assert.strictEqual(third.status, 429);
+    assert.strictEqual(third.headers.get("x-ratelimit-remaining"), "0");
+    assert.ok(Number(third.headers.get("retry-after")) > 0);
+    const parsed = (await third.json()) as { error: string; retry_after_seconds: number };
+    assert.match(parsed.error, /rate limited/);
+    assert.ok(parsed.retry_after_seconds > 0);
+  });
+
+  it("does not create the identity it refused", async () => {
+    const stored = JSON.parse(fs.readFileSync(AGENTS_PATH, "utf-8")) as { agents: Array<{ name: string }> };
+    const names = stored.agents.map(a => a.name);
+    assert.ok(names.includes("RateLimitedBotOne"));
+    assert.ok(!names.includes("RateLimitedBotThree"));
+  });
+
+  it("keeps refusing for the rest of the window", async () => {
+    const res = await register("RateLimitedBotFour");
+    assert.strictEqual(res.status, 429);
+  });
+
+  it("publishes the limit it enforces on the developer API page", async () => {
+    const html = await (await fetch(`http://localhost:${port}/developers`)).text();
+    assert.ok(
+      html.includes("allows 2 registrations per hour per client"),
+      "the API page should state the limit this server is enforcing",
+    );
+    assert.ok(html.includes("X-RateLimit-Limit"), "the API page should name the headers the endpoint returns");
+  });
+});

--- a/test/http.test.ts
+++ b/test/http.test.ts
@@ -2036,7 +2036,10 @@ describe("HTTP transport", () => {
     assert.ok(html.includes("/api/docs"), "Should link to Swagger docs");
     assert.ok(html.includes("/api/digest/weekly"), "Should show weekly digest endpoint in quickstart");
     assert.ok(html.includes("Rate Limits"), "Should have rate limits section");
-    assert.ok(html.includes("no rate limits"), "Should state no rate limits");
+    assert.ok(html.includes("no rate limits"), "Should state where there are no rate limits");
+    assert.ok(html.includes("X-RateLimit-Limit"), "Should name the headers the limited endpoints return");
+    assert.ok(html.includes("registrations per hour per client"), "Should state the registration limit");
+    assert.ok(!/no rate limits\.?<\/p>/.test(html), "Should not claim the whole API is unlimited");
     assert.ok(html.includes("/feed.xml"), "Should link to RSS feed");
     assert.ok(!html.includes("${BASE_URL}"), "Should not have unresolved BASE_URL");
   });

--- a/test/marketplace-api.test.ts
+++ b/test/marketplace-api.test.ts
@@ -12,6 +12,9 @@ const LEDGER_PATH = path.join(__dirname, "..", "data", "ledger_entries.json");
 const BALANCES_PATH = path.join(__dirname, "..", "data", "agent_balances.json");
 const REQUESTS_PATH = path.join(__dirname, "..", "data", "referral_requests.json");
 
+const PLATFORM_SECRET = "marketplace-api-test-secret";
+const PLATFORM_AUTH = { Authorization: `Bearer ${PLATFORM_SECRET}` };
+
 let serverPort = 0;
 let serverProc: ChildProcess;
 
@@ -61,7 +64,7 @@ function startHttpServer(): Promise<ChildProcess> {
     const serverPath = path.join(__dirname, "..", "dist", "serve.js");
     const proc = spawn("node", [serverPath], {
       stdio: ["pipe", "pipe", "pipe"],
-      env: { ...process.env, PORT: "0", BASE_URL: "http://localhost" },
+      env: { ...process.env, PORT: "0", BASE_URL: "http://localhost", AGENTDEALS_PLATFORM_SECRET: PLATFORM_SECRET },
     });
 
     const timeout = setTimeout(() => {
@@ -115,7 +118,7 @@ describe("Marketplace API Endpoints", () => {
   it("POST /api/conversions records a conversion", async () => {
     const res = await fetch(`http://localhost:${serverPort}/api/conversions`, {
       method: "POST",
-      headers: { "Content-Type": "application/json" },
+      headers: { "Content-Type": "application/json", ...PLATFORM_AUTH },
       body: JSON.stringify({
         vendor: "Railway",
         referral_code: "TEST123",
@@ -134,7 +137,7 @@ describe("Marketplace API Endpoints", () => {
   it("POST /api/conversions rejects missing vendor", async () => {
     const res = await fetch(`http://localhost:${serverPort}/api/conversions`, {
       method: "POST",
-      headers: { "Content-Type": "application/json" },
+      headers: { "Content-Type": "application/json", ...PLATFORM_AUTH },
       body: JSON.stringify({ commission_amount: 5.00 }),
     });
     assert.strictEqual(res.status, 400);
@@ -145,7 +148,7 @@ describe("Marketplace API Endpoints", () => {
   it("POST /api/conversions rejects invalid commission_amount", async () => {
     const res = await fetch(`http://localhost:${serverPort}/api/conversions`, {
       method: "POST",
-      headers: { "Content-Type": "application/json" },
+      headers: { "Content-Type": "application/json", ...PLATFORM_AUTH },
       body: JSON.stringify({ vendor: "Railway", commission_amount: -1 }),
     });
     assert.strictEqual(res.status, 400);
@@ -156,7 +159,7 @@ describe("Marketplace API Endpoints", () => {
   it("POST /api/conversions rejects invalid JSON", async () => {
     const res = await fetch(`http://localhost:${serverPort}/api/conversions`, {
       method: "POST",
-      headers: { "Content-Type": "application/json" },
+      headers: { "Content-Type": "application/json", ...PLATFORM_AUTH },
       body: "not-json",
     });
     assert.strictEqual(res.status, 400);
@@ -169,6 +172,7 @@ describe("Marketplace API Endpoints", () => {
   it("POST /api/conversions/confirm returns confirmed count", async () => {
     const res = await fetch(`http://localhost:${serverPort}/api/conversions/confirm`, {
       method: "POST",
+      headers: { "Content-Type": "application/json", ...PLATFORM_AUTH },
     });
     assert.strictEqual(res.status, 200);
     const body = await res.json();
@@ -181,7 +185,7 @@ describe("Marketplace API Endpoints", () => {
   it("POST /api/conversions/clawback rejects missing entry_id", async () => {
     const res = await fetch(`http://localhost:${serverPort}/api/conversions/clawback`, {
       method: "POST",
-      headers: { "Content-Type": "application/json" },
+      headers: { "Content-Type": "application/json", ...PLATFORM_AUTH },
       body: JSON.stringify({}),
     });
     assert.strictEqual(res.status, 400);
@@ -192,7 +196,7 @@ describe("Marketplace API Endpoints", () => {
   it("POST /api/conversions/clawback returns 404 for nonexistent entry", async () => {
     const res = await fetch(`http://localhost:${serverPort}/api/conversions/clawback`, {
       method: "POST",
-      headers: { "Content-Type": "application/json" },
+      headers: { "Content-Type": "application/json", ...PLATFORM_AUTH },
       body: JSON.stringify({ entry_id: "nonexistent_id" }),
     });
     assert.strictEqual(res.status, 404);
@@ -203,7 +207,7 @@ describe("Marketplace API Endpoints", () => {
   it("POST /api/conversions/clawback rejects invalid JSON", async () => {
     const res = await fetch(`http://localhost:${serverPort}/api/conversions/clawback`, {
       method: "POST",
-      headers: { "Content-Type": "application/json" },
+      headers: { "Content-Type": "application/json", ...PLATFORM_AUTH },
       body: "bad-json",
     });
     assert.strictEqual(res.status, 400);

--- a/test/platform-auth.test.ts
+++ b/test/platform-auth.test.ts
@@ -1,0 +1,123 @@
+import { describe, it } from "node:test";
+import assert from "node:assert";
+
+const {
+  PLATFORM_SECRET_ENV,
+  PLATFORM_CREDENTIAL_REQUIRED,
+  authorizedAsPlatform,
+  platformSecretConfigured,
+  platformSecretMatches,
+  presentedBearerToken,
+} = await import("../dist/platform-auth.js");
+
+describe("platform credential", () => {
+  describe("presentedBearerToken", () => {
+    it("reads the token out of a Bearer authorization header", () => {
+      assert.strictEqual(presentedBearerToken({ authorization: "Bearer s3cret" }), "s3cret");
+    });
+
+    it("accepts the scheme in any case", () => {
+      assert.strictEqual(presentedBearerToken({ authorization: "bearer s3cret" }), "s3cret");
+    });
+
+    it("returns null when the header is absent", () => {
+      assert.strictEqual(presentedBearerToken({}), null);
+    });
+
+    it("returns null for a non-Bearer scheme", () => {
+      assert.strictEqual(presentedBearerToken({ authorization: "Basic s3cret" }), null);
+    });
+
+    it("returns null for a Bearer header with no token", () => {
+      assert.strictEqual(presentedBearerToken({ authorization: "Bearer   " }), null);
+    });
+
+    it("reads the first value when the header arrives repeated", () => {
+      assert.strictEqual(presentedBearerToken({ authorization: ["Bearer first", "Bearer second"] }), "first");
+    });
+  });
+
+  describe("platformSecretMatches", () => {
+    it("accepts the configured secret", () => {
+      assert.strictEqual(platformSecretMatches("s3cret", "s3cret"), true);
+    });
+
+    it("rejects a different secret of the same length", () => {
+      assert.strictEqual(platformSecretMatches("s3cres", "s3cret"), false);
+    });
+
+    it("rejects a different secret of a different length", () => {
+      assert.strictEqual(platformSecretMatches("s3", "s3cret"), false);
+    });
+
+    it("rejects a prefix of the configured secret", () => {
+      assert.strictEqual(platformSecretMatches("s3cre", "s3cret"), false);
+    });
+
+    it("rejects every presented value when no secret is configured", () => {
+      assert.strictEqual(platformSecretMatches("anything", undefined), false);
+      assert.strictEqual(platformSecretMatches("anything", ""), false);
+      assert.strictEqual(platformSecretMatches("anything", "   "), false);
+      assert.strictEqual(platformSecretMatches("", undefined), false);
+      assert.strictEqual(platformSecretMatches(null, undefined), false);
+    });
+
+    it("rejects an absent credential against a configured secret", () => {
+      assert.strictEqual(platformSecretMatches(null, "s3cret"), false);
+    });
+
+    it("ignores surrounding whitespace in the configured value", () => {
+      assert.strictEqual(platformSecretMatches("s3cret", "  s3cret  "), true);
+    });
+  });
+
+  describe("platformSecretConfigured", () => {
+    it("is false for absent, empty and whitespace-only values", () => {
+      assert.strictEqual(platformSecretConfigured(undefined), false);
+      assert.strictEqual(platformSecretConfigured(""), false);
+      assert.strictEqual(platformSecretConfigured(" \t "), false);
+    });
+
+    it("is true for a real value", () => {
+      assert.strictEqual(platformSecretConfigured("s3cret"), true);
+    });
+  });
+
+  describe("authorizedAsPlatform", () => {
+    it("authorizes a request carrying the configured secret", () => {
+      assert.strictEqual(authorizedAsPlatform({ authorization: "Bearer s3cret" }, "s3cret"), true);
+    });
+
+    it("refuses a request carrying an agent-shaped key", () => {
+      assert.strictEqual(authorizedAsPlatform({ authorization: "Bearer agd_abc123" }, "s3cret"), false);
+    });
+
+    it("refuses every request when the environment has no secret", () => {
+      assert.strictEqual(authorizedAsPlatform({ authorization: "Bearer s3cret" }, undefined), false);
+      assert.strictEqual(authorizedAsPlatform({}, undefined), false);
+    });
+
+    it("falls back to the environment variable when no secret is passed", () => {
+      const restore = process.env[PLATFORM_SECRET_ENV];
+      try {
+        process.env[PLATFORM_SECRET_ENV] = "from-env";
+        assert.strictEqual(authorizedAsPlatform({ authorization: "Bearer from-env" }), true);
+        assert.strictEqual(authorizedAsPlatform({ authorization: "Bearer other" }), false);
+        delete process.env[PLATFORM_SECRET_ENV];
+        assert.strictEqual(authorizedAsPlatform({ authorization: "Bearer from-env" }), false);
+      } finally {
+        if (restore === undefined) delete process.env[PLATFORM_SECRET_ENV];
+        else process.env[PLATFORM_SECRET_ENV] = restore;
+      }
+    });
+  });
+
+  it("names the environment variable the deployment sets", () => {
+    assert.strictEqual(PLATFORM_SECRET_ENV, "AGENTDEALS_PLATFORM_SECRET");
+  });
+
+  it("tells the caller which credential the endpoint wants", () => {
+    assert.match(PLATFORM_CREDENTIAL_REQUIRED, /platform credential/);
+    assert.match(PLATFORM_CREDENTIAL_REQUIRED, /not an agent API key/);
+  });
+});

--- a/test/rate-limit.test.ts
+++ b/test/rate-limit.test.ts
@@ -1,0 +1,133 @@
+import { describe, it } from "node:test";
+import assert from "node:assert";
+
+const {
+  REGISTRATION_LIMIT_DEFAULT,
+  REGISTRATION_LIMIT_ENV,
+  REGISTRATION_WINDOW_MS,
+  createRateLimiter,
+  createRegistrationLimiter,
+  rateLimitHeaders,
+  registrationLimitFrom,
+} = await import("../dist/rate-limit.js");
+
+describe("rate limiter", () => {
+  it("allows exactly the configured number of calls in a window", () => {
+    const limiter = createRateLimiter({ limit: 3, windowMs: 60_000, maxKeys: 100 });
+    const now = 1_000_000;
+    for (let i = 0; i < 3; i++) {
+      assert.strictEqual(limiter.check("1.2.3.4", now).allowed, true, `call ${i + 1} should pass`);
+    }
+    assert.strictEqual(limiter.check("1.2.3.4", now).allowed, false);
+  });
+
+  it("counts each caller separately", () => {
+    const limiter = createRateLimiter({ limit: 2, windowMs: 60_000, maxKeys: 100 });
+    const now = 1_000_000;
+    limiter.check("1.2.3.4", now);
+    limiter.check("1.2.3.4", now);
+    assert.strictEqual(limiter.check("1.2.3.4", now).allowed, false);
+    assert.strictEqual(limiter.check("5.6.7.8", now).allowed, true);
+  });
+
+  it("starts a fresh window once the old one has elapsed", () => {
+    const limiter = createRateLimiter({ limit: 2, windowMs: 60_000, maxKeys: 100 });
+    const now = 1_000_000;
+    limiter.check("1.2.3.4", now);
+    limiter.check("1.2.3.4", now);
+    assert.strictEqual(limiter.check("1.2.3.4", now).allowed, false);
+    assert.strictEqual(limiter.check("1.2.3.4", now + 59_999).allowed, false);
+    assert.strictEqual(limiter.check("1.2.3.4", now + 60_000).allowed, true);
+  });
+
+  it("counts down the remaining allowance and stops at zero", () => {
+    const limiter = createRateLimiter({ limit: 2, windowMs: 60_000, maxKeys: 100 });
+    const now = 1_000_000;
+    assert.strictEqual(limiter.check("1.2.3.4", now).remaining, 1);
+    assert.strictEqual(limiter.check("1.2.3.4", now).remaining, 0);
+    assert.strictEqual(limiter.check("1.2.3.4", now).remaining, 0);
+  });
+
+  it("reports the seconds left in the window", () => {
+    const limiter = createRateLimiter({ limit: 1, windowMs: 60_000, maxKeys: 100 });
+    const now = 1_000_000;
+    assert.strictEqual(limiter.check("1.2.3.4", now).resetSeconds, 60);
+    assert.strictEqual(limiter.check("1.2.3.4", now + 30_000).resetSeconds, 30);
+    assert.strictEqual(limiter.check("1.2.3.4", now + 59_999).resetSeconds, 1);
+  });
+
+  it("bounds the key map so a spread of callers cannot grow it without limit", () => {
+    const limiter = createRateLimiter({ limit: 1, windowMs: 60_000, maxKeys: 4 });
+    const now = 1_000_000;
+    for (let i = 0; i < 50; i++) limiter.check(`10.0.0.${i}`, now);
+    assert.strictEqual(limiter.check("10.0.0.49", now).allowed, false, "the most recent caller is still counted");
+    assert.strictEqual(limiter.check("10.0.0.0", now).allowed, true, "the oldest caller has been evicted");
+  });
+
+  it("keeps the most recently seen callers when evicting", () => {
+    const limiter = createRateLimiter({ limit: 2, windowMs: 60_000, maxKeys: 2 });
+    const now = 1_000_000;
+    limiter.check("a", now);
+    limiter.check("b", now);
+    limiter.check("a", now);
+    limiter.check("c", now);
+    assert.strictEqual(limiter.check("a", now).allowed, false, "a was refreshed and stays counted");
+    assert.strictEqual(limiter.check("b", now).allowed, true, "b was the least recently used and was evicted");
+  });
+
+  it("forgets every caller on reset", () => {
+    const limiter = createRateLimiter({ limit: 1, windowMs: 60_000, maxKeys: 100 });
+    const now = 1_000_000;
+    limiter.check("1.2.3.4", now);
+    assert.strictEqual(limiter.check("1.2.3.4", now).allowed, false);
+    limiter.reset();
+    assert.strictEqual(limiter.check("1.2.3.4", now).allowed, true);
+  });
+
+  it("publishes its own limit", () => {
+    assert.strictEqual(createRateLimiter({ limit: 7, windowMs: 1000, maxKeys: 10 }).limit, 7);
+  });
+});
+
+describe("rateLimitHeaders", () => {
+  it("renders the three headers as strings", () => {
+    const headers = rateLimitHeaders({ allowed: true, limit: 5, remaining: 3, resetSeconds: 42 });
+    assert.deepStrictEqual(headers, {
+      "X-RateLimit-Limit": "5",
+      "X-RateLimit-Remaining": "3",
+      "X-RateLimit-Reset": "42",
+    });
+  });
+});
+
+describe("registration limiter", () => {
+  it("names the environment variable that tunes it", () => {
+    assert.strictEqual(REGISTRATION_LIMIT_ENV, "AGENTDEALS_REGISTER_LIMIT_PER_HOUR");
+  });
+
+  it("measures its window in one hour", () => {
+    assert.strictEqual(REGISTRATION_WINDOW_MS, 3_600_000);
+  });
+
+  it("falls back to the default for anything that is not a positive whole number", () => {
+    assert.strictEqual(registrationLimitFrom(undefined), REGISTRATION_LIMIT_DEFAULT);
+    assert.strictEqual(registrationLimitFrom(""), REGISTRATION_LIMIT_DEFAULT);
+    assert.strictEqual(registrationLimitFrom("many"), REGISTRATION_LIMIT_DEFAULT);
+    assert.strictEqual(registrationLimitFrom("0"), REGISTRATION_LIMIT_DEFAULT);
+    assert.strictEqual(registrationLimitFrom("-4"), REGISTRATION_LIMIT_DEFAULT);
+    assert.strictEqual(registrationLimitFrom("2.5"), REGISTRATION_LIMIT_DEFAULT);
+  });
+
+  it("takes a positive whole number as the limit", () => {
+    assert.strictEqual(registrationLimitFrom("12"), 12);
+  });
+
+  it("builds a limiter at the configured limit", () => {
+    assert.strictEqual(createRegistrationLimiter("3").limit, 3);
+    assert.strictEqual(createRegistrationLimiter(undefined).limit, REGISTRATION_LIMIT_DEFAULT);
+  });
+
+  it("defaults to a small number of identities per hour", () => {
+    assert.ok(REGISTRATION_LIMIT_DEFAULT > 0 && REGISTRATION_LIMIT_DEFAULT <= 10);
+  });
+});


### PR DESCRIPTION
Refs #1164.

`POST /api/conversions`, `/api/conversions/confirm` and `/api/conversions/clawback` were publicly reachable. The first writes ledger entries crediting an agent balance from a caller-supplied amount with no upper bound; the second is the state transition that moves a balance from pending to confirmed, which is what `request_payout` pays out.

## What now guards them

All three take `AGENTDEALS_PLATFORM_SECRET` as `Authorization: Bearer <secret>`, compared with a timing-safe digest equality in `src/platform-auth.ts`.

**A deployment with no secret set refuses every caller.** That is the branch that matters most, because production has no secret set today: the first deploy after this merge closes the endpoints rather than opening them. It has its own server in the suite, and its own mutation — flipping the unconfigured case to `return true` is the fail-open bug this design exists to prevent.

**An agent API key does not authenticate here.** A conversion asserts that a vendor paid *us*, so it is a statement about our own revenue. Letting an agent make it is the self-dealing shape the marketplace invites, so there is a mutation that swaps `authorizedAsPlatform` for `authenticateRequest` and a test that presents a real registered agent's key to each of the three routes.

The check runs before the body is read, so an unauthenticated caller cannot make the process do the parse.

## Validation on the amount and the vendor

- `commission_amount` is bounded at `MAX_COMMISSION_AMOUNT` (10,000) and must be finite. `typeof x === "number"` admits `Infinity`, which `1e400` produces through `JSON.parse`; it is now reported as not a number rather than as too large.
- The vendor must be one we hold a referral link into, resolved through `allOurReferralLinks` — the same enumeration that renders the buttons, covering `data/platform_codes.json` and `offer.referral`. A vendor that merely documents its own programme does not qualify: `Vercel` has `referral_program.available` and is refused, which is the negative fixture for that distinction.

## Registration stays open, and is now bounded

`POST /api/agents/register` still accepts anyone — an open registry is the point — but a client gets `AGENTDEALS_REGISTER_LIMIT_PER_HOUR` (default 5) per hour, with `X-RateLimit-Limit`, `X-RateLimit-Remaining` and `X-RateLimit-Reset` on every response and `Retry-After` on the `429`. The limiter is keyed on a truncated hash of the caller's address under a salt generated at boot, so it holds no address.

It is keyed on `x-forwarded-for`, which the caller controls, so it bounds an ordinary client and a naive script and does not bound a caller that rotates the header. Nothing above depends on it.

## The page that said there were none

`/developers` published *"There are currently no rate limits ... if this changes, we will add an `X-RateLimit-*` header before enforcing any limits"*, and a test pinned that sentence. The page now says which paths are limited, and takes the registration figure from `registrationLimiter.limit` rather than a literal, so the published number is the enforced one — a test starts a server at a limit of 2 and asserts the page says 2. Two mutations cover it: hardcoding the figure, and dropping the paragraph.

## Verification

- **2,662 tests / 0 failures** (61 new), `tsc --noEmit` and `validate-data` clean at 1,580 offers / 444 changes.
- **`scripts/mutate-1164.sh`: 26 mutations, 26 killed, no survivors, none by the compiler.** The one first-pass survivor was instructive — the finite check was unobservable because the upper bound already caught `Infinity`, so the test now asserts *which* reason the caller is given rather than only the status.
- **Sweep of all 3,916 published paths against a `main` worktree: 3,915 byte-identical.** The only page that moves is `/developers` (+354 bytes). Sponsored anchors unchanged at 76 across 71 pages.
- **`scripts/e2e-1164.mjs`: 30 checks**, including a real MCP `initialize` → `tools/call` (`get_referral_code({vendor: "Railway"})` unchanged) and a run against a server with no secret configured.
- Screenshots of the changed section and the page hero.

## Operator note

Nothing calls these endpoints today — no workflow, no script, no MCP tool. After this merge they answer `401` until `AGENTDEALS_PLATFORM_SECRET` is set in the deployment environment. That is the intended resting state.