### PR TITLE
Make agent identity, attribution and credit balances survive a deploy (#1163)

### DIFF
--- a/scripts/e2e-1163.mjs
+++ b/scripts/e2e-1163.mjs
@@ -1,0 +1,224 @@
+import { spawn } from "node:child_process";
+import { createServer } from "node:http";
+import { readFileSync, writeFileSync, existsSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const REPO = path.join(path.dirname(fileURLToPath(import.meta.url)), "..");
+const AGENTS_PATH = path.join(REPO, "data", "agents.json");
+const REQUESTS_PATH = path.join(REPO, "data", "referral_requests.json");
+
+let passed = 0;
+let failed = 0;
+function check(label, ok, detail = "") {
+  if (ok) { passed++; console.log(`  PASS  ${label}`); }
+  else { failed++; console.log(`  FAIL  ${label}${detail ? ` — ${detail}` : ""}`); }
+}
+
+const originals = new Map();
+for (const p of [AGENTS_PATH, REQUESTS_PATH]) {
+  originals.set(p, existsSync(p) ? readFileSync(p, "utf-8") : null);
+}
+function restoreData() {
+  for (const [p, held] of originals) if (held !== null) writeFileSync(p, held, "utf-8");
+}
+
+function upstashDouble() {
+  const keys = new Map();
+  const lists = new Map();
+  const server = createServer((req, res) => {
+    let body = "";
+    req.on("data", (c) => { body += c; });
+    req.on("end", () => {
+      let cmd = [];
+      try { cmd = JSON.parse(body); } catch { cmd = []; }
+      const op = String(cmd[0] ?? "").toUpperCase();
+      const key = String(cmd[1] ?? "");
+      let result = null;
+      if (op === "SET") { keys.set(key, String(cmd[2])); result = "OK"; }
+      else if (op === "GET") { result = keys.has(key) ? keys.get(key) : null; }
+      else if (op === "MGET") { result = cmd.slice(1).map((k) => keys.get(String(k)) ?? null); }
+      else if (op === "INCR") { const n = Number(keys.get(key) ?? "0") + 1; keys.set(key, String(n)); result = n; }
+      else if (op === "INCRBY") { const n = Number(keys.get(key) ?? "0") + Number(cmd[2]); keys.set(key, String(n)); result = n; }
+      else if (op === "LPUSH") { const l = lists.get(key) ?? []; for (const v of cmd.slice(2)) l.unshift(String(v)); lists.set(key, l); result = l.length; }
+      else if (op === "LRANGE") { result = (lists.get(key) ?? []).slice(Number(cmd[2]), Number(cmd[3]) + 1); }
+      else if (op === "LTRIM") { lists.set(key, (lists.get(key) ?? []).slice(Number(cmd[2]), Number(cmd[3]) + 1)); result = "OK"; }
+      else if (op === "DEL") { keys.delete(key); lists.delete(key); result = 1; }
+      else if (op === "EXPIRE") { result = 1; }
+      else if (op === "SCAN") { result = ["0", [...keys.keys()]]; }
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ result }));
+    });
+  });
+  return new Promise((resolve) => {
+    server.listen(0, "127.0.0.1", () => resolve({ server, keys, url: `http://127.0.0.1:${server.address().port}` }));
+  });
+}
+
+function startServer(env) {
+  return new Promise((resolve, reject) => {
+    const proc = spawn("node", [path.join(REPO, "dist", "serve.js")], {
+      cwd: REPO,
+      stdio: ["pipe", "pipe", "pipe"],
+      env: { ...process.env, PORT: "0", BASE_URL: "http://127.0.0.1", ...env },
+    });
+    const timeout = setTimeout(() => { proc.kill("SIGKILL"); reject(new Error("startup timeout")); }, 30000);
+    proc.stderr.on("data", (b) => {
+      const m = b.toString().match(/running on http:\/\/localhost:(\d+)/);
+      if (m) { clearTimeout(timeout); resolve({ proc, port: parseInt(m[1], 10) }); }
+    });
+    proc.on("error", (e) => { clearTimeout(timeout); reject(e); });
+  });
+}
+
+async function mcpSession(base, clientName) {
+  const init = await fetch(`${base}/mcp`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json", Accept: "application/json, text/event-stream" },
+    body: JSON.stringify({
+      jsonrpc: "2.0", id: 1, method: "initialize",
+      params: { protocolVersion: "2025-06-18", capabilities: {}, clientInfo: { name: clientName, version: "1.0.0" } },
+    }),
+  });
+  const sessionId = init.headers.get("mcp-session-id");
+  await fetch(`${base}/mcp`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json", Accept: "application/json, text/event-stream", "Mcp-Session-Id": sessionId },
+    body: JSON.stringify({ jsonrpc: "2.0", method: "notifications/initialized" }),
+  });
+  let id = 1;
+  return {
+    sessionId,
+    ok: init.status === 200 && !!sessionId,
+    async call(name, args) {
+      const res = await fetch(`${base}/mcp`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json", Accept: "application/json, text/event-stream", "Mcp-Session-Id": sessionId },
+        body: JSON.stringify({ jsonrpc: "2.0", id: ++id + 100, method: "tools/call", params: { name, arguments: args } }),
+      });
+      const text = await res.text();
+      const line = text.split("\n").find((l) => l.startsWith("data: ")) ?? text;
+      const payload = JSON.parse(line.replace(/^data: /, ""));
+      const content = payload?.result?.content?.[0]?.text ?? "";
+      let parsed = null;
+      try { parsed = JSON.parse(content); } catch { parsed = null; }
+      return { status: res.status, isError: payload?.result?.isError === true, text: content, json: parsed };
+    },
+    async list() {
+      const res = await fetch(`${base}/mcp`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json", Accept: "application/json, text/event-stream", "Mcp-Session-Id": sessionId },
+        body: JSON.stringify({ jsonrpc: "2.0", id: ++id + 200, method: "tools/list", params: {} }),
+      });
+      const text = await res.text();
+      const line = text.split("\n").find((l) => l.startsWith("data: ")) ?? text;
+      return JSON.parse(line.replace(/^data: /, ""))?.result?.tools ?? [];
+    },
+  };
+}
+
+const redis = await upstashDouble();
+let first;
+let second;
+let plain;
+
+try {
+  writeFileSync(AGENTS_PATH, JSON.stringify({ agents: [] }, null, 2), "utf-8");
+  writeFileSync(REQUESTS_PATH, JSON.stringify({ referral_requests: [] }, null, 2), "utf-8");
+
+  const env = {
+    UPSTASH_REDIS_REST_URL: redis.url,
+    UPSTASH_REDIS_REST_TOKEN: "e2e-1163",
+    AGENTDEALS_ROLLUP_DIR: "/tmp/e2e-1163-rollups",
+  };
+
+  console.log("A durable deployment");
+  first = await startServer(env);
+  const baseA = `http://127.0.0.1:${first.port}`;
+
+  const statsA = await (await fetch(`${baseA}/api/stats`)).json();
+  check("identity storage reports durable", statsA.identity_storage?.durable === true, JSON.stringify(statsA.identity_storage?.backend));
+  check("every identity store was read from the backend", (statsA.identity_storage?.stores ?? []).every((s) => s.hydrated), "a store was not hydrated");
+  check("all seven identity stores are covered", (statsA.identity_storage?.stores ?? []).length >= 7, `${statsA.identity_storage?.stores?.length} stores`);
+
+  const sessionA = await mcpSession(baseA, "e2e-1163");
+  check("MCP initialize returns a session", sessionA.ok);
+
+  const name = `e2e-1163-probe-${Date.now()}`;
+  const registered = await sessionA.call("register_agent", { name });
+  const issuedKey = registered.json?.api_key;
+  check("register_agent issues a key over MCP", !!issuedKey, registered.text.slice(0, 120));
+
+  const onDisk = JSON.parse(readFileSync(AGENTS_PATH, "utf-8"));
+  check("the registration did not go to the image's file", onDisk.agents.length === 0, `${onDisk.agents.length} on disk`);
+  check("the registration went to the durable store", [...redis.keys.keys()].includes("agentdeals:store:agents"), [...redis.keys.keys()].join(","));
+
+  first.proc.kill("SIGKILL");
+  first = undefined;
+  await new Promise((r) => setTimeout(r, 400));
+
+  console.log("\nThe same deployment, restarted");
+  second = await startServer(env);
+  const baseB = `http://127.0.0.1:${second.port}`;
+
+  const me = await fetch(`${baseB}/api/agents/me`, { headers: { Authorization: `Bearer ${issuedKey}` } });
+  check("a key issued before the restart still authenticates", me.status === 200, `status ${me.status}`);
+
+  const sessionB = await mcpSession(baseB, "e2e-1163-restarted");
+  const attributed = await sessionB.call("get_referral_code", { vendor: "Railway", api_key: issuedKey });
+  check("get_referral_code attributes the pre-restart key", attributed.json?.attribution === "attributed", attributed.text.slice(0, 160));
+  check("the referral URL is unchanged", String(attributed.json?.referral_url ?? "").includes("referralCode=7RZL9q"), attributed.json?.referral_url);
+
+  const unknown = await sessionB.call("get_referral_code", { vendor: "Railway", api_key: "agd_this_key_was_never_issued" });
+  check("an unrecognised key is named as unrecognised", unknown.json?.attribution === "key_not_recognised", unknown.text.slice(0, 160));
+  check("an unrecognised key still gets the code", !!unknown.json?.referral_url, "no code returned");
+  check("the reason is stated, not left to inference", /not in the agent registry/i.test(String(unknown.json?.attribution_note ?? "")), unknown.json?.attribution_note);
+
+  const anonymous = await sessionB.call("get_referral_code", { vendor: "Railway" });
+  check("no key is distinguished from a bad key", anonymous.json?.attribution === "no_key", anonymous.text.slice(0, 160));
+
+  const httpUnknown = await (await fetch(`${baseB}/api/referral/Railway`, { headers: { Authorization: "Bearer agd_nope" } })).json();
+  check("the HTTP referral endpoint makes the same distinction", httpUnknown.attribution === "key_not_recognised", JSON.stringify(httpUnknown.attribution));
+
+  const balance = await sessionB.call("check_balance", { api_key: issuedKey });
+  check("check_balance reports that payouts are unavailable", balance.json?.payouts_available === false, balance.text.slice(0, 160));
+
+  const payout = await sessionB.call("request_payout", { api_key: issuedKey });
+  check("request_payout reports the missing capability", payout.isError && /not enabled/i.test(payout.text), payout.text.slice(0, 160));
+
+  const tools = await sessionB.list();
+  const balanceTool = tools.find((t) => t.name === "check_balance");
+  const payoutTool = tools.find((t) => t.name === "request_payout");
+  check("check_balance no longer calls the balance available for withdrawal", !/available for withdrawal/i.test(balanceTool?.description ?? ""), balanceTool?.description?.slice(0, 120));
+  check("request_payout no longer promises a stablecoin transfer", !/stablecoin transfer/i.test(payoutTool?.description ?? ""), payoutTool?.description?.slice(0, 120));
+  check("request_payout states that payouts are not enabled", /not enabled/i.test(payoutTool?.description ?? ""), payoutTool?.description?.slice(0, 120));
+
+  const marketplace = await (await fetch(`${baseB}/marketplace`)).text();
+  check("the marketplace page does not promise a payout at $10", !/request payouts when your confirmed balance reaches/i.test(marketplace), "the promise is still rendered");
+  check("the marketplace page states why", /Payouts are not enabled yet/i.test(marketplace), "no reason rendered");
+  check("the How It Works card does not promise payment via x402", !/Get paid when your codes convert via x402/.test(marketplace), "the card still promises payment");
+
+  const offers = await (await fetch(`${baseB}/api/offers?limit=1`)).json();
+  check("the read API is unaffected", offers.total > 1000, `total ${offers.total}`);
+
+  second.proc.kill("SIGKILL");
+  second = undefined;
+
+  console.log("\nA deployment with no durable backend");
+  plain = await startServer({ UPSTASH_REDIS_REST_URL: "", UPSTASH_REDIS_REST_TOKEN: "", AGENTDEALS_ROLLUP_DIR: "/tmp/e2e-1163-rollups" });
+  const baseC = `http://127.0.0.1:${plain.port}`;
+  const statsC = await (await fetch(`${baseC}/api/stats`)).json();
+  check("identity storage reports the container filesystem", statsC.identity_storage?.backend === "container_filesystem", JSON.stringify(statsC.identity_storage?.backend));
+  check("identity storage does not claim to survive a deploy", statsC.identity_storage?.survives_deploy === false, JSON.stringify(statsC.identity_storage));
+  plain.proc.kill("SIGKILL");
+  plain = undefined;
+} finally {
+  first?.proc.kill("SIGKILL");
+  second?.proc.kill("SIGKILL");
+  plain?.proc.kill("SIGKILL");
+  redis.server.close();
+  restoreData();
+}
+
+console.log(`\n${passed} passed, ${failed} failed`);
+process.exit(failed === 0 ? 0 : 1);

--- a/scripts/mutate-1163.sh
+++ b/scripts/mutate-1163.sh
@@ -1,0 +1,386 @@
+#!/usr/bin/env bash
+set -u
+
+REPO="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$REPO" || exit 1
+
+STORE="src/durable-store.ts"
+AGENTS="src/agents.ts"
+ATTRIB="src/referral-attribution.ts"
+X402="src/x402.ts"
+SERVE="src/serve.ts"
+BACKUP_DIR="$(mktemp -d)"
+cp "$STORE" "$BACKUP_DIR/durable-store.ts"
+cp "$AGENTS" "$BACKUP_DIR/agents.ts"
+cp "$ATTRIB" "$BACKUP_DIR/referral-attribution.ts"
+cp "$X402" "$BACKUP_DIR/x402.ts"
+cp "$SERVE" "$BACKUP_DIR/serve.ts"
+
+restore() {
+  cp "$BACKUP_DIR/durable-store.ts" "$STORE"
+  cp "$BACKUP_DIR/agents.ts" "$AGENTS"
+  cp "$BACKUP_DIR/referral-attribution.ts" "$ATTRIB"
+  cp "$BACKUP_DIR/x402.ts" "$X402"
+  cp "$BACKUP_DIR/serve.ts" "$SERVE"
+}
+trap restore EXIT
+
+killed=0
+survived=0
+TESTS="test/durable-identity.test.ts test/marketplace-api.test.ts"
+
+run_mutation() {
+  local name="$1"
+  shift
+  echo "=== $name"
+  restore
+  "$@"
+  if diff -q "$BACKUP_DIR/durable-store.ts" "$STORE" > /dev/null \
+    && diff -q "$BACKUP_DIR/agents.ts" "$AGENTS" > /dev/null \
+    && diff -q "$BACKUP_DIR/referral-attribution.ts" "$ATTRIB" > /dev/null \
+    && diff -q "$BACKUP_DIR/x402.ts" "$X402" > /dev/null \
+    && diff -q "$BACKUP_DIR/serve.ts" "$SERVE" > /dev/null; then
+    echo "    NOT APPLIED: the mutation changed no file, so it proves nothing"
+    survived=$((survived + 1))
+    return
+  fi
+  if ! npm run build > /tmp/mutate-1163-build.log 2>&1; then
+    echo "    NOT APPLIED: the mutation does not compile, so no test ran"
+    tail -3 /tmp/mutate-1163-build.log
+    survived=$((survived + 1))
+    return
+  fi
+  if timeout 900 node --test --test-concurrency 1 $TESTS > /tmp/mutate-1163-test.log 2>&1; then
+    echo "    SURVIVED"
+    survived=$((survived + 1))
+  else
+    echo "    KILLED: $(grep -c '✖ ' /tmp/mutate-1163-test.log) failing assertion(s)"
+    grep '✖ ' /tmp/mutate-1163-test.log | head -4
+    killed=$((killed + 1))
+  fi
+}
+
+py() { python3 - "$@"; }
+
+m_an_unread_store_is_written_anyway() {
+  py <<'PY'
+p = "src/durable-store.ts"
+s = open(p).read()
+s = s.replace("""      lastWriteError = hydratedFromBackend
+        ? `${opts.name} had to be read from durable storage first, so this change was not applied`
+        : `${opts.name} was not read from durable storage, so writing would discard what is stored`;
+      restoreLastPersisted();
+      return { ok: false, error: lastWriteError };""", "")
+open(p, "w").write(s)
+PY
+}
+
+m_a_failed_write_is_reported_as_success() {
+  py <<'PY'
+p = "src/durable-store.ts"
+s = open(p).read()
+s = s.replace("""    if (!res.ok) {
+      lastWriteError = res.error ?? "durable write failed";
+      restoreLastPersisted();
+      return { ok: false, error: lastWriteError };
+    }""", "")
+open(p, "w").write(s)
+PY
+}
+
+m_a_failed_write_keeps_the_unstored_records() {
+  py <<'PY'
+p = "src/durable-store.ts"
+s = open(p).read()
+s = s.replace("""      lastWriteError = res.error ?? "durable write failed";
+      restoreLastPersisted();""",
+              """      lastWriteError = res.error ?? "durable write failed";""")
+open(p, "w").write(s)
+PY
+}
+
+m_a_failed_read_counts_as_an_empty_store() {
+  py <<'PY'
+p = "src/durable-store.ts"
+s = open(p).read()
+s = s.replace("""    if (!res.ok) {
+      lastReadError = res.error ?? "durable read failed";
+      hydratedFromBackend = false;
+      return;
+    }""",
+              """    if (!res.ok) {
+      lastReadError = res.error ?? "durable read failed";
+      hydratedFromBackend = true;
+      cache = [];
+      persisted = serialize([]);
+      return;
+    }""")
+open(p, "w").write(s)
+PY
+}
+
+m_the_file_is_written_even_with_a_backend() {
+  py <<'PY'
+p = "src/durable-store.ts"
+s = open(p).read()
+s = s.replace("""    cache = next;
+    if (!backend) {
+      writeFile(next);
+      return;
+    }
+    unflushed = true;""",
+              """    cache = next;
+    writeFile(next);
+    if (!backend) return;
+    unflushed = true;""")
+open(p, "w").write(s)
+PY
+}
+
+m_a_save_is_never_marked_for_writing() {
+  py <<'PY'
+p = "src/durable-store.ts"
+s = open(p).read()
+s = s.replace("""    unflushed = true;
+  }
+
+  async function runFlush()""",
+              """    unflushed = false;
+  }
+
+  async function runFlush()""")
+open(p, "w").write(s)
+PY
+}
+
+m_every_flush_spends_a_write() {
+  py <<'PY'
+p = "src/durable-store.ts"
+s = open(p).read()
+s = s.replace("    if (!backend || !unflushed) return { ok: true };",
+              "    if (!backend) return { ok: true };")
+open(p, "w").write(s)
+PY
+}
+
+m_durability_is_claimed_without_reading_the_backend() {
+  py <<'PY'
+p = "src/durable-store.ts"
+s = open(p).read()
+s = s.replace("  const durable = backend !== null && stores.every(s => s.hydrated);",
+              "  const durable = backend !== null;")
+open(p, "w").write(s)
+PY
+}
+
+m_a_stored_value_is_ignored_in_favour_of_the_file() {
+  py <<'PY'
+p = "src/durable-store.ts"
+s = open(p).read()
+s = s.replace("""      cache = stored;
+      persisted = serialize(stored);""",
+              """      cache = readFile();
+      persisted = serialize(cache);""")
+open(p, "w").write(s)
+PY
+}
+
+m_a_store_reports_itself_hydrated_regardless() {
+  py <<'PY'
+p = "src/durable-store.ts"
+s = open(p).read()
+s = s.replace("      hydrated: backend ? hydratedFromBackend : cache !== null,",
+              "      hydrated: true,")
+open(p, "w").write(s)
+PY
+}
+
+m_a_seeded_store_is_never_written_back() {
+  py <<'PY'
+p = "src/durable-store.ts"
+s = open(p).read()
+s = s.replace("    unflushed = seed.length > 0;",
+              "    unflushed = false;")
+open(p, "w").write(s)
+PY
+}
+
+m_a_recovered_read_reports_the_dropped_change_as_saved() {
+  py <<'PY'
+p = "src/durable-store.ts"
+s = open(p).read()
+s = s.replace("""      lastWriteError = hydratedFromBackend
+        ? `${opts.name} had to be read from durable storage first, so this change was not applied`
+        : `${opts.name} was not read from durable storage, so writing would discard what is stored`;
+      restoreLastPersisted();
+      return { ok: false, error: lastWriteError };""",
+              """      if (!hydratedFromBackend) {
+        lastWriteError = `${opts.name} was not read from durable storage, so writing would discard what is stored`;
+        restoreLastPersisted();
+        return { ok: false, error: lastWriteError };
+      }""")
+open(p, "w").write(s)
+PY
+}
+
+m_a_refused_write_leaves_the_records_in_memory() {
+  py <<'PY'
+p = "src/durable-store.ts"
+s = open(p).read()
+s = s.replace("""    if (persisted === null) {
+      cache = null;
+      return;
+    }""",
+              """    if (persisted === null) {
+      return;
+    }""")
+open(p, "w").write(s)
+PY
+}
+
+m_the_registry_is_always_readable() {
+  py <<'PY'
+p = "src/agents.ts"
+s = open(p).read()
+s = s.replace("  return agentStore.status().hydrated;",
+              "  return true;")
+open(p, "w").write(s)
+PY
+}
+
+m_an_unrecognised_key_is_reported_as_no_key() {
+  py <<'PY'
+p = "src/referral-attribution.ts"
+s = open(p).read()
+s = s.replace("""  if (!agent) return outcome("key_not_recognised");
+  return recordAttribution(agent, referral);""",
+              """  if (!agent) return outcome("no_key");
+  return recordAttribution(agent, referral);""")
+open(p, "w").write(s)
+PY
+}
+
+m_an_unstored_attribution_is_reported_as_recorded() {
+  py <<'PY'
+p = "src/referral-attribution.ts"
+s = open(p).read()
+s = s.replace("""  const persisted = await persistDurableStores();
+  return outcome(persisted.ok ? "attributed" : "not_recorded");""",
+              """  await persistDurableStores();
+  return outcome("attributed");""")
+open(p, "w").write(s)
+PY
+}
+
+m_an_empty_bearer_counts_as_a_credential() {
+  py <<'PY'
+p = "src/referral-attribution.ts"
+s = open(p).read()
+s = s.replace("""  if (typeof authHeader === "string" && authHeader.startsWith("Bearer ") && authHeader.slice(7).trim()) {
+    return true;
+  }""",
+              """  if (typeof authHeader === "string" && authHeader.startsWith("Bearer ")) {
+    return true;
+  }""")
+open(p, "w").write(s)
+PY
+}
+
+m_a_missing_credential_is_reported_as_unrecognised() {
+  py <<'PY'
+p = "src/referral-attribution.ts"
+s = open(p).read()
+s = s.replace("""  if (!hasAuthCredential(headers)) return outcome("no_key");
+  if (!agentRegistryReadable()) return outcome("registry_unavailable");
+  return outcome("key_not_recognised");""",
+              """  if (!agentRegistryReadable()) return outcome("registry_unavailable");
+  return outcome("key_not_recognised");""")
+open(p, "w").write(s)
+PY
+}
+
+m_payouts_are_always_available() {
+  py <<'PY'
+p = "src/x402.ts"
+s = open(p).read()
+s = s.replace("  return transferFn !== defaultTransferFn;",
+              "  return true;")
+open(p, "w").write(s)
+PY
+}
+
+m_payouts_are_never_available() {
+  py <<'PY'
+p = "src/x402.ts"
+s = open(p).read()
+s = s.replace("  return transferFn !== defaultTransferFn;",
+              "  return false;")
+open(p, "w").write(s)
+PY
+}
+
+m_registration_answers_before_the_write_is_durable() {
+  py <<'PY'
+p = "src/serve.ts"
+s = open(p).read()
+s = s.replace("""      if (!(await identityWritePersisted(res))) return;
+      res.writeHead(201, { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*", ...registrationHeaders });""",
+              """      res.writeHead(201, { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*", ...registrationHeaders });""")
+open(p, "w").write(s)
+PY
+}
+
+m_the_stats_endpoint_stops_reporting_storage() {
+  py <<'PY'
+p = "src/serve.ts"
+s = open(p).read()
+s = s.replace("    res.end(JSON.stringify({ ...getConnectionStats(sessions.size), identity_storage: identityStorageReport() }));",
+              "    res.end(JSON.stringify(getConnectionStats(sessions.size)));")
+open(p, "w").write(s)
+PY
+}
+
+m_the_payout_endpoint_drops_its_capability_check() {
+  py <<'PY'
+p = "src/serve.ts"
+s = open(p).read()
+s = s.replace("""    if (!payoutsAvailable()) {
+      res.writeHead(501, { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" });
+      res.end(JSON.stringify({ error: PAYOUTS_UNAVAILABLE_REASON, payouts_available: false }));
+      return;
+    }
+
+""", "")
+open(p, "w").write(s)
+PY
+}
+
+run_mutation "an unread store is written anyway" m_an_unread_store_is_written_anyway
+run_mutation "a failed write is reported as success" m_a_failed_write_is_reported_as_success
+run_mutation "a failed write keeps the unstored records" m_a_failed_write_keeps_the_unstored_records
+run_mutation "a failed read counts as an empty store" m_a_failed_read_counts_as_an_empty_store
+run_mutation "the file is written even with a backend" m_the_file_is_written_even_with_a_backend
+run_mutation "a save is never marked for writing" m_a_save_is_never_marked_for_writing
+run_mutation "every flush spends a write" m_every_flush_spends_a_write
+run_mutation "durability is claimed without reading the backend" m_durability_is_claimed_without_reading_the_backend
+run_mutation "a stored value is ignored in favour of the file" m_a_stored_value_is_ignored_in_favour_of_the_file
+run_mutation "a store reports itself hydrated regardless" m_a_store_reports_itself_hydrated_regardless
+run_mutation "a seeded store is never written back" m_a_seeded_store_is_never_written_back
+run_mutation "a recovered read reports the dropped change as saved" m_a_recovered_read_reports_the_dropped_change_as_saved
+run_mutation "a refused write leaves the records in memory" m_a_refused_write_leaves_the_records_in_memory
+run_mutation "the registry is always readable" m_the_registry_is_always_readable
+run_mutation "an unrecognised key is reported as no key" m_an_unrecognised_key_is_reported_as_no_key
+run_mutation "an unstored attribution is reported as recorded" m_an_unstored_attribution_is_reported_as_recorded
+run_mutation "an empty bearer counts as a credential" m_an_empty_bearer_counts_as_a_credential
+run_mutation "a missing credential is reported as unrecognised" m_a_missing_credential_is_reported_as_unrecognised
+run_mutation "payouts are always available" m_payouts_are_always_available
+run_mutation "payouts are never available" m_payouts_are_never_available
+run_mutation "registration answers before the write is durable" m_registration_answers_before_the_write_is_durable
+run_mutation "the stats endpoint stops reporting storage" m_the_stats_endpoint_stops_reporting_storage
+run_mutation "the payout endpoint drops its capability check" m_the_payout_endpoint_drops_its_capability_check
+
+restore
+npm run build > /dev/null 2>&1
+echo
+echo "killed: $killed  survived: $survived"
+[ "$survived" -eq 0 ]

--- a/src/agents.ts
+++ b/src/agents.ts
@@ -1,39 +1,32 @@
-import fs from "node:fs";
 import path from "node:path";
 import { createHash, randomBytes } from "node:crypto";
 import { fileURLToPath } from "node:url";
 import type { Agent } from "./types.js";
+import { createDurableStore } from "./durable-store.js";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const AGENTS_PATH = path.join(__dirname, "..", "data", "agents.json");
 
-let cachedAgents: Agent[] | null = null;
+const agentStore = createDurableStore<Agent>({
+  name: "agents",
+  property: "agents",
+  filePath: () => AGENTS_PATH,
+});
 
 function loadAgents(): Agent[] {
-  if (cachedAgents) return cachedAgents;
-
-  if (!fs.existsSync(AGENTS_PATH)) {
-    cachedAgents = [];
-    return cachedAgents;
-  }
-
-  try {
-    const raw = fs.readFileSync(AGENTS_PATH, "utf-8");
-    const data = JSON.parse(raw) as { agents?: Agent[] };
-    cachedAgents = Array.isArray(data.agents) ? data.agents : [];
-  } catch {
-    cachedAgents = [];
-  }
-  return cachedAgents;
+  return agentStore.read();
 }
 
 function saveAgents(agents: Agent[]): void {
-  fs.writeFileSync(AGENTS_PATH, JSON.stringify({ agents }, null, 2), "utf-8");
-  cachedAgents = agents;
+  agentStore.save(agents);
 }
 
 export function resetAgentsCache(): void {
-  cachedAgents = null;
+  agentStore.reset();
+}
+
+export function agentRegistryReadable(): boolean {
+  return agentStore.status().hydrated;
 }
 
 export function hashApiKey(key: string): string {
@@ -97,8 +90,7 @@ export function registerAgent(opts: {
     registered_at: new Date().toISOString(),
   };
 
-  agents.push(agent);
-  saveAgents(agents);
+  saveAgents([...agents, agent]);
 
   const result: RegisterResult = { agent };
   if (apiKey) result.api_key = apiKey;
@@ -204,13 +196,12 @@ async function verifyVestauthSignature(
  */
 export function updateAgentX402Address(agentId: string, x402Address: string | null): Agent {
   const agents = loadAgents();
-  const agent = agents.find(a => a.id === agentId);
-  if (!agent) {
+  if (!agents.some(a => a.id === agentId)) {
     throw new Error(`Agent not found: ${agentId}`);
   }
-  agent.x402_address = x402Address;
-  saveAgents(agents);
-  return agent;
+  const next = agents.map(a => (a.id === agentId ? { ...a, x402_address: x402Address } : a));
+  saveAgents(next);
+  return next.find(a => a.id === agentId)!;
 }
 
 /**
@@ -218,13 +209,12 @@ export function updateAgentX402Address(agentId: string, x402Address: string | nu
  */
 export function updateAgentTrustTier(agentId: string, newTier: "new" | "verified" | "trusted"): Agent {
   const agents = loadAgents();
-  const agent = agents.find(a => a.id === agentId);
-  if (!agent) {
+  if (!agents.some(a => a.id === agentId)) {
     throw new Error(`Agent not found: ${agentId}`);
   }
-  agent.trust_tier = newTier;
-  saveAgents(agents);
-  return agent;
+  const next = agents.map(a => (a.id === agentId ? { ...a, trust_tier: newTier } : a));
+  saveAgents(next);
+  return next.find(a => a.id === agentId)!;
 }
 
 export async function validateVestauthUrl(url: string): Promise<{ valid: boolean; error?: string }> {

--- a/src/durable-store.ts
+++ b/src/durable-store.ts
@@ -1,0 +1,250 @@
+import fs from "node:fs";
+
+export interface DurableBackend {
+  get(key: string): Promise<{ ok: boolean; value: unknown; error?: string }>;
+  set(key: string, value: unknown): Promise<{ ok: boolean; error?: string }>;
+}
+
+export type DurableStoreMode = "file" | "durable";
+
+export interface DurableStoreStatus {
+  name: string;
+  mode: DurableStoreMode;
+  hydrated: boolean;
+  seeded_from_file: boolean;
+  unflushed_writes: boolean;
+  last_write_at: string | null;
+  last_write_error: string | null;
+  last_read_error: string | null;
+}
+
+export interface WriteOutcome {
+  ok: boolean;
+  error?: string;
+}
+
+export interface DurableStore<T> {
+  read(): T[];
+  save(next: T[]): void;
+  hydrate(): Promise<void>;
+  flush(): Promise<WriteOutcome>;
+  reset(): void;
+  status(): DurableStoreStatus;
+}
+
+export const DURABLE_KEY_PREFIX = "agentdeals:store:";
+
+let backend: DurableBackend | null = null;
+const registry: DurableStore<unknown>[] = [];
+
+export function configureDurableBackend(next: DurableBackend | null): void {
+  backend = next;
+  for (const store of registry) store.reset();
+}
+
+export function durableBackendConfigured(): boolean {
+  return backend !== null;
+}
+
+export function createDurableStore<T>(opts: {
+  name: string;
+  property: string;
+  filePath: () => string;
+}): DurableStore<T> {
+  const redisKey = `${DURABLE_KEY_PREFIX}${opts.name}`;
+
+  let cache: T[] | null = null;
+  let persisted: string | null = null;
+  let unflushed = false;
+  let hydratedFromBackend = false;
+  let seededFromFile = false;
+  let lastWriteAt: string | null = null;
+  let lastWriteError: string | null = null;
+  let lastReadError: string | null = null;
+  let flushChain: Promise<WriteOutcome> = Promise.resolve({ ok: true });
+
+  function listOf(container: unknown): T[] | null {
+    if (!container || typeof container !== "object") return null;
+    const list = (container as Record<string, unknown>)[opts.property];
+    return Array.isArray(list) ? (list as T[]) : null;
+  }
+
+  function serialize(value: T[]): string {
+    return JSON.stringify({ [opts.property]: value }, null, 2);
+  }
+
+  function readFile(): T[] {
+    const filePath = opts.filePath();
+    if (!fs.existsSync(filePath)) return [];
+    try {
+      return listOf(JSON.parse(fs.readFileSync(filePath, "utf-8"))) ?? [];
+    } catch {
+      return [];
+    }
+  }
+
+  function restoreLastPersisted(): void {
+    unflushed = false;
+    if (persisted === null) {
+      cache = null;
+      return;
+    }
+    try {
+      cache = listOf(JSON.parse(persisted)) ?? [];
+    } catch {
+      cache = [];
+    }
+  }
+
+  function writeFile(next: T[]): void {
+    const body = serialize(next);
+    try {
+      fs.writeFileSync(opts.filePath(), body, "utf-8");
+      persisted = body;
+      lastWriteAt = new Date().toISOString();
+      lastWriteError = null;
+    } catch (err) {
+      lastWriteError = err instanceof Error ? err.message : String(err);
+      restoreLastPersisted();
+    }
+  }
+
+  function read(): T[] {
+    if (cache) return cache;
+    cache = readFile();
+    if (!backend) persisted = serialize(cache);
+    return cache;
+  }
+
+  function save(next: T[]): void {
+    cache = next;
+    if (!backend) {
+      writeFile(next);
+      return;
+    }
+    unflushed = true;
+  }
+
+  async function runFlush(): Promise<WriteOutcome> {
+    if (!backend || !unflushed) return { ok: true };
+    if (!hydratedFromBackend) {
+      await hydrate();
+      lastWriteError = hydratedFromBackend
+        ? `${opts.name} had to be read from durable storage first, so this change was not applied`
+        : `${opts.name} was not read from durable storage, so writing would discard what is stored`;
+      restoreLastPersisted();
+      return { ok: false, error: lastWriteError };
+    }
+    const next = cache ?? [];
+    const body = serialize(next);
+    unflushed = false;
+    const res = await backend.set(redisKey, { [opts.property]: next });
+    if (!res.ok) {
+      lastWriteError = res.error ?? "durable write failed";
+      restoreLastPersisted();
+      return { ok: false, error: lastWriteError };
+    }
+    persisted = body;
+    lastWriteAt = new Date().toISOString();
+    lastWriteError = null;
+    return { ok: true };
+  }
+
+  function flush(): Promise<WriteOutcome> {
+    const run = () => runFlush();
+    flushChain = flushChain.then(run, run);
+    return flushChain;
+  }
+
+  async function hydrate(): Promise<void> {
+    if (!backend) {
+      read();
+      return;
+    }
+    const res = await backend.get(redisKey);
+    if (!res.ok) {
+      lastReadError = res.error ?? "durable read failed";
+      hydratedFromBackend = false;
+      return;
+    }
+    lastReadError = null;
+    hydratedFromBackend = true;
+    const stored = listOf(res.value);
+    if (stored) {
+      cache = stored;
+      persisted = serialize(stored);
+      seededFromFile = false;
+      unflushed = false;
+      return;
+    }
+    const seed = readFile();
+    cache = seed;
+    persisted = null;
+    seededFromFile = true;
+    unflushed = seed.length > 0;
+  }
+
+  function reset(): void {
+    cache = null;
+    persisted = null;
+    unflushed = false;
+    hydratedFromBackend = false;
+    seededFromFile = false;
+    lastWriteAt = null;
+    lastWriteError = null;
+    lastReadError = null;
+    flushChain = Promise.resolve({ ok: true });
+  }
+
+  function status(): DurableStoreStatus {
+    return {
+      name: opts.name,
+      mode: backend ? "durable" : "file",
+      hydrated: backend ? hydratedFromBackend : cache !== null,
+      seeded_from_file: seededFromFile,
+      unflushed_writes: unflushed,
+      last_write_at: lastWriteAt,
+      last_write_error: lastWriteError,
+      last_read_error: lastReadError,
+    };
+  }
+
+  const store: DurableStore<T> = { read, save, hydrate, flush, reset, status };
+  registry.push(store as DurableStore<unknown>);
+  return store;
+}
+
+export async function hydrateDurableStores(): Promise<void> {
+  for (const store of registry) await store.hydrate();
+}
+
+export async function persistDurableStores(): Promise<WriteOutcome> {
+  let failure: WriteOutcome | null = null;
+  for (const store of registry) {
+    const res = await store.flush();
+    if (!res.ok && !failure) failure = res;
+  }
+  return failure ?? { ok: true };
+}
+
+export function durableStoreStatuses(): DurableStoreStatus[] {
+  return registry.map(store => store.status());
+}
+
+export interface IdentityStorageReport {
+  durable: boolean;
+  backend: "redis" | "container_filesystem";
+  survives_deploy: boolean;
+  stores: DurableStoreStatus[];
+}
+
+export function identityStorageReport(): IdentityStorageReport {
+  const stores = durableStoreStatuses();
+  const durable = backend !== null && stores.every(s => s.hydrated);
+  return {
+    durable,
+    backend: backend ? "redis" : "container_filesystem",
+    survives_deploy: durable,
+    stores,
+  };
+}

--- a/src/friends.ts
+++ b/src/friends.ts
@@ -1,6 +1,6 @@
-import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import { createDurableStore } from "./durable-store.js";
 import { getAgentById } from "./agents.js";
 import { getActiveCodesForVendor, getAllActiveCodes, calculateCodeScore, type SubmittedReferralCode } from "./referral-codes.js";
 
@@ -13,33 +13,22 @@ export interface AgentFriendship {
   created_at: string;
 }
 
-let cachedFriends: AgentFriendship[] | null = null;
+const friendStore = createDurableStore<AgentFriendship>({
+  name: "agent_friends",
+  property: "agent_friends",
+  filePath: () => FRIENDS_PATH,
+});
 
 function loadFriends(): AgentFriendship[] {
-  if (cachedFriends) return cachedFriends;
-
-  if (!fs.existsSync(FRIENDS_PATH)) {
-    cachedFriends = [];
-    return cachedFriends;
-  }
-
-  try {
-    const raw = fs.readFileSync(FRIENDS_PATH, "utf-8");
-    const data = JSON.parse(raw) as { agent_friends?: AgentFriendship[] };
-    cachedFriends = Array.isArray(data.agent_friends) ? data.agent_friends : [];
-  } catch {
-    cachedFriends = [];
-  }
-  return cachedFriends;
+  return friendStore.read();
 }
 
 function saveFriends(friends: AgentFriendship[]): void {
-  fs.writeFileSync(FRIENDS_PATH, JSON.stringify({ agent_friends: friends }, null, 2), "utf-8");
-  cachedFriends = friends;
+  friendStore.save(friends);
 }
 
 export function resetFriendsCache(): void {
-  cachedFriends = null;
+  friendStore.reset();
 }
 
 const MAX_FRIENDS = 100;

--- a/src/ledger.ts
+++ b/src/ledger.ts
@@ -5,6 +5,7 @@ import { fileURLToPath } from "node:url";
 import { attributeConversion, markConversion, getRequestsByAgent } from "./referral-requests.js";
 import { updateAgentTrustTier, getAgentById } from "./agents.js";
 import { calculateTrustTier, getCodesByAgent } from "./referral-codes.js";
+import { createDurableStore } from "./durable-store.js";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const LEDGER_PATH = path.join(__dirname, "..", "data", "ledger_entries.json");
@@ -58,52 +59,36 @@ export interface VendorClawbackConfig {
 }
 
 // --- Caches ---
-let cachedLedger: LedgerEntry[] | null = null;
-let cachedBalances: AgentBalance[] | null = null;
 let cachedClawbackConfig: VendorClawbackConfig[] | null = null;
+
+const ledgerStore = createDurableStore<LedgerEntry>({
+  name: "ledger_entries",
+  property: "ledger_entries",
+  filePath: () => LEDGER_PATH,
+});
+
+const balanceStore = createDurableStore<AgentBalance>({
+  name: "agent_balances",
+  property: "agent_balances",
+  filePath: () => BALANCES_PATH,
+});
 
 // --- Load/Save helpers ---
 
 function loadLedger(): LedgerEntry[] {
-  if (cachedLedger) return cachedLedger;
-  if (!fs.existsSync(LEDGER_PATH)) {
-    cachedLedger = [];
-    return cachedLedger;
-  }
-  try {
-    const raw = fs.readFileSync(LEDGER_PATH, "utf-8");
-    const data = JSON.parse(raw) as { ledger_entries?: LedgerEntry[] };
-    cachedLedger = Array.isArray(data.ledger_entries) ? data.ledger_entries : [];
-  } catch {
-    cachedLedger = [];
-  }
-  return cachedLedger;
+  return ledgerStore.read();
 }
 
 function saveLedger(entries: LedgerEntry[]): void {
-  fs.writeFileSync(LEDGER_PATH, JSON.stringify({ ledger_entries: entries }, null, 2), "utf-8");
-  cachedLedger = entries;
+  ledgerStore.save(entries);
 }
 
 function loadBalances(): AgentBalance[] {
-  if (cachedBalances) return cachedBalances;
-  if (!fs.existsSync(BALANCES_PATH)) {
-    cachedBalances = [];
-    return cachedBalances;
-  }
-  try {
-    const raw = fs.readFileSync(BALANCES_PATH, "utf-8");
-    const data = JSON.parse(raw) as { agent_balances?: AgentBalance[] };
-    cachedBalances = Array.isArray(data.agent_balances) ? data.agent_balances : [];
-  } catch {
-    cachedBalances = [];
-  }
-  return cachedBalances;
+  return balanceStore.read();
 }
 
 function saveBalances(balances: AgentBalance[]): void {
-  fs.writeFileSync(BALANCES_PATH, JSON.stringify({ agent_balances: balances }, null, 2), "utf-8");
-  cachedBalances = balances;
+  balanceStore.save(balances);
 }
 
 function loadClawbackConfig(): VendorClawbackConfig[] {
@@ -123,8 +108,8 @@ function loadClawbackConfig(): VendorClawbackConfig[] {
 }
 
 export function resetLedgerCache(): void {
-  cachedLedger = null;
-  cachedBalances = null;
+  ledgerStore.reset();
+  balanceStore.reset();
   cachedClawbackConfig = null;
 }
 

--- a/src/referral-attribution.ts
+++ b/src/referral-attribution.ts
@@ -1,0 +1,80 @@
+import { agentRegistryReadable, getAgentByApiKeyHash, hashApiKey } from "./agents.js";
+import { logReferralRequest } from "./referral-requests.js";
+import { persistDurableStores } from "./durable-store.js";
+import type { Agent } from "./types.js";
+
+export type AttributionStatus =
+  | "attributed"
+  | "no_key"
+  | "key_not_recognised"
+  | "registry_unavailable"
+  | "not_recorded";
+
+export interface AttributionOutcome {
+  status: AttributionStatus;
+  note: string;
+}
+
+export interface AttributableReferral {
+  vendor: string;
+  referral: { code?: string | null; url: string };
+}
+
+export const ATTRIBUTION_NOTES: Record<AttributionStatus, string> = {
+  attributed: "Recorded for attribution against your agent.",
+  no_key: "No API key was supplied, so this request was not attributed to any agent.",
+  key_not_recognised:
+    "This API key is not in the agent registry, so nothing was attributed. Register again with register_agent to get a key that resolves.",
+  registry_unavailable:
+    "The agent registry could not be read, so this request was not attributed. Your key may still be valid — retry later.",
+  not_recorded:
+    "Your key was recognised, but the attribution could not be stored, so no credit will be recorded for this request.",
+};
+
+function outcome(status: AttributionStatus): AttributionOutcome {
+  return { status, note: ATTRIBUTION_NOTES[status] };
+}
+
+export function hasAuthCredential(headers: Record<string, string | string[] | undefined>): boolean {
+  const authHeader = headers["authorization"];
+  if (typeof authHeader === "string" && authHeader.startsWith("Bearer ") && authHeader.slice(7).trim()) {
+    return true;
+  }
+  return typeof headers["signature"] === "string" && typeof headers["signature-input"] === "string";
+}
+
+export async function recordAttribution(
+  agent: Agent,
+  referral: AttributableReferral,
+): Promise<AttributionOutcome> {
+  logReferralRequest({
+    agent_id: agent.id,
+    vendor: referral.vendor,
+    referral_code: referral.referral.code ?? "",
+    referral_url: referral.referral.url,
+  });
+  const persisted = await persistDurableStores();
+  return outcome(persisted.ok ? "attributed" : "not_recorded");
+}
+
+export async function attributeByApiKey(
+  apiKey: string | undefined,
+  referral: AttributableReferral,
+): Promise<AttributionOutcome> {
+  if (!apiKey) return outcome("no_key");
+  if (!agentRegistryReadable()) return outcome("registry_unavailable");
+  const agent = getAgentByApiKeyHash(hashApiKey(apiKey));
+  if (!agent) return outcome("key_not_recognised");
+  return recordAttribution(agent, referral);
+}
+
+export async function attributeAuthenticatedRequest(
+  agent: Agent | null,
+  headers: Record<string, string | string[] | undefined>,
+  referral: AttributableReferral,
+): Promise<AttributionOutcome> {
+  if (agent) return recordAttribution(agent, referral);
+  if (!hasAuthCredential(headers)) return outcome("no_key");
+  if (!agentRegistryReadable()) return outcome("registry_unavailable");
+  return outcome("key_not_recognised");
+}

--- a/src/referral-codes.ts
+++ b/src/referral-codes.ts
@@ -1,7 +1,7 @@
-import fs from "node:fs";
 import path from "node:path";
 import { randomBytes } from "node:crypto";
 import { fileURLToPath } from "node:url";
+import { createDurableStore } from "./durable-store.js";
 import { getAgentById } from "./agents.js";
 import { loadOffers } from "./data.js";
 
@@ -30,33 +30,22 @@ export interface SubmittedReferralCode {
   updated_at: string;
 }
 
-let cachedCodes: SubmittedReferralCode[] | null = null;
+const codeStore = createDurableStore<SubmittedReferralCode>({
+  name: "referral_codes",
+  property: "referral_codes",
+  filePath: () => CODES_PATH,
+});
 
 function loadCodes(): SubmittedReferralCode[] {
-  if (cachedCodes) return cachedCodes;
-
-  if (!fs.existsSync(CODES_PATH)) {
-    cachedCodes = [];
-    return cachedCodes;
-  }
-
-  try {
-    const raw = fs.readFileSync(CODES_PATH, "utf-8");
-    const data = JSON.parse(raw) as { referral_codes?: SubmittedReferralCode[] };
-    cachedCodes = Array.isArray(data.referral_codes) ? data.referral_codes : [];
-  } catch {
-    cachedCodes = [];
-  }
-  return cachedCodes;
+  return codeStore.read();
 }
 
 function saveCodes(codes: SubmittedReferralCode[]): void {
-  fs.writeFileSync(CODES_PATH, JSON.stringify({ referral_codes: codes }, null, 2), "utf-8");
-  cachedCodes = codes;
+  codeStore.save(codes);
 }
 
 export function resetReferralCodesCache(): void {
-  cachedCodes = null;
+  codeStore.reset();
 }
 
 function generateCodeId(): string {

--- a/src/referral-requests.ts
+++ b/src/referral-requests.ts
@@ -1,7 +1,7 @@
-import fs from "node:fs";
 import path from "node:path";
 import { randomBytes } from "node:crypto";
 import { fileURLToPath } from "node:url";
+import { createDurableStore } from "./durable-store.js";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const REQUESTS_PATH =
@@ -18,33 +18,22 @@ export interface ReferralRequest {
   conversion_id: string | null;
 }
 
-let cachedRequests: ReferralRequest[] | null = null;
+const requestStore = createDurableStore<ReferralRequest>({
+  name: "referral_requests",
+  property: "referral_requests",
+  filePath: () => REQUESTS_PATH,
+});
 
 function loadRequests(): ReferralRequest[] {
-  if (cachedRequests) return cachedRequests;
-
-  if (!fs.existsSync(REQUESTS_PATH)) {
-    cachedRequests = [];
-    return cachedRequests;
-  }
-
-  try {
-    const raw = fs.readFileSync(REQUESTS_PATH, "utf-8");
-    const data = JSON.parse(raw) as { referral_requests?: ReferralRequest[] };
-    cachedRequests = Array.isArray(data.referral_requests) ? data.referral_requests : [];
-  } catch {
-    cachedRequests = [];
-  }
-  return cachedRequests;
+  return requestStore.read();
 }
 
 function saveRequests(requests: ReferralRequest[]): void {
-  fs.writeFileSync(REQUESTS_PATH, JSON.stringify({ referral_requests: requests }, null, 2), "utf-8");
-  cachedRequests = requests;
+  requestStore.save(requests);
 }
 
 export function resetReferralRequestsCache(): void {
-  cachedRequests = null;
+  requestStore.reset();
 }
 
 function generateRequestId(): string {
@@ -70,8 +59,7 @@ export function logReferralRequest(opts: {
     requested_at: new Date().toISOString(),
     conversion_id: null,
   };
-  requests.push(request);
-  saveRequests(requests);
+  saveRequests([...requests, request]);
   return request;
 }
 
@@ -122,9 +110,7 @@ export function getRequestById(id: string): ReferralRequest | null {
  */
 export function markConversion(requestId: string, conversionId: string): boolean {
   const requests = loadRequests();
-  const request = requests.find(r => r.id === requestId);
-  if (!request) return false;
-  request.conversion_id = conversionId;
-  saveRequests(requests);
+  if (!requests.some(r => r.id === requestId)) return false;
+  saveRequests(requests.map(r => (r.id === requestId ? { ...r, conversion_id: conversionId } : r)));
   return true;
 }

--- a/src/serve.ts
+++ b/src/serve.ts
@@ -11,7 +11,7 @@ import { estimateCosts } from "./costs.js";
 import { classifyRequest } from "./client-class.js";
 import { acceptSignal, ackMissing, checkRateLimit, clientAddress, RATE_LIMIT_PER_MINUTE, SIGNAL_ACK_PARAM, SIGNAL_BODY_MAX, SIGNAL_DOC_PATH, SIGNAL_PATH, type SignalInput } from "./signal.js";
 import { agentBlock, DEFERENCE, signalExampleSlug, signalHeaderValue, signalHtmlBlock, signalLlmsSection, SIGNAL_HEADER_NAME } from "./signal-copy.js";
-import { recordApiHit, recordSessionConnect, recordSessionDisconnect, recordLandingPageView, getStats, getConnectionStats, loadTelemetry, flushTelemetry, flushPending, FLUSH_INTERVAL_SECONDS, logRequest, getPublicRequestLogResult, getTelemetryHealth, recordPageView, getPageViews, recordReferralListingCall, recordReferralVendorLookup, getReferralMarketplaceStats, getSessionClassification, recordSearchQuery, getSearchAnalytics, getApiHitsByEndpoint, recordTraffic, getTrafficReport, getSignalReport, publicSignalReport, getRollupDaySource, getRollupDatesAvailable, setDurableRollupCoverage, redisJsonGet, redisJsonMget, redisJsonSet } from "./stats.js";
+import { recordApiHit, recordSessionConnect, recordSessionDisconnect, recordLandingPageView, getStats, getConnectionStats, loadTelemetry, flushTelemetry, flushPending, FLUSH_INTERVAL_SECONDS, logRequest, getPublicRequestLogResult, getTelemetryHealth, recordPageView, getPageViews, recordReferralListingCall, recordReferralVendorLookup, getReferralMarketplaceStats, getSessionClassification, recordSearchQuery, getSearchAnalytics, getApiHitsByEndpoint, recordTraffic, getTrafficReport, getSignalReport, publicSignalReport, getRollupDaySource, getRollupDatesAvailable, setDurableRollupCoverage, redisJsonGet, redisJsonMget, redisJsonSet, redisJsonSetWithoutExpiry, useRedis } from "./stats.js";
 import { buildDailyRollup, readRollups, coverageOf, ROLLUP_DATE_PATTERN } from "./analytics-rollup.js";
 import { configureVendorSeries, recordVendorRequest, flushVendorSeries, readVendorSeries, vendorSeriesGauge, vendorExportAuthorized, isSeriesDate, seriesDateRange, VENDOR_SERIES_PATH, VENDOR_SERIES_RETENTION_DAYS, VENDOR_SERIES_NOTES } from "./vendor-series.js";
 import { openapiSpec } from "./openapi.js";
@@ -22,15 +22,16 @@ import { stabilityFaqAnswer, stabilityVerdictClause, type ComparisonSide, type S
 import { publishedVendorLevel, vendorVerdictSentence, narrowingSentence, changeKindNoun, DEMOTING_KINDS_PHRASE, type VendorVerdictInput } from "./vendor-verdict.js";
 import { growthLimitPhrases } from "./growth-limits.js";
 import { registerAgent, authenticateRequest, validateVestauthUrl, hashApiKey, updateAgentX402Address, getAgentById } from "./agents.js";
-import { logReferralRequest } from "./referral-requests.js";
+import { attributeAuthenticatedRequest } from "./referral-attribution.js";
 import { recordConversion, confirmEligibleEntries, clawbackEntry, getAgentBalance, getAgentLedgerEntries, recordPayout, MAX_COMMISSION_AMOUNT, MINIMUM_PAYOUT_AMOUNT, getLeaderboard } from "./ledger.js";
 import { PLATFORM_CREDENTIAL_REQUIRED, authorizedAsPlatform } from "./platform-auth.js";
 import { createRegistrationLimiter, rateLimitHeaders } from "./rate-limit.js";
-import { validateX402Address, executeTransfer, generateCorrelationId } from "./x402.js";
+import { validateX402Address, executeTransfer, generateCorrelationId, payoutsAvailable, PAYOUTS_UNAVAILABLE_REASON } from "./x402.js";
 import { submitReferralCode, getCodesByAgent, getCodeById, updateCode, revokeCode, calculateTrustTier, getDailySubmissionCount, getDailyLimit, getRankedCodesForVendor, calculateCodeScore } from "./referral-codes.js";
 import { getBestReferralCode, listAllReferralCodes } from "./platform-codes.js";
 import { REFERRAL_CONDITIONS_HEADING, allOurReferralLinks, hasAnyReferralSurface, heldReferralLinkForVendor, ourReferralLinkFor, referralLinkCountClause, referrerDisclosureSentence } from "./referral-surfaces.js";
 import { runHealthCheck, getLastReport, startPeriodicChecks } from "./referral-health.js";
+import { configureDurableBackend, hydrateDurableStores, persistDurableStores, identityStorageReport } from "./durable-store.js";
 import { addFriend, removeFriend, getFriends, getFriendCodesForVendors } from "./friends.js";
 import { subscribe as watchlistSubscribe, getSubscription as getWatchlistSubscription, unsubscribe as watchlistUnsubscribe, listSubscriptions as listWatchlistSubscriptions } from "./watchlist.js";
 import { toSlug, vendorSlugMap, resolveVendorSlug, namedVendorSlug } from "./vendor-slug.js";
@@ -388,6 +389,25 @@ setInterval(() => {
 // Load cumulative telemetry from Redis or disk (survives deploys)
 const telemetryFile = join(__dirname, "..", "data", "telemetry.json");
 await loadTelemetry(telemetryFile);
+
+if (useRedis()) {
+  configureDurableBackend({
+    get: (key) => redisJsonGet(key).then(r => ({ ok: r.ok, value: r.value, error: r.error })),
+    set: (key, value) => redisJsonSetWithoutExpiry(key, value),
+  });
+}
+await hydrateDurableStores();
+
+async function identityWritePersisted(res: import("node:http").ServerResponse): Promise<boolean> {
+  const outcome = await persistDurableStores();
+  if (outcome.ok) return true;
+  res.writeHead(503, { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" });
+  res.end(JSON.stringify({
+    error: "Durable storage is unavailable, so this change was not saved and has been discarded. Retry later.",
+    detail: outcome.error ?? null,
+  }));
+  return false;
+}
 
 const rollupDir = process.env.AGENTDEALS_ROLLUP_DIR ?? join(__dirname, "..", "data", "analytics");
 const durableRollups = readRollups(rollupDir);
@@ -51415,7 +51435,7 @@ ${globalNavCss()}
     <div class="step"><div class="step-num">1</div><h3>Register</h3><p>Create an agent identity with an API key</p></div>
     <div class="step"><div class="step-num">2</div><h3>Submit Codes</h3><p>Add referral codes for any vendor in our index</p></div>
     <div class="step"><div class="step-num">3</div><h3>Codes Get Ranked</h3><p>Trust + performance + recency determines visibility</p></div>
-    <div class="step"><div class="step-num">4</div><h3>Earn Revenue</h3><p>Get paid when your codes convert via x402</p></div>
+    <div class="step"><div class="step-num">4</div><h3>Earn Revenue</h3><p>${payoutsAvailable() ? "Get paid when your codes convert via x402" : "Accrue credit when your codes convert. Withdrawal is not enabled yet."}</p></div>
   </div>
 
   <div class="section">
@@ -51473,7 +51493,7 @@ ${globalNavCss()}
     <p>View your codes, earnings, and leaderboard rank at <a href="/agents/dashboard">/agents/dashboard</a> (requires API key).</p>
 
     <h3>4. Get paid</h3>
-    <p>Set your x402 address and request payouts when your confirmed balance reaches $10:</p>
+    <p>${payoutsAvailable() ? "Set your x402 address and request payouts when your confirmed balance reaches $10:" : "Payouts are not enabled yet &mdash; no transfer provider is configured, so no confirmed credit can be withdrawn today. Credit accrues and is reported by <code>check_balance</code>. You can register the address now:"}</p>
     <div class="code-block">curl -X PATCH ${escHtmlServer(BASE_URL)}/api/agents/me \\
   -H "Authorization: Bearer YOUR_API_KEY" \\
   -H "Content-Type: application/json" \\
@@ -51645,7 +51665,7 @@ ${sortedCodes.map(c => {
   <h2>Quick Actions</h2>
   <div class="actions">
 ${!agent.x402_address ? '    <a href="/marketplace#getting-started" class="action-btn primary">Set x402 Address</a>' : ""}
-${(balance?.confirmed_balance ?? 0) >= 10 ? `    <a href="/developers" class="action-btn primary">Request Payout ($${balance!.confirmed_balance.toFixed(2)} available)</a>` : ""}
+${payoutsAvailable() && (balance?.confirmed_balance ?? 0) >= 10 ? `    <a href="/developers" class="action-btn primary">Request Payout ($${balance!.confirmed_balance.toFixed(2)} available)</a>` : ""}
     <a href="/marketplace#getting-started" class="action-btn">Submit a Code</a>
     <a href="/api/leaderboard" class="action-btn">View Leaderboard</a>
     <a href="/marketplace" class="action-btn">Marketplace Info</a>
@@ -54093,7 +54113,7 @@ const httpServer = createHttpServer(async (req, res) => {
     res.end(JSON.stringify(openapiSpec));
   } else if (url.pathname === "/api/stats" && isGetOrHead) {
     res.writeHead(200, { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" });
-    res.end(JSON.stringify(getConnectionStats(sessions.size)));
+    res.end(JSON.stringify({ ...getConnectionStats(sessions.size), identity_storage: identityStorageReport() }));
   } else if (url.pathname === "/api/pageviews" && isGetOrHead) {
     const data = await getPageViews();
     res.writeHead(200, { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" });
@@ -55939,6 +55959,7 @@ ${catList}
 
       recordApiHit("/api/agents/register");
       logRequest({ ts: new Date().toISOString(), type: "api", endpoint: "/api/agents/register", params: { name: parsed.name }, user_agent: req.headers["user-agent"] ?? "unknown", result_count: 1 });
+      if (!(await identityWritePersisted(res))) return;
       res.writeHead(201, { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*", ...registrationHeaders });
       res.end(JSON.stringify(responseBody));
     } catch (err: any) {
@@ -55985,16 +56006,8 @@ ${catList}
       return;
     }
 
-    // If authenticated, log the attribution request
     const agent = await authenticateRequest(req as any);
-    if (agent) {
-      logReferralRequest({
-        agent_id: agent.id,
-        vendor: referralData.vendor,
-        referral_code: referralData.referral.code ?? "",
-        referral_url: referralData.referral.url,
-      });
-    }
+    const attribution = await attributeAuthenticatedRequest(agent, req.headers, referralData);
 
     recordApiHit("/api/referral/:vendor");
     logRequest({ ts: new Date().toISOString(), type: "api", endpoint: `/api/referral/${vendor}`, params: { authenticated: !!agent }, user_agent: req.headers["user-agent"] ?? "unknown", result_count: 1 });
@@ -56005,7 +56018,9 @@ ${catList}
       referral_url: referralData.referral.url,
       referee_value: referralData.referral.referee_value,
       type: referralData.referral.type,
-      attributed: !!agent,
+      attributed: attribution.status === "attributed",
+      attribution: attribution.status,
+      attribution_note: attribution.note,
     }));
 
   // --- POST /api/conversions: Record a new conversion ---
@@ -56061,6 +56076,7 @@ ${catList}
 
       recordApiHit("/api/conversions");
       logRequest({ ts: new Date().toISOString(), type: "api", endpoint: "/api/conversions", params: { vendor: parsed.vendor }, user_agent: req.headers["user-agent"] ?? "unknown", result_count: 1 });
+      if (!(await identityWritePersisted(res))) return;
       res.writeHead(201, { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" });
       res.end(JSON.stringify(entry));
     } catch (err: any) {
@@ -56099,7 +56115,13 @@ ${catList}
     recordApiHit("/api/agents/:id/balance");
     logRequest({ ts: new Date().toISOString(), type: "api", endpoint: `/api/agents/${agentId}/balance`, params: {}, user_agent: req.headers["user-agent"] ?? "unknown", result_count: 1 });
     res.writeHead(200, { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" });
-    res.end(JSON.stringify(summary));
+    res.end(JSON.stringify({
+      ...summary,
+      payouts_available: payoutsAvailable(),
+      payout_note: payoutsAvailable()
+        ? "Confirmed balance can be withdrawn with POST /api/agents/:id/payout."
+        : PAYOUTS_UNAVAILABLE_REASON,
+    }));
 
   // --- POST /api/conversions/confirm: Confirm eligible entries ---
   } else if (url.pathname === "/api/conversions/confirm" && req.method === "POST") {
@@ -56113,6 +56135,7 @@ ${catList}
       const confirmed = confirmEligibleEntries();
       recordApiHit("/api/conversions/confirm");
       logRequest({ ts: new Date().toISOString(), type: "api", endpoint: "/api/conversions/confirm", params: {}, user_agent: req.headers["user-agent"] ?? "unknown", result_count: confirmed.length });
+      if (!(await identityWritePersisted(res))) return;
       res.writeHead(200, { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" });
       res.end(JSON.stringify({ confirmed_count: confirmed.length, confirmed_ids: confirmed }));
     } catch (err: any) {
@@ -56156,6 +56179,7 @@ ${catList}
 
     recordApiHit("/api/conversions/clawback");
     logRequest({ ts: new Date().toISOString(), type: "api", endpoint: "/api/conversions/clawback", params: { entry_id: parsed.entry_id }, user_agent: req.headers["user-agent"] ?? "unknown", result_count: 1 });
+    if (!(await identityWritePersisted(res))) return;
     res.writeHead(200, { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" });
     res.end(JSON.stringify({ success: true, entry_id: parsed.entry_id }));
 
@@ -56194,6 +56218,7 @@ ${catList}
         const updated = updateAgentX402Address(agent.id, parsed.x402_address);
         recordApiHit("/api/agents/me");
         logRequest({ ts: new Date().toISOString(), type: "api", endpoint: "PATCH /api/agents/me", params: { x402_address: !!parsed.x402_address }, user_agent: req.headers["user-agent"] ?? "unknown", result_count: 1 });
+        if (!(await identityWritePersisted(res))) return;
         res.writeHead(200, { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" });
         res.end(JSON.stringify({
           id: updated.id,
@@ -56227,6 +56252,12 @@ ${catList}
     if (agent.id !== agentId) {
       res.writeHead(403, { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" });
       res.end(JSON.stringify({ error: "You can only request payout for your own account" }));
+      return;
+    }
+
+    if (!payoutsAvailable()) {
+      res.writeHead(501, { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" });
+      res.end(JSON.stringify({ error: PAYOUTS_UNAVAILABLE_REASON, payouts_available: false }));
       return;
     }
 
@@ -56288,6 +56319,7 @@ ${catList}
 
       recordApiHit("/api/agents/:id/payout");
       logRequest({ ts: new Date().toISOString(), type: "api", endpoint: `/api/agents/${agentId}/payout`, params: { correlation_id: correlationId, amount: confirmedBalance, status: "success" }, user_agent: req.headers["user-agent"] ?? "unknown", result_count: 1 });
+      if (!(await identityWritePersisted(res))) return;
       res.writeHead(200, { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" });
       res.end(JSON.stringify({
         success: true,
@@ -56397,6 +56429,7 @@ ${catList}
 
       recordApiHit("/api/referral-codes");
       logRequest({ ts: new Date().toISOString(), type: "api", endpoint: "POST /api/referral-codes", params: { vendor: parsed.vendor, status: code.status }, user_agent: req.headers["user-agent"] ?? "unknown", result_count: 1 });
+      if (!(await identityWritePersisted(res))) return;
       res.writeHead(201, { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" });
       res.end(JSON.stringify(code));
     } catch (err: any) {
@@ -56490,6 +56523,7 @@ ${catList}
 
       recordApiHit("/api/referral-codes/:id");
       logRequest({ ts: new Date().toISOString(), type: "api", endpoint: `PUT /api/referral-codes/${codeId}`, params: {}, user_agent: req.headers["user-agent"] ?? "unknown", result_count: 1 });
+      if (!(await identityWritePersisted(res))) return;
       res.writeHead(200, { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" });
       res.end(JSON.stringify(updated));
     } catch (err: any) {
@@ -56514,6 +56548,7 @@ ${catList}
 
       recordApiHit("/api/referral-codes/:id");
       logRequest({ ts: new Date().toISOString(), type: "api", endpoint: `DELETE /api/referral-codes/${codeId}`, params: {}, user_agent: req.headers["user-agent"] ?? "unknown", result_count: 1 });
+      if (!(await identityWritePersisted(res))) return;
       res.writeHead(200, { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" });
       res.end(JSON.stringify(revoked));
     } catch (err: any) {
@@ -56554,6 +56589,7 @@ ${catList}
       const friendship = addFriend(agent.id, parsed.agent_id);
       recordApiHit("/api/friends");
       logRequest({ ts: new Date().toISOString(), type: "api", endpoint: "POST /api/friends", params: { friend_id: parsed.agent_id }, user_agent: req.headers["user-agent"] ?? "unknown", result_count: 1 });
+      if (!(await identityWritePersisted(res))) return;
       res.writeHead(201, { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" });
       res.end(JSON.stringify(friendship));
     } catch (err: any) {
@@ -56576,6 +56612,7 @@ ${catList}
       removeFriend(agent.id, friendId);
       recordApiHit("/api/friends/:agent_id");
       logRequest({ ts: new Date().toISOString(), type: "api", endpoint: "DELETE /api/friends/" + friendId, params: {}, user_agent: req.headers["user-agent"] ?? "unknown", result_count: 1 });
+      if (!(await identityWritePersisted(res))) return;
       res.writeHead(200, { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" });
       res.end(JSON.stringify({ removed: true }));
     } catch (err: any) {
@@ -56687,6 +56724,7 @@ ${catList}
     try {
       const sub = watchlistSubscribe(parsed.vendor, parsed.webhook_url);
       recordApiHit("/api/watchlist");
+      if (!(await identityWritePersisted(res))) return;
       res.writeHead(201, { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" });
       res.end(JSON.stringify({ id: sub.id, vendor: sub.vendor, webhook_url: sub.webhook_url, secret: sub.secret, created_at: sub.created_at }));
     } catch (err: any) {
@@ -56721,6 +56759,7 @@ ${catList}
       res.end(JSON.stringify({ error: "Subscription not found" }));
     } else {
       recordApiHit("/api/watchlist/:id");
+      if (!(await identityWritePersisted(res))) return;
       res.writeHead(200, { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" });
       res.end(JSON.stringify({ ok: true }));
     }
@@ -56907,6 +56946,10 @@ setInterval(() => {
   flushVendorSeries().catch((err) => console.error(`[vendor-series] flush failed: ${err?.message ?? err}`));
 }, FLUSH_INTERVAL_SECONDS * 1000).unref();
 
+setInterval(() => {
+  persistDurableStores().catch((err) => console.error(`[durable-store] flush failed: ${err?.message ?? err}`));
+}, FLUSH_INTERVAL_SECONDS * 1000).unref();
+
 // Flush on graceful shutdown. Buffered counters go first: they exist only in memory, so
 // a missed flush here is the one interval of data this design accepts losing on an
 // *unclean* exit and should never lose on a clean one.
@@ -56917,6 +56960,7 @@ async function onShutdown() {
   try {
     await flushPending();
     await flushVendorSeries(true);
+    await persistDurableStores();
     await flushTelemetry();
   } catch (err: any) {
     console.error(`[telemetry] shutdown flush failed: ${err?.message ?? err}`);

--- a/src/server.ts
+++ b/src/server.ts
@@ -7,11 +7,12 @@ import { getCategories, getDealChanges, getPersonalizedChanges, getNewOffers, ge
 import { toSlug, vendorSlugMap, resolveVendorSlug } from "./vendor-slug.js";
 import { recordToolCall, logRequest, recordSearchQuery } from "./stats.js";
 import { registerAgent, validateVestauthUrl, getAgentByApiKeyHash, hashApiKey, updateAgentX402Address } from "./agents.js";
-import { logReferralRequest } from "./referral-requests.js";
+import { attributeByApiKey } from "./referral-attribution.js";
+import { persistDurableStores } from "./durable-store.js";
 import { getAgentBalance, getAgentLedgerEntries, recordPayout, MINIMUM_PAYOUT_AMOUNT, getLeaderboard } from "./ledger.js";
 import { submitReferralCode, getCodesByAgent, calculateTrustTier, getDailySubmissionCount, getDailyLimit, getRankedCodesForVendor, calculateCodeScore } from "./referral-codes.js";
 import { getBestReferralCode } from "./platform-codes.js";
-import { validateX402Address, executeTransfer, generateCorrelationId } from "./x402.js";
+import { validateX402Address, executeTransfer, generateCorrelationId, payoutsAvailable, PAYOUTS_UNAVAILABLE_REASON } from "./x402.js";
 import { addFriend, removeFriend, getFriends, getFriendCodesForVendors } from "./friends.js";
 import { getStackRecommendation } from "./stacks.js";
 import { estimateCosts } from "./costs.js";
@@ -46,6 +47,24 @@ function toConciseOffer(offer: Offer | EnrichedOffer) {
 
 function toConciseDealChange(change: DealChange) {
   return { vendor: change.vendor, change_type: change.change_type, date: change.date, date_source: change.date_source, summary: change.summary };
+}
+
+interface ToolTextResult {
+  [key: string]: unknown;
+  isError: true;
+  content: { type: "text"; text: string }[];
+}
+
+async function unpersistedWriteResult(): Promise<ToolTextResult | null> {
+  const persisted = await persistDurableStores();
+  if (persisted.ok) return null;
+  return {
+    isError: true,
+    content: [{
+      type: "text" as const,
+      text: `Not saved: durable storage is unavailable, so this change was discarded and nothing was recorded. Retry later.${persisted.error ? ` (${persisted.error})` : ""}`,
+    }],
+  };
 }
 
 export function createServer(getSessionId?: () => string | undefined, getClientName?: () => string | undefined): McpServer {
@@ -1040,6 +1059,9 @@ Suggested monitoring cadence: run this check weekly to catch pricing changes ear
           response.vestauth_public_key_url = result.agent.vestauth_public_key_url;
         }
 
+        const unpersisted = await unpersistedWriteResult();
+        if (unpersisted) return unpersisted;
+
         logRequest({ ts: new Date().toISOString(), type: "mcp", endpoint: "register_agent", params: { name }, result_count: 1, session_id: getSessionId?.() });
 
         return {
@@ -1060,7 +1082,7 @@ Suggested monitoring cadence: run this check weekly to catch pricing changes ear
     "get_referral_code",
     {
       description:
-        "Get the referral code and URL for a specific vendor. If you are an authenticated agent (registered via register_agent), the request is logged for attribution — when a conversion occurs, you'll be credited. Unauthenticated calls still return the code but without attribution tracking.",
+        "Get the referral code and URL for a specific vendor. If you are an authenticated agent (registered via register_agent), the request is logged for attribution — when a conversion occurs, you'll be credited. Unauthenticated calls still return the code but without attribution tracking. The response always states whether attribution happened and, when it did not, why.",
       annotations: {
         readOnlyHint: true,
         destructiveHint: false,
@@ -1082,21 +1104,8 @@ Suggested monitoring cadence: run this check weekly to catch pricing changes ear
           };
         }
 
-        // If API key provided, authenticate and log attribution
-        let attributed = false;
-        if (api_key) {
-          const hash = hashApiKey(api_key);
-          const agent = getAgentByApiKeyHash(hash);
-          if (agent) {
-            logReferralRequest({
-              agent_id: agent.id,
-              vendor: referralData.vendor,
-              referral_code: referralData.referral.code ?? "",
-              referral_url: referralData.referral.url,
-            });
-            attributed = true;
-          }
-        }
+        const outcome = await attributeByApiKey(api_key, referralData);
+        const attributed = outcome.status === "attributed";
 
         const response = {
           vendor: referralData.vendor,
@@ -1105,6 +1114,8 @@ Suggested monitoring cadence: run this check weekly to catch pricing changes ear
           referee_value: referralData.referral.referee_value,
           type: referralData.referral.type,
           attributed,
+          attribution: outcome.status,
+          attribution_note: outcome.note,
         };
 
         logRequest({ ts: new Date().toISOString(), type: "mcp", endpoint: "get_referral_code", params: { vendor, attributed }, result_count: 1, session_id: getSessionId?.() });
@@ -1126,7 +1137,7 @@ Suggested monitoring cadence: run this check weekly to catch pricing changes ear
     "check_balance",
     {
       description:
-        "Check your referral credit balance. Requires authentication via API key (from register_agent). Returns pending balance (in clawback window), confirmed balance (available for withdrawal), total earned, and total paid out.",
+        "Check your referral credit balance. Requires authentication via API key (from register_agent). Returns pending balance (in the clawback window), confirmed balance, total earned, and total paid out, plus whether payouts are currently available. Confirmed credit is not withdrawable while payouts_available is false.",
       annotations: {
         readOnlyHint: true,
         destructiveHint: false,
@@ -1158,10 +1169,19 @@ Suggested monitoring cadence: run this check weekly to catch pricing changes ear
           updated_at: null,
         };
 
+        const payoutsEnabled = payoutsAvailable();
+        const balanceResponse = {
+          ...summary,
+          payouts_available: payoutsEnabled,
+          payout_note: payoutsEnabled
+            ? "Confirmed balance can be withdrawn with request_payout."
+            : PAYOUTS_UNAVAILABLE_REASON,
+        };
+
         logRequest({ ts: new Date().toISOString(), type: "mcp", endpoint: "check_balance", params: { agent_id: agent.id }, result_count: 1, session_id: getSessionId?.() });
 
         return {
-          content: [{ type: "text" as const, text: JSON.stringify(summary, null, 2) }],
+          content: [{ type: "text" as const, text: JSON.stringify(balanceResponse, null, 2) }],
         };
       } catch (err: any) {
         return {
@@ -1177,7 +1197,7 @@ Suggested monitoring cadence: run this check weekly to catch pricing changes ear
     "request_payout",
     {
       description:
-        "Request a payout of your confirmed referral credits via x402 stablecoin transfer. Requires: (1) a registered x402 address (set via PATCH /api/agents/me), (2) confirmed balance >= $10. Full balance is withdrawn — no partial payouts in Phase 2.",
+        "Request a payout of your confirmed referral credits. Payouts are not enabled yet — no transfer provider is configured, so this call reports that and moves no funds. When enabled it will require a registered payout address (set via PATCH /api/agents/me) and a confirmed balance of at least $10, and will withdraw the full balance.",
       annotations: {
         readOnlyHint: false,
         destructiveHint: false,
@@ -1189,6 +1209,13 @@ Suggested monitoring cadence: run this check weekly to catch pricing changes ear
     async ({ api_key }) => {
       try {
         recordToolCall("request_payout", getClientName?.());
+
+        if (!payoutsAvailable()) {
+          return {
+            isError: true,
+            content: [{ type: "text" as const, text: PAYOUTS_UNAVAILABLE_REASON }],
+          };
+        }
 
         const hash = hashApiKey(api_key);
         const agent = getAgentByApiKeyHash(hash);
@@ -1241,6 +1268,9 @@ Suggested monitoring cadence: run this check weekly to catch pricing changes ear
           correlation_id: correlationId,
           metadata: { chain: transferResult.chain, token: transferResult.token },
         });
+
+        const unpersisted = await unpersistedWriteResult();
+        if (unpersisted) return unpersisted;
 
         logRequest({ ts: new Date().toISOString(), type: "mcp", endpoint: "request_payout", params: { agent_id: agent.id, correlation_id: correlationId, amount: confirmedBalance, status: "success" }, result_count: 1, session_id: getSessionId?.() });
 
@@ -1312,6 +1342,9 @@ Suggested monitoring cadence: run this check weekly to catch pricing changes ear
           agent_id: agent.id,
           trust_tier: trustTier,
         });
+
+        const unpersisted = await unpersistedWriteResult();
+        if (unpersisted) return unpersisted;
 
         logRequest({ ts: new Date().toISOString(), type: "mcp", endpoint: "submit_referral_code", params: { vendor, status: submitted.status }, result_count: 1, session_id: getSessionId?.() });
 
@@ -1471,6 +1504,11 @@ Suggested monitoring cadence: run this check weekly to catch pricing changes ear
         } else {
           const codes = getFriendCodesForVendors(agent.id);
           result = { action: "codes", vendors: codes, total_vendors: codes.length };
+        }
+
+        if (action === "add" || action === "remove") {
+          const unpersisted = await unpersistedWriteResult();
+          if (unpersisted) return unpersisted;
         }
 
         logRequest({ ts: new Date().toISOString(), type: "mcp", endpoint: "manage_friends", params: { action, agent_id }, result_count: 1, session_id: getSessionId?.() });

--- a/src/stats.ts
+++ b/src/stats.ts
@@ -1796,6 +1796,11 @@ export async function redisJsonSet(key: string, value: unknown, ttlSeconds: numb
   return res.ok ? { ok: true } : { ok: false, error: res.error };
 }
 
+export async function redisJsonSetWithoutExpiry(key: string, value: unknown): Promise<JsonWriteResult> {
+  const res = await redisCommand<string>(["SET", key, JSON.stringify(value)]);
+  return res.ok ? { ok: true } : { ok: false, error: res.error };
+}
+
 async function redisMget(keys: string[]): Promise<RedisResult<(string | null)[]>> {
   const res = await redisCommand<(string | null)[]>(["MGET", ...keys]);
   if (!res.ok) return res;

--- a/src/watchlist.ts
+++ b/src/watchlist.ts
@@ -1,7 +1,7 @@
-import fs from "node:fs";
 import path from "node:path";
 import crypto from "node:crypto";
 import { fileURLToPath } from "node:url";
+import { createDurableStore } from "./durable-store.js";
 import { loadDealChanges } from "./data.js";
 import type { DealChange } from "./types.js";
 
@@ -24,31 +24,22 @@ interface WatchlistData {
   subscriptions: WatchlistSubscription[];
 }
 
-let cached: WatchlistData | null = null;
+const watchlistStore = createDurableStore<WatchlistSubscription>({
+  name: "watchlist",
+  property: "subscriptions",
+  filePath: () => WATCHLIST_PATH,
+});
 
 function load(): WatchlistData {
-  if (cached) return cached;
-  if (!fs.existsSync(WATCHLIST_PATH)) {
-    cached = { subscriptions: [] };
-    return cached;
-  }
-  try {
-    const raw = fs.readFileSync(WATCHLIST_PATH, "utf-8");
-    cached = JSON.parse(raw) as WatchlistData;
-    if (!Array.isArray(cached!.subscriptions)) cached = { subscriptions: [] };
-  } catch {
-    cached = { subscriptions: [] };
-  }
-  return cached!;
+  return { subscriptions: watchlistStore.read() };
 }
 
 function save(data: WatchlistData): void {
-  fs.writeFileSync(WATCHLIST_PATH, JSON.stringify(data, null, 2), "utf-8");
-  cached = data;
+  watchlistStore.save(data.subscriptions);
 }
 
 export function resetWatchlistCache(): void {
-  cached = null;
+  watchlistStore.reset();
 }
 
 export function subscribe(vendor: string, webhookUrl: string): WatchlistSubscription {

--- a/src/x402.ts
+++ b/src/x402.ts
@@ -70,6 +70,13 @@ async function defaultTransferFn(req: TransferRequest): Promise<TransferResult> 
 
 let transferFn: (req: TransferRequest) => Promise<TransferResult> = defaultTransferFn;
 
+export const PAYOUTS_UNAVAILABLE_REASON =
+  "Payouts are not enabled: no transfer provider is configured, so confirmed credit cannot be withdrawn yet. Credit continues to accrue and check_balance reports it.";
+
+export function payoutsAvailable(): boolean {
+  return transferFn !== defaultTransferFn;
+}
+
 /**
  * Replace the transfer implementation (for testing).
  */

--- a/test/durable-identity.test.ts
+++ b/test/durable-identity.test.ts
@@ -1,0 +1,566 @@
+import { describe, it, before, after, beforeEach } from "node:test";
+import assert from "node:assert";
+import { spawn, type ChildProcess } from "node:child_process";
+import { createServer, type Server } from "node:http";
+import path from "node:path";
+import fs from "node:fs";
+import os from "node:os";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const AGENTS_PATH = path.join(__dirname, "..", "data", "agents.json");
+const REQUESTS_PATH = path.join(__dirname, "..", "data", "referral_requests.json");
+
+const managedPaths: [string, string][] = [
+  [AGENTS_PATH, JSON.stringify({ agents: [] })],
+  [REQUESTS_PATH, JSON.stringify({ referral_requests: [] })],
+];
+const managedOriginals = new Map<string, string | null>();
+
+function holdManagedFiles(): void {
+  for (const [p] of managedPaths) {
+    managedOriginals.set(p, fs.existsSync(p) ? fs.readFileSync(p, "utf-8") : null);
+  }
+  for (const [p, empty] of managedPaths) fs.writeFileSync(p, empty, "utf-8");
+}
+
+function releaseManagedFiles(): void {
+  for (const [p] of managedPaths) {
+    const held = managedOriginals.get(p) ?? null;
+    if (held !== null) fs.writeFileSync(p, held, "utf-8");
+    else if (fs.existsSync(p)) fs.unlinkSync(p);
+  }
+}
+
+holdManagedFiles();
+process.on("exit", releaseManagedFiles);
+
+const {
+  createDurableStore,
+  configureDurableBackend,
+  hydrateDurableStores,
+  persistDurableStores,
+  identityStorageReport,
+  DURABLE_KEY_PREFIX,
+} = await import("../dist/durable-store.js");
+const { registerAgent, getAgentByApiKeyHash, hashApiKey, agentRegistryReadable, resetAgentsCache } =
+  await import("../dist/agents.js");
+const { attributeByApiKey, attributeAuthenticatedRequest, hasAuthCredential, ATTRIBUTION_NOTES } =
+  await import("../dist/referral-attribution.js");
+const { payoutsAvailable, setTransferFn, resetTransferFn, PAYOUTS_UNAVAILABLE_REASON } =
+  await import("../dist/x402.js");
+
+interface StoredRow {
+  id: string;
+  value: string;
+}
+
+function memoryBackend(seed: Record<string, unknown> = {}) {
+  const store = new Map<string, unknown>(Object.entries(seed));
+  const calls: { op: string; key: string }[] = [];
+  let failReads = false;
+  let failWrites = false;
+  return {
+    store,
+    calls,
+    failReads: (on: boolean) => { failReads = on; },
+    failWrites: (on: boolean) => { failWrites = on; },
+    writeCount: () => calls.filter(c => c.op === "set").length,
+    backend: {
+      async get(key: string) {
+        calls.push({ op: "get", key });
+        if (failReads) return { ok: false, value: null, error: "read refused" };
+        return { ok: true, value: store.has(key) ? store.get(key) : null };
+      },
+      async set(key: string, value: unknown) {
+        calls.push({ op: "set", key });
+        if (failWrites) return { ok: false, error: "write refused" };
+        store.set(key, value);
+        return { ok: true };
+      },
+    },
+  };
+}
+
+describe("A store backed by durable storage keeps its records across a process restart", () => {
+  const tmpFile = path.join(os.tmpdir(), `durable-store-${process.pid}.json`);
+
+  after(() => {
+    configureDurableBackend(null);
+    if (fs.existsSync(tmpFile)) fs.unlinkSync(tmpFile);
+  });
+
+  beforeEach(() => {
+    if (fs.existsSync(tmpFile)) fs.unlinkSync(tmpFile);
+  });
+
+  it("writes to the backend and reads the same records back on a fresh hydrate", async () => {
+    const harness = memoryBackend();
+    const store = createDurableStore<StoredRow>({ name: "rows_roundtrip", property: "rows", filePath: () => tmpFile });
+    configureDurableBackend(harness.backend);
+
+    await store.hydrate();
+    store.save([{ id: "a", value: "first" }]);
+    assert.deepStrictEqual(await store.flush(), { ok: true });
+
+    store.reset();
+    await store.hydrate();
+    assert.deepStrictEqual(store.read(), [{ id: "a", value: "first" }]);
+    assert.strictEqual(fs.existsSync(tmpFile), false);
+  });
+
+  it("collapses several saves into a single backend write", async () => {
+    const harness = memoryBackend();
+    const store = createDurableStore<StoredRow>({ name: "rows_collapse", property: "rows", filePath: () => tmpFile });
+    configureDurableBackend(harness.backend);
+
+    await store.hydrate();
+    store.save([{ id: "a", value: "1" }]);
+    store.save([{ id: "a", value: "2" }]);
+    store.save([{ id: "a", value: "3" }]);
+    await store.flush();
+
+    assert.strictEqual(harness.writeCount(), 1);
+    assert.deepStrictEqual(store.read(), [{ id: "a", value: "3" }]);
+  });
+
+  it("costs no backend write when nothing changed", async () => {
+    const harness = memoryBackend();
+    const store = createDurableStore<StoredRow>({ name: "rows_idle", property: "rows", filePath: () => tmpFile });
+    configureDurableBackend(harness.backend);
+
+    await store.hydrate();
+    await store.flush();
+    await store.flush();
+
+    assert.strictEqual(harness.writeCount(), 0);
+  });
+
+  it("seeds an absent key from the committed file and persists the seed on the first flush", async () => {
+    const harness = memoryBackend();
+    fs.writeFileSync(tmpFile, JSON.stringify({ rows: [{ id: "seed", value: "committed" }] }), "utf-8");
+    const store = createDurableStore<StoredRow>({ name: "rows_seed", property: "rows", filePath: () => tmpFile });
+    configureDurableBackend(harness.backend);
+
+    await store.hydrate();
+    assert.deepStrictEqual(store.read(), [{ id: "seed", value: "committed" }]);
+    assert.strictEqual(store.status().seeded_from_file, true);
+
+    await store.flush();
+    assert.deepStrictEqual(harness.store.get(`${DURABLE_KEY_PREFIX}rows_seed`), {
+      rows: [{ id: "seed", value: "committed" }],
+    });
+  });
+
+  it("refuses to write when the backend could not be read, so a failed read cannot erase what is stored", async () => {
+    const harness = memoryBackend({
+      [`${DURABLE_KEY_PREFIX}rows_unread`]: { rows: [{ id: "kept", value: "stored" }] },
+    });
+    const store = createDurableStore<StoredRow>({ name: "rows_unread", property: "rows", filePath: () => tmpFile });
+    configureDurableBackend(harness.backend);
+
+    harness.failReads(true);
+    await store.hydrate();
+    assert.strictEqual(store.status().hydrated, false);
+    assert.strictEqual(store.status().last_read_error, "read refused");
+
+    store.save([{ id: "overwrite", value: "would clobber" }]);
+    const outcome = await store.flush();
+    assert.strictEqual(outcome.ok, false);
+    assert.strictEqual(harness.writeCount(), 0);
+    assert.deepStrictEqual(harness.store.get(`${DURABLE_KEY_PREFIX}rows_unread`), {
+      rows: [{ id: "kept", value: "stored" }],
+    });
+  });
+
+  it("refuses a write whose store it had to read first, rather than reporting a change it dropped", async () => {
+    const harness = memoryBackend({
+      [`${DURABLE_KEY_PREFIX}rows_recovered`]: { rows: [{ id: "stored", value: "already there" }] },
+    });
+    const store = createDurableStore<StoredRow>({ name: "rows_recovered", property: "rows", filePath: () => tmpFile });
+    configureDurableBackend(harness.backend);
+
+    harness.failReads(true);
+    await store.hydrate();
+    assert.strictEqual(store.status().hydrated, false);
+
+    harness.failReads(false);
+    store.save([{ id: "stored", value: "already there" }, { id: "new", value: "added while blind" }]);
+    const refused = await store.flush();
+    assert.strictEqual(refused.ok, false, "a change made against records we had not read must not be reported as saved");
+    assert.deepStrictEqual(store.read(), [{ id: "stored", value: "already there" }]);
+    assert.strictEqual(harness.writeCount(), 0);
+
+    store.save([{ id: "stored", value: "already there" }, { id: "new", value: "added after reading" }]);
+    assert.deepStrictEqual(await store.flush(), { ok: true }, "the retry lands once the store has been read");
+    assert.deepStrictEqual(harness.store.get(`${DURABLE_KEY_PREFIX}rows_recovered`), {
+      rows: [{ id: "stored", value: "already there" }, { id: "new", value: "added after reading" }],
+    });
+  });
+
+  it("reports a failed write and rolls the in-memory records back to what is stored", async () => {
+    const harness = memoryBackend();
+    const store = createDurableStore<StoredRow>({ name: "rows_writefail", property: "rows", filePath: () => tmpFile });
+    configureDurableBackend(harness.backend);
+
+    await store.hydrate();
+    store.save([{ id: "a", value: "durable" }]);
+    await store.flush();
+
+    harness.failWrites(true);
+    store.save([{ id: "a", value: "durable" }, { id: "b", value: "lost" }]);
+    const outcome = await store.flush();
+
+    assert.strictEqual(outcome.ok, false);
+    assert.strictEqual(outcome.error, "write refused");
+    assert.deepStrictEqual(store.read(), [{ id: "a", value: "durable" }]);
+    assert.strictEqual(store.status().last_write_error, "write refused");
+  });
+
+  it("falls back to the file when no backend is configured, and says so", async () => {
+    configureDurableBackend(null);
+    const store = createDurableStore<StoredRow>({ name: "rows_filemode", property: "rows", filePath: () => tmpFile });
+
+    store.save([{ id: "a", value: "on disk" }]);
+    assert.deepStrictEqual(JSON.parse(fs.readFileSync(tmpFile, "utf-8")), { rows: [{ id: "a", value: "on disk" }] });
+
+    const status = store.status();
+    assert.strictEqual(status.mode, "file");
+    assert.deepStrictEqual(await store.flush(), { ok: true });
+  });
+});
+
+describe("The identity storage report distinguishes durable from ephemeral", () => {
+  after(() => configureDurableBackend(null));
+
+  it("reports the container filesystem, and no survival across a deploy, when no backend is configured", async () => {
+    configureDurableBackend(null);
+    await hydrateDurableStores();
+    const report = identityStorageReport();
+    assert.strictEqual(report.durable, false);
+    assert.strictEqual(report.backend, "container_filesystem");
+    assert.strictEqual(report.survives_deploy, false);
+  });
+
+  it("reports durable storage once every store has been read from the backend", async () => {
+    const harness = memoryBackend();
+    configureDurableBackend(harness.backend);
+    await hydrateDurableStores();
+    const report = identityStorageReport();
+    assert.strictEqual(report.durable, true);
+    assert.strictEqual(report.backend, "redis");
+    assert.strictEqual(report.survives_deploy, true);
+    assert.ok(report.stores.length >= 7);
+    assert.ok(report.stores.every((s: { hydrated: boolean }) => s.hydrated));
+  });
+
+  it("stops reporting durable storage when a store could not be read", async () => {
+    const harness = memoryBackend();
+    configureDurableBackend(harness.backend);
+    harness.failReads(true);
+    await hydrateDurableStores();
+    const report = identityStorageReport();
+    assert.strictEqual(report.durable, false);
+    assert.strictEqual(report.backend, "redis");
+    assert.strictEqual(report.survives_deploy, false);
+  });
+});
+
+describe("An unrecognised API key is reported as unrecognised, not silently unattributed", () => {
+  const referral = { vendor: "Railway", referral: { code: "ABC", url: "https://railway.com/?referralCode=ABC" } };
+
+  after(() => {
+    configureDurableBackend(null);
+    resetAgentsCache();
+  });
+
+  it("names the missing key when no key was supplied", async () => {
+    configureDurableBackend(null);
+    const outcome = await attributeByApiKey(undefined, referral);
+    assert.strictEqual(outcome.status, "no_key");
+    assert.strictEqual(outcome.note, ATTRIBUTION_NOTES.no_key);
+  });
+
+  it("names the unrecognised key when the registry is readable and the key is absent", async () => {
+    const harness = memoryBackend();
+    configureDurableBackend(harness.backend);
+    await hydrateDurableStores();
+
+    const outcome = await attributeByApiKey("agd_not_a_real_key", referral);
+    assert.strictEqual(outcome.status, "key_not_recognised");
+    assert.notStrictEqual(outcome.note, ATTRIBUTION_NOTES.no_key);
+  });
+
+  it("distinguishes a registry it could not read from a key that does not exist", async () => {
+    const harness = memoryBackend();
+    configureDurableBackend(harness.backend);
+    harness.failReads(true);
+    await hydrateDurableStores();
+
+    assert.strictEqual(agentRegistryReadable(), false);
+    const outcome = await attributeByApiKey("agd_not_a_real_key", referral);
+    assert.strictEqual(outcome.status, "registry_unavailable");
+  });
+
+  it("reports that a recognised key was not recorded when the attribution write fails", async () => {
+    const harness = memoryBackend();
+    configureDurableBackend(harness.backend);
+    await hydrateDurableStores();
+
+    const registered = registerAgent({ name: `AttributionProbe-${process.pid}` });
+    assert.ok(registered.api_key);
+    assert.deepStrictEqual(await persistDurableStores(), { ok: true });
+
+    harness.failWrites(true);
+    const outcome = await attributeByApiKey(registered.api_key!, referral);
+    assert.strictEqual(outcome.status, "not_recorded");
+  });
+
+  it("records the attribution when the key resolves and the write lands", async () => {
+    const harness = memoryBackend();
+    configureDurableBackend(harness.backend);
+    await hydrateDurableStores();
+
+    const registered = registerAgent({ name: `AttributionProbe2-${process.pid}` });
+    await persistDurableStores();
+
+    const outcome = await attributeByApiKey(registered.api_key!, referral);
+    assert.strictEqual(outcome.status, "attributed");
+    const stored = harness.store.get(`${DURABLE_KEY_PREFIX}referral_requests`) as { referral_requests: unknown[] };
+    assert.strictEqual(stored.referral_requests.length, 1);
+  });
+
+  it("treats a request carrying no credential differently from one carrying a bad credential", async () => {
+    const harness = memoryBackend();
+    configureDurableBackend(harness.backend);
+    await hydrateDurableStores();
+
+    const bare = await attributeAuthenticatedRequest(null, {}, referral);
+    assert.strictEqual(bare.status, "no_key");
+
+    const withKey = await attributeAuthenticatedRequest(null, { authorization: "Bearer agd_nope" }, referral);
+    assert.strictEqual(withKey.status, "key_not_recognised");
+
+    assert.strictEqual(hasAuthCredential({ authorization: "Bearer " }), false);
+    assert.strictEqual(hasAuthCredential({ signature: "s", "signature-input": "i" }), true);
+  });
+});
+
+describe("An API key issued before a restart still authenticates after it", () => {
+  after(() => {
+    configureDurableBackend(null);
+    resetAgentsCache();
+  });
+
+  it("resolves a key that was issued by a previous process", async () => {
+    const harness = memoryBackend();
+    configureDurableBackend(harness.backend);
+    await hydrateDurableStores();
+
+    const registered = registerAgent({ name: `RestartProbe-${process.pid}` });
+    const issuedKey = registered.api_key!;
+    assert.deepStrictEqual(await persistDurableStores(), { ok: true });
+
+    configureDurableBackend(harness.backend);
+    await hydrateDurableStores();
+
+    const resolved = getAgentByApiKeyHash(hashApiKey(issuedKey));
+    assert.ok(resolved, "a key issued before the restart must still resolve");
+    assert.strictEqual(resolved!.id, registered.agent.id);
+
+    const onDisk = JSON.parse(fs.readFileSync(AGENTS_PATH, "utf-8")) as { agents: unknown[] };
+    assert.strictEqual(onDisk.agents.length, 0, "the registration must not have gone to the image's file");
+  });
+});
+
+describe("Payouts are described as unavailable while no transfer provider is installed", () => {
+  after(() => resetTransferFn());
+
+  it("reports no payout capability with the default implementation", () => {
+    resetTransferFn();
+    assert.strictEqual(payoutsAvailable(), false);
+  });
+
+  it("reports payout capability once a transfer implementation is installed", () => {
+    setTransferFn(async (req: { correlation_id: string }) => ({ success: true, correlation_id: req.correlation_id }));
+    assert.strictEqual(payoutsAvailable(), true);
+    resetTransferFn();
+  });
+
+  it("states the reason rather than a balance threshold", () => {
+    assert.match(PAYOUTS_UNAVAILABLE_REASON, /not enabled/i);
+    assert.doesNotMatch(PAYOUTS_UNAVAILABLE_REASON, /available for withdrawal/i);
+  });
+});
+
+function upstashDouble(): Promise<{ server: Server; url: string; keys: Map<string, string> }> {
+  const keys = new Map<string, string>();
+  const lists = new Map<string, string[]>();
+  const server = createServer((req, res) => {
+    let body = "";
+    req.on("data", (chunk) => { body += chunk; });
+    req.on("end", () => {
+      let cmd: (string | number)[];
+      try { cmd = JSON.parse(body); } catch { cmd = []; }
+      const op = String(cmd[0] ?? "").toUpperCase();
+      const key = String(cmd[1] ?? "");
+      let result: unknown = null;
+      if (op === "SET") { keys.set(key, String(cmd[2])); result = "OK"; }
+      else if (op === "GET") { result = keys.has(key) ? keys.get(key) : null; }
+      else if (op === "MGET") { result = cmd.slice(1).map((k) => keys.get(String(k)) ?? null); }
+      else if (op === "INCR") { const n = Number(keys.get(key) ?? "0") + 1; keys.set(key, String(n)); result = n; }
+      else if (op === "INCRBY") { const n = Number(keys.get(key) ?? "0") + Number(cmd[2]); keys.set(key, String(n)); result = n; }
+      else if (op === "LPUSH") { const list = lists.get(key) ?? []; for (const v of cmd.slice(2)) list.unshift(String(v)); lists.set(key, list); result = list.length; }
+      else if (op === "LRANGE") { result = (lists.get(key) ?? []).slice(Number(cmd[2]), Number(cmd[3]) + 1); }
+      else if (op === "LTRIM") { lists.set(key, (lists.get(key) ?? []).slice(Number(cmd[2]), Number(cmd[3]) + 1)); result = "OK"; }
+      else if (op === "DEL") { keys.delete(key); lists.delete(key); result = 1; }
+      else if (op === "EXPIRE") { result = 1; }
+      else if (op === "SCAN") { result = ["0", [...keys.keys()]]; }
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ result }));
+    });
+  });
+  return new Promise((resolve) => {
+    server.listen(0, () => {
+      const port = (server.address() as import("net").AddressInfo).port;
+      resolve({ server, url: `http://127.0.0.1:${port}`, keys });
+    });
+  });
+}
+
+function startAgentDeals(extraEnv: Record<string, string>): Promise<{ proc: ChildProcess; port: number }> {
+  return new Promise((resolve, reject) => {
+    const serverPath = path.join(__dirname, "..", "dist", "serve.js");
+    const proc = spawn("node", [serverPath], {
+      stdio: ["pipe", "pipe", "pipe"],
+      env: { ...process.env, PORT: "0", BASE_URL: "http://localhost", ...extraEnv },
+    });
+    const timeout = setTimeout(() => { proc.kill(); reject(new Error("Server startup timeout")); }, 20000);
+    proc.stderr!.on("data", (data: Buffer) => {
+      const match = data.toString().match(/running on http:\/\/localhost:(\d+)/);
+      if (match) { clearTimeout(timeout); resolve({ proc, port: parseInt(match[1], 10) }); }
+    });
+    proc.on("error", (err) => { clearTimeout(timeout); reject(err); });
+  });
+}
+
+describe("A registration issued by one server process survives into the next one", () => {
+  let redis: { server: Server; url: string; keys: Map<string, string> };
+  let first: ChildProcess | undefined;
+  let second: ChildProcess | undefined;
+
+  before(async () => {
+    redis = await upstashDouble();
+  });
+
+  after(() => {
+    first?.kill();
+    second?.kill();
+    redis?.server.close();
+    resetAgentsCache();
+  });
+
+  it("authenticates the key against a second process that shares only the durable store", async () => {
+    const env = {
+      UPSTASH_REDIS_REST_URL: redis.url,
+      UPSTASH_REDIS_REST_TOKEN: "double",
+      AGENTDEALS_ROLLUP_DIR: path.join(os.tmpdir(), `rollups-${process.pid}`),
+    };
+
+    const started = await startAgentDeals(env);
+    first = started.proc;
+
+    const registered = await fetch(`http://localhost:${started.port}/api/agents/register`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ name: `DeployProbe-${process.pid}` }),
+    });
+    assert.strictEqual(registered.status, 201);
+    const issued = (await registered.json()) as { api_key: string; id: string };
+    assert.ok(issued.api_key);
+
+    const statsBefore = await (await fetch(`http://localhost:${started.port}/api/stats`)).json() as {
+      identity_storage: { durable: boolean; backend: string; survives_deploy: boolean };
+    };
+    assert.strictEqual(statsBefore.identity_storage.durable, true);
+    assert.strictEqual(statsBefore.identity_storage.backend, "redis");
+
+    assert.strictEqual(
+      JSON.parse(fs.readFileSync(AGENTS_PATH, "utf-8")).agents.length,
+      0,
+      "the registration must not have been written to the image's file",
+    );
+
+    first.kill();
+    first = undefined;
+    await new Promise((r) => setTimeout(r, 300));
+
+    const restarted = await startAgentDeals(env);
+    second = restarted.proc;
+
+    const me = await fetch(`http://localhost:${restarted.port}/api/agents/me`, {
+      headers: { Authorization: `Bearer ${issued.api_key}` },
+    });
+    assert.strictEqual(me.status, 200, "a key issued before the restart must still authenticate");
+    const body = (await me.json()) as { id: string };
+    assert.strictEqual(body.id, issued.id);
+  });
+
+  it("refuses a registration rather than issuing a key it cannot store", async () => {
+    const started = await startAgentDeals({
+      UPSTASH_REDIS_REST_URL: "https://unreachable.upstash.invalid",
+      UPSTASH_REDIS_REST_TOKEN: "unreachable",
+      AGENTDEALS_ROLLUP_DIR: path.join(os.tmpdir(), `rollups-down-${process.pid}`),
+    });
+    try {
+      const res = await fetch(`http://localhost:${started.port}/api/agents/register`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ name: `UnreachableProbe-${process.pid}` }),
+      });
+      assert.strictEqual(res.status, 503);
+      const body = (await res.json()) as { error: string; api_key?: string };
+      assert.strictEqual(body.api_key, undefined, "no key may be issued when it cannot be stored");
+      assert.match(body.error, /not saved|discarded/i);
+
+      const stats = await (await fetch(`http://localhost:${started.port}/api/stats`)).json() as {
+        identity_storage: { durable: boolean; stores: { name: string; hydrated: boolean }[] };
+      };
+      assert.strictEqual(stats.identity_storage.durable, false);
+      assert.ok(stats.identity_storage.stores.some(s => s.name === "agents" && !s.hydrated));
+
+      assert.strictEqual(
+        JSON.parse(fs.readFileSync(AGENTS_PATH, "utf-8")).agents.length,
+        0,
+        "a refused registration must not fall back to the ephemeral file",
+      );
+
+      const retry = await fetch(`http://localhost:${started.port}/api/agents/register`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ name: `UnreachableProbe-${process.pid}` }),
+      });
+      assert.strictEqual(retry.status, 503, "a refused registration must not leave the name taken");
+    } finally {
+      started.proc.kill();
+    }
+  });
+
+  it("reports ephemeral identity storage when the process has no durable backend", async () => {
+    const started = await startAgentDeals({
+      UPSTASH_REDIS_REST_URL: "",
+      UPSTASH_REDIS_REST_TOKEN: "",
+      AGENTDEALS_ROLLUP_DIR: path.join(os.tmpdir(), `rollups-nb-${process.pid}`),
+    });
+    try {
+      const stats = await (await fetch(`http://localhost:${started.port}/api/stats`)).json() as {
+        identity_storage: { durable: boolean; backend: string; survives_deploy: boolean };
+      };
+      assert.strictEqual(stats.identity_storage.durable, false);
+      assert.strictEqual(stats.identity_storage.backend, "container_filesystem");
+      assert.strictEqual(stats.identity_storage.survives_deploy, false);
+    } finally {
+      started.proc.kill();
+    }
+  });
+});

--- a/test/marketplace-api.test.ts
+++ b/test/marketplace-api.test.ts
@@ -315,21 +315,33 @@ describe("Marketplace API Endpoints", () => {
     assert.strictEqual(res.status, 403);
   });
 
-  it("POST /api/agents/:id/payout requires x402_address", async () => {
-    // Clear the x402 address first
+  it("POST /api/agents/:id/payout reports that payouts are not enabled, whatever the address is", async () => {
     await fetch(`http://localhost:${serverPort}/api/agents/me`, {
       method: "PATCH",
       headers: { "Content-Type": "application/json", Authorization: `Bearer ${testApiKey}` },
       body: JSON.stringify({ x402_address: null }),
     });
 
-    const res = await fetch(`http://localhost:${serverPort}/api/agents/${testAgentId}/payout`, {
+    const withoutAddress = await fetch(`http://localhost:${serverPort}/api/agents/${testAgentId}/payout`, {
       method: "POST",
       headers: { Authorization: `Bearer ${testApiKey}` },
     });
-    assert.strictEqual(res.status, 402);
-    const body = await res.json();
-    assert.ok(body.error.includes("No x402 address"));
+    assert.strictEqual(withoutAddress.status, 501);
+    const body = await withoutAddress.json() as { error: string; payouts_available: boolean };
+    assert.strictEqual(body.payouts_available, false);
+    assert.match(body.error, /not enabled/i);
+    assert.doesNotMatch(body.error, /No x402 address/);
+
+    await fetch(`http://localhost:${serverPort}/api/agents/me`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json", Authorization: `Bearer ${testApiKey}` },
+      body: JSON.stringify({ x402_address: "0x742d35Cc6634C0532925a3b844Bc9e7595f2bD18" }),
+    });
+    const withAddress = await fetch(`http://localhost:${serverPort}/api/agents/${testAgentId}/payout`, {
+      method: "POST",
+      headers: { Authorization: `Bearer ${testApiKey}` },
+    });
+    assert.strictEqual(withAddress.status, 501, "registering an address must not imply a payout is possible");
   });
 
   // --- POST /api/referral-codes ---

--- a/test/signal.test.ts
+++ b/test/signal.test.ts
@@ -787,7 +787,7 @@ describe("#1083 the operator's read path is a credential, not a second endpoint"
     proc = await new Promise<ChildProcess>((resolve, reject) => {
       const child = spawn("node", [path.join(REPO, "dist", "serve.js")], {
         stdio: ["pipe", "pipe", "pipe"],
-        env: { ...process.env, PORT: "0", BASE_URL: "http://localhost", AGENTDEALS_PLATFORM_SECRET: SECRET },
+        env: { ...process.env, PORT: "0", BASE_URL: "http://localhost", AGENTDEALS_PLATFORM_SECRET: SECRET, UPSTASH_REDIS_REST_URL: "", UPSTASH_REDIS_REST_TOKEN: "" },
       });
       const timeout = setTimeout(() => { child.kill(); reject(new Error("startup timeout")); }, 20000);
       child.stderr!.on("data", (d: Buffer) => {


### PR DESCRIPTION
Refs #1163

## The falsification first

There is no Railway volume at `/app/data`. Production serves exactly the data the image was built from: `/api/offers` answers `total: 1580`, matching `data/index.json` at HEAD, and `/api/changes` serves records that entered the repo in the data commit of 2026-08-28 (`BugBug`, `Comet ML`, `Apollo GraphOS`). A volume mounted at `/app/data` would shadow `data/index.json` entirely, so the site could not be serving today's committed data. The mechanism in the issue stands.

## What changed

Seven runtime stores — `agents`, `referral_requests`, `referral_codes`, `agent_friends`, `watchlist`, `ledger_entries`, `agent_balances` — all had the same shape: a module-level cache, a lazy `fs.readFileSync`, and an `fs.writeFileSync` into a directory the Dockerfile bakes into the image. They now share `src/durable-store.ts`, which reads and writes through the same Upstash credentials `stats.ts` already uses. No new dependency and no new service.

**The read API stayed synchronous.** Every store is hydrated once, before `httpServer.listen()`, so `getAgentByApiKeyHash()` and its siblings are unchanged and no call site had to become async. Writes are the part that had to change: a `save()` marks the store for writing, and the endpoint that is about to tell a caller something happened awaits `persistDurableStores()` first. Thirteen mutating routes do that, plus the four MCP tools that write. A five-minute interval and the shutdown handler flush anything else.

I took that shape over making the store functions async because the async version needed `await` at roughly 170 call sites, most of them in tests, including `assert.throws` blocks that silently stop asserting when the callee starts returning a promise. Neither shape is enforced by the compiler — a missing `await` and a missing flush are both invisible to `tsc` — so the enforcement is a test either way, and this one has the smaller surface to get wrong.

## Three states, not two — again

The credential lesson from #1164 applies to storage. A store is not "durable or not"; it is stored, ephemeral, or **unreadable**, and the third is the one that loses data:

- **Stored** — the backend was read at boot. Writes go to it. `data/*.json` is never written.
- **Ephemeral** — no Upstash credentials. Exactly today's behaviour, file-backed, and `/api/stats` says so.
- **Unreadable** — credentials present, the read failed. **Writes are refused, not diverted to the file.** Serving the committed file here and then writing it back would replace whatever is in Redis with an empty registry, which is worse than the bug being fixed.

`GET /api/stats` carries `identity_storage`: `durable`, `backend`, `survives_deploy`, and per-store `hydrated` / `unflushed_writes` / `last_write_error`. It reports the capability, not the contents — no record counts.

Two consequences worth naming:

- **A refused registration issues no key.** `POST /api/agents/register` answers 503 and the agent it built is dropped from memory, so the name is not left taken by a record that was never stored. There is a test for the retry.
- **A write made against records we had not read is refused even when the retry read succeeds.** The first draft re-read the store and then wrote, which silently discarded the caller's change while answering 201. That is the defect this issue is about, one level down. It now refuses and self-heals on the caller's retry.

## `get_referral_code` names the reason

`attributed: false` covered three different situations. The response now carries `attribution` and `attribution_note` alongside it: `attributed`, `no_key`, `key_not_recognised`, `registry_unavailable`, `not_recorded`. The code is still returned in every case — it is public and withholding it helps nobody.

`GET /api/referral/:vendor` published the same undifferentiated `attributed: !!agent` and got the same treatment, since an agent reading the HTTP surface has the same problem. `authenticateRequest` cannot tell "no credential" from "bad credential", so `hasAuthCredential()` makes that distinction explicit rather than inferring it from a null.

## Payouts

`payoutsAvailable()` is true only when a transfer implementation other than the stub is installed. Not an env var: setting `X402_CDP_API_KEY` does not install a provider, and a capability check that can be satisfied without the capability is the thing being fixed.

- `check_balance` no longer calls the confirmed balance "available for withdrawal", and its response carries `payouts_available` and a reason.
- `request_payout` no longer describes an x402 stablecoin transfer. It reports the missing capability **before** the address and balance checks, because telling an agent to register an address implies that registering one leads somewhere.
- `/marketplace` no longer says "request payouts when your confirmed balance reaches $10", and the dashboard's Request Payout button is gated on the same check.
- `GET /api/agents/:id/balance` reports `payouts_available` too.

Neither tool is removed, and the submission path is untouched.

**One consequence I want to be explicit about:** while payouts are disabled, the address and balance branches of the payout endpoint are unreachable, so `test/marketplace-api.test.ts` now asserts what the endpoint actually answers rather than a 402 it can no longer return. The address requirement itself is still covered at the unit level in `test/payout.test.ts` (`updateAgentX402Address`, and `recordPayout` refusing below the minimum), and both branches become reachable the moment a provider is installed.

## Verification

- **2,709 tests / 0 failures** (+24), `tsc --noEmit` and `validate-data` clean.
- **`scripts/e2e-1163.mjs`: 26 checks, all passing.** It stands up an Upstash double, registers an agent through a real MCP `initialize` → `tools/call`, kills the process, starts a second one against the same store, and authenticates the key issued by the first. `data/agents.json` is asserted empty at both ends, so the key demonstrably travelled through the durable store and not the file.
- **`scripts/mutate-1163.sh`: 23 mutations, 23 killed, no survivors.**
- **Sweep of all 3,916 published paths against a `main` worktree: 3,915 byte-identical.** The only page that moves is `/marketplace` (+160 bytes) — the "Get paid" step and the fourth How It Works card, both of which now state that payouts are not enabled. Sponsored anchors unchanged at 76 across 71 pages.

## Two things for the PM

**AC-2 asks for a note confirming this was checked against a real redeploy.** The restart proof above is two processes sharing only the store, which is the mechanism, but it is not a Railway deploy. Production has Upstash configured, so after this merges I can confirm `identity_storage.durable` and register a probe agent — the survival check needs the *next* deploy after that, so it lands next cycle rather than this one. I would rather say that than imply I checked something I could not.

**The orphaned friend fixtures are seeded, not deleted.** On first boot each key is absent, so each store seeds from its committed file and persists that once. For `agent_friends.json` that promotes the two edges pointing at four agent IDs that do not exist into durable storage. AC-6 says not to change those semantics here, so I did not — but the issue also says they should not ship pointing at nothing, and that is now a one-line data change rather than a behaviour change.

## Cost

Seven `GET`s at boot; one `SET` per store per flush, and repeated saves between flushes collapse into a single write. The interval backstop bounds the steady state at 7 commands per five minutes in the worst case where every store is dirty every interval — about 2,000 a day against the 300,000/month budget `stats.ts` tracks. An oversized value would surface as `last_write_error` on `/api/stats` and a 503 on the write, not as silence.
