### PR TITLE
Keep changes that have not taken effect out of the home page's past-tense lists (#1171)

### DIFF
--- a/scripts/mutate-1171.sh
+++ b/scripts/mutate-1171.sh
@@ -1,0 +1,198 @@
+#!/usr/bin/env bash
+set -u
+
+REPO="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$REPO" || exit 1
+
+SERVE="src/serve.ts"
+BACKUP_DIR="$(mktemp -d)"
+cp "$SERVE" "$BACKUP_DIR/serve.ts"
+
+restore() {
+  cp "$BACKUP_DIR/serve.ts" "$SERVE"
+}
+trap restore EXIT
+
+killed=0
+survived=0
+TESTS="test/homepage-past-tense-changes.test.ts test/change-structured-data.test.ts"
+
+py() { python3 - "$@"; }
+
+run_mutation() {
+  local name="$1"
+  shift
+  echo "=== $name"
+  restore
+  "$@"
+  if diff -q "$BACKUP_DIR/serve.ts" "$SERVE" > /dev/null; then
+    echo "    NOT APPLIED: the mutation changed no file, so it proves nothing"
+    survived=$((survived + 1))
+    return
+  fi
+  if ! npm run build > /tmp/mutate-1171-build.log 2>&1; then
+    echo "    NOT APPLIED: the mutation does not compile, so no test ran"
+    tail -3 /tmp/mutate-1171-build.log
+    survived=$((survived + 1))
+    return
+  fi
+  if timeout 900 node --test --test-concurrency 1 $TESTS > /tmp/mutate-1171-test.log 2>&1; then
+    echo "    SURVIVED"
+    survived=$((survived + 1))
+  else
+    echo "    KILLED: $(grep -c '✖ ' /tmp/mutate-1171-test.log) failing assertion(s)"
+    grep '✖ ' /tmp/mutate-1171-test.log | head -3
+    killed=$((killed + 1))
+  fi
+}
+
+m_the_past_tense_list_stops_filtering() {
+  py <<'PY'
+p = "src/serve.ts"
+s = open(p).read()
+s = s.replace("const recentChanges = [...dealChanges]\n  .filter(hasAlreadyTakenEffect)",
+              "const recentChanges = [...dealChanges]\n  .filter(() => true)")
+open(p, "w").write(s)
+PY
+}
+
+m_a_change_taking_effect_today_counts_as_future() {
+  py <<'PY'
+p = "src/serve.ts"
+s = open(p).read()
+s = s.replace("const hasAlreadyTakenEffect = (c: { date: string }) => c.date <= today;",
+              "const hasAlreadyTakenEffect = (c: { date: string }) => c.date < today;")
+open(p, "w").write(s)
+PY
+}
+
+m_the_boundary_is_inverted() {
+  py <<'PY'
+p = "src/serve.ts"
+s = open(p).read()
+s = s.replace("const hasAlreadyTakenEffect = (c: { date: string }) => c.date <= today;",
+              "const hasAlreadyTakenEffect = (c: { date: string }) => c.date >= today;")
+open(p, "w").write(s)
+PY
+}
+
+m_the_filter_runs_after_the_list_is_cut() {
+  py <<'PY'
+p = "src/serve.ts"
+s = open(p).read()
+s = s.replace("const recentChanges = [...dealChanges]\n  .filter(hasAlreadyTakenEffect)\n  .sort((a, b) => b.date.localeCompare(a.date))\n  .slice(0, 5);",
+              "const recentChanges = [...dealChanges]\n  .sort((a, b) => b.date.localeCompare(a.date))\n  .slice(0, 5)\n  .filter(hasAlreadyTakenEffect);")
+open(p, "w").write(s)
+PY
+}
+
+m_the_countdown_list_is_filled_from_past_changes() {
+  py <<'PY'
+p = "src/serve.ts"
+s = open(p).read()
+s = s.replace("  .filter((c) => !hasAlreadyTakenEffect(c))",
+              "  .filter((c) => hasAlreadyTakenEffect(c))")
+open(p, "w").write(s)
+PY
+}
+
+m_today_is_read_as_tomorrow() {
+  py <<'PY'
+p = "src/serve.ts"
+s = open(p).read()
+s = s.replace("const today = new Date().toISOString().slice(0, 10);\nconst hasAlreadyTakenEffect",
+              "const today = new Date(Date.now() + 86400000).toISOString().slice(0, 10);\nconst hasAlreadyTakenEffect")
+open(p, "w").write(s)
+PY
+}
+
+m_today_is_read_as_yesterday() {
+  py <<'PY'
+p = "src/serve.ts"
+s = open(p).read()
+s = s.replace("const today = new Date().toISOString().slice(0, 10);\nconst hasAlreadyTakenEffect",
+              "const today = new Date(Date.now() - 86400000).toISOString().slice(0, 10);\nconst hasAlreadyTakenEffect")
+open(p, "w").write(s)
+PY
+}
+
+m_the_past_tense_list_is_ordered_oldest_first() {
+  py <<'PY'
+p = "src/serve.ts"
+s = open(p).read()
+s = s.replace("  .filter(hasAlreadyTakenEffect)\n  .sort((a, b) => b.date.localeCompare(a.date))",
+              "  .filter(hasAlreadyTakenEffect)\n  .sort((a, b) => a.date.localeCompare(b.date))")
+open(p, "w").write(s)
+PY
+}
+
+m_the_past_tense_list_is_cut_to_three() {
+  py <<'PY'
+p = "src/serve.ts"
+s = open(p).read()
+s = s.replace("  .filter(hasAlreadyTakenEffect)\n  .sort((a, b) => b.date.localeCompare(a.date))\n  .slice(0, 5);",
+              "  .filter(hasAlreadyTakenEffect)\n  .sort((a, b) => b.date.localeCompare(a.date))\n  .slice(0, 3);")
+open(p, "w").write(s)
+PY
+}
+
+m_the_advertised_total_counts_every_change() {
+  py <<'PY'
+p = "src/serve.ts"
+s = open(p).read()
+s = s.replace("    numberOfItems: recentChanges.length,",
+              "    numberOfItems: dealChanges.slice(0, 5).length,")
+open(p, "w").write(s)
+PY
+}
+
+m_the_structured_data_is_drawn_from_every_change() {
+  py <<'PY'
+p = "src/serve.ts"
+s = open(p).read()
+s = s.replace("    itemListElement: recentChanges.map((c, i) => ({",
+              "    itemListElement: [...dealChanges].sort((a, b) => b.date.localeCompare(a.date)).slice(0, 5).map((c, i) => ({")
+open(p, "w").write(s)
+PY
+}
+
+m_the_whats_changed_section_is_drawn_from_every_change() {
+  py <<'PY'
+p = "src/serve.ts"
+s = open(p).read()
+s = s.replace("function buildChangesHtml(): string {\n  return recentChanges.map((c) => {",
+              "function buildChangesHtml(): string {\n  return [...dealChanges].sort((a, b) => b.date.localeCompare(a.date)).slice(0, 5).map((c) => {")
+open(p, "w").write(s)
+PY
+}
+
+m_the_fresh_intel_section_is_drawn_from_every_change() {
+  py <<'PY'
+p = "src/serve.ts"
+s = open(p).read()
+s = s.replace("  const entries = recentChanges.map((c) => {",
+              "  const entries = [...dealChanges].sort((a, b) => b.date.localeCompare(a.date)).slice(0, 5).map((c) => {")
+open(p, "w").write(s)
+PY
+}
+
+run_mutation "the past-tense list stops filtering out changes that have not taken effect" m_the_past_tense_list_stops_filtering
+run_mutation "a change taking effect today is treated as not yet taken effect" m_a_change_taking_effect_today_counts_as_future
+run_mutation "the boundary is inverted so only future changes count as taken effect" m_the_boundary_is_inverted
+run_mutation "the filter runs after the list has already been cut to five" m_the_filter_runs_after_the_list_is_cut
+run_mutation "the countdown list is filled from changes that have already taken effect" m_the_countdown_list_is_filled_from_past_changes
+run_mutation "today is read as tomorrow, so a change one day out counts as past" m_today_is_read_as_tomorrow
+run_mutation "today is read as yesterday, so a change taking effect today is still counted down to" m_today_is_read_as_yesterday
+run_mutation "the past-tense list is ordered oldest first" m_the_past_tense_list_is_ordered_oldest_first
+run_mutation "the past-tense list is cut to three entries" m_the_past_tense_list_is_cut_to_three
+run_mutation "the advertised total counts every change rather than the rendered list" m_the_advertised_total_counts_every_change
+run_mutation "the structured data entries are drawn from every change rather than the rendered list" m_the_structured_data_is_drawn_from_every_change
+run_mutation "the What's Changed section is drawn from every change rather than the filtered list" m_the_whats_changed_section_is_drawn_from_every_change
+run_mutation "the Fresh Intel section is drawn from every change rather than the filtered list" m_the_fresh_intel_section_is_drawn_from_every_change
+
+restore
+npm run build > /dev/null 2>&1
+echo
+echo "killed: $killed"
+echo "survived: $survived"
+[ "$survived" -eq 0 ]

--- a/src/serve.ts
+++ b/src/serve.ts
@@ -448,15 +448,18 @@ export function changeLogFreshnessNote(now: Date = new Date()): string {
   return `  <p class="log-freshness" style="color:var(--text-dim);font-size:.8rem;margin:-1rem 0 1.5rem">We last added an entry to this log ${when}, on ${freshness.last_recorded_date}. The counts above are changes by the date they took effect, not by the date we recorded them.</p>\n`;
 }
 
+const today = new Date().toISOString().slice(0, 10);
+const hasAlreadyTakenEffect = (c: { date: string }) => c.date <= today;
+
 // Prepare recent deal changes for landing page (5 most recent, sorted newest first)
 const recentChanges = [...dealChanges]
+  .filter(hasAlreadyTakenEffect)
   .sort((a, b) => b.date.localeCompare(a.date))
   .slice(0, 5);
 
 // Prepare upcoming deadlines (future dates, soonest first, max 5)
-const today = new Date().toISOString().slice(0, 10);
 const upcomingDeadlines = [...dealChanges]
-  .filter((c) => c.date > today)
+  .filter((c) => !hasAlreadyTakenEffect(c))
   .sort((a, b) => a.date.localeCompare(b.date))
   .slice(0, 5);
 

--- a/test/change-structured-data.test.ts
+++ b/test/change-structured-data.test.ts
@@ -124,8 +124,8 @@ describe("the machine-readable change lists carry the entries the pages carry", 
   for (const route of ROUTES) {
     it(`states the effective date of a dated entry on ${route}`, () => {
       assert.strictEqual(
-        itemFor(changeList(bodies.get(route)!, route), UPCOMING, route).datePublished,
-        UPCOMING_DATE,
+        itemFor(changeList(bodies.get(route)!, route), RECENT, route).datePublished,
+        RECENT_DATE,
         `${route} dropped the effective date from an entry that has one`
       );
     });
@@ -138,6 +138,22 @@ describe("the machine-readable change lists carry the entries the pages carry", 
       );
     });
   }
+
+  it("carries an entry that has not taken effect on the routes that list changes by date, and not on the home page", () => {
+    for (const route of ["/changes", "/expiring"]) {
+      assert.strictEqual(
+        itemFor(changeList(bodies.get(route)!, route), UPCOMING, route).datePublished,
+        UPCOMING_DATE,
+        `${route} dropped an announced change that has not taken effect yet`
+      );
+    }
+    const home = changeList(bodies.get("/")!, "/");
+    assert.ok(home.items.length > 0, "the home page listed no changes at all, so the absence below proves nothing");
+    assert.ok(
+      !home.items.some((it) => it.headline?.startsWith(`${UPCOMING}:`)),
+      `the home page dated ${UPCOMING} as a change that has already happened`
+    );
+  });
 
   it("counts the entry it could not date in the total it advertises", () => {
     const list = changeList(bodies.get("/expiring")!, "/expiring");

--- a/test/homepage-past-tense-changes.test.ts
+++ b/test/homepage-past-tense-changes.test.ts
@@ -1,0 +1,266 @@
+import { describe, it, before, after } from "node:test";
+import assert from "node:assert";
+import { spawn, type ChildProcess } from "node:child_process";
+import { writeFileSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO = path.join(__dirname, "..");
+
+const TODAY = new Date().toISOString().slice(0, 10);
+const dayOffset = (days: number) =>
+  new Date(Date.parse(TODAY) + days * 86400000).toISOString().slice(0, 10);
+
+const FUTURE = [
+  { vendor: "Kestrelmark", date: dayOffset(1), type: "free_tier_removed", source: "vendor_page" },
+  { vendor: "Aurorabase", date: dayOffset(13), type: "new_free_tier", source: "vendor_page" },
+  { vendor: "Beaconstack", date: dayOffset(31), type: "product_deprecated", source: "hand_written" },
+  { vendor: "Cirruslane", date: dayOffset(38), type: "product_deprecated", source: "hand_written" },
+];
+const EFFECTIVE_TODAY = { vendor: "Datumforge", date: TODAY, type: "limits_reduced", source: "vendor_page" };
+const PAST = [
+  { vendor: "Everglow", date: dayOffset(-2), type: "free_tier_removed", source: "vendor_page" },
+  { vendor: "Foldergrid", date: dayOffset(-4), type: "limits_reduced", source: "hand_written" },
+  { vendor: "Gustline", date: dayOffset(-9), type: "pricing_restructured", source: "discovered" },
+  { vendor: "Halcyonio", date: dayOffset(-15), type: "limits_increased", source: "vendor_page" },
+  { vendor: "Ironvale", date: dayOffset(-21), type: "limits_reduced", source: "discovered" },
+  { vendor: "Junipernet", date: dayOffset(-40), type: "free_tier_removed", source: "vendor_page" },
+];
+
+const EXPECTED_RECENT = [EFFECTIVE_TODAY, ...PAST].slice(0, 5).map((c) => c.vendor);
+
+function change(spec: { vendor: string; date: string; type: string; source: string }) {
+  return {
+    vendor: spec.vendor,
+    change_type: spec.type,
+    date: spec.date,
+    date_source: spec.source,
+    summary: `${spec.vendor} changed the terms of its free allowance.`,
+    previous_state: "10 GB storage",
+    current_state: "2 GB storage",
+    impact: "high",
+    source_url: `https://example.com/${spec.vendor.toLowerCase()}/pricing`,
+    category: "Databases",
+    alternatives: [],
+    recorded_date: spec.date,
+  };
+}
+
+function fixtureChanges() {
+  return [...FUTURE, EFFECTIVE_TODAY, ...PAST].map(change);
+}
+
+function sliceSection(html: string, startMarker: string, endMarker: string, label: string): string {
+  const start = html.indexOf(startMarker);
+  assert.ok(start >= 0, `the home page did not render the ${label} section at all`);
+  const end = html.indexOf(endMarker, start);
+  assert.ok(end > start, `the ${label} section did not close where expected`);
+  return html.slice(start, end);
+}
+
+function entryDates(section: string, dateClass: string): string[] {
+  return [...section.matchAll(new RegExp(`class="${dateClass}"[^>]*>([^<]*)<`, "g"))]
+    .map((m) => m[1].match(/\d{4}-\d{2}-\d{2}/)?.[0])
+    .filter((d): d is string => Boolean(d));
+}
+
+function vendorsIn(section: string): string[] {
+  return [...FUTURE, EFFECTIVE_TODAY, ...PAST]
+    .map((c) => ({ vendor: c.vendor, at: section.indexOf(`>${c.vendor}<`) }))
+    .filter((c) => c.at >= 0)
+    .sort((a, b) => a.at - b.at)
+    .map((c) => c.vendor);
+}
+
+type Item = { headline?: string; datePublished?: string };
+
+function itemListItems(html: string): Item[] {
+  const lists: Item[][] = [];
+  for (const block of html.matchAll(/<script type="application\/ld\+json">([\s\S]*?)<\/script>/g)) {
+    const json = JSON.parse(block[1]);
+    if (json["@type"] !== "ItemList" || !Array.isArray(json.itemListElement)) continue;
+    lists.push(json.itemListElement.map((el: any) => el.item));
+  }
+  assert.strictEqual(lists.length, 1, "expected exactly one change ItemList in the home page structured data");
+  return lists[0];
+}
+
+function serveHomePage(changes: unknown[]): Promise<{ proc: ChildProcess; tmp: string; html: string }> {
+  const tmp = mkdtempSync(path.join(tmpdir(), "homepage-past-tense-"));
+  const changesPath = path.join(tmp, "changes.json");
+  writeFileSync(changesPath, JSON.stringify({ changes }, null, 2));
+  return new Promise<{ proc: ChildProcess; port: number }>((resolve, reject) => {
+    const child = spawn("node", [path.join(REPO, "dist", "serve.js")], {
+      stdio: ["pipe", "pipe", "pipe"],
+      env: {
+        ...process.env,
+        PORT: "0",
+        BASE_URL: "http://localhost:3000",
+        AGENTDEALS_CHANGES_PATH: changesPath,
+      },
+    });
+    const timeout = setTimeout(() => {
+      child.kill();
+      reject(new Error("Server startup timeout"));
+    }, 30000);
+    child.stderr!.on("data", (data: Buffer) => {
+      const m = data.toString().match(/running on http:\/\/localhost:(\d+)/);
+      if (m) {
+        clearTimeout(timeout);
+        resolve({ proc: child, port: parseInt(m[1], 10) });
+      }
+    });
+    child.on("error", (err) => {
+      clearTimeout(timeout);
+      reject(err);
+    });
+  }).then(async ({ proc, port }) => ({
+    proc,
+    tmp,
+    html: await (await fetch(`http://localhost:${port}/`)).text(),
+  }));
+}
+
+describe("the home page's past-tense change lists carry only changes that have taken effect", () => {
+  let tmp: string;
+  let proc: ChildProcess;
+  let html = "";
+
+  before(async () => {
+    ({ proc, tmp, html } = await serveHomePage(fixtureChanges()));
+  });
+
+  after(() => {
+    if (proc) proc.kill();
+    if (tmp) rmSync(tmp, { recursive: true, force: true });
+  });
+
+  const whatsChanged = () =>
+    sliceSection(html, 'id="whats-changed"', 'href="/api/changes"', "Recent pricing changes");
+  const freshIntel = () =>
+    sliceSection(html, 'id="recent-changes"', 'href="/expiring" class="see-all-link"', "Fresh Intel");
+  const comingSoon = () =>
+    sliceSection(html, "Pricing changes coming soon", "expiring soon", "Pricing changes coming soon");
+
+  it("dates every entry under Recent pricing changes on or before today", () => {
+    const dates = entryDates(whatsChanged(), "change-date");
+    assert.strictEqual(dates.length, 5, "Recent pricing changes did not render five entries, so the dates below prove nothing");
+    for (const date of dates) {
+      assert.ok(date <= TODAY, `Recent pricing changes leads with ${date}, which has not arrived yet`);
+    }
+  });
+
+  it("dates every entry under Fresh Intel on or before today", () => {
+    const dates = entryDates(freshIntel(), "rc-date");
+    assert.strictEqual(dates.length, 5, "Fresh Intel did not render five entries, so the dates below prove nothing");
+    for (const date of dates) {
+      assert.ok(date <= TODAY, `Fresh Intel leads with ${date}, which has not arrived yet`);
+    }
+  });
+
+  it("publishes no datePublished later than the day the page was built", () => {
+    const items = itemListItems(html);
+    assert.strictEqual(items.length, 5, "the ItemList did not carry five entries, so the dates below prove nothing");
+    const dated = items.filter((it) => it.datePublished);
+    assert.ok(dated.length > 0, "no entry carried a datePublished at all, so the bound below is vacuous");
+    for (const item of dated) {
+      assert.ok(
+        item.datePublished! <= TODAY,
+        `the structured data dates ${item.headline} as published on ${item.datePublished}, a day that has not arrived`
+      );
+    }
+  });
+
+  it("keeps a change out of the past-tense list until the day it takes effect", () => {
+    const soon = vendorsIn(comingSoon());
+    for (const upcoming of FUTURE) {
+      assert.ok(
+        soon.includes(upcoming.vendor),
+        `${upcoming.vendor} takes effect on ${upcoming.date} and is missing from Pricing changes coming soon`
+      );
+      assert.ok(
+        !vendorsIn(whatsChanged()).includes(upcoming.vendor),
+        `${upcoming.vendor} takes effect on ${upcoming.date} and is listed under Recent pricing changes`
+      );
+      assert.ok(
+        !vendorsIn(freshIntel()).includes(upcoming.vendor),
+        `${upcoming.vendor} takes effect on ${upcoming.date} and is listed under Fresh Intel`
+      );
+    }
+  });
+
+  it("never lists the same change as both already changed and changing soon", () => {
+    const recent = vendorsIn(whatsChanged());
+    const soon = vendorsIn(comingSoon());
+    assert.ok(recent.length > 0 && soon.length > 0, "one of the two lists is empty, so an empty overlap proves nothing");
+    const both = recent.filter((v) => soon.includes(v));
+    assert.deepStrictEqual(both, [], `listed as both already changed and changing soon: ${both.join(", ")}`);
+  });
+
+  it("counts a change that takes effect today as one that has happened", () => {
+    assert.ok(
+      vendorsIn(whatsChanged()).includes(EFFECTIVE_TODAY.vendor),
+      `${EFFECTIVE_TODAY.vendor} takes effect today and is missing from Recent pricing changes`
+    );
+    assert.ok(
+      !vendorsIn(comingSoon()).includes(EFFECTIVE_TODAY.vendor),
+      `${EFFECTIVE_TODAY.vendor} takes effect today and is still counted down to`
+    );
+  });
+
+  it("still fills all five slots from the changes that have taken effect", () => {
+    assert.deepStrictEqual(
+      vendorsIn(whatsChanged()),
+      EXPECTED_RECENT,
+      "Recent pricing changes is not the five newest changes that have taken effect"
+    );
+  });
+});
+
+describe("the home page counts the changes it lists, not the changes it holds", () => {
+  const SPARSE_PAST = PAST.slice(0, 2);
+  let tmp: string;
+  let proc: ChildProcess;
+  let html = "";
+
+  before(async () => {
+    ({ proc, tmp, html } = await serveHomePage([...FUTURE, ...SPARSE_PAST].map(change)));
+  });
+
+  after(() => {
+    if (proc) proc.kill();
+    if (tmp) rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it("advertises the number of entries it published, not the cap it could have filled", () => {
+    const section = sliceSection(html, 'id="recent-changes"', 'href="/expiring" class="see-all-link"', "Fresh Intel");
+    assert.deepStrictEqual(
+      vendorsIn(section),
+      SPARSE_PAST.map((c) => c.vendor),
+      "Fresh Intel did not render exactly the changes that have taken effect"
+    );
+    const items = itemListItems(html);
+    assert.strictEqual(
+      items.length,
+      SPARSE_PAST.length,
+      "the structured data carried a different number of entries than the section rendered"
+    );
+    const numberOfItems = JSON.parse(
+      [...html.matchAll(/<script type="application\/ld\+json">([\s\S]*?)<\/script>/g)]
+        .map((m) => m[1])
+        .find((b) => JSON.parse(b)["@type"] === "ItemList")!
+    ).numberOfItems;
+    assert.strictEqual(
+      numberOfItems,
+      SPARSE_PAST.length,
+      `the structured data advertises ${numberOfItems} entries on a list of ${SPARSE_PAST.length}`
+    );
+  });
+
+  it("still counts down to every change that has not taken effect", () => {
+    const soon = vendorsIn(sliceSection(html, "Pricing changes coming soon", "expiring soon", "Pricing changes coming soon"));
+    assert.deepStrictEqual(soon, FUTURE.map((c) => c.vendor));
+  });
+});


### PR DESCRIPTION
Refs #1171

The home page's "Recent pricing changes" section led with three changes that have not happened yet, and published all three as schema.org `datePublished`.

## The defect

`recentChanges` selected the five newest changes with no date filter. Sorting by date descending and taking the top five does not merely *include* future-dated records — it guarantees they occupy the top slots. Three of 444 tracked changes are future-dated, and all three were rows 1, 2 and 3.

| Slot (before) | Date shown |
|---|---|
| 1 | 2026-10-07 |
| 2 | 2026-09-30 |
| 3 | 2026-09-12 |
| 4 | discovered 2026-08-28 |
| 5 | discovered 2026-08-28 |

The same array feeds the Fresh Intel section's `ItemList`, where **every** `datePublished` was a future date — positions 4 and 5 carried none at all, because a discovery-dated record is correctly left undated. Row 1 read "end of support. All environments, services, and templates will stop working." That service has 38 days left. Further down the same page, the identical record rendered under "Pricing changes coming soon" with a 13-day countdown.

## The change

`today` moves above the selection, and the two lists become one partition of it:

```ts
const hasAlreadyTakenEffect = (c: { date: string }) => c.date <= today;
```

`recentChanges` filters on it, `upcomingDeadlines` filters on its negation. The disjointness AC-5 asks for is then structural rather than a coincidence of two predicates that happen to agree — neither can be edited without moving the other. `upcomingDeadlines` is unchanged in behaviour: `!(date <= today)` is the `date > today` it already had, and the countdown section renders byte-for-byte what it rendered before.

The filter runs before the `slice(0, 5)`, so the list still fills all five slots from the changes that have taken effect (AC-7).

## The existing test that had to move

`change-structured-data.test.ts` asserted "states the effective date of a dated entry on /" using the future-dated fixture, so it pinned the behaviour this issue calls a bug. The property is right; the example was wrong for a past-tense list. It now demonstrates the property with the past-dated fixture, which appears on all three routes, and a new assertion states where a not-yet-effective change may and may not appear: present on `/changes` and `/expiring`, absent from `/`.

## Verification

- **2,719 tests / 0 failures** (+10), `tsc --noEmit` and `validate-data` clean at 1,580 offers / 444 changes.
- **`mutate-1171.sh`: 13 mutations, 13 killed, no survivors, none by the compiler.** First pass was 12/1. The survivor replaced `numberOfItems: recentChanges.length` with `dealChanges.slice(0, 5).length` — equivalent under a fixture holding six past-dated changes, because both are 5. The reachable state is a store with fewer than five past-dated changes, so the second suite builds it: two past and four future, where the section renders two entries and the structured data must advertise two rather than the cap. Same lesson as the last three cycles — a survivor is usually a state today's data cannot reach, and the answer is to build the state, not to weaken the mutation.
- **Sweep of all 3,915 published paths against a `main` worktree: 3,914 byte-identical.** The only page that moves is `/` (+725 bytes).
- **Sweep of every `datePublished` in every page's JSON-LD, before and after:** 9 pages carry a future date on `main`, 8 after this change. `/` is the one that leaves. The other eight are outside this issue and reported on it.
- Screenshots of the section before and after, and of the countdown section showing all three future records still present at 13, 31 and 38 days.
