### PR TITLE
Name both ChatGPT Business seat types on the OpenAI Codex record, and cite a page that can show the next price

### DIFF
--- a/data/index.json
+++ b/data/index.json
@@ -28486,9 +28486,9 @@
     {
       "vendor": "OpenAI Codex",
       "category": "AI Coding",
-      "description": "Cloud-native coding agent by OpenAI. Switched to pay-as-you-go token-based pricing (April 2026). Included in ChatGPT Plus ($20/mo), Pro ($200/mo), and Business ($20/user/mo, cut from $25). Teams can add Codex-only seats with no rate limits, billed on token consumption. $100 credit per new Codex team member (up to $500/team, limited time). 2M+ weekly users. API via codex-mini at $1.50/1M input, $6/1M output tokens.",
+      "description": "Cloud-native coding agent by OpenAI. Available with a ChatGPT subscription and, separately, with an API key billed on token use; both routes are current. ChatGPT Business has two seat types, both carrying Codex: Standard at $20/user/mo billed annually ($25 monthly) and Premium at $100/user/mo billed annually ($125 monthly), where Premium buys 5x more usage than Standard and removes the five-hour usage limit. Also in ChatGPT Plus ($20/mo) and Pro (from $100/mo). Codex-only pay-as-you-go seats closed to new Business workspaces in June 2026; existing seats continue. The Codex pricing page we cite lists only the Standard seat — the Premium seat is published on OpenAI's business pricing page. $100 credit per new Codex team member (up to $500/team, limited time). 2M+ weekly users. API via codex-mini at $1.50/1M input, $6/1M output tokens.",
       "tier": "Freemium",
-      "url": "https://openai.com/index/codex-flexible-pricing-for-teams/",
+      "url": "https://developers.openai.com/codex/pricing/",
       "tags": [
         "ai",
         "coding",
@@ -28497,7 +28497,7 @@
         "openai",
         "developer tools"
       ],
-      "verifiedDate": "2026-08-02",
+      "verifiedDate": "2026-08-30",
       "referral_program": {
         "available": false,
         "referrer_benefit": "N/A",
@@ -28507,9 +28507,9 @@
         "notes": "No public affiliate/referral program."
       },
       "source_check": {
-        "checked": "2026-08-28",
-        "outcome": "unreadable",
-        "detail": "HTTP 403"
+        "checked": "2026-08-30",
+        "outcome": "ok",
+        "detail": "url"
       }
     },
     {

--- a/scripts/mutate-1172.sh
+++ b/scripts/mutate-1172.sh
@@ -1,0 +1,215 @@
+#!/usr/bin/env bash
+set -u
+
+REPO="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$REPO" || exit 1
+
+INDEX="data/index.json"
+SUITE="test/source-can-show-a-later-price.test.ts"
+BACKUP_DIR="$(mktemp -d)"
+cp "$INDEX" "$BACKUP_DIR/index.json"
+cp "$SUITE" "$BACKUP_DIR/suite.ts"
+
+restore() {
+  cp "$BACKUP_DIR/index.json" "$INDEX"
+  cp "$BACKUP_DIR/suite.ts" "$SUITE"
+}
+trap restore EXIT
+
+killed=0
+survived=0
+TESTS="test/source-can-show-a-later-price.test.ts"
+
+py() { python3 - "$@"; }
+
+run_mutation() {
+  local name="$1"
+  shift
+  echo "=== $name"
+  restore
+  "$@"
+  if diff -q "$BACKUP_DIR/index.json" "$INDEX" > /dev/null && diff -q "$BACKUP_DIR/suite.ts" "$SUITE" > /dev/null; then
+    echo "    NOT APPLIED: the mutation changed no file, so it proves nothing"
+    survived=$((survived + 1))
+    return
+  fi
+  if timeout 600 node --test --test-concurrency 1 $TESTS > /tmp/mutate-1172-test.log 2>&1; then
+    echo "    SURVIVED"
+    survived=$((survived + 1))
+  else
+    echo "    KILLED: $(grep -c '✖ ' /tmp/mutate-1172-test.log) failing assertion(s)"
+    grep '✖ ' /tmp/mutate-1172-test.log | head -3
+    killed=$((killed + 1))
+  fi
+}
+
+m_the_record_goes_back_to_the_announcement_post() {
+  py <<'PY'
+p = "data/index.json"
+s = open(p).read()
+s = s.replace('"url": "https://developers.openai.com/codex/pricing/"',
+              '"url": "https://openai.com/index/codex-flexible-pricing-for-teams/"')
+open(p, "w").write(s)
+PY
+}
+
+m_the_record_goes_back_to_its_old_description() {
+  py <<'PY'
+import json
+p = "data/index.json"
+d = json.load(open(p))
+for o in d["offers"]:
+    if o["vendor"] == "OpenAI Codex":
+        o["description"] = ("Cloud-native coding agent by OpenAI. Switched to pay-as-you-go token-based pricing "
+                            "(April 2026). Included in ChatGPT Plus ($20/mo), Pro ($200/mo), and Business "
+                            "($20/user/mo, cut from $25). Teams can add Codex-only seats with no rate limits, "
+                            "billed on token consumption.")
+json.dump(d, open(p, "w"), indent=2, ensure_ascii=False)
+PY
+}
+
+m_only_the_cheap_seat_is_named() {
+  py <<'PY'
+p = "data/index.json"
+s = open(p).read()
+s = s.replace("Standard at $20/user/mo billed annually ($25 monthly) and Premium at $100/user/mo billed annually ($125 monthly), where Premium buys 5x more usage than Standard and removes the five-hour usage limit.",
+              "Standard at $20/user/mo billed annually ($25 monthly).")
+open(p, "w").write(s)
+PY
+}
+
+m_the_premium_seat_is_named_without_its_price() {
+  py <<'PY'
+p = "data/index.json"
+s = open(p).read()
+s = s.replace("Premium at $100/user/mo billed annually ($125 monthly)",
+              "a Premium seat billed annually")
+open(p, "w").write(s)
+PY
+}
+
+m_the_standard_seat_is_named_without_its_price() {
+  py <<'PY'
+p = "data/index.json"
+s = open(p).read()
+s = s.replace("Standard at $20/user/mo billed annually ($25 monthly)",
+              "a Standard seat billed annually")
+open(p, "w").write(s)
+PY
+}
+
+m_the_reason_to_buy_the_premium_seat_is_dropped() {
+  py <<'PY'
+p = "data/index.json"
+s = open(p).read()
+s = s.replace(", where Premium buys 5x more usage than Standard and removes the five-hour usage limit", "")
+open(p, "w").write(s)
+PY
+}
+
+m_the_five_hour_limit_is_dropped_but_the_usage_multiple_stays() {
+  py <<'PY'
+p = "data/index.json"
+s = open(p).read()
+s = s.replace("Premium buys 5x more usage than Standard and removes the five-hour usage limit",
+              "Premium buys 5x more usage than Standard")
+open(p, "w").write(s)
+PY
+}
+
+m_token_billing_is_dropped_from_the_opening() {
+  py <<'PY'
+p = "data/index.json"
+s = open(p).read()
+s = s.replace("Available with a ChatGPT subscription and, separately, with an API key billed on token use; both routes are current.",
+              "Available with a ChatGPT subscription.")
+open(p, "w").write(s)
+PY
+}
+
+m_the_closed_payg_seat_is_offered_again() {
+  py <<'PY'
+p = "data/index.json"
+s = open(p).read()
+s = s.replace("Codex-only pay-as-you-go seats closed to new Business workspaces in June 2026; existing seats continue.",
+              "Teams can add Codex-only seats with no rate limits, billed on token consumption.")
+open(p, "w").write(s)
+PY
+}
+
+m_a_new_record_cites_a_post_frozen_at_publication() {
+  py <<'PY'
+import json
+p = "data/index.json"
+d = json.load(open(p))
+d["offers"].append({
+    "vendor": "Mutantcorp",
+    "category": "AI Coding",
+    "description": "Free tier for the mutation run only.",
+    "tier": "Free",
+    "url": "https://mutantcorp.example/blog/we-changed-our-pricing",
+    "tags": ["ai"],
+    "verifiedDate": "2026-08-30",
+})
+json.dump(d, open(p, "w"), indent=2, ensure_ascii=False)
+PY
+}
+
+m_the_post_detector_never_reports_one() {
+  py <<'PY'
+p = "test/source-can-show-a-later-price.test.ts"
+s = open(p).read()
+s = s.replace("  const segments = parsed.pathname.split(\"/\").filter(Boolean);",
+              "  const segments: string[] = [];")
+open(p, "w").write(s)
+PY
+}
+
+m_a_listing_page_counts_as_one_of_its_entries() {
+  py <<'PY'
+p = "test/source-can-show-a-later-price.test.ts"
+s = open(p).read()
+s = s.replace("for (let i = 0; i < segments.length - 1; i++) {",
+              "for (let i = 0; i < segments.length; i++) {")
+open(p, "w").write(s)
+PY
+}
+
+m_the_path_openai_publishes_posts_under_is_dropped() {
+  py <<'PY'
+p = "test/source-can-show-a-later-price.test.ts"
+s = open(p).read()
+s = s.replace("/^(index|blog|news|press|", "/^(blog|news|press|")
+open(p, "w").write(s)
+PY
+}
+
+m_the_ratchet_baseline_swallows_every_host() {
+  py <<'PY'
+p = "test/source-can-show-a-later-price.test.ts"
+s = open(p).read()
+s = s.replace("    .filter((o) => !SOURCES_STILL_FROZEN_AT_PUBLICATION.has(o.url))",
+              "    .filter((o) => !o.url.startsWith(\"http\"))")
+open(p, "w").write(s)
+PY
+}
+
+run_mutation "the record goes back to the announcement post" m_the_record_goes_back_to_the_announcement_post
+run_mutation "the record goes back to its old description" m_the_record_goes_back_to_its_old_description
+run_mutation "only the cheap seat is named" m_only_the_cheap_seat_is_named
+run_mutation "the premium seat is named without its price" m_the_premium_seat_is_named_without_its_price
+run_mutation "the standard seat is named without its price" m_the_standard_seat_is_named_without_its_price
+run_mutation "the reason to buy the premium seat is dropped" m_the_reason_to_buy_the_premium_seat_is_dropped
+run_mutation "the five-hour limit is dropped but the usage multiple stays" m_the_five_hour_limit_is_dropped_but_the_usage_multiple_stays
+run_mutation "token billing is dropped from the opening" m_token_billing_is_dropped_from_the_opening
+run_mutation "the closed pay-as-you-go seat is offered again" m_the_closed_payg_seat_is_offered_again
+run_mutation "a new record cites a post frozen at publication" m_a_new_record_cites_a_post_frozen_at_publication
+run_mutation "the post detector never reports one" m_the_post_detector_never_reports_one
+run_mutation "a listing page counts as one of its entries" m_a_listing_page_counts_as_one_of_its_entries
+run_mutation "the path OpenAI publishes posts under is dropped" m_the_path_openai_publishes_posts_under_is_dropped
+run_mutation "the ratchet baseline swallows every host" m_the_ratchet_baseline_swallows_every_host
+
+restore
+echo
+echo "killed=$killed survived=$survived"
+[ "$survived" -eq 0 ]

--- a/test/source-can-show-a-later-price.test.ts
+++ b/test/source-can-show-a-later-price.test.ts
@@ -1,0 +1,132 @@
+import { describe, it } from "node:test";
+import assert from "node:assert";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO = path.join(__dirname, "..");
+
+interface CatalogueOffer {
+  vendor: string;
+  description: string;
+  url: string;
+}
+
+const FROZEN_AT_PUBLICATION =
+  /^(index|blog|news|press|announcement|announcements|post|posts|update|updates|release|releases|story|stories|article|articles|changelog)$/i;
+
+const SOURCES_STILL_FROZEN_AT_PUBLICATION = new Set([
+  "https://www.userlike.com/en/blog/startup-deals",
+]);
+
+function datedPostSegment(url: string): string | null {
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return null;
+  }
+  const segments = parsed.pathname.split("/").filter(Boolean);
+  for (let i = 0; i < segments.length - 1; i++) {
+    if (FROZEN_AT_PUBLICATION.test(segments[i])) return segments[i];
+  }
+  return null;
+}
+
+function unbaselinedFrozenSources(list: CatalogueOffer[]): string[] {
+  return list
+    .filter((o) => datedPostSegment(o.url) !== null)
+    .filter((o) => !SOURCES_STILL_FROZEN_AT_PUBLICATION.has(o.url))
+    .map((o) => `${o.vendor} -> ${o.url}`);
+}
+
+const offers: CatalogueOffer[] = JSON.parse(
+  readFileSync(path.join(REPO, "data", "index.json"), "utf8"),
+).offers;
+
+function offerFor(vendor: string): CatalogueOffer {
+  const offer = offers.find((o) => o.vendor === vendor);
+  assert.ok(offer, `${vendor} is no longer in the catalogue`);
+  return offer;
+}
+
+describe("a page frozen at publication cannot report a price set after it", () => {
+  it("reads the post out of the path vendors publish posts under", () => {
+    assert.strictEqual(
+      datedPostSegment("https://openai.com/index/codex-flexible-pricing-for-teams/"),
+      "index",
+    );
+    assert.strictEqual(datedPostSegment("https://vendor.example/blog/we-cut-our-prices"), "blog");
+    assert.strictEqual(datedPostSegment("https://vendor.example/en/news/2026/free-tier"), "news");
+    assert.strictEqual(datedPostSegment("https://vendor.example/changelog/v4"), "changelog");
+  });
+
+  it("leaves a page that is rewritten when the price changes", () => {
+    assert.strictEqual(datedPostSegment("https://developers.openai.com/codex/pricing/"), null);
+    assert.strictEqual(datedPostSegment("https://vendor.example/pricing"), null);
+    assert.strictEqual(datedPostSegment("https://vendor.example/plans/team"), null);
+  });
+
+  it("does not read a listing page as one of its own entries", () => {
+    assert.strictEqual(datedPostSegment("https://vendor.example/blog"), null);
+    assert.strictEqual(datedPostSegment("https://vendor.example/blog/"), null);
+  });
+
+  it("survives a url the catalogue cannot parse", () => {
+    assert.strictEqual(datedPostSegment("not a url"), null);
+  });
+
+  it("adds no record verified against a page that can never move", () => {
+    assert.deepStrictEqual(unbaselinedFrozenSources(offers), []);
+  });
+
+  it("would report one that was added, which is the only reason the line above means anything", () => {
+    const added = {
+      vendor: "Examplecorp",
+      description: "A record whose cited page is a post.",
+      url: "https://examplecorp.example/blog/we-changed-our-pricing",
+    };
+    assert.deepStrictEqual(unbaselinedFrozenSources([...offers, added]), [
+      "Examplecorp -> https://examplecorp.example/blog/we-changed-our-pricing",
+    ]);
+  });
+
+  it("carries a baseline every entry of which the catalogue still contains and still cites", () => {
+    for (const url of SOURCES_STILL_FROZEN_AT_PUBLICATION) {
+      assert.ok(
+        offers.some((o) => o.url === url),
+        `${url} is baselined but no record cites it, so the baseline should lose it`,
+      );
+      assert.ok(datedPostSegment(url), `${url} is baselined but is not a post`);
+    }
+  });
+
+  it("no longer verifies OpenAI Codex against one", () => {
+    assert.strictEqual(datedPostSegment(offerFor("OpenAI Codex").url), null);
+  });
+});
+
+describe("what the OpenAI Codex record tells a team pricing a coding agent", () => {
+  const description = offerFor("OpenAI Codex").description;
+
+  it("names both ChatGPT Business seat types, each with a per-user price", () => {
+    assert.match(description, /Standard at \$\d+(\.\d+)?\/user\/mo/);
+    assert.match(description, /Premium at \$\d+(\.\d+)?\/user\/mo/);
+  });
+
+  it("says what the more expensive seat buys, which is why anyone would pay it", () => {
+    assert.match(description, /Premium buys \d+x more usage than Standard/);
+    assert.match(description, /removes the five-hour usage limit/);
+  });
+
+  it("holds subscription access and token billing open at the same time", () => {
+    assert.match(description, /subscription/i);
+    assert.match(description, /billed on token use/i);
+    assert.doesNotMatch(description, /switched to pay-as-you-go/i);
+  });
+
+  it("does not offer a team a Business route that closed to new workspaces", () => {
+    assert.doesNotMatch(description, /Teams can add Codex-only seats/i);
+  });
+});


### PR DESCRIPTION
Refs #1172

## What was wrong

Our OpenAI Codex record enumerated the subscription routes into Codex and stopped one seat short. It named ChatGPT Business at `$20/user/mo` and did not mention the **Premium seat at `$100/user/mo`**, whose stated benefit is *5x more usage than Standard, with no 5-hour limit*. For a team running a coding agent, that limit — and the price of escaping it — is the decision. We published the cheap seat and omitted the one that answers the question.

Reading the page we cite turned up a second defect the issue did not name. `https://openai.com/index/codex-flexible-pricing-for-teams/` opens with:

> **Update on June 24, 2026:** Starting today, new Codex pay-as-you-go seats will no longer be available for Business plans. Existing pay-as-you-go seats are not affected.

Our record said *"Teams can add Codex-only seats with no rate limits, billed on token consumption"* — present tense, for a route that closed to new workspaces on 2026-06-24, **six weeks before the record's `verifiedDate` of 2026-08-02**. The correction was sitting on the page we cited the whole time.

## What changed

`data/index.json`, one record:

- **Both Business seat types, each with its price.** Standard `$20/user/mo` annual (`$25` monthly), Premium `$100/user/mo` annual (`$125` monthly), and what the Premium seat buys.
- **Subscriptions and token billing are stated concurrently.** `Switched to pay-as-you-go token-based pricing (April 2026)` is gone; both routes are current and the record now says so.
- **The closed route is described as closed** rather than offered.
- **`Pro ($200/mo)` → `Pro (from $100/mo)`.** Beyond the literal AC text, but it sits inside the sentence AC-1 required rewriting, and the page now cited says `From $100/month` with a `$200/month` tier above it. Re-asserting `$200` as the Pro price would have been publishing a figure this cycle proved wrong.
- **`source_url` → `https://developers.openai.com/codex/pricing/`.** A page that is rewritten when a price changes, not a post frozen at publication.
- **`verifiedDate` → `2026-08-30`, `source_check` → `ok`.** Both from a real read, not from a status code.

### Why that source_url, and what it costs

The issue's `403` diagnosis is about the wrong thing, and the distinction decides this choice. Same URL, same moment:

| Client | User agent | `openai.com/business/pricing/` |
|---|---|---|
| `curl` | our verifier string | **200**, 3/3 |
| Node `fetch` (what `fetchPageText` uses) | our verifier string | **403**, 3/3 |

The host is not blocking our identity — it serves the same string fine to `curl`. It is blocking the HTTP client. So an `openai.com` URL keeps `source_check: unreadable` no matter what we call ourselves, and AC-6 cannot be satisfied by picking a different page on that host.

I probed eight candidate pages with the real `fetchPageText`. **No page exists that both our fetcher can read and states the Premium seat.** `developers.openai.com/codex/pricing/` reads at 200 with 8 price signals and classifies `ok`; it carries Free `$0`, Go `$8`, Plus `$20`, Pro from `$100`, API-key token billing and Business `$20/user/month` inside the 12,000 characters we actually read — but no Premium seat. So the record states the Premium figures and says plainly that the page it cites does not list them and where they are published. That is AC-4's fallback applied where it actually bites.

Every added figure is on a page a third party can open: `openai.com/business/pricing/` renders *"Standard seat $20 / month … Premium seat $100 / month — 5x more usage than standard, with no 5-hour limit"* and *"All ChatGPT, ChatGPT Work, and Codex features"*; `openai.com/index/premium-seats-chatgpt-business/` states the same four prices in prose.

## What a reader gets back

`source_check: unreadable` was not cosmetic. Before, `/vendor/openai-codex` answered four of its FAQ questions with *"We cannot confirm that today. We could not read the page we cite for OpenAI Codex"*, showed `source unconfirmed` in its own comparison table, and withheld the stability level entirely — the API published `risk_level: null`. All four answers are now substantive, the level is `caution` with the recorded change as its cause, and the API publishes it.

## Tests

`test/source-can-show-a-later-price.test.ts`, 12 assertions in two groups.

The first states the property behind AC-4: **a page frozen at publication cannot report a price set after it.** `datedPostSegment` reads a post out of a URL path, with a ratchet over the whole catalogue so a new record citing one fails. One record remains and is baselined.

The second pins the claims the issue asked the record to make — both seat types each with a per-user price, what the expensive seat buys, subscriptions and token billing held open together, and the closed route not offered — by shape rather than by number, so a price change does not break them but a regression does.

`scripts/mutate-1172.sh`: **14 mutations, 14 killed, no survivors** — on the second pass. The first pass scored 13/1, and the survivor is the interesting one: replacing the ratchet's baseline filter with one that excludes every `http` URL made the sweep vacuous, and nothing noticed, because the ratchet had no positive control. It now also asserts that a record it *should* report is reported, and that every baselined URL is still cited by a record and still a post.

## Verification

- **2,731 / 2,731**, `tsc --noEmit` and `validate-data` clean at 1,580 offers / 444 changes, `no-private-context` green.
- **Sweep of all 3,916 published paths against a `main` worktree: 3,890 byte-identical.** The 26 that move are the Codex vendor page, the four `/compare/*-vs-openai-codex` pages, the `/alternative-to/*` and category pages that list Codex, `/stack-check`, and `/freshness` (verified-in-7-days 298 → 299). No path changes status; sponsored anchors unchanged at 76 across 71 pages.
- Real MCP `initialize` → `tools/call` on `search_deals`.
- Screenshots of the vendor page before and after.

## Reported, not fixed

Detail is on the issue. In short: `codex-mini` is no longer on OpenAI's API pricing page (out of scope per the issue, and the replacement figures are on the issue); the change record dated 2026-04-03 still states the closed pay-as-you-go seat in its `current_state`; and 3 of the 18 records carrying `source_check: HTTP 403` return 200 to `curl` with our own verifier string, which is a measurement for whoever picks up the wider `unreadable` question.