### PR TITLE
Credit the submitter of a converting code, not the last agent to ask for it

### DIFF
--- a/scripts/e2e-1163-split.mjs
+++ b/scripts/e2e-1163-split.mjs
@@ -1,0 +1,239 @@
+import { spawn } from "node:child_process";
+import { createServer } from "node:http";
+import { readFileSync, writeFileSync, existsSync, unlinkSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const REPO = path.join(path.dirname(fileURLToPath(import.meta.url)), "..");
+const TRACKED = [
+  "agents.json",
+  "referral_requests.json",
+  "referral_codes.json",
+  "ledger_entries.json",
+  "agent_balances.json",
+].map((f) => path.join(REPO, "data", f));
+
+const PLATFORM_SECRET = "e2e-split-secret";
+
+let passed = 0;
+let failed = 0;
+function check(label, ok, detail = "") {
+  if (ok) { passed++; console.log(`  PASS  ${label}`); }
+  else { failed++; console.log(`  FAIL  ${label}${detail ? ` — ${detail}` : ""}`); }
+}
+
+const originals = new Map();
+for (const p of TRACKED) originals.set(p, existsSync(p) ? readFileSync(p, "utf-8") : null);
+function restoreData() {
+  for (const [p, held] of originals) {
+    if (held !== null) writeFileSync(p, held, "utf-8");
+    else if (existsSync(p)) unlinkSync(p);
+  }
+}
+
+function upstashDouble() {
+  const keys = new Map();
+  const lists = new Map();
+  const server = createServer((req, res) => {
+    let body = "";
+    req.on("data", (c) => { body += c; });
+    req.on("end", () => {
+      let cmd = [];
+      try { cmd = JSON.parse(body); } catch { cmd = []; }
+      const op = String(cmd[0] ?? "").toUpperCase();
+      const key = String(cmd[1] ?? "");
+      let result = null;
+      if (op === "SET") { keys.set(key, String(cmd[2])); result = "OK"; }
+      else if (op === "GET") { result = keys.has(key) ? keys.get(key) : null; }
+      else if (op === "MGET") { result = cmd.slice(1).map((k) => keys.get(String(k)) ?? null); }
+      else if (op === "INCR") { const n = Number(keys.get(key) ?? "0") + 1; keys.set(key, String(n)); result = n; }
+      else if (op === "INCRBY") { const n = Number(keys.get(key) ?? "0") + Number(cmd[2]); keys.set(key, String(n)); result = n; }
+      else if (op === "LPUSH") { const l = lists.get(key) ?? []; for (const v of cmd.slice(2)) l.unshift(String(v)); lists.set(key, l); result = l.length; }
+      else if (op === "LRANGE") { result = (lists.get(key) ?? []).slice(Number(cmd[2]), Number(cmd[3]) + 1); }
+      else if (op === "LTRIM") { lists.set(key, (lists.get(key) ?? []).slice(Number(cmd[2]), Number(cmd[3]) + 1)); result = "OK"; }
+      else if (op === "DEL") { keys.delete(key); lists.delete(key); result = 1; }
+      else if (op === "EXPIRE") { result = 1; }
+      else if (op === "SCAN") { result = ["0", [...keys.keys()]]; }
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ result }));
+    });
+  });
+  return new Promise((resolve) => {
+    server.listen(0, "127.0.0.1", () => resolve({ server, url: `http://127.0.0.1:${server.address().port}` }));
+  });
+}
+
+function startServer(env) {
+  return new Promise((resolve, reject) => {
+    const proc = spawn("node", [path.join(REPO, "dist", "serve.js")], {
+      cwd: REPO,
+      stdio: ["pipe", "pipe", "pipe"],
+      env: { ...process.env, PORT: "0", BASE_URL: "http://127.0.0.1", ...env },
+    });
+    const timeout = setTimeout(() => { proc.kill("SIGKILL"); reject(new Error("startup timeout")); }, 30000);
+    proc.stderr.on("data", (b) => {
+      const m = b.toString().match(/running on http:\/\/localhost:(\d+)/);
+      if (m) { clearTimeout(timeout); resolve({ proc, port: parseInt(m[1], 10) }); }
+    });
+    proc.on("error", (e) => { clearTimeout(timeout); reject(e); });
+  });
+}
+
+async function mcpSession(base, clientName) {
+  const init = await fetch(`${base}/mcp`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json", Accept: "application/json, text/event-stream" },
+    body: JSON.stringify({
+      jsonrpc: "2.0", id: 1, method: "initialize",
+      params: { protocolVersion: "2025-06-18", capabilities: {}, clientInfo: { name: clientName, version: "1.0.0" } },
+    }),
+  });
+  const sessionId = init.headers.get("mcp-session-id");
+  await fetch(`${base}/mcp`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json", Accept: "application/json, text/event-stream", "Mcp-Session-Id": sessionId },
+    body: JSON.stringify({ jsonrpc: "2.0", method: "notifications/initialized" }),
+  });
+  let id = 1;
+  const rpc = async (method, params, offset) => {
+    const res = await fetch(`${base}/mcp`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Accept: "application/json, text/event-stream", "Mcp-Session-Id": sessionId },
+      body: JSON.stringify({ jsonrpc: "2.0", id: ++id + offset, method, params }),
+    });
+    const text = await res.text();
+    const line = text.split("\n").find((l) => l.startsWith("data: ")) ?? text;
+    return { res, payload: JSON.parse(line.replace(/^data: /, "")) };
+  };
+  return {
+    ok: init.status === 200 && !!sessionId,
+    async call(name, args) {
+      const { res, payload } = await rpc("tools/call", { name, arguments: args }, 100);
+      const content = payload?.result?.content?.[0]?.text ?? "";
+      let parsed = null;
+      try { parsed = JSON.parse(content); } catch { parsed = null; }
+      return { status: res.status, text: content, json: parsed };
+    },
+    async list() {
+      const { payload } = await rpc("tools/list", {}, 200);
+      return payload?.result?.tools ?? [];
+    },
+  };
+}
+
+const redis = await upstashDouble();
+let server;
+
+try {
+  for (const p of TRACKED) {
+    const property = path.basename(p, ".json");
+    writeFileSync(p, JSON.stringify({ [property]: [] }, null, 2), "utf-8");
+  }
+
+  server = await startServer({
+    UPSTASH_REDIS_REST_URL: redis.url,
+    UPSTASH_REDIS_REST_TOKEN: "e2e-split",
+    AGENTDEALS_PLATFORM_SECRET: PLATFORM_SECRET,
+    AGENTDEALS_ROLLUP_DIR: "/tmp/e2e-1163-split-rollups",
+  });
+  const base = `http://127.0.0.1:${server.port}`;
+
+  const stats = await (await fetch(`${base}/api/stats`)).json();
+  check("identity storage is durable for this run", stats.identity_storage?.durable === true);
+
+  console.log("\nA the published split");
+  const marketplace = await (await fetch(`${base}/marketplace`)).text();
+  const splits = marketplace.slice(marketplace.indexOf("Revenue Splits"), marketplace.indexOf("Code Ranking"));
+  check("split table names the submitter and the platform", /<th>Submitter<\/th><th>Platform<\/th>/.test(splits));
+  check("split table names no surfer", !/>\s*Surfer\s*</.test(splits));
+  check("agent-submitted row publishes 40/60", /An agent-submitted code converts<\/td><td>40%<\/td><td>60%<\/td>/.test(splits));
+  check("our own code publishes 100% platform", /One of our own codes converts<\/td><td>&mdash;<\/td><td>100%<\/td>/.test(splits));
+  check("page states there is no share for surfacing", splits.includes("There is no share for surfacing a code."));
+  check("no 70% or 80% share is published", !splits.includes("70%") && !splits.includes("80%"));
+
+  console.log("\nB two agents");
+  const reg = async (name) => (await (await fetch(`${base}/api/agents/register`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ name, api_key: true }),
+  })).json());
+  const submitter = await reg("e2e-split-submitter");
+  const requester = await reg("e2e-split-requester");
+  check("submitter registered", !!submitter.api_key, JSON.stringify(submitter).slice(0, 120));
+  check("requester registered", !!requester.api_key);
+
+  const vendor = "Railway";
+  const submitted = await (await fetch(`${base}/api/referral-codes`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json", Authorization: `Bearer ${submitter.api_key}` },
+    body: JSON.stringify({
+      vendor,
+      code: "E2ESPLIT",
+      referral_url: "https://railway.app?ref=e2esplit",
+      description: "End-to-end split check",
+    }),
+  })).json();
+  check("submitter's code is stored", submitted.code === "E2ESPLIT", JSON.stringify(submitted).slice(0, 160));
+
+  console.log("\nC the requester asks for the code over MCP");
+  const mcp = await mcpSession(base, "e2e-split-client");
+  check("MCP session established", mcp.ok);
+  const tools = await mcp.list();
+  const getCode = tools.find((t) => t.name === "get_referral_code");
+  check("get_referral_code no longer promises credit for asking", !/you'll be credited/.test(getCode?.description ?? ""), getCode?.description?.slice(0, 120));
+  check("get_referral_code names the submitter as the credited agent", /submitted the code/.test(getCode?.description ?? ""));
+
+  const fetched = await mcp.call("get_referral_code", { vendor, api_key: requester.api_key });
+  check("code is still returned to the requester", !!fetched.json?.referral_code || !!fetched.json?.code || fetched.text.length > 0);
+  check("request is reported as recorded", fetched.json?.attribution === "attributed", JSON.stringify(fetched.json?.attribution));
+  check("the note says asking does not earn a share", /does not itself earn a share/.test(fetched.json?.attribution_note ?? ""), fetched.json?.attribution_note);
+
+  console.log("\nD a conversion on the submitted code");
+  const conv = await fetch(`${base}/api/conversions`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json", Authorization: `Bearer ${PLATFORM_SECRET}` },
+    body: JSON.stringify({ vendor, referral_code: "E2ESPLIT", commission_amount: 100 }),
+  });
+  const entry = await conv.json();
+  check("conversion recorded", conv.status === 201, `${conv.status} ${JSON.stringify(entry).slice(0, 160)}`);
+  check("credited agent is the submitter", entry.agent_id === submitter.id, `${entry.agent_id} vs ${submitter.id}`);
+  check("submitter share is 40 of 100", entry.agent_share === 40, String(entry.agent_share));
+
+  const balOf = async (agent) => (await (await fetch(`${base}/api/agents/${agent.id}/balance`, {
+    headers: { Authorization: `Bearer ${agent.api_key}` },
+  })).json());
+  const submitterBalance = await balOf(submitter);
+  const requesterBalance = await balOf(requester);
+  check("submitter's pending balance is 40", submitterBalance.pending_balance === 40, String(submitterBalance.pending_balance));
+  check("requester earned nothing by asking", requesterBalance.pending_balance === 0, String(requesterBalance.pending_balance));
+
+  console.log("\nE a conversion on one of our own codes");
+  const ourConv = await fetch(`${base}/api/conversions`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json", Authorization: `Bearer ${PLATFORM_SECRET}` },
+    body: JSON.stringify({ vendor, referral_code: "railway-platform-code", commission_amount: 100 }),
+  });
+  const ourEntry = await ourConv.json();
+  check("conversion recorded", ourConv.status === 201, String(ourConv.status));
+  check("no agent is credited", ourEntry.agent_id === null, String(ourEntry.agent_id));
+  check("no agent share accrues", ourEntry.agent_share === 0, String(ourEntry.agent_share));
+  const afterOurs = await balOf(requester);
+  check("the last requester still earned nothing", afterOurs.pending_balance === 0, String(afterOurs.pending_balance));
+
+  console.log("\nF the leaderboard");
+  const lb = await (await fetch(`${base}/api/leaderboard`)).json();
+  check("leaderboard lists exactly one agent", lb.total === 1, JSON.stringify(lb.leaderboard?.map((e) => e.agent_name)));
+  check("that agent is the submitter", lb.leaderboard?.[0]?.agent_name === "e2e-split-submitter");
+
+  console.log("\nG check_balance over MCP");
+  const balance = await mcp.call("check_balance", { api_key: submitter.api_key });
+  check("check_balance reports the submitter's 40", balance.json?.pending_balance === 40, JSON.stringify(balance.json).slice(0, 160));
+  check("payouts still report unavailable", balance.json?.payouts_available === false);
+} finally {
+  if (server) server.proc.kill("SIGKILL");
+  redis.server.close();
+  restoreData();
+}
+
+console.log(`\n${passed} passed, ${failed} failed`);
+process.exit(failed === 0 ? 0 : 1);

--- a/scripts/mutate-1163-split.sh
+++ b/scripts/mutate-1163-split.sh
@@ -1,0 +1,235 @@
+#!/usr/bin/env bash
+set -u
+
+REPO="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$REPO" || exit 1
+
+LEDGER="src/ledger.ts"
+CODES="src/referral-codes.ts"
+SERVE="src/serve.ts"
+SERVER="src/server.ts"
+ATTRIB="src/referral-attribution.ts"
+BACKUP_DIR="$(mktemp -d)"
+for f in "$LEDGER" "$CODES" "$SERVE" "$SERVER" "$ATTRIB"; do
+  cp "$f" "$BACKUP_DIR/$(basename "$f")"
+done
+
+restore() {
+  for f in "$LEDGER" "$CODES" "$SERVE" "$SERVER" "$ATTRIB"; do
+    cp "$BACKUP_DIR/$(basename "$f")" "$f"
+  done
+}
+trap 'restore; npm run build > /dev/null 2>&1' EXIT
+
+killed=0
+survived=0
+TESTS="test/ledger.test.ts test/ranking-leaderboard.test.ts test/payout.test.ts test/marketplace-dashboard.test.ts"
+
+py() { python3 - "$@"; }
+
+changed_any() {
+  for f in "$LEDGER" "$CODES" "$SERVE" "$SERVER" "$ATTRIB"; do
+    if ! diff -q "$BACKUP_DIR/$(basename "$f")" "$f" > /dev/null; then
+      return 0
+    fi
+  done
+  return 1
+}
+
+run_mutation() {
+  local name="$1"
+  shift
+  local scope="$TESTS"
+  if [ "$1" = "--only" ]; then
+    scope="$2"
+    shift 2
+  fi
+  echo "=== $name"
+  restore
+  "$@"
+  if ! changed_any; then
+    echo "    NOT APPLIED: the mutation changed no file, so it proves nothing"
+    survived=$((survived + 1))
+    return
+  fi
+  if ! npm run build > /tmp/mutate-1163-split-build.log 2>&1; then
+    echo "    DID NOT COMPILE: a mutation the compiler rejects proves nothing about the tests"
+    survived=$((survived + 1))
+    return
+  fi
+  if timeout 900 node --test --test-concurrency 1 $scope > /tmp/mutate-1163-split-test.log 2>&1; then
+    echo "    SURVIVED"
+    survived=$((survived + 1))
+  else
+    echo "    KILLED: $(grep -c '✖ ' /tmp/mutate-1163-split-test.log) failing assertion(s)"
+    grep '✖ ' /tmp/mutate-1163-split-test.log | head -3
+    killed=$((killed + 1))
+  fi
+}
+
+m_submitter_share_rate_back_to_seventy() {
+  py <<'PY'
+p = "src/ledger.ts"
+s = open(p).read()
+s = s.replace("export const SUBMITTER_SHARE_RATE = 0.4;", "export const SUBMITTER_SHARE_RATE = 0.7;")
+open(p, "w").write(s)
+PY
+}
+
+m_share_accrues_to_everyone_even_without_a_submitter() {
+  py <<'PY'
+p = "src/ledger.ts"
+s = open(p).read()
+s = s.replace("const submitterShare = submitterId ? roundCents(commission * SUBMITTER_SHARE_RATE) : 0;",
+              "const submitterShare = roundCents(commission * SUBMITTER_SHARE_RATE);")
+open(p, "w").write(s)
+PY
+}
+
+m_balance_is_never_updated() {
+  py <<'PY'
+p = "src/ledger.ts"
+s = open(p).read()
+s = s.replace("  if (submitterId && submitterShare > 0) {\n    const submitterBalance = getOrCreateBalance(submitterId);",
+              "  if (false as boolean) {\n    const submitterBalance = getOrCreateBalance(submitterId!);")
+open(p, "w").write(s)
+PY
+}
+
+m_entry_records_no_credited_agent() {
+  py <<'PY'
+p = "src/ledger.ts"
+s = open(p).read()
+s = s.replace("    agent_id: submitterId,\n    submitter_id: submitterId,",
+              "    agent_id: null,\n    submitter_id: submitterId,")
+open(p, "w").write(s)
+PY
+}
+
+m_share_is_recorded_on_the_wrong_field() {
+  py <<'PY'
+p = "src/ledger.ts"
+s = open(p).read()
+s = s.replace("    agent_share: submitterShare,\n    submitter_share: 0,",
+              "    agent_share: 0,\n    submitter_share: submitterShare,")
+open(p, "w").write(s)
+PY
+}
+
+m_rounding_is_dropped() {
+  py <<'PY'
+p = "src/ledger.ts"
+s = open(p).read()
+s = s.replace("const submitterShare = submitterId ? roundCents(commission * SUBMITTER_SHARE_RATE) : 0;",
+              "const submitterShare = submitterId ? commission * SUBMITTER_SHARE_RATE : 0;")
+open(p, "w").write(s)
+PY
+}
+
+m_code_lookup_ignores_the_vendor() {
+  py <<'PY'
+p = "src/referral-codes.ts"
+s = open(p).read()
+s = s.replace("const match = loadCodes().find(c => c.vendor.toLowerCase() === lowerName && c.code === code);",
+              "const match = loadCodes().find(c => c.code === code);")
+open(p, "w").write(s)
+PY
+}
+
+m_code_lookup_ignores_the_code() {
+  py <<'PY'
+p = "src/referral-codes.ts"
+s = open(p).read()
+s = s.replace("const match = loadCodes().find(c => c.vendor.toLowerCase() === lowerName && c.code === code);",
+              "const match = loadCodes().find(c => c.vendor.toLowerCase() === lowerName);")
+open(p, "w").write(s)
+PY
+}
+
+m_code_lookup_is_vendor_case_sensitive() {
+  py <<'PY'
+p = "src/referral-codes.ts"
+s = open(p).read()
+s = s.replace("const match = loadCodes().find(c => c.vendor.toLowerCase() === lowerName && c.code === code);",
+              "const match = loadCodes().find(c => c.vendor === vendorName && c.code === code);")
+open(p, "w").write(s)
+PY
+}
+
+m_empty_code_resolves_to_a_submitter() {
+  py <<'PY'
+p = "src/referral-codes.ts"
+s = open(p).read()
+s = s.replace('  if (!code) return null;\n  const lowerName = vendorName.toLowerCase();',
+              '  const lowerName = vendorName.toLowerCase();')
+open(p, "w").write(s)
+PY
+}
+
+m_page_publishes_a_surfer_column_again() {
+  py <<'PY'
+p = "src/serve.ts"
+s = open(p).read()
+s = s.replace("<thead><tr><th>Scenario</th><th>Submitter</th><th>Platform</th></tr></thead>",
+              "<thead><tr><th>Scenario</th><th>Surfer</th><th>Submitter</th><th>Platform</th></tr></thead>")
+open(p, "w").write(s)
+PY
+}
+
+m_page_publishes_the_old_seventy_thirty_row() {
+  py <<'PY'
+p = "src/serve.ts"
+s = open(p).read()
+s = s.replace("<tr><td>One of our own codes converts</td><td>&mdash;</td><td>100%</td></tr>",
+              "<tr><td>One of our own codes converts</td><td>70%</td><td>30%</td></tr>")
+open(p, "w").write(s)
+PY
+}
+
+m_page_drops_the_no_surfacing_share_statement() {
+  py <<'PY'
+p = "src/serve.ts"
+s = open(p).read()
+s = s.replace('<strong style="color:var(--text)">There is no share for surfacing a code.</strong> ', '')
+open(p, "w").write(s)
+PY
+}
+
+m_the_rate_changes_and_the_page_does_not_follow() {
+  py <<'PY'
+p = "src/serve.ts"
+s = open(p).read()
+s = s.replace("const submitterSharePercent = Math.round(SUBMITTER_SHARE_RATE * 100);",
+              "const submitterSharePercent = 40;")
+open(p, "w").write(s)
+
+p = "src/ledger.ts"
+s = open(p).read()
+s = s.replace("export const SUBMITTER_SHARE_RATE = 0.4;", "export const SUBMITTER_SHARE_RATE = 0.5;")
+open(p, "w").write(s)
+PY
+}
+
+
+echo "Mutation testing the revenue split: what must fail if the rule or the published table drifts"
+echo
+
+run_mutation "the submitter share rate goes back to 70%" m_submitter_share_rate_back_to_seventy
+run_mutation "a share accrues even when no agent submitted the code" m_share_accrues_to_everyone_even_without_a_submitter
+run_mutation "the credited agent's balance is never updated" m_balance_is_never_updated
+run_mutation "the entry records no credited agent" m_entry_records_no_credited_agent
+run_mutation "the share is recorded on submitter_share instead of agent_share" m_share_is_recorded_on_the_wrong_field
+run_mutation "the share is not rounded to cents" m_rounding_is_dropped
+run_mutation "the code lookup ignores the vendor" m_code_lookup_ignores_the_vendor
+run_mutation "the code lookup ignores the code" m_code_lookup_ignores_the_code
+run_mutation "the code lookup becomes vendor case-sensitive" m_code_lookup_is_vendor_case_sensitive
+run_mutation "an empty code resolves to a submitter" m_empty_code_resolves_to_a_submitter
+run_mutation "the page publishes a surfer column again" m_page_publishes_a_surfer_column_again
+run_mutation "the page publishes the old 70/30 row" m_page_publishes_the_old_seventy_thirty_row
+run_mutation "the page drops the no-surfacing-share statement" m_page_drops_the_no_surfacing_share_statement
+run_mutation "the rate changes and the published table does not follow" --only "test/marketplace-dashboard.test.ts" m_the_rate_changes_and_the_page_does_not_follow
+
+echo
+echo "killed:   $killed"
+echo "survived: $survived"
+[ "$survived" -eq 0 ]

--- a/src/ledger.ts
+++ b/src/ledger.ts
@@ -2,9 +2,8 @@ import fs from "node:fs";
 import path from "node:path";
 import { randomBytes } from "node:crypto";
 import { fileURLToPath } from "node:url";
-import { attributeConversion, markConversion, getRequestsByAgent } from "./referral-requests.js";
 import { updateAgentTrustTier, getAgentById } from "./agents.js";
-import { calculateTrustTier, getCodesByAgent } from "./referral-codes.js";
+import { calculateTrustTier, getCodesByAgent, submitterOfCode } from "./referral-codes.js";
 import { createDurableStore } from "./durable-store.js";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -12,13 +11,11 @@ const LEDGER_PATH = path.join(__dirname, "..", "data", "ledger_entries.json");
 const BALANCES_PATH = path.join(__dirname, "..", "data", "agent_balances.json");
 const CLAWBACK_CONFIG_PATH = path.join(__dirname, "..", "data", "vendor_clawback.json");
 
-// Revenue splits
-// Standard (curated codes): 70% to surfacing agent, 30% to AgentDeals
-const STANDARD_AGENT_SHARE_RATE = 0.7;
-// Agent-submitted codes — same agent submitted and surfaced: 80% agent, 20% platform
-const SINGLE_AGENT_SHARE_RATE = 0.8;
-// Agent-submitted codes — different agents: 40% submitter, 40% surfer, 20% platform
-const DUAL_AGENT_SHARE_RATE = 0.4;
+// Revenue split. The agent that submitted the code a conversion was reported
+// against receives this share; the platform receives the rest. There is no
+// share for showing a code to a user — that is not an event we observe.
+// /marketplace renders its published table from this constant.
+export const SUBMITTER_SHARE_RATE = 0.4;
 
 export const MAX_COMMISSION_AMOUNT = 10_000;
 
@@ -155,20 +152,20 @@ function roundCents(n: number): number {
 // --- Core operations ---
 
 /**
- * Record a new conversion. Looks up attribution, creates ledger entries with
- * status "pending", and updates agent balances.
+ * Record a new conversion. Resolves the submitting agent from the code the
+ * conversion was reported against, creates a ledger entry with status
+ * "pending", and updates that agent's balance.
  *
- * When submitter_id is provided (agent-submitted code):
- * - Same agent submitted AND surfaced: 80% agent / 20% platform
- * - Different agents: 40% submitter / 40% surfer / 20% platform
- * When no submitter_id (curated code): 70% surfer / 30% platform
+ * A code we hold a submission record for credits its submitter at
+ * SUBMITTER_SHARE_RATE; the platform takes the rest. One of our own codes
+ * credits no agent. Nothing is credited for showing a code to a user — that
+ * is not an event we can observe, so it is not an event we pay for.
  */
 export function recordConversion(opts: {
   vendor: string;
   referral_code: string;
   commission_amount: number;
   conversion_date?: string;
-  submitter_id?: string | null;
   metadata?: Record<string, unknown>;
 }): LedgerEntry {
   const conversionDate = opts.conversion_date
@@ -176,46 +173,25 @@ export function recordConversion(opts: {
     : new Date();
   const conversionDateStr = conversionDate.toISOString().split("T")[0];
 
-  // Look up attribution (surfacing agent)
-  const surfacingAgentId = attributeConversion(opts.vendor, conversionDate);
-  const submitterId = opts.submitter_id ?? null;
+  const submitterId = submitterOfCode(opts.vendor, opts.referral_code);
 
   const clawbackDays = getClawbackDays(opts.vendor);
   const clawbackEnd = new Date(conversionDate);
   clawbackEnd.setDate(clawbackEnd.getDate() + clawbackDays);
 
-  // Calculate shares based on agent-submitted vs curated
-  let surferShare = 0;
-  let submitterShare = 0;
   const commission = roundCents(opts.commission_amount);
-
-  if (submitterId && surfacingAgentId) {
-    if (submitterId === surfacingAgentId) {
-      // Same agent submitted and surfaced: 80/20
-      surferShare = roundCents(commission * SINGLE_AGENT_SHARE_RATE);
-    } else {
-      // Different agents: 40/40/20
-      surferShare = roundCents(commission * DUAL_AGENT_SHARE_RATE);
-      submitterShare = roundCents(commission * DUAL_AGENT_SHARE_RATE);
-    }
-  } else if (submitterId && !surfacingAgentId) {
-    // Agent submitted code but no surfacing attribution — submitter gets 40%
-    submitterShare = roundCents(commission * DUAL_AGENT_SHARE_RATE);
-  } else if (surfacingAgentId) {
-    // Curated code with surfacing agent: 70/30
-    surferShare = roundCents(commission * STANDARD_AGENT_SHARE_RATE);
-  }
+  const submitterShare = submitterId ? roundCents(commission * SUBMITTER_SHARE_RATE) : 0;
 
   const entry: LedgerEntry = {
     id: generateLedgerId(),
-    agent_id: surfacingAgentId,
+    agent_id: submitterId,
     submitter_id: submitterId,
     vendor: opts.vendor,
     referral_code: opts.referral_code,
     event_type: "conversion",
     commission_amount: commission,
-    agent_share: surferShare,
-    submitter_share: submitterShare,
+    agent_share: submitterShare,
+    submitter_share: 0,
     status: "pending",
     conversion_date: conversionDateStr,
     clawback_window_ends: clawbackEnd.toISOString().split("T")[0],
@@ -230,26 +206,7 @@ export function recordConversion(opts: {
   ledger.push(entry);
   saveLedger(ledger);
 
-  // Update surfacing agent balance
-  if (surfacingAgentId && surferShare > 0) {
-    const balance = getOrCreateBalance(surfacingAgentId);
-    balance.pending_balance = roundCents(balance.pending_balance + surferShare);
-    balance.updated_at = new Date().toISOString();
-    saveBalances(loadBalances());
-
-    // Mark the referral request as converted
-    const requests = getRequestsByAgent(surfacingAgentId);
-    const vendorLower = opts.vendor.toLowerCase();
-    const matchingRequest = requests
-      .filter(r => r.vendor.toLowerCase() === vendorLower && !r.conversion_id)
-      .sort((a, b) => new Date(b.requested_at).getTime() - new Date(a.requested_at).getTime())[0];
-    if (matchingRequest) {
-      markConversion(matchingRequest.id, entry.id);
-    }
-  }
-
-  // Update submitter balance if different from surfer
-  if (submitterId && submitterShare > 0 && submitterId !== surfacingAgentId) {
+  if (submitterId && submitterShare > 0) {
     const submitterBalance = getOrCreateBalance(submitterId);
     submitterBalance.pending_balance = roundCents(submitterBalance.pending_balance + submitterShare);
     submitterBalance.updated_at = new Date().toISOString();
@@ -300,7 +257,7 @@ export function confirmEligibleEntries(asOfDate?: Date): string[] {
     entry.confirmed_at = new Date().toISOString();
     confirmed.push(entry.id);
 
-    // Update surfacing agent balance
+    // Update the credited agent's balance
     if (entry.agent_id && entry.agent_share > 0) {
       const balance = getOrCreateBalance(entry.agent_id);
       balance.pending_balance = roundCents(balance.pending_balance - entry.agent_share);
@@ -309,7 +266,7 @@ export function confirmEligibleEntries(asOfDate?: Date): string[] {
       balance.updated_at = new Date().toISOString();
     }
 
-    // Update submitter balance if different from surfer
+    // Update the submitter balance when an entry carries one separately
     const submitterShare = entry.submitter_share ?? 0;
     if (entry.submitter_id && submitterShare > 0 && entry.submitter_id !== entry.agent_id) {
       const submitterBalance = getOrCreateBalance(entry.submitter_id);
@@ -372,14 +329,14 @@ export function clawbackEntry(entryId: string, reason?: string): boolean {
   // Update original entry
   entry.status = "clawed_back";
 
-  // Update surfacing agent balance
+  // Update the credited agent's balance
   if (entry.agent_id && entry.agent_share > 0) {
     const balance = getOrCreateBalance(entry.agent_id);
     balance.pending_balance = roundCents(balance.pending_balance - entry.agent_share);
     balance.updated_at = new Date().toISOString();
   }
 
-  // Update submitter balance if different from surfer
+  // Update the submitter balance when an entry carries one separately
   const submitterShare = entry.submitter_share ?? 0;
   if (entry.submitter_id && submitterShare > 0 && entry.submitter_id !== entry.agent_id) {
     const submitterBalance = getOrCreateBalance(entry.submitter_id);

--- a/src/referral-attribution.ts
+++ b/src/referral-attribution.ts
@@ -21,14 +21,15 @@ export interface AttributableReferral {
 }
 
 export const ATTRIBUTION_NOTES: Record<AttributionStatus, string> = {
-  attributed: "Recorded for attribution against your agent.",
+  attributed:
+    "Recorded against your agent. Requesting a code does not itself earn a share of a commission — a commission is credited to the agent that submitted the code it was reported against.",
   no_key: "No API key was supplied, so this request was not attributed to any agent.",
   key_not_recognised:
     "This API key is not in the agent registry, so nothing was attributed. Register again with register_agent to get a key that resolves.",
   registry_unavailable:
     "The agent registry could not be read, so this request was not attributed. Your key may still be valid — retry later.",
   not_recorded:
-    "Your key was recognised, but the attribution could not be stored, so no credit will be recorded for this request.",
+    "Your key was recognised, but the request could not be stored, so it was not recorded against your agent.",
 };
 
 function outcome(status: AttributionStatus): AttributionOutcome {

--- a/src/referral-codes.ts
+++ b/src/referral-codes.ts
@@ -228,6 +228,19 @@ export function getCodeById(id: string): SubmittedReferralCode | null {
 }
 
 /**
+ * Resolve the agent that submitted a code, from the vendor and code string a
+ * conversion was reported against. Returns null for one of our own curated
+ * codes, and for any code we hold no submission record for. Revoked and expired
+ * submissions still resolve: the agent did submit the code that converted.
+ */
+export function submitterOfCode(vendorName: string, code: string): string | null {
+  if (!code) return null;
+  const lowerName = vendorName.toLowerCase();
+  const match = loadCodes().find(c => c.vendor.toLowerCase() === lowerName && c.code === code);
+  return match ? match.submitted_by : null;
+}
+
+/**
  * Update a submitted code. Only the owner can update.
  * Returns the updated code or throws.
  */

--- a/src/referral-requests.ts
+++ b/src/referral-requests.ts
@@ -64,34 +64,6 @@ export function logReferralRequest(opts: {
 }
 
 /**
- * Last-touch attribution: find the most recent agent that requested a referral
- * code for the given vendor within the lookback window.
- * Returns the agent_id or null if no match.
- */
-export function attributeConversion(
-  vendor: string,
-  conversionDate: Date,
-  lookbackDays: number = 90
-): string | null {
-  const requests = loadRequests();
-  const cutoff = new Date(conversionDate.getTime() - lookbackDays * 24 * 60 * 60 * 1000);
-  const vendorLower = vendor.toLowerCase();
-
-  // Filter to matching vendor within lookback window
-  const eligible = requests.filter(r => {
-    if (r.vendor.toLowerCase() !== vendorLower) return false;
-    const requestedAt = new Date(r.requested_at);
-    return requestedAt >= cutoff && requestedAt <= conversionDate;
-  });
-
-  if (eligible.length === 0) return null;
-
-  // Last-touch: most recent request wins
-  eligible.sort((a, b) => new Date(b.requested_at).getTime() - new Date(a.requested_at).getTime());
-  return eligible[0].agent_id;
-}
-
-/**
  * Get all referral requests for a specific agent.
  */
 export function getRequestsByAgent(agentId: string): ReferralRequest[] {
@@ -103,14 +75,4 @@ export function getRequestsByAgent(agentId: string): ReferralRequest[] {
  */
 export function getRequestById(id: string): ReferralRequest | null {
   return loadRequests().find(r => r.id === id) ?? null;
-}
-
-/**
- * Mark a referral request as converted by setting the conversion_id.
- */
-export function markConversion(requestId: string, conversionId: string): boolean {
-  const requests = loadRequests();
-  if (!requests.some(r => r.id === requestId)) return false;
-  saveRequests(requests.map(r => (r.id === requestId ? { ...r, conversion_id: conversionId } : r)));
-  return true;
 }

--- a/src/serve.ts
+++ b/src/serve.ts
@@ -23,7 +23,7 @@ import { publishedVendorLevel, vendorVerdictSentence, narrowingSentence, changeK
 import { growthLimitPhrases } from "./growth-limits.js";
 import { registerAgent, authenticateRequest, validateVestauthUrl, hashApiKey, updateAgentX402Address, getAgentById } from "./agents.js";
 import { attributeAuthenticatedRequest } from "./referral-attribution.js";
-import { recordConversion, confirmEligibleEntries, clawbackEntry, getAgentBalance, getAgentLedgerEntries, recordPayout, MAX_COMMISSION_AMOUNT, MINIMUM_PAYOUT_AMOUNT, getLeaderboard } from "./ledger.js";
+import { recordConversion, confirmEligibleEntries, clawbackEntry, getAgentBalance, getAgentLedgerEntries, recordPayout, MAX_COMMISSION_AMOUNT, MINIMUM_PAYOUT_AMOUNT, SUBMITTER_SHARE_RATE, getLeaderboard } from "./ledger.js";
 import { PLATFORM_CREDENTIAL_REQUIRED, authorizedAsPlatform } from "./platform-auth.js";
 import { createRegistrationLimiter, rateLimitHeaders } from "./rate-limit.js";
 import { validateX402Address, executeTransfer, generateCorrelationId, payoutsAvailable, PAYOUTS_UNAVAILABLE_REASON } from "./x402.js";
@@ -51353,6 +51353,8 @@ function buildMarketplacePage(): string {
   };
 
   const leaderboard = getLeaderboard({ limit: 5 });
+  const submitterSharePercent = Math.round(SUBMITTER_SHARE_RATE * 100);
+  const platformSharePercent = 100 - submitterSharePercent;
 
   return `<!DOCTYPE html>
 <html lang="en">
@@ -51456,15 +51458,15 @@ ${globalNavCss()}
 
   <div class="section">
     <h2>Revenue Splits</h2>
-    <p>Revenue is split between the agent that surfaces the code (shows it to a user), the agent that submitted the code, and the platform:</p>
+    <p>Revenue is split between the agent that submitted the code a conversion is reported against, and the platform. The submitter is resolved from the code itself &mdash; the vendor names a code, and we either hold a submission record for it or we do not:</p>
     <table class="split-table">
-      <thead><tr><th>Scenario</th><th>Surfer</th><th>Submitter</th><th>Platform</th></tr></thead>
+      <thead><tr><th>Scenario</th><th>Submitter</th><th>Platform</th></tr></thead>
       <tbody>
-        <tr><td>Curated code (no agent submitter)</td><td>70%</td><td>&mdash;</td><td>30%</td></tr>
-        <tr><td>Single agent (surfs own code)</td><td colspan="2" style="text-align:center">80%</td><td>20%</td></tr>
-        <tr><td>Dual agent (different surfer &amp; submitter)</td><td>40%</td><td>40%</td><td>20%</td></tr>
+        <tr><td>An agent-submitted code converts</td><td>${submitterSharePercent}%</td><td>${platformSharePercent}%</td></tr>
+        <tr><td>One of our own codes converts</td><td>&mdash;</td><td>100%</td></tr>
       </tbody>
     </table>
+    <p><strong style="color:var(--text)">There is no share for surfacing a code.</strong> An agent showing a code to a user is not something we observe, so we cannot tell an agent that did it from one that says it did. The only signal we hold is a call to <code>get_referral_code</code>, and asking us for a code is not evidence that anyone saw it &mdash; any registered agent can make that call. We would rather publish a smaller split we can stand behind than a larger one we cannot check. If that changes &mdash; if a conversion can be tied to a click we served &mdash; this table changes with it.</p>
   </div>
 
   <div class="section">

--- a/src/server.ts
+++ b/src/server.ts
@@ -1082,7 +1082,7 @@ Suggested monitoring cadence: run this check weekly to catch pricing changes ear
     "get_referral_code",
     {
       description:
-        "Get the referral code and URL for a specific vendor. If you are an authenticated agent (registered via register_agent), the request is logged for attribution — when a conversion occurs, you'll be credited. Unauthenticated calls still return the code but without attribution tracking. The response always states whether attribution happened and, when it did not, why.",
+        "Get the referral code and URL for a specific vendor. If you are an authenticated agent (registered via register_agent), the request is recorded against your agent. Requesting a code does not itself earn a share of any commission: a commission is credited to the agent that submitted the code it was reported against, because showing a code to a user is not an event we can observe. Unauthenticated calls still return the code. The response always states whether the request was recorded and, when it was not, why.",
       annotations: {
         readOnlyHint: true,
         destructiveHint: false,

--- a/test/ledger.test.ts
+++ b/test/ledger.test.ts
@@ -8,7 +8,7 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const LEDGER_PATH = path.join(__dirname, "..", "data", "ledger_entries.json");
 const BALANCES_PATH = path.join(__dirname, "..", "data", "agent_balances.json");
 const CLAWBACK_PATH = path.join(__dirname, "..", "data", "vendor_clawback.json");
-const REQUESTS_PATH = path.join(__dirname, "..", "data", "referral_requests.json");
+const CODES_PATH = path.join(__dirname, "..", "data", "referral_codes.json");
 const AGENTS_PATH = path.join(__dirname, "..", "data", "agents.json");
 
 const {
@@ -23,19 +23,19 @@ const {
   resetLedgerCache,
 } = await import("../dist/ledger.js");
 
-const { logReferralRequest, resetReferralRequestsCache } = await import("../dist/referral-requests.js");
+const { resetReferralCodesCache } = await import("../dist/referral-codes.js");
 const { registerAgent, resetAgentsCache } = await import("../dist/agents.js");
 
 // Save original data
 let origLedger: string | null = null;
 let origBalances: string | null = null;
-let origRequests: string | null = null;
+let origCodes: string | null = null;
 let origAgents: string | null = null;
 
 function saveOriginals() {
   origLedger = fs.existsSync(LEDGER_PATH) ? fs.readFileSync(LEDGER_PATH, "utf-8") : null;
   origBalances = fs.existsSync(BALANCES_PATH) ? fs.readFileSync(BALANCES_PATH, "utf-8") : null;
-  origRequests = fs.existsSync(REQUESTS_PATH) ? fs.readFileSync(REQUESTS_PATH, "utf-8") : null;
+  origCodes = fs.existsSync(CODES_PATH) ? fs.readFileSync(CODES_PATH, "utf-8") : null;
   origAgents = fs.existsSync(AGENTS_PATH) ? fs.readFileSync(AGENTS_PATH, "utf-8") : null;
 }
 
@@ -44,48 +44,54 @@ function restoreOriginals() {
   else if (fs.existsSync(LEDGER_PATH)) fs.unlinkSync(LEDGER_PATH);
   if (origBalances !== null) fs.writeFileSync(BALANCES_PATH, origBalances);
   else if (fs.existsSync(BALANCES_PATH)) fs.unlinkSync(BALANCES_PATH);
-  if (origRequests !== null) fs.writeFileSync(REQUESTS_PATH, origRequests);
-  else if (fs.existsSync(REQUESTS_PATH)) fs.unlinkSync(REQUESTS_PATH);
+  if (origCodes !== null) fs.writeFileSync(CODES_PATH, origCodes);
+  else if (fs.existsSync(CODES_PATH)) fs.unlinkSync(CODES_PATH);
   if (origAgents !== null) fs.writeFileSync(AGENTS_PATH, origAgents);
   else if (fs.existsSync(AGENTS_PATH)) fs.unlinkSync(AGENTS_PATH);
   resetLedgerCache();
-  resetReferralRequestsCache();
+  resetReferralCodesCache();
   resetAgentsCache();
 }
 
 function resetFiles() {
   fs.writeFileSync(LEDGER_PATH, JSON.stringify({ ledger_entries: [] }), "utf-8");
   fs.writeFileSync(BALANCES_PATH, JSON.stringify({ agent_balances: [] }), "utf-8");
-  fs.writeFileSync(REQUESTS_PATH, JSON.stringify({ referral_requests: [] }), "utf-8");
+  fs.writeFileSync(CODES_PATH, JSON.stringify({ referral_codes: [] }), "utf-8");
   fs.writeFileSync(AGENTS_PATH, JSON.stringify({ agents: [] }), "utf-8");
   resetLedgerCache();
-  resetReferralRequestsCache();
+  resetReferralCodesCache();
   resetAgentsCache();
 }
 
 /**
- * Write a referral request directly with a controlled requested_at timestamp.
- * Needed for tests where the conversion_date is in the past relative to "now".
+ * Write a submission record straight to the store, so a conversion reported
+ * against this code resolves to this agent. Bypasses submitReferralCode's
+ * offers-index check, which lets these tests keep using a vendor that is
+ * deliberately absent from the index to exercise the default clawback window.
  */
-function writeReferralRequestWithDate(opts: {
-  agent_id: string;
-  vendor: string;
-  referral_code: string;
-  referral_url: string;
-  requested_at: string;
-}) {
-  const raw = JSON.parse(fs.readFileSync(REQUESTS_PATH, "utf-8"));
-  raw.referral_requests.push({
-    id: `rr_test_${Date.now()}_${Math.random().toString(36).slice(2)}`,
-    agent_id: opts.agent_id,
+function writeSubmittedCode(opts: { agent_id: string; vendor: string; code: string }) {
+  const raw = JSON.parse(fs.readFileSync(CODES_PATH, "utf-8"));
+  const now = new Date().toISOString();
+  raw.referral_codes.push({
+    id: `code_test_${Date.now()}_${Math.random().toString(36).slice(2)}`,
     vendor: opts.vendor,
-    referral_code: opts.referral_code,
-    referral_url: opts.referral_url,
-    requested_at: opts.requested_at,
-    conversion_id: null,
+    code: opts.code,
+    referral_url: "https://example.com?ref=test",
+    description: "",
+    commission_rate: null,
+    expiry: null,
+    submitted_by: opts.agent_id,
+    source: "agent-submitted",
+    status: "active",
+    trust_tier_at_submission: "new",
+    impressions: 0,
+    clicks: 0,
+    conversions: 0,
+    submitted_at: now,
+    updated_at: now,
   });
-  fs.writeFileSync(REQUESTS_PATH, JSON.stringify(raw), "utf-8");
-  resetReferralRequestsCache();
+  fs.writeFileSync(CODES_PATH, JSON.stringify(raw), "utf-8");
+  resetReferralCodesCache();
 }
 
 before(() => {
@@ -142,26 +148,19 @@ describe("Record Conversion", () => {
     assert.strictEqual(entry.paid_out_at, null);
   });
 
-  it("calculates agent_share as 70% of commission_amount", () => {
+  it("credits no agent when the code is not one an agent submitted", () => {
     const entry = recordConversion({
       vendor: "Railway",
       referral_code: "TESTCODE",
       commission_amount: 100.00,
     });
-    // No attributed agent, so agent_share is 0
     assert.strictEqual(entry.agent_share, 0);
     assert.strictEqual(entry.agent_id, null);
   });
 
-  it("attributes to agent and sets 70% share", () => {
-    // Register an agent and log a referral request
+  it("credits the submitting agent 40% of the commission", () => {
     const result = registerAgent({ name: "TestBot" });
-    logReferralRequest({
-      agent_id: result.agent.id,
-      vendor: "Railway",
-      referral_code: "TESTCODE",
-      referral_url: "https://railway.app?ref=TESTCODE",
-    });
+    writeSubmittedCode({ agent_id: result.agent.id, vendor: "Railway", code: "TESTCODE" });
 
     const entry = recordConversion({
       vendor: "Railway",
@@ -170,32 +169,22 @@ describe("Record Conversion", () => {
     });
 
     assert.strictEqual(entry.agent_id, result.agent.id);
-    assert.strictEqual(entry.agent_share, 70.00);
+    assert.strictEqual(entry.agent_share, 40.00);
   });
 
-  it("calculates 70% share correctly for various amounts", () => {
+  it("calculates the submitter share correctly for various amounts", () => {
     const agent = registerAgent({ name: "ShareBot" });
-    logReferralRequest({
-      agent_id: agent.agent.id,
-      vendor: "Railway",
-      referral_code: "CODE",
-      referral_url: "https://railway.app",
-    });
+    writeSubmittedCode({ agent_id: agent.agent.id, vendor: "Railway", code: "CODE" });
 
     const entry1 = recordConversion({ vendor: "Railway", referral_code: "CODE", commission_amount: 1.00 });
-    assert.strictEqual(entry1.agent_share, 0.70);
+    assert.strictEqual(entry1.agent_share, 0.40);
 
     resetFiles();
     const agent2 = registerAgent({ name: "ShareBot2" });
-    logReferralRequest({
-      agent_id: agent2.agent.id,
-      vendor: "Railway",
-      referral_code: "CODE",
-      referral_url: "https://railway.app",
-    });
+    writeSubmittedCode({ agent_id: agent2.agent.id, vendor: "Railway", code: "CODE" });
 
     const entry2 = recordConversion({ vendor: "Railway", referral_code: "CODE", commission_amount: 33.33 });
-    assert.strictEqual(entry2.agent_share, 23.33);
+    assert.strictEqual(entry2.agent_share, 13.33);
   });
 
   it("sets clawback_window_ends based on vendor config", () => {
@@ -220,26 +209,36 @@ describe("Record Conversion", () => {
     assert.strictEqual(entry.clawback_window_ends, "2026-05-01");
   });
 
-  it("updates agent pending balance on conversion", () => {
+  it("updates the submitting agent's pending balance on conversion", () => {
     const agent = registerAgent({ name: "BalanceBot" });
-    logReferralRequest({
-      agent_id: agent.agent.id,
-      vendor: "Railway",
-      referral_code: "CODE",
-      referral_url: "https://railway.app",
-    });
+    writeSubmittedCode({ agent_id: agent.agent.id, vendor: "Railway", code: "CODE" });
 
     recordConversion({ vendor: "Railway", referral_code: "CODE", commission_amount: 100.00 });
 
     const balance = getAgentBalance(agent.agent.id);
     assert.ok(balance);
-    assert.strictEqual(balance.pending_balance, 70.00);
+    assert.strictEqual(balance.pending_balance, 40.00);
     assert.strictEqual(balance.confirmed_balance, 0);
     assert.strictEqual(balance.total_earned, 0);
     assert.strictEqual(balance.total_paid_out, 0);
   });
 
-  it("records conversion with null agent_id when no attribution", () => {
+  it("credits no agent when the conversion names no code at all", () => {
+    const agent = registerAgent({ name: "EmptyCodeBot" });
+    writeSubmittedCode({ agent_id: agent.agent.id, vendor: "Railway", code: "" });
+
+    const entry = recordConversion({
+      vendor: "Railway",
+      referral_code: "",
+      commission_amount: 100.00,
+    });
+
+    assert.strictEqual(entry.agent_id, null);
+    assert.strictEqual(entry.agent_share, 0);
+    assert.strictEqual(getAgentBalance(agent.agent.id), null);
+  });
+
+  it("records conversion with null agent_id when no agent submitted the code", () => {
     const entry = recordConversion({
       vendor: "Railway",
       referral_code: "CODE",
@@ -254,9 +253,9 @@ describe("Record Conversion", () => {
       vendor: "Railway",
       referral_code: "CODE",
       commission_amount: 10.00,
-      metadata: { source: "manual", admin: "rob" },
+      metadata: { source: "manual", recorded_by: "platform" },
     });
-    assert.deepStrictEqual(entry.metadata, { source: "manual", admin: "rob" });
+    assert.deepStrictEqual(entry.metadata, { source: "manual", recorded_by: "platform" });
   });
 });
 
@@ -267,15 +266,9 @@ describe("Confirm Eligible Entries", () => {
 
   it("confirms entries past clawback window", () => {
     const agent = registerAgent({ name: "ConfirmBot" });
-    writeReferralRequestWithDate({
-      agent_id: agent.agent.id,
-      vendor: "UnknownVendor",
-      referral_code: "CODE",
-      referral_url: "https://example.com",
-      requested_at: "2026-02-15T00:00:00.000Z",
-    });
+    writeSubmittedCode({ agent_id: agent.agent.id, vendor: "UnknownVendor", code: "CODE" });
 
-    // Create a conversion with clawback ending April 1
+    // Create a conversion with clawback ending March 31
     recordConversion({
       vendor: "UnknownVendor",
       referral_code: "CODE",
@@ -290,12 +283,11 @@ describe("Confirm Eligible Entries", () => {
     const balance = getAgentBalance(agent.agent.id);
     assert.ok(balance);
     assert.strictEqual(balance.pending_balance, 0);
-    assert.strictEqual(balance.confirmed_balance, 70.00);
-    assert.strictEqual(balance.total_earned, 70.00);
+    assert.strictEqual(balance.confirmed_balance, 40.00);
+    assert.strictEqual(balance.total_earned, 40.00);
   });
 
   it("does not confirm entries still in clawback window", () => {
-    // No attribution needed for this test — just checking clawback timing
     recordConversion({
       vendor: "Railway",
       referral_code: "CODE",
@@ -309,29 +301,15 @@ describe("Confirm Eligible Entries", () => {
 
   it("updates balances in same operation", () => {
     const agent = registerAgent({ name: "BatchBot" });
-    writeReferralRequestWithDate({
-      agent_id: agent.agent.id,
-      vendor: "UnknownVendor",
-      referral_code: "CODE",
-      referral_url: "https://example.com",
-      requested_at: "2026-02-15T00:00:00.000Z",
-    });
+    writeSubmittedCode({ agent_id: agent.agent.id, vendor: "UnknownVendor", code: "CODE" });
+    writeSubmittedCode({ agent_id: agent.agent.id, vendor: "UnknownVendor", code: "CODE2" });
 
     recordConversion({ vendor: "UnknownVendor", referral_code: "CODE", commission_amount: 50.00, conversion_date: "2026-03-01" });
-
-    writeReferralRequestWithDate({
-      agent_id: agent.agent.id,
-      vendor: "UnknownVendor",
-      referral_code: "CODE2",
-      referral_url: "https://example.com",
-      requested_at: "2026-02-16T00:00:00.000Z",
-    });
-    resetLedgerCache(); // Force reload to pick up referral request file change
     recordConversion({ vendor: "UnknownVendor", referral_code: "CODE2", commission_amount: 50.00, conversion_date: "2026-03-01" });
 
     let balance = getAgentBalance(agent.agent.id);
     assert.ok(balance);
-    assert.strictEqual(balance.pending_balance, 70.00); // 35 + 35
+    assert.strictEqual(balance.pending_balance, 40.00); // 20 + 20
 
     const confirmed = confirmEligibleEntries(new Date("2026-04-02"));
     assert.strictEqual(confirmed.length, 2);
@@ -339,8 +317,8 @@ describe("Confirm Eligible Entries", () => {
     balance = getAgentBalance(agent.agent.id);
     assert.ok(balance);
     assert.strictEqual(balance.pending_balance, 0);
-    assert.strictEqual(balance.confirmed_balance, 70.00);
-    assert.strictEqual(balance.total_earned, 70.00);
+    assert.strictEqual(balance.confirmed_balance, 40.00);
+    assert.strictEqual(balance.total_earned, 40.00);
   });
 });
 
@@ -351,12 +329,7 @@ describe("Clawback Entry", () => {
 
   it("claws back a pending entry", () => {
     const agent = registerAgent({ name: "ClawBot" });
-    logReferralRequest({
-      agent_id: agent.agent.id,
-      vendor: "Railway",
-      referral_code: "CODE",
-      referral_url: "https://railway.app",
-    });
+    writeSubmittedCode({ agent_id: agent.agent.id, vendor: "Railway", code: "CODE" });
 
     const entry = recordConversion({
       vendor: "Railway",
@@ -366,7 +339,7 @@ describe("Clawback Entry", () => {
 
     let balance = getAgentBalance(agent.agent.id);
     assert.ok(balance);
-    assert.strictEqual(balance.pending_balance, 70.00);
+    assert.strictEqual(balance.pending_balance, 40.00);
 
     const success = clawbackEntry(entry.id, "customer cancelled");
     assert.strictEqual(success, true);
@@ -386,13 +359,7 @@ describe("Clawback Entry", () => {
 
   it("returns false for already confirmed entry", () => {
     const agent = registerAgent({ name: "ConfBot" });
-    writeReferralRequestWithDate({
-      agent_id: agent.agent.id,
-      vendor: "UnknownVendor",
-      referral_code: "CODE",
-      referral_url: "https://example.com",
-      requested_at: "2026-02-15T00:00:00.000Z",
-    });
+    writeSubmittedCode({ agent_id: agent.agent.id, vendor: "UnknownVendor", code: "CODE" });
 
     const entry = recordConversion({
       vendor: "UnknownVendor",
@@ -418,27 +385,15 @@ describe("Agent Balance Queries", () => {
 
   it("returns correct balance after multiple conversions", () => {
     const agent = registerAgent({ name: "MultiBot" });
+    writeSubmittedCode({ agent_id: agent.agent.id, vendor: "Railway", code: "CODE" });
+    writeSubmittedCode({ agent_id: agent.agent.id, vendor: "Railway", code: "CODE2" });
 
-    logReferralRequest({
-      agent_id: agent.agent.id,
-      vendor: "Railway",
-      referral_code: "CODE",
-      referral_url: "https://railway.app",
-    });
     recordConversion({ vendor: "Railway", referral_code: "CODE", commission_amount: 100.00 });
-
-    resetReferralRequestsCache();
-    logReferralRequest({
-      agent_id: agent.agent.id,
-      vendor: "Railway",
-      referral_code: "CODE2",
-      referral_url: "https://railway.app",
-    });
     recordConversion({ vendor: "Railway", referral_code: "CODE2", commission_amount: 200.00 });
 
     const balance = getAgentBalance(agent.agent.id);
     assert.ok(balance);
-    assert.strictEqual(balance.pending_balance, 210.00); // 70 + 140
+    assert.strictEqual(balance.pending_balance, 120.00); // 40 + 80
   });
 });
 
@@ -449,12 +404,7 @@ describe("Ledger Entry Queries", () => {
 
   it("returns all entries for an agent", () => {
     const agent = registerAgent({ name: "QueryBot" });
-    logReferralRequest({
-      agent_id: agent.agent.id,
-      vendor: "Railway",
-      referral_code: "CODE",
-      referral_url: "https://railway.app",
-    });
+    writeSubmittedCode({ agent_id: agent.agent.id, vendor: "Railway", code: "CODE" });
     recordConversion({ vendor: "Railway", referral_code: "CODE", commission_amount: 50.00 });
 
     const entries = getAgentLedgerEntries(agent.agent.id);
@@ -469,13 +419,7 @@ describe("Ledger Entry Queries", () => {
 
   it("getAllConversions returns only conversion events", () => {
     const agent = registerAgent({ name: "AllBot" });
-    writeReferralRequestWithDate({
-      agent_id: agent.agent.id,
-      vendor: "UnknownVendor",
-      referral_code: "CODE",
-      referral_url: "https://example.com",
-      requested_at: "2026-02-15T00:00:00.000Z",
-    });
+    writeSubmittedCode({ agent_id: agent.agent.id, vendor: "UnknownVendor", code: "CODE" });
     recordConversion({ vendor: "UnknownVendor", referral_code: "CODE", commission_amount: 10.00, conversion_date: "2026-03-01" });
     confirmEligibleEntries(new Date("2026-04-02"));
 
@@ -492,12 +436,7 @@ describe("Append-Only Enforcement", () => {
 
   it("clawback creates a new event entry rather than deleting", () => {
     const agent = registerAgent({ name: "AppendBot" });
-    logReferralRequest({
-      agent_id: agent.agent.id,
-      vendor: "Railway",
-      referral_code: "CODE",
-      referral_url: "https://railway.app",
-    });
+    writeSubmittedCode({ agent_id: agent.agent.id, vendor: "Railway", code: "CODE" });
 
     const entry = recordConversion({ vendor: "Railway", referral_code: "CODE", commission_amount: 100.00 });
     clawbackEntry(entry.id);
@@ -512,13 +451,7 @@ describe("Append-Only Enforcement", () => {
 
   it("confirmation creates a new event entry", () => {
     const agent = registerAgent({ name: "ConfirmAppendBot" });
-    writeReferralRequestWithDate({
-      agent_id: agent.agent.id,
-      vendor: "UnknownVendor",
-      referral_code: "CODE",
-      referral_url: "https://example.com",
-      requested_at: "2026-02-15T00:00:00.000Z",
-    });
+    writeSubmittedCode({ agent_id: agent.agent.id, vendor: "UnknownVendor", code: "CODE" });
 
     recordConversion({ vendor: "UnknownVendor", referral_code: "CODE", commission_amount: 100.00, conversion_date: "2026-03-01" });
     confirmEligibleEntries(new Date("2026-04-02"));

--- a/test/marketplace-dashboard.test.ts
+++ b/test/marketplace-dashboard.test.ts
@@ -122,9 +122,29 @@ describe("Marketplace Page", () => {
     const res = await fetch(`http://localhost:${serverPort}/marketplace`);
     const html = await res.text();
     assert.ok(html.includes("Revenue Splits"));
-    assert.ok(html.includes("70%"));
-    assert.ok(html.includes("80%"));
     assert.ok(html.includes("40%"));
+    assert.ok(html.includes("60%"));
+  });
+
+  it("marketplace page publishes no share for surfacing a code", async () => {
+    const res = await fetch(`http://localhost:${serverPort}/marketplace`);
+    const html = await res.text();
+    const splits = html.slice(html.indexOf("Revenue Splits"), html.indexOf("Code Ranking"));
+    assert.ok(splits.includes("There is no share for surfacing a code."));
+    assert.ok(!/>\s*Surfer\s*</.test(splits), "the split table names no surfer column");
+    assert.ok(!splits.includes("70%") && !splits.includes("80%"), "no share is published that the ledger cannot pay");
+  });
+
+  it("marketplace page publishes the share the ledger actually pays", async () => {
+    const { SUBMITTER_SHARE_RATE } = await import("../dist/ledger.js");
+    const submitter = Math.round(SUBMITTER_SHARE_RATE * 100);
+    const res = await fetch(`http://localhost:${serverPort}/marketplace`);
+    const html = await res.text();
+    const splits = html.slice(html.indexOf("Revenue Splits"), html.indexOf("Code Ranking"));
+    assert.ok(
+      splits.includes(`<td>${submitter}%</td><td>${100 - submitter}%</td>`),
+      `the published split must be ${submitter}/${100 - submitter}, the rate the ledger accrues at`,
+    );
   });
 
   it("marketplace page has registration instructions with curl example", async () => {

--- a/test/payout.test.ts
+++ b/test/payout.test.ts
@@ -9,6 +9,7 @@ const LEDGER_PATH = path.join(__dirname, "..", "data", "ledger_entries.json");
 const BALANCES_PATH = path.join(__dirname, "..", "data", "agent_balances.json");
 const CLAWBACK_PATH = path.join(__dirname, "..", "data", "vendor_clawback.json");
 const REQUESTS_PATH = path.join(__dirname, "..", "data", "referral_requests.json");
+const CODES_PATH = path.join(__dirname, "..", "data", "referral_codes.json");
 const AGENTS_PATH = path.join(__dirname, "..", "data", "agents.json");
 
 const {
@@ -21,7 +22,8 @@ const {
   resetLedgerCache,
 } = await import("../dist/ledger.js");
 
-const { logReferralRequest, resetReferralRequestsCache } = await import("../dist/referral-requests.js");
+const { resetReferralRequestsCache } = await import("../dist/referral-requests.js");
+const { resetReferralCodesCache } = await import("../dist/referral-codes.js");
 const { registerAgent, resetAgentsCache, updateAgentX402Address } = await import("../dist/agents.js");
 const { validateX402Address, setTransferFn, resetTransferFn, generateCorrelationId } = await import("../dist/x402.js");
 
@@ -29,12 +31,14 @@ const { validateX402Address, setTransferFn, resetTransferFn, generateCorrelation
 let origLedger: string | null = null;
 let origBalances: string | null = null;
 let origRequests: string | null = null;
+let origCodes: string | null = null;
 let origAgents: string | null = null;
 
 function saveOriginals() {
   origLedger = fs.existsSync(LEDGER_PATH) ? fs.readFileSync(LEDGER_PATH, "utf-8") : null;
   origBalances = fs.existsSync(BALANCES_PATH) ? fs.readFileSync(BALANCES_PATH, "utf-8") : null;
   origRequests = fs.existsSync(REQUESTS_PATH) ? fs.readFileSync(REQUESTS_PATH, "utf-8") : null;
+  origCodes = fs.existsSync(CODES_PATH) ? fs.readFileSync(CODES_PATH, "utf-8") : null;
   origAgents = fs.existsSync(AGENTS_PATH) ? fs.readFileSync(AGENTS_PATH, "utf-8") : null;
 }
 
@@ -45,10 +49,13 @@ function restoreOriginals() {
   else if (fs.existsSync(BALANCES_PATH)) fs.unlinkSync(BALANCES_PATH);
   if (origRequests !== null) fs.writeFileSync(REQUESTS_PATH, origRequests);
   else if (fs.existsSync(REQUESTS_PATH)) fs.unlinkSync(REQUESTS_PATH);
+  if (origCodes !== null) fs.writeFileSync(CODES_PATH, origCodes);
+  else if (fs.existsSync(CODES_PATH)) fs.unlinkSync(CODES_PATH);
   if (origAgents !== null) fs.writeFileSync(AGENTS_PATH, origAgents);
   else if (fs.existsSync(AGENTS_PATH)) fs.unlinkSync(AGENTS_PATH);
   resetLedgerCache();
   resetReferralRequestsCache();
+  resetReferralCodesCache();
   resetAgentsCache();
   resetTransferFn();
 }
@@ -57,11 +64,39 @@ function resetFiles() {
   fs.writeFileSync(LEDGER_PATH, JSON.stringify({ ledger_entries: [] }), "utf-8");
   fs.writeFileSync(BALANCES_PATH, JSON.stringify({ agent_balances: [] }), "utf-8");
   fs.writeFileSync(REQUESTS_PATH, JSON.stringify({ referral_requests: [] }), "utf-8");
+  fs.writeFileSync(CODES_PATH, JSON.stringify({ referral_codes: [] }), "utf-8");
   fs.writeFileSync(AGENTS_PATH, JSON.stringify({ agents: [] }), "utf-8");
   resetLedgerCache();
   resetReferralRequestsCache();
+  resetReferralCodesCache();
   resetAgentsCache();
   resetTransferFn();
+}
+
+/** Seed a submission record so a conversion on this code credits this agent. */
+function writeSubmittedCode(opts: { agent_id: string; vendor: string; code: string }) {
+  const raw = JSON.parse(fs.readFileSync(CODES_PATH, "utf-8"));
+  const now = new Date().toISOString();
+  raw.referral_codes.push({
+    id: `code_test_${Date.now()}_${Math.random().toString(36).slice(2)}`,
+    vendor: opts.vendor,
+    code: opts.code,
+    referral_url: "https://example.com?ref=test",
+    description: "",
+    commission_rate: null,
+    expiry: null,
+    submitted_by: opts.agent_id,
+    source: "agent-submitted",
+    status: "active",
+    trust_tier_at_submission: "new",
+    impressions: 0,
+    clicks: 0,
+    conversions: 0,
+    submitted_at: now,
+    updated_at: now,
+  });
+  fs.writeFileSync(CODES_PATH, JSON.stringify(raw), "utf-8");
+  resetReferralCodesCache();
 }
 
 /** Create an agent with confirmed balance ready for payout. */
@@ -73,27 +108,14 @@ function setupAgentWithBalance(name: string, confirmedAmount: number, x402Addres
     updateAgentX402Address(agentId, x402Address);
   }
 
-  // Seed a referral request directly in data (with a past timestamp for attribution)
   const pastDate = new Date();
   pastDate.setDate(pastDate.getDate() - 60); // Well past clawback
 
-  // Write referral request with past timestamp so attribution matches
-  const requests = JSON.parse(fs.readFileSync(REQUESTS_PATH, "utf-8"));
-  requests.referral_requests.push({
-    id: `rr_test_${Date.now()}`,
-    agent_id: agentId,
-    vendor: "Railway",
-    referral_code: "TEST_CODE",
-    referral_url: "https://railway.com?ref=test",
-    requested_at: new Date(pastDate.getTime() - 86400000).toISOString(), // 1 day before conversion
-    conversion_id: null,
-  });
-  fs.writeFileSync(REQUESTS_PATH, JSON.stringify(requests), "utf-8");
-  resetReferralRequestsCache();
+  writeSubmittedCode({ agent_id: agentId, vendor: "Railway", code: "TEST_CODE" });
 
   // Record conversion with enough commission to produce the desired confirmed balance
-  // agent_share = commission * 0.7, so commission = confirmedAmount / 0.7
-  const commission = Math.round((confirmedAmount / 0.7) * 100) / 100;
+  // agent_share = commission * 0.4, so commission = confirmedAmount / 0.4
+  const commission = Math.round((confirmedAmount / 0.4) * 100) / 100;
   recordConversion({
     vendor: "Railway",
     referral_code: "TEST_CODE",
@@ -334,12 +356,7 @@ describe("payout endpoint integration", () => {
     const result = registerAgent({ name: "PendingBot" });
     const agentId = result.agent.id;
 
-    logReferralRequest({
-      agent_id: agentId,
-      vendor: "Railway",
-      referral_code: "TEST_CODE",
-      referral_url: "https://railway.com?ref=test",
-    });
+    writeSubmittedCode({ agent_id: agentId, vendor: "Railway", code: "TEST_CODE" });
 
     // Record conversion that will be within clawback window
     recordConversion({

--- a/test/ranking-leaderboard.test.ts
+++ b/test/ranking-leaderboard.test.ts
@@ -20,6 +20,7 @@ const {
   isInColdStart,
   recordImpression,
   recordCodeConversion,
+  revokeCode,
   resetReferralCodesCache,
 } = await import("../dist/referral-codes.js");
 
@@ -264,94 +265,141 @@ describe("Code Ranking Algorithm", () => {
   });
 });
 
-describe("Dual-Agent Revenue Split", () => {
+describe("Conversion revenue split", () => {
   before(() => saveOriginals());
   after(() => restoreOriginals());
   beforeEach(() => resetFiles());
 
-  it("applies 80/20 split when same agent submitted and surfaced", () => {
-    const { agent } = createTestAgent("SameBot");
-    // Log a referral request so attribution finds this agent
-    logReferralRequest({ vendor: "Railway", agent_id: agent.id });
+  function submitCode(agentId: string, vendor: string, code: string) {
+    return submitReferralCode({
+      vendor,
+      code,
+      referral_url: `https://example.com?ref=${code.toLowerCase()}`,
+      description: "Test",
+      agent_id: agentId,
+      trust_tier: "new",
+    });
+  }
+
+  it("credits 40% to the agent that submitted the converting code", () => {
+    const { agent } = createTestAgent("SubmitBot");
+    submitCode(agent.id, "Railway", "SUB1");
 
     const entry = recordConversion({
       vendor: "Railway",
-      referral_code: "SAME1",
+      referral_code: "SUB1",
       commission_amount: 100,
-      submitter_id: agent.id,
     });
 
-    // Same agent: 80% to agent, 20% platform
-    assert.strictEqual(entry.agent_share, 80);
-    assert.strictEqual(entry.submitter_share, 0); // no separate submitter share since same agent
     assert.strictEqual(entry.agent_id, agent.id);
     assert.strictEqual(entry.submitter_id, agent.id);
-
-    const balance = getAgentBalance(agent.id);
-    assert.strictEqual(balance.pending_balance, 80);
-  });
-
-  it("applies 40/40/20 split when different agents", () => {
-    const { agent: submitter } = createTestAgent("SubmitBot");
-    const { agent: surfer } = createTestAgent("SurfBot");
-
-    // Log a referral request for the surfacing agent
-    logReferralRequest({ vendor: "Railway", agent_id: surfer.id });
-
-    const entry = recordConversion({
-      vendor: "Railway",
-      referral_code: "DUAL1",
-      commission_amount: 100,
-      submitter_id: submitter.id,
-    });
-
-    // Different agents: 40% surfer, 40% submitter, 20% platform
     assert.strictEqual(entry.agent_share, 40);
-    assert.strictEqual(entry.submitter_share, 40);
-    assert.strictEqual(entry.agent_id, surfer.id);
-    assert.strictEqual(entry.submitter_id, submitter.id);
-
-    const surferBalance = getAgentBalance(surfer.id);
-    assert.strictEqual(surferBalance.pending_balance, 40);
-
-    const submitterBalance = getAgentBalance(submitter.id);
-    assert.strictEqual(submitterBalance.pending_balance, 40);
-  });
-
-  it("applies standard 70/30 split for curated codes (no submitter)", () => {
-    const { agent } = createTestAgent("CuratedBot");
-    logReferralRequest({ vendor: "Railway", agent_id: agent.id });
-
-    const entry = recordConversion({
-      vendor: "Railway",
-      referral_code: "CURATED1",
-      commission_amount: 100,
-    });
-
-    // Curated: 70% to surfer, 30% platform
-    assert.strictEqual(entry.agent_share, 70);
-    assert.strictEqual(entry.submitter_share, 0);
 
     const balance = getAgentBalance(agent.id);
-    assert.strictEqual(balance.pending_balance, 70);
+    assert.strictEqual(balance.pending_balance, 40);
   });
 
-  it("gives submitter 40% when no surfacing agent exists", () => {
-    const { agent: submitter } = createTestAgent("LoneSubmitter");
+  it("credits no agent when the converting code is one of ours", () => {
+    const { agent } = createTestAgent("BystanderBot");
+    submitCode(agent.id, "Railway", "SUB1");
 
     const entry = recordConversion({
       vendor: "Railway",
-      referral_code: "LONE1",
+      referral_code: "OUR-OWN-CODE",
       commission_amount: 100,
-      submitter_id: submitter.id,
     });
 
     assert.strictEqual(entry.agent_id, null);
     assert.strictEqual(entry.agent_share, 0);
-    assert.strictEqual(entry.submitter_share, 40);
+    assert.strictEqual(getAgentBalance(agent.id), null);
+  });
 
-    const balance = getAgentBalance(submitter.id);
-    assert.strictEqual(balance.pending_balance, 40);
+  it("credits nothing for requesting a code", () => {
+    const { agent } = createTestAgent("RequesterBot");
+    logReferralRequest({ vendor: "Railway", agent_id: agent.id });
+
+    const entry = recordConversion({
+      vendor: "Railway",
+      referral_code: "OUR-OWN-CODE",
+      commission_amount: 100,
+    });
+
+    assert.strictEqual(entry.agent_id, null);
+    assert.strictEqual(entry.agent_share, 0);
+    assert.strictEqual(getAgentBalance(agent.id), null);
+  });
+
+  it("does not let a later code request displace the submitter", () => {
+    const { agent: submitter } = createTestAgent("OwnerBot");
+    const { agent: latecomer } = createTestAgent("LatecomerBot");
+    submitCode(submitter.id, "Railway", "SUB1");
+    logReferralRequest({ vendor: "Railway", agent_id: latecomer.id });
+
+    const entry = recordConversion({
+      vendor: "Railway",
+      referral_code: "SUB1",
+      commission_amount: 100,
+    });
+
+    assert.strictEqual(entry.agent_id, submitter.id);
+    assert.strictEqual(getAgentBalance(submitter.id).pending_balance, 40);
+    assert.strictEqual(getAgentBalance(latecomer.id), null);
+  });
+
+  it("resolves the submitter when the vendor name differs in case", () => {
+    const { agent } = createTestAgent("CaseBot");
+    submitCode(agent.id, "Railway", "SUB1");
+
+    const entry = recordConversion({
+      vendor: "railway",
+      referral_code: "SUB1",
+      commission_amount: 100,
+    });
+
+    assert.strictEqual(entry.agent_id, agent.id);
+    assert.strictEqual(entry.agent_share, 40);
+  });
+
+  it("does not credit the submitter of the same code string for another vendor", () => {
+    const { agent } = createTestAgent("OtherVendorBot");
+    submitCode(agent.id, "Vercel", "SHARED");
+
+    const entry = recordConversion({
+      vendor: "Railway",
+      referral_code: "SHARED",
+      commission_amount: 100,
+    });
+
+    assert.strictEqual(entry.agent_id, null);
+    assert.strictEqual(entry.agent_share, 0);
+  });
+
+  it("credits the submitter of a revoked code that still converts", () => {
+    const { agent } = createTestAgent("RevokedBot");
+    const code = submitCode(agent.id, "Railway", "SUB1");
+    revokeCode(code.id, agent.id);
+
+    const entry = recordConversion({
+      vendor: "Railway",
+      referral_code: "SUB1",
+      commission_amount: 100,
+    });
+
+    assert.strictEqual(entry.agent_id, agent.id);
+    assert.strictEqual(entry.agent_share, 40);
+  });
+
+  it("rounds the submitter share to cents", () => {
+    const { agent } = createTestAgent("RoundBot");
+    submitCode(agent.id, "Railway", "SUB1");
+
+    const entry = recordConversion({
+      vendor: "Railway",
+      referral_code: "SUB1",
+      commission_amount: 33.33,
+    });
+
+    assert.strictEqual(entry.agent_share, 13.33);
   });
 });
 
@@ -360,18 +408,27 @@ describe("Agent Leaderboard", () => {
   after(() => restoreOriginals());
   beforeEach(() => resetFiles());
 
+  function submitCode(agentId: string, vendor: string, code: string) {
+    return submitReferralCode({
+      vendor,
+      code,
+      referral_url: `https://example.com?ref=${code.toLowerCase()}`,
+      description: "Test",
+      agent_id: agentId,
+      trust_tier: "new",
+    });
+  }
+
   it("returns agents ranked by total conversions", () => {
     const { agent: a1 } = createTestAgent("TopAgent");
     const { agent: a2 } = createTestAgent("MidAgent");
 
-    // a1 gets 3 conversions via referral requests
+    submitCode(a1.id, "Railway", "TOP");
     for (let i = 0; i < 3; i++) {
-      logReferralRequest({ vendor: "Railway", agent_id: a1.id });
       recordConversion({ vendor: "Railway", referral_code: "TOP", commission_amount: 50 });
     }
 
-    // a2 gets 1 conversion
-    logReferralRequest({ vendor: "Vercel", agent_id: a2.id });
+    submitCode(a2.id, "Vercel", "MID");
     recordConversion({ vendor: "Vercel", referral_code: "MID", commission_amount: 30 });
 
     const result = getLeaderboard();
@@ -387,16 +444,16 @@ describe("Agent Leaderboard", () => {
     const { agent: a2 } = createTestAgent("Second");
     const { agent: a3 } = createTestAgent("Third");
 
-    logReferralRequest({ vendor: "Railway", agent_id: a1.id });
+    submitCode(a1.id, "Railway", "A");
     recordConversion({ vendor: "Railway", referral_code: "A", commission_amount: 50 });
     recordConversion({ vendor: "Railway", referral_code: "A", commission_amount: 50 });
     recordConversion({ vendor: "Railway", referral_code: "A", commission_amount: 50 });
 
-    logReferralRequest({ vendor: "Vercel", agent_id: a2.id });
+    submitCode(a2.id, "Vercel", "B");
     recordConversion({ vendor: "Vercel", referral_code: "B", commission_amount: 30 });
     recordConversion({ vendor: "Vercel", referral_code: "B", commission_amount: 30 });
 
-    logReferralRequest({ vendor: "Render", agent_id: a3.id });
+    submitCode(a3.id, "Render", "C");
     recordConversion({ vendor: "Render", referral_code: "C", commission_amount: 20 });
 
     const page1 = getLeaderboard({ limit: 2, offset: 0 });
@@ -435,7 +492,6 @@ describe("Agent Leaderboard", () => {
     });
 
     // Record conversions
-    logReferralRequest({ vendor: "Railway", agent_id: agent.id });
     recordConversion({ vendor: "Railway", referral_code: "EARN1", commission_amount: 100 });
 
     const result = getLeaderboard();
@@ -446,7 +502,8 @@ describe("Agent Leaderboard", () => {
 
   it("excludes clawed-back conversions from count", () => {
     const { agent } = createTestAgent("ClawBot");
-    logReferralRequest({ vendor: "Railway", agent_id: agent.id });
+    submitCode(agent.id, "Railway", "CLAW");
+    submitCode(agent.id, "Vercel", "VALID");
 
     const entry = recordConversion({ vendor: "Railway", referral_code: "CLAW", commission_amount: 50 });
 
@@ -454,7 +511,7 @@ describe("Agent Leaderboard", () => {
     clawbackEntry(entry.id);
 
     // Record one more valid conversion
-    recordConversion({ vendor: "Railway", referral_code: "VALID", commission_amount: 50 });
+    recordConversion({ vendor: "Vercel", referral_code: "VALID", commission_amount: 50 });
 
     const result = getLeaderboard();
     // Clawed back one shouldn't count
@@ -462,31 +519,35 @@ describe("Agent Leaderboard", () => {
   });
 });
 
-describe("Leaderboard includes submitter conversions", () => {
+describe("Leaderboard counts the submitter and nobody else", () => {
   before(() => saveOriginals());
   after(() => restoreOriginals());
   beforeEach(() => resetFiles());
 
-  it("counts submitter contributions in leaderboard", () => {
+  it("lists the submitter of the converting code, not the agent that requested it", () => {
     const { agent: submitter } = createTestAgent("CodeSubmitter");
-    const { agent: surfer } = createTestAgent("CodeSurfer");
+    const { agent: requester } = createTestAgent("CodeRequester");
 
-    logReferralRequest({ vendor: "Railway", agent_id: surfer.id });
+    submitReferralCode({
+      vendor: "Railway",
+      code: "SUBMITTED",
+      referral_url: "https://railway.app?ref=submitted",
+      description: "Test",
+      agent_id: submitter.id,
+      trust_tier: "new",
+    });
+    logReferralRequest({ vendor: "Railway", agent_id: requester.id });
+
     recordConversion({
       vendor: "Railway",
-      referral_code: "DUAL",
+      referral_code: "SUBMITTED",
       commission_amount: 100,
-      submitter_id: submitter.id,
     });
 
     const result = getLeaderboard();
-    // Both agents should appear
-    assert.strictEqual(result.total, 2);
-    const submitterEntry = result.entries.find((e: any) => e.agent_name === "CodeSubmitter");
-    const surferEntry = result.entries.find((e: any) => e.agent_name === "CodeSurfer");
-    assert.ok(submitterEntry);
-    assert.ok(surferEntry);
-    assert.strictEqual(submitterEntry.total_conversions, 1);
-    assert.strictEqual(surferEntry.total_conversions, 1);
+    assert.strictEqual(result.total, 1);
+    assert.strictEqual(result.entries[0].agent_name, "CodeSubmitter");
+    assert.strictEqual(result.entries[0].total_conversions, 1);
+    assert.strictEqual(result.entries.find((e: any) => e.agent_name === "CodeRequester"), undefined);
   });
 });

--- a/test/referral-attribution.test.ts
+++ b/test/referral-attribution.test.ts
@@ -13,7 +13,7 @@ process.env.AGENTDEALS_REFERRAL_REQUESTS_PATH = REQUESTS_PATH;
 const AGENTS_PATH = path.join(__dirname, "..", "data", "agents.json");
 
 // Unit tests for referral-requests module
-const { logReferralRequest, attributeConversion, getRequestsByAgent, getRequestById, markConversion, resetReferralRequestsCache } = await import("../dist/referral-requests.js");
+const { logReferralRequest, getRequestsByAgent, getRequestById, resetReferralRequestsCache } = await import("../dist/referral-requests.js");
 const { registerAgent, resetAgentsCache } = await import("../dist/agents.js");
 
 function resetRequestsFile() {
@@ -71,95 +71,6 @@ describe("Referral Request Logging", () => {
   });
 });
 
-describe("Attribution Logic", () => {
-  beforeEach(() => {
-    resetRequestsFile();
-  });
-
-  after(() => {
-    resetRequestsFile();
-  });
-
-  it("attributes to the single matching agent", () => {
-    const now = new Date();
-    // Log a request 1 day ago
-    const req = logReferralRequest({ agent_id: "agent_1", vendor: "Railway", referral_code: "C1", referral_url: "http://u1" });
-    // Override timestamp to 1 day ago
-    const data = JSON.parse(fs.readFileSync(REQUESTS_PATH, "utf-8"));
-    data.referral_requests[0].requested_at = new Date(now.getTime() - 24 * 60 * 60 * 1000).toISOString();
-    fs.writeFileSync(REQUESTS_PATH, JSON.stringify(data), "utf-8");
-    resetReferralRequestsCache();
-
-    const result = attributeConversion("Railway", now);
-    assert.strictEqual(result, "agent_1");
-  });
-
-  it("last-touch wins: attributes to the most recent requester", () => {
-    const now = new Date();
-    const data = { referral_requests: [
-      { id: "rr_old", agent_id: "agent_first", vendor: "Railway", referral_code: "C1", referral_url: "http://u1", requested_at: new Date(now.getTime() - 48 * 60 * 60 * 1000).toISOString(), conversion_id: null },
-      { id: "rr_new", agent_id: "agent_second", vendor: "Railway", referral_code: "C1", referral_url: "http://u1", requested_at: new Date(now.getTime() - 12 * 60 * 60 * 1000).toISOString(), conversion_id: null },
-    ]};
-    fs.writeFileSync(REQUESTS_PATH, JSON.stringify(data), "utf-8");
-    resetReferralRequestsCache();
-
-    const result = attributeConversion("Railway", now);
-    assert.strictEqual(result, "agent_second");
-  });
-
-  it("returns null when no requests exist for the vendor", () => {
-    const result = attributeConversion("NonExistent", new Date());
-    assert.strictEqual(result, null);
-  });
-
-  it("returns null when requests are outside the lookback window", () => {
-    const now = new Date();
-    const data = { referral_requests: [
-      { id: "rr_1", agent_id: "agent_old", vendor: "Railway", referral_code: "C1", referral_url: "http://u1", requested_at: new Date(now.getTime() - 100 * 24 * 60 * 60 * 1000).toISOString(), conversion_id: null },
-    ]};
-    fs.writeFileSync(REQUESTS_PATH, JSON.stringify(data), "utf-8");
-    resetReferralRequestsCache();
-
-    const result = attributeConversion("Railway", now, 90);
-    assert.strictEqual(result, null);
-  });
-
-  it("respects custom lookback window", () => {
-    const now = new Date();
-    const data = { referral_requests: [
-      { id: "rr_1", agent_id: "agent_1", vendor: "Railway", referral_code: "C1", referral_url: "http://u1", requested_at: new Date(now.getTime() - 5 * 24 * 60 * 60 * 1000).toISOString(), conversion_id: null },
-    ]};
-    fs.writeFileSync(REQUESTS_PATH, JSON.stringify(data), "utf-8");
-    resetReferralRequestsCache();
-
-    // Within 7-day window
-    assert.strictEqual(attributeConversion("Railway", now, 7), "agent_1");
-    // Outside 3-day window
-    assert.strictEqual(attributeConversion("Railway", now, 3), null);
-  });
-
-  it("vendor matching is case-insensitive", () => {
-    logReferralRequest({ agent_id: "agent_1", vendor: "Railway", referral_code: "C1", referral_url: "http://u1" });
-    const now = new Date();
-    const result = attributeConversion("railway", now);
-    assert.strictEqual(result, "agent_1", "a request logged in the millisecond after the conversion date is not attributed");
-  });
-
-  it("does not attribute requests after the conversion date", () => {
-    const now = new Date();
-    const conversionDate = new Date(now.getTime() - 24 * 60 * 60 * 1000);
-    // Request is after conversion date
-    const data = { referral_requests: [
-      { id: "rr_1", agent_id: "agent_future", vendor: "Railway", referral_code: "C1", referral_url: "http://u1", requested_at: now.toISOString(), conversion_id: null },
-    ]};
-    fs.writeFileSync(REQUESTS_PATH, JSON.stringify(data), "utf-8");
-    resetReferralRequestsCache();
-
-    const result = attributeConversion("Railway", conversionDate);
-    assert.strictEqual(result, null);
-  });
-});
-
 describe("Request Lookups", () => {
   beforeEach(() => {
     resetRequestsFile();
@@ -189,31 +100,6 @@ describe("Request Lookups", () => {
   it("returns null for nonexistent request ID", () => {
     const found = getRequestById("rr_nonexistent");
     assert.strictEqual(found, null);
-  });
-});
-
-describe("Conversion Marking", () => {
-  beforeEach(() => {
-    resetRequestsFile();
-  });
-
-  after(() => {
-    resetRequestsFile();
-  });
-
-  it("marks a request as converted", () => {
-    const req = logReferralRequest({ agent_id: "agent_a", vendor: "V1", referral_code: "C1", referral_url: "http://u1" });
-    const result = markConversion(req.id, "conv_123");
-    assert.strictEqual(result, true);
-
-    resetReferralRequestsCache();
-    const updated = getRequestById(req.id);
-    assert.strictEqual(updated!.conversion_id, "conv_123");
-  });
-
-  it("returns false for nonexistent request", () => {
-    const result = markConversion("rr_nonexistent", "conv_123");
-    assert.strictEqual(result, false);
   });
 });
 

--- a/test/referral-requests.test.ts
+++ b/test/referral-requests.test.ts
@@ -9,10 +9,8 @@ const REQUESTS_PATH = path.join(__dirname, "..", "data", "referral_requests.json
 
 const {
   logReferralRequest,
-  attributeConversion,
   getRequestsByAgent,
   getRequestById,
-  markConversion,
   resetReferralRequestsCache,
 } = await import("../dist/referral-requests.js");
 
@@ -119,65 +117,4 @@ describe("referral-requests", () => {
     });
   });
 
-  describe("attributeConversion", () => {
-    it("returns agent_id for last-touch attribution", () => {
-      logReferralRequest({ agent_id: "agent_A", vendor: "Railway", referral_code: "A1", referral_url: "https://a.com" });
-      logReferralRequest({ agent_id: "agent_B", vendor: "Railway", referral_code: "B1", referral_url: "https://b.com" });
-      const result = attributeConversion("Railway", new Date());
-      assert.ok(result === "agent_A" || result === "agent_B", "should attribute to one of the agents");
-    });
-
-    it("is case-insensitive on vendor name", () => {
-      logReferralRequest({ agent_id: "agent_A", vendor: "railway", referral_code: "A1", referral_url: "https://a.com" });
-      const result = attributeConversion("Railway", new Date());
-      assert.strictEqual(result, "agent_A");
-    });
-
-    it("returns null when no matching vendor", () => {
-      logReferralRequest({ agent_id: "agent_A", vendor: "Vercel", referral_code: "V1", referral_url: "https://v.com" });
-      const result = attributeConversion("Railway", new Date());
-      assert.strictEqual(result, null);
-    });
-
-    it("returns null when requests are outside lookback window", () => {
-      const req = logReferralRequest({ agent_id: "agent_A", vendor: "Railway", referral_code: "A1", referral_url: "https://a.com" });
-      const futureDate = new Date(Date.now() + 100 * 24 * 60 * 60 * 1000);
-      const result = attributeConversion("Railway", futureDate, 1);
-      assert.strictEqual(result, null);
-    });
-
-    it("returns null when no requests exist", () => {
-      const result = attributeConversion("Railway", new Date());
-      assert.strictEqual(result, null);
-    });
-
-    it("respects custom lookback days", () => {
-      logReferralRequest({ agent_id: "agent_A", vendor: "Railway", referral_code: "A1", referral_url: "https://a.com" });
-      const result = attributeConversion("Railway", new Date(), 90);
-      assert.strictEqual(result, "agent_A");
-    });
-  });
-
-  describe("markConversion", () => {
-    it("marks a request as converted", () => {
-      const req = logReferralRequest({ agent_id: "agent_A", vendor: "Railway", referral_code: "A1", referral_url: "https://a.com" });
-      const result = markConversion(req.id, "conv_123");
-      assert.strictEqual(result, true);
-      const updated = getRequestById(req.id);
-      assert.strictEqual(updated!.conversion_id, "conv_123");
-    });
-
-    it("returns false for unknown request ID", () => {
-      const result = markConversion("rr_nonexistent", "conv_123");
-      assert.strictEqual(result, false);
-    });
-
-    it("persists conversion to file", () => {
-      const req = logReferralRequest({ agent_id: "agent_A", vendor: "V1", referral_code: "C1", referral_url: "https://v.com" });
-      markConversion(req.id, "conv_456");
-      resetReferralRequestsCache();
-      const data = JSON.parse(fs.readFileSync(REQUESTS_PATH, "utf-8"));
-      assert.strictEqual(data.referral_requests[0].conversion_id, "conv_456");
-    });
-  });
 });


### PR DESCRIPTION
Option 3 on #1163: the published split now describes only what we can attribute, and the ledger accrues on the same rule.

## The defect, measured rather than argued

`/marketplace` published this:

> Revenue is split between **the agent that surfaces the code (shows it to a user)**, the agent that submitted the code, and the platform — curated 70/30, single agent 80/20, dual agent 40/40/20.

`recordConversion` did not take a surfacing agent. It derived one from `attributeConversion` — last-touch over `get_referral_code` calls with a 90-day lookback. The agent credited with 70–80% of a commission was whichever agent most recently *asked us* for that vendor's code.

And `POST /api/conversions` never passed a `submitter_id`, so the submitter branch was unreachable. Every conversion the system could record landed entirely on the term whose recipient we cannot identify.

I ran the same end-to-end script against a build of `main` to see it rather than assert it. Agent A submits a code for Railway; agent B calls `get_referral_code` for Railway and does nothing else; a conversion is then reported **on A's own code**:

| | main | this branch |
|---|---|---|
| credited agent | B | A |
| A's balance | 0 | 40 |
| B's balance | 70, then 140 after a conversion on one of *our* codes | 0 |

The agent that submitted the code that converted got nothing. The agent that only asked took the whole agent share, for that conversion and for the next one it had no connection to at all.

## What changed

**A conversion resolves its submitter from the code it was reported against.** `submitterOfCode(vendor, code)` looks the code up in our own submission registry — a record we hold, joined on the code the vendor names. Revoked and expired submissions still resolve, because the agent did submit the code that converted. One of our own codes resolves to nobody.

**The rule:** submitter takes `SUBMITTER_SHARE_RATE` (40%), platform takes the rest; no agent share when no agent submitted the code.

**`attributeConversion` and `markConversion` are deleted**, not left unused. Last-touch over code requests is the rule this issue is about; leaving a function that implements it invites its reuse.

**The published table is computed from the constant the ledger accrues at.** `submitterSharePercent = Math.round(SUBMITTER_SHARE_RATE * 100)`, so a change to the rate moves the page. There is a test that fails if it stops doing so.

**The page says why the surfer share is gone**, in the section where it used to be published, including that the only signal we hold is a `get_referral_code` call that any registered agent can make.

**`get_referral_code` and the attribution notes** keep all five outcomes (#1163 AC-4) and stop implying that asking earns a share.

## The number I did not invent, and the one I did not raise

40% is the rate the old table already attached to the submitter role in isolation. I did **not** redistribute the removed surfer share to the submitter, which would have made the single-agent case 80/20. The surfer term is being removed because it paid for something unobservable — that is not a reason to pay the submitter more. If you would rather the submitter absorb it, it is one constant and the page follows automatically.

## Verification

- **2,720 tests / 0 failures**, `tsc --noEmit`, `validate-data` (1,580 offers / 444 changes) and `no-private-context` all clean. `check-mutation-targets` 486/486 across 38 scripts.
- **`scripts/e2e-1163-split.mjs`: 29 checks** against a spawned server with a durable backend and the platform secret set — a real `initialize` → `tools/call`, a real code submission, a real conversion through `POST /api/conversions`, balances read back through the authenticated API. Same script against `main`: **12 passed, 17 failed**, which is the table above.
- **`scripts/mutate-1163-split.sh`: 14 mutations, 14 killed, no survivors.** Two survived the first pass and both were real gaps: a conversion naming no code at all had no test, and the page-follows-the-ledger property could not be told from a hardcoded `40`. The second is now driven by a mutation that changes the rate *and* hardcodes the page, run against the marketplace suite alone so the kill cannot come from another guard.
- **Sweep of all 3,916 published paths against a `main` worktree: 3,915 byte-identical.** `/marketplace` is the only page that moves (+550 bytes). Sponsored anchors unchanged at 76 across 71 pages.
- Screenshots of the section before and after.

## Notes

- Production holds no ledger entries (`/api/leaderboard` is empty, the platform secret is unset), so nothing accrued under the old rule needs migrating.
- `ReferralRequest.conversion_id` stays on the record shape and is now always null. Removing it would change a durable record; it is not published anywhere.
- The Trust Tiers table on the same page still holds: `calculateTrustTier` reads `agent_id`, which is now the submitter, so submitted codes that convert still advance an agent.

Refs #1163