### PR TITLE
Publish the ranking seed on /vendor and /alternative-to, and say what the category count counts

### DIFF
--- a/scripts/e2e-1166.mjs
+++ b/scripts/e2e-1166.mjs
@@ -1,0 +1,222 @@
+import { createHash } from "node:crypto";
+
+const BASE = process.env.E2E_BASE ?? "http://localhost:3112";
+
+let pass = 0;
+let fail = 0;
+const check = (ok, label, detail = "") => {
+  if (ok) { pass++; console.log(`  ok   ${label}`); }
+  else { fail++; console.log(`  FAIL ${label}${detail ? ` — ${detail}` : ""}`); }
+};
+
+const get = async (path) => {
+  const res = await fetch(`${BASE}${path}`);
+  if (!res.ok) throw new Error(`${path} -> ${res.status}`);
+  return res.headers.get("content-type")?.includes("json") ? res.json() : res.text();
+};
+
+const readerSeed = (date, queryKey, band) =>
+  createHash("sha256").update(`${date}|${queryKey}|p${band}`).digest("hex");
+
+function readerRng(seedHex) {
+  let a = parseInt(seedHex.slice(0, 8), 16) >>> 0;
+  return () => {
+    a |= 0;
+    a = (a + 0x6d2b79f5) | 0;
+    let t = Math.imul(a ^ (a >>> 15), 1 | a);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+function readerPermutation(seedHex, n) {
+  const positions = Array.from({ length: n }, (_, i) => i);
+  const rng = readerRng(seedHex);
+  for (let i = n - 1; i > 0; i--) {
+    const j = Math.floor(rng() * (i + 1));
+    const tmp = positions[i];
+    positions[i] = positions[j];
+    positions[j] = tmp;
+  }
+  return positions;
+}
+
+const decode = (s) => s
+  .replace(/&amp;/g, "&").replace(/&lt;/g, "<").replace(/&gt;/g, ">")
+  .replace(/&quot;/g, '"').replace(/&#39;/g, "'").replace(/&rsquo;/g, "’");
+
+function parseAuditBlock(html) {
+  const block = html.match(/<div class="audit-block">[\s\S]*?<\/div>/);
+  if (!block) return null;
+  const field = (name) => {
+    const m = block[0].match(new RegExp(`<dt>${name}</dt><dd>([^<]*)</dd>`));
+    return m ? decode(m[1]) : null;
+  };
+  const truncation = block[0].match(/first (\d+) of (\d+) entries/);
+  return {
+    date: field("date"),
+    query_key: field("query_key"),
+    seed: field("seed"),
+    tie_count: Number(field("tie_count")),
+    shown: truncation ? Number(truncation[1]) : null,
+    total: truncation ? Number(truncation[2]) : null,
+  };
+}
+
+function vendorPageAlternatives(html) {
+  const section = html.slice(html.indexOf('<div class="alt-grid">'));
+  return [...section.matchAll(/<span class="alt-name">([^<]+)<\/span>/g)].map((m) => decode(m[1]));
+}
+
+function alternativeToList(html) {
+  const section = html.slice(html.indexOf("All Free Alternatives"));
+  return [...section.matchAll(/class="alt-vendor-name">([^<]+)</g)].map((m) => decode(m[1]));
+}
+
+console.log(`\n#1166 — a reader recomputes our published order (${BASE})\n`);
+
+console.log("1. every ranked surface publishes the block /criteria promises");
+const surfaces = [
+  ["/best/free-databases", "html"],
+  ["/vendor/doppler", "html"],
+  ["/alternative-to/doppler", "html"],
+];
+for (const [path] of surfaces) {
+  const html = await get(path);
+  const audit = parseAuditBlock(html);
+  check(audit !== null, `${path} renders an audit block`);
+  if (!audit) continue;
+  check(/^\d{4}-\d{2}-\d{2}$/.test(audit.date ?? ""), `${path} publishes a date`, audit.date ?? "");
+  check((audit.query_key ?? "").length > 0, `${path} publishes a query_key`, audit.query_key ?? "");
+  check(/^[0-9a-f]{64}$/.test(audit.seed ?? ""), `${path} publishes a full seed`, audit.seed ?? "");
+  check(Number.isInteger(audit.tie_count), `${path} publishes a tie_count`, String(audit.tie_count));
+}
+
+const stack = await get("/api/stack?use_case=Next.js+SaaS+app");
+check(stack.stack.every((r) => /^[0-9a-f]{64}$/.test(r.tie_break?.seed ?? "")), "/api/stack returns the same block");
+const risk = await get("/api/vendor-risk/doppler");
+check(/^[0-9a-f]{64}$/.test(risk.tie_break?.seed ?? ""), "/api/vendor-risk returns the same block");
+const details = await get("/api/details/doppler?alternatives=true");
+check(/^[0-9a-f]{64}$/.test(details.offer?.tie_break?.seed ?? ""), "/api/details/:vendor returns the same block");
+
+console.log("\n2. the published seed is the one the published algorithm produces");
+for (const path of ["/best/free-databases", "/vendor/doppler", "/alternative-to/doppler", "/vendor/supabase"]) {
+  const audit = parseAuditBlock(await get(path));
+  if (!audit) { check(false, `${path} seed = sha256(date|query_key|p0)`, "no audit block to check"); continue; }
+  const derived = readerSeed(audit.date, audit.query_key, 0);
+  check(derived === audit.seed, `${path} seed = sha256(date|query_key|p0)`, `${derived.slice(0, 16)} vs ${(audit.seed ?? "").slice(0, 16)}`);
+}
+
+console.log("\n3. the served order is the seed's permutation of the public index order");
+
+function landsBackInIndexOrder(topBand, seed, tieCount, indexRank) {
+  const inputIndexOf = readerPermutation(seed, tieCount);
+  const recovered = topBand.map((vendor, outputPos) => ({ vendor, inputPos: inputIndexOf[outputPos] }));
+  if (recovered.some((r) => !indexRank.has(r.vendor))) return null;
+  const byInputPos = [...recovered].sort((a, b) => a.inputPos - b.inputPos).map((r) => r.vendor);
+  const byIndexOrder = [...recovered].sort((a, b) => indexRank.get(a.vendor) - indexRank.get(b.vendor)).map((r) => r.vendor);
+  return { ok: byInputPos.join("|") === byIndexOrder.join("|"), byInputPos, byIndexOrder };
+}
+
+async function auditRankedPrefix(path, category, excludeVendor, servedOf) {
+  const html = await get(path);
+  const audit = parseAuditBlock(html);
+  if (!audit) { check(false, `${path} — no audit block, so no order can be recomputed`); return; }
+  const served = servedOf(html);
+  const label = `${path} (${audit.tie_count} tied, ${served.length} shown)`;
+
+  const api = await get(`/api/offers?category=${encodeURIComponent(category)}&limit=500`);
+  const indexOrder = api.offers.map((o) => o.vendor).filter((v) => v !== excludeVendor);
+  const indexRank = new Map(indexOrder.map((v, i) => [v, i]));
+
+  const topBand = served.slice(0, Math.min(served.length, audit.tie_count));
+  if (topBand.length < 2) { check(true, `${label} — fewer than two tied entries shown, nothing to permute`); return; }
+
+  const unknown = topBand.filter((v) => !indexRank.has(v));
+  check(unknown.length === 0, `${label} — every shown vendor is in the public index`, unknown.join(", "));
+  if (unknown.length > 0) return;
+
+  const served0 = landsBackInIndexOrder(topBand, audit.seed, audit.tie_count, indexRank);
+  check(
+    served0.ok,
+    `${label} — inverting the seed's permutation lands the shown entries back in index order`,
+    `\n       by seed:  ${served0.byInputPos.join(", ")}\n       by index: ${served0.byIndexOrder.join(", ")}`,
+  );
+
+  const handPlaced = [topBand[topBand.length - 1], ...topBand.slice(0, topBand.length - 1)];
+  const tampered = landsBackInIndexOrder(handPlaced, audit.seed, audit.tie_count, indexRank);
+  check(
+    tampered !== null && !tampered.ok,
+    `${label} — the same check rejects the served list with its last entry moved to the top`,
+  );
+
+  const shuffled = (() => {
+    const band = indexOrder.filter((v) => topBand.includes(v));
+    if (band.length !== audit.tie_count) return null;
+    const out = band.slice();
+    const rng = readerRng(audit.seed);
+    for (let i = out.length - 1; i > 0; i--) {
+      const j = Math.floor(rng() * (i + 1));
+      const tmp = out[i]; out[i] = out[j]; out[j] = tmp;
+    }
+    return out;
+  })();
+  if (shuffled) {
+    check(shuffled.join("|") === topBand.join("|"), `${label} — full forward recompute reproduces the served order`,
+      `\n       recomputed: ${shuffled.join(", ")}\n       served:     ${topBand.join(", ")}`);
+  }
+}
+
+await auditRankedPrefix("/vendor/supabase", "Databases", "Supabase", vendorPageAlternatives);
+await auditRankedPrefix("/vendor/doppler", "Secrets Management", "Doppler", vendorPageAlternatives);
+await auditRankedPrefix("/vendor/sentry", "Monitoring", "Sentry", vendorPageAlternatives);
+await auditRankedPrefix("/vendor/vercel", "Cloud Hosting", "Vercel", vendorPageAlternatives);
+
+for (const path of ["/alternative-to/vercel", "/alternative-to/doppler", "/alternative-to/openai"]) {
+  const html = await get(path);
+  const audit = parseAuditBlock(html);
+  if (!audit) { check(false, `${path} — no audit block to reconcile against the list`); continue; }
+  const listed = alternativeToList(html);
+  const cards = html.slice(html.indexOf("All Free Alternatives")).split('<div class="alt-row').slice(1);
+  const undemerited = cards.map((c) => !c.includes("alt-demerit"));
+  const firstDemerited = undemerited.indexOf(false);
+  const bandSize = firstDemerited === -1 ? cards.length : firstDemerited;
+  check(
+    bandSize === audit.tie_count,
+    `${path} — the published tie_count matches the entries the page shows no demerit against`,
+    `block says ${audit.tie_count}, page shows ${bandSize} of ${listed.length}`,
+  );
+  check(
+    firstDemerited === -1 || undemerited.slice(firstDemerited).every((u) => !u),
+    `${path} — no undemerited entry is ranked below a demoted one`,
+  );
+}
+
+console.log("\n4. the order rotates with the date and nothing else");
+const a = parseAuditBlock(await get("/vendor/supabase"));
+if (!a) {
+  check(false, "a vendor page publishes a query key to vary", "no audit block");
+} else {
+  check(readerSeed(a.date, a.query_key, 0) !== readerSeed("1999-01-01", a.query_key, 0), "a different date gives a different seed");
+  check(readerSeed(a.date, a.query_key, 0) !== readerSeed(a.date, "alternatives:Databases:Neon", 0), "a different query key gives a different seed");
+  check(!a.query_key.includes("referral") && !a.query_key.includes("sponsor"), "the query key carries no commercial input", a.query_key);
+}
+
+console.log("\n5. /criteria and llms.txt name what they count");
+const criteria = await get("/criteria");
+const llms = await get("/llms.txt");
+const apiCats = await get("/api/categories");
+const bestIndex = await get("/best");
+const bestPages = new Set([...bestIndex.matchAll(/href="\/best\/([a-z0-9-]+)"/g)].map((m) => m[1])).size;
+check(!/of 57 categories/.test(criteria), "/criteria no longer calls 57 best-of pages 57 categories");
+check(!/of 57 categories/.test(llms), "llms.txt no longer calls 57 best-of pages 57 categories");
+const scope = new RegExp(`of the ${bestPages} categories with a best-of page`);
+check(scope.test(criteria), `/criteria names its scope as the ${bestPages} categories with a best-of page`);
+check(scope.test(llms), `llms.txt names its scope as the ${bestPages} categories with a best-of page`);
+check(
+  criteria.includes(`The site publishes ${apiCats.categories.length} categories in all`),
+  `/criteria states the ${apiCats.categories.length} categories the rest of the site publishes`,
+);
+
+console.log(`\n${pass} passed, ${fail} failed\n`);
+process.exit(fail === 0 ? 0 : 1);

--- a/scripts/mutate-1166.sh
+++ b/scripts/mutate-1166.sh
@@ -1,0 +1,265 @@
+#!/usr/bin/env bash
+set -u
+
+REPO="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$REPO" || exit 1
+
+SERVE="src/serve.ts"
+DATA="src/data.ts"
+BACKUP_DIR="$(mktemp -d)"
+for f in "$SERVE" "$DATA"; do
+  cp "$f" "$BACKUP_DIR/$(basename "$f")"
+done
+
+restore() {
+  for f in "$SERVE" "$DATA"; do
+    cp "$BACKUP_DIR/$(basename "$f")" "$f"
+  done
+}
+trap 'restore; npm run build > /dev/null 2>&1' EXIT
+
+killed=0
+survived=0
+TESTS="test/ranked-surfaces.test.ts test/best-of-ranking.test.ts"
+
+py() { python3 - "$@"; }
+
+changed_any() {
+  for f in "$SERVE" "$DATA"; do
+    if ! diff -q "$BACKUP_DIR/$(basename "$f")" "$f" > /dev/null; then
+      return 0
+    fi
+  done
+  return 1
+}
+
+run_mutation() {
+  local name="$1"
+  shift
+  local scope="$TESTS"
+  if [ "$1" = "--only" ]; then
+    scope="$2"
+    shift 2
+  fi
+  echo "=== $name"
+  restore
+  "$@"
+  if ! changed_any; then
+    echo "    NOT APPLIED: the mutation changed no file, so it proves nothing"
+    survived=$((survived + 1))
+    return
+  fi
+  if ! npm run build > /tmp/mutate-1166-build.log 2>&1; then
+    echo "    DID NOT COMPILE: a mutation the compiler rejects proves nothing about the tests"
+    survived=$((survived + 1))
+    return
+  fi
+  if timeout 900 node --test --test-concurrency 1 $scope > /tmp/mutate-1166-test.log 2>&1; then
+    echo "    SURVIVED"
+    survived=$((survived + 1))
+  else
+    echo "    KILLED: $(grep -c '✖ ' /tmp/mutate-1166-test.log) failing assertion(s)"
+    grep '✖ ' /tmp/mutate-1166-test.log | head -3
+    killed=$((killed + 1))
+  fi
+}
+
+m_vendor_page_drops_the_block() {
+  py <<'PY'
+p = "src/serve.ts"
+s = open(p).read()
+s = s.replace("""    </div>${membershipExclusionsHtml}
+${renderAuditBlock(alternativesRanking.tie_break, { shown: alternatives.length, total: alternativesRanking.entries.length })}
+  </div>` : "";""",
+"""    </div>${membershipExclusionsHtml}
+  </div>` : "";""")
+open(p, "w").write(s)
+PY
+}
+
+m_alternative_to_drops_the_block() {
+  py <<'PY'
+p = "src/serve.ts"
+s = open(p).read()
+s = s.replace("""${enrichedAlts.map(a => altCard(a, false)).join("\\n")}
+    </div>
+${renderAuditBlock(altRanking.tie_break)}""",
+"""${enrichedAlts.map(a => altCard(a, false)).join("\\n")}
+    </div>""")
+open(p, "w").write(s)
+PY
+}
+
+m_block_omits_the_seed() {
+  py <<'PY'
+p = "src/serve.ts"
+s = open(p).read()
+s = s.replace("      <dt>seed</dt><dd>${escHtmlServer(tie.seed)}</dd>\n", "")
+open(p, "w").write(s)
+PY
+}
+
+m_block_omits_the_tie_count() {
+  py <<'PY'
+p = "src/serve.ts"
+s = open(p).read()
+s = s.replace("      <dt>tie_count</dt><dd>${tie.tie_count}</dd>\n", "")
+open(p, "w").write(s)
+PY
+}
+
+m_block_omits_the_query_key() {
+  py <<'PY'
+p = "src/serve.ts"
+s = open(p).read()
+s = s.replace("      <dt>query_key</dt><dd>${escHtmlServer(tie.query_key)}</dd>\n", "")
+open(p, "w").write(s)
+PY
+}
+
+m_seed_is_recomputed_for_the_wrong_band() {
+  py <<'PY'
+p = "src/serve.ts"
+s = open(p).read()
+s = s.replace("      <dt>seed</dt><dd>${escHtmlServer(tie.seed)}</dd>",
+              "      <dt>seed</dt><dd>${escHtmlServer(tieBreakSeed(tie.date, tie.query_key, 1))}</dd>")
+s = s.replace("TIME_LIMITED_TIER_RULES, type TieBreak } from \"./ranking.js\";",
+              "TIME_LIMITED_TIER_RULES, tieBreakSeed, type TieBreak } from \"./ranking.js\";")
+open(p, "w").write(s)
+PY
+}
+
+m_vendor_page_publishes_another_surfaces_query_key() {
+  py <<'PY'
+p = "src/serve.ts"
+s = open(p).read()
+s = s.replace("{ queryKey: `alternatives:${primary.category}:${vendorName}`, changes: dealChanges },",
+              "{ queryKey: `alternative-to:${vendorName}`, changes: dealChanges },")
+open(p, "w").write(s)
+PY
+}
+
+m_truncation_note_always_claims_a_prefix() {
+  py <<'PY'
+p = "src/serve.ts"
+s = open(p).read()
+s = s.replace("const truncationNote = listed && listed.shown < listed.total",
+              "const truncationNote = listed")
+open(p, "w").write(s)
+PY
+}
+
+m_truncation_note_never_appears() {
+  py <<'PY'
+p = "src/serve.ts"
+s = open(p).read()
+s = s.replace("    ? ` The list above is the first ${listed.shown} of ${listed.total} entries in that order.`",
+              "    ? ``")
+open(p, "w").write(s)
+PY
+}
+
+m_truncation_note_reports_the_cap_as_the_total() {
+  py <<'PY'
+p = "src/serve.ts"
+s = open(p).read()
+s = s.replace("${renderAuditBlock(alternativesRanking.tie_break, { shown: alternatives.length, total: alternativesRanking.entries.length })}",
+              "${renderAuditBlock(alternativesRanking.tie_break, { shown: alternatives.length, total: alternatives.length })}")
+open(p, "w").write(s)
+PY
+}
+
+m_criteria_calls_best_of_pages_categories_again() {
+  py <<'PY'
+p = "src/serve.ts"
+s = open(p).read()
+s = s.replace("  const scope = `of the ${s.bestOfPageCount} categories with a best-of page`;",
+              "  const scope = `of ${s.bestOfPageCount} categories`;")
+open(p, "w").write(s)
+PY
+}
+
+m_criteria_drops_the_full_category_count() {
+  py <<'PY'
+p = "src/serve.ts"
+s = open(p).read()
+s = s.replace(" The site publishes ${categories.length} categories in all; the ${categories.length - bestOfPageCount} with fewer than ${BEST_OF_MIN_VENDORS} generally-available offers have no best-of page and are not counted here.", "")
+open(p, "w").write(s)
+PY
+}
+
+m_llms_txt_hardcodes_the_old_sentence() {
+  py <<'PY'
+p = "src/serve.ts"
+s = open(p).read()
+s = s.replace("large ties are the normal case — ${uniqueTopClause(summariseBestOfTies())} — and",
+              "large ties are the normal case — 0 of 57 categories has a unique number one — and")
+open(p, "w").write(s)
+PY
+}
+
+m_unique_top_counts_every_page() {
+  py <<'PY'
+p = "src/serve.ts"
+s = open(p).read()
+s = s.replace("if (r.tie_break.tie_count === 1) categoriesWithUniqueTop.push(categoryName);",
+              "if (r.tie_break.tie_count >= 1) categoriesWithUniqueTop.push(categoryName);")
+open(p, "w").write(s)
+PY
+}
+
+m_mean_tie_divides_by_the_wrong_denominator() {
+  py <<'PY'
+p = "src/serve.ts"
+s = open(p).read()
+s = s.replace("meanTie: bestOfPageCount > 0 ? (tieSum / bestOfPageCount).toFixed(1) : \"0\",",
+              "meanTie: bestOfPageCount > 0 ? (tieSum / (bestOfPageCount + 1)).toFixed(1) : \"0\",")
+open(p, "w").write(s)
+PY
+}
+
+m_details_api_drops_the_block() {
+  py <<'PY'
+p = "src/data.ts"
+s = open(p).read()
+s = s.replace("""      relatedVendors,
+      tie_break: relatedRanking.tie_break,
+    };""",
+"""      relatedVendors,
+      tie_break: undefined as unknown as TieBreak,
+    };""")
+open(p, "w").write(s)
+PY
+}
+
+m_vendor_risk_api_drops_the_block() {
+  py <<'PY'
+p = "src/data.ts"
+s = open(p).read()
+s = s.replace("      tie_break: alternativesRanking.tie_break,\n",
+              "      tie_break: undefined as unknown as TieBreak,\n")
+open(p, "w").write(s)
+PY
+}
+
+run_mutation "the vendor page ranks its alternatives and prints no seed" m_vendor_page_drops_the_block
+run_mutation "the alternatives page ranks its list and prints no seed" m_alternative_to_drops_the_block
+run_mutation "the block omits the seed" m_block_omits_the_seed
+run_mutation "the block omits the tie count" m_block_omits_the_tie_count
+run_mutation "the block omits the query key" m_block_omits_the_query_key
+run_mutation "the seed is recomputed for a band the list is not in" m_seed_is_recomputed_for_the_wrong_band
+run_mutation "the vendor page publishes another surface's query key" m_vendor_page_publishes_another_surfaces_query_key
+run_mutation "a complete list claims to be a prefix" m_truncation_note_always_claims_a_prefix
+run_mutation "a truncated list never says it is truncated" m_truncation_note_never_appears
+run_mutation "a truncated list reports the cap as the total" m_truncation_note_reports_the_cap_as_the_total
+run_mutation "/criteria calls best-of pages categories again" m_criteria_calls_best_of_pages_categories_again
+run_mutation "/criteria drops the count the rest of the site publishes" m_criteria_drops_the_full_category_count
+run_mutation "llms.txt goes back to a hardcoded figure" m_llms_txt_hardcodes_the_old_sentence
+run_mutation "the unique-top count stops meaning unique" m_unique_top_counts_every_page
+run_mutation "the mean tie is divided by the wrong denominator" m_mean_tie_divides_by_the_wrong_denominator
+run_mutation "/api/details drops the block" m_details_api_drops_the_block
+run_mutation "/api/vendor-risk drops the block" m_vendor_risk_api_drops_the_block
+
+echo
+echo "killed=$killed survived=$survived"
+[ "$survived" -eq 0 ]

--- a/src/data.ts
+++ b/src/data.ts
@@ -3,7 +3,7 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 import type { Offer, EnrichedOffer, OfferIndex, DealChange, DealChangesIndex, ChangeDateSource, StabilityClass, Referral, RiskCause, LinkUnreachable } from "./types.js";
 import { isUrlSuspended } from "./referral-health.js";
-import { rankForListing } from "./ranking.js";
+import { rankForListing, type TieBreak } from "./ranking.js";
 import { unreachableNoticeForUrl, resetLinkHealthCache } from "./link-health.js";
 import { quarantineSummary, resetVerificationStateCache, type QuarantineSummary } from "./verification-state.js";
 import { cannotVouchForLevel, levelWithheldReason, withheldLevelSentence } from "./source-check.js";
@@ -80,7 +80,7 @@ export function getCategories(): { name: string; count: number }[] {
 export function getOfferDetails(
   vendorName: string,
   includeAlternatives: boolean = false
-): { offer: Offer & { relatedVendors: string[]; alternatives?: Offer[] } } | { error: string; suggestions: string[] } {
+): { offer: Offer & { relatedVendors: string[]; alternatives?: Offer[]; tie_break: TieBreak } } | { error: string; suggestions: string[] } {
   const offers = loadOffers();
   const lowerName = vendorName.toLowerCase();
   const match = offers.find((o) => o.vendor.toLowerCase() === lowerName);
@@ -89,12 +89,17 @@ export function getOfferDetails(
     // Related vendors and alternatives are a recommendation, so they resolve
     // through the shared selection module (#1025) rather than `.slice(0, 5)`
     // over data/index.json order.
-    const sameCategoryOffers = rankForListing(
+    const relatedRanking = rankForListing(
       filterAlternatives(offers.filter((o) => o.category === match.category && o.vendor !== match.vendor), match),
       { queryKey: `related:${match.category}:${match.vendor}`, changes: loadDealChanges() },
-    ).entries.slice(0, 5).map((e) => e.offer);
+    );
+    const sameCategoryOffers = relatedRanking.entries.slice(0, 5).map((e) => e.offer);
     const relatedVendors = sameCategoryOffers.map((o) => o.vendor);
-    const result: Offer & { relatedVendors: string[]; alternatives?: Offer[] } = { ...match, relatedVendors };
+    const result: Offer & { relatedVendors: string[]; alternatives?: Offer[]; tie_break: TieBreak } = {
+      ...match,
+      relatedVendors,
+      tie_break: relatedRanking.tie_break,
+    };
     if (includeAlternatives) {
       result.alternatives = sameCategoryOffers.map(o => stripReferrerValue(o));
     }
@@ -666,6 +671,7 @@ export interface VendorRiskResult {
   free_tier_longevity_days: number;
   changes: DealChange[];
   alternatives: Array<{ vendor: string; category: string; tier: string; risk_level: "stable" | "caution" | "risky" | null; risk_cause: RiskCause | null; link_unreachable: LinkUnreachable | null; demerits: Array<{ code: string; points: number; reason: string }> }>;
+  tie_break: TieBreak;
   summary: string;
 }
 
@@ -784,10 +790,11 @@ export function checkVendorRisk(
   // resolves through the shared selection module (#1025) rather than the old
   // "risk bucket, then alphabetical" sort — which ranked on the count of
   // changes we happen to have recorded and broke ties with the alphabet.
-  const alternatives = rankForListing(
+  const alternativesRanking = rankForListing(
     filterAlternatives(offers.filter((o) => o.category === offer.category && o.vendor !== offer.vendor), offer),
     { queryKey: `vendor-risk-alternatives:${offer.vendor}`, changes: allChanges },
-  ).entries.slice(0, 3).map((e) => ({
+  );
+  const alternatives = alternativesRanking.entries.slice(0, 3).map((e) => ({
     vendor: e.offer.vendor,
     category: e.offer.category,
     tier: e.offer.tier,
@@ -833,6 +840,7 @@ export function checkVendorRisk(
       free_tier_longevity_days: longevityDays,
       changes: vendorChanges,
       alternatives,
+      tie_break: alternativesRanking.tie_break,
       summary,
     },
   };

--- a/src/serve.ts
+++ b/src/serve.ts
@@ -40,7 +40,7 @@ import { faqPageJsonLd, type FaqItem } from "./faq-provenance.js";
 import { SSE_KEEPALIVE_FRAME, keepaliveIntervalMs, sessionRecoveryBody } from "./mcp-stream.js";
 import { ASSISTANTS_API_SHUTDOWN } from "./assistants-shutdown.js";
 import { discontinuedOnOrBefore } from "./product-deprecation.js";
-import { rankOffers, rankForListing, rotateListing, utcDate, CRITERIA_PATH, DEMOTE_ONLY_POLICY, DISCLOSURE_RATIONALE, TIE_BREAK_ALGORITHM, GATE_TABLE, DEMERIT_TABLE, NOT_FREE_TIER_RULES, TIME_LIMITED_TIER_RULES } from "./ranking.js";
+import { rankOffers, rankForListing, rotateListing, utcDate, CRITERIA_PATH, DEMOTE_ONLY_POLICY, DISCLOSURE_RATIONALE, TIE_BREAK_ALGORITHM, GATE_TABLE, DEMERIT_TABLE, NOT_FREE_TIER_RULES, TIME_LIMITED_TIER_RULES, type TieBreak } from "./ranking.js";
 import type { RankedEntry, RankingResult } from "./ranking.js";
 import { verificationLedger, QUARANTINE_AFTER_FAILURES } from "./verification-state.js";
 import { partitionAlternatives, partitionAlternativesAcross, productRoleSentence, MEMBERSHIP_GATE_RULES, MEMBERSHIP_GATE_ORDER, MEMBERSHIP_GATE_SYMMETRY, MEMBERSHIP_GATE_SCOPE, MEMBERSHIP_GATE_CORRECTIONS } from "./product-role.js";
@@ -1548,6 +1548,29 @@ function renderDemerits(entry: RankedEntry<EnrichedOfferRow>): string {
   return `<ul class="demerit-list">${items}</ul>`;
 }
 
+function auditBlockCss(): string {
+  return `.audit-block{background:var(--bg-card);border:1px solid var(--border);border-radius:8px;padding:1rem 1.25rem;margin:2rem 0;font-size:.8rem;color:var(--text-muted)}
+.audit-block dl{display:grid;grid-template-columns:auto 1fr;gap:.25rem .75rem;margin:.5rem 0 0}
+.audit-block dt{color:var(--text-dim)}
+.audit-block dd{font-family:var(--mono);color:var(--text);word-break:break-all}
+@media(max-width:768px){.audit-block dl{grid-template-columns:1fr}}`;
+}
+
+function renderAuditBlock(tie: TieBreak, listed?: { shown: number; total: number }): string {
+  const truncationNote = listed && listed.shown < listed.total
+    ? ` The list above is the first ${listed.shown} of ${listed.total} entries in that order.`
+    : "";
+  return `  <div class="audit-block">
+    <strong style="color:var(--text)">Recompute today's order yourself.</strong> The order above is a permutation seeded only on the UTC date and the query key &mdash; no vendor name, slug, id or offer field is an input.${truncationNote} <a href="${CRITERIA_PATH}">The algorithm is published</a>, so anyone can reproduce this page's order without asking us.
+    <dl>
+      <dt>date</dt><dd>${escHtmlServer(tie.date)}</dd>
+      <dt>query_key</dt><dd>${escHtmlServer(tie.query_key)}</dd>
+      <dt>seed</dt><dd>${escHtmlServer(tie.seed)}</dd>
+      <dt>tie_count</dt><dd>${tie.tie_count}</dd>
+    </dl>
+  </div>`;
+}
+
 function buildBestOfPage(slug: string): string | null {
   const entry = bestOfSlugMap.get(slug);
   if (!entry) return null;
@@ -1701,12 +1724,9 @@ h2{font-family:var(--serif);font-size:1.4rem;color:var(--text);margin:2.5rem 0 1
 .best-disclosure{margin:.5rem 0;font-size:.78rem;color:var(--text-dim)}
 .best-disclosure-label{text-transform:uppercase;letter-spacing:.04em;font-size:.68rem}
 .best-disclosure ul{margin:.25rem 0 0 1rem}
-.audit-block{background:var(--bg-card);border:1px solid var(--border);border-radius:8px;padding:1rem 1.25rem;margin:2rem 0;font-size:.8rem;color:var(--text-muted)}
-.audit-block dl{display:grid;grid-template-columns:auto 1fr;gap:.25rem .75rem;margin:.5rem 0 0}
-.audit-block dt{color:var(--text-dim)}
-.audit-block dd{font-family:var(--mono);color:var(--text);word-break:break-all}
+${auditBlockCss()}
 footer{text-align:center;color:var(--text-dim);font-size:.8rem;padding:3rem 0 2rem;border-top:1px solid var(--border);margin-top:3rem}
-@media(max-width:768px){h1{font-size:1.5rem}.best-pick{flex-direction:column;gap:.5rem}.best-pick-rank{text-align:left}.compare-table{font-size:.75rem}.compare-table th,.compare-table td{padding:.4rem .5rem}.audit-block dl{grid-template-columns:1fr}}
+@media(max-width:768px){h1{font-size:1.5rem}.best-pick{flex-direction:column;gap:.5rem}.best-pick-rank{text-align:left}.compare-table{font-size:.75rem}.compare-table th,.compare-table td{padding:.4rem .5rem}}
 ${globalNavCss()}
 ${mcpCtaCss()}
 </style>
@@ -1730,15 +1750,7 @@ ${reviewsHtml}
   <p class="page-meta" style="margin-bottom:1rem">These offers are in this category but rank below the list above. Each one names the recorded fact behind it. ${escHtmlServer(DISCLOSURE_RATIONALE)}</p>
 ${demotedHtml}
 
-  <div class="audit-block">
-    <strong style="color:var(--text)">Recompute today's order yourself.</strong> The order above is a permutation seeded only on the UTC date and the query key &mdash; no vendor name, slug, id or offer field is an input. <a href="${CRITERIA_PATH}">The algorithm is published</a>, so anyone can reproduce this page's order without asking us.
-    <dl>
-      <dt>date</dt><dd>${escHtmlServer(tie.date)}</dd>
-      <dt>query_key</dt><dd>${escHtmlServer(tie.query_key)}</dd>
-      <dt>seed</dt><dd>${escHtmlServer(tie.seed)}</dd>
-      <dt>tie_count</dt><dd>${tie.tie_count}</dd>
-    </dl>
-  </div>
+${renderAuditBlock(tie)}
 
   <h2>Quick Comparison</h2>
   <table class="compare-table">
@@ -1859,6 +1871,37 @@ ${globalNavCss()}
 
 // --- Ranking criteria page ---
 
+interface BestOfTieSummary {
+  bestOfPageCount: number;
+  categoriesWithUniqueTop: string[];
+  meanTie: string;
+}
+
+// Measured live rather than asserted, so the numbers on the page are today's.
+function summariseBestOfTies(date = utcDate()): BestOfTieSummary {
+  const categoriesWithUniqueTop: string[] = [];
+  let tieSum = 0;
+  let bestOfPageCount = 0;
+  for (const [, { categoryName }] of bestOfSlugMap) {
+    const r = rankCategory(categoryName, date);
+    bestOfPageCount++;
+    tieSum += r.tie_break.tie_count;
+    if (r.tie_break.tie_count === 1) categoriesWithUniqueTop.push(categoryName);
+  }
+  return {
+    bestOfPageCount,
+    categoriesWithUniqueTop,
+    meanTie: bestOfPageCount > 0 ? (tieSum / bestOfPageCount).toFixed(1) : "0",
+  };
+}
+
+function uniqueTopClause(s: BestOfTieSummary): string {
+  const found = s.categoriesWithUniqueTop;
+  const scope = `of the ${s.bestOfPageCount} categories with a best-of page`;
+  const named = found.length === 0 ? "" : ` (${found.join(", ")})`;
+  return `${found.length} ${scope} ${found.length === 1 ? "has" : "have"} a unique number one${named}`;
+}
+
 /**
  * The published method. Every claim on this page is generated from the same
  * constants the ranking itself uses, so the page cannot drift from the code.
@@ -1866,17 +1909,8 @@ ${globalNavCss()}
 function buildCriteriaPage(): string {
   const date = utcDate();
 
-  // Measured live rather than asserted, so the numbers on the page are today's.
-  let pagesWithUniqueTop = 0;
-  let tieSum = 0;
-  let pageCount = 0;
-  for (const [, { categoryName }] of bestOfSlugMap) {
-    const r = rankCategory(categoryName, date);
-    pageCount++;
-    tieSum += r.tie_break.tie_count;
-    if (r.tie_break.tie_count === 1) pagesWithUniqueTop++;
-  }
-  const meanTie = pageCount > 0 ? (tieSum / pageCount).toFixed(1) : "0";
+  const tieSummary = summariseBestOfTies(date);
+  const { bestOfPageCount, categoriesWithUniqueTop, meanTie } = tieSummary;
 
   const title = "How AgentDeals ranks — published criteria — AgentDeals";
   const metaDesc = "Our ranking method in full: the gates, the demerits and their weights, the tie-break seed, and the reason there is no top slot to sell. Recompute any ranked page yourself.";
@@ -1992,7 +2026,9 @@ ${demeritRows}
 
   <h2>3. Ties, and why there is no top slot to sell</h2>
   <div class="callout">
-    <strong>Zero of ${pageCount} categories have a unique number one.</strong> Under every criterion we currently record, there is no single best free database, no best free AI/ML tool, no best free anything. On average ${meanTie} offers tie at the top of a category.
+    <strong>${uniqueTopClause(tieSummary).replace(/^0 /, "Zero ")}.</strong> ${categoriesWithUniqueTop.length === 0
+      ? "Under every criterion we currently record, there is no single best free database, no best free AI/ML tool, no best free anything."
+      : "Everywhere else, under every criterion we currently record, there is no single best free tier of anything."} On average ${meanTie} offers tie at the top of those categories. The site publishes ${categories.length} categories in all; the ${categories.length - bestOfPageCount} with fewer than ${BEST_OF_MIN_VENDORS} generally-available offers have no best-of page and are not counted here.
   </div>
   <p>We think that is the honest answer and a better thing to publish than a manufactured winner. It is also the strongest form of &ldquo;our recommendations are not for sale&rdquo;: there is no top slot, so there is nothing to buy. A vendor cannot improve its position by talking to us &mdash; only by improving its offer, or by us being able to verify it.</p>
 
@@ -3790,10 +3826,11 @@ function buildVendorPage(slug: string): string | null {
     offers.filter(o => o.category === primary.category && o.vendor !== vendorName),
     primary,
   );
-  const alternatives = rankForListing(
+  const alternativesRanking = rankForListing(
     alternativesMembership.kept,
     { queryKey: `alternatives:${primary.category}:${vendorName}`, changes: dealChanges },
-  ).entries.slice(0, 12).map(e => e.offer);
+  );
+  const alternatives = alternativesRanking.entries.slice(0, 12).map(e => e.offer);
 
   // Comparison pages featuring this vendor
   const vendorComparisons = Array.from(comparisonMap.entries())
@@ -3986,6 +4023,7 @@ ${alternatives.map(a => `      <a href="/vendor/${toSlug(a.vendor)}" class="alt-
         <span class="alt-tier">${escHtmlServer(a.tier)}</span>
       </a>`).join("\n")}
     </div>${membershipExclusionsHtml}
+${renderAuditBlock(alternativesRanking.tie_break, { shown: alternatives.length, total: alternativesRanking.entries.length })}
   </div>` : "";
 
   // Comparisons HTML — include both /compare/ pages and root-level VS pages
@@ -4260,6 +4298,7 @@ h1 .risk-badge{font-size:.75rem;font-weight:600;padding:.2rem .6rem;border-radiu
 .change-detail{font-size:.8rem;color:var(--text-dim);margin-top:.25rem}
 .state-label{font-family:var(--mono);font-size:.7rem;color:var(--text-dim)}
 .no-changes{color:var(--text-dim);font-size:.9rem;font-style:italic}
+${auditBlockCss()}
 .alt-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(180px,1fr));gap:.5rem}
 .alt-card{display:block;padding:.5rem .75rem;border:1px solid var(--border);border-radius:8px;background:var(--bg-card);transition:all .2s;text-decoration:none}
 .alt-card:hover{border-color:var(--accent);background:var(--accent-glow);text-decoration:none}
@@ -4517,6 +4556,7 @@ ${curatedAlts.map(a => altCard(a, true)).join("\n")}
     <div class="alt-list">
 ${enrichedAlts.map(a => altCard(a, false)).join("\n")}
     </div>
+${renderAuditBlock(altRanking.tie_break)}
   </div>` : `<div class="section"><p class="no-changes">No alternatives found for ${escHtmlServer(vendorName)}.</p></div>`;
 
   // Category trends link
@@ -4631,6 +4671,7 @@ h3{font-family:var(--serif);font-size:1rem;color:var(--text);margin-bottom:.5rem
 .more-link{font-size:.85rem;margin-top:.5rem}
 .section{margin-bottom:2rem;padding-top:1.5rem;border-top:1px solid var(--border)}
 .section-note{color:var(--text-dim);font-size:.85rem;margin-bottom:1rem}
+${auditBlockCss()}
 .alt-list{display:flex;flex-direction:column;gap:.5rem}
 .alt-row{padding:.75rem 1rem;border:1px solid var(--border);border-radius:8px;background:var(--bg-card);transition:border-color .2s}
 .alt-row:hover{border-color:var(--accent)}
@@ -54730,7 +54771,7 @@ AgentDeals helps developers find free tiers, startup credits, and deals on devel
 
 ## How ranking works — read this before trusting an order
 
-Recommendations are not for sale. Every ranked surface resolves through one module in which offers start at zero and can only be demoted, on a specific recorded fact with a date. There is no signal a vendor can acquire, lobby for or buy. Because almost nothing separates one healthy free tier from another, large ties are the normal case — 0 of 57 categories has a unique number one — and tied offers are ordered by a permutation seeded on the UTC date and the query key alone. Every ranked response publishes that seed so you can recompute the order yourself. We do NOT model technical fit between a product and a role; apply that yourself. Full method: ${BASE_URL}${CRITERIA_PATH}
+Recommendations are not for sale. Every ranked surface resolves through one module in which offers start at zero and can only be demoted, on a specific recorded fact with a date. There is no signal a vendor can acquire, lobby for or buy. Because almost nothing separates one healthy free tier from another, large ties are the normal case — ${uniqueTopClause(summariseBestOfTies())} — and tied offers are ordered by a permutation seeded on the UTC date and the query key alone. Every ranked response publishes that seed so you can recompute the order yourself. We do NOT model technical fit between a product and a role; apply that yourself. Full method: ${BASE_URL}${CRITERIA_PATH}
 
 ${signalLlmsSection(BASE_URL)}
 ## MCP Tools (4)

--- a/test/best-of-ranking.test.ts
+++ b/test/best-of-ranking.test.ts
@@ -162,9 +162,11 @@ describe("/criteria publishes the method", () => {
     assert.match(html, /No vendor name, slug, id, index or offer field is an input/);
   });
 
-  it("publishes the finding rather than hiding it", async () => {
+  it("publishes the finding rather than hiding it, and says what it counted", async () => {
     const { html } = await get("/criteria");
-    assert.match(html, /Zero of \d+ categories have a unique number one/);
+    assert.match(html, /Zero of the \d+ categories with a best-of page have a unique number one/);
+    assert.match(html, /The site publishes \d+ categories in all/);
+    assert.ok(!/of 57 categories have/.test(html), "57 counts best-of pages, and the site publishes more categories than that");
   });
 
   it("says what we do not model", async () => {

--- a/test/ranked-surfaces.test.ts
+++ b/test/ranked-surfaces.test.ts
@@ -225,3 +225,114 @@ describe("the criteria are discoverable by an agent that never renders HTML", ()
     assert.match(text, /the <code>\/api\/stack<\/code> endpoint and the <code>plan_stack<\/code> MCP tool/);
   });
 });
+
+// #1166: /criteria offers a recompute. A surface that ranks and then drops its
+// tie_break turns that offer into an assertion, which is what this enumeration
+// exists to prevent. Adding a ranked surface means adding a row here.
+const RANKED_SURFACES: Array<{
+  queryKeyPrefix: string;
+  publishedAt: string;
+  seedIn: "html" | "json";
+  jsonSeed?: (body: any) => unknown;
+}> = [
+  { queryKeyPrefix: "best-of", publishedAt: "/best/free-databases", seedIn: "html" },
+  { queryKeyPrefix: "alternatives", publishedAt: "/vendor/doppler", seedIn: "html" },
+  { queryKeyPrefix: "alternative-to", publishedAt: "/alternative-to/doppler", seedIn: "html" },
+  { queryKeyPrefix: "related", publishedAt: "/api/details/doppler", seedIn: "json", jsonSeed: (b) => b.offer?.tie_break?.seed },
+  { queryKeyPrefix: "vendor-risk-alternatives", publishedAt: "/api/vendor-risk/doppler", seedIn: "json", jsonSeed: (b) => b.tie_break?.seed },
+  { queryKeyPrefix: "stack", publishedAt: "/api/stack?use_case=Next.js+SaaS+app", seedIn: "json", jsonSeed: (b) => b.stack?.[0]?.tie_break?.seed },
+];
+
+function rankingCallQueryKeyPrefixes(): string[] {
+  const prefixes: string[] = [];
+  for (const file of ["serve.ts", "data.ts", "stacks.ts"]) {
+    const src = readFileSync(path.join(REPO, "src", file), "utf8");
+    for (const m of src.matchAll(/\brank(?:Offers|ForListing)\(/g)) {
+      const window = src.slice(m.index!, m.index! + 600);
+      const key = window.match(/queryKey:\s*`([a-z-]+)/);
+      assert.ok(key, `a ranking call in src/${file} passes no literal query key prefix`);
+      prefixes.push(key![1]);
+    }
+  }
+  return prefixes;
+}
+
+describe("every ranked surface publishes the seed that ordered it", () => {
+  it("no ranking call site is missing from the enumeration above", () => {
+    const found = [...new Set(rankingCallQueryKeyPrefixes())].sort();
+    const registered = [...new Set(RANKED_SURFACES.map((s) => s.queryKeyPrefix))].sort();
+    assert.deepStrictEqual(
+      found,
+      registered,
+      "a surface resolves through the ranking module without a row saying where it publishes its seed",
+    );
+  });
+
+  for (const surface of RANKED_SURFACES) {
+    it(`${surface.publishedAt} publishes the date, query_key, seed and tie_count for ${surface.queryKeyPrefix}`, async () => {
+      const { status, text } = await get(surface.publishedAt);
+      assert.strictEqual(status, 200);
+      if (surface.seedIn === "json") {
+        assert.match(String(surface.jsonSeed!(JSON.parse(text))), /^[0-9a-f]{64}$/);
+        return;
+      }
+      const block = text.match(/<div class="audit-block">[\s\S]*?<\/div>/);
+      assert.ok(block, "the page ranks a list and renders no audit block");
+      assert.match(block[0], /<dt>date<\/dt><dd>\d{4}-\d{2}-\d{2}<\/dd>/);
+      assert.match(block[0], new RegExp(`<dt>query_key</dt><dd>${surface.queryKeyPrefix}:`));
+      assert.match(block[0], /<dt>seed<\/dt><dd>[0-9a-f]{64}<\/dd>/);
+      assert.match(block[0], /<dt>tie_count<\/dt><dd>\d+<\/dd>/);
+    });
+  }
+
+  it("the seed a page prints is the one the published algorithm derives", async () => {
+    const { createHash } = await import("node:crypto");
+    for (const p of ["/best/free-databases", "/vendor/supabase", "/alternative-to/vercel"]) {
+      const { text } = await get(p);
+      const block = text.match(/<div class="audit-block">[\s\S]*?<\/div>/)![0];
+      const date = block.match(/<dt>date<\/dt><dd>([^<]+)</)![1];
+      const queryKey = block.match(/<dt>query_key<\/dt><dd>([^<]+)</)![1].replace(/&amp;/g, "&");
+      const seed = block.match(/<dt>seed<\/dt><dd>([^<]+)</)![1];
+      assert.strictEqual(createHash("sha256").update(`${date}|${queryKey}|p0`).digest("hex"), seed, `${p} prints a seed its own inputs do not produce`);
+    }
+  });
+
+  it("every best-of card previews a ranked order the page it links to publishes a seed for", async () => {
+    const { text } = await get("/best");
+    const slugs = [...new Set([...text.matchAll(/href="\/best\/([a-z0-9-]+)"/g)].map((m) => m[1]))];
+    assert.ok(slugs.length > 40, `expected the full best-of index, got ${slugs.length}`);
+    for (const slug of slugs.slice(0, 5)) {
+      const { text: page } = await get(`/best/${slug}`);
+      assert.match(page, /<div class="audit-block">/, `/best/${slug} carries no seed for the order previewed on /best`);
+    }
+  });
+
+  it("the tie figures on /criteria are the ones the best-of pages themselves publish", async () => {
+    const { text: index } = await get("/best");
+    const slugs = [...new Set([...index.matchAll(/href="\/best\/([a-z0-9-]+)"/g)].map((m) => m[1]))];
+    const tieCounts: number[] = [];
+    for (const slug of slugs) {
+      const { text } = await get(`/best/${slug}`);
+      const block = text.match(/<div class="audit-block">[\s\S]*?<\/div>/)![0];
+      tieCounts.push(Number(block.match(/<dt>tie_count<\/dt><dd>(\d+)<\/dd>/)![1]));
+    }
+    const uniqueTop = tieCounts.filter((n) => n === 1).length;
+    const meanTie = (tieCounts.reduce((a, b) => a + b, 0) / tieCounts.length).toFixed(1);
+
+    const { text: criteria } = await get("/criteria");
+    const claim = criteria.match(/<div class="callout">([\s\S]*?)<\/div>/)![1];
+    assert.match(claim, new RegExp(`of the ${slugs.length} categories with a best-of page`), "the denominator must be the number of best-of pages");
+    assert.match(claim, new RegExp(`${uniqueTop === 0 ? "Zero" : String(uniqueTop)} of the`), `the page must publish the ${uniqueTop} its own best-of pages add up to`);
+    assert.ok(claim.includes(`${meanTie} offers tie at the top`), `the mean must be ${meanTie}, the mean of the published tie counts`);
+
+    const { text: llms } = await get("/llms.txt");
+    assert.match(llms, new RegExp(`${uniqueTop} of the ${slugs.length} categories with a best-of page`), "llms.txt must carry the same figure and the same scope");
+  });
+
+  it("the vendor page says how much of the ranked order it is showing", async () => {
+    const { text: truncated } = await get("/vendor/supabase");
+    assert.match(truncated, /The list above is the first \d+ of \d+ entries in that order\./);
+    const { text: whole } = await get("/vendor/doppler");
+    assert.ok(!/The list above is the first/.test(whole), "a list that shows every entry must not claim to be a prefix");
+  });
+});


### PR DESCRIPTION
Refs #1166

`/criteria` §3 says *"You can recompute today's order yourself and check it against what we served, without asking us."* The two page types that carry **11,206 of 11,439** ranked hits computed the block that makes that possible and dropped it at the template.

## What changed

**`/vendor/:slug` and `/alternative-to/:slug` render the audit block.** Both already resolve their alternatives through `rankForListing`; both discarded the returned `tie_break`. The values come from that same call — no second computation. `/best`'s inline markup moved into a shared `renderAuditBlock()`, so the four fields cannot drift apart across surfaces.

The vendor grid is capped at 12, so its block says which prefix it is showing: *"The list above is the first 12 of 41 entries in that order."* 1,368 of 1,572 vendor pages are capped, so a block that stayed silent about it would describe an order the page does not show.

**Two JSON surfaces ranked and dropped it too**, and I fixed them rather than write a weaker test than AC-7 asks for — see "Scope" below.

**`/criteria` and `llms.txt` name what they count.** 57 is the number of best-of pages; the site publishes 66 categories on `/api/categories`, `/developers` and the homepage. I took AC-4's second option and named the scope, and added the full count with the reason nine categories have no best-of page.

Two things were wrong underneath the wording. The word **"Zero" was hardcoded prose over a computed denominator** — `pagesWithUniqueTop` was calculated and never read, so the sentence would have kept saying "Zero" after it stopped being true. And `llms.txt` carried `0 of 57` as a **literal**. Both now derive from one `uniqueTopClause()`.

## AC-3: a reader completes the exercise, on a capped page

`scripts/e2e-1166.mjs` reimplements sha256 → mulberry32 → Fisher-Yates from the published algorithm string rather than importing `src/ranking.ts`, because importing our own shuffle would prove nothing.

The interesting part is that **the permutation is fixed by `(seed, n)` alone — it never touches the elements.** So a reader who cannot know band membership can still run the permutation over the identity, recover the input index of each entry they *can* see, and check those land back in `/api/offers` order. That check works on a capped list, which matters: restricting the demonstration to the 204 uncapped vendor pages would have covered 13% of them.

It is falsifiable, and the script proves that rather than asserting it — the same check is re-run against the served list with its last entry moved to the top, and must reject it.

```
/vendor/supabase (37 tied, 12 shown) — inverting the seed's permutation lands the shown entries back in index order   ok
/vendor/supabase (37 tied, 12 shown) — the same check rejects the served list with its last entry moved to the top    ok
/vendor/doppler  (2 tied, 3 shown)  — full forward recompute reproduces the served order                             ok
```

**49/49 on this branch, 7/27 against a build of `main`.**

## AC-7

`test/ranked-surfaces.test.ts` scans `serve.ts`, `data.ts` and `stacks.ts` for every `rankOffers`/`rankForListing` call, keys each by its literal query-key prefix, and asserts the set equals a registry naming where each publishes its seed. Verified by injecting a new ranked surface: the guard fails and names it.

```
+   'editors-choice',
  actual:   [ 'alternative-to', 'alternatives', 'best-of', 'editors-choice', 'related', 'stack', 'vendor-risk-alternatives' ]
  expected: [ 'alternative-to', 'alternatives', 'best-of', 'related', 'stack', 'vendor-risk-alternatives' ]
```

## Scope: two surfaces beyond AC-1 and AC-2

`/api/details/:vendor` (`search_deals`) and `/api/vendor-risk/:vendor` (`compare_vendors`) both rank through the module and returned no `tie_break`. AC-7 asks for a test that fails when a ranked surface drops it; written honestly, that test fails on these two today, so the choice was to fix them or to write a weaker test than the AC describes. The standing note — a published claim is in scope wherever it renders — points the same way, and §3 names the JSON APIs explicitly. Both are named on the issue.

I did **not** put a block on the `/best` index, whose 57 cards each preview `qualified.slice(0, 3)`. A test pins the alternative instead: every card links to a page that publishes the seed for the order it previews.

## Verification

- **2,731 / 2,731** (+11), `tsc --noEmit`, `validate-data` (1,580 offers / 444 changes) and `no-private-context` clean.
- `scripts/mutate-1166.sh` — **17 mutations, 17 killed, no survivors, none by the compiler.**
- `check-mutation-targets` 503/503 across 39 scripts.
- **Sweep of all 3,916 published paths against a `main` worktree.** 3,202 move and they are exactly the intended set: 1,572 `/vendor/*`, 1,572 `/alternative-to/*`, 57 `/best/*` and `/criteria`. No status changes; sponsored anchors unchanged at 76 across 71 pages. The 57 best-of pages move by **exactly 26 bytes each** — the audit-block media query relocating into the shared CSS helper, no content change — and the `/best` index is byte-identical.
- Real MCP `initialize` → `tools/call`: `search_deals` and `compare_vendors` both return the `tie_break` with its algorithm string.
- Screenshots of the vendor alternatives section and the `/criteria` callout, before and after.
