### PR TITLE
Add curated alternatives to the pool instead of intersecting them with the category

### DIFF
--- a/data/curated_alternatives_unmatched.json
+++ b/data/curated_alternatives_unmatched.json
@@ -1,0 +1,817 @@
+{
+  "unmatched": [
+    {
+      "name": "Amazon ECS Express Mode",
+      "named_by": [
+        "AWS"
+      ]
+    },
+    {
+      "name": "Amazon EKS native service mesh",
+      "named_by": [
+        "AWS"
+      ]
+    },
+    {
+      "name": "Amazon Neptune",
+      "named_by": [
+        "Neo4j AuraDB"
+      ]
+    },
+    {
+      "name": "Amazon WorkSpaces",
+      "named_by": [
+        "Microsoft"
+      ]
+    },
+    {
+      "name": "Anthropic Claude",
+      "named_by": [
+        "OpenAI"
+      ]
+    },
+    {
+      "name": "Anthropic Claude API",
+      "named_by": [
+        "DeepSeek",
+        "Google Gemini API",
+        "OpenAI"
+      ]
+    },
+    {
+      "name": "Apache Ozone",
+      "named_by": [
+        "MinIO"
+      ]
+    },
+    {
+      "name": "Apollo.io",
+      "named_by": [
+        "Prospect.io"
+      ]
+    },
+    {
+      "name": "AWS CDK",
+      "named_by": [
+        "AWS"
+      ]
+    },
+    {
+      "name": "AWS Fargate",
+      "named_by": [
+        "AWS"
+      ]
+    },
+    {
+      "name": "AWS Free Tier",
+      "named_by": [
+        "LocalStack"
+      ]
+    },
+    {
+      "name": "AWS Lambda",
+      "named_by": [
+        "Atlassian Forge"
+      ]
+    },
+    {
+      "name": "AWS Partner Network",
+      "named_by": [
+        "Microsoft Partner Developer Benefits"
+      ]
+    },
+    {
+      "name": "AWS S3",
+      "named_by": [
+        "Firebase",
+        "Uploadthing"
+      ]
+    },
+    {
+      "name": "Azure Container Apps",
+      "named_by": [
+        "AWS"
+      ]
+    },
+    {
+      "name": "Azure for Startups",
+      "named_by": [
+        "Cloudflare Startup Program",
+        "DigitalOcean",
+        "Google Cloud"
+      ]
+    },
+    {
+      "name": "Azure GPU VMs",
+      "named_by": [
+        "AWS"
+      ]
+    },
+    {
+      "name": "Azure OpenAI Realtime",
+      "named_by": [
+        "OpenAI"
+      ]
+    },
+    {
+      "name": "Azure Virtual Desktop",
+      "named_by": [
+        "Microsoft"
+      ]
+    },
+    {
+      "name": "BigCommerce API",
+      "named_by": [
+        "Amazon SP-API",
+        "Google Content API for Shopping"
+      ]
+    },
+    {
+      "name": "Bing Web Search API",
+      "named_by": [
+        "Google Programmable Search Engine"
+      ]
+    },
+    {
+      "name": "Bitly",
+      "named_by": [
+        "Dub.co"
+      ]
+    },
+    {
+      "name": "Bluesky API",
+      "named_by": [
+        "X (Twitter)",
+        "X API (Twitter)"
+      ]
+    },
+    {
+      "name": "Bluesky AT Protocol",
+      "named_by": [
+        "X (Twitter)"
+      ]
+    },
+    {
+      "name": "Ceph",
+      "named_by": [
+        "MinIO"
+      ]
+    },
+    {
+      "name": "Citrix DaaS",
+      "named_by": [
+        "Microsoft"
+      ]
+    },
+    {
+      "name": "Codacy",
+      "named_by": [
+        "SonarQube Cloud"
+      ]
+    },
+    {
+      "name": "CodeClimate",
+      "named_by": [
+        "SonarQube Cloud"
+      ]
+    },
+    {
+      "name": "Codeium",
+      "named_by": [
+        "Alibaba Cloud Qwen Code"
+      ]
+    },
+    {
+      "name": "CodeSandbox",
+      "named_by": [
+        "Replit"
+      ]
+    },
+    {
+      "name": "Cody",
+      "named_by": [
+        "GitHub Copilot"
+      ]
+    },
+    {
+      "name": "Cohere API",
+      "named_by": [
+        "OpenAI"
+      ]
+    },
+    {
+      "name": "Crossplane",
+      "named_by": [
+        "HashiCorp"
+      ]
+    },
+    {
+      "name": "Cyberduck",
+      "named_by": [
+        "odrive"
+      ]
+    },
+    {
+      "name": "DALL-E (credits)",
+      "named_by": [
+        "xAI (Grok)"
+      ]
+    },
+    {
+      "name": "Dgraph Cloud",
+      "named_by": [
+        "Neo4j AuraDB"
+      ]
+    },
+    {
+      "name": "DigitalOcean App Platform",
+      "named_by": [
+        "AWS"
+      ]
+    },
+    {
+      "name": "DigitalOcean Hatch",
+      "named_by": [
+        "Google Cloud"
+      ]
+    },
+    {
+      "name": "Docker Desktop",
+      "named_by": [
+        "Testcontainers Cloud"
+      ]
+    },
+    {
+      "name": "DragonflyDB",
+      "named_by": [
+        "Redis"
+      ]
+    },
+    {
+      "name": "DynamoDB",
+      "named_by": [
+        "Fauna"
+      ]
+    },
+    {
+      "name": "Elastic Cloud",
+      "named_by": [
+        "searchly.com"
+      ]
+    },
+    {
+      "name": "ElevenLabs",
+      "named_by": [
+        "OpenAI"
+      ]
+    },
+    {
+      "name": "env0",
+      "named_by": [
+        "HCP Terraform",
+        "Terragrunt Scale"
+      ]
+    },
+    {
+      "name": "Fargate Platform Version 1.4.0+",
+      "named_by": [
+        "AWS"
+      ]
+    },
+    {
+      "name": "Firebase Auth",
+      "named_by": [
+        "Auth0"
+      ]
+    },
+    {
+      "name": "FreshBooks API",
+      "named_by": [
+        "Xero Developer API"
+      ]
+    },
+    {
+      "name": "GarageHQ",
+      "named_by": [
+        "MinIO"
+      ]
+    },
+    {
+      "name": "Gemini 2.5 Flash",
+      "named_by": [
+        "Google Gemini API"
+      ]
+    },
+    {
+      "name": "Gemini 3.0 Flash",
+      "named_by": [
+        "Google Gemini API"
+      ]
+    },
+    {
+      "name": "Gemini Code Assist",
+      "named_by": [
+        "GitHub Copilot"
+      ]
+    },
+    {
+      "name": "Giphy API",
+      "named_by": [
+        "Google Tenor API"
+      ]
+    },
+    {
+      "name": "Git LFS",
+      "named_by": [
+        "Unity DevOps"
+      ]
+    },
+    {
+      "name": "GitHub Copilot Free",
+      "named_by": [
+        "Gemini Code Assist"
+      ]
+    },
+    {
+      "name": "Gitpod",
+      "named_by": [
+        "Replit"
+      ]
+    },
+    {
+      "name": "Google Cloud for Startups",
+      "named_by": [
+        "DigitalOcean"
+      ]
+    },
+    {
+      "name": "Google Cloud GPUs",
+      "named_by": [
+        "AWS"
+      ]
+    },
+    {
+      "name": "Google Cloud Partner Advantage",
+      "named_by": [
+        "Microsoft Partner Developer Benefits"
+      ]
+    },
+    {
+      "name": "Google Cloud Speech-to-Text",
+      "named_by": [
+        "OpenAI"
+      ]
+    },
+    {
+      "name": "Google Custom Search",
+      "named_by": [
+        "Brave Search API"
+      ]
+    },
+    {
+      "name": "Google for Startups Cloud",
+      "named_by": [
+        "Google"
+      ]
+    },
+    {
+      "name": "Google for Startups Cloud Program",
+      "named_by": [
+        "Cloudflare Startup Program"
+      ]
+    },
+    {
+      "name": "Google Gemini",
+      "named_by": [
+        "Anthropic",
+        "OpenAI"
+      ]
+    },
+    {
+      "name": "Google Gemini 2.5 Flash",
+      "named_by": [
+        "Google Gemini 2.0 Flash"
+      ]
+    },
+    {
+      "name": "Google Gemini 2.5 Pro",
+      "named_by": [
+        "Google Gemini 2.0 Flash"
+      ]
+    },
+    {
+      "name": "Google Gemini Advanced",
+      "named_by": [
+        "Anthropic Claude"
+      ]
+    },
+    {
+      "name": "Google Maps API key authentication",
+      "named_by": [
+        "Google Maps"
+      ]
+    },
+    {
+      "name": "Google Merchant API",
+      "named_by": [
+        "Google Content API for Shopping"
+      ]
+    },
+    {
+      "name": "Google Workspace Enterprise Plus",
+      "named_by": [
+        "Microsoft"
+      ]
+    },
+    {
+      "name": "gpt-image-1",
+      "named_by": [
+        "OpenAI"
+      ]
+    },
+    {
+      "name": "Imgur API",
+      "named_by": [
+        "Google Tenor API"
+      ]
+    },
+    {
+      "name": "Istio",
+      "named_by": [
+        "AWS"
+      ]
+    },
+    {
+      "name": "JetBrains AI",
+      "named_by": [
+        "Google"
+      ]
+    },
+    {
+      "name": "Jira Cloud",
+      "named_by": [
+        "Atlassian"
+      ]
+    },
+    {
+      "name": "KeyDB",
+      "named_by": [
+        "Redis"
+      ]
+    },
+    {
+      "name": "Lambda Cloud",
+      "named_by": [
+        "AWS"
+      ]
+    },
+    {
+      "name": "Last.fm API",
+      "named_by": [
+        "Spotify API"
+      ]
+    },
+    {
+      "name": "Lemlist",
+      "named_by": [
+        "Prospect.io"
+      ]
+    },
+    {
+      "name": "Linkerd",
+      "named_by": [
+        "AWS"
+      ]
+    },
+    {
+      "name": "Linode",
+      "named_by": [
+        "DigitalOcean",
+        "OVHcloud"
+      ]
+    },
+    {
+      "name": "Mac client",
+      "named_by": [
+        "AWS"
+      ]
+    },
+    {
+      "name": "MailerSend",
+      "named_by": [
+        "Amazon SES"
+      ]
+    },
+    {
+      "name": "Mailgun",
+      "named_by": [
+        "SendGrid",
+        "SendGrid Accelerate"
+      ]
+    },
+    {
+      "name": "Mastodon API",
+      "named_by": [
+        "X (Twitter)",
+        "X API (Twitter)"
+      ]
+    },
+    {
+      "name": "Mistral",
+      "named_by": [
+        "Anthropic"
+      ]
+    },
+    {
+      "name": "Mistral API",
+      "named_by": [
+        "OpenAI"
+      ]
+    },
+    {
+      "name": "Moto (open-source AWS mock)",
+      "named_by": [
+        "LocalStack"
+      ]
+    },
+    {
+      "name": "MultCloud",
+      "named_by": [
+        "odrive"
+      ]
+    },
+    {
+      "name": "MusicBrainz API",
+      "named_by": [
+        "Spotify API"
+      ]
+    },
+    {
+      "name": "Node.js 22 Lambda runtime",
+      "named_by": [
+        "AWS"
+      ]
+    },
+    {
+      "name": "OpenAI API",
+      "named_by": [
+        "DeepSeek",
+        "Google Gemini API"
+      ]
+    },
+    {
+      "name": "OpenAI ChatGPT Plus",
+      "named_by": [
+        "Anthropic Claude"
+      ]
+    },
+    {
+      "name": "OpenAI GPT-4o",
+      "named_by": [
+        "Anthropic"
+      ]
+    },
+    {
+      "name": "OpenAI Realtime API (GA)",
+      "named_by": [
+        "OpenAI"
+      ]
+    },
+    {
+      "name": "OpenTofu",
+      "named_by": [
+        "HashiCorp"
+      ]
+    },
+    {
+      "name": "OrbStack",
+      "named_by": [
+        "Docker Desktop"
+      ]
+    },
+    {
+      "name": "Perforce",
+      "named_by": [
+        "Unity DevOps"
+      ]
+    },
+    {
+      "name": "Perplexity",
+      "named_by": [
+        "OpenAI"
+      ]
+    },
+    {
+      "name": "PlanetScale",
+      "named_by": [
+        "Amazon Aurora PostgreSQL",
+        "DigitalOcean",
+        "Supabase",
+        "Xata Lite"
+      ]
+    },
+    {
+      "name": "Podman",
+      "named_by": [
+        "Docker Hub",
+        "Testcontainers Cloud"
+      ]
+    },
+    {
+      "name": "Podman Desktop",
+      "named_by": [
+        "Docker Desktop"
+      ]
+    },
+    {
+      "name": "QuickBooks API",
+      "named_by": [
+        "Xero Developer API"
+      ]
+    },
+    {
+      "name": "Rancher Desktop",
+      "named_by": [
+        "Docker Desktop"
+      ]
+    },
+    {
+      "name": "rclone",
+      "named_by": [
+        "odrive"
+      ]
+    },
+    {
+      "name": "Reddit API",
+      "named_by": [
+        "X (Twitter)"
+      ]
+    },
+    {
+      "name": "SeaweedFS",
+      "named_by": [
+        "MinIO"
+      ]
+    },
+    {
+      "name": "Selenium IDE",
+      "named_by": [
+        "everystep-automation.com"
+      ]
+    },
+    {
+      "name": "Self-hosted Connect apps",
+      "named_by": [
+        "Atlassian Forge"
+      ]
+    },
+    {
+      "name": "SerpAPI",
+      "named_by": [
+        "Brave Search API",
+        "Google Programmable Search Engine"
+      ]
+    },
+    {
+      "name": "Shopify API",
+      "named_by": [
+        "Amazon SP-API",
+        "Google Content API for Shopping"
+      ]
+    },
+    {
+      "name": "Short.io",
+      "named_by": [
+        "Dub.co"
+      ]
+    },
+    {
+      "name": "Stability AI",
+      "named_by": [
+        "OpenAI"
+      ]
+    },
+    {
+      "name": "Stable Diffusion (self-hosted)",
+      "named_by": [
+        "xAI (Grok)"
+      ]
+    },
+    {
+      "name": "Standard WorkSpaces clients",
+      "named_by": [
+        "AWS"
+      ]
+    },
+    {
+      "name": "Supabase Auth",
+      "named_by": [
+        "Auth0"
+      ]
+    },
+    {
+      "name": "Supabase Storage",
+      "named_by": [
+        "Firebase"
+      ]
+    },
+    {
+      "name": "Temporal",
+      "named_by": [
+        "DBOS"
+      ]
+    },
+    {
+      "name": "Terraform",
+      "named_by": [
+        "AWS"
+      ]
+    },
+    {
+      "name": "Testcontainers (open-source)",
+      "named_by": [
+        "Testcontainers Cloud"
+      ]
+    },
+    {
+      "name": "Upstash Redis",
+      "named_by": [
+        "Cloudflare Durable Objects"
+      ]
+    },
+    {
+      "name": "UptimeObserver",
+      "named_by": [
+        "Servervana"
+      ]
+    },
+    {
+      "name": "Valkey",
+      "named_by": [
+        "Redis"
+      ]
+    },
+    {
+      "name": "Vercel Blob",
+      "named_by": [
+        "Uploadthing"
+      ]
+    },
+    {
+      "name": "Vultr",
+      "named_by": [
+        "DigitalOcean",
+        "Hetzner",
+        "OVHcloud"
+      ]
+    },
+    {
+      "name": "Wave API",
+      "named_by": [
+        "Xero Developer API"
+      ]
+    },
+    {
+      "name": "Web client",
+      "named_by": [
+        "AWS"
+      ]
+    },
+    {
+      "name": "Windmill",
+      "named_by": [
+        "n8n"
+      ]
+    },
+    {
+      "name": "Windows client",
+      "named_by": [
+        "AWS"
+      ]
+    },
+    {
+      "name": "WooCommerce API",
+      "named_by": [
+        "Amazon SP-API"
+      ]
+    },
+    {
+      "name": "Xitoring",
+      "named_by": [
+        "Servervana"
+      ]
+    },
+    {
+      "name": "ZITADEL",
+      "named_by": [
+        "Phase Two"
+      ]
+    },
+    {
+      "name": "Zoho Workplace",
+      "named_by": [
+        "Microsoft"
+      ]
+    }
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -47,7 +47,8 @@
     "verify-freshness": "node scripts/verify-freshness.js",
     "validate": "node scripts/validate-data.ts",
     "test:referral-pipeline": "npm run build && node scripts/test-referral-pipeline.ts",
-    "build:mcpb": "npm run build && npx @anthropic-ai/mcpb pack ."
+    "build:mcpb": "npm run build && npx @anthropic-ai/mcpb pack .",
+    "queue:curated-alternatives": "node scripts/curated-alternatives-queue.js"
   },
   "dependencies": {
     "@modelcontextprotocol/ext-apps": "^1.5.0",

--- a/scripts/curated-alternatives-queue.js
+++ b/scripts/curated-alternatives-queue.js
@@ -1,0 +1,54 @@
+import { readFileSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { unmatchedCuratedNames } from "../dist/curated-alternatives.js";
+
+const HELP = `curated-alternatives-queue.js — collect curated alternative names we do not carry.
+
+Usage:
+  node scripts/curated-alternatives-queue.js [--check]
+
+Every deal_changes record may name alternatives by hand. A name that matches no
+offer in data/index.json cannot be linked on any page, so it is written to
+data/curated_alternatives_unmatched.json as a review queue instead of being
+dropped at render time. Reads data/deal_changes.json and data/index.json; makes
+no network calls.
+
+  --check  exit 1 if the committed file does not match the current data
+  --help   show this message`;
+
+if (process.argv.includes("--help") || process.argv.includes("-h")) {
+  console.log(HELP);
+  process.exit(0);
+}
+
+const REPO = join(dirname(fileURLToPath(import.meta.url)), "..");
+const QUEUE_PATH = join(REPO, "data", "curated_alternatives_unmatched.json");
+
+const changes = JSON.parse(readFileSync(join(REPO, "data", "deal_changes.json"), "utf8")).changes;
+const offers = JSON.parse(readFileSync(join(REPO, "data", "index.json"), "utf8")).offers;
+
+const unmatched = unmatchedCuratedNames(changes, offers);
+const serialised = JSON.stringify({ unmatched }, null, 2) + "\n";
+
+if (process.argv.includes("--check")) {
+  let committed = "";
+  try {
+    committed = readFileSync(QUEUE_PATH, "utf8");
+  } catch {
+    console.error(`${QUEUE_PATH} does not exist. Run: npm run queue:curated-alternatives`);
+    process.exit(1);
+  }
+  if (committed !== serialised) {
+    console.error(`${QUEUE_PATH} is stale. Run: npm run queue:curated-alternatives`);
+    process.exit(1);
+  }
+  console.log(`${unmatched.length} unmatched curated names, file up to date`);
+  process.exit(0);
+}
+
+writeFileSync(QUEUE_PATH, serialised);
+console.log(`${unmatched.length} unmatched curated names written to data/curated_alternatives_unmatched.json`);
+for (const entry of unmatched) {
+  console.log(`  ${entry.name} — named by ${entry.named_by.join(", ")}`);
+}

--- a/scripts/mutate-1032-phase0.sh
+++ b/scripts/mutate-1032-phase0.sh
@@ -1,0 +1,314 @@
+#!/usr/bin/env bash
+set -u
+
+REPO="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$REPO" || exit 1
+
+SERVE="src/serve.ts"
+CURATED="src/curated-alternatives.ts"
+BACKUP_DIR="$(mktemp -d)"
+for f in "$SERVE" "$CURATED"; do
+  cp "$f" "$BACKUP_DIR/$(basename "$f")"
+done
+
+restore() {
+  for f in "$SERVE" "$CURATED"; do
+    cp "$BACKUP_DIR/$(basename "$f")" "$f"
+  done
+}
+trap 'restore; npm run build > /dev/null 2>&1' EXIT
+
+killed=0
+survived=0
+TESTS="test/curated-alternatives.test.ts test/ranked-surfaces.test.ts"
+
+py() { python3 - "$@"; }
+
+changed_any() {
+  for f in "$SERVE" "$CURATED"; do
+    if ! diff -q "$BACKUP_DIR/$(basename "$f")" "$f" > /dev/null; then
+      return 0
+    fi
+  done
+  return 1
+}
+
+run_mutation() {
+  local name="$1"
+  shift
+  local scope="$TESTS"
+  if [ "$1" = "--only" ]; then
+    scope="$2"
+    shift 2
+  fi
+  echo "=== $name"
+  restore
+  "$@"
+  if ! changed_any; then
+    echo "    NOT APPLIED: the mutation changed no file, so it proves nothing"
+    survived=$((survived + 1))
+    return
+  fi
+  if ! npm run build > /tmp/mutate-1032-build.log 2>&1; then
+    echo "    DID NOT COMPILE: a mutation the compiler rejects proves nothing about the tests"
+    survived=$((survived + 1))
+    return
+  fi
+  if timeout 900 node --test --test-concurrency 1 $scope > /tmp/mutate-1032-test.log 2>&1; then
+    echo "    SURVIVED"
+    survived=$((survived + 1))
+  else
+    echo "    KILLED: $(grep -c '✖ ' /tmp/mutate-1032-test.log) failing assertion(s)"
+    grep '✖ ' /tmp/mutate-1032-test.log | head -3
+    killed=$((killed + 1))
+  fi
+}
+
+m_pool_is_intersected_again() {
+  py <<'PY'
+p = "src/serve.ts"
+s = open(p).read()
+s = s.replace(
+  "partitionAlternativesAcross(addCuratedToPool(dedupedAlts, curated.matched), vendorOffers)",
+  "partitionAlternativesAcross(dedupedAlts, vendorOffers)")
+open(p, "w").write(s)
+PY
+}
+
+m_curated_block_gone_from_the_vendor_page() {
+  py <<'PY'
+p = "src/serve.ts"
+s = open(p).read()
+s = s.replace("${curatedAlternativesHtml}${alternativesHtml}", "${alternativesHtml}")
+open(p, "w").write(s)
+PY
+}
+
+m_curated_block_gone_from_the_alternatives_page() {
+  py <<'PY'
+p = "src/serve.ts"
+s = open(p).read()
+s = s.replace("${curatedHtml}\n", "")
+open(p, "w").write(s)
+PY
+}
+
+m_curated_matching_is_case_insensitive() {
+  py <<'PY'
+p = "src/curated-alternatives.ts"
+s = open(p).read()
+s = s.replace(
+  "    if (!byVendor.has(offer.vendor)) byVendor.set(offer.vendor, offer);",
+  "    if (!byVendor.has(offer.vendor.toLowerCase())) byVendor.set(offer.vendor.toLowerCase(), offer);")
+s = s.replace("const offer = byVendor.get(name);", "const offer = byVendor.get(name.toLowerCase());")
+open(p, "w").write(s)
+PY
+}
+
+m_curated_matching_falls_back_to_a_prefix() {
+  py <<'PY'
+p = "src/curated-alternatives.ts"
+s = open(p).read()
+s = s.replace(
+  "    const offer = byVendor.get(name);",
+  "    const offer = byVendor.get(name) ?? offers.find(o => o.vendor.startsWith(name));")
+open(p, "w").write(s)
+PY
+}
+
+m_curated_names_read_from_every_vendor() {
+  py <<'PY'
+p = "src/curated-alternatives.ts"
+s = open(p).read()
+s = s.replace("    if (change.vendor.toLowerCase() !== lowerVendor) continue;\n", "")
+open(p, "w").write(s)
+PY
+}
+
+m_curated_names_are_case_sensitive() {
+  py <<'PY'
+p = "src/curated-alternatives.ts"
+s = open(p).read()
+s = s.replace("if (change.vendor.toLowerCase() !== lowerVendor) continue;",
+              "if (change.vendor !== vendorName) continue;")
+open(p, "w").write(s)
+PY
+}
+
+m_curated_names_keep_duplicates() {
+  py <<'PY'
+p = "src/curated-alternatives.ts"
+s = open(p).read()
+s = s.replace("      if (name === vendorName || seen.has(name)) continue;",
+              "      if (name === vendorName) continue;")
+open(p, "w").write(s)
+PY
+}
+
+m_vendor_names_itself_as_an_alternative() {
+  py <<'PY'
+p = "src/curated-alternatives.ts"
+s = open(p).read()
+s = s.replace("      if (name === vendorName || seen.has(name)) continue;",
+              "      if (seen.has(name)) continue;")
+open(p, "w").write(s)
+PY
+}
+
+m_pool_widening_replaces_the_category_pool() {
+  py <<'PY'
+p = "src/curated-alternatives.ts"
+s = open(p).read()
+s = s.replace("  const widened = [...pool];", "  const widened: Offer[] = [];")
+open(p, "w").write(s)
+PY
+}
+
+m_pool_widening_duplicates_a_member() {
+  py <<'PY'
+p = "src/curated-alternatives.ts"
+s = open(p).read()
+s = s.replace("    if (present.has(offer.vendor)) continue;\n", "")
+open(p, "w").write(s)
+PY
+}
+
+m_queue_keeps_names_we_do_carry() {
+  py <<'PY'
+p = "src/curated-alternatives.ts"
+s = open(p).read()
+s = s.replace("      if (indexed.has(name)) continue;\n", "")
+open(p, "w").write(s)
+PY
+}
+
+m_queue_forgets_who_named_each_entry() {
+  py <<'PY'
+p = "src/curated-alternatives.ts"
+s = open(p).read()
+s = s.replace("      byName.get(name)!.add(change.vendor);", "      byName.get(name)!.add(name);")
+open(p, "w").write(s)
+PY
+}
+
+m_queue_order_is_unstable() {
+  py <<'PY'
+p = "src/curated-alternatives.ts"
+s = open(p).read()
+s = s.replace("    .sort((a, b) => a.name.localeCompare(b.name));",
+              "    .sort((a, b) => b.name.localeCompare(a.name));")
+open(p, "w").write(s)
+PY
+}
+
+m_curated_block_skips_the_membership_gate() {
+  py <<'PY'
+p = "src/curated-alternatives.ts"
+s = open(p).read()
+s = s.replace("  const partition = partitionAlternativesAcross(matched, subjects);",
+              "  const partition = { kept: matched, removed: [] };")
+open(p, "w").write(s)
+PY
+}
+
+m_curated_gate_ignores_the_subject_s_own_gates() {
+  py <<'PY'
+p = "src/curated-alternatives.ts"
+s = open(p).read()
+s = s.replace("  const partition = partitionAlternativesAcross(matched, subjects);",
+              "  const partition = partitionAlternativesAcross(matched, []);")
+open(p, "w").write(s)
+PY
+}
+
+m_curated_block_publishes_no_seed() {
+  py <<'PY'
+p = "src/serve.ts"
+s = open(p).read()
+s = s.replace("""    </div>
+${renderAuditBlock(curatedVendorRanking.tie_break, { shown: curatedVendorAlts.length, total: curatedVendorRanking.entries.length })}
+  </div>` : "";""",
+"""    </div>
+  </div>` : "";""")
+open(p, "w").write(s)
+PY
+}
+
+m_curated_order_bypasses_the_ranking_module() {
+  py <<'PY'
+p = "src/serve.ts"
+s = open(p).read()
+s = s.replace("  const curatedVendorAlts = curatedVendorRanking?.entries.map(e => e.offer) ?? [];",
+              "  const curatedVendorAlts = curatedVendorRanking ? partitionAlternativesAcross(resolveCuratedAlternatives(vendorName, allChanges, offers).matched, vendorOffers).kept : [];")
+open(p, "w").write(s)
+PY
+}
+
+m_category_grid_takes_the_curated_members() {
+  py <<'PY'
+p = "src/serve.ts"
+s = open(p).read()
+s = s.replace("""  const alternativesMembership = partitionAlternatives(
+    offers.filter(o => o.category === primary.category && o.vendor !== vendorName),
+    primary,
+  );""",
+"""  const alternativesMembership = partitionAlternatives(
+    addCuratedToPool(
+      offers.filter(o => o.category === primary.category && o.vendor !== vendorName),
+      resolveCuratedAlternatives(vendorName, allChanges, offers).matched,
+    ),
+    primary,
+  );""")
+open(p, "w").write(s)
+PY
+}
+
+m_count_sentence_ignores_the_added_categories() {
+  py <<'PY'
+p = "src/serve.ts"
+s = open(p).read()
+s = s.replace(
+  "across the ${listedCategories.join(\", \")} categor${listedCategories.length > 1 ? \"ies\" : \"y\"}.",
+  "across the ${vendorCategories.join(\", \")} categor${vendorCategories.length > 1 ? \"ies\" : \"y\"}.")
+open(p, "w").write(s)
+PY
+}
+
+m_the_two_pages_word_the_block_differently() {
+  py <<'PY'
+p = "src/serve.ts"
+s = open(p).read()
+s = s.replace("""    <p class="section-note" style="margin:0 0 1rem;font-size:.85rem;color:var(--text-muted)">${curatedAltsNote(vendorName)}</p>""",
+"""    <p class="section-note" style="margin:0 0 1rem;font-size:.85rem;color:var(--text-muted)">Alternatives named in this vendor&rsquo;s change records.</p>""")
+open(p, "w").write(s)
+PY
+}
+
+run_mutation "the alternatives pool is intersected with the category again" m_pool_is_intersected_again
+run_mutation "the vendor page drops the curated block" m_curated_block_gone_from_the_vendor_page
+run_mutation "the alternatives page drops the curated block" m_curated_block_gone_from_the_alternatives_page
+run_mutation "a curated name matches a vendor whose case differs" m_curated_matching_is_case_insensitive
+run_mutation "a curated name falls back to a prefix match" m_curated_matching_falls_back_to_a_prefix
+run_mutation "curated names are read from every vendor's records" m_curated_names_read_from_every_vendor
+run_mutation "a change record's vendor must match case to be read" m_curated_names_are_case_sensitive
+run_mutation "a name repeated across records is listed twice" m_curated_names_keep_duplicates
+run_mutation "a vendor can be its own curated alternative" m_vendor_names_itself_as_an_alternative
+run_mutation "widening the pool discards the category members" m_pool_widening_replaces_the_category_pool
+run_mutation "widening the pool duplicates a member it already holds" m_pool_widening_duplicates_a_member
+run_mutation "the queue keeps names the catalogue carries" m_queue_keeps_names_we_do_carry
+run_mutation "the queue forgets which vendors named each entry" m_queue_forgets_who_named_each_entry
+run_mutation "the queue is written in the reverse order" m_queue_order_is_unstable
+run_mutation "the curated block skips the membership gate" m_curated_block_skips_the_membership_gate
+run_mutation "the curated gate ignores the gates the subject itself carries" m_curated_gate_ignores_the_subject_s_own_gates
+run_mutation "the curated block publishes no seed" m_curated_block_publishes_no_seed
+run_mutation "the curated block is ordered outside the ranking module" m_curated_order_bypasses_the_ranking_module
+run_mutation "the category grid takes the curated members" m_category_grid_takes_the_curated_members
+run_mutation "the count sentence ignores the categories curation added" m_count_sentence_ignores_the_added_categories
+run_mutation "the two pages word the curated block differently" m_the_two_pages_word_the_block_differently
+
+restore
+npm run build > /dev/null 2>&1
+echo
+echo "killed:   $killed"
+echo "survived: $survived"
+[ "$survived" -eq 0 ]

--- a/src/curated-alternatives.ts
+++ b/src/curated-alternatives.ts
@@ -1,0 +1,93 @@
+import type { DealChange, Offer } from "./types.js";
+import { partitionAlternativesAcross, type MembershipGate, type RoleCarrier } from "./product-role.js";
+
+export interface CuratedAlternatives {
+  matched: Offer[];
+  unmatched: string[];
+}
+
+export interface CuratedAlternativesForVendor {
+  kept: Offer[];
+  removed: Array<{ offer: Offer; gate: MembershipGate }>;
+  unmatched: string[];
+}
+
+export interface UnmatchedCuratedName {
+  name: string;
+  named_by: string[];
+}
+
+function namesFromChanges(vendorName: string, changes: DealChange[]): string[] {
+  const lowerVendor = vendorName.toLowerCase();
+  const ordered: string[] = [];
+  const seen = new Set<string>();
+  for (const change of changes) {
+    if (change.vendor.toLowerCase() !== lowerVendor) continue;
+    for (const name of change.alternatives ?? []) {
+      if (name === vendorName || seen.has(name)) continue;
+      seen.add(name);
+      ordered.push(name);
+    }
+  }
+  return ordered;
+}
+
+export function curatedAlternativeNames(vendorName: string, changes: DealChange[]): string[] {
+  return namesFromChanges(vendorName, changes);
+}
+
+export function resolveCuratedAlternatives(
+  vendorName: string,
+  changes: DealChange[],
+  offers: Offer[],
+): CuratedAlternatives {
+  const byVendor = new Map<string, Offer>();
+  for (const offer of offers) {
+    if (!byVendor.has(offer.vendor)) byVendor.set(offer.vendor, offer);
+  }
+  const matched: Offer[] = [];
+  const unmatched: string[] = [];
+  for (const name of namesFromChanges(vendorName, changes)) {
+    const offer = byVendor.get(name);
+    if (offer) matched.push(offer);
+    else unmatched.push(name);
+  }
+  return { matched, unmatched };
+}
+
+export function curatedAlternativesFor(
+  vendorName: string,
+  changes: DealChange[],
+  offers: Offer[],
+  subjects: RoleCarrier[],
+): CuratedAlternativesForVendor {
+  const { matched, unmatched } = resolveCuratedAlternatives(vendorName, changes, offers);
+  const partition = partitionAlternativesAcross(matched, subjects);
+  return { kept: partition.kept, removed: partition.removed, unmatched };
+}
+
+export function addCuratedToPool(pool: Offer[], curated: Offer[]): Offer[] {
+  const present = new Set(pool.map(o => o.vendor));
+  const widened = [...pool];
+  for (const offer of curated) {
+    if (present.has(offer.vendor)) continue;
+    present.add(offer.vendor);
+    widened.push(offer);
+  }
+  return widened;
+}
+
+export function unmatchedCuratedNames(changes: DealChange[], offers: Offer[]): UnmatchedCuratedName[] {
+  const indexed = new Set(offers.map(o => o.vendor));
+  const byName = new Map<string, Set<string>>();
+  for (const change of changes) {
+    for (const name of change.alternatives ?? []) {
+      if (indexed.has(name)) continue;
+      if (!byName.has(name)) byName.set(name, new Set());
+      byName.get(name)!.add(change.vendor);
+    }
+  }
+  return [...byName.entries()]
+    .map(([name, namedBy]) => ({ name, named_by: [...namedBy].sort() }))
+    .sort((a, b) => a.name.localeCompare(b.name));
+}

--- a/src/serve.ts
+++ b/src/serve.ts
@@ -44,6 +44,7 @@ import { rankOffers, rankForListing, rotateListing, utcDate, CRITERIA_PATH, DEMO
 import type { RankedEntry, RankingResult } from "./ranking.js";
 import { verificationLedger, QUARANTINE_AFTER_FAILURES } from "./verification-state.js";
 import { partitionAlternatives, partitionAlternativesAcross, productRoleSentence, MEMBERSHIP_GATE_RULES, MEMBERSHIP_GATE_ORDER, MEMBERSHIP_GATE_SYMMETRY, MEMBERSHIP_GATE_SCOPE, MEMBERSHIP_GATE_CORRECTIONS } from "./product-role.js";
+import { resolveCuratedAlternatives, curatedAlternativesFor, addCuratedToPool } from "./curated-alternatives.js";
 import type { Agent, ChangeDateSource, DealChange, RiskCause, LinkUnreachable, Offer } from "./types.js";
 import { changeDateLabel, changeDateClause, changeDatePublished, changeEventStartDate, capListSections, latestEventDate, feedEntryUpdated, undatedGroupHeading, firstReadHeading, discoveryBatchNote, DISCOVERED_DATE_PREFIX, UNDATED_GROUP_NOTE } from "./change-dates.js";
 import { FEED_CORRECTIONS, correctionEntriesXml } from "./feed-corrections.js";
@@ -3623,6 +3624,12 @@ const erosionAffectedCategories = (() => {
   return new Set([...catNeg.entries()].sort((a, b) => b[1] - a[1]).slice(0, 10).map(e => e[0]));
 })();
 
+const CURATED_ALTS_HEADING = "Recommended Migration Targets";
+
+function curatedAltsNote(vendorName: string): string {
+  return `These alternatives were identified from ${escHtmlServer(vendorName)}&rsquo;s pricing changes as recommended replacements.`;
+}
+
 function buildVendorPage(slug: string): string | null {
   const vendorName = vendorSlugMap.get(slug);
   if (!vendorName) return null;
@@ -3673,6 +3680,16 @@ function buildVendorPage(slug: string): string | null {
     { queryKey: `alternatives:${primary.category}:${vendorName}`, changes: dealChanges },
   );
   const alternatives = alternativesRanking.entries.slice(0, 12).map(e => e.offer);
+
+  const curatedVendorRanking = (() => {
+    const kept = curatedAlternativesFor(vendorName, allChanges, offers, vendorOffers).kept;
+    if (kept.length === 0) return null;
+    return rankForListing(kept, {
+      queryKey: `curated-alternatives:${vendorName}`,
+      changes: dealChanges,
+    });
+  })();
+  const curatedVendorAlts = curatedVendorRanking?.entries.map(e => e.offer) ?? [];
 
   const vendorComparisons = Array.from(comparisonMap.entries())
     .filter(([, [a, b]]) => a === vendorName || b === vendorName);
@@ -3841,6 +3858,18 @@ ${enrichedAlts.map(a => {
 
   const membershipExclusionsHtml = alternativesMembership.removed.length > 0 ? `
     <p class="alt-excluded" style="margin:.7rem 0 0;font-size:.85rem;color:var(--text-muted)">Left out of this list: ${alternativesMembership.removed.map(r => `<a href="/vendor/${toSlug(r.offer.vendor)}">${escHtmlServer(r.offer.vendor)}</a> (${escHtmlServer(MEMBERSHIP_GATE_RULES[r.gate].label.toLowerCase())})`).join(", ")}. Each is still listed in <a href="/category/${toSlug(primary.category)}">${escHtmlServer(primary.category)}</a>, with the vendor's own words we read that from on its page. <a href="${CRITERIA_PATH}#membership">How we decide this</a>.</p>` : "";
+  const curatedAlternativesHtml = curatedVendorRanking ? `
+  <div class="section">
+    <h2>${CURATED_ALTS_HEADING}</h2>
+    <p class="section-note" style="margin:0 0 1rem;font-size:.85rem;color:var(--text-muted)">${curatedAltsNote(vendorName)}</p>
+    <div class="alt-grid">
+${curatedVendorAlts.map(a => `      <a href="/vendor/${toSlug(a.vendor)}" class="alt-card">
+        <span class="alt-name">${escHtmlServer(a.vendor)}</span>
+        <span class="alt-tier">${escHtmlServer(a.tier)}</span>
+      </a>`).join("\n")}
+    </div>
+${renderAuditBlock(curatedVendorRanking.tie_break, { shown: curatedVendorAlts.length, total: curatedVendorRanking.entries.length })}
+  </div>` : "";
   const alternativesHtml = alternatives.length > 0 ? `
   <div class="section">
     <h2>Alternatives in ${escHtmlServer(primary.category)}</h2>
@@ -4182,7 +4211,7 @@ ${growthPathHtml}
     ${changesHtml}
     <p style="margin-top:.75rem;font-size:.8rem"><a href="/pricing-changes">View all ${dealChanges.length} pricing changes across all vendors &rarr;</a></p>
   </div>
-${alternativesHtml}
+${curatedAlternativesHtml}${alternativesHtml}
 ${comparisonsHtml}
 ${altPagesHtml}
 ${reportAppearancesHtml}
@@ -4246,7 +4275,9 @@ function buildAlternativesPage(slug: string): string | null {
       dedupedAlts.push(a);
     }
   }
-  const altMembership = partitionAlternativesAcross(dedupedAlts, vendorOffers);
+  const curated = resolveCuratedAlternatives(vendorName, allChanges, offers);
+  const curatedAltNames = new Set(curated.matched.map(o => o.vendor));
+  const altMembership = partitionAlternativesAcross(addCuratedToPool(dedupedAlts, curated.matched), vendorOffers);
   const altRanking = rankForListing(enrichOffers(altMembership.kept), {
     queryKey: `alternative-to:${vendorName}`,
     changes: dealChanges,
@@ -4254,15 +4285,11 @@ function buildAlternativesPage(slug: string): string | null {
   const enrichedAlts = altRanking.entries.map(e => e.offer);
   const altDemerits = new Map(altRanking.entries.map(e => [e.offer.vendor, e]));
 
-  const curatedAltNames = new Set<string>();
-  for (const c of vendorChanges) {
-    if (c.alternatives && c.alternatives.length > 0) {
-      for (const alt of c.alternatives) curatedAltNames.add(alt);
-    }
+  const curatedAlts = enrichedAlts.filter(a => curatedAltNames.has(a.vendor));
+  const listedCategories = [...vendorCategories];
+  for (const a of enrichedAlts) {
+    if (!listedCategories.includes(a.category)) listedCategories.push(a.category);
   }
-  const curatedAlts = curatedAltNames.size > 0
-    ? enrichedAlts.filter(a => curatedAltNames.has(a.vendor))
-    : [];
 
   const currentYear = new Date().getFullYear();
   const title = `Best ${vendorName} Alternatives with Free Tiers (${currentYear}) | AgentDeals`;
@@ -4333,8 +4360,8 @@ function buildAlternativesPage(slug: string): string | null {
 
   const curatedHtml = curatedAlts.length > 0 ? `
   <div class="section">
-    <h2>Recommended Migration Targets</h2>
-    <p class="section-note">These alternatives were identified from ${escHtmlServer(vendorName)}&rsquo;s pricing changes as recommended replacements.</p>
+    <h2>${CURATED_ALTS_HEADING}</h2>
+    <p class="section-note">${curatedAltsNote(vendorName)}</p>
     <div class="alt-list">
 ${curatedAlts.map(a => altCard(a, true)).join("\n")}
     </div>
@@ -4387,7 +4414,7 @@ ${renderAuditBlock(altRanking.tie_break)}
     : riskLevel === "caution"
     ? `${vendorName} has a free tier (${primary.tier}), but it's flagged as "caution" because of one specific recorded change${riskCause ? `, ${changeDateClause(riskCause)}: ${riskCause.summary}` : "."}`
     : `${vendorName}'s free tier (${primary.tier}) is considered risky because of one specific recorded change${riskCause ? `, ${changeDateClause(riskCause)}: ${riskCause.summary}` : "."} Consider migrating to a more stable alternative.`;
-  const faqCountAnswer = `There are ${enrichedAlts.length} free alternatives to ${vendorName} tracked on AgentDeals across the ${vendorCategories.join(", ")} categor${vendorCategories.length > 1 ? "ies" : "y"}.`;
+  const faqCountAnswer = `There are ${enrichedAlts.length} free alternatives to ${vendorName} tracked on AgentDeals across the ${listedCategories.join(", ")} categor${listedCategories.length > 1 ? "ies" : "y"}.`;
   const faqChangesAnswer = vendorChanges.length > 0
     ? `Yes, ${vendorName} has ${vendorChanges.length} recorded pricing change${vendorChanges.length !== 1 ? "s" : ""}. The most recent was ${changeDateClause(vendorChanges[0])}: ${vendorChanges[0].summary}`
     : altLevelWithheld

--- a/test/curated-alternatives.test.ts
+++ b/test/curated-alternatives.test.ts
@@ -1,0 +1,433 @@
+import { describe, it, before, after } from "node:test";
+import assert from "node:assert";
+import { spawn, type ChildProcess } from "node:child_process";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  curatedAlternativeNames,
+  resolveCuratedAlternatives,
+  curatedAlternativesFor,
+  addCuratedToPool,
+  unmatchedCuratedNames,
+} from "../dist/curated-alternatives.js";
+import { partitionAlternativesAcross } from "../dist/product-role.js";
+import type { DealChange, Offer } from "../src/types.ts";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO = path.join(__dirname, "..");
+
+const offers: Offer[] = JSON.parse(readFileSync(path.join(REPO, "data", "index.json"), "utf-8")).offers;
+const changes: DealChange[] = JSON.parse(readFileSync(path.join(REPO, "data", "deal_changes.json"), "utf-8")).changes;
+
+function offerFixture(vendor: string, category: string, extra: Partial<Offer> = {}): Offer {
+  return {
+    vendor,
+    category,
+    description: `${vendor} description`,
+    tier: "Free",
+    url: `https://example.com/${vendor.toLowerCase()}`,
+    tags: [],
+    verifiedDate: "2026-08-01",
+    ...extra,
+  };
+}
+
+function changeFixture(vendor: string, alternatives: string[]): DealChange {
+  return {
+    vendor,
+    change_type: "limits_reduced",
+    date: "2026-01-01",
+    summary: `${vendor} reduced its limits`,
+    previous_state: "before",
+    current_state: "after",
+    impact: "medium",
+    source_url: "https://example.com/pricing",
+    category: "Databases",
+    alternatives,
+  };
+}
+
+function slugOf(vendor: string): string {
+  return vendor.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "");
+}
+
+function categoriesOf(vendor: string): Set<string> {
+  return new Set(offers.filter(o => o.vendor === vendor).map(o => o.category));
+}
+
+function categoryPoolFor(vendor: string): Offer[] {
+  const cats = categoriesOf(vendor);
+  const seen = new Set<string>();
+  const pool: Offer[] = [];
+  for (const o of offers) {
+    if (!cats.has(o.category) || o.vendor === vendor || seen.has(o.vendor)) continue;
+    seen.add(o.vendor);
+    pool.push(o);
+  }
+  return pool;
+}
+
+describe("curated alternative names", () => {
+  it("reads every alternative named by the vendor's own change records", () => {
+    const records = [changeFixture("Xata", ["Neon", "Supabase"]), changeFixture("Xata", ["CockroachDB"])];
+    assert.deepStrictEqual(curatedAlternativeNames("Xata", records), ["Neon", "Supabase", "CockroachDB"]);
+  });
+
+  it("matches a vendor whose change records differ in case", () => {
+    const records = [changeFixture("xata", ["Neon"])];
+    assert.deepStrictEqual(curatedAlternativeNames("Xata", records), ["Neon"]);
+  });
+
+  it("reads nothing from another vendor's records", () => {
+    const records = [changeFixture("Xata", ["Neon"])];
+    assert.deepStrictEqual(curatedAlternativeNames("Neon", records), []);
+  });
+
+  it("keeps one entry for a name repeated across records", () => {
+    const records = [changeFixture("Xata", ["Neon"]), changeFixture("Xata", ["Neon"])];
+    assert.deepStrictEqual(curatedAlternativeNames("Xata", records), ["Neon"]);
+  });
+
+  it("never names the vendor as its own alternative", () => {
+    const records = [changeFixture("Xata", ["Xata", "Neon"])];
+    assert.deepStrictEqual(curatedAlternativeNames("Xata", records), ["Neon"]);
+  });
+});
+
+describe("resolving curated names against the catalogue", () => {
+  const catalogue = [
+    offerFixture("Neon", "Databases"),
+    offerFixture("Bruno", "API Development"),
+  ];
+
+  it("matches a name in another category", () => {
+    const resolved = resolveCuratedAlternatives("Postman", [changeFixture("Postman", ["Bruno"])], catalogue);
+    assert.deepStrictEqual(resolved.matched.map(o => o.vendor), ["Bruno"]);
+    assert.deepStrictEqual(resolved.unmatched, []);
+  });
+
+  it("requires an exact vendor name and does not match a prefix", () => {
+    const resolved = resolveCuratedAlternatives("Dub.co", [changeFixture("Dub.co", ["Bit", "neon", "Neon Serverless"])], catalogue);
+    assert.deepStrictEqual(resolved.matched, []);
+    assert.deepStrictEqual(resolved.unmatched, ["Bit", "neon", "Neon Serverless"]);
+  });
+
+  it("reports a name we do not carry as unmatched", () => {
+    const resolved = resolveCuratedAlternatives("Dub.co", [changeFixture("Dub.co", ["Bitly", "Short.io"])], catalogue);
+    assert.deepStrictEqual(resolved.matched, []);
+    assert.deepStrictEqual(resolved.unmatched, ["Bitly", "Short.io"]);
+  });
+
+  it("does not match a catalogue entry whose name merely begins with the curated name", () => {
+    const longerNames = [
+      offerFixture("Bitly Enterprise", "Dev Utilities"),
+      offerFixture("Neon Serverless Postgres", "Databases"),
+    ];
+    const resolved = resolveCuratedAlternatives("Dub.co", [changeFixture("Dub.co", ["Bitly", "Neon"])], longerNames);
+    assert.deepStrictEqual(resolved.matched, []);
+    assert.deepStrictEqual(resolved.unmatched, ["Bitly", "Neon"]);
+  });
+
+  it("does not match a catalogue entry whose name merely contains the curated name", () => {
+    const embedded = [offerFixture("Cloudflare R2 Storage", "Storage")];
+    const resolved = resolveCuratedAlternatives("Firebase", [changeFixture("Firebase", ["R2"])], embedded);
+    assert.deepStrictEqual(resolved.matched, []);
+    assert.deepStrictEqual(resolved.unmatched, ["R2"]);
+  });
+});
+
+describe("the curated set a vendor page renders", () => {
+  const EMULATOR_ROLE = {
+    deployment_model: "local_dev_only" as const,
+    is_addon: false,
+    source_url: "https://example.com/docs",
+    source_quote: "runs on your machine",
+    reviewed: "2026-08-01",
+  };
+
+  it("removes a curated name a membership gate would remove", () => {
+    const catalogue = [
+      offerFixture("Emulator", "Databases", { product_role: EMULATOR_ROLE }),
+      offerFixture("Turso", "Databases"),
+    ];
+    const subject = offerFixture("Neon", "Databases");
+    const curated = curatedAlternativesFor(
+      "Neon",
+      [changeFixture("Neon", ["Emulator", "Turso"])],
+      catalogue,
+      [subject],
+    );
+    assert.deepStrictEqual(curated.kept.map(o => o.vendor), ["Turso"]);
+    assert.deepStrictEqual(curated.removed.map(r => [r.offer.vendor, r.gate]), [["Emulator", "local_dev_only"]]);
+  });
+
+  it("keeps a curated name whose gate the subject carries too", () => {
+    const catalogue = [offerFixture("Emulator", "Databases", { product_role: EMULATOR_ROLE })];
+    const subject = offerFixture("LocalStack", "Databases", { product_role: EMULATOR_ROLE });
+    const curated = curatedAlternativesFor(
+      "LocalStack",
+      [changeFixture("LocalStack", ["Emulator"])],
+      catalogue,
+      [subject],
+    );
+    assert.deepStrictEqual(curated.kept.map(o => o.vendor), ["Emulator"]);
+    assert.deepStrictEqual(curated.removed, []);
+  });
+
+  it("reports the names it could not match alongside the ones it kept", () => {
+    const catalogue = [offerFixture("Turso", "Databases")];
+    const subject = offerFixture("Neon", "Databases");
+    const curated = curatedAlternativesFor(
+      "Neon",
+      [changeFixture("Neon", ["Turso", "PlanetScale"])],
+      catalogue,
+      [subject],
+    );
+    assert.deepStrictEqual(curated.kept.map(o => o.vendor), ["Turso"]);
+    assert.deepStrictEqual(curated.unmatched, ["PlanetScale"]);
+  });
+});
+
+describe("widening the pool with curated names", () => {
+  it("adds a curated offer the category pool does not hold", () => {
+    const pool = [offerFixture("Katalon", "Testing")];
+    const widened = addCuratedToPool(pool, [offerFixture("Bruno", "API Development")]);
+    assert.deepStrictEqual(widened.map(o => o.vendor), ["Katalon", "Bruno"]);
+  });
+
+  it("does not duplicate a curated offer the category pool already holds", () => {
+    const pool = [offerFixture("Neon", "Databases")];
+    const widened = addCuratedToPool(pool, [offerFixture("Neon", "Databases")]);
+    assert.deepStrictEqual(widened.map(o => o.vendor), ["Neon"]);
+  });
+
+  it("keeps every member the category pool produced", () => {
+    const pool = [offerFixture("A", "Databases"), offerFixture("B", "Databases")];
+    const widened = addCuratedToPool(pool, [offerFixture("C", "Storage")]);
+    for (const original of pool) {
+      assert.ok(widened.some(o => o.vendor === original.vendor), `${original.vendor} left the pool`);
+    }
+  });
+
+  it("returns a pool at least as large as the one it was given, for every vendor we carry", () => {
+    for (const vendor of new Set(offers.map(o => o.vendor))) {
+      const pool = categoryPoolFor(vendor);
+      const curated = resolveCuratedAlternatives(vendor, changes, offers);
+      const widened = addCuratedToPool(pool, curated.matched);
+      assert.ok(widened.length >= pool.length, `${vendor} lost members`);
+      for (const original of pool) {
+        assert.ok(widened.some(o => o.vendor === original.vendor), `${vendor} lost ${original.vendor}`);
+      }
+    }
+  });
+
+  it("leaves the membership gate to decide what the widened pool keeps", () => {
+    const localOnly = offerFixture("Emulator", "Databases", {
+      product_role: {
+        deployment_model: "local_dev_only",
+        is_addon: false,
+        source_url: "https://example.com/docs",
+        source_quote: "runs on your machine",
+        reviewed: "2026-08-01",
+      },
+    });
+    const subject = offerFixture("Hosted DB", "Databases");
+    const widened = addCuratedToPool([], [localOnly]);
+    const partitioned = partitionAlternativesAcross(widened, [subject]);
+    assert.deepStrictEqual(partitioned.kept, []);
+    assert.deepStrictEqual(partitioned.removed.map(r => r.gate), ["local_dev_only"]);
+  });
+});
+
+describe("the queue of curated names we do not carry", () => {
+  it("records which vendors named each name", () => {
+    const records = [changeFixture("Firebase", ["AWS S3"]), changeFixture("Uploadthing", ["AWS S3"])];
+    const queue = unmatchedCuratedNames(records, [offerFixture("Neon", "Databases")]);
+    assert.deepStrictEqual(queue, [{ name: "AWS S3", named_by: ["Firebase", "Uploadthing"] }]);
+  });
+
+  it("omits a name the catalogue carries", () => {
+    const records = [changeFixture("Xata", ["Neon", "PlanetScale"])];
+    const queue = unmatchedCuratedNames(records, [offerFixture("Neon", "Databases")]);
+    assert.deepStrictEqual(queue.map(e => e.name), ["PlanetScale"]);
+  });
+
+  it("matches the file committed alongside the catalogue", () => {
+    const committed = JSON.parse(
+      readFileSync(path.join(REPO, "data", "curated_alternatives_unmatched.json"), "utf-8"),
+    ) as { unmatched: Array<{ name: string; named_by: string[] }> };
+    assert.deepStrictEqual(committed.unmatched, unmatchedCuratedNames(changes, offers));
+  });
+
+  it("holds no name that also appears in the catalogue", () => {
+    const committed = JSON.parse(
+      readFileSync(path.join(REPO, "data", "curated_alternatives_unmatched.json"), "utf-8"),
+    ) as { unmatched: Array<{ name: string }> };
+    const indexed = new Set(offers.map(o => o.vendor));
+    for (const entry of committed.unmatched) {
+      assert.ok(!indexed.has(entry.name), `${entry.name} is in the catalogue`);
+    }
+  });
+
+  it("names no curated alternative outside the subject's category that a membership gate would remove", () => {
+    for (const subject of new Set(changes.map(c => c.vendor))) {
+      const subjectCategories = categoriesOf(subject);
+      if (subjectCategories.size === 0) continue;
+      const curated = resolveCuratedAlternatives(subject, changes, offers);
+      for (const candidate of curated.matched) {
+        if (subjectCategories.has(candidate.category)) continue;
+        const removed = partitionAlternativesAcross([candidate], offers.filter(o => o.vendor === subject)).removed;
+        assert.deepStrictEqual(
+          removed,
+          [],
+          `${candidate.vendor} is gated for ${subject} and sits in ${candidate.category}, which the exclusion sentence on /vendor/${slugOf(subject)} names as ${[...subjectCategories].join(", ")}`,
+        );
+      }
+    }
+  });
+
+  it("holds every curated name the catalogue does not carry", () => {
+    const indexed = new Set(offers.map(o => o.vendor));
+    const queued = new Set(unmatchedCuratedNames(changes, offers).map(e => e.name));
+    for (const change of changes) {
+      for (const name of change.alternatives ?? []) {
+        if (!indexed.has(name)) assert.ok(queued.has(name), `${name} is missing from the queue`);
+      }
+    }
+  });
+});
+
+let serverPort = 0;
+let proc: ChildProcess | null = null;
+
+function startServer(): Promise<ChildProcess> {
+  return new Promise((resolve, reject) => {
+    const child = spawn("node", [path.join(REPO, "dist", "serve.js")], {
+      stdio: ["pipe", "pipe", "pipe"],
+      env: { ...process.env, PORT: "0", BASE_URL: "http://localhost" },
+    });
+    const timeout = setTimeout(() => { child.kill(); reject(new Error("Server startup timeout")); }, 20000);
+    child.stderr!.on("data", (data: Buffer) => {
+      const m = data.toString().match(/running on http:\/\/localhost:(\d+)/);
+      if (m) { serverPort = parseInt(m[1], 10); clearTimeout(timeout); resolve(child); }
+    });
+    child.on("error", (err) => { clearTimeout(timeout); reject(err); });
+  });
+}
+
+const get = async (p: string) => {
+  const res = await fetch(`http://localhost:${serverPort}${p}`);
+  return { status: res.status, body: await res.text() };
+};
+
+const CURATED_HEADING = "Recommended Migration Targets";
+
+function curatedSection(body: string): string | null {
+  const start = body.indexOf(CURATED_HEADING);
+  if (start === -1) return null;
+  const end = body.indexOf("</div>\n  </div>", start);
+  return body.slice(start, end === -1 ? body.length : end);
+}
+
+describe("curated alternatives on the published pages", () => {
+  before(async () => { proc = await startServer(); });
+  after(() => { if (proc) proc.kill(); });
+
+  const POSTMAN_CURATED = ["Bruno", "Insomnia", "Hoppscotch", "Apidog", "Thunder Client"];
+
+  it("names all five curated alternatives to Postman on the alternatives page", async () => {
+    const res = await get("/alternative-to/postman");
+    assert.strictEqual(res.status, 200);
+    const section = curatedSection(res.body);
+    assert.ok(section, "no curated section");
+    for (const vendor of POSTMAN_CURATED) {
+      assert.ok(section.includes(`>${vendor}<`), `${vendor} is not in the curated section`);
+    }
+  });
+
+  it("names all five curated alternatives to Postman on the vendor page", async () => {
+    const res = await get("/vendor/postman");
+    assert.strictEqual(res.status, 200);
+    const section = curatedSection(res.body);
+    assert.ok(section, "no curated section");
+    for (const vendor of POSTMAN_CURATED) {
+      assert.ok(section.includes(`>${vendor}<`), `${vendor} is not in the curated section`);
+    }
+  });
+
+  it("carries the curated alternatives into the full alternatives list", async () => {
+    const res = await get("/alternative-to/postman");
+    for (const vendor of POSTMAN_CURATED) {
+      assert.ok(res.body.includes(`/vendor/${slugOf(vendor)}`), `${vendor} is not linked`);
+    }
+  });
+
+  it("counts the categories the alternatives list actually spans", async () => {
+    const res = await get("/alternative-to/postman");
+    const sentence = res.body.match(/There are \d+ free alternatives to Postman tracked on AgentDeals across the ([^.]+) categor(?:y|ies)\./);
+    assert.ok(sentence, "no count sentence");
+    assert.ok(sentence[1].includes("API Development"), `categories read ${sentence[1]}`);
+  });
+
+  it("publishes the same wording for the curated block on both page types", async () => {
+    const vendorPage = await get("/vendor/postman");
+    const altPage = await get("/alternative-to/postman");
+    const note = "These alternatives were identified from Postman&rsquo;s pricing changes as recommended replacements.";
+    assert.ok(vendorPage.body.includes(note));
+    assert.ok(altPage.body.includes(note));
+  });
+
+  it("shows no curated block for a vendor whose curated names we do not carry", async () => {
+    for (const url of ["/alternative-to/dub-co", "/vendor/dub-co"]) {
+      const res = await get(url);
+      assert.strictEqual(res.status, 200);
+      assert.strictEqual(curatedSection(res.body), null, `${url} shows a curated block`);
+      assert.ok(!res.body.includes("Bitly"), `${url} names Bitly`);
+      assert.ok(!res.body.includes("Short.io"), `${url} names Short.io`);
+    }
+  });
+
+  it("keeps every category member on a page whose curated names are all in category", async () => {
+    const res = await get("/alternative-to/xata");
+    assert.strictEqual(res.status, 200);
+    const count = res.body.match(/All Free Alternatives \((\d+)\)/);
+    assert.ok(count, "no alternatives count");
+    assert.ok(Number(count[1]) >= categoryPoolFor("Xata").length - 5, `only ${count[1]} alternatives`);
+    for (const vendor of ["Neon", "Supabase", "CockroachDB"]) {
+      assert.ok(res.body.includes(`>${vendor}<`), `${vendor} is not listed`);
+    }
+  });
+
+  it("orders the curated block through the shared ranking module", async () => {
+    const { createHash } = await import("node:crypto");
+    const { rankForListing } = await import("../dist/ranking.js");
+    const body = (await get("/vendor/postman")).body;
+    const start = body.indexOf(CURATED_HEADING);
+    const grid = body.slice(start, body.indexOf('<div class="audit-block">', start));
+    const rendered = [...grid.matchAll(/<span class="alt-name">([^<]+)<\/span>/g)].map(m => m[1]);
+
+    const kept = partitionAlternativesAcross(
+      resolveCuratedAlternatives("Postman", changes, offers).matched,
+      offers.filter(o => o.vendor === "Postman"),
+    ).kept;
+    const ranking = rankForListing(kept, { queryKey: "curated-alternatives:Postman", changes });
+    assert.deepStrictEqual(rendered, ranking.entries.map(e => e.offer.vendor));
+
+    const block = body.slice(start).match(/<div class="audit-block">[\s\S]*?<\/div>/)![0];
+    const date = block.match(/<dt>date<\/dt><dd>([^<]+)</)![1];
+    const queryKey = block.match(/<dt>query_key<\/dt><dd>([^<]+)</)![1].replace(/&amp;/g, "&");
+    const seed = block.match(/<dt>seed<\/dt><dd>([^<]+)</)![1];
+    assert.strictEqual(queryKey, "curated-alternatives:Postman");
+    assert.strictEqual(createHash("sha256").update(`${date}|${queryKey}|p0`).digest("hex"), seed);
+  });
+
+  it("leaves the category heading on the vendor page describing the category list", async () => {
+    const res = await get("/vendor/postman");
+    assert.ok(res.body.includes("<h2>Alternatives in Testing</h2>"));
+    const categoryList = res.body.slice(res.body.indexOf("<h2>Alternatives in Testing</h2>"));
+    for (const vendor of POSTMAN_CURATED) {
+      assert.ok(!categoryList.includes(`>${vendor}<`), `${vendor} is inside the category list`);
+    }
+  });
+});

--- a/test/ranked-surfaces.test.ts
+++ b/test/ranked-surfaces.test.ts
@@ -220,6 +220,7 @@ const RANKED_SURFACES: Array<{
   { queryKeyPrefix: "best-of", publishedAt: "/best/free-databases", seedIn: "html" },
   { queryKeyPrefix: "alternatives", publishedAt: "/vendor/doppler", seedIn: "html" },
   { queryKeyPrefix: "alternative-to", publishedAt: "/alternative-to/doppler", seedIn: "html" },
+  { queryKeyPrefix: "curated-alternatives", publishedAt: "/vendor/postman", seedIn: "html" },
   { queryKeyPrefix: "related", publishedAt: "/api/details/doppler", seedIn: "json", jsonSeed: (b) => b.offer?.tie_break?.seed },
   { queryKeyPrefix: "vendor-risk-alternatives", publishedAt: "/api/vendor-risk/doppler", seedIn: "json", jsonSeed: (b) => b.tie_break?.seed },
   { queryKeyPrefix: "stack", publishedAt: "/api/stack?use_case=Next.js+SaaS+app", seedIn: "json", jsonSeed: (b) => b.stack?.[0]?.tie_break?.seed },
@@ -258,12 +259,13 @@ describe("every ranked surface publishes the seed that ordered it", () => {
         assert.match(String(surface.jsonSeed!(JSON.parse(text))), /^[0-9a-f]{64}$/);
         return;
       }
-      const block = text.match(/<div class="audit-block">[\s\S]*?<\/div>/);
-      assert.ok(block, "the page ranks a list and renders no audit block");
-      assert.match(block[0], /<dt>date<\/dt><dd>\d{4}-\d{2}-\d{2}<\/dd>/);
-      assert.match(block[0], new RegExp(`<dt>query_key</dt><dd>${surface.queryKeyPrefix}:`));
-      assert.match(block[0], /<dt>seed<\/dt><dd>[0-9a-f]{64}<\/dd>/);
-      assert.match(block[0], /<dt>tie_count<\/dt><dd>\d+<\/dd>/);
+      const blocks = text.match(/<div class="audit-block">[\s\S]*?<\/div>/g) ?? [];
+      assert.ok(blocks.length > 0, "the page ranks a list and renders no audit block");
+      const block = blocks.find((b) => new RegExp(`<dt>query_key</dt><dd>${surface.queryKeyPrefix}:`).test(b));
+      assert.ok(block, `no audit block on the page names ${surface.queryKeyPrefix}`);
+      assert.match(block, /<dt>date<\/dt><dd>\d{4}-\d{2}-\d{2}<\/dd>/);
+      assert.match(block, /<dt>seed<\/dt><dd>[0-9a-f]{64}<\/dd>/);
+      assert.match(block, /<dt>tie_count<\/dt><dd>\d+<\/dd>/);
     });
   }
 


### PR DESCRIPTION
Refs https://github.com/robhunter/agentdeals/issues/1032 — Phase 0 (AC-0a through AC-0e).

## What was wrong

`serve.ts` computed the curated list as `enrichedAlts.filter(a => curatedAltNames.has(a.vendor))`, where `enrichedAlts` is the same-category pool. A curated name rendered only when the category already contained it — the one case where writing it down added nothing. And only `/alternative-to/:slug` read the list at all.

Measured on `main` today, over the 422 curated pairs in 131 change records naming 95 vendors:

| | pairs |
|---|---|
| same category — rendered | 165 |
| indexed, another category — dropped | 92 |
| names no offer we carry | 165 |

## What changed

- **AC-0a.** A curated name joins the alternatives pool regardless of category, on `/alternative-to/:slug`. It is added, never intersected. Ordering still comes from `rankForListing`.
- **AC-0b.** `/vendor/:slug` renders the curated list in its own block, in the wording `/alternative-to/:slug` already publishes, from one shared string so the two cannot drift.
- **AC-0c.** Curated names with no matching offer are written to `data/curated_alternatives_unmatched.json` — **132 distinct names**, each with the vendors that named it. `npm run queue:curated-alternatives` regenerates it; `--check` fails if it is stale, and a test asserts the committed file equals what the data implies.
- **AC-0d.** No page loses an alternative. Asserted for every vendor in the catalogue, and measured page by page below.
- **AC-0e.** `/alternative-to/dub-co` and `/vendor/dub-co` render no curated block, because Bitly and Short.io are not in the index. Both are in the queue file. Name matching is exact — a fixture with `Bitly Enterprise` in the catalogue and `Bitly` as the curated name must not match.

## Per-surface effect

**68 of 3,921 deterministic paths move. 3,853 are byte-identical to a `main` build.**

| surface | pages | effect |
|---|---|---|
| `/vendor/:slug` | **51** | gain a curated block. The category grid, its heading, its count and its FAQ answers are untouched |
| `/alternative-to/:slug` | **17** | gain 1–5 cross-category members |
| `/category`, `/best`, search, `/api/offers`, `/api/details`, `/api/vendor-risk`, `/api/stack`, `llms.txt` | 0 | unchanged |

The 17, with their alternatives count before and after:

`aws` 36→41 · `postman` 43→48 · `logz-io` 13→17 · `digitalocean` 48→51 · `n8n` 4→7 · `amazon-kiro-aws-startups` 12→15 · `firebase` 41→43 · `cloudflare-durable-objects` 61→63 · `dbos` 6→8 · `alibaba-cloud-qwen-code` 69→71 · `sonarqube-cloud` 52→53 · `hetzner` 13→14 · `google-cloud` 12→13 · `pythonanywhere` 61→62 · `unity-devops` 36→37 · `everystep-automation-com` 43→44 · `imageengine` 51→52

**Zero pages lose an alternative.** No category falls below three.

`/alternative-to/postman` now renders Bruno, Insomnia, Hoppscotch, Apidog and Thunder Client — all five, in the curated block and in the full list — and so does `/vendor/postman`, which took more AI-agent traffic than `/alternative-to/:slug` did.

## Three decisions to rule on

**1. The vendor page's category grid stays category-only.** Its heading is `Alternatives in {category}`, its outgrow sentence ends `in the same category`, its meta description says `N alternatives in {category}` and its `FAQPage` answer says `The top free alternatives to X in {category} include …`. Folding cross-category members into that grid makes four published sentences false, and correcting them means new copy. The curated block sits above the grid instead, so the five names are on the page and every sentence stays true. **The consequence is that curated cross-category names are not in the vendor page's `FAQPage` JSON-LD** — the surface this issue was filed about. Getting them there needs the clause `in {category}` removed from that answer, which is your sentence to write, not mine.

**2. One sentence changed its input, not its words.** `/alternative-to`'s FAQ answer *"There are N free alternatives to X tracked on AgentDeals across the {categories} categor(y|ies)"* now takes the categories the rendered list actually spans, not the vendor's own. Same words; on `/alternative-to/postman` it now reads `Testing, API Development`. Without this the sentence is false on all 17 pages.

**3. The curated block is a new ranked surface and publishes its own seed.** `#1166`'s AC-7 guard caught it on the first run — a ranked list with no audit block. It now publishes `query_key: curated-alternatives:{vendor}`, its date, seed and tie_count, and a test recomputes the order through the shared module. I also widened that guard: it scanned only the *first* audit block on a page, so a page with two ranked lists could publish one seed and pass.

## Latent case reported rather than fixed

The exclusion sentence under the category grid reads *"Left out of this list: X (…). Each is still listed in {the subject's category}"*. If a curated name in **another** category is ever classified `local_dev_only` or `is_addon`, that sentence names the wrong category. Zero records hit this today — the only curated name carrying a `product_role` is MinIO, and `self_hosted` is not a gate. A test now fails the day one does, so the sentence gets fixed deliberately rather than going quietly false.

Also unchanged: `/criteria` describes the membership gates but says nothing about curation adding members. That is a paragraph of new copy and I have not written it.

## Verification

- **2,765 tests / 0 failures** (+34), `tsc --noEmit`, `validate-data` (1,580 offers / 444 changes) and `no-private-context` clean.
- **`mutate-1032-phase0.sh`: 21 mutations, 21 killed, no survivors, none by the compiler.** Two survived the first pass and both were real: a prefix-match fallback my fixtures were too short to distinguish from an exact match, and dropping the membership gate from the curated set — equivalent at today's data, so the gate moved into `curatedAlternativesFor()` where a constructed fixture can tell the two programs apart.
- **Route sweep of all 3,923 published paths against a `main` worktree**, baseline run twice: only `/health` and `/api/stats` are nondeterministic; of the remaining 3,921, exactly the 68 predicted pages move and no others.
- `check-mutation-targets` 524/524 across 40 scripts. Live MCP `initialize` → `tools/call` on `search_deals`. Screenshot of the block on `/vendor/postman`.
