### PR TITLE
Date a vendor Offer only from a change that ends it

### DIFF
--- a/scripts/mutate-1180.sh
+++ b/scripts/mutate-1180.sh
@@ -1,0 +1,227 @@
+#!/usr/bin/env bash
+set -u
+
+REPO="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$REPO" || exit 1
+
+SERVE="src/serve.ts"
+DATES="src/change-dates.ts"
+SUITE="test/offer-price-validity.test.ts"
+BACKUP_DIR="$(mktemp -d)"
+cp "$SERVE" "$BACKUP_DIR/serve.ts"
+cp "$DATES" "$BACKUP_DIR/change-dates.ts"
+cp "$SUITE" "$BACKUP_DIR/suite.ts"
+
+restore() {
+  cp "$BACKUP_DIR/serve.ts" "$SERVE"
+  cp "$BACKUP_DIR/change-dates.ts" "$DATES"
+  cp "$BACKUP_DIR/suite.ts" "$SUITE"
+}
+trap restore EXIT
+
+killed=0
+survived=0
+TESTS="test/offer-price-validity.test.ts"
+
+py() { python3 - "$@"; }
+
+run_mutation() {
+  local name="$1"
+  shift
+  echo "=== $name"
+  restore
+  "$@"
+  if diff -q "$BACKUP_DIR/serve.ts" "$SERVE" > /dev/null \
+    && diff -q "$BACKUP_DIR/change-dates.ts" "$DATES" > /dev/null \
+    && diff -q "$BACKUP_DIR/suite.ts" "$SUITE" > /dev/null; then
+    echo "    NOT APPLIED: the mutation changed no file, so it proves nothing"
+    survived=$((survived + 1))
+    return
+  fi
+  if ! npm run build > /tmp/mutate-1180-build.log 2>&1; then
+    echo "    NOT APPLIED: the mutation does not compile, so no test ran"
+    tail -3 /tmp/mutate-1180-build.log
+    survived=$((survived + 1))
+    return
+  fi
+  if timeout 900 node --test --test-concurrency 1 $TESTS > /tmp/mutate-1180-test.log 2>&1; then
+    echo "    SURVIVED"
+    survived=$((survived + 1))
+  else
+    echo "    KILLED: $(grep -c '✖ ' /tmp/mutate-1180-test.log) failing assertion(s)"
+    grep '✖ ' /tmp/mutate-1180-test.log | head -3
+    killed=$((killed + 1))
+  fi
+}
+
+m_the_field_goes_back_to_the_last_change_date() {
+  py <<'PY'
+p = "src/serve.ts"
+s = open(p).read()
+s = s.replace("...(offerExpiry ? { priceValidUntil: offerExpiry } : {}),",
+              "priceValidUntil: lastPricingChange ?? primary.verifiedDate,")
+open(p, "w").write(s)
+PY
+}
+
+m_the_field_falls_back_to_the_verified_date() {
+  py <<'PY'
+p = "src/serve.ts"
+s = open(p).read()
+s = s.replace("...(offerExpiry ? { priceValidUntil: offerExpiry } : {}),",
+              "priceValidUntil: offerExpiry ?? primary.verifiedDate,")
+open(p, "w").write(s)
+PY
+}
+
+m_the_expiry_is_computed_against_the_epoch() {
+  py <<'PY'
+p = "src/serve.ts"
+s = open(p).read()
+s = s.replace("const offerExpiry = offerExpiryAfter(vendorChanges, servedOn);",
+              'const offerExpiry = offerExpiryAfter(vendorChanges, "1970-01-01");')
+open(p, "w").write(s)
+PY
+}
+
+m_the_boundary_admits_a_change_dated_today() {
+  py <<'PY'
+p = "src/change-dates.ts"
+s = open(p).read()
+s = s.replace("if (!c.date || c.date <= onDate) continue;",
+              "if (!c.date || c.date < onDate) continue;")
+open(p, "w").write(s)
+PY
+}
+
+m_the_boundary_is_inverted() {
+  py <<'PY'
+p = "src/change-dates.ts"
+s = open(p).read()
+s = s.replace("if (!c.date || c.date <= onDate) continue;",
+              "if (!c.date || c.date >= onDate) continue;")
+open(p, "w").write(s)
+PY
+}
+
+m_the_latest_future_change_wins() {
+  py <<'PY'
+p = "src/change-dates.ts"
+s = open(p).read()
+s = s.replace("if (earliest === null || c.date < earliest) earliest = c.date;",
+              "if (earliest === null || c.date > earliest) earliest = c.date;")
+open(p, "w").write(s)
+PY
+}
+
+m_a_discovery_date_can_end_the_offer() {
+  py <<'PY'
+p = "src/change-dates.ts"
+s = open(p).read()
+s = s.replace("    if (!isEventDated(c)) continue;\n    if (!endsTheListedOffer(c)) continue;",
+              "    if (!endsTheListedOffer(c)) continue;")
+open(p, "w").write(s)
+PY
+}
+
+m_a_deprecation_of_another_product_ends_the_offer() {
+  py <<'PY'
+p = "src/change-dates.ts"
+s = open(p).read()
+s = s.replace("    if (!isEventDated(c)) continue;\n    if (!endsTheListedOffer(c)) continue;",
+              "    if (!isEventDated(c)) continue;")
+open(p, "w").write(s)
+PY
+}
+
+m_only_a_deprecation_can_end_the_offer() {
+  py <<'PY'
+p = "src/change-dates.ts"
+s = open(p).read()
+s = s.replace("  if (change.change_type !== PRODUCT_DEPRECATED) return true;",
+              "  if (change.change_type !== PRODUCT_DEPRECATED) return false;")
+open(p, "w").write(s)
+PY
+}
+
+m_a_deprecation_naming_the_vendor_alone_is_excluded() {
+  py <<'PY'
+p = "src/change-dates.ts"
+s = open(p).read()
+s = s.replace("  return deprecationEndsTheListedProduct(change);",
+              "  return !deprecationEndsTheListedProduct(change);")
+open(p, "w").write(s)
+PY
+}
+
+m_the_expiry_is_read_from_every_vendors_changes() {
+  py <<'PY'
+p = "src/serve.ts"
+s = open(p).read()
+s = s.replace("const offerExpiry = offerExpiryAfter(vendorChanges, servedOn);",
+              "const offerExpiry = offerExpiryAfter(allChanges, servedOn);")
+open(p, "w").write(s)
+PY
+}
+
+run_mutation_scoped() {
+  local name="$1"
+  local pattern="$2"
+  shift 2
+  echo "=== $name"
+  echo "    scoped to: $pattern"
+  restore
+  "$@"
+  if diff -q "$BACKUP_DIR/serve.ts" "$SERVE" > /dev/null \
+    && diff -q "$BACKUP_DIR/change-dates.ts" "$DATES" > /dev/null; then
+    echo "    NOT APPLIED: the mutation changed no file, so it proves nothing"
+    survived=$((survived + 1))
+    return
+  fi
+  if ! npm run build > /tmp/mutate-1180-build.log 2>&1; then
+    echo "    NOT APPLIED: the mutation does not compile, so no test ran"
+    tail -3 /tmp/mutate-1180-build.log
+    survived=$((survived + 1))
+    return
+  fi
+  if timeout 900 node --test --test-concurrency 1 --test-name-pattern "$pattern" $TESTS > /tmp/mutate-1180-test.log 2>&1; then
+    echo "    SURVIVED"
+    survived=$((survived + 1))
+  else
+    echo "    KILLED: $(grep -c '✖ ' /tmp/mutate-1180-test.log) failing assertion(s)"
+    grep '✖ ' /tmp/mutate-1180-test.log | head -3
+    killed=$((killed + 1))
+  fi
+}
+
+m_the_source_ratchet_accepts_any_count() {
+  py <<'PY'
+p = "src/serve.ts"
+s = open(p).read()
+s = s.replace("        ...(offerExpiry ? { priceValidUntil: offerExpiry } : {}),",
+              "        ...(offerExpiry ? { priceValidUntil: offerExpiry } : {}),\n        ...(offerExpiry ? { priceValidUntil: offerExpiry } : {}),")
+open(p, "w").write(s)
+PY
+}
+
+run_mutation "the field goes back to the date the price last changed" m_the_field_goes_back_to_the_last_change_date
+run_mutation "an absent expiry falls back to the date we last checked" m_the_field_falls_back_to_the_verified_date
+run_mutation "the expiry is computed against the epoch rather than the day of service" m_the_expiry_is_computed_against_the_epoch
+run_mutation "a change taking effect today is treated as still upcoming" m_the_boundary_admits_a_change_dated_today
+run_mutation "the boundary is inverted so only past changes can end the offer" m_the_boundary_is_inverted
+run_mutation "the last future change wins rather than the first" m_the_latest_future_change_wins
+run_mutation "a change dated by when we read the page can end the offer" m_a_discovery_date_can_end_the_offer
+run_mutation "a deprecation of a separately named product can end the offer" m_a_deprecation_of_another_product_ends_the_offer
+run_mutation "only a deprecation can end the offer" m_only_a_deprecation_can_end_the_offer
+run_mutation "a deprecation naming the vendor alone is the one kind excluded" m_a_deprecation_naming_the_vendor_alone_is_excluded
+run_mutation "the expiry is read from every vendor's changes rather than this one's" m_the_expiry_is_read_from_every_vendors_changes
+run_mutation_scoped "the field goes back to the date the price last changed, judged by the catalog sweep alone" "no vendor page publishes a price expiry that has already passed" m_the_field_goes_back_to_the_last_change_date
+run_mutation_scoped "an absent expiry falls back to the date we last checked, judged by the catalog sweep alone" "no vendor page publishes a price expiry that has already passed" m_the_field_falls_back_to_the_verified_date
+run_mutation "the field is emitted twice from the render source" m_the_source_ratchet_accepts_any_count
+
+restore
+npm run build > /dev/null 2>&1
+echo
+echo "killed: $killed"
+echo "survived: $survived"
+[ "$survived" -eq 0 ]

--- a/src/change-dates.ts
+++ b/src/change-dates.ts
@@ -1,6 +1,9 @@
 import type { DealChange, ChangeDateSource } from "./types.js";
+import { PRODUCT_DEPRECATED, deprecationEndsTheListedProduct } from "./product-deprecation.js";
 
 type DatedChange = Pick<DealChange, "date" | "date_source">;
+
+type ExpiringChange = Pick<DealChange, "date" | "date_source" | "change_type" | "vendor" | "summary">;
 
 export const DISCOVERED_DATE_PREFIX = "discovered";
 
@@ -102,6 +105,22 @@ export function feedEntryUpdated(day: string, now: Date = new Date()): string {
   const noon = Date.parse(`${day}T12:00:00Z`);
   if (Number.isNaN(noon)) return now.toISOString();
   return new Date(Math.min(noon, now.getTime())).toISOString();
+}
+
+export function endsTheListedOffer(change: ExpiringChange): boolean {
+  if (change.change_type !== PRODUCT_DEPRECATED) return true;
+  return deprecationEndsTheListedProduct(change);
+}
+
+export function offerExpiryAfter(changes: ExpiringChange[], onDate: string): string | null {
+  let earliest: string | null = null;
+  for (const c of changes) {
+    if (!c.date || c.date <= onDate) continue;
+    if (!isEventDated(c)) continue;
+    if (!endsTheListedOffer(c)) continue;
+    if (earliest === null || c.date < earliest) earliest = c.date;
+  }
+  return earliest;
 }
 
 export function latestEventDate(changes: DatedChange[], notAfter?: string): string | null {

--- a/src/serve.ts
+++ b/src/serve.ts
@@ -46,7 +46,7 @@ import { verificationLedger, QUARANTINE_AFTER_FAILURES } from "./verification-st
 import { partitionAlternatives, partitionAlternativesAcross, productRoleSentence, MEMBERSHIP_GATE_RULES, MEMBERSHIP_GATE_ORDER, MEMBERSHIP_GATE_SYMMETRY, MEMBERSHIP_GATE_SCOPE, MEMBERSHIP_GATE_CORRECTIONS } from "./product-role.js";
 import { resolveCuratedAlternatives, curatedAlternativesFor, addCuratedToPool } from "./curated-alternatives.js";
 import type { Agent, ChangeDateSource, DealChange, RiskCause, LinkUnreachable, Offer } from "./types.js";
-import { changeDateLabel, changeDateClause, changeDatePublished, changeEventStartDate, capListSections, latestEventDate, feedEntryUpdated, undatedGroupHeading, firstReadHeading, discoveryBatchNote, DISCOVERED_DATE_PREFIX, UNDATED_GROUP_NOTE } from "./change-dates.js";
+import { changeDateLabel, changeDateClause, changeDatePublished, changeEventStartDate, capListSections, latestEventDate, offerExpiryAfter, feedEntryUpdated, undatedGroupHeading, firstReadHeading, discoveryBatchNote, DISCOVERED_DATE_PREFIX, UNDATED_GROUP_NOTE } from "./change-dates.js";
 import { FEED_CORRECTIONS, correctionEntriesXml } from "./feed-corrections.js";
 import type { AgentBalance } from "./ledger.js";
 import type { SubmittedReferralCode } from "./referral-codes.js";
@@ -3654,7 +3654,8 @@ function buildVendorPage(slug: string): string | null {
     ? `  <p class="risk-cause-line" style="margin:.4rem 0 .6rem;font-size:.9rem;color:var(--text-muted)"><strong style="color:${riskColor}">Why ${riskLevel}:</strong> <span class="risk-cause-date" style="font-family:var(--mono)">${escHtmlServer(changeDateLabel(riskCause))}</span> &mdash; ${escHtmlServer(riskCause.summary)} <a href="#changes" style="white-space:nowrap">Full history &darr;</a></p>`
     : "";
 
-  const discontinuedOn = discontinuedOnOrBefore(vendorChanges, new Date().toISOString().slice(0, 10));
+  const servedOn = new Date().toISOString().slice(0, 10);
+  const discontinuedOn = discontinuedOnOrBefore(vendorChanges, servedOn);
 
   const linkUnreachable = enriched.link_unreachable;
   const h1RiskBadge = enriched.risk_level === null || (linkUnreachable && riskLevel === "stable")
@@ -3948,6 +3949,7 @@ ${allCompareLinks.join("\n")}
 
   const lastPricingChange = latestEventDate(vendorChanges);
   const lastUpdated = lastPricingChange && lastPricingChange > primary.verifiedDate ? lastPricingChange : primary.verifiedDate;
+  const offerExpiry = offerExpiryAfter(vendorChanges, servedOn);
 
   const watchlistSnippet = `curl -X POST ${BASE_URL}/api/watchlist \\
   -H "Content-Type: application/json" \\
@@ -4004,7 +4006,7 @@ ${allCompareLinks.join("\n")}
         price: "0",
         priceCurrency: "USD",
         description: primary.tier,
-        priceValidUntil: lastPricingChange ?? primary.verifiedDate,
+        ...(offerExpiry ? { priceValidUntil: offerExpiry } : {}),
       },
     },
   };

--- a/test/http.test.ts
+++ b/test/http.test.ts
@@ -1436,7 +1436,7 @@ describe("HTTP transport", () => {
     const response = await fetch(`http://localhost:${serverPort}/vendor/railway`);
     const html = await response.text();
     assert.ok(html.includes("dateModified"), "JSON-LD should include dateModified");
-    assert.ok(html.includes("priceValidUntil"), "JSON-LD should include priceValidUntil");
+    assert.ok(html.includes('"@type":"Offer"'), "JSON-LD should include an Offer");
   });
 
   it("GET /vendor/:slug includes watchlist CTA", async () => {

--- a/test/offer-price-validity.test.ts
+++ b/test/offer-price-validity.test.ts
@@ -1,0 +1,291 @@
+import { describe, it, before, after } from "node:test";
+import assert from "node:assert";
+import { spawn, type ChildProcess } from "node:child_process";
+import { readFileSync, writeFileSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO = path.join(__dirname, "..");
+
+const TODAY = new Date().toISOString().slice(0, 10);
+const dayOffset = (days: number) =>
+  new Date(Date.parse(TODAY) + days * 86400000).toISOString().slice(0, 10);
+
+interface ChangeSpec {
+  vendor: string;
+  date: string;
+  type: string;
+  source: string;
+  summary?: string;
+}
+
+const FIXTURE_VENDORS = [
+  "Aurorabase",
+  "Beaconstack",
+  "Cirruslane",
+  "Datumforge",
+  "Everglow",
+  "Foldergrid",
+  "Gustline",
+  "Halcyonio",
+];
+
+const FIXTURE_CHANGES: ChangeSpec[] = [
+  { vendor: "Aurorabase", date: dayOffset(21), type: "limits_reduced", source: "vendor_page" },
+  { vendor: "Beaconstack", date: dayOffset(45), type: "free_tier_removed", source: "hand_written" },
+  { vendor: "Beaconstack", date: dayOffset(12), type: "limits_reduced", source: "vendor_page" },
+  { vendor: "Beaconstack", date: dayOffset(-30), type: "pricing_restructured", source: "vendor_page" },
+  { vendor: "Cirruslane", date: dayOffset(-3), type: "limits_reduced", source: "vendor_page" },
+  { vendor: "Cirruslane", date: dayOffset(-400), type: "free_tier_removed", source: "hand_written" },
+  {
+    vendor: "Everglow",
+    date: dayOffset(18),
+    type: "product_deprecated",
+    source: "hand_written",
+    summary: "Everglow Meshpipe end of support. The mesh routing add-on is being retired.",
+  },
+  {
+    vendor: "Foldergrid",
+    date: dayOffset(26),
+    type: "product_deprecated",
+    source: "hand_written",
+    summary: "Foldergrid is shutting down. The whole service closes to all accounts.",
+  },
+  { vendor: "Gustline", date: dayOffset(9), type: "limits_reduced", source: "discovered" },
+  { vendor: "Halcyonio", date: TODAY, type: "limits_reduced", source: "vendor_page" },
+];
+
+const EXPECTED_EXPIRY: Record<string, string | null> = {
+  Aurorabase: dayOffset(21),
+  Beaconstack: dayOffset(12),
+  Cirruslane: null,
+  Datumforge: null,
+  Everglow: null,
+  Foldergrid: dayOffset(26),
+  Gustline: null,
+  Halcyonio: null,
+};
+
+function offer(vendor: string) {
+  return {
+    vendor,
+    category: "Databases",
+    description: `${vendor} publishes a free allowance of 10 GB storage and 1M reads per month.`,
+    tier: "Free",
+    url: `https://example.com/${vendor.toLowerCase()}/pricing`,
+    tags: ["database"],
+    verifiedDate: dayOffset(-11),
+  };
+}
+
+function change(spec: ChangeSpec) {
+  return {
+    vendor: spec.vendor,
+    change_type: spec.type,
+    date: spec.date,
+    date_source: spec.source,
+    summary: spec.summary ?? `${spec.vendor} changed the terms of its free allowance.`,
+    previous_state: "10 GB storage",
+    current_state: "2 GB storage",
+    impact: "medium",
+    source_url: `https://example.com/${spec.vendor.toLowerCase()}/pricing`,
+    category: "Databases",
+    alternatives: [],
+    recorded_date: TODAY,
+  };
+}
+
+function toSlug(name: string): string {
+  return name.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "");
+}
+
+function offerJsonLd(html: string): Record<string, any> | null {
+  const blocks = [...html.matchAll(/<script type="application\/ld\+json">([\s\S]*?)<\/script>/g)];
+  for (const block of blocks) {
+    let parsed: any;
+    try {
+      parsed = JSON.parse(block[1]);
+    } catch {
+      continue;
+    }
+    const offers = parsed?.mainEntity?.offers;
+    if (offers && offers["@type"] === "Offer") return offers;
+  }
+  return null;
+}
+
+function startServer(env: Record<string, string>): Promise<{ proc: ChildProcess; port: number }> {
+  return new Promise((resolve, reject) => {
+    const child = spawn("node", [path.join(REPO, "dist", "serve.js")], {
+      stdio: ["pipe", "pipe", "pipe"],
+      env: { ...process.env, PORT: "0", BASE_URL: "http://localhost:3000", ...env },
+    });
+    const timeout = setTimeout(() => {
+      child.kill();
+      reject(new Error("Server startup timeout"));
+    }, 30000);
+    child.stderr!.on("data", (data: Buffer) => {
+      const m = data.toString().match(/running on http:\/\/localhost:(\d+)/);
+      if (m) {
+        clearTimeout(timeout);
+        resolve({ proc: child, port: parseInt(m[1], 10) });
+      }
+    });
+    child.on("error", (err) => {
+      clearTimeout(timeout);
+      reject(err);
+    });
+  });
+}
+
+describe("a vendor page states a free tier's price expiry only when a dated change ends it", () => {
+  let tmp: string;
+  let proc: ChildProcess;
+  const pages = new Map<string, string>();
+
+  before(async () => {
+    tmp = mkdtempSync(path.join(tmpdir(), "offer-expiry-"));
+    const indexPath = path.join(tmp, "index.json");
+    const changesPath = path.join(tmp, "deal_changes.json");
+    writeFileSync(indexPath, JSON.stringify({ offers: FIXTURE_VENDORS.map(offer) }));
+    writeFileSync(changesPath, JSON.stringify({ changes: FIXTURE_CHANGES.map(change) }));
+    const started = await startServer({
+      AGENTDEALS_INDEX_PATH: indexPath,
+      AGENTDEALS_CHANGES_PATH: changesPath,
+    });
+    proc = started.proc;
+    for (const vendor of FIXTURE_VENDORS) {
+      const res = await fetch(`http://localhost:${started.port}/vendor/${toSlug(vendor)}`);
+      assert.strictEqual(res.status, 200, `/vendor/${toSlug(vendor)} did not render`);
+      pages.set(vendor, await res.text());
+    }
+  });
+
+  after(() => {
+    if (proc) proc.kill();
+    if (tmp) rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it("emits an Offer for every vendor, so the assertions below are about a rendered field", () => {
+    for (const vendor of FIXTURE_VENDORS) {
+      const offers = offerJsonLd(pages.get(vendor)!);
+      assert.ok(offers, `/vendor/${toSlug(vendor)} emitted no Offer in its JSON-LD`);
+      assert.strictEqual(offers!.price, "0");
+    }
+  });
+
+  it("carries the date of the soonest change that ends the offer", () => {
+    const dated = Object.entries(EXPECTED_EXPIRY).filter(([, date]) => date !== null);
+    assert.ok(dated.length >= 2, "fewer than two vendors expect a date, so a missing field could pass this suite");
+    for (const [vendor, expected] of dated) {
+      const offers = offerJsonLd(pages.get(vendor)!)!;
+      assert.strictEqual(
+        offers.priceValidUntil,
+        expected,
+        `/vendor/${toSlug(vendor)} published priceValidUntil ${offers.priceValidUntil ?? "(absent)"}`
+      );
+    }
+  });
+
+  it("omits the field when no future change ends the offer", () => {
+    for (const [vendor, expected] of Object.entries(EXPECTED_EXPIRY)) {
+      if (expected !== null) continue;
+      const offers = offerJsonLd(pages.get(vendor)!)!;
+      assert.ok(
+        !("priceValidUntil" in offers),
+        `/vendor/${toSlug(vendor)} published priceValidUntil ${offers.priceValidUntil}`
+      );
+    }
+  });
+
+  it("prefers the first of several future changes over the last", () => {
+    const beaconstack = offerJsonLd(pages.get("Beaconstack")!)!;
+    assert.strictEqual(
+      beaconstack.priceValidUntil,
+      dayOffset(12),
+      `Beaconstack has changes at ${dayOffset(12)} and ${dayOffset(45)} and published ${beaconstack.priceValidUntil}`
+    );
+  });
+
+  it("does not date the offer from a deprecation of a separately named product", () => {
+    const everglow = offerJsonLd(pages.get("Everglow")!)!;
+    assert.ok(
+      !("priceValidUntil" in everglow),
+      `Everglow's free tier was dated ${everglow.priceValidUntil} by the retirement of Everglow Meshpipe`
+    );
+    const foldergrid = offerJsonLd(pages.get("Foldergrid")!)!;
+    assert.strictEqual(
+      foldergrid.priceValidUntil,
+      dayOffset(26),
+      "a deprecation naming the vendor itself did not date the offer"
+    );
+  });
+
+  it("treats a change taking effect today as one that has already happened", () => {
+    const halcyonio = offerJsonLd(pages.get("Halcyonio")!)!;
+    assert.ok(
+      !("priceValidUntil" in halcyonio),
+      `Halcyonio's change takes effect on ${TODAY} and the offer was dated ${halcyonio.priceValidUntil}`
+    );
+  });
+
+  it("does not date the offer from a change carrying a discovery date", () => {
+    const gustline = offerJsonLd(pages.get("Gustline")!)!;
+    assert.ok(
+      !("priceValidUntil" in gustline),
+      `Gustline's offer was dated ${gustline.priceValidUntil} from a change whose date records when we read the page`
+    );
+  });
+});
+
+describe("no vendor page publishes a price expiry that has already passed", () => {
+  let proc: ChildProcess;
+  let port = 0;
+  let slugs: string[] = [];
+
+  before(async () => {
+    const offers = JSON.parse(readFileSync(path.join(REPO, "data", "index.json"), "utf8")).offers;
+    slugs = [...new Set<string>(offers.map((o: { vendor: string }) => toSlug(o.vendor)))];
+    const started = await startServer({});
+    proc = started.proc;
+    port = started.port;
+  });
+
+  after(() => {
+    if (proc) proc.kill();
+  });
+
+  it("serves an expiry no earlier than the day the page was built, on every vendor page", async () => {
+    assert.ok(slugs.length > 1000, `only ${slugs.length} vendor pages were checked`);
+    const expired: string[] = [];
+    let present = 0;
+    for (const slug of slugs) {
+      const html = await (await fetch(`http://localhost:${port}/vendor/${slug}`)).text();
+      const offers = offerJsonLd(html);
+      assert.ok(offers, `/vendor/${slug} emitted no Offer in its JSON-LD`);
+      const until = offers!.priceValidUntil;
+      if (until === undefined) continue;
+      present++;
+      if (until < TODAY) expired.push(`${slug} ${until}`);
+    }
+    assert.deepStrictEqual(
+      expired.slice(0, 10),
+      [],
+      `${expired.length} of ${slugs.length} vendor pages publish an expiry earlier than ${TODAY}, and ${present} carry the field at all`
+    );
+  });
+});
+
+describe("the vendor page is the only surface that dates an Offer", () => {
+  it("finds priceValidUntil at one emission point in the render source", () => {
+    const source = readFileSync(path.join(REPO, "src", "serve.ts"), "utf8");
+    const emissions = source.match(/priceValidUntil/g) ?? [];
+    assert.strictEqual(
+      emissions.length,
+      1,
+      `priceValidUntil is written at ${emissions.length} places in serve.ts; each one needs the same bound`
+    );
+  });
+});


### PR DESCRIPTION
Refs #1180

`priceValidUntil` held the date the price last *changed*. schema.org defines it as the date after which the price is no longer available — the opposite end of the same interval. Reproduced against `data/index.json` and `data/deal_changes.json` on 2026-08-30: **1,570 of 1,572 vendor pages past-dated, 0 today, 2 in the future**. Staleness of the 1,570: 840 within 30 days, 589 at 31–90, 117 at 91–180, 19 at 181–365, 5 over a year. Longest 628 days.

Current production, read through the canonical-host redirect: `/vendor/vercel` `2026-02-01`, `/vendor/railway` `2025-10-01`.

## The change

`offerExpiryAfter(vendorChanges, servedOn)` in `src/change-dates.ts` returns the **earliest** future change date for the vendor, or `null`. The property is spread into the `Offer` only when it is non-null, so it is absent rather than substituted.

Three exclusions, in order of how much they matter:

1. **A deprecation naming a product apart from the vendor does not end the offer.** This is the AWS case and it is why AC-2 taken literally would have published something false. AWS's two future records are App Mesh (2026-09-30) and Proton (2026-10-07); the offer we publish for AWS is the always-free tier — Lambda 1M invocations, DynamoDB 25 GB, CloudWatch. Neither retirement ends it. `deprecationEndsTheListedProduct` already answers exactly this question for the *past* case: it is what decides whether a `product_deprecated` record makes `/vendor/aws` say "Discontinued". If a past App Mesh retirement does not discontinue AWS, a future one should not expire its price. `endsTheListedOffer` is the one call site to flip if you want the literal reading of AC-2 — that would set `/vendor/aws` to 2026-09-30 and take the population to 2.
2. **A change dated by discovery does not end the offer.** `date_source: discovered` records when we read the page, not when anything takes effect. No such record is future-dated today, so this is inert; it stops a data bug from repopulating the field with a non-event date.
3. **A change taking effect today has already happened.** `c.date <= onDate`, matching the `hasAlreadyTakenEffect` partition the home page uses.

## AC-4: the honest population is 1

| | main | this branch |
|---|---|---|
| pages carrying `priceValidUntil` | 1,572 | **1** |
| of those, already expired | 1,570 | **0** |

The one is **`/vendor/deepgram` → `2026-09-12`**, from a `new_free_tier` record whose summary reads "Flux TTS is free until September 12, 2026" — a stated end of validity, which is the case the property exists for.

`/vendor/aws` would be the second under the literal reading. Named above with the one-line flip.

## AC-5: still one emission point

`priceValidUntil` is written at exactly one place in `src/serve.ts`. Nine other `Offer` emissions carry no date. A test asserts the count, so a second emission has to be a deliberate edit.

## Verification

- **2,774 tests / 0 failures** (+9). `tsc --noEmit`, `validate-data` (1,580 offers / 444 changes) and `no-private-context` clean. `check-mutation-targets` 536/536 across 41 scripts.
- **`scripts/mutate-1180.sh`: 14 mutations, 14 killed, no survivors, none by the compiler.** Two are scoped to the catalog sweep alone, so the sweep is shown to catch a reverted implementation without the fixture suite standing in for it.
- **Sweep of all 3,928 published paths against a `main` worktree.** 2,355 byte-identical, 0 status changes. 1,571 vendor pages are **exactly 31 bytes shorter** — the removed `,"priceValidUntil":"YYYY-MM-DD"`, confirmed as the only textual difference by byte-diffing `/vendor/vercel` and `/vendor/aws`. `/vendor/deepgram` is byte-identical. The remaining two, `/api/signals` and `/api/stats`, differ only in the worktree path they echo and in live counters.
- Local MCP `initialize` → `tools/call` on `search_deals`, and a screenshot of `/vendor/vercel`.

## The test

`test/offer-price-validity.test.ts` renders vendor pages and reads the JSON-LD, never the expression.

- Eight fixture vendors served from a temporary index and change file. Three expect a date (including one whose two future changes must resolve to the earlier), five expect the field absent for a different reason each: past changes only, no changes at all, a deprecation of a separately named product, a discovery-dated change, and a change taking effect today.
- A sweep of all 1,572 real vendor pages asserting no expiry earlier than the day the page was built.

**The positive control is in the fixture suite, not the sweep, and that is deliberate.** A real-data control has to name a vendor and a date; the only one available is Deepgram's 2026-09-12, which stops being future on 2026-09-13 and would take the suite red for a reason unrelated to the code. The fixture control is dated relative to the day it runs and cannot rot.

Against a `main` build the new file fails 6 of its 9 tests; the two that pass on both are the precondition that an `Offer` is emitted at all and the single-emission-point count.

## One test changed

`test/http.test.ts` asserted `/vendor/railway` includes `priceValidUntil`. Railway has no known expiry, so that assertion pinned the defect. It now asserts the `Offer` is emitted, which is what the surrounding test was checking.

## Reported, not fixed

A vendor whose product was discontinued in the past still emits an active `Offer` at `price: "0"` while the page above it reads "Discontinued". `discontinuedOn` is computed on that page and the JSON-LD does not consult it. Out of scope here — AC-1 forbids a past date in this field, so an expiry is not the remedy — but it is the same disagreement between the page and its structured data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)