### PR TITLE
Remove the comments that ship inside template literals

### DIFF
--- a/scripts/mutate-1177.sh
+++ b/scripts/mutate-1177.sh
@@ -1,0 +1,186 @@
+#!/usr/bin/env bash
+set -u
+
+REPO="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$REPO" || exit 1
+
+SERVE="src/serve.ts"
+APPS="src/mcp-apps.ts"
+SUITE="test/served-comments.test.ts"
+BACKUP_DIR="$(mktemp -d)"
+cp "$SERVE" "$BACKUP_DIR/serve.ts"
+cp "$APPS" "$BACKUP_DIR/mcp-apps.ts"
+cp "$SUITE" "$BACKUP_DIR/suite.ts"
+
+restore() {
+  cp "$BACKUP_DIR/serve.ts" "$SERVE"
+  cp "$BACKUP_DIR/mcp-apps.ts" "$APPS"
+  cp "$BACKUP_DIR/suite.ts" "$SUITE"
+}
+trap restore EXIT
+
+killed=0
+survived=0
+TESTS="test/served-comments.test.ts"
+
+py() { python3 - "$@"; }
+
+run_mutation() {
+  local name="$1"
+  shift
+  echo "=== $name"
+  restore
+  "$@"
+  if diff -q "$BACKUP_DIR/serve.ts" "$SERVE" > /dev/null \
+    && diff -q "$BACKUP_DIR/mcp-apps.ts" "$APPS" > /dev/null \
+    && diff -q "$BACKUP_DIR/suite.ts" "$SUITE" > /dev/null; then
+    echo "    NOT APPLIED: the mutation changed no file, so it proves nothing"
+    survived=$((survived + 1))
+    return
+  fi
+  if ! npm run build > /tmp/mutate-1177-build.log 2>&1; then
+    echo "    NOT APPLIED: the mutation does not compile, so no test ran"
+    tail -3 /tmp/mutate-1177-build.log
+    survived=$((survived + 1))
+    return
+  fi
+  if timeout 900 node --test --test-concurrency 1 $TESTS > /tmp/mutate-1177-test.log 2>&1; then
+    echo "    SURVIVED"
+    survived=$((survived + 1))
+  else
+    echo "    KILLED: $(grep -c '✖ ' /tmp/mutate-1177-test.log) failing assertion(s)"
+    grep '✖ ' /tmp/mutate-1177-test.log | head -3
+    killed=$((killed + 1))
+  fi
+}
+
+m_a_css_comment_returns_to_the_home_page() {
+  py <<'PY'
+p = "src/serve.ts"
+s = open(p).read()
+s = s.replace(".hero{text-align:center;padding:5rem 0 3rem}",
+              "/* Hero */\n.hero{text-align:center;padding:5rem 0 3rem}")
+open(p, "w").write(s)
+PY
+}
+
+m_a_line_comment_returns_to_a_script_block() {
+  py <<'PY'
+p = "src/serve.ts"
+s = open(p).read()
+s = s.replace("      var newUrl = window.location.pathname + '?s=' + encodeURIComponent(services.join(','));",
+              "      // Update URL\n      var newUrl = window.location.pathname + '?s=' + encodeURIComponent(services.join(','));")
+open(p, "w").write(s)
+PY
+}
+
+m_a_block_comment_returns_to_a_script_block() {
+  py <<'PY'
+p = "src/serve.ts"
+s = open(p).read()
+s = s.replace("      var newUrl = window.location.pathname + '?s=' + encodeURIComponent(services.join(','));",
+              "      /* Update URL */\n      var newUrl = window.location.pathname + '?s=' + encodeURIComponent(services.join(','));")
+open(p, "w").write(s)
+PY
+}
+
+m_a_comment_returns_to_the_concatenated_script() {
+  py <<'PY'
+p = "src/serve.ts"
+s = open(p).read()
+s = s.replace("    + '    var cost = v.starter;\\n'",
+              "    + '    // use starter tier cost as baseline\\n'\n    + '    var cost = v.starter;\\n'")
+open(p, "w").write(s)
+PY
+}
+
+m_a_trailing_comment_returns_to_the_concatenated_script() {
+  py <<'PY'
+p = "src/serve.ts"
+s = open(p).read()
+s = s.replace("    + '    var cost = v.starter;\\n'",
+              "    + '    var cost = v.starter; // use starter tier cost as baseline\\n'")
+open(p, "w").write(s)
+PY
+}
+
+m_a_comment_returns_to_the_apps_module() {
+  py <<'PY'
+p = "src/mcp-apps.ts"
+s = open(p).read()
+s = s.replace("  if (Array.isArray(data) && data[0]?.name && data[0]?.count !== undefined) {",
+              "  // Category list mode\n  if (Array.isArray(data) && data[0]?.name && data[0]?.count !== undefined) {")
+open(p, "w").write(s)
+PY
+}
+
+m_the_scan_covers_the_whole_page_rather_than_its_markup_blocks() {
+  py <<'PY'
+p = "test/served-comments.test.ts"
+s = open(p).read()
+s = s.replace("""function commentsInServedHtml(html: string): string[] {
+  const found: string[] = [];""",
+              """function commentsInServedHtml(html: string): string[] {
+  const found: string[] = commentsIn(html, true);""")
+open(p, "w").write(s)
+PY
+}
+
+m_the_route_sample_narrows_to_the_home_page() {
+  py <<'PY'
+p = "test/served-comments.test.ts"
+s = open(p).read()
+s = s.replace('  const routes = new Set<string>(["/"]);',
+              '  const routes = new Set<string>(["/"]);\n  if (routes.size) return [...routes];')
+open(p, "w").write(s)
+PY
+}
+
+m_a_comment_returns_to_an_apps_template_literal() {
+  py <<'PY'
+p = "src/mcp-apps.ts"
+s = open(p).read()
+s = s.replace("  if (mode === \"estimate\" && (data.services || data.costs)) {",
+              "  // Estimate mode\n  if (mode === \"estimate\" && (data.services || data.costs)) {")
+open(p, "w").write(s)
+PY
+}
+
+m_a_comment_returns_after_a_nested_template_literal() {
+  py <<'PY'
+p = "src/mcp-apps.ts"
+s = open(p).read()
+s = s.replace("  const results = data.results || [];",
+              "  // Search results mode\n  const results = data.results || [];")
+open(p, "w").write(s)
+PY
+}
+
+m_the_app_resource_list_is_empty() {
+  py <<'PY'
+p = "test/served-comments.test.ts"
+s = open(p).read()
+s = s.replace("        .filter((uri) => uri.startsWith(\"ui://\"));",
+              "        .filter((uri) => uri.startsWith(\"ui://\"))\n        .slice(0, 0);")
+open(p, "w").write(s)
+PY
+}
+
+run_mutation "a css comment returns to the home page" m_a_css_comment_returns_to_the_home_page
+run_mutation "a line comment returns to a script block" m_a_line_comment_returns_to_a_script_block
+run_mutation "a block comment returns to a script block" m_a_block_comment_returns_to_a_script_block
+run_mutation "a comment returns to the script built by string concatenation" m_a_comment_returns_to_the_concatenated_script
+run_mutation "a trailing comment returns to the script built by string concatenation" m_a_trailing_comment_returns_to_the_concatenated_script
+run_mutation "a comment returns to the apps module" m_a_comment_returns_to_the_apps_module
+run_mutation "the scan covers the whole page rather than its style and script blocks" m_the_scan_covers_the_whole_page_rather_than_its_markup_blocks
+run_mutation "the route sample narrows to the home page" m_the_route_sample_narrows_to_the_home_page
+run_mutation "a comment returns to a template literal inside an apps script block" m_a_comment_returns_to_an_apps_template_literal
+run_mutation "a comment returns to a position that follows a nested template literal" m_a_comment_returns_after_a_nested_template_literal
+run_mutation "the app resource list is empty" m_the_app_resource_list_is_empty
+
+restore
+npm run build > /dev/null 2>&1
+echo
+echo "killed: $killed"
+echo "survived: $survived"
+[ "$survived" -eq 0 ]

--- a/src/mcp-apps.ts
+++ b/src/mcp-apps.ts
@@ -81,7 +81,6 @@ function render(args, data) {
   const el = document.getElementById("app");
   if (!data) { el.innerHTML = '<div class="empty">Loading...</div>'; return; }
 
-  // Category list mode
   if (Array.isArray(data) && data[0]?.name && data[0]?.count !== undefined) {
     const total = data.reduce((s, c) => s + c.count, 0);
     el.innerHTML = \`
@@ -96,7 +95,6 @@ function render(args, data) {
     return;
   }
 
-  // Single vendor detail mode
   if (data.vendor && !data.results) {
     const stability = data.stability || "unknown";
     const stabBadge = stability === "stable" ? "badge-green" : stability === "watch" ? "badge-yellow" : stability === "volatile" ? "badge-red" : "badge-gray";
@@ -123,7 +121,6 @@ function render(args, data) {
     return;
   }
 
-  // Search results mode
   const results = data.results || [];
   const total = data.total || results.length;
   el.innerHTML = \`
@@ -168,7 +165,6 @@ function render(args, data) {
   if (!data) { el.innerHTML = '<div class="empty">Loading...</div>'; return; }
   const mode = args.mode || "recommend";
 
-  // Recommend mode
   if (mode === "recommend" && data.recommendations) {
     const recs = data.recommendations || [];
     el.innerHTML = \`
@@ -189,7 +185,6 @@ function render(args, data) {
     return;
   }
 
-  // Estimate mode
   if (mode === "estimate" && (data.services || data.costs)) {
     const services = data.services || data.costs || [];
     const total = data.total_monthly || services.reduce((s, v) => s + (v.monthly_cost || 0), 0);
@@ -216,7 +211,6 @@ function render(args, data) {
     return;
   }
 
-  // Audit mode
   if (mode === "audit") {
     const risks = data.risks || data.risk_flags || [];
     const gaps = data.gaps || data.coverage_gaps || [];
@@ -247,7 +241,6 @@ function render(args, data) {
     return;
   }
 
-  // Fallback: render raw data
   el.innerHTML = \`<div class="card"><h2>Stack Analysis</h2><pre style="font-size:12px;color:#94a3b8;overflow-x:auto;white-space:pre-wrap">\${esc(JSON.stringify(data, null, 2))}</pre></div>\`;
 }
 
@@ -273,13 +266,10 @@ function render(args, data) {
   const el = document.getElementById("app");
   if (!data) { el.innerHTML = '<div class="empty">Loading...</div>'; return; }
 
-  // Single vendor risk check
   if (data.risk_level || data.stability) {
     const vendor = data.vendor || (args.vendors && args.vendors[0]) || "Vendor";
     let risk = data.risk_level || data.stability || "unknown";
     const cause = data.risk_cause || null;
-    // #1038: caution/risky are negative claims about a named company. They
-    // render only alongside the dated record that produced them.
     const showRisk = risk === "stable" || risk === "low" || risk === "unknown" || !!cause;
     if (!showRisk) risk = "unknown";
     const riskBadge = risk === "stable" || risk === "low" ? "badge-green" : risk === "watch" || risk === "medium" ? "badge-yellow" : risk === "unknown" ? "badge-gray" : "badge-red";
@@ -305,7 +295,6 @@ function render(args, data) {
     return;
   }
 
-  // Two-vendor comparison
   const vendorA = data.vendor_a || data.vendors?.[0] || {};
   const vendorB = data.vendor_b || data.vendors?.[1] || {};
   const nameA = vendorA.vendor || vendorA.name || (args.vendors && args.vendors[0]) || "Vendor A";
@@ -384,14 +373,12 @@ function render(args, data) {
   const el = document.getElementById("app");
   if (!data) { el.innerHTML = '<div class="empty">Loading...</div>'; return; }
 
-  // Detect personalized vs standard response
   const isPersonalized = Array.isArray(data.your_stack_changes);
   const changes = isPersonalized ? data.your_stack_changes : (data.deal_changes || data.changes || []);
   const advisory = isPersonalized ? (data.advisory || []) : [];
   const summary = isPersonalized ? data.summary : null;
   const expiring = data.expiring_deals || data.expiring || [];
 
-  // Categorize changes
   const removals = changes.filter(c => c.change_type === "free_tier_removed" || c.change_type === "open_source_killed" || c.change_type === "product_deprecated");
   const reductions = changes.filter(c => c.change_type === "limits_reduced" || c.change_type === "restriction");
   const positive = changes.filter(c => c.change_type === "limits_increased" || c.change_type === "new_free_tier" || c.change_type === "startup_program_expanded");
@@ -479,7 +466,6 @@ function render(args, data) {
     <div class="link-row"><a href="${BASE_URL}/pricing-changes" target="_blank">Full changelog on agentdeals.dev \\u2192</a></div>
   \`;
 
-  // Wire up filter buttons
   el.querySelectorAll(".filter-btn").forEach(btn => {
     btn.addEventListener("click", () => {
       el.querySelectorAll(".filter-btn").forEach(b => b.classList.remove("active"));
@@ -488,7 +474,6 @@ function render(args, data) {
     });
   });
 
-  // Wire up advisory toggle
   const advisoryEl = document.getElementById("advisory-section");
   if (advisoryEl) {
     advisoryEl.querySelector("h3").addEventListener("click", () => {

--- a/src/serve.ts
+++ b/src/serve.ts
@@ -175,7 +175,6 @@ const swaggerDocsHtml = `<!DOCTYPE html>
     *, *:before, *:after { box-sizing: inherit; }
     body { margin: 0; background: #0f172a; color: #f1f5f9; }
     .topbar { display: none; }
-    /* Dark theme overrides matching landing page */
     .swagger-ui { background: #0f172a; }
     .swagger-ui .opblock-tag { color: #f1f5f9; border-bottom-color: #334155; }
     .swagger-ui .opblock-tag:hover { background: rgba(59,130,246,0.05); }
@@ -223,7 +222,6 @@ const swaggerDocsHtml = `<!DOCTYPE html>
     .swagger-ui .opblock-body pre.microlight { background: #1e293b !important; color: #f1f5f9; border: 1px solid #334155; }
     .swagger-ui .response-control-media-type__accept-message { color: #3b82f6; }
     .swagger-ui .loading-container .loading::after { color: #3b82f6; }
-    /* Back link */
     .back-link { display: block; padding: 12px 20px; background: #1e293b; border-bottom: 1px solid #334155; font-family: 'Inter', sans-serif; font-size: 14px; }
     .back-link a { color: #3b82f6; text-decoration: none; }
     .back-link a:hover { text-decoration: underline; }
@@ -46288,7 +46286,6 @@ function buildStackCheckPage(): string {
     a:hover{text-decoration:underline}
     .subtitle{color:var(--text-muted);font-size:1rem;margin-bottom:1.5rem}
 
-    /* Input section */
     .input-section{background:var(--bg-elevated);border:1px solid var(--border);border-radius:12px;padding:1.5rem;margin:1.5rem 0}
     .input-row{display:flex;gap:.75rem;margin-bottom:1rem}
     .input-row input{flex:1;background:var(--bg);color:var(--text);border:1px solid var(--border);border-radius:8px;padding:.75rem 1rem;font-size:.95rem;font-family:var(--sans)}
@@ -46298,13 +46295,11 @@ function buildStackCheckPage(): string {
     .btn-primary:hover{opacity:.9}
     .btn-primary:disabled{opacity:.5;cursor:not-allowed}
 
-    /* Preset stacks */
     .presets{display:flex;flex-wrap:wrap;gap:.5rem;margin-top:.5rem}
     .presets label{font-size:.8rem;color:var(--text-muted);margin-bottom:.25rem;display:block;width:100%}
     .preset-btn{background:var(--bg);color:var(--text-muted);border:1px solid var(--border);border-radius:6px;padding:.4rem .8rem;font-size:.8rem;font-family:var(--sans);cursor:pointer;transition:all .15s}
     .preset-btn:hover{border-color:var(--accent);color:var(--accent)}
 
-    /* Health grade */
     .grade-section{text-align:center;padding:2rem 1.5rem;background:var(--bg-elevated);border:1px solid var(--border);border-radius:12px;margin:1.5rem 0}
     .grade-badge{display:inline-flex;align-items:center;justify-content:center;width:80px;height:80px;border-radius:50%;font-size:2.5rem;font-weight:800;font-family:var(--serif);margin-bottom:.75rem}
     .grade-A{background:rgba(63,185,80,.15);color:var(--green);border:3px solid var(--green)}
@@ -46315,7 +46310,6 @@ function buildStackCheckPage(): string {
     .grade-label{font-size:1rem;color:var(--text);font-weight:600;margin-bottom:.25rem}
     .grade-desc{font-size:.85rem;color:var(--text-muted)}
 
-    /* Risk summary */
     .risk-summary{display:grid;grid-template-columns:repeat(3,1fr);gap:.75rem;margin:1.5rem 0}
     .risk-stat{text-align:center;padding:1rem;background:var(--bg-elevated);border:1px solid var(--border);border-radius:10px}
     .risk-stat .count{font-size:1.8rem;font-weight:700}
@@ -46324,7 +46318,6 @@ function buildStackCheckPage(): string {
     .risk-moderate .count{color:var(--yellow)}
     .risk-high .count{color:var(--red)}
 
-    /* Service cards */
     .service-cards{display:grid;gap:.75rem;margin:1.5rem 0}
     .service-card{background:var(--bg-elevated);border:1px solid var(--border);border-radius:10px;padding:1.25rem;transition:border-color .15s}
     .service-card:hover{border-color:var(--accent)}
@@ -46350,7 +46343,6 @@ function buildStackCheckPage(): string {
     .card-not-found{opacity:.7}
     .card-suggestions{font-size:.8rem;color:var(--text-dim);margin-top:.25rem}
 
-    /* Gaps & recommendations */
     .recs-section{background:var(--bg-elevated);border:1px solid var(--border);border-radius:12px;padding:1.25rem;margin:1.5rem 0}
     .rec-item{font-size:.85rem;color:var(--text-muted);padding:.5rem 0;border-bottom:1px solid var(--border)}
     .rec-item:last-child{border-bottom:none}
@@ -46359,25 +46351,21 @@ function buildStackCheckPage(): string {
     .gap-cat{font-weight:600;color:var(--text);min-width:100px}
     .gap-rec{color:var(--text-muted)}
 
-    /* Share bar */
     .share-bar{display:flex;align-items:center;gap:.75rem;margin:1.5rem 0;padding:.75rem 1rem;background:var(--bg-elevated);border:1px solid var(--border);border-radius:10px}
     .share-url{flex:1;font-family:var(--mono);font-size:.8rem;color:var(--text-dim);overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
     .share-btn{background:var(--accent);color:#fff;border:none;padding:.5rem 1rem;border-radius:6px;font-size:.8rem;font-family:var(--sans);cursor:pointer;font-weight:600;white-space:nowrap;transition:all .15s}
     .share-btn:hover{opacity:.9}
     .share-btn.copied{background:var(--green)}
 
-    /* FAQ */
     .faq-section{margin:2rem 0}
     .faq-item{border-bottom:1px solid var(--border);padding:1rem 0}
     .faq-q{font-weight:600;color:var(--text);font-size:.95rem;margin-bottom:.25rem}
     .faq-a{color:var(--text-muted);font-size:.85rem;line-height:1.6}
 
-    /* Related links */
     .related-links{display:flex;flex-wrap:wrap;gap:.5rem;margin:1.5rem 0}
     .related-link{font-size:.8rem;color:var(--accent);background:var(--bg-elevated);border:1px solid var(--border);border-radius:6px;padding:.4rem .8rem;text-decoration:none;transition:all .15s}
     .related-link:hover{border-color:var(--accent);text-decoration:none}
 
-    /* Loading state */
     .loading{text-align:center;padding:2rem;color:var(--text-muted)}
     .loading .spinner{display:inline-block;width:20px;height:20px;border:2px solid var(--border);border-top-color:var(--accent);border-radius:50%;animation:spin .6s linear infinite;margin-right:.5rem;vertical-align:middle}
     @keyframes spin{to{transform:rotate(360deg)}}
@@ -46478,7 +46466,6 @@ function buildStackCheckPage(): string {
       var services = input.split(',').map(function(s) { return s.trim(); }).filter(Boolean);
       if (services.length === 0) return;
 
-      // Update URL
       var newUrl = window.location.pathname + '?s=' + encodeURIComponent(services.join(','));
       history.replaceState(null, '', newUrl);
 
@@ -46501,7 +46488,6 @@ function buildStackCheckPage(): string {
       document.getElementById('results').style.display = 'block';
       document.getElementById('check-btn').disabled = false;
 
-      // Compute health grade
       var riskCounts = { stable: 0, caution: 0, risky: 0, not_found: 0 };
       var totalFound = 0;
       for (var i = 0; i < data.services.length; i++) {
@@ -46532,18 +46518,15 @@ function buildStackCheckPage(): string {
         '<div class="grade-label">' + gradeLabel + '</div>' +
         '<div class="grade-desc">' + gradeDesc + '</div>';
 
-      // Share URL
       var shareUrl = window.location.origin + '/stack-check?s=' + encodeURIComponent(inputServices.join(','));
       document.getElementById('share-url').textContent = shareUrl;
       document.getElementById('share-bar').style.display = 'flex';
 
-      // Risk summary
       document.getElementById('risk-summary').innerHTML =
         '<div class="risk-stat risk-low"><div class="count">' + riskCounts.stable + '</div><div class="label">Stable</div></div>' +
         '<div class="risk-stat risk-moderate"><div class="count">' + riskCounts.caution + '</div><div class="label">Caution</div></div>' +
         '<div class="risk-stat risk-high"><div class="count">' + riskCounts.risky + '</div><div class="label">High Risk</div></div>';
 
-      // Service cards
       var cardsHtml = '';
       var negTypes = ['free_tier_removed','limits_reduced','restriction','product_deprecated','open_source_killed','pricing_model_change','pricing_restructured'];
       var posTypes = ['limits_increased','new_free_tier','startup_program_expanded','pricing_postponed'];
@@ -46560,7 +46543,6 @@ function buildStackCheckPage(): string {
         }
         var rl = svc.risk_level || 'stable';
         var rc = svc.risk_cause || null;
-        // #1038: a warning renders only with its dated cause.
         if (rl !== 'stable' && !rc) rl = 'stable';
         var slug = toSlug(svc.vendor);
         cardsHtml += '<div class="service-card"><div class="card-header"><span class="card-vendor"><a href="/vendor/' + esc(slug) + '">' + esc(svc.vendor) + '</a></span>';
@@ -46587,7 +46569,6 @@ function buildStackCheckPage(): string {
       }
       document.getElementById('service-cards').innerHTML = cardsHtml;
 
-      // Gaps
       if (data.gaps && data.gaps.length > 0) {
         document.getElementById('gaps-section').style.display = 'block';
         var gapsHtml = '';
@@ -46601,7 +46582,6 @@ function buildStackCheckPage(): string {
         document.getElementById('gaps-section').style.display = 'none';
       }
 
-      // Recommendations
       if (data.recommendations && data.recommendations.length > 0) {
         document.getElementById('recs-section').style.display = 'block';
         var recsHtml = '';
@@ -46634,7 +46614,6 @@ function buildStackCheckPage(): string {
       });
     }
 
-    // Auto-check if URL has ?s= parameter
     (function() {
       var params = new URLSearchParams(window.location.search);
       var s = params.get('s');
@@ -46848,11 +46827,9 @@ ${globalNavCss()}
 
     if (!a && !b) { results.innerHTML = ''; shareBar.style.display = 'none'; return; }
 
-    // Single-vendor mode
     if (a && !b) { fetchSingle(a); return; }
     if (b && !a) { fetchSingle(b); return; }
 
-    // Update URL
     var params = new URLSearchParams();
     params.set('a', a); params.set('b', b);
     history.replaceState(null, '', '/compare-tool?' + params.toString());
@@ -46899,7 +46876,6 @@ ${globalNavCss()}
   }
 
   function riskBadge(level, cause) {
-    // #1038: caution/risky render only with the dated record behind them.
     if (level !== 'stable' && !cause) return '';
     var cls = level === 'stable' ? 'badge-stable' : level === 'caution' ? 'badge-caution' : 'badge-risky';
     var badge = '<span class="badge ' + cls + '">' + level + '</span>';
@@ -46947,14 +46923,12 @@ ${globalNavCss()}
     html += renderVendorCard(b);
     html += '</div>';
 
-    // Category match info
     if (data.shared_categories) {
       html += '<p style="margin-top:1rem;font-size:.85rem;color:var(--text-muted)">Both vendors are in the <strong>' + escHtml(data.category_overlap[0]) + '</strong> category — direct competitors.</p>';
     } else {
       html += '<p style="margin-top:1rem;font-size:.85rem;color:var(--text-muted)">Cross-category comparison: <strong>' + escHtml(a.category) + '</strong> vs <strong>' + escHtml(b.category) + '</strong>.</p>';
     }
 
-    // Links to related pages
     html += '<div style="margin-top:1rem;font-size:.85rem;display:flex;gap:1rem;flex-wrap:wrap">';
     html += '<a href="/compare">Browse all comparisons</a>';
     html += '<a href="/category/' + toSlug(a.category) + '">' + escHtml(a.category) + ' category</a>';
@@ -47006,7 +46980,6 @@ ${globalNavCss()}
     }
   }
 
-  // Auto-load from URL params
   (function() {
     var params = new URLSearchParams(window.location.search);
     var a = params.get('a');
@@ -47264,7 +47237,6 @@ function buildEstimatePage(): string {
           + '<td class="notes-col">' + v.notes + '</td>'
           + '</tr>');
 
-        // Check for cheaper alternatives at the highest paid tier
         var bestTier = v.scale > 0 ? 'scale' : v.growth > 0 ? 'growth' : v.starter > 0 ? 'starter' : null;
         if (bestTier) {
           var alt = findCheaperAlt(catId, slug, bestTier);
@@ -47306,7 +47278,6 @@ function buildEstimatePage(): string {
       });
     }
 
-    // Load from URL params on page load
     (function() {
       var params = new URLSearchParams(window.location.search);
       var hasAny = false;
@@ -47583,7 +47554,6 @@ function buildBudgetBuilderPage(): string {
     + '  else { selectedCategories.add(catId); }\n'
     + '  var btn = document.querySelector(".cat-toggle[data-cat=\'" + catId + "\']");\n'
     + '  if (btn) btn.classList.toggle("active", selectedCategories.has(catId));\n'
-    + '  // Clear project preset active state if manually changed\n'
     + '  document.querySelectorAll(".project-preset").forEach(function(b) { b.classList.remove("active"); });\n'
     + '  updateBuildBtn();\n'
     + '}\n'
@@ -47610,15 +47580,13 @@ function buildBudgetBuilderPage(): string {
     + 'function recommendVendor(catId, budget) {\n'
     + '  var vendors = CATEGORY_VENDORS[catId] || [];\n'
     + '  if (vendors.length === 0) return null;\n'
-    + '  // Score each vendor: lower cost + lower risk = better\n'
     + '  var scored = vendors.map(function(v) {\n'
-    + '    var cost = v.starter; // use starter tier cost as baseline\n'
+    + '    var cost = v.starter;\n'
     + '    if (budget === 0) {\n'
-    + '      // For $0 budget, only consider free tiers\n'
     + '      cost = 0;\n'
     + '    }\n'
     + '    var riskPenalty = v.risk_cause ? (v.risk_level === "risky" ? 100 : v.risk_level === "caution" ? 30 : 0) : 0;\n'
-    + '    var score = cost + riskPenalty - (v.free !== "" && cost === 0 ? 50 : 0); // bonus for free tier\n'
+    + '    var score = cost + riskPenalty - (v.free !== "" && cost === 0 ? 50 : 0);\n'
     + '    return { vendor: v, cost: cost, score: score };\n'
     + '  });\n'
     + '  scored.sort(function(a, b) { return a.score - b.score; });\n'
@@ -47633,7 +47601,7 @@ function buildBudgetBuilderPage(): string {
     + '  var riskCounts = { stable: 0, caution: 0, risky: 0 };\n'
     + '  var stackHtml = "";\n'
     + '  var catKeys = Array.from(selectedCategories);\n'
-    + '  var paidEquivalent = 0; // Estimate what these services would cost at paid tier\n'
+    + '  var paidEquivalent = 0;\n'
     + '\n'
     + '  catKeys.forEach(function(catId) {\n'
     + '    var rec = recommendVendor(catId, selectedBudget);\n'
@@ -47641,9 +47609,8 @@ function buildBudgetBuilderPage(): string {
     + '    var cost = selectedBudget === 0 ? 0 : rec.starter;\n'
     + '    totalCost += cost;\n'
     + '    if (riskCounts[rec.risk_level] !== undefined) riskCounts[rec.risk_level]++;\n'
-    + '    paidEquivalent += rec.growth > 0 ? rec.growth : rec.starter > 0 ? rec.starter : 25; // estimate paid value\n'
+    + '    paidEquivalent += rec.growth > 0 ? rec.growth : rec.starter > 0 ? rec.starter : 25;\n'
     + '\n'
-    + '    // Get alternatives (next 2 vendors)\n'
     + '    var vendors = CATEGORY_VENDORS[catId] || [];\n'
     + '    var alts = vendors.filter(function(v) { return v.slug !== rec.slug; }).slice(0, 2);\n'
     + '\n'
@@ -47672,7 +47639,6 @@ function buildBudgetBuilderPage(): string {
     + '\n'
     + '  document.getElementById("stack-cards").innerHTML = stackHtml;\n'
     + '\n'
-    + '  // Budget bar\n'
     + '  var budgetMax = Math.max(selectedBudget, totalCost, 1);\n'
     + '  var pct = Math.min(100, (totalCost / budgetMax) * 100);\n'
     + '  var barColor = totalCost <= selectedBudget || selectedBudget === 0 ? "var(--green)" : "var(--red)";\n'
@@ -47683,7 +47649,6 @@ function buildBudgetBuilderPage(): string {
     + '  var barLabel = document.getElementById("budget-bar-label");\n'
     + '  barLabel.textContent = selectedBudget === 0 ? "Free tier only" : "of $" + selectedBudget + "/mo budget";\n'
     + '\n'
-    + '  // Summary cards\n'
     + '  var totalServices = catKeys.length;\n'
     + '  var freeCount = 0;\n'
     + '  catKeys.forEach(function(catId) {\n'
@@ -47697,7 +47662,6 @@ function buildBudgetBuilderPage(): string {
     + '    <div class="summary-card"><div class="value">\' + (totalServices - freeCount) + \'</div><div class="label">Paid Services</div></div>\n'
     + '  \';\n'
     + '\n'
-    + '  // Savings callout\n'
     + '  var savings = paidEquivalent - totalCost;\n'
     + '  if (savings > 0) {\n'
     + '    document.getElementById("savings-callout").style.display = "block";\n'
@@ -47706,7 +47670,6 @@ function buildBudgetBuilderPage(): string {
     + '    document.getElementById("savings-callout").style.display = "none";\n'
     + '  }\n'
     + '\n'
-    + '  // Risk summary\n'
     + '  var total = riskCounts.stable + riskCounts.caution + riskCounts.risky;\n'
     + '  var riskHtml = \'<h3>Stack Risk Assessment</h3>\';\n'
     + '  riskHtml += \'<div class="risk-meter">\';\n'
@@ -47718,7 +47681,6 @@ function buildBudgetBuilderPage(): string {
     + '  if (riskCounts.risky > 0) riskHtml += \'<p style="color:var(--red);font-size:.85rem;margin-top:.25rem">&#x26a0; \' + riskCounts.risky + \' service(s) have removed a free tier or changed an open-source licence in the last 12 months. Consider alternatives.</p>\';\n'
     + '  document.getElementById("risk-summary").innerHTML = riskHtml;\n'
     + '\n'
-    + '  // Shareable URL\n'
     + '  var shareUrl = window.location.origin + "/budget-builder?budget=" + selectedBudget + "&categories=" + Array.from(selectedCategories).join(",");\n'
     + '  document.getElementById("share-url").textContent = shareUrl;\n'
     + '  document.getElementById("share-bar").style.display = "flex";\n'
@@ -47735,7 +47697,6 @@ function buildBudgetBuilderPage(): string {
     + '  });\n'
     + '}\n'
     + '\n'
-    + '// Auto-load from URL params\n'
     + '(function() {\n'
     + '  var params = new URLSearchParams(window.location.search);\n'
     + '  var budget = params.get("budget");\n'
@@ -48777,12 +48738,10 @@ ${undatedSorted.map(c => buildChangeEntry(c)).join("\n")}
       }
     });
     document.getElementById('pc-visible-count').textContent = visible;
-    // Hide empty month groups
     document.querySelectorAll('.month-group').forEach(function(g) {
       var visEntries = g.querySelectorAll('.pc-entry:not([style*="display: none"])');
       g.style.display = visEntries.length > 0 ? '' : 'none';
     });
-    // Hide upcoming section entries too
     var upSection = document.querySelector('.upcoming-section');
     if (upSection) {
       var upVis = upSection.querySelectorAll('.pc-entry:not([style*="display: none"])');
@@ -48827,7 +48786,6 @@ ${undatedSorted.map(c => buildChangeEntry(c)).join("\n")}
       applyFilters();
     });
   }
-  // Highlight anchor on load
   if (window.location.hash) {
     var target = document.getElementById(window.location.hash.slice(1));
     if (target) {
@@ -51794,7 +51752,6 @@ a:hover{color:var(--accent-hover);text-decoration:underline}
 .container{max-width:960px;margin:0 auto;padding:0 1.5rem;position:relative;z-index:1}
 .accent-bar{width:100%;height:4px;background:linear-gradient(90deg,#3b82f6,#8b5cf6);position:fixed;top:0;left:0;z-index:100}
 
-/* Hero */
 .hero{text-align:center;padding:5rem 0 3rem}
 .hero-label{display:inline-block;font-family:var(--mono);font-size:.75rem;font-weight:500;color:var(--accent);text-transform:uppercase;letter-spacing:.15em;border:1px solid var(--border);border-radius:20px;padding:.35rem 1rem;margin-bottom:1.5rem;background:var(--accent-glow)}
 .hero h1{font-family:var(--sans);font-size:3.5rem;color:var(--text);line-height:1.1;margin-bottom:1rem;letter-spacing:-.02em;font-weight:700}
@@ -51806,7 +51763,6 @@ a:hover{color:var(--accent-hover);text-decoration:underline}
 .btn-secondary{display:inline-flex;align-items:center;gap:.5rem;padding:.75rem 1.75rem;background:transparent;color:var(--text);border-radius:8px;font-size:.95rem;font-weight:500;transition:all .2s;border:1px solid var(--border)}
 .btn-secondary:hover{border-color:var(--accent);color:var(--accent);text-decoration:none}
 
-/* Stats bar */
 .stats-bar{display:grid;grid-template-columns:repeat(4,1fr);border:1px solid var(--border);border-radius:12px;overflow:hidden;margin:0 auto 4rem;max-width:640px;background:var(--bg-card);backdrop-filter:blur(12px)}
 .stat-item{text-align:center;padding:1.25rem 1rem;position:relative}
 .stat-item+.stat-item::before{content:'';position:absolute;left:0;top:20%;height:60%;width:1px;background:var(--border)}
@@ -51815,22 +51771,18 @@ a:hover{color:var(--accent-hover);text-decoration:underline}
 .stat-num.stat-cyan{color:var(--accent-cyan)}
 .stat-label{font-size:.75rem;color:var(--text-dim);text-transform:uppercase;letter-spacing:.1em;margin-top:.15rem}
 
-/* Section divider */
 .divider{width:100%;height:1px;background:var(--border);margin:0}
 .wavy-divider{width:100%;overflow:hidden;line-height:0;margin:0}
 .wavy-divider svg{display:block;width:100%;height:40px}
 
-/* Sections */
 .section{padding:4rem 0}
 .section-label{font-family:var(--mono);font-size:.7rem;font-weight:500;color:var(--accent);text-transform:uppercase;letter-spacing:.2em;margin-bottom:.75rem}
 .section h2{font-family:var(--sans);font-size:2rem;color:var(--text);margin-bottom:1rem;letter-spacing:-.01em;font-weight:700}
 .section p{color:var(--text-muted);margin-bottom:1rem;max-width:600px}
 
-/* Problem / solution */
 .problem-text{font-family:var(--sans);font-size:1.35rem;color:var(--text-muted);line-height:1.6;max-width:600px;margin-bottom:1rem}
 .problem-text strong{color:var(--text)}
 
-/* How it works cards */
 .how-grid{display:grid;grid-template-columns:repeat(3,1fr);gap:1rem;margin-top:2rem}
 .how-card{background:var(--bg-card);backdrop-filter:blur(12px);border:1px solid var(--border);border-radius:12px;padding:1.5rem;transition:border-color .2s}
 .how-card:hover{border-color:var(--accent)}
@@ -51840,7 +51792,6 @@ a:hover{color:var(--accent-hover);text-decoration:underline}
 .how-card pre{background:var(--bg);border:1px solid var(--border);border-radius:8px;padding:.75rem;font-size:.75rem;color:var(--text-muted);line-height:1.5;overflow-x:auto}
 .how-card code{font-family:var(--mono);font-size:.75rem}
 
-/* Changes */
 .change-entry{padding:.75rem 0;border-bottom:1px solid rgba(51,65,85,0.6)}
 .change-entry:last-child{border-bottom:none}
 .change-header{display:flex;align-items:center;gap:.5rem;flex-wrap:wrap;margin-bottom:.2rem}
@@ -51851,7 +51802,6 @@ a:hover{color:var(--accent-hover);text-decoration:underline}
 .see-all-link{display:inline-flex;align-items:center;gap:.3rem;margin-top:1rem;font-size:.85rem;font-family:var(--mono);color:var(--accent);text-decoration:none;padding:.5rem 0}
 .see-all-link:hover{color:var(--accent-hover);text-decoration:underline}
 
-/* Recent Changes Section */
 .rc-list{display:flex;flex-direction:column;gap:.5rem;margin-top:1rem}
 .rc-entry{padding:.75rem 1rem;border:1px solid var(--border);border-radius:8px;background:var(--bg-card);transition:border-color .2s}
 .rc-entry:hover{border-color:var(--accent)}
@@ -51861,7 +51811,6 @@ a:hover{color:var(--accent-hover);text-decoration:underline}
 .rc-date{font-family:var(--mono);color:var(--text-dim);font-size:.75rem;margin-left:auto}
 .rc-summary{color:var(--text-muted);font-size:.85rem}
 
-/* Deadlines */
 .deadlines-section{background:linear-gradient(180deg,rgba(248,81,73,0.04) 0%,transparent 100%);border:1px solid rgba(248,81,73,0.15);border-radius:12px;padding:1.5rem;margin-bottom:2rem}
 .deadline-item{display:flex;gap:1rem;padding:.75rem 0;border-bottom:1px solid rgba(51,65,85,0.6);align-items:flex-start}
 .deadline-item:last-child{border-bottom:none}
@@ -51875,7 +51824,6 @@ a:hover{color:var(--accent-hover);text-decoration:underline}
 .deadline-header{display:flex;align-items:center;gap:.5rem;flex-wrap:wrap;margin-bottom:.2rem}
 .deadline-date{font-family:var(--mono);color:var(--text-dim);font-size:.75rem;margin-left:auto}
 
-/* Changing Soon */
 .cs-list{display:flex;flex-direction:column;gap:0}
 .cs-entry{display:flex;gap:1rem;padding:.75rem 0;border-bottom:1px solid rgba(51,65,85,0.6);align-items:flex-start}
 .cs-entry:last-child{border-bottom:none}
@@ -51889,7 +51837,6 @@ a:hover{color:var(--accent-hover);text-decoration:underline}
 .cs-rel{font-family:var(--mono);color:var(--text-dim);font-size:.75rem;margin-left:auto}
 .cs-summary{color:var(--text-muted);font-size:.85rem;line-height:1.4}
 
-/* Browse */
 .browse-controls{margin-bottom:1.25rem}
 .search-input{width:100%;padding:.75rem 1rem;background:var(--bg-elevated);border:1px solid var(--border);border-radius:10px;color:var(--text);font-family:var(--sans);font-size:.9rem;outline:none;transition:border-color .2s}
 .search-input:focus{border-color:var(--accent);box-shadow:0 0 0 3px var(--accent-glow)}
@@ -51912,7 +51859,6 @@ a:hover{color:var(--accent-hover);text-decoration:underline}
 .show-more:hover{border-color:var(--accent);background:var(--accent-glow)}
 .browse-status{color:var(--text-dim);font-size:.8rem;margin-top:.5rem;font-family:var(--mono)}
 
-/* Connect */
 .connect-block{background:var(--bg-card);backdrop-filter:blur(12px);border:1px solid var(--border);border-radius:12px;padding:1.5rem;margin-top:1.5rem}
 .connect-block pre{background:var(--bg);border:1px solid var(--border);border-radius:8px;padding:1rem;overflow-x:auto;font-size:.8rem;color:var(--text-muted);line-height:1.5;margin-top:.75rem;position:relative}
 .connect-block code{font-family:var(--mono)}
@@ -51932,13 +51878,11 @@ a:hover{color:var(--accent-hover);text-decoration:underline}
 .transport-content{display:none}
 .transport-content.active{display:block}
 
-/* Badges row */
 .badges{display:flex;gap:1rem;flex-wrap:wrap;margin-top:1.5rem}
 .badge{display:inline-flex;align-items:center;gap:.5rem;padding:.5rem 1rem;border:1px solid var(--border);border-radius:10px;color:var(--text-muted);font-size:.85rem;transition:all .2s}
 .badge:hover{border-color:var(--accent);color:var(--text);text-decoration:none}
 .badge-dot{width:6px;height:6px;border-radius:50%;background:var(--accent)}
 
-/* Stack builder */
 .sb-form{display:flex;gap:.75rem;margin-top:1.5rem}
 .sb-input{flex:1;padding:.75rem 1rem;background:var(--bg);border:1px solid var(--border);border-radius:8px;color:var(--text);font-size:.95rem;font-family:var(--sans);outline:none;transition:border-color .2s}
 .sb-input:focus{border-color:var(--accent)}
@@ -51972,11 +51916,9 @@ a:hover{color:var(--accent-hover);text-decoration:underline}
 .sb-cta p{max-width:none;margin:0 auto .5rem;text-align:center;font-size:.9rem;color:var(--text-muted)}
 .sb-cta a{font-family:var(--mono);font-size:.85rem}
 
-/* Footer */
 footer{text-align:center;color:var(--text-dim);font-size:.8rem;padding:3rem 0 2rem;border-top:1px solid var(--border);margin-top:3rem}
 footer a{color:var(--text-muted)}
 
-/* Responsive */
 @media(max-width:768px){
   .hero{padding:3rem 0 2rem}
   .hero h1{font-size:2.25rem}
@@ -52331,7 +52273,6 @@ ${buildRecentChangesSection()}
   <footer>AgentDeals &mdash; open source, built for agents | <a href="/developers">REST API</a> | <a href="/privacy">Privacy</a> | <a href="/press">Press</a> | <a href="/disclosure">Affiliate Disclosure</a></footer>
 </div>
 <script>
-/* Client tab switching */
 (function(){
   var tabs=document.querySelectorAll('.client-tab');
   var panels=document.querySelectorAll('.client-panel');
@@ -52344,7 +52285,6 @@ ${buildRecentChangesSection()}
       if(panel)panel.classList.add('active');
     });
   });
-  /* Transport toggle within each panel */
   document.querySelectorAll('.transport-toggle').forEach(function(toggle){
     var block=toggle.closest('.connect-block');
     toggle.querySelectorAll('.transport-btn').forEach(function(btn){
@@ -52357,7 +52297,6 @@ ${buildRecentChangesSection()}
     });
   });
 })();
-/* Copy config button */
 function copyConfig(btn){
   var code=btn.parentElement.querySelector('code');
   if(!code)return;

--- a/test/served-comments.test.ts
+++ b/test/served-comments.test.ts
@@ -1,0 +1,242 @@
+import { describe, it, before, after } from "node:test";
+import assert from "node:assert";
+import { spawn, type ChildProcess } from "node:child_process";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+let server: ChildProcess;
+let base = "";
+
+function startServer(): Promise<ChildProcess> {
+  return new Promise((resolve, reject) => {
+    const serverPath = path.join(__dirname, "..", "dist", "serve.js");
+    const proc = spawn("node", [serverPath], {
+      stdio: ["pipe", "pipe", "pipe"],
+      env: { ...process.env, PORT: "0", BASE_URL: "http://localhost" },
+    });
+    const timeout = setTimeout(() => {
+      proc.kill();
+      reject(new Error("Server startup timeout"));
+    }, 15000);
+    proc.stderr!.on("data", (data: Buffer) => {
+      const match = data.toString().match(/running on http:\/\/localhost:(\d+)/);
+      if (match) {
+        base = `http://localhost:${match[1]}`;
+        clearTimeout(timeout);
+        resolve(proc);
+      }
+    });
+    proc.on("error", (err) => {
+      clearTimeout(timeout);
+      reject(err);
+    });
+  });
+}
+
+type Region = { start: number; end: number; tag: string };
+
+function regions(html: string, openPattern: string, closeTag: string): Region[] {
+  const found: Region[] = [];
+  const re = new RegExp(openPattern, "g");
+  let match: RegExpExecArray | null;
+  while ((match = re.exec(html)) !== null) {
+    const start = match.index + match[0].length;
+    const end = html.indexOf(closeTag, start);
+    if (end === -1) break;
+    found.push({ start, end, tag: match[0] });
+    re.lastIndex = end;
+  }
+  return found;
+}
+
+function commentsIn(source: string, isJavaScript: boolean): string[] {
+  const found: string[] = [];
+  const stack: string[] = [isJavaScript ? "code" : "css"];
+  let i = 0;
+  let prev = "";
+  while (i < source.length) {
+    const state = stack[stack.length - 1];
+    const c = source[i];
+    const n = source[i + 1];
+
+    if (state === "template") {
+      if (c === "\\") { i += 2; continue; }
+      if (c === "`") { stack.pop(); i++; prev = "`"; continue; }
+      if (c === "$" && n === "{") { stack.push("code"); i += 2; prev = "{"; continue; }
+      i++;
+      continue;
+    }
+
+    if (c === '"' || c === "'") {
+      const quote = c;
+      i++;
+      while (i < source.length) {
+        if (source[i] === "\\") { i += 2; continue; }
+        if (source[i] === quote) { i++; break; }
+        i++;
+      }
+      prev = "s";
+      continue;
+    }
+    if (state === "code" && c === "`") { stack.push("template"); i++; continue; }
+    if (state === "code" && c === "}" && stack.length > 1) { stack.pop(); i++; prev = "}"; continue; }
+    if (state === "code" && c === "/" && n === "/") {
+      let end = source.indexOf("\n", i);
+      if (end === -1) end = source.length;
+      found.push(source.slice(i, end).trim());
+      i = end;
+      continue;
+    }
+    if (c === "/" && n === "*") {
+      let end = source.indexOf("*/", i + 2);
+      end = end === -1 ? source.length : end + 2;
+      found.push(source.slice(i, end).trim());
+      i = end;
+      continue;
+    }
+    if (state === "code" && c === "/" && !/[\w$)\]]$/.test(prev)) {
+      let j = i + 1;
+      let inClass = false;
+      let closed = false;
+      while (j < source.length) {
+        const d = source[j];
+        if (d === "\\") { j += 2; continue; }
+        if (d === "[") inClass = true;
+        else if (d === "]") inClass = false;
+        else if (d === "/" && !inClass) { closed = true; break; }
+        else if (d === "\n") break;
+        j++;
+      }
+      if (closed) { i = j + 1; prev = "r"; continue; }
+    }
+    if (!/\s/.test(c)) prev = c;
+    i++;
+  }
+  return found;
+}
+
+function commentsInServedHtml(html: string): string[] {
+  const found: string[] = [];
+  for (const r of regions(html, "<style[^>]*>", "</style>")) {
+    found.push(...commentsIn(html.slice(r.start, r.end), false));
+  }
+  for (const r of regions(html, "<script[^>]*>", "</script>")) {
+    found.push(...commentsIn(html.slice(r.start, r.end), true));
+  }
+  return found;
+}
+
+async function locs(sitemap: string): Promise<string[]> {
+  const body = await (await fetch(`${base}${sitemap}`)).text();
+  return [...body.matchAll(/<loc>([^<]+)<\/loc>/g)].map(
+    (m) => m[1].replace(/^https?:\/\/[^/]+/, "") || "/",
+  );
+}
+
+async function sampledRoutes(): Promise<string[]> {
+  const routes = new Set<string>(["/"]);
+  for (const p of await locs("/sitemap-misc.xml")) routes.add(p);
+  for (const p of await locs("/sitemap-reports.xml")) routes.add(p);
+  for (const p of (await locs("/sitemap-pages.xml")).slice(0, 80)) routes.add(p);
+  for (const p of (await locs("/sitemap-vendors.xml")).slice(0, 5)) routes.add(p);
+  for (const p of (await locs("/sitemap-comparisons.xml")).slice(0, 5)) routes.add(p);
+  return [...routes].filter((p) => !p.endsWith(".xml"));
+}
+
+describe("served html", () => {
+  before(async () => {
+    server = await startServer();
+  });
+  after(() => {
+    server?.kill();
+  });
+
+  it("carries no comments in its style or script blocks", async () => {
+    const routes = await sampledRoutes();
+    assert.ok(routes.length > 100, `expected a broad sample, got ${routes.length}`);
+
+    const offenders: string[] = [];
+    for (const route of routes) {
+      const response = await fetch(`${base}${route}`);
+      if (!response.ok) continue;
+      const found = commentsInServedHtml(await response.text());
+      for (const c of found.slice(0, 3)) offenders.push(`${route}: ${c.slice(0, 80)}`);
+    }
+
+    assert.deepStrictEqual(offenders, []);
+  });
+
+  it("keeps comment-shaped text that is page content rather than markup", async () => {
+    const html = await (await fetch(`${base}/`)).text();
+    assert.ok(html.includes("// Local (recommended)"));
+    assert.deepStrictEqual(commentsInServedHtml(html), []);
+  });
+});
+
+function mcpRequest(proc: ChildProcess, request: object): Promise<any> {
+  return new Promise((resolve, reject) => {
+    const timeout = setTimeout(() => reject(new Error("MCP request timeout")), 15000);
+    let buffer = "";
+    const onData = (data: Buffer) => {
+      buffer += data.toString();
+      for (const line of buffer.split("\n")) {
+        if (!line.trim()) continue;
+        try {
+          const parsed = JSON.parse(line.trim());
+          clearTimeout(timeout);
+          proc.stdout!.off("data", onData);
+          resolve(parsed);
+          return;
+        } catch {
+          continue;
+        }
+      }
+    };
+    proc.stdout!.on("data", onData);
+    proc.stdin!.write(JSON.stringify(request) + "\n");
+  });
+}
+
+describe("mcp app resources", () => {
+  it("carry no comments in their style or script blocks", async () => {
+    const serverPath = path.join(__dirname, "..", "dist", "index.js");
+    const proc = spawn("node", [serverPath], { stdio: ["pipe", "pipe", "pipe"] });
+    try {
+      await mcpRequest(proc, {
+        jsonrpc: "2.0", id: 1, method: "initialize",
+        params: {
+          protocolVersion: "2024-11-05",
+          capabilities: {},
+          clientInfo: { name: "test", version: "0.0.1" },
+        },
+      });
+      proc.stdin!.write(JSON.stringify({ jsonrpc: "2.0", method: "notifications/initialized" }) + "\n");
+
+      const listed = await mcpRequest(proc, {
+        jsonrpc: "2.0", id: 2, method: "resources/list", params: {},
+      });
+      const uris = (listed.result.resources as { uri: string }[])
+        .map((r) => r.uri)
+        .filter((uri) => uri.startsWith("ui://"));
+      assert.ok(uris.length >= 4, `expected ui:// resources, got ${uris.length}`);
+
+      const offenders: string[] = [];
+      let id = 3;
+      for (const uri of uris) {
+        const read = await mcpRequest(proc, {
+          jsonrpc: "2.0", id: id++, method: "resources/read", params: { uri },
+        });
+        for (const content of read.result.contents as { text?: string }[]) {
+          for (const c of commentsInServedHtml(content.text ?? "").slice(0, 3)) {
+            offenders.push(`${uri}: ${c.slice(0, 80)}`);
+          }
+        }
+      }
+      assert.deepStrictEqual(offenders, []);
+    } finally {
+      proc.kill();
+    }
+  });
+});


### PR DESCRIPTION
Refs https://github.com/robhunter/agentdeals/issues/1177

The earlier sweep removed 3,287 comments through the TypeScript parser, which was the right tool for the source but blind to the one place comments actually reach a reader. Inside a template literal a comment is string content, not a comment node, so the AST never sees it — and those are exactly the comments that get emitted into browser `<style>` and `<script>` blocks and sent over the wire on every request.

## Removed

| File | Comments |
|---|---|
| `src/serve.ts` | 65 |
| `src/mcp-apps.ts` | 15 |
| **Total** | **80** |

The issue's count was 67. The extra 13 are in `/budget-builder`, where the browser script is assembled by concatenating quoted strings — `+ '  // Budget bar\n'` — so the comments live inside string literals in the source and no scan of the source as TypeScript can see them either.

## What was shipping

| Surface | Before | After |
|---|---|---|
| HTTP pages (3,915 scanned) | 65 comments on 7 pages | **0** |
| `ui://` MCP app resources (4) | 15 comments | **0** |

19 of the 65 were on the home page.

## Verification

- **3,915 paths compared against a `main` build.** 3,908 byte-identical, 0 errors. The 7 that differ are the 7 that carried comments, and every differing line is accounted for: 61 whole-line removals and 4 lines where only a trailing comment was stripped, which is 65 — the exact count found on `main`.
- **Source is clean** under a scanner that tracks `${}` interpolation depth, across all tracked `.ts`/`.js`/`.mjs`/`.cjs`. Shell and YAML remain clean.
- `tsc`, `lint`, `validate` (1,580 offers, 444 changes), `no-private-context` 9/9, `check-mutation-targets` 547/547.
- **`scripts/mutate-1177.sh`: 11/11 killed, 0 survived.**
- Real MCP `initialize` → `tools/call` over HTTP returns results.
- Suite: 2,777 tests, 2,774 pass. See the note on CI below.

## The guard

`test/served-comments.test.ts` asserts on the rendered artifact rather than the source, which is what the issue is actually about. It fails against a `main` build and passes here.

Two things it has to get right, both proven by mutation:

**It reads only `<style>` and `<script>` bodies.** The home page serves an MCP configuration sample inside `<pre><code>` whose first line is `// Local (recommended)`. That is page content a reader is meant to see, not markup, and a check of the shape "no served line begins with `//`" would delete it. Widening the scan to the whole page is a mutation, and it is killed.

**It tracks `${}` depth.** A scanner that pairs backticks naively desynchronises on a nested template literal and goes blind to whatever follows. That blindness hid 4 comments in `src/mcp-apps.ts` from my own first pass — they were only found by reading the assembled resource back over MCP. Reintroducing a comment in that position is a mutation, and it is killed.

Coverage is a 232-route sample plus the 4 app resources; the sample asserts its own breadth, and narrowing it to one page is a killed mutation.

## CI

The `Tests` job will be red on this PR, for a reason that predates it. Three tests in `test/weekly-window-provenance.test.ts` require the current week to contain a discovery batch. The week rolled over at 00:00 UTC today and is empty, so the precondition cannot hold. The same 3 fail identically on `main` — 25 tests, 22 pass, 3 fail on both — and they are unrelated to anything here. Written up with a diagnosis and a suggested shape in https://github.com/robhunter/agentdeals/issues/1184.

## Found while verifying, not fixed here

`/budget-builder` ships a script block that cannot parse, so the entire 22.5 KB page application is dead and has been since the page was added on 2026-04-08. Filed as https://github.com/robhunter/agentdeals/issues/1185 with the cause, browser evidence and a blast-radius sweep — 1 unparseable block out of 7,668 across the site.