### PR TITLE
Select the week a discovery-batch guard needs instead of pinning it to the current week

### DIFF
--- a/scripts/mutate-1184.sh
+++ b/scripts/mutate-1184.sh
@@ -1,0 +1,160 @@
+#!/usr/bin/env bash
+set -u
+
+REPO="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$REPO" || exit 1
+
+DATA="src/data.ts"
+SERVE="src/serve.ts"
+SUITE="test/weekly-window-provenance.test.ts"
+BACKUP_DIR="$(mktemp -d)"
+cp "$DATA" "$BACKUP_DIR/data.ts"
+cp "$SERVE" "$BACKUP_DIR/serve.ts"
+cp "$SUITE" "$BACKUP_DIR/suite.ts"
+
+restore() {
+  cp "$BACKUP_DIR/data.ts" "$DATA"
+  cp "$BACKUP_DIR/serve.ts" "$SERVE"
+  cp "$BACKUP_DIR/suite.ts" "$SUITE"
+}
+trap restore EXIT
+
+killed=0
+survived=0
+TESTS="test/weekly-window-provenance.test.ts"
+
+py() { python3 - "$@"; }
+
+run_mutation() {
+  local name="$1"
+  shift
+  echo "=== $name"
+  restore
+  "$@"
+  if diff -q "$BACKUP_DIR/data.ts" "$DATA" > /dev/null \
+    && diff -q "$BACKUP_DIR/serve.ts" "$SERVE" > /dev/null \
+    && diff -q "$BACKUP_DIR/suite.ts" "$SUITE" > /dev/null; then
+    echo "    NOT APPLIED: the mutation changed no file, so it proves nothing"
+    survived=$((survived + 1))
+    return
+  fi
+  if ! npm run build > /tmp/mutate-1184-build.log 2>&1; then
+    echo "    NOT APPLIED: the mutation does not compile, so no test ran"
+    tail -3 /tmp/mutate-1184-build.log
+    survived=$((survived + 1))
+    return
+  fi
+  if timeout 900 node --test --test-concurrency 1 $TESTS > /tmp/mutate-1184-test.log 2>&1; then
+    echo "    SURVIVED"
+    survived=$((survived + 1))
+  else
+    echo "    KILLED: $(grep -c '✖ ' /tmp/mutate-1184-test.log) failing assertion(s)"
+    grep '✖ ' /tmp/mutate-1184-test.log | head -3
+    killed=$((killed + 1))
+  fi
+}
+
+m_the_headline_counts_the_discovery_batch_as_changes() {
+  py <<'PY'
+p = "src/data.ts"
+s = open(p).read()
+s = s.replace("across ${weekChanges.length} developer tool pricing change",
+              "across ${weekChanges.length + weekDiscovered.length} developer tool pricing change")
+open(p, "w").write(s)
+PY
+}
+
+m_the_discovery_batch_loses_its_own_heading() {
+  py <<'PY'
+p = "src/data.ts"
+s = open(p).read()
+s = s.replace("    mdSections.push(`## ${firstReadHeading(weekDiscovered.length)}`);",
+              "    mdSections.push(`## Other Notable Changes`);")
+open(p, "w").write(s)
+PY
+}
+
+m_a_week_with_no_discovery_batch_still_gets_the_sentence() {
+  py <<'PY'
+p = "src/data.ts"
+s = open(p).read()
+s = s.replace('const discoveryNote = weekDiscovered.length > 0 ? discoveryBatchNote(weekDiscovered.length, `during ${dateLabel}`) : "";',
+              'const discoveryNote = discoveryBatchNote(weekDiscovered.length, `during ${dateLabel}`);')
+open(p, "w").write(s)
+PY
+}
+
+m_this_week_names_a_discovery_batch_it_does_not_have() {
+  py <<'PY'
+p = "src/serve.ts"
+s = open(p).read()
+s = s.replace("const firstReadHtml = digest.discovered_in_week > 0",
+              "const firstReadHtml = digest.discovered_in_week >= 0")
+open(p, "w").write(s)
+PY
+}
+
+m_the_feed_drops_the_entry_that_carries_the_correction() {
+  py <<'PY'
+p = "src/serve.ts"
+s = open(p).read()
+s = s.replace('${[...corrections, ...weekEntries].join("\\n")}',
+              '${[...weekEntries].join("\\n")}')
+open(p, "w").write(s)
+PY
+}
+
+m_the_feed_publishes_a_week_that_tracked_no_change() {
+  py <<'PY'
+p = "src/serve.ts"
+s = open(p).read()
+s = s.replace("      if (digest.top_changes.length === 0) continue;\n", "")
+open(p, "w").write(s)
+PY
+}
+
+m_the_feed_reaches_further_back_than_it_publishes() {
+  py <<'PY'
+p = "src/serve.ts"
+s = open(p).read()
+s = s.replace("    for (let w = 0; w < 4; w++) {\n      const digest = getFormattedWeeklyDigest(w, 50);",
+              "    for (let w = 0; w < 12; w++) {\n      const digest = getFormattedWeeklyDigest(w, 50);")
+open(p, "w").write(s)
+PY
+}
+
+m_a_change_that_has_not_taken_effect_is_reported_as_tracked() {
+  py <<'PY'
+p = "src/data.ts"
+s = open(p).read()
+s = s.replace("    ? { start: thirtyDaysAgo, end: today }\n    : weekWindow;",
+              "    ? { start: thirtyDaysAgo }\n    : weekWindow;")
+open(p, "w").write(s)
+PY
+}
+
+m_the_summary_opens_with_a_count_it_did_not_return() {
+  py <<'PY'
+p = "src/data.ts"
+s = open(p).read()
+s = s.replace("parts.push(`${changes.length} pricing change${changes.length !== 1 ? \"s\" : \"\"} with a known effective date tracked",
+              "parts.push(`${changes.length + 1} pricing change${changes.length !== 1 ? \"s\" : \"\"} with a known effective date tracked")
+open(p, "w").write(s)
+PY
+}
+
+run_mutation "the headline counts the discovery batch as changes" m_the_headline_counts_the_discovery_batch_as_changes
+run_mutation "the discovery batch loses its own heading" m_the_discovery_batch_loses_its_own_heading
+run_mutation "a week with no discovery batch still gets the sentence" m_a_week_with_no_discovery_batch_still_gets_the_sentence
+run_mutation "/this-week names a discovery batch it does not have" m_this_week_names_a_discovery_batch_it_does_not_have
+run_mutation "the feed drops the entry that carries the correction" m_the_feed_drops_the_entry_that_carries_the_correction
+run_mutation "the feed publishes a week that tracked no change" m_the_feed_publishes_a_week_that_tracked_no_change
+run_mutation "the feed reaches further back than it publishes" m_the_feed_reaches_further_back_than_it_publishes
+run_mutation "a change that has not taken effect is reported as tracked" m_a_change_that_has_not_taken_effect_is_reported_as_tracked
+run_mutation "the summary opens with a count it did not return" m_the_summary_opens_with_a_count_it_did_not_return
+
+restore
+npm run build > /dev/null 2>&1
+echo
+echo "killed=$killed survived=$survived"
+[ "$survived" -eq 0 ]

--- a/test/weekly-window-provenance.test.ts
+++ b/test/weekly-window-provenance.test.ts
@@ -29,6 +29,20 @@ function dated(dateSource: string, date: string) {
   return { vendor: "Acme", date, date_source: dateSource, change_type: "limits_reduced" };
 }
 
+const WEEKS_OF_ARCHIVE = 120;
+const FEED_WEEKS = 4;
+
+async function mostRecentWeekWithADiscoveryBatch() {
+  const { getFormattedWeeklyDigest } = await import("../dist/data.js");
+  for (let weeksAgo = 0; weeksAgo < WEEKS_OF_ARCHIVE; weeksAgo++) {
+    const digest = getFormattedWeeklyDigest(weeksAgo, 200);
+    if (digest.discovered_in_week > 0) return digest;
+  }
+  throw new Error(
+    `no week in the last ${WEEKS_OF_ARCHIVE} carries a page read for the first time, so the split between the two counts cannot be checked`
+  );
+}
+
 describe("one definition of the week a digest is about", () => {
   it("runs Monday to Sunday whichever day of the week it is handed", () => {
     assert.deepStrictEqual(isoWeekWindow(new Date("2026-08-26T09:00:00Z")), {
@@ -128,10 +142,8 @@ describe("a weekly digest counts only changes with an effective date", () => {
   });
 
   it("never states the combined total as a number of changes", async () => {
-    const { getFormattedWeeklyDigest } = await import("../dist/data.js");
-    const digest = getFormattedWeeklyDigest(0, 200);
+    const digest = await mostRecentWeekWithADiscoveryBatch();
     const combined = digest.changes_in_week + digest.discovered_in_week;
-    assert.ok(digest.discovered_in_week > 0, "the corpus should carry a discovery batch to guard against");
     assert.ok(
       !digest.headline.includes(`across ${combined} developer tool pricing change`),
       digest.headline
@@ -154,8 +166,7 @@ describe("a weekly digest counts only changes with an effective date", () => {
   });
 
   it("gives the discovery batch its own heading and its own sentence", async () => {
-    const { getFormattedWeeklyDigest } = await import("../dist/data.js");
-    const digest = getFormattedWeeklyDigest(0, 200);
+    const digest = await mostRecentWeekWithADiscoveryBatch();
     assert.ok(digest.discovery_note.length > 0);
     assert.ok(digest.digest_markdown.includes(`## ${firstReadHeading(digest.discovered_in_week)}`));
     assert.ok(digest.digest_markdown.includes(digest.discovery_note));
@@ -205,16 +216,13 @@ describe("the digest returns only what the window it names contains", () => {
     const { getWeeklyDigest } = await import("../dist/data.js");
     const digest = getWeeklyDigest();
     const today = new Date().toISOString().slice(0, 10);
-    const future = publishedChanges.filter((c) => eventDated(c) && c.date > today);
-    assert.ok(future.length > 0, "the corpus should carry a future-dated change to place");
-    for (const c of future) {
+    for (const c of digest.deal_changes) {
+      assert.ok(c.date <= today, `${c.vendor} ${c.date} should not be reported as a change already tracked`);
+    }
+    for (const c of publishedChanges.filter((c) => eventDated(c) && c.date > today)) {
       assert.ok(
         digest.upcoming_deadlines.some((d) => d.vendor === c.vendor && d.date === c.date),
         `${c.vendor} ${c.date} should be an upcoming deadline`
-      );
-      assert.ok(
-        !digest.deal_changes.some((d) => d.vendor === c.vendor && d.date === c.date && d.date > today),
-        `${c.vendor} ${c.date} should not be reported as a change already tracked`
       );
     }
   });
@@ -222,7 +230,10 @@ describe("the digest returns only what the window it names contains", () => {
   it("opens its summary with the number of changes it actually returns", async () => {
     const { getWeeklyDigest } = await import("../dist/data.js");
     const digest = getWeeklyDigest();
-    assert.match(digest.summary, new RegExp(`^${digest.deal_changes.length} pricing change`));
+    const opening = digest.deal_changes.length === 0
+      ? "No pricing change"
+      : `${digest.deal_changes.length} pricing change`;
+    assert.ok(digest.summary.startsWith(opening), digest.summary);
     assert.ok(digest.summary.includes("with a known effective date"), digest.summary);
     if (digest.discovered_changes.length > 0) {
       assert.ok(digest.summary.includes("read for the first time this week"), digest.summary);
@@ -274,32 +285,54 @@ describe("every weekly surface reports the same week", () => {
     if (proc) { proc.kill("SIGKILL"); proc = null; }
   });
 
-  it("publishes one count for the week across the page, the API and the feed", async () => {
+  it("publishes one count for the current week on the page and in the API", async () => {
     proc = await startHttpServer();
     const base = `http://127.0.0.1:${serverPort}`;
     const weekly = await (await fetch(`${base}/api/digest/weekly?limit=200`)).json() as {
       changes_in_week: number; discovered_in_week: number; headline: string;
     };
     const page = await (await fetch(`${base}/this-week`)).text();
+
+    assert.ok(page.includes(weekly.headline), "/this-week should carry the headline the API publishes");
+    if (weekly.discovered_in_week > 0) {
+      const combined = weekly.changes_in_week + weekly.discovered_in_week;
+      assert.ok(!page.includes(`across ${combined} developer tool pricing change`), "/this-week");
+      assert.ok(page.includes(firstReadHeading(weekly.discovered_in_week)), "/this-week");
+    } else {
+      assert.ok(!page.includes("read for the first time"), "/this-week");
+    }
+  });
+
+  it("keeps a corrected count out of every weekly entry and inside the entry correcting it", async () => {
+    proc = await startHttpServer();
+    const base = `http://127.0.0.1:${serverPort}`;
     const feed = await (await fetch(`${base}/feed.xml`)).text();
-
-    const combined = weekly.changes_in_week + weekly.discovered_in_week;
-    assert.ok(weekly.discovered_in_week > 0, "the corpus should carry a discovery batch to guard against");
-    const inflated = `across ${combined} developer tool pricing change`;
-
-    assert.ok(!page.includes(inflated), "/this-week");
-    assert.ok(page.includes(weekly.headline), "/this-week should carry the headline");
-    assert.ok(page.includes(firstReadHeading(weekly.discovered_in_week)), "/this-week");
+    const corrected = await mostRecentWeekWithADiscoveryBatch();
+    const inflated = `across ${corrected.changes_in_week + corrected.discovered_in_week} developer tool pricing change`;
 
     const entries = feed.split("<entry>").slice(1);
     const corrections = entries.filter((e) => e.includes("urn:agentdeals:correction:"));
     const weeks = entries.filter((e) => !e.includes("urn:agentdeals:correction:"));
-    assert.ok(weeks.length > 0, "/feed.xml should carry weekly entries");
     for (const entry of weeks) assert.ok(!entry.includes(inflated), "/feed.xml weekly entry");
     assert.ok(
       corrections.some((e) => e.includes(inflated)),
       "a corrected count should survive only inside the entry correcting it"
     );
+  });
+
+  it("carries a feed entry for each recent week that tracked a change, and for no other", async () => {
+    proc = await startHttpServer();
+    const base = `http://127.0.0.1:${serverPort}`;
+    const feed = await (await fetch(`${base}/feed.xml`)).text();
+    const { getFormattedWeeklyDigest } = await import("../dist/data.js");
+
+    const expected: string[] = [];
+    for (let weeksAgo = 0; weeksAgo < FEED_WEEKS; weeksAgo++) {
+      const digest = getFormattedWeeklyDigest(weeksAgo, 50);
+      if (digest.top_changes.length > 0) expected.push(`urn:agentdeals:weekly-digest:${digest.week_of}`);
+    }
+    const served = [...feed.matchAll(/<id>(urn:agentdeals:weekly-digest:[^<]+)<\/id>/g)].map((m) => m[1]);
+    assert.deepStrictEqual(served, expected);
   });
 
   it("counts the last thirty days on /changes the way the week is counted", async () => {


### PR DESCRIPTION
Refs #1184

`main` is green again. Three tests required the current ISO week to hold a batch of pages read for the first time; the week rolled over at 00:00 UTC and starts empty, so they failed and blocked every open pull request including #1187.

## Why the precondition could not just be dropped

`assert.ok(digest.discovered_in_week > 0, ...)` was not only there to keep the guard meaningful — it was load-bearing against a false failure. The assertion under it is that the headline never states `across <changes + discovered> developer tool pricing change`. When a week has no discovery batch that string is `across <changes> ...`, which is exactly what a correct headline says: `/digest/2026-w34` publishes "1 product deprecated across 1 developer tool pricing change". Removing the precondition would have turned a red Monday into a red every-week-with-a-change.

So the guard has to run against a week that has a batch. It now selects the most recent one, which also means it runs every day instead of only on the days the current week happens to hold one.

## The third test was pinned to a coincidence

Its last assertion required the inflated count to appear inside the feed's correction entry. The correction quotes `154 developer tool pricing changes`, and 154 is the combined count of the week of 2026-08-24 — so that assertion only ever passed while the current week *was* the week being corrected. It was going to break at the rollover whether or not the new week had discoveries.

It is now split. The current week is checked for agreement between `/this-week` and `/api/digest/weekly` whatever it holds, with the first-read heading required when there is a batch and forbidden when there is not. The inflated count is checked against the week the correction is about.

## Two more in the same file, found by running the suite at a simulated clock

| Test | Would have gone red |
|---|---|
| `routes a future-dated change to the deadlines rather than to the week` | **2026-10-07** — last future-dated record is AWS 2026-10-07, and the filter is `c.date > today` |
| `opens its summary with the number of changes it actually returns` | **2026-11-07** — 30 days after the last dated change the summary opens "No pricing change …" while the regex expected `^0 pricing change` |

Both fail on `main` at those instants and are fixed here. The first now asserts the property that needs no precondition — no entry in `deal_changes` is dated after today — which is stronger than the per-record loop it replaces because it catches any future-dated leak rather than only enumerated ones. The `weeks.length > 0` assertion on the feed had the same defect (the feed only reaches back four weeks and skips weeks with no changes) and is replaced by a comparison against the weeks that actually tracked a change.

## Verification

`Date` was replaced with a fixed-instant subclass via `--import`, inherited by the spawned server through `NODE_OPTIONS`, so the whole suite runs at any date against the real corpus.

**This branch: 27/27 at every instant tested** — 2026-08-31, 2026-09-07, 2026-09-28 (after the batch ages out of the four-week feed window), 2026-10-07, 2026-11-07, 2026-12-01, 2027-06-07, 2028-01-03.

**`main` at the same instants:** 22/25, then 21/25 from 2026-10-07, then 20/25 from 2026-11-07.

**Mutation: 9 applied, 9 killed, 0 survived** (`scripts/mutate-1184.sh`), each by the test it targets — headline inflation, the batch losing its heading, a note on a week with none, `/this-week` naming a batch it does not have, the feed dropping the correction, the feed publishing an empty week, the feed reaching past its window, a not-yet-effective change reported as tracked, and the summary opening with a count it did not return.

That the headline guard is *live* is the point. With the inflation defect applied to `main` today, the failure reported is `the corpus should carry a discovery batch to guard against` — the precondition, not the defect; the inflation assertion is never reached. On this branch the same defect is reported as the inflated headline.

Full suite 2779/2779, `tsc --noEmit` clean, `validate-data` 1580 offers / 444 changes, `no-private-context` 9/9. No source changes — one test file and one mutation script.

## Not fixed here

Seven more tests outside this file are pinned to the calendar the same way, one of which goes red tomorrow. Inventory with dates posted on #1184.
