### PR TITLE
Prove the monthly report rendered from the corpus under test rather than a second vendor

### DIFF
--- a/test/change-date-provenance.test.ts
+++ b/test/change-date-provenance.test.ts
@@ -402,9 +402,9 @@ describe("no surface renders a discovery date as the date the vendor changed som
   });
 
   it("keeps the discovery out of the monthly report it would otherwise land in", async () => {
-    const { dated, discovered } = await bodies(`/reports/${TODAY.slice(0, 7)}`);
+    const { dated, discovered, status } = await bodies(`/reports/${TODAY.slice(0, 7)}`);
+    assert.strictEqual(status[0], 200, "the same month renders when the change carries an effective date, so a miss below is about the date");
     assert.ok(dated.includes(SUBJECT), "the dated control should appear in this month's report");
-    assert.ok(discovered.includes(CONTROL), "the report did not render at all, so the absence below proves nothing");
     assert.ok(!discovered.includes(SUBJECT), "a change with no known effective date was counted in a monthly report");
   });
 


### PR DESCRIPTION
Refs #1184

`main` goes red tomorrow without this. Same class as #1188, different file and a monthly rather than weekly boundary.

## What breaks

`keeps the discovery out of the monthly report it would otherwise land in` reads `/reports/<current month>`. The subject fixture is dated today, so it is always in that month. The vendor used to prove the page rendered is dated ten days back — which on the 1st to the 10th of any month is the *previous* month. The current month's report then holds nothing event-dated, `buildMonthlyReportPage` returns null, the route 404s, and the check fails on its own precondition: `the report did not render at all, so the absence below proves nothing`.

Verified against the real code at a simulated clock: red 2026-09-01 through 2026-09-10, green from 2026-09-11. It repeats on the first ten days of every month.

## Why not move the fixture

The obvious fix is to give that vendor a date inside the current month. I tried it, and it fails on the 1st: the only same-month date available is the 1st itself, which is today, and a change dated today is classified as upcoming rather than as having recently taken effect. That broke two other tests in the file (`keeps the discovery out of every month group and off the upcoming list` and `never lists the discovery among changes that recently took effect`). A control that is both in the current month and strictly in the past does not exist on the 1st.

## What this does instead

The test already serves two corpora that differ only in `date_source`. The dated one is a better positive control than a second vendor, because it is the same route, the same month and the same record. Asserting it returns 200 establishes that the route works and the month is populated; the discovery-dated corpus then either omits the subject or has no report at all, and both are the property holding.

## Verification

**36/36 at 2026-09-01, 09-02, 09-05, 09-10, 09-11, 09-30, 10-01, and 2027-02-01, 02-28, 03-01** — including the 1st, which is the case that defeated the fixture approach, and February.

The guard is still live. With `changesEffectiveIn` mutated to drop its `isEventDated` filter — a discovery-dated change counted in a monthly report, the exact regression this test exists for — the test fails at **2026-09-05** (a date that was previously red) and at **2026-09-20** (a date that was previously green). Removing the second-vendor assertion did not make it vacuous.

Full suite 2779/2779, `tsc --noEmit` clean, `no-private-context` 9/9. One test file, no source changes.
