### PR TITLE
Gate alternatives membership on published product subtypes (#1032 Phase 2)

### DIFF
--- a/data/index.json
+++ b/data/index.json
@@ -41,6 +41,22 @@
         "checked": "2026-08-28",
         "outcome": "ok",
         "detail": "text"
+      },
+      "product_subtypes": {
+        "taxonomy": "Cloud Hosting",
+        "labels": [
+          {
+            "subtype": "static_site",
+            "source_url": "https://vercel.com/docs",
+            "source_quote": "Ship anything with Vercel"
+          },
+          {
+            "subtype": "serverless_function",
+            "source_url": "https://vercel.com/docs",
+            "source_quote": "Ship anything with Vercel"
+          }
+        ],
+        "reviewed": "2026-08-31"
       }
     },
     {
@@ -86,6 +102,17 @@
         "checked": "2026-08-28",
         "outcome": "ok",
         "detail": "text"
+      },
+      "product_subtypes": {
+        "taxonomy": "Cloud Hosting",
+        "labels": [
+          {
+            "subtype": "container_app",
+            "source_url": "https://render.com/docs",
+            "source_quote": "Run your code in just a few clicks with Render. You decide what's possible, and we'll help bring it to life."
+          }
+        ],
+        "reviewed": "2026-08-31"
       }
     },
     {
@@ -126,6 +153,17 @@
         "checked": "2026-08-28",
         "outcome": "ok",
         "detail": "text"
+      },
+      "product_subtypes": {
+        "taxonomy": "Cloud Hosting",
+        "labels": [
+          {
+            "subtype": "serverless_function",
+            "source_url": "https://developers.cloudflare.com/workers/",
+            "source_quote": "Build and deploy serverless applications across Cloudflare"
+          }
+        ],
+        "reviewed": "2026-08-31"
       }
     },
     {
@@ -157,6 +195,22 @@
         "checked": "2026-08-28",
         "outcome": "ok",
         "detail": "text"
+      },
+      "product_subtypes": {
+        "taxonomy": "Cloud Hosting",
+        "labels": [
+          {
+            "subtype": "static_site",
+            "source_url": "https://docs.netlify.com/",
+            "source_quote": "Build & deploy faster with any modern frontend stack or AI agent."
+          },
+          {
+            "subtype": "serverless_function",
+            "source_url": "https://docs.netlify.com/",
+            "source_quote": "Build & deploy faster with any modern frontend stack or AI agent."
+          }
+        ],
+        "reviewed": "2026-08-31"
       }
     },
     {
@@ -194,6 +248,17 @@
         "checked": "2026-08-28",
         "outcome": "ok",
         "detail": "text"
+      },
+      "product_subtypes": {
+        "taxonomy": "Cloud Hosting",
+        "labels": [
+          {
+            "subtype": "static_site",
+            "source_url": "https://developers.cloudflare.com/pages/",
+            "source_quote": "Deploy full-stack applications instantly to the Cloudflare global network with Pages."
+          }
+        ],
+        "reviewed": "2026-08-31"
       }
     },
     {
@@ -255,6 +320,17 @@
         "checked": "2026-08-28",
         "outcome": "ok",
         "detail": "text"
+      },
+      "product_subtypes": {
+        "taxonomy": "Cloud Hosting",
+        "labels": [
+          {
+            "subtype": "container_app",
+            "source_url": "https://railway.com/",
+            "source_quote": "Railway is a full-stack cloud for deploying web apps, servers, databases, and more with automatic scaling, monitoring, and security."
+          }
+        ],
+        "reviewed": "2026-08-31"
       }
     },
     {
@@ -296,6 +372,17 @@
         "checked": "2026-08-28",
         "outcome": "ok",
         "detail": "text"
+      },
+      "product_subtypes": {
+        "taxonomy": "Cloud Hosting",
+        "labels": [
+          {
+            "subtype": "container_app",
+            "source_url": "https://fly.io/",
+            "source_quote": "Sandboxes aren't enough. Give your agent a real computer and get back to building."
+          }
+        ],
+        "reviewed": "2026-08-31"
       }
     },
     {
@@ -328,6 +415,17 @@
         "checked": "2026-08-28",
         "outcome": "ok",
         "detail": "text"
+      },
+      "product_subtypes": {
+        "taxonomy": "Cloud Hosting",
+        "labels": [
+          {
+            "subtype": "serverless_function",
+            "source_url": "https://deno.com/deploy",
+            "source_quote": "One simple platform for anything that runs with JavaScript or Typescript."
+          }
+        ],
+        "reviewed": "2026-08-31"
       }
     },
     {
@@ -349,6 +447,17 @@
         "checked": "2026-08-28",
         "outcome": "ok",
         "detail": "text"
+      },
+      "product_subtypes": {
+        "taxonomy": "Cloud Hosting",
+        "labels": [
+          {
+            "subtype": "serverless_function",
+            "source_url": "https://docs.val.town/",
+            "source_quote": "Val Town lets you - and your LLM - write and run JavaScript, always deployed in 100ms. You can make websites, APIs, MCP servers, crons, Slack bots, email automations, webhook handlers, and more."
+          }
+        ],
+        "reviewed": "2026-08-31"
       }
     },
     {
@@ -370,6 +479,17 @@
         "checked": "2026-08-28",
         "outcome": "ok",
         "detail": "text"
+      },
+      "product_subtypes": {
+        "taxonomy": "Cloud Hosting",
+        "labels": [
+          {
+            "subtype": "container_app",
+            "source_url": "https://www.koyeb.com/",
+            "source_quote": "Deploy intensive applications across GPUs, CPUs, and Accelerators in minutes - scale in 50+ locations."
+          }
+        ],
+        "reviewed": "2026-08-31"
       }
     },
     {
@@ -522,6 +642,27 @@
         "checked": "2026-08-28",
         "outcome": "ok",
         "detail": "text"
+      },
+      "product_subtypes": {
+        "taxonomy": "Databases",
+        "labels": [
+          {
+            "subtype": "relational",
+            "source_url": "https://supabase.com/",
+            "source_quote": "Build production-grade applications with a Postgres database, Authentication, instant APIs, Realtime, Functions, Storage and Vector embeddings."
+          },
+          {
+            "subtype": "vector",
+            "source_url": "https://supabase.com/",
+            "source_quote": "Build production-grade applications with a Postgres database, Authentication, instant APIs, Realtime, Functions, Storage and Vector embeddings."
+          },
+          {
+            "subtype": "backend_platform",
+            "source_url": "https://supabase.com/",
+            "source_quote": "Build production-grade applications with a Postgres database, Authentication, instant APIs, Realtime, Functions, Storage and Vector embeddings."
+          }
+        ],
+        "reviewed": "2026-08-31"
       }
     },
     {
@@ -567,6 +708,22 @@
         "checked": "2026-08-28",
         "outcome": "ok",
         "detail": "text"
+      },
+      "product_subtypes": {
+        "taxonomy": "Databases",
+        "labels": [
+          {
+            "subtype": "relational",
+            "source_url": "https://neon.com/",
+            "source_quote": "The backend for apps and agents. Build with Lakebase Postgres, Auth, Functions, Storage, and an AI Gateway: instant, branchable, serverless."
+          },
+          {
+            "subtype": "backend_platform",
+            "source_url": "https://neon.com/",
+            "source_quote": "The backend for apps and agents. Build with Lakebase Postgres, Auth, Functions, Storage, and an AI Gateway: instant, branchable, serverless."
+          }
+        ],
+        "reviewed": "2026-08-31"
       }
     },
     {
@@ -597,6 +754,17 @@
         "checked": "2026-08-28",
         "outcome": "ok",
         "detail": "text"
+      },
+      "product_subtypes": {
+        "taxonomy": "Databases",
+        "labels": [
+          {
+            "subtype": "document",
+            "source_url": "https://www.mongodb.com/products/platform/atlas-database",
+            "source_quote": "Find out how the document model eliminates operational complexity while ensuring unmatched resilience, scalability, and enterprise-grade security through the Atlas cloud database."
+          }
+        ],
+        "reviewed": "2026-08-31"
       }
     },
     {
@@ -618,6 +786,17 @@
         "checked": "2026-08-28",
         "outcome": "ok",
         "detail": "text"
+      },
+      "product_subtypes": {
+        "taxonomy": "Databases",
+        "labels": [
+          {
+            "subtype": "relational",
+            "source_url": "https://www.cockroachlabs.com/",
+            "source_quote": "CockroachDB is a cloud-agnostic, AI-native, PostgreSQL-compatible data platform built for modern applications."
+          }
+        ],
+        "reviewed": "2026-08-31"
       }
     },
     {
@@ -639,6 +818,17 @@
         "checked": "2026-08-28",
         "outcome": "ok",
         "detail": "text"
+      },
+      "product_subtypes": {
+        "taxonomy": "Databases",
+        "labels": [
+          {
+            "subtype": "relational",
+            "source_url": "https://turso.tech/",
+            "source_quote": "A full SQLite drop-in replacement, built for the agentic future."
+          }
+        ],
+        "reviewed": "2026-08-31"
       }
     },
     {
@@ -661,6 +851,22 @@
         "checked": "2026-08-28",
         "outcome": "ok",
         "detail": "text"
+      },
+      "product_subtypes": {
+        "taxonomy": "Databases",
+        "labels": [
+          {
+            "subtype": "kv_cache",
+            "source_url": "https://upstash.com/",
+            "source_quote": "Serverless Redis, Vector and Search databases with low latency and pay-as-you-go pricing."
+          },
+          {
+            "subtype": "vector",
+            "source_url": "https://upstash.com/",
+            "source_quote": "Serverless Redis, Vector and Search databases with low latency and pay-as-you-go pricing."
+          }
+        ],
+        "reviewed": "2026-08-31"
       }
     },
     {
@@ -685,6 +891,22 @@
         "checked": "2026-08-28",
         "outcome": "ok",
         "detail": "text"
+      },
+      "product_subtypes": {
+        "taxonomy": "Databases",
+        "labels": [
+          {
+            "subtype": "document",
+            "source_url": "https://firebase.google.com/docs/firestore",
+            "source_quote": "Use the flexible, scalable NoSQL cloud database from Google Cloud to store and sync data for client and server-side development."
+          },
+          {
+            "subtype": "backend_platform",
+            "source_url": "https://firebase.google.com/docs/firestore",
+            "source_quote": "Use the flexible, scalable NoSQL cloud database from Google Cloud to store and sync data for client and server-side development."
+          }
+        ],
+        "reviewed": "2026-08-31"
       }
     },
     {
@@ -705,6 +927,11 @@
         "checked": "2026-08-28",
         "outcome": "states_no_terms",
         "detail": "the page names Databricks (Lakeflow Connect) but states no amount, tier or rate we can read"
+      },
+      "product_subtypes": {
+        "taxonomy": "Databases",
+        "labels": [],
+        "reviewed": "2026-08-31"
       }
     },
     {
@@ -728,6 +955,17 @@
         "checked": "2026-08-28",
         "outcome": "ok",
         "detail": "text"
+      },
+      "product_subtypes": {
+        "taxonomy": "Databases",
+        "labels": [
+          {
+            "subtype": "backend_platform",
+            "source_url": "https://www.convex.dev/",
+            "source_quote": "Convex is the reactive backend platform that keeps up with you and your agents."
+          }
+        ],
+        "reviewed": "2026-08-31"
       }
     },
     {
@@ -752,6 +990,17 @@
         "checked": "2026-08-28",
         "outcome": "ok",
         "detail": "text"
+      },
+      "product_subtypes": {
+        "taxonomy": "Databases",
+        "labels": [
+          {
+            "subtype": "backend_platform",
+            "source_url": "https://appwrite.io/docs",
+            "source_quote": "Ship faster with Appwrite. Quick starts and deep guides for web and mobile: Authentication, Databases, Storage, Functions, Messaging, and hosting."
+          }
+        ],
+        "reviewed": "2026-08-31"
       }
     },
     {
@@ -774,6 +1023,17 @@
         "checked": "2026-08-28",
         "outcome": "ok",
         "detail": "text"
+      },
+      "product_subtypes": {
+        "taxonomy": "Databases",
+        "labels": [
+          {
+            "subtype": "relational",
+            "source_url": "https://aiven.io/postgresql",
+            "source_quote": "Aiven for PostgreSQL - Managed Postgres database service with Postgres extensions, database forking, connection pooling."
+          }
+        ],
+        "reviewed": "2026-08-31"
       }
     },
     {
@@ -796,6 +1056,17 @@
         "checked": "2026-08-28",
         "outcome": "ok",
         "detail": "text"
+      },
+      "product_subtypes": {
+        "taxonomy": "Databases",
+        "labels": [
+          {
+            "subtype": "relational",
+            "source_url": "https://xata.io/",
+            "source_quote": "Postgres platform with instant branching and scale-to-zero compute."
+          }
+        ],
+        "reviewed": "2026-08-31"
       }
     },
     {
@@ -835,6 +1106,17 @@
         "checked": "2026-08-28",
         "outcome": "ok",
         "detail": "text"
+      },
+      "product_subtypes": {
+        "taxonomy": "Databases",
+        "labels": [
+          {
+            "subtype": "relational",
+            "source_url": "https://developers.cloudflare.com/d1/",
+            "source_quote": "Build serverless SQL databases on Cloudflare"
+          }
+        ],
+        "reviewed": "2026-08-31"
       }
     },
     {
@@ -857,6 +1139,22 @@
         "checked": "2026-08-28",
         "outcome": "ok",
         "detail": "text"
+      },
+      "product_subtypes": {
+        "taxonomy": "Databases",
+        "labels": [
+          {
+            "subtype": "relational",
+            "source_url": "https://nhost.io/",
+            "source_quote": "Nhost is a managed backend platform with Postgres, GraphQL, Auth, Storage, and serverless Functions."
+          },
+          {
+            "subtype": "backend_platform",
+            "source_url": "https://nhost.io/",
+            "source_quote": "Nhost is a managed backend platform with Postgres, GraphQL, Auth, Storage, and serverless Functions."
+          }
+        ],
+        "reviewed": "2026-08-31"
       }
     },
     {
@@ -881,6 +1179,17 @@
         "checked": "2026-08-28",
         "outcome": "states_no_terms",
         "detail": "the page names PocketBase but states no amount, tier or rate we can read"
+      },
+      "product_subtypes": {
+        "taxonomy": "Databases",
+        "labels": [
+          {
+            "subtype": "backend_platform",
+            "source_url": "https://pocketbase.io/",
+            "source_quote": "Open Source backend in 1 file with realtime database, authentication, file storage and admin dashboard"
+          }
+        ],
+        "reviewed": "2026-08-31"
       }
     },
     {
@@ -1654,6 +1963,17 @@
         "checked": "2026-08-28",
         "outcome": "ok",
         "detail": "text"
+      },
+      "product_subtypes": {
+        "taxonomy": "Databases",
+        "labels": [
+          {
+            "subtype": "kv_cache",
+            "source_url": "https://developers.cloudflare.com/kv/",
+            "source_quote": "Workers KV is a global, low-latency, key-value data store for building dynamic and performant APIs and websites."
+          }
+        ],
+        "reviewed": "2026-08-31"
       }
     },
     {
@@ -1693,6 +2013,17 @@
         "checked": "2026-08-28",
         "outcome": "ok",
         "detail": "text"
+      },
+      "product_subtypes": {
+        "taxonomy": "Cloud Hosting",
+        "labels": [
+          {
+            "subtype": "serverless_function",
+            "source_url": "https://developers.cloudflare.com/durable-objects/",
+            "source_quote": "Build stateful serverless applications with Durable Objects, including AI agents, real-time chat, and collaborative apps."
+          }
+        ],
+        "reviewed": "2026-08-31"
       }
     },
     {
@@ -2620,6 +2951,17 @@
         "checked": "2026-08-28",
         "outcome": "ok",
         "detail": "text"
+      },
+      "product_subtypes": {
+        "taxonomy": "Databases",
+        "labels": [
+          {
+            "subtype": "kv_cache",
+            "source_url": "https://www.gomomento.com/",
+            "source_quote": "Run Valkey with a web-scale gateway, Kubernetes-native control, hardened runtime images, and production modules built for platform teams."
+          }
+        ],
+        "reviewed": "2026-08-31"
       }
     },
     {
@@ -3655,6 +3997,17 @@
         "checked": "2026-08-28",
         "outcome": "states_no_terms",
         "detail": "the page names GitHub Pages but states no amount, tier or rate we can read"
+      },
+      "product_subtypes": {
+        "taxonomy": "Cloud Hosting",
+        "labels": [
+          {
+            "subtype": "static_site",
+            "source_url": "https://docs.github.com/en/pages",
+            "source_quote": "GitHub Pages turns any GitHub repository into a live website - no separate hosting required."
+          }
+        ],
+        "reviewed": "2026-08-31"
       }
     },
     {
@@ -3694,6 +4047,17 @@
         "checked": "2026-08-28",
         "outcome": "ok",
         "detail": "text"
+      },
+      "product_subtypes": {
+        "taxonomy": "Databases",
+        "labels": [
+          {
+            "subtype": "relational",
+            "source_url": "https://www.thenile.dev/",
+            "source_quote": "Postgres re-engineered for multi-tenant apps."
+          }
+        ],
+        "reviewed": "2026-08-31"
       }
     },
     {
@@ -6404,6 +6768,17 @@
         "checked": "2026-08-28",
         "outcome": "ok",
         "detail": "text"
+      },
+      "product_subtypes": {
+        "taxonomy": "Cloud Hosting",
+        "labels": [
+          {
+            "subtype": "shared_web_hosting",
+            "source_url": "https://www.pythonanywhere.com/",
+            "source_quote": "Host, run, and code Python in the cloud"
+          }
+        ],
+        "reviewed": "2026-08-31"
       }
     },
     {
@@ -6491,6 +6866,17 @@
         "checked": "2026-08-28",
         "outcome": "ok",
         "detail": "text"
+      },
+      "product_subtypes": {
+        "taxonomy": "Databases",
+        "labels": [
+          {
+            "subtype": "kv_cache",
+            "source_url": "https://redis.io/about/",
+            "source_quote": "Learn about Redis, the fast in-memory database for caching, vector search, and NoSQL."
+          }
+        ],
+        "reviewed": "2026-08-31"
       }
     },
     {
@@ -6826,6 +7212,32 @@
         "checked": "2026-08-28",
         "outcome": "ok",
         "detail": "text"
+      },
+      "product_subtypes": {
+        "taxonomy": "Databases",
+        "labels": [
+          {
+            "subtype": "relational",
+            "source_url": "https://surrealdb.com/",
+            "source_quote": "SurrealDB is a database and an agent memory layer. Documents, graphs, vectors, and SQL in one engine - and context for your AI agents wherever your data lives."
+          },
+          {
+            "subtype": "document",
+            "source_url": "https://surrealdb.com/",
+            "source_quote": "SurrealDB is a database and an agent memory layer. Documents, graphs, vectors, and SQL in one engine - and context for your AI agents wherever your data lives."
+          },
+          {
+            "subtype": "graph",
+            "source_url": "https://surrealdb.com/",
+            "source_quote": "SurrealDB is a database and an agent memory layer. Documents, graphs, vectors, and SQL in one engine - and context for your AI agents wherever your data lives."
+          },
+          {
+            "subtype": "vector",
+            "source_url": "https://surrealdb.com/",
+            "source_quote": "SurrealDB is a database and an agent memory layer. Documents, graphs, vectors, and SQL in one engine - and context for your AI agents wherever your data lives."
+          }
+        ],
+        "reviewed": "2026-08-31"
       }
     },
     {
@@ -7145,6 +7557,17 @@
         "checked": "2026-08-28",
         "outcome": "ok",
         "detail": "text"
+      },
+      "product_subtypes": {
+        "taxonomy": "Databases",
+        "labels": [
+          {
+            "subtype": "vector",
+            "source_url": "https://weaviate.io/pricing",
+            "source_quote": "Compare pricing options for our different levels of vector database services and solutions."
+          }
+        ],
+        "reviewed": "2026-08-31"
       }
     },
     {
@@ -7165,6 +7588,17 @@
         "checked": "2026-08-28",
         "outcome": "ok",
         "detail": "text"
+      },
+      "product_subtypes": {
+        "taxonomy": "Databases",
+        "labels": [
+          {
+            "subtype": "vector",
+            "source_url": "https://zilliz.com/",
+            "source_quote": "Zilliz offers a fully managed Vector Lakebase powered by Milvus, unifying real-time vector search, lake-scale discovery, and AI data operations."
+          }
+        ],
+        "reviewed": "2026-08-31"
       }
     },
     {
@@ -7186,6 +7620,17 @@
         "checked": "2026-08-28",
         "outcome": "ok",
         "detail": "text"
+      },
+      "product_subtypes": {
+        "taxonomy": "Databases",
+        "labels": [
+          {
+            "subtype": "analytical",
+            "source_url": "https://docs.lancedb.com/",
+            "source_quote": "Multimodal lakehouse for AI."
+          }
+        ],
+        "reviewed": "2026-08-31"
       }
     },
     {
@@ -7206,6 +7651,17 @@
         "checked": "2026-08-28",
         "outcome": "ok",
         "detail": "text"
+      },
+      "product_subtypes": {
+        "taxonomy": "Databases",
+        "labels": [
+          {
+            "subtype": "vector",
+            "source_url": "https://upstash.com/",
+            "source_quote": "Serverless Redis, Vector and Search databases with low latency and pay-as-you-go pricing."
+          }
+        ],
+        "reviewed": "2026-08-31"
       }
     },
     {
@@ -7226,6 +7682,17 @@
         "checked": "2026-08-28",
         "outcome": "ok",
         "detail": "text"
+      },
+      "product_subtypes": {
+        "taxonomy": "Databases",
+        "labels": [
+          {
+            "subtype": "vector",
+            "source_url": "https://www.trychroma.com/",
+            "source_quote": "Fast, serverless, and scalable infrastructure supporting vector, full-text, regex, and metadata search."
+          }
+        ],
+        "reviewed": "2026-08-31"
       }
     },
     {
@@ -7246,6 +7713,17 @@
         "checked": "2026-08-28",
         "outcome": "ok",
         "detail": "text"
+      },
+      "product_subtypes": {
+        "taxonomy": "Databases",
+        "labels": [
+          {
+            "subtype": "vector",
+            "source_url": "https://turbopuffer.com/",
+            "source_quote": "vector and full-text search built on object storage: fast, 10x cheaper, and extremely scalable"
+          }
+        ],
+        "reviewed": "2026-08-31"
       }
     },
     {
@@ -7631,6 +8109,22 @@
         "checked": "2026-08-28",
         "outcome": "states_no_terms",
         "detail": "the page names CrateDB but states no amount, tier or rate we can read"
+      },
+      "product_subtypes": {
+        "taxonomy": "Databases",
+        "labels": [
+          {
+            "subtype": "relational",
+            "source_url": "https://cratedb.com/",
+            "source_quote": "CrateDB is the operational analytics database for fast-moving data. Ingest millions of events per second and query billions of records in milliseconds. Standard SQL, no pre-aggregation, no schema redesign."
+          },
+          {
+            "subtype": "analytical",
+            "source_url": "https://cratedb.com/",
+            "source_quote": "CrateDB is the operational analytics database for fast-moving data. Ingest millions of events per second and query billions of records in milliseconds. Standard SQL, no pre-aggregation, no schema redesign."
+          }
+        ],
+        "reviewed": "2026-08-31"
       }
     },
     {
@@ -7651,6 +8145,17 @@
         "checked": "2026-08-28",
         "outcome": "ok",
         "detail": "text"
+      },
+      "product_subtypes": {
+        "taxonomy": "Databases",
+        "labels": [
+          {
+            "subtype": "graph",
+            "source_url": "https://neo4j.com/",
+            "source_quote": "Connect data as it's stored with Neo4j. Perform powerful, complex queries at scale and speed with our graph data platform."
+          }
+        ],
+        "reviewed": "2026-08-31"
       }
     },
     {
@@ -7671,6 +8176,17 @@
         "checked": "2026-08-28",
         "outcome": "ok",
         "detail": "text"
+      },
+      "product_subtypes": {
+        "taxonomy": "Databases",
+        "labels": [
+          {
+            "subtype": "timeseries",
+            "source_url": "https://www.influxdata.com/influxdb-pricing/",
+            "source_quote": "The time series database built to scale with you"
+          }
+        ],
+        "reviewed": "2026-08-31"
       }
     },
     {
@@ -17221,6 +17737,17 @@
         "checked": "2026-08-28",
         "outcome": "states_no_terms",
         "detail": "the page names ampt.dev but states no amount, tier or rate we can read"
+      },
+      "product_subtypes": {
+        "taxonomy": "Cloud Hosting",
+        "labels": [
+          {
+            "subtype": "serverless_function",
+            "source_url": "https://getampt.com/docs",
+            "source_quote": "Ampt lets developers write apps with their favorite tools and JavaScript frameworks, then automatically provisions, manages, and optimizes cloud resources for them."
+          }
+        ],
+        "reviewed": "2026-08-31"
       }
     },
     {
@@ -17239,6 +17766,17 @@
         "checked": "2026-08-28",
         "outcome": "states_no_terms",
         "detail": "the page names anvil.works but states no amount, tier or rate we can read"
+      },
+      "product_subtypes": {
+        "taxonomy": "Cloud Hosting",
+        "labels": [
+          {
+            "subtype": "site_builder",
+            "source_url": "https://anvil.works/",
+            "source_quote": "Anvil is a free Python-based drag-and-drop web app builder"
+          }
+        ],
+        "reviewed": "2026-08-31"
       }
     },
     {
@@ -17257,6 +17795,17 @@
         "checked": "2026-08-28",
         "outcome": "ok",
         "detail": "text"
+      },
+      "product_subtypes": {
+        "taxonomy": "Cloud Hosting",
+        "labels": [
+          {
+            "subtype": "container_app",
+            "source_url": "https://apply.build/",
+            "source_quote": "Deploy from GitHub in minutes to European infrastructure. WAF, vulnerability scanning, metrics, and logs included in every plan."
+          }
+        ],
+        "reviewed": "2026-08-31"
       }
     },
     {
@@ -17275,6 +17824,17 @@
         "checked": "2026-08-28",
         "outcome": "states_no_terms",
         "detail": "the page names Clever Cloud but states no amount, tier or rate we can read"
+      },
+      "product_subtypes": {
+        "taxonomy": "Cloud Hosting",
+        "labels": [
+          {
+            "subtype": "container_app",
+            "source_url": "https://clever.cloud/",
+            "source_quote": "Clever Cloud provides you with the best tools to host, deploy and maintain your applications in operational conditions, at a controlled cost."
+          }
+        ],
+        "reviewed": "2026-08-31"
       }
     },
     {
@@ -17293,6 +17853,17 @@
         "checked": "2026-08-28",
         "outcome": "states_no_terms",
         "detail": "the page names Choreo but states no amount, tier or rate we can read"
+      },
+      "product_subtypes": {
+        "taxonomy": "Cloud Hosting",
+        "labels": [
+          {
+            "subtype": "container_app",
+            "source_url": "https://wso2.com/choreo/",
+            "source_quote": "Automate workflows, reduce complexity, and empower teams to build, secure, and deploy at scale with an all-in-one AI-native internal developer platform."
+          }
+        ],
+        "reviewed": "2026-08-31"
       }
     },
     {
@@ -17311,6 +17882,11 @@
         "checked": "2026-08-28",
         "outcome": "states_no_terms",
         "detail": "the page names codenameone.com but states no amount, tier or rate we can read"
+      },
+      "product_subtypes": {
+        "taxonomy": "Cloud Hosting",
+        "labels": [],
+        "reviewed": "2026-08-31"
       }
     },
     {
@@ -17329,6 +17905,17 @@
         "checked": "2026-08-28",
         "outcome": "states_no_terms",
         "detail": "the page names Daestro but states no amount, tier or rate we can read"
+      },
+      "product_subtypes": {
+        "taxonomy": "Cloud Hosting",
+        "labels": [
+          {
+            "subtype": "container_app",
+            "source_url": "https://daestro.com/",
+            "source_quote": "Container Orchestrator for Batch & Cron Jobs"
+          }
+        ],
+        "reviewed": "2026-08-31"
       }
     },
     {
@@ -17347,6 +17934,17 @@
         "checked": "2026-08-28",
         "outcome": "ok",
         "detail": "url"
+      },
+      "product_subtypes": {
+        "taxonomy": "Cloud Hosting",
+        "labels": [
+          {
+            "subtype": "shared_web_hosting",
+            "source_url": "https://domcloud.co/",
+            "source_quote": "DOM Cloud is a free, modern hosting service for your web applications."
+          }
+        ],
+        "reviewed": "2026-08-31"
       }
     },
     {
@@ -17365,6 +17963,17 @@
         "checked": "2026-08-28",
         "outcome": "ok",
         "detail": "text"
+      },
+      "product_subtypes": {
+        "taxonomy": "Cloud Hosting",
+        "labels": [
+          {
+            "subtype": "container_app",
+            "source_url": "https://encore.dev/",
+            "source_quote": "Encore automates infrastructure from development to production, so developers and agents ship without waiting on Terraform PRs or platform tickets."
+          }
+        ],
+        "reviewed": "2026-08-31"
       }
     },
     {
@@ -17383,6 +17992,17 @@
         "checked": "2026-08-28",
         "outcome": "ok",
         "detail": "text"
+      },
+      "product_subtypes": {
+        "taxonomy": "Cloud Hosting",
+        "labels": [
+          {
+            "subtype": "container_app",
+            "source_url": "https://flightcontrol.dev/",
+            "source_quote": "Provision, deploy, and operate production-grade AWS infrastructure with developers and AI agents."
+          }
+        ],
+        "reviewed": "2026-08-31"
       }
     },
     {
@@ -17401,6 +18021,17 @@
         "checked": "2026-08-28",
         "outcome": "ok",
         "detail": "text"
+      },
+      "product_subtypes": {
+        "taxonomy": "Cloud Hosting",
+        "labels": [
+          {
+            "subtype": "container_app",
+            "source_url": "https://gigalixir.com/",
+            "source_quote": "The only platform built to unlock the full power of Elixir and Phoenix, while providing a high-performance, buildpack-driven home for all your production applications."
+          }
+        ],
+        "reviewed": "2026-08-31"
       }
     },
     {
@@ -17419,6 +18050,17 @@
         "checked": "2026-08-28",
         "outcome": "ok",
         "detail": "text"
+      },
+      "product_subtypes": {
+        "taxonomy": "Cloud Hosting",
+        "labels": [
+          {
+            "subtype": "container_app",
+            "source_url": "https://leapcell.io/",
+            "source_quote": "Leapcell is a modern cloud platform and PaaS for developers, offering seamless web hosting for apps, APIs, and databases."
+          }
+        ],
+        "reviewed": "2026-08-31"
       }
     },
     {
@@ -17437,6 +18079,17 @@
         "checked": "2026-08-28",
         "outcome": "ok",
         "detail": "text"
+      },
+      "product_subtypes": {
+        "taxonomy": "Cloud Hosting",
+        "labels": [
+          {
+            "subtype": "container_app",
+            "source_url": "https://northflank.com/",
+            "source_quote": "Run AI agents, services, databases, and GPUs in secure microVMs. One governed path from commit to production, on our cloud or your own."
+          }
+        ],
+        "reviewed": "2026-08-31"
       }
     },
     {
@@ -17455,6 +18108,11 @@
         "checked": "2026-08-28",
         "outcome": "states_no_terms",
         "detail": "the page names WunderGraph but states no amount, tier or rate we can read"
+      },
+      "product_subtypes": {
+        "taxonomy": "Cloud Hosting",
+        "labels": [],
+        "reviewed": "2026-08-31"
       }
     },
     {
@@ -17473,6 +18131,11 @@
         "checked": "2026-08-28",
         "outcome": "states_no_terms",
         "detail": "the page names YepCode but states no amount, tier or rate we can read"
+      },
+      "product_subtypes": {
+        "taxonomy": "Cloud Hosting",
+        "labels": [],
+        "reviewed": "2026-08-31"
       }
     },
     {
@@ -17491,6 +18154,11 @@
         "checked": "2026-08-28",
         "outcome": "ok",
         "detail": "text"
+      },
+      "product_subtypes": {
+        "taxonomy": "Cloud Hosting",
+        "labels": [],
+        "reviewed": "2026-08-31"
       }
     },
     {
@@ -17511,6 +18179,17 @@
         "checked": "2026-08-28",
         "outcome": "ok",
         "detail": "text"
+      },
+      "product_subtypes": {
+        "taxonomy": "Cloud Hosting",
+        "labels": [
+          {
+            "subtype": "backend_as_a_service",
+            "source_url": "https://www.back4app.com/",
+            "source_quote": "Launch your backend in minutes with no infrastructure hassles. Our low-code platform, ready-to-use components, and AI-powered tools will help you build faster and scale without limits."
+          }
+        ],
+        "reviewed": "2026-08-31"
       }
     },
     {
@@ -17565,6 +18244,11 @@
         "checked": "2026-08-28",
         "outcome": "states_no_terms",
         "detail": "the page names connectycube.com but states no amount, tier or rate we can read"
+      },
+      "product_subtypes": {
+        "taxonomy": "Cloud Hosting",
+        "labels": [],
+        "reviewed": "2026-08-31"
       }
     },
     {
@@ -17583,6 +18267,11 @@
         "checked": "2026-08-28",
         "outcome": "states_no_terms",
         "detail": "the page names ETLR but states no amount, tier or rate we can read"
+      },
+      "product_subtypes": {
+        "taxonomy": "Cloud Hosting",
+        "labels": [],
+        "reviewed": "2026-08-31"
       }
     },
     {
@@ -17601,6 +18290,11 @@
         "checked": "2026-08-28",
         "outcome": "states_no_terms",
         "detail": "the page names Flutter Flow but states no amount, tier or rate we can read"
+      },
+      "product_subtypes": {
+        "taxonomy": "Cloud Hosting",
+        "labels": [],
+        "reviewed": "2026-08-31"
       }
     },
     {
@@ -17619,6 +18313,11 @@
         "checked": "2026-08-28",
         "outcome": "states_no_terms",
         "detail": "the page names IFTTT but states no amount, tier or rate we can read"
+      },
+      "product_subtypes": {
+        "taxonomy": "Cloud Hosting",
+        "labels": [],
+        "reviewed": "2026-08-31"
       }
     },
     {
@@ -17637,6 +18336,11 @@
         "checked": "2026-08-28",
         "outcome": "ok",
         "detail": "text"
+      },
+      "product_subtypes": {
+        "taxonomy": "Cloud Hosting",
+        "labels": [],
+        "reviewed": "2026-08-31"
       }
     },
     {
@@ -17655,6 +18359,17 @@
         "checked": "2026-08-28",
         "outcome": "states_no_terms",
         "detail": "the page names LeanCloud but states no amount, tier or rate we can read"
+      },
+      "product_subtypes": {
+        "taxonomy": "Cloud Hosting",
+        "labels": [
+          {
+            "subtype": "backend_as_a_service",
+            "source_url": "https://leancloud.app/",
+            "source_quote": "LeanCloud is the leading backend-as-a-service provider that offers a complete set of cloud services including object storage, file storage, web hosting, container, instant messaging, push notification"
+          }
+        ],
+        "reviewed": "2026-08-31"
       }
     },
     {
@@ -17673,6 +18388,17 @@
         "checked": "2026-08-28",
         "outcome": "ok",
         "detail": "url"
+      },
+      "product_subtypes": {
+        "taxonomy": "Cloud Hosting",
+        "labels": [
+          {
+            "subtype": "backend_as_a_service",
+            "source_url": "https://paraio.com/",
+            "source_quote": "ParaIO.com is a cloud-based backend service built with open source Para framework. Your objects - stored, indexed and cached."
+          }
+        ],
+        "reviewed": "2026-08-31"
       }
     },
     {
@@ -17691,6 +18417,17 @@
         "checked": "2026-08-28",
         "outcome": "states_no_terms",
         "detail": "the page names simperium.com but states no amount, tier or rate we can read"
+      },
+      "product_subtypes": {
+        "taxonomy": "Cloud Hosting",
+        "labels": [
+          {
+            "subtype": "backend_as_a_service",
+            "source_url": "https://simperium.com/",
+            "source_quote": "Simperium is a cross-platform data sync service."
+          }
+        ],
+        "reviewed": "2026-08-31"
       }
     },
     {
@@ -17845,6 +18582,17 @@
         "checked": "2026-08-28",
         "outcome": "states_no_terms",
         "detail": "the page names Alwaysdata but states no amount, tier or rate we can read"
+      },
+      "product_subtypes": {
+        "taxonomy": "Cloud Hosting",
+        "labels": [
+          {
+            "subtype": "shared_web_hosting",
+            "source_url": "https://www.alwaysdata.com/en/",
+            "source_quote": "Fully managed and all-inclusive hosting, without unexpected expenses. Unlimited databases, mailboxes and websites."
+          }
+        ],
+        "reviewed": "2026-08-31"
       }
     },
     {
@@ -17863,6 +18611,17 @@
         "checked": "2026-08-28",
         "outcome": "ok",
         "detail": "text"
+      },
+      "product_subtypes": {
+        "taxonomy": "Cloud Hosting",
+        "labels": [
+          {
+            "subtype": "shared_web_hosting",
+            "source_url": "https://www.awardspace.com/",
+            "source_quote": "AwardSpace.com is a pioneer in web hosting, offering Free Hosting with PHP/MySQL and no ads, alongside premium plans like Shared, WordPress, Semi-Dedicated, and VPS Cloud Hosting."
+          }
+        ],
+        "reviewed": "2026-08-31"
       }
     },
     {
@@ -17881,6 +18640,17 @@
         "checked": "2026-08-28",
         "outcome": "states_no_terms",
         "detail": "the page names Bubble but states no amount, tier or rate we can read"
+      },
+      "product_subtypes": {
+        "taxonomy": "Cloud Hosting",
+        "labels": [
+          {
+            "subtype": "site_builder",
+            "source_url": "https://bubble.io/",
+            "source_quote": "Build web & mobile apps with the only no-code AI app builder"
+          }
+        ],
+        "reviewed": "2026-08-31"
       }
     },
     {
@@ -17899,6 +18669,17 @@
         "checked": "2026-08-28",
         "outcome": "states_no_terms",
         "detail": "the page names dAppling Network but states no amount, tier or rate we can read"
+      },
+      "product_subtypes": {
+        "taxonomy": "Cloud Hosting",
+        "labels": [
+          {
+            "subtype": "static_site",
+            "source_url": "https://www.dappling.network/",
+            "source_quote": "Decentralized Web Hosting for the Future."
+          }
+        ],
+        "reviewed": "2026-08-31"
       }
     },
     {
@@ -17917,6 +18698,17 @@
         "checked": "2026-08-28",
         "outcome": "states_no_terms",
         "detail": "the page names FreeFlarum but states no amount, tier or rate we can read"
+      },
+      "product_subtypes": {
+        "taxonomy": "Cloud Hosting",
+        "labels": [
+          {
+            "subtype": "managed_cms_hosting",
+            "source_url": "https://freeflarum.com/",
+            "source_quote": "Create your own Flarum forum in under 1 minute with 1-click installation!"
+          }
+        ],
+        "reviewed": "2026-08-31"
       }
     },
     {
@@ -17936,6 +18728,22 @@
         "checked": "2026-08-28",
         "outcome": "ok",
         "detail": "text"
+      },
+      "product_subtypes": {
+        "taxonomy": "Cloud Hosting",
+        "labels": [
+          {
+            "subtype": "static_site",
+            "source_url": "https://sevalla.com/",
+            "source_quote": "Ship production apps without infrastructure overhead. Run applications, databases, storage, and static sites on one platform."
+          },
+          {
+            "subtype": "container_app",
+            "source_url": "https://sevalla.com/",
+            "source_quote": "Ship production apps without infrastructure overhead. Run applications, databases, storage, and static sites on one platform."
+          }
+        ],
+        "reviewed": "2026-08-31"
       }
     },
     {
@@ -17954,6 +18762,17 @@
         "checked": "2026-08-28",
         "outcome": "states_no_terms",
         "detail": "the page names MDB GO but states no amount, tier or rate we can read"
+      },
+      "product_subtypes": {
+        "taxonomy": "Cloud Hosting",
+        "labels": [
+          {
+            "subtype": "container_app",
+            "source_url": "https://mdbgo.com/",
+            "source_quote": "Create and host anything with a single command"
+          }
+        ],
+        "reviewed": "2026-08-31"
       }
     },
     {
@@ -17972,6 +18791,17 @@
         "checked": "2026-08-28",
         "outcome": "states_no_terms",
         "detail": "the page names Neocities but states no amount, tier or rate we can read"
+      },
+      "product_subtypes": {
+        "taxonomy": "Cloud Hosting",
+        "labels": [
+          {
+            "subtype": "static_site",
+            "source_url": "https://neocities.org/about",
+            "source_quote": "Neocities gives you a free place to create a personal, static HTML web site that looks, sounds, and feels like you."
+          }
+        ],
+        "reviewed": "2026-08-31"
       }
     },
     {
@@ -17990,6 +18820,17 @@
         "checked": "2026-08-28",
         "outcome": "ok",
         "detail": "url"
+      },
+      "product_subtypes": {
+        "taxonomy": "Cloud Hosting",
+        "labels": [
+          {
+            "subtype": "site_builder",
+            "source_url": "https://oaysus.com/",
+            "source_quote": "Mirin designs and builds your site, then gives you a simple way to update it after launch."
+          }
+        ],
+        "reviewed": "2026-08-31"
       }
     },
     {
@@ -18008,6 +18849,27 @@
         "checked": "2026-08-28",
         "outcome": "ok",
         "detail": "text"
+      },
+      "product_subtypes": {
+        "taxonomy": "Cloud Hosting",
+        "labels": [
+          {
+            "subtype": "serverless_function",
+            "source_url": "https://www.pandastack.io/",
+            "source_quote": "Firecracker microVMs that boot in 49ms. Agent sandboxes with fork & snapshot, git-driven app hosting, dedicated Postgres 16 and serverless functions on one open-source substrate."
+          },
+          {
+            "subtype": "container_app",
+            "source_url": "https://www.pandastack.io/",
+            "source_quote": "Firecracker microVMs that boot in 49ms. Agent sandboxes with fork & snapshot, git-driven app hosting, dedicated Postgres 16 and serverless functions on one open-source substrate."
+          },
+          {
+            "subtype": "agent_sandbox",
+            "source_url": "https://www.pandastack.io/",
+            "source_quote": "Firecracker microVMs that boot in 49ms. Agent sandboxes with fork & snapshot, git-driven app hosting, dedicated Postgres 16 and serverless functions on one open-source substrate."
+          }
+        ],
+        "reviewed": "2026-08-31"
       }
     },
     {
@@ -18026,6 +18888,17 @@
         "checked": "2026-08-28",
         "outcome": "ok",
         "detail": "text"
+      },
+      "product_subtypes": {
+        "taxonomy": "Cloud Hosting",
+        "labels": [
+          {
+            "subtype": "managed_cms_hosting",
+            "source_url": "https://pantheon.io/",
+            "source_quote": "Pantheon.io is the platform built for WordPress, Drupal, and Next.js. We deliver your business needs to build, host, and manage with digital speed and agility."
+          }
+        ],
+        "reviewed": "2026-08-31"
       }
     },
     {
@@ -18044,6 +18917,17 @@
         "checked": "2026-08-28",
         "outcome": "ok",
         "detail": "text"
+      },
+      "product_subtypes": {
+        "taxonomy": "Cloud Hosting",
+        "labels": [
+          {
+            "subtype": "container_app",
+            "source_url": "https://qoddi.com/",
+            "source_quote": "App Hosting Platform - Deploy, manage and scale Node.js, Python, GO, Java, Ruby, PHP apps in seconds."
+          }
+        ],
+        "reviewed": "2026-08-31"
       }
     },
     {
@@ -18062,6 +18946,17 @@
         "checked": "2026-08-28",
         "outcome": "ok",
         "detail": "text"
+      },
+      "product_subtypes": {
+        "taxonomy": "Cloud Hosting",
+        "labels": [
+          {
+            "subtype": "managed_cms_hosting",
+            "source_url": "https://readthedocs.org/",
+            "source_quote": "Read the Docs is a documentation building and hosting platform aimed at helping developers creating documentation from code with versioned documentation, integrated search, pull request previews and more."
+          }
+        ],
+        "reviewed": "2026-08-31"
       }
     },
     {
@@ -18080,6 +18975,17 @@
         "checked": "2026-08-28",
         "outcome": "ok",
         "detail": "text"
+      },
+      "product_subtypes": {
+        "taxonomy": "Cloud Hosting",
+        "labels": [
+          {
+            "subtype": "shared_web_hosting",
+            "source_url": "https://serv00.com/",
+            "source_quote": "Revolutionary hosting for FREE! 3 GB for free, no adverts, no hooks"
+          }
+        ],
+        "reviewed": "2026-08-31"
       }
     },
     {
@@ -18116,6 +19022,17 @@
         "checked": "2026-08-28",
         "outcome": "states_no_terms",
         "detail": "the page names surge.sh but states no amount, tier or rate we can read"
+      },
+      "product_subtypes": {
+        "taxonomy": "Cloud Hosting",
+        "labels": [
+          {
+            "subtype": "static_site",
+            "source_url": "https://surge.sh/",
+            "source_quote": "Shipping web projects should be fast, easy, and low risk. Surge is static web publishing for Front-End Developers, right from the CLI."
+          }
+        ],
+        "reviewed": "2026-08-31"
       }
     },
     {
@@ -18134,6 +19051,17 @@
         "checked": "2026-08-28",
         "outcome": "states_no_terms",
         "detail": "the page names tilda.cc but states no amount, tier or rate we can read"
+      },
+      "product_subtypes": {
+        "taxonomy": "Cloud Hosting",
+        "labels": [
+          {
+            "subtype": "site_builder",
+            "source_url": "https://tilda.cc/",
+            "source_quote": "Create a website, online store, landing page with Tilda intuitive website builder. Build your site from hundreds of pre-designed templates and publish it today."
+          }
+        ],
+        "reviewed": "2026-08-31"
       }
     },
     {
@@ -18152,6 +19080,17 @@
         "checked": "2026-08-28",
         "outcome": "states_no_terms",
         "detail": "the page names Versoly but states no amount, tier or rate we can read"
+      },
+      "product_subtypes": {
+        "taxonomy": "Cloud Hosting",
+        "labels": [
+          {
+            "subtype": "site_builder",
+            "source_url": "https://versoly.com/",
+            "source_quote": "Versoly is the most flexible no-code website builder. Easily create beautiful landing pages and CMS driven websites."
+          }
+        ],
+        "reviewed": "2026-08-31"
       }
     },
     {
@@ -18572,6 +19511,17 @@
         "checked": "2026-08-28",
         "outcome": "states_no_terms",
         "detail": "the page names 8base.com but states no amount, tier or rate we can read"
+      },
+      "product_subtypes": {
+        "taxonomy": "Databases",
+        "labels": [
+          {
+            "subtype": "backend_platform",
+            "source_url": "https://www.8base.com/product",
+            "source_quote": "Serverless graphql backend-as-a-service"
+          }
+        ],
+        "reviewed": "2026-08-31"
       }
     },
     {
@@ -18590,6 +19540,17 @@
         "checked": "2026-08-28",
         "outcome": "ok",
         "detail": "text"
+      },
+      "product_subtypes": {
+        "taxonomy": "Databases",
+        "labels": [
+          {
+            "subtype": "backend_platform",
+            "source_url": "https://codehooks.io/docs",
+            "source_quote": "Codehooks.io is the complete backend for webhooks and automations. Receive, store, process, and deliver webhooks with a built-in database, queues, cron, and retries behind every endpoint."
+          }
+        ],
+        "reviewed": "2026-08-31"
       }
     },
     {
@@ -18608,6 +19569,17 @@
         "checked": "2026-08-28",
         "outcome": "states_no_terms",
         "detail": "the page names Couchbase Capella but states no amount, tier or rate we can read"
+      },
+      "product_subtypes": {
+        "taxonomy": "Databases",
+        "labels": [
+          {
+            "subtype": "document",
+            "source_url": "https://docs.couchbase.com/cloud/get-started/intro.html",
+            "source_quote": "Capella is the easiest way to use our Couchbase NoSQL database."
+          }
+        ],
+        "reviewed": "2026-08-31"
       }
     },
     {
@@ -18626,6 +19598,22 @@
         "checked": "2026-08-28",
         "outcome": "ok",
         "detail": "text"
+      },
+      "product_subtypes": {
+        "taxonomy": "Databases",
+        "labels": [
+          {
+            "subtype": "relational",
+            "source_url": "https://filess.io",
+            "source_quote": "Ship your full stack apps in seconds. Web Hosting, Managed Databases (MySQL, PostgreSQL, MongoDB, MariaDB & SQL Server) and Secure Tunnels."
+          },
+          {
+            "subtype": "document",
+            "source_url": "https://filess.io",
+            "source_quote": "Ship your full stack apps in seconds. Web Hosting, Managed Databases (MySQL, PostgreSQL, MongoDB, MariaDB & SQL Server) and Secure Tunnels."
+          }
+        ],
+        "reviewed": "2026-08-31"
       }
     },
     {
@@ -18644,6 +19632,17 @@
         "checked": "2026-08-28",
         "outcome": "ok",
         "detail": "text"
+      },
+      "product_subtypes": {
+        "taxonomy": "Databases",
+        "labels": [
+          {
+            "subtype": "document",
+            "source_url": "https://restdb.io/",
+            "source_quote": "Simple online NoSQL database backend with automatic APIs and low code JavaScript hooks"
+          }
+        ],
+        "reviewed": "2026-08-31"
       }
     },
     {
@@ -18662,6 +19661,11 @@
         "checked": "2026-08-28",
         "outcome": "states_no_terms",
         "detail": "the page names SeaTable but states no amount, tier or rate we can read"
+      },
+      "product_subtypes": {
+        "taxonomy": "Databases",
+        "labels": [],
+        "reviewed": "2026-08-31"
       }
     },
     {
@@ -18680,6 +19684,11 @@
         "checked": "2026-08-28",
         "outcome": "ok",
         "detail": "text"
+      },
+      "product_subtypes": {
+        "taxonomy": "Databases",
+        "labels": [],
+        "reviewed": "2026-08-31"
       }
     },
     {
@@ -18698,6 +19707,11 @@
         "checked": "2026-08-28",
         "outcome": "ok",
         "detail": "text"
+      },
+      "product_subtypes": {
+        "taxonomy": "Databases",
+        "labels": [],
+        "reviewed": "2026-08-31"
       }
     },
     {
@@ -24988,6 +26002,11 @@
         "checked": "2026-08-28",
         "outcome": "ok",
         "detail": "text"
+      },
+      "product_subtypes": {
+        "taxonomy": "Databases",
+        "labels": [],
+        "reviewed": "2026-08-31"
       }
     },
     {
@@ -26565,6 +27584,11 @@
         "checked": "2026-08-28",
         "outcome": "does_not_name_vendor",
         "detail": "the page never names MongoDB and is not served from its domain"
+      },
+      "product_subtypes": {
+        "taxonomy": "Databases",
+        "labels": [],
+        "reviewed": "2026-08-31"
       }
     },
     {
@@ -28582,6 +29606,17 @@
         "checked": "2026-08-28",
         "outcome": "ok",
         "detail": "text"
+      },
+      "product_subtypes": {
+        "taxonomy": "Databases",
+        "labels": [
+          {
+            "subtype": "analytical",
+            "source_url": "https://cloud.google.com/bigquery/pricing",
+            "source_quote": "BigQuery is a serverless data analytics platform."
+          }
+        ],
+        "reviewed": "2026-08-31"
       }
     },
     {
@@ -28602,6 +29637,22 @@
         "checked": "2026-08-28",
         "outcome": "ok",
         "detail": "url"
+      },
+      "product_subtypes": {
+        "taxonomy": "Cloud Hosting",
+        "labels": [
+          {
+            "subtype": "serverless_function",
+            "source_url": "https://cloud.google.com/run/docs",
+            "source_quote": "Fully managed application platform to run your code, function, or container on top of Google's highly scalable infrastructure."
+          },
+          {
+            "subtype": "container_app",
+            "source_url": "https://cloud.google.com/run/docs",
+            "source_quote": "Fully managed application platform to run your code, function, or container on top of Google's highly scalable infrastructure."
+          }
+        ],
+        "reviewed": "2026-08-31"
       }
     },
     {
@@ -29058,6 +30109,17 @@
         "checked": "2026-08-28",
         "outcome": "ok",
         "detail": "text"
+      },
+      "product_subtypes": {
+        "taxonomy": "Databases",
+        "labels": [
+          {
+            "subtype": "relational",
+            "source_url": "https://aws.amazon.com/rds/aurora/",
+            "source_quote": "Amazon Aurora is a global-scale relational database service built for the cloud with full MySQL and PostgreSQL compatibility."
+          }
+        ],
+        "reviewed": "2026-08-31"
       }
     },
     {
@@ -30386,6 +31448,17 @@
         "checked": "2026-08-28",
         "outcome": "states_no_terms",
         "detail": "the page names Cloudflare Sandboxes but states no amount, tier or rate we can read"
+      },
+      "product_subtypes": {
+        "taxonomy": "Cloud Hosting",
+        "labels": [
+          {
+            "subtype": "agent_sandbox",
+            "source_url": "https://developers.cloudflare.com/sandbox/",
+            "source_quote": "Build secure, isolated code execution environments powered by Cloudflare Workers and Containers."
+          }
+        ],
+        "reviewed": "2026-08-31"
       }
     },
     {
@@ -30416,6 +31489,17 @@
         "checked": "2026-08-28",
         "outcome": "unreadable",
         "detail": "HTTP 404"
+      },
+      "product_subtypes": {
+        "taxonomy": "Cloud Hosting",
+        "labels": [
+          {
+            "subtype": "agent_sandbox",
+            "source_url": "https://developers.cloudflare.com/dynamic-workers/",
+            "source_quote": "Spin up isolated Workers on demand to execute code."
+          }
+        ],
+        "reviewed": "2026-08-31"
       }
     },
     {

--- a/docs/subtype-taxonomy.md
+++ b/docs/subtype-taxonomy.md
@@ -1,8 +1,14 @@
 # Subtype taxonomy — `Databases` and `Cloud Hosting`
 
-Status: **proposed by PM, not yet applied to any record.** This is the document
-[#1032](https://github.com/robhunter/agentdeals/issues/1032) Phase 2 is blocked on. It covers two of 66
-categories on purpose — prove the shape here before anyone touches the other 64.
+Status: **superseded.** Phase 2 shipped against the two taxonomies published later on
+[#1032](https://github.com/robhunter/agentdeals/issues/1032), in
+[the Databases comment](https://github.com/robhunter/agentdeals/issues/1032#issuecomment-5470406203) and
+[the Cloud Hosting comment](https://github.com/robhunter/agentdeals/issues/1032#issuecomment-5473686674).
+Those differ from this document in the subtype names, in the assignment of several records, and in Rule 3
+below, which the Databases comment reverses: a page must not backfill from the category to reach three
+entries. The applied taxonomies and their definitions are in `src/product-role.ts` and published at
+`/criteria#subtypes`. The four rules and the reasoning here are what the applied version was built from.
+It covers two of 66 categories on purpose — prove the shape here before anyone touches the other 64.
 
 ## What a subtype is for
 

--- a/scripts/membership-impact.js
+++ b/scripts/membership-impact.js
@@ -1,5 +1,5 @@
 import { loadOffers } from "../dist/data.js";
-import { partitionAlternatives, partitionRoleCandidates, MEMBERSHIP_GATE_RULES } from "../dist/product-role.js";
+import { partitionAlternatives, partitionRoleCandidates, MEMBERSHIP_GATE_RULES, SUBTYPE_TAXONOMIES } from "../dist/product-role.js";
 
 const HELP = `membership-impact.js — report what the #1032 membership gates remove.
 
@@ -29,8 +29,29 @@ const gated = classified.filter((o) => o.product_role.deployment_model === "loca
 const removalsByOffer = new Map();
 const listsAffected = new Map();
 const categoryShrink = [];
+const removalsByGate = new Map();
+const pagesBelowThree = [];
 
 const categories = [...new Set(offers.map((o) => o.category))].sort();
+
+const subtypeCoverage = Object.keys(SUBTYPE_TAXONOMIES).map((taxonomy) => {
+  const inTaxonomy = offers.filter((o) => o.category === taxonomy);
+  const labelled = inTaxonomy.filter((o) => o.product_subtypes && o.product_subtypes.labels.length > 0);
+  const emptied = inTaxonomy.filter((o) => o.product_subtypes && o.product_subtypes.labels.length === 0);
+  const unclassified = inTaxonomy.filter((o) => !o.product_subtypes);
+  const bySubtype = SUBTYPE_TAXONOMIES[taxonomy].map((entry) => ({
+    subtype: entry.subtype,
+    records: labelled.filter((o) => o.product_subtypes.labels.some((l) => l.subtype === entry.subtype)).map((o) => o.vendor),
+  }));
+  return {
+    taxonomy,
+    records: inTaxonomy.length,
+    labelled: labelled.length,
+    classified_as_none: emptied.map((o) => o.vendor),
+    unclassified: unclassified.map((o) => o.vendor),
+    by_subtype: bySubtype,
+  };
+});
 
 for (const category of categories) {
   const inCategory = offers.filter((o) => o.category === category);
@@ -49,7 +70,11 @@ for (const category of categories) {
         const entry = removalsByOffer.get(k) ?? { gate: r.gate, lists: 0 };
         entry.lists += 1;
         removalsByOffer.set(k, entry);
+        removalsByGate.set(r.gate, (removalsByGate.get(r.gate) ?? 0) + 1);
       }
+    }
+    if (kept.length < 3) {
+      pagesBelowThree.push({ page: `/vendor/${subject.vendor}`, category, kept: kept.map((o) => o.vendor) });
     }
     if (kept.length < minKept) {
       minKept = kept.length;
@@ -83,7 +108,10 @@ const report = {
   })),
   alternatives_lists_shrunk: [...listsAffected.entries()].map(([category, lists]) => ({ category, lists })),
   removals: [...removalsByOffer.entries()].map(([offer, v]) => ({ offer, gate: v.gate, lists: v.lists })),
+  removals_by_gate: [...removalsByGate.entries()].map(([gate, removals]) => ({ gate, removals })),
   categories_below_three: categoryShrink,
+  pages_below_three: pagesBelowThree,
+  subtype_coverage: subtypeCoverage,
   role_recommendation_impact: roleImpact,
 };
 
@@ -103,10 +131,28 @@ if (asJson) {
   for (const a of report.alternatives_lists_shrunk) {
     console.log(`  ${a.category}: ${a.lists} lists`);
   }
+  console.log("\nremovals by gate, summed over every page:");
+  for (const g of report.removals_by_gate) {
+    console.log(`  ${g.gate}: ${g.removals}`);
+  }
+  console.log("\nsubtype coverage:");
+  for (const c of report.subtype_coverage) {
+    console.log(`  ${c.taxonomy}: ${c.labelled} labelled of ${c.records}, ${c.classified_as_none.length} classified as none, ${c.unclassified.length} unclassified`);
+    for (const s of c.by_subtype) {
+      console.log(`    ${s.subtype} (${s.records.length}): ${s.records.join(", ")}`);
+    }
+    if (c.classified_as_none.length > 0) console.log(`    none apply: ${c.classified_as_none.join(", ")}`);
+    if (c.unclassified.length > 0) console.log(`    unclassified: ${c.unclassified.join(", ")}`);
+  }
   console.log("\ncategories where an alternatives list falls below 3:");
   if (report.categories_below_three.length === 0) console.log("  none");
   for (const c of report.categories_below_three) {
     console.log(`  ${c.category}: ${c.min_alternatives} on /vendor/${c.on_page} (${c.total_in_category} in category)`);
+  }
+  console.log("\nevery page whose alternatives list falls below 3:");
+  if (report.pages_below_three.length === 0) console.log("  none");
+  for (const p of report.pages_below_three) {
+    console.log(`  ${p.page} (${p.category}): ${p.kept.length} — ${p.kept.join(", ") || "empty"}`);
   }
   console.log("\nrole recommendations (/api/stack, plan_stack):");
   if (report.role_recommendation_impact.length === 0) console.log("  none");

--- a/scripts/mutate-1032-phase0.sh
+++ b/scripts/mutate-1032-phase0.sh
@@ -69,8 +69,8 @@ m_pool_is_intersected_again() {
 p = "src/serve.ts"
 s = open(p).read()
 s = s.replace(
-  "partitionAlternativesAcross(addCuratedToPool(dedupedAlts, curated.matched), vendorOffers)",
-  "partitionAlternativesAcross(dedupedAlts, vendorOffers)")
+  "partitionAlternativesAcross(addCuratedToPool(dedupedAlts, curated.matched), vendorOffers, {",
+  "partitionAlternativesAcross(dedupedAlts, vendorOffers, {")
 open(p, "w").write(s)
 PY
 }
@@ -205,7 +205,7 @@ m_curated_block_skips_the_membership_gate() {
   py <<'PY'
 p = "src/curated-alternatives.ts"
 s = open(p).read()
-s = s.replace("  const partition = partitionAlternativesAcross(matched, subjects);",
+s = s.replace("  const partition = partitionAlternativesAcross(matched, subjects, { applySubtypes: false });",
               "  const partition = { kept: matched, removed: [] };")
 open(p, "w").write(s)
 PY
@@ -215,8 +215,8 @@ m_curated_gate_ignores_the_subject_s_own_gates() {
   py <<'PY'
 p = "src/curated-alternatives.ts"
 s = open(p).read()
-s = s.replace("  const partition = partitionAlternativesAcross(matched, subjects);",
-              "  const partition = partitionAlternativesAcross(matched, []);")
+s = s.replace("  const partition = partitionAlternativesAcross(matched, subjects, { applySubtypes: false });",
+              "  const partition = partitionAlternativesAcross(matched, [], { applySubtypes: false });")
 open(p, "w").write(s)
 PY
 }

--- a/scripts/mutate-1032-phase2.sh
+++ b/scripts/mutate-1032-phase2.sh
@@ -1,0 +1,243 @@
+#!/usr/bin/env bash
+set -u
+
+REPO="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$REPO" || exit 1
+
+ROLE="src/product-role.ts"
+SERVE="src/serve.ts"
+CURATED="src/curated-alternatives.ts"
+FILES=("$ROLE" "$SERVE" "$CURATED")
+BACKUP_DIR="$(mktemp -d)"
+for f in "${FILES[@]}"; do
+  cp "$f" "$BACKUP_DIR/$(basename "$f")"
+done
+
+restore() {
+  for f in "${FILES[@]}"; do
+    cp "$BACKUP_DIR/$(basename "$f")" "$f"
+  done
+}
+trap 'restore; npm run build > /dev/null 2>&1' EXIT
+
+killed=0
+survived=0
+TESTS="test/product-role.test.ts test/alternatives-membership.test.ts test/curated-alternatives.test.ts"
+
+py() { python3 - "$@"; }
+
+changed_any() {
+  for f in "${FILES[@]}"; do
+    if ! diff -q "$BACKUP_DIR/$(basename "$f")" "$f" > /dev/null; then
+      return 0
+    fi
+  done
+  return 1
+}
+
+run_mutation() {
+  local name="$1"
+  shift
+  local scope="$TESTS"
+  if [ "$1" = "--only" ]; then
+    scope="$2"
+    shift 2
+  fi
+  echo "=== $name"
+  restore
+  "$@"
+  if ! changed_any; then
+    echo "    NOT APPLIED: the mutation changed no file, so it proves nothing"
+    survived=$((survived + 1))
+    return
+  fi
+  if ! npm run build > /tmp/mutate-1032-p2-build.log 2>&1; then
+    echo "    DID NOT COMPILE: a mutation the compiler rejects proves nothing about the tests"
+    survived=$((survived + 1))
+    return
+  fi
+  if timeout 900 node --test --test-concurrency 1 $scope > /tmp/mutate-1032-p2-test.log 2>&1; then
+    echo "    SURVIVED"
+    survived=$((survived + 1))
+  else
+    echo "    KILLED: $(grep -c '✖ ' /tmp/mutate-1032-p2-test.log) failing assertion(s)"
+    grep '✖ ' /tmp/mutate-1032-p2-test.log | head -3
+    killed=$((killed + 1))
+  fi
+}
+
+m_subtype_gate_never_fires() {
+  py <<'PY'
+p = "src/product-role.ts"
+s = open(p).read()
+s = s.replace("  const fromSubtypes = subtypeGate(candidate, subjectProfiles);",
+              "  const fromSubtypes: MembershipGate | null = subjectProfiles.length < 0 ? subtypeGate(candidate, subjectProfiles) : null;")
+open(p, "w").write(s)
+PY
+}
+
+m_match_requires_every_subtype() {
+  py <<'PY'
+p = "src/product-role.ts"
+s = open(p).read()
+s = s.replace("""  for (const subtype of own.subtypes) {
+    if (shared.subtypes.has(subtype)) return null;
+  }""",
+"""  if ([...own.subtypes].every(subtype => shared.subtypes.has(subtype))) return null;""")
+open(p, "w").write(s)
+PY
+}
+
+m_unclassified_candidate_is_gated() {
+  py <<'PY'
+p = "src/product-role.ts"
+s = open(p).read()
+s = s.replace("""  const own = subtypesOf(candidate);
+  if (!own) return null;
+  const shared""",
+"""  const own = subtypesOf(candidate) ?? { taxonomy: subjectProfiles[0]?.taxonomy ?? "", subtypes: new Set<string>() };
+  const shared""")
+open(p, "w").write(s)
+PY
+}
+
+m_unclassified_subject_gates_everything() {
+  py <<'PY'
+p = "src/product-role.ts"
+s = open(p).read()
+s = s.replace("  if (!shared || shared.subtypes.size === 0) return null;",
+              "  if (!shared) return null;")
+open(p, "w").write(s)
+PY
+}
+
+m_taxonomy_is_not_compared() {
+  py <<'PY'
+p = "src/product-role.ts"
+s = open(p).read()
+s = s.replace("  const shared = subjectProfiles.find(p => p.taxonomy === own.taxonomy);",
+              "  const shared = subjectProfiles[0];")
+open(p, "w").write(s)
+PY
+}
+
+m_empty_labels_report_the_wrong_gate() {
+  py <<'PY'
+p = "src/product-role.ts"
+s = open(p).read()
+s = s.replace('  return own.subtypes.size === 0 ? "not_in_taxonomy" : "subtype_mismatch";',
+              '  return "subtype_mismatch";')
+open(p, "w").write(s)
+PY
+}
+
+m_subtypes_are_unioned_across_taxonomies() {
+  py <<'PY'
+p = "src/product-role.ts"
+s = open(p).read()
+s = s.replace("""    if (!byTaxonomy.has(own.taxonomy)) byTaxonomy.set(own.taxonomy, new Set());
+    for (const subtype of own.subtypes) byTaxonomy.get(own.taxonomy)!.add(subtype);""",
+"""    if (!byTaxonomy.has("all")) byTaxonomy.set("all", new Set());
+    for (const subtype of own.subtypes) byTaxonomy.get("all")!.add(subtype);""")
+open(p, "w").write(s)
+PY
+}
+
+m_curated_names_are_subtype_gated() {
+  py <<'PY'
+p = "src/curated-alternatives.ts"
+s = open(p).read()
+s = s.replace("partitionAlternativesAcross(matched, subjects, { applySubtypes: false })",
+              "partitionAlternativesAcross(matched, subjects)")
+open(p, "w").write(s)
+PY
+}
+
+m_alternatives_page_subtype_gates_curated_names() {
+  py <<'PY'
+p = "src/serve.ts"
+s = open(p).read()
+s = s.replace("    subtypeExempt: candidate => curatedAltNames.has(candidate.vendor),",
+              "    subtypeExempt: () => false,")
+open(p, "w").write(s)
+PY
+}
+
+m_vendor_page_hides_the_subtypes() {
+  py <<'PY'
+p = "src/serve.ts"
+s = open(p).read()
+s = s.replace("${productRoleLine}${productSubtypesLine}",
+              "${productRoleLine}")
+open(p, "w").write(s)
+PY
+}
+
+m_vendor_page_hides_the_subtype_source() {
+  py <<'PY'
+p = "src/serve.ts"
+s = open(p).read()
+s = s.replace("""    const read = sources.length > 0
+      ? ` We read that on""",
+"""    const read = sources.length > 2
+      ? ` We read that on""")
+open(p, "w").write(s)
+PY
+}
+
+m_criteria_page_drops_the_taxonomy_tables() {
+  py <<'PY'
+p = "src/serve.ts"
+s = open(p).read()
+s = s.replace("""${subtypeTaxonomyTables}
+  <p>Subtypes are published""",
+"""  <p>Subtypes are published""")
+open(p, "w").write(s)
+PY
+}
+
+m_criteria_page_prints_names_without_definitions() {
+  py <<'PY'
+p = "src/serve.ts"
+s = open(p).read()
+s = s.replace("<td>${escHtmlServer(e.definition)}</td></tr>",
+              "<td></td></tr>")
+open(p, "w").write(s)
+PY
+}
+
+m_category_pages_are_filtered_too() {
+  py <<'PY'
+p = "src/product-role.ts"
+s = open(p).read()
+s = s.replace("""export function subtypesOf(offer: RoleCarrier): SubtypeProfile | null {
+  const classified = offer.product_subtypes;
+  if (!classified) return null;""",
+"""export function subtypesOf(offer: RoleCarrier): SubtypeProfile | null {
+  const classified = offer.product_subtypes;
+  if (!classified) return { taxonomy: "Databases", subtypes: new Set<string>() };""")
+open(p, "w").write(s)
+PY
+}
+
+echo "mutations for #1032 Phase 2 — subtypes gate membership and nothing else"
+echo
+
+run_mutation "the subtype gate never fires" m_subtype_gate_never_fires
+run_mutation "membership requires every subtype to match rather than one" m_match_requires_every_subtype
+run_mutation "a record we never classified is gated" m_unclassified_candidate_is_gated
+run_mutation "a subject with no subtype of its own gates every candidate" m_unclassified_subject_gates_everything
+run_mutation "subtypes are compared without checking the taxonomy" m_taxonomy_is_not_compared
+run_mutation "subtypes are unioned across taxonomies" m_subtypes_are_unioned_across_taxonomies
+run_mutation "an empty label set reports the mismatch gate" m_empty_labels_report_the_wrong_gate
+run_mutation "curated names are subtype gated in the curated block" m_curated_names_are_subtype_gated
+run_mutation "curated names are subtype gated on the alternatives page" m_alternatives_page_subtype_gates_curated_names
+run_mutation "the vendor page publishes no subtypes" m_vendor_page_hides_the_subtypes
+run_mutation "the vendor page publishes subtypes with no source" m_vendor_page_hides_the_subtype_source
+run_mutation "the criteria page drops the taxonomy tables" m_criteria_page_drops_the_taxonomy_tables
+run_mutation "the criteria page names subtypes without their definitions" m_criteria_page_prints_names_without_definitions
+run_mutation "an unclassified record is treated as classified with no labels" m_category_pages_are_filtered_too
+
+echo
+echo "killed=$killed survived=$survived"
+[ "$survived" -eq 0 ]

--- a/src/curated-alternatives.ts
+++ b/src/curated-alternatives.ts
@@ -62,7 +62,7 @@ export function curatedAlternativesFor(
   subjects: RoleCarrier[],
 ): CuratedAlternativesForVendor {
   const { matched, unmatched } = resolveCuratedAlternatives(vendorName, changes, offers);
-  const partition = partitionAlternativesAcross(matched, subjects);
+  const partition = partitionAlternativesAcross(matched, subjects, { applySubtypes: false });
   return { kept: partition.kept, removed: partition.removed, unmatched };
 }
 

--- a/src/product-role.ts
+++ b/src/product-role.ts
@@ -1,10 +1,10 @@
-import type { Offer, ProductRole } from "./types.js";
+import type { Offer, ProductRole, ProductSubtypes } from "./types.js";
 
-export type RoleCarrier = { product_role?: ProductRole };
+export type RoleCarrier = { product_role?: ProductRole; product_subtypes?: ProductSubtypes };
 
-export type MembershipGate = "local_dev_only" | "addon";
+export type MembershipGate = "local_dev_only" | "addon" | "not_in_taxonomy" | "subtype_mismatch";
 
-export const MEMBERSHIP_GATE_ORDER: MembershipGate[] = ["local_dev_only", "addon"];
+export const MEMBERSHIP_GATE_ORDER: MembershipGate[] = ["local_dev_only", "addon", "not_in_taxonomy", "subtype_mismatch"];
 
 export const MEMBERSHIP_GATE_RULES: Record<MembershipGate, { label: string; rule: string }> = {
   local_dev_only: {
@@ -15,7 +15,78 @@ export const MEMBERSHIP_GATE_RULES: Record<MembershipGate, { label: string; rule
     label: "Extends another product",
     rule: "The product adds a capability to another product rather than replacing it. It is not an alternative to the thing it augments.",
   },
+  not_in_taxonomy: {
+    label: "None of this category's subtypes apply",
+    rule: "The offer is listed in the category, but it is not one of the kinds of product the category's subtypes describe, so it is not an alternative to any of them.",
+  },
+  subtype_mismatch: {
+    label: "Shares no subtype with this product",
+    rule: "Two offers in a category are alternatives when their subtype sets share at least one member. This offer shares none with the vendor the list is about.",
+  },
 };
+
+export const SUBTYPE_TAXONOMIES: Record<string, Array<{ subtype: string; definition: string }>> = {
+  Databases: [
+    { subtype: "relational", definition: "tables, rows and joins under SQL — Postgres, MySQL, SQLite family" },
+    { subtype: "document", definition: "schemaless JSON/BSON documents as the stored unit" },
+    { subtype: "vector", definition: "stores embeddings and answers similarity queries as its primary access path" },
+    { subtype: "kv_cache", definition: "key to value, no query language over the value" },
+    { subtype: "graph", definition: "nodes and edges are the primary model, with a traversal query language" },
+    { subtype: "timeseries", definition: "rows are time-indexed measurements, retention is a first-class setting" },
+    { subtype: "analytical", definition: "columnar warehouse for aggregate scans, not row-level transactions" },
+    { subtype: "backend_platform", definition: "bundles a database with auth, functions or storage as one product" },
+  ],
+  "Cloud Hosting": [
+    { subtype: "static_site", definition: "serves prebuilt files from a CDN; there is no server process you control" },
+    { subtype: "serverless_function", definition: "your code runs per request with no long-lived instance, billed by invocation or CPU time" },
+    { subtype: "container_app", definition: "you deploy an app or image and the platform keeps a process running for it" },
+    { subtype: "shared_web_hosting", definition: "a directory on a managed server, reached by FTP or SSH, with a bundled MySQL or Postgres" },
+    { subtype: "managed_cms_hosting", definition: "hosting specialised to one CMS or documentation framework, provisioned and updated by the host" },
+    { subtype: "site_builder", definition: "you author the site in the vendor's own editor and it is served from there" },
+    { subtype: "backend_as_a_service", definition: "an API bundling a datastore with auth, push or realtime; there is no server you deploy" },
+    { subtype: "agent_sandbox", definition: "isolated execution environments provisioned programmatically, sold for AI agent workloads" },
+  ],
+};
+
+export const SUBTYPE_MEMBERSHIP_RULE =
+  "Two offers in the same category are alternatives when their subtype sets share at least one member. A record we have not classified carries no subtype gate at all, in either direction.";
+
+export function subtypeDefinition(taxonomy: string, subtype: string): string | null {
+  return SUBTYPE_TAXONOMIES[taxonomy]?.find(t => t.subtype === subtype)?.definition ?? null;
+}
+
+export interface SubtypeProfile {
+  taxonomy: string;
+  subtypes: Set<string>;
+}
+
+export function subtypesOf(offer: RoleCarrier): SubtypeProfile | null {
+  const classified = offer.product_subtypes;
+  if (!classified) return null;
+  return { taxonomy: classified.taxonomy, subtypes: new Set(classified.labels.map(l => l.subtype)) };
+}
+
+export function subtypesAcross(subjects: RoleCarrier[]): SubtypeProfile[] {
+  const byTaxonomy = new Map<string, Set<string>>();
+  for (const subject of subjects) {
+    const own = subtypesOf(subject);
+    if (!own) continue;
+    if (!byTaxonomy.has(own.taxonomy)) byTaxonomy.set(own.taxonomy, new Set());
+    for (const subtype of own.subtypes) byTaxonomy.get(own.taxonomy)!.add(subtype);
+  }
+  return [...byTaxonomy.entries()].map(([taxonomy, subtypes]) => ({ taxonomy, subtypes }));
+}
+
+function subtypeGate(candidate: RoleCarrier, subjectProfiles: SubtypeProfile[]): MembershipGate | null {
+  const own = subtypesOf(candidate);
+  if (!own) return null;
+  const shared = subjectProfiles.find(p => p.taxonomy === own.taxonomy);
+  if (!shared || shared.subtypes.size === 0) return null;
+  for (const subtype of own.subtypes) {
+    if (shared.subtypes.has(subtype)) return null;
+  }
+  return own.subtypes.size === 0 ? "not_in_taxonomy" : "subtype_mismatch";
+}
 
 export const MEMBERSHIP_GATE_SYMMETRY =
   "A gate removes an offer from an alternatives list only when the vendor the list is about does not carry the same gate. One local emulator is still an alternative to another; one add-on is still an alternative to another.";
@@ -35,8 +106,10 @@ export function membershipGatesFor(offer: RoleCarrier): Set<MembershipGate> {
   return gates;
 }
 
-function gateAgainst(candidate: RoleCarrier, subjectGates: Set<MembershipGate>): MembershipGate | null {
+function gateAgainst(candidate: RoleCarrier, subjectGates: Set<MembershipGate>, subjectProfiles: SubtypeProfile[]): MembershipGate | null {
   const candidateGates = membershipGatesFor(candidate);
+  const fromSubtypes = subtypeGate(candidate, subjectProfiles);
+  if (fromSubtypes) candidateGates.add(fromSubtypes);
   for (const gate of MEMBERSHIP_GATE_ORDER) {
     if (candidateGates.has(gate) && !subjectGates.has(gate)) return gate;
   }
@@ -44,7 +117,7 @@ function gateAgainst(candidate: RoleCarrier, subjectGates: Set<MembershipGate>):
 }
 
 export function alternativeMembershipGate(candidate: RoleCarrier, subject: RoleCarrier): MembershipGate | null {
-  return gateAgainst(candidate, membershipGatesFor(subject));
+  return gateAgainst(candidate, membershipGatesFor(subject), subtypesAcross([subject]));
 }
 
 export function membershipGatesAcross(subjects: RoleCarrier[]): Set<MembershipGate> {
@@ -68,12 +141,22 @@ export interface AlternativesPartition<T extends RoleCarrier> {
   removed: Array<{ offer: T; gate: MembershipGate }>;
 }
 
-export function partitionAlternativesAcross<T extends RoleCarrier>(candidates: T[], subjects: RoleCarrier[]): AlternativesPartition<T> {
+export interface MembershipOptions<T extends RoleCarrier = RoleCarrier> {
+  applySubtypes?: boolean;
+  subtypeExempt?: (candidate: T) => boolean;
+}
+
+export const CURATED_SUBTYPE_EXEMPTION =
+  "A curated alternative is a pair a person wrote down for this vendor by name. That is a stronger claim than a subtype match, so subtypes never remove one; the product-role gates still do, because a local emulator does not replace a hosted service whoever names it.";
+
+export function partitionAlternativesAcross<T extends RoleCarrier>(candidates: T[], subjects: RoleCarrier[], options: MembershipOptions<T> = {}): AlternativesPartition<T> {
   const subjectGates = membershipGatesAcross(subjects);
+  const subjectProfiles = options.applySubtypes === false ? [] : subtypesAcross(subjects);
   const kept: T[] = [];
   const removed: Array<{ offer: T; gate: MembershipGate }> = [];
   for (const candidate of candidates) {
-    const gate = gateAgainst(candidate, subjectGates);
+    const profiles = options.subtypeExempt?.(candidate) ? [] : subjectProfiles;
+    const gate = gateAgainst(candidate, subjectGates, profiles);
     if (gate) removed.push({ offer: candidate, gate });
     else kept.push(candidate);
   }

--- a/src/serve.ts
+++ b/src/serve.ts
@@ -43,7 +43,7 @@ import { discontinuedOnOrBefore } from "./product-deprecation.js";
 import { rankOffers, rankForListing, rotateListing, utcDate, CRITERIA_PATH, DEMOTE_ONLY_POLICY, DISCLOSURE_RATIONALE, TIE_BREAK_ALGORITHM, GATE_TABLE, DEMERIT_TABLE, NOT_FREE_TIER_RULES, TIME_LIMITED_TIER_RULES, type TieBreak } from "./ranking.js";
 import type { RankedEntry, RankingResult } from "./ranking.js";
 import { verificationLedger, QUARANTINE_AFTER_FAILURES } from "./verification-state.js";
-import { partitionAlternatives, partitionAlternativesAcross, productRoleSentence, MEMBERSHIP_GATE_RULES, MEMBERSHIP_GATE_ORDER, MEMBERSHIP_GATE_SYMMETRY, MEMBERSHIP_GATE_SCOPE, MEMBERSHIP_GATE_CORRECTIONS } from "./product-role.js";
+import { partitionAlternatives, partitionAlternativesAcross, productRoleSentence, MEMBERSHIP_GATE_RULES, MEMBERSHIP_GATE_ORDER, MEMBERSHIP_GATE_SYMMETRY, MEMBERSHIP_GATE_SCOPE, MEMBERSHIP_GATE_CORRECTIONS, SUBTYPE_TAXONOMIES, SUBTYPE_MEMBERSHIP_RULE, subtypeDefinition } from "./product-role.js";
 import { resolveCuratedAlternatives, curatedAlternativesFor, addCuratedToPool } from "./curated-alternatives.js";
 import type { Agent, ChangeDateSource, DealChange, RiskCause, LinkUnreachable, Offer } from "./types.js";
 import { changeDateLabel, changeDateClause, changeDatePublished, changeEventStartDate, capListSections, latestEventDate, offerExpiryAfter, feedEntryUpdated, undatedGroupHeading, firstReadHeading, discoveryBatchNote, DISCOVERED_DATE_PREFIX, UNDATED_GROUP_NOTE } from "./change-dates.js";
@@ -1836,6 +1836,18 @@ function buildCriteriaPage(): string {
   const membershipGateRows = MEMBERSHIP_GATE_ORDER.map(g => `<tr><td><code>${escHtmlServer(g)}</code> &mdash; ${escHtmlServer(MEMBERSHIP_GATE_RULES[g].label)}</td><td>${escHtmlServer(MEMBERSHIP_GATE_RULES[g].rule)}</td></tr>`).join("\n");
   const classifiedCount = offers.filter(o => o.product_role).length;
   const gatedCount = offers.filter(o => o.product_role && (o.product_role.deployment_model === "local_dev_only" || o.product_role.is_addon)).length;
+  const subtypeTaxonomyTables = Object.entries(SUBTYPE_TAXONOMIES).map(([taxonomy, entries]) => `  <h4>${escHtmlServer(taxonomy)}</h4>
+  <table><thead><tr><th>Subtype</th><th>What it means</th></tr></thead><tbody>
+${entries.map(e => `<tr><td><code>${escHtmlServer(e.subtype)}</code></td><td>${escHtmlServer(e.definition)}</td></tr>`).join("\n")}
+  </tbody></table>`).join("\n");
+  const subtypeCoverageClause = (() => {
+    const parts = Object.keys(SUBTYPE_TAXONOMIES).map(taxonomy => {
+      const inTaxonomy = offers.filter(o => o.category === taxonomy);
+      const done = inTaxonomy.filter(o => o.product_subtypes).length;
+      return `${done} of ${inTaxonomy.length} in ${taxonomy}`;
+    });
+    return `We have classified ${parts.join(", ")}; the other ${offers.length - offers.filter(o => o.product_subtypes).length} records in the index carry no subtype and are gated by none.`;
+  })();
 
   const jsonLd = {
     "@context": "https://schema.org",
@@ -1954,15 +1966,20 @@ ${demeritRows}
   <h2>4. What we do not model</h2>
   <p>We rank on offer terms, verification recency and recorded adverse changes. <strong style="color:var(--text)">We do not model technical fit</strong> &mdash; whether a particular product suits a particular role in your architecture. A vector database and a relational database sit in the same category here. If you are asking us which of two products fits your app, we are the wrong source; if you are asking whose free tier we could confirm this week and whose was withdrawn in March, that is exactly what this is for.</p>
 
-  <h2 id="membership">5. Two product properties that decide membership, and never order</h2>
-  <p>Section 4 is about fit and it still stands. This is a different thing: two factual properties of a product, of the same kind as its category and read from the vendor's own words. They answer whether a product <em>could</em> stand in for another at all, not whether it would suit you better.</p>
+  <h2 id="membership">5. Product properties that decide membership, and never order</h2>
+  <p>Section 4 is about fit and it still stands. This is a different thing: factual properties of a product, of the same kind as its category and read from the vendor's own words. They answer whether a product <em>could</em> stand in for another at all, not whether it would suit you better.</p>
   <table><thead><tr><th>Property</th><th>What it means</th></tr></thead><tbody>
 ${membershipGateRows}
   </tbody></table>
   <p>${escHtmlServer(MEMBERSHIP_GATE_SYMMETRY)}</p>
   <p>${escHtmlServer(MEMBERSHIP_GATE_SCOPE)}</p>
-  <p><strong style="color:var(--text)">Neither property is available on request.</strong> A vendor cannot ask to be classified, declassified, or exempted, for the same reason there is no top slot to buy. ${escHtmlServer(MEMBERSHIP_GATE_CORRECTIONS)}</p>
+  <p><strong style="color:var(--text)">No property here is available on request.</strong> A vendor cannot ask to be classified, declassified, or exempted, for the same reason there is no top slot to buy. ${escHtmlServer(MEMBERSHIP_GATE_CORRECTIONS)}</p>
   <p>The honest limit: we have classified ${classifiedCount} of ${offers.length} records, ${gatedCount} of which carry a gate. <strong style="color:var(--text)">A record with no classification has not been reviewed &mdash; it does not mean we have checked and found it hosted.</strong> Absence of the property publishes nothing in either direction and gates nothing, which is the same rule we use for a link we were merely refused.</p>
+
+  <h3 id="subtypes">Subtypes</h3>
+  <p>A category is a coarse property. Where we have published a subtype taxonomy for a category, the same discipline applies one level finer: a subtype is what the vendor's own copy says the product <em>is</em>, it is multi-label, and it decides membership only. ${escHtmlServer(SUBTYPE_MEMBERSHIP_RULE)}</p>
+${subtypeTaxonomyTables}
+  <p>Subtypes are published on every classified vendor page with the source URL and the sentence they were read from, exactly as the properties above are. ${subtypeCoverageClause}</p>
 
   <h2>6. What agents tell us, and what we do with it</h2>
   <p>Agents can report which vendor they recommended, at <a href="${SIGNAL_DOC_PATH}"><code>${escHtmlServer(SIGNAL_PATH)}</code></a>. <strong style="color:var(--text)">Those counts never affect any order we publish</strong> &mdash; not now, not behind a flag. A self-reported counter that influenced placement would be a purchasable ranking with extra steps, and the whole reason to trust this index is that there is no such thing.</p>
@@ -3670,6 +3687,24 @@ function buildVendorPage(slug: string): string | null {
     return `  <p class="product-role-line" style="margin:.4rem 0 .6rem;font-size:.9rem;color:var(--text-muted)"><strong>Product role:</strong> ${escHtmlServer(sentence)} We read that from <a href="${escHtmlServer(role.source_url)}" rel="nofollow noopener">${escHtmlServer(role.source_url)}</a> on <span class="product-role-reviewed" style="font-family:var(--mono)">${escHtmlServer(role.reviewed)}</span>, where it says: &ldquo;${escHtmlServer(role.source_quote)}&rdquo; <a href="${CRITERIA_PATH}#membership">How we use this</a>.</p>`;
   })();
 
+  const productSubtypesLine = (() => {
+    const classified = primary.product_subtypes;
+    if (!classified) return "";
+    const body = classified.labels.length === 0
+      ? `${escHtmlServer(MEMBERSHIP_GATE_RULES.not_in_taxonomy.label)}.`
+      : classified.labels
+          .map(l => `<code>${escHtmlServer(l.subtype)}</code> &mdash; ${escHtmlServer(subtypeDefinition(classified.taxonomy, l.subtype) ?? "")}`)
+          .join("; ") + ".";
+    const sources = [...new Map(classified.labels.map(l => [l.source_url, l])).values()];
+    const provenance = sources
+      .map(l => `<a href="${escHtmlServer(l.source_url)}" rel="nofollow noopener">${escHtmlServer(l.source_url)}</a>, where it says: &ldquo;${escHtmlServer(l.source_quote)}&rdquo;`)
+      .join(" and from ");
+    const read = sources.length > 0
+      ? ` We read that on <span class="product-subtypes-reviewed" style="font-family:var(--mono)">${escHtmlServer(classified.reviewed)}</span> from ${provenance}`
+      : "";
+    return `\n  <p class="product-subtypes-line" style="margin:.4rem 0 .6rem;font-size:.9rem;color:var(--text-muted)"><strong>Subtypes in ${escHtmlServer(classified.taxonomy)}:</strong> ${body}${read} <a href="${CRITERIA_PATH}#subtypes">How we use this</a>.</p>`;
+  })();
+
   const alternativesMembership = partitionAlternatives(
     offers.filter(o => o.category === primary.category && o.vendor !== vendorName),
     primary,
@@ -4058,7 +4093,7 @@ ${allCompareLinks.join("\n")}
     { q: `Is ${vendorName}'s free tier reliable?`, a: faqReliableAnswer },
     { q: `Is ${vendorName}'s free tier good for production?`, a: faqProductionAnswer },
     { q: `What changed in ${vendorName}'s pricing recently?`, a: faqChangedAnswer },
-    { q: `What are the best free alternatives to ${vendorName}?`, a: faqAlternativesAnswer },
+    ...(alternatives.length > 0 ? [{ q: `What are the best free alternatives to ${vendorName}?`, a: faqAlternativesAnswer }] : []),
     { q: `When will I outgrow ${vendorName}'s free tier?`, a: faqOutgrowAnswer },
     { q: `What category is ${vendorName} in?`, a: faqCategoryAnswer },
   ];
@@ -4171,7 +4206,7 @@ ${mcpCtaCss()}
   <h1>${escHtmlServer(vendorName)} Free Tier ${currentYear}${h1RiskBadge}</h1>
 ${riskCauseLine}
 ${linkUnreachableLine}
-${productRoleLine}
+${productRoleLine}${productSubtypesLine}
   <p class="page-meta">Limits, pricing history, and ${alternatives.length} alternatives.${verifiedSentence} Last updated ${escHtmlServer(lastUpdated)}.</p>
 ${quickVerdictHtml}
 ${categoryContextHtml}
@@ -4277,7 +4312,9 @@ function buildAlternativesPage(slug: string): string | null {
   }
   const curated = resolveCuratedAlternatives(vendorName, allChanges, offers);
   const curatedAltNames = new Set(curated.matched.map(o => o.vendor));
-  const altMembership = partitionAlternativesAcross(addCuratedToPool(dedupedAlts, curated.matched), vendorOffers);
+  const altMembership = partitionAlternativesAcross(addCuratedToPool(dedupedAlts, curated.matched), vendorOffers, {
+    subtypeExempt: candidate => curatedAltNames.has(candidate.vendor),
+  });
   const altRanking = rankForListing(enrichOffers(altMembership.kept), {
     queryKey: `alternative-to:${vendorName}`,
     changes: dealChanges,

--- a/src/types.ts
+++ b/src/types.ts
@@ -48,6 +48,18 @@ export interface ProductRole {
   reviewed: string;
 }
 
+export interface SubtypeLabel {
+  subtype: string;
+  source_url: string;
+  source_quote: string;
+}
+
+export interface ProductSubtypes {
+  taxonomy: string;
+  labels: SubtypeLabel[];
+  reviewed: string;
+}
+
 export interface Offer {
   vendor: string;
   category: string;
@@ -62,6 +74,7 @@ export interface Offer {
   referral?: Referral;
   referral_program?: ReferralProgram;
   product_role?: ProductRole;
+  product_subtypes?: ProductSubtypes;
   source_check?: SourceCheck;
 }
 

--- a/test/alternatives-membership.test.ts
+++ b/test/alternatives-membership.test.ts
@@ -341,16 +341,86 @@ describe("#1032 a classification must not contradict what we already publish", (
       `we recommend these as alternatives in our own dated records and cannot also hold that they replace nothing: ${conflicts.join(", ")}`
     );
   });
+
+  it("never lets a subtype remove a pair a person wrote into a change record", async () => {
+    const { curatedAlternativesFor } = await import("../dist/curated-alternatives.js");
+    const allChanges = JSON.parse(readFileSync(path.join(REPO, "data", "deal_changes.json"), "utf-8")).changes;
+    const dropped: string[] = [];
+    let pairs = 0;
+    for (const vendor of new Set(offers.map((o) => o.vendor))) {
+      const result = curatedAlternativesFor(vendor, allChanges, offers, offers.filter((o) => o.vendor === vendor));
+      pairs += result.kept.length + result.removed.length;
+      for (const r of result.removed) {
+        if (r.gate === "subtype_mismatch" || r.gate === "not_in_taxonomy") dropped.push(`${vendor} -> ${r.offer.vendor}`);
+      }
+    }
+    assert.ok(pairs > 100, `the change records must resolve to pairs for this test to mean anything, found ${pairs}`);
+    assert.deepStrictEqual(dropped, [], `a curated pair is a stronger claim than a taxonomy match: ${dropped.join(", ")}`);
+  });
+
+  it("keeps a curated name whose subtype differs from the subject's on both published surfaces", async () => {
+    const subject = "Vercel";
+    const crossing = ["Render", "Railway"];
+    const { partitionAlternatives } = await import("../dist/product-role.js");
+    const vercel = offers.find((o) => o.vendor === subject)!;
+    for (const name of crossing) {
+      const candidate = offers.find((o) => o.vendor === name)!;
+      assert.equal(
+        partitionAlternatives([candidate], vercel).removed[0]?.gate,
+        "subtype_mismatch",
+        `${name} must be subtype-gated against ${subject} for this test to mean anything`
+      );
+    }
+    const cardName: Record<string, string> = {
+      "/vendor/vercel": "alt-name",
+      "/alternative-to/vercel": "alt-vendor-name",
+    };
+    for (const [url, cls] of Object.entries(cardName)) {
+      const { body } = await get(url);
+      const listed = [...body.matchAll(new RegExp(`class="${cls}">([^<]+)<`, "g"))].map(m => m[1]);
+      assert.ok(listed.length > 3, `${url} rendered no alternatives cards, so this test proves nothing`);
+      for (const name of crossing) {
+        assert.ok(listed.includes(name), `${url} drops the curated name ${name} from its cards`);
+      }
+    }
+  });
 });
 
 describe("#1032 the rule is published", () => {
-  it("explains both properties on the criteria page", async () => {
+  it("explains every membership property on the criteria page", async () => {
     const { status, body } = await get("/criteria");
     assert.equal(status, 200);
     assert.ok(body.includes('id="membership"'), "the criteria page must carry the anchor the vendor pages link to");
     assert.ok(body.includes("local_dev_only"), "the criteria page must name the deployment property");
     assert.ok(body.includes("addon"), "the criteria page must name the add-on property");
-    assert.match(body, /Neither property is available on request/, "the criteria page must say the classification cannot be requested");
+    assert.match(body, /available on request/, "the criteria page must say the classification cannot be requested");
     assert.match(body, /has not been reviewed/, "the criteria page must say what an unclassified record means");
+  });
+
+  it("publishes every subtype it gates on, with the definition it gates by", async () => {
+    const { SUBTYPE_TAXONOMIES } = await import("../dist/product-role.js");
+    const { status, body } = await get("/criteria");
+    assert.equal(status, 200);
+    assert.ok(body.includes('id="subtypes"'), "the criteria page must carry the subtype anchor the vendor pages link to");
+    for (const [taxonomy, entries] of Object.entries(SUBTYPE_TAXONOMIES) as [string, Array<{ subtype: string; definition: string }>][]) {
+      assert.ok(body.includes(taxonomy), `${taxonomy} is not named on the criteria page`);
+      for (const entry of entries) {
+        assert.ok(body.includes(`<code>${entry.subtype}</code>`), `${entry.subtype} is not named on the criteria page`);
+        assert.ok(body.includes(entry.definition.replace(/&/g, "&amp;")), `${entry.subtype} is named without the definition it gates by`);
+      }
+    }
+  });
+
+  it("publishes the subtypes and their source on the vendor page that carries them", async () => {
+    const { body } = await get("/vendor/neon");
+    const line = body.match(/<p class="product-subtypes-line"[\s\S]*?<\/p>/);
+    assert.ok(line, "the vendor page must publish its subtypes");
+    const neon = offers.find((o) => o.vendor === "Neon")!;
+    for (const label of neon.product_subtypes!.labels) {
+      assert.ok(line[0].includes(`<code>${label.subtype}</code>`), `${label.subtype} is not published on /vendor/neon`);
+      assert.ok(line[0].includes(label.source_url), `${label.subtype} is published without the URL it was read from`);
+      assert.ok(line[0].includes(label.source_quote.slice(0, 40)), `${label.subtype} is published without the sentence it was read from`);
+    }
+    assert.ok(line[0].includes(neon.product_subtypes!.reviewed), "the vendor page must publish the date the subtypes were reviewed");
   });
 });

--- a/test/curated-alternatives.test.ts
+++ b/test/curated-alternatives.test.ts
@@ -388,12 +388,16 @@ describe("curated alternatives on the published pages", () => {
     }
   });
 
-  it("keeps every category member on a page whose curated names are all in category", async () => {
+  it("keeps every ungated category member on a page whose curated names are all in category", async () => {
+    const { partitionAlternativesAcross } = await import("../dist/product-role.js");
     const res = await get("/alternative-to/xata");
     assert.strictEqual(res.status, 200);
     const count = res.body.match(/All Free Alternatives \((\d+)\)/);
     assert.ok(count, "no alternatives count");
-    assert.ok(Number(count[1]) >= categoryPoolFor("Xata").length - 5, `only ${count[1]} alternatives`);
+    const xata = offers.filter(o => o.vendor === "Xata");
+    const ungated = partitionAlternativesAcross(categoryPoolFor("Xata"), xata).kept.length;
+    assert.ok(ungated > 0, "the ungated pool must not be empty for this test to mean anything");
+    assert.strictEqual(Number(count[1]), ungated, `expected every ungated category member, saw ${count[1]} of ${ungated}`);
     for (const vendor of ["Neon", "Supabase", "CockroachDB"]) {
       assert.ok(res.body.includes(`>${vendor}<`), `${vendor} is not listed`);
     }

--- a/test/product-role.test.ts
+++ b/test/product-role.test.ts
@@ -12,8 +12,11 @@ import {
   partitionRoleCandidates,
   filterAlternatives,
   productRoleSentence,
+  subtypesOf,
+  subtypeDefinition,
   MEMBERSHIP_GATE_ORDER,
   MEMBERSHIP_GATE_RULES,
+  SUBTYPE_TAXONOMIES,
 } from "../src/product-role.ts";
 import { rankForListing, rankOffers } from "../src/ranking.ts";
 import type { Offer, ProductRole, DeploymentModel } from "../src/types.ts";
@@ -45,6 +48,22 @@ function offer(vendor: string, role?: Partial<ProductRole>): Offer {
           } as ProductRole,
         }
       : {}),
+  };
+}
+
+function labelled(vendor: string, subtypes: string[], taxonomy = "Databases"): Offer {
+  return {
+    ...offer(vendor),
+    category: taxonomy,
+    product_subtypes: {
+      taxonomy,
+      labels: subtypes.map(subtype => ({
+        subtype,
+        source_url: `https://${vendor.toLowerCase()}.example/`,
+        source_quote: `${vendor} is a ${subtype}`,
+      })),
+      reviewed: "2026-08-31",
+    },
   };
 }
 
@@ -88,6 +107,99 @@ describe("#1032 which product properties gate membership", () => {
       [...MEMBERSHIP_GATE_ORDER].sort(),
       "the published table and the applied order must name the same gates"
     );
+  });
+});
+
+describe("#1032 Phase 2 subtypes gate on sharing at least one label", () => {
+  const relational = labelled("Relational", ["relational"]);
+  const vector = labelled("Vector", ["vector"]);
+  const multi = labelled("Multi", ["relational", "vector"]);
+  const none = labelled("None", []);
+  const unlabelled = offer("Unlabelled");
+  const otherTaxonomy = labelled("Hosted App", ["container_app"], "Cloud Hosting");
+
+  it("removes a candidate that shares no subtype with the subject", () => {
+    assert.equal(alternativeMembershipGate(vector, relational), "subtype_mismatch");
+  });
+
+  it("keeps a candidate that shares one subtype out of several", () => {
+    assert.equal(alternativeMembershipGate(multi, relational), null);
+    assert.equal(alternativeMembershipGate(multi, vector), null);
+  });
+
+  it("keeps a candidate on the page of a subject that shares one of its labels", () => {
+    assert.equal(alternativeMembershipGate(relational, multi), null);
+    assert.equal(alternativeMembershipGate(vector, multi), null);
+  });
+
+  it("removes a candidate that carries no subtype from a labelled subject", () => {
+    assert.equal(alternativeMembershipGate(none, relational), "not_in_taxonomy");
+  });
+
+  it("never gates a record we have not classified, in either direction", () => {
+    assert.equal(alternativeMembershipGate(unlabelled, relational), null);
+    assert.equal(alternativeMembershipGate(relational, unlabelled), null);
+  });
+
+  it("applies no subtype gate on the page of a subject that carries no subtype of its own", () => {
+    assert.equal(alternativeMembershipGate(relational, none), null);
+    assert.equal(alternativeMembershipGate(vector, none), null);
+  });
+
+  it("never compares subtypes across two different taxonomies", () => {
+    assert.equal(alternativeMembershipGate(otherTaxonomy, relational), null);
+    assert.equal(alternativeMembershipGate(relational, otherTaxonomy), null);
+  });
+
+  it("lets a caller exempt a candidate from the subtype gate without exempting the role gates", () => {
+    const gatedAddon = { ...labelled("CuratedAddon", ["vector"]), product_role: addon.product_role };
+    const exempt = partitionAlternativesAcross([vector, gatedAddon], [relational], { subtypeExempt: () => true });
+    assert.deepStrictEqual(exempt.kept.map(o => o.vendor), ["Vector"]);
+    assert.deepStrictEqual(exempt.removed.map(r => r.gate), ["addon"]);
+    const applied = partitionAlternativesAcross([vector], [relational]);
+    assert.deepStrictEqual(applied.removed.map(r => r.gate), ["subtype_mismatch"]);
+  });
+
+  it("publishes a definition for every subtype the taxonomies name", () => {
+    for (const [taxonomy, entries] of Object.entries(SUBTYPE_TAXONOMIES)) {
+      for (const entry of entries) {
+        assert.equal(subtypeDefinition(taxonomy, entry.subtype), entry.definition);
+      }
+    }
+  });
+
+  it("uses only subtypes its own taxonomy names", () => {
+    const strays: string[] = [];
+    for (const record of index.offers) {
+      const classified = record.product_subtypes;
+      if (!classified) continue;
+      const known = new Set((SUBTYPE_TAXONOMIES[classified.taxonomy] ?? []).map(e => e.subtype));
+      assert.ok(known.size > 0, `${classified.taxonomy} has no published taxonomy`);
+      assert.equal(classified.taxonomy, record.category, `${record.vendor} is classified under a taxonomy that is not its category`);
+      for (const label of classified.labels) {
+        if (!known.has(label.subtype)) strays.push(`${record.vendor}: ${label.subtype}`);
+      }
+    }
+    assert.deepStrictEqual(strays, []);
+  });
+
+  it("carries a source URL and the sentence read from it on every label", () => {
+    const bare: string[] = [];
+    for (const record of index.offers) {
+      for (const label of record.product_subtypes?.labels ?? []) {
+        if (!/^https:\/\//.test(label.source_url) || label.source_quote.trim().length < 10) {
+          bare.push(`${record.vendor}: ${label.subtype}`);
+        }
+      }
+    }
+    assert.deepStrictEqual(bare, [], "a subtype nobody can check is not a published property");
+  });
+
+  it("reads back the labels it was given", () => {
+    assert.deepStrictEqual([...subtypesOf(multi)!.subtypes], ["relational", "vector"]);
+    assert.equal(subtypesOf(multi)!.taxonomy, "Databases");
+    assert.equal(subtypesOf(unlabelled), null);
+    assert.deepStrictEqual([...subtypesOf(none)!.subtypes], []);
   });
 });
 
@@ -165,9 +277,35 @@ describe("#1032 neither property can reach scoring or ordering", () => {
   const rankingSource = readFileSync(join(REPO, "src", "ranking.ts"), "utf8");
 
   it("the selection module does not mention either property", () => {
-    for (const banned of [/product_role/, /deployment_model/, /is_addon/, /local_dev_only/]) {
+    for (const banned of [/product_role/, /deployment_model/, /is_addon/, /local_dev_only/, /product_subtypes/, /subtypes/]) {
       assert.ok(!banned.test(rankingSource), `the selection module must not read ${banned}`);
     }
+  });
+
+  it("relabelling every subtype leaves the order of a listing byte-identical", () => {
+    const candidates = index.offers.filter((o) => o.category === "Databases");
+    assert.ok(candidates.length > 10, "this test needs a category with enough records to order");
+    const opts = { queryKey: "order-check", changes: [], date: "2026-08-25" };
+    const before = rankForListing(candidates, opts);
+    const relabelled = candidates.map((o) => ({
+      ...o,
+      product_subtypes: {
+        taxonomy: "Databases",
+        labels: [{ subtype: "graph", source_url: "https://example.invalid/docs", source_quote: "relabelled for this test" }],
+        reviewed: "2026-08-25",
+      },
+    }));
+    const after = rankForListing(relabelled as Offer[], opts);
+    assert.deepStrictEqual(
+      after.entries.map((e) => e.offer.vendor),
+      before.entries.map((e) => e.offer.vendor),
+      "a subtype must not move a single position"
+    );
+    assert.deepStrictEqual(
+      after.entries.map((e) => e.demerit_total),
+      before.entries.map((e) => e.demerit_total),
+      "a subtype must not add or remove a single demerit point"
+    );
   });
 
   it("flipping every classification leaves the order of a listing byte-identical", () => {
@@ -269,17 +407,30 @@ describe("#1032 what the gates do to the catalogue", () => {
     assert.ok(!kept.includes("DynamoDB Local"), "a downloadable emulator is not an alternative to a hosted database");
   });
 
-  it("does not drop any category's alternatives list below three entries", () => {
-    const thin: string[] = [];
+  function keptCounts(): Array<{ label: string; kept: number }> {
+    const counts: Array<{ label: string; kept: number }> = [];
     for (const category of categories) {
       const inCategory = index.offers.filter((o) => o.category === category);
       if (inCategory.length < 4) continue;
       for (const subject of inCategory) {
         const kept = filterAlternatives(inCategory.filter((o) => o.vendor !== subject.vendor), subject);
-        if (kept.length < 3) thin.push(`${subject.vendor} (${category}): ${kept.length}`);
+        counts.push({ label: `${subject.vendor} (${category})`, kept: kept.length });
       }
     }
-    assert.deepStrictEqual(thin, [], `these alternatives lists fall below three entries: ${thin.join("; ")}`);
+    return counts;
+  }
+
+  it("leaves no alternatives list empty", () => {
+    const empty = keptCounts().filter((c) => c.kept === 0).map((c) => c.label).sort();
+    assert.deepStrictEqual(empty, [], `an empty list states in our own voice that we index no peer at all: ${empty.join("; ")}`);
+  });
+
+  it("names every alternatives list the gates leave below three entries", () => {
+    const thin = keptCounts().filter((c) => c.kept < 3).map((c) => `${c.label}: ${c.kept}`).sort();
+    assert.deepStrictEqual(thin, [
+      "InfluxDB Cloud (Databases): 1",
+      "Neo4j AuraDB (Databases): 2",
+    ]);
   });
 
   it("leaves reviewed products that are their own category's real thing ungated", () => {

--- a/test/sponsored-link-targets.test.ts
+++ b/test/sponsored-link-targets.test.ts
@@ -126,7 +126,7 @@ describe("every link we mark sponsored is a referral link we hold", () => {
   it("sweeps the whole published surface rather than a chosen sample", () => {
     assert.ok(paths.length > 3000, `expected the sitemap to enumerate the site, saw ${paths.length} paths`);
     const sponsored = [...bodies.values()].flatMap(sponsoredAnchorsIn);
-    assert.ok(sponsored.length > 50, `expected the sweep to find the sponsored links we publish, saw ${sponsored.length}`);
+    assert.ok(sponsored.length > 25, `expected the sweep to find the sponsored links we publish, saw ${sponsored.length}`);
   });
 
   it("points every sponsored link at a URL that attributes the signup to us", () => {


### PR DESCRIPTION
Refs https://github.com/robhunter/agentdeals/issues/1032 — Phase 2, both taxonomies.

An alternative meant *same category, minus this vendor*. Under that rule `/vendor/neon` offered six vector stores, three key-value stores and a warehouse as replacements for a serverless Postgres, and `/vendor/vercel` offered a documentation host, a forum host and a chat SDK. Two offers in a category are now alternatives when their **subtype sets share at least one member**.

## What is in the data

**99 of the 107 records** in `Databases` and `Cloud Hosting` carry a `product_subtypes` classification. Every label was read from the vendor's own site today and carries the URL and the sentence it was read from, published on the vendor page and in the API record.

| | Databases | Cloud Hosting |
|---|---|---|
| labelled | 35 | 49 |
| classified as *none of this category's subtypes apply* | 6 | 9 |
| left unclassified | 4 | 4 |

The 8 unclassified are not an oversight and are listed with their reason at the bottom. A record we have not classified is gated by nothing, in either direction.

## What it does to the two pages the issue is about

`/vendor/neon` — 12 alternatives → **19**, and every one is relational or a backend platform:

> CockroachDB · Turso · Supabase · Gel · PocketBase · 8base.com · Aiven · Nhost · Xata · Cloudflare D1 · Nile · SurrealDB Cloud · CrateDB · filess.io · Amazon Aurora PostgreSQL · Firebase · Convex · Appwrite Cloud · codehooks.io

Every vector store, key-value store, warehouse and graph store is gone, each named on the page with the reason. `compare_vendors` over a real MCP session returns Nhost, Convex and Turso where `main` returns Gel, Upstash and SurrealDB Cloud.

`/vendor/vercel` — the seven the issue quotes are gone; 18 remain, of which 14 are static hosts, serverless platforms or CDN-served sites.

`/redis-alternatives`, a hand-built page titled *Best Free Caching and Key-Value Stores*, drops from 8 items to 5 and stops offering Supabase, Neon, MongoDB Atlas, CockroachDB and Turso as Redis alternatives.

## Scope, measured rather than asserted

Sweep of every published path against a `main` build: **3,917 paths, 3,732 byte-identical, 185 move, 0 status changes.** The 185 are exactly the predicted set — 99 vendor pages (exactly the 99 classified records, checked name by name), 84 `/alternative-to` pages (all inside the two categories), `/criteria` and `/redis-alternatives`. **No category page, best-of page, search result or comparison page moves by a byte.**

Removals summed over every page: `subtype_mismatch` 2,724, `not_in_taxonomy` 651, `local_dev_only` 148, `addon` 86. `node scripts/membership-impact.js` prints the whole report including per-subtype membership.

**Below three.** Two pages, both in Databases, both named by a test that pins the exact set: `/vendor/influxdb-cloud` at 1 and `/vendor/neo4j-auradb` at 2. **No page is left empty.** Following the ruling in the Databases comment, neither page backfills from the category to reach three. Note this reverses Rule 3 of the committed `docs/subtype-taxonomy.md`, which says the opposite; I have marked that document superseded and left its rules intact.

**A cost worth seeing.** Sponsored anchors fall from **78 on 72 pages to 50 on 44 pages**, because Railway — the one referral link we hold — is a `container_app` and is now gated off the 31 Cloud Hosting pages whose subject is not a container platform. It stays in the curated Migration Targets block on `/vendor/vercel` and `/vendor/netlify`, where a person named it.

## Three design decisions

**1. A curated alternative is exempt from the subtype gate; the product-role gates still apply.** Measured before deciding: with the gate applied to curated names it drops 7 hand-written pairs, including Vercel → Render, Vercel → Railway, Netlify → Railway and PythonAnywhere → Render. A pair someone wrote into a change record by name is a stronger claim than a taxonomy match, and the taxonomy exists to substitute for that judgement where we do not have it. A local emulator is still not an alternative to a hosted service whoever names it, so `local_dev_only` and `addon` still remove one.

**2. Subtypes are only ever compared inside one taxonomy.** Without this, a cross-category curated pair (Cloudflare Durable Objects → Neon) compares `serverless_function` against `relational` and is dropped for sharing nothing. A mutation that removes the taxonomy check is killed.

**3. A subject that carries no subtype of its own applies no subtype gate** — the Phase 1 symmetry rule. Otherwise `/vendor/seatable`, classified as *none apply*, would render zero alternatives.

Also: the alternatives FAQ item is dropped rather than answered when the list is empty, because its zero branch says *"We don't currently track other vendors in the same category as X"*, which this gate could make false in exactly the `FAQPage` JSON-LD the issue is about. No page reaches zero today, so this is defensive.

## Where the vendor's own copy disagreed with the proposed assignment

Rule 1 says vendor copy wins. It moved eleven records. The consequential ones:

- **Neon → `relational` + `backend_platform`.** Its headline today is *"The backend for apps and agents. Build with Lakebase Postgres, Auth, Functions, Storage, and an AI Gateway"* — the same sentence shape that earns Supabase `backend_platform`. Refusing it for Neon and granting it to Supabase would be applying the rule inconsistently on the two records that matter most. **This is the disagreement to overrule first if any:** it is why Firebase, Convex, Appwrite Cloud, 8base.com and codehooks.io stay on `/vendor/neon`, against the validation table in the taxonomy document. Removing `backend_platform` from the Neon record reverses it and touches nothing else.
- **CrateDB → `relational` + `analytical`, not `relational` + `timeseries`.** Its own page leads with *"the operational analytics database"* and *"Distributed SQL"*; time-series appears in a list of capabilities, which Rule 1 excludes. This is why BigQuery has peers (CrateDB, LanceDB) and InfluxDB has none of its own.
- **LanceDB → `analytical`, not `vector`.** Both `lancedb.com` and `docs.lancedb.com` title it *"Multimodal lakehouse for AI"*.
- **Convex → `backend_platform` only.** *"the reactive backend platform"*; vector search appears as a plan feature bullet.
- **Aiven → `relational` only.** `aiven.io/postgresql` says *"Managed Postgres database service"*; no cache claim I could quote.
- **PandaStack → `serverless_function` + `container_app` + `agent_sandbox`.** Its own copy: *"Agent sandboxes with fork & snapshot, git-driven app hosting… and serverless functions"*.
- **SurrealDB Cloud gains `vector`** — its own sentence is *"Documents, graphs, vectors, and SQL in one engine"*.
- Also moved: Couchbase Capella and codehooks.io lose `kv_cache`, PocketBase loses `relational`, Firebase keeps `document` from the Firestore docs. **8base.com did not move** — `8base.com/product` says *"Serverless graphql backend-as-a-service"*.

Eight records carry a quote that names the product without naming its kind, and keep the proposed label: Vercel, Netlify, Cloudflare Pages, Deno Deploy, Fly.io, Serv00.com, simperium.com and Momento.

## Eight records left unclassified, and why

Four are already gated by Phase 1 and need no subtype: Hasura Cloud, Prisma Accelerate, DynamoDB Local. The rest could not be read at all today:

- **bismuth.cloud** and **Claw.cloud** — `ERR_NAME_NOT_RESOLVED` in headless Chromium. The domains do not resolve.
- **Gel** (`geldata.com`) — 502 on the root, `/pricing`, the docs host and the blog.
- **OpenVPS** — connection timeout.
- **SourceForge** — Cloudflare blocks us, in curl and in a real browser.

They keep full category membership, which is the safe direction, and they are why `/vendor/vercel` still shows four records whose sites we cannot reach.

## Verification

- **2,802 tests, 0 failures** (+18). `tsc`, `validate-data` (1,580 offers / 444 changes), `lint:duplicates` and `no-private-context` clean. `check-mutation-targets` 582 across 45 scripts.
- **`scripts/mutate-1032-phase2.sh`: 14 mutations, 14 killed, 0 survived.** Two survivors in an earlier run were real coverage holes and are now covered — nothing asserted that a curated pair crossing a subtype boundary survives on either published surface, and the vendor-page source assertion passed against a mutation that removed the provenance sentence, because the source URL also appears in the page's own vendor link.
- Real MCP `initialize` → `notifications/initialized` → `tools/call` on the branch build.
- Screenshots of `/vendor/neon` and `/criteria#subtypes`.
- The three tests that changed and why: the criteria test matched wording that had to change because there are no longer exactly two properties; the `/alternative-to/xata` count test asserted the category pool was intact, which Phase 2 deliberately shrinks, and now asserts the exact ungated pool; the thin-tier test forbade any list below three, which the Databases ruling reverses, and now pins the exact set and separately forbids an empty list.
