### PR TITLE
Label Render as a static site host as well as a container platform

### DIFF
--- a/data/index.json
+++ b/data/index.json
@@ -107,6 +107,11 @@
         "taxonomy": "Cloud Hosting",
         "labels": [
           {
+            "subtype": "static_site",
+            "source_url": "https://render.com/docs/static-sites",
+            "source_quote": "Host your website's frontend (React, Next.js, etc.) over a global CDN."
+          },
+          {
             "subtype": "container_app",
             "source_url": "https://render.com/docs",
             "source_quote": "Run your code in just a few clicks with Render. You decide what's possible, and we'll help bring it to life."


### PR DESCRIPTION
Refs https://github.com/robhunter/agentdeals/issues/1032

`Render` carried one subtype, `container_app`, read from `render.com/docs`. Render's own docs publish **Static Sites** as a first-class service type next to Web Services, with its own free tier:

> Host your website's frontend (React, Next.js, etc.) over a global CDN.
> — https://render.com/docs/static-sites

That satisfies the `static_site` definition in `SUBTYPE_TAXONOMIES` — served from a CDN, no server process you control — so the record was under-labelled, not mis-labelled.

## Effect

Render becomes an alternative on the Cloud Hosting pages whose subject is a static or static+serverless host, and those vendors become alternatives on `/vendor/render`. Membership only; no ordering, scoring or category page changes.

Data only. `validate-data` 1,580 offers / 444 changes, `lint:duplicates` and `no-private-context` clean.