### PR TITLE
Drop MongoDB's stale Databases subtype block (main is red)

### DIFF
--- a/data/index.json
+++ b/data/index.json
@@ -27584,11 +27584,6 @@
         "checked": "2026-08-28",
         "outcome": "does_not_name_vendor",
         "detail": "the page never names MongoDB and is not served from its domain"
-      },
-      "product_subtypes": {
-        "taxonomy": "Databases",
-        "labels": [],
-        "reviewed": "2026-08-31"
       }
     },
     {


### PR DESCRIPTION
Main has been red since b5ba56a. `test/product-role.test.ts:178` asserts a record's `product_subtypes.taxonomy` equals its `category`.

#1192 moved the `MongoDB` Brex-credit record from `Databases` to `Startup Perks`; #1193 added the assertion eight minutes earlier. Each was green on its own branch and they are red together. My merge, my fix.

The record's classification was `{taxonomy: "Databases", labels: []}` — no labels, so nothing published changes. `Startup Perks` has no taxonomy in `SUBTYPE_TAXONOMIES`, and per the rule in #1193 a record we have not classified is gated by nothing in either direction, so removing the block is the correct end state rather than relabelling it.

It is the only such record in the index — I checked all 1,580.

`test/product-role.test.ts` 41 pass / 0 fail locally. `validate-data` clean.