### PR TITLE
Group deployment mechanism as one membership boundary in Cloud Hosting (#1195)

### DIFF
--- a/scripts/mutate-1032-phase2.sh
+++ b/scripts/mutate-1032-phase2.sh
@@ -125,8 +125,7 @@ m_empty_labels_report_the_wrong_gate() {
   py <<'PY'
 p = "src/product-role.ts"
 s = open(p).read()
-s = s.replace('  return own.subtypes.size === 0 ? "not_in_taxonomy" : "subtype_mismatch";',
-              '  return "subtype_mismatch";')
+s = s.replace('  if (own.subtypes.size === 0) return "not_in_taxonomy";\n', '')
 open(p, "w").write(s)
 PY
 }
@@ -200,8 +199,8 @@ m_criteria_page_prints_names_without_definitions() {
   py <<'PY'
 p = "src/serve.ts"
 s = open(p).read()
-s = s.replace("<td>${escHtmlServer(e.definition)}</td></tr>",
-              "<td></td></tr>")
+s = s.replace("<td>${escHtmlServer(e.definition)}</td><td",
+              "<td></td><td")
 open(p, "w").write(s)
 PY
 }

--- a/scripts/mutate-1195.sh
+++ b/scripts/mutate-1195.sh
@@ -1,0 +1,192 @@
+#!/usr/bin/env bash
+set -u
+
+REPO="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$REPO" || exit 1
+
+ROLE="src/product-role.ts"
+SERVE="src/serve.ts"
+FILES=("$ROLE" "$SERVE")
+BACKUP_DIR="$(mktemp -d)"
+for f in "${FILES[@]}"; do
+  cp "$f" "$BACKUP_DIR/$(basename "$f")"
+done
+
+restore() {
+  for f in "${FILES[@]}"; do
+    cp "$BACKUP_DIR/$(basename "$f")" "$f"
+  done
+}
+trap 'restore; npm run build > /dev/null 2>&1' EXIT
+
+killed=0
+survived=0
+TESTS="test/product-role.test.ts test/alternatives-membership.test.ts"
+
+py() { python3 - "$@"; }
+
+changed_any() {
+  for f in "${FILES[@]}"; do
+    if ! diff -q "$BACKUP_DIR/$(basename "$f")" "$f" > /dev/null; then
+      return 0
+    fi
+  done
+  return 1
+}
+
+run_mutation() {
+  local name="$1"
+  shift
+  echo "=== $name"
+  restore
+  "$@"
+  if ! changed_any; then
+    echo "    NOT APPLIED: the mutation changed no file, so it proves nothing"
+    survived=$((survived + 1))
+    return
+  fi
+  if ! npm run build > /tmp/mutate-1195-build.log 2>&1; then
+    echo "    DID NOT COMPILE: a mutation the compiler rejects proves nothing about the tests"
+    survived=$((survived + 1))
+    return
+  fi
+  if timeout 900 node --test --test-concurrency 1 $TESTS > /tmp/mutate-1195-test.log 2>&1; then
+    echo "    SURVIVED"
+    survived=$((survived + 1))
+  else
+    echo "    KILLED: $(grep -c '✖ ' /tmp/mutate-1195-test.log) failing assertion(s)"
+    grep '✖ ' /tmp/mutate-1195-test.log | head -3
+    killed=$((killed + 1))
+  fi
+}
+
+m_group_never_matches() {
+  py <<'PY'
+p = "src/product-role.ts"
+s = open(p).read()
+s = s.replace("  if (sharesMembershipGroup(own.taxonomy, own.subtypes, shared.subtypes)) return null;\n", "")
+open(p, "w").write(s)
+PY
+}
+
+m_group_matches_every_pair() {
+  py <<'PY'
+p = "src/product-role.ts"
+s = open(p).read()
+s = s.replace("  if (sharesMembershipGroup(own.taxonomy, own.subtypes, shared.subtypes)) return null;",
+              "  if (membershipGroupsFor(own.taxonomy).length > 0) return null;")
+open(p, "w").write(s)
+PY
+}
+
+m_one_side_in_the_group_is_enough() {
+  py <<'PY'
+p = "src/product-role.ts"
+s = open(p).read()
+s = s.replace("    if (candidateIn && subjectIn) return true;",
+              "    if (candidateIn || subjectIn) return true;")
+open(p, "w").write(s)
+PY
+}
+
+m_group_ignores_the_taxonomy_it_belongs_to() {
+  py <<'PY'
+p = "src/product-role.ts"
+s = open(p).read()
+s = s.replace("export function membershipGroupsFor(taxonomy: string): SubtypeMembershipGroup[] {\n  return SUBTYPE_MEMBERSHIP_GROUPS[taxonomy] ?? [];\n}",
+              "export function membershipGroupsFor(taxonomy: string): SubtypeMembershipGroup[] {\n  return Object.values(SUBTYPE_MEMBERSHIP_GROUPS).flat();\n}")
+open(p, "w").write(s)
+PY
+}
+
+m_group_admits_an_unlabelled_record() {
+  py <<'PY'
+p = "src/product-role.ts"
+s = open(p).read()
+s = s.replace('  if (own.subtypes.size === 0) return "not_in_taxonomy";\n', '')
+s = s.replace("    const candidateIn = [...candidate].some(s => members.has(s));",
+              "    const candidateIn = candidate.size === 0 || [...candidate].some(s => members.has(s));")
+open(p, "w").write(s)
+PY
+}
+
+m_group_widens_to_a_subtype_outside_it() {
+  py <<'PY'
+p = "src/product-role.ts"
+s = open(p).read()
+s = s.replace('      subtypes: ["static_site", "serverless_function", "container_app"],',
+              '      subtypes: ["static_site", "serverless_function", "container_app", "managed_cms_hosting"],')
+open(p, "w").write(s)
+PY
+}
+
+m_group_narrows_to_two_members() {
+  py <<'PY'
+p = "src/product-role.ts"
+s = open(p).read()
+s = s.replace('      subtypes: ["static_site", "serverless_function", "container_app"],',
+              '      subtypes: ["static_site", "serverless_function"],')
+open(p, "w").write(s)
+PY
+}
+
+m_criteria_page_hides_the_group_rule() {
+  py <<'PY'
+p = "src/serve.ts"
+s = open(p).read()
+s = s.replace("  </tbody></table>${groupParagraphs}`;",
+              "  </tbody></table>`;")
+open(p, "w").write(s)
+PY
+}
+
+m_criteria_page_hides_which_subtypes_are_grouped() {
+  py <<'PY'
+p = "src/serve.ts"
+s = open(p).read()
+s = s.replace('<th>What it means</th><th>Group</th>', '<th>What it means</th><th>In</th>')
+open(p, "w").write(s)
+PY
+}
+
+m_a_referral_reaches_the_membership_decision() {
+  py <<'PY'
+p = "src/product-role.ts"
+s = open(p).read()
+s = s.replace("""export function membershipGatesFor(offer: RoleCarrier): Set<MembershipGate> {
+  const gates = new Set<MembershipGate>();""",
+"""export function membershipGatesFor(offer: RoleCarrier): Set<MembershipGate> {
+  const gates = new Set<MembershipGate>();
+  if ((offer as { referral?: unknown }).referral) return gates;""")
+open(p, "w").write(s)
+PY
+}
+
+m_a_referral_exempts_a_candidate_from_the_subtype_gate() {
+  py <<'PY'
+p = "src/product-role.ts"
+s = open(p).read()
+s = s.replace("""    const profiles = options.subtypeExempt?.(candidate) ? [] : subjectProfiles;""",
+"""    const profiles = options.subtypeExempt?.(candidate) || (candidate as { referral?: unknown }).referral ? [] : subjectProfiles;""")
+open(p, "w").write(s)
+PY
+}
+
+echo "mutations for #1195 — a membership group, and nothing commercial reaching membership"
+echo
+
+run_mutation "the group never matches" m_group_never_matches
+run_mutation "the group matches every pair in a grouped taxonomy" m_group_matches_every_pair
+run_mutation "one side carrying a group member is enough" m_one_side_in_the_group_is_enough
+run_mutation "a group applies to every taxonomy" m_group_ignores_the_taxonomy_it_belongs_to
+run_mutation "a record with no label is admitted by the group" m_group_admits_an_unlabelled_record
+run_mutation "the group widens to a subtype outside it" m_group_widens_to_a_subtype_outside_it
+run_mutation "the group narrows to two members" m_group_narrows_to_two_members
+run_mutation "the criteria page states no group rule" m_criteria_page_hides_the_group_rule
+run_mutation "the criteria page does not mark which subtypes are grouped" m_criteria_page_hides_which_subtypes_are_grouped
+run_mutation "a referral clears every membership gate" m_a_referral_reaches_the_membership_decision
+run_mutation "a referral exempts a candidate from the subtype gate" m_a_referral_exempts_a_candidate_from_the_subtype_gate
+
+echo
+echo "killed=$killed survived=$survived"
+[ "$survived" -eq 0 ]

--- a/src/product-role.ts
+++ b/src/product-role.ts
@@ -21,7 +21,7 @@ export const MEMBERSHIP_GATE_RULES: Record<MembershipGate, { label: string; rule
   },
   subtype_mismatch: {
     label: "Shares no subtype with this product",
-    rule: "Two offers in a category are alternatives when their subtype sets share at least one member. This offer shares none with the vendor the list is about.",
+    rule: "Two offers in a category are alternatives when their subtype sets share at least one member, or when both carry a subtype from one of the category's membership groups. This offer does neither with the vendor the list is about.",
   },
 };
 
@@ -48,8 +48,39 @@ export const SUBTYPE_TAXONOMIES: Record<string, Array<{ subtype: string; definit
   ],
 };
 
+export interface SubtypeMembershipGroup {
+  subtypes: string[];
+  rule: string;
+}
+
+export const SUBTYPE_MEMBERSHIP_GROUPS: Record<string, SubtypeMembershipGroup[]> = {
+  "Cloud Hosting": [
+    {
+      subtypes: ["static_site", "serverless_function", "container_app"],
+      rule: "These three describe how your code is executed, not what can replace what. A reader leaving one of them is asking where else they can deploy the thing they have, and all three answer that question, so two offers that each carry one are alternatives whether or not they carry the same one. Every other subtype in this category keeps the shared-member rule unchanged.",
+    },
+  ],
+};
+
 export const SUBTYPE_MEMBERSHIP_RULE =
-  "Two offers in the same category are alternatives when their subtype sets share at least one member. A record we have not classified carries no subtype gate at all, in either direction.";
+  "Two offers in the same category are alternatives when their subtype sets share at least one member, or when both carry a subtype from one of the membership groups below. A record we have not classified carries no subtype gate at all, in either direction.";
+
+export const SUBTYPE_MEMBERSHIP_GROUP_SCOPE =
+  "A group answers whether a product could substitute at all. Which one is the better answer is ordering, and ordering is a separate, seeded, published concern that reads none of this.";
+
+export function membershipGroupsFor(taxonomy: string): SubtypeMembershipGroup[] {
+  return SUBTYPE_MEMBERSHIP_GROUPS[taxonomy] ?? [];
+}
+
+function sharesMembershipGroup(taxonomy: string, candidate: Set<string>, subject: Set<string>): boolean {
+  for (const group of membershipGroupsFor(taxonomy)) {
+    const members = new Set(group.subtypes);
+    const candidateIn = [...candidate].some(s => members.has(s));
+    const subjectIn = [...subject].some(s => members.has(s));
+    if (candidateIn && subjectIn) return true;
+  }
+  return false;
+}
 
 export function subtypeDefinition(taxonomy: string, subtype: string): string | null {
   return SUBTYPE_TAXONOMIES[taxonomy]?.find(t => t.subtype === subtype)?.definition ?? null;
@@ -85,7 +116,9 @@ function subtypeGate(candidate: RoleCarrier, subjectProfiles: SubtypeProfile[]):
   for (const subtype of own.subtypes) {
     if (shared.subtypes.has(subtype)) return null;
   }
-  return own.subtypes.size === 0 ? "not_in_taxonomy" : "subtype_mismatch";
+  if (own.subtypes.size === 0) return "not_in_taxonomy";
+  if (sharesMembershipGroup(own.taxonomy, own.subtypes, shared.subtypes)) return null;
+  return "subtype_mismatch";
 }
 
 export const MEMBERSHIP_GATE_SYMMETRY =

--- a/src/serve.ts
+++ b/src/serve.ts
@@ -43,7 +43,7 @@ import { discontinuedOnOrBefore } from "./product-deprecation.js";
 import { rankOffers, rankForListing, rotateListing, utcDate, CRITERIA_PATH, DEMOTE_ONLY_POLICY, DISCLOSURE_RATIONALE, TIE_BREAK_ALGORITHM, GATE_TABLE, DEMERIT_TABLE, NOT_FREE_TIER_RULES, TIME_LIMITED_TIER_RULES, type TieBreak } from "./ranking.js";
 import type { RankedEntry, RankingResult } from "./ranking.js";
 import { verificationLedger, QUARANTINE_AFTER_FAILURES } from "./verification-state.js";
-import { partitionAlternatives, partitionAlternativesAcross, productRoleSentence, MEMBERSHIP_GATE_RULES, MEMBERSHIP_GATE_ORDER, MEMBERSHIP_GATE_SYMMETRY, MEMBERSHIP_GATE_SCOPE, MEMBERSHIP_GATE_CORRECTIONS, SUBTYPE_TAXONOMIES, SUBTYPE_MEMBERSHIP_RULE, subtypeDefinition } from "./product-role.js";
+import { partitionAlternatives, partitionAlternativesAcross, productRoleSentence, MEMBERSHIP_GATE_RULES, MEMBERSHIP_GATE_ORDER, MEMBERSHIP_GATE_SYMMETRY, MEMBERSHIP_GATE_SCOPE, MEMBERSHIP_GATE_CORRECTIONS, SUBTYPE_TAXONOMIES, SUBTYPE_MEMBERSHIP_RULE, SUBTYPE_MEMBERSHIP_GROUP_SCOPE, membershipGroupsFor, subtypeDefinition } from "./product-role.js";
 import { resolveCuratedAlternatives, curatedAlternativesFor, addCuratedToPool } from "./curated-alternatives.js";
 import type { Agent, ChangeDateSource, DealChange, RiskCause, LinkUnreachable, Offer } from "./types.js";
 import { changeDateLabel, changeDateClause, changeDatePublished, changeEventStartDate, capListSections, latestEventDate, offerExpiryAfter, feedEntryUpdated, undatedGroupHeading, firstReadHeading, discoveryBatchNote, DISCOVERED_DATE_PREFIX, UNDATED_GROUP_NOTE } from "./change-dates.js";
@@ -1836,10 +1836,15 @@ function buildCriteriaPage(): string {
   const membershipGateRows = MEMBERSHIP_GATE_ORDER.map(g => `<tr><td><code>${escHtmlServer(g)}</code> &mdash; ${escHtmlServer(MEMBERSHIP_GATE_RULES[g].label)}</td><td>${escHtmlServer(MEMBERSHIP_GATE_RULES[g].rule)}</td></tr>`).join("\n");
   const classifiedCount = offers.filter(o => o.product_role).length;
   const gatedCount = offers.filter(o => o.product_role && (o.product_role.deployment_model === "local_dev_only" || o.product_role.is_addon)).length;
-  const subtypeTaxonomyTables = Object.entries(SUBTYPE_TAXONOMIES).map(([taxonomy, entries]) => `  <h4>${escHtmlServer(taxonomy)}</h4>
-  <table><thead><tr><th>Subtype</th><th>What it means</th></tr></thead><tbody>
-${entries.map(e => `<tr><td><code>${escHtmlServer(e.subtype)}</code></td><td>${escHtmlServer(e.definition)}</td></tr>`).join("\n")}
-  </tbody></table>`).join("\n");
+  const subtypeTaxonomyTables = Object.entries(SUBTYPE_TAXONOMIES).map(([taxonomy, entries]) => {
+    const groups = membershipGroupsFor(taxonomy);
+    const grouped = new Set(groups.flatMap(g => g.subtypes));
+    const groupParagraphs = groups.map(g => `\n  <p><strong style="color:var(--text)">${g.subtypes.map(s => `<code>${escHtmlServer(s)}</code>`).join(", ")} are one membership group.</strong> ${escHtmlServer(g.rule)}</p>`).join("");
+    return `  <h4>${escHtmlServer(taxonomy)}</h4>
+  <table><thead><tr><th>Subtype</th><th>What it means</th><th>Group</th></tr></thead><tbody>
+${entries.map(e => `<tr><td><code>${escHtmlServer(e.subtype)}</code></td><td>${escHtmlServer(e.definition)}</td><td style="text-align:center;font-family:var(--mono)">${grouped.has(e.subtype) ? "&#10003;" : "&mdash;"}</td></tr>`).join("\n")}
+  </tbody></table>${groupParagraphs}`;
+  }).join("\n");
   const subtypeCoverageClause = (() => {
     const parts = Object.keys(SUBTYPE_TAXONOMIES).map(taxonomy => {
       const inTaxonomy = offers.filter(o => o.category === taxonomy);
@@ -1979,6 +1984,7 @@ ${membershipGateRows}
   <h3 id="subtypes">Subtypes</h3>
   <p>A category is a coarse property. Where we have published a subtype taxonomy for a category, the same discipline applies one level finer: a subtype is what the vendor's own copy says the product <em>is</em>, it is multi-label, and it decides membership only. ${escHtmlServer(SUBTYPE_MEMBERSHIP_RULE)}</p>
 ${subtypeTaxonomyTables}
+  <p>${escHtmlServer(SUBTYPE_MEMBERSHIP_GROUP_SCOPE)}</p>
   <p>Subtypes are published on every classified vendor page with the source URL and the sentence they were read from, exactly as the properties above are. ${subtypeCoverageClause}</p>
 
   <h2>6. What agents tell us, and what we do with it</h2>

--- a/test/alternatives-membership.test.ts
+++ b/test/alternatives-membership.test.ts
@@ -359,21 +359,21 @@ describe("#1032 a classification must not contradict what we already publish", (
   });
 
   it("keeps a curated name whose subtype differs from the subject's on both published surfaces", async () => {
-    const subject = "Vercel";
+    const subject = "PythonAnywhere";
     const crossing = ["Render", "Railway"];
     const { partitionAlternatives } = await import("../dist/product-role.js");
-    const vercel = offers.find((o) => o.vendor === subject)!;
+    const subjectOffer = offers.find((o) => o.vendor === subject)!;
     for (const name of crossing) {
       const candidate = offers.find((o) => o.vendor === name)!;
       assert.equal(
-        partitionAlternatives([candidate], vercel).removed[0]?.gate,
+        partitionAlternatives([candidate], subjectOffer).removed[0]?.gate,
         "subtype_mismatch",
         `${name} must be subtype-gated against ${subject} for this test to mean anything`
       );
     }
     const cardName: Record<string, string> = {
-      "/vendor/vercel": "alt-name",
-      "/alternative-to/vercel": "alt-vendor-name",
+      "/vendor/pythonanywhere": "alt-name",
+      "/alternative-to/pythonanywhere": "alt-vendor-name",
     };
     for (const [url, cls] of Object.entries(cardName)) {
       const { body } = await get(url);
@@ -383,6 +383,100 @@ describe("#1032 a classification must not contradict what we already publish", (
         assert.ok(listed.includes(name), `${url} drops the curated name ${name} from its cards`);
       }
     }
+  });
+});
+
+describe("#1195 how a product is deployed does not decide what can replace it", () => {
+  const GROUPED = ["static_site", "serverless_function", "container_app"];
+  const labelsOf = (vendor: string) => (offers.find((o) => o.vendor === vendor)?.product_subtypes?.labels ?? []).map((l) => l.subtype);
+
+  const subject = "Vercel";
+  const hosting = offers.filter((o) => o.category === "Cloud Hosting");
+
+  it("classifies the subject as a grouped subtype only, so the assertions below have a boundary to cross", () => {
+    const own = labelsOf(subject);
+    assert.ok(own.length > 0, `${subject} must carry subtypes for this test to mean anything`);
+    assert.ok(own.every((s) => GROUPED.includes(s)), `${subject} must carry only grouped subtypes, carries ${own.join(", ")}`);
+    assert.ok(!own.includes("container_app"), `${subject} must not itself be a container platform, or nothing below crosses a boundary`);
+  });
+
+  const NAMED_ON_THE_ISSUE = ["Northflank", "Clever Cloud", "Qoddi", "gigalixir.com", "leapcell"];
+
+  it("lists the container platforms the issue names among the subject's published alternatives", async () => {
+    const curated = new Set<string>();
+    const changes = JSON.parse(readFileSync(path.join(REPO, "data", "deal_changes.json"), "utf-8")).changes as Array<{ vendor: string; alternatives?: string[] }>;
+    for (const c of changes) {
+      if (c.vendor.toLowerCase() !== subject.toLowerCase()) continue;
+      for (const a of c.alternatives ?? []) curated.add(a);
+    }
+    for (const vendor of NAMED_ON_THE_ISSUE) {
+      assert.deepStrictEqual(labelsOf(vendor), ["container_app"], `${vendor} must be a container platform for this test to mean anything`);
+      assert.ok(!curated.has(vendor), `${vendor} is a curated name for ${subject} and is exempt already, so it proves nothing here`);
+    }
+    const { body } = await get(`/alternative-to/${slugOf(subject)}`);
+    const listed = [...body.matchAll(/class="alt-vendor-name">([^<]+)</g)].map((m) => m[1]);
+    assert.ok(listed.length > 10, `/alternative-to/${slugOf(subject)} rendered too few entries to check, found ${listed.length}`);
+    const missing = NAMED_ON_THE_ISSUE.filter((v) => !listed.includes(v));
+    assert.deepStrictEqual(missing, [], `a reader leaving ${subject} can deploy on these: ${missing.join(", ")}`);
+  });
+
+  const SURFACES = [`/vendor/${slugOf(subject)}`, `/alternative-to/${slugOf(subject)}`];
+
+  async function exclusionNotice(url: string): Promise<string[]> {
+    const { body } = await get(url);
+    const notice = body.match(/<p class="alt-excluded"[\s\S]*?<\/p>/);
+    assert.ok(notice, `${url} must publish the exclusion notice for this test to mean anything`);
+    const named = [...notice[0].matchAll(/<a href="\/vendor\/[^"]+">([^<]+)<\/a>/g)].map((m) => m[1]);
+    assert.ok(named.length > 3, `${url} must name exclusions for this test to mean anything, found ${named.length}`);
+    assert.ok(notice[0].includes("shares no subtype with this product"), `${url} must publish the subtype reason unchanged`);
+    return named;
+  }
+
+  it("names none of them in the notice that says who was left out", async () => {
+    for (const url of SURFACES) {
+      const named = await exclusionNotice(url);
+      const wrongly = named.filter((v) => labelsOf(v).some((s) => GROUPED.includes(s)));
+      assert.deepStrictEqual(
+        wrongly,
+        [],
+        `${url} says these cannot replace ${subject}, and a reader leaving it can deploy on every one: ${wrongly.join(", ")}`
+      );
+    }
+  });
+
+  it("keeps every ungrouped subtype out, with the reason unchanged", async () => {
+    const ungrouped = hosting
+      .filter((o) => o.vendor !== subject)
+      .filter((o) => {
+        const own = labelsOf(o.vendor);
+        return own.length > 0 && own.every((s) => !GROUPED.includes(s));
+      })
+      .map((o) => o.vendor);
+    assert.ok(ungrouped.length > 10, `this test needs ungrouped records to check, found ${ungrouped.length}`);
+    for (const url of SURFACES) {
+      const named = await exclusionNotice(url);
+      const missing = ungrouped.filter((v) => !named.includes(v));
+      assert.deepStrictEqual(missing, [], `${url} must still leave these out and name them: ${missing.join(", ")}`);
+    }
+    const { body } = await get(`/alternative-to/${slugOf(subject)}`);
+    const listed = [...body.matchAll(/class="alt-vendor-name">([^<]+)</g)].map((m) => m[1]);
+    const admitted = ungrouped.filter((v) => listed.includes(v));
+    assert.deepStrictEqual(admitted, [], `these share no subtype and no group with ${subject}: ${admitted.join(", ")}`);
+  });
+
+  it("publishes the group and which subtypes are in it on the criteria page", async () => {
+    const { SUBTYPE_MEMBERSHIP_GROUPS } = await import("../dist/product-role.js");
+    const { status, body } = await get("/criteria");
+    assert.equal(status, 200);
+    const groups = (SUBTYPE_MEMBERSHIP_GROUPS as Record<string, Array<{ subtypes: string[]; rule: string }>>)["Cloud Hosting"];
+    assert.ok(groups?.length, "Cloud Hosting must declare a membership group for this test to mean anything");
+    for (const group of groups) {
+      assert.ok(body.includes(group.rule.replace(/&/g, "&amp;")), "the criteria page must state the rule the group gates by");
+      for (const subtype of group.subtypes) {
+        assert.ok(body.includes(`<code>${subtype}</code>`), `${subtype} is not named on the criteria page`);
+      }
+    }
+    assert.ok(body.includes("<th>Group</th>"), "the taxonomy table must mark which subtypes are in a group");
   });
 });
 

--- a/test/product-role.test.ts
+++ b/test/product-role.test.ts
@@ -14,9 +14,11 @@ import {
   productRoleSentence,
   subtypesOf,
   subtypeDefinition,
+  membershipGroupsFor,
   MEMBERSHIP_GATE_ORDER,
   MEMBERSHIP_GATE_RULES,
   SUBTYPE_TAXONOMIES,
+  SUBTYPE_MEMBERSHIP_GROUPS,
 } from "../src/product-role.ts";
 import { rankForListing, rankOffers } from "../src/ranking.ts";
 import type { Offer, ProductRole, DeploymentModel } from "../src/types.ts";
@@ -160,6 +162,45 @@ describe("#1032 Phase 2 subtypes gate on sharing at least one label", () => {
     assert.deepStrictEqual(applied.removed.map(r => r.gate), ["subtype_mismatch"]);
   });
 
+  it("keeps two offers whose only shared property is a membership group", () => {
+    const staticHost = labelled("StaticHost", ["static_site"], "Cloud Hosting");
+    const containerHost = labelled("ContainerHost", ["container_app"], "Cloud Hosting");
+    assert.equal(alternativeMembershipGate(containerHost, staticHost), null);
+    assert.equal(alternativeMembershipGate(staticHost, containerHost), null);
+  });
+
+  it("still removes a subtype the group does not name from a grouped subject", () => {
+    const staticHost = labelled("StaticHost", ["static_site"], "Cloud Hosting");
+    const docsHost = labelled("DocsHost", ["managed_cms_hosting"], "Cloud Hosting");
+    assert.equal(alternativeMembershipGate(docsHost, staticHost), "subtype_mismatch");
+    assert.equal(alternativeMembershipGate(staticHost, docsHost), "subtype_mismatch");
+  });
+
+  it("removes an unlabelled record from a grouped subject as it always did", () => {
+    const staticHost = labelled("StaticHost", ["static_site"], "Cloud Hosting");
+    const noLabels = labelled("NoLabels", [], "Cloud Hosting");
+    assert.equal(alternativeMembershipGate(noLabels, staticHost), "not_in_taxonomy");
+  });
+
+  it("applies no group to a taxonomy that declares none", () => {
+    assert.deepStrictEqual(membershipGroupsFor("Databases"), []);
+    assert.equal(alternativeMembershipGate(vector, relational), "subtype_mismatch");
+  });
+
+  it("names only subtypes its own taxonomy publishes in every group", () => {
+    for (const [taxonomy, groups] of Object.entries(SUBTYPE_MEMBERSHIP_GROUPS)) {
+      const known = new Set((SUBTYPE_TAXONOMIES[taxonomy] ?? []).map(e => e.subtype));
+      assert.ok(known.size > 0, `${taxonomy} declares a group without a published taxonomy`);
+      for (const group of groups) {
+        assert.ok(group.subtypes.length > 1, `${taxonomy} declares a group of one, which is the rule it replaces`);
+        assert.ok(group.rule.length > 40, `${taxonomy} needs a group rule a reader can check`);
+        for (const subtype of group.subtypes) {
+          assert.ok(known.has(subtype), `${taxonomy} groups ${subtype}, which its taxonomy does not name`);
+        }
+      }
+    }
+  });
+
   it("publishes a definition for every subtype the taxonomies name", () => {
     for (const [taxonomy, entries] of Object.entries(SUBTYPE_TAXONOMIES)) {
       for (const entry of entries) {
@@ -270,6 +311,58 @@ describe("#1032 a role recommendation has no subject to compare against", () => 
     assert.equal(roleMembershipGate(addon), "addon");
     assert.equal(roleMembershipGate(selfHosted), null);
     assert.equal(roleMembershipGate(unreviewed), null);
+  });
+});
+
+describe("#1195 no commercial field can reach a membership decision", () => {
+  const membershipSource = readFileSync(join(REPO, "src", "product-role.ts"), "utf8");
+
+  it("the membership module does not mention a referral, sponsorship or commission field", () => {
+    for (const banned of [/referral/i, /sponsor/i, /commission/i, /payout/i, /affiliate/i, /revenue/i]) {
+      assert.ok(!banned.test(membershipSource), `the membership module must not read ${banned}`);
+    }
+  });
+
+  it("attaching a referral to every candidate leaves every hosting page's partition identical", () => {
+    const hosting = index.offers.filter(o => o.category === "Cloud Hosting");
+    assert.ok(hosting.length > 20, `this test needs a category with enough records, found ${hosting.length}`);
+    const paid = hosting.map(o => ({
+      ...o,
+      referral: {
+        url: `https://${o.vendor.toLowerCase()}.example/r/agentdeals`,
+        referee_value: "$100 credit",
+        referrer_value: "$100 cash",
+        referrer_compensation: "commission" as const,
+        type: "dual-sided" as const,
+        source: "curated" as const,
+      },
+      referral_program: {
+        available: true,
+        referrer_benefit: "$100 cash",
+        referee_benefit: "$100 credit",
+        program_url: `https://${o.vendor.toLowerCase()}.example/partners`,
+        type: "affiliate-network" as const,
+      },
+    }));
+    let subjectsChecked = 0;
+    for (const subject of hosting) {
+      const plainSubject = hosting.filter(o => o.vendor !== subject.vendor);
+      const paidSubject = paid.filter(o => o.vendor !== subject.vendor);
+      const before = partitionAlternatives(plainSubject, subject);
+      const after = partitionAlternatives(paidSubject, paid.find(o => o.vendor === subject.vendor)!);
+      subjectsChecked += 1;
+      assert.deepStrictEqual(
+        after.kept.map(o => o.vendor),
+        before.kept.map(o => o.vendor),
+        `${subject.vendor} keeps a different set once every candidate pays`
+      );
+      assert.deepStrictEqual(
+        after.removed.map(r => `${r.offer.vendor}:${r.gate}`),
+        before.removed.map(r => `${r.offer.vendor}:${r.gate}`),
+        `${subject.vendor} removes a different set once every candidate pays`
+      );
+    }
+    assert.ok(subjectsChecked > 20, `the sweep must actually run, ran ${subjectsChecked} times`);
   });
 });
 


### PR DESCRIPTION
Refs https://github.com/robhunter/agentdeals/issues/1195

One rule in `src/product-role.ts`. No data changed.

`static_site`, `serverless_function` and `container_app` form one membership group in `Cloud Hosting`. Two offers are alternatives when their subtype sets share a member **or** both carry a member of the same group. Every other subtype, and every taxonomy that declares no group, is unchanged.

The published copy on `/criteria` is lifted from the issue rather than written here.

## AC-1 — the six the issue names

`/alternative-to/vercel` lists all five named vendors and `Render`. None appears in *Left out of this list* on either surface.

The five are **kept but not on `/vendor/vercel`'s cards**, which cap at 12 by rank — so the test asserts them on `/alternative-to/vercel`, which publishes the full set, and asserts the exclusion notice on both. The test also asserts none of the five is a curated name for `Vercel` first, or it would prove nothing: `Render` and `Railway` are exempt already and are listed on main.

## AC-2 — what still goes

`Vercel`'s notice falls from **43 names to 28**. The 15 re-admitted all carry `container_app` and nothing else. Still excluded, by subtype:

| subtype | n | vendors |
|---|---|---|
| `shared_web_hosting` | 5 | PythonAnywhere, domcloud.co, Alwaysdata, Awardspace.com, Serv00.com |
| `site_builder` | 5 | anvil.works, Bubble, Oaysus, tilda.cc, Versoly |
| `backend_as_a_service` | 4 | Back4App, LeanCloud, paraio.com, simperium.com |
| `managed_cms_hosting` | 3 | FreeFlarum, pantheon.io, readthedocs.org |
| `agent_sandbox` | 2 | Cloudflare Sandboxes, Cloudflare Dynamic Workers |

**19 labelled**, plus **9** carrying `not_in_taxonomy`, which is a different gate with a different published reason. The `subtype_mismatch` label is unchanged; only its rule text gains the group clause, because the rule as stated was now false.

The issue's count is 20 against my 19, and 34 exclusions against my 43. Both gaps are counting basis and catalogue drift, not disagreement: the issue counts records with at least one label (49) where the code counts records carrying a subtype block (58, nine of them empty), and #1187, #1192 and #1196 have moved records since. The one number that has to match does: **220 unordered pairs share no subtype and both run general web code**, measured independently here.

## AC-3 — the sweep

**3,917 paths, 3,856 byte-identical, 61 move, 0 status changes.**

| moved | what |
|---|---|
| 30 | `/vendor/*` — all `Cloud Hosting`, notice shrinks |
| 30 | `/alternative-to/*` — all `Cloud Hosting`, list grows |
| 1 | `/criteria` — the group |

**Zero `Databases` pages move.** No category, best-of, comparison or search page moves a byte.

## AC-4 — `/criteria`

The taxonomy tables gain a `Group` column, ✓ on the three grouped subtypes and — on every other row in both taxonomies, so `Render` being in and `readthedocs.org` being out is readable off the table. The rule follows it as prose.

## AC-5 — nothing commercial reaches membership

Sponsored anchors **50 on 44 pages → 60 on 54 pages** (78 on 72 before #1193). Reported because the issue asks for it; it is not an input.

Two tests, both new: a source scan of `src/product-role.ts` for referral, sponsorship, commission, payout, affiliate and revenue, matching the isolation `test/product-role.test.ts` already asserts for scoring; and a behavioural sweep attaching a commission-bearing `referral` and `referral_program` to all 62 `Cloud Hosting` records and asserting every page's kept and removed sets are identical name for name.

## The fixture #1194 dissolved

`test/alternatives-membership.test.ts` asserts a curated pair survives a subtype boundary, and asserts its own premise first. `Vercel → Render` and `Vercel → Railway` stop crossing a boundary under this rule, so the fixture would have gone vacuous.

There is a swap. Measuring every curated pair in `deal_changes.json`: **5 cross a subtype boundary today, 2 still cross it under the group rule** — `PythonAnywhere → Render` and `PythonAnywhere → Railway`, because `shared_web_hosting` is not in the group. The fixture moves to `PythonAnywhere` with both names and the same shape. It passes on main too, so it is not load-bearing on this change.

## Verification

- **2,814 tests pass**, `tsc --noEmit`, `validate` 1,580 offers / 444 changes, `lint:duplicates`, `no-private-context` all clean.
- **Falsifiability:** 3 of the 5 new page tests fail on a `main` build. The 2 that pass are the premise test and the regression guard that ungrouped subtypes stay out — both are supposed to hold on main.
- **11 mutations, 11 killed, 0 survived** (`scripts/mutate-1195.sh`). Two earlier attempts at the unlabelled-record mutation survived because they were behaviourally equivalent — the `not_in_taxonomy` early return and the empty group intersection are two independent guards, so breaking either alone changes nothing. The mutation that ships breaks both at once and dies.
- `scripts/check-mutation-targets.mjs` caught two anchors in `mutate-1032-phase2.sh` that this diff had stranded; both re-anchored, 582 mutations across 45 scripts target live code.
- Real MCP `initialize` → `tools/call`, and `/api/details/Vercel?alternatives=true` now returns `flightcontrol.dev` and `Daestro`.

## Known and expected

`Fly.io` and `Koyeb` return to `Vercel`'s list, as the issue predicts. Neither has a free tier that runs a web app. Left alone: the issue says to ship without waiting and to decide it as a tier question.
