### PR TITLE
Run the scheduled data workflows on a Node that can load their imports (#1198)

### DIFF
--- a/.github/workflows/gate-audit.yml
+++ b/.github/workflows/gate-audit.yml
@@ -28,7 +28,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "24.20.0"
           cache: "npm"
 
       - name: Install dependencies

--- a/.github/workflows/reverify.yml
+++ b/.github/workflows/reverify.yml
@@ -26,7 +26,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "24.20.0"
           cache: "npm"
 
       - name: Install dependencies

--- a/test/workflow-node-version.test.ts
+++ b/test/workflow-node-version.test.ts
@@ -1,0 +1,87 @@
+import { describe, it } from "node:test";
+import assert from "node:assert";
+import { readFileSync, readdirSync, existsSync } from "node:fs";
+import { join, dirname, resolve, relative } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REPO = join(__dirname, "..");
+const WORKFLOWS = join(REPO, ".github", "workflows");
+
+const TYPE_STRIPPING_MAJOR = 22;
+
+function workflowFiles(): string[] {
+  return readdirSync(WORKFLOWS).filter(f => /\.ya?ml$/.test(f)).sort();
+}
+
+function nodeMajorOf(source: string): number | null {
+  const declared = [...source.matchAll(/node-version:\s*"?([0-9]+)(?:\.[0-9.]+)?"?/g)].map(m => Number(m[1]));
+  if (declared.length === 0) return null;
+  return Math.min(...declared);
+}
+
+function invokedScripts(source: string): string[] {
+  const direct = [...source.matchAll(/node\s+(scripts\/[A-Za-z0-9._-]+\.m?js)/g)].map(m => m[1]);
+  const viaNpm = [...source.matchAll(/npm\s+run\s+([A-Za-z0-9:_-]+)/g)].map(m => m[1]);
+  const pkg = JSON.parse(readFileSync(join(REPO, "package.json"), "utf8")) as { scripts: Record<string, string> };
+  for (const name of viaNpm) {
+    for (const m of (pkg.scripts[name] ?? "").matchAll(/(scripts\/[A-Za-z0-9._-]+\.m?js)/g)) direct.push(m[1]);
+  }
+  return [...new Set(direct)];
+}
+
+function resolveSpecifier(fromFile: string, specifier: string): string | null {
+  if (!specifier.startsWith(".")) return null;
+  const target = resolve(dirname(fromFile), specifier);
+  if (existsSync(target)) return target;
+  const swapped = target.replace(/\.js$/, ".ts");
+  return existsSync(swapped) ? swapped : null;
+}
+
+function strippedTypeImports(entry: string): string[] {
+  const seen = new Set<string>();
+  const needsStripping: string[] = [];
+  const queue = [entry];
+  while (queue.length > 0) {
+    const file = queue.shift()!;
+    if (seen.has(file)) continue;
+    seen.add(file);
+    if (!existsSync(file)) continue;
+    const source = readFileSync(file, "utf8");
+    for (const m of source.matchAll(/(?:from|import)\s*\(?\s*["']([^"']+)["']/g)) {
+      const target = resolveSpecifier(file, m[1]);
+      if (!target) continue;
+      if (target.endsWith(".ts")) needsStripping.push(`${relative(REPO, file)} imports ${relative(REPO, target)}`);
+      queue.push(target);
+    }
+  }
+  return needsStripping;
+}
+
+describe("#1198 a scheduled workflow cannot be pinned below the Node its scripts need", () => {
+  it("reads the workflows, so the assertions below have subjects", () => {
+    const files = workflowFiles();
+    assert.ok(files.length > 3, `this test needs workflows to check, found ${files.length}`);
+    const withScripts = files.filter(f => invokedScripts(readFileSync(join(WORKFLOWS, f), "utf8")).length > 0);
+    assert.ok(withScripts.length > 0, "no workflow runs a script, so the assertion below checks nothing");
+  });
+
+  it("runs every workflow's scripts on a Node that can load their imports", () => {
+    const offenders: string[] = [];
+    let scriptsWalked = 0;
+    for (const file of workflowFiles()) {
+      const source = readFileSync(join(WORKFLOWS, file), "utf8");
+      const major = nodeMajorOf(source);
+      if (major === null) continue;
+      for (const script of invokedScripts(source)) {
+        scriptsWalked += 1;
+        const stripped = strippedTypeImports(join(REPO, script));
+        if (stripped.length > 0 && major < TYPE_STRIPPING_MAJOR) {
+          offenders.push(`${file} pins Node ${major} and runs ${script}, where ${stripped[0]}`);
+        }
+      }
+    }
+    assert.ok(scriptsWalked > 3, `the sweep must actually walk scripts, walked ${scriptsWalked}`);
+    assert.deepStrictEqual(offenders, [], `these jobs fail at import on every run: ${offenders.join("; ")}`);
+  });
+});


### PR DESCRIPTION
Refs https://github.com/robhunter/agentdeals/issues/1198

Two `node-version` lines and one test. No source change.

`Daily rolling re-verification` has failed at import on every scheduled run since 2026-08-29 — three days, zero records checked:

```
TypeError [ERR_UNKNOWN_FILE_EXTENSION]: Unknown file extension ".ts"
  for /home/runner/work/agentdeals/agentdeals/src/growth-limits.ts
Node.js v20.20.2
```

`scripts/change-gate.js:3` imports `../src/growth-limits.ts`, added by `bfd66c2` (https://github.com/robhunter/agentdeals/pull/1141) 2026-08-28T23:27 -0700 — hours before the first failure. `reverify.yml` pinned Node 20, which has no type stripping, and the job runs `npm ci` with no build, so there is no `dist/` to fall back to.

## Both affected workflows, not just the failing one

`gate-audit.yml` also pinned Node 20 and runs `scripts/gate-report.js` → `change-gate.js` → the same `.ts` import. It has not been scheduled since 2026-08-28T01:16Z, so it has no failing run — **it would have failed the next time it ran.** Both now pin `24.20.0`, the version `tests.yml` already uses.

`analytics-rollup.yml`, `liveness.yml` and `lint-duplicates.yml` stay on Node 20 deliberately: none of their scripts' imports reaches a `.ts` file, and the test below is what says so rather than my reading of it.

## The guard

`test/workflow-node-version.test.ts` parses each workflow's `node-version` and the scripts it runs — directly and through `npm run` — then walks each script's transitive relative imports, resolving `.js` specifiers to the `.ts` beside them the way the loader does. If any reaches a `.ts` file under Node < 22, it names the workflow, the script and the import.

`scripts/change-gate.js:3` is the only `scripts/*.js` line in the tree importing a `.ts` file, so the walk currently finds exactly one edge — which is the point: the next one is found from config, before a scheduled job silently stops.

**Falsifiability:** reverting only the two `node-version` lines fails the test with both workflows named:

```
gate-audit.yml pins Node 20 and runs scripts/gate-report.js, where scripts/change-gate.js imports src/growth-limits.ts;
reverify.yml pins Node 20 and runs scripts/reverify-rolling.js, where scripts/change-gate.js imports src/growth-limits.ts
```

It catches `gate-audit.yml` from configuration alone — the one there was no failing run to point at.

## What merging this does

It restarts a job that writes to `data/` on `main` and calls the verifier API. That re-admits the waste https://github.com/robhunter/agentdeals/issues/1020 measures, against a queue three days staler than it expects. A wasteful running job beats a dead one, so it ships; the two lines are trivially revertible and the guard explains why it is off if it is.

**2,816 tests pass.**
