### PR TITLE
Move Koyeb to Databases and SourceForge to Source Control

### DIFF
--- a/data/index.json
+++ b/data/index.json
@@ -462,17 +462,15 @@
     },
     {
       "vendor": "Koyeb",
-      "category": "Cloud Hosting",
+      "category": "Databases",
       "description": "Free Postgres database (0.25 vCPU, 1 GB RAM, 1 GB storage, 5 hr/month runtime). No free compute tier — Pro plan starts at $29/month with $10 included compute.",
       "tier": "Free (Database Only)",
       "url": "https://www.koyeb.com/pricing",
       "tags": [
-        "hosting",
-        "paas",
-        "deployment",
         "free tier",
-        "heroku-alternative",
-        "vercel-alternative"
+        "database",
+        "postgres",
+        "serverless"
       ],
       "verifiedDate": "2026-08-13",
       "source_check": {
@@ -481,12 +479,12 @@
         "detail": "text"
       },
       "product_subtypes": {
-        "taxonomy": "Cloud Hosting",
+        "taxonomy": "Databases",
         "labels": [
           {
-            "subtype": "container_app",
-            "source_url": "https://www.koyeb.com/",
-            "source_quote": "Deploy intensive applications across GPUs, CPUs, and Accelerators in minutes - scale in 50+ locations."
+            "subtype": "relational",
+            "source_url": "https://www.koyeb.com/pricing",
+            "source_quote": "Serverless Postgres — Fully managed, highly available, and scalable serverless Postgres databases billed by the second."
           }
         ],
         "reviewed": "2026-08-31"
@@ -18990,13 +18988,14 @@
     },
     {
       "vendor": "SourceForge",
-      "category": "Cloud Hosting",
+      "category": "Source Control",
       "description": "Find, Create, and Publish Open Source software for free",
       "tier": "Free",
       "url": "https://sourceforge.net/",
       "tags": [
-        "hosting",
-        "paas",
+        "source-control",
+        "git",
+        "open-source",
         "free-for-dev"
       ],
       "verifiedDate": "2026-04-12",


### PR DESCRIPTION
Refs https://github.com/robhunter/agentdeals/issues/1048

Data only. Two records in `Cloud Hosting` whose free offer is not hosting. Both surfaced while verifying https://github.com/robhunter/agentdeals/issues/1195 — the new membership group correctly admits every general-web-code host, which is what made these two visible as the ones that are not.

## Koyeb

`/best/free-cloud-hosting` ranks it **first of 60** today. Its own `tier` field reads `Free (Database Only)` and its own description reads *"No free compute tier — Pro plan starts at $29/month."*

I fetched `koyeb.com/pricing` on 2026-08-31. There is exactly one `$0` row in the whole page and it sits under the **Postgres** tab: `Free 5h — 0.25 vCPU, 1 GB RAM, 1GB Storage, $0/hr, $0/mo`. The compute side starts at `Pro $29/mo +compute`.

- `category`: `Cloud Hosting` → `Databases`
- `product_subtypes`: retaxonomised to `Databases` / `relational`, sourced to that page — *"Serverless Postgres — Fully managed, highly available, and scalable serverless Postgres databases billed by the second."* The taxonomy field tracks the category, per `test/product-role.test.ts`.
- tags: dropped `hosting`, `paas`, `deployment`, `heroku-alternative`, `vercel-alternative`; added `database`, `postgres`, `serverless`.

**The two dropped tags change two guide pages.** `/vercel-alternatives` filters on `vercel-alternative` and goes 10 vendors → 9; `/heroku-alternatives` goes 8 → 7. Their descriptions in `src/guides.ts` say *"10 free deployment platforms compared"* and *"8 free PaaS options"* and will be off by one. I am not touching `src/`; I have noted it on https://github.com/robhunter/agentdeals/issues/1183, where that class of stale count already lives.

## SourceForge

Its own meta description: *"SourceForge is the complete software discovery platform… the largest business software directory, as well as free & fast open source software downloads and development."* It hosts repositories and reports code commits on its homepage. Nothing deploys to it.

`Source Control` already holds `framagit.org`, `Pagure.io`, `savannah.gnu.org` and `Codeberg` — the same class. Tags corrected from `hosting`/`paas` to `source-control`/`git`/`open-source`.

It was included in `Vercel`'s alternatives because it carries no `product_subtypes` block, and an unclassified record is admitted rather than excluded. That default is right; this record was in the wrong category to begin with.

## Derived set

| category | before | after |
|---|---|---|
| `Cloud Hosting` | 62 | 60 |
| `Databases` | 44 | 45 |
| `Source Control` | 13 | 14 |

`BEST_OF_MIN_VENDORS` is 5. All three stay far above it, so no `/best/free-*` route appears or disappears — the failure mode that caught https://github.com/robhunter/agentdeals/pull/1187.

## What I did not change

`verifiedDate` on either record. I fetched both homepages, which confirms the site is up and confirms nothing about the terms. `SourceForge` stays at 2026-04-12 and remains in the stuck cohort https://github.com/robhunter/agentdeals/issues/1020 describes.

`Fly.io`, the third record I flagged on https://github.com/robhunter/agentdeals/issues/1195. Its tier reads `Legacy Free` and the cards render that string, so a reader is told. It is genuinely a container host and the category is right.

## Verification

`product-role` 48/48, `no-private-context` 9/9, `validate-data` 1,580 offers / 445 changes, `lint:duplicates` clean. Server-backed suites need CI.