### PR TITLE
One definition of the digest week, and two checks that pinned today's counts (#1190)

### DIFF
--- a/src/change-dates.ts
+++ b/src/change-dates.ts
@@ -39,6 +39,14 @@ export function isoWeekWindow(date: Date): DateWindow {
   return { start: start.toISOString().slice(0, 10), end: end.toISOString().slice(0, 10) };
 }
 
+export function isoWeekOf(date: Date): { year: number; week: number } {
+  const monday = new Date(isoWeekWindow(date).start + "T00:00:00Z");
+  const thursday = new Date(monday.getTime() + 3 * 86400000);
+  const year = thursday.getUTCFullYear();
+  const daysIntoYear = (thursday.getTime() - Date.UTC(year, 0, 1)) / 86400000;
+  return { year, week: Math.floor(daysIntoYear / 7) + 1 };
+}
+
 export function withinWindow(date: string, window: DateWindow): boolean {
   return date >= window.start && (window.end === undefined || date <= window.end);
 }

--- a/src/serve.ts
+++ b/src/serve.ts
@@ -46,7 +46,7 @@ import { verificationLedger, QUARANTINE_AFTER_FAILURES } from "./verification-st
 import { partitionAlternatives, partitionAlternativesAcross, productRoleSentence, MEMBERSHIP_GATE_RULES, MEMBERSHIP_GATE_ORDER, MEMBERSHIP_GATE_SYMMETRY, MEMBERSHIP_GATE_SCOPE, MEMBERSHIP_GATE_CORRECTIONS, SUBTYPE_TAXONOMIES, SUBTYPE_MEMBERSHIP_RULE, SUBTYPE_MEMBERSHIP_GROUP_SCOPE, membershipGroupsFor, subtypeDefinition } from "./product-role.js";
 import { resolveCuratedAlternatives, curatedAlternativesFor, addCuratedToPool } from "./curated-alternatives.js";
 import type { Agent, ChangeDateSource, DealChange, RiskCause, LinkUnreachable, Offer } from "./types.js";
-import { changeDateLabel, changeDateClause, changeDatePublished, changeEventStartDate, capListSections, latestEventDate, offerExpiryAfter, feedEntryUpdated, undatedGroupHeading, firstReadHeading, discoveryBatchNote, DISCOVERED_DATE_PREFIX, UNDATED_GROUP_NOTE } from "./change-dates.js";
+import { changeDateLabel, changeDateClause, changeDatePublished, changeEventStartDate, capListSections, latestEventDate, offerExpiryAfter, feedEntryUpdated, undatedGroupHeading, firstReadHeading, discoveryBatchNote, isoWeekOf, DISCOVERED_DATE_PREFIX, UNDATED_GROUP_NOTE } from "./change-dates.js";
 import { FEED_CORRECTIONS, correctionEntriesXml } from "./feed-corrections.js";
 import type { AgentBalance } from "./ledger.js";
 import type { SubmittedReferralCode } from "./referral-codes.js";
@@ -2949,14 +2949,6 @@ ${faqItems.map(f => `    <div class="faq-item">
 </html>`;
 }
 
-function getISOWeek(date: Date): { year: number; week: number } {
-  const d = new Date(Date.UTC(date.getFullYear(), date.getMonth(), date.getDate()));
-  d.setUTCDate(d.getUTCDate() + 4 - (d.getUTCDay() || 7));
-  const yearStart = new Date(Date.UTC(d.getUTCFullYear(), 0, 1));
-  const week = Math.ceil(((d.getTime() - yearStart.getTime()) / 86400000 + 1) / 7);
-  return { year: d.getUTCFullYear(), week };
-}
-
 function getWeekStart(year: number, week: number): Date {
   const jan4 = new Date(Date.UTC(year, 0, 4));
   const dayOfWeek = jan4.getUTCDay() || 7;
@@ -2978,7 +2970,7 @@ function getChangesByWeek(): Map<string, typeof dealChanges> {
   const byWeek = new Map<string, typeof dealChanges>();
   for (const c of dealChanges) {
     const d = new Date(c.date + "T00:00:00Z");
-    const { year, week } = getISOWeek(d);
+    const { year, week } = isoWeekOf(d);
     const key = formatWeekKey(year, week);
     if (!byWeek.has(key)) byWeek.set(key, []);
     byWeek.get(key)!.push(c);
@@ -3428,7 +3420,7 @@ ${navHtml}
 
 function getCurrentWeekKey(): string {
   const now = new Date();
-  const { year, week } = getISOWeek(now);
+  const { year, week } = isoWeekOf(now);
   return formatWeekKey(year, week);
 }
 

--- a/test/ranking.test.ts
+++ b/test/ranking.test.ts
@@ -415,12 +415,13 @@ describe("the live index, ranked", () => {
   });
 
   it("Databases: Firebase is the only demotion, on a named recorded fact", () => {
-    const r = rankOffers(index.offers.filter((o) => o.category === "Databases"), {
+    const offers = index.offers.filter((o) => o.category === "Databases");
+    const r = rankOffers(offers, {
       queryKey: "best-of:Databases",
       changes: dealChanges,
       date: TODAY,
     });
-    assert.strictEqual(r.qualified.length, 41);
+    assert.strictEqual(r.qualified.length, offers.length - r.demoted.length - r.excluded.length);
     assert.deepStrictEqual(vendorsOf(r.demoted), ["Firebase"]);
     assert.strictEqual(r.demoted[0].demerits[0].code, "free_tier_withdrawn");
     assert.strictEqual(r.excluded.length, 2);

--- a/test/weekly-window-provenance.test.ts
+++ b/test/weekly-window-provenance.test.ts
@@ -43,6 +43,26 @@ async function mostRecentWeekWithADiscoveryBatch() {
   );
 }
 
+async function digestForWeekStarting(weekStart: string) {
+  const { getFormattedWeeklyDigest } = await import("../dist/data.js");
+  const weeksAgo = Math.round(
+    (Date.parse(isoWeekWindow(new Date()).start) - Date.parse(weekStart)) / (7 * 86400000)
+  );
+  const digest = getFormattedWeeklyDigest(weeksAgo, 200);
+  assert.strictEqual(digest.week_of, weekStart);
+  return digest;
+}
+
+function combinedCountPhrase(digest: { changes_in_week: number; discovered_in_week: number }): string {
+  return `across ${digest.changes_in_week + digest.discovered_in_week} developer tool pricing change`;
+}
+
+function weekCorrectedBy(correction: { id: string }): string {
+  const match = correction.id.match(/weekly-digest-(\d{4}-\d{2}-\d{2})$/);
+  assert.ok(match, `a correction id should name the week it replaces: ${correction.id}`);
+  return match![1];
+}
+
 describe("one definition of the week a digest is about", () => {
   it("runs Monday to Sunday whichever day of the week it is handed", () => {
     assert.deepStrictEqual(isoWeekWindow(new Date("2026-08-26T09:00:00Z")), {
@@ -265,12 +285,12 @@ describe("every weekly surface reports the same week", () => {
   let serverPort = 0;
   let proc: ChildProcess | null = null;
 
-  function startHttpServer(): Promise<ChildProcess> {
+  function startHttpServer(timeZone = "UTC"): Promise<ChildProcess> {
     return new Promise((resolve, reject) => {
       const serverPath = path.join(REPO, "dist", "serve.js");
       const p = spawn("node", [serverPath], {
         stdio: ["pipe", "pipe", "pipe"],
-        env: { ...process.env, PORT: "0", BASE_URL: "http://127.0.0.1" },
+        env: { ...process.env, PORT: "0", BASE_URL: "http://127.0.0.1", TZ: timeZone },
       });
       const timeout = setTimeout(() => { p.kill("SIGKILL"); reject(new Error("Server startup timeout")); }, 20000);
       p.stderr!.on("data", (data: Buffer) => {
@@ -307,17 +327,30 @@ describe("every weekly surface reports the same week", () => {
     proc = await startHttpServer();
     const base = `http://127.0.0.1:${serverPort}`;
     const feed = await (await fetch(`${base}/feed.xml`)).text();
-    const corrected = await mostRecentWeekWithADiscoveryBatch();
-    const inflated = `across ${corrected.changes_in_week + corrected.discovered_in_week} developer tool pricing change`;
 
     const entries = feed.split("<entry>").slice(1);
     const corrections = entries.filter((e) => e.includes("urn:agentdeals:correction:"));
     const weeks = entries.filter((e) => !e.includes("urn:agentdeals:correction:"));
-    for (const entry of weeks) assert.ok(!entry.includes(inflated), "/feed.xml weekly entry");
-    assert.ok(
-      corrections.some((e) => e.includes(inflated)),
-      "a corrected count should survive only inside the entry correcting it"
-    );
+
+    for (const entry of weeks) {
+      const id = entry.match(/<id>urn:agentdeals:weekly-digest:(\d{4}-\d{2}-\d{2})<\/id>/);
+      assert.ok(id, "a weekly entry should name the week it covers");
+      const digest = await digestForWeekStarting(id![1]);
+      if (digest.discovered_in_week === 0) continue;
+      assert.ok(
+        !entry.includes(combinedCountPhrase(digest)),
+        `/feed.xml weekly entry for ${digest.week_of}`
+      );
+    }
+
+    assert.ok(FEED_CORRECTIONS.length > 0);
+    for (const correction of FEED_CORRECTIONS) {
+      const digest = await digestForWeekStarting(weekCorrectedBy(correction));
+      assert.ok(
+        corrections.some((e) => e.includes(combinedCountPhrase(digest))),
+        `a corrected count should survive only inside the entry correcting it: ${correction.id}`
+      );
+    }
   });
 
   it("carries a feed entry for each recent week that tracked a change, and for no other", async () => {
@@ -361,6 +394,15 @@ describe("every weekly surface reports the same week", () => {
     const archive = await (await fetch(`${base}/digest/archive`)).text();
     assert.ok(archive.includes("1 change + 153 first read"), "the archive should split the week it holds");
     assert.ok(!archive.includes("154 changes"), "the archive should not count the batch as changes");
+  });
+
+  it("files a change in the same week whatever zone the server clock is set to", async () => {
+    proc = await startHttpServer("UTC");
+    const utc = await (await fetch(`http://127.0.0.1:${serverPort}/digest/archive`)).text();
+    proc.kill("SIGKILL");
+    proc = await startHttpServer("America/Los_Angeles");
+    const behindUtc = await (await fetch(`http://127.0.0.1:${serverPort}/digest/archive`)).text();
+    assert.strictEqual(behindUtc, utc);
   });
 
   it("tells an API caller how many of its records carry an effective date", async () => {


### PR DESCRIPTION
Refs #1190.

`main` is red at `9d7f789`, and has been since 13:41Z today. Every open pull request inherits it, which is what #1200's `test` failure is. Neither failure on #1200 is caused by that diff.

## 1. What turned `main` red

`test/weekly-window-provenance.test.ts:316`. One test, one assertion, and it is the *first* one — the `/feed.xml weekly entry` loop, not the correction check.

The test resolved "the week whose count was corrected" as **the most recent week that carries a discovery batch**. Until this morning that was the week of 2026-08-24: 1 dated change + 153 pages read for the first time, combined 154, which is the number the published correction quotes.

`9d7f789` (rolling re-verification) recorded one `discovered` change — Zoho Docs, dated 2026-08-31. That is the current week. So "most recent week with a discovery batch" became a week holding 0 dated changes and 1 discovered one, and the phrase the test then forbade in every weekly entry was `across 1 developer tool pricing change`.

The feed's entry for the week of 2026-08-24 says exactly that, correctly — that week has one dated change. The test matched a different week's honest headline against a number computed from this week.

Fixed by never comparing across weeks. Each weekly entry is now checked against its own week, resolved from the `<id>` the entry publishes, and each correction is checked against the week its own id names. Nothing depends on which week happens to hold a batch, so the next re-verification run cannot move it.

## 2. `test/ranking.test.ts:423` — the other failure on #1200

`assert.strictEqual(r.qualified.length, 41)` inside `Databases: Firebase is the only demotion, on a named recorded fact`. A catalogue-size snapshot in a test about demotion reasons; any correct addition to Databases breaks it, which is what #1200's data change does.

Replaced with the partition the three bands are supposed to form:

```ts
assert.strictEqual(r.qualified.length, offers.length - r.demoted.length - r.excluded.length);
```

That still fails if an offer is silently dropped between the input and the bands, and it does not move when the catalogue does.

## 3. Found on the way: `/digest/*` depends on the server's clock zone

`src/serve.ts` carried its own `getISOWeek`, which read a date parsed as UTC midnight back with **local** getters:

```ts
const d = new Date(Date.UTC(date.getFullYear(), date.getMonth(), date.getDate()));
```

West of UTC every date shifts back a day, so every Monday-dated change files into the previous week. **71 of 445 change records** land in the wrong week on a host set to `America/Los_Angeles`.

Production and CI both run UTC, so no reader has seen this and no CI run has caught it. What it does do is make local verification of the digest lie: running the suite here showed three failures where CI shows one, and the two extras were this.

`getISOWeek` is deleted. The week number now comes from `isoWeekOf` in `src/change-dates.ts`, built on the `isoWeekWindow` the rest of the weekly surfaces already use, so the two definitions cannot drift apart.

## Verification

**No published page moves.** Under UTC, `3,917 of 3,917` paths are byte-identical between this branch and `main` — same status, same body. The week keys are unchanged: 0 differences against the old function over all 445 change records and over a daily sweep of 2015-01-01 → 2035-01-01 (7,305 days). No archive URL moves.

**Under `America/Los_Angeles`, 26 pages differ from `main`** — 25 `/digest/*` weeks and `/digest/archive` — and `main` publishes one fewer path in its sitemap than it does under UTC.

**Mutation checks**, each scoped to the file that should catch it:

| mutation | result |
|---|---|
| headline count `weekChanges.length` → `+ weekDiscovered.length` | kills the rewritten feed test |
| correction id `weekly-digest-2026-08-24` → `-08-17` | kills it |
| `qualified` band drops one entry unaccounted (`.slice(1)`) | kills the Databases test |
| `isoWeekOf` → the deleted local-getter version (i.e. `main`) | kills the new clock-zone test |

**Test classification.** `files a change in the same week whatever zone the server clock is set to` fails on a `main` build — it is a regression guard for §3. The rewritten `keeps a corrected count…` passes on `main`: the assertion was the defect, not the code, and it still kills both mutations above.

**Full suite** 2,924 passing, 0 failing. `tsc` clean. Real MCP `initialize` → `notifications/initialized` → `tools/call track_changes` against `dist/serve.js`.

**#1200 specifically:** with that branch's `data/index.json` and these fixes, its two named failures are gone.
