### PR TITLE
Hold one transition to one record however a re-read grades it (#1203)

### DIFF
--- a/data/deal_changes.json
+++ b/data/deal_changes.json
@@ -4626,36 +4626,6 @@
       "recorded_date": "2026-08-28"
     },
     {
-      "vendor": "Algolia",
-      "change_type": "pricing_restructured",
-      "date": "2026-08-28",
-      "date_source": "discovered",
-      "summary": "The 'Grow' plan offers 10K search requests/month and 100K records included. It's now a paid plan with overage fees. A 'Free' plan is available with 10K search requests/month and 50K records. It has fewer features.",
-      "previous_state": "Search-as-a-service — 10K search requests/month, 1M records, AI recommendations included",
-      "current_state": "A 'Free' plan includes 10K search requests/month and 50K records. The 'Grow' plan includes 10K search requests /month and 100K records, with overages at $0.50/1K requests and $0.40/1K records.",
-      "impact": "high",
-      "source_url": "https://www.algolia.com/pricing",
-      "category": "Search",
-      "alternatives": [],
-      "detected_by": "reverify-ai",
-      "recorded_date": "2026-08-28"
-    },
-    {
-      "vendor": "Stripe Atlas",
-      "change_type": "limits_reduced",
-      "date": "2026-08-28",
-      "date_source": "discovered",
-      "summary": "The perks offered have changed. While the $50,000+ in discounts is still mentioned, the specific credits for AWS ($5K) and DigitalOcean ($5K) are no longer listed. The Stripe product credits are now $2,500 instead of $2.5K processing credits.",
-      "previous_state": "$50,000+ in founder perks — $5K AWS credits, $5K DigitalOcean credits, 1yr GitHub, $2.5K Stripe processing credits, plus Notion, Slack, Zendesk, Intercom, and more",
-      "current_state": "Atlas incorporates your company for $500 and includes $2,500 in Stripe product credits for your first year after incorporation, plus access to over $50,000 in partner discounts.",
-      "impact": "medium",
-      "source_url": "https://stripe.com/atlas",
-      "category": "Startup Programs",
-      "alternatives": [],
-      "detected_by": "reverify-ai",
-      "recorded_date": "2026-08-28"
-    },
-    {
       "vendor": "Semgrep",
       "change_type": "limits_reduced",
       "date": "2026-08-28",
@@ -4926,21 +4896,6 @@
       "recorded_date": "2026-08-28"
     },
     {
-      "vendor": "Tomorrow.io Weather API",
-      "change_type": "limits_reduced",
-      "date": "2026-08-28",
-      "date_source": "discovered",
-      "summary": "The free tier now has limitations on forecast days (5-day forecast), historical data (24 hours), and monitored locations (1). It also includes access to core weather data layers and industry-based insights templates. There are also paid tiers with increased limits and features.",
-      "previous_state": "Offers free plan of weather API. Provides accurate and up-to-date weather forecasting with global coverage, historical data and weather monitoring solutions.",
-      "current_state": "The free plan includes a 5-Day Forecast, Weather Timelines and Trendlines, Weather API Access, Core Weather Data Layers, Industry-Based Insights Templates, 24 hours Historical Weather Data, and 1 Automatically monitored Location.",
-      "impact": "medium",
-      "source_url": "https://www.tomorrow.io/weather-api/",
-      "category": "Dev Utilities",
-      "alternatives": [],
-      "detected_by": "reverify-ai",
-      "recorded_date": "2026-08-28"
-    },
-    {
       "vendor": "StreamBackdrops",
       "change_type": "pricing_model_change",
       "date": "2026-08-28",
@@ -5106,21 +5061,6 @@
       "recorded_date": "2026-08-28"
     },
     {
-      "vendor": "Bitrise",
-      "change_type": "limits_reduced",
-      "date": "2026-08-28",
-      "date_source": "discovered",
-      "summary": "The Hobby plan now has a monthly build credit limit and a build timeout of 210 minutes, and includes access to Linux Medium and macOS Medium build compute types. Previously 300 credits/month and 90-minute build timeout.",
-      "previous_state": "Mobile CI/CD platform — free Hobby plan: 300 credits/month, 1 private app (unlimited public apps), 1 user, 5 concurrent builds, 90-minute build timeout. Supports iOS, Android, Flutter, React Native",
-      "current_state": "Hobby: Free, Access for a team of one, Enough build credits for you to build your small project a few times per month, Support from the Bitrise Community via Slack or Discuss forum, Linux Medium, M2 Pro Medium, macOS Medium build compute types, 2 GB dependency cache storage, 210 minute build timeout.",
-      "impact": "medium",
-      "source_url": "https://bitrise.io/pricing",
-      "category": "CI/CD",
-      "alternatives": [],
-      "detected_by": "reverify-ai",
-      "recorded_date": "2026-08-28"
-    },
-    {
       "vendor": "Zipcodestack",
       "change_type": "limits_reduced",
       "date": "2026-08-28",
@@ -5211,21 +5151,6 @@
       "recorded_date": "2026-08-28"
     },
     {
-      "vendor": "Algolia",
-      "change_type": "new_free_tier",
-      "date": "2026-08-28",
-      "date_source": "discovered",
-      "summary": "The 'Grow' plan offers 10K search requests/month and 100K records included. The 'Build' tier name is absent. There's also a 'Free' tier with 10K search requests/month and 50K records.",
-      "previous_state": "Search-as-a-service — 10K search requests/month, 1M records, AI recommendations included",
-      "current_state": "The 'Grow' plan includes 10K search requests /month and 100K records. A 'Free' plan includes 10K search requests/month and 50K records.",
-      "impact": "medium",
-      "source_url": "https://www.algolia.com/pricing",
-      "category": "Search",
-      "alternatives": [],
-      "detected_by": "reverify-ai",
-      "recorded_date": "2026-08-28"
-    },
-    {
       "vendor": "userforge.com",
       "change_type": "limits_increased",
       "date": "2026-08-28",
@@ -5236,21 +5161,6 @@
       "impact": "medium",
       "source_url": "https://userforge.com/",
       "category": "Design",
-      "alternatives": [],
-      "detected_by": "reverify-ai",
-      "recorded_date": "2026-08-28"
-    },
-    {
-      "vendor": "StreamBackdrops",
-      "change_type": "free_tier_removed",
-      "date": "2026-08-28",
-      "date_source": "discovered",
-      "summary": "Free samples are available with no signup, the vendor now primarily offers HD editions starting at $4.99.",
-      "previous_state": "Free HD virtual backgrounds for video calls and team meetings. Professional backgrounds for Zoom, Teams, and Google Meet. No signup required, free for personal use.",
-      "current_state": "HD editions from $4.99. Free samples — no signup.",
-      "impact": "high",
-      "source_url": "https://streambackdrops.com",
-      "category": "Dev Utilities",
       "alternatives": [],
       "detected_by": "reverify-ai",
       "recorded_date": "2026-08-28"

--- a/scripts/change-log.js
+++ b/scripts/change-log.js
@@ -47,8 +47,18 @@ export function isEventDated(change) {
   return EVENT_DATED_SOURCES.includes(change?.date_source);
 }
 
+export const SUPPRESSED_ALREADY_RECORDED = "already_recorded";
+export const SUPPRESSED_WITHIN_REPICK_WINDOW = "recorded_within_repick_window";
+export const SUPPRESSED_SAME_TRANSITION_REGRADED = "same_transition_graded_differently";
+
 export function changeKey(change) {
   return [change.vendor, change.change_type, change.date, change.source_url].join("|");
+}
+
+export function baselineKey(change) {
+  const previous = typeof change?.previous_state === "string" ? change.previous_state.trim() : "";
+  if (!previous) return null;
+  return [change.vendor, change.date, change.source_url, previous].join("|");
 }
 
 export function isoDay(now) {
@@ -101,12 +111,15 @@ export function buildChangeEntry(offer, result, options = {}) {
 export function selectNewChanges(existing, candidates, options = {}) {
   const windowDays = options.windowDays ?? DEFAULT_REPICK_WINDOW_DAYS;
   const keys = new Set(existing.map(changeKey));
+  const baselines = new Map();
   const recent = new Map();
   for (const change of existing) {
     const stamp = change.recorded_date || change.date;
     const pair = `${change.vendor}|${change.change_type}`;
     const previous = recent.get(pair);
     if (!previous || stamp > previous) recent.set(pair, stamp);
+    const baseline = baselineKey(change);
+    if (baseline && !baselines.has(baseline)) baselines.set(baseline, changeKey(change));
   }
 
   const fresh = [];
@@ -114,17 +127,27 @@ export function selectNewChanges(existing, candidates, options = {}) {
   for (const candidate of candidates) {
     const key = changeKey(candidate);
     if (keys.has(key)) {
-      suppressed.push({ candidate, reason: "already_recorded" });
+      suppressed.push({ candidate, reason: SUPPRESSED_ALREADY_RECORDED });
+      continue;
+    }
+    const baseline = baselineKey(candidate);
+    if (baseline && baselines.has(baseline)) {
+      suppressed.push({
+        candidate,
+        reason: SUPPRESSED_SAME_TRANSITION_REGRADED,
+        collidedWith: baselines.get(baseline),
+      });
       continue;
     }
     const pair = `${candidate.vendor}|${candidate.change_type}`;
     const lastStamp = recent.get(pair);
     if (lastStamp && daysBetween(lastStamp, candidate.recorded_date) < windowDays) {
-      suppressed.push({ candidate, reason: "recorded_within_repick_window" });
+      suppressed.push({ candidate, reason: SUPPRESSED_WITHIN_REPICK_WINDOW });
       continue;
     }
     fresh.push(candidate);
     keys.add(key);
+    if (baseline) baselines.set(baseline, key);
     recent.set(pair, candidate.recorded_date);
   }
   return { fresh, suppressed };

--- a/scripts/change-refusals.js
+++ b/scripts/change-refusals.js
@@ -19,9 +19,9 @@ export function refusalKey(refusal) {
   return [refusal.vendor, refusal.source_url, refusal.reason].join("|");
 }
 
-export function buildRefusalEntry({ candidate, reason, detail }, options = {}) {
+export function buildRefusalEntry({ candidate, reason, detail, collidedWith }, options = {}) {
   const now = options.now ?? new Date();
-  return {
+  const entry = {
     vendor: candidate.vendor,
     change_type: candidate.change_type,
     reason,
@@ -33,6 +33,8 @@ export function buildRefusalEntry({ candidate, reason, detail }, options = {}) {
     category: candidate.category ?? null,
     refused_date: isoDay(now),
   };
+  if (collidedWith) entry.collided_with = collidedWith;
+  return entry;
 }
 
 export function readRefusals(path = refusalsPath()) {

--- a/scripts/e2e-1203.mjs
+++ b/scripts/e2e-1203.mjs
@@ -1,0 +1,68 @@
+import { mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import assert from "node:assert";
+
+const { runAiMode } = await import("./reverify-rolling.js");
+
+const scratch = mkdtempSync(path.join(tmpdir(), "e2e-1203-"));
+const changesPath = path.join(scratch, "deal_changes.json");
+const refusalsPath = path.join(scratch, "change_refusals.json");
+writeFileSync(changesPath, JSON.stringify({ changes: [] }, null, 2) + "\n");
+
+const OFFER = {
+  vendor: "Examplebase",
+  category: "Databases",
+  tier: "Free",
+  description: "500 MB storage and 2 GB egress per month, free forever",
+  url: "https://examplebase.dev/pricing",
+};
+
+const PAGE =
+  "Examplebase pricing. Free plan: 250 MB storage and 1 GB egress per month. " +
+  "Pro plan $19/month with 10 GB storage. Prices in USD.";
+
+const grade = (change_type, summary) => async () => ({
+  status: "changed",
+  change_type,
+  summary,
+  current_state: "Free plan: 250 MB storage and 1 GB egress per month.",
+  impact: "medium",
+});
+
+const run = (verifyFn) =>
+  runAiMode([{ index: 0, offer: OFFER }], { offers: [{ ...OFFER }] }, false, new Date("2026-08-31T09:00:00Z"), {
+    fetchFn: async () => ({ ok: true, text: PAGE }),
+    verifyFn,
+    confirmFn: async () => ({ verdict: "yes", reason: null }),
+    rateLimitMs: 0,
+    changesPath,
+    refusalsPath,
+  });
+
+const first = await run(grade("limits_reduced", "Storage cut from 500 MB to 250 MB and egress from 2 GB to 1 GB."));
+assert.strictEqual(first.recorded.length, 1, "the first reading should be recorded");
+assert.strictEqual(first.recorded[0].change_type, "limits_reduced");
+
+const second = await run(grade("limits_increased", "Storage is now 250 MB and egress 1 GB on the free plan."));
+assert.strictEqual(second.recorded.length, 0, "a re-read graded differently should not be recorded");
+assert.strictEqual(second.suppressed.length, 1);
+assert.strictEqual(second.suppressed[0].reason, "same_transition_graded_differently");
+
+const stored = JSON.parse(readFileSync(changesPath, "utf-8")).changes;
+assert.strictEqual(stored.length, 1, `one transition should hold one record, found ${stored.length}`);
+assert.strictEqual(stored[0].change_type, "limits_reduced");
+
+const refusals = JSON.parse(readFileSync(refusalsPath, "utf-8")).refusals;
+const collision = refusals.find((r) => r.reason === "same_transition_graded_differently");
+assert.ok(collision, "the collision should be written to the refusal log");
+assert.strictEqual(collision.change_type, "limits_increased");
+assert.strictEqual(collision.collided_with, ["Examplebase", "limits_reduced", "2026-08-31", OFFER.url].join("|"));
+assert.strictEqual(collision.previous_state, OFFER.description);
+
+const third = await run(grade("limits_reduced", "Storage cut from 500 MB to 250 MB and egress from 2 GB to 1 GB."));
+assert.strictEqual(third.suppressed[0].reason, "already_recorded", "an identical re-read keeps its own reason");
+
+console.log("recorded:", stored.length, "record —", stored[0].change_type);
+console.log("refused :", collision.reason, "->", collision.collided_with);
+console.log("e2e-1203 OK");

--- a/scripts/mutate-1203.sh
+++ b/scripts/mutate-1203.sh
@@ -1,0 +1,205 @@
+#!/usr/bin/env bash
+set -u
+
+REPO="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$REPO" || exit 1
+
+LOG="scripts/change-log.js"
+REFUSALS="scripts/change-refusals.js"
+ROLLING="scripts/reverify-rolling.js"
+FILES=("$LOG" "$REFUSALS" "$ROLLING")
+BACKUP_DIR="$(mktemp -d)"
+for f in "${FILES[@]}"; do
+  cp "$f" "$BACKUP_DIR/$(basename "$f")"
+done
+
+restore() {
+  for f in "${FILES[@]}"; do
+    cp "$BACKUP_DIR/$(basename "$f")" "$f"
+  done
+}
+trap 'restore' EXIT
+
+killed=0
+survived=0
+TESTS="test/change-log-writer.test.ts test/change-refusals.test.ts test/reverify-rolling.test.ts"
+
+py() { python3 - "$@"; }
+
+changed_any() {
+  for f in "${FILES[@]}"; do
+    if ! diff -q "$BACKUP_DIR/$(basename "$f")" "$f" > /dev/null; then
+      return 0
+    fi
+  done
+  return 1
+}
+
+run_mutation() {
+  local name="$1"
+  shift
+  echo "=== $name"
+  restore
+  "$@"
+  if ! changed_any; then
+    echo "    NOT APPLIED: the mutation changed no file, so it proves nothing"
+    survived=$((survived + 1))
+    return
+  fi
+  if timeout 900 node --test --test-concurrency 1 $TESTS > /tmp/mutate-1203-test.log 2>&1; then
+    echo "    SURVIVED"
+    survived=$((survived + 1))
+  else
+    echo "    KILLED: $(grep -c '✖ ' /tmp/mutate-1203-test.log) failing assertion(s)"
+    grep '✖ ' /tmp/mutate-1203-test.log | head -3
+    killed=$((killed + 1))
+  fi
+}
+
+m_no_baseline_check() {
+  py <<'PY'
+p = "scripts/change-log.js"
+s = open(p).read()
+s = s.replace("""    const baseline = baselineKey(candidate);
+    if (baseline && baselines.has(baseline)) {
+      suppressed.push({
+        candidate,
+        reason: SUPPRESSED_SAME_TRANSITION_REGRADED,
+        collidedWith: baselines.get(baseline),
+      });
+      continue;
+    }
+""", "    const baseline = baselineKey(candidate);\n")
+open(p, "w").write(s)
+PY
+}
+
+m_baseline_ignores_previous_state() {
+  py <<'PY'
+p = "scripts/change-log.js"
+s = open(p).read()
+s = s.replace('  return [change.vendor, change.date, change.source_url, previous].join("|");',
+              '  return [change.vendor, change.date, change.source_url].join("|");')
+open(p, "w").write(s)
+PY
+}
+
+m_baseline_reads_a_missing_previous_state() {
+  py <<'PY'
+p = "scripts/change-log.js"
+s = open(p).read()
+s = s.replace("  if (!previous) return null;\n", "")
+open(p, "w").write(s)
+PY
+}
+
+m_fresh_candidate_leaves_no_baseline() {
+  py <<'PY'
+p = "scripts/change-log.js"
+s = open(p).read()
+s = s.replace("    if (baseline) baselines.set(baseline, key);\n", "")
+open(p, "w").write(s)
+PY
+}
+
+m_baseline_index_skips_the_stored_log() {
+  py <<'PY'
+p = "scripts/change-log.js"
+s = open(p).read()
+s = s.replace("    if (baseline && !baselines.has(baseline)) baselines.set(baseline, changeKey(change));\n", "")
+open(p, "w").write(s)
+PY
+}
+
+m_baseline_check_runs_before_the_exact_key() {
+  py <<'PY'
+p = "scripts/change-log.js"
+s = open(p).read()
+s = s.replace("""    if (keys.has(key)) {
+      suppressed.push({ candidate, reason: SUPPRESSED_ALREADY_RECORDED });
+      continue;
+    }
+    const baseline = baselineKey(candidate);""",
+"""    const baseline = baselineKey(candidate);
+    if (keys.has(key) && !baselines.has(baseline)) {
+      suppressed.push({ candidate, reason: SUPPRESSED_ALREADY_RECORDED });
+      continue;
+    }""")
+open(p, "w").write(s)
+PY
+}
+
+m_collided_key_not_carried() {
+  py <<'PY'
+p = "scripts/change-log.js"
+s = open(p).read()
+s = s.replace("        collidedWith: baselines.get(baseline),\n", "")
+open(p, "w").write(s)
+PY
+}
+
+m_refusal_drops_the_collided_key() {
+  py <<'PY'
+p = "scripts/change-refusals.js"
+s = open(p).read()
+s = s.replace("  if (collidedWith) entry.collided_with = collidedWith;\n", "")
+open(p, "w").write(s)
+PY
+}
+
+m_refusal_always_carries_a_collided_key() {
+  py <<'PY'
+p = "scripts/change-refusals.js"
+s = open(p).read()
+s = s.replace("  if (collidedWith) entry.collided_with = collidedWith;",
+              "  entry.collided_with = collidedWith ?? null;")
+open(p, "w").write(s)
+PY
+}
+
+m_every_suppression_becomes_a_refusal() {
+  py <<'PY'
+p = "scripts/reverify-rolling.js"
+s = open(p).read()
+s = s.replace("    .filter((entry) => entry.reason === SUPPRESSED_SAME_TRANSITION_REGRADED)\n", "")
+open(p, "w").write(s)
+PY
+}
+
+m_summary_does_not_split_the_two_counts() {
+  py <<'PY'
+p = "scripts/reverify-rolling.js"
+s = open(p).read()
+s = s.replace("    lines.push(`Already recorded, not written again: ${result.suppressed.length - regraded}`);",
+              "    lines.push(`Already recorded, not written again: ${result.suppressed.length}`);")
+open(p, "w").write(s)
+PY
+}
+
+m_summary_reports_no_disagreement() {
+  py <<'PY'
+p = "scripts/reverify-rolling.js"
+s = open(p).read()
+s = s.replace("Same transition re-read and graded differently, not written again: ${regraded}",
+              "Same transition re-read and graded differently, not written again: 0")
+open(p, "w").write(s)
+PY
+}
+
+run_mutation "the baseline collision is never checked" m_no_baseline_check
+run_mutation "the baseline ignores previous_state" m_baseline_ignores_previous_state
+run_mutation "a record with no previous_state still gets a baseline" m_baseline_reads_a_missing_previous_state
+run_mutation "an accepted candidate leaves no baseline behind it" m_fresh_candidate_leaves_no_baseline
+run_mutation "the stored log contributes no baselines" m_baseline_index_skips_the_stored_log
+run_mutation "the baseline check runs before the exact key" m_baseline_check_runs_before_the_exact_key
+run_mutation "the collided key is not carried out of the suppression" m_collided_key_not_carried
+run_mutation "the refusal drops the collided key" m_refusal_drops_the_collided_key
+run_mutation "every refusal carries a collision field" m_refusal_always_carries_a_collided_key
+run_mutation "every suppression is written as a refusal" m_every_suppression_becomes_a_refusal
+run_mutation "the summary does not split the two counts" m_summary_does_not_split_the_two_counts
+run_mutation "the summary reports no disagreement" m_summary_reports_no_disagreement
+
+restore
+echo
+echo "killed: $killed   survived: $survived"
+[ "$survived" -eq 0 ]

--- a/scripts/reverify-rolling.js
+++ b/scripts/reverify-rolling.js
@@ -5,7 +5,11 @@ import { resolve, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 import { reverifyBatch } from "./reverify.js";
 import { fetchPageText, verifyOfferAgainstPage, createVerifierClient, VERIFIER_MODEL } from "./verify-freshness.js";
-import { buildChangeEntry, appendChangeEntries } from "./change-log.js";
+import {
+  buildChangeEntry,
+  appendChangeEntries,
+  SUPPRESSED_SAME_TRANSITION_REGRADED,
+} from "./change-log.js";
 import {
   gateCandidates,
   confirmDescribesChange,
@@ -286,21 +290,21 @@ export async function runAiMode(picked, data, dryRun, now, options = {}) {
     console.log(`  ? ${candidate.vendor} (${candidate.change_type}) recorded without a second opinion: ${error}`);
   }
 
-  const refusals = (options.recordRefusalsFn ?? recordRefusals)(rejected, {
-    dryRun,
-    now,
-    path: options.refusalsPath,
-  });
-  console.log(`  → ${refusals.written.length} refusal(s) written to ${refusals.path}`);
-
   const { appended, suppressed } = appendFn(accepted, {
     dryRun,
     windowDays: options.windowDays,
     path: options.changesPath,
   });
-  for (const { candidate, reason } of suppressed) {
-    console.log(`  – ${candidate.vendor} (${candidate.change_type}) not recorded: ${reason}`);
+  for (const { candidate, reason, collidedWith } of suppressed) {
+    const against = collidedWith ? ` (collides with ${collidedWith})` : "";
+    console.log(`  – ${candidate.vendor} (${candidate.change_type}) not recorded: ${reason}${against}`);
   }
+
+  const refusals = (options.recordRefusalsFn ?? recordRefusals)(
+    [...rejected, ...regradeRefusals(suppressed)],
+    { dryRun, now, path: options.refusalsPath }
+  );
+  console.log(`  → ${refusals.written.length} refusal(s) written to ${refusals.path}`);
 
   return { verified, flagged, changed, changes, recorded: appended, suppressed, unclassified, rejected, unchecked, reclassified, rewritten, overruled, sourceChecks, attempts: recorder.attempts };
 }
@@ -308,6 +312,17 @@ export async function runAiMode(picked, data, dryRun, now, options = {}) {
 export function repickWindowDays(total, batchSize) {
   if (!batchSize || batchSize < 1) return 1;
   return Math.max(1, Math.ceil(total / batchSize));
+}
+
+export function regradeRefusals(suppressed) {
+  return (suppressed ?? [])
+    .filter((entry) => entry.reason === SUPPRESSED_SAME_TRANSITION_REGRADED)
+    .map(({ candidate, reason, collidedWith }) => ({
+      candidate,
+      reason,
+      detail: `same vendor, date, source_url and previous_state as ${collidedWith}`,
+      collidedWith,
+    }));
 }
 
 export function refusedVendorLines(rejected) {
@@ -354,7 +369,9 @@ export function summaryLines(result, { useAi, checked, oldestRemaining, total, q
     }
     lines.push(`Recorded without a second opinion: ${(result.unchecked ?? []).length}`);
     lines.push(`Recorded to data/deal_changes.json: ${result.recorded.length}`);
-    lines.push(`Already recorded, not written again: ${result.suppressed.length}`);
+    const regraded = regradeRefusals(result.suppressed).length;
+    lines.push(`Already recorded, not written again: ${result.suppressed.length - regraded}`);
+    lines.push(`Same transition re-read and graded differently, not written again: ${regraded}`);
     lines.push(`Detected but not recordable: ${result.unclassified.length}`);
   } else {
     lines.push("Change detection: not run. URL mode compares nothing and cannot report a change.");

--- a/test/change-log-writer.test.ts
+++ b/test/change-log-writer.test.ts
@@ -18,11 +18,13 @@ const {
   appendChangeEntries,
   changeLogFreshness,
   changeKey,
+  baselineKey,
   CHANGE_TYPES,
   DETECTED_BY_AI,
+  SUPPRESSED_SAME_TRANSITION_REGRADED,
 } = await import("../scripts/change-log.js");
 
-const { runUrlMode, runAiMode, summaryLines, repickWindowDays } = await import("../scripts/reverify-rolling.js");
+const { runUrlMode, runAiMode, summaryLines, repickWindowDays, regradeRefusals } = await import("../scripts/reverify-rolling.js");
 const { firstSeenDates } = await import("../scripts/backfill-change-recorded-dates.js");
 const { report, DEFAULT_THRESHOLD_DAYS, detectorSchedule, flagTokens, DETECTOR_CLI_OPTIONS, WORKFLOW_PATH } = await import("../scripts/check-change-log-staleness.js");
 const { VERIFIER_API_KEY_ENV, VERIFIER_MODEL } = await import("../scripts/verify-freshness.js");
@@ -206,6 +208,106 @@ describe("change log writer", () => {
       assert.strictEqual(fresh.length, 0);
       assert.strictEqual(suppressed[0].reason, "already_recorded");
     });
+
+    it("writes one record for one transition however the re-read grades it", () => {
+      const first = candidate();
+      const regraded = { ...candidate(), change_type: "limits_increased" };
+      const { fresh, suppressed } = selectNewChanges([first], [regraded], { windowDays: 0 });
+      assert.strictEqual(fresh.length, 0);
+      assert.strictEqual(suppressed[0].reason, SUPPRESSED_SAME_TRANSITION_REGRADED);
+      assert.strictEqual(suppressed[0].collidedWith, changeKey(first));
+    });
+
+    it("holds one transition to one record within a single batch", () => {
+      const graded = (change_type: string) => ({ ...candidate(), change_type });
+      const { fresh, suppressed } = selectNewChanges(
+        [],
+        [graded("limits_reduced"), graded("limits_increased"), graded("new_free_tier")],
+        { windowDays: 0 }
+      );
+      assert.strictEqual(fresh.length, 1);
+      assert.strictEqual(fresh[0].change_type, "limits_reduced");
+      assert.deepStrictEqual(
+        suppressed.map((s: any) => s.reason),
+        [SUPPRESSED_SAME_TRANSITION_REGRADED, SUPPRESSED_SAME_TRANSITION_REGRADED]
+      );
+    });
+
+    it("writes both records when one pricing page moves two products", () => {
+      const vps = {
+        ...candidate(),
+        change_type: "pricing_restructured",
+        previous_state: "VPS-1 $4.90/mo, VPS-2 ~$8/mo, VPS-4 $26.00/mo",
+      };
+      const cloud = {
+        ...candidate(),
+        change_type: "limits_reduced",
+        previous_state: "Standard pricing on Public Cloud instances and Bare Metal",
+      };
+      const { fresh, suppressed } = selectNewChanges([vps], [cloud], { windowDays: 0 });
+      assert.strictEqual(fresh.length, 1);
+      assert.strictEqual(suppressed.length, 0);
+    });
+
+    it("does not read two records with no baseline as one transition", () => {
+      const stored = { ...candidate(), previous_state: "" };
+      const incoming = { ...candidate(), change_type: "limits_increased", previous_state: "" };
+      assert.strictEqual(baselineKey(stored), null);
+      const { fresh, suppressed } = selectNewChanges([stored], [incoming], { windowDays: 0 });
+      assert.strictEqual(fresh.length, 1);
+      assert.strictEqual(suppressed.length, 0);
+    });
+
+    it("hands the collided key to the refusal log", () => {
+      const first = candidate();
+      const { suppressed } = selectNewChanges([first], [{ ...candidate(), change_type: "limits_increased" }], {
+        windowDays: 0,
+      });
+      const refusals = regradeRefusals(suppressed);
+      assert.strictEqual(refusals.length, 1);
+      assert.strictEqual(refusals[0].reason, SUPPRESSED_SAME_TRANSITION_REGRADED);
+      assert.strictEqual(refusals[0].collidedWith, changeKey(first));
+      assert.match(refusals[0].detail, /previous_state/);
+    });
+
+    it("leaves the other suppression reasons out of the refusal log", () => {
+      const { suppressed } = selectNewChanges([candidate()], [candidate()], { windowDays: 0 });
+      assert.strictEqual(suppressed[0].reason, "already_recorded");
+      assert.deepStrictEqual(regradeRefusals(suppressed), []);
+    });
+  });
+
+  describe("one transition holds one record across the whole stored log", () => {
+    const stored = JSON.parse(
+      readFileSync(path.join(REPO, "data", "deal_changes.json"), "utf-8")
+    ).changes as Array<Record<string, string>>;
+
+    it("stores no two records for one vendor, date, page and baseline", () => {
+      const groups = new Map<string, Array<Record<string, string>>>();
+      for (const change of stored) {
+        const key = baselineKey(change);
+        if (!key) continue;
+        if (!groups.has(key)) groups.set(key, []);
+        groups.get(key)!.push(change);
+      }
+      const collisions = [...groups.values()]
+        .filter(group => group.length > 1)
+        .map(group => `${group[0].vendor} ${group[0].date}: ${group.map(c => c.change_type).join(" + ")}`);
+      assert.deepStrictEqual(collisions, []);
+    });
+
+    it("keeps both records where one page moved two products on one day", () => {
+      const pair = stored.filter(c => c.vendor === "OVHcloud" && c.date === "2026-04-01");
+      assert.strictEqual(pair.length, 2);
+      assert.strictEqual(pair[0].source_url, pair[1].source_url);
+      assert.notStrictEqual(pair[0].previous_state, pair[1].previous_state);
+      assert.notStrictEqual(baselineKey(pair[0]), baselineKey(pair[1]));
+    });
+
+    it("is not vacuous — most of the log carries a baseline the rule can read", () => {
+      const withBaseline = stored.filter(c => baselineKey(c) !== null);
+      assert.ok(withBaseline.length > stored.length / 2, `records carrying a baseline: ${withBaseline.length}`);
+    });
   });
 
   describe("what the run tells whoever reads the log", () => {
@@ -224,6 +326,17 @@ describe("change log writer", () => {
       assert.ok(lines.includes("Recorded to data/deal_changes.json: 1"));
       assert.ok(lines.includes("Already recorded, not written again: 1"));
       assert.ok(lines.includes("Detected but not recordable: 1"));
+    });
+
+    it("counts a re-read that agreed apart from one that graded the same transition differently", () => {
+      const suppressed = [
+        { candidate: {}, reason: "already_recorded" },
+        { candidate: {}, reason: "recorded_within_repick_window" },
+        { candidate: {}, reason: SUPPRESSED_SAME_TRANSITION_REGRADED, collidedWith: "k" },
+      ];
+      const lines = summaryLines({ ...aiResult, suppressed }, { ...context, useAi: true });
+      assert.ok(lines.includes("Already recorded, not written again: 2"));
+      assert.ok(lines.includes("Same transition re-read and graded differently, not written again: 1"));
     });
 
     it("derives the re-pick window from how long the catalogue takes to come round", () => {

--- a/test/change-refusals.test.ts
+++ b/test/change-refusals.test.ts
@@ -110,6 +110,22 @@ describe("a refusal outlives the run that made it", () => {
     );
   });
 
+  it("stores the record a refusal collided with when there was one", () => {
+    const collidedWith = "Weaviate|limits_increased|2026-08-28|https://weaviate.io/pricing";
+    const entry = buildRefusalEntry(
+      { ...WEAVIATE_REFUSED, reason: "same_transition_graded_differently", collidedWith },
+      { now: NOW }
+    );
+    assert.strictEqual(entry.collided_with, collidedWith);
+    assert.strictEqual(entry.change_type, "limits_reduced");
+    assert.strictEqual(entry.previous_state, WEAVIATE_OFFER.description);
+  });
+
+  it("adds no collision field to a refusal that did not collide with anything", () => {
+    const entry = buildRefusalEntry(WEAVIATE_REFUSED, { now: NOW });
+    assert.ok(!("collided_with" in entry), "a gate refusal carries a collision key");
+  });
+
   it("reads no refusals from a file that is not there yet", () => {
     assert.deepStrictEqual(readRefusals(path.join(tmpdir(), "no-such-refusals.json")), []);
   });

--- a/test/weekly-window-provenance.test.ts
+++ b/test/weekly-window-provenance.test.ts
@@ -63,6 +63,19 @@ function weekCorrectedBy(correction: { id: string }): string {
   return match![1];
 }
 
+function countCorrectedBy(correction: { summaryHtml: string }): string {
+  const match = correction.summaryHtml.match(/across \d+ developer tool pricing change/);
+  assert.ok(match, "a correction should quote the count it replaces");
+  return match![0];
+}
+
+function changeCount(n: number): string {
+  return `${n} change${n === 1 ? "" : "s"}`;
+}
+
+const ARCHIVED_BATCH_WEEK = "2026-08-24";
+const ARCHIVED_BATCH_SLUG = "2026-w35";
+
 describe("one definition of the week a digest is about", () => {
   it("runs Monday to Sunday whichever day of the week it is handed", () => {
     assert.deepStrictEqual(isoWeekWindow(new Date("2026-08-26T09:00:00Z")), {
@@ -345,10 +358,15 @@ describe("every weekly surface reports the same week", () => {
 
     assert.ok(FEED_CORRECTIONS.length > 0);
     for (const correction of FEED_CORRECTIONS) {
-      const digest = await digestForWeekStarting(weekCorrectedBy(correction));
+      await digestForWeekStarting(weekCorrectedBy(correction));
+      const quoted = countCorrectedBy(correction);
       assert.ok(
-        corrections.some((e) => e.includes(combinedCountPhrase(digest))),
-        `a corrected count should survive only inside the entry correcting it: ${correction.id}`
+        corrections.some((e) => e.includes(quoted)),
+        `a corrected count should survive inside the entry correcting it: ${correction.id}`
+      );
+      assert.ok(
+        !weeks.some((e) => e.includes(quoted)),
+        `a corrected count should survive nowhere else: ${correction.id}`
       );
     }
   });
@@ -382,18 +400,31 @@ describe("every weekly surface reports the same week", () => {
   it("labels the discovery batch on the archived week that holds it", async () => {
     proc = await startHttpServer();
     const base = `http://127.0.0.1:${serverPort}`;
-    const week = await (await fetch(`${base}/digest/2026-w35`)).text();
-    assert.ok(week.includes("Week 35, 2026. 1 change tracked."), "the archived week should count one change");
-    assert.ok(week.includes(firstReadHeading(153)), "the archived week should name its discovery batch");
-    assert.ok(!week.includes("154 changes tracked"), "the archived week should not count the batch as changes");
+    const digest = await digestForWeekStarting(ARCHIVED_BATCH_WEEK);
+    assert.ok(digest.discovered_in_week > 0, "the archived week under test should hold a discovery batch");
+    const week = await (await fetch(`${base}/digest/${ARCHIVED_BATCH_SLUG}`)).text();
+    assert.ok(week.includes(`${changeCount(digest.changes_in_week)} tracked.`), "the archived week should count its dated changes");
+    assert.ok(week.includes(firstReadHeading(digest.discovered_in_week)), "the archived week should name its discovery batch");
+    assert.ok(
+      !week.includes(`${changeCount(digest.changes_in_week + digest.discovered_in_week)} tracked.`),
+      "the archived week should not count the batch as changes"
+    );
   });
 
   it("separates the two counts in the archive index", async () => {
     proc = await startHttpServer();
     const base = `http://127.0.0.1:${serverPort}`;
+    const digest = await digestForWeekStarting(ARCHIVED_BATCH_WEEK);
+    assert.ok(digest.discovered_in_week > 0, "the archived week under test should hold a discovery batch");
     const archive = await (await fetch(`${base}/digest/archive`)).text();
-    assert.ok(archive.includes("1 change + 153 first read"), "the archive should split the week it holds");
-    assert.ok(!archive.includes("154 changes"), "the archive should not count the batch as changes");
+    assert.ok(
+      archive.includes(`${changeCount(digest.changes_in_week)} + ${digest.discovered_in_week} first read`),
+      "the archive should split the week it holds"
+    );
+    assert.ok(
+      !archive.includes(changeCount(digest.changes_in_week + digest.discovered_in_week)),
+      "the archive should not count the batch as changes"
+    );
   });
 
   it("files a change in the same week whatever zone the server clock is set to", async () => {


### PR DESCRIPTION
Refs #1203

`change_type` was inside the deduplication key, so a re-read that reached a different grade produced a different key and `already_recorded` did not fire. Both readings were written.

## The rule

`baselineKey()` is `vendor | date | source_url | previous_state`. A candidate whose baseline key matches a record already in the log is suppressed as `same_transition_graded_differently`, whatever its `change_type`. The check runs after the exact-key check, so an identical re-read keeps its existing `already_recorded` reason, and before the re-pick window, which had the same hole (it is keyed on `vendor|change_type`).

`previous_state` is the discriminator the issue names. A record with no `previous_state` gets no baseline key and is never collided — 97 of the stored records are in that state and none of them is a detector candidate.

Fresh candidates enter the baseline index as they are accepted, so three gradings of one page inside a single batch also resolve to one record.

## AC-2 — the refusal

Suppressed collisions now go through `recordRefusals` alongside gate refusals, carrying `reason: same_transition_graded_differently` and `collided_with: <the changeKey it lost to>`. Refusals are recorded after the append rather than before it, since the collision is only known once the append has run.

One limit worth stating: `refusalKey` is `vendor|source_url|reason`, so two collisions on one page under one reason merge to a single entry. The durable file answers *which pages the detector disagreed with itself about*; the per-run count is AC-6's job. I did not widen `refusalKey` — `test/change-refusals.test.ts` pins it as a deliberate design and the change would be out of scope here.

## AC-4 — the six records

Applied to the stored log the rule finds exactly the five groups the issue names, and OVHcloud's 2026-04-01 pair is correctly not among them. 445 → 439 records (438 after #1204 landed).

| vendor | deleted | kept | why |
|---|---|---|---|
| Bitrise | `limits_reduced` | `limits_increased` | the only quantity stated on both sides is the build timeout, 90 → 210 minutes. The reduction rests on the page no longer printing a credit count. |
| Tomorrow.io Weather API | `limits_reduced` | `limits_increased` | `previous_state` states no quantity, so neither direction is measured. Between two equally unsupported readings the adverse one is the costlier error, and AC-4 rules it out. |
| Algolia | `pricing_restructured`, `new_free_tier` | `limits_reduced` | records go 1M → 50K, stated on both sides. `new_free_tier` is contradicted by a baseline that already describes a free tier. |
| Stripe Atlas | `limits_reduced` | `pricing_restructured` | its own quantities are $2.5K → $2,500 — the same number. The survivor's `$5K` misquotes the baseline; correcting published record text is the PM's call, not mine. |
| StreamBackdrops | `free_tier_removed` | `pricing_model_change` | both records' `current_state` say free samples still exist with no signup, so the removal claim refutes itself. |

## AC-5 — what moved on the site

`/vendor/bitrise` and `/vendor/tomorrow-io-weather-api` now read stable. `/vendor/algolia` and `/vendor/stripe-atlas` still read "requires caution", now resting on a single record whose direction its own quantities support.

**`/vendor/streambackdrops` swung from "free tier removed" to "stable", and that needs a decision that is not mine.** `RISK_DEMOTION` in `src/data.ts` maps `restriction` and `pricing_model_change` to `null` while `CHANGE_DIRECTION` in the same file calls both `negative`. 13 vendors publish a stable verdict whose only adverse record is one of those two types; StreamBackdrops is now the 13th. `getBadgeStatus` has the same shape — its negative set is the only one of ten in the tree that omits `restriction`. Both predate this PR and I have left them alone.

## Verification

- **2,829 tests, 2,829 pass** on the rebased branch. `tsc` clean, `validate-data` 1580 offers / 438 changes.
- **`scripts/mutate-1203.sh` — 12 mutations, 12 killed, 0 survivors.** Including reordering the baseline check above the exact-key check, dropping `previous_state` from the baseline, and giving a record with no `previous_state` a baseline anyway.
- **`scripts/e2e-1203.mjs`** drives the real `runAiMode` path three times over one offer: first grading recorded, second grading suppressed and written to the refusal log with its collision key, third identical re-read reported as `already_recorded`.
- **Route sweep, 3,917 paths, main vs branch.** 1,888 differ. 1,572 are every vendor page carrying the site-wide total (445 → 439); the rest are the five vendors' own surfaces plus the pages that aggregate them. No route added or removed.

## Three tests in `test/weekly-window-provenance.test.ts`

Deleting six `discovered` records dated 2026-08-28 moved week 35's batch from 153 to 147, and three tests pinned 153/154 as literals. Two now derive both counts from the digest for that week; both pass unchanged against `main`'s data as well as this branch's, which is what shows they are derived rather than retuned.

The third asserted that a published correction quotes a count recomputed live. That coupling is wrong in principle — the correction is a dated statement of what we published on 2026-08-29 and must not move when the underlying records do. It now reads the corrected count out of the correction's own text and asserts it appears inside the correction entry and in no weekly entry, which is both stronger and independent of the data.
