### PR TITLE
One verdict engine, and an event verdict that expires (#1206)

### DIFF
--- a/scripts/mutate-1143.sh
+++ b/scripts/mutate-1143.sh
@@ -117,8 +117,8 @@ m_a_stable_rating_never_mentions_the_records_it_holds() {
   py <<'PY'
 p = "src/vendor-verdict.ts"
 s = open(p).read()
-s = s.replace('  return `We rate it stable — we hold no ${DEMOTING_KINDS_PHRASE} for this vendor. ${narrowingSentence(input.changes)}`;',
-              '  return `We rate it stable — we hold no ${DEMOTING_KINDS_PHRASE} for this vendor.`;')
+s = s.replace('  return `We rate it stable. ${narrowingSentence(input.changes)}`;',
+              '  return `We rate it stable.`;')
 open(p, "w").write(s)
 PY
 }

--- a/scripts/mutate-1206.sh
+++ b/scripts/mutate-1206.sh
@@ -1,0 +1,217 @@
+#!/usr/bin/env bash
+set -u
+
+REPO="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$REPO" || exit 1
+
+DATA="src/data.ts"
+SERVE="src/serve.ts"
+VERDICT="src/vendor-verdict.ts"
+FILES=("$DATA" "$SERVE" "$VERDICT")
+BACKUP_DIR="$(mktemp -d)"
+for f in "${FILES[@]}"; do
+  cp "$f" "$BACKUP_DIR/$(basename "$f")"
+done
+
+restore() {
+  for f in "${FILES[@]}"; do
+    cp "$BACKUP_DIR/$(basename "$f")" "$f"
+  done
+  npx tsc > /dev/null 2>&1
+}
+trap 'restore' EXIT
+
+killed=0
+survived=0
+TESTS="test/one-verdict-engine.test.ts test/vendor-risk.test.ts test/risk-badge.test.ts"
+
+py() { python3 - "$@"; }
+
+changed_any() {
+  for f in "${FILES[@]}"; do
+    if ! diff -q "$BACKUP_DIR/$(basename "$f")" "$f" > /dev/null; then
+      return 0
+    fi
+  done
+  return 1
+}
+
+run_mutation() {
+  local name="$1"
+  shift
+  echo "=== $name"
+  for f in "${FILES[@]}"; do cp "$BACKUP_DIR/$(basename "$f")" "$f"; done
+  "$@"
+  if ! changed_any; then
+    echo "    NOT APPLIED: the mutation changed no file, so it proves nothing"
+    survived=$((survived + 1))
+    return
+  fi
+  if ! npx tsc > /tmp/mutate-1206-build.log 2>&1; then
+    echo "    NOT APPLIED: the mutation does not compile"
+    survived=$((survived + 1))
+    return
+  fi
+  if timeout 900 node --test --test-concurrency 1 $TESTS > /tmp/mutate-1206-test.log 2>&1; then
+    echo "    SURVIVED"
+    survived=$((survived + 1))
+  else
+    echo "    KILLED: $(grep -c '✖ ' /tmp/mutate-1206-test.log) failing assertion(s)"
+    grep '✖ ' /tmp/mutate-1206-test.log | head -3
+    killed=$((killed + 1))
+  fi
+}
+
+m_no_verdict_ever_expires() {
+  py <<'PY'
+p = "src/data.ts"
+s = open(p).read()
+s = s.replace("  if (!CHANGE_IS_AN_EVENT.has(change.change_type)) return false;",
+              "  if (!CHANGE_IS_AN_EVENT.has(change.change_type)) return false;\n  return false;")
+open(p, "w").write(s)
+PY
+}
+
+m_a_condition_verdict_expires_too() {
+  py <<'PY'
+p = "src/data.ts"
+s = open(p).read()
+s = s.replace("  if (!CHANGE_IS_AN_EVENT.has(change.change_type)) return false;", "")
+open(p, "w").write(s)
+PY
+}
+
+m_the_window_is_open_ended() {
+  py <<'PY'
+p = "src/data.ts"
+s = open(p).read()
+s = s.replace("export const VERDICT_WINDOW_DAYS = 180;", "export const VERDICT_WINDOW_DAYS = 200000;")
+open(p, "w").write(s)
+PY
+}
+
+m_the_window_closes_immediately() {
+  py <<'PY'
+p = "src/data.ts"
+s = open(p).read()
+s = s.replace("export const VERDICT_WINDOW_DAYS = 180;", "export const VERDICT_WINDOW_DAYS = 0;")
+open(p, "w").write(s)
+PY
+}
+
+m_the_vendor_page_ignores_the_expiry() {
+  py <<'PY'
+p = "src/data.ts"
+s = open(p).read()
+s = s.replace("    const demotion = demotionInForce(c, nowMs);", "    const demotion = demotionForChange(c);")
+open(p, "w").write(s)
+PY
+}
+
+m_the_volatility_scale_ignores_the_expiry() {
+  py <<'PY'
+p = "src/data.ts"
+s = open(p).read()
+s = s.replace("  const riskScaleActs = vendorChanges.some(c => demotionInForce(c, nowMs) !== null);",
+              "  const riskScaleActs = vendorChanges.some(c => demotionForChange(c) !== null);")
+open(p, "w").write(s)
+PY
+}
+
+m_a_restriction_does_not_demote() {
+  py <<'PY'
+p = "src/data.ts"
+s = open(p).read()
+s = s.replace('  restriction: "caution",\n  pricing_model_change: "caution",',
+              '  restriction: null,\n  pricing_model_change: "caution",')
+open(p, "w").write(s)
+PY
+}
+
+m_a_pricing_model_change_does_not_demote() {
+  py <<'PY'
+p = "src/data.ts"
+s = open(p).read()
+s = s.replace('  restriction: "caution",\n  pricing_model_change: "caution",',
+              '  restriction: "caution",\n  pricing_model_change: null,')
+open(p, "w").write(s)
+PY
+}
+
+m_the_badge_keeps_its_own_list_of_removals() {
+  py <<'PY'
+p = "src/serve.ts"
+s = open(p).read()
+s = s.replace("""  if (assessment.level === "risky" && assessment.cause) {
+    return {
+      status: "removed",
+      label: assessment.cause.change_type === PRODUCT_DEPRECATED ? "deprecated" : "free tier removed",
+      verifiedDate: assessment.cause.date,
+    };
+  }""",
+"""  const removal = vendorChanges.find(c =>
+    c.change_type === "free_tier_removed" || c.change_type === "product_deprecated" || c.change_type === "open_source_killed"
+  );
+  if (removal) {
+    return { status: "removed", label: removal.change_type === "product_deprecated" ? "deprecated" : "free tier removed", verifiedDate: removal.date };
+  }""")
+open(p, "w").write(s)
+PY
+}
+
+m_the_badge_keeps_its_own_window_on_negatives() {
+  py <<'PY'
+p = "src/serve.ts"
+s = open(p).read()
+s = s.replace("""  if (assessment.level === "caution") {
+    return { status: "at-risk", label: "at risk", verifiedDate: latestVerified };
+  }""",
+"""  const hasRecentNegativeChange = vendorChanges.some(c =>
+    (c.change_type === "limits_reduced" || c.change_type === "pricing_restructured" || c.change_type === "pricing_model_change") &&
+    Math.floor((Date.now() - new Date(c.date).getTime()) / (1000 * 60 * 60 * 24)) <= 90
+  );
+  if (hasRecentNegativeChange) {
+    return { status: "at-risk", label: "at risk", verifiedDate: latestVerified };
+  }""")
+open(p, "w").write(s)
+PY
+}
+
+m_the_badge_reads_stable_for_a_cautioned_vendor() {
+  py <<'PY'
+p = "src/serve.ts"
+s = open(p).read()
+s = s.replace("""  if (assessment.level === "caution") {
+    return { status: "at-risk", label: "at risk", verifiedDate: latestVerified };
+  }""", "")
+open(p, "w").write(s)
+PY
+}
+
+m_a_stable_verdict_lists_the_types_it_rules_out() {
+  py <<'PY'
+p = "src/vendor-verdict.ts"
+s = open(p).read()
+s = s.replace("  return `We rate it stable. ${narrowingSentence(input.changes)}`;",
+              "  return `We rate it stable — we hold no free tier removal, limit reduction or pricing restructure for this vendor. ${narrowingSentence(input.changes)}`;")
+open(p, "w").write(s)
+PY
+}
+
+run_mutation "no verdict ever expires" m_no_verdict_ever_expires
+run_mutation "a condition verdict expires too" m_a_condition_verdict_expires_too
+run_mutation "the window never closes" m_the_window_is_open_ended
+run_mutation "the window closes immediately" m_the_window_closes_immediately
+run_mutation "the vendor page ignores the expiry" m_the_vendor_page_ignores_the_expiry
+run_mutation "the volatility scale ignores the expiry" m_the_volatility_scale_ignores_the_expiry
+run_mutation "a restriction does not demote" m_a_restriction_does_not_demote
+run_mutation "a pricing model change does not demote" m_a_pricing_model_change_does_not_demote
+run_mutation "the badge keeps its own list of removals" m_the_badge_keeps_its_own_list_of_removals
+run_mutation "the badge keeps its own window on negatives" m_the_badge_keeps_its_own_window_on_negatives
+run_mutation "the badge reads stable for a cautioned vendor" m_the_badge_reads_stable_for_a_cautioned_vendor
+run_mutation "a stable verdict lists the types it rules out" m_a_stable_verdict_lists_the_types_it_rules_out
+
+restore
+echo
+echo "killed: $killed   survived: $survived"
+[ "$survived" -eq 0 ]

--- a/src/data.ts
+++ b/src/data.ts
@@ -292,13 +292,13 @@ export const SEVERE_CHANGE_TYPES = new Set(["free_tier_removed", "open_source_ki
 const NEGATIVE_STABILITY_TYPES = NEGATIVE_CHANGE_TYPES;
 const POSITIVE_STABILITY_TYPES = POSITIVE_CHANGE_TYPES;
 
-export function classifyStability(vendorChanges: DealChange[]): StabilityClass {
+export function classifyStability(vendorChanges: DealChange[], nowMs: number = Date.now()): StabilityClass {
   if (vendorChanges.length === 0) return "stable";
 
   const hasVolatile = vendorChanges.some(isSevereChange);
   const negativeCount = vendorChanges.filter(c => NEGATIVE_STABILITY_TYPES.has(c.change_type)).length;
   const positiveCount = vendorChanges.filter(c => POSITIVE_STABILITY_TYPES.has(c.change_type)).length;
-  const riskScaleActs = vendorChanges.some(c => demotionForChange(c) !== null);
+  const riskScaleActs = vendorChanges.some(c => demotionInForce(c, nowMs) !== null);
 
   if (hasVolatile || (negativeCount >= 2 && riskScaleActs)) return "volatile";
 
@@ -624,6 +624,8 @@ export const RISK_DEMOTION: Record<DealChange["change_type"], "risky" | "caution
   open_source_killed: "risky",
   limits_reduced: "caution",
   pricing_restructured: "caution",
+  restriction: "caution",
+  pricing_model_change: "caution",
   limits_increased: null,
   new_free_tier: null,
   new_tier: null,
@@ -632,9 +634,45 @@ export const RISK_DEMOTION: Record<DealChange["change_type"], "risky" | "caution
   rebranded: null,
   record_corrected: null,
   product_deprecated: null,
-  restriction: null,
-  pricing_model_change: null,
 };
+
+export const VERDICT_WINDOW_DAYS = 180;
+
+export const CHANGE_IS_AN_EVENT = new Set<DealChange["change_type"]>([
+  "pricing_restructured",
+  "limits_reduced",
+  "pricing_model_change",
+]);
+
+export const CHANGE_IS_A_CONDITION = new Set<DealChange["change_type"]>([
+  "free_tier_removed",
+  "open_source_killed",
+  "restriction",
+  "product_deprecated",
+]);
+
+export function changeTypesThatCanDemote(): Set<DealChange["change_type"]> {
+  const types = Object.entries(RISK_DEMOTION)
+    .filter(([, level]) => level !== null)
+    .map(([type]) => type as DealChange["change_type"]);
+  return new Set([...types, PRODUCT_DEPRECATED as DealChange["change_type"]]);
+}
+
+export function verdictHasLapsed(
+  change: Pick<DealChange, "change_type" | "date">,
+  nowMs: number = Date.now(),
+): boolean {
+  if (!CHANGE_IS_AN_EVENT.has(change.change_type)) return false;
+  const windowOpens = new Date(nowMs - VERDICT_WINDOW_DAYS * 24 * 60 * 60 * 1000).toISOString().slice(0, 10);
+  return change.date < windowOpens;
+}
+
+export function demotionInForce(
+  change: Pick<DealChange, "change_type" | "vendor" | "summary" | "date">,
+  nowMs: number = Date.now(),
+): "risky" | "caution" | null {
+  return verdictHasLapsed(change, nowMs) ? null : demotionForChange(change);
+}
 
 const RISK_RANK: Record<"stable" | "caution" | "risky", number> = { stable: 0, caution: 1, risky: 2 };
 
@@ -648,7 +686,7 @@ export function vendorRiskAssessment(vendorChanges: DealChange[], nowMs: number 
 
   let best: { level: "caution" | "risky"; cause: DealChange } | null = null;
   for (const c of vendorChanges) {
-    const demotion = demotionForChange(c);
+    const demotion = demotionInForce(c, nowMs);
     if (!demotion) continue;
     const level = demotion === "risky" && c.date < twelveMonthsAgo ? "caution" : demotion;
     if (!best || RISK_RANK[level] > RISK_RANK[best.level] || (level === best.level && c.date > best.cause.date)) {
@@ -728,9 +766,9 @@ export function checkVendorRisk(
   } else if (riskLevel === "caution" && cause) {
     summary = `${offer.vendor} warrants caution — ${changeDateClause(cause)}: ${cause.summary} Monitor for further changes.${unreachableClause}`;
   } else if (withheldReason) {
-    summary = `We hold no free tier removal, limit reduction or pricing restructure on record for ${offer.vendor}. ${withheldLevelSentence(withheldReason, offer.vendor, unreachableSince)} Nothing we have read describes this offer. Treat that as a statement about our records, not as a stable pricing history.`;
+    summary = `${withheldLevelSentence(withheldReason, offer.vendor, unreachableSince)} Nothing we have read describes this offer. Treat that as a statement about our records, not as a stable pricing history.`;
   } else {
-    summary = `${offer.vendor} has a stable pricing history with no free tier removal, limit reduction or pricing restructure on record. Free tier verified for ${longevityDays} days.`;
+    summary = `${offer.vendor} has a stable pricing history. Free tier verified for ${longevityDays} days.`;
   }
 
   return {

--- a/src/serve.ts
+++ b/src/serve.ts
@@ -19,7 +19,7 @@ import { LINK_GRACE_DAYS } from "./link-health.js";
 import { levelWithheldReason, withheldLevelClause, withheldLevelSentence } from "./source-check.js";
 import { buildComparisonMap, comparisonSlug } from "./comparison-pairs.js";
 import { stabilityFaqAnswer, stabilityVerdictClause, type ComparisonSide, type StabilityRating } from "./comparison-verdict.js";
-import { publishedVendorLevel, vendorVerdictSentence, narrowingSentence, changeKindNoun, DEMOTING_KINDS_PHRASE, type VendorVerdictInput } from "./vendor-verdict.js";
+import { publishedVendorLevel, vendorVerdictSentence, narrowingSentence, changeKindNoun, type VendorVerdictInput } from "./vendor-verdict.js";
 import { growthLimitPhrases } from "./growth-limits.js";
 import { registerAgent, authenticateRequest, validateVestauthUrl, hashApiKey, updateAgentX402Address, getAgentById } from "./agents.js";
 import { attributeAuthenticatedRequest } from "./referral-attribution.js";
@@ -39,7 +39,7 @@ import { linkifyVerdictBlocks, overdueReport, pageCompiledClause, pageDataProven
 import { faqPageJsonLd, type FaqItem } from "./faq-provenance.js";
 import { SSE_KEEPALIVE_FRAME, keepaliveIntervalMs, sessionRecoveryBody } from "./mcp-stream.js";
 import { ASSISTANTS_API_SHUTDOWN } from "./assistants-shutdown.js";
-import { discontinuedOnOrBefore } from "./product-deprecation.js";
+import { discontinuedOnOrBefore, PRODUCT_DEPRECATED } from "./product-deprecation.js";
 import { rankOffers, rankForListing, rotateListing, utcDate, CRITERIA_PATH, DEMOTE_ONLY_POLICY, DISCLOSURE_RATIONALE, TIE_BREAK_ALGORITHM, GATE_TABLE, DEMERIT_TABLE, NOT_FREE_TIER_RULES, TIME_LIMITED_TIER_RULES, type TieBreak } from "./ranking.js";
 import type { RankedEntry, RankingResult } from "./ranking.js";
 import { verificationLedger, QUARANTINE_AFTER_FAILURES } from "./verification-state.js";
@@ -690,14 +690,14 @@ function getBadgeStatus(vendorSlug: string): { status: BadgeStatus; label: strin
   if (!vendorName) return { status: "unknown", label: "unknown", verifiedDate: null };
 
   const vendorChanges = dealChanges.filter(c => toSlug(c.vendor) === vendorSlug);
-  const hasRemoval = vendorChanges.some(c =>
-    c.change_type === "free_tier_removed" || c.change_type === "product_deprecated" || c.change_type === "open_source_killed"
-  );
-  if (hasRemoval) {
-    const removal = vendorChanges.find(c =>
-      c.change_type === "free_tier_removed" || c.change_type === "product_deprecated" || c.change_type === "open_source_killed"
-    )!;
-    return { status: "removed", label: removal.change_type === "product_deprecated" ? "deprecated" : "free tier removed", verifiedDate: removal.date };
+  const assessment = vendorRiskAssessment(vendorChanges);
+
+  if (assessment.level === "risky" && assessment.cause) {
+    return {
+      status: "removed",
+      label: assessment.cause.change_type === PRODUCT_DEPRECATED ? "deprecated" : "free tier removed",
+      verifiedDate: assessment.cause.date,
+    };
   }
 
   const vendorOffers = offers.filter(o => toSlug(o.vendor) === vendorSlug);
@@ -706,13 +706,11 @@ function getBadgeStatus(vendorSlug: string): { status: BadgeStatus; label: strin
   const latestVerified = vendorOffers.reduce((max, o) => o.verifiedDate > max ? o.verifiedDate : max, vendorOffers[0].verifiedDate);
   const daysSince = Math.floor((Date.now() - new Date(latestVerified).getTime()) / (1000 * 60 * 60 * 24));
 
-  const hasRecentNegativeChange = vendorChanges.some(c =>
-    (c.change_type === "limits_reduced" || c.change_type === "pricing_restructured" || c.change_type === "pricing_model_change") &&
-    Math.floor((Date.now() - new Date(c.date).getTime()) / (1000 * 60 * 60 * 24)) <= 90
-  );
-
-  if (hasRecentNegativeChange || daysSince > 30) {
-    return { status: "at-risk", label: hasRecentNegativeChange ? "at risk" : "stale", verifiedDate: latestVerified };
+  if (assessment.level === "caution") {
+    return { status: "at-risk", label: "at risk", verifiedDate: latestVerified };
+  }
+  if (daysSince > 30) {
+    return { status: "at-risk", label: "stale", verifiedDate: latestVerified };
   }
 
   return { status: "active", label: "active", verifiedDate: latestVerified };
@@ -4060,7 +4058,7 @@ ${allCompareLinks.join("\n")}
   const faqReliableAnswer = levelWithheld
     ? `We cannot say. ${withheldLevelSentence(levelWithheld, vendorName, unconfirmableSince)} Nothing we have read describes these terms, so we are not publishing a stability judgement for this vendor until that is fixed.`
     : riskLevel === "stable"
-    ? `${vendorName}'s free tier is considered stable: we hold no ${DEMOTING_KINDS_PHRASE} on record for this vendor.${vendorChanges.length > 0 ? ` ${narrowingSentence(vendorChanges)} See the pricing history below.` : ""}`
+    ? `${vendorName}'s free tier is considered stable.${vendorChanges.length > 0 ? ` ${narrowingSentence(vendorChanges)} See the pricing history below.` : ""}`
     : riskLevel === "caution"
     ? `${vendorName}'s free tier requires caution because of one specific recorded change${riskCause ? `, ${changeDateClause(riskCause)}: ${riskCause.summary}` : "."}`
     : `${vendorName}'s free tier is considered risky because of one specific recorded change${riskCause ? `, ${changeDateClause(riskCause)}: ${riskCause.summary}` : "."} Consider alternatives.`;
@@ -4074,7 +4072,7 @@ ${allCompareLinks.join("\n")}
       : `${vendorName}'s free tier is usable for prototyping and development, but we rate it ${riskLevel}${riskCause ? ` because of one recorded ${changeKindNoun(riskCause.change_type)}, ${changeDateClause(riskCause)}` : ""}. Consider alternatives with more stable pricing for critical services.`)
     : `${vendorName} does not offer a free tier for production use. Consider free alternatives in ${primary.category}.`;
   const faqChangedAnswer = vendorChanges.length > 0
-    ? `Yes, ${vendorName} has had ${vendorChanges.length} recorded pricing change${vendorChanges.length > 1 ? "s" : ""}. Most recently: ${vendorChanges[0].summary} (${changeDateLabel(vendorChanges[0])}).`
+    ? `${vendorName} has had ${vendorChanges.length} recorded pricing change${vendorChanges.length > 1 ? "s" : ""}. Most recently: ${vendorChanges[0].summary} (${changeDateLabel(vendorChanges[0])}).`
     : levelWithheld
     ? `We hold no recorded pricing changes for ${vendorName}, but ${withheldClause}, so that is a statement about our records rather than a positive signal.`
     : `No, ${vendorName} has had no recorded pricing changes. This is a positive stability signal.`;
@@ -4440,7 +4438,7 @@ ${renderAuditBlock(altRanking.tie_break)}
 
   const topStableAlts = enrichedAlts.filter(a => a.risk_level === "stable").slice(0, 5);
   const faqBestAltsAnswer = topStableAlts.length > 0
-    ? `The best free alternatives to ${vendorName} include ${topStableAlts.map(a => `${a.vendor} (${a.tier})`).join(", ")}. We hold no free tier removal, limit reduction or pricing restructure on record for any of them.`
+    ? `The best free alternatives to ${vendorName} include ${topStableAlts.map(a => `${a.vendor} (${a.tier})`).join(", ")}.`
     : `There are ${enrichedAlts.length} free alternatives to ${vendorName} available. ${enrichedAlts.slice(0, 3).map(a => a.vendor).join(", ")} are among the options.`;
   const faqFreeTierAnswer = altLevelWithheld
     ? `We cannot confirm that today. ${altWithheldSentence} Our stored record says ${vendorName} offers a free tier (${primary.tier}), but we have not confirmed those terms against the source we cite.`
@@ -4451,7 +4449,7 @@ ${renderAuditBlock(altRanking.tie_break)}
     : `${vendorName}'s free tier (${primary.tier}) is considered risky because of one specific recorded change${riskCause ? `, ${changeDateClause(riskCause)}: ${riskCause.summary}` : "."} Consider migrating to a more stable alternative.`;
   const faqCountAnswer = `There are ${enrichedAlts.length} free alternatives to ${vendorName} tracked on AgentDeals across the ${listedCategories.join(", ")} categor${listedCategories.length > 1 ? "ies" : "y"}.`;
   const faqChangesAnswer = vendorChanges.length > 0
-    ? `Yes, ${vendorName} has ${vendorChanges.length} recorded pricing change${vendorChanges.length !== 1 ? "s" : ""}. The most recent was ${changeDateClause(vendorChanges[0])}: ${vendorChanges[0].summary}`
+    ? `${vendorName} has ${vendorChanges.length} recorded pricing change${vendorChanges.length !== 1 ? "s" : ""}. The most recent was ${changeDateClause(vendorChanges[0])}: ${vendorChanges[0].summary}`
     : altLevelWithheld
     ? `We hold no recorded pricing changes for ${vendorName}, but ${altWithheldClause}, so that is a statement about our records rather than a positive signal.`
     : `No, ${vendorName} has no recorded pricing changes on AgentDeals. This indicates stable pricing.`;
@@ -19172,7 +19170,7 @@ ${mcpCtaCss()}
   </div>
 
   <h2 id="changes">6. Recent Deal Changes</h2>
-  <p class="section-intro">Both platforms have had significant free tier changes recently. From our deal change tracker:</p>
+  <p class="section-intro">From our deal change tracker:</p>
   <div style="display:grid;gap:.75rem;margin:1rem 0">
     ${supabasePause ? `<div class="diff-card" style="border-left-color:#d29922">
       <h3>Supabase — ${escHtmlServer(supabasePause.date)}</h3>
@@ -19494,7 +19492,7 @@ ${mcpCtaCss()}
   </div>
 
   <h2 id="changes">6. Recent Deal Changes</h2>
-  <p class="section-intro">Both platforms have restructured their pricing recently. From our deal change tracker:</p>
+  <p class="section-intro">From our deal change tracker:</p>
   <div style="display:grid;gap:.75rem;margin:1rem 0">
     ${vercelChange ? `<div class="diff-card" style="border-left-color:#d29922">
       <h3>Vercel — ${escHtmlServer(vercelChange.date)}</h3>
@@ -19813,7 +19811,7 @@ ${mcpCtaCss()}
   </div>
 
   <h2 id="changes">6. Recent Deal Changes</h2>
-  <p class="section-intro">Both platforms have restructured their pricing recently. From our deal change tracker:</p>
+  <p class="section-intro">From our deal change tracker:</p>
   <div style="display:grid;gap:.75rem;margin:1rem 0">
     ${neonChange ? `<div class="diff-card" style="border-left-color:#d29922">
       <h3>Neon — ${escHtmlServer(neonChange.date)}</h3>
@@ -20134,7 +20132,7 @@ ${mcpCtaCss()}
   </div>
 
   <h2 id="changes">6. Recent Deal Changes</h2>
-  <p class="section-intro">Both platforms have evolved their free tier positioning recently. From our deal change tracker:</p>
+  <p class="section-intro">From our deal change tracker:</p>
   <div style="display:grid;gap:.75rem;margin:1rem 0">
     ${railwayChange ? `<div class="diff-card" style="border-left-color:#d29922">
       <h3>Railway — ${escHtmlServer(railwayChange.date)}</h3>

--- a/src/vendor-verdict.ts
+++ b/src/vendor-verdict.ts
@@ -5,8 +5,6 @@ import { withheldLevelClause, type LevelWithheldReason } from "./source-check.js
 
 export type PublishedRiskLevel = "stable" | "caution" | "risky";
 
-export const DEMOTING_KINDS_PHRASE = "free tier removal, limit reduction or pricing restructure";
-
 export const CHANGE_KIND_NOUN: Record<DealChange["change_type"], string> = {
   free_tier_removed: "free tier removal",
   open_source_killed: "move away from open source",
@@ -102,5 +100,5 @@ export function vendorVerdictSentence(input: VendorVerdictInput): string {
   }
 
   if (input.changes.length === 0) return `It's stable — zero pricing changes recorded.`;
-  return `We rate it stable — we hold no ${DEMOTING_KINDS_PHRASE} for this vendor. ${narrowingSentence(input.changes)}`;
+  return `We rate it stable. ${narrowingSentence(input.changes)}`;
 }

--- a/test/audit-stack.test.ts
+++ b/test/audit-stack.test.ts
@@ -46,12 +46,19 @@ describe("auditStack logic", () => {
   });
 
   it("detects risk from deal changes", async () => {
-    const { auditStack } = await import("../dist/data.js");
-    const result = auditStack(["Vercel", "Supabase"]);
+    const { auditStack, loadOffers, loadDealChanges, vendorRiskLevel } = await import("../dist/data.js");
+    const changes = loadDealChanges();
+    const demoted = [...new Set(loadOffers().map(o => o.vendor))]
+      .filter(v => vendorRiskLevel(changes.filter(c => c.vendor.toLowerCase() === v.toLowerCase())) !== "stable")
+      .slice(0, 2);
+    assert.strictEqual(demoted.length, 2, "the index holds fewer than two vendors the risk scale demotes");
+    const result = auditStack(demoted);
     assert.ok(result.risks_found >= 2, `Should find at least 2 risks, got ${result.risks_found}`);
-    const vercel = result.services.find(s => s.vendor === "Vercel");
-    assert.ok(vercel);
-    assert.strictEqual(vercel.risk_level, "caution");
+    for (const vendor of demoted) {
+      const service = result.services.find(s => s.vendor === vendor);
+      assert.ok(service, `${vendor} is missing from the audit`);
+      assert.notStrictEqual(service.risk_level, "stable", `${vendor} audits as stable`);
+    }
   });
 
   it("includes recommendations for risky/caution vendors", async () => {

--- a/test/one-verdict-engine.test.ts
+++ b/test/one-verdict-engine.test.ts
@@ -1,0 +1,252 @@
+import { describe, it, before, after } from "node:test";
+import assert from "node:assert";
+import { spawn, type ChildProcess } from "node:child_process";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  CHANGE_DIRECTION,
+  CHANGE_IS_AN_EVENT,
+  CHANGE_IS_A_CONDITION,
+  RISK_DEMOTION,
+  SEVERE_TYPES_WITHOUT_FLAT_DEMOTION,
+  VERDICT_WINDOW_DAYS,
+  VOLATILE_TYPES,
+  changeTypesThatCanDemote,
+  demotionInForce,
+  loadDealChanges,
+  loadOffers,
+  vendorRiskAssessment,
+  verdictHasLapsed,
+} from "../dist/data.js";
+import { PRODUCT_DEPRECATED, deprecationEndsTheListedProduct } from "../dist/product-deprecation.js";
+import { vendorSlugMap } from "../dist/vendor-slug.js";
+import type { DealChange } from "../src/types.ts";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO = path.join(__dirname, "..");
+
+const DAY = 24 * 60 * 60 * 1000;
+const NOW = Date.parse("2026-06-15T00:00:00Z");
+
+function record(overrides: Partial<DealChange> = {}): DealChange {
+  return {
+    vendor: "V",
+    change_type: "pricing_restructured",
+    date: "2026-06-01",
+    summary: "s",
+    previous_state: "",
+    current_state: "",
+    impact: "medium",
+    source_url: "",
+    category: "c",
+    alternatives: [],
+    ...overrides,
+  } as DealChange;
+}
+
+const isoDaysBefore = (days: number) => new Date(NOW - days * DAY).toISOString().slice(0, 10);
+
+describe("#1206 one risk scale, and every change type sits on one side of it", () => {
+  it("classifies every change type the risk scale can act on as an event or a condition", () => {
+    const unclassified: string[] = [];
+    const both: string[] = [];
+    for (const changeType of changeTypesThatCanDemote()) {
+      const isEvent = CHANGE_IS_AN_EVENT.has(changeType);
+      const isCondition = CHANGE_IS_A_CONDITION.has(changeType);
+      if (!isEvent && !isCondition) unclassified.push(changeType);
+      if (isEvent && isCondition) both.push(changeType);
+    }
+    assert.deepStrictEqual(unclassified, [], "these demote a vendor and nothing says whether the verdict expires");
+    assert.deepStrictEqual(both, [], "these are classified as both an event and a condition");
+  });
+
+  it("keeps the types that skip the expiry check off the expiring side", () => {
+    const wrong = [...VOLATILE_TYPES].filter(t => CHANGE_IS_AN_EVENT.has(t as DealChange["change_type"]));
+    assert.deepStrictEqual(wrong, [], "these expire, and the volatility scale reads them without the expiry check");
+  });
+
+  it("acts on every change type it calls negative, apart from the one it judges per record", () => {
+    const ignored = Object.entries(CHANGE_DIRECTION)
+      .filter(([type, direction]) => direction === "negative" && RISK_DEMOTION[type as DealChange["change_type"]] === null)
+      .map(([type]) => type);
+    assert.deepStrictEqual(
+      ignored,
+      Object.keys(SEVERE_TYPES_WITHOUT_FLAT_DEMOTION),
+      "these point down and the risk scale does not act on them",
+    );
+  });
+
+  it("publishes no stable verdict over a record it calls negative and still holds in force", () => {
+    const held = new Map<string, DealChange[]>();
+    for (const c of loadDealChanges()) {
+      const key = c.vendor.toLowerCase();
+      if (!held.has(key)) held.set(key, []);
+      held.get(key)!.push(c);
+    }
+    const wrong: string[] = [];
+    let checked = 0;
+    for (const vendor of new Set(loadOffers().map(o => o.vendor))) {
+      const changes = held.get(vendor.toLowerCase()) ?? [];
+      const inForce = changes.filter(c =>
+        CHANGE_DIRECTION[c.change_type] === "negative" &&
+        !verdictHasLapsed(c) &&
+        !(c.change_type === PRODUCT_DEPRECATED && !deprecationEndsTheListedProduct(c)));
+      if (inForce.length === 0) continue;
+      checked++;
+      if (vendorRiskAssessment(changes).level === "stable") {
+        wrong.push(`${vendor} holds ${inForce.map(c => c.change_type).join(", ")} and reads stable`);
+      }
+    }
+    assert.ok(checked > 0, "no vendor holds a record that points down, so this asserts nothing");
+    assert.deepStrictEqual(wrong.slice(0, 20), [], `stable verdicts over a record that points down:\n${wrong.slice(0, 20).join("\n")}`);
+  });
+});
+
+describe("#1206 an event verdict expires, a condition verdict does not", () => {
+  it("drops an event verdict once the record falls outside the window", () => {
+    for (const changeType of CHANGE_IS_AN_EVENT) {
+      if (RISK_DEMOTION[changeType] === null) continue;
+      const inside = record({ change_type: changeType, date: isoDaysBefore(VERDICT_WINDOW_DAYS - 1) });
+      const outside = record({ change_type: changeType, date: isoDaysBefore(VERDICT_WINDOW_DAYS + 1) });
+      assert.strictEqual(verdictHasLapsed(inside, NOW), false, `${changeType} inside the window`);
+      assert.strictEqual(verdictHasLapsed(outside, NOW), true, `${changeType} outside the window`);
+      assert.strictEqual(vendorRiskAssessment([inside], NOW).level, RISK_DEMOTION[changeType], changeType);
+      assert.strictEqual(vendorRiskAssessment([outside], NOW).level, "stable", changeType);
+      assert.strictEqual(vendorRiskAssessment([outside], NOW).cause, null, changeType);
+    }
+  });
+
+  it("holds a condition verdict however old the record is", () => {
+    for (const changeType of CHANGE_IS_A_CONDITION) {
+      const ancient = record({ change_type: changeType, date: isoDaysBefore(VERDICT_WINDOW_DAYS * 10) });
+      assert.strictEqual(verdictHasLapsed(ancient, NOW), false, changeType);
+      assert.strictEqual(demotionInForce(ancient, NOW), demotionInForce(record({ change_type: changeType }), NOW), changeType);
+    }
+  });
+
+  it("keeps the newest record in force when an older one on the same vendor has expired", () => {
+    const expired = record({ change_type: "pricing_restructured", date: isoDaysBefore(VERDICT_WINDOW_DAYS + 30) });
+    const live = record({ change_type: "limits_reduced", date: isoDaysBefore(10) });
+    const assessment = vendorRiskAssessment([expired, live], NOW);
+    assert.strictEqual(assessment.level, "caution");
+    assert.strictEqual(assessment.cause?.change_type, "limits_reduced");
+  });
+});
+
+describe("#1206 the badge and the vendor page read the same scale", () => {
+  let serverPort = 0;
+  let proc: ChildProcess | null = null;
+
+  before(async () => {
+    const started = await new Promise<{ child: ChildProcess; port: number }>((resolve, reject) => {
+      const child = spawn("node", [path.join(REPO, "dist", "serve.js")], {
+        stdio: ["pipe", "pipe", "pipe"],
+        env: { ...process.env, PORT: "0", BASE_URL: "http://localhost" },
+      });
+      const timeout = setTimeout(() => { child.kill(); reject(new Error("Server startup timeout")); }, 30000);
+      child.stderr!.on("data", (data: Buffer) => {
+        const m = data.toString().match(/running on http:\/\/localhost:(\d+)/);
+        if (m) { clearTimeout(timeout); resolve({ child, port: parseInt(m[1], 10) }); }
+      });
+      child.on("error", (err) => { clearTimeout(timeout); reject(err); });
+    });
+    proc = started.child;
+    serverPort = started.port;
+  });
+
+  after(() => { if (proc) proc.kill(); });
+
+  const LEVEL_FOR_BADGE: Record<string, string> = {
+    "deprecated": "risky",
+    "free tier removed": "risky",
+    "at risk": "caution",
+    "stale": "stable",
+    "active": "stable",
+  };
+
+  const badgeLabel = (svg: string): string | null => {
+    const title = svg.match(/<title>([\s\S]*?)<\/title>/)?.[1] ?? "";
+    const right = title.split(": ").slice(1).join(": ");
+    if (!right) return null;
+    return right.split(" · ")[0].trim();
+  };
+
+  it("gives the badge the level the risk scale reached, for every vendor", async () => {
+    const changes = loadDealChanges();
+    const held = new Map<string, DealChange[]>();
+    for (const c of changes) {
+      const key = c.vendor.toLowerCase();
+      if (!held.has(key)) held.set(key, []);
+      held.get(key)!.push(c);
+    }
+    const slugs = [...vendorSlugMap.entries()];
+    const disagreeing: string[] = [];
+    let queue = 0;
+    const worker = async () => {
+      while (queue < slugs.length) {
+        const [slug, vendor] = slugs[queue++];
+        const res = await fetch(`http://localhost:${serverPort}/badge/${slug}.svg`);
+        if (res.status !== 200) { disagreeing.push(`/badge/${slug}.svg returned ${res.status}`); continue; }
+        const label = badgeLabel(await res.text());
+        if (label === null) { disagreeing.push(`/badge/${slug}.svg carries no readable label`); continue; }
+        if (label === "not found") continue;
+        const level = LEVEL_FOR_BADGE[label];
+        if (level === undefined) { disagreeing.push(`/badge/${slug}.svg reads "${label}"`); continue; }
+        const expected = vendorRiskAssessment(held.get(vendor.toLowerCase()) ?? []).level;
+        if (level !== expected) disagreeing.push(`/badge/${slug}.svg reads ${level}, the risk scale reads ${expected}`);
+      }
+    };
+    await Promise.all(Array.from({ length: 12 }, worker));
+    assert.deepStrictEqual(disagreeing.slice(0, 20), [], `badges disagreeing with the risk scale:\n${disagreeing.slice(0, 20).join("\n")}`);
+  });
+
+  it("calls a badge deprecated only where the record ends the product we list", async () => {
+    const changes = loadDealChanges();
+    const wrong: string[] = [];
+    let checked = 0;
+    for (const [slug, vendor] of vendorSlugMap) {
+      const deprecations = changes.filter(c =>
+        c.vendor.toLowerCase() === vendor.toLowerCase() && c.change_type === "product_deprecated");
+      if (deprecations.length === 0) continue;
+      if (deprecations.some(c => deprecationEndsTheListedProduct(c))) continue;
+      checked++;
+      const svg = await (await fetch(`http://localhost:${serverPort}/badge/${slug}.svg`)).text();
+      if (badgeLabel(svg) === "deprecated") wrong.push(`/badge/${slug}.svg`);
+    }
+    assert.ok(checked > 0, "no vendor retired one of its other products, so this asserts nothing");
+    assert.deepStrictEqual(wrong, [], "these badges call a vendor deprecated over a record that ends another product");
+  });
+
+  it("gives the vendor risk endpoint the level the risk scale reached", async () => {
+    const changes = loadDealChanges();
+    const vendors = [...new Set(loadOffers().map(o => o.vendor))];
+    const demoted = vendors.filter(v =>
+      vendorRiskAssessment(changes.filter(c => c.vendor.toLowerCase() === v.toLowerCase())).level !== "stable");
+    const sample = [...demoted.slice(0, 15), ...vendors.filter(v => !demoted.includes(v)).slice(0, 15)];
+    assert.ok(demoted.length > 0, "the index holds no vendor the risk scale demotes");
+    const wrong: string[] = [];
+    for (const vendor of sample) {
+      const res = await fetch(`http://localhost:${serverPort}/api/vendor-risk/${encodeURIComponent(vendor)}`);
+      if (res.status !== 200) continue;
+      const body = await res.json() as { risk_level: string | null };
+      if (body.risk_level === null) continue;
+      const expected = vendorRiskAssessment(changes.filter(c => c.vendor.toLowerCase() === vendor.toLowerCase())).level;
+      if (body.risk_level !== expected) wrong.push(`${vendor}: endpoint ${body.risk_level}, risk scale ${expected}`);
+    }
+    assert.deepStrictEqual(wrong, [], "the vendor risk endpoint disagrees with the risk scale");
+  });
+
+  it("names no change type in a stable verdict, so the sentence survives a change to the risk map", async () => {
+    const changes = loadDealChanges();
+    const stable = [...vendorSlugMap.entries()].filter(([, vendor]) =>
+      vendorRiskAssessment(changes.filter(c => c.vendor.toLowerCase() === vendor.toLowerCase())).level === "stable");
+    assert.ok(stable.length > 0, "no vendor reads stable, so this asserts nothing");
+    const enumerating = /no free tier removal, limit reduction or pricing restructure/;
+    const wrong: string[] = [];
+    for (const [slug] of stable.slice(0, 40)) {
+      const html = await (await fetch(`http://localhost:${serverPort}/vendor/${slug}`)).text();
+      if (enumerating.test(html)) wrong.push(`/vendor/${slug}`);
+    }
+    assert.deepStrictEqual(wrong, [], "these pages list the change types a stable verdict rules out");
+  });
+});

--- a/test/risk-badge.test.ts
+++ b/test/risk-badge.test.ts
@@ -241,28 +241,22 @@ describe("#1147 — a shutdown of the product we list demotes the vendor", () =>
 
   it("a vendor that retired one of its other services keeps the level its own record earned", async () => {
     const { enrichOffers, loadOffers, loadDealChanges } = await import("../dist/data.js");
+    const { deprecationEndsTheListedProduct } = await import("../dist/product-deprecation.js");
     const enriched = enrichOffers(loadOffers());
     const held = changesByVendor(loadDealChanges() as Change[]);
-    const expected: Record<string, string> = {
-      "Google Gemini API": "stable",
-      "MiniMax": "stable",
-      "AWS": "caution",
-      "Firebase": "caution",
-    };
-    for (const [vendor, level] of Object.entries(expected)) {
-      const offer = enriched.find((o: { vendor: string }) => o.vendor === vendor);
-      assert.ok(offer, `${vendor} has no offer to rate`);
-      assert.ok(
-        (held.get(vendor.toLowerCase()) ?? []).some((c) => c.change_type === "product_deprecated"),
-        `${vendor} holds no deprecation record, so it is not controlling anything`,
-      );
-      assert.strictEqual(offer.risk_level, level, `${vendor} should stay ${level}`);
+    let controlled = 0;
+    for (const offer of enriched) {
+      const deprecations = (held.get(offer.vendor.toLowerCase()) ?? [])
+        .filter((c) => c.change_type === "product_deprecated");
+      if (deprecations.length === 0 || deprecations.some((c) => deprecationEndsTheListedProduct(c))) continue;
+      controlled++;
       assert.notStrictEqual(
         offer.risk_cause?.change_type,
         "product_deprecated",
-        `${vendor} was demoted for retiring one of its other products`,
+        `${offer.vendor} was demoted for retiring one of its other products`,
       );
     }
+    assert.ok(controlled > 0, "no vendor retired one of its other services, so this asserts nothing");
   });
 
   it("no offer in the index carries a stable level beside a volatile stability", async () => {
@@ -274,14 +268,17 @@ describe("#1147 — a shutdown of the product we list demotes the vendor", () =>
   });
 
   it("keeps a vendor whose narrowings the risk scale does not act on off both ends of the scale", async () => {
-    const { classifyStability } = await import("../dist/data.js");
-    const restriction = (date: string) => ({
-      vendor: "V", change_type: "restriction", date, summary: "Free tier narrowed",
+    const { classifyStability, demotionForChange, NEGATIVE_CHANGE_TYPES } = await import("../dist/data.js");
+    const retiredElsewhere = (date: string) => ({
+      vendor: "V", change_type: "product_deprecated", date, summary: "Widget Pro is discontinued.",
       previous_state: "", current_state: "", impact: "medium" as const, source_url: "", category: "c", alternatives: [],
     });
-    const three = [restriction("2026-01-01"), restriction("2026-04-01"), restriction("2026-06-01")];
+    const one = retiredElsewhere("2026-01-01");
+    assert.ok(NEGATIVE_CHANGE_TYPES.has(one.change_type), "the fixture stopped being a narrowing");
+    assert.strictEqual(demotionForChange(one), null, "the risk scale now acts on the fixture");
+    const three = [retiredElsewhere("2026-01-01"), retiredElsewhere("2026-04-01"), retiredElsewhere("2026-06-01")];
     assert.strictEqual(classifyStability(three), "watch");
-    assert.strictEqual(classifyStability([restriction("2026-01-01")]), "watch");
+    assert.strictEqual(classifyStability([one]), "watch");
   });
 
   it("never calls a vendor stable on a scale where it holds a narrowing", async () => {

--- a/test/vendor-risk.test.ts
+++ b/test/vendor-risk.test.ts
@@ -21,21 +21,39 @@ describe("checkVendorRisk logic", () => {
     assert.ok(result.result.category.length > 0);
   });
 
-  it("returns caution for vendor with pricing_restructured", async () => {
-    const { checkVendorRisk } = await import("../dist/data.js");
-    const result = checkVendorRisk("Vercel");
-    assert.ok(!("error" in result), "Vercel should be found");
-    assert.strictEqual(result.result.risk_level, "caution", "Vercel should be caution due to pricing_restructured");
-    assert.ok(result.result.changes.length > 0, "Should have recorded changes");
-    assert.ok(result.result.changes.some(c => c.change_type === "pricing_restructured"), "Should have pricing_restructured change");
+  it("gives every demoting change type the level the risk map assigns it", async () => {
+    const { vendorRiskAssessment, RISK_DEMOTION, VERDICT_WINDOW_DAYS } = await import("../dist/data.js");
+    const insideTheWindow = new Date(Date.now() - (VERDICT_WINDOW_DAYS - 1) * 24 * 60 * 60 * 1000)
+      .toISOString().slice(0, 10);
+    const demoting = Object.entries(RISK_DEMOTION).filter(([, level]) => level !== null);
+    assert.ok(demoting.length > 0, "no change type demotes, so this asserts nothing");
+    for (const [changeType, level] of demoting) {
+      const record = {
+        vendor: "V", change_type: changeType, date: insideTheWindow, summary: "s",
+        previous_state: "", current_state: "", impact: "medium", source_url: "", category: "c", alternatives: [],
+      };
+      const assessment = vendorRiskAssessment([record]);
+      assert.strictEqual(assessment.level, level, `${changeType} inside the window`);
+      assert.strictEqual(assessment.cause?.change_type, changeType, `${changeType} names its own record`);
+    }
   });
 
-  it("returns caution for vendor with limits_reduced", async () => {
-    const { checkVendorRisk } = await import("../dist/data.js");
-    const result = checkVendorRisk("Supabase");
-    assert.ok(!("error" in result), "Supabase should be found");
-    assert.strictEqual(result.result.risk_level, "caution", "Supabase should be caution due to limits_reduced");
-    assert.ok(result.result.changes.length > 0, "Should have recorded changes");
+  it("reports the level the risk engine reached for every vendor it demotes", async () => {
+    const { checkVendorRisk, loadOffers, loadDealChanges, vendorRiskAssessment } = await import("../dist/data.js");
+    const changes = loadDealChanges();
+    const forVendor = (v: string) => changes.filter(c => c.vendor.toLowerCase() === v.toLowerCase());
+    const demoted = [...new Set(loadOffers().map(o => o.vendor))]
+      .filter(v => vendorRiskAssessment(forVendor(v)).level !== "stable");
+    assert.ok(demoted.length > 0, "the index holds no vendor the risk scale demotes");
+    let published = 0;
+    for (const vendor of demoted) {
+      const result = checkVendorRisk(vendor);
+      if ("error" in result || result.result.risk_level === null) continue;
+      published++;
+      assert.strictEqual(result.result.risk_level, vendorRiskAssessment(forVendor(vendor)).level, vendor);
+      assert.ok(result.result.changes.length > 0, `${vendor} carries a level with no record behind it`);
+    }
+    assert.ok(published > 0, "no demoted vendor published a level");
   });
 
   it("returns error with suggestions for unknown vendor", async () => {

--- a/test/vendor-verdict.test.ts
+++ b/test/vendor-verdict.test.ts
@@ -5,7 +5,6 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 import {
   CHANGE_KIND_NOUN,
-  DEMOTING_KINDS_PHRASE,
   narrowingSentence,
   publishedVendorLevel,
   vendorVerdictSentence,
@@ -101,7 +100,7 @@ describe("vendor verdict — a stable rating reports direction, not volume", () 
   it("says the one record it holds did not narrow the terms", () => {
     const c = change({ change_type: "limits_increased" });
     const sentence = vendorVerdictSentence(input({ changes: [c] }));
-    assert.ok(sentence.includes(`we hold no ${DEMOTING_KINDS_PHRASE} for this vendor`));
+    assert.ok(sentence.startsWith("We rate it stable."));
     assert.ok(sentence.endsWith("The one change we have recorded did not narrow the terms."));
   });
 
@@ -443,8 +442,9 @@ describe("vendor verdict — as rendered", () => {
 
   it("counts one narrowing on the route that carried a repair as a second", async () => {
     const digitalocean = verdictParagraph(await get("/vendor/digitalocean"));
-    assert.match(digitalocean, /One recorded restriction narrowed the terms/);
+    assert.match(digitalocean, /one recorded restriction/);
     assert.doesNotMatch(digitalocean, /2 recorded changes narrowed the terms/);
+    assert.doesNotMatch(digitalocean, /corrects our own earlier entry/);
 
     const neo4j = verdictParagraph(await get("/vendor/neo4j-auradb"));
     assert.match(neo4j, /The one record we hold corrects our own earlier entry rather than reporting a change the vendor made\./);
@@ -461,7 +461,8 @@ describe("vendor verdict — as rendered", () => {
       const verdict = verdictParagraph(html);
       assert.doesNotMatch(verdict, STABILITY_SCALE_WORDS, `/vendor/${slug} verdict`);
       assert.ok(verdict.includes(row.sentence), `/vendor/${slug} verdict does not render "${row.sentence}"`);
-      assert.match(row.sentence, /narrowed the terms/, `/vendor/${slug} still names the records that pointed down`);
+      assert.notStrictEqual(row.expected, "stable", `/vendor/${slug} still reads stable over a record that points down`);
+      assert.match(row.sentence, /one recorded /, `/vendor/${slug} still names no record behind its level`);
     }
   });
 


### PR DESCRIPTION
Refs #1206

`/vendor/docker-hub` asked *"what changed recently?"* and answered with a change dated **2024-12-10**. `vendorRiskAssessment` had no expiry, so a `caution` verdict once earned was permanent.

## What changed

**An event verdict expires; a condition verdict does not.** `pricing_restructured`, `limits_reduced` and `pricing_model_change` are things a vendor did on a date — once absorbed, the new terms are simply the terms, and `description` already carries them. `free_tier_removed`, `open_source_killed`, `restriction` and `product_deprecated` are states the vendor entered and has not left. The window is `VERDICT_WINDOW_DAYS`, one exported constant, 180 days, so the swap to the re-read rule when #1058 lands is one edit.

**One engine, three renderers.** `getBadgeStatus` called `vendorRiskAssessment` for nothing and kept its own list of change types; it now delegates, and a badge deprecation goes through `deprecationEndsTheListedProduct`. `classifyStability` read the risk scale without the expiry — it reads `demotionInForce` now.

**`RISK_DEMOTION` gives `restriction` and `pricing_model_change` caution.** `CHANGE_DIRECTION` already called both negative; the two maps disagreeing is what let 13 vendors publish `stable` over a record that points down.

**The stable summary no longer enumerates change types.** `"no free tier removal, limit reduction or pricing restructure on record"` asserted the absence of the type that was missing from the map. It goes stale the moment the map gains a key.

## Acceptance criteria

| AC | | |
|---|---|---|
| 1 | one engine | `getBadgeStatus` and `classifyStability` both call it; no second list of change types in `serve.ts` |
| 2 | `restriction`, `pricing_model_change` → caution | done |
| 3 | no present-tense verdict outside the window | the record stays on the page with its date, and the alternatives push does not fire |
| 4 | 15 stop publishing a present-tense caution | **14 of 15 — see below on Netlify** |
| 5 | 6 condition verdicts unchanged | sendgrid, storj, amazon-ses, x-twitter, minio, brave-search-api all unchanged |
| 6 | 101 inside 90 days unchanged | 104 measured, 0 changed |
| 7 | badge deprecation via `deprecationEndsTheListedProduct` | `/badge/google-gemini-api.svg` `deprecated` → `at risk`; `/badge/minimax.svg` `deprecated` → `stale` |
| 8 | no `recently` about a change outside the window | four compare intros and two FAQ answers; **two question strings left, see below** |
| 9 | badge verdict and page verdict agree for every vendor | `test/one-verdict-engine.test.ts` |
| 10 (comment) | the stable summary does not enumerate types | done |

### AC-4 and AC-2 conflict on Netlify

Netlify keeps `caution`, and it has to. It holds a `pricing_model_change` dated 2026-04-17 (136 days — inside the window) and a `restriction` dated 2026-03-01, which is a condition and never expires. Both demote only because of AC-2, so the AC-4 list was measured before AC-2 was applied. Its `pricing_restructured` from 2025-09-04 does expire, as intended — the cause moved, not the level.

**Xero Developer API** is the other edge: its `pricing_model_change` is dated 2026-03-02, 182 days, two days outside the window, so it stays `stable`. It never published a caution, so nothing on the site moves.

### AC-8: two question strings left

`serve.ts:4093` still asks `What changed in <vendor>'s pricing recently?` and `serve.ts:4463` `Has <vendor> changed their pricing recently?`. I removed the recency **assertions** — the four `/compare/` intros, and the `Yes,` that answered those two questions. The answers now state the count and the date and claim nothing about recency.

Rewriting the two questions is new copy. Give me exact wording and I will apply it.

## What moves

28 of 1,572 vendors change verdict: 14 `caution` → `stable` (Vercel, Render, Fly.io, AWS, Supabase, Neon, Firebase, Sentry, Cloudflare Durable Objects, Stripe, Docker Hub, Atlassian, PythonAnywhere, Amazon SP-API), 13 `stable` → `caution` (DigitalOcean, Xata, Google Gemini API, Postman, Apollo GraphOS, Mockerito, StreamBackdrops, Tencent RTC, Squash Labs, Pingmeter.com, PandaStack, Shadcn Studio, Sendinblue), and Netlify keeps `caution` on a newer cause.

Badge labels move where the verdict does. A `free_tier_removed` older than 12 months already decayed `risky` → `caution` on the page; the badge now follows it, so those read `at risk` rather than `free tier removed`. The 12-month decay itself is untouched, per the issue.

## Verification

- **2,851 tests**, `tsc` clean, `check-mutation-targets` 617 of 617
- **12 of 12 mutations killed** — `scripts/mutate-1206.sh`
- **3,919-path sweep against `main`**: 2,516 differ, 0 non-200. Every vendor page holding a record differs; the 602 record-free pages that differ carry exactly the removed enumeration in the FAQ and the schema.org block
- **Real MCP** `initialize` → `notifications/initialized` → `tools/call compare_vendors` over the HTTP transport: Docker Hub reports `stable` with the 2024 record still listed
- `GET /api/vendor-risk/Postman` `stable` → `caution`; `GET /api/vendor-risk/Docker Hub` `caution` → `stable`
- Screenshot of `/vendor/docker-hub`: green `stable` badge, verdict reads *"We rate it stable. One recorded pricing restructure narrowed the terms, on 2024-12-10."*, the pricing-change card still on the page

🤖 Generated with [Claude Code](https://claude.com/claude-code)