### PR TITLE
Stop the vendor and alternatives FAQ asking when a pricing change happened (#1206)

### DIFF
--- a/src/serve.ts
+++ b/src/serve.ts
@@ -4088,7 +4088,7 @@ ${allCompareLinks.join("\n")}
     { q: `What is ${vendorName}'s free tier?`, a: faqTierAnswer },
     { q: `Is ${vendorName}'s free tier reliable?`, a: faqReliableAnswer },
     { q: `Is ${vendorName}'s free tier good for production?`, a: faqProductionAnswer },
-    { q: `What changed in ${vendorName}'s pricing recently?`, a: faqChangedAnswer },
+    { q: `What changed in ${vendorName}'s pricing?`, a: faqChangedAnswer },
     ...(alternatives.length > 0 ? [{ q: `What are the best free alternatives to ${vendorName}?`, a: faqAlternativesAnswer }] : []),
     { q: `When will I outgrow ${vendorName}'s free tier?`, a: faqOutgrowAnswer },
     { q: `What category is ${vendorName} in?`, a: faqCategoryAnswer },
@@ -4458,7 +4458,7 @@ ${renderAuditBlock(altRanking.tie_break)}
     { q: `What are the best free alternatives to ${vendorName}?`, a: faqBestAltsAnswer },
     { q: `Is ${vendorName}'s free tier still available?`, a: faqFreeTierAnswer },
     { q: `How many free alternatives to ${vendorName} exist?`, a: faqCountAnswer },
-    { q: `Has ${vendorName} changed their pricing recently?`, a: faqChangesAnswer },
+    { q: `Has ${vendorName} changed their pricing?`, a: faqChangesAnswer },
   ];
 
   const altFaqJsonLd = faqPageJsonLd("/alternative-to/" + slug, altFaqItems);

--- a/test/one-verdict-engine.test.ts
+++ b/test/one-verdict-engine.test.ts
@@ -249,4 +249,63 @@ describe("#1206 the badge and the vendor page read the same scale", () => {
     }
     assert.deepStrictEqual(wrong, [], "these pages list the change types a stable verdict rules out");
   });
+
+  const RECENCY = /recently/i;
+  const STATES_A_DATE = /\d{4}-\d{2}-\d{2}/;
+
+  interface FaqItem { path: string; question: string; answer: string }
+
+  const faqItemsIn = (pagePath: string, html: string): FaqItem[] => {
+    const items: FaqItem[] = [];
+    for (const block of html.matchAll(/<script type="application\/ld\+json">([\s\S]*?)<\/script>/g)) {
+      let parsed: unknown;
+      try { parsed = JSON.parse(block[1]); } catch { continue; }
+      for (const entry of (Array.isArray(parsed) ? parsed : [parsed]) as Array<Record<string, any>>) {
+        if (!entry || entry["@type"] !== "FAQPage" || !Array.isArray(entry.mainEntity)) continue;
+        for (const q of entry.mainEntity) {
+          const answer = q?.acceptedAnswer?.text;
+          if (typeof q?.name === "string" && typeof answer === "string") {
+            items.push({ path: pagePath, question: q.name, answer });
+          }
+        }
+      }
+    }
+    return items;
+  };
+
+  const faqSample = async (): Promise<FaqItem[]> => {
+    const changes = loadDealChanges();
+    const withChanges = new Set(changes.map(c => c.vendor.toLowerCase()));
+    const slugs = [...vendorSlugMap.entries()];
+    const recorded = slugs.filter(([, v]) => withChanges.has(v.toLowerCase())).slice(0, 30);
+    const silent = slugs.filter(([, v]) => !withChanges.has(v.toLowerCase())).slice(0, 30);
+    const items: FaqItem[] = [];
+    for (const [slug] of [...recorded, ...silent]) {
+      for (const prefix of ["/vendor/", "/alternative-to/"]) {
+        const res = await fetch(`http://localhost:${serverPort}${prefix}${slug}`);
+        if (res.status !== 200) continue;
+        items.push(...faqItemsIn(prefix + slug, await res.text()));
+      }
+    }
+    return items;
+  };
+
+  it("asks no question about a vendor's pricing history that presumes it is recent", async () => {
+    const items = await faqSample();
+    const fromVendorPages = items.filter(i => i.path.startsWith("/vendor/"));
+    const fromAlternativePages = items.filter(i => i.path.startsWith("/alternative-to/"));
+    assert.ok(fromVendorPages.length > 0, "no vendor page published a structured FAQ, so this asserts nothing");
+    assert.ok(fromAlternativePages.length > 0, "no alternatives page published a structured FAQ, so this asserts nothing");
+    const presuming = items.filter(i => RECENCY.test(i.question)).map(i => `${i.path}: ${i.question}`);
+    assert.deepStrictEqual([...new Set(presuming)].slice(0, 10), [],
+      "a question carries no date, so it cannot say when the change it asks about happened");
+  });
+
+  it("dates every answer that calls a change recent", async () => {
+    const undated = (await faqSample())
+      .filter(i => RECENCY.test(i.answer) && !STATES_A_DATE.test(i.answer))
+      .map(i => `${i.path}: ${i.answer.slice(0, 120)}`);
+    assert.deepStrictEqual([...new Set(undated)].slice(0, 10), [],
+      "these answers call a change recent without saying when it happened");
+  });
 });


### PR DESCRIPTION
Refs #1206 — AC-8, the last two sites. Exact strings taken from the PM's comment of 2026-08-31.

## What changed

`src/serve.ts:4091` and `src/serve.ts:4461`, one word each:

- `What changed in ${vendorName}'s pricing recently?` → `What changed in ${vendorName}'s pricing?`
- `Has ${vendorName} changed their pricing recently?` → `Has ${vendorName} changed their pricing?`

Both strings reach the schema.org `FAQPage` block and the visible `<details>` summary. The answers under them already state the count and the date, so nothing else moves.

## Guard

Two assertions in `test/one-verdict-engine.test.ts`, scoped to the FAQ item lists on `/vendor/:slug` and `/alternative-to/:slug`, over a 60-vendor sample split between vendors that hold a change record and vendors that hold none:

1. No question may contain `recently`. A question carries no date, so it can never qualify the claim.
2. Any answer that contains `recently` must state a `YYYY-MM-DD`. This is what keeps `Most recently: <summary> (<date>)` legal and an undated version not.

Scoped to those two routes, as asked — `recently` elsewhere on the site is often a real computed claim.

## Verification

- 2,842 tests pass.
- 2 mutations, 2 killed: restoring `recently` to the alternatives question fails assertion 1; dropping `changeDateLabel` from `faqChangedAnswer` fails assertion 2.
- `tsc --noEmit` clean, `npm run validate` clean (1,580 offers, 438 changes), `test/no-private-context.test.ts` 9/9.
- Full-path sweep against a `main` build: 3,919 paths, **3,145 move** — all 1,572 `/vendor/` pages, all 1,572 `/alternative-to/` pages, and `/api/stats` (non-deterministic). No other page changes a byte, and no path 404s or 500s.
- Line-level diff on `/vendor/vercel` and `/alternative-to/sendgrid`: exactly two lines each, the JSON-LD question and the `<summary>`.
- Real MCP `initialize` → `tools/call` against `dist/serve.js`.