### PR TITLE
Offer a substitute only where a record says what kind of product it is (#1209)

### DIFF
--- a/src/data.ts
+++ b/src/data.ts
@@ -7,7 +7,7 @@ import { rankForListing, type TieBreak } from "./ranking.js";
 import { unreachableNoticeForUrl, resetLinkHealthCache } from "./link-health.js";
 import { quarantineSummary, resetVerificationStateCache, type QuarantineSummary } from "./verification-state.js";
 import { cannotVouchForLevel, levelWithheldReason, withheldLevelSentence } from "./source-check.js";
-import { filterAlternatives } from "./product-role.js";
+import { substitutesFor } from "./product-role.js";
 import { DATE_SOURCES, isEventDated, changeDateClause, isoWeekWindow, changesInWindow, discoveryBatchNote, firstReadHeading, type DateWindow } from "./change-dates.js";
 import { PRODUCT_DEPRECATED, deprecationEndsTheListedProduct } from "./product-deprecation.js";
 
@@ -87,7 +87,7 @@ export function getOfferDetails(
 
   if (match) {
     const relatedRanking = rankForListing(
-      filterAlternatives(offers.filter((o) => o.category === match.category && o.vendor !== match.vendor), match),
+      substitutesFor(offers, match),
       { queryKey: `related:${match.category}:${match.vendor}`, changes: loadDealChanges() },
     );
     const sameCategoryOffers = relatedRanking.entries.slice(0, 5).map((e) => e.offer);
@@ -735,7 +735,7 @@ export function checkVendorRisk(
   );
 
   const alternativesRanking = rankForListing(
-    filterAlternatives(offers.filter((o) => o.category === offer.category && o.vendor !== offer.vendor), offer),
+    substitutesFor(offers, offer),
     { queryKey: `vendor-risk-alternatives:${offer.vendor}`, changes: allChanges },
   );
   const alternatives = alternativesRanking.entries.slice(0, 3).map((e) => ({

--- a/src/product-role.ts
+++ b/src/product-role.ts
@@ -63,7 +63,7 @@ export const SUBTYPE_MEMBERSHIP_GROUPS: Record<string, SubtypeMembershipGroup[]>
 };
 
 export const SUBTYPE_MEMBERSHIP_RULE =
-  "Two offers in the same category are alternatives when their subtype sets share at least one member, or when both carry a subtype from one of the membership groups below. A record we have not classified carries no subtype gate at all, in either direction.";
+  "Two offers in the same category are alternatives when their subtype sets share at least one member, or when both carry a subtype from one of the membership groups below.";
 
 export const SUBTYPE_MEMBERSHIP_GROUP_SCOPE =
   "A group answers whether a product could substitute at all. Which one is the better answer is ordering, and ordering is a separate, seeded, published concern that reads none of this.";
@@ -198,6 +198,40 @@ export function partitionAlternativesAcross<T extends RoleCarrier>(candidates: T
 
 export function partitionAlternatives<T extends RoleCarrier>(candidates: T[], subject: RoleCarrier): AlternativesPartition<T> {
   return partitionAlternativesAcross(candidates, [subject]);
+}
+
+export interface SubstitutesPartition<T extends RoleCarrier> extends AlternativesPartition<T> {
+  unclassified: T[];
+}
+
+export function classifiedTaxonomies(subjects: RoleCarrier[]): Set<string> {
+  return new Set(subtypesAcross(subjects).filter(p => p.subtypes.size > 0).map(p => p.taxonomy));
+}
+
+export function subtypeGateBinds(subjects: RoleCarrier[], category: string): boolean {
+  return classifiedTaxonomies(subjects).has(category);
+}
+
+export function partitionSubstitutes<T extends RoleCarrier & { category: string }>(
+  candidates: T[],
+  subjects: RoleCarrier[],
+  options: MembershipOptions<T> = {},
+): SubstitutesPartition<T> {
+  const binds = classifiedTaxonomies(subjects);
+  const admissible: T[] = [];
+  const unclassified: T[] = [];
+  for (const candidate of candidates) {
+    if (options.subtypeExempt?.(candidate) || binds.has(candidate.category)) admissible.push(candidate);
+    else unclassified.push(candidate);
+  }
+  const partition = partitionAlternativesAcross(admissible, subjects, options);
+  return { kept: partition.kept, removed: partition.removed, unclassified };
+}
+
+export type SubstituteCandidate = RoleCarrier & { vendor: string; category: string };
+
+export function substitutesFor<T extends SubstituteCandidate>(all: T[], subject: SubstituteCandidate): T[] {
+  return partitionSubstitutes(all.filter(o => o.category === subject.category && o.vendor !== subject.vendor), [subject]).kept;
 }
 
 export function filterAlternatives<T extends RoleCarrier>(candidates: T[], subject: RoleCarrier): T[] {

--- a/src/serve.ts
+++ b/src/serve.ts
@@ -4203,7 +4203,7 @@ ${mcpCtaCss()}
 ${riskCauseLine}
 ${linkUnreachableLine}
 ${productRoleLine}${productSubtypesLine}
-  <p class="page-meta">Limits, pricing history, and ${alternatives.length} alternatives.${verifiedSentence} Last updated ${escHtmlServer(lastUpdated)}.</p>
+  <p class="page-meta">Limits, pricing history${alternatives.length > 0 ? `, and ${alternatives.length} alternatives` : ""}.${verifiedSentence} Last updated ${escHtmlServer(lastUpdated)}.</p>
 ${quickVerdictHtml}
 ${categoryContextHtml}
 ${changeNoticeHtml}

--- a/src/serve.ts
+++ b/src/serve.ts
@@ -43,7 +43,7 @@ import { discontinuedOnOrBefore, PRODUCT_DEPRECATED } from "./product-deprecatio
 import { rankOffers, rankForListing, rotateListing, utcDate, CRITERIA_PATH, DEMOTE_ONLY_POLICY, DISCLOSURE_RATIONALE, TIE_BREAK_ALGORITHM, GATE_TABLE, DEMERIT_TABLE, NOT_FREE_TIER_RULES, TIME_LIMITED_TIER_RULES, type TieBreak } from "./ranking.js";
 import type { RankedEntry, RankingResult } from "./ranking.js";
 import { verificationLedger, QUARANTINE_AFTER_FAILURES } from "./verification-state.js";
-import { partitionAlternatives, partitionAlternativesAcross, productRoleSentence, MEMBERSHIP_GATE_RULES, MEMBERSHIP_GATE_ORDER, MEMBERSHIP_GATE_SYMMETRY, MEMBERSHIP_GATE_SCOPE, MEMBERSHIP_GATE_CORRECTIONS, SUBTYPE_TAXONOMIES, SUBTYPE_MEMBERSHIP_RULE, SUBTYPE_MEMBERSHIP_GROUP_SCOPE, membershipGroupsFor, subtypeDefinition } from "./product-role.js";
+import { partitionAlternatives, partitionSubstitutes, productRoleSentence, MEMBERSHIP_GATE_RULES, MEMBERSHIP_GATE_ORDER, MEMBERSHIP_GATE_SYMMETRY, MEMBERSHIP_GATE_SCOPE, MEMBERSHIP_GATE_CORRECTIONS, SUBTYPE_TAXONOMIES, SUBTYPE_MEMBERSHIP_RULE, SUBTYPE_MEMBERSHIP_GROUP_SCOPE, membershipGroupsFor, subtypeDefinition } from "./product-role.js";
 import { resolveCuratedAlternatives, curatedAlternativesFor, addCuratedToPool } from "./curated-alternatives.js";
 import type { Agent, ChangeDateSource, DealChange, RiskCause, LinkUnreachable, Offer } from "./types.js";
 import { changeDateLabel, changeDateClause, changeDatePublished, changeEventStartDate, capListSections, latestEventDate, offerExpiryAfter, feedEntryUpdated, undatedGroupHeading, firstReadHeading, discoveryBatchNote, isoWeekOf, DISCOVERED_DATE_PREFIX, UNDATED_GROUP_NOTE } from "./change-dates.js";
@@ -1849,7 +1849,7 @@ ${entries.map(e => `<tr><td><code>${escHtmlServer(e.subtype)}</code></td><td>${e
       const done = inTaxonomy.filter(o => o.product_subtypes).length;
       return `${done} of ${inTaxonomy.length} in ${taxonomy}`;
     });
-    return `We have classified ${parts.join(", ")}; the other ${offers.length - offers.filter(o => o.product_subtypes).length} records in the index carry no subtype and are gated by none.`;
+    return `We have classified ${parts.join(", ")}; the other ${offers.length - offers.filter(o => o.product_subtypes).length} records in the index carry no subtype.`;
   })();
 
   const jsonLd = {
@@ -3701,9 +3701,9 @@ function buildVendorPage(slug: string): string | null {
     return `\n  <p class="product-subtypes-line" style="margin:.4rem 0 .6rem;font-size:.9rem;color:var(--text-muted)"><strong>Subtypes in ${escHtmlServer(classified.taxonomy)}:</strong> ${body}${read} <a href="${CRITERIA_PATH}#subtypes">How we use this</a>.</p>`;
   })();
 
-  const alternativesMembership = partitionAlternatives(
+  const alternativesMembership = partitionSubstitutes(
     offers.filter(o => o.category === primary.category && o.vendor !== vendorName),
-    primary,
+    [primary],
   );
   const alternativesRanking = rankForListing(
     alternativesMembership.kept,
@@ -3735,8 +3735,8 @@ function buildVendorPage(slug: string): string | null {
     ? ` Discontinued ${discontinuedOn}.`
     : enriched.link_unreachable ? "" : ` Verified ${verifiedMonth}.`;
   const metaDesc = hasFree
-    ? `${vendorName} free tier includes ${descLimits}.${verifiedSentence} Compare with ${alternatives.length} alternatives in ${primary.category}.`
-    : `${vendorName} pricing details and ${alternatives.length} free alternatives in ${primary.category}.${verifiedSentence}`;
+    ? `${vendorName} free tier includes ${descLimits}.${verifiedSentence}${alternatives.length > 0 ? ` Compare with ${alternatives.length} alternatives in ${primary.category}.` : ""}`
+    : `${vendorName} pricing details${alternatives.length > 0 ? ` and ${alternatives.length} free alternatives in ${primary.category}` : ""}.${verifiedSentence}`;
 
   const keyLimit = primary.description.slice(0, 120).replace(/\.\s.*$/, "");
   const unconfirmableSince = linkUnreachable
@@ -4308,7 +4308,7 @@ function buildAlternativesPage(slug: string): string | null {
   }
   const curated = resolveCuratedAlternatives(vendorName, allChanges, offers);
   const curatedAltNames = new Set(curated.matched.map(o => o.vendor));
-  const altMembership = partitionAlternativesAcross(addCuratedToPool(dedupedAlts, curated.matched), vendorOffers, {
+  const altMembership = partitionSubstitutes(addCuratedToPool(dedupedAlts, curated.matched), vendorOffers, {
     subtypeExempt: candidate => curatedAltNames.has(candidate.vendor),
   });
   const altRanking = rankForListing(enrichOffers(altMembership.kept), {
@@ -4327,7 +4327,10 @@ function buildAlternativesPage(slug: string): string | null {
   const currentYear = new Date().getFullYear();
   const title = `Best ${vendorName} Alternatives with Free Tiers (${currentYear}) | AgentDeals`;
   const topAlts = enrichedAlts.slice(0, 3).map(a => a.vendor).join(", ");
-  const metaDesc = `Compare ${enrichedAlts.length} free alternatives to ${vendorName} for ${vendorCategories[0]}. ${topAlts ? `Side-by-side free tier limits for ${topAlts}.` : "Find stable, verified free-tier tools."}`;
+  const noAlternativesSentence = `No alternatives found for ${vendorName}.`;
+  const metaDesc = enrichedAlts.length > 0
+    ? `Compare ${enrichedAlts.length} free alternatives to ${vendorName} for ${vendorCategories[0]}. ${topAlts ? `Side-by-side free tier limits for ${topAlts}.` : "Find stable, verified free-tier tools."}`
+    : noAlternativesSentence;
 
   const situationHtml = (() => {
     const parts: string[] = [];
@@ -4409,7 +4412,7 @@ ${curatedAlts.map(a => altCard(a, true)).join("\n")}
 ${enrichedAlts.map(a => altCard(a, false)).join("\n")}
     </div>
 ${renderAuditBlock(altRanking.tie_break)}
-  </div>` : `<div class="section"><p class="no-changes">No alternatives found for ${escHtmlServer(vendorName)}.</p></div>`;
+  </div>` : `<div class="section"><p class="no-changes">${escHtmlServer(noAlternativesSentence)}</p></div>`;
 
   const trendsHtml = vendorCategories.map(c =>
     `<a href="/trends/${toSlug(c)}" class="action-pill">&#x2191; ${escHtmlServer(c)} Pricing Trends</a>`
@@ -4455,7 +4458,7 @@ ${renderAuditBlock(altRanking.tie_break)}
     : `No, ${vendorName} has no recorded pricing changes on AgentDeals. This indicates stable pricing.`;
 
   const altFaqItems = [
-    { q: `What are the best free alternatives to ${vendorName}?`, a: faqBestAltsAnswer },
+    ...(enrichedAlts.length > 0 ? [{ q: `What are the best free alternatives to ${vendorName}?`, a: faqBestAltsAnswer }] : []),
     { q: `Is ${vendorName}'s free tier still available?`, a: faqFreeTierAnswer },
     { q: `How many free alternatives to ${vendorName} exist?`, a: faqCountAnswer },
     { q: `Has ${vendorName} changed their pricing?`, a: faqChangesAnswer },
@@ -4487,8 +4490,7 @@ ${renderAuditBlock(altRanking.tie_break)}
 ${OG_IMAGE_META}${GOOGLE_VERIFICATION_META}<link rel="icon" type="image/png" href="/favicon.png">
 <link rel="alternate" type="application/atom+xml" title="AgentDeals — Weekly Pricing Digest" href="/feed.xml">
 <link rel="preconnect" href="https://fonts.googleapis.com"><link rel="preconnect" href="https://fonts.gstatic.com" crossorigin><link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
-<script type="application/ld+json">${JSON.stringify(jsonLd)}</script>
-<script type="application/ld+json">${JSON.stringify(altFaqJsonLd)}</script>
+${enrichedAlts.length > 0 ? `<script type="application/ld+json">${JSON.stringify(jsonLd)}</script>\n` : ""}<script type="application/ld+json">${JSON.stringify(altFaqJsonLd)}</script>
 ${buildBreadcrumbJsonLd([{ name: "Home", url: BASE_URL + "/" }, { name: "Alternatives", url: BASE_URL + "/alternatives" }, { name: vendorName + " Alternatives", url: BASE_URL + "/alternative-to/" + slug }])}
 <style>
 *{margin:0;padding:0;box-sizing:border-box}
@@ -4558,7 +4560,7 @@ ${mcpCtaCss()}
   ${buildGlobalNav("alternatives")}
   <div class="breadcrumb"><a href="/">AgentDeals</a> &rsaquo; <a href="/alternative-to">Alternatives</a> &rsaquo; ${escHtmlServer(vendorName)}</div>
   <h1>Best ${escHtmlServer(vendorName)} Alternatives with Free Tiers (${currentYear})</h1>
-  <p class="page-meta">${enrichedAlts.length} free alternative${enrichedAlts.length !== 1 ? "s" : ""} in ${vendorCategories.map(c => escHtmlServer(c)).join(", ")}. Sorted by pricing stability.</p>
+  <p class="page-meta">${enrichedAlts.length > 0 ? `${enrichedAlts.length} free alternative${enrichedAlts.length !== 1 ? "s" : ""} in ${vendorCategories.map(c => escHtmlServer(c)).join(", ")}. Sorted by pricing stability.` : escHtmlServer(noAlternativesSentence)}</p>
 
   <div class="situation-box">
     <h2>Current ${escHtmlServer(vendorName)} Situation</h2>

--- a/src/server-remote.ts
+++ b/src/server-remote.ts
@@ -17,8 +17,8 @@ import {
 import { getGuideList, getGuideBySlug } from "./guides.js";
 import { registerMcpAppsResources, TOOL_UI_META } from "./mcp-apps.js";
 import { MCP_INSTRUCTIONS } from "./mcp-instructions.js";
-import { filterAlternatives } from "./product-role.js";
-import type { ProductRole } from "./types.js";
+import { substitutesFor } from "./product-role.js";
+import type { ProductRole, ProductSubtypes } from "./types.js";
 
 function mcpError(msg: string) {
   return {
@@ -619,17 +619,14 @@ Suggested monitoring cadence: run this check weekly to catch pricing changes ear
       mimeType: "text/plain",
     },
     async (_uri, { slug }) => {
-      const data = (await fetchOffers({ limit: 2000 })) as { offers: Array<{ vendor: string; category: string; tier: string; description: string; url: string; verifiedDate: string; tags: string[]; eligibility?: { type: string; conditions: string[] }; expires_date?: string; product_role?: ProductRole }>; total: number };
+      const data = (await fetchOffers({ limit: 2000 })) as { offers: Array<{ vendor: string; category: string; tier: string; description: string; url: string; verifiedDate: string; tags: string[]; eligibility?: { type: string; conditions: string[] }; expires_date?: string; product_role?: ProductRole; product_subtypes?: ProductSubtypes }>; total: number };
       const match = data.offers.find(o => toSlug(o.vendor) === slug);
       if (!match) {
         return { contents: [{ uri: `agentdeals://vendor/${slug}`, text: `No vendor found matching "${slug}".`, mimeType: "text/plain" }] };
       }
 
       const changesData = (await fetchDealChanges({ vendor: match.vendor, since: "2020-01-01" })) as { changes: Array<{ date: string; change_type: string; summary: string; previous_state: string; current_state: string }> };
-      const alternatives = filterAlternatives(
-        data.offers.filter(o => o.category === match.category && o.vendor !== match.vendor),
-        match,
-      ).slice(0, 5);
+      const alternatives = substitutesFor(data.offers, match).slice(0, 5);
 
       let text = `# ${match.vendor}\n\n`;
       text += `**Category:** ${match.category}\n`;

--- a/src/server.ts
+++ b/src/server.ts
@@ -18,7 +18,7 @@ import { getStackRecommendation } from "./stacks.js";
 import { estimateCosts } from "./costs.js";
 import { getGuideList, getGuideBySlug } from "./guides.js";
 import type { Offer, EnrichedOffer, DealChange } from "./types.js";
-import { filterAlternatives } from "./product-role.js";
+import { substitutesFor } from "./product-role.js";
 import { registerMcpAppsResources, TOOL_UI_META } from "./mcp-apps.js";
 import { MCP_INSTRUCTIONS } from "./mcp-instructions.js";
 import { MCP_SIGNAL_FOOTER } from "./signal-copy.js";
@@ -803,10 +803,7 @@ Suggested monitoring cadence: run this check weekly to catch pricing changes ear
       }
       const changes = loadDealChanges().filter(c => c.vendor.toLowerCase() === match.vendor.toLowerCase());
       const stability = classifyStability(changes);
-      const alternatives = filterAlternatives(
-        offers.filter(o => o.category === match.category && o.vendor !== match.vendor),
-        match,
-      ).slice(0, 5);
+      const alternatives = substitutesFor(offers, match).slice(0, 5);
 
       let text = `# ${match.vendor}\n\n`;
       text += `**Category:** ${match.category}\n`;

--- a/test/alternatives-membership.test.ts
+++ b/test/alternatives-membership.test.ts
@@ -205,8 +205,15 @@ describe("#1032 every page in an affected category, not only the one in the issu
     gatedByCategory.set(o.category, [...(gatedByCategory.get(o.category) ?? []), o]);
   }
 
+  const bindsIn = (category: string) =>
+    offers.some((o) => o.category === category && (o.product_subtypes?.labels.length ?? 0) > 0);
+
   it("has categories to sweep, so the assertions below have subjects", () => {
     assert.ok(gatedByCategory.size > 0, "no category carries a gated record, so the sweep below checks nothing");
+    assert.ok(
+      [...gatedByCategory.keys()].some(bindsIn),
+      "no category with a gated record carries a taxonomy, so the grid sweep below asserts only absence",
+    );
   });
 
   for (const [category, gatedHere] of gatedByCategory) {
@@ -226,6 +233,10 @@ describe("#1032 every page in an affected category, not only the one in the issu
           if (grid.includes(gated.vendor)) offenders.push(`${gated.vendor} on /vendor/${slugOf(subject.vendor)}`);
         }
       }
+      if (!bindsIn(category)) {
+        assert.strictEqual(gridsChecked, 0, `${category} carries no subtype taxonomy, so no page in it may offer a category grid`);
+        return;
+      }
       assert.ok(gridsChecked > 5, `the sweep must actually read grids, read ${gridsChecked}`);
       assert.deepStrictEqual(offenders, [], `these offers cannot replace the vendor whose page lists them: ${offenders.join("; ")}`);
     });
@@ -234,6 +245,10 @@ describe("#1032 every page in an affected category, not only the one in the issu
       const subject = offers.find((o) => o.category === category && !gatedHere.some((g) => g.vendor === o.vendor))!;
       const { body } = await get(`/vendor/${slugOf(subject.vendor)}`);
       const notice = body.match(/<p class="alt-excluded"[\s\S]*?<\/p>/);
+      if (!bindsIn(category)) {
+        assert.strictEqual(notice, null, `${category} offers no category grid, so it has nothing to name a removal from`);
+        return;
+      }
       assert.ok(notice, `/vendor/${slugOf(subject.vendor)} removed offers without naming them`);
       for (const gated of gatedHere) {
         assert.ok(notice[0].includes(gated.vendor), `${gated.vendor} must be named on /vendor/${slugOf(subject.vendor)}`);

--- a/test/curated-alternatives.test.ts
+++ b/test/curated-alternatives.test.ts
@@ -427,10 +427,12 @@ describe("curated alternatives on the published pages", () => {
   });
 
   it("leaves the category heading on the vendor page describing the category list", async () => {
-    const res = await get("/vendor/postman");
-    assert.ok(res.body.includes("<h2>Alternatives in Testing</h2>"));
-    const categoryList = res.body.slice(res.body.indexOf("<h2>Alternatives in Testing</h2>"));
-    for (const vendor of POSTMAN_CURATED) {
+    const heading = "<h2>Alternatives in Databases</h2>";
+    const res = await get("/vendor/firebase");
+    assert.ok(res.body.includes(heading), "the subject must render a category list for the assertion to mean anything");
+    const categoryList = res.body.slice(res.body.indexOf(heading));
+    for (const vendor of ["Cloudflare R2", "Backblaze B2"]) {
+      assert.ok(res.body.includes(`>${vendor}<`), `${vendor} must be curated onto the page for this to test anything`);
       assert.ok(!categoryList.includes(`>${vendor}<`), `${vendor} is inside the category list`);
     }
   });

--- a/test/ranked-surfaces.test.ts
+++ b/test/ranked-surfaces.test.ts
@@ -72,14 +72,21 @@ describe("/vendor/:slug alternatives", () => {
 });
 
 describe("/alternative-to/:slug", () => {
-  it("names the recorded fact behind every demotion", async () => {
-    const { status, text } = await get("/alternative-to/openai");
-    assert.strictEqual(status, 200);
-    assert.match(text, /<strong>&minus;3 free_tier_withdrawn<\/strong> Recorded [a-z ]+ on \d{4}-\d{2}-\d{2}/, "a withdrawn free tier must name the change and its date");
-    assert.match(text, /<strong>&minus;2 time_limited_offer<\/strong> Tier &quot;[^&]+&quot; is a credit grant/, "a credit grant must say so");
-    assert.match(text, /<strong>&minus;1 stale_verification<\/strong>[^<]*not a change by the vendor/, "our own verification gap must be labelled as ours");
-    assert.match(text, /How we rank/);
-  });
+  const DEMOTION_EVIDENCE: Array<{ path: string; pattern: RegExp; why: string }> = [
+    { path: "/alternative-to/openai", pattern: /<strong>&minus;3 free_tier_withdrawn<\/strong> Recorded [a-z ]+ on \d{4}-\d{2}-\d{2}/, why: "a withdrawn free tier must name the change and its date" },
+    { path: "/alternative-to/openai", pattern: /<strong>&minus;2 time_limited_offer<\/strong> Tier &quot;[^&]+&quot; is a credit grant/, why: "a credit grant must say so" },
+    { path: "/alternative-to/vercel", pattern: /<strong>&minus;1 stale_verification<\/strong>[^<]*not a change by the vendor/, why: "our own verification gap must be labelled as ours" },
+  ];
+
+  for (const { path, pattern, why } of DEMOTION_EVIDENCE) {
+    it(`names the recorded fact behind every demotion on ${path}`, async () => {
+      const { status, text } = await get(path);
+      assert.strictEqual(status, 200);
+      assert.match(text, /All Free Alternatives \(\d+\)/, `${path} must rank a list for the assertion to mean anything`);
+      assert.match(text, pattern, why);
+      assert.match(text, /How we rank/);
+    });
+  }
 
   it("no longer claims to be sorted by stability", async () => {
     const { text } = await get("/alternative-to/vercel");
@@ -103,12 +110,13 @@ describe("/alternative-to/:slug", () => {
     assert.notDeepStrictEqual(vendors, [...vendors].sort((a, b) => a.localeCompare(b)), "alternatives are still alphabetical");
   });
 
-  it("does not empty out a page whose category peers are all eligibility-gated", async () => {
+  it("offers no substitute from a category we hold no product taxonomy for", async () => {
     const { status, text } = await get("/alternative-to/brex");
     assert.strictEqual(status, 200);
     const shown = (text.match(/class="alt-vendor-name"/g) ?? []).length;
-    assert.ok(shown > 0, "a gated category must still list its peers, labelled");
-    assert.match(text, /eligibility_restricted/, "the gate must be stated on the entries it applies to");
+    assert.strictEqual(shown, 0, "Startup Perks carries no subtype taxonomy, so no record in it is offered as a substitute");
+    assert.doesNotMatch(text, /All Free Alternatives \(/, "a page with no substitutes must not head a list of them");
+    assert.doesNotMatch(text, /"@type":"ItemList"/, "an empty set must not ship as structured data");
   });
 });
 
@@ -218,8 +226,8 @@ const RANKED_SURFACES: Array<{
   jsonSeed?: (body: any) => unknown;
 }> = [
   { queryKeyPrefix: "best-of", publishedAt: "/best/free-databases", seedIn: "html" },
-  { queryKeyPrefix: "alternatives", publishedAt: "/vendor/doppler", seedIn: "html" },
-  { queryKeyPrefix: "alternative-to", publishedAt: "/alternative-to/doppler", seedIn: "html" },
+  { queryKeyPrefix: "alternatives", publishedAt: "/vendor/vercel", seedIn: "html" },
+  { queryKeyPrefix: "alternative-to", publishedAt: "/alternative-to/vercel", seedIn: "html" },
   { queryKeyPrefix: "curated-alternatives", publishedAt: "/vendor/postman", seedIn: "html" },
   { queryKeyPrefix: "related", publishedAt: "/api/details/doppler", seedIn: "json", jsonSeed: (b) => b.offer?.tie_break?.seed },
   { queryKeyPrefix: "vendor-risk-alternatives", publishedAt: "/api/vendor-risk/doppler", seedIn: "json", jsonSeed: (b) => b.tie_break?.seed },

--- a/test/source-check-pages.test.ts
+++ b/test/source-check-pages.test.ts
@@ -17,6 +17,11 @@ const SOURCED_FROM_A_MARKETPLACE = {
   url: "https://dealmarket.example/offers",
   tags: ["databases"],
   verifiedDate: "2026-08-11",
+  product_subtypes: {
+    taxonomy: "Databases",
+    labels: [{ subtype: "relational", source_url: "https://dealmarket.example/offers", source_quote: "managed Postgres" }],
+    reviewed: "2026-08-28",
+  },
   source_check: {
     checked: "2026-08-28",
     outcome: "does_not_name_vendor",

--- a/test/substitute-evidence.test.ts
+++ b/test/substitute-evidence.test.ts
@@ -185,6 +185,16 @@ describe("a page with no evidence of a product class", () => {
     );
   });
 
+  it("counts no list on the vendor page either", async () => {
+    const { status, body } = await get("/vendor/datadog");
+    assert.strictEqual(status, 200);
+    const subhead = body.match(/<p class="page-meta">([\s\S]*?)<\/p>/)?.[1] ?? "";
+    assert.ok(subhead.length > 0, "the vendor page must carry a subhead for this to test anything");
+    assert.doesNotMatch(subhead, /\b0 alternatives\b/, "the subhead counts a list the page does not publish");
+    const metaDesc = body.match(/<meta name="description" content="([^"]*)"/)?.[1] ?? "";
+    assert.doesNotMatch(metaDesc, /\b0 (free )?alternatives\b/);
+  });
+
   it("names none of them through the vendor page or the API either", async () => {
     const vendor = await get("/vendor/sendgrid");
     assert.strictEqual(vendor.status, 200);

--- a/test/substitute-evidence.test.ts
+++ b/test/substitute-evidence.test.ts
@@ -1,0 +1,213 @@
+import { describe, it, before, after } from "node:test";
+import assert from "node:assert";
+import { spawn, type ChildProcess } from "node:child_process";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { partitionSubstitutes, subtypeGateBinds, substitutesFor } from "../dist/product-role.js";
+import type { Offer } from "../src/types.ts";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO = path.join(__dirname, "..");
+
+const offers: Offer[] = JSON.parse(readFileSync(path.join(REPO, "data", "index.json"), "utf-8")).offers;
+
+const CLASSIFIED_CATEGORIES = ["Databases", "Cloud Hosting"];
+const SENDGRID_WRONG_CLASS = ["Bench", "Remote for Startups", "Esri Startup Program"];
+const SENDGRID_CURATED = ["Postmark", "Resend", "Amazon SES"];
+
+function offerFixture(vendor: string, category: string, subtypes?: string[]): Offer {
+  return {
+    vendor,
+    category,
+    description: `${vendor} description`,
+    tier: "Free",
+    url: `https://${vendor.toLowerCase()}.example/pricing`,
+    tags: [],
+    verifiedDate: "2026-08-01",
+    ...(subtypes
+      ? {
+          product_subtypes: {
+            taxonomy: category,
+            labels: subtypes.map(subtype => ({ subtype, source_url: "https://x.example", source_quote: "q" })),
+            reviewed: "2026-08-01",
+          },
+        }
+      : {}),
+  } as Offer;
+}
+
+describe("a category is not a product class", () => {
+  it("offers nothing from a category the subject carries no subtype for", () => {
+    const subject = offerFixture("Subject", "Email");
+    const peer = offerFixture("Peer", "Email");
+    const partition = partitionSubstitutes([peer], [subject]);
+    assert.deepStrictEqual(partition.kept, []);
+    assert.deepStrictEqual(partition.unclassified.map(o => o.vendor), ["Peer"]);
+  });
+
+  it("keeps the gated pool where the subject carries a subtype", () => {
+    const subject = offerFixture("Subject", "Databases", ["relational"]);
+    const sameClass = offerFixture("SameClass", "Databases", ["relational"]);
+    const otherClass = offerFixture("OtherClass", "Databases", ["graph"]);
+    const partition = partitionSubstitutes([sameClass, otherClass], [subject]);
+    assert.deepStrictEqual(partition.kept.map(o => o.vendor), ["SameClass"]);
+    assert.deepStrictEqual(partition.removed.map(r => r.gate), ["subtype_mismatch"]);
+    assert.deepStrictEqual(partition.unclassified, []);
+  });
+
+  it("offers nothing to a record we classified as none of its category's subtypes", () => {
+    const subject = offerFixture("Subject", "Databases", []);
+    const peer = offerFixture("Peer", "Databases", ["relational"]);
+    assert.strictEqual(subtypeGateBinds([subject], "Databases"), false);
+    assert.deepStrictEqual(partitionSubstitutes([peer], [subject]).kept, []);
+  });
+
+  it("lets a name written down for this vendor through an unclassified category", () => {
+    const subject = offerFixture("Subject", "Email");
+    const curated = offerFixture("Curated", "Email");
+    const peer = offerFixture("Peer", "Email");
+    const partition = partitionSubstitutes([curated, peer], [subject], {
+      subtypeExempt: candidate => candidate.vendor === "Curated",
+    });
+    assert.deepStrictEqual(partition.kept.map(o => o.vendor), ["Curated"]);
+    assert.deepStrictEqual(partition.unclassified.map(o => o.vendor), ["Peer"]);
+  });
+
+  it("still applies the product-role gates to a name written down for this vendor", () => {
+    const subject = offerFixture("Subject", "Databases", ["relational"]);
+    const emulator = { ...offerFixture("Emulator", "Databases"), product_role: { deployment_model: "local_dev_only", is_addon: false, source_url: "https://x.example", source_quote: "q", reviewed: "2026-08-01" } } as Offer;
+    const partition = partitionSubstitutes([emulator], [subject], { subtypeExempt: () => true });
+    assert.deepStrictEqual(partition.kept, []);
+    assert.deepStrictEqual(partition.removed.map(r => r.gate), ["local_dev_only"]);
+  });
+
+  it("holds a taxonomy for the two categories the published controls rest on", () => {
+    for (const category of CLASSIFIED_CATEGORIES) {
+      const classified = offers.filter(o => o.category === category && (o.product_subtypes?.labels.length ?? 0) > 0);
+      assert.ok(classified.length > 0, `${category} must carry a taxonomy for the controls below to be controls`);
+    }
+  });
+
+  it("reaches every same-category consumer through one rule", () => {
+    const sendgrid = offers.find(o => o.vendor === "SendGrid")!;
+    assert.ok(sendgrid, "SendGrid must be in the index");
+    assert.deepStrictEqual(substitutesFor(offers, sendgrid), []);
+  });
+});
+
+let serverPort = 0;
+let proc: ChildProcess | null = null;
+
+function startServer(): Promise<ChildProcess> {
+  return new Promise((resolve, reject) => {
+    const child = spawn("node", [path.join(REPO, "dist", "serve.js")], {
+      stdio: ["pipe", "pipe", "pipe"],
+      env: { ...process.env, PORT: "0", BASE_URL: "http://localhost" },
+    });
+    const timeout = setTimeout(() => { child.kill(); reject(new Error("Server startup timeout")); }, 20000);
+    child.stderr!.on("data", (data: Buffer) => {
+      const m = data.toString().match(/running on http:\/\/localhost:(\d+)/);
+      if (m) { serverPort = parseInt(m[1], 10); clearTimeout(timeout); resolve(child); }
+    });
+    child.on("error", (err) => { clearTimeout(timeout); reject(err); });
+  });
+}
+
+const get = async (p: string) => {
+  const res = await fetch(`http://localhost:${serverPort}${p}`);
+  return { status: res.status, body: await res.text() };
+};
+
+function jsonLdBlocks(body: string): Array<Record<string, unknown>> {
+  return [...body.matchAll(/<script type="application\/ld\+json">([\s\S]*?)<\/script>/g)]
+    .map(m => { try { return JSON.parse(m[1]); } catch { return null; } })
+    .filter((b): b is Record<string, unknown> => b !== null);
+}
+
+before(async () => { proc = await startServer(); });
+after(() => { proc?.kill(); });
+
+describe("/alternative-to/sendgrid", () => {
+  it("names no product from another class on any surface that carries the list", async () => {
+    const { status, body } = await get("/alternative-to/sendgrid");
+    assert.strictEqual(status, 200);
+
+    const blocks = jsonLdBlocks(body);
+    const itemList = blocks.find(b => b["@type"] === "ItemList") as { itemListElement: Array<{ item: { name: string } }> } | undefined;
+    const faq = blocks.find(b => b["@type"] === "FAQPage") as { mainEntity: Array<{ name: string; acceptedAnswer: { text: string } }> } | undefined;
+    assert.ok(itemList, "the page must ship an ItemList for this assertion to mean anything");
+    assert.ok(faq, "the page must ship FAQPage structured data");
+
+    const ogDescription = body.match(/<meta property="og:description" content="([^"]*)"/)?.[1] ?? "";
+    const rendered = [...body.matchAll(/class="alt-vendor-name">([^<]+)</g)].map(m => m[1]);
+    const listed = itemList.itemListElement.map(e => e.item.name);
+    const faqText = faq.mainEntity.map(e => `${e.name} ${e.acceptedAnswer.text}`).join(" ");
+
+    for (const wrong of SENDGRID_WRONG_CLASS) {
+      assert.ok(!rendered.includes(wrong), `${wrong} is still rendered as a SendGrid alternative`);
+      assert.ok(!listed.includes(wrong), `${wrong} is still in the ItemList`);
+      assert.ok(!ogDescription.includes(wrong), `${wrong} is still in og:description`);
+      assert.ok(!faqText.includes(wrong), `${wrong} is still in an FAQ answer`);
+    }
+
+    for (const name of SENDGRID_CURATED) {
+      assert.ok(rendered.includes(name), `${name} was written down for SendGrid and must survive`);
+      assert.ok(listed.includes(name), `${name} must reach the ItemList`);
+    }
+
+    assert.deepStrictEqual([...new Set(listed)].sort(), [...new Set(rendered)].sort(), "the ItemList and the rendered list are not the same set");
+    assert.ok(ogDescription.includes(String(listed.length)), "og:description must count the set the page publishes");
+  });
+});
+
+describe("a page with no evidence of a product class", () => {
+  it("offers no substitute, heads no list of them, and still answers", async () => {
+    const { status, body } = await get("/alternative-to/datadog");
+    assert.strictEqual(status, 200);
+    assert.strictEqual((body.match(/class="alt-vendor-name"/g) ?? []).length, 0);
+    assert.doesNotMatch(body, /All Free Alternatives \(/);
+    assert.ok(!jsonLdBlocks(body).some(b => b["@type"] === "ItemList"), "an empty set must not ship as an ItemList");
+    const ogDescription = body.match(/<meta property="og:description" content="([^"]*)"/)?.[1] ?? "";
+    assert.doesNotMatch(ogDescription, /Compare 0 /);
+    const subhead = body.match(/<p class="page-meta">([\s\S]*?)<\/p>/)?.[1] ?? "";
+    assert.doesNotMatch(subhead, /^0 free alternative/, "the subhead counts a list the page does not publish");
+    assert.doesNotMatch(subhead, /Sorted by/, "the subhead claims an ordering over an empty list");
+  });
+
+  it("asks no question it cannot answer", async () => {
+    const { body } = await get("/alternative-to/datadog");
+    const faq = jsonLdBlocks(body).find(b => b["@type"] === "FAQPage") as { mainEntity: Array<{ name: string }> } | undefined;
+    assert.ok(faq, "the page must still ship FAQPage structured data");
+    assert.ok(
+      !faq.mainEntity.some(q => q.name.startsWith("What are the best free alternatives")),
+      "the page asks for a best alternative it publishes none of",
+    );
+  });
+
+  it("names none of them through the vendor page or the API either", async () => {
+    const vendor = await get("/vendor/sendgrid");
+    assert.strictEqual(vendor.status, 200);
+    const risk = await get("/api/vendor-risk/SendGrid");
+    assert.strictEqual(risk.status, 200);
+    const named = JSON.parse(risk.body).alternatives.map((a: { vendor: string }) => a.vendor);
+    for (const wrong of SENDGRID_WRONG_CLASS) {
+      assert.ok(!named.includes(wrong), `${wrong} is still offered through /api/vendor-risk`);
+      assert.ok(!vendor.body.includes(`>${wrong}<`), `${wrong} is still named on /vendor/sendgrid`);
+    }
+  });
+});
+
+describe("the categories we did classify are untouched", () => {
+  const CONTROLS: Array<[string, number]> = [["neon", 20], ["vercel", 31], ["supabase", 26]];
+
+  for (const [slug, expected] of CONTROLS) {
+    it(`/alternative-to/${slug} still offers ${expected}`, async () => {
+      const { status, body } = await get(`/alternative-to/${slug}`);
+      assert.strictEqual(status, 200);
+      const heading = body.match(/All Free Alternatives \((\d+)\)/);
+      assert.ok(heading, `/alternative-to/${slug} must still head a list`);
+      assert.strictEqual(Number(heading[1]), expected);
+    });
+  }
+});

--- a/test/vendor-verdict.test.ts
+++ b/test/vendor-verdict.test.ts
@@ -452,18 +452,24 @@ describe("vendor verdict — as rendered", () => {
   });
 
   it("resolves the four routes that rendered a green badge over a negative verdict", async () => {
+    let cellsChecked = 0;
     for (const slug of ["digitalocean", "google-gemini-api", "postman", "xata"]) {
       const row = vendorRows().find(r => r.slug === slug);
       assert.ok(row, `/vendor/${slug} is a rendered route`);
       const html = await get(`/vendor/${slug}`);
       assert.strictEqual(badgeWord(html), row.expected, `/vendor/${slug} badge`);
-      assert.strictEqual(comparisonCell(html).word, row.expected, `/vendor/${slug} comparison cell`);
+      const cell = comparisonCell(html);
+      if (cell.rendered) {
+        cellsChecked += 1;
+        assert.strictEqual(cell.word, row.expected, `/vendor/${slug} comparison cell`);
+      }
       const verdict = verdictParagraph(html);
       assert.doesNotMatch(verdict, STABILITY_SCALE_WORDS, `/vendor/${slug} verdict`);
       assert.ok(verdict.includes(row.sentence), `/vendor/${slug} verdict does not render "${row.sentence}"`);
       assert.notStrictEqual(row.expected, "stable", `/vendor/${slug} still reads stable over a record that points down`);
       assert.match(row.sentence, /one recorded /, `/vendor/${slug} still names no record behind its level`);
     }
+    assert.ok(cellsChecked > 0, "no route under test rendered a comparison cell, so the badge agreement is unchecked");
   });
 
   it("stops offering a product whose own shutdown date has passed", async () => {


### PR DESCRIPTION
Refs #1209

## What was published

`/alternative-to/sendgrid`, in the `FAQPage` block, the `ItemList` and `og:description`: Bench (bookkeeping), Remote for Startups (employer of record) and Esri Startup Program (GIS), offered as the best free alternatives to an email API. Reproduced on a build of `main` before changing anything — 95 alternatives, all three named.

Alternatives membership was same-category, gated by subtype only where a subtype existed. 98 of 1,580 records carry one, in 2 of 66 categories.

## The rule

The same-category pool is offered as substitutes only where the subject carries a product subtype, so the gate can discriminate within it. A name written down for the vendor on a change record passes in any category. Everything else stays listed in its category, searchable, and on best-of pages — those are inventory, which `MEMBERSHIP_GATE_SCOPE` already says these gates never filter.

`partitionSubstitutes` is the one rule and every consumer routes through it: `/alternative-to`, `/vendor`, `/api/vendor-risk`, `/api/details`, and both the local and remote MCP servers. Verified over a real MCP `initialize` → `tools/call`: `search_deals({vendor: "SendGrid"})` returns no alternatives and no `relatedVendors`; Neon and Vercel still return five each.

A record classified as *none of this category's subtypes apply* now receives no substitutes. It already carried that gate as a candidate and not as a subject — 14 records were removed from everyone else's list while being offered the whole category on their own.

## The number that is not in the issue

**1,449 of 1,572 `/alternative-to` pages now publish no substitute**, and published entries fall from 70,011 to 1,531. 123 pages keep a list: 84 vendors classified in Databases or Cloud Hosting, and 39 whose only surviving entries are curated. This follows from AC-3 as written and from the AC-5/AC-6 outcomes the issue specifies, but the aggregate is not stated there, so it should be seen before this is judged. It is one predicate to revert.

## Acceptance criteria

| AC | check | result |
|---|---|---|
| 1 | sendgrid: rendered list, `ItemList`, `og:description` and FAQ answers are one set | pass |
| 2 | `change.alternatives` survives in every category | pass |
| 3 | no page offers a same-category record where no taxonomy and no curated list exist | pass |
| 4 | neon 20, vercel 31, supabase 26 | unchanged |
| 5 | sendgrid keeps Postmark, Resend, Amazon SES | pass |
| 6 | datadog 58→0, postman 48→5, auth0 29→1, sendgrid 95→3 | pass |
| 7 | 3,918 paths swept before and after, 0 status changes | pass |

`/alternative-to/cloudflare-workers` moves 36 → 31 and is the one classified subject that moves: it holds records in Cloud Hosting and in Education, and the five Education peers are not evidenced substitutes.

## Verification

- **2,858 tests, 0 failures**; `tsc --noEmit` clean; `validate-data` clean; `no-private-context` 9/9.
- **7 of 7 mutations killed**, each by a test naming the property: zero-label subject regaining its category, every candidate admissible, curated exemption dropped, the API/MCP consumer un-routed, the page un-routed, an empty `ItemList` shipping, and the unanswerable FAQ question shipping.
- **Full-path sweep against a `main` build**: 3,918 paths, 2,978 deterministic paths move — 1,489 `/alternative-to`, 1,488 `/vendor`, `/criteria`. `/api/stats` differs only in accumulated runtime counters. The `/vendor` set was checked against an independent prediction (a page moves iff its primary record carries no subtype label): 1,488 predicted, 1,488 moved, 0 unexplained, 0 predicted-but-still.
- Screenshots of `/alternative-to/sendgrid` and `/alternative-to/datadog`.

## Copy I did not write

Two strings are now thin and both need your wording, not mine:

1. An emptied page still carries `<title>Best Datadog Alternatives with Free Tiers (2026)</title>` and `<h1>` to match. The page names none.
2. The empty state reuses the existing `No alternatives found for <vendor>.` for the body, the subhead and `og:description`. AC-3 says saying we have no list is correct; that sentence predates this change and may not be the sentence you want on 1,449 pages.

I also deleted a clause on `/criteria` that this makes false — the coverage line ended *"and are gated by none"*, and unclassified records are now gated as subjects. `SUBTYPE_MEMBERSHIP_RULE` lost its last sentence for the same reason. Neither is replaced with a description of the new rule, because that is copy. One sentence from you and it goes back.

## A guard I inverted, deliberately

`ranked-surfaces.test.ts` asserted *"does not empty out a page whose category peers are all eligibility-gated"* against `/alternative-to/brex` — that a gated category must still list its peers with the gate labelled. AC-3 reverses that for Startup Perks, which is the category this issue is about. The test now asserts the new behaviour instead. Worth knowing: `eligibility_restricted` was the only gate that reached a reader through that page, and it now renders on **zero** pages site-wide.

Six other guards lost their subject because their category is unclassified. None were weakened by assertion-dropping: the fixtures in `source-check-pages` were given a subtype so their comparison table still renders, the seed and demerit checks were re-pointed at classified vendors, the category-heading check moved from Postman to Firebase where cross-category curated names still exist, and the two sweeps in `alternatives-membership` now assert *zero grids* where no taxonomy binds rather than skipping.