### PR TITLE
Serve a page that names no substitute, stop submitting it for indexing (#1209)

### DIFF
--- a/scripts/mutate-1032-phase0.sh
+++ b/scripts/mutate-1032-phase0.sh
@@ -69,8 +69,8 @@ m_pool_is_intersected_again() {
 p = "src/serve.ts"
 s = open(p).read()
 s = s.replace(
-  "partitionAlternativesAcross(addCuratedToPool(dedupedAlts, curated.matched), vendorOffers, {",
-  "partitionAlternativesAcross(dedupedAlts, vendorOffers, {")
+  "partitionSubstitutes(addCuratedToPool(pool, curated.matched), vendorOffers, {",
+  "partitionSubstitutes(pool, vendorOffers, {")
 open(p, "w").write(s)
 PY
 }

--- a/scripts/mutate-1032-phase2.sh
+++ b/scripts/mutate-1032-phase2.sh
@@ -156,7 +156,7 @@ m_alternatives_page_subtype_gates_curated_names() {
   py <<'PY'
 p = "src/serve.ts"
 s = open(p).read()
-s = s.replace("    subtypeExempt: candidate => curatedAltNames.has(candidate.vendor),",
+s = s.replace("    subtypeExempt: candidate => curatedNames.has(candidate.vendor),",
               "    subtypeExempt: () => false,")
 open(p, "w").write(s)
 PY

--- a/scripts/mutate-1093.sh
+++ b/scripts/mutate-1093.sh
@@ -52,7 +52,7 @@ case_run "the disallow names a path nothing serves" \
   'Disallow: /nothing-we-serve'
 
 case_run "the search page drops its robots meta" \
-  "+ SEARCH_PAGE_ROBOTS_META + '\\n'
+  "+ NOINDEX_FOLLOW_META + '\\n'
     " \
   "+ "
 

--- a/scripts/mutate-1209-indexing.sh
+++ b/scripts/mutate-1209-indexing.sh
@@ -1,0 +1,176 @@
+#!/usr/bin/env bash
+set -u
+
+REPO="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$REPO" || exit 1
+
+SERVE="src/serve.ts"
+FILES=("$SERVE")
+BACKUP_DIR="$(mktemp -d)"
+for f in "${FILES[@]}"; do
+  cp "$f" "$BACKUP_DIR/$(basename "$f")"
+done
+
+restore() {
+  for f in "${FILES[@]}"; do
+    cp "$BACKUP_DIR/$(basename "$f")" "$f"
+  done
+  npx tsc > /dev/null 2>&1
+}
+trap 'restore' EXIT
+
+killed=0
+survived=0
+TESTS="test/alternatives-crawl-space.test.ts test/search-crawl-space.test.ts"
+
+py() { python3 - "$@"; }
+
+changed_any() {
+  for f in "${FILES[@]}"; do
+    if ! diff -q "$BACKUP_DIR/$(basename "$f")" "$f" > /dev/null; then
+      return 0
+    fi
+  done
+  return 1
+}
+
+run_mutation() {
+  local name="$1"
+  shift
+  echo "=== $name"
+  for f in "${FILES[@]}"; do cp "$BACKUP_DIR/$(basename "$f")" "$f"; done
+  "$@"
+  if ! changed_any; then
+    echo "    NOT APPLIED: the mutation changed no file, so it proves nothing"
+    survived=$((survived + 1))
+    return
+  fi
+  if ! npx tsc > /tmp/mutate-1209-build.log 2>&1; then
+    echo "    NOT APPLIED: the mutation does not compile"
+    survived=$((survived + 1))
+    return
+  fi
+  if timeout 900 node --test --test-concurrency 1 $TESTS > /tmp/mutate-1209-test.log 2>&1; then
+    echo "    SURVIVED"
+    survived=$((survived + 1))
+  else
+    echo "    KILLED: $(grep -c '✖ ' /tmp/mutate-1209-test.log) failing assertion(s)"
+    grep '✖ ' /tmp/mutate-1209-test.log | head -3
+    killed=$((killed + 1))
+  fi
+}
+
+m_no_page_ever_asks_to_be_left_out() {
+  py <<'PY'
+p = "src/serve.ts"
+s = open(p).read()
+s = s.replace(r'${publishesSubstitutes ? "" : NOINDEX_FOLLOW_META + "\n"}<link rel="canonical" href="${BASE_URL}/alternative-to/${slug}">',
+              r'<link rel="canonical" href="${BASE_URL}/alternative-to/${slug}">')
+open(p, "w").write(s)
+PY
+}
+
+m_every_page_asks_to_be_left_out() {
+  py <<'PY'
+p = "src/serve.ts"
+s = open(p).read()
+s = s.replace(r'${publishesSubstitutes ? "" : NOINDEX_FOLLOW_META + "\n"}<link rel="canonical" href="${BASE_URL}/alternative-to/${slug}">',
+              r'${NOINDEX_FOLLOW_META + "\n"}<link rel="canonical" href="${BASE_URL}/alternative-to/${slug}">')
+open(p, "w").write(s)
+PY
+}
+
+m_the_page_forbids_the_links_out_as_well() {
+  py <<'PY'
+p = "src/serve.ts"
+s = open(p).read()
+s = s.replace('const NOINDEX_FOLLOW_META = \'<meta name="robots" content="noindex,follow">\';',
+              'const NOINDEX_FOLLOW_META = \'<meta name="robots" content="noindex,nofollow">\';')
+open(p, "w").write(s)
+PY
+}
+
+m_the_sitemap_submits_every_address_again() {
+  py <<'PY'
+p = "src/serve.ts"
+s = open(p).read()
+s = s.replace("      if (!alternativesPagePublishesSubstitutes(s, sitemapChanges)) continue;\n", "")
+open(p, "w").write(s)
+PY
+}
+
+m_the_sitemap_submits_the_empty_pages_instead() {
+  py <<'PY'
+p = "src/serve.ts"
+s = open(p).read()
+s = s.replace("      if (!alternativesPagePublishesSubstitutes(s, sitemapChanges)) continue;",
+              "      if (alternativesPagePublishesSubstitutes(s, sitemapChanges)) continue;")
+open(p, "w").write(s)
+PY
+}
+
+m_the_sitemap_reads_the_removals_not_the_list() {
+  py <<'PY'
+p = "src/serve.ts"
+s = open(p).read()
+s = s.replace("  return vendorSubstitutes(vendorName, vendorOffers, allChanges).membership.kept.length > 0;",
+              "  return vendorSubstitutes(vendorName, vendorOffers, allChanges).membership.removed.length > 0;")
+open(p, "w").write(s)
+PY
+}
+
+m_the_empty_page_keeps_its_questions() {
+  py <<'PY'
+p = "src/serve.ts"
+s = open(p).read()
+s = s.replace("  const altFaqItems = publishesSubstitutes\n    ? [", "  const altFaqItems = true\n    ? [")
+open(p, "w").write(s)
+PY
+}
+
+m_the_empty_page_keeps_promising_a_list() {
+  py <<'PY'
+p = "src/serve.ts"
+s = open(p).read()
+s = s.replace("""  const title = publishesSubstitutes
+    ? `Best ${vendorName} Alternatives with Free Tiers (${currentYear}) | AgentDeals`
+    : `${heading} — none listed yet | AgentDeals`;""",
+              "  const title = `Best ${vendorName} Alternatives with Free Tiers (${currentYear}) | AgentDeals`;")
+open(p, "w").write(s)
+PY
+}
+
+m_the_empty_heading_keeps_promising_a_list() {
+  py <<'PY'
+p = "src/serve.ts"
+s = open(p).read()
+s = s.replace("  <h1>${publishesSubstitutes ? `Best ${escHtmlServer(vendorName)} Alternatives with Free Tiers (${currentYear})` : escHtmlServer(heading)}</h1>",
+              "  <h1>Best ${escHtmlServer(vendorName)} Alternatives with Free Tiers (${currentYear})</h1>")
+open(p, "w").write(s)
+PY
+}
+
+m_the_empty_page_sends_the_reader_nowhere() {
+  py <<'PY'
+p = "src/serve.ts"
+s = open(p).read()
+s = s.replace('The <a href="/category/${toSlug(homeCategory)}">${escHtmlServer(homeCategory)}</a> category lists every offer we track alongside it.',
+              'The ${escHtmlServer(homeCategory)} category lists every offer we track alongside it.')
+open(p, "w").write(s)
+PY
+}
+
+run_mutation "no page ever asks to be left out of the index" m_no_page_ever_asks_to_be_left_out
+run_mutation "every alternatives page asks to be left out of the index" m_every_page_asks_to_be_left_out
+run_mutation "the page forbids the links out as well" m_the_page_forbids_the_links_out_as_well
+run_mutation "the sitemap submits every vendor address again" m_the_sitemap_submits_every_address_again
+run_mutation "the sitemap submits the pages that name nothing" m_the_sitemap_submits_the_empty_pages_instead
+run_mutation "the sitemap reads the removals rather than the list" m_the_sitemap_reads_the_removals_not_the_list
+run_mutation "the page that names nothing keeps its questions" m_the_empty_page_keeps_its_questions
+run_mutation "the page that names nothing keeps promising a list" m_the_empty_page_keeps_promising_a_list
+run_mutation "the heading keeps promising a list" m_the_empty_heading_keeps_promising_a_list
+run_mutation "the page that names nothing sends the reader nowhere" m_the_empty_page_sends_the_reader_nowhere
+
+echo
+echo "killed=$killed survived=$survived"
+[ "$survived" -eq 0 ]

--- a/src/product-role.ts
+++ b/src/product-role.ts
@@ -63,7 +63,7 @@ export const SUBTYPE_MEMBERSHIP_GROUPS: Record<string, SubtypeMembershipGroup[]>
 };
 
 export const SUBTYPE_MEMBERSHIP_RULE =
-  "Two offers in the same category are alternatives when their subtype sets share at least one member, or when both carry a subtype from one of the membership groups below.";
+  "Two offers in the same category are alternatives when their subtype sets share at least one member, or when both carry a subtype from one of the membership groups below. A record we have not classified is offered no substitutes and is offered as one to no one. It stays listed in its category, in search, and on best-of pages.";
 
 export const SUBTYPE_MEMBERSHIP_GROUP_SCOPE =
   "A group answers whether a product could substitute at all. Which one is the better answer is ordering, and ordering is a separate, seeded, published concern that reads none of this.";

--- a/src/serve.ts
+++ b/src/serve.ts
@@ -43,7 +43,7 @@ import { discontinuedOnOrBefore, PRODUCT_DEPRECATED } from "./product-deprecatio
 import { rankOffers, rankForListing, rotateListing, utcDate, CRITERIA_PATH, DEMOTE_ONLY_POLICY, DISCLOSURE_RATIONALE, TIE_BREAK_ALGORITHM, GATE_TABLE, DEMERIT_TABLE, NOT_FREE_TIER_RULES, TIME_LIMITED_TIER_RULES, type TieBreak } from "./ranking.js";
 import type { RankedEntry, RankingResult } from "./ranking.js";
 import { verificationLedger, QUARANTINE_AFTER_FAILURES } from "./verification-state.js";
-import { partitionAlternatives, partitionSubstitutes, productRoleSentence, MEMBERSHIP_GATE_RULES, MEMBERSHIP_GATE_ORDER, MEMBERSHIP_GATE_SYMMETRY, MEMBERSHIP_GATE_SCOPE, MEMBERSHIP_GATE_CORRECTIONS, SUBTYPE_TAXONOMIES, SUBTYPE_MEMBERSHIP_RULE, SUBTYPE_MEMBERSHIP_GROUP_SCOPE, membershipGroupsFor, subtypeDefinition } from "./product-role.js";
+import { partitionAlternatives, partitionSubstitutes, type SubstitutesPartition, productRoleSentence, MEMBERSHIP_GATE_RULES, MEMBERSHIP_GATE_ORDER, MEMBERSHIP_GATE_SYMMETRY, MEMBERSHIP_GATE_SCOPE, MEMBERSHIP_GATE_CORRECTIONS, SUBTYPE_TAXONOMIES, SUBTYPE_MEMBERSHIP_RULE, SUBTYPE_MEMBERSHIP_GROUP_SCOPE, membershipGroupsFor, subtypeDefinition } from "./product-role.js";
 import { resolveCuratedAlternatives, curatedAlternativesFor, addCuratedToPool } from "./curated-alternatives.js";
 import type { Agent, ChangeDateSource, DealChange, RiskCause, LinkUnreachable, Offer } from "./types.js";
 import { changeDateLabel, changeDateClause, changeDatePublished, changeEventStartDate, capListSections, latestEventDate, offerExpiryAfter, feedEntryUpdated, undatedGroupHeading, firstReadHeading, discoveryBatchNote, isoWeekOf, DISCOVERED_DATE_PREFIX, UNDATED_GROUP_NOTE } from "./change-dates.js";
@@ -146,7 +146,7 @@ const OG_IMAGE_META = `<meta property="og:image" content="${BASE_URL}/og-image.p
 
 const SEARCH_QUERY_DISALLOW = "Disallow: /search?";
 const ROBOTS_MAX_AGE_SECONDS = 3600;
-const SEARCH_PAGE_ROBOTS_META = '<meta name="robots" content="noindex,follow">';
+const NOINDEX_FOLLOW_META = '<meta name="robots" content="noindex,follow">';
 const NOFOLLOW_ATTR = ' rel="nofollow"';
 
 function searchQueryHref(params: URLSearchParams | string): string {
@@ -1849,7 +1849,7 @@ ${entries.map(e => `<tr><td><code>${escHtmlServer(e.subtype)}</code></td><td>${e
       const done = inTaxonomy.filter(o => o.product_subtypes).length;
       return `${done} of ${inTaxonomy.length} in ${taxonomy}`;
     });
-    return `We have classified ${parts.join(", ")}; the other ${offers.length - offers.filter(o => o.product_subtypes).length} records in the index carry no subtype.`;
+    return `We have classified ${parts.join(", ")}; the other ${offers.length - offers.filter(o => o.product_subtypes).length} records carry no subtype, so they are offered no substitutes and are offered as one to no one. Classifying a category restores both directions.`;
   })();
 
   const jsonLd = {
@@ -4265,6 +4265,37 @@ ${faqHtml}
 </html>`;
 }
 
+interface VendorSubstitutes {
+  categories: string[];
+  curatedNames: Set<string>;
+  membership: SubstitutesPartition<Offer>;
+}
+
+function vendorSubstitutes(vendorName: string, vendorOffers: Offer[], allChanges: DealChange[]): VendorSubstitutes {
+  const categories = [...new Set(vendorOffers.map(o => o.category))];
+  const seen = new Set<string>();
+  const pool: Offer[] = [];
+  for (const o of offers) {
+    if (o.vendor === vendorName || !categories.includes(o.category) || seen.has(o.vendor)) continue;
+    seen.add(o.vendor);
+    pool.push(o);
+  }
+  const curated = resolveCuratedAlternatives(vendorName, allChanges, offers);
+  const curatedNames = new Set(curated.matched.map(o => o.vendor));
+  const membership = partitionSubstitutes(addCuratedToPool(pool, curated.matched), vendorOffers, {
+    subtypeExempt: candidate => curatedNames.has(candidate.vendor),
+  });
+  return { categories, curatedNames, membership };
+}
+
+function alternativesPagePublishesSubstitutes(slug: string, allChanges: DealChange[]): boolean {
+  const vendorName = vendorSlugMap.get(slug);
+  if (!vendorName) return false;
+  const vendorOffers = offers.filter(o => o.vendor === vendorName);
+  if (vendorOffers.length === 0) return false;
+  return vendorSubstitutes(vendorName, vendorOffers, allChanges).membership.kept.length > 0;
+}
+
 function buildAlternativesPage(slug: string): string | null {
   const vendorName = vendorSlugMap.get(slug);
   if (!vendorName) return null;
@@ -4294,23 +4325,10 @@ function buildAlternativesPage(slug: string): string | null {
   const riskLevel = enriched.risk_level && (enriched.risk_level === "stable" || riskCause) ? enriched.risk_level : "stable";
   const riskColor = riskColors[riskLevel] ?? "#8b949e";
 
-  const vendorCategories = [...new Set(vendorOffers.map(o => o.category))];
-
-  const allAlternatives = offers
-    .filter(o => vendorCategories.includes(o.category) && o.vendor !== vendorName);
-  const seen = new Set<string>();
-  const dedupedAlts: typeof allAlternatives = [];
-  for (const a of allAlternatives) {
-    if (!seen.has(a.vendor)) {
-      seen.add(a.vendor);
-      dedupedAlts.push(a);
-    }
-  }
-  const curated = resolveCuratedAlternatives(vendorName, allChanges, offers);
-  const curatedAltNames = new Set(curated.matched.map(o => o.vendor));
-  const altMembership = partitionSubstitutes(addCuratedToPool(dedupedAlts, curated.matched), vendorOffers, {
-    subtypeExempt: candidate => curatedAltNames.has(candidate.vendor),
-  });
+  const substitutes = vendorSubstitutes(vendorName, vendorOffers, allChanges);
+  const vendorCategories = substitutes.categories;
+  const curatedAltNames = substitutes.curatedNames;
+  const altMembership = substitutes.membership;
   const altRanking = rankForListing(enrichOffers(altMembership.kept), {
     queryKey: `alternative-to:${vendorName}`,
     changes: dealChanges,
@@ -4325,12 +4343,17 @@ function buildAlternativesPage(slug: string): string | null {
   }
 
   const currentYear = new Date().getFullYear();
-  const title = `Best ${vendorName} Alternatives with Free Tiers (${currentYear}) | AgentDeals`;
+  const publishesSubstitutes = enrichedAlts.length > 0;
+  const homeCategory = vendorCategories[0];
+  const heading = `${vendorName} Alternatives`;
+  const title = publishesSubstitutes
+    ? `Best ${vendorName} Alternatives with Free Tiers (${currentYear}) | AgentDeals`
+    : `${heading} — none listed yet | AgentDeals`;
   const topAlts = enrichedAlts.slice(0, 3).map(a => a.vendor).join(", ");
-  const noAlternativesSentence = `No alternatives found for ${vendorName}.`;
-  const metaDesc = enrichedAlts.length > 0
-    ? `Compare ${enrichedAlts.length} free alternatives to ${vendorName} for ${vendorCategories[0]}. ${topAlts ? `Side-by-side free tier limits for ${topAlts}.` : "Find stable, verified free-tier tools."}`
-    : noAlternativesSentence;
+  const metaDesc = publishesSubstitutes
+    ? `Compare ${enrichedAlts.length} free alternatives to ${vendorName} for ${homeCategory}. ${topAlts ? `Side-by-side free tier limits for ${topAlts}.` : "Find stable, verified free-tier tools."}`
+    : `We publish no substitute list for ${vendorName} yet. See the ${homeCategory} category for every offer we track alongside it.`;
+  const noSubstitutesHtml = `We publish a substitute list only where a record says what kind of product it is. ${escHtmlServer(vendorName)}'s does not yet, so this page names none. The <a href="/category/${toSlug(homeCategory)}">${escHtmlServer(homeCategory)}</a> category lists every offer we track alongside it.`;
 
   const situationHtml = (() => {
     const parts: string[] = [];
@@ -4412,7 +4435,7 @@ ${curatedAlts.map(a => altCard(a, true)).join("\n")}
 ${enrichedAlts.map(a => altCard(a, false)).join("\n")}
     </div>
 ${renderAuditBlock(altRanking.tie_break)}
-  </div>` : `<div class="section"><p class="no-changes">${escHtmlServer(noAlternativesSentence)}</p></div>`;
+  </div>` : "";
 
   const trendsHtml = vendorCategories.map(c =>
     `<a href="/trends/${toSlug(c)}" class="action-pill">&#x2191; ${escHtmlServer(c)} Pricing Trends</a>`
@@ -4457,23 +4480,27 @@ ${renderAuditBlock(altRanking.tie_break)}
     ? `We hold no recorded pricing changes for ${vendorName}, but ${altWithheldClause}, so that is a statement about our records rather than a positive signal.`
     : `No, ${vendorName} has no recorded pricing changes on AgentDeals. This indicates stable pricing.`;
 
-  const altFaqItems = [
-    ...(enrichedAlts.length > 0 ? [{ q: `What are the best free alternatives to ${vendorName}?`, a: faqBestAltsAnswer }] : []),
-    { q: `Is ${vendorName}'s free tier still available?`, a: faqFreeTierAnswer },
-    { q: `How many free alternatives to ${vendorName} exist?`, a: faqCountAnswer },
-    { q: `Has ${vendorName} changed their pricing?`, a: faqChangesAnswer },
-  ];
+  const altFaqItems = publishesSubstitutes
+    ? [
+      { q: `What are the best free alternatives to ${vendorName}?`, a: faqBestAltsAnswer },
+      { q: `Is ${vendorName}'s free tier still available?`, a: faqFreeTierAnswer },
+      { q: `How many free alternatives to ${vendorName} exist?`, a: faqCountAnswer },
+      { q: `Has ${vendorName} changed their pricing?`, a: faqChangesAnswer },
+    ]
+    : [];
 
-  const altFaqJsonLd = faqPageJsonLd("/alternative-to/" + slug, altFaqItems);
+  const altFaqJsonLd = altFaqItems.length > 0
+    ? `<script type="application/ld+json">${JSON.stringify(faqPageJsonLd("/alternative-to/" + slug, altFaqItems))}</script>`
+    : "";
 
-  const altFaqHtml = `
+  const altFaqHtml = altFaqItems.length > 0 ? `
   <div class="section faq-section">
     <h2>Frequently Asked Questions</h2>
     ${altFaqItems.map(item => `<details class="faq-item">
       <summary class="faq-q">${escHtmlServer(item.q)}</summary>
       <div class="faq-a">${escHtmlServer(item.a)}</div>
     </details>`).join("\n    ")}
-  </div>`;
+  </div>` : "";
 
   return `<!DOCTYPE html>
 <html lang="en">
@@ -4482,7 +4509,7 @@ ${renderAuditBlock(altRanking.tie_break)}
 <meta name="viewport" content="width=device-width,initial-scale=1">
 <title>${escHtmlServer(title)}</title>
 <meta name="description" content="${escHtmlServer(metaDesc)}">
-<link rel="canonical" href="${BASE_URL}/alternative-to/${slug}">
+${publishesSubstitutes ? "" : NOINDEX_FOLLOW_META + "\n"}<link rel="canonical" href="${BASE_URL}/alternative-to/${slug}">
 <meta property="og:title" content="${escHtmlServer(title)}">
 <meta property="og:description" content="${escHtmlServer(metaDesc)}">
 <meta property="og:type" content="website">
@@ -4490,7 +4517,7 @@ ${renderAuditBlock(altRanking.tie_break)}
 ${OG_IMAGE_META}${GOOGLE_VERIFICATION_META}<link rel="icon" type="image/png" href="/favicon.png">
 <link rel="alternate" type="application/atom+xml" title="AgentDeals — Weekly Pricing Digest" href="/feed.xml">
 <link rel="preconnect" href="https://fonts.googleapis.com"><link rel="preconnect" href="https://fonts.gstatic.com" crossorigin><link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
-${enrichedAlts.length > 0 ? `<script type="application/ld+json">${JSON.stringify(jsonLd)}</script>\n` : ""}<script type="application/ld+json">${JSON.stringify(altFaqJsonLd)}</script>
+${publishesSubstitutes ? `<script type="application/ld+json">${JSON.stringify(jsonLd)}</script>\n` : ""}${altFaqJsonLd}
 ${buildBreadcrumbJsonLd([{ name: "Home", url: BASE_URL + "/" }, { name: "Alternatives", url: BASE_URL + "/alternatives" }, { name: vendorName + " Alternatives", url: BASE_URL + "/alternative-to/" + slug }])}
 <style>
 *{margin:0;padding:0;box-sizing:border-box}
@@ -4559,8 +4586,8 @@ ${mcpCtaCss()}
 <div class="container">
   ${buildGlobalNav("alternatives")}
   <div class="breadcrumb"><a href="/">AgentDeals</a> &rsaquo; <a href="/alternative-to">Alternatives</a> &rsaquo; ${escHtmlServer(vendorName)}</div>
-  <h1>Best ${escHtmlServer(vendorName)} Alternatives with Free Tiers (${currentYear})</h1>
-  <p class="page-meta">${enrichedAlts.length > 0 ? `${enrichedAlts.length} free alternative${enrichedAlts.length !== 1 ? "s" : ""} in ${vendorCategories.map(c => escHtmlServer(c)).join(", ")}. Sorted by pricing stability.` : escHtmlServer(noAlternativesSentence)}</p>
+  <h1>${publishesSubstitutes ? `Best ${escHtmlServer(vendorName)} Alternatives with Free Tiers (${currentYear})` : escHtmlServer(heading)}</h1>
+  <p class="page-meta">${publishesSubstitutes ? `${enrichedAlts.length} free alternative${enrichedAlts.length !== 1 ? "s" : ""} in ${vendorCategories.map(c => escHtmlServer(c)).join(", ")}. Sorted by pricing stability.` : noSubstitutesHtml}</p>
 
   <div class="situation-box">
     <h2>Current ${escHtmlServer(vendorName)} Situation</h2>
@@ -51284,7 +51311,7 @@ function buildSearchPage(query: string, categoryFilter: string, typeFilter: stri
   return '<!DOCTYPE html>\n<html lang="en">\n<head>\n<meta charset="utf-8">\n<meta name="viewport" content="width=device-width,initial-scale=1">\n'
     + '<title>' + titleText + '</title>\n'
     + '<meta name="description" content="' + escHtmlServer(metaDescText) + '">\n'
-    + SEARCH_PAGE_ROBOTS_META + '\n'
+    + NOINDEX_FOLLOW_META + '\n'
     + '<link rel="canonical" href="' + BASE_URL + '/search">\n'
     + '<meta property="og:title" content="' + titleText + '">\n'
     + '<meta property="og:description" content="' + escHtmlServer(metaDescText) + '">\n'
@@ -53969,7 +53996,9 @@ ${catList}
     }
     xml += '  <url>\n    <loc>' + BASE_URL + '/x402-services</loc>\n    <lastmod>' + editorialDate + '</lastmod>\n    <changefreq>weekly</changefreq>\n    <priority>0.8</priority>\n  </url>\n'
       + '  <url>\n    <loc>' + BASE_URL + '/alternative-to</loc>\n    <lastmod>' + latestVerified + '</lastmod>\n    <changefreq>weekly</changefreq>\n    <priority>0.7</priority>\n  </url>\n';
+    const sitemapChanges = loadDealChanges();
     for (const s of vendorSlugMap.keys()) {
+      if (!alternativesPagePublishesSubstitutes(s, sitemapChanges)) continue;
       const altLastmod = vendorLastmod.get(s) || now;
       xml += '  <url>\n    <loc>' + BASE_URL + '/alternative-to/' + s + '</loc>\n    <lastmod>' + altLastmod + '</lastmod>\n    <changefreq>weekly</changefreq>\n    <priority>0.5</priority>\n  </url>\n';
     }

--- a/test/alternatives-crawl-space.test.ts
+++ b/test/alternatives-crawl-space.test.ts
@@ -1,0 +1,159 @@
+import { describe, it, before, after } from "node:test";
+import assert from "node:assert";
+import { spawn, type ChildProcess } from "node:child_process";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import type { Offer } from "../src/types.ts";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO = path.join(__dirname, "..");
+
+const offers: Offer[] = JSON.parse(readFileSync(path.join(REPO, "data", "index.json"), "utf-8")).offers;
+
+const NOINDEX_FOLLOW = '<meta name="robots" content="noindex,follow">';
+
+function slugOf(vendor: string): string {
+  return vendor.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "");
+}
+
+let serverPort = 0;
+let proc: ChildProcess | null = null;
+
+function startServer(): Promise<ChildProcess> {
+  return new Promise((resolve, reject) => {
+    const child = spawn("node", [path.join(REPO, "dist", "serve.js")], {
+      stdio: ["pipe", "pipe", "pipe"],
+      env: { ...process.env, PORT: "0", BASE_URL: "http://localhost", TZ: "UTC" },
+    });
+    const timeout = setTimeout(() => { child.kill(); reject(new Error("Server startup timeout")); }, 20000);
+    child.stderr!.on("data", (data: Buffer) => {
+      const m = data.toString().match(/running on http:\/\/localhost:(\d+)/);
+      if (m) { serverPort = parseInt(m[1], 10); clearTimeout(timeout); resolve(child); }
+    });
+    child.on("error", (err) => { clearTimeout(timeout); reject(err); });
+  });
+}
+
+interface Rendered {
+  slug: string;
+  status: number;
+  body: string;
+  named: number;
+}
+
+const pages = new Map<string, Rendered>();
+let submitted = new Set<string>();
+
+function substituteNames(body: string): number {
+  return (body.match(/class="alt-vendor-name"/g) ?? []).length;
+}
+
+async function renderAll(slugs: string[]): Promise<void> {
+  const queue = [...slugs];
+  const worker = async () => {
+    for (let slug = queue.pop(); slug !== undefined; slug = queue.pop()) {
+      const res = await fetch(`http://localhost:${serverPort}/alternative-to/${slug}`);
+      const body = await res.text();
+      pages.set(slug, { slug, status: res.status, body, named: substituteNames(body) });
+    }
+  };
+  await Promise.all(Array.from({ length: 12 }, worker));
+}
+
+const withSubstitutes = () => [...pages.values()].filter(p => p.named > 0);
+const withoutSubstitutes = () => [...pages.values()].filter(p => p.named === 0);
+
+before(async () => {
+  proc = await startServer();
+  const slugs = [...new Set(offers.map(o => slugOf(o.vendor)))];
+  await renderAll(slugs);
+  const sitemap = await (await fetch(`http://localhost:${serverPort}/sitemap-pages.xml`)).text();
+  submitted = new Set([...sitemap.matchAll(/<loc>[^<]*\/alternative-to\/([^<]+)<\/loc>/g)].map(m => m[1]));
+  assert.ok(pages.size > 1000, `every vendor must have an alternatives page for this test to mean anything, rendered ${pages.size}`);
+  assert.ok(withSubstitutes().length > 0, "some page must name a substitute for this test to mean anything");
+  assert.ok(withoutSubstitutes().length > 0, "some page must name none for this test to mean anything");
+});
+
+after(() => { if (proc) proc.kill(); });
+
+describe("#1209 a page that names no substitute is served but not submitted", () => {
+  it("keeps every vendor address live, whether or not it names a substitute", () => {
+    const dead = [...pages.values()].filter(p => p.status !== 200).map(p => `${p.slug} (${p.status})`);
+    assert.deepEqual(dead, [], "a vendor page links here, and the list returns when the vendor is classified");
+  });
+
+  it("asks not to be indexed when it names none", () => {
+    const indexable = withoutSubstitutes().filter(p => !p.body.includes(NOINDEX_FOLLOW)).map(p => p.slug);
+    assert.deepEqual(indexable.slice(0, 10), [], `${indexable.length} pages naming no substitute ask to be indexed`);
+  });
+
+  it("stays indexable when it names one", () => {
+    const blocked = withSubstitutes().filter(p => p.body.includes(NOINDEX_FOLLOW)).map(p => p.slug);
+    assert.deepEqual(blocked.slice(0, 10), [], `${blocked.length} pages naming a substitute ask not to be indexed`);
+  });
+
+  it("lets a crawler follow the links out of a page it may not index", () => {
+    for (const page of withoutSubstitutes().slice(0, 50)) {
+      const tag = page.body.match(/<meta name="robots"[^>]*>/);
+      assert.ok(tag, `${page.slug} must carry a robots tag`);
+      assert.ok(!/nofollow/.test(tag[0]), `${page.slug} names a category page worth crawling`);
+    }
+  });
+
+  it("submits an address for indexing only when the page behind it names a substitute", () => {
+    const disagreements: string[] = [];
+    for (const page of pages.values()) {
+      const wanted = page.named > 0;
+      if (submitted.has(page.slug) !== wanted) {
+        disagreements.push(`${page.slug} names ${page.named} and is ${submitted.has(page.slug) ? "" : "not "}submitted`);
+      }
+    }
+    assert.deepEqual(disagreements.slice(0, 10), [], `${disagreements.length} addresses disagree with the page they point at`);
+    assert.equal(submitted.size, withSubstitutes().length);
+  });
+});
+
+describe("#1209 a page that names no substitute makes no claim it cannot support", () => {
+  it("does not offer a question it cannot answer", () => {
+    const withFaq = withoutSubstitutes().filter(p => p.body.includes('"@type":"FAQPage"')).map(p => p.slug);
+    assert.deepEqual(withFaq.slice(0, 10), [], `${withFaq.length} pages naming no substitute publish FAQ structured data`);
+  });
+
+  it("publishes no list for a machine to read", () => {
+    const withList = withoutSubstitutes().filter(p => p.body.includes('"@type":"ItemList"')).map(p => p.slug);
+    assert.deepEqual(withList.slice(0, 10), [], `${withList.length} pages naming no substitute publish an ItemList`);
+  });
+
+  it("does not promise a list in the title or the heading", () => {
+    const promising = withoutSubstitutes()
+      .filter(p => /<title>Best /.test(p.body) || /<h1>Best /.test(p.body))
+      .map(p => p.slug);
+    assert.deepEqual(promising.slice(0, 10), [], `${promising.length} pages naming no substitute are titled as a list of the best ones`);
+  });
+
+  it("sends the reader to the category the vendor is listed in, in place of the list", () => {
+    const byVendor = new Map<string, string>();
+    for (const offer of offers) {
+      if (!byVendor.has(slugOf(offer.vendor))) byVendor.set(slugOf(offer.vendor), offer.category);
+    }
+    const missing: string[] = [];
+    for (const page of withoutSubstitutes()) {
+      const category = byVendor.get(page.slug);
+      if (!category) continue;
+      const lede = page.body.match(/<p class="page-meta">[\s\S]*?<\/p>/);
+      if (!lede || !lede[0].includes(`href="/category/${slugOf(category)}"`)) missing.push(page.slug);
+    }
+    assert.deepEqual(missing.slice(0, 10), [], `${missing.length} pages naming no substitute offer the reader nowhere to go`);
+  });
+
+  it("keeps naming the substitutes it has where it has them", () => {
+    const named = withSubstitutes();
+    const total = named.reduce((sum, p) => sum + p.named, 0);
+    assert.ok(total >= named.length, "a page counted as naming substitutes must name at least one each");
+    for (const page of named.slice(0, 20)) {
+      assert.ok(page.body.includes('"@type":"ItemList"'), `${page.slug} names substitutes and must publish them for a machine to read`);
+      assert.ok(/<title>Best /.test(page.body), `${page.slug} names substitutes and its title says so`);
+    }
+  });
+});

--- a/test/served-scripts.test.ts
+++ b/test/served-scripts.test.ts
@@ -76,11 +76,17 @@ const TEMPLATE_SAMPLES = 5;
 
 async function everyPageTemplate(): Promise<string[]> {
   const routes = new Set<string>(["/"]);
+  const vendorSlugs: string[] = [];
   for (const sitemap of locsIn(await body("/sitemap.xml"))) {
     const repeated = /vendors|comparisons/.test(sitemap);
     const locs = locsIn(await body(sitemap));
+    for (const loc of locs) {
+      const slug = loc.match(/^\/vendor\/([^/]+)$/)?.[1];
+      if (slug) vendorSlugs.push(slug);
+    }
     for (const loc of repeated ? locs.slice(0, TEMPLATE_SAMPLES) : locs) routes.add(loc);
   }
+  for (const slug of vendorSlugs) routes.add(`/alternative-to/${slug}`);
   return [...routes].filter((route) => !route.endsWith(".xml"));
 }
 

--- a/test/sponsored-link-targets.test.ts
+++ b/test/sponsored-link-targets.test.ts
@@ -49,6 +49,10 @@ async function everyPublishedPath(base: string): Promise<string[]> {
   for (const extra of ["/", "/hosting-pricing", "/disclosure", "/referral-programs", "/marketplace"]) {
     if (!paths.includes(extra)) paths.push(extra);
   }
+  for (const p of [...paths]) {
+    const slug = p.match(/^\/vendor\/([^/]+)$/)?.[1];
+    if (slug) paths.push(`/alternative-to/${slug}`);
+  }
   return [...new Set(paths)];
 }
 

--- a/test/substitute-evidence.test.ts
+++ b/test/substitute-evidence.test.ts
@@ -177,11 +177,14 @@ describe("a page with no evidence of a product class", () => {
 
   it("asks no question it cannot answer", async () => {
     const { body } = await get("/alternative-to/datadog");
-    const faq = jsonLdBlocks(body).find(b => b["@type"] === "FAQPage") as { mainEntity: Array<{ name: string }> } | undefined;
-    assert.ok(faq, "the page must still ship FAQPage structured data");
+    const faq = jsonLdBlocks(body).find(b => b["@type"] === "FAQPage");
+    assert.ok(!faq, "a page with no substitute list publishes no questions about one");
+    const vendor = await get("/vendor/datadog");
+    const vendorFaq = jsonLdBlocks(vendor.body).find(b => b["@type"] === "FAQPage") as { mainEntity: Array<{ name: string }> } | undefined;
+    assert.ok(vendorFaq, "the questions we can answer about the vendor stay published on the vendor page");
     assert.ok(
-      !faq.mainEntity.some(q => q.name.startsWith("What are the best free alternatives")),
-      "the page asks for a best alternative it publishes none of",
+      !vendorFaq.mainEntity.some(q => q.name.startsWith("What are the best free alternatives")),
+      "the vendor page asks for a best alternative it publishes none of",
     );
   });
 


### PR DESCRIPTION
Refs #1209. The second half of the merge that should have been one: #1211 shipped the gate, this stops the emptied pages being submitted for indexing.

## What was live between the two

1,449 of 1,572 `/alternative-to` pages name no substitute. Each kept `<title>Best Datadog Alternatives with Free Tiers (2026)</title>` over a body naming none, a `FAQPage` asking *"What are the best free alternatives to Datadog?"*, and its entry in `sitemap-pages.xml` — 1,572 of the 1,828 URLs in that file.

## The rule

A page that cannot name a substitute emits `<meta name="robots" content="noindex,follow">` and is left out of `sitemap-pages.xml`. It keeps serving 200: vendor pages link to it, and it re-enters the index on its own as categories are classified. `follow`, so the category link in the body is crawled.

**One predicate, two surfaces.** `vendorSubstitutes` is the computation the page renders; `alternativesPagePublishesSubstitutes` is the sitemap's read of the same result. The address and the page behind it cannot disagree about whether there is a list — and the test asserts that equivalence over all 1,572 pages, not a sample.

## Copy

Verbatim from the issue comment: the `<title>`, `<h1>`, `og:description`, the body sentence with the category linked to `/category/:slug`, the `/criteria` coverage line, and `SUBTYPE_MEMBERSHIP_RULE`'s replacement sentence.

## Numbers

| | before | after |
|---|---|---|
| `sitemap-pages.xml` URLs | 1,828 | 379 |
| `/alternative-to` entries in it | 1,572 | 123 |
| pages served | 1,572 | 1,572 |

Differential sweep, main vs branch, both at `TZ=UTC`, base normalised out: **3,924 paths, 0 status changes, 1,451 moved** — the 1,449 emptied pages, `/criteria`, and `sitemap-pages.xml`. The 123 pages that still publish a list are byte-identical to main.

## Three things to look at

**1. I inverted a guard.** `test/substitute-evidence.test.ts` asserted the empty page *must still ship* `FAQPage` structured data. AC says it ships none, so the assertion is now the opposite. It also checks that `/vendor/datadog` still publishes the questions we can answer — two of the four dropped questions were about the vendor's own free tier and pricing changes, not the list, and both remain published on the vendor page, which stays indexed.

**2. Two sitemap-driven sweeps lost 1,449 pages of coverage.** `served-scripts` and `sponsored-link-targets` enumerate the site through the sitemap, so a page we serve but do not submit fell out of both. Rather than lower their floors, both now derive `/alternative-to/<slug>` from every `/vendor/<slug>` address they find, so they sweep the same routes as before this change.

**3. Three vendors carry two categories** — PostHog, Amplitude and Zoom. The sentence has one slot and names the first. Say the word if you want both named and I will take the wording from you.

Also: re-pointed two mutation anchors #1211 had left targeting code that no longer exists (`mutate-1032-phase0.sh`, `mutate-1032-phase2.sh`), and renamed `SEARCH_PAGE_ROBOTS_META` to `NOINDEX_FOLLOW_META` now that two surfaces use it.

One observation, not acted on: the agent CTA at the foot of an emptied page still reads *"When you name one of these vendors in your answer"*. It is the same block category and best-of pages carry, so I left it alone.

## Verification

- **2,869 tests, 0 failures**; `tsc` clean; `validate-data` clean; 627 mutation targets resolve.
- **10 of 10 mutations killed** (`scripts/mutate-1209-indexing.sh`) — including the sitemap reading a different set from the page, the empty page keeping its questions, its title, its heading, and the link out.
- **Every new test run against a main build first.** Five fail there, which is the new behaviour. Five pass, which are regression guards. One passed on main for the wrong reason — it found the category link in the situation box rather than in the sentence — and now scopes to the paragraph, where it fails on main and kills its mutation.
- Full-surface sweep of all 1,572 pages: `in sitemap` ⟺ `page names a substitute` ⟺ `no noindex`, 0 violations.
- Real MCP `initialize` → `tools/call`: `search_deals({vendor: "Datadog"})` returns `alternatives: []`, `relatedVendors: []`.
- Screenshots of an emptied page and a listed one.
