### PR TITLE
Charge a demerit for a pricing page we have confirmed is dead (#1201)

### DIFF
--- a/scripts/mutate-1201.sh
+++ b/scripts/mutate-1201.sh
@@ -1,0 +1,207 @@
+#!/usr/bin/env bash
+set -u
+
+REPO="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$REPO" || exit 1
+
+RANKING="src/ranking.ts"
+DATA="src/data.ts"
+SERVE="src/serve.ts"
+STACKS="src/stacks.ts"
+FILES=("$RANKING" "$DATA" "$SERVE" "$STACKS")
+BACKUP_DIR="$(mktemp -d)"
+for f in "${FILES[@]}"; do
+  cp "$f" "$BACKUP_DIR/$(basename "$f")"
+done
+
+restore() {
+  for f in "${FILES[@]}"; do
+    cp "$BACKUP_DIR/$(basename "$f")" "$f"
+  done
+  npx tsc > /dev/null 2>&1
+}
+trap 'restore' EXIT
+
+killed=0
+survived=0
+TESTS="test/link-unreachable-demerit.test.ts test/ranked-surfaces.test.ts test/ranking.test.ts"
+
+py() { python3 - "$@"; }
+
+changed_any() {
+  for f in "${FILES[@]}"; do
+    if ! diff -q "$BACKUP_DIR/$(basename "$f")" "$f" > /dev/null; then
+      return 0
+    fi
+  done
+  return 1
+}
+
+run_mutation() {
+  local name="$1"
+  shift
+  echo "=== $name"
+  for f in "${FILES[@]}"; do cp "$BACKUP_DIR/$(basename "$f")" "$f"; done
+  "$@"
+  if ! changed_any; then
+    echo "    NOT APPLIED: the mutation changed no file, so it proves nothing"
+    survived=$((survived + 1))
+    return
+  fi
+  if ! npx tsc > /tmp/mutate-1201-build.log 2>&1; then
+    echo "    NOT APPLIED: the mutation does not compile"
+    survived=$((survived + 1))
+    return
+  fi
+  if timeout 900 node --test --test-concurrency 1 $TESTS > /tmp/mutate-1201-test.log 2>&1; then
+    echo "    SURVIVED"
+    survived=$((survived + 1))
+  else
+    echo "    KILLED: $(grep -c '✖ ' /tmp/mutate-1201-test.log) failing assertion(s)"
+    grep '✖ ' /tmp/mutate-1201-test.log | head -3
+    killed=$((killed + 1))
+  fi
+}
+
+m_the_demerit_never_fires() {
+  py <<'PY'
+p = "src/ranking.ts"
+s = open(p).read()
+s = s.replace("  const linkDemerit = unreachableLinkDemerit(offer, lookUpLink(offer.url, Date.parse(date)));",
+              "  const linkDemerit = unreachableLinkDemerit(offer, null);")
+open(p, "w").write(s)
+PY
+}
+
+m_a_dead_link_costs_one_point() {
+  py <<'PY'
+p = "src/ranking.ts"
+s = open(p).read()
+s = s.replace("    points: unreachable.terminal ? 3 : 2,", "    points: 1,")
+open(p, "w").write(s)
+PY
+}
+
+m_a_dead_link_costs_nothing() {
+  py <<'PY'
+p = "src/ranking.ts"
+s = open(p).read()
+s = s.replace("    points: unreachable.terminal ? 3 : 2,", "    points: 0,")
+open(p, "w").write(s)
+PY
+}
+
+m_a_permanently_gone_page_costs_the_same_as_any_other() {
+  py <<'PY'
+p = "src/ranking.ts"
+s = open(p).read()
+s = s.replace("    code: unreachable.terminal ? \"link_gone\" : \"link_unreachable\",", "    code: \"link_unreachable\",")
+s = s.replace("    points: unreachable.terminal ? 3 : 2,", "    points: 2,")
+open(p, "w").write(s)
+PY
+}
+
+m_the_record_pays_twice_for_one_dead_link() {
+  py <<'PY'
+p = "src/ranking.ts"
+s = open(p).read()
+s = s.replace("  const stale = linkDemerit ? null : staleVerificationDemerit(offer, date, verificationLedger);",
+              "  const stale = staleVerificationDemerit(offer, date, verificationLedger);")
+open(p, "w").write(s)
+PY
+}
+
+m_the_demerit_is_labelled_a_limit_of_ours() {
+  py <<'PY'
+p = "src/ranking.ts"
+s = open(p).read()
+s = s.replace("    date: unreachable.checked,\n    reason: withheldLevelSentence(",
+              "    date: unreachable.checked,\n    about_us: true,\n    reason: withheldLevelSentence(")
+open(p, "w").write(s)
+PY
+}
+
+m_the_ranking_reads_no_link_health_by_default() {
+  py <<'PY'
+p = "src/ranking.ts"
+s = open(p).read()
+s = s.replace("  const lookUpLink = opts.linkHealth ?? unreachableNoticeForUrl;",
+              "  const lookUpLink = opts.linkHealth ?? (() => null);")
+open(p, "w").write(s)
+PY
+}
+
+m_the_demerit_reason_is_written_a_second_time() {
+  py <<'PY'
+p = "src/ranking.ts"
+s = open(p).read()
+s = s.replace("    reason: withheldLevelSentence(\"link_unreachable\", offer.vendor, since),",
+              "    reason: `${offer.vendor} could not be checked${since}.`,")
+open(p, "w").write(s)
+PY
+}
+
+m_the_criteria_page_states_no_trigger() {
+  py <<'PY'
+p = "src/ranking.ts"
+s = open(p).read()
+s = s.replace("    code: \"link_unreachable\",\n    points: 2,\n    trigger:", "    code: \"link_unreachable\",\n    points: 1,\n    trigger:")
+open(p, "w").write(s)
+PY
+}
+
+m_the_category_listing_drops_the_notice() {
+  py <<'PY'
+p = "src/serve.ts"
+s = open(p).read()
+s = s.replace("${escHtmlServer(o.description)}${listingUnreachableNoticeHtml(o)}", "${escHtmlServer(o.description)}")
+open(p, "w").write(s)
+PY
+}
+
+m_the_detail_endpoint_drops_the_field() {
+  py <<'PY'
+p = "src/data.ts"
+s = open(p).read()
+s = s.replace("  return { ...offer, link_unreachable: unreachableNoticeForUrl(offer.url) };",
+              "  return { ...offer, link_unreachable: null };")
+open(p, "w").write(s)
+PY
+}
+
+m_a_favourable_stability_class_is_published_anyway() {
+  py <<'PY'
+p = "src/data.ts"
+s = open(p).read()
+s = s.replace("  if (!linkUnreachable) return stability;", "  if (!linkUnreachable) return stability;\n  return stability;")
+open(p, "w").write(s)
+PY
+}
+
+m_an_adverse_stability_class_is_withheld_too() {
+  py <<'PY'
+p = "src/data.ts"
+s = open(p).read()
+s = s.replace("  return FAVOURABLE_STABILITY_CLASSES.has(stability) ? null : stability;", "  return null;")
+open(p, "w").write(s)
+PY
+}
+
+run_mutation "the demerit never fires" m_the_demerit_never_fires
+run_mutation "a dead link costs one point" m_a_dead_link_costs_one_point
+run_mutation "a dead link costs nothing" m_a_dead_link_costs_nothing
+run_mutation "a permanently gone page costs the same as any other" m_a_permanently_gone_page_costs_the_same_as_any_other
+run_mutation "the record pays twice for one dead link" m_the_record_pays_twice_for_one_dead_link
+run_mutation "the demerit is labelled a limit of ours" m_the_demerit_is_labelled_a_limit_of_ours
+run_mutation "the ranking reads no link health by default" m_the_ranking_reads_no_link_health_by_default
+run_mutation "the demerit reason is written a second time" m_the_demerit_reason_is_written_a_second_time
+run_mutation "the published weight disagrees with the charged one" m_the_criteria_page_states_no_trigger
+run_mutation "the category listing drops the notice" m_the_category_listing_drops_the_notice
+run_mutation "the detail endpoint drops the field" m_the_detail_endpoint_drops_the_field
+run_mutation "a favourable stability class is published anyway" m_a_favourable_stability_class_is_published_anyway
+run_mutation "an adverse stability class is withheld too" m_an_adverse_stability_class_is_withheld_too
+
+restore
+echo
+echo "killed: $killed   survived: $survived"
+[ "$survived" -eq 0 ]

--- a/src/data.ts
+++ b/src/data.ts
@@ -77,10 +77,16 @@ export function getCategories(): { name: string; count: number }[] {
     .sort((a, b) => a.name.localeCompare(b.name));
 }
 
+export type OfferWithLinkHealth = Offer & { link_unreachable: LinkUnreachable | null };
+
+export function withLinkHealth<T extends Offer>(offer: T): T & { link_unreachable: LinkUnreachable | null } {
+  return { ...offer, link_unreachable: unreachableNoticeForUrl(offer.url) };
+}
+
 export function getOfferDetails(
   vendorName: string,
   includeAlternatives: boolean = false
-): { offer: Offer & { relatedVendors: string[]; alternatives?: Offer[]; tie_break: TieBreak } } | { error: string; suggestions: string[] } {
+): { offer: OfferWithLinkHealth & { relatedVendors: string[]; alternatives?: OfferWithLinkHealth[]; tie_break: TieBreak } } | { error: string; suggestions: string[] } {
   const offers = loadOffers();
   const lowerName = vendorName.toLowerCase();
   const match = offers.find((o) => o.vendor.toLowerCase() === lowerName);
@@ -92,13 +98,13 @@ export function getOfferDetails(
     );
     const sameCategoryOffers = relatedRanking.entries.slice(0, 5).map((e) => e.offer);
     const relatedVendors = sameCategoryOffers.map((o) => o.vendor);
-    const result: Offer & { relatedVendors: string[]; alternatives?: Offer[]; tie_break: TieBreak } = {
-      ...match,
+    const result: OfferWithLinkHealth & { relatedVendors: string[]; alternatives?: OfferWithLinkHealth[]; tie_break: TieBreak } = {
+      ...withLinkHealth(match),
       relatedVendors,
       tie_break: relatedRanking.tie_break,
     };
     if (includeAlternatives) {
-      result.alternatives = sameCategoryOffers.map(o => stripReferrerValue(o));
+      result.alternatives = sameCategoryOffers.map(o => stripReferrerValue(withLinkHealth(o)));
     }
     return { offer: stripReferrerValue(result) };
   }
@@ -309,6 +315,24 @@ export function classifyStability(vendorChanges: DealChange[], nowMs: number = D
   return "stable";
 }
 
+const FAVOURABLE_STABILITY_CLASSES = new Set<StabilityClass>(["stable", "improving"]);
+
+export function withheldStability(
+  linkUnreachable: LinkUnreachable | null,
+  stability: StabilityClass,
+): StabilityClass | null {
+  if (!linkUnreachable) return stability;
+  return FAVOURABLE_STABILITY_CLASSES.has(stability) ? null : stability;
+}
+
+export function publishedStabilityFor(vendorName: string): StabilityClass | null {
+  const key = vendorName.toLowerCase();
+  const stability = classifyStability(loadDealChanges().filter((c) => c.vendor.toLowerCase() === key));
+  const offer = loadOffers().find((o) => o.vendor.toLowerCase() === key);
+  if (!offer) return stability;
+  return withheldStability(unreachableNoticeForUrl(offer.url), stability);
+}
+
 export function getStabilityMap(): Map<string, StabilityClass> {
   const changes = loadDealChanges();
   const vendorChangesMap = new Map<string, DealChange[]>();
@@ -375,7 +399,10 @@ export function enrichOffers(offers: Offer[]): EnrichedOffer[] {
       ? { date: assessment.cause.date, date_source: assessment.cause.date_source, change_type: assessment.cause.change_type, summary: assessment.cause.summary }
       : null;
 
-    const stability = classifyStability(vendorAllChangesList.get(key) ?? []);
+    const stability = withheldStability(
+      link_unreachable,
+      classifyStability(vendorAllChangesList.get(key) ?? []),
+    );
 
     const days_since_verified = Math.floor(
       (now.getTime() - new Date(offer.verifiedDate).getTime()) / (24 * 60 * 60 * 1000)

--- a/src/ranking.ts
+++ b/src/ranking.ts
@@ -1,5 +1,7 @@
 import { createHash } from "node:crypto";
-import type { ChangeDateSource, DealChange, Offer } from "./types.js";
+import { LINK_GRACE_DAYS, unreachableNoticeForUrl } from "./link-health.js";
+import { withheldLevelSentence } from "./source-check.js";
+import type { ChangeDateSource, DealChange, LinkUnreachable, Offer } from "./types.js";
 
 export const CRITERIA_PATH = "/criteria";
 
@@ -78,6 +80,8 @@ export const GATE_TABLE: { code: GateCode; description: string }[] = [
 
 export type DemeritCode =
   | "free_tier_withdrawn"
+  | "link_gone"
+  | "link_unreachable"
   | "time_limited_offer"
   | "stale_verification"
   | "expiring_soon";
@@ -98,10 +102,22 @@ export const DEMERIT_TABLE: { code: DemeritCode; points: number; trigger: string
       `A recorded free-tier removal, open-source licence change or product deprecation within the last ${ADVERSE_CHANGE_WINDOW_DAYS} days.`,
   },
   {
+    code: "link_gone",
+    points: 3,
+    trigger:
+      "The vendor's own server answers 410 for the pricing page we cite, stating the page is permanently gone. Recorded on the first such check, with no grace period.",
+  },
+  {
     code: "time_limited_offer",
     points: 2,
     trigger:
       "The stated tier is a credit grant, trial, scholarship, beta, preview or sandbox allowance — the free part runs out.",
+  },
+  {
+    code: "link_unreachable",
+    points: 2,
+    trigger:
+      `The pricing page we cite did not resolve on our check — a 404 answered by a full request, or a hostname with no address — and has still not resolved ${LINK_GRACE_DAYS} days after the last date it was reachable. Being refused (403, 429, 5xx, timeout) is evidence about our checker and never produces this.`,
   },
   {
     code: "stale_verification",
@@ -213,11 +229,14 @@ export function utcDate(now: Date = new Date()): string {
   return now.toISOString().slice(0, 10);
 }
 
+export type LinkHealthLookup = (url: string, nowMs?: number) => LinkUnreachable | null;
+
 export interface RankOptions {
   queryKey: string;
   changes: DealChange[];
   date?: string;
   verificationLedger?: VerificationLedger;
+  linkHealth?: LinkHealthLookup;
 }
 
 function daysBetween(fromIso: string, toIso: string): number {
@@ -296,11 +315,31 @@ function staleVerificationDemerit(
   };
 }
 
+export function unreachableLinkDemerit(
+  offer: Offer,
+  unreachable: LinkUnreachable | null,
+): Demerit | null {
+  if (!unreachable) return null;
+  const since = unreachable.last_reachable ? ` since ${unreachable.last_reachable}` : "";
+  return {
+    code: unreachable.terminal ? "link_gone" : "link_unreachable",
+    points: unreachable.terminal ? 3 : 2,
+    date: unreachable.checked,
+    reason: withheldLevelSentence("link_unreachable", offer.vendor, since),
+  };
+}
+
 export function evaluate<T extends Offer>(
   offer: T,
-  opts: { date: string; changesForVendor: DealChange[]; verificationLedger?: VerificationLedger },
+  opts: {
+    date: string;
+    changesForVendor: DealChange[];
+    verificationLedger?: VerificationLedger;
+    linkHealth?: LinkHealthLookup;
+  },
 ): RankedEntry<T> {
   const { date, changesForVendor, verificationLedger } = opts;
+  const lookUpLink = opts.linkHealth ?? unreachableNoticeForUrl;
   const demerits: Demerit[] = [];
   const disclosures: Disclosure[] = [];
 
@@ -334,6 +373,9 @@ export function evaluate<T extends Offer>(
     });
   }
 
+  const linkDemerit = unreachableLinkDemerit(offer, lookUpLink(offer.url, Date.parse(date)));
+  if (linkDemerit) demerits.push(linkDemerit);
+
   const tierClass = classifyTier(offer.tier);
   if (tierClass.class === "time_limited") {
     demerits.push({
@@ -343,7 +385,7 @@ export function evaluate<T extends Offer>(
     });
   }
 
-  const stale = staleVerificationDemerit(offer, date, verificationLedger);
+  const stale = linkDemerit ? null : staleVerificationDemerit(offer, date, verificationLedger);
   if (stale) demerits.push(stale);
 
   if (offer.expires_date && offer.expires_date >= date) {
@@ -390,6 +432,7 @@ export function rankOffers<T extends Offer>(candidates: T[], opts: RankOptions):
         date,
         changesForVendor: byVendor.get(offer.vendor.toLowerCase()) ?? [],
         verificationLedger: opts.verificationLedger,
+        linkHealth: opts.linkHealth,
       }),
     );
   }

--- a/src/serve.ts
+++ b/src/serve.ts
@@ -15,7 +15,7 @@ import { recordApiHit, recordSessionConnect, recordSessionDisconnect, recordLand
 import { buildDailyRollup, readRollups, coverageOf, ROLLUP_DATE_PATTERN } from "./analytics-rollup.js";
 import { configureVendorSeries, recordVendorRequest, flushVendorSeries, readVendorSeries, vendorSeriesGauge, vendorExportAuthorized, isSeriesDate, seriesDateRange, VENDOR_SERIES_PATH, VENDOR_SERIES_RETENTION_DAYS, VENDOR_SERIES_NOTES } from "./vendor-series.js";
 import { openapiSpec } from "./openapi.js";
-import { LINK_GRACE_DAYS } from "./link-health.js";
+import { LINK_GRACE_DAYS, unreachableNoticeForUrl } from "./link-health.js";
 import { levelWithheldReason, withheldLevelClause, withheldLevelSentence } from "./source-check.js";
 import { buildComparisonMap, comparisonSlug } from "./comparison-pairs.js";
 import { stabilityFaqAnswer, stabilityVerdictClause, type ComparisonSide, type StabilityRating } from "./comparison-verdict.js";
@@ -1061,6 +1061,13 @@ const relatedCategoriesMap: Record<string, string[]> = {
   "API Gateway": ["API Development", "Cloud Hosting", "Security"],
 };
 
+function listingUnreachableNoticeHtml(offer: Offer): string {
+  const unreachable = unreachableNoticeForUrl(offer.url);
+  if (!unreachable) return "";
+  const since = unreachable.last_reachable ? ` since ${unreachable.last_reachable}` : "";
+  return `<span class="listing-link-unreachable" style="display:block;margin-top:.3rem;color:#f85149">${escHtmlServer(withheldLevelSentence("link_unreachable", offer.vendor, since))}</span>`;
+}
+
 function buildCategoryPage(slug: string): string | null {
   const categoryName = categorySlugMap.get(slug);
   if (!categoryName) return null;
@@ -1073,7 +1080,7 @@ function buildCategoryPage(slug: string): string | null {
   const offersHtml = catOffers.map((o) => `        <tr>
           <td style="font-weight:600;color:var(--text);white-space:nowrap"><a href="/vendor/${toSlug(o.vendor)}" style="color:var(--text)">${escHtmlServer(o.vendor)}</a></td>
           <td style="font-family:var(--mono);color:var(--accent);white-space:nowrap">${escHtmlServer(o.tier)}</td>
-          <td style="color:var(--text-muted)">${escHtmlServer(o.description)}</td>
+          <td style="color:var(--text-muted)">${escHtmlServer(o.description)}${listingUnreachableNoticeHtml(o)}</td>
           <td style="font-family:var(--mono);color:var(--text-dim);white-space:nowrap">${escHtmlServer(o.verifiedDate)}</td>
         </tr>`).join("\n");
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -3,7 +3,7 @@ import { join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 import { McpServer, ResourceTemplate } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
-import { getCategories, getDealChanges, getPersonalizedChanges, getNewOffers, getNewestDeals, getOfferDetails, searchOffers, enrichOffers, compareServices, checkVendorRisk, auditStack, getExpiringDeals, getWeeklyDigest, loadOffers, loadDealChanges, classifyStability, getStabilityMap, getVendorReferral, sanitizeQuery } from "./data.js";
+import { getCategories, getDealChanges, getPersonalizedChanges, getNewOffers, getNewestDeals, getOfferDetails, searchOffers, enrichOffers, compareServices, checkVendorRisk, auditStack, getExpiringDeals, getWeeklyDigest, loadOffers, loadDealChanges, classifyStability, getStabilityMap, publishedStabilityFor, getVendorReferral, sanitizeQuery } from "./data.js";
 import { toSlug, vendorSlugMap, resolveVendorSlug } from "./vendor-slug.js";
 import { recordToolCall, logRequest, recordSearchQuery } from "./stats.js";
 import { registerAgent, validateVestauthUrl, getAgentByApiKeyHash, hashApiKey, updateAgentX402Address } from "./agents.js";
@@ -331,10 +331,9 @@ export function createServer(getSessionId?: () => string | undefined, getClientN
               content: [{ type: "text" as const, text: result.error }],
             };
           }
-          const stabMap = getStabilityMap();
           const enrichedResult = {
             ...result.result,
-            stability: stabMap.get(result.result.vendor.toLowerCase()) ?? "stable",
+            stability: publishedStabilityFor(result.result.vendor),
             referral_code: getBestReferralCode(result.result.vendor),
           };
           logRequest({ ts: new Date().toISOString(), type: "mcp", endpoint: "compare_vendors", params: { vendors }, result_count: 1, session_id: getSessionId?.() });
@@ -355,14 +354,13 @@ export function createServer(getSessionId?: () => string | undefined, getClientN
 
           let result: any = comparison.comparison;
 
-          const stabMap = getStabilityMap();
           const riskA = checkVendorRisk(vendors[0]);
           const riskB = checkVendorRisk(vendors[1]);
           result = {
             ...result,
             stability: {
-              [vendors[0]]: stabMap.get(comparison.comparison.vendor_a.vendor.toLowerCase()) ?? "stable",
-              [vendors[1]]: stabMap.get(comparison.comparison.vendor_b.vendor.toLowerCase()) ?? "stable",
+              [vendors[0]]: publishedStabilityFor(comparison.comparison.vendor_a.vendor),
+              [vendors[1]]: publishedStabilityFor(comparison.comparison.vendor_b.vendor),
             },
             risk_level: {
               [vendors[0]]: "result" in riskA ? riskA.result.risk_level : "stable",

--- a/src/server.ts
+++ b/src/server.ts
@@ -3,7 +3,7 @@ import { join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 import { McpServer, ResourceTemplate } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
-import { getCategories, getDealChanges, getPersonalizedChanges, getNewOffers, getNewestDeals, getOfferDetails, searchOffers, enrichOffers, compareServices, checkVendorRisk, auditStack, getExpiringDeals, getWeeklyDigest, loadOffers, loadDealChanges, classifyStability, getStabilityMap, publishedStabilityFor, getVendorReferral, sanitizeQuery } from "./data.js";
+import { getCategories, getDealChanges, getPersonalizedChanges, getNewOffers, getNewestDeals, getOfferDetails, searchOffers, enrichOffers, compareServices, checkVendorRisk, auditStack, getExpiringDeals, getWeeklyDigest, loadOffers, loadDealChanges, classifyStability, publishedStabilityFor, getVendorReferral, sanitizeQuery } from "./data.js";
 import { toSlug, vendorSlugMap, resolveVendorSlug } from "./vendor-slug.js";
 import { recordToolCall, logRequest, recordSearchQuery } from "./stats.js";
 import { registerAgent, validateVestauthUrl, getAgentByApiKeyHash, hashApiKey, updateAgentX402Address } from "./agents.js";

--- a/src/stacks.ts
+++ b/src/stacks.ts
@@ -1,6 +1,7 @@
-import { searchOffers, loadDealChanges, vendorRiskLevel, classifyStability } from "./data.js";
+import { searchOffers, loadDealChanges, vendorRiskLevel, classifyStability, withheldStability } from "./data.js";
 import { rankOffers, utcDate, CRITERIA_PATH, DEMOTE_ONLY_POLICY, NOT_MODELLED_NOTICE } from "./ranking.js";
 import type { Demerit, Disclosure, TieBreak } from "./ranking.js";
+import { unreachableNoticeForUrl } from "./link-health.js";
 import { verificationLedger } from "./verification-state.js";
 import type { Offer, StabilityClass, DealChange } from "./types.js";
 import { partitionRoleCandidates, MEMBERSHIP_GATE_RULES } from "./product-role.js";
@@ -12,7 +13,7 @@ export interface StackCandidate {
   url: string;
   verified_date: string;
   risk_level: "stable" | "caution" | "risky";
-  stability: StabilityClass;
+  stability: StabilityClass | null;
   demerits: Demerit[];
   disclosures: Disclosure[];
 }
@@ -221,7 +222,7 @@ function toCandidate(
     url: offer.url,
     verified_date: offer.verifiedDate,
     risk_level: vendorRiskLevel(vendorChanges),
-    stability: classifyStability(vendorChanges),
+    stability: withheldStability(unreachableNoticeForUrl(offer.url), classifyStability(vendorChanges)),
     demerits,
     disclosures,
   };

--- a/src/types.ts
+++ b/src/types.ts
@@ -108,7 +108,7 @@ export interface EnrichedOffer extends Offer {
   expires_soon: string | null;
   risk_level: RiskLevel | null;
   risk_cause: RiskCause | null;
-  stability: StabilityClass;
+  stability: StabilityClass | null;
   days_since_verified: number;
   link_unreachable: LinkUnreachable | null;
 }

--- a/test/link-unreachable-demerit.test.ts
+++ b/test/link-unreachable-demerit.test.ts
@@ -1,0 +1,305 @@
+import { describe, it, before, after } from "node:test";
+import assert from "node:assert";
+import { spawn, type ChildProcess } from "node:child_process";
+import { readFileSync, writeFileSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const { rankOffers, evaluate, DEMERIT_TABLE } = await import("../dist/ranking.js");
+const { withheldStability } = await import("../dist/data.js");
+
+type Offer = import("../src/types.ts").Offer;
+type LinkUnreachable = import("../src/types.ts").LinkUnreachable;
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO = path.join(__dirname, "..");
+
+const TODAY = "2026-08-25";
+
+function offer(over: Partial<Offer> = {}): Offer {
+  return {
+    vendor: "Acme",
+    category: "Databases",
+    description: "A free tier.",
+    tier: "Free",
+    url: "https://example.com/pricing",
+    tags: [],
+    verifiedDate: "2026-08-20",
+    ...over,
+  };
+}
+
+function notice(over: Partial<LinkUnreachable> = {}): LinkUnreachable {
+  return { last_reachable: "2026-02-01", checked: TODAY, terminal: false, ...over };
+}
+
+function lookupFor(map: Record<string, LinkUnreachable>) {
+  return (url: string) => map[url] ?? null;
+}
+
+const noLinks = lookupFor({});
+
+describe("a confirmed dead pricing page is a fact about the vendor", () => {
+  it("costs two points, and is not labelled as a limit of ours", () => {
+    const e = evaluate(offer(), {
+      date: TODAY,
+      changesForVendor: [],
+      linkHealth: lookupFor({ "https://example.com/pricing": notice() }),
+    });
+    assert.deepStrictEqual(e.demerits.map((d) => d.code), ["link_unreachable"]);
+    assert.strictEqual(e.demerit_total, 2);
+    assert.notStrictEqual(e.demerits[0].about_us, true);
+  });
+
+  it("outranks the one-point demerit that measures our own confidence", () => {
+    const table = new Map(DEMERIT_TABLE.map((d: { code: string; points: number }) => [d.code, d.points]));
+    assert.strictEqual(table.get("link_unreachable"), 2);
+    assert.strictEqual(table.get("link_gone"), 3);
+    assert.ok(table.get("link_unreachable")! > table.get("stale_verification")!);
+    assert.ok(table.get("link_gone")! >= table.get("free_tier_withdrawn")!);
+  });
+
+  it("states its trigger on the published table, as the other demerits do", () => {
+    for (const code of ["link_unreachable", "link_gone"]) {
+      const row = DEMERIT_TABLE.find((d: { code: string }) => d.code === code);
+      assert.ok(row, `${code} is missing from the published table`);
+      assert.ok(row!.trigger.length > 40, `${code} publishes no trigger`);
+    }
+  });
+
+  it("names the date the page was last reachable", () => {
+    const e = evaluate(offer({ vendor: "Datree" }), {
+      date: TODAY,
+      changesForVendor: [],
+      linkHealth: lookupFor({ "https://example.com/pricing": notice({ last_reachable: "2026-07-10" }) }),
+    });
+    assert.strictEqual(e.demerits[0].reason, "Datree's pricing page has not resolved for us since 2026-07-10.");
+    assert.strictEqual(e.demerits[0].date, TODAY);
+  });
+
+  it("carries no date claim when we have never seen the page resolve", () => {
+    const e = evaluate(offer({ vendor: "Datree" }), {
+      date: TODAY,
+      changesForVendor: [],
+      linkHealth: lookupFor({ "https://example.com/pricing": notice({ last_reachable: null }) }),
+    });
+    assert.strictEqual(e.demerits[0].reason, "Datree's pricing page has not resolved for us.");
+  });
+});
+
+describe("a page the vendor's own server says is permanently gone", () => {
+  it("costs three points under its own code", () => {
+    const e = evaluate(offer(), {
+      date: TODAY,
+      changesForVendor: [],
+      linkHealth: lookupFor({ "https://example.com/pricing": notice({ terminal: true }) }),
+    });
+    assert.deepStrictEqual(e.demerits.map((d) => d.code), ["link_gone"]);
+    assert.strictEqual(e.demerit_total, 3);
+  });
+});
+
+describe("one dead link is charged once", () => {
+  it("scores two, not three, when the record is also past the staleness window", () => {
+    const stale = offer({ verifiedDate: "2026-01-05" });
+    const withoutLink = evaluate(stale, { date: TODAY, changesForVendor: [], linkHealth: noLinks });
+    assert.deepStrictEqual(withoutLink.demerits.map((d) => d.code), ["stale_verification"]);
+
+    const withLink = evaluate(stale, {
+      date: TODAY,
+      changesForVendor: [],
+      linkHealth: lookupFor({ "https://example.com/pricing": notice() }),
+    });
+    assert.deepStrictEqual(withLink.demerits.map((d) => d.code), ["link_unreachable"]);
+    assert.strictEqual(withLink.demerit_total, 2);
+  });
+
+  it("still charges a recorded free-tier removal alongside it — a different fact", () => {
+    const e = evaluate(offer({ tier: "Free Credits" }), {
+      date: TODAY,
+      changesForVendor: [],
+      linkHealth: lookupFor({ "https://example.com/pricing": notice() }),
+    });
+    assert.deepStrictEqual(e.demerits.map((d) => d.code), ["link_unreachable", "time_limited_offer"]);
+    assert.strictEqual(e.demerit_total, 4);
+  });
+});
+
+describe("being refused is evidence about our checker", () => {
+  it("leaves a record in the qualified band, exactly as before", () => {
+    const result = rankOffers([offer()], {
+      queryKey: "refused",
+      changes: [],
+      date: TODAY,
+      linkHealth: noLinks,
+    });
+    assert.strictEqual(result.qualified.length, 1);
+    assert.strictEqual(result.qualified[0].demerit_total, 0);
+  });
+});
+
+describe("a record whose pricing page does not resolve", () => {
+  it("cannot be in the qualified band", () => {
+    const candidates = [offer({ vendor: "Reachable", url: "https://example.com/live" }), offer({ vendor: "Dead" })];
+    const result = rankOffers(candidates, {
+      queryKey: "qualified-band",
+      changes: [],
+      date: TODAY,
+      linkHealth: lookupFor({ "https://example.com/pricing": notice() }),
+    });
+    assert.deepStrictEqual(result.qualified.map((e) => e.offer.vendor), ["Reachable"]);
+    assert.deepStrictEqual(result.demoted.map((e) => e.offer.vendor), ["Dead"]);
+  });
+
+  it("is out of the qualified band of its own category across the whole index", () => {
+    const offers: Offer[] = JSON.parse(readFileSync(path.join(REPO, "data", "index.json"), "utf-8")).offers;
+    const changes = JSON.parse(readFileSync(path.join(REPO, "data", "deal_changes.json"), "utf-8")).changes;
+    const health = JSON.parse(readFileSync(path.join(REPO, "data", "link_health.json"), "utf-8"));
+    const dead = new Set<string>(
+      health.links.filter((l: { outcome: string }) => l.outcome === "unreachable").map((l: { url: string }) => l.url),
+    );
+    const categories = [...new Set(offers.filter((o) => dead.has(o.url)).map((o) => o.category))];
+
+    const offending: string[] = [];
+    for (const category of categories) {
+      const result = rankOffers(offers.filter((o) => o.category === category), {
+        queryKey: `best-of:${category}`,
+        changes,
+        date: "2026-09-01",
+      });
+      for (const entry of result.qualified) {
+        if (dead.has(entry.offer.url)) offending.push(`${entry.offer.vendor} (${category})`);
+      }
+    }
+    assert.deepStrictEqual(offending, [], "every record with a dead pricing page must carry a demerit");
+    assert.ok(categories.length > 0, "the index holds no dead link, so this assertion has no subject");
+  });
+});
+
+describe("stability is withheld the way the risk level already is", () => {
+  it("withholds a favourable class when the pricing page does not resolve", () => {
+    assert.strictEqual(withheldStability(notice(), "stable"), null);
+    assert.strictEqual(withheldStability(notice(), "improving"), null);
+  });
+
+  it("publishes an adverse class, which the dead link does not soften", () => {
+    assert.strictEqual(withheldStability(notice(), "watch"), "watch");
+    assert.strictEqual(withheldStability(notice(), "volatile"), "volatile");
+  });
+
+  it("leaves a reachable record alone", () => {
+    assert.strictEqual(withheldStability(null, "stable"), "stable");
+    assert.strictEqual(withheldStability(null, "improving"), "improving");
+  });
+});
+
+type FixtureOffer = { vendor: string; url: string; category: string };
+
+function slugOf(vendor: string): string {
+  return vendor.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "");
+}
+
+const indexOffers: FixtureOffer[] = JSON.parse(
+  readFileSync(path.join(REPO, "data", "index.json"), "utf-8"),
+).offers;
+const changedVendors = new Set<string>(
+  JSON.parse(readFileSync(path.join(REPO, "data", "deal_changes.json"), "utf-8")).changes.map(
+    (c: { vendor: string }) => c.vendor.toLowerCase(),
+  ),
+);
+const rowsPerVendor = new Map<string, number>();
+for (const o of indexOffers) rowsPerVendor.set(o.vendor, (rowsPerVendor.get(o.vendor) ?? 0) + 1);
+const rowsPerUrl = new Map<string, number>();
+for (const o of indexOffers) rowsPerUrl.set(o.url, (rowsPerUrl.get(o.url) ?? 0) + 1);
+
+const eligible = indexOffers.filter(
+  (o) =>
+    !changedVendors.has(o.vendor.toLowerCase()) &&
+    slugOf(o.vendor).length > 2 &&
+    o.url.startsWith("http") &&
+    rowsPerVendor.get(o.vendor) === 1 &&
+    rowsPerUrl.get(o.url) === 1,
+);
+const deadSubject = eligible[0];
+const liveSubject = eligible.find((o) => o.category === deadSubject.category && o.vendor !== deadSubject.vendor)!;
+
+let fixtureDir = "";
+let serverPort = 0;
+let proc: ChildProcess | null = null;
+
+function startServer(fixturePath: string): Promise<ChildProcess> {
+  return new Promise((resolve, reject) => {
+    const child = spawn("node", [path.join(REPO, "dist", "serve.js")], {
+      stdio: ["pipe", "pipe", "pipe"],
+      env: { ...process.env, PORT: "0", BASE_URL: "http://localhost", AGENTDEALS_LINK_HEALTH_PATH: fixturePath },
+    });
+    const timeout = setTimeout(() => { child.kill(); reject(new Error("Server startup timeout")); }, 30000);
+    child.stderr!.on("data", (data: Buffer) => {
+      const m = data.toString().match(/running on http:\/\/localhost:(\d+)/);
+      if (m) { serverPort = parseInt(m[1], 10); clearTimeout(timeout); resolve(child); }
+    });
+    child.on("error", (err) => { clearTimeout(timeout); reject(err); });
+  });
+}
+
+const get = async (p: string) => {
+  const res = await fetch(`http://localhost:${serverPort}${p}`);
+  return { status: res.status, body: await res.text() };
+};
+
+before(async () => {
+  assert.ok(deadSubject && liveSubject, "the fixture needs two vendors in one category carrying no change records");
+  fixtureDir = mkdtempSync(path.join(tmpdir(), "unreachable-demerit-"));
+  const fixturePath = path.join(fixtureDir, "link_health.json");
+  writeFileSync(fixturePath, JSON.stringify({
+    generated_at: "2026-08-25",
+    links: [
+      { url: deadSubject.url, checked: "2026-08-25", outcome: "unreachable", detail: "GET 404", terminal: false, last_reachable: "2026-01-04", consecutive_unreachable: 6 },
+    ],
+  }, null, 2));
+  proc = await startServer(fixturePath);
+});
+
+after(() => {
+  if (proc) proc.kill();
+  if (fixtureDir) rmSync(fixtureDir, { recursive: true, force: true });
+});
+
+describe("the listing surfaces that used to drop the fact", () => {
+  it("renders it on the category page, in the same words the vendor page uses", async () => {
+    const { status, body } = await get(`/category/${slugOf(deadSubject.category)}`);
+    assert.strictEqual(status, 200);
+    assert.ok(
+      body.includes(`${deadSubject.vendor}&#039;s pricing page has not resolved for us since 2026-01-04.`)
+        || body.includes(`${deadSubject.vendor}'s pricing page has not resolved for us since 2026-01-04.`),
+      "the category listing names no dead link",
+    );
+    assert.ok(!body.includes(`${liveSubject.vendor}'s pricing page has not resolved`), "a reachable row must be untouched");
+  });
+
+  it("publishes both codes on the criteria page with their weights", async () => {
+    const { status, body } = await get("/criteria");
+    assert.strictEqual(status, 200);
+    assert.match(body, /<code>link_unreachable<\/code><\/td><td[^>]*>&minus;2</);
+    assert.match(body, /<code>link_gone<\/code><\/td><td[^>]*>&minus;3</);
+  });
+
+  it("returns the fact from the detail endpoint in the shape the risk endpoint uses", async () => {
+    const detail = JSON.parse((await get(`/api/details/${encodeURIComponent(deadSubject.vendor)}`)).body);
+    const risk = JSON.parse((await get(`/api/vendor-risk/${encodeURIComponent(deadSubject.vendor)}`)).body);
+    assert.deepStrictEqual(detail.offer.link_unreachable, { last_reachable: "2026-01-04", checked: "2026-08-25", terminal: false });
+    assert.deepStrictEqual(detail.offer.link_unreachable, risk.link_unreachable);
+
+    const live = JSON.parse((await get(`/api/details/${encodeURIComponent(liveSubject.vendor)}`)).body);
+    assert.strictEqual(live.offer.link_unreachable, null);
+  });
+
+  it("withholds the stability class from the offers endpoint", async () => {
+    const { body } = await get(`/api/offers?q=${encodeURIComponent(deadSubject.vendor)}&limit=50`);
+    const row = JSON.parse(body).offers.find((o: { url: string }) => o.url === deadSubject.url);
+    assert.ok(row, "the offer must come back for this assertion to have a subject");
+    assert.strictEqual(row.stability, null);
+    assert.notStrictEqual(row.link_unreachable, null);
+  });
+});

--- a/test/product-role.test.ts
+++ b/test/product-role.test.ts
@@ -20,7 +20,7 @@ import {
   SUBTYPE_TAXONOMIES,
   SUBTYPE_MEMBERSHIP_GROUPS,
 } from "../src/product-role.ts";
-import { rankForListing, rankOffers } from "../src/ranking.ts";
+import { rankForListing, rankOffers } from "../dist/ranking.js";
 import type { Offer, ProductRole, DeploymentModel } from "../src/types.ts";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));

--- a/test/ranked-surfaces.test.ts
+++ b/test/ranked-surfaces.test.ts
@@ -75,7 +75,8 @@ describe("/alternative-to/:slug", () => {
   const DEMOTION_EVIDENCE: Array<{ path: string; pattern: RegExp; why: string }> = [
     { path: "/alternative-to/openai", pattern: /<strong>&minus;3 free_tier_withdrawn<\/strong> Recorded [a-z ]+ on \d{4}-\d{2}-\d{2}/, why: "a withdrawn free tier must name the change and its date" },
     { path: "/alternative-to/openai", pattern: /<strong>&minus;2 time_limited_offer<\/strong> Tier &quot;[^&]+&quot; is a credit grant/, why: "a credit grant must say so" },
-    { path: "/alternative-to/vercel", pattern: /<strong>&minus;1 stale_verification<\/strong>[^<]*not a change by the vendor/, why: "our own verification gap must be labelled as ours" },
+    { path: "/alternative-to/n8n", pattern: /<strong>&minus;1 stale_verification<\/strong>[^<]*not a change by the vendor/, why: "our own verification gap must be labelled as ours" },
+    { path: "/alternative-to/vercel", pattern: /<strong>&minus;2 link_unreachable<\/strong>[^<]*pricing page has not resolved for us since \d{4}-\d{2}-\d{2}/, why: "a dead pricing page must name the date it was last reachable" },
   ];
 
   for (const { path, pattern, why } of DEMOTION_EVIDENCE) {
@@ -168,7 +169,7 @@ describe("/referral-programs stops being ordered by our own money", () => {
     assert.ok(vendors.length >= 4, `expected several unpaid programmes, got ${vendors.length}`);
     assert.notDeepStrictEqual(vendors, [...vendors].sort((a, b) => a.localeCompare(b)), "still alphabetical inside the section");
 
-    const { rotateListing } = await import("../src/ranking.ts");
+    const { rotateListing } = await import("../dist/ranking.js");
     const { hasOurReferralLink } = await import("../dist/referral-surfaces.js");
     const index = JSON.parse(readFileSync(path.join(REPO, "data", "index.json"), "utf8")) as {
       offers: { vendor: string; referral?: unknown; referral_program?: { available?: boolean } }[];

--- a/test/ranking.test.ts
+++ b/test/ranking.test.ts
@@ -15,7 +15,7 @@ const {
   utcDate,
   DEMERIT_TABLE,
   GATE_TABLE,
-} = await import("../src/ranking.ts");
+} = await import("../dist/ranking.js");
 
 type Offer = import("../src/types.ts").Offer;
 type DealChange = import("../src/types.ts").DealChange;

--- a/test/referral-disclosure-predicate.test.ts
+++ b/test/referral-disclosure-predicate.test.ts
@@ -195,7 +195,7 @@ describe("the referral programs directory labels our commercial relationships", 
       .find((d: any) => d["@type"] === type);
 
   const inventoryRotation = async () => {
-    const { rotateListing } = await import("../src/ranking.ts");
+    const { rotateListing } = await import("../dist/ranking.js");
     const seen = new Set<string>();
     const sourceOrder: string[] = [];
     for (const o of offers) {


### PR DESCRIPTION
Refs #1201

`bismuth.cloud` ranked 10th of 58 on `/best/free-cloud-hosting` this morning and `Datree` 4th of 51 on `/best/free-security`, both with a pricing page our own checker has failed on six consecutive times. The demerit table paid 1 point for "we have not looked in 90 days" and 0 for "we looked and the page is gone".

## What changed

**Two codes, not one.** `link_unreachable` costs **2**; `link_gone` — the vendor's own server answering 410 — costs **3**.

- 2 for `link_unreachable`: stronger than `stale_verification` (1), which the table's own text says "measures our confidence, not the vendor", and equal to `time_limited_offer` (2), the other code that says the offer is not what the record makes it look like. Weaker than `free_tier_withdrawn` (3), which is a dated record of the vendor changing terms — a dead page is not evidence the terms changed.
- 3 for `link_gone`: AC-4 offered a third point or a gate. I took the third point. A gate would have removed the one record in that state from `/best/free-security` entirely — `buildBestOfPage` renders `qualified` and `demoted` and never `excluded` — and the issue's own scope note says a dead link is a fact to publish, not to hide. A separate code rather than a variable weight keeps every row of the published `/criteria` table literally true. `SOOS` is the one record affected; it moves from −1 to −3.

**One dead link is charged once.** Where a link demerit fires, `stale_verification` is suppressed. **10 of the 19** affected records were paying it, so they score 2 rather than 3 (SOOS 3 rather than 4). The other 9: 5 were inside the 90-day window and 4 are already gated.

**The lookup is default-on.** `evaluate()` falls back to `unreachableNoticeForUrl` when no `linkHealth` is passed, so all six `rankOffers`/`rankForListing` call sites — and any future one — read the index without opting in. Injecting the lookup is for tests. The predicate is the same `unreachableNotice` the vendor page already uses, including its 14-day grace, so a page that renders the notice is exactly a page that pays the demerit.

**The three surfaces that dropped it.**
- Category listings render `withheldLevelSentence("link_unreachable", …)` — the sentence `src/source-check.ts:23` already publishes on vendor pages, not a second wording. `/best/*` gets the same sentence through the demerit reason.
- `/api/details/:vendor` returns `link_unreachable` in the shape `/api/vendor-risk/:vendor` uses, on the offer and on its alternatives.
- A **favourable** stability class (`stable` or `improving`) is withheld where the link does not resolve — `enrichOffers`, `compare_vendors` and `plan_stack` candidates. An adverse class (`watch`, `volatile`) is still published: a dead link does not soften a recorded fact. This is scoped to link health only. Mirroring `risk_level`'s full `cannotVouchForLevel` predicate would also have withheld stability from the 788 of 1,580 records with a source-check outcome, which is not what #1201 asks for.

## Every affected record, before and after

19 links in `data/link_health.json` carry `outcome: "unreachable"` and each maps to exactly one offer. Ranking date 2026-09-01.

| vendor | category | before | after | `/best` page | position before | position after |
|---|---|---|---|---|---|---|
| Datree | Security | 0 | 2 | `/best/free-security` | **#4 of 51** | demoted −2 |
| bismuth.cloud | Cloud Hosting | 0 | 2 | `/best/free-cloud-hosting` | **#10 of 58** | demoted −2 |
| VolaryDDNS | DNS & Domain Management | 0 | 2 | `/best/free-dns-domain-management` | **#12 of 29** | demoted −2 |
| engagespot.co | Messaging | 0 | 2 | `/best/free-messaging` | **#14 of 27** | demoted −2 |
| Labelbox | AI / ML | 0 | 2 | `/best/free-ai-ml` | **#41 of 63** | demoted −2 |
| SOOS | Security | 1 | 3 | `/best/free-security` | demoted −1 | demoted −3 |
| Cloudflare Dynamic Workers | Cloud Hosting | 3 | 4 | `/best/free-cloud-hosting` | demoted −3 | demoted −4 |
| cState | Status Pages | 1 | 2 | `/best/free-status-pages` | demoted −1 | demoted −2 |
| Claw.cloud | Cloud Hosting | 1 | 2 | `/best/free-cloud-hosting` | demoted −1 | demoted −2 |
| Langtrace | AI / ML | 1 | 2 | `/best/free-ai-ml` | demoted −1 | demoted −2 |
| Evernote | Productivity & Notes | 1 | 2 | `/best/free-productivity-notes` | demoted −1 | demoted −2 |
| Microsoft To Do | Productivity & Notes | 1 | 2 | `/best/free-productivity-notes` | demoted −1 | demoted −2 |
| Wdrfree SVG | Design | 1 | 2 | `/best/free-design` | demoted −1 | demoted −2 |
| Code Time | IDE & Code Editors | 1 | 2 | `/best/free-ide-code-editors` | demoted −1 | demoted −2 |
| tollbooth | Dev Utilities | 1 | 2 | `/best/free-dev-utilities` | demoted −1 | demoted −2 |
| GPU-Bridge | AI / ML | gated | gated | — | — | — |
| Google Vertex AI Agent Engine | AI / ML | gated | gated | — | — | — |
| Strale | Dev Utilities | gated | gated | — | — | — |
| Google AI Pro/Ultra | Cloud IaaS | gated | gated | — | — | — |

The four gated records never reach `evaluate` — three are `not_a_free_offer`, one `eligibility_restricted` — so they were already off every ranked surface.

**Five records left the qualified band.** That is one more than #1201 counted: Labelbox was 84 days past verification on the measurement date and inside the 90-day window, so it too carried nothing.

The alternatives block on `/vendor/*`, the 18% surface:

| vendor | `/vendor` blocks listing it, before → after | moved down within a block | `/alternative-to` lists, before → after | moved down |
|---|---|---|---|---|
| bismuth.cloud | 31 → 19 | 17 | 48 → 48 | 44 |
| Claw.cloud | 19 → 19 | 0 | 48 → 48 | 0 |
| Cloudflare Dynamic Workers | 1 → 1 | 0 | 2 → 2 | 0 |

bismuth.cloud drops off 12 vendor pages entirely — those blocks are truncated, and it is no longer high enough to be shown.

## Verification

**2,888 tests pass**, `tsc --noEmit` clean, `npm run validate` clean.

**18 new tests.** 17 fail on a `main` build; the 18th is a deliberate regression guard — a link we were merely refused (403) still qualifies, which must hold on both.

**13 mutations, 13 killed** (`scripts/mutate-1201.sh`), including: the demerit never fires; it costs 1 point; it costs 0; a 410 is charged like any other 404; the record pays twice; it is labelled `about_us`; the ranking reads no link health by default; the reason is written a second time instead of reused; the published weight disagrees with the charged one; the category listing drops the notice; the detail endpoint drops the field; a favourable stability class is published anyway; an adverse one is withheld too.

**A site-wide corpus guard**, not a sample: every offer whose URL is `unreachable` in `data/link_health.json` is asserted absent from the qualified band of its own category ranking.

**Differential sweep of 2,470 paths** against a `main` build: **0 status changes**, 2,351 byte-identical, 119 moved. The moved set is exactly the prediction — `/criteria`, `/best` plus its 10 affected category pages, the 11 category pages holding one of the 19, 47 vendor alternatives blocks and 47 `/alternative-to` lists whose order changed, plus two pages that moved without an order change: `/vendor/cloudflare-dynamic-workers` (its alternatives `tie_count` fell 2 → 1) and `/alternative-to/cloudflare-sandboxes` (two demerit labels and the counts sentence).

**Real MCP `initialize` → `tools/call`:** `search_deals` and `compare_vendors` return `"stability": null` for Datree beside a populated `link_unreachable`, and `"watch"` for Vercel and `"stable"` for Snyk unchanged.

## Two things worth your attention

**Four test files now import `../dist/ranking.js` rather than `../src/ranking.ts`.** `ranking.ts` now has a value import of `./link-health.js`, and Node's type stripping does not resolve a `.js` specifier to a `.ts` file, so loading the source directly throws `ERR_MODULE_NOT_FOUND`. CI builds before it tests, so this changes nothing there. The alternative — attaching link health to the offer upstream instead of looking it up in `evaluate` — would have left every plain-`Offer` call site silently without the demerit, which is the failure mode this issue is about.

**A guard lost its subject and I re-pointed it.** `ranked-surfaces.test.ts` asserted `/alternative-to/vercel` renders `−1 stale_verification` labelled as ours. The only record on that page carrying it was Claw.cloud, which now carries `link_unreachable` instead. The property is unchanged and still real, so the assertion moved to `/alternative-to/n8n`, which still carries two of them, and I added a second row asserting the new label on `/alternative-to/vercel`.

## Found, not fixed

`risk_level` is withheld on 788 of 1,580 records whose source-check outcome is `does_not_name_vendor`, `states_no_terms` or `unreadable` — and `stability` is still published as `stable` on every one of them. That is the same defect one field over, at 50x the scale, and outside what #1201 asks for. Worth its own issue.
