### PR TITLE
Declare the thirteen Monitoring subtypes and the group of five (#1212)

### DIFF
--- a/scripts/mutate-1212.sh
+++ b/scripts/mutate-1212.sh
@@ -1,0 +1,177 @@
+#!/usr/bin/env bash
+set -u
+
+REPO="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$REPO" || exit 1
+
+ROLE="src/product-role.ts"
+SERVE="src/serve.ts"
+FILES=("$ROLE" "$SERVE")
+BACKUP_DIR="$(mktemp -d)"
+for f in "${FILES[@]}"; do
+  cp "$f" "$BACKUP_DIR/$(basename "$f")"
+done
+
+restore() {
+  for f in "${FILES[@]}"; do
+    cp "$BACKUP_DIR/$(basename "$f")" "$f"
+  done
+  npx tsc > /dev/null 2>&1
+}
+trap 'restore' EXIT
+
+killed=0
+survived=0
+ROLE_TESTS="test/product-role.test.ts"
+PAGE_TESTS="test/product-role.test.ts test/alternatives-membership.test.ts"
+
+py() { python3 - "$@"; }
+
+changed_any() {
+  for f in "${FILES[@]}"; do
+    if ! diff -q "$BACKUP_DIR/$(basename "$f")" "$f" > /dev/null; then
+      return 0
+    fi
+  done
+  return 1
+}
+
+run_mutation() {
+  local tests="$1"
+  local name="$2"
+  shift 2
+  echo "=== $name"
+  for f in "${FILES[@]}"; do cp "$BACKUP_DIR/$(basename "$f")" "$f"; done
+  "$@"
+  if ! changed_any; then
+    echo "    NOT APPLIED: the mutation changed no file, so it proves nothing"
+    survived=$((survived + 1))
+    return
+  fi
+  if ! npx tsc > /tmp/mutate-1212-build.log 2>&1; then
+    echo "    NOT APPLIED: the mutation does not compile"
+    survived=$((survived + 1))
+    return
+  fi
+  if timeout 900 node --test --test-concurrency 1 $tests > /tmp/mutate-1212-test.log 2>&1; then
+    echo "    SURVIVED"
+    survived=$((survived + 1))
+  else
+    echo "    KILLED: $(grep -c '✖ ' /tmp/mutate-1212-test.log) failing assertion(s)"
+    grep '✖ ' /tmp/mutate-1212-test.log | head -3
+    killed=$((killed + 1))
+  fi
+}
+
+m_the_category_declares_no_taxonomy() {
+  py <<'PY'
+import re
+p = "src/product-role.ts"
+s = open(p).read()
+s = re.sub(r'  Monitoring: \[\n(?:    \{ subtype:.*\n)+  \],\n', '', s, count=1)
+open(p, "w").write(s)
+PY
+}
+
+m_one_function_is_left_undeclared() {
+  py <<'PY'
+p = "src/product-role.ts"
+s = open(p).read()
+s = "\n".join(l for l in s.split("\n") if 'subtype: "page_change_watch"' not in l)
+open(p, "w").write(s)
+PY
+}
+
+m_a_function_is_declared_without_a_definition() {
+  py <<'PY'
+import re
+p = "src/product-role.ts"
+s = open(p).read()
+s = re.sub(r'(\{ subtype: "synthetic_check", definition: )"[^"]*"', r'\1""', s, count=1)
+open(p, "w").write(s)
+PY
+}
+
+m_a_function_is_declared_under_another_name() {
+  py <<'PY'
+p = "src/product-role.ts"
+s = open(p).read()
+s = s.replace('{ subtype: "uptime_check", definition:', '{ subtype: "uptime_checks", definition:', 1)
+open(p, "w").write(s)
+PY
+}
+
+m_the_category_declares_no_membership_group() {
+  py <<'PY'
+import re
+p = "src/product-role.ts"
+s = open(p).read()
+s = re.sub(r'  Monitoring: \[\n    \{\n      subtypes: \["host_metrics".*\n      rule: "A reader leaving one of these.*\n    \},\n  \],\n', '', s, count=1)
+open(p, "w").write(s)
+PY
+}
+
+m_exception_grouping_joins_the_group() {
+  py <<'PY'
+p = "src/product-role.ts"
+s = open(p).read()
+s = s.replace('subtypes: ["host_metrics", "apm_traces", "log_management", "metrics_backend", "dashboards"],',
+              'subtypes: ["host_metrics", "apm_traces", "log_management", "metrics_backend", "dashboards", "error_tracking"],')
+open(p, "w").write(s)
+PY
+}
+
+m_the_view_is_left_out_of_the_group() {
+  py <<'PY'
+p = "src/product-role.ts"
+s = open(p).read()
+s = s.replace('subtypes: ["host_metrics", "apm_traces", "log_management", "metrics_backend", "dashboards"],',
+              'subtypes: ["host_metrics", "apm_traces", "log_management", "metrics_backend"],')
+open(p, "w").write(s)
+PY
+}
+
+m_the_group_admits_a_subtype_from_any_category() {
+  py <<'PY'
+p = "src/product-role.ts"
+s = open(p).read()
+s = s.replace("export function membershipGroupsFor(taxonomy: string): SubtypeMembershipGroup[] {\n  return SUBTYPE_MEMBERSHIP_GROUPS[taxonomy] ?? [];\n}",
+              "export function membershipGroupsFor(taxonomy: string): SubtypeMembershipGroup[] {\n  return Object.values(SUBTYPE_MEMBERSHIP_GROUPS).flat();\n}")
+open(p, "w").write(s)
+PY
+}
+
+m_the_criteria_page_publishes_two_taxonomies() {
+  py <<'PY'
+p = "src/serve.ts"
+s = open(p).read()
+s = s.replace("const subtypeTaxonomyTables = Object.entries(SUBTYPE_TAXONOMIES).map(",
+              "const subtypeTaxonomyTables = Object.entries(SUBTYPE_TAXONOMIES).slice(0, 2).map(")
+open(p, "w").write(s)
+PY
+}
+
+m_the_criteria_page_states_no_coverage_for_the_newest_taxonomy() {
+  py <<'PY'
+p = "src/serve.ts"
+s = open(p).read()
+s = s.replace("const parts = Object.keys(SUBTYPE_TAXONOMIES).map(taxonomy => {",
+              "const parts = Object.keys(SUBTYPE_TAXONOMIES).slice(0, 2).map(taxonomy => {")
+open(p, "w").write(s)
+PY
+}
+
+run_mutation "$ROLE_TESTS" "the category declares no taxonomy" m_the_category_declares_no_taxonomy
+run_mutation "$ROLE_TESTS" "one function is left undeclared" m_one_function_is_left_undeclared
+run_mutation "$ROLE_TESTS" "a function is declared without a definition" m_a_function_is_declared_without_a_definition
+run_mutation "$ROLE_TESTS" "a function is declared under another name" m_a_function_is_declared_under_another_name
+run_mutation "$ROLE_TESTS" "the category declares no membership group" m_the_category_declares_no_membership_group
+run_mutation "$ROLE_TESTS" "exception grouping joins the group" m_exception_grouping_joins_the_group
+run_mutation "$ROLE_TESTS" "the view is left out of the group" m_the_view_is_left_out_of_the_group
+run_mutation "$ROLE_TESTS" "the group admits a subtype from any category" m_the_group_admits_a_subtype_from_any_category
+run_mutation "$PAGE_TESTS" "the criteria page publishes two taxonomies" m_the_criteria_page_publishes_two_taxonomies
+run_mutation "$PAGE_TESTS" "the criteria page states no coverage for the newest taxonomy" m_the_criteria_page_states_no_coverage_for_the_newest_taxonomy
+
+echo
+echo "killed=$killed survived=$survived"
+[ "$survived" -eq 0 ]

--- a/src/product-role.ts
+++ b/src/product-role.ts
@@ -46,6 +46,21 @@ export const SUBTYPE_TAXONOMIES: Record<string, Array<{ subtype: string; definit
     { subtype: "backend_as_a_service", definition: "an API bundling a datastore with auth, push or realtime; there is no server you deploy" },
     { subtype: "agent_sandbox", definition: "isolated execution environments provisioned programmatically, sold for AI agent workloads" },
   ],
+  Monitoring: [
+    { subtype: "uptime_check", definition: "polls a URL or host from outside your infrastructure on a fixed interval and alerts when it stops answering; it runs no code of yours" },
+    { subtype: "synthetic_check", definition: "runs a check you author — a scripted browser session, a multi-step API call, or an assertion on a response body — on a schedule from outside your infrastructure, and reports whether the behaviour it asserts still holds" },
+    { subtype: "host_metrics", definition: "an agent you install on a machine reports CPU, memory, disk and process state for that machine" },
+    { subtype: "apm_traces", definition: "instruments application code and reports per-request latency, throughput and spans across services" },
+    { subtype: "log_management", definition: "ingests, stores and queries log lines; the line is the stored unit and retention is a priced dimension" },
+    { subtype: "metrics_backend", definition: "stores time-indexed measurements and serves queries over them; dashboards and alerting are built on top rather than sold as the product" },
+    { subtype: "dashboards", definition: "renders charts, dashboards and alert rules over telemetry held in stores it does not own; what is sold is the view, not the store" },
+    { subtype: "error_tracking", definition: "captures unhandled exceptions with stack traces and groups repeat occurrences into one issue" },
+    { subtype: "cron_monitor", definition: "waits for a scheduled job to check in and alerts on the absence of the check-in rather than on a failure it observed" },
+    { subtype: "status_page", definition: "publishes a page your own users read to see whether your service is up" },
+    { subtype: "upstream_status_watch", definition: "watches status pages or endpoints belonging to third parties you depend on, and reports to you rather than to your users" },
+    { subtype: "on_call_response", definition: "routes a firing alert to a named human by schedule and escalation policy" },
+    { subtype: "page_change_watch", definition: "fetches a web page on a schedule and notifies you when its content differs from last time" },
+  ],
 };
 
 export interface SubtypeMembershipGroup {
@@ -58,6 +73,12 @@ export const SUBTYPE_MEMBERSHIP_GROUPS: Record<string, SubtypeMembershipGroup[]>
     {
       subtypes: ["static_site", "serverless_function", "container_app"],
       rule: "These three describe how your code is executed, not what can replace what. A reader leaving one of them is asking where else they can deploy the thing they have, and all three answer that question, so two offers that each carry one are alternatives whether or not they carry the same one. Every other subtype in this category keeps the shared-member rule unchanged.",
+    },
+  ],
+  Monitoring: [
+    {
+      subtypes: ["host_metrics", "apm_traces", "log_management", "metrics_backend", "dashboards"],
+      rule: "A reader leaving one of these is asking where else to send telemetry, what will store it and what will show it, and all five answer some part of that, so two offers that each carry one are alternatives whether or not they carry the same one. error_tracking sits outside this group deliberately: a reader leaving Sentry wants exception grouping, and every platform that also offers it carries the error_tracking label itself. Every other subtype in this category keeps the shared-member rule unchanged.",
     },
   ],
 };

--- a/test/alternatives-membership.test.ts
+++ b/test/alternatives-membership.test.ts
@@ -483,12 +483,15 @@ describe("#1195 how a product is deployed does not decide what can replace it", 
     const { SUBTYPE_MEMBERSHIP_GROUPS } = await import("../dist/product-role.js");
     const { status, body } = await get("/criteria");
     assert.equal(status, 200);
-    const groups = (SUBTYPE_MEMBERSHIP_GROUPS as Record<string, Array<{ subtypes: string[]; rule: string }>>)["Cloud Hosting"];
-    assert.ok(groups?.length, "Cloud Hosting must declare a membership group for this test to mean anything");
-    for (const group of groups) {
-      assert.ok(body.includes(group.rule.replace(/&/g, "&amp;")), "the criteria page must state the rule the group gates by");
-      for (const subtype of group.subtypes) {
-        assert.ok(body.includes(`<code>${subtype}</code>`), `${subtype} is not named on the criteria page`);
+    const declared = SUBTYPE_MEMBERSHIP_GROUPS as Record<string, Array<{ subtypes: string[]; rule: string }>>;
+    const taxonomies = Object.keys(declared);
+    assert.ok(taxonomies.length > 0, "a taxonomy must declare a membership group for this test to mean anything");
+    for (const taxonomy of taxonomies) {
+      for (const group of declared[taxonomy]) {
+        assert.ok(body.includes(group.rule.replace(/&/g, "&amp;")), `the criteria page must state the rule ${taxonomy}'s group gates by`);
+        for (const subtype of group.subtypes) {
+          assert.ok(body.includes(`<code>${subtype}</code>`), `${subtype} is not named on the criteria page`);
+        }
       }
     }
     assert.ok(body.includes("<th>Group</th>"), "the taxonomy table must mark which subtypes are in a group");
@@ -517,6 +520,19 @@ describe("#1032 the rule is published", () => {
         assert.ok(body.includes(`<code>${entry.subtype}</code>`), `${entry.subtype} is not named on the criteria page`);
         assert.ok(body.includes(entry.definition.replace(/&/g, "&amp;")), `${entry.subtype} is named without the definition it gates by`);
       }
+    }
+  });
+
+  it("states how far classification has got in every taxonomy it publishes", async () => {
+    const { SUBTYPE_TAXONOMIES } = await import("../dist/product-role.js");
+    const { body } = await get("/criteria");
+    for (const taxonomy of Object.keys(SUBTYPE_TAXONOMIES as Record<string, unknown>)) {
+      const inTaxonomy = offers.filter((o) => o.category === taxonomy);
+      const labelled = inTaxonomy.filter((o) => o.product_subtypes).length;
+      assert.ok(
+        body.includes(`${labelled} of ${inTaxonomy.length} in ${taxonomy}`),
+        `the criteria page must say how many of the ${inTaxonomy.length} ${taxonomy} records carry a subtype`
+      );
     }
   });
 

--- a/test/product-role.test.ts
+++ b/test/product-role.test.ts
@@ -242,6 +242,79 @@ describe("#1032 Phase 2 subtypes gate on sharing at least one label", () => {
     assert.equal(subtypesOf(unlabelled), null);
     assert.deepStrictEqual([...subtypesOf(none)!.subtypes], []);
   });
+
+  it("publishes no subtype name twice in one taxonomy", () => {
+    for (const [taxonomy, entries] of Object.entries(SUBTYPE_TAXONOMIES)) {
+      const names = entries.map(e => e.subtype);
+      assert.deepStrictEqual([...new Set(names)], names, `${taxonomy} names a subtype twice, and the second definition is unreachable`);
+    }
+  });
+
+  it("gives every subtype a definition long enough to classify by", () => {
+    for (const [taxonomy, entries] of Object.entries(SUBTYPE_TAXONOMIES)) {
+      for (const entry of entries) {
+        assert.ok(entry.definition.length > 40, `${taxonomy}/${entry.subtype} needs a definition a labeller can apply`);
+      }
+    }
+  });
+});
+
+describe("#1212 the functions Monitoring splits by", () => {
+  const MONITORING_SUBTYPES = [
+    "uptime_check",
+    "synthetic_check",
+    "host_metrics",
+    "apm_traces",
+    "log_management",
+    "metrics_backend",
+    "dashboards",
+    "error_tracking",
+    "cron_monitor",
+    "status_page",
+    "upstream_status_watch",
+    "on_call_response",
+    "page_change_watch",
+  ];
+
+  const TELEMETRY_GROUP = ["host_metrics", "apm_traces", "log_management", "metrics_backend", "dashboards"];
+
+  it("publishes all thirteen, so a record may carry any of them", () => {
+    assert.deepStrictEqual(SUBTYPE_TAXONOMIES["Monitoring"]?.map(e => e.subtype), MONITORING_SUBTYPES);
+  });
+
+  it("groups the five that answer where telemetry goes, and only those five", () => {
+    assert.deepStrictEqual(membershipGroupsFor("Monitoring").map(g => g.subtypes), [TELEMETRY_GROUP]);
+  });
+
+  it("offers two telemetry products as substitutes whichever part of the pipeline each carries", () => {
+    const traces = labelled("Traces", ["apm_traces"], "Monitoring");
+    const view = labelled("View", ["dashboards"], "Monitoring");
+    assert.equal(alternativeMembershipGate(view, traces), null);
+    assert.equal(alternativeMembershipGate(traces, view), null);
+  });
+
+  it("keeps exception grouping outside that group in both directions", () => {
+    const logs = labelled("Logs", ["log_management"], "Monitoring");
+    const exceptions = labelled("Exceptions", ["error_tracking"], "Monitoring");
+    assert.equal(alternativeMembershipGate(exceptions, logs), "subtype_mismatch");
+    assert.equal(alternativeMembershipGate(logs, exceptions), "subtype_mismatch");
+  });
+
+  it("leaves every subtype outside the group on the shared-label rule", () => {
+    const uptime = labelled("Uptime", ["uptime_check"], "Monitoring");
+    const secondUptime = labelled("SecondUptime", ["uptime_check"], "Monitoring");
+    const onCall = labelled("OnCall", ["on_call_response"], "Monitoring");
+    const traces = labelled("Traces", ["apm_traces"], "Monitoring");
+    assert.equal(alternativeMembershipGate(secondUptime, uptime), null);
+    assert.equal(alternativeMembershipGate(onCall, uptime), "subtype_mismatch");
+    assert.equal(alternativeMembershipGate(traces, uptime), "subtype_mismatch");
+  });
+
+  it("compares a Monitoring label against nothing in another category", () => {
+    const traces = labelled("Traces", ["apm_traces"], "Monitoring");
+    const relationalDb = labelled("RelationalDb", ["relational"]);
+    assert.equal(alternativeMembershipGate(traces, relationalDb), null);
+  });
 });
 
 describe("#1032 a gate removes a candidate only where the subject cannot carry it too", () => {


### PR DESCRIPTION
Refs #1212.

Definitions only. `data/index.json` is untouched, no record carries a Monitoring label, and no page but `/criteria` changes a byte.

## Verbatim, checked rather than transcribed

`SUBTYPE_TAXONOMIES["Monitoring"]` holds the thirteen subtypes and `SUBTYPE_MEMBERSHIP_GROUPS["Monitoring"]` the one group of five. I pulled both blocks out of the issue body with the API, parsed them, and compared them against the built module — `JSON.stringify` equal on both, so nothing was retyped.

## Nothing moves

A 3,924-path differential sweep against a main build: 3,923 byte-identical, **1 moved — `/criteria`** — and 0 status changes. One path was the prediction and one path is what moved.

The pages a labelling mistake would show up on were checked directly as well: all 59 Monitoring vendors' `/vendor/` and `/alternative-to/` pages plus `/category/monitoring`, 119 paths, byte-identical.

`/criteria#subtypes` renders the Monitoring table and the group paragraph in the same shape as the two taxonomies already there, with the Group column ticked on exactly the five telemetry subtypes. The coverage line reads `41 of 45 in Databases, 57 of 60 in Cloud Hosting, 0 of 59 in Monitoring`.

## Tests

2,897 pass, 0 fail. Nine are new.

**Three fail on a main build**, and they are the new behaviour: the thirteen names, the group of five, and `dashboards` being a substitute for `apm_traces`, which is a `subtype_mismatch` without the group.

**Two are the guards on the group's edges** — `error_tracking` stays outside it in both directions, and every subtype outside it stays on the shared-label rule. Both pass on main for a reason that will not hold again: main declares no Monitoring group, so everything mismatches there. They are what catches a later widening.

**Two are invariants across every taxonomy**, not just this one: no subtype name published twice in one taxonomy, and every definition long enough to classify by. The second is what catches an emptied definition — `subtypeDefinition` reading its own map back cannot.

**Two are on the criteria page.** It now states coverage for every taxonomy it declares, counted from the index, so the assertion keeps meaning something as labels land rather than pinning today's zero. The existing group test is re-pointed off Cloud Hosting and onto every taxonomy that declares a group.

**10 of 10 mutations killed** (`scripts/mutate-1212.sh`): the taxonomy dropped, one subtype dropped, a definition emptied, a subtype renamed, the group dropped, `error_tracking` added to it, `dashboards` removed from it, groups flattened across taxonomies, and the criteria page rendering or counting only the first two taxonomies.

Real MCP `initialize` → `notifications/initialized` → `tools/call` against the branch build.

## What this does not do

No record is labelled, so Monitoring's alternatives pages stay exactly as #1209 left them. The 59 labels are a separate data change.
