### PR TITLE
Classify all 59 Monitoring records against the thirteen subtypes (#1212)

### DIFF
--- a/data/index.json
+++ b/data/index.json
@@ -1364,6 +1364,27 @@
         "checked": "2026-08-28",
         "outcome": "ok",
         "detail": "text"
+      },
+      "product_subtypes": {
+        "taxonomy": "Monitoring",
+        "labels": [
+          {
+            "subtype": "error_tracking",
+            "source_url": "https://sentry.io/pricing/",
+            "source_quote": "Error Monitoring"
+          },
+          {
+            "subtype": "apm_traces",
+            "source_url": "https://sentry.io/pricing/",
+            "source_quote": "Tracing"
+          },
+          {
+            "subtype": "log_management",
+            "source_url": "https://sentry.io/pricing/",
+            "source_quote": "Logs"
+          }
+        ],
+        "reviewed": "2026-09-01"
       }
     },
     {
@@ -1391,6 +1412,37 @@
         "checked": "2026-08-28",
         "outcome": "states_no_terms",
         "detail": "the page names Datadog but states no amount, tier or rate we can read"
+      },
+      "product_subtypes": {
+        "taxonomy": "Monitoring",
+        "labels": [
+          {
+            "subtype": "host_metrics",
+            "source_url": "https://www.datadoghq.com/pricing/",
+            "source_quote": "into your stack’s health & performance Infrastructure Infrastructure Monitoring Metrics Network Monitoring Container Monitoring Kubernetes Autoscaling"
+          },
+          {
+            "subtype": "apm_traces",
+            "source_url": "https://www.datadoghq.com/pricing/",
+            "source_quote": "Cloud Cost Management Applications Application Performance Monitoring OTLP APM Ingest Serverless Monitoring Universal Service Monitoring"
+          },
+          {
+            "subtype": "log_management",
+            "source_url": "https://www.datadoghq.com/pricing/",
+            "source_quote": "Logs Log Management Error Tracking Sensitive Data Scanner Audit Trail Observability Pipelines"
+          },
+          {
+            "subtype": "metrics_backend",
+            "source_url": "https://www.datadoghq.com/pricing/",
+            "source_quote": "updateQueryParam('product', product)"
+          },
+          {
+            "subtype": "synthetic_check",
+            "source_url": "https://www.datadoghq.com/pricing/",
+            "source_quote": "Real User Monitoring & Session Replay Synthetic Testing & Monitoring Software Delivery Code Coverage"
+          }
+        ],
+        "reviewed": "2026-09-01"
       }
     },
     {
@@ -1413,6 +1465,27 @@
         "checked": "2026-08-28",
         "outcome": "ok",
         "detail": "text"
+      },
+      "product_subtypes": {
+        "taxonomy": "Monitoring",
+        "labels": [
+          {
+            "subtype": "metrics_backend",
+            "source_url": "https://grafana.com/pricing/",
+            "source_quote": "Fully-managed, highly-scalable metrics service in Grafana Cloud with built-in features to optimize cost."
+          },
+          {
+            "subtype": "log_management",
+            "source_url": "https://grafana.com/pricing/",
+            "source_quote": "Fully-managed log aggregation system powered by Grafana Loki."
+          },
+          {
+            "subtype": "apm_traces",
+            "source_url": "https://grafana.com/pricing/",
+            "source_quote": "Fully-managed, easy-to-use, highly-scalable, and cost-effective distributed tracing backend."
+          }
+        ],
+        "reviewed": "2026-09-01"
       }
     },
     {
@@ -1435,6 +1508,42 @@
         "checked": "2026-08-28",
         "outcome": "ok",
         "detail": "text"
+      },
+      "product_subtypes": {
+        "taxonomy": "Monitoring",
+        "labels": [
+          {
+            "subtype": "uptime_check",
+            "source_url": "https://betterstack.com/pricing",
+            "source_quote": "The most reliable uptime monitoring"
+          },
+          {
+            "subtype": "log_management",
+            "source_url": "https://betterstack.com/pricing",
+            "source_quote": "3 GB logs retained for 3 days"
+          },
+          {
+            "subtype": "error_tracking",
+            "source_url": "https://betterstack.com/pricing",
+            "source_quote": "AI‑native error tracking built on Better Stack"
+          },
+          {
+            "subtype": "metrics_backend",
+            "source_url": "https://betterstack.com/pricing",
+            "source_quote": "Embedded charts & metrics"
+          },
+          {
+            "subtype": "status_page",
+            "source_url": "https://betterstack.com/pricing",
+            "source_quote": "Quick status page updates"
+          },
+          {
+            "subtype": "on_call_response",
+            "source_url": "https://betterstack.com/pricing",
+            "source_quote": "On-call calendar ICS export"
+          }
+        ],
+        "reviewed": "2026-09-01"
       }
     },
     {
@@ -1456,6 +1565,22 @@
         "checked": "2026-08-28",
         "outcome": "ok",
         "detail": "text"
+      },
+      "product_subtypes": {
+        "taxonomy": "Monitoring",
+        "labels": [
+          {
+            "subtype": "log_management",
+            "source_url": "https://axiom.co/pricing",
+            "source_quote": "Log management"
+          },
+          {
+            "subtype": "metrics_backend",
+            "source_url": "https://axiom.co/pricing",
+            "source_quote": "Metrics skill"
+          }
+        ],
+        "reviewed": "2026-09-01"
       }
     },
     {
@@ -1508,6 +1633,42 @@
         "checked": "2026-08-28",
         "outcome": "ok",
         "detail": "text"
+      },
+      "product_subtypes": {
+        "taxonomy": "Monitoring",
+        "labels": [
+          {
+            "subtype": "apm_traces",
+            "source_url": "https://newrelic.com/pricing",
+            "source_quote": "New Relic, Datadog, and Dynatrace cost comparison"
+          },
+          {
+            "subtype": "log_management",
+            "source_url": "https://newrelic.com/pricing",
+            "source_quote": "Advanced logs obfuscation: Create and track rules directly in the log management UI and mask or hash sensitive log data."
+          },
+          {
+            "subtype": "host_metrics",
+            "source_url": "https://newrelic.com/pricing",
+            "source_quote": "With New Relic usage-based pricing , you no longer have to count hosts or CPUs."
+          },
+          {
+            "subtype": "metrics_backend",
+            "source_url": "https://newrelic.com/pricing",
+            "source_quote": "Our straightforward pricing is based on just two core metrics—users and data ingest OR compute and data ingest—making it easy to understand what you’re paying for."
+          },
+          {
+            "subtype": "error_tracking",
+            "source_url": "https://newrelic.com/pricing",
+            "source_quote": "Core users—starting at $49 per user— can access everything basic users can plus telemetry data in their IDE via the New Relic CodeStream integration, error tracking, logs, and more."
+          },
+          {
+            "subtype": "synthetic_check",
+            "source_url": "https://newrelic.com/pricing",
+            "source_quote": "Additional synthetics checks beyond the amount included in your edition are available at $0.005 per check."
+          }
+        ],
+        "reviewed": "2026-09-01"
       }
     },
     {
@@ -1530,6 +1691,17 @@
         "checked": "2026-08-28",
         "outcome": "ok",
         "detail": "text"
+      },
+      "product_subtypes": {
+        "taxonomy": "Monitoring",
+        "labels": [
+          {
+            "subtype": "uptime_check",
+            "source_url": "https://uptimerobot.com/pricing/",
+            "source_quote": "Uptime monitoring"
+          }
+        ],
+        "reviewed": "2026-09-01"
       }
     },
     {
@@ -4026,6 +4198,27 @@
         "checked": "2026-08-28",
         "outcome": "ok",
         "detail": "text"
+      },
+      "product_subtypes": {
+        "taxonomy": "Monitoring",
+        "labels": [
+          {
+            "subtype": "uptime_check",
+            "source_url": "https://pulsetic.com/pricing/",
+            "source_quote": "We'll alert you if your website is down"
+          },
+          {
+            "subtype": "cron_monitor",
+            "source_url": "https://pulsetic.com/pricing/",
+            "source_quote": "Cron Monitoring"
+          },
+          {
+            "subtype": "status_page",
+            "source_url": "https://pulsetic.com/pricing/",
+            "source_quote": "Status Pages"
+          }
+        ],
+        "reviewed": "2026-09-01"
       }
     },
     {
@@ -5174,6 +5367,17 @@
         "checked": "2026-08-28",
         "outcome": "ok",
         "detail": "text"
+      },
+      "product_subtypes": {
+        "taxonomy": "Monitoring",
+        "labels": [
+          {
+            "subtype": "cron_monitor",
+            "source_url": "https://healthchecks.io/pricing/",
+            "source_quote": "Fully Managed, Worry-Free Cron Job Monitoring Service"
+          }
+        ],
+        "reviewed": "2026-09-01"
       }
     },
     {
@@ -6207,6 +6411,17 @@
         "checked": "2026-08-28",
         "outcome": "states_no_terms",
         "detail": "the page names Prometheus but states no amount, tier or rate we can read"
+      },
+      "product_subtypes": {
+        "taxonomy": "Monitoring",
+        "labels": [
+          {
+            "subtype": "metrics_backend",
+            "source_url": "https://prometheus.io/",
+            "source_quote": "Instrument, collect, store, and query your metrics for alerting, dashboarding, and other use cases."
+          }
+        ],
+        "reviewed": "2026-09-01"
       }
     },
     {
@@ -6229,6 +6444,17 @@
         "checked": "2026-08-28",
         "outcome": "states_no_terms",
         "detail": "the page names Jaeger but states no amount, tier or rate we can read"
+      },
+      "product_subtypes": {
+        "taxonomy": "Monitoring",
+        "labels": [
+          {
+            "subtype": "apm_traces",
+            "source_url": "https://www.jaegertracing.io/",
+            "source_quote": "open source, distributed tracing platform"
+          }
+        ],
+        "reviewed": "2026-09-01"
       }
     },
     {
@@ -6972,6 +7198,17 @@
         "checked": "2026-08-28",
         "outcome": "ok",
         "detail": "text"
+      },
+      "product_subtypes": {
+        "taxonomy": "Monitoring",
+        "labels": [
+          {
+            "subtype": "uptime_check",
+            "source_url": "https://www.statuscake.com/pricing/",
+            "source_quote": "Uptime Monitoring"
+          }
+        ],
+        "reviewed": "2026-09-01"
       }
     },
     {
@@ -6991,6 +7228,17 @@
         "checked": "2026-08-28",
         "outcome": "ok",
         "detail": "text"
+      },
+      "product_subtypes": {
+        "taxonomy": "Monitoring",
+        "labels": [
+          {
+            "subtype": "on_call_response",
+            "source_url": "https://www.pagerduty.com/pricing/",
+            "source_quote": "Escalation policies connect services to individual users and/or schedules to ensure the right people are notified at the right time."
+          }
+        ],
+        "reviewed": "2026-09-01"
       }
     },
     {
@@ -7119,6 +7367,32 @@
         "checked": "2026-08-28",
         "outcome": "ok",
         "detail": "text"
+      },
+      "product_subtypes": {
+        "taxonomy": "Monitoring",
+        "labels": [
+          {
+            "subtype": "cron_monitor",
+            "source_url": "https://cronitor.io/pricing",
+            "source_quote": "Cron Job Monitoring"
+          },
+          {
+            "subtype": "uptime_check",
+            "source_url": "https://cronitor.io/pricing",
+            "source_quote": "Uptime Monitoring"
+          },
+          {
+            "subtype": "status_page",
+            "source_url": "https://cronitor.io/pricing",
+            "source_quote": "Status Pages"
+          },
+          {
+            "subtype": "synthetic_check",
+            "source_url": "https://cronitor.io/pricing",
+            "source_quote": "events free $10 /mo per 100,000 events Custom Synthetic browser checks × $1 /mo per 1,000 checks Custom Fastest check"
+          }
+        ],
+        "reviewed": "2026-09-01"
       }
     },
     {
@@ -7257,6 +7531,27 @@
         "checked": "2026-08-28",
         "outcome": "ok",
         "detail": "text"
+      },
+      "product_subtypes": {
+        "taxonomy": "Monitoring",
+        "labels": [
+          {
+            "subtype": "log_management",
+            "source_url": "https://sematext.com/pricing",
+            "source_quote": "Sematext is a fully managed log management solution, with built-in replication,"
+          },
+          {
+            "subtype": "host_metrics",
+            "source_url": "https://sematext.com/pricing",
+            "source_quote": "install the agent Sematext will start providing valuable performance insights."
+          },
+          {
+            "subtype": "synthetic_check",
+            "source_url": "https://sematext.com/pricing",
+            "source_quote": "Start free trial Synthetics Monitor performance and availability of your site and APIs."
+          }
+        ],
+        "reviewed": "2026-09-01"
       }
     },
     {
@@ -8267,6 +8562,17 @@
         "checked": "2026-08-28",
         "outcome": "ok",
         "detail": "text"
+      },
+      "product_subtypes": {
+        "taxonomy": "Monitoring",
+        "labels": [
+          {
+            "subtype": "uptime_check",
+            "source_url": "https://www.uptimia.com/pricing",
+            "source_quote": "Uptime monitoring pricing that costs less than downtime."
+          }
+        ],
+        "reviewed": "2026-09-01"
       }
     },
     {
@@ -8288,6 +8594,32 @@
         "checked": "2026-08-28",
         "outcome": "ok",
         "detail": "text"
+      },
+      "product_subtypes": {
+        "taxonomy": "Monitoring",
+        "labels": [
+          {
+            "subtype": "uptime_check",
+            "source_url": "https://onlineornot.com/pricing",
+            "source_quote": "Website down checker"
+          },
+          {
+            "subtype": "cron_monitor",
+            "source_url": "https://onlineornot.com/pricing",
+            "source_quote": "Cron Job Monitoring"
+          },
+          {
+            "subtype": "status_page",
+            "source_url": "https://onlineornot.com/pricing",
+            "source_quote": "Status page included"
+          },
+          {
+            "subtype": "synthetic_check",
+            "source_url": "https://onlineornot.com/pricing",
+            "source_quote": "Monitoring Heartbeat Monitoring Website Monitoring Synthetic monitoring Status Pages Pricing Changelog Support Schedule a demo"
+          }
+        ],
+        "reviewed": "2026-09-01"
       }
     },
     {
@@ -8308,6 +8640,27 @@
         "checked": "2026-08-28",
         "outcome": "ok",
         "detail": "text"
+      },
+      "product_subtypes": {
+        "taxonomy": "Monitoring",
+        "labels": [
+          {
+            "subtype": "uptime_check",
+            "source_url": "https://hyperping.com/pricing",
+            "source_quote": "Hyperping bundles uptime monitoring, on-call and a status page on your own domain — in one plan."
+          },
+          {
+            "subtype": "status_page",
+            "source_url": "https://hyperping.com/pricing",
+            "source_quote": "Pricing Status page on your domain."
+          },
+          {
+            "subtype": "host_metrics",
+            "source_url": "https://hyperping.com/pricing",
+            "source_quote": "SERVER MONITORING Server agents A lightweight agent that reports CPU, memory, disk and network from your servers."
+          }
+        ],
+        "reviewed": "2026-09-01"
       }
     },
     {
@@ -8328,6 +8681,22 @@
         "checked": "2026-08-28",
         "outcome": "ok",
         "detail": "text"
+      },
+      "product_subtypes": {
+        "taxonomy": "Monitoring",
+        "labels": [
+          {
+            "subtype": "on_call_response",
+            "source_url": "https://incident.io/pricing",
+            "source_quote": "On-call Alert routing and grouping"
+          },
+          {
+            "subtype": "status_page",
+            "source_url": "https://incident.io/pricing",
+            "source_quote": "Status Pages"
+          }
+        ],
+        "reviewed": "2026-09-01"
       }
     },
     {
@@ -8349,6 +8718,27 @@
         "checked": "2026-08-28",
         "outcome": "ok",
         "detail": "text"
+      },
+      "product_subtypes": {
+        "taxonomy": "Monitoring",
+        "labels": [
+          {
+            "subtype": "apm_traces",
+            "source_url": "https://www.appsignal.com/plans",
+            "source_quote": "All-in-one APM The complete monitoring toolkit for developers."
+          },
+          {
+            "subtype": "error_tracking",
+            "source_url": "https://www.appsignal.com/plans",
+            "source_quote": "help your codebase grow from your first error to your second database cluster"
+          },
+          {
+            "subtype": "log_management",
+            "source_url": "https://www.appsignal.com/plans",
+            "source_quote": "Long-term log storage Automatically export and store logs from AppSignal to your S3-compatible storage for long-term retention."
+          }
+        ],
+        "reviewed": "2026-09-01"
       }
     },
     {
@@ -8372,6 +8762,32 @@
         "checked": "2026-08-28",
         "outcome": "ok",
         "detail": "text"
+      },
+      "product_subtypes": {
+        "taxonomy": "Monitoring",
+        "labels": [
+          {
+            "subtype": "apm_traces",
+            "source_url": "https://middleware.io/pricing/",
+            "source_quote": "Monitoring Monitor servers, cloud & infra health APM Track app performance & fix slowdowns Log Monitoring Debug faster with AI"
+          },
+          {
+            "subtype": "log_management",
+            "source_url": "https://middleware.io/pricing/",
+            "source_quote": "Customer Stories Product Updates Ebooks & Whitepaper Blogs Events Webinar Docs Podcasts 4,200+ engineers SREs, backend, and platform"
+          },
+          {
+            "subtype": "host_metrics",
+            "source_url": "https://middleware.io/pricing/",
+            "source_quote": "Product Products Infrastructure Monitoring Monitor servers, cloud & infra health APM Track app performance & fix"
+          },
+          {
+            "subtype": "synthetic_check",
+            "source_url": "https://middleware.io/pricing/",
+            "source_quote": "OpsAI SRE Agent Detect, debug & auto-fix issues Synthetic Monitoring Test APIs & prevent outages Browser Testing Test web apps"
+          }
+        ],
+        "reviewed": "2026-09-01"
       }
     },
     {
@@ -8393,6 +8809,22 @@
         "checked": "2026-08-28",
         "outcome": "ok",
         "detail": "text"
+      },
+      "product_subtypes": {
+        "taxonomy": "Monitoring",
+        "labels": [
+          {
+            "subtype": "host_metrics",
+            "source_url": "https://360monitoring.com/pricing/",
+            "source_quote": "Website Monitoring Server Monitoring Blocklist Monitoring Full Site Check"
+          },
+          {
+            "subtype": "uptime_check",
+            "source_url": "https://360monitoring.com/pricing/",
+            "source_quote": "Your 360° server uptime solution."
+          }
+        ],
+        "reviewed": "2026-09-01"
       }
     },
     {
@@ -11845,6 +12277,17 @@
         "checked": "2026-08-28",
         "outcome": "states_no_terms",
         "detail": "the page names StatusPile but states no amount, tier or rate we can read"
+      },
+      "product_subtypes": {
+        "taxonomy": "Monitoring",
+        "labels": [
+          {
+            "subtype": "upstream_status_watch",
+            "source_url": "https://www.statuspile.com/",
+            "source_quote": "Your status page of status pages (open sourced and free to use)"
+          }
+        ],
+        "reviewed": "2026-09-01"
       }
     },
     {
@@ -15166,6 +15609,17 @@
         "checked": "2026-08-28",
         "outcome": "states_no_terms",
         "detail": "the page names assertible.com but states no amount, tier or rate we can read"
+      },
+      "product_subtypes": {
+        "taxonomy": "Monitoring",
+        "labels": [
+          {
+            "subtype": "synthetic_check",
+            "source_url": "https://assertible.com",
+            "source_quote": "With Assertible, you can run your API tests against any environment, like staging or production ."
+          }
+        ],
+        "reviewed": "2026-09-01"
       }
     },
     {
@@ -15184,6 +15638,22 @@
         "checked": "2026-08-28",
         "outcome": "states_no_terms",
         "detail": "the page names bleemeo.com but states no amount, tier or rate we can read"
+      },
+      "product_subtypes": {
+        "taxonomy": "Monitoring",
+        "labels": [
+          {
+            "subtype": "host_metrics",
+            "source_url": "https://bleemeo.com",
+            "source_quote": "CPU, memory, disk, and network metrics collected every 10 seconds"
+          },
+          {
+            "subtype": "uptime_check",
+            "source_url": "https://bleemeo.com",
+            "source_quote": "with uptime checks from global probes."
+          }
+        ],
+        "reviewed": "2026-09-01"
       }
     },
     {
@@ -15202,6 +15672,11 @@
         "checked": "2026-08-28",
         "outcome": "states_no_terms",
         "detail": "the page names Core Web Vitals History but states no amount, tier or rate we can read"
+      },
+      "product_subtypes": {
+        "taxonomy": "Monitoring",
+        "labels": [],
+        "reviewed": "2026-09-01"
       }
     },
     {
@@ -15220,6 +15695,17 @@
         "checked": "2026-08-28",
         "outcome": "states_no_terms",
         "detail": "the page names deadmanssnitch.com but states no amount, tier or rate we can read"
+      },
+      "product_subtypes": {
+        "taxonomy": "Monitoring",
+        "labels": [
+          {
+            "subtype": "cron_monitor",
+            "source_url": "https://deadmanssnitch.com/",
+            "source_quote": "If they don't execute when they should, Dead Man's Snitch alerts you."
+          }
+        ],
+        "reviewed": "2026-09-01"
       }
     },
     {
@@ -15238,6 +15724,17 @@
         "checked": "2026-08-28",
         "outcome": "states_no_terms",
         "detail": "the page names downtimemonkey.com but states no amount, tier or rate we can read"
+      },
+      "product_subtypes": {
+        "taxonomy": "Monitoring",
+        "labels": [
+          {
+            "subtype": "uptime_check",
+            "source_url": "https://downtimemonkey.com/",
+            "source_quote": "Websites checked every minute."
+          }
+        ],
+        "reviewed": "2026-09-01"
       }
     },
     {
@@ -15256,6 +15753,11 @@
         "checked": "2026-08-28",
         "outcome": "states_no_terms",
         "detail": "the page names economize.cloud but states no amount, tier or rate we can read"
+      },
+      "product_subtypes": {
+        "taxonomy": "Monitoring",
+        "labels": [],
+        "reviewed": "2026-09-01"
       }
     },
     {
@@ -15274,6 +15776,17 @@
         "checked": "2026-08-28",
         "outcome": "ok",
         "detail": "text"
+      },
+      "product_subtypes": {
+        "taxonomy": "Monitoring",
+        "labels": [
+          {
+            "subtype": "host_metrics",
+            "source_url": "https://fivenines.io/",
+            "source_quote": "Server metrics via the open-source agent on Linux and Windows."
+          }
+        ],
+        "reviewed": "2026-09-01"
       }
     },
     {
@@ -15292,6 +15805,17 @@
         "checked": "2026-08-28",
         "outcome": "ok",
         "detail": "text"
+      },
+      "product_subtypes": {
+        "taxonomy": "Monitoring",
+        "labels": [
+          {
+            "subtype": "upstream_status_watch",
+            "source_url": "https://incidenthub.cloud/",
+            "source_quote": "The vendor outage monitor and status page aggregator that watches 1125+ third-party services in real time"
+          }
+        ],
+        "reviewed": "2026-09-01"
       }
     },
     {
@@ -15310,6 +15834,22 @@
         "checked": "2026-08-28",
         "outcome": "states_no_terms",
         "detail": "the page names inspector.dev but states no amount, tier or rate we can read"
+      },
+      "product_subtypes": {
+        "taxonomy": "Monitoring",
+        "labels": [
+          {
+            "subtype": "apm_traces",
+            "source_url": "https://www.inspector.dev",
+            "source_quote": "the exact code changes needed to fix bugs and improve application performance while staying in your agentic workflow. With the AI integration you can"
+          },
+          {
+            "subtype": "error_tracking",
+            "source_url": "https://www.inspector.dev",
+            "source_quote": "Never be the last to know your app broke"
+          }
+        ],
+        "reviewed": "2026-09-01"
       }
     },
     {
@@ -15328,6 +15868,11 @@
         "checked": "2026-08-28",
         "outcome": "ok",
         "detail": "text"
+      },
+      "product_subtypes": {
+        "taxonomy": "Monitoring",
+        "labels": [],
+        "reviewed": "2026-09-01"
       }
     },
     {
@@ -15346,6 +15891,11 @@
         "checked": "2026-08-28",
         "outcome": "states_no_terms",
         "detail": "the page names loader.io but states no amount, tier or rate we can read"
+      },
+      "product_subtypes": {
+        "taxonomy": "Monitoring",
+        "labels": [],
+        "reviewed": "2026-09-01"
       }
     },
     {
@@ -15364,6 +15914,22 @@
         "checked": "2026-08-28",
         "outcome": "ok",
         "detail": "text"
+      },
+      "product_subtypes": {
+        "taxonomy": "Monitoring",
+        "labels": [
+          {
+            "subtype": "uptime_check",
+            "source_url": "https://monitormonk.com",
+            "source_quote": "MonitorMonk keeps an eye on your websites and services 24/7"
+          },
+          {
+            "subtype": "status_page",
+            "source_url": "https://monitormonk.com",
+            "source_quote": "display their status on beautiful status pages"
+          }
+        ],
+        "reviewed": "2026-09-01"
       }
     },
     {
@@ -15382,6 +15948,27 @@
         "checked": "2026-08-28",
         "outcome": "states_no_terms",
         "detail": "the page names netdata.cloud but states no amount, tier or rate we can read"
+      },
+      "product_subtypes": {
+        "taxonomy": "Monitoring",
+        "labels": [
+          {
+            "subtype": "host_metrics",
+            "source_url": "https://www.netdata.cloud/",
+            "source_quote": "Metrics Management eBPF Monitoring"
+          },
+          {
+            "subtype": "metrics_backend",
+            "source_url": "https://www.netdata.cloud/",
+            "source_quote": "Centralized metrics streaming and storage"
+          },
+          {
+            "subtype": "synthetic_check",
+            "source_url": "https://www.netdata.cloud/",
+            "source_quote": "Infrastructure Monitoring Container Monitoring Synthetic Checks Application Performance Database Monitoring Troubleshooting"
+          }
+        ],
+        "reviewed": "2026-09-01"
       }
     },
     {
@@ -15400,6 +15987,11 @@
         "checked": "2026-08-28",
         "outcome": "states_no_terms",
         "detail": "the page names OntarioNet.ca CN Test but states no amount, tier or rate we can read"
+      },
+      "product_subtypes": {
+        "taxonomy": "Monitoring",
+        "labels": [],
+        "reviewed": "2026-09-01"
       }
     },
     {
@@ -15418,6 +16010,17 @@
         "checked": "2026-08-28",
         "outcome": "ok",
         "detail": "text"
+      },
+      "product_subtypes": {
+        "taxonomy": "Monitoring",
+        "labels": [
+          {
+            "subtype": "page_change_watch",
+            "source_url": "https://pagecrawl.io/",
+            "source_quote": "Get notified when any webpage changes."
+          }
+        ],
+        "reviewed": "2026-09-01"
       }
     },
     {
@@ -15436,6 +16039,17 @@
         "checked": "2026-08-28",
         "outcome": "ok",
         "detail": "text"
+      },
+      "product_subtypes": {
+        "taxonomy": "Monitoring",
+        "labels": [
+          {
+            "subtype": "on_call_response",
+            "source_url": "https://pagertree.com/",
+            "source_quote": "Centralize alerts and notify the right people at the right time."
+          }
+        ],
+        "reviewed": "2026-09-01"
       }
     },
     {
@@ -15454,6 +16068,22 @@
         "checked": "2026-08-28",
         "outcome": "ok",
         "detail": "text"
+      },
+      "product_subtypes": {
+        "taxonomy": "Monitoring",
+        "labels": [
+          {
+            "subtype": "uptime_check",
+            "source_url": "https://phare.io/",
+            "source_quote": "Uptime monitoring, alerts, incidents AI"
+          },
+          {
+            "subtype": "status_page",
+            "source_url": "https://phare.io/",
+            "source_quote": "customizable status page"
+          }
+        ],
+        "reviewed": "2026-09-01"
       }
     },
     {
@@ -15472,6 +16102,17 @@
         "checked": "2026-08-28",
         "outcome": "states_no_terms",
         "detail": "the page names pingbreak.com but states no amount, tier or rate we can read"
+      },
+      "product_subtypes": {
+        "taxonomy": "Monitoring",
+        "labels": [
+          {
+            "subtype": "uptime_check",
+            "source_url": "https://pingbreak.com/",
+            "source_quote": "Pingbreak checks all of your websites each minute and alerts you instantly by Direct Message (DM) or slack, discord, mattermost, mail notifications."
+          }
+        ],
+        "reviewed": "2026-09-01"
       }
     },
     {
@@ -15490,6 +16131,17 @@
         "checked": "2026-08-28",
         "outcome": "ok",
         "detail": "text"
+      },
+      "product_subtypes": {
+        "taxonomy": "Monitoring",
+        "labels": [
+          {
+            "subtype": "uptime_check",
+            "source_url": "https://pingmeter.com/",
+            "source_quote": "Multiple servers in different countries will scan your website and furnish a performance report for you"
+          }
+        ],
+        "reviewed": "2026-09-01"
       }
     },
     {
@@ -15508,6 +16160,22 @@
         "checked": "2026-08-28",
         "outcome": "states_no_terms",
         "detail": "the page names pingpong.one but states no amount, tier or rate we can read"
+      },
+      "product_subtypes": {
+        "taxonomy": "Monitoring",
+        "labels": [
+          {
+            "subtype": "status_page",
+            "source_url": "https://pingpong.one/",
+            "source_quote": "Hosted status page A central place for all status updates."
+          },
+          {
+            "subtype": "uptime_check",
+            "source_url": "https://pingpong.one/",
+            "source_quote": "Measure the performance and uptime of your website or API and showcase the result on your status page. If your site goes down, you will be notified instantly."
+          }
+        ],
+        "reviewed": "2026-09-01"
       }
     },
     {
@@ -15526,6 +16194,11 @@
         "checked": "2026-08-28",
         "outcome": "ok",
         "detail": "text"
+      },
+      "product_subtypes": {
+        "taxonomy": "Monitoring",
+        "labels": [],
+        "reviewed": "2026-09-01"
       }
     },
     {
@@ -15544,6 +16217,17 @@
         "checked": "2026-08-28",
         "outcome": "states_no_terms",
         "detail": "the page names Servervana but states no amount, tier or rate we can read"
+      },
+      "product_subtypes": {
+        "taxonomy": "Monitoring",
+        "labels": [
+          {
+            "subtype": "uptime_check",
+            "source_url": "https://servervana.com",
+            "source_quote": "Uptime monitoring."
+          }
+        ],
+        "reviewed": "2026-09-01"
       }
     },
     {
@@ -15562,6 +16246,22 @@
         "checked": "2026-08-28",
         "outcome": "ok",
         "detail": "text"
+      },
+      "product_subtypes": {
+        "taxonomy": "Monitoring",
+        "labels": [
+          {
+            "subtype": "host_metrics",
+            "source_url": "https://simpleobservability.com",
+            "source_quote": "Server monitoring Monitor your entire fleet."
+          },
+          {
+            "subtype": "log_management",
+            "source_url": "https://simpleobservability.com",
+            "source_quote": "Dashboard Configuration Metrics Logs"
+          }
+        ],
+        "reviewed": "2026-09-01"
       }
     },
     {
@@ -15580,6 +16280,22 @@
         "checked": "2026-08-28",
         "outcome": "states_no_terms",
         "detail": "the page names sitesure.net but states no amount, tier or rate we can read"
+      },
+      "product_subtypes": {
+        "taxonomy": "Monitoring",
+        "labels": [
+          {
+            "subtype": "uptime_check",
+            "source_url": "https://sitesure.net",
+            "source_quote": "Sitesure will check your website, API endpoint, or TCP service at a regular interval from around the world and notify you when the response is not expected."
+          },
+          {
+            "subtype": "cron_monitor",
+            "source_url": "https://sitesure.net",
+            "source_quote": "It works for cron jobs and any other scheduler."
+          }
+        ],
+        "reviewed": "2026-09-01"
       }
     },
     {
@@ -15598,6 +16314,17 @@
         "checked": "2026-08-28",
         "outcome": "states_no_terms",
         "detail": "the page names skylight.io but states no amount, tier or rate we can read"
+      },
+      "product_subtypes": {
+        "taxonomy": "Monitoring",
+        "labels": [
+          {
+            "subtype": "apm_traces",
+            "source_url": "https://www.skylight.io/",
+            "source_quote": "Skylight is a smart profiler for Ruby and Rails applications."
+          }
+        ],
+        "reviewed": "2026-09-01"
       }
     },
     {
@@ -15616,6 +16343,17 @@
         "checked": "2026-08-28",
         "outcome": "states_no_terms",
         "detail": "the page names statusgator.com but states no amount, tier or rate we can read"
+      },
+      "product_subtypes": {
+        "taxonomy": "Monitoring",
+        "labels": [
+          {
+            "subtype": "upstream_status_watch",
+            "source_url": "https://statusgator.com/",
+            "source_quote": "Status aggregation Aggregate the status of all vendors to a single page"
+          }
+        ],
+        "reviewed": "2026-09-01"
       }
     },
     {
@@ -15634,6 +16372,17 @@
         "checked": "2026-08-28",
         "outcome": "ok",
         "detail": "text"
+      },
+      "product_subtypes": {
+        "taxonomy": "Monitoring",
+        "labels": [
+          {
+            "subtype": "uptime_check",
+            "source_url": "https://dicloud.net/sweetuptime-server-uptime-monitoring/",
+            "source_quote": "Get notified when your website & server is down before your customer got angry"
+          }
+        ],
+        "reviewed": "2026-09-01"
       }
     },
     {
@@ -15652,6 +16401,22 @@
         "checked": "2026-08-28",
         "outcome": "ok",
         "detail": "text"
+      },
+      "product_subtypes": {
+        "taxonomy": "Monitoring",
+        "labels": [
+          {
+            "subtype": "host_metrics",
+            "source_url": "https://syagent.com/",
+            "source_quote": "Monitor Linux servers, processes, disks, network"
+          },
+          {
+            "subtype": "uptime_check",
+            "source_url": "https://syagent.com/",
+            "source_quote": "Uptime HTTP, PING, PUSH"
+          }
+        ],
+        "reviewed": "2026-09-01"
       }
     },
     {
@@ -15670,6 +16435,22 @@
         "checked": "2026-08-28",
         "outcome": "states_no_terms",
         "detail": "the page names UptimeObserver.com but states no amount, tier or rate we can read"
+      },
+      "product_subtypes": {
+        "taxonomy": "Monitoring",
+        "labels": [
+          {
+            "subtype": "uptime_check",
+            "source_url": "https://uptimeobserver.com",
+            "source_quote": "UptimeObserver monitors websites, APIs, DNS records, Server Ports, Domain Name Expiry and SSL Expiry for downtime and performance issues, alerting you when something goes wrong."
+          },
+          {
+            "subtype": "status_page",
+            "source_url": "https://uptimeobserver.com",
+            "source_quote": "Status Pages"
+          }
+        ],
+        "reviewed": "2026-09-01"
       }
     },
     {
@@ -15688,6 +16469,22 @@
         "checked": "2026-08-28",
         "outcome": "ok",
         "detail": "text"
+      },
+      "product_subtypes": {
+        "taxonomy": "Monitoring",
+        "labels": [
+          {
+            "subtype": "uptime_check",
+            "source_url": "https://uptimetoolbox.com/",
+            "source_quote": "We're now monitoring your site. Besides letting you know if your site goes down, we'll also keep an eye on your domain expirations and SSL certificates"
+          },
+          {
+            "subtype": "status_page",
+            "source_url": "https://uptimetoolbox.com/",
+            "source_quote": "Status Page Builder"
+          }
+        ],
+        "reviewed": "2026-09-01"
       }
     },
     {
@@ -15706,6 +16503,17 @@
         "checked": "2026-08-28",
         "outcome": "states_no_terms",
         "detail": "the page names Wachete but states no amount, tier or rate we can read"
+      },
+      "product_subtypes": {
+        "taxonomy": "Monitoring",
+        "labels": [
+          {
+            "subtype": "page_change_watch",
+            "source_url": "https://www.wachete.com",
+            "source_quote": "Get told the moment it changes"
+          }
+        ],
+        "reviewed": "2026-09-01"
       }
     },
     {
@@ -15724,6 +16532,32 @@
         "checked": "2026-08-28",
         "outcome": "ok",
         "detail": "text"
+      },
+      "product_subtypes": {
+        "taxonomy": "Monitoring",
+        "labels": [
+          {
+            "subtype": "uptime_check",
+            "source_url": "https://xitoring.com/",
+            "source_quote": "HTTP(S), DNS, TCP, UDP, Ping, and mail server monitoring."
+          },
+          {
+            "subtype": "host_metrics",
+            "source_url": "https://xitoring.com/",
+            "source_quote": "HTTP(S), DNS, TCP, UDP, Ping, and mail server monitoring."
+          },
+          {
+            "subtype": "status_page",
+            "source_url": "https://xitoring.com/",
+            "source_quote": "The whitelabel status page is a huge plus."
+          },
+          {
+            "subtype": "synthetic_check",
+            "source_url": "https://xitoring.com/",
+            "source_quote": "Uptime & Synthetic Multi-protocol checks from 15+ global nodes."
+          }
+        ],
+        "reviewed": "2026-09-01"
       }
     },
     {
@@ -29817,6 +30651,27 @@
         "checked": "2026-08-28",
         "outcome": "ok",
         "detail": "text"
+      },
+      "product_subtypes": {
+        "taxonomy": "Monitoring",
+        "labels": [
+          {
+            "subtype": "metrics_backend",
+            "source_url": "https://cloud.google.com/monitoring/pricing",
+            "source_quote": "Read API calls: $0.50/million time series returned"
+          },
+          {
+            "subtype": "uptime_check",
+            "source_url": "https://cloud.google.com/monitoring/pricing",
+            "source_quote": "Execution of Monitoring uptime checks $0.30/1,000 executions"
+          },
+          {
+            "subtype": "synthetic_check",
+            "source_url": "https://cloud.google.com/monitoring/pricing",
+            "source_quote": "Execution of Monitoring Synthetic Monitors $1.20/1,000 executions"
+          }
+        ],
+        "reviewed": "2026-09-01"
       }
     },
     {
@@ -32423,6 +33278,27 @@
         "checked": "2026-08-28",
         "outcome": "ok",
         "detail": "text"
+      },
+      "product_subtypes": {
+        "taxonomy": "Monitoring",
+        "labels": [
+          {
+            "subtype": "apm_traces",
+            "source_url": "https://signoz.io/pricing/",
+            "source_quote": "APM & Distributed Tracing Out of Box"
+          },
+          {
+            "subtype": "log_management",
+            "source_url": "https://signoz.io/pricing/",
+            "source_quote": "Log Management"
+          },
+          {
+            "subtype": "metrics_backend",
+            "source_url": "https://signoz.io/pricing/",
+            "source_quote": "Metrics Explorer - search, query, and analyze all metrics"
+          }
+        ],
+        "reviewed": "2026-09-01"
       }
     },
     {
@@ -32445,6 +33321,27 @@
         "checked": "2026-08-28",
         "outcome": "states_no_terms",
         "detail": "the page names Elastic but states no amount, tier or rate we can read"
+      },
+      "product_subtypes": {
+        "taxonomy": "Monitoring",
+        "labels": [
+          {
+            "subtype": "log_management",
+            "source_url": "https://www.elastic.co/pricing/self-managed",
+            "source_quote": "Centralize and analyze logs"
+          },
+          {
+            "subtype": "metrics_backend",
+            "source_url": "https://www.elastic.co/pricing/self-managed",
+            "source_quote": "optimized storage of metrics"
+          },
+          {
+            "subtype": "synthetic_check",
+            "source_url": "https://www.elastic.co/pricing/self-managed",
+            "source_quote": "users' experience with real user monitoring (RUM), synthetic testing, and uptime monitoring App performance monitoring Monitor,"
+          }
+        ],
+        "reviewed": "2026-09-01"
       }
     },
     {
@@ -32466,6 +33363,22 @@
         "checked": "2026-08-28",
         "outcome": "ok",
         "detail": "text"
+      },
+      "product_subtypes": {
+        "taxonomy": "Monitoring",
+        "labels": [
+          {
+            "subtype": "dashboards",
+            "source_url": "https://grafana.com/oss/grafana/",
+            "source_quote": "60 min Getting started with Grafana dashboard design Watch"
+          },
+          {
+            "subtype": "synthetic_check",
+            "source_url": "https://grafana.com/oss/grafana/",
+            "source_quote": "Database Observability Frontend Observability Synthetic Monitoring Performance & Load Testing Incident Response & Management AI"
+          }
+        ],
+        "reviewed": "2026-09-01"
       }
     },
     {

--- a/data/index.json
+++ b/data/index.json
@@ -1371,17 +1371,27 @@
           {
             "subtype": "error_tracking",
             "source_url": "https://sentry.io/pricing/",
-            "source_quote": "Error Monitoring"
+            "source_quote": "Errors 50K $0.00"
           },
           {
             "subtype": "apm_traces",
             "source_url": "https://sentry.io/pricing/",
-            "source_quote": "Tracing"
+            "source_quote": "Tracing 5M spans"
           },
           {
             "subtype": "log_management",
             "source_url": "https://sentry.io/pricing/",
-            "source_quote": "Logs"
+            "source_quote": "Logs 5GB 5GB +$0.50/GB additional"
+          },
+          {
+            "subtype": "uptime_check",
+            "source_url": "https://sentry.io/pricing/",
+            "source_quote": "Uptime Monitoring 1 uptime monitor"
+          },
+          {
+            "subtype": "cron_monitor",
+            "source_url": "https://sentry.io/pricing/",
+            "source_quote": "Cron Monitoring 1 cron monitor"
           }
         ],
         "reviewed": "2026-09-01"


### PR DESCRIPTION
Closes the data half of https://github.com/robhunter/agentdeals/issues/1212. The taxonomy landed in `src/product-role.ts` in #1216; this labels the records against it.

## What ships

All 59 Monitoring records gain `product_subtypes`. 53 carry 113 labels; 6 carry `labels: []`.

Every label carries the vendor URL it was read from and the sentence read from it, so a wrong label is visible from the quote without re-reading the page. All thirteen declared subtypes are populated:

| subtype | records | | subtype | records |
|---|---|---|---|---|
| `uptime_check` | 24 | | `error_tracking` | 5 |
| `synthetic_check` | 12 | | `on_call_response` | 4 |
| `host_metrics` | 12 | | `upstream_status_watch` | 3 |
| `log_management` | 12 | | `page_change_watch` | 2 |
| `status_page` | 12 | | `dashboards` | 1 |
| `apm_traces` | 10 | | | |
| `metrics_backend` | 10 | | | |
| `cron_monitor` | 6 | | | |

`dashboards` has one member, Grafana. That is the reason the taxonomy went from eleven subtypes to thirteen: `metrics_backend` excludes products where the dashboard is what is sold, so without it the category's best-known product would have carried no label and published no alternatives permanently.

## The six empty label lists

`Core Web Vitals History`, `OntarioNet.ca CN Test`, `economize.cloud`, `linkok.com`, `loader.io`, `robusta.dev`.

Five are miscategorised into Monitoring and belong to https://github.com/robhunter/agentdeals/issues/1048 — load testing, broken-link checking, cloud cost management. robusta.dev is correctly in Monitoring, but its own page says *"Integrates with incident.io, PagerDuty, FireHydrant, Rootly and more. We don't replace your incident tools."*, so `on_call_response` is refused by the vendor.

They ship as `labels: []` rather than as an absent field on purpose. An absent field is not gated: it reads as never reviewed and is published as a substitute on every classified page in the category. `labels: []` is what "reviewed, none of the thirteen apply" looks like, and it renders `not_in_taxonomy` in the excluded line. Shipping these six with the field absent would have published 318 substitute pairs nobody checked.

## Derived effect

Measured by replaying `vendorSubstitutes` over the patched index and diffing against `HEAD`. The replay reproduces production `/alternative-to/vercel` exactly — same 28 exclusions, same gates — before being used here.

- **52 `/alternative-to` pages go from empty to publishing**, and `/alternative-to/sentry` goes from 6 to 43. 1,256 substitute pairs across the 53. 1,818 same-category pairs are excluded and disclosed with a gate. Corrected after fetching all 59 Monitoring pages on production: 58 publish nothing, and Sentry's 6 are curated pairs, which are subtype-exempt. Counts include the Sentry relabel in the second commit.
- **No page outside Monitoring changes.** No Monitoring vendor holds a record in another category, so the blast radius is the category.
- The six empty-label records are offered as a substitute **0 times**, and their own pages stay empty.

The defect that motivated the taxonomy is gone: `/alternative-to/datadog` currently offers UptimeRobot, Pulsetic, StatusCake and Uptimia as substitutes for an APM. All four are now `subtype_mismatch`. Hyperping, OnlineOrNot and Cronitor stay, and correctly — each carries `synthetic_check`, which Datadog carries too.

Smallest lists are the check that the gate is not just permissive: Wachete and pagecrawl.io are offered only each other, `page_change_watch` being a set of two. StatusPile, statusgator.com and incidenthub.cloud are offered only each other.

## Checks

`data/index.json` only. No `src/`, no `test/`. Round-trip asserted byte-identical through `json.dumps(indent=2, ensure_ascii=False)` before and after. `scripts/lint-duplicates.js` clean. `/criteria`'s coverage sentence is computed from this data at render time, so it moves to `59 of 59 in Monitoring` with no code change.

