### PR TITLE
Derive the two fixtures that assumed Monitoring was unclassified

### DIFF
--- a/test/product-role.test.ts
+++ b/test/product-role.test.ts
@@ -573,14 +573,23 @@ describe("#1032 what the gates do to the catalogue", () => {
     assert.ok(!kept.includes("DynamoDB Local"), "a downloadable emulator is not an alternative to a hosted database");
   });
 
-  function keptCounts(): Array<{ label: string; kept: number }> {
-    const counts: Array<{ label: string; kept: number }> = [];
+  function withoutRole(offer: Offer): Offer {
+    const { product_role, ...rest } = offer;
+    return rest as Offer;
+  }
+
+  function keptCounts(): Array<{ label: string; kept: number; subtypePool: number }> {
+    const counts: Array<{ label: string; kept: number; subtypePool: number }> = [];
     for (const category of categories) {
       const inCategory = index.offers.filter((o) => o.category === category);
       if (inCategory.length < 4) continue;
       for (const subject of inCategory) {
-        const kept = filterAlternatives(inCategory.filter((o) => o.vendor !== subject.vendor), subject);
-        counts.push({ label: `${subject.vendor} (${category})`, kept: kept.length });
+        const peers = inCategory.filter((o) => o.vendor !== subject.vendor);
+        counts.push({
+          label: `${subject.vendor} (${category})`,
+          kept: filterAlternatives(peers, subject).length,
+          subtypePool: filterAlternatives(peers.map(withoutRole), subject).length,
+        });
       }
     }
     return counts;
@@ -591,12 +600,20 @@ describe("#1032 what the gates do to the catalogue", () => {
     assert.deepStrictEqual(empty, [], `an empty list states in our own voice that we index no peer at all: ${empty.join("; ")}`);
   });
 
-  it("names every alternatives list the gates leave below three entries", () => {
-    const thin = keptCounts().filter((c) => c.kept < 3).map((c) => `${c.label}: ${c.kept}`).sort();
-    assert.deepStrictEqual(thin, [
-      "InfluxDB Cloud (Databases): 1",
-      "Neo4j AuraDB (Databases): 2",
-    ]);
+  it("names every alternatives list below three entries that the subtype pool does not account for", () => {
+    const thin = keptCounts().filter((c) => c.kept < 3);
+    const notFromTheSubtype = thin
+      .filter((c) => c.subtypePool >= 3)
+      .map((c) => `${c.label}: ${c.kept} of ${c.subtypePool}`)
+      .sort();
+    assert.deepStrictEqual(
+      notFromTheSubtype,
+      [
+        "InfluxDB Cloud (Databases): 1 of 4",
+        "Neo4j AuraDB (Databases): 2 of 5",
+      ],
+      `every list below three entries, whatever thinned it: ${thin.map((c) => `${c.label}: ${c.kept}`).sort().join("; ")}`
+    );
   });
 
   it("leaves reviewed products that are their own category's real thing ungated", () => {

--- a/test/substitute-evidence.test.ts
+++ b/test/substitute-evidence.test.ts
@@ -5,16 +5,47 @@ import { readFileSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { partitionSubstitutes, subtypeGateBinds, substitutesFor } from "../dist/product-role.js";
-import type { Offer } from "../src/types.ts";
+import { toSlug, vendorSlugMap } from "../dist/vendor-slug.js";
+import { curatedAlternativeNames } from "../dist/curated-alternatives.js";
+import type { DealChange, Offer } from "../src/types.ts";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const REPO = path.join(__dirname, "..");
 
 const offers: Offer[] = JSON.parse(readFileSync(path.join(REPO, "data", "index.json"), "utf-8")).offers;
+const changes: DealChange[] = JSON.parse(readFileSync(path.join(REPO, "data", "deal_changes.json"), "utf-8")).changes;
 
 const CLASSIFIED_CATEGORIES = ["Databases", "Cloud Hosting"];
 const SENDGRID_WRONG_CLASS = ["Bench", "Remote for Startups", "Esri Startup Program"];
 const SENDGRID_CURATED = ["Postmark", "Resend", "Amazon SES"];
+
+interface UnclassifiedSubject {
+  vendor: string;
+  slug: string;
+  category: string;
+  peers: number;
+}
+
+function unclassifiedSubject(): UnclassifiedSubject | null {
+  const inCategory = new Map<string, Offer[]>();
+  const classified = new Set<string>();
+  for (const offer of offers) {
+    if (!inCategory.has(offer.category)) inCategory.set(offer.category, []);
+    inCategory.get(offer.category)!.push(offer);
+    if ((offer.product_subtypes?.labels.length ?? 0) > 0) classified.add(offer.category);
+  }
+  const ranked = [...inCategory.entries()]
+    .filter(([category]) => !classified.has(category))
+    .sort((a, b) => b[1].length - a[1].length || a[0].localeCompare(b[0]));
+  for (const [category, list] of ranked) {
+    const vendors = [...new Set(list.map(o => o.vendor))].sort();
+    const vendor = vendors.find(v => curatedAlternativeNames(v, changes).length === 0 && vendorSlugMap.get(toSlug(v)) === v);
+    if (vendor) return { vendor, slug: toSlug(vendor), category, peers: vendors.length - 1 };
+  }
+  return null;
+}
+
+const subjectWithNoClass = unclassifiedSubject();
 
 function offerFixture(vendor: string, category: string, subtypes?: string[]): Offer {
   return {
@@ -162,10 +193,18 @@ describe("/alternative-to/sendgrid", () => {
 });
 
 describe("a page with no evidence of a product class", () => {
+  it("draws its subject from the largest category no record carries a subtype for", () => {
+    assert.ok(
+      subjectWithNoClass,
+      "every category now carries a subtype, so this block has no subject left and needs one that publishes an empty substitute list for another reason",
+    );
+    assert.ok(subjectWithNoClass!.peers >= 3, `${subjectWithNoClass!.vendor} must have same-category peers it would be offered but for the gate, found ${subjectWithNoClass!.peers}`);
+  });
+
   it("offers no substitute, heads no list of them, and still answers", async () => {
-    const { status, body } = await get("/alternative-to/datadog");
+    const { status, body } = await get(`/alternative-to/${subjectWithNoClass!.slug}`);
     assert.strictEqual(status, 200);
-    assert.strictEqual((body.match(/class="alt-vendor-name"/g) ?? []).length, 0);
+    assert.strictEqual((body.match(/class="alt-vendor-name"/g) ?? []).length, 0, `/alternative-to/${subjectWithNoClass!.slug} names a substitute`);
     assert.doesNotMatch(body, /All Free Alternatives \(/);
     assert.ok(!jsonLdBlocks(body).some(b => b["@type"] === "ItemList"), "an empty set must not ship as an ItemList");
     const ogDescription = body.match(/<meta property="og:description" content="([^"]*)"/)?.[1] ?? "";
@@ -176,10 +215,10 @@ describe("a page with no evidence of a product class", () => {
   });
 
   it("asks no question it cannot answer", async () => {
-    const { body } = await get("/alternative-to/datadog");
+    const { body } = await get(`/alternative-to/${subjectWithNoClass!.slug}`);
     const faq = jsonLdBlocks(body).find(b => b["@type"] === "FAQPage");
     assert.ok(!faq, "a page with no substitute list publishes no questions about one");
-    const vendor = await get("/vendor/datadog");
+    const vendor = await get(`/vendor/${subjectWithNoClass!.slug}`);
     const vendorFaq = jsonLdBlocks(vendor.body).find(b => b["@type"] === "FAQPage") as { mainEntity: Array<{ name: string }> } | undefined;
     assert.ok(vendorFaq, "the questions we can answer about the vendor stay published on the vendor page");
     assert.ok(
@@ -189,7 +228,7 @@ describe("a page with no evidence of a product class", () => {
   });
 
   it("counts no list on the vendor page either", async () => {
-    const { status, body } = await get("/vendor/datadog");
+    const { status, body } = await get(`/vendor/${subjectWithNoClass!.slug}`);
     assert.strictEqual(status, 200);
     const subhead = body.match(/<p class="page-meta">([\s\S]*?)<\/p>/)?.[1] ?? "";
     assert.ok(subhead.length > 0, "the vendor page must carry a subhead for this to test anything");


### PR DESCRIPTION
Unblocks https://github.com/robhunter/agentdeals/pull/1217. Refs #1212.

Three assertions go red on that PR. Both fixtures are correct about the site and wrong about the data: each pins a fact that a classification data PR is expected to change, and the labels land in a PR that does not edit `test/`.

## What was pinned

**`substitute-evidence.test.ts`** used `/alternative-to/datadog` as the page that publishes no substitute list. Datadog is classified in #1217, so it publishes 27. A third assertion in the same block still passed — the subhead no longer says `0 alternatives` because the page now has 27 — so it had stopped testing anything.

**`product-role.test.ts`** listed the two alternatives lists the gates leave below three entries. #1217 adds five more, all in Monitoring, all of them arithmetic: `page_change_watch` has exactly two members, so Wachete and pagecrawl.io can only ever be offered each other.

## What they read now

The empty-list fixture comes from the index: the largest category no record carries a subtype for, then the first vendor in it with no curated alternative and a slug that resolves to itself. Today that is APITemplate.io in Dev Utilities, 109 records. When Dev Utilities is classified the fixture moves on its own. A new assertion states the block has a subject and that it has same-category peers, so an empty list is evidence of a gate rather than an empty category.

The register keeps its two entries and its exact form, with the criterion narrowed: a list below three is named only where the subtype gate alone would have left three or more — a gate, not a small product class, did the thinning. `InfluxDB Cloud: 1 of 4` and `Neo4j AuraDB: 2 of 5`, unchanged from main. The five Monitoring lists are `1 of 1` and `2 of 2` and no longer qualify. The full thin list is still printed in the assertion message.

This is not what #1217's comment asked for — that asked for the five names to be added. Adding them works and goes red again on the AI / ML data PR, and on each of the ~60 categories after it, each time needing a round trip through `test/`. One line reverts to the literal register if you would rather have it.

## Checks

2,898 tests pass on this branch and 2,898 on this branch merged with `pm/monitoring-subtypes-2026-09-01` — that merge is what #1217 becomes, and the three failures are gone. `tsc --noEmit` clean. No `src/`, no `data/`, so no served byte moves.

Mutations, on the merged tree:

| mutation | result |
|---|---|
| `partitionSubstitutes` admits unclassified candidates | killed by both derived-fixture page assertions |
| `membershipGatesFor` stops emitting `addon` | killed by the register, which prints the five Monitoring lists it did not name |
| membership groups always mismatch | killed by 5 assertions elsewhere, including two from #1216; the register does not move under the old form either |
| deployment gate widened to `self_hosted` | killed elsewhere; register unchanged under the old form too |
| gate symmetry dropped | killed elsewhere; the thin set is byte-identical, so the old register missed it as well |

The last three are the check that the narrowed criterion gives nothing up: in every case where the old register would have fired and the new one would not, it did not fire either.