### PR TITLE
Mark GitHub Models retired — GitHub ended it on 2026-07-30 (#1221)

### DIFF
--- a/data/index.json
+++ b/data/index.json
@@ -30707,9 +30707,9 @@
     {
       "vendor": "GitHub Models",
       "category": "AI / ML",
-      "description": "Free access to 100+ AI models via GitHub Marketplace — GPT-4o, Llama, Mistral, Phi, and more. Free tier: 10-15 RPM, 50-150 requests/day depending on model tier. OpenAI-compatible API endpoint",
-      "tier": "Free",
-      "url": "https://github.com/marketplace/models",
+      "description": "GitHub retired GitHub Models on 2026-07-30, so there is no free tier. GitHub's own documentation states \"GitHub Models has been retired.\" The former offer was free access to 100+ models via GitHub Marketplace at 10-15 RPM and 50-150 requests/day.",
+      "tier": "Retired",
+      "url": "https://docs.github.com/en/github-models/about-github-models",
       "tags": [
         "ai",
         "ml",
@@ -30720,15 +30720,6 @@
         "openai-compatible"
       ],
       "verifiedDate": "2026-08-20",
-      "payment_protocols": [
-        {
-          "protocol": "x402",
-          "chain": "Base",
-          "settlement": "USDC",
-          "pricing_model": "per-request",
-          "example_cost": "$0.001-0.01/request"
-        }
-      ],
       "referral_program": {
         "available": false,
         "referrer_benefit": "N/A",


### PR DESCRIPTION
Refs https://github.com/robhunter/agentdeals/issues/1221.

`https://github.com/marketplace/models` is now a sign-in wall, so `source_check` reads it as `states_no_terms` and `/vendor/github-models` publishes *"GitHub Models Free Tier 2026 — Verified August 2026 — Free access to 100+ AI models via GitHub Marketplace"* over an offer that ended five weeks ago.

https://docs.github.com/en/github-models/about-github-models reads *"GitHub Models has been retired. As of July 30, 2026..."*, and that sentence is the page's entire meta description.

## The edit

One record, four fields.

| field | before | after |
|---|---|---|
| `url` | `https://github.com/marketplace/models` | `https://docs.github.com/en/github-models/about-github-models` |
| `tier` | `Free` | `Retired` |
| `description` | *"Free access to 100+ AI models... Free tier: 10-15 RPM"* | opens *"GitHub retired GitHub Models on 2026-07-30, so there is no free tier"* and keeps the former terms as history |
| `payment_protocols` | x402 on Base, per-request | removed |

The x402 block claimed a settlement path on a product that no longer accepts requests.

`tier: "Retired"` follows the `Google Content API for Shopping` precedent, which carries `Free (Deprecated)` with its sunset date in the description.

**The record stays.** `/vendor/github-models` is in `sitemap-vendors.xml`; removing it would 404 an indexed URL.

## Derived effects

- `src/data.ts:880` and `:915` filter related and alternative offers on `o.tier.toLowerCase().includes("free")`, so the record leaves those lists. Intended.
- `src/serve.ts:3735` sets `hasFree` false when the description contains `no free tier`, which flips the *"Is GitHub Models free? Yes"* answer in the JSON-LD.
- AI / ML holds 70 records against `BEST_OF_MIN_VENDORS` of 5, so no best-of page appears or disappears.
- `data/index.json` round-trips byte-identical through `json.dumps(indent=2, ensure_ascii=False)` plus a newline, asserted before and after.

`node scripts/validate-data.ts` reports *"All data valid. 1580 offers, 438 deal changes"* and `node scripts/lint-duplicates.js` is clean. The test suite needs `dist/`, which this checkout cannot build, so CI is the first full run.

## What this does not fix

The page still reads *"GitHub Models Free Tier 2026"* and *"Verified August 2026"*. No data field can change either, which is #1221 criterion 5. And the same shape is live on 591 other `states_no_terms` records that I have no way to sort by how long the read has been failing.
