### PR TITLE
Gate a substitute we have never read against its category's subtypes (#1218)

### DIFF
--- a/src/product-role.ts
+++ b/src/product-role.ts
@@ -1,10 +1,10 @@
 import type { Offer, ProductRole, ProductSubtypes } from "./types.js";
 
-export type RoleCarrier = { product_role?: ProductRole; product_subtypes?: ProductSubtypes };
+export type RoleCarrier = { product_role?: ProductRole; product_subtypes?: ProductSubtypes; category?: string };
 
-export type MembershipGate = "local_dev_only" | "addon" | "not_in_taxonomy" | "subtype_mismatch";
+export type MembershipGate = "local_dev_only" | "addon" | "not_yet_classified" | "not_in_taxonomy" | "subtype_mismatch";
 
-export const MEMBERSHIP_GATE_ORDER: MembershipGate[] = ["local_dev_only", "addon", "not_in_taxonomy", "subtype_mismatch"];
+export const MEMBERSHIP_GATE_ORDER: MembershipGate[] = ["local_dev_only", "addon", "not_yet_classified", "not_in_taxonomy", "subtype_mismatch"];
 
 export const MEMBERSHIP_GATE_RULES: Record<MembershipGate, { label: string; rule: string }> = {
   local_dev_only: {
@@ -14,6 +14,10 @@ export const MEMBERSHIP_GATE_RULES: Record<MembershipGate, { label: string; rule
   addon: {
     label: "Extends another product",
     rule: "The product adds a capability to another product rather than replacing it. It is not an alternative to the thing it augments.",
+  },
+  not_yet_classified: {
+    label: "We have not classified this record",
+    rule: "The offer is listed in a category whose subtypes we publish, and we have not yet read it against them. We therefore hold no basis for offering it as an alternative to anything here. This states what we have not done rather than a finding about the product, and it stops applying the day we classify the record.",
   },
   not_in_taxonomy: {
     label: "None of this category's subtypes apply",
@@ -84,7 +88,7 @@ export const SUBTYPE_MEMBERSHIP_GROUPS: Record<string, SubtypeMembershipGroup[]>
 };
 
 export const SUBTYPE_MEMBERSHIP_RULE =
-  "Two offers in the same category are alternatives when their subtype sets share at least one member, or when both carry a subtype from one of the membership groups below. A record we have not classified is offered no substitutes and is offered as one to no one. It stays listed in its category, in search, and on best-of pages.";
+  "Two offers in the same category are alternatives when their subtype sets share at least one member, or when both carry a subtype from one of the membership groups below. A record we have not classified is offered no substitutes, and is offered as one only where a person wrote the pair down by name. It stays listed in its category, in search, and on best-of pages.";
 
 export const SUBTYPE_MEMBERSHIP_GROUP_SCOPE =
   "A group answers whether a product could substitute at all. Which one is the better answer is ordering, and ordering is a separate, seeded, published concern that reads none of this.";
@@ -129,11 +133,17 @@ export function subtypesAcross(subjects: RoleCarrier[]): SubtypeProfile[] {
   return [...byTaxonomy.entries()].map(([taxonomy, subtypes]) => ({ taxonomy, subtypes }));
 }
 
+function classifiedSubjectProfile(taxonomy: string | undefined, subjectProfiles: SubtypeProfile[]): SubtypeProfile | null {
+  if (!taxonomy) return null;
+  const shared = subjectProfiles.find(p => p.taxonomy === taxonomy);
+  return shared && shared.subtypes.size > 0 ? shared : null;
+}
+
 function subtypeGate(candidate: RoleCarrier, subjectProfiles: SubtypeProfile[]): MembershipGate | null {
   const own = subtypesOf(candidate);
-  if (!own) return null;
-  const shared = subjectProfiles.find(p => p.taxonomy === own.taxonomy);
-  if (!shared || shared.subtypes.size === 0) return null;
+  if (!own) return classifiedSubjectProfile(candidate.category, subjectProfiles) ? "not_yet_classified" : null;
+  const shared = classifiedSubjectProfile(own.taxonomy, subjectProfiles);
+  if (!shared) return null;
   for (const subtype of own.subtypes) {
     if (shared.subtypes.has(subtype)) return null;
   }

--- a/src/serve.ts
+++ b/src/serve.ts
@@ -43,7 +43,7 @@ import { discontinuedOnOrBefore, PRODUCT_DEPRECATED } from "./product-deprecatio
 import { rankOffers, rankForListing, rotateListing, utcDate, CRITERIA_PATH, DEMOTE_ONLY_POLICY, DISCLOSURE_RATIONALE, TIE_BREAK_ALGORITHM, GATE_TABLE, DEMERIT_TABLE, NOT_FREE_TIER_RULES, TIME_LIMITED_TIER_RULES, type TieBreak } from "./ranking.js";
 import type { RankedEntry, RankingResult } from "./ranking.js";
 import { verificationLedger, QUARANTINE_AFTER_FAILURES } from "./verification-state.js";
-import { partitionAlternatives, partitionSubstitutes, type SubstitutesPartition, productRoleSentence, MEMBERSHIP_GATE_RULES, MEMBERSHIP_GATE_ORDER, MEMBERSHIP_GATE_SYMMETRY, MEMBERSHIP_GATE_SCOPE, MEMBERSHIP_GATE_CORRECTIONS, SUBTYPE_TAXONOMIES, SUBTYPE_MEMBERSHIP_RULE, SUBTYPE_MEMBERSHIP_GROUP_SCOPE, membershipGroupsFor, subtypeDefinition } from "./product-role.js";
+import { partitionAlternatives, partitionSubstitutes, type SubstitutesPartition, productRoleSentence, MEMBERSHIP_GATE_RULES, MEMBERSHIP_GATE_ORDER, MEMBERSHIP_GATE_SYMMETRY, MEMBERSHIP_GATE_SCOPE, MEMBERSHIP_GATE_CORRECTIONS, SUBTYPE_TAXONOMIES, SUBTYPE_MEMBERSHIP_RULE, SUBTYPE_MEMBERSHIP_GROUP_SCOPE, CURATED_SUBTYPE_EXEMPTION, membershipGroupsFor, subtypeDefinition } from "./product-role.js";
 import { resolveCuratedAlternatives, curatedAlternativesFor, addCuratedToPool } from "./curated-alternatives.js";
 import type { Agent, ChangeDateSource, DealChange, RiskCause, LinkUnreachable, Offer } from "./types.js";
 import { changeDateLabel, changeDateClause, changeDatePublished, changeEventStartDate, capListSections, latestEventDate, offerExpiryAfter, feedEntryUpdated, undatedGroupHeading, firstReadHeading, discoveryBatchNote, isoWeekOf, DISCOVERED_DATE_PREFIX, UNDATED_GROUP_NOTE } from "./change-dates.js";
@@ -1856,7 +1856,9 @@ ${entries.map(e => `<tr><td><code>${escHtmlServer(e.subtype)}</code></td><td>${e
       const done = inTaxonomy.filter(o => o.product_subtypes).length;
       return `${done} of ${inTaxonomy.length} in ${taxonomy}`;
     });
-    return `We have classified ${parts.join(", ")}; the other ${offers.length - offers.filter(o => o.product_subtypes).length} records carry no subtype, so they are offered no substitutes and are offered as one to no one. Classifying a category restores both directions.`;
+    const unclassified = offers.filter(o => !o.product_subtypes);
+    const inPublishedTaxonomy = unclassified.filter(o => SUBTYPE_TAXONOMIES[o.category]).length;
+    return `We have classified ${parts.join(", ")}; the other ${unclassified.length} records carry no subtype, so they are offered no substitutes, and are offered as one only where a person wrote the pair down by name. ${inPublishedTaxonomy} of them sit in a category whose subtypes we do publish. Classifying a category restores both directions.`;
   })();
 
   const jsonLd = {
@@ -1984,13 +1986,15 @@ ${membershipGateRows}
   <p>${escHtmlServer(MEMBERSHIP_GATE_SYMMETRY)}</p>
   <p>${escHtmlServer(MEMBERSHIP_GATE_SCOPE)}</p>
   <p><strong style="color:var(--text)">No property here is available on request.</strong> A vendor cannot ask to be classified, declassified, or exempted, for the same reason there is no top slot to buy. ${escHtmlServer(MEMBERSHIP_GATE_CORRECTIONS)}</p>
-  <p>The honest limit: we have classified ${classifiedCount} of ${offers.length} records, ${gatedCount} of which carry a gate. <strong style="color:var(--text)">A record with no classification has not been reviewed &mdash; it does not mean we have checked and found it hosted.</strong> Absence of the property publishes nothing in either direction and gates nothing, which is the same rule we use for a link we were merely refused.</p>
+  <p>The honest limit: we have classified ${classifiedCount} of ${offers.length} records, ${gatedCount} of which carry a gate. <strong style="color:var(--text)">A record with no classification has not been reviewed &mdash; it does not mean we have checked and found it hosted.</strong> Absence of the property publishes nothing in either direction and gates nothing, which is the same rule we use for a link we were merely refused. Subtypes are the deliberate exception, and the next section says why.</p>
 
   <h3 id="subtypes">Subtypes</h3>
   <p>A category is a coarse property. Where we have published a subtype taxonomy for a category, the same discipline applies one level finer: a subtype is what the vendor's own copy says the product <em>is</em>, it is multi-label, and it decides membership only. ${escHtmlServer(SUBTYPE_MEMBERSHIP_RULE)}</p>
 ${subtypeTaxonomyTables}
   <p>${escHtmlServer(SUBTYPE_MEMBERSHIP_GROUP_SCOPE)}</p>
   <p>Subtypes are published on every classified vendor page with the source URL and the sentence they were read from, exactly as the properties above are. ${subtypeCoverageClause}</p>
+  <p><strong style="color:var(--text)">Where a taxonomy is published, silence is not a pass.</strong> A record we have not read against it is held out of that category's alternatives lists and named there, rather than offered on the strength of a reading we never did. That is the opposite of how the properties above treat absence, and it is deliberate: those describe a product we looked at, while a missing subtype describes only us.</p>
+  <p>${escHtmlServer(CURATED_SUBTYPE_EXEMPTION)}</p>
 
   <h2>6. What agents tell us, and what we do with it</h2>
   <p>Agents can report which vendor they recommended, at <a href="${SIGNAL_DOC_PATH}"><code>${escHtmlServer(SIGNAL_PATH)}</code></a>. <strong style="color:var(--text)">Those counts never affect any order we publish</strong> &mdash; not now, not behind a flag. A self-reported counter that influenced placement would be a purchasable ranking with extra steps, and the whole reason to trust this index is that there is no such thing.</p>
@@ -4360,7 +4364,11 @@ function buildAlternativesPage(slug: string): string | null {
   const metaDesc = publishesSubstitutes
     ? `Compare ${enrichedAlts.length} free alternatives to ${vendorName} for ${homeCategory}. ${topAlts ? `Side-by-side free tier limits for ${topAlts}.` : "Find stable, verified free-tier tools."}`
     : `We publish no substitute list for ${vendorName} yet. See the ${homeCategory} category for every offer we track alongside it.`;
-  const noSubstitutesHtml = `We publish a substitute list only where a record says what kind of product it is. ${escHtmlServer(vendorName)}'s does not yet, so this page names none. The <a href="/category/${toSlug(homeCategory)}">${escHtmlServer(homeCategory)}</a> category lists every offer we track alongside it.`;
+  const subjectSaysWhatItIs = vendorOffers.some(o => (o.product_subtypes?.labels.length ?? 0) > 0);
+  const noSubstitutesReason = subjectSaysWhatItIs
+    ? `${escHtmlServer(vendorName)}'s does, and nothing else we track says it is the same kind of product, so this page names none.`
+    : `${escHtmlServer(vendorName)}'s does not yet, so this page names none.`;
+  const noSubstitutesHtml = `We publish a substitute list only where a record says what kind of product it is. ${noSubstitutesReason} The <a href="/category/${toSlug(homeCategory)}">${escHtmlServer(homeCategory)}</a> category lists every offer we track alongside it.`;
 
   const situationHtml = (() => {
     const parts: string[] = [];

--- a/test/product-role.test.ts
+++ b/test/product-role.test.ts
@@ -29,10 +29,10 @@ const index = JSON.parse(readFileSync(join(REPO, "data", "index.json"), "utf8"))
 
 const DEPLOYMENT_MODELS: DeploymentModel[] = ["hosted", "self_hosted", "local_dev_only"];
 
-function offer(vendor: string, role?: Partial<ProductRole>): Offer {
+function offer(vendor: string, role?: Partial<ProductRole>, category = "Databases"): Offer {
   return {
     vendor,
-    category: "Databases",
+    category,
     description: `${vendor} description`,
     tier: "Free",
     url: `https://${vendor.toLowerCase()}.example/pricing`,
@@ -138,9 +138,29 @@ describe("#1032 Phase 2 subtypes gate on sharing at least one label", () => {
     assert.equal(alternativeMembershipGate(none, relational), "not_in_taxonomy");
   });
 
-  it("never gates a record we have not classified, in either direction", () => {
-    assert.equal(alternativeMembershipGate(unlabelled, relational), null);
+  it("gates a record we have never read against the subject's taxonomy, and says which of us that is about", () => {
+    assert.equal(alternativeMembershipGate(unlabelled, relational), "not_yet_classified");
+    assert.notEqual(
+      MEMBERSHIP_GATE_RULES.not_yet_classified.label,
+      MEMBERSHIP_GATE_RULES.not_in_taxonomy.label,
+      "a record we did not read and a record we read and found nothing for are two different findings"
+    );
+  });
+
+  it("gates nothing on the page of a subject we have not classified", () => {
     assert.equal(alternativeMembershipGate(relational, unlabelled), null);
+    assert.equal(alternativeMembershipGate(unlabelled, unlabelled), null);
+  });
+
+  it("leaves an unread record alone where the subject is classified in another taxonomy", () => {
+    assert.equal(alternativeMembershipGate(offer("Unread Host", undefined, "Cloud Hosting"), relational), null);
+  });
+
+  it("prefers what we found over what we have not looked at", () => {
+    const unreadAddon = { ...offer("Unread Addon"), product_role: addon.product_role };
+    const unreadEmulator = { ...offer("Unread Emulator"), product_role: emulator.product_role };
+    assert.equal(alternativeMembershipGate(unreadAddon, relational), "addon");
+    assert.equal(alternativeMembershipGate(unreadEmulator, relational), "local_dev_only");
   });
 
   it("applies no subtype gate on the page of a subject that carries no subtype of its own", () => {
@@ -595,9 +615,9 @@ describe("#1032 what the gates do to the catalogue", () => {
     return counts;
   }
 
-  it("leaves no alternatives list empty", () => {
-    const empty = keptCounts().filter((c) => c.kept === 0).map((c) => c.label).sort();
-    assert.deepStrictEqual(empty, [], `an empty list states in our own voice that we index no peer at all: ${empty.join("; ")}`);
+  it("empties no alternatives list the subtype gate alone would have filled", () => {
+    const empty = keptCounts().filter((c) => c.kept === 0 && c.subtypePool > 0).map((c) => c.label).sort();
+    assert.deepStrictEqual(empty, [], `a product-role gate, not a subtype, is what left these lists with nothing in them: ${empty.join("; ")}`);
   });
 
   it("names every alternatives list below three entries that the subtype pool does not account for", () => {
@@ -608,10 +628,7 @@ describe("#1032 what the gates do to the catalogue", () => {
       .sort();
     assert.deepStrictEqual(
       notFromTheSubtype,
-      [
-        "InfluxDB Cloud (Databases): 1 of 4",
-        "Neo4j AuraDB (Databases): 2 of 5",
-      ],
+      [],
       `every list below three entries, whatever thinned it: ${thin.map((c) => `${c.label}: ${c.kept}`).sort().join("; ")}`
     );
   });

--- a/test/ranked-surfaces.test.ts
+++ b/test/ranked-surfaces.test.ts
@@ -4,6 +4,9 @@ import { spawn, type ChildProcess } from "node:child_process";
 import { readFileSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import { loadOffers, enrichOffers } from "../dist/data.js";
+import { substitutesFor } from "../dist/product-role.js";
+import { toSlug, vendorSlugMap } from "../dist/vendor-slug.js";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const REPO = path.join(__dirname, "..");
@@ -35,6 +38,23 @@ after(() => { if (proc) proc.kill(); });
 
 const stripComments = (src: string) =>
   src.split("\n").filter((l) => !/^\s*(\*|\/\/|\/\*|\*\/)/.test(l)).join("\n");
+
+const deadLinkSubjectSlug = (() => {
+  const offers = loadOffers();
+  const dated = new Set(
+    enrichOffers(offers)
+      .filter((o) => o.link_unreachable && !o.link_unreachable.terminal && o.link_unreachable.last_reachable)
+      .map((o) => o.vendor)
+  );
+  if (dated.size === 0) return null;
+  const subjects = [...new Set(offers.map((o) => o.vendor))].sort();
+  for (const vendor of subjects) {
+    if (vendorSlugMap.get(toSlug(vendor)) !== vendor) continue;
+    const subject = offers.find((o) => o.vendor === vendor)!;
+    if (substitutesFor(offers, subject).some((a) => dated.has(a.vendor))) return toSlug(vendor);
+  }
+  return null;
+})();
 
 describe("the templates no longer name winners", () => {
   const stacks = stripComments(readFileSync(path.join(REPO, "src", "stacks.ts"), "utf8"));
@@ -76,8 +96,15 @@ describe("/alternative-to/:slug", () => {
     { path: "/alternative-to/openai", pattern: /<strong>&minus;3 free_tier_withdrawn<\/strong> Recorded [a-z ]+ on \d{4}-\d{2}-\d{2}/, why: "a withdrawn free tier must name the change and its date" },
     { path: "/alternative-to/openai", pattern: /<strong>&minus;2 time_limited_offer<\/strong> Tier &quot;[^&]+&quot; is a credit grant/, why: "a credit grant must say so" },
     { path: "/alternative-to/n8n", pattern: /<strong>&minus;1 stale_verification<\/strong>[^<]*not a change by the vendor/, why: "our own verification gap must be labelled as ours" },
-    { path: "/alternative-to/vercel", pattern: /<strong>&minus;2 link_unreachable<\/strong>[^<]*pricing page has not resolved for us since \d{4}-\d{2}-\d{2}/, why: "a dead pricing page must name the date it was last reachable" },
+    { path: `/alternative-to/${deadLinkSubjectSlug ?? ""}`, pattern: /<strong>&minus;2 link_unreachable<\/strong>[^<]*pricing page has not resolved for us since \d{4}-\d{2}-\d{2}/, why: "a dead pricing page must name the date it was last reachable" },
   ];
+
+  it("draws the dead-link subject from a list that publishes one today", () => {
+    assert.ok(
+      deadLinkSubjectSlug,
+      "no alternatives list publishes a record with an unreachable pricing page, so the row below asserts nothing and needs a surface that does"
+    );
+  });
 
   for (const { path, pattern, why } of DEMOTION_EVIDENCE) {
     it(`names the recorded fact behind every demotion on ${path}`, async () => {

--- a/test/substitute-evidence.test.ts
+++ b/test/substitute-evidence.test.ts
@@ -4,7 +4,7 @@ import { spawn, type ChildProcess } from "node:child_process";
 import { readFileSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { partitionSubstitutes, subtypeGateBinds, substitutesFor } from "../dist/product-role.js";
+import { partitionSubstitutes, subtypeGateBinds, substitutesFor, MEMBERSHIP_GATE_ORDER, MEMBERSHIP_GATE_RULES } from "../dist/product-role.js";
 import { toSlug, vendorSlugMap } from "../dist/vendor-slug.js";
 import { curatedAlternativeNames } from "../dist/curated-alternatives.js";
 import type { DealChange, Offer } from "../src/types.ts";
@@ -250,16 +250,128 @@ describe("a page with no evidence of a product class", () => {
   });
 });
 
-describe("the categories we did classify are untouched", () => {
-  const CONTROLS: Array<[string, number]> = [["neon", 20], ["vercel", 31], ["supabase", 26]];
+describe("what a classified page leaves out, and why it says it left it out", () => {
+  const SUBJECT = "Vercel";
 
-  for (const [slug, expected] of CONTROLS) {
-    it(`/alternative-to/${slug} still offers ${expected}`, async () => {
+  function pagePartition(vendorName: string) {
+    const vendorOffers = offers.filter(o => o.vendor === vendorName);
+    const categories = new Set(vendorOffers.map(o => o.category));
+    const seen = new Set<string>();
+    const pool: Offer[] = [];
+    for (const o of offers) {
+      if (o.vendor === vendorName || !categories.has(o.category) || seen.has(o.vendor)) continue;
+      seen.add(o.vendor);
+      pool.push(o);
+    }
+    return partitionSubstitutes(pool, vendorOffers);
+  }
+
+  it("names every excluded record with the reason our own partition assigned it", async () => {
+    const { status, body } = await get(`/alternative-to/${toSlug(SUBJECT)}`);
+    assert.strictEqual(status, 200);
+    const notice = body.match(/<p class="alt-excluded"[\s\S]*?<\/p>/)?.[0];
+    assert.ok(notice, `/alternative-to/${toSlug(SUBJECT)} must publish the line that names what it left out`);
+
+    const removed = pagePartition(SUBJECT).removed;
+    assert.ok(removed.length > 0, `${SUBJECT} must exclude something for this to test anything`);
+    for (const { offer, gate } of removed) {
+      const label = MEMBERSHIP_GATE_RULES[gate].label.toLowerCase();
+      assert.ok(
+        notice.includes(`>${offer.vendor}</a> (${label})`),
+        `${offer.vendor} is excluded as ${gate} and the page does not say so`
+      );
+    }
+  });
+
+  it("separates a record it read and found nothing for from one it never read", async () => {
+    const { body } = await get(`/alternative-to/${toSlug(SUBJECT)}`);
+    const notice = body.match(/<p class="alt-excluded"[\s\S]*?<\/p>/)?.[0] ?? "";
+    const byGate = new Map<string, string[]>();
+    for (const { offer, gate } of pagePartition(SUBJECT).removed) {
+      if (!byGate.has(gate)) byGate.set(gate, []);
+      byGate.get(gate)!.push(offer.vendor);
+    }
+    for (const gate of ["not_in_taxonomy", "not_yet_classified"] as const) {
+      assert.ok((byGate.get(gate) ?? []).length > 0, `${SUBJECT}'s page must exclude at least one record as ${gate}`);
+    }
+    assert.notStrictEqual(
+      MEMBERSHIP_GATE_RULES.not_in_taxonomy.label.toLowerCase(),
+      MEMBERSHIP_GATE_RULES.not_yet_classified.label.toLowerCase()
+    );
+    assert.ok(notice.includes(MEMBERSHIP_GATE_RULES.not_in_taxonomy.label.toLowerCase()));
+    assert.ok(notice.includes(MEMBERSHIP_GATE_RULES.not_yet_classified.label.toLowerCase()));
+  });
+
+  it("still turns a product-role finding away under its own reason", () => {
+    const neon = offers.filter(o => o.vendor === "Neon");
+    assert.ok(neon.length > 0, "Neon must be in the index");
+    const gates = new Map(pagePartition("Neon").removed.map(r => [r.offer.vendor, r.gate]));
+    assert.strictEqual(gates.get("Hasura Cloud"), "addon");
+    assert.strictEqual(gates.get("Prisma Accelerate"), "addon");
+    assert.strictEqual(gates.get("DynamoDB Local"), "local_dev_only");
+  });
+
+  it("does not blame a record that does say what kind of product it is", async () => {
+    const classifiedWithNothingToOffer = offers
+      .filter(o => (o.product_subtypes?.labels.length ?? 0) > 0 && vendorSlugMap.get(toSlug(o.vendor)) === o.vendor)
+      .find(o => substitutesFor(offers, o).length === 0);
+    assert.ok(
+      classifiedWithNothingToOffer,
+      "every classified record now has a substitute, so the branch that explains an empty list to a classified subject has no subject"
+    );
+    const { status, body } = await get(`/alternative-to/${toSlug(classifiedWithNothingToOffer!.vendor)}`);
+    assert.strictEqual(status, 200);
+    assert.doesNotMatch(
+      body,
+      /'s does not yet, so this page names none/,
+      `${classifiedWithNothingToOffer!.vendor} carries a subtype and the page says its record does not`
+    );
+    assert.match(body, /nothing else we track says it is the same kind of product/);
+  });
+
+  it("publishes the new reason on /criteria beside the four it already published", async () => {
+    const { status, body } = await get("/criteria");
+    assert.strictEqual(status, 200);
+    for (const gate of MEMBERSHIP_GATE_ORDER) {
+      assert.ok(body.includes(`<code>${gate}</code>`), `/criteria does not name the ${gate} gate it applies`);
+      assert.ok(body.includes(MEMBERSHIP_GATE_RULES[gate].label), `/criteria does not publish the ${gate} label the pages render`);
+    }
+    assert.doesNotMatch(body, /offered as one to no one/, "the page claims an absolute the curated exemption breaks");
+  });
+});
+
+describe("the categories we did classify are untouched", () => {
+  const CONTROLS = ["neon", "vercel", "supabase"];
+  const readAgainstItsSubtypes = new Set(offers.filter(o => o.product_subtypes).map(o => o.vendor));
+
+  for (const slug of CONTROLS) {
+    it(`/alternative-to/${slug} heads a list, and every name on it is one we read`, async () => {
       const { status, body } = await get(`/alternative-to/${slug}`);
       assert.strictEqual(status, 200);
       const heading = body.match(/All Free Alternatives \((\d+)\)/);
       assert.ok(heading, `/alternative-to/${slug} must still head a list`);
-      assert.strictEqual(Number(heading[1]), expected);
+
+      const listed = body.slice(body.indexOf("All Free Alternatives"));
+      const rendered = [...listed.matchAll(/class="alt-vendor-name">([^<]+)</g)].map(m => m[1]);
+      assert.strictEqual(rendered.length, Number(heading[1]), "the heading counts a different list from the one below it");
+      assert.ok(rendered.length >= 15, `/alternative-to/${slug} publishes ${rendered.length}, which is a collapse rather than a gate`);
+
+      const curated = new Set(curatedAlternativeNames(vendorSlugMap.get(slug)!, changes));
+      const unread = rendered.filter(v => !readAgainstItsSubtypes.has(v) && !curated.has(v));
+      assert.deepStrictEqual(unread, [], `offered as substitutes without ever being read against ${slug}'s taxonomy: ${unread.join(", ")}`);
     });
   }
+
+  it("offers no record it has never read as a substitute anywhere, unless a person named it", () => {
+    const curatedEverywhere = new Set(changes.flatMap(c => c.alternatives ?? []));
+    const leaked = new Set<string>();
+    for (const subject of offers) {
+      for (const substitute of substitutesFor(offers, subject)) {
+        if (!substitute.product_subtypes && !curatedEverywhere.has(substitute.vendor)) {
+          leaked.add(`${subject.vendor} -> ${substitute.vendor}`);
+        }
+      }
+    }
+    assert.deepStrictEqual([...leaked].sort(), [], `substitutes we never read against the subject's taxonomy: ${[...leaked].sort().join("; ")}`);
+  });
 });


### PR DESCRIPTION
Refs #1218

`subtypeGate` returned `null` for an absent `product_subtypes`, so the record with less evidence behind it was the one we published. A fifth gate, `not_yet_classified`, closes that.

## What changes on the site

Measured against a `main` build, not read off the diff.

| | main | branch |
|---|---|---|
| published substitute pairs | 2,784 | 2,604 |
| pairs whose substitute we had never read | 285 | 105 |
| — of those, reached by the subtype path | **180** | **0** |
| — of those, reached because a person named the pair | 105 | 105 |
| `/alternative-to` pages publishing a never-read record | 84 | 0 |
| pages publishing any substitute | 175 | 174 |

The 180 are the four records the issue names, at the counts it names: `bismuth.cloud` 48, `Claw.cloud` 48, `OpenVPS` 48, `Gel` 36. The replay reproduces the issue's census exactly before being used to measure anything.

**The 105 that remain are the curated exemption, and it was undocumented.** A pair a person wrote down by name is subtype-exempt — `CURATED_SUBTYPE_EXEMPTION` has said so in the tree since #1032 and `/criteria` has never rendered it. That is why AC-5's sentence could not simply be left alone: gating the subtype path makes *"offered as one to no one"* true of 180 pairs and still false of 105. The sentence now names the exemption and the paragraph below it defines what "wrote the pair down by name" means, from the existing string.

## The page that stops publishing a list

`/alternative-to/influxdb-cloud` published exactly one substitute: `Gel`. InfluxDB Cloud is our only `timeseries` record, so every other Databases record is a real subtype mismatch, and the single name we offered as its alternative was the one we had never read. It now publishes none and leaves `sitemap-pages.xml` (431 → 430) under the #1213 rule.

That exposed a sentence that would have been false. The empty-list page said *"We publish a substitute list only where a record says what kind of product it is. X's does not yet"* — and InfluxDB Cloud's does. There are now two reasons and the page picks the true one.

`/redis-alternatives` drops `Gel` from Other Databases Tools, 5 → 4.

## Ordering

`not_yet_classified` sits below `local_dev_only` and `addon`, so AC-4's three controls keep the reason they had: `Hasura Cloud` and `Prisma Accelerate` are still `addon`, `DynamoDB Local` still `local_dev_only`. They carry both findings and the one we established outranks the one we have not looked into.

## `/alternative-to/vercel`, live

> Left out of this list: … codenameone.com (none of this category's subtypes apply), … WunderGraph (none of this category's subtypes apply), YepCode (none of this category's subtypes apply), … **bismuth.cloud (we have not classified this record), Claw.cloud (we have not classified this record)**, … **OpenVPS (we have not classified this record)**.

`All Free Alternatives (31)` → `(28)`.

## Acceptance criteria

1. ✅ `/alternative-to/vercel` lists none of the three. Verified on a running server.
2. ✅ Each appears in `alt-excluded` under a reason distinct from WunderGraph's.
3. ✅ `codenameone.com`, `WunderGraph`, `YepCode` unchanged, wording included.
4. ✅ `Hasura Cloud`, `Prisma Accelerate`, `DynamoDB Local` unchanged.
5. ✅ `/criteria` publishes the fifth gate in the same table; the absolute is gone and what replaced it is true of the 105.
6. ✅ No page gained a substitute. 1,572 `/alternative-to` pages swept: 1,488 byte-identical, 84 moved, 0 status changes.

## Verification

**Differential sweep, two servers, same data.** 2,532 sitemap-enumerated paths: 2,361 byte-identical, 171 moved, **0 status changes**. The 171 are 84 `/alternative-to`, the same 84 `/vendor` pages, `/criteria`, `/redis-alternatives` and `sitemap-pages.xml`. Separately, all 1,572 `/alternative-to` pages including the de-indexed ones: 1,488 identical, 84 moved.

**Tests: 2,908 pass.** Eight fail on `main` and are the new behaviour. Five pass on `main` and are guards: two that the gate does not fire on an unclassified subject or across taxonomies, one on gate order, one that no list is emptied by a product-role gate, one that the excluded line names the reason the partition assigned.

**7 of 7 mutations killed** — removing the gate (8 tests), firing it without checking the subject is classified (13), ignoring the candidate's own category (1), ordering it above the role gates (2), reusing the `not_in_taxonomy` wording (2), keeping the `/criteria` absolute (1), giving one reason for every empty list (1).

**Live:** `/alternative-to/vercel`, `/alternative-to/influxdb-cloud`, `/criteria` read on a running server, plus a real MCP `initialize` → `tools/call`, and `/api/details/Vercel` and `/api/vendor-risk/Vercel` checked because `substitutesFor` reaches them too. `/criteria` screenshotted.

## Two pinned fixtures replaced rather than re-pinned

- `substitute-evidence.test.ts` pinned `neon 20, vercel 31, supabase 26`. Those numbers move again the moment the four records are classified, on a data PR that cannot edit `test/`. Replaced with the criterion they were standing in for: each page still heads a list, the heading counts the list below it, the list has not collapsed, and every name on it is one we read or one a person wrote down.
- `ranked-surfaces.test.ts` named `/alternative-to/vercel` as the page carrying a `link_unreachable` demotion. Both records that carried it there — `bismuth.cloud` and `Claw.cloud` (#1046) — are removed by this change, so the subject is now derived from whichever list publishes a dead link today. It picks `alwaysdata` on `main` and `cloudflare-sandboxes` here, and fails loudly rather than silently if no list publishes one.

## Two things to look at

**I wrote three sentences of site copy** and would rather you replaced them than let them stand by default: the second empty-list reason on the alternatives page, and the *"silence is not a pass"* paragraph on `/criteria`. The gate's own label and rule are also mine — the issue said the wording is the part that matters, so: `not_yet_classified` — *"We have not classified this record"*.

**Only two published pairs still carry a dead link** after this, both `Cloudflare Dynamic Workers`. Before it, `bismuth.cloud` and `Claw.cloud` carried one across 96 pairs. The never-read records were most of what our dead-link demotion had to demote on alternatives pages.
