### PR TITLE
Declare the sixteen AI / ML subtypes and the inference membership group (#1222)

### DIFF
--- a/src/product-role.ts
+++ b/src/product-role.ts
@@ -65,6 +65,24 @@ export const SUBTYPE_TAXONOMIES: Record<string, Array<{ subtype: string; definit
     { subtype: "on_call_response", definition: "routes a firing alert to a named human by schedule and escalation policy" },
     { subtype: "page_change_watch", definition: "fetches a web page on a schedule and notifies you when its content differs from last time" },
   ],
+  "AI / ML": [
+    { subtype: "llm_api", definition: "the vendor runs language or multimodal models on its own infrastructure and sells calls to them by model name; you send a prompt and receive a completion" },
+    { subtype: "llm_observability", definition: "records the prompts, responses, latency, cost and tool calls an application sent to a model, for reading afterwards" },
+    { subtype: "llm_evaluation", definition: "scores model or agent output against a dataset, a rubric or a judge model on runs you trigger" },
+    { subtype: "model_gateway", definition: "one endpoint that reaches models run by several independent providers; what is sold is the routing, key management and fallback, not the weights" },
+    { subtype: "model_hosting", definition: "you supply or select a model and the platform serves it behind an endpoint on hardware you choose" },
+    { subtype: "embeddings_api", definition: "returns a vector for text or media so it can be compared to other vectors; the vector is the output, not a completion" },
+    { subtype: "gpu_compute", definition: "sells accelerator time for code you write; the unit billed is machine time, not a model call" },
+    { subtype: "speech_api", definition: "converts recorded or streamed speech to text, or text to speech" },
+    { subtype: "document_extraction", definition: "turns a document or a scan into text or structured fields" },
+    { subtype: "image_video_generation", definition: "produces images or video from a prompt or a source image" },
+    { subtype: "vector_store", definition: "stores embeddings and answers nearest-neighbour queries as its primary access path" },
+    { subtype: "data_labeling", definition: "produces labelled or annotated training data" },
+    { subtype: "experiment_tracking", definition: "records training or evaluation runs, their metrics and artifacts, and keeps a registry of model versions" },
+    { subtype: "web_search_api", definition: "answers a query with current web results shaped for a model to read" },
+    { subtype: "agent_sandbox", definition: "isolated execution environments provisioned programmatically for code an agent writes" },
+    { subtype: "agent_tool_access", definition: "supplies an agent with authenticated connections to third-party applications it can call as tools" },
+  ],
 };
 
 export interface SubtypeMembershipGroup {
@@ -83,6 +101,12 @@ export const SUBTYPE_MEMBERSHIP_GROUPS: Record<string, SubtypeMembershipGroup[]>
     {
       subtypes: ["host_metrics", "apm_traces", "log_management", "metrics_backend", "dashboards"],
       rule: "A reader leaving one of these is asking where else to send telemetry, what will store it and what will show it, and all five answer some part of that, so two offers that each carry one are alternatives whether or not they carry the same one. error_tracking sits outside this group deliberately: a reader leaving Sentry wants exception grouping, and every platform that also offers it carries the error_tracking label itself. Every other subtype in this category keeps the shared-member rule unchanged.",
+    },
+  ],
+  "AI / ML": [
+    {
+      subtypes: ["llm_api", "model_gateway"],
+      rule: "A reader leaving one of these is asking where else to send a prompt and get a completion back. Whether the vendor runs the weights itself or routes the call to a provider that does is a procurement question, not a different product, so two offers that each carry one are alternatives whether or not they carry the same one. Every other subtype in this category keeps the shared-member rule unchanged.",
     },
   ],
 };

--- a/src/serve.ts
+++ b/src/serve.ts
@@ -1857,8 +1857,9 @@ ${entries.map(e => `<tr><td><code>${escHtmlServer(e.subtype)}</code></td><td>${e
       return `${done} of ${inTaxonomy.length} in ${taxonomy}`;
     });
     const unclassified = offers.filter(o => !o.product_subtypes);
-    const inPublishedTaxonomy = unclassified.filter(o => SUBTYPE_TAXONOMIES[o.category]).length;
-    return `We have classified ${parts.join(", ")}; the other ${unclassified.length} records carry no subtype, so they are offered no substitutes, and are offered as one only where a person wrote the pair down by name. ${inPublishedTaxonomy} of them sit in a category whose subtypes we do publish. Classifying a category restores both directions.`;
+    const started = new Set(offers.filter(o => (o.product_subtypes?.labels.length ?? 0) > 0).map(o => o.category));
+    const whereTheGateBinds = unclassified.filter(o => started.has(o.category)).length;
+    return `We have classified ${parts.join(", ")}; the other ${unclassified.length} records carry no subtype, so they are offered no substitutes, and are offered as one only where a person wrote the pair down by name. ${whereTheGateBinds} of them sit in a category we have started, where that gate binds on them today. Classifying a category restores both directions.`;
   })();
 
   const jsonLd = {

--- a/test/product-role.test.ts
+++ b/test/product-role.test.ts
@@ -337,6 +337,67 @@ describe("#1212 the functions Monitoring splits by", () => {
   });
 });
 
+describe("#1222 the functions AI / ML splits by", () => {
+  const AI_ML_SUBTYPES = [
+    "llm_api",
+    "llm_observability",
+    "llm_evaluation",
+    "model_gateway",
+    "model_hosting",
+    "embeddings_api",
+    "gpu_compute",
+    "speech_api",
+    "document_extraction",
+    "image_video_generation",
+    "vector_store",
+    "data_labeling",
+    "experiment_tracking",
+    "web_search_api",
+    "agent_sandbox",
+    "agent_tool_access",
+  ];
+
+  const INFERENCE_GROUP = ["llm_api", "model_gateway"];
+
+  it("publishes all sixteen, so a record may carry any of them", () => {
+    assert.deepStrictEqual(SUBTYPE_TAXONOMIES["AI / ML"]?.map(e => e.subtype), AI_ML_SUBTYPES);
+  });
+
+  it("groups the two that answer where a prompt goes, and only those two", () => {
+    assert.deepStrictEqual(membershipGroupsFor("AI / ML").map(g => g.subtypes), [INFERENCE_GROUP]);
+  });
+
+  it("offers a router as a substitute for a provider that runs the weights itself", () => {
+    const provider = labelled("Provider", ["llm_api"], "AI / ML");
+    const router = labelled("Router", ["model_gateway"], "AI / ML");
+    assert.equal(alternativeMembershipGate(router, provider), null);
+    assert.equal(alternativeMembershipGate(provider, router), null);
+  });
+
+  it("keeps everything else in the category on the shared-label rule", () => {
+    const provider = labelled("Provider", ["llm_api"], "AI / ML");
+    const tracing = labelled("Tracing", ["llm_observability"], "AI / ML");
+    const scoring = labelled("Scoring", ["llm_evaluation"], "AI / ML");
+    assert.equal(alternativeMembershipGate(tracing, provider), "subtype_mismatch");
+    assert.equal(alternativeMembershipGate(scoring, tracing), "subtype_mismatch");
+    assert.equal(alternativeMembershipGate(labelled("SecondTracing", ["llm_observability"], "AI / ML"), tracing), null);
+  });
+
+  it("shares a subtype name with Cloud Hosting and compares nothing across the two", () => {
+    const hostingSandbox = labelled("HostingSandbox", ["agent_sandbox"], "Cloud Hosting");
+    const aiSandbox = labelled("AiSandbox", ["agent_sandbox"], "AI / ML");
+    assert.ok(SUBTYPE_TAXONOMIES["Cloud Hosting"]?.some(e => e.subtype === "agent_sandbox"));
+    assert.ok(SUBTYPE_TAXONOMIES["AI / ML"]?.some(e => e.subtype === "agent_sandbox"));
+    assert.equal(alternativeMembershipGate(hostingSandbox, aiSandbox), null);
+    assert.equal(alternativeMembershipGate(aiSandbox, hostingSandbox), null);
+  });
+
+  it("defines the name it shares with Cloud Hosting in each taxonomy's own words", () => {
+    assert.ok((subtypeDefinition("Cloud Hosting", "agent_sandbox") ?? "").length > 20);
+    assert.ok((subtypeDefinition("AI / ML", "agent_sandbox") ?? "").length > 20);
+  });
+});
+
 describe("#1032 a gate removes a candidate only where the subject cannot carry it too", () => {
   it("removes a local-only product from a hosted product's alternatives", () => {
     assert.equal(alternativeMembershipGate(emulator, hosted), "local_dev_only");


### PR DESCRIPTION
Refs #1222

Definitions only. Nothing on the site moves until the labels land.

## Not retyped

The entire content of this change is sixteen definitions and one group rule you wrote. Transcription is the only real failure mode — a typo in a subtype name silently rejects your data PR the next day and nobody knows why. So I parsed the sixteen-row table and the blockquote out of the issue body with the API, generated the source from that, and then compared the built module back to a fresh parse:

```
taxonomy identical: true
group identical: true
```

`agent_sandbox` is the first subtype name two taxonomies share. `subtypeGate` never compares across taxonomies, and there is now a test for that in both directions.

## What moves

**One path.** 2,531 paths swept against a `main` build: 2,530 byte-identical, **`/criteria` moved**, 0 status changes. Separately, all 1,572 `/alternative-to` pages — including all 70 AI / ML ones, which is where a mistake would show — **1,572 byte-identical**. All 66 category pages byte-identical.

`/criteria` now reads `0 of 70 in AI / ML` and publishes all sixteen definitions with the group.

## One correction carried in

Yesterday's #1218 sentence counted unclassified records *in a category whose subtypes we publish*. Declaring this taxonomy would have made that read **77**, over 70 records the gate does not bind on at all — no AI / ML record carries a label, so `binds` is empty and every AI / ML page publishes nothing rather than gating anything. It now counts the categories we have **started**, which is 7 today and becomes 13 when your labels land.

I would not have caught that from the diff. It came out of predicting the unchanged set before running the sweep.

## Acceptance criteria

1. ✅ `SUBTYPE_TAXONOMIES["AI / ML"]` names the sixteen with these definitions, verified against the issue body programmatically.
2. ✅ `SUBTYPE_MEMBERSHIP_GROUPS["AI / ML"]` holds `llm_api` + `model_gateway` with that rule.
3. ✅ `/criteria` renders all sixteen and the group and counts `0 of 70`. The tests that assert this iterate `SUBTYPE_TAXONOMIES` — declaring a taxonomy is what makes them require it, so no new page test was needed.
4. ✅ No fixture pins AI / ML as unclassified. #1219's two fixtures read the index and this changes no record; the empty-substitutes one still resolves to Dev Utilities, which is larger.

**2,914 tests.** Six new, classified against a `main` build: five fail there — the sixteen, the group, the router-for-provider pair the group admits, and the two that read `agent_sandbox` out of a taxonomy `main` does not declare. The sixth passes on `main`, because the shared-label rule it guards is the one this change does not touch; it is there so a later widening of the group has to move it.
