### PR TITLE
Repoint eight offers from a domain root to the pricing page (#1110)

### DIFF
--- a/data/index.json
+++ b/data/index.json
@@ -10066,7 +10066,7 @@
       "category": "AI / ML",
       "description": "Integration platform for AI Agents and LLMs. Integrate over 200+ tools across the agentic internet.",
       "tier": "Free",
-      "url": "https://composio.dev/",
+      "url": "https://composio.dev/pricing",
       "tags": [
         "developer-tools",
         "free-for-dev"
@@ -11624,7 +11624,7 @@
       "category": "AI / ML",
       "description": "API for online search and rapid insights and comprehensive research, with the capability of organization of research results. 1000 request/month for the Free tier with No credit card required.",
       "tier": "Free",
-      "url": "https://tavily.com/",
+      "url": "https://www.tavily.com/pricing",
       "tags": [
         "developer-tools",
         "free-for-dev"
@@ -18528,7 +18528,7 @@
       "category": "AI / ML",
       "description": "Open-source LLM engineering platform that helps teams collaboratively debug, analyze, and iterate on their LLM applications. Free forever plan includes 50k observations per month and all platform features. [#opensource](https://github.com/langfuse/langfuse)",
       "tier": "Free",
-      "url": "https://langfuse.com/",
+      "url": "https://langfuse.com/pricing",
       "tags": [
         "ai",
         "ml",
@@ -18626,7 +18626,7 @@
       "category": "AI / ML",
       "description": "A LLMOps platform helping AI teams measure, monitor, and optimize LLM applications for reliability, cost-efficiency, and performance. With a powerful DSPy component, we enable seamless collaboration between engineers and non-technical teams to fine-tune and productionize GenAI products. Free plan includes all platform features, 1k traces/month and 1 workflow DSPy optimizers. [#opensource](https://github.com/langwatch/langwatch)",
       "tier": "Free",
-      "url": "https://langwatch.ai",
+      "url": "https://langwatch.ai/pricing",
       "tags": [
         "ai",
         "ml",
@@ -18661,7 +18661,7 @@
       "category": "AI / ML",
       "description": "AI media gateway providing unified access to leading image generation models via an OpenAI-compatible API. The platform itself is free to use with zero markup and no subscription fee. Inference costs for most models are billed at provider price, but FLUX.1 [schnell] FP8 is offered free forever with unlimited usage for registered users. Built-in failover and provider resilience included.",
       "tier": "Free",
-      "url": "https://lumenfall.ai/",
+      "url": "https://lumenfall.ai/pricing",
       "tags": [
         "ai",
         "ml",
@@ -18720,7 +18720,7 @@
       "category": "AI / ML",
       "description": "An AI-native fast, simple, and secure alternative to popular business intelligence solutions like Tableau, Power BI, and Looker. Othor utilizes large language models (LLMs) to deliver custom business intelligence solutions in minutes. The Free Forever plan provides one workspace with five datasource connections for one user, with no limits on analytics. [#opensource](https://github.com/othorai/othor.ai)",
       "tier": "Free",
-      "url": "https://othor.ai/",
+      "url": "https://othor.ai/pricing",
       "tags": [
         "ai",
         "ml",
@@ -31357,7 +31357,7 @@
       "category": "AI / ML",
       "description": "Cloud-hosted Ollama for running open-source LLMs — free tier for light usage with 1 concurrent model. Access Llama, Mistral, Gemma, and other open models via API",
       "tier": "Free",
-      "url": "https://ollama.com",
+      "url": "https://ollama.com/pricing",
       "tags": [
         "ai",
         "ml",
@@ -31444,7 +31444,7 @@
       "category": "AI / ML",
       "description": "Free inference for open-source models with 100 requests/day limit and $1 free credits. Supports DeepSeek-R1, DeepSeek-V3, QwQ-32B, and other open-source models. China-based provider.",
       "tier": "Free (Limited)",
-      "url": "https://siliconflow.cn",
+      "url": "https://siliconflow.cn/pricing",
       "tags": [
         "ai",
         "ml",


### PR DESCRIPTION
First batch of https://github.com/robhunter/agentdeals/issues/1110, from the measurement posted there. Only the `url` field changes on eight records.

## What moves

**Three where the root carries no price text at all.** All three currently sit at `source_check.outcome: states_no_terms` with one consecutive failure recorded against them.

| vendor | root | `/pricing` |
|---|---|---|
| SiliconFlow | 0 | 98 |
| LangWatch | 0 | 28 |
| Othor AI | 0 | 6 |

**Five where the root carries some and the pricing page carries three times as much or more.**

| vendor | root | `/pricing` | ratio |
|---|---|---|---|
| Composio | 1 | 64 | 64× |
| Ollama Cloud | 4 | 77 | 19× |
| Langfuse | 5 | 70 | 14× |
| Lumenfall.ai | 2 | 9 | 4.5× |
| Tavily AI | 2 | 6 | 3× |

Signal counts come from this repo's own `priceSignals` in `scripts/change-gate.js`, re-run against live pages this morning; every number reproduces the measurement on the issue exactly.

**The control that keeps this a ratio rather than a path preference:** Keywords AI scores 20 on the root against 13 on `/pricing`. Repointing it would lose signal, so it stays. Zenable (11 → 11), Mediaworkbench (5 → 5), Parseur (19 → 23) and Cerebras (3 → 4) gain nothing and stay. `OCR.Space` and `ReportGPT` carry signal on the root and 404 on every candidate.

## Why it matters beyond signal count

`data/change_refusals.json` already holds a refusal for Tavily AI, verbatim:

> a free tier was recorded as removed from `https://tavily.com/`, a domain root that states no price, ending or replacement where the free tier was — a homepage's silence is not evidence that one ended

The gate caught a false `free_tier_removed` that existed only because we point the detector at a homepage. That refusal keys on vendor and change type, not URL, so it survives this change; what changes is that the detector now reads a page which can answer the question.

## Derived effects checked

- **Only `url` changes.** Diffed every record's category, tier, `verifiedDate`, `source_check` and `product_subtypes` before and after: zero differences. The diff is 8 insertions and 8 deletions.
- **`verifiedDate` and `source_check` are deliberately left alone.** They carry a verdict about the old page for at most one rotation; the next re-verification run reads the new URL and overwrites both. Deleting `source_check` would create an absent state that no record in the index has ever had, and this codebase treats absent and empty differently in several places.
- **The verification-state key is `offerKey(vendor, url)`**, so seven of the eight lose their `consecutive_failures` history. That is the right outcome — a new URL deserves a fresh count — and none of the eight is quarantined, so nothing silently leaves quarantine.
- **`data/page-reviews.json` references Lumenfall.ai by slug, not URL.** Unaffected.
- No new duplicate URL is introduced.
- Tavily's stored URL is the post-redirect `https://www.tavily.com/pricing`, so the fetch does not spend a hop.

`data/index.json` round-trips byte-identical through `json.dumps(indent=2, ensure_ascii=False)` plus a newline, asserted before and after. No `test/` or `src/` file is touched.
