### PR TITLE
Publish the eligibility gate on the vendor page and the category page (#1215)

### DIFF
--- a/src/eligibility.ts
+++ b/src/eligibility.ts
@@ -1,0 +1,17 @@
+import { gateFor } from "./ranking.js";
+import type { Gate } from "./ranking.js";
+import type { Offer } from "./types.js";
+
+export const CONDITION_RECORDING_AN_UNREAD_PROGRAM = "Startup program — check vendor for eligibility details";
+
+export function eligibilityGate(offer: Pick<Offer, "eligibility">): Gate | null {
+  if (!offer.eligibility) return null;
+  const gate = gateFor(offer as Offer, "");
+  return gate && gate.code === "eligibility_restricted" ? gate : null;
+}
+
+export function publishableEligibilityConditions(offer: Pick<Offer, "eligibility">): string[] {
+  return (offer.eligibility?.conditions ?? []).filter(
+    (condition) => condition !== CONDITION_RECORDING_AN_UNREAD_PROGRAM,
+  );
+}

--- a/src/serve.ts
+++ b/src/serve.ts
@@ -42,6 +42,7 @@ import { ASSISTANTS_API_SHUTDOWN } from "./assistants-shutdown.js";
 import { discontinuedOnOrBefore, PRODUCT_DEPRECATED } from "./product-deprecation.js";
 import { rankOffers, rankForListing, rotateListing, utcDate, CRITERIA_PATH, DEMOTE_ONLY_POLICY, DISCLOSURE_RATIONALE, TIE_BREAK_ALGORITHM, GATE_TABLE, DEMERIT_TABLE, NOT_FREE_TIER_RULES, TIME_LIMITED_TIER_RULES, type TieBreak } from "./ranking.js";
 import type { RankedEntry, RankingResult } from "./ranking.js";
+import { eligibilityGate, publishableEligibilityConditions } from "./eligibility.js";
 import { verificationLedger, QUARANTINE_AFTER_FAILURES } from "./verification-state.js";
 import { partitionAlternatives, partitionSubstitutes, type SubstitutesPartition, productRoleSentence, MEMBERSHIP_GATE_RULES, MEMBERSHIP_GATE_ORDER, MEMBERSHIP_GATE_SYMMETRY, MEMBERSHIP_GATE_SCOPE, MEMBERSHIP_GATE_CORRECTIONS, SUBTYPE_TAXONOMIES, SUBTYPE_MEMBERSHIP_RULE, SUBTYPE_MEMBERSHIP_GROUP_SCOPE, CURATED_SUBTYPE_EXEMPTION, membershipGroupsFor, subtypeDefinition } from "./product-role.js";
 import { resolveCuratedAlternatives, curatedAlternativesFor, addCuratedToPool } from "./curated-alternatives.js";
@@ -1068,6 +1069,16 @@ function listingUnreachableNoticeHtml(offer: Offer): string {
   return `<span class="listing-link-unreachable" style="display:block;margin-top:.3rem;color:#f85149">${escHtmlServer(withheldLevelSentence("link_unreachable", offer.vendor, since))}</span>`;
 }
 
+function listingEligibilityNoticeHtml(offer: Offer): string {
+  const gate = eligibilityGate(offer);
+  if (!gate) return "";
+  const conditions = publishableEligibilityConditions(offer);
+  const conditionsHtml = conditions.length > 0
+    ? `<span class="listing-eligibility-conditions" style="display:block;color:var(--text-dim)">Eligibility: ${conditions.map(c => escHtmlServer(c)).join("; ")}</span>`
+    : "";
+  return `<span class="listing-eligibility-restricted" style="display:block;margin-top:.3rem;color:#d29922">${escHtmlServer(gate.reason)}${conditionsHtml}</span>`;
+}
+
 function buildCategoryPage(slug: string): string | null {
   const categoryName = categorySlugMap.get(slug);
   if (!categoryName) return null;
@@ -1080,7 +1091,7 @@ function buildCategoryPage(slug: string): string | null {
   const offersHtml = catOffers.map((o) => `        <tr>
           <td style="font-weight:600;color:var(--text);white-space:nowrap"><a href="/vendor/${toSlug(o.vendor)}" style="color:var(--text)">${escHtmlServer(o.vendor)}</a></td>
           <td style="font-family:var(--mono);color:var(--accent);white-space:nowrap">${escHtmlServer(o.tier)}</td>
-          <td style="color:var(--text-muted)">${escHtmlServer(o.description)}${listingUnreachableNoticeHtml(o)}</td>
+          <td style="color:var(--text-muted)">${escHtmlServer(o.description)}${listingEligibilityNoticeHtml(o)}${listingUnreachableNoticeHtml(o)}</td>
           <td style="font-family:var(--mono);color:var(--text-dim);white-space:nowrap">${escHtmlServer(o.verifiedDate)}</td>
         </tr>`).join("\n");
 
@@ -1923,7 +1934,7 @@ ${globalNavCss()}
 
   <p>Every surface that presents vendors as a recommendation &mdash; the <a href="/best">best-of pages</a>, the alternatives on every vendor page, the <code>/api/stack</code> endpoint and the <code>plan_stack</code> MCP tool &mdash; resolves through one shared module. There is no second scorer, no per-page ordering, no vendor allowlist, pin, boost or override anywhere in the selection path. Nothing derived from our own editorial copy is an input: an offer cannot rank higher because we wrote more words about it.</p>
 
-  <h2>1. Gates &mdash; what is excluded, and why</h2>
+  <h2 id="gates">1. Gates &mdash; what is excluded, and why</h2>
   <p>A gate removes an offer from ranked surfaces entirely. It still appears on its category page and its vendor page; it is simply not something we would put in front of you as a recommendation.</p>
   <table><thead><tr><th>Gate</th><th>Meaning</th></tr></thead><tbody>
 ${gateRows}
@@ -3688,6 +3699,16 @@ function buildVendorPage(slug: string): string | null {
     ? `  <p class="link-unreachable-line" style="margin:.4rem 0 .6rem;font-size:.9rem;color:var(--text-muted)"><strong style="color:#f85149">Link unreachable:</strong> ${escHtmlServer(primary.url)} did not resolve on our check of <span class="link-checked-date" style="font-family:var(--mono)">${escHtmlServer(linkUnreachable.checked)}</span>. ${linkUnreachable.last_reachable ? `Last reachable <span class="link-last-reachable" style="font-family:var(--mono)">${escHtmlServer(linkUnreachable.last_reachable)}</span>.` : "We have no date on which it was reachable."}</p>`
     : "";
 
+  const primaryEligibilityGate = eligibilityGate(primary);
+  const primaryEligibilityConditions = publishableEligibilityConditions(primary);
+  const eligibilityGateLine = primaryEligibilityGate
+    ? `\n  <p class="eligibility-gate-line" style="margin:.4rem 0 .6rem;font-size:.9rem;color:var(--text-muted)"><strong style="color:#d29922;font-family:var(--mono)">${escHtmlServer(primaryEligibilityGate.code)}</strong> ${escHtmlServer(primaryEligibilityGate.reason)} <a href="${CRITERIA_PATH}#gates">How we use this</a>.</p>${
+        primaryEligibilityConditions.length > 0
+          ? `\n  <ul class="eligibility-conditions" style="margin:.2rem 0 .6rem 1.1rem;padding:0;font-size:.9rem;color:var(--text-muted)">${primaryEligibilityConditions.map(c => `<li>${escHtmlServer(c)}</li>`).join("")}</ul>`
+          : ""
+      }`
+    : "";
+
   const productRoleLine = (() => {
     const role = primary.product_role;
     const sentence = productRoleSentence(primary);
@@ -3746,9 +3767,10 @@ function buildVendorPage(slug: string): string | null {
   const verifiedSentence = discontinuedOn
     ? ` Discontinued ${discontinuedOn}.`
     : enriched.link_unreachable ? "" : ` Verified ${verifiedMonth}.`;
-  const metaDesc = hasFree
+  const eligibilityGateSentence = primaryEligibilityGate ? `${primaryEligibilityGate.reason} ` : "";
+  const metaDesc = eligibilityGateSentence + (hasFree
     ? `${vendorName} free tier includes ${descLimits}.${verifiedSentence}${alternatives.length > 0 ? ` Compare with ${alternatives.length} alternatives in ${primary.category}.` : ""}`
-    : `${vendorName} pricing details${alternatives.length > 0 ? ` and ${alternatives.length} free alternatives in ${primary.category}` : ""}.${verifiedSentence}`;
+    : `${vendorName} pricing details${alternatives.length > 0 ? ` and ${alternatives.length} free alternatives in ${primary.category}` : ""}.${verifiedSentence}`);
 
   const keyLimit = primary.description.slice(0, 120).replace(/\.\s.*$/, "");
   const unconfirmableSince = linkUnreachable
@@ -4061,8 +4083,13 @@ ${allCompareLinks.join("\n")}
     : "";
   const withUnconfirmedTermsCaveat = (terms: string) =>
     `${terms}${/[.!?…]$/.test(terms.trim()) ? "" : "."} We have not confirmed these terms against the source we cite, so treat them as unverified.`;
+  const eligibilityConditionsSentence = primaryEligibilityConditions.length > 0
+    ? ` Eligibility: ${primaryEligibilityConditions.join("; ")}.`
+    : "";
   const faqFreeAnswer = levelWithheld
-    ? `${unconfirmedTermsPreamble}Our stored record says ${vendorName} offers a free tier: ${primary.tier}. ${withUnconfirmedTermsCaveat(storedTerms)}`
+    ? `${eligibilityGateSentence}${unconfirmedTermsPreamble}Our stored record says ${vendorName} offers a free tier: ${primary.tier}. ${withUnconfirmedTermsCaveat(storedTerms)}${eligibilityConditionsSentence}`
+    : primaryEligibilityGate
+    ? `${eligibilityGateSentence}${vendorName} offers a free tier: ${primary.tier}. ${storedTerms}${eligibilityConditionsSentence}`
     : `Yes, ${vendorName} offers a free tier: ${primary.tier}. ${storedTerms}`;
   const faqTierAnswer = levelWithheld
     ? `${unconfirmedTermsPreamble}Our stored record calls ${vendorName}'s free tier "${primary.tier}". ${withUnconfirmedTermsCaveat(primary.description)}`
@@ -4211,7 +4238,7 @@ ${mcpCtaCss()}
 <div class="container">
   ${buildGlobalNav("categories")}
   <div class="breadcrumb"><a href="/">AgentDeals</a> &rsaquo; <a href="/vendor">Vendors</a> &rsaquo; ${escHtmlServer(vendorName)}</div>
-  <h1>${escHtmlServer(vendorName)} Free Tier ${currentYear}${h1RiskBadge}</h1>
+  <h1>${escHtmlServer(vendorName)} Free Tier ${currentYear}${h1RiskBadge}</h1>${eligibilityGateLine}
 ${riskCauseLine}
 ${linkUnreachableLine}
 ${productRoleLine}${productSubtypesLine}

--- a/test/eligibility-disclosure.test.ts
+++ b/test/eligibility-disclosure.test.ts
@@ -1,0 +1,236 @@
+import { describe, it, before, after } from "node:test";
+import assert from "node:assert";
+import { spawn, type ChildProcess } from "node:child_process";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const { eligibilityGate, publishableEligibilityConditions, CONDITION_RECORDING_AN_UNREAD_PROGRAM } =
+  await import("../dist/eligibility.js");
+const { gateFor } = await import("../dist/ranking.js");
+
+type Offer = import("../src/types.ts").Offer;
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO = path.join(__dirname, "..");
+
+const offers: Offer[] = JSON.parse(readFileSync(path.join(REPO, "data", "index.json"), "utf-8")).offers;
+
+function slugOf(vendor: string): string {
+  return vendor.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "");
+}
+
+const vendorsHoldingAGatedRecord = [...new Set(offers.filter(o => o.eligibility).map(o => o.vendor))];
+
+let port = 0;
+let proc: ChildProcess | null = null;
+
+function startServer(): Promise<ChildProcess> {
+  return new Promise((resolve, reject) => {
+    const child = spawn("node", [path.join(REPO, "dist", "serve.js")], {
+      stdio: ["pipe", "pipe", "pipe"],
+      env: { ...process.env, PORT: "0", BASE_URL: "http://localhost", TZ: "UTC" },
+    });
+    const timeout = setTimeout(() => { child.kill(); reject(new Error("Server startup timeout")); }, 30000);
+    child.stderr!.on("data", (data: Buffer) => {
+      const m = data.toString().match(/running on http:\/\/localhost:(\d+)/);
+      if (m) { port = parseInt(m[1], 10); clearTimeout(timeout); resolve(child); }
+    });
+    child.on("error", (e) => { clearTimeout(timeout); reject(e); });
+  });
+}
+
+const pages = new Map<string, string>();
+
+async function page(pathname: string): Promise<string> {
+  const cached = pages.get(pathname);
+  if (cached !== undefined) return cached;
+  const res = await fetch(`http://localhost:${port}${pathname}`);
+  const body = await res.text();
+  pages.set(pathname, body);
+  return body;
+}
+
+function jsonLdBlocks(html: string): Record<string, any>[] {
+  const out: Record<string, any>[] = [];
+  for (const m of html.matchAll(/<script type="application\/ld\+json">([\s\S]*?)<\/script>/g)) {
+    try { out.push(JSON.parse(m[1])); } catch { continue; }
+  }
+  return out;
+}
+
+function blockOfType(html: string, type: string): Record<string, any> | undefined {
+  return jsonLdBlocks(html).find(b => b["@type"] === type);
+}
+
+function faqAnswer(html: string, prefix: string): string | undefined {
+  const faq = blockOfType(html, "FAQPage");
+  const item = faq?.mainEntity?.find((q: { name: string }) => q.name.startsWith(prefix));
+  return item?.acceptedAnswer?.text;
+}
+
+function renderedOffer(html: string): Offer | undefined {
+  const webPage = blockOfType(html, "WebPage");
+  const vendor = webPage?.mainEntity?.name;
+  const tier = webPage?.mainEntity?.offers?.description;
+  if (typeof vendor !== "string" || typeof tier !== "string") return undefined;
+  return offers.find(o => o.vendor === vendor && o.tier === tier);
+}
+
+type RenderedPage = { vendor: string; slug: string; html: string; offer: Offer };
+
+let rendered: RenderedPage[] = [];
+
+before(async () => {
+  proc = await startServer();
+  for (const vendor of vendorsHoldingAGatedRecord) {
+    const slug = slugOf(vendor);
+    const html = await page(`/vendor/${slug}`);
+    const offer = renderedOffer(html);
+    if (offer) rendered.push({ vendor, slug, html, offer });
+  }
+});
+
+after(() => { proc?.kill(); });
+
+describe("a vendor page whose record is gated on eligibility says so", () => {
+  it("covers every vendor holding a gated record", () => {
+    assert.ok(
+      vendorsHoldingAGatedRecord.length > 0,
+      "no record in the index carries an eligibility gate, so this file has no subject",
+    );
+    assert.strictEqual(rendered.length, vendorsHoldingAGatedRecord.length);
+  });
+
+  it("never answers the free-tier question with a bare yes over a gated record", () => {
+    const gated = rendered.filter(p => p.offer.eligibility);
+    assert.ok(gated.length > 0, "no vendor page renders a gated record, so this assertion has no subject");
+    const offenders = gated
+      .filter(p => (faqAnswer(p.html, `Is ${p.vendor} free?`) ?? "").startsWith("Yes"))
+      .map(p => p.slug);
+    assert.deepStrictEqual(offenders, []);
+  });
+
+  it("opens that answer with the same sentence the ranking gate composes", () => {
+    for (const p of rendered.filter(x => x.offer.eligibility)) {
+      const answer = faqAnswer(p.html, `Is ${p.vendor} free?`) ?? "";
+      assert.ok(
+        answer.startsWith(gateFor(p.offer, "")!.reason),
+        `${p.slug} opens with ${answer.slice(0, 60)}`,
+      );
+    }
+  });
+
+  it("still answers yes where the page renders an ungated record for a vendor that also holds a gated one", () => {
+    const controls = rendered.filter(p => !p.offer.eligibility);
+    assert.ok(
+      controls.length > 0,
+      "every vendor holding a gated record now renders it, so the over-fire control has no subject",
+    );
+    for (const p of controls) {
+      assert.ok(
+        (faqAnswer(p.html, `Is ${p.vendor} free?`) ?? "").startsWith("Yes"),
+        `${p.slug} lost an answer it was entitled to`,
+      );
+      assert.ok(!p.html.includes("eligibility-gate-line"), `${p.slug} renders a gate it does not carry`);
+    }
+  });
+
+  it("carries the qualification into the page description too", () => {
+    for (const p of rendered.filter(x => x.offer.eligibility)) {
+      const description = blockOfType(p.html, "WebPage")?.description ?? "";
+      assert.ok(description.startsWith(gateFor(p.offer, "")!.reason), `${p.slug} description is unqualified`);
+    }
+  });
+
+  it("publishes every condition it holds except the one recording that no program was read", () => {
+    const withRealConditions = rendered.filter(
+      p => p.offer.eligibility && publishableEligibilityConditions(p.offer).length > 0,
+    );
+    assert.ok(withRealConditions.length > 0, "no gated record holds a publishable condition");
+    for (const p of withRealConditions) {
+      const list = p.html.match(/<ul class="eligibility-conditions"[^>]*>([\s\S]*?)<\/ul>/)?.[1];
+      assert.ok(list, `${p.slug} renders no conditions list`);
+      for (const condition of publishableEligibilityConditions(p.offer)) {
+        assert.ok(list!.includes(`<li>${escapeHtml(condition)}</li>`), `${p.slug} withholds ${condition}`);
+      }
+    }
+    const placeholderOnly = rendered.filter(
+      p => p.offer.eligibility && publishableEligibilityConditions(p.offer).length === 0,
+    );
+    assert.ok(
+      placeholderOnly.length > 0,
+      "the placeholder condition is gone from the data, so this branch has no subject",
+    );
+    for (const p of placeholderOnly) {
+      assert.ok(p.html.includes("eligibility-gate-line"), `${p.slug} states no restriction`);
+      assert.ok(!p.html.includes(escapeHtml(CONDITION_RECORDING_AN_UNREAD_PROGRAM)), `${p.slug} publishes the placeholder`);
+    }
+  });
+});
+
+describe("the category page a gated offer is sent to states the restriction", () => {
+  it("names it on the row for every gated offer in the category", async () => {
+    const gatedByCategory = new Map<string, Offer[]>();
+    for (const o of offers) {
+      if (!o.eligibility) continue;
+      const list = gatedByCategory.get(o.category) ?? [];
+      list.push(o);
+      gatedByCategory.set(o.category, list);
+    }
+    assert.ok(gatedByCategory.size > 0, "no category holds a gated offer, so this block has no subject");
+    for (const [category, gated] of gatedByCategory) {
+      const html = await page(`/category/${slugOf(category)}`);
+      for (const o of gated) {
+        assert.ok(
+          html.includes(escapeHtml(gateFor(o, "")!.reason)),
+          `/category/${slugOf(category)} omits the restriction on ${o.vendor}`,
+        );
+      }
+    }
+  });
+
+  it("keeps every gated offer on the category page and the vendor page the gate promises", async () => {
+    for (const o of offers.filter(x => x.eligibility)) {
+      const category = await page(`/category/${slugOf(o.category)}`);
+      assert.ok(category.includes(`/vendor/${slugOf(o.vendor)}`), `${o.vendor} left its category page`);
+      const vendor = await page(`/vendor/${slugOf(o.vendor)}`);
+      assert.ok(vendor.includes("<h1>"), `/vendor/${slugOf(o.vendor)} stopped rendering`);
+    }
+  });
+});
+
+describe("the disclosure reuses one composition", () => {
+  it("returns the ranking gate unchanged for a record carrying eligibility", () => {
+    const gated = offers.find(o => o.eligibility)!;
+    assert.deepStrictEqual(eligibilityGate(gated), gateFor(gated, ""));
+    assert.strictEqual(eligibilityGate(gated)!.code, "eligibility_restricted");
+  });
+
+  it("returns nothing for a record gated on anything else", () => {
+    const expired: Offer = {
+      vendor: "Acme", category: "Databases", description: "A free tier.", tier: "Free",
+      url: "https://example.com/pricing", tags: [], verifiedDate: "2026-08-20", expires_date: "2026-01-01",
+    };
+    assert.strictEqual(gateFor(expired, "2026-09-01")!.code, "offer_expired");
+    assert.strictEqual(eligibilityGate(expired), null);
+    assert.deepStrictEqual(publishableEligibilityConditions(expired), []);
+  });
+
+  it("drops only the condition that records an unread program", () => {
+    const offer = {
+      eligibility: {
+        type: "student" as const,
+        conditions: ["Raised less than $25M", CONDITION_RECORDING_AN_UNREAD_PROGRAM, "Pre-Series B"],
+      },
+    };
+    assert.deepStrictEqual(publishableEligibilityConditions(offer as Offer), [
+      "Raised less than $25M",
+      "Pre-Series B",
+    ]);
+  });
+});
+
+function escapeHtml(s: string): string {
+  return s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;");
+}


### PR DESCRIPTION
Eight of the nine acceptance criteria on https://github.com/robhunter/agentdeals/issues/1215. **AC-6 is not here** — see the last section.

`/criteria` promises that a gated offer *"still appears on its category page and its vendor page"*. It does. Neither page said why. `gateFor` has composed the sentence since the gate was written and only `/alternative-to` rendered it — 3 pages on a 3.0% surface.

## What changed

**One string, from one function.** `src/eligibility.ts` wraps `gateFor` and returns the gate only when it is `eligibility_restricted`. Both new surfaces render `gate.reason` verbatim, so `/vendor/aws-activate` and `/alternative-to/digitalocean` now say the same words. There is no second phrasing anywhere in the diff.

**Vendor page.** Directly under the `<h1>`, in the slot `link_unreachable` uses, with the gate code as its label exactly as the `alt-demerit` block does:

> **`eligibility_restricted`** Restricted to accelerator (AWS Activate Portfolio) applicants — not generally available. [How we use this](https://agentdeals.dev/criteria#gates).
> - Backed by approved VC, accelerator, or incubator
> - Have provider Organization ID
> - Pre-Series B
> - Founded within last 10 years

Four stored conditions, all four published. `/criteria`'s gate section gained an `id` so the link has somewhere to land.

**`FAQPage`, `Is X free?`** — the criterion I read as the most important, because the JSON-LD is the block a model lifts whole. The answer opens with the gate sentence and then states the tier; the word `Yes` is gone. **29 pages answered `Yes` before**, which is the issue's census reproduced exactly by the new test running against a `main` build. Where the record is *also* source-unconfirmed, the gate sentence precedes the existing `We cannot confirm that today.` preamble — restriction first, then confidence.

**`WebPage.description`** takes the same prefix, and so does the `<meta name="description">` it shares.

**Category page.** Every gated row now carries `gate.reason` and its conditions, through the same per-row mechanism `link_unreachable` already used there. `/category/cloud-iaas` renders 9, `/category/startup-perks` 93.

## AC-5: the `<h1>` keeps its name

`X Free Tier 2026` stays and gains the sentence adjacent to it. The `<h1>` is also the `<title>` and the anchor text of every inbound link to the page — changing it changes what the page is *called* everywhere it is cited, and what is wrong here is a missing qualification, not a wrong name. A reader who arrives from a search result reading `AWS Activate Free Tier 2026` and finds a page headed something else has been handed a second puzzle. The qualification is one line below the heading and above everything else on the page.

## AC-9: the placeholder is not fit to publish

`Startup program — check vendor for eligibility details` is the only condition stored on **25 of the 52** records in scope. A reader cannot use it to decide whether they qualify, and rendered as a disclosure it reads as a condition we checked when what it records is that we did not read one — the same defect one level down.

So it is withheld. `publishableEligibilityConditions` filters exactly that one string; those 25 pages render the gate sentence and no list. When the data is fixed the conditions render on their own, and a test asserts that this branch still has a subject, so it goes red rather than silent if the placeholder disappears.

The other two high-frequency strings — `First deal free, then 99€/year or invite friends` (56) and `Free for Brex customers` (29) — **are** published. They are not terms of the vendor's program, but they are true conditions of access and a reader can act on them. Those 86 records are https://github.com/robhunter/agentdeals/issues/1118's and their fate is separate.

## Measurement

| | |
|---|---|
| Vendor pages moved | **133** |
| Category pages moved | **18** — every category holding a gated record |
| `/criteria` | 1, the new anchor `id` |
| Byte-identical | **3,059 of 3,210** across the full vendor, `/alternative-to` and category slug set |
| `/alternative-to` pages moved | **0** |
| Status changes | **0** |

Two counts in the issue are worth restating, because they differ and both are right:

- **52** records carry `eligibility` outside `joinsecret.com` / `brex.com`, over 52 distinct vendors.
- **47** of those vendor pages render the gated record. The other **5** — PostHog, Sentry, Cloudflare Workers, Amplitude, DigitalOcean — render an ungated record instead and are the negative control. They still answer `Yes`, and a test fails if any of them stops.
- **133** vendor pages render a gated record in total, because the 86 `joinsecret`/`brex` records reach the same code path. The issue expects that.

## Tests

`test/eligibility-disclosure.test.ts`, 11 tests. **5 fail on a `main` build**, including the AC-8 assertion, whose failure lists 29 slugs. The two that pass on `main` are the ones that must — the over-fire control and the nothing-was-removed check — so neither is vacuous.

Subjects are derived, never named: gated vendors come from the index, the negative controls are *"vendors holding a gated record whose page renders an ungated one"*, and the rendered record is identified from the page's own JSON-LD rather than by reimplementing which record a vendor page picks. Every block asserts its subject exists with a message saying what it means if it does not.

8 of 8 mutations killed. A ninth — renaming the conditions list's class — survived the first pass, because the assertion could be satisfied by the conditions appearing in the JSON-LD. The assertion now reads the `<ul>` itself, and removing or truncating the list both go red.

2,925 tests pass. MCP handshake and a `search_deals` call verified against the built server; the eligibility object on the API surface is untouched.

## AC-6 is not in this PR

The category page still ledes `18 verified free tiers and developer deals.` over 9 gated records. That count claim needs a sentence I do not have — asked on the issue at 09:35 UTC, unanswered when this was opened, and I do not write site copy.

What is here instead is the per-row disclosure, which needed no new words. It does not satisfy AC-6 and does not close it: **a reader scanning `/category/cloud-iaas` now sees the restriction on each of the 9 rows, but the number at the top of the page still counts all 18 as verified free tiers.** One sentence and I will ship it.

Refs #1215
