### PR TITLE
Mark three hijacked domains retired — two now serve gambling sites (#1229)

### DIFF
--- a/data/index.json
+++ b/data/index.json
@@ -11605,8 +11605,8 @@
     {
       "vendor": "Supportivekoala",
       "category": "Dev Utilities",
-      "description": "Allows you to autogenerate images by your input via templates. The free plan allows you to create up to 50 images per month.",
-      "tier": "Free",
+      "description": "supportivekoala.com no longer serves the product. Checked 2026-09-01: the domain redirects to buyingpropertysingapore.com, which serves an online gambling site, so the expired domain has been taken over by an unrelated party. The former offer was template-based image autogeneration with 50 images per month on the free plan.",
+      "tier": "Retired",
       "url": "https://supportivekoala.com/",
       "tags": [
         "developer-tools",
@@ -20192,8 +20192,8 @@
     {
       "vendor": "Oaysus",
       "category": "Cloud Hosting",
-      "description": "Visual page builder for developer-built React, Vue, or Svelte components. Free tier includes 1 site with 3 pages, form submissions, and global CDN hosting.",
-      "tier": "Free",
+      "description": "oaysus.com no longer serves the product. Checked 2026-09-01: the domain redirects to mirin.com, a website design agency with no connection to the former product. The former offer was a visual page builder for React, Vue and Svelte components with 1 site, 3 pages and CDN hosting on the free tier.",
+      "tier": "Retired",
       "url": "https://oaysus.com",
       "tags": [
         "hosting",
@@ -20205,17 +20205,6 @@
         "checked": "2026-08-28",
         "outcome": "ok",
         "detail": "url"
-      },
-      "product_subtypes": {
-        "taxonomy": "Cloud Hosting",
-        "labels": [
-          {
-            "subtype": "site_builder",
-            "source_url": "https://oaysus.com/",
-            "source_quote": "Mirin designs and builds your site, then gives you a simple way to update it after launch."
-          }
-        ],
-        "reviewed": "2026-08-31"
       }
     },
     {
@@ -22591,8 +22580,8 @@
     {
       "vendor": "QRME.SH",
       "category": "Storage",
-      "description": "Fast, beautiful bulk QR code generator – no login, no watermark, no ads. Up to 100 URLs per bulk export.",
-      "tier": "Free",
+      "description": "qrme.sh no longer serves the product. Checked 2026-09-01: the domain redirects to hz-mobile.de, which serves an online gambling site, so the expired domain has been taken over by an unrelated party. The former offer was a bulk QR code generator with no login and up to 100 URLs per export.",
+      "tier": "Retired",
       "url": "https://qrme.sh",
       "tags": [
         "storage",


### PR DESCRIPTION
Three records publish a URL that no longer belongs to the product. Two of them now serve online gambling sites.

## What I checked

I probed all 1,580 published offer URLs with `curl -L` today and compared the registrable domain we publish against the one the request actually lands on. 47 differ. For those 47 I fetched the destination and checked whether it still names the vendor; 19 do not. These three are the ones where the destination is an unrelated business.

| record | verified | lands on | what is there now |
|---|---|---|---|
| Supportivekoala | 2026-07-14 | `buyingpropertysingapore.com/artra/` | `QQEMAS SITUS SLOT GACOR SLOT777` — an online slots site |
| QRME.SH | 2026-07-19 | `hz-mobile.de` | `TX88 – NHÀ CÁI TRỰC TUYẾN` — an online betting site |
| Oaysus | 2026-07-16 | `mirin.com` | a website design agency, no connection to the former product |

All three are expired domains taken over by someone else. All three were stamped `verifiedDate` inside the last seven weeks.

**`source_check` ran on all three on 2026-08-28 and returned `ok` for Supportivekoala and Oaysus.** The checker has a `does_not_name_vendor` outcome — it fires on 90 records and fired correctly on Ninja Outreach — and it did not fire on a slots casino. That is https://github.com/robhunter/agentdeals/issues/1229, filed alongside this.

## What changes

`tier` `Free` → `Retired`, following the GitHub Models precedent in 64d2a34. The description states what the domain serves now and the date I checked, and preserves what the offer used to be.

**The records stay.** All three slugs are in `sitemap-vendors.xml` and return 200 today. Deleting them would 404 an indexed URL, which is the objection I raised against the duplicate merge on https://github.com/robhunter/agentdeals/issues/1220 and it applies to me here too.

**I also removed a `product_subtypes` label I added yesterday.** Oaysus carried `site_builder` sourced to the quote *"Mirin designs and builds your site, then gives you a simple way to update it after launch."* That is Mirin's copy. I labelled our record from a different company's website because I fetched `oaysus.com` and read what the redirect served. Any label whose `source_url` is a bare domain root is exposed to this.

## What this does not fix

`url` still points at the hijacked domain, so `/vendor/supportivekoala` still renders an outbound link to a gambling site. I could not fix that from data: there is no successor page to point at and the Wayback Machine holds no snapshot of any of the three. Suppressing the outbound link on a `Retired` record is code and it is criterion 4 on https://github.com/robhunter/agentdeals/issues/1229.

## Derived effects

`tier` no longer contains `free`, so `src/data.ts:880,915` drops all three from related-offer lists and `serve.ts:3735` flips `hasFree` false, which changes the `Is X free?` JSON-LD — the same chain 64d2a34 documented.

Categories: Dev Utilities, Storage and Cloud Hosting each lose one free record. Cloud Hosting is classified, so removing the Oaysus label removes it from `/alternative-to` pairs; it is one record in a 60-record category and no page empties.

`lint-duplicates.js` passes. 1,580 records before and after. `data/index.json` round-trips byte-identical through `json.dumps(indent=2, ensure_ascii=False)` plus a trailing newline, asserted before and after the edit.

Refs #1229.
