### PR TITLE
Retired records must say "no free tier" — /vendor/supportivekoala answered "Yes" (#1229)

### DIFF
--- a/data/index.json
+++ b/data/index.json
@@ -11605,7 +11605,7 @@
     {
       "vendor": "Supportivekoala",
       "category": "Dev Utilities",
-      "description": "supportivekoala.com no longer serves the product. Checked 2026-09-01: the domain redirects to buyingpropertysingapore.com, which serves an online gambling site, so the expired domain has been taken over by an unrelated party. The former offer was template-based image autogeneration with 50 images per month on the free plan.",
+      "description": "There is no free tier: supportivekoala.com no longer serves the product. Checked 2026-09-01, the domain redirects to buyingpropertysingapore.com, which serves an online gambling site, so the expired domain has been taken over by an unrelated party. The former offer was template-based image autogeneration with 50 images per month on the free plan.",
       "tier": "Retired",
       "url": "https://supportivekoala.com/",
       "tags": [
@@ -20192,7 +20192,7 @@
     {
       "vendor": "Oaysus",
       "category": "Cloud Hosting",
-      "description": "oaysus.com no longer serves the product. Checked 2026-09-01: the domain redirects to mirin.com, a website design agency with no connection to the former product. The former offer was a visual page builder for React, Vue and Svelte components with 1 site, 3 pages and CDN hosting on the free tier.",
+      "description": "There is no free tier: oaysus.com no longer serves the product. Checked 2026-09-01, the domain redirects to mirin.com, a website design agency with no connection to the former product. The former offer was a visual page builder for React, Vue and Svelte components with 1 site, 3 pages and CDN hosting on the free tier.",
       "tier": "Retired",
       "url": "https://oaysus.com",
       "tags": [
@@ -22580,7 +22580,7 @@
     {
       "vendor": "QRME.SH",
       "category": "Storage",
-      "description": "qrme.sh no longer serves the product. Checked 2026-09-01: the domain redirects to hz-mobile.de, which serves an online gambling site, so the expired domain has been taken over by an unrelated party. The former offer was a bulk QR code generator with no login and up to 100 URLs per export.",
+      "description": "There is no free tier: qrme.sh no longer serves the product. Checked 2026-09-01, the domain redirects to hz-mobile.de, which serves an online gambling site, so the expired domain has been taken over by an unrelated party. The former offer was a bulk QR code generator with no login and up to 100 URLs per export.",
       "tier": "Retired",
       "url": "https://qrme.sh",
       "tags": [


### PR DESCRIPTION
Follow-up to https://github.com/robhunter/agentdeals/pull/1230, which I merged and then checked on production.

`/vendor/supportivekoala` answered **`Is Supportivekoala free?` → `Yes, Supportivekoala offers a free tier: Retired.`**

`serve.ts:3761` computes `hasFree` from `description.toLowerCase().includes("no free tier")`, not from `tier`. Setting `tier` to `Retired` does not flip it. The GitHub Models precedent in 64d2a34 worked because its description opens *"GitHub retired GitHub Models on 2026-07-30, so there is no free tier"* — I read that commit's derived-effects note, quoted the mechanism in my own PR body, and then wrote descriptions that do not contain the string.

All three descriptions now open `There is no free tier:` and are otherwise unchanged. The same substring gates `serve.ts:2274-2275`, which is the comparison-page path.

**This is the argument for criterion 4 on https://github.com/robhunter/agentdeals/issues/1229, not against it.** A retired record's rendering should follow from `tier`, not from whether a human remembered a magic phrase in prose. Two data fields now have to agree for a page to be correct, and nothing tests that they do.

`lint-duplicates.js` passes. 1,580 records. `data/index.json` round-trips byte-identical.

Refs #1229.