### PR TITLE
Read the retired tier: no outbound link, no "Yes, X offers a free tier" (#1229)

### DIFF
--- a/scripts/mutate-1229.sh
+++ b/scripts/mutate-1229.sh
@@ -1,0 +1,156 @@
+#!/usr/bin/env bash
+set -u
+
+REPO="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$REPO" || exit 1
+
+RETIREMENT="src/retirement.ts"
+SERVE="src/serve.ts"
+BACKUP_DIR="$(mktemp -d)"
+cp "$RETIREMENT" "$BACKUP_DIR/retirement.ts"
+cp "$SERVE" "$BACKUP_DIR/serve.ts"
+
+restore() {
+  cp "$BACKUP_DIR/retirement.ts" "$RETIREMENT"
+  cp "$BACKUP_DIR/serve.ts" "$SERVE"
+  npx tsc > /dev/null 2>&1
+}
+trap restore EXIT
+
+killed=0
+survived=0
+TESTS="test/retired-records.test.ts"
+
+run_mutation() {
+  local name="$1"
+  shift
+  echo "=== $name"
+  restore
+  "$@"
+  local changed=0
+  for f in "$RETIREMENT" "$SERVE"; do
+    diff -q "$BACKUP_DIR/$(basename "$f")" "$f" > /dev/null || changed=1
+  done
+  if [ "$changed" -eq 0 ]; then
+    echo "    NOT APPLIED: the mutation changed no file, so it proves nothing"
+    survived=$((survived + 1))
+    return
+  fi
+  if ! npx tsc > /tmp/mutate-1229-build.log 2>&1; then
+    echo "    KILLED: does not compile"
+    killed=$((killed + 1))
+    return
+  fi
+  if timeout 600 node --test $TESTS > /tmp/mutate-1229-test.log 2>&1; then
+    echo "    SURVIVED"
+    survived=$((survived + 1))
+  else
+    echo "    KILLED: $(grep -c '✖ ' /tmp/mutate-1229-test.log) failing assertion(s)"
+    grep '✖ ' /tmp/mutate-1229-test.log | head -4
+    killed=$((killed + 1))
+  fi
+}
+
+py() { python3 - "$@"; }
+
+m_nothing_is_retired() {
+  py <<'PY'
+p = "src/retirement.ts"
+s = open(p).read()
+s = s.replace("  return RETIRED_TIER.test(offer?.tier ?? \"\");", "  return false;")
+open(p, "w").write(s)
+PY
+}
+
+m_everything_free_is_retired() {
+  py <<'PY'
+p = "src/retirement.ts"
+s = open(p).read()
+s = s.replace(
+  "const RETIRED_TIER = /\\b(?:retired|deprecated|discontinued|sunset|withdrawn)\\b/i;",
+  "const RETIRED_TIER = /\\b(?:retired|deprecated|discontinued|sunset|withdrawn|free)\\b/i;")
+open(p, "w").write(s)
+PY
+}
+
+m_sentence_reads_the_description() {
+  py <<'PY'
+p = "src/retirement.ts"
+s = open(p).read()
+s = s.replace(
+  "  return `${vendorName}'s offer is recorded as ${tier}.`;",
+  "  return `${vendorName}'s offer is recorded.`;")
+open(p, "w").write(s)
+PY
+}
+
+m_listing_rows_keep_the_link() {
+  py <<'PY'
+p = "src/serve.ts"
+s = open(p).read()
+s = s.replace("  if (offerRetired(offer)) return \"\";\n", "")
+open(p, "w").write(s)
+PY
+}
+
+m_vendor_page_keeps_its_pricing_card() {
+  py <<'PY'
+p = "src/serve.ts"
+s = open(p).read()
+s = s.replace("${offerRetired(primary) ? \"\" : `<div class=\"detail-card\">", "${false ? \"\" : `<div class=\"detail-card\">")
+open(p, "w").write(s)
+PY
+}
+
+m_alternatives_page_keeps_its_pricing_row() {
+  py <<'PY'
+p = "src/serve.ts"
+s = open(p).read()
+s = s.replace("    if (!offerRetired(primary)) {\n      parts.push(`<div class=\"risk-row\"><span class=\"risk-label\">Pricing Page:",
+              "    if (true) {\n      parts.push(`<div class=\"risk-row\"><span class=\"risk-label\">Pricing Page:")
+open(p, "w").write(s)
+PY
+}
+
+m_structured_data_keeps_the_url() {
+  py <<'PY'
+p = "src/serve.ts"
+s = open(p).read()
+s = s.replace("...(offerRetired(primary) ? {} : { url: primary.url }),", "url: primary.url,")
+open(p, "w").write(s)
+PY
+}
+
+m_free_question_falls_through_to_yes() {
+  py <<'PY'
+p = "src/serve.ts"
+s = open(p).read()
+s = s.replace("  const faqFreeAnswer = retiredSentence\n    ? `${retiredSentence} ${storedTerms}`\n    : levelWithheld",
+              "  const faqFreeAnswer = levelWithheld")
+open(p, "w").write(s)
+PY
+}
+
+m_tier_question_falls_through() {
+  py <<'PY'
+p = "src/serve.ts"
+s = open(p).read()
+s = s.replace("  const faqTierAnswer = retiredSentence\n    ? `${retiredSentence} ${primary.description}`\n    : levelWithheld",
+              "  const faqTierAnswer = levelWithheld")
+open(p, "w").write(s)
+PY
+}
+
+run_mutation "nothing is retired" m_nothing_is_retired
+run_mutation "every free tier reads as retired" m_everything_free_is_retired
+run_mutation "the sentence drops the tier it reports" m_sentence_reads_the_description
+run_mutation "listing rows keep the outbound link" m_listing_rows_keep_the_link
+run_mutation "the vendor page keeps its pricing card" m_vendor_page_keeps_its_pricing_card
+run_mutation "the alternatives page keeps its pricing row" m_alternatives_page_keeps_its_pricing_row
+run_mutation "structured data keeps the application URL" m_structured_data_keeps_the_url
+run_mutation "the free-tier question falls through to yes" m_free_question_falls_through_to_yes
+run_mutation "the tier question falls through" m_tier_question_falls_through
+
+echo
+echo "killed $killed, survived $survived"
+[ "$survived" -eq 0 ]

--- a/src/retirement.ts
+++ b/src/retirement.ts
@@ -1,0 +1,13 @@
+import type { Offer } from "./types.js";
+
+const RETIRED_TIER = /\b(?:retired|deprecated|discontinued|sunset|withdrawn)\b/i;
+
+export type OfferTierAndUrl = Pick<Offer, "tier" | "url">;
+
+export function offerRetired(offer: Pick<Offer, "tier"> | null | undefined): boolean {
+  return RETIRED_TIER.test(offer?.tier ?? "");
+}
+
+export function recordedTierSentence(vendorName: string, tier: string): string {
+  return `${vendorName}'s offer is recorded as ${tier}.`;
+}

--- a/src/serve.ts
+++ b/src/serve.ts
@@ -16,6 +16,7 @@ import { buildDailyRollup, readRollups, coverageOf, ROLLUP_DATE_PATTERN } from "
 import { configureVendorSeries, recordVendorRequest, flushVendorSeries, readVendorSeries, vendorSeriesGauge, vendorExportAuthorized, isSeriesDate, seriesDateRange, VENDOR_SERIES_PATH, VENDOR_SERIES_RETENTION_DAYS, VENDOR_SERIES_NOTES } from "./vendor-series.js";
 import { openapiSpec } from "./openapi.js";
 import { LINK_GRACE_DAYS, unreachableNoticeForUrl } from "./link-health.js";
+import { offerRetired, recordedTierSentence, type OfferTierAndUrl } from "./retirement.js";
 import { levelWithheldReason, withheldLevelClause, withheldLevelSentence } from "./source-check.js";
 import { buildComparisonMap, comparisonSlug } from "./comparison-pairs.js";
 import { stabilityFaqAnswer, stabilityVerdictClause, type ComparisonSide, type StabilityRating } from "./comparison-verdict.js";
@@ -684,6 +685,11 @@ function escHtmlServer(s: string): string {
   return s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;");
 }
 
+function offerPricingLink(offer: OfferTierAndUrl, label: string): string {
+  if (offerRetired(offer)) return "";
+  return `<a href="${escHtmlServer(offer.url)}" target="_blank" rel="noopener">${label}</a>`;
+}
+
 type BadgeStatus = "active" | "at-risk" | "removed" | "unknown";
 
 function getBadgeStatus(vendorSlug: string): { status: BadgeStatus; label: string; verifiedDate: string | null } {
@@ -1228,7 +1234,7 @@ function buildCategoryPage(slug: string): string | null {
         description: o.description,
         applicationCategory: categoryName,
         offers: { "@type": "Offer", price: "0", priceCurrency: "USD", description: o.tier },
-        url: o.url,
+        ...(offerRetired(o) ? {} : { url: o.url }),
       },
     })),
   };
@@ -1554,7 +1560,7 @@ function buildBestOfPage(slug: string): string | null {
             <a href="/vendor/${toSlug(o.vendor)}">Full profile</a>
             <a href="/alternative-to/${toSlug(o.vendor)}">Alternatives</a>
             ${relatedCompareLinks}
-            <a href="${escHtmlServer(o.url)}" target="_blank" rel="noopener">Pricing page &nearr;</a>
+            ${offerPricingLink(o, "Pricing page &nearr;")}
           </div>
         </div>
       </div>`;
@@ -1591,7 +1597,7 @@ function buildBestOfPage(slug: string): string | null {
         description: e.offer.description,
         applicationCategory: categoryName,
         offers: { "@type": "Offer", price: "0", priceCurrency: "USD", description: e.offer.tier },
-        url: e.offer.url,
+        ...(offerRetired(e.offer) ? {} : { url: e.offer.url }),
       },
     })),
   };
@@ -3758,7 +3764,8 @@ function buildVendorPage(slug: string): string | null {
     .filter(([, [a, b]]) => a === vendorName || b === vendorName);
 
   const currentYear = new Date().getFullYear();
-  const hasFree = primary.tier.toLowerCase() !== "none" && !primary.description.toLowerCase().includes("no free tier");
+  const retiredSentence = offerRetired(primary) ? recordedTierSentence(vendorName, primary.tier) : "";
+  const hasFree = !retiredSentence && primary.tier.toLowerCase() !== "none" && !primary.description.toLowerCase().includes("no free tier");
   const title = hasFree
     ? `${vendorName} Free Tier ${currentYear}: Limits, Pricing & What Changed | AgentDeals`
     : `${vendorName} Pricing ${currentYear}: Plans, Costs & Free Alternatives | AgentDeals`;
@@ -3793,7 +3800,7 @@ function buildVendorPage(slug: string): string | null {
     : "";
   const quickVerdictHtml = `
   <div class="quick-verdict">
-    <p>${escHtmlServer(vendorName)}'s free tier offers ${escHtmlServer(keyLimit)}. ${verdictLine2}${verdictLine3 ? " " + verdictLine3 : ""}</p>
+    <p>${retiredSentence ? `${escHtmlServer(retiredSentence)} ${escHtmlServer(keyLimit)}.` : `${escHtmlServer(vendorName)}'s free tier offers ${escHtmlServer(keyLimit)}.`} ${verdictLine2}${verdictLine3 ? " " + verdictLine3 : ""}</p>
   </div>`;
 
   const catMapping = categoryComparisonMap[primary.category];
@@ -4063,7 +4070,7 @@ ${allCompareLinks.join("\n")}
       name: vendorName,
       description: primary.description,
       applicationCategory: primary.category,
-      url: primary.url,
+      ...(offerRetired(primary) ? {} : { url: primary.url }),
       offers: {
         "@type": "Offer",
         price: "0",
@@ -4086,12 +4093,16 @@ ${allCompareLinks.join("\n")}
   const eligibilityConditionsSentence = primaryEligibilityConditions.length > 0
     ? ` Eligibility: ${primaryEligibilityConditions.join("; ")}.`
     : "";
-  const faqFreeAnswer = levelWithheld
+  const faqFreeAnswer = retiredSentence
+    ? `${retiredSentence} ${storedTerms}`
+    : levelWithheld
     ? `${eligibilityGateSentence}${unconfirmedTermsPreamble}Our stored record says ${vendorName} offers a free tier: ${primary.tier}. ${withUnconfirmedTermsCaveat(storedTerms)}${eligibilityConditionsSentence}`
     : primaryEligibilityGate
     ? `${eligibilityGateSentence}${vendorName} offers a free tier: ${primary.tier}. ${storedTerms}${eligibilityConditionsSentence}`
     : `Yes, ${vendorName} offers a free tier: ${primary.tier}. ${storedTerms}`;
-  const faqTierAnswer = levelWithheld
+  const faqTierAnswer = retiredSentence
+    ? `${retiredSentence} ${primary.description}`
+    : levelWithheld
     ? `${unconfirmedTermsPreamble}Our stored record calls ${vendorName}'s free tier "${primary.tier}". ${withUnconfirmedTermsCaveat(primary.description)}`
     : `${vendorName}'s free tier is called "${primary.tier}". ${primary.description}`;
   const faqReliableAnswer = levelWithheld
@@ -4259,11 +4270,11 @@ ${referralCalloutHtml}
         <div class="cat-pills">${allCategories.map(c => `<a href="/category/${toSlug(c)}" class="cat-pill">${escHtmlServer(c)}</a>`).join("")}</div>
       </div>
     </div>
-    <div class="detail-card">
+    ${offerRetired(primary) ? "" : `<div class="detail-card">
       <div class="detail-label">Pricing Page</div>
       <div class="detail-value"><a href="${escHtmlServer(primary.url)}" rel="noopener" target="_blank">Visit &rarr;</a></div>
     </div>
-    <div class="detail-card">
+    `}<div class="detail-card">
       <div class="detail-label">${discontinuedOn ? "Discontinued" : linkUnreachable ? "Link last reachable" : "Verified"}</div>
       <div class="detail-value" style="font-family:var(--mono)">${escHtmlServer(discontinuedOn ?? (linkUnreachable ? (linkUnreachable.last_reachable ?? "no reachable date on record") : primary.verifiedDate))}</div>
     </div>
@@ -4412,7 +4423,9 @@ function buildAlternativesPage(slug: string): string | null {
       parts.push(`<div class="risk-row"><span class="risk-label">Why:</span> <span class="risk-cause-date" style="font-family:var(--mono)">${escHtmlServer(changeDateLabel(riskCause))}</span> &mdash; ${escHtmlServer(riskCause.summary)}</div>`);
     }
     parts.push(`<div class="risk-row"><span class="risk-label">Category:</span> ${vendorCategories.map(c => `<a href="/category/${toSlug(c)}" class="cat-pill">${escHtmlServer(c)}</a>`).join(" ")}</div>`);
-    parts.push(`<div class="risk-row"><span class="risk-label">Pricing Page:</span> <a href="${escHtmlServer(primary.url)}" rel="noopener" target="_blank">${escHtmlServer(primary.url.replace(/^https?:\/\//, "").slice(0, 50))}${primary.url.replace(/^https?:\/\//, "").length > 50 ? "..." : ""}</a></div>`);
+    if (!offerRetired(primary)) {
+      parts.push(`<div class="risk-row"><span class="risk-label">Pricing Page:</span> <a href="${escHtmlServer(primary.url)}" rel="noopener" target="_blank">${escHtmlServer(primary.url.replace(/^https?:\/\//, "").slice(0, 50))}${primary.url.replace(/^https?:\/\//, "").length > 50 ? "..." : ""}</a></div>`);
+    }
     if (vendorChanges.length > 0) {
       parts.push(`<div class="changes-summary"><h3>Recent Pricing Changes (${vendorChanges.length})</h3>`);
       parts.push(vendorChanges.slice(0, 5).map(c => {
@@ -6816,7 +6829,7 @@ function buildTimelyAlternativesPage(slug: string): string | null {
         <div class="alt-card-links">
           <a href="/vendor/${toSlug(o.vendor)}">Full profile</a>
           <a href="/alternative-to/${toSlug(o.vendor)}">More alternatives</a>
-          <a href="${escHtmlServer(o.url)}" target="_blank" rel="noopener">Pricing page &nearr;</a>
+          ${offerPricingLink(o, "Pricing page &nearr;")}
         </div>
         ${o.referral ? `<div style="margin-top:.5rem;padding:.4rem .75rem;border:1px solid #3fb95040;border-left:3px solid #3fb950;border-radius:0 6px 6px 0;background:#3fb95010;font-size:.8rem">\ud83d\udd17 <a href="${escHtmlServer(o.referral.url)}" rel="noopener sponsored" target="_blank" style="color:#3fb950">${escHtmlServer(o.referral.referee_value ?? "Save with our referral link")}</a> <a href="/disclosure" style="font-size:.7rem;color:var(--text-dim)">(disclosure)</a></div>` : ""}
       </div>`;
@@ -6836,7 +6849,7 @@ function buildTimelyAlternativesPage(slug: string): string | null {
         <p class="alt-card-desc">${escHtmlServer(o.description)}</p>
         <div class="alt-card-links">
           <a href="/vendor/${toSlug(o.vendor)}">Full profile</a>
-          <a href="${escHtmlServer(o.url)}" target="_blank" rel="noopener">Pricing page &nearr;</a>
+          ${offerPricingLink(o, "Pricing page &nearr;")}
         </div>
         ${o.referral ? `<div style="margin-top:.5rem;padding:.4rem .75rem;border:1px solid #3fb95040;border-left:3px solid #3fb950;border-radius:0 6px 6px 0;background:#3fb95010;font-size:.8rem">\ud83d\udd17 <a href="${escHtmlServer(o.referral.url)}" rel="noopener sponsored" target="_blank" style="color:#3fb950">${escHtmlServer(o.referral.referee_value ?? "Save with our referral link")}</a> <a href="/disclosure" style="font-size:.7rem;color:var(--text-dim)">(disclosure)</a></div>` : ""}
       </div>`;
@@ -6864,7 +6877,7 @@ function buildTimelyAlternativesPage(slug: string): string | null {
         name: o.vendor,
         description: o.description,
         offers: { "@type": "Offer", price: "0", priceCurrency: "USD", description: o.tier },
-        url: o.url,
+        ...(offerRetired(o) ? {} : { url: o.url }),
       },
     })),
   };
@@ -8557,7 +8570,7 @@ function buildAiFreeTiersPage(): string {
         <div class="alt-card-links">
           <a href="/vendor/${toSlug(o.vendor)}">Full profile</a>
           <a href="/alternative-to/${toSlug(o.vendor)}">Alternatives</a>
-          <a href="${escHtmlServer(o.url)}" target="_blank" rel="noopener">Pricing &nearr;</a>
+          ${offerPricingLink(o, "Pricing &nearr;")}
         </div>
         ${o.referral ? `<div style="margin-top:.5rem;padding:.4rem .75rem;border:1px solid #3fb95040;border-left:3px solid #3fb950;border-radius:0 6px 6px 0;background:#3fb95010;font-size:.8rem">\ud83d\udd17 <a href="${escHtmlServer(o.referral.url)}" rel="noopener sponsored" target="_blank" style="color:#3fb950">${escHtmlServer(o.referral.referee_value ?? "Save with our referral link")}</a> <a href="/disclosure" style="font-size:.7rem;color:var(--text-dim)">(disclosure)</a></div>` : ""}
       </div>`;
@@ -8590,7 +8603,7 @@ function buildAiFreeTiersPage(): string {
         name: o.vendor,
         description: o.description,
         offers: { "@type": "Offer", price: "0", priceCurrency: "USD", description: o.tier },
-        url: o.url,
+        ...(offerRetired(o) ? {} : { url: o.url }),
       },
     })),
   };
@@ -8814,7 +8827,7 @@ function buildHostingAlternativesPage(): string {
         <div class="alt-card-links">
           <a href="/vendor/${toSlug(o.vendor)}">Full profile</a>
           <a href="/alternative-to/${toSlug(o.vendor)}">Alternatives</a>
-          <a href="${escHtmlServer(o.url)}" target="_blank" rel="noopener">Pricing &nearr;</a>
+          ${offerPricingLink(o, "Pricing &nearr;")}
         </div>
         ${o.referral ? `<div style="margin-top:.5rem;padding:.4rem .75rem;border:1px solid #3fb95040;border-left:3px solid #3fb950;border-radius:0 6px 6px 0;background:#3fb95010;font-size:.8rem">\ud83d\udd17 <a href="${escHtmlServer(o.referral.url)}" rel="noopener sponsored" target="_blank" style="color:#3fb950">${escHtmlServer(o.referral.referee_value ?? "Save with our referral link")}</a> <a href="/disclosure" style="font-size:.7rem;color:var(--text-dim)">(disclosure)</a></div>` : ""}
       </div>`;
@@ -8845,7 +8858,7 @@ function buildHostingAlternativesPage(): string {
         name: o.vendor,
         description: o.description,
         offers: { "@type": "Offer", price: "0", priceCurrency: "USD", description: o.tier },
-        url: o.url,
+        ...(offerRetired(o) ? {} : { url: o.url }),
       },
     })),
   };
@@ -9152,7 +9165,7 @@ function buildDatabaseAlternativesPage(): string {
         <div class="alt-card-links">
           <a href="/vendor/${toSlug(o.vendor)}">Full profile</a>
           <a href="/alternative-to/${toSlug(o.vendor)}">Alternatives</a>
-          <a href="${escHtmlServer(o.url)}" target="_blank" rel="noopener">Pricing &nearr;</a>
+          ${offerPricingLink(o, "Pricing &nearr;")}
         </div>
         ${o.referral ? `<div style="margin-top:.5rem;padding:.4rem .75rem;border:1px solid #3fb95040;border-left:3px solid #3fb950;border-radius:0 6px 6px 0;background:#3fb95010;font-size:.8rem">\ud83d\udd17 <a href="${escHtmlServer(o.referral.url)}" rel="noopener sponsored" target="_blank" style="color:#3fb950">${escHtmlServer(o.referral.referee_value ?? "Save with our referral link")}</a> <a href="/disclosure" style="font-size:.7rem;color:var(--text-dim)">(disclosure)</a></div>` : ""}
       </div>`;
@@ -9183,7 +9196,7 @@ function buildDatabaseAlternativesPage(): string {
         name: o.vendor,
         description: o.description,
         offers: { "@type": "Offer", price: "0", priceCurrency: "USD", description: o.tier },
-        url: o.url,
+        ...(offerRetired(o) ? {} : { url: o.url }),
       },
     })),
   };
@@ -9491,7 +9504,7 @@ function buildMonitoringAlternativesPage(): string {
         <div class="alt-card-links">
           <a href="/vendor/${toSlug(o.vendor)}">Full profile</a>
           <a href="/alternative-to/${toSlug(o.vendor)}">Alternatives</a>
-          <a href="${escHtmlServer(o.url)}" target="_blank" rel="noopener">Pricing &nearr;</a>
+          ${offerPricingLink(o, "Pricing &nearr;")}
         </div>
         ${o.referral ? `<div style="margin-top:.5rem;padding:.4rem .75rem;border:1px solid #3fb95040;border-left:3px solid #3fb950;border-radius:0 6px 6px 0;background:#3fb95010;font-size:.8rem">\ud83d\udd17 <a href="${escHtmlServer(o.referral.url)}" rel="noopener sponsored" target="_blank" style="color:#3fb950">${escHtmlServer(o.referral.referee_value ?? "Save with our referral link")}</a> <a href="/disclosure" style="font-size:.7rem;color:var(--text-dim)">(disclosure)</a></div>` : ""}
       </div>`;
@@ -9522,7 +9535,7 @@ function buildMonitoringAlternativesPage(): string {
         name: o.vendor,
         description: o.description,
         offers: { "@type": "Offer", price: "0", priceCurrency: "USD", description: o.tier },
-        url: o.url,
+        ...(offerRetired(o) ? {} : { url: o.url }),
       },
     })),
   };
@@ -9819,7 +9832,7 @@ function buildCiCdAlternativesPage(): string {
         <div class="alt-card-links">
           <a href="/vendor/${toSlug(o.vendor)}">Full profile</a>
           <a href="/alternative-to/${toSlug(o.vendor)}">Alternatives</a>
-          <a href="${escHtmlServer(o.url)}" target="_blank" rel="noopener">Pricing &nearr;</a>
+          ${offerPricingLink(o, "Pricing &nearr;")}
         </div>
         ${o.referral ? `<div style="margin-top:.5rem;padding:.4rem .75rem;border:1px solid #3fb95040;border-left:3px solid #3fb950;border-radius:0 6px 6px 0;background:#3fb95010;font-size:.8rem">\ud83d\udd17 <a href="${escHtmlServer(o.referral.url)}" rel="noopener sponsored" target="_blank" style="color:#3fb950">${escHtmlServer(o.referral.referee_value ?? "Save with our referral link")}</a> <a href="/disclosure" style="font-size:.7rem;color:var(--text-dim)">(disclosure)</a></div>` : ""}
       </div>`;
@@ -9850,7 +9863,7 @@ function buildCiCdAlternativesPage(): string {
         name: o.vendor,
         description: o.description,
         offers: { "@type": "Offer", price: "0", priceCurrency: "USD", description: o.tier },
-        url: o.url,
+        ...(offerRetired(o) ? {} : { url: o.url }),
       },
     })),
   };
@@ -10141,7 +10154,7 @@ function buildSecurityAlternativesPage(): string {
         <div class="alt-card-links">
           <a href="/vendor/${toSlug(o.vendor)}">Full profile</a>
           <a href="/alternative-to/${toSlug(o.vendor)}">Alternatives</a>
-          <a href="${escHtmlServer(o.url)}" target="_blank" rel="noopener">Pricing &nearr;</a>
+          ${offerPricingLink(o, "Pricing &nearr;")}
         </div>
         ${o.referral ? `<div style="margin-top:.5rem;padding:.4rem .75rem;border:1px solid #3fb95040;border-left:3px solid #3fb950;border-radius:0 6px 6px 0;background:#3fb95010;font-size:.8rem">\ud83d\udd17 <a href="${escHtmlServer(o.referral.url)}" rel="noopener sponsored" target="_blank" style="color:#3fb950">${escHtmlServer(o.referral.referee_value ?? "Save with our referral link")}</a> <a href="/disclosure" style="font-size:.7rem;color:var(--text-dim)">(disclosure)</a></div>` : ""}
       </div>`;
@@ -10172,7 +10185,7 @@ function buildSecurityAlternativesPage(): string {
         name: o.vendor,
         description: o.description,
         offers: { "@type": "Offer", price: "0", priceCurrency: "USD", description: o.tier },
-        url: o.url,
+        ...(offerRetired(o) ? {} : { url: o.url }),
       },
     })),
   };
@@ -10478,7 +10491,7 @@ function buildTestingAlternativesPage(): string {
         <div class="alt-card-links">
           <a href="/vendor/${toSlug(o.vendor)}">Full profile</a>
           <a href="/alternative-to/${toSlug(o.vendor)}">Alternatives</a>
-          <a href="${escHtmlServer(o.url)}" target="_blank" rel="noopener">Pricing &nearr;</a>
+          ${offerPricingLink(o, "Pricing &nearr;")}
         </div>
         ${o.referral ? `<div style="margin-top:.5rem;padding:.4rem .75rem;border:1px solid #3fb95040;border-left:3px solid #3fb950;border-radius:0 6px 6px 0;background:#3fb95010;font-size:.8rem">\ud83d\udd17 <a href="${escHtmlServer(o.referral.url)}" rel="noopener sponsored" target="_blank" style="color:#3fb950">${escHtmlServer(o.referral.referee_value ?? "Save with our referral link")}</a> <a href="/disclosure" style="font-size:.7rem;color:var(--text-dim)">(disclosure)</a></div>` : ""}
       </div>`;
@@ -10509,7 +10522,7 @@ function buildTestingAlternativesPage(): string {
         name: o.vendor,
         description: o.description,
         offers: { "@type": "Offer", price: "0", priceCurrency: "USD", description: o.tier },
-        url: o.url,
+        ...(offerRetired(o) ? {} : { url: o.url }),
       },
     })),
   };
@@ -10799,7 +10812,7 @@ function buildStorageAlternativesPage(): string {
         <div class="alt-card-links">
           <a href="/vendor/${toSlug(o.vendor)}">Full profile</a>
           <a href="/alternative-to/${toSlug(o.vendor)}">Alternatives</a>
-          <a href="${escHtmlServer(o.url)}" target="_blank" rel="noopener">Pricing &nearr;</a>
+          ${offerPricingLink(o, "Pricing &nearr;")}
         </div>
         ${o.referral ? `<div style="margin-top:.5rem;padding:.4rem .75rem;border:1px solid #3fb95040;border-left:3px solid #3fb950;border-radius:0 6px 6px 0;background:#3fb95010;font-size:.8rem">\ud83d\udd17 <a href="${escHtmlServer(o.referral.url)}" rel="noopener sponsored" target="_blank" style="color:#3fb950">${escHtmlServer(o.referral.referee_value ?? "Save with our referral link")}</a> <a href="/disclosure" style="font-size:.7rem;color:var(--text-dim)">(disclosure)</a></div>` : ""}
       </div>`;
@@ -10830,7 +10843,7 @@ function buildStorageAlternativesPage(): string {
         name: o.vendor,
         description: o.description,
         offers: { "@type": "Offer", price: "0", priceCurrency: "USD", description: o.tier },
-        url: o.url,
+        ...(offerRetired(o) ? {} : { url: o.url }),
       },
     })),
   };
@@ -11111,7 +11124,7 @@ function buildAnalyticsAlternativesPage(): string {
         <div class="alt-card-links">
           <a href="/vendor/${toSlug(o.vendor)}">Full profile</a>
           <a href="/alternative-to/${toSlug(o.vendor)}">Alternatives</a>
-          <a href="${escHtmlServer(o.url)}" target="_blank" rel="noopener">Pricing &nearr;</a>
+          ${offerPricingLink(o, "Pricing &nearr;")}
         </div>
         ${o.referral ? `<div style="margin-top:.5rem;padding:.4rem .75rem;border:1px solid #3fb95040;border-left:3px solid #3fb950;border-radius:0 6px 6px 0;background:#3fb95010;font-size:.8rem">\ud83d\udd17 <a href="${escHtmlServer(o.referral.url)}" rel="noopener sponsored" target="_blank" style="color:#3fb950">${escHtmlServer(o.referral.referee_value ?? "Save with our referral link")}</a> <a href="/disclosure" style="font-size:.7rem;color:var(--text-dim)">(disclosure)</a></div>` : ""}
       </div>`;
@@ -11142,7 +11155,7 @@ function buildAnalyticsAlternativesPage(): string {
         name: o.vendor,
         description: o.description,
         offers: { "@type": "Offer", price: "0", priceCurrency: "USD", description: o.tier },
-        url: o.url,
+        ...(offerRetired(o) ? {} : { url: o.url }),
       },
     })),
   };
@@ -11427,7 +11440,7 @@ function buildAiMlAlternativesPage(): string {
         <div class="alt-card-links">
           <a href="/vendor/${toSlug(o.vendor)}">Full profile</a>
           <a href="/alternative-to/${toSlug(o.vendor)}">Alternatives</a>
-          <a href="${escHtmlServer(o.url)}" target="_blank" rel="noopener">Pricing &nearr;</a>
+          ${offerPricingLink(o, "Pricing &nearr;")}
         </div>
         ${o.referral ? `<div style="margin-top:.5rem;padding:.4rem .75rem;border:1px solid #3fb95040;border-left:3px solid #3fb950;border-radius:0 6px 6px 0;background:#3fb95010;font-size:.8rem">\ud83d\udd17 <a href="${escHtmlServer(o.referral.url)}" rel="noopener sponsored" target="_blank" style="color:#3fb950">${escHtmlServer(o.referral.referee_value ?? "Save with our referral link")}</a> <a href="/disclosure" style="font-size:.7rem;color:var(--text-dim)">(disclosure)</a></div>` : ""}
       </div>`;
@@ -11458,7 +11471,7 @@ function buildAiMlAlternativesPage(): string {
         name: o.vendor,
         description: o.description,
         offers: { "@type": "Offer", price: "0", priceCurrency: "USD", description: o.tier },
-        url: o.url,
+        ...(offerRetired(o) ? {} : { url: o.url }),
       },
     })),
   };
@@ -11749,7 +11762,7 @@ function buildEmailAlternativesPage(): string {
         <div class="alt-card-links">
           <a href="/vendor/${toSlug(o.vendor)}">Full profile</a>
           <a href="/alternative-to/${toSlug(o.vendor)}">Alternatives</a>
-          <a href="${escHtmlServer(o.url)}" target="_blank" rel="noopener">Pricing &nearr;</a>
+          ${offerPricingLink(o, "Pricing &nearr;")}
         </div>
         ${o.referral ? `<div style="margin-top:.5rem;padding:.4rem .75rem;border:1px solid #3fb95040;border-left:3px solid #3fb950;border-radius:0 6px 6px 0;background:#3fb95010;font-size:.8rem">\ud83d\udd17 <a href="${escHtmlServer(o.referral.url)}" rel="noopener sponsored" target="_blank" style="color:#3fb950">${escHtmlServer(o.referral.referee_value ?? "Save with our referral link")}</a> <a href="/disclosure" style="font-size:.7rem;color:var(--text-dim)">(disclosure)</a></div>` : ""}
       </div>`;
@@ -11780,7 +11793,7 @@ function buildEmailAlternativesPage(): string {
         name: o.vendor,
         description: o.description,
         offers: { "@type": "Offer", price: "0", priceCurrency: "USD", description: o.tier },
-        url: o.url,
+        ...(offerRetired(o) ? {} : { url: o.url }),
       },
     })),
   };
@@ -12082,7 +12095,7 @@ function buildDesignAlternativesPage(): string {
         <div class="alt-card-links">
           <a href="/vendor/${toSlug(o.vendor)}">Full profile</a>
           <a href="/alternative-to/${toSlug(o.vendor)}">Alternatives</a>
-          <a href="${escHtmlServer(o.url)}" target="_blank" rel="noopener">Pricing &nearr;</a>
+          ${offerPricingLink(o, "Pricing &nearr;")}
         </div>
         ${o.referral ? `<div style="margin-top:.5rem;padding:.4rem .75rem;border:1px solid #3fb95040;border-left:3px solid #3fb950;border-radius:0 6px 6px 0;background:#3fb95010;font-size:.8rem">\ud83d\udd17 <a href="${escHtmlServer(o.referral.url)}" rel="noopener sponsored" target="_blank" style="color:#3fb950">${escHtmlServer(o.referral.referee_value ?? "Save with our referral link")}</a> <a href="/disclosure" style="font-size:.7rem;color:var(--text-dim)">(disclosure)</a></div>` : ""}
       </div>`;
@@ -12113,7 +12126,7 @@ function buildDesignAlternativesPage(): string {
         name: o.vendor,
         description: o.description,
         offers: { "@type": "Offer", price: "0", priceCurrency: "USD", description: o.tier },
-        url: o.url,
+        ...(offerRetired(o) ? {} : { url: o.url }),
       },
     })),
   };
@@ -12419,7 +12432,7 @@ function buildProjectManagementAlternativesPage(): string {
         <div class="alt-card-links">
           <a href="/vendor/${toSlug(o.vendor)}">Full profile</a>
           <a href="/alternative-to/${toSlug(o.vendor)}">Alternatives</a>
-          <a href="${escHtmlServer(o.url)}" target="_blank" rel="noopener">Pricing &nearr;</a>
+          ${offerPricingLink(o, "Pricing &nearr;")}
         </div>
         ${o.referral ? `<div style="margin-top:.5rem;padding:.4rem .75rem;border:1px solid #3fb95040;border-left:3px solid #3fb950;border-radius:0 6px 6px 0;background:#3fb95010;font-size:.8rem">\ud83d\udd17 <a href="${escHtmlServer(o.referral.url)}" rel="noopener sponsored" target="_blank" style="color:#3fb950">${escHtmlServer(o.referral.referee_value ?? "Save with our referral link")}</a> <a href="/disclosure" style="font-size:.7rem;color:var(--text-dim)">(disclosure)</a></div>` : ""}
       </div>`;
@@ -12450,7 +12463,7 @@ function buildProjectManagementAlternativesPage(): string {
         name: o.vendor,
         description: o.description,
         offers: { "@type": "Offer", price: "0", priceCurrency: "USD", description: o.tier },
-        url: o.url,
+        ...(offerRetired(o) ? {} : { url: o.url }),
       },
     })),
   };
@@ -12747,7 +12760,7 @@ function buildIdeCodeEditorsAlternativesPage(): string {
         <div class="alt-card-links">
           <a href="/vendor/${toSlug(o.vendor)}">Full profile</a>
           <a href="/alternative-to/${toSlug(o.vendor)}">Alternatives</a>
-          <a href="${escHtmlServer(o.url)}" target="_blank" rel="noopener">Pricing &nearr;</a>
+          ${offerPricingLink(o, "Pricing &nearr;")}
         </div>
         ${o.referral ? `<div style="margin-top:.5rem;padding:.4rem .75rem;border:1px solid #3fb95040;border-left:3px solid #3fb950;border-radius:0 6px 6px 0;background:#3fb95010;font-size:.8rem">\ud83d\udd17 <a href="${escHtmlServer(o.referral.url)}" rel="noopener sponsored" target="_blank" style="color:#3fb950">${escHtmlServer(o.referral.referee_value ?? "Save with our referral link")}</a> <a href="/disclosure" style="font-size:.7rem;color:var(--text-dim)">(disclosure)</a></div>` : ""}
       </div>`;
@@ -12778,7 +12791,7 @@ function buildIdeCodeEditorsAlternativesPage(): string {
         name: o.vendor,
         description: o.description,
         offers: { "@type": "Offer", price: "0", priceCurrency: "USD", description: o.tier },
-        url: o.url,
+        ...(offerRetired(o) ? {} : { url: o.url }),
       },
     })),
   };
@@ -13056,7 +13069,7 @@ function buildFreeLlmApisPage(): string {
         <div class="alt-card-links">
           <a href="/vendor/${toSlug(o.vendor)}">Full profile</a>
           <a href="/alternative-to/${toSlug(o.vendor)}">Alternatives</a>
-          <a href="${escHtmlServer(o.url)}" target="_blank" rel="noopener">Pricing &nearr;</a>
+          ${offerPricingLink(o, "Pricing &nearr;")}
         </div>
         ${o.referral ? `<div style="margin-top:.5rem;padding:.4rem .75rem;border:1px solid #3fb95040;border-left:3px solid #3fb950;border-radius:0 6px 6px 0;background:#3fb95010;font-size:.8rem">\ud83d\udd17 <a href="${escHtmlServer(o.referral.url)}" rel="noopener sponsored" target="_blank" style="color:#3fb950">${escHtmlServer(o.referral.referee_value ?? "Save with our referral link")}</a> <a href="/disclosure" style="font-size:.7rem;color:var(--text-dim)">(disclosure)</a></div>` : ""}
       </div>`;
@@ -13087,7 +13100,7 @@ function buildFreeLlmApisPage(): string {
         name: o.vendor,
         description: o.description,
         offers: { "@type": "Offer", price: "0", priceCurrency: "USD", description: o.tier },
-        url: o.url,
+        ...(offerRetired(o) ? {} : { url: o.url }),
       },
     })),
   };
@@ -13374,7 +13387,7 @@ function buildApiDevelopmentAlternativesPage(): string {
         <div class="alt-card-links">
           <a href="/vendor/${toSlug(o.vendor)}">Full profile</a>
           <a href="/alternative-to/${toSlug(o.vendor)}">Alternatives</a>
-          <a href="${escHtmlServer(o.url)}" target="_blank" rel="noopener">Pricing &nearr;</a>
+          ${offerPricingLink(o, "Pricing &nearr;")}
         </div>
         ${o.referral ? `<div style="margin-top:.5rem;padding:.4rem .75rem;border:1px solid #3fb95040;border-left:3px solid #3fb950;border-radius:0 6px 6px 0;background:#3fb95010;font-size:.8rem">\ud83d\udd17 <a href="${escHtmlServer(o.referral.url)}" rel="noopener sponsored" target="_blank" style="color:#3fb950">${escHtmlServer(o.referral.referee_value ?? "Save with our referral link")}</a> <a href="/disclosure" style="font-size:.7rem;color:var(--text-dim)">(disclosure)</a></div>` : ""}
       </div>`;
@@ -13405,7 +13418,7 @@ function buildApiDevelopmentAlternativesPage(): string {
         name: o.vendor,
         description: o.description,
         offers: { "@type": "Offer", price: "0", priceCurrency: "USD", description: o.tier },
-        url: o.url,
+        ...(offerRetired(o) ? {} : { url: o.url }),
       },
     })),
   };
@@ -13689,7 +13702,7 @@ function buildTeamCollaborationAlternativesPage(): string {
         <div class="alt-card-links">
           <a href="/vendor/${toSlug(o.vendor)}">Full profile</a>
           <a href="/alternative-to/${toSlug(o.vendor)}">Alternatives</a>
-          <a href="${escHtmlServer(o.url)}" target="_blank" rel="noopener">Pricing &nearr;</a>
+          ${offerPricingLink(o, "Pricing &nearr;")}
         </div>
         ${o.referral ? `<div style="margin-top:.5rem;padding:.4rem .75rem;border:1px solid #3fb95040;border-left:3px solid #3fb950;border-radius:0 6px 6px 0;background:#3fb95010;font-size:.8rem">\ud83d\udd17 <a href="${escHtmlServer(o.referral.url)}" rel="noopener sponsored" target="_blank" style="color:#3fb950">${escHtmlServer(o.referral.referee_value ?? "Save with our referral link")}</a> <a href="/disclosure" style="font-size:.7rem;color:var(--text-dim)">(disclosure)</a></div>` : ""}
       </div>`;
@@ -13720,7 +13733,7 @@ function buildTeamCollaborationAlternativesPage(): string {
         name: o.vendor,
         description: o.description,
         offers: { "@type": "Offer", price: "0", priceCurrency: "USD", description: o.tier },
-        url: o.url,
+        ...(offerRetired(o) ? {} : { url: o.url }),
       },
     })),
   };
@@ -14093,7 +14106,7 @@ function buildFreeStartupStackPage(): string {
         <div class="pick-links">
           <a href="/vendor/${toSlug(rec.vendor)}">Full profile</a>
           <a href="/alternative-to/${toSlug(rec.vendor)}">Alternatives</a>
-          <a href="${escHtmlServer(rec.url)}" target="_blank" rel="noopener">Pricing &nearr;</a>
+          ${offerPricingLink(rec, "Pricing &nearr;")}
         </div>
       </div>` : "";
 
@@ -14406,7 +14419,7 @@ function buildFreeAiStackPage(): string {
         <div class="pick-links">
           <a href="/vendor/${toSlug(rec.vendor)}">Full profile</a>
           <a href="/alternative-to/${toSlug(rec.vendor)}">Alternatives</a>
-          <a href="${escHtmlServer(rec.url)}" target="_blank" rel="noopener">Pricing &nearr;</a>
+          ${offerPricingLink(rec, "Pricing &nearr;")}
         </div>
       </div>` : "";
 
@@ -14756,7 +14769,7 @@ function buildFreeDevopsStackPage(): string {
         <div class="pick-links">
           <a href="/vendor/${toSlug(rec.vendor)}">Full profile</a>
           <a href="/alternative-to/${toSlug(rec.vendor)}">Alternatives</a>
-          <a href="${escHtmlServer(rec.url)}" target="_blank" rel="noopener">Pricing &nearr;</a>
+          ${offerPricingLink(rec, "Pricing &nearr;")}
         </div>
       </div>` : "";
 
@@ -15107,7 +15120,7 @@ function buildFreeFrontendStackPage(): string {
         <div class="pick-links">
           <a href="/vendor/${toSlug(rec.vendor)}">Full profile</a>
           <a href="/alternative-to/${toSlug(rec.vendor)}">Alternatives</a>
-          <a href="${escHtmlServer(rec.url)}" target="_blank" rel="noopener">Pricing &nearr;</a>
+          ${offerPricingLink(rec, "Pricing &nearr;")}
         </div>
       </div>` : "";
 
@@ -15475,7 +15488,7 @@ function buildFreeNextjsStackPage(): string {
         <div class="pick-links">
           <a href="/vendor/${toSlug(rec.vendor)}">Full profile</a>
           <a href="/alternative-to/${toSlug(rec.vendor)}">Alternatives</a>
-          <a href="${escHtmlServer(rec.url)}" target="_blank" rel="noopener">Pricing &nearr;</a>
+          ${offerPricingLink(rec, "Pricing &nearr;")}
         </div>
       </div>` : "";
 
@@ -15871,7 +15884,7 @@ function buildFreeDjangoStackPage(): string {
         <div class="pick-links">
           <a href="/vendor/${toSlug(rec.vendor)}">Full profile</a>
           <a href="/alternative-to/${toSlug(rec.vendor)}">Alternatives</a>
-          <a href="${escHtmlServer(rec.url)}" target="_blank" rel="noopener">Pricing &nearr;</a>
+          ${offerPricingLink(rec, "Pricing &nearr;")}
         </div>
       </div>` : cat.recommended.vendor === "Django Built-in Auth" ? `
       <div class="stack-pick">
@@ -16307,7 +16320,7 @@ function buildFreeFastapiStackPage(): string {
         <div class="pick-links">
           <a href="/vendor/${toSlug(rec.vendor)}">Full profile</a>
           <a href="/alternative-to/${toSlug(rec.vendor)}">Alternatives</a>
-          <a href="${escHtmlServer(rec.url)}" target="_blank" rel="noopener">Pricing &nearr;</a>
+          ${offerPricingLink(rec, "Pricing &nearr;")}
         </div>
       </div>` : cat.recommended.vendor === "FastAPI Built-in" ? `
       <div class="stack-pick">
@@ -16760,7 +16773,7 @@ function buildFreeGoStackPage(): string {
         <div class="pick-links">
           <a href="/vendor/${toSlug(rec.vendor)}">Full profile</a>
           <a href="/alternative-to/${toSlug(rec.vendor)}">Alternatives</a>
-          <a href="${escHtmlServer(rec.url)}" target="_blank" rel="noopener">Pricing &nearr;</a>
+          ${offerPricingLink(rec, "Pricing &nearr;")}
         </div>
       </div>` : (cat.recommended.vendor === "Go Goroutines" || cat.recommended.vendor === "swaggo/swag") ? `
       <div class="stack-pick">
@@ -17247,7 +17260,7 @@ function buildFreeSaasStackPage(): string {
         <div class="pick-links">
           <a href="/vendor/${toSlug(rec.vendor)}">Full profile</a>
           <a href="/alternative-to/${toSlug(rec.vendor)}">Alternatives</a>
-          <a href="${escHtmlServer(rec.url)}" target="_blank" rel="noopener">Pricing &nearr;</a>
+          ${offerPricingLink(rec, "Pricing &nearr;")}
         </div>
       </div>` : (cat.recommended.vendor === "Stripe") ? `
       <div class="stack-pick">
@@ -31876,7 +31889,7 @@ function buildX402ServicesPage(): string {
       "@type": "ListItem",
       position: i + 1,
       name: o.vendor,
-      url: o.url,
+      ...(offerRetired(o) ? {} : { url: o.url }),
     })),
   };
 
@@ -50137,7 +50150,7 @@ function buildAgentStackPage(): string {
             <td class="role-cell">${escHtmlServer(svc.role)}</td>
             <td><a href="/vendor/${svc.slug}" class="vendor-link">${escHtmlServer(svc.vendorName)}</a> <span class="tier-badge">${escHtmlServer(svc.tier)}</span></td>
             <td class="limits-cell">${escHtmlServer(shortLimits)}</td>
-            <td class="link-cell"><a href="${escHtmlServer(svc.url)}" target="_blank" rel="noopener">Pricing \u2192</a></td>
+            <td class="link-cell">${offerPricingLink(svc, "Pricing →")}</td>
           </tr>`;
     }).join("\n");
 

--- a/test/retired-records.test.ts
+++ b/test/retired-records.test.ts
@@ -1,0 +1,209 @@
+import { describe, it, before, after } from "node:test";
+import assert from "node:assert";
+import { spawn, type ChildProcess } from "node:child_process";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const { offerRetired, recordedTierSentence } = await import("../dist/retirement.js");
+
+type Offer = import("../src/types.ts").Offer;
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO = path.join(__dirname, "..");
+
+const offers: Offer[] = JSON.parse(readFileSync(path.join(REPO, "data", "index.json"), "utf-8")).offers;
+
+function slugOf(vendor: string): string {
+  return vendor.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "");
+}
+
+function escapeHtml(s: string): string {
+  return s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;");
+}
+
+let port = 0;
+let proc: ChildProcess | null = null;
+
+function startServer(): Promise<ChildProcess> {
+  return new Promise((resolve, reject) => {
+    const child = spawn("node", [path.join(REPO, "dist", "serve.js")], {
+      stdio: ["pipe", "pipe", "pipe"],
+      env: { ...process.env, PORT: "0", BASE_URL: "http://localhost", TZ: "UTC" },
+    });
+    const timeout = setTimeout(() => { child.kill(); reject(new Error("Server startup timeout")); }, 30000);
+    child.stderr!.on("data", (data: Buffer) => {
+      const m = data.toString().match(/running on http:\/\/localhost:(\d+)/);
+      if (m) { port = parseInt(m[1], 10); clearTimeout(timeout); resolve(child); }
+    });
+    child.on("error", (e) => { clearTimeout(timeout); reject(e); });
+  });
+}
+
+const pages = new Map<string, string>();
+
+async function page(pathname: string): Promise<string> {
+  const cached = pages.get(pathname);
+  if (cached !== undefined) return cached;
+  const res = await fetch(`http://localhost:${port}${pathname}`);
+  const body = await res.text();
+  pages.set(pathname, body);
+  return body;
+}
+
+async function fetchAll(paths: string[], workers = 12): Promise<void> {
+  const queue = paths.filter(p => !pages.has(p));
+  let next = 0;
+  await Promise.all(
+    Array.from({ length: Math.min(workers, queue.length) }, async () => {
+      while (next < queue.length) await page(queue[next++]);
+    }),
+  );
+}
+
+function jsonLdBlocks(html: string): Record<string, any>[] {
+  const out: Record<string, any>[] = [];
+  for (const m of html.matchAll(/<script type="application\/ld\+json">([\s\S]*?)<\/script>/g)) {
+    try { out.push(JSON.parse(m[1])); } catch { continue; }
+  }
+  return out;
+}
+
+function blockOfType(html: string, type: string): Record<string, any> | undefined {
+  return jsonLdBlocks(html).find(b => b["@type"] === type);
+}
+
+function faqAnswer(html: string, prefix: string): string | undefined {
+  const faq = blockOfType(html, "FAQPage");
+  const item = faq?.mainEntity?.find((q: { name: string }) => q.name.startsWith(prefix));
+  return item?.acceptedAnswer?.text;
+}
+
+function renderedOffer(html: string): Offer | undefined {
+  const webPage = blockOfType(html, "WebPage");
+  const vendor = webPage?.mainEntity?.name;
+  const tier = webPage?.mainEntity?.offers?.description;
+  if (typeof vendor !== "string" || typeof tier !== "string") return undefined;
+  return offers.find(o => o.vendor === vendor && o.tier === tier);
+}
+
+function anchorsTo(html: string, url: string): number {
+  const pattern = new RegExp(`<a [^>]*href="${url.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}"`, "g");
+  return [...html.matchAll(pattern)].length;
+}
+
+const retiredRecords = offers.filter(o => offerRetired(o));
+const retiredUrls = [...new Set(retiredRecords.map(o => o.url))];
+const vendorPaths = [...new Set(offers.map(o => `/vendor/${slugOf(o.vendor)}`))];
+
+type RenderedPage = { slug: string; html: string; offer: Offer };
+const renderedVendorPages: RenderedPage[] = [];
+
+let sweptPaths: string[] = [];
+
+before(async () => {
+  proc = await startServer();
+  const sitemapPaths = new Set<string>(["/", "/best", "/categories", "/vendor"]);
+  for (const sitemap of ["/sitemap.xml", "/sitemap-vendors.xml", "/sitemap-comparisons.xml", "/sitemap-pages.xml", "/sitemap-reports.xml", "/sitemap-misc.xml"]) {
+    for (const entry of (await page(sitemap)).matchAll(/<loc>([^<]+)<\/loc>/g)) {
+      sitemapPaths.add(new URL(entry[1]).pathname);
+    }
+  }
+  for (const o of offers) {
+    sitemapPaths.add(`/vendor/${slugOf(o.vendor)}`);
+    sitemapPaths.add(`/alternative-to/${slugOf(o.vendor)}`);
+    sitemapPaths.add(`/category/${slugOf(o.category)}`);
+  }
+  sweptPaths = [...sitemapPaths].sort();
+  await fetchAll(sweptPaths);
+  for (const p of vendorPaths) {
+    const html = await page(p);
+    const offer = renderedOffer(html);
+    if (offer) renderedVendorPages.push({ slug: p.slice("/vendor/".length), html, offer });
+  }
+});
+
+after(() => { proc?.kill(); });
+
+describe("a record marked retired in its tier is read as retired", () => {
+  it("has a subject in the index, including one whose source check passed", () => {
+    assert.ok(retiredRecords.length > 0, "no record in the index carries a retired tier, so this file has no subject");
+    const passedItsSourceCheck = retiredRecords.filter(o => o.source_check?.outcome === "ok");
+    assert.ok(
+      passedItsSourceCheck.length > 0,
+      "every retired record is now held back by its source check, so the combination this file guards is untested",
+    );
+  });
+
+  it("never answers the free-tier question with a bare yes", () => {
+    const retiredPages = renderedVendorPages.filter(p => offerRetired(p.offer));
+    assert.ok(retiredPages.length > 0, "no vendor page renders a retired record");
+    const offenders = retiredPages
+      .filter(p => (faqAnswer(p.html, `Is ${p.offer.vendor} free?`) ?? "").startsWith("Yes"))
+      .map(p => p.slug);
+    assert.deepStrictEqual(offenders, []);
+  });
+
+  it("answers it from the stored tier rather than from the description", () => {
+    for (const p of renderedVendorPages.filter(x => offerRetired(x.offer))) {
+      const sentence = recordedTierSentence(p.offer.vendor, p.offer.tier);
+      for (const question of [`Is ${p.offer.vendor} free?`, `What is ${p.offer.vendor}'s free tier?`]) {
+        const answer = faqAnswer(p.html, question) ?? "";
+        const opening = `${answer.split(". ")[0]}.`;
+        assert.ok(
+          opening.includes(p.offer.tier),
+          `${p.slug} opens its answer to "${question}" without naming the tier it stores: ${opening}`,
+        );
+        assert.ok(answer.startsWith(sentence), `${p.slug} answers "${question}" with ${answer.slice(0, 70)}`);
+      }
+    }
+  });
+
+  it("sends no reader to the URL it holds for the offer", () => {
+    for (const p of renderedVendorPages.filter(x => offerRetired(x.offer))) {
+      assert.strictEqual(anchorsTo(p.html, escapeHtml(p.offer.url)), 0, `/vendor/${p.slug} still links to ${p.offer.url}`);
+      const application = blockOfType(p.html, "WebPage")?.mainEntity ?? {};
+      assert.ok(!("url" in application), `/vendor/${p.slug} publishes ${p.offer.url} as the application URL`);
+    }
+  });
+
+  it("sends no reader there from any other page we serve either", () => {
+    assert.ok(sweptPaths.length > 1000, `swept only ${sweptPaths.length} paths`);
+    const offenders: string[] = [];
+    for (const p of sweptPaths) {
+      const html = pages.get(p) ?? "";
+      for (const url of retiredUrls) {
+        if (anchorsTo(html, escapeHtml(url)) > 0) offenders.push(`${p} -> ${url}`);
+      }
+    }
+    assert.deepStrictEqual(offenders, []);
+  });
+});
+
+describe("a record that is not retired keeps everything the gate would take away", () => {
+  it("still links to its pricing page from its vendor page", () => {
+    const live = renderedVendorPages.filter(p => !offerRetired(p.offer));
+    assert.ok(live.length > 1000, `only ${live.length} vendor pages render a live record`);
+    const missing = live.filter(p => anchorsTo(p.html, escapeHtml(p.offer.url)) === 0).map(p => p.slug);
+    assert.deepStrictEqual(missing, []);
+  });
+
+  it("still publishes that URL as the application URL", () => {
+    for (const p of renderedVendorPages.filter(x => !offerRetired(x.offer))) {
+      assert.strictEqual(blockOfType(p.html, "WebPage")?.mainEntity?.url, p.offer.url, `/vendor/${p.slug}`);
+    }
+  });
+
+  it("still answers yes where nothing else withholds the answer", () => {
+    const plainlyFree = renderedVendorPages.filter(
+      p => !offerRetired(p.offer) && !p.offer.eligibility && p.offer.source_check?.outcome === "ok"
+        && p.offer.tier.toLowerCase() !== "none"
+        && !p.offer.description.toLowerCase().includes("no free tier"),
+    );
+    assert.ok(plainlyFree.length > 100, `only ${plainlyFree.length} vendor pages are plainly free`);
+    const quiet = plainlyFree
+      .filter(p => !(faqAnswer(p.html, `Is ${p.offer.vendor} free?`) ?? "").startsWith("Yes"))
+      .map(p => p.slug);
+    assert.deepStrictEqual(quiet, []);
+  });
+});


### PR DESCRIPTION
Refs #1229 — criterion 4 and both criteria added in the comment of 2026-09-01T14:33Z. The detector criteria (1, 2, 3, 5, 6) are **not** in this PR.

You wrote that criterion 4 and the FAQ answer "are the same underlying gap: retirement is stored in `tier` and read by almost nothing," and that you would fix them together. This is that fix: one predicate over `tier`, and every surface that asserted a live offer over a retired record now routes through it.

## What a retired record published this morning

`/vendor/supportivekoala`, on `main`, above the fold:

> **Supportivekoala's free tier offers There is no free tier: supportivekoala.com no longer serves the product.** It's stable — zero pricing changes recorded.
>
> **Pricing Page** — Visit → *(to the slots casino)*
>
> **Is Supportivekoala free?** — *Yes, Supportivekoala offers a free tier: Retired.*
>
> **What is Supportivekoala's free tier?** — *Supportivekoala's free tier is called "Retired".*

Four separate assertions of a live free tier, one of them a link. `hasFree` (`src/serve.ts:3761`) already reads `tier === "none"` and the description, and neither catches `Retired`.

## The predicate

`src/retirement.ts` — `offerRetired(offer)` tests the stored `tier` against `retired|deprecated|discontinued|sunset|withdrawn`. Over the 89 distinct tier strings in `data/index.json` it selects exactly `Retired` (4 records) and `Free (Deprecated)` (1). `Legacy Free`, `Free Forever`, `Always Free` and the other 86 are untouched, and a test asserts that by consequence rather than by list: every record it does **not** select must still render its pricing link, still publish `SoftwareApplication.url`, and still answer `Yes`.

`Free (Deprecated)` is in because of your second added criterion. A word list rather than a value set because the next retirement may be spelled `Retired (2026-07-30)`, and a set fails silently where a word list does not.

## No outbound link

Every anchor built from an offer's `url` now goes through one function, `offerPricingLink` — 30 call sites, output byte-identical for a live record. Two sites have their own container and are gated in place: the vendor page's **Pricing Page** detail card and the `/alternative-to` situation box's **Pricing Page:** row. The card is dropped rather than emptied; the grid renders three cards and the **Tier** card next to it already reads `Retired`.

`SoftwareApplication.url` in JSON-LD is gated the same way at 22 sites — a machine following our structured data lands where the anchor used to send a reader, so leaving it would have made the fix cosmetic.

**Left carrying the URL, deliberately:** `/api/offers`, the MCP tool results, and `data/index.json` itself. That field is the provenance of what we read; a consumer auditing us needs it. Say the word if you want it withheld there too.

## The FAQ answers

`faqFreeAnswer` gains a retirement branch **ahead of** `levelWithheld` and `primaryEligibilityGate`, not beside them. Ordering it first fixes three more pages than the criterion asks for: `/vendor/qrme-sh`, `/vendor/github-models` and `/vendor/google-content-api-for-shopping` answer through `levelWithheld` today, and that branch reads *"Our stored record says QRME.SH offers a free tier: Retired"* — which asserts a free tier we do not hold. A page cannot be right by coincidence and also right on purpose; retirement is the more certain fact and wins.

`faqTierAnswer` takes the same branch. *"Supportivekoala's free tier is called 'Retired'"* is the same defect one question down, and you took the same position on `What is X's free tier?` in #1215 this afternoon.

`hasFree` reads the predicate too. That moves exactly one record — `/vendor/google-content-api-for-shopping`, whose `<title>` and `<meta name="description">` claimed a free tier because its description never says otherwise.

## One sentence I wrote — veto it and I will change it in a follow-up

```
<Vendor>'s offer is recorded as <tier>.
```

Composed in `recordedTierSentence`, one place, used in three: both FAQ answers and the quick verdict. Everything after it is your description, unedited. I chose a sentence that reports the stored value rather than answering `No`, because `No` is false of `Free (Deprecated)` — Google Content API for Shopping was free and is being sunset, and your second added criterion puts it inside this gate. It is the only prose in the diff.

## Measurement

3,928 paths swept across the full vendor / `/alternative-to` / category slug set plus every sitemap document. **3,905 byte-identical, 23 moved, 0 status changes.** The 23 are exactly the set a census of `main` predicted before I wrote any code — the 5 vendor pages, 5 `/alternative-to`, 5 `/best`, 3 `/category` and 5 topic guides that render one of these records. `/api/offers?limit=2000` did not move.

2,933 tests, 8 new (2,925 on `main`). **4 fail on a `main` build**; the 4 that pass there are the fixture guard and the three over-fire controls, and the controls pass through the code path a widened predicate would break. **9 of 9 mutations killed** (`scripts/mutate-1229.sh`), after re-aiming one that survived: my first version asserted the answer began with `recordedTierSentence(...)`, which the mutation dropping the tier from that function satisfied trivially. The assertion now also requires the opening sentence to name the record's stored `tier`.

## Found, not fixed — a retired record is still ranked and recommended

Not in this PR and not in any criterion, but it is the same gap and it is louder than the link was:

| record | `/best` position | of |
|---|---|---|
| **Oaysus** | **5** | 55 |
| QRME.SH | 19 | 50 |
| Supportivekoala | 36 | 103 |
| GitHub Models | 43 | 46 |

Those are positions in `qualified`, under a lede reading `N offers meet our criteria for this category`. `rankOffers` has no rule for retirement, so `oaysus.com` — now a design agency — is our fifth-best free cloud hosting offer. The card states `Retired` and the description says the domain no longer serves the product, so the page refutes itself rather than lying, but nothing demotes or excludes it.

Also still true on `/vendor/supportivekoala` and not touched here, because each needs a sentence I would be writing: the `<h1>` reads `Supportivekoala Free Tier 2026`, the badge reads `stable`, and the change history reads *"No recorded pricing changes. This is a good sign — stable pricing."*