### PR TITLE
State the gated share in the count claim a category page ledes with (#1215)

### DIFF
--- a/scripts/mutate-1215-ac6.sh
+++ b/scripts/mutate-1215-ac6.sh
@@ -1,0 +1,156 @@
+#!/usr/bin/env bash
+set -u
+
+REPO="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$REPO" || exit 1
+
+ELIGIBILITY="src/eligibility.ts"
+SERVE="src/serve.ts"
+BACKUP_DIR="$(mktemp -d)"
+cp "$ELIGIBILITY" "$BACKUP_DIR/eligibility.ts"
+cp "$SERVE" "$BACKUP_DIR/serve.ts"
+
+restore() {
+  cp "$BACKUP_DIR/eligibility.ts" "$ELIGIBILITY"
+  cp "$BACKUP_DIR/serve.ts" "$SERVE"
+  npx tsc > /dev/null 2>&1
+}
+trap restore EXIT
+
+killed=0
+survived=0
+TESTS="test/eligibility-disclosure.test.ts"
+
+run_mutation() {
+  local name="$1"
+  shift
+  echo "=== $name"
+  restore
+  "$@"
+  local changed=0
+  for f in "$ELIGIBILITY" "$SERVE"; do
+    diff -q "$BACKUP_DIR/$(basename "$f")" "$f" > /dev/null || changed=1
+  done
+  if [ "$changed" -eq 0 ]; then
+    echo "    NOT APPLIED: the mutation changed no file, so it proves nothing"
+    survived=$((survived + 1))
+    return
+  fi
+  if ! npx tsc > /tmp/mutate-1215-ac6-build.log 2>&1; then
+    echo "    KILLED: does not compile"
+    killed=$((killed + 1))
+    return
+  fi
+  if timeout 600 node --test $TESTS > /tmp/mutate-1215-ac6-test.log 2>&1; then
+    echo "    SURVIVED"
+    survived=$((survived + 1))
+  else
+    echo "    KILLED: $(grep -c '✖ ' /tmp/mutate-1215-ac6-test.log) failing assertion(s)"
+    grep '✖ ' /tmp/mutate-1215-ac6-test.log | head -4
+    killed=$((killed + 1))
+  fi
+}
+
+py() { python3 - "$@"; }
+
+m_lede_never_qualifies() {
+  py <<'PY'
+p = "src/eligibility.ts"
+s = open(p).read()
+s = s.replace("  if (gated === 0) return `${counted}.`;", "  if (gated >= 0) return `${counted}.`;")
+open(p, "w").write(s)
+PY
+}
+
+m_lede_always_qualifies() {
+  py <<'PY'
+p = "src/eligibility.ts"
+s = open(p).read()
+s = s.replace("  if (gated === 0) return `${counted}.`;", "")
+open(p, "w").write(s)
+PY
+}
+
+m_lede_counts_the_whole_category() {
+  py <<'PY'
+p = "src/serve.ts"
+s = open(p).read()
+s = s.replace("${gatedShareLede(catCount, catGatedCount)}", "${gatedShareLede(catCount, catCount)}")
+open(p, "w").write(s)
+PY
+}
+
+m_lede_states_a_partial_share_as_total() {
+  py <<'PY'
+p = "src/eligibility.ts"
+s = open(p).read()
+s = s.replace("  if (gated >= total) return `${counted}, none of them generally available",
+              "  if (gated >= 1) return `${counted}, none of them generally available")
+open(p, "w").write(s)
+PY
+}
+
+m_description_clause_removed() {
+  py <<'PY'
+p = "src/serve.ts"
+s = open(p).read()
+s = s.replace("${catGatedClause ? ` ${catGatedClause}` : \"\"}", "")
+open(p, "w").write(s)
+PY
+}
+
+m_description_clause_appended_last() {
+  py <<'PY'
+p = "src/serve.ts"
+s = open(p).read()
+old = "developer deals.${catGatedClause ? ` ${catGatedClause}` : \"\"} Verified pricing for ${catOffers.slice(0, 5).map(o => o.vendor).join(\", \")}${catCount > 5 ? \" and more\" : \"\"}.`;"
+new = "developer deals. Verified pricing for ${catOffers.slice(0, 5).map(o => o.vendor).join(\", \")}${catCount > 5 ? \" and more\" : \"\"}.${catGatedClause ? ` ${catGatedClause}` : \"\"}`;"
+assert old in s
+s = s.replace(old, new)
+open(p, "w").write(s)
+PY
+}
+
+m_tier_answer_drops_the_gate() {
+  py <<'PY'
+p = "src/serve.ts"
+s = open(p).read()
+s = s.replace("    : eligibilityGateSentence + (levelWithheld\n    ? `${unconfirmedTermsPreamble}Our stored record calls",
+              "    : \"\" + (levelWithheld\n    ? `${unconfirmedTermsPreamble}Our stored record calls")
+open(p, "w").write(s)
+PY
+}
+
+m_production_answer_drops_the_gate() {
+  py <<'PY'
+p = "src/serve.ts"
+s = open(p).read()
+s = s.replace("  const faqProductionAnswer = eligibilityGateSentence + (levelWithheld",
+              "  const faqProductionAnswer = \"\" + (levelWithheld")
+open(p, "w").write(s)
+PY
+}
+
+m_gate_spreads_to_the_stability_answer() {
+  py <<'PY'
+p = "src/serve.ts"
+s = open(p).read()
+s = s.replace("{ q: `Is ${vendorName}'s free tier reliable?`, a: faqReliableAnswer }",
+              "{ q: `Is ${vendorName}'s free tier reliable?`, a: faqProductionAnswer }")
+open(p, "w").write(s)
+PY
+}
+
+run_mutation "the lede never qualifies the count" m_lede_never_qualifies
+run_mutation "the lede qualifies every category" m_lede_always_qualifies
+run_mutation "the lede counts the whole category as gated" m_lede_counts_the_whole_category
+run_mutation "a partial share reads as the whole category" m_lede_states_a_partial_share_as_total
+run_mutation "the search snippet drops the qualification" m_description_clause_removed
+run_mutation "the search snippet appends it after the vendor list" m_description_clause_appended_last
+run_mutation "the free-tier terms answer drops the gate" m_tier_answer_drops_the_gate
+run_mutation "the production answer drops the gate" m_production_answer_drops_the_gate
+run_mutation "the gate spreads to the stability answer" m_gate_spreads_to_the_stability_answer
+
+echo
+echo "killed $killed, survived $survived"
+[ "$survived" -eq 0 ]

--- a/src/eligibility.ts
+++ b/src/eligibility.ts
@@ -10,6 +10,21 @@ export function eligibilityGate(offer: Pick<Offer, "eligibility">): Gate | null 
   return gate && gate.code === "eligibility_restricted" ? gate : null;
 }
 
+export function gatedShareLede(total: number, gated: number): string {
+  const counted = `${total} verified free tiers and developer deals`;
+  if (gated === 0) return `${counted}.`;
+  if (gated >= total) return `${counted}, none of them generally available — each requires an application or qualification.`;
+  if (gated === 1) return `${counted}. 1 of them is not generally available — it requires an application or qualification.`;
+  return `${counted}. ${gated} of them are not generally available — each requires an application or qualification.`;
+}
+
+export function gatedShareDescriptionClause(total: number, gated: number): string {
+  if (gated === 0) return "";
+  if (gated >= total) return `All ${total} require an application or qualification.`;
+  if (gated === 1) return "1 requires an application or qualification.";
+  return `${gated} require an application or qualification.`;
+}
+
 export function publishableEligibilityConditions(offer: Pick<Offer, "eligibility">): string[] {
   return (offer.eligibility?.conditions ?? []).filter(
     (condition) => condition !== CONDITION_RECORDING_AN_UNREAD_PROGRAM,

--- a/src/serve.ts
+++ b/src/serve.ts
@@ -43,7 +43,7 @@ import { ASSISTANTS_API_SHUTDOWN } from "./assistants-shutdown.js";
 import { discontinuedOnOrBefore, PRODUCT_DEPRECATED } from "./product-deprecation.js";
 import { rankOffers, rankForListing, rotateListing, utcDate, CRITERIA_PATH, DEMOTE_ONLY_POLICY, DISCLOSURE_RATIONALE, TIE_BREAK_ALGORITHM, GATE_TABLE, DEMERIT_TABLE, NOT_FREE_TIER_RULES, TIME_LIMITED_TIER_RULES, type TieBreak } from "./ranking.js";
 import type { RankedEntry, RankingResult } from "./ranking.js";
-import { eligibilityGate, publishableEligibilityConditions } from "./eligibility.js";
+import { eligibilityGate, gatedShareDescriptionClause, gatedShareLede, publishableEligibilityConditions } from "./eligibility.js";
 import { verificationLedger, QUARANTINE_AFTER_FAILURES } from "./verification-state.js";
 import { partitionAlternatives, partitionSubstitutes, type SubstitutesPartition, productRoleSentence, MEMBERSHIP_GATE_RULES, MEMBERSHIP_GATE_ORDER, MEMBERSHIP_GATE_SYMMETRY, MEMBERSHIP_GATE_SCOPE, MEMBERSHIP_GATE_CORRECTIONS, SUBTYPE_TAXONOMIES, SUBTYPE_MEMBERSHIP_RULE, SUBTYPE_MEMBERSHIP_GROUP_SCOPE, CURATED_SUBTYPE_EXEMPTION, membershipGroupsFor, subtypeDefinition } from "./product-role.js";
 import { resolveCuratedAlternatives, curatedAlternativesFor, addCuratedToPool } from "./curated-alternatives.js";
@@ -1091,8 +1091,10 @@ function buildCategoryPage(slug: string): string | null {
 
   const catOffers = offers.filter((o) => o.category === categoryName);
   const catCount = catOffers.length;
+  const catGatedCount = catOffers.filter((o) => eligibilityGate(o)).length;
+  const catGatedClause = gatedShareDescriptionClause(catCount, catGatedCount);
   const title = `Free ${categoryName} Tools & Deals (${catCount} offers) — AgentDeals`;
-  const metaDesc = `Compare ${catCount} free ${categoryName.toLowerCase()} tools, free tiers, and developer deals. Verified pricing for ${catOffers.slice(0, 5).map(o => o.vendor).join(", ")}${catCount > 5 ? " and more" : ""}.`;
+  const metaDesc = `Compare ${catCount} free ${categoryName.toLowerCase()} tools, free tiers, and developer deals.${catGatedClause ? ` ${catGatedClause}` : ""} Verified pricing for ${catOffers.slice(0, 5).map(o => o.vendor).join(", ")}${catCount > 5 ? " and more" : ""}.`;
 
   const offersHtml = catOffers.map((o) => `        <tr>
           <td style="font-weight:600;color:var(--text);white-space:nowrap"><a href="/vendor/${toSlug(o.vendor)}" style="color:var(--text)">${escHtmlServer(o.vendor)}</a></td>
@@ -1308,7 +1310,7 @@ ${mcpCtaCss()}
   ${buildGlobalNav("categories")}
   <div class="breadcrumb"><a href="/">AgentDeals</a> &rsaquo; ${escHtmlServer(categoryName)}</div>
   <h1>Free ${escHtmlServer(categoryName)} Tools</h1>
-  <p class="cat-meta">${catCount} verified free tiers and developer deals.${dataVerifiedSegment(catOffers)}</p>
+  <p class="cat-meta">${gatedShareLede(catCount, catGatedCount)}${dataVerifiedSegment(catOffers)}</p>
 
   ${introHtml}
   ${analysisCta}
@@ -4102,9 +4104,9 @@ ${allCompareLinks.join("\n")}
     : `Yes, ${vendorName} offers a free tier: ${primary.tier}. ${storedTerms}`;
   const faqTierAnswer = retiredSentence
     ? `${retiredSentence} ${primary.description}`
-    : levelWithheld
+    : eligibilityGateSentence + (levelWithheld
     ? `${unconfirmedTermsPreamble}Our stored record calls ${vendorName}'s free tier "${primary.tier}". ${withUnconfirmedTermsCaveat(primary.description)}`
-    : `${vendorName}'s free tier is called "${primary.tier}". ${primary.description}`;
+    : `${vendorName}'s free tier is called "${primary.tier}". ${primary.description}`);
   const faqReliableAnswer = levelWithheld
     ? `We cannot say. ${withheldLevelSentence(levelWithheld, vendorName, unconfirmableSince)} Nothing we have read describes these terms, so we are not publishing a stability judgement for this vendor until that is fixed.`
     : riskLevel === "stable"
@@ -4114,13 +4116,13 @@ ${allCompareLinks.join("\n")}
     : `${vendorName}'s free tier is considered risky because of one specific recorded change${riskCause ? `, ${changeDateClause(riskCause)}: ${riskCause.summary}` : "."} Consider alternatives.`;
   const faqCategoryAnswer = `${vendorName} is categorized under ${allCategories.join(", ")} on AgentDeals.${alternatives.length > 0 ? ` Other vendors in ${primary.category} include ${alternatives.slice(0, 5).map(a => a.vendor).join(", ")}.` : ""}`;
 
-  const faqProductionAnswer = levelWithheld
+  const faqProductionAnswer = eligibilityGateSentence + (levelWithheld
     ? `${withheldLevelSentence(levelWithheld, vendorName, unconfirmableSince)} We cannot confirm what this offer provides today, so we are not recommending it for production or for anything else until we can.`
     : hasFree
     ? (riskLevel === "stable"
       ? `${vendorName}'s free tier can be suitable for small production workloads and side projects. We rate it stable and it offers ${escHtmlServer(keyLimit)}, so it's a reasonable starting point.${vendorChanges.length > 0 ? ` ${narrowingSentence(vendorChanges)}` : ""} Monitor your usage against the limits and have an upgrade plan ready.`
       : `${vendorName}'s free tier is usable for prototyping and development, but we rate it ${riskLevel}${riskCause ? ` because of one recorded ${changeKindNoun(riskCause.change_type)}, ${changeDateClause(riskCause)}` : ""}. Consider alternatives with more stable pricing for critical services.`)
-    : `${vendorName} does not offer a free tier for production use. Consider free alternatives in ${primary.category}.`;
+    : `${vendorName} does not offer a free tier for production use. Consider free alternatives in ${primary.category}.`);
   const faqChangedAnswer = vendorChanges.length > 0
     ? `${vendorName} has had ${vendorChanges.length} recorded pricing change${vendorChanges.length > 1 ? "s" : ""}. Most recently: ${vendorChanges[0].summary} (${changeDateLabel(vendorChanges[0])}).`
     : levelWithheld

--- a/test/eligibility-disclosure.test.ts
+++ b/test/eligibility-disclosure.test.ts
@@ -200,6 +200,109 @@ describe("the category page a gated offer is sent to states the restriction", ()
   });
 });
 
+describe("a category page does not count a gated offer as a plain free tier", () => {
+  const categoryNames = [...new Set(offers.map(o => o.category))].sort();
+  const censusOf = (category: string) => {
+    const inCategory = offers.filter(o => o.category === category);
+    return { total: inCategory.length, gated: inCategory.filter(o => eligibilityGate(o)).length };
+  };
+  const ledeOf = (html: string) => html.match(/<p class="cat-meta">([\s\S]*?)<\/p>/)?.[1] ?? "";
+  const descriptionOf = (html: string) => html.match(/<meta name="description" content="([^"]*)"/)?.[1] ?? "";
+  const restrictedRows = (html: string) => [...html.matchAll(/class="listing-eligibility-restricted"/g)].length;
+  const QUALIFICATION = "application or qualification";
+
+  it("has an entirely gated category, a partly gated one and an ungated one to measure", () => {
+    const censuses = categoryNames.map(censusOf);
+    assert.ok(censuses.some(c => c.gated > 0 && c.gated === c.total), "no category is entirely gated");
+    assert.ok(censuses.some(c => c.gated > 0 && c.gated < c.total), "no category is partly gated");
+    assert.ok(censuses.some(c => c.gated === 0), "every category holds a gated record");
+  });
+
+  it("qualifies the count claim rather than closing it", async () => {
+    for (const category of categoryNames) {
+      const { total, gated } = censusOf(category);
+      const html = await page(`/category/${slugOf(category)}`);
+      const lede = ledeOf(html);
+      const where = `/category/${slugOf(category)} (${gated} of ${total})`;
+      if (gated === 0) {
+        assert.ok(lede.startsWith(`${total} verified free tiers and developer deals.`), `${where} lede is ${lede}`);
+        assert.ok(!lede.includes(QUALIFICATION), `${where} states a restriction it does not hold`);
+        continue;
+      }
+      assert.ok(lede.includes(QUALIFICATION), `${where} lede is ${lede}`);
+      if (gated === total) {
+        assert.ok(lede.includes("none of them generally available"), `${where} lede is ${lede}`);
+        assert.ok(
+          !lede.startsWith(`${total} verified free tiers and developer deals.`),
+          `${where} closes the count claim before qualifying it: ${lede}`,
+        );
+      } else {
+        assert.ok(lede.includes(`${gated} of them`), `${where} lede does not name ${gated}: ${lede}`);
+      }
+    }
+  });
+
+  it("states a number the rows below it agree with", async () => {
+    for (const category of categoryNames) {
+      const { total, gated } = censusOf(category);
+      const html = await page(`/category/${slugOf(category)}`);
+      assert.strictEqual(restrictedRows(html), gated, `/category/${slugOf(category)} restricted rows`);
+      if (gated > 0 && gated < total) {
+        assert.ok(ledeOf(html).includes(`${restrictedRows(html)} of them`), `/category/${slugOf(category)}`);
+      }
+    }
+  });
+
+  it("carries the same qualification into the search snippet, ahead of the vendor list", async () => {
+    for (const category of categoryNames) {
+      const { total, gated } = censusOf(category);
+      const html = await page(`/category/${slugOf(category)}`);
+      const description = descriptionOf(html);
+      const where = `/category/${slugOf(category)} (${gated} of ${total})`;
+      if (gated === 0) {
+        assert.ok(!description.includes(QUALIFICATION), `${where} description is ${description}`);
+        continue;
+      }
+      assert.ok(description.includes(QUALIFICATION), `${where} description is ${description}`);
+      assert.ok(
+        description.indexOf(QUALIFICATION) < description.indexOf("Verified pricing for"),
+        `${where} appends the qualification after the vendor list, where a snippet truncates it`,
+      );
+    }
+  });
+});
+
+describe("the other answers on a gated vendor page", () => {
+  const gatedPages = () => rendered.filter(p => p.offer.eligibility);
+
+  it("qualifies the two that state or recommend the terms", () => {
+    assert.ok(gatedPages().length > 0, "no vendor page renders a gated record");
+    for (const p of gatedPages()) {
+      const reason = gateFor(p.offer, "")!.reason;
+      for (const question of [`What is ${p.vendor}'s free tier?`, `Is ${p.vendor}'s free tier good for production?`]) {
+        const answer = faqAnswer(p.html, question) ?? "";
+        assert.ok(answer.startsWith(reason), `${p.slug} answers "${question}" with ${answer.slice(0, 70)}`);
+      }
+    }
+  });
+
+  it("leaves the four that describe our record rather than the offer alone", () => {
+    for (const p of gatedPages()) {
+      const reason = gateFor(p.offer, "")!.reason;
+      for (const question of [
+        `Is ${p.vendor}'s free tier reliable?`,
+        `What changed in ${p.vendor}'s pricing?`,
+        `When will I outgrow ${p.vendor}'s free tier?`,
+        `What category is ${p.vendor} in?`,
+      ]) {
+        const answer = faqAnswer(p.html, question);
+        if (answer === undefined) continue;
+        assert.ok(!answer.startsWith(reason), `${p.slug} qualified "${question}", which is about our record`);
+      }
+    }
+  });
+});
+
 describe("the disclosure reuses one composition", () => {
   it("returns the ranking gate unchanged for a record carrying eligibility", () => {
     const gated = offers.find(o => o.eligibility)!;


### PR DESCRIPTION
Refs #1215 — AC-6, and the "yes, extend it" from your comment of 2026-09-01T14:04Z. This is the last criterion on the issue.

Your sentences, verbatim, in `gatedShareLede` and `gatedShareDescriptionClause` (`src/eligibility.ts`) so both surfaces read one composition. Live on this branch:

| page | lede |
|---|---|
| `/category/cloud-iaas` | `18 verified free tiers and developer deals. 9 of them are not generally available — each requires an application or qualification.` |
| `/category/startup-perks` | `93 verified free tiers and developer deals, none of them generally available — each requires an application or qualification.` |
| `/category/monitoring` | `59 verified free tiers and developer deals.` — unchanged |

Meta descriptions take the clause after the first sentence, ahead of `Verified pricing for …`, as you asked:

- `/category/cloud-iaas`: `Compare 18 free cloud iaas tools, free tiers, and developer deals. **9 require an application or qualification.** Verified pricing for AWS, Azure, DigitalOcean, Oracle Cloud, AWS Activate and more.`
- `/category/startup-perks`: `… developer deals. **All 93 require an application or qualification.** Verified pricing for …`

`og:description` reads the same variable, so it moved with it. The `<title>` still reads `(18 offers)`, as you specified.

## One inflection I made — say if you want it different

Your copy is written for a plural share. **12 of the 18 categories hold exactly one gated record**, and rendered as written they read `1 of them are not generally available` and `1 require an application or qualification`. So there is a singular branch:

- lede: `45 verified free tiers and developer deals. 1 of them is not generally available — it requires an application or qualification.`
- description: `1 requires an application or qualification.`

Same sentence, agreement fixed. I did not think that needed a round trip, but it is a change to your words and it is the only one.

## The other two FAQ answers

`What is X's free tier?` and `Is X's free tier good for production?` now open with `gate.reason`, repeated verbatim as you asked rather than shortened, because each JSON-LD answer is lifted alone. `/vendor/aws-activate` today:

> **What is AWS Activate's free tier?** — *Restricted to accelerator (AWS Activate Portfolio) applicants — not generally available.* AWS Activate's free tier is called "Portfolio". …
>
> **Is AWS Activate's free tier good for production?** — *Restricted to accelerator (AWS Activate Portfolio) applicants — not generally available.* AWS Activate's free tier can be suitable for small production workloads …

`Is X's free tier reliable?`, `What changed in X's pricing?`, `When will I outgrow…` and `What category…` are untouched, and a test fails if any of them starts carrying the gate — that is the four you told me to leave alone, held as an over-fire control rather than a comment.

## Measurement

3,928 paths swept. **3,777 byte-identical, 151 moved, 0 status changes** — 18 category pages and the 133 vendor pages that render a gated record, which is the same 133 #1228 moved. No `/best`, no `/alternative-to`, no `/compare`.

17 tests in `test/eligibility-disclosure.test.ts`, 6 new. **4 of the 6 fail on a `main` build**; the two that pass are the fixture guard (an entirely gated, a partly gated and an ungated category must all exist to measure) and the over-fire control above, which passes on `main` because nothing qualified those four answers there either. **9 of 9 mutations killed** (`scripts/mutate-1215-ac6.sh`).

The strongest of the six is not a restatement of the composer: **the number the lede states must equal the number of rows below it carrying `listing-eligibility-restricted`**, across all 66 categories. It kills the mutation that counts the whole category as gated, which a test comparing the lede against `gatedShareLede(...)` cannot see.

## Found, not fixed — a third count claim on the same page

`/category/cloud-iaas` still carries, one paragraph below the lede:

> We track **18** cloud iaas services with free tiers. AWS leads with 25 GB.

Same claim, same page, and AC-6 named the lede and the description. I have not touched it because it needs a sentence you have not written. Give me one and it ships in a follow-up; the count and the gated share are both already in scope at that point in the builder.
