### PR TITLE
Remove a change record read off the domain that took over oaysus.com (#1229)

### DIFF
--- a/data/deal_changes.json
+++ b/data/deal_changes.json
@@ -5496,21 +5496,6 @@
       "recorded_date": "2026-08-28"
     },
     {
-      "vendor": "Oaysus",
-      "change_type": "limits_increased",
-      "date": "2026-08-28",
-      "date_source": "discovered",
-      "summary": "The free tier now includes up to 10 pages. Previously 3 pages. The description of the service has changed to focus on a website scorecard and homepage redesign, rather than a visual page builder for React, Vue, or Svelte components.",
-      "previous_state": "Visual page builder for developer-built React, Vue, or Svelte components. Free tier includes 1 site with 3 pages, form submissions, and global CDN hosting.",
-      "current_state": "Free to see it. No credit card. No sales calls. No setup fee. Up to 10 pages. Cancel any month from your dashboard.",
-      "impact": "medium",
-      "source_url": "https://oaysus.com",
-      "category": "Cloud Hosting",
-      "alternatives": [],
-      "detected_by": "reverify-ai",
-      "recorded_date": "2026-08-28"
-    },
-    {
       "vendor": "readthedocs.org",
       "change_type": "pricing_restructured",
       "date": "2026-08-28",


### PR DESCRIPTION
`/vendor/oaysus` publishes this right now:

> **What changed in Oaysus's pricing?** — *Oaysus has had 1 recorded pricing change. Most recently: The free tier now includes up to 10 pages. Previously 3 pages. The description of the service has changed to focus on a website scorecard and homepage redesign, rather than a visual page builder for React, Vue, or Svelte components. (discovered 2026-08-28)*

There is no such change. `oaysus.com` is an expired domain that redirects to `mirin.com`, a website design agency with no connection to the product. The change detector fetched the domain root on 2026-08-28, read Mirin's site, and recorded its contents as an improvement to Oaysus's free tier.

The record is `limits_increased`, so `evaluate` reads it as a favourable change. The vendor page therefore also answers *"Oaysus's free tier is considered stable. The one change we have recorded did not narrow the terms."* We read a stranger's website and published it as good news about a dead product.

Removing the record. The vendor record itself is already `tier: "Retired"` from #1230.

## Why only this one

Five change records exist across the 19 cross-domain records in https://github.com/robhunter/agentdeals/issues/1229. Three are correct — GoSquared `rebranded`, StreamBackdrops `pricing_model_change` ("The vendor is now called MeetBackdrops"), Highlight.io `free_tier_removed` ("own page now redirects to launchdarkly.com"). The detector narrates a redirect accurately whenever the destination says who it is.

It failed here because Mirin's site is a plausible product page that never mentions Oaysus, so there was nothing to contradict the assumption that it was Oaysus's own updated site. The other two hijacks are gambling sites and produced no change record at all — a slots page yields no plausible pricing event.

**77 of the 147 changes recorded on 2026-08-28 cite a bare domain root**, which is the population exposed to this substitution. That is evidence for #1229's effective-URL field, not for a new detector, and I have put it there.

Data only. No `src/` or `test/` changes.
