### PR TITLE
Gate a retired offer out of the ranked set (#1235)

### DIFF
--- a/scripts/mutate-1235-gate.sh
+++ b/scripts/mutate-1235-gate.sh
@@ -1,0 +1,84 @@
+#!/bin/bash
+set -u
+cd "$(dirname "$0")/.." || exit 1
+
+TESTS="test/retired-ranking.test.ts test/retired-records.test.ts test/ranking.test.ts test/tier-vocabulary.test.ts test/eligibility-disclosure.test.ts"
+
+run_case() {
+  local name="$1" file="$2" from="$3" to="$4"
+  cp "$file" /tmp/mut-backup
+  python3 - "$file" "$from" "$to" <<'PY'
+import sys
+path, old, new = sys.argv[1], sys.argv[2], sys.argv[3]
+s = open(path).read()
+n = s.count(old)
+if n != 1:
+    print(f"PATTERN-MISS ({n})")
+    sys.exit(3)
+open(path, "w").write(s.replace(old, new))
+PY
+  if [ $? -eq 3 ]; then cp /tmp/mut-backup "$file"; echo "SKIP    $name (pattern not found exactly once)"; return; fi
+  if ! npm run build > /tmp/mut-build.log 2>&1; then
+    cp /tmp/mut-backup "$file"
+    echo "KILLED  $name (build)"
+    return
+  fi
+  node --test $TESTS > /tmp/mut-test.log 2>&1
+  local code=$?
+  cp /tmp/mut-backup "$file"
+  if [ $code -ne 0 ]; then
+    echo "KILLED  $name  <- $(grep -m1 '✖ ' /tmp/mut-test.log | sed 's/^ *//')"
+  else
+    echo "SURVIVED $name"
+  fi
+}
+
+run_case "the ranker stops consulting the retirement gate" src/ranking.ts \
+  '  const retired = retiredGateFor(offer);
+  if (retired) return retired;' \
+  '  const retired = null as ReturnType<typeof retiredGateFor>;
+  if (retired) return retired;'
+
+run_case "the gate predicate widens to the one the vendor page uses" src/ranking.ts \
+  'export function retiredGateFor(offer: Pick<Offer, "tier" | "vendor">): Gate | null {
+  if (!offerEnded(offer)) return null;' \
+  'export function retiredGateFor(offer: Pick<Offer, "tier" | "vendor">): Gate | null {
+  if (!/retired|deprecated|discontinued|sunset|withdrawn/i.test(offer.tier)) return null;'
+
+run_case "the retirement gate is ordered behind the eligibility gate" src/ranking.ts \
+  '  const retired = retiredGateFor(offer);
+  if (retired) return retired;
+  const restricted = eligibilityGateFor(offer);
+  if (restricted) return restricted;' \
+  '  const restricted = eligibilityGateFor(offer);
+  if (restricted) return restricted;
+  const retired = retiredGateFor(offer);
+  if (retired) return retired;'
+
+run_case "the ended vocabulary loses the value the data uses" src/retirement.ts \
+  'export const ENDED_TIERS = ["Retired", "Discontinued", "Sunset", "Withdrawn"] as const;' \
+  'export const ENDED_TIERS = ["Discontinued", "Sunset", "Withdrawn"] as const;'
+
+run_case "an ended tier falls through to the free class again" src/ranking.ts \
+  '  if (offerEnded({ tier })) return { class: "retired", note: RETIRED_TIER_NOTE };' \
+  '  if (false) return { class: "retired", note: RETIRED_TIER_NOTE };'
+
+run_case "the ended tier is matched loosely instead of exactly" src/retirement.ts \
+  '  return ENDED_TIER_SET.has((offer?.tier ?? "").trim().toLowerCase());' \
+  '  return [...ENDED_TIER_SET].some(t => (offer?.tier ?? "").toLowerCase().includes(t));'
+
+run_case "the new gate code is left undocumented on the criteria page" src/ranking.ts \
+  '  {
+    code: "offer_retired",
+    description:
+      "The tier we hold records the offer as ended. The vendor page stays up, because it answers the question the reader arrived with, but a withdrawn offer is not ranked at any position.",
+  },' \
+  ''
+
+run_case "the best-of lede counts the ranked set instead of the picks it renders" src/serve.ts \
+  '  const pickCount = qualified.length;' \
+  '  const pickCount = ranking.ranked.length;'
+
+run_case "the gate reason drops the tier it is reporting" src/retirement.ts \
+  '  return `${vendorName}'"'"'s offer is recorded as ${tier}.`;' \
+  '  return `${vendorName}'"'"'s offer is recorded.`;'

--- a/src/eligibility.ts
+++ b/src/eligibility.ts
@@ -1,13 +1,11 @@
-import { gateFor } from "./ranking.js";
+import { eligibilityGateFor } from "./ranking.js";
 import type { Gate } from "./ranking.js";
 import type { Offer } from "./types.js";
 
 export const CONDITION_RECORDING_AN_UNREAD_PROGRAM = "Startup program — check vendor for eligibility details";
 
 export function eligibilityGate(offer: Pick<Offer, "eligibility">): Gate | null {
-  if (!offer.eligibility) return null;
-  const gate = gateFor(offer as Offer, "");
-  return gate && gate.code === "eligibility_restricted" ? gate : null;
+  return eligibilityGateFor(offer);
 }
 
 export function gatedShareLede(total: number, gated: number): string {

--- a/src/ranking.ts
+++ b/src/ranking.ts
@@ -1,6 +1,6 @@
 import { createHash } from "node:crypto";
 import { LINK_GRACE_DAYS, unreachableNoticeForUrl } from "./link-health.js";
-import { offerEnded, recordedTierSentence } from "./retirement.js";
+import { listEndedTiers, offerEnded, recordedTierSentence } from "./retirement.js";
 import { withheldLevelSentence } from "./source-check.js";
 import type { ChangeDateSource, DealChange, LinkUnreachable, Offer } from "./types.js";
 
@@ -79,7 +79,7 @@ export const GATE_TABLE: { code: GateCode; description: string }[] = [
   {
     code: "offer_retired",
     description:
-      "The tier we hold records the offer as ended. The vendor page stays up, because it answers the question the reader arrived with, but a withdrawn offer is not ranked at any position.",
+      `The tier we hold records the offer as ended: ${listEndedTiers()}. The vendor page stays up and still answers whether the offer exists, but an ended offer is not ranked at any position.`,
   },
   {
     code: "verification_lapsed",

--- a/src/ranking.ts
+++ b/src/ranking.ts
@@ -1,5 +1,6 @@
 import { createHash } from "node:crypto";
 import { LINK_GRACE_DAYS, unreachableNoticeForUrl } from "./link-health.js";
+import { offerEnded, recordedTierSentence } from "./retirement.js";
 import { withheldLevelSentence } from "./source-check.js";
 import type { ChangeDateSource, DealChange, LinkUnreachable, Offer } from "./types.js";
 
@@ -17,7 +18,9 @@ const VERIFICATION_LAPSED_DAYS = 180;
 const EXPIRING_SOON_DAYS = 90;
 const ADVERSE_CHANGE_WINDOW_DAYS = 365;
 
-export type TierClass = "free" | "time_limited" | "not_free";
+export type TierClass = "free" | "time_limited" | "not_free" | "retired";
+
+export const RETIRED_TIER_NOTE = "an offer the vendor has ended";
 
 export const NOT_FREE_TIER_RULES: { pattern: RegExp; note: string }[] = [
   { pattern: /^paid$/i, note: "no free offer at all" },
@@ -36,6 +39,7 @@ export const TIME_LIMITED_TIER_RULES: { pattern: RegExp; note: string }[] = [
 ];
 
 export function classifyTier(tier: string): { class: TierClass; note: string } {
+  if (offerEnded({ tier })) return { class: "retired", note: RETIRED_TIER_NOTE };
   for (const rule of TIME_LIMITED_TIER_RULES) {
     if (rule.pattern.test(tier)) return { class: "time_limited", note: rule.note };
   }
@@ -49,6 +53,7 @@ export type GateCode =
   | "eligibility_restricted"
   | "not_a_free_offer"
   | "offer_expired"
+  | "offer_retired"
   | "verification_lapsed";
 
 export interface Gate {
@@ -70,6 +75,11 @@ export const GATE_TABLE: { code: GateCode; description: string }[] = [
   {
     code: "offer_expired",
     description: "The offer's own stated expiry date has already passed.",
+  },
+  {
+    code: "offer_retired",
+    description:
+      "The tier we hold records the offer as ended. The vendor page stays up, because it answers the question the reader arrived with, but a withdrawn offer is not ranked at any position.",
   },
   {
     code: "verification_lapsed",
@@ -250,14 +260,28 @@ function shiftDays(dateIso: string, days: number): string {
   return new Date(Date.parse(dateIso) + days * DAY_MS).toISOString().slice(0, 10);
 }
 
+export function eligibilityGateFor(offer: Pick<Offer, "eligibility">): Gate | null {
+  if (!offer.eligibility) return null;
+  const program = offer.eligibility.program ? ` (${offer.eligibility.program})` : "";
+  return {
+    code: "eligibility_restricted",
+    reason: `Restricted to ${offer.eligibility.type}${program} applicants — not generally available.`,
+  };
+}
+
+export function retiredGateFor(offer: Pick<Offer, "tier" | "vendor">): Gate | null {
+  if (!offerEnded(offer)) return null;
+  return {
+    code: "offer_retired",
+    reason: recordedTierSentence(offer.vendor, offer.tier),
+  };
+}
+
 export function gateFor(offer: Offer, date: string): Gate | null {
-  if (offer.eligibility) {
-    const program = offer.eligibility.program ? ` (${offer.eligibility.program})` : "";
-    return {
-      code: "eligibility_restricted",
-      reason: `Restricted to ${offer.eligibility.type}${program} applicants — not generally available.`,
-    };
-  }
+  const retired = retiredGateFor(offer);
+  if (retired) return retired;
+  const restricted = eligibilityGateFor(offer);
+  if (restricted) return restricted;
   const tierClass = classifyTier(offer.tier);
   if (tierClass.class === "not_free") {
     return {

--- a/src/retirement.ts
+++ b/src/retirement.ts
@@ -2,10 +2,18 @@ import type { Offer } from "./types.js";
 
 const RETIRED_TIER = /\b(?:retired|deprecated|discontinued|sunset|withdrawn)\b/i;
 
+export const ENDED_TIERS = ["Retired", "Discontinued", "Sunset", "Withdrawn"] as const;
+
+const ENDED_TIER_SET = new Set<string>(ENDED_TIERS.map(t => t.toLowerCase()));
+
 export type OfferTierAndUrl = Pick<Offer, "tier" | "url">;
 
 export function offerRetired(offer: Pick<Offer, "tier"> | null | undefined): boolean {
   return RETIRED_TIER.test(offer?.tier ?? "");
+}
+
+export function offerEnded(offer: Pick<Offer, "tier"> | null | undefined): boolean {
+  return ENDED_TIER_SET.has((offer?.tier ?? "").trim().toLowerCase());
 }
 
 export function recordedTierSentence(vendorName: string, tier: string): string {

--- a/src/retirement.ts
+++ b/src/retirement.ts
@@ -16,6 +16,12 @@ export function offerEnded(offer: Pick<Offer, "tier"> | null | undefined): boole
   return ENDED_TIER_SET.has((offer?.tier ?? "").trim().toLowerCase());
 }
 
+export function listEndedTiers(): string {
+  const all = [...ENDED_TIERS];
+  const last = all.pop()!;
+  return all.length ? `${all.join(", ")} or ${last}` : last;
+}
+
 export function recordedTierSentence(vendorName: string, tier: string): string {
   return `${vendorName}'s offer is recorded as ${tier}.`;
 }

--- a/test/ranking.test.ts
+++ b/test/ranking.test.ts
@@ -65,7 +65,7 @@ describe("tier classification", () => {
     const unclassified = new Set<string>();
     for (const o of index.offers) {
       const c = classifyTier(o.tier);
-      if (!["free", "time_limited", "not_free"].includes(c.class)) unclassified.add(o.tier);
+      if (!["free", "time_limited", "not_free", "retired"].includes(c.class)) unclassified.add(o.tier);
     }
     assert.strictEqual(unclassified.size, 0, `unclassified tiers: ${[...unclassified].join(", ")}`);
   });
@@ -94,14 +94,14 @@ describe("tier classification", () => {
   });
 
   it("puts every offer in exactly one class and lets no expiring tier into the free bucket", () => {
-    const counts = { free: 0, time_limited: 0, not_free: 0 };
+    const counts = { free: 0, time_limited: 0, not_free: 0, retired: 0 };
     const freeTiers = new Set<string>();
     for (const o of index.offers) {
       const tierClass = classifyTier(o.tier).class;
       counts[tierClass]++;
       if (tierClass === "free") freeTiers.add(o.tier);
     }
-    assert.strictEqual(counts.free + counts.time_limited + counts.not_free, index.offers.length);
+    assert.strictEqual(counts.free + counts.time_limited + counts.not_free + counts.retired, index.offers.length);
     assert.ok(counts.time_limited >= 20, `expected the time-limited class to be populated, found ${counts.time_limited}`);
     assert.ok(counts.not_free >= 15, `expected the not-free class to be populated, found ${counts.not_free}`);
     for (const tier of freeTiers) {
@@ -135,8 +135,12 @@ describe("gates", () => {
 
   it("every gate code is documented on the criteria page table", () => {
     const documented = new Set(GATE_TABLE.map((g) => g.code));
-    for (const code of ["eligibility_restricted", "not_a_free_offer", "offer_expired", "verification_lapsed"]) {
+    for (const code of ["eligibility_restricted", "not_a_free_offer", "offer_expired", "offer_retired", "verification_lapsed"]) {
       assert.ok(documented.has(code as never), `${code} must be documented`);
+    }
+    for (const o of index.offers) {
+      const gate = gateFor(o, TODAY);
+      if (gate) assert.ok(documented.has(gate.code), `${o.vendor} is gated ${gate.code}, which the table does not describe`);
     }
   });
 });

--- a/test/retired-ranking.test.ts
+++ b/test/retired-ranking.test.ts
@@ -224,4 +224,13 @@ describe("the best-of pages count what they list", () => {
     const criteria = await page("/criteria");
     assert.match(criteria, /<code>offer_retired<\/code>/);
   });
+
+  it("names every value of the ended vocabulary in the published gate row", async () => {
+    const criteria = await page("/criteria");
+    const row = /<code>offer_retired<\/code><\/td><td>(.*?)<\/td>/s.exec(criteria);
+    assert.ok(row, "the criteria table has no offer_retired row");
+    for (const tier of ENDED_TIERS) {
+      assert.ok(row![1].includes(tier), `the published row does not name ${tier}`);
+    }
+  });
 });

--- a/test/retired-ranking.test.ts
+++ b/test/retired-ranking.test.ts
@@ -1,0 +1,227 @@
+import { describe, it, before, after } from "node:test";
+import assert from "node:assert";
+import { spawn, type ChildProcess } from "node:child_process";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const { offerEnded, offerRetired, ENDED_TIERS } = await import("../dist/retirement.js");
+const { classifyTier, gateFor, rankOffers } = await import("../dist/ranking.js");
+
+type Offer = import("../src/types.ts").Offer;
+type DealChange = import("../src/types.ts").DealChange;
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO = path.join(__dirname, "..");
+
+const offers: Offer[] = JSON.parse(readFileSync(path.join(REPO, "data", "index.json"), "utf-8")).offers;
+const dealChanges: DealChange[] = JSON.parse(readFileSync(path.join(REPO, "data", "deal_changes.json"), "utf-8")).changes;
+
+const TODAY = "2026-09-01";
+
+function slugOf(vendor: string): string {
+  return vendor.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "");
+}
+
+function baseOffer(over: Partial<Offer> = {}): Offer {
+  return {
+    vendor: "Acme",
+    category: "Databases",
+    description: "A free tier.",
+    tier: "Free",
+    url: "https://example.com/pricing",
+    tags: [],
+    verifiedDate: TODAY,
+    ...over,
+  };
+}
+
+function rankCategory(categoryName: string) {
+  return rankOffers(offers.filter(o => o.category === categoryName), {
+    queryKey: `best-of:${categoryName}`,
+    changes: dealChanges,
+    date: TODAY,
+  });
+}
+
+const endedRecords = offers.filter(o => offerEnded(o));
+const categoriesWithAnEndedRecord = [...new Set(endedRecords.map(o => o.category))];
+
+let port = 0;
+let proc: ChildProcess | null = null;
+const pages = new Map<string, string>();
+
+function startServer(): Promise<ChildProcess> {
+  return new Promise((resolve, reject) => {
+    const child = spawn("node", [path.join(REPO, "dist", "serve.js")], {
+      stdio: ["pipe", "pipe", "pipe"],
+      env: { ...process.env, PORT: "0", BASE_URL: "http://localhost", TZ: "UTC" },
+    });
+    const timeout = setTimeout(() => { child.kill(); reject(new Error("Server startup timeout")); }, 30000);
+    child.stderr!.on("data", (data: Buffer) => {
+      const m = data.toString().match(/running on http:\/\/localhost:(\d+)/);
+      if (m) { port = parseInt(m[1], 10); clearTimeout(timeout); resolve(child); }
+    });
+    child.on("error", (e) => { clearTimeout(timeout); reject(e); });
+  });
+}
+
+async function page(pathname: string): Promise<string> {
+  const cached = pages.get(pathname);
+  if (cached !== undefined) return cached;
+  const res = await fetch(`http://localhost:${port}${pathname}`);
+  const body = await res.text();
+  pages.set(pathname, body);
+  return body;
+}
+
+let bestOfPaths: string[] = [];
+
+before(async () => {
+  proc = await startServer();
+  const index = await page("/best");
+  bestOfPaths = [...new Set([...index.matchAll(/href="(\/best\/[a-z0-9-]+)"/g)].map(m => m[1]))].sort();
+  for (const p of bestOfPaths) await page(p);
+  for (const o of endedRecords) await page(`/vendor/${slugOf(o.vendor)}`);
+  await page("/sitemap-vendors.xml");
+  await page("/criteria");
+});
+
+after(() => { proc?.kill(); });
+
+describe("a tier that records the offer as ended is gated, not ranked", () => {
+  it("has a subject in the index", () => {
+    assert.ok(endedRecords.length > 0, "no record carries an ended tier, so this file has no subject");
+  });
+
+  it("gives the ended tier its own class instead of the free fall-through", () => {
+    for (const tier of ENDED_TIERS) {
+      assert.strictEqual(classifyTier(tier).class, "retired", `${tier} still reaches a rule table or the default`);
+    }
+    assert.strictEqual(classifyTier("Free").class, "free");
+  });
+
+  it("gates a record whose tier records the offer as ended", () => {
+    const gate = gateFor(baseOffer({ tier: "Retired" }), TODAY);
+    assert.strictEqual(gate?.code, "offer_retired");
+    assert.match(gate!.reason, /Retired/);
+  });
+
+  it("does not gate a deprecated offer that is still being served", () => {
+    assert.strictEqual(gateFor(baseOffer({ tier: "Free (Deprecated)" }), TODAY), null);
+    assert.strictEqual(classifyTier("Free (Deprecated)").class, "free");
+  });
+
+  it("reads the ended tier ahead of an eligibility restriction on the same record", () => {
+    const both = baseOffer({ tier: "Retired", eligibility: { type: "student", conditions: ["enrolled"] } });
+    assert.strictEqual(gateFor(both, TODAY)?.code, "offer_retired");
+    assert.strictEqual(gateFor(baseOffer({ eligibility: { type: "student", conditions: ["enrolled"] } }), TODAY)?.code, "eligibility_restricted");
+  });
+
+  it("reads the whole tier string, not a word inside it", () => {
+    assert.ok(offerEnded({ tier: "Retired" }));
+    assert.ok(offerEnded({ tier: "  retired  " }));
+    for (const tier of ["Free (Sunset 2026)", "Free until sunset", "Retired Plan Migration Credit", "Not Discontinued"]) {
+      assert.ok(!offerEnded({ tier }), `"${tier}" was read as an ended offer`);
+      assert.notStrictEqual(gateFor(baseOffer({ tier }), TODAY)?.code, "offer_retired");
+    }
+  });
+
+  it("is narrower than the predicate the vendor page uses to withhold a link", () => {
+    const withheldFromLinking = offers.filter(o => offerRetired(o));
+    const gated = offers.filter(o => offerEnded(o));
+    assert.ok(gated.length < withheldFromLinking.length, "the gate predicate is not narrower than offerRetired");
+    for (const o of gated) {
+      assert.ok(offerRetired(o), `${o.vendor} is gated but not read as retired on its own page`);
+    }
+  });
+});
+
+describe("the ended records leave the ranked set and nothing else does", () => {
+  it("excludes every ended record from its category's qualified set", () => {
+    for (const record of endedRecords) {
+      const ranking = rankCategory(record.category);
+      const qualified = ranking.qualified.map(e => e.offer.vendor);
+      assert.ok(!qualified.includes(record.vendor), `${record.vendor} still qualifies in ${record.category}`);
+      const excluded = ranking.excluded.find(e => e.offer.vendor === record.vendor);
+      assert.strictEqual(excluded?.gate.code, "offer_retired", `${record.vendor} left qualified for another reason`);
+    }
+  });
+
+  it("gates no record the ended vocabulary does not name", () => {
+    for (const categoryName of [...new Set(offers.map(o => o.category))]) {
+      for (const entry of rankCategory(categoryName).excluded) {
+        if (entry.gate.code !== "offer_retired") continue;
+        assert.ok(
+          offerEnded(entry.offer),
+          `${entry.offer.vendor} was gated as retired on tier "${entry.offer.tier}"`,
+        );
+      }
+    }
+  });
+
+  it("demerits a still-served deprecated offer rather than gating it", () => {
+    const deprecated = offers.find(o => o.tier === "Free (Deprecated)");
+    assert.ok(deprecated, "no record carries a deprecated-but-served tier, so this control has no subject");
+    const ranking = rankCategory(deprecated!.category);
+    assert.ok(
+      !ranking.excluded.some(e => e.offer.vendor === deprecated!.vendor),
+      `${deprecated!.vendor} was gated with the ended records`,
+    );
+    const entry = ranking.demoted.find(e => e.offer.vendor === deprecated!.vendor);
+    assert.ok(entry, `${deprecated!.vendor} carries no demerit for its deprecation`);
+    assert.ok(entry!.demerits.some(d => d.code === "free_tier_withdrawn"));
+  });
+
+  it("removes exactly one record from each affected category and none from the others", () => {
+    for (const categoryName of [...new Set(offers.map(o => o.category))]) {
+      const ranking = rankCategory(categoryName);
+      const retiredHere = ranking.excluded.filter(e => e.gate.code === "offer_retired").length;
+      const endedHere = offers.filter(o => o.category === categoryName && offerEnded(o)).length;
+      assert.strictEqual(retiredHere, endedHere, `${categoryName} gated ${retiredHere} records as retired, data holds ${endedHere}`);
+      assert.strictEqual(
+        ranking.qualified.length + ranking.demoted.length + ranking.excluded.length,
+        offers.filter(o => o.category === categoryName).length,
+      );
+    }
+  });
+});
+
+describe("the best-of pages count what they list", () => {
+  it("names no ended record on any best-of page", async () => {
+    for (const p of bestOfPaths) {
+      const html = await page(p);
+      for (const record of endedRecords) {
+        assert.ok(!html.includes(`>${record.vendor}</a>`), `${p} still lists ${record.vendor}`);
+      }
+    }
+  });
+
+  it("ledes with the number of picks it actually renders", async () => {
+    let checked = 0;
+    for (const p of bestOfPaths) {
+      const html = await page(p);
+      const lede = /<div class="tie-note">.*?<strong>(\d+) offers? meets? our criteria/s.exec(html);
+      assert.ok(lede, `${p} has no count in its lede`);
+      const cards = [...html.matchAll(/<div class="best-pick">/g)].length;
+      assert.strictEqual(Number(lede![1]), cards, `${p} ledes ${lede![1]} and renders ${cards} picks`);
+      checked++;
+    }
+    assert.ok(checked >= categoriesWithAnEndedRecord.length, `only ${checked} best-of pages were checked`);
+  });
+
+  it("keeps the vendor page and the sitemap entry for every ended record", async () => {
+    const sitemap = await page("/sitemap-vendors.xml");
+    for (const record of endedRecords) {
+      const slug = slugOf(record.vendor);
+      const res = await fetch(`http://localhost:${port}/vendor/${slug}`);
+      assert.strictEqual(res.status, 200, `/vendor/${slug} no longer answers`);
+      assert.ok(sitemap.includes(`/vendor/${slug}<`), `/vendor/${slug} left sitemap-vendors.xml`);
+    }
+  });
+
+  it("publishes the new gate code in the criteria page table", async () => {
+    const criteria = await page("/criteria");
+    assert.match(criteria, /<code>offer_retired<\/code>/);
+  });
+});

--- a/test/tier-vocabulary.json
+++ b/test/tier-vocabulary.json
@@ -55,7 +55,6 @@
   "Personal",
   "Portfolio",
   "Public (Free)",
-  "Retired",
   "Self-Hosted",
   "Spark",
   "Standard",


### PR DESCRIPTION
Refs #1235 — acceptance criteria 1, 2 and 3.

**Was a draft; the copy is now answered.** The one published sentence in this change is the PM's, given verbatim on the issue. It is [quoted below](#the-one-string-that-is-mine). Everything else here is mechanism.

## The bug

`classifyTier` (`src/ranking.ts`) tests two rule tables and falls through to `{ class: "free", note: "an ongoing free tier" }`. `Retired` matches neither table, so four dead offers were classified as ongoing free tiers, took no gate and no demerit, and landed in `qualified`:

| page | record | was | the domain today |
|---|---|---|---|
| `/best/free-cloud-hosting` | Oaysus | **5 of 55** | a website design agency |
| `/best/free-storage` | QRME.SH | 19 of 50 | a sports betting site |
| `/best/free-dev-utilities` | Supportivekoala | 36 of 103 | a slots casino |
| `/best/free-ai-ml` | GitHub Models | 43 of 46 | retired by GitHub 2026-07-30 |

## The fix

`ENDED_TIERS` in `src/retirement.ts` is a **closed four-value vocabulary** — `Retired`, `Discontinued`, `Sunset`, `Withdrawn` — matched against the whole trimmed tier string. `classifyTier` consults it first and returns a new `retired` class; `gateFor` turns that into an `offer_retired` gate.

**Why the predicate is not `offerRetired`.** That one matches `retired|deprecated|discontinued|sunset|withdrawn` anywhere in the string, which is five records — the four above plus Google Content API for Shopping's `Free (Deprecated)`. Criterion 2 says gate the dead and demerit the withdrawing, and **the demerit half already exists**: that record sits in `demoted` at −3 with `free_tier_withdrawn`, off a recorded `product_deprecated` change. So no new `DemeritCode` and no new tier rule were needed. A test pins it in `demoted` and out of `excluded`.

The two mechanisms compose. A future `Retired (was Free)` is **not** caught by the exact match — and fails CI in the fixture merged in #1236, because it is a new string reaching the free default. Fail-loud in both directions rather than fail-open in one.

`gateFor` now consults retirement **before** eligibility. To keep that free of side effects, the eligibility branch is extracted to `eligibilityGateFor` and `src/eligibility.ts` delegates to it, so a record that is both retired and eligibility-restricted still reports its eligibility notice on the category page while gating as retired in the ranker.

## <a name="the-one-string-that-is-mine"></a>The one published string, and whose it is

One row in the gates table on `/criteria`. **The PM's wording, verbatim:**

> `offer_retired` — *The tier we hold records the offer as ended: Retired, Discontinued, Sunset or Withdrawn. The vendor page stays up and still answers whether the offer exists, but an ended offer is not ranked at any position.*

The list of four values is composed from `ENDED_TIERS` rather than retyped, so a fifth value cannot drift out of the published sentence, and a test asserts the rendered row names every value in the set. The rendered text today is byte-identical to the string above.

That is the whole copy surface. The gate's `reason` reuses `recordedTierSentence`, live on those four vendor pages since #1232, and **it has no new rendering surface**: `buildBestOfPage` renders `qualified` and `demoted` and never `excluded`, and the category page's per-row notice is eligibility-specific. `grep` across both full sweeps confirms `offer is recorded as Retired` appears on the same four paths before and after.

## Measurement

Full sweep, 3,922 paths, `main` build against this branch, `TZ=UTC`:

```
3,916 byte-identical    6 moved    0 status changes
```

The 6: `/best/free-cloud-hosting`, `/best/free-storage`, `/best/free-dev-utilities`, `/best/free-ai-ml`, `/best`, `/criteria`. `/best/free-cloud-hosting` goes from *"55 offers meet our criteria"* to 54 and no longer lists Oaysus.

**Predicting the unchanged set mattered more than the changed one here.** Oaysus is named on 102 paths and GitHub Models on 125, and none of those moved: the vendor and `/alternative-to` lists had already dropped both through the subtype membership gate, so they appear only in the *"Left out of this list"* line, which is not a recommendation. Criterion 3 holds — all four keep their vendor page and their `sitemap-vendors.xml` entry, asserted by test.

Per category, at `date=2026-09-01`:

```
Cloud Hosting    pool 60  qualified 54  demoted  3  excluded 3  {offer_retired 1, not_a_free_offer 2}
Storage          pool 55  qualified 49  demoted  4  excluded 2  {offer_retired 1, eligibility_restricted 1}
Dev Utilities    pool 109 qualified 102 demoted  5  excluded 2  {offer_retired 1, not_a_free_offer 1}
AI / ML          pool 70  qualified 45  demoted 17  excluded 8  {offer_retired 1, not_a_free_offer 6, eligibility_restricted 1}
API Development  pool 42  qualified 39  demoted  2  excluded 1  {not_a_free_offer 1}
```

The last row is the control: the category holding `Free (Deprecated)` gates nothing new.

## Tests

16 new in `test/retired-ranking.test.ts`, plus a widened gate-code assertion in `test/ranking.test.ts` that now walks every record in the index and fails on any gate code the published table does not describe.

**5 of the 16 go red with the gate removed** — the rest bind the classification, the predicate's narrowness, the `/criteria` row, the page-and-sitemap preservation, and the lede-versus-cards invariant.

Two controls worth naming:

- **The best-of lede is asserted against the cards below it**, not against `qualified.length`. A mutation feeding the lede `ranked.length` is killed; one comparing the lede to its own composer would not have been.
- **`gates no record the ended vocabulary does not name`** walks every category and fails if any record gated `offer_retired` is not in the closed set. That is the consequence, not a copy of the list.

**9 of 9 mutations killed** — `scripts/mutate-1235-gate.sh`. One survived first time round: swapping the exact match for a substring match changed nothing, because no tier string in the data contains an ended word without being one. That was a hole in my test, not in the code; `reads the whole tier string, not a word inside it` now pins four near-misses and kills it.

## Not in this PR

- **Criterion 5, Fly.io.** Needs a data change and a second reason form — asked on the issue.
- **Criterion 6, the retirement branch on the vendor page.** It reaches six surfaces, not the four the issue's comment names; enumerated on the issue with the strings each one publishes today.
- **`/vendor/google-content-api-for-shopping` has no pricing-page link and answers `Is X free?` with the recorded-tier sentence**, because #1232's broader `offerRetired` fires on it. By this issue's own reading that record is a live offer, so #1232 over-fired. Left alone deliberately: restoring the link means re-asserting *"Yes, X offers a free tier: Free (Deprecated)"* over a record whose description names a sunset date that has now passed, which is a copy decision rather than a mechanism one.

