### PR TITLE
Remove the duplicated "Startup Program" suffix from four program names

### DIFF
--- a/data/index.json
+++ b/data/index.json
@@ -27345,7 +27345,7 @@
         "conditions": [
           "Startup program — check vendor for eligibility details"
         ],
-        "program": "Scaleway Startup Program Startup Program"
+        "program": "Scaleway Startup Program"
       },
       "source_check": {
         "checked": "2026-08-28",
@@ -27371,7 +27371,7 @@
         "conditions": [
           "Startup program — check vendor for eligibility details"
         ],
-        "program": "ScaleGrid Startup Program Startup Program"
+        "program": "ScaleGrid Startup Program"
       },
       "source_check": {
         "checked": "2026-08-28",
@@ -27662,7 +27662,7 @@
         "conditions": [
           "Startup program — check vendor for eligibility details"
         ],
-        "program": "Shotstack Startup Program Startup Program"
+        "program": "Shotstack Startup Program"
       },
       "expires_date": "2026-07-31",
       "source_check": {
@@ -27688,7 +27688,7 @@
         "conditions": [
           "Startup program — check vendor for eligibility details"
         ],
-        "program": "Esri Startup Program Startup Program"
+        "program": "Esri Startup Program"
       },
       "source_check": {
         "checked": "2026-08-28",


### PR DESCRIPTION
Four eligibility records publish a literally duplicated phrase in the gate reason. On production right now:

```
/vendor/scaleway-startup-program  Restricted to startup (Scaleway Startup Program Startup Program) applicants
/vendor/esri-startup-program      Restricted to startup (Esri Startup Program Startup Program) applicants
```

Same for ScaleGrid and Shotstack. `eligibilityGateFor` composes `Restricted to ${type} (${program}) applicants`, and these four carry `program` = vendor name + `" Startup Program"` where the vendor name already ends in `Startup Program`.

Set `program` to the vendor name. Data only — the gate fires on the same records with the same code, so nothing moves between `qualified`, `demoted` and `excluded`. Only the composed string changes.

## The wider pattern, not fixed here

27 records carry `program` == vendor + `" Startup Program"`, a mechanical suffix rather than a program name. These four are the subset where it reads as a duplication; the other 23 read redundantly — *"Restricted to startup (HubSpot for Startups Startup Program) applicants"*, *"Restricted to startup (FeedBear Startup Program) applicants"*.

The remaining 109 eligibility records carry real program names — `AWS Activate Portfolio`, `GitHub Student Developer Pack`, `Sentry for Open Source` — so the field works and this is one bulk import that skipped it.

Correcting the other 23 needs each vendor's actual program name read off their page, which is the same fetch as filling in their eligibility criteria (all 23 carry only the `Startup program — check vendor for eligibility details` placeholder). I am doing that as one job rather than guessing a name here.
