### PR TITLE
Stop rating an offer the vendor has ended (#1235)

### DIFF
--- a/scripts/census-1235-surfaces.mjs
+++ b/scripts/census-1235-surfaces.mjs
@@ -1,0 +1,55 @@
+import { spawn } from "node:child_process";
+import { writeFileSync } from "node:fs";
+import path from "node:path";
+
+const repo = process.argv[2];
+const out = process.argv[3];
+const slugs = process.argv.slice(4);
+
+function startServer() {
+  return new Promise((resolve, reject) => {
+    const p = spawn("node", [path.join(repo, "dist", "serve.js")], {
+      cwd: repo,
+      stdio: ["pipe", "pipe", "pipe"],
+      env: { ...process.env, PORT: "0", BASE_URL: "http://127.0.0.1", TZ: "UTC" },
+    });
+    const timeout = setTimeout(() => { p.kill("SIGKILL"); reject(new Error("timeout")); }, 60000);
+    const onData = (b) => {
+      const m = b.toString().match(/running on http:\/\/localhost:(\d+)/);
+      if (m) { clearTimeout(timeout); resolve({ proc: p, port: parseInt(m[1], 10) }); }
+    };
+    p.stderr.on("data", onData);
+    p.stdout.on("data", onData);
+    p.on("error", (e) => { clearTimeout(timeout); reject(e); });
+  });
+}
+
+const { proc, port } = await startServer();
+const base = `http://127.0.0.1:${port}`;
+
+const text = (s) => s.replace(/<[^>]*>/g, " ").replace(/\s+/g, " ").trim();
+
+const result = {};
+for (const slug of slugs) {
+  const html = await (await fetch(`${base}/vendor/${slug}`)).text();
+  const h1 = /<h1>([\s\S]*?)<\/h1>/.exec(html);
+  const badge = h1 ? /<span class="risk-badge"[^>]*>([a-z]+)<\/span>/.exec(h1[1]) : null;
+  const verdict = /<div class="quick-verdict">\s*<p>([\s\S]*?)<\/p>/.exec(html);
+  const faq = {};
+  for (const [, q, a] of html.matchAll(/"name":"([^"]*?)","acceptedAnswer":\{"@type":"Answer","text":"([\s\S]*?)"\}/g)) {
+    if (/alternatives to|category is/.test(q)) continue;
+    faq[q.replace(/^[A-Za-z0-9. ]*?(free|reliable|production|changed|outgrow)/, "$1")] = a;
+  }
+  const alts = /<h2[^>]*>[^<]*[Aa]lternatives[\s\S]*?<\/table>/.exec(html);
+  result[slug] = {
+    h1: h1 ? text(h1[1]) : null,
+    badge: badge ? badge[1] : null,
+    verdict: verdict ? text(verdict[1]) : null,
+    faq,
+    altNames: alts ? [...alts[0].matchAll(/\/vendor\/([a-z0-9-]+)"/g)].map(m => m[1]) : [],
+  };
+}
+
+writeFileSync(out, JSON.stringify(result, null, 0));
+console.error(`${slugs.length} vendor pages -> ${out}`);
+proc.kill("SIGKILL");

--- a/scripts/mutate-1235-vendor-page.sh
+++ b/scripts/mutate-1235-vendor-page.sh
@@ -1,0 +1,134 @@
+#!/bin/bash
+set -u
+cd "$(dirname "$0")/.." || exit 1
+
+TESTS="test/retired-vendor-page.test.ts test/retired-ranking.test.ts test/vendor-verdict.test.ts test/tier-vocabulary.test.ts test/ranking.test.ts"
+
+run_case() {
+  local name="$1" file="$2" from="$3" to="$4"
+  cp "$file" /tmp/mut-backup
+  python3 - "$file" "$from" "$to" <<'PY'
+import sys
+path, old, new = sys.argv[1], sys.argv[2], sys.argv[3]
+s = open(path).read()
+n = s.count(old)
+if n != 1:
+    print(f"PATTERN-MISS ({n})")
+    sys.exit(3)
+open(path, "w").write(s.replace(old, new))
+PY
+  if [ $? -eq 3 ]; then cp /tmp/mut-backup "$file"; echo "SKIP     $name (pattern not found exactly once)"; return; fi
+  if ! npm run build > /tmp/mut-build.log 2>&1; then
+    cp /tmp/mut-backup "$file"
+    echo "KILLED   $name (build)"
+    return
+  fi
+  TZ=UTC node --test $TESTS > /tmp/mut-test.log 2>&1
+  local code=$?
+  cp /tmp/mut-backup "$file"
+  if [ $code -ne 0 ]; then
+    echo "KILLED   $name  <- $(grep -m1 '✖ ' /tmp/mut-test.log | sed 's/^ *//')"
+  else
+    echo "SURVIVED $name"
+  fi
+}
+
+run_case "the quick verdict stops reading the ending" src/vendor-verdict.ts \
+  '  if (input.offerEnded) return endedVerdictSentence();' \
+  '  if (false) return endedVerdictSentence();'
+
+run_case "the quick verdict reads withholding first" src/vendor-verdict.ts \
+  '  if (input.offerEnded) return endedVerdictSentence();
+  if (withholdingDecides(input)) {' \
+  '  if (withholdingDecides(input)) {
+    if (input.offerEnded) return endedVerdictSentence();'
+
+run_case "the verdict word still rates an ended offer" src/vendor-verdict.ts \
+  '  if (input.offerEnded) return null;
+  if (withholdingDecides(input)) return null;' \
+  '  if (withholdingDecides(input)) return null;'
+
+run_case "the history block stops reading the ending" src/serve.ts \
+  '  }).join("\n") : offerHasEnded
+    ? `<p class="no-changes">${escHtmlServer(endedHistorySentence(vendorName))}</p>`
+    : levelWithheld' \
+  '  }).join("\n") : levelWithheld'
+
+run_case "the history block reads withholding first" src/serve.ts \
+  '  }).join("\n") : offerHasEnded
+    ? `<p class="no-changes">${escHtmlServer(endedHistorySentence(vendorName))}</p>`
+    : levelWithheld' \
+  '  }).join("\n") : levelWithheld
+    ? `<p class="no-changes">No recorded pricing changes for ${escHtmlServer(vendorName)} — but ${escHtmlServer(withheldClause)}, so nothing we have read describes these terms. Treat the empty history as a statement about our records, not about this vendor'"'"'s pricing.</p>`
+    : offerHasEnded'
+
+run_case "the reliability answer stops reading the ending" src/serve.ts \
+  '  const faqReliableAnswer = offerHasEnded
+    ? endedReliabilitySentence(vendorName)
+    : levelWithheld' \
+  '  const faqReliableAnswer = levelWithheld'
+
+run_case "the reliability answer reads withholding first" src/serve.ts \
+  '  const faqReliableAnswer = offerHasEnded
+    ? endedReliabilitySentence(vendorName)
+    : levelWithheld
+    ? `We cannot say.' \
+  '  const faqReliableAnswer = levelWithheld
+    ? `We cannot say.'
+
+run_case "the change answer stops reading the ending" src/serve.ts \
+  '    : offerHasEnded
+    ? endedEmptyChangeHistorySentence(vendorName)
+    : levelWithheld' \
+  '    : levelWithheld'
+
+run_case "the change answer drops the ending after recorded changes" src/serve.ts \
+  '${offerHasEnded ? ` ${ENDED_SINCE_CHANGES_SENTENCE}` : ""}' \
+  ''
+
+run_case "the heading keeps the free-tier form" src/serve.ts \
+  '  <h1>${offerHasEnded ? escHtmlServer(endedHeadline(vendorName)) : `${escHtmlServer(vendorName)} Free Tier ${currentYear}`}${h1RiskBadge}</h1>' \
+  '  <h1>${escHtmlServer(vendorName)} Free Tier ${currentYear}${h1RiskBadge}</h1>'
+
+run_case "the badge keeps the risk word" src/serve.ts \
+  '  const h1RiskBadge = offerHasEnded
+    ? ` <span class="risk-badge" style="background:${retiredBadgeColor}20;color:${retiredBadgeColor};border:1px solid ${retiredBadgeColor}40">${ENDED_BADGE_LABEL}</span>`
+    : enriched.risk_level === null' \
+  '  const h1RiskBadge = enriched.risk_level === null'
+
+run_case "the page reads the loose retirement predicate, not the ended vocabulary" src/serve.ts \
+  '  const offerHasEnded = offerEnded(primary);' \
+  '  const offerHasEnded = offerRetired(primary);'
+
+run_case "the closed legacy tier is matched loosely" src/ranking.ts \
+  '{ pattern: /^legacy free$/i, note: "a free tier closed to new accounts" }' \
+  '{ pattern: /legacy free/i, note: "a free tier closed to new accounts" }'
+
+run_case "the closed legacy tier has no rule" src/ranking.ts \
+  '  { pattern: /^legacy free$/i, note: "a free tier closed to new accounts" },
+' \
+  ''
+
+run_case "the verdict sentence loses its second half" src/retirement.ts \
+  'return "This offer has ended — we keep the page for the record and no longer rate it.";' \
+  'return "This offer has ended.";'
+
+run_case "the history sentence stops denying stability" src/retirement.ts \
+  ' An empty history is not evidence of stability here.`;' \
+  '`;'
+
+run_case "the reliability sentence stops saying why we keep the page" src/retirement.ts \
+  ' We keep the page so the question has an answer, but a stability judgement only applies to an offer you can still get.`;' \
+  '`;'
+
+run_case "the empty-history answer reads as a stable one" src/retirement.ts \
+  ', not a stable one.`;' \
+  '.`;'
+
+run_case "the shared clause changes under every form that embeds it" src/retirement.ts \
+  'export const ENDED_OFFER_CLAUSE = "the offer has ended";' \
+  'export const ENDED_OFFER_CLAUSE = "the offer is ended";'
+
+run_case "the heading loses the retirement word" src/retirement.ts \
+  'return `${vendorName} — free tier retired`;' \
+  'return `${vendorName} — free tier`;'

--- a/scripts/sweep-paths.mjs
+++ b/scripts/sweep-paths.mjs
@@ -1,0 +1,55 @@
+import { spawn } from "node:child_process";
+import { createHash } from "node:crypto";
+import { writeFileSync } from "node:fs";
+import path from "node:path";
+
+const repo = process.argv[2];
+const out = process.argv[3];
+const CONCURRENCY = 16;
+
+function startServer() {
+  return new Promise((resolve, reject) => {
+    const p = spawn("node", [path.join(repo, "dist", "serve.js")], {
+      cwd: repo,
+      stdio: ["pipe", "pipe", "pipe"],
+      env: { ...process.env, PORT: "0", BASE_URL: "http://127.0.0.1", TZ: "UTC" },
+    });
+    const timeout = setTimeout(() => { p.kill("SIGKILL"); reject(new Error("timeout")); }, 60000);
+    const onData = (b) => {
+      const m = b.toString().match(/running on http:\/\/localhost:(\d+)/);
+      if (m) { clearTimeout(timeout); resolve({ proc: p, port: parseInt(m[1], 10) }); }
+    };
+    p.stderr.on("data", onData);
+    p.stdout.on("data", onData);
+    p.on("error", (e) => { clearTimeout(timeout); reject(e); });
+  });
+}
+
+const { proc, port } = await startServer();
+const base = `http://127.0.0.1:${port}`;
+const stripHost = (u) => u.replace(/^https?:\/\/[^/]+/, "");
+
+const index = await (await fetch(`${base}/sitemap.xml`)).text();
+const paths = new Set(["/", "/criteria", "/best", "/sitemap.xml"]);
+for (const m of index.matchAll(/<loc>([^<]+)<\/loc>/g)) {
+  const child = stripHost(m[1]);
+  paths.add(child);
+  const xml = await (await fetch(`${base}${child}`)).text();
+  for (const l of xml.matchAll(/<loc>([^<]+)<\/loc>/g)) paths.add(stripHost(l[1]));
+}
+
+const list = [...paths].sort();
+const results = {};
+let i = 0;
+await Promise.all(Array.from({ length: CONCURRENCY }, async () => {
+  while (i < list.length) {
+    const p = list[i++];
+    const res = await fetch(`${base}${p}`);
+    const body = await res.text();
+    results[p] = `${res.status} ${createHash("sha256").update(body).digest("hex").slice(0, 16)}`;
+  }
+}));
+
+writeFileSync(out, JSON.stringify(results, null, 0));
+console.error(`${list.length} paths -> ${out}`);
+proc.kill("SIGKILL");

--- a/src/ranking.ts
+++ b/src/ranking.ts
@@ -27,6 +27,7 @@ export const NOT_FREE_TIER_RULES: { pattern: RegExp; note: string }[] = [
   { pattern: /^freemium$/i, note: "paid product with a trial-shaped entry point, not a stated free tier" },
   { pattern: /^pay[-\s]?as[-\s]?you[-\s]?go$/i, note: "usage-billed from the first request" },
   { pattern: /^pay[-\s]?per[-\s]?use\b/i, note: "usage-billed from the first request" },
+  { pattern: /^legacy free$/i, note: "a free tier closed to new accounts" },
   { pattern: /^conditional$/i, note: "availability is not stated in terms we can check" },
   { pattern: /^exempt\s*\/\s*paid$/i, note: "free only by case-by-case exemption" },
 ];

--- a/src/retirement.ts
+++ b/src/retirement.ts
@@ -25,3 +25,29 @@ export function listEndedTiers(): string {
 export function recordedTierSentence(vendorName: string, tier: string): string {
   return `${vendorName}'s offer is recorded as ${tier}.`;
 }
+
+export const ENDED_OFFER_CLAUSE = "the offer has ended";
+
+export const ENDED_BADGE_LABEL = "retired";
+
+export function endedHeadline(vendorName: string): string {
+  return `${vendorName} — free tier retired`;
+}
+
+export function endedVerdictSentence(): string {
+  return "This offer has ended — we keep the page for the record and no longer rate it.";
+}
+
+export function endedHistorySentence(vendorName: string): string {
+  return `No recorded pricing changes for ${vendorName} — but ${ENDED_OFFER_CLAUSE}, so this history describes a tier that is no longer available. An empty history is not evidence of stability here.`;
+}
+
+export function endedReliabilitySentence(vendorName: string): string {
+  return `${vendorName} has ended this offer, so there is nothing to rate. We keep the page so the question has an answer, but a stability judgement only applies to an offer you can still get.`;
+}
+
+export function endedEmptyChangeHistorySentence(vendorName: string): string {
+  return `${vendorName} has no recorded pricing changes, but ${ENDED_OFFER_CLAUSE} — so the empty history describes a tier that is no longer available, not a stable one.`;
+}
+
+export const ENDED_SINCE_CHANGES_SENTENCE = "The offer has since ended.";

--- a/src/serve.ts
+++ b/src/serve.ts
@@ -16,7 +16,7 @@ import { buildDailyRollup, readRollups, coverageOf, ROLLUP_DATE_PATTERN } from "
 import { configureVendorSeries, recordVendorRequest, flushVendorSeries, readVendorSeries, vendorSeriesGauge, vendorExportAuthorized, isSeriesDate, seriesDateRange, VENDOR_SERIES_PATH, VENDOR_SERIES_RETENTION_DAYS, VENDOR_SERIES_NOTES } from "./vendor-series.js";
 import { openapiSpec } from "./openapi.js";
 import { LINK_GRACE_DAYS, unreachableNoticeForUrl } from "./link-health.js";
-import { offerRetired, recordedTierSentence, type OfferTierAndUrl } from "./retirement.js";
+import { offerEnded, offerRetired, recordedTierSentence, endedHeadline, endedHistorySentence, endedReliabilitySentence, endedEmptyChangeHistorySentence, ENDED_BADGE_LABEL, ENDED_SINCE_CHANGES_SENTENCE, type OfferTierAndUrl } from "./retirement.js";
 import { levelWithheldReason, withheldLevelClause, withheldLevelSentence } from "./source-check.js";
 import { buildComparisonMap, comparisonSlug } from "./comparison-pairs.js";
 import { stabilityFaqAnswer, stabilityVerdictClause, type ComparisonSide, type StabilityRating } from "./comparison-verdict.js";
@@ -3700,7 +3700,11 @@ function buildVendorPage(slug: string): string | null {
   const discontinuedOn = discontinuedOnOrBefore(vendorChanges, servedOn);
 
   const linkUnreachable = enriched.link_unreachable;
-  const h1RiskBadge = enriched.risk_level === null || (linkUnreachable && riskLevel === "stable")
+  const offerHasEnded = offerEnded(primary);
+  const retiredBadgeColor = "#8b949e";
+  const h1RiskBadge = offerHasEnded
+    ? ` <span class="risk-badge" style="background:${retiredBadgeColor}20;color:${retiredBadgeColor};border:1px solid ${retiredBadgeColor}40">${ENDED_BADGE_LABEL}</span>`
+    : enriched.risk_level === null || (linkUnreachable && riskLevel === "stable")
     ? ""
     : ` <span class="risk-badge" style="background:${riskColor}20;color:${riskColor};border:1px solid ${riskColor}40">${riskLevel}</span>`;
   const linkUnreachableLine = linkUnreachable
@@ -3793,6 +3797,7 @@ function buildVendorPage(slug: string): string | null {
     changes: vendorChanges,
     levelWithheld,
     unconfirmableSince,
+    offerEnded: offerHasEnded,
   };
   const verdictLine2 = vendorVerdictSentence(verdictInput);
   const verdictLine3 = discontinuedOn
@@ -3882,7 +3887,9 @@ ${enrichedAlts.map(a => {
         <div class="change-summary">${escHtmlServer(c.summary)}</div>
         ${c.previous_state && c.current_state ? `<div class="change-detail"><span class="state-label">Before:</span> ${escHtmlServer(c.previous_state)}</div><div class="change-detail"><span class="state-label">After:</span> ${escHtmlServer(c.current_state)}</div>` : ""}
       </div>`;
-  }).join("\n") : levelWithheld
+  }).join("\n") : offerHasEnded
+    ? `<p class="no-changes">${escHtmlServer(endedHistorySentence(vendorName))}</p>`
+    : levelWithheld
     ? `<p class="no-changes">No recorded pricing changes for ${escHtmlServer(vendorName)} — but ${escHtmlServer(withheldClause)}, so nothing we have read describes these terms. Treat the empty history as a statement about our records, not about this vendor's pricing.</p>`
     : `<p class="no-changes">No recorded pricing changes for ${escHtmlServer(vendorName)}. This is a good sign — stable pricing.</p>`;
 
@@ -4107,7 +4114,9 @@ ${allCompareLinks.join("\n")}
     : eligibilityGateSentence + (levelWithheld
     ? `${unconfirmedTermsPreamble}Our stored record calls ${vendorName}'s free tier "${primary.tier}". ${withUnconfirmedTermsCaveat(primary.description)}`
     : `${vendorName}'s free tier is called "${primary.tier}". ${primary.description}`);
-  const faqReliableAnswer = levelWithheld
+  const faqReliableAnswer = offerHasEnded
+    ? endedReliabilitySentence(vendorName)
+    : levelWithheld
     ? `We cannot say. ${withheldLevelSentence(levelWithheld, vendorName, unconfirmableSince)} Nothing we have read describes these terms, so we are not publishing a stability judgement for this vendor until that is fixed.`
     : riskLevel === "stable"
     ? `${vendorName}'s free tier is considered stable.${vendorChanges.length > 0 ? ` ${narrowingSentence(vendorChanges)} See the pricing history below.` : ""}`
@@ -4124,7 +4133,9 @@ ${allCompareLinks.join("\n")}
       : `${vendorName}'s free tier is usable for prototyping and development, but we rate it ${riskLevel}${riskCause ? ` because of one recorded ${changeKindNoun(riskCause.change_type)}, ${changeDateClause(riskCause)}` : ""}. Consider alternatives with more stable pricing for critical services.`)
     : `${vendorName} does not offer a free tier for production use. Consider free alternatives in ${primary.category}.`);
   const faqChangedAnswer = vendorChanges.length > 0
-    ? `${vendorName} has had ${vendorChanges.length} recorded pricing change${vendorChanges.length > 1 ? "s" : ""}. Most recently: ${vendorChanges[0].summary} (${changeDateLabel(vendorChanges[0])}).`
+    ? `${vendorName} has had ${vendorChanges.length} recorded pricing change${vendorChanges.length > 1 ? "s" : ""}. Most recently: ${vendorChanges[0].summary} (${changeDateLabel(vendorChanges[0])}).${offerHasEnded ? ` ${ENDED_SINCE_CHANGES_SENTENCE}` : ""}`
+    : offerHasEnded
+    ? endedEmptyChangeHistorySentence(vendorName)
     : levelWithheld
     ? `We hold no recorded pricing changes for ${vendorName}, but ${withheldClause}, so that is a statement about our records rather than a positive signal.`
     : `No, ${vendorName} has had no recorded pricing changes. This is a positive stability signal.`;
@@ -4251,7 +4262,7 @@ ${mcpCtaCss()}
 <div class="container">
   ${buildGlobalNav("categories")}
   <div class="breadcrumb"><a href="/">AgentDeals</a> &rsaquo; <a href="/vendor">Vendors</a> &rsaquo; ${escHtmlServer(vendorName)}</div>
-  <h1>${escHtmlServer(vendorName)} Free Tier ${currentYear}${h1RiskBadge}</h1>${eligibilityGateLine}
+  <h1>${offerHasEnded ? escHtmlServer(endedHeadline(vendorName)) : `${escHtmlServer(vendorName)} Free Tier ${currentYear}`}${h1RiskBadge}</h1>${eligibilityGateLine}
 ${riskCauseLine}
 ${linkUnreachableLine}
 ${productRoleLine}${productSubtypesLine}

--- a/src/vendor-verdict.ts
+++ b/src/vendor-verdict.ts
@@ -2,6 +2,7 @@ import type { DealChange, RiskCause } from "./types.js";
 import { CHANGE_DIRECTION, isACorrectionToOurOwnRecord } from "./data.js";
 import { changeDateClause } from "./change-dates.js";
 import { withheldLevelClause, type LevelWithheldReason } from "./source-check.js";
+import { endedVerdictSentence } from "./retirement.js";
 
 export type PublishedRiskLevel = "stable" | "caution" | "risky";
 
@@ -32,6 +33,7 @@ export interface VendorVerdictInput {
   changes: Array<Pick<DealChange, "date" | "date_source" | "change_type">>;
   levelWithheld: LevelWithheldReason | null;
   unconfirmableSince: string;
+  offerEnded?: boolean;
 }
 
 export function publishedVendorLevel(
@@ -59,6 +61,7 @@ export function withholdingDecides(input: VendorVerdictInput): boolean {
 }
 
 export function vendorVerdictWord(input: VendorVerdictInput): PublishedRiskLevel | null {
+  if (input.offerEnded) return null;
   if (withholdingDecides(input)) return null;
   return publishedVendorLevel(input.level, input.cause);
 }
@@ -86,6 +89,7 @@ export function narrowingSentence(changes: VendorVerdictInput["changes"]): strin
 }
 
 export function vendorVerdictSentence(input: VendorVerdictInput): string {
+  if (input.offerEnded) return endedVerdictSentence();
   if (withholdingDecides(input)) {
     const clause = withheldLevelClause(input.levelWithheld!, input.unconfirmableSince);
     return `${clause.charAt(0).toUpperCase()}${clause.slice(1)}, so we cannot confirm these terms today.`;

--- a/test/retired-vendor-page.test.ts
+++ b/test/retired-vendor-page.test.ts
@@ -1,0 +1,345 @@
+import { describe, it, before, after } from "node:test";
+import assert from "node:assert";
+import { spawn, type ChildProcess } from "node:child_process";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const {
+  offerEnded,
+  offerRetired,
+  endedHeadline,
+  endedVerdictSentence,
+  endedHistorySentence,
+  endedReliabilitySentence,
+  endedEmptyChangeHistorySentence,
+  ENDED_BADGE_LABEL,
+  ENDED_OFFER_CLAUSE,
+  ENDED_SINCE_CHANGES_SENTENCE,
+} = await import("../dist/retirement.js");
+const { vendorVerdictSentence, vendorVerdictWord } = await import("../dist/vendor-verdict.js");
+const { classifyTier, gateFor, rankOffers } = await import("../dist/ranking.js");
+
+type Offer = import("../src/types.ts").Offer;
+type DealChange = import("../src/types.ts").DealChange;
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO = path.join(__dirname, "..");
+
+const offers: Offer[] = JSON.parse(readFileSync(path.join(REPO, "data", "index.json"), "utf-8")).offers;
+const dealChanges: DealChange[] = JSON.parse(readFileSync(path.join(REPO, "data", "deal_changes.json"), "utf-8")).changes;
+
+const TODAY = "2026-09-01";
+
+function slugOf(vendor: string): string {
+  return vendor.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "");
+}
+
+const endedRecords = offers.filter(o => offerEnded(o));
+const retiredButNotEnded = offers.filter(o => offerRetired(o) && !offerEnded(o));
+
+let port = 0;
+let proc: ChildProcess | null = null;
+const pages = new Map<string, string>();
+
+function startServer(): Promise<ChildProcess> {
+  return new Promise((resolve, reject) => {
+    const child = spawn("node", [path.join(REPO, "dist", "serve.js")], {
+      stdio: ["pipe", "pipe", "pipe"],
+      env: { ...process.env, PORT: "0", BASE_URL: "http://localhost", TZ: "UTC" },
+    });
+    const timeout = setTimeout(() => { child.kill(); reject(new Error("Server startup timeout")); }, 30000);
+    child.stderr!.on("data", (data: Buffer) => {
+      const m = data.toString().match(/running on http:\/\/localhost:(\d+)/);
+      if (m) { port = parseInt(m[1], 10); clearTimeout(timeout); resolve(child); }
+    });
+    child.on("error", (e) => { clearTimeout(timeout); reject(e); });
+  });
+}
+
+async function page(pathname: string): Promise<string> {
+  const cached = pages.get(pathname);
+  if (cached !== undefined) return cached;
+  const res = await fetch(`http://localhost:${port}${pathname}`);
+  const body = await res.text();
+  pages.set(pathname, body);
+  return body;
+}
+
+function headingOf(html: string): string {
+  const m = /<h1>([\s\S]*?)<\/h1>/.exec(html);
+  return m ? m[1] : "";
+}
+
+function faqAnswer(html: string, questionFragment: string): string {
+  const pattern = new RegExp(`"name":"([^"]*${questionFragment}[^"]*)","acceptedAnswer":\\{"@type":"Answer","text":"([\\s\\S]*?)"\\}`);
+  const m = pattern.exec(html);
+  return m ? m[2] : "";
+}
+
+function textOf(html: string): string {
+  return html.replace(/<[^>]*>/g, " ").replace(/\s+/g, " ");
+}
+
+before(async () => {
+  proc = await startServer();
+  for (const o of endedRecords) await page(`/vendor/${slugOf(o.vendor)}`);
+  for (const o of retiredButNotEnded) await page(`/vendor/${slugOf(o.vendor)}`);
+});
+
+after(() => { proc?.kill(); });
+
+describe("the sentences an ended offer publishes", () => {
+  it("shares one clause across every form that names the ending", () => {
+    assert.strictEqual(ENDED_OFFER_CLAUSE, "the offer has ended");
+    assert.ok(endedHistorySentence("Acme").includes(ENDED_OFFER_CLAUSE));
+    assert.ok(endedEmptyChangeHistorySentence("Acme").includes(ENDED_OFFER_CLAUSE));
+  });
+
+  it("heads the page and badges it", () => {
+    assert.strictEqual(endedHeadline("Acme"), "Acme — free tier retired");
+    assert.strictEqual(ENDED_BADGE_LABEL, "retired");
+  });
+
+  it("says the ending in the verdict without rating it", () => {
+    assert.strictEqual(
+      endedVerdictSentence(),
+      "This offer has ended — we keep the page for the record and no longer rate it.",
+    );
+  });
+
+  it("says an empty history is not evidence of stability", () => {
+    assert.strictEqual(
+      endedHistorySentence("Acme"),
+      "No recorded pricing changes for Acme — but the offer has ended, so this history describes a tier that is no longer available. An empty history is not evidence of stability here.",
+    );
+  });
+
+  it("says there is nothing to rate", () => {
+    assert.strictEqual(
+      endedReliabilitySentence("Acme"),
+      "Acme has ended this offer, so there is nothing to rate. We keep the page so the question has an answer, but a stability judgement only applies to an offer you can still get.",
+    );
+  });
+
+  it("says the empty history describes a tier that is gone", () => {
+    assert.strictEqual(
+      endedEmptyChangeHistorySentence("Acme"),
+      "Acme has no recorded pricing changes, but the offer has ended — so the empty history describes a tier that is no longer available, not a stable one.",
+    );
+  });
+
+  it("says the ending follows the changes it does hold", () => {
+    assert.strictEqual(ENDED_SINCE_CHANGES_SENTENCE, "The offer has since ended.");
+  });
+});
+
+describe("a tier closed to new accounts is not a free offer", () => {
+  it("has a subject in the index", () => {
+    const carriers = offers.filter(o => /^legacy free$/i.test(o.tier.trim()));
+    assert.ok(carriers.length > 0, "no record carries the Legacy Free tier any more");
+  });
+
+  it("classifies the tier as not free, with the note the gate publishes", () => {
+    assert.deepStrictEqual(classifyTier("Legacy Free"), {
+      class: "not_free",
+      note: "a free tier closed to new accounts",
+    });
+  });
+
+  it("gates every carrier as not_a_free_offer rather than by eligibility", () => {
+    for (const offer of offers.filter(o => /^legacy free$/i.test(o.tier.trim()))) {
+      const gate = gateFor(offer, TODAY);
+      assert.strictEqual(gate?.code, "not_a_free_offer", `${offer.vendor} took a different gate`);
+      assert.strictEqual(gate?.reason, `Tier "${offer.tier}" is a free tier closed to new accounts.`);
+    }
+  });
+
+  it("removes every carrier from its category's qualified set", () => {
+    for (const offer of offers.filter(o => /^legacy free$/i.test(o.tier.trim()))) {
+      const ranking = rankOffers(offers.filter(o => o.category === offer.category), {
+        queryKey: `best-of:${offer.category}`,
+        changes: dealChanges,
+        date: TODAY,
+      });
+      assert.ok(
+        !ranking.qualified.some((q: { offer: Offer }) => q.offer.vendor === offer.vendor),
+        `${offer.vendor} is still ranked in ${offer.category}`,
+      );
+    }
+  });
+
+  it("matches the whole tier string, not a word inside it", () => {
+    for (const near of ["Legacy Free Plus", "Free", "Legacy", "Legacy Free Tier", "Extended Legacy Free"]) {
+      assert.notStrictEqual(
+        classifyTier(near).note,
+        "a free tier closed to new accounts",
+        `${near} was read as a closed legacy tier`,
+      );
+    }
+  });
+});
+
+describe("an ended offer is not rated, on every surface that rates one", () => {
+  it("has subjects in the index", () => {
+    assert.ok(endedRecords.length > 0, "no record carries an ended tier");
+  });
+
+  it("heads the page with the retirement form and badges it retired", async () => {
+    for (const record of endedRecords) {
+      const heading = headingOf(await page(`/vendor/${slugOf(record.vendor)}`));
+      assert.ok(heading.includes(endedHeadline(record.vendor)), `${record.vendor} still heads with the free-tier form`);
+      assert.ok(!/Free Tier \d{4}/.test(heading), `${record.vendor} still heads with a free-tier year`);
+      assert.match(heading, new RegExp(`risk-badge[^>]*>${ENDED_BADGE_LABEL}<`), `${record.vendor} carries no retired badge`);
+    }
+  });
+
+  it("says the offer has ended in the quick verdict", async () => {
+    for (const record of endedRecords) {
+      const html = await page(`/vendor/${slugOf(record.vendor)}`);
+      const verdict = /<div class="quick-verdict">([\s\S]*?)<\/div>/.exec(html);
+      assert.ok(verdict, `${record.vendor} has no quick verdict`);
+      assert.ok(textOf(verdict![1]).includes(endedVerdictSentence()), `${record.vendor} still publishes a rating in its verdict`);
+    }
+  });
+
+  it("says an empty history is not evidence of stability", async () => {
+    for (const record of endedRecords) {
+      const html = await page(`/vendor/${slugOf(record.vendor)}`);
+      const changes = dealChanges.filter(c => c.vendor.toLowerCase() === record.vendor.toLowerCase());
+      if (changes.length > 0) continue;
+      assert.ok(
+        textOf(html).includes(endedHistorySentence(record.vendor)),
+        `${record.vendor} still reads its empty history as a good sign`,
+      );
+    }
+  });
+
+  it("answers the reliability question with nothing to rate", async () => {
+    for (const record of endedRecords) {
+      const html = await page(`/vendor/${slugOf(record.vendor)}`);
+      assert.strictEqual(
+        faqAnswer(html, "free tier reliable"),
+        endedReliabilitySentence(record.vendor),
+        `${record.vendor} still publishes a reliability judgement`,
+      );
+    }
+  });
+
+  it("names the ending in the change-history answer, whichever branch it takes", async () => {
+    for (const record of endedRecords) {
+      const html = await page(`/vendor/${slugOf(record.vendor)}`);
+      const answer = faqAnswer(html, "changed in");
+      assert.ok(answer.length > 0, `${record.vendor} has no change-history answer`);
+      assert.ok(
+        answer.includes(ENDED_OFFER_CLAUSE) || answer.includes(ENDED_SINCE_CHANGES_SENTENCE),
+        `${record.vendor} answers the change question without naming the ending: ${answer}`,
+      );
+      const changes = dealChanges.filter(c => c.vendor.toLowerCase() === record.vendor.toLowerCase());
+      if (changes.length === 0) {
+        assert.strictEqual(answer, endedEmptyChangeHistorySentence(record.vendor));
+      } else {
+        assert.ok(answer.endsWith(ENDED_SINCE_CHANGES_SENTENCE), `${record.vendor} drops the ending after its recorded changes`);
+      }
+    }
+  });
+
+  it("publishes no stability reassurance anywhere on an ended record's page", async () => {
+    const reassurances = [
+      "This is a good sign — stable pricing",
+      "is considered stable",
+      "This is a positive stability signal",
+      "It's stable — zero pricing changes recorded",
+    ];
+    for (const record of endedRecords) {
+      const text = textOf(await page(`/vendor/${slugOf(record.vendor)}`));
+      for (const phrase of reassurances) {
+        assert.ok(!text.includes(phrase), `${record.vendor} still publishes "${phrase}"`);
+      }
+    }
+  });
+});
+
+describe("the retirement branch is decided before the withholding branch", () => {
+  const withheldAndEnded = {
+    level: null,
+    cause: null,
+    changes: [],
+    levelWithheld: "states_no_terms" as const,
+    unconfirmableSince: "",
+    offerEnded: true,
+  };
+
+  it("states the ending rather than our inability to read the page", () => {
+    assert.strictEqual(vendorVerdictSentence(withheldAndEnded), endedVerdictSentence());
+    assert.strictEqual(vendorVerdictWord(withheldAndEnded), null);
+  });
+
+  it("publishes no rating word for an ended offer whose page we can read", () => {
+    const endedOnly = { ...withheldAndEnded, levelWithheld: null, level: "stable" as const };
+    assert.strictEqual(vendorVerdictSentence(endedOnly), endedVerdictSentence());
+    assert.strictEqual(vendorVerdictWord(endedOnly), null);
+  });
+
+  it("still rates a live offer whose page we can read", () => {
+    const live = { ...withheldAndEnded, levelWithheld: null, offerEnded: false, level: "stable" as const };
+    assert.strictEqual(vendorVerdictWord(live), "stable");
+  });
+
+  it("still withholds when the offer has not ended", () => {
+    const withheldOnly = { ...withheldAndEnded, offerEnded: false };
+    assert.notStrictEqual(vendorVerdictSentence(withheldOnly), endedVerdictSentence());
+    assert.strictEqual(vendorVerdictWord(withheldOnly), null);
+  });
+
+  it("covers records that would otherwise never reach the retirement copy", async () => {
+    const withholding = endedRecords.filter(o => o.source_check?.outcome === "states_no_terms");
+    assert.ok(withholding.length > 0, "no ended record withholds a level, so the ordering is untested by the data");
+    for (const record of withholding) {
+      const text = textOf(await page(`/vendor/${slugOf(record.vendor)}`));
+      assert.ok(text.includes(endedVerdictSentence()), `${record.vendor} took the withholding branch instead`);
+    }
+  });
+});
+
+describe("a deprecated offer the ranker still rates keeps its rating", () => {
+  it("has a subject in the index", () => {
+    assert.ok(retiredButNotEnded.length > 0, "no record is retired-worded without being ended");
+  });
+
+  it("is not headed as retired and keeps its published rating", async () => {
+    for (const record of retiredButNotEnded) {
+      const html = await page(`/vendor/${slugOf(record.vendor)}`);
+      const heading = headingOf(html);
+      assert.ok(!heading.includes(endedHeadline(record.vendor)), `${record.vendor} is headed as ended`);
+      assert.ok(!textOf(html).includes(endedVerdictSentence()), `${record.vendor} is told it has ended`);
+    }
+  });
+
+  it("is demoted rather than gated, which is why it still has something to rate", () => {
+    for (const record of retiredButNotEnded) {
+      const ranking = rankOffers(offers.filter(o => o.category === record.category), {
+        queryKey: `best-of:${record.category}`,
+        changes: dealChanges,
+        date: TODAY,
+      });
+      assert.ok(
+        !ranking.excluded.some((e: { offer: Offer }) => e.offer.vendor === record.vendor),
+        `${record.vendor} is gated, so the page should say the offer ended`,
+      );
+    }
+  });
+});
+
+describe("the live catalog keeps the page it had", () => {
+  it("heads all but the ended records with the free-tier form", async () => {
+    const live = offers.filter(o => !offerEnded(o)).slice(0, 60);
+    let headed = 0;
+    for (const record of live) {
+      const heading = headingOf(await page(`/vendor/${slugOf(record.vendor)}`));
+      if (/Free Tier \d{4}/.test(heading)) headed++;
+      assert.ok(!heading.includes("free tier retired"), `${record.vendor} is headed as retired`);
+    }
+    assert.strictEqual(headed, live.length, `${live.length - headed} live records lost the free-tier heading`);
+  });
+});

--- a/test/tier-vocabulary.json
+++ b/test/tier-vocabulary.json
@@ -40,7 +40,6 @@
   "Hobby",
   "Individual",
   "Individual (Free)",
-  "Legacy Free",
   "Lite",
   "Little Lemur",
   "M0 Free",

--- a/test/vendor-verdict.test.ts
+++ b/test/vendor-verdict.test.ts
@@ -14,6 +14,7 @@ import {
 import { CHANGE_DIRECTION, enrichOffers, loadDealChanges, loadOffers, vendorRiskAssessment, classifyStability } from "../dist/data.js";
 import { vendorSlugMap } from "../dist/vendor-slug.js";
 import { levelWithheldReason } from "../dist/source-check.js";
+import { offerEnded, ENDED_BADGE_LABEL } from "../dist/retirement.js";
 import type { DealChange, RiskCause } from "../dist/types.js";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -191,6 +192,8 @@ interface VendorRow {
   slug: string;
   vendor: string;
   expected: "stable" | "caution" | "risky";
+  badge: string;
+  ended: boolean;
   withheld: ReturnType<typeof levelWithheldReason>;
   badgeRendered: boolean;
   sentence: string;
@@ -210,6 +213,7 @@ function vendorRows(): VendorRow[] {
       .sort((a, b) => b.date.localeCompare(a.date));
     const withheld = levelWithheldReason(primary, enriched.link_unreachable);
     const expected = publishedVendorLevel(enriched.risk_level ?? null, enriched.risk_cause ?? null);
+    const ended = offerEnded(primary);
     const unconfirmableSince = enriched.link_unreachable?.last_reachable
       ? ` since ${enriched.link_unreachable.last_reachable}`
       : "";
@@ -217,14 +221,17 @@ function vendorRows(): VendorRow[] {
       slug,
       vendor,
       expected,
+      ended,
+      badge: ended ? ENDED_BADGE_LABEL : expected,
       withheld,
-      badgeRendered: !(enriched.risk_level === null || (enriched.link_unreachable && expected === "stable")),
+      badgeRendered: ended || !(enriched.risk_level === null || (enriched.link_unreachable && expected === "stable")),
       sentence: vendorVerdictSentence({
         level: enriched.risk_level ?? null,
         cause: enriched.risk_cause ?? null,
         changes: vendorChanges,
         levelWithheld: withheld,
         unconfirmableSince,
+        offerEnded: ended,
       }),
       changes: vendorChanges,
     });
@@ -359,8 +366,8 @@ describe("vendor verdict — as rendered", () => {
         const verdict = verdictParagraph(html);
         const cell = comparisonCell(html);
 
-        if (row.badgeRendered && badge !== row.expected) {
-          wrong.push(`${row.slug}: h1 badge is ${badge ?? "absent"}, expected ${row.expected}`);
+        if (row.badgeRendered && badge !== row.badge) {
+          wrong.push(`${row.slug}: h1 badge is ${badge ?? "absent"}, expected ${row.badge}`);
         }
         if (!row.badgeRendered && badge !== null) {
           wrong.push(`${row.slug}: h1 badge renders ${badge} for a rating we are withholding`);


### PR DESCRIPTION
Refs #1235 — acceptance criteria 5 and 6, the last two on the issue.

Every string published here is the PM's, given verbatim on the issue. No wording is mine.

## The bug

`/vendor/oaysus` — a domain that has belonged to a website design agency for weeks — published six separate reassurances that the offer is fine:

| surface | before |
|---|---|
| `<h1>` | *Oaysus **Free Tier 2026*** |
| risk badge | **`stable`**, in green |
| quick verdict | *… **It's stable — zero pricing changes recorded.*** |
| history block | *No recorded pricing changes for Oaysus. **This is a good sign — stable pricing.*** |
| FAQ *reliable* | *Oaysus's free tier is considered **stable**.* |
| FAQ *changed* | *No, Oaysus has had no recorded pricing changes. **This is a positive stability signal.*** |

Criterion 5 is separate: `Legacy Free` fell through `classifyTier` to the free default, so Fly.io — whose own description reads *"no free tier for new accounts"* — was ranked as a free cloud hosting offer.

## Criterion 6

One shared clause, `the offer has ended`, with the four sentence forms the PM specified. They live together in `src/retirement.ts` alongside `recordedTierSentence`, so the vocabulary and the prose that reports it are in one place.

**The ordering point.** The retirement branch is tested **before** `levelWithheld` on all three surfaces that have both. Two of the four ended records are `states_no_terms`, and ordering it after would have given half the population *"We cannot say. The page we cite states no terms we can read"* — a true sentence about our reading rather than about the offer. A mutation for each of the three surfaces moves the branch after withholding; all three are killed.

**The predicate is `offerEnded`, not `offerRetired`.** The loose match also fires on `Free (Deprecated)`, and the ranker **demotes** that record rather than gating it — `/vendor/google-content-api-for-shopping` publishes a `risky` badge off a recorded `product_deprecated` change. Telling that page *"we no longer rate it"* would contradict the rating one screen above. A test asserts the deprecated record keeps its heading and its rating, and a mutation swapping the predicate is killed by it.

## Criterion 5

One row, the PM's:

```ts
{ pattern: /^legacy free$/i, note: "a free tier closed to new accounts" }
```

`gateFor` composes `Tier "Legacy Free" is a free tier closed to new accounts.` from the existing `not_a_free_offer` code and the existing `/criteria` row. Fly.io leaves `qualified`; `/best/free-cloud-hosting` goes from 54 to 53.

**#1236's fixture went red, which is the fixture working.** `Legacy Free` no longer reaches the free default, so `test/tier-vocabulary.json` pinned a string that no longer belongs there. Removed, one line.

## Measurement

Full sitemap sweep, 2,577 paths, pre-change build against this branch, `TZ=UTC`:

```
2,512 byte-identical    65 moved    0 status changes
```

The 65: 33 vendor pages, 29 `/alternative-to` pages, `/best`, `/best/free-cloud-hosting`, `/criteria`.

**Only 4 pages changed anything they say about themselves.** I censused the heading, the badge, the verdict and every FAQ answer except the two that enumerate alternatives, across all 33 moved vendor pages on both builds. The set that moved is exactly the four ended records — Oaysus, Supportivekoala, QRME.SH, GitHub Models.

The other 29 are Cloud Hosting pages whose alternatives list re-seeded when the pool went 54 to 53. Fly.io was named in the top-5 alternatives answer on 5 of them and is now named on none; the remaining 24 differ only in which five of the same pool they show. No vendor's rating word, verdict or reliability answer moved.

`/criteria` moved once, for the new tier rule row — the pattern and the PM's note, rendered by the table that was already there.

## Tests

28 new in `test/retired-vendor-page.test.ts`, plus the expectation model in `test/vendor-verdict.test.ts` taught the retirement branch. 2,991 pass.

`vendorRows()` asserted the old behaviour and went red on all four records — *"h1 badge is retired, expected stable"*. That is the corpus invariant doing its job, so it gained the branch in the same order the page uses rather than an exemption.

**The published strings are pinned literally.** My first pass asserted the rendered page against the same function that composed it, which is a tautology — mutating `endedHistorySentence` to return `""` would have passed, because every string contains `""`. Seven mutations now edit the sentence bodies directly and all seven are killed by literal assertions.

**20 of 21 mutations killed** — `scripts/mutate-1235-vendor-page.sh`.

**The survivor, named.** *"the change answer drops the ending after recorded changes"* survives. The PM asked for the existing count sentence plus `The offer has since ended.` when an ended record does hold changes, and it is implemented — but **no record reaches that branch**. All four ended records have zero change records; the belief that GitHub Models has one does not hold against `data/deal_changes.json`, where the GitHub entries are all Copilot and Actions. The join test asserts the branch by construction, so it starts exercising it the moment a change is recorded for an ended vendor, which is #1103's ground. I would rather report this than pin it with a record I invented.

## Verified end to end

Real MCP `initialize` → `tools/call` against `dist/index.js`, plus a live server census of all four vendor pages and the deprecated control.

## Reported, not fixed

`search_deals` applies no gate at all. `gateFor` gates **163 of 1,580 records**, and every one of them comes back from the tool with no marker — Oaysus is returned as a Cloud Hosting result carrying `"stability": "stable"`, and Fly.io is returned under the tier this PR just classified as not a free offer. The ranked web surfaces and the MCP tool disagree about the same 163 records. Same shape as the eligibility-enum gap reported on #1215 and measured on #1236; unfiled, because the PM has ranked MCP below the web surfaces on traffic.
