### PR TITLE
Read the ranking gate on the vendor page, not one gate code (#1238)

### DIFF
--- a/scripts/mutate-1238.sh
+++ b/scripts/mutate-1238.sh
@@ -1,0 +1,124 @@
+#!/bin/bash
+set -u
+cd "$(dirname "$0")/.." || exit 1
+
+TESTS="test/gated-vendor-answers.test.ts test/eligibility-disclosure.test.ts test/retired-records.test.ts test/retired-vendor-page.test.ts"
+
+run_case() {
+  local name="$1" file="$2" from="$3" to="$4"
+  cp "$file" /tmp/mut-backup
+  python3 - "$file" "$from" "$to" <<'PY'
+import sys
+path, old, new = sys.argv[1], sys.argv[2], sys.argv[3]
+s = open(path).read()
+n = s.count(old)
+if n != 1:
+    print(f"PATTERN-MISS ({n})")
+    sys.exit(3)
+open(path, "w").write(s.replace(old, new))
+PY
+  if [ $? -eq 3 ]; then cp /tmp/mut-backup "$file"; echo "SKIP     $name (pattern not found exactly once)"; return; fi
+  if ! npm run build > /tmp/mut-build.log 2>&1; then
+    cp /tmp/mut-backup "$file"
+    echo "KILLED   $name (build)"
+    return
+  fi
+  TZ=UTC node --test --test-concurrency 1 $TESTS > /tmp/mut-test.log 2>&1
+  local code=$?
+  cp /tmp/mut-backup "$file"
+  if [ $code -ne 0 ]; then
+    echo "KILLED   $name  <- $(grep -m1 '✖ ' /tmp/mut-test.log | sed 's/^ *//')"
+  else
+    echo "SURVIVED $name"
+  fi
+}
+
+run_case "the free-tier answer stops reading the gate" src/serve.ts \
+  '    : primaryGateBeyondEligibility
+    ? `${primaryGateBeyondEligibility.reason} ${levelWithheld ? `${unconfirmedTermsPreamble}${withUnconfirmedTermsCaveat(storedTerms)}` : storedTerms}`
+    : levelWithheld
+    ? `${eligibilityGateSentence}${unconfirmedTermsPreamble}Our stored record says' \
+  '    : levelWithheld
+    ? `${eligibilityGateSentence}${unconfirmedTermsPreamble}Our stored record says'
+
+run_case "the free-tier answer reads only the tier rule" src/serve.ts \
+  '  const primaryGateBeyondEligibility = primaryGate && primaryGate.code !== "eligibility_restricted" ? primaryGate : null;' \
+  '  const primaryGateBeyondEligibility = primaryGate && primaryGate.code === "not_a_free_offer" ? primaryGate : null;'
+
+run_case "the free-tier answer is tested after the withheld level" src/serve.ts \
+  '    : primaryGateBeyondEligibility
+    ? `${primaryGateBeyondEligibility.reason} ${levelWithheld ? `${unconfirmedTermsPreamble}${withUnconfirmedTermsCaveat(storedTerms)}` : storedTerms}`
+    : levelWithheld' \
+  '    : levelWithheld && false
+    ? `${primaryGateBeyondEligibility!.reason} ${levelWithheld ? `${unconfirmedTermsPreamble}${withUnconfirmedTermsCaveat(storedTerms)}` : storedTerms}`
+    : levelWithheld'
+
+run_case "the gated free-tier answer drops the stored terms" src/serve.ts \
+  '? `${primaryGateBeyondEligibility.reason} ${levelWithheld ? `${unconfirmedTermsPreamble}${withUnconfirmedTermsCaveat(storedTerms)}` : storedTerms}`' \
+  '? `${primaryGateBeyondEligibility.reason}`'
+
+run_case "the gated free-tier answer drops the unverified caveat" src/serve.ts \
+  '? `${primaryGateBeyondEligibility.reason} ${levelWithheld ? `${unconfirmedTermsPreamble}${withUnconfirmedTermsCaveat(storedTerms)}` : storedTerms}`' \
+  '? `${primaryGateBeyondEligibility.reason} ${storedTerms}`'
+
+run_case "the tier answer stops reading the gate" src/serve.ts \
+  '    : primaryGateBeyondEligibility
+    ? `${primaryGateBeyondEligibility.reason} ${levelWithheld ? `${unconfirmedTermsPreamble}${withUnconfirmedTermsCaveat(primary.description)}` : primary.description}`
+    : eligibilityGateSentence + (levelWithheld' \
+  '    : eligibilityGateSentence + (levelWithheld'
+
+run_case "the production answer stops reading the gate" src/serve.ts \
+  '  const faqProductionAnswer = productionGate
+    ? `${productionGate.reason} ${NO_FREE_TIER_FOR_PRODUCTION}`
+    : eligibilityGateSentence' \
+  '  const faqProductionAnswer = eligibilityGateSentence'
+
+run_case "the production answer takes the expiry gate only" src/serve.ts \
+  'const GATES_LEAVING_NO_FREE_TIER: readonly string[] = ["not_a_free_offer", "offer_expired"];' \
+  'const GATES_LEAVING_NO_FREE_TIER: readonly string[] = ["offer_expired"];'
+
+run_case "the production answer takes the tier gate only" src/serve.ts \
+  'const GATES_LEAVING_NO_FREE_TIER: readonly string[] = ["not_a_free_offer", "offer_expired"];' \
+  'const GATES_LEAVING_NO_FREE_TIER: readonly string[] = ["not_a_free_offer"];'
+
+run_case "the production answer widens to every gate" src/serve.ts \
+  '  const productionGate = primaryGate && GATES_LEAVING_NO_FREE_TIER.includes(primaryGate.code) ? primaryGate : null;' \
+  '  const productionGate = primaryGate;'
+
+run_case "the production sentence changes" src/serve.ts \
+  'const NO_FREE_TIER_FOR_PRODUCTION = "There is no free tier here to run in production.";' \
+  'const NO_FREE_TIER_FOR_PRODUCTION = "This offer is not free.";'
+
+run_case "the stability rating returns to a gated record" src/serve.ts \
+  "\${primaryGate ? \"It\" : \"We rate it stable and it\"} offers" \
+  '${"We rate it stable and it"} offers'
+
+run_case "the stability rating leaves every record" src/serve.ts \
+  "\${primaryGate ? \"It\" : \"We rate it stable and it\"} offers" \
+  '${"It"} offers'
+
+run_case "the heading stops reading the title predicate" src/serve.ts \
+  '  const headline = offerHasEnded ? endedHeadline(vendorName) : hasFree ? freeTierHeadline : pricingHeadline;' \
+  '  const headline = offerHasEnded ? endedHeadline(vendorName) : freeTierHeadline;'
+
+run_case "the heading takes the pricing form everywhere" src/serve.ts \
+  '  const headline = offerHasEnded ? endedHeadline(vendorName) : hasFree ? freeTierHeadline : pricingHeadline;' \
+  '  const headline = offerHasEnded ? endedHeadline(vendorName) : pricingHeadline;'
+
+run_case "the gate line reads eligibility only" src/serve.ts \
+  '  const linedGate = primaryGate && primaryGate.code !== "offer_retired" ? primaryGate : null;' \
+  '  const linedGate = primaryEligibilityGate;'
+
+run_case "the gate line renders on every gated page" src/serve.ts \
+  '  const linedGate = primaryGate && primaryGate.code !== "offer_retired" ? primaryGate : null;' \
+  '  const linedGate = primaryGate;'
+
+run_case "the gate line drops the reason" src/serve.ts \
+  '<strong style="color:#d29922;font-family:var(--mono)">${escHtmlServer(linedGate.code)}</strong> ${escHtmlServer(linedGate.reason)} <a href="${CRITERIA_PATH}#gates">' \
+  '<strong style="color:#d29922;font-family:var(--mono)">${escHtmlServer(linedGate.code)}</strong> <a href="${CRITERIA_PATH}#gates">'
+
+run_case "the gate reads a fixed date rather than the served one" src/serve.ts \
+  '  const primaryGate = gateFor(primary, servedOn);' \
+  '  const primaryGate = gateFor(primary, "2020-01-01");'
+
+npm run build > /tmp/mut-build.log 2>&1 && echo "rebuilt from restored source"

--- a/src/serve.ts
+++ b/src/serve.ts
@@ -41,7 +41,7 @@ import { faqPageJsonLd, type FaqItem } from "./faq-provenance.js";
 import { SSE_KEEPALIVE_FRAME, keepaliveIntervalMs, sessionRecoveryBody } from "./mcp-stream.js";
 import { ASSISTANTS_API_SHUTDOWN } from "./assistants-shutdown.js";
 import { discontinuedOnOrBefore, PRODUCT_DEPRECATED } from "./product-deprecation.js";
-import { rankOffers, rankForListing, rotateListing, utcDate, CRITERIA_PATH, DEMOTE_ONLY_POLICY, DISCLOSURE_RATIONALE, TIE_BREAK_ALGORITHM, GATE_TABLE, DEMERIT_TABLE, NOT_FREE_TIER_RULES, TIME_LIMITED_TIER_RULES, type TieBreak } from "./ranking.js";
+import { rankOffers, rankForListing, rotateListing, utcDate, gateFor, CRITERIA_PATH, DEMOTE_ONLY_POLICY, DISCLOSURE_RATIONALE, TIE_BREAK_ALGORITHM, GATE_TABLE, DEMERIT_TABLE, NOT_FREE_TIER_RULES, TIME_LIMITED_TIER_RULES, type TieBreak } from "./ranking.js";
 import type { RankedEntry, RankingResult } from "./ranking.js";
 import { eligibilityGate, gatedShareDescriptionClause, gatedShareLede, publishableEligibilityConditions } from "./eligibility.js";
 import { verificationLedger, QUARANTINE_AFTER_FAILURES } from "./verification-state.js";
@@ -3668,6 +3668,10 @@ const erosionAffectedCategories = (() => {
 
 const CURATED_ALTS_HEADING = "Recommended Migration Targets";
 
+const NO_FREE_TIER_FOR_PRODUCTION = "There is no free tier here to run in production.";
+
+const GATES_LEAVING_NO_FREE_TIER: readonly string[] = ["not_a_free_offer", "offer_expired"];
+
 function curatedAltsNote(vendorName: string): string {
   return `These alternatives were identified from ${escHtmlServer(vendorName)}&rsquo;s pricing changes as recommended replacements.`;
 }
@@ -3713,8 +3717,12 @@ function buildVendorPage(slug: string): string | null {
 
   const primaryEligibilityGate = eligibilityGate(primary);
   const primaryEligibilityConditions = publishableEligibilityConditions(primary);
-  const eligibilityGateLine = primaryEligibilityGate
-    ? `\n  <p class="eligibility-gate-line" style="margin:.4rem 0 .6rem;font-size:.9rem;color:var(--text-muted)"><strong style="color:#d29922;font-family:var(--mono)">${escHtmlServer(primaryEligibilityGate.code)}</strong> ${escHtmlServer(primaryEligibilityGate.reason)} <a href="${CRITERIA_PATH}#gates">How we use this</a>.</p>${
+  const primaryGate = gateFor(primary, servedOn);
+  const primaryGateBeyondEligibility = primaryGate && primaryGate.code !== "eligibility_restricted" ? primaryGate : null;
+  const productionGate = primaryGate && GATES_LEAVING_NO_FREE_TIER.includes(primaryGate.code) ? primaryGate : null;
+  const linedGate = primaryGate && primaryGate.code !== "offer_retired" ? primaryGate : null;
+  const gateLine = linedGate
+    ? `\n  <p class="gate-line" style="margin:.4rem 0 .6rem;font-size:.9rem;color:var(--text-muted)"><strong style="color:#d29922;font-family:var(--mono)">${escHtmlServer(linedGate.code)}</strong> ${escHtmlServer(linedGate.reason)} <a href="${CRITERIA_PATH}#gates">How we use this</a>.</p>${
         primaryEligibilityConditions.length > 0
           ? `\n  <ul class="eligibility-conditions" style="margin:.2rem 0 .6rem 1.1rem;padding:0;font-size:.9rem;color:var(--text-muted)">${primaryEligibilityConditions.map(c => `<li>${escHtmlServer(c)}</li>`).join("")}</ul>`
           : ""
@@ -3772,9 +3780,12 @@ function buildVendorPage(slug: string): string | null {
   const currentYear = new Date().getFullYear();
   const retiredSentence = offerRetired(primary) ? recordedTierSentence(vendorName, primary.tier) : "";
   const hasFree = !retiredSentence && primary.tier.toLowerCase() !== "none" && !primary.description.toLowerCase().includes("no free tier");
+  const freeTierHeadline = `${vendorName} Free Tier ${currentYear}`;
+  const pricingHeadline = `${vendorName} Pricing ${currentYear}`;
+  const headline = offerHasEnded ? endedHeadline(vendorName) : hasFree ? freeTierHeadline : pricingHeadline;
   const title = hasFree
-    ? `${vendorName} Free Tier ${currentYear}: Limits, Pricing & What Changed | AgentDeals`
-    : `${vendorName} Pricing ${currentYear}: Plans, Costs & Free Alternatives | AgentDeals`;
+    ? `${freeTierHeadline}: Limits, Pricing & What Changed | AgentDeals`
+    : `${pricingHeadline}: Plans, Costs & Free Alternatives | AgentDeals`;
   const descLimits = primary.description.slice(0, 100).replace(/\.\s.*$/, "");
   const verifiedMonth = (() => { const d = primary.verifiedDate.split("-"); const months = ["January","February","March","April","May","June","July","August","September","October","November","December"]; return `${months[parseInt(d[1],10)-1]} ${d[0]}`; })();
   const verifiedSentence = discontinuedOn
@@ -4104,6 +4115,8 @@ ${allCompareLinks.join("\n")}
     : "";
   const faqFreeAnswer = retiredSentence
     ? `${retiredSentence} ${storedTerms}`
+    : primaryGateBeyondEligibility
+    ? `${primaryGateBeyondEligibility.reason} ${levelWithheld ? `${unconfirmedTermsPreamble}${withUnconfirmedTermsCaveat(storedTerms)}` : storedTerms}`
     : levelWithheld
     ? `${eligibilityGateSentence}${unconfirmedTermsPreamble}Our stored record says ${vendorName} offers a free tier: ${primary.tier}. ${withUnconfirmedTermsCaveat(storedTerms)}${eligibilityConditionsSentence}`
     : primaryEligibilityGate
@@ -4111,6 +4124,8 @@ ${allCompareLinks.join("\n")}
     : `Yes, ${vendorName} offers a free tier: ${primary.tier}. ${storedTerms}`;
   const faqTierAnswer = retiredSentence
     ? `${retiredSentence} ${primary.description}`
+    : primaryGateBeyondEligibility
+    ? `${primaryGateBeyondEligibility.reason} ${levelWithheld ? `${unconfirmedTermsPreamble}${withUnconfirmedTermsCaveat(primary.description)}` : primary.description}`
     : eligibilityGateSentence + (levelWithheld
     ? `${unconfirmedTermsPreamble}Our stored record calls ${vendorName}'s free tier "${primary.tier}". ${withUnconfirmedTermsCaveat(primary.description)}`
     : `${vendorName}'s free tier is called "${primary.tier}". ${primary.description}`);
@@ -4125,11 +4140,13 @@ ${allCompareLinks.join("\n")}
     : `${vendorName}'s free tier is considered risky because of one specific recorded change${riskCause ? `, ${changeDateClause(riskCause)}: ${riskCause.summary}` : "."} Consider alternatives.`;
   const faqCategoryAnswer = `${vendorName} is categorized under ${allCategories.join(", ")} on AgentDeals.${alternatives.length > 0 ? ` Other vendors in ${primary.category} include ${alternatives.slice(0, 5).map(a => a.vendor).join(", ")}.` : ""}`;
 
-  const faqProductionAnswer = eligibilityGateSentence + (levelWithheld
+  const faqProductionAnswer = productionGate
+    ? `${productionGate.reason} ${NO_FREE_TIER_FOR_PRODUCTION}`
+    : eligibilityGateSentence + (levelWithheld
     ? `${withheldLevelSentence(levelWithheld, vendorName, unconfirmableSince)} We cannot confirm what this offer provides today, so we are not recommending it for production or for anything else until we can.`
     : hasFree
     ? (riskLevel === "stable"
-      ? `${vendorName}'s free tier can be suitable for small production workloads and side projects. We rate it stable and it offers ${escHtmlServer(keyLimit)}, so it's a reasonable starting point.${vendorChanges.length > 0 ? ` ${narrowingSentence(vendorChanges)}` : ""} Monitor your usage against the limits and have an upgrade plan ready.`
+      ? `${vendorName}'s free tier can be suitable for small production workloads and side projects. ${primaryGate ? "It" : "We rate it stable and it"} offers ${escHtmlServer(keyLimit)}, so it's a reasonable starting point.${vendorChanges.length > 0 ? ` ${narrowingSentence(vendorChanges)}` : ""} Monitor your usage against the limits and have an upgrade plan ready.`
       : `${vendorName}'s free tier is usable for prototyping and development, but we rate it ${riskLevel}${riskCause ? ` because of one recorded ${changeKindNoun(riskCause.change_type)}, ${changeDateClause(riskCause)}` : ""}. Consider alternatives with more stable pricing for critical services.`)
     : `${vendorName} does not offer a free tier for production use. Consider free alternatives in ${primary.category}.`);
   const faqChangedAnswer = vendorChanges.length > 0
@@ -4262,7 +4279,7 @@ ${mcpCtaCss()}
 <div class="container">
   ${buildGlobalNav("categories")}
   <div class="breadcrumb"><a href="/">AgentDeals</a> &rsaquo; <a href="/vendor">Vendors</a> &rsaquo; ${escHtmlServer(vendorName)}</div>
-  <h1>${offerHasEnded ? escHtmlServer(endedHeadline(vendorName)) : `${escHtmlServer(vendorName)} Free Tier ${currentYear}`}${h1RiskBadge}</h1>${eligibilityGateLine}
+  <h1>${escHtmlServer(headline)}${h1RiskBadge}</h1>${gateLine}
 ${riskCauseLine}
 ${linkUnreachableLine}
 ${productRoleLine}${productSubtypesLine}

--- a/test/eligibility-disclosure.test.ts
+++ b/test/eligibility-disclosure.test.ts
@@ -7,7 +7,7 @@ import { fileURLToPath } from "node:url";
 
 const { eligibilityGate, publishableEligibilityConditions, CONDITION_RECORDING_AN_UNREAD_PROGRAM } =
   await import("../dist/eligibility.js");
-const { gateFor } = await import("../dist/ranking.js");
+const { gateFor, utcDate } = await import("../dist/ranking.js");
 
 type Offer = import("../src/types.ts").Offer;
 
@@ -122,7 +122,7 @@ describe("a vendor page whose record is gated on eligibility says so", () => {
   });
 
   it("still answers yes where the page renders an ungated record for a vendor that also holds a gated one", () => {
-    const controls = rendered.filter(p => !p.offer.eligibility);
+    const controls = rendered.filter(p => !p.offer.eligibility && !gateFor(p.offer, utcDate()));
     assert.ok(
       controls.length > 0,
       "every vendor holding a gated record now renders it, so the over-fire control has no subject",
@@ -132,7 +132,7 @@ describe("a vendor page whose record is gated on eligibility says so", () => {
         (faqAnswer(p.html, `Is ${p.vendor} free?`) ?? "").startsWith("Yes"),
         `${p.slug} lost an answer it was entitled to`,
       );
-      assert.ok(!p.html.includes("eligibility-gate-line"), `${p.slug} renders a gate it does not carry`);
+      assert.ok(!p.html.includes("gate-line"), `${p.slug} renders a gate it does not carry`);
     }
   });
 
@@ -163,7 +163,7 @@ describe("a vendor page whose record is gated on eligibility says so", () => {
       "the placeholder condition is gone from the data, so this branch has no subject",
     );
     for (const p of placeholderOnly) {
-      assert.ok(p.html.includes("eligibility-gate-line"), `${p.slug} states no restriction`);
+      assert.ok(p.html.includes("gate-line"), `${p.slug} states no restriction`);
       assert.ok(!p.html.includes(escapeHtml(CONDITION_RECORDING_AN_UNREAD_PROGRAM)), `${p.slug} publishes the placeholder`);
     }
   });

--- a/test/gated-vendor-answers.test.ts
+++ b/test/gated-vendor-answers.test.ts
@@ -1,0 +1,349 @@
+import { describe, it, before, after } from "node:test";
+import assert from "node:assert";
+import { spawn, type ChildProcess } from "node:child_process";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const { gateFor, utcDate } = await import("../dist/ranking.js");
+const { vendorSlugMap } = await import("../dist/vendor-slug.js");
+const { offerEnded } = await import("../dist/retirement.js");
+
+type Offer = import("../src/types.ts").Offer;
+type Gate = { code: string; reason: string };
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO = path.join(__dirname, "..");
+
+const offers: Offer[] = JSON.parse(readFileSync(path.join(REPO, "data", "index.json"), "utf-8")).offers;
+const TODAY = utcDate();
+
+const PAY_AS_YOU_GO_REASON = 'Tier "Pay-as-you-go" is usage-billed from the first request.';
+const DIGITALOCEAN_EXPIRY_REASON = "Offer expired on 2026-06-30.";
+const NO_FREE_TIER_FOR_PRODUCTION = "There is no free tier here to run in production.";
+const STABLE_RATING_CLAUSE = "We rate it stable and";
+const RECOMMENDATION_CLAUSE = "so it's a reasonable starting point";
+
+const UNGATED_PAGES_ANSWERING_YES = 745;
+const UNGATED_PAGES_RECOMMENDING = 582;
+
+let port = 0;
+let proc: ChildProcess | null = null;
+
+function startServer(): Promise<ChildProcess> {
+  return new Promise((resolve, reject) => {
+    const child = spawn("node", [path.join(REPO, "dist", "serve.js")], {
+      stdio: ["pipe", "pipe", "pipe"],
+      env: { ...process.env, PORT: "0", BASE_URL: "http://localhost", TZ: "UTC" },
+    });
+    const timeout = setTimeout(() => { child.kill(); reject(new Error("Server startup timeout")); }, 60000);
+    child.stderr!.on("data", (data: Buffer) => {
+      const m = data.toString().match(/running on http:\/\/localhost:(\d+)/);
+      if (m) { port = parseInt(m[1], 10); clearTimeout(timeout); resolve(child); }
+    });
+    child.on("error", (e) => { clearTimeout(timeout); reject(e); });
+  });
+}
+
+const pages = new Map<string, string>();
+
+async function page(pathname: string): Promise<string> {
+  const cached = pages.get(pathname);
+  if (cached !== undefined) return cached;
+  const res = await fetch(`http://localhost:${port}${pathname}`);
+  const body = await res.text();
+  pages.set(pathname, body);
+  return body;
+}
+
+async function fetchAll(paths: string[], workers = 12): Promise<void> {
+  const queue = paths.filter(p => !pages.has(p));
+  let next = 0;
+  await Promise.all(
+    Array.from({ length: Math.min(workers, queue.length) }, async () => {
+      while (next < queue.length) await page(queue[next++]);
+    }),
+  );
+}
+
+function jsonLdBlocks(html: string): Record<string, any>[] {
+  const out: Record<string, any>[] = [];
+  for (const m of html.matchAll(/<script type="application\/ld\+json">([\s\S]*?)<\/script>/g)) {
+    try { out.push(JSON.parse(m[1])); } catch { continue; }
+  }
+  return out;
+}
+
+function blockOfType(html: string, type: string): Record<string, any> | undefined {
+  return jsonLdBlocks(html).find(b => b["@type"] === type);
+}
+
+function faqAnswer(html: string, prefix: string): string {
+  const faq = blockOfType(html, "FAQPage");
+  const item = faq?.mainEntity?.find((q: { name: string }) => q.name.startsWith(prefix));
+  return item?.acceptedAnswer?.text ?? "";
+}
+
+function textOf(html: string): string {
+  return html.replace(/<[^>]*>/g, " ").replace(/&quot;/g, '"').replace(/&amp;/g, "&").replace(/\s+/g, " ").trim();
+}
+
+function headingOf(html: string): string {
+  const m = /<h1>([\s\S]*?)<\/h1>/.exec(html);
+  return m ? textOf(m[1]) : "";
+}
+
+function titleOf(html: string): string {
+  const m = /<title>([\s\S]*?)<\/title>/.exec(html);
+  return m ? textOf(m[1]) : "";
+}
+
+function gateLineOf(html: string): string | null {
+  const m = /<p class="gate-line"[\s\S]*?<\/p>/.exec(html);
+  return m ? textOf(m[0]) : null;
+}
+
+type VendorPage = { slug: string; vendor: string; primary: Offer; gate: Gate | null; html: string };
+
+const primaries: { slug: string; vendor: string; primary: Offer }[] = [];
+for (const [slug, vendor] of vendorSlugMap.entries()) {
+  const vendorOffers = offers.filter(o => o.vendor === vendor);
+  if (vendorOffers.length === 0) continue;
+  primaries.push({ slug, vendor, primary: vendorOffers[0] });
+}
+
+const rendered: VendorPage[] = [];
+
+before(async () => {
+  proc = await startServer();
+  await fetchAll(primaries.map(p => `/vendor/${p.slug}`));
+  for (const p of primaries) {
+    rendered.push({ ...p, gate: gateFor(p.primary, TODAY), html: await page(`/vendor/${p.slug}`) });
+  }
+});
+
+after(() => { proc?.kill(); });
+
+const gated = () => rendered.filter(p => p.gate);
+const ungated = () => rendered.filter(p => !p.gate);
+const freeAnswer = (p: VendorPage) => faqAnswer(p.html, `Is ${p.vendor} free?`);
+const productionAnswer = (p: VendorPage) => faqAnswer(p.html, `Is ${p.vendor}'s free tier good for production?`);
+
+describe("the page a gated record renders does not answer the free-tier question with yes", () => {
+  it("renders one page per vendor and reads the record that page renders", () => {
+    assert.ok(rendered.length > 1500, `only ${rendered.length} vendor pages rendered`);
+    for (const p of rendered) {
+      assert.strictEqual(
+        blockOfType(p.html, "WebPage")?.mainEntity?.offers?.description,
+        p.primary.tier,
+        `/vendor/${p.slug} renders a record other than the first this vendor holds`,
+      );
+    }
+  });
+
+  it("holds a subject for every gate code the ranker can return on this data", () => {
+    const codes = new Set(gated().map(p => p.gate!.code));
+    assert.ok(codes.has("not_a_free_offer"), "no vendor page renders a record gated as not_a_free_offer");
+    assert.ok(codes.has("offer_expired"), "no vendor page renders a record gated as offer_expired");
+    assert.ok(codes.has("eligibility_restricted"), "no vendor page renders a record gated on eligibility");
+    assert.ok(codes.has("offer_retired"), "no vendor page renders a record gated as offer_retired");
+  });
+
+  it("answers no gated record with yes, whichever code gates it", () => {
+    const offenders = gated()
+      .filter(p => freeAnswer(p).startsWith("Yes"))
+      .map(p => `${p.slug} (${p.gate!.code})`);
+    assert.deepStrictEqual(offenders, []);
+  });
+
+  it("opens that answer with the sentence the gate composes", () => {
+    for (const p of gated().filter(x => x.gate!.code !== "eligibility_restricted" && !offerEnded(x.primary))) {
+      assert.ok(
+        freeAnswer(p).startsWith(p.gate!.reason),
+        `/vendor/${p.slug} opens with ${freeAnswer(p).slice(0, 70)}`,
+      );
+    }
+  });
+
+  it("states the terms the record does hold after that sentence", () => {
+    for (const p of gated().filter(x => x.gate!.code !== "eligibility_restricted" && !offerEnded(x.primary))) {
+      const answer = freeAnswer(p);
+      const opening = p.primary.description.slice(0, 60);
+      assert.ok(
+        answer.includes(opening),
+        `/vendor/${p.slug} drops the stored terms: ${answer.slice(0, 120)}`,
+      );
+    }
+  });
+
+  it("publishes the composed sentence verbatim on the pages the issue names", () => {
+    const stripe = rendered.find(p => p.slug === "stripe")!;
+    const turbopuffer = rendered.find(p => p.slug === "turbopuffer")!;
+    const digitalocean = rendered.find(p => p.slug === "digitalocean")!;
+    assert.ok(freeAnswer(stripe).startsWith(PAY_AS_YOU_GO_REASON), freeAnswer(stripe).slice(0, 90));
+    assert.ok(freeAnswer(turbopuffer).startsWith(PAY_AS_YOU_GO_REASON), freeAnswer(turbopuffer).slice(0, 90));
+    assert.ok(freeAnswer(digitalocean).startsWith(DIGITALOCEAN_EXPIRY_REASON), freeAnswer(digitalocean).slice(0, 90));
+  });
+
+  it("names no free tier in the tier answer either", () => {
+    const subjects = gated().filter(p => p.gate!.code !== "eligibility_restricted" && !offerEnded(p.primary));
+    assert.ok(subjects.length > 0, "no vendor page renders a record gated outside eligibility");
+    for (const p of subjects) {
+      const answer = faqAnswer(p.html, `What is ${p.vendor}'s free tier?`);
+      assert.ok(answer.startsWith(p.gate!.reason), `/vendor/${p.slug} opens with ${answer.slice(0, 70)}`);
+      assert.ok(
+        !answer.includes(`${p.vendor}'s free tier is called`),
+        `/vendor/${p.slug} still names a free tier`,
+      );
+    }
+  });
+
+  it("keeps the unverified-terms caveat where the source check also withholds the level", () => {
+    const withheld = gated().filter(
+      p => p.gate!.code === "not_a_free_offer" && p.primary.source_check && p.primary.source_check.outcome !== "ok",
+    );
+    assert.ok(withheld.length > 0, "no gated record's source check withholds the level, so this branch has no subject");
+    for (const p of withheld) {
+      const answer = freeAnswer(p);
+      assert.ok(answer.startsWith(p.gate!.reason), `/vendor/${p.slug} leads with our reading rather than the tier`);
+      assert.ok(
+        answer.includes("treat them as unverified"),
+        `/vendor/${p.slug} drops the caveat: ${answer.slice(0, 120)}`,
+      );
+      assert.ok(
+        !answer.includes(`offers a free tier: ${p.primary.tier}`),
+        `/vendor/${p.slug} still says the record holds a free tier`,
+      );
+    }
+  });
+});
+
+describe("the ungated pages keep the answer they had", () => {
+  it("answers yes on every ungated record nothing else withholds", () => {
+    const plainlyFree = ungated().filter(
+      p => p.primary.source_check?.outcome === "ok"
+        && p.primary.tier.toLowerCase() !== "none"
+        && !p.primary.description.toLowerCase().includes("no free tier"),
+    );
+    assert.ok(plainlyFree.length > 100, `only ${plainlyFree.length} ungated pages are plainly free`);
+    const quiet = plainlyFree.filter(p => !freeAnswer(p).startsWith("Yes")).map(p => p.slug);
+    assert.deepStrictEqual(quiet, []);
+  });
+
+  it("counts at least as many ungated pages answering yes as the census found", () => {
+    const answering = ungated().filter(p => freeAnswer(p).startsWith("Yes")).length;
+    assert.ok(
+      answering >= UNGATED_PAGES_ANSWERING_YES,
+      `${answering} ungated pages answer yes, down from ${UNGATED_PAGES_ANSWERING_YES}`,
+    );
+  });
+
+  it("counts at least as many ungated pages recommending the tier for production", () => {
+    const recommending = ungated().filter(p => productionAnswer(p).includes(RECOMMENDATION_CLAUSE)).length;
+    assert.ok(
+      recommending >= UNGATED_PAGES_RECOMMENDING,
+      `${recommending} ungated pages recommend the tier, down from ${UNGATED_PAGES_RECOMMENDING}`,
+    );
+  });
+
+  it("still rates those tiers stable in the production answer", () => {
+    const rating = ungated().filter(p => productionAnswer(p).includes(STABLE_RATING_CLAUSE)).length;
+    assert.ok(rating >= UNGATED_PAGES_RECOMMENDING, `only ${rating} ungated pages still carry the stable rating`);
+  });
+});
+
+describe("the production answer reads the same gate", () => {
+  it("recommends no record gated as not a free offer or as expired", () => {
+    const subjects = gated().filter(p => p.gate!.code === "not_a_free_offer" || p.gate!.code === "offer_expired");
+    assert.ok(subjects.length > 0, "no record is gated as not a free offer or as expired");
+    for (const p of subjects) {
+      assert.strictEqual(
+        productionAnswer(p),
+        `${p.gate!.reason} ${NO_FREE_TIER_FOR_PRODUCTION}`,
+        `/vendor/${p.slug}`,
+      );
+    }
+  });
+
+  it("publishes that answer verbatim on the pages the issue names", () => {
+    const stripe = rendered.find(p => p.slug === "stripe")!;
+    assert.strictEqual(
+      productionAnswer(stripe),
+      `${PAY_AS_YOU_GO_REASON} ${NO_FREE_TIER_FOR_PRODUCTION}`,
+    );
+  });
+
+  it("volunteers no stability rating on a record the ranked surfaces refuse to rate", () => {
+    const offenders = gated().filter(p => productionAnswer(p).includes(STABLE_RATING_CLAUSE)).map(p => p.slug);
+    assert.deepStrictEqual(offenders, []);
+  });
+
+  it("keeps the restriction prefix and the rest of the sentence on an eligibility-gated record", () => {
+    const subjects = gated().filter(
+      p => p.gate!.code === "eligibility_restricted" && productionAnswer(p).includes(RECOMMENDATION_CLAUSE),
+    );
+    assert.ok(subjects.length > 0, "no eligibility-gated page still recommends the tier");
+    for (const p of subjects) {
+      const answer = productionAnswer(p);
+      assert.ok(answer.startsWith(p.gate!.reason), `/vendor/${p.slug} drops the restriction`);
+      assert.ok(answer.includes(`${p.vendor}'s free tier can be suitable for small production workloads`), p.slug);
+      assert.ok(answer.includes(`It offers `), `/vendor/${p.slug}: ${answer.slice(0, 160)}`);
+    }
+  });
+});
+
+describe("the heading agrees with the title on the same page", () => {
+  it("uses the free-tier form in both places or in neither", () => {
+    const disagreeing: string[] = [];
+    for (const p of rendered) {
+      const titleClaimsFree = / Free Tier \d{4}:/.test(titleOf(p.html));
+      const headingClaimsFree = / Free Tier \d{4}\b/.test(headingOf(p.html));
+      if (titleClaimsFree !== headingClaimsFree) disagreeing.push(p.slug);
+    }
+    assert.deepStrictEqual(disagreeing, []);
+  });
+
+  it("heads a page whose title withholds the free-tier form with the pricing form", () => {
+    const withheld = rendered.filter(p => !offerEnded(p.primary) && !/ Free Tier \d{4}:/.test(titleOf(p.html)));
+    assert.ok(withheld.length > 0, "every live vendor page titles itself as a free tier");
+    for (const p of withheld) {
+      assert.ok(
+        headingOf(p.html).startsWith(`${p.vendor} Pricing `),
+        `/vendor/${p.slug} is headed ${headingOf(p.html)}`,
+      );
+    }
+  });
+});
+
+describe("a reader sees why the record is gated without opening the FAQ", () => {
+  it("carries a gate line on every gated page except the ended ones", () => {
+    for (const p of gated().filter(x => x.gate!.code !== "offer_retired")) {
+      const line = gateLineOf(p.html);
+      assert.ok(line, `/vendor/${p.slug} states no gate above the fold`);
+      assert.ok(line!.includes(p.gate!.code), `/vendor/${p.slug} names no gate code`);
+      assert.ok(line!.includes(p.gate!.reason), `/vendor/${p.slug} states no reason: ${line}`);
+    }
+  });
+
+  it("carries none on an ungated page", () => {
+    const offenders = ungated().filter(p => gateLineOf(p.html) !== null).map(p => p.slug);
+    assert.deepStrictEqual(offenders, []);
+  });
+
+  it("carries none on an ended page, which states the ending in its own heading", () => {
+    const ended = rendered.filter(p => offerEnded(p.primary));
+    assert.ok(ended.length > 0, "no record in the index has ended, so this control has no subject");
+    for (const p of ended) {
+      assert.strictEqual(gateLineOf(p.html), null, `/vendor/${p.slug} repeats the ending as a gate line`);
+      assert.ok(headingOf(p.html).includes("free tier retired"), `/vendor/${p.slug} is headed ${headingOf(p.html)}`);
+    }
+  });
+
+  it("states the expiry date on the page the issue names", () => {
+    const digitalocean = rendered.find(p => p.slug === "digitalocean")!;
+    assert.ok(
+      (gateLineOf(digitalocean.html) ?? "").includes(DIGITALOCEAN_EXPIRY_REASON),
+      gateLineOf(digitalocean.html) ?? "no gate line",
+    );
+  });
+});

--- a/test/retired-records.test.ts
+++ b/test/retired-records.test.ts
@@ -6,6 +6,7 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 
 const { offerRetired, recordedTierSentence } = await import("../dist/retirement.js");
+const { gateFor, utcDate } = await import("../dist/ranking.js");
 
 type Offer = import("../src/types.ts").Offer;
 
@@ -197,6 +198,7 @@ describe("a record that is not retired keeps everything the gate would take away
   it("still answers yes where nothing else withholds the answer", () => {
     const plainlyFree = renderedVendorPages.filter(
       p => !offerRetired(p.offer) && !p.offer.eligibility && p.offer.source_check?.outcome === "ok"
+        && !gateFor(p.offer, utcDate())
         && p.offer.tier.toLowerCase() !== "none"
         && !p.offer.description.toLowerCase().includes("no free tier"),
     );

--- a/test/retired-vendor-page.test.ts
+++ b/test/retired-vendor-page.test.ts
@@ -71,6 +71,11 @@ function headingOf(html: string): string {
   return m ? m[1] : "";
 }
 
+function titleOf(html: string): string {
+  const m = /<title>([\s\S]*?)<\/title>/.exec(html);
+  return m ? m[1] : "";
+}
+
 function faqAnswer(html: string, questionFragment: string): string {
   const pattern = new RegExp(`"name":"([^"]*${questionFragment}[^"]*)","acceptedAnswer":\\{"@type":"Answer","text":"([\\s\\S]*?)"\\}`);
   const m = pattern.exec(html);
@@ -332,14 +337,18 @@ describe("a deprecated offer the ranker still rates keeps its rating", () => {
 });
 
 describe("the live catalog keeps the page it had", () => {
-  it("heads all but the ended records with the free-tier form", async () => {
+  it("heads all but the ended records with the form their own title uses", async () => {
     const live = offers.filter(o => !offerEnded(o)).slice(0, 60);
     let headed = 0;
+    let titled = 0;
     for (const record of live) {
-      const heading = headingOf(await page(`/vendor/${slugOf(record.vendor)}`));
+      const html = await page(`/vendor/${slugOf(record.vendor)}`);
+      const heading = headingOf(html);
       if (/Free Tier \d{4}/.test(heading)) headed++;
+      if (/ Free Tier \d{4}:/.test(titleOf(html))) titled++;
       assert.ok(!heading.includes("free tier retired"), `${record.vendor} is headed as retired`);
     }
-    assert.strictEqual(headed, live.length, `${live.length - headed} live records lost the free-tier heading`);
+    assert.ok(titled > 0, "no live record in this sample carries the free-tier title");
+    assert.strictEqual(headed, titled, `${titled - headed} live records lost the free-tier heading`);
   });
 });


### PR DESCRIPTION
Refs #1238

`faqFreeAnswer` branched on `eligibility_restricted` alone, so the other four gate codes fell through to `Yes`. The vendor page now consults `gateFor` for four surfaces: the free-tier answer, the tier answer, the production answer and a gate line under the heading.

## What moves

**20 pages, not 10.** The issue counted the ten gated primaries answering `Yes`. Ten more take the `levelWithheld` branch first and read *"Our stored record says X offers a free tier: Pay-per-use"* — the same false claim, one branch further on. The gate is now tested **ahead of** `levelWithheld`, on the same reasoning as #1235 criterion 6: the tier string is a fact we hold, the terms are a fact we could not confirm. Those ten keep both the withheld preamble and the unverified-terms caveat; only the sentence asserting a free tier is gone.

```
/vendor/turbopuffer   Is Turbopuffer free?
  before  Yes, Turbopuffer offers a free tier: Pay-as-you-go. Serverless vector database — …
  after   Tier "Pay-as-you-go" is usage-billed from the first request. Serverless vector database — …

/vendor/strale        Is Strale free?
  before  We cannot confirm that today. Strale's pricing page has not resolved for us since
          2026-04-14. Our stored record says Strale offers a free tier: Pay-per-use. …
  after   Tier "Pay-per-use" is usage-billed from the first request. We cannot confirm that
          today. Strale's pricing page has not resolved for us since 2026-04-14. …
```

## Against the criteria

| | |
|---|---|
| 1. No gated record answers `Yes` | **10 → 0.** Not a code list: any code other than `eligibility_restricted` takes the new branch, so a sixth gate code lands there without a change here. |
| 2. The answer states what the record does offer | `${gate.reason} ${storedTerms}` — the shape the retired branch already uses. |
| 3. `<h1>` agrees with `<title>` | **5 → 0.** Both read one expression. Fly.io, Hetzner, Turbopuffer, Augment Code and Google Content API for Shopping now head `X Pricing 2026`. |
| 4. A fixture over the join | `test/gated-vendor-answers.test.ts`, joined over `vendorSlugMap` → `vendorOffers[0]` as measured, and read off the rendered page rather than recomputed. |
| 5. Negative control | **745 ungated answer `Yes`, 670 do not — unmoved.** Also a rule: every ungated primary with a passing source check, a tier and no *"no free tier"* in its description still answers `Yes`. |
| 6. `/vendor/digitalocean` states the expiry | `offer_expired Offer expired on 2026-06-30.` renders directly under the `<h1>`, above the fold. |
| A. Gated `not_a_free_offer`/`offer_expired` not recommended | **20 pages.** Your sentence, verbatim: `Tier "Pay-as-you-go" is usage-billed from the first request. There is no free tier here to run in production.` |
| B. `eligibility_restricted` keeps its answer, less `We rate it stable and` | **22 pages.** One capital letter is the only character of mine: `… side projects. It offers …`. |
| C. Negative control | **582 ungated still recommend — unmoved.** |

## Beyond the criteria, one line to revert

`What is X's free tier?` reads the same gate. It is the same join, the same `${gate.reason} ${description}` shape and no new prose, and leaving it makes `/vendor/stripe` deny a free tier in one answer and name it in the next. Named here because you did not ask for it.

## Copy

Nothing in this PR is written by me except the capital `I` in `It offers`. `NO_FREE_TIER_FOR_PRODUCTION` is your sentence from the issue; every other published string is `gateFor`'s `reason`, already live on 133 pages.

## Two answers lose something, both worth naming

- **fly-io and turbopuffer** lose `Consider free alternatives in <Category>.` from the production answer, because you asked for the gate reason "and stop". Adding it back is one existing sentence, your call.
- **The ten withheld records** lose *"We cannot confirm what this offer provides today"* from the production answer. That answer no longer publishes any terms, so the caveat has nothing left to qualify. The free-tier answer, which does publish terms, keeps it.

## Verification

- **2,577 paths swept against a `main` build. 2,421 byte-identical, 156 moved, 0 status changes, 0 outside `/vendor/`.** 133 of the 156 differ by exactly one line — the `eligibility-gate-line` class renamed to `gate-line`, since it now carries four other codes. 22 of those also carry the production answer. The remaining 23 are the 20 gated pages and the 5 headings, less the 2 in both sets.
- 3,013 tests pass, 22 new. 12 of the 22 fail against a `main` build.
- `scripts/mutate-1238.sh`: **19 of 19 killed**, including both orderings of the gate against `levelWithheld`, each half of the two-code production list, and a fixed date in place of the served one.
- Three fixtures went red on this branch and are updated, not weakened: the #1215 control set now means "ungated by `gateFor`" rather than "no eligibility object" (DigitalOcean was in it), and #1235's live-catalog heading check now compares the heading to that page's own title.

## Found while measuring, not fixed

- **The quick verdict is a fifth consumer.** All 153 gated non-ended pages open `"<Vendor>'s free tier offers …"`; 20 of them name a free tier the tier rules deny and rate it. `/vendor/fly-io`: *"Fly.io's free tier offers Pay-as-you-go only — no free tier for new accounts. We rate it stable."*
- **`Is X's free tier reliable?` is a sixth.** 10 of the 20 answer *"considered stable"*, *"requires caution"* or *"considered risky"*.
- Both need a sentence I will not write. One from you turns either on.
- **Every gated vendor page publishes `"price": "0"` in schema.org**, including `/vendor/oaysus` with `"description": "Retired"`. That is the machine-readable half of this issue and it is untouched by #1241, which covers `/api/*` and the MCP tools.
- **One record is gated twice.** `google-ai-pro-ultra`, tier `Conditional`, holds an eligibility object and a not-free tier. `gateFor` returns eligibility first, so its page reads *"Restricted to … — not generally available. Google AI Pro/Ultra offers a free tier: Conditional."*
- **Ten eligibility-gated primaries also hold a past `expires_date`** — Brex 2026-05-31, Mercury 2026-04-15, Heroku for Startups 2026-04-30 and seven more. Same precedence, so no page says the offer expired.

Screenshots of `/vendor/digitalocean` and `/vendor/turbopuffer` checked before merge.
