### PR TITLE
Read the ranking gate on every claim a vendor page makes (#1238)

### DIFF
--- a/scripts/mutate-1238-claims.sh
+++ b/scripts/mutate-1238-claims.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+set -uo pipefail
+
+REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO"
+
+TESTS=(
+  test/gated-vendor-answers.test.ts
+  test/vendor-verdict.test.ts
+  test/eligibility-disclosure.test.ts
+  test/offer-price-validity.test.ts
+  test/retired-vendor-page.test.ts
+  test/vendor-risk.test.ts
+)
+
+SOURCES=(src/serve.ts src/vendor-verdict.ts src/vendor-history.ts src/data.ts)
+
+backup() { for f in "${SOURCES[@]}"; do cp "$f" "/tmp/$(basename "$f").orig"; done; }
+restore() { for f in "${SOURCES[@]}"; do cp "/tmp/$(basename "$f").orig" "$f"; done; }
+
+backup
+trap 'restore; npm run build >/dev/null 2>&1' EXIT
+
+killed=0
+survived=0
+
+run_mutation() {
+  local name="$1"; shift
+  restore
+  if ! "$@"; then
+    echo "NOT APPLIED                $name"
+    return
+  fi
+  if ! npm run build >/dev/null 2>&1; then
+    echo "KILLED (does not compile)  $name"
+    killed=$((killed + 1))
+    return
+  fi
+  if node --test --test-concurrency 1 "${TESTS[@]}" >/tmp/mutation-out.txt 2>&1; then
+    echo "SURVIVED                   $name"
+    survived=$((survived + 1))
+  else
+    echo "KILLED                     $name"
+    killed=$((killed + 1))
+  fi
+}
+
+sub() {
+  python3 - "$1" "$2" "$3" <<'PY'
+import sys
+path, old, new = sys.argv[1], sys.argv[2], sys.argv[3]
+text = open(path, encoding="utf-8").read()
+if old not in text:
+    sys.exit("mutation target not found in " + path)
+open(path, "w", encoding="utf-8").write(text.replace(old, new, 1))
+PY
+}
+
+run_mutation "hasFree ignores the gate" \
+  sub src/serve.ts 'const hasFree = !retiredSentence && !productionGate' 'const hasFree = !retiredSentence'
+
+run_mutation "verdict opens on the free tier again" \
+  sub src/serve.ts 'const verdictSubject = primaryGate ? primaryGate.reason : retiredSentence;' 'const verdictSubject = retiredSentence;'
+
+run_mutation "verdict input never reports the gate" \
+  sub src/serve.ts 'gated: primaryGate !== null,' 'gated: false,'
+
+run_mutation "verdict sentence drops its gated branch" \
+  sub src/vendor-verdict.ts 'if (input.gated) return vendorHistorySentence(input.vendor, level, input.cause);' ''
+
+run_mutation "stable history sentence loses its subject" \
+  sub src/vendor-history.ts 'has a stable pricing history.' 'free tier is stable.'
+
+run_mutation "caution history sentence loses its subject" \
+  sub src/vendor-history.ts 'warrants caution' "'s free tier warrants caution"
+
+run_mutation "risky history sentence loses its subject" \
+  sub src/vendor-history.ts 'is high risk' "'s free tier is high risk"
+
+run_mutation "reliability answer drops its gated branch" \
+  sub src/serve.ts '    : primaryGate
+    ? `${primaryGate.reason} ${vendorHistorySentence(vendorName, riskLevel, riskCause)}${riskLevel === "stable" && vendorChanges.length > 0 ? ` ${narrowingSentence(vendorChanges)} See the pricing history below.` : ""}`' ''
+
+run_mutation "outgrow question asked on a gated page" \
+  sub src/serve.ts '...(primaryGate ? [] : [{ q: ' '...(false ? [] : [{ q: '
+
+run_mutation "growth section rendered on a gated page" \
+  sub src/serve.ts 'growthBullets.length > 0 && !discontinuedOn && !primaryGate' 'growthBullets.length > 0 && !discontinuedOn'
+
+run_mutation "structured data publishes a zero price again" \
+  sub src/serve.ts '...(primaryGate
+        ? {}
+        : {' '...(false
+        ? {}
+        : {'
+
+run_mutation "comparison cell states no gate code" \
+  sub src/serve.ts '">${escHtmlServer(gate.code)}</span>' '"></span>'
+
+run_mutation "comparison cell is never told the gate" \
+  sub src/serve.ts 'stabilityCellHtml(enriched.risk_level, riskCause, linkUnreachable, primary, primaryGate)' 'stabilityCellHtml(enriched.risk_level, riskCause, linkUnreachable, primary)'
+
+run_mutation "production answer states no pricing history" \
+  sub src/serve.ts 'is usable for prototyping and development. ${vendorHistorySentence(vendorName, riskLevel, riskCause)}' 'is usable for prototyping and development.'
+
+run_mutation "empty history reads as a good sign again" \
+  sub src/serve.ts '    : primaryGate
+    ? `<p class="no-changes">No recorded pricing changes for ${escHtmlServer(vendorName)}.</p>`' ''
+
+run_mutation "changed answer reads as a positive signal again" \
+  sub src/serve.ts '    : primaryGate
+    ? `No, ${vendorName} has had no recorded pricing changes.`' ''
+
+run_mutation "verdict recommends a gated record for a workload" \
+  sub src/serve.ts 'alternatives.length > 0 && !levelWithheld && !primaryGate' 'alternatives.length > 0 && !levelWithheld'
+
+run_mutation "vendor-risk summary hardcodes the stable form" \
+  sub src/data.ts 'vendorHistorySentence(offer.vendor, riskLevel, cause)' 'vendorHistorySentence(offer.vendor, "stable", cause)'
+
+echo
+echo "killed $killed, survived $survived"

--- a/src/data.ts
+++ b/src/data.ts
@@ -10,6 +10,7 @@ import { cannotVouchForLevel, levelWithheldReason, withheldLevelSentence } from 
 import { substitutesFor } from "./product-role.js";
 import { DATE_SOURCES, isEventDated, changeDateClause, isoWeekWindow, changesInWindow, discoveryBatchNote, firstReadHeading, type DateWindow } from "./change-dates.js";
 import { PRODUCT_DEPRECATED, deprecationEndsTheListedProduct } from "./product-deprecation.js";
+import { vendorHistorySentence } from "./vendor-history.js";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const INDEX_PATH =
@@ -788,14 +789,12 @@ export function checkVendorRisk(
   const unreachableClause = linkUnreachable
     ? ` Its pricing page has not resolved for us${unreachableSince}, so we cannot confirm its current terms.`
     : "";
-  if (riskLevel === "risky" && cause) {
-    summary = `${offer.vendor} is high risk — ${changeDateClause(cause)}: ${cause.summary} Consider alternatives.${unreachableClause}`;
-  } else if (riskLevel === "caution" && cause) {
-    summary = `${offer.vendor} warrants caution — ${changeDateClause(cause)}: ${cause.summary} Monitor for further changes.${unreachableClause}`;
+  if ((riskLevel === "risky" || riskLevel === "caution") && cause) {
+    summary = `${vendorHistorySentence(offer.vendor, riskLevel, cause)}${unreachableClause}`;
   } else if (withheldReason) {
     summary = `${withheldLevelSentence(withheldReason, offer.vendor, unreachableSince)} Nothing we have read describes this offer. Treat that as a statement about our records, not as a stable pricing history.`;
   } else {
-    summary = `${offer.vendor} has a stable pricing history. Free tier verified for ${longevityDays} days.`;
+    summary = `${vendorHistorySentence(offer.vendor, "stable", cause)} Free tier verified for ${longevityDays} days.`;
   }
 
   return {

--- a/src/serve.ts
+++ b/src/serve.ts
@@ -21,6 +21,7 @@ import { levelWithheldReason, withheldLevelClause, withheldLevelSentence } from 
 import { buildComparisonMap, comparisonSlug } from "./comparison-pairs.js";
 import { stabilityFaqAnswer, stabilityVerdictClause, type ComparisonSide, type StabilityRating } from "./comparison-verdict.js";
 import { publishedVendorLevel, vendorVerdictSentence, narrowingSentence, changeKindNoun, type VendorVerdictInput } from "./vendor-verdict.js";
+import { vendorHistorySentence } from "./vendor-history.js";
 import { growthLimitPhrases } from "./growth-limits.js";
 import { registerAgent, authenticateRequest, validateVestauthUrl, hashApiKey, updateAgentX402Address, getAgentById } from "./agents.js";
 import { attributeAuthenticatedRequest } from "./referral-attribution.js";
@@ -41,7 +42,7 @@ import { faqPageJsonLd, type FaqItem } from "./faq-provenance.js";
 import { SSE_KEEPALIVE_FRAME, keepaliveIntervalMs, sessionRecoveryBody } from "./mcp-stream.js";
 import { ASSISTANTS_API_SHUTDOWN } from "./assistants-shutdown.js";
 import { discontinuedOnOrBefore, PRODUCT_DEPRECATED } from "./product-deprecation.js";
-import { rankOffers, rankForListing, rotateListing, utcDate, gateFor, CRITERIA_PATH, DEMOTE_ONLY_POLICY, DISCLOSURE_RATIONALE, TIE_BREAK_ALGORITHM, GATE_TABLE, DEMERIT_TABLE, NOT_FREE_TIER_RULES, TIME_LIMITED_TIER_RULES, type TieBreak } from "./ranking.js";
+import { rankOffers, rankForListing, rotateListing, utcDate, gateFor, CRITERIA_PATH, DEMOTE_ONLY_POLICY, DISCLOSURE_RATIONALE, TIE_BREAK_ALGORITHM, GATE_TABLE, DEMERIT_TABLE, NOT_FREE_TIER_RULES, TIME_LIMITED_TIER_RULES, type TieBreak, type Gate } from "./ranking.js";
 import type { RankedEntry, RankingResult } from "./ranking.js";
 import { eligibilityGate, gatedShareDescriptionClause, gatedShareLede, publishableEligibilityConditions } from "./eligibility.js";
 import { verificationLedger, QUARANTINE_AFTER_FAILURES } from "./verification-state.js";
@@ -495,7 +496,11 @@ function stabilityCellHtml(
   cause: RiskCause | null | undefined,
   linkUnreachable: LinkUnreachable | null | undefined,
   offer?: Pick<Offer, "source_check">,
+  gate?: Gate | null,
 ): string {
+  if (gate) {
+    return `<span class="stability-gate" style="color:var(--text-dim);font-family:var(--mono)" title="${escHtmlServer(gate.reason)}">${escHtmlServer(gate.code)}</span>`;
+  }
   if (linkUnreachable) {
     const since = linkUnreachable.last_reachable ? ` since ${linkUnreachable.last_reachable}` : "";
     return `<span style="color:var(--text-dim)" title="Link has not resolved${escHtmlServer(since)}">link unreachable</span>`;
@@ -3779,7 +3784,7 @@ function buildVendorPage(slug: string): string | null {
 
   const currentYear = new Date().getFullYear();
   const retiredSentence = offerRetired(primary) ? recordedTierSentence(vendorName, primary.tier) : "";
-  const hasFree = !retiredSentence && primary.tier.toLowerCase() !== "none" && !primary.description.toLowerCase().includes("no free tier");
+  const hasFree = !retiredSentence && !productionGate && primary.tier.toLowerCase() !== "none" && !primary.description.toLowerCase().includes("no free tier");
   const freeTierHeadline = `${vendorName} Free Tier ${currentYear}`;
   const pricingHeadline = `${vendorName} Pricing ${currentYear}`;
   const headline = offerHasEnded ? endedHeadline(vendorName) : hasFree ? freeTierHeadline : pricingHeadline;
@@ -3803,22 +3808,28 @@ function buildVendorPage(slug: string): string | null {
   const levelWithheld = levelWithheldReason(primary, linkUnreachable);
   const withheldClause = levelWithheld ? withheldLevelClause(levelWithheld, unconfirmableSince) : "";
   const verdictInput: VendorVerdictInput = {
+    vendor: vendorName,
     level: enriched.risk_level ?? null,
     cause: riskCause,
     changes: vendorChanges,
     levelWithheld,
     unconfirmableSince,
     offerEnded: offerHasEnded,
+    gated: primaryGate !== null,
   };
   const verdictLine2 = vendorVerdictSentence(verdictInput);
   const verdictLine3 = discontinuedOn
     ? `${vendorName} was discontinued on ${discontinuedOn}, so it is not a current option${alternatives.length > 0 ? ` — the ${alternatives.length} alternatives below are replacements` : ""}.`
-    : alternatives.length > 0 && !levelWithheld
+    : alternatives.length > 0 && !levelWithheld && !primaryGate
     ? `Best for ${primary.category.toLowerCase()} workloads${alternatives.length >= 5 ? ` — ${alternatives.length} alternatives available` : ""}.`
     : "";
+  const verdictSubject = primaryGate ? primaryGate.reason : retiredSentence;
+  const verdictOpening = verdictSubject
+    ? `${escHtmlServer(verdictSubject)} ${escHtmlServer(keyLimit)}.`
+    : `${escHtmlServer(vendorName)}'s free tier offers ${escHtmlServer(keyLimit)}.`;
   const quickVerdictHtml = `
   <div class="quick-verdict">
-    <p>${retiredSentence ? `${escHtmlServer(retiredSentence)} ${escHtmlServer(keyLimit)}.` : `${escHtmlServer(vendorName)}'s free tier offers ${escHtmlServer(keyLimit)}.`} ${verdictLine2}${verdictLine3 ? " " + verdictLine3 : ""}</p>
+    <p>${verdictOpening} ${verdictLine2}${verdictLine3 ? " " + verdictLine3 : ""}</p>
   </div>`;
 
   const catMapping = categoryComparisonMap[primary.category];
@@ -3846,7 +3857,7 @@ function buildVendorPage(slug: string): string | null {
     const topAlt = alternatives[0];
     growthBullets.push(`At that point, consider <a href="/vendor/${toSlug(topAlt.vendor)}">${escHtmlServer(topAlt.vendor)}</a> which offers ${escHtmlServer(topAlt.tier)} in the same category.`);
   }
-  const growthPathHtml = growthBullets.length > 0 && !discontinuedOn ? `
+  const growthPathHtml = growthBullets.length > 0 && !discontinuedOn && !primaryGate ? `
   <div class="section growth-section">
     <h2>When You'll Outgrow ${escHtmlServer(vendorName)}'s Free Tier</h2>
     <ul class="growth-list">
@@ -3871,7 +3882,7 @@ function buildVendorPage(slug: string): string | null {
           <tr class="current-vendor-row">
             <td><strong>${escHtmlServer(vendorName)}</strong></td>
             <td>${escHtmlServer(primary.tier)}</td>
-            <td>${stabilityCellHtml(enriched.risk_level, riskCause, linkUnreachable, primary)}</td>
+            <td>${stabilityCellHtml(enriched.risk_level, riskCause, linkUnreachable, primary, primaryGate)}</td>
           </tr>
 ${enrichedAlts.map(a => {
   return `          <tr>
@@ -3902,6 +3913,8 @@ ${enrichedAlts.map(a => {
     ? `<p class="no-changes">${escHtmlServer(endedHistorySentence(vendorName))}</p>`
     : levelWithheld
     ? `<p class="no-changes">No recorded pricing changes for ${escHtmlServer(vendorName)} — but ${escHtmlServer(withheldClause)}, so nothing we have read describes these terms. Treat the empty history as a statement about our records, not about this vendor's pricing.</p>`
+    : primaryGate
+    ? `<p class="no-changes">No recorded pricing changes for ${escHtmlServer(vendorName)}.</p>`
     : `<p class="no-changes">No recorded pricing changes for ${escHtmlServer(vendorName)}. This is a good sign — stable pricing.</p>`;
 
   const latestChange = vendorChanges[0];
@@ -4091,13 +4104,17 @@ ${allCompareLinks.join("\n")}
       description: primary.description,
       applicationCategory: primary.category,
       ...(offerRetired(primary) ? {} : { url: primary.url }),
-      offers: {
-        "@type": "Offer",
-        price: "0",
-        priceCurrency: "USD",
-        description: primary.tier,
-        ...(offerExpiry ? { priceValidUntil: offerExpiry } : {}),
-      },
+      ...(primaryGate
+        ? {}
+        : {
+            offers: {
+              "@type": "Offer",
+              price: "0",
+              priceCurrency: "USD",
+              description: primary.tier,
+              ...(offerExpiry ? { priceValidUntil: offerExpiry } : {}),
+            },
+          }),
     },
   };
   if (pricingEvents.length > 0) {
@@ -4133,6 +4150,8 @@ ${allCompareLinks.join("\n")}
     ? endedReliabilitySentence(vendorName)
     : levelWithheld
     ? `We cannot say. ${withheldLevelSentence(levelWithheld, vendorName, unconfirmableSince)} Nothing we have read describes these terms, so we are not publishing a stability judgement for this vendor until that is fixed.`
+    : primaryGate
+    ? `${primaryGate.reason} ${vendorHistorySentence(vendorName, riskLevel, riskCause)}${riskLevel === "stable" && vendorChanges.length > 0 ? ` ${narrowingSentence(vendorChanges)} See the pricing history below.` : ""}`
     : riskLevel === "stable"
     ? `${vendorName}'s free tier is considered stable.${vendorChanges.length > 0 ? ` ${narrowingSentence(vendorChanges)} See the pricing history below.` : ""}`
     : riskLevel === "caution"
@@ -4147,6 +4166,8 @@ ${allCompareLinks.join("\n")}
     : hasFree
     ? (riskLevel === "stable"
       ? `${vendorName}'s free tier can be suitable for small production workloads and side projects. ${primaryGate ? "It" : "We rate it stable and it"} offers ${escHtmlServer(keyLimit)}, so it's a reasonable starting point.${vendorChanges.length > 0 ? ` ${narrowingSentence(vendorChanges)}` : ""} Monitor your usage against the limits and have an upgrade plan ready.`
+      : primaryGate
+      ? `${vendorName}'s free tier is usable for prototyping and development. ${vendorHistorySentence(vendorName, riskLevel, riskCause)}`
       : `${vendorName}'s free tier is usable for prototyping and development, but we rate it ${riskLevel}${riskCause ? ` because of one recorded ${changeKindNoun(riskCause.change_type)}, ${changeDateClause(riskCause)}` : ""}. Consider alternatives with more stable pricing for critical services.`)
     : `${vendorName} does not offer a free tier for production use. Consider free alternatives in ${primary.category}.`);
   const faqChangedAnswer = vendorChanges.length > 0
@@ -4155,6 +4176,8 @@ ${allCompareLinks.join("\n")}
     ? endedEmptyChangeHistorySentence(vendorName)
     : levelWithheld
     ? `We hold no recorded pricing changes for ${vendorName}, but ${withheldClause}, so that is a statement about our records rather than a positive signal.`
+    : primaryGate
+    ? `No, ${vendorName} has had no recorded pricing changes.`
     : `No, ${vendorName} has had no recorded pricing changes. This is a positive stability signal.`;
   const faqAlternativesAnswer = alternatives.length > 0
     ? `The top free alternatives to ${vendorName} in ${primary.category} include ${alternatives.slice(0, 5).map(a => `${a.vendor} (${a.tier})`).join(", ")}. See all ${alternatives.length} alternatives above.`
@@ -4170,7 +4193,7 @@ ${allCompareLinks.join("\n")}
     { q: `Is ${vendorName}'s free tier good for production?`, a: faqProductionAnswer },
     { q: `What changed in ${vendorName}'s pricing?`, a: faqChangedAnswer },
     ...(alternatives.length > 0 ? [{ q: `What are the best free alternatives to ${vendorName}?`, a: faqAlternativesAnswer }] : []),
-    { q: `When will I outgrow ${vendorName}'s free tier?`, a: faqOutgrowAnswer },
+    ...(primaryGate ? [] : [{ q: `When will I outgrow ${vendorName}'s free tier?`, a: faqOutgrowAnswer }]),
     { q: `What category is ${vendorName} in?`, a: faqCategoryAnswer },
   ];
 

--- a/src/vendor-history.ts
+++ b/src/vendor-history.ts
@@ -1,0 +1,18 @@
+import type { RiskCause } from "./types.js";
+import { changeDateClause } from "./change-dates.js";
+
+export type PublishedRiskLevel = "stable" | "caution" | "risky";
+
+export function vendorHistorySentence(
+  vendor: string,
+  level: PublishedRiskLevel,
+  cause: RiskCause | null,
+): string {
+  if (level === "risky" && cause) {
+    return `${vendor} is high risk — ${changeDateClause(cause)}: ${cause.summary} Consider alternatives.`;
+  }
+  if (level === "caution" && cause) {
+    return `${vendor} warrants caution — ${changeDateClause(cause)}: ${cause.summary} Monitor for further changes.`;
+  }
+  return `${vendor} has a stable pricing history.`;
+}

--- a/src/vendor-verdict.ts
+++ b/src/vendor-verdict.ts
@@ -3,8 +3,9 @@ import { CHANGE_DIRECTION, isACorrectionToOurOwnRecord } from "./data.js";
 import { changeDateClause } from "./change-dates.js";
 import { withheldLevelClause, type LevelWithheldReason } from "./source-check.js";
 import { endedVerdictSentence } from "./retirement.js";
+import { vendorHistorySentence, type PublishedRiskLevel } from "./vendor-history.js";
 
-export type PublishedRiskLevel = "stable" | "caution" | "risky";
+export type { PublishedRiskLevel };
 
 export const CHANGE_KIND_NOUN: Record<DealChange["change_type"], string> = {
   free_tier_removed: "free tier removal",
@@ -28,12 +29,14 @@ export function changeKindNoun(changeType: string): string {
 }
 
 export interface VendorVerdictInput {
+  vendor: string;
   level: PublishedRiskLevel | null;
   cause: RiskCause | null;
   changes: Array<Pick<DealChange, "date" | "date_source" | "change_type">>;
   levelWithheld: LevelWithheldReason | null;
   unconfirmableSince: string;
   offerEnded?: boolean;
+  gated?: boolean;
 }
 
 export function publishedVendorLevel(
@@ -94,8 +97,9 @@ export function vendorVerdictSentence(input: VendorVerdictInput): string {
     const clause = withheldLevelClause(input.levelWithheld!, input.unconfirmableSince);
     return `${clause.charAt(0).toUpperCase()}${clause.slice(1)}, so we cannot confirm these terms today.`;
   }
-
   const level = publishedVendorLevel(input.level, input.cause);
+  if (input.gated) return vendorHistorySentence(input.vendor, level, input.cause);
+
   if (level !== "stable" && input.cause) {
     const unconfirmed = input.levelWithheld
       ? ` ${capitalise(withheldLevelClause(input.levelWithheld, input.unconfirmableSince))}, so we cannot confirm the terms above.`

--- a/test/eligibility-disclosure.test.ts
+++ b/test/eligibility-disclosure.test.ts
@@ -72,9 +72,9 @@ function faqAnswer(html: string, prefix: string): string | undefined {
 function renderedOffer(html: string): Offer | undefined {
   const webPage = blockOfType(html, "WebPage");
   const vendor = webPage?.mainEntity?.name;
-  const tier = webPage?.mainEntity?.offers?.description;
-  if (typeof vendor !== "string" || typeof tier !== "string") return undefined;
-  return offers.find(o => o.vendor === vendor && o.tier === tier);
+  const description = webPage?.mainEntity?.description;
+  if (typeof vendor !== "string" || typeof description !== "string") return undefined;
+  return offers.find(o => o.vendor === vendor && o.description === description);
 }
 
 type RenderedPage = { vendor: string; slug: string; html: string; offer: Offer };
@@ -286,18 +286,16 @@ describe("the other answers on a gated vendor page", () => {
     }
   });
 
-  it("leaves the four that describe our record rather than the offer alone", () => {
+  it("leaves the two that describe our record rather than the offer alone", () => {
     for (const p of gatedPages()) {
       const reason = gateFor(p.offer, "")!.reason;
       for (const question of [
-        `Is ${p.vendor}'s free tier reliable?`,
         `What changed in ${p.vendor}'s pricing?`,
-        `When will I outgrow ${p.vendor}'s free tier?`,
         `What category is ${p.vendor} in?`,
       ]) {
         const answer = faqAnswer(p.html, question);
-        if (answer === undefined) continue;
-        assert.ok(!answer.startsWith(reason), `${p.slug} qualified "${question}", which is about our record`);
+        assert.ok(answer !== undefined, `${p.slug} no longer answers "${question}"`);
+        assert.ok(!answer!.startsWith(reason), `${p.slug} qualified "${question}", which is about our record`);
       }
     }
   });

--- a/test/gated-vendor-answers.test.ts
+++ b/test/gated-vendor-answers.test.ts
@@ -134,8 +134,8 @@ describe("the page a gated record renders does not answer the free-tier question
     assert.ok(rendered.length > 1500, `only ${rendered.length} vendor pages rendered`);
     for (const p of rendered) {
       assert.strictEqual(
-        blockOfType(p.html, "WebPage")?.mainEntity?.offers?.description,
-        p.primary.tier,
+        blockOfType(p.html, "WebPage")?.mainEntity?.description,
+        p.primary.description,
         `/vendor/${p.slug} renders a record other than the first this vendor holds`,
       );
     }
@@ -344,6 +344,152 @@ describe("a reader sees why the record is gated without opening the FAQ", () => 
     assert.ok(
       (gateLineOf(digitalocean.html) ?? "").includes(DIGITALOCEAN_EXPIRY_REASON),
       gateLineOf(digitalocean.html) ?? "no gate line",
+    );
+  });
+});
+
+const CLAIMS_A_RATING = (vendor: string) => [
+  `${vendor}'s free tier offers `,
+  `${vendor}'s free tier is considered `,
+  `${vendor}'s free tier requires caution`,
+  "We rate it stable",
+  "We rate it caution",
+  "We rate it risky",
+  "It's stable —",
+  "This is a good sign",
+  "This is a positive stability signal",
+  `Yes, ${vendor} offers a free tier`,
+];
+
+const NAMES_A_FREE_TIER = (vendor: string) => [
+  `${vendor}'s free tier is called`,
+  `${vendor} offers a free tier:`,
+];
+
+function visibleText(html: string): string {
+  const stripped = html
+    .replace(/<script[\s\S]*?<\/script>/g, " ")
+    .replace(/<style[\s\S]*?<\/style>/g, " ")
+    .replace(/<[^>]+>/g, " ");
+  return stripped
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&amp;/g, "&")
+    .replace(/\s+/g, " ");
+}
+
+function pageProse(p: VendorPage): string {
+  const faq = blockOfType(p.html, "FAQPage");
+  const answers = (faq?.mainEntity ?? []).map((q: { acceptedAnswer: { text: string } }) => q.acceptedAnswer.text);
+  return `${visibleText(p.html)} ${answers.join(" ")}`;
+}
+
+function outgrowQuestionAsked(p: VendorPage): boolean {
+  const faq = blockOfType(p.html, "FAQPage");
+  return (faq?.mainEntity ?? []).some((q: { name: string }) => q.name.startsWith("When will I outgrow"));
+}
+
+const offerBlock = (p: VendorPage) => blockOfType(p.html, "WebPage")?.mainEntity?.offers;
+
+const currentVendorRow = (html: string) => /<tr class="current-vendor-row">[\s\S]*?<\/tr>/.exec(html)?.[0] ?? null;
+
+const UNGATED_VERDICTS_OPENING_ON_A_FREE_TIER = 1414;
+const UNGATED_PAGES_RATING_RELIABILITY = 745;
+const UNGATED_PAGES_ASKING_ABOUT_OUTGROWING = 1415;
+const UNGATED_PAGES_PUBLISHING_A_ZERO_PRICE = 1415;
+
+describe("no page a gated record renders claims a free tier or rates one", () => {
+  it("makes none of the claims a page makes about an offer it does list", () => {
+    const offenders: string[] = [];
+    for (const p of gated()) {
+      const prose = pageProse(p);
+      for (const claim of CLAIMS_A_RATING(p.vendor)) {
+        if (prose.includes(claim)) offenders.push(`${p.slug} (${p.gate!.code}): ${claim}`);
+      }
+      if (p.gate!.code === "eligibility_restricted") continue;
+      for (const claim of NAMES_A_FREE_TIER(p.vendor)) {
+        if (prose.includes(claim)) offenders.push(`${p.slug} (${p.gate!.code}): ${claim}`);
+      }
+    }
+    assert.deepStrictEqual(offenders.slice(0, 20), []);
+  });
+
+  it("opens the verdict with the gate's own sentence instead", () => {
+    for (const p of gated()) {
+      const verdict = /<div class="quick-verdict">\s*<p>([\s\S]*?)<\/p>/.exec(p.html)?.[1] ?? "";
+      assert.ok(
+        textOf(verdict).startsWith(textOf(p.gate!.reason)),
+        `/vendor/${p.slug} opens ${textOf(verdict).slice(0, 90)}`,
+      );
+    }
+  });
+
+  it("offers no upgrade threshold for a tier it does not list", () => {
+    const asked = gated().filter(outgrowQuestionAsked).map(p => p.slug);
+    assert.deepStrictEqual(asked.slice(0, 20), []);
+    const sectioned = gated().filter(p => p.html.includes('class="section growth-section"')).map(p => p.slug);
+    assert.deepStrictEqual(sectioned.slice(0, 20), []);
+  });
+
+  it("publishes no zero-price Offer in its structured data", () => {
+    const offenders = gated().filter(p => offerBlock(p) !== undefined).map(p => `${p.slug} ${JSON.stringify(offerBlock(p))}`);
+    assert.deepStrictEqual(offenders.slice(0, 20), []);
+  });
+
+  it("names the gate rather than a rating in its own comparison row", () => {
+    const rows = gated().map(p => ({ p, row: currentVendorRow(p.html) })).filter(r => r.row !== null);
+    assert.ok(rows.length > 0, "no gated page renders itself in a comparison table");
+    for (const { p, row } of rows) {
+      assert.ok(!/stability-dot/.test(row!), `/vendor/${p.slug} rates itself in its comparison row`);
+      assert.ok(row!.includes(p.gate!.code), `/vendor/${p.slug} states no gate in its comparison row`);
+    }
+  });
+});
+
+describe("the same page an ungated record renders is unchanged", () => {
+  it("still makes every one of those claims somewhere", () => {
+    const unmade: string[] = [];
+    for (const claim of [...CLAIMS_A_RATING("<vendor>"), ...NAMES_A_FREE_TIER("<vendor>")]) {
+      const made = ungated().filter(p => pageProse(p).includes(claim.replace(/<vendor>/g, p.vendor))).length;
+      if (made === 0) unmade.push(claim);
+    }
+    assert.deepStrictEqual(unmade, [], "claims no ungated page makes, so the gated assertion above is vacuous for them");
+  });
+
+  it("still opens its verdict on the free tier", () => {
+    const opening = ungated().filter(p => pageProse(p).includes(`${p.vendor}'s free tier offers `)).length;
+    assert.ok(
+      opening >= UNGATED_VERDICTS_OPENING_ON_A_FREE_TIER,
+      `${opening} ungated verdicts open on the free tier, down from ${UNGATED_VERDICTS_OPENING_ON_A_FREE_TIER}`,
+    );
+  });
+
+  it("still rates the free tier in its reliability answer", () => {
+    const rating = ungated().filter(p => {
+      const answer = faqAnswer(p.html, `Is ${p.vendor}'s free tier reliable?`);
+      return /is considered stable|requires caution|is considered risky/.test(answer);
+    }).length;
+    assert.ok(
+      rating >= UNGATED_PAGES_RATING_RELIABILITY,
+      `${rating} ungated pages rate the tier, down from ${UNGATED_PAGES_RATING_RELIABILITY}`,
+    );
+  });
+
+  it("still answers when the reader will outgrow it", () => {
+    const asked = ungated().filter(outgrowQuestionAsked).length;
+    assert.ok(
+      asked >= UNGATED_PAGES_ASKING_ABOUT_OUTGROWING,
+      `${asked} ungated pages answer it, down from ${UNGATED_PAGES_ASKING_ABOUT_OUTGROWING}`,
+    );
+  });
+
+  it("still publishes a zero-price Offer", () => {
+    const publishing = ungated().filter(p => offerBlock(p)?.price === "0").length;
+    assert.ok(
+      publishing >= UNGATED_PAGES_PUBLISHING_A_ZERO_PRICE,
+      `${publishing} ungated pages publish one, down from ${UNGATED_PAGES_PUBLISHING_A_ZERO_PRICE}`,
     );
   });
 });

--- a/test/gated-vendor-answers.test.ts
+++ b/test/gated-vendor-answers.test.ts
@@ -278,6 +278,22 @@ describe("the production answer reads the same gate", () => {
     assert.deepStrictEqual(offenders, []);
   });
 
+  it("states the pricing history rather than a rating where the level is not stable", () => {
+    const subjects = gated().filter(p => productionAnswer(p).includes("is usable for prototyping and development"));
+    assert.ok(subjects.length > 0, "no gated page takes the branch that rated the tier");
+    for (const p of subjects) {
+      const answer = productionAnswer(p);
+      assert.ok(answer.startsWith(p.gate!.reason), `/vendor/${p.slug} drops the restriction`);
+      assert.ok(!/we rate it (stable|caution|risky)/i.test(answer), `/vendor/${p.slug}: ${answer.slice(0, 160)}`);
+      assert.ok(
+        ["warrants caution", "is high risk", "has a stable pricing history"].some(
+          form => answer.includes(`${p.vendor} ${form}`),
+        ),
+        `/vendor/${p.slug} names no pricing history: ${answer.slice(0, 160)}`,
+      );
+    }
+  });
+
   it("keeps the restriction prefix and the rest of the sentence on an eligibility-gated record", () => {
     const subjects = gated().filter(
       p => p.gate!.code === "eligibility_restricted" && productionAnswer(p).includes(RECOMMENDATION_CLAUSE),
@@ -301,6 +317,21 @@ describe("the heading agrees with the title on the same page", () => {
       if (titleClaimsFree !== headingClaimsFree) disagreeing.push(p.slug);
     }
     assert.deepStrictEqual(disagreeing, []);
+  });
+
+  it("withholds the free-tier form from a page whose gate says there is no free tier", () => {
+    const subjects = gated().filter(p => p.gate!.code === "not_a_free_offer" || p.gate!.code === "offer_expired");
+    assert.ok(subjects.length > 0, "no record is gated as not a free offer or as expired");
+    for (const p of subjects) {
+      assert.ok(!/ Free Tier \d{4}/.test(headingOf(p.html)), `/vendor/${p.slug} is headed ${headingOf(p.html)}`);
+      assert.ok(!/ Free Tier \d{4}:/.test(titleOf(p.html)), `/vendor/${p.slug} is titled ${titleOf(p.html)}`);
+    }
+  });
+
+  it("keeps it on a page whose gate is the restriction rather than the tier", () => {
+    const restricted = gated().filter(p => p.gate!.code === "eligibility_restricted");
+    const heading = restricted.filter(p => / Free Tier \d{4}/.test(headingOf(p.html))).length;
+    assert.ok(heading > 100, `only ${heading} of ${restricted.length} restricted pages still head a free tier`);
   });
 
   it("heads a page whose title withholds the free-tier form with the pricing form", () => {
@@ -348,7 +379,7 @@ describe("a reader sees why the record is gated without opening the FAQ", () => 
   });
 });
 
-const CLAIMS_A_RATING = (vendor: string) => [
+const CLAIMS_A_RATING = (vendor: string, category: string) => [
   `${vendor}'s free tier offers `,
   `${vendor}'s free tier is considered `,
   `${vendor}'s free tier requires caution`,
@@ -359,6 +390,7 @@ const CLAIMS_A_RATING = (vendor: string) => [
   "This is a good sign",
   "This is a positive stability signal",
   `Yes, ${vendor} offers a free tier`,
+  `Best for ${category.toLowerCase()} workloads`,
 ];
 
 const NAMES_A_FREE_TIER = (vendor: string) => [
@@ -405,7 +437,7 @@ describe("no page a gated record renders claims a free tier or rates one", () =>
     const offenders: string[] = [];
     for (const p of gated()) {
       const prose = pageProse(p);
-      for (const claim of CLAIMS_A_RATING(p.vendor)) {
+      for (const claim of CLAIMS_A_RATING(p.vendor, p.primary.category)) {
         if (prose.includes(claim)) offenders.push(`${p.slug} (${p.gate!.code}): ${claim}`);
       }
       if (p.gate!.code === "eligibility_restricted") continue;
@@ -451,8 +483,12 @@ describe("no page a gated record renders claims a free tier or rates one", () =>
 describe("the same page an ungated record renders is unchanged", () => {
   it("still makes every one of those claims somewhere", () => {
     const unmade: string[] = [];
-    for (const claim of [...CLAIMS_A_RATING("<vendor>"), ...NAMES_A_FREE_TIER("<vendor>")]) {
-      const made = ungated().filter(p => pageProse(p).includes(claim.replace(/<vendor>/g, p.vendor))).length;
+    for (const claim of [...CLAIMS_A_RATING("<vendor>", "<category>"), ...NAMES_A_FREE_TIER("<vendor>")]) {
+      const made = ungated().filter(p =>
+        pageProse(p).includes(
+          claim.replace(/<vendor>/g, p.vendor).replace(/<category>/g, p.primary.category.toLowerCase()),
+        ),
+      ).length;
       if (made === 0) unmade.push(claim);
     }
     assert.deepStrictEqual(unmade, [], "claims no ungated page makes, so the gated assertion above is vacuous for them");

--- a/test/offer-price-validity.test.ts
+++ b/test/offer-price-validity.test.ts
@@ -261,19 +261,22 @@ describe("no vendor page publishes a price expiry that has already passed", () =
     assert.ok(slugs.length > 1000, `only ${slugs.length} vendor pages were checked`);
     const expired: string[] = [];
     let present = 0;
+    let emitting = 0;
     for (const slug of slugs) {
       const html = await (await fetch(`http://localhost:${port}/vendor/${slug}`)).text();
       const offers = offerJsonLd(html);
-      assert.ok(offers, `/vendor/${slug} emitted no Offer in its JSON-LD`);
-      const until = offers!.priceValidUntil;
+      if (!offers) continue;
+      emitting++;
+      const until = offers.priceValidUntil;
       if (until === undefined) continue;
       present++;
       if (until < TODAY) expired.push(`${slug} ${until}`);
     }
+    assert.ok(emitting > 1000, `only ${emitting} of ${slugs.length} vendor pages emit an Offer at all`);
     assert.deepStrictEqual(
       expired.slice(0, 10),
       [],
-      `${expired.length} of ${slugs.length} vendor pages publish an expiry earlier than ${TODAY}, and ${present} carry the field at all`
+      `${expired.length} of ${emitting} vendor pages publish an expiry earlier than ${TODAY}, and ${present} carry the field at all`
     );
   });
 });

--- a/test/retired-vendor-page.test.ts
+++ b/test/retired-vendor-page.test.ts
@@ -267,6 +267,7 @@ describe("an ended offer is not rated, on every surface that rates one", () => {
 
 describe("the retirement branch is decided before the withholding branch", () => {
   const withheldAndEnded = {
+    vendor: "Oaysus",
     level: null,
     cause: null,
     changes: [],

--- a/test/vendor-risk.test.ts
+++ b/test/vendor-risk.test.ts
@@ -204,3 +204,29 @@ describe("check_vendor_risk REST endpoint", () => {
     assert.ok(body.error.includes("not found"));
   });
 });
+
+describe("the summary names the level it publishes", () => {
+  it("uses one sentence form per level, over the whole catalog", async () => {
+    const { checkVendorRisk, loadOffers } = await import("../dist/data.js");
+    const forms: Record<string, string> = {
+      stable: "has a stable pricing history.",
+      caution: "warrants caution —",
+      risky: "is high risk —",
+    };
+    const seen = new Set<string>();
+    const wrong: string[] = [];
+    for (const vendor of [...new Set(loadOffers().map(o => o.vendor))]) {
+      const checked = checkVendorRisk(vendor);
+      if ("error" in checked) continue;
+      const { risk_level, summary } = checked.result;
+      if (risk_level === null) continue;
+      if (!summary.startsWith(vendor)) continue;
+      seen.add(risk_level);
+      if (!summary.includes(`${vendor} ${forms[risk_level]}`)) {
+        wrong.push(`${vendor} (${risk_level}): ${summary.slice(0, 110)}`);
+      }
+    }
+    assert.deepStrictEqual(wrong.slice(0, 10), []);
+    assert.deepStrictEqual([...seen].sort(), ["caution", "risky", "stable"]);
+  });
+});

--- a/test/vendor-verdict.test.ts
+++ b/test/vendor-verdict.test.ts
@@ -15,7 +15,16 @@ import { CHANGE_DIRECTION, enrichOffers, loadDealChanges, loadOffers, vendorRisk
 import { vendorSlugMap } from "../dist/vendor-slug.js";
 import { levelWithheldReason } from "../dist/source-check.js";
 import { offerEnded, ENDED_BADGE_LABEL } from "../dist/retirement.js";
+import { gateFor, utcDate } from "../dist/ranking.js";
 import type { DealChange, RiskCause } from "../dist/types.js";
+
+type Gate = { code: string; reason: string };
+
+const GATED_LEVEL_PHRASE: Record<"stable" | "caution" | "risky", string> = {
+  stable: "has a stable pricing history",
+  caution: "warrants caution",
+  risky: "is high risk",
+};
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const REPO = path.join(__dirname, "..");
@@ -43,7 +52,7 @@ function causeOf(c: DealChange): RiskCause {
 }
 
 function input(over: Partial<VendorVerdictInput> = {}): VendorVerdictInput {
-  return { level: "stable", cause: null, changes: [], levelWithheld: null, unconfirmableSince: "", ...over };
+  return { vendor: "Vendor A", level: "stable", cause: null, changes: [], levelWithheld: null, unconfirmableSince: "", ...over };
 }
 
 describe("vendor verdict — one rating word, and it carries its cause", () => {
@@ -198,6 +207,8 @@ interface VendorRow {
   badgeRendered: boolean;
   sentence: string;
   changes: DealChange[];
+  gate: Gate | null;
+  cause: RiskCause | null;
 }
 
 function vendorRows(): VendorRow[] {
@@ -217,6 +228,7 @@ function vendorRows(): VendorRow[] {
     const unconfirmableSince = enriched.link_unreachable?.last_reachable
       ? ` since ${enriched.link_unreachable.last_reachable}`
       : "";
+    const gate = gateFor(primary, utcDate());
     rows.push({
       slug,
       vendor,
@@ -226,14 +238,18 @@ function vendorRows(): VendorRow[] {
       withheld,
       badgeRendered: ended || !(enriched.risk_level === null || (enriched.link_unreachable && expected === "stable")),
       sentence: vendorVerdictSentence({
+        vendor,
         level: enriched.risk_level ?? null,
         cause: enriched.risk_cause ?? null,
         changes: vendorChanges,
         levelWithheld: withheld,
         unconfirmableSince,
         offerEnded: ended,
+        gated: gate !== null,
       }),
       changes: vendorChanges,
+      gate,
+      cause: enriched.risk_cause ?? null,
     });
   }
   return rows;
@@ -250,6 +266,12 @@ describe("vendor verdict — corpus invariant, computed offline", () => {
       }
       if (!row.badgeRendered) {
         if (/\bWe rate it\b/.test(row.sentence)) wrong.push(`${row.slug}: rates a vendor whose badge is withheld`);
+        continue;
+      }
+      if (row.gate) {
+        if (!row.sentence.includes(`${row.vendor} ${GATED_LEVEL_PHRASE[row.expected]}`)) {
+          wrong.push(`${row.slug}: badge says ${row.expected}, gated verdict says ${row.sentence}`);
+        }
         continue;
       }
       const named = row.sentence.match(/We rate it (stable|caution|risky)\b/)?.[1]
@@ -381,7 +403,10 @@ describe("vendor verdict — as rendered", () => {
         if (COUNT_AS_EVIDENCE.test(verdict) && row.changes.length > 0) {
           wrong.push(`${row.slug}: verdict offers a count of changes as its evidence`);
         }
-        if (cell.rendered && !row.withheld && cell.word !== row.expected) {
+        if (cell.rendered && row.gate && cell.word !== null) {
+          wrong.push(`${row.slug}: comparison table rates a gated record ${cell.word}`);
+        }
+        if (cell.rendered && !row.withheld && !row.gate && cell.word !== row.expected) {
           wrong.push(`${row.slug}: comparison table says ${cell.word ?? "nothing"}, h1 badge says ${row.expected}`);
         }
       }
@@ -404,10 +429,13 @@ describe("vendor verdict — as rendered", () => {
             wrong.push(`${row.slug}: the "${name}" answer reaches for a second scale — ${text}`);
           }
         }
-        if (!row.withheld && !answers.reliable.includes(row.expected)) {
+        const carriesTheRating = row.gate
+          ? answers.reliable.includes(`${row.vendor} ${GATED_LEVEL_PHRASE[row.expected]}`)
+          : answers.reliable.includes(row.expected);
+        if (!row.withheld && !row.ended && !carriesTheRating) {
           wrong.push(`${row.slug}: the reliability answer does not carry the ${row.expected} rating`);
         }
-        if (!row.withheld && row.expected === "stable" && !answers.reliable.includes(narrowingSentence(row.changes))) {
+        if (!row.withheld && !row.ended && row.expected === "stable" && !answers.reliable.includes(narrowingSentence(row.changes))) {
           wrong.push(`${row.slug}: the reliability answer does not say what the records it holds did — ${answers.reliable}`);
         }
         const productionRating = answers.production.match(/we rate it (stable|caution|risky)\b/)?.[1];
@@ -447,11 +475,16 @@ describe("vendor verdict — as rendered", () => {
     assert.deepStrictEqual(wrong.slice(0, 20), [], `vendor routes claiming a narrowing they cannot show:\n${wrong.slice(0, 20).join("\n")}`);
   });
 
-  it("counts one narrowing on the route that carried a repair as a second", async () => {
-    const digitalocean = verdictParagraph(await get("/vendor/digitalocean"));
-    assert.match(digitalocean, /one recorded restriction/);
-    assert.doesNotMatch(digitalocean, /2 recorded changes narrowed the terms/);
-    assert.doesNotMatch(digitalocean, /corrects our own earlier entry/);
+  it("counts one narrowing where a repair to our own entry sits beside it", async () => {
+    const digitalocean = vendorRows().find(r => r.slug === "digitalocean")!;
+    assert.ok(
+      digitalocean.gate,
+      "/vendor/digitalocean renders an ungated record again, so assert this on the page rather than on the composer",
+    );
+    const composed = narrowingSentence(digitalocean.changes);
+    assert.match(composed, /One recorded restriction/);
+    assert.doesNotMatch(composed, /2 recorded changes narrowed the terms/);
+    assert.doesNotMatch(composed, /corrects our own earlier entry/);
 
     const neo4j = verdictParagraph(await get("/vendor/neo4j-auradb"));
     assert.match(neo4j, /The one record we hold corrects our own earlier entry rather than reporting a change the vendor made\./);
@@ -474,7 +507,10 @@ describe("vendor verdict — as rendered", () => {
       assert.doesNotMatch(verdict, STABILITY_SCALE_WORDS, `/vendor/${slug} verdict`);
       assert.ok(verdict.includes(row.sentence), `/vendor/${slug} verdict does not render "${row.sentence}"`);
       assert.notStrictEqual(row.expected, "stable", `/vendor/${slug} still reads stable over a record that points down`);
-      assert.match(row.sentence, /one recorded /, `/vendor/${slug} still names no record behind its level`);
+      assert.ok(
+        row.gate ? row.sentence.includes(row.cause!.summary) : /one recorded /.test(row.sentence),
+        `/vendor/${slug} still names no record behind its level`,
+      );
     }
     assert.ok(cellsChecked > 0, "no route under test rendered a comparison cell, so the badge agreement is unchecked");
   });


### PR DESCRIPTION
Refs #1238.

`gateFor(primary, servedOn)` was already computed once on the vendor page. Four more composers never read it, and four more turned up while building the page-level test this issue asks for.

## The criterion first

`test/gated-vendor-answers.test.ts` now holds a page-level assertion. For every offer where `gateFor(primary, servedOn)` is non-null, the whole rendered page — visible text plus every FAQ answer in the JSON-LD — must contain none of the claims a page makes about an offer we do list:

```
<Vendor>'s free tier offers            <Vendor>'s free tier is considered
<Vendor>'s free tier requires caution  Yes, <Vendor> offers a free tier
We rate it stable / caution / risky    It's stable —
This is a good sign                    This is a positive stability signal
Best for <category> workloads
```

and, outside `eligibility_restricted`, none of `<Vendor>'s free tier is called` or `<Vendor> offers a free tier:`.

Its control is the one that makes it worth having: every one of those strings must still appear on at least one ungated page, so the assertion cannot pass by the string ceasing to exist anywhere.

## The four the issue names

| composer | gated before | gated after | ungated control |
|---|---|---|---|
| quick verdict opens `X's free tier offers` | 153 | **0** | 1,414, unchanged |
| `Is X's free tier reliable?` rates the tier | 39 | **0** | 745, unchanged |
| `When will I outgrow X's free tier?` asked | 157 | **0** | 1,415, unchanged |
| schema.org `Offer` at `"price": "0"` | 157 | **0** | 1,415, unchanged |

The rating is not dropped from the reliability answer — its subject changes. `Stripe's free tier is considered stable.` becomes `Tier "Pay-as-you-go" is usage-billed from the first request. Stripe has a stable pricing history. One recorded pricing restructure narrowed the terms, on 2026-02-01. See the pricing history below.`

## Four more, found by reading for the test rather than for the criteria

- **The compare table rates the record in its own row.** `How Fly.io Compares` published `Fly.io | Legacy Free | stable` under a column headed `Free Tier`. The stability cell now carries the gate code, with the reason as its tooltip — the same two strings the gate line above already publishes.
- **The verdict recommends the record for a workload.** `Best for cloud hosting workloads — 12 alternatives available.` on a record the ranker excludes. Suppressed on the same rule that already suppressed it for a discontinued product.
- **An empty change history reads as a good sign.** 20 gated pages said `This is a good sign — stable pricing.` and answered `What changed in X's pricing?` with `This is a positive stability signal.` Both sentences are removed on a gated page; the first clause stays.
- **The production answer rates the tier where the level is not stable.** #1242 removed `We rate it stable and` from the stable branch. Six pages take the other branch and read `X's free tier is usable for prototyping and development, but we rate it caution because of …`.

The `<h1>` and `<title>` also stop taking the free-tier form on the 20 pages whose gate says there is no free tier — `hasFree` now reads `productionGate`. The 133 `eligibility_restricted` pages keep it: the tier is real, and the restriction is stated directly under the heading.

## No new prose

Every published string is one of three things that already existed:

1. the gate's own composed `reason`, live since #1215;
2. the record's own `description`;
3. a sentence `/api/vendor-risk` publishes today — `X has a stable pricing history.`, `X warrants caution — <date>: <summary> Monitor for further changes.`, `X is high risk — <date>: <summary> Consider alternatives.`

Those three are extracted to `src/vendor-history.ts` and `src/data.ts` composes its summary from them, so the two surfaces cannot drift. `/api/vendor-risk` is byte-identical on every vendor sampled, and a new test pins one sentence form per level across the whole catalog — it had only been asserted non-empty.

## Numbers

- **Sweep:** 2,413 of 2,570 sitemap paths byte-identical. 157 moved, and the moved set is exactly the gated set — 0 pages in one and not the other. 0 status changes.
- **Tests:** 3,027 pass, 0 fail. 14 new, 11 red on `main`.
- **Mutations:** 18 of 18 killed. `scripts/mutate-1238-claims.sh`.
- Verified against a running server, and `/api/vendor-risk` compared between builds rather than assumed.

## One decision worth vetoing

The `stable` / `caution` / `risky` badge beside the `<h1>` stays on the 42 gated pages that carry one, because the verdict beneath it now names its subject — `Fly.io has a stable pricing history.` — rather than rating the tier. Removing it instead is a one-line change.
