### PR TITLE
Ask no free-tier question a gated page then denies or rates (#1238)

### DIFF
--- a/scripts/mutate-1238-questions.sh
+++ b/scripts/mutate-1238-questions.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+set -uo pipefail
+
+REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO"
+
+TESTS=(
+  test/gated-vendor-answers.test.ts
+  test/vendor-verdict.test.ts
+  test/eligibility-disclosure.test.ts
+  test/retired-vendor-page.test.ts
+  test/retired-records.test.ts
+)
+
+SOURCES=(src/serve.ts)
+
+backup() { for f in "${SOURCES[@]}"; do cp "$f" "/tmp/$(basename "$f").qorig"; done; }
+restore() { for f in "${SOURCES[@]}"; do cp "/tmp/$(basename "$f").qorig" "$f"; done; }
+
+backup
+trap 'restore; npm run build >/dev/null 2>&1' EXIT
+
+killed=0
+survived=0
+
+run_mutation() {
+  local name="$1"; shift
+  restore
+  if ! "$@"; then
+    echo "NOT APPLIED                $name"
+    return
+  fi
+  if ! npm run build >/dev/null 2>&1; then
+    echo "KILLED (does not compile)  $name"
+    killed=$((killed + 1))
+    return
+  fi
+  if TZ=UTC node --test --test-concurrency 1 "${TESTS[@]}" >/tmp/mutation-out.txt 2>&1; then
+    echo "SURVIVED                   $name"
+    survived=$((survived + 1))
+  else
+    echo "KILLED                     $name"
+    killed=$((killed + 1))
+  fi
+}
+
+sub() {
+  python3 - "$1" "$2" "$3" <<'PY'
+import sys
+path, old, new = sys.argv[1], sys.argv[2], sys.argv[3]
+text = open(path, encoding="utf-8").read()
+if old not in text:
+    sys.exit("mutation target not found in " + path)
+open(path, "w", encoding="utf-8").write(text.replace(old, new, 1))
+PY
+}
+
+run_mutation "the tier question ignores the gate" \
+  sub src/serve.ts 'const gateStatesThereIsNoFreeTier = productionGate !== null;' 'const gateStatesThereIsNoFreeTier = false;'
+
+run_mutation "the tier question is withheld from every page" \
+  sub src/serve.ts 'const gateStatesThereIsNoFreeTier = productionGate !== null;' 'const gateStatesThereIsNoFreeTier = true;'
+
+run_mutation "the tier question is withheld from every gated page" \
+  sub src/serve.ts 'const gateStatesThereIsNoFreeTier = productionGate !== null;' 'const gateStatesThereIsNoFreeTier = primaryGate !== null;'
+
+run_mutation "the reliability question ignores the gate" \
+  sub src/serve.ts 'const reliabilityAnswerWouldRateAGatedOffer = primaryGate !== null && !offerHasEnded && !levelWithheld;' 'const reliabilityAnswerWouldRateAGatedOffer = false;'
+
+run_mutation "the reliability question is withheld from every page" \
+  sub src/serve.ts 'const reliabilityAnswerWouldRateAGatedOffer = primaryGate !== null && !offerHasEnded && !levelWithheld;' 'const reliabilityAnswerWouldRateAGatedOffer = true;'
+
+run_mutation "the reliability question ignores an ended offer" \
+  sub src/serve.ts 'const reliabilityAnswerWouldRateAGatedOffer = primaryGate !== null && !offerHasEnded && !levelWithheld;' 'const reliabilityAnswerWouldRateAGatedOffer = primaryGate !== null && !levelWithheld;'
+
+run_mutation "the reliability question ignores a withheld level" \
+  sub src/serve.ts 'const reliabilityAnswerWouldRateAGatedOffer = primaryGate !== null && !offerHasEnded && !levelWithheld;' 'const reliabilityAnswerWouldRateAGatedOffer = primaryGate !== null && !offerHasEnded;'
+
+run_mutation "the free-tier question the gate answers is dropped too" \
+  sub src/serve.ts '    { q: `Is ${vendorName} free?`, a: faqFreeAnswer },
+' ''
+
+run_mutation "the reliability answer stops naming the tier it rates" \
+  sub src/serve.ts "? \`\${vendorName}'s free tier is considered stable." "? \`\${vendorName} is stable."
+
+run_mutation "the production answer rates a gated tier again" \
+  sub src/serve.ts '${primaryGate ? "It" : "We rate it stable and it"}' '${"We rate it stable and it"}'
+
+echo
+echo "killed $killed, survived $survived"

--- a/src/serve.ts
+++ b/src/serve.ts
@@ -4141,8 +4141,6 @@ ${allCompareLinks.join("\n")}
     : `Yes, ${vendorName} offers a free tier: ${primary.tier}. ${storedTerms}`;
   const faqTierAnswer = retiredSentence
     ? `${retiredSentence} ${primary.description}`
-    : primaryGateBeyondEligibility
-    ? `${primaryGateBeyondEligibility.reason} ${levelWithheld ? `${unconfirmedTermsPreamble}${withUnconfirmedTermsCaveat(primary.description)}` : primary.description}`
     : eligibilityGateSentence + (levelWithheld
     ? `${unconfirmedTermsPreamble}Our stored record calls ${vendorName}'s free tier "${primary.tier}". ${withUnconfirmedTermsCaveat(primary.description)}`
     : `${vendorName}'s free tier is called "${primary.tier}". ${primary.description}`);
@@ -4150,8 +4148,6 @@ ${allCompareLinks.join("\n")}
     ? endedReliabilitySentence(vendorName)
     : levelWithheld
     ? `We cannot say. ${withheldLevelSentence(levelWithheld, vendorName, unconfirmableSince)} Nothing we have read describes these terms, so we are not publishing a stability judgement for this vendor until that is fixed.`
-    : primaryGate
-    ? `${primaryGate.reason} ${vendorHistorySentence(vendorName, riskLevel, riskCause)}${riskLevel === "stable" && vendorChanges.length > 0 ? ` ${narrowingSentence(vendorChanges)} See the pricing history below.` : ""}`
     : riskLevel === "stable"
     ? `${vendorName}'s free tier is considered stable.${vendorChanges.length > 0 ? ` ${narrowingSentence(vendorChanges)} See the pricing history below.` : ""}`
     : riskLevel === "caution"
@@ -4186,10 +4182,13 @@ ${allCompareLinks.join("\n")}
     ? `${growthBullets[0].replace(/<[^>]*>/g, "")} When you outgrow the free tier, evaluate paid plans against alternatives — sometimes a competitor's free tier covers what you need.`
     : `When your usage exceeds the free tier limits, you'll need to upgrade or evaluate alternatives in the same category.`;
 
+  const gateStatesThereIsNoFreeTier = productionGate !== null;
+  const reliabilityAnswerWouldRateAGatedOffer = primaryGate !== null && !offerHasEnded && !levelWithheld;
+
   const vendorFaqItems = [
     { q: `Is ${vendorName} free?`, a: faqFreeAnswer },
-    { q: `What is ${vendorName}'s free tier?`, a: faqTierAnswer },
-    { q: `Is ${vendorName}'s free tier reliable?`, a: faqReliableAnswer },
+    ...(gateStatesThereIsNoFreeTier ? [] : [{ q: `What is ${vendorName}'s free tier?`, a: faqTierAnswer }]),
+    ...(reliabilityAnswerWouldRateAGatedOffer ? [] : [{ q: `Is ${vendorName}'s free tier reliable?`, a: faqReliableAnswer }]),
     { q: `Is ${vendorName}'s free tier good for production?`, a: faqProductionAnswer },
     { q: `What changed in ${vendorName}'s pricing?`, a: faqChangedAnswer },
     ...(alternatives.length > 0 ? [{ q: `What are the best free alternatives to ${vendorName}?`, a: faqAlternativesAnswer }] : []),

--- a/test/gated-vendor-answers.test.ts
+++ b/test/gated-vendor-answers.test.ts
@@ -84,6 +84,18 @@ function faqAnswer(html: string, prefix: string): string {
   return item?.acceptedAnswer?.text ?? "";
 }
 
+function faqPairs(html: string): { q: string; a: string }[] {
+  const faq = blockOfType(html, "FAQPage");
+  return (faq?.mainEntity ?? []).map((item: { name: string; acceptedAnswer: { text: string } }) => ({
+    q: item.name,
+    a: item.acceptedAnswer.text,
+  }));
+}
+
+function asks(html: string, question: string): boolean {
+  return faqPairs(html).some(pair => pair.q === question);
+}
+
 function textOf(html: string): string {
   return html.replace(/<[^>]*>/g, " ").replace(/&quot;/g, '"').replace(/&amp;/g, "&").replace(/\s+/g, " ").trim();
 }
@@ -185,17 +197,13 @@ describe("the page a gated record renders does not answer the free-tier question
     assert.ok(freeAnswer(digitalocean).startsWith(DIGITALOCEAN_EXPIRY_REASON), freeAnswer(digitalocean).slice(0, 90));
   });
 
-  it("names no free tier in the tier answer either", () => {
+  it("asks nothing about a free tier its own gate says is not there", () => {
     const subjects = gated().filter(p => p.gate!.code !== "eligibility_restricted" && !offerEnded(p.primary));
     assert.ok(subjects.length > 0, "no vendor page renders a record gated outside eligibility");
-    for (const p of subjects) {
-      const answer = faqAnswer(p.html, `What is ${p.vendor}'s free tier?`);
-      assert.ok(answer.startsWith(p.gate!.reason), `/vendor/${p.slug} opens with ${answer.slice(0, 70)}`);
-      assert.ok(
-        !answer.includes(`${p.vendor}'s free tier is called`),
-        `/vendor/${p.slug} still names a free tier`,
-      );
-    }
+    const asking = subjects
+      .filter(p => asks(p.html, `What is ${p.vendor}'s free tier?`))
+      .map(p => `${p.slug} (${p.gate!.code})`);
+    assert.deepStrictEqual(asking, []);
   });
 
   it("keeps the unverified-terms caveat where the source check also withholds the level", () => {
@@ -480,7 +488,94 @@ describe("no page a gated record renders claims a free tier or rates one", () =>
   });
 });
 
+const DECLINES_TO_RATE = [
+  "so there is nothing to rate",
+  "we are not publishing a stability judgement",
+];
+
+const RATES_THE_FREE_TIER = (vendor: string) => [
+  `${vendor}'s free tier is considered stable`,
+  `${vendor}'s free tier is considered risky`,
+  `${vendor}'s free tier requires caution`,
+  "We rate it stable",
+  "We rate it caution",
+  "We rate it risky",
+];
+
+const QUESTIONS_A_GATE_DOES_NOT_TOUCH = (vendor: string) => [
+  `Is ${vendor} free?`,
+  `Is ${vendor}'s free tier good for production?`,
+  `What changed in ${vendor}'s pricing?`,
+  `What category is ${vendor} in?`,
+];
+
+const GATED_PAGES_DECLINING_TO_RATE = 100;
+const GATED_PAGES_NAMING_A_RESTRICTED_TIER = 130;
+
+describe("no question a gated page asks presupposes what its own answer denies", () => {
+  const reliability = (p: VendorPage) => faqAnswer(p.html, `Is ${p.vendor}'s free tier reliable?`);
+
+  it("asks whether the free tier is reliable only where the answer declines to rate it", () => {
+    const asking = gated().filter(p => asks(p.html, `Is ${p.vendor}'s free tier reliable?`));
+    assert.ok(
+      asking.length > GATED_PAGES_DECLINING_TO_RATE,
+      `only ${asking.length} gated pages still ask it, so this assertion has almost no subject`,
+    );
+    const rating = asking
+      .filter(p => !DECLINES_TO_RATE.some(form => reliability(p).includes(form)))
+      .map(p => `${p.slug} (${p.gate!.code}): ${reliability(p).slice(0, 90)}`);
+    assert.deepStrictEqual(rating.slice(0, 20), []);
+  });
+
+  it("answers no question naming a free tier with a rating of that tier", () => {
+    const subjects = gated().filter(p => faqPairs(p.html).some(pair => /free tier/i.test(pair.q)));
+    assert.ok(subjects.length > 0, "no gated page asks about a free tier at all, so this has no subject");
+    const offenders: string[] = [];
+    for (const p of subjects) {
+      for (const { q, a } of faqPairs(p.html)) {
+        if (!/free tier/i.test(q)) continue;
+        for (const form of RATES_THE_FREE_TIER(p.vendor)) {
+          if (a.includes(form)) offenders.push(`${p.slug} (${p.gate!.code}) asked "${q}": ${form}`);
+        }
+      }
+    }
+    assert.deepStrictEqual(offenders.slice(0, 20), []);
+  });
+
+  it("keeps every question the gate does not touch", () => {
+    for (const p of gated()) {
+      for (const q of QUESTIONS_A_GATE_DOES_NOT_TOUCH(p.vendor)) {
+        assert.ok(asks(p.html, q), `/vendor/${p.slug} no longer asks "${q}"`);
+      }
+    }
+  });
+
+  it("still asks what the tier is where the gate is the restriction rather than the tier", () => {
+    const asking = gated().filter(p => asks(p.html, `What is ${p.vendor}'s free tier?`)).length;
+    assert.ok(
+      asking > GATED_PAGES_NAMING_A_RESTRICTED_TIER,
+      `only ${asking} gated pages still ask what the tier is, down from ${GATED_PAGES_NAMING_A_RESTRICTED_TIER}`,
+    );
+  });
+});
+
+const UNGATED_PAGES_ASKING_WHAT_THE_TIER_IS = 1415;
+const UNGATED_PAGES_ASKING_WHETHER_IT_IS_RELIABLE = 1415;
+
 describe("the same page an ungated record renders is unchanged", () => {
+  it("still asks what its free tier is and whether that tier is reliable", () => {
+    const tier = ungated().filter(p => asks(p.html, `What is ${p.vendor}'s free tier?`)).length;
+    const reliable = ungated().filter(p => asks(p.html, `Is ${p.vendor}'s free tier reliable?`)).length;
+    assert.ok(
+      tier >= UNGATED_PAGES_ASKING_WHAT_THE_TIER_IS,
+      `${tier} ungated pages ask what the tier is, down from ${UNGATED_PAGES_ASKING_WHAT_THE_TIER_IS}`,
+    );
+    assert.ok(
+      reliable >= UNGATED_PAGES_ASKING_WHETHER_IT_IS_RELIABLE,
+      `${reliable} ungated pages ask whether it is reliable, down from ${UNGATED_PAGES_ASKING_WHETHER_IT_IS_RELIABLE}`,
+    );
+  });
+
   it("still makes every one of those claims somewhere", () => {
     const unmade: string[] = [];
     for (const claim of [...CLAIMS_A_RATING("<vendor>", "<category>"), ...NAMES_A_FREE_TIER("<vendor>")]) {

--- a/test/vendor-verdict.test.ts
+++ b/test/vendor-verdict.test.ts
@@ -359,20 +359,18 @@ describe("vendor verdict — as rendered", () => {
     };
   };
 
-  const faqAnswers = (html: string, vendor: string): { reliable: string; production: string } => {
+  const faqAnswers = (html: string, vendor: string): { reliable: string | null; production: string } => {
     const blocks = [...html.matchAll(/<script type="application\/ld\+json">([\s\S]*?)<\/script>/g)]
       .map(m => JSON.parse(m[1]) as Record<string, unknown>);
     const faq = blocks.find(b => b["@type"] === "FAQPage") as
       { mainEntity: Array<{ name: string; acceptedAnswer: { text: string } }> } | undefined;
     assert.ok(faq, `${vendor} emits FAQ structured data`);
-    const find = (name: string) => {
-      const q = faq.mainEntity.find(e => e.name === name);
-      assert.ok(q, `the structured data answers "${name}"`);
-      return q.acceptedAnswer.text;
-    };
+    const find = (name: string) => faq.mainEntity.find(e => e.name === name)?.acceptedAnswer.text ?? null;
+    const production = find(`Is ${vendor}'s free tier good for production?`);
+    assert.ok(production, `the structured data answers "Is ${vendor}'s free tier good for production?"`);
     return {
       reliable: find(`Is ${vendor}'s free tier reliable?`),
-      production: find(`Is ${vendor}'s free tier good for production?`),
+      production,
     };
   };
 
@@ -425,18 +423,24 @@ describe("vendor verdict — as rendered", () => {
         const html = await get(`/vendor/${row.slug}`);
         const answers = faqAnswers(html, row.vendor);
         for (const [name, text] of Object.entries(answers)) {
-          if (OTHER_SCALE_ON_A_SURFACE_THAT_EMBEDS_SUMMARIES.test(text)) {
+          if (text !== null && OTHER_SCALE_ON_A_SURFACE_THAT_EMBEDS_SUMMARIES.test(text)) {
             wrong.push(`${row.slug}: the "${name}" answer reaches for a second scale — ${text}`);
           }
         }
-        const carriesTheRating = row.gate
-          ? answers.reliable.includes(`${row.vendor} ${GATED_LEVEL_PHRASE[row.expected]}`)
-          : answers.reliable.includes(row.expected);
-        if (!row.withheld && !row.ended && !carriesTheRating) {
-          wrong.push(`${row.slug}: the reliability answer does not carry the ${row.expected} rating`);
+        const wouldRateAGatedOffer = row.gate !== null && !row.withheld && !row.ended;
+        if (wouldRateAGatedOffer && answers.reliable !== null) {
+          wrong.push(`${row.slug}: asks whether a gated free tier is reliable — ${answers.reliable}`);
         }
-        if (!row.withheld && !row.ended && row.expected === "stable" && !answers.reliable.includes(narrowingSentence(row.changes))) {
-          wrong.push(`${row.slug}: the reliability answer does not say what the records it holds did — ${answers.reliable}`);
+        if (!wouldRateAGatedOffer && answers.reliable === null) {
+          wrong.push(`${row.slug}: no longer asks whether its free tier is reliable`);
+        }
+        if (answers.reliable !== null && !row.withheld && !row.ended) {
+          if (!answers.reliable.includes(row.expected)) {
+            wrong.push(`${row.slug}: the reliability answer does not carry the ${row.expected} rating`);
+          }
+          if (row.expected === "stable" && !answers.reliable.includes(narrowingSentence(row.changes))) {
+            wrong.push(`${row.slug}: the reliability answer does not say what the records it holds did — ${answers.reliable}`);
+          }
         }
         const productionRating = answers.production.match(/we rate it (stable|caution|risky)\b/)?.[1];
         if (productionRating && productionRating !== row.expected) {


### PR DESCRIPTION
Refs #1238 — the remaining criterion, read at the level of the question rather than the answer.

## What was wrong

Your census: **32 of 32 sampled gated primaries still ask `What is X's free tier?`**, and some still rate one. Reproduced over all 157 gated primaries, not a sample:

| question | asked on gated pages | of which answered with a rating |
|---|---|---|
| `What is X's free tier?` | 157 | — |
| `Is X's free tier reliable?` | 157 | **39** |
| `Is X's free tier good for production?` | 157 | 7 |

`/vendor/github` was your example and it is exact: *"Is GitHub's free tier reliable?"* → *"Restricted to student (GitHub Student Developer Pack) applicants — not generally available. GitHub has a stable pricing history."*

## What changed

Two predicates, both about whether the question should be asked at all:

- **`What is X's free tier?` is withheld where the gate itself states there is no free tier** — `not_a_free_offer` and `offer_expired`. 157 → 137.
- **`Is X's free tier reliable?` is withheld wherever the answer would rate a gated offer.** 157 → 118.

Both are still asked where the answer *declines* to rate — the 4 ended records, which answer with the sentence from #1235 criterion 6 (*"X has ended this offer, so there is nothing to rate"*), and the 114 whose level the source check withholds (*"we are not publishing a stability judgement"*). Removing those would have unpublished a criterion you already have.

`/vendor/fly-io` now asks four questions and none presupposes a free tier. The rating did not disappear — the verdict one screen up still reads *"Fly.io has a stable pricing history."*

## What I did not change, and why

**The 133 `eligibility_restricted` pages keep `What is X's free tier?` and both keep `Is X's free tier good for production?`.** Two of your own shipped criteria pin them:

- `test/eligibility-disclosure.test.ts:278` — *"qualifies the two that state or recommend the terms"* requires exactly these two answers on an eligibility-gated page, opening with the restriction (#1215).
- `test/retired-records.test.ts:151` — requires `What is X's free tier?` on a retired page to open with the stored-tier sentence (#1232).

On an eligibility page the answer does not deny the premise: the tier is real for someone who qualifies and the restriction is the first clause. Widening either predicate to `primaryGate !== null` is a one-line change and I have left the mutation in the script that proves what it costs — it takes those criteria red, which is the answer to whether you want it.

**7 eligibility pages still answer `Is X's free tier good for production?` with a pricing-history rating** — e.g. *"Restricted to fintech (Mercury Perks) applicants — not generally available. Mercury's free tier is usable for prototyping and development. Mercury warrants caution — …"*. That is the substitution you asked for in #1243: the rating's subject is the vendor's history, not the tier. Named here so it is your call, not mine.

## Proof

**Sweep, whole bodies, both builds.** 2,577 paths: **2,528 byte-identical, 49 moved, 0 status changes.** All 49 are `/vendor/*`, and **every changed line on every moved page is inside the FAQ block** — 0 pages changed anything outside it.

The moved set was predicted independently, from `gateFor` plus `main`'s own rendered answers, before the diff: **49 predicted, 49 moved, 0 in one and not the other.** 39 lost the reliability question, 20 lost the tier question, 10 lost both.

**Tests.** 3,032 pass, 0 fail. 5 new; **3 red on `main`** — `asks nothing about a free tier its own gate says is not there` (20 offenders), `asks whether the free tier is reliable only where the answer declines to rate it` (39), and `vendor-verdict`'s stability-question check.

Controls, so none of it can pass vacuously:
- gated pages still asking the reliability question must number **> 100** — otherwise the "declines to rate" assertion has almost no subject
- gated pages still asking the tier question must number **> 130**
- every gated page must still ask all four questions the gate does not touch
- all 1,415 ungated pages must still ask both

**Mutations: 10 of 10 killed** (`scripts/mutate-1238-questions.sh`). Both directions — each predicate forced to `false` (the question returns) and to `true` (the question vanishes from every page), plus dropping `!offerHasEnded` and `!levelWithheld` one at a time, plus re-rating a gated tier in the production answer to prove the general net bites.

## Found while sweeping, not fixed

**`/alternative-to/<slug>` answers `Is X's free tier still available?` with `Yes` on 10 of the 16 gated records that have one.** `/alternative-to/stripe` reads *"Yes, Stripe currently offers a free tier (Pay-as-you-go)."* Its composer reads `risk_level` and the withheld level and holds no gate at all — a fourth surface for #1241's shape rather than a fifth composer for this one. Filed nowhere yet; counts on the issue.
