### PR TITLE
Carry the ranking gate on every JSON surface (#1241 Part 1)

### DIFF
--- a/scripts/mutate-1241-gate-field.sh
+++ b/scripts/mutate-1241-gate-field.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+set -uo pipefail
+
+REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO"
+
+TESTS=(
+  test/api-gate-field.test.ts
+)
+
+SOURCES=(src/data.ts src/serve.ts src/server.ts src/gate-disclosure.ts)
+
+backup() { for f in "${SOURCES[@]}"; do cp "$f" "/tmp/$(basename "$f").gorig"; done; }
+restore() { for f in "${SOURCES[@]}"; do cp "/tmp/$(basename "$f").gorig" "$f"; done; }
+
+backup
+trap 'restore; npm run build >/dev/null 2>&1' EXIT
+
+killed=0
+survived=0
+
+run_mutation() {
+  local name="$1"; shift
+  restore
+  if ! "$@"; then
+    echo "NOT APPLIED                $name"
+    return
+  fi
+  if ! npm run build >/dev/null 2>&1; then
+    echo "KILLED (does not compile)  $name"
+    killed=$((killed + 1))
+    return
+  fi
+  if TZ=UTC node --test --test-concurrency 1 "${TESTS[@]}" >/tmp/mutation-out.txt 2>&1; then
+    echo "SURVIVED                   $name"
+    survived=$((survived + 1))
+  else
+    echo "KILLED                     $name"
+    killed=$((killed + 1))
+  fi
+}
+
+sub() {
+  python3 - "$1" "$2" "$3" <<'PY'
+import sys
+path, old, new = sys.argv[1], sys.argv[2], sys.argv[3]
+text = open(path, encoding="utf-8").read()
+if old not in text:
+    sys.exit("mutation target not found in " + path)
+open(path, "w", encoding="utf-8").write(text.replace(old, new, 1))
+PY
+}
+
+run_mutation "the per-offer gate is always null" \
+  sub src/data.ts 'gate: gateFor(offer, servedOn) };' 'gate: null };'
+
+run_mutation "the per-offer gate reads one gate code out of five, as the surfaces did before" \
+  sub src/data.ts 'gate: gateFor(offer, servedOn) };' \
+                  'gate: gateFor(offer, servedOn)?.code === "eligibility_restricted" ? gateFor(offer, servedOn) : null };'
+
+run_mutation "the vendor detail carries no gate" \
+  sub src/data.ts 'gate: gateForOffer(match),' 'gate: null,'
+
+run_mutation "the alternatives on a vendor detail always report no gate" \
+  sub src/data.ts 'stripReferrerValue({ ...withLinkHealth(o), gate: gateForOffer(o) })' 'stripReferrerValue({ ...withLinkHealth(o), gate: null })'
+
+run_mutation "vendor-risk rates a gated offer again" \
+  sub src/data.ts 'risk_level: gate || (cannotVouchForLevel(offer, linkUnreachable) && riskLevel === "stable") ? null : riskLevel,' \
+                  'risk_level: cannotVouchForLevel(offer, linkUnreachable) && riskLevel === "stable" ? null : riskLevel,'
+
+run_mutation "vendor-risk reassures about a gated offer again" \
+  sub src/data.ts 'summary = `${gateRiskSummary(gate)}${unreadCitation}`;' \
+                  'summary = `${vendorHistorySentence(offer.vendor, "stable", cause)} Free tier verified for ${longevityDays} days.`;'
+
+run_mutation "a gated summary drops the citation we could not read" \
+  sub src/data.ts 'summary = `${gateRiskSummary(gate)}${unreadCitation}`;' 'summary = gateRiskSummary(gate);'
+
+run_mutation "a gated alternative on vendor-risk keeps its rating" \
+  sub src/data.ts 'risk_level: altGate || (cannotVouchForLevel(e.offer, unreachable) && a.level === "stable") ? null : a.level,' \
+                  'risk_level: cannotVouchForLevel(e.offer, unreachable) && a.level === "stable" ? null : a.level,'
+
+run_mutation "vendor-risk counts free-tier days for an offer with no free tier" \
+  sub src/data.ts 'free_tier_longevity_days: gate && GATES_WITHOUT_A_LONGEVITY_REFERENT.has(gate.code) ? null : longevityDays,' \
+                  'free_tier_longevity_days: longevityDays,'
+
+run_mutation "vendor-risk withholds the day count from every gated code, not the two with no referent" \
+  sub src/data.ts 'gate && GATES_WITHOUT_A_LONGEVITY_REFERENT.has(gate.code) ? null : longevityDays' \
+                  'gate ? null : longevityDays'
+
+run_mutation "a retired offer gets the generic decline instead of its own sentence" \
+  sub src/data.ts '  if (gate.code === "offer_retired") return endedVerdictSentence();
+' ''
+
+run_mutation "/api/offers counts the returned page instead of the whole match" \
+  sub src/serve.ts 'gateDisclosureFor("offer", results.map(o => gateForOffer(o)))' \
+                   'gateDisclosureFor("offer", paged.map(o => gateForOffer(o)))'
+
+run_mutation "/api/offers publishes no response-level count" \
+  sub src/serve.ts ', ...offersDisclosure })));' ' })));'
+
+run_mutation "search_deals publishes no response-level count" \
+  sub src/server.ts ', offset: effectiveOffset, ...disclosure }' ', offset: effectiveOffset }'
+
+run_mutation "concise mode drops the gate" \
+  sub src/server.ts 'url: offer.url, gate: gateForOffer(offer),' 'url: offer.url,'
+
+run_mutation "the disclosure never uses the all-gated form" \
+  sub src/gate-disclosure.ts 'if (gated >= total && total > 1) return `None of ${subject} are on our ranked list — ${clauses}.`;
+' ''
+
+run_mutation "the disclosure never uses the singular form" \
+  sub src/gate-disclosure.ts 'if (gated === 1) return `One of ${subject} is not on our ranked list — ${clauses}.`;
+' ''
+
+run_mutation "the clause list ignores plural agreement" \
+  sub src/gate-disclosure.ts 'clauses.push(n === 1 ? clause.one : clause.many(n));' 'clauses.push(clause.many(n));'
+
+run_mutation "the clause list reports only the first gate code it finds" \
+  sub src/gate-disclosure.ts '    clauses.push(n === 1 ? clause.one : clause.many(n));' \
+                             '    clauses.push(n === 1 ? clause.one : clause.many(n));
+    break;'
+
+run_mutation "the clause order follows the gate table rather than the criteria" \
+  sub src/gate-disclosure.ts 'for (const clause of GATE_CLAUSES) {' 'for (const clause of [...GATE_CLAUSES].reverse()) {'
+
+run_mutation "the subject is always plural" \
+  sub src/gate-disclosure.ts '${total === 1 ? "" : "s"}' 's'
+
+echo
+echo "killed $killed, survived $survived"

--- a/src/data.ts
+++ b/src/data.ts
@@ -3,7 +3,7 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 import type { Offer, EnrichedOffer, OfferIndex, DealChange, DealChangesIndex, ChangeDateSource, StabilityClass, Referral, RiskCause, LinkUnreachable } from "./types.js";
 import { isUrlSuspended } from "./referral-health.js";
-import { rankForListing, type TieBreak } from "./ranking.js";
+import { rankForListing, gateFor, utcDate, type TieBreak, type Gate, type GateCode } from "./ranking.js";
 import { unreachableNoticeForUrl, resetLinkHealthCache } from "./link-health.js";
 import { quarantineSummary, resetVerificationStateCache, type QuarantineSummary } from "./verification-state.js";
 import { cannotVouchForLevel, levelWithheldReason, withheldLevelSentence } from "./source-check.js";
@@ -11,6 +11,18 @@ import { substitutesFor } from "./product-role.js";
 import { DATE_SOURCES, isEventDated, changeDateClause, isoWeekWindow, changesInWindow, discoveryBatchNote, firstReadHeading, type DateWindow } from "./change-dates.js";
 import { PRODUCT_DEPRECATED, deprecationEndsTheListedProduct } from "./product-deprecation.js";
 import { vendorHistorySentence } from "./vendor-history.js";
+import { endedVerdictSentence } from "./retirement.js";
+
+export function gateForOffer(offer: Offer): Gate | null {
+  return gateFor(offer, utcDate());
+}
+
+export function gateRiskSummary(gate: Gate): string {
+  if (gate.code === "offer_retired") return endedVerdictSentence();
+  return `${gate.reason} We do not rate an offer we do not list.`;
+}
+
+const GATES_WITHOUT_A_LONGEVITY_REFERENT = new Set<GateCode>(["offer_retired", "not_a_free_offer"]);
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const INDEX_PATH =
@@ -87,7 +99,7 @@ export function withLinkHealth<T extends Offer>(offer: T): T & { link_unreachabl
 export function getOfferDetails(
   vendorName: string,
   includeAlternatives: boolean = false
-): { offer: OfferWithLinkHealth & { relatedVendors: string[]; alternatives?: OfferWithLinkHealth[]; tie_break: TieBreak } } | { error: string; suggestions: string[] } {
+): { offer: OfferWithLinkHealth & { gate: Gate | null; relatedVendors: string[]; alternatives?: Array<OfferWithLinkHealth & { gate: Gate | null }>; tie_break: TieBreak } } | { error: string; suggestions: string[] } {
   const offers = loadOffers();
   const lowerName = vendorName.toLowerCase();
   const match = offers.find((o) => o.vendor.toLowerCase() === lowerName);
@@ -99,13 +111,14 @@ export function getOfferDetails(
     );
     const sameCategoryOffers = relatedRanking.entries.slice(0, 5).map((e) => e.offer);
     const relatedVendors = sameCategoryOffers.map((o) => o.vendor);
-    const result: OfferWithLinkHealth & { relatedVendors: string[]; alternatives?: OfferWithLinkHealth[]; tie_break: TieBreak } = {
+    const result: OfferWithLinkHealth & { gate: Gate | null; relatedVendors: string[]; alternatives?: Array<OfferWithLinkHealth & { gate: Gate | null }>; tie_break: TieBreak } = {
       ...withLinkHealth(match),
+      gate: gateForOffer(match),
       relatedVendors,
       tie_break: relatedRanking.tie_break,
     };
     if (includeAlternatives) {
-      result.alternatives = sameCategoryOffers.map(o => stripReferrerValue(withLinkHealth(o)));
+      result.alternatives = sameCategoryOffers.map(o => stripReferrerValue({ ...withLinkHealth(o), gate: gateForOffer(o) }));
     }
     return { offer: stripReferrerValue(result) };
   }
@@ -353,6 +366,7 @@ export function getStabilityMap(): Map<string, StabilityClass> {
 export function enrichOffers(offers: Offer[]): EnrichedOffer[] {
   const changes = loadDealChanges();
   const now = new Date();
+  const servedOn = utcDate();
   const ninetyDaysMs = 90 * 24 * 60 * 60 * 1000;
   const cutoffDate = new Date(now.getTime() - ninetyDaysMs).toISOString().slice(0, 10);
 
@@ -409,7 +423,7 @@ export function enrichOffers(offers: Offer[]): EnrichedOffer[] {
       (now.getTime() - new Date(offer.verifiedDate).getTime()) / (24 * 60 * 60 * 1000)
     );
 
-    const enriched = { ...offer, recent_change, expires_soon, risk_level, risk_cause, stability, days_since_verified, link_unreachable };
+    const enriched = { ...offer, recent_change, expires_soon, risk_level, risk_cause, stability, days_since_verified, link_unreachable, gate: gateFor(offer, servedOn) };
     return stripReferrerValue(enriched);
   });
 }
@@ -640,9 +654,10 @@ export interface VendorRiskResult {
   risk_level: "stable" | "caution" | "risky" | null;
   risk_cause: RiskCause | null;
   link_unreachable: LinkUnreachable | null;
-  free_tier_longevity_days: number;
+  gate: Gate | null;
+  free_tier_longevity_days: number | null;
   changes: DealChange[];
-  alternatives: Array<{ vendor: string; category: string; tier: string; risk_level: "stable" | "caution" | "risky" | null; risk_cause: RiskCause | null; link_unreachable: LinkUnreachable | null; demerits: Array<{ code: string; points: number; reason: string }> }>;
+  alternatives: Array<{ vendor: string; category: string; tier: string; risk_level: "stable" | "caution" | "risky" | null; risk_cause: RiskCause | null; link_unreachable: LinkUnreachable | null; gate: Gate | null; demerits: Array<{ code: string; points: number; reason: string }> }>;
   tie_break: TieBreak;
   summary: string;
 }
@@ -743,6 +758,7 @@ export function checkVendorRisk(
   }
 
   const offer = match.offer;
+  const gate = gateForOffer(offer);
   const allChanges = loadDealChanges();
   const vendorChanges = allChanges
     .filter((c) => c.vendor.toLowerCase() === offer.vendor.toLowerCase())
@@ -773,10 +789,12 @@ export function checkVendorRisk(
     ...(() => {
       const a = vendorRiskAssessment(allChanges.filter((c) => c.vendor.toLowerCase() === e.offer.vendor.toLowerCase()));
       const unreachable = unreachableNoticeForUrl(e.offer.url);
+      const altGate = gateForOffer(e.offer);
       return {
-        risk_level: cannotVouchForLevel(e.offer, unreachable) && a.level === "stable" ? null : a.level,
+        risk_level: altGate || (cannotVouchForLevel(e.offer, unreachable) && a.level === "stable") ? null : a.level,
         risk_cause: a.cause ? { date: a.cause.date, date_source: a.cause.date_source, change_type: a.cause.change_type, summary: a.cause.summary } : null,
         link_unreachable: unreachable,
+        gate: altGate,
       };
     })(),
     demerits: e.demerits.map((d) => ({ code: d.code, points: d.points, reason: d.reason })),
@@ -789,7 +807,12 @@ export function checkVendorRisk(
   const unreachableClause = linkUnreachable
     ? ` Its pricing page has not resolved for us${unreachableSince}, so we cannot confirm its current terms.`
     : "";
-  if ((riskLevel === "risky" || riskLevel === "caution") && cause) {
+  if (gate) {
+    const unreadCitation = withheldReason
+      ? ` ${withheldLevelSentence(withheldReason, offer.vendor, unreachableSince)}`
+      : "";
+    summary = `${gateRiskSummary(gate)}${unreadCitation}`;
+  } else if ((riskLevel === "risky" || riskLevel === "caution") && cause) {
     summary = `${vendorHistorySentence(offer.vendor, riskLevel, cause)}${unreachableClause}`;
   } else if (withheldReason) {
     summary = `${withheldLevelSentence(withheldReason, offer.vendor, unreachableSince)} Nothing we have read describes this offer. Treat that as a statement about our records, not as a stable pricing history.`;
@@ -801,10 +824,11 @@ export function checkVendorRisk(
     result: {
       vendor: offer.vendor,
       category: offer.category,
-      risk_level: cannotVouchForLevel(offer, linkUnreachable) && riskLevel === "stable" ? null : riskLevel,
+      risk_level: gate || (cannotVouchForLevel(offer, linkUnreachable) && riskLevel === "stable") ? null : riskLevel,
       risk_cause: cause ? { date: cause.date, date_source: cause.date_source, change_type: cause.change_type, summary: cause.summary } : null,
       link_unreachable: linkUnreachable,
-      free_tier_longevity_days: longevityDays,
+      gate,
+      free_tier_longevity_days: gate && GATES_WITHOUT_A_LONGEVITY_REFERENT.has(gate.code) ? null : longevityDays,
       changes: vendorChanges,
       alternatives,
       tie_break: alternativesRanking.tie_break,
@@ -981,7 +1005,7 @@ export function getNewestDeals(params: {
   since?: string;
   limit?: number;
   category?: string;
-}): { deals: Array<Offer & { days_since_update: number }>; total: number } {
+}): { deals: Array<Offer & { days_since_update: number; gate: Gate | null }>; total: number } {
   const now = new Date();
   const defaultSince = new Date(now.getTime() - 30 * 24 * 60 * 60 * 1000)
     .toISOString()
@@ -1003,6 +1027,7 @@ export function getNewestDeals(params: {
     days_since_update: Math.floor(
       (now.getTime() - new Date(o.verifiedDate).getTime()) / (24 * 60 * 60 * 1000)
     ),
+    gate: gateForOffer(o),
   }));
 
   return { deals, total: deals.length };

--- a/src/gate-disclosure.ts
+++ b/src/gate-disclosure.ts
@@ -1,0 +1,63 @@
+import type { Gate, GateCode } from "./ranking.js";
+
+const GATE_CLAUSES: { code: GateCode; one: string; many: (n: number) => string }[] = [
+  {
+    code: "eligibility_restricted",
+    one: "1 requires an application or qualification",
+    many: (n) => `${n} require an application or qualification`,
+  },
+  {
+    code: "not_a_free_offer",
+    one: "1 is not a free offer",
+    many: (n) => `${n} are not free offers`,
+  },
+  {
+    code: "offer_expired",
+    one: "1 has expired",
+    many: (n) => `${n} have expired`,
+  },
+  {
+    code: "offer_retired",
+    one: "1 has ended",
+    many: (n) => `${n} have ended`,
+  },
+  {
+    code: "verification_lapsed",
+    one: "1 has not been re-confirmed recently enough",
+    many: (n) => `${n} have not been re-confirmed recently enough`,
+  },
+];
+
+export function gateClauseList(codes: GateCode[]): string {
+  const clauses: string[] = [];
+  for (const clause of GATE_CLAUSES) {
+    const n = codes.filter((c) => c === clause.code).length;
+    if (n === 0) continue;
+    clauses.push(n === 1 ? clause.one : clause.many(n));
+  }
+  return clauses.join(", ");
+}
+
+export function gateDisclosureSentence(subject: string, total: number, codes: GateCode[]): string {
+  const gated = codes.length;
+  if (gated === 0 || total === 0) return "";
+  const clauses = gateClauseList(codes);
+  if (gated >= total && total > 1) return `None of ${subject} are on our ranked list — ${clauses}.`;
+  if (gated === 1) return `One of ${subject} is not on our ranked list — ${clauses}.`;
+  return `${gated} of ${subject} are not on our ranked list — ${clauses}.`;
+}
+
+export function matchingSubject(noun: string, total: number): string {
+  return `the ${total} ${noun}${total === 1 ? "" : "s"} matching this query`;
+}
+
+export interface GateDisclosure {
+  gated: number;
+  gate_summary?: string;
+}
+
+export function gateDisclosureFor(noun: string, gates: (Gate | null)[]): GateDisclosure {
+  const codes = gates.filter((g): g is Gate => g !== null).map((g) => g.code);
+  const summary = gateDisclosureSentence(matchingSubject(noun, gates.length), gates.length, codes);
+  return { gated: codes.length, ...(summary ? { gate_summary: summary } : {}) };
+}

--- a/src/openapi.ts
+++ b/src/openapi.ts
@@ -40,12 +40,15 @@ export const openapiSpec = {
                   type: "object",
                   properties: {
                     offers: { type: "array", items: { $ref: "#/components/schemas/Offer" } },
-                    total: { type: "integer", description: "Total matching offers (before pagination)" }
+                    total: { type: "integer", description: "Total matching offers (before pagination)" },
+                    gated: { type: "integer", description: "How many of the `total` matching offers carry a non-null `gate` — counted over the whole match, not the returned page (#1241)." },
+                    gate_summary: { type: "string", description: "One line stating how many of the matching offers are not on our ranked list and why. Absent when `gated` is 0." }
                   }
                 },
                 example: {
-                  offers: [{ vendor: "Supabase", category: "Cloud Hosting", description: "Open-source Firebase alternative with Postgres database, auth, storage, and edge functions. Free tier: 2 projects, 500MB database, 1GB file storage, 50K monthly active users.", tier: "Free", url: "https://supabase.com/pricing", tags: ["database", "auth", "serverless"], verifiedDate: "2026-03-01" }],
-                  total: 1
+                  offers: [{ vendor: "Supabase", category: "Cloud Hosting", description: "Open-source Firebase alternative with Postgres database, auth, storage, and edge functions. Free tier: 2 projects, 500MB database, 1GB file storage, 50K monthly active users.", tier: "Free", url: "https://supabase.com/pricing", tags: ["database", "auth", "serverless"], verifiedDate: "2026-03-01", gate: null }],
+                  total: 1,
+                  gated: 0
                 }
               }
             }
@@ -372,10 +375,11 @@ export const openapiSpec = {
                   properties: {
                     vendor: { type: "string" },
                     category: { type: "string" },
-                    risk_level: { type: "string", enum: ["stable", "caution", "risky"], nullable: true, description: "Null where the offer's own link is confirmed unreachable (#1046) — we withhold the level rather than publish a favourable one we cannot check." },
+                    risk_level: { type: "string", enum: ["stable", "caution", "risky"], nullable: true, description: "Null where the offer's own link is confirmed unreachable (#1046) — we withhold the level rather than publish a favourable one we cannot check. Also null where gate is non-null (#1241): an offer we have decided not to list is not one we rate." },
                     link_unreachable: { type: "object", nullable: true, description: "Non-null only where a check reached a conclusion about the destination: a 404 confirmed by a full request, a 410, or a hostname with no address. Being refused (403, 429, 5xx, timeout) is evidence about our checker and never produces one of these.", properties: { last_reachable: { type: "string", format: "date", nullable: true }, checked: { type: "string", format: "date" }, terminal: { type: "boolean" } } },
                     risk_cause: { type: "object", nullable: true, description: "The single dated record that produced a non-stable risk_level. Never null when risk_level is caution or risky (#1038) — a client that renders the level must be able to render the reason.", properties: { date: { type: "string" }, change_type: { type: "string" }, summary: { type: "string" } } },
-                    free_tier_longevity_days: { type: "number" },
+                    gate: { $ref: "#/components/schemas/Gate" },
+                    free_tier_longevity_days: { type: "number", nullable: true, description: "Null where the gate code is offer_retired or not_a_free_offer (#1241) — a count of days a free tier has held has no referent where our own record says there is no free tier." },
                     changes: { type: "array", items: { $ref: "#/components/schemas/DealChange" } },
                     alternatives: {
                       type: "array",
@@ -385,8 +389,9 @@ export const openapiSpec = {
                           vendor: { type: "string" },
                           category: { type: "string" },
                           tier: { type: "string" },
-                          risk_level: { type: "string", enum: ["stable", "caution", "risky"], nullable: true, description: "Null where this alternative's own link is confirmed unreachable (#1046)." },
+                          risk_level: { type: "string", enum: ["stable", "caution", "risky"], nullable: true, description: "Null where this alternative's own link is confirmed unreachable (#1046), and null where its gate is non-null (#1241) — rankForListing demotes a gated record to the tail rather than dropping it, so an alternative can be one we do not list." },
                           link_unreachable: { type: "object", nullable: true, properties: { last_reachable: { type: "string", format: "date", nullable: true }, checked: { type: "string", format: "date" }, terminal: { type: "boolean" } } },
+                          gate: { $ref: "#/components/schemas/Gate" },
                           risk_cause: { type: "object", nullable: true, description: "The single dated record that produced a non-stable risk_level. Never null when risk_level is caution or risky (#1038) — a client that renders the level must be able to render the reason.", properties: { date: { type: "string" }, change_type: { type: "string" }, summary: { type: "string" } } }
                         }
                       }
@@ -917,9 +922,20 @@ export const openapiSpec = {
           url: { type: "string", format: "uri", description: "Pricing/offer page URL" },
           tags: { type: "array", items: { type: "string" }, description: "Searchable tags" },
           verifiedDate: { type: "string", format: "date", description: "Date the offer was last verified (YYYY-MM-DD)" },
-          eligibility: { $ref: "#/components/schemas/Eligibility" }
+          eligibility: { $ref: "#/components/schemas/Eligibility" },
+          gate: { $ref: "#/components/schemas/Gate" }
         },
         required: ["vendor", "category", "description", "tier", "url", "tags", "verifiedDate"]
+      },
+      Gate: {
+        type: "object",
+        nullable: true,
+        description: "Why we do not rank this offer, or null where we do. The same verdict rankOffers applies, from the same function (#1241) — nothing is filtered out of a response because of it, so a caller asking whether an offer exists still gets the record. The full code table is published at /criteria.",
+        properties: {
+          code: { type: "string", enum: ["eligibility_restricted", "not_a_free_offer", "offer_expired", "offer_retired", "verification_lapsed"] },
+          reason: { type: "string", description: "The reason we publish for this record, naming the tier, date or restriction the code was decided on." }
+        },
+        required: ["code", "reason"]
       },
       Eligibility: {
         type: "object",

--- a/src/serve.ts
+++ b/src/serve.ts
@@ -5,7 +5,7 @@ import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
 import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
 import { createServer, getServerCard } from "./server.js";
-import { vendorRiskAssessment, NEGATIVE_CHANGE_TYPES, POSITIVE_CHANGE_TYPES, SEVERE_CHANGE_TYPES, loadOffers, getCategories, getNewOffers, getNewestDeals, searchOffers, enrichOffers, loadDealChanges, getDealChanges, getPersonalizedChanges, getOfferDetails, compareServices, checkVendorRisk, auditStack, getExpiringDeals, getWeeklyDigest, getFormattedWeeklyDigest, getFreshnessMetrics, getStabilityMap, getVendorReferral, sanitizeQuery, getChangeLogFreshness, isEventDated, partitionByDateProvenance } from "./data.js";
+import { vendorRiskAssessment, NEGATIVE_CHANGE_TYPES, POSITIVE_CHANGE_TYPES, SEVERE_CHANGE_TYPES, loadOffers, getCategories, getNewOffers, getNewestDeals, searchOffers, enrichOffers, gateForOffer, loadDealChanges, getDealChanges, getPersonalizedChanges, getOfferDetails, compareServices, checkVendorRisk, auditStack, getExpiringDeals, getWeeklyDigest, getFormattedWeeklyDigest, getFreshnessMetrics, getStabilityMap, getVendorReferral, sanitizeQuery, getChangeLogFreshness, isEventDated, partitionByDateProvenance } from "./data.js";
 import { getStackRecommendation } from "./stacks.js";
 import { estimateCosts } from "./costs.js";
 import { classifyRequest } from "./client-class.js";
@@ -45,6 +45,7 @@ import { discontinuedOnOrBefore, PRODUCT_DEPRECATED } from "./product-deprecatio
 import { rankOffers, rankForListing, rotateListing, utcDate, gateFor, CRITERIA_PATH, DEMOTE_ONLY_POLICY, DISCLOSURE_RATIONALE, TIE_BREAK_ALGORITHM, GATE_TABLE, DEMERIT_TABLE, NOT_FREE_TIER_RULES, TIME_LIMITED_TIER_RULES, type TieBreak, type Gate } from "./ranking.js";
 import type { RankedEntry, RankingResult } from "./ranking.js";
 import { eligibilityGate, gatedShareDescriptionClause, gatedShareLede, publishableEligibilityConditions } from "./eligibility.js";
+import { gateDisclosureFor } from "./gate-disclosure.js";
 import { verificationLedger, QUARANTINE_AFTER_FAILURES } from "./verification-state.js";
 import { partitionAlternatives, partitionSubstitutes, type SubstitutesPartition, productRoleSentence, MEMBERSHIP_GATE_RULES, MEMBERSHIP_GATE_ORDER, MEMBERSHIP_GATE_SYMMETRY, MEMBERSHIP_GATE_SCOPE, MEMBERSHIP_GATE_CORRECTIONS, SUBTYPE_TAXONOMIES, SUBTYPE_MEMBERSHIP_RULE, SUBTYPE_MEMBERSHIP_GROUP_SCOPE, CURATED_SUBTYPE_EXEMPTION, membershipGroupsFor, subtypeDefinition } from "./product-role.js";
 import { resolveCuratedAlternatives, curatedAlternativesFor, addCuratedToPool } from "./curated-alternatives.js";
@@ -53299,8 +53300,9 @@ const httpServer = createHttpServer(async (req, res) => {
       unfilteredCount: offersFiltered && sanitizedQ ? searchOffers(sanitizedQ).length : total,
     });
     logRequest({ ts: new Date().toISOString(), type: "api", endpoint: "/api/offers", params: { q, category, limit, offset }, user_agent: req.headers["user-agent"] ?? "unknown", result_count: paged.length });
+    const offersDisclosure = gateDisclosureFor("offer", results.map(o => gateForOffer(o)));
     res.writeHead(200, { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" });
-    res.end(JSON.stringify(withAgentBlock({ offers: offersWithCodes, total })));
+    res.end(JSON.stringify(withAgentBlock({ offers: offersWithCodes, total, ...offersDisclosure })));
   } else if (url.pathname === "/api/compare" && isGetOrHead) {
     recordApiHit("/api/compare");
     const a = url.searchParams.get("a") || "";

--- a/src/server.ts
+++ b/src/server.ts
@@ -3,7 +3,8 @@ import { join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 import { McpServer, ResourceTemplate } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
-import { getCategories, getDealChanges, getPersonalizedChanges, getNewOffers, getNewestDeals, getOfferDetails, searchOffers, enrichOffers, compareServices, checkVendorRisk, auditStack, getExpiringDeals, getWeeklyDigest, loadOffers, loadDealChanges, classifyStability, publishedStabilityFor, getVendorReferral, sanitizeQuery } from "./data.js";
+import { getCategories, getDealChanges, getPersonalizedChanges, getNewOffers, getNewestDeals, getOfferDetails, searchOffers, enrichOffers, gateForOffer, compareServices, checkVendorRisk, auditStack, getExpiringDeals, getWeeklyDigest, loadOffers, loadDealChanges, classifyStability, publishedStabilityFor, getVendorReferral, sanitizeQuery } from "./data.js";
+import { gateDisclosureFor } from "./gate-disclosure.js";
 import { toSlug, vendorSlugMap, resolveVendorSlug } from "./vendor-slug.js";
 import { recordToolCall, logRequest, recordSearchQuery } from "./stats.js";
 import { registerAgent, validateVestauthUrl, getAgentByApiKeyHash, hashApiKey, updateAgentX402Address } from "./agents.js";
@@ -29,7 +30,7 @@ const __dirname_server = dirname(fileURLToPath(import.meta.url));
 const PKG_VERSION = JSON.parse(readFileSync(join(__dirname_server, "..", "package.json"), "utf-8")).version;
 
 function toConciseOffer(offer: Offer | EnrichedOffer) {
-  const base = { vendor: offer.vendor, tier: offer.tier, description: offer.description, url: offer.url, ...(offer.payment_protocols?.length ? { payment_protocols: offer.payment_protocols.map(p => p.protocol) } : {}) };
+  const base = { vendor: offer.vendor, tier: offer.tier, description: offer.description, url: offer.url, gate: gateForOffer(offer), ...(offer.payment_protocols?.length ? { payment_protocols: offer.payment_protocols.map(p => p.protocol) } : {}) };
   const enriched = offer as Partial<EnrichedOffer>;
   if (enriched.risk_level !== undefined) {
     return { ...base, risk_level: enriched.risk_level, risk_cause: enriched.risk_cause ?? null, stability: enriched.stability };
@@ -154,6 +155,7 @@ export function createServer(getSessionId?: () => string | undefined, getClientN
           const enrichedResult = {
             ...result,
             deals: result.deals.map(o => ({ ...o, referral_code: getBestReferralCode(o.vendor) })),
+            ...gateDisclosureFor("deal", result.deals.map(o => o.gate)),
           };
           return {
             content: [{ type: "text" as const, text: JSON.stringify(enrichedResult, null, 2) }, SIGNAL_FOOTER_CONTENT],
@@ -211,8 +213,9 @@ export function createServer(getSessionId?: () => string | undefined, getClientN
         const outputResults = response_format === "concise"
           ? resultsWithCodes.map(r => ({ ...toConciseOffer(r), referral_code: r.referral_code }))
           : resultsWithCodes;
+        const disclosure = gateDisclosureFor("result", filtered.map(o => gateForOffer(o)));
         return {
-          content: [{ type: "text" as const, text: JSON.stringify({ results: outputResults, total: finalTotal, limit: effectiveLimit, offset: effectiveOffset }, null, 2) }, SIGNAL_FOOTER_CONTENT],
+          content: [{ type: "text" as const, text: JSON.stringify({ results: outputResults, total: finalTotal, limit: effectiveLimit, offset: effectiveOffset, ...disclosure }, null, 2) }, SIGNAL_FOOTER_CONTENT],
         };
       } catch (err) {
         console.error("search_deals error:", err);

--- a/src/types.ts
+++ b/src/types.ts
@@ -111,6 +111,7 @@ export interface EnrichedOffer extends Offer {
   stability: StabilityClass | null;
   days_since_verified: number;
   link_unreachable: LinkUnreachable | null;
+  gate: import("./ranking.js").Gate | null;
 }
 
 export interface OfferIndex {

--- a/test/api-gate-field.test.ts
+++ b/test/api-gate-field.test.ts
@@ -1,0 +1,453 @@
+import { describe, it, before, after } from "node:test";
+import assert from "node:assert";
+import { spawn, type ChildProcess } from "node:child_process";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const { gateFor, utcDate, GATE_TABLE } = await import("../dist/ranking.js");
+const { gateClauseList, gateDisclosureSentence, matchingSubject } = await import("../dist/gate-disclosure.js");
+
+type Offer = import("../src/types.ts").Offer;
+type Gate = { code: string; reason: string } | null;
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO = path.join(__dirname, "..");
+
+const offers: Offer[] = JSON.parse(readFileSync(path.join(REPO, "data", "index.json"), "utf-8")).offers;
+const TODAY = utcDate();
+
+const CATALOG_SIZE = offers.length;
+const MOST_OF_THE_CATALOG = 0.8;
+
+const NOT_RATED_CLAUSE = "We do not rate an offer we do not list.";
+const ENDED_VERDICT = "This offer has ended — we keep the page for the record and no longer rate it.";
+const STABLE_HISTORY = "has a stable pricing history.";
+
+const UNREAD_CITATION_FORMS = [
+  /^.+'s pricing page has not resolved for us( since \d{4}-\d{2}-\d{2})?\.$/,
+  /^The page we cite for .+ does not name it\.$/,
+  /^The page we cite for .+ states no terms we can read\.$/,
+  /^We could not read the page we cite for .+\.$/,
+];
+
+function gateSummaryShape(summary: string, gate: { code: string; reason: string }): string | null {
+  const opening = gate.code === "offer_retired" ? ENDED_VERDICT : `${gate.reason} ${NOT_RATED_CLAUSE}`;
+  if (summary === opening) return null;
+  if (!summary.startsWith(`${opening} `)) return `does not open with the gate's own verdict: ${summary}`;
+  const rest = summary.slice(opening.length + 1);
+  if (UNREAD_CITATION_FORMS.some(form => form.test(rest))) return null;
+  return `carries prose that is neither the gate's verdict nor a citation we could not read: ${rest}`;
+}
+
+let port = 0;
+let proc: ChildProcess | null = null;
+
+function startServer(): Promise<ChildProcess> {
+  return new Promise((resolve, reject) => {
+    const child = spawn("node", [path.join(REPO, "dist", "serve.js")], {
+      stdio: ["pipe", "pipe", "pipe"],
+      env: { ...process.env, PORT: "0", BASE_URL: "http://localhost", TZ: "UTC" },
+    });
+    const timeout = setTimeout(() => { child.kill(); reject(new Error("Server startup timeout")); }, 60000);
+    child.stderr!.on("data", (data: Buffer) => {
+      const m = data.toString().match(/running on http:\/\/localhost:(\d+)/);
+      if (m) { port = parseInt(m[1], 10); clearTimeout(timeout); resolve(child); }
+    });
+    child.on("error", (e) => { clearTimeout(timeout); reject(e); });
+  });
+}
+
+async function getJson(pathname: string): Promise<any> {
+  const res = await fetch(`http://localhost:${port}${pathname}`);
+  return res.json();
+}
+
+function parseSSE(text: string): any[] {
+  const out: any[] = [];
+  for (const line of text.split("\n")) {
+    if (line.startsWith("data: ")) { try { out.push(JSON.parse(line.slice(6))); } catch { continue; } }
+  }
+  return out;
+}
+
+async function mcpPost(sessionId: string | null, msg: object): Promise<{ responses: any[]; sessionId: string | null }> {
+  const headers: Record<string, string> = { "Content-Type": "application/json", "Accept": "application/json, text/event-stream" };
+  if (sessionId) headers["mcp-session-id"] = sessionId;
+  const res = await fetch(`http://localhost:${port}/mcp`, { method: "POST", headers, body: JSON.stringify(msg) });
+  const text = await res.text();
+  return { responses: parseSSE(text), sessionId: res.headers.get("mcp-session-id") || sessionId };
+}
+
+let mcpSession: string | null = null;
+let mcpCallId = 100;
+
+async function searchDeals(args: Record<string, unknown>): Promise<any> {
+  if (!mcpSession) {
+    const init = await mcpPost(null, {
+      jsonrpc: "2.0", id: 1, method: "initialize",
+      params: { protocolVersion: "2025-03-26", capabilities: {}, clientInfo: { name: "gate-field-test", version: "1.0" } },
+    });
+    mcpSession = init.sessionId;
+    await mcpPost(mcpSession, { jsonrpc: "2.0", method: "notifications/initialized" });
+  }
+  const id = mcpCallId++;
+  const { responses } = await mcpPost(mcpSession, {
+    jsonrpc: "2.0", id, method: "tools/call",
+    params: { name: "search_deals", arguments: args },
+  });
+  return JSON.parse(responses.find(r => r.id === id).result.content[0].text);
+}
+
+function recordKey(o: { vendor: string; tier: string; url: string }): string {
+  return `${o.vendor}|${o.tier}|${o.url}`;
+}
+
+const expectedGates = new Map<string, Gate>(
+  offers.map(o => [recordKey(o), (gateFor(o, TODAY) as Gate) ?? null]),
+);
+
+const gatedRecords = offers.filter(o => gateFor(o, TODAY) !== null);
+const gatedByCode = (code: string) => gatedRecords.filter(o => gateFor(o, TODAY)!.code === code);
+
+const CLAUSE_TEXT: Record<string, [string, (n: number) => string]> = {
+  eligibility_restricted: ["1 requires an application or qualification", n => `${n} require an application or qualification`],
+  not_a_free_offer: ["1 is not a free offer", n => `${n} are not free offers`],
+  offer_expired: ["1 has expired", n => `${n} have expired`],
+  offer_retired: ["1 has ended", n => `${n} have ended`],
+};
+const CLAUSE_ORDER = ["eligibility_restricted", "not_a_free_offer", "offer_expired", "offer_retired"];
+
+function expectedSummary(noun: string, records: Offer[]): string {
+  const codes = records.map(o => gateFor(o, TODAY)).filter(Boolean).map(g => g!.code);
+  if (codes.length === 0) return "";
+  const clauses = CLAUSE_ORDER
+    .map(code => ({ code, n: codes.filter(c => c === code).length }))
+    .filter(({ n }) => n > 0)
+    .map(({ code, n }) => (n === 1 ? CLAUSE_TEXT[code][0] : CLAUSE_TEXT[code][1](n)))
+    .join(", ");
+  const total = records.length;
+  const subject = `the ${total} ${noun}${total === 1 ? "" : "s"} matching this query`;
+  if (codes.length >= total && total > 1) return `None of ${subject} are on our ranked list — ${clauses}.`;
+  if (codes.length === 1) return `One of ${subject} is not on our ranked list — ${clauses}.`;
+  return `${codes.length} of ${subject} are not on our ranked list — ${clauses}.`;
+}
+
+function inCategory(category: string): Offer[] {
+  return offers.filter(o => o.category === category);
+}
+
+function categoryWhere(predicate: (gated: number, total: number) => boolean): string {
+  const categories = [...new Set(offers.map(o => o.category))].sort();
+  const found = categories.find(c => {
+    const rows = inCategory(c);
+    return rows.length > 3 && predicate(rows.filter(o => gateFor(o, TODAY) !== null).length, rows.length);
+  });
+  assert.ok(found, "no category matched the shape this test needs");
+  return found!;
+}
+
+function firstVendorGatedAs(code: string): string {
+  const record = gatedByCode(code)[0];
+  assert.ok(record, `no record is currently gated ${code}`);
+  return record.vendor;
+}
+
+function firstRecordForItsVendor(offer: Offer): boolean {
+  return offers.find(o => o.vendor.toLowerCase() === offer.vendor.toLowerCase()) === offer;
+}
+
+function vendorWhoseOwnRecordIsGatedAs(code: string): string {
+  const record = gatedByCode(code).find(firstRecordForItsVendor);
+  assert.ok(record, `every record gated ${code} belongs to a vendor whose first record is a different one`);
+  return record!.vendor;
+}
+
+describe("every JSON surface carries the ranker's gate (issue #1241 Part 1)", () => {
+  before(async () => { mcpSession = null; proc = await startServer(); });
+  after(() => { if (proc) { proc.kill(); proc = null; } });
+
+  it("/api/offers returns the same gate the ranker applies, for every record in the catalog", async () => {
+    const seen = new Map<string, Gate>();
+    for (let offset = 0; offset < CATALOG_SIZE; offset += 200) {
+      const body = await getJson(`/api/offers?limit=200&offset=${offset}`);
+      for (const offer of body.offers) {
+        assert.ok("gate" in offer, `${offer.vendor} (${offer.tier}) came back with no gate field`);
+        seen.set(recordKey(offer), offer.gate ?? null);
+      }
+    }
+    assert.strictEqual(seen.size, CATALOG_SIZE, "not every record was paged through");
+    const disagreeing: string[] = [];
+    for (const [key, gate] of seen) {
+      const expected = expectedGates.get(key) ?? null;
+      if (JSON.stringify(gate) !== JSON.stringify(expected)) disagreeing.push(key);
+    }
+    assert.deepStrictEqual(disagreeing, [], "records whose published gate is not gateFor's verdict");
+  });
+
+  it("the ungated majority publishes gate null, and the gate has not swallowed the catalog", async () => {
+    const nulls: string[] = [];
+    for (let offset = 0; offset < CATALOG_SIZE; offset += 200) {
+      const body = await getJson(`/api/offers?limit=200&offset=${offset}`);
+      for (const offer of body.offers) if (offer.gate === null) nulls.push(recordKey(offer));
+    }
+    assert.strictEqual(nulls.length, CATALOG_SIZE - gatedRecords.length);
+    assert.ok(nulls.length > CATALOG_SIZE * MOST_OF_THE_CATALOG, `only ${nulls.length} of ${CATALOG_SIZE} records are ungated`);
+  });
+
+  it("nothing is filtered out — a caller asking about a gated vendor by name still gets the record", async () => {
+    const sample = GATE_TABLE.flatMap((entry: { code: string }) => gatedByCode(entry.code).slice(0, 5));
+    assert.ok(sample.length > 5, "no gated records to ask about");
+    const absent: string[] = [];
+    for (const record of sample) {
+      const body = await getJson(`/api/offers?q=${encodeURIComponent(record.vendor)}&limit=50`);
+      const row = body.offers.find((o: any) => recordKey(o) === recordKey(record));
+      if (!row) { absent.push(record.vendor); continue; }
+      assert.strictEqual(row.gate.code, gateFor(record, TODAY)!.code, record.vendor);
+    }
+    assert.deepStrictEqual(absent, [], "gated records a search by vendor name no longer returns");
+  });
+
+  it("/api/details carries the gate on the subject and on every alternative", async () => {
+    const gatedVendor = firstVendorGatedAs("offer_retired");
+    const gated = await getJson(`/api/details/${encodeURIComponent(gatedVendor)}`);
+    assert.strictEqual(gated.offer.gate.code, "offer_retired");
+
+    const body = await getJson("/api/details/Supabase?alternatives=true");
+    assert.strictEqual(body.offer.gate, null);
+    assert.ok(body.alternatives.length > 0);
+    for (const alt of body.alternatives) assert.ok("gate" in alt, `${alt.vendor} alternative carries no gate`);
+  });
+
+  it("an alternative that is itself gated says so — rankForListing demotes, it does not drop", async () => {
+    const vendors = [...new Set(offers.map(o => o.vendor))];
+    const disagreeing: string[] = [];
+    let gatedAlternativesSeen = 0;
+    let riskAlternativesRated = 0;
+    for (const vendor of vendors) {
+      const detail = await getJson(`/api/details/${encodeURIComponent(vendor)}?alternatives=true`);
+      for (const alt of detail.alternatives ?? []) {
+        const expected = expectedGates.get(recordKey(alt)) ?? null;
+        if (JSON.stringify(alt.gate ?? null) !== JSON.stringify(expected)) disagreeing.push(`${vendor} -> ${alt.vendor}`);
+        if (expected) gatedAlternativesSeen++;
+      }
+      if (!detail.alternatives?.some((a: any) => a.gate)) continue;
+      const risk = await getJson(`/api/vendor-risk/${encodeURIComponent(vendor)}`);
+      for (const alt of risk.alternatives ?? []) {
+        if (alt.gate && alt.risk_level !== null) riskAlternativesRated++;
+      }
+    }
+    assert.ok(gatedAlternativesSeen > 0, "no gated record surfaced as an alternative — this test proved nothing");
+    assert.deepStrictEqual(disagreeing, [], "alternatives whose published gate is not gateFor's verdict");
+    assert.strictEqual(riskAlternativesRated, 0, "a gated record was offered as a more-stable alternative with a rating");
+  });
+
+  it("search_deals returns the ranker's verdict on every row of a category holding gated records", async () => {
+    const category = categoryWhere((gated, total) => gated > 0 && gated < total);
+    const body = await searchDeals({ category, limit: 200 });
+    const disagreeing: string[] = [];
+    for (const row of body.results) {
+      assert.ok("gate" in row, `${row.vendor} came back from MCP with no gate`);
+      const expected = expectedGates.get(recordKey(row)) ?? null;
+      if (JSON.stringify(row.gate ?? null) !== JSON.stringify(expected)) disagreeing.push(row.vendor);
+    }
+    assert.deepStrictEqual(disagreeing, []);
+    assert.ok(body.results.some((r: any) => r.gate !== null), `${category} returned no gated row`);
+  });
+
+  it("search_deals carries the gate in concise mode and on the vendor branch", async () => {
+    const category = categoryWhere((gated, total) => gated === total);
+    const concise = await searchDeals({ category, limit: 3, response_format: "concise" });
+    for (const row of concise.results) assert.ok(row.gate, `${row.vendor} lost its gate in concise mode`);
+
+    const retired = firstVendorGatedAs("offer_retired");
+    const vendor = await searchDeals({ vendor: retired });
+    assert.strictEqual(vendor.gate.code, "offer_retired");
+  });
+});
+
+describe("the response states how many of its offers are gated (issue #1241 Part 1)", () => {
+  before(async () => { mcpSession = null; proc = await startServer(); });
+  after(() => { if (proc) { proc.kill(); proc = null; } });
+
+  it("a fully gated category says so at the response level on both surfaces", async () => {
+    const category = categoryWhere((gated, total) => gated === total);
+    const records = inCategory(category);
+
+    const api = await getJson(`/api/offers?category=${encodeURIComponent(category)}&limit=5`);
+    assert.strictEqual(api.total, records.length);
+    assert.strictEqual(api.gated, records.length);
+    assert.strictEqual(api.gate_summary, expectedSummary("offer", records));
+    assert.match(api.gate_summary, /^None of the \d+ offers matching this query are on our ranked list — /);
+
+    const mcp = await searchDeals({ category, limit: 5 });
+    assert.strictEqual(mcp.gated, records.length);
+    assert.strictEqual(mcp.gate_summary, expectedSummary("result", records));
+  });
+
+  it("the count covers the whole match, not the returned page", async () => {
+    const category = categoryWhere((gated, total) => gated === total && total > 5);
+    const body = await getJson(`/api/offers?category=${encodeURIComponent(category)}&limit=5`);
+    assert.strictEqual(body.offers.length, 5);
+    assert.ok(body.total > 5);
+    assert.strictEqual(body.gated, body.total);
+  });
+
+  it("a partly gated category names each kind and counts only the gated", async () => {
+    const category = categoryWhere((gated, total) => gated > 1 && gated < total);
+    const records = inCategory(category);
+    const body = await getJson(`/api/offers?category=${encodeURIComponent(category)}&limit=5`);
+    assert.strictEqual(body.gated, records.filter(o => gateFor(o, TODAY) !== null).length);
+    assert.ok(body.gated < body.total);
+    assert.strictEqual(body.gate_summary, expectedSummary("offer", records));
+  });
+
+  it("an ungated category counts zero and says nothing", async () => {
+    const category = categoryWhere(gated => gated === 0);
+    const body = await getJson(`/api/offers?category=${encodeURIComponent(category)}&limit=5`);
+    assert.ok(body.total > 0);
+    assert.strictEqual(body.gated, 0);
+    assert.ok(!("gate_summary" in body), "a summary was published for a response with nothing to disclose");
+    for (const offer of body.offers) assert.strictEqual(offer.gate, null);
+  });
+
+  it("the count equals the number of gated offers a caller can see when the page holds them all", async () => {
+    const category = categoryWhere((gated, total) => gated > 0 && gated < total);
+    const body = await getJson(`/api/offers?category=${encodeURIComponent(category)}&limit=500`);
+    const visible = body.offers.filter((o: any) => o.gate !== null).length;
+    assert.strictEqual(body.offers.length, body.total);
+    assert.strictEqual(body.gated, visible);
+  });
+});
+
+describe("/api/vendor-risk does not rate an offer we do not list (issue #1241 Part 1)", () => {
+  before(async () => { proc = await startServer(); });
+  after(() => { if (proc) { proc.kill(); proc = null; } });
+
+  it("a retired record gets the sentence the vendor page already publishes", async () => {
+    const body = await getJson(`/api/vendor-risk/${encodeURIComponent(vendorWhoseOwnRecordIsGatedAs("offer_retired"))}`);
+    assert.strictEqual(body.risk_level, null);
+    assert.strictEqual(body.gate.code, "offer_retired");
+    assert.ok(body.summary.startsWith(ENDED_VERDICT), body.summary);
+    assert.strictEqual(body.free_tier_longevity_days, null);
+  });
+
+  it("the other gate codes open with the gate's own reason and decline to rate", async () => {
+    for (const code of ["not_a_free_offer", "offer_expired", "eligibility_restricted"]) {
+      const vendor = vendorWhoseOwnRecordIsGatedAs(code);
+      const body = await getJson(`/api/vendor-risk/${encodeURIComponent(vendor)}`);
+      assert.strictEqual(body.risk_level, null, vendor);
+      assert.strictEqual(body.gate.code, code, vendor);
+      assert.ok(body.summary.startsWith(`${body.gate.reason} ${NOT_RATED_CLAUSE}`), `${vendor}: ${body.summary}`);
+    }
+  });
+
+  it("a gated record whose cited page we could not read still says which page we could not read", async () => {
+    const withheld = gatedRecords.filter(o => firstRecordForItsVendor(o) && o.source_check && o.source_check.outcome !== "ok");
+    assert.ok(withheld.length > 0, "no gated record currently carries a source check we could not read");
+    let cited = 0;
+    for (const record of withheld.slice(0, 25)) {
+      const body = await getJson(`/api/vendor-risk/${encodeURIComponent(record.vendor)}`);
+      if (!body.gate) continue;
+      assert.ok(body.summary.length > `${body.gate.reason} ${NOT_RATED_CLAUSE}`.length, `${record.vendor} dropped the citation it could not read`);
+      cited++;
+    }
+    assert.ok(cited > 0, "no gated record with an unreadable citation resolved to its own record");
+  });
+
+  it("a count of days a free tier has held is withheld where our record says there is no free tier", async () => {
+    for (const code of ["offer_retired", "not_a_free_offer"]) {
+      const vendor = vendorWhoseOwnRecordIsGatedAs(code);
+      const body = await getJson(`/api/vendor-risk/${encodeURIComponent(vendor)}`);
+      assert.strictEqual(body.free_tier_longevity_days, null, vendor);
+    }
+  });
+
+  it("a restricted or expired offer keeps its day count — the tier it names is real for whoever qualifies", async () => {
+    for (const code of ["eligibility_restricted", "offer_expired"]) {
+      const vendor = vendorWhoseOwnRecordIsGatedAs(code);
+      const body = await getJson(`/api/vendor-risk/${encodeURIComponent(vendor)}`);
+      assert.strictEqual(body.gate.code, code, vendor);
+      assert.ok(typeof body.free_tier_longevity_days === "number", `${vendor} lost its day count`);
+    }
+  });
+
+  it("no gated vendor is handed a level or a stability sentence, across every gated record", async () => {
+    const rated: string[] = [];
+    const reassured: string[] = [];
+    const offShape: string[] = [];
+    const seen = new Set<string>();
+    let reported = 0;
+    for (const offer of gatedRecords) {
+      if (seen.has(offer.vendor.toLowerCase())) continue;
+      seen.add(offer.vendor.toLowerCase());
+      const body = await getJson(`/api/vendor-risk/${encodeURIComponent(offer.vendor)}`);
+      if (body.error || !body.gate) continue;
+      reported++;
+      if (body.risk_level !== null) rated.push(offer.vendor);
+      if (body.summary.includes(STABLE_HISTORY)) reassured.push(offer.vendor);
+      const problem = gateSummaryShape(body.summary, body.gate);
+      if (problem) offShape.push(`${offer.vendor} ${problem}`);
+    }
+    assert.deepStrictEqual(offShape, [], "gated summaries that are not the gate's verdict, alone or followed by an unread citation");
+    assert.ok(reported > seen.size * 0.9, `only ${reported} of ${seen.size} gated vendors resolved to their gated record`);
+    assert.deepStrictEqual(rated, [], "gated vendors still handed a risk_level");
+    assert.deepStrictEqual(reassured, [], "gated vendors still told their pricing history is stable");
+  });
+
+  it("ungated vendors keep their rating, their longevity and their sentence", async () => {
+    const ungated = offers.filter(o => gateFor(o, TODAY) === null).slice(0, 40);
+    let stillRated = 0;
+    for (const offer of ungated) {
+      const body = await getJson(`/api/vendor-risk/${encodeURIComponent(offer.vendor)}`);
+      if (body.error || body.gate) continue;
+      assert.ok(typeof body.free_tier_longevity_days === "number", offer.vendor);
+      assert.ok(!body.summary.includes(NOT_RATED_CLAUSE), offer.vendor);
+      if (body.risk_level !== null) stillRated++;
+    }
+    assert.ok(stillRated > 10, `only ${stillRated} of 40 ungated vendors still carry a risk_level`);
+  });
+});
+
+describe("the disclosure sentence has one form per count (issue #1241)", () => {
+  it("says nothing when nothing is gated", () => {
+    assert.strictEqual(gateDisclosureSentence("them", 12, []), "");
+  });
+
+  it("uses the four forms the criteria set out", () => {
+    assert.strictEqual(
+      gateDisclosureSentence("them", 3, ["eligibility_restricted", "eligibility_restricted", "eligibility_restricted"]),
+      "None of them are on our ranked list — 3 require an application or qualification.",
+    );
+    assert.strictEqual(
+      gateDisclosureSentence("them", 3, ["not_a_free_offer"]),
+      "One of them is not on our ranked list — 1 is not a free offer.",
+    );
+    assert.strictEqual(
+      gateDisclosureSentence("them", 5, ["offer_expired", "offer_retired"]),
+      "2 of them are not on our ranked list — 1 has expired, 1 has ended.",
+    );
+  });
+
+  it("orders the clauses by gate code and agrees in number", () => {
+    assert.strictEqual(
+      gateClauseList(["offer_retired", "not_a_free_offer", "eligibility_restricted", "not_a_free_offer", "offer_expired"]),
+      "1 requires an application or qualification, 2 are not free offers, 1 has expired, 1 has ended",
+    );
+  });
+
+  it("keeps the subject singular when the whole match is one offer", () => {
+    assert.strictEqual(matchingSubject("offer", 1), "the 1 offer matching this query");
+    assert.strictEqual(matchingSubject("offer", 2), "the 2 offers matching this query");
+    assert.strictEqual(
+      gateDisclosureSentence(matchingSubject("offer", 1), 1, ["offer_retired"]),
+      "One of the 1 offer matching this query is not on our ranked list — 1 has ended.",
+    );
+  });
+
+  it("has a clause for every gate code the ranker can return", () => {
+    for (const entry of GATE_TABLE) {
+      assert.notStrictEqual(gateClauseList([entry.code]), "", `no clause for gate code ${entry.code}`);
+    }
+  });
+});


### PR DESCRIPTION
Refs https://github.com/robhunter/agentdeals/issues/1241 — Part 1.

## What moved

`gateFor` had two call sites. Every other surface that said anything about availability re-derived it. All five criteria for Part 1 are live, plus the response-level count added to the issue this cycle.

**Per-offer `gate`.** `/api/offers`, `/api/details/{vendor}`, `/api/newest` and `search_deals` (search, vendor, `since` and concise branches) return `{code, reason}` or `null`, from `gateFor` itself.

Census over the whole catalog, no sample — for every one of the 1,580 records, the `gate` in the API response equals `gateFor(record, servedOn)`:

| | |
|---|---|
| records paged through `/api/offers` | 1,580 of 1,580 |
| carrying a `gate` field | 1,580 |
| whose `gate` equals `gateFor` | **1,580, 0 disagreeing** |
| `gate: null` | 1,417 |
| gated | 163 — 138 `eligibility_restricted`, 19 `not_a_free_offer`, 4 `offer_retired`, 2 `offer_expired` |

Nothing is filtered out: the PM's sharpest body, PostHog's `YC Deal`, still comes back — now with `"gate": {"code": "eligibility_restricted", "reason": "Restricted to accelerator (PostHog for Y Combinator) applicants — not generally available."}`.

**`/api/vendor-risk`.** Measured against production for the 157 gated records whose vendor name resolves to them:

| | before | after |
|---|---|---|
| `risk_level` non-null | 44 | **0** |
| — of which `stable` | 31 | 0 |
| — `caution` | 11 | 0 |
| — `risky` | 2 | 0 |
| summary asserts *"has a stable pricing history"* | 31 | **0** |
| summary counts *"Free tier verified for N days"* | 31 | 0 |
| `free_tier_longevity_days` on the retired / not-free set | 23 | **0** |

The issue measured the `stable` branch. The `caution` and `risky` branches publish a level on a gated record too — that is where the other 13 come from.

**Response-level count.** `/api/offers` and `search_deals` carry `gated` over the whole match (not the returned page) and one sentence in the four forms the issue sets out:

```
/api/offers?category=Startup%20Perks   "total": 93, "gated": 93,
  "None of the 93 offers matching this query are on our ranked list — 93 require an application or qualification."

/api/offers?category=Payments          "total": 18, "gated": 4,
  "4 of the 18 offers matching this query are not on our ranked list — 1 requires an application or qualification, 3 are not free offers."

/api/offers?category=Email             "total": 55, "gated": 0, no sentence
```

The composer is `src/gate-disclosure.ts` and takes its subject as an argument, so Part 2's category lede calls the same function with `them`.

## Two decisions worth seeing

**A gated record whose citation we could not read keeps both sentences.** `test/source-check.test.ts:236` requires that a withheld level says *which* reason held it back, and JetBrains is gated **and** cited to a page stating no terms. Applying the gate sentence alone would have retracted that criterion silently. It now reads `<gate reason> We do not rate an offer we do not list. The page we cite for JetBrains states no terms we can read.` — the gate first, as on the vendor page since #1242. A catalog-wide assertion pins every gated summary to exactly one of those two shapes.

**`rankForListing` demotes a gated record to the tail; it does not drop it.** The issue says the `alternatives` array "is built by `rankForListing`, so it **is** gated" — it isn't. `ranking.ts:517` appends `result.excluded` as a `gatedTail`, so when a category has fewer ungated substitutes than the slice takes, a gated record surfaces as an alternative. Measured over all 1,572 vendors:

- **5** vendors offer a gated record on `/api/details?alternatives=true` — `Qdrant → Google Vector Search 2.0`, `Pinecone → Google Gemini Embedding 2`, `Kaggle → Vast.ai`, `Cloudflare Dynamic Workers → Cloudflare Sandboxes`, `Modal → Vast.ai`.
- **3** on `/api/vendor-risk`, of which **2 were rated `stable`** as a *more-stable alternative*.

Both now carry the gate, and a gated alternative gets `risk_level: null` like the subject. Found by a surviving mutation, not by reading.

## Verification

- **2,577 of 2,577 HTML paths byte-identical to `main`**, 0 moved, 0 status changes — Part 1 touches JSON only.
- **Negative control against production:** 150 of 150 ungated vendors return a byte-identical `/api/vendor-risk` `risk_level`, `summary` and `free_tier_longevity_days`. 188 of 189 `/api/offers` rows over four ungated categories are identical ignoring the new field; the one difference is an agent-submitted referral code in production's durable store, not code.
- **3,056 tests, 33 new, 0 failing.** 15 of the new assertions go red on `main`; the 6 that pass there are the sentence-composer units and the ungated control, which should pass on both.
- **21 of 21 mutations killed**, none by a compile error — `scripts/mutate-1241-gate-field.sh`.
- **End-to-end over a real MCP `initialize` → `tools/call`:** `search_deals({category: "Cloud Hosting", limit: 60})` returns the issue's own two rows — position 7 `Fly.io` `not_a_free_offer`, position 48 `Oaysus` `offer_retired` — plus two the census did not name, and a lede reading *"4 of the 60 results matching this query are not on our ranked list — 3 are not free offers, 1 has ended."*
- `/api/openapi.json` documents `Gate`, the null `risk_level` and the null `free_tier_longevity_days`, with 3 `$ref`s resolving.

## Reported, not fixed

- **163 gated records still publish a `risk_level` and a `stability` beside the new gate** on `/api/offers` and `search_deals` — 49 with a non-null `risk_level` (34 of them `stable`) and 131 with `stability: "stable"`. The issue defers `stability` explicitly; `risk_level` on the offer object is named in no criterion, and it now disagrees with the same field on `/api/vendor-risk`. One line each, the PM's call.
- **One clause is mine.** The issue's clause table covers four gate codes; `verification_lapsed` has none. It reaches 0 records today (it is a documented floor), but a count with no clause would not sum, so it composes as `N have not been re-confirmed recently enough`. Replace it if you would rather word it differently.
- `verification_lapsed` aside, no prose here is new: the gate reasons are already live on 133 vendor pages, `endedVerdictSentence()` and the citation sentences are the PM's.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
