### PR TITLE
Correct four records whose source page redirects or changed product

### DIFF
--- a/data/change_refusals.json
+++ b/data/change_refusals.json
@@ -1667,6 +1667,18 @@
       "source_url": "https://www.zoneedit.com/free-dns/",
       "category": "DNS & Domain Management",
       "refused_date": "2026-09-01"
+    },
+    {
+      "vendor": "Keywords AI",
+      "change_type": "free_tier_removed",
+      "reason": "free_tier_still_offered",
+      "detail": "a free tier was recorded as removed because keywordsai.co redirects off-domain, and the redirect destination still offers one — respan.ai/pricing lists Free $0 with 100k logs, 1k scores, 5 datasets, 2 evaluators and 5 prompts. The vendor rebranded to Respan, a change already recorded on 2026-04-13. Refused by hand: auditRecord returns on the off-domain redirect branch before any free_tier_removed gate is reached",
+      "summary": "Keywords AI's own page now redirects to respan.ai.",
+      "previous_state": "The best LLM monitoring platform. One format to call 200+ LLMs with 2 lines of code. 10,000 free requests every month and $0 for platform features!",
+      "current_state": "The page does not explicitly state a free tier. It showcases features and capabilities of the platform, with mentions of cost savings and budget controls, but does not detail a free usage allowance.",
+      "source_url": "https://keywordsai.co",
+      "category": "AI / ML",
+      "refused_date": "2026-09-02"
     }
   ]
 }

--- a/data/deal_changes.json
+++ b/data/deal_changes.json
@@ -6951,21 +6951,6 @@
       "recorded_date": "2026-09-01"
     },
     {
-      "vendor": "Keywords AI",
-      "change_type": "free_tier_removed",
-      "date": "2026-09-01",
-      "date_source": "discovered",
-      "summary": "Keywords AI's own page now redirects to respan.ai.",
-      "previous_state": "The best LLM monitoring platform. One format to call 200+ LLMs with 2 lines of code. 10,000 free requests every month and $0 for platform features!",
-      "current_state": "The page does not explicitly state a free tier. It showcases features and capabilities of the platform, with mentions of cost savings and budget controls, but does not detail a free usage allowance.",
-      "impact": "high",
-      "source_url": "https://keywordsai.co",
-      "category": "AI / ML",
-      "alternatives": [],
-      "detected_by": "reverify-ai",
-      "recorded_date": "2026-09-01"
-    },
-    {
       "vendor": "LangSmith",
       "change_type": "pricing_model_change",
       "date": "2026-09-01",

--- a/data/index.json
+++ b/data/index.json
@@ -3537,18 +3537,15 @@
     {
       "vendor": "Stripe Atlas",
       "category": "Startup Programs",
-      "description": "$50,000+ in founder perks — $5K AWS credits, $5K DigitalOcean credits, 1yr GitHub, $2.5K Stripe processing credits, plus Notion, Slack, Zendesk, Intercom, and more",
+      "description": "$500 one-time incorporation (Delaware filing and fees, tax ID, founder equity issuance, 83(b) filing, document templates, first year of registered agent), $100/year after. Includes $2,500 in Stripe product credits and access to over $50,000 in partner discounts.",
       "tier": "Founder Perks",
       "url": "https://stripe.com/atlas",
       "tags": [
         "fintech",
         "incorporation",
-        "startup perks",
-        "aws",
-        "digitalocean",
-        "github"
+        "startup perks"
       ],
-      "verifiedDate": "2026-07-05",
+      "verifiedDate": "2026-09-02",
       "eligibility": {
         "type": "fintech",
         "conditions": [
@@ -3556,7 +3553,6 @@
         ],
         "program": "Stripe Atlas Founder Perks"
       },
-      "expires_date": "2026-06-30",
       "referral_program": {
         "available": false,
         "referrer_benefit": "N/A",
@@ -3566,7 +3562,7 @@
         "notes": "Partner ecosystem for integrations. No individual referral program."
       },
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "ok",
         "detail": "text"
       }
@@ -3709,9 +3705,9 @@
     {
       "vendor": "Highlight.io",
       "category": "Logging",
-      "description": "500 sessions, 1K errors, 1M logs, 25M traces/month. 3-month retention for sessions/errors, 30-day for logs/traces. Up to 15 seats",
-      "tier": "Free",
-      "url": "https://www.highlight.io/pricing",
+      "description": "Acquired by LaunchDarkly; highlight.io now redirects to launchdarkly.com and the hosted free tier is no longer offered under this name. The open-source project remains self-hostable (repo active, last pushed 2026-08-20).",
+      "tier": "Free OSS",
+      "url": "https://github.com/highlight/highlight",
       "tags": [
         "logging",
         "observability",
@@ -3719,11 +3715,11 @@
         "error-tracking",
         "tracing"
       ],
-      "verifiedDate": "2026-07-23",
+      "verifiedDate": "2026-09-02",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "ok",
-        "detail": "url"
+        "detail": "text"
       }
     },
     {
@@ -18486,18 +18482,18 @@
     {
       "vendor": "Keywords AI",
       "category": "AI / ML",
-      "description": "The best LLM monitoring platform. One format to call 200+ LLMs with 2 lines of code. 10,000 free requests every month and $0 for platform features!",
+      "description": "Rebranded to Respan; keywordsai.co redirects to respan.ai. Free plan: full platform, 100k logs, 1k scores, 5 datasets, 2 evaluators, 5 prompts. No credit card required.",
       "tier": "Free",
-      "url": "https://keywordsai.co",
+      "url": "https://www.respan.ai/pricing",
       "tags": [
         "ai",
         "ml",
         "generative-ai",
         "free-for-dev"
       ],
-      "verifiedDate": "2026-08-08",
+      "verifiedDate": "2026-09-02",
       "source_check": {
-        "checked": "2026-09-01",
+        "checked": "2026-09-02",
         "outcome": "ok",
         "detail": "text"
       },
@@ -18506,21 +18502,21 @@
         "labels": [
           {
             "subtype": "llm_observability",
-            "source_url": "https://keywordsai.co",
+            "source_url": "https://www.respan.ai",
             "source_quote": "Observe calls in traces, watch spend in metrics, and run evals"
           },
           {
             "subtype": "llm_evaluation",
-            "source_url": "https://keywordsai.co",
+            "source_url": "https://www.respan.ai",
             "source_quote": "Route, observe, and evaluate every LLM call"
           },
           {
             "subtype": "model_gateway",
-            "source_url": "https://keywordsai.co",
+            "source_url": "https://www.respan.ai",
             "source_quote": "Point the SDK you already use at one endpoint to reach 1,000+ models"
           }
         ],
-        "reviewed": "2026-09-01"
+        "reviewed": "2026-09-02"
       }
     },
     {
@@ -18694,7 +18690,7 @@
     {
       "vendor": "Mediaworkbench.ai",
       "category": "AI / ML",
-      "description": "MediaWorkbench.ai offers 100,000 free words for Azure OpenAI, DeepSeek, and Google Gemini models, enabling users to access powerful tools for code generation, deep research, and image creation.",
+      "description": "Social media scheduling, publishing and analytics. Free plan at $0/month. The pricing page states no per-plan entitlements: the feature list shown is identical for all four plans.",
       "tier": "Free",
       "url": "https://mediaworkbench.ai",
       "tags": [
@@ -18703,11 +18699,11 @@
         "generative-ai",
         "free-for-dev"
       ],
-      "verifiedDate": "2026-08-10",
+      "verifiedDate": "2026-09-02",
       "source_check": {
-        "checked": "2026-09-01",
+        "checked": "2026-09-02",
         "outcome": "ok",
-        "detail": "url"
+        "detail": "text"
       },
       "product_subtypes": {
         "taxonomy": "AI / ML",


### PR DESCRIPTION
Data only. No `src/`, no `test/`.

Four published records verified against the vendors' live pages today. Two came in via Rob from an outside spot-check; I verified every claim myself before changing anything, and one of them did not survive that check.

## Keywords AI — free tier is alive, we published it as removed

`keywordsai.co` 301s to `www.respan.ai`. The vendor rebranded; the footer reads *"© 2026 Keywords AI, Inc. · Respan® is a registered trademark"*. `respan.ai/pricing` lists `Free · $0 · Full platform · 100k logs · 1k scores · 5 datasets · 2 evaluators · 5 prompts`.

- Repointed `url`, rewrote `description`.
- Fixed three `product_subtypes` labels whose `source_quote` I confirmed is present on respan.ai but was cited to `keywordsai.co`.
- Left `vendor` unchanged — `toSlug(o.vendor)` derives the live page address, so a rename would 404 it.
- Removed the 2026-09-01 `free_tier_removed`/high record and quarantined it in `change_refusals.json` as `free_tier_still_offered`.

Our own change log has carried a `rebranded` record for this vendor since 2026-04-13, summary *"Rebranded to Respan, free tier preserved"*. The gate defect that let the contradiction through is https://github.com/robhunter/agentdeals/issues/1249.

## Mediaworkbench.ai — the description was for a different product

We published *"100,000 free words for Azure OpenAI, DeepSeek, and Google Gemini models"*. `Azure`, `DeepSeek`, `Gemini`, `100,000` and `free words` each return zero occurrences on the page, which is now social media scheduling and analytics.

A free plan does exist at `$0 /monthly`. The only feature list on the page sits behind an `Access Features` tooltip, and I extracted and diffed it for all four plans — `$49`, `$39`, `$29` and `$0` render the same 11 items. It is the product catalogue, not a per-plan entitlement, so the description now says the page states none.

## Stripe Atlas — stale terms, and an expiry two months in the past

Description replaced with what the page carries: $500 one-time (Delaware filing and fees, tax ID, founder equity, 83(b), templates, first year of registered agent), $100/year after, $2,500 in Stripe product credits, over $50,000 in partner discounts.

Cleared `expires_date: 2026-06-30`. The program is live and the page states no end date; the record had been rendering as expired for two months.

Dropped the `aws`, `digitalocean` and `github` tags. Those perks are no longer itemised, and the `aws` tag was placing Atlas on `/aws-free-tier-2026` via the `o.tags?.some(t => t === "aws")` filter.

**One claim I did not act on.** The outside check reported the page names *"Mercury, Xero and AWS"* and that Google and OpenAI were detector artefacts. From a US vantage the page reads *"discounts on tools such as Google, Xero and OAI"* — Mercury and AWS appear zero times. Fetching `stripe.com/gb/atlas` reproduces the other triple exactly. Same path, two editions, two different partner lists, so our record was right and the difference is regional. Left the partner names out of the description entirely rather than publish one region's list as fact.

## Highlight.io — hosted product gone, OSS alive

`highlight.io` and `/pricing` both 308 to `launchdarkly.com`. The repo is unarchived, 9,373 stars, last pushed 2026-08-20. Tier `Free` → `Free OSS`, URL repointed to the repository, description states the acquisition.

The existing `free_tier_removed` change record for Highlight.io **stands** — the hosted tier really is gone. Only its grounds were weak.

## Checks

- `npm run validate` — `✓ All data valid. 1580 offers, 465 deal changes.`
- All three files round-trip byte-identical through `json.dumps(indent=2, ensure_ascii=False)` plus a trailing newline; asserted before and after writing.
- No vendor renamed, no category changed.
- `source_check` said `outcome: "ok"` on all four of these records, including two whose URL redirects to another company. That is https://github.com/robhunter/agentdeals/issues/1229, not addressed here.
