### PR TITLE
State the whole gated set on the category lede (#1241 Part 2)

### DIFF
--- a/scripts/mutate-1215-ac6.sh
+++ b/scripts/mutate-1215-ac6.sh
@@ -19,7 +19,7 @@ trap restore EXIT
 
 killed=0
 survived=0
-TESTS="test/eligibility-disclosure.test.ts"
+TESTS="test/eligibility-disclosure.test.ts test/category-gate-lede.test.ts"
 
 run_mutation() {
   local name="$1"
@@ -57,7 +57,7 @@ m_lede_never_qualifies() {
   py <<'PY'
 p = "src/eligibility.ts"
 s = open(p).read()
-s = s.replace("  if (gated === 0) return `${counted}.`;", "  if (gated >= 0) return `${counted}.`;")
+s = s.replace("  if (codes.length === 0) return `${counted}.`;", "  if (codes.length >= 0) return `${counted}.`;")
 open(p, "w").write(s)
 PY
 }
@@ -66,7 +66,7 @@ m_lede_always_qualifies() {
   py <<'PY'
 p = "src/eligibility.ts"
 s = open(p).read()
-s = s.replace("  if (gated === 0) return `${counted}.`;", "")
+s = s.replace("  if (codes.length === 0) return `${counted}.`;", "")
 open(p, "w").write(s)
 PY
 }
@@ -75,7 +75,7 @@ m_lede_counts_the_whole_category() {
   py <<'PY'
 p = "src/serve.ts"
 s = open(p).read()
-s = s.replace("${gatedShareLede(catCount, catGatedCount)}", "${gatedShareLede(catCount, catCount)}")
+s = s.replace("${gatedShareLede(catCount, catGates)}", "${gatedShareLede(catCount, catGates.map(() => null))}")
 open(p, "w").write(s)
 PY
 }
@@ -84,8 +84,8 @@ m_lede_states_a_partial_share_as_total() {
   py <<'PY'
 p = "src/eligibility.ts"
 s = open(p).read()
-s = s.replace("  if (gated >= total) return `${counted}, none of them generally available",
-              "  if (gated >= 1) return `${counted}, none of them generally available")
+s = s.replace("  return codes.length >= total && codes.every((code) => code === \"eligibility_restricted\");",
+              "  return codes.length >= 1 && codes.every((code) => code === \"eligibility_restricted\");")
 open(p, "w").write(s)
 PY
 }

--- a/scripts/mutate-1241-category-lede.sh
+++ b/scripts/mutate-1241-category-lede.sh
@@ -1,0 +1,157 @@
+#!/usr/bin/env bash
+set -uo pipefail
+
+REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO"
+
+TESTS=(
+  test/category-gate-lede.test.ts
+  test/eligibility-disclosure.test.ts
+)
+
+SOURCES=(src/serve.ts src/eligibility.ts src/gate-disclosure.ts)
+
+backup() { for f in "${SOURCES[@]}"; do cp "$f" "/tmp/$(basename "$f").ledeorig"; done; }
+restore() { for f in "${SOURCES[@]}"; do cp "/tmp/$(basename "$f").ledeorig" "$f"; done; }
+
+backup
+trap 'restore; npm run build >/dev/null 2>&1' EXIT
+
+killed=0
+survived=0
+
+run_mutation() {
+  local name="$1"; shift
+  restore
+  if ! "$@"; then
+    echo "NOT APPLIED                $name"
+    return
+  fi
+  if ! npm run build >/dev/null 2>&1; then
+    echo "KILLED (does not compile)  $name"
+    killed=$((killed + 1))
+    return
+  fi
+  if TZ=UTC node --test --test-concurrency 1 "${TESTS[@]}" >/tmp/mutation-lede-out.txt 2>&1; then
+    echo "SURVIVED                   $name"
+    survived=$((survived + 1))
+  else
+    echo "KILLED                     $name"
+    killed=$((killed + 1))
+  fi
+}
+
+sub() {
+  python3 - "$1" "$2" "$3" <<'PY'
+import sys
+path, old, new = sys.argv[1], sys.argv[2], sys.argv[3]
+text = open(path, encoding="utf-8").read()
+if old not in text:
+    sys.exit("mutation target not found in " + path)
+open(path, "w", encoding="utf-8").write(text.replace(old, new, 1))
+PY
+}
+
+run_mutation "the lede counts eligibility alone again" \
+  sub src/serve.ts 'const catGates = catOffers.map((o) => gateFor(o, catServedOn));' \
+                   'const catGates = catOffers.map((o) => eligibilityGate(o));'
+
+run_mutation "the lede counts every record as gated" \
+  sub src/serve.ts 'const catGates = catOffers.map((o) => gateFor(o, catServedOn));' \
+                   'const catGates = catOffers.map((o) => gateFor(o, catServedOn) ?? { code: "not_a_free_offer" as const, reason: "x" });'
+
+run_mutation "the lede states no gate at all" \
+  sub src/eligibility.ts 'const codes = gatedCodes(gates);
+  if (codes.length === 0) return `${counted}.`;' \
+                         'const codes: GateCode[] = [];
+  if (codes.length === 0) return `${counted}.`;'
+
+run_mutation "the retired clause is dropped from the list" \
+  sub src/gate-disclosure.ts '    code: "offer_retired",
+    one: "1 has ended",
+    many: (n) => `${n} have ended`,' \
+                             '    code: "offer_retired",
+    one: "",
+    many: () => "",'
+
+run_mutation "the not-free clause is dropped from the list" \
+  sub src/gate-disclosure.ts '    code: "not_a_free_offer",
+    one: "1 is not a free offer",
+    many: (n) => `${n} are not free offers`,' \
+                             '    code: "not_a_free_offer",
+    one: "",
+    many: () => "",'
+
+run_mutation "the eligibility clause loses its wording" \
+  sub src/gate-disclosure.ts 'one: "1 requires an application or qualification",' \
+                             'one: "1 is not on our ranked list",'
+
+run_mutation "the clause list drops every code but the first" \
+  sub src/gate-disclosure.ts 'return clauses.join(", ");' \
+                             'return clauses.slice(0, 1).join(", ");'
+
+run_mutation "the count names the first gate code rather than the whole set" \
+  sub src/eligibility.ts 'return `${counted}. ${gateDisclosureSentence("them", total, codes)}`;' \
+                         'return `${counted}. ${gateDisclosureSentence("them", total, codes.slice(0, 1))}`;'
+
+run_mutation "the entirely gated form is applied to any gated category" \
+  sub src/eligibility.ts 'return codes.length >= total && codes.every((code) => code === "eligibility_restricted");' \
+                         'return codes.every((code) => code === "eligibility_restricted");'
+
+run_mutation "the entirely gated pages lose their published wording" \
+  sub src/eligibility.ts 'return `${counted}, none of them generally available — each requires an application or qualification.`;' \
+                         'return `${counted}. ${gateDisclosureSentence("them", total, codes)}`;'
+
+run_mutation "the search snippet counts eligibility alone again" \
+  sub src/eligibility.ts 'export function gatedShareDescriptionClause(total: number, gates: (Gate | null)[]): string {
+  const codes = gatedCodes(gates);' \
+                         'export function gatedShareDescriptionClause(total: number, gates: (Gate | null)[]): string {
+  const codes = gatedCodes(gates).filter((code) => code === "eligibility_restricted");'
+
+run_mutation "the search snippet drops the clause entirely" \
+  sub src/serve.ts 'const catGatedClause = gatedShareDescriptionClause(catCount, catGates);' \
+                   'const catGatedClause = "";'
+
+run_mutation "the snippet clause follows the vendor list" \
+  sub src/serve.ts 'free tiers, and developer deals.${catGatedClause ? ` ${catGatedClause}` : ""} Verified pricing for ${catOffers.slice(0, 5).map(o => o.vendor).join(", ")}${catCount > 5 ? " and more" : ""}.`;' \
+                   'free tiers, and developer deals. Verified pricing for ${catOffers.slice(0, 5).map(o => o.vendor).join(", ")}${catCount > 5 ? " and more" : ""}.${catGatedClause ? ` ${catGatedClause}` : ""}`;'
+
+run_mutation "the record put forward is the first one again" \
+  sub src/serve.ts 'const topVendor = catOffers.find((_, i) => catGates[i] === null);' \
+                   'const topVendor = catOffers[0];'
+
+run_mutation "the record put forward skips only eligibility" \
+  sub src/serve.ts 'const topVendor = catOffers.find((_, i) => catGates[i] === null);' \
+                   'const topVendor = catOffers.find((o) => !eligibilityGate(o));'
+
+run_mutation "the record put forward is the last one" \
+  sub src/serve.ts 'const topVendor = catOffers.find((_, i) => catGates[i] === null);' \
+                   'const topVendor = catOffers[catOffers.length - 1];'
+
+run_mutation "the claim is dropped on every category" \
+  sub src/serve.ts 'const topVendor = catOffers.find((_, i) => catGates[i] === null);' \
+                   'const topVendor = undefined as typeof catOffers[number] | undefined;'
+
+run_mutation "the singular form is used for every count" \
+  sub src/gate-disclosure.ts 'if (gated === 1) return `One of ${subject} is not on our ranked list — ${clauses}.`;' \
+                             'if (gated >= 1) return `One of ${subject} is not on our ranked list — ${clauses}.`;'
+
+run_mutation "the plural clause is used for a single record" \
+  sub src/gate-disclosure.ts 'clauses.push(n === 1 ? clause.one : clause.many(n));' \
+                             'clauses.push(clause.many(n));'
+
+run_mutation "the best-service answer keeps the first record while the intro moves" \
+  sub src/serve.ts '${topVendor ? ` ${escHtmlServer(topVendor.vendor)} offers ${escHtmlServer(keyLimit)} on their ${escHtmlServer(topVendor.tier)} plan.` : ""}' \
+                   '${catOffers[0] ? ` ${escHtmlServer(catOffers[0].vendor)} offers ${escHtmlServer(keyLimit)} on their ${escHtmlServer(catOffers[0].tier)} plan.` : ""}'
+
+run_mutation "the best-service answer leaves a gap where the claim was" \
+  sub src/serve.ts 'services include ${topAlts}.${topVendor ? ` ${escHtmlServer(topVendor.vendor)}' \
+                   'services include ${topAlts}. ${topVendor ? `${escHtmlServer(topVendor.vendor)}'
+
+run_mutation "the gate date is fixed before every expiry" \
+  sub src/serve.ts 'const catServedOn = utcDate();' \
+                   'const catServedOn = "2000-01-01";'
+
+echo
+echo "killed:   $killed"
+echo "survived: $survived"

--- a/src/eligibility.ts
+++ b/src/eligibility.ts
@@ -1,5 +1,6 @@
 import { eligibilityGateFor } from "./ranking.js";
-import type { Gate } from "./ranking.js";
+import type { Gate, GateCode } from "./ranking.js";
+import { gateClauseList, gateDisclosureSentence } from "./gate-disclosure.js";
 import type { Offer } from "./types.js";
 
 export const CONDITION_RECORDING_AN_UNREAD_PROGRAM = "Startup program — check vendor for eligibility details";
@@ -8,19 +9,29 @@ export function eligibilityGate(offer: Pick<Offer, "eligibility">): Gate | null 
   return eligibilityGateFor(offer);
 }
 
-export function gatedShareLede(total: number, gated: number): string {
-  const counted = `${total} verified free tiers and developer deals`;
-  if (gated === 0) return `${counted}.`;
-  if (gated >= total) return `${counted}, none of them generally available — each requires an application or qualification.`;
-  if (gated === 1) return `${counted}. 1 of them is not generally available — it requires an application or qualification.`;
-  return `${counted}. ${gated} of them are not generally available — each requires an application or qualification.`;
+export function gatedCodes(gates: (Gate | null)[]): GateCode[] {
+  return gates.filter((g): g is Gate => g !== null).map((g) => g.code);
 }
 
-export function gatedShareDescriptionClause(total: number, gated: number): string {
-  if (gated === 0) return "";
-  if (gated >= total) return `All ${total} require an application or qualification.`;
-  if (gated === 1) return "1 requires an application or qualification.";
-  return `${gated} require an application or qualification.`;
+function eligibilityAccountsForEveryOffer(codes: GateCode[], total: number): boolean {
+  return codes.length >= total && codes.every((code) => code === "eligibility_restricted");
+}
+
+export function gatedShareLede(total: number, gates: (Gate | null)[]): string {
+  const counted = `${total} verified free tiers and developer deals`;
+  const codes = gatedCodes(gates);
+  if (codes.length === 0) return `${counted}.`;
+  if (eligibilityAccountsForEveryOffer(codes, total)) {
+    return `${counted}, none of them generally available — each requires an application or qualification.`;
+  }
+  return `${counted}. ${gateDisclosureSentence("them", total, codes)}`;
+}
+
+export function gatedShareDescriptionClause(total: number, gates: (Gate | null)[]): string {
+  const codes = gatedCodes(gates);
+  if (codes.length === 0) return "";
+  if (eligibilityAccountsForEveryOffer(codes, total)) return `All ${total} require an application or qualification.`;
+  return `${gateClauseList(codes)}.`;
 }
 
 export function publishableEligibilityConditions(offer: Pick<Offer, "eligibility">): string[] {

--- a/src/serve.ts
+++ b/src/serve.ts
@@ -1097,8 +1097,9 @@ function buildCategoryPage(slug: string): string | null {
 
   const catOffers = offers.filter((o) => o.category === categoryName);
   const catCount = catOffers.length;
-  const catGatedCount = catOffers.filter((o) => eligibilityGate(o)).length;
-  const catGatedClause = gatedShareDescriptionClause(catCount, catGatedCount);
+  const catServedOn = utcDate();
+  const catGates = catOffers.map((o) => gateFor(o, catServedOn));
+  const catGatedClause = gatedShareDescriptionClause(catCount, catGates);
   const title = `Free ${categoryName} Tools & Deals (${catCount} offers) — AgentDeals`;
   const metaDesc = `Compare ${catCount} free ${categoryName.toLowerCase()} tools, free tiers, and developer deals.${catGatedClause ? ` ${catGatedClause}` : ""} Verified pricing for ${catOffers.slice(0, 5).map(o => o.vendor).join(", ")}${catCount > 5 ? " and more" : ""}.`;
 
@@ -1139,7 +1140,7 @@ function buildCategoryPage(slug: string): string | null {
     ? `This category has been relatively stable &mdash; only ${catChangeCount} pricing changes recorded across all vendors.`
     : `This category has seen some movement &mdash; ${catChangeCount} pricing changes recorded across vendors.`;
 
-  const topVendor = catOffers[0];
+  const topVendor = catOffers.find((_, i) => catGates[i] === null);
   const keyLimitMatch = topVendor?.description.match(/(\d[\d,]*\s*(?:GB|GiB|MB|TB|requests?|calls?|MAU|users?|emails?|messages?|builds?|minutes?|hours?|projects?|repos?|sites?|apps?|databases?|invocations?|events?))/i);
   const keyLimit = keyLimitMatch ? keyLimitMatch[1] : "a generous free tier";
 
@@ -1203,7 +1204,7 @@ function buildCategoryPage(slug: string): string | null {
   const faqItems = [
     {
       q: `What is the best free ${categoryName.toLowerCase()} service?`,
-      a: `Based on our data, the most popular free ${categoryName.toLowerCase()} services include ${topAlts}. ${topVendor ? `${escHtmlServer(topVendor.vendor)} offers ${escHtmlServer(keyLimit)} on their ${escHtmlServer(topVendor.tier)} plan.` : ""} The best choice depends on your specific requirements.`,
+      a: `Based on our data, the most popular free ${categoryName.toLowerCase()} services include ${topAlts}.${topVendor ? ` ${escHtmlServer(topVendor.vendor)} offers ${escHtmlServer(keyLimit)} on their ${escHtmlServer(topVendor.tier)} plan.` : ""} The best choice depends on your specific requirements.`,
     },
     {
       q: `How many free ${categoryName.toLowerCase()} tools are there?`,
@@ -1316,7 +1317,7 @@ ${mcpCtaCss()}
   ${buildGlobalNav("categories")}
   <div class="breadcrumb"><a href="/">AgentDeals</a> &rsaquo; ${escHtmlServer(categoryName)}</div>
   <h1>Free ${escHtmlServer(categoryName)} Tools</h1>
-  <p class="cat-meta">${gatedShareLede(catCount, catGatedCount)}${dataVerifiedSegment(catOffers)}</p>
+  <p class="cat-meta">${gatedShareLede(catCount, catGates)}${dataVerifiedSegment(catOffers)}</p>
 
   ${introHtml}
   ${analysisCta}

--- a/test/category-gate-lede.test.ts
+++ b/test/category-gate-lede.test.ts
@@ -1,0 +1,338 @@
+import { describe, it, before, after } from "node:test";
+import assert from "node:assert";
+import { spawn, type ChildProcess } from "node:child_process";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const { gateFor, utcDate } = await import("../dist/ranking.js");
+
+type Offer = import("../src/types.ts").Offer;
+type Gate = { code: string; reason: string } | null;
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO = path.join(__dirname, "..");
+
+const offers: Offer[] = JSON.parse(readFileSync(path.join(REPO, "data", "index.json"), "utf-8")).offers;
+const TODAY = utcDate();
+
+const ALL_GATED_ELIGIBILITY_LEDE = "none of them generally available — each requires an application or qualification.";
+const RANKED_LIST_PHRASE = "not on our ranked list";
+
+const CLAUSE_FORMS: Record<string, (n: number) => string> = {
+  eligibility_restricted: (n) => (n === 1 ? "1 requires an application or qualification" : `${n} require an application or qualification`),
+  not_a_free_offer: (n) => (n === 1 ? "1 is not a free offer" : `${n} are not free offers`),
+  offer_expired: (n) => (n === 1 ? "1 has expired" : `${n} have expired`),
+  offer_retired: (n) => (n === 1 ? "1 has ended" : `${n} have ended`),
+  verification_lapsed: (n) => (n === 1 ? "1 has not been re-confirmed recently enough" : `${n} have not been re-confirmed recently enough`),
+};
+
+const CLAUSE_ORDER = ["eligibility_restricted", "not_a_free_offer", "offer_expired", "offer_retired", "verification_lapsed"];
+
+function clausesFor(codes: string[]): string {
+  const parts: string[] = [];
+  for (const code of CLAUSE_ORDER) {
+    const n = codes.filter((c) => c === code).length;
+    if (n === 0) continue;
+    const form = CLAUSE_FORMS[code];
+    assert.ok(form, `no clause form for gate code ${code}`);
+    parts.push(form(n));
+  }
+  return parts.join(", ");
+}
+
+function expectedLede(total: number, codes: string[]): string {
+  const counted = `${total} verified free tiers and developer deals`;
+  if (codes.length === 0) return `${counted}.`;
+  if (codes.length >= total && codes.every((c) => c === "eligibility_restricted")) {
+    return `${counted}, ${ALL_GATED_ELIGIBILITY_LEDE}`;
+  }
+  const clauses = clausesFor(codes);
+  if (codes.length >= total && total > 1) return `${counted}. None of them are on our ranked list — ${clauses}.`;
+  if (codes.length === 1) return `${counted}. One of them is not on our ranked list — ${clauses}.`;
+  return `${counted}. ${codes.length} of them are not on our ranked list — ${clauses}.`;
+}
+
+function slugOf(name: string): string {
+  return name.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "");
+}
+
+interface CategoryCensus {
+  name: string;
+  slug: string;
+  records: Offer[];
+  gates: Gate[];
+  codes: string[];
+  total: number;
+  gated: number;
+}
+
+const census: CategoryCensus[] = [...new Set(offers.map((o) => o.category))].sort().map((name) => {
+  const records = offers.filter((o) => o.category === name);
+  const gates: Gate[] = records.map((o) => gateFor(o, TODAY));
+  return {
+    name,
+    slug: slugOf(name),
+    records,
+    gates,
+    codes: gates.filter((g): g is NonNullable<Gate> => g !== null).map((g) => g.code),
+    total: records.length,
+    gated: gates.filter((g) => g !== null).length,
+  };
+});
+
+let port = 0;
+let proc: ChildProcess | null = null;
+
+function startServer(): Promise<ChildProcess> {
+  return new Promise((resolve, reject) => {
+    const child = spawn("node", [path.join(REPO, "dist", "serve.js")], {
+      stdio: ["pipe", "pipe", "pipe"],
+      env: { ...process.env, PORT: "0", BASE_URL: "http://localhost", TZ: "UTC" },
+    });
+    const timeout = setTimeout(() => { child.kill(); reject(new Error("Server startup timeout")); }, 60000);
+    child.stderr!.on("data", (data: Buffer) => {
+      const m = data.toString().match(/running on http:\/\/localhost:(\d+)/);
+      if (m) { port = parseInt(m[1], 10); clearTimeout(timeout); resolve(child); }
+    });
+    child.on("error", (e) => { clearTimeout(timeout); reject(e); });
+  });
+}
+
+const fetched = new Map<string, string>();
+
+async function page(pathname: string): Promise<string> {
+  const cached = fetched.get(pathname);
+  if (cached !== undefined) return cached;
+  const body = await (await fetch(`http://localhost:${port}${pathname}`)).text();
+  fetched.set(pathname, body);
+  return body;
+}
+
+function textOf(fragment: string): string {
+  return fragment.replace(/<[^>]+>/g, "").replace(/&mdash;/g, "—").replace(/&amp;/g, "&").trim();
+}
+
+function ledeOf(html: string): string {
+  return textOf(html.match(/<p class="cat-meta">([\s\S]*?)<\/p>/)?.[1] ?? "");
+}
+
+function introOf(html: string): string {
+  return textOf(html.match(/<div class="cat-intro">\s*<p>([\s\S]*?)<\/p>/)?.[1] ?? "");
+}
+
+function descriptionOf(html: string): string {
+  return (html.match(/<meta name="description" content="([^"]*)"/)?.[1] ?? "").replace(/&amp;/g, "&");
+}
+
+function leaderNamedIn(intro: string): string | null {
+  return intro.match(/services with free tiers\.\s+(.+?) leads with /)?.[1] ?? null;
+}
+
+function renderedFaqAnswer(html: string, question: string): string | undefined {
+  for (const m of html.matchAll(/<summary class="faq-q">([\s\S]*?)<\/summary>\s*<div class="faq-a">([\s\S]*?)<\/div>/g)) {
+    if (textOf(m[1]) === question) return m[2];
+  }
+  return undefined;
+}
+
+function bestServiceClaimIn(answer: string): string | null {
+  return answer.match(/services include .+?\.\s(.+?) offers .+? on their .+? plan\./)?.[1] ?? null;
+}
+
+function disclosedCountIn(lede: string, total: number): number {
+  if (lede.includes(ALL_GATED_ELIGIBILITY_LEDE)) return total;
+  if (lede.includes(`None of them are ${RANKED_LIST_PHRASE}`)) return total;
+  if (lede.includes(`One of them is ${RANKED_LIST_PHRASE}`)) return 1;
+  const named = lede.match(/(\d[\d,]*) of them are not on our ranked list/);
+  return named ? parseInt(named[1].replace(/,/g, ""), 10) : 0;
+}
+
+describe("a category page discloses every gated record, not eligibility alone", () => {
+  before(async () => { proc = await startServer(); });
+  after(() => { proc?.kill(); });
+
+  it("holds the four populations the sentence forms are written for", () => {
+    assert.ok(census.some((c) => c.gated === 0), "no category is free of gated records");
+    assert.ok(census.some((c) => c.gated === 1), "no category holds exactly one gated record");
+    assert.ok(census.some((c) => c.gated > 1 && c.gated < c.total), "no category is partly gated");
+    assert.ok(census.some((c) => c.gated === c.total && c.total > 1), "no category is entirely gated");
+    assert.ok(
+      census.some((c) => new Set(c.codes).size > 1),
+      "no category mixes gate codes, so the clause list is never exercised",
+    );
+    assert.ok(
+      census.some((c) => c.gated > 0 && !c.codes.includes("eligibility_restricted")),
+      "every gated category holds an eligibility record, so the widening is untested",
+    );
+  });
+
+  it("states the sentence its own records compose", async () => {
+    for (const c of census) {
+      const lede = ledeOf(await page(`/category/${c.slug}`));
+      const expected = expectedLede(c.total, c.codes);
+      assert.ok(
+        lede.startsWith(expected),
+        `/category/${c.slug} (${c.gated} of ${c.total})\n  reads: ${lede}\n  should: ${expected}`,
+      );
+      assert.ok(!lede.includes("  "), `/category/${c.slug} lede holds a gap: ${lede}`);
+      const rest = lede.slice(expected.length);
+      assert.ok(
+        rest === "" || /^ Data verified through \d{4}-\d{2}-\d{2}\.$/.test(rest),
+        `/category/${c.slug} lede carries ${JSON.stringify(rest)} after the sentence`,
+      );
+    }
+  });
+
+  it("never names a number below the number of records the ranker gates", async () => {
+    let disclosing = 0;
+    for (const c of census) {
+      const lede = ledeOf(await page(`/category/${c.slug}`));
+      const disclosed = disclosedCountIn(lede, c.total);
+      assert.ok(
+        disclosed >= c.gated,
+        `/category/${c.slug} names ${disclosed} of ${c.gated} gated records: ${lede}`,
+      );
+      if (c.gated > 0) {
+        assert.strictEqual(disclosed, c.gated, `/category/${c.slug} names ${disclosed}, gate replay says ${c.gated}`);
+        disclosing++;
+      }
+    }
+    assert.strictEqual(disclosing, census.filter((c) => c.gated > 0).length);
+    assert.ok(disclosing > 20, `only ${disclosing} categories disclose a gated count`);
+  });
+
+  it("keeps the eligibility wording on every category holding an eligibility record", async () => {
+    let carrying = 0;
+    for (const c of census) {
+      const restricted = c.codes.filter((code) => code === "eligibility_restricted").length;
+      const lede = ledeOf(await page(`/category/${c.slug}`));
+      if (restricted === 0) {
+        assert.ok(
+          !lede.includes("application or qualification"),
+          `/category/${c.slug} states a restriction no record holds: ${lede}`,
+        );
+        continue;
+      }
+      carrying++;
+      const clause = restricted === c.total
+        ? ALL_GATED_ELIGIBILITY_LEDE
+        : CLAUSE_FORMS.eligibility_restricted(restricted);
+      assert.ok(lede.includes(clause), `/category/${c.slug} drops the eligibility clause: ${lede}`);
+    }
+    assert.ok(carrying >= 13, `only ${carrying} categories carry the eligibility clause`);
+  });
+
+  it("leaves the entirely gated pages on the wording they already publish", async () => {
+    const entirely = census.filter((c) => c.gated === c.total && c.total > 1);
+    assert.ok(entirely.length > 0, "no category is entirely gated");
+    for (const c of entirely) {
+      const lede = ledeOf(await page(`/category/${c.slug}`));
+      assert.ok(lede.includes(ALL_GATED_ELIGIBILITY_LEDE), `/category/${c.slug} lede is ${lede}`);
+      assert.ok(
+        !lede.startsWith(`${c.total} verified free tiers and developer deals.`),
+        `/category/${c.slug} closes the count claim before qualifying it: ${lede}`,
+      );
+    }
+  });
+
+  it("carries the widened clause list into the search snippet", async () => {
+    for (const c of census) {
+      const description = descriptionOf(await page(`/category/${c.slug}`));
+      if (c.gated === 0) {
+        assert.ok(
+          !/application or qualification|not a free offer|are not free offers|has expired|have expired|has ended|have ended/.test(description),
+          `/category/${c.slug} description states a gate no record holds: ${description}`,
+        );
+        continue;
+      }
+      const clause = c.codes.length >= c.total && c.codes.every((code) => code === "eligibility_restricted")
+        ? `All ${c.total} require an application or qualification.`
+        : `${clausesFor(c.codes)}.`;
+      assert.ok(description.includes(clause), `/category/${c.slug} description is ${description}`);
+      assert.ok(
+        description.indexOf(clause) < description.indexOf("Verified pricing for"),
+        `/category/${c.slug} appends the clause after the vendor list, where a snippet truncates it`,
+      );
+    }
+  });
+});
+
+describe("the record a category page puts forward is one the ranker lists", () => {
+  before(async () => { proc = proc ?? await startServer(); });
+  after(() => { proc?.kill(); });
+
+  it("names no record the ranker gates", async () => {
+    let named = 0;
+    for (const c of census) {
+      const leader = leaderNamedIn(introOf(await page(`/category/${c.slug}`)));
+      if (leader === null) continue;
+      named++;
+      const held = c.records.filter((o) => o.vendor === leader);
+      assert.ok(held.length > 0, `/category/${c.slug} names ${leader}, which holds no record in the category`);
+      for (const record of held) {
+        const gate = gateFor(record, TODAY);
+        assert.strictEqual(
+          gate,
+          null,
+          `/category/${c.slug} names ${leader} (${record.tier}) — ${gate?.code}: ${gate?.reason}`,
+        );
+      }
+    }
+    assert.ok(named > 50, `only ${named} categories put a record forward`);
+  });
+
+  it("omits the claim exactly where every record is gated", async () => {
+    for (const c of census) {
+      const leader = leaderNamedIn(introOf(await page(`/category/${c.slug}`)));
+      if (c.gated === c.total) {
+        assert.strictEqual(leader, null, `/category/${c.slug} names ${leader} with every record gated`);
+      } else {
+        assert.notStrictEqual(leader, null, `/category/${c.slug} names no record with ${c.total - c.gated} ungated`);
+      }
+    }
+    assert.ok(census.some((c) => c.gated === c.total), "no category is entirely gated");
+  });
+
+  it("answers the best-service question with the same record", async () => {
+    let claiming = 0;
+    for (const c of census) {
+      const html = await page(`/category/${c.slug}`);
+      const answer = renderedFaqAnswer(html, `What is the best free ${c.name.toLowerCase()} service?`);
+      assert.ok(answer, `/category/${c.slug} stopped answering the best-service question`);
+      const claimed = bestServiceClaimIn(answer);
+      const leader = leaderNamedIn(introOf(html));
+      assert.strictEqual(claimed, leader, `/category/${c.slug} answers about ${claimed} and leads with ${leader}`);
+      if (claimed === null) continue;
+      claiming++;
+      for (const record of c.records.filter((o) => o.vendor === claimed)) {
+        const gate = gateFor(record, TODAY);
+        assert.strictEqual(gate, null, `/category/${c.slug} answers with ${claimed} (${record.tier}) — ${gate?.code}`);
+      }
+    }
+    assert.ok(claiming > 50, `only ${claiming} categories answer with a record`);
+  });
+
+  it("closes the answer cleanly on a category that has no record to put forward", async () => {
+    const entirely = census.filter((c) => c.gated === c.total);
+    assert.ok(entirely.length > 0, "no category is entirely gated");
+    for (const c of entirely) {
+      const html = await page(`/category/${c.slug}`);
+      const answer = renderedFaqAnswer(html, `What is the best free ${c.name.toLowerCase()} service?`);
+      assert.ok(answer, `/category/${c.slug} stopped answering the best-service question`);
+      assert.ok(!answer.includes("  "), `/category/${c.slug} answer holds a gap where the claim was: ${answer}`);
+      assert.ok(!/ offers .+? on their .+? plan\./.test(answer), `/category/${c.slug} answer is ${answer}`);
+      assert.ok(!introOf(html).includes("  "), `/category/${c.slug} intro holds a gap where the claim was`);
+    }
+  });
+
+  it("still puts a record forward on a category whose first record is gated", async () => {
+    const displaced = census.filter((c) => c.gates[0] !== null && c.gated < c.total);
+    assert.ok(displaced.length > 0, "no category leads with a gated record in the data");
+    for (const c of displaced) {
+      const leader = leaderNamedIn(introOf(await page(`/category/${c.slug}`)));
+      assert.notStrictEqual(leader, null, `/category/${c.slug} drops the claim rather than moving it`);
+      assert.notStrictEqual(leader, c.records[0].vendor, `/category/${c.slug} still names ${leader}`);
+    }
+  });
+});

--- a/test/eligibility-disclosure.test.ts
+++ b/test/eligibility-disclosure.test.ts
@@ -204,7 +204,11 @@ describe("a category page does not count a gated offer as a plain free tier", ()
   const categoryNames = [...new Set(offers.map(o => o.category))].sort();
   const censusOf = (category: string) => {
     const inCategory = offers.filter(o => o.category === category);
-    return { total: inCategory.length, gated: inCategory.filter(o => eligibilityGate(o)).length };
+    return {
+      total: inCategory.length,
+      restricted: inCategory.filter(o => eligibilityGate(o)).length,
+      gated: inCategory.filter(o => gateFor(o, utcDate())).length,
+    };
   };
   const ledeOf = (html: string) => html.match(/<p class="cat-meta">([\s\S]*?)<\/p>/)?.[1] ?? "";
   const descriptionOf = (html: string) => html.match(/<meta name="description" content="([^"]*)"/)?.[1] ?? "";
@@ -218,24 +222,36 @@ describe("a category page does not count a gated offer as a plain free tier", ()
     assert.ok(censuses.some(c => c.gated === 0), "every category holds a gated record");
   });
 
+  it("holds a category gated by something other than eligibility, so the two counts are separable", () => {
+    const censuses = categoryNames.map(censusOf);
+    assert.ok(censuses.some(c => c.gated > c.restricted), "eligibility accounts for every gated record");
+    assert.ok(censuses.some(c => c.gated > 0 && c.restricted === 0), "no category is gated without eligibility");
+  });
+
   it("qualifies the count claim rather than closing it", async () => {
     for (const category of categoryNames) {
-      const { total, gated } = censusOf(category);
+      const { total, restricted, gated } = censusOf(category);
       const html = await page(`/category/${slugOf(category)}`);
       const lede = ledeOf(html);
-      const where = `/category/${slugOf(category)} (${gated} of ${total})`;
+      const where = `/category/${slugOf(category)} (${gated} gated, ${restricted} restricted, of ${total})`;
       if (gated === 0) {
         assert.ok(lede.startsWith(`${total} verified free tiers and developer deals.`), `${where} lede is ${lede}`);
         assert.ok(!lede.includes(QUALIFICATION), `${where} states a restriction it does not hold`);
         continue;
       }
-      assert.ok(lede.includes(QUALIFICATION), `${where} lede is ${lede}`);
-      if (gated === total) {
+      assert.strictEqual(
+        lede.includes(QUALIFICATION),
+        restricted > 0,
+        `${where} states the eligibility clause on ${restricted} restricted records: ${lede}`,
+      );
+      if (gated === total && restricted === total) {
         assert.ok(lede.includes("none of them generally available"), `${where} lede is ${lede}`);
         assert.ok(
           !lede.startsWith(`${total} verified free tiers and developer deals.`),
           `${where} closes the count claim before qualifying it: ${lede}`,
         );
+      } else if (gated === 1) {
+        assert.ok(lede.includes("One of them is not on our ranked list"), `${where} lede is ${lede}`);
       } else {
         assert.ok(lede.includes(`${gated} of them`), `${where} lede does not name ${gated}: ${lede}`);
       }
@@ -244,22 +260,29 @@ describe("a category page does not count a gated offer as a plain free tier", ()
 
   it("states a number the rows below it agree with", async () => {
     for (const category of categoryNames) {
-      const { total, gated } = censusOf(category);
+      const { total, restricted, gated } = censusOf(category);
       const html = await page(`/category/${slugOf(category)}`);
-      assert.strictEqual(restrictedRows(html), gated, `/category/${slugOf(category)} restricted rows`);
-      if (gated > 0 && gated < total) {
-        assert.ok(ledeOf(html).includes(`${restrictedRows(html)} of them`), `/category/${slugOf(category)}`);
+      const lede = ledeOf(html);
+      assert.strictEqual(restrictedRows(html), restricted, `/category/${slugOf(category)} restricted rows`);
+      if (gated > 1 && gated < total) {
+        assert.ok(lede.includes(`${gated} of them`), `/category/${slugOf(category)} lede is ${lede}`);
+      }
+      if (restricted > 0 && gated < total) {
+        const clause = restricted === 1
+          ? "1 requires an application or qualification"
+          : `${restricted} require an application or qualification`;
+        assert.ok(lede.includes(clause), `/category/${slugOf(category)} does not name ${restricted}: ${lede}`);
       }
     }
   });
 
   it("carries the same qualification into the search snippet, ahead of the vendor list", async () => {
     for (const category of categoryNames) {
-      const { total, gated } = censusOf(category);
+      const { total, restricted } = censusOf(category);
       const html = await page(`/category/${slugOf(category)}`);
       const description = descriptionOf(html);
-      const where = `/category/${slugOf(category)} (${gated} of ${total})`;
-      if (gated === 0) {
+      const where = `/category/${slugOf(category)} (${restricted} restricted of ${total})`;
+      if (restricted === 0) {
         assert.ok(!description.includes(QUALIFICATION), `${where} description is ${description}`);
         continue;
       }


### PR DESCRIPTION
Refs #1241 — Part 2. Part 1 (#1247) put the gate on the JSON surfaces; this puts it on the category lede and the leader claim.

## What moved

**The lede counted one gate code out of five.** `gatedShareLede` took an eligibility count, so 11 of the 24 categories holding a gated record named a number below their own. It now composes from `gate-disclosure.ts` — the module Part 1 already ships on `/api/offers` and `search_deals` — so both surfaces state the same four sentence forms over the same counts.

**The leader claim never consulted the gate.** `topVendor` was `catOffers[0]`. It is now the first record the ranker does not gate, and the claim is omitted where every record is gated.

Census over all 66 categories against a `gateFor` replay of `data/index.json`, no sample:

| | before | after |
|---|---|---|
| categories naming a gated count below their own | **11** | 0 |
| categories putting a gated record forward | **6** | 0 |
| ledes matching the composer over their own records | — | 66 of 66 |

`/category/payments` read *"1 of them is not generally available … Stripe leads with a generous free tier"* over a `Pay-as-you-go` record. It now reads:

> 18 verified free tiers and developer deals. 4 of them are not on our ranked list — 1 requires an application or qualification, 3 are not free offers.

and puts Paddle forward.

## Three decisions

**The entirely gated pages keep the wording they already publish.** The issue offers that as the `all` form, and `test/eligibility-disclosure.test.ts:235` — a shipped #1215 criterion — requires those two pages not to close the count claim before qualifying it. Taking the new `all` form instead would have deleted that criterion silently. It applies only where eligibility accounts for every record and falls through to the widened forms otherwise, so a mixed all-gated category cannot inherit a false clause.

**The search snippet takes the same clause list.** `gatedShareDescriptionClause` had the same eligibility-only defect on the same page. For eligibility-only categories its output is byte-identical to before; 11 categories gain the missing clauses.

**A second consumer of the leader moved with it, and needed a fix.** The category FAQ answer *"What is the best free X service?"* also reads `topVendor` — `/category/payments` answered *"Stripe offers a generous free tier on their Pay-as-you-go plan"*. Omitting the claim left a double space in the rendered answer, which the FAQ JSON-LD hides because `faq-provenance.ts:65` collapses whitespace. Fixed at the join and pinned against the rendered page, not the JSON-LD — the first version of that test read the normalized surface and a mutation survived it.

## Verification

- **2,553 of 2,577 paths byte-identical** to a main build. The 24 that move are exactly the categories holding a gated record — 24 predicted, 24 moved, 0 either side; all 42 ungated categories byte-identical.
- **Every changed line on every moved page** lands on one of seven surfaces, 0 outside: 22 ledes, 11 meta descriptions, 11 `og:description`, 11 `ItemList` descriptions, 6 leader claims, 6 FAQ answers, 6 `FAQPage` blocks.
- **3,068 tests, 12 new, 0 failing.** Main is 3,056 and also green.
- **22 of 22 mutations killed**, none by a compile error — `scripts/mutate-1241-category-lede.sh`.
- **#1215's own mutations restored.** Four targets in `scripts/mutate-1215-ac6.sh` no longer existed after this change, which scores them as passing. Repointed; the script now reports the same 7 killed / 1 not-applied / 1 survived on this branch as on main, with the four lede mutations failing 15, 4, 15 and 24 assertions against 6, 4, 6 and 6 before.
- `npm run validate` clean, `check-mutation-targets` back to main's 13 stale.
- Rendered and read back on a running server, including screenshots of `/category/payments` and `/category/startup-perks`.

## Reported, not fixed

- **25 gated rows carry no row notice** — `listingEligibilityNoticeHtml` is eligibility-only, so 19 `not_a_free_offer`, 4 `offer_retired` and 2 `offer_expired` rows across 11 categories sit under a lede that counts them. Left alone because the row markup count is a shipped #1215 assertion and the AC names only the lede and the leader.
- **13 categories name a gated record among the first five** in the FAQ answer's *"most popular free X services include …"* and the meta description's *"Verified pricing for …"* — 24 records, including all three `Pay-as-you-go` payments records. That list is `catOffers.slice(0, 5)`, a different claim from the leader, and changing it moves the vendor list on every category page.
