### PR TITLE
Read the entirely gated lede in the form the page publishes

### DIFF
--- a/scripts/mutate-1190-lede-forms.sh
+++ b/scripts/mutate-1190-lede-forms.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+set -uo pipefail
+
+REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO"
+
+TESTS=(
+  test/category-gate-lede.test.ts
+  test/eligibility-disclosure.test.ts
+)
+
+SOURCES=(src/eligibility.ts src/gate-disclosure.ts test/category-gate-lede.test.ts)
+
+backup() { for f in "${SOURCES[@]}"; do cp "$f" "/tmp/$(basename "$f").lorig"; done; }
+restore() { for f in "${SOURCES[@]}"; do cp "/tmp/$(basename "$f").lorig" "$f"; done; }
+
+backup
+trap 'restore; npm run build >/dev/null 2>&1' EXIT
+
+killed=0
+survived=0
+
+run_mutation() {
+  local name="$1"; shift
+  restore
+  if ! "$@"; then
+    echo "NOT APPLIED                $name"
+    return
+  fi
+  if ! npm run build >/dev/null 2>&1; then
+    echo "KILLED (does not compile)  $name"
+    killed=$((killed + 1))
+    return
+  fi
+  if TZ=UTC node --test --test-concurrency 1 "${TESTS[@]}" >/tmp/mutation-1190-out.txt 2>&1; then
+    echo "SURVIVED                   $name"
+    survived=$((survived + 1))
+  else
+    local failed
+    failed=$(grep -c '^ *✖' /tmp/mutation-1190-out.txt || true)
+    echo "KILLED ($failed assertions) $name"
+    killed=$((killed + 1))
+  fi
+}
+
+sub() {
+  python3 - "$1" "$2" "$3" <<'PY'
+import sys
+path, old, new = sys.argv[1], sys.argv[2], sys.argv[3]
+text = open(path, encoding="utf-8").read()
+if old not in text:
+    sys.exit("mutation target not found in " + path)
+open(path, "w", encoding="utf-8").write(text.replace(old, new, 1))
+PY
+}
+
+run_mutation "the all-gated sentence denies the ranked list twice" \
+  sub src/gate-disclosure.ts 'return `None of ${subject} are on our ranked list' \
+                             'return `None of ${subject} are not on our ranked list'
+
+run_mutation "eligibility wording covers any entirely gated set, whatever gated it" \
+  sub src/eligibility.ts 'return codes.length >= total && codes.every((code) => code === "eligibility_restricted");' \
+                         'return codes.length >= total;'
+
+run_mutation "the all-gated form is dropped and the count form takes it" \
+  sub src/gate-disclosure.ts 'if (gated >= total && total > 1) return' \
+                             'if (false && gated >= total && total > 1) return'
+
+run_mutation "the single-record form is dropped and the count form takes it" \
+  sub src/gate-disclosure.ts 'if (gated === 1) return `One of ${subject}' \
+                             'if (false) return `One of ${subject}'
+
+run_mutation "the retired clause keeps its singular verb in the plural" \
+  sub src/gate-disclosure.ts 'many: (n) => `${n} have ended`' \
+                             'many: (n) => `${n} has ended`'
+
+run_mutation "the clause list states the first code and stops" \
+  sub src/gate-disclosure.ts 'return clauses.join(", ");' \
+                             'return clauses.slice(0, 1).join(", ");'
+
+run_mutation "the lede states the count and no gate sentence at all" \
+  sub src/eligibility.ts 'return `${counted}. ${gateDisclosureSentence("them", total, codes)}`;' \
+                         'return `${counted}.`;'
+
+run_mutation "the count this test reads back is the one the branch never matched" \
+  sub test/category-gate-lede.test.ts 'lede.includes(`None of them are ${ON_THE_RANKED_LIST}`)' \
+                                      'lede.includes(`None of them are ${RANKED_LIST_PHRASE}`)'
+
+echo
+echo "killed: $killed  survived: $survived"

--- a/test/category-gate-lede.test.ts
+++ b/test/category-gate-lede.test.ts
@@ -6,6 +6,7 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 
 const { gateFor, utcDate } = await import("../dist/ranking.js");
+const { gatedShareLede } = await import("../dist/eligibility.js");
 
 type Offer = import("../src/types.ts").Offer;
 type Gate = { code: string; reason: string } | null;
@@ -18,6 +19,7 @@ const TODAY = utcDate();
 
 const ALL_GATED_ELIGIBILITY_LEDE = "none of them generally available — each requires an application or qualification.";
 const RANKED_LIST_PHRASE = "not on our ranked list";
+const ON_THE_RANKED_LIST = "on our ranked list";
 
 const CLAUSE_FORMS: Record<string, (n: number) => string> = {
   eligibility_restricted: (n) => (n === 1 ? "1 requires an application or qualification" : `${n} require an application or qualification`),
@@ -41,10 +43,14 @@ function clausesFor(codes: string[]): string {
   return parts.join(", ");
 }
 
+function eligibilityAccountsForAll(c: { codes: string[]; total: number }): boolean {
+  return c.codes.length >= c.total && c.codes.every((code) => code === "eligibility_restricted");
+}
+
 function expectedLede(total: number, codes: string[]): string {
   const counted = `${total} verified free tiers and developer deals`;
   if (codes.length === 0) return `${counted}.`;
-  if (codes.length >= total && codes.every((c) => c === "eligibility_restricted")) {
+  if (eligibilityAccountsForAll({ codes, total })) {
     return `${counted}, ${ALL_GATED_ELIGIBILITY_LEDE}`;
   }
   const clauses = clausesFor(codes);
@@ -140,12 +146,12 @@ function bestServiceClaimIn(answer: string): string | null {
   return answer.match(/services include .+?\.\s(.+?) offers .+? on their .+? plan\./)?.[1] ?? null;
 }
 
-function disclosedCountIn(lede: string, total: number): number {
+function disclosedCountIn(lede: string, total: number): number | null {
   if (lede.includes(ALL_GATED_ELIGIBILITY_LEDE)) return total;
-  if (lede.includes(`None of them are ${RANKED_LIST_PHRASE}`)) return total;
+  if (lede.includes(`None of them are ${ON_THE_RANKED_LIST}`)) return total;
   if (lede.includes(`One of them is ${RANKED_LIST_PHRASE}`)) return 1;
   const named = lede.match(/(\d[\d,]*) of them are not on our ranked list/);
-  return named ? parseInt(named[1].replace(/,/g, ""), 10) : 0;
+  return named ? parseInt(named[1].replace(/,/g, ""), 10) : null;
 }
 
 describe("a category page discloses every gated record, not eligibility alone", () => {
@@ -189,14 +195,21 @@ describe("a category page discloses every gated record, not eligibility alone", 
     for (const c of census) {
       const lede = ledeOf(await page(`/category/${c.slug}`));
       const disclosed = disclosedCountIn(lede, c.total);
+      if (c.gated === 0) {
+        assert.strictEqual(disclosed, null, `/category/${c.slug} discloses a gated count holding no gated record: ${lede}`);
+        continue;
+      }
+      assert.notStrictEqual(
+        disclosed,
+        null,
+        `/category/${c.slug} states its gated set in a form this test reads as no disclosure at all: ${lede}`,
+      );
       assert.ok(
-        disclosed >= c.gated,
+        disclosed! >= c.gated,
         `/category/${c.slug} names ${disclosed} of ${c.gated} gated records: ${lede}`,
       );
-      if (c.gated > 0) {
-        assert.strictEqual(disclosed, c.gated, `/category/${c.slug} names ${disclosed}, gate replay says ${c.gated}`);
-        disclosing++;
-      }
+      assert.strictEqual(disclosed, c.gated, `/category/${c.slug} names ${disclosed}, gate replay says ${c.gated}`);
+      disclosing++;
     }
     assert.strictEqual(disclosing, census.filter((c) => c.gated > 0).length);
     assert.ok(disclosing > 20, `only ${disclosing} categories disclose a gated count`);
@@ -223,15 +236,29 @@ describe("a category page discloses every gated record, not eligibility alone", 
     assert.ok(carrying >= 13, `only ${carrying} categories carry the eligibility clause`);
   });
 
-  it("leaves the entirely gated pages on the wording they already publish", async () => {
-    const entirely = census.filter((c) => c.gated === c.total && c.total > 1);
-    assert.ok(entirely.length > 0, "no category is entirely gated");
+  it("leaves the pages eligibility gates entirely on the wording they already publish", async () => {
+    const entirely = census.filter((c) => eligibilityAccountsForAll(c) && c.total > 1);
+    assert.ok(entirely.length > 0, "no category is gated entirely by eligibility");
     for (const c of entirely) {
       const lede = ledeOf(await page(`/category/${c.slug}`));
       assert.ok(lede.includes(ALL_GATED_ELIGIBILITY_LEDE), `/category/${c.slug} lede is ${lede}`);
       assert.ok(
         !lede.startsWith(`${c.total} verified free tiers and developer deals.`),
         `/category/${c.slug} closes the count claim before qualifying it: ${lede}`,
+      );
+    }
+  });
+
+  it("states the clause list where every record is gated and eligibility is not the whole reason", async () => {
+    for (const c of census.filter((c) => c.gated === c.total && c.total > 1 && !eligibilityAccountsForAll(c))) {
+      const lede = ledeOf(await page(`/category/${c.slug}`));
+      assert.ok(
+        lede.includes(`None of them are ${ON_THE_RANKED_LIST} — ${clausesFor(c.codes)}.`),
+        `/category/${c.slug} lede is ${lede}`,
+      );
+      assert.ok(
+        !lede.includes(ALL_GATED_ELIGIBILITY_LEDE),
+        `/category/${c.slug} says each record requires an application, over ${new Set(c.codes).size} gate codes: ${lede}`,
       );
     }
   });
@@ -333,6 +360,59 @@ describe("the record a category page puts forward is one the ranker lists", () =
       const leader = leaderNamedIn(introOf(await page(`/category/${c.slug}`)));
       assert.notStrictEqual(leader, null, `/category/${c.slug} drops the claim rather than moving it`);
       assert.notStrictEqual(leader, c.records[0].vendor, `/category/${c.slug} still names ${leader}`);
+    }
+  });
+});
+
+const GATE_CODES = ["eligibility_restricted", "not_a_free_offer", "offer_expired", "offer_retired", "verification_lapsed"];
+
+function population(total: number, codes: string[]): { total: number; codes: string[]; gates: Gate[] } {
+  const gates: Gate[] = codes.map((code) => ({ code, reason: "" }));
+  while (gates.length < total) gates.push(null as unknown as Gate);
+  return { total, codes, gates };
+}
+
+const FORMS = [
+  { name: "no record gated", ...population(12, []) },
+  { name: "one record gated", ...population(12, ["not_a_free_offer"]) },
+  { name: "some gated, one code", ...population(12, Array(4).fill("eligibility_restricted")) },
+  { name: "some gated, four codes", ...population(12, ["eligibility_restricted", "eligibility_restricted", "not_a_free_offer", "offer_expired", "offer_retired"]) },
+  { name: "all gated by eligibility", ...population(12, Array(12).fill("eligibility_restricted")) },
+  { name: "all gated, eligibility and one more", ...population(12, [...Array(11).fill("eligibility_restricted"), "offer_retired"]) },
+  { name: "all gated, no eligibility", ...population(3, ["not_a_free_offer", "offer_expired", "offer_retired"]) },
+  { name: "the only record gated", ...population(1, ["offer_retired"]) },
+  { name: "every code at once", ...population(9, [...GATE_CODES, ...GATE_CODES.slice(0, 4)]) },
+];
+
+describe("the sentence forms hold whether or not a category exercises them today", () => {
+  it("covers every form the composer can reach", () => {
+    const composed = FORMS.map((f) => gatedShareLede(f.total, f.gates));
+    for (const shape of ["none of them generally available", "None of them are on our ranked list", "One of them is not on our ranked list", "of them are not on our ranked list"]) {
+      assert.ok(composed.some((lede) => lede.includes(shape)), `no population above composes "${shape}"`);
+    }
+    for (const code of GATE_CODES) {
+      assert.ok(FORMS.some((f) => f.codes.includes(code)), `no population above holds a ${code} record`);
+    }
+  });
+
+  it("composes the sentence this test asserts on the page", () => {
+    for (const form of FORMS) {
+      assert.strictEqual(
+        gatedShareLede(form.total, form.gates),
+        expectedLede(form.total, form.codes),
+        `${form.name} (${form.codes.length} of ${form.total})`,
+      );
+    }
+  });
+
+  it("reads its own count back out of every one of them", () => {
+    for (const form of FORMS) {
+      const lede = gatedShareLede(form.total, form.gates);
+      assert.strictEqual(
+        disclosedCountIn(lede, form.total),
+        form.codes.length === 0 ? null : form.codes.length,
+        `${form.name} composes ${JSON.stringify(lede)}`,
+      );
     }
   });
 });

--- a/test/eligibility-disclosure.test.ts
+++ b/test/eligibility-disclosure.test.ts
@@ -250,6 +250,12 @@ describe("a category page does not count a gated offer as a plain free tier", ()
           !lede.startsWith(`${total} verified free tiers and developer deals.`),
           `${where} closes the count claim before qualifying it: ${lede}`,
         );
+      } else if (gated === total && total > 1) {
+        assert.ok(lede.includes("None of them are on our ranked list"), `${where} lede is ${lede}`);
+        assert.ok(
+          !lede.includes("none of them generally available"),
+          `${where} says each record requires an application, on ${restricted} restricted of ${gated} gated: ${lede}`,
+        );
       } else if (gated === 1) {
         assert.ok(lede.includes("One of them is not on our ranked list"), `${where} lede is ${lede}`);
       } else {


### PR DESCRIPTION
Three of the four failures on https://github.com/robhunter/agentdeals/pull/1252 are one defect: the tests that read a category lede have no branch for a category that is entirely gated by more than one gate code. The renderer has had one since #1241 Part 2. No category has held that shape until now, so the branch has never been reached.

`src/eligibility.ts` composes `93 verified free tiers and developer deals. None of them are on our ranked list — 91 require an application or qualification, 2 have ended.` for Startup Perks once two of its records retire. Against that lede:

| | reads | should |
|---|---|---|
| `category-gate-lede.test.ts:145` | `None of them are **not** on our ranked list` | `None of them are on our ranked list` |
| `category-gate-lede.test.ts:231` | every entirely gated page states `none of them generally available` | only where eligibility gates every record |
| `eligibility-disclosure.test.ts:256` | every page not entirely restricted names `93 of them` | the all-gated form names no number |

The first has never matched any output the composer can produce. It fell through to the numeric pattern, which does not match either, and returned `0` — so the page's own disclosure scored as no disclosure at all, and `/category/startup-perks` failed for naming `0` of `93`.

## What changed

Nothing in `src/`. `git diff --stat main` is three files, none of them a source file, so no page moves.

`disclosedCountIn` reads the form the page publishes, and returns `null` rather than `0` where it recognises nothing — a lede stating its gated set in a form the test cannot read is now a different failure from a lede stating no gated set. Both are asserted: a category with no gated record must parse as `null`, which is a stronger check than the `0 >= 0` it replaced.

The two branch models gain the missing arm. The entirely-gated-by-eligibility population keeps the wording it publishes today, and an entirely gated category with a second gate code is asserted to state the clause list and **not** to claim every record requires an application.

## The form is covered whether or not a category holds it

Adding a branch for a shape the corpus does not hold leaves that branch untested until the data arrives — which is how this got here. So the forms are now driven from the composer over nine synthetic populations, covering all five gate codes and every sentence form:

- `gatedShareLede` composes what this test asserts on the page, for each of the nine.
- `disclosedCountIn` reads each composed lede back to the count that produced it.

That is the whole loop: prose pinned to the composer, parser pinned to the prose, neither depending on `data/index.json` holding a category of the right shape.

## Verification

`scripts/mutate-1190-lede-forms.sh`, 8 mutations, 8 killed, 0 survived, none by a compile error:

```
KILLED (8)  the all-gated sentence denies the ranked list twice
KILLED (6)  eligibility wording covers any entirely gated set, whatever gated it
KILLED (6)  the all-gated form is dropped and the count form takes it
KILLED (12) the single-record form is dropped and the count form takes it
KILLED (4)  the retired clause keeps its singular verb in the plural
KILLED (9)  the clause list states the first code and stops
KILLED (20) the lede states the count and no gate sentence at all
KILLED (4)  the count this test reads back is the one the branch never matched
```

The last restores the line this PR corrects and the new round-trip fails, so the parser is under test rather than merely used. The first is the same string on the composer's side.

Merged locally with `pm/retire-dead-startup-programs` and run against its data: 3,072 tests, 1 failure — the stability badge on `/vendor/feedbear`, which is https://github.com/robhunter/agentdeals/issues/1241 and not this. Before this change the same merge fails 4.

Refs #1190
