### PR TITLE
State no rating beside the name of a record the ranker gates

### DIFF
--- a/scripts/mutate-1241-vendor-badge.sh
+++ b/scripts/mutate-1241-vendor-badge.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+set -uo pipefail
+
+REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO"
+
+TESTS=(
+  test/vendor-verdict.test.ts
+  test/retired-vendor-page.test.ts
+  test/link-liveness-pages.test.ts
+)
+
+SOURCES=(src/vendor-verdict.ts src/serve.ts)
+
+backup() { for f in "${SOURCES[@]}"; do cp "$f" "/tmp/$(basename "$f").borig"; done; }
+restore() { for f in "${SOURCES[@]}"; do cp "/tmp/$(basename "$f").borig" "$f"; done; }
+
+backup
+trap 'restore; npm run build >/dev/null 2>&1' EXIT
+
+killed=0
+survived=0
+
+run_mutation() {
+  local name="$1"; shift
+  restore
+  if ! "$@"; then
+    echo "NOT APPLIED                $name"
+    return
+  fi
+  if ! npm run build >/dev/null 2>&1; then
+    echo "KILLED (does not compile)  $name"
+    killed=$((killed + 1))
+    return
+  fi
+  if TZ=UTC node --test --test-concurrency 1 "${TESTS[@]}" >/tmp/mutation-1241-out.txt 2>&1; then
+    echo "SURVIVED                   $name"
+    survived=$((survived + 1))
+  else
+    local failed
+    failed=$(grep -c '^ *✖' /tmp/mutation-1241-out.txt || true)
+    echo "KILLED ($failed assertions) $name"
+    killed=$((killed + 1))
+  fi
+}
+
+sub() {
+  python3 - "$1" "$2" "$3" <<'PY'
+import sys
+path, old, new = sys.argv[1], sys.argv[2], sys.argv[3]
+text = open(path, encoding="utf-8").read()
+if old not in text:
+    sys.exit("mutation target not found in " + path)
+open(path, "w", encoding="utf-8").write(text.replace(old, new, 1))
+PY
+}
+
+run_mutation "the badge rates a record the ranker gates, as it did before" \
+  sub src/vendor-verdict.ts '  if (input.gated) return { kind: "none" };
+  if (input.level === null)' \
+                            '  if (input.level === null)'
+
+run_mutation "the badge reads one gate code out of five" \
+  sub src/serve.ts 'gated: primaryGate !== null,
+    linkUnreachable' \
+                   'gated: primaryGate !== null && primaryGate.code === "eligibility_restricted",
+    linkUnreachable'
+
+run_mutation "the badge rates an ended offer instead of naming its state" \
+  sub src/vendor-verdict.ts 'if (input.offerEnded) return { kind: "ended" };' \
+                            'if (input.offerEnded && false) return { kind: "ended" };'
+
+run_mutation "the cause line explains a level the verdict does not state" \
+  sub src/vendor-verdict.ts '  const word = vendorVerdictWord(input);
+  return word !== null && word !== "stable" && input.cause !== null;' \
+                            '  return publishedVendorLevel(input.level, input.cause) !== "stable" && input.cause !== null;'
+
+run_mutation "the badge ignores an unreachable link" \
+  sub src/serve.ts 'linkUnreachable: Boolean(linkUnreachable),' \
+                   'linkUnreachable: false,'
+
+run_mutation "the badge rates a vendor we hold no level for" \
+  sub src/vendor-verdict.ts '  if (input.level === null) return { kind: "none" };' \
+                            ''
+
+run_mutation "the ended badge is the rating word" \
+  sub src/serve.ts 'border:1px solid ${retiredBadgeColor}40">${ENDED_BADGE_LABEL}</span>' \
+                   'border:1px solid ${retiredBadgeColor}40">${riskLevel}</span>'
+
+echo
+echo "killed: $killed  survived: $survived"

--- a/src/serve.ts
+++ b/src/serve.ts
@@ -20,7 +20,7 @@ import { offerEnded, offerRetired, recordedTierSentence, endedHeadline, endedHis
 import { levelWithheldReason, withheldLevelClause, withheldLevelSentence } from "./source-check.js";
 import { buildComparisonMap, comparisonSlug } from "./comparison-pairs.js";
 import { stabilityFaqAnswer, stabilityVerdictClause, type ComparisonSide, type StabilityRating } from "./comparison-verdict.js";
-import { publishedVendorLevel, vendorVerdictSentence, narrowingSentence, changeKindNoun, type VendorVerdictInput } from "./vendor-verdict.js";
+import { publishedVendorLevel, vendorVerdictSentence, vendorBadge, statesRiskCause, narrowingSentence, changeKindNoun, type VendorVerdictInput } from "./vendor-verdict.js";
 import { vendorHistorySentence } from "./vendor-history.js";
 import { growthLimitPhrases } from "./growth-limits.js";
 import { registerAgent, authenticateRequest, validateVestauthUrl, hashApiKey, updateAgentX402Address, getAgentById } from "./agents.js";
@@ -3703,28 +3703,47 @@ function buildVendorPage(slug: string): string | null {
   const riskCause = enriched.risk_cause;
   const riskLevel = publishedVendorLevel(enriched.risk_level ?? null, riskCause);
   const riskColor = riskColors[riskLevel] ?? "#8b949e";
-  const riskCauseLine = riskLevel !== "stable" && riskCause
-    ? `  <p class="risk-cause-line" style="margin:.4rem 0 .6rem;font-size:.9rem;color:var(--text-muted)"><strong style="color:${riskColor}">Why ${riskLevel}:</strong> <span class="risk-cause-date" style="font-family:var(--mono)">${escHtmlServer(changeDateLabel(riskCause))}</span> &mdash; ${escHtmlServer(riskCause.summary)} <a href="#changes" style="white-space:nowrap">Full history &darr;</a></p>`
-    : "";
 
   const servedOn = new Date().toISOString().slice(0, 10);
   const discontinuedOn = discontinuedOnOrBefore(vendorChanges, servedOn);
 
   const linkUnreachable = enriched.link_unreachable;
   const offerHasEnded = offerEnded(primary);
+  const primaryGate = gateFor(primary, servedOn);
+  const unconfirmableSince = linkUnreachable
+    ? (linkUnreachable.last_reachable ? ` since ${linkUnreachable.last_reachable}` : "")
+    : "";
+  const levelWithheld = levelWithheldReason(primary, linkUnreachable);
+  const withheldClause = levelWithheld ? withheldLevelClause(levelWithheld, unconfirmableSince) : "";
+  const verdictInput: VendorVerdictInput = {
+    vendor: vendorName,
+    level: enriched.risk_level ?? null,
+    cause: riskCause,
+    changes: vendorChanges,
+    levelWithheld,
+    unconfirmableSince,
+    offerEnded: offerHasEnded,
+    gated: primaryGate !== null,
+    linkUnreachable: Boolean(linkUnreachable),
+  };
+
+  const riskCauseLine = statesRiskCause(verdictInput) && riskCause
+    ? `  <p class="risk-cause-line" style="margin:.4rem 0 .6rem;font-size:.9rem;color:var(--text-muted)"><strong style="color:${riskColor}">Why ${riskLevel}:</strong> <span class="risk-cause-date" style="font-family:var(--mono)">${escHtmlServer(changeDateLabel(riskCause))}</span> &mdash; ${escHtmlServer(riskCause.summary)} <a href="#changes" style="white-space:nowrap">Full history &darr;</a></p>`
+    : "";
+
   const retiredBadgeColor = "#8b949e";
-  const h1RiskBadge = offerHasEnded
+  const badge = vendorBadge(verdictInput);
+  const h1RiskBadge = badge.kind === "ended"
     ? ` <span class="risk-badge" style="background:${retiredBadgeColor}20;color:${retiredBadgeColor};border:1px solid ${retiredBadgeColor}40">${ENDED_BADGE_LABEL}</span>`
-    : enriched.risk_level === null || (linkUnreachable && riskLevel === "stable")
-    ? ""
-    : ` <span class="risk-badge" style="background:${riskColor}20;color:${riskColor};border:1px solid ${riskColor}40">${riskLevel}</span>`;
+    : badge.kind === "rating"
+    ? ` <span class="risk-badge" style="background:${riskColor}20;color:${riskColor};border:1px solid ${riskColor}40">${badge.word}</span>`
+    : "";
   const linkUnreachableLine = linkUnreachable
     ? `  <p class="link-unreachable-line" style="margin:.4rem 0 .6rem;font-size:.9rem;color:var(--text-muted)"><strong style="color:#f85149">Link unreachable:</strong> ${escHtmlServer(primary.url)} did not resolve on our check of <span class="link-checked-date" style="font-family:var(--mono)">${escHtmlServer(linkUnreachable.checked)}</span>. ${linkUnreachable.last_reachable ? `Last reachable <span class="link-last-reachable" style="font-family:var(--mono)">${escHtmlServer(linkUnreachable.last_reachable)}</span>.` : "We have no date on which it was reachable."}</p>`
     : "";
 
   const primaryEligibilityGate = eligibilityGate(primary);
   const primaryEligibilityConditions = publishableEligibilityConditions(primary);
-  const primaryGate = gateFor(primary, servedOn);
   const primaryGateBeyondEligibility = primaryGate && primaryGate.code !== "eligibility_restricted" ? primaryGate : null;
   const productionGate = primaryGate && GATES_LEAVING_NO_FREE_TIER.includes(primaryGate.code) ? primaryGate : null;
   const linedGate = primaryGate && primaryGate.code !== "offer_retired" ? primaryGate : null;
@@ -3804,21 +3823,6 @@ function buildVendorPage(slug: string): string | null {
     : `${vendorName} pricing details${alternatives.length > 0 ? ` and ${alternatives.length} free alternatives in ${primary.category}` : ""}.${verifiedSentence}`);
 
   const keyLimit = primary.description.slice(0, 120).replace(/\.\s.*$/, "");
-  const unconfirmableSince = linkUnreachable
-    ? (linkUnreachable.last_reachable ? ` since ${linkUnreachable.last_reachable}` : "")
-    : "";
-  const levelWithheld = levelWithheldReason(primary, linkUnreachable);
-  const withheldClause = levelWithheld ? withheldLevelClause(levelWithheld, unconfirmableSince) : "";
-  const verdictInput: VendorVerdictInput = {
-    vendor: vendorName,
-    level: enriched.risk_level ?? null,
-    cause: riskCause,
-    changes: vendorChanges,
-    levelWithheld,
-    unconfirmableSince,
-    offerEnded: offerHasEnded,
-    gated: primaryGate !== null,
-  };
   const verdictLine2 = vendorVerdictSentence(verdictInput);
   const verdictLine3 = discontinuedOn
     ? `${vendorName} was discontinued on ${discontinuedOn}, so it is not a current option${alternatives.length > 0 ? ` — the ${alternatives.length} alternatives below are replacements` : ""}.`

--- a/src/vendor-verdict.ts
+++ b/src/vendor-verdict.ts
@@ -37,7 +37,13 @@ export interface VendorVerdictInput {
   unconfirmableSince: string;
   offerEnded?: boolean;
   gated?: boolean;
+  linkUnreachable?: boolean;
 }
+
+export type VendorBadge =
+  | { kind: "ended" }
+  | { kind: "rating"; word: PublishedRiskLevel }
+  | { kind: "none" };
 
 export function publishedVendorLevel(
   level: PublishedRiskLevel | null,
@@ -67,6 +73,20 @@ export function vendorVerdictWord(input: VendorVerdictInput): PublishedRiskLevel
   if (input.offerEnded) return null;
   if (withholdingDecides(input)) return null;
   return publishedVendorLevel(input.level, input.cause);
+}
+
+export function vendorBadge(input: VendorVerdictInput): VendorBadge {
+  if (input.offerEnded) return { kind: "ended" };
+  if (input.gated) return { kind: "none" };
+  if (input.level === null) return { kind: "none" };
+  const level = publishedVendorLevel(input.level, input.cause);
+  if (input.linkUnreachable && level === "stable") return { kind: "none" };
+  return { kind: "rating", word: level };
+}
+
+export function statesRiskCause(input: VendorVerdictInput): boolean {
+  const word = vendorVerdictWord(input);
+  return word !== null && word !== "stable" && input.cause !== null;
 }
 
 export function narrowingSentence(changes: VendorVerdictInput["changes"]): string {

--- a/test/risk-badge.test.ts
+++ b/test/risk-badge.test.ts
@@ -143,12 +143,30 @@ describe("#1038 — the level is checkable", () => {
 
   it("the vendor page publishes the dated cause beside the badge in the <h1>", async () => {
     const { enrichOffers, loadOffers } = await import("../dist/data.js");
+    const { gateFor, utcDate } = await import("../dist/ranking.js");
+    const seen = new Set<string>();
     const warned = enrichOffers(loadOffers())
-      .filter((o: { risk_level: string | null }) => o.risk_level && o.risk_level !== "stable")
-      .slice(0, 6);
-    assert.ok(warned.length > 0, "expected at least one warned vendor to test");
+      .filter((o: { vendor: string }) => {
+        if (seen.has(o.vendor)) return false;
+        seen.add(o.vendor);
+        return true;
+      })
+      .filter((o: { risk_level: string | null }) => o.risk_level && o.risk_level !== "stable");
+    const listed = warned.filter((o: object) => gateFor(o, utcDate()) === null).slice(0, 6);
+    const gated = warned.filter((o: object) => gateFor(o, utcDate()) !== null).slice(0, 6);
+    assert.ok(listed.length > 0, "expected at least one warned vendor the ranker lists");
+    assert.ok(gated.length > 0, "no warned vendor is gated, so the withheld badge is unchecked here");
 
-    for (const offer of warned) {
+    for (const offer of gated) {
+      const { text } = await get(`/vendor/${toSlug(offer.vendor)}`);
+      const h1 = text.match(/<h1>[\s\S]*?<\/h1>/)?.[0] ?? "";
+      assert.ok(
+        !new RegExp(offer.risk_level!).test(h1),
+        `${offer.vendor}: the <h1> of a ${gateFor(offer, utcDate())!.code} record reads ${offer.risk_level}`,
+      );
+    }
+
+    for (const offer of listed) {
       const { text } = await get(`/vendor/${toSlug(offer.vendor)}`);
       const h1 = text.match(/<h1>[\s\S]*?<\/h1>/)?.[0] ?? "";
       assert.ok(new RegExp(offer.risk_level!).test(h1), `${offer.vendor}: expected ${offer.risk_level} in the <h1>`);

--- a/test/vendor-verdict.test.ts
+++ b/test/vendor-verdict.test.ts
@@ -7,6 +7,8 @@ import {
   CHANGE_KIND_NOUN,
   narrowingSentence,
   publishedVendorLevel,
+  statesRiskCause,
+  vendorBadge,
   vendorVerdictSentence,
   vendorVerdictWord,
   type VendorVerdictInput,
@@ -14,7 +16,7 @@ import {
 import { CHANGE_DIRECTION, enrichOffers, loadDealChanges, loadOffers, vendorRiskAssessment, classifyStability } from "../dist/data.js";
 import { vendorSlugMap } from "../dist/vendor-slug.js";
 import { levelWithheldReason } from "../dist/source-check.js";
-import { offerEnded, ENDED_BADGE_LABEL } from "../dist/retirement.js";
+import { offerEnded, endedVerdictSentence, ENDED_BADGE_LABEL } from "../dist/retirement.js";
 import { gateFor, utcDate } from "../dist/ranking.js";
 import type { DealChange, RiskCause } from "../dist/types.js";
 
@@ -98,6 +100,45 @@ describe("vendor verdict — one rating word, and it carries its cause", () => {
       vendorVerdictSentence(withheld),
       "Its pricing page has not resolved for us since 2026-05-02, so we cannot confirm these terms today.",
     );
+  });
+});
+
+describe("the badge beside a vendor's name says what the verdict below it says", () => {
+  const cause = causeOf(change({ change_type: "pricing_restructured", date: "2026-08-28" }));
+
+  it("rates a record the ranker lists", () => {
+    assert.deepStrictEqual(vendorBadge(input({ level: "stable" })), { kind: "rating", word: "stable" });
+    assert.deepStrictEqual(vendorBadge(input({ level: "caution", cause })), { kind: "rating", word: "caution" });
+  });
+
+  it("states no rating on a record the ranker gates", () => {
+    for (const level of ["stable", "caution", "risky"] as const) {
+      const gated = input({ level, cause, gated: true, changes: [change()] });
+      assert.deepStrictEqual(vendorBadge(gated), { kind: "none" }, `a gated record rated ${level}`);
+    }
+  });
+
+  it("states the offer has ended rather than rating it, whatever its history says", () => {
+    const ended = input({ level: "caution", cause, gated: true, offerEnded: true, changes: [change(), change()] });
+    assert.deepStrictEqual(vendorBadge(ended), { kind: "ended" });
+    assert.strictEqual(vendorVerdictSentence(ended), endedVerdictSentence());
+    assert.strictEqual(statesRiskCause(ended), false);
+  });
+
+  it("withholds the badge on the two grounds it withheld it on before", () => {
+    assert.deepStrictEqual(vendorBadge(input({ level: null })), { kind: "none" });
+    assert.deepStrictEqual(vendorBadge(input({ level: "stable", linkUnreachable: true })), { kind: "none" });
+    assert.deepStrictEqual(
+      vendorBadge(input({ level: "risky", cause, linkUnreachable: true })),
+      { kind: "rating", word: "risky" },
+    );
+  });
+
+  it("explains a level only where the verdict states one", () => {
+    assert.strictEqual(statesRiskCause(input({ level: "caution", cause })), true);
+    assert.strictEqual(statesRiskCause(input({ level: "caution", cause, gated: true })), true);
+    assert.strictEqual(statesRiskCause(input({ level: "stable" })), false);
+    assert.strictEqual(statesRiskCause(input({ level: "caution", cause, offerEnded: true })), false);
   });
 });
 
@@ -236,7 +277,7 @@ function vendorRows(): VendorRow[] {
       ended,
       badge: ended ? ENDED_BADGE_LABEL : expected,
       withheld,
-      badgeRendered: ended || !(enriched.risk_level === null || (enriched.link_unreachable && expected === "stable")),
+      badgeRendered: ended || !(gate || enriched.risk_level === null || (enriched.link_unreachable && expected === "stable")),
       sentence: vendorVerdictSentence({
         vendor,
         level: enriched.risk_level ?? null,
@@ -264,14 +305,25 @@ describe("vendor verdict — corpus invariant, computed offline", () => {
         wrong.push(`${row.slug}: verdict reaches for a second scale — ${row.sentence}`);
         continue;
       }
-      if (!row.badgeRendered) {
-        if (/\bWe rate it\b/.test(row.sentence)) wrong.push(`${row.slug}: rates a vendor whose badge is withheld`);
+      if (row.ended) {
+        if (row.sentence !== endedVerdictSentence()) {
+          wrong.push(`${row.slug}: badge says ${row.badge}, verdict of an ended offer says ${row.sentence}`);
+        }
+        continue;
+      }
+      if (row.withheld && row.expected === "stable") {
+        if (/\bWe rate it\b/.test(row.sentence)) wrong.push(`${row.slug}: rates a vendor whose level we withhold`);
         continue;
       }
       if (row.gate) {
+        if (row.badgeRendered) wrong.push(`${row.slug}: rates a gated record ${row.badge} beside its name`);
         if (!row.sentence.includes(`${row.vendor} ${GATED_LEVEL_PHRASE[row.expected]}`)) {
-          wrong.push(`${row.slug}: badge says ${row.expected}, gated verdict says ${row.sentence}`);
+          wrong.push(`${row.slug}: gated verdict says ${row.sentence}, over a history we read as ${row.expected}`);
         }
+        continue;
+      }
+      if (!row.badgeRendered) {
+        if (/\bWe rate it\b/.test(row.sentence)) wrong.push(`${row.slug}: rates a vendor whose badge is withheld`);
         continue;
       }
       const named = row.sentence.match(/We rate it (stable|caution|risky)\b/)?.[1]
@@ -377,6 +429,7 @@ describe("vendor verdict — as rendered", () => {
   it("renders on every vendor route the one rating its own records support", async () => {
     const rows = vendorRows();
     const wrong: string[] = [];
+    let rating = 0;
     let index = 0;
     const worker = async () => {
       while (index < rows.length) {
@@ -386,6 +439,13 @@ describe("vendor verdict — as rendered", () => {
         const verdict = verdictParagraph(html);
         const cell = comparisonCell(html);
 
+        if (badge !== null && badge !== ENDED_BADGE_LABEL) rating++;
+        if (row.gate && !row.ended && badge !== null) {
+          wrong.push(`${row.slug}: the h1 of a ${row.gate.code} record rates it ${badge}`);
+        }
+        if (row.gate && row.ended && badge !== ENDED_BADGE_LABEL) {
+          wrong.push(`${row.slug}: the h1 of an ended offer reads ${badge ?? "nothing"}`);
+        }
         if (row.badgeRendered && badge !== row.badge) {
           wrong.push(`${row.slug}: h1 badge is ${badge ?? "absent"}, expected ${row.badge}`);
         }
@@ -411,6 +471,8 @@ describe("vendor verdict — as rendered", () => {
     };
     await Promise.all(Array.from({ length: 12 }, worker));
     assert.deepStrictEqual(wrong.slice(0, 20), [], `vendor routes rendering more than one judgement:\n${wrong.slice(0, 20).join("\n")}`);
+    assert.ok(rating > 700, `only ${rating} vendor pages rate the vendor beside its name`);
+    assert.ok(rows.some(r => r.gate && !r.ended), "no gated record reaches a vendor page, so the gate criterion has no subject");
   });
 
   it("answers both of its own stability questions with the same word", async () => {
@@ -501,7 +563,11 @@ describe("vendor verdict — as rendered", () => {
       const row = vendorRows().find(r => r.slug === slug);
       assert.ok(row, `/vendor/${slug} is a rendered route`);
       const html = await get(`/vendor/${slug}`);
-      assert.strictEqual(badgeWord(html), row.expected, `/vendor/${slug} badge`);
+      assert.strictEqual(
+        badgeWord(html),
+        row.gate ? null : row.expected,
+        `/vendor/${slug} badge, over a ${row.gate?.code ?? "listed"} record`,
+      );
       const cell = comparisonCell(html);
       if (cell.rendered) {
         cellsChecked += 1;
@@ -517,6 +583,10 @@ describe("vendor verdict — as rendered", () => {
       );
     }
     assert.ok(cellsChecked > 0, "no route under test rendered a comparison cell, so the badge agreement is unchecked");
+    assert.ok(
+      vendorRows().some(r => ["digitalocean", "google-gemini-api", "postman", "xata"].includes(r.slug) && !r.gate),
+      "every route under test is now gated, so no rendered badge is checked against its verdict here",
+    );
   });
 
   it("stops offering a product whose own shutdown date has passed", async () => {


### PR DESCRIPTION
The sixth surface on this issue, and it is larger than the page that found it. **43 vendor pages rendered a rating word beside the vendor's name for a record the ranker gates** — `/vendor/stripe` carried a green `stable` badge over a `Pay-as-you-go` record. All 43 now render none.

```
                        before   after
stable                      30       0
caution                     11       0
risky                        2       0
                        ------   -----
eligibility_restricted      31       0
not_a_free_offer            11       0
offer_expired                1       0
```

The four `offer_retired` pages already read `retired`: the badge did consult `offerEnded`. What it never consulted was `gateFor`, which is the same one-input-out-of-five shape as the five surfaces before it.

## One derivation, three consumers

`vendorBadge` and `statesRiskCause` join `vendorVerdictWord` in `src/vendor-verdict.ts`, and the page composes the badge, the cause line and the verdict from one `VendorVerdictInput` built once. The badge cannot disagree with the verdict by construction rather than by two conditions that happen to match.

The gate is the only new input. The two grounds the badge was already withheld on — no level, and an unreachable link over a stable level — are unchanged, and an ended offer still names its state rather than a rating.

## What `/vendor/feedbear` actually published

Rendered from `pm/retire-dead-startup-programs` before this change:

```
<h1>  FeedBear — free tier retired  [retired]
      Why caution: discovered 2026-08-28 — The Startup plan is now $40/month …
      This offer has ended — we keep the page for the record and no longer rate it.
```

The badge reads `retired`, not `caution` — `vendor-verdict.test.ts:273` reports `row.expected`, the level the vendor's history scores, rather than the badge the page renders. The contradiction on that page is the **risk-cause line**: `Why caution:` immediately above a verdict that declines to rate. `Why <level>:` explains a level the page states, so it now renders only where the verdict states one. On the same branch after this change: no cause line, and 0 occurrences of `caution`, `stable` or `risky` anywhere on the page, against 1 before.

That line reaches 0 pages on `main` — every retired record in the index carries 0 change records, which is the same reason you gave for the badge branch having had no subject. It is covered by a unit test on the composer rather than by a record in the corpus, so it does not wait for the data.

## Acceptance criterion

`test/vendor-verdict.test.ts` asserts over every vendor route that a page whose record `gateFor` gates renders no rating word in its `<h1>`, and that an ended offer renders the ended label. Positive control in the same experiment: more than 700 vendor pages must still rate the vendor beside its name, and the gated population must be non-empty.

`test/risk-badge.test.ts`'s #1038 criterion — a page that publishes a warning publishes its dated cause — keeps every assertion it had, on the warned records the ranker lists. Its gated counterparts gained the opposite assertion rather than being dropped from the population.

## Verification

2,577 paths swept against `main`: **2,534 byte-identical, 43 moved, 0 status changes**, every one a `/vendor/` page. The moved set was predicted from `gateFor` plus `main`'s own rendered badge before the diff: 43 predicted, 43 moved, 0 in one and not the other. Every changed line on every moved page is inside the `<h1>`, 0 outside:

```
< <h1>Stripe Pricing 2026 <span class="risk-badge" …>stable</span></h1>
> <h1>Stripe Pricing 2026</h1>
```

3,077 tests, 5 new, 0 red; `main` green at 3,072. Merged locally with `pm/retire-dead-startup-programs` and run against its data: 3,077 tests, 0 red. That branch reports four failures today — three went with #1254 and this is the fourth.

`scripts/mutate-1241-vendor-badge.sh`, 7 mutations, **6 killed, 1 survived**, none by a compile error:

```
KILLED (9)   the badge rates a record the ranker gates, as it did before
KILLED (6)   the badge reads one gate code out of five
KILLED (10)  the badge rates an ended offer instead of naming its state
KILLED (6)   the cause line explains a level the verdict does not state
KILLED (7)   the badge rates a vendor we hold no level for
KILLED (7)   the ended badge is the rating word
SURVIVED     the badge ignores an unreachable link
```

The survivor is evidence about the code. Passing `linkUnreachable: false` changes no page, because **20 records carry a `link_unreachable` block and all 20 already have `risk_level: null`** — so the earlier branch decides every one of them and the unreachable-link branch has no subject. I kept it rather than deleting it: it is the second of the two guards #1046 put on that badge, and it is unit-tested on the composer even though no record can reach it through the page.

## Left for you, with counts

**43 gated pages still name a level in prose** — 30 `X has a stable pricing history`, 11 `X warrants caution`, 2 `X is high risk`, in the verdict and in the production FAQ answer. The same 43, because the same level composes both. That is the #1238 form, where the subject moved from the tier to the vendor's pricing history, and each sentence carries that subject; the `<h1>` badge carried none, which is why it went. If you want the level off gated pages entirely, that is one more predicate and it retracts the #1238 wording.

**0 records are in the third class I checked for** — a page whose level we withhold while the badge still renders one. It is empty today.

Refs #1241