### PR TITLE
Read the gate before answering whether a retired offer suits production

### DIFF
--- a/src/eligibility.ts
+++ b/src/eligibility.ts
@@ -1,4 +1,4 @@
-import { eligibilityGateFor } from "./ranking.js";
+import { eligibilityGateFor, gateFor } from "./ranking.js";
 import type { Gate, GateCode } from "./ranking.js";
 import { gateClauseList, gateDisclosureSentence } from "./gate-disclosure.js";
 import type { Offer } from "./types.js";
@@ -7,6 +7,11 @@ export const CONDITION_RECORDING_AN_UNREAD_PROGRAM = "Startup program — check 
 
 export function eligibilityGate(offer: Pick<Offer, "eligibility">): Gate | null {
   return eligibilityGateFor(offer);
+}
+
+export function eligibilityGateAsPublished(offer: Offer, date: string): Gate | null {
+  const gate = gateFor(offer, date);
+  return gate && gate.code === "eligibility_restricted" ? gate : null;
 }
 
 export function gatedCodes(gates: (Gate | null)[]): GateCode[] {

--- a/src/serve.ts
+++ b/src/serve.ts
@@ -44,7 +44,7 @@ import { ASSISTANTS_API_SHUTDOWN } from "./assistants-shutdown.js";
 import { discontinuedOnOrBefore, PRODUCT_DEPRECATED } from "./product-deprecation.js";
 import { rankOffers, rankForListing, rotateListing, utcDate, gateFor, CRITERIA_PATH, DEMOTE_ONLY_POLICY, DISCLOSURE_RATIONALE, TIE_BREAK_ALGORITHM, GATE_TABLE, DEMERIT_TABLE, NOT_FREE_TIER_RULES, TIME_LIMITED_TIER_RULES, type TieBreak, type Gate } from "./ranking.js";
 import type { RankedEntry, RankingResult } from "./ranking.js";
-import { eligibilityGate, gatedShareDescriptionClause, gatedShareLede, publishableEligibilityConditions } from "./eligibility.js";
+import { eligibilityGateAsPublished, gatedShareDescriptionClause, gatedShareLede, publishableEligibilityConditions } from "./eligibility.js";
 import { gateDisclosureFor } from "./gate-disclosure.js";
 import { verificationLedger, QUARANTINE_AFTER_FAILURES } from "./verification-state.js";
 import { partitionAlternatives, partitionSubstitutes, type SubstitutesPartition, productRoleSentence, MEMBERSHIP_GATE_RULES, MEMBERSHIP_GATE_ORDER, MEMBERSHIP_GATE_SYMMETRY, MEMBERSHIP_GATE_SCOPE, MEMBERSHIP_GATE_CORRECTIONS, SUBTYPE_TAXONOMIES, SUBTYPE_MEMBERSHIP_RULE, SUBTYPE_MEMBERSHIP_GROUP_SCOPE, CURATED_SUBTYPE_EXEMPTION, membershipGroupsFor, subtypeDefinition } from "./product-role.js";
@@ -1082,7 +1082,7 @@ function listingUnreachableNoticeHtml(offer: Offer): string {
 }
 
 function listingEligibilityNoticeHtml(offer: Offer): string {
-  const gate = eligibilityGate(offer);
+  const gate = eligibilityGateAsPublished(offer, utcDate());
   if (!gate) return "";
   const conditions = publishableEligibilityConditions(offer);
   const conditionsHtml = conditions.length > 0
@@ -3744,7 +3744,7 @@ function buildVendorPage(slug: string): string | null {
     ? `  <p class="link-unreachable-line" style="margin:.4rem 0 .6rem;font-size:.9rem;color:var(--text-muted)"><strong style="color:#f85149">Link unreachable:</strong> ${escHtmlServer(primary.url)} did not resolve on our check of <span class="link-checked-date" style="font-family:var(--mono)">${escHtmlServer(linkUnreachable.checked)}</span>. ${linkUnreachable.last_reachable ? `Last reachable <span class="link-last-reachable" style="font-family:var(--mono)">${escHtmlServer(linkUnreachable.last_reachable)}</span>.` : "We have no date on which it was reachable."}</p>`
     : "";
 
-  const primaryEligibilityGate = eligibilityGate(primary);
+  const primaryEligibilityGate = eligibilityGateAsPublished(primary, servedOn);
   const primaryEligibilityConditions = publishableEligibilityConditions(primary);
   const primaryGateBeyondEligibility = primaryGate && primaryGate.code !== "eligibility_restricted" ? primaryGate : null;
   const noFreeTierGate = primaryGate && GATES_LEAVING_NO_FREE_TIER.includes(primaryGate.code) ? primaryGate : null;

--- a/src/serve.ts
+++ b/src/serve.ts
@@ -3679,6 +3679,8 @@ const NO_FREE_TIER_FOR_PRODUCTION = "There is no free tier here to run in produc
 
 const GATES_LEAVING_NO_FREE_TIER: readonly string[] = ["not_a_free_offer", "offer_expired"];
 
+const GATES_LEAVING_NOTHING_TO_RUN_IN_PRODUCTION: readonly string[] = [...GATES_LEAVING_NO_FREE_TIER, "offer_retired"];
+
 function curatedAltsNote(vendorName: string): string {
   return `These alternatives were identified from ${escHtmlServer(vendorName)}&rsquo;s pricing changes as recommended replacements.`;
 }
@@ -3745,7 +3747,8 @@ function buildVendorPage(slug: string): string | null {
   const primaryEligibilityGate = eligibilityGate(primary);
   const primaryEligibilityConditions = publishableEligibilityConditions(primary);
   const primaryGateBeyondEligibility = primaryGate && primaryGate.code !== "eligibility_restricted" ? primaryGate : null;
-  const productionGate = primaryGate && GATES_LEAVING_NO_FREE_TIER.includes(primaryGate.code) ? primaryGate : null;
+  const noFreeTierGate = primaryGate && GATES_LEAVING_NO_FREE_TIER.includes(primaryGate.code) ? primaryGate : null;
+  const productionGate = primaryGate && GATES_LEAVING_NOTHING_TO_RUN_IN_PRODUCTION.includes(primaryGate.code) ? primaryGate : null;
   const linedGate = primaryGate && primaryGate.code !== "offer_retired" ? primaryGate : null;
   const gateLine = linedGate
     ? `\n  <p class="gate-line" style="margin:.4rem 0 .6rem;font-size:.9rem;color:var(--text-muted)"><strong style="color:#d29922;font-family:var(--mono)">${escHtmlServer(linedGate.code)}</strong> ${escHtmlServer(linedGate.reason)} <a href="${CRITERIA_PATH}#gates">How we use this</a>.</p>${
@@ -3805,7 +3808,7 @@ function buildVendorPage(slug: string): string | null {
 
   const currentYear = new Date().getFullYear();
   const retiredSentence = offerRetired(primary) ? recordedTierSentence(vendorName, primary.tier) : "";
-  const hasFree = !retiredSentence && !productionGate && primary.tier.toLowerCase() !== "none" && !primary.description.toLowerCase().includes("no free tier");
+  const hasFree = !retiredSentence && !noFreeTierGate && primary.tier.toLowerCase() !== "none" && !primary.description.toLowerCase().includes("no free tier");
   const freeTierHeadline = `${vendorName} Free Tier ${currentYear}`;
   const pricingHeadline = `${vendorName} Pricing ${currentYear}`;
   const headline = offerHasEnded ? endedHeadline(vendorName) : hasFree ? freeTierHeadline : pricingHeadline;
@@ -4188,7 +4191,7 @@ ${allCompareLinks.join("\n")}
     ? `${growthBullets[0].replace(/<[^>]*>/g, "")} When you outgrow the free tier, evaluate paid plans against alternatives — sometimes a competitor's free tier covers what you need.`
     : `When your usage exceeds the free tier limits, you'll need to upgrade or evaluate alternatives in the same category.`;
 
-  const gateStatesThereIsNoFreeTier = productionGate !== null;
+  const gateStatesThereIsNoFreeTier = noFreeTierGate !== null;
   const reliabilityAnswerWouldRateAGatedOffer = primaryGate !== null && !offerHasEnded && !levelWithheld;
 
   const vendorFaqItems = [

--- a/test/eligibility-disclosure.test.ts
+++ b/test/eligibility-disclosure.test.ts
@@ -5,7 +5,7 @@ import { readFileSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
-const { eligibilityGate, publishableEligibilityConditions, CONDITION_RECORDING_AN_UNREAD_PROGRAM } =
+const { eligibilityGate, eligibilityGateAsPublished, publishableEligibilityConditions, CONDITION_RECORDING_AN_UNREAD_PROGRAM } =
   await import("../dist/eligibility.js");
 const { gateFor, utcDate } = await import("../dist/ranking.js");
 
@@ -21,6 +21,10 @@ function slugOf(vendor: string): string {
 }
 
 const vendorsHoldingAGatedRecord = [...new Set(offers.filter(o => o.eligibility).map(o => o.vendor))];
+
+const TODAY = utcDate();
+
+const publishesARestriction = (offer: Offer) => gateFor(offer, TODAY)?.code === "eligibility_restricted";
 
 let port = 0;
 let proc: ChildProcess | null = null;
@@ -137,15 +141,30 @@ describe("a vendor page whose record is gated on eligibility says so", () => {
   });
 
   it("carries the qualification into the page description too", () => {
-    for (const p of rendered.filter(x => x.offer.eligibility)) {
+    const subjects = rendered.filter(x => publishesARestriction(x.offer));
+    assert.ok(subjects.length > 0, "no rendered page has the restriction as its effective gate");
+    for (const p of subjects) {
       const description = blockOfType(p.html, "WebPage")?.description ?? "";
-      assert.ok(description.startsWith(gateFor(p.offer, "")!.reason), `${p.slug} description is unqualified`);
+      assert.ok(description.startsWith(gateFor(p.offer, TODAY)!.reason), `${p.slug} description is unqualified`);
+    }
+  });
+
+  it("states the restriction in that description only where the restriction is the effective gate", () => {
+    const others = rendered.filter(x => !publishesARestriction(x.offer));
+    assert.ok(others.length > 0, "every rendered page has the restriction as its effective gate");
+    for (const p of others) {
+      const description = blockOfType(p.html, "WebPage")?.description ?? "";
+      const restriction = eligibilityGate(p.offer)?.reason;
+      assert.ok(
+        restriction === undefined || !description.includes(restriction),
+        `${p.slug} states a restriction its own gate outranks: ${description.slice(0, 90)}`,
+      );
     }
   });
 
   it("publishes every condition it holds except the one recording that no program was read", () => {
     const withRealConditions = rendered.filter(
-      p => p.offer.eligibility && publishableEligibilityConditions(p.offer).length > 0,
+      p => publishesARestriction(p.offer) && publishableEligibilityConditions(p.offer).length > 0,
     );
     assert.ok(withRealConditions.length > 0, "no gated record holds a publishable condition");
     for (const p of withRealConditions) {
@@ -156,7 +175,7 @@ describe("a vendor page whose record is gated on eligibility says so", () => {
       }
     }
     const placeholderOnly = rendered.filter(
-      p => p.offer.eligibility && publishableEligibilityConditions(p.offer).length === 0,
+      p => publishesARestriction(p.offer) && publishableEligibilityConditions(p.offer).length === 0,
     );
     assert.ok(
       placeholderOnly.length > 0,
@@ -173,7 +192,7 @@ describe("the category page a gated offer is sent to states the restriction", ()
   it("names it on the row for every gated offer in the category", async () => {
     const gatedByCategory = new Map<string, Offer[]>();
     for (const o of offers) {
-      if (!o.eligibility) continue;
+      if (!publishesARestriction(o)) continue;
       const list = gatedByCategory.get(o.category) ?? [];
       list.push(o);
       gatedByCategory.set(o.category, list);
@@ -183,7 +202,7 @@ describe("the category page a gated offer is sent to states the restriction", ()
       const html = await page(`/category/${slugOf(category)}`);
       for (const o of gated) {
         assert.ok(
-          html.includes(escapeHtml(gateFor(o, "")!.reason)),
+          html.includes(escapeHtml(gateFor(o, TODAY)!.reason)),
           `/category/${slugOf(category)} omits the restriction on ${o.vendor}`,
         );
       }
@@ -206,7 +225,7 @@ describe("a category page does not count a gated offer as a plain free tier", ()
     const inCategory = offers.filter(o => o.category === category);
     return {
       total: inCategory.length,
-      restricted: inCategory.filter(o => eligibilityGate(o)).length,
+      restricted: inCategory.filter(publishesARestriction).length,
       gated: inCategory.filter(o => gateFor(o, utcDate())).length,
     };
   };
@@ -345,6 +364,43 @@ describe("the disclosure reuses one composition", () => {
     assert.strictEqual(gateFor(expired, "2026-09-01")!.code, "offer_expired");
     assert.strictEqual(eligibilityGate(expired), null);
     assert.deepStrictEqual(publishableEligibilityConditions(expired), []);
+  });
+
+  it("publishes the restriction where nothing outranks it", () => {
+    const restricted: Offer = {
+      vendor: "Acme", category: "Databases", description: "A free tier.", tier: "Free",
+      url: "https://example.com/pricing", tags: [], verifiedDate: "2026-08-20",
+      eligibility: { type: "startup", conditions: ["Pre-Series B"], program: "Acme for Startups" },
+    };
+    assert.strictEqual(gateFor(restricted, "2026-09-02")!.code, "eligibility_restricted");
+    assert.deepStrictEqual(
+      eligibilityGateAsPublished(restricted, "2026-09-02"),
+      gateFor(restricted, "2026-09-02"),
+    );
+  });
+
+  it("withholds it from a record whose own tier records the offer as ended", () => {
+    const ended: Offer = {
+      vendor: "Acme", category: "Databases", description: "A free tier.", tier: "Retired",
+      url: "https://example.com/pricing", tags: [], verifiedDate: "2026-08-20",
+      eligibility: { type: "startup", conditions: ["Pre-Series B"], program: "Acme for Startups" },
+    };
+    assert.strictEqual(gateFor(ended, "2026-09-02")!.code, "offer_retired");
+    assert.ok(eligibilityGate(ended), "the record still carries an eligibility block");
+    assert.strictEqual(eligibilityGateAsPublished(ended, "2026-09-02"), null);
+  });
+
+  it("keeps it where the expiry date has passed, because the ranker still returns the restriction", () => {
+    const expired: Offer = {
+      vendor: "Acme", category: "Databases", description: "A free tier.", tier: "Free",
+      url: "https://example.com/pricing", tags: [], verifiedDate: "2026-08-20", expires_date: "2026-01-01",
+      eligibility: { type: "startup", conditions: ["Pre-Series B"], program: "Acme for Startups" },
+    };
+    assert.strictEqual(gateFor(expired, "2026-09-02")!.code, "eligibility_restricted");
+    assert.deepStrictEqual(
+      eligibilityGateAsPublished(expired, "2026-09-02"),
+      gateFor(expired, "2026-09-02"),
+    );
   });
 
   it("drops only the condition that records an unread program", () => {

--- a/test/gated-vendor-answers.test.ts
+++ b/test/gated-vendor-answers.test.ts
@@ -273,6 +273,30 @@ describe("the production answer reads the same gate", () => {
     }
   });
 
+  it("recommends no record whose own tier records the offer as ended", () => {
+    const subjects = gated().filter(p => offerEnded(p.primary));
+    assert.ok(subjects.length > 0, "no vendor page renders an offer its own tier records as ended");
+    for (const p of subjects) {
+      assert.strictEqual(
+        productionAnswer(p),
+        `${p.gate!.reason} ${NO_FREE_TIER_FOR_PRODUCTION}`,
+        `/vendor/${p.slug}`,
+      );
+    }
+  });
+
+  it("opens with whatever opens the free-tier answer on the same page", () => {
+    const subjects = gated().filter(p => freeAnswer(p).startsWith(p.gate!.reason));
+    assert.ok(
+      subjects.length > 100,
+      `only ${subjects.length} gated pages open the free-tier answer with the gate, so this has no subject`,
+    );
+    const contradicting = subjects
+      .filter(p => !productionAnswer(p).startsWith(p.gate!.reason))
+      .map(p => `${p.slug} (${p.gate!.code}): ${productionAnswer(p).slice(0, 60)}`);
+    assert.deepStrictEqual(contradicting, []);
+  });
+
   it("publishes that answer verbatim on the pages the issue names", () => {
     const stripe = rendered.find(p => p.slug === "stripe")!;
     assert.strictEqual(


### PR DESCRIPTION
Two surfaces on the vendor page still decided availability without asking `gateFor` for it, in the same shape as the six already fixed on this issue.

## 1. The production answer

`Is X's free tier good for production?` chose its opening from a list of two gate codes, `not_a_free_offer` and `offer_expired`. `offer_retired` was not on it, so the four retired pages fell through to a branch written for something else. Read off a build of `main`:

| page | before | after |
|---|---|---|
| `/vendor/oaysus` | `Oaysus does not offer a free tier for production use. Consider free alternatives in Cloud Hosting.` | `Oaysus's offer is recorded as Retired. There is no free tier here to run in production.` |
| `/vendor/github-models` | `The page we cite for GitHub Models states no terms we can read. We cannot confirm what this offer provides today…` | `GitHub Models's offer is recorded as Retired. There is no free tier here to run in production.` |
| `/vendor/supportivekoala`, `/vendor/qrme-sh` | the same fall-through | the retirement |

Neither old answer is false. Both give the wrong reason, and both contradict the three other answers on their own page, which have opened with the retirement since #1232. The `/vendor/oaysus` sentence is the branch for a vendor that never had a free tier, published over a record that had one until the domain was sold.

**Adding `offer_retired` to the existing list would have cost something, so I split the list instead.** That list had a second consumer: `gateStatesThereIsNoFreeTier`, the #1246 predicate deciding whether the page asks `What is X's free tier?` at all. Folding retired into it deletes that question from 4 live pages, and from 12 once #1252 lands — measured on #1252's data, 130 gated pages asking it drops to 125. So the two decisions now read two lists. `GATES_LEAVING_NO_FREE_TIER` is unchanged and still decides which questions get asked; `GATES_LEAVING_NOTHING_TO_RUN_IN_PRODUCTION` extends it with `offer_retired` and decides only the production answer. A retired page keeps the question, because answering what the offer used to be is the reason #1235 kept the page up at all.

## 2. The restriction a stronger gate outranks

`eligibilityGate` reads `offer.eligibility` and nothing else. Two surfaces composed from it directly — the vendor page's meta description and every category row — so a record carrying an eligibility block published its restriction even where `gateFor` returns a code that outranks it.

`gateFor` puts `offer_retired` ahead of `eligibility_restricted`. A retired startup program therefore states *"Restricted to startup applicants — not generally available"* on its own category row and in its own page description, while the FAQ on the same page says the offer is recorded as Retired. The restriction describes qualifying for something that no longer exists.

Both surfaces now read `eligibilityGateAsPublished`, which returns the eligibility gate only when it is the gate `gateFor` returns.

**This changes no page on `main`.** Census over three datasets, every record, no sample:

| dataset | records carrying an eligibility block | whose effective gate outranks it |
|---|---|---|
| `main` | 137 | **0** |
| #1252 | 130 | **0** |
| #1244 | 138 | **2** — The GoSquared Early Stage Plan, Ninja Outreach |

A branch for a shape the corpus does not hold is untested until the data arrives, which is what #1190 is about, so it is covered by synthetic records driven through the composer rather than by the corpus: an eligibility record with tier `Retired` returns `null`; an eligibility record whose expiry has passed still returns the restriction, because `gateFor` puts eligibility ahead of expiry; an ordinary eligibility record returns exactly what `gateFor` returns.

## What this does to the two open data PRs

The four affected test files run against each branch's `data/index.json` on top of this branch's `src/`:

| dataset | before | after |
|---|---|---|
| `main` | 103 pass, 0 fail | 109 pass, 0 fail |
| #1252 `pm/retire-dead-startup-programs` | 103 pass, 0 fail | 109 pass, 0 fail |
| #1244 `pm/redirect-queue-2026-09-01` | 102 pass, **7 fail** | 109 pass, **0 fail** |

Of the seven on #1244, two were the `src` surfaces above and four were test subjects derived from `o.eligibility` rather than from `gateFor`; those four are narrowed here, in the same file, on the same predicate the page uses. The seventh was the production answer.

## Verification

- 4 mutations on the two gate lists, 4 killed. Dropping `offer_retired` is killed by exactly the two new production assertions and nothing else, so nothing else was covering it. Adding all five codes is killed by four pre-existing assertions, which is what establishes `offer_retired` as the only correct addition.
- Full suite green on `main` data: 3,083 tests, 0 fail.
- Path sweep, branch build against a `main` build: **2,577 paths, 2,573 byte-identical, 4 moved, 0 status changes, 0 appearing or disappearing.** The 4 are exactly the `offer_retired` pages, and each differs by exactly two lines — the production answer, once in the `FAQPage` JSON-LD and once in the rendered `.faq-a`. Nothing else on any page.

Refs #1241
Refs #1190
