### PR TITLE
Read a vendor page to its end rather than to 12,000 characters

### DIFF
--- a/data/index.json
+++ b/data/index.json
@@ -922,7 +922,7 @@
       ],
       "verifiedDate": "2026-08-12",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names Databricks (Lakeflow Connect) but states no amount, tier or rate we can read"
       },
@@ -1174,7 +1174,7 @@
       ],
       "verifiedDate": "2026-08-11",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names PocketBase but states no amount, tier or rate we can read"
       },
@@ -1419,9 +1419,9 @@
         "notes": "Partner Network for resellers and system integrators. No individual referral program."
       },
       "source_check": {
-        "checked": "2026-08-28",
-        "outcome": "states_no_terms",
-        "detail": "the page names Datadog but states no amount, tier or rate we can read"
+        "checked": "2026-09-02",
+        "outcome": "ok",
+        "detail": "text"
       },
       "product_subtypes": {
         "taxonomy": "Monitoring",
@@ -2432,9 +2432,9 @@
       ],
       "verifiedDate": "2026-08-23",
       "source_check": {
-        "checked": "2026-08-28",
-        "outcome": "states_no_terms",
-        "detail": "the page names SonarQube Cloud but states no amount, tier or rate we can read"
+        "checked": "2026-09-02",
+        "outcome": "ok",
+        "detail": "text"
       }
     },
     {
@@ -2463,7 +2463,7 @@
         "notes": "Hetzner credits for both parties."
       },
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names Hetzner but states no amount, tier or rate we can read"
       }
@@ -2520,7 +2520,7 @@
       ],
       "verifiedDate": "2026-07-23",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names Hurricane Electric DNS but states no amount, tier or rate we can read"
       }
@@ -2540,7 +2540,7 @@
       ],
       "verifiedDate": "2026-07-23",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names deSEC but states no amount, tier or rate we can read"
       }
@@ -2568,9 +2568,9 @@
         "notes": "Channel partner program for agencies and consultants. No self-service referral program."
       },
       "source_check": {
-        "checked": "2026-08-28",
-        "outcome": "states_no_terms",
-        "detail": "the page names Fastly but states no amount, tier or rate we can read"
+        "checked": "2026-09-02",
+        "outcome": "ok",
+        "detail": "text"
       }
     },
     {
@@ -3374,7 +3374,7 @@
         "notes": "No public affiliate program. Content Creators Program provides product access for promotion. Reseller partnerships available."
       },
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names JetBrains but states no amount, tier or rate we can read"
       }
@@ -3404,7 +3404,7 @@
         "program": "1Password for Open Source Projects"
       },
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names 1Password but states no amount, tier or rate we can read"
       }
@@ -3441,7 +3441,7 @@
         "notes": "No affiliate/referral program for Sentry.io error monitoring. Sponsored account program available for open source."
       },
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names Sentry but states no amount, tier or rate we can read"
       }
@@ -3678,7 +3678,7 @@
       ],
       "verifiedDate": "2026-07-28",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names Typesense Cloud but states no amount, tier or rate we can read"
       }
@@ -3697,7 +3697,7 @@
       ],
       "verifiedDate": "2026-08-24",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names Statically but states no amount, tier or rate we can read"
       }
@@ -3737,7 +3737,7 @@
       ],
       "verifiedDate": "2026-07-24",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names Baselime but states no amount, tier or rate we can read"
       }
@@ -3991,7 +3991,7 @@
         "notes": "No individual referral program."
       },
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names GitHub Container Registry but states no amount, tier or rate we can read"
       }
@@ -4231,7 +4231,7 @@
         "notes": "No individual referral program."
       },
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names GitHub Pages but states no amount, tier or rate we can read"
       },
@@ -4417,7 +4417,7 @@
         "reviewed": "2026-08-25"
       },
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names MinIO but states no amount, tier or rate we can read"
       }
@@ -4599,7 +4599,7 @@
       ],
       "verifiedDate": "2026-08-19",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names Orama but states no amount, tier or rate we can read"
       }
@@ -4619,7 +4619,7 @@
       ],
       "verifiedDate": "2026-07-27",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names Quay.io but states no amount, tier or rate we can read"
       }
@@ -4639,7 +4639,7 @@
       ],
       "verifiedDate": "2026-07-23",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names BrowserStack Percy but states no amount, tier or rate we can read"
       }
@@ -5026,7 +5026,7 @@
       ],
       "verifiedDate": "2026-04-23",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names Canva but states no amount, tier or rate we can read"
       }
@@ -5150,9 +5150,9 @@
       ],
       "verifiedDate": "2026-08-15",
       "source_check": {
-        "checked": "2026-08-28",
-        "outcome": "states_no_terms",
-        "detail": "the page names Google Maps Platform but states no amount, tier or rate we can read"
+        "checked": "2026-09-02",
+        "outcome": "ok",
+        "detail": "text"
       }
     },
     {
@@ -5690,7 +5690,7 @@
       ],
       "verifiedDate": "2026-07-27",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names Upptime but states no amount, tier or rate we can read"
       }
@@ -5785,7 +5785,7 @@
       ],
       "verifiedDate": "2026-07-29",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names Docusaurus but states no amount, tier or rate we can read"
       }
@@ -5804,7 +5804,7 @@
       ],
       "verifiedDate": "2026-07-27",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names Nextra but states no amount, tier or rate we can read"
       }
@@ -5824,7 +5824,7 @@
       ],
       "verifiedDate": "2026-07-28",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names VitePress but states no amount, tier or rate we can read"
       }
@@ -5843,7 +5843,7 @@
       ],
       "verifiedDate": "2026-07-26",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names Sphinx but states no amount, tier or rate we can read"
       }
@@ -5862,7 +5862,7 @@
       ],
       "verifiedDate": "2026-07-28",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names Formspree but states no amount, tier or rate we can read"
       }
@@ -5938,7 +5938,7 @@
       ],
       "verifiedDate": "2026-07-26",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names Meilisearch but states no amount, tier or rate we can read"
       }
@@ -5977,7 +5977,7 @@
       ],
       "verifiedDate": "2026-07-29",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names Playwright but states no amount, tier or rate we can read"
       }
@@ -5997,7 +5997,7 @@
       ],
       "verifiedDate": "2026-07-28",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names Puppeteer but states no amount, tier or rate we can read"
       }
@@ -6016,7 +6016,7 @@
       ],
       "verifiedDate": "2026-07-30",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names UNPKG but states no amount, tier or rate we can read"
       }
@@ -6036,7 +6036,7 @@
       ],
       "verifiedDate": "2026-07-29",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names esm.sh but states no amount, tier or rate we can read"
       }
@@ -6055,7 +6055,7 @@
       ],
       "verifiedDate": "2026-08-23",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names Excalidraw but states no amount, tier or rate we can read"
       }
@@ -6113,7 +6113,7 @@
       ],
       "verifiedDate": "2026-07-29",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names Harbor but states no amount, tier or rate we can read"
       }
@@ -6151,7 +6151,7 @@
       ],
       "verifiedDate": "2026-07-29",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names Exceptionless but states no amount, tier or rate we can read"
       }
@@ -6232,7 +6232,7 @@
       ],
       "verifiedDate": "2026-08-22",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names Keycloak but states no amount, tier or rate we can read"
       }
@@ -6389,7 +6389,7 @@
       ],
       "verifiedDate": "2026-07-29",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names Traefik but states no amount, tier or rate we can read"
       }
@@ -6410,7 +6410,7 @@
       ],
       "verifiedDate": "2026-07-30",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names Argo CD but states no amount, tier or rate we can read"
       }
@@ -6450,7 +6450,7 @@
       ],
       "verifiedDate": "2026-07-31",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names Automatisch but states no amount, tier or rate we can read"
       }
@@ -6470,7 +6470,7 @@
       ],
       "verifiedDate": "2026-07-30",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names Strapi but states no amount, tier or rate we can read"
       }
@@ -6490,7 +6490,7 @@
       ],
       "verifiedDate": "2026-08-25",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names Payload CMS but states no amount, tier or rate we can read"
       }
@@ -6512,7 +6512,7 @@
       ],
       "verifiedDate": "2026-08-22",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names Prometheus but states no amount, tier or rate we can read"
       },
@@ -6545,7 +6545,7 @@
       ],
       "verifiedDate": "2026-08-26",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names Jaeger but states no amount, tier or rate we can read"
       },
@@ -6634,7 +6634,7 @@
       ],
       "verifiedDate": "2026-08-21",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names Woodpecker CI but states no amount, tier or rate we can read"
       }
@@ -6655,7 +6655,7 @@
       ],
       "verifiedDate": "2026-07-29",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names Hoppscotch but states no amount, tier or rate we can read"
       }
@@ -6763,7 +6763,7 @@
       ],
       "verifiedDate": "2026-08-23",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names Moto but states no amount, tier or rate we can read"
       }
@@ -6784,7 +6784,7 @@
       ],
       "verifiedDate": "2026-08-13",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names AWS SAM CLI but states no amount, tier or rate we can read"
       }
@@ -6812,7 +6812,7 @@
         "reviewed": "2026-08-25"
       },
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names DynamoDB Local but states no amount, tier or rate we can read"
       }
@@ -6840,9 +6840,9 @@
         "reviewed": "2026-08-25"
       },
       "source_check": {
-        "checked": "2026-08-28",
-        "outcome": "states_no_terms",
-        "detail": "the page names ElasticMQ but states no amount, tier or rate we can read"
+        "checked": "2026-09-02",
+        "outcome": "ok",
+        "detail": "text"
       }
     },
     {
@@ -6872,7 +6872,7 @@
         "reviewed": "2026-08-25"
       },
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names CloudDev but states no amount, tier or rate we can read"
       }
@@ -6903,7 +6903,7 @@
         "reviewed": "2026-08-25"
       },
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names Vera AWS but states no amount, tier or rate we can read"
       }
@@ -7024,7 +7024,7 @@
       ],
       "verifiedDate": "2026-07-07",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names X (Twitter) but states no amount, tier or rate we can read"
       }
@@ -7476,7 +7476,7 @@
       ],
       "verifiedDate": "2026-07-31",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names OpenWeatherMap but states no amount, tier or rate we can read"
       }
@@ -7919,7 +7919,7 @@
       ],
       "verifiedDate": "2026-08-25",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names VirusTotal but states no amount, tier or rate we can read"
       }
@@ -8007,7 +8007,7 @@
       ],
       "verifiedDate": "2026-07-31",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names Scale AI but states no amount, tier or rate we can read"
       },
@@ -8610,9 +8610,9 @@
       ],
       "verifiedDate": "2026-07-06",
       "source_check": {
-        "checked": "2026-08-28",
-        "outcome": "states_no_terms",
-        "detail": "the page names Bruno but states no amount, tier or rate we can read"
+        "checked": "2026-09-02",
+        "outcome": "ok",
+        "detail": "text"
       }
     },
     {
@@ -8671,9 +8671,9 @@
       ],
       "verifiedDate": "2026-07-07",
       "source_check": {
-        "checked": "2026-08-28",
-        "outcome": "states_no_terms",
-        "detail": "the page names CrateDB but states no amount, tier or rate we can read"
+        "checked": "2026-09-02",
+        "outcome": "ok",
+        "detail": "text"
       },
       "product_subtypes": {
         "taxonomy": "Databases",
@@ -8811,7 +8811,7 @@
       ],
       "verifiedDate": "2026-08-23",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names Amazon SP-API but states no amount, tier or rate we can read"
       }
@@ -9116,7 +9116,7 @@
       ],
       "verifiedDate": "2026-07-06",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names Drone CI but states no amount, tier or rate we can read"
       }
@@ -9281,7 +9281,7 @@
       ],
       "verifiedDate": "2026-08-14",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names Zoho but states no amount, tier or rate we can read"
       }
@@ -9298,7 +9298,7 @@
       ],
       "verifiedDate": "2026-07-29",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names Zoho Assist but states no amount, tier or rate we can read"
       }
@@ -9349,9 +9349,9 @@
       ],
       "verifiedDate": "2026-08-01",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
-        "detail": "the page names Connect but states no amount, tier or rate we can read"
+        "detail": "the page names Zoho Connect but states no amount, tier or rate we can read"
       }
     },
     {
@@ -9401,9 +9401,9 @@
       ],
       "verifiedDate": "2026-07-31",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
-        "detail": "the page names Showtime but states no amount, tier or rate we can read"
+        "detail": "the page names Zoho Showtime but states no amount, tier or rate we can read"
       }
     },
     {
@@ -9435,9 +9435,9 @@
       ],
       "verifiedDate": "2026-07-27",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
-        "detail": "the page names Wiki but states no amount, tier or rate we can read"
+        "detail": "the page names Zoho Wiki but states no amount, tier or rate we can read"
       }
     },
     {
@@ -9469,9 +9469,9 @@
       ],
       "verifiedDate": "2026-07-31",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
-        "detail": "the page names Desk but states no amount, tier or rate we can read"
+        "detail": "the page names Zoho Desk but states no amount, tier or rate we can read"
       }
     },
     {
@@ -9486,9 +9486,9 @@
       ],
       "verifiedDate": "2026-07-30",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
-        "detail": "the page names Cliq but states no amount, tier or rate we can read"
+        "detail": "the page names Zoho Cliq but states no amount, tier or rate we can read"
       }
     },
     {
@@ -9522,9 +9522,9 @@
       ],
       "verifiedDate": "2026-08-01",
       "source_check": {
-        "checked": "2026-08-28",
-        "outcome": "states_no_terms",
-        "detail": "the page names Zoho Forms but states no amount, tier or rate we can read"
+        "checked": "2026-09-02",
+        "outcome": "ok",
+        "detail": "text"
       }
     },
     {
@@ -9616,9 +9616,9 @@
       ],
       "verifiedDate": "2026-08-01",
       "source_check": {
-        "checked": "2026-08-28",
-        "outcome": "states_no_terms",
-        "detail": "the page names Brainboard but states no amount, tier or rate we can read"
+        "checked": "2026-09-02",
+        "outcome": "ok",
+        "detail": "text"
       }
     },
     {
@@ -9635,7 +9635,7 @@
       ],
       "verifiedDate": "2026-07-31",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names Cloud 66 but states no amount, tier or rate we can read"
       }
@@ -9654,7 +9654,7 @@
       ],
       "verifiedDate": "2026-08-02",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names deployment.io but states no amount, tier or rate we can read"
       }
@@ -9713,7 +9713,7 @@
       ],
       "verifiedDate": "2026-08-26",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names Codeberg but states no amount, tier or rate we can read"
       }
@@ -9764,7 +9764,7 @@
       ],
       "verifiedDate": "2026-08-03",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names heptapod.net but states no amount, tier or rate we can read"
       }
@@ -9781,9 +9781,9 @@
       ],
       "verifiedDate": "2026-08-01",
       "source_check": {
-        "checked": "2026-08-28",
-        "outcome": "states_no_terms",
-        "detail": "the page names Pagure.io but states no amount, tier or rate we can read"
+        "checked": "2026-09-02",
+        "outcome": "ok",
+        "detail": "text"
       }
     },
     {
@@ -9798,7 +9798,7 @@
       ],
       "verifiedDate": "2026-08-02",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names pijul.com but states no amount, tier or rate we can read"
       }
@@ -9815,7 +9815,7 @@
       ],
       "verifiedDate": "2026-08-01",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names RocketGit but states no amount, tier or rate we can read"
       }
@@ -9832,7 +9832,7 @@
       ],
       "verifiedDate": "2026-08-02",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names savannah.gnu.org but states no amount, tier or rate we can read"
       }
@@ -9849,7 +9849,7 @@
       ],
       "verifiedDate": "2026-07-31",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names savannah.nongnu.org but states no amount, tier or rate we can read"
       }
@@ -9866,7 +9866,7 @@
       ],
       "verifiedDate": "2026-08-26",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names APITemplate.io but states no amount, tier or rate we can read"
       }
@@ -9933,7 +9933,7 @@
       ],
       "verifiedDate": "2026-08-04",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names Beeceptor but states no amount, tier or rate we can read"
       }
@@ -9950,9 +9950,9 @@
       ],
       "verifiedDate": "2026-07-30",
       "source_check": {
-        "checked": "2026-08-28",
-        "outcome": "states_no_terms",
-        "detail": "the page names Browse AI but states no amount, tier or rate we can read"
+        "checked": "2026-09-02",
+        "outcome": "ok",
+        "detail": "text"
       }
     },
     {
@@ -10106,7 +10106,7 @@
       ],
       "verifiedDate": "2026-08-25",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names Conversion Tools but states no amount, tier or rate we can read"
       }
@@ -10123,9 +10123,9 @@
       ],
       "verifiedDate": "2026-07-05",
       "source_check": {
-        "checked": "2026-08-28",
-        "outcome": "states_no_terms",
-        "detail": "the page names Country-State-City Microservice API but states no amount, tier or rate we can read"
+        "checked": "2026-09-02",
+        "outcome": "ok",
+        "detail": "text"
       }
     },
     {
@@ -10208,7 +10208,7 @@
       ],
       "verifiedDate": "2026-08-26",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "does_not_name_vendor",
         "detail": "the page never names CurrencyScoop and is not served from its domain"
       }
@@ -10242,7 +10242,7 @@
       ],
       "verifiedDate": "2026-08-03",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names Data Fetcher but states no amount, tier or rate we can read"
       }
@@ -10259,7 +10259,7 @@
       ],
       "verifiedDate": "2026-08-03",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names Data Miner but states no amount, tier or rate we can read"
       }
@@ -10276,7 +10276,7 @@
       ],
       "verifiedDate": "2026-08-22",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names Dataimporter.io but states no amount, tier or rate we can read"
       }
@@ -10293,7 +10293,7 @@
       ],
       "verifiedDate": "2026-08-02",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names Datalore but states no amount, tier or rate we can read"
       }
@@ -10344,7 +10344,7 @@
       ],
       "verifiedDate": "2026-07-31",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names DeepAR but states no amount, tier or rate we can read"
       },
@@ -10383,7 +10383,7 @@
       ],
       "verifiedDate": "2026-08-28",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "does_not_name_vendor",
         "detail": "the page never names DiffJSON and is not served from its domain"
       }
@@ -10400,7 +10400,7 @@
       ],
       "verifiedDate": "2026-08-25",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names Disease.sh but states no amount, tier or rate we can read"
       }
@@ -10451,7 +10451,7 @@
       ],
       "verifiedDate": "2026-08-02",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names drawDB but states no amount, tier or rate we can read"
       }
@@ -10502,7 +10502,7 @@
       ],
       "verifiedDate": "2026-08-02",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names ExtendsClass but states no amount, tier or rate we can read"
       }
@@ -10536,7 +10536,7 @@
       ],
       "verifiedDate": "2026-07-08",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names FormatJSONOnline.com but states no amount, tier or rate we can read"
       }
@@ -10553,7 +10553,7 @@
       ],
       "verifiedDate": "2026-07-06",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names FraudLabs Pro but states no amount, tier or rate we can read"
       }
@@ -10710,7 +10710,7 @@
       ],
       "verifiedDate": "2026-07-08",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names IP.City but states no amount, tier or rate we can read"
       }
@@ -10880,7 +10880,7 @@
       ],
       "verifiedDate": "2026-07-06",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names JSONGrid but states no amount, tier or rate we can read"
       }
@@ -10897,7 +10897,7 @@
       ],
       "verifiedDate": "2026-08-02",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names JSONing but states no amount, tier or rate we can read"
       }
@@ -10931,7 +10931,7 @@
       ],
       "verifiedDate": "2026-07-09",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names KillBait API but states no amount, tier or rate we can read"
       }
@@ -10999,7 +10999,7 @@
       ],
       "verifiedDate": "2026-07-30",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names Maxim AI but states no amount, tier or rate we can read"
       },
@@ -11095,7 +11095,7 @@
       ],
       "verifiedDate": "2026-08-01",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names Mocko.dev but states no amount, tier or rate we can read"
       }
@@ -11112,7 +11112,7 @@
       ],
       "verifiedDate": "2026-08-02",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names Multi-Exit IP Address Checker but states no amount, tier or rate we can read"
       }
@@ -11143,7 +11143,7 @@
         "notes": "Channel partner program only. No individual referral program."
       },
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names Cloudflare Mesh but states no amount, tier or rate we can read"
       }
@@ -11160,7 +11160,7 @@
       ],
       "verifiedDate": "2026-08-26",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names News API but states no amount, tier or rate we can read"
       }
@@ -11222,7 +11222,7 @@
       ],
       "verifiedDate": "2026-07-30",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names OpenAPI3 Designer but states no amount, tier or rate we can read"
       }
@@ -11301,7 +11301,7 @@
       ],
       "verifiedDate": "2026-07-06",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names pdfEndpoint.com but states no amount, tier or rate we can read"
       }
@@ -11318,7 +11318,7 @@
       ],
       "verifiedDate": "2026-07-08",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names Pixela but states no amount, tier or rate we can read"
       }
@@ -11352,7 +11352,7 @@
       ],
       "verifiedDate": "2026-08-04",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names Preset Cloud but states no amount, tier or rate we can read"
       }
@@ -11457,7 +11457,7 @@
       ],
       "verifiedDate": "2026-07-10",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names ROBOHASH but states no amount, tier or rate we can read"
       }
@@ -11525,7 +11525,7 @@
       ],
       "verifiedDate": "2026-08-02",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names Simplescraper but states no amount, tier or rate we can read"
       }
@@ -11593,7 +11593,7 @@
       ],
       "verifiedDate": "2026-07-06",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names Sqlable but states no amount, tier or rate we can read"
       }
@@ -11715,7 +11715,7 @@
       ],
       "verifiedDate": "2026-08-04",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names Treblle but states no amount, tier or rate we can read"
       }
@@ -11766,7 +11766,7 @@
       ],
       "verifiedDate": "2026-07-09",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names WeatherXu but states no amount, tier or rate we can read"
       }
@@ -11800,7 +11800,7 @@
       ],
       "verifiedDate": "2026-07-31",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names What The Diff but states no amount, tier or rate we can read"
       }
@@ -11817,7 +11817,7 @@
       ],
       "verifiedDate": "2026-08-02",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names wrapapi.com but states no amount, tier or rate we can read"
       }
@@ -11885,7 +11885,7 @@
       ],
       "verifiedDate": "2026-07-09",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names Gemfury but states no amount, tier or rate we can read"
       }
@@ -11902,7 +11902,7 @@
       ],
       "verifiedDate": "2026-07-07",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names jitpack.io but states no amount, tier or rate we can read"
       }
@@ -11952,7 +11952,7 @@
       ],
       "verifiedDate": "2026-07-08",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names RepoFlow but states no amount, tier or rate we can read"
       }
@@ -12003,7 +12003,7 @@
       ],
       "verifiedDate": "2026-08-01",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names 3Cols but states no amount, tier or rate we can read"
       }
@@ -12020,7 +12020,7 @@
       ],
       "verifiedDate": "2026-08-04",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names BookmarkOS.com but states no amount, tier or rate we can read"
       }
@@ -12071,7 +12071,7 @@
       ],
       "verifiedDate": "2026-08-01",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names cally.com but states no amount, tier or rate we can read"
       }
@@ -12122,7 +12122,7 @@
       ],
       "verifiedDate": "2026-07-11",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names DevToolLab but states no amount, tier or rate we can read"
       }
@@ -12156,7 +12156,7 @@
       ],
       "verifiedDate": "2026-08-03",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names element.io but states no amount, tier or rate we can read"
       }
@@ -12173,7 +12173,7 @@
       ],
       "verifiedDate": "2026-07-12",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names Fibery but states no amount, tier or rate we can read"
       }
@@ -12190,7 +12190,7 @@
       ],
       "verifiedDate": "2026-07-09",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names Fibo but states no amount, tier or rate we can read"
       }
@@ -12207,7 +12207,7 @@
       ],
       "verifiedDate": "2026-07-07",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names Fizzy but states no amount, tier or rate we can read"
       }
@@ -12224,7 +12224,7 @@
       ],
       "verifiedDate": "2026-08-05",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names flat.social but states no amount, tier or rate we can read"
       }
@@ -12241,7 +12241,7 @@
       ],
       "verifiedDate": "2026-08-01",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names flock.com but states no amount, tier or rate we can read"
       }
@@ -12275,7 +12275,7 @@
       ],
       "verifiedDate": "2026-08-04",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names gitter.im but states no amount, tier or rate we can read"
       }
@@ -12292,7 +12292,7 @@
       ],
       "verifiedDate": "2026-07-06",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names gokanban.io but states no amount, tier or rate we can read"
       }
@@ -12309,7 +12309,7 @@
       ],
       "verifiedDate": "2026-08-02",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names Hackmd.io but states no amount, tier or rate we can read"
       }
@@ -12343,7 +12343,7 @@
       ],
       "verifiedDate": "2026-07-31",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names Keybase but states no amount, tier or rate we can read"
       }
@@ -12377,7 +12377,7 @@
       ],
       "verifiedDate": "2026-08-02",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names Lockitbot but states no amount, tier or rate we can read"
       }
@@ -12394,7 +12394,7 @@
       ],
       "verifiedDate": "2026-08-04",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names meet.jit.si but states no amount, tier or rate we can read"
       }
@@ -12411,7 +12411,7 @@
       ],
       "verifiedDate": "2026-08-12",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names Miro but states no amount, tier or rate we can read"
       }
@@ -12428,7 +12428,7 @@
       ],
       "verifiedDate": "2026-08-03",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names Nuclino but states no amount, tier or rate we can read"
       }
@@ -12445,7 +12445,7 @@
       ],
       "verifiedDate": "2026-08-04",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names OnlineInterview.io but states no amount, tier or rate we can read"
       }
@@ -12462,7 +12462,7 @@
       ],
       "verifiedDate": "2026-07-08",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names Pendulums but states no amount, tier or rate we can read"
       }
@@ -12530,7 +12530,7 @@
       ],
       "verifiedDate": "2026-08-03",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names Revolt.chat but states no amount, tier or rate we can read"
       }
@@ -12547,7 +12547,7 @@
       ],
       "verifiedDate": "2026-08-02",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names Rocket.Chat but states no amount, tier or rate we can read"
       }
@@ -12581,7 +12581,7 @@
       ],
       "verifiedDate": "2026-08-05",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names Screen Sharing via Browser but states no amount, tier or rate we can read"
       }
@@ -12598,7 +12598,7 @@
       ],
       "verifiedDate": "2026-07-08",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names seafile.com but states no amount, tier or rate we can read"
       }
@@ -12632,7 +12632,7 @@
       ],
       "verifiedDate": "2026-08-06",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names Slab but states no amount, tier or rate we can read"
       }
@@ -12649,7 +12649,7 @@
       ],
       "verifiedDate": "2026-07-07",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names StatusPile but states no amount, tier or rate we can read"
       },
@@ -12677,7 +12677,7 @@
       ],
       "verifiedDate": "2026-08-02",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names Stickies but states no amount, tier or rate we can read"
       }
@@ -12711,7 +12711,7 @@
       ],
       "verifiedDate": "2026-07-31",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names talky.io but states no amount, tier or rate we can read"
       }
@@ -12745,7 +12745,7 @@
       ],
       "verifiedDate": "2026-07-07",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names Teamplify but states no amount, tier or rate we can read"
       }
@@ -12779,9 +12779,9 @@
       ],
       "verifiedDate": "2026-07-09",
       "source_check": {
-        "checked": "2026-08-28",
-        "outcome": "states_no_terms",
-        "detail": "the page names TimeCamp but states no amount, tier or rate we can read"
+        "checked": "2026-09-02",
+        "outcome": "ok",
+        "detail": "text"
       }
     },
     {
@@ -12796,7 +12796,7 @@
       ],
       "verifiedDate": "2026-08-05",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names tldraw.com but states no amount, tier or rate we can read"
       }
@@ -12830,7 +12830,7 @@
       ],
       "verifiedDate": "2026-07-09",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names Tugboat but states no amount, tier or rate we can read"
       }
@@ -12847,7 +12847,7 @@
       ],
       "verifiedDate": "2026-08-02",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names twist.com but states no amount, tier or rate we can read"
       }
@@ -12932,7 +12932,7 @@
       ],
       "verifiedDate": "2026-08-04",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names windmill.dev but states no amount, tier or rate we can read"
       }
@@ -12949,7 +12949,7 @@
       ],
       "verifiedDate": "2026-08-03",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names wistia.com but states no amount, tier or rate we can read"
       }
@@ -12966,7 +12966,7 @@
       ],
       "verifiedDate": "2026-07-12",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names wormhol.org but states no amount, tier or rate we can read"
       }
@@ -12983,7 +12983,7 @@
       ],
       "verifiedDate": "2026-08-23",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names Wormhole but states no amount, tier or rate we can read"
       }
@@ -13000,7 +13000,7 @@
       ],
       "verifiedDate": "2026-08-02",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names zoom.us but states no amount, tier or rate we can read"
       }
@@ -13017,7 +13017,7 @@
       ],
       "verifiedDate": "2026-07-31",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names Zulip but states no amount, tier or rate we can read"
       }
@@ -13110,7 +13110,7 @@
       ],
       "verifiedDate": "2026-08-02",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names Prismic but states no amount, tier or rate we can read"
       }
@@ -13148,7 +13148,7 @@
       ],
       "verifiedDate": "2026-08-02",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names Squidex but states no amount, tier or rate we can read"
       }
@@ -13186,7 +13186,7 @@
       ],
       "verifiedDate": "2026-08-06",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names TinaCMS but states no amount, tier or rate we can read"
       }
@@ -13222,7 +13222,7 @@
       ],
       "verifiedDate": "2026-08-01",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names Appinvento but states no amount, tier or rate we can read"
       }
@@ -13273,7 +13273,7 @@
       ],
       "verifiedDate": "2026-08-03",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names Metalama but states no amount, tier or rate we can read"
       }
@@ -13307,7 +13307,7 @@
       ],
       "verifiedDate": "2026-07-05",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names v0.dev but states no amount, tier or rate we can read"
       }
@@ -13324,7 +13324,7 @@
       ],
       "verifiedDate": "2026-08-02",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names beanstalkapp.com but states no amount, tier or rate we can read"
       }
@@ -13341,7 +13341,7 @@
       ],
       "verifiedDate": "2026-08-13",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names codacy.com but states no amount, tier or rate we can read"
       }
@@ -13358,7 +13358,7 @@
       ],
       "verifiedDate": "2026-08-02",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names Codeac.io but states no amount, tier or rate we can read"
       }
@@ -13375,7 +13375,7 @@
       ],
       "verifiedDate": "2026-08-05",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names CodeFactor but states no amount, tier or rate we can read"
       }
@@ -13409,7 +13409,7 @@
       ],
       "verifiedDate": "2026-08-07",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names CodSpeed but states no amount, tier or rate we can read"
       }
@@ -13426,7 +13426,7 @@
       ],
       "verifiedDate": "2026-08-13",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names coveralls.io but states no amount, tier or rate we can read"
       }
@@ -13443,7 +13443,7 @@
       ],
       "verifiedDate": "2026-08-02",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names deepscan.io but states no amount, tier or rate we can read"
       }
@@ -13460,7 +13460,7 @@
       ],
       "verifiedDate": "2026-08-04",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names DeepSource but states no amount, tier or rate we can read"
       }
@@ -13494,7 +13494,7 @@
       ],
       "verifiedDate": "2026-08-05",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names gerrithub.io but states no amount, tier or rate we can read"
       }
@@ -13511,7 +13511,7 @@
       ],
       "verifiedDate": "2026-08-02",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names goreportcard.com but states no amount, tier or rate we can read"
       }
@@ -13545,7 +13545,7 @@
       ],
       "verifiedDate": "2026-08-04",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names holistic.dev but states no amount, tier or rate we can read"
       }
@@ -13613,7 +13613,7 @@
       ],
       "verifiedDate": "2026-08-05",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names scrutinizer-ci.com but states no amount, tier or rate we can read"
       }
@@ -13630,7 +13630,7 @@
       ],
       "verifiedDate": "2026-08-06",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names semanticdiff.com but states no amount, tier or rate we can read"
       }
@@ -13647,7 +13647,7 @@
       ],
       "verifiedDate": "2026-07-10",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names shields.io but states no amount, tier or rate we can read"
       }
@@ -13681,7 +13681,7 @@
       ],
       "verifiedDate": "2026-07-08",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names libraries.io but states no amount, tier or rate we can read"
       }
@@ -13734,7 +13734,7 @@
       ],
       "verifiedDate": "2026-07-16",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names appveyor.com but states no amount, tier or rate we can read"
       }
@@ -13753,7 +13753,7 @@
       ],
       "verifiedDate": "2026-07-10",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names bytebase.com but states no amount, tier or rate we can read"
       }
@@ -13867,9 +13867,9 @@
       ],
       "verifiedDate": "2026-07-10",
       "source_check": {
-        "checked": "2026-08-28",
-        "outcome": "states_no_terms",
-        "detail": "the page names Nx Cloud but states no amount, tier or rate we can read"
+        "checked": "2026-09-02",
+        "outcome": "ok",
+        "detail": "text"
       }
     },
     {
@@ -13905,7 +13905,7 @@
       ],
       "verifiedDate": "2026-07-10",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names Shipfox but states no amount, tier or rate we can read"
       }
@@ -13944,7 +13944,7 @@
       ],
       "verifiedDate": "2026-07-11",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names Terramate but states no amount, tier or rate we can read"
       }
@@ -13989,7 +13989,7 @@
         "reviewed": "2026-08-25"
       },
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names Appetize but states no amount, tier or rate we can read"
       }
@@ -14025,7 +14025,7 @@
       ],
       "verifiedDate": "2026-08-24",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names Bencher but states no amount, tier or rate we can read"
       }
@@ -14079,7 +14079,7 @@
       ],
       "verifiedDate": "2026-08-05",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names CORS-Tester but states no amount, tier or rate we can read"
       }
@@ -14115,7 +14115,7 @@
       ],
       "verifiedDate": "2026-08-05",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names gridlastic.com but states no amount, tier or rate we can read"
       }
@@ -14133,7 +14133,7 @@
       ],
       "verifiedDate": "2026-08-02",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names katalon.com but states no amount, tier or rate we can read"
       }
@@ -14151,7 +14151,7 @@
       ],
       "verifiedDate": "2026-08-04",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names Keploy but states no amount, tier or rate we can read"
       }
@@ -14169,7 +14169,7 @@
       ],
       "verifiedDate": "2026-08-05",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names loadmill.com but states no amount, tier or rate we can read"
       }
@@ -14205,7 +14205,7 @@
       ],
       "verifiedDate": "2026-08-05",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names pagegym.com but states no amount, tier or rate we can read"
       }
@@ -14223,7 +14223,7 @@
       ],
       "verifiedDate": "2026-08-03",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names qase.io but states no amount, tier or rate we can read"
       }
@@ -14277,7 +14277,7 @@
       ],
       "verifiedDate": "2026-07-12",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names SSR (Server-side Rendering) Checker but states no amount, tier or rate we can read"
       }
@@ -14313,7 +14313,7 @@
       ],
       "verifiedDate": "2026-08-03",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names Testspace.com but states no amount, tier or rate we can read"
       }
@@ -14349,7 +14349,7 @@
       ],
       "verifiedDate": "2026-08-05",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names UseWebhook.com but states no amount, tier or rate we can read"
       }
@@ -14403,7 +14403,7 @@
       ],
       "verifiedDate": "2026-08-04",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names websitepulse.com but states no amount, tier or rate we can read"
       }
@@ -14421,7 +14421,7 @@
       ],
       "verifiedDate": "2026-08-04",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names kogiQA but states no amount, tier or rate we can read"
       }
@@ -14455,7 +14455,7 @@
       ],
       "verifiedDate": "2026-07-10",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names CertKit but states no amount, tier or rate we can read"
       }
@@ -14489,7 +14489,7 @@
       ],
       "verifiedDate": "2026-07-12",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names crypteron.com but states no amount, tier or rate we can read"
       }
@@ -14506,7 +14506,7 @@
       ],
       "verifiedDate": "2026-07-11",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names CyberChef but states no amount, tier or rate we can read"
       }
@@ -14540,7 +14540,7 @@
       ],
       "verifiedDate": "2026-07-06",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names DJ Checkup but states no amount, tier or rate we can read"
       }
@@ -14574,7 +14574,7 @@
       ],
       "verifiedDate": "2026-07-09",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names Have I been pwned? but states no amount, tier or rate we can read"
       }
@@ -14591,7 +14591,7 @@
       ],
       "verifiedDate": "2026-07-11",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names Internet.nl but states no amount, tier or rate we can read"
       }
@@ -14625,7 +14625,7 @@
       ],
       "verifiedDate": "2026-07-06",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names meterian.io but states no amount, tier or rate we can read"
       }
@@ -14642,7 +14642,7 @@
       ],
       "verifiedDate": "2026-07-10",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names Mozilla Observatory but states no amount, tier or rate we can read"
       }
@@ -14659,7 +14659,7 @@
       ],
       "verifiedDate": "2026-07-11",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names Public Cloud Threat Intelligence but states no amount, tier or rate we can read"
       }
@@ -14676,7 +14676,7 @@
       ],
       "verifiedDate": "2026-08-16",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names Safety but states no amount, tier or rate we can read"
       }
@@ -14693,7 +14693,7 @@
       ],
       "verifiedDate": "2026-07-08",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names qualys.com but states no amount, tier or rate we can read"
       }
@@ -14710,7 +14710,7 @@
       ],
       "verifiedDate": "2026-07-10",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names Smart Grow Vault but states no amount, tier or rate we can read"
       }
@@ -14744,7 +14744,7 @@
       ],
       "verifiedDate": "2026-07-13",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names ssllabs.com but states no amount, tier or rate we can read"
       }
@@ -14761,7 +14761,7 @@
       ],
       "verifiedDate": "2026-07-09",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names Sucuri SiteCheck but states no amount, tier or rate we can read"
       }
@@ -14814,7 +14814,7 @@
       ],
       "verifiedDate": "2026-07-11",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names 360username but states no amount, tier or rate we can read"
       }
@@ -14833,7 +14833,7 @@
       ],
       "verifiedDate": "2026-07-12",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names Aserto but states no amount, tier or rate we can read"
       }
@@ -14871,7 +14871,7 @@
       ],
       "verifiedDate": "2026-07-13",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names Authgear but states no amount, tier or rate we can read"
       }
@@ -14909,7 +14909,7 @@
       ],
       "verifiedDate": "2026-07-07",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names Authy but states no amount, tier or rate we can read"
       }
@@ -14928,7 +14928,7 @@
       ],
       "verifiedDate": "2026-07-13",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names Cerbos Hub but states no amount, tier or rate we can read"
       }
@@ -14947,7 +14947,7 @@
       ],
       "verifiedDate": "2026-07-07",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names Cloud-IAM but states no amount, tier or rate we can read"
       }
@@ -14985,7 +14985,7 @@
       ],
       "verifiedDate": "2026-07-11",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names logintc.com but states no amount, tier or rate we can read"
       }
@@ -15104,7 +15104,7 @@
       ],
       "verifiedDate": "2026-07-11",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names PropelAuth but states no amount, tier or rate we can read"
       }
@@ -15123,9 +15123,9 @@
       ],
       "verifiedDate": "2026-07-09",
       "source_check": {
-        "checked": "2026-08-28",
-        "outcome": "states_no_terms",
-        "detail": "the page names Stack Auth but states no amount, tier or rate we can read"
+        "checked": "2026-09-02",
+        "outcome": "ok",
+        "detail": "url"
       }
     },
     {
@@ -15142,7 +15142,7 @@
       ],
       "verifiedDate": "2026-07-13",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names ZITADEL Cloud but states no amount, tier or rate we can read"
       }
@@ -15176,7 +15176,7 @@
       ],
       "verifiedDate": "2026-08-04",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names Diawi but states no amount, tier or rate we can read"
       }
@@ -15261,7 +15261,7 @@
       ],
       "verifiedDate": "2026-08-05",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names jamf.com but states no amount, tier or rate we can read"
       }
@@ -15278,7 +15278,7 @@
       ],
       "verifiedDate": "2026-08-05",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names Miradore but states no amount, tier or rate we can read"
       }
@@ -15329,7 +15329,7 @@
       ],
       "verifiedDate": "2026-08-03",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names runcloud.io but states no amount, tier or rate we can read"
       }
@@ -15381,7 +15381,7 @@
       ],
       "verifiedDate": "2026-08-18",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names courier.com but states no amount, tier or rate we can read"
       }
@@ -15471,7 +15471,7 @@
       ],
       "verifiedDate": "2026-08-08",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names httpSMS but states no amount, tier or rate we can read"
       }
@@ -15561,7 +15561,7 @@
       ],
       "verifiedDate": "2026-08-08",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names SMSGate but states no amount, tier or rate we can read"
       }
@@ -15615,7 +15615,7 @@
       ],
       "verifiedDate": "2026-08-07",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names webpushr but states no amount, tier or rate we can read"
       }
@@ -15633,7 +15633,7 @@
       ],
       "verifiedDate": "2026-08-07",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names bugfender.com but states no amount, tier or rate we can read"
       }
@@ -15705,7 +15705,7 @@
       ],
       "verifiedDate": "2026-08-06",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names logzab.com but states no amount, tier or rate we can read"
       }
@@ -15723,9 +15723,9 @@
       ],
       "verifiedDate": "2026-08-05",
       "source_check": {
-        "checked": "2026-08-28",
-        "outcome": "states_no_terms",
-        "detail": "the page names ManageEngine Log360 Cloud but states no amount, tier or rate we can read"
+        "checked": "2026-09-02",
+        "outcome": "ok",
+        "detail": "text"
       }
     },
     {
@@ -15793,7 +15793,7 @@
       ],
       "verifiedDate": "2026-08-08",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names Free PO editor but states no amount, tier or rate we can read"
       }
@@ -15810,7 +15810,7 @@
       ],
       "verifiedDate": "2026-08-08",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names lingohub.com but states no amount, tier or rate we can read"
       }
@@ -15844,7 +15844,7 @@
       ],
       "verifiedDate": "2026-08-06",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names Localit but states no amount, tier or rate we can read"
       }
@@ -15895,7 +15895,7 @@
       ],
       "verifiedDate": "2026-08-06",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names POEditor but states no amount, tier or rate we can read"
       }
@@ -15946,7 +15946,7 @@
       ],
       "verifiedDate": "2026-08-08",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names Tolgee but states no amount, tier or rate we can read"
       }
@@ -15963,7 +15963,7 @@
       ],
       "verifiedDate": "2026-08-07",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names transifex.com but states no amount, tier or rate we can read"
       }
@@ -15981,7 +15981,7 @@
       ],
       "verifiedDate": "2026-07-12",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names assertible.com but states no amount, tier or rate we can read"
       },
@@ -16010,9 +16010,9 @@
       ],
       "verifiedDate": "2026-07-11",
       "source_check": {
-        "checked": "2026-08-28",
-        "outcome": "states_no_terms",
-        "detail": "the page names bleemeo.com but states no amount, tier or rate we can read"
+        "checked": "2026-09-02",
+        "outcome": "ok",
+        "detail": "text"
       },
       "product_subtypes": {
         "taxonomy": "Monitoring",
@@ -16044,7 +16044,7 @@
       ],
       "verifiedDate": "2026-07-08",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names Core Web Vitals History but states no amount, tier or rate we can read"
       },
@@ -16067,7 +16067,7 @@
       ],
       "verifiedDate": "2026-07-09",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names deadmanssnitch.com but states no amount, tier or rate we can read"
       },
@@ -16096,7 +16096,7 @@
       ],
       "verifiedDate": "2026-07-09",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names downtimemonkey.com but states no amount, tier or rate we can read"
       },
@@ -16125,7 +16125,7 @@
       ],
       "verifiedDate": "2026-07-12",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names economize.cloud but states no amount, tier or rate we can read"
       },
@@ -16206,7 +16206,7 @@
       ],
       "verifiedDate": "2026-07-11",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names inspector.dev but states no amount, tier or rate we can read"
       },
@@ -16263,7 +16263,7 @@
       ],
       "verifiedDate": "2026-07-09",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names loader.io but states no amount, tier or rate we can read"
       },
@@ -16320,9 +16320,9 @@
       ],
       "verifiedDate": "2026-07-08",
       "source_check": {
-        "checked": "2026-08-28",
-        "outcome": "states_no_terms",
-        "detail": "the page names netdata.cloud but states no amount, tier or rate we can read"
+        "checked": "2026-09-02",
+        "outcome": "ok",
+        "detail": "text"
       },
       "product_subtypes": {
         "taxonomy": "Monitoring",
@@ -16359,7 +16359,7 @@
       ],
       "verifiedDate": "2026-07-10",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names OntarioNet.ca CN Test but states no amount, tier or rate we can read"
       },
@@ -16474,7 +16474,7 @@
       ],
       "verifiedDate": "2026-07-12",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names pingbreak.com but states no amount, tier or rate we can read"
       },
@@ -16532,7 +16532,7 @@
       ],
       "verifiedDate": "2026-07-14",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names pingpong.one but states no amount, tier or rate we can read"
       },
@@ -16589,7 +16589,7 @@
       ],
       "verifiedDate": "2026-07-15",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names Servervana but states no amount, tier or rate we can read"
       },
@@ -16652,7 +16652,7 @@
       ],
       "verifiedDate": "2026-07-10",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names sitesure.net but states no amount, tier or rate we can read"
       },
@@ -16686,7 +16686,7 @@
       ],
       "verifiedDate": "2026-07-13",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names skylight.io but states no amount, tier or rate we can read"
       },
@@ -16715,7 +16715,7 @@
       ],
       "verifiedDate": "2026-07-10",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names statusgator.com but states no amount, tier or rate we can read"
       },
@@ -16807,7 +16807,7 @@
       ],
       "verifiedDate": "2026-07-11",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names UptimeObserver.com but states no amount, tier or rate we can read"
       },
@@ -16875,7 +16875,7 @@
       ],
       "verifiedDate": "2026-07-11",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names Wachete but states no amount, tier or rate we can read"
       },
@@ -16984,7 +16984,7 @@
       ],
       "verifiedDate": "2026-08-04",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names elmah.io but states no amount, tier or rate we can read"
       }
@@ -17002,7 +17002,7 @@
       ],
       "verifiedDate": "2026-08-05",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names Embrace but states no amount, tier or rate we can read"
       }
@@ -17038,7 +17038,7 @@
       ],
       "verifiedDate": "2026-08-10",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names Jam but states no amount, tier or rate we can read"
       }
@@ -17056,7 +17056,7 @@
       ],
       "verifiedDate": "2026-08-07",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names memfault.com but states no amount, tier or rate we can read"
       }
@@ -17126,7 +17126,7 @@
       ],
       "verifiedDate": "2026-07-12",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names 10minutemail but states no amount, tier or rate we can read"
       }
@@ -17230,7 +17230,7 @@
       ],
       "verifiedDate": "2026-07-13",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names Buttondown but states no amount, tier or rate we can read"
       }
@@ -17264,7 +17264,7 @@
       ],
       "verifiedDate": "2026-07-10",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names dkimvalidator.com but states no amount, tier or rate we can read"
       }
@@ -17315,7 +17315,7 @@
       ],
       "verifiedDate": "2026-07-14",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names EmailLabs.io but states no amount, tier or rate we can read"
       }
@@ -17366,7 +17366,7 @@
       ],
       "verifiedDate": "2026-07-12",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names EtherealMail but states no amount, tier or rate we can read"
       }
@@ -17434,7 +17434,7 @@
       ],
       "verifiedDate": "2026-07-12",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names Inboxes App but states no amount, tier or rate we can read"
       }
@@ -17468,7 +17468,7 @@
       ],
       "verifiedDate": "2026-07-12",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names mail-tester.com but states no amount, tier or rate we can read"
       }
@@ -17502,7 +17502,7 @@
       ],
       "verifiedDate": "2026-07-15",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names mailcatcher.me but states no amount, tier or rate we can read"
       }
@@ -17519,7 +17519,7 @@
       ],
       "verifiedDate": "2026-08-20",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names mailchannels.com but states no amount, tier or rate we can read"
       }
@@ -17570,7 +17570,7 @@
       ],
       "verifiedDate": "2026-07-13",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names MailerLite.com but states no amount, tier or rate we can read"
       }
@@ -17740,7 +17740,7 @@
       ],
       "verifiedDate": "2026-04-14",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names Substack but states no amount, tier or rate we can read"
       }
@@ -17774,7 +17774,7 @@
       ],
       "verifiedDate": "2026-07-12",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names temp-mail.io but states no amount, tier or rate we can read"
       }
@@ -18033,7 +18033,7 @@
       ],
       "verifiedDate": "2026-08-06",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names Form.taxi but states no amount, tier or rate we can read"
       }
@@ -18118,7 +18118,7 @@
       ],
       "verifiedDate": "2026-08-06",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names formspark.io but states no amount, tier or rate we can read"
       }
@@ -18135,7 +18135,7 @@
       ],
       "verifiedDate": "2026-08-06",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names Formsubmit.co but states no amount, tier or rate we can read"
       }
@@ -18152,7 +18152,7 @@
       ],
       "verifiedDate": "2026-08-07",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names Formware.io but states no amount, tier or rate we can read"
       }
@@ -18186,7 +18186,7 @@
       ],
       "verifiedDate": "2026-08-06",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names Kwes.io but states no amount, tier or rate we can read"
       }
@@ -18237,7 +18237,7 @@
       ],
       "verifiedDate": "2026-08-06",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names smartforms.dev but states no amount, tier or rate we can read"
       }
@@ -18305,7 +18305,7 @@
       ],
       "verifiedDate": "2026-08-09",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names Vidhook but states no amount, tier or rate we can read"
       }
@@ -18322,7 +18322,7 @@
       ],
       "verifiedDate": "2026-08-08",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names WaiverStevie.com but states no amount, tier or rate we can read"
       }
@@ -18469,7 +18469,7 @@
       ],
       "verifiedDate": "2026-08-10",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names Clair but states no amount, tier or rate we can read"
       },
@@ -18631,9 +18631,9 @@
       ],
       "verifiedDate": "2026-08-10",
       "source_check": {
-        "checked": "2026-08-28",
-        "outcome": "states_no_terms",
-        "detail": "the page names LangWatch but states no amount, tier or rate we can read"
+        "checked": "2026-09-02",
+        "outcome": "ok",
+        "detail": "text"
       },
       "product_subtypes": {
         "taxonomy": "AI / ML",
@@ -18725,9 +18725,9 @@
       ],
       "verifiedDate": "2026-08-09",
       "source_check": {
-        "checked": "2026-08-28",
-        "outcome": "states_no_terms",
-        "detail": "the page names Othor AI but states no amount, tier or rate we can read"
+        "checked": "2026-09-02",
+        "outcome": "ok",
+        "detail": "text"
       },
       "product_subtypes": {
         "taxonomy": "AI / ML",
@@ -18749,7 +18749,7 @@
       ],
       "verifiedDate": "2026-08-07",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names Pollinations.AI but states no amount, tier or rate we can read"
       },
@@ -18870,7 +18870,7 @@
       ],
       "verifiedDate": "2026-08-07",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names bootstrapcdn.com but states no amount, tier or rate we can read"
       }
@@ -18924,7 +18924,7 @@
       ],
       "verifiedDate": "2026-08-07",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names developers.google.com but states no amount, tier or rate we can read"
       }
@@ -18942,7 +18942,7 @@
       ],
       "verifiedDate": "2026-08-08",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names Microsoft Ajax but states no amount, tier or rate we can read"
       }
@@ -18989,9 +18989,9 @@
       ],
       "verifiedDate": "2026-08-18",
       "source_check": {
-        "checked": "2026-08-28",
-        "outcome": "states_no_terms",
-        "detail": "the page names OVHcloud but states no amount, tier or rate we can read"
+        "checked": "2026-09-02",
+        "outcome": "ok",
+        "detail": "text"
       }
     },
     {
@@ -19025,7 +19025,7 @@
       ],
       "verifiedDate": "2026-08-07",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names raw.githack.com but states no amount, tier or rate we can read"
       }
@@ -19043,7 +19043,7 @@
       ],
       "verifiedDate": "2026-08-28",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names Skypack but states no amount, tier or rate we can read"
       }
@@ -19079,7 +19079,7 @@
       ],
       "verifiedDate": "2026-08-08",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names toranproxy.com but states no amount, tier or rate we can read"
       }
@@ -19115,7 +19115,7 @@
       ],
       "verifiedDate": "2026-07-13",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names ampt.dev but states no amount, tier or rate we can read"
       },
@@ -19144,7 +19144,7 @@
       ],
       "verifiedDate": "2026-07-10",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names anvil.works but states no amount, tier or rate we can read"
       },
@@ -19202,7 +19202,7 @@
       ],
       "verifiedDate": "2026-07-15",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names Clever Cloud but states no amount, tier or rate we can read"
       },
@@ -19231,7 +19231,7 @@
       ],
       "verifiedDate": "2026-07-17",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names Choreo but states no amount, tier or rate we can read"
       },
@@ -19260,7 +19260,7 @@
       ],
       "verifiedDate": "2026-07-15",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names codenameone.com but states no amount, tier or rate we can read"
       },
@@ -19283,7 +19283,7 @@
       ],
       "verifiedDate": "2026-07-16",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names Daestro but states no amount, tier or rate we can read"
       },
@@ -19486,7 +19486,7 @@
       ],
       "verifiedDate": "2026-07-12",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names WunderGraph but states no amount, tier or rate we can read"
       },
@@ -19509,9 +19509,9 @@
       ],
       "verifiedDate": "2026-07-15",
       "source_check": {
-        "checked": "2026-08-28",
-        "outcome": "states_no_terms",
-        "detail": "the page names YepCode but states no amount, tier or rate we can read"
+        "checked": "2026-09-02",
+        "outcome": "ok",
+        "detail": "text"
       },
       "product_subtypes": {
         "taxonomy": "Cloud Hosting",
@@ -19622,7 +19622,7 @@
       ],
       "verifiedDate": "2026-07-15",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names connectycube.com but states no amount, tier or rate we can read"
       },
@@ -19645,7 +19645,7 @@
       ],
       "verifiedDate": "2026-07-15",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names ETLR but states no amount, tier or rate we can read"
       },
@@ -19668,7 +19668,7 @@
       ],
       "verifiedDate": "2026-07-11",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names Flutter Flow but states no amount, tier or rate we can read"
       },
@@ -19691,7 +19691,7 @@
       ],
       "verifiedDate": "2026-07-17",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names IFTTT but states no amount, tier or rate we can read"
       },
@@ -19737,7 +19737,7 @@
       ],
       "verifiedDate": "2026-07-15",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names LeanCloud but states no amount, tier or rate we can read"
       },
@@ -19795,7 +19795,7 @@
       ],
       "verifiedDate": "2026-07-14",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names simperium.com but states no amount, tier or rate we can read"
       },
@@ -19874,7 +19874,7 @@
       ],
       "verifiedDate": "2026-08-05",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names manubes but states no amount, tier or rate we can read"
       }
@@ -19908,7 +19908,7 @@
       ],
       "verifiedDate": "2026-08-12",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names outsystems.com but states no amount, tier or rate we can read"
       }
@@ -19942,7 +19942,7 @@
       ],
       "verifiedDate": "2026-08-07",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names UI Bakery but states no amount, tier or rate we can read"
       }
@@ -19960,7 +19960,7 @@
       ],
       "verifiedDate": "2026-07-15",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names Alwaysdata but states no amount, tier or rate we can read"
       },
@@ -20018,7 +20018,7 @@
       ],
       "verifiedDate": "2026-08-12",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names Bubble but states no amount, tier or rate we can read"
       },
@@ -20047,7 +20047,7 @@
       ],
       "verifiedDate": "2026-07-16",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names dAppling Network but states no amount, tier or rate we can read"
       },
@@ -20076,7 +20076,7 @@
       ],
       "verifiedDate": "2026-07-16",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names FreeFlarum but states no amount, tier or rate we can read"
       },
@@ -20140,7 +20140,7 @@
       ],
       "verifiedDate": "2026-07-17",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names MDB GO but states no amount, tier or rate we can read"
       },
@@ -20169,7 +20169,7 @@
       ],
       "verifiedDate": "2026-07-14",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names Neocities but states no amount, tier or rate we can read"
       },
@@ -20390,7 +20390,7 @@
       ],
       "verifiedDate": "2026-07-15",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names surge.sh but states no amount, tier or rate we can read"
       },
@@ -20419,7 +20419,7 @@
       ],
       "verifiedDate": "2026-07-14",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names tilda.cc but states no amount, tier or rate we can read"
       },
@@ -20448,7 +20448,7 @@
       ],
       "verifiedDate": "2026-07-13",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names Versoly but states no amount, tier or rate we can read"
       },
@@ -20477,7 +20477,7 @@
       ],
       "verifiedDate": "2026-08-09",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names 1984.is but states no amount, tier or rate we can read"
       }
@@ -20513,7 +20513,7 @@
       ],
       "verifiedDate": "2026-08-09",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names duckdns.org but states no amount, tier or rate we can read"
       }
@@ -20531,7 +20531,7 @@
       ],
       "verifiedDate": "2026-08-09",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names Dynv6.com but states no amount, tier or rate we can read"
       }
@@ -20585,7 +20585,7 @@
       ],
       "verifiedDate": "2026-08-09",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names LocalCert but states no amount, tier or rate we can read"
       }
@@ -20603,7 +20603,7 @@
       ],
       "verifiedDate": "2026-08-09",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names luadns.com but states no amount, tier or rate we can read"
       }
@@ -20648,7 +20648,7 @@
       ],
       "verifiedDate": "2026-08-12",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names nextdns.io but states no amount, tier or rate we can read"
       }
@@ -20684,7 +20684,7 @@
       ],
       "verifiedDate": "2026-08-05",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names sslip.io but states no amount, tier or rate we can read"
       }
@@ -20774,7 +20774,7 @@
       ],
       "verifiedDate": "2026-08-26",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names DigitalPlat but states no amount, tier or rate we can read"
       }
@@ -20810,7 +20810,7 @@
       ],
       "verifiedDate": "2026-08-09",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "does_not_name_vendor",
         "detail": "the page never names pp.ua and is not served from its domain"
       }
@@ -20844,7 +20844,7 @@
       ],
       "verifiedDate": "2026-08-07",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names C2 Object Storage but states no amount, tier or rate we can read"
       }
@@ -20879,7 +20879,7 @@
       ],
       "verifiedDate": "2026-07-15",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names 8base.com but states no amount, tier or rate we can read"
       },
@@ -20937,7 +20937,7 @@
       ],
       "verifiedDate": "2026-07-15",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names Couchbase Capella but states no amount, tier or rate we can read"
       },
@@ -21029,7 +21029,7 @@
       ],
       "verifiedDate": "2026-07-12",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names SeaTable but states no amount, tier or rate we can read"
       },
@@ -21131,7 +21131,7 @@
       ],
       "verifiedDate": "2026-08-11",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names conveyor.cloud but states no amount, tier or rate we can read"
       }
@@ -21199,7 +21199,7 @@
       ],
       "verifiedDate": "2026-08-11",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names localtunnel but states no amount, tier or rate we can read"
       }
@@ -21250,7 +21250,7 @@
       ],
       "verifiedDate": "2026-08-09",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names Radmin VPN but states no amount, tier or rate we can read"
       }
@@ -21301,7 +21301,7 @@
       ],
       "verifiedDate": "2026-08-17",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names Xirsys but states no amount, tier or rate we can read"
       }
@@ -21335,7 +21335,7 @@
       ],
       "verifiedDate": "2026-07-13",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names acunote.com but states no amount, tier or rate we can read"
       }
@@ -21369,7 +21369,7 @@
       ],
       "verifiedDate": "2026-07-15",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names Backlog but states no amount, tier or rate we can read"
       }
@@ -21488,7 +21488,7 @@
       ],
       "verifiedDate": "2026-07-14",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names Crosswork but states no amount, tier or rate we can read"
       }
@@ -21505,7 +21505,7 @@
       ],
       "verifiedDate": "2026-08-10",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names diagrams.net but states no amount, tier or rate we can read"
       }
@@ -21522,7 +21522,7 @@
       ],
       "verifiedDate": "2026-07-14",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names easyretro.io but states no amount, tier or rate we can read"
       }
@@ -21539,7 +21539,7 @@
       ],
       "verifiedDate": "2026-07-17",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names freedcamp.com but states no amount, tier or rate we can read"
       }
@@ -21573,7 +21573,7 @@
       ],
       "verifiedDate": "2026-08-13",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names gleek.io but states no amount, tier or rate we can read"
       }
@@ -21607,7 +21607,7 @@
       ],
       "verifiedDate": "2026-07-16",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names Hygger but states no amount, tier or rate we can read"
       }
@@ -21624,7 +21624,7 @@
       ],
       "verifiedDate": "2026-08-08",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names Ilograph but states no amount, tier or rate we can read"
       }
@@ -21658,7 +21658,7 @@
       ],
       "verifiedDate": "2026-07-15",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names kanbanflow.com but states no amount, tier or rate we can read"
       }
@@ -21675,7 +21675,7 @@
       ],
       "verifiedDate": "2026-07-16",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names kanbantool.com but states no amount, tier or rate we can read"
       }
@@ -21692,7 +21692,7 @@
       ],
       "verifiedDate": "2026-08-09",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names Kumu.io but states no amount, tier or rate we can read"
       }
@@ -21726,7 +21726,7 @@
       ],
       "verifiedDate": "2026-08-11",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names Lucidchart but states no amount, tier or rate we can read"
       }
@@ -21743,7 +21743,7 @@
       ],
       "verifiedDate": "2026-07-14",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names MeisterTask but states no amount, tier or rate we can read"
       }
@@ -21760,7 +21760,7 @@
       ],
       "verifiedDate": "2026-07-13",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names nTask but states no amount, tier or rate we can read"
       }
@@ -21777,7 +21777,7 @@
       ],
       "verifiedDate": "2026-07-17",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names Plane but states no amount, tier or rate we can read"
       }
@@ -21794,7 +21794,7 @@
       ],
       "verifiedDate": "2026-07-15",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names planitpoker.com but states no amount, tier or rate we can read"
       }
@@ -21828,7 +21828,7 @@
       ],
       "verifiedDate": "2026-07-17",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names Pulse.red but states no amount, tier or rate we can read"
       }
@@ -21896,7 +21896,7 @@
       ],
       "verifiedDate": "2026-07-21",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names taiga.io but states no amount, tier or rate we can read"
       }
@@ -21947,7 +21947,7 @@
       ],
       "verifiedDate": "2026-08-14",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names teamwork.com but states no amount, tier or rate we can read"
       }
@@ -21981,7 +21981,7 @@
       ],
       "verifiedDate": "2026-07-17",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names Tenzu but states no amount, tier or rate we can read"
       }
@@ -21998,7 +21998,7 @@
       ],
       "verifiedDate": "2026-07-16",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names titanapps.io but states no amount, tier or rate we can read"
       }
@@ -22032,7 +22032,7 @@
       ],
       "verifiedDate": "2026-07-16",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names Tweek but states no amount, tier or rate we can read"
       }
@@ -22049,7 +22049,7 @@
       ],
       "verifiedDate": "2026-07-16",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names Yodiz but states no amount, tier or rate we can read"
       }
@@ -22066,7 +22066,7 @@
       ],
       "verifiedDate": "2026-07-18",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names zenhub.com but states no amount, tier or rate we can read"
       }
@@ -22083,7 +22083,7 @@
       ],
       "verifiedDate": "2026-07-16",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names Zube but states no amount, tier or rate we can read"
       }
@@ -22137,7 +22137,7 @@
       ],
       "verifiedDate": "2026-07-16",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names Dropshare but states no amount, tier or rate we can read"
       }
@@ -22155,7 +22155,7 @@
       ],
       "verifiedDate": "2026-07-17",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names embed.ly but states no amount, tier or rate we can read"
       }
@@ -22245,7 +22245,7 @@
       ],
       "verifiedDate": "2026-07-17",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names GoFile.io but states no amount, tier or rate we can read"
       }
@@ -22263,7 +22263,7 @@
       ],
       "verifiedDate": "2026-07-15",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names gumlet.com but states no amount, tier or rate we can read"
       }
@@ -22389,9 +22389,9 @@
       ],
       "verifiedDate": "2026-07-13",
       "source_check": {
-        "checked": "2026-08-28",
-        "outcome": "states_no_terms",
-        "detail": "the page names MConverter but states no amount, tier or rate we can read"
+        "checked": "2026-09-02",
+        "outcome": "ok",
+        "detail": "text"
       }
     },
     {
@@ -22407,7 +22407,7 @@
       ],
       "verifiedDate": "2026-07-17",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names nitropack.io but states no amount, tier or rate we can read"
       }
@@ -22461,7 +22461,7 @@
       ],
       "verifiedDate": "2026-07-17",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names We.Team but states no amount, tier or rate we can read"
       }
@@ -22524,7 +22524,7 @@
       ],
       "verifiedDate": "2026-07-19",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names plot.ly but states no amount, tier or rate we can read"
       }
@@ -22586,7 +22586,7 @@
       ],
       "verifiedDate": "2026-07-19",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names QRME.SH but states no amount, tier or rate we can read"
       }
@@ -22622,7 +22622,7 @@
       ],
       "verifiedDate": "2026-07-16",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names QuickChart but states no amount, tier or rate we can read"
       }
@@ -22640,7 +22640,7 @@
       ],
       "verifiedDate": "2026-07-17",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names resmush.it but states no amount, tier or rate we can read"
       }
@@ -22694,7 +22694,7 @@
       ],
       "verifiedDate": "2026-07-18",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names sync.com but states no amount, tier or rate we can read"
       }
@@ -22712,7 +22712,7 @@
       ],
       "verifiedDate": "2026-07-20",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names tinypng.com but states no amount, tier or rate we can read"
       }
@@ -22730,7 +22730,7 @@
       ],
       "verifiedDate": "2026-07-14",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names transloadit.com but states no amount, tier or rate we can read"
       }
@@ -22748,7 +22748,7 @@
       ],
       "verifiedDate": "2026-07-18",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names twicpics.com but states no amount, tier or rate we can read"
       }
@@ -22766,7 +22766,7 @@
       ],
       "verifiedDate": "2026-07-17",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names VaocherApp QR Code Generator but states no amount, tier or rate we can read"
       }
@@ -22785,7 +22785,7 @@
       ],
       "verifiedDate": "2026-07-19",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names odrive but states no amount, tier or rate we can read"
       }
@@ -22803,7 +22803,7 @@
       ],
       "verifiedDate": "2026-07-15",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names AllTheFreeStock but states no amount, tier or rate we can read"
       }
@@ -22821,7 +22821,7 @@
       ],
       "verifiedDate": "2026-07-17",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names Ant Design Landing Page but states no amount, tier or rate we can read"
       }
@@ -22839,7 +22839,7 @@
       ],
       "verifiedDate": "2026-07-17",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names Calendar Icons Generator but states no amount, tier or rate we can read"
       }
@@ -22857,7 +22857,7 @@
       ],
       "verifiedDate": "2026-07-17",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names Carousel Hero but states no amount, tier or rate we can read"
       }
@@ -22893,7 +22893,7 @@
       ],
       "verifiedDate": "2026-07-16",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "does_not_name_vendor",
         "detail": "the page never names clevebrush.com and is not served from its domain"
       }
@@ -22911,7 +22911,7 @@
       ],
       "verifiedDate": "2026-07-05",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names cloudconvert.com but states no amount, tier or rate we can read"
       }
@@ -22965,7 +22965,7 @@
       ],
       "verifiedDate": "2026-07-15",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names CodeMyUI but states no amount, tier or rate we can read"
       }
@@ -22983,7 +22983,7 @@
       ],
       "verifiedDate": "2026-07-19",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names ColorKit but states no amount, tier or rate we can read"
       }
@@ -23001,9 +23001,9 @@
       ],
       "verifiedDate": "2026-04-12",
       "source_check": {
-        "checked": "2026-08-28",
-        "outcome": "states_no_terms",
-        "detail": "the page names coolors but states no amount, tier or rate we can read"
+        "checked": "2026-09-02",
+        "outcome": "ok",
+        "detail": "text"
       }
     },
     {
@@ -23019,7 +23019,7 @@
       ],
       "verifiedDate": "2026-07-19",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names css-gradient.com but states no amount, tier or rate we can read"
       }
@@ -23055,7 +23055,7 @@
       ],
       "verifiedDate": "2026-07-21",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names DaisyUI but states no amount, tier or rate we can read"
       }
@@ -23127,7 +23127,7 @@
       ],
       "verifiedDate": "2026-07-18",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names framer.com but states no amount, tier or rate we can read"
       }
@@ -23145,7 +23145,7 @@
       ],
       "verifiedDate": "2026-07-16",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names Glyphs but states no amount, tier or rate we can read"
       }
@@ -23163,7 +23163,7 @@
       ],
       "verifiedDate": "2026-07-17",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names Gradientos but states no amount, tier or rate we can read"
       }
@@ -23199,7 +23199,7 @@
       ],
       "verifiedDate": "2026-07-18",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names haikei.app but states no amount, tier or rate we can read"
       }
@@ -23217,7 +23217,7 @@
       ],
       "verifiedDate": "2026-07-18",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names hypercolor.dev but states no amount, tier or rate we can read"
       }
@@ -23235,7 +23235,7 @@
       ],
       "verifiedDate": "2026-07-20",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names HyperUI but states no amount, tier or rate we can read"
       }
@@ -23271,7 +23271,7 @@
       ],
       "verifiedDate": "2026-07-20",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names iconify.design but states no amount, tier or rate we can read"
       }
@@ -23307,7 +23307,7 @@
       ],
       "verifiedDate": "2026-07-18",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names Image BG Blurer but states no amount, tier or rate we can read"
       }
@@ -23343,7 +23343,7 @@
       ],
       "verifiedDate": "2026-07-19",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names lensdump.com but states no amount, tier or rate we can read"
       }
@@ -23379,7 +23379,7 @@
       ],
       "verifiedDate": "2026-07-17",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names Lorem Picsum but states no amount, tier or rate we can read"
       }
@@ -23415,7 +23415,7 @@
       ],
       "verifiedDate": "2026-07-19",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names Lucide but states no amount, tier or rate we can read"
       }
@@ -23433,7 +23433,7 @@
       ],
       "verifiedDate": "2026-07-16",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names MagicPattern but states no amount, tier or rate we can read"
       }
@@ -23451,7 +23451,7 @@
       ],
       "verifiedDate": "2026-07-19",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names marvelapp.com but states no amount, tier or rate we can read"
       }
@@ -23469,7 +23469,7 @@
       ],
       "verifiedDate": "2026-07-20",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names Mastershot but states no amount, tier or rate we can read"
       }
@@ -23505,7 +23505,7 @@
       ],
       "verifiedDate": "2026-07-18",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names Mindmup.com but states no amount, tier or rate we can read"
       }
@@ -23541,7 +23541,7 @@
       ],
       "verifiedDate": "2026-07-21",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names mockupmark.com but states no amount, tier or rate we can read"
       }
@@ -23559,7 +23559,7 @@
       ],
       "verifiedDate": "2026-07-19",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names Mossaik but states no amount, tier or rate we can read"
       }
@@ -23577,7 +23577,7 @@
       ],
       "verifiedDate": "2026-07-19",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names Nappy but states no amount, tier or rate we can read"
       }
@@ -23631,7 +23631,7 @@
       ],
       "verifiedDate": "2026-07-17",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names Octopus.do but states no amount, tier or rate we can read"
       }
@@ -23649,7 +23649,7 @@
       ],
       "verifiedDate": "2026-07-21",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names OKLCH but states no amount, tier or rate we can read"
       }
@@ -23667,7 +23667,7 @@
       ],
       "verifiedDate": "2026-07-20",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names okso.app but states no amount, tier or rate we can read"
       }
@@ -23721,7 +23721,7 @@
       ],
       "verifiedDate": "2026-07-18",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names PNG to WebP Converter but states no amount, tier or rate we can read"
       }
@@ -23739,7 +23739,7 @@
       ],
       "verifiedDate": "2026-08-25",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names Pravatar but states no amount, tier or rate we can read"
       }
@@ -23757,7 +23757,7 @@
       ],
       "verifiedDate": "2026-07-17",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names Proto.io but states no amount, tier or rate we can read"
       }
@@ -23775,7 +23775,7 @@
       ],
       "verifiedDate": "2026-07-20",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names Quant Ux but states no amount, tier or rate we can read"
       }
@@ -23793,7 +23793,7 @@
       ],
       "verifiedDate": "2026-07-19",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names resizeappicon.com but states no amount, tier or rate we can read"
       }
@@ -23811,7 +23811,7 @@
       ],
       "verifiedDate": "2026-07-18",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names Responsively App but states no amount, tier or rate we can read"
       }
@@ -23829,7 +23829,7 @@
       ],
       "verifiedDate": "2026-07-19",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names Rive but states no amount, tier or rate we can read"
       }
@@ -23901,7 +23901,7 @@
       ],
       "verifiedDate": "2026-04-05",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names smartmockups.com but states no amount, tier or rate we can read"
       }
@@ -23919,7 +23919,7 @@
       ],
       "verifiedDate": "2026-07-17",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names Shadcn Space but states no amount, tier or rate we can read"
       }
@@ -23955,7 +23955,7 @@
       ],
       "verifiedDate": "2026-07-22",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names storyset.com but states no amount, tier or rate we can read"
       }
@@ -23991,7 +23991,7 @@
       ],
       "verifiedDate": "2026-07-21",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names SVG Converter but states no amount, tier or rate we can read"
       }
@@ -24027,7 +24027,7 @@
       ],
       "verifiedDate": "2026-07-19",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names Tailark but states no amount, tier or rate we can read"
       }
@@ -24045,7 +24045,7 @@
       ],
       "verifiedDate": "2026-07-23",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names Tailcolors but states no amount, tier or rate we can read"
       }
@@ -24063,7 +24063,7 @@
       ],
       "verifiedDate": "2026-07-23",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names Tailkits but states no amount, tier or rate we can read"
       }
@@ -24099,7 +24099,7 @@
       ],
       "verifiedDate": "2026-07-18",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names TW Elements but states no amount, tier or rate we can read"
       }
@@ -24117,7 +24117,7 @@
       ],
       "verifiedDate": "2026-07-20",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names tweakcn but states no amount, tier or rate we can read"
       }
@@ -24153,7 +24153,7 @@
       ],
       "verifiedDate": "2026-07-19",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names unDraw but states no amount, tier or rate we can read"
       }
@@ -24171,7 +24171,7 @@
       ],
       "verifiedDate": "2026-07-19",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names Unicorn Platform but states no amount, tier or rate we can read"
       }
@@ -24225,7 +24225,7 @@
       ],
       "verifiedDate": "2026-07-24",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names vector.express but states no amount, tier or rate we can read"
       }
@@ -24243,7 +24243,7 @@
       ],
       "verifiedDate": "2026-07-21",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names vectr.com but states no amount, tier or rate we can read"
       }
@@ -24261,7 +24261,7 @@
       ],
       "verifiedDate": "2026-07-18",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names Vertopal but states no amount, tier or rate we can read"
       }
@@ -24279,7 +24279,7 @@
       ],
       "verifiedDate": "2026-07-22",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names Volume but states no amount, tier or rate we can read"
       }
@@ -24333,7 +24333,7 @@
       ],
       "verifiedDate": "2026-07-22",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names Webstudio but states no amount, tier or rate we can read"
       }
@@ -24351,7 +24351,7 @@
       ],
       "verifiedDate": "2026-07-22",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names whimsical.com but states no amount, tier or rate we can read"
       }
@@ -24369,7 +24369,7 @@
       ],
       "verifiedDate": "2026-08-18",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names Zeplin but states no amount, tier or rate we can read"
       }
@@ -24387,7 +24387,7 @@
       ],
       "verifiedDate": "2026-08-13",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names Clockwork Micro but states no amount, tier or rate we can read"
       }
@@ -24513,7 +24513,7 @@
       ],
       "verifiedDate": "2026-08-09",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names maps.stamen.com but states no amount, tier or rate we can read"
       }
@@ -24531,7 +24531,7 @@
       ],
       "verifiedDate": "2026-08-12",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names maptiler.com but states no amount, tier or rate we can read"
       }
@@ -24585,7 +24585,7 @@
       ],
       "verifiedDate": "2026-08-09",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names osmnames but states no amount, tier or rate we can read"
       }
@@ -24621,7 +24621,7 @@
       ],
       "verifiedDate": "2026-08-08",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names stadiamaps.com but states no amount, tier or rate we can read"
       }
@@ -24638,7 +24638,7 @@
       ],
       "verifiedDate": "2026-07-20",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names build.opensuse.org but states no amount, tier or rate we can read"
       }
@@ -24655,7 +24655,7 @@
       ],
       "verifiedDate": "2026-07-22",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names copr.fedorainfracloud.org but states no amount, tier or rate we can read"
       }
@@ -24672,7 +24672,7 @@
       ],
       "verifiedDate": "2026-08-09",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names Android Studio but states no amount, tier or rate we can read"
       }
@@ -24689,7 +24689,7 @@
       ],
       "verifiedDate": "2026-08-09",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names AndroidIDE but states no amount, tier or rate we can read"
       }
@@ -24706,7 +24706,7 @@
       ],
       "verifiedDate": "2026-08-11",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names Apache Netbeans but states no amount, tier or rate we can read"
       }
@@ -24723,7 +24723,7 @@
       ],
       "verifiedDate": "2026-08-14",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names apiary.io but states no amount, tier or rate we can read"
       }
@@ -24740,7 +24740,7 @@
       ],
       "verifiedDate": "2026-08-10",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names BBEdit but states no amount, tier or rate we can read"
       }
@@ -24774,7 +24774,7 @@
       ],
       "verifiedDate": "2026-08-12",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names BlueJ but states no amount, tier or rate we can read"
       }
@@ -24808,7 +24808,7 @@
       ],
       "verifiedDate": "2026-08-10",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names Brackets but states no amount, tier or rate we can read"
       }
@@ -24825,7 +24825,7 @@
       ],
       "verifiedDate": "2026-08-08",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names cacher.io but states no amount, tier or rate we can read"
       }
@@ -24859,7 +24859,7 @@
       ],
       "verifiedDate": "2026-08-08",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names code.cs50.io but states no amount, tier or rate we can read"
       }
@@ -24876,7 +24876,7 @@
       ],
       "verifiedDate": "2026-08-10",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names Code::Blocks but states no amount, tier or rate we can read"
       }
@@ -24927,7 +24927,7 @@
       ],
       "verifiedDate": "2026-08-10",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names Components.studio but states no amount, tier or rate we can read"
       }
@@ -24944,7 +24944,7 @@
       ],
       "verifiedDate": "2026-08-10",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names Eclipse Che but states no amount, tier or rate we can read"
       }
@@ -24961,7 +24961,7 @@
       ],
       "verifiedDate": "2026-08-09",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names ForgeCode but states no amount, tier or rate we can read"
       }
@@ -24978,7 +24978,7 @@
       ],
       "verifiedDate": "2026-08-08",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names GetVM but states no amount, tier or rate we can read"
       }
@@ -24995,7 +24995,7 @@
       ],
       "verifiedDate": "2026-08-12",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names JDoodle but states no amount, tier or rate we can read"
       }
@@ -25012,7 +25012,7 @@
       ],
       "verifiedDate": "2026-08-16",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names MarsCode but states no amount, tier or rate we can read"
       }
@@ -25063,7 +25063,7 @@
       ],
       "verifiedDate": "2026-08-09",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names OneCompiler but states no amount, tier or rate we can read"
       }
@@ -25097,7 +25097,7 @@
       ],
       "verifiedDate": "2026-08-09",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names PHPSandbox but states no amount, tier or rate we can read"
       }
@@ -25132,7 +25132,7 @@
       ],
       "verifiedDate": "2026-08-11",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names SoloLearn but states no amount, tier or rate we can read"
       }
@@ -25149,7 +25149,7 @@
       ],
       "verifiedDate": "2026-08-14",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names stackblitz.com but states no amount, tier or rate we can read"
       }
@@ -25166,7 +25166,7 @@
       ],
       "verifiedDate": "2026-08-12",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names Sublime Text but states no amount, tier or rate we can read"
       }
@@ -25183,7 +25183,7 @@
       ],
       "verifiedDate": "2026-08-10",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names Visual Studio Code but states no amount, tier or rate we can read"
       }
@@ -25217,7 +25217,7 @@
       ],
       "verifiedDate": "2026-08-13",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names VSCodium but states no amount, tier or rate we can read"
       }
@@ -25234,7 +25234,7 @@
       ],
       "verifiedDate": "2026-08-16",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names wakatime.com but states no amount, tier or rate we can read"
       }
@@ -25251,7 +25251,7 @@
       ],
       "verifiedDate": "2026-08-11",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names Wave Terminal but states no amount, tier or rate we can read"
       }
@@ -25268,7 +25268,7 @@
       ],
       "verifiedDate": "2026-08-10",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names WebComponents.dev but states no amount, tier or rate we can read"
       }
@@ -25285,9 +25285,9 @@
       ],
       "verifiedDate": "2026-08-12",
       "source_check": {
-        "checked": "2026-08-28",
-        "outcome": "states_no_terms",
-        "detail": "the page names Zed but states no amount, tier or rate we can read"
+        "checked": "2026-09-02",
+        "outcome": "ok",
+        "detail": "text"
       }
     },
     {
@@ -25339,7 +25339,7 @@
       ],
       "verifiedDate": "2026-07-21",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names Avo but states no amount, tier or rate we can read"
       }
@@ -25393,7 +25393,7 @@
       ],
       "verifiedDate": "2026-08-23",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names Clicky but states no amount, tier or rate we can read"
       }
@@ -25411,7 +25411,7 @@
       ],
       "verifiedDate": "2026-07-20",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names counter.dev but states no amount, tier or rate we can read"
       }
@@ -25501,7 +25501,7 @@
       ],
       "verifiedDate": "2026-07-20",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names GoatCounter but states no amount, tier or rate we can read"
       }
@@ -25555,7 +25555,7 @@
       ],
       "verifiedDate": "2026-07-22",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names Hightouch but states no amount, tier or rate we can read"
       }
@@ -25591,7 +25591,7 @@
       ],
       "verifiedDate": "2026-07-22",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names LogSpot but states no amount, tier or rate we can read"
       }
@@ -25609,7 +25609,7 @@
       ],
       "verifiedDate": "2026-07-26",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names MetricsWave but states no amount, tier or rate we can read"
       }
@@ -25627,7 +25627,7 @@
       ],
       "verifiedDate": "2026-07-21",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names Moesif but states no amount, tier or rate we can read"
       }
@@ -25645,7 +25645,7 @@
       ],
       "verifiedDate": "2026-07-21",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names Repohistory but states no amount, tier or rate we can read"
       }
@@ -25663,7 +25663,7 @@
       ],
       "verifiedDate": "2026-07-20",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names Row Zero but states no amount, tier or rate we can read"
       }
@@ -25699,7 +25699,7 @@
       ],
       "verifiedDate": "2026-07-21",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names StatCounter but states no amount, tier or rate we can read"
       }
@@ -25735,9 +25735,9 @@
       ],
       "verifiedDate": "2026-07-21",
       "source_check": {
-        "checked": "2026-08-28",
-        "outcome": "states_no_terms",
-        "detail": "the page names Trackingplan but states no amount, tier or rate we can read"
+        "checked": "2026-09-02",
+        "outcome": "ok",
+        "detail": "text"
       }
     },
     {
@@ -25771,7 +25771,7 @@
       ],
       "verifiedDate": "2026-07-20",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names Lyssna but states no amount, tier or rate we can read"
       }
@@ -25789,7 +25789,7 @@
       ],
       "verifiedDate": "2026-07-21",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names FullStory.com but states no amount, tier or rate we can read"
       }
@@ -25879,7 +25879,7 @@
       ],
       "verifiedDate": "2026-07-21",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names OpenReplay.com but states no amount, tier or rate we can read"
       }
@@ -25915,9 +25915,9 @@
       ],
       "verifiedDate": "2026-07-21",
       "source_check": {
-        "checked": "2026-08-28",
-        "outcome": "states_no_terms",
-        "detail": "the page names UXtweak.com but states no amount, tier or rate we can read"
+        "checked": "2026-09-02",
+        "outcome": "ok",
+        "detail": "text"
       }
     },
     {
@@ -26075,7 +26075,7 @@
       ],
       "verifiedDate": "2026-08-13",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names Moesif API Monetization but states no amount, tier or rate we can read"
       }
@@ -26093,7 +26093,7 @@
       ],
       "verifiedDate": "2026-08-12",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names ParityVend but states no amount, tier or rate we can read"
       }
@@ -26165,7 +26165,7 @@
       ],
       "verifiedDate": "2026-08-16",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names Container Registry Service but states no amount, tier or rate we can read"
       }
@@ -26183,7 +26183,7 @@
       ],
       "verifiedDate": "2026-07-22",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names Play with Docker but states no amount, tier or rate we can read"
       }
@@ -26218,7 +26218,7 @@
       ],
       "verifiedDate": "2026-08-11",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names GraphComment but states no amount, tier or rate we can read"
       }
@@ -26235,7 +26235,7 @@
       ],
       "verifiedDate": "2026-08-13",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names IntenseDebate but states no amount, tier or rate we can read"
       }
@@ -26269,7 +26269,7 @@
       ],
       "verifiedDate": "2026-08-11",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names Utterances but states no amount, tier or rate we can read"
       }
@@ -26341,7 +26341,7 @@
       ],
       "verifiedDate": "2026-08-12",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names screenshotmachine.com but states no amount, tier or rate we can read"
       }
@@ -26395,7 +26395,7 @@
       ],
       "verifiedDate": "2026-08-11",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names thumbnail.ws but states no amount, tier or rate we can read"
       }
@@ -26412,7 +26412,7 @@
       ],
       "verifiedDate": "2026-08-11",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names FlutLab but states no amount, tier or rate we can read"
       }
@@ -26429,7 +26429,7 @@
       ],
       "verifiedDate": "2026-07-19",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names Bearer but states no amount, tier or rate we can read"
       }
@@ -26497,7 +26497,7 @@
       ],
       "verifiedDate": "2026-07-22",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names Base64 decoder/encoder but states no amount, tier or rate we can read"
       }
@@ -26514,7 +26514,7 @@
       ],
       "verifiedDate": "2026-07-21",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names BinShare.net but states no amount, tier or rate we can read"
       }
@@ -26531,7 +26531,7 @@
       ],
       "verifiedDate": "2026-07-21",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names Blynk but states no amount, tier or rate we can read"
       }
@@ -26548,7 +26548,7 @@
       ],
       "verifiedDate": "2026-07-24",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names Bricks Note Calculator but states no amount, tier or rate we can read"
       }
@@ -26565,7 +26565,7 @@
       ],
       "verifiedDate": "2026-07-24",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names Carbon.now.sh but states no amount, tier or rate we can read"
       }
@@ -26599,7 +26599,7 @@
       ],
       "verifiedDate": "2026-07-20",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names Codepng but states no amount, tier or rate we can read"
       }
@@ -26616,7 +26616,7 @@
       ],
       "verifiedDate": "2026-07-20",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names CodeToImage but states no amount, tier or rate we can read"
       }
@@ -26650,7 +26650,7 @@
       ],
       "verifiedDate": "2026-07-21",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names datelist.io but states no amount, tier or rate we can read"
       }
@@ -26684,7 +26684,7 @@
       ],
       "verifiedDate": "2026-07-21",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names Exif Editor but states no amount, tier or rate we can read"
       }
@@ -26701,7 +26701,7 @@
       ],
       "verifiedDate": "2026-07-21",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names Format Express but states no amount, tier or rate we can read"
       }
@@ -26718,7 +26718,7 @@
       ],
       "verifiedDate": "2026-07-23",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names Hook Relay but states no amount, tier or rate we can read"
       }
@@ -26752,7 +26752,7 @@
       ],
       "verifiedDate": "2026-07-23",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names newreleases.io but states no amount, tier or rate we can read"
       }
@@ -26769,7 +26769,7 @@
       ],
       "verifiedDate": "2026-07-21",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names OnlineExifViewer but states no amount, tier or rate we can read"
       }
@@ -26820,7 +26820,7 @@
       ],
       "verifiedDate": "2026-08-16",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names QuickType.io but states no amount, tier or rate we can read"
       }
@@ -26854,7 +26854,7 @@
       ],
       "verifiedDate": "2026-07-27",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names ray.so but states no amount, tier or rate we can read"
       }
@@ -26871,7 +26871,7 @@
       ],
       "verifiedDate": "2026-07-24",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names redirect.pizza but states no amount, tier or rate we can read"
       }
@@ -26888,7 +26888,7 @@
       ],
       "verifiedDate": "2026-07-20",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names redirection.io but states no amount, tier or rate we can read"
       }
@@ -26939,7 +26939,7 @@
       ],
       "verifiedDate": "2026-07-21",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names Smartcar API but states no amount, tier or rate we can read"
       }
@@ -26990,7 +26990,7 @@
       ],
       "verifiedDate": "2026-07-22",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names superfeedr.com but states no amount, tier or rate we can read"
       }
@@ -27024,7 +27024,7 @@
       ],
       "verifiedDate": "2026-07-21",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names UUID Generator but states no amount, tier or rate we can read"
       }
@@ -27058,7 +27058,7 @@
       ],
       "verifiedDate": "2026-07-21",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names videoinu but states no amount, tier or rate we can read"
       }
@@ -27092,7 +27092,7 @@
       ],
       "verifiedDate": "2026-07-25",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names Webacus but states no amount, tier or rate we can read"
       }
@@ -27126,7 +27126,7 @@
       ],
       "verifiedDate": "2026-07-25",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names Dadroit V Web but states no amount, tier or rate we can read"
       }
@@ -27761,7 +27761,7 @@
         "program": "Achieved Startup Deal"
       },
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "does_not_name_vendor",
         "detail": "the page never names Achieved and is not served from its domain"
       }
@@ -27786,7 +27786,7 @@
         "program": "Aircall Startup Deal"
       },
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "does_not_name_vendor",
         "detail": "the page never names Aircall and is not served from its domain"
       }
@@ -27812,7 +27812,7 @@
         "program": "Amazon AWS Startup Deal"
       },
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "does_not_name_vendor",
         "detail": "the page never names Amazon AWS and is not served from its domain"
       }
@@ -27837,7 +27837,7 @@
         "program": "Axonaut Startup Deal"
       },
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "does_not_name_vendor",
         "detail": "the page never names Axonaut and is not served from its domain"
       }
@@ -27862,7 +27862,7 @@
         "program": "Azameo Startup Deal"
       },
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "does_not_name_vendor",
         "detail": "the page never names Azameo and is not served from its domain"
       }
@@ -27887,7 +27887,7 @@
         "program": "Batch Startup Deal"
       },
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "does_not_name_vendor",
         "detail": "the page never names Batch and is not served from its domain"
       }
@@ -27937,7 +27937,7 @@
         "program": "Botnation Startup Deal"
       },
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "does_not_name_vendor",
         "detail": "the page never names Botnation and is not served from its domain"
       }
@@ -27962,7 +27962,7 @@
         "program": "CaptainData Startup Deal"
       },
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "does_not_name_vendor",
         "detail": "the page never names CaptainData and is not served from its domain"
       }
@@ -27987,7 +27987,7 @@
         "program": "Carta Startup Deal"
       },
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "does_not_name_vendor",
         "detail": "the page never names Carta and is not served from its domain"
       }
@@ -28012,7 +28012,7 @@
         "program": "Caviar Startup Deal"
       },
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "does_not_name_vendor",
         "detail": "the page never names Caviar and is not served from its domain"
       }
@@ -28037,7 +28037,7 @@
         "program": "Clear Channel Outdoor Startup Deal"
       },
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "does_not_name_vendor",
         "detail": "the page never names Clear Channel Outdoor and is not served from its domain"
       }
@@ -28063,7 +28063,7 @@
         "program": "CloudImage Startup Deal"
       },
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "does_not_name_vendor",
         "detail": "the page never names CloudImage and is not served from its domain"
       }
@@ -28089,7 +28089,7 @@
         "program": "Cloudtalk Startup Deal"
       },
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "does_not_name_vendor",
         "detail": "the page never names Cloudtalk and is not served from its domain"
       }
@@ -28115,7 +28115,7 @@
         "program": "Cloudways Startup Deal"
       },
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "does_not_name_vendor",
         "detail": "the page never names Cloudways and is not served from its domain"
       }
@@ -28140,7 +28140,7 @@
         "program": "ColdCRM Startup Deal"
       },
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "does_not_name_vendor",
         "detail": "the page never names ColdCRM and is not served from its domain"
       }
@@ -28165,7 +28165,7 @@
         "program": "Crowdfire Startup Deal"
       },
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "does_not_name_vendor",
         "detail": "the page never names Crowdfire and is not served from its domain"
       }
@@ -28190,7 +28190,7 @@
         "program": "Dareboost Startup Deal"
       },
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "does_not_name_vendor",
         "detail": "the page never names Dareboost and is not served from its domain"
       }
@@ -28215,7 +28215,7 @@
         "program": "Datananas Startup Deal"
       },
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "does_not_name_vendor",
         "detail": "the page never names Datananas and is not served from its domain"
       }
@@ -28240,7 +28240,7 @@
         "program": "Docsend Startup Deal"
       },
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "does_not_name_vendor",
         "detail": "the page never names Docsend and is not served from its domain"
       }
@@ -28265,7 +28265,7 @@
         "program": "E-Goi Startup Deal"
       },
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "does_not_name_vendor",
         "detail": "the page never names E-Goi and is not served from its domain"
       }
@@ -28291,7 +28291,7 @@
         "program": "Experian Startup Deal"
       },
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "does_not_name_vendor",
         "detail": "the page never names Experian and is not served from its domain"
       }
@@ -28316,7 +28316,7 @@
         "program": "findmassleads Startup Deal"
       },
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "does_not_name_vendor",
         "detail": "the page never names findmassleads and is not served from its domain"
       }
@@ -28341,7 +28341,7 @@
         "program": "Forter Startup Deal"
       },
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "does_not_name_vendor",
         "detail": "the page never names Forter and is not served from its domain"
       }
@@ -28366,7 +28366,7 @@
         "program": "Freebe Startup Deal"
       },
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "does_not_name_vendor",
         "detail": "the page never names Freebe and is not served from its domain"
       }
@@ -28391,7 +28391,7 @@
         "program": "Freshchat Startup Deal"
       },
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "does_not_name_vendor",
         "detail": "the page never names Freshchat and is not served from its domain"
       }
@@ -28416,7 +28416,7 @@
         "program": "Freshdesk Startup Deal"
       },
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "does_not_name_vendor",
         "detail": "the page never names Freshdesk and is not served from its domain"
       }
@@ -28441,7 +28441,7 @@
         "program": "Freshmarketer Startup Deal"
       },
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "does_not_name_vendor",
         "detail": "the page never names Freshmarketer and is not served from its domain"
       }
@@ -28466,7 +28466,7 @@
         "program": "Freshsales Startup Deal"
       },
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "does_not_name_vendor",
         "detail": "the page never names Freshsales and is not served from its domain"
       }
@@ -28491,7 +28491,7 @@
         "program": "Front Startup Deal"
       },
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "does_not_name_vendor",
         "detail": "the page never names Front and is not served from its domain"
       }
@@ -28516,7 +28516,7 @@
         "program": "GoCardLess Startup Deal"
       },
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "does_not_name_vendor",
         "detail": "the page never names GoCardLess and is not served from its domain"
       }
@@ -28541,7 +28541,7 @@
         "program": "GOOGLE ADS Startup Deal"
       },
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "does_not_name_vendor",
         "detail": "the page never names GOOGLE ADS and is not served from its domain"
       }
@@ -28566,7 +28566,7 @@
         "program": "Gorgias Startup Deal"
       },
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "does_not_name_vendor",
         "detail": "the page never names Gorgias and is not served from its domain"
       }
@@ -28591,7 +28591,7 @@
         "program": "Guideline 401(k) Startup Deal"
       },
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "does_not_name_vendor",
         "detail": "the page never names Guideline 401(k) and is not served from its domain"
       }
@@ -28616,7 +28616,7 @@
         "program": "Harvestr Startup Deal"
       },
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "does_not_name_vendor",
         "detail": "the page never names Harvestr and is not served from its domain"
       }
@@ -28641,7 +28641,7 @@
         "program": "Instacart Startup Deal"
       },
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "does_not_name_vendor",
         "detail": "the page never names Instacart and is not served from its domain"
       }
@@ -28666,7 +28666,7 @@
         "program": "Intercom Startup Deal"
       },
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "does_not_name_vendor",
         "detail": "the page never names Intercom and is not served from its domain"
       }
@@ -28691,7 +28691,7 @@
         "program": "InVision Startup Deal"
       },
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "does_not_name_vendor",
         "detail": "the page never names InVision and is not served from its domain"
       }
@@ -28716,7 +28716,7 @@
         "program": "Kaspr Startup Deal"
       },
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "does_not_name_vendor",
         "detail": "the page never names Kaspr and is not served from its domain"
       }
@@ -28741,7 +28741,7 @@
         "program": "Klaviyo Startup Deal"
       },
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "does_not_name_vendor",
         "detail": "the page never names Klaviyo and is not served from its domain"
       }
@@ -28766,7 +28766,7 @@
         "program": "Knotel Startup Deal"
       },
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "does_not_name_vendor",
         "detail": "the page never names Knotel and is not served from its domain"
       }
@@ -28791,7 +28791,7 @@
         "program": "La Fabrique Juridique Startup Deal"
       },
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "does_not_name_vendor",
         "detail": "the page never names La Fabrique Juridique and is not served from its domain"
       }
@@ -28816,7 +28816,7 @@
         "program": "Legalstart Startup Deal"
       },
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "does_not_name_vendor",
         "detail": "the page never names Legalstart and is not served from its domain"
       }
@@ -28841,7 +28841,7 @@
         "program": "Libeo Startup Deal"
       },
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "does_not_name_vendor",
         "detail": "the page never names Libeo and is not served from its domain"
       }
@@ -28866,7 +28866,7 @@
         "program": "Mention Startup Deal"
       },
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "does_not_name_vendor",
         "detail": "the page never names Mention and is not served from its domain"
       }
@@ -28901,7 +28901,7 @@
         "notes": "Referee must run M10+ cluster for 30+ days."
       },
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "does_not_name_vendor",
         "detail": "the page never names MongoDB and is not served from its domain"
       }
@@ -28926,7 +28926,7 @@
         "program": "Ninja Outreach Startup Deal"
       },
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "does_not_name_vendor",
         "detail": "the page never names Ninja Outreach and is not served from its domain"
       }
@@ -28951,7 +28951,7 @@
         "program": "noCRM Startup Deal"
       },
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "does_not_name_vendor",
         "detail": "the page never names noCRM and is not served from its domain"
       }
@@ -28976,7 +28976,7 @@
         "program": "PayFit Startup Deal"
       },
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "does_not_name_vendor",
         "detail": "the page never names PayFit and is not served from its domain"
       }
@@ -29001,7 +29001,7 @@
         "program": "Phantom Buster Startup Deal"
       },
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "does_not_name_vendor",
         "detail": "the page never names Phantom Buster and is not served from its domain"
       }
@@ -29026,9 +29026,9 @@
         "program": "Pipedrive Startup Deal"
       },
       "source_check": {
-        "checked": "2026-08-28",
-        "outcome": "does_not_name_vendor",
-        "detail": "the page never names Pipedrive and is not served from its domain"
+        "checked": "2026-09-02",
+        "outcome": "ok",
+        "detail": "text"
       }
     },
     {
@@ -29051,7 +29051,7 @@
         "program": "PixelMe Startup Deal"
       },
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "does_not_name_vendor",
         "detail": "the page never names PixelMe and is not served from its domain"
       }
@@ -29076,7 +29076,7 @@
         "program": "Postscript Startup Deal"
       },
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "does_not_name_vendor",
         "detail": "the page never names Postscript and is not served from its domain"
       }
@@ -29101,7 +29101,7 @@
         "program": "ProspectIn Startup Deal"
       },
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "does_not_name_vendor",
         "detail": "the page never names ProspectIn and is not served from its domain"
       }
@@ -29126,7 +29126,7 @@
         "program": "Publist Startup Deal"
       },
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "does_not_name_vendor",
         "detail": "the page never names Publist and is not served from its domain"
       }
@@ -29151,7 +29151,7 @@
         "program": "Qonto Startup Deal"
       },
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "does_not_name_vendor",
         "detail": "the page never names Qonto and is not served from its domain"
       }
@@ -29176,7 +29176,7 @@
         "program": "Quartzy Startup Deal"
       },
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "does_not_name_vendor",
         "detail": "the page never names Quartzy and is not served from its domain"
       }
@@ -29201,7 +29201,7 @@
         "program": "Quickbooks Startup Deal"
       },
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "does_not_name_vendor",
         "detail": "the page never names Quickbooks and is not served from its domain"
       }
@@ -29226,7 +29226,7 @@
         "program": "Salesforce Startup Deal"
       },
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "does_not_name_vendor",
         "detail": "the page never names Salesforce and is not served from its domain"
       }
@@ -29251,7 +29251,7 @@
         "program": "Scalingo Startup Deal"
       },
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "does_not_name_vendor",
         "detail": "the page never names Scalingo and is not served from its domain"
       }
@@ -29276,7 +29276,7 @@
         "program": "Science Exchange Startup Deal"
       },
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "does_not_name_vendor",
         "detail": "the page never names Science Exchange and is not served from its domain"
       }
@@ -29301,7 +29301,7 @@
         "program": "Scrapingbee Startup Deal"
       },
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "does_not_name_vendor",
         "detail": "the page never names Scrapingbee and is not served from its domain"
       }
@@ -29326,7 +29326,7 @@
         "program": "Seeqle Startup Deal"
       },
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "does_not_name_vendor",
         "detail": "the page never names Seeqle and is not served from its domain"
       }
@@ -29351,7 +29351,7 @@
         "program": "Sellsy Startup Deal"
       },
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "does_not_name_vendor",
         "detail": "the page never names Sellsy and is not served from its domain"
       }
@@ -29384,7 +29384,7 @@
         "notes": "No active affiliate program. Marketplace partner program for integrations only."
       },
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "does_not_name_vendor",
         "detail": "the page never names SendGrid and is not served from its domain"
       }
@@ -29434,7 +29434,7 @@
         "program": "Shine Startup Deal"
       },
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "does_not_name_vendor",
         "detail": "the page never names Shine and is not served from its domain"
       }
@@ -29459,7 +29459,7 @@
         "program": "Shippo Startup Deal"
       },
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "does_not_name_vendor",
         "detail": "the page never names Shippo and is not served from its domain"
       }
@@ -29484,7 +29484,7 @@
         "program": "Slite Startup Deal"
       },
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "does_not_name_vendor",
         "detail": "the page never names Slite and is not served from its domain"
       }
@@ -29509,7 +29509,7 @@
         "program": "Snap Startup Deal"
       },
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "does_not_name_vendor",
         "detail": "the page never names Snap and is not served from its domain"
       }
@@ -29534,7 +29534,7 @@
         "program": "Snapcall Startup Deal"
       },
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "does_not_name_vendor",
         "detail": "the page never names Snapcall and is not served from its domain"
       }
@@ -29559,7 +29559,7 @@
         "program": "Social Champ Startup Deal"
       },
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "does_not_name_vendor",
         "detail": "the page never names Social Champ and is not served from its domain"
       }
@@ -29584,7 +29584,7 @@
         "program": "SocialBee Startup Deal"
       },
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "does_not_name_vendor",
         "detail": "the page never names SocialBee and is not served from its domain"
       }
@@ -29609,7 +29609,7 @@
         "program": "Solium Startup Deal"
       },
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "does_not_name_vendor",
         "detail": "the page never names Solium and is not served from its domain"
       }
@@ -29634,7 +29634,7 @@
         "program": "Squarespace Startup Deal"
       },
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "does_not_name_vendor",
         "detail": "the page never names Squarespace and is not served from its domain"
       }
@@ -29659,7 +29659,7 @@
         "program": "Stitch Labs Startup Deal"
       },
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "does_not_name_vendor",
         "detail": "the page never names Stitch Labs and is not served from its domain"
       }
@@ -29685,7 +29685,7 @@
         "program": "Themecloud Startup Deal"
       },
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "does_not_name_vendor",
         "detail": "the page never names Themecloud and is not served from its domain"
       }
@@ -29710,7 +29710,7 @@
         "program": "Twilio Startup Deal"
       },
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "does_not_name_vendor",
         "detail": "the page never names Twilio and is not served from its domain"
       }
@@ -29735,7 +29735,7 @@
         "program": "Userguiding Startup Deal"
       },
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "does_not_name_vendor",
         "detail": "the page never names Userguiding and is not served from its domain"
       }
@@ -29760,7 +29760,7 @@
         "program": "Weglot Startup Deal"
       },
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "does_not_name_vendor",
         "detail": "the page never names Weglot and is not served from its domain"
       }
@@ -29785,7 +29785,7 @@
         "program": "WEWORK Startup Deal"
       },
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "does_not_name_vendor",
         "detail": "the page never names WEWORK and is not served from its domain"
       }
@@ -29810,7 +29810,7 @@
         "program": "Wisepops Startup Deal"
       },
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "does_not_name_vendor",
         "detail": "the page never names Wisepops and is not served from its domain"
       }
@@ -29835,7 +29835,7 @@
         "program": "Wizishop Startup Deal"
       },
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "does_not_name_vendor",
         "detail": "the page never names Wizishop and is not served from its domain"
       }
@@ -29860,7 +29860,7 @@
         "program": "WP Engine Startup Deal"
       },
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "does_not_name_vendor",
         "detail": "the page never names WP Engine and is not served from its domain"
       }
@@ -29885,7 +29885,7 @@
         "program": "Yousign Startup Deal"
       },
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "does_not_name_vendor",
         "detail": "the page never names Yousign and is not served from its domain"
       }
@@ -29910,7 +29910,7 @@
         "program": "Zentail Startup Deal"
       },
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "does_not_name_vendor",
         "detail": "the page never names Zentail and is not served from its domain"
       }
@@ -29935,7 +29935,7 @@
         "program": "Zoom Startup Deal"
       },
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "does_not_name_vendor",
         "detail": "the page never names Zoom and is not served from its domain"
       }
@@ -29955,7 +29955,7 @@
       ],
       "verifiedDate": "2026-08-16",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names Selenium Grid but states no amount, tier or rate we can read"
       }
@@ -29982,7 +29982,7 @@
         "program": "BrowserStack Open Source"
       },
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names BrowserStack but states no amount, tier or rate we can read"
       }
@@ -30106,7 +30106,7 @@
       ],
       "verifiedDate": "2026-08-15",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names Locust but states no amount, tier or rate we can read"
       }
@@ -30145,7 +30145,7 @@
       ],
       "verifiedDate": "2026-07-30",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names Gitleaks but states no amount, tier or rate we can read"
       }
@@ -30164,7 +30164,7 @@
       ],
       "verifiedDate": "2026-07-30",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names TruffleHog but states no amount, tier or rate we can read"
       }
@@ -30186,7 +30186,7 @@
       ],
       "verifiedDate": "2026-07-29",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names Checkov but states no amount, tier or rate we can read"
       }
@@ -30206,7 +30206,7 @@
       ],
       "verifiedDate": "2026-08-01",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names Trivy but states no amount, tier or rate we can read"
       }
@@ -30226,7 +30226,7 @@
       ],
       "verifiedDate": "2026-07-25",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names Grype but states no amount, tier or rate we can read"
       }
@@ -30246,7 +30246,7 @@
       ],
       "verifiedDate": "2026-07-25",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names OWASP ZAP but states no amount, tier or rate we can read"
       }
@@ -30266,9 +30266,9 @@
       ],
       "verifiedDate": "2026-07-30",
       "source_check": {
-        "checked": "2026-08-28",
-        "outcome": "states_no_terms",
-        "detail": "the page names Nuclei but states no amount, tier or rate we can read"
+        "checked": "2026-09-02",
+        "outcome": "ok",
+        "detail": "text"
       }
     },
     {
@@ -30285,7 +30285,7 @@
       ],
       "verifiedDate": "2026-07-25",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names CodeQL but states no amount, tier or rate we can read"
       }
@@ -30304,7 +30304,7 @@
       ],
       "verifiedDate": "2026-07-24",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names Dependabot but states no amount, tier or rate we can read"
       }
@@ -30434,7 +30434,7 @@
       ],
       "verifiedDate": "2026-08-16",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names DigitalOcean DNS but states no amount, tier or rate we can read"
       }
@@ -30478,7 +30478,7 @@
       ],
       "verifiedDate": "2026-08-17",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names Hetzner DNS but states no amount, tier or rate we can read"
       }
@@ -30641,7 +30641,7 @@
       ],
       "verifiedDate": "2026-08-17",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names Claude Code but states no amount, tier or rate we can read"
       }
@@ -30714,7 +30714,7 @@
       ],
       "verifiedDate": "2026-07-29",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names Cline but states no amount, tier or rate we can read"
       }
@@ -30736,7 +30736,7 @@
       ],
       "verifiedDate": "2026-07-27",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names Aider but states no amount, tier or rate we can read"
       }
@@ -30801,7 +30801,7 @@
       ],
       "verifiedDate": "2026-07-27",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names Google Antigravity but states no amount, tier or rate we can read"
       }
@@ -31018,9 +31018,9 @@
       ],
       "verifiedDate": "2026-08-18",
       "source_check": {
-        "checked": "2026-08-28",
-        "outcome": "states_no_terms",
-        "detail": "the page names Google Compute Engine but states no amount, tier or rate we can read"
+        "checked": "2026-09-02",
+        "outcome": "ok",
+        "detail": "text"
       }
     },
     {
@@ -31239,7 +31239,7 @@
         "notes": "No individual referral program."
       },
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names GitHub Models but states no amount, tier or rate we can read"
       }
@@ -31270,7 +31270,7 @@
         }
       ],
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names NVIDIA NIM but states no amount, tier or rate we can read"
       },
@@ -31336,9 +31336,9 @@
       ],
       "verifiedDate": "2026-08-27",
       "source_check": {
-        "checked": "2026-08-28",
-        "outcome": "states_no_terms",
-        "detail": "the page names Google Gemini Code Assist but states no amount, tier or rate we can read"
+        "checked": "2026-09-02",
+        "outcome": "ok",
+        "detail": "url"
       }
     },
     {
@@ -31357,7 +31357,7 @@
       ],
       "verifiedDate": "2026-08-17",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names LLM7.io but states no amount, tier or rate we can read"
       },
@@ -31398,9 +31398,9 @@
         }
       ],
       "source_check": {
-        "checked": "2026-08-28",
-        "outcome": "states_no_terms",
-        "detail": "the page names SiliconFlow but states no amount, tier or rate we can read"
+        "checked": "2026-09-02",
+        "outcome": "ok",
+        "detail": "text"
       },
       "product_subtypes": {
         "taxonomy": "AI / ML",
@@ -31430,7 +31430,7 @@
       ],
       "verifiedDate": "2026-08-20",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "does_not_name_vendor",
         "detail": "the page never names Zhipu AI and is not served from its domain"
       },
@@ -31594,7 +31594,7 @@
       ],
       "verifiedDate": "2026-08-20",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names YouTube but states no amount, tier or rate we can read"
       }
@@ -31614,7 +31614,7 @@
       ],
       "verifiedDate": "2026-08-23",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names Tubi but states no amount, tier or rate we can read"
       }
@@ -31634,7 +31634,7 @@
       ],
       "verifiedDate": "2026-08-21",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names Pluto TV but states no amount, tier or rate we can read"
       }
@@ -31695,7 +31695,7 @@
       ],
       "verifiedDate": "2026-08-20",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names Pandora but states no amount, tier or rate we can read"
       }
@@ -31715,7 +31715,7 @@
       ],
       "verifiedDate": "2026-08-19",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names iHeartRadio but states no amount, tier or rate we can read"
       }
@@ -31736,7 +31736,7 @@
       ],
       "verifiedDate": "2026-08-22",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names SoundCloud but states no amount, tier or rate we can read"
       }
@@ -31756,7 +31756,7 @@
       ],
       "verifiedDate": "2026-08-18",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names Plex but states no amount, tier or rate we can read"
       }
@@ -31774,7 +31774,7 @@
       ],
       "verifiedDate": "2026-08-20",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names Apple Podcasts but states no amount, tier or rate we can read"
       }
@@ -31792,7 +31792,7 @@
       ],
       "verifiedDate": "2026-08-21",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names Pocket Casts but states no amount, tier or rate we can read"
       }
@@ -31843,7 +31843,7 @@
       ],
       "verifiedDate": "2026-07-14",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names Todoist but states no amount, tier or rate we can read"
       }
@@ -31882,7 +31882,7 @@
       ],
       "verifiedDate": "2026-08-19",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names Google Keep but states no amount, tier or rate we can read"
       }
@@ -32001,7 +32001,7 @@
       ],
       "verifiedDate": "2026-08-18",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names Simplenote but states no amount, tier or rate we can read"
       }
@@ -32154,7 +32154,7 @@
       ],
       "verifiedDate": "2026-08-19",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names Flickr but states no amount, tier or rate we can read"
       }
@@ -32299,7 +32299,7 @@
       ],
       "verifiedDate": "2026-08-24",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names Apple Passwords but states no amount, tier or rate we can read"
       }
@@ -32320,7 +32320,7 @@
       ],
       "verifiedDate": "2026-08-21",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names KeePassXC but states no amount, tier or rate we can read"
       }
@@ -32417,7 +32417,7 @@
       ],
       "verifiedDate": "2026-08-23",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names Zoom but states no amount, tier or rate we can read"
       }
@@ -32476,7 +32476,7 @@
       ],
       "verifiedDate": "2026-08-22",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names Signal but states no amount, tier or rate we can read"
       }
@@ -32495,7 +32495,7 @@
       ],
       "verifiedDate": "2026-08-22",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names Telegram but states no amount, tier or rate we can read"
       }
@@ -32514,7 +32514,7 @@
       ],
       "verifiedDate": "2026-08-21",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names WhatsApp but states no amount, tier or rate we can read"
       }
@@ -32535,7 +32535,7 @@
       ],
       "verifiedDate": "2026-08-20",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names Photopea but states no amount, tier or rate we can read"
       }
@@ -32555,7 +32555,7 @@
       ],
       "verifiedDate": "2026-08-23",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names GIMP but states no amount, tier or rate we can read"
       }
@@ -32639,7 +32639,7 @@
       ],
       "verifiedDate": "2026-08-23",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names Blender but states no amount, tier or rate we can read"
       }
@@ -32659,7 +32659,7 @@
       ],
       "verifiedDate": "2026-08-23",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names Nike Training Club but states no amount, tier or rate we can read"
       }
@@ -32679,7 +32679,7 @@
       ],
       "verifiedDate": "2026-08-19",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names Samsung Health but states no amount, tier or rate we can read"
       }
@@ -32816,7 +32816,7 @@
         "notes": "Channel partner program only. No individual referral program."
       },
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names Cloudflare WARP but states no amount, tier or rate we can read"
       }
@@ -32882,7 +32882,7 @@
         "notes": "Channel partner program only. No individual referral program."
       },
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names Cloudflare Sandboxes but states no amount, tier or rate we can read"
       },
@@ -32995,7 +32995,7 @@
       ],
       "verifiedDate": "2026-08-21",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names MIT OpenCourseWare but states no amount, tier or rate we can read"
       }
@@ -33035,7 +33035,7 @@
       ],
       "verifiedDate": "2026-08-22",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names edX but states no amount, tier or rate we can read"
       }
@@ -33053,7 +33053,7 @@
       ],
       "verifiedDate": "2026-08-18",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names Gmail but states no amount, tier or rate we can read"
       }
@@ -33139,7 +33139,7 @@
       ],
       "verifiedDate": "2026-08-23",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names Pocket but states no amount, tier or rate we can read"
       }
@@ -33178,7 +33178,7 @@
       ],
       "verifiedDate": "2026-08-21",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names Feedly but states no amount, tier or rate we can read"
       }
@@ -33237,9 +33237,9 @@
       ],
       "verifiedDate": "2026-08-23",
       "source_check": {
-        "checked": "2026-08-28",
-        "outcome": "states_no_terms",
-        "detail": "the page names Mint (Credit Karma) but states no amount, tier or rate we can read"
+        "checked": "2026-09-02",
+        "outcome": "ok",
+        "detail": "url"
       }
     },
     {
@@ -33277,7 +33277,7 @@
       ],
       "verifiedDate": "2026-08-21",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names Insight Timer but states no amount, tier or rate we can read"
       }
@@ -33297,7 +33297,7 @@
       ],
       "verifiedDate": "2026-08-21",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names Waking Up but states no amount, tier or rate we can read"
       }
@@ -33350,9 +33350,9 @@
         "kubernetes_control_plane": "Free (pay for workers only)"
       },
       "source_check": {
-        "checked": "2026-08-28",
-        "outcome": "states_no_terms",
-        "detail": "the page names OVHcloud but states no amount, tier or rate we can read"
+        "checked": "2026-09-02",
+        "outcome": "ok",
+        "detail": "text"
       }
     },
     {
@@ -33371,9 +33371,9 @@
       ],
       "verifiedDate": "2026-08-18",
       "source_check": {
-        "checked": "2026-08-28",
-        "outcome": "states_no_terms",
-        "detail": "the page names OVHcloud but states no amount, tier or rate we can read"
+        "checked": "2026-09-02",
+        "outcome": "ok",
+        "detail": "text"
       }
     },
     {
@@ -33640,9 +33640,9 @@
       ],
       "verifiedDate": "2026-08-19",
       "source_check": {
-        "checked": "2026-08-28",
-        "outcome": "states_no_terms",
-        "detail": "the page names Google GLM 5 but states no amount, tier or rate we can read"
+        "checked": "2026-09-02",
+        "outcome": "ok",
+        "detail": "url"
       },
       "product_subtypes": {
         "taxonomy": "AI / ML",
@@ -33672,9 +33672,9 @@
       ],
       "verifiedDate": "2026-08-17",
       "source_check": {
-        "checked": "2026-08-28",
-        "outcome": "states_no_terms",
-        "detail": "the page names Google Gemini Embedding 2 but states no amount, tier or rate we can read"
+        "checked": "2026-09-02",
+        "outcome": "ok",
+        "detail": "text"
       },
       "product_subtypes": {
         "taxonomy": "AI / ML",
@@ -33705,7 +33705,7 @@
       ],
       "verifiedDate": "2026-08-18",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names Google Content API for Shopping but states no amount, tier or rate we can read"
       }
@@ -34014,9 +34014,9 @@
       ],
       "verifiedDate": "2026-08-27",
       "source_check": {
-        "checked": "2026-08-28",
-        "outcome": "states_no_terms",
-        "detail": "the page names Elastic but states no amount, tier or rate we can read"
+        "checked": "2026-09-02",
+        "outcome": "ok",
+        "detail": "text"
       },
       "product_subtypes": {
         "taxonomy": "Monitoring",
@@ -34104,7 +34104,7 @@
       ],
       "verifiedDate": "2026-08-27",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names Postal but states no amount, tier or rate we can read"
       }
@@ -34148,7 +34148,7 @@
       ],
       "verifiedDate": "2026-08-27",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names swaggo/swag but states no amount, tier or rate we can read"
       }

--- a/scripts/mutate-1258.sh
+++ b/scripts/mutate-1258.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+set -u
+
+REPO="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$REPO" || exit 1
+
+VERIFY="scripts/verify-freshness.js"
+BACKUP_DIR="$(mktemp -d)"
+cp "$VERIFY" "$BACKUP_DIR/verify-freshness.js"
+
+restore() {
+  cp "$BACKUP_DIR/verify-freshness.js" "$VERIFY"
+}
+trap restore EXIT
+
+killed=0
+survived=0
+TESTS="test/whole-page-read.test.ts test/change-gate.test.ts test/verify-freshness.test.ts"
+
+run_mutation() {
+  local name="$1"
+  shift
+  echo "=== $name"
+  restore
+  "$@"
+  if diff -q "$BACKUP_DIR/verify-freshness.js" "$VERIFY" > /dev/null; then
+    echo "    NOT APPLIED: the mutation changed no file, so it proves nothing"
+    survived=$((survived + 1))
+    return
+  fi
+  if timeout 900 node --test --test-concurrency 1 $TESTS > /tmp/mutate-1258-test.log 2>&1; then
+    echo "    SURVIVED"
+    survived=$((survived + 1))
+  else
+    echo "    KILLED: $(grep -c '✖ ' /tmp/mutate-1258-test.log) failing assertion(s)"
+    grep '✖ ' /tmp/mutate-1258-test.log | head -4
+    killed=$((killed + 1))
+  fi
+}
+
+py() { python3 - "$@"; }
+
+m_cut_restored_at_fetch() {
+  py <<'PY'
+p = "scripts/verify-freshness.js"
+s = open(p).read()
+s = s.replace("      text,\n      truncated: false,", "      text: text.slice(0, MAX_PAGE_TEXT_LENGTH),\n      truncated: text.length > MAX_PAGE_TEXT_LENGTH,")
+open(p, "w").write(s)
+PY
+}
+
+m_prompt_stops_truncating() {
+  py <<'PY'
+p = "scripts/verify-freshness.js"
+s = open(p).read()
+s = s.replace('  const pageText = String(wholePageText ?? "").slice(0, MAX_PAGE_TEXT_LENGTH);', '  const pageText = String(wholePageText ?? "");')
+open(p, "w").write(s)
+PY
+}
+
+m_ceiling_never_refuses() {
+  py <<'PY'
+p = "scripts/verify-freshness.js"
+s = open(p).read()
+s = s.replace("    if (bytes > ceiling) {", "    if (false) {")
+s = s.replace("  if (Number.isFinite(declared) && declared > ceiling) {", "  if (false) {")
+open(p, "w").write(s)
+PY
+}
+
+m_ceiling_ignores_declared_length() {
+  py <<'PY'
+p = "scripts/verify-freshness.js"
+s = open(p).read()
+s = s.replace("  if (Number.isFinite(declared) && declared > ceiling) {", "  if (false) {")
+open(p, "w").write(s)
+PY
+}
+
+m_ceiling_counts_characters() {
+  py <<'PY'
+p = "scripts/verify-freshness.js"
+s = open(p).read()
+s = s.replace("    bytes += chunk.length;", "    bytes += 0;")
+open(p, "w").write(s)
+PY
+}
+
+m_ceiling_set_below_the_corpus() {
+  py <<'PY'
+p = "scripts/verify-freshness.js"
+s = open(p).read()
+s = s.replace("export const MAX_PAGE_BYTES = 16_000_000;", "export const MAX_PAGE_BYTES = 100_000;")
+open(p, "w").write(s)
+PY
+}
+
+m_truncated_flag_lies() {
+  py <<'PY'
+p = "scripts/verify-freshness.js"
+s = open(p).read()
+s = s.replace("      truncated: false,", "      truncated: true,")
+open(p, "w").write(s)
+PY
+}
+
+run_mutation "the cut goes back to where the page is fetched" m_cut_restored_at_fetch
+run_mutation "the prompt stops applying the cut" m_prompt_stops_truncating
+run_mutation "the ceiling never refuses anything" m_ceiling_never_refuses
+run_mutation "the ceiling ignores a declared content length" m_ceiling_ignores_declared_length
+run_mutation "the ceiling stops counting bytes" m_ceiling_counts_characters
+run_mutation "the ceiling is set below pages we already read" m_ceiling_set_below_the_corpus
+run_mutation "the reader claims it truncated when it did not" m_truncated_flag_lies
+
+echo
+echo "killed $killed, survived $survived"

--- a/scripts/verify-freshness.js
+++ b/scripts/verify-freshness.js
@@ -12,6 +12,7 @@ const DEFAULT_THRESHOLD_DAYS = 25;
 const FETCH_TIMEOUT_MS = 15_000;
 const RATE_LIMIT_MS = 500;
 export const MAX_PAGE_TEXT_LENGTH = 12_000;
+export const MAX_PAGE_BYTES = 16_000_000;
 const MAX_RESPONSE_TOKENS = 400;
 
 export const VERIFIER_MODEL = "google/gemma-3-27b-it";
@@ -56,7 +57,42 @@ function stripHtml(html) {
     .trim();
 }
 
-export async function fetchPageText(url) {
+export function pageTooLargeError(bytes) {
+  return `page too large: ${bytes} bytes`;
+}
+
+async function cancelBody(res) {
+  try {
+    await res.body?.cancel();
+  } catch {}
+}
+
+export async function readBodyWithin(res, ceiling) {
+  const declared = Number(res.headers?.get?.("content-length"));
+  if (Number.isFinite(declared) && declared > ceiling) {
+    await cancelBody(res);
+    return { tooLarge: true, bytes: declared };
+  }
+  if (!res.body) {
+    const html = await res.text();
+    const bytes = Buffer.byteLength(html);
+    return bytes > ceiling ? { tooLarge: true, bytes } : { html };
+  }
+  const chunks = [];
+  let bytes = 0;
+  for await (const chunk of res.body) {
+    bytes += chunk.length;
+    if (bytes > ceiling) {
+      await cancelBody(res);
+      return { tooLarge: true, bytes };
+    }
+    chunks.push(chunk);
+  }
+  return { html: Buffer.concat(chunks).toString("utf-8") };
+}
+
+export async function fetchPageText(url, options = {}) {
+  const ceiling = options.maxBytes ?? MAX_PAGE_BYTES;
   const controller = new AbortController();
   const timeout = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
   try {
@@ -71,17 +107,21 @@ export async function fetchPageText(url) {
       redirect: "follow",
     });
     if (!res.ok) {
+      await cancelBody(res);
       return { ok: false, error: `HTTP ${res.status}` };
     }
-    const html = await res.text();
-    const text = stripHtml(html);
+    const body = await readBodyWithin(res, ceiling);
+    if (body.tooLarge) {
+      return { ok: false, error: pageTooLargeError(body.bytes) };
+    }
+    const text = stripHtml(body.html);
     if (text.length < 50) {
       return { ok: false, error: "page content too short (likely JS-rendered SPA)" };
     }
     return {
       ok: true,
-      text: text.slice(0, MAX_PAGE_TEXT_LENGTH),
-      truncated: text.length > MAX_PAGE_TEXT_LENGTH,
+      text,
+      truncated: false,
       finalUrl: res.url || url,
     };
   } catch (err) {
@@ -156,7 +196,8 @@ export function parseVerifierResponse(raw) {
   return { status: "unclear", summary: "Could not parse AI response" };
 }
 
-export async function verifyOfferAgainstPage(client, offer, pageText) {
+export async function verifyOfferAgainstPage(client, offer, wholePageText) {
+  const pageText = String(wholePageText ?? "").slice(0, MAX_PAGE_TEXT_LENGTH);
   const prompt = `You are verifying whether a vendor's deal/free-tier information is still accurate.
 
 STORED DEAL INFO:

--- a/scripts/whole-page-census.js
+++ b/scripts/whole-page-census.js
@@ -1,0 +1,219 @@
+#!/usr/bin/env node
+
+import { readFileSync, writeFileSync, existsSync, mkdirSync } from "node:fs";
+import { createHash } from "node:crypto";
+import { resolve, dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { MAX_PAGE_TEXT_LENGTH, readBodyWithin } from "./verify-freshness.js";
+import { priceSignals } from "./change-gate.js";
+import { pageNamesVendor, classifySource, sourceCheckRecord } from "./vendor-naming.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const INDEX_PATH =
+  process.env.AGENTDEALS_INDEX_PATH || resolve(__dirname, "..", "data", "index.json");
+const CONCURRENCY = 12;
+const FETCH_TIMEOUT_MS = 20_000;
+const HARD_CEILING = 64_000_000;
+
+function arg(name, fallback = null) {
+  const at = process.argv.indexOf(name);
+  return at !== -1 ? process.argv[at + 1] : fallback;
+}
+
+function stripHtml(html) {
+  return html
+    .replace(/<script[\s\S]*?<\/script>/gi, "")
+    .replace(/<style[\s\S]*?<\/style>/gi, "")
+    .replace(/<[^>]+>/g, " ")
+    .replace(/&nbsp;/g, " ")
+    .replace(/&amp;/g, "&")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+async function fetchMeasured(url) {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+  try {
+    const res = await fetch(url, {
+      method: "GET",
+      signal: controller.signal,
+      headers: {
+        "User-Agent":
+          "Mozilla/5.0 (compatible; AgentDeals-Verify/1.0; +https://github.com/robhunter/agentdeals)",
+        Accept: "text/html,application/xhtml+xml",
+      },
+      redirect: "follow",
+    });
+    if (!res.ok) return { ok: false, error: `HTTP ${res.status}` };
+    const body = await readBodyWithin(res, HARD_CEILING);
+    if (body.tooLarge) return { ok: false, error: `page too large: ${body.bytes} bytes` };
+    const bytes = Buffer.byteLength(body.html);
+    const text = stripHtml(body.html);
+    if (text.length < 50) {
+      return { ok: false, error: "page content too short (likely JS-rendered SPA)" };
+    }
+    return { ok: true, text, bytes };
+  } catch (err) {
+    return { ok: false, error: err.name === "AbortError" ? "timeout" : err.message };
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+async function mapWithConcurrency(items, limit, fn) {
+  let next = 0;
+  const workers = Array.from({ length: Math.min(limit, items.length) }, async () => {
+    while (true) {
+      const i = next++;
+      if (i >= items.length) return;
+      await fn(items[i]);
+    }
+  });
+  await Promise.all(workers);
+}
+
+const ABSENCE = new Set(["states_no_terms", "does_not_name_vendor"]);
+
+async function main() {
+  const out = arg("--out", "/tmp/whole-page-census.json");
+  const cacheDir = arg("--cache", "/tmp/wholepage-cache");
+  const population = arg("--population", "absence");
+
+  const data = JSON.parse(readFileSync(INDEX_PATH, "utf-8"));
+  const all = data.offers || [];
+  const offers =
+    population === "all"
+      ? all.filter((o) => o.url)
+      : all.filter((o) => o.url && ABSENCE.has(o.source_check?.outcome));
+
+  const urls = [...new Set(offers.map((o) => o.url))];
+  console.error(`${offers.length} offers, ${urls.length} distinct URLs (population=${population})`);
+
+  if (!existsSync(cacheDir)) mkdirSync(cacheDir, { recursive: true });
+  const cachePath = (url) => join(cacheDir, `${createHash("sha1").update(url).digest("hex")}.json`);
+
+  let done = 0;
+  const pages = new Map();
+  await mapWithConcurrency(urls, CONCURRENCY, async (url) => {
+    let page;
+    if (existsSync(cachePath(url))) {
+      page = JSON.parse(readFileSync(cachePath(url), "utf-8"));
+    } else {
+      page = await fetchMeasured(url);
+      writeFileSync(cachePath(url), JSON.stringify(page));
+    }
+    done++;
+    if (done % 50 === 0) console.error(`  ${done}/${urls.length}`);
+    pages.set(url, page);
+  });
+
+  const write = process.argv.includes("--write");
+  const checked = arg("--checked", new Date().toISOString().slice(0, 10));
+  let restamped = 0;
+  let heldOnFailedFetch = 0;
+
+  const rows = offers.map((offer) => {
+    const whole = pages.get(offer.url) ?? { ok: false, error: "not fetched" };
+    const cut = whole.ok
+      ? { ok: true, text: whole.text.slice(0, MAX_PAGE_TEXT_LENGTH) }
+      : whole;
+    const wholeClass = classifySource(offer, whole, whole.ok ? priceSignals(whole.text).length : 0);
+    const cutClass = classifySource(offer, cut, cut.ok ? priceSignals(cut.text).length : 0);
+    const firstSignal = whole.ok
+      ? (() => {
+          const sigs = priceSignals(whole.text);
+          if (sigs.length === 0) return null;
+          const at = whole.text.indexOf(sigs[0]);
+          return { signal: sigs[0], at: at < 0 ? null : at };
+        })()
+      : null;
+
+    const storedOutcome = offer.source_check?.outcome ?? null;
+    if (write && ABSENCE.has(storedOutcome)) {
+      if (whole.ok) {
+        offer.source_check = sourceCheckRecord(
+          offer,
+          whole,
+          priceSignals(whole.text).length,
+          checked
+        );
+        restamped++;
+      } else {
+        heldOnFailedFetch++;
+      }
+    }
+
+    return {
+      vendor: offer.vendor,
+      url: offer.url,
+      stored: storedOutcome,
+      fetch_ok: whole.ok,
+      error: whole.ok ? null : whole.error,
+      bytes: whole.bytes ?? null,
+      chars: whole.ok ? whole.text.length : null,
+      longer_than_cut: whole.ok ? whole.text.length > MAX_PAGE_TEXT_LENGTH : null,
+      signals_whole: whole.ok ? priceSignals(whole.text).length : null,
+      signals_cut: cut.ok ? priceSignals(cut.text).length : null,
+      named_whole: whole.ok ? pageNamesVendor(whole.text, offer.vendor, { url: offer.url }).named : null,
+      named_cut: cut.ok ? pageNamesVendor(cut.text, offer.vendor, { url: offer.url }).named : null,
+      outcome_whole: wholeClass.outcome,
+      outcome_cut: cutClass.outcome,
+      first_signal: firstSignal,
+    };
+  });
+
+  writeFileSync(out, JSON.stringify(rows, null, 1) + "\n");
+  if (write) writeFileSync(INDEX_PATH, JSON.stringify(data, null, 2) + "\n");
+
+  const fetched = rows.filter((r) => r.fetch_ok);
+  const longer = fetched.filter((r) => r.longer_than_cut);
+  const flipped = fetched.filter(
+    (r) => ABSENCE.has(r.outcome_cut) && !ABSENCE.has(r.outcome_whole)
+  );
+  const stands = fetched.filter((r) => ABSENCE.has(r.outcome_whole));
+  const storedAbsence = fetched.filter((r) => ABSENCE.has(r.stored));
+  const storedAbsenceNowOk = storedAbsence.filter((r) => !ABSENCE.has(r.outcome_whole));
+  const cutExplains = storedAbsenceNowOk.filter((r) => ABSENCE.has(r.outcome_cut));
+  const storedOk = fetched.filter((r) => r.stored === "ok");
+  const storedOkNowAbsence = storedOk.filter((r) => ABSENCE.has(r.outcome_whole));
+  const bytes = fetched.map((r) => r.bytes).sort((a, b) => a - b);
+  const pct = (p) => bytes[Math.min(bytes.length - 1, Math.floor((bytes.length - 1) * p))];
+
+  console.error("");
+  console.error(`population              ${rows.length}`);
+  console.error(`fetched                 ${fetched.length}`);
+  console.error(`fetch failed            ${rows.length - fetched.length}`);
+  console.error(`longer than the cut     ${longer.length}`);
+  console.error(`absence claim FALSE     ${flipped.length}`);
+  console.error(`absence claim stands    ${stands.length}`);
+  console.error("");
+  console.error(`stored absence          ${storedAbsence.length}`);
+  console.error(`  now reads ok          ${storedAbsenceNowOk.length}`);
+  console.error(`    the cut explains    ${cutExplains.length}`);
+  console.error(`    the page changed    ${storedAbsenceNowOk.length - cutExplains.length}`);
+  console.error(`stored ok               ${storedOk.length}`);
+  console.error(`  now reads absence     ${storedOkNowAbsence.length}`);
+  if (write) {
+    console.error("");
+    console.error(`re-stamped              ${restamped}`);
+    console.error(`held on a failed fetch  ${heldOnFailedFetch}`);
+  }
+  console.error("");
+  console.error(`bytes  p50 ${pct(0.5)}  p90 ${pct(0.9)}  p99 ${pct(0.99)}  max ${bytes[bytes.length - 1]}`);
+  console.error(`chars  max ${Math.max(...fetched.map((r) => r.chars))}`);
+  console.error("");
+  for (const r of flipped.sort((a, b) => (a.first_signal?.at ?? 0) - (b.first_signal?.at ?? 0))) {
+    console.error(
+      `  ${r.outcome_cut} -> ${r.outcome_whole}  ${r.vendor}  chars=${r.chars} bytes=${r.bytes} sig@${r.first_signal?.at ?? "-"} "${r.first_signal?.signal ?? ""}"`
+    );
+  }
+  console.error("");
+  console.error(`wrote ${out}`);
+}
+
+main();

--- a/test/change-gate.test.ts
+++ b/test/change-gate.test.ts
@@ -582,11 +582,11 @@ describe("a recorded change must describe a change", () => {
       assert.strictEqual(page.truncated, false);
     });
 
-    it("says a page longer than the fetch limit was cut", async () => {
+    it("says a page longer than the verifier's prompt limit was also read whole", async () => {
       const page = await readWith(html(2000));
       assert.strictEqual(page.ok, true);
-      assert.strictEqual(page.truncated, true);
-      assert.strictEqual(page.text.length, MAX_PAGE_TEXT_LENGTH);
+      assert.strictEqual(page.truncated, false);
+      assert.ok(page.text.length > MAX_PAGE_TEXT_LENGTH);
     });
   });
 

--- a/test/source-check-pages.test.ts
+++ b/test/source-check-pages.test.ts
@@ -58,6 +58,24 @@ const SOURCED_FROM_A_PAGE_STATING_NO_FIGURES = {
   },
 };
 
+const QUOTED_FROM_THE_PAGE_IT_CITES = {
+  ...SOURCED_FROM_A_MARKETPLACE,
+  vendor: "Longcorp",
+  url: "https://longcorp.example/pricing",
+  product_subtypes: {
+    taxonomy: "Databases",
+    labels: [
+      {
+        subtype: "relational",
+        source_url: "https://longcorp.example/pricing",
+        source_quote: "Standard Events and Metrics Up to 5 hosts",
+      },
+    ],
+    reviewed: "2026-09-02",
+  },
+  source_check: { checked: "2026-09-02", outcome: "ok", detail: "text" },
+};
+
 let fixtureDir = "";
 let serverPort = 0;
 let proc: ChildProcess | null = null;
@@ -112,6 +130,7 @@ before(async () => {
           SOURCED_FROM_ITS_OWN_PAGE,
           SOURCED_FROM_A_PAGE_WE_COULD_NOT_READ,
           SOURCED_FROM_A_PAGE_STATING_NO_FIGURES,
+          QUOTED_FROM_THE_PAGE_IT_CITES,
         ],
       },
       null,
@@ -310,4 +329,30 @@ describe("an alternatives page for a vendor whose source we cannot vouch for", (
       assert.match(stillAvailable, reason);
     });
   }
+});
+
+describe("a page we quote from is not also a page we say we can read nothing on", () => {
+  it("renders, so the assertions below are about a real page", async () => {
+    const res = await get("/vendor/longcorp");
+    assert.equal(res.status, 200);
+  });
+
+  it("quotes the page it cites", async () => {
+    const { body } = await get("/vendor/longcorp");
+    assert.match(
+      body,
+      /https:\/\/longcorp\.example\/pricing<\/a>, where it says: &ldquo;Standard Events and Metrics Up to 5 hosts&rdquo;/
+    );
+  });
+
+  it("does not also say that page states no terms it can read", async () => {
+    const { body } = await get("/vendor/longcorp");
+    assert.doesNotMatch(body, /states no terms we can read/);
+  });
+
+  it("keeps saying so where the quote comes from a different page", async () => {
+    const { body } = await get("/vendor/prosecorp");
+    assert.match(body, /dealmarket\.example\/offers<\/a>, where it says:/);
+    assert.match(body, /states no terms we can read/);
+  });
 });

--- a/test/whole-page-read.test.ts
+++ b/test/whole-page-read.test.ts
@@ -1,0 +1,232 @@
+import { describe, it } from "node:test";
+import assert from "node:assert";
+import { readFileSync, readdirSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const SCRIPTS = path.join(__dirname, "..", "scripts");
+
+const {
+  fetchPageText,
+  verifyOfferAgainstPage,
+  readBodyWithin,
+  pageTooLargeError,
+  MAX_PAGE_TEXT_LENGTH,
+  MAX_PAGE_BYTES,
+  VERIFIER_MODEL,
+  VERIFIER_BASE_URL,
+} = await import("../scripts/verify-freshness.js");
+const { priceSignals } = await import("../scripts/change-gate.js");
+const { classifySource, pageNamesVendor } = await import("../scripts/vendor-naming.js");
+
+const nav = (vendor: string) => `${vendor} Docs Blog Careers Support Community Login Sign up `.repeat(300);
+
+function pageStatingTermsAfterTheCut(vendor: string) {
+  return `<html><body><nav>${nav(vendor)}</nav><main>${vendor} pricing. Free plan: $0 per month for up to 5 hosts.</main></body></html>`;
+}
+
+function pageStatingNoTermsAtAnyLength(vendor: string) {
+  return `<html><body><nav>${nav(vendor)}</nav><main>${vendor} helps teams ship. Talk to our team about what you need.</main></body></html>`;
+}
+
+const SHORT_PAGE = `<html><body><p>Widgetson pricing. The free plan is $0 per month for up to 5 hosts, with 1-day retention.</p></body></html>`;
+
+async function readWith(body: string, init: ResponseInit = {}, options = {}) {
+  const original = globalThis.fetch;
+  globalThis.fetch = (async () => new Response(body, { status: 200, ...init })) as typeof fetch;
+  try {
+    return await fetchPageText("https://example.test/pricing", options);
+  } finally {
+    globalThis.fetch = original;
+  }
+}
+
+const OFFER = {
+  vendor: "Widgetson",
+  category: "Monitoring",
+  tier: "Free",
+  description: "Free for up to 5 hosts",
+  url: "https://example.test/pricing",
+};
+
+function outcomeFor(text: string) {
+  const page = { ok: true, text };
+  return classifySource(OFFER, page, priceSignals(text).length).outcome;
+}
+
+describe("a page is read to its end, not to a fixed number of characters", () => {
+  it("returns every character of a page longer than the verifier's prompt limit", async () => {
+    const page = await readWith(pageStatingTermsAfterTheCut(OFFER.vendor));
+    assert.strictEqual(page.ok, true);
+    assert.strictEqual(page.truncated, false);
+    assert.ok(
+      page.text.length > MAX_PAGE_TEXT_LENGTH,
+      `the fixture must be longer than ${MAX_PAGE_TEXT_LENGTH} characters for this to mean anything, got ${page.text.length}`
+    );
+    assert.ok(page.text.includes("Free plan: $0 per month for up to 5 hosts"));
+  });
+
+  it("states the terms only past the character the reader used to stop at", async () => {
+    const page = await readWith(pageStatingTermsAfterTheCut(OFFER.vendor));
+    const at = page.text.indexOf("$0");
+    assert.ok(
+      at > MAX_PAGE_TEXT_LENGTH,
+      `the fixture's first price signal must fall past the prompt limit, found at ${at}`
+    );
+  });
+
+  it("names the vendor and reads its terms from the whole page", async () => {
+    const page = await readWith(pageStatingTermsAfterTheCut(OFFER.vendor));
+    assert.strictEqual(pageNamesVendor(page.text, OFFER.vendor, { url: OFFER.url }).named, true);
+    assert.ok(priceSignals(page.text).length > 0);
+    assert.strictEqual(outcomeFor(page.text), "ok");
+  });
+
+  it("would have called the same page one that states no terms, had it stopped at the limit", async () => {
+    const page = await readWith(pageStatingTermsAfterTheCut(OFFER.vendor));
+    assert.strictEqual(outcomeFor(page.text.slice(0, MAX_PAGE_TEXT_LENGTH)), "states_no_terms");
+  });
+
+  it("still finds no terms on a long page that states none", async () => {
+    const page = await readWith(pageStatingNoTermsAtAnyLength(OFFER.vendor));
+    assert.ok(page.text.length > MAX_PAGE_TEXT_LENGTH);
+    assert.strictEqual(outcomeFor(page.text), "states_no_terms");
+  });
+
+  it("reads a short page whole, as it always did", async () => {
+    const page = await readWith(SHORT_PAGE);
+    assert.strictEqual(page.ok, true);
+    assert.strictEqual(page.truncated, false);
+    assert.strictEqual(outcomeFor(page.text), "ok");
+  });
+});
+
+describe("the verifier prompt carries the limit, so the reader does not have to", () => {
+  function promptCapturingClient() {
+    const prompts: string[] = [];
+    return {
+      prompts,
+      client: {
+        model: VERIFIER_MODEL,
+        baseUrl: VERIFIER_BASE_URL,
+        complete: async (prompt: string) => {
+          prompts.push(prompt);
+          return '{"status":"confirmed"}';
+        },
+      },
+    };
+  }
+
+  function pageTextIn(prompt: string) {
+    const start = prompt.indexOf("CURRENT PRICING PAGE TEXT (truncated):\n");
+    assert.ok(start !== -1, "the prompt must label the page text for this assertion to mean anything");
+    const from = start + "CURRENT PRICING PAGE TEXT (truncated):\n".length;
+    const end = prompt.indexOf("\n\nCompare the stored deal info", from);
+    assert.ok(end !== -1, "the prompt must close the page text block");
+    return prompt.slice(from, end);
+  }
+
+  it("sends no more page text than it ever did, however long the page is", async () => {
+    const { prompts, client } = promptCapturingClient();
+    const whole = `${"a".repeat(MAX_PAGE_TEXT_LENGTH)}TAIL`;
+    await verifyOfferAgainstPage(client, OFFER, whole);
+    const sent = pageTextIn(prompts[0]);
+    assert.strictEqual(sent.length, MAX_PAGE_TEXT_LENGTH);
+    assert.ok(!sent.includes("TAIL"));
+  });
+
+  it("sends a short page unchanged", async () => {
+    const { prompts, client } = promptCapturingClient();
+    await verifyOfferAgainstPage(client, OFFER, "Free plan: $0 per month.");
+    assert.strictEqual(pageTextIn(prompts[0]), "Free plan: $0 per month.");
+  });
+});
+
+describe("an unbounded read is refused rather than held", () => {
+  it("refuses a body larger than the ceiling and names the size", async () => {
+    const page = await readWith("x".repeat(5_000), {}, { maxBytes: 1_000 });
+    assert.strictEqual(page.ok, false);
+    assert.match(page.error, /^page too large: \d+ bytes$/);
+  });
+
+  it("refuses on a declared length without reading the body", async () => {
+    const declared = MAX_PAGE_BYTES + 1;
+    const page = await readWith(SHORT_PAGE, {
+      headers: { "content-length": String(declared) },
+    });
+    assert.strictEqual(page.ok, false);
+    assert.strictEqual(page.error, pageTooLargeError(declared));
+  });
+
+  it("accepts a body at the ceiling", async () => {
+    const page = await readWith(SHORT_PAGE, {}, { maxBytes: Buffer.byteLength(SHORT_PAGE) });
+    assert.strictEqual(page.ok, true);
+  });
+
+  it("counts bytes rather than characters", async () => {
+    const body = `<html><body><p>Widgetson pricing — free plan ${"€".repeat(200)}</p></body></html>`;
+    const chars = body.length;
+    const bytes = Buffer.byteLength(body);
+    assert.ok(bytes > chars, "the fixture must be wider in bytes than in characters");
+    const page = await readWith(body, {}, { maxBytes: chars });
+    assert.strictEqual(page.ok, false);
+  });
+
+  it("sets a ceiling above every page in the index", () => {
+    const LARGEST_PAGE_MEASURED = 4_764_715;
+    assert.ok(
+      MAX_PAGE_BYTES > LARGEST_PAGE_MEASURED * 2,
+      `${MAX_PAGE_BYTES} leaves no room above the ${LARGEST_PAGE_MEASURED}-byte page we already read`
+    );
+  });
+
+  describe("readBodyWithin", () => {
+    it("returns the body when it fits", async () => {
+      const result = await readBodyWithin(new Response("hello"), 100);
+      assert.strictEqual(result.html, "hello");
+      assert.strictEqual(result.tooLarge, undefined);
+    });
+
+    it("reports the size it stopped at", async () => {
+      const result = await readBodyWithin(new Response("x".repeat(500)), 100);
+      assert.strictEqual(result.tooLarge, true);
+      assert.ok(result.bytes > 100);
+    });
+  });
+});
+
+describe("the character limit belongs to the verifier prompt alone", () => {
+  const readers = ["change-gate.js", "vendor-naming.js", "reverify-rolling.js", "source-naming-audit.js"];
+
+  for (const file of readers) {
+    it(`${file} introduces no limit of its own`, () => {
+      const source = readFileSync(path.join(SCRIPTS, file), "utf-8");
+      assert.doesNotMatch(source, /MAX_PAGE_TEXT_LENGTH/);
+    });
+  }
+
+  it("names the limit only where the prompt is built and where the old cut is measured", () => {
+    const files = readdirSync(SCRIPTS).filter((f) => f.endsWith(".js"));
+    const naming = files
+      .filter((f) => readFileSync(path.join(SCRIPTS, f), "utf-8").includes("MAX_PAGE_TEXT_LENGTH"))
+      .sort();
+    assert.deepStrictEqual(naming, ["verify-freshness.js", "whole-page-census.js"]);
+  });
+
+  it("applies the limit inside the function that builds the prompt", () => {
+    const source = readFileSync(path.join(SCRIPTS, "verify-freshness.js"), "utf-8");
+    const from = source.indexOf("export async function verifyOfferAgainstPage");
+    const to = source.indexOf("export function sleep", from) >= 0 ? source.indexOf("export function sleep", from) : source.length;
+    assert.ok(from !== -1);
+    assert.match(source.slice(from, to), /slice\(0,\s*MAX_PAGE_TEXT_LENGTH\)/);
+  });
+
+  it("does not apply it where the page is fetched", () => {
+    const source = readFileSync(path.join(SCRIPTS, "verify-freshness.js"), "utf-8");
+    const from = source.indexOf("export async function fetchPageText");
+    const to = source.indexOf("export function createVerifierClient", from);
+    assert.ok(from !== -1 && to > from);
+    assert.doesNotMatch(source.slice(from, to), /MAX_PAGE_TEXT_LENGTH/);
+  });
+});


### PR DESCRIPTION
Moves the 12,000-character cut from `fetchPageText` to `verifyOfferAgainstPage`, which is the only consumer that needs it, and re-stamps the 680 absence-claim records against the whole page.

Refs #1258

## What changed

`fetchPageText` returned `text.slice(0, MAX_PAGE_TEXT_LENGTH)`, so `classifySource`, `pageNamesVendor`, `priceSignals` and `describesChange` all inherited a cap that only the verifier prompt needed. It now returns the whole stripped text and `verifyOfferAgainstPage` applies the cut itself, so the prompt is byte-identical in size and cost for any given page.

The read is bounded by a byte ceiling instead: `MAX_PAGE_BYTES = 16_000_000`. The largest page in the index is **4,764,715 bytes**, so the ceiling is 3.4x the measured maximum. `readBodyWithin` refuses on `content-length` before touching the body and otherwise streams, so an oversized body is refused rather than held. Both paths cancel the stream.

## The census

`scripts/whole-page-census.js` fetches each URL once, classifies against the whole text and against the same text cut at 12,000, and reports the difference. Run over the whole index, 2026-09-02.

| | records |
|---|---|
| absence claims in the catalog | 680 |
| fetched | 677 |
| longer than the cut | 135 |
| **absence claim false on the whole page** | **38** |
| — of those, the cut explains | **29** |
| — of those, the page changed since we stamped it | 9 |
| absence claim stands | 639 |

The 29 reproduce the issue's list exactly, same vendors and same first-signal positions. All 29 records changed outcome — including Datadog, Fastly, Google Compute Engine, Google Maps Platform and all three OVHcloud records.

**The 9 the cut does not explain** are stale stamps, not truncation: CrateDB, Browse AI, Country-State-City Microservice API, Stack Auth, LangWatch, Othor AI, UXtweak.com, SiliconFlow, Mint (Credit Karma). Seven of them sit on pages *shorter* than the cut, so truncation cannot be the cause — the page changed since we last read it. They are correct as `ok` today and I wrote them, but they belong to #1114's queue rather than to this issue.

**AC-4 asked what happens to the 792 `ok` records.** 788 fetched; **7** would classify `states_no_terms` on a whole-page read today. None are caused by the cut — truncation can only make a check falsely negative. I did not write them: they are the same stale-stamp class as the 9 above, and re-stamping the `ok` population would newly withhold a level from 7 vendors on evidence this issue did not gather.

**AC-6, the negative control.** 135 records sit on a page longer than the cut; **104 of them still read as an absence claim** after the re-stamp. The population did not collapse, so the re-stamp is not over-firing.

**Two of the 38 are recovered by a false signal**, exactly as the issue predicted: Zed on `2026 Daily d` and Pagure.io on `2024 libuser A user` — years read as quantities, which is #1119. Their absence claims may well have been correct. I wrote them anyway, because the re-stamp has to be a mechanical application of `classifySource` rather than my curation of it; hand-written `source_check` blocks are what produced five wrong ones on #1252. When #1119 lands they will re-stamp back.

**3 records were held at their existing stamp** because the fetch failed today. A failed fetch classifies `unreadable`, so writing it would have converted a transient network error into a published absence claim — the exact defect class this issue is about.

## AC-5, and where it does not hold

`/vendor/datadog` carried the sentence **7 times** beside a quote from the page it said it could not read. It now carries it **0 times** and keeps the quote. Verified on a server running this branch's data.

The invariant as written — *no vendor page renders a source-check sentence and a source quote from the same URL* — **is not true after this change, and I do not think it should be.** 45 records held that shape before; **38 still do.** Every one of the 38 quotes is descriptive (`product_role` / `product_subtypes`), and **none of the 38 quotes contains a price signal** — measured, and it was also 0 before, so "does the quote contain a price signal" is a vacuous test that would not have caught Datadog either.

Those 38 pages say "states no terms we can read", which in this codebase means *no price terms*, next to a quote about what the product is. Both statements are true; they only read as a contradiction because the sentence says "terms" where it means "pricing terms". **That is a wording fix on one sentence, not a truncation fix**, and it is a change to published site copy, so it is yours. Happy to take it as its own issue.

What I pinned instead is the rendered-page assertion in the fixed shape: a record whose page states terms renders the quote and no absence sentence, with a control that keeps the sentence where the quote comes from a different page.

## What moved

2,577 paths swept, `TZ=UTC`, both sides built from source.

| | |
|---|---|
| byte-identical | 2,356 |
| moved | 221 |
| status changes | 0 (all 2,577 return 200 either side) |

57 vendor pages moved: **36 predicted from the changed records, 0 predicted-but-unmoved**, plus 21 whose own record did not change but whose comparison table carries a row for one that did — `/vendor/prometheus` gains a `stable` dot on a neighbour's row, `/vendor/groq` loses a `source unconfirmed` label on one.

The remaining 164 are the ranker's second-order effect: a record with a confirmed source outranks one without, so `/alternative-to/*` and `/best*` lists reorder. Every changed line on every moved path is a stability cell, a source-check sentence, or a list whose membership change names one of the 38. One path, `/hetzner-alternatives`, differs only by a `—` placeholder becoming a level.

## A consequence worth naming

`pageComplete` in the change gate was `!page.truncated`, so it was **false for every page over 12,000 characters**. `storedDimensionsAbsentFromPage` — the branch that reclassifies a change as a restructure when the whole page states nothing about a stored dimension — could therefore never fire on a long page. It can now. That is the correct behaviour and it is what AC-2 asks for, but it changes gate outcomes and not just `source_check`, so it should not arrive as a surprise.

## Tests

3,109 pass, 0 fail. 26 new.

`test/whole-page-read.test.ts` covers the fixture the issue asked for — a page that names the vendor and prices it only after character 12,000, asserted to classify `ok`, with the same page cut at 12,000 asserted to classify `states_no_terms` so the fixture is known to straddle the cut. Plus a long page that genuinely states no terms, asserted to still classify `states_no_terms`; the prompt asserted to receive no more text than it ever did; and the ceiling asserted on bytes rather than characters.

It also ratchets AC-2 structurally: `MAX_PAGE_TEXT_LENGTH` is named in exactly two files, and inside `verify-freshness.js` it appears in `verifyOfferAgainstPage` and not in `fetchPageText`.

`scripts/mutate-1258.sh`: **7 mutations, 7 killed, 0 survived**, including restoring the cut at fetch and removing it from the prompt.
