### PR TITLE
Refuse a page we barely read rather than call it silent (#1263)

### DIFF
--- a/data/index.json
+++ b/data/index.json
@@ -2541,8 +2541,8 @@
       "verifiedDate": "2026-07-23",
       "source_check": {
         "checked": "2026-09-02",
-        "outcome": "states_no_terms",
-        "detail": "the page names deSEC but states no amount, tier or rate we can read"
+        "outcome": "unreadable",
+        "detail": "page content too short (likely JS-rendered SPA)"
       }
     },
     {
@@ -3375,8 +3375,8 @@
       },
       "source_check": {
         "checked": "2026-09-02",
-        "outcome": "states_no_terms",
-        "detail": "the page names JetBrains but states no amount, tier or rate we can read"
+        "outcome": "unreadable",
+        "detail": "page content too short (likely JS-rendered SPA)"
       }
     },
     {
@@ -4640,8 +4640,8 @@
       "verifiedDate": "2026-07-23",
       "source_check": {
         "checked": "2026-09-02",
-        "outcome": "states_no_terms",
-        "detail": "the page names BrowserStack Percy but states no amount, tier or rate we can read"
+        "outcome": "unreadable",
+        "detail": "page content too short (likely JS-rendered SPA)"
       }
     },
     {
@@ -5027,8 +5027,8 @@
       "verifiedDate": "2026-04-23",
       "source_check": {
         "checked": "2026-09-02",
-        "outcome": "states_no_terms",
-        "detail": "the page names Canva but states no amount, tier or rate we can read"
+        "outcome": "unreadable",
+        "detail": "page content too short (likely JS-rendered SPA)"
       }
     },
     {
@@ -5863,8 +5863,8 @@
       "verifiedDate": "2026-07-28",
       "source_check": {
         "checked": "2026-09-02",
-        "outcome": "states_no_terms",
-        "detail": "the page names Formspree but states no amount, tier or rate we can read"
+        "outcome": "unreadable",
+        "detail": "page content too short (likely JS-rendered SPA)"
       }
     },
     {
@@ -6056,8 +6056,8 @@
       "verifiedDate": "2026-08-23",
       "source_check": {
         "checked": "2026-09-02",
-        "outcome": "states_no_terms",
-        "detail": "the page names Excalidraw but states no amount, tier or rate we can read"
+        "outcome": "unreadable",
+        "detail": "page content too short (likely JS-rendered SPA)"
       }
     },
     {
@@ -6656,8 +6656,8 @@
       "verifiedDate": "2026-07-29",
       "source_check": {
         "checked": "2026-09-02",
-        "outcome": "states_no_terms",
-        "detail": "the page names Hoppscotch but states no amount, tier or rate we can read"
+        "outcome": "unreadable",
+        "detail": "page content too short (likely JS-rendered SPA)"
       }
     },
     {
@@ -7025,8 +7025,8 @@
       "verifiedDate": "2026-07-07",
       "source_check": {
         "checked": "2026-09-02",
-        "outcome": "states_no_terms",
-        "detail": "the page names X (Twitter) but states no amount, tier or rate we can read"
+        "outcome": "unreadable",
+        "detail": "page content too short (likely JS-rendered SPA)"
       }
     },
     {
@@ -7920,8 +7920,8 @@
       "verifiedDate": "2026-08-25",
       "source_check": {
         "checked": "2026-09-02",
-        "outcome": "states_no_terms",
-        "detail": "the page names VirusTotal but states no amount, tier or rate we can read"
+        "outcome": "unreadable",
+        "detail": "page content too short (likely JS-rendered SPA)"
       }
     },
     {
@@ -10107,8 +10107,8 @@
       "verifiedDate": "2026-08-25",
       "source_check": {
         "checked": "2026-09-02",
-        "outcome": "states_no_terms",
-        "detail": "the page names Conversion Tools but states no amount, tier or rate we can read"
+        "outcome": "unreadable",
+        "detail": "page content too short (likely JS-rendered SPA)"
       }
     },
     {
@@ -10294,8 +10294,8 @@
       "verifiedDate": "2026-08-02",
       "source_check": {
         "checked": "2026-09-02",
-        "outcome": "states_no_terms",
-        "detail": "the page names Datalore but states no amount, tier or rate we can read"
+        "outcome": "unreadable",
+        "detail": "page content too short (likely JS-rendered SPA)"
       }
     },
     {
@@ -10345,8 +10345,8 @@
       "verifiedDate": "2026-07-31",
       "source_check": {
         "checked": "2026-09-02",
-        "outcome": "states_no_terms",
-        "detail": "the page names DeepAR but states no amount, tier or rate we can read"
+        "outcome": "unreadable",
+        "detail": "page content too short (likely JS-rendered SPA)"
       },
       "product_subtypes": {
         "taxonomy": "AI / ML",
@@ -10452,8 +10452,8 @@
       "verifiedDate": "2026-08-02",
       "source_check": {
         "checked": "2026-09-02",
-        "outcome": "states_no_terms",
-        "detail": "the page names drawDB but states no amount, tier or rate we can read"
+        "outcome": "unreadable",
+        "detail": "page content too short (likely JS-rendered SPA)"
       }
     },
     {
@@ -10932,8 +10932,8 @@
       "verifiedDate": "2026-07-09",
       "source_check": {
         "checked": "2026-09-02",
-        "outcome": "states_no_terms",
-        "detail": "the page names KillBait API but states no amount, tier or rate we can read"
+        "outcome": "unreadable",
+        "detail": "page content too short (likely JS-rendered SPA)"
       }
     },
     {
@@ -11302,8 +11302,8 @@
       "verifiedDate": "2026-07-06",
       "source_check": {
         "checked": "2026-09-02",
-        "outcome": "states_no_terms",
-        "detail": "the page names pdfEndpoint.com but states no amount, tier or rate we can read"
+        "outcome": "unreadable",
+        "detail": "page content too short (likely JS-rendered SPA)"
       }
     },
     {
@@ -11526,8 +11526,8 @@
       "verifiedDate": "2026-08-02",
       "source_check": {
         "checked": "2026-09-02",
-        "outcome": "states_no_terms",
-        "detail": "the page names Simplescraper but states no amount, tier or rate we can read"
+        "outcome": "unreadable",
+        "detail": "page content too short (likely JS-rendered SPA)"
       }
     },
     {
@@ -12004,8 +12004,8 @@
       "verifiedDate": "2026-08-01",
       "source_check": {
         "checked": "2026-09-02",
-        "outcome": "states_no_terms",
-        "detail": "the page names 3Cols but states no amount, tier or rate we can read"
+        "outcome": "unreadable",
+        "detail": "page content too short (likely JS-rendered SPA)"
       }
     },
     {
@@ -12293,8 +12293,8 @@
       "verifiedDate": "2026-07-06",
       "source_check": {
         "checked": "2026-09-02",
-        "outcome": "states_no_terms",
-        "detail": "the page names gokanban.io but states no amount, tier or rate we can read"
+        "outcome": "unreadable",
+        "detail": "page content too short (likely JS-rendered SPA)"
       }
     },
     {
@@ -12650,8 +12650,8 @@
       "verifiedDate": "2026-07-07",
       "source_check": {
         "checked": "2026-09-02",
-        "outcome": "states_no_terms",
-        "detail": "the page names StatusPile but states no amount, tier or rate we can read"
+        "outcome": "unreadable",
+        "detail": "page content too short (likely JS-rendered SPA)"
       },
       "product_subtypes": {
         "taxonomy": "Monitoring",
@@ -12797,8 +12797,8 @@
       "verifiedDate": "2026-08-05",
       "source_check": {
         "checked": "2026-09-02",
-        "outcome": "states_no_terms",
-        "detail": "the page names tldraw.com but states no amount, tier or rate we can read"
+        "outcome": "unreadable",
+        "detail": "page content too short (likely JS-rendered SPA)"
       }
     },
     {
@@ -12967,8 +12967,8 @@
       "verifiedDate": "2026-07-12",
       "source_check": {
         "checked": "2026-09-02",
-        "outcome": "states_no_terms",
-        "detail": "the page names wormhol.org but states no amount, tier or rate we can read"
+        "outcome": "unreadable",
+        "detail": "page content too short (likely JS-rendered SPA)"
       }
     },
     {
@@ -13495,8 +13495,8 @@
       "verifiedDate": "2026-08-05",
       "source_check": {
         "checked": "2026-09-02",
-        "outcome": "states_no_terms",
-        "detail": "the page names gerrithub.io but states no amount, tier or rate we can read"
+        "outcome": "unreadable",
+        "detail": "page content too short (likely JS-rendered SPA)"
       }
     },
     {
@@ -13631,8 +13631,8 @@
       "verifiedDate": "2026-08-06",
       "source_check": {
         "checked": "2026-09-02",
-        "outcome": "states_no_terms",
-        "detail": "the page names semanticdiff.com but states no amount, tier or rate we can read"
+        "outcome": "unreadable",
+        "detail": "page content too short (likely JS-rendered SPA)"
       }
     },
     {
@@ -14456,8 +14456,8 @@
       "verifiedDate": "2026-07-10",
       "source_check": {
         "checked": "2026-09-02",
-        "outcome": "states_no_terms",
-        "detail": "the page names CertKit but states no amount, tier or rate we can read"
+        "outcome": "unreadable",
+        "detail": "page content too short (likely JS-rendered SPA)"
       }
     },
     {
@@ -14557,7 +14557,7 @@
       ],
       "verifiedDate": "2026-07-11",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names Dotenv but states no amount, tier or rate we can read"
       }
@@ -14711,8 +14711,8 @@
       "verifiedDate": "2026-07-10",
       "source_check": {
         "checked": "2026-09-02",
-        "outcome": "states_no_terms",
-        "detail": "the page names Smart Grow Vault but states no amount, tier or rate we can read"
+        "outcome": "unreadable",
+        "detail": "page content too short (likely JS-rendered SPA)"
       }
     },
     {
@@ -15330,8 +15330,8 @@
       "verifiedDate": "2026-08-03",
       "source_check": {
         "checked": "2026-09-02",
-        "outcome": "states_no_terms",
-        "detail": "the page names runcloud.io but states no amount, tier or rate we can read"
+        "outcome": "unreadable",
+        "detail": "page content too short (likely JS-rendered SPA)"
       }
     },
     {
@@ -15472,8 +15472,8 @@
       "verifiedDate": "2026-08-08",
       "source_check": {
         "checked": "2026-09-02",
-        "outcome": "states_no_terms",
-        "detail": "the page names httpSMS but states no amount, tier or rate we can read"
+        "outcome": "unreadable",
+        "detail": "page content too short (likely JS-rendered SPA)"
       }
     },
     {
@@ -15794,8 +15794,8 @@
       "verifiedDate": "2026-08-08",
       "source_check": {
         "checked": "2026-09-02",
-        "outcome": "states_no_terms",
-        "detail": "the page names Free PO editor but states no amount, tier or rate we can read"
+        "outcome": "unreadable",
+        "detail": "page content too short (likely JS-rendered SPA)"
       }
     },
     {
@@ -17435,8 +17435,8 @@
       "verifiedDate": "2026-07-12",
       "source_check": {
         "checked": "2026-09-02",
-        "outcome": "states_no_terms",
-        "detail": "the page names Inboxes App but states no amount, tier or rate we can read"
+        "outcome": "unreadable",
+        "detail": "page content too short (likely JS-rendered SPA)"
       }
     },
     {
@@ -18750,8 +18750,8 @@
       "verifiedDate": "2026-08-07",
       "source_check": {
         "checked": "2026-09-02",
-        "outcome": "states_no_terms",
-        "detail": "the page names Pollinations.AI but states no amount, tier or rate we can read"
+        "outcome": "unreadable",
+        "detail": "page content too short (likely JS-rendered SPA)"
       },
       "product_subtypes": {
         "taxonomy": "AI / ML",
@@ -19487,8 +19487,8 @@
       "verifiedDate": "2026-07-12",
       "source_check": {
         "checked": "2026-09-02",
-        "outcome": "states_no_terms",
-        "detail": "the page names WunderGraph but states no amount, tier or rate we can read"
+        "outcome": "unreadable",
+        "detail": "page content too short (likely JS-rendered SPA)"
       },
       "product_subtypes": {
         "taxonomy": "Cloud Hosting",
@@ -20019,8 +20019,8 @@
       "verifiedDate": "2026-08-12",
       "source_check": {
         "checked": "2026-09-02",
-        "outcome": "states_no_terms",
-        "detail": "the page names Bubble but states no amount, tier or rate we can read"
+        "outcome": "unreadable",
+        "detail": "page content too short (likely JS-rendered SPA)"
       },
       "product_subtypes": {
         "taxonomy": "Cloud Hosting",
@@ -20514,8 +20514,8 @@
       "verifiedDate": "2026-08-09",
       "source_check": {
         "checked": "2026-09-02",
-        "outcome": "states_no_terms",
-        "detail": "the page names duckdns.org but states no amount, tier or rate we can read"
+        "outcome": "unreadable",
+        "detail": "page content too short (likely JS-rendered SPA)"
       }
     },
     {
@@ -20586,8 +20586,8 @@
       "verifiedDate": "2026-08-09",
       "source_check": {
         "checked": "2026-09-02",
-        "outcome": "states_no_terms",
-        "detail": "the page names LocalCert but states no amount, tier or rate we can read"
+        "outcome": "unreadable",
+        "detail": "page content too short (likely JS-rendered SPA)"
       }
     },
     {
@@ -21302,8 +21302,8 @@
       "verifiedDate": "2026-08-17",
       "source_check": {
         "checked": "2026-09-02",
-        "outcome": "states_no_terms",
-        "detail": "the page names Xirsys but states no amount, tier or rate we can read"
+        "outcome": "unreadable",
+        "detail": "page content too short (likely JS-rendered SPA)"
       }
     },
     {
@@ -21506,8 +21506,8 @@
       "verifiedDate": "2026-08-10",
       "source_check": {
         "checked": "2026-09-02",
-        "outcome": "states_no_terms",
-        "detail": "the page names diagrams.net but states no amount, tier or rate we can read"
+        "outcome": "unreadable",
+        "detail": "page content too short (likely JS-rendered SPA)"
       }
     },
     {
@@ -22033,8 +22033,8 @@
       "verifiedDate": "2026-07-16",
       "source_check": {
         "checked": "2026-09-02",
-        "outcome": "states_no_terms",
-        "detail": "the page names Tweek but states no amount, tier or rate we can read"
+        "outcome": "unreadable",
+        "detail": "page content too short (likely JS-rendered SPA)"
       }
     },
     {
@@ -22138,8 +22138,8 @@
       "verifiedDate": "2026-07-16",
       "source_check": {
         "checked": "2026-09-02",
-        "outcome": "states_no_terms",
-        "detail": "the page names Dropshare but states no amount, tier or rate we can read"
+        "outcome": "unreadable",
+        "detail": "page content too short (likely JS-rendered SPA)"
       }
     },
     {
@@ -22246,8 +22246,8 @@
       "verifiedDate": "2026-07-17",
       "source_check": {
         "checked": "2026-09-02",
-        "outcome": "states_no_terms",
-        "detail": "the page names GoFile.io but states no amount, tier or rate we can read"
+        "outcome": "unreadable",
+        "detail": "page content too short (likely JS-rendered SPA)"
       }
     },
     {
@@ -22822,8 +22822,8 @@
       "verifiedDate": "2026-07-17",
       "source_check": {
         "checked": "2026-09-02",
-        "outcome": "states_no_terms",
-        "detail": "the page names Ant Design Landing Page but states no amount, tier or rate we can read"
+        "outcome": "unreadable",
+        "detail": "page content too short (likely JS-rendered SPA)"
       }
     },
     {
@@ -23164,8 +23164,8 @@
       "verifiedDate": "2026-07-17",
       "source_check": {
         "checked": "2026-09-02",
-        "outcome": "states_no_terms",
-        "detail": "the page names Gradientos but states no amount, tier or rate we can read"
+        "outcome": "unreadable",
+        "detail": "page content too short (likely JS-rendered SPA)"
       }
     },
     {
@@ -23470,8 +23470,8 @@
       "verifiedDate": "2026-07-20",
       "source_check": {
         "checked": "2026-09-02",
-        "outcome": "states_no_terms",
-        "detail": "the page names Mastershot but states no amount, tier or rate we can read"
+        "outcome": "unreadable",
+        "detail": "page content too short (likely JS-rendered SPA)"
       }
     },
     {
@@ -23542,8 +23542,8 @@
       "verifiedDate": "2026-07-21",
       "source_check": {
         "checked": "2026-09-02",
-        "outcome": "states_no_terms",
-        "detail": "the page names mockupmark.com but states no amount, tier or rate we can read"
+        "outcome": "unreadable",
+        "detail": "page content too short (likely JS-rendered SPA)"
       }
     },
     {
@@ -23668,8 +23668,8 @@
       "verifiedDate": "2026-07-20",
       "source_check": {
         "checked": "2026-09-02",
-        "outcome": "states_no_terms",
-        "detail": "the page names okso.app but states no amount, tier or rate we can read"
+        "outcome": "unreadable",
+        "detail": "page content too short (likely JS-rendered SPA)"
       }
     },
     {
@@ -23740,8 +23740,8 @@
       "verifiedDate": "2026-08-25",
       "source_check": {
         "checked": "2026-09-02",
-        "outcome": "states_no_terms",
-        "detail": "the page names Pravatar but states no amount, tier or rate we can read"
+        "outcome": "unreadable",
+        "detail": "page content too short (likely JS-rendered SPA)"
       }
     },
     {
@@ -23902,8 +23902,8 @@
       "verifiedDate": "2026-04-05",
       "source_check": {
         "checked": "2026-09-02",
-        "outcome": "states_no_terms",
-        "detail": "the page names smartmockups.com but states no amount, tier or rate we can read"
+        "outcome": "unreadable",
+        "detail": "page content too short (likely JS-rendered SPA)"
       }
     },
     {
@@ -24028,8 +24028,8 @@
       "verifiedDate": "2026-07-19",
       "source_check": {
         "checked": "2026-09-02",
-        "outcome": "states_no_terms",
-        "detail": "the page names Tailark but states no amount, tier or rate we can read"
+        "outcome": "unreadable",
+        "detail": "page content too short (likely JS-rendered SPA)"
       }
     },
     {
@@ -24118,8 +24118,8 @@
       "verifiedDate": "2026-07-20",
       "source_check": {
         "checked": "2026-09-02",
-        "outcome": "states_no_terms",
-        "detail": "the page names tweakcn but states no amount, tier or rate we can read"
+        "outcome": "unreadable",
+        "detail": "page content too short (likely JS-rendered SPA)"
       }
     },
     {
@@ -24586,8 +24586,8 @@
       "verifiedDate": "2026-08-09",
       "source_check": {
         "checked": "2026-09-02",
-        "outcome": "states_no_terms",
-        "detail": "the page names osmnames but states no amount, tier or rate we can read"
+        "outcome": "unreadable",
+        "detail": "page content too short (likely JS-rendered SPA)"
       }
     },
     {
@@ -24639,8 +24639,8 @@
       "verifiedDate": "2026-07-20",
       "source_check": {
         "checked": "2026-09-02",
-        "outcome": "states_no_terms",
-        "detail": "the page names build.opensuse.org but states no amount, tier or rate we can read"
+        "outcome": "ok",
+        "detail": "text"
       }
     },
     {
@@ -24996,8 +24996,8 @@
       "verifiedDate": "2026-08-12",
       "source_check": {
         "checked": "2026-09-02",
-        "outcome": "states_no_terms",
-        "detail": "the page names JDoodle but states no amount, tier or rate we can read"
+        "outcome": "unreadable",
+        "detail": "page content too short (likely JS-rendered SPA)"
       }
     },
     {
@@ -25592,8 +25592,8 @@
       "verifiedDate": "2026-07-22",
       "source_check": {
         "checked": "2026-09-02",
-        "outcome": "states_no_terms",
-        "detail": "the page names LogSpot but states no amount, tier or rate we can read"
+        "outcome": "ok",
+        "detail": "text"
       }
     },
     {
@@ -26094,8 +26094,8 @@
       "verifiedDate": "2026-08-12",
       "source_check": {
         "checked": "2026-09-02",
-        "outcome": "states_no_terms",
-        "detail": "the page names ParityVend but states no amount, tier or rate we can read"
+        "outcome": "unreadable",
+        "detail": "page content too short (likely JS-rendered SPA)"
       }
     },
     {
@@ -26515,8 +26515,8 @@
       "verifiedDate": "2026-07-21",
       "source_check": {
         "checked": "2026-09-02",
-        "outcome": "states_no_terms",
-        "detail": "the page names BinShare.net but states no amount, tier or rate we can read"
+        "outcome": "unreadable",
+        "detail": "page content too short (likely JS-rendered SPA)"
       }
     },
     {
@@ -26549,8 +26549,8 @@
       "verifiedDate": "2026-07-24",
       "source_check": {
         "checked": "2026-09-02",
-        "outcome": "states_no_terms",
-        "detail": "the page names Bricks Note Calculator but states no amount, tier or rate we can read"
+        "outcome": "unreadable",
+        "detail": "page content too short (likely JS-rendered SPA)"
       }
     },
     {
@@ -26566,8 +26566,8 @@
       "verifiedDate": "2026-07-24",
       "source_check": {
         "checked": "2026-09-02",
-        "outcome": "states_no_terms",
-        "detail": "the page names Carbon.now.sh but states no amount, tier or rate we can read"
+        "outcome": "unreadable",
+        "detail": "page content too short (likely JS-rendered SPA)"
       }
     },
     {
@@ -26855,8 +26855,8 @@
       "verifiedDate": "2026-07-27",
       "source_check": {
         "checked": "2026-09-02",
-        "outcome": "states_no_terms",
-        "detail": "the page names ray.so but states no amount, tier or rate we can read"
+        "outcome": "unreadable",
+        "detail": "page content too short (likely JS-rendered SPA)"
       }
     },
     {
@@ -27025,8 +27025,8 @@
       "verifiedDate": "2026-07-21",
       "source_check": {
         "checked": "2026-09-02",
-        "outcome": "states_no_terms",
-        "detail": "the page names UUID Generator but states no amount, tier or rate we can read"
+        "outcome": "unreadable",
+        "detail": "page content too short (likely JS-rendered SPA)"
       }
     },
     {
@@ -27401,8 +27401,8 @@
       },
       "source_check": {
         "checked": "2026-09-02",
-        "outcome": "states_no_terms",
-        "detail": "the page names Twilio Startups Program but states no amount, tier or rate we can read"
+        "outcome": "unreadable",
+        "detail": "page content too short (likely JS-rendered SPA)"
       }
     },
     {
@@ -31358,8 +31358,8 @@
       "verifiedDate": "2026-08-17",
       "source_check": {
         "checked": "2026-09-02",
-        "outcome": "states_no_terms",
-        "detail": "the page names LLM7.io but states no amount, tier or rate we can read"
+        "outcome": "unreadable",
+        "detail": "page content too short (likely JS-rendered SPA)"
       },
       "product_subtypes": {
         "taxonomy": "AI / ML",
@@ -31431,8 +31431,8 @@
       "verifiedDate": "2026-08-20",
       "source_check": {
         "checked": "2026-09-02",
-        "outcome": "does_not_name_vendor",
-        "detail": "the page never names Zhipu AI and is not served from its domain"
+        "outcome": "unreadable",
+        "detail": "page content too short (likely JS-rendered SPA)"
       },
       "product_subtypes": {
         "taxonomy": "AI / ML",
@@ -31595,8 +31595,8 @@
       "verifiedDate": "2026-08-20",
       "source_check": {
         "checked": "2026-09-02",
-        "outcome": "states_no_terms",
-        "detail": "the page names YouTube but states no amount, tier or rate we can read"
+        "outcome": "unreadable",
+        "detail": "page content too short (likely JS-rendered SPA)"
       }
     },
     {
@@ -31696,8 +31696,8 @@
       "verifiedDate": "2026-08-20",
       "source_check": {
         "checked": "2026-09-02",
-        "outcome": "states_no_terms",
-        "detail": "the page names Pandora but states no amount, tier or rate we can read"
+        "outcome": "unreadable",
+        "detail": "page content too short (likely JS-rendered SPA)"
       }
     },
     {
@@ -31737,8 +31737,8 @@
       "verifiedDate": "2026-08-22",
       "source_check": {
         "checked": "2026-09-02",
-        "outcome": "states_no_terms",
-        "detail": "the page names SoundCloud but states no amount, tier or rate we can read"
+        "outcome": "unreadable",
+        "detail": "page content too short (likely JS-rendered SPA)"
       }
     },
     {
@@ -32576,7 +32576,7 @@
       ],
       "verifiedDate": "2026-08-27",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names Inkscape but states no amount, tier or rate we can read"
       }
@@ -33278,8 +33278,8 @@
       "verifiedDate": "2026-08-21",
       "source_check": {
         "checked": "2026-09-02",
-        "outcome": "states_no_terms",
-        "detail": "the page names Insight Timer but states no amount, tier or rate we can read"
+        "outcome": "unreadable",
+        "detail": "page content too short (likely JS-rendered SPA)"
       }
     },
     {

--- a/scripts/mutate-1263.sh
+++ b/scripts/mutate-1263.sh
@@ -1,0 +1,137 @@
+#!/usr/bin/env bash
+set -u
+
+REPO="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$REPO" || exit 1
+
+VERIFY="scripts/verify-freshness.js"
+BACKUP_DIR="$(mktemp -d)"
+cp "$VERIFY" "$BACKUP_DIR/verify-freshness.js"
+
+restore() {
+  cp "$BACKUP_DIR/verify-freshness.js" "$VERIFY"
+}
+trap restore EXIT
+
+killed=0
+survived=0
+TESTS="test/short-page-floor.test.ts test/whole-page-read.test.ts test/change-gate.test.ts test/verify-freshness.test.ts test/verification-state.test.ts"
+
+run_mutation() {
+  local name="$1"
+  shift
+  echo "=== $name"
+  restore
+  "$@"
+  if diff -q "$BACKUP_DIR/verify-freshness.js" "$VERIFY" > /dev/null; then
+    echo "    NOT APPLIED: the mutation changed no file, so it proves nothing"
+    survived=$((survived + 1))
+    return
+  fi
+  if timeout 900 node --test --test-concurrency 1 $TESTS > /tmp/mutate-1263-test.log 2>&1; then
+    echo "    SURVIVED"
+    survived=$((survived + 1))
+  else
+    echo "    KILLED: $(grep -c '✖ ' /tmp/mutate-1263-test.log) failing assertion(s)"
+    grep '✖ ' /tmp/mutate-1263-test.log | head -4
+    killed=$((killed + 1))
+  fi
+}
+
+py() { python3 - "$@"; }
+
+m_floor_back_to_fifty() {
+  py <<'PY'
+p = "scripts/verify-freshness.js"
+s = open(p).read()
+s = s.replace("export const MIN_PAGE_TEXT_LENGTH = 500;", "export const MIN_PAGE_TEXT_LENGTH = 50;")
+open(p, "w").write(s)
+PY
+}
+
+m_floor_raised_past_the_shortest_confirmed_page() {
+  py <<'PY'
+p = "scripts/verify-freshness.js"
+s = open(p).read()
+s = s.replace("export const MIN_PAGE_TEXT_LENGTH = 500;", "export const MIN_PAGE_TEXT_LENGTH = 1000;")
+open(p, "w").write(s)
+PY
+}
+
+m_floor_off_by_one_at_the_boundary() {
+  py <<'PY'
+p = "scripts/verify-freshness.js"
+s = open(p).read()
+s = s.replace("if (page.text.length < floor) {", "if (page.text.length <= floor) {")
+open(p, "w").write(s)
+PY
+}
+
+m_floor_not_applied_at_fetch() {
+  py <<'PY'
+p = "scripts/verify-freshness.js"
+s = open(p).read()
+s = s.replace("""    return withMinimumLength({
+      ok: true,
+      text,
+      truncated: false,
+      finalUrl: res.url || url,
+    });""", """    return {
+      ok: true,
+      text,
+      truncated: false,
+      finalUrl: res.url || url,
+    };""")
+open(p, "w").write(s)
+PY
+}
+
+m_refusal_drops_the_measured_length() {
+  py <<'PY'
+p = "scripts/verify-freshness.js"
+s = open(p).read()
+s = s.replace("return { ok: false, error: PAGE_TOO_SHORT_ERROR, chars: page.text.length };", "return { ok: false, error: PAGE_TOO_SHORT_ERROR };")
+open(p, "w").write(s)
+PY
+}
+
+m_refusal_leaves_the_text_readable() {
+  py <<'PY'
+p = "scripts/verify-freshness.js"
+s = open(p).read()
+s = s.replace("return { ok: false, error: PAGE_TOO_SHORT_ERROR, chars: page.text.length };", "return { ok: true, text: page.text, chars: page.text.length };")
+open(p, "w").write(s)
+PY
+}
+
+m_refusal_renamed_out_of_the_empty_page_class() {
+  py <<'PY'
+p = "scripts/verify-freshness.js"
+s = open(p).read()
+s = s.replace('export const PAGE_TOO_SHORT_ERROR = "page content too short (likely JS-rendered SPA)";', 'export const PAGE_TOO_SHORT_ERROR = "page under the readable length";')
+open(p, "w").write(s)
+PY
+}
+
+m_floor_applied_to_a_failed_fetch() {
+  py <<'PY'
+p = "scripts/verify-freshness.js"
+s = open(p).read()
+s = s.replace("export function withMinimumLength(page, floor = MIN_PAGE_TEXT_LENGTH) {\n  if (!page.ok) return page;", "export function withMinimumLength(page, floor = MIN_PAGE_TEXT_LENGTH) {\n  if (!page.ok) return { ok: false, error: PAGE_TOO_SHORT_ERROR, chars: 0 };")
+open(p, "w").write(s)
+PY
+}
+
+run_mutation "the floor goes back to the number that let a 53-character page speak" m_floor_back_to_fifty
+run_mutation "the floor rises past the shortest page we confirm terms from" m_floor_raised_past_the_shortest_confirmed_page
+run_mutation "the boundary refuses a page of exactly the floor" m_floor_off_by_one_at_the_boundary
+run_mutation "the fetch stops applying the floor" m_floor_not_applied_at_fetch
+run_mutation "the refusal stops reporting the length it measured" m_refusal_drops_the_measured_length
+run_mutation "the refusal returns the text it refused" m_refusal_leaves_the_text_readable
+run_mutation "the refusal is renamed out of the empty-page failure class" m_refusal_renamed_out_of_the_empty_page_class
+run_mutation "the floor overwrites a fetch that never produced a body" m_floor_applied_to_a_failed_fetch
+
+restore
+echo ""
+echo "killed:   $killed"
+echo "survived: $survived"

--- a/scripts/short-page-census.js
+++ b/scripts/short-page-census.js
@@ -1,0 +1,228 @@
+#!/usr/bin/env node
+
+import { readFileSync, writeFileSync, existsSync, mkdirSync } from "node:fs";
+import { createHash } from "node:crypto";
+import { resolve, dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  MIN_PAGE_TEXT_LENGTH,
+  PAGE_TOO_SHORT_ERROR,
+  readBodyWithin,
+  withMinimumLength,
+} from "./verify-freshness.js";
+import { priceSignals } from "./change-gate.js";
+import { classifySource, sourceCheckRecord } from "./vendor-naming.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const INDEX_PATH =
+  process.env.AGENTDEALS_INDEX_PATH || resolve(__dirname, "..", "data", "index.json");
+const CONCURRENCY = 12;
+const FETCH_TIMEOUT_MS = 20_000;
+const HARD_CEILING = 64_000_000;
+const ABSENCE = new Set(["states_no_terms", "does_not_name_vendor"]);
+const OLD_FLOOR = 50;
+const CANDIDATE_FLOORS = [50, 100, 200, 500, 600, 1_000, 2_000];
+
+function arg(name, fallback = null) {
+  const at = process.argv.indexOf(name);
+  return at !== -1 ? process.argv[at + 1] : fallback;
+}
+
+function stripHtml(html) {
+  return html
+    .replace(/<script[\s\S]*?<\/script>/gi, "")
+    .replace(/<style[\s\S]*?<\/style>/gi, "")
+    .replace(/<[^>]+>/g, " ")
+    .replace(/&nbsp;/g, " ")
+    .replace(/&amp;/g, "&")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+async function fetchUnfloored(url) {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+  try {
+    const res = await fetch(url, {
+      method: "GET",
+      signal: controller.signal,
+      headers: {
+        "User-Agent":
+          "Mozilla/5.0 (compatible; AgentDeals-Verify/1.0; +https://github.com/robhunter/agentdeals)",
+        Accept: "text/html,application/xhtml+xml",
+      },
+      redirect: "follow",
+    });
+    if (!res.ok) return { ok: false, error: `HTTP ${res.status}` };
+    const body = await readBodyWithin(res, HARD_CEILING);
+    if (body.tooLarge) return { ok: false, error: `page too large: ${body.bytes} bytes` };
+    const text = stripHtml(body.html);
+    return { ok: true, text, bytes: Buffer.byteLength(body.html) };
+  } catch (err) {
+    return { ok: false, error: err.name === "AbortError" ? "timeout" : err.message };
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+async function mapWithConcurrency(items, limit, fn) {
+  let next = 0;
+  const workers = Array.from({ length: Math.min(limit, items.length) }, async () => {
+    while (true) {
+      const i = next++;
+      if (i >= items.length) return;
+      await fn(items[i]);
+    }
+  });
+  await Promise.all(workers);
+}
+
+function outcomeAt(offer, page, floor) {
+  const floored = withMinimumLength(page, floor);
+  const signals = floored.ok ? priceSignals(floored.text).length : 0;
+  return classifySource(offer, floored, signals).outcome;
+}
+
+function bodyWasRead(page) {
+  return page.ok || page.error === PAGE_TOO_SHORT_ERROR;
+}
+
+const BUCKET_EDGES = [50, 100, 200, 500, 1_000, 2_000, 5_000];
+
+function bucket(chars) {
+  if (chars === null) return "no fetch";
+  for (const edge of BUCKET_EDGES) {
+    if (chars < edge) return `under ${edge}`;
+  }
+  return "5000 and over";
+}
+
+async function main() {
+  const out = arg("--out", "/tmp/short-page-census.json");
+  const cacheDir = arg("--cache", null);
+  const write = process.argv.includes("--write");
+  const checked = arg("--checked", new Date().toISOString().slice(0, 10));
+  const floor = Number(arg("--floor", String(MIN_PAGE_TEXT_LENGTH)));
+
+  const data = JSON.parse(readFileSync(INDEX_PATH, "utf-8"));
+  const all = (data.offers || []).filter((o) => o.url);
+  const absence = all.filter((o) => ABSENCE.has(o.source_check?.outcome));
+  const confirmed = all.filter((o) => o.source_check?.outcome === "ok");
+  const offers = [...absence, ...confirmed];
+  const urls = [...new Set(offers.map((o) => o.url))];
+
+  console.error(
+    `floor ${floor}; ${absence.length} absence + ${confirmed.length} ok = ${offers.length} offers, ${urls.length} distinct URLs`
+  );
+
+  if (cacheDir && !existsSync(cacheDir)) mkdirSync(cacheDir, { recursive: true });
+  const cachePath = (url) =>
+    join(cacheDir ?? "", `${createHash("sha1").update(url).digest("hex")}.json`);
+
+  let done = 0;
+  const pages = new Map();
+  await mapWithConcurrency(urls, CONCURRENCY, async (url) => {
+    let page;
+    if (cacheDir && existsSync(cachePath(url))) {
+      page = JSON.parse(readFileSync(cachePath(url), "utf-8"));
+    } else {
+      page = await fetchUnfloored(url);
+      if (cacheDir) writeFileSync(cachePath(url), JSON.stringify(page));
+    }
+    done++;
+    if (done % 100 === 0) console.error(`  ${done}/${urls.length}`);
+    pages.set(url, page);
+  });
+
+  let restamped = 0;
+  let held = 0;
+  const rows = offers.map((offer) => {
+    const page = pages.get(offer.url) ?? { ok: false, error: "not fetched" };
+    const stored = offer.source_check?.outcome ?? null;
+    const chars = page.ok ? page.text.length : null;
+    const row = {
+      vendor: offer.vendor,
+      slug: offer.slug ?? null,
+      url: offer.url,
+      stored,
+      fetch_ok: page.ok,
+      error: page.ok ? null : page.error,
+      chars,
+      bytes: page.bytes ?? null,
+      outcome_old: outcomeAt(offer, page, OLD_FLOOR),
+      outcome_new: outcomeAt(offer, page, floor),
+    };
+    if (write && ABSENCE.has(stored)) {
+      const floored = withMinimumLength(page, floor);
+      if (bodyWasRead(floored)) {
+        offer.source_check = sourceCheckRecord(
+          offer,
+          floored,
+          floored.ok ? priceSignals(floored.text).length : 0,
+          checked
+        );
+        restamped++;
+      } else {
+        held++;
+      }
+    }
+    return row;
+  });
+
+  writeFileSync(out, JSON.stringify(rows, null, 1) + "\n");
+  if (write) writeFileSync(INDEX_PATH, JSON.stringify(data, null, 2) + "\n");
+
+  const absenceRows = rows.filter((r) => ABSENCE.has(r.stored));
+  const okRows = rows.filter((r) => r.stored === "ok");
+  const readAbsence = absenceRows.filter((r) => r.fetch_ok);
+  const readOk = okRows.filter((r) => r.fetch_ok);
+
+  const counts = new Map();
+  for (const r of readAbsence) counts.set(bucket(r.chars), (counts.get(bucket(r.chars)) ?? 0) + 1);
+
+  console.error("");
+  console.error(`absence records          ${absenceRows.length}`);
+  console.error(`  body read              ${readAbsence.length}`);
+  console.error(`  fetch failed           ${absenceRows.length - readAbsence.length}`);
+  for (const key of [...BUCKET_EDGES.map((e) => `under ${e}`), "5000 and over"]) {
+    console.error(`    ${key.padEnd(16)} ${counts.get(key) ?? 0}`);
+  }
+
+  console.error("");
+  console.error("floor      absence -> unreadable      ok records lost");
+  for (const candidate of CANDIDATE_FLOORS) {
+    const moved = readAbsence.filter((r) => r.chars < candidate).length;
+    const lost = readOk.filter((r) => r.chars < candidate).length;
+    console.error(`${String(candidate).padEnd(10)} ${String(moved).padEnd(24)} ${lost}`);
+  }
+
+  const shortestOk = [...readOk].sort((a, b) => a.chars - b.chars).slice(0, 6);
+  console.error("");
+  console.error("shortest confirmed pages in the catalog");
+  for (const r of shortestOk) console.error(`  ${String(r.chars).padStart(6)}  ${r.vendor}  ${r.url}`);
+
+  const movesToUnreadable = readAbsence.filter(
+    (r) => r.outcome_new === "unreadable" && r.outcome_old !== "unreadable"
+  );
+  const standsAtNewFloor = readAbsence.filter((r) => ABSENCE.has(r.outcome_new));
+  const nowOk = readAbsence.filter((r) => r.outcome_new === "ok");
+
+  console.error("");
+  console.error(`re-read at floor ${floor}`);
+  console.error(`  moves to unreadable    ${movesToUnreadable.length}`);
+  console.error(`  now reads ok           ${nowOk.length}`);
+  console.error(`  absence claim stands   ${standsAtNewFloor.length}`);
+  if (write) {
+    console.error("");
+    console.error(`re-stamped               ${restamped}`);
+    console.error(`held on a failed fetch   ${held}`);
+  }
+  console.error("");
+  console.error(`wrote ${out}`);
+}
+
+main();

--- a/scripts/sweep-bodies.mjs
+++ b/scripts/sweep-bodies.mjs
@@ -1,0 +1,58 @@
+import { spawn } from "node:child_process";
+import { createHash } from "node:crypto";
+import { writeFileSync, mkdirSync, existsSync } from "node:fs";
+import path from "node:path";
+
+const repo = process.argv[2];
+const outDir = process.argv[3];
+const CONCURRENCY = 16;
+
+function startServer() {
+  return new Promise((resolve, reject) => {
+    const p = spawn("node", [path.join(repo, "dist", "serve.js")], {
+      cwd: repo,
+      stdio: ["pipe", "pipe", "pipe"],
+      env: { ...process.env, PORT: "0", BASE_URL: "http://127.0.0.1", TZ: "UTC" },
+    });
+    const timeout = setTimeout(() => { p.kill("SIGKILL"); reject(new Error("timeout")); }, 60000);
+    const onData = (b) => {
+      const m = b.toString().match(/running on http:\/\/localhost:(\d+)/);
+      if (m) { clearTimeout(timeout); resolve({ proc: p, port: parseInt(m[1], 10) }); }
+    };
+    p.stderr.on("data", onData);
+    p.stdout.on("data", onData);
+    p.on("error", (e) => { clearTimeout(timeout); reject(e); });
+  });
+}
+
+const { proc, port } = await startServer();
+const base = `http://127.0.0.1:${port}`;
+const stripHost = (u) => u.replace(/^https?:\/\/[^/]+/, "");
+
+const index = await (await fetch(`${base}/sitemap.xml`)).text();
+const paths = new Set(["/", "/criteria", "/best", "/sitemap.xml"]);
+for (const m of index.matchAll(/<loc>([^<]+)<\/loc>/g)) {
+  const child = stripHost(m[1]);
+  paths.add(child);
+  const xml = await (await fetch(`${base}${child}`)).text();
+  for (const l of xml.matchAll(/<loc>([^<]+)<\/loc>/g)) paths.add(stripHost(l[1]));
+}
+
+if (!existsSync(outDir)) mkdirSync(outDir, { recursive: true });
+const list = [...paths].sort();
+const results = {};
+let i = 0;
+await Promise.all(Array.from({ length: CONCURRENCY }, async () => {
+  while (i < list.length) {
+    const p = list[i++];
+    const res = await fetch(`${base}${p}`);
+    const body = await res.text();
+    const digest = createHash("sha256").update(body).digest("hex");
+    results[p] = `${res.status} ${digest.slice(0, 16)}`;
+    writeFileSync(path.join(outDir, `${createHash("sha1").update(p).digest("hex")}.html`), body);
+  }
+}));
+
+writeFileSync(path.join(outDir, "index.json"), JSON.stringify(results, null, 0));
+console.error(`${list.length} paths -> ${outDir}`);
+proc.kill("SIGKILL");

--- a/scripts/verify-freshness.js
+++ b/scripts/verify-freshness.js
@@ -13,6 +13,8 @@ const FETCH_TIMEOUT_MS = 15_000;
 const RATE_LIMIT_MS = 500;
 export const MAX_PAGE_TEXT_LENGTH = 12_000;
 export const MAX_PAGE_BYTES = 16_000_000;
+export const MIN_PAGE_TEXT_LENGTH = 500;
+export const PAGE_TOO_SHORT_ERROR = "page content too short (likely JS-rendered SPA)";
 const MAX_RESPONSE_TOKENS = 400;
 
 export const VERIFIER_MODEL = "google/gemma-3-27b-it";
@@ -59,6 +61,14 @@ function stripHtml(html) {
 
 export function pageTooLargeError(bytes) {
   return `page too large: ${bytes} bytes`;
+}
+
+export function withMinimumLength(page, floor = MIN_PAGE_TEXT_LENGTH) {
+  if (!page.ok) return page;
+  if (page.text.length < floor) {
+    return { ok: false, error: PAGE_TOO_SHORT_ERROR, chars: page.text.length };
+  }
+  return page;
 }
 
 async function cancelBody(res) {
@@ -115,15 +125,12 @@ export async function fetchPageText(url, options = {}) {
       return { ok: false, error: pageTooLargeError(body.bytes) };
     }
     const text = stripHtml(body.html);
-    if (text.length < 50) {
-      return { ok: false, error: "page content too short (likely JS-rendered SPA)" };
-    }
-    return {
+    return withMinimumLength({
       ok: true,
       text,
       truncated: false,
       finalUrl: res.url || url,
-    };
+    });
   } catch (err) {
     const reason = err.name === "AbortError" ? "timeout" : err.message;
     return { ok: false, error: reason };

--- a/scripts/whole-page-census.js
+++ b/scripts/whole-page-census.js
@@ -4,7 +4,7 @@ import { readFileSync, writeFileSync, existsSync, mkdirSync } from "node:fs";
 import { createHash } from "node:crypto";
 import { resolve, dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
-import { MAX_PAGE_TEXT_LENGTH, readBodyWithin } from "./verify-freshness.js";
+import { MAX_PAGE_TEXT_LENGTH, readBodyWithin, withMinimumLength } from "./verify-freshness.js";
 import { priceSignals } from "./change-gate.js";
 import { pageNamesVendor, classifySource, sourceCheckRecord } from "./vendor-naming.js";
 
@@ -54,10 +54,7 @@ async function fetchMeasured(url) {
     if (body.tooLarge) return { ok: false, error: `page too large: ${body.bytes} bytes` };
     const bytes = Buffer.byteLength(body.html);
     const text = stripHtml(body.html);
-    if (text.length < 50) {
-      return { ok: false, error: "page content too short (likely JS-rendered SPA)" };
-    }
-    return { ok: true, text, bytes };
+    return withMinimumLength({ ok: true, text, bytes });
   } catch (err) {
     return { ok: false, error: err.name === "AbortError" ? "timeout" : err.message };
   } finally {

--- a/test/change-gate.test.ts
+++ b/test/change-gate.test.ts
@@ -46,7 +46,7 @@ const {
 } = await import("../scripts/change-gate.js");
 
 const { runAiMode, summaryLines } = await import("../scripts/reverify-rolling.js");
-const { fetchPageText, MAX_PAGE_TEXT_LENGTH } = await import("../scripts/verify-freshness.js");
+const { fetchPageText, MAX_PAGE_TEXT_LENGTH, MIN_PAGE_TEXT_LENGTH } = await import("../scripts/verify-freshness.js");
 const { CHANGE_TYPES } = await import("../scripts/change-log.js");
 
 const NOW = new Date("2026-08-28T09:00:00Z");
@@ -577,9 +577,11 @@ describe("a recorded change must describe a change", () => {
     }
 
     it("says a short page was read whole", async () => {
-      const page = await readWith(html(10));
+      const repeats = Math.ceil(MIN_PAGE_TEXT_LENGTH / "pricing detail ".length);
+      const page = await readWith(html(repeats));
       assert.strictEqual(page.ok, true);
       assert.strictEqual(page.truncated, false);
+      assert.ok(page.text.length < MAX_PAGE_TEXT_LENGTH);
     });
 
     it("says a page longer than the verifier's prompt limit was also read whole", async () => {

--- a/test/short-page-floor.test.ts
+++ b/test/short-page-floor.test.ts
@@ -1,0 +1,183 @@
+import { describe, it } from "node:test";
+import assert from "node:assert";
+import { readFileSync, readdirSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const SCRIPTS = path.join(__dirname, "..", "scripts");
+
+const {
+  fetchPageText,
+  withMinimumLength,
+  MIN_PAGE_TEXT_LENGTH,
+  PAGE_TOO_SHORT_ERROR,
+} = await import("../scripts/verify-freshness.js");
+const { priceSignals } = await import("../scripts/change-gate.js");
+const { classifySource } = await import("../scripts/vendor-naming.js");
+const { classifyFetchError, FAILURE_EMPTY_PAGE } = await import("../scripts/verification-state.js");
+
+const PREVIOUS_FLOOR = 50;
+
+const SHORTEST_CONFIRMED_PAGES = [
+  { host: "cdnjs.com", chars: 694 },
+  { host: "formlets.com", chars: 825 },
+  { host: "groq.com/pricing", chars: 950 },
+];
+
+const ABSENCE_CLAIMS_UNDER_THE_NEW_FLOOR = 63;
+const CONFIRMED_RECORDS_UNDER_THE_NEW_FLOOR = 0;
+
+const OFFER = {
+  vendor: "Widgetson",
+  category: "Monitoring",
+  tier: "Free",
+  description: "Free for up to 5 hosts",
+  url: "https://widgetson.example/pricing",
+};
+
+function pageOfExactly(chars: number, opening: string) {
+  const filler = " We help teams ship software they can operate.";
+  let inner = opening;
+  assert.ok(inner.length <= chars, `the opening is longer than the ${chars}-character fixture`);
+  while (inner.length + filler.length <= chars) inner += filler;
+  const short = chars - inner.length;
+  if (short > 0) inner += ` ${"o".repeat(short - 1)}`;
+  return `<html><body><p>${inner}</p></body></html>`;
+}
+
+const STATES_ITS_TERMS = `${OFFER.vendor} pricing. Free plan: $0 per month for up to 5 hosts.`;
+const STATES_NO_TERMS = `${OFFER.vendor} pricing. Talk to our team about what you need.`;
+
+async function readWith(body: string) {
+  const original = globalThis.fetch;
+  globalThis.fetch = (async () => new Response(body, { status: 200 })) as typeof fetch;
+  try {
+    return await fetchPageText(OFFER.url);
+  } finally {
+    globalThis.fetch = original;
+  }
+}
+
+function outcomeFor(page: { ok: boolean; text?: string }) {
+  const signals = page.ok ? priceSignals(page.text as string).length : 0;
+  return classifySource(OFFER, page, signals).outcome;
+}
+
+describe("a page shorter than the floor is one we did not read", () => {
+  it("refuses a page of 60 characters that names the vendor and states no price", async () => {
+    const page = await readWith(pageOfExactly(60, STATES_NO_TERMS));
+    assert.strictEqual(page.ok, false);
+    assert.strictEqual(page.error, PAGE_TOO_SHORT_ERROR);
+    assert.strictEqual(outcomeFor(page), "unreadable");
+  });
+
+  it("would have called that same page one that states no terms, at the previous floor", async () => {
+    const original = globalThis.fetch;
+    globalThis.fetch = (async () =>
+      new Response(pageOfExactly(60, STATES_NO_TERMS), { status: 200 })) as typeof fetch;
+    let text: string;
+    try {
+      const raw = await fetchPageText(OFFER.url);
+      text = raw.text ?? "";
+    } finally {
+      globalThis.fetch = original;
+    }
+    assert.strictEqual(text, "", "the reader must return no text below the floor");
+    const asPreviouslyRead = withMinimumLength(
+      { ok: true, text: pageOfExactly(60, STATES_NO_TERMS).replace(/<[^>]+>/g, "").trim() },
+      PREVIOUS_FLOOR
+    );
+    assert.strictEqual(outcomeFor(asPreviouslyRead), "states_no_terms");
+  });
+
+  it("reports the length it measured, so the refusal can be sized", async () => {
+    const page = await readWith(pageOfExactly(53, `${OFFER.vendor} pricing.`));
+    assert.strictEqual(page.chars, 53);
+  });
+
+  it("refuses a page that states its terms but renders too little of them to read", async () => {
+    const page = await readWith(pageOfExactly(120, STATES_ITS_TERMS));
+    assert.strictEqual(page.ok, false);
+    assert.strictEqual(outcomeFor(page), "unreadable");
+  });
+
+  it("keeps the refusal in the empty-page failure class", () => {
+    assert.strictEqual(classifyFetchError(PAGE_TOO_SHORT_ERROR), FAILURE_EMPTY_PAGE);
+  });
+});
+
+describe("the floor sits above every confirmed page in the catalog", () => {
+  for (const { host, chars } of SHORTEST_CONFIRMED_PAGES) {
+    it(`reads a ${chars}-character page, the length ${host} strips to`, async () => {
+      const page = await readWith(pageOfExactly(chars, STATES_ITS_TERMS));
+      assert.strictEqual(page.ok, true);
+      assert.strictEqual(page.text.length, chars);
+      assert.strictEqual(outcomeFor(page), "ok");
+    });
+  }
+
+  it("leaves the shortest confirmed page room above the floor", () => {
+    const shortest = Math.min(...SHORTEST_CONFIRMED_PAGES.map((p) => p.chars));
+    assert.ok(
+      MIN_PAGE_TEXT_LENGTH < shortest,
+      `a floor of ${MIN_PAGE_TEXT_LENGTH} takes ${shortest}-character pages that read their terms today`
+    );
+  });
+
+  it("sits above the previous floor by enough to reach the cohort piled on it", () => {
+    assert.ok(MIN_PAGE_TEXT_LENGTH > PREVIOUS_FLOOR);
+    assert.strictEqual(CONFIRMED_RECORDS_UNDER_THE_NEW_FLOOR, 0);
+    assert.ok(ABSENCE_CLAIMS_UNDER_THE_NEW_FLOOR > 0);
+  });
+});
+
+describe("the floor is a boundary, not a range", () => {
+  it("accepts a page of exactly the floor", async () => {
+    const page = await readWith(pageOfExactly(MIN_PAGE_TEXT_LENGTH, STATES_ITS_TERMS));
+    assert.strictEqual(page.ok, true);
+    assert.strictEqual(page.text.length, MIN_PAGE_TEXT_LENGTH);
+  });
+
+  it("refuses a page one character below it", async () => {
+    const page = await readWith(pageOfExactly(MIN_PAGE_TEXT_LENGTH - 1, STATES_ITS_TERMS));
+    assert.strictEqual(page.ok, false);
+    assert.strictEqual(page.chars, MIN_PAGE_TEXT_LENGTH - 1);
+  });
+});
+
+describe("withMinimumLength", () => {
+  it("passes a fetch that never produced a body through unchanged", () => {
+    const failed = { ok: false, error: "HTTP 429" };
+    assert.strictEqual(withMinimumLength(failed), failed);
+  });
+
+  it("applies the shared floor when given none", () => {
+    const text = "a".repeat(MIN_PAGE_TEXT_LENGTH - 1);
+    assert.strictEqual(withMinimumLength({ ok: true, text }).ok, false);
+    assert.strictEqual(withMinimumLength({ ok: true, text: `${text}a` }).ok, true);
+  });
+
+  it("keeps every field of a page it accepts", () => {
+    const page = { ok: true, text: "a".repeat(MIN_PAGE_TEXT_LENGTH), truncated: false, finalUrl: OFFER.url };
+    assert.deepStrictEqual(withMinimumLength(page), page);
+  });
+});
+
+describe("one floor, named once", () => {
+  it("is the only place a fetched page is measured for length", () => {
+    const files = readdirSync(SCRIPTS).filter((f) => f.endsWith(".js") || f.endsWith(".mjs"));
+    const naming = files.filter((f) =>
+      readFileSync(path.join(SCRIPTS, f), "utf-8").includes(PAGE_TOO_SHORT_ERROR)
+    );
+    assert.deepStrictEqual(naming, ["verify-freshness.js"]);
+  });
+
+  it("applies inside the function that fetches the page", () => {
+    const source = readFileSync(path.join(SCRIPTS, "verify-freshness.js"), "utf-8");
+    const from = source.indexOf("export async function fetchPageText");
+    const to = source.indexOf("export function createVerifierClient", from);
+    assert.ok(from !== -1 && to > from);
+    assert.match(source.slice(from, to), /withMinimumLength\(/);
+  });
+});

--- a/test/whole-page-read.test.ts
+++ b/test/whole-page-read.test.ts
@@ -14,6 +14,7 @@ const {
   pageTooLargeError,
   MAX_PAGE_TEXT_LENGTH,
   MAX_PAGE_BYTES,
+  MIN_PAGE_TEXT_LENGTH,
   VERIFIER_MODEL,
   VERIFIER_BASE_URL,
 } = await import("../scripts/verify-freshness.js");
@@ -30,7 +31,8 @@ function pageStatingNoTermsAtAnyLength(vendor: string) {
   return `<html><body><nav>${nav(vendor)}</nav><main>${vendor} helps teams ship. Talk to our team about what you need.</main></body></html>`;
 }
 
-const SHORT_PAGE = `<html><body><p>Widgetson pricing. The free plan is $0 per month for up to 5 hosts, with 1-day retention.</p></body></html>`;
+const SHORT_PAGE_BODY = `Widgetson pricing. The free plan is $0 per month for up to 5 hosts, with 1-day retention.${" Paid plans add retention, alerting and single sign-on.".repeat(9)}`;
+const SHORT_PAGE = `<html><body><p>${SHORT_PAGE_BODY}</p></body></html>`;
 
 async function readWith(body: string, init: ResponseInit = {}, options = {}) {
   const original = globalThis.fetch;
@@ -98,6 +100,7 @@ describe("a page is read to its end, not to a fixed number of characters", () =>
     const page = await readWith(SHORT_PAGE);
     assert.strictEqual(page.ok, true);
     assert.strictEqual(page.truncated, false);
+    assert.ok(page.text.length >= MIN_PAGE_TEXT_LENGTH && page.text.length < MAX_PAGE_TEXT_LENGTH);
     assert.strictEqual(outcomeFor(page.text), "ok");
   });
 });


### PR DESCRIPTION
Refs #1263.

`fetchPageText` refused a page under **50** stripped characters as a JS-rendered shell. A React shell with a `<title>`, a meta description and a nav clears 50, so it was read as a fully-fetched page and classified `states_no_terms`. `xirsys.com/pricing/` strips to 53 characters, and `/vendor/xirsys` said the page states no terms we can read — twelve times.

The floor is now `MIN_PAGE_TEXT_LENGTH = 500`, applied by `withMinimumLength`, which `fetchPageText` and the census harness both call so there is one number rather than two.

## Where the number comes from

Every URL in both populations re-fetched today through `fetchPageText`'s own reader.

| floor | absence claims that become `unreadable` | confirmed records lost |
|---|---|---|
| 50 | 0 | 0 |
| 100 | 23 | 0 |
| 200 | 40 | 0 |
| **500** | **63** | **0** |
| 600 | 70 | 0 |
| 1,000 | 89 | **3** |
| 2,000 | 163 | 26 |

The three lost at 1,000 are `cdnjs.com` (694), `formlets.com` (825) and `groq.com/pricing` (950) — the three shortest confirmed pages in the catalog, and all three read their terms. 500 is bounded on both sides by measurement.

Absence-claim length distribution, 642 of 643 records read:

| stripped text | records |
|---|---|
| under 100 | 23 |
| 100–200 | 17 |
| 200–500 | 23 |
| 500–1,000 | 26 |
| 1,000–2,000 | 74 |
| 2,000–5,000 | 199 |
| 5,000 and over | 280 |

## The re-stamp

642 of 643 records re-read and re-stamped. **63 move to `unreadable`** — 62 from `states_no_terms`, 1 from `does_not_name_vendor`, 63 distinct URLs. All four examples on a pricing path move: Xirsys (53), BrowserStack Percy (104), Formspree (222), Canva (342).

Two records move the other way, to `ok`: `build.opensuse.org` (1,864 chars) and LogSpot (6,123). Those are page changes since the last stamp, not this floor.

**All 63 movers have the floor as their sole cause** — every one of them classifies the same as its stored outcome when re-read at the old floor, so none is a stale stamp riding along. That is different from #1258, where 9 of 38 were.

**One record held: Engage (`engage.so`, HTTP 522).** The write rule is that a stamp is written when the body was read — including when it was read and found too short — and held when the fetch never produced a body, so a transport failure cannot publish a claim about a page.

Negative control: 577 of the 578 read absence-claim records above the floor still assert absence, and the one that does not is `build.opensuse.org` above.

Outcome census: `ok` 827 → 829, `states_no_terms` 550 → 486, `does_not_name_vendor` 93 → 92, `unreadable` 110 → 173.

## What the reader sees

2,577 paths swept on a local build of `main` and of this branch. **2,475 byte-identical, 102 moved, 0 status changes.**

- **77 vendor pages.** 64 are the changed records themselves — the 65th is Twilio Startups Program, a retired record whose page states the retirement instead of the source-check notice, so it is byte-identical. The other 13 moved because a neighbour's row in their comparison table changed.
- **16 `/compare`, 5 `/alternative-to`, 2 `/best`, 1 `/analytics-alternatives`, 1 `/trends`.** Every changed line is the withheld-level sentence, in the rendered page and in the FAQ JSON-LD, except `/trends/analytics`, `/analytics-alternatives` and `/best/free-analytics`, which reorder because LogSpot is no longer gated.

Across all 2,577 bodies: *"states no terms we can read"* falls 7,447 → 6,613 occurrences on 829 → 752 pages, and *"could not read the page we cite"* rises 1,176 → 2,005 on 133 → 228 pages.

`/vendor/xirsys`: 12 occurrences of the absence sentence → 0, and 0 → 12 of the sentence saying we could not read the page. 60 of the 63 movers carry zero occurrences of the absence sentence afterwards; the other 3 carry it only in a neighbour's row of a comparison table — tilda.cc, Versoly and anvil.works, all of which still assert absence correctly.

## Cohort restated for #1124

`page content too short` records: **43 → 106.** That is the browser-retry scope now.

## Tests

3,126 tests, 17 new, 0 red. `tsc --noEmit` clean, `validate-data` clean, real MCP `initialize` → `tools/call` returns Xirsys with `outcome: "unreadable"`.

Pinned as fixtures: 694, 825 and 950 characters each classify `ok`, so a later raise of the constant cannot silently take the three shortest confirmed pages. A 60-character page naming the vendor and stating no price classifies `unreadable`; at the previous floor the same page classified `states_no_terms`.

`scripts/mutate-1263.sh`: 8 mutations, 8 killed, including the floor returning to 50, rising to 1,000, moving off the boundary, leaving the fetch, and being applied to a fetch that never produced a body.

Three existing fixtures were shorter than the new floor and were lengthened; each now asserts it sits between the floor and the prompt limit, so it cannot drift under either.

## Consequence

A page between 50 and 500 characters now fails the fetch in the rolling re-verification, so after three consecutive failures it enters quarantine under `empty_page` and its `verifiedDate` stops advancing. That is correct — we should not advance a verification date on a page we did not read — but it moves about 63 URLs into a queue that was 43.
