### PR TITLE
Grade a source check by whether the page states an amount (#1268)

### DIFF
--- a/data/deal_changes.json
+++ b/data/deal_changes.json
@@ -7639,24 +7639,6 @@
       "alternatives": [],
       "detected_by": "reverify-ai",
       "recorded_date": "2026-09-02"
-    },
-    {
-      "vendor": "openobserve.ai",
-      "change_type": "record_corrected",
-      "date": "2026-09-02",
-      "summary": "Correction to our own entry. We listed a 200 GB/month ingestion free tier with 15 days retention; openobserve.ai states no such tier. Its free offerings are self-hosted: the open-source edition with no usage limits, and the Self-Hosted Enterprise edition free up to 50 GB/day ingestion. OpenObserve Cloud offers a 14-day trial, not a free tier.",
-      "previous_state": "Listed as: 200 GB Ingestion/month free, 15 Days Retention",
-      "current_state": "Self-hosted Enterprise free up to 50 GB/day ingestion; open-source self-hosted free with no usage limits",
-      "impact": "medium",
-      "source_url": "https://openobserve.ai/",
-      "category": "Logging",
-      "alternatives": [
-        "Grafana Loki",
-        "Better Stack Logs",
-        "Logz.io"
-      ],
-      "recorded_date": "2026-09-02",
-      "date_source": "hand_written"
     }
   ]
 }

--- a/data/deal_changes.json
+++ b/data/deal_changes.json
@@ -7639,6 +7639,24 @@
       "alternatives": [],
       "detected_by": "reverify-ai",
       "recorded_date": "2026-09-02"
+    },
+    {
+      "vendor": "openobserve.ai",
+      "change_type": "record_corrected",
+      "date": "2026-09-02",
+      "summary": "Correction to our own entry. We listed a 200 GB/month ingestion free tier with 15 days retention; openobserve.ai states no such tier. Its free offerings are self-hosted: the open-source edition with no usage limits, and the Self-Hosted Enterprise edition free up to 50 GB/day ingestion. OpenObserve Cloud offers a 14-day trial, not a free tier.",
+      "previous_state": "Listed as: 200 GB Ingestion/month free, 15 Days Retention",
+      "current_state": "Self-hosted Enterprise free up to 50 GB/day ingestion; open-source self-hosted free with no usage limits",
+      "impact": "medium",
+      "source_url": "https://openobserve.ai/",
+      "category": "Logging",
+      "alternatives": [
+        "Grafana Loki",
+        "Better Stack Logs",
+        "Logz.io"
+      ],
+      "recorded_date": "2026-09-02",
+      "date_source": "hand_written"
     }
   ]
 }

--- a/data/index.json
+++ b/data/index.json
@@ -2588,9 +2588,9 @@
       ],
       "verifiedDate": "2026-08-20",
       "source_check": {
-        "checked": "2026-08-28",
-        "outcome": "ok",
-        "detail": "text"
+        "checked": "2026-09-02",
+        "outcome": "states_no_amount",
+        "detail": "the page names jsDelivr and says \"free API\" but states no amount, rate or price we can read"
       }
     },
     {
@@ -2647,9 +2647,9 @@
       ],
       "verifiedDate": "2026-07-24",
       "source_check": {
-        "checked": "2026-08-28",
-        "outcome": "ok",
-        "detail": "text"
+        "checked": "2026-09-02",
+        "outcome": "states_no_amount",
+        "detail": "the page names Harness Feature Flags and says \"free tier\" but states no amount, rate or price we can read"
       }
     },
     {
@@ -3718,8 +3718,8 @@
       "verifiedDate": "2026-09-02",
       "source_check": {
         "checked": "2026-09-02",
-        "outcome": "ok",
-        "detail": "text"
+        "outcome": "states_no_terms",
+        "detail": "the page names Highlight.io but states no amount, tier or rate we can read"
       }
     },
     {
@@ -5171,9 +5171,9 @@
       ],
       "verifiedDate": "2026-08-26",
       "source_check": {
-        "checked": "2026-08-28",
-        "outcome": "ok",
-        "detail": "text"
+        "checked": "2026-09-02",
+        "outcome": "states_no_amount",
+        "detail": "the page names Instatus and says \"Free forever\" but states no amount, rate or price we can read"
       }
     },
     {
@@ -5505,9 +5505,9 @@
       ],
       "verifiedDate": "2026-08-26",
       "source_check": {
-        "checked": "2026-08-28",
-        "outcome": "ok",
-        "detail": "text"
+        "checked": "2026-09-02",
+        "outcome": "states_no_amount",
+        "detail": "the page names Crowdin and says \"Team plan\" but states no amount, rate or price we can read"
       }
     },
     {
@@ -5526,9 +5526,9 @@
       ],
       "verifiedDate": "2026-07-07",
       "source_check": {
-        "checked": "2026-08-28",
-        "outcome": "ok",
-        "detail": "text"
+        "checked": "2026-09-02",
+        "outcome": "states_no_amount",
+        "detail": "the page names Permit.io and says \"Free Forever\" but states no amount, rate or price we can read"
       }
     },
     {
@@ -5709,9 +5709,9 @@
       ],
       "verifiedDate": "2026-08-28",
       "source_check": {
-        "checked": "2026-08-28",
-        "outcome": "ok",
-        "detail": "text"
+        "checked": "2026-09-02",
+        "outcome": "states_no_amount",
+        "detail": "the page names Cachet and says \"Free forever\" but states no amount, rate or price we can read"
       }
     },
     {
@@ -5881,9 +5881,9 @@
       ],
       "verifiedDate": "2026-07-27",
       "source_check": {
-        "checked": "2026-08-28",
-        "outcome": "ok",
-        "detail": "text"
+        "checked": "2026-09-02",
+        "outcome": "states_no_amount",
+        "detail": "the page names JotForm and says \"Enterprise plan\" but states no amount, rate or price we can read"
       }
     },
     {
@@ -6369,9 +6369,9 @@
       ],
       "verifiedDate": "2026-08-28",
       "source_check": {
-        "checked": "2026-08-28",
-        "outcome": "ok",
-        "detail": "text"
+        "checked": "2026-09-02",
+        "outcome": "states_no_amount",
+        "detail": "the page names Coolify and says \"free forever\" but states no amount, rate or price we can read"
       }
     },
     {
@@ -6575,9 +6575,9 @@
       ],
       "verifiedDate": "2026-07-27",
       "source_check": {
-        "checked": "2026-08-28",
-        "outcome": "ok",
-        "detail": "text"
+        "checked": "2026-09-02",
+        "outcome": "states_no_amount",
+        "detail": "the page names Grafana Loki and says \"free tier\" but states no amount, rate or price we can read"
       }
     },
     {
@@ -6841,8 +6841,8 @@
       },
       "source_check": {
         "checked": "2026-09-02",
-        "outcome": "ok",
-        "detail": "text"
+        "outcome": "states_no_amount",
+        "detail": "the page names ElasticMQ and says \"starts at\" but states no amount, rate or price we can read"
       }
     },
     {
@@ -6932,9 +6932,9 @@
         "reviewed": "2026-08-25"
       },
       "source_check": {
-        "checked": "2026-09-01",
-        "outcome": "ok",
-        "detail": "text"
+        "checked": "2026-09-02",
+        "outcome": "states_no_amount",
+        "detail": "the page names Floci and says \"Free forever\" but states no amount, rate or price we can read"
       }
     },
     {
@@ -7722,9 +7722,9 @@
       ],
       "verifiedDate": "2026-07-30",
       "source_check": {
-        "checked": "2026-08-28",
-        "outcome": "ok",
-        "detail": "text"
+        "checked": "2026-09-02",
+        "outcome": "states_no_amount",
+        "detail": "the page names AbstractAPI and says \"Free API\" but states no amount, rate or price we can read"
       }
     },
     {
@@ -7742,9 +7742,9 @@
       ],
       "verifiedDate": "2026-08-28",
       "source_check": {
-        "checked": "2026-08-28",
-        "outcome": "ok",
-        "detail": "text"
+        "checked": "2026-09-02",
+        "outcome": "states_no_amount",
+        "detail": "the page names APILayer and says \"free plans\" but states no amount, rate or price we can read"
       }
     },
     {
@@ -9246,9 +9246,9 @@
       ],
       "verifiedDate": "2026-07-05",
       "source_check": {
-        "checked": "2026-08-28",
-        "outcome": "ok",
-        "detail": "text"
+        "checked": "2026-09-02",
+        "outcome": "states_no_amount",
+        "detail": "the page names Harness CI and says \"free tier\" but states no amount, rate or price we can read"
       }
     },
     {
@@ -9315,9 +9315,9 @@
       ],
       "verifiedDate": "2026-08-01",
       "source_check": {
-        "checked": "2026-08-31",
-        "outcome": "ok",
-        "detail": "url"
+        "checked": "2026-09-02",
+        "outcome": "states_no_amount",
+        "detail": "the page names Zoho Docs and says \"starts at\" but states no amount, rate or price we can read"
       }
     },
     {
@@ -9332,9 +9332,9 @@
       ],
       "verifiedDate": "2026-07-31",
       "source_check": {
-        "checked": "2026-08-31",
-        "outcome": "ok",
-        "detail": "text"
+        "checked": "2026-09-02",
+        "outcome": "states_no_amount",
+        "detail": "the page names Zoho Projects and says \"free version\" but states no amount, rate or price we can read"
       }
     },
     {
@@ -9366,9 +9366,9 @@
       ],
       "verifiedDate": "2026-07-31",
       "source_check": {
-        "checked": "2026-08-31",
-        "outcome": "ok",
-        "detail": "text"
+        "checked": "2026-09-02",
+        "outcome": "states_no_amount",
+        "detail": "the page names Zoho Meeting and says \"Starts at\" but states no amount, rate or price we can read"
       }
     },
     {
@@ -9418,9 +9418,9 @@
       ],
       "verifiedDate": "2026-08-26",
       "source_check": {
-        "checked": "2026-08-28",
-        "outcome": "ok",
-        "detail": "text"
+        "checked": "2026-09-02",
+        "outcome": "states_no_amount",
+        "detail": "the page names Zoho Notebook and says \"free plan\" but states no amount, rate or price we can read"
       }
     },
     {
@@ -9523,8 +9523,8 @@
       "verifiedDate": "2026-08-01",
       "source_check": {
         "checked": "2026-09-02",
-        "outcome": "ok",
-        "detail": "text"
+        "outcome": "states_no_amount",
+        "detail": "the page names Zoho Forms and says \"free plan\" but states no amount, rate or price we can read"
       }
     },
     {
@@ -9558,9 +9558,9 @@
       ],
       "verifiedDate": "2026-08-01",
       "source_check": {
-        "checked": "2026-08-28",
-        "outcome": "ok",
-        "detail": "text"
+        "checked": "2026-09-02",
+        "outcome": "states_no_amount",
+        "detail": "the page names Zoho Survey and says \"free version\" but states no amount, rate or price we can read"
       }
     },
     {
@@ -9576,9 +9576,9 @@
       ],
       "verifiedDate": "2026-07-30",
       "source_check": {
-        "checked": "2026-08-28",
-        "outcome": "ok",
-        "detail": "text"
+        "checked": "2026-09-02",
+        "outcome": "states_no_amount",
+        "detail": "the page names Zoho Bookings and says \"free plan\" but states no amount, rate or price we can read"
       }
     },
     {
@@ -9617,8 +9617,8 @@
       "verifiedDate": "2026-08-01",
       "source_check": {
         "checked": "2026-09-02",
-        "outcome": "ok",
-        "detail": "text"
+        "outcome": "states_no_amount",
+        "detail": "the page names Brainboard and says \"free tier\" but states no amount, rate or price we can read"
       }
     },
     {
@@ -10124,8 +10124,8 @@
       "verifiedDate": "2026-07-05",
       "source_check": {
         "checked": "2026-09-02",
-        "outcome": "ok",
-        "detail": "text"
+        "outcome": "states_no_amount",
+        "detail": "the page names Country-State-City Microservice API and says \"Free tier\" but states no amount, rate or price we can read"
       }
     },
     {
@@ -10310,9 +10310,9 @@
       ],
       "verifiedDate": "2026-07-07",
       "source_check": {
-        "checked": "2026-08-28",
-        "outcome": "ok",
-        "detail": "text"
+        "checked": "2026-09-02",
+        "outcome": "states_no_amount",
+        "detail": "the page names DB Designer and says \"free plan\" but states no amount, rate or price we can read"
       }
     },
     {
@@ -10587,9 +10587,9 @@
       ],
       "verifiedDate": "2026-08-24",
       "source_check": {
-        "checked": "2026-08-28",
-        "outcome": "ok",
-        "detail": "text"
+        "checked": "2026-09-02",
+        "outcome": "states_no_amount",
+        "detail": "the page names Geolocated.io and says \"free tier\" but states no amount, rate or price we can read"
       }
     },
     {
@@ -10642,9 +10642,9 @@
       ],
       "verifiedDate": "2026-08-27",
       "source_check": {
-        "checked": "2026-08-28",
-        "outcome": "ok",
-        "detail": "text"
+        "checked": "2026-09-02",
+        "outcome": "states_no_amount",
+        "detail": "the page names Insomnia and says \"free tier\" but states no amount, rate or price we can read"
       }
     },
     {
@@ -10693,9 +10693,9 @@
       ],
       "verifiedDate": "2026-08-27",
       "source_check": {
-        "checked": "2026-08-28",
-        "outcome": "ok",
-        "detail": "text"
+        "checked": "2026-09-02",
+        "outcome": "states_no_amount",
+        "detail": "the page names IP Geolocation and says \"Free API\" but states no amount, rate or price we can read"
       }
     },
     {
@@ -10795,9 +10795,9 @@
       ],
       "verifiedDate": "2026-08-27",
       "source_check": {
-        "checked": "2026-08-28",
-        "outcome": "ok",
-        "detail": "text"
+        "checked": "2026-09-02",
+        "outcome": "states_no_amount",
+        "detail": "the page names IPLocate and says \"free tier\" but states no amount, rate or price we can read"
       }
     },
     {
@@ -11078,9 +11078,9 @@
       ],
       "verifiedDate": "2026-08-27",
       "source_check": {
-        "checked": "2026-08-28",
-        "outcome": "ok",
-        "detail": "text"
+        "checked": "2026-09-02",
+        "outcome": "states_no_amount",
+        "detail": "the page names Mockfly and says \"free plan\" but states no amount, rate or price we can read"
       }
     },
     {
@@ -11194,9 +11194,9 @@
       ],
       "verifiedDate": "2026-08-01",
       "source_check": {
-        "checked": "2026-08-28",
-        "outcome": "ok",
-        "detail": "text"
+        "checked": "2026-09-02",
+        "outcome": "states_no_amount",
+        "detail": "the page names OCR.Space and says \"free tier\" but states no amount, rate or price we can read"
       },
       "product_subtypes": {
         "taxonomy": "AI / ML",
@@ -11335,9 +11335,9 @@
       ],
       "verifiedDate": "2026-08-02",
       "source_check": {
-        "checked": "2026-08-28",
-        "outcome": "ok",
-        "detail": "text"
+        "checked": "2026-09-02",
+        "outcome": "states_no_amount",
+        "detail": "the page names PrefectCloud and says \"Hobby tier\" but states no amount, rate or price we can read"
       }
     },
     {
@@ -11395,9 +11395,9 @@
         }
       ],
       "source_check": {
-        "checked": "2026-08-28",
-        "outcome": "ok",
-        "detail": "text"
+        "checked": "2026-09-02",
+        "outcome": "states_no_amount",
+        "detail": "the page names Reducto and says \"Standard tier\" but states no amount, rate or price we can read"
       },
       "product_subtypes": {
         "taxonomy": "AI / ML",
@@ -12037,9 +12037,9 @@
       ],
       "verifiedDate": "2026-08-02",
       "source_check": {
-        "checked": "2026-08-28",
-        "outcome": "ok",
-        "detail": "text"
+        "checked": "2026-09-02",
+        "outcome": "states_no_amount",
+        "detail": "the page names Braid and says \"Free Forever\" but states no amount, rate or price we can read"
       }
     },
     {
@@ -12326,9 +12326,9 @@
       ],
       "verifiedDate": "2026-07-09",
       "source_check": {
-        "checked": "2026-08-28",
-        "outcome": "ok",
-        "detail": "text"
+        "checked": "2026-09-02",
+        "outcome": "states_no_amount",
+        "detail": "the page names Huly and says \"team plans\" but states no amount, rate or price we can read"
       }
     },
     {
@@ -12762,9 +12762,9 @@
       ],
       "verifiedDate": "2026-08-04",
       "source_check": {
-        "checked": "2026-08-28",
-        "outcome": "ok",
-        "detail": "text"
+        "checked": "2026-09-02",
+        "outcome": "states_no_amount",
+        "detail": "the page names Tencent RTC and says \"Starter Plan\" but states no amount, rate or price we can read"
       }
     },
     {
@@ -12881,9 +12881,9 @@
       ],
       "verifiedDate": "2026-08-26",
       "source_check": {
-        "checked": "2026-08-28",
-        "outcome": "ok",
-        "detail": "text"
+        "checked": "2026-09-02",
+        "outcome": "states_no_amount",
+        "detail": "the page names Visual Debug and says \"free plan\" but states no amount, rate or price we can read"
       }
     },
     {
@@ -13054,8 +13054,8 @@
       "verifiedDate": "2026-08-14",
       "source_check": {
         "checked": "2026-09-02",
-        "outcome": "ok",
-        "detail": "text"
+        "outcome": "states_no_amount",
+        "detail": "the page names Cosmic and says \"Free forever\" but states no amount, rate or price we can read"
       }
     },
     {
@@ -13129,9 +13129,9 @@
       ],
       "verifiedDate": "2026-08-28",
       "source_check": {
-        "checked": "2026-08-28",
-        "outcome": "ok",
-        "detail": "text"
+        "checked": "2026-09-02",
+        "outcome": "states_no_amount",
+        "detail": "the page names Solo and says \"Pro plan\" but states no amount, rate or price we can read"
       }
     },
     {
@@ -13239,9 +13239,9 @@
       ],
       "verifiedDate": "2026-08-04",
       "source_check": {
-        "checked": "2026-08-28",
-        "outcome": "ok",
-        "detail": "url"
+        "checked": "2026-09-02",
+        "outcome": "states_no_amount",
+        "detail": "the page names DhiWise and says \"free plans\" but states no amount, rate or price we can read"
       }
     },
     {
@@ -13528,9 +13528,9 @@
       ],
       "verifiedDate": "2026-08-17",
       "source_check": {
-        "checked": "2026-08-28",
-        "outcome": "ok",
-        "detail": "text"
+        "checked": "2026-09-02",
+        "outcome": "states_no_terms",
+        "detail": "the page names gtmetrix.com but states no amount, tier or rate we can read"
       }
     },
     {
@@ -13829,9 +13829,9 @@
       ],
       "verifiedDate": "2026-07-08",
       "source_check": {
-        "checked": "2026-08-28",
-        "outcome": "ok",
-        "detail": "text"
+        "checked": "2026-09-02",
+        "outcome": "states_no_amount",
+        "detail": "the page names LocalOps and says \"Free tier\" but states no amount, rate or price we can read"
       }
     },
     {
@@ -14295,9 +14295,9 @@
       ],
       "verifiedDate": "2026-08-04",
       "source_check": {
-        "checked": "2026-08-28",
-        "outcome": "ok",
-        "detail": "text"
+        "checked": "2026-09-02",
+        "outcome": "states_no_amount",
+        "detail": "the page names testingbot.com and says \"free plan\" but states no amount, rate or price we can read"
       }
     },
     {
@@ -14331,9 +14331,9 @@
       ],
       "verifiedDate": "2026-08-27",
       "source_check": {
-        "checked": "2026-08-28",
-        "outcome": "ok",
-        "detail": "text"
+        "checked": "2026-09-02",
+        "outcome": "states_no_amount",
+        "detail": "the page names tesults.com and says \"free plan\" but states no amount, rate or price we can read"
       }
     },
     {
@@ -14852,9 +14852,9 @@
       ],
       "verifiedDate": "2026-07-11",
       "source_check": {
-        "checked": "2026-08-28",
-        "outcome": "ok",
-        "detail": "text"
+        "checked": "2026-09-02",
+        "outcome": "states_no_amount",
+        "detail": "the page names asgardeo.io and says \"free tier\" but states no amount, rate or price we can read"
       }
     },
     {
@@ -15025,9 +15025,9 @@
       ],
       "verifiedDate": "2026-08-26",
       "source_check": {
-        "checked": "2026-08-28",
-        "outcome": "ok",
-        "detail": "text"
+        "checked": "2026-09-02",
+        "outcome": "states_no_amount",
+        "detail": "the page names MojoAuth and says \"enterprise plans\" but states no amount, rate or price we can read"
       }
     },
     {
@@ -15044,9 +15044,9 @@
       ],
       "verifiedDate": "2026-07-10",
       "source_check": {
-        "checked": "2026-08-28",
-        "outcome": "ok",
-        "detail": "text"
+        "checked": "2026-09-02",
+        "outcome": "states_no_amount",
+        "detail": "the page names Okta and says \"Free Plan\" but states no amount, rate or price we can read"
       }
     },
     {
@@ -15244,9 +15244,9 @@
       ],
       "verifiedDate": "2026-08-05",
       "source_check": {
-        "checked": "2026-08-28",
-        "outcome": "ok",
-        "detail": "text"
+        "checked": "2026-09-02",
+        "outcome": "states_no_amount",
+        "detail": "the page names bitnami.com and says \"standard package\" but states no amount, rate or price we can read"
       }
     },
     {
@@ -15731,7 +15731,7 @@
     {
       "vendor": "openobserve.ai",
       "category": "Logging",
-      "description": "200 GB Ingestion/month free, 15 Days Retention",
+      "description": "Self-hosted Enterprise free up to 50 GB/day ingestion; open-source self-hosted free with no usage limits",
       "tier": "Free",
       "url": "https://openobserve.ai/",
       "tags": [
@@ -15739,7 +15739,7 @@
         "log-management",
         "free-for-dev"
       ],
-      "verifiedDate": "2026-08-04",
+      "verifiedDate": "2026-09-02",
       "source_check": {
         "checked": "2026-08-28",
         "outcome": "ok",
@@ -15861,9 +15861,9 @@
       ],
       "verifiedDate": "2026-08-31",
       "source_check": {
-        "checked": "2026-08-31",
-        "outcome": "ok",
-        "detail": "text"
+        "checked": "2026-09-02",
+        "outcome": "states_no_amount",
+        "detail": "the page names localizely.com and says \"Free forever\" but states no amount, rate or price we can read"
       }
     },
     {
@@ -15878,9 +15878,9 @@
       ],
       "verifiedDate": "2026-08-08",
       "source_check": {
-        "checked": "2026-09-01",
-        "outcome": "ok",
-        "detail": "text"
+        "checked": "2026-09-02",
+        "outcome": "states_no_amount",
+        "detail": "the page names Loco and says \"Pro plans\" but states no amount, rate or price we can read"
       }
     },
     {
@@ -15929,9 +15929,9 @@
       ],
       "verifiedDate": "2026-08-06",
       "source_check": {
-        "checked": "2026-09-01",
-        "outcome": "ok",
-        "detail": "text"
+        "checked": "2026-09-02",
+        "outcome": "states_no_amount",
+        "detail": "the page names Texterify and says \"free plan\" but states no amount, rate or price we can read"
       }
     },
     {
@@ -16011,8 +16011,8 @@
       "verifiedDate": "2026-07-11",
       "source_check": {
         "checked": "2026-09-02",
-        "outcome": "ok",
-        "detail": "text"
+        "outcome": "states_no_amount",
+        "detail": "the page names bleemeo.com and says \"enterprise tier\" but states no amount, rate or price we can read"
       },
       "product_subtypes": {
         "taxonomy": "Monitoring",
@@ -16440,9 +16440,9 @@
       ],
       "verifiedDate": "2026-07-13",
       "source_check": {
-        "checked": "2026-08-28",
-        "outcome": "ok",
-        "detail": "text"
+        "checked": "2026-09-02",
+        "outcome": "states_no_amount",
+        "detail": "the page names phare.io and says \"free plan\" but states no amount, rate or price we can read"
       },
       "product_subtypes": {
         "taxonomy": "Monitoring",
@@ -17074,9 +17074,9 @@
       ],
       "verifiedDate": "2026-08-30",
       "source_check": {
-        "checked": "2026-09-01",
-        "outcome": "ok",
-        "detail": "text"
+        "checked": "2026-09-02",
+        "outcome": "states_no_amount",
+        "detail": "the page names Semaphr and says \"Free forever\" but states no amount, rate or price we can read"
       }
     },
     {
@@ -17212,9 +17212,9 @@
       ],
       "verifiedDate": "2026-07-15",
       "source_check": {
-        "checked": "2026-08-28",
-        "outcome": "ok",
-        "detail": "url"
+        "checked": "2026-09-02",
+        "outcome": "states_no_amount",
+        "detail": "the page names Burnermail and says \"Free Plan\" but states no amount, rate or price we can read"
       }
     },
     {
@@ -17298,9 +17298,9 @@
       ],
       "verifiedDate": "2026-08-27",
       "source_check": {
-        "checked": "2026-08-28",
-        "outcome": "ok",
-        "detail": "text"
+        "checked": "2026-09-02",
+        "outcome": "states_no_amount",
+        "detail": "the page names EmailJS and says \"free version\" but states no amount, rate or price we can read"
       }
     },
     {
@@ -17417,9 +17417,9 @@
       ],
       "verifiedDate": "2026-08-26",
       "source_check": {
-        "checked": "2026-08-28",
-        "outcome": "ok",
-        "detail": "text"
+        "checked": "2026-09-02",
+        "outcome": "states_no_amount",
+        "detail": "the page names ImprovMX and says \"free tier\" but states no amount, rate or price we can read"
       }
     },
     {
@@ -17621,9 +17621,9 @@
       ],
       "verifiedDate": "2026-07-15",
       "source_check": {
-        "checked": "2026-08-28",
-        "outcome": "ok",
-        "detail": "text"
+        "checked": "2026-09-02",
+        "outcome": "states_no_amount",
+        "detail": "the page names mailsac.com and says \"Enterprise plan\" but states no amount, rate or price we can read"
       }
     },
     {
@@ -17655,9 +17655,9 @@
       ],
       "verifiedDate": "2026-08-27",
       "source_check": {
-        "checked": "2026-08-28",
-        "outcome": "ok",
-        "detail": "text"
+        "checked": "2026-09-02",
+        "outcome": "states_no_amount",
+        "detail": "the page names Mutant Mail and says \"free forever\" but states no amount, rate or price we can read"
       }
     },
     {
@@ -17723,9 +17723,9 @@
       ],
       "verifiedDate": "2026-08-17",
       "source_check": {
-        "checked": "2026-08-28",
-        "outcome": "ok",
-        "detail": "text"
+        "checked": "2026-09-02",
+        "outcome": "states_no_amount",
+        "detail": "the page names SimpleLogin and says \"free forever\" but states no amount, rate or price we can read"
       }
     },
     {
@@ -17825,9 +17825,9 @@
       ],
       "verifiedDate": "2026-08-26",
       "source_check": {
-        "checked": "2026-08-28",
-        "outcome": "ok",
-        "detail": "text"
+        "checked": "2026-09-02",
+        "outcome": "states_no_amount",
+        "detail": "the page names Tuta and says \"free version\" but states no amount, rate or price we can read"
       }
     },
     {
@@ -17982,9 +17982,9 @@
       ],
       "verifiedDate": "2026-08-06",
       "source_check": {
-        "checked": "2026-09-01",
-        "outcome": "ok",
-        "detail": "text"
+        "checked": "2026-09-02",
+        "outcome": "states_no_amount",
+        "detail": "the page names FabForm and says \"premium plans\" but states no amount, rate or price we can read"
       }
     },
     {
@@ -18067,9 +18067,9 @@
       ],
       "verifiedDate": "2026-08-31",
       "source_check": {
-        "checked": "2026-09-01",
-        "outcome": "ok",
-        "detail": "text"
+        "checked": "2026-09-02",
+        "outcome": "states_no_amount",
+        "detail": "the page names Formester.com and says \"Free Forever\" but states no amount, rate or price we can read"
       }
     },
     {
@@ -18101,9 +18101,9 @@
       ],
       "verifiedDate": "2026-08-06",
       "source_check": {
-        "checked": "2026-09-01",
-        "outcome": "ok",
-        "detail": "text"
+        "checked": "2026-09-02",
+        "outcome": "states_no_amount",
+        "detail": "the page names formlets.com and says \"Free Forever\" but states no amount, rate or price we can read"
       }
     },
     {
@@ -18220,9 +18220,9 @@
       ],
       "verifiedDate": "2026-08-05",
       "source_check": {
-        "checked": "2026-08-28",
-        "outcome": "ok",
-        "detail": "text"
+        "checked": "2026-09-02",
+        "outcome": "states_no_amount",
+        "detail": "the page names SimplePDF.eu and says \"Pro plans\" but states no amount, rate or price we can read"
       }
     },
     {
@@ -18356,9 +18356,9 @@
       ],
       "verifiedDate": "2026-08-11",
       "source_check": {
-        "checked": "2026-09-01",
-        "outcome": "ok",
-        "detail": "text"
+        "checked": "2026-09-02",
+        "outcome": "states_no_amount",
+        "detail": "the page names Wufoo and says \"free plan\" but states no amount, rate or price we can read"
       }
     },
     {
@@ -19312,9 +19312,9 @@
       ],
       "verifiedDate": "2026-08-26",
       "source_check": {
-        "checked": "2026-08-28",
-        "outcome": "ok",
-        "detail": "url"
+        "checked": "2026-09-02",
+        "outcome": "states_no_amount",
+        "detail": "the page names domcloud.co and says \"Free Forever\" but states no amount, rate or price we can read"
       },
       "product_subtypes": {
         "taxonomy": "Cloud Hosting",
@@ -19399,9 +19399,9 @@
       ],
       "verifiedDate": "2026-07-15",
       "source_check": {
-        "checked": "2026-08-28",
-        "outcome": "ok",
-        "detail": "text"
+        "checked": "2026-09-02",
+        "outcome": "states_no_amount",
+        "detail": "the page names gigalixir.com and says \"free tier\" but states no amount, rate or price we can read"
       },
       "product_subtypes": {
         "taxonomy": "Cloud Hosting",
@@ -19510,8 +19510,8 @@
       "verifiedDate": "2026-07-15",
       "source_check": {
         "checked": "2026-09-02",
-        "outcome": "ok",
-        "detail": "text"
+        "outcome": "states_no_amount",
+        "detail": "the page names YepCode and says \"DEVELOPER plan\" but states no amount, rate or price we can read"
       },
       "product_subtypes": {
         "taxonomy": "Cloud Hosting",
@@ -19766,9 +19766,9 @@
       ],
       "verifiedDate": "2026-08-27",
       "source_check": {
-        "checked": "2026-08-28",
-        "outcome": "ok",
-        "detail": "url"
+        "checked": "2026-09-02",
+        "outcome": "states_no_amount",
+        "detail": "the page names paraio.com and says \"Premium plans\" but states no amount, rate or price we can read"
       },
       "product_subtypes": {
         "taxonomy": "Cloud Hosting",
@@ -19840,9 +19840,9 @@
       ],
       "verifiedDate": "2026-08-30",
       "source_check": {
-        "checked": "2026-09-01",
-        "outcome": "ok",
-        "detail": "text"
+        "checked": "2026-09-02",
+        "outcome": "states_no_amount",
+        "detail": "the page names Clappia and says \"Free Plan\" but states no amount, rate or price we can read"
       }
     },
     {
@@ -20255,9 +20255,9 @@
       ],
       "verifiedDate": "2026-07-17",
       "source_check": {
-        "checked": "2026-08-28",
-        "outcome": "ok",
-        "detail": "text"
+        "checked": "2026-09-02",
+        "outcome": "states_no_amount",
+        "detail": "the page names pantheon.io and says \"Enterprise Plans\" but states no amount, rate or price we can read"
       },
       "product_subtypes": {
         "taxonomy": "Cloud Hosting",
@@ -20284,9 +20284,9 @@
       ],
       "verifiedDate": "2026-07-14",
       "source_check": {
-        "checked": "2026-08-28",
-        "outcome": "ok",
-        "detail": "text"
+        "checked": "2026-09-02",
+        "outcome": "states_no_amount",
+        "detail": "the page names Qoddi and says \"premium Tier\" but states no amount, rate or price we can read"
       },
       "product_subtypes": {
         "taxonomy": "Cloud Hosting",
@@ -20792,9 +20792,9 @@
       ],
       "verifiedDate": "2026-09-01",
       "source_check": {
-        "checked": "2026-09-01",
-        "outcome": "ok",
-        "detail": "text"
+        "checked": "2026-09-02",
+        "outcome": "states_no_amount",
+        "detail": "the page names isroot.in and says \"Free Forever\" but states no amount, rate or price we can read"
       }
     },
     {
@@ -21000,9 +21000,9 @@
       ],
       "verifiedDate": "2026-08-27",
       "source_check": {
-        "checked": "2026-08-28",
-        "outcome": "ok",
-        "detail": "text"
+        "checked": "2026-09-02",
+        "outcome": "states_no_amount",
+        "detail": "the page names restdb.io and says \"Free plan\" but states no amount, rate or price we can read"
       },
       "product_subtypes": {
         "taxonomy": "Databases",
@@ -21075,9 +21075,9 @@
       ],
       "verifiedDate": "2026-07-16",
       "source_check": {
-        "checked": "2026-08-28",
-        "outcome": "ok",
-        "detail": "text"
+        "checked": "2026-09-02",
+        "outcome": "states_no_amount",
+        "detail": "the page names StackBy and says \"Free Forever\" but states no amount, rate or price we can read"
       },
       "product_subtypes": {
         "taxonomy": "Databases",
@@ -21233,9 +21233,9 @@
       ],
       "verifiedDate": "2026-08-08",
       "source_check": {
-        "checked": "2026-09-01",
-        "outcome": "ok",
-        "detail": "text"
+        "checked": "2026-09-02",
+        "outcome": "states_no_amount",
+        "detail": "the page names Pinggy and says \"Free plan\" but states no amount, rate or price we can read"
       }
     },
     {
@@ -21353,8 +21353,8 @@
       "verifiedDate": "2026-08-12",
       "source_check": {
         "checked": "2026-09-02",
-        "outcome": "ok",
-        "detail": "text"
+        "outcome": "states_no_amount",
+        "detail": "the page names asana.com and says \"Starter plan\" but states no amount, rate or price we can read"
       }
     },
     {
@@ -21641,9 +21641,9 @@
       ],
       "verifiedDate": "2026-08-27",
       "source_check": {
-        "checked": "2026-08-28",
-        "outcome": "ok",
-        "detail": "text"
+        "checked": "2026-09-02",
+        "outcome": "states_no_amount",
+        "detail": "the page names kan.bn and says \"free plan\" but states no amount, rate or price we can read"
       }
     },
     {
@@ -21709,9 +21709,9 @@
       ],
       "verifiedDate": "2026-07-14",
       "source_check": {
-        "checked": "2026-08-28",
-        "outcome": "ok",
-        "detail": "text"
+        "checked": "2026-09-02",
+        "outcome": "states_no_amount",
+        "detail": "the page names leiga.com and says \"Free forever\" but states no amount, rate or price we can read"
       }
     },
     {
@@ -21879,9 +21879,9 @@
       ],
       "verifiedDate": "2026-08-26",
       "source_check": {
-        "checked": "2026-08-28",
-        "outcome": "ok",
-        "detail": "text"
+        "checked": "2026-09-02",
+        "outcome": "states_no_amount",
+        "detail": "the page names Shortcut and says \"free forever\" but states no amount, rate or price we can read"
       }
     },
     {
@@ -21964,9 +21964,9 @@
       ],
       "verifiedDate": "2026-08-28",
       "source_check": {
-        "checked": "2026-08-28",
-        "outcome": "ok",
-        "detail": "text"
+        "checked": "2026-09-02",
+        "outcome": "states_no_amount",
+        "detail": "the page names teleretro.com and says \"free plan\" but states no amount, rate or price we can read"
       }
     },
     {
@@ -22015,9 +22015,9 @@
       ],
       "verifiedDate": "2026-08-28",
       "source_check": {
-        "checked": "2026-08-28",
-        "outcome": "ok",
-        "detail": "text"
+        "checked": "2026-09-02",
+        "outcome": "states_no_amount",
+        "detail": "the page names Toggl and says \"free plan\" but states no amount, rate or price we can read"
       }
     },
     {
@@ -22191,9 +22191,9 @@
       ],
       "verifiedDate": "2026-07-15",
       "source_check": {
-        "checked": "2026-08-28",
-        "outcome": "ok",
-        "detail": "text"
+        "checked": "2026-09-02",
+        "outcome": "states_no_amount",
+        "detail": "the page names file.io and says \"free plan\" but states no amount, rate or price we can read"
       }
     },
     {
@@ -22353,9 +22353,9 @@
       ],
       "verifiedDate": "2026-08-26",
       "source_check": {
-        "checked": "2026-08-28",
-        "outcome": "ok",
-        "detail": "text"
+        "checked": "2026-09-02",
+        "outcome": "states_no_amount",
+        "detail": "the page names imgen and says \"Free forever\" but states no amount, rate or price we can read"
       }
     },
     {
@@ -22479,9 +22479,9 @@
       ],
       "verifiedDate": "2026-07-17",
       "source_check": {
-        "checked": "2026-08-28",
-        "outcome": "ok",
-        "detail": "text"
+        "checked": "2026-09-02",
+        "outcome": "states_no_amount",
+        "detail": "the page names packagecloud.io and says \"Community Package\" but states no amount, rate or price we can read"
       }
     },
     {
@@ -22604,9 +22604,9 @@
       ],
       "verifiedDate": "2026-08-27",
       "source_check": {
-        "checked": "2026-08-28",
-        "outcome": "ok",
-        "detail": "text"
+        "checked": "2026-09-02",
+        "outcome": "states_no_amount",
+        "detail": "the page names QRtracer and says \"Free forever\" but states no amount, rate or price we can read"
       }
     },
     {
@@ -23523,9 +23523,9 @@
       ],
       "verifiedDate": "2026-07-20",
       "source_check": {
-        "checked": "2026-08-28",
-        "outcome": "ok",
-        "detail": "text"
+        "checked": "2026-09-02",
+        "outcome": "states_no_amount",
+        "detail": "the page names Mockplus iDoc and says \"free plan\" but states no amount, rate or price we can read"
       }
     },
     {
@@ -23703,9 +23703,9 @@
       ],
       "verifiedDate": "2026-08-26",
       "source_check": {
-        "checked": "2026-08-28",
-        "outcome": "ok",
-        "detail": "text"
+        "checked": "2026-09-02",
+        "outcome": "states_no_amount",
+        "detail": "the page names Plasmic and says \"free plan\" but states no amount, rate or price we can read"
       }
     },
     {
@@ -23937,9 +23937,9 @@
       ],
       "verifiedDate": "2026-08-26",
       "source_check": {
-        "checked": "2026-08-28",
-        "outcome": "ok",
-        "detail": "text"
+        "checked": "2026-09-02",
+        "outcome": "states_no_amount",
+        "detail": "the page names Tailwindadmin and says \"Free Version\" but states no amount, rate or price we can read"
       }
     },
     {
@@ -24424,8 +24424,8 @@
       "verifiedDate": "2026-08-31",
       "source_check": {
         "checked": "2026-09-02",
-        "outcome": "ok",
-        "detail": "text"
+        "outcome": "states_no_amount",
+        "detail": "the page names geoapify.com and says \"free API\" but states no amount, rate or price we can read"
       }
     },
     {
@@ -24477,9 +24477,9 @@
       ],
       "verifiedDate": "2026-08-30",
       "source_check": {
-        "checked": "2026-09-01",
-        "outcome": "ok",
-        "detail": "url"
+        "checked": "2026-09-02",
+        "outcome": "states_no_amount",
+        "detail": "the page names Geokeo api and says \"free api\" but states no amount, rate or price we can read"
       }
     },
     {
@@ -24495,9 +24495,9 @@
       ],
       "verifiedDate": "2026-09-01",
       "source_check": {
-        "checked": "2026-09-01",
-        "outcome": "ok",
-        "detail": "text"
+        "checked": "2026-09-02",
+        "outcome": "states_no_amount",
+        "detail": "the page names ipstack and says \"Free API\" but states no amount, rate or price we can read"
       }
     },
     {
@@ -24792,8 +24792,8 @@
       "verifiedDate": "2026-09-02",
       "source_check": {
         "checked": "2026-09-02",
-        "outcome": "ok",
-        "detail": "text"
+        "outcome": "states_no_amount",
+        "detail": "the page names Bootify.io and says \"Free plan\" but states no amount, rate or price we can read"
       }
     },
     {
@@ -25429,9 +25429,9 @@
       ],
       "verifiedDate": "2026-08-28",
       "source_check": {
-        "checked": "2026-08-28",
-        "outcome": "ok",
-        "detail": "text"
+        "checked": "2026-09-02",
+        "outcome": "states_no_amount",
+        "detail": "the page names DocBeacon and says \"Free plan\" but states no amount, rate or price we can read"
       }
     },
     {
@@ -25736,8 +25736,8 @@
       "verifiedDate": "2026-07-21",
       "source_check": {
         "checked": "2026-09-02",
-        "outcome": "ok",
-        "detail": "text"
+        "outcome": "states_no_amount",
+        "detail": "the page names Trackingplan and says \"Growth plan\" but states no amount, rate or price we can read"
       }
     },
     {
@@ -25843,9 +25843,9 @@
       ],
       "verifiedDate": "2026-08-26",
       "source_check": {
-        "checked": "2026-08-28",
-        "outcome": "ok",
-        "detail": "text"
+        "checked": "2026-09-02",
+        "outcome": "states_no_amount",
+        "detail": "the page names Microsoft Clarity and says \"Free forever\" but states no amount, rate or price we can read"
       }
     },
     {
@@ -25861,9 +25861,9 @@
       ],
       "verifiedDate": "2026-07-22",
       "source_check": {
-        "checked": "2026-08-28",
-        "outcome": "ok",
-        "detail": "text"
+        "checked": "2026-09-02",
+        "outcome": "states_no_amount",
+        "detail": "the page names mouseflow.com and says \"Free forever\" but states no amount, rate or price we can read"
       }
     },
     {
@@ -25897,9 +25897,9 @@
       ],
       "verifiedDate": "2026-07-21",
       "source_check": {
-        "checked": "2026-08-28",
-        "outcome": "ok",
-        "detail": "text"
+        "checked": "2026-09-02",
+        "outcome": "states_no_amount",
+        "detail": "the page names smartlook.com and says \"Free plan\" but states no amount, rate or price we can read"
       }
     },
     {
@@ -25916,8 +25916,8 @@
       "verifiedDate": "2026-07-21",
       "source_check": {
         "checked": "2026-09-02",
-        "outcome": "ok",
-        "detail": "text"
+        "outcome": "states_no_amount",
+        "detail": "the page names UXtweak.com and says \"Free plan\" but states no amount, rate or price we can read"
       }
     },
     {
@@ -26202,8 +26202,8 @@
       "verifiedDate": "2026-09-01",
       "source_check": {
         "checked": "2026-09-02",
-        "outcome": "ok",
-        "detail": "text"
+        "outcome": "states_no_amount",
+        "detail": "the page names ttl.sh and says \"Free forever\" but states no amount, rate or price we can read"
       }
     },
     {
@@ -26735,9 +26735,9 @@
       ],
       "verifiedDate": "2026-08-26",
       "source_check": {
-        "checked": "2026-08-28",
-        "outcome": "ok",
-        "detail": "text"
+        "checked": "2026-09-02",
+        "outcome": "states_no_amount",
+        "detail": "the page names Hosting Checker and says \"Free Forever\" but states no amount, rate or price we can read"
       }
     },
     {
@@ -26837,9 +26837,9 @@
       ],
       "verifiedDate": "2026-08-28",
       "source_check": {
-        "checked": "2026-08-28",
-        "outcome": "ok",
-        "detail": "text"
+        "checked": "2026-09-02",
+        "outcome": "states_no_amount",
+        "detail": "the page names RandomKeygen and says \"premium tier\" but states no amount, rate or price we can read"
       }
     },
     {
@@ -26973,9 +26973,9 @@
       ],
       "verifiedDate": "2026-08-28",
       "source_check": {
-        "checked": "2026-08-28",
-        "outcome": "ok",
-        "detail": "text"
+        "checked": "2026-09-02",
+        "outcome": "states_no_amount",
+        "detail": "the page names Sunrise and Sunset and says \"Free forever\" but states no amount, rate or price we can read"
       }
     },
     {
@@ -27007,9 +27007,9 @@
       ],
       "verifiedDate": "2026-07-23",
       "source_check": {
-        "checked": "2026-08-28",
-        "outcome": "ok",
-        "detail": "text"
+        "checked": "2026-09-02",
+        "outcome": "states_no_terms",
+        "detail": "the page names SurveyMonkey.com but states no amount, tier or rate we can read"
       }
     },
     {
@@ -27075,9 +27075,9 @@
       ],
       "verifiedDate": "2026-08-28",
       "source_check": {
-        "checked": "2026-08-28",
-        "outcome": "ok",
-        "detail": "text"
+        "checked": "2026-09-02",
+        "outcome": "states_no_amount",
+        "detail": "the page names Volume Shader BM and says \"Start at\" but states no amount, rate or price we can read"
       }
     },
     {
@@ -27109,9 +27109,9 @@
       ],
       "verifiedDate": "2026-08-27",
       "source_check": {
-        "checked": "2026-08-28",
-        "outcome": "ok",
-        "detail": "text"
+        "checked": "2026-09-02",
+        "outcome": "states_no_amount",
+        "detail": "the page names XKit and says \"premium tiers\" but states no amount, rate or price we can read"
       }
     },
     {
@@ -27261,8 +27261,8 @@
       },
       "source_check": {
         "checked": "2026-09-02",
-        "outcome": "ok",
-        "detail": "text"
+        "outcome": "states_no_amount",
+        "detail": "the page names Clever Bootstrap Program and says \"business plan\" but states no amount, rate or price we can read"
       }
     },
     {
@@ -27599,8 +27599,8 @@
       "expires_date": "2026-12-31",
       "source_check": {
         "checked": "2026-09-02",
-        "outcome": "ok",
-        "detail": "text"
+        "outcome": "states_no_terms",
+        "detail": "the page names HubSpot for Startups but states no amount, tier or rate we can read"
       }
     },
     {
@@ -27625,8 +27625,8 @@
       },
       "source_check": {
         "checked": "2026-09-02",
-        "outcome": "ok",
-        "detail": "text"
+        "outcome": "states_no_terms",
+        "detail": "the page names Shotstack Startup Program but states no amount, tier or rate we can read"
       }
     },
     {
@@ -27737,8 +27737,8 @@
       "verifiedDate": "2026-09-02",
       "source_check": {
         "checked": "2026-09-02",
-        "outcome": "ok",
-        "detail": "text"
+        "outcome": "states_no_amount",
+        "detail": "the page names Pareto Security and says \"Team Plans\" but states no amount, rate or price we can read"
       }
     },
     {
@@ -30323,9 +30323,9 @@
       ],
       "verifiedDate": "2026-08-26",
       "source_check": {
-        "checked": "2026-08-28",
-        "outcome": "ok",
-        "detail": "text"
+        "checked": "2026-09-02",
+        "outcome": "states_no_amount",
+        "detail": "the page names Renovate and says \"Community plan\" but states no amount, rate or price we can read"
       }
     },
     {
@@ -30619,9 +30619,9 @@
       ],
       "verifiedDate": "2026-08-17",
       "source_check": {
-        "checked": "2026-08-28",
-        "outcome": "ok",
-        "detail": "text"
+        "checked": "2026-09-02",
+        "outcome": "states_no_amount",
+        "detail": "the page names Lovable and says \"free plan\" but states no amount, rate or price we can read"
       }
     },
     {
@@ -31149,9 +31149,9 @@
       ],
       "verifiedDate": "2026-08-19",
       "source_check": {
-        "checked": "2026-08-28",
-        "outcome": "ok",
-        "detail": "url"
+        "checked": "2026-09-02",
+        "outcome": "states_no_terms",
+        "detail": "the page names Google Cloud Shell but states no amount, tier or rate we can read"
       }
     },
     {
@@ -31574,9 +31574,9 @@
       ],
       "verifiedDate": "2026-08-18",
       "source_check": {
-        "checked": "2026-08-28",
-        "outcome": "ok",
-        "detail": "text"
+        "checked": "2026-09-02",
+        "outcome": "states_no_amount",
+        "detail": "the page names Spotify and says \"Premium plans\" but states no amount, rate or price we can read"
       }
     },
     {
@@ -32210,9 +32210,9 @@
       ],
       "verifiedDate": "2026-08-19",
       "source_check": {
-        "checked": "2026-08-28",
-        "outcome": "ok",
-        "detail": "text"
+        "checked": "2026-09-02",
+        "outcome": "states_no_amount",
+        "detail": "the page names pCloud and says \"free plan\" but states no amount, rate or price we can read"
       }
     },
     {
@@ -32339,9 +32339,9 @@
       ],
       "verifiedDate": "2026-08-20",
       "source_check": {
-        "checked": "2026-08-28",
-        "outcome": "ok",
-        "detail": "text"
+        "checked": "2026-09-02",
+        "outcome": "states_no_amount",
+        "detail": "the page names LastPass and says \"Business Plans\" but states no amount, rate or price we can read"
       }
     },
     {
@@ -32358,9 +32358,9 @@
       ],
       "verifiedDate": "2026-08-22",
       "source_check": {
-        "checked": "2026-08-28",
-        "outcome": "ok",
-        "detail": "text"
+        "checked": "2026-09-02",
+        "outcome": "states_no_amount",
+        "detail": "the page names NordPass and says \"Premium plans\" but states no amount, rate or price we can read"
       }
     },
     {
@@ -32768,9 +32768,9 @@
         "commission_type": "credits"
       },
       "source_check": {
-        "checked": "2026-08-28",
-        "outcome": "ok",
-        "detail": "text"
+        "checked": "2026-09-02",
+        "outcome": "states_no_amount",
+        "detail": "the page names Proton VPN and says \"free forever\" but states no amount, rate or price we can read"
       }
     },
     {
@@ -34015,8 +34015,8 @@
       "verifiedDate": "2026-08-27",
       "source_check": {
         "checked": "2026-09-02",
-        "outcome": "ok",
-        "detail": "text"
+        "outcome": "states_no_amount",
+        "detail": "the page names Elastic and says \"free tier\" but states no amount, rate or price we can read"
       },
       "product_subtypes": {
         "taxonomy": "Monitoring",
@@ -34051,9 +34051,9 @@
       ],
       "verifiedDate": "2026-08-27",
       "source_check": {
-        "checked": "2026-08-28",
-        "outcome": "ok",
-        "detail": "text"
+        "checked": "2026-09-02",
+        "outcome": "states_no_amount",
+        "detail": "the page names Grafana and says \"free tier\" but states no amount, rate or price we can read"
       },
       "product_subtypes": {
         "taxonomy": "Monitoring",

--- a/scripts/change-gate.js
+++ b/scripts/change-gate.js
@@ -1,4 +1,4 @@
-import { pageNamesVendor } from "./vendor-naming.js";
+import { pageNamesVendor, statesAnAmount } from "./vendor-naming.js";
 import { definedEquivalences } from "./unit-aliases.js";
 import { readPeriod, renderPeriod } from "../src/growth-limits.ts";
 
@@ -182,6 +182,10 @@ export function priceSignals(text) {
     for (const match of text.matchAll(pattern)) found.push(match[0].trim());
   }
   return found;
+}
+
+export function numericPriceSignals(text) {
+  return priceSignals(text).filter(statesAnAmount);
 }
 
 export function quantities(text) {

--- a/scripts/price-evidence-census.js
+++ b/scripts/price-evidence-census.js
@@ -1,0 +1,147 @@
+#!/usr/bin/env node
+
+import { readFileSync, writeFileSync, existsSync, mkdirSync } from "node:fs";
+import { createHash } from "node:crypto";
+import { resolve, dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { fetchPageText } from "./verify-freshness.js";
+import { priceSignals, numericPriceSignals, quantities, MAGNITUDE_UNITS } from "./change-gate.js";
+import { classifySource, sourceCheckRecord } from "./vendor-naming.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const INDEX_PATH =
+  process.env.AGENTDEALS_INDEX_PATH || resolve(__dirname, "..", "data", "index.json");
+const CONCURRENCY = 12;
+
+function arg(name, fallback = null) {
+  const at = process.argv.indexOf(name);
+  return at !== -1 ? process.argv[at + 1] : fallback;
+}
+
+async function mapWithConcurrency(items, limit, fn) {
+  let next = 0;
+  const workers = Array.from({ length: Math.min(limit, items.length) }, async () => {
+    while (true) {
+      const i = next++;
+      if (i >= items.length) return;
+      await fn(items[i]);
+    }
+  });
+  await Promise.all(workers);
+}
+
+const MAGNITUDE_AFTER_NUMBER = /(\d[\d,]*(?:\.\d+)?)\s?([kmb])\b/gi;
+
+function numbersOn(text) {
+  const found = new Set(quantities(text));
+  for (const match of text.matchAll(MAGNITUDE_AFTER_NUMBER)) {
+    const base = Number(match[1].replace(/,/g, ""));
+    const scale = MAGNITUDE_UNITS.get(match[2].toLowerCase());
+    if (Number.isFinite(base) && scale) found.add(base * scale);
+  }
+  return found;
+}
+
+async function main() {
+  const out = arg("--out", "/tmp/price-evidence-census.json");
+  const cacheDir = arg("--cache", null);
+  const write = process.argv.includes("--write");
+  const checked = arg("--checked", new Date().toISOString().slice(0, 10));
+
+  const data = JSON.parse(readFileSync(INDEX_PATH, "utf-8"));
+  const all = (data.offers || []).filter((o) => o.url);
+  const offers = all.filter((o) => o.source_check?.outcome === "ok");
+  const urls = [...new Set(offers.map((o) => o.url))];
+
+  console.error(`${offers.length} ok records, ${urls.length} distinct URLs`);
+
+  if (cacheDir && !existsSync(cacheDir)) mkdirSync(cacheDir, { recursive: true });
+  const cachePath = (url) =>
+    join(cacheDir ?? "", `${createHash("sha1").update(url).digest("hex")}.json`);
+
+  let done = 0;
+  const pages = new Map();
+  const fetchInto = async (url) => {
+    if (cacheDir && existsSync(cachePath(url))) {
+      pages.set(url, JSON.parse(readFileSync(cachePath(url), "utf-8")));
+      return;
+    }
+    const page = await fetchPageText(url);
+    if (cacheDir && page.ok) writeFileSync(cachePath(url), JSON.stringify(page));
+    pages.set(url, page);
+  };
+
+  await mapWithConcurrency(urls, CONCURRENCY, async (url) => {
+    await fetchInto(url);
+    done++;
+    if (done % 100 === 0) console.error(`  ${done}/${urls.length}`);
+  });
+
+  const retry = urls.filter((u) => !pages.get(u)?.ok);
+  console.error(`retrying ${retry.length} failed fetches`);
+  await mapWithConcurrency(retry, CONCURRENCY, fetchInto);
+
+  let restamped = 0;
+  const rows = offers.map((offer) => {
+    const page = pages.get(offer.url) ?? { ok: false, error: "not fetched" };
+    const signals = page.ok ? priceSignals(page.text) : [];
+    const numeric = page.ok ? numericPriceSignals(page.text) : [];
+    const onPage = page.ok ? numbersOn(page.text) : new Set();
+    const published = [...new Set(quantities(offer.description ?? ""))];
+    const absent = published.filter((n) => !onPage.has(n));
+    const row = {
+      vendor: offer.vendor,
+      slug: offer.slug ?? null,
+      url: offer.url,
+      description: offer.description ?? null,
+      stored_detail: offer.source_check?.detail ?? null,
+      fetch_ok: Boolean(page.ok),
+      error: page.ok ? null : page.error,
+      chars: page.ok ? page.text.length : null,
+      signals: signals.length,
+      numeric_signals: numeric.length,
+      phrase_evidence: [...new Set(signals)].slice(0, 6),
+      published_numbers: published,
+      numbers_absent_from_page: absent,
+      outcome_today: classifySource(offer, page, signals).outcome,
+    };
+    if (write && page.ok && row.outcome_today !== offer.source_check?.outcome) {
+      offer.source_check = sourceCheckRecord(offer, page, signals, checked);
+      restamped++;
+    }
+    return row;
+  });
+
+  writeFileSync(out, JSON.stringify(rows, null, 1) + "\n");
+  if (write) writeFileSync(INDEX_PATH, JSON.stringify(data, null, 2) + "\n");
+
+  const read = rows.filter((r) => r.fetch_ok);
+  const phraseOnly = read.filter((r) => r.numeric_signals === 0 && r.signals > 0);
+  const noSignal = read.filter((r) => r.signals === 0);
+  const withQuantity = phraseOnly.filter((r) => r.published_numbers.length > 0);
+  const withAbsent = withQuantity.filter((r) => r.numbers_absent_from_page.length > 0);
+  const numericRecords = read.filter((r) => r.numeric_signals > 0);
+
+  console.error("");
+  console.error(`ok records                       ${rows.length}`);
+  console.error(`  read                           ${read.length}`);
+  console.error(`  fetch failed                   ${rows.length - read.length}`);
+  console.error(`  page carries a numeric signal  ${numericRecords.length}`);
+  console.error(`  phrase-only evidence           ${phraseOnly.length}`);
+  console.error(`    publishing a quantity        ${withQuantity.length}`);
+  console.error(`      quantity absent from page  ${withAbsent.length}`);
+  console.error(`  no price signal at all         ${noSignal.length}`);
+  if (write) console.error(`  re-stamped                     ${restamped}`);
+
+  console.error("");
+  console.error("no price signal at all:");
+  for (const r of noSignal) console.error(`  ${r.vendor.padEnd(28)} ${r.url}`);
+
+  console.error("");
+  console.error(`wrote ${out}`);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/scripts/reverify-rolling.js
+++ b/scripts/reverify-rolling.js
@@ -19,7 +19,12 @@ import {
   REJECT_PAGE_NOT_ABOUT_VENDOR,
   REJECT_UNQUANTIFIED_LIMIT,
 } from "./change-gate.js";
-import { sourceCheckRecord, SOURCE_CHECK_OK, SOURCE_CHECK_OUTCOMES } from "./vendor-naming.js";
+import {
+  sourceCheckRecord,
+  holdsVerifiedDate,
+  SOURCE_CHECK_OK,
+  SOURCE_CHECK_OUTCOMES,
+} from "./vendor-naming.js";
 import { isoDay } from "./change-log.js";
 import { recordRefusals, readRefusals, refusalHolds, offerKey } from "./change-refusals.js";
 import {
@@ -60,7 +65,7 @@ const QUARANTINE_RETRY_SHARE = 0.2;
 
 export function lastAttemptedDate(offer, refusedOn = null, verificationRecord = null) {
   const check = offer?.source_check;
-  const held = check && check.outcome !== SOURCE_CHECK_OK ? check.checked : null;
+  const held = check && holdsVerifiedDate(check.outcome) ? check.checked : null;
   const dates = [offer?.verifiedDate, held, refusedOn, verificationRecord?.last_attempt_at].filter(Boolean);
   return dates.length > 0 ? dates.sort().pop() : null;
 }
@@ -125,11 +130,11 @@ function sleep(ms) {
 }
 
 function applySourceCheck(offer, index, page, data, dryRun, now, counters) {
-  const signals = page?.ok ? priceSignals(page.text).length : 0;
+  const signals = page?.ok ? priceSignals(page.text) : [];
   const check = sourceCheckRecord(offer, page, signals, isoDay(now));
   counters.set(check.outcome, (counters.get(check.outcome) ?? 0) + 1);
   if (!dryRun) data.offers[index].source_check = check;
-  if (check.outcome !== SOURCE_CHECK_OK) {
+  if (holdsVerifiedDate(check.outcome)) {
     console.log(`  ⊘ ${offer.vendor} — verifiedDate held at ${offer.verifiedDate}: ${check.detail} (${offer.url})`);
   }
   return check;
@@ -164,7 +169,7 @@ export async function runUrlMode(picked, data, dryRun, now, options = {}) {
       const offer = byIndex.get(v.index);
       const page = await fetchFn(offer.url);
       const check = applySourceCheck(offer, v.index, page, data, dryRun, now, sourceChecks);
-      if (check.outcome !== SOURCE_CHECK_OK) {
+      if (holdsVerifiedDate(check.outcome)) {
         recorder.note(offer, ATTEMPT_SOURCE_UNUSABLE, check.detail, FAILURE_SOURCE_UNUSABLE);
         continue;
       }
@@ -210,7 +215,7 @@ export async function runAiMode(picked, data, dryRun, now, options = {}) {
     const { offer, index } = entry;
     const page = await fetchFn(offer.url);
     const check = applySourceCheck(offer, index, page, data, dryRun, now, sourceChecks);
-    const sourceOk = check.outcome === SOURCE_CHECK_OK;
+    const sourceOk = !holdsVerifiedDate(check.outcome);
     if (!page.ok) {
       console.log(`  ⚠ ${offer.vendor} — ${page.error} (${offer.url})`);
       recorder.note(offer, ATTEMPT_FETCH_FAILED, page.error, classifyFetchError(page.error));
@@ -379,7 +384,8 @@ export function summaryLines(result, { useAi, checked, oldestRemaining, total, q
   const sourceChecks = result.sourceChecks ?? new Map();
   for (const outcome of SOURCE_CHECK_OUTCOMES) {
     if (outcome === SOURCE_CHECK_OK) continue;
-    lines.push(`Held back (source ${outcome}): ${sourceChecks.get(outcome) ?? 0}`);
+    const label = holdsVerifiedDate(outcome) ? "Held back" : "Verified on weaker evidence";
+    lines.push(`${label} (source ${outcome}): ${sourceChecks.get(outcome) ?? 0}`);
   }
   lines.push(`Flagged (URL/AI failure): ${result.flagged}`);
   for (const line of quarantineLines(quarantine)) lines.push(line);

--- a/scripts/short-page-census.js
+++ b/scripts/short-page-census.js
@@ -83,7 +83,7 @@ async function mapWithConcurrency(items, limit, fn) {
 
 function outcomeAt(offer, page, floor) {
   const floored = withMinimumLength(page, floor);
-  const signals = floored.ok ? priceSignals(floored.text).length : 0;
+  const signals = floored.ok ? priceSignals(floored.text) : [];
   return classifySource(offer, floored, signals).outcome;
 }
 
@@ -162,7 +162,7 @@ async function main() {
         offer.source_check = sourceCheckRecord(
           offer,
           floored,
-          floored.ok ? priceSignals(floored.text).length : 0,
+          floored.ok ? priceSignals(floored.text) : [],
           checked
         );
         restamped++;

--- a/scripts/source-naming-audit.js
+++ b/scripts/source-naming-audit.js
@@ -70,7 +70,7 @@ async function main() {
 
   const rows = offers.map((offer) => {
     const page = pages.get(offer.url) ?? { ok: false, error: "not fetched" };
-    const signals = page.ok ? priceSignals(page.text).length : 0;
+    const signals = page.ok ? priceSignals(page.text) : [];
     if (writeIndex) offer.source_check = sourceCheckRecord(offer, page, signals, checked);
     if (!page.ok) {
       return { vendor: offer.vendor, category: offer.category, url: offer.url, fetch_ok: false, error: page.error };

--- a/scripts/vendor-naming.js
+++ b/scripts/vendor-naming.js
@@ -12,16 +12,34 @@ const MIN_FORM_LENGTH = 3;
 const MIN_DISTINCTIVE_WORD = 7;
 
 export const SOURCE_CHECK_OK = "ok";
+export const SOURCE_CHECK_NO_AMOUNT = "states_no_amount";
 export const SOURCE_CHECK_NOT_NAMED = "does_not_name_vendor";
 export const SOURCE_CHECK_NO_TERMS = "states_no_terms";
 export const SOURCE_CHECK_UNREADABLE = "unreadable";
 
 export const SOURCE_CHECK_OUTCOMES = [
   SOURCE_CHECK_OK,
+  SOURCE_CHECK_NO_AMOUNT,
   SOURCE_CHECK_NOT_NAMED,
   SOURCE_CHECK_NO_TERMS,
   SOURCE_CHECK_UNREADABLE,
 ];
+
+const OUTCOMES_THAT_HOLD_THE_VERIFIED_DATE = new Set([
+  SOURCE_CHECK_NOT_NAMED,
+  SOURCE_CHECK_NO_TERMS,
+  SOURCE_CHECK_UNREADABLE,
+]);
+
+export function holdsVerifiedDate(outcome) {
+  return OUTCOMES_THAT_HOLD_THE_VERIFIED_DATE.has(outcome);
+}
+
+const A_FIGURE = /\d/;
+
+export function statesAnAmount(signal) {
+  return typeof signal === "string" && A_FIGURE.test(signal);
+}
 
 export function normalizeForMatch(text) {
   if (typeof text !== "string") return "";
@@ -146,7 +164,7 @@ export function pageNamesVendor(pageText, vendor, options = {}) {
   return result(false, null, null);
 }
 
-export function classifySource(offer, page, priceSignalCount) {
+export function classifySource(offer, page, signals) {
   if (!page || !page.ok) {
     return { outcome: SOURCE_CHECK_UNREADABLE, detail: page?.error ?? "not fetched" };
   }
@@ -157,16 +175,23 @@ export function classifySource(offer, page, priceSignalCount) {
       detail: `the page never names ${offer.vendor} and is not served from its domain`,
     };
   }
-  if (!(priceSignalCount > 0)) {
+  const found = Array.isArray(signals) ? signals : [];
+  if (found.length === 0) {
     return {
       outcome: SOURCE_CHECK_NO_TERMS,
       detail: `the page names ${offer.vendor} but states no amount, tier or rate we can read`,
     };
   }
+  if (!found.some(statesAnAmount)) {
+    return {
+      outcome: SOURCE_CHECK_NO_AMOUNT,
+      detail: `the page names ${offer.vendor} and says "${found[0]}" but states no amount, rate or price we can read`,
+    };
+  }
   return { outcome: SOURCE_CHECK_OK, detail: naming.via };
 }
 
-export function sourceCheckRecord(offer, page, priceSignalCount, checked) {
-  const { outcome, detail } = classifySource(offer, page, priceSignalCount);
+export function sourceCheckRecord(offer, page, signals, checked) {
+  const { outcome, detail } = classifySource(offer, page, signals);
   return { checked, outcome, detail };
 }

--- a/scripts/verification-state.js
+++ b/scripts/verification-state.js
@@ -6,7 +6,7 @@ import { fileURLToPath } from "node:url";
 import { isoDay } from "./change-log.js";
 import { offerKey } from "./change-refusals.js";
 import {
-  SOURCE_CHECK_OK,
+  holdsVerifiedDate,
   SOURCE_CHECK_UNREADABLE,
 } from "./vendor-naming.js";
 
@@ -237,7 +237,7 @@ export function backfillVerificationState(state, offers, options = {}) {
     const key = offerKey(offer?.vendor, offer?.url);
     if (state.has(key)) continue;
     const check = offer?.source_check;
-    if (!check || check.outcome === SOURCE_CHECK_OK) continue;
+    if (!check || !holdsVerifiedDate(check.outcome)) continue;
     const link = linkHealth.get(offer.url) ?? null;
     const failures = backfillFailureCount(link);
     const record = {

--- a/scripts/whole-page-census.js
+++ b/scripts/whole-page-census.js
@@ -119,8 +119,8 @@ async function main() {
     const cut = whole.ok
       ? { ok: true, text: whole.text.slice(0, MAX_PAGE_TEXT_LENGTH) }
       : whole;
-    const wholeClass = classifySource(offer, whole, whole.ok ? priceSignals(whole.text).length : 0);
-    const cutClass = classifySource(offer, cut, cut.ok ? priceSignals(cut.text).length : 0);
+    const wholeClass = classifySource(offer, whole, whole.ok ? priceSignals(whole.text) : []);
+    const cutClass = classifySource(offer, cut, cut.ok ? priceSignals(cut.text) : []);
     const firstSignal = whole.ok
       ? (() => {
           const sigs = priceSignals(whole.text);
@@ -136,7 +136,7 @@ async function main() {
         offer.source_check = sourceCheckRecord(
           offer,
           whole,
-          priceSignals(whole.text).length,
+          priceSignals(whole.text),
           checked
         );
         restamped++;

--- a/src/data.ts
+++ b/src/data.ts
@@ -826,7 +826,7 @@ export function checkVendorRisk(
   } else {
     summary = `${vendorHistorySentence(offer.vendor, "stable", cause)} Free tier verified for ${longevityDays} days.`;
   }
-  if (!withheldReason && sourceStatesNoAmount(offer)) {
+  if (!gate && !withheldReason && sourceStatesNoAmount(offer)) {
     summary = `${summary} ${amountUnstatedSentence(offer.vendor)}`;
   }
 

--- a/src/data.ts
+++ b/src/data.ts
@@ -1,12 +1,18 @@
 import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import type { Offer, EnrichedOffer, OfferIndex, DealChange, DealChangesIndex, ChangeDateSource, StabilityClass, Referral, RiskCause, LinkUnreachable } from "./types.js";
+import type { Offer, EnrichedOffer, OfferIndex, DealChange, DealChangesIndex, ChangeDateSource, StabilityClass, Referral, RiskCause, LinkUnreachable, SourceCheck } from "./types.js";
 import { isUrlSuspended } from "./referral-health.js";
 import { rankForListing, gateFor, utcDate, type TieBreak, type Gate, type GateCode } from "./ranking.js";
 import { unreachableNoticeForUrl, resetLinkHealthCache } from "./link-health.js";
 import { quarantineSummary, resetVerificationStateCache, type QuarantineSummary } from "./verification-state.js";
-import { cannotVouchForLevel, levelWithheldReason, withheldLevelSentence } from "./source-check.js";
+import {
+  amountUnstatedSentence,
+  cannotVouchForLevel,
+  levelWithheldReason,
+  sourceStatesNoAmount,
+  withheldLevelSentence,
+} from "./source-check.js";
 import { substitutesFor } from "./product-role.js";
 import { DATE_SOURCES, isEventDated, changeDateClause, isoWeekWindow, changesInWindow, discoveryBatchNote, firstReadHeading, type DateWindow } from "./change-dates.js";
 import { PRODUCT_DEPRECATED, deprecationEndsTheListedProduct } from "./product-deprecation.js";
@@ -654,6 +660,7 @@ export interface VendorRiskResult {
   risk_level: "stable" | "caution" | "risky" | null;
   risk_cause: RiskCause | null;
   link_unreachable: LinkUnreachable | null;
+  source_check: SourceCheck | null;
   gate: Gate | null;
   free_tier_longevity_days: number | null;
   changes: DealChange[];
@@ -819,6 +826,9 @@ export function checkVendorRisk(
   } else {
     summary = `${vendorHistorySentence(offer.vendor, "stable", cause)} Free tier verified for ${longevityDays} days.`;
   }
+  if (!withheldReason && sourceStatesNoAmount(offer)) {
+    summary = `${summary} ${amountUnstatedSentence(offer.vendor)}`;
+  }
 
   return {
     result: {
@@ -827,6 +837,7 @@ export function checkVendorRisk(
       risk_level: gate || (cannotVouchForLevel(offer, linkUnreachable) && riskLevel === "stable") ? null : riskLevel,
       risk_cause: cause ? { date: cause.date, date_source: cause.date_source, change_type: cause.change_type, summary: cause.summary } : null,
       link_unreachable: linkUnreachable,
+      source_check: offer.source_check ?? null,
       gate,
       free_tier_longevity_days: gate && GATES_WITHOUT_A_LONGEVITY_REFERENT.has(gate.code) ? null : longevityDays,
       changes: vendorChanges,

--- a/src/openapi.ts
+++ b/src/openapi.ts
@@ -379,6 +379,7 @@ export const openapiSpec = {
                     link_unreachable: { type: "object", nullable: true, description: "Non-null only where a check reached a conclusion about the destination: a 404 confirmed by a full request, a 410, or a hostname with no address. Being refused (403, 429, 5xx, timeout) is evidence about our checker and never produces one of these.", properties: { last_reachable: { type: "string", format: "date", nullable: true }, checked: { type: "string", format: "date" }, terminal: { type: "boolean" } } },
                     risk_cause: { type: "object", nullable: true, description: "The single dated record that produced a non-stable risk_level. Never null when risk_level is caution or risky (#1038) — a client that renders the level must be able to render the reason.", properties: { date: { type: "string" }, change_type: { type: "string" }, summary: { type: "string" } } },
                     gate: { $ref: "#/components/schemas/Gate" },
+                    source_check: { $ref: "#/components/schemas/SourceCheck" },
                     free_tier_longevity_days: { type: "number", nullable: true, description: "Null where the gate code is offer_retired or not_a_free_offer (#1241) — a count of days a free tier has held has no referent where our own record says there is no free tier." },
                     changes: { type: "array", items: { $ref: "#/components/schemas/DealChange" } },
                     alternatives: {
@@ -923,9 +924,32 @@ export const openapiSpec = {
           tags: { type: "array", items: { type: "string" }, description: "Searchable tags" },
           verifiedDate: { type: "string", format: "date", description: "Date the offer was last verified (YYYY-MM-DD)" },
           eligibility: { $ref: "#/components/schemas/Eligibility" },
-          gate: { $ref: "#/components/schemas/Gate" }
+          gate: { $ref: "#/components/schemas/Gate" },
+          source_check: { $ref: "#/components/schemas/SourceCheck" }
         },
         required: ["vendor", "category", "description", "tier", "url", "tags", "verifiedDate"]
+      },
+      SourceCheck: {
+        type: "object",
+        nullable: true,
+        description: "What we found on the page at url when we last read it, and so how much of this record that page supports. The outcome grades our evidence, not the offer (#1268).",
+        properties: {
+          checked: { type: "string", format: "date", description: "The day we last read the page." },
+          outcome: {
+            type: "string",
+            enum: ["ok", "states_no_amount", "does_not_name_vendor", "states_no_terms", "unreadable"],
+            description: [
+              "ok — the page names the vendor and states at least one amount, rate or price in figures.",
+              "states_no_amount — the page names the vendor and names a plan or tier, but every price signal on it is a phrase such as \"Enterprise plan\" or \"Free forever\" and none is a figure (#1268). The quantities in description come from our own entry, not from that page. risk_level is still published and the summary says so, rather than being withheld.",
+              "does_not_name_vendor — the page never names the vendor and is not served from its domain.",
+              "states_no_terms — the page names the vendor but carries no price signal of any kind.",
+              "unreadable — the fetch produced no body we could read.",
+              "The last three withhold a favourable risk_level; the first two do not."
+            ].join(" ")
+          },
+          detail: { type: "string", description: "What the check found, in its own words: for ok, how the page named the vendor; for states_no_amount, the phrase that was the page's entire price evidence; otherwise why the page cannot confirm the record." }
+        },
+        required: ["checked", "outcome", "detail"]
       },
       Gate: {
         type: "object",

--- a/src/serve.ts
+++ b/src/serve.ts
@@ -17,7 +17,7 @@ import { configureVendorSeries, recordVendorRequest, flushVendorSeries, readVend
 import { openapiSpec } from "./openapi.js";
 import { LINK_GRACE_DAYS, unreachableNoticeForUrl } from "./link-health.js";
 import { offerEnded, offerRetired, recordedTierSentence, endedHeadline, endedHistorySentence, endedReliabilitySentence, endedEmptyChangeHistorySentence, ENDED_BADGE_LABEL, ENDED_SINCE_CHANGES_SENTENCE, type OfferTierAndUrl } from "./retirement.js";
-import { levelWithheldReason, withheldLevelClause, withheldLevelSentence } from "./source-check.js";
+import { amountUnstatedSentence, levelWithheldReason, sourceStatesNoAmount, withheldLevelClause, withheldLevelSentence } from "./source-check.js";
 import { buildComparisonMap, comparisonSlug } from "./comparison-pairs.js";
 import { stabilityFaqAnswer, stabilityVerdictClause, type ComparisonSide, type StabilityRating } from "./comparison-verdict.js";
 import { publishedVendorLevel, vendorVerdictSentence, vendorBadge, statesRiskCause, narrowingSentence, changeKindNoun, type VendorVerdictInput } from "./vendor-verdict.js";
@@ -3744,6 +3744,10 @@ function buildVendorPage(slug: string): string | null {
     ? `  <p class="link-unreachable-line" style="margin:.4rem 0 .6rem;font-size:.9rem;color:var(--text-muted)"><strong style="color:#f85149">Link unreachable:</strong> ${escHtmlServer(primary.url)} did not resolve on our check of <span class="link-checked-date" style="font-family:var(--mono)">${escHtmlServer(linkUnreachable.checked)}</span>. ${linkUnreachable.last_reachable ? `Last reachable <span class="link-last-reachable" style="font-family:var(--mono)">${escHtmlServer(linkUnreachable.last_reachable)}</span>.` : "We have no date on which it was reachable."}</p>`
     : "";
 
+  const amountUnstatedLine = !levelWithheld && sourceStatesNoAmount(primary)
+    ? `  <p class="amount-unstated-line" style="margin:.4rem 0 .6rem;font-size:.9rem;color:var(--text-muted)"><strong style="color:#d29922">Source states no amount:</strong> ${escHtmlServer(amountUnstatedSentence(vendorName))}</p>`
+    : "";
+
   const primaryEligibilityGate = eligibilityGateAsPublished(primary, servedOn);
   const primaryEligibilityConditions = publishableEligibilityConditions(primary);
   const primaryGateBeyondEligibility = primaryGate && primaryGate.code !== "eligibility_restricted" ? primaryGate : null;
@@ -4313,6 +4317,7 @@ ${mcpCtaCss()}
   <h1>${escHtmlServer(headline)}${h1RiskBadge}</h1>${gateLine}
 ${riskCauseLine}
 ${linkUnreachableLine}
+${amountUnstatedLine}
 ${productRoleLine}${productSubtypesLine}
   <p class="page-meta">Limits, pricing history${alternatives.length > 0 ? `, and ${alternatives.length} alternatives` : ""}.${verifiedSentence} Last updated ${escHtmlServer(lastUpdated)}.</p>
 ${quickVerdictHtml}

--- a/src/serve.ts
+++ b/src/serve.ts
@@ -3745,7 +3745,7 @@ function buildVendorPage(slug: string): string | null {
     : "";
 
   const amountUnstatedLine = !levelWithheld && sourceStatesNoAmount(primary)
-    ? `  <p class="amount-unstated-line" style="margin:.4rem 0 .6rem;font-size:.9rem;color:var(--text-muted)"><strong style="color:#d29922">Source states no amount:</strong> ${escHtmlServer(amountUnstatedSentence(vendorName))}</p>`
+    ? `\n  <p class="amount-unstated-line" style="margin:.4rem 0 .6rem;font-size:.9rem;color:var(--text-muted)"><strong style="color:#d29922">Source states no amount:</strong> ${escHtmlServer(amountUnstatedSentence(vendorName))}</p>`
     : "";
 
   const primaryEligibilityGate = eligibilityGateAsPublished(primary, servedOn);
@@ -4316,8 +4316,7 @@ ${mcpCtaCss()}
   <div class="breadcrumb"><a href="/">AgentDeals</a> &rsaquo; <a href="/vendor">Vendors</a> &rsaquo; ${escHtmlServer(vendorName)}</div>
   <h1>${escHtmlServer(headline)}${h1RiskBadge}</h1>${gateLine}
 ${riskCauseLine}
-${linkUnreachableLine}
-${amountUnstatedLine}
+${linkUnreachableLine}${amountUnstatedLine}
 ${productRoleLine}${productSubtypesLine}
   <p class="page-meta">Limits, pricing history${alternatives.length > 0 ? `, and ${alternatives.length} alternatives` : ""}.${verifiedSentence} Last updated ${escHtmlServer(lastUpdated)}.</p>
 ${quickVerdictHtml}

--- a/src/source-check.ts
+++ b/src/source-check.ts
@@ -2,6 +2,7 @@ import type { Offer, SourceCheck, SourceCheckOutcome } from "./types.js";
 
 export const SOURCE_CHECK_OUTCOMES: SourceCheckOutcome[] = [
   "ok",
+  "states_no_amount",
   "does_not_name_vendor",
   "states_no_terms",
   "unreadable",
@@ -47,6 +48,14 @@ export function withheldLevelSentence(
 
 export function sourceDoesNotNameVendor(offer: Pick<Offer, "source_check">): boolean {
   return offer.source_check?.outcome === "does_not_name_vendor";
+}
+
+export function sourceStatesNoAmount(offer: Pick<Offer, "source_check">): boolean {
+  return offer.source_check?.outcome === "states_no_amount";
+}
+
+export function amountUnstatedSentence(subject: string): string {
+  return `The page we cite for ${subject} names a plan but states no amount, so these limits come from our own record rather than from that page.`;
 }
 
 export function sourceCheckNotice(offer: Pick<Offer, "source_check">): SourceCheck | null {

--- a/src/types.ts
+++ b/src/types.ts
@@ -78,7 +78,12 @@ export interface Offer {
   source_check?: SourceCheck;
 }
 
-export type SourceCheckOutcome = "ok" | "does_not_name_vendor" | "states_no_terms" | "unreadable";
+export type SourceCheckOutcome =
+  | "ok"
+  | "states_no_amount"
+  | "does_not_name_vendor"
+  | "states_no_terms"
+  | "unreadable";
 
 export interface SourceCheck {
   checked: string;

--- a/test/api-gate-field.test.ts
+++ b/test/api-gate-field.test.ts
@@ -7,6 +7,7 @@ import { fileURLToPath } from "node:url";
 
 const { gateFor, utcDate, GATE_TABLE } = await import("../dist/ranking.js");
 const { gateClauseList, gateDisclosureSentence, matchingSubject } = await import("../dist/gate-disclosure.js");
+const { LEVEL_WITHHOLDING_OUTCOMES } = await import("../dist/source-check.js");
 
 type Offer = import("../src/types.ts").Offer;
 type Gate = { code: string; reason: string } | null;
@@ -343,7 +344,7 @@ describe("/api/vendor-risk does not rate an offer we do not list (issue #1241 Pa
   });
 
   it("a gated record whose cited page we could not read still says which page we could not read", async () => {
-    const withheld = gatedRecords.filter(o => firstRecordForItsVendor(o) && o.source_check && o.source_check.outcome !== "ok");
+    const withheld = gatedRecords.filter(o => firstRecordForItsVendor(o) && o.source_check && LEVEL_WITHHOLDING_OUTCOMES.includes(o.source_check.outcome));
     assert.ok(withheld.length > 0, "no gated record currently carries a source check we could not read");
     let cited = 0;
     for (const record of withheld.slice(0, 25)) {

--- a/test/price-evidence-grade.test.ts
+++ b/test/price-evidence-grade.test.ts
@@ -1,0 +1,217 @@
+import { describe, it } from "node:test";
+import assert from "node:assert";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  SOURCE_CHECK_OUTCOMES,
+  LEVEL_WITHHOLDING_OUTCOMES,
+  cannotVouchForLevel,
+  levelWithheldReason,
+  sourceCheckNotice,
+  sourceStatesNoAmount,
+  amountUnstatedSentence,
+} from "../dist/source-check.js";
+import { openapiSpec } from "../dist/openapi.js";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const INDEX_PATH = path.join(__dirname, "..", "data", "index.json");
+
+const { priceSignals, numericPriceSignals } = await import("../scripts/change-gate.js");
+const { classifySource, holdsVerifiedDate, statesAnAmount, SOURCE_CHECK_NO_AMOUNT } =
+  await import("../scripts/vendor-naming.js");
+
+const OFFER = {
+  vendor: "Widgetson",
+  category: "Object Storage",
+  tier: "Free",
+  description: "10 GB storage",
+  url: "https://widgetson.example/pricing",
+};
+
+const nav = `${OFFER.vendor} Docs Blog Careers Support Community Login Sign up `.repeat(12);
+
+function pageSaying(claim: string) {
+  return { ok: true, text: `${nav} ${OFFER.vendor} pricing. ${claim} Talk to our team about what you need.` };
+}
+
+const ONLY_A_PLAN_BY_NAME = pageSaying("Free forever.");
+const THE_QUANTITY_WE_PUBLISH = pageSaying(`${OFFER.description} free.`);
+const THE_QUANTITY_AS_A_RATE = pageSaying(`${OFFER.description} per month free.`);
+const NOTHING_PRICE_SHAPED = pageSaying("We help teams ship software they can operate.");
+
+function gradeOf(page: { ok: boolean; text: string }) {
+  return classifySource(OFFER, page, priceSignals(page.text)).outcome;
+}
+
+describe("a page that names a plan and a page that states an amount are different evidence", () => {
+  it("grades a page whose only price evidence is a plan name apart from one stating the quantity", () => {
+    assert.notStrictEqual(gradeOf(ONLY_A_PLAN_BY_NAME), gradeOf(THE_QUANTITY_WE_PUBLISH));
+    assert.notStrictEqual(gradeOf(ONLY_A_PLAN_BY_NAME), gradeOf(THE_QUANTITY_AS_A_RATE));
+  });
+
+  it("confirms the record only from the page that states the amount as a rate", () => {
+    assert.strictEqual(gradeOf(THE_QUANTITY_AS_A_RATE), "ok");
+    assert.strictEqual(gradeOf(ONLY_A_PLAN_BY_NAME), SOURCE_CHECK_NO_AMOUNT);
+  });
+
+  it("reads the plan name as a price signal and the figure beside it as an amount", () => {
+    assert.ok(priceSignals(ONLY_A_PLAN_BY_NAME.text).length > 0);
+    assert.strictEqual(numericPriceSignals(ONLY_A_PLAN_BY_NAME.text).length, 0);
+    assert.ok(numericPriceSignals(THE_QUANTITY_AS_A_RATE.text).length > 0);
+  });
+
+  it("reads a bare quantity with no period or currency beside it as no signal at all", () => {
+    assert.deepStrictEqual(priceSignals(THE_QUANTITY_WE_PUBLISH.text), []);
+    assert.strictEqual(gradeOf(THE_QUANTITY_WE_PUBLISH), "states_no_terms");
+  });
+
+  it("leaves a page with no price signal of any kind where it already was", () => {
+    assert.strictEqual(priceSignals(NOTHING_PRICE_SHAPED.text).length, 0);
+    assert.strictEqual(gradeOf(NOTHING_PRICE_SHAPED), "states_no_terms");
+  });
+
+  it("names the phrase that was the page's whole price evidence", () => {
+    const graded = classifySource(OFFER, ONLY_A_PLAN_BY_NAME, priceSignals(ONLY_A_PLAN_BY_NAME.text));
+    assert.match(graded.detail, /Free forever/);
+    assert.match(graded.detail, /Widgetson/);
+  });
+
+  it("still reports a page that does not name the vendor as one about somebody else", () => {
+    const strangerOffer = { ...OFFER, url: "https://dealmarket.example/offers" };
+    const elsewhere = { ok: true, text: "Someothercorp pricing. Enterprise plan available." };
+    assert.strictEqual(
+      classifySource(strangerOffer, elsewhere, priceSignals(elsewhere.text)).outcome,
+      "does_not_name_vendor"
+    );
+  });
+});
+
+describe("which price signals count as an amount", () => {
+  const cases: Array<[string, boolean]> = [
+    ["$20", true],
+    ["500 GB per month", true],
+    ["100 daily requests", true],
+    ["1000 USD", true],
+    ["Enterprise plan", false],
+    ["Free forever", false],
+    ["starts at", false],
+    ["Team plan", false],
+  ];
+
+  for (const [signal, isAmount] of cases) {
+    it(`${isAmount ? "counts" : "does not count"} "${signal}" as an amount`, () => {
+      assert.strictEqual(statesAnAmount(signal), isAmount);
+    });
+  }
+
+  it("splits every signal the matcher can produce into one side or the other", () => {
+    const page = "Widgetson Free forever. Enterprise plan starts at $20 per month for 500 GB per month.";
+    const all = priceSignals(page);
+    const amounts = numericPriceSignals(page);
+    assert.ok(all.length > amounts.length, "the fixture must carry both kinds for the split to mean anything");
+    assert.deepStrictEqual(amounts, all.filter(statesAnAmount));
+  });
+});
+
+describe("what the new grade does and does not change about a record", () => {
+  const graded = {
+    source_check: {
+      checked: "2026-09-02",
+      outcome: SOURCE_CHECK_NO_AMOUNT,
+      detail: `the page names Widgetson and says "Free forever" but states no amount, rate or price we can read`,
+    },
+  };
+
+  it("belongs to the vocabulary both sides of the pipeline share", () => {
+    assert.ok(SOURCE_CHECK_OUTCOMES.includes(SOURCE_CHECK_NO_AMOUNT));
+  });
+
+  it("does not withhold the stability level, so no record joins the withholding population", () => {
+    assert.strictEqual(LEVEL_WITHHOLDING_OUTCOMES.includes(SOURCE_CHECK_NO_AMOUNT), false);
+    assert.strictEqual(cannotVouchForLevel(graded, null), false);
+    assert.strictEqual(levelWithheldReason(graded, null), null);
+  });
+
+  it("still reports the check to a caller, unlike the grade that confirms the record", () => {
+    assert.ok(sourceCheckNotice(graded));
+    assert.strictEqual(sourceStatesNoAmount(graded), true);
+    assert.strictEqual(sourceStatesNoAmount({ source_check: { checked: "2026-09-02", outcome: "ok", detail: "text" } }), false);
+  });
+
+  it("says where the quantities came from instead", () => {
+    const sentence = amountUnstatedSentence("Widgetson");
+    assert.match(sentence, /Widgetson/);
+    assert.match(sentence, /our own record/);
+  });
+
+  it("keeps the verified date moving, unlike the three grades that cannot confirm anything", () => {
+    assert.strictEqual(holdsVerifiedDate(SOURCE_CHECK_NO_AMOUNT), false);
+    assert.strictEqual(holdsVerifiedDate("ok"), false);
+    for (const outcome of ["does_not_name_vendor", "states_no_terms", "unreadable"]) {
+      assert.strictEqual(holdsVerifiedDate(outcome), true, `${outcome} must hold the verified date`);
+    }
+  });
+
+  it("holds the verified date for exactly the grades that withhold a level", () => {
+    assert.deepStrictEqual(
+      SOURCE_CHECK_OUTCOMES.filter(holdsVerifiedDate).sort(),
+      [...LEVEL_WITHHOLDING_OUTCOMES].sort()
+    );
+  });
+});
+
+describe("what an agent reading the API is told about the grade", () => {
+  const spec = openapiSpec as unknown as {
+    components: { schemas: Record<string, { properties?: Record<string, { enum?: string[]; description?: string; $ref?: string }> }> };
+    paths: Record<string, { get: { responses: Record<string, { content: Record<string, { schema: { properties?: Record<string, unknown> } }> }> } }>;
+  };
+
+  it("documents every outcome the writer can write, and no others", () => {
+    const documented = spec.components.schemas.SourceCheck.properties!.outcome.enum!;
+    assert.deepStrictEqual([...documented].sort(), [...SOURCE_CHECK_OUTCOMES].sort());
+  });
+
+  it("says what each outcome means in terms of what was found on the page", () => {
+    const described = spec.components.schemas.SourceCheck.properties!.outcome.description!;
+    for (const outcome of SOURCE_CHECK_OUTCOMES) {
+      assert.ok(described.includes(`${outcome} —`), `${outcome} is offered as a value but never explained`);
+    }
+  });
+
+  it("carries the check on the record the search endpoints return", () => {
+    assert.strictEqual(
+      spec.components.schemas.Offer.properties!.source_check.$ref,
+      "#/components/schemas/SourceCheck"
+    );
+  });
+
+  it("carries the check on the endpoint that rates a vendor", () => {
+    const risk = spec.paths["/api/vendor-risk/{vendor}"].get.responses["200"].content["application/json"].schema;
+    assert.deepStrictEqual(
+      (risk.properties as Record<string, { $ref?: string }>).source_check,
+      { $ref: "#/components/schemas/SourceCheck" }
+    );
+  });
+});
+
+describe("the catalog after the grade was applied", () => {
+  const index = JSON.parse(readFileSync(INDEX_PATH, "utf-8")) as {
+    offers: Array<{ vendor: string; source_check?: { outcome: string; detail: string } }>;
+  };
+  const graded = index.offers.filter((o) => o.source_check?.outcome === SOURCE_CHECK_NO_AMOUNT);
+
+  it("holds records at the new grade, so the surfaces above are reachable from real data", () => {
+    assert.ok(graded.length > 0);
+  });
+
+  it("quotes the page's own words in every one of their details", () => {
+    for (const offer of graded) {
+      assert.match(
+        offer.source_check!.detail,
+        /^the page names .+ and says ".+" but states no amount, rate or price we can read$/,
+        `${offer.vendor} carries a detail the grade did not write`
+      );
+    }
+  });
+});

--- a/test/restriction-evidence.test.ts
+++ b/test/restriction-evidence.test.ts
@@ -348,7 +348,7 @@ describe("every restriction we have stored survives its own rule", () => {
     for (const vendor of ["Postman", "Netlify", "Google Gemini API", "GitHub Copilot"]) {
       assert.ok(kept.has(vendor), `${vendor} keeps its restriction record`);
     }
-    assert.strictEqual(stored.filter(c => c.change_type === "record_corrected").length, 2);
+    assert.strictEqual(stored.filter(c => c.change_type === "record_corrected").length, 3);
   });
 
   it("is not vacuous — the population is large enough to have caught the seven", () => {

--- a/test/restriction-evidence.test.ts
+++ b/test/restriction-evidence.test.ts
@@ -348,7 +348,7 @@ describe("every restriction we have stored survives its own rule", () => {
     for (const vendor of ["Postman", "Netlify", "Google Gemini API", "GitHub Copilot"]) {
       assert.ok(kept.has(vendor), `${vendor} keeps its restriction record`);
     }
-    assert.strictEqual(stored.filter(c => c.change_type === "record_corrected").length, 3);
+    assert.strictEqual(stored.filter(c => c.change_type === "record_corrected").length, 2);
   });
 
   it("is not vacuous — the population is large enough to have caught the seven", () => {

--- a/test/short-page-floor.test.ts
+++ b/test/short-page-floor.test.ts
@@ -60,7 +60,7 @@ async function readWith(body: string) {
 }
 
 function outcomeFor(page: { ok: boolean; text?: string }) {
-  const signals = page.ok ? priceSignals(page.text as string).length : 0;
+  const signals = page.ok ? priceSignals(page.text as string) : [];
   return classifySource(OFFER, page, signals).outcome;
 }
 

--- a/test/source-check-pages.test.ts
+++ b/test/source-check-pages.test.ts
@@ -323,6 +323,13 @@ describe("a vendor page whose cited source names a plan but states no amount", (
     assert.match(risk.summary, /names a plan but states no amount/);
   });
 
+  it("says nothing of the kind on a page whose source stated an amount", async () => {
+    const { body } = await get("/vendor/controlcorp");
+    assert.equal(body.includes("Controlcorp"), true);
+    assert.doesNotMatch(body, /amount-unstated-line/);
+    assert.doesNotMatch(body, /names a plan but states no amount/);
+  });
+
   it("leaves the endpoint's answer for a page we could read alone", async () => {
     const { body } = await get("/api/vendor-risk/controlcorp");
     const risk = JSON.parse(body);

--- a/test/source-check-pages.test.ts
+++ b/test/source-check-pages.test.ts
@@ -76,6 +76,19 @@ const QUOTED_FROM_THE_PAGE_IT_CITES = {
   source_check: { checked: "2026-09-02", outcome: "ok", detail: "text" },
 };
 
+const SOURCED_FROM_A_PAGE_NAMING_ONLY_A_PLAN = {
+  ...SOURCED_FROM_A_MARKETPLACE,
+  vendor: "Plancorp",
+  url: "https://plancorp.example/pricing",
+  description: "10 GB storage, 5 projects",
+  tier: "Free",
+  source_check: {
+    checked: "2026-09-02",
+    outcome: "states_no_amount",
+    detail: 'the page names Plancorp and says "Free forever" but states no amount, rate or price we can read',
+  },
+};
+
 let fixtureDir = "";
 let serverPort = 0;
 let proc: ChildProcess | null = null;
@@ -130,6 +143,7 @@ before(async () => {
           SOURCED_FROM_ITS_OWN_PAGE,
           SOURCED_FROM_A_PAGE_WE_COULD_NOT_READ,
           SOURCED_FROM_A_PAGE_STATING_NO_FIGURES,
+          SOURCED_FROM_A_PAGE_NAMING_ONLY_A_PLAN,
           QUOTED_FROM_THE_PAGE_IT_CITES,
         ],
       },
@@ -266,6 +280,54 @@ describe("a vendor page whose cited source names it but states no terms we can r
     assert.match(own, /states no terms we can read/);
     assert.doesNotMatch(own, /could not read the page we cite/);
     assert.doesNotMatch(own, /does not name it/);
+  });
+});
+
+describe("a vendor page whose cited source names a plan but states no amount", () => {
+  it("says on the page which of the two its record rests on", async () => {
+    const { body } = await get("/vendor/plancorp");
+    assert.equal(body.includes("Plancorp"), true);
+    const line = body.match(/<p class="amount-unstated-line"[\s\S]*?<\/p>/)?.[0] ?? "";
+    assert.match(line, /names a plan but states no amount/);
+    assert.match(line, /our own record/);
+  });
+
+  it("keeps its stability level rather than withholding it", async () => {
+    const { body } = await get("/vendor/plancorp");
+    const row = body.match(/<tr class="current-vendor-row">[\s\S]*?<\/tr>/)?.[0] ?? "";
+    assert.ok(row.includes("Plancorp"), "the row under test must be the vendor's own");
+    assert.match(row, /stability-dot/);
+    assert.doesNotMatch(row, /source unconfirmed/);
+  });
+
+  it("does not borrow the sentence written for a page that states nothing", async () => {
+    const own = aboutThisVendor(await get("/vendor/plancorp"));
+    assert.doesNotMatch(own, /states no terms we can read/);
+    assert.doesNotMatch(own, /could not read the page we cite/);
+    assert.doesNotMatch(own, /does not name it/);
+  });
+
+  it("carries the grade and its reason through the API", async () => {
+    const { body } = await get("/api/offers?q=plancorp");
+    const offer = JSON.parse(body).offers[0];
+    assert.strictEqual(offer.source_check.outcome, "states_no_amount");
+    assert.strictEqual(offer.risk_level, "stable");
+    assert.match(offer.source_check.detail, /Free forever/);
+  });
+
+  it("qualifies the level the risk endpoint publishes instead of leaving it bare", async () => {
+    const { body } = await get("/api/vendor-risk/plancorp");
+    const risk = JSON.parse(body);
+    assert.strictEqual(risk.risk_level, "stable");
+    assert.strictEqual(risk.source_check.outcome, "states_no_amount");
+    assert.match(risk.summary, /names a plan but states no amount/);
+  });
+
+  it("leaves the endpoint's answer for a page we could read alone", async () => {
+    const { body } = await get("/api/vendor-risk/controlcorp");
+    const risk = JSON.parse(body);
+    assert.strictEqual(risk.source_check.outcome, "ok");
+    assert.doesNotMatch(risk.summary, /states no amount/);
   });
 });
 

--- a/test/vendor-naming.test.ts
+++ b/test/vendor-naming.test.ts
@@ -160,19 +160,19 @@ describe("what a re-verification learned about the cited page", () => {
   const offer = { vendor: "Cloudways", url: "https://www.joinsecret.com/offers" };
 
   it("separates a page about somebody else from a page that says nothing", () => {
-    const notNamed = classifySource(offer, { ok: true, text: JOINSECRET_OFFERS_PAGE }, 78);
+    const notNamed = classifySource(offer, { ok: true, text: JOINSECRET_OFFERS_PAGE }, priceSignals(JOINSECRET_OFFERS_PAGE));
     assert.strictEqual(notNamed.outcome, SOURCE_CHECK_NOT_NAMED);
 
     const noTerms = classifySource(
       { vendor: "Doczilla", url: "https://doczilla.app" },
       { ok: true, text: "Doczilla creates PDFs and screenshots." },
-      0
+      []
     );
     assert.strictEqual(noTerms.outcome, SOURCE_CHECK_NO_TERMS);
   });
 
   it("records a fetch failure as its own outcome rather than as a naming verdict", () => {
-    const result = classifySource(offer, { ok: false, error: "HTTP 503" }, 0);
+    const result = classifySource(offer, { ok: false, error: "HTTP 503" }, []);
     assert.strictEqual(result.outcome, SOURCE_CHECK_UNREADABLE);
     assert.match(result.detail, /503/);
   });
@@ -181,7 +181,7 @@ describe("what a re-verification learned about the cited page", () => {
     const result = classifySource(
       { vendor: "Vercel", url: "https://vercel.com/pricing" },
       { ok: true, text: "Vercel Hobby plan, free forever. Pro is $20/month." },
-      3
+      priceSignals("Vercel Hobby plan, free forever. Pro is $20/month.")
     );
     assert.strictEqual(result.outcome, SOURCE_CHECK_OK);
   });

--- a/test/whole-page-read.test.ts
+++ b/test/whole-page-read.test.ts
@@ -54,7 +54,7 @@ const OFFER = {
 
 function outcomeFor(text: string) {
   const page = { ok: true, text };
-  return classifySource(OFFER, page, priceSignals(text).length).outcome;
+  return classifySource(OFFER, page, priceSignals(text)).outcome;
 }
 
 describe("a page is read to its end, not to a fixed number of characters", () => {


### PR DESCRIPTION
Refs #1268.

`classifySource` granted `ok` on `priceSignalCount > 0`, and `priceSignals` matches phrases as well as figures. So a page whose entire price evidence was `"Enterprise plan"` certified a record identically to one stating a rate, and `sourceCheckNotice` returned `null` for both — which is what let 122 records publish quantities with no caveat against pages that state none.

`ok` is now two grades.

| grade | the page | level |
|---|---|---|
| `ok` | names the vendor and states an amount, rate or price **in figures** | published, unqualified |
| `states_no_amount` | names the vendor and names a plan or tier, but **every** price signal is a phrase | published, **qualified** |
| `does_not_name_vendor` / `states_no_terms` / `unreadable` | unchanged | withheld |

The split is one predicate — `statesAnAmount`, a figure inside the matched signal. `CURRENCY_AMOUNT`, `METERED_RATE` and `PERIODIC_ALLOWANCE` all require a digit; `NAMED_TIER` never contains one. `numericPriceSignals` in `change-gate.js` and `classifySource` in `vendor-naming.js` share that one definition rather than each carrying a copy.

`classifySource` now takes the signal array rather than its count, so it can ask what the signals were and not only how many there were. All seven call sites updated.

## Census, on the day of the fix (AC-2)

829 `ok` records, 828 read through `fetchPageText`, one fetch failure (`degoo.com`, HTTP 503, retried once).

| | 2026-08-28 (yours) | today |
|---|---|---|
| read | 825 | 828 |
| page carries a numeric signal | 703 | **707** |
| phrase-only evidence | 122 | **115** |
| — publishing a quantity | 83 | 80 |
| — — quantity absent from the page | 55 | **54** |
| no price signal at all | 7 | **6** |

## What was written

121 records re-stamped: **115 → `states_no_amount`**, **6 → `states_no_terms`**. One held: `degoo.com`, whose fetch produced no body — the same write rule as #1263, keyed on whether the body was read.

Every other field of every record is byte-identical: 121 of 1,580 records differ, all of them in `source_check` alone.

## AC-7 — no record joins the withholding sentence because of this change

Every mover was re-classified twice on the same body, once at each classifier.

- **115 of 115** movers to `states_no_amount` classify **`ok`** at the old classifier. The grade is their sole cause; no stale stamp rode along.
- **6 of 6** movers to `states_no_terms` classify **`states_no_terms`** at the old classifier too. They are stale stamps that would fail today's check whichever classifier ran, which is what AC-3 asked for — not records the new grade pushed into that sentence.

So no record moves from `ok` to `states_no_terms` as a result of this change.

## AC-3 — the records whose page has no price signal at all

Five of your seven still have none and are re-stamped: `github.com/highlight/highlight`, `gtmetrix.com`, `surveymonkey.com`, `hubspot.com/startups`, `shotstack.io/solutions/startups/`. Two recovered — `build.opensuse.org` and the Vertex AI embeddings doc (`Google Gemini Embedding 2`) each carry one numeric signal today and classify `ok`. One joined: `cloud.google.com/shell`.

## AC-4 — openobserve.ai

The grade does not reach it. Its page carries `50 GB/day` and `4 PB/day` today, so it is `ok` under the new classifier as well — the record needed correcting, not grading.

**We already knew.** `deal_changes.json` has held a `limits_reduced` record for `openobserve.ai` since **2026-08-28**, `detected_by: reverify-ai`:

> previous_state: `200 GB Ingestion/month free, 15 Days Retention`
> current_state: `The Self Hosted Enterprise plan is free up to 50 GB/day ingestion … The OSS plan is completely free for self hosting with no usage limits.`

The detector read the page, recorded exactly the discrepancy this issue names, and never touched the record — a live instance of #1103. For five days `/vendor/openobserve-ai` published `200 GB Ingestion/month` directly above its own change record saying otherwise.

The description is now `Self-hosted Enterprise free up to 50 GB/day ingestion; open-source self-hosted free with no usage limits`, which is what both `openobserve.ai/` and `openobserve.ai/pricing` state; `verifiedDate` advances to today. The URL is unchanged and the trail is intact — the only `200 GB Ingestion/month` left on the page is the `Before:` line of the 2026-08-28 change record.

I did **not** add a `record_corrected` entry beside it. The dated public record of the error already exists and a second one would only duplicate it — at a cost of 1,581 moved bodies, because the `View all N pricing changes` counter appears on every vendor page. Measured both ways before deciding.

## AC-5 — negative control

2,577 paths swept against `main`, TZ pinned.

**2,438 byte-identical, 139 moved, 0 added, 0 removed, 0 status changes.**

122 vendor pages moved. Predicted from the changed records: **0 moved that were not re-stamped or corrected, 0 re-stamped or corrected that did not move.** None of the 707 records whose page carries a numeric signal moved on any surface.

The other 17 are neighbours, each attributable: `/best/free-logging`, `/best/free-code-quality`, `/best/free-dev-utilities`, `/category/logging`, five `/compare/*` and three `/trends/*` pages carrying gtmetrix, shotstack or openobserve; two `/events/*` pages that rendered gtmetrix's stability; `/freshness` and `/sitemap-vendors.xml` for openobserve's date; `/stack-check`, whose inlined `VENDOR_LOOKUP` carries descriptions.

One render fix on the way there: the notice's placeholder emitted a blank line on every vendor page even when empty, moving 1,572 bodies for whitespace. It is now appended inline.

## AC-1 — what the API says

`/api/offers`, `/api/details`, `/api/compare` and the MCP tools already spread the record, so `source_check.outcome` reaches them unchanged. `/api/vendor-risk/{vendor}` gains `source_check` — it rates a vendor and had no way to say what the rating rests on.

`openapi.ts` gains a `SourceCheck` schema explaining each grade in terms of what was found on the page, referenced from `Offer` and from the risk endpoint. A test asserts the documented enum equals the vocabulary the writer can write, and that every value carries an explanation — a sixth grade cannot be added without documenting it.

## What the reader sees

`/vendor/jsdelivr`:

> **Source states no amount:** The page we cite for jsDelivr names a plan but states no amount, so these limits come from our own record rather than from that page.

`/api/vendor-risk/jsDelivr` summary:

> jsDelivr has a stable pricing history. Free tier verified for 13 days. The page we cite for jsDelivr names a plan but states no amount, so these limits come from our own record rather than from that page.

**That sentence is the only new site copy in this PR and it is mine — say the word and I will change it.** Everything else the grade produces is either an existing sentence or the `detail` string, which quotes the page's own phrase.

A gated record does not get the qualification: a record we do not rank has no level to qualify, and `api-gate-field.test.ts` holds gated summaries to the gate's verdict alone or followed by a citation we could not read. `Clever Bootstrap Program` caught that.

## A consequence I chose against

`states_no_amount` does **not** hold the `verifiedDate`. The rolling pipeline held it for every outcome other than `ok`, so shipping the grade without this would have stopped 115 records advancing and started them toward `verification_lapsed` — a queue change this issue never asked for, on records whose pages we read fine. One predicate, `holdsVerifiedDate`, now governs it in `reverify-rolling.js` and in `backfillVerificationState`, and a test asserts the grades that hold the date are exactly the grades that withhold a level.

## One thing to carry to #1264

`priceSignals` does not read a bare quantity. `"10 GB storage free"` produces **zero** signals — a page needs a currency amount, a rate with a period, or a periodic allowance. Your positive control in AC-6 is pinned with that literal wording and it does clear the criterion, but by landing in `states_no_terms` rather than `ok`, so I pinned the intended pair beside it (`10 GB storage per month free` → `ok`, `Free forever` → `states_no_amount`).

That means some of the 492 records now saying *"states no terms we can read"* cite pages that do state quantities — just not as rates. Worth knowing before that sentence is reworded.

## Tests

3,161 tests, 35 new, 0 red. Real MCP `initialize` → `tools/call` on `/mcp` returns jsDelivr with `outcome: states_no_amount` and the detail naming `free API`.

10 mutations, 10 killed — including grading every signalled page `ok`, calling every signal an amount, calling none of them one, writing `states_no_terms` for a page that names a plan, holding the verified date for the new grade, withholding the level for it, qualifying a gated record's summary, rendering the notice on every vendor page, and leaving the grade out of `openapi.ts`. The last of those survived the first pass — no test asserted that a record whose source stated an amount carries no notice — so it now has one.
