### PR TITLE
Match a vendor name at word boundaries and say which record answered (#1269)

### DIFF
--- a/scripts/e2e-1269.mjs
+++ b/scripts/e2e-1269.mjs
@@ -1,0 +1,165 @@
+import { spawn } from "node:child_process";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO = path.join(__dirname, "..");
+
+const failures = [];
+function check(ok, message) {
+  console.log(`${ok ? "PASS" : "FAIL"}  ${message}`);
+  if (!ok) failures.push(message);
+}
+
+function startLocalServer() {
+  return new Promise((resolve, reject) => {
+    const proc = spawn("node", [path.join(REPO, "dist", "serve.js")], {
+      stdio: ["pipe", "pipe", "pipe"],
+      env: { ...process.env, PORT: "0", BASE_URL: "http://localhost" },
+    });
+    const timeout = setTimeout(() => {
+      proc.kill();
+      reject(new Error("server startup timeout"));
+    }, 60000);
+    proc.stderr.on("data", (data) => {
+      const match = data.toString().match(/running on http:\/\/localhost:(\d+)/);
+      if (match) {
+        clearTimeout(timeout);
+        resolve({ proc, base: `http://localhost:${match[1]}` });
+      }
+    });
+    proc.on("error", (err) => {
+      clearTimeout(timeout);
+      reject(err);
+    });
+  });
+}
+
+async function mcpSession(base) {
+  const init = await fetch(`${base}/mcp`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json", Accept: "application/json, text/event-stream" },
+    body: JSON.stringify({
+      jsonrpc: "2.0", id: 1, method: "initialize",
+      params: { protocolVersion: "2025-06-18", capabilities: {}, clientInfo: { name: "agentdeals-e2e-1269", version: "1.0.0" } },
+    }),
+  });
+  const sessionId = init.headers.get("mcp-session-id");
+  await fetch(`${base}/mcp`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json", Accept: "application/json, text/event-stream", "Mcp-Session-Id": sessionId },
+    body: JSON.stringify({ jsonrpc: "2.0", method: "notifications/initialized" }),
+  });
+  let id = 1;
+  return {
+    ok: init.status === 200 && !!sessionId,
+    async call(name, args) {
+      const res = await fetch(`${base}/mcp`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json", Accept: "application/json, text/event-stream", "Mcp-Session-Id": sessionId },
+        body: JSON.stringify({ jsonrpc: "2.0", id: ++id + 100, method: "tools/call", params: { name, arguments: args } }),
+      });
+      const text = await res.text();
+      const line = text.split("\n").find((l) => l.startsWith("data: ")) ?? text;
+      const payload = JSON.parse(line.replace(/^data: /, ""));
+      const content = payload?.result?.content?.[0]?.text ?? "";
+      let parsed = null;
+      try { parsed = JSON.parse(content); } catch { parsed = null; }
+      return { status: res.status, isError: payload?.result?.isError === true, text: content, json: parsed };
+    },
+  };
+}
+
+const WORDS = ["hosting", "models", "memory", "projects", "testing", "community"];
+
+const { proc, base } = await startLocalServer();
+try {
+  console.log(`server: ${base}\n`);
+
+  console.log("--- /api/vendor-risk answers a word that names no vendor with 404");
+  for (const word of WORDS) {
+    const res = await fetch(`${base}/api/vendor-risk/${encodeURIComponent(word)}`);
+    const body = await res.json();
+    check(res.status === 404 && !body.vendor, `${word} -> ${res.status} ${body.vendor ?? "no vendor"}`);
+  }
+
+  console.log("\n--- /api/vendor-risk still answers a real vendor, and types the match");
+  for (const [query, vendor, type] of [["Vercel", "Vercel", "exact"], ["AWS Lambda Free", "AWS", "inferred"]]) {
+    const res = await fetch(`${base}/api/vendor-risk/${encodeURIComponent(query)}`);
+    const body = await res.json();
+    check(
+      res.status === 200 && body.vendor === vendor && body.vendor_match?.type === type && body.vendor_match?.requested === query,
+      `${query} -> ${res.status} ${body.vendor} ${JSON.stringify(body.vendor_match)}`,
+    );
+  }
+
+  console.log("\n--- /api/compare refuses a word that names no vendor");
+  const cmp = await fetch(`${base}/api/compare?a=hosting&b=netlify`);
+  const cmpBody = await cmp.json();
+  check(cmp.status === 404 && !cmpBody.vendor_a, `?a=hosting&b=netlify -> ${cmp.status}`);
+
+  const cmpOk = await fetch(`${base}/api/compare?a=Supabase&b=Neon`);
+  const cmpOkBody = await cmpOk.json();
+  check(
+    cmpOk.status === 200 && cmpOkBody.vendor_a_match?.type === "exact" && cmpOkBody.vendor_b_match?.type === "exact",
+    `?a=Supabase&b=Neon -> ${cmpOk.status} ${JSON.stringify(cmpOkBody.vendor_a_match)}`,
+  );
+
+  console.log("\n--- /api/audit-stack reports what it could not match");
+  const audit = await fetch(`${base}/api/audit-stack?services=${encodeURIComponent("hosting,memory,models,redis")}`);
+  const auditBody = await audit.json();
+  check(
+    auditBody.services.every((s) => s.status === "not_found") && auditBody.risks_found === 0,
+    `four words -> ${auditBody.services.map((s) => s.status).join(",")} risks_found=${auditBody.risks_found}`,
+  );
+
+  console.log("\n--- openapi.json publishes the match type");
+  const spec = await (await fetch(`${base}/api/openapi.json`)).json();
+  check(!!spec.components?.schemas?.VendorMatch, "components.schemas.VendorMatch is published");
+  check(
+    spec.paths?.["/api/vendor-risk/{vendor}"]?.get?.responses?.["200"]?.content?.["application/json"]?.schema?.properties?.vendor_match?.$ref === "#/components/schemas/VendorMatch",
+    "the vendor-risk 200 references it",
+  );
+
+  console.log("\n--- a real MCP session");
+  const mcp = await mcpSession(base);
+  check(mcp.ok, "initialize returned a session");
+
+  const stack = await mcp.call("plan_stack", { mode: "audit", services: ["hosting", "memory", "models", "redis"] });
+  const statuses = (stack.json?.services ?? []).map((s) => `${s.vendor}=${s.status}`);
+  check(
+    (stack.json?.services ?? []).every((s) => s.status === "not_found" && !s.cheaper_alternative),
+    `plan_stack audit -> ${statuses.join(" ")}`,
+  );
+  check(
+    (stack.json?.services ?? []).every((s) => WORDS.concat("redis").includes(s.vendor)),
+    "every row still carries the name the caller sent",
+  );
+
+  const stackReal = await mcp.call("plan_stack", { mode: "audit", services: ["Vercel", "Supabase"] });
+  check(
+    (stackReal.json?.services ?? []).every((s) => s.status === "found"),
+    `plan_stack audit of a real stack -> ${(stackReal.json?.services ?? []).map((s) => `${s.vendor}=${s.status}`).join(" ")}`,
+  );
+
+  const risk = await mcp.call("compare_vendors", { vendors: ["memory"] });
+  check(risk.isError === true, `compare_vendors["memory"] -> ${risk.isError ? "error" : risk.json?.vendor}`);
+
+  const inferred = await mcp.call("compare_vendors", { vendors: ["AWS Lambda Free"] });
+  check(
+    inferred.json?.vendor === "AWS" && inferred.json?.vendor_match?.type === "inferred",
+    `compare_vendors["AWS Lambda Free"] -> ${inferred.json?.vendor} ${JSON.stringify(inferred.json?.vendor_match)}`,
+  );
+  check(
+    (inferred.json?.summary ?? "").includes("AWS Lambda Free"),
+    "the summary names the name the caller sent",
+  );
+
+  const pair = await mcp.call("compare_vendors", { vendors: ["hosting", "netlify"] });
+  check(pair.isError === true, `compare_vendors["hosting","netlify"] -> ${pair.isError ? "error" : "comparison"}`);
+} finally {
+  proc.kill();
+}
+
+console.log(`\n${failures.length === 0 ? "ALL PASS" : `${failures.length} FAILED`}`);
+process.exit(failures.length === 0 ? 0 : 1);

--- a/scripts/mutate-1269.sh
+++ b/scripts/mutate-1269.sh
@@ -1,0 +1,197 @@
+#!/usr/bin/env bash
+set -u
+
+REPO="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$REPO" || exit 1
+
+FILES="src/data.ts src/slug.ts"
+BACKUP_DIR="$(mktemp -d)"
+for f in $FILES; do cp "$f" "$BACKUP_DIR/$(basename "$f")"; done
+
+restore() {
+  for f in $FILES; do cp "$BACKUP_DIR/$(basename "$f")" "$f"; done
+  npm run build > /dev/null 2>&1
+}
+trap restore EXIT
+
+killed=0
+survived=0
+TESTS="test/vendor-match-boundaries.test.ts test/audit-stack.test.ts test/vendor-risk.test.ts test/vendor-slug.test.ts"
+
+run_mutation() {
+  local name="$1"
+  shift
+  echo "=== $name"
+  for f in $FILES; do cp "$BACKUP_DIR/$(basename "$f")" "$f"; done
+  "$@"
+  local changed=0
+  for f in $FILES; do
+    diff -q "$BACKUP_DIR/$(basename "$f")" "$f" > /dev/null || changed=1
+  done
+  if [ "$changed" -eq 0 ]; then
+    echo "    NOT APPLIED: the mutation changed no file, so it proves nothing"
+    survived=$((survived + 1))
+    return
+  fi
+  if ! npm run build > /tmp/mutate-1269-build.log 2>&1; then
+    echo "    KILLED: the mutation does not typecheck"
+    killed=$((killed + 1))
+    return
+  fi
+  if timeout 900 node --test --test-concurrency 1 $TESTS > /tmp/mutate-1269-test.log 2>&1; then
+    echo "    SURVIVED"
+    survived=$((survived + 1))
+  else
+    echo "    KILLED: $(grep -c '✖ ' /tmp/mutate-1269-test.log) failing assertion(s)"
+    grep '✖ ' /tmp/mutate-1269-test.log | head -4
+    killed=$((killed + 1))
+  fi
+}
+
+py() { python3 - "$@"; }
+
+m_back_to_raw_substring() {
+  py <<'PY'
+p = "src/data.ts"
+s = open(p).read()
+s = s.replace(
+  "  const namedWithQualifiers = offers.filter((o) => isSubSlug(toSlug(o.vendor), asked));",
+  "  const namedWithQualifiers = offers.filter((o) => name.toLowerCase().includes(o.vendor.toLowerCase()));")
+open(p, "w").write(s)
+PY
+}
+
+m_confident_match_uses_the_other_direction() {
+  py <<'PY'
+p = "src/data.ts"
+s = open(p).read()
+s = s.replace(
+  "  const namedWithQualifiers = offers.filter((o) => isSubSlug(toSlug(o.vendor), asked));",
+  "  const namedWithQualifiers = offers.filter((o) => isSubSlug(asked, toSlug(o.vendor)));")
+open(p, "w").write(s)
+PY
+}
+
+m_first_of_several_matches_wins() {
+  py <<'PY'
+p = "src/data.ts"
+s = open(p).read()
+s = s.replace(
+  "  if (namedWithQualifiers.length === 1) return { type: \"inferred\", offer: namedWithQualifiers[0] };",
+  "  if (namedWithQualifiers.length >= 1) return { type: \"inferred\", offer: namedWithQualifiers[0] };")
+open(p, "w").write(s)
+PY
+}
+
+m_suggestions_repeat_a_vendor() {
+  py <<'PY'
+p = "src/data.ts"
+s = open(p).read()
+s = s.replace(
+  "  const suggestions = [...new Set([...namedWithQualifiers, ...longerNamesContainingIt].map((o) => o.vendor))];",
+  "  const suggestions = [...namedWithQualifiers, ...longerNamesContainingIt].map((o) => o.vendor);")
+open(p, "w").write(s)
+PY
+}
+
+m_no_suggestions_for_a_word_inside_a_longer_name() {
+  py <<'PY'
+p = "src/data.ts"
+s = open(p).read()
+s = s.replace(
+  "  const longerNamesContainingIt = offers.filter((o) => isSubSlug(asked, toSlug(o.vendor)));",
+  "  const longerNamesContainingIt: Offer[] = [];")
+open(p, "w").write(s)
+PY
+}
+
+m_empty_input_falls_through_to_matching() {
+  py <<'PY'
+p = "src/data.ts"
+s = open(p).read()
+s = s.replace(
+  "  const asked = toSlug(name);\n  if (!asked) return { type: \"none\", suggestions: [] };",
+  "  const asked = toSlug(name);")
+open(p, "w").write(s)
+PY
+}
+
+m_every_match_reports_itself_as_exact() {
+  py <<'PY'
+p = "src/data.ts"
+s = open(p).read()
+s = s.replace(
+  "  return { requested, matched: match.offer.vendor, type: match.type };",
+  "  return { requested, matched: match.offer.vendor, type: \"exact\" };")
+open(p, "w").write(s)
+PY
+}
+
+m_the_summary_stops_naming_the_other_record() {
+  py <<'PY'
+p = "src/data.ts"
+s = open(p).read()
+s = s.replace(
+  "  if (matchNotice.type === \"inferred\") {\n    summary = `${answeredAboutAnotherNameSentence(matchNotice)} ${summary}`;\n  }",
+  "")
+open(p, "w").write(s)
+PY
+}
+
+m_audit_treats_an_inferred_match_as_found() {
+  py <<'PY'
+p = "src/data.ts"
+s = open(p).read()
+s = s.replace(
+  "    if (match.type !== \"exact\") {",
+  "    if (match.type === \"none\") {")
+open(p, "w").write(s)
+PY
+}
+
+m_audit_drops_the_suggestion_it_matched() {
+  py <<'PY'
+p = "src/data.ts"
+s = open(p).read()
+s = s.replace(
+  "      const suggestions = match.type === \"inferred\" ? [match.offer.vendor] : match.suggestions;",
+  "      const suggestions = match.type === \"inferred\" ? [] : match.suggestions;")
+open(p, "w").write(s)
+PY
+}
+
+m_boundary_prefix_matches_mid_word() {
+  py <<'PY'
+p = "src/slug.ts"
+s = open(p).read()
+s = s.replace('  if (haystack.startsWith(needle + "-")) return true;', "  if (haystack.startsWith(needle)) return true;")
+open(p, "w").write(s)
+PY
+}
+
+m_boundary_suffix_matches_mid_word() {
+  py <<'PY'
+p = "src/slug.ts"
+s = open(p).read()
+s = s.replace('  if (haystack.endsWith("-" + needle)) return true;', "  if (haystack.endsWith(needle)) return true;")
+open(p, "w").write(s)
+PY
+}
+
+run_mutation "the matcher goes back to a raw substring test" m_back_to_raw_substring
+run_mutation "a fragment of a longer vendor name becomes a confident match" m_confident_match_uses_the_other_direction
+run_mutation "a query naming several vendors answers as the first" m_first_of_several_matches_wins
+run_mutation "suggestions repeat a vendor once per record" m_suggestions_repeat_a_vendor
+run_mutation "a word inside a longer vendor name is offered no suggestion" m_no_suggestions_for_a_word_inside_a_longer_name
+run_mutation "input that slugs to nothing is matched rather than refused" m_empty_input_falls_through_to_matching
+run_mutation "every match reports itself as exact" m_every_match_reports_itself_as_exact
+run_mutation "the summary stops naming the record it answered about" m_the_summary_stops_naming_the_other_record
+run_mutation "an audit treats an inferred match as a service it analysed" m_audit_treats_an_inferred_match_as_found
+run_mutation "an audit drops the suggestion it inferred" m_audit_drops_the_suggestion_it_matched
+run_mutation "the boundary prefix test matches mid-word" m_boundary_prefix_matches_mid_word
+run_mutation "the boundary suffix test matches mid-word" m_boundary_suffix_matches_mid_word
+
+restore
+echo ""
+echo "killed:   $killed"
+echo "survived: $survived"

--- a/scripts/vendor-match-census.mjs
+++ b/scripts/vendor-match-census.mjs
@@ -1,0 +1,64 @@
+import { findVendor, loadOffers } from "../dist/data.js";
+
+const offers = loadOffers();
+
+function resolvedBySubstring(name) {
+  const lower = name.toLowerCase();
+  const exact = offers.find((o) => o.vendor.toLowerCase() === lower);
+  if (exact) return { type: "exact", vendor: exact.vendor };
+  const fuzzy = offers.filter(
+    (o) => o.vendor.toLowerCase().includes(lower) || lower.includes(o.vendor.toLowerCase())
+  );
+  if (fuzzy.length === 1) return { type: "inferred", vendor: fuzzy[0].vendor };
+  return { type: "none" };
+}
+
+function resolvedNow(name) {
+  const match = findVendor(offers, name);
+  if (match.type === "none") return { type: "none" };
+  return { type: match.type, vendor: match.offer.vendor };
+}
+
+function vocabulary() {
+  const words = new Set();
+  for (const o of offers) {
+    for (const word of String(o.description || "").toLowerCase().match(/[a-z0-9][a-z0-9+.#-]*/g) || []) {
+      if (word.length >= 5) words.add(word);
+    }
+  }
+  return [...words].sort();
+}
+
+function misresolved(words, resolve) {
+  return words.filter((word) => {
+    const r = resolve(word);
+    return r.type === "inferred" && r.vendor.toLowerCase() !== word;
+  });
+}
+
+const words = vocabulary();
+const before = misresolved(words, resolvedBySubstring);
+const after = misresolved(words, resolvedNow);
+
+const vendorsOf = (list, resolve) => new Set(list.map((w) => resolve(w).vendor));
+
+console.log(`vocabulary: ${words.length} distinct words of 5+ chars from ${offers.length} descriptions`);
+console.log(`substring rule: ${before.length} words -> ${vendorsOf(before, resolvedBySubstring).size} distinct vendors`);
+console.log(`boundary rule:  ${after.length} words -> ${vendorsOf(after, resolvedNow).size} distinct vendors`);
+
+const kept = new Set(after);
+console.log(`rejected: ${before.filter((w) => !kept.has(w)).length}, kept: ${after.length}`);
+
+if (process.argv.includes("--dump")) {
+  console.log("\nstill resolving:");
+  for (const word of after) console.log(`  ${word} -> ${resolvedNow(word).vendor}`);
+}
+
+if (process.argv.includes("--rows")) {
+  console.log("\nrows:");
+  for (const word of process.argv.slice(process.argv.indexOf("--rows") + 1)) {
+    const b = resolvedBySubstring(word);
+    const a = resolvedNow(word);
+    console.log(`  ${word.padEnd(24)} substring=${b.vendor ?? b.type}  boundary=${a.vendor ?? a.type}`);
+  }
+}

--- a/src/data.ts
+++ b/src/data.ts
@@ -14,6 +14,7 @@ import {
   withheldLevelSentence,
 } from "./source-check.js";
 import { substitutesFor } from "./product-role.js";
+import { isSubSlug, toSlug } from "./slug.js";
 import { DATE_SOURCES, isEventDated, changeDateClause, isoWeekWindow, changesInWindow, discoveryBatchNote, firstReadHeading, type DateWindow } from "./change-dates.js";
 import { PRODUCT_DEPRECATED, deprecationEndsTheListedProduct } from "./product-deprecation.js";
 import { vendorHistorySentence } from "./vendor-history.js";
@@ -634,28 +635,56 @@ export function getPersonalizedChanges(
   };
 }
 
-function findVendor(offers: Offer[], name: string): { offer: Offer | null; suggestions: string[] } {
+export type VendorMatch =
+  | { type: "exact"; offer: Offer }
+  | { type: "inferred"; offer: Offer }
+  | { type: "none"; suggestions: string[] };
+
+export interface VendorMatchNotice {
+  requested: string;
+  matched: string;
+  type: "exact" | "inferred";
+}
+
+const MAX_SUGGESTIONS = 5;
+
+export function vendorMatchNotice(requested: string, match: VendorMatch): VendorMatchNotice | null {
+  if (match.type === "none") return null;
+  return { requested, matched: match.offer.vendor, type: match.type };
+}
+
+export function answeredAboutAnotherNameSentence(notice: VendorMatchNotice): string {
+  return `We have no record under "${notice.requested}", so this answer is about ${notice.matched}.`;
+}
+
+export function findVendor(offers: Offer[], name: string): VendorMatch {
   const lower = name.toLowerCase();
   const exact = offers.find((o) => o.vendor.toLowerCase() === lower);
-  if (exact) return { offer: exact, suggestions: [] };
+  if (exact) return { type: "exact", offer: exact };
 
-  const fuzzy = offers.filter(
-    (o) => o.vendor.toLowerCase().includes(lower) || lower.includes(o.vendor.toLowerCase())
-  );
-  if (fuzzy.length === 1) return { offer: fuzzy[0], suggestions: [] };
+  const asked = toSlug(name);
+  if (!asked) return { type: "none", suggestions: [] };
 
-  return { offer: null, suggestions: fuzzy.slice(0, 5).map((o) => o.vendor) };
+  const namedWithQualifiers = offers.filter((o) => isSubSlug(toSlug(o.vendor), asked));
+  if (namedWithQualifiers.length === 1) return { type: "inferred", offer: namedWithQualifiers[0] };
+
+  const longerNamesContainingIt = offers.filter((o) => isSubSlug(asked, toSlug(o.vendor)));
+  const suggestions = [...new Set([...namedWithQualifiers, ...longerNamesContainingIt].map((o) => o.vendor))];
+  return { type: "none", suggestions: suggestions.slice(0, MAX_SUGGESTIONS) };
 }
 
 export interface ComparisonResult {
   vendor_a: Offer & { deal_changes: DealChange[] };
   vendor_b: Offer & { deal_changes: DealChange[] };
+  vendor_a_match: VendorMatchNotice;
+  vendor_b_match: VendorMatchNotice;
   shared_categories: boolean;
   category_overlap: string[];
 }
 
 export interface VendorRiskResult {
   vendor: string;
+  vendor_match: VendorMatchNotice;
   category: string;
   risk_level: "stable" | "caution" | "risky" | null;
   risk_cause: RiskCause | null;
@@ -757,7 +786,7 @@ export function checkVendorRisk(
   const offers = loadOffers();
   const match = findVendor(offers, vendorName);
 
-  if (!match.offer) {
+  if (match.type === "none") {
     return {
       error: `Vendor "${vendorName}" not found.${match.suggestions.length > 0 ? ` Did you mean: ${match.suggestions.join(", ")}?` : ""}`,
       ...(match.suggestions.length > 0 ? { suggestions: match.suggestions } : {}),
@@ -765,6 +794,7 @@ export function checkVendorRisk(
   }
 
   const offer = match.offer;
+  const matchNotice = vendorMatchNotice(vendorName, match)!;
   const gate = gateForOffer(offer);
   const allChanges = loadDealChanges();
   const vendorChanges = allChanges
@@ -829,10 +859,14 @@ export function checkVendorRisk(
   if (!gate && !withheldReason && sourceStatesNoAmount(offer)) {
     summary = `${summary} ${amountUnstatedSentence(offer.vendor)}`;
   }
+  if (matchNotice.type === "inferred") {
+    summary = `${answeredAboutAnotherNameSentence(matchNotice)} ${summary}`;
+  }
 
   return {
     result: {
       vendor: offer.vendor,
+      vendor_match: matchNotice,
       category: offer.category,
       risk_level: gate || (cannotVouchForLevel(offer, linkUnreachable) && riskLevel === "stable") ? null : riskLevel,
       risk_cause: cause ? { date: cause.date, date_source: cause.date_source, change_type: cause.change_type, summary: cause.summary } : null,
@@ -890,11 +924,12 @@ export function auditStack(serviceNames: string[]): AuditResult {
   for (const name of serviceNames) {
     const match = findVendor(offers, name);
 
-    if (!match.offer) {
+    if (match.type !== "exact") {
+      const suggestions = match.type === "inferred" ? [match.offer.vendor] : match.suggestions;
       services.push({
         vendor: name,
         status: "not_found",
-        ...(match.suggestions.length > 0 ? { suggestions: match.suggestions } : {}),
+        ...(suggestions.length > 0 ? { suggestions } : {}),
       });
       continue;
     }
@@ -984,28 +1019,34 @@ export function compareServices(
   const matchA = findVendor(offers, vendorA);
   const matchB = findVendor(offers, vendorB);
 
-  if (!matchA.offer || !matchB.offer) {
+  if (matchA.type === "none" || matchB.type === "none") {
+    const suggestionsA = matchA.type === "none" ? matchA.suggestions : [];
+    const suggestionsB = matchB.type === "none" ? matchB.suggestions : [];
     return {
       error: [
-        !matchA.offer ? `Vendor "${vendorA}" not found.${matchA.suggestions.length > 0 ? ` Did you mean: ${matchA.suggestions.join(", ")}?` : ""}` : null,
-        !matchB.offer ? `Vendor "${vendorB}" not found.${matchB.suggestions.length > 0 ? ` Did you mean: ${matchB.suggestions.join(", ")}?` : ""}` : null,
+        matchA.type === "none" ? `Vendor "${vendorA}" not found.${suggestionsA.length > 0 ? ` Did you mean: ${suggestionsA.join(", ")}?` : ""}` : null,
+        matchB.type === "none" ? `Vendor "${vendorB}" not found.${suggestionsB.length > 0 ? ` Did you mean: ${suggestionsB.join(", ")}?` : ""}` : null,
       ].filter(Boolean).join(" "),
-      ...(matchA.suggestions.length > 0 ? { suggestions_a: matchA.suggestions } : {}),
-      ...(matchB.suggestions.length > 0 ? { suggestions_b: matchB.suggestions } : {}),
+      ...(suggestionsA.length > 0 ? { suggestions_a: suggestionsA } : {}),
+      ...(suggestionsB.length > 0 ? { suggestions_b: suggestionsB } : {}),
     };
   }
 
+  const offerA = matchA.offer;
+  const offerB = matchB.offer;
   const changes = loadDealChanges();
-  const changesA = changes.filter((c) => c.vendor.toLowerCase() === matchA.offer!.vendor.toLowerCase());
-  const changesB = changes.filter((c) => c.vendor.toLowerCase() === matchB.offer!.vendor.toLowerCase());
+  const changesA = changes.filter((c) => c.vendor.toLowerCase() === offerA.vendor.toLowerCase());
+  const changesB = changes.filter((c) => c.vendor.toLowerCase() === offerB.vendor.toLowerCase());
 
-  const sharedCategories = matchA.offer.category === matchB.offer.category;
-  const categoryOverlap = sharedCategories ? [matchA.offer.category] : [];
+  const sharedCategories = offerA.category === offerB.category;
+  const categoryOverlap = sharedCategories ? [offerA.category] : [];
 
   return {
     comparison: {
-      vendor_a: stripReferrerValue({ ...matchA.offer, deal_changes: changesA }),
-      vendor_b: stripReferrerValue({ ...matchB.offer, deal_changes: changesB }),
+      vendor_a: stripReferrerValue({ ...offerA, deal_changes: changesA }),
+      vendor_b: stripReferrerValue({ ...offerB, deal_changes: changesB }),
+      vendor_a_match: vendorMatchNotice(vendorA, matchA)!,
+      vendor_b_match: vendorMatchNotice(vendorB, matchB)!,
       shared_categories: sharedCategories,
       category_overlap: categoryOverlap,
     },

--- a/src/openapi.ts
+++ b/src/openapi.ts
@@ -275,8 +275,8 @@ export const openapiSpec = {
         summary: "Compare two vendors side by side",
         description: "Returns a structured comparison of two developer tool vendors including free tier details, pricing, and recent deal changes.",
         parameters: [
-          { name: "a", in: "query", required: true, description: "First vendor name (case-insensitive, fuzzy match supported)", schema: { type: "string" }, example: "Supabase" },
-          { name: "b", in: "query", required: true, description: "Second vendor name (case-insensitive, fuzzy match supported)", schema: { type: "string" }, example: "Neon" }
+          { name: "a", in: "query", required: true, description: "First vendor name (case-insensitive; a qualified name such as 'Supabase database' resolves to the vendor it names, see VendorMatch)", schema: { type: "string" }, example: "Supabase" },
+          { name: "b", in: "query", required: true, description: "Second vendor name (case-insensitive; a qualified name such as 'Neon free tier' resolves to the vendor it names, see VendorMatch)", schema: { type: "string" }, example: "Neon" }
         ],
         responses: {
           "200": {
@@ -288,6 +288,8 @@ export const openapiSpec = {
                   properties: {
                     vendor_a: { $ref: "#/components/schemas/Offer" },
                     vendor_b: { $ref: "#/components/schemas/Offer" },
+                    vendor_a_match: { $ref: "#/components/schemas/VendorMatch" },
+                    vendor_b_match: { $ref: "#/components/schemas/VendorMatch" },
                     shared_categories: { type: "boolean" },
                     category_overlap: { type: "array", items: { type: "string" } }
                   }
@@ -326,7 +328,7 @@ export const openapiSpec = {
         summary: "Audit your infrastructure stack",
         description: "Analyze your current services for pricing risks, cost savings, and missing capabilities. Returns per-service risk assessment, cheaper alternatives, and gap analysis.",
         parameters: [
-          { name: "services", in: "query", required: true, description: "Comma-separated vendor names (e.g. 'Vercel,Supabase,Clerk')", schema: { type: "string" }, example: "Vercel,Supabase,Clerk" }
+          { name: "services", in: "query", required: true, description: "Comma-separated vendor names (e.g. 'Vercel,Supabase,Clerk'). An audit reports only names it matched exactly; anything else comes back as status not_found with suggestions, so that risks_found and cheaper_alternative are never computed for a product you did not name (#1269).", schema: { type: "string" }, example: "Vercel,Supabase,Clerk" }
         ],
         responses: {
           "200": {
@@ -363,7 +365,7 @@ export const openapiSpec = {
         summary: "Check vendor pricing stability and risk",
         description: "Before depending on a vendor's free tier, check if their pricing is stable. Returns risk level (stable/caution/risky), pricing change history, free tier longevity, and more-stable alternatives.",
         parameters: [
-          { name: "vendor", in: "path", required: true, description: "Vendor name (case-insensitive, fuzzy match supported)", schema: { type: "string" }, example: "Vercel" }
+          { name: "vendor", in: "path", required: true, description: "Vendor name (case-insensitive; a qualified name such as 'Vercel Pro plan' resolves to the vendor it names, see VendorMatch)", schema: { type: "string" }, example: "Vercel" }
         ],
         responses: {
           "200": {
@@ -374,6 +376,7 @@ export const openapiSpec = {
                   type: "object",
                   properties: {
                     vendor: { type: "string" },
+                    vendor_match: { $ref: "#/components/schemas/VendorMatch" },
                     category: { type: "string" },
                     risk_level: { type: "string", enum: ["stable", "caution", "risky"], nullable: true, description: "Null where the offer's own link is confirmed unreachable (#1046) — we withhold the level rather than publish a favourable one we cannot check. Also null where gate is non-null (#1241): an offer we have decided not to list is not one we rate." },
                     link_unreachable: { type: "object", nullable: true, description: "Non-null only where a check reached a conclusion about the destination: a 404 confirmed by a full request, a 410, or a hostname with no address. Being refused (403, 429, 5xx, timeout) is evidence about our checker and never produces one of these.", properties: { last_reachable: { type: "string", format: "date", nullable: true }, checked: { type: "string", format: "date" }, terminal: { type: "boolean" } } },
@@ -928,6 +931,16 @@ export const openapiSpec = {
           source_check: { $ref: "#/components/schemas/SourceCheck" }
         },
         required: ["vendor", "category", "description", "tier", "url", "tags", "verifiedDate"]
+      },
+      VendorMatch: {
+        type: "object",
+        description: "Which name you asked about and which record answered. A name we hold verbatim matches exact. A name we do not hold matches inferred only when a vendor name we do hold appears in it as a whole word or dotted segment — \"AWS Lambda Free\" resolves to AWS, \"launchdarkly.com\" to LaunchDarkly. A fragment that merely appears inside a longer vendor name resolves to nothing and returns 404 with suggestions, because an accidental hit used to be returned shaped exactly like an exact one (#1269).",
+        properties: {
+          requested: { type: "string", description: "The name as you sent it." },
+          matched: { type: "string", description: "The vendor this response is about." },
+          type: { type: "string", enum: ["exact", "inferred"] }
+        },
+        required: ["requested", "matched", "type"]
       },
       SourceCheck: {
         type: "object",

--- a/src/server.ts
+++ b/src/server.ts
@@ -240,7 +240,7 @@ export function createServer(getSessionId?: () => string | undefined, getClientN
       inputSchema: {
         mode: z.enum(["recommend", "estimate", "audit"]).describe("recommend: free-tier stack for a use case. estimate: cost analysis at scale. audit: risk + cost + gap analysis."),
         use_case: z.string().optional().describe("What you're building (for recommend mode, e.g. 'Next.js SaaS app')"),
-        services: z.array(z.string()).optional().describe("Current vendor names (for estimate/audit mode, e.g. ['Vercel', 'Supabase'])"),
+        services: z.array(z.string()).optional().describe("Current vendor names (for estimate/audit mode, e.g. ['Vercel', 'Supabase']). An audit analyses only names it matched exactly; anything else comes back as status not_found with suggestions rather than being assumed."),
         scale: z.enum(["hobby", "startup", "growth"]).optional().describe("Scale for cost estimation (default: hobby)"),
         requirements: z.array(z.string()).optional().describe("Specific infra needs for recommend mode (e.g. ['database', 'auth', 'email'])"),
       },

--- a/src/slug.ts
+++ b/src/slug.ts
@@ -1,0 +1,10 @@
+export function toSlug(name: string): string {
+  return name.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-|-$/g, "");
+}
+
+export function isSubSlug(needle: string, haystack: string): boolean {
+  if (needle === haystack) return true;
+  if (haystack.startsWith(needle + "-")) return true;
+  if (haystack.endsWith("-" + needle)) return true;
+  return haystack.includes("-" + needle + "-");
+}

--- a/src/vendor-slug.ts
+++ b/src/vendor-slug.ts
@@ -1,8 +1,7 @@
 import { loadOffers } from "./data.js";
+import { isSubSlug, toSlug } from "./slug.js";
 
-export function toSlug(name: string): string {
-  return name.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-|-$/g, "");
-}
+export { isSubSlug, toSlug };
 
 function buildVendorSlugMap(): Map<string, string> {
   const offers = loadOffers();
@@ -22,13 +21,6 @@ export type VendorSlugResolution =
   | { type: "redirect"; slug: string }
   | { type: "disambiguate"; slugs: string[] }
   | { type: "none" };
-
-export function isSubSlug(needle: string, haystack: string): boolean {
-  if (needle === haystack) return true;
-  if (haystack.startsWith(needle + "-")) return true;
-  if (haystack.endsWith("-" + needle)) return true;
-  return haystack.includes("-" + needle + "-");
-}
 
 const NAMES_MORE_THAN_ONE_SUBJECT = /\s(?:\+|&|and|or|vs\.?|versus)\s|\s*\/\s*|,/i;
 

--- a/test/vendor-match-boundaries.test.ts
+++ b/test/vendor-match-boundaries.test.ts
@@ -1,0 +1,260 @@
+import { describe, it } from "node:test";
+import assert from "node:assert";
+
+const { findVendor, loadOffers, checkVendorRisk, auditStack, compareServices } = await import(
+  "../dist/data.js"
+);
+const { toSlug, isSubSlug } = await import("../dist/slug.js");
+const vendorSlug = await import("../dist/vendor-slug.js");
+
+const offers = loadOffers();
+
+const WORDS_THAT_NAME_NO_VENDOR = [
+  "hosting",
+  "models",
+  "memory",
+  "projects",
+  "testing",
+  "community",
+  "redis",
+  "postgresql",
+  "credit",
+  "https",
+  "support",
+  "website",
+  "repository",
+  "mandatory",
+];
+
+const NAMES_QUALIFIED_BY_EXTRA_WORDS: Array<[string, string]> = [
+  ["AWS Lambda Free", "AWS"],
+  ["Vercel Pro plan", "Vercel"],
+  ["Neon free tier", "Neon"],
+  ["Supabase database", "Supabase"],
+  ["github-hosted", "GitHub"],
+  ["openai-compatible", "OpenAI"],
+  ["launchdarkly.com", "LaunchDarkly"],
+  ["postman-alternative", "Postman"],
+  ["gitbook.io", "GitBook"],
+];
+
+function vocabularyFromDescriptions(): string[] {
+  const words = new Set<string>();
+  for (const o of offers) {
+    for (const word of String(o.description || "").toLowerCase().match(/[a-z0-9][a-z0-9+.#-]*/g) || []) {
+      if (word.length >= 5) words.add(word);
+    }
+  }
+  return [...words];
+}
+
+describe("vendor matching: one boundary rule, shared with the slug path", () => {
+  it("uses the same isSubSlug the slug resolver uses, not a copy", () => {
+    assert.strictEqual(vendorSlug.isSubSlug, isSubSlug);
+    assert.strictEqual(vendorSlug.toSlug, toSlug);
+  });
+
+  it("never matches a vendor name that falls inside a longer word", () => {
+    assert.strictEqual(isSubSlug("ory", "memory"), false);
+    assert.strictEqual(isSubSlug("ory", "mandatory"), false);
+    assert.strictEqual(isSubSlug("redis", "rediscover"), false);
+    assert.strictEqual(isSubSlug("neon", "neondescript"), false);
+  });
+
+  it("still matches a vendor name that is a whole hyphenated word", () => {
+    assert.strictEqual(isSubSlug("front", "front-end"), true);
+    assert.strictEqual(isSubSlug("aws", "aws-lambda-free"), true);
+  });
+});
+
+describe("findVendor", () => {
+  it("returns an exact match as exact", () => {
+    const match = findVendor(offers, "Vercel");
+    assert.strictEqual(match.type, "exact");
+    assert.strictEqual(match.offer.vendor, "Vercel");
+  });
+
+  it("matches case-insensitively without leaving the exact branch", () => {
+    const match = findVendor(offers, "vErCeL");
+    assert.strictEqual(match.type, "exact");
+    assert.strictEqual(match.offer.vendor, "Vercel");
+  });
+
+  it("resolves a vendor name carrying extra words, and marks it inferred", () => {
+    for (const [query, vendor] of NAMES_QUALIFIED_BY_EXTRA_WORDS) {
+      const match = findVendor(offers, query);
+      assert.strictEqual(match.type, "inferred", query);
+      assert.strictEqual(match.offer.vendor, vendor, query);
+    }
+  });
+
+  it("returns not-found for a word that only appears inside a longer vendor name", () => {
+    for (const word of WORDS_THAT_NAME_NO_VENDOR) {
+      const match = findVendor(offers, word);
+      assert.strictEqual(match.type, "none", `${word} should not resolve to a vendor`);
+    }
+  });
+
+  it("offers the longer vendor names as suggestions instead of answering as one of them", () => {
+    assert.deepStrictEqual(findVendor(offers, "hosting").suggestions, ["Hosting Checker"]);
+    assert.deepStrictEqual(findVendor(offers, "models").suggestions, ["GitHub Models"]);
+    assert.deepStrictEqual(findVendor(offers, "redis").suggestions, ["Redis Cloud"]);
+  });
+
+  it("returns not-found when a query names more than one vendor", () => {
+    const match = findVendor(offers, "GitHub Actions minutes");
+    assert.strictEqual(match.type, "none");
+    assert.deepStrictEqual(match.suggestions, ["GitHub Actions", "GitHub"]);
+  });
+
+  it("suggests each vendor once even where several records share the name", () => {
+    for (const query of ["hosting", "models", "GitHub Actions minutes", "Cloudflare R2 storage"]) {
+      const match = findVendor(offers, query);
+      if (match.type !== "none") continue;
+      assert.deepStrictEqual(
+        match.suggestions,
+        [...new Set(match.suggestions)],
+        `${query} repeats a suggestion`,
+      );
+    }
+  });
+
+  it("returns not-found for input that slugs to nothing", () => {
+    for (const query of ["", "   ", "!!!", "稀宇科技"]) {
+      assert.strictEqual(findVendor(offers, query).type, "none");
+    }
+  });
+
+  it("resolves every word it does resolve by naming that vendor in full", () => {
+    for (const word of vocabularyFromDescriptions()) {
+      const match = findVendor(offers, word);
+      if (match.type !== "inferred") continue;
+      assert.ok(
+        isSubSlug(toSlug(match.offer.vendor), toSlug(word)),
+        `${word} resolved to ${match.offer.vendor} without naming it at a boundary`,
+      );
+    }
+  });
+
+  it("leaves far fewer description words resolving to a vendor they do not name", () => {
+    const misresolved = vocabularyFromDescriptions().filter((word) => {
+      const match = findVendor(offers, word);
+      return match.type === "inferred" && match.offer.vendor.toLowerCase() !== word;
+    });
+    assert.ok(
+      misresolved.length < 150,
+      `${misresolved.length} words still resolve to a vendor they do not name`,
+    );
+  });
+});
+
+describe("checkVendorRisk names the record it answered about", () => {
+  it("reports an exact match as exact", () => {
+    const result = checkVendorRisk("Vercel");
+    assert.ok(!("error" in result));
+    assert.deepStrictEqual(result.result.vendor_match, {
+      requested: "Vercel",
+      matched: "Vercel",
+      type: "exact",
+    });
+  });
+
+  it("reports an inferred match, and says so in the summary", () => {
+    const result = checkVendorRisk("AWS Lambda Free");
+    assert.ok(!("error" in result));
+    assert.deepStrictEqual(result.result.vendor_match, {
+      requested: "AWS Lambda Free",
+      matched: "AWS",
+      type: "inferred",
+    });
+    assert.ok(
+      result.result.summary.includes("AWS Lambda Free") && result.result.summary.includes("AWS"),
+      "summary does not name both the requested and the matched name",
+    );
+  });
+
+  it("answers a word that names no vendor with an error, not a vendor", () => {
+    for (const word of WORDS_THAT_NAME_NO_VENDOR) {
+      const result = checkVendorRisk(word);
+      assert.ok("error" in result, `${word} returned a vendor`);
+    }
+  });
+});
+
+describe("auditStack analyses only the services it was actually given", () => {
+  it("reports a name it could not match exactly as not_found with suggestions", () => {
+    const result = auditStack(["hosting", "memory", "models", "redis"]);
+    assert.strictEqual(result.risks_found, 0);
+    assert.strictEqual(result.savings_opportunities, 0);
+    for (const svc of result.services) {
+      assert.strictEqual(svc.status, "not_found", svc.vendor);
+      assert.strictEqual(svc.cheaper_alternative, undefined, svc.vendor);
+      assert.strictEqual(svc.risk_level, undefined, svc.vendor);
+    }
+    assert.deepStrictEqual(
+      result.services.map((s) => s.vendor),
+      ["hosting", "memory", "models", "redis"],
+    );
+  });
+
+  it("keeps the requested name on the row rather than substituting one", () => {
+    const result = auditStack(["hosting"]);
+    assert.strictEqual(result.services[0].vendor, "hosting");
+    assert.deepStrictEqual(result.services[0].suggestions, ["Hosting Checker"]);
+  });
+
+  it("does not count an inferred match as a service it audited", () => {
+    const result = auditStack(["AWS Lambda Free"]);
+    assert.strictEqual(result.services[0].status, "not_found");
+    assert.deepStrictEqual(result.services[0].suggestions, ["AWS"]);
+    assert.strictEqual(result.risks_found, 0);
+  });
+
+  it("still audits a stack of exactly named vendors", () => {
+    const result = auditStack(["Vercel", "Supabase"]);
+    for (const svc of result.services) {
+      assert.strictEqual(svc.status, "found");
+      assert.ok(svc.category);
+      assert.ok(svc.risk_level);
+    }
+  });
+
+  it("does not treat a category as covered by a service it could not match", () => {
+    const unmatched = auditStack(["hosting", "memory", "models", "redis"]);
+    const nothing = auditStack([]);
+    assert.deepStrictEqual(
+      unmatched.gaps.map((g) => g.category),
+      nothing.gaps.map((g) => g.category),
+    );
+  });
+});
+
+describe("compareServices", () => {
+  it("refuses to compare a word that names no vendor", () => {
+    const result = compareServices("hosting", "netlify");
+    assert.ok("error" in result);
+    assert.deepStrictEqual(result.suggestions_a, ["Hosting Checker"]);
+  });
+
+  it("names the records it compared, on both sides", () => {
+    const result = compareServices("Supabase database", "Neon");
+    assert.ok(!("error" in result));
+    assert.deepStrictEqual(result.comparison.vendor_a_match, {
+      requested: "Supabase database",
+      matched: "Supabase",
+      type: "inferred",
+    });
+    assert.deepStrictEqual(result.comparison.vendor_b_match, {
+      requested: "Neon",
+      matched: "Neon",
+      type: "exact",
+    });
+  });
+
+  it("still compares two exactly named vendors", () => {
+    const result = compareServices("Supabase", "Neon");
+    assert.ok(!("error" in result));
+    assert.strictEqual(result.comparison.vendor_a.vendor, "Supabase");
+    assert.strictEqual(result.comparison.vendor_b.vendor, "Neon");
+  });
+});

--- a/test/vendor-match-boundaries.test.ts
+++ b/test/vendor-match-boundaries.test.ts
@@ -108,13 +108,18 @@ describe("findVendor", () => {
   });
 
   it("suggests each vendor once even where several records share the name", () => {
-    for (const query of ["hosting", "models", "GitHub Actions minutes", "Cloudflare R2 storage"]) {
-      const match = findVendor(offers, query);
+    const sharedNames = [...new Map<string, number>(
+      offers.map((o) => [o.vendor, offers.filter((x) => x.vendor === o.vendor).length]),
+    )].filter(([, n]) => n > 1).map(([vendor]) => vendor);
+    assert.ok(sharedNames.length > 0, "no vendor has more than one record, so this asserts nothing");
+
+    for (const vendor of sharedNames) {
+      const match = findVendor(offers, `${toSlug(vendor)}.com`);
       if (match.type !== "none") continue;
       assert.deepStrictEqual(
         match.suggestions,
         [...new Set(match.suggestions)],
-        `${query} repeats a suggestion`,
+        `a query naming ${vendor} repeats it in its suggestions`,
       );
     }
   });
@@ -123,6 +128,26 @@ describe("findVendor", () => {
     for (const query of ["", "   ", "!!!", "稀宇科技"]) {
       assert.strictEqual(findVendor(offers, query).type, "none");
     }
+  });
+
+  it("does not match a vendor whose own name slugs to nothing", () => {
+    const unslugabble = [{
+      vendor: "稀宇科技",
+      category: "AI / ML",
+      description: "",
+      tier: "Free",
+      url: "https://example.com",
+      tags: [],
+      verifiedDate: "2026-01-01",
+    }] as unknown as typeof offers;
+    for (const query of ["", "   ", "!!!"]) {
+      assert.strictEqual(
+        findVendor(unslugabble, query).type,
+        "none",
+        `${JSON.stringify(query)} resolved to a vendor with no slug`,
+      );
+    }
+    assert.strictEqual(findVendor(unslugabble, "稀宇科技").type, "exact");
   });
 
   it("resolves every word it does resolve by naming that vendor in full", () => {


### PR DESCRIPTION
Refs #1269.

`findVendor` fell back to `o.vendor.toLowerCase().includes(lower) || lower.includes(o.vendor.toLowerCase())`, and returned a single accidental hit shaped exactly like an exact one. `"memory".includes("ory")` is true, so an agent asking about `memory` was told at HTTP 200 that **Ory** is an Auth product rated `stable`.

## The rule

A raw `includes` is replaced by `isSubSlug` — the boundary-respecting test `resolveVendorSlug` already used for the HTML slug path — moved into `src/slug.ts` so both paths import one definition. A test asserts they are the same function object, not two copies.

Only one direction survives as a confident match: **a vendor name we hold appears in the query as a whole word or dotted segment**. That is what the fallback exists for — `AWS Lambda Free` → AWS, `launchdarkly.com` → LaunchDarkly, `openai-compatible` → OpenAI. The other direction — a fragment that merely appears inside a longer vendor name — no longer resolves at all; it comes back not-found with the longer names as suggestions.

**A symmetric boundary rule would not have been enough, and I measured that before choosing.** Applying `isSubSlug` in both directions rejects only 316 of the 577 and still returns `hosting` → Hosting Checker, `models` → GitHub Models, `projects` → Zoho Projects, `community` → Visual Studio Community, `redis` → Redis Cloud and `postgresql` → Amazon Aurora PostgreSQL — 6 of the 8 rows the issue's census leads with, including the two it calls the dangerous ones. Those are all boundary-legitimate *completions*. Every case the fallback legitimately serves is the other direction, so that is the direction kept.

## Census (AC-3, AC-6)

`scripts/vendor-match-census.mjs`, run on this build. It measures the prior rule and the live `findVendor` side by side, so the current rule is never copied into the harness.

```
vocabulary: 4842 distinct words of 5+ chars from 1580 descriptions
substring rule: 577 words -> 389 distinct vendors
boundary rule:   80 words ->  65 distinct vendors
rejected: 504, kept: 80
```

577 → **80**. The issue predicted 576 → 73 over a 4,737-word vocabulary; the gap is tokenizer, not rule.

Of the 80 kept, nearly all are the vendor's own hostname (`github.com`, `notion.site`, `tuta.com`) or a qualified phrase (`mongodb-like`, `stripe-inspired`, `plex-provided`). **Four are English compounds whose second half is a real vendor name** — `cross-modal` → Modal, `front-end` → Front, `volume-based` → Volume, `email-to-slack` → Slack. Those are genuine boundary matches and no rule short of a vendor-name-versus-English-word list separates them, so they stay — but they now arrive typed `inferred` and carrying a sentence naming the substitution, instead of silently.

## Typed result (AC-2)

`findVendor` returns `exact` / `inferred` / `none`. Every response built on a match carries a `vendor_match` — `{requested, matched, type}` — including exact ones, so a caller does not have to read absence as a signal:

```
/api/vendor-risk/Vercel           {"requested":"Vercel","matched":"Vercel","type":"exact"}
/api/vendor-risk/AWS%20Lambda%20Free  {"requested":"AWS Lambda Free","matched":"AWS","type":"inferred"}
```

`/api/compare` carries `vendor_a_match` and `vendor_b_match`. An inferred match also opens the summary with the substitution, so a caller reading only prose still sees it:

> We have no record under "AWS Lambda Free", so this answer is about AWS. AWS has a stable pricing history.

## `plan_stack` (AC-4)

An audit now analyses only names it matched **exactly**. An inferred match is reported `status: "not_found"` with the matched name as its suggestion, and is not counted into `risks_found`, not given a `cheaper_alternative`, and not allowed to mark its category covered — so a gap analysis is never computed against a product the caller did not name. The row keeps the caller's own string in `vendor` rather than substituting one.

Before, `["hosting","memory","models","redis"]` returned `status: "found"` four times and `risks_found: 0`. Now all four are `not_found`, three with a suggestion.

## Two of the six carry no suggestion, and that is deliberate

`hosting`, `models`, `projects` and `community` come back with the longer name that contains them. `memory` and `testing` come back with none, because nothing in the catalog contains them at a boundary — the only candidates were Ory and testingbot.com, reached by the mid-word match this PR removes. A prefix-only suggestion channel would recover `testing` → testingbot.com but not `memory`; I did not add one, because it would put a second matching rule back in the tree for the sake of one row. Flagged on the issue if you want it.

## Verification

- **`scripts/e2e-1269.mjs`** — 21 checks against a real server: HTTP for `/api/vendor-risk`, `/api/compare`, `/api/audit-stack` and `/api/openapi.json`, then a real MCP `initialize` → `notifications/initialized` → `tools/call` for `plan_stack` and `compare_vendors`. All pass. `compare_vendors(["memory"])` is an error; `compare_vendors(["AWS Lambda Free"])` returns AWS typed `inferred`; `plan_stack` audit of a real stack still reports `found`.
- **3,186 tests, 25 new, 0 red.**
- **12 mutations, 12 killed** (`scripts/mutate-1269.sh`), including reverting to the raw substring test, swapping the kept direction, matching mid-word at the prefix and at the suffix, reporting every match as exact, and letting an audit treat an inferred match as found. Two survived a first pass and both were real gaps: the suggestion dedupe was only reachable through a vendor holding several records, and the empty-slug guard is unreachable from the catalog and needed a synthetic population.
- **2,577 paths swept against a worktree of `main`: 2,577 byte-identical, 0 moved, 0 added, 0 removed.** This change reaches only the JSON and MCP surfaces; the HTML slug path is untouched, as #1269 asks.
- `openapi.json` publishes a `VendorMatch` schema describing the rule, and the `fuzzy match supported` parameter text — which no longer described what happens — is replaced on all three endpoints.