### PR TITLE
Repoint Google Cloud Shell and correct gtmetrix.com's unsupported free-tier numbers (#1268)

### DIFF
--- a/data/index.json
+++ b/data/index.json
@@ -13519,9 +13519,9 @@
     {
       "vendor": "gtmetrix.com",
       "category": "Code Quality",
-      "description": "Website performance testing — Lighthouse-based reports with Core Web Vitals, waterfall charts, and optimization recommendations. Free plan: 5 monitored URLs, daily checks, 20 on-demand tests/day",
+      "description": "Website performance testing — Lighthouse-based reports with Core Web Vitals, waterfall charts, and optimization recommendations. Free account: testing from Seattle and London, dashboard with filters and tags, daily/weekly/monthly monitoring, e-mail alerts, and 1-month CrUX history. GTmetrix states no on-demand test or monitored-slot quantity for the free account; the cheapest paid plan (Lite, $5.99/mo) lists 50 monthly on-demand tests and 1 monitored slot.",
       "tier": "Free",
-      "url": "https://gtmetrix.com/",
+      "url": "https://gtmetrix.com/free-plan-features.html",
       "tags": [
         "developer-tools",
         "free-for-dev"
@@ -31140,7 +31140,7 @@
       "category": "Dev Utilities",
       "description": "Always Free: browser-based terminal with 5 GB persistent disk, pre-installed tools (gcloud, kubectl, docker, git), and built-in code editor",
       "tier": "Always Free",
-      "url": "https://cloud.google.com/shell",
+      "url": "https://docs.cloud.google.com/shell/docs/quotas-limits",
       "tags": [
         "terminal",
         "ide",


### PR DESCRIPTION
Two of the six records that fell out of `ok` when #1268 shipped. Both cite a page that states nothing about the offer we publish; neither is a case of the vendor withdrawing terms.

**Google Cloud Shell** — `cloud.google.com/shell` 301s to `docs.cloud.google.com/shell/docs`, whose only figure is the generic `$300 in free credit`. Repointed to `docs.cloud.google.com/shell/docs/quotas-limits`, which states *"Cloud Shell provisions 5 GB of free persistent disk storage mounted as your $HOME directory"* — the exact quantity the record publishes. Fetched and matched today. `src/serve.ts:33804` hardcodes the same "5 GB persistent home directory" on `/free-tier-*`; it agrees with the record and the vendor, so nothing there needs to change.

**gtmetrix.com** — this one is not a repoint. The record published *"Free plan: 5 monitored URLs, daily checks, 20 on-demand tests/day"*, and **none of those two numbers appear on any GTmetrix page.** `gtmetrix.com/pricing.html` has no free column at all: the cheapest plan is Lite at $5.99/mo with **50 monthly on-demand tests and 1 monitored slot**, so our free tier was published as five times more monitored slots and roughly twelve times more tests than the entry paid plan. `gtmetrix.com/free-plan-features.html` is the vendor's own free-account page and states features with no quantities. Description rewritten to what that page supports, plus the Lite figures for contrast, and the URL points at it.

**Why I did not simply repoint gtmetrix.com to `/pricing.html`.** That page is dense with numbers, so it would have graded `ok` under #1268's new classifier while every number in our record stayed unsupported — the evidence grade would have gone up and the evidence would not have. That is #1109's defect (a page saturated with prices belonging to someone else) reappearing one level down, at plan granularity rather than vendor granularity. Worth knowing before the next bulk repoint: **a page having numbers is not that page having *these* numbers.**

**Not in this PR.** SurveyMonkey.com (`surveymonkey.com/pricing/` returns 6,660 stripped characters and states neither "10 questions" nor "100 responses" — likely the JS-shell case #1263 covers, and I did not want to repoint onto a page we cannot read). HubSpot for Startups (`/startups/pricing` 404s; the discount bands are not on a page I could find). Shotstack Startup Program. Highlight.io — the repo genuinely is where its free offering lives now that highlight.io redirects to LaunchDarkly, so its URL is right and its grade is the honest one.

Data-only. `npm run validate` clean: 1580 offers, 492 deal changes. No `src/` or `test/` changes. Round-trip asserted byte-identical before writing.
