### PR TITLE
Show one plan lineup per vendor and correct the Cursor and Augment Code rows (#1067)

### DIFF
--- a/scripts/mutate-1067.sh
+++ b/scripts/mutate-1067.sh
@@ -1,0 +1,214 @@
+#!/usr/bin/env bash
+set -u
+
+REPO="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$REPO" || exit 1
+
+FILES="src/change-lineup.ts"
+BACKUP_DIR="$(mktemp -d)"
+for f in $FILES; do cp "$f" "$BACKUP_DIR/$(basename "$f")"; done
+
+restore() {
+  for f in $FILES; do cp "$BACKUP_DIR/$(basename "$f")" "$f"; done
+  npm run build > /dev/null 2>&1
+}
+trap restore EXIT
+
+killed=0
+survived=0
+TESTS="test/change-lineup.test.ts"
+
+run_mutation() {
+  local name="$1"
+  shift
+  echo "=== $name"
+  for f in $FILES; do cp "$BACKUP_DIR/$(basename "$f")" "$f"; done
+  "$@"
+  local changed=0
+  for f in $FILES; do
+    diff -q "$BACKUP_DIR/$(basename "$f")" "$f" > /dev/null || changed=1
+  done
+  if [ "$changed" -eq 0 ]; then
+    echo "    NOT APPLIED: the mutation changed no file, so it proves nothing"
+    survived=$((survived + 1))
+    return
+  fi
+  if ! npm run build > /tmp/mutate-1067-build.log 2>&1; then
+    echo "    KILLED: the mutation does not typecheck"
+    killed=$((killed + 1))
+    return
+  fi
+  if timeout 900 npx tsx --test $TESTS > /tmp/mutate-1067-test.log 2>&1; then
+    echo "    SURVIVED"
+    survived=$((survived + 1))
+  else
+    echo "    KILLED: $(grep -c '✖ ' /tmp/mutate-1067-test.log) failing assertion(s)"
+    grep '✖ ' /tmp/mutate-1067-test.log | head -4
+    killed=$((killed + 1))
+  fi
+}
+
+py() { python3 - "$@"; }
+
+m_one_price_is_a_lineup() {
+  py <<'PY'
+p = "src/change-lineup.ts"
+s = open(p).read()
+s = s.replace("export const PRICES_THAT_MAKE_A_LINEUP = 2;", "export const PRICES_THAT_MAKE_A_LINEUP = 1;")
+open(p, "w").write(s)
+PY
+}
+
+m_three_prices_make_a_lineup() {
+  py <<'PY'
+p = "src/change-lineup.ts"
+s = open(p).read()
+s = s.replace("export const PRICES_THAT_MAKE_A_LINEUP = 2;", "export const PRICES_THAT_MAKE_A_LINEUP = 3;")
+open(p, "w").write(s)
+PY
+}
+
+m_repeated_price_counts_twice() {
+  py <<'PY'
+p = "src/change-lineup.ts"
+s = open(p).read()
+s = s.replace(
+  "  return new Set(text.match(PRICE_TOKEN) ?? []);",
+  "  return new Set((text.match(PRICE_TOKEN) ?? []).map((m, i) => `${m}#${i}`));")
+open(p, "w").write(s)
+PY
+}
+
+m_reads_only_the_summary() {
+  py <<'PY'
+p = "src/change-lineup.ts"
+s = open(p).read()
+s = s.replace(
+  "  const text = [change.summary, change.current_state].filter(Boolean).join(\" \");",
+  "  const text = [change.summary].filter(Boolean).join(\" \");")
+open(p, "w").write(s)
+PY
+}
+
+m_reads_only_the_current_state() {
+  py <<'PY'
+p = "src/change-lineup.ts"
+s = open(p).read()
+s = s.replace(
+  "  const text = [change.summary, change.current_state].filter(Boolean).join(\" \");",
+  "  const text = [change.current_state].filter(Boolean).join(\" \");")
+open(p, "w").write(s)
+PY
+}
+
+m_a_correction_states_a_vendor_lineup() {
+  py <<'PY'
+p = "src/change-lineup.ts"
+s = open(p).read()
+s = s.replace("  if (change.change_type === NOT_A_VENDOR_CHANGE) return false;\n", "")
+open(p, "w").write(s)
+PY
+}
+
+m_price_needs_no_digit() {
+  py <<'PY'
+p = "src/change-lineup.ts"
+s = open(p).read()
+s = s.replace("const PRICE_TOKEN = /\\$\\d[\\d,]*(?:\\.\\d+)?/g;", "const PRICE_TOKEN = /\\$\\d*/g;")
+open(p, "w").write(s)
+PY
+}
+
+m_price_stops_at_the_decimal_point() {
+  py <<'PY'
+p = "src/change-lineup.ts"
+s = open(p).read()
+s = s.replace("const PRICE_TOKEN = /\\$\\d[\\d,]*(?:\\.\\d+)?/g;", "const PRICE_TOKEN = /\\$\\d[\\d,]*/g;")
+open(p, "w").write(s)
+PY
+}
+
+m_any_other_record_supersedes_regardless_of_date() {
+  py <<'PY'
+p = "src/change-lineup.ts"
+s = open(p).read()
+s = s.replace(
+  "    if (newest !== change && newest.date > change.date) superseded.set(change, newest);",
+  "    if (newest !== change) superseded.set(change, newest);")
+open(p, "w").write(s)
+PY
+}
+
+m_the_oldest_lineup_is_the_current_one() {
+  py <<'PY'
+p = "src/change-lineup.ts"
+s = open(p).read()
+s = s.replace(
+  "    if (!held || change.date > held.date) newestByVendor.set(change.vendor, change);",
+  "    if (!held || change.date < held.date) newestByVendor.set(change.vendor, change);")
+open(p, "w").write(s)
+PY
+}
+
+m_lineups_supersede_across_vendors() {
+  py <<'PY'
+p = "src/change-lineup.ts"
+s = open(p).read()
+s = s.replace("newestByVendor.get(change.vendor)!", "[...newestByVendor.values()].sort((a, b) => (a.date < b.date ? 1 : -1))[0]")
+s = s.replace(
+  "    const held = newestByVendor.get(change.vendor);\n    if (!held || change.date > held.date) newestByVendor.set(change.vendor, change);",
+  "    const held = newestByVendor.get(change.vendor);\n    if (!held || change.date > held.date) newestByVendor.set(change.vendor, change);")
+open(p, "w").write(s)
+PY
+}
+
+m_records_stating_no_lineup_get_marked_too() {
+  py <<'PY'
+p = "src/change-lineup.ts"
+s = open(p).read()
+s = s.replace(
+  "  for (const change of changes) {\n    if (!statesAPlanLineup(change)) continue;\n    const newest = newestByVendor.get(change.vendor)!;",
+  "  for (const change of changes) {\n    const newest = newestByVendor.get(change.vendor);\n    if (!newest) continue;")
+open(p, "w").write(s)
+PY
+}
+
+m_the_note_names_no_date() {
+  py <<'PY'
+p = "src/change-lineup.ts"
+s = open(p).read()
+s = s.replace(
+  "  return `Superseded by our ${formatDate(newest.date)} record`;",
+  "  return \"Superseded by a later record\";")
+open(p, "w").write(s)
+PY
+}
+
+m_the_timeline_date_drops_the_year() {
+  py <<'PY'
+p = "src/change-lineup.ts"
+s = open(p).read()
+s = s.replace(
+  '{ month: "short", day: "numeric", year: "numeric" }',
+  '{ month: "short", day: "numeric" }')
+open(p, "w").write(s)
+PY
+}
+
+run_mutation "one price is a lineup" m_one_price_is_a_lineup
+run_mutation "three prices are needed for a lineup" m_three_prices_make_a_lineup
+run_mutation "the same price named twice counts twice" m_repeated_price_counts_twice
+run_mutation "prices are read from the summary only" m_reads_only_the_summary
+run_mutation "prices are read from the current state only" m_reads_only_the_current_state
+run_mutation "a correction to our own record states a vendor lineup" m_a_correction_states_a_vendor_lineup
+run_mutation "a dollar sign with no digit is a price" m_price_needs_no_digit
+run_mutation "a price stops at the decimal point" m_price_stops_at_the_decimal_point
+run_mutation "a same-dated record supersedes its twin" m_any_other_record_supersedes_regardless_of_date
+run_mutation "the oldest lineup is the current one" m_the_oldest_lineup_is_the_current_one
+run_mutation "a record stating no lineup is marked too" m_records_stating_no_lineup_get_marked_too
+run_mutation "the note names no date" m_the_note_names_no_date
+run_mutation "the timeline date drops the year" m_the_timeline_date_drops_the_year
+
+echo
+echo "killed=$killed survived=$survived"
+[ "$survived" -eq 0 ]

--- a/src/change-lineup.ts
+++ b/src/change-lineup.ts
@@ -1,0 +1,47 @@
+export interface LineupClaim {
+  vendor: string;
+  date: string;
+  change_type?: string;
+  summary?: string;
+  current_state?: string;
+}
+
+const PRICE_TOKEN = /\$\d[\d,]*(?:\.\d+)?/g;
+
+export const PRICES_THAT_MAKE_A_LINEUP = 2;
+export const NOT_A_VENDOR_CHANGE = "record_corrected";
+
+export function statedPrices(change: LineupClaim): Set<string> {
+  const text = [change.summary, change.current_state].filter(Boolean).join(" ");
+  return new Set(text.match(PRICE_TOKEN) ?? []);
+}
+
+export function statesAPlanLineup(change: LineupClaim): boolean {
+  if (change.change_type === NOT_A_VENDOR_CHANGE) return false;
+  return statedPrices(change).size >= PRICES_THAT_MAKE_A_LINEUP;
+}
+
+export function supersededLineups<T extends LineupClaim>(changes: readonly T[]): Map<T, T> {
+  const newestByVendor = new Map<string, T>();
+  for (const change of changes) {
+    if (!statesAPlanLineup(change)) continue;
+    const held = newestByVendor.get(change.vendor);
+    if (!held || change.date > held.date) newestByVendor.set(change.vendor, change);
+  }
+
+  const superseded = new Map<T, T>();
+  for (const change of changes) {
+    if (!statesAPlanLineup(change)) continue;
+    const newest = newestByVendor.get(change.vendor)!;
+    if (newest !== change && newest.date > change.date) superseded.set(change, newest);
+  }
+  return superseded;
+}
+
+export function changeTimelineDate(iso: string): string {
+  return new Date(iso).toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" });
+}
+
+export function supersessionNote(newest: LineupClaim, formatDate: (iso: string) => string): string {
+  return `Superseded by our ${formatDate(newest.date)} record`;
+}

--- a/src/serve.ts
+++ b/src/serve.ts
@@ -22,6 +22,7 @@ import { buildComparisonMap, comparisonSlug } from "./comparison-pairs.js";
 import { stabilityFaqAnswer, stabilityVerdictClause, type ComparisonSide, type StabilityRating } from "./comparison-verdict.js";
 import { publishedVendorLevel, vendorVerdictSentence, vendorBadge, statesRiskCause, narrowingSentence, changeKindNoun, type VendorVerdictInput } from "./vendor-verdict.js";
 import { vendorHistorySentence } from "./vendor-history.js";
+import { changeTimelineDate, supersededLineups, supersessionNote } from "./change-lineup.js";
 import { growthLimitPhrases } from "./growth-limits.js";
 import { registerAgent, authenticateRequest, validateVestauthUrl, hashApiKey, updateAgentX402Address, getAgentById } from "./agents.js";
 import { attributeAuthenticatedRequest } from "./referral-attribution.js";
@@ -5357,7 +5358,7 @@ const ALTERNATIVES_PAGES: AlternativesPageConfig[] = [
     slug: "cursor-alternatives",
     title: "Cursor Alternatives — Best Free AI Code Editors for 2026",
     metaDesc: "Cursor moved to credit-based pricing in 2025. Compare free AI coding alternatives: Claude Code, GitHub Copilot, Cline, Aider, Windsurf, Augment Code, Amazon Q Developer, Gemini CLI. Verified 2026 limits.",
-    contextHtml: `<p><strong>Cursor</strong> — the AI-powered code editor built on VS Code — shifted to <strong>credit-based pricing</strong> in mid-2025, plus a new <strong>$200/month Ultra tier</strong>. The free tier still exists (2,000 completions/month, 50 slow premium requests), but the credit model makes costs less predictable for heavy users. Developers are actively evaluating alternatives.</p>
+    contextHtml: `<p><strong>Cursor</strong> — the AI-powered code editor built on VS Code — shifted to <strong>credit-based pricing</strong> in mid-2025, plus a new <strong>$200/month Ultra tier</strong>. The free tier still exists (limited Agent requests, no published figure), but the credit model makes costs less predictable for heavy users. Developers are actively evaluating alternatives.</p>
       <p>The AI coding tool landscape has exploded in 2026. Terminal-based agents (Claude Code, Aider, Gemini CLI), IDE extensions (GitHub Copilot, Windsurf, Augment Code), and open-source autonomous agents (Cline) each offer different trade-offs between cost, flexibility, and capability.</p>
       <p>Below are the best free alternatives to Cursor, compared by <strong>what you actually get for free</strong> — exact limits, open-source status, and what each tool is best at.</p>`,
     tag: "cursor-alternative",
@@ -5380,7 +5381,7 @@ const ALTERNATIVES_PAGES: AlternativesPageConfig[] = [
     <tbody>
       <tr>
         <td style="font-weight:600;color:var(--text-dim)">Cursor</td>
-        <td>2,000 completions/mo, 50 slow premium req</td>
+        <td>Limited Agent requests</td>
         <td>IDE (VS Code fork)</td>
         <td>\u2014</td>
         <td style="color:var(--text-dim)">Inline editing + chat in one IDE</td>
@@ -11676,7 +11677,7 @@ ${buildCards(other)}
       <tr>
         <td style="font-weight:600"><a href="/vendor/cursor" style="color:var(--text)">Cursor</a></td>
         <td>AI Coding</td>
-        <td>2,000 completions, 50 requests</td>
+        <td>Limited Agent requests</td>
         <td>No</td>
         <td>AI-native code editor with Composer</td>
       </tr>
@@ -12982,7 +12983,7 @@ ${buildCards(other)}
       <tr>
         <td style="font-weight:600"><a href="/vendor/cursor" style="color:var(--text)">Cursor</a></td>
         <td>AI IDE</td>
-        <td>2,000 completions/mo, 50 slow requests</td>
+        <td>Limited Agent requests</td>
         <td>No</td>
         <td>AI-native editor with deep codebase understanding</td>
       </tr>
@@ -24550,7 +24551,7 @@ function buildFirebaseStudioShutdownPage(): string {
     { name: "CodeSandbox", slug: "codesandbox", freeCompute: "400 VM credits/month", freeStorage: "20 GB", collaboration: "Real-time collaboration", aiFeatures: "AI code suggestions", bestFor: "Web development, React/Vue/Angular projects", type: "cloud-ide" },
     { name: "StackBlitz", slug: "stackblitz", freeCompute: "Unlimited (WebContainer, runs in browser)", freeStorage: "Browser-based", collaboration: "Share via URL", aiFeatures: "Bolt.new integration", bestFor: "Instant startup, frontend frameworks, no server needed", type: "cloud-ide" },
     { name: "Coder", slug: "coder", freeCompute: "Unlimited (self-hosted OSS)", freeStorage: "Your infrastructure", collaboration: "Team workspaces", aiFeatures: "AI assistant integration", bestFor: "Enterprise, self-hosted, full control", type: "cloud-ide" },
-    { name: "Cursor", slug: "cursor", freeCompute: "Local (2,000 completions + 50 premium requests/mo)", freeStorage: "Local", collaboration: "N/A", aiFeatures: "AI-first: chat, edit, compose, multi-file", bestFor: "AI-assisted coding, VS Code users wanting AI superpowers", type: "cloud-ide" },
+    { name: "Cursor", slug: "cursor", freeCompute: "Local (limited Agent requests)", freeStorage: "Local", collaboration: "N/A", aiFeatures: "AI-first: chat, edit, compose, multi-file", bestFor: "AI-assisted coding, VS Code users wanting AI superpowers", type: "cloud-ide" },
     { name: "Windsurf", slug: "windsurf", freeCompute: "Local (free tier with quotas)", freeStorage: "Local", collaboration: "N/A", aiFeatures: "Cascade flows, AI agents, multi-file edits", bestFor: "Agentic coding, AI-driven development", type: "cloud-ide" },
     { name: "Bolt.new", slug: "bolt-new", freeCompute: "Limited free tokens", freeStorage: "Project-based", collaboration: "Share via URL", aiFeatures: "Full-stack AI builder from prompts", bestFor: "Non-coders building full apps, rapid prototyping", type: "ai-builder" },
     { name: "Lovable", slug: "lovable", freeCompute: "5 free generations/day", freeStorage: "Project-based", collaboration: "Team sharing", aiFeatures: "AI app builder, Supabase integration", bestFor: "MVPs, startup prototyping, design-to-code", type: "ai-builder" },
@@ -26793,12 +26794,12 @@ function buildAiCodingPricing2026Page(): string {
     {
       name: "Cursor",
       slug: "cursor",
-      free: "Limited requests",
+      free: "Limited Agent requests",
       pro: "$20/mo",
-      power: "$60/mo (Pro+) / $200/mo (Ultra)",
-      teams: "$40/seat",
-      model: "Credit-based (6 plans)",
-      freeDetails: "6 plans: Free (2,000 completions/month), Hobby ($10/mo), Pro ($20/mo, 500 fast premium requests), Pro+ ($60/mo, 10x premium vs Pro), Business ($40/seat), Ultra ($200/mo). Credit-based pricing since June 2025.",
+      power: "Pro+ / Ultra",
+      teams: "$40/user/mo",
+      model: "Credit-based",
+      freeDetails: "Hobby is the free plan: no credit card, limited Agent requests, Composer access — Cursor publishes no completion or request figure for it. Paid: Individual $20/mo (Pro), Pro+ (3x Pro's Agent limits), Ultra (20x), Teams $40/user/mo, Enterprise custom.",
     },
     {
       name: "Windsurf",
@@ -26853,12 +26854,12 @@ function buildAiCodingPricing2026Page(): string {
     {
       name: "Augment Code",
       slug: "augment-code",
-      free: "Limited usage",
-      pro: "$20\u201360/mo",
-      power: "\u2014",
-      teams: "Custom",
-      model: "Credit-based (Oct 2025)",
-      freeDetails: "Free tier for individual developers with limited usage. Professional plan uses credit-based consumption ($20\u201360/month depending on usage). Shifted from flat per-seat to credit-based model in October 2025. Deep codebase understanding is the key differentiator.",
+      free: "No free tier",
+      pro: "$20/mo flat",
+      power: "$100/mo flat (Business)",
+      teams: "Included up to 50 seats",
+      model: "Flat + pay-as-you-go top-ups",
+      freeDetails: "No free tier. Standard $20/month flat and Business $100/month flat, each covering up to 50 seats with $20 and $100 of included monthly usage respectively across LLM, Context Engine and compute; top-ups are pay-as-you-go. Enterprise is custom-priced. Flat team pricing with no per-seat charge.",
     },
     {
       name: "Cline",
@@ -26903,13 +26904,19 @@ function buildAiCodingPricing2026Page(): string {
     </div>`;
   }).join("\n    ");
 
+  const supersededAiCodingLineups = supersededLineups(aiCodingChanges);
+
   const changeTimelineRows = aiCodingChanges.map(c => {
-    const dateStr = new Date(c.date).toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" });
+    const dateStr = changeTimelineDate(c.date);
     const impactColor = c.impact === "high" ? "#f85149" : c.impact === "medium" ? "#d29922" : "#3fb950";
-    return `<tr>
+    const newest = supersededAiCodingLineups.get(c);
+    const historyNote = newest
+      ? `<div class="superseded-note">${escHtmlServer(supersessionNote(newest, changeTimelineDate))}</div>`
+      : "";
+    return `<tr${newest ? ` class="superseded-row"` : ""}>
       <td style="font-family:var(--mono);font-size:.8rem;white-space:nowrap">${escHtmlServer(dateStr)}</td>
       <td style="font-weight:600">${escHtmlServer(c.vendor)}</td>
-      <td style="font-size:.85rem">${escHtmlServer(c.summary)}</td>
+      <td style="font-size:.85rem">${escHtmlServer(c.summary)}${historyNote}</td>
       <td><span style="color:${impactColor};font-size:.8rem;font-weight:600">${escHtmlServer(c.impact?.toUpperCase() ?? "N/A")}</span></td>
     </tr>`;
   }).join("\n        ");
@@ -26974,6 +26981,8 @@ h3{font-family:var(--serif);font-size:1.1rem;color:var(--text);margin:1.5rem 0 .
 .pricing-table th{text-align:left;padding:.75rem .5rem;border-bottom:2px solid var(--border);color:var(--text-muted);font-weight:600;font-size:.75rem;text-transform:uppercase;letter-spacing:.05em}
 .pricing-table td{padding:.6rem .5rem;border-bottom:1px solid var(--border)}
 .pricing-table tr:hover{background:var(--accent-glow)}
+.superseded-row td{color:var(--text-dim)}
+.superseded-note{margin-top:.35rem;font-size:.75rem;color:var(--text-dim);text-transform:uppercase;letter-spacing:.04em}
 .diff-card{padding:1.25rem;border:1px solid var(--border);border-left:3px solid var(--accent);border-radius:8px;background:var(--bg-card);margin-bottom:.75rem}
 .diff-card h3{margin:0 0 .5rem;font-size:1rem}
 .diff-desc{color:var(--text-muted);font-size:.9rem;line-height:1.6}
@@ -27186,16 +27195,16 @@ function buildAiCodingToolsPricingPage(): string {
       name: "Cursor",
       slug: "cursor",
       category: "ide",
-      free: "2K completions/mo",
+      free: "Limited Agent requests",
       pro: "$20/mo",
-      power: "$60/mo (Pro+) / $200/mo (Ultra)",
-      teams: "$40/seat",
-      model: "Credit-based (6 plans)",
-      freeDetails: "6-plan structure: Free (2,000 completions/month, 50 slow premium requests), Hobby ($10/mo — lighter paid tier), Pro ($20/mo — unlimited completions, 500 fast premium requests), Pro+ ($60/mo — 10x premium vs Pro, priority access), Business ($40/seat — admin controls, SSO), Ultra ($200/mo — highest credit limits). Credit-based pricing model since June 2025.",
+      power: "Pro+ / Ultra",
+      teams: "$40/user/mo",
+      model: "Credit-based",
+      freeDetails: "Hobby is Cursor's free plan — no credit card required, limited Agent requests, access to Composer. Cursor's pricing page states no completion or premium-request figure for it. Individual plans start at $20/mo (Pro), with Pro+ at 3x Pro's Agent limits and Ultra at 20x. Teams $40/user/mo (Premium at 5x Standard). Enterprise is custom-priced with pooled usage and SCIM.",
       freeType: "limited",
-      monthlyCostSolo: "$10–$60",
+      monthlyCostSolo: "$20",
       monthlyCostTeam5: "$200",
-      hiddenCosts: "6 tiers now (added Hobby at $10/mo). Credit consumption varies by model — Opus burns 10x faster than Sonnet. Pro+ ($60/mo) fills the gap between Pro and Ultra. Ultra ($200/mo) still needed for highest limits.",
+      hiddenCosts: "Credit consumption varies by model — Opus burns 10x faster than Sonnet.",
     },
     {
       name: "Windsurf",
@@ -27351,16 +27360,16 @@ function buildAiCodingToolsPricingPage(): string {
       name: "Augment Code",
       slug: "augment-code",
       category: "ide",
-      free: "Limited usage",
-      pro: "$20\u201360/mo",
-      power: "\u2014",
-      teams: "Custom",
-      model: "Credit-based (Oct 2025)",
-      freeDetails: "Free tier for individual developers with limited usage. Professional plan uses credit-based consumption ($20\u201360/month depending on usage). Shifted from flat per-seat to credit-based model in October 2025. Deep codebase understanding is the key differentiator.",
-      freeType: "limited",
-      monthlyCostSolo: "$20\u201360",
-      monthlyCostTeam5: "Custom",
-      hiddenCosts: "Credit-based means unpredictable costs. Usage can spike to $60/mo under heavy load. Codebase indexing is the value-add but costs scale with repo size.",
+      free: "No free tier",
+      pro: "$20/mo flat",
+      power: "$100/mo flat (Business)",
+      teams: "Included up to 50 seats",
+      model: "Flat + pay-as-you-go top-ups",
+      freeDetails: "No free tier. Standard $20/month flat and Business $100/month flat, each covering up to 50 seats with $20 and $100 of included monthly usage respectively across LLM, Context Engine and compute; top-ups are pay-as-you-go. Enterprise is custom-priced. Flat team pricing with no per-seat charge.",
+      freeType: "none",
+      monthlyCostSolo: "$20",
+      monthlyCostTeam5: "$20",
+      hiddenCosts: "Included usage is $20/month on Standard and $100/month on Business; beyond it, top-ups are pay-as-you-go. Codebase indexing is the value-add but costs scale with repo size.",
     },
     {
       name: "OpenAI Codex",
@@ -27510,13 +27519,19 @@ function buildAiCodingToolsPricingPage(): string {
       '</tr>';
   }).join("\n        ");
 
-  const changeTimelineRows = aiCodingChanges.map(c => {
-    const dateStr = new Date(c.date).toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" });
+  const supersededAiCodingLineups = supersededLineups(aiCodingChanges);
+
+  const changeTimelineRows = aiCodingChanges.map((c: any) => {
+    const dateStr = changeTimelineDate(c.date);
     const impactColor = c.impact === "high" ? "#f85149" : c.impact === "medium" ? "#d29922" : "#3fb950";
-    return '<tr>' +
+    const newest = supersededAiCodingLineups.get(c);
+    const historyNote = newest
+      ? '<div class="superseded-note">' + escHtmlServer(supersessionNote(newest, changeTimelineDate)) + '</div>'
+      : "";
+    return '<tr' + (newest ? ' class="superseded-row"' : "") + '>' +
       '<td style="font-family:var(--mono);font-size:.8rem;white-space:nowrap">' + escHtmlServer(dateStr) + '</td>' +
       '<td style="font-weight:600">' + escHtmlServer(c.vendor) + '</td>' +
-      '<td style="font-size:.85rem">' + escHtmlServer(c.summary) + '</td>' +
+      '<td style="font-size:.85rem">' + escHtmlServer(c.summary) + historyNote + '</td>' +
       '<td><span style="color:' + impactColor + ';font-size:.8rem;font-weight:600">' + escHtmlServer(c.impact?.toUpperCase() ?? "N/A") + '</span></td>' +
       '</tr>';
   }).join("\n        ");
@@ -27540,7 +27555,7 @@ function buildAiCodingToolsPricingPage(): string {
 
   const faqEntries = [
     { q: "What is the best free AI coding tool in 2026?", a: "Gemini Code Assist offers the most generous free tier with 6,000 completions/day (180,000/month) and 240 chat messages/day. For open-source alternatives, Cline and Aider are fully free with BYO API keys. Gemini CLI offers 1,000 free requests/day. Amazon Kiro offers 50 free credits/month — limited, but enough to try spec-driven development." },
-    { q: "How much does Cursor cost vs Windsurf?", a: "Both charge $20/month Pro and $200/month Power (Ultra/Max). Cursor now has 6 plans (added Hobby at $10/mo), Windsurf has 4 (Free, Pro $20, Teams $40, Max $200). Windsurf raised Pro from $15 to $20 in March 2026. Windsurf's SWE-1.5 Fast Agent model optimizes for iteration speed." },
+    { q: "How much does Cursor cost vs Windsurf?", a: "Both start at $20/month for an individual paid plan and $40/user/month for teams. Cursor's free plan is called Hobby. Above Pro at $20/mo, Cursor lists Pro+ at 3x Pro's Agent limits and Ultra at 20x, with Enterprise custom-priced. Windsurf has 4 plans (Free, Pro $20, Teams $40/seat, Max $200) and raised Pro from $15 to $20 in March 2026. Windsurf's SWE-1.5 Fast Agent model optimizes for iteration speed." },
     { q: "Is GitHub Copilot still the cheapest AI coding tool?", a: "Yes, GitHub Copilot Pro at $10/month is the cheapest paid AI coding subscription. It also offers a free tier with 2,000 completions/month and 50 premium requests/month. Pro includes 300 premium requests. Overage costs $0.04/request. Note: advanced reasoning models (Claude Opus 4, o3) consume 5x\u201320x premium requests per interaction." },
     { q: "What are the hidden costs of BYO-key AI coding tools?", a: "Tools like Cline and Aider are free to install but require API keys. Typical costs: $5-50/month for moderate use with Claude Sonnet or GPT-4o. Heavy agentic usage (Cline with Opus) can reach $50-100/month in API costs alone." },
     { q: "Which AI coding tool is best for teams?", a: "GitHub Copilot Business ($19/seat) is cheapest for teams. Gemini Code Assist Enterprise matches at $19/seat with Google Cloud integration. Cursor and Windsurf Business ($40/seat) offer the highest AI throughput per developer." },
@@ -27606,6 +27621,8 @@ function buildAiCodingToolsPricingPage(): string {
     '.pricing-table th{text-align:left;padding:.75rem .5rem;border-bottom:2px solid var(--border);color:var(--text-muted);font-weight:600;font-size:.75rem;text-transform:uppercase;letter-spacing:.05em}\n' +
     '.pricing-table td{padding:.6rem .5rem;border-bottom:1px solid var(--border)}\n' +
     '.pricing-table tr:hover{background:var(--accent-glow)}\n' +
+    '.superseded-row td{color:var(--text-dim)}\n' +
+    '.superseded-note{margin-top:.35rem;font-size:.75rem;color:var(--text-dim);text-transform:uppercase;letter-spacing:.04em}\n' +
     '.diff-card{padding:1.25rem;border:1px solid var(--border);border-left:3px solid var(--accent);border-radius:8px;background:var(--bg-card);margin-bottom:.75rem}\n' +
     '.diff-card h3{margin:0 0 .5rem;font-size:1rem}\n' +
     '.diff-desc{color:var(--text-muted);font-size:.9rem;line-height:1.6}\n' +

--- a/test/change-lineup.test.ts
+++ b/test/change-lineup.test.ts
@@ -1,0 +1,251 @@
+import { describe, it, before, after } from "node:test";
+import assert from "node:assert";
+import { spawn, type ChildProcess } from "node:child_process";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import type { DealChange } from "../src/types.ts";
+import {
+  changeTimelineDate,
+  statedPrices,
+  statesAPlanLineup,
+  supersededLineups,
+  supersessionNote,
+} from "../src/change-lineup.ts";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO = path.join(__dirname, "..");
+
+const stored: DealChange[] = JSON.parse(
+  readFileSync(path.join(REPO, "data", "deal_changes.json"), "utf-8")
+).changes;
+
+const claim = (over: Partial<DealChange> = {}) => ({
+  vendor: "Cursor",
+  date: "2026-04-13",
+  summary: "Pro $20/mo, Ultra $200/mo",
+  current_state: "Two paid tiers",
+  ...over,
+});
+
+describe("a change record states a plan lineup when it names more than one price", () => {
+  it("reads prices out of the summary and the current state together", () => {
+    assert.deepStrictEqual(
+      [...statedPrices({ vendor: "X", date: "2026-01-01", summary: "Pro $20/mo", current_state: "Teams $40/seat" })],
+      ["$20", "$40"]
+    );
+  });
+
+  it("counts one price as a single fact, not a lineup", () => {
+    assert.strictEqual(statesAPlanLineup(claim({ summary: "Pro rose to $20/mo", current_state: "Pro $20/mo" })), false);
+  });
+
+  it("counts the same price named twice as one price", () => {
+    assert.strictEqual(statesAPlanLineup(claim({ summary: "Pro $20/mo", current_state: "Pro is $20/mo" })), false);
+  });
+
+  it("counts two distinct prices as a lineup", () => {
+    assert.strictEqual(statesAPlanLineup(claim()), true);
+  });
+
+  it("reads a price with a decimal and a price with a comma", () => {
+    assert.deepStrictEqual(
+      [...statedPrices({ vendor: "X", date: "2026-01-01", summary: "$19.99/mo and $1,400/year" })],
+      ["$19.99", "$1,400"]
+    );
+  });
+
+  it("states no lineup when it names no price at all", () => {
+    assert.strictEqual(
+      statesAPlanLineup({ vendor: "AWS", date: "2026-09-30", summary: "App Mesh: end of support September 30" }),
+      false
+    );
+  });
+
+  it("states no vendor lineup when it is a correction to our own record", () => {
+    assert.strictEqual(statesAPlanLineup(claim({ change_type: "record_corrected" })), false);
+    assert.strictEqual(statesAPlanLineup(claim({ change_type: "pricing_restructured" })), true);
+  });
+});
+
+describe("the newest lineup a vendor has is the one that reads as current", () => {
+  it("supersedes an older lineup with the newest one", () => {
+    const older = claim({ date: "2026-03-19" });
+    const newest = claim({ date: "2026-04-13" });
+    const superseded = supersededLineups([newest, older]);
+    assert.strictEqual(superseded.get(older), newest);
+    assert.strictEqual(superseded.has(newest), false);
+  });
+
+  it("does not let one vendor's lineup supersede another's", () => {
+    const cursor = claim({ vendor: "Cursor", date: "2026-04-13" });
+    const windsurf = claim({ vendor: "Windsurf", date: "2026-03-19" });
+    assert.strictEqual(supersededLineups([cursor, windsurf]).size, 0);
+  });
+
+  it("leaves a record that states no lineup alone, however old", () => {
+    const single = claim({ date: "2026-01-01", summary: "Pro rose to $20/mo", current_state: "Pro $20/mo" });
+    const newest = claim({ date: "2026-04-13" });
+    const superseded = supersededLineups([newest, single]);
+    assert.strictEqual(superseded.has(single), false);
+  });
+
+  it("supersedes nothing when two lineups carry the same date", () => {
+    const first = claim({ date: "2026-04-01", summary: "VPS-1 $7.60/mo, VPS-4 $43.50/mo" });
+    const second = claim({ date: "2026-04-01", summary: "IPv4 up $1/mo, deployments up $2/mo" });
+    assert.strictEqual(supersededLineups([first, second]).size, 0);
+  });
+
+  it("names the record that replaced it, not the fact that one exists", () => {
+    assert.strictEqual(
+      supersessionNote({ vendor: "Windsurf", date: "2026-04-13" }, () => "Apr 13, 2026"),
+      "Superseded by our Apr 13, 2026 record"
+    );
+  });
+
+  it("dates the replacement the way the timeline beside it is dated", () => {
+    assert.strictEqual(
+      supersessionNote({ vendor: "Windsurf", date: "2026-04-13" }, changeTimelineDate),
+      `Superseded by our ${changeTimelineDate("2026-04-13")} record`
+    );
+  });
+});
+
+describe("the stored change log, read through the rule", () => {
+  const superseded = supersededLineups(stored);
+  const find = (vendor: string, date: string) =>
+    stored.find(c => c.vendor === vendor && c.date === date && statesAPlanLineup(c))!;
+
+  it("supersedes every marked record with a strictly later one for the same vendor", () => {
+    for (const [older, newest] of superseded) {
+      assert.strictEqual(older.vendor, newest.vendor);
+      assert.ok(newest.date > older.date, `${older.vendor} ${older.date} is replaced by ${newest.date}`);
+    }
+  });
+
+  it("marks Windsurf's March lineup, which the April one restates", () => {
+    const march = find("Windsurf", "2026-03-19");
+    assert.strictEqual(superseded.get(march)?.date, "2026-04-13");
+  });
+
+  it("marks the Cursor record that prices a Hobby plan the free plan is named after", () => {
+    const april = find("Cursor", "2026-04-13");
+    assert.ok(april.summary.includes("Hobby ($10/mo)"));
+    assert.strictEqual(superseded.get(april)?.date, "2026-08-28");
+  });
+
+  it("leaves our newest read of a vendor standing when a correction follows it", () => {
+    const newest = find("Cursor", "2026-08-28");
+    assert.strictEqual(superseded.has(newest), false);
+    const correction = stored.find(c => c.vendor === "Cursor" && c.change_type === "record_corrected")!;
+    assert.ok(correction.date > newest.date, "the correction is the later record");
+  });
+
+  it("leaves AWS's deprecations standing, each naming a different product", () => {
+    const aws = stored.filter(c => c.vendor === "AWS" && c.change_type === "product_deprecated");
+    assert.ok(aws.length >= 5, `AWS deprecation records: ${aws.length}`);
+    for (const record of aws) assert.strictEqual(superseded.has(record), false);
+  });
+
+  it("is not vacuous — the log holds vendors with more than one lineup", () => {
+    assert.ok(superseded.size >= 3, `superseded records: ${superseded.size}`);
+  });
+});
+
+let serverPort = 0;
+let proc: ChildProcess | null = null;
+
+function startServer(): Promise<ChildProcess> {
+  return new Promise((resolve, reject) => {
+    const child = spawn("node", [path.join(REPO, "dist", "serve.js")], {
+      stdio: ["pipe", "pipe", "pipe"],
+      env: { ...process.env, PORT: "0", BASE_URL: "http://localhost" },
+    });
+    const timeout = setTimeout(() => { child.kill(); reject(new Error("Server startup timeout")); }, 20000);
+    child.stderr!.on("data", (data: Buffer) => {
+      const m = data.toString().match(/running on http:\/\/localhost:(\d+)/);
+      if (m) { serverPort = parseInt(m[1], 10); clearTimeout(timeout); resolve(child); }
+    });
+    child.on("error", (err) => { clearTimeout(timeout); reject(err); });
+  });
+}
+
+const get = async (p: string) => (await fetch(`http://localhost:${serverPort}${p}`)).text();
+
+const rowsOf = (body: string) => body.match(/<tr[^>]*>[\s\S]*?<\/tr>/g) ?? [];
+const isChangeRow = (row: string) => /<td[^>]*>[A-Z][a-z]{2} \d{1,2}, \d{4}<\/td>/.test(row);
+const withoutChangeRows = (body: string) =>
+  rowsOf(body).filter(isChangeRow).reduce((rest, row) => rest.replace(row, ""), body);
+const AI_CODING_PAGES = ["/ai-coding-pricing-2026", "/ai-coding-tools-pricing"];
+
+describe("the AI coding pages state one lineup per vendor", () => {
+  before(async () => { proc = await startServer(); });
+  after(() => { proc?.kill(); });
+
+  it("leaves at most one change row per vendor reading as a current lineup", async () => {
+    for (const page of AI_CODING_PAGES) {
+      const body = await get(page);
+      const unmarked = new Map<string, number>();
+      for (const row of rowsOf(body).filter(isChangeRow)) {
+        const vendor = row.match(/<td style="font-weight:600">([^<]+)<\/td>/)?.[1];
+        if (!vendor) continue;
+        const summary = row.match(/<td style="font-size:.85rem">([\s\S]*?)<\/td>/)?.[1] ?? "";
+        const prices = new Set(summary.replace(/<div[\s\S]*$/, "").match(/\$\d[\d,]*(?:\.\d+)?/g) ?? []);
+        if (prices.size < 2) continue;
+        if (row.includes("superseded-note")) continue;
+        unmarked.set(vendor, (unmarked.get(vendor) ?? 0) + 1);
+      }
+      const competing = [...unmarked].filter(([, n]) => n > 1).map(([vendor, n]) => `${page} ${vendor} ${n}`);
+      assert.deepStrictEqual(competing, []);
+    }
+  });
+
+  it("marks Windsurf's superseded row with the date of the record that replaced it", async () => {
+    for (const page of AI_CODING_PAGES) {
+      const body = await get(page);
+      const march = rowsOf(body).find(r => r.includes("Windsurf") && r.includes("Ultimate $40/mo"));
+      assert.ok(march, `${page} renders the March Windsurf record`);
+      assert.ok(
+        march!.includes(`Superseded by our ${changeTimelineDate("2026-04-13")} record`),
+        `${page} names the record that replaced the March one`
+      );
+    }
+  });
+
+  it("prices no Cursor plan named Hobby outside the change log recording that we did", async () => {
+    for (const page of AI_CODING_PAGES) {
+      const currentFacts = withoutChangeRows(await get(page));
+      const priced = [...currentFacts.matchAll(/Hobby(?: tier| plan)?(?: at)? \(?\$\d[\d,]*/g)].map(m => m[0]);
+      assert.deepStrictEqual(priced, [], `${page} prices a Hobby plan`);
+    }
+  });
+
+  it("offers no free tier for a vendor whose record we have retired", async () => {
+    const offers: Array<{ vendor: string; tier: string }> = JSON.parse(
+      readFileSync(path.join(REPO, "data", "index.json"), "utf-8")
+    ).offers;
+    const retired = new Set(offers.filter(o => o.tier === "Retired").map(o => o.vendor));
+    assert.ok(retired.size > 0, "the catalogue holds a retired record to test against");
+
+    for (const page of AI_CODING_PAGES) {
+      const body = await get(page);
+      const freeTierTables = (body.match(/<table[\s\S]*?<\/table>/g) ?? []).filter(t => /<th[^>]*>Free Tier<\/th>/.test(t));
+      assert.ok(freeTierTables.length > 0, `${page} renders a table with a free-tier column`);
+      const promising = freeTierTables
+        .flatMap(rowsOf)
+        .filter(row => [...retired].some(vendor => row.includes(`>${vendor}<`)))
+        .filter(row => !/No free tier/.test(row));
+      assert.deepStrictEqual(promising, [], `${page} states a free tier for a retired record`);
+    }
+  });
+
+  it("keeps Copilot's completion figure off every Cursor fact row", async () => {
+    for (const page of AI_CODING_PAGES) {
+      const body = await get(page);
+      const carrying = rowsOf(body)
+        .filter(row => !isChangeRow(row))
+        .filter(row => row.includes(">Cursor<") && /2,?000 completions/.test(row));
+      assert.deepStrictEqual(carrying, [], `${page} states Cursor's free tier in completions`);
+    }
+  });
+});


### PR DESCRIPTION
Refs #1067 — AC-1 defects 2 and 3, and AC-2.

## AC-2 — one lineup, superseded rows readable as history

`src/change-lineup.ts` reads a change record's stated prices out of its summary and current state. Two distinct prices make it a lineup claim. For a given vendor only the newest lineup claim reads as current; the older ones render dimmed with the date of the record that replaced them.

Four records are marked on these two pages:

| vendor | record | superseded by |
|---|---|---|
| Windsurf | 2026-03-19 | 2026-04-13 |
| Cursor | 2025-06-01 | 2026-08-28 |
| Cursor | 2026-04-07 | 2026-08-28 |
| Cursor | 2026-04-13 | 2026-08-28 |

Windsurf is the pair AC-2 names: the 2026-04-13 record's own `previous_state` — "Pro $20/mo and Ultimate $40/mo listed; Max tier and SWE-1.5 model missing" — restates what the March record left in place. The page's prose, table and newest record already agreed on one lineup; the March row was the fourth version.

**A correction to our own record is not a vendor lineup.** Without that exclusion the 2026-09-02 correction became Cursor's current lineup and marked our own 2026-08-28 read of cursor.com superseded, which is the wrong way round.

### Why recency and not a supersession inference

I measured a stricter rule first: B replaces A when B is a later record of the same type whose `previous_state` shares a price with A's stated lineup. It fires on exactly the right four pairs and rejects OpenAI, DigitalOcean, Amazon Kiro, Google, X and Amazon SP-API, whose repeated records are different dimensions rather than restatements.

I did not ship it, because it asserts the older record is now false, and the evidence only supports the weaker claim: a newer lineup exists. The rendered note says that and nothing more. The stricter rule is worth having if you want a `superseded_by` field in `/api/changes` — it is a better predicate than recency, and the census is on this PR's branch.

23 vendor+type pairs hold more than one record; 53 records are involved. AWS's six `product_deprecated` records name six different products and state no lineup, so none is marked — the test pins that.

## AC-1 defects 2 and 3 — the Cursor literals

Applied verbatim from the strings supplied on the issue: `serve.ts` 26801 and 27194 (`freeDetails`), 24553 (`freeCompute`), 5360 (context paragraph), 5383, 11679 and 12985 (table cells). 11679 and 12985 are both Cursor's rows, checked by eye as asked.

Lines 5397, 11672, 12930, 12978, 13048, 13057 and 14368 carry the 2,000-completions figure on GitHub Copilot's own row, where it is correct. Untouched.

**Adjacent fields carrying the same fabrication, corrected as deletions rather than new copy**, because they publish the $10 tier or a figure our own corrected record does not support: `model: "Credit-based (6 plans)"`, `free: "2K completions/mo"`, `power: "$60/mo (Pro+) / $200/mo (Ultra)"`, `monthlyCostSolo: "$10–$60"`, and `hiddenCosts: "6 tiers now (added Hobby at $10/mo)…"`. Neither #1275's `index.json` description nor the 2026-08-28 record states $60 or $200 for Cursor, so the page no longer does either.

**One string I recombined rather than substituted** and would rather you owned: the FAQ answer to "How much does Cursor cost vs Windsurf?" was built on "Cursor now has 6 plans (added Hobby at $10/mo)". Every clause in the replacement is lifted from your #1275 description; say the word and I will take whatever you write instead.

## Augment Code was still on sale as a free tier

Both pages listed it as `free: "Limited usage"`, `pro: "$20–60/mo"` — five days after our detector recorded the removal at HIGH impact and a day after #1274 set the record to `Retired`. Its rows and `freeDetails` now carry the description the catalogue holds after #1275.

A test fails if either page's free-tier table names a vendor whose record is `Retired` without saying so.

## Not fixed, reported

- **Every change date on these pages renders a day early outside UTC.** `new Date("2026-03-19").toLocaleDateString(…)` parses as midnight UTC and formats in the local zone. Pre-existing on every timeline; production is UTC so it is right there. The supersession note uses the same formatter, so the note and the row it points at always agree.
- **The "Price convergence" paragraph** still reads "The $20/mo Pro and $200/mo Power price points have emerged as the de facto standard", and $200 is no longer a Cursor figure we can support. Editorial, so yours.
- **`serve.ts:27544` still answers the Copilot cost question in premium requests at $0.04 overage.** You gave the AI-credits table on the issue but no sentence; I have not written one.

## Verification

3,237 tests, 24 new, 0 red. tsc clean, `npm run validate` clean, `scripts/stale-page-facts.js` unchanged at 57 pages / 216 pairs. 13 mutations in `scripts/mutate-1067.sh`, 13 killed, no survivors on the first pass. 2,577 paths swept against a worktree of main: 2,571 byte-identical, 6 moved, 0 added, 0 removed — the two AI coding pages, and `/ai-ml-alternatives`, `/cursor-alternatives`, `/ide-code-editors-alternatives` and `/firebase-studio-shutdown` for the four Cursor cells. Rendered and read the result.

🤖 Generated with [Claude Code](https://claude.com/claude-code)