### PR TITLE
Price GitHub Copilot in AI credits and restore Cursor's Pro+ and Ultra (#1067)

### DIFF
--- a/scripts/census-1067-tier-prices.mjs
+++ b/scripts/census-1067-tier-prices.mjs
@@ -1,0 +1,116 @@
+import { readFileSync } from "node:fs";
+import ts from "typescript";
+
+const SOURCE = "src/serve.ts";
+
+const src = ts.createSourceFile(SOURCE, readFileSync(SOURCE, "utf8"), ts.ScriptTarget.Latest, true);
+
+const rows = [];
+
+function stringValue(node) {
+  if (ts.isStringLiteral(node) || ts.isNoSubstitutionTemplateLiteral(node)) return node.text;
+  return null;
+}
+
+function visit(node) {
+  if (ts.isObjectLiteralExpression(node)) {
+    const props = new Map();
+    for (const p of node.properties) {
+      if (!ts.isPropertyAssignment(p)) continue;
+      const key = ts.isIdentifier(p.name) || ts.isStringLiteral(p.name) ? p.name.text : null;
+      if (!key) continue;
+      const value = stringValue(p.initializer);
+      if (value !== null) props.set(key, value);
+    }
+    if (props.has("slug")) {
+      const { line } = src.getLineAndCharacterOfPosition(node.getStart(src));
+      rows.push({ slug: props.get("slug"), line: line + 1, props });
+    }
+  }
+  ts.forEachChild(node, visit);
+}
+visit(src);
+
+const catalogue = new Map();
+for (const offer of JSON.parse(readFileSync("data/index.json", "utf8")).offers) {
+  const slug = offer.vendor.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-|-$/g, "");
+  const prior = catalogue.get(slug) || { vendor: offer.vendor, text: "" };
+  prior.text += " " + (offer.description || "");
+  catalogue.set(slug, prior);
+}
+
+const TIER = "(Free|Hobby|Starter|Basic|Individual|Pro\\+|Pro|Plus|Premium|Team|Teams|Business|Standard|Ultra|Ultimate|Max|Power|Enterprise|Indie|Student|Personal|Growth|Scale)";
+const priceAfter = new RegExp("\\b" + TIER + "\\b(?: plan| tier| seat)?(?: is| at|:)?[ (\\u2014-]{0,3}\\$(\\d[\\d,]*)", "gi");
+const priceBefore = new RegExp("\\$(\\d[\\d,]*)(?:/[a-z]+)*(?:/[a-z]+)? \\(" + TIER + "\\)", "gi");
+
+export function tierPrices(text) {
+  const out = new Map();
+  const add = (tier, price) => {
+    const key = tier.toLowerCase();
+    if (!out.has(key)) out.set(key, new Set());
+    out.get(key).add(Number(price.replace(/,/g, "")));
+  };
+  for (const m of text.matchAll(priceAfter)) add(m[1], m[2]);
+  for (const m of text.matchAll(priceBefore)) add(m[2], m[1]);
+  return out;
+}
+
+let pagesWithSlug = 0;
+let compared = 0;
+const contradictions = [];
+const recordSilent = [];
+
+for (const row of rows) {
+  const record = catalogue.get(row.slug);
+  if (!record) continue;
+  pagesWithSlug++;
+  const pageText = [...row.props.entries()].filter(([k]) => k !== "slug" && k !== "url").map(([, v]) => v).join(". ");
+  const pageTiers = tierPrices(pageText);
+  const recordTiers = tierPrices(record.text);
+  for (const [tier, pagePrices] of pageTiers) {
+    const recordPrices = recordTiers.get(tier);
+    if (!recordPrices) {
+      if (new RegExp("\\b" + tier.replace("+", "\\+") + "\\b", "i").test(record.text)) {
+        recordSilent.push({ slug: row.slug, line: row.line, tier, page: [...pagePrices].join("/") });
+      }
+      continue;
+    }
+    compared++;
+    for (const price of pagePrices) {
+      if (!recordPrices.has(price)) {
+        contradictions.push({
+          slug: row.slug,
+          line: row.line,
+          tier,
+          page: [...pagePrices].join("/"),
+          record: [...recordPrices].join("/"),
+        });
+      }
+    }
+  }
+}
+
+console.log(`object literals with a slug: ${rows.length}`);
+console.log(`resolving to a catalogue vendor: ${pagesWithSlug}`);
+console.log(`tier names priced on both sides: ${compared}`);
+console.log(`contradictions: ${contradictions.length}`);
+console.log(`page prices a tier the record names but never prices: ${recordSilent.length}`);
+console.log("");
+for (const c of contradictions) {
+  console.log(`DISAGREE ${SOURCE}:${c.line}  ${c.slug}  ${c.tier}: page $${c.page} vs record $${c.record}`);
+}
+for (const c of recordSilent) {
+  console.log(`SILENT   ${SOURCE}:${c.line}  ${c.slug}  ${c.tier}: page $${c.page}, record names the tier with no price`);
+}
+
+const withdrawnCursorString =
+  "6 plans: Free (2,000 completions/month), Hobby ($10/mo), Pro ($20/mo), Pro+ ($60/mo), Business ($40/seat), Ultra ($200/mo).";
+const cursorRecord =
+  "Hobby is Cursor's free plan - no credit card required. Pro $20/mo, Pro+ $60/mo, Ultra $200/mo, Teams $40/user/mo.";
+const withdrawn = tierPrices(withdrawnCursorString);
+const held = tierPrices(cursorRecord);
+
+console.log("");
+console.log("against the withdrawn Cursor string:");
+console.log(`  disagreements: ${[...withdrawn].filter(([t, p]) => held.has(t) && [...p].some(x => !held.get(t).has(x))).length}`);
+console.log(`  page priced, record silent: ${[...withdrawn].filter(([t]) => !held.has(t) && new RegExp("\\b" + t + "\\b", "i").test(cursorRecord)).map(([t]) => t).join(", ")}`);

--- a/scripts/mutate-1067-billing.sh
+++ b/scripts/mutate-1067-billing.sh
@@ -1,0 +1,149 @@
+#!/usr/bin/env bash
+set -u
+
+REPO="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$REPO" || exit 1
+
+FILES="src/serve.ts"
+BACKUP_DIR="$(mktemp -d)"
+for f in $FILES; do cp "$f" "$BACKUP_DIR/$(basename "$f")"; done
+
+restore() {
+  for f in $FILES; do cp "$BACKUP_DIR/$(basename "$f")" "$f"; done
+  npm run build > /dev/null 2>&1
+}
+trap restore EXIT
+
+killed=0
+survived=0
+TESTS="test/copilot-billing-unit.test.ts"
+
+run_mutation() {
+  local name="$1"
+  shift
+  echo "=== $name"
+  for f in $FILES; do cp "$BACKUP_DIR/$(basename "$f")" "$f"; done
+  "$@"
+  local changed=0
+  for f in $FILES; do
+    diff -q "$BACKUP_DIR/$(basename "$f")" "$f" > /dev/null || changed=1
+  done
+  if [ "$changed" -eq 0 ]; then
+    echo "    NOT APPLIED: the mutation changed no file, so it proves nothing"
+    survived=$((survived + 1))
+    return
+  fi
+  if ! npm run build > /tmp/mutate-1067-billing-build.log 2>&1; then
+    echo "    KILLED: the mutation does not typecheck"
+    killed=$((killed + 1))
+    return
+  fi
+  if timeout 900 npx tsx --test $TESTS > /tmp/mutate-1067-billing-test.log 2>&1; then
+    echo "    SURVIVED"
+    survived=$((survived + 1))
+  else
+    echo "    KILLED: $(grep -c '✖ ' /tmp/mutate-1067-billing-test.log) failing assertion(s)"
+    grep '✖ ' /tmp/mutate-1067-billing-test.log | head -4
+    killed=$((killed + 1))
+  fi
+}
+
+py() { python3 - "$@"; }
+
+swap() {
+  py <<PY
+p = "src/serve.ts"
+s = open(p).read()
+before = s
+s = s.replace("""$1""", """$2""", $3)
+assert s != before, "mutation string not found"
+open(p, "w").write(s)
+PY
+}
+
+m_copilot_power_back_to_pro_plus() {
+  swap 'power: "$100/mo (Max)",' 'power: "$39/mo (Pro+)",' 2
+}
+
+m_copilot_model_back_to_premium_requests() {
+  swap 'model: "Tier + AI credits",' 'model: "Tier + premium requests",' 2
+}
+
+m_copilot_free_details_page_one_back() {
+  swap '2,000 code completions/month plus limited chat and agent use. On paid plans' \
+       '2,000 code completions/month, 50 premium requests/month. Pro: 300 premium requests. On paid plans' 1
+}
+
+m_copilot_free_details_page_two_back() {
+  swap '2,000 code completions/month plus limited chat and agent usage, no credit card.' \
+       '2,000 code completions/month, 50 premium requests/month.' 1
+}
+
+m_copilot_hidden_costs_back() {
+  swap "Agent and chat usage is metered — an AI credit is \$0.01" \
+       "Advanced models burn 5x–20x premium requests faster" 1
+}
+
+m_copilot_faq_back() {
+  swap 'The free tier gives 2,000 code completions a month plus limited chat and agent use.' \
+       'The free tier gives 2,000 code completions and 50 premium requests a month.' 1
+}
+
+m_free_ai_stack_back() {
+  swap 'why: "2,000 completions/month free.' \
+       'why: "2,000 completions/month + 50 premium requests free.' 1
+}
+
+m_overage_no_longer_marked_retired() {
+  swap "and the \$0.04 per-request overage are retired; GitHub's own billing docs label that model legacy." \
+       "and the \$0.04 per-request overage still apply." 1
+}
+
+m_credit_price_dropped_page_one() {
+  swap "metered in GitHub AI Credits at \$0.01 each" "metered in GitHub AI Credits" 1
+}
+
+m_credit_price_dropped_page_two() {
+  swap "metered in GitHub AI Credits at \$0.01 per credit" "metered in GitHub AI Credits" 1
+}
+
+m_cursor_power_back_to_unpriced() {
+  swap 'power: "$200/mo (Ultra)",' 'power: "Pro+ / Ultra",' 2
+}
+
+m_cursor_pro_plus_price_dropped_page_one() {
+  swap "Pro \$20/mo, Pro+ \$60/mo (3x Pro's Agent limits), Ultra \$200/mo (20x)" \
+       "Individual \$20/mo (Pro), Pro+ (3x Pro's Agent limits), Ultra (20x)" 1
+}
+
+m_hidden_costs_truncated_again() {
+  swap "escHtmlServer(t.monthlyCostTeam5) + '</td>' +
+      '<td style=\"font-size:.85rem;color:var(--text-muted)\">' + escHtmlServer(t.hiddenCosts)" \
+       "escHtmlServer(t.monthlyCostTeam5) + '</td>' +
+      '<td style=\"font-size:.85rem;color:var(--text-muted)\">' + escHtmlServer(t.hiddenCosts.substring(0, 80))" 1
+}
+
+m_cursor_pro_plus_price_dropped_page_two() {
+  swap "Pro is \$20/mo, Pro+ \$60/mo at 3x Pro's Agent limits, Ultra \$200/mo at 20x." \
+       "Individual plans start at \$20/mo (Pro), with Pro+ at 3x Pro's Agent limits and Ultra at 20x." 1
+}
+
+run_mutation "Copilot's power cell names Pro+ instead of Max" m_copilot_power_back_to_pro_plus
+run_mutation "Copilot's billing model reads premium requests" m_copilot_model_back_to_premium_requests
+run_mutation "the first page states a premium-request allowance" m_copilot_free_details_page_one_back
+run_mutation "the second page states a premium-request allowance" m_copilot_free_details_page_two_back
+run_mutation "the hidden-cost note is written in premium requests" m_copilot_hidden_costs_back
+run_mutation "the FAQ answer states a premium-request allowance" m_copilot_faq_back
+run_mutation "the free AI stack page states a premium-request allowance" m_free_ai_stack_back
+run_mutation "the per-request overage is no longer marked retired" m_overage_no_longer_marked_retired
+run_mutation "the first page states no price for an AI credit" m_credit_price_dropped_page_one
+run_mutation "the second page states no price for an AI credit" m_credit_price_dropped_page_two
+run_mutation "the hidden-cost cell is truncated again" m_hidden_costs_truncated_again
+run_mutation "Cursor's power cell carries no price" m_cursor_power_back_to_unpriced
+run_mutation "the first page drops Pro+ and Ultra's prices" m_cursor_pro_plus_price_dropped_page_one
+run_mutation "the second page drops Pro+ and Ultra's prices" m_cursor_pro_plus_price_dropped_page_two
+
+echo ""
+echo "killed:   $killed"
+echo "survived: $survived"
+[ "$survived" -eq 0 ]

--- a/src/serve.ts
+++ b/src/serve.ts
@@ -14366,7 +14366,7 @@ function buildFreeAiStackPage(): string {
     {
       name: "AI Coding Assistant",
       icon: "💻",
-      recommended: { vendor: "GitHub Copilot", why: "2,000 completions/month + 50 premium requests free. VS Code native with deep GitHub integration. The simplest on-ramp to AI-assisted development." },
+      recommended: { vendor: "GitHub Copilot", why: "2,000 completions/month free. VS Code native with deep GitHub integration. The simplest on-ramp to AI-assisted development." },
       alternatives: ["Cursor", "Amazon Q Developer", "Cline", "Aider"],
       outgrow: "When you exceed 2,000 completions/month or need unlimited chat. Cline and Aider are free with your own API keys — no completion limits, just API costs.",
       relatedPage: "/ide-code-editors-alternatives",
@@ -26796,10 +26796,10 @@ function buildAiCodingPricing2026Page(): string {
       slug: "cursor",
       free: "Limited Agent requests",
       pro: "$20/mo",
-      power: "Pro+ / Ultra",
+      power: "$200/mo (Ultra)",
       teams: "$40/user/mo",
       model: "Credit-based",
-      freeDetails: "Hobby is the free plan: no credit card, limited Agent requests, Composer access — Cursor publishes no completion or request figure for it. Paid: Individual $20/mo (Pro), Pro+ (3x Pro's Agent limits), Ultra (20x), Teams $40/user/mo, Enterprise custom.",
+      freeDetails: "Hobby is the free plan: no credit card, limited Agent requests, Composer access — Cursor publishes no completion or request figure for it. Paid: Pro $20/mo, Pro+ $60/mo (3x Pro's Agent limits), Ultra $200/mo (20x), Teams $40/user/mo, Enterprise custom.",
     },
     {
       name: "Windsurf",
@@ -26816,10 +26816,10 @@ function buildAiCodingPricing2026Page(): string {
       slug: "github-copilot",
       free: "2K completions/mo",
       pro: "$10/mo",
-      power: "$39/mo (Pro+)",
+      power: "$100/mo (Max)",
       teams: "$19/seat",
-      model: "Tier + premium requests",
-      freeDetails: "2,000 code completions/month, 50 premium requests/month. Pro: 300 premium requests. Pro+ ($39): 1,500 premium requests, all models (Claude Opus 4, o3). Business: 300/user. Enterprise ($39/seat): 1,000/user. Overage $0.04/request. Student plan (Mar 2026): premium models via Auto mode only, no manual selection.",
+      model: "Tier + AI credits",
+      freeDetails: "2,000 code completions/month plus limited chat and agent use. On paid plans completions and next edit suggestions are unlimited and consume nothing; everything else is metered in GitHub AI Credits at $0.01 each — Pro $10/mo ($15 of credits), Pro+ $39/mo ($70), Max $100/mo ($200). Business $19/seat (1,900 credits/user), Enterprise $39/seat (3,900/user). Student plan (Mar 2026): premium models via Auto mode only, no manual selection.",
     },
     {
       name: "Gemini Code Assist",
@@ -27197,10 +27197,10 @@ function buildAiCodingToolsPricingPage(): string {
       category: "ide",
       free: "Limited Agent requests",
       pro: "$20/mo",
-      power: "Pro+ / Ultra",
+      power: "$200/mo (Ultra)",
       teams: "$40/user/mo",
       model: "Credit-based",
-      freeDetails: "Hobby is Cursor's free plan — no credit card required, limited Agent requests, access to Composer. Cursor's pricing page states no completion or premium-request figure for it. Individual plans start at $20/mo (Pro), with Pro+ at 3x Pro's Agent limits and Ultra at 20x. Teams $40/user/mo (Premium at 5x Standard). Enterprise is custom-priced with pooled usage and SCIM.",
+      freeDetails: "Hobby is Cursor's free plan — no credit card required, limited Agent requests, access to Composer. Cursor's pricing page states no completion or premium-request figure for it. Pro is $20/mo, Pro+ $60/mo at 3x Pro's Agent limits, Ultra $200/mo at 20x. Teams $40/user/mo (Premium at 5x Standard). Enterprise is custom-priced with pooled usage and SCIM. Cursor renders only the selected tier's price in the page body; the full ladder is in the page's JSON-LD Offer list.",
       freeType: "limited",
       monthlyCostSolo: "$20",
       monthlyCostTeam5: "$200",
@@ -27242,14 +27242,14 @@ function buildAiCodingToolsPricingPage(): string {
       category: "ide",
       free: "2K completions/mo",
       pro: "$10/mo",
-      power: "$39/mo (Pro+)",
+      power: "$100/mo (Max)",
       teams: "$19/seat",
-      model: "Tier + premium requests",
-      freeDetails: "2,000 code completions/month, 50 premium requests/month. Pro ($10/mo): 300 premium requests. Pro+ ($39/mo): 1,500 premium requests, all AI models including Claude Opus 4 and o3. Business ($19/seat): 300 premium requests/user. Enterprise ($39/seat): 1,000/user. Overage: $0.04/premium request. Advanced reasoning models consume 5x–20x per interaction. Student plan (Mar 2026): premium models (GPT-5.4, Claude Opus/Sonnet) removed from self-selection — available only via Auto mode.",
+      model: "Tier + AI credits",
+      freeDetails: "2,000 code completions/month plus limited chat and agent usage, no credit card. On every paid plan, code completions and next edit suggestions are unlimited and do not consume credits — all other usage is metered in GitHub AI Credits at $0.01 per credit. Pro $10/mo: $15 of monthly credits (1,000 base + 500 flex). Pro+ $39/mo: $70 (3,900 + 3,100), adds premium models including Opus. Max $100/mo: $200 (10,000 + 10,000), 2.9x Pro+'s included usage. Business $19/seat: 1,900 credits/user. Enterprise $39/seat: 3,900/user. Student plan (Mar 2026): premium models available only via Auto mode.",
       freeType: "limited",
       monthlyCostSolo: "$10",
       monthlyCostTeam5: "$95",
-      hiddenCosts: "Premium request model means advanced models (Claude Opus 4, o3) burn requests 5x–20x faster. Free tier's 50 premium requests can exhaust in a few complex sessions. Overage at $0.04/request adds up — 100 extra requests = $4. Pro+ at $39/mo required for full model access and 1,500 premium requests. Student plan (Mar 2026): premium model self-selection removed — GPT-5.4, Claude Opus, Sonnet only via Auto mode.",
+      hiddenCosts: "Agent and chat usage is metered — an AI credit is $0.01, and Pro's $15 monthly allowance drains faster on premium models. Code completions and next edit suggestions are exempt and unlimited on every paid plan. Premium requests, their 5x–20x model multipliers and the $0.04 per-request overage are retired; GitHub's own billing docs label that model legacy. Reaching the full model lineup still means Pro+ at $39/mo. Student plan (Mar 2026): premium model self-selection removed — GPT-5.4, Claude Opus, Sonnet only via Auto mode.",
     },
     {
       name: "Gemini Code Assist",
@@ -27515,7 +27515,7 @@ function buildAiCodingToolsPricingPage(): string {
       '<td style="font-weight:600"><a href="/vendor/' + escHtmlServer(t.slug) + '" style="color:var(--text)">' + escHtmlServer(t.name) + '</a></td>' +
       '<td style="font-family:var(--mono);font-size:.85rem">' + escHtmlServer(t.monthlyCostSolo) + '</td>' +
       '<td style="font-family:var(--mono);font-size:.85rem">' + escHtmlServer(t.monthlyCostTeam5) + '</td>' +
-      '<td style="font-size:.85rem;color:var(--text-muted)">' + escHtmlServer(t.hiddenCosts.substring(0, 80)) + (t.hiddenCosts.length > 80 ? "..." : "") + '</td>' +
+      '<td style="font-size:.85rem;color:var(--text-muted)">' + escHtmlServer(t.hiddenCosts) + '</td>' +
       '</tr>';
   }).join("\n        ");
 
@@ -27555,8 +27555,8 @@ function buildAiCodingToolsPricingPage(): string {
 
   const faqEntries = [
     { q: "What is the best free AI coding tool in 2026?", a: "Gemini Code Assist offers the most generous free tier with 6,000 completions/day (180,000/month) and 240 chat messages/day. For open-source alternatives, Cline and Aider are fully free with BYO API keys. Gemini CLI offers 1,000 free requests/day. Amazon Kiro offers 50 free credits/month — limited, but enough to try spec-driven development." },
-    { q: "How much does Cursor cost vs Windsurf?", a: "Both start at $20/month for an individual paid plan and $40/user/month for teams. Cursor's free plan is called Hobby. Above Pro at $20/mo, Cursor lists Pro+ at 3x Pro's Agent limits and Ultra at 20x, with Enterprise custom-priced. Windsurf has 4 plans (Free, Pro $20, Teams $40/seat, Max $200) and raised Pro from $15 to $20 in March 2026. Windsurf's SWE-1.5 Fast Agent model optimizes for iteration speed." },
-    { q: "Is GitHub Copilot still the cheapest AI coding tool?", a: "Yes, GitHub Copilot Pro at $10/month is the cheapest paid AI coding subscription. It also offers a free tier with 2,000 completions/month and 50 premium requests/month. Pro includes 300 premium requests. Overage costs $0.04/request. Note: advanced reasoning models (Claude Opus 4, o3) consume 5x\u201320x premium requests per interaction." },
+    { q: "How much does Cursor cost vs Windsurf?", a: "Both start at $20/month for an individual paid plan and $40/user/month for teams, and both top out at $200/month — Cursor Ultra and Windsurf Max. Cursor's free plan is called Hobby. Between them sits Pro+ at $60/mo with 3x Pro's Agent limits; Ultra is 20x. Windsurf has 4 plans (Free, Pro $20, Teams $40/seat, Max $200) and raised Pro from $15 to $20 in March 2026. Windsurf's SWE-1.5 Fast Agent model optimizes for iteration speed." },
+    { q: "Is GitHub Copilot still the cheapest AI coding tool?", a: "Yes \u2014 Copilot Pro at $10/month is the cheapest paid plan among the tools compared here. The free tier gives 2,000 code completions a month plus limited chat and agent use. On paid plans, completions and next edit suggestions are unlimited and consume nothing; agent and chat work is metered in GitHub AI Credits at $0.01 each \u2014 $15 of credits on Pro, $70 on Pro+ ($39/mo), $200 on Max ($100/mo). GitHub's premium-request billing and its $0.04 overage are retired; the docs now label that model legacy." },
     { q: "What are the hidden costs of BYO-key AI coding tools?", a: "Tools like Cline and Aider are free to install but require API keys. Typical costs: $5-50/month for moderate use with Claude Sonnet or GPT-4o. Heavy agentic usage (Cline with Opus) can reach $50-100/month in API costs alone." },
     { q: "Which AI coding tool is best for teams?", a: "GitHub Copilot Business ($19/seat) is cheapest for teams. Gemini Code Assist Enterprise matches at $19/seat with Google Cloud integration. Cursor and Windsurf Business ($40/seat) offer the highest AI throughput per developer." },
     { q: "Are AI app builders like Bolt.new and Lovable worth it?", a: "For prototyping and MVPs, yes. Bolt.new offers 1M free tokens/month and Lovable gives 5 daily credits. Both generate full-stack apps from natural language. They are not designed for production-grade software development." },

--- a/test/copilot-billing-unit.test.ts
+++ b/test/copilot-billing-unit.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, before, after } from "node:test";
+import assert from "node:assert";
+import { spawn, type ChildProcess } from "node:child_process";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO = path.join(__dirname, "..");
+
+const AI_CODING_PAGES = ["/ai-coding-pricing-2026", "/ai-coding-tools-pricing"];
+const PREMIUM_REQUEST_QUANTITY = /\b\d[\d,]*\s+premium[ -]requests?\b/gi;
+
+let serverPort = 0;
+let proc: ChildProcess | null = null;
+
+function startServer(): Promise<ChildProcess> {
+  return new Promise((resolve, reject) => {
+    const child = spawn("node", [path.join(REPO, "dist", "serve.js")], {
+      stdio: ["pipe", "pipe", "pipe"],
+      env: { ...process.env, PORT: "0", BASE_URL: "http://localhost" },
+    });
+    const timeout = setTimeout(() => { child.kill(); reject(new Error("Server startup timeout")); }, 20000);
+    child.stderr!.on("data", (data: Buffer) => {
+      const m = data.toString().match(/running on http:\/\/localhost:(\d+)/);
+      if (m) { serverPort = parseInt(m[1], 10); clearTimeout(timeout); resolve(child); }
+    });
+    child.on("error", (err) => { clearTimeout(timeout); reject(err); });
+  });
+}
+
+const get = async (p: string) => (await fetch(`http://localhost:${serverPort}${p}`)).text();
+
+const rowsOf = (body: string) => body.match(/<tr[^>]*>[\s\S]*?<\/tr>/g) ?? [];
+const isChangeRow = (row: string) => /<td[^>]*>[A-Z][a-z]{2} \d{1,2}, \d{4}<\/td>/.test(row);
+const withoutChangeRows = (body: string) =>
+  rowsOf(body).filter(isChangeRow).reduce((rest, row) => rest.replace(row, ""), body);
+
+const sentencesOf = (body: string) =>
+  body.replace(/<[^>]*>/g, "\n").split(/(?<=[.;!?])\s+|\n+/).map(s => s.trim()).filter(Boolean);
+
+describe("GitHub Copilot is priced in the unit GitHub bills in", () => {
+  it("states no premium-request quantity in any page literal", () => {
+    const source = readFileSync(path.join(REPO, "src", "serve.ts"), "utf-8");
+    assert.deepStrictEqual(source.match(PREMIUM_REQUEST_QUANTITY) ?? [], []);
+  });
+
+  it("holds a catalogue record for Copilot Free that states its allowance in AI credits", () => {
+    const offers: Array<{ vendor: string; tier: string; description: string }> = JSON.parse(
+      readFileSync(path.join(REPO, "data", "index.json"), "utf-8")
+    ).offers;
+    const free = offers.find(o => o.vendor === "GitHub Copilot" && o.tier === "Free");
+    assert.ok(free, "the catalogue holds GitHub Copilot's free tier");
+    assert.match(free!.description, /AI Credits/i);
+    assert.doesNotMatch(free!.description, PREMIUM_REQUEST_QUANTITY);
+  });
+});
+
+describe("the AI coding pages carry Copilot's current plan ladder", () => {
+  before(async () => { proc = await startServer(); });
+  after(() => { proc?.kill(); });
+
+  it("names Max as the top individual plan on both pages", async () => {
+    for (const page of AI_CODING_PAGES) {
+      assert.match(await get(page), /\$100\/mo \(Max\)/, `${page} omits Copilot Max`);
+    }
+  });
+
+  it("names the AI-credit unit and its price on both pages", async () => {
+    for (const page of AI_CODING_PAGES) {
+      const body = await get(page);
+      assert.match(body, /AI Credits at \$0\.01/i, `${page} states no price for an AI credit`);
+      assert.doesNotMatch(body, /Tier \+ premium requests/i, `${page} bills Copilot in the retired unit`);
+    }
+  });
+
+  it("states the retired unit only as retired, outside the change log", async () => {
+    for (const page of AI_CODING_PAGES) {
+      const currentFacts = withoutChangeRows(await get(page));
+      const stated = sentencesOf(currentFacts)
+        .filter(s => /premium[ -]requests?/i.test(s))
+        .filter(s => !/retired|legacy/i.test(s))
+        .filter(s => !/\bno\b[^.]*premium[ -]request/i.test(s));
+      assert.deepStrictEqual(stated, [], `${page} states the premium-request unit as a current fact`);
+    }
+  });
+
+  it("shows the whole hidden-cost note, not a truncation of it", async () => {
+    const body = await get("/ai-coding-tools-pricing");
+    assert.doesNotMatch(body, /monthly a\.\.\./, "the hidden-cost cell is cut mid-word");
+    assert.match(body, /the \$0\.04 per-request overage are retired/, "the hidden-cost cell stops before the correction");
+  });
+
+  it("prices Cursor's paid ladder at the figures its pricing page publishes", async () => {
+    for (const page of AI_CODING_PAGES) {
+      const body = await get(page);
+      assert.match(body, /\$200\/mo \(Ultra\)/, `${page} omits Cursor Ultra's price`);
+      assert.match(body, /Pro\+ \$60\/mo/, `${page} omits Cursor Pro\\+'s price`);
+    }
+  });
+});


### PR DESCRIPTION
Applies the strings supplied on https://github.com/robhunter/agentdeals/issues/1067, at the lines named there. Refs #1067.

## Cursor — the two prices restored

`serve.ts:26799`, `27200` — `power: "Pro+ / Ultra"` → `"$200/mo (Ultra)"`. `26802`, `27203` — both `freeDetails`, now stating Pro $20, Pro+ $60 at 3x, Ultra $200 at 20x, and that the full ladder is in the page's JSON-LD. `27558` — the Cursor-vs-Windsurf FAQ answer, the string I had recombined, replaced verbatim.

The `/ai-coding-pricing-2026` convergence copy and the `$200/mo Power Tier` stat card are untouched, as asked.

## GitHub Copilot — priced in the unit GitHub bills in

`26819`, `27245` — `power: "$39/mo (Pro+)"` → `"$100/mo (Max)"`. `26821`, `27247` — `model: "Tier + premium requests"` → `"Tier + AI credits"`. `26822`, `27248` — both `freeDetails`. `27252` — `hiddenCosts`. `27559` — the cost FAQ answer.

## Two things found while verifying

**`/free-ai-stack` recommended Copilot on the retired unit.** `serve.ts:14369` read *"2,000 completions/month + 50 premium requests free"* — after the strings above, the only page literal left stating an allowance in premium requests, and one our own catalogue record contradicts: the record states the free tier's allowance in AI credits. On `main` the phrase `<digits> premium requests` appears 12 times in `serve.ts`; the supplied strings clear 11 and this was the twelfth. Deleted rather than rewritten.

**The hidden-cost column truncated the correction away.** `serve.ts:27518` rendered `t.hiddenCosts.substring(0, 80)`, so 16 of 17 rows on `/ai-coding-tools-pricing` ended mid-word. Copilot's read *"Agent and chat usage is metered — an AI credit is $0.01, and Pro's $15 monthly a..."* — the sentence saying premium requests and the $0.04 overage are retired begins at character 200 and never reached a reader. That cell now renders in full.

The same `substring(0, 80)` is at `serve.ts:28278`, `29162` and `30533` on three other pages. Not touched here — say if you want them.

## Tests

`test/copilot-billing-unit.test.ts`, 7 assertions: both pages name Max and price an AI credit; the catalogue record for Copilot Free states its allowance in credits and no premium-request quantity; no page literal states a premium-request quantity; outside the change log, no sentence states the unit without saying it is retired or legacy; the hidden-cost cell is not truncated; Cursor's Pro+ and Ultra prices are on both pages.

Change-log rows are excluded from the sentence rule on purpose — `deal_changes.json:120` records the day GitHub introduced premium-request billing, which is history and should stay as written.

## Measured and not shipped

I tried to make the underlying defect mechanical: *a page must not price a named tier differently from the catalogue record for the same vendor.* `scripts/census-1067-tier-prices.mjs` parses every object literal in `serve.ts` carrying a `slug` — 556 of them, 396 resolving to a catalogue vendor — and compares tier-name/price pairs against the record.

The naive adjacency window flags 4 pairs and all 4 are artifacts: `Pro $10/mo: $15 of credits` reads $15 as Pro's price; `$20/month on Standard and $100/month on Business` crosses the conjunction; `Basic` is an App Platform plan on the page and a Droplet size in the record; Codex's `Pro` is ChatGPT Pro on the page and something else in the record. Tightened to require the price adjacent to the tier name, it flags 0 of 41 comparable pairs.

**It would not have caught the defect it was designed for.** Run against the withdrawn Cursor string, the disagreement rule fires on nothing: the catalogue never priced Hobby at all, so there was no disagreement to find — the page over-specified where the record was silent. The variant that does fire on it — *page prices a tier the record names but never prices* — returns 9 pairs today and all 9 are the same class of artifact (`Scale` is a Neon plan and an estimator bucket; `Free` matches `"No free tier — $200 in expiring AWS credits"`).

A gate that flags nothing today and would have missed this defect is not worth the build time, so it is a script and not a test.

## Verification

3,244 tests, 7 new, 0 red. `tsc` and `npm run validate` clean — 1,580 offers, 493 deal changes. `stale-page-facts` unchanged at 57 pages and 216 pairs.

14 mutations, 13 killed. The survivor is honest: dropping the credit price from `/ai-coding-tools-pricing`'s Copilot card leaves the page still stating it in the FAQ answer, and the assertion is a page-level claim.

2,577 paths swept against a worktree of `main`: 2,574 byte-identical, 3 moved — `/ai-coding-pricing-2026`, `/ai-coding-tools-pricing`, `/free-ai-stack` — 0 added, 0 removed. Both pages screenshotted.
