### PR TITLE
Read the prices a page states in its markup (#1279)

### DIFF
--- a/data/index.json
+++ b/data/index.json
@@ -749,9 +749,12 @@
         "notes": "Referee must run M10+ cluster for 30+ days. Not valid for existing MongoDB users."
       },
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-03",
         "outcome": "ok",
-        "detail": "text"
+        "detail": "text",
+        "unrendered_prices": [
+          "Dedicated Clusters USD 57"
+        ]
       },
       "product_subtypes": {
         "taxonomy": "Databases",
@@ -813,9 +816,14 @@
       ],
       "verifiedDate": "2026-08-11",
       "source_check": {
-        "checked": "2026-09-01",
+        "checked": "2026-09-03",
         "outcome": "ok",
-        "detail": "text"
+        "detail": "text",
+        "unrendered_prices": [
+          "Developer USD 5.99",
+          "Scaler USD 29",
+          "Pro USD 499"
+        ]
       },
       "product_subtypes": {
         "taxonomy": "Databases",
@@ -1361,9 +1369,14 @@
         "notes": "No affiliate/referral program for Sentry.io error monitoring. Sponsored account program available for open source."
       },
       "source_check": {
-        "checked": "2026-09-01",
+        "checked": "2026-09-03",
         "outcome": "ok",
-        "detail": "text"
+        "detail": "text",
+        "unrendered_prices": [
+          "Business Annual Subscription USD 960.00",
+          "Business Monthly Subscription USD 89",
+          "Team Monthly Subscription USD 29"
+        ]
       },
       "product_subtypes": {
         "taxonomy": "Monitoring",
@@ -1900,9 +1913,17 @@
         "commission_type": "one-time"
       },
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-03",
         "outcome": "ok",
-        "detail": "text"
+        "detail": "text",
+        "unrendered_prices": [
+          "Starter USD 9",
+          "Standard USD 18",
+          "Professional USD 499",
+          "Starter USD 96.96",
+          "Standard USD 194.04",
+          "Professional USD 5388.96"
+        ]
       }
     },
     {
@@ -2242,9 +2263,12 @@
       ],
       "verifiedDate": "2026-07-24",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-03",
         "outcome": "ok",
-        "detail": "text"
+        "detail": "text",
+        "unrendered_prices": [
+          "Monthly Active Users USD 0.05"
+        ]
       }
     },
     {
@@ -2346,9 +2370,13 @@
         "notes": "No referral or affiliate program. Community has requested it but not available."
       },
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-03",
         "outcome": "ok",
-        "detail": "text"
+        "detail": "text",
+        "unrendered_prices": [
+          "Pro+ USD 60",
+          "Ultra USD 200"
+        ]
       }
     },
     {
@@ -2647,9 +2675,10 @@
       ],
       "verifiedDate": "2026-07-24",
       "source_check": {
-        "checked": "2026-09-02",
-        "outcome": "states_no_amount",
-        "detail": "the page names Harness Feature Flags and says \"free tier\" but states no amount, rate or price we can read"
+        "checked": "2026-09-03",
+        "outcome": "ok",
+        "detail": "the page names Harness Feature Flags, renders \"free tier\" and no amount, and its markup states 1 typed price (Free Plan USD 0)",
+        "read": "markup"
       }
     },
     {
@@ -4417,9 +4446,10 @@
         "reviewed": "2026-08-25"
       },
       "source_check": {
-        "checked": "2026-09-02",
-        "outcome": "states_no_terms",
-        "detail": "the page names MinIO but states no amount, tier or rate we can read"
+        "checked": "2026-09-03",
+        "outcome": "ok",
+        "detail": "the page names MinIO, renders no terms we can read, and its markup states 1 typed price (AIStor Free USD 0)",
+        "read": "markup"
       }
     },
     {
@@ -5505,9 +5535,15 @@
       ],
       "verifiedDate": "2026-08-26",
       "source_check": {
-        "checked": "2026-09-02",
-        "outcome": "states_no_amount",
-        "detail": "the page names Crowdin and says \"Team plan\" but states no amount, rate or price we can read"
+        "checked": "2026-09-03",
+        "outcome": "ok",
+        "detail": "the page names Crowdin, renders \"Team plan\" and no amount, and its markup states 4 typed prices (Free Plan USD 0.00, Pro USD 50.00, Team USD 150.00, +1 more)",
+        "read": "markup",
+        "unrendered_prices": [
+          "Pro USD 50.00",
+          "Team USD 150.00",
+          "Team+ USD 450.00"
+        ]
       }
     },
     {
@@ -5670,9 +5706,13 @@
       ],
       "verifiedDate": "2026-07-27",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-03",
         "outcome": "ok",
-        "detail": "text"
+        "detail": "text",
+        "unrendered_prices": [
+          "Pro USD 100",
+          "Scale USD 500"
+        ]
       }
     },
     {
@@ -5881,9 +5921,10 @@
       ],
       "verifiedDate": "2026-07-27",
       "source_check": {
-        "checked": "2026-09-02",
-        "outcome": "states_no_amount",
-        "detail": "the page names JotForm and says \"Enterprise plan\" but states no amount, rate or price we can read"
+        "checked": "2026-09-03",
+        "outcome": "ok",
+        "detail": "the page names JotForm, renders \"Enterprise plan\" and no amount, and its markup states 1 typed price (USD 0.00)",
+        "read": "markup"
       }
     },
     {
@@ -5919,9 +5960,13 @@
       ],
       "verifiedDate": "2026-08-21",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-03",
         "outcome": "ok",
-        "detail": "text"
+        "detail": "text",
+        "unrendered_prices": [
+          "IPinfo Core USD 31",
+          "IPinfo Max USD 196"
+        ]
       }
     },
     {
@@ -5938,9 +5983,10 @@
       ],
       "verifiedDate": "2026-07-26",
       "source_check": {
-        "checked": "2026-09-02",
-        "outcome": "states_no_terms",
-        "detail": "the page names Meilisearch but states no amount, tier or rate we can read"
+        "checked": "2026-09-03",
+        "outcome": "ok",
+        "detail": "the page names Meilisearch, renders no terms we can read, and its markup states 1 typed price (USD 0)",
+        "read": "markup"
       }
     },
     {
@@ -7162,9 +7208,12 @@
       ],
       "verifiedDate": "2026-08-28",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-03",
         "outcome": "ok",
-        "detail": "text"
+        "detail": "text",
+        "unrendered_prices": [
+          "Hobbyist (annual) USD 96"
+        ]
       }
     },
     {
@@ -7681,9 +7730,12 @@
       ],
       "verifiedDate": "2026-07-05",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-03",
         "outcome": "ok",
-        "detail": "text"
+        "detail": "text",
+        "unrendered_prices": [
+          "USD 69.00"
+        ]
       },
       "product_subtypes": {
         "taxonomy": "Monitoring",
@@ -7841,9 +7893,13 @@
       ],
       "verifiedDate": "2026-08-23",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-03",
         "outcome": "ok",
-        "detail": "text"
+        "detail": "text",
+        "unrendered_prices": [
+          "Growth Annual USD 499.99",
+          "Professional Annual USD 999.99"
+        ]
       }
     },
     {
@@ -9246,9 +9302,10 @@
       ],
       "verifiedDate": "2026-07-05",
       "source_check": {
-        "checked": "2026-09-02",
-        "outcome": "states_no_amount",
-        "detail": "the page names Harness CI and says \"free tier\" but states no amount, rate or price we can read"
+        "checked": "2026-09-03",
+        "outcome": "ok",
+        "detail": "the page names Harness CI, renders \"free tier\" and no amount, and its markup states 1 typed price (Free Plan USD 0)",
+        "read": "markup"
       }
     },
     {
@@ -9418,9 +9475,14 @@
       ],
       "verifiedDate": "2026-08-26",
       "source_check": {
-        "checked": "2026-09-02",
-        "outcome": "states_no_amount",
-        "detail": "the page names Zoho Notebook and says \"free plan\" but states no amount, rate or price we can read"
+        "checked": "2026-09-03",
+        "outcome": "ok",
+        "detail": "the page names Zoho Notebook, renders \"free plan\" and no amount, and its markup states 3 typed prices (Notebook Essential INR 0, Notebook Pro INR 83.25, Notebook for Business INR 333.25)",
+        "read": "markup",
+        "unrendered_prices": [
+          "Notebook Pro INR 83.25",
+          "Notebook for Business INR 333.25"
+        ]
       }
     },
     {
@@ -9558,9 +9620,10 @@
       ],
       "verifiedDate": "2026-08-01",
       "source_check": {
-        "checked": "2026-09-02",
-        "outcome": "states_no_amount",
-        "detail": "the page names Zoho Survey and says \"free version\" but states no amount, rate or price we can read"
+        "checked": "2026-09-03",
+        "outcome": "ok",
+        "detail": "the page names Zoho Survey, renders \"free version\" and no amount, and its markup states 1 typed price (INR 0)",
+        "read": "markup"
       }
     },
     {
@@ -9576,9 +9639,10 @@
       ],
       "verifiedDate": "2026-07-30",
       "source_check": {
-        "checked": "2026-09-02",
-        "outcome": "states_no_amount",
-        "detail": "the page names Zoho Bookings and says \"free plan\" but states no amount, rate or price we can read"
+        "checked": "2026-09-03",
+        "outcome": "ok",
+        "detail": "the page names Zoho Bookings, renders \"free plan\" and no amount, and its markup states 1 typed price (Free plan up to 1 service USD 0)",
+        "read": "markup"
       }
     },
     {
@@ -9616,9 +9680,10 @@
       ],
       "verifiedDate": "2026-08-01",
       "source_check": {
-        "checked": "2026-09-02",
-        "outcome": "states_no_amount",
-        "detail": "the page names Brainboard and says \"free tier\" but states no amount, rate or price we can read"
+        "checked": "2026-09-03",
+        "outcome": "ok",
+        "detail": "the page names Brainboard, renders \"free tier\" and no amount, and its markup states 1 typed price (USD 0)",
+        "read": "markup"
       }
     },
     {
@@ -9654,9 +9719,10 @@
       ],
       "verifiedDate": "2026-08-02",
       "source_check": {
-        "checked": "2026-09-02",
-        "outcome": "states_no_terms",
-        "detail": "the page names deployment.io but states no amount, tier or rate we can read"
+        "checked": "2026-09-03",
+        "outcome": "ok",
+        "detail": "the page names deployment.io, renders no terms we can read, and its markup states 1 typed price (USD 0)",
+        "read": "markup"
       }
     },
     {
@@ -9950,9 +10016,13 @@
       ],
       "verifiedDate": "2026-07-30",
       "source_check": {
-        "checked": "2026-09-02",
+        "checked": "2026-09-03",
         "outcome": "ok",
-        "detail": "text"
+        "detail": "text",
+        "unrendered_prices": [
+          "Personal Plan USD 19",
+          "Professional Plan USD 69"
+        ]
       }
     },
     {
@@ -10242,9 +10312,10 @@
       ],
       "verifiedDate": "2026-08-03",
       "source_check": {
-        "checked": "2026-09-02",
-        "outcome": "states_no_terms",
-        "detail": "the page names Data Fetcher but states no amount, tier or rate we can read"
+        "checked": "2026-09-03",
+        "outcome": "ok",
+        "detail": "the page names Data Fetcher, renders no terms we can read, and its markup states 1 typed price (Free USD 0)",
+        "read": "markup"
       }
     },
     {
@@ -10276,9 +10347,10 @@
       ],
       "verifiedDate": "2026-08-22",
       "source_check": {
-        "checked": "2026-09-02",
-        "outcome": "states_no_terms",
-        "detail": "the page names Dataimporter.io but states no amount, tier or rate we can read"
+        "checked": "2026-09-03",
+        "outcome": "ok",
+        "detail": "the page names Dataimporter.io, renders no terms we can read, and its markup states 1 typed price (USD 0)",
+        "read": "markup"
       }
     },
     {
@@ -10502,9 +10574,10 @@
       ],
       "verifiedDate": "2026-08-02",
       "source_check": {
-        "checked": "2026-09-02",
-        "outcome": "states_no_terms",
-        "detail": "the page names ExtendsClass but states no amount, tier or rate we can read"
+        "checked": "2026-09-03",
+        "outcome": "ok",
+        "detail": "the page names ExtendsClass, renders no terms we can read, and its markup states 1 typed price (0)",
+        "read": "markup"
       }
     },
     {
@@ -10536,9 +10609,10 @@
       ],
       "verifiedDate": "2026-07-08",
       "source_check": {
-        "checked": "2026-09-02",
-        "outcome": "states_no_terms",
-        "detail": "the page names FormatJSONOnline.com but states no amount, tier or rate we can read"
+        "checked": "2026-09-03",
+        "outcome": "ok",
+        "detail": "the page names FormatJSONOnline.com, renders no terms we can read, and its markup states 1 typed price (USD 0)",
+        "read": "markup"
       }
     },
     {
@@ -11078,9 +11152,10 @@
       ],
       "verifiedDate": "2026-08-27",
       "source_check": {
-        "checked": "2026-09-02",
-        "outcome": "states_no_amount",
-        "detail": "the page names Mockfly and says \"free plan\" but states no amount, rate or price we can read"
+        "checked": "2026-09-03",
+        "outcome": "ok",
+        "detail": "the page names Mockfly, renders \"free plan\" and no amount, and its markup states 1 typed price (USD 0)",
+        "read": "markup"
       }
     },
     {
@@ -11335,9 +11410,10 @@
       ],
       "verifiedDate": "2026-08-02",
       "source_check": {
-        "checked": "2026-09-02",
-        "outcome": "states_no_amount",
-        "detail": "the page names PrefectCloud and says \"Hobby tier\" but states no amount, rate or price we can read"
+        "checked": "2026-09-03",
+        "outcome": "ok",
+        "detail": "the page names PrefectCloud, renders \"Hobby tier\" and no amount, and its markup states 3 typed prices (Hobby USD 0, Starter USD 100, Team USD 100)",
+        "read": "markup"
       }
     },
     {
@@ -11352,9 +11428,10 @@
       ],
       "verifiedDate": "2026-08-04",
       "source_check": {
-        "checked": "2026-09-02",
-        "outcome": "states_no_terms",
-        "detail": "the page names Preset Cloud but states no amount, tier or rate we can read"
+        "checked": "2026-09-03",
+        "outcome": "ok",
+        "detail": "the page names Preset Cloud, renders no terms we can read, and its markup states 1 typed price (Starter Plan USD 0)",
+        "read": "markup"
       }
     },
     {
@@ -11395,9 +11472,10 @@
         }
       ],
       "source_check": {
-        "checked": "2026-09-02",
-        "outcome": "states_no_amount",
-        "detail": "the page names Reducto and says \"Standard tier\" but states no amount, rate or price we can read"
+        "checked": "2026-09-03",
+        "outcome": "ok",
+        "detail": "the page names Reducto, renders \"Standard tier\" and no amount, and its markup states 1 typed price (USD 0)",
+        "read": "markup"
       },
       "product_subtypes": {
         "taxonomy": "AI / ML",
@@ -12190,9 +12268,10 @@
       ],
       "verifiedDate": "2026-07-09",
       "source_check": {
-        "checked": "2026-09-02",
-        "outcome": "states_no_terms",
-        "detail": "the page names Fibo but states no amount, tier or rate we can read"
+        "checked": "2026-09-03",
+        "outcome": "ok",
+        "detail": "the page names Fibo, renders no terms we can read, and its markup states 1 typed price (EUR 0)",
+        "read": "markup"
       }
     },
     {
@@ -12762,9 +12841,10 @@
       ],
       "verifiedDate": "2026-08-04",
       "source_check": {
-        "checked": "2026-09-02",
-        "outcome": "states_no_amount",
-        "detail": "the page names Tencent RTC and says \"Starter Plan\" but states no amount, rate or price we can read"
+        "checked": "2026-09-03",
+        "outcome": "ok",
+        "detail": "the page names Tencent RTC, renders \"Starter Plan\" and no amount, and its markup states 1 typed price (USD 0)",
+        "read": "markup"
       }
     },
     {
@@ -13053,9 +13133,10 @@
       ],
       "verifiedDate": "2026-08-14",
       "source_check": {
-        "checked": "2026-09-02",
-        "outcome": "states_no_amount",
-        "detail": "the page names Cosmic and says \"Free forever\" but states no amount, rate or price we can read"
+        "checked": "2026-09-03",
+        "outcome": "ok",
+        "detail": "the page names Cosmic, renders \"Free forever\" and no amount, and its markup states 1 typed price (USD 0)",
+        "read": "markup"
       }
     },
     {
@@ -13110,9 +13191,10 @@
       ],
       "verifiedDate": "2026-08-02",
       "source_check": {
-        "checked": "2026-09-02",
-        "outcome": "states_no_terms",
-        "detail": "the page names Prismic but states no amount, tier or rate we can read"
+        "checked": "2026-09-03",
+        "outcome": "ok",
+        "detail": "the page names Prismic, renders no terms we can read, and its markup states 1 typed price (0)",
+        "read": "markup"
       }
     },
     {
@@ -13341,9 +13423,10 @@
       ],
       "verifiedDate": "2026-08-13",
       "source_check": {
-        "checked": "2026-09-02",
-        "outcome": "states_no_terms",
-        "detail": "the page names codacy.com but states no amount, tier or rate we can read"
+        "checked": "2026-09-03",
+        "outcome": "ok",
+        "detail": "the page names codacy.com, renders no terms we can read, and its markup states 1 typed price (USD 0)",
+        "read": "markup"
       }
     },
     {
@@ -13753,9 +13836,10 @@
       ],
       "verifiedDate": "2026-07-10",
       "source_check": {
-        "checked": "2026-09-02",
-        "outcome": "states_no_terms",
-        "detail": "the page names bytebase.com but states no amount, tier or rate we can read"
+        "checked": "2026-09-03",
+        "outcome": "ok",
+        "detail": "the page names bytebase.com, renders no terms we can read, and its markup states 1 typed price (USD 0)",
+        "read": "markup"
       }
     },
     {
@@ -13810,9 +13894,17 @@
       ],
       "verifiedDate": "2026-07-09",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-03",
         "outcome": "ok",
-        "detail": "text"
+        "detail": "text",
+        "unrendered_prices": [
+          "USD 21",
+          "EUR 21",
+          "GBP 21",
+          "USD 43",
+          "EUR 43",
+          "GBP 43"
+        ]
       }
     },
     {
@@ -13829,9 +13921,10 @@
       ],
       "verifiedDate": "2026-07-08",
       "source_check": {
-        "checked": "2026-09-02",
-        "outcome": "states_no_amount",
-        "detail": "the page names LocalOps and says \"Free tier\" but states no amount, rate or price we can read"
+        "checked": "2026-09-03",
+        "outcome": "ok",
+        "detail": "the page names LocalOps, renders \"Free tier\" and no amount, and its markup states 1 typed price (USD 0)",
+        "read": "markup"
       }
     },
     {
@@ -13905,9 +13998,10 @@
       ],
       "verifiedDate": "2026-07-10",
       "source_check": {
-        "checked": "2026-09-02",
-        "outcome": "states_no_terms",
-        "detail": "the page names Shipfox but states no amount, tier or rate we can read"
+        "checked": "2026-09-03",
+        "outcome": "ok",
+        "detail": "the page names Shipfox, renders no terms we can read, and its markup states 1 typed price (USD 0)",
+        "read": "markup"
       }
     },
     {
@@ -14169,9 +14263,10 @@
       ],
       "verifiedDate": "2026-08-05",
       "source_check": {
-        "checked": "2026-09-02",
-        "outcome": "states_no_terms",
-        "detail": "the page names loadmill.com but states no amount, tier or rate we can read"
+        "checked": "2026-09-03",
+        "outcome": "ok",
+        "detail": "the page names loadmill.com, renders no terms we can read, and its markup states 1 typed price (USD 0)",
+        "read": "markup"
       }
     },
     {
@@ -14814,9 +14909,10 @@
       ],
       "verifiedDate": "2026-07-11",
       "source_check": {
-        "checked": "2026-09-02",
-        "outcome": "states_no_terms",
-        "detail": "the page names 360username but states no amount, tier or rate we can read"
+        "checked": "2026-09-03",
+        "outcome": "ok",
+        "detail": "the page names 360username, renders no terms we can read, and its markup states 1 typed price (USD 0)",
+        "read": "markup"
       }
     },
     {
@@ -14947,9 +15043,10 @@
       ],
       "verifiedDate": "2026-07-07",
       "source_check": {
-        "checked": "2026-09-02",
-        "outcome": "states_no_terms",
-        "detail": "the page names Cloud-IAM but states no amount, tier or rate we can read"
+        "checked": "2026-09-03",
+        "outcome": "ok",
+        "detail": "the page names Cloud-IAM, renders no terms we can read, and its markup states 1 typed price (EUR 0)",
+        "read": "markup"
       }
     },
     {
@@ -15176,9 +15273,10 @@
       ],
       "verifiedDate": "2026-08-04",
       "source_check": {
-        "checked": "2026-09-02",
-        "outcome": "states_no_terms",
-        "detail": "the page names Diawi but states no amount, tier or rate we can read"
+        "checked": "2026-09-03",
+        "outcome": "ok",
+        "detail": "the page names Diawi, renders no terms we can read, and its markup states 1 typed price (USD 0)",
+        "read": "markup"
       }
     },
     {
@@ -15507,9 +15605,13 @@
       ],
       "verifiedDate": "2026-08-30",
       "source_check": {
-        "checked": "2026-09-01",
+        "checked": "2026-09-03",
         "outcome": "ok",
-        "detail": "text"
+        "detail": "text",
+        "unrendered_prices": [
+          "Medium USD 12",
+          "Large USD 25"
+        ]
       }
     },
     {
@@ -15561,9 +15663,10 @@
       ],
       "verifiedDate": "2026-08-08",
       "source_check": {
-        "checked": "2026-09-02",
-        "outcome": "states_no_terms",
-        "detail": "the page names SMSGate but states no amount, tier or rate we can read"
+        "checked": "2026-09-03",
+        "outcome": "ok",
+        "detail": "the page names SMSGate, renders no terms we can read, and its markup states 1 typed price (USD 0)",
+        "read": "markup"
       }
     },
     {
@@ -15912,9 +16015,13 @@
       ],
       "verifiedDate": "2026-08-27",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-03",
         "outcome": "ok",
-        "detail": "text"
+        "detail": "text",
+        "unrendered_prices": [
+          "Business Plan EUR 99.00",
+          "Team Plan EUR 35.00"
+        ]
       }
     },
     {
@@ -16010,9 +16117,13 @@
       ],
       "verifiedDate": "2026-07-11",
       "source_check": {
-        "checked": "2026-09-02",
-        "outcome": "states_no_amount",
-        "detail": "the page names bleemeo.com and says \"enterprise tier\" but states no amount, rate or price we can read"
+        "checked": "2026-09-03",
+        "outcome": "ok",
+        "detail": "the page names bleemeo.com, renders \"enterprise tier\" and no amount, and its markup states 1 typed price (EUR 10.99)",
+        "read": "markup",
+        "unrendered_prices": [
+          "EUR 10.99"
+        ]
       },
       "product_subtypes": {
         "taxonomy": "Monitoring",
@@ -16125,9 +16236,10 @@
       ],
       "verifiedDate": "2026-07-12",
       "source_check": {
-        "checked": "2026-09-02",
-        "outcome": "states_no_terms",
-        "detail": "the page names economize.cloud but states no amount, tier or rate we can read"
+        "checked": "2026-09-03",
+        "outcome": "ok",
+        "detail": "the page names economize.cloud, renders no terms we can read, and its markup states 1 typed price (USD 0)",
+        "read": "markup"
       },
       "product_subtypes": {
         "taxonomy": "Monitoring",
@@ -16148,9 +16260,12 @@
       ],
       "verifiedDate": "2026-07-07",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-03",
         "outcome": "ok",
-        "detail": "text"
+        "detail": "text",
+        "unrendered_prices": [
+          "Pro EUR 49"
+        ]
       },
       "product_subtypes": {
         "taxonomy": "Monitoring",
@@ -16382,9 +16497,12 @@
       ],
       "verifiedDate": "2026-07-12",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-03",
         "outcome": "ok",
-        "detail": "text"
+        "detail": "text",
+        "unrendered_prices": [
+          "Ultimate USD 99"
+        ]
       },
       "product_subtypes": {
         "taxonomy": "Monitoring",
@@ -16875,9 +16993,10 @@
       ],
       "verifiedDate": "2026-07-11",
       "source_check": {
-        "checked": "2026-09-02",
-        "outcome": "states_no_terms",
-        "detail": "the page names Wachete but states no amount, tier or rate we can read"
+        "checked": "2026-09-03",
+        "outcome": "ok",
+        "detail": "the page names Wachete, renders no terms we can read, and its markup states 1 typed price (USD 0)",
+        "read": "markup"
       },
       "product_subtypes": {
         "taxonomy": "Monitoring",
@@ -17126,9 +17245,10 @@
       ],
       "verifiedDate": "2026-07-12",
       "source_check": {
-        "checked": "2026-09-02",
-        "outcome": "states_no_terms",
-        "detail": "the page names 10minutemail but states no amount, tier or rate we can read"
+        "checked": "2026-09-03",
+        "outcome": "ok",
+        "detail": "the page names 10minutemail, renders no terms we can read, and its markup states 1 typed price (USD 0)",
+        "read": "markup"
       }
     },
     {
@@ -17298,9 +17418,10 @@
       ],
       "verifiedDate": "2026-08-27",
       "source_check": {
-        "checked": "2026-09-02",
-        "outcome": "states_no_amount",
-        "detail": "the page names EmailJS and says \"free version\" but states no amount, rate or price we can read"
+        "checked": "2026-09-03",
+        "outcome": "ok",
+        "detail": "the page names EmailJS, renders \"free version\" and no amount, and its markup states 1 typed price (USD 0)",
+        "read": "markup"
       }
     },
     {
@@ -17366,9 +17487,10 @@
       ],
       "verifiedDate": "2026-07-12",
       "source_check": {
-        "checked": "2026-09-02",
-        "outcome": "states_no_terms",
-        "detail": "the page names EtherealMail but states no amount, tier or rate we can read"
+        "checked": "2026-09-03",
+        "outcome": "ok",
+        "detail": "the page names EtherealMail, renders no terms we can read, and its markup states 1 typed price (USD 0)",
+        "read": "markup"
       }
     },
     {
@@ -17774,9 +17896,10 @@
       ],
       "verifiedDate": "2026-07-12",
       "source_check": {
-        "checked": "2026-09-02",
-        "outcome": "states_no_terms",
-        "detail": "the page names temp-mail.io but states no amount, tier or rate we can read"
+        "checked": "2026-09-03",
+        "outcome": "ok",
+        "detail": "the page names temp-mail.io, renders no terms we can read, and its markup states 1 typed price (USD 0)",
+        "read": "markup"
       }
     },
     {
@@ -17982,9 +18105,10 @@
       ],
       "verifiedDate": "2026-08-06",
       "source_check": {
-        "checked": "2026-09-02",
-        "outcome": "states_no_amount",
-        "detail": "the page names FabForm and says \"premium plans\" but states no amount, rate or price we can read"
+        "checked": "2026-09-03",
+        "outcome": "ok",
+        "detail": "the page names FabForm, renders \"premium plans\" and no amount, and its markup states 1 typed price (USD 0)",
+        "read": "markup"
       }
     },
     {
@@ -18067,9 +18191,13 @@
       ],
       "verifiedDate": "2026-08-31",
       "source_check": {
-        "checked": "2026-09-02",
-        "outcome": "states_no_amount",
-        "detail": "the page names Formester.com and says \"Free Forever\" but states no amount, rate or price we can read"
+        "checked": "2026-09-03",
+        "outcome": "ok",
+        "detail": "the page names Formester.com, renders \"Free Forever\" and no amount, and its markup states 1 typed price (USD 13)",
+        "read": "markup",
+        "unrendered_prices": [
+          "USD 13"
+        ]
       }
     },
     {
@@ -18152,9 +18280,13 @@
       ],
       "verifiedDate": "2026-08-07",
       "source_check": {
-        "checked": "2026-09-02",
-        "outcome": "states_no_terms",
-        "detail": "the page names Formware.io but states no amount, tier or rate we can read"
+        "checked": "2026-09-03",
+        "outcome": "ok",
+        "detail": "the page names Formware.io, renders no terms we can read, and its markup states 2 typed prices (Free Plan USD 0, PRO Plan USD 29.99)",
+        "read": "markup",
+        "unrendered_prices": [
+          "PRO Plan USD 29.99"
+        ]
       }
     },
     {
@@ -18254,9 +18386,13 @@
       ],
       "verifiedDate": "2026-08-06",
       "source_check": {
-        "checked": "2026-09-01",
+        "checked": "2026-09-03",
         "outcome": "ok",
-        "detail": "text"
+        "detail": "text",
+        "unrendered_prices": [
+          "Pro Plan USD 9",
+          "Agency Plan USD 19"
+        ]
       }
     },
     {
@@ -19231,9 +19367,10 @@
       ],
       "verifiedDate": "2026-07-17",
       "source_check": {
-        "checked": "2026-09-02",
-        "outcome": "states_no_terms",
-        "detail": "the page names Choreo but states no amount, tier or rate we can read"
+        "checked": "2026-09-03",
+        "outcome": "ok",
+        "detail": "the page names Choreo, renders no terms we can read, and its markup states 1 typed price (USD 0.00)",
+        "read": "markup"
       },
       "product_subtypes": {
         "taxonomy": "Cloud Hosting",
@@ -19399,9 +19536,10 @@
       ],
       "verifiedDate": "2026-07-15",
       "source_check": {
-        "checked": "2026-09-02",
-        "outcome": "states_no_amount",
-        "detail": "the page names gigalixir.com and says \"free tier\" but states no amount, rate or price we can read"
+        "checked": "2026-09-03",
+        "outcome": "ok",
+        "detail": "the page names gigalixir.com, renders \"free tier\" and no amount, and its markup states 1 typed price (USD 0)",
+        "read": "markup"
       },
       "product_subtypes": {
         "taxonomy": "Cloud Hosting",
@@ -19691,9 +19829,10 @@
       ],
       "verifiedDate": "2026-07-17",
       "source_check": {
-        "checked": "2026-09-02",
-        "outcome": "states_no_terms",
-        "detail": "the page names IFTTT but states no amount, tier or rate we can read"
+        "checked": "2026-09-03",
+        "outcome": "ok",
+        "detail": "the page names IFTTT, renders no terms we can read, and its markup states 1 typed price (USD 0)",
+        "read": "markup"
       },
       "product_subtypes": {
         "taxonomy": "Cloud Hosting",
@@ -19891,9 +20030,13 @@
       ],
       "verifiedDate": "2026-07-05",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-03",
         "outcome": "ok",
-        "detail": "text"
+        "detail": "text",
+        "unrendered_prices": [
+          "Mendix Basic Plan USD 75.00",
+          "Mendix Standard Plan USD 998.00"
+        ]
       }
     },
     {
@@ -21075,9 +21218,10 @@
       ],
       "verifiedDate": "2026-07-16",
       "source_check": {
-        "checked": "2026-09-02",
-        "outcome": "states_no_amount",
-        "detail": "the page names StackBy and says \"Free Forever\" but states no amount, rate or price we can read"
+        "checked": "2026-09-03",
+        "outcome": "ok",
+        "detail": "the page names StackBy, renders \"Free Forever\" and no amount, and its markup states 1 typed price (USD 0)",
+        "read": "markup"
       },
       "product_subtypes": {
         "taxonomy": "Databases",
@@ -21216,9 +21360,12 @@
       ],
       "verifiedDate": "2026-08-28",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-03",
         "outcome": "ok",
-        "detail": "text"
+        "detail": "text",
+        "unrendered_prices": [
+          "USD 30"
+        ]
       }
     },
     {
@@ -21726,9 +21873,10 @@
       ],
       "verifiedDate": "2026-08-11",
       "source_check": {
-        "checked": "2026-09-02",
-        "outcome": "states_no_terms",
-        "detail": "the page names Lucidchart but states no amount, tier or rate we can read"
+        "checked": "2026-09-03",
+        "outcome": "ok",
+        "detail": "the page names Lucidchart, renders no terms we can read, and its markup states 1 typed price (USD 0.00)",
+        "read": "markup"
       }
     },
     {
@@ -21743,9 +21891,14 @@
       ],
       "verifiedDate": "2026-07-14",
       "source_check": {
-        "checked": "2026-09-02",
-        "outcome": "states_no_terms",
-        "detail": "the page names MeisterTask but states no amount, tier or rate we can read"
+        "checked": "2026-09-03",
+        "outcome": "ok",
+        "detail": "the page names MeisterTask, renders no terms we can read, and its markup states 3 typed prices (Basic USD 0, Pro USD 13, Business USD 25)",
+        "read": "markup",
+        "unrendered_prices": [
+          "Pro USD 13",
+          "Business USD 25"
+        ]
       }
     },
     {
@@ -21777,9 +21930,10 @@
       ],
       "verifiedDate": "2026-07-17",
       "source_check": {
-        "checked": "2026-09-02",
-        "outcome": "states_no_terms",
-        "detail": "the page names Plane but states no amount, tier or rate we can read"
+        "checked": "2026-09-03",
+        "outcome": "ok",
+        "detail": "the page names Plane, renders no terms we can read, and its markup states 1 typed price (USD 0)",
+        "read": "markup"
       }
     },
     {
@@ -21879,9 +22033,14 @@
       ],
       "verifiedDate": "2026-08-26",
       "source_check": {
-        "checked": "2026-09-02",
-        "outcome": "states_no_amount",
-        "detail": "the page names Shortcut and says \"free forever\" but states no amount, rate or price we can read"
+        "checked": "2026-09-03",
+        "outcome": "ok",
+        "detail": "the page names Shortcut, renders \"free forever\" and no amount, and its markup states 3 typed prices (Free USD 0, Team USD 8.50, Business USD 12)",
+        "read": "markup",
+        "unrendered_prices": [
+          "Team USD 8.50",
+          "Business USD 12"
+        ]
       }
     },
     {
@@ -21913,9 +22072,12 @@
       ],
       "verifiedDate": "2026-07-18",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-03",
         "outcome": "ok",
-        "detail": "text"
+        "detail": "text",
+        "unrendered_prices": [
+          "Enterprise USD 250"
+        ]
       }
     },
     {
@@ -21947,9 +22109,10 @@
       ],
       "verifiedDate": "2026-08-14",
       "source_check": {
-        "checked": "2026-09-02",
-        "outcome": "states_no_terms",
-        "detail": "the page names teamwork.com but states no amount, tier or rate we can read"
+        "checked": "2026-09-03",
+        "outcome": "ok",
+        "detail": "the page names teamwork.com, renders no terms we can read, and its markup states 1 typed price (USD 0.00)",
+        "read": "markup"
       }
     },
     {
@@ -21964,9 +22127,10 @@
       ],
       "verifiedDate": "2026-08-28",
       "source_check": {
-        "checked": "2026-09-02",
-        "outcome": "states_no_amount",
-        "detail": "the page names teleretro.com and says \"free plan\" but states no amount, rate or price we can read"
+        "checked": "2026-09-03",
+        "outcome": "ok",
+        "detail": "the page names teleretro.com, renders \"free plan\" and no amount, and its markup states 1 typed price (USD 0)",
+        "read": "markup"
       }
     },
     {
@@ -22015,9 +22179,13 @@
       ],
       "verifiedDate": "2026-08-28",
       "source_check": {
-        "checked": "2026-09-02",
-        "outcome": "states_no_amount",
-        "detail": "the page names Toggl and says \"free plan\" but states no amount, rate or price we can read"
+        "checked": "2026-09-03",
+        "outcome": "ok",
+        "detail": "the page names Toggl, renders \"free plan\" and no amount, and its markup states 3 typed prices (Toggl Track's Free plan USD 00.00, Toggl Track's Starter plan USD 10.00, Toggl Track's Premium plan USD 20.00)",
+        "read": "markup",
+        "unrendered_prices": [
+          "Toggl Track's Starter plan USD 10.00"
+        ]
       }
     },
     {
@@ -22173,9 +22341,15 @@
       ],
       "verifiedDate": "2026-08-28",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-03",
         "outcome": "ok",
-        "detail": "text"
+        "detail": "text",
+        "unrendered_prices": [
+          "EUR 0.99",
+          "EUR 4.99",
+          "EUR 9.99",
+          "EUR 19.99"
+        ]
       }
     },
     {
@@ -22263,9 +22437,13 @@
       ],
       "verifiedDate": "2026-07-15",
       "source_check": {
-        "checked": "2026-09-02",
-        "outcome": "states_no_terms",
-        "detail": "the page names gumlet.com but states no amount, tier or rate we can read"
+        "checked": "2026-09-03",
+        "outcome": "ok",
+        "detail": "the page names gumlet.com, renders no terms we can read, and its markup states 1 typed price (USD 6)",
+        "read": "markup",
+        "unrendered_prices": [
+          "USD 6"
+        ]
       }
     },
     {
@@ -22568,9 +22746,17 @@
         "commission_type": "credits"
       },
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-03",
         "outcome": "ok",
-        "detail": "text"
+        "detail": "text",
+        "unrendered_prices": [
+          "CHF 4.99",
+          "CHF 3.99",
+          "CHF 12.99",
+          "CHF 9.99",
+          "CHF 19.99",
+          "CHF 14.99"
+        ]
       }
     },
     {
@@ -23019,9 +23205,10 @@
       ],
       "verifiedDate": "2026-07-19",
       "source_check": {
-        "checked": "2026-09-02",
-        "outcome": "states_no_terms",
-        "detail": "the page names css-gradient.com but states no amount, tier or rate we can read"
+        "checked": "2026-09-03",
+        "outcome": "ok",
+        "detail": "the page names css-gradient.com, renders no terms we can read, and its markup states 1 typed price (USD 0)",
+        "read": "markup"
       }
     },
     {
@@ -23721,9 +23908,10 @@
       ],
       "verifiedDate": "2026-07-18",
       "source_check": {
-        "checked": "2026-09-02",
-        "outcome": "states_no_terms",
-        "detail": "the page names PNG to WebP Converter but states no amount, tier or rate we can read"
+        "checked": "2026-09-03",
+        "outcome": "ok",
+        "detail": "the page names PNG to WebP Converter, renders no terms we can read, and its markup states 1 typed price (USD 0)",
+        "read": "markup"
       }
     },
     {
@@ -24153,9 +24341,10 @@
       ],
       "verifiedDate": "2026-07-19",
       "source_check": {
-        "checked": "2026-09-02",
-        "outcome": "states_no_terms",
-        "detail": "the page names unDraw but states no amount, tier or rate we can read"
+        "checked": "2026-09-03",
+        "outcome": "ok",
+        "detail": "the page names unDraw, renders no terms we can read, and its markup states 1 typed price (USD 0)",
+        "read": "markup"
       }
     },
     {
@@ -24621,9 +24810,10 @@
       ],
       "verifiedDate": "2026-08-08",
       "source_check": {
-        "checked": "2026-09-02",
-        "outcome": "states_no_terms",
-        "detail": "the page names stadiamaps.com but states no amount, tier or rate we can read"
+        "checked": "2026-09-03",
+        "outcome": "ok",
+        "detail": "the page names stadiamaps.com, renders no terms we can read, and its markup states 1 typed price (USD 0)",
+        "read": "markup"
       }
     },
     {
@@ -24808,9 +24998,10 @@
       ],
       "verifiedDate": "2026-08-10",
       "source_check": {
-        "checked": "2026-09-02",
-        "outcome": "states_no_terms",
-        "detail": "the page names Brackets but states no amount, tier or rate we can read"
+        "checked": "2026-09-03",
+        "outcome": "ok",
+        "detail": "the page names Brackets, renders no terms we can read, and its markup states 1 typed price (USD 0)",
+        "read": "markup"
       }
     },
     {
@@ -24961,9 +25152,10 @@
       ],
       "verifiedDate": "2026-08-09",
       "source_check": {
-        "checked": "2026-09-02",
-        "outcome": "states_no_terms",
-        "detail": "the page names ForgeCode but states no amount, tier or rate we can read"
+        "checked": "2026-09-03",
+        "outcome": "ok",
+        "detail": "the page names ForgeCode, renders no terms we can read, and its markup states 1 typed price (USD 0)",
+        "read": "markup"
       }
     },
     {
@@ -25183,9 +25375,10 @@
       ],
       "verifiedDate": "2026-08-10",
       "source_check": {
-        "checked": "2026-09-02",
-        "outcome": "states_no_terms",
-        "detail": "the page names Visual Studio Code but states no amount, tier or rate we can read"
+        "checked": "2026-09-03",
+        "outcome": "ok",
+        "detail": "the page names Visual Studio Code, renders no terms we can read, and its markup states 1 typed price (USD 0)",
+        "read": "markup"
       }
     },
     {
@@ -25429,9 +25622,16 @@
       ],
       "verifiedDate": "2026-08-28",
       "source_check": {
-        "checked": "2026-09-02",
-        "outcome": "states_no_amount",
-        "detail": "the page names DocBeacon and says \"Free plan\" but states no amount, rate or price we can read"
+        "checked": "2026-09-03",
+        "outcome": "ok",
+        "detail": "the page names DocBeacon, renders \"Free plan\" and no amount, and its markup states 6 typed prices (Free Monthly USD 0, Free Annual USD 0, Pro Monthly USD 25, +3 more)",
+        "read": "markup",
+        "unrendered_prices": [
+          "Pro Monthly USD 25",
+          "Pro Annual USD 20",
+          "Business Monthly USD 300",
+          "Business Annual USD 240"
+        ]
       }
     },
     {
@@ -25735,9 +25935,10 @@
       ],
       "verifiedDate": "2026-07-21",
       "source_check": {
-        "checked": "2026-09-02",
-        "outcome": "states_no_amount",
-        "detail": "the page names Trackingplan and says \"Growth plan\" but states no amount, rate or price we can read"
+        "checked": "2026-09-03",
+        "outcome": "ok",
+        "detail": "the page names Trackingplan, renders \"Growth plan\" and no amount, and its markup states 1 typed price (USD 0)",
+        "read": "markup"
       }
     },
     {
@@ -25771,9 +25972,10 @@
       ],
       "verifiedDate": "2026-07-20",
       "source_check": {
-        "checked": "2026-09-02",
-        "outcome": "states_no_terms",
-        "detail": "the page names Lyssna but states no amount, tier or rate we can read"
+        "checked": "2026-09-03",
+        "outcome": "ok",
+        "detail": "the page names Lyssna, renders no terms we can read, and its markup states 1 typed price (USD 0)",
+        "read": "markup"
       }
     },
     {
@@ -25879,9 +26081,10 @@
       ],
       "verifiedDate": "2026-07-21",
       "source_check": {
-        "checked": "2026-09-02",
-        "outcome": "states_no_terms",
-        "detail": "the page names OpenReplay.com but states no amount, tier or rate we can read"
+        "checked": "2026-09-03",
+        "outcome": "ok",
+        "detail": "the page names OpenReplay.com, renders no terms we can read, and its markup states 1 typed price (Self-Hosted (Open Source) USD 0)",
+        "read": "markup"
       }
     },
     {
@@ -26480,9 +26683,12 @@
       ],
       "verifiedDate": "2026-07-21",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-03",
         "outcome": "ok",
-        "detail": "url"
+        "detail": "url",
+        "unrendered_prices": [
+          "IDR 1399000"
+        ]
       }
     },
     {
@@ -26616,9 +26822,10 @@
       ],
       "verifiedDate": "2026-07-20",
       "source_check": {
-        "checked": "2026-09-02",
-        "outcome": "states_no_terms",
-        "detail": "the page names CodeToImage but states no amount, tier or rate we can read"
+        "checked": "2026-09-03",
+        "outcome": "ok",
+        "detail": "the page names CodeToImage, renders no terms we can read, and its markup states 1 typed price (USD 0)",
+        "read": "markup"
       }
     },
     {
@@ -26684,9 +26891,10 @@
       ],
       "verifiedDate": "2026-07-21",
       "source_check": {
-        "checked": "2026-09-02",
-        "outcome": "states_no_terms",
-        "detail": "the page names Exif Editor but states no amount, tier or rate we can read"
+        "checked": "2026-09-03",
+        "outcome": "ok",
+        "detail": "the page names Exif Editor, renders no terms we can read, and its markup states 1 typed price (USD 0)",
+        "read": "markup"
       }
     },
     {
@@ -26735,9 +26943,10 @@
       ],
       "verifiedDate": "2026-08-26",
       "source_check": {
-        "checked": "2026-09-02",
-        "outcome": "states_no_amount",
-        "detail": "the page names Hosting Checker and says \"Free Forever\" but states no amount, rate or price we can read"
+        "checked": "2026-09-03",
+        "outcome": "ok",
+        "detail": "the page names Hosting Checker, renders \"Free Forever\" and no amount, and its markup states 1 typed price (USD 0)",
+        "read": "markup"
       }
     },
     {
@@ -26837,9 +27046,10 @@
       ],
       "verifiedDate": "2026-08-28",
       "source_check": {
-        "checked": "2026-09-02",
-        "outcome": "states_no_amount",
-        "detail": "the page names RandomKeygen and says \"premium tier\" but states no amount, rate or price we can read"
+        "checked": "2026-09-03",
+        "outcome": "ok",
+        "detail": "the page names RandomKeygen, renders \"premium tier\" and no amount, and its markup states 1 typed price (USD 0)",
+        "read": "markup"
       }
     },
     {
@@ -27126,9 +27336,10 @@
       ],
       "verifiedDate": "2026-07-25",
       "source_check": {
-        "checked": "2026-09-02",
-        "outcome": "states_no_terms",
-        "detail": "the page names Dadroit V Web but states no amount, tier or rate we can read"
+        "checked": "2026-09-03",
+        "outcome": "ok",
+        "detail": "the page names Dadroit V Web, renders no terms we can read, and its markup states 1 typed price (USD 0)",
+        "read": "markup"
       }
     },
     {
@@ -27736,9 +27947,10 @@
       ],
       "verifiedDate": "2026-09-02",
       "source_check": {
-        "checked": "2026-09-02",
-        "outcome": "states_no_amount",
-        "detail": "the page names Pareto Security and says \"Team Plans\" but states no amount, rate or price we can read"
+        "checked": "2026-09-03",
+        "outcome": "ok",
+        "detail": "the page names Pareto Security, renders \"Team Plans\" and no amount, and its markup states 1 typed price (USD 0)",
+        "read": "markup"
       }
     },
     {
@@ -31654,9 +31866,17 @@
       ],
       "verifiedDate": "2026-08-19",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-03",
         "outcome": "ok",
-        "detail": "text"
+        "detail": "text",
+        "unrendered_prices": [
+          "Peacock Select Monthly USD 7.99",
+          "Peacock Select Annual USD 79.99",
+          "Peacock Premium Monthly USD 10.99",
+          "Peacock Premium Annual USD 109.99",
+          "Peacock Premium Plus Monthly USD 16.99",
+          "Peacock Premium Plus Annual USD 169.99"
+        ]
       }
     },
     {
@@ -33800,9 +34020,13 @@
         }
       ],
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-03",
         "outcome": "ok",
-        "detail": "text"
+        "detail": "text",
+        "unrendered_prices": [
+          "USD 6.49",
+          "Image generation (per image) USD 0.0006"
+        ]
       },
       "product_subtypes": {
         "taxonomy": "AI / ML",

--- a/scripts/mutate-1279.sh
+++ b/scripts/mutate-1279.sh
@@ -1,0 +1,253 @@
+#!/usr/bin/env bash
+set -u
+
+REPO="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$REPO" || exit 1
+
+FILES="scripts/structured-prices.js scripts/vendor-naming.js scripts/verify-freshness.js"
+BACKUP_DIR="$(mktemp -d)"
+for f in $FILES; do cp "$f" "$BACKUP_DIR/$(basename "$f")"; done
+
+restore() {
+  for f in $FILES; do cp "$BACKUP_DIR/$(basename "$f")" "$f"; done
+  npm run build > /dev/null 2>&1
+}
+trap restore EXIT
+
+killed=0
+survived=0
+TESTS="test/typed-price-read.test.ts test/source-check.test.ts test/price-evidence-grade.test.ts test/short-page-floor.test.ts test/whole-page-read.test.ts"
+
+run_mutation() {
+  local name="$1"
+  shift
+  echo "=== $name"
+  for f in $FILES; do cp "$BACKUP_DIR/$(basename "$f")" "$f"; done
+  "$@"
+  local changed=0
+  for f in $FILES; do
+    diff -q "$BACKUP_DIR/$(basename "$f")" "$f" > /dev/null || changed=1
+  done
+  if [ "$changed" -eq 0 ]; then
+    echo "    NOT APPLIED: the mutation changed no file, so it proves nothing"
+    survived=$((survived + 1))
+    return
+  fi
+  if ! npm run build > /tmp/mutate-1279-build.log 2>&1; then
+    echo "    KILLED: the mutation does not typecheck"
+    killed=$((killed + 1))
+    return
+  fi
+  if timeout 900 npx tsx --test $TESTS > /tmp/mutate-1279-test.log 2>&1; then
+    echo "    SURVIVED"
+    survived=$((survived + 1))
+  else
+    echo "    KILLED: $(grep -c '✖ ' /tmp/mutate-1279-test.log) failing assertion(s)"
+    grep '✖ ' /tmp/mutate-1279-test.log | head -4
+    killed=$((killed + 1))
+  fi
+}
+
+py() {
+  python3 - "$@"
+}
+
+m_only_the_offer_type_is_read() {
+  py <<'PY'
+p = "scripts/structured-prices.js"
+s = open(p).read()
+s = s.replace(
+  '''export const PRICED_TYPES = new Set([
+  "Offer",
+  "AggregateOffer",
+  "PriceSpecification",
+  "UnitPriceSpecification",
+]);''',
+  'export const PRICED_TYPES = new Set(["Offer"]);')
+open(p, "w").write(s)
+PY
+}
+
+m_a_range_low_price_is_not_a_price() {
+  py <<'PY'
+p = "scripts/structured-prices.js"
+s = open(p).read()
+s = s.replace('const PRICE_KEYS = ["price", "lowPrice"];', 'const PRICE_KEYS = ["price"];')
+open(p, "w").write(s)
+PY
+}
+
+m_a_type_array_is_ignored() {
+  py <<'PY'
+p = "scripts/structured-prices.js"
+s = open(p).read()
+s = s.replace('  if (Array.isArray(raw)) return raw.filter((t) => typeof t === "string");\n', '')
+open(p, "w").write(s)
+PY
+}
+
+m_a_price_needs_no_figure() {
+  py <<'PY'
+p = "scripts/structured-prices.js"
+s = open(p).read()
+s = s.replace('  if (!trimmed || !A_FIGURE.test(trimmed)) return null;', '  if (!trimmed) return null;')
+open(p, "w").write(s)
+PY
+}
+
+m_a_malformed_block_stops_the_read() {
+  py <<'PY'
+p = "scripts/structured-prices.js"
+s = open(p).read()
+s = s.replace('''    let value;
+    try {
+      value = JSON.parse(block);
+    } catch {
+      continue;
+    }''', '    const value = JSON.parse(block);')
+open(p, "w").write(s)
+PY
+}
+
+m_the_same_price_counts_twice() {
+  py <<'PY'
+p = "scripts/structured-prices.js"
+s = open(p).read()
+s = s.replace('return { blocks: blocks.length, parsed, prices: distinctPrices(prices) };',
+              'return { blocks: blocks.length, parsed, prices };')
+open(p, "w").write(s)
+PY
+}
+
+m_an_unnamed_twin_is_kept() {
+  py <<'PY'
+p = "scripts/structured-prices.js"
+s = open(p).read()
+s = s.replace('  return distinct.filter((price) => price.name || !named.has(amountKey(price)));',
+              '  return distinct;')
+open(p, "w").write(s)
+PY
+}
+
+m_a_nameless_offer_takes_no_name_from_its_item() {
+  py <<'PY'
+p = "scripts/structured-prices.js"
+s = open(p).read()
+s = s.replace('''  const offered = node.itemOffered;
+  if (offered && typeof offered === "object" && typeof offered.name === "string" && offered.name.trim()) {
+    return offered.name.trim();
+  }
+''', '')
+open(p, "w").write(s)
+PY
+}
+
+m_absent_markup_reads_the_same_as_priceless_markup() {
+  py <<'PY'
+p = "scripts/structured-prices.js"
+s = open(p).read()
+s = s.replace('  if (structured.blocks === 0) return NO_STRUCTURED_DATA;\n', '')
+open(p, "w").write(s)
+PY
+}
+
+m_a_zero_counts_as_a_price_the_page_hides() {
+  py <<'PY'
+p = "scripts/structured-prices.js"
+s = open(p).read()
+s = s.replace('  return structured.prices.filter((price) => !isZero(price) && !renderedIn(price, text));',
+              '  return structured.prices.filter((price) => !renderedIn(price, text));')
+open(p, "w").write(s)
+PY
+}
+
+m_a_price_inside_a_longer_number_counts_as_rendered() {
+  py <<'PY'
+p = "scripts/structured-prices.js"
+s = open(p).read()
+s = s.replace('    if (new RegExp(`(?<![\\\\d.,])${form.replace(/\\./g, "\\\\.")}(?![\\\\d])`).test(text)) return true;',
+              '    if (text.includes(form)) return true;')
+open(p, "w").write(s)
+PY
+}
+
+m_markup_cannot_lift_a_grade() {
+  py <<'PY'
+p = "scripts/vendor-naming.js"
+s = open(p).read()
+s = s.replace('  if (!rendersAnAmount && structured && structured.prices.length > 0) {',
+              '  if (false && !rendersAnAmount && structured && structured.prices.length > 0) {')
+open(p, "w").write(s)
+PY
+}
+
+m_markup_overrides_a_rendered_amount() {
+  py <<'PY'
+p = "scripts/vendor-naming.js"
+s = open(p).read()
+s = s.replace('  if (!rendersAnAmount && structured && structured.prices.length > 0) {',
+              '  if (structured && structured.prices.length > 0) {')
+open(p, "w").write(s)
+PY
+}
+
+m_the_grade_does_not_say_which_reading_made_it() {
+  py <<'PY'
+p = "scripts/vendor-naming.js"
+s = open(p).read()
+s = s.replace('      read: READ_FROM_MARKUP,\n', '')
+open(p, "w").write(s)
+PY
+}
+
+m_the_unrendered_prices_are_not_recorded() {
+  py <<'PY'
+p = "scripts/vendor-naming.js"
+s = open(p).read()
+s = s.replace('''  if (unrendered.length > 0) {
+    record.unrendered_prices = unrendered.slice(0, MAX_UNRENDERED_PRICES_RECORDED).map(priceLabel);
+  }''', '')
+open(p, "w").write(s)
+PY
+}
+
+m_the_page_is_fetched_without_reading_its_markup() {
+  py <<'PY'
+p = "scripts/verify-freshness.js"
+s = open(p).read()
+s = s.replace('      structured: readStructuredPrices(body.html),\n', '')
+open(p, "w").write(s)
+PY
+}
+
+m_the_markup_is_read_after_the_scripts_are_stripped() {
+  py <<'PY'
+p = "scripts/verify-freshness.js"
+s = open(p).read()
+s = s.replace('      structured: readStructuredPrices(body.html),',
+              '      structured: readStructuredPrices(text),')
+open(p, "w").write(s)
+PY
+}
+
+run_mutation "only Offer nodes carry a price" m_only_the_offer_type_is_read
+run_mutation "a range's low price is not a price" m_a_range_low_price_is_not_a_price
+run_mutation "a node typed as a list is ignored" m_a_type_array_is_ignored
+run_mutation "a price needs no figure in it" m_a_price_needs_no_figure
+run_mutation "a malformed block stops the read" m_a_malformed_block_stops_the_read
+run_mutation "the same price stated twice counts twice" m_the_same_price_counts_twice
+run_mutation "an unnamed twin of a named price is kept" m_an_unnamed_twin_is_kept
+run_mutation "a nameless offer takes no name from its item" m_a_nameless_offer_takes_no_name_from_its_item
+run_mutation "absent markup reads the same as priceless markup" m_absent_markup_reads_the_same_as_priceless_markup
+run_mutation "a zero counts as a price the page hides" m_a_zero_counts_as_a_price_the_page_hides
+run_mutation "a price inside a longer number counts as rendered" m_a_price_inside_a_longer_number_counts_as_rendered
+run_mutation "markup cannot lift a grade" m_markup_cannot_lift_a_grade
+run_mutation "markup overrides a rendered amount" m_markup_overrides_a_rendered_amount
+run_mutation "the grade does not say which reading made it" m_the_grade_does_not_say_which_reading_made_it
+run_mutation "the prices a page hides are not recorded" m_the_unrendered_prices_are_not_recorded
+run_mutation "the page is fetched without reading its markup" m_the_page_is_fetched_without_reading_its_markup
+run_mutation "the markup is read after the scripts are stripped" m_the_markup_is_read_after_the_scripts_are_stripped
+
+echo
+echo "killed=$killed survived=$survived"
+[ "$survived" -eq 0 ]

--- a/scripts/reverify-rolling.js
+++ b/scripts/reverify-rolling.js
@@ -22,6 +22,7 @@ import {
 import {
   sourceCheckRecord,
   holdsVerifiedDate,
+  READ_FROM_MARKUP,
   SOURCE_CHECK_OK,
   SOURCE_CHECK_OUTCOMES,
 } from "./vendor-naming.js";
@@ -133,6 +134,16 @@ function applySourceCheck(offer, index, page, data, dryRun, now, counters) {
   const signals = page?.ok ? priceSignals(page.text) : [];
   const check = sourceCheckRecord(offer, page, signals, isoDay(now));
   counters.set(check.outcome, (counters.get(check.outcome) ?? 0) + 1);
+  if (check.read === READ_FROM_MARKUP) {
+    counters.set(READ_FROM_MARKUP, (counters.get(READ_FROM_MARKUP) ?? 0) + 1);
+    console.log(`  ⌗ ${offer.vendor} — ${check.detail} (${offer.url})`);
+  }
+  if (check.unrendered_prices) {
+    counters.set(UNRENDERED, (counters.get(UNRENDERED) ?? 0) + 1);
+    console.log(
+      `  ⌗ ${offer.vendor} — the page publishes prices it does not render: ${check.unrendered_prices.join(", ")} (${offer.url})`
+    );
+  }
   if (!dryRun) data.offers[index].source_check = check;
   if (holdsVerifiedDate(check.outcome)) {
     console.log(`  ⊘ ${offer.vendor} — verifiedDate held at ${offer.verifiedDate}: ${check.detail} (${offer.url})`);
@@ -140,8 +151,10 @@ function applySourceCheck(offer, index, page, data, dryRun, now, counters) {
   return check;
 }
 
+const UNRENDERED = "unrendered_prices";
+
 function emptySourceCounters() {
-  return new Map(SOURCE_CHECK_OUTCOMES.map((outcome) => [outcome, 0]));
+  return new Map([...SOURCE_CHECK_OUTCOMES, READ_FROM_MARKUP, UNRENDERED].map((key) => [key, 0]));
 }
 
 function attemptRecorder() {
@@ -387,6 +400,8 @@ export function summaryLines(result, { useAi, checked, oldestRemaining, total, q
     const label = holdsVerifiedDate(outcome) ? "Held back" : "Verified on weaker evidence";
     lines.push(`${label} (source ${outcome}): ${sourceChecks.get(outcome) ?? 0}`);
   }
+  lines.push(`Graded on a price the page states in its markup, not its text: ${sourceChecks.get(READ_FROM_MARKUP) ?? 0}`);
+  lines.push(`Publishing a price in markup the page never renders: ${sourceChecks.get(UNRENDERED) ?? 0}`);
   lines.push(`Flagged (URL/AI failure): ${result.flagged}`);
   for (const line of quarantineLines(quarantine)) lines.push(line);
   if (repicked !== undefined) {
@@ -468,7 +483,8 @@ async function main() {
       })
     : await runUrlMode(picked, data, dryRun, now);
 
-  const sourceChecksWritten = [...(result.sourceChecks ?? new Map()).values()].reduce((a, b) => a + b, 0);
+  const checks = result.sourceChecks ?? new Map();
+  const sourceChecksWritten = SOURCE_CHECK_OUTCOMES.reduce((a, outcome) => a + (checks.get(outcome) ?? 0), 0);
   if (!dryRun && (result.verified > 0 || sourceChecksWritten > 0)) {
     writeFileSync(INDEX_PATH, JSON.stringify(data, null, 2) + "\n");
   }

--- a/scripts/short-page-census.js
+++ b/scripts/short-page-census.js
@@ -11,6 +11,7 @@ import {
   withMinimumLength,
 } from "./verify-freshness.js";
 import { priceSignals } from "./change-gate.js";
+import { readStructuredPrices } from "./structured-prices.js";
 import { classifySource, sourceCheckRecord } from "./vendor-naming.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -61,7 +62,12 @@ async function fetchUnfloored(url) {
     const body = await readBodyWithin(res, HARD_CEILING);
     if (body.tooLarge) return { ok: false, error: `page too large: ${body.bytes} bytes` };
     const text = stripHtml(body.html);
-    return { ok: true, text, bytes: Buffer.byteLength(body.html) };
+    return {
+      ok: true,
+      text,
+      bytes: Buffer.byteLength(body.html),
+      structured: readStructuredPrices(body.html),
+    };
   } catch (err) {
     return { ok: false, error: err.name === "AbortError" ? "timeout" : err.message };
   } finally {

--- a/scripts/structured-prices.js
+++ b/scripts/structured-prices.js
@@ -1,0 +1,161 @@
+const JSON_LD_BLOCK = /<script[^>]*\btype\s*=\s*["']application\/ld\+json["'][^>]*>([\s\S]*?)<\/script>/gi;
+
+export const PRICED_TYPES = new Set([
+  "Offer",
+  "AggregateOffer",
+  "PriceSpecification",
+  "UnitPriceSpecification",
+]);
+
+const PRICE_KEYS = ["price", "lowPrice"];
+const MAX_NODES = 5_000;
+const A_FIGURE = /\d/;
+
+export function jsonLdBlocks(html) {
+  if (typeof html !== "string") return [];
+  return [...html.matchAll(JSON_LD_BLOCK)].map((match) => match[1]);
+}
+
+function typeNames(node) {
+  const raw = node["@type"];
+  if (typeof raw === "string") return [raw];
+  if (Array.isArray(raw)) return raw.filter((t) => typeof t === "string");
+  return [];
+}
+
+function readPrice(raw) {
+  if (typeof raw === "number") return Number.isFinite(raw) ? String(raw) : null;
+  if (typeof raw !== "string") return null;
+  const trimmed = raw.trim();
+  if (!trimmed || !A_FIGURE.test(trimmed)) return null;
+  return trimmed;
+}
+
+function readName(node) {
+  if (typeof node.name === "string" && node.name.trim()) return node.name.trim();
+  const offered = node.itemOffered;
+  if (offered && typeof offered === "object" && typeof offered.name === "string" && offered.name.trim()) {
+    return offered.name.trim();
+  }
+  return null;
+}
+
+function collect(root, into) {
+  const queue = [root];
+  let seen = 0;
+  while (queue.length > 0 && seen < MAX_NODES) {
+    const node = queue.shift();
+    if (Array.isArray(node)) {
+      for (const child of node) queue.push(child);
+      continue;
+    }
+    if (!node || typeof node !== "object") continue;
+    seen++;
+    const types = typeNames(node);
+    if (types.some((t) => PRICED_TYPES.has(t))) {
+      for (const key of PRICE_KEYS) {
+        const price = readPrice(node[key]);
+        if (price === null) continue;
+        into.push({
+          type: types.find((t) => PRICED_TYPES.has(t)),
+          name: readName(node),
+          price,
+          currency: typeof node.priceCurrency === "string" ? node.priceCurrency : null,
+        });
+        break;
+      }
+    }
+    for (const value of Object.values(node)) {
+      if (value && typeof value === "object") queue.push(value);
+    }
+  }
+}
+
+export function priceValue(price) {
+  const digits = String(price.price).replace(/[^0-9.]/g, "");
+  const value = Number(digits);
+  return Number.isFinite(value) ? value : null;
+}
+
+function amountKey(price) {
+  return `${priceValue(price) ?? price.price}|${price.currency ?? ""}`;
+}
+
+export function distinctPrices(prices) {
+  const seen = new Set();
+  const distinct = [];
+  for (const price of prices) {
+    const key = `${amountKey(price)}|${price.name ?? ""}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    distinct.push(price);
+  }
+  const named = new Set(distinct.filter((p) => p.name).map(amountKey));
+  return distinct.filter((price) => price.name || !named.has(amountKey(price)));
+}
+
+export function typedPrices(html) {
+  return readStructuredPrices(html).prices;
+}
+
+export function readStructuredPrices(html) {
+  const blocks = jsonLdBlocks(html);
+  let parsed = 0;
+  const prices = [];
+  for (const block of blocks) {
+    let value;
+    try {
+      value = JSON.parse(block);
+    } catch {
+      continue;
+    }
+    parsed++;
+    collect(value, prices);
+  }
+  return { blocks: blocks.length, parsed, prices: distinctPrices(prices) };
+}
+
+export const NO_STRUCTURED_DATA = "its markup carries no structured data";
+
+export function structuredDetail(structured) {
+  if (!structured) return null;
+  if (structured.blocks === 0) return NO_STRUCTURED_DATA;
+  if (structured.prices.length === 0) {
+    return `the ${structured.blocks} structured-data block${structured.blocks === 1 ? "" : "s"} in its markup state no price`;
+  }
+  return `its markup states ${priceList(structured.prices)}`;
+}
+
+export function priceLabel(price) {
+  const amount = price.currency ? `${price.currency} ${price.price}` : price.price;
+  return price.name ? `${price.name} ${amount}` : amount;
+}
+
+export function priceList(prices, limit = 3) {
+  const shown = prices.slice(0, limit).map(priceLabel).join(", ");
+  const rest = prices.length - Math.min(limit, prices.length);
+  const count = `${prices.length} typed price${prices.length === 1 ? "" : "s"}`;
+  return rest > 0 ? `${count} (${shown}, +${rest} more)` : `${count} (${shown})`;
+}
+
+export function isZero(price) {
+  return priceValue(price) === 0;
+}
+
+export function renderedIn(price, text) {
+  if (typeof text !== "string") return false;
+  const digits = String(price.price).replace(/[^0-9.]/g, "");
+  if (!digits) return false;
+  const whole = digits.replace(/\.0+$/, "");
+  const withGrouping = whole.replace(/\B(?=(\d{3})+(?!\d))/g, ",");
+  for (const form of new Set([digits, whole, withGrouping])) {
+    if (!form) continue;
+    if (new RegExp(`(?<![\\d.,])${form.replace(/\./g, "\\.")}(?![\\d])`).test(text)) return true;
+  }
+  return false;
+}
+
+export function unrenderedPrices(structured, text) {
+  if (!structured || structured.prices.length === 0) return [];
+  return structured.prices.filter((price) => !isZero(price) && !renderedIn(price, text));
+}

--- a/scripts/typed-price-census.js
+++ b/scripts/typed-price-census.js
@@ -1,0 +1,206 @@
+#!/usr/bin/env node
+
+import { readFileSync, writeFileSync, existsSync, mkdirSync } from "node:fs";
+import { createHash } from "node:crypto";
+import { resolve, dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { readBodyWithin, withMinimumLength } from "./verify-freshness.js";
+import { readStructuredPrices, unrenderedPrices, isZero } from "./structured-prices.js";
+import { priceSignals } from "./change-gate.js";
+import { classifySource, sourceCheckRecord } from "./vendor-naming.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const INDEX_PATH =
+  process.env.AGENTDEALS_INDEX_PATH || resolve(__dirname, "..", "data", "index.json");
+const CONCURRENCY = 12;
+const FETCH_TIMEOUT_MS = 20_000;
+const HARD_CEILING = 64_000_000;
+
+function arg(name, fallback = null) {
+  const at = process.argv.indexOf(name);
+  return at !== -1 ? process.argv[at + 1] : fallback;
+}
+
+function stripHtml(html) {
+  return html
+    .replace(/<script[\s\S]*?<\/script>/gi, "")
+    .replace(/<style[\s\S]*?<\/style>/gi, "")
+    .replace(/<[^>]+>/g, " ")
+    .replace(/&nbsp;/g, " ")
+    .replace(/&amp;/g, "&")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+async function fetchMeasured(url) {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+  try {
+    const res = await fetch(url, {
+      method: "GET",
+      signal: controller.signal,
+      headers: {
+        "User-Agent":
+          "Mozilla/5.0 (compatible; AgentDeals-Verify/1.0; +https://github.com/robhunter/agentdeals)",
+        Accept: "text/html,application/xhtml+xml",
+      },
+      redirect: "follow",
+    });
+    if (!res.ok) return { ok: false, error: `HTTP ${res.status}` };
+    const body = await readBodyWithin(res, HARD_CEILING);
+    if (body.tooLarge) return { ok: false, error: `page too large: ${body.bytes} bytes` };
+    return withMinimumLength({
+      ok: true,
+      text: stripHtml(body.html),
+      structured: readStructuredPrices(body.html),
+    });
+  } catch (err) {
+    return { ok: false, error: err.name === "AbortError" ? "timeout" : err.message };
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+async function mapWithConcurrency(items, limit, fn) {
+  let next = 0;
+  const workers = Array.from({ length: Math.min(limit, items.length) }, async () => {
+    while (true) {
+      const i = next++;
+      if (i >= items.length) return;
+      await fn(items[i]);
+    }
+  });
+  await Promise.all(workers);
+}
+
+const REGRADED_FROM = new Set(["states_no_terms", "states_no_amount"]);
+
+async function main() {
+  const out = arg("--out", "/tmp/typed-price-census.json");
+  const cacheDir = arg("--cache", "/tmp/typed-price-cache");
+
+  const data = JSON.parse(readFileSync(INDEX_PATH, "utf-8"));
+  const offers = (data.offers || []).filter((o) => o.url);
+  const urls = [...new Set(offers.map((o) => o.url))];
+  console.error(`${offers.length} offers, ${urls.length} distinct URLs`);
+
+  if (!existsSync(cacheDir)) mkdirSync(cacheDir, { recursive: true });
+  const cachePath = (url) => join(cacheDir, `${createHash("sha1").update(url).digest("hex")}.json`);
+
+  let done = 0;
+  const pages = new Map();
+  await mapWithConcurrency(urls, CONCURRENCY, async (url) => {
+    let page;
+    if (existsSync(cachePath(url))) {
+      page = JSON.parse(readFileSync(cachePath(url), "utf-8"));
+    } else {
+      page = await fetchMeasured(url);
+      writeFileSync(cachePath(url), JSON.stringify(page));
+    }
+    done++;
+    if (done % 100 === 0) console.error(`  ${done}/${urls.length}`);
+    pages.set(url, page);
+  });
+
+  const write = process.argv.includes("--write");
+  const checked = arg("--checked", new Date().toISOString().slice(0, 10));
+  let restampedRegrade = 0;
+  let restampedFlag = 0;
+
+  const rows = offers.map((offer) => {
+    const page = pages.get(offer.url) ?? { ok: false, error: "not fetched" };
+    const signals = page.ok ? priceSignals(page.text) : [];
+    const structured = page.structured ?? { blocks: 0, parsed: 0, prices: [] };
+    const withMarkup = classifySource(offer, page, signals);
+    const withoutMarkup = classifySource(offer, page.ok ? { ...page, structured: null } : page, signals);
+    const unrendered = page.ok ? unrenderedPrices(page.structured, page.text) : [];
+    const stored = offer.source_check?.outcome ?? null;
+    const regraded =
+      page.ok && REGRADED_FROM.has(withoutMarkup.outcome) && !REGRADED_FROM.has(withMarkup.outcome);
+    const flagOnly = page.ok && !regraded && stored === withMarkup.outcome && unrendered.length > 0;
+    if (write && (regraded || flagOnly)) {
+      offer.source_check = sourceCheckRecord(offer, page, signals, checked);
+      if (regraded) restampedRegrade++;
+      else restampedFlag++;
+    }
+    return {
+      vendor: offer.vendor,
+      url: offer.url,
+      stored,
+      fetch_ok: page.ok,
+      error: page.ok ? null : page.error,
+      chars: page.ok ? page.text.length : null,
+      blocks: structured.blocks,
+      parsed: structured.parsed,
+      typed_prices: structured.prices.length,
+      typed_nonzero: structured.prices.filter((p) => !isZero(p)).length,
+      signals: signals.length,
+      outcome_today: withoutMarkup.outcome,
+      outcome_with_markup: withMarkup.outcome,
+      read: withMarkup.read ?? null,
+      unrendered: unrendered.length,
+      unrendered_sample: unrendered.slice(0, 3).map((p) => `${p.name ?? "—"} ${p.currency ?? ""} ${p.price}`.trim()),
+    };
+  });
+
+  writeFileSync(out, JSON.stringify(rows, null, 1) + "\n");
+  if (write) writeFileSync(INDEX_PATH, JSON.stringify(data, null, 2) + "\n");
+
+  const fetched = rows.filter((r) => r.fetch_ok);
+  const urlRows = new Map();
+  for (const r of rows) if (!urlRows.has(r.url)) urlRows.set(r.url, r);
+  const urlList = [...urlRows.values()];
+  const urlsFetched = urlList.filter((r) => r.fetch_ok);
+  const urlsTyped = urlsFetched.filter((r) => r.typed_prices > 0);
+  const urlsTypedOnly = urlsTyped.filter((r) => r.signals === 0 || !r.signals);
+  const regraded = fetched.filter(
+    (r) => REGRADED_FROM.has(r.outcome_today) && !REGRADED_FROM.has(r.outcome_with_markup)
+  );
+  const ladders = regraded.filter((r) => r.typed_prices >= 3);
+  const singles = regraded.filter((r) => r.typed_prices === 1);
+  const zeroOnly = regraded.filter((r) => r.typed_nonzero === 0);
+  const storedRegraded = fetched.filter(
+    (r) => REGRADED_FROM.has(r.stored) && !REGRADED_FROM.has(r.outcome_with_markup) && r.typed_prices > 0
+  );
+  const unrenderedRows = fetched.filter((r) => r.unrendered > 0);
+  const unreadableTyped = rows.filter((r) => !r.fetch_ok && r.typed_prices > 0);
+
+  const say = (label, value) => console.error(`${label.padEnd(42)}${value}`);
+  console.error("");
+  say("distinct URLs", urlList.length);
+  say("  fetched", urlsFetched.length);
+  say("  carrying a typed price", urlsTyped.length);
+  say("  typed price and no rendered signal", urlsTypedOnly.length);
+  console.error("");
+  say("records", rows.length);
+  say("  on a page carrying a typed price", fetched.filter((r) => r.typed_prices > 0).length);
+  say("  re-graded by reading the markup", regraded.length);
+  say("    on a ladder of 3 or more prices", ladders.length);
+  say("    on a single typed price", singles.length);
+  say("    on zero-priced nodes only", zeroOnly.length);
+  say("  stored as states_no_* and re-graded", storedRegraded.length);
+  console.error("");
+  say("records with unrendered typed prices", unrenderedRows.length);
+  say("  typed prices the page never renders", unrenderedRows.reduce((a, r) => a + r.unrendered, 0));
+  say("unreadable pages carrying typed prices", unreadableTyped.length);
+  if (write) {
+    console.error("");
+    say("re-stamped after a re-grade", restampedRegrade);
+    say("re-stamped to record unrendered prices", restampedFlag);
+  }
+  console.error("");
+  console.error(`wrote ${out}`);
+}
+
+const isMainModule =
+  process.argv[1] && resolve(process.argv[1]) === resolve(fileURLToPath(import.meta.url));
+if (isMainModule) {
+  main().catch((err) => {
+    console.error(`Fatal error: ${err.message}`);
+    process.exit(1);
+  });
+}

--- a/scripts/vendor-naming.js
+++ b/scripts/vendor-naming.js
@@ -1,3 +1,5 @@
+import { priceLabel, structuredDetail, unrenderedPrices } from "./structured-prices.js";
+
 const NAME_QUALIFIERS = new Set([
   "cloud", "ci", "cd", "api", "apis", "ai", "app", "apps", "platform", "hosting",
   "storage", "object", "free", "inc", "ltd", "llc", "labs", "software", "services",
@@ -164,6 +166,13 @@ export function pageNamesVendor(pageText, vendor, options = {}) {
   return result(false, null, null);
 }
 
+export const READ_FROM_MARKUP = "markup";
+
+function markupClause(structured) {
+  const detail = structuredDetail(structured);
+  return detail ? `, and ${detail}` : "";
+}
+
 export function classifySource(offer, page, signals) {
   if (!page || !page.ok) {
     return { outcome: SOURCE_CHECK_UNREADABLE, detail: page?.error ?? "not fetched" };
@@ -175,23 +184,41 @@ export function classifySource(offer, page, signals) {
       detail: `the page never names ${offer.vendor} and is not served from its domain`,
     };
   }
+  const structured = page.structured ?? null;
   const found = Array.isArray(signals) ? signals : [];
+  const rendersAnAmount = found.some(statesAnAmount);
+  if (!rendersAnAmount && structured && structured.prices.length > 0) {
+    const rendered = found.length === 0 ? "renders no terms we can read" : `renders "${found[0]}" and no amount`;
+    return {
+      outcome: SOURCE_CHECK_OK,
+      detail: `the page names ${offer.vendor}, ${rendered}, and ${structuredDetail(structured)}`,
+      read: READ_FROM_MARKUP,
+    };
+  }
   if (found.length === 0) {
     return {
       outcome: SOURCE_CHECK_NO_TERMS,
-      detail: `the page names ${offer.vendor} but states no amount, tier or rate we can read`,
+      detail: `the page names ${offer.vendor} but states no amount, tier or rate we can read${markupClause(structured)}`,
     };
   }
-  if (!found.some(statesAnAmount)) {
+  if (!rendersAnAmount) {
     return {
       outcome: SOURCE_CHECK_NO_AMOUNT,
-      detail: `the page names ${offer.vendor} and says "${found[0]}" but states no amount, rate or price we can read`,
+      detail: `the page names ${offer.vendor} and says "${found[0]}" but states no amount, rate or price we can read${markupClause(structured)}`,
     };
   }
   return { outcome: SOURCE_CHECK_OK, detail: naming.via };
 }
 
+export const MAX_UNRENDERED_PRICES_RECORDED = 6;
+
 export function sourceCheckRecord(offer, page, signals, checked) {
-  const { outcome, detail } = classifySource(offer, page, signals);
-  return { checked, outcome, detail };
+  const { outcome, detail, read } = classifySource(offer, page, signals);
+  const record = { checked, outcome, detail };
+  if (read) record.read = read;
+  const unrendered = page?.ok ? unrenderedPrices(page.structured, page.text) : [];
+  if (unrendered.length > 0) {
+    record.unrendered_prices = unrendered.slice(0, MAX_UNRENDERED_PRICES_RECORDED).map(priceLabel);
+  }
+  return record;
 }

--- a/scripts/verify-freshness.js
+++ b/scripts/verify-freshness.js
@@ -4,6 +4,7 @@ import { readFileSync, writeFileSync } from "node:fs";
 import { resolve, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 import { CHANGE_TYPES } from "./change-log.js";
+import { readStructuredPrices } from "./structured-prices.js";
 
 const CHANGE_TYPE_VALUES = CHANGE_TYPES.join(", ");
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -66,7 +67,9 @@ export function pageTooLargeError(bytes) {
 export function withMinimumLength(page, floor = MIN_PAGE_TEXT_LENGTH) {
   if (!page.ok) return page;
   if (page.text.length < floor) {
-    return { ok: false, error: PAGE_TOO_SHORT_ERROR, chars: page.text.length };
+    const short = { ok: false, error: PAGE_TOO_SHORT_ERROR, chars: page.text.length };
+    if (page.structured) short.structured = page.structured;
+    return short;
   }
   return page;
 }
@@ -128,6 +131,7 @@ export async function fetchPageText(url, options = {}) {
     return withMinimumLength({
       ok: true,
       text,
+      structured: readStructuredPrices(body.html),
       truncated: false,
       finalUrl: res.url || url,
     });

--- a/scripts/whole-page-census.js
+++ b/scripts/whole-page-census.js
@@ -6,6 +6,7 @@ import { resolve, dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { MAX_PAGE_TEXT_LENGTH, readBodyWithin, withMinimumLength } from "./verify-freshness.js";
 import { priceSignals } from "./change-gate.js";
+import { readStructuredPrices } from "./structured-prices.js";
 import { pageNamesVendor, classifySource, sourceCheckRecord } from "./vendor-naming.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -54,7 +55,7 @@ async function fetchMeasured(url) {
     if (body.tooLarge) return { ok: false, error: `page too large: ${body.bytes} bytes` };
     const bytes = Buffer.byteLength(body.html);
     const text = stripHtml(body.html);
-    return withMinimumLength({ ok: true, text, bytes });
+    return withMinimumLength({ ok: true, text, bytes, structured: readStructuredPrices(body.html) });
   } catch (err) {
     return { ok: false, error: err.name === "AbortError" ? "timeout" : err.message };
   } finally {

--- a/src/openapi.ts
+++ b/src/openapi.ts
@@ -952,7 +952,7 @@ export const openapiSpec = {
             type: "string",
             enum: ["ok", "states_no_amount", "does_not_name_vendor", "states_no_terms", "unreadable"],
             description: [
-              "ok — the page names the vendor and states at least one amount, rate or price in figures.",
+              "ok — the page names the vendor and states at least one amount, rate or price, either in figures the page renders or as a typed price in its schema.org markup (#1279).",
               "states_no_amount — the page names the vendor and names a plan or tier, but every price signal on it is a phrase such as \"Enterprise plan\" or \"Free forever\" and none is a figure (#1268). The quantities in description come from our own entry, not from that page. risk_level is still published and the summary says so, rather than being withheld.",
               "does_not_name_vendor — the page never names the vendor and is not served from its domain.",
               "states_no_terms — the page names the vendor but carries no price signal of any kind.",
@@ -960,7 +960,13 @@ export const openapiSpec = {
               "The last three withhold a favourable risk_level; the first two do not."
             ].join(" ")
           },
-          detail: { type: "string", description: "What the check found, in its own words: for ok, how the page named the vendor; for states_no_amount, the phrase that was the page's entire price evidence; otherwise why the page cannot confirm the record." }
+          detail: { type: "string", description: "What the check found, in its own words: for ok, how the page named the vendor, or what its markup states when the rendered page states no amount; for states_no_amount, the phrase that was the page's entire price evidence; otherwise why the page cannot confirm the record. Where the page was read for schema.org markup, the detail says whether that markup was absent, present and priceless, or priced." },
+          read: { type: "string", enum: ["markup"], description: "Present when the ok grade rests on typed prices in the page's schema.org markup rather than on a figure the page renders (#1279)." },
+          unrendered_prices: {
+            type: "array",
+            items: { type: "string" },
+            description: "Non-zero prices the page publishes as schema.org Offer data but does not render in its text — a tab or toggle layout showing one tier at a time. At most the first six are listed. The record is not written from these; they are recorded so a disagreement between markup and page can be reviewed (#1279)."
+          }
         },
         required: ["checked", "outcome", "detail"]
       },

--- a/src/types.ts
+++ b/src/types.ts
@@ -89,6 +89,8 @@ export interface SourceCheck {
   checked: string;
   outcome: SourceCheckOutcome;
   detail: string;
+  read?: "markup";
+  unrendered_prices?: string[];
 }
 
 export type StabilityClass = "stable" | "watch" | "volatile" | "improving";

--- a/test/typed-price-read.test.ts
+++ b/test/typed-price-read.test.ts
@@ -1,0 +1,316 @@
+import { describe, it } from "node:test";
+import assert from "node:assert";
+import { readFileSync, readdirSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const SCRIPTS = path.join(__dirname, "..", "scripts");
+
+const {
+  jsonLdBlocks,
+  readStructuredPrices,
+  structuredDetail,
+  unrenderedPrices,
+  priceLabel,
+  NO_STRUCTURED_DATA,
+} = await import("../scripts/structured-prices.js");
+const { fetchPageText } = await import("../scripts/verify-freshness.js");
+const { classifySource, sourceCheckRecord, READ_FROM_MARKUP } = await import("../scripts/vendor-naming.js");
+const { priceSignals } = await import("../scripts/change-gate.js");
+const { runUrlMode, summaryLines } = await import("../scripts/reverify-rolling.js");
+
+const OFFER = {
+  vendor: "Widgetson",
+  category: "Monitoring",
+  tier: "Free",
+  description: "Free for up to 5 hosts",
+  url: "https://widgetson.example/pricing",
+};
+
+const PROSE =
+  "Widgetson pricing. Pick the plan that fits your team." +
+  " Every plan includes alerting, dashboards and single sign-on.".repeat(12);
+
+function page(body: string) {
+  return `<html><head><title>Widgetson pricing</title></head><body><main>${body}</main></body></html>`;
+}
+
+function ldBlock(value: unknown) {
+  return `<script type="application/ld+json">${JSON.stringify(value)}</script>`;
+}
+
+const LADDER = {
+  "@context": "https://schema.org",
+  "@type": "Product",
+  name: "Widgetson",
+  offers: [
+    { "@type": "Offer", name: "Free", price: "0", priceCurrency: "USD" },
+    { "@type": "Offer", name: "Pro", price: "20", priceCurrency: "USD" },
+    { "@type": "Offer", name: "Ultra", price: "200", priceCurrency: "USD" },
+  ],
+};
+
+const ONLY_TYPED_PRICES = page(`<p>${PROSE}</p>`) + ldBlock(LADDER);
+const MALFORMED_LD =
+  page(`<p>${PROSE} The Pro plan is $20 per month.</p>`) +
+  `<script type="application/ld+json">{"@type":"Offer","price":</script>`;
+const NO_LD = page(`<p>${PROSE}</p>`);
+
+async function readWith(body: string) {
+  const original = globalThis.fetch;
+  globalThis.fetch = (async () => new Response(body, { status: 200 })) as typeof fetch;
+  try {
+    return await fetchPageText(OFFER.url);
+  } finally {
+    globalThis.fetch = original;
+  }
+}
+
+function gradeOf(page: { ok: boolean; text?: string }) {
+  return classifySource(OFFER, page, page.ok ? priceSignals(page.text ?? "") : []);
+}
+
+describe("prices published as schema.org markup", () => {
+  it("collects every typed node under a product's offer list", () => {
+    const { blocks, parsed, prices } = readStructuredPrices(ONLY_TYPED_PRICES);
+    assert.strictEqual(blocks, 1);
+    assert.strictEqual(parsed, 1);
+    assert.deepStrictEqual(
+      prices.map((p) => `${p.name} ${p.price}`),
+      ["Free 0", "Pro 20", "Ultra 200"],
+    );
+    assert.deepStrictEqual([...new Set(prices.map((p) => p.currency))], ["USD"]);
+  });
+
+  it("reads the shapes vendors publish: a graph, a bare array, a range and a unit rate", () => {
+    const graph = ldBlock({ "@context": "https://schema.org", "@graph": [LADDER] });
+    assert.strictEqual(readStructuredPrices(graph).prices.length, 3);
+
+    const array = ldBlock([{ "@type": "Offer", name: "Team", price: 40, priceCurrency: "USD" }]);
+    assert.deepStrictEqual(readStructuredPrices(array).prices[0].price, "40");
+
+    const range = ldBlock({ "@type": "AggregateOffer", lowPrice: "9.99", priceCurrency: "EUR" });
+    assert.deepStrictEqual(readStructuredPrices(range).prices, [
+      { type: "AggregateOffer", name: null, price: "9.99", currency: "EUR" },
+    ]);
+
+    const rate = ldBlock({
+      "@type": ["UnitPriceSpecification", "Thing"],
+      name: "Per seat",
+      price: "8",
+      priceCurrency: "GBP",
+    });
+    assert.strictEqual(readStructuredPrices(rate).prices[0].type, "UnitPriceSpecification");
+  });
+
+  it("names the plan from the item a nameless offer is for", () => {
+    const nested = ldBlock({
+      "@type": "Offer",
+      price: "15",
+      priceCurrency: "USD",
+      itemOffered: { "@type": "Service", name: "Starter" },
+    });
+    assert.strictEqual(readStructuredPrices(nested).prices[0].name, "Starter");
+  });
+
+  it("counts a ladder published twice on the same page once", () => {
+    const twice = ONLY_TYPED_PRICES + ldBlock(LADDER);
+    assert.strictEqual(jsonLdBlocks(twice).length, 2);
+    assert.strictEqual(readStructuredPrices(twice).prices.length, 3);
+  });
+
+  it("counts one price however many ways the page spells the same amount", () => {
+    const spellings = ldBlock([
+      { "@type": "Offer", name: "Free", price: "0", priceCurrency: "USD" },
+      { "@type": "Offer", name: "Free", price: "0.00", priceCurrency: "USD" },
+      { "@type": "Offer", price: "0", priceCurrency: "USD" },
+    ]);
+    assert.deepStrictEqual(readStructuredPrices(spellings).prices, [
+      { type: "Offer", name: "Free", price: "0", currency: "USD" },
+    ]);
+  });
+
+  it("counts an offer and the unit rate nested inside it as one price", () => {
+    const nested = ldBlock({
+      "@type": "Offer",
+      name: "Pro",
+      price: "20",
+      priceCurrency: "USD",
+      priceSpecification: { "@type": "UnitPriceSpecification", price: "20", priceCurrency: "USD" },
+    });
+    assert.deepStrictEqual(readStructuredPrices(nested).prices, [
+      { type: "Offer", name: "Pro", price: "20", currency: "USD" },
+    ]);
+  });
+
+  it("keeps an unnamed price the page states at no other plan's amount", () => {
+    const mixed = ldBlock([
+      { "@type": "Offer", name: "Pro", price: "20", priceCurrency: "USD" },
+      { "@type": "Offer", price: "40", priceCurrency: "USD" },
+    ]);
+    assert.deepStrictEqual(
+      readStructuredPrices(mixed).prices.map((p) => `${p.name ?? "—"} ${p.price}`),
+      ["Pro 20", "— 40"],
+    );
+  });
+
+  it("ignores typed nodes that carry no price and values that are not figures", () => {
+    const priceless = ldBlock({ "@type": "Offer", name: "Contact us", availability: "InStock" });
+    assert.deepStrictEqual(readStructuredPrices(priceless).prices, []);
+
+    const wordy = ldBlock({ "@type": "Offer", name: "Free", price: "Free" });
+    assert.deepStrictEqual(readStructuredPrices(wordy).prices, []);
+
+    const untyped = ldBlock({ "@type": "Product", name: "Widgetson", price: "20" });
+    assert.deepStrictEqual(readStructuredPrices(untyped).prices, []);
+  });
+});
+
+describe("reading a page whose prices are only in its markup", () => {
+  it("does not grade a page that states a typed price as stating no terms", async () => {
+    const read = await readWith(ONLY_TYPED_PRICES);
+    assert.ok(read.ok);
+    assert.strictEqual(priceSignals(read.text).length, 0);
+    const grade = gradeOf(read);
+    assert.strictEqual(grade.outcome, "ok");
+    assert.strictEqual(grade.read, READ_FROM_MARKUP);
+    assert.match(grade.detail, /3 typed prices/);
+    assert.match(grade.detail, /Pro USD 20/);
+  });
+
+  it("grades the same page as stating no terms when its markup is not read", async () => {
+    const read = await readWith(ONLY_TYPED_PRICES);
+    assert.strictEqual(gradeOf({ ...read, structured: null }).outcome, "states_no_terms");
+  });
+
+  it("keeps a page that renders a figure graded on what it renders", async () => {
+    const read = await readWith(page(`<p>${PROSE} The Pro plan is $20 per month.</p>`) + ldBlock(LADDER));
+    const grade = gradeOf(read);
+    assert.strictEqual(grade.outcome, "ok");
+    assert.strictEqual(grade.read, undefined);
+  });
+
+  it("lifts a page whose only rendered signal names a plan without an amount", async () => {
+    const read = await readWith(page(`<p>${PROSE} Free forever for small teams.</p>`) + ldBlock(LADDER));
+    assert.ok(priceSignals(read.text).length > 0);
+    assert.strictEqual(gradeOf({ ...read, structured: null }).outcome, "states_no_amount");
+    const grade = gradeOf(read);
+    assert.strictEqual(grade.outcome, "ok");
+    assert.strictEqual(grade.read, READ_FROM_MARKUP);
+  });
+});
+
+describe("a malformed block does not cost us the page", () => {
+  it("reads the page and its rendered price when a block will not parse", async () => {
+    const read = await readWith(MALFORMED_LD);
+    assert.ok(read.ok);
+    assert.strictEqual(read.structured.blocks, 1);
+    assert.strictEqual(read.structured.parsed, 0);
+    assert.deepStrictEqual(read.structured.prices, []);
+    assert.strictEqual(gradeOf(read).outcome, "ok");
+  });
+
+  it("says whether the markup was absent, present without a price, or unparsed", async () => {
+    const none = await readWith(NO_LD);
+    assert.strictEqual(structuredDetail(none.structured), NO_STRUCTURED_DATA);
+    assert.match(gradeOf(none).detail, /carries no structured data/);
+
+    const priceless = await readWith(page(`<p>${PROSE}</p>`) + ldBlock({ "@type": "Organization", name: "Widgetson" }));
+    assert.match(structuredDetail(priceless.structured) ?? "", /1 structured-data block .* state no price/);
+    assert.match(gradeOf(priceless).detail, /state no price/);
+
+    assert.strictEqual(structuredDetail(null), null);
+  });
+
+  it("leaves a page read without a markup pass described as it was", () => {
+    const grade = classifySource(OFFER, { ok: true, text: `${OFFER.vendor} pricing. Talk to us.` }, []);
+    assert.strictEqual(grade.outcome, "states_no_terms");
+    assert.strictEqual(grade.detail, "the page names Widgetson but states no amount, tier or rate we can read");
+  });
+});
+
+describe("a typed price is evidence, not a correction", () => {
+  it("keeps the markup out of the text the verifier reads", async () => {
+    const read = await readWith(ONLY_TYPED_PRICES);
+    for (const figure of ["20", "200", "USD"]) {
+      assert.ok(!read.text.includes(figure), `the verifier's page text carries ${figure} from the markup`);
+    }
+  });
+
+  it("records the prices a page publishes but never renders", async () => {
+    const read = await readWith(page(`<p>${PROSE} Pro is $20 per month.</p>`) + ldBlock(LADDER));
+    assert.deepStrictEqual(unrenderedPrices(read.structured, read.text).map(priceLabel), ["Ultra USD 200"]);
+    const record = sourceCheckRecord(OFFER, read, priceSignals(read.text), "2026-09-03");
+    assert.deepStrictEqual(record.unrendered_prices, ["Ultra USD 200"]);
+  });
+
+  it("does not count a rendered price or a zero as unrendered", async () => {
+    const read = await readWith(
+      page(`<p>${PROSE} Free is $0, Pro is $20 per month and Ultra is $200 per month.</p>`) + ldBlock(LADDER),
+    );
+    assert.deepStrictEqual(unrenderedPrices(read.structured, read.text), []);
+    assert.strictEqual(sourceCheckRecord(OFFER, read, priceSignals(read.text), "2026-09-03").unrendered_prices, undefined);
+  });
+
+  it("does not read a longer figure on the page as the price it contains", async () => {
+    const read = await readWith(
+      page(`<p>${PROSE} Pro is $20 per month and ingests 2000 events.</p>`) + ldBlock(LADDER),
+    );
+    assert.deepStrictEqual(unrenderedPrices(read.structured, read.text).map(priceLabel), ["Ultra USD 200"]);
+  });
+});
+
+describe("every check that grades a page reads its markup", () => {
+  const writers = readdirSync(SCRIPTS)
+    .filter((f) => f.endsWith(".js") || f.endsWith(".mjs"))
+    .map((f) => ({ file: f, source: readFileSync(path.join(SCRIPTS, f), "utf-8") }))
+    .filter(({ source }) => /\bsourceCheckRecord\b/.test(source) && !/export function sourceCheckRecord/.test(source));
+
+  it("finds the scripts that write a source check, so the assertion below has subjects", () => {
+    assert.ok(writers.length >= 4, `expected several scripts to write a source check, found ${writers.length}`);
+  });
+
+  for (const { file, source } of writers) {
+    it(`${file} reads the page's markup before grading it`, () => {
+      const readsMarkup =
+        /from "\.\/structured-prices\.js"/.test(source) || /fetchPageText/.test(source);
+      assert.ok(readsMarkup, `${file} grades a page without reading the prices in its markup`);
+    });
+  }
+});
+
+describe("the rolling re-verification carries the markup reading through", () => {
+  const NOW = new Date("2026-09-03T00:00:00Z");
+  const offer = { ...OFFER, verifiedDate: "2026-04-12" };
+
+  it("writes the reading and the unrendered prices onto the record", async () => {
+    const read = await readWith(page(`<p>${PROSE} Pro is $20 per month.</p>`) + ldBlock(LADDER));
+    const data = { offers: [{ ...offer }] };
+    const result = await runUrlMode([{ index: 0, offer }], data, false, NOW, {
+      batchFn: async (batch: any[]) => ({ verified: batch.map((b) => ({ index: b.index })), flagged: [] }),
+      fetchFn: async () => read,
+    });
+    const check = data.offers[0].source_check;
+    assert.strictEqual(check.outcome, "ok");
+    assert.deepStrictEqual(check.unrendered_prices, ["Ultra USD 200"]);
+    assert.strictEqual(result.sourceChecks.get("unrendered_prices"), 1);
+  });
+
+  it("counts a record graded on its markup alone in the run summary", async () => {
+    const read = await readWith(ONLY_TYPED_PRICES);
+    const data = { offers: [{ ...offer }] };
+    const result = await runUrlMode([{ index: 0, offer }], data, false, NOW, {
+      batchFn: async (batch: any[]) => ({ verified: batch.map((b) => ({ index: b.index })), flagged: [] }),
+      fetchFn: async () => read,
+    });
+    assert.strictEqual(data.offers[0].source_check.read, READ_FROM_MARKUP);
+    const lines = summaryLines(result, {
+      useAi: false,
+      checked: 1,
+      oldestRemaining: "2026-07-13",
+      total: 1,
+    });
+    assert.ok(lines.some((l: string) => /states in its markup, not its text: 1$/.test(l)), lines.join("\n"));
+  });
+});


### PR DESCRIPTION
Refs #1279.

## What was thrown away

Five fetch paths ran `replace(/<script[\s\S]*?<\/script>/gi, "")` before reading a page. Vendors publish their price ladder inside one of those blocks, as schema.org `Offer` objects — typed, machine-readable, and the single highest-confidence price statement on the page. We deleted it, then graded the record on what was left.

Measured today over every distinct URL in `data/index.json` — 1,487 URLs, 1,317 read (the 170 that failed include 105 under the #1263 length floor):

| | |
|---|---|
| pages carrying a typed price | **217** |
| of those, carrying no rendered price signal at all | **43** |
| pages carrying two or more typed prices | 89 |

## What changed

**`scripts/structured-prices.js`** extracts `<script type="application/ld+json">` blocks *before* the strip, parses each, and walks it for every node typed `Offer`, `AggregateOffer`, `PriceSpecification` or `UnitPriceSpecification` carrying `price` or `lowPrice`, keeping its `name` and `priceCurrency`. A block that fails to parse is skipped; the fetch still succeeds and the rest of the page is still read (AC-1).

The same amount stated twice counts once. Two real shapes made that necessary: a page emitting its whole ladder in two blocks (Cursor emits six blocks for five prices), and the standard `Offer` → `priceSpecification` → `UnitPriceSpecification` nesting, which restates each price without a name. Turso reads as 9 nodes and 5 prices; ngrok as 7 and 4.

**`fetchPageText`** returns `structured: { blocks, parsed, prices }`. The text it hands the verifier is byte-for-byte what it was.

**`classifySource`** cannot return `states_no_terms` or `states_no_amount` for a page carrying a typed price (AC-2), and its `detail` now distinguishes the three readings — markup absent, markup present and priceless, markup priced (AC-4). A page object with no markup pass keeps its old wording exactly, so nothing claims a reading it did not do.

**`sourceCheckRecord`** adds two optional fields, both documented in the OpenAPI schema: `read: "markup"` when the `ok` grade rests on the markup rather than a rendered figure, and `unrendered_prices` — non-zero typed prices absent from the rendered text.

## The re-grades (AC-2, AC-5)

Written into `data/index.json` by `scripts/typed-price-census.js --write`. **71 records re-graded**, every one toward `ok`, no record graded down. Three independent corpus passes today returned 71 each time.

| | records |
|---|---|
| `states_no_terms` → `ok` | 43 |
| `states_no_amount` → `ok` | 28 |
| of the 71, on a ladder of 3+ typed prices | 7 |
| of the 71, on a single typed price | 63 |
| of the 71, resting on zero-priced nodes only | **60** |

**60 of 71 rest entirely on a typed `0`** — usually `{"name":"Free","price":"0"}`. For a free-tier record that is the exact fact the outcome said was absent, but it confirms the price and not the limits, and #1268's `states_no_amount` grade was built to say precisely that. AC-2 rules it out, so those 60 now read `ok` with the reading in `detail`. Flagging it rather than quietly narrowing the criterion — if you would rather they stayed at `states_no_amount` with a markup detail, that is a one-line change.

The 7 with a real ladder are the reader-facing half: DocBeacon, MeisterTask, Crowdin, PrefectCloud, Toggl, Zoho Notebook, Shortcut. `/vendor/toggl` said *"The page we cite for Toggl names a plan but states no amount, so these limits come from our own record"* while toggl.com's markup states Free $0.00, Starter $10.00, Premium $20.00.

## A typed price is evidence, not a correction (AC-3)

Nothing writes a record from the markup. The verifier's page text excludes it, so no change record can be built from a typed price, and there is a test that fails if the markup leaks into that text.

Where the markup carries a non-zero price the page does not render, the record says so. **36 records, 81 prices listed** (capped at six per record; 126 found in total). The rolling run prints each one and counts them in its summary.

The first row of that list is the mechanism behind the #1067 error:

```json
"source_check": {"checked":"2026-09-03","outcome":"ok","detail":"text",
  "unrendered_prices":["Pro+ USD 60","Ultra USD 200"]}
```

Also there: Brevo (6 of 66), Turso, Sentry, Proton Drive, ngrok, Peacock, MongoDB Atlas.

## Left alone, and why

- **5 pages carrying typed prices are graded `unreadable`** — drawDB, Tweek, Dropshare, Tailark, UUID Generator — because they strip to under the #1263 floor. Their prices are readable and their prose is not. Lifting that would advance the verified date of pages we genuinely cannot read, so `unreadable` stands; the 5 are reported, not changed.
- **`monitor-pricing.js` and `check-pricing-changes.js` still hash rendered text only.** A price that changes only in the markup is a change we cannot see. Adding it to the hash would fire a false positive on every watched page at once, so it belongs in its own issue.
- **The change gate still refuses on `REJECT_NO_PRICE_SIGNAL` read from rendered text**, so a genuine change on a tab-strip page can still be refused. Same reason.

## Checks

3,272 tests, 28 new, 0 red. `tsc` and `validate` clean. 17 mutations across the three changed scripts, 17 killed, no survivors on the first pass.

2,577 paths swept against a worktree of `main`: 2,396 byte-identical, **181 moved, 0 added, 0 removed**. Every moved page names at least one of the 71 re-graded vendors and none gained an absence sentence. *"states no terms we can read"* falls from 6,686 occurrences to 6,110; *"names a plan but states no amount"* from 115 to 87 — exactly the 28.

Verified on a local server: `/api/offers` serves 71 records with `read: "markup"` and 36 with `unrendered_prices`, and `/vendor/toggl` renders no source notice where it rendered one.
