### PR TITLE
Correct the Hetzner record against the vendor's current prices (#1181)

### DIFF
--- a/data/index.json
+++ b/data/index.json
@@ -2468,7 +2468,7 @@
     {
       "vendor": "Hetzner",
       "category": "Infrastructure",
-      "description": "Budget cloud VMs from €3.99/month (CX22: 2 vCPU, 4 GB RAM, 40 GB SSD, 20 TB traffic). Post-April 2026 pricing: CX22 up from €2.99 (+33%), CX32 up from €5.99 to ~€8/mo, CX42 up from €14.99 to ~€20/mo. All regions affected (Germany, Finland, US, Singapore). No free tier but exceptionally competitive pricing with 20 TB traffic included. Increase driven by DRAM (+171% YoY) and NVMe SSD cost surges from AI infrastructure demand",
+      "description": "Budget cloud VMs, no free tier. As of 2026-09-03 hetzner.com marks every shared-vCPU plan — CX23, CX33, CX43, CX53 and the Arm CAX11–CAX41 — \"not available\". The cheapest orderable plan is CPX12 at €11.99/month (1 vCPU AMD, 2 GB RAM, 40 GB NVMe, 0.5 TB traffic); CPX22 is €19.99 (2 vCPU, 4 GB, 80 GB, 20 TB traffic). Dedicated-vCPU CCX13 is €43.49/month in the EU and $51.59 in the US. Two 2026 increases: April 1 across all lines, then June 15, which applies to new orders and rescales only — existing contracts keep their terms. The June round also renamed the lineup, so the CX22/CX32/CX42 names no longer exist. Server Auction, IPs, storage, Load Balancers, Volumes, Snapshots and Object Storage were excluded from the June round.",
       "tier": "Budget",
       "url": "https://www.hetzner.com/cloud/",
       "tags": [
@@ -2480,7 +2480,7 @@
         "eu",
         "price-increase-2026"
       ],
-      "verifiedDate": "2026-08-15",
+      "verifiedDate": "2026-09-03",
       "referral_program": {
         "available": true,
         "referrer_benefit": "€10 credit",


### PR DESCRIPTION
Refs #1181. Data only — `data/index.json`, one record.

## What the record said

> Budget cloud VMs from **€3.99/month (CX22**: 2 vCPU, 4 GB RAM, 40 GB SSD, 20 TB traffic). Post-April 2026 pricing: CX22 up from €2.99 (+33%), CX32 up from €5.99 to ~€8/mo, CX42 up from €14.99 to ~€20/mo.

`verifiedDate: 2026-08-15`, two months after the June 15 adjustment.

**CX22, CX32 and CX42 no longer exist.** The June standardization renamed the lineup. Nothing Hetzner sells is €3.99.

## What hetzner.com says today

Read 2026-09-03 from the three plan pages, with prices from Hetzner's own price API — each row's `product-key` in the page markup resolves against `https://website-price-api.hetzner.com/api/v1/products/<key>`.

| family | plan | EU €/mo | US $/mo | SIN €/mo | availability |
|---|---|---|---|---|---|
| Cost-Optimized | CX23 | 5.99 | — | — | **not available** |
| | CX33 | 8.99 | — | — | **not available** |
| | CX43 | 16.49 | — | — | **not available** |
| | CX53 | 29.99 | — | — | **not available** |
| | CAX11 | 6.49 | — | — | **not available** |
| | CAX21 | 10.99 | — | — | **not available** |
| | CAX31 | 21.49 | — | — | **not available** |
| | CAX41 | 41.49 | — | — | **not available** |
| Regular Performance | CPX12 | 11.99 | — | 15.99 | orderable |
| | CPX22 | 19.99 | — | 26.99 | orderable |
| | CPX32 | 35.99 | — | 49.49 | orderable |
| | CPX42 | 69.99 | — | 93.99 | orderable |
| | CPX52 | 100.99 | — | 134.99 | orderable |
| | CPX62 | 130.49 | — | 172.49 | orderable |
| | CPX11 | — | 21.09 | — | orderable |
| | CPX21 | — | 38.09 | — | orderable |
| | CPX31 | — | 74.09 | — | orderable |
| | CPX41 | — | 142.09 | — | orderable |
| | CPX51 | — | 280.09 | — | orderable |
| General Purpose | CCX13 | 43.49 | 51.59 | 54.49 | orderable |
| | CCX23 | 86.49 | 103.59 | 108.99 | orderable |
| | CCX33 | 138.99 | 166.59 | 174.99 | orderable |
| | CCX43 | 276.49 | 330.09 | 341.49 | orderable |
| | CCX53 | 533.99 | 636.09 | 652.49 | orderable |
| | CCX63 | 853.99 | 1015.09 | 1036.99 | orderable |

"not available" is Hetzner's own label, not an inference: those rows carry `class="cloud-matrix-product not-available"` and a `product-highlight-label-NotAvailable` div reading "not available". The CCX and CPX blocks contain the string zero times.

So the cheapest orderable Hetzner cloud plan is **CPX12 at €11.99**, not €3.99 — and it carries 0.5 TB of included traffic, not the 20 TB the record attached to the entry price. CPX22 at €19.99 is the cheapest plan with 20 TB.

## Checks

`npm run validate` clean — 1580 offers, 493 deal changes. `data/index.json` round-trips byte-identical through `json.dumps(indent=2, ensure_ascii=False)` plus a trailing newline, asserted before and after. No `test/` fixture pins any string this touches. No `src/`, no `test/`.

`source_check` left alone — a script computes it, and `/cloud/` is a JS shell that renders no price, which is why it reads `states_no_terms`.

The render-source half is on #1181; eight literal sites in `serve.ts` still publish April numbers and I have listed them there.