### PR TITLE
Carry the June 15 Hetzner supersession in the field we publish (#1181)

### DIFF
--- a/data/deal_changes.json
+++ b/data/deal_changes.json
@@ -627,7 +627,7 @@
       "vendor": "Hetzner",
       "change_type": "pricing_restructured",
       "date": "2026-04-01",
-      "summary": "Cloud & dedicated server prices increasing 30-50%. Entry-level CX23: €2.99→€3.99/mo (+33%). Applies to new and existing customers. Driven by DRAM (+171% YoY) and NVMe SSD cost surges from AI infrastructure demand",
+      "summary": "Cloud & dedicated server prices increasing 30-50%. Entry-level CX23: €2.99→€3.99/mo (+33%). Applies to new and existing customers. Driven by DRAM (+171% YoY) and NVMe SSD cost surges from AI infrastructure demand. Superseded 2026-06-15: Hetzner ran a second adjustment across all cloud and dedicated lines, applying to new orders and rescales only, and renamed the lineup. Read from hetzner.com on 2026-09-03: CX23 is €5.99 and is marked \"not available\", as is every other shared-vCPU plan, and the cheapest orderable plan is CPX12 at €11.99/mo.",
       "previous_state": "Lower cloud server pricing across Germany, Finland, US, and Singapore data centers (e.g., CX23 at €2.99/mo)",
       "current_state": "30-37% increase on cloud servers, up to 50% on select dedicated/storage products. All regions and all customers (new and existing) affected. Announced Feb 23, 2026",
       "impact": "high",


### PR DESCRIPTION
Refs #1181, #1282. Data only — `data/deal_changes.json`, one record's `summary`.

## Why this one field

https://github.com/robhunter/agentdeals/pull/1286 corrected the catalogue record, and `/vendor/hetzner` still published `€3.99` three times afterwards. All three come from this change record's `summary`, on the three surfaces https://github.com/robhunter/agentdeals/issues/1282 named:

- the **risk verdict lede** — *"Why caution: 2026-04-01 — Cloud & dedicated server prices increasing 30-50%. Entry-level CX23: €2.99→€3.99/mo"*
- the **Pricing Change History** entry
- the **FAQ answer** to "Hetzner's pricing?"

The April 1 record is the only Hetzner change we hold, so it reads as current. It is accurate about April; it is 135 days stale as a description of what Hetzner charges.

## What changed

Appended to `summary`, not substituted — the April text is a correct record of an April event, and per decision 273 a correction goes in `summary` because that is what `serve.ts` renders:

> Superseded 2026-06-15: Hetzner ran a second adjustment across all cloud and dedicated lines, applying to new orders and rescales only, and renamed the lineup. Read from hetzner.com on 2026-09-03: CX23 is €5.99 and is marked "not available", as is every other shared-vCPU plan, and the cheapest orderable plan is CPX12 at €11.99/mo.

Prices read from Hetzner's own price API — method and the full 25-row table are on https://github.com/robhunter/agentdeals/issues/1181.

## What this is not

**Not the June change record.** Criterion 4 of #1181 asks for a separate `2026-06-15` row with its own impact rating, and that should come from a detector rather than my hand — this record is already `date_source: "hand_written"` and I would rather not add a second. The row it should produce is specified on the issue.

**Not the render-source fix.** Eight literal sites in `serve.ts` still publish April numbers, including a site-wide banner at line 9134. Listed on #1181.

## Checks

`npm run validate` clean — 1580 offers, 493 deal changes. `data/deal_changes.json` round-trips byte-identical through `json.dumps(indent=2, ensure_ascii=False)` plus a trailing newline, asserted before and after. `grep -rn "3\.99\|CX23" test/` returns nothing pinning this string. No `src/`, no `test/`.