### PR TITLE
Record that a change is no longer in force (#1282, #1276)

### DIFF
--- a/data/deal_changes.json
+++ b/data/deal_changes.json
@@ -285,7 +285,17 @@
         "GitHub Pages"
       ],
       "recorded_date": "2026-03-31",
-      "date_source": "hand_written"
+      "date_source": "hand_written",
+      "resolution": {
+        "state": "reversed",
+        "date": "2026-04-14",
+        "source_url": "https://www.netlify.com/pricing/",
+        "resolved_by": {
+          "vendor": "Netlify",
+          "date": "2026-04-14",
+          "change_type": "limits_increased"
+        }
+      }
     },
     {
       "vendor": "Supabase",
@@ -4179,7 +4189,7 @@
       "vendor": "Cursor",
       "change_type": "pricing_restructured",
       "date": "2026-04-13",
-      "summary": "Cursor now offers 6 plans: Free, Hobby ($10/mo), Pro ($20/mo), Pro+ ($60/mo), Business ($40/seat), Ultra ($200/mo). Hobby tier added as lighter paid option between Free and Pro. Credit-based pricing model since June 2025. Retracted 2026-09-02: Cursor has never offered a $10/month Hobby tier - Hobby is the name of its free plan. This row was our error, not a change Cursor made.",
+      "summary": "Cursor now offers 6 plans: Free, Hobby ($10/mo), Pro ($20/mo), Pro+ ($60/mo), Business ($40/seat), Ultra ($200/mo). Hobby tier added as lighter paid option between Free and Pro. Credit-based pricing model since June 2025.",
       "previous_state": "5-tier structure (Free, Pro, Pro+, Business, Ultra)",
       "current_state": "Retracted 2026-09-02. Cursor has no $10/month Hobby tier and there is no evidence it ever had one — Hobby is the name of its free plan. The lineup on cursor.com/pricing today is Hobby (free), Pro $20, Pro+ $60, Ultra $200, Teams $40/user, Enterprise custom. This row is our error, not a vendor change.",
       "impact": "low",
@@ -4191,7 +4201,18 @@
         "Claude Code"
       ],
       "recorded_date": "2026-04-13",
-      "date_source": "hand_written"
+      "date_source": "hand_written",
+      "resolution": {
+        "state": "retracted",
+        "date": "2026-09-02",
+        "detail": "Retracted 2026-09-02: Cursor has never offered a $10/month Hobby tier - Hobby is the name of its free plan. This row was our error, not a change Cursor made.",
+        "source_url": "https://www.cursor.com/pricing",
+        "resolved_by": {
+          "vendor": "Cursor",
+          "date": "2026-09-02",
+          "change_type": "record_corrected"
+        }
+      }
     },
     {
       "vendor": "n8n",
@@ -4506,7 +4527,7 @@
       "vendor": "GitHub Copilot",
       "change_type": "restriction",
       "date": "2026-04-10",
-      "summary": "GitHub paused new Copilot Pro trials due to abuse. Existing trials continued through their term. New users could still subscribe to Pro directly (paid) until the broader April 20 signup pause closed that path too. Resolved: Copilot Pro is open to new subscribers, verified 2026-09-02 against GitHub's plans documentation.",
+      "summary": "GitHub paused new Copilot Pro trials due to abuse. Existing trials continued through their term. New users could still subscribe to Pro directly (paid) until the broader April 20 signup pause closed that path too.",
       "previous_state": "Copilot Pro offered a 30-day free trial to any new user",
       "current_state": "Resolved. Copilot Pro is open to new subscribers today (verified 2026-09-02 against GitHub's plans documentation); the trial pause is no longer reflected in GitHub's current plan pages.",
       "impact": "medium",
@@ -4519,13 +4540,19 @@
         "Claude Code"
       ],
       "recorded_date": "2026-04-21",
-      "date_source": "hand_written"
+      "date_source": "hand_written",
+      "resolution": {
+        "state": "reversed",
+        "date": "2026-09-02",
+        "detail": "Resolved: Copilot Pro is open to new subscribers, verified 2026-09-02 against GitHub's plans documentation.",
+        "source_url": "https://docs.github.com/en/copilot/get-started/plans"
+      }
     },
     {
       "vendor": "GitHub Copilot",
       "change_type": "restriction",
       "date": "2026-04-20",
-      "summary": "GitHub paused new signups for Copilot Pro, Pro+, and Copilot Student plans citing infrastructure strain from agentic AI workflows (long-running, parallelized sessions overwhelming capacity). Existing users are unaffected. Free tier signups remain open. Same announcement also removed Claude Opus from Pro (now Pro+ only) and tightened usage limits on individual plans. Reversed: GitHub's changelog post for this change is marked Retired, and its plans documentation offers Copilot Pro, Pro+, Max and Copilot Student to new users, verified 2026-09-02. The only pause still on that page is a separate one dated 2026-04-22 on self-serve purchases of Copilot Business and Copilot Enterprise.",
+      "summary": "GitHub paused new signups for Copilot Pro, Pro+, and Copilot Student plans citing infrastructure strain from agentic AI workflows (long-running, parallelized sessions overwhelming capacity). Existing users are unaffected. Free tier signups remain open. Same announcement also removed Claude Opus from Pro (now Pro+ only) and tightened usage limits on individual plans.",
       "previous_state": "Pro ($10/mo), Pro+ ($39/mo), and Copilot Student plans accepting new signups. Claude Opus available on Pro. Standard individual-plan usage limits.",
       "current_state": "Reversed. GitHub's changelog post for this change is marked Retired, and its plans documentation offers Copilot Pro, Pro+, Max and Copilot Student to new users today (verified 2026-09-02). The pause that remains in force is a separate one dated 2026-04-22 on self-serve purchase of Copilot Business and Copilot Enterprise. Free tier was unaffected throughout.",
       "impact": "high",
@@ -4539,7 +4566,13 @@
         "Cline"
       ],
       "recorded_date": "2026-04-21",
-      "date_source": "hand_written"
+      "date_source": "hand_written",
+      "resolution": {
+        "state": "reversed",
+        "date": "2026-09-02",
+        "detail": "Reversed: GitHub's changelog post for this change is marked Retired, and its plans documentation offers Copilot Pro, Pro+, Max and Copilot Student to new users, verified 2026-09-02. The only pause still on that page is a separate one dated 2026-04-22 on self-serve purchases of Copilot Business and Copilot Enterprise.",
+        "source_url": "https://docs.github.com/en/copilot/get-started/plans"
+      }
     },
     {
       "vendor": "Amazon SES",

--- a/scripts/mutate-1282.sh
+++ b/scripts/mutate-1282.sh
@@ -1,0 +1,195 @@
+#!/usr/bin/env bash
+set -u
+
+REPO="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$REPO" || exit 1
+
+FILES="src/change-resolution.ts src/data.ts src/change-lineup.ts src/serve.ts"
+BACKUP_DIR="$(mktemp -d)"
+for f in $FILES; do cp "$f" "$BACKUP_DIR/$(basename "$f")"; done
+
+restore() {
+  for f in $FILES; do cp "$BACKUP_DIR/$(basename "$f")" "$f"; done
+  npm run build > /dev/null 2>&1
+}
+trap restore EXIT
+
+killed=0
+survived=0
+TESTS="test/change-resolution.test.ts test/change-lineup.test.ts"
+
+run_mutation() {
+  local name="$1"
+  shift
+  echo "=== $name"
+  for f in $FILES; do cp "$BACKUP_DIR/$(basename "$f")" "$f"; done
+  "$@"
+  local changed=0
+  for f in $FILES; do
+    diff -q "$BACKUP_DIR/$(basename "$f")" "$f" > /dev/null || changed=1
+  done
+  if [ "$changed" -eq 0 ]; then
+    echo "    NOT APPLIED: the mutation changed no file, so it proves nothing"
+    survived=$((survived + 1))
+    return
+  fi
+  if ! npm run build > /tmp/mutate-1282-build.log 2>&1; then
+    echo "    KILLED: the mutation does not typecheck"
+    killed=$((killed + 1))
+    return
+  fi
+  if timeout 900 node --test $TESTS > /tmp/mutate-1282-test.log 2>&1; then
+    echo "    SURVIVED"
+    survived=$((survived + 1))
+  else
+    echo "    KILLED: $(grep -c '✖ ' /tmp/mutate-1282-test.log) failing assertion(s)"
+    grep '✖ ' /tmp/mutate-1282-test.log | head -4
+    killed=$((killed + 1))
+  fi
+}
+
+py() {
+  python3 - "$@"
+}
+
+m_a_resolution_does_not_reach_the_summary() {
+  py <<'PY'
+p = "src/change-resolution.ts"
+s = open(p).read()
+s = s.replace('''export function withResolutionInSummary<T extends ResolvableChange>(change: T): T {
+  if (!change.resolution) return change;
+  return { ...change, summary: summaryWithResolution(change) };
+}''', '''export function withResolutionInSummary<T extends ResolvableChange>(change: T): T {
+  return change;
+}''')
+open(p, "w").write(s)
+PY
+}
+
+m_the_summary_states_the_resolution_twice() {
+  py <<'PY'
+p = "src/change-resolution.ts"
+s = open(p).read()
+s = s.replace('  return change.summary.includes(detail) ? change.summary : `${change.summary} ${detail}`;',
+              '  return `${change.summary} ${detail}`;')
+open(p, "w").write(s)
+PY
+}
+
+m_a_resolved_change_still_demotes() {
+  py <<'PY'
+p = "src/data.ts"
+s = open(p).read()
+s = s.replace('  if (isNoLongerInForce(change)) return null;\n  const flat = RISK_DEMOTION[change.change_type];',
+              '  const flat = RISK_DEMOTION[change.change_type];')
+open(p, "w").write(s)
+PY
+}
+
+m_a_resolved_change_still_counts_toward_stability() {
+  py <<'PY'
+p = "src/data.ts"
+s = open(p).read()
+s = s.replace('  const stillInForce = vendorChanges.filter((c) => !isNoLongerInForce(c));',
+              '  const stillInForce = vendorChanges;')
+open(p, "w").write(s)
+PY
+}
+
+m_a_retracted_record_still_states_a_lineup() {
+  py <<'PY'
+p = "src/change-lineup.ts"
+s = open(p).read()
+s = s.replace('  if (theEventNeverHappened(change)) return false;\n', '')
+open(p, "w").write(s)
+PY
+}
+
+m_a_reversal_reads_as_a_retraction() {
+  py <<'PY'
+p = "src/change-resolution.ts"
+s = open(p).read()
+s = s.replace('  return change.resolution?.state === "retracted";',
+              '  return Boolean(change.resolution);')
+open(p, "w").write(s)
+PY
+}
+
+m_prose_alone_passes_the_guard() {
+  py <<'PY'
+p = "src/change-resolution.ts"
+s = open(p).read()
+s = s.replace('''const RESOLUTION_ASSERTIONS = [
+  /\\breversed\\b/i,''', '''const RESOLUTION_ASSERTIONS = [
+  /\\bnothing at all\\b/i,''')
+open(p, "w").write(s)
+PY
+}
+
+m_the_detail_is_not_stripped_before_the_guard_reads_it() {
+  py <<'PY'
+p = "src/change-resolution.ts"
+s = open(p).read()
+s = s.replace('''  const withoutDetail = (text: string | undefined) =>
+    detail && text ? text.split(detail).join(" ") : text;''',
+'''  const withoutDetail = (text: string | undefined) => text;''')
+open(p, "w").write(s)
+PY
+}
+
+m_a_resolving_record_need_not_exist() {
+  py <<'PY'
+p = "src/change-resolution.ts"
+s = open(p).read()
+s = s.replace('''  return (
+    log.find((c) => c.vendor === ref.vendor && c.date === ref.date && c.change_type === ref.change_type) ?? null
+  );''', '''  return log[0] ?? null;''')
+open(p, "w").write(s)
+PY
+}
+
+m_risk_cause_drops_the_record_state() {
+  py <<'PY'
+p = "src/data.ts"
+s = open(p).read()
+s = s.replace('''    current_state: cause.current_state,
+    resolution: cause.resolution ?? null,''', '')
+open(p, "w").write(s)
+PY
+}
+
+m_the_vendor_page_does_not_mark_a_resolved_change() {
+  py <<'PY'
+p = "src/serve.ts"
+s = open(p).read()
+s = s.replace('return `<div class="change-item${isNoLongerInForce(c) ? " change-resolved" : ""}">',
+              'return `<div class="change-item">')
+open(p, "w").write(s)
+PY
+}
+
+m_the_change_log_does_not_mark_a_resolved_change() {
+  py <<'PY'
+p = "src/serve.ts"
+s = open(p).read()
+s = s.replace('${isNoLongerInForce(c) ? " pc-resolved" : ""}', '')
+open(p, "w").write(s)
+PY
+}
+
+run_mutation "a resolution does not reach the summary" m_a_resolution_does_not_reach_the_summary
+run_mutation "the summary states the resolution twice" m_the_summary_states_the_resolution_twice
+run_mutation "a resolved change still demotes" m_a_resolved_change_still_demotes
+run_mutation "a resolved change still counts toward stability" m_a_resolved_change_still_counts_toward_stability
+run_mutation "a retracted record still states a lineup" m_a_retracted_record_still_states_a_lineup
+run_mutation "a reversal reads as a retraction" m_a_reversal_reads_as_a_retraction
+run_mutation "prose alone passes the guard" m_prose_alone_passes_the_guard
+run_mutation "the detail is not stripped before the guard reads it" m_the_detail_is_not_stripped_before_the_guard_reads_it
+run_mutation "a resolving record need not exist" m_a_resolving_record_need_not_exist
+run_mutation "risk_cause drops the record state" m_risk_cause_drops_the_record_state
+run_mutation "the vendor page does not mark a resolved change" m_the_vendor_page_does_not_mark_a_resolved_change
+run_mutation "the change log does not mark a resolved change" m_the_change_log_does_not_mark_a_resolved_change
+
+echo
+echo "killed $killed  survived $survived"
+[ "$survived" -eq 0 ]

--- a/src/change-lineup.ts
+++ b/src/change-lineup.ts
@@ -1,9 +1,13 @@
+import { theEventNeverHappened } from "./change-resolution.js";
+import type { ChangeResolution } from "./types.js";
+
 export interface LineupClaim {
   vendor: string;
   date: string;
   change_type?: string;
   summary?: string;
   current_state?: string;
+  resolution?: ChangeResolution | null;
 }
 
 const PRICE_TOKEN = /\$\d[\d,]*(?:\.\d+)?/g;
@@ -18,6 +22,7 @@ export function statedPrices(change: LineupClaim): Set<string> {
 
 export function statesAPlanLineup(change: LineupClaim): boolean {
   if (change.change_type === NOT_A_VENDOR_CHANGE) return false;
+  if (theEventNeverHappened(change)) return false;
   return statedPrices(change).size >= PRICES_THAT_MAKE_A_LINEUP;
 }
 

--- a/src/change-resolution.ts
+++ b/src/change-resolution.ts
@@ -1,0 +1,64 @@
+import type { ChangeResolution, ChangeResolutionState } from "./types.js";
+
+export interface ResolvableChange {
+  summary: string;
+  current_state?: string;
+  resolution?: ChangeResolution | null;
+}
+
+export const RESOLUTION_STATES: ChangeResolutionState[] = ["reversed", "retracted"];
+
+export function isNoLongerInForce(change: { resolution?: ChangeResolution | null }): boolean {
+  return Boolean(change.resolution);
+}
+
+export function theEventNeverHappened(change: { resolution?: ChangeResolution | null }): boolean {
+  return change.resolution?.state === "retracted";
+}
+
+export function resolvingRecord<T extends { vendor: string; date: string; change_type: string }>(
+  change: { resolution?: ChangeResolution | null },
+  log: readonly T[],
+): T | null {
+  const ref = change.resolution?.resolved_by;
+  if (!ref) return null;
+  return (
+    log.find((c) => c.vendor === ref.vendor && c.date === ref.date && c.change_type === ref.change_type) ?? null
+  );
+}
+
+export function summaryWithResolution(change: ResolvableChange): string {
+  const detail = change.resolution?.detail;
+  if (!detail) return change.summary;
+  return change.summary.includes(detail) ? change.summary : `${change.summary} ${detail}`;
+}
+
+export function withResolutionInSummary<T extends ResolvableChange>(change: T): T {
+  if (!change.resolution) return change;
+  return { ...change, summary: summaryWithResolution(change) };
+}
+
+const RESOLUTION_ASSERTIONS = [
+  /\breversed\b/i,
+  /\bretracted\b/i,
+  /\brescinded\b/i,
+  /\bno longer in force\b/i,
+  /(?:^|[.;—-]\s)resolved\b/i,
+  /\bthis (?:row|record) (?:is|was) our error\b/i,
+];
+
+export function prosePutsAResolutionIn(text: string | undefined | null): boolean {
+  if (!text) return false;
+  return RESOLUTION_ASSERTIONS.some((pattern) => pattern.test(text));
+}
+
+export function fieldsAssertingAResolution(change: ResolvableChange): string[] {
+  const detail = change.resolution?.detail ?? "";
+  const withoutDetail = (text: string | undefined) =>
+    detail && text ? text.split(detail).join(" ") : text;
+  const fields: Array<[string, string | undefined]> = [
+    ["summary", withoutDetail(change.summary)],
+    ["current_state", withoutDetail(change.current_state)],
+  ];
+  return fields.filter(([, text]) => prosePutsAResolutionIn(text)).map(([name]) => name);
+}

--- a/src/data.ts
+++ b/src/data.ts
@@ -18,6 +18,7 @@ import { isSubSlug, toSlug } from "./slug.js";
 import { DATE_SOURCES, isEventDated, changeDateClause, isoWeekWindow, changesInWindow, discoveryBatchNote, firstReadHeading, type DateWindow } from "./change-dates.js";
 import { PRODUCT_DEPRECATED, deprecationEndsTheListedProduct } from "./product-deprecation.js";
 import { vendorHistorySentence } from "./vendor-history.js";
+import { isNoLongerInForce, withResolutionInSummary } from "./change-resolution.js";
 import { endedVerdictSentence } from "./retirement.js";
 
 export function gateForOffer(offer: Offer): Gate | null {
@@ -298,8 +299,9 @@ export const SEVERE_TYPES_WITHOUT_FLAT_DEMOTION: Record<string, string> = {
 };
 
 export function demotionForChange(
-  change: Pick<DealChange, "change_type" | "vendor" | "summary">,
+  change: Pick<DealChange, "change_type" | "vendor" | "summary"> & { resolution?: DealChange["resolution"] },
 ): "risky" | "caution" | null {
+  if (isNoLongerInForce(change)) return null;
   const flat = RISK_DEMOTION[change.change_type];
   if (flat) return flat;
   if (change.change_type === PRODUCT_DEPRECATED) {
@@ -309,7 +311,7 @@ export function demotionForChange(
 }
 
 export function isSevereChange(
-  change: Pick<DealChange, "change_type" | "vendor" | "summary">,
+  change: Pick<DealChange, "change_type" | "vendor" | "summary"> & { resolution?: DealChange["resolution"] },
 ): boolean {
   return VOLATILE_TYPES.has(change.change_type) && demotionForChange(change) !== null;
 }
@@ -322,10 +324,11 @@ const POSITIVE_STABILITY_TYPES = POSITIVE_CHANGE_TYPES;
 export function classifyStability(vendorChanges: DealChange[], nowMs: number = Date.now()): StabilityClass {
   if (vendorChanges.length === 0) return "stable";
 
-  const hasVolatile = vendorChanges.some(isSevereChange);
-  const negativeCount = vendorChanges.filter(c => NEGATIVE_STABILITY_TYPES.has(c.change_type)).length;
-  const positiveCount = vendorChanges.filter(c => POSITIVE_STABILITY_TYPES.has(c.change_type)).length;
-  const riskScaleActs = vendorChanges.some(c => demotionInForce(c, nowMs) !== null);
+  const stillInForce = vendorChanges.filter((c) => !isNoLongerInForce(c));
+  const hasVolatile = stillInForce.some(isSevereChange);
+  const negativeCount = stillInForce.filter(c => NEGATIVE_STABILITY_TYPES.has(c.change_type)).length;
+  const positiveCount = stillInForce.filter(c => POSITIVE_STABILITY_TYPES.has(c.change_type)).length;
+  const riskScaleActs = stillInForce.some(c => demotionInForce(c, nowMs) !== null);
 
   if (hasVolatile || (negativeCount >= 2 && riskScaleActs)) return "volatile";
 
@@ -418,7 +421,7 @@ export function enrichOffers(offers: Offer[]): EnrichedOffer[] {
         ? null
         : assessment.level;
     const risk_cause = assessment.cause
-      ? { date: assessment.cause.date, date_source: assessment.cause.date_source, change_type: assessment.cause.change_type, summary: assessment.cause.summary }
+      ? riskCauseOf(assessment.cause)
       : null;
 
     const stability = withheldStability(
@@ -481,7 +484,7 @@ export function loadDealChanges(): DealChange[] {
     return cachedChanges;
   }
 
-  cachedChanges = data.changes;
+  cachedChanges = data.changes.map(withResolutionInSummary);
   return cachedChanges;
 }
 
@@ -747,7 +750,7 @@ export function verdictHasLapsed(
 }
 
 export function demotionInForce(
-  change: Pick<DealChange, "change_type" | "vendor" | "summary" | "date">,
+  change: Pick<DealChange, "change_type" | "vendor" | "summary" | "date"> & { resolution?: DealChange["resolution"] },
   nowMs: number = Date.now(),
 ): "risky" | "caution" | null {
   return verdictHasLapsed(change, nowMs) ? null : demotionForChange(change);
@@ -774,6 +777,18 @@ export function vendorRiskAssessment(vendorChanges: DealChange[], nowMs: number 
   }
 
   return best ? { level: best.level, cause: best.cause } : { level: "stable", cause: null };
+}
+
+export function riskCauseOf(cause: DealChange | null | undefined): RiskCause | null {
+  if (!cause) return null;
+  return {
+    date: cause.date,
+    date_source: cause.date_source,
+    change_type: cause.change_type,
+    summary: cause.summary,
+    current_state: cause.current_state,
+    resolution: cause.resolution ?? null,
+  };
 }
 
 export function vendorRiskLevel(vendorChanges: DealChange[]): "stable" | "caution" | "risky" {
@@ -829,7 +844,7 @@ export function checkVendorRisk(
       const altGate = gateForOffer(e.offer);
       return {
         risk_level: altGate || (cannotVouchForLevel(e.offer, unreachable) && a.level === "stable") ? null : a.level,
-        risk_cause: a.cause ? { date: a.cause.date, date_source: a.cause.date_source, change_type: a.cause.change_type, summary: a.cause.summary } : null,
+        risk_cause: riskCauseOf(a.cause),
         link_unreachable: unreachable,
         gate: altGate,
       };
@@ -869,7 +884,7 @@ export function checkVendorRisk(
       vendor_match: matchNotice,
       category: offer.category,
       risk_level: gate || (cannotVouchForLevel(offer, linkUnreachable) && riskLevel === "stable") ? null : riskLevel,
-      risk_cause: cause ? { date: cause.date, date_source: cause.date_source, change_type: cause.change_type, summary: cause.summary } : null,
+      risk_cause: riskCauseOf(cause),
       link_unreachable: linkUnreachable,
       source_check: offer.source_check ?? null,
       gate,

--- a/src/openapi.ts
+++ b/src/openapi.ts
@@ -380,7 +380,7 @@ export const openapiSpec = {
                     category: { type: "string" },
                     risk_level: { type: "string", enum: ["stable", "caution", "risky"], nullable: true, description: "Null where the offer's own link is confirmed unreachable (#1046) — we withhold the level rather than publish a favourable one we cannot check. Also null where gate is non-null (#1241): an offer we have decided not to list is not one we rate." },
                     link_unreachable: { type: "object", nullable: true, description: "Non-null only where a check reached a conclusion about the destination: a 404 confirmed by a full request, a 410, or a hostname with no address. Being refused (403, 429, 5xx, timeout) is evidence about our checker and never produces one of these.", properties: { last_reachable: { type: "string", format: "date", nullable: true }, checked: { type: "string", format: "date" }, terminal: { type: "boolean" } } },
-                    risk_cause: { type: "object", nullable: true, description: "The single dated record that produced a non-stable risk_level. Never null when risk_level is caution or risky (#1038) — a client that renders the level must be able to render the reason.", properties: { date: { type: "string" }, change_type: { type: "string" }, summary: { type: "string" } } },
+                    risk_cause: { type: "object", nullable: true, description: "The single dated record that produced a non-stable risk_level. Never null when risk_level is caution or risky (#1038) — a client that renders the level must be able to render the reason.", properties: { date: { type: "string" }, change_type: { type: "string" }, summary: { type: "string" }, current_state: { type: "string" }, resolution: { $ref: "#/components/schemas/ChangeResolution" } } },
                     gate: { $ref: "#/components/schemas/Gate" },
                     source_check: { $ref: "#/components/schemas/SourceCheck" },
                     free_tier_longevity_days: { type: "number", nullable: true, description: "Null where the gate code is offer_retired or not_a_free_offer (#1241) — a count of days a free tier has held has no referent where our own record says there is no free tier." },
@@ -396,7 +396,7 @@ export const openapiSpec = {
                           risk_level: { type: "string", enum: ["stable", "caution", "risky"], nullable: true, description: "Null where this alternative's own link is confirmed unreachable (#1046), and null where its gate is non-null (#1241) — rankForListing demotes a gated record to the tail rather than dropping it, so an alternative can be one we do not list." },
                           link_unreachable: { type: "object", nullable: true, properties: { last_reachable: { type: "string", format: "date", nullable: true }, checked: { type: "string", format: "date" }, terminal: { type: "boolean" } } },
                           gate: { $ref: "#/components/schemas/Gate" },
-                          risk_cause: { type: "object", nullable: true, description: "The single dated record that produced a non-stable risk_level. Never null when risk_level is caution or risky (#1038) — a client that renders the level must be able to render the reason.", properties: { date: { type: "string" }, change_type: { type: "string" }, summary: { type: "string" } } }
+                          risk_cause: { type: "object", nullable: true, description: "The single dated record that produced a non-stable risk_level. Never null when risk_level is caution or risky (#1038) — a client that renders the level must be able to render the reason.", properties: { date: { type: "string" }, change_type: { type: "string" }, summary: { type: "string" }, current_state: { type: "string" }, resolution: { $ref: "#/components/schemas/ChangeResolution" } } }
                         }
                       }
                     },
@@ -1015,9 +1015,23 @@ export const openapiSpec = {
           impact: { type: "string", enum: ["high", "medium", "low"] },
           source_url: { type: "string", format: "uri" },
           category: { type: "string" },
-          alternatives: { type: "array", items: { type: "string" } }
+          alternatives: { type: "array", items: { type: "string" } },
+          resolution: { $ref: "#/components/schemas/ChangeResolution" }
         },
         required: ["vendor", "change_type", "date", "summary", "previous_state", "current_state", "impact", "source_url", "category", "alternatives"]
+      },
+      ChangeResolution: {
+        type: "object",
+        nullable: true,
+        description: "Present when the change this record describes is no longer in force. state is 'reversed' when the vendor ended it and 'retracted' when the record was our error. date is the day from which it stopped being in force, or the day we established that, whichever we can source. resolved_by names the change record that ended it, when one exists. A record carrying this field never rates the vendor.",
+        properties: {
+          state: { type: "string", enum: ["reversed", "retracted"] },
+          date: { type: "string", format: "date" },
+          detail: { type: "string" },
+          source_url: { type: "string", format: "uri" },
+          resolved_by: { type: "object", properties: { vendor: { type: "string" }, date: { type: "string", format: "date" }, change_type: { type: "string" } } }
+        },
+        required: ["state", "date"]
       }
     }
   }

--- a/src/serve.ts
+++ b/src/serve.ts
@@ -23,6 +23,7 @@ import { stabilityFaqAnswer, stabilityVerdictClause, type ComparisonSide, type S
 import { publishedVendorLevel, vendorVerdictSentence, vendorBadge, statesRiskCause, narrowingSentence, changeKindNoun, type VendorVerdictInput } from "./vendor-verdict.js";
 import { vendorHistorySentence } from "./vendor-history.js";
 import { changeTimelineDate, supersededLineups, supersessionNote } from "./change-lineup.js";
+import { isNoLongerInForce } from "./change-resolution.js";
 import { growthLimitPhrases } from "./growth-limits.js";
 import { registerAgent, authenticateRequest, validateVestauthUrl, hashApiKey, updateAgentX402Address, getAgentById } from "./agents.js";
 import { attributeAuthenticatedRequest } from "./referral-attribution.js";
@@ -3903,7 +3904,7 @@ ${enrichedAlts.map(a => {
   const changesHtml = vendorChanges.length > 0 ? vendorChanges.map(c => {
     const badge = changeTypeBadge[c.change_type] ?? { label: c.change_type, color: "#8b949e" };
     const anchor = `${toSlug(c.vendor)}-${c.date}`;
-    return `<div class="change-item">
+    return `<div class="change-item${isNoLongerInForce(c) ? " change-resolved" : ""}">
         <div class="change-head">
           <span class="badge" style="background:${badge.color}">${badge.label}</span>
           <span class="change-date"><a href="/pricing-changes#${anchor}" style="color:var(--text-dim);text-decoration:none">${changeDateLabel(c)}</a></span>
@@ -4270,6 +4271,7 @@ h1 .risk-badge{font-size:.75rem;font-weight:600;padding:.2rem .6rem;border-radiu
 .change-summary{font-size:.85rem;color:var(--text-muted)}
 .change-detail{font-size:.8rem;color:var(--text-dim);margin-top:.25rem}
 .state-label{font-family:var(--mono);font-size:.7rem;color:var(--text-dim)}
+.change-resolved{opacity:.6;border-left-style:dashed}
 .no-changes{color:var(--text-dim);font-size:.9rem;font-style:italic}
 ${auditBlockCss()}
 .alt-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(180px,1fr));gap:.5rem}
@@ -26913,7 +26915,7 @@ function buildAiCodingPricing2026Page(): string {
     const historyNote = newest
       ? `<div class="superseded-note">${escHtmlServer(supersessionNote(newest, changeTimelineDate))}</div>`
       : "";
-    return `<tr${newest ? ` class="superseded-row"` : ""}>
+    return `<tr${newest || isNoLongerInForce(c) ? ` class="superseded-row"` : ""}>
       <td style="font-family:var(--mono);font-size:.8rem;white-space:nowrap">${escHtmlServer(dateStr)}</td>
       <td style="font-weight:600">${escHtmlServer(c.vendor)}</td>
       <td style="font-size:.85rem">${escHtmlServer(c.summary)}${historyNote}</td>
@@ -27528,7 +27530,7 @@ function buildAiCodingToolsPricingPage(): string {
     const historyNote = newest
       ? '<div class="superseded-note">' + escHtmlServer(supersessionNote(newest, changeTimelineDate)) + '</div>'
       : "";
-    return '<tr' + (newest ? ' class="superseded-row"' : "") + '>' +
+    return '<tr' + (newest || isNoLongerInForce(c) ? ' class="superseded-row"' : "") + '>' +
       '<td style="font-family:var(--mono);font-size:.8rem;white-space:nowrap">' + escHtmlServer(dateStr) + '</td>' +
       '<td style="font-weight:600">' + escHtmlServer(c.vendor) + '</td>' +
       '<td style="font-size:.85rem">' + escHtmlServer(c.summary) + historyNote + '</td>' +
@@ -48786,7 +48788,7 @@ function buildPricingChangesPage(): string {
       : "";
     const vendorCat = (c.category || "").toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/(^-|-$)/g, "");
     const changeYear = dated ? c.date.slice(0, 4) : "";
-    return `      <div class="pc-entry${isUpcoming ? " pc-upcoming" : ""}${dated ? "" : " pc-undated"}" id="${changeAnchor(c)}" data-type="${escHtmlServer(c.change_type)}" data-impact="${escHtmlServer(c.impact)}" data-category="${category}" data-vendor-cat="${vendorCat}" data-year="${changeYear}">
+    return `      <div class="pc-entry${isUpcoming ? " pc-upcoming" : ""}${dated ? "" : " pc-undated"}${isNoLongerInForce(c) ? " pc-resolved" : ""}" id="${changeAnchor(c)}" data-type="${escHtmlServer(c.change_type)}" data-impact="${escHtmlServer(c.impact)}" data-category="${category}" data-vendor-cat="${vendorCat}" data-year="${changeYear}">
         <div class="pc-left">
           <div class="pc-date">${dated ? c.date : `${DISCOVERED_DATE_PREFIX} ${c.date}`}</div>
           ${isUpcoming ? `<div class="pc-upcoming-badge">upcoming</div>` : ""}
@@ -49030,6 +49032,7 @@ h1{font-family:var(--serif);font-size:2.25rem;color:var(--text);margin:1rem 0 .5
 .month-group{margin-bottom:2rem}
 .month-heading{font-family:var(--serif);font-size:1.15rem;color:var(--text);margin-bottom:.75rem;padding-bottom:.5rem;border-bottom:1px solid var(--border)}
 .pc-entry{display:flex;gap:1rem;padding:.75rem;margin-bottom:.5rem;border:1px solid var(--border);border-radius:8px;background:var(--bg-card);transition:border-color .2s,background .2s}
+.pc-resolved{opacity:.6;border-style:dashed}
 .pc-entry:hover{border-color:var(--accent)}
 .pc-entry:target{border-color:var(--accent);background:var(--accent-glow)}
 .pc-upcoming{border-color:rgba(88,166,255,0.3)}

--- a/src/types.ts
+++ b/src/types.ts
@@ -97,11 +97,29 @@ export type StabilityClass = "stable" | "watch" | "volatile" | "improving";
 
 export type RiskLevel = "stable" | "caution" | "risky";
 
+export type ChangeResolutionState = "reversed" | "retracted";
+
+export interface ChangeRecordRef {
+  vendor: string;
+  date: string;
+  change_type: string;
+}
+
+export interface ChangeResolution {
+  state: ChangeResolutionState;
+  date: string;
+  detail?: string;
+  source_url?: string;
+  resolved_by?: ChangeRecordRef;
+}
+
 export interface RiskCause {
   date: string;
   date_source?: ChangeDateSource;
   change_type: string;
   summary: string;
+  current_state?: string;
+  resolution?: ChangeResolution | null;
 }
 
 export interface LinkUnreachable {
@@ -141,6 +159,7 @@ export interface DealChange {
   detected_by?: string;
   recorded_date?: string;
   date_source?: ChangeDateSource;
+  resolution?: ChangeResolution | null;
 }
 
 export interface DealChangesIndex {

--- a/test/change-lineup.test.ts
+++ b/test/change-lineup.test.ts
@@ -11,7 +11,7 @@ import {
   statesAPlanLineup,
   supersededLineups,
   supersessionNote,
-} from "../src/change-lineup.ts";
+} from "../dist/change-lineup.js";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const REPO = path.join(__dirname, "..");
@@ -128,10 +128,12 @@ describe("the stored change log, read through the rule", () => {
     assert.strictEqual(superseded.get(march)?.date, "2026-04-13");
   });
 
-  it("marks the Cursor record that prices a Hobby plan the free plan is named after", () => {
-    const april = find("Cursor", "2026-04-13");
+  it("leaves the retracted Cursor Hobby record out of the lineup population entirely", () => {
+    const april = stored.find(c => c.vendor === "Cursor" && c.date === "2026-04-13")!;
     assert.ok(april.summary.includes("Hobby ($10/mo)"));
-    assert.strictEqual(superseded.get(april)?.date, "2026-08-28");
+    assert.strictEqual(april.resolution?.state, "retracted");
+    assert.strictEqual(statesAPlanLineup(april), false);
+    assert.strictEqual(superseded.has(april), false);
   });
 
   it("leaves our newest read of a vendor standing when a correction follows it", () => {

--- a/test/change-resolution.test.ts
+++ b/test/change-resolution.test.ts
@@ -1,0 +1,305 @@
+import { describe, it, before, after } from "node:test";
+import assert from "node:assert";
+import { spawn, type ChildProcess } from "node:child_process";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import type { DealChange } from "../src/types.ts";
+import {
+  RESOLUTION_STATES,
+  fieldsAssertingAResolution,
+  isNoLongerInForce,
+  prosePutsAResolutionIn,
+  resolvingRecord,
+  summaryWithResolution,
+  theEventNeverHappened,
+  withResolutionInSummary,
+} from "../dist/change-resolution.js";
+import {
+  classifyStability,
+  demotionForChange,
+  demotionInForce,
+  isSevereChange,
+  loadDealChanges,
+  vendorRiskAssessment,
+} from "../dist/data.js";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO = path.join(__dirname, "..");
+
+const stored: DealChange[] = JSON.parse(
+  readFileSync(path.join(REPO, "data", "deal_changes.json"), "utf-8")
+).changes;
+
+const change = (over: Partial<DealChange> = {}): DealChange => ({
+  vendor: "Example",
+  change_type: "restriction",
+  date: "2026-04-20",
+  summary: "The vendor paused new signups.",
+  previous_state: "Open to new signups",
+  current_state: "Paused",
+  impact: "high",
+  source_url: "https://example.com/changelog",
+  category: "Cloud Hosting",
+  alternatives: [],
+  ...over,
+});
+
+const reversed = (over: Partial<DealChange> = {}) =>
+  change({
+    resolution: { state: "reversed", date: "2026-09-02", detail: "Reversed: signups are open again." },
+    ...over,
+  });
+
+describe("a record can say its change is no longer in force", () => {
+  it("carries the resolution wherever the summary is read", () => {
+    assert.strictEqual(
+      summaryWithResolution(reversed()),
+      "The vendor paused new signups. Reversed: signups are open again."
+    );
+  });
+
+  it("leaves a record with no resolution exactly as stored", () => {
+    const plain = change();
+    assert.strictEqual(summaryWithResolution(plain), plain.summary);
+    assert.strictEqual(withResolutionInSummary(plain), plain);
+  });
+
+  it("does not state the resolution twice when the summary already carries it", () => {
+    const once = withResolutionInSummary(reversed());
+    assert.strictEqual(withResolutionInSummary(once).summary, once.summary);
+  });
+
+  it("separates a change the vendor ended from a record we withdrew", () => {
+    assert.strictEqual(theEventNeverHappened(reversed()), false);
+    assert.strictEqual(
+      theEventNeverHappened(change({ resolution: { state: "retracted", date: "2026-09-02", detail: "Retracted." } })),
+      true
+    );
+    assert.strictEqual(isNoLongerInForce(change()), false);
+  });
+});
+
+describe("a change no longer in force does not rate the vendor", () => {
+  it("stops demoting on the type that would otherwise demote", () => {
+    assert.strictEqual(demotionForChange(change()), "caution");
+    assert.strictEqual(demotionForChange(reversed()), null);
+    assert.strictEqual(demotionInForce(reversed(), Date.parse("2026-04-21T00:00:00Z")), null);
+  });
+
+  it("stops counting as severe when the vendor gave the free tier back", () => {
+    const removal = change({ change_type: "free_tier_removed" });
+    assert.strictEqual(isSevereChange(removal), true);
+    assert.strictEqual(isSevereChange({ ...removal, resolution: reversed().resolution }), false);
+  });
+
+  it("cannot be the vendor's risk cause", () => {
+    const nowMs = Date.parse("2026-05-01T00:00:00Z");
+    assert.strictEqual(vendorRiskAssessment([change()], nowMs).level, "caution");
+    const resolved = vendorRiskAssessment([reversed()], nowMs);
+    assert.strictEqual(resolved.level, "stable");
+    assert.strictEqual(resolved.cause, null);
+  });
+
+  it("names the still-standing record when a vendor has one of each", () => {
+    const nowMs = Date.parse("2026-05-01T00:00:00Z");
+    const standing = change({ date: "2026-04-01", summary: "Limits cut on the free plan." });
+    const assessment = vendorRiskAssessment([reversed(), standing], nowMs);
+    assert.strictEqual(assessment.level, "caution");
+    assert.strictEqual(assessment.cause?.date, "2026-04-01");
+  });
+
+  it("leaves a vendor stable when its only adverse record has been reversed", () => {
+    const nowMs = Date.parse("2026-05-01T00:00:00Z");
+    assert.strictEqual(classifyStability([change()], nowMs), "watch");
+    assert.strictEqual(classifyStability([reversed()], nowMs), "stable");
+  });
+
+  it("does not read a reversed record as the vendor improving", () => {
+    const nowMs = Date.parse("2026-05-01T00:00:00Z");
+    assert.strictEqual(classifyStability([reversed({ change_type: "new_free_tier" })], nowMs), "stable");
+  });
+});
+
+describe("no record publishes a retraction the structured field does not hold", () => {
+  it("finds a resolution asserted in prose", () => {
+    assert.strictEqual(prosePutsAResolutionIn("Reversed: signups reopened."), true);
+    assert.strictEqual(prosePutsAResolutionIn("Retracted 2026-09-02: no such plan."), true);
+    assert.strictEqual(prosePutsAResolutionIn("The pause is no longer in force."), true);
+    assert.strictEqual(prosePutsAResolutionIn("The vendor paused new signups."), false);
+  });
+
+  it("would fail on a record that states its retraction in free text alone", () => {
+    const proseOnly = change({ summary: "The vendor paused new signups. Reversed: signups are open again." });
+    assert.deepStrictEqual(fieldsAssertingAResolution(proseOnly), ["summary"]);
+    assert.strictEqual(isNoLongerInForce(proseOnly), false);
+  });
+
+  it("does not count the resolution's own detail as free text", () => {
+    assert.deepStrictEqual(fieldsAssertingAResolution(withResolutionInSummary(reversed())), []);
+  });
+
+  it("holds across every stored change record", () => {
+    const proseOnly = stored
+      .filter((c) => !isNoLongerInForce(c) && fieldsAssertingAResolution(c).length > 0)
+      .map((c) => `${c.vendor} ${c.date} ${fieldsAssertingAResolution(c).join("+")}`);
+    assert.deepStrictEqual(proseOnly, []);
+  });
+
+  it("holds across every record as it is served", () => {
+    const served = loadDealChanges();
+    const proseOnly = served
+      .filter((c) => !isNoLongerInForce(c) && fieldsAssertingAResolution(c).length > 0)
+      .map((c) => `${c.vendor} ${c.date}`);
+    assert.deepStrictEqual(proseOnly, []);
+  });
+
+  it("is not vacuous — the log holds records that have been resolved", () => {
+    const resolved = stored.filter(isNoLongerInForce);
+    assert.ok(resolved.length >= 3, `resolved records: ${resolved.length}`);
+    for (const record of resolved) {
+      assert.ok(RESOLUTION_STATES.includes(record.resolution!.state), `${record.vendor} ${record.date}`);
+      assert.match(record.resolution!.date, /^\d{4}-\d{2}-\d{2}$/);
+      assert.ok((record.resolution!.detail ?? "").trim().length > 0 || record.resolution!.source_url, `${record.vendor} ${record.date}`);
+      assert.ok(record.resolution!.date >= record.date, `${record.vendor} resolved after it happened`);
+    }
+  });
+
+  it("names a record we hold when it names one at all", () => {
+    const named = stored.filter((c) => c.resolution?.resolved_by);
+    assert.ok(named.length >= 2, `records naming a resolving record: ${named.length}`);
+    for (const record of named) {
+      const resolver = resolvingRecord(record, stored);
+      assert.ok(resolver, `${record.vendor} ${record.date} names a record in the log`);
+      assert.strictEqual(resolver!.vendor, record.vendor);
+      assert.ok(resolver!.date >= record.date, `${record.vendor} is resolved by a later record`);
+    }
+  });
+
+  it("serves the resolution alongside the claim it withdraws", () => {
+    for (const record of loadDealChanges().filter(isNoLongerInForce)) {
+      const detail = record.resolution!.detail;
+      if (!detail) continue;
+      assert.ok(
+        record.summary.includes(detail),
+        `${record.vendor} ${record.date} serves its resolution`
+      );
+    }
+  });
+});
+
+describe("the Netlify seat charge our own log already recorded as lifted", () => {
+  const march = stored.find((c) => c.vendor === "Netlify" && c.date === "2026-03-01")!;
+
+  it("is resolved by the April record naming the same seat charge", () => {
+    assert.strictEqual(march.resolution?.state, "reversed");
+    const resolver = resolvingRecord(march, stored)!;
+    assert.strictEqual(resolver.date, "2026-04-14");
+    assert.ok(resolver.summary.includes("unlimited team seats"));
+  });
+
+  it("no longer rates Netlify", () => {
+    const netlify = loadDealChanges().filter((c) => c.vendor === "Netlify");
+    const cause = vendorRiskAssessment(netlify).cause;
+    assert.notStrictEqual(cause?.date, "2026-03-01");
+  });
+});
+
+describe("the reversed GitHub Copilot signup pause", () => {
+  const pause = stored.find((c) => c.vendor === "GitHub Copilot" && c.date === "2026-04-20")!;
+  const trials = stored.find((c) => c.vendor === "GitHub Copilot" && c.date === "2026-04-10")!;
+
+  it("is recorded as reversed rather than deleted", () => {
+    assert.strictEqual(pause.resolution?.state, "reversed");
+    assert.strictEqual(trials.resolution?.state, "reversed");
+    assert.ok(pause.summary.includes("paused new signups"), "the event it recorded is still history");
+  });
+
+  it("is no longer what GitHub Copilot is rated on", () => {
+    const copilot = loadDealChanges().filter((c) => c.vendor === "GitHub Copilot");
+    const cause = vendorRiskAssessment(copilot).cause;
+    assert.notStrictEqual(cause?.date, "2026-04-20");
+    assert.notStrictEqual(cause?.date, "2026-04-10");
+  });
+});
+
+let serverPort = 0;
+let proc: ChildProcess | null = null;
+
+function startServer(): Promise<ChildProcess> {
+  return new Promise((resolve, reject) => {
+    const child = spawn("node", [path.join(REPO, "dist", "serve.js")], {
+      stdio: ["pipe", "pipe", "pipe"],
+      env: { ...process.env, PORT: "0", BASE_URL: "http://localhost" },
+    });
+    const timeout = setTimeout(() => { child.kill(); reject(new Error("Server startup timeout")); }, 20000);
+    child.stderr!.on("data", (data: Buffer) => {
+      const m = data.toString().match(/running on http:\/\/localhost:(\d+)/);
+      if (m) { serverPort = parseInt(m[1], 10); clearTimeout(timeout); resolve(child); }
+    });
+    child.on("error", (err) => { clearTimeout(timeout); reject(err); });
+  });
+}
+
+describe("what a reader and an agent are told about a resolved change", () => {
+  before(async () => { proc = await startServer(); });
+  after(() => { proc?.kill(); });
+
+  const get = async (p: string) => (await fetch(`http://localhost:${serverPort}${p}`)).text();
+  const getJson = async (p: string) => (await fetch(`http://localhost:${serverPort}${p}`)).json() as any;
+
+  it("renders the reversed pause as history on the vendor page", async () => {
+    const body = await get("/vendor/github-copilot");
+    const items = body.split('<div class="change-item').slice(1);
+    const pause = items.find((i) => i.includes("#github-copilot-2026-04-20"));
+    assert.ok(pause, "the vendor page renders the April 20 record");
+    assert.ok(pause!.startsWith(" change-resolved"), "the reversed record is marked as no longer in force");
+    assert.ok(pause!.includes("marked Retired"), "the reversal travels with the claim");
+    const standing = items.find((i) => i.includes("#github-copilot-2026-08-28"));
+    assert.ok(standing && !standing.startsWith(" change-resolved"), "a standing record is not marked");
+  });
+
+  it("does not lead the vendor page with a pause GitHub lifted", async () => {
+    const body = await get("/vendor/github-copilot");
+    const verdict = body.slice(0, body.indexOf("change-item"));
+    assert.ok(!verdict.includes("paused for new signups"), "the risk verdict cites a standing record");
+  });
+
+  it("marks the reversed record on the change log", async () => {
+    const body = await get("/pricing-changes");
+    const entries = body.split('<div class="pc-entry').slice(1);
+    const pause = entries.find((e) => e.includes("paused new signups for Copilot Pro"));
+    assert.ok(pause, "/pricing-changes renders the April 20 record");
+    assert.ok(pause!.startsWith(" pc-resolved") || pause!.slice(0, 60).includes("pc-resolved"));
+  });
+
+  it("gives an agent the resolution in risk_cause", async () => {
+    const risk = await getJson("/api/vendor-risk/GitHub%20Copilot");
+    assert.strictEqual(risk.vendor, "GitHub Copilot", "the endpoint resolved the vendor");
+    assert.ok(risk.risk_cause, "GitHub Copilot is rated on a standing record");
+    assert.strictEqual(risk.risk_cause.resolution, null, "a resolved change is never the cause");
+    assert.ok("current_state" in risk.risk_cause, "risk_cause carries the record's current state");
+    assert.notStrictEqual(risk.risk_cause.date, "2026-04-20");
+    assert.notStrictEqual(risk.risk_cause.date, "2026-04-10");
+  });
+
+  it("carries the same shape on /api/offers", async () => {
+    const offers = await getJson("/api/offers?category=AI%20Coding");
+    const withCause = (offers.offers ?? offers).filter((o: any) => o.risk_cause);
+    assert.ok(withCause.length > 0, "the category has a rated vendor");
+    for (const offer of withCause) {
+      assert.ok("current_state" in offer.risk_cause, `${offer.vendor} risk_cause carries current_state`);
+      assert.strictEqual(offer.risk_cause.resolution, null, `${offer.vendor} is not rated on a resolved change`);
+    }
+  });
+
+  it("serves the reversal wherever the change log is read", async () => {
+    const changes = await getJson("/api/changes?since=2026-04-01");
+    const pause = (changes.changes ?? changes).find(
+      (c: any) => c.vendor === "GitHub Copilot" && c.date === "2026-04-20"
+    );
+    assert.ok(pause, "the API serves the April 20 record");
+    assert.strictEqual(pause.resolution?.state, "reversed");
+    assert.ok(pause.summary.includes("marked Retired"), "the summary cannot be read without the reversal");
+  });
+});


### PR DESCRIPTION
Refs #1282, Refs #1276.

## What was wrong

A correction written into `current_state` reached two render paths. Everything that states a verdict reads `summary` — 354 references in `src/serve.ts` against 9 for `current_state` — so a retracted claim kept being published beside the record that retracted it.

## The mechanism

A change record can carry a `resolution`:

```json
"resolution": {
  "state": "reversed",
  "date": "2026-04-14",
  "source_url": "https://www.netlify.com/pricing/",
  "resolved_by": { "vendor": "Netlify", "date": "2026-04-14", "change_type": "limits_increased" }
}
```

`reversed` means the vendor ended it. `retracted` means the record was our error. `detail` is the sentence a reader sees; `resolved_by` names the change record that ended it, when we hold one.

**The detail is concatenated onto `summary` in `loadDealChanges`, and the stored summary no longer contains it.** The claim and its withdrawal cannot be separated on any of the 354 sites, because the only place a summary is produced is the place that joins them. Every served summary in this PR is byte-identical to the one on `main`; what changed is that the retraction is no longer removable by editing one field.

Behaviour, all through one predicate:

- `demotionForChange` returns `null` for a resolved record, so it is never a vendor's risk cause, never counts as severe, and drops out of `classifyStability`'s negative and positive counts.
- A `retracted` record leaves the plan-lineup population — its prices were never real, so calling it "superseded by our newer read" would assert the old prices were once true.
- `risk_cause` carries `current_state` and `resolution` on `/api/vendor-risk` and `/api/offers`. `ChangeResolution` is in the OpenAPI schema.
- The vendor page, `/pricing-changes` and both AI-coding change tables render a resolved record dimmed and dashed.

## The four records

| record | state | resolved_by |
|---|---|---|
| GitHub Copilot 2026-04-20 `restriction` high | reversed | — |
| GitHub Copilot 2026-04-10 `restriction` medium | reversed | — |
| Cursor 2026-04-13 `pricing_restructured` low | retracted | Cursor 2026-09-02 `record_corrected` |
| Netlify 2026-03-01 `restriction` **high** | reversed | Netlify 2026-04-14 `limits_increased` |

## Netlify: we already held the reversal

#1276 AC-5 asked for the five restriction records 120+ days old to be re-read. The Netlify one did not need a fetch to settle — **our own log already recorded the lift.** The 2026-04-14 `limits_increased` record, written on 2026-04-21, says:

> Credit Pro also gained unlimited team seats (was $20/seat per Git contributor), which effectively removes the prior CMS/Identity 'every committer becomes a $19 Pro seat' gotcha for free-tier users who ever upgrade.

We published the March restriction as a standing high-impact fact for 142 days with the record that ended it sitting directly above it on the same page. Not a detection failure — the vocabulary had no way to connect them, which is exactly what #1276 argues.

`netlify.com/pricing` confirms it today: *"As of April 14th, credit-based Pro plans no longer charge for any seat"*, and Pro is *"$20 /month for unlimited members, with free & unlimited Git Contributors on all repos"*.

**The Netlify resolution carries no `detail`, deliberately.** I am not writing the sentence — the behaviour is fixed now and the sentence is one field away whenever you want to add one. On the rendered page a reader gets the story anyway: the March row is dimmed and the April row directly above it explains the lift.

## The other four restriction records

- **Postman 2026-03-01** — still in force. `postman.com/pricing` today: *"Free and Solo are single-player plans. Team is for collaboration"*, Team $19 per user/month. Left standing.
- **GitHub Copilot 2026-03-12** — not settled from `github.com/features/copilot/plans`. The page confirms a dedicated Student plan exists; whether manual model selection is still barred is not on it. Left standing.
- **Google Gemini API 2026-04-01 and 2026-04-08** — `ai.google.dev` 302s and then fails for our fetcher, as you found. Unreadable, not "confirmed standing". #1124's class.

## #1282 AC-5: the census re-run

Your census read commits since 2026-08-15. I ran it over **all 117 commits that have ever touched `data/deal_changes.json`**, keying by (vendor, date, change_type) and looking for a record whose `current_state` moved while `summary` did not:

- **5 records**, of which 4 are the 2026-09-02 batch you found.
- The fifth is Google Gemini 2025-12-15 `limits_reduced`, edited 2026-02-26 to add "Gemini 2.0 Flash retiring March 2026" — a detail addition, not a retraction.
- 14 records had both fields move together.

So four was the whole population, not an artefact of the two-week window.

A second reading, independent of git history: a prose detector over all 493 stored records — `reversed`, `retracted`, `rescinded`, `no longer in force`, sentence-initial `resolved`, and "this row is our error" — fires on exactly the 3 records that were already retracted in prose and nothing else. That detector is now the guard test: **a record whose `summary` or `current_state` asserts a resolution must carry the structured field.**

## Two things I found and did not fix

- **`previous_state` on the GitHub Copilot 2026-08-28 record restates the April 20 pause** — *"**April 20, 2026: GitHub paused new signups for Pro, Pro+, and Copilot Student plans...**"* and later *"OSS maintainers get Pro free (when signups reopen)"*. It renders as the "Before:" line, where describing the pre-change state is what the field is for, so it is defensible as written — but the last clause reads as though signups are still closed. Your call; it is a copy edit.
- **`/best/free-background-jobs` is not deterministic.** Swept against a worktree of `main` it moves; swept `main` against `main` it also moves, and it is byte-identical on a cold fetch. Something accumulating in server state reaches its bytes. Pre-existing, unfiled.

## Verification

- **3,300 tests, 32 new, 0 red.** `tsc` and `validate` clean; 1,580 offers, 493 changes.
- **12 mutations, 12 killed**, no survivors on the first pass — `scripts/mutate-1282.sh`.
- **2,577 paths swept** against a worktree of `main`, with the two new CSS rules normalised out: **2,571 byte-identical, 6 moved, 0 added, 0 removed.** The six are `/vendor/netlify`, `/vendor/github-copilot`, `/vendor/cursor`, `/pricing-changes` and both AI-coding pages. (A seventh, `/best/free-background-jobs`, moves in the `main`-against-`main` control too.)
- `stale-page-facts` unchanged at 57 pages and 216 pairs.
- Screenshotted `/vendor/github-copilot` and `/vendor/netlify`: the resolved rows render dimmed and dashed with the reversal in the summary; the standing rows next to them do not.
