### PR TITLE
Evaluate a change whose page redirects off-domain (#1249)

### DIFF
--- a/scripts/change-gate.js
+++ b/scripts/change-gate.js
@@ -11,6 +11,7 @@ export const REJECT_CONFIRMED_UNCHANGED = "confirmed_unchanged";
 export const REJECT_STATES_NO_TERMS = "states_no_terms";
 export const REJECT_NO_REMOVAL_EVIDENCE = "no_removal_evidence";
 export const REJECT_REMOVAL_READ_FROM_ROOT = "removal_read_from_root";
+export const REJECT_REMOVAL_READ_FROM_REDIRECT = "removal_read_from_redirect";
 export const REJECT_FREE_TIER_STILL_OFFERED = "free_tier_still_offered";
 export const REJECT_NO_BASELINE = "no_baseline";
 export const REJECT_DANGLING_REFERENCE = "dangling_reference";
@@ -29,6 +30,7 @@ export const GATE_REASONS = [
   REJECT_STATES_NO_TERMS,
   REJECT_NO_REMOVAL_EVIDENCE,
   REJECT_REMOVAL_READ_FROM_ROOT,
+  REJECT_REMOVAL_READ_FROM_REDIRECT,
   REJECT_FREE_TIER_STILL_OFFERED,
   REJECT_NO_BASELINE,
   REJECT_DANGLING_REFERENCE,
@@ -861,6 +863,16 @@ export function registrableHost(url) {
   }
 }
 
+const STATES_A_REDIRECT = /\b(?:page|site|domain|url)\s+(?:now\s+)?redirects?\s+to\b/i;
+
+export function statesARedirect(text) {
+  return typeof text === "string" && STATES_A_REDIRECT.test(text);
+}
+
+export function redirectClauseFor(vendor, host) {
+  return `${vendor}'s own page now redirects to ${host}`;
+}
+
 export function redirectedOffDomain(requestedUrl, finalUrl) {
   const from = registrableHost(requestedUrl);
   const to = registrableHost(finalUrl);
@@ -1195,21 +1207,17 @@ export function lostTheSubjectOfItsClaim(record, evidence, summary) {
 }
 
 export function auditRecord(record, context = {}) {
-  let evidence = summaryEvidence(record?.summary);
+  const movedTo = redirectedOffDomain(record?.source_url, context.finalUrl)
+    ? registrableHost(context.finalUrl)
+    : null;
+  const annotated =
+    movedTo && !statesARedirect(record?.summary)
+      ? summaryFromClauses([redirectClauseFor(record?.vendor, movedTo), record?.summary])
+      : record?.summary;
+
+  let evidence = summaryEvidence(annotated);
   let dropped = evidence.dropped;
   const refuse = (reason, detail) => ({ outcome: OUTCOME_REFUSED, reason, detail, summary: null, dropped });
-
-  const movedOffDomain = redirectedOffDomain(record?.source_url, context.finalUrl);
-  if (movedOffDomain) {
-    const host = registrableHost(context.finalUrl);
-    return {
-      outcome: OUTCOME_REWRITTEN,
-      reason: null,
-      detail: `the page we cite redirects to ${host}, so the change is sourced from the redirect rather than from what the page failed to say`,
-      summary: summaryFromClauses([`${record.vendor}'s own page now redirects to ${host}`, ...evidence.kept]),
-      dropped,
-    };
-  }
 
   if (evidence.kept.length === 0) {
     const restated = withBaselineRestored(evidence, true);
@@ -1272,6 +1280,12 @@ export function auditRecord(record, context = {}) {
         `a free tier was recorded as removed from ${record.source_url}, a domain root that states no price, ending or replacement where the free tier was — a homepage's silence is not evidence that one ended`
       );
     }
+    if (!evidenced && evidence.kept.every(statesARedirect)) {
+      return refuse(
+        REJECT_REMOVAL_READ_FROM_REDIRECT,
+        `a free tier was recorded as removed and the only surviving evidence is that ${record.source_url} redirects elsewhere — a redirect states where a page moved to, not what the destination charges`
+      );
+    }
     if (!evidenced && dropped.some(({ kind }) => kind === CLAUSE_ABSENCE)) {
       return refuse(
         REJECT_NO_REMOVAL_EVIDENCE,
@@ -1309,13 +1323,18 @@ export function auditRecord(record, context = {}) {
   }
 
   const restored = evidence.restored ?? 0;
-  if ((dropped.length === 0 && restored === 0) || rewritten === record?.summary) {
+  const nothingMoved = annotated === record?.summary && dropped.length === 0 && restored === 0;
+  if (nothingMoved || rewritten === record?.summary) {
     return { outcome: OUTCOME_UNCHANGED, reason: null, detail: null, summary: null, dropped };
   }
+  const droppedClauses = `dropped ${dropped.length} clause(s) that stated our reading rather than the vendor's terms, and restated ${restored} as the vendor's earlier terms`;
   return {
     outcome: OUTCOME_REWRITTEN,
     reason: null,
-    detail: `dropped ${dropped.length} clause(s) that stated our reading rather than the vendor's terms, and restated ${restored} as the vendor's earlier terms`,
+    detail:
+      annotated === record?.summary
+        ? droppedClauses
+        : `the page we cite redirects to ${movedTo}, so the summary now states that before the terms it carried — ${droppedClauses}`,
     summary: rewritten,
     dropped,
   };

--- a/scripts/mutate-1249.sh
+++ b/scripts/mutate-1249.sh
@@ -1,0 +1,135 @@
+#!/usr/bin/env bash
+set -u
+
+REPO="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$REPO" || exit 1
+
+FILES="scripts/change-gate.js"
+BACKUP_DIR="$(mktemp -d)"
+for f in $FILES; do cp "$f" "$BACKUP_DIR/$(basename "$f")"; done
+
+restore() {
+  for f in $FILES; do cp "$BACKUP_DIR/$(basename "$f")" "$f"; done
+}
+trap restore EXIT
+
+killed=0
+survived=0
+TESTS="test/change-summary.test.ts"
+
+run_mutation() {
+  local name="$1"
+  shift
+  echo "=== $name"
+  for f in $FILES; do cp "$BACKUP_DIR/$(basename "$f")" "$f"; done
+  "$@"
+  local changed=0
+  for f in $FILES; do
+    diff -q "$BACKUP_DIR/$(basename "$f")" "$f" > /dev/null || changed=1
+  done
+  if [ "$changed" -eq 0 ]; then
+    echo "    NOT APPLIED: the mutation changed no file, so it proves nothing"
+    survived=$((survived + 1))
+    return
+  fi
+  if timeout 900 npx tsx --test $TESTS > /tmp/mutate-1249-test.log 2>&1; then
+    echo "    SURVIVED"
+    survived=$((survived + 1))
+  else
+    echo "    KILLED: $(grep -c '✖ ' /tmp/mutate-1249-test.log) failing assertion(s)"
+    grep '✖ ' /tmp/mutate-1249-test.log | head -4
+    killed=$((killed + 1))
+  fi
+}
+
+py() { python3 - "$@"; }
+
+swap() {
+  py <<PY
+p = "scripts/change-gate.js"
+s = open(p).read()
+before = s
+s = s.replace("""$1""", """$2""", $3)
+assert s != before, "mutation string not found"
+open(p, "w").write(s)
+PY
+}
+
+m_redirect_terminates_again() {
+  swap 'if (evidence.kept.length === 0) {' \
+       'if (movedTo) return { outcome: OUTCOME_REWRITTEN, reason: null, detail: "x", summary: summaryFromClauses([redirectClauseFor(record?.vendor, movedTo), ...evidence.kept]), dropped };
+  if (evidence.kept.length === 0) {' 1
+}
+
+m_redirect_only_gate_removed() {
+  swap 'if (!evidenced && evidence.kept.every(statesARedirect)) {' \
+       'if (false && !evidenced && evidence.kept.every(statesARedirect)) {' 1
+}
+
+m_redirect_only_gate_ignores_the_removal_evidence() {
+  swap 'if (!evidenced && evidence.kept.every(statesARedirect)) {' \
+       'if (evidence.kept.every(statesARedirect)) {' 1
+}
+
+m_redirect_only_gate_accepts_any_surviving_clause() {
+  swap 'if (!evidenced && evidence.kept.every(statesARedirect)) {' \
+       'if (!evidenced && evidence.kept.some(statesARedirect)) {' 1
+}
+
+m_annotation_never_applied() {
+  swap '    movedTo && !statesARedirect(record?.summary)' \
+       '    false && movedTo && !statesARedirect(record?.summary)' 1
+}
+
+m_annotation_applied_twice() {
+  swap '    movedTo && !statesARedirect(record?.summary)' \
+       '    movedTo' 1
+}
+
+m_annotation_drops_the_original_summary() {
+  swap '? summaryFromClauses([redirectClauseFor(record?.vendor, movedTo), record?.summary])' \
+       '? summaryFromClauses([redirectClauseFor(record?.vendor, movedTo)])' 1
+}
+
+m_unchanged_ignores_the_annotation() {
+  swap '  const nothingMoved = annotated === record?.summary && dropped.length === 0 && restored === 0;' \
+       '  const nothingMoved = dropped.length === 0 && restored === 0;' 1
+}
+
+m_redirect_reader_matches_nothing() {
+  swap 'const STATES_A_REDIRECT = /\\b(?:page|site|domain|url)\\s+(?:now\\s+)?redirects?\\s+to\\b/i;' \
+       'const STATES_A_REDIRECT = /\\bnever matches this\\b/i;' 1
+}
+
+m_redirect_reader_matches_any_mention() {
+  swap 'const STATES_A_REDIRECT = /\\b(?:page|site|domain|url)\\s+(?:now\\s+)?redirects?\\s+to\\b/i;' \
+       'const STATES_A_REDIRECT = /./i;' 1
+}
+
+m_removal_from_root_gate_removed() {
+  swap 'if (!evidenced && isDomainRoot(record?.source_url)) {' \
+       'if (false && !evidenced && isDomainRoot(record?.source_url)) {' 1
+}
+
+m_still_offered_gate_removed() {
+  swap 'if (reportsSomethingStillFree(record?.summary)) {' \
+       'if (false && reportsSomethingStillFree(record?.summary)) {' 1
+}
+
+run_mutation "the redirect branch returns early again, exempting every gate below it" m_redirect_terminates_again
+run_mutation "the redirect-only refusal is removed" m_redirect_only_gate_removed
+run_mutation "the redirect-only refusal fires even where the summary states a removal" m_redirect_only_gate_ignores_the_removal_evidence
+run_mutation "the redirect-only refusal fires on any clause that mentions a redirect" m_redirect_only_gate_accepts_any_surviving_clause
+run_mutation "the redirect is never stated in the summary" m_annotation_never_applied
+run_mutation "the redirect is stated again on a summary that already carries it" m_annotation_applied_twice
+run_mutation "the annotation replaces the summary instead of preceding it" m_annotation_drops_the_original_summary
+run_mutation "an annotated record is reported unchanged and loses the redirect" m_unchanged_ignores_the_annotation
+run_mutation "no clause is read as reporting a redirect" m_redirect_reader_matches_nothing
+run_mutation "every clause is read as reporting a redirect" m_redirect_reader_matches_any_mention
+run_mutation "the root refusal is removed" m_removal_from_root_gate_removed
+run_mutation "the still-offered refusal is removed" m_still_offered_gate_removed
+
+echo
+echo "killed:   $killed"
+echo "survived: $survived"
+[ "$survived" -eq 0 ]

--- a/test/change-summary.test.ts
+++ b/test/change-summary.test.ts
@@ -40,9 +40,11 @@ const {
   REJECT_FREE_TIER_STILL_OFFERED,
   REJECT_NO_BASELINE,
   REJECT_NO_REMOVAL_EVIDENCE,
+  REJECT_REMOVAL_READ_FROM_REDIRECT,
   REJECT_REMOVAL_READ_FROM_ROOT,
   REJECT_STATES_NO_DIFFERENCE,
   REJECT_STATES_NO_TERMS,
+  statesARedirect,
 } = await import("../scripts/change-gate.js");
 
 const { sweepRecords } = await import("../scripts/sweep-change-summaries.js");
@@ -104,6 +106,29 @@ const A_REMOVAL_WHOSE_PRODUCT_MOVED_TO_ANOTHER_COMPANY = {
   current_state: "The page promotes a free trial and then paid plans.",
   impact: "high",
   source_url: "https://www.highlight.io/pricing",
+};
+
+const A_REMOVAL_SOURCED_FROM_NOTHING_BUT_A_REDIRECT = {
+  vendor: "Keywords AI",
+  change_type: "free_tier_removed",
+  summary:
+    "The page does not explicitly state a free tier. It showcases features and capabilities of the platform, with mentions of cost savings and budget controls, but does not detail a free usage allowance.",
+  previous_state:
+    "The best LLM monitoring platform. 10,000 free requests every month and $0 for platform features!",
+  current_state: "The page does not explicitly state a free tier.",
+  impact: "high",
+  source_url: "https://keywordsai.co",
+};
+
+const A_MEASURED_CHANGE_READ_AFTER_A_REDIRECT = {
+  vendor: "staticforms.xyz",
+  change_type: "limits_reduced",
+  summary: "The free plan now offers 500 submissions per month instead of 250.",
+  previous_state:
+    "Integrate HTML forms easily without any server-side code for free. After the user submits the form, an email with the form content will be sent to your registered address.",
+  current_state: "Free plan, 500 a month",
+  impact: "low",
+  source_url: "https://www.staticforms.xyz/",
 };
 
 const A_REAL_REDUCTION_WEARING_OUR_SUBJECT = {
@@ -382,11 +407,98 @@ describe("a change record must state a term the vendor's page carries now", () =
       assert.strictEqual(verdict.outcome, OUTCOME_REFUSED);
     });
 
-    it("keeps the same removal when the page it read belongs to somebody else now", () => {
+    it("reads a clause that reports where a page moved to", () => {
+      assert.strictEqual(statesARedirect("Highlight.io's own page now redirects to launchdarkly.com."), true);
+      assert.strictEqual(statesARedirect("The free plan now offers 500 submissions per month."), false);
+    });
+
+    it("refuses a removal whose only surviving evidence is that the page moved", () => {
       const verdict = auditRecord(A_REMOVAL_WHOSE_PRODUCT_MOVED_TO_ANOTHER_COMPANY, {
         finalUrl: "https://launchdarkly.com/",
       });
+      assert.strictEqual(verdict.outcome, OUTCOME_REFUSED);
+      assert.strictEqual(verdict.reason, REJECT_REMOVAL_READ_FROM_REDIRECT);
+    });
+
+    it("refuses it again when re-read from the summary the redirect already produced", () => {
+      const asPublished = {
+        ...A_REMOVAL_WHOSE_PRODUCT_MOVED_TO_ANOTHER_COMPANY,
+        summary: "Highlight.io's own page now redirects to launchdarkly.com.",
+      };
+      const verdict = auditRecord(asPublished, { finalUrl: "https://launchdarkly.com/" });
+      assert.strictEqual(verdict.outcome, OUTCOME_REFUSED);
+      assert.strictEqual(verdict.reason, REJECT_REMOVAL_READ_FROM_REDIRECT);
+    });
+
+    it("refuses a removal read from a root that redirects, which no gate below the redirect could reach", () => {
+      const verdict = auditRecord(A_REMOVAL_SOURCED_FROM_NOTHING_BUT_A_REDIRECT, {
+        finalUrl: "https://www.respan.ai",
+      });
+      assert.strictEqual(verdict.outcome, OUTCOME_REFUSED);
+      assert.strictEqual(verdict.reason, REJECT_REMOVAL_READ_FROM_ROOT);
+    });
+
+    it("refuses the same record at the gate", () => {
+      const verdict = describesChange(A_REMOVAL_SOURCED_FROM_NOTHING_BUT_A_REDIRECT, {
+        finalUrl: "https://www.respan.ai",
+      });
+      assert.strictEqual(verdict.ok, false);
+      assert.strictEqual(verdict.reason, REJECT_REMOVAL_READ_FROM_ROOT);
+    });
+
+    it("keeps a measured change that survives alongside the redirect, and states both", () => {
+      const verdict = auditRecord(A_MEASURED_CHANGE_READ_AFTER_A_REDIRECT, {
+        finalUrl: "https://www.staticforms.dev/",
+      });
+      assert.strictEqual(verdict.outcome, OUTCOME_REWRITTEN);
+      assert.strictEqual(
+        verdict.summary,
+        "staticforms.xyz's own page now redirects to staticforms.dev. The free plan now offers 500 submissions per month instead of 250."
+      );
+    });
+
+    it("states the redirect once when the summary it audits already carries it", () => {
+      const asPublished = applyAudit(
+        A_MEASURED_CHANGE_READ_AFTER_A_REDIRECT,
+        auditRecord(A_MEASURED_CHANGE_READ_AFTER_A_REDIRECT, {
+          finalUrl: "https://www.staticforms.dev/",
+        })
+      );
+      const verdict = auditRecord(asPublished, { finalUrl: "https://www.staticforms.dev/" });
+      assert.strictEqual(verdict.outcome, OUTCOME_UNCHANGED);
+      assert.strictEqual(applyAudit(asPublished, verdict).summary, asPublished.summary);
+    });
+
+    it("keeps a removal whose one surviving clause states the removal as well as the redirect", () => {
+      const statesWhereItWentAndWhatIsLeft = {
+        ...A_REMOVAL_WHOSE_PRODUCT_MOVED_TO_ANOTHER_COMPANY,
+        summary: "The pricing page now redirects to a subscription-only replacement",
+      };
+      const verdict = auditRecord(statesWhereItWentAndWhatIsLeft);
       assert.notStrictEqual(verdict.outcome, OUTCOME_REFUSED);
+    });
+
+    it("keeps a removal that names what the destination charges beside the redirect", () => {
+      const namesThePriceItLandedOn = {
+        ...A_REMOVAL_WHOSE_PRODUCT_MOVED_TO_ANOTHER_COMPANY,
+        summary:
+          "Highlight.io's own page now redirects to launchdarkly.com. The entry plan is $89 per month.",
+      };
+      const verdict = auditRecord(namesThePriceItLandedOn, {
+        finalUrl: "https://launchdarkly.com/",
+      });
+      assert.notStrictEqual(verdict.outcome, OUTCOME_REFUSED);
+    });
+
+    it("still refuses a removal for its own change type when the page redirects", () => {
+      const stillOffered = {
+        ...A_REMOVAL_SOURCED_FROM_NOTHING_BUT_A_REDIRECT,
+        source_url: "https://keywordsai.co/pricing",
+        summary: "Sign up for free with 100k logs. The page no longer names the old allowance.",
+      };
+      const verdict = auditRecord(stillOffered, { finalUrl: "https://www.respan.ai" });
+      assert.strictEqual(verdict.outcome, OUTCOME_REFUSED);
+      assert.strictEqual(verdict.reason, REJECT_FREE_TIER_STILL_OFFERED);
     });
   });
 


### PR DESCRIPTION
Refs #1249

`auditRecord` returned on the off-domain redirect branch at `change-gate.js:1198`, which was the first thing it did. Everything below it was skipped, including the whole `free_tier_removed` block and its three refusals. A removal sourced from nothing but a redirect could not be refused, because refusal was downstream of the return.

## What changed

The branch annotates instead of terminating. The redirect clause is stated ahead of the record's summary, the combined text goes through the normal clause machinery, and every gate for the record's own `change_type` stays reachable. Where a record survives, the summary it produces is the same text the old branch produced.

One new refusal, `removal_read_from_redirect`: a `free_tier_removed` whose surviving evidence is only the redirect clause, and whose text states no removal, is refused whether or not `source_url` is a root.

## Acceptance criteria

**AC-1** — Keywords AI (`https://keywordsai.co` → `https://www.respan.ai`, `free_tier_removed`) returns `OUTCOME_REFUSED` with `removal_read_from_root`, both as published and from the pre-gate summary. Tested at `auditRecord` and at `describesChange`.

**AC-2** — staticforms.xyz still passes. From its pre-gate summary the gate rewrites to `staticforms.xyz's own page now redirects to staticforms.dev. The free plan now offers 500 submissions per month instead of 250.` — both clauses asserted as one exact string.

**AC-3** — the gates run after the redirect. `free_tier_still_offered` is asserted firing on a redirected record.

**AC-4** — 653 records audited, all 493 published changes and all 160 refusals, each against a `main` build with the same context. **4 change outcome, and all 4 redirect off-domain. 0 records that do not redirect move.**

| record | was | now |
|---|---|---|
| Highlight.io `free_tier_removed` | rewritten | refused `removal_read_from_redirect` |
| Keywords AI `free_tier_removed` | rewritten | refused `removal_read_from_root` |
| staticforms.xyz `limits_reduced` | rewritten | unchanged |
| Anthropic API `pricing_model_change` | rewritten | unchanged |

**AC-5** — Highlight.io is refused, from its pre-gate summary and from the summary the redirect branch produced. The refusal does not depend on having re-fetched the page.

## A second defect this fixes

Re-auditing a record whose summary already reports its redirect stated it twice. On `main` all four records above audit to a doubled sentence — `Anthropic API's own page now redirects to platform.claude.com. Anthropic API's own page now redirects to platform.claude.com. Pricing has changed...`. `sweep-change-summaries.js` reads published summaries, so a sweep without `--restore-from` would have written that. The two surviving records now audit to `unchanged`.

## Verification

- 3,309 tests, 10 new, 0 red. `tsc` and `validate` clean; 1,580 offers, 493 deal changes.
- 12 mutations in `scripts/mutate-1249.sh`, 12 killed, no survivors. The first restores the early return; it is killed by 5 assertions.
- `node scripts/sweep-change-summaries.js --dry-run` run against `main` and against this branch. Both rewrite the same 2 records byte-identically; this branch additionally refuses Highlight.io.
- No data file is touched.

## For the PM

**Highlight.io is still published and the gate now refuses it.** Its conclusion holds — the hosted free tier is genuinely gone — but its only stated grounds are that the page moved, which is what AC-5 asks to refuse. Nothing removes it automatically: `sweep-change-summaries.js` is a manual tool, referenced by no workflow. Withdrawing it or re-sourcing it from the destination's pricing is a call I have not made, and re-sourcing means a new summary sentence.

**Unrelated, found in the sweep and present on `main`:** sweeping Augment Code's summary drops a verb — `this row previously stated the lowest tier was Business` becomes `this row previously the lowest tier was Business`. A sweep run without `--dry-run` would publish that.