### PR TITLE
Read the resolution at the four render paths that ignored it (#1282)

### DIFF
--- a/src/change-resolution.ts
+++ b/src/change-resolution.ts
@@ -16,6 +16,16 @@ export function theEventNeverHappened(change: { resolution?: ChangeResolution | 
   return change.resolution?.state === "retracted";
 }
 
+export const EVENT_CANCELLED = "https://schema.org/EventCancelled";
+
+export function eventResolutionFields(change: {
+  resolution?: ChangeResolution | null;
+}): { eventStatus: string } | { endDate: string } | Record<string, never> {
+  if (!change.resolution) return {};
+  if (theEventNeverHappened(change)) return { eventStatus: EVENT_CANCELLED };
+  return change.resolution.date ? { endDate: change.resolution.date } : {};
+}
+
 export function resolvingRecord<T extends { vendor: string; date: string; change_type: string }>(
   change: { resolution?: ChangeResolution | null },
   log: readonly T[],

--- a/src/serve.ts
+++ b/src/serve.ts
@@ -23,7 +23,7 @@ import { stabilityFaqAnswer, stabilityVerdictClause, type ComparisonSide, type S
 import { publishedVendorLevel, vendorVerdictSentence, vendorBadge, statesRiskCause, narrowingSentence, changeKindNoun, type VendorVerdictInput } from "./vendor-verdict.js";
 import { vendorHistorySentence } from "./vendor-history.js";
 import { changeTimelineDate, supersededLineups, supersessionNote } from "./change-lineup.js";
-import { isNoLongerInForce } from "./change-resolution.js";
+import { isNoLongerInForce, eventResolutionFields } from "./change-resolution.js";
 import { growthLimitPhrases } from "./growth-limits.js";
 import { registerAgent, authenticateRequest, validateVestauthUrl, hashApiKey, updateAgentX402Address, getAgentById } from "./agents.js";
 import { attributeAuthenticatedRequest } from "./referral-attribution.js";
@@ -4093,6 +4093,7 @@ ${allCompareLinks.join("\n")}
     "@type": "Event",
     name: `${vendorName} pricing change: ${c.change_type.replace(/_/g, " ")}`,
     ...changeEventStartDate(c),
+    ...eventResolutionFields(c),
     description: c.summary,
   }));
   const jsonLd: Record<string, any> = {
@@ -4487,7 +4488,7 @@ function buildAlternativesPage(slug: string): string | null {
       parts.push(`<div class="changes-summary"><h3>Recent Pricing Changes (${vendorChanges.length})</h3>`);
       parts.push(vendorChanges.slice(0, 5).map(c => {
         const badge = changeTypeBadge[c.change_type] ?? { label: c.change_type, color: "#8b949e" };
-        return `<div class="change-item">
+        return `<div class="change-item${isNoLongerInForce(c) ? " change-resolved" : ""}">
           <div class="change-head">
             <span class="badge" style="background:${badge.color}">${badge.label}</span>
             <span class="change-date">${changeDateLabel(c)}</span>
@@ -4651,6 +4652,7 @@ h3{font-family:var(--serif);font-size:1rem;color:var(--text);margin-bottom:.5rem
 .cat-pill{display:inline-block;padding:.15rem .5rem;border-radius:12px;font-size:.7rem;font-weight:500;background:var(--accent-glow);color:var(--accent);border:1px solid rgba(59,130,246,0.2)}
 .changes-summary{margin-top:1rem;padding-top:1rem;border-top:1px solid var(--border)}
 .change-item{margin-bottom:.5rem;padding:.5rem .75rem;border-left:3px solid var(--border);background:var(--bg-card);border-radius:0 8px 8px 0}
+.change-resolved{opacity:.6;border-left-style:dashed}
 .change-head{display:flex;align-items:center;gap:.5rem;margin-bottom:.2rem;flex-wrap:wrap}
 .badge{display:inline-block;padding:.1rem .4rem;border-radius:10px;font-size:.65rem;font-weight:600;color:#fff}
 .change-date{font-family:var(--mono);font-size:.75rem;color:var(--text-dim)}
@@ -46385,7 +46387,7 @@ function buildStackCheckPage(): string {
   const totalOffers = allOffers.length;
   const totalChanges = allChanges.length;
 
-  const vendorLookup: Record<string, { vendor: string; category: string; description: string; tier: string; slug: string; risk_level: string; risk_cause: RiskCause | null; stability: string; recent_changes: Array<{ date: string; change_type: string; summary: string; impact: string }> }> = {};
+  const vendorLookup: Record<string, { vendor: string; category: string; description: string; tier: string; slug: string; risk_level: string; risk_cause: RiskCause | null; stability: string; recent_changes: Array<{ date: string; change_type: string; summary: string; impact: string; resolved: boolean }> }> = {};
   for (const offer of allOffers) {
     const slug = toSlug(offer.vendor);
     const allVendorChanges = allChanges
@@ -46405,7 +46407,7 @@ function buildStackCheckPage(): string {
         ? { date: changeDateLabel(assessment.cause), date_source: assessment.cause.date_source, change_type: assessment.cause.change_type, summary: assessment.cause.summary }
         : null,
       stability,
-      recent_changes: vendorChanges.map(c => ({ date: changeDateLabel(c), change_type: c.change_type, summary: c.summary, impact: c.impact })),
+      recent_changes: vendorChanges.map(c => ({ date: changeDateLabel(c), change_type: c.change_type, summary: c.summary, impact: c.impact, resolved: isNoLongerInForce(c) })),
     };
     vendorLookup[offer.vendor.toLowerCase()] = vendorLookup[slug];
   }
@@ -46525,6 +46527,7 @@ function buildStackCheckPage(): string {
     .card-tier{font-size:.85rem;color:var(--text-muted);margin:.25rem 0}
     .card-changes{margin:.5rem 0}
     .change-item{font-size:.8rem;color:var(--text-dim);padding:.25rem 0;border-top:1px solid var(--border)}
+    .change-resolved{opacity:.6;border-top-style:dashed}
     .change-item:first-child{border-top:none}
     .change-type{font-size:.7rem;font-weight:600;text-transform:uppercase;letter-spacing:.03em;margin-right:.4rem}
     .change-negative{color:var(--red)}
@@ -46747,7 +46750,7 @@ function buildStackCheckPage(): string {
           for (var j = 0; j < shown; j++) {
             var ch = svc.recent_changes[j];
             var cls = negTypes.indexOf(ch.change_type) >= 0 ? 'change-negative' : posTypes.indexOf(ch.change_type) >= 0 ? 'change-positive' : 'change-neutral';
-            cardsHtml += '<div class="change-item"><span class="change-type ' + cls + '">' + esc(ch.change_type.replace(/_/g, ' ')) + '</span>' + esc(ch.date) + ' — ' + esc(ch.summary) + '</div>';
+            cardsHtml += '<div class="change-item' + (ch.resolved ? ' change-resolved' : '') + '"><span class="change-type ' + cls + '">' + esc(ch.change_type.replace(/_/g, ' ')) + '</span>' + esc(ch.date) + ' — ' + esc(ch.summary) + '</div>';
           }
           cardsHtml += '</div>';
         }
@@ -46924,6 +46927,7 @@ h2{font-family:var(--serif);font-size:1.25rem;color:var(--text);margin:1.5rem 0 
 .vendor-links{display:flex;gap:.75rem;margin-top:.75rem;font-size:.85rem}
 .changes-timeline{margin-top:1rem}
 .change-item{padding:.5rem 0;border-bottom:1px solid rgba(51,65,85,0.5);font-size:.85rem}
+.change-resolved{opacity:.6;border-bottom-style:dashed}
 .change-item:last-child{border-bottom:none}
 .change-date{color:var(--text-dim);font-family:var(--mono);font-size:.8rem}
 .change-type{font-family:var(--mono);font-size:.75rem;padding:.1rem .4rem;border-radius:3px;margin:0 .25rem}
@@ -47096,7 +47100,7 @@ ${globalNavCss()}
     if (changes.length > 0) {
       html += '<div class="changes-timeline"><strong style="font-size:.85rem">Recent Changes</strong>';
       changes.slice(0, 5).forEach(function(c) {
-        html += '<div class="change-item"><span class="change-date">' + escHtml(c.date) + '</span> ' + changeTypeBadge(c.change_type) + ' ' + escHtml(c.summary.length > 120 ? c.summary.slice(0, 120) + '...' : c.summary) + '</div>';
+        html += '<div class="change-item' + (c.resolution ? ' change-resolved' : '') + '"><span class="change-date">' + escHtml(c.date) + '</span> ' + changeTypeBadge(c.change_type) + ' ' + escHtml(c.summary.length > 120 ? c.summary.slice(0, 120) + '...' : c.summary) + '</div>';
       });
       html += '</div>';
     }

--- a/test/change-resolution.test.ts
+++ b/test/change-resolution.test.ts
@@ -6,6 +6,7 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 import type { DealChange } from "../src/types.ts";
 import {
+  EVENT_CANCELLED,
   RESOLUTION_STATES,
   fieldsAssertingAResolution,
   isNoLongerInForce,
@@ -241,6 +242,28 @@ function startServer(): Promise<ChildProcess> {
   });
 }
 
+async function vendorEvents(get: (p: string) => Promise<string>, page: string): Promise<any[]> {
+  const body = await get(page);
+  const blocks = [...body.matchAll(/<script type="application\/ld\+json">([\s\S]*?)<\/script>/g)];
+  const events: any[] = [];
+  for (const [, raw] of blocks) {
+    let parsed: any;
+    try {
+      parsed = JSON.parse(raw);
+    } catch {
+      continue;
+    }
+    for (const value of Object.values(parsed ?? {})) {
+      if (!Array.isArray(value)) continue;
+      for (const entry of value) {
+        if (entry && typeof entry === "object" && (entry as any)["@type"] === "Event") events.push(entry);
+      }
+    }
+  }
+  assert.ok(events.length > 0, `${page} publishes at least one Event`);
+  return events;
+}
+
 describe("what a reader and an agent are told about a resolved change", () => {
   before(async () => { proc = await startServer(); });
   after(() => { proc?.kill(); });
@@ -301,5 +324,52 @@ describe("what a reader and an agent are told about a resolved change", () => {
     assert.ok(pause, "the API serves the April 20 record");
     assert.strictEqual(pause.resolution?.state, "reversed");
     assert.ok(pause.summary.includes("marked Retired"), "the summary cannot be read without the reversal");
+  });
+
+  it("marks the resolved record on the alternatives page, where no detail sentence carries it", async () => {
+    const body = await get("/alternative-to/netlify");
+    const items = body.split('<div class="change-item').slice(1);
+    const lifted = items.find((i) => i.includes("charged as a full Pro seat"));
+    assert.ok(lifted, "/alternative-to/netlify renders the March record");
+    assert.ok(lifted!.startsWith(" change-resolved"), "the reversed record is marked");
+    const standing = items.find((i) => i.includes("Restructured to credit-based pricing"));
+    assert.ok(standing && !standing.startsWith(" change-resolved"), "a standing record is not marked");
+    assert.ok(body.includes(".change-resolved{"), "the page carries the rule that dims it");
+  });
+
+  it("ends the structured event on the vendor page for a change the vendor reversed", async () => {
+    const events = await vendorEvents(get, "/vendor/netlify");
+    const march = events.find((e) => e.startDate === "2026-03-01");
+    assert.ok(march, "the vendor page publishes the March record as an Event");
+    assert.strictEqual(march.endDate, "2026-04-14", "the event ends on the date it stopped being in force");
+    const standing = events.find((e) => e.startDate === "2026-04-17");
+    assert.ok(standing && !("endDate" in standing), "a standing record has no end");
+  });
+
+  it("cancels the structured event for a record we withdrew", async () => {
+    const events = await vendorEvents(get, "/vendor/cursor");
+    const retracted = events.find((e) => e.eventStatus);
+    assert.ok(retracted, "the retracted record is published with a status");
+    assert.strictEqual(retracted.eventStatus, EVENT_CANCELLED);
+    assert.strictEqual(retracted.startDate, "2026-04-13");
+    assert.ok(!events.some((e) => e.startDate === "2026-04-07" && e.eventStatus), "a standing record has no status");
+  });
+
+  it("tells the stack checker which of its changes are no longer in force", async () => {
+    const body = await get("/stack-check");
+    assert.ok(body.includes('"resolved":true'), "a resolved record reaches the page's data");
+    assert.ok(body.includes('"resolved":false'), "a standing record reaches it too");
+    assert.ok(body.includes(".change-resolved{"), "the page carries the rule that dims it");
+    assert.ok(body.includes("' change-resolved'"), "the renderer applies it");
+  });
+
+  it("gives the comparison tool the resolution it renders on", async () => {
+    const compared = await getJson("/api/compare?a=Netlify&b=Vercel");
+    const march = compared.vendor_a.deal_changes.find((c: any) => c.date === "2026-03-01");
+    assert.ok(march, "/api/compare serves the March record");
+    assert.strictEqual(march.resolution?.state, "reversed");
+    const body = await get("/compare-tool");
+    assert.ok(body.includes(".change-resolved{"), "the page carries the rule that dims it");
+    assert.ok(body.includes("' change-resolved'"), "the renderer applies it");
   });
 });


### PR DESCRIPTION
Refs #1282

AC-1. `isNoLongerInForce` reached five render sites; four more rendered a change record without it. Those four were covered only by `withResolutionInSummary` concatenating `resolution.detail` onto `summary` — free text doing the work the structured field was supposed to do. Netlify's record has no `detail`, which is what exposed them.

| `src/serve.ts` | surface | now |
|---|---|---|
| `4491` | `/alternative-to/*` | `change-resolved` on the row, plus the rule that dims it |
| `4093` | JSON-LD `Event` on `/vendor/*` | `eventStatus` / `endDate` |
| `46752` | `/stack-check` | `change-resolved`, driven by a new `resolved` flag |
| `47102` | `/compare-tool` | `change-resolved`, driven by `c.resolution` |

## The two questions you left open

**Does `resolution` belong in the JSON-LD `Event`?** Yes, and schema.org already has both halves, so neither needs a sentence:

- **retracted → `eventStatus: https://schema.org/EventCancelled`.** You noted this "means the event never happened" — that is exactly what a retraction asserts, and the codebase already says so: `theEventNeverHappened()` returns true for `retracted` and nothing else. Cursor's April 13 Hobby row is the case.
- **reversed → `endDate`.** The event did happen and then stopped. `endDate` is the plain schema.org way to say so, and it carries the date rather than only the fact.

A `description` prefix was the other option and I did not take it: it is prose, and it would have put the answer in the one field that already fails when nobody writes a sentence.

**Should a resolution render without a `detail`?** It does now, on all four paths, without a fallback sentence — the treatment is visual and the JSON-LD is structured. I did not add "No longer in force as of <date>". It is reader-facing copy and it is yours to write; if you want it, the fallback has one place to go and the structured fields to build it from are already there.

## Verified on a running server

- `/alternative-to/netlify` — 1 of 4 rows carries `change-resolved`, the 2026-03-01 restriction. Screenshotted: it is visibly dimmed and dashed against the three around it, with the April 14 row that lifted it directly above.
- `/vendor/netlify` JSON-LD — the March `Event` carries `endDate: 2026-04-14`; the other three carry no `endDate` and no `eventStatus`.
- `/vendor/cursor` JSON-LD — the April 13 `Event` carries `eventStatus: EventCancelled`; the other four carry neither.
- `/vendor/github-copilot` — both reversed records carry `endDate: 2026-09-02`.
- `/stack-check` — `"resolved":true` and `"resolved":false` both present in the page data.
- `/compare-tool?a=Netlify&b=Vercel` — screenshotted; the March row renders dimmed. `/api/compare` already served `resolution` on `vendor_a.deal_changes`, so only the renderer changed.

## Tests

3,314 tests, 5 new, 0 red. `tsc` and `validate` clean; 1,580 offers, 493 deal changes. Each new test asserts a standing record on the same page is **not** marked, so none of them passes on a renderer that marks everything.

I did not run the full 2,577-path corpus sweep on this one. The change adds a CSS rule to three pages, so every `/alternative-to/*` page moves by those bytes by construction and the sweep's signal would be swamped. Verification is the per-surface checks above instead. No data file is touched.