### PR TITLE
Retract the Highlight.io free-tier removal (#1249)

### DIFF
--- a/data/deal_changes.json
+++ b/data/deal_changes.json
@@ -5926,13 +5926,19 @@
       "date_source": "discovered",
       "summary": "Highlight.io's own page now redirects to launchdarkly.com.",
       "previous_state": "500 sessions, 1K errors, 1M logs, 25M traces/month. 3-month retention for sessions/errors, 30-day for logs/traces. Up to 15 seats",
-      "current_state": "The page promotes a free trial and then paid plans for CodeControl and AgentControl. No specific limits for a free tier are provided.",
+      "current_state": "LaunchDarkly's Developer plan is $0/month forever and includes 5,000 session replays and 5,000 errors a month, 1 project and 3 environments, with 14-day data retention. The open-source project remains self-hostable.",
       "impact": "high",
       "source_url": "https://www.highlight.io/pricing",
       "category": "Logging",
       "alternatives": [],
       "detected_by": "reverify-ai",
-      "recorded_date": "2026-08-28"
+      "recorded_date": "2026-08-28",
+      "resolution": {
+        "state": "retracted",
+        "date": "2026-09-03",
+        "detail": "Retracted 2026-09-03: no free tier was removed. Highlight.io was acquired by LaunchDarkly, and LaunchDarkly's free Developer plan carries 5,000 session replays and 5,000 errors a month at $0/month. This row was our error.",
+        "source_url": "https://launchdarkly.com/pricing/"
+      }
     },
     {
       "vendor": "Harness Feature Flags",

--- a/data/index.json
+++ b/data/index.json
@@ -3734,7 +3734,7 @@
     {
       "vendor": "Highlight.io",
       "category": "Logging",
-      "description": "Acquired by LaunchDarkly; highlight.io now redirects to launchdarkly.com and the hosted free tier is no longer offered under this name. The open-source project remains self-hostable (repo active, last pushed 2026-08-20).",
+      "description": "Acquired by LaunchDarkly; highlight.io now redirects to launchdarkly.com. LaunchDarkly's free Developer plan carries 5,000 session replays and 5,000 errors a month. The open-source project remains self-hostable (repo active, last pushed 2026-08-20).",
       "tier": "Free OSS",
       "url": "https://github.com/highlight/highlight",
       "tags": [


### PR DESCRIPTION
Data only. No `src/`, no `test/`. `npm run validate` clean — 1,580 offers, 493 changes. Both files round-trip byte-identical through `json.dumps(indent=2, ensure_ascii=False)`.

## Highlight.io 2026-08-28 — retracted

Verified today: `highlight.io` and `www.highlight.io/pricing` both land on `launchdarkly.com`. LaunchDarkly's pricing page publishes a **Developer plan at $0/mo, forever**, and its own comparison table gives that tier **5K session replays and 5K errors per month**, 1 project / 3 environments, 14-day retention.

Session replay and error monitoring are the product. The free tier moved; it was not removed.

The record published `free_tier_removed` at `high` impact, and `/api/vendor-risk/Highlight.io` returned `risk_level: "risky"` with this record as the cause. `current_state` read *"The page promotes a free trial and then paid plans for CodeControl and AgentControl. No specific limits for a free tier are provided"* — the limits are on the page.

Changed: `resolution` added (`retracted`, sourced to `launchdarkly.com/pricing`), `current_state` re-read from the destination, and the offer description now names where the free tier went. `summary` is unchanged — the redirect it reports is true.

`demotionForChange` returns `null` for a resolved record, so the `risky` rating should clear on deploy. That is a derived effect, not a separate edit, and I will check it on production.

## Netlify 2026-03-01 — the blank `detail`

`resolution.detail` was left blank deliberately in #1288, to show the structured field worked without a sentence. A census of 663 production pages says it does not: 27 of 85 occurrences of a resolved record carry no marker of any kind, and 24 of those 27 are this record. Numbers on https://github.com/robhunter/agentdeals/issues/1282.

The sentence is sourced to `netlify.com/pricing`, which states: *"As of April 14th, credit-based Pro plans no longer charge for any seat."*

This ends today's exposure. It does not fix the mechanism — that is still #1282, and the fallback belongs in `summaryWithResolution`.
