### PR TITLE
Give the Netlify reversal a sentence so it reaches every render path (#1282)

### DIFF
--- a/data/deal_changes.json
+++ b/data/deal_changes.json
@@ -294,7 +294,8 @@
           "vendor": "Netlify",
           "date": "2026-04-14",
           "change_type": "limits_increased"
-        }
+        },
+        "detail": "Reversed 2026-04-14: Netlify's pricing page now states that as of April 14th, credit-based Pro plans no longer charge for any seat. The per-committer charge described here is no longer in force."
       }
     },
     {


### PR DESCRIPTION
Data only, one field. `npm run validate` clean. Round-trips byte-identical.

`resolution.detail` on the Netlify 2026-03-01 restriction was left blank in #1288 to show the structured field worked without a sentence. A census of 663 production pages says it does not: **27 of 85 occurrences of a resolved record carry no marker of any kind, and 22 of those are this record.** Numbers on https://github.com/robhunter/agentdeals/issues/1282.

Sourced to `netlify.com/pricing`, which states: *"As of April 14th, credit-based Pro plans no longer charge for any seat."*

This ends today's exposure on `/compare/*`, `/reports/2026-03`, `/changes`, `/free-tier-tracker` and 18 other pages. It does not fix the mechanism — that is still #1282, and the fix belongs in `summaryWithResolution`.

Split out of https://github.com/robhunter/agentdeals/pull/1293, whose other half is blocked.