### PR TITLE
Let the risk invariants see a withdrawn record (#1295)

### DIFF
--- a/scripts/mutate-1295.sh
+++ b/scripts/mutate-1295.sh
@@ -1,0 +1,213 @@
+#!/usr/bin/env bash
+set -u
+
+REPO="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$REPO" || exit 1
+
+FILES="src/change-resolution.ts src/vendor-verdict.ts test/one-verdict-engine.test.ts test/risk-badge.test.ts test/enrich.test.ts test/vendor-verdict.test.ts"
+BACKUP_DIR="$(mktemp -d)"
+for f in $FILES; do cp "$f" "$BACKUP_DIR/$(basename "$f")"; done
+
+restore() {
+  for f in $FILES; do cp "$BACKUP_DIR/$(basename "$f")" "$(echo "$f")"; done
+  npm run build > /dev/null 2>&1
+}
+
+restore_paths() {
+  cp "$BACKUP_DIR/change-resolution.ts" src/change-resolution.ts
+  cp "$BACKUP_DIR/vendor-verdict.ts" src/vendor-verdict.ts
+  cp "$BACKUP_DIR/one-verdict-engine.test.ts" test/one-verdict-engine.test.ts
+  cp "$BACKUP_DIR/risk-badge.test.ts" test/risk-badge.test.ts
+  cp "$BACKUP_DIR/enrich.test.ts" test/enrich.test.ts
+  cp "$BACKUP_DIR/vendor-verdict.test.ts" test/vendor-verdict.test.ts
+}
+
+trap 'restore_paths; npm run build > /dev/null 2>&1' EXIT
+
+killed=0
+survived=0
+TESTS="test/one-verdict-engine.test.ts test/risk-badge.test.ts test/enrich.test.ts test/vendor-verdict.test.ts test/change-resolution.test.ts"
+
+run_mutation() {
+  local name="$1"
+  shift
+  echo "=== $name"
+  restore_paths
+  "$@"
+  local changed=0
+  for f in $FILES; do
+    diff -q "$BACKUP_DIR/$(basename "$f")" "$f" > /dev/null || changed=1
+  done
+  if [ "$changed" -eq 0 ]; then
+    echo "    NOT APPLIED: the mutation changed no file, so it proves nothing"
+    survived=$((survived + 1))
+    return
+  fi
+  if ! npm run build > /tmp/mutate-1295-build.log 2>&1; then
+    echo "    KILLED: the mutation does not typecheck"
+    killed=$((killed + 1))
+    return
+  fi
+  if timeout 900 npx tsx --test $TESTS > /tmp/mutate-1295-test.log 2>&1; then
+    echo "    SURVIVED"
+    survived=$((survived + 1))
+  else
+    echo "    KILLED: $(grep -c '✖ ' /tmp/mutate-1295-test.log) failing assertion(s)"
+    grep '✖ ' /tmp/mutate-1295-test.log | head -4
+    killed=$((killed + 1))
+  fi
+}
+
+py() { python3 - "$@"; }
+
+m_nothing_is_ever_no_longer_in_force() {
+  py <<'PY'
+p = "src/change-resolution.ts"
+s = open(p).read()
+s = s.replace('''export function isNoLongerInForce(change: { resolution?: ChangeResolution | null }): boolean {
+  return Boolean(change.resolution);
+}''', '''export function isNoLongerInForce(change: { resolution?: ChangeResolution | null }): boolean {
+  return false;
+}''')
+open(p, "w").write(s)
+PY
+}
+
+m_everything_is_no_longer_in_force() {
+  py <<'PY'
+p = "src/change-resolution.ts"
+s = open(p).read()
+s = s.replace('''export function isNoLongerInForce(change: { resolution?: ChangeResolution | null }): boolean {
+  return Boolean(change.resolution);
+}''', '''export function isNoLongerInForce(change: { resolution?: ChangeResolution | null }): boolean {
+  return true;
+}''')
+open(p, "w").write(s)
+PY
+}
+
+m_one_verdict_stops_exempting_a_withdrawal() {
+  py <<'PY'
+p = "test/one-verdict-engine.test.ts"
+s = open(p).read()
+s = s.replace("  if (isNoLongerInForce(change)) return false;\n", "")
+open(p, "w").write(s)
+PY
+}
+
+m_one_verdict_exempts_every_removal() {
+  py <<'PY'
+p = "test/one-verdict-engine.test.ts"
+s = open(p).read()
+s = s.replace("  if (isNoLongerInForce(change)) return false;",
+              "  if (isNoLongerInForce(change) || change.change_type === \"free_tier_removed\") return false;")
+open(p, "w").write(s)
+PY
+}
+
+m_one_verdict_drops_its_vacuity_guard() {
+  py <<'PY'
+p = "test/one-verdict-engine.test.ts"
+s = open(p).read()
+s = s.replace('    assert.ok(checked > 0, "no vendor holds a record that points down, so this asserts nothing");\n', "")
+s = s.replace("  if (isNoLongerInForce(change)) return false;",
+              "  if (true) return false;")
+open(p, "w").write(s)
+PY
+}
+
+m_risk_badge_stops_exempting_a_withdrawal() {
+  py <<'PY'
+p = "test/risk-badge.test.ts"
+s = open(p).read()
+s = s.replace("""      const narrowing = changes.filter(
+        (c) => NEGATIVE_CHANGE_TYPES.has(c.change_type) && !isNoLongerInForce(c as never),
+      ).length;""",
+"""      const narrowing = changes.filter(
+        (c) => NEGATIVE_CHANGE_TYPES.has(c.change_type),
+      ).length;""")
+s = s.replace('    const counts = (c: Change) => NEGATIVE_CHANGE_TYPES.has(c.change_type) && !isNoLongerInForce(c as never);',
+              '    const counts = (c: Change) => NEGATIVE_CHANGE_TYPES.has(c.change_type);')
+open(p, "w").write(s)
+PY
+}
+
+m_risk_badge_counts_no_narrowing_at_all() {
+  py <<'PY'
+p = "test/risk-badge.test.ts"
+s = open(p).read()
+s = s.replace("""      const narrowing = changes.filter(
+        (c) => NEGATIVE_CHANGE_TYPES.has(c.change_type) && !isNoLongerInForce(c as never),
+      ).length;""",
+"""      const narrowing = changes.filter(
+        (c) => NEGATIVE_CHANGE_TYPES.has(c.change_type) && false,
+      ).length;""")
+open(p, "w").write(s)
+PY
+}
+
+m_enrich_admits_a_standing_narrowing() {
+  py <<'PY'
+p = "test/enrich.test.ts"
+s = open(p).read()
+s = s.replace("      FAVOURABLE.has(c.change_type) || isNoLongerInForce(c as never);",
+              "      FAVOURABLE.has(c.change_type) || true;")
+open(p, "w").write(s)
+PY
+}
+
+m_vendor_verdict_stops_exempting_a_withdrawal() {
+  py <<'PY'
+p = "test/vendor-verdict.test.ts"
+s = open(p).read()
+s = s.replace('  CHANGE_DIRECTION[c.change_type] === "negative" && !isNoLongerInForce(c);',
+              '  CHANGE_DIRECTION[c.change_type] === "negative";')
+open(p, "w").write(s)
+PY
+}
+
+m_the_verdict_sentence_counts_a_withdrawn_narrowing() {
+  py <<'PY'
+p = "src/vendor-verdict.ts"
+s = open(p).read()
+s = s.replace('    .filter(c => CHANGE_DIRECTION[c.change_type] === "negative" && !isNoLongerInForce(c))',
+              '    .filter(c => CHANGE_DIRECTION[c.change_type] === "negative")')
+open(p, "w").write(s)
+PY
+}
+
+m_the_verdict_sentence_counts_no_narrowing_at_all() {
+  py <<'PY'
+p = "src/vendor-verdict.ts"
+s = open(p).read()
+s = s.replace('    .filter(c => CHANGE_DIRECTION[c.change_type] === "negative" && !isNoLongerInForce(c))',
+              '    .filter(c => CHANGE_DIRECTION[c.change_type] === "negative" && false)')
+open(p, "w").write(s)
+PY
+}
+
+m_the_verdict_input_drops_the_resolution_again() {
+  py <<'PY'
+p = "src/vendor-verdict.ts"
+s = open(p).read()
+s = s.replace('  changes: Array<Pick<DealChange, "date" | "date_source" | "change_type"> & { resolution?: DealChange["resolution"] }>;',
+              '  changes: Array<Pick<DealChange, "date" | "date_source" | "change_type">>;')
+open(p, "w").write(s)
+PY
+}
+
+run_mutation "the predicate the exemptions ride on never fires" m_nothing_is_ever_no_longer_in_force
+run_mutation "the predicate the exemptions ride on always fires" m_everything_is_no_longer_in_force
+run_mutation "one-verdict-engine counts a withdrawn record again" m_one_verdict_stops_exempting_a_withdrawal
+run_mutation "one-verdict-engine exempts every removal, not only a withdrawn one" m_one_verdict_exempts_every_removal
+run_mutation "one-verdict-engine exempts everything and drops its vacuity guard" m_one_verdict_drops_its_vacuity_guard
+run_mutation "risk-badge counts a withdrawn narrowing again" m_risk_badge_stops_exempting_a_withdrawal
+run_mutation "risk-badge counts no narrowing at all" m_risk_badge_counts_no_narrowing_at_all
+run_mutation "enrich requires a stable verdict over a standing narrowing" m_enrich_admits_a_standing_narrowing
+run_mutation "the vendor page may establish a narrowing from a withdrawn record" m_vendor_verdict_stops_exempting_a_withdrawal
+run_mutation "the verdict sentence counts a withdrawn record as a narrowing" m_the_verdict_sentence_counts_a_withdrawn_narrowing
+run_mutation "the verdict sentence counts no narrowing at all" m_the_verdict_sentence_counts_no_narrowing_at_all
+run_mutation "the verdict input drops the resolution from its projection again" m_the_verdict_input_drops_the_resolution_again
+
+echo
+echo "killed: $killed  survived: $survived"

--- a/src/vendor-verdict.ts
+++ b/src/vendor-verdict.ts
@@ -1,5 +1,6 @@
 import type { DealChange, RiskCause } from "./types.js";
 import { CHANGE_DIRECTION, isACorrectionToOurOwnRecord } from "./data.js";
+import { isNoLongerInForce } from "./change-resolution.js";
 import { changeDateClause } from "./change-dates.js";
 import { withheldLevelClause, type LevelWithheldReason } from "./source-check.js";
 import { endedVerdictSentence } from "./retirement.js";
@@ -32,7 +33,7 @@ export interface VendorVerdictInput {
   vendor: string;
   level: PublishedRiskLevel | null;
   cause: RiskCause | null;
-  changes: Array<Pick<DealChange, "date" | "date_source" | "change_type">>;
+  changes: Array<Pick<DealChange, "date" | "date_source" | "change_type"> & { resolution?: DealChange["resolution"] }>;
   levelWithheld: LevelWithheldReason | null;
   unconfirmableSince: string;
   offerEnded?: boolean;
@@ -60,7 +61,7 @@ function narrowingChanges(
   changes: VendorVerdictInput["changes"],
 ): VendorVerdictInput["changes"] {
   return changes
-    .filter(c => CHANGE_DIRECTION[c.change_type] === "negative")
+    .filter(c => CHANGE_DIRECTION[c.change_type] === "negative" && !isNoLongerInForce(c))
     .slice()
     .sort((a, b) => b.date.localeCompare(a.date));
 }

--- a/test/enrich.test.ts
+++ b/test/enrich.test.ts
@@ -51,6 +51,7 @@ describe("enrichOffers", () => {
   it("counts nothing — the number of records a vendor has cannot move its risk level", async () => {
     const { enrichOffers, loadOffers, loadDealChanges } = await import("../dist/data.js");
     const { levelWithheldReason } = await import("../dist/source-check.js");
+    const { isNoLongerInForce } = await import("../dist/change-resolution.js");
     const changes = loadDealChanges();
     const offers = loadOffers();
 
@@ -68,9 +69,12 @@ describe("enrichOffers", () => {
       byVendor.get(key)!.push(c);
     }
 
+    const nothingLeftToWarnAbout = (c: { change_type: string }) =>
+      FAVOURABLE.has(c.change_type) || isNoLongerInForce(c as never);
+
     let checked = 0;
     for (const [vendor, vendorChanges] of byVendor) {
-      if (!vendorChanges.every((c) => FAVOURABLE.has(c.change_type))) continue;
+      if (!vendorChanges.every(nothingLeftToWarnAbout)) continue;
       const offer = offers.find((o: { vendor: string }) => o.vendor.toLowerCase() === vendor);
       if (!offer) continue;
       const enriched = enrichOffers([offer])[0];
@@ -78,7 +82,7 @@ describe("enrichOffers", () => {
       assert.strictEqual(
         enriched.risk_level,
         "stable",
-        `${offer.vendor} has ${vendorChanges.length} record(s), all favourable or neutral (${vendorChanges.map((c) => c.change_type).join(", ")}), and must not be warned`,
+        `${offer.vendor} has ${vendorChanges.length} record(s), none of them a standing warning (${vendorChanges.map((c) => c.change_type).join(", ")}), and must not be warned`,
       );
       assert.strictEqual(enriched.risk_cause, null);
       checked++;

--- a/test/one-verdict-engine.test.ts
+++ b/test/one-verdict-engine.test.ts
@@ -18,6 +18,7 @@ import {
   vendorRiskAssessment,
   verdictHasLapsed,
 } from "../dist/data.js";
+import { isNoLongerInForce } from "../dist/change-resolution.js";
 import { PRODUCT_DEPRECATED, deprecationEndsTheListedProduct } from "../dist/product-deprecation.js";
 import { vendorSlugMap } from "../dist/vendor-slug.js";
 import type { DealChange } from "../src/types.ts";
@@ -45,6 +46,18 @@ function record(overrides: Partial<DealChange> = {}): DealChange {
 }
 
 const isoDaysBefore = (days: number) => new Date(NOW - days * DAY).toISOString().slice(0, 10);
+
+const withdrawn = (change: DealChange): DealChange => ({
+  ...change,
+  resolution: { state: "retracted", date: isoDaysBefore(1), source_url: "https://example.test/withdrawal" },
+});
+
+function pointsDownAndStillHolds(change: DealChange, nowMs: number = Date.now()): boolean {
+  if (CHANGE_DIRECTION[change.change_type] !== "negative") return false;
+  if (isNoLongerInForce(change)) return false;
+  if (verdictHasLapsed(change, nowMs)) return false;
+  return !(change.change_type === PRODUCT_DEPRECATED && !deprecationEndsTheListedProduct(change));
+}
 
 describe("#1206 one risk scale, and every change type sits on one side of it", () => {
   it("classifies every change type the risk scale can act on as an event or a condition", () => {
@@ -87,10 +100,7 @@ describe("#1206 one risk scale, and every change type sits on one side of it", (
     let checked = 0;
     for (const vendor of new Set(loadOffers().map(o => o.vendor))) {
       const changes = held.get(vendor.toLowerCase()) ?? [];
-      const inForce = changes.filter(c =>
-        CHANGE_DIRECTION[c.change_type] === "negative" &&
-        !verdictHasLapsed(c) &&
-        !(c.change_type === PRODUCT_DEPRECATED && !deprecationEndsTheListedProduct(c)));
+      const inForce = changes.filter(c => pointsDownAndStillHolds(c));
       if (inForce.length === 0) continue;
       checked++;
       if (vendorRiskAssessment(changes).level === "stable") {
@@ -99,6 +109,16 @@ describe("#1206 one risk scale, and every change type sits on one side of it", (
     }
     assert.ok(checked > 0, "no vendor holds a record that points down, so this asserts nothing");
     assert.deepStrictEqual(wrong.slice(0, 20), [], `stable verdicts over a record that points down:\n${wrong.slice(0, 20).join("\n")}`);
+  });
+
+  it("checks a vendor whose one adverse record stands, and exempts the same one withdrawn", () => {
+    const standing = record({ change_type: "free_tier_removed", date: isoDaysBefore(30) });
+
+    assert.strictEqual(pointsDownAndStillHolds(standing, NOW), true, "the invariant no longer checks a standing removal");
+    assert.notStrictEqual(vendorRiskAssessment([standing], NOW).level, "stable");
+
+    assert.strictEqual(pointsDownAndStillHolds(withdrawn(standing), NOW), false, "the invariant still checks a withdrawn removal");
+    assert.strictEqual(vendorRiskAssessment([withdrawn(standing)], NOW).level, "stable");
   });
 });
 

--- a/test/risk-badge.test.ts
+++ b/test/risk-badge.test.ts
@@ -36,7 +36,13 @@ after(() => { if (proc) proc.kill(); });
 
 const toSlug = (v: string) => v.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-|-$/g, "");
 
-type Change = { vendor: string; change_type: string; date: string; summary: string };
+type Change = {
+  vendor: string;
+  change_type: string;
+  date: string;
+  summary: string;
+  resolution?: { state: string; date: string; source_url?: string } | null;
+};
 
 function changesByVendor(changes: Change[]): Map<string, Change[]> {
   const m = new Map<string, Change[]>();
@@ -299,17 +305,44 @@ describe("#1147 — a shutdown of the product we list demotes the vendor", () =>
     assert.strictEqual(classifyStability([one]), "watch");
   });
 
-  it("never calls a vendor stable on a scale where it holds a narrowing", async () => {
+  it("never calls a vendor stable on a scale where it holds a narrowing that still stands", async () => {
     const { classifyStability, loadDealChanges, NEGATIVE_CHANGE_TYPES } = await import("../dist/data.js");
+    const { isNoLongerInForce } = await import("../dist/change-resolution.js");
     const held = changesByVendor(loadDealChanges() as Change[]);
     const wrong: string[] = [];
+    let checked = 0;
     for (const [vendor, changes] of held) {
-      const narrowing = changes.filter((c) => NEGATIVE_CHANGE_TYPES.has(c.change_type)).length;
-      if (narrowing > 0 && classifyStability(changes as never) === "stable") {
-        wrong.push(`${vendor} holds ${narrowing} narrowing record(s) and reads stable`);
+      const narrowing = changes.filter(
+        (c) => NEGATIVE_CHANGE_TYPES.has(c.change_type) && !isNoLongerInForce(c as never),
+      ).length;
+      if (narrowing === 0) continue;
+      checked++;
+      if (classifyStability(changes as never) === "stable") {
+        wrong.push(`${vendor} holds ${narrowing} standing narrowing record(s) and reads stable`);
       }
     }
+    assert.ok(checked > 0, "no vendor holds a narrowing that still stands, so this asserts nothing");
     assert.deepStrictEqual(wrong, []);
+  });
+
+  it("counts a vendor's one standing narrowing, and stops counting the same one withdrawn", async () => {
+    const { classifyStability, NEGATIVE_CHANGE_TYPES } = await import("../dist/data.js");
+    const { isNoLongerInForce } = await import("../dist/change-resolution.js");
+    const standing: Change = {
+      vendor: "V", change_type: "free_tier_removed", date: "2026-06-01",
+      summary: "The free plan is gone.",
+    };
+    const counts = (c: Change) => NEGATIVE_CHANGE_TYPES.has(c.change_type) && !isNoLongerInForce(c as never);
+    const retracted: Change = {
+      ...standing,
+      resolution: { state: "retracted", date: "2026-06-10", source_url: "https://example.test/withdrawal" },
+    };
+
+    assert.strictEqual(counts(standing), true, "the invariant no longer counts a standing narrowing");
+    assert.notStrictEqual(classifyStability([standing] as never), "stable");
+
+    assert.strictEqual(counts(retracted), false, "the invariant still counts a withdrawn narrowing");
+    assert.strictEqual(classifyStability([retracted] as never), "stable");
   });
 
   it("the volatile population is not empty, so that invariant is not vacuous", async () => {

--- a/test/vendor-verdict.test.ts
+++ b/test/vendor-verdict.test.ts
@@ -37,6 +37,9 @@ const OTHER_SCALE_ON_A_SURFACE_THAT_EMBEDS_SUMMARIES = /\bvolatile\b|on our watc
 const COUNT_AS_EVIDENCE = /\b\d+ pricing changes? recorded/;
 const CLAIMS_A_NARROWING = /(?:One recorded [^.]*|(?<!None of the )\d+ recorded changes) narrowed the terms/;
 
+const establishesANarrowing = (c: DealChange): boolean =>
+  CHANGE_DIRECTION[c.change_type] === "negative" && !isNoLongerInForce(c);
+
 function change(over: Partial<DealChange> = {}): DealChange {
   return {
     vendor: "Vendor A",
@@ -185,6 +188,25 @@ describe("vendor verdict — a stable rating reports direction, not volume", () 
       change({ change_type: "rebranded", date: "2026-03-01" }),
     ];
     assert.strictEqual(narrowingSentence(changes), "None of the 3 recorded changes narrowed the terms.");
+  });
+
+  it("does not let a withdrawn record establish the narrowing the verdict says is not there", () => {
+    const standing = change({ change_type: "free_tier_removed", date: "2026-08-28" });
+    const withdrawn = change({
+      change_type: "free_tier_removed",
+      date: "2026-08-28",
+      resolution: { state: "retracted", date: "2026-09-03", source_url: "https://example.test/withdrawal" },
+    });
+
+    assert.strictEqual(establishesANarrowing(standing), true);
+    assert.match(narrowingSentence([standing]), /One recorded free tier removal narrowed the terms/);
+
+    assert.strictEqual(establishesANarrowing(withdrawn), false);
+    assert.strictEqual(narrowingSentence([withdrawn]), "The one change we have recorded did not narrow the terms.");
+    assert.doesNotMatch(
+      vendorVerdictSentence(input({ level: "stable", changes: [withdrawn] })),
+      /narrowed the terms/,
+    );
   });
 
   it("says what a record that repairs our own entry is, rather than counting it as a change", () => {
@@ -524,9 +546,7 @@ describe("vendor verdict — as rendered", () => {
         const row = rows[index++];
         const html = await get(`/vendor/${row.slug}`);
         const verdict = verdictParagraph(html);
-        const narrowing = row.changes.filter(
-          c => CHANGE_DIRECTION[c.change_type] === "negative" && !isNoLongerInForce(c),
-        );
+        const narrowing = row.changes.filter(establishesANarrowing);
         if (CLAIMS_A_NARROWING.test(verdict) && narrowing.length === 0) {
           wrong.push(`${row.slug}: names a narrowing over ${row.changes.length} record(s), none of which still point down`);
         }

--- a/test/vendor-verdict.test.ts
+++ b/test/vendor-verdict.test.ts
@@ -15,6 +15,7 @@ import {
 } from "../dist/vendor-verdict.js";
 import { CHANGE_DIRECTION, enrichOffers, loadDealChanges, loadOffers, vendorRiskAssessment, classifyStability } from "../dist/data.js";
 import { vendorSlugMap } from "../dist/vendor-slug.js";
+import { isNoLongerInForce } from "../dist/change-resolution.js";
 import { levelWithheldReason } from "../dist/source-check.js";
 import { offerEnded, endedVerdictSentence, ENDED_BADGE_LABEL } from "../dist/retirement.js";
 import { gateFor, utcDate } from "../dist/ranking.js";
@@ -523,9 +524,11 @@ describe("vendor verdict — as rendered", () => {
         const row = rows[index++];
         const html = await get(`/vendor/${row.slug}`);
         const verdict = verdictParagraph(html);
-        const narrowing = row.changes.filter(c => CHANGE_DIRECTION[c.change_type] === "negative");
+        const narrowing = row.changes.filter(
+          c => CHANGE_DIRECTION[c.change_type] === "negative" && !isNoLongerInForce(c),
+        );
         if (CLAIMS_A_NARROWING.test(verdict) && narrowing.length === 0) {
-          wrong.push(`${row.slug}: names a narrowing over ${row.changes.length} record(s), none of which point down`);
+          wrong.push(`${row.slug}: names a narrowing over ${row.changes.length} record(s), none of which still point down`);
         }
         if (row.changes.every(c => c.change_type === "record_corrected")) {
           if (!/corrects? our own earlier entr/.test(verdict)) {


### PR DESCRIPTION
Refs #1295

`demotionForChange` has returned `null` for a resolved record since #1288. Two invariants written before that vocabulary existed still counted one, so a vendor whose **only** adverse record is withdrawn could not satisfy both. That is what holds #1293 red.

## The two invariants (AC-1, AC-2)

`test/one-verdict-engine.test.ts` — the `inForce` filter is now a named `pointsDownAndStillHolds`, and a resolution joins the two exemptions already there: a lapsed verdict, and a deprecation that does not end the listed product. The test's own name already said "and still holds in force"; the code now matches it.

`test/risk-badge.test.ts` — the narrowing count exempts a resolved record, and the test now asserts `checked > 0` (AC-3), which `one-verdict-engine` already did.

**Verified against #1293 rather than reasoned about.** On a worktree of `origin/pm/resolution-detail-and-highlight-retraction`:

- before this branch: `2 fail` — exactly the two the issue quotes, `Highlight.io holds free_tier_removed and reads stable` and `highlight.io holds 1 narrowing record(s) and reads stable`
- with this branch merged in: **3,316 tests, 0 red**, #1293's data untouched

## The paired cases (AC-4)

Each invariant gets a synthetic pair asserting *both* halves — that the population still contains a standing removal, and that it no longer contains the same record withdrawn. Widening the exemption fails the first half:

```
pointsDownAndStillHolds(standing)  === true   and vendorRiskAssessment([standing])  !== stable
pointsDownAndStillHolds(withdrawn) === false  and vendorRiskAssessment([withdrawn]) === stable
```

## Verdict movement (AC-5)

Measured over every vendor holding a resolved record, comparing the verdict against the same records with `resolution` stripped:

| vendor | records | risk | stability |
|---|---|---|---|
| GitHub Copilot | 6 | caution → caution | volatile → volatile |
| Netlify | 4 | caution → caution | volatile → volatile |
| Cursor | 5 | caution → caution | volatile → volatile |
| **Highlight.io** (with #1293) | 1 | **risky → stable** | **volatile → stable** |

**One vendor moves, and it is the one the issue names.** The other three each hold a standing adverse record, which is exactly why they never hit the wall.

## The grep you asked for

Four test files reason about change direction. Two are the ones above. The other two both made the same assumption:

- `test/vendor-verdict.test.ts` — "names a narrowing only where a record of the vendor's own establishes one" counted a withdrawn record among the establishers, so a page claiming a narrowing over nothing but withdrawn records passed. Tightened.
- `test/enrich.test.ts` — the mirror invariant, "a vendor whose whole history is favourable must read stable". A withdrawn adverse record put the vendor outside the population rather than inside it, so nothing *required* the stable verdict. Widened, so the carve-outs above are matched by a check that demands the lift rather than only permitting it. It admits zero extra vendors on `main` and exactly Highlight.io on #1293's data.

## One production defect, found by the tightening

`narrowingChanges` in `src/vendor-verdict.ts` counted a withdrawn record. So the exemption I am shipping makes this reachable on a vendor whose only negative record is withdrawn:

> We rate it stable. One recorded free tier removal narrowed the terms, discovered 2026-08-28.

`VendorVerdictInput.changes` was also projected to three fields — `date`, `date_source`, `change_type` — so the sentence could not have read a resolution even if it wanted to. Both call sites in `serve.ts` already pass whole records; only the type dropped it. Fixed both, because shipping the exemption without this ships a self-contradicting sentence.

**Inert today, and I would rather say so than imply otherwise.** 2,577 paths swept on `main` + #1293's data, with and against this branch: **2,577 byte-identical, 0 moved.** Highlight.io's verdict is on the withheld path (`states_no_terms`), so it renders the "we cannot confirm these terms" sentence rather than a narrowing count. The fix is a latch on a reachable contradiction, not a correction to a rendered one. The synthetic test is what proves it reachable.

## Reported, not fixed

`/vendor/highlight-io` on `main` + #1293 carries the `change-resolved` marker and `eventStatus: EventCancelled` from #1292, and still presents the retracted record as a live change on two surfaces:

- the page banner — `⚠️ Pricing change: Highlight.io's own page now redirects to launchdarkly.com. Retracted 2026-09-03: …`
- the FAQ answer — `Highlight.io has had 1 recorded pricing change.`

Both are #1282 item 2, and both are covered only by the appended sentence. I did not tighten the render-side assertion that would go red on them, because a red test that blocks a correct data change is how this issue started.

## Checks

3,317 tests, 4 new, 0 red. `tsc` and `validate` clean. 12 mutations across `src/change-resolution.ts`, `src/vendor-verdict.ts` and the four test files, **12 killed, 0 survivors** — one of them by `tsc` rather than by a test, which is the weaker kind of kill, and it is the projection mutation where the type is the guard. `scripts/mutate-1295.sh`.

2,577 paths swept against a worktree of `main`: 2,577 byte-identical, 0 moved, 0 added, 0 removed.
