### PR TITLE
Prefix the resolution so a truncated summary still carries it (#1282)

### DIFF
--- a/scripts/census-1282-resolution-markers.mjs
+++ b/scripts/census-1282-resolution-markers.mjs
@@ -1,0 +1,117 @@
+import { readFileSync } from "node:fs";
+
+const BASE = process.argv[2] ?? "http://localhost:3000";
+const REPO = new URL("..", import.meta.url).pathname;
+
+const stored = JSON.parse(readFileSync(`${REPO}/data/deal_changes.json`, "utf-8")).changes;
+const resolved = stored.filter((c) => c.resolution);
+
+const escServer = (s) =>
+  s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;");
+const escClient = (s) => escServer(s).replace(/'/g, "&#39;");
+
+const KEY_LEN = 40;
+const keys = resolved.map((c) => {
+  const raw = c.summary.slice(0, KEY_LEN);
+  return { record: `${c.vendor} ${c.date}`, needles: [...new Set([raw, escServer(raw), escClient(raw)])] };
+});
+
+const STRUCTURAL = ["change-resolved", "pc-resolved", "superseded-row", "EventCancelled", "endDate", '"resolved":true'];
+const tags = resolved.map((c) =>
+  c.resolution.state === "reversed"
+    ? `No longer in force (${c.resolution.date}).`
+    : `Retracted — this record was our error (${c.resolution.date}).`
+);
+const details = resolved.map((c) => c.resolution.detail).filter(Boolean);
+
+async function get(p) {
+  const res = await fetch(`${BASE}${p}`);
+  return { status: res.status, body: await res.text() };
+}
+
+async function sitemapPaths() {
+  const out = new Set();
+  for (const map of ["pages", "vendors", "comparisons", "reports", "misc"]) {
+    const { body } = await get(`/sitemap-${map}.xml`);
+    for (const [, loc] of body.matchAll(/<loc>([^<]+)<\/loc>/g)) {
+      try {
+        out.add(new URL(loc).pathname);
+      } catch {
+        out.add(loc);
+      }
+    }
+  }
+  return [...out].sort();
+}
+
+const paths = await sitemapPaths();
+process.stderr.write(`${paths.length} paths from five sitemaps\n`);
+
+const occurrences = [];
+let nonOk = 0;
+
+for (const p of paths) {
+  let page;
+  try {
+    page = await get(p);
+  } catch (err) {
+    process.stderr.write(`FETCH FAIL ${p} ${err.message}\n`);
+    nonOk++;
+    continue;
+  }
+  if (page.status !== 200) {
+    nonOk++;
+    continue;
+  }
+  const body = page.body;
+  for (const { record, needles } of keys) {
+    for (const needle of needles) {
+      let at = body.indexOf(needle);
+      while (at !== -1) {
+        const before = body.slice(Math.max(0, at - 2500), at);
+        const after = body.slice(at, at + 900);
+        const window = before + after;
+        const tight = body.slice(Math.max(0, at - 120), at);
+        occurrences.push({
+          path: p,
+          record,
+          structural: STRUCTURAL.some((m) => window.includes(m)),
+          detail: details.some((d) => window.includes(d)),
+          tag: tags.some((t) => tight.includes(t)),
+        });
+        at = body.indexOf(needle, at + needle.length);
+      }
+    }
+  }
+}
+
+const total = occurrences.length;
+const tally = (f) => occurrences.filter(f).length;
+const unmarked = occurrences.filter((o) => !o.structural && !o.detail && !o.tag);
+
+console.log(`paths fetched: ${paths.length}, non-200 or failed: ${nonOk}`);
+console.log(`occurrences of a resolved record: ${total}`);
+console.log(`  carrying the derived tag:      ${tally((o) => o.tag)}`);
+console.log(`  carrying a structural marker:  ${tally((o) => o.structural)}`);
+console.log(`  carrying the detail sentence:  ${tally((o) => o.detail)}`);
+console.log(`  carrying nothing:              ${unmarked.length}`);
+
+const byRecord = {};
+for (const o of occurrences) {
+  byRecord[o.record] ??= { n: 0, tag: 0, structural: 0, detail: 0, none: 0 };
+  const r = byRecord[o.record];
+  r.n++;
+  if (o.tag) r.tag++;
+  if (o.structural) r.structural++;
+  if (o.detail) r.detail++;
+  if (!o.tag && !o.structural && !o.detail) r.none++;
+}
+console.log("\nrecord | occurrences | tag | structural | detail | none");
+for (const [record, r] of Object.entries(byRecord).sort()) {
+  console.log(`${record} | ${r.n} | ${r.tag} | ${r.structural} | ${r.detail} | ${r.none}`);
+}
+
+if (unmarked.length) {
+  console.log("\nunmarked:");
+  for (const p of [...new Set(unmarked.map((o) => `${o.path}  (${o.record})`))].sort()) console.log(`  ${p}`);
+}

--- a/scripts/mutate-1282-prefix.sh
+++ b/scripts/mutate-1282-prefix.sh
@@ -1,0 +1,193 @@
+#!/usr/bin/env bash
+set -u
+
+REPO="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$REPO" || exit 1
+
+FILES="src/change-resolution.ts src/serve.ts"
+BACKUP_DIR="$(mktemp -d)"
+for f in $FILES; do cp "$f" "$BACKUP_DIR/$(basename "$f")"; done
+
+restore() {
+  for f in $FILES; do cp "$BACKUP_DIR/$(basename "$f")" "$f"; done
+  npm run build > /dev/null 2>&1
+}
+trap restore EXIT
+
+killed=0
+survived=0
+TESTS="test/change-resolution.test.ts test/change-lineup.test.ts"
+
+run_mutation() {
+  local name="$1"
+  shift
+  echo "=== $name"
+  for f in $FILES; do cp "$BACKUP_DIR/$(basename "$f")" "$f"; done
+  "$@"
+  local changed=0
+  for f in $FILES; do
+    diff -q "$BACKUP_DIR/$(basename "$f")" "$f" > /dev/null || changed=1
+  done
+  if [ "$changed" -eq 0 ]; then
+    echo "    NOT APPLIED: the mutation changed no file, so it proves nothing"
+    survived=$((survived + 1))
+    return
+  fi
+  if ! npm run build > /tmp/mutate-1282p-build.log 2>&1; then
+    echo "    KILLED: the mutation does not typecheck"
+    killed=$((killed + 1))
+    return
+  fi
+  if timeout 900 node --test $TESTS > /tmp/mutate-1282p-test.log 2>&1; then
+    echo "    SURVIVED"
+    survived=$((survived + 1))
+  else
+    echo "    KILLED: $(grep -c '✖ ' /tmp/mutate-1282p-test.log) failing assertion(s)"
+    grep '✖ ' /tmp/mutate-1282p-test.log | head -4
+    killed=$((killed + 1))
+  fi
+}
+
+py() {
+  python3 - "$@"
+}
+
+m_the_tag_is_appended_instead_of_prefixed() {
+  py <<'PY'
+p = "src/change-resolution.ts"
+s = open(p).read()
+s = s.replace("  const tagged = change.summary.startsWith(tag) ? change.summary : `${tag} ${change.summary}`;",
+              "  const tagged = change.summary.endsWith(tag) ? change.summary : `${change.summary} ${tag}`;")
+open(p, "w").write(s)
+PY
+}
+
+m_no_tag_is_derived_at_all() {
+  py <<'PY'
+p = "src/change-resolution.ts"
+s = open(p).read()
+s = s.replace("  const tagged = change.summary.startsWith(tag) ? change.summary : `${tag} ${change.summary}`;",
+              "  const tagged = change.summary;")
+open(p, "w").write(s)
+PY
+}
+
+m_the_tag_fires_only_when_no_detail_was_written() {
+  py <<'PY'
+p = "src/change-resolution.ts"
+s = open(p).read()
+s = s.replace("  const tagged = change.summary.startsWith(tag) ? change.summary : `${tag} ${change.summary}`;",
+              "  const tagged = detail || change.summary.startsWith(tag) ? change.summary : `${tag} ${change.summary}`;")
+open(p, "w").write(s)
+PY
+}
+
+m_both_states_derive_the_same_tag() {
+  py <<'PY'
+p = "src/change-resolution.ts"
+s = open(p).read()
+s = s.replace('  retracted: (date) => `Retracted — this record was our error (${date}).`,',
+              '  retracted: (date) => `No longer in force (${date}).`,')
+open(p, "w").write(s)
+PY
+}
+
+m_the_tag_does_not_name_its_date() {
+  py <<'PY'
+p = "src/change-resolution.ts"
+s = open(p).read()
+s = s.replace('  reversed: (date) => `No longer in force (${date}).`,\n  retracted: (date) => `Retracted — this record was our error (${date}).`,',
+              '  reversed: () => "No longer in force.",\n  retracted: () => "Retracted.",')
+open(p, "w").write(s)
+PY
+}
+
+m_the_tag_is_prefixed_a_second_time_on_reload() {
+  py <<'PY'
+p = "src/change-resolution.ts"
+s = open(p).read()
+s = s.replace("  const tagged = change.summary.startsWith(tag) ? change.summary : `${tag} ${change.summary}`;",
+              "  const tagged = `${tag} ${change.summary}`;")
+open(p, "w").write(s)
+PY
+}
+
+m_the_detail_is_prefixed_ahead_of_the_claim() {
+  py <<'PY'
+p = "src/change-resolution.ts"
+s = open(p).read()
+s = s.replace("  return `${tagged} ${detail}`;", "  return `${detail} ${tagged}`;")
+open(p, "w").write(s)
+PY
+}
+
+m_the_detail_is_dropped_now_that_a_tag_exists() {
+  py <<'PY'
+p = "src/change-resolution.ts"
+s = open(p).read()
+s = s.replace("  if (!detail || tagged.includes(detail)) return tagged;\n  return `${tagged} ${detail}`;",
+              "  return tagged;")
+open(p, "w").write(s)
+PY
+}
+
+m_the_guard_reads_the_derived_tag_as_free_text() {
+  py <<'PY'
+p = "src/change-resolution.ts"
+s = open(p).read()
+s = s.replace("    ? [resolutionTag(change.resolution), change.resolution.detail ?? \"\"].filter(Boolean)",
+              "    ? [change.resolution.detail ?? \"\"].filter(Boolean)")
+open(p, "w").write(s)
+PY
+}
+
+m_the_guard_reads_the_written_detail_as_free_text() {
+  py <<'PY'
+p = "src/change-resolution.ts"
+s = open(p).read()
+s = s.replace("    ? [resolutionTag(change.resolution), change.resolution.detail ?? \"\"].filter(Boolean)",
+              "    ? [resolutionTag(change.resolution)].filter(Boolean)")
+open(p, "w").write(s)
+PY
+}
+
+m_the_guard_strips_the_tag_from_a_record_that_has_no_resolution() {
+  py <<'PY'
+p = "src/change-resolution.ts"
+s = open(p).read()
+s = s.replace('''  const written = change.resolution
+    ? [resolutionTag(change.resolution), change.resolution.detail ?? ""].filter(Boolean)
+    : [];''',
+              '''  const written = RESOLUTION_STATES.map((state) =>
+    resolutionTag({ state, date: (change.resolution?.date ?? "2026-09-02") })
+  ).concat(change.resolution?.detail ?? "").filter(Boolean);''')
+open(p, "w").write(s)
+PY
+}
+
+m_a_retracted_claim_is_typed_back_into_a_page() {
+  py <<'PY'
+p = "src/serve.ts"
+s = open(p).read()
+s = s.replace('      hiddenCosts: "Credit-based pricing can pause sites on exhaustion.',
+              '      hiddenCosts: "Every repo committer is now charged as a full Pro seat ($19/mo) when using CMS/Identity with private repos. Credit-based pricing can pause sites on exhaustion.')
+open(p, "w").write(s)
+PY
+}
+
+run_mutation "the tag is appended instead of prefixed" m_the_tag_is_appended_instead_of_prefixed
+run_mutation "no tag is derived at all" m_no_tag_is_derived_at_all
+run_mutation "the tag fires only when no detail was written" m_the_tag_fires_only_when_no_detail_was_written
+run_mutation "both states derive the same tag" m_both_states_derive_the_same_tag
+run_mutation "the tag does not name its date" m_the_tag_does_not_name_its_date
+run_mutation "the tag is prefixed a second time on reload" m_the_tag_is_prefixed_a_second_time_on_reload
+run_mutation "the detail is prefixed ahead of the claim" m_the_detail_is_prefixed_ahead_of_the_claim
+run_mutation "the detail is dropped now that a tag exists" m_the_detail_is_dropped_now_that_a_tag_exists
+run_mutation "the guard reads the derived tag as free text" m_the_guard_reads_the_derived_tag_as_free_text
+run_mutation "the guard reads the written detail as free text" m_the_guard_reads_the_written_detail_as_free_text
+run_mutation "the guard strips a tag no resolution wrote" m_the_guard_strips_the_tag_from_a_record_that_has_no_resolution
+run_mutation "a retracted claim is typed back into a page" m_a_retracted_claim_is_typed_back_into_a_page
+
+echo
+echo "killed: $killed  survived: $survived"
+[ "$survived" -eq 0 ]

--- a/scripts/mutate-1282.sh
+++ b/scripts/mutate-1282.sh
@@ -70,8 +70,8 @@ m_the_summary_states_the_resolution_twice() {
   py <<'PY'
 p = "src/change-resolution.ts"
 s = open(p).read()
-s = s.replace('  return change.summary.includes(detail) ? change.summary : `${change.summary} ${detail}`;',
-              '  return `${change.summary} ${detail}`;')
+s = s.replace('  if (!detail || tagged.includes(detail)) return tagged;\n  return `${tagged} ${detail}`;',
+              '  return detail ? `${tagged} ${detail}` : tagged;')
 open(p, "w").write(s)
 PY
 }
@@ -130,9 +130,9 @@ m_the_detail_is_not_stripped_before_the_guard_reads_it() {
   py <<'PY'
 p = "src/change-resolution.ts"
 s = open(p).read()
-s = s.replace('''  const withoutDetail = (text: string | undefined) =>
-    detail && text ? text.split(detail).join(" ") : text;''',
-'''  const withoutDetail = (text: string | undefined) => text;''')
+s = s.replace('''  const withoutWhatTheFieldItselfWrote = (text: string | undefined) =>
+    text ? written.reduce((rest, piece) => rest.split(piece).join(" "), text) : text;''',
+'''  const withoutWhatTheFieldItselfWrote = (text: string | undefined) => text;''')
 open(p, "w").write(s)
 PY
 }

--- a/src/change-resolution.ts
+++ b/src/change-resolution.ts
@@ -37,10 +37,23 @@ export function resolvingRecord<T extends { vendor: string; date: string; change
   );
 }
 
+const RESOLUTION_TAGS: Record<ChangeResolutionState, (date: string) => string> = {
+  reversed: (date) => `No longer in force (${date}).`,
+  retracted: (date) => `Retracted — this record was our error (${date}).`,
+};
+
+export function resolutionTag(resolution: ChangeResolution): string {
+  return RESOLUTION_TAGS[resolution.state](resolution.date);
+}
+
 export function summaryWithResolution(change: ResolvableChange): string {
-  const detail = change.resolution?.detail;
-  if (!detail) return change.summary;
-  return change.summary.includes(detail) ? change.summary : `${change.summary} ${detail}`;
+  const resolution = change.resolution;
+  if (!resolution) return change.summary;
+  const tag = resolutionTag(resolution);
+  const detail = resolution.detail;
+  const tagged = change.summary.startsWith(tag) ? change.summary : `${tag} ${change.summary}`;
+  if (!detail || tagged.includes(detail)) return tagged;
+  return `${tagged} ${detail}`;
 }
 
 export function withResolutionInSummary<T extends ResolvableChange>(change: T): T {
@@ -63,12 +76,14 @@ export function prosePutsAResolutionIn(text: string | undefined | null): boolean
 }
 
 export function fieldsAssertingAResolution(change: ResolvableChange): string[] {
-  const detail = change.resolution?.detail ?? "";
-  const withoutDetail = (text: string | undefined) =>
-    detail && text ? text.split(detail).join(" ") : text;
+  const written = change.resolution
+    ? [resolutionTag(change.resolution), change.resolution.detail ?? ""].filter(Boolean)
+    : [];
+  const withoutWhatTheFieldItselfWrote = (text: string | undefined) =>
+    text ? written.reduce((rest, piece) => rest.split(piece).join(" "), text) : text;
   const fields: Array<[string, string | undefined]> = [
-    ["summary", withoutDetail(change.summary)],
-    ["current_state", withoutDetail(change.current_state)],
+    ["summary", withoutWhatTheFieldItselfWrote(change.summary)],
+    ["current_state", withoutWhatTheFieldItselfWrote(change.current_state)],
   ];
   return fields.filter(([, text]) => prosePutsAResolutionIn(text)).map(([name]) => name);
 }

--- a/src/serve.ts
+++ b/src/serve.ts
@@ -30357,7 +30357,7 @@ function buildHostingPricingPage(): string {
       freeType: "limited",
       monthlyCostSolo: "$0–19",
       monthlyCostTeam: "$19/seat",
-      hiddenCosts: "CRITICAL: Every repo committer is now charged as a full Pro seat ($19/mo) when using CMS/Identity with private repos (changed March 2026). Credit-based pricing can pause sites on exhaustion. 300 build minutes is tight for large sites. Bandwidth overage is $55/100 GB.",
+      hiddenCosts: "Credit-based pricing can pause sites on exhaustion. 300 build minutes is tight for large sites. Bandwidth overage is $55/100 GB.",
     },
     {
       name: "Deno Deploy",
@@ -44577,7 +44577,7 @@ ${mcpCtaCss()}
 
   <div class="diff-card">
     <h3><a href="/vendor/netlify">Netlify</a> &mdash; Credit-Based Free Tier</h3>
-    <div class="diff-desc"><strong>Free tier:</strong> 300 credits/month. Bandwidth costs 10 credits/GB (~30 GB), builds cost 15 credits each (~20 builds). Sites pause on credit exhaustion &mdash; no overages. Serverless functions at Level 0 (125K invocations). Legacy accounts (pre-Sep 2025) keep the old model: 100 GB bandwidth + 300 build minutes. <strong>Key limitation:</strong> The credit system is less predictable than flat limits. Heavy builders or bandwidth-intensive sites can exhaust credits quickly. Every repo committer is now charged as a Pro seat ($19/mo) when using Netlify CMS or Identity with private repos.</div>
+    <div class="diff-desc"><strong>Free tier:</strong> 300 credits/month. Bandwidth costs 10 credits/GB (~30 GB), builds cost 15 credits each (~20 builds). Sites pause on credit exhaustion &mdash; no overages. Serverless functions at Level 0 (125K invocations). Legacy accounts (pre-Sep 2025) keep the old model: 100 GB bandwidth + 300 build minutes. <strong>Key limitation:</strong> The credit system is less predictable than flat limits. Heavy builders or bandwidth-intensive sites can exhaust credits quickly.</div>
   </div>
 
   <div class="diff-card">

--- a/test/change-resolution.test.ts
+++ b/test/change-resolution.test.ts
@@ -11,6 +11,7 @@ import {
   fieldsAssertingAResolution,
   isNoLongerInForce,
   prosePutsAResolutionIn,
+  resolutionTag,
   resolvingRecord,
   summaryWithResolution,
   theEventNeverHappened,
@@ -56,8 +57,36 @@ describe("a record can say its change is no longer in force", () => {
   it("carries the resolution wherever the summary is read", () => {
     assert.strictEqual(
       summaryWithResolution(reversed()),
-      "The vendor paused new signups. Reversed: signups are open again."
+      "No longer in force (2026-09-02). The vendor paused new signups. Reversed: signups are open again."
     );
+  });
+
+  it("states the resolution before the claim, and the explanation after it", () => {
+    const served = summaryWithResolution(reversed());
+    const tag = resolutionTag(reversed().resolution!);
+    assert.ok(served.startsWith(tag), "the derived tag leads");
+    assert.ok(
+      served.indexOf("paused new signups") < served.indexOf("signups are open again"),
+      "the detail stays behind the claim it explains"
+    );
+  });
+
+  it("marks a record whose resolution carries no written detail", () => {
+    const bare = change({ resolution: { state: "retracted", date: "2026-09-02" } });
+    assert.strictEqual(
+      summaryWithResolution(bare),
+      "Retracted — this record was our error (2026-09-02). The vendor paused new signups."
+    );
+  });
+
+  it("derives a different tag for a change the vendor ended than for one we withdrew", () => {
+    assert.notStrictEqual(
+      resolutionTag({ state: "reversed", date: "2026-09-02" }),
+      resolutionTag({ state: "retracted", date: "2026-09-02" })
+    );
+    for (const state of RESOLUTION_STATES) {
+      assert.match(resolutionTag({ state, date: "2026-09-02" }), /2026-09-02/, `${state} names its date`);
+    }
   });
 
   it("leaves a record with no resolution exactly as stored", () => {
@@ -69,6 +98,8 @@ describe("a record can say its change is no longer in force", () => {
   it("does not state the resolution twice when the summary already carries it", () => {
     const once = withResolutionInSummary(reversed());
     assert.strictEqual(withResolutionInSummary(once).summary, once.summary);
+    const bare = withResolutionInSummary(change({ resolution: { state: "retracted", date: "2026-09-02" } }));
+    assert.strictEqual(withResolutionInSummary(bare).summary, bare.summary);
   });
 
   it("separates a change the vendor ended from a record we withdrew", () => {
@@ -78,6 +109,60 @@ describe("a record can say its change is no longer in force", () => {
       true
     );
     assert.strictEqual(isNoLongerInForce(change()), false);
+  });
+});
+
+describe("the resolution survives the render sites that cut the summary short", () => {
+  const serveSource = readFileSync(path.join(REPO, "src", "serve.ts"), "utf-8");
+  const cuts = [
+    ...serveSource.matchAll(/summary[^\n]{0,60}?\.(?:substring|slice)\(0,\s*(\d+)\)/g),
+  ].map((m) => Number(m[1]));
+  const resolvedRecords = stored.filter(isNoLongerInForce);
+
+  it("is measuring render sites that exist", () => {
+    assert.ok(cuts.length >= 20, `render sites truncating a summary: ${cuts.length}`);
+    assert.ok(resolvedRecords.length >= 3, `resolved records: ${resolvedRecords.length}`);
+  });
+
+  it("states the resolution inside the narrowest cut any render site makes", () => {
+    const narrowest = Math.min(...cuts);
+    for (const record of resolvedRecords) {
+      const shown = summaryWithResolution(record).slice(0, narrowest);
+      assert.ok(
+        shown.includes(resolutionTag(record.resolution!)),
+        `${record.vendor} ${record.date} cut at ${narrowest}: ${shown}`
+      );
+    }
+  });
+
+  it("leaves room for the claim itself after the tag", () => {
+    const narrowest = Math.min(...cuts);
+    for (const record of resolvedRecords) {
+      const tag = resolutionTag(record.resolution!);
+      assert.ok(
+        narrowest - tag.length >= 60,
+        `${record.vendor} ${record.date} leaves ${narrowest - tag.length} characters of claim`
+      );
+    }
+  });
+
+  it("reaches records a trailing sentence cannot", () => {
+    const widest = Math.max(...cuts);
+    const narrowest = Math.min(...cuts);
+    const beyondAnAppend = resolvedRecords.filter((c) => {
+      const detail = c.resolution!.detail;
+      return detail ? !`${c.summary} ${detail}`.slice(0, widest).includes(detail) : false;
+    });
+    assert.ok(
+      beyondAnAppend.length > 0,
+      `resolved records whose detail cannot reach the widest cut: ${beyondAnAppend.length}`
+    );
+    for (const record of beyondAnAppend) {
+      assert.ok(
+        summaryWithResolution(record).slice(0, narrowest).includes(resolutionTag(record.resolution!)),
+        `${record.vendor} ${record.date} is marked where its own detail could not reach`
+      );
+    }
   });
 });
 
@@ -140,6 +225,13 @@ describe("no record publishes a retraction the structured field does not hold", 
     assert.deepStrictEqual(fieldsAssertingAResolution(withResolutionInSummary(reversed())), []);
   });
 
+  it("does not count the derived tag as free text either", () => {
+    const bare = withResolutionInSummary(change({ resolution: { state: "retracted", date: "2026-09-02" } }));
+    assert.ok(prosePutsAResolutionIn(bare.summary), "the tag reads as a resolution");
+    assert.deepStrictEqual(fieldsAssertingAResolution(bare), []);
+    assert.deepStrictEqual(fieldsAssertingAResolution({ ...bare, resolution: null }), ["summary"]);
+  });
+
   it("holds across every stored change record", () => {
     const proseOnly = stored
       .filter((c) => !isNoLongerInForce(c) && fieldsAssertingAResolution(c).length > 0)
@@ -175,6 +267,22 @@ describe("no record publishes a retraction the structured field does not hold", 
       assert.strictEqual(resolver!.vendor, record.vendor);
       assert.ok(resolver!.date >= record.date, `${record.vendor} is resolved by a later record`);
     }
+  });
+
+  it("is not also typed into a page, where no resolution can follow it", () => {
+    const serveSource = readFileSync(path.join(REPO, "src", "serve.ts"), "utf-8");
+    const opening = (c: DealChange) => c.summary.slice(0, 40);
+    const typedIn = (records: DealChange[]) =>
+      records.filter((c) => opening(c).length >= 30 && serveSource.includes(opening(c)));
+
+    assert.deepStrictEqual(
+      typedIn(stored.filter(isNoLongerInForce)).map((c) => `${c.vendor} ${c.date}`),
+      []
+    );
+    assert.ok(
+      typedIn(stored.filter((c) => !isNoLongerInForce(c))).length > 0,
+      "change text does reach page copy, so the check above has something to find"
+    );
   });
 
   it("serves the resolution alongside the claim it withdraws", () => {


### PR DESCRIPTION
Refs #1282

`summaryWithResolution` appended the resolution. About 40 render sites cut the summary short, so the appended sentence was the one part guaranteed not to arrive. This prefixes a tag derived from `state` and `date`, and leaves `detail` where it was.

## The append could not have worked, measured rather than argued

30 sites in `serve.ts` truncate a summary: 18 at 117 characters, 9 at 137, one each at 120, 177 and 200. Against all five resolved records, at every one of those widths:

| record | served length | detail reaches a 117 cut | a 200 cut |
|---|---|---|---|
| Netlify 2026-03-01 | 391 | no | no |
| Cursor 2026-04-13 | 379 | no | no |
| GitHub Copilot 2026-04-10 | 321 | no | no |
| GitHub Copilot 2026-04-20 | 687 | no | no |
| Highlight.io 2026-08-28 | 280 | no | no |

Not "usually fails" — the detail is unreachable from the end of the string at every width any render site uses. A better-written sentence, or a derived one appended, would score exactly the same.

The tags are 32 and 51 characters, leaving 84 and 65 of the claim inside the narrowest cut:

```
No longer in force (2026-04-14). Every repo committer is now charged as a full Pro seat…
Retracted — this record was our error (2026-09-02). Cursor now offers 6 plans: Free, Hobby…
```

## What a reader gets

`/free-tier-tracker`, before and after — a 117-character cut, previously unmarked:

> **before** Netlify · Restricted · 2026-03-01 · Every repo committer is now charged as a full Pro seat ($19/mo) when using Netlify CMS or Identity with a private rep…
> **after** Netlify · Restricted · 2026-03-01 · No longer in force (2026-04-14). Every repo committer is now charged as a full Pro seat ($19/mo) when using Netlify C…

`/q2-pricing-preview-2026`, the retracted Cursor row:

> **before** Cursor now offers 6 plans: Free, Hobby ($10/mo), Pro ($20/mo)… Hobby tier added as lighter paid option between Free and Pro….
> **after** Retracted — this record was our error (2026-09-02). Cursor now offers 6 plans: Free, Hobby ($10/mo)…

## AC-5 census, re-run

Fetching all 2,571 paths in the five sitemaps and asking of each occurrence of a resolved record whether anything marks it:

| | occurrences | derived tag | structural marker | detail sentence | **nothing** |
|---|---|---|---|---|---|
| main | 103 | 0 | 34 | 90 | **13** |
| this branch | 101 | 101 | 34 | 90 | **0** |

The 13 unmarked on main are `/free-ai-stack`, `/free-devops-stack`, `/free-frontend-stack`, `/free-nextjs-stack`, `/free-startup-stack`, `/free-tier-tracker`, `/hosting-alternatives`, `/hosting-pricing`, `/hosting-free-tier-comparison-2026` and `/q2-pricing-preview-2026`. All truncation.

`scripts/census-1282-resolution-markers.mjs` is the instrument, so this is repeatable rather than a number in a comment.

## Two of them were not render sites at all

103 occurrences became 101 because two were hardcoded strings that never read a record:

- `serve.ts:30360` — `hiddenCosts: "CRITICAL: Every repo committer is now charged as a full Pro seat ($19/mo) when using CMS/Identity with private repos (changed March 2026). …"`, on `/hosting-pricing`. It was the only one of 91 `hiddenCosts` entries carrying a `CRITICAL:` prefix, and the prefix was attached to the retracted clause.
- `serve.ts:44580` — the same claim as page prose on `/hosting-free-tier-comparison-2026`.

No change to `summaryWithResolution` can reach either. Both retracted clauses are deleted; nothing was rewritten. A guard test now fails if any resolved record's summary opening appears as a literal in `serve.ts`, and it carries a non-vacuity check: 6 standing records' text *does* appear as page copy today, so the check has a populated class to search.

## Sweep

2,571 paths against a worktree of `main`:

```
status changed:                                        0
byte-identical:                                     2513
moved, every changed line carries the derived tag:    56
moved, also removing the hardcoded claim:              2
moved, anything else:                                  0
```

## Tests

3,326 tests, 9 new, 0 red. 12 mutations in `scripts/mutate-1282-prefix.sh`, 12 killed, no survivors, every kill from an assertion rather than from `tsc`. The two that matter: appending the tag instead of prefixing it, and firing the tag only when `detail` is blank — both die on the narrowest-cut test.

`scripts/mutate-1282.sh` had two targets that no longer existed after #1288 rewrote the lines they patched; both are repointed and it is back to 12/12 from 10/12.

The truncation test reads the cut widths out of `src/serve.ts` rather than hard-coding them, so a new render site that cuts below the tag length fails instead of silently publishing a bare tag.

## Reported, not fixed

- **`resolution.date` means two different things.** Netlify's `2026-04-14` is when the charge stopped; both GitHub Copilot records carry `2026-09-02`, which their own `detail` says is when we verified — *"verified 2026-09-02 against GitHub's plans documentation"*. We do not know when GitHub lifted the pause. The tag says `No longer in force (<date>)` rather than `reversed <date>` for exactly this reason: it is true under both readings. `eventResolutionFields` still publishes that date as JSON-LD `endDate`, which does assert an effective end, so the ambiguity is still live on `/vendor/github-copilot`.
- **`monthlyCostTeam: "$19/seat"`** sits two lines above the `hiddenCosts` string I edited, on the same Netlify entry. If the April 14 reversal means Pro no longer charges per seat, that figure is stale too — but changing a published price needs its own source, so I left it.
- **Two `detail` fields now open with a word the tag already said** — Highlight.io's and Cursor's both begin `Retracted <date>:`. Only visible where the summary is not truncated. Trimming them is a copy edit on stored data.
- **`/hosting-pricing` renders the 2026-03-01 record as "Feb 28, 2026"** — #1281, unrelated to this change.
