### PR TITLE
Draw the availability answer from the records, not the verdict (#1297)

### DIFF
--- a/scripts/census-1297-faq-absence-claims.mjs
+++ b/scripts/census-1297-faq-absence-claims.mjs
@@ -1,0 +1,107 @@
+import { readFileSync } from "node:fs";
+
+const BASE = process.argv[2] ?? "http://localhost:3000";
+const REPO = new URL("..", import.meta.url).pathname;
+
+const stored = JSON.parse(readFileSync(`${REPO}/data/deal_changes.json`, "utf-8")).changes;
+const { vendorSlugMap } = await import(`${REPO}/dist/vendor-slug.js`);
+const { CHANGE_DIRECTION } = await import(`${REPO}/dist/data.js`);
+const { CHANGE_KIND_NOUN } = await import(`${REPO}/dist/vendor-verdict.js`);
+
+const NAMED_BY_THE_OLD_SENTENCE = new Set(["free_tier_removed", "limits_reduced", "pricing_restructured"]);
+const DENIAL = /none of them a free tier removal, limit reduction or pricing restructure/;
+
+const held = new Map();
+for (const c of stored) {
+  const key = c.vendor.toLowerCase();
+  if (!held.has(key)) held.set(key, []);
+  held.get(key).push(c);
+}
+
+async function get(path) {
+  const res = await fetch(`${BASE}${path}`, { headers: { "user-agent": "curl/8.0" } });
+  return { status: res.status, body: await res.text() };
+}
+
+function availabilityAnswer(body) {
+  for (const [, json] of body.matchAll(/<script type="application\/ld\+json">([\s\S]*?)<\/script>/g)) {
+    let parsed;
+    try {
+      parsed = JSON.parse(json);
+    } catch {
+      continue;
+    }
+    if (parsed["@type"] !== "FAQPage") continue;
+    for (const entry of parsed.mainEntity ?? []) {
+      if (/free tier still available\?$/.test(entry.name)) return entry.acceptedAnswer?.text ?? "";
+    }
+  }
+  return null;
+}
+
+const slugs = [...vendorSlugMap.entries()];
+const rows = [];
+let queue = 0;
+const worker = async () => {
+  while (queue < slugs.length) {
+    const [slug, vendor] = slugs[queue++];
+    const { status, body } = await get(`/alternative-to/${slug}`);
+    if (status !== 200) {
+      rows.push({ slug, vendor, status, answer: null });
+      continue;
+    }
+    const records = held.get(vendor.toLowerCase()) ?? [];
+    rows.push({
+      slug,
+      vendor,
+      status,
+      answer: availabilityAnswer(body),
+      records: records.length,
+      negative: [...new Set(records.filter(c => CHANGE_DIRECTION[c.change_type] === "negative").map(c => c.change_type))],
+    });
+  }
+};
+await Promise.all(Array.from({ length: 12 }, worker));
+
+const published = rows.filter(r => r.answer !== null);
+const affirms = published.filter(r => /^Yes, /.test(r.answer));
+const withRecords = affirms.filter(r => r.records > 0);
+const withNegative = affirms.filter(r => r.negative.length > 0);
+
+const deniesNamed = withNegative.filter(r => DENIAL.test(r.answer) && r.negative.some(t => NAMED_BY_THE_OLD_SENTENCE.has(t)));
+const deniesAny = withNegative.filter(r => DENIAL.test(r.answer));
+const claimsNone = affirms.filter(r => /No pricing changes have been recorded\./.test(r.answer) && r.records > 0);
+const namesNarrowing = withNegative.filter(r => / narrowed the terms/.test(r.answer) && !/did not narrow|None of the/.test(r.answer));
+
+const NEGATION = /\b(?:none|no|not|zero|never|neither|nor)\b/i;
+const kindsCalledAbsent = (answer, kinds) => {
+  const called = [];
+  for (const sentence of answer.split(/(?<=[.!?])\s+/)) {
+    if (!NEGATION.test(sentence)) continue;
+    for (const kind of kinds) {
+      if (sentence.toLowerCase().includes(CHANGE_KIND_NOUN[kind])) called.push(kind);
+    }
+  }
+  return [...new Set(called)].sort();
+};
+const denialsForAHeldKind = published.filter(r => kindsCalledAbsent(r.answer, r.negative ?? []).length > 0);
+
+console.log(`vendor slugs:                                    ${rows.length}`);
+console.log(`  /alternative-to publishes the answer:          ${published.length}`);
+console.log(`  answer opens "Yes, ":                          ${affirms.length}`);
+console.log(`    of those, vendor holds >=1 record:           ${withRecords.length}`);
+console.log(`    of those, vendor holds >=1 negative record:  ${withNegative.length}`);
+console.log("");
+console.log(`DENIES one of the three named types it holds:     ${deniesNamed.length}`);
+console.log(`DENIES while holding any negative record:         ${deniesAny.length}`);
+console.log(`denies a kind it holds (derived from the nouns):  ${denialsForAHeldKind.length}`);
+console.log(`claims zero changes while holding some:           ${claimsNone.length}`);
+console.log(`names the narrowing record it holds:              ${namesNarrowing.length}`);
+console.log("");
+for (const r of deniesAny) console.log(`  DENIES  ${r.slug} — holds ${r.negative.join(", ")} (${r.records} records)`);
+for (const r of namesNarrowing) console.log(`  NAMES   ${r.slug} — holds ${r.negative.join(", ")} (${r.records} records)`);
+
+if (process.env.DUMP_ANSWERS) {
+  console.log("\n--- every answer over a vendor holding a record ---");
+  for (const r of withRecords) console.log(`${r.slug}\t${r.answer}`);
+}

--- a/scripts/mutate-1297.sh
+++ b/scripts/mutate-1297.sh
@@ -1,0 +1,191 @@
+#!/usr/bin/env bash
+set -u
+
+REPO="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$REPO" || exit 1
+
+FILES="src/serve.ts src/vendor-verdict.ts"
+BACKUP_DIR="$(mktemp -d)"
+for f in $FILES; do cp "$f" "$BACKUP_DIR/$(basename "$f")"; done
+
+restore() {
+  for f in $FILES; do cp "$BACKUP_DIR/$(basename "$f")" "$f"; done
+  npm run build > /dev/null 2>&1
+}
+trap restore EXIT
+
+killed=0
+survived=0
+TESTS="test/alternative-to-record-claims.test.ts test/vendor-verdict.test.ts"
+
+run_mutation() {
+  local name="$1"
+  shift
+  echo "=== $name"
+  for f in $FILES; do cp "$BACKUP_DIR/$(basename "$f")" "$f"; done
+  "$@"
+  local changed=0
+  for f in $FILES; do
+    diff -q "$BACKUP_DIR/$(basename "$f")" "$f" > /dev/null || changed=1
+  done
+  if [ "$changed" -eq 0 ]; then
+    echo "    NOT APPLIED: the mutation changed no file, so it proves nothing"
+    survived=$((survived + 1))
+    return
+  fi
+  if ! npm run build > /tmp/mutate-1297-build.log 2>&1; then
+    echo "    KILLED: the mutation does not typecheck"
+    killed=$((killed + 1))
+    return
+  fi
+  if timeout 900 node --test --test-concurrency 1 $TESTS > /tmp/mutate-1297-test.log 2>&1; then
+    echo "    SURVIVED"
+    survived=$((survived + 1))
+  else
+    echo "    KILLED: $(grep -c '✖ ' /tmp/mutate-1297-test.log) failing assertion(s)"
+    grep '✖ ' /tmp/mutate-1297-test.log | head -4
+    killed=$((killed + 1))
+  fi
+}
+
+py() {
+  python3 - "$@"
+}
+
+ANSWER='vendorChanges.length === 0 ? "No pricing changes have been recorded." : narrowingSentence(vendorChanges)'
+
+m_the_answer_is_derived_from_the_verdict_again() {
+  py <<PY
+p = "src/serve.ts"
+s = open(p).read()
+s = s.replace('''$ANSWER''',
+              '''vendorChanges.length === 0 ? "No pricing changes have been recorded." : \`We hold \${vendorChanges.length === 1 ? "1 recorded change" : \`\${vendorChanges.length} recorded changes\`} for this vendor, none of them a free tier removal, limit reduction or pricing restructure.\`''')
+open(p, "w").write(s)
+PY
+}
+
+m_the_answer_says_nothing_about_the_records() {
+  py <<PY
+p = "src/serve.ts"
+s = open(p).read()
+s = s.replace('''\${$ANSWER}''', '''''')
+open(p, "w").write(s)
+PY
+}
+
+m_the_answer_reads_an_empty_record_set() {
+  py <<PY
+p = "src/serve.ts"
+s = open(p).read()
+s = s.replace('''$ANSWER''',
+              '''vendorChanges.length === 0 ? "No pricing changes have been recorded." : narrowingSentence([])''')
+open(p, "w").write(s)
+PY
+}
+
+m_the_answer_reads_the_history_sentence_instead() {
+  py <<PY
+p = "src/serve.ts"
+s = open(p).read()
+s = s.replace('''$ANSWER''',
+              '''vendorChanges.length === 0 ? "No pricing changes have been recorded." : vendorHistorySentence(vendorName, riskLevel, riskCause)''')
+open(p, "w").write(s)
+PY
+}
+
+m_the_empty_history_branch_is_inverted() {
+  py <<PY
+p = "src/serve.ts"
+s = open(p).read()
+s = s.replace('''$ANSWER''',
+              '''vendorChanges.length > 0 ? "No pricing changes have been recorded." : narrowingSentence(vendorChanges)''')
+open(p, "w").write(s)
+PY
+}
+
+m_a_single_record_gets_no_sentence() {
+  py <<PY
+p = "src/serve.ts"
+s = open(p).read()
+s = s.replace('''$ANSWER''',
+              '''vendorChanges.length < 2 ? "No pricing changes have been recorded." : narrowingSentence(vendorChanges)''')
+open(p, "w").write(s)
+PY
+}
+
+m_only_the_newest_record_is_read() {
+  py <<PY
+p = "src/serve.ts"
+s = open(p).read()
+s = s.replace('''$ANSWER''',
+              '''vendorChanges.length === 0 ? "No pricing changes have been recorded." : narrowingSentence(vendorChanges.slice(0, 1))''')
+open(p, "w").write(s)
+PY
+}
+
+m_a_withdrawn_record_narrows_again() {
+  py <<'PY'
+p = "src/vendor-verdict.ts"
+s = open(p).read()
+s = s.replace('    .filter(c => CHANGE_DIRECTION[c.change_type] === "negative" && !isNoLongerInForce(c))',
+              '    .filter(c => CHANGE_DIRECTION[c.change_type] === "negative")')
+open(p, "w").write(s)
+PY
+}
+
+m_a_favourable_record_narrows() {
+  py <<'PY'
+p = "src/vendor-verdict.ts"
+s = open(p).read()
+s = s.replace('    .filter(c => CHANGE_DIRECTION[c.change_type] === "negative" && !isNoLongerInForce(c))',
+              '    .filter(c => CHANGE_DIRECTION[c.change_type] !== "negative" && !isNoLongerInForce(c))')
+open(p, "w").write(s)
+PY
+}
+
+m_the_sentence_is_always_empty() {
+  py <<'PY'
+p = "src/vendor-verdict.ts"
+s = open(p).read()
+s = s.replace('export function narrowingSentence(changes: VendorVerdictInput["changes"]): string {',
+              'export function narrowingSentence(changes: VendorVerdictInput["changes"]): string {\n  if (changes.length >= 0) return "";')
+open(p, "w").write(s)
+PY
+}
+
+m_nothing_ever_narrowed() {
+  py <<'PY'
+p = "src/vendor-verdict.ts"
+s = open(p).read()
+s = s.replace('  const narrowing = narrowingChanges(byTheVendor);',
+              '  const narrowing: VendorVerdictInput["changes"] = [];')
+open(p, "w").write(s)
+PY
+}
+
+m_a_correction_counts_as_a_change_the_vendor_made() {
+  py <<'PY'
+p = "src/vendor-verdict.ts"
+s = open(p).read()
+s = s.replace('  const byTheVendor = changes.filter(c => !isACorrectionToOurOwnRecord(c));',
+              '  const byTheVendor = changes;')
+open(p, "w").write(s)
+PY
+}
+
+run_mutation "the answer is derived from the verdict again" m_the_answer_is_derived_from_the_verdict_again
+run_mutation "the answer says nothing about the records" m_the_answer_says_nothing_about_the_records
+run_mutation "the answer reads an empty record set" m_the_answer_reads_an_empty_record_set
+run_mutation "the answer reads the history sentence instead" m_the_answer_reads_the_history_sentence_instead
+run_mutation "the empty-history branch is inverted" m_the_empty_history_branch_is_inverted
+run_mutation "a single record gets no sentence" m_a_single_record_gets_no_sentence
+run_mutation "only the newest record is read" m_only_the_newest_record_is_read
+run_mutation "a withdrawn record narrows again" m_a_withdrawn_record_narrows_again
+run_mutation "a favourable record narrows" m_a_favourable_record_narrows
+run_mutation "the sentence is always empty" m_the_sentence_is_always_empty
+run_mutation "nothing ever narrowed" m_nothing_ever_narrowed
+run_mutation "a correction counts as a change the vendor made" m_a_correction_counts_as_a_change_the_vendor_made
+
+echo
+echo "killed: $killed  survived: $survived"
+[ "$survived" -eq 0 ]

--- a/src/serve.ts
+++ b/src/serve.ts
@@ -4583,7 +4583,7 @@ ${renderAuditBlock(altRanking.tie_break)}
   const faqFreeTierAnswer = altLevelWithheld
     ? `We cannot confirm that today. ${altWithheldSentence} Our stored record says ${vendorName} offers a free tier (${primary.tier}), but we have not confirmed those terms against the source we cite.`
     : riskLevel === "stable"
-    ? `Yes, ${vendorName} currently offers a free tier (${primary.tier}). ${vendorChanges.length === 0 ? "No pricing changes have been recorded." : `We hold ${vendorChanges.length === 1 ? "1 recorded change" : `${vendorChanges.length} recorded changes`} for this vendor, none of them a free tier removal, limit reduction or pricing restructure.`}`
+    ? `Yes, ${vendorName} currently offers a free tier (${primary.tier}). ${vendorChanges.length === 0 ? "No pricing changes have been recorded." : narrowingSentence(vendorChanges)}`
     : riskLevel === "caution"
     ? `${vendorName} has a free tier (${primary.tier}), but it's flagged as "caution" because of one specific recorded change${riskCause ? `, ${changeDateClause(riskCause)}: ${riskCause.summary}` : "."}`
     : `${vendorName}'s free tier (${primary.tier}) is considered risky because of one specific recorded change${riskCause ? `, ${changeDateClause(riskCause)}: ${riskCause.summary}` : "."} Consider migrating to a more stable alternative.`;

--- a/test/alternative-to-record-claims.test.ts
+++ b/test/alternative-to-record-claims.test.ts
@@ -1,0 +1,194 @@
+import { describe, it, before, after } from "node:test";
+import assert from "node:assert";
+import { spawn, type ChildProcess } from "node:child_process";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { CHANGE_DIRECTION, loadDealChanges } from "../dist/data.js";
+import { CHANGE_KIND_NOUN, narrowingSentence } from "../dist/vendor-verdict.js";
+import { isNoLongerInForce } from "../dist/change-resolution.js";
+import { vendorSlugMap } from "../dist/vendor-slug.js";
+import type { DealChange } from "../src/types.ts";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO = path.join(__dirname, "..");
+
+const AVAILABILITY_QUESTION = /free tier still available\?$/;
+const NEGATION = /\b(?:none|no|not|zero|never|neither|nor)\b/i;
+const SENTENCE_BREAK = /(?<=[.!?])\s+/;
+
+function heldBy(vendor: string, changes: DealChange[]): DealChange[] {
+  return changes.filter(c => c.vendor.toLowerCase() === vendor.toLowerCase());
+}
+
+function negativeKinds(records: DealChange[]): string[] {
+  return [...new Set(records.filter(c => CHANGE_DIRECTION[c.change_type] === "negative").map(c => c.change_type))];
+}
+
+function stillNarrowing(records: DealChange[]): DealChange[] {
+  return records.filter(c => CHANGE_DIRECTION[c.change_type] === "negative" && !isNoLongerInForce(c));
+}
+
+function kindsCalledAbsent(answer: string, kinds: string[]): string[] {
+  const called: string[] = [];
+  for (const sentence of answer.split(SENTENCE_BREAK)) {
+    if (!NEGATION.test(sentence)) continue;
+    for (const kind of kinds) {
+      const noun = CHANGE_KIND_NOUN[kind as DealChange["change_type"]];
+      if (noun && sentence.toLowerCase().includes(noun)) called.push(kind);
+    }
+  }
+  return [...new Set(called)].sort();
+}
+
+function availabilityAnswer(body: string): string | null {
+  for (const [, json] of body.matchAll(/<script type="application\/ld\+json">([\s\S]*?)<\/script>/g)) {
+    let parsed: { "@type"?: string; mainEntity?: Array<{ name: string; acceptedAnswer?: { text?: string } }> };
+    try {
+      parsed = JSON.parse(json);
+    } catch {
+      continue;
+    }
+    if (parsed["@type"] !== "FAQPage") continue;
+    for (const entry of parsed.mainEntity ?? []) {
+      if (AVAILABILITY_QUESTION.test(entry.name)) return entry.acceptedAnswer?.text ?? "";
+    }
+  }
+  return null;
+}
+
+describe("#1297 the answer about our records reads the records", () => {
+  let port = 0;
+  let proc: ChildProcess | null = null;
+  const answers = new Map<string, string>();
+  const changes = loadDealChanges();
+  const holders = [...vendorSlugMap.entries()].filter(([, vendor]) => heldBy(vendor, changes).length > 0);
+
+  before(async () => {
+    const started = await new Promise<{ child: ChildProcess; port: number }>((resolve, reject) => {
+      const child = spawn("node", [path.join(REPO, "dist", "serve.js")], {
+        cwd: REPO,
+        stdio: ["ignore", "ignore", "pipe"],
+        env: { ...process.env, PORT: "0", BASE_URL: "http://localhost" },
+      });
+      const timeout = setTimeout(() => { child.kill(); reject(new Error("Server startup timeout")); }, 30000);
+      child.stderr!.on("data", (data: Buffer) => {
+        const m = data.toString().match(/running on http:\/\/localhost:(\d+)/);
+        if (m) { clearTimeout(timeout); resolve({ child, port: parseInt(m[1], 10) }); }
+      });
+      child.on("error", (err) => { clearTimeout(timeout); reject(err); });
+    });
+    proc = started.child;
+    port = started.port;
+
+    let queue = 0;
+    const worker = async () => {
+      while (queue < holders.length) {
+        const [slug] = holders[queue++];
+        const res = await fetch(`http://localhost:${port}/alternative-to/${slug}`);
+        if (res.status !== 200) continue;
+        const answer = availabilityAnswer(await res.text());
+        if (answer !== null) answers.set(slug, answer);
+      }
+    };
+    await Promise.all(Array.from({ length: 12 }, worker));
+  });
+
+  after(() => { if (proc) proc.kill(); });
+
+  it("calls no kind of change absent from a vendor that holds one", () => {
+    const wrong: string[] = [];
+    let checked = 0;
+    for (const [slug, vendor] of holders) {
+      const answer = answers.get(slug);
+      if (answer === undefined) continue;
+      const kinds = negativeKinds(heldBy(vendor, changes));
+      if (kinds.length === 0) continue;
+      checked++;
+      const absent = kindsCalledAbsent(answer, kinds);
+      if (absent.length > 0) wrong.push(`/alternative-to/${slug} calls ${absent.join(", ")} absent and holds it`);
+    }
+    assert.ok(checked > 0, "no published answer belongs to a vendor holding a negative record, so this asserts nothing");
+    assert.deepStrictEqual(wrong.slice(0, 20), [], `answers denying a kind the vendor holds:\n${wrong.slice(0, 20).join("\n")}`);
+  });
+
+  it("still says something about the records where none of them narrowed the terms", () => {
+    const silent: string[] = [];
+    let checked = 0;
+    for (const [slug, vendor] of holders) {
+      const answer = answers.get(slug);
+      if (answer === undefined || !answer.startsWith("Yes, ")) continue;
+      if (negativeKinds(heldBy(vendor, changes)).length > 0) continue;
+      checked++;
+      const beyondTheTier = answer.split(SENTENCE_BREAK).slice(1).join(" ").trim();
+      if (beyondTheTier === "") silent.push(`/alternative-to/${slug}`);
+    }
+    assert.ok(checked > 0, "no published answer belongs to a vendor whose records are all non-negative");
+    assert.deepStrictEqual(silent, [], `answers that hold records and describe none of them:\n${silent.join("\n")}`);
+  });
+
+  it("accounts for every narrowing record the vendor holds, by kind or by count", () => {
+    const unaccounted: string[] = [];
+    let named = 0;
+    let counted = 0;
+    for (const [slug, vendor] of holders) {
+      const answer = answers.get(slug);
+      if (answer === undefined || !answer.startsWith("Yes, ")) continue;
+      const narrowing = stillNarrowing(heldBy(vendor, changes));
+      if (narrowing.length === 0) continue;
+      if (narrowing.length === 1) {
+        named++;
+        const noun = CHANGE_KIND_NOUN[narrowing[0].change_type];
+        if (!answer.toLowerCase().includes(noun)) unaccounted.push(`/alternative-to/${slug} holds a ${noun} and names no kind`);
+        continue;
+      }
+      counted++;
+      if (!new RegExp(`\\b${narrowing.length}\\b`).test(answer)) {
+        unaccounted.push(`/alternative-to/${slug} holds ${narrowing.length} and states no such count`);
+      }
+    }
+    assert.ok(named > 0, "no published answer belongs to a vendor holding exactly one narrowing record");
+    assert.ok(counted > 0, "no published answer belongs to a vendor holding more than one narrowing record");
+    assert.deepStrictEqual(unaccounted.slice(0, 20), [], `answers that account for no record they hold:\n${unaccounted.slice(0, 20).join("\n")}`);
+  });
+
+  it("tells no vendor that holds a record that we hold none", () => {
+    const wrong: string[] = [];
+    let checked = 0;
+    for (const [slug, vendor] of holders) {
+      const answer = answers.get(slug);
+      if (answer === undefined) continue;
+      checked++;
+      if (/No pricing changes have been recorded|no recorded pricing changes|zero pricing changes/i.test(answer)) {
+        wrong.push(`/alternative-to/${slug} holds ${heldBy(vendor, changes).length} and publishes an empty history`);
+      }
+    }
+    assert.ok(checked > 0, "no published answer belongs to a vendor holding any record");
+    assert.deepStrictEqual(wrong.slice(0, 20), [], `answers publishing an empty history over records:\n${wrong.slice(0, 20).join("\n")}`);
+  });
+
+  it("reads a denial of a held kind as a denial, and the record-derived sentence as none", () => {
+    const denial =
+      "Yes, Neon currently offers a free tier (Free). We hold 1 recorded change for this vendor, " +
+      "none of them a free tier removal, limit reduction or pricing restructure.";
+    assert.deepStrictEqual(
+      kindsCalledAbsent(denial, ["pricing_restructured", "limits_reduced", "free_tier_removed"]),
+      ["free_tier_removed", "limits_reduced", "pricing_restructured"],
+      "the rule reports no denial in a sentence that denies three kinds by name",
+    );
+    assert.deepStrictEqual(
+      kindsCalledAbsent(denial, ["product_deprecated"]),
+      [],
+      "the rule reports a denial of a kind the sentence does not name",
+    );
+
+    const derived = `Yes, Neon currently offers a free tier (Free). ${narrowingSentence([
+      { vendor: "Neon", change_type: "pricing_restructured", date: "2026-01-15", date_source: "announced" },
+    ] as DealChange[])}`;
+    assert.match(derived, /pricing restructure narrowed the terms/);
+    assert.deepStrictEqual(
+      kindsCalledAbsent(derived, ["pricing_restructured"]),
+      [],
+      "the rule reports a denial in a sentence that names the record as held",
+    );
+  });
+});


### PR DESCRIPTION
Refs #1297

`/alternative-to/*` answered *"Is X's free tier still available?"* by branching on `riskLevel` and then stating a conclusion about our own records. `/vendor/*` answers the same question about the same records by calling `narrowingSentence`, which reads them. This call site was the outlier, and it is now one expression.

```diff
-`We hold ${n} recorded changes for this vendor, none of them a free tier removal, limit reduction or pricing restructure.`
+narrowingSentence(vendorChanges)
```

## Measured over every vendor slug, both sides, same instrument

`scripts/census-1297-faq-absence-claims.mjs`, run against a `main` worktree and against this branch:

| | main | branch |
|---|---|---|
| slugs whose `/alternative-to` publishes the answer | 226 | 226 |
| of those, the answer affirms a free tier | 114 | 114 |
| of those, the vendor holds ≥1 record | 24 | 24 |
| of those, the vendor holds ≥1 **negative** record | 11 | 11 |
| **denies a kind the vendor holds** | **11** | **0** |
| names the narrowing record it holds | 0 | 11 |

10 of the 11 deny by name; MiniMax is the eleventh and is different — see AC-5 below.

## Why the type list could never have tracked the records

"Stable while holding a negative record" is reachable by more than one route, and the sentence named a fixed subset of one of them:

| route | records among the 11 |
|---|---|
| `verdictHasLapsed` expired an event verdict at 180 days | 11 |
| `demotionForChange` declines to act on the record's type | 8 |
| `isNoLongerInForce` — a resolution withdrew it | 0 today, opened by #1295 |

AWS holds both routes at once (1 lapsed, 6 declined); Firebase holds one of each; MiniMax holds only a declined one and no lapsed record at all, so it is not an expiry case. `narrowingChanges` is route-agnostic — it filters on direction and on withdrawal — so a fourth route cannot reopen this.

## Acceptance criteria

1. **No page states we hold no record of a type we hold.** 11 → 0, table above.
2. **The 62 where the sentence was true still say something.** 13 of the 24 hold only non-narrowing records and now read *"None of the N recorded changes narrowed the terms."* or *"The one change we have recorded did not narrow the terms."* A test asserts every such answer carries a sentence beyond the tier clause.
3. **Consistent with the same vendor's `/vendor/*` history.** Both pages now call the same function. Verified page-by-page on the 11.
4. **Distinguishes absence from expiry.** The answer no longer asserts absence; it names the record and its date. It does not yet *name* the expiry — the issue says naming it is optional, and the wording for that is the PM's call, not mine. Flagged below.
5. **MiniMax.** The claim is now about **negative records generally**, not the three named types. Its `product_deprecated` was the one case where the old sentence was literally true and still read as reassurance; it now reads *"One recorded product deprecation narrowed the terms, on 2026-08-20."* Enumerating type names in prose is what made this a bug — the list was a hand-copied subset of `CHANGE_DIRECTION` and drifted from it.
6. **A guard, with its population asserted non-empty.** `test/alternative-to-record-claims.test.ts`, 5 tests. Against a `main` worktree it goes red on 2 of them, naming exactly the 10 deniers and MiniMax separately. A fifth test feeds the old sentence to the detection rule and asserts it reports all three denied kinds, and feeds the new one and asserts it reports none — so the guard cannot pass by failing to detect.

## Verification

- **3,331 tests, 5 new, 5 failing.** The same 5 fail on a `main` worktree at the same commit with the same messages — Railway's re-anchor, the stale-fact budget at 59 against a baseline of 57, jsDelivr's evidence detail, and two search-recording fixtures. They arrived with `e34b09c` (rolling re-verification, 10:46Z); `main`'s last Tests run was `a69655c` at 09:42Z and was green. Nothing here touches them; details on #1190.
- **12 mutations, 12 killed, 0 survivors, none killed by `tsc`** — `scripts/mutate-1297.sh`. Includes reverting to the old sentence, swapping in the verdict-derived `vendorHistorySentence`, inverting the empty-history branch, reading only the newest record, and four mutations of `narrowingChanges`/`narrowingSentence`.
- **Sweep of 2,577 sitemap paths against a `main` worktree:** 2,553 byte-identical, **24 moved, 0 status changes**. Every changed line on all 24 is inside the availability answer. The 24 are exactly the vendors holding a record whose page publishes it.
- Rendered HTML and the `FAQPage` JSON-LD checked on both sides for `/alternative-to/{neon,docker-hub,minimax,aws}`, and screenshotted.

## Reported, not fixed

- **`narrowingChanges` counts records `demotionForChange` explicitly declines to act on** — 64 records across 58 vendors. `/vendor/aws` already publishes *"7 recorded changes narrowed the terms"* where 6 are deprecations of other AWS products the risk scale deliberately ignores. Pre-existing and shared; this change makes `/alternative-to/aws` agree with it rather than introducing it. Fixing it moves `/vendor/*` too, so it is wider than this issue.
- **Naming the expiry** (AC-4's optional half) needs a sentence I would have to write. Left for the PM.
- **The population moves daily.** Supabase was one of the 11 in the issue body and is not one now — a new `pricing_restructured` dated today put it inside the 180-day window, so it reads `caution`. The guard is what holds, not the count.
