### PR TITLE
Name ourselves, a page and a check date in every product response (#1256)

### DIFF
--- a/scripts/census-1256-provenance.mjs
+++ b/scripts/census-1256-provenance.mjs
@@ -1,0 +1,140 @@
+import { spawn } from "node:child_process";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const REPO = path.join(path.dirname(fileURLToPath(import.meta.url)), "..");
+
+function startServer() {
+  return new Promise((resolve, reject) => {
+    const proc = spawn("node", [path.join(REPO, "dist", "serve.js")], {
+      cwd: REPO,
+      stdio: ["pipe", "pipe", "pipe"],
+      env: { ...process.env, PORT: "0", BASE_URL: process.env.CENSUS_BASE_URL ?? "https://agentdeals.dev" },
+    });
+    const timeout = setTimeout(() => { proc.kill("SIGKILL"); reject(new Error("startup timeout")); }, 60000);
+    proc.stderr.on("data", (b) => {
+      const m = b.toString().match(/running on http:\/\/localhost:(\d+)/);
+      if (m) { clearTimeout(timeout); resolve({ proc, port: parseInt(m[1], 10) }); }
+    });
+    proc.on("error", (e) => { clearTimeout(timeout); reject(e); });
+  });
+}
+
+async function mcpSession(base) {
+  const init = await fetch(`${base}/mcp`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json", Accept: "application/json, text/event-stream" },
+    body: JSON.stringify({
+      jsonrpc: "2.0", id: 1, method: "initialize",
+      params: { protocolVersion: "2025-06-18", capabilities: {}, clientInfo: { name: "census", version: "1.0.0" } },
+    }),
+  });
+  const sessionId = init.headers.get("mcp-session-id");
+  await fetch(`${base}/mcp`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json", Accept: "application/json, text/event-stream", "Mcp-Session-Id": sessionId },
+    body: JSON.stringify({ jsonrpc: "2.0", method: "notifications/initialized" }),
+  });
+  let id = 10;
+  return {
+    ok: init.status === 200 && !!sessionId,
+    async call(name, args) {
+      const res = await fetch(`${base}/mcp`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json", Accept: "application/json, text/event-stream", "Mcp-Session-Id": sessionId },
+        body: JSON.stringify({ jsonrpc: "2.0", id: ++id, method: "tools/call", params: { name, arguments: args } }),
+      });
+      const text = await res.text();
+      const line = text.split("\n").find((l) => l.startsWith("data: ")) ?? text;
+      const payload = JSON.parse(line.replace(/^data: /, ""));
+      const items = payload?.result?.content ?? [];
+      const whole = items.map((c) => c.text ?? "").join("\n");
+      let first = null;
+      try { first = JSON.parse(items[0]?.text ?? ""); } catch { first = null; }
+      return { text: whole, json: first };
+    },
+  };
+}
+
+const TOOL_CALLS = [
+  ["search_deals", {}],
+  ["search_deals", { vendor: "supabase" }],
+  ["track_changes", {}],
+  ["compare_vendors", { vendors: ["Supabase", "Neon"] }],
+  ["compare_vendors", { vendors: ["Supabase"] }],
+  ["plan_stack", { mode: "recommend", use_case: "Next.js SaaS app" }],
+  ["plan_stack", { mode: "estimate", services: ["Vercel"] }],
+];
+
+const HTTP_PATHS = [
+  "/api/changes?limit=2",
+  "/api/offers?limit=20",
+  "/api/details/supabase",
+  "/api/categories",
+  "/api/newest?limit=10",
+  "/api/new?days=7",
+  "/api/stack?use_case=Next.js+SaaS+app",
+  "/api/costs?services=Vercel",
+  "/api/audit-stack?services=Vercel",
+  "/api/compare?a=Supabase&b=Neon",
+  "/api/vendor-risk/supabase",
+  "/api/expiring?within_days=30",
+  "/api/digest",
+];
+
+const { proc, port } = await startServer();
+const base = `http://127.0.0.1:${port}`;
+const rows = [];
+
+try {
+  const session = await mcpSession(base);
+  if (!session.ok) throw new Error("mcp initialize failed");
+
+  for (const [name, args] of TOOL_CALLS) {
+    const { text, json } = await session.call(name, args);
+    const label = Object.keys(args).length === 0 ? name : `${name}(${Object.values(args).flat().join(",")})`;
+    rows.push({
+      surface: label,
+      chars: text.length,
+      mentions: (text.match(/agentdeals/gi) ?? []).length,
+      has_provenance_key: json !== null && Object.prototype.hasOwnProperty.call(json, "_provenance"),
+      cite_as: json?._provenance?.cite_as ?? null,
+      verified: json?._provenance?.verified ?? null,
+      deference_count: (text.match(/This is a request from the site/g) ?? []).length,
+    });
+  }
+
+  for (const p of HTTP_PATHS) {
+    const res = await fetch(`${base}${p}`);
+    const text = await res.text();
+    let json = null;
+    try { json = JSON.parse(text); } catch { json = null; }
+    rows.push({
+      surface: p,
+      chars: text.length,
+      mentions: (text.match(/agentdeals/gi) ?? []).length,
+      has_provenance_key: json !== null && Object.prototype.hasOwnProperty.call(json, "_provenance"),
+      cite_as: json?._provenance?.cite_as ?? null,
+      verified: json?._provenance?.verified ?? null,
+      deference_count: (text.match(/This is a request from the site/g) ?? []).length,
+    });
+  }
+  const paths = [...new Set(rows.map((r) => r.cite_as).filter(Boolean).map((c) => {
+    const m = c.match(/\((https?:\/\/[^,)]+)/);
+    return m ? new URL(m[1]).pathname : null;
+  }).filter(Boolean))];
+  for (const p of paths) {
+    const res = await fetch(`${base}${p}`, { redirect: "manual" });
+    rows.push({ surface: `cited path ${p}`, chars: 0, mentions: 0, has_provenance_key: res.status === 200, cite_as: null, verified: null, deference_count: res.status });
+  }
+} finally {
+  proc.kill("SIGKILL");
+}
+
+console.log(JSON.stringify(rows, null, 2));
+const pad = (s, n) => String(s).padEnd(n);
+console.log("");
+console.log(`${pad("surface", 26)} ${pad("chars", 9)} ${pad("names us", 9)} ${pad("_provenance", 12)} deference`);
+for (const r of rows) {
+  console.log(`${pad(r.surface, 26)} ${pad(r.chars, 9)} ${pad(r.mentions, 9)} ${pad(r.has_provenance_key, 12)} ${r.deference_count}`);
+}

--- a/scripts/mutate-1256.sh
+++ b/scripts/mutate-1256.sh
@@ -1,0 +1,303 @@
+#!/usr/bin/env bash
+set -u
+
+REPO="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$REPO" || exit 1
+
+FILES="src/provenance.ts src/server.ts src/serve.ts src/server-remote.ts src/data.ts"
+BACKUP_DIR="$(mktemp -d)"
+for f in $FILES; do cp "$f" "$BACKUP_DIR/$(basename "$f")"; done
+
+restore() {
+  for f in $FILES; do cp "$BACKUP_DIR/$(basename "$f")" "$f"; done
+  npm run build > /dev/null 2>&1
+}
+trap restore EXIT
+
+killed=0
+survived=0
+TESTS="test/response-provenance.test.ts test/served-response-citation.test.ts"
+
+run_mutation() {
+  local name="$1"
+  shift
+  echo "=== $name"
+  for f in $FILES; do cp "$BACKUP_DIR/$(basename "$f")" "$f"; done
+  "$@"
+  local changed=0
+  for f in $FILES; do
+    diff -q "$BACKUP_DIR/$(basename "$f")" "$f" > /dev/null || changed=1
+  done
+  if [ "$changed" -eq 0 ]; then
+    echo "    NOT APPLIED: the mutation changed no file, so it proves nothing"
+    survived=$((survived + 1))
+    return
+  fi
+  if ! npm run build > /tmp/mutate-1256-build.log 2>&1; then
+    echo "    KILLED BY TSC ONLY: rewrite it to typecheck"
+    killed=$((killed + 1))
+    return
+  fi
+  if timeout 900 node --test --test-concurrency 1 $TESTS > /tmp/mutate-1256-test.log 2>&1; then
+    echo "    SURVIVED"
+    survived=$((survived + 1))
+  else
+    echo "    KILLED: $(grep -c '✖ ' /tmp/mutate-1256-test.log) failing assertion(s)"
+    grep '  ✖ ' /tmp/mutate-1256-test.log | head -3
+    killed=$((killed + 1))
+  fi
+}
+
+py() {
+  python3 - "$@"
+}
+
+m_the_newest_date_stands_in_for_the_oldest() {
+  py <<'PY'
+p = "src/provenance.ts"
+s = open(p).read()
+s = s.replace('.filter((d): d is string => d !== null).sort();',
+              '.filter((d): d is string => d !== null).sort().reverse();')
+open(p, "w").write(s)
+PY
+}
+
+m_the_response_time_stands_in_for_the_record_date() {
+  py <<'PY'
+p = "src/provenance.ts"
+s = open(p).read()
+s = s.replace('  const date = oldestDate(dated);',
+              '  const date = new Date().toISOString().slice(0, 10);')
+open(p, "w").write(s)
+PY
+}
+
+m_a_set_is_dated_as_though_it_were_one_record() {
+  py <<'PY'
+p = "src/provenance.ts"
+s = open(p).read()
+s = s.replace('const clause = single ? `checked ${date}` : `oldest figure checked ${date}`;',
+              'const clause = `checked ${date}`;')
+open(p, "w").write(s)
+PY
+}
+
+m_one_record_is_dated_as_though_it_were_a_set() {
+  py <<'PY'
+p = "src/provenance.ts"
+s = open(p).read()
+s = s.replace('const clause = single ? `checked ${date}` : `oldest figure checked ${date}`;',
+              'const clause = `oldest figure checked ${date}`;')
+open(p, "w").write(s)
+PY
+}
+
+m_the_vendor_page_is_never_narrow_enough() {
+  py <<'PY'
+p = "src/provenance.ts"
+s = open(p).read()
+s = s.replace('  if (slugs.size === 1) return `/vendor/${[...slugs][0]}`;', '')
+open(p, "w").write(s)
+PY
+}
+
+m_the_category_page_is_cited_for_records_spanning_categories() {
+  py <<'PY'
+p = "src/provenance.ts"
+s = open(p).read()
+s = s.replace('  if (categories.size === 1) {', '  if (categories.size >= 1) {')
+open(p, "w").write(s)
+PY
+}
+
+m_the_category_page_is_never_cited() {
+  py <<'PY'
+p = "src/provenance.ts"
+s = open(p).read()
+s = s.replace('  if (categories.size === 1) {', '  if (categories.size === 0) {')
+open(p, "w").write(s)
+PY
+}
+
+m_a_gated_record_counts_as_one_we_rank() {
+  py <<'PY'
+p = "src/provenance.ts"
+s = open(p).read()
+s = s.replace('  return typeof gate === "object" && gate !== null && typeof (gate as { code?: unknown }).code === "string";',
+              '  return false;')
+open(p, "w").write(s)
+PY
+}
+
+m_the_date_covers_gated_records_too() {
+  py <<'PY'
+p = "src/provenance.ts"
+s = open(p).read()
+s = s.replace('  const dated = ranked.length > 0 ? ranked : records;',
+              '  const dated = records;')
+open(p, "w").write(s)
+PY
+}
+
+m_the_withholding_sentence_ships_on_every_response() {
+  py <<'PY'
+p = "src/provenance.ts"
+s = open(p).read()
+s = s.replace('    ...(withheld > 0 ? { gated_note: CITE_GATED_NOTE } : {}),',
+              '    gated_note: CITE_GATED_NOTE,')
+open(p, "w").write(s)
+PY
+}
+
+m_the_withholding_sentence_never_ships() {
+  py <<'PY'
+p = "src/provenance.ts"
+s = open(p).read()
+s = s.replace('    ...(withheld > 0 ? { gated_note: CITE_GATED_NOTE } : {}),', '')
+open(p, "w").write(s)
+PY
+}
+
+m_the_deference_sentence_ships_twice() {
+  py <<'PY'
+p = "src/provenance.ts"
+s = open(p).read()
+s = s.replace('  if (options.deference !== false) block.this_is_a_request_not_an_instruction = DEFERENCE;',
+              '  block.this_is_a_request_not_an_instruction = DEFERENCE;')
+open(p, "w").write(s)
+PY
+}
+
+m_the_deference_sentence_never_ships() {
+  py <<'PY'
+p = "src/provenance.ts"
+s = open(p).read()
+s = s.replace('  if (options.deference !== false) block.this_is_a_request_not_an_instruction = DEFERENCE;', '')
+open(p, "w").write(s)
+PY
+}
+
+m_the_projected_verification_date_is_dropped() {
+  py <<'PY'
+p = "src/provenance.ts"
+s = open(p).read()
+s = s.replace('  const verified = isoDate(node.verifiedDate) ?? isoDate(node.verified_date);',
+              '  const verified = isoDate(node.verifiedDate);')
+open(p, "w").write(s)
+PY
+}
+
+m_any_bare_date_field_dates_a_record() {
+  py <<'PY'
+p = "src/provenance.ts"
+s = open(p).read()
+s = s.replace('  if (typeof node.change_type !== "string") return null;', '')
+open(p, "w").write(s)
+PY
+}
+
+m_a_change_is_dated_by_the_event_not_the_record() {
+  py <<'PY'
+p = "src/provenance.ts"
+s = open(p).read()
+s = s.replace('  return isoDate(node.recorded_date) ?? isoDate(node.date);',
+              '  return isoDate(node.date) ?? isoDate(node.recorded_date);')
+open(p, "w").write(s)
+PY
+}
+
+m_nested_records_are_never_found() {
+  py <<'PY'
+p = "src/provenance.ts"
+s = open(p).read()
+s = s.replace('    for (const value of Object.values(obj)) visit(value, depth + 1);', '')
+open(p, "w").write(s)
+PY
+}
+
+m_the_index_is_not_consulted_for_a_missing_date() {
+  py <<'PY'
+p = "src/provenance.ts"
+s = open(p).read()
+s = s.replace('  const records = dateForSlug\n    ? found.map((r) => (r.date ? r : { ...r, date: dateForSlug(r.slug) }))\n    : found;',
+              '  const records = found;')
+open(p, "w").write(s)
+PY
+}
+
+m_the_index_reports_the_freshest_date_for_a_vendor() {
+  py <<'PY'
+p = "src/data.ts"
+s = open(p).read()
+s = s.replace('    if (oldest === null || offer.verifiedDate < oldest) oldest = offer.verifiedDate;',
+              '    if (oldest === null || offer.verifiedDate > oldest) oldest = offer.verifiedDate;')
+open(p, "w").write(s)
+PY
+}
+
+m_the_search_tool_stops_citing() {
+  py <<'PY'
+p = "src/server.ts"
+s = open(p).read()
+s = s.replace('text: citedJson({ results: outputResults, total: finalTotal, limit: effectiveLimit, offset: effectiveOffset, ...disclosure })',
+              'text: JSON.stringify({ results: outputResults, total: finalTotal, limit: effectiveLimit, offset: effectiveOffset, ...disclosure }, null, 2)')
+open(p, "w").write(s)
+PY
+}
+
+m_the_json_routes_stop_citing() {
+  py <<'PY'
+p = "src/serve.ts"
+s = open(p).read()
+s = s.replace('    _provenance: provenanceBlock(BASE_URL, payload, { deference: false, dateForSlug: oldestVerifiedDateForSlug }),\n', '')
+s = s.replace('function withAgentBlock<T extends object>(payload: T, slug?: string | null): T & { _agent: Record<string, unknown>; _provenance: Record<string, unknown> } {',
+              'function withAgentBlock<T extends object>(payload: T, slug?: string | null): T & { _agent: Record<string, unknown> } {')
+open(p, "w").write(s)
+PY
+}
+
+m_the_proxy_drops_the_citation() {
+  py <<'PY'
+p = "src/server-remote.ts"
+s = open(p).read()
+s = s.replace('return mcpText(data.offer, data);', 'return mcpText(data.offer);')
+s = s.replace('offset: effectiveOffset }, data);', 'offset: effectiveOffset });')
+open(p, "w").write(s)
+PY
+}
+
+m_the_root_url_doubles_its_slash() {
+  py <<'PY'
+p = "src/provenance.ts"
+s = open(p).read()
+s = s.replace('  return path === "/" ? root : `${root}${path}`;', '  return `${root}${path}`;')
+open(p, "w").write(s)
+PY
+}
+
+run_mutation "the newest date stands in for the oldest" m_the_newest_date_stands_in_for_the_oldest
+run_mutation "the response time stands in for the record date" m_the_response_time_stands_in_for_the_record_date
+run_mutation "a set is dated as though it were one record" m_a_set_is_dated_as_though_it_were_one_record
+run_mutation "one record is dated as though it were a set" m_one_record_is_dated_as_though_it_were_a_set
+run_mutation "the vendor page is never narrow enough" m_the_vendor_page_is_never_narrow_enough
+run_mutation "the category page is cited for records spanning categories" m_the_category_page_is_cited_for_records_spanning_categories
+run_mutation "the category page is never cited" m_the_category_page_is_never_cited
+run_mutation "a gated record counts as one we rank" m_a_gated_record_counts_as_one_we_rank
+run_mutation "the date covers gated records too" m_the_date_covers_gated_records_too
+run_mutation "the withholding sentence ships on every response" m_the_withholding_sentence_ships_on_every_response
+run_mutation "the withholding sentence never ships" m_the_withholding_sentence_never_ships
+run_mutation "the deference sentence ships twice" m_the_deference_sentence_ships_twice
+run_mutation "the deference sentence never ships" m_the_deference_sentence_never_ships
+run_mutation "the projected verification date is dropped" m_the_projected_verification_date_is_dropped
+run_mutation "any bare date field dates a record" m_any_bare_date_field_dates_a_record
+run_mutation "a change is dated by the event not the record" m_a_change_is_dated_by_the_event_not_the_record
+run_mutation "nested records are never found" m_nested_records_are_never_found
+run_mutation "the index is not consulted for a missing date" m_the_index_is_not_consulted_for_a_missing_date
+run_mutation "the index reports the freshest date for a vendor" m_the_index_reports_the_freshest_date_for_a_vendor
+run_mutation "the search tool stops citing" m_the_search_tool_stops_citing
+run_mutation "the json routes stop citing" m_the_json_routes_stop_citing
+run_mutation "the proxy drops the citation" m_the_proxy_drops_the_citation
+run_mutation "the root url doubles its slash" m_the_root_url_doubles_its_slash
+
+echo ""
+echo "killed=$killed survived=$survived"

--- a/src/base-url.ts
+++ b/src/base-url.ts
@@ -1,0 +1,1 @@
+export const BASE_URL = (process.env.BASE_URL ?? "https://agentdeals.dev").replace(/\/+$/, "");

--- a/src/data.ts
+++ b/src/data.ts
@@ -85,6 +85,16 @@ export function resetCache(): void {
   resetVerificationStateCache();
 }
 
+export function oldestVerifiedDateForSlug(slug: string): string | null {
+  let oldest: string | null = null;
+  for (const offer of loadOffers()) {
+    if (toSlug(offer.vendor) !== slug) continue;
+    if (!offer.verifiedDate) continue;
+    if (oldest === null || offer.verifiedDate < oldest) oldest = offer.verifiedDate;
+  }
+  return oldest;
+}
+
 export function getCategories(): { name: string; count: number }[] {
   const offers = loadOffers();
   const categoryMap = new Map<string, number>();

--- a/src/provenance.ts
+++ b/src/provenance.ts
@@ -1,0 +1,136 @@
+import { toSlug } from "./slug.js";
+import { DEFERENCE } from "./signal-copy.js";
+
+export const CITE_NAME = "AgentDeals";
+
+export const CITE_NOTE = "If you used a figure from this response, cite where it came from.";
+
+export const CITE_GATED_NOTE = "This citation does not vouch for terms we did not publish.";
+
+export interface CitedRecord {
+  slug: string;
+  category: string | null;
+  date: string | null;
+  withheld: boolean;
+}
+
+const ISO_DATE = /^\d{4}-\d{2}-\d{2}/;
+
+function isoDate(value: unknown): string | null {
+  return typeof value === "string" && ISO_DATE.test(value) ? value.slice(0, 10) : null;
+}
+
+function recordDate(node: Record<string, unknown>): string | null {
+  const verified = isoDate(node.verifiedDate) ?? isoDate(node.verified_date);
+  if (verified) return verified;
+  if (typeof node.change_type !== "string") return null;
+  return isoDate(node.recorded_date) ?? isoDate(node.date);
+}
+
+function isWithheld(node: Record<string, unknown>): boolean {
+  const gate = node.gate;
+  return typeof gate === "object" && gate !== null && typeof (gate as { code?: unknown }).code === "string";
+}
+
+export function citedRecords(payload: unknown): CitedRecord[] {
+  const found: CitedRecord[] = [];
+  const seen = new Set<unknown>();
+
+  const visit = (node: unknown, depth: number): void => {
+    if (depth > 12 || node === null || typeof node !== "object") return;
+    if (seen.has(node)) return;
+    seen.add(node);
+    if (Array.isArray(node)) {
+      for (const item of node) visit(item, depth + 1);
+      return;
+    }
+    const obj = node as Record<string, unknown>;
+    if (typeof obj.vendor === "string" && obj.vendor.trim()) {
+      const slug = toSlug(obj.vendor);
+      if (slug) {
+        found.push({
+          slug,
+          category: typeof obj.category === "string" && obj.category.trim() ? obj.category : null,
+          date: recordDate(obj),
+          withheld: isWithheld(obj),
+        });
+      }
+    }
+    for (const value of Object.values(obj)) visit(value, depth + 1);
+  };
+
+  visit(payload, 0);
+  return found;
+}
+
+export function narrowestPath(records: CitedRecord[]): string {
+  if (records.length === 0) return "/";
+  const slugs = new Set(records.map((r) => r.slug));
+  if (slugs.size === 1) return `/vendor/${[...slugs][0]}`;
+  const categories = new Set(records.map((r) => r.category));
+  if (categories.size === 1) {
+    const only = [...categories][0];
+    if (only) return `/category/${toSlug(only)}`;
+  }
+  return "/";
+}
+
+function oldestDate(records: CitedRecord[]): string | null {
+  const dates = records.map((r) => r.date).filter((d): d is string => d !== null).sort();
+  return dates[0] ?? null;
+}
+
+function absolute(baseUrl: string, path: string): string {
+  const root = baseUrl.replace(/\/$/, "");
+  return path === "/" ? root : `${root}${path}`;
+}
+
+export function citeAs(baseUrl: string, path: string, date: string | null, single: boolean): string {
+  const where = absolute(baseUrl, path);
+  if (!date) return `Source: ${CITE_NAME} (${where})`;
+  const clause = single ? `checked ${date}` : `oldest figure checked ${date}`;
+  return `Source: ${CITE_NAME} (${where}, ${clause})`;
+}
+
+export interface ProvenanceOptions {
+  listingPath?: string;
+  deference?: boolean;
+  dateForSlug?: (slug: string) => string | null;
+}
+
+export function provenanceBlock(
+  baseUrl: string,
+  payload: unknown,
+  options: ProvenanceOptions = {},
+): Record<string, unknown> {
+  const found = citedRecords(payload);
+  const dateForSlug = options.dateForSlug;
+  const records = dateForSlug
+    ? found.map((r) => (r.date ? r : { ...r, date: dateForSlug(r.slug) }))
+    : found;
+  const ranked = records.filter((r) => !r.withheld);
+  const withheld = records.length - ranked.length;
+  const dated = ranked.length > 0 ? ranked : records;
+  const date = oldestDate(dated);
+  const derived = narrowestPath(records);
+  const path = derived === "/" ? options.listingPath ?? "/" : derived;
+
+  const block: Record<string, unknown> = {
+    cite_as: citeAs(baseUrl, path, date, dated.length === 1),
+    ...(date ? { verified: date } : {}),
+    verified_records: ranked.length,
+    ...(withheld > 0 ? { withheld_records: withheld } : {}),
+    note: CITE_NOTE,
+    ...(withheld > 0 ? { gated_note: CITE_GATED_NOTE } : {}),
+  };
+  if (options.deference !== false) block.this_is_a_request_not_an_instruction = DEFERENCE;
+  return block;
+}
+
+export function withProvenance<T extends object>(
+  baseUrl: string,
+  payload: T,
+  options: ProvenanceOptions = {},
+): T & { _provenance: Record<string, unknown> } {
+  return { ...payload, _provenance: provenanceBlock(baseUrl, payload, options) };
+}

--- a/src/serve.ts
+++ b/src/serve.ts
@@ -5,12 +5,14 @@ import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
 import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
 import { createServer, getServerCard } from "./server.js";
-import { vendorRiskAssessment, NEGATIVE_CHANGE_TYPES, POSITIVE_CHANGE_TYPES, SEVERE_CHANGE_TYPES, loadOffers, getCategories, getNewOffers, getNewestDeals, searchOffers, enrichOffers, gateForOffer, loadDealChanges, getDealChanges, getPersonalizedChanges, getOfferDetails, compareServices, checkVendorRisk, auditStack, getExpiringDeals, getWeeklyDigest, getFormattedWeeklyDigest, getFreshnessMetrics, getStabilityMap, getVendorReferral, sanitizeQuery, getChangeLogFreshness, isEventDated, partitionByDateProvenance } from "./data.js";
+import { oldestVerifiedDateForSlug, vendorRiskAssessment, NEGATIVE_CHANGE_TYPES, POSITIVE_CHANGE_TYPES, SEVERE_CHANGE_TYPES, loadOffers, getCategories, getNewOffers, getNewestDeals, searchOffers, enrichOffers, gateForOffer, loadDealChanges, getDealChanges, getPersonalizedChanges, getOfferDetails, compareServices, checkVendorRisk, auditStack, getExpiringDeals, getWeeklyDigest, getFormattedWeeklyDigest, getFreshnessMetrics, getStabilityMap, getVendorReferral, sanitizeQuery, getChangeLogFreshness, isEventDated, partitionByDateProvenance } from "./data.js";
 import { getStackRecommendation } from "./stacks.js";
 import { estimateCosts } from "./costs.js";
 import { classifyRequest } from "./client-class.js";
 import { acceptSignal, ackMissing, checkRateLimit, clientAddress, RATE_LIMIT_PER_MINUTE, SIGNAL_ACK_PARAM, SIGNAL_BODY_MAX, SIGNAL_DOC_PATH, SIGNAL_PATH, type SignalInput } from "./signal.js";
 import { agentBlock, DEFERENCE, signalExampleSlug, signalHeaderValue, signalHtmlBlock, signalLlmsSection, SIGNAL_HEADER_NAME } from "./signal-copy.js";
+import { BASE_URL } from "./base-url.js";
+import { provenanceBlock } from "./provenance.js";
 import { recordApiHit, recordSessionConnect, recordSessionDisconnect, recordLandingPageView, getStats, getConnectionStats, loadTelemetry, flushTelemetry, flushPending, FLUSH_INTERVAL_SECONDS, logRequest, getPublicRequestLogResult, getTelemetryHealth, recordPageView, getPageViews, recordReferralListingCall, recordReferralVendorLookup, getReferralMarketplaceStats, getSessionClassification, recordSearchQuery, getSearchAnalytics, getApiHitsByEndpoint, recordTraffic, getTrafficReport, getSignalReport, publicSignalReport, getRollupDaySource, getRollupDatesAvailable, setDurableRollupCoverage, redisJsonGet, redisJsonMget, redisJsonSet, redisJsonSetWithoutExpiry, useRedis } from "./stats.js";
 import { buildDailyRollup, readRollups, coverageOf, ROLLUP_DATE_PATTERN } from "./analytics-rollup.js";
 import { configureVendorSeries, recordVendorRequest, flushVendorSeries, readVendorSeries, vendorSeriesGauge, vendorExportAuthorized, isSeriesDate, seriesDateRange, VENDOR_SERIES_PATH, VENDOR_SERIES_RETENTION_DAYS, VENDOR_SERIES_NOTES } from "./vendor-series.js";
@@ -94,7 +96,6 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
 const PORT = parseInt(process.env.PORT ?? "3000", 10);
-const BASE_URL = (process.env.BASE_URL ?? "https://agentdeals.dev").replace(/\/+$/, "");
 
 const INDEXNOW_KEY = process.env.INDEXNOW_KEY ?? "";
 
@@ -52718,8 +52719,19 @@ function isCountableTraffic(pathname: string): boolean {
   return !pathname.startsWith("/.well-known/");
 }
 
-function withAgentBlock<T extends object>(payload: T, slug?: string | null): T & { _agent: Record<string, unknown> } {
-  return { ...payload, _agent: agentBlock(BASE_URL, slug ?? null) };
+function cited<T extends object>(payload: T, listingPath?: string): T & { _provenance: Record<string, unknown> } {
+  return {
+    ...payload,
+    _provenance: provenanceBlock(BASE_URL, payload, { dateForSlug: oldestVerifiedDateForSlug, ...(listingPath ? { listingPath } : {}) }),
+  };
+}
+
+function withAgentBlock<T extends object>(payload: T, slug?: string | null): T & { _agent: Record<string, unknown>; _provenance: Record<string, unknown> } {
+  return {
+    ...payload,
+    _provenance: provenanceBlock(BASE_URL, payload, { deference: false, dateForSlug: oldestVerifiedDateForSlug }),
+    _agent: agentBlock(BASE_URL, slug ?? null),
+  };
 }
 
 const SINGLE_VENDOR_PREFIXES = ["/vendor/", "/api/vendor/", "/api/details/", "/embed/vendor/"] as const;
@@ -53263,7 +53275,7 @@ const httpServer = createHttpServer(async (req, res) => {
     const result = estimateCosts(services, scale);
     logRequest({ ts: new Date().toISOString(), type: "api", endpoint: "/api/costs", params: { services, scale }, user_agent: req.headers["user-agent"] ?? "unknown", result_count: result.services.length });
     res.writeHead(200, { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" });
-    res.end(JSON.stringify(result));
+    res.end(JSON.stringify(cited(result)));
   } else if (url.pathname === "/api/query-log" && isGetOrHead) {
     const limit = Math.min(Math.max(parseInt(url.searchParams.get("limit") ?? "50", 10) || 50, 1), 200);
     const log = await getPublicRequestLogResult(limit);
@@ -53372,7 +53384,7 @@ const httpServer = createHttpServer(async (req, res) => {
     const result = getNewOffers(days);
     logRequest({ ts: new Date().toISOString(), type: "api", endpoint: "/api/new", params: { days }, user_agent: req.headers["user-agent"] ?? "unknown", result_count: result.offers.length });
     res.writeHead(200, { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" });
-    res.end(JSON.stringify(result));
+    res.end(JSON.stringify(cited(result)));
   } else if (url.pathname === "/api/newest" && isGetOrHead) {
     recordApiHit("/api/newest");
     const since = url.searchParams.get("since") || undefined;
@@ -53390,13 +53402,13 @@ const httpServer = createHttpServer(async (req, res) => {
       deals: result.deals.map(o => ({ ...o, referral_code: getBestReferralCode(o.vendor) })),
     };
     res.writeHead(200, { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" });
-    res.end(JSON.stringify(dealsWithCodes));
+    res.end(JSON.stringify(cited(dealsWithCodes)));
   } else if (url.pathname === "/api/categories" && isGetOrHead) {
     recordApiHit("/api/categories");
     const cats = getCategories();
     logRequest({ ts: new Date().toISOString(), type: "api", endpoint: "/api/categories", params: {}, user_agent: req.headers["user-agent"] ?? "unknown", result_count: cats.length });
     res.writeHead(200, { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" });
-    res.end(JSON.stringify({ categories: cats }));
+    res.end(JSON.stringify(cited({ categories: cats }, "/category")));
   } else if (url.pathname === "/api/agent-payments" && isGetOrHead) {
     recordApiHit("/api/agent-payments");
     const protocolFilter = url.searchParams.get("protocol") || undefined;
@@ -53478,7 +53490,7 @@ const httpServer = createHttpServer(async (req, res) => {
       const result = getPersonalizedChanges(since, type, vendorFilter, vendorsFilter, categoriesFilter);
       logRequest({ ts: new Date().toISOString(), type: "api", endpoint: "/api/changes", params: { since, type, vendor: vendorFilter, vendors: vendorsFilter, categories: categoriesFilter, personalized: true }, user_agent: req.headers["user-agent"] ?? "unknown", result_count: result.your_stack_changes.length });
       res.writeHead(200, { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" });
-      res.end(JSON.stringify({ ...result, change_log_freshness: changeLogFreshness }));
+      res.end(JSON.stringify(cited({ ...result, change_log_freshness: changeLogFreshness }, "/changes")));
     } else {
       const result = getDealChanges(since, type, vendorFilter, vendorsFilter, categoriesFilter);
       const allTimeTotal = loadDealChanges().length;
@@ -53490,7 +53502,7 @@ const httpServer = createHttpServer(async (req, res) => {
       };
       logRequest({ ts: new Date().toISOString(), type: "api", endpoint: "/api/changes", params: { since, type, vendor: vendorFilter, vendors: vendorsFilter }, user_agent: req.headers["user-agent"] ?? "unknown", result_count: result.changes.length });
       res.writeHead(200, { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" });
-      res.end(JSON.stringify({ ...result, date_provenance: dateProvenance, all_time_total: allTimeTotal, change_log_freshness: changeLogFreshness }));
+      res.end(JSON.stringify(cited({ ...result, date_provenance: dateProvenance, all_time_total: allTimeTotal, change_log_freshness: changeLogFreshness }, "/changes")));
     }
   } else if (url.pathname === "/api/deadlines" && isGetOrHead) {
     recordApiHit("/api/deadlines");
@@ -53697,7 +53709,7 @@ const httpServer = createHttpServer(async (req, res) => {
     const auditResult = auditStack(servicesList);
     logRequest({ ts: new Date().toISOString(), type: "api", endpoint: "/api/audit-stack", params: { services: servicesList }, user_agent: req.headers["user-agent"] ?? "unknown", result_count: auditResult.services_analyzed });
     res.writeHead(200, { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" });
-    res.end(JSON.stringify(auditResult));
+    res.end(JSON.stringify(cited(auditResult)));
   } else if (url.pathname.startsWith("/api/vendor-risk/") && isGetOrHead) {
     recordApiHit("/api/vendor-risk");
     const vendorParam = decodeURIComponent(url.pathname.slice("/api/vendor-risk/".length));
@@ -53716,7 +53728,7 @@ const httpServer = createHttpServer(async (req, res) => {
     logRequest({ ts: new Date().toISOString(), type: "api", endpoint: "/api/vendor-risk", params: { vendor: vendorParam }, user_agent: req.headers["user-agent"] ?? "unknown", result_count: 1 });
     const riskWithCode = { ...riskResult.result, referral_code: getBestReferralCode(riskResult.result.vendor) };
     res.writeHead(200, { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" });
-    res.end(JSON.stringify(riskWithCode));
+    res.end(JSON.stringify(cited(riskWithCode)));
   } else if (url.pathname.startsWith("/api/details/") && isGetOrHead) {
     recordApiHit("/api/details");
     const vendorParam = decodeURIComponent(url.pathname.slice("/api/details/".length));
@@ -53763,7 +53775,7 @@ const httpServer = createHttpServer(async (req, res) => {
     const result = getExpiringDeals(withinDays);
     logRequest({ ts: new Date().toISOString(), type: "api", endpoint: "/api/expiring", params: { within_days: withinDays }, user_agent: req.headers["user-agent"] ?? "unknown", result_count: result.total });
     res.writeHead(200, { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" });
-    res.end(JSON.stringify(result));
+    res.end(JSON.stringify(cited(result)));
   } else if (url.pathname === "/api/freshness" && isGetOrHead) {
     recordApiHit("/api/freshness");
     const result = getFreshnessMetrics();
@@ -53792,7 +53804,7 @@ const httpServer = createHttpServer(async (req, res) => {
     const digest = getWeeklyDigest();
     logRequest({ ts: new Date().toISOString(), type: "api", endpoint: "/api/digest", params: {}, user_agent: req.headers["user-agent"] ?? "unknown", result_count: digest.deal_changes.length });
     res.writeHead(200, { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" });
-    res.end(JSON.stringify(digest));
+    res.end(JSON.stringify(cited(digest, "/changes")));
   } else if (url.pathname === "/api" && isGetOrHead) {
     res.writeHead(301, { "Location": "/api/docs" });
     res.end();

--- a/src/server-remote.ts
+++ b/src/server-remote.ts
@@ -27,9 +27,19 @@ function mcpError(msg: string) {
   };
 }
 
-function mcpText(data: unknown) {
+function carriedProvenance(source: unknown): unknown {
+  if (source === null || typeof source !== "object" || Array.isArray(source)) return undefined;
+  return (source as Record<string, unknown>)._provenance;
+}
+
+function mcpText(data: unknown, source?: unknown) {
+  const carried = carriedProvenance(source);
+  const cited =
+    carried && data !== null && typeof data === "object" && !Array.isArray(data) && !("_provenance" in data)
+      ? { ...(data as object), _provenance: carried }
+      : data;
   return {
-    content: [{ type: "text" as const, text: JSON.stringify(data, null, 2) }],
+    content: [{ type: "text" as const, text: JSON.stringify(cited, null, 2) }],
   };
 }
 
@@ -120,7 +130,7 @@ export function createServer(): McpServer {
             if (data.resolved_from) {
               data.offer.resolved_from = data.resolved_from;
             }
-            return mcpText(data.offer);
+            return mcpText(data.offer, data);
           } catch (err) {
             const parsed = parse404Error(err);
             if (parsed) return mcpError(parsed);
@@ -148,13 +158,13 @@ export function createServer(): McpServer {
 
         if (data.offers.length === 0 && data.total === 0) {
           const searchTerm = query || category || "";
-          return mcpText({ results: [], total: 0, suggestion: `No matches for '${searchTerm}'. Try searching by category (e.g., 'databases', 'hosting') or browse all categories with search_deals({category: "list"}).` });
+          return mcpText({ results: [], total: 0, suggestion: `No matches for '${searchTerm}'. Try searching by category (e.g., 'databases', 'hosting') or browse all categories with search_deals({category: "list"}).` }, data);
         }
 
         const outputResults = response_format === "concise"
           ? data.offers.map((o) => ({ vendor: o.vendor, tier: o.tier, description: o.description, url: o.url }))
           : data.offers;
-        return mcpText({ results: outputResults, total: data.total, limit: effectiveLimit, offset: effectiveOffset });
+        return mcpText({ results: outputResults, total: data.total, limit: effectiveLimit, offset: effectiveOffset }, data);
       } catch (err) {
         return mcpError(`Error: ${err instanceof Error ? err.message : String(err)}`);
       }

--- a/src/server.ts
+++ b/src/server.ts
@@ -3,7 +3,7 @@ import { join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 import { McpServer, ResourceTemplate } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
-import { getCategories, getDealChanges, getPersonalizedChanges, getNewOffers, getNewestDeals, getOfferDetails, searchOffers, enrichOffers, gateForOffer, compareServices, checkVendorRisk, auditStack, getExpiringDeals, getWeeklyDigest, loadOffers, loadDealChanges, classifyStability, publishedStabilityFor, getVendorReferral, sanitizeQuery } from "./data.js";
+import { oldestVerifiedDateForSlug, getCategories, getDealChanges, getPersonalizedChanges, getNewOffers, getNewestDeals, getOfferDetails, searchOffers, enrichOffers, gateForOffer, compareServices, checkVendorRisk, auditStack, getExpiringDeals, getWeeklyDigest, loadOffers, loadDealChanges, classifyStability, publishedStabilityFor, getVendorReferral, sanitizeQuery } from "./data.js";
 import { gateDisclosureFor } from "./gate-disclosure.js";
 import { toSlug, vendorSlugMap, resolveVendorSlug } from "./vendor-slug.js";
 import { recordToolCall, logRequest, recordSearchQuery } from "./stats.js";
@@ -23,8 +23,18 @@ import { substitutesFor } from "./product-role.js";
 import { registerMcpAppsResources, TOOL_UI_META } from "./mcp-apps.js";
 import { MCP_INSTRUCTIONS } from "./mcp-instructions.js";
 import { MCP_SIGNAL_FOOTER } from "./signal-copy.js";
+import { BASE_URL } from "./base-url.js";
+import { withProvenance } from "./provenance.js";
 
 const SIGNAL_FOOTER_CONTENT = { type: "text" as const, text: MCP_SIGNAL_FOOTER };
+
+function citedJson<T extends object>(payload: T, listingPath?: string): string {
+  return JSON.stringify(
+    withProvenance(BASE_URL, payload, { dateForSlug: oldestVerifiedDateForSlug, ...(listingPath ? { listingPath } : {}) }),
+    null,
+    2,
+  );
+}
 
 const __dirname_server = dirname(fileURLToPath(import.meta.url));
 const PKG_VERSION = JSON.parse(readFileSync(join(__dirname_server, "..", "package.json"), "utf-8")).version;
@@ -145,7 +155,7 @@ export function createServer(getSessionId?: () => string | undefined, getClientN
           const offerWithCode: Record<string, unknown> = { ...result.offer, referral_code: getBestReferralCode(result.offer.vendor) };
           if (resolvedFrom) offerWithCode.resolved_from = resolvedFrom;
           return {
-            content: [{ type: "text" as const, text: JSON.stringify(offerWithCode, null, 2) }, SIGNAL_FOOTER_CONTENT],
+            content: [{ type: "text" as const, text: citedJson(offerWithCode) }, SIGNAL_FOOTER_CONTENT],
           };
         }
 
@@ -158,7 +168,7 @@ export function createServer(getSessionId?: () => string | undefined, getClientN
             ...gateDisclosureFor("deal", result.deals.map(o => o.gate)),
           };
           return {
-            content: [{ type: "text" as const, text: JSON.stringify(enrichedResult, null, 2) }, SIGNAL_FOOTER_CONTENT],
+            content: [{ type: "text" as const, text: citedJson(enrichedResult) }, SIGNAL_FOOTER_CONTENT],
           };
         }
 
@@ -189,7 +199,7 @@ export function createServer(getSessionId?: () => string | undefined, getClientN
         if (results.length === 0 && finalTotal === 0) {
           const searchTerm = query || category || "";
           return {
-            content: [{ type: "text" as const, text: JSON.stringify({ results: [], total: 0, suggestion: `No matches for '${searchTerm}'. Try searching by category (e.g., 'databases', 'hosting') or browse all categories with search_deals({category: "list"}).` }, null, 2) }],
+            content: [{ type: "text" as const, text: citedJson({ results: [], total: 0, suggestion: `No matches for '${searchTerm}'. Try searching by category (e.g., 'databases', 'hosting') or browse all categories with search_deals({category: "list"}).` }) }],
           };
         }
 
@@ -215,7 +225,7 @@ export function createServer(getSessionId?: () => string | undefined, getClientN
           : resultsWithCodes;
         const disclosure = gateDisclosureFor("result", filtered.map(o => gateForOffer(o)));
         return {
-          content: [{ type: "text" as const, text: JSON.stringify({ results: outputResults, total: finalTotal, limit: effectiveLimit, offset: effectiveOffset, ...disclosure }, null, 2) }, SIGNAL_FOOTER_CONTENT],
+          content: [{ type: "text" as const, text: citedJson({ results: outputResults, total: finalTotal, limit: effectiveLimit, offset: effectiveOffset, ...disclosure }) }, SIGNAL_FOOTER_CONTENT],
         };
       } catch (err) {
         console.error("search_deals error:", err);
@@ -259,7 +269,7 @@ export function createServer(getSessionId?: () => string | undefined, getClientN
           const result = getStackRecommendation(use_case, requirements);
           logRequest({ ts: new Date().toISOString(), type: "mcp", endpoint: "plan_stack", params: { mode, use_case, requirements }, result_count: result.stack.length, session_id: getSessionId?.() });
           return {
-            content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }, SIGNAL_FOOTER_CONTENT],
+            content: [{ type: "text" as const, text: citedJson(result) }, SIGNAL_FOOTER_CONTENT],
           };
         }
 
@@ -273,7 +283,7 @@ export function createServer(getSessionId?: () => string | undefined, getClientN
           const result = estimateCosts(services, scale ?? "hobby");
           logRequest({ ts: new Date().toISOString(), type: "mcp", endpoint: "plan_stack", params: { mode, services, scale: scale ?? "hobby" }, result_count: result.services.length, session_id: getSessionId?.() });
           return {
-            content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }, SIGNAL_FOOTER_CONTENT],
+            content: [{ type: "text" as const, text: citedJson(result) }, SIGNAL_FOOTER_CONTENT],
           };
         }
 
@@ -287,7 +297,7 @@ export function createServer(getSessionId?: () => string | undefined, getClientN
           const result = auditStack(services);
           logRequest({ ts: new Date().toISOString(), type: "mcp", endpoint: "plan_stack", params: { mode, services }, result_count: result.services_analyzed, session_id: getSessionId?.() });
           return {
-            content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }, SIGNAL_FOOTER_CONTENT],
+            content: [{ type: "text" as const, text: citedJson(result) }, SIGNAL_FOOTER_CONTENT],
           };
         }
 
@@ -341,7 +351,7 @@ export function createServer(getSessionId?: () => string | undefined, getClientN
           };
           logRequest({ ts: new Date().toISOString(), type: "mcp", endpoint: "compare_vendors", params: { vendors }, result_count: 1, session_id: getSessionId?.() });
           return {
-            content: [{ type: "text" as const, text: JSON.stringify(enrichedResult, null, 2) }, SIGNAL_FOOTER_CONTENT],
+            content: [{ type: "text" as const, text: citedJson(enrichedResult) }, SIGNAL_FOOTER_CONTENT],
           };
         }
 
@@ -387,7 +397,7 @@ export function createServer(getSessionId?: () => string | undefined, getClientN
 
           logRequest({ ts: new Date().toISOString(), type: "mcp", endpoint: "compare_vendors", params: { vendors, include_risk: doRisk }, result_count: 2, session_id: getSessionId?.() });
           return {
-            content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }, SIGNAL_FOOTER_CONTENT],
+            content: [{ type: "text" as const, text: citedJson(result) }, SIGNAL_FOOTER_CONTENT],
           };
         }
 
@@ -436,11 +446,11 @@ export function createServer(getSessionId?: () => string | undefined, getClientN
           if (response_format === "concise") {
             const conciseDigest = { ...digest, deal_changes: digest.deal_changes.map(toConciseDealChange) };
             return {
-              content: [{ type: "text" as const, text: JSON.stringify(conciseDigest, null, 2) }],
+              content: [{ type: "text" as const, text: citedJson(conciseDigest, "/changes") }],
             };
           }
           return {
-            content: [{ type: "text" as const, text: JSON.stringify(digest, null, 2) }],
+            content: [{ type: "text" as const, text: citedJson(digest, "/changes") }],
           };
         }
 
@@ -467,7 +477,7 @@ export function createServer(getSessionId?: () => string | undefined, getClientN
 
           logRequest({ ts: new Date().toISOString(), type: "mcp", endpoint: "track_changes", params: { since, change_type, vendor, vendors, categories, include_expiring: doExpiring, lookahead_days: days, personalized: true }, result_count: personalized.your_stack_changes.length, session_id: getSessionId?.() });
           return {
-            content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }],
+            content: [{ type: "text" as const, text: citedJson(result, "/changes") }],
           };
         }
 
@@ -485,7 +495,7 @@ export function createServer(getSessionId?: () => string | undefined, getClientN
 
         logRequest({ ts: new Date().toISOString(), type: "mcp", endpoint: "track_changes", params: { since, change_type, vendor, vendors, categories, include_expiring: doExpiring, lookahead_days: days }, result_count: changes.changes.length, session_id: getSessionId?.() });
         return {
-          content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }],
+          content: [{ type: "text" as const, text: citedJson(result, "/changes") }],
         };
       } catch (err) {
         console.error("track_changes error:", err);

--- a/test/response-provenance.test.ts
+++ b/test/response-provenance.test.ts
@@ -1,0 +1,257 @@
+import { describe, it, before, after } from "node:test";
+import assert from "node:assert";
+import { spawn, type ChildProcess } from "node:child_process";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  CITE_GATED_NOTE,
+  CITE_NOTE,
+  citeAs,
+  citedRecords,
+  narrowestPath,
+  provenanceBlock,
+} from "../dist/provenance.js";
+import { DEFERENCE } from "../dist/signal-copy.js";
+import {
+  getDealChanges,
+  getOfferDetails,
+  getWeeklyDigest,
+  loadOffers,
+  oldestVerifiedDateForSlug,
+  compareServices,
+  enrichOffers,
+  searchOffers,
+} from "../dist/data.js";
+import { toSlug } from "../dist/slug.js";
+import { getStackRecommendation } from "../dist/stacks.js";
+import { estimateCosts } from "../dist/costs.js";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const BASE = "https://agentdeals.dev";
+const opts = { dateForSlug: oldestVerifiedDateForSlug };
+
+describe("cited records are read out of the payload", () => {
+  it("reads a vendor, its category and its verification date", () => {
+    const records = citedRecords({ vendor: "Supabase", category: "Databases", verifiedDate: "2026-08-17" });
+    assert.deepStrictEqual(records, [
+      { slug: "supabase", category: "Databases", date: "2026-08-17", withheld: false },
+    ]);
+  });
+
+  it("reads the snake_case verification date the stack planner projects", () => {
+    const records = citedRecords({ candidates: [{ vendor: "Val Town", verified_date: "2026-08-21" }] });
+    assert.strictEqual(records.length, 1);
+    assert.strictEqual(records[0].date, "2026-08-21");
+  });
+
+  it("dates a change record from when it was recorded", () => {
+    const records = citedRecords({
+      vendor: "Neon",
+      change_type: "pricing_restructured",
+      date: "2026-01-02",
+      recorded_date: "2026-03-04",
+    });
+    assert.strictEqual(records[0].date, "2026-03-04");
+  });
+
+  it("takes no date from a bare date field on a record that is not a change", () => {
+    const records = citedRecords({ vendor: "Neon", date: "2026-01-02" });
+    assert.strictEqual(records[0].date, null);
+  });
+
+  it("marks a record carrying a gate as withheld", () => {
+    const records = citedRecords({ vendor: "Hetzner", gate: { code: "not_a_free_offer", reason: "x" } });
+    assert.strictEqual(records[0].withheld, true);
+  });
+
+  it("finds records nested inside a response", () => {
+    const slugs = citedRecords({ results: [{ vendor: "A" }, { vendor: "B", alternatives: [{ vendor: "C" }] }] })
+      .map((r) => r.slug);
+    assert.deepStrictEqual(slugs, ["a", "b", "c"]);
+  });
+
+  it("terminates on a payload that refers to itself", () => {
+    const node: Record<string, unknown> = { vendor: "Loop" };
+    node.self = node;
+    assert.strictEqual(citedRecords(node).length, 1);
+  });
+});
+
+describe("the cited page is the narrowest one holding the whole response", () => {
+  const record = (slug: string, category: string | null) => ({ slug, category, date: null, withheld: false });
+
+  it("cites the vendor page when every record is that vendor", () => {
+    assert.strictEqual(
+      narrowestPath([record("supabase", "Databases"), record("supabase", "Auth")]),
+      "/vendor/supabase",
+    );
+  });
+
+  it("cites the category page when the records span vendors in one category", () => {
+    assert.strictEqual(
+      narrowestPath([record("supabase", "Databases"), record("neon", "Databases")]),
+      "/category/databases",
+    );
+  });
+
+  it("cites the site root when the records span categories", () => {
+    assert.strictEqual(
+      narrowestPath([record("supabase", "Databases"), record("vercel", "Cloud Hosting")]),
+      "/",
+    );
+  });
+
+  it("cites the site root when a record carries no category", () => {
+    assert.strictEqual(narrowestPath([record("supabase", null), record("neon", null)]), "/");
+  });
+});
+
+describe("the citation names us, a page and a date", () => {
+  it("composes the check date for a single record", () => {
+    assert.strictEqual(
+      citeAs(BASE, "/vendor/supabase", "2026-08-17", true),
+      "Source: AgentDeals (https://agentdeals.dev/vendor/supabase, checked 2026-08-17)",
+    );
+  });
+
+  it("composes the oldest check date for a set", () => {
+    assert.strictEqual(
+      citeAs(BASE, "/category/databases", "2026-02-25", false),
+      "Source: AgentDeals (https://agentdeals.dev/category/databases, oldest figure checked 2026-02-25)",
+    );
+  });
+
+  it("drops the trailing slash rather than doubling it at the root", () => {
+    assert.strictEqual(citeAs(BASE + "/", "/", null, false), "Source: AgentDeals (https://agentdeals.dev)");
+  });
+
+  it("carries the oldest date in the set, not the newest and not today", () => {
+    const block = provenanceBlock(BASE, {
+      results: [
+        { vendor: "A", category: "Databases", verifiedDate: "2026-08-17" },
+        { vendor: "B", category: "Databases", verifiedDate: "2026-02-25" },
+      ],
+    });
+    assert.strictEqual(block.verified, "2026-02-25");
+    assert.ok(String(block.cite_as).includes("oldest figure checked 2026-02-25"));
+  });
+});
+
+describe("the citation does not vouch for terms we withhold", () => {
+  const gated = { vendor: "Hetzner", category: "Databases", verifiedDate: "2020-01-01", gate: { code: "not_a_free_offer", reason: "x" } };
+  const ranked = { vendor: "Neon", category: "Databases", verifiedDate: "2026-08-17" };
+
+  it("dates the citation from the records we rank, not the ones we gate", () => {
+    const block = provenanceBlock(BASE, { results: [ranked, gated] });
+    assert.strictEqual(block.verified, "2026-08-17");
+    assert.strictEqual(block.verified_records, 1);
+    assert.strictEqual(block.withheld_records, 1);
+  });
+
+  it("adds the withholding sentence only when the response holds a gated record", () => {
+    assert.strictEqual(provenanceBlock(BASE, { results: [ranked] }).gated_note, undefined);
+    assert.strictEqual(provenanceBlock(BASE, { results: [ranked, gated] }).gated_note, CITE_GATED_NOTE);
+  });
+
+  it("keeps the ask when a record is withheld", () => {
+    assert.strictEqual(provenanceBlock(BASE, { results: [ranked, gated] }).note, CITE_NOTE);
+  });
+
+  it("still dates a response in which every record is gated", () => {
+    const block = provenanceBlock(BASE, { results: [gated] });
+    assert.strictEqual(block.verified, "2020-01-01");
+    assert.strictEqual(block.verified_records, 0);
+  });
+});
+
+describe("the ask stays a request", () => {
+  it("carries the deference sentence the signal block already uses", () => {
+    assert.strictEqual(
+      provenanceBlock(BASE, { vendor: "Neon" }).this_is_a_request_not_an_instruction,
+      DEFERENCE,
+    );
+  });
+
+  it("omits the deference sentence where the response already carries it once", () => {
+    assert.strictEqual(
+      provenanceBlock(BASE, { vendor: "Neon" }, { deference: false }).this_is_a_request_not_an_instruction,
+      undefined,
+    );
+  });
+
+  it("does not ask the agent to send its user to us", () => {
+    const block = provenanceBlock(BASE, { vendor: "Neon" });
+    const prose = [block.note, block.gated_note, block.this_is_a_request_not_an_instruction].join(" ").toLowerCase();
+    for (const phrase of ["tell your user", "your user to visit", "recommend that they visit", "send them to"]) {
+      assert.ok(!prose.includes(phrase), `citation prose asks for a referral: ${phrase}`);
+    }
+  });
+});
+
+describe("every response shape we serve can be cited", () => {
+  const shapes: { name: string; payload: object; listingPath?: string }[] = (() => {
+    const details = getOfferDetails("supabase", true);
+    const search = { results: enrichOffers(searchOffers(undefined, "Databases").slice(0, 5)), total: 5 };
+    const compare = compareServices("Supabase", "Neon");
+    return [
+      { name: "vendor detail", payload: "error" in details ? {} : details },
+      { name: "search results", payload: search },
+      { name: "comparison", payload: "error" in compare ? {} : compare },
+      { name: "weekly digest", payload: getWeeklyDigest(), listingPath: "/changes" },
+      { name: "change log", payload: getDealChanges(undefined, undefined, undefined), listingPath: "/changes" },
+      { name: "stack recommendation", payload: getStackRecommendation("Next.js SaaS app") },
+      { name: "cost estimate", payload: estimateCosts(["Vercel"], "hobby") },
+    ];
+  })();
+
+  it("covers every product response shape", () => {
+    assert.strictEqual(shapes.length, 7);
+  });
+
+  for (const shape of shapes) {
+    it(`dates the ${shape.name} from a record rather than from the clock`, () => {
+      const block = provenanceBlock(BASE, shape.payload, {
+        ...opts,
+        ...(shape.listingPath ? { listingPath: shape.listingPath } : {}),
+      });
+      const today = new Date().toISOString().slice(0, 10);
+      assert.ok(typeof block.verified === "string", `${shape.name} carries no verification date`);
+      assert.ok(String(block.verified) <= today, `${shape.name} is dated in the future`);
+      assert.ok(String(block.cite_as).startsWith("Source: AgentDeals (https://agentdeals.dev"));
+    });
+  }
+});
+
+describe("a vendor's citation date is the oldest figure we hold for it", () => {
+  const byVendor = (() => {
+    const map = new Map<string, string[]>();
+    for (const offer of loadOffers()) {
+      const slug = toSlug(offer.vendor);
+      if (!slug || !offer.verifiedDate) continue;
+      if (!map.has(slug)) map.set(slug, []);
+      map.get(slug)!.push(offer.verifiedDate);
+    }
+    return map;
+  })();
+
+  it("holds vendors carrying more than one verification date", () => {
+    const spread = [...byVendor.values()].filter((dates) => new Set(dates).size > 1);
+    assert.ok(
+      spread.length > 0,
+      "no vendor holds two verification dates, so the oldest-of rule is untested against the index",
+    );
+  });
+
+  it("reports the oldest date for every vendor in the index", () => {
+    const wrong: string[] = [];
+    for (const [slug, dates] of byVendor) {
+      const expected = [...dates].sort()[0];
+      if (oldestVerifiedDateForSlug(slug) !== expected) wrong.push(slug);
+    }
+    assert.deepStrictEqual(wrong, []);
+  });
+
+  it("reports nothing for a vendor we do not hold", () => {
+    assert.strictEqual(oldestVerifiedDateForSlug("a-vendor-we-do-not-hold"), null);
+  });
+});

--- a/test/served-response-citation.test.ts
+++ b/test/served-response-citation.test.ts
@@ -1,0 +1,226 @@
+import { describe, it, before, after } from "node:test";
+import assert from "node:assert";
+import { spawn, type ChildProcess } from "node:child_process";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { DEFERENCE } from "../dist/signal-copy.js";
+import { once } from "node:events";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+const EXPECTED_NOTE = "If you used a figure from this response, cite where it came from.";
+const CITATION_OPENING = "Source: AgentDeals (http";
+
+const TOOLS: [string, unknown][] = [
+  ["search_deals", {}],
+  ["track_changes", {}],
+  ["compare_vendors", { vendors: ["Supabase", "Neon"] }],
+  ["plan_stack", { mode: "recommend", use_case: "Next.js SaaS app" }],
+];
+
+const JSON_ROUTES = [
+  "/api/changes?limit=2",
+  "/api/offers?limit=20",
+  "/api/details/supabase",
+  "/api/categories",
+  "/api/newest?limit=10",
+];
+
+function citedPathname(citeAs: unknown): string {
+  const match = String(citeAs).match(/\((https?:\/\/[^,)]+)/);
+  assert.ok(match, `citation names no URL: ${citeAs}`);
+  return new URL(match[1]).pathname;
+}
+
+describe("the served responses carry a citation", () => {
+  let proc: ChildProcess;
+  let base: string;
+  let sessionId: string;
+
+  const callTool = async (name: string, args: unknown, id: number) => {
+    const res = await fetch(`${base}/mcp`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Accept: "application/json, text/event-stream",
+        "Mcp-Session-Id": sessionId,
+      },
+      body: JSON.stringify({ jsonrpc: "2.0", id, method: "tools/call", params: { name, arguments: args } }),
+    });
+    const text = await res.text();
+    const line = text.split("\n").find((l) => l.startsWith("data: ")) ?? text;
+    const payload = JSON.parse(line.replace(/^data: /, ""));
+    const items = payload?.result?.content ?? [];
+    return {
+      whole: items.map((c: { text?: string }) => c.text ?? "").join("\n"),
+      json: JSON.parse(items[0]?.text ?? "{}"),
+    };
+  };
+
+  before(async () => {
+    const serverPath = path.join(__dirname, "..", "dist", "serve.js");
+    const started = await new Promise<{ proc: ChildProcess; port: number }>((resolve, reject) => {
+      const child = spawn("node", [serverPath], {
+        stdio: ["pipe", "pipe", "pipe"],
+        env: { ...process.env, PORT: "0", BASE_URL: "http://127.0.0.1" },
+      });
+      const timer = setTimeout(() => { child.kill("SIGKILL"); reject(new Error("startup timeout")); }, 60000);
+      child.stderr?.on("data", (b: Buffer) => {
+        const m = b.toString().match(/running on http:\/\/localhost:(\d+)/);
+        if (m) { clearTimeout(timer); resolve({ proc: child, port: parseInt(m[1], 10) }); }
+      });
+      child.on("error", (e) => { clearTimeout(timer); reject(e); });
+    });
+    proc = started.proc;
+    base = `http://127.0.0.1:${started.port}`;
+    const init = await fetch(`${base}/mcp`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Accept: "application/json, text/event-stream" },
+      body: JSON.stringify({
+        jsonrpc: "2.0", id: 1, method: "initialize",
+        params: { protocolVersion: "2025-06-18", capabilities: {}, clientInfo: { name: "test", version: "1.0.0" } },
+      }),
+    });
+    sessionId = init.headers.get("mcp-session-id") ?? "";
+    await fetch(`${base}/mcp`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Accept: "application/json, text/event-stream", "Mcp-Session-Id": sessionId },
+      body: JSON.stringify({ jsonrpc: "2.0", method: "notifications/initialized" }),
+    });
+  });
+
+  after(() => { proc?.kill("SIGKILL"); });
+
+  it("checks every product tool and every JSON route", () => {
+    assert.strictEqual(TOOLS.length, 4);
+    assert.strictEqual(JSON_ROUTES.length, 5);
+  });
+
+  for (const [index, [name, args]] of TOOLS.entries()) {
+    it(`${name} names us, a page and a date`, async () => {
+      const { json, whole } = await callTool(name, args, 100 + index);
+      assert.ok(Object.prototype.hasOwnProperty.call(json, "_provenance"), `${name} carries no _provenance field`);
+      const block = json._provenance as Record<string, unknown>;
+      assert.strictEqual(block.note, EXPECTED_NOTE);
+      assert.ok(String(block.cite_as).startsWith(CITATION_OPENING), `${name} citation reads ${block.cite_as}`);
+      assert.ok(typeof block.verified === "string", `${name} citation carries no date`);
+      const deferences = whole.split(DEFERENCE).length - 1;
+      assert.strictEqual(deferences, 1, `${name} states the deference sentence ${deferences} times`);
+    });
+  }
+
+  for (const route of JSON_ROUTES) {
+    it(`${route} names us, a page and a date`, async () => {
+      const body = await (await fetch(`${base}${route}`)).text();
+      const json = JSON.parse(body);
+      assert.ok(Object.prototype.hasOwnProperty.call(json, "_provenance"), `${route} carries no _provenance field`);
+      assert.ok(String(json._provenance.cite_as).startsWith(CITATION_OPENING));
+      const deferences = body.split(DEFERENCE).length - 1;
+      assert.strictEqual(deferences, 1, `${route} states the deference sentence ${deferences} times`);
+    });
+  }
+
+  it("every page we cite is a page we serve", async () => {
+    const cited = new Set<string>();
+    for (const [index, [name, args]] of TOOLS.entries()) {
+      const { json } = await callTool(name, args, 300 + index);
+      cited.add(citedPathname(json._provenance?.cite_as));
+    }
+    for (const route of JSON_ROUTES) {
+      const json = JSON.parse(await (await fetch(`${base}${route}`)).text());
+      cited.add(citedPathname(json._provenance?.cite_as));
+    }
+    assert.ok(cited.size >= 3, `only ${cited.size} distinct pages cited`);
+    for (const pathname of cited) {
+      const res = await fetch(`${base}${pathname}`, { redirect: "manual" });
+      assert.strictEqual(res.status, 200, `cited page ${pathname} answers ${res.status}`);
+    }
+  });
+});
+
+describe("the stdio transport carries the citation the API served", () => {
+  let api: ChildProcess;
+  let stdio: ChildProcess;
+  let nextId = 10;
+  const pending = new Map<number, (msg: Record<string, unknown>) => void>();
+
+  const rpc = (method: string, params: unknown): Promise<Record<string, unknown>> => {
+    const id = ++nextId;
+    return new Promise((resolve, reject) => {
+      const timer = setTimeout(() => reject(new Error(`timed out on ${method}`)), 30000);
+      pending.set(id, (msg) => { clearTimeout(timer); resolve(msg); });
+      stdio.stdin?.write(JSON.stringify({ jsonrpc: "2.0", id, method, params }) + "\n");
+    });
+  };
+
+  before(async () => {
+    const repo = path.join(__dirname, "..");
+    const started = await new Promise<{ proc: ChildProcess; port: number }>((resolve, reject) => {
+      const child = spawn("node", [path.join(repo, "dist", "serve.js")], {
+        stdio: ["pipe", "pipe", "pipe"],
+        env: { ...process.env, PORT: "0", BASE_URL: "http://127.0.0.1" },
+      });
+      const timer = setTimeout(() => { child.kill("SIGKILL"); reject(new Error("startup timeout")); }, 60000);
+      child.stderr?.on("data", (b: Buffer) => {
+        const m = b.toString().match(/running on http:\/\/localhost:(\d+)/);
+        if (m) { clearTimeout(timer); resolve({ proc: child, port: parseInt(m[1], 10) }); }
+      });
+      child.on("error", (e) => { clearTimeout(timer); reject(e); });
+    });
+    api = started.proc;
+
+    stdio = spawn("node", [path.join(repo, "dist", "index.js")], {
+      stdio: ["pipe", "pipe", "pipe"],
+      env: { ...process.env, AGENTDEALS_API_URL: `http://127.0.0.1:${started.port}` },
+    });
+    let buffered = "";
+    stdio.stdout?.on("data", (b: Buffer) => {
+      buffered += b.toString();
+      let cut: number;
+      while ((cut = buffered.indexOf("\n")) >= 0) {
+        const line = buffered.slice(0, cut).trim();
+        buffered = buffered.slice(cut + 1);
+        if (!line) continue;
+        try {
+          const msg = JSON.parse(line) as { id?: number };
+          if (typeof msg.id === "number" && pending.has(msg.id)) {
+            pending.get(msg.id)!(msg as Record<string, unknown>);
+            pending.delete(msg.id);
+          }
+        } catch { /* a partial frame is not a message */ }
+      }
+    });
+    await once(stdio.stderr!, "data");
+    await rpc("initialize", { protocolVersion: "2025-06-18", capabilities: {}, clientInfo: { name: "test", version: "1.0.0" } });
+    stdio.stdin?.write(JSON.stringify({ jsonrpc: "2.0", method: "notifications/initialized" }) + "\n");
+  });
+
+  after(() => { stdio?.kill("SIGKILL"); api?.kill("SIGKILL"); });
+
+  const STDIO_CALLS: [string, unknown][] = [
+    ["search_deals", {}],
+    ["search_deals", { vendor: "supabase" }],
+    ["track_changes", {}],
+    ["compare_vendors", { vendors: ["Supabase", "Neon"] }],
+    ["plan_stack", { mode: "recommend", use_case: "Next.js SaaS app" }],
+    ["plan_stack", { mode: "estimate", services: ["Vercel"] }],
+  ];
+
+  it("checks every product call the stdio server proxies", () => {
+    assert.strictEqual(STDIO_CALLS.length, 6);
+  });
+
+  for (const [name, args] of STDIO_CALLS) {
+    const label = `${name} ${JSON.stringify(args)}`;
+    it(`${label} keeps the citation through the proxy`, async () => {
+      const msg = await rpc("tools/call", { name, arguments: args }) as {
+        result?: { content?: { text?: string }[] };
+      };
+      const text = msg.result?.content?.[0]?.text ?? "";
+      const json = JSON.parse(text) as { _provenance?: Record<string, unknown> };
+      assert.ok(json._provenance, `${label} lost the citation in the proxy`);
+      assert.ok(String(json._provenance.cite_as).startsWith(CITATION_OPENING));
+      assert.strictEqual(json._provenance.note, EXPECTED_NOTE);
+    });
+  }
+});


### PR DESCRIPTION
Refs #1256. Base is `40ca9fe`.

Four product tools and our busiest JSON route returned **0** mentions of AgentDeals. A model that read 145,713 characters of `/api/changes` had no string to attribute it to, and — per the PM's eval — the only URL in the payload was `supabase.com/pricing`, so 10 of 15 control answers cited the vendor instead of us.

Every product response now carries a `_provenance` block. The three strings are the PM's, verbatim.

## What the composition does

`cite_as` is composed, not stored. The page it names is **derived from the response** rather than chosen per call site, so it is the narrowest page that actually contains the whole response:

| response | cites |
|---|---|
| every record is one vendor | `/vendor/<slug>` |
| records span vendors in one category | `/category/<slug>` |
| records span categories | the site root, or the route's own listing page |

`/api/details/supabase` composes to exactly the PM's example string.

**Deriving it caught a case hand-picking would have got wrong.** `search_deals({vendor:"supabase"})` returns Supabase *plus five alternatives*, so the obvious answer is `/vendor/supabase`. I checked instead of assuming: that page names **1 of the 5** alternatives, and `/category/databases` names **5 of 5**. The derived answer is the correct one.

Date is the record's, never the clock: `checked <date>` for one record, `oldest figure checked <date>` for a set. Where a payload projects the field under another name — the stack planner emits `verified_date`, change records carry `recorded_date` — it is read; where a payload carries no date at all (cost estimates), the date is looked up from the index by slug rather than fabricated.

**AC-4** is structural. The date is computed over the records we rank; `verified_records` and `withheld_records` count them separately, and `gated_note` ships only when the response holds a gated record.

**AC-3.** The deference sentence is `DEFERENCE`, reused unchanged. It ships **exactly once per response** — suppressed inside `_provenance` where `_agent` already carries it — and the tests assert the count, not the presence.

## Both transports

`src/index.ts` — the stdio server, a separate implementation from the HTTP one — proxies our own JSON API, so it inherited the block for free on most routes. Two paths projected the payload down to a sub-object (`data.offer`, and a rebuilt results envelope) and dropped it. Those now carry it forward. A test boots both servers and asserts the citation survives the proxy on 6 calls.

## Measured

Paired census, `main` worktree vs branch, one instrument, 20 surfaces:

| | main | branch |
|---|---|---|
| surfaces carrying a `_provenance` field | 0 | **20** |
| surfaces naming AgentDeals | 3 | **20** |

The 3 on `main` are not citations — they are the `agentdeals.dev` host inside the signal-POST URL, which is why **AC-6 asserts on the field by key**, as the PM revised it. `/api/offers` passes a substring test on `main` today with no change at all.

**AC-5 — added characters, absolute and as a share:** 227–535 characters, 0.2%–52.6%. Worst share is `/api/costs?services=Vercel`: 741 → 1,131 (+390, 52.6%). Best is `/api/changes?limit=2`: +400 on 203,223 (0.2%). Responses carrying `_agent` pay less (227–322) because the deference sentence is not repeated.

## Verification

- **3,395 tests, 51 new.** `main` measured at 3,344 in a worktree of the same commit. **5 failing on both**, unchanged and pre-existing — `price-evidence-grade:208`, `risk-badge:82`, `search-recording-wiring:61` and `:101`, `stale-page-facts:152`. Diagnosis on #1190.
- **Negative control:** `test/served-response-citation.test.ts` imports nothing new, so it runs against `main` unmodified. **16 of 18 red there**, 18 of 18 green here. The 2 that pass on `main` are the population assertions, so the guard cannot pass by checking nothing.
- **23 mutations, 23 killed, 0 survivors**, none killed by `tsc` alone (`scripts/mutate-1256.sh`).
- **Sweep of all 2,577 sitemap paths** against a `main` worktree: **2,577 byte-identical, 0 moved.** The change is JSON-only, including after moving `BASE_URL` into a module that both servers import.
- **Real MCP both ways.** `initialize` → `tools/call` over streamable-HTTP for the four tools, and over stdio against a local API for six calls.
- **Every page cited returns 200.** A test extracts the URL from every `cite_as` produced across the whole battery and fetches it. This is a guard, not a review — the PM's own first draft named `/category/database`, which 404s.

## One thing I did not do, and it is yours

`search_deals({category:"list"})` returns a **bare JSON array**, so it cannot carry a field. I wrapped it as `{categories: [...]}` — the shape `/api/categories` already publishes — and `test/http.test.ts` went red in two places on `assert.ok(Array.isArray(categories))`, in both server implementations.

**I reverted it.** The response holds no verified figures, only category names and counts, so its citation was the only dateless one of the 20; and a published response shape with tests on it is your call, not mine. Aligning the two surfaces is a one-line change once you say so.

Also not covered: 19 further `/api/*` routes exist. I cited the 13 that publish vendor records and both MCP servers consume. The rest are telemetry and referral operations — `/api/metrics`, `/api/traffic`, `/api/pageviews`, `/api/query-log`, `/api/stats` and similar — which report on us rather than on a record, and have no verification date to carry.