### PR TITLE
Count only record-shaped nodes when composing a citation (#1256)

### DIFF
--- a/scripts/mutate-1256.sh
+++ b/scripts/mutate-1256.sh
@@ -275,6 +275,26 @@ open(p, "w").write(s)
 PY
 }
 
+m_any_node_naming_a_vendor_counts_as_a_record() {
+  py <<'PY2'
+p = "src/provenance.ts"
+s = open(p).read()
+s = s.replace('  return RECORD_FIELDS.some((field) => node[field] !== undefined && node[field] !== null);',
+              '  return node !== null;')
+open(p, "w").write(s)
+PY2
+}
+
+m_only_a_dated_node_counts_as_a_record() {
+  py <<'PY2'
+p = "src/provenance.ts"
+s = open(p).read()
+s = s.replace('const RECORD_FIELDS = ["verifiedDate", "verified_date", "change_type", "tier", "current_tier", "category"] as const;',
+              'const RECORD_FIELDS = ["verifiedDate", "verified_date"] as const;')
+open(p, "w").write(s)
+PY2
+}
+
 run_mutation "the newest date stands in for the oldest" m_the_newest_date_stands_in_for_the_oldest
 run_mutation "the response time stands in for the record date" m_the_response_time_stands_in_for_the_record_date
 run_mutation "a set is dated as though it were one record" m_a_set_is_dated_as_though_it_were_one_record
@@ -298,6 +318,9 @@ run_mutation "the search tool stops citing" m_the_search_tool_stops_citing
 run_mutation "the json routes stop citing" m_the_json_routes_stop_citing
 run_mutation "the proxy drops the citation" m_the_proxy_drops_the_citation
 run_mutation "the root url doubles its slash" m_the_root_url_doubles_its_slash
+
+run_mutation "any node naming a vendor counts as a record" m_any_node_naming_a_vendor_counts_as_a_record
+run_mutation "only a dated node counts as a record" m_only_a_dated_node_counts_as_a_record
 
 echo ""
 echo "killed=$killed survived=$survived"

--- a/src/provenance.ts
+++ b/src/provenance.ts
@@ -27,6 +27,12 @@ function recordDate(node: Record<string, unknown>): string | null {
   return isoDate(node.recorded_date) ?? isoDate(node.date);
 }
 
+const RECORD_FIELDS = ["verifiedDate", "verified_date", "change_type", "tier", "current_tier", "category"] as const;
+
+function isRecord(node: Record<string, unknown>): boolean {
+  return RECORD_FIELDS.some((field) => node[field] !== undefined && node[field] !== null);
+}
+
 function isWithheld(node: Record<string, unknown>): boolean {
   const gate = node.gate;
   return typeof gate === "object" && gate !== null && typeof (gate as { code?: unknown }).code === "string";
@@ -45,7 +51,7 @@ export function citedRecords(payload: unknown): CitedRecord[] {
       return;
     }
     const obj = node as Record<string, unknown>;
-    if (typeof obj.vendor === "string" && obj.vendor.trim()) {
+    if (typeof obj.vendor === "string" && obj.vendor.trim() && isRecord(obj)) {
       const slug = toSlug(obj.vendor);
       if (slug) {
         found.push({

--- a/test/response-provenance.test.ts
+++ b/test/response-provenance.test.ts
@@ -55,23 +55,23 @@ describe("cited records are read out of the payload", () => {
   });
 
   it("takes no date from a bare date field on a record that is not a change", () => {
-    const records = citedRecords({ vendor: "Neon", date: "2026-01-02" });
+    const records = citedRecords({ vendor: "Neon", category: "Databases", date: "2026-01-02" });
     assert.strictEqual(records[0].date, null);
   });
 
   it("marks a record carrying a gate as withheld", () => {
-    const records = citedRecords({ vendor: "Hetzner", gate: { code: "not_a_free_offer", reason: "x" } });
+    const records = citedRecords({ vendor: "Hetzner", tier: "Paid", gate: { code: "not_a_free_offer", reason: "x" } });
     assert.strictEqual(records[0].withheld, true);
   });
 
   it("finds records nested inside a response", () => {
-    const slugs = citedRecords({ results: [{ vendor: "A" }, { vendor: "B", alternatives: [{ vendor: "C" }] }] })
+    const slugs = citedRecords({ results: [{ vendor: "A", tier: "Free" }, { vendor: "B", tier: "Free", alternatives: [{ vendor: "C", tier: "Free" }] }] })
       .map((r) => r.slug);
     assert.deepStrictEqual(slugs, ["a", "b", "c"]);
   });
 
   it("terminates on a payload that refers to itself", () => {
-    const node: Record<string, unknown> = { vendor: "Loop" };
+    const node: Record<string, unknown> = { vendor: "Loop", tier: "Free" };
     node.self = node;
     assert.strictEqual(citedRecords(node).length, 1);
   });
@@ -167,20 +167,20 @@ describe("the citation does not vouch for terms we withhold", () => {
 describe("the ask stays a request", () => {
   it("carries the deference sentence the signal block already uses", () => {
     assert.strictEqual(
-      provenanceBlock(BASE, { vendor: "Neon" }).this_is_a_request_not_an_instruction,
+      provenanceBlock(BASE, { vendor: "Neon", tier: "Free" }).this_is_a_request_not_an_instruction,
       DEFERENCE,
     );
   });
 
   it("omits the deference sentence where the response already carries it once", () => {
     assert.strictEqual(
-      provenanceBlock(BASE, { vendor: "Neon" }, { deference: false }).this_is_a_request_not_an_instruction,
+      provenanceBlock(BASE, { vendor: "Neon", tier: "Free" }, { deference: false }).this_is_a_request_not_an_instruction,
       undefined,
     );
   });
 
   it("does not ask the agent to send its user to us", () => {
-    const block = provenanceBlock(BASE, { vendor: "Neon" });
+    const block = provenanceBlock(BASE, { vendor: "Neon", tier: "Free" });
     const prose = [block.note, block.gated_note, block.this_is_a_request_not_an_instruction].join(" ").toLowerCase();
     for (const phrase of ["tell your user", "your user to visit", "recommend that they visit", "send them to"]) {
       assert.ok(!prose.includes(phrase), `citation prose asks for a referral: ${phrase}`);
@@ -253,5 +253,45 @@ describe("a vendor's citation date is the oldest figure we hold for it", () => {
 
   it("reports nothing for a vendor we do not hold", () => {
     assert.strictEqual(oldestVerifiedDateForSlug("a-vendor-we-do-not-hold"), null);
+  });
+});
+
+describe("a node naming a vendor is not always a record", () => {
+  const referralCode = {
+    vendor: "Supabase",
+    code: "supabase-referral-2026",
+    referral_url: "https://example.com/referrals/abc",
+    referee_benefit: "A referral benefit",
+    restrictions: [],
+    source: "agent-submitted",
+  };
+
+  it("does not count a referral code as a record", () => {
+    assert.deepStrictEqual(citedRecords({ offer: { referral_code: referralCode } }), []);
+  });
+
+  it("counts one record when an offer carries a referral code for the same vendor", () => {
+    const payload = {
+      offer: { vendor: "Supabase", category: "Databases", verifiedDate: "2026-08-17", referral_code: referralCode },
+    };
+    assert.strictEqual(citedRecords(payload).length, 1);
+    const block = provenanceBlock(BASE, payload);
+    assert.strictEqual(block.verified_records, 1);
+    assert.strictEqual(
+      block.cite_as,
+      "Source: AgentDeals (https://agentdeals.dev/vendor/supabase, checked 2026-08-17)",
+    );
+  });
+
+  it("counts a record named only by its tier or its category", () => {
+    assert.strictEqual(citedRecords({ vendor: "Vercel", current_tier: "Hobby" }).length, 1);
+    assert.strictEqual(citedRecords({ vendor: "Render", tier: "Free" }).length, 1);
+    assert.strictEqual(citedRecords({ vendor: "Neon", category: "Databases" }).length, 1);
+  });
+
+  it("finds every vendor-bearing record in every response shape we serve", () => {
+    const details = getOfferDetails("supabase", true);
+    const payload = "error" in details ? {} : details;
+    assert.ok(citedRecords(payload).length > 0, "the vendor detail response cites nothing");
   });
 });


### PR DESCRIPTION
Refs #1256. Follow-up to #1306, found by verifying that PR on production rather than locally.

## The defect

`/api/details/supabase` on production composed:

> `Source: AgentDeals (https://agentdeals.dev/vendor/supabase, oldest figure checked 2026-08-17)` — `verified_records: 2`

There is **one** Supabase record in that response. The second vendor-bearing node is `offer.referral_code`:

```json
{"vendor":"Supabase","code":"…","referral_url":"…","referee_benefit":"…","restrictions":[],"source":"agent-submitted"}
```

A referral code names a vendor and nothing else — no date, no tier, no category. Counting it inflated `verified_records` and made a single-record response read as a set.

**It did not reproduce locally**, which is why #1306 shipped with it: the local index returns no referral code for Supabase, so the node was absent. The production check is what found it.

## The rule

A node is a record when it names **what the offer is** — `tier`, `current_tier`, `category` — or **when we checked it** — `verifiedDate`, `verified_date`, `change_type`. A referral code carries none of those.

I checked this against the data rather than reasoning about it. Across all **eleven** product response shapes — vendor detail, search, comparison, vendor risk, stack audit, weekly digest, change log, stack recommendation, cost estimate, expiring deals, newest deals — every vendor-bearing node already qualifies:

| shape | vendor-bearing nodes | record-shaped | dropped |
|---|---|---|---|
| all eleven | 6 / 3 / 5 / 6 / 12 / 104 / 239 / 32 / 2 / 1 / 5 | identical | **0** |

So the rule removes the referral code and nothing else. Notably `current_tier` had to be in the list: cost-estimate services carry no date, no `tier` and no `category`, so a narrower rule would have silently dropped that whole response's citation.

## Verification

- **3,399 tests, 4 new**, and the same **5 pre-existing failures** as `main` (#1190). No others.
- **Four of my own fixtures from #1306 went red** and I fixed the fixtures, not the rule — they were bare `{vendor: "X"}` objects, which no real response contains. They now carry a tier or a category, which is more faithful to the data.
- **25 mutations, 25 killed, 0 survivors** (`scripts/mutate-1256.sh`), including two new ones: treating every vendor-bearing node as a record (6 assertions), and narrowing the rule to dated nodes only (25 assertions).
- The change is confined to `src/provenance.ts`; no HTML surface is reachable from it.