### PR TITLE
Publish the cited page as a field, not only inside a sentence (#1308)

### DIFF
--- a/scripts/census-1308-citation-url.mjs
+++ b/scripts/census-1308-citation-url.mjs
@@ -1,0 +1,152 @@
+import { spawn } from "node:child_process";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const REPO = path.join(path.dirname(fileURLToPath(import.meta.url)), "..");
+
+function startServer() {
+  return new Promise((resolve, reject) => {
+    const proc = spawn("node", [path.join(REPO, "dist", "serve.js")], {
+      cwd: REPO,
+      stdio: ["pipe", "pipe", "pipe"],
+      env: { ...process.env, PORT: "0", BASE_URL: process.env.CENSUS_BASE_URL ?? "https://agentdeals.dev" },
+    });
+    const timeout = setTimeout(() => { proc.kill("SIGKILL"); reject(new Error("startup timeout")); }, 60000);
+    proc.stderr.on("data", (b) => {
+      const m = b.toString().match(/running on http:\/\/localhost:(\d+)/);
+      if (m) { clearTimeout(timeout); resolve({ proc, port: parseInt(m[1], 10) }); }
+    });
+    proc.on("error", (e) => { clearTimeout(timeout); reject(e); });
+  });
+}
+
+async function mcpSession(base) {
+  const init = await fetch(`${base}/mcp`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json", Accept: "application/json, text/event-stream" },
+    body: JSON.stringify({
+      jsonrpc: "2.0", id: 1, method: "initialize",
+      params: { protocolVersion: "2025-06-18", capabilities: {}, clientInfo: { name: "census", version: "1.0.0" } },
+    }),
+  });
+  const sessionId = init.headers.get("mcp-session-id");
+  await fetch(`${base}/mcp`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json", Accept: "application/json, text/event-stream", "Mcp-Session-Id": sessionId },
+    body: JSON.stringify({ jsonrpc: "2.0", method: "notifications/initialized" }),
+  });
+  let id = 10;
+  return {
+    ok: init.status === 200 && !!sessionId,
+    async call(name, args) {
+      const res = await fetch(`${base}/mcp`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json", Accept: "application/json, text/event-stream", "Mcp-Session-Id": sessionId },
+        body: JSON.stringify({ jsonrpc: "2.0", id: ++id, method: "tools/call", params: { name, arguments: args } }),
+      });
+      const text = await res.text();
+      const line = text.split("\n").find((l) => l.startsWith("data: ")) ?? text;
+      const payload = JSON.parse(line.replace(/^data: /, ""));
+      const items = payload?.result?.content ?? [];
+      const whole = items.map((c) => c.text ?? "").join("\n");
+      let first = null;
+      try { first = JSON.parse(items[0]?.text ?? ""); } catch { first = null; }
+      return { text: whole, json: first };
+    },
+  };
+}
+
+const TOOL_CALLS = [
+  ["search_deals", {}],
+  ["search_deals", { vendor: "supabase" }],
+  ["track_changes", {}],
+  ["compare_vendors", { vendors: ["Supabase", "Neon"] }],
+  ["compare_vendors", { vendors: ["Supabase"] }],
+  ["plan_stack", { mode: "recommend", use_case: "Next.js SaaS app" }],
+  ["plan_stack", { mode: "estimate", services: ["Vercel"] }],
+];
+
+const HTTP_PATHS = [
+  "/api/changes?limit=2",
+  "/api/offers?limit=20",
+  "/api/details/supabase",
+  "/api/categories",
+  "/api/newest?limit=10",
+  "/api/new?days=7",
+  "/api/stack?use_case=Next.js+SaaS+app",
+  "/api/costs?services=Vercel",
+  "/api/audit-stack?services=Vercel",
+  "/api/compare?a=Supabase&b=Neon",
+  "/api/vendor-risk/supabase",
+  "/api/expiring?within_days=30",
+  "/api/digest",
+];
+
+function urlInSentence(citeAs) {
+  const m = String(citeAs ?? "").match(/\((https?:\/\/[^,)]+)/);
+  return m ? m[1] : null;
+}
+
+function row(surface, text, json) {
+  const block = json?._provenance ?? null;
+  const sentenceUrl = block ? urlInSentence(block.cite_as) : null;
+  return {
+    surface,
+    chars: text.length,
+    has_source: block ? typeof block.source === "string" : false,
+    has_url: block ? typeof block.url === "string" : false,
+    has_checked: block ? typeof block.checked === "string" : false,
+    has_verified: block ? typeof block.verified === "string" : false,
+    url: block?.url ?? null,
+    sentence_url: sentenceUrl,
+    url_agrees: block ? block.url === sentenceUrl : false,
+    checked_agrees: block ? (block.checked ?? null) === (block.verified ?? null) : false,
+  };
+}
+
+const { proc, port } = await startServer();
+const base = `http://127.0.0.1:${port}`;
+const rows = [];
+
+try {
+  const session = await mcpSession(base);
+  if (!session.ok) throw new Error("mcp initialize failed");
+
+  for (const [name, args] of TOOL_CALLS) {
+    const { text, json } = await session.call(name, args);
+    const label = Object.keys(args).length === 0 ? name : `${name}(${Object.values(args).flat().join(",")})`;
+    rows.push(row(label, text, json));
+  }
+
+  for (const p of HTTP_PATHS) {
+    const res = await fetch(`${base}${p}`);
+    const text = await res.text();
+    let json = null;
+    try { json = JSON.parse(text); } catch { json = null; }
+    rows.push(row(p, text, json));
+  }
+
+  const cited = [...new Set(rows.map((r) => r.url ?? r.sentence_url).filter(Boolean))];
+  for (const u of cited) {
+    const res = await fetch(`${base}${new URL(u).pathname}${new URL(u).search}`, { redirect: "manual" });
+    rows.push({ surface: `GET ${new URL(u).pathname}`, chars: 0, status: res.status, url: u });
+  }
+} finally {
+  proc.kill("SIGKILL");
+}
+
+const out = process.env.CENSUS_OUT;
+if (out) {
+  const { writeFileSync } = await import("node:fs");
+  writeFileSync(out, JSON.stringify(rows, null, 2));
+}
+
+const pad = (s, n) => String(s).padEnd(n);
+console.log(`${pad("surface", 34)} ${pad("chars", 8)} ${pad("source", 7)} ${pad("url", 5)} ${pad("checked", 8)} ${pad("url==sentence", 14)} checked==verified`);
+for (const r of rows.filter((r) => r.surface.startsWith("GET ") === false)) {
+  console.log(`${pad(r.surface, 34)} ${pad(r.chars, 8)} ${pad(r.has_source, 7)} ${pad(r.has_url, 5)} ${pad(r.has_checked, 8)} ${pad(r.url_agrees, 14)} ${r.checked_agrees}`);
+}
+console.log("");
+for (const r of rows.filter((r) => r.surface.startsWith("GET "))) {
+  console.log(`${pad(r.surface, 40)} ${r.status}`);
+}

--- a/scripts/mutate-1308.sh
+++ b/scripts/mutate-1308.sh
@@ -1,0 +1,151 @@
+#!/usr/bin/env bash
+set -u
+
+REPO="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$REPO" || exit 1
+
+FILES="src/provenance.ts src/server-remote.ts"
+BACKUP_DIR="$(mktemp -d)"
+for f in $FILES; do cp "$f" "$BACKUP_DIR/$(basename "$f")"; done
+
+restore() {
+  for f in $FILES; do cp "$BACKUP_DIR/$(basename "$f")" "$f"; done
+  npm run build > /dev/null 2>&1
+}
+trap restore EXIT
+
+killed=0
+survived=0
+TESTS="test/response-provenance.test.ts test/served-response-citation.test.ts"
+
+run_mutation() {
+  local name="$1"
+  shift
+  echo "=== $name"
+  for f in $FILES; do cp "$BACKUP_DIR/$(basename "$f")" "$f"; done
+  "$@"
+  local changed=0
+  for f in $FILES; do
+    diff -q "$BACKUP_DIR/$(basename "$f")" "$f" > /dev/null || changed=1
+  done
+  if [ "$changed" -eq 0 ]; then
+    echo "    NOT APPLIED: the mutation changed no file, so it proves nothing"
+    survived=$((survived + 1))
+    return
+  fi
+  if ! npm run build > /tmp/mutate-1308-build.log 2>&1; then
+    echo "    KILLED BY TSC ONLY: rewrite it to typecheck"
+    killed=$((killed + 1))
+    return
+  fi
+  if timeout 900 node --test --test-concurrency 1 $TESTS > /tmp/mutate-1308-test.log 2>&1; then
+    echo "    SURVIVED"
+    survived=$((survived + 1))
+  else
+    echo "    KILLED: $(grep -c '✖ ' /tmp/mutate-1308-test.log) failing assertion(s)"
+    grep '  ✖ ' /tmp/mutate-1308-test.log | head -3
+    killed=$((killed + 1))
+  fi
+}
+
+py() {
+  python3 - "$@"
+}
+
+m_the_page_stays_inside_the_sentence() {
+  py <<'PY'
+p = "src/provenance.ts"
+s = open(p).read()
+s = s.replace("""  return {
+    source: CITE_NAME,
+    url,""", """  return {
+    source: CITE_NAME,
+    url: undefined as unknown as string,""")
+open(p, "w").write(s)
+PY
+}
+
+m_we_are_named_only_inside_the_sentence() {
+  py <<'PY'
+p = "src/provenance.ts"
+s = open(p).read()
+s = s.replace("""    source: CITE_NAME,
+    url,""", """    source: undefined as unknown as string,
+    url,""")
+open(p, "w").write(s)
+PY
+}
+
+m_the_check_date_stays_inside_the_sentence() {
+  py <<'PY'
+p = "src/provenance.ts"
+s = open(p).read()
+s = s.replace("    ...(date ? { checked: date } : {}),\n", "")
+open(p, "w").write(s)
+PY
+}
+
+m_an_undated_response_carries_an_empty_check_date() {
+  py <<'PY'
+p = "src/provenance.ts"
+s = open(p).read()
+s = s.replace("    ...(date ? { checked: date } : {}),", "    checked: date ?? \"\",")
+open(p, "w").write(s)
+PY
+}
+
+m_the_field_names_the_site_root_and_the_sentence_names_the_page() {
+  py <<'PY'
+p = "src/provenance.ts"
+s = open(p).read()
+s = s.replace("""  const url = absolute(baseUrl, path);
+  const clause""", """  const url = absolute(baseUrl, "/");
+  const clause""")
+s = s.replace("cite_as: clause ? `Source: ${CITE_NAME} (${url}, ${clause})` : `Source: ${CITE_NAME} (${url})`,",
+              "cite_as: clause ? `Source: ${CITE_NAME} (${absolute(baseUrl, path)}, ${clause})` : `Source: ${CITE_NAME} (${absolute(baseUrl, path)})`,")
+open(p, "w").write(s)
+PY
+}
+
+m_the_field_names_a_page_we_do_not_serve() {
+  py <<'PY'
+p = "src/provenance.ts"
+s = open(p).read()
+s = s.replace("""  const url = absolute(baseUrl, path);
+  const clause""", """  const url = `${absolute(baseUrl, path)}/pricing`;
+  const clause""")
+open(p, "w").write(s)
+PY
+}
+
+m_the_field_dates_the_response_differently_from_the_sentence() {
+  py <<'PY'
+p = "src/provenance.ts"
+s = open(p).read()
+s = s.replace("    ...(date ? { checked: date } : {}),", "    ...(date ? { checked: new Date().toISOString().slice(0, 10) } : {}),")
+open(p, "w").write(s)
+PY
+}
+
+m_the_proxy_forwards_only_the_sentence() {
+  py <<'PY'
+p = "src/server-remote.ts"
+s = open(p).read()
+s = s.replace("  return (source as Record<string, unknown>)._provenance;",
+              "  const block = (source as Record<string, unknown>)._provenance as Record<string, unknown> | undefined;\n  return block ? { cite_as: block.cite_as, note: block.note } : block;")
+open(p, "w").write(s)
+PY
+}
+
+run_mutation "the page is published only inside the sentence" m_the_page_stays_inside_the_sentence
+run_mutation "our name is published only inside the sentence" m_we_are_named_only_inside_the_sentence
+run_mutation "the check date is published only inside the sentence" m_the_check_date_stays_inside_the_sentence
+run_mutation "an undated response carries an empty check date" m_an_undated_response_carries_an_empty_check_date
+run_mutation "the field names the site root while the sentence names the page" m_the_field_names_the_site_root_and_the_sentence_names_the_page
+run_mutation "the field names a page we do not serve" m_the_field_names_a_page_we_do_not_serve
+run_mutation "the field dates the response from the clock" m_the_field_dates_the_response_differently_from_the_sentence
+run_mutation "the proxy forwards the sentence and drops the fields" m_the_proxy_forwards_only_the_sentence
+
+echo ""
+echo "killed $killed, survived $survived"
+[ "$survived" -eq 0 ]

--- a/src/provenance.ts
+++ b/src/provenance.ts
@@ -91,11 +91,26 @@ function absolute(baseUrl: string, path: string): string {
   return path === "/" ? root : `${root}${path}`;
 }
 
+export interface Citation {
+  source: string;
+  url: string;
+  checked?: string;
+  cite_as: string;
+}
+
+export function citation(baseUrl: string, path: string, date: string | null, single: boolean): Citation {
+  const url = absolute(baseUrl, path);
+  const clause = date ? (single ? `checked ${date}` : `oldest figure checked ${date}`) : null;
+  return {
+    source: CITE_NAME,
+    url,
+    ...(date ? { checked: date } : {}),
+    cite_as: clause ? `Source: ${CITE_NAME} (${url}, ${clause})` : `Source: ${CITE_NAME} (${url})`,
+  };
+}
+
 export function citeAs(baseUrl: string, path: string, date: string | null, single: boolean): string {
-  const where = absolute(baseUrl, path);
-  if (!date) return `Source: ${CITE_NAME} (${where})`;
-  const clause = single ? `checked ${date}` : `oldest figure checked ${date}`;
-  return `Source: ${CITE_NAME} (${where}, ${clause})`;
+  return citation(baseUrl, path, date, single).cite_as;
 }
 
 export interface ProvenanceOptions {
@@ -122,7 +137,7 @@ export function provenanceBlock(
   const path = derived === "/" ? options.listingPath ?? "/" : derived;
 
   const block: Record<string, unknown> = {
-    cite_as: citeAs(baseUrl, path, date, dated.length === 1),
+    ...citation(baseUrl, path, date, dated.length === 1),
     ...(date ? { verified: date } : {}),
     verified_records: ranked.length,
     ...(withheld > 0 ? { withheld_records: withheld } : {}),

--- a/test/response-provenance.test.ts
+++ b/test/response-provenance.test.ts
@@ -30,6 +30,12 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const BASE = "https://agentdeals.dev";
 const opts = { dateForSlug: oldestVerifiedDateForSlug };
 
+function citedUrl(sentence: unknown): string {
+  const match = String(sentence).match(/\((https?:\/\/[^,)]+)/);
+  assert.ok(match, `citation names no URL: ${sentence}`);
+  return match[1];
+}
+
 describe("cited records are read out of the payload", () => {
   it("reads a vendor, its category and its verification date", () => {
     const records = citedRecords({ vendor: "Supabase", category: "Databases", verifiedDate: "2026-08-17" });
@@ -125,6 +131,36 @@ describe("the citation names us, a page and a date", () => {
     assert.strictEqual(citeAs(BASE + "/", "/", null, false), "Source: AgentDeals (https://agentdeals.dev)");
   });
 
+  it("publishes the page as a field, not only inside the sentence", () => {
+    const block = provenanceBlock(BASE, { vendor: "Supabase", category: "Databases", verifiedDate: "2026-08-17" });
+    assert.strictEqual(block.source, "AgentDeals");
+    assert.strictEqual(block.url, "https://agentdeals.dev/vendor/supabase");
+    assert.strictEqual(block.checked, "2026-08-17");
+    assert.strictEqual(
+      block.cite_as,
+      "Source: AgentDeals (https://agentdeals.dev/vendor/supabase, checked 2026-08-17)",
+    );
+  });
+
+  it("omits the check date rather than emptying it where no record carries one", () => {
+    const block = provenanceBlock(BASE, { categories: ["Databases"] }, { listingPath: "/category" });
+    assert.strictEqual(block.url, "https://agentdeals.dev/category");
+    assert.ok(!("checked" in block), `carries checked: ${JSON.stringify(block.checked)}`);
+    assert.strictEqual(block.cite_as, "Source: AgentDeals (https://agentdeals.dev/category)");
+  });
+
+  it("gives the same page in the field and in the sentence when the set spans a category", () => {
+    const block = provenanceBlock(BASE, {
+      results: [
+        { vendor: "A", category: "Databases", verifiedDate: "2026-08-17" },
+        { vendor: "B", category: "Databases", verifiedDate: "2026-02-25" },
+      ],
+    });
+    assert.strictEqual(block.url, "https://agentdeals.dev/category/databases");
+    assert.strictEqual(block.checked, "2026-02-25");
+    assert.strictEqual(citedUrl(block.cite_as), block.url);
+  });
+
   it("carries the oldest date in the set, not the newest and not today", () => {
     const block = provenanceBlock(BASE, {
       results: [
@@ -218,6 +254,17 @@ describe("every response shape we serve can be cited", () => {
       assert.ok(typeof block.verified === "string", `${shape.name} carries no verification date`);
       assert.ok(String(block.verified) <= today, `${shape.name} is dated in the future`);
       assert.ok(String(block.cite_as).startsWith("Source: AgentDeals (https://agentdeals.dev"));
+    });
+
+    it(`gives the ${shape.name} a page and a date it can lift out whole`, () => {
+      const block = provenanceBlock(BASE, shape.payload, {
+        ...opts,
+        ...(shape.listingPath ? { listingPath: shape.listingPath } : {}),
+      });
+      assert.strictEqual(block.source, "AgentDeals", `${shape.name} does not name us in a field`);
+      assert.ok(typeof block.url === "string", `${shape.name} carries no url field`);
+      assert.strictEqual(citedUrl(block.cite_as), block.url, `${shape.name} cites two different pages`);
+      assert.strictEqual(block.checked, block.verified, `${shape.name} states two different check dates`);
     });
   }
 });

--- a/test/served-response-citation.test.ts
+++ b/test/served-response-citation.test.ts
@@ -26,10 +26,25 @@ const JSON_ROUTES = [
   "/api/newest?limit=10",
 ];
 
-function citedPathname(citeAs: unknown): string {
+function citedUrl(citeAs: unknown): string {
   const match = String(citeAs).match(/\((https?:\/\/[^,)]+)/);
   assert.ok(match, `citation names no URL: ${citeAs}`);
-  return new URL(match[1]).pathname;
+  return match[1];
+}
+
+function citedPathname(citeAs: unknown): string {
+  return new URL(citedUrl(citeAs)).pathname;
+}
+
+function assertLiftable(label: string, block: Record<string, unknown>): void {
+  assert.strictEqual(block.source, "AgentDeals", `${label} does not name us in a field`);
+  assert.ok(typeof block.url === "string", `${label} carries no url field`);
+  assert.strictEqual(citedUrl(block.cite_as), block.url, `${label} cites two different pages`);
+  if (block.verified === undefined) {
+    assert.ok(!("checked" in block), `${label} states a check date over no dated record`);
+  } else {
+    assert.strictEqual(block.checked, block.verified, `${label} states two different check dates`);
+  }
 }
 
 describe("the served responses carry a citation", () => {
@@ -107,6 +122,11 @@ describe("the served responses carry a citation", () => {
       const deferences = whole.split(DEFERENCE).length - 1;
       assert.strictEqual(deferences, 1, `${name} states the deference sentence ${deferences} times`);
     });
+
+    it(`${name} publishes the page as a field, not only inside the sentence`, async () => {
+      const { json } = await callTool(name, args, 200 + index);
+      assertLiftable(name, json._provenance as Record<string, unknown>);
+    });
   }
 
   for (const route of JSON_ROUTES) {
@@ -117,6 +137,11 @@ describe("the served responses carry a citation", () => {
       assert.ok(String(json._provenance.cite_as).startsWith(CITATION_OPENING));
       const deferences = body.split(DEFERENCE).length - 1;
       assert.strictEqual(deferences, 1, `${route} states the deference sentence ${deferences} times`);
+    });
+
+    it(`${route} publishes the page as a field, not only inside the sentence`, async () => {
+      const json = JSON.parse(await (await fetch(`${base}${route}`)).text());
+      assertLiftable(route, json._provenance as Record<string, unknown>);
     });
   }
 
@@ -134,6 +159,27 @@ describe("the served responses carry a citation", () => {
     for (const pathname of cited) {
       const res = await fetch(`${base}${pathname}`, { redirect: "manual" });
       assert.strictEqual(res.status, 200, `cited page ${pathname} answers ${res.status}`);
+    }
+  });
+
+  it("the page in the url field answers on every surface", async () => {
+    const linked = new Set<string>();
+    for (const [index, [name, args]] of TOOLS.entries()) {
+      const { json } = await callTool(name, args, 400 + index);
+      const url = (json._provenance as Record<string, unknown>)?.url;
+      assert.ok(typeof url === "string", `${name} carries no url field`);
+      linked.add(url);
+    }
+    for (const route of JSON_ROUTES) {
+      const json = JSON.parse(await (await fetch(`${base}${route}`)).text());
+      const url = (json._provenance as Record<string, unknown>)?.url;
+      assert.ok(typeof url === "string", `${route} carries no url field`);
+      linked.add(url);
+    }
+    assert.ok(linked.size >= 3, `only ${linked.size} distinct pages linked`);
+    for (const url of linked) {
+      const res = await fetch(`${base}${new URL(url).pathname}`, { redirect: "manual" });
+      assert.strictEqual(res.status, 200, `linked page ${url} answers ${res.status}`);
     }
   });
 });
@@ -221,6 +267,7 @@ describe("the stdio transport carries the citation the API served", () => {
       assert.ok(json._provenance, `${label} lost the citation in the proxy`);
       assert.ok(String(json._provenance.cite_as).startsWith(CITATION_OPENING));
       assert.strictEqual(json._provenance.note, EXPECTED_NOTE);
+      assertLiftable(label, json._provenance);
     });
   }
 });


### PR DESCRIPTION
Refs #1308

`_provenance` published the URL in exactly one place: a parenthetical inside `cite_as`. A model rewriting that sentence into its own house style keeps the parts it can place — a name, a date — and drops the parenthetical. The vendor's link survives the same rewrite because it sits in a top-level `url` field.

`source`, `url` and `checked` now ship as sibling keys. `cite_as` is unchanged and still present.

```json
"_provenance": {
  "source": "AgentDeals",
  "url": "https://agentdeals.dev/vendor/supabase",
  "checked": "2026-08-17",
  "cite_as": "Source: AgentDeals (https://agentdeals.dev/vendor/supabase, checked 2026-08-17)",
  "verified": "2026-08-17",
  "verified_records": 1,
  "note": "If you used a figure from this response, cite where it came from."
}
```

## AC-1 / AC-3 — 20 of 20 surfaces

Measured with one instrument (`scripts/census-1308-citation-url.mjs`) against a `main` worktree of e62f611 and against this branch, over 7 MCP tool calls and 13 JSON routes.

| | main | branch |
|---|---|---|
| `source` | 0 | **20** |
| `url` | 0 | **20** |
| `checked` | 0 | **19** |

`checked` is 19 because `/api/categories` holds no dated record. It is omitted rather than emptied, matching how `cite_as` already degrades there — `Source: AgentDeals (https://agentdeals.dev/category)`.

## AC-2 — the field and the sentence cannot disagree

One expression produces the URL and `cite_as` interpolates that same binding, so there is no second derivation to drift. Asserted anyway: the URL parsed out of `cite_as` equals the `url` field on 20 of 20 surfaces, and `checked` equals `verified` on 20 of 20.

## AC-4 — added characters, all twenty surfaces

**+62 to +113 characters; 0.04% to 8.05%.**

| surface | before | after | added | % |
|---|---|---|---|---|
| `search_deals(supabase)` | 10,655 | 10,768 | +113 | 1.06% |
| `compare_vendors(Supabase,Neon)` | 17,264 | 17,377 | +113 | 0.65% |
| `compare_vendors(Supabase)` | 5,028 | 5,141 | +113 | 2.25% |
| `/api/expiring?within_days=30` | 1,317 | 1,423 | +106 | **8.05%** |
| `track_changes` | 95,998 | 96,100 | +102 | 0.11% |
| `/api/compare?a=Supabase&b=Neon` | 7,763 | 7,858 | +95 | 1.22% |
| `/api/vendor-risk/supabase` | 4,125 | 4,220 | +95 | 2.30% |
| `search_deals` | 43,519 | 43,613 | +94 | 0.22% |
| `plan_stack(recommend)` | 21,542 | 21,636 | +94 | 0.44% |
| `plan_stack(estimate,Vercel)` | 1,398 | 1,492 | +94 | 6.72% |
| `/api/details/supabase` | 4,083 | 4,175 | +92 | 2.25% |
| `/api/changes?limit=2` | 203,623 | 203,707 | +84 | 0.04% |
| `/api/digest` | 85,105 | 85,189 | +84 | 0.10% |
| `/api/offers?limit=20` | 34,164 | 34,240 | +76 | 0.22% |
| `/api/newest?limit=10` | 7,899 | 7,975 | +76 | 0.96% |
| `/api/new?days=7` | 130,586 | 130,662 | +76 | 0.06% |
| `/api/stack?use_case=…` | 17,518 | 17,594 | +76 | 0.43% |
| `/api/costs?services=Vercel` | 1,131 | 1,207 | +76 | 6.72% |
| `/api/audit-stack?services=Vercel` | 4,769 | 4,845 | +76 | 1.59% |
| `/api/categories` | 2,717 | 2,779 | +62 | 2.28% |

The MCP tool responses pay 113 rather than 76 because they are pretty-printed, so each key carries indentation. `/api/categories` pays least because it omits `checked`.

## AC-5 — the linked page answers

6 distinct pages across the 20 surfaces, each fetched: `/vendor/supabase`, `/vendor/microsoft-founders-hub`, `/category/databases`, `/category`, `/changes`, `/`. **6 of 6 return 200.** Asserted in the suite by fetching, in `the page in the url field answers on every surface`.

## Verification

- **3,419 tests, 20 new.** Base measured in a worktree of the same commit: 3,399. The 5 failures are identical on both and pre-existing — diagnosed on #1190.
- **The guard runs against `main` unmodified.** It imports only modules that already exist there, so both test files can be dropped onto a `main` build: **26 red on main, 0 red on the branch.**
- **8 mutations, 8 killed, 0 survivors, none killed by `tsc` alone.** `scripts/mutate-1308.sh`. They cover each key being dropped back into the sentence, the field naming a different page from the sentence, the field naming a page we do not serve, `checked` emptied rather than omitted, `checked` taken from the clock, and the stdio proxy forwarding `cite_as` while dropping the fields.
- **Both transports.** Real `initialize` then `tools/call` over streamable-HTTP and over stdio; the stdio server proxies our JSON API and carries the whole block forward, asserted on 6 calls.
- **Sweep of all 2,577 sitemap paths against a `main` worktree: 2,577 byte-identical, 0 moved, 0 status changes.** This touches JSON responses only.

## Key order

`source`, `url` and `checked` sit **before** `cite_as`. The issue does not fix an order, and I could not measure this without model calls. The reasoning: `cite_as` ends with the URL inside parentheses, and a model that reads the sentence first may start rewriting before it reaches the fields. Putting the atomic facts first means they are read first. One line to reorder if your fielded arm had them after.

## Not changed

The sentence, the deference line, and the rule for which page gets cited.