### PR TITLE
Answer /api/changes with one shape and a page (#1309)

### DIFF
--- a/scripts/mutate-1309.sh
+++ b/scripts/mutate-1309.sh
@@ -1,0 +1,199 @@
+#!/usr/bin/env bash
+set -u
+
+REPO="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$REPO" || exit 1
+
+FILES="src/serve.ts src/data.ts src/server-remote.ts src/api-client.ts"
+BACKUP_DIR="$(mktemp -d)"
+for f in $FILES; do cp "$f" "$BACKUP_DIR/$(basename "$f")"; done
+
+restore() {
+  for f in $FILES; do cp "$BACKUP_DIR/$(basename "$f")" "$f"; done
+  npm run build > /dev/null 2>&1
+}
+trap restore EXIT
+
+killed=0
+survived=0
+TESTS="test/changes-pagination.test.ts"
+
+run_mutation() {
+  local name="$1"
+  shift
+  echo "=== $name"
+  for f in $FILES; do cp "$BACKUP_DIR/$(basename "$f")" "$f"; done
+  "$@"
+  local changed=0
+  for f in $FILES; do
+    diff -q "$BACKUP_DIR/$(basename "$f")" "$f" > /dev/null || changed=1
+  done
+  if [ "$changed" -eq 0 ]; then
+    echo "    NOT APPLIED: the mutation changed no file, so it proves nothing"
+    survived=$((survived + 1))
+    return
+  fi
+  if ! npm run build > /tmp/mutate-1309-build.log 2>&1; then
+    echo "    KILLED BY TSC ONLY: rewrite it to typecheck"
+    killed=$((killed + 1))
+    return
+  fi
+  if timeout 900 node --test --test-concurrency 1 $TESTS > /tmp/mutate-1309-test.log 2>&1; then
+    echo "    SURVIVED"
+    survived=$((survived + 1))
+  else
+    echo "    KILLED: $(grep -c '✖ ' /tmp/mutate-1309-test.log) failing assertion(s)"
+    grep '  ✖ ' /tmp/mutate-1309-test.log | head -3
+    killed=$((killed + 1))
+  fi
+}
+
+py() {
+  python3 - "$@"
+}
+
+m_limit_is_read_and_not_applied() {
+  py <<'PY'
+p = "src/serve.ts"
+s = open(p).read()
+s = s.replace("    const page = result.changes.slice(offset, offset + limit);",
+              "    const page = result.changes;")
+open(p, "w").write(s)
+PY
+}
+
+m_total_reports_the_page_not_the_window() {
+  py <<'PY'
+p = "src/serve.ts"
+s = open(p).read()
+s = s.replace("      total: result.total,\n      returned: page.length,",
+              "      total: page.length,\n      returned: page.length,")
+open(p, "w").write(s)
+PY
+}
+
+m_offset_is_read_and_not_applied() {
+  py <<'PY'
+p = "src/serve.ts"
+s = open(p).read()
+s = s.replace("    const page = result.changes.slice(offset, offset + limit);",
+              "    const page = result.changes.slice(0, limit);")
+open(p, "w").write(s)
+PY
+}
+
+m_the_singular_category_is_ignored_again() {
+  py <<'PY'
+p = "src/serve.ts"
+s = open(p).read()
+s = s.replace('const categoriesFilter = url.searchParams.get("categories") || url.searchParams.get("category") || undefined;',
+              'const categoriesFilter = url.searchParams.get("categories") || undefined;')
+open(p, "w").write(s)
+PY
+}
+
+m_a_filter_returns_a_second_shape() {
+  py <<'PY'
+p = "src/serve.ts"
+s = open(p).read()
+s = s.replace("""    res.end(JSON.stringify(cited({
+      changes: page,
+      total: result.total,""",
+              """    res.end(JSON.stringify(cited({
+      ...(vendorsFilter || categoriesFilter ? { your_stack_changes: page } : { changes: page }),
+      total: result.total,""")
+open(p, "w").write(s)
+PY
+}
+
+m_the_period_is_not_named() {
+  py <<'PY'
+p = "src/serve.ts"
+s = open(p).read()
+s = s.replace("      summary: context.summary,\n", "")
+open(p, "w").write(s)
+PY
+}
+
+m_an_unreadable_page_size_is_ignored_rather_than_refused() {
+  py <<'PY'
+p = "src/serve.ts"
+s = open(p).read()
+s = s.replace("""    if (badPaging) {
+      res.writeHead(400, { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" });
+      res.end(JSON.stringify({ error: `Invalid '${badPaging[0]}' parameter. Expected a non-negative integer.` }));
+      return;
+    }""",
+              """    if (badPaging) {
+      void badPaging;
+    }""")
+s = s.replace("    const limit = limitParam === null ? CHANGES_DEFAULT_LIMIT : parseInt(limitParam, 10);",
+              "    const limit = limitParam === null || !/^\\d+$/.test(limitParam) ? CHANGES_DEFAULT_LIMIT : parseInt(limitParam, 10);")
+s = s.replace("    const offset = offsetParam === null ? 0 : parseInt(offsetParam, 10);",
+              "    const offset = offsetParam === null || !/^\\d+$/.test(offsetParam) ? 0 : parseInt(offsetParam, 10);")
+open(p, "w").write(s)
+PY
+}
+
+m_the_whole_window_is_unreachable() {
+  py <<'PY'
+p = "src/serve.ts"
+s = open(p).read()
+s = s.replace("    const limit = limitParam === null ? CHANGES_DEFAULT_LIMIT : parseInt(limitParam, 10);",
+              "    const limit = Math.min(limitParam === null ? CHANGES_DEFAULT_LIMIT : parseInt(limitParam, 10), 50);")
+open(p, "w").write(s)
+PY
+}
+
+m_the_default_page_grows_past_its_budget() {
+  py <<'PY'
+p = "src/serve.ts"
+s = open(p).read()
+s = s.replace("const CHANGES_DEFAULT_LIMIT = 20;", "const CHANGES_DEFAULT_LIMIT = 200;")
+open(p, "w").write(s)
+PY
+}
+
+m_the_proxy_pin_truncates_the_window() {
+  py <<'PY'
+p = "src/server-remote.ts"
+s = open(p).read()
+s = s.replace("export const TRACK_CHANGES_LIMIT = 1000;", "export const TRACK_CHANGES_LIMIT = 20;")
+open(p, "w").write(s)
+PY
+}
+
+m_the_proxy_drops_the_page_size_again() {
+  py <<'PY'
+p = "src/api-client.ts"
+s = open(p).read()
+s = s.replace("  if (params.limit) p.limit = params.limit;\n", "")
+open(p, "w").write(s)
+PY
+}
+
+run_mutation "limit is read and not applied" m_limit_is_read_and_not_applied
+run_mutation "total reports the page instead of the window" m_total_reports_the_page_not_the_window
+run_mutation "offset is read and not applied" m_offset_is_read_and_not_applied
+run_mutation "the singular category spelling is ignored again" m_the_singular_category_is_ignored_again
+run_mutation "a filter returns a second top-level shape" m_a_filter_returns_a_second_shape
+run_mutation "the period the answer covers is not named" m_the_period_is_not_named
+run_mutation "an unreadable page size is ignored rather than refused" m_an_unreadable_page_size_is_ignored_rather_than_refused
+run_mutation "the whole window becomes unreachable" m_the_whole_window_is_unreachable
+run_mutation "the default page grows past its budget" m_the_default_page_grows_past_its_budget
+run_mutation "the proxy pin truncates the window" m_the_proxy_pin_truncates_the_window
+m_the_proxy_drops_the_category_filter_again() {
+  py <<'PY2'
+p = "src/api-client.ts"
+s = open(p).read()
+s = s.replace("  if (params.categories) p.categories = params.categories;\n", "")
+open(p, "w").write(s)
+PY2
+}
+
+run_mutation "the proxy drops the page size again" m_the_proxy_drops_the_page_size_again
+run_mutation "the proxy drops the category filter again" m_the_proxy_drops_the_category_filter_again
+
+echo ""
+echo "killed $killed, survived $survived"
+[ "$survived" -eq 0 ]

--- a/src/api-client.ts
+++ b/src/api-client.ts
@@ -84,12 +84,16 @@ export async function fetchDealChanges(params: {
   type?: string;
   vendor?: string;
   vendors?: string;
+  categories?: string;
+  limit?: string;
 }): Promise<unknown> {
   const p: Record<string, string> = {};
   if (params.since) p.since = params.since;
   if (params.type) p.type = params.type;
   if (params.vendor) p.vendor = params.vendor;
   if (params.vendors) p.vendors = params.vendors;
+  if (params.categories) p.categories = params.categories;
+  if (params.limit) p.limit = params.limit;
   return apiFetch("/api/changes", p);
 }
 

--- a/src/data.ts
+++ b/src/data.ts
@@ -548,6 +548,8 @@ export function getChangeLogFreshness(now: Date = new Date()): ChangeLogFreshnes
   return changeLogFreshness(loadDealChanges(), now);
 }
 
+export const DEFAULT_CHANGE_WINDOW_DAYS = 30;
+
 export function getDealChanges(
   since?: string,
   changeType?: string,
@@ -560,10 +562,10 @@ export function getDealChanges(
   if (since) {
     results = results.filter((c) => c.date >= since);
   } else {
-    const thirtyDaysAgo = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000)
+    const windowStart = new Date(Date.now() - DEFAULT_CHANGE_WINDOW_DAYS * 24 * 60 * 60 * 1000)
       .toISOString()
       .slice(0, 10);
-    results = results.filter((c) => c.date >= thirtyDaysAgo);
+    results = results.filter((c) => c.date >= windowStart);
   }
 
   if (changeType) {
@@ -610,6 +612,42 @@ const HIGH_IMPACT_CHANGE_TYPES = new Set([
   "limits_reduced", "new_free_tier",
 ]);
 
+export interface ChangeContext {
+  advisory: DealChange[];
+  summary: PersonalizedChanges["summary"];
+}
+
+export function changeContext(
+  matched: DealChange[],
+  since?: string,
+  changeType?: string
+): ChangeContext {
+  const allResult = getDealChanges(since, changeType);
+
+  const matchedKeys = new Set(matched.map((c) => `${c.vendor}|${c.date}|${c.change_type}`));
+
+  const advisory = allResult.changes
+    .filter((c) => c.impact === "high" && HIGH_IMPACT_CHANGE_TYPES.has(c.change_type))
+    .filter((c) => !matchedKeys.has(`${c.vendor}|${c.date}|${c.change_type}`))
+    .slice(0, 3);
+
+  const ecosystemHighImpact = allResult.changes.filter(
+    (c) => c.impact === "high"
+  ).length;
+
+  const sinceDate = since ? new Date(since) : new Date(Date.now() - DEFAULT_CHANGE_WINDOW_DAYS * 24 * 60 * 60 * 1000);
+  const periodDays = Math.max(1, Math.ceil((Date.now() - sinceDate.getTime()) / (24 * 60 * 60 * 1000)));
+
+  return {
+    advisory,
+    summary: {
+      stack_changes_count: matched.length,
+      ecosystem_high_impact_count: ecosystemHighImpact,
+      period_days: periodDays,
+    },
+  };
+}
+
 export function getPersonalizedChanges(
   since?: string,
   changeType?: string,
@@ -618,33 +656,12 @@ export function getPersonalizedChanges(
   categories?: string
 ): PersonalizedChanges {
   const stackResult = getDealChanges(since, changeType, vendor, vendors, categories);
-
-  const allResult = getDealChanges(since, changeType);
-
-  const stackVendorDates = new Set(
-    stackResult.changes.map((c) => `${c.vendor}|${c.date}|${c.change_type}`)
-  );
-
-  const advisory = allResult.changes
-    .filter((c) => c.impact === "high" && HIGH_IMPACT_CHANGE_TYPES.has(c.change_type))
-    .filter((c) => !stackVendorDates.has(`${c.vendor}|${c.date}|${c.change_type}`))
-    .slice(0, 3);
-
-  const ecosystemHighImpact = allResult.changes.filter(
-    (c) => c.impact === "high"
-  ).length;
-
-  const sinceDate = since ? new Date(since) : new Date(Date.now() - 30 * 24 * 60 * 60 * 1000);
-  const periodDays = Math.max(1, Math.ceil((Date.now() - sinceDate.getTime()) / (24 * 60 * 60 * 1000)));
+  const context = changeContext(stackResult.changes, since, changeType);
 
   return {
     your_stack_changes: stackResult.changes,
-    advisory,
-    summary: {
-      stack_changes_count: stackResult.changes.length,
-      ecosystem_high_impact_count: ecosystemHighImpact,
-      period_days: periodDays,
-    },
+    advisory: context.advisory,
+    summary: context.summary,
   };
 }
 

--- a/src/openapi.ts
+++ b/src/openapi.ts
@@ -148,50 +148,47 @@ export const openapiSpec = {
     "/api/changes": {
       get: {
         summary: "Deal and pricing changes",
-        description: "Returns tracked pricing and tier changes across vendors. Filter by date, change type, vendor, or category. When vendors or categories are provided, returns personalized results with advisory section for high-impact changes outside your filter.",
+        description: "Returns tracked pricing and tier changes across vendors. Filter by date, change type, vendor, or category.",
         parameters: [
           { name: "since", in: "query", description: "Filter changes after this date (YYYY-MM-DD)", schema: { type: "string", format: "date" }, example: "2025-01-01" },
           { name: "type", in: "query", description: "Filter by change type", schema: { type: "string", enum: ["free_tier_removed", "limits_reduced", "restriction", "limits_increased", "new_free_tier", "new_tier", "pricing_restructured", "open_source_killed", "pricing_model_change", "startup_program_expanded", "pricing_postponed", "product_deprecated", "record_corrected"] } },
           { name: "vendor", in: "query", description: "Filter by vendor name", schema: { type: "string" } },
-          { name: "vendors", in: "query", description: "Comma-separated vendor names to filter by (e.g. 'Vercel,Supabase,Clerk'). Triggers personalized response.", schema: { type: "string" }, example: "Vercel,Supabase" },
-          { name: "categories", in: "query", description: "Comma-separated category names to filter by (e.g. 'Database,Cloud Hosting'). Case-insensitive partial match. Triggers personalized response.", schema: { type: "string" }, example: "Database,Hosting" }
+          { name: "vendors", in: "query", description: "Comma-separated vendor names to filter by (e.g. 'Vercel,Supabase,Clerk')", schema: { type: "string" }, example: "Vercel,Supabase" },
+          { name: "category", in: "query", description: "Comma-separated category names to filter by (e.g. 'Database,Cloud Hosting'). Case-insensitive partial match.", schema: { type: "string" }, example: "Database,Hosting" },
+          { name: "categories", in: "query", description: "Comma-separated category names to filter by (e.g. 'Database,Cloud Hosting'). Case-insensitive partial match.", schema: { type: "string" }, example: "Database,Hosting" },
+          { name: "limit", in: "query", description: "Max results per page", schema: { type: "integer", default: 20 } },
+          { name: "offset", in: "query", description: "Number of results to skip", schema: { type: "integer", default: 0 } }
         ],
         responses: {
           "200": {
-            description: "List of deal changes. When vendors or categories are provided, returns personalized response with your_stack_changes, advisory, and summary fields instead of changes/total.",
+            description: "List of deal changes",
             content: {
               "application/json": {
                 schema: {
-                  oneOf: [
-                    {
+                  type: "object",
+                  properties: {
+                    changes: { type: "array", items: { $ref: "#/components/schemas/DealChange" } },
+                    total: { type: "integer" },
+                    returned: { type: "integer" },
+                    limit: { type: "integer" },
+                    offset: { type: "integer" },
+                    advisory: { type: "array", items: { $ref: "#/components/schemas/DealChange" }, description: "Top 3 high-impact changes outside your filter" },
+                    summary: {
                       type: "object",
-                      description: "Standard response (no vendor/category filters)",
                       properties: {
-                        changes: { type: "array", items: { $ref: "#/components/schemas/DealChange" } },
-                        total: { type: "integer" }
-                      }
-                    },
-                    {
-                      type: "object",
-                      description: "Personalized response (vendor/category filters active)",
-                      properties: {
-                        your_stack_changes: { type: "array", items: { $ref: "#/components/schemas/DealChange" } },
-                        advisory: { type: "array", items: { $ref: "#/components/schemas/DealChange" }, description: "Top 3 high-impact changes outside your filter" },
-                        summary: {
-                          type: "object",
-                          properties: {
-                            stack_changes_count: { type: "integer" },
-                            ecosystem_high_impact_count: { type: "integer" },
-                            period_days: { type: "integer" }
-                          }
-                        }
+                        stack_changes_count: { type: "integer" },
+                        ecosystem_high_impact_count: { type: "integer" },
+                        period_days: { type: "integer" }
                       }
                     }
-                  ]
+                  }
                 },
                 example: {
                   changes: [{ vendor: "Heroku", change_type: "free_tier_removed", date: "2022-11-28", summary: "Heroku eliminated all free dynos, free Postgres, and free Redis.", previous_state: "Free dyno (550-1000 hrs/mo), free Postgres (10K rows), free Redis (25MB)", current_state: "No free tier. Cheapest plan: $5/mo Eco dyno.", impact: "high", source_url: "https://blog.heroku.com/next-chapter", category: "Cloud Hosting", alternatives: ["Railway", "Render", "Fly.io"] }],
-                  total: 1
+                  total: 1,
+                  returned: 1,
+                  limit: 20,
+                  offset: 0
                 }
               }
             }

--- a/src/serve.ts
+++ b/src/serve.ts
@@ -5,7 +5,7 @@ import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
 import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
 import { createServer, getServerCard } from "./server.js";
-import { oldestVerifiedDateForSlug, vendorRiskAssessment, NEGATIVE_CHANGE_TYPES, POSITIVE_CHANGE_TYPES, SEVERE_CHANGE_TYPES, loadOffers, getCategories, getNewOffers, getNewestDeals, searchOffers, enrichOffers, gateForOffer, loadDealChanges, getDealChanges, getPersonalizedChanges, getOfferDetails, compareServices, checkVendorRisk, auditStack, getExpiringDeals, getWeeklyDigest, getFormattedWeeklyDigest, getFreshnessMetrics, getStabilityMap, getVendorReferral, sanitizeQuery, getChangeLogFreshness, isEventDated, partitionByDateProvenance } from "./data.js";
+import { oldestVerifiedDateForSlug, vendorRiskAssessment, NEGATIVE_CHANGE_TYPES, POSITIVE_CHANGE_TYPES, SEVERE_CHANGE_TYPES, loadOffers, getCategories, getNewOffers, getNewestDeals, searchOffers, enrichOffers, gateForOffer, loadDealChanges, getDealChanges, changeContext, DEFAULT_CHANGE_WINDOW_DAYS, getOfferDetails, compareServices, checkVendorRisk, auditStack, getExpiringDeals, getWeeklyDigest, getFormattedWeeklyDigest, getFreshnessMetrics, getStabilityMap, getVendorReferral, sanitizeQuery, getChangeLogFreshness, isEventDated, partitionByDateProvenance } from "./data.js";
 import { getStackRecommendation } from "./stacks.js";
 import { estimateCosts } from "./costs.js";
 import { classifyRequest } from "./client-class.js";
@@ -48363,7 +48363,7 @@ function buildDeveloperHubPage(): string {
     { method: "GET", path: "/api/categories", desc: "List all categories with counts", params: "" },
     { method: "GET", path: "/api/new", desc: "Recently added or updated offers", params: "days" },
     { method: "GET", path: "/api/newest", desc: "Newest deals by verification date", params: "limit" },
-    { method: "GET", path: "/api/changes", desc: "Pricing and deal changes", params: "vendors, categories" },
+    { method: "GET", path: "/api/changes", desc: "Pricing and deal changes", params: "since, type, vendor, vendors, category, categories, limit, offset" },
     { method: "GET", path: "/api/details/:vendor", desc: "Vendor detail with alternatives", params: "" },
     { method: "GET", path: "/api/compare", desc: "Compare two vendors side by side", params: "a, b" },
     { method: "GET", path: "/api/audit-stack", desc: "Audit your infrastructure stack", params: "services" },
@@ -52713,6 +52713,8 @@ const canonicalHost = (() => {
   try { return new URL(BASE_URL).hostname; } catch { return undefined; }
 })();
 
+const CHANGES_DEFAULT_LIMIT = 20;
+
 const TRAFFIC_EXCLUDED_PATHS = new Set(["/mcp", "/favicon.png", "/favicon.ico", "/og-image.png"]);
 function isCountableTraffic(pathname: string): boolean {
   if (TRAFFIC_EXCLUDED_PATHS.has(pathname)) return false;
@@ -53478,32 +53480,49 @@ const httpServer = createHttpServer(async (req, res) => {
     const type = url.searchParams.get("type") || undefined;
     const vendorFilter = url.searchParams.get("vendor") || undefined;
     const vendorsFilter = url.searchParams.get("vendors") || undefined;
-    const categoriesFilter = url.searchParams.get("categories") || undefined;
+    const categoriesFilter = url.searchParams.get("categories") || url.searchParams.get("category") || undefined;
     if (since && !/^\d{4}-\d{2}-\d{2}/.test(since)) {
       res.writeHead(400, { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" });
       res.end(JSON.stringify({ error: "Invalid 'since' parameter. Expected ISO date string (YYYY-MM-DD)." }));
       return;
     }
-    const isPersonalized = !!(vendorsFilter || categoriesFilter);
-    const changeLogFreshness = getChangeLogFreshness();
-    if (isPersonalized) {
-      const result = getPersonalizedChanges(since, type, vendorFilter, vendorsFilter, categoriesFilter);
-      logRequest({ ts: new Date().toISOString(), type: "api", endpoint: "/api/changes", params: { since, type, vendor: vendorFilter, vendors: vendorsFilter, categories: categoriesFilter, personalized: true }, user_agent: req.headers["user-agent"] ?? "unknown", result_count: result.your_stack_changes.length });
-      res.writeHead(200, { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" });
-      res.end(JSON.stringify(cited({ ...result, change_log_freshness: changeLogFreshness }, "/changes")));
-    } else {
-      const result = getDealChanges(since, type, vendorFilter, vendorsFilter, categoriesFilter);
-      const allTimeTotal = loadDealChanges().length;
-      const { dated, discovered } = partitionByDateProvenance(result.changes);
-      const dateProvenance = {
-        event_dated: dated.length,
-        discovered: discovered.length,
-        note: discovered.length > 0 ? discoveryBatchNote(discovered.length, "in this window") : "",
-      };
-      logRequest({ ts: new Date().toISOString(), type: "api", endpoint: "/api/changes", params: { since, type, vendor: vendorFilter, vendors: vendorsFilter }, user_agent: req.headers["user-agent"] ?? "unknown", result_count: result.changes.length });
-      res.writeHead(200, { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" });
-      res.end(JSON.stringify(cited({ ...result, date_provenance: dateProvenance, all_time_total: allTimeTotal, change_log_freshness: changeLogFreshness }, "/changes")));
+    const limitParam = url.searchParams.get("limit");
+    const offsetParam = url.searchParams.get("offset");
+    const badPaging = [["limit", limitParam], ["offset", offsetParam]].find(
+      ([, value]) => value !== null && !/^\d+$/.test(value as string),
+    );
+    if (badPaging) {
+      res.writeHead(400, { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" });
+      res.end(JSON.stringify({ error: `Invalid '${badPaging[0]}' parameter. Expected a non-negative integer.` }));
+      return;
     }
+    const limit = limitParam === null ? CHANGES_DEFAULT_LIMIT : parseInt(limitParam, 10);
+    const offset = offsetParam === null ? 0 : parseInt(offsetParam, 10);
+    const changeLogFreshness = getChangeLogFreshness();
+    const result = getDealChanges(since, type, vendorFilter, vendorsFilter, categoriesFilter);
+    const page = result.changes.slice(offset, offset + limit);
+    const context = changeContext(result.changes, since, type);
+    const allTimeTotal = loadDealChanges().length;
+    const { dated, discovered } = partitionByDateProvenance(result.changes);
+    const dateProvenance = {
+      event_dated: dated.length,
+      discovered: discovered.length,
+      note: discovered.length > 0 ? discoveryBatchNote(discovered.length, "in this window") : "",
+    };
+    logRequest({ ts: new Date().toISOString(), type: "api", endpoint: "/api/changes", params: { since, type, vendor: vendorFilter, vendors: vendorsFilter, categories: categoriesFilter, limit, offset }, user_agent: req.headers["user-agent"] ?? "unknown", result_count: page.length });
+    res.writeHead(200, { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" });
+    res.end(JSON.stringify(cited({
+      changes: page,
+      total: result.total,
+      returned: page.length,
+      limit,
+      offset,
+      advisory: context.advisory,
+      summary: context.summary,
+      date_provenance: dateProvenance,
+      all_time_total: allTimeTotal,
+      change_log_freshness: changeLogFreshness,
+    }, "/changes")));
   } else if (url.pathname === "/api/deadlines" && isGetOrHead) {
     recordApiHit("/api/deadlines");
     const allChanges = loadDealChanges();
@@ -54003,7 +54022,7 @@ Parameters:
 
 - GET /api/offers — Search deals (params: q, category, eligibility_type, sort, limit, offset)
 - GET /api/categories — List all categories with counts
-- GET /api/changes — Pricing changes (params: since, change_type, vendor)
+- GET /api/changes — Pricing changes (params: since, type, vendor, vendors, category, categories, limit, offset)
 - GET /api/new — Recently added offers (params: days)
 - GET /api/newest — Newest deals (params: since, limit, category)
 - GET /api/compare — Compare two vendors (params: a, b)

--- a/src/server-remote.ts
+++ b/src/server-remote.ts
@@ -18,6 +18,8 @@ import { getGuideList, getGuideBySlug } from "./guides.js";
 import { registerMcpAppsResources, TOOL_UI_META } from "./mcp-apps.js";
 import { MCP_INSTRUCTIONS } from "./mcp-instructions.js";
 import { substitutesFor } from "./product-role.js";
+
+export const TRACK_CHANGES_LIMIT = 1000;
 import type { ProductRole, ProductSubtypes } from "./types.js";
 
 function mcpError(msg: string) {
@@ -300,7 +302,7 @@ export function createServer(): McpServer {
           return mcpText(data);
         }
 
-        const params: Record<string, string | undefined> = { since, type: change_type, vendor, vendors };
+        const params: Record<string, string | undefined> = { since, type: change_type, vendor, vendors, limit: String(TRACK_CHANGES_LIMIT) };
         if (categories) params.categories = categories;
         const changes = await fetchDealChanges(params) as Record<string, unknown>;
         const doExpiring = include_expiring !== false;
@@ -316,11 +318,10 @@ export function createServer(): McpServer {
           if (Array.isArray(result.changes)) {
             result = { ...result, changes: result.changes.map((c: Record<string, unknown>) => ({ vendor: c.vendor, change_type: c.change_type, date: c.date, summary: c.summary })) };
           }
-          if (Array.isArray(result.your_stack_changes)) {
+          if (Array.isArray(result.advisory)) {
             result = {
               ...result,
-              your_stack_changes: result.your_stack_changes.map((c: Record<string, unknown>) => ({ vendor: c.vendor, change_type: c.change_type, date: c.date, summary: c.summary })),
-              advisory: (result.advisory || []).map((c: Record<string, unknown>) => ({ vendor: c.vendor, change_type: c.change_type, date: c.date, summary: c.summary })),
+              advisory: result.advisory.map((c: Record<string, unknown>) => ({ vendor: c.vendor, change_type: c.change_type, date: c.date, summary: c.summary })),
             };
           }
         }

--- a/test/change-resolution.test.ts
+++ b/test/change-resolution.test.ts
@@ -425,7 +425,7 @@ describe("what a reader and an agent are told about a resolved change", () => {
   });
 
   it("serves the reversal wherever the change log is read", async () => {
-    const changes = await getJson("/api/changes?since=2026-04-01");
+    const changes = await getJson("/api/changes?since=2026-04-01&limit=10000");
     const pause = (changes.changes ?? changes).find(
       (c: any) => c.vendor === "GitHub Copilot" && c.date === "2026-04-20"
     );

--- a/test/changes-pagination.test.ts
+++ b/test/changes-pagination.test.ts
@@ -1,0 +1,286 @@
+import { describe, it, before, after } from "node:test";
+import assert from "node:assert";
+import { spawn, type ChildProcess } from "node:child_process";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { once } from "node:events";
+import { getDealChanges, loadDealChanges } from "../dist/data.js";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+const DEFAULT_BUDGET_BYTES = 40000;
+
+const SHAPE_KEYS = [
+  "changes",
+  "total",
+  "returned",
+  "limit",
+  "offset",
+  "advisory",
+  "summary",
+  "date_provenance",
+  "all_time_total",
+  "change_log_freshness",
+  "_provenance",
+];
+
+const QUERIES = [
+  "",
+  "?limit=2",
+  "?limit=2&offset=2",
+  "?limit=1000",
+  "?since=2026-01-01",
+  "?type=free_tier_removed",
+  "?vendor=Slack",
+  "?vendors=Slack",
+  "?vendors=Slack,Exa",
+  "?category=Databases",
+  "?categories=Databases",
+  "?vendors=a-vendor-we-do-not-hold",
+];
+
+describe("/api/changes answers one shape and pages", () => {
+  let proc: ChildProcess;
+  let base: string;
+
+  const get = async (query: string): Promise<{ status: number; body: string; json: Record<string, unknown> }> => {
+    const res = await fetch(`${base}/api/changes${query}`);
+    const body = await res.text();
+    let json: Record<string, unknown> = {};
+    try { json = JSON.parse(body); } catch { json = {}; }
+    return { status: res.status, body, json };
+  };
+
+  before(async () => {
+    const serverPath = path.join(__dirname, "..", "dist", "serve.js");
+    const started = await new Promise<{ proc: ChildProcess; port: number }>((resolve, reject) => {
+      const child = spawn("node", [serverPath], {
+        stdio: ["pipe", "pipe", "pipe"],
+        env: { ...process.env, PORT: "0", BASE_URL: "http://127.0.0.1" },
+      });
+      const timer = setTimeout(() => { child.kill("SIGKILL"); reject(new Error("startup timeout")); }, 60000);
+      child.stderr?.on("data", (b: Buffer) => {
+        const m = b.toString().match(/running on http:\/\/localhost:(\d+)/);
+        if (m) { clearTimeout(timer); resolve({ proc: child, port: parseInt(m[1], 10) }); }
+      });
+      child.on("error", (e) => { clearTimeout(timer); reject(e); });
+    });
+    proc = started.proc;
+    base = `http://127.0.0.1:${started.port}`;
+  });
+
+  after(() => { proc?.kill("SIGKILL"); });
+
+  it("covers a filter of every kind the route accepts", () => {
+    assert.strictEqual(QUERIES.length, 12);
+  });
+
+  for (const query of QUERIES) {
+    it(`answers /api/changes${query || " with no parameters"} with the same top-level keys`, async () => {
+      const { status, json } = await get(query);
+      assert.strictEqual(status, 200, `/api/changes${query} answers ${status}`);
+      assert.deepStrictEqual(Object.keys(json).sort(), [...SHAPE_KEYS].sort(), `/api/changes${query} answers a different shape`);
+      assert.ok(Array.isArray(json.changes), `/api/changes${query} carries no changes array`);
+      assert.strictEqual(typeof json.total, "number", `/api/changes${query} carries no total`);
+    });
+  }
+
+  it("returns the number of records asked for", async () => {
+    for (const limit of [1, 2, 5]) {
+      const { json } = await get(`?limit=${limit}`);
+      assert.strictEqual((json.changes as unknown[]).length, limit, `limit=${limit} returned a different count`);
+      assert.strictEqual(json.returned, limit);
+      assert.strictEqual(json.limit, limit);
+    }
+  });
+
+  it("reports the unlimited count so a caller can page", async () => {
+    const full = await get("?limit=1000");
+    const paged = await get("?limit=2");
+    assert.strictEqual(paged.json.total, full.json.total, "total moved with the page size");
+    assert.strictEqual(paged.json.total, (full.json.changes as unknown[]).length);
+    assert.ok((full.json.changes as unknown[]).length > 2, "the window holds too few records to test paging");
+  });
+
+  it("pages through the window without repeating or skipping a record", async () => {
+    const full = await get("?limit=1000");
+    const all = (full.json.changes as { vendor: string; date: string; change_type: string }[])
+      .map((c) => `${c.vendor}|${c.date}|${c.change_type}`);
+    const walked: string[] = [];
+    for (let offset = 0; offset < 10; offset += 5) {
+      const { json } = await get(`?limit=5&offset=${offset}`);
+      assert.strictEqual(json.offset, offset);
+      for (const c of json.changes as { vendor: string; date: string; change_type: string }[]) {
+        walked.push(`${c.vendor}|${c.date}|${c.change_type}`);
+      }
+    }
+    assert.deepStrictEqual(walked, all.slice(0, 10));
+  });
+
+  it("keeps the default response inside a stated budget", async () => {
+    const { body, json } = await get("");
+    assert.ok(
+      body.length <= DEFAULT_BUDGET_BYTES,
+      `the default response is ${body.length} bytes against a budget of ${DEFAULT_BUDGET_BYTES}`,
+    );
+    assert.strictEqual(json.limit, 20, "the default page size is not the one /developers publishes");
+  });
+
+  it("reaches the whole window by asking rather than by omitting a parameter", async () => {
+    const windowSize = getDealChanges().changes.length;
+    const { json } = await get("?limit=1000");
+    assert.strictEqual((json.changes as unknown[]).length, windowSize);
+    assert.strictEqual(json.total, windowSize);
+  });
+
+  it("answers the singular and plural spelling of a filter identically", async () => {
+    const singularVendor = await get("?vendor=Slack");
+    const pluralVendor = await get("?vendors=Slack");
+    assert.deepStrictEqual(singularVendor.json.changes, pluralVendor.json.changes, "vendor and vendors disagree");
+
+    const singularCategory = await get("?category=Databases");
+    const pluralCategory = await get("?categories=Databases");
+    assert.deepStrictEqual(singularCategory.json.changes, pluralCategory.json.changes, "category and categories disagree");
+  });
+
+  it("names the period every answer covers", async () => {
+    for (const query of QUERIES) {
+      const { json } = await get(query);
+      const summary = json.summary as { period_days?: unknown };
+      assert.strictEqual(typeof summary?.period_days, "number", `/api/changes${query} does not name its period`);
+    }
+  });
+
+  it("refuses a page size it cannot read rather than ignoring it", async () => {
+    for (const query of ["?limit=abc", "?offset=-1", "?limit=1.5"]) {
+      const { status, json } = await get(query);
+      assert.strictEqual(status, 400, `/api/changes${query} answers ${status}`);
+      assert.ok(typeof json.error === "string", `/api/changes${query} refuses without saying why`);
+    }
+  });
+
+  it("changes the response for every parameter /developers publishes for this route", async () => {
+    const page = await (await fetch(`${base}/developers`)).text();
+    const row = page.match(/<a href="[^"]*\/api\/changes">\/api\/changes<\/a><\/td><td>[^<]*<\/td><td><code>([^<]*)<\/code>/);
+    assert.ok(row, "/developers publishes no parameter list for /api/changes");
+    const published = row[1].split(",").map((p) => p.trim()).filter(Boolean);
+    assert.ok(published.length > 0, "/developers publishes an empty parameter list for /api/changes");
+
+    const probe: Record<string, string> = {
+      since: "2026-08-25",
+      type: "free_tier_removed",
+      vendor: "Slack",
+      vendors: "Slack",
+      category: "Databases",
+      categories: "Databases",
+      limit: "2",
+      offset: "3",
+    };
+    const baseline = (await get("")).body;
+    const inert: string[] = [];
+    for (const name of published) {
+      assert.ok(probe[name] !== undefined, `/developers publishes ${name} and the test has no value to probe it with`);
+      const { body } = await get(`?${name}=${encodeURIComponent(probe[name])}`);
+      if (body === baseline) inert.push(name);
+    }
+    assert.deepStrictEqual(inert, [], "/developers publishes parameters that do not change the response");
+  });
+
+  it("keeps the stdio proxy's pinned page size above the whole window", async () => {
+    const { TRACK_CHANGES_LIMIT } = await import("../dist/server-remote.js");
+    assert.ok(
+      TRACK_CHANGES_LIMIT >= loadDealChanges().length,
+      `the proxy pins ${TRACK_CHANGES_LIMIT} against ${loadDealChanges().length} stored changes, so it would truncate`,
+    );
+  });
+});
+
+describe("the stdio proxy asks for what it means to return", () => {
+  let api: ChildProcess;
+  let stdio: ChildProcess;
+  let nextId = 10;
+  const pending = new Map<number, (msg: Record<string, unknown>) => void>();
+
+  const rpc = (method: string, params: unknown): Promise<Record<string, unknown>> => {
+    const id = ++nextId;
+    return new Promise((resolve, reject) => {
+      const timer = setTimeout(() => reject(new Error(`timed out on ${method}`)), 30000);
+      pending.set(id, (msg) => { clearTimeout(timer); resolve(msg); });
+      stdio.stdin?.write(JSON.stringify({ jsonrpc: "2.0", id, method, params }) + "\n");
+    });
+  };
+
+  const trackChanges = async (args: Record<string, unknown>): Promise<Record<string, unknown>> => {
+    const msg = await rpc("tools/call", { name: "track_changes", arguments: args }) as {
+      result?: { content?: { text?: string }[] };
+    };
+    return JSON.parse(msg.result?.content?.[0]?.text ?? "{}");
+  };
+
+  before(async () => {
+    const repo = path.join(__dirname, "..");
+    const started = await new Promise<{ proc: ChildProcess; port: number }>((resolve, reject) => {
+      const child = spawn("node", [path.join(repo, "dist", "serve.js")], {
+        stdio: ["pipe", "pipe", "pipe"],
+        env: { ...process.env, PORT: "0", BASE_URL: "http://127.0.0.1" },
+      });
+      const timer = setTimeout(() => { child.kill("SIGKILL"); reject(new Error("startup timeout")); }, 60000);
+      child.stderr?.on("data", (b: Buffer) => {
+        const m = b.toString().match(/running on http:\/\/localhost:(\d+)/);
+        if (m) { clearTimeout(timer); resolve({ proc: child, port: parseInt(m[1], 10) }); }
+      });
+      child.on("error", (e) => { clearTimeout(timer); reject(e); });
+    });
+    api = started.proc;
+
+    stdio = spawn("node", [path.join(repo, "dist", "index.js")], {
+      stdio: ["pipe", "pipe", "pipe"],
+      env: { ...process.env, AGENTDEALS_API_URL: `http://127.0.0.1:${started.port}` },
+    });
+    let buffered = "";
+    stdio.stdout?.on("data", (b: Buffer) => {
+      buffered += b.toString();
+      let cut: number;
+      while ((cut = buffered.indexOf("\n")) >= 0) {
+        const line = buffered.slice(0, cut).trim();
+        buffered = buffered.slice(cut + 1);
+        if (!line) continue;
+        try {
+          const msg = JSON.parse(line) as { id?: number };
+          if (typeof msg.id === "number" && pending.has(msg.id)) {
+            pending.get(msg.id)!(msg as Record<string, unknown>);
+            pending.delete(msg.id);
+          }
+        } catch { /* a partial frame is not a message */ }
+      }
+    });
+    await once(stdio.stderr!, "data");
+    await rpc("initialize", { protocolVersion: "2025-06-18", capabilities: {}, clientInfo: { name: "test", version: "1.0.0" } });
+    stdio.stdin?.write(JSON.stringify({ jsonrpc: "2.0", method: "notifications/initialized" }) + "\n");
+  });
+
+  after(() => { stdio?.kill("SIGKILL"); api?.kill("SIGKILL"); });
+
+  it("returns the whole window rather than the route's default page", async () => {
+    const result = await trackChanges({ since: "2026-01-01", include_expiring: false });
+    const changes = result.changes as unknown[];
+    assert.ok(Array.isArray(changes), "track_changes returned no changes array");
+    assert.strictEqual(changes.length, result.total, "the proxy returned a page and reported a window");
+    assert.ok(changes.length > 20, `the proxy returned ${changes.length}, the route's default page size`);
+  });
+
+  it("forwards a category filter instead of dropping it", async () => {
+    const filtered = await trackChanges({ since: "2026-01-01", categories: "Databases", include_expiring: false });
+    const unfiltered = await trackChanges({ since: "2026-01-01", include_expiring: false });
+    assert.ok(
+      (filtered.total as number) < (unfiltered.total as number),
+      `filtering by category returned ${filtered.total} of ${unfiltered.total}, so the filter was dropped`,
+    );
+    for (const change of filtered.changes as { category?: string }[]) {
+      assert.ok(
+        (change.category ?? "").toLowerCase().includes("database"),
+        `a category filter returned ${change.category}`,
+      );
+    }
+  });
+});

--- a/test/http.test.ts
+++ b/test/http.test.ts
@@ -676,7 +676,12 @@ describe("HTTP transport", () => {
     const body = await response.json() as any;
     assert.ok(Array.isArray(body.changes));
     assert.ok(typeof body.total === "number");
-    assert.strictEqual(body.changes.length, body.total);
+    assert.strictEqual(body.changes.length, body.returned);
+    assert.ok(body.returned <= body.total, "a page cannot hold more than the window");
+
+    const whole = await (await fetch(`http://localhost:${serverPort}/api/changes?limit=10000`)).json() as any;
+    assert.strictEqual(whole.changes.length, whole.total);
+    assert.strictEqual(whole.total, body.total);
   });
 
   it("GET /api/changes includes all_time_total alongside 30-day total", async () => {
@@ -720,17 +725,17 @@ describe("HTTP transport", () => {
     assert.ok(body.error.includes("Invalid"));
   });
 
-  it("GET /api/changes filters by vendors (comma-separated) — personalized response", async () => {
+  it("GET /api/changes filters by vendors (comma-separated)", async () => {
     proc = await startHttpServer();
 
-    const response = await fetch(`http://localhost:${serverPort}/api/changes?since=2020-01-01&vendors=Netlify,OpenAI`);
+    const response = await fetch(`http://localhost:${serverPort}/api/changes?since=2020-01-01&vendors=Netlify,OpenAI&limit=10000`);
     assert.strictEqual(response.status, 200);
     const body = await response.json() as any;
-    assert.ok(Array.isArray(body.your_stack_changes), "Expected your_stack_changes array");
+    assert.ok(Array.isArray(body.changes), "Expected changes array");
     assert.ok(Array.isArray(body.advisory), "Expected advisory array");
     assert.ok(body.summary, "Expected summary object");
-    assert.ok(body.your_stack_changes.length >= 2, `Expected at least 2 stack changes for Netlify+OpenAI, got ${body.your_stack_changes.length}`);
-    for (const change of body.your_stack_changes) {
+    assert.ok(body.changes.length >= 2, `Expected at least 2 changes for Netlify+OpenAI, got ${body.changes.length}`);
+    for (const change of body.changes) {
       const vendorLower = change.vendor.toLowerCase();
       assert.ok(
         vendorLower.includes("netlify") || vendorLower.includes("openai"),
@@ -740,16 +745,16 @@ describe("HTTP transport", () => {
     assert.ok(body.advisory.length <= 3, "Advisory should be max 3");
   });
 
-  it("GET /api/changes filters by categories — personalized response", async () => {
+  it("GET /api/changes filters by categories", async () => {
     proc = await startHttpServer();
 
-    const response = await fetch(`http://localhost:${serverPort}/api/changes?since=2020-01-01&categories=Database`);
+    const response = await fetch(`http://localhost:${serverPort}/api/changes?since=2020-01-01&categories=Database&limit=10000`);
     assert.strictEqual(response.status, 200);
     const body = await response.json() as any;
-    assert.ok(Array.isArray(body.your_stack_changes), "Expected your_stack_changes array");
+    assert.ok(Array.isArray(body.changes), "Expected changes array");
     assert.ok(Array.isArray(body.advisory), "Expected advisory array");
     assert.ok(body.summary, "Expected summary object");
-    for (const change of body.your_stack_changes) {
+    for (const change of body.changes) {
       assert.ok(
         change.category.toLowerCase().includes("database"),
         `Unexpected category: ${change.category}`

--- a/test/weekly-window-provenance.test.ts
+++ b/test/weekly-window-provenance.test.ts
@@ -439,7 +439,7 @@ describe("every weekly surface reports the same week", () => {
   it("tells an API caller how many of its records carry an effective date", async () => {
     proc = await startHttpServer();
     const base = `http://127.0.0.1:${serverPort}`;
-    const body = await (await fetch(`${base}/api/changes?since=2026-08-22`)).json() as {
+    const body = await (await fetch(`${base}/api/changes?since=2026-08-22&limit=10000`)).json() as {
       changes: Array<{ date_source: string }>;
       date_provenance: { event_dated: number; discovered: number; note: string };
     };


### PR DESCRIPTION
Refs #1309

## AC-2 / AC-3 — `limit` works, `total` reports the window

`limit` and `offset` follow `/api/offers`, which is the reference that matches the rule AC-2 states. Default page is 20; `returned` says how many came back; `total` is the unlimited count.

| query | main | branch | delta |
|---|---|---|---|
| `/api/changes` | 203,707 | **21,590** | **−89.4%** |
| `?limit=2` | 203,707 | **2,533** | −98.8% |
| `?category=Databases` | 203,707 | **11,511** | −94.3% |
| `?type=free_tier_removed` | 24,728 | 18,072 | −26.9% |
| `?limit=1000` | 203,707 | 203,849 | +142 |

The whole window is reachable by asking (`?limit=1000`), not by omitting a parameter.

**`/api/newest` is not a usable reference for `total`.** `/api/newest?limit=3` reports `total: 3` — the limited count. `/api/offers?limit=3` reports `total: 1580`. AC-2's rule ("`total` still reports the unlimited count so a caller can page") is `/api/offers`'s behaviour, so that is what this follows. `/api/newest` disagrees with both and is untouched here.

## AC-1 — one top-level schema

Every parameter combination now returns the same eleven keys: `changes`, `total`, `returned`, `limit`, `offset`, `advisory`, `summary`, `date_provenance`, `all_time_total`, `change_log_freshness`, `_provenance`. Asserted by key set over 12 queries covering every filter the route accepts.

`your_stack_changes` is gone. It held exactly what `changes` holds — `getPersonalizedChanges` computed it by calling `getDealChanges` with the same arguments — so this is a rename, not a loss. `advisory` and `summary` took the first option AC-1 offers and are present on every response.

**The cost, named.** `?vendor=Slack` was 2,029 bytes and is now 4,455 (+119.6%), because `advisory` is now on every response and it was not on that one before. On an unfiltered request `advisory` is empty by construction — every high-impact record is already in `changes` — so the default response pays nothing. If you would rather have `advisory` on its own route, that restores 2,029 and it is one line; the issue offers both and I took the one that does not invent a public URL.

## AC-4 — every published parameter changes the response

`/developers`, `/llms-full.txt` and `/api/openapi.json` now list `since, type, vendor, vendors, category, categories, limit, offset`.

A test parses the parameter list out of the rendered `/developers` row, probes each name with a value, and fails naming any that leave the response byte-identical. It also fails if `/developers` grows a parameter the test has no probe for, so the list cannot drift ahead of the check.

`category` was silently ignored and now filters identically to `categories`; `vendor` and `vendors` already agreed on a single name and now return the same body. Asserted both ways.

## AC-5 — the period is named on every response

`summary.period_days` ships on every response, asserted over all 12 queries.

**Your AC-5 premise is half wrong and it is worth correcting.** The default response is *not* unwindowed. `getDealChanges` applies the same 30-day default to both shapes — that is why `/api/changes` returns 239 of 524 records, oldest `2026-08-20`. `?vendors=X` was therefore *already* the default response filtered over the same period; the 30 days was never the difference between them. The real differences were the key names and the two extra blocks, and both are now gone.

## Two defects the issue did not name

**The stdio proxy dropped the `categories` filter it accepts.** `track_changes({categories: "Databases"})` set `params.categories`, and `fetchDealChanges` built its query string from `since`/`type`/`vendor`/`vendors` only — so the filter never reached the wire and the tool answered unfiltered. Pre-existing on `main`. Fixed here because I was editing that exact call; a test now asserts the filtered answer is narrower than the unfiltered one and that every record it returns is in the category.

**`/api/openapi.json` published the dual schema as a `oneOf`**, with `"Triggers personalized response"` on two parameters and a `200` description saying `your_stack_changes` replaces `changes`/`total`. All of it describes behaviour that no longer exists. I deleted the false clauses rather than writing replacements, and added only field names and the `limit`/`offset` entries, reusing `/api/offers`'s existing wording verbatim.

## Five existing tests changed, and which are contract changes

Copied onto a `main` build, 2 of the 5 pass unchanged and 3 fail:

| test | on main | why |
|---|---|---|
| `change-resolution` — serves the reversal wherever the change log is read | **passes** | added `?limit=1000`; the parameter was ignored on `main`, so behaviour is identical. Strengthening. |
| `weekly-window-provenance` — tells an API caller how many of its records carry an effective date | **passes** | same. |
| `http` — GET /api/changes returns deal changes | fails | asserted `changes.length === total`, which is the defect AC-2 names. Now asserts `changes.length === returned`, `returned <= total`, and the identity at `?limit=10000`. |
| `http` — filters by vendors (comma-separated) | fails | asserted `your_stack_changes`. |
| `http` — filters by categories | fails | asserted `your_stack_changes`. |

The three that fail are each pinning the contract the issue calls a defect.

## One judgement worth your eye

**`date_provenance` counts the window, not the page.** A caller getting 20 records can see `date_provenance.event_dated: 226`. I kept window semantics because the field's own note ends `"in this window"`, and making it page-dependent would mean the same window reports different provenance at different page sizes. Say so if you want it per-page.

## Verification

- **3,444 tests, 25 new**, against a base of 3,419 measured in a worktree of the same commit. The 5 failures are identical on both and pre-existing (#1190).
- **The guard runs against `main`.** `test/changes-pagination.test.ts` imports only modules that exist there (the one new export is behind a dynamic import): **19 of 25 red on main, 0 red on the branch.**
- **12 mutations, 12 killed, 0 survivors, none killed by `tsc` alone.** `scripts/mutate-1309.sh`.
  One mutation survived the first run and found a real gap: removing the proxy's `limit` forwarding changed nothing any test could see, so the pin was inert. That is what the two stdio tests exist for now.
- **Both transports.** Real `initialize` then `tools/call` over stdio asserting `track_changes` still returns the whole window and honours a category filter.
- **Sweep of all 2,577 sitemap paths: byte-identical, 0 moved.** `/developers`, `/llms-full.txt` and `/api/openapi.json` are not in the sitemap, so I fetched all three directly and read the rows back.

## Not done — needs copy

AC-3 asks for the budget to be **stated on `/developers`**. The default is published machine-readably (`default: 20` in the OpenAPI spec) and enforced by a test, but the `/developers` table has no column for a default and I am not writing the sentence. One line from you.