### PR TITLE
Date the Deepgram change when we found it, not when its promo expires

### DIFF
--- a/data/deal_changes.json
+++ b/data/deal_changes.json
@@ -6363,8 +6363,8 @@
     {
       "vendor": "Deepgram",
       "change_type": "new_free_tier",
-      "date": "2026-09-12",
-      "date_source": "vendor_page",
+      "date": "2026-08-28",
+      "date_source": "discovered",
       "summary": "The $200 free credit is still offered, but the details have expanded. Text-to-Speech's Flux TTS is free until September 12, 2026, and Voice Agent API's Flux TTS is also free until September 12, 2026.",
       "previous_state": "Speech-to-text and text-to-speech API — $200 free credits on signup (no credit card required), ~43K minutes transcription with Nova model, credits never expire. Access to all model endpoints",
       "current_state": "Free $200 Credit then pay-as-you-go. Flux TTS is free until 9/12/2026. Voice Agent API's Flux TTS is free through September 12, 2026.",


### PR DESCRIPTION
Data-only. One record, two fields.

The Deepgram change record stored `date: "2026-09-12"` with `date_source: "vendor_page"`. That date is the expiry of the Flux TTS promotion the summary describes — *"Flux TTS is free until September 12, 2026"* — not the date anything changed. It was nine days in the future, and `vendor_page` is one of the two event-dated sources, so the site published it as an established fact.

**What `/vendor/deepgram` published.** Run against the site's own helpers in `src/change-dates.ts`, before and after:

| derived value | before | after |
|---|---|---|
| `dateModified` and "Last updated" | `2026-09-12` | `2026-07-30` |
| `priceValidUntil` on the free-credits `Offer` | `2026-09-12` | *(absent)* |
| schema.org `Event.startDate` | `2026-09-12` | *(absent)* |
| `datePublished` | `2026-09-12` | *(absent)* |
| change-log label | `2026-09-12` | `discovered 2026-08-28` |

`2026-07-30` is Deepgram's actual `verifiedDate`; `lastUpdated` falls back to it once no event-dated change outranks it.

**The change is `date` → `2026-08-28` and `date_source` → `discovered`.** That is what we know: `reverify-ai` found the page had changed on 2026-08-28. We do not know when Deepgram changed it. `discovered` is the source that says so, and it correctly suppresses `startDate`, `datePublished` and the expiry derivation.

**Nothing is lost.** The September 12 expiry is still stated in `summary` and `current_state`, where it is prose about the promotion rather than a date field claiming the change happened then.

**One thing I did not fix, reported on https://github.com/robhunter/agentdeals/issues/1267.** `priceValidUntil` came from `offerExpiryAfter`, which accepts any future-dated change where `endsTheListedOffer` is true — and that helper returns `true` for every `change_type` except `product_deprecated`. This record is a `new_free_tier`. The site classified a new free tier as an event that ends the listed offer. It happened to produce a defensible date here by coincidence; the logic is inverted for the positive change types. That is `src/`, so it is not in this PR.

`npm run validate` passes: 1,580 offers, 524 deal changes. `deal_changes.json` round-trips byte-identical through `json.dumps(indent=2, ensure_ascii=False)` before and after the edit.
