### PR TITLE
Cite a page on the nine product routes that named none (#1313)

### DIFF
--- a/src/provenance.ts
+++ b/src/provenance.ts
@@ -114,6 +114,7 @@ export function citeAs(baseUrl: string, path: string, date: string | null, singl
 }
 
 export interface ProvenanceOptions {
+  path?: string;
   listingPath?: string;
   deference?: boolean;
   dateForSlug?: (slug: string) => string | null;
@@ -133,7 +134,7 @@ export function provenanceBlock(
   const withheld = records.length - ranked.length;
   const dated = ranked.length > 0 ? ranked : records;
   const date = oldestDate(dated);
-  const derived = narrowestPath(records);
+  const derived = options.path ?? narrowestPath(records);
   const path = derived === "/" ? options.listingPath ?? "/" : derived;
 
   const block: Record<string, unknown> = {

--- a/src/serve.ts
+++ b/src/serve.ts
@@ -48699,6 +48699,22 @@ function buildDeveloperHubPage(): string {
     + "  \"total\": 42\n"
     + "}</div>\n"
     + "\n"
+    + "    <h2>Provenance</h2>\n"
+    + "    <p>Every response that carries index data includes a <code>_provenance</code> object, so an agent can attribute a figure without parsing prose out of a sentence.</p>\n"
+    + "    <table class=\"endpoint-table\">\n"
+    + "      <thead><tr><th>Field</th><th>Meaning</th></tr></thead>\n"
+    + "      <tbody>\n"
+    + "      <tr><td><code>source</code></td><td>Always <code>AgentDeals</code>.</td></tr>\n"
+    + "      <tr><td><code>url</code></td><td>The page on agentdeals.dev that publishes this data.</td></tr>\n"
+    + "      <tr><td><code>checked</code></td><td>The oldest verification date among the records in this response. Omitted where the response holds no dated record.</td></tr>\n"
+    + "      <tr><td><code>verified</code></td><td>The same date as <code>checked</code>. Kept for callers written before <code>checked</code> existed.</td></tr>\n"
+    + "      <tr><td><code>cite_as</code></td><td>A citation sentence built from the three fields above, ready to use as written.</td></tr>\n"
+    + "      <tr><td><code>note</code></td><td>Our request that you cite the source if you use a figure from the response.</td></tr>\n"
+    + "      </tbody>\n"
+    + "    </table>\n"
+    + "    <p>Operational endpoints &mdash; <code>/api/stats</code>, <code>/api/traffic</code>, <code>/api/query-log</code>, <code>/api/pageviews</code>, <code>/api/freshness</code> and <code>/api/watchlist</code> &mdash; carry no provenance block. They report on this service rather than on the index.</p>\n"
+    + "    <p>If you use a figure, cite <code>url</code> and <code>checked</code>. The index is free and we keep it current; attribution is how the people who need it find their way here.</p>\n"
+    + "\n"
     + "    <h2>Rate Limits</h2>\n"
     + "    <p>The read endpoints above have <strong>no rate limits</strong>. We trust developers to be reasonable.</p>\n"
     + "    <p>Two write paths are limited. <code>POST /api/agents/register</code> allows " + registrationLimiter.limit + " registrations per hour per client and returns <code>X-RateLimit-Limit</code>, <code>X-RateLimit-Remaining</code> and <code>X-RateLimit-Reset</code> on every response. The attribution beacon at <code>" + SIGNAL_PATH + "</code> allows " + RATE_LIMIT_PER_MINUTE + " per minute &mdash; <a href=\"" + SIGNAL_DOC_PATH + "\">its own page</a> covers how that limit is keyed. Over either limit you get a <code>429</code> with <code>Retry-After</code>.</p>\n"
@@ -52728,6 +52744,33 @@ function cited<T extends object>(payload: T, listingPath?: string): T & { _prove
   };
 }
 
+const LLM_PRICING_CATEGORY = "AI / ML";
+const HOSTING_PRICING_CATEGORY = "Cloud Hosting";
+const LLM_PRICING_PAGE = `/category/${toSlug(LLM_PRICING_CATEGORY)}`;
+const HOSTING_PRICING_PAGE = `/category/${toSlug(HOSTING_PRICING_CATEGORY)}`;
+const REFERRAL_CODE_LISTING_PAGE = "/marketplace";
+
+function digestWeekPath(weekOf: string): string {
+  const { year, week } = isoWeekOf(new Date(weekOf + "T00:00:00Z"));
+  return `/digest/${formatWeekKey(year, week)}`;
+}
+
+function referralCodePage(vendor: string): string {
+  const slug = toSlug(vendor);
+  return vendorSlugMap.has(slug) ? `/vendor/${slug}` : REFERRAL_CODE_LISTING_PAGE;
+}
+
+function citedUndated<T extends object>(payload: T, path: string): T & { _provenance: Record<string, unknown> } {
+  return { ...payload, _provenance: provenanceBlock(BASE_URL, payload, { path }) };
+}
+
+function citedAt<T extends object>(payload: T, path: string): T & { _provenance: Record<string, unknown> } {
+  return {
+    ...payload,
+    _provenance: provenanceBlock(BASE_URL, payload, { path, dateForSlug: oldestVerifiedDateForSlug }),
+  };
+}
+
 function withAgentBlock<T extends object>(payload: T, slug?: string | null): T & { _agent: Record<string, unknown>; _provenance: Record<string, unknown> } {
   return {
     ...payload,
@@ -53539,7 +53582,7 @@ const httpServer = createHttpServer(async (req, res) => {
       }));
     logRequest({ ts: new Date().toISOString(), type: "api", endpoint: "/api/deadlines", params: { type: typeFilter }, user_agent: req.headers["user-agent"] ?? "unknown", result_count: deadlines.length });
     res.writeHead(200, { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" });
-    res.end(JSON.stringify({ deadlines, count: deadlines.length }));
+    res.end(JSON.stringify(citedAt({ deadlines, count: deadlines.length }, "/deadlines")));
   } else if (url.pathname === "/api/ai-coding-pricing" && isGetOrHead) {
     recordApiHit("/api/ai-coding-pricing");
     const aiCodingOffers = offers.filter(o => o.category === "AI Coding");
@@ -53576,10 +53619,10 @@ const httpServer = createHttpServer(async (req, res) => {
     }).filter(t => !categoryFilter || !validCategories.includes(categoryFilter) || t.category === categoryFilter);
     logRequest({ ts: new Date().toISOString(), type: "api", endpoint: "/api/ai-coding-pricing", params: { type: categoryFilter }, user_agent: req.headers["user-agent"] ?? "unknown", result_count: tools.length });
     res.writeHead(200, { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" });
-    res.end(JSON.stringify({ tools, changes: aiChanges, count: tools.length, categories: Object.keys(categoryMap) }));
+    res.end(JSON.stringify(citedAt({ tools, changes: aiChanges, count: tools.length, categories: Object.keys(categoryMap) }, "/ai-coding-tools-pricing")));
   } else if (url.pathname === "/api/hosting-pricing" && isGetOrHead) {
     recordApiHit("/api/hosting-pricing");
-    const hostingOffers = offers.filter(o => o.category === "Cloud Hosting");
+    const hostingOffers = offers.filter(o => o.category === HOSTING_PRICING_CATEGORY);
     const hostingCategoryMap: Record<string, string[]> = {
       "traditional-paas": ["Railway", "Render", "Fly.io", "Koyeb", "Northflank"],
       "edge-serverless": ["Cloudflare Workers", "Cloudflare Pages", "Netlify", "Deno Deploy", "Val Town"],
@@ -53610,10 +53653,10 @@ const httpServer = createHttpServer(async (req, res) => {
     }).filter(t => !hostingTypeFilter || !validHostingTypes.includes(hostingTypeFilter) || t.category === hostingTypeFilter);
     logRequest({ ts: new Date().toISOString(), type: "api", endpoint: "/api/hosting-pricing", params: { type: hostingTypeFilter }, user_agent: req.headers["user-agent"] ?? "unknown", result_count: hostingTools.length });
     res.writeHead(200, { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" });
-    res.end(JSON.stringify({ platforms: hostingTools, changes: hostingApiChanges, count: hostingTools.length, categories: Object.keys(hostingCategoryMap) }));
+    res.end(JSON.stringify(citedAt({ platforms: hostingTools, changes: hostingApiChanges, count: hostingTools.length, categories: Object.keys(hostingCategoryMap) }, HOSTING_PRICING_PAGE)));
   } else if (url.pathname === "/api/llm-pricing" && isGetOrHead) {
     recordApiHit("/api/llm-pricing");
-    const llmOffers = offers.filter(o => o.category === "AI / ML");
+    const llmOffers = offers.filter(o => o.category === LLM_PRICING_CATEGORY);
     const llmCategoryMap: Record<string, string[]> = {
       "frontier": ["OpenAI", "Anthropic", "Google Gemini", "Mistral", "Cohere", "xAI"],
       "inference": ["Groq", "Cerebras", "OpenRouter", "NVIDIA NIM", "SiliconFlow"],
@@ -53643,7 +53686,7 @@ const httpServer = createHttpServer(async (req, res) => {
     }).filter(t => !llmTypeFilter || !validLlmTypes.includes(llmTypeFilter) || t.category === llmTypeFilter);
     logRequest({ ts: new Date().toISOString(), type: "api", endpoint: "/api/llm-pricing", params: { type: llmTypeFilter }, user_agent: req.headers["user-agent"] ?? "unknown", result_count: llmProviders.length });
     res.writeHead(200, { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" });
-    res.end(JSON.stringify({ providers: llmProviders, changes: llmApiChanges, count: llmProviders.length, categories: Object.keys(llmCategoryMap) }));
+    res.end(JSON.stringify(citedAt({ providers: llmProviders, changes: llmApiChanges, count: llmProviders.length, categories: Object.keys(llmCategoryMap) }, LLM_PRICING_PAGE)));
   } else if (url.pathname === "/api/startup-credits" && isGetOrHead) {
     recordApiHit("/api/startup-credits");
     const startupOffers = offers.filter(o =>
@@ -53679,7 +53722,7 @@ const httpServer = createHttpServer(async (req, res) => {
     }).filter(t => !startupTypeFilter || !validStartupTypes.includes(startupTypeFilter) || t.category === startupTypeFilter);
     logRequest({ ts: new Date().toISOString(), type: "api", endpoint: "/api/startup-credits", params: { type: startupTypeFilter }, user_agent: req.headers["user-agent"] ?? "unknown", result_count: startupPrograms.length });
     res.writeHead(200, { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" });
-    res.end(JSON.stringify({ programs: startupPrograms, changes: startupApiChanges, count: startupPrograms.length, categories: Object.keys(startupCategoryMap) }));
+    res.end(JSON.stringify(citedAt({ programs: startupPrograms, changes: startupApiChanges, count: startupPrograms.length, categories: Object.keys(startupCategoryMap) }, "/startup-credits")));
   } else if (url.pathname === "/api/referral-programs" && isGetOrHead) {
     recordApiHit("/api/referral-programs");
     const seen = new Set<string>();
@@ -53710,7 +53753,7 @@ const httpServer = createHttpServer(async (req, res) => {
     const refCategories = [...new Set(refPrograms.map(p => p.category))].sort();
     logRequest({ ts: new Date().toISOString(), type: "api", endpoint: "/api/referral-programs", params: { category: refCategoryFilter }, user_agent: req.headers["user-agent"] ?? "unknown", result_count: refPrograms.length });
     res.writeHead(200, { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" });
-    res.end(JSON.stringify({ programs: refPrograms, count: refPrograms.length, categories: refCategories }));
+    res.end(JSON.stringify(citedAt({ programs: refPrograms, count: refPrograms.length, categories: refCategories }, "/referral-programs")));
   } else if (url.pathname === "/api/audit-stack" && isGetOrHead) {
     recordApiHit("/api/audit-stack");
     const servicesParam = url.searchParams.get("services");
@@ -53816,7 +53859,7 @@ const httpServer = createHttpServer(async (req, res) => {
       res.end(digest.digest_html);
     } else {
       res.writeHead(200, { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*", "Cache-Control": "public, max-age=3600" });
-      res.end(JSON.stringify(digest));
+      res.end(JSON.stringify(citedAt(digest, digestWeekPath(digest.week_of))));
     }
   } else if (url.pathname === "/api/digest" && isGetOrHead) {
     recordApiHit("/api/digest");
@@ -55541,7 +55584,9 @@ ${catList}
     recordReferralListingCall(sourceFilter ?? null);
     logRequest({ ts: new Date().toISOString(), type: "api", endpoint: "GET /api/referral-codes", params: { source: sourceFilter ?? "all", category: categoryName ?? "all" }, user_agent: req.headers["user-agent"] ?? "unknown", result_count: filtered.length });
     res.writeHead(200, { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" });
-    res.end(JSON.stringify({ codes: filtered, total: filtered.length }));
+    const codeVendors = new Set(filtered.map(c => c.vendor));
+    const codeListingPage = codeVendors.size === 1 ? referralCodePage([...codeVendors][0]) : REFERRAL_CODE_LISTING_PAGE;
+    res.end(JSON.stringify(citedUndated({ codes: filtered, total: filtered.length }, codeListingPage)));
 
   } else if (url.pathname === "/api/referral-codes" && req.method === "POST") {
     const agent = await authenticateRequest(req as any);
@@ -55639,14 +55684,14 @@ ${catList}
       recordApiHit("/api/referral-codes/:vendor");
       logRequest({ ts: new Date().toISOString(), type: "api", endpoint: `/api/referral-codes/${vendorParam}`, params: { source: best.source }, user_agent: req.headers["user-agent"] ?? "unknown", result_count: 1 });
       res.writeHead(200, { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" });
-      res.end(JSON.stringify({
+      res.end(JSON.stringify(citedUndated({
         vendor: best.vendor,
         code: best.code,
         referral_url: best.referral_url,
         referee_benefit: best.referee_benefit,
         restrictions: best.restrictions,
         source: best.source,
-      }));
+      }, referralCodePage(best.vendor))));
       return;
     }
 

--- a/test/documented-route-citation.test.ts
+++ b/test/documented-route-citation.test.ts
@@ -1,0 +1,271 @@
+import { describe, it, before, after } from "node:test";
+import assert from "node:assert";
+import { spawn, type ChildProcess } from "node:child_process";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { DEFERENCE } from "../dist/signal-copy.js";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+const CITATION_OPENING = "Source: AgentDeals (http";
+
+const OPERATIONAL_ROUTES = new Map<string, string>([
+  ["/api/freshness", "reports on our own index, not on a vendor record"],
+  ["/api/query-log", "a request log"],
+  ["/api/pageviews", "our own analytics"],
+  ["/api/traffic", "our own analytics"],
+  ["/api/stats", "our own service counters"],
+  ["/api/watchlist", "a caller's own subscriptions"],
+  ["/api/watchlist/:id", "one caller's own subscription"],
+  ["/api/feed", "an Atom feed, not a JSON body"],
+]);
+
+const PROBES = new Map<string, string>([
+  ["/api/offers", "/api/offers?limit=3"],
+  ["/api/categories", "/api/categories"],
+  ["/api/new", "/api/new?days=3"],
+  ["/api/newest", "/api/newest?limit=3"],
+  ["/api/changes", "/api/changes?limit=2"],
+  ["/api/details/:vendor", "/api/details/supabase"],
+  ["/api/compare", "/api/compare?a=Supabase&b=Neon"],
+  ["/api/audit-stack", "/api/audit-stack?services=Vercel"],
+  ["/api/vendor-risk/:vendor", "/api/vendor-risk/supabase"],
+  ["/api/deadlines", "/api/deadlines"],
+  ["/api/ai-coding-pricing", "/api/ai-coding-pricing"],
+  ["/api/hosting-pricing", "/api/hosting-pricing"],
+  ["/api/llm-pricing", "/api/llm-pricing"],
+  ["/api/startup-credits", "/api/startup-credits"],
+  ["/api/referral-programs", "/api/referral-programs"],
+  ["/api/expiring", "/api/expiring?days=30"],
+  ["/api/digest", "/api/digest"],
+  ["/api/digest/weekly", "/api/digest/weekly"],
+  ["/api/stack", "/api/stack?use_case=saas"],
+  ["/api/costs", "/api/costs?services=Vercel&scale=startup"],
+  ["/api/referral-codes", "/api/referral-codes"],
+  ["/api/referral-codes/:vendor", "/api/referral-codes/railway"],
+]);
+
+const DATED = [
+  "/api/deadlines",
+  "/api/ai-coding-pricing",
+  "/api/hosting-pricing",
+  "/api/llm-pricing",
+  "/api/startup-credits",
+  "/api/referral-programs",
+  "/api/digest/weekly",
+];
+
+const UNDATED = ["/api/referral-codes", "/api/referral-codes/:vendor"];
+
+const CITE_THE_SITE_ROOT = ["/api/new", "/api/newest", "/api/audit-stack", "/api/stack", "/api/costs"];
+
+const SOURCE_POPULATION_PAGES: [string, string, number][] = [
+  ["/api/llm-pricing", "providers", 60],
+  ["/api/hosting-pricing", "platforms", 50],
+  ["/api/referral-programs", "programs", 15],
+  ["/api/deadlines", "deadlines", 0],
+];
+
+const ALWAYS_PUBLISHED = ["source", "url", "cite_as", "note"];
+const PUBLISHED_WHERE_DATED = ["checked", "verified"];
+
+function documentedProvenanceFields(html: string): string[] {
+  const section = html.slice(html.indexOf("<h2>Provenance</h2>"), html.indexOf("<h2>Rate Limits</h2>"));
+  return [...section.matchAll(/<tr><td><code>([a-z_]+)<\/code><\/td>/g)].map(([, field]) => field);
+}
+
+function documentedOperationalRoutes(html: string): string[] {
+  const section = html.slice(html.indexOf("<h2>Provenance</h2>"), html.indexOf("<h2>Rate Limits</h2>"));
+  const sentence = section.slice(section.indexOf("Operational endpoints"));
+  return [...sentence.matchAll(/<code>(\/api\/[a-z-/]+)<\/code>/g)].map(([, route]) => route);
+}
+
+function documentedGetRoutes(html: string): string[] {
+  const rows = [...html.matchAll(
+    /<tr><td><code>(GET|POST|PUT|DELETE)<\/code><\/td><td>(?:<a href="[^"]*">|<code>)(\/api\/[^<]+)/g,
+  )];
+  return rows.filter(([, method]) => method === "GET").map(([, , route]) => route);
+}
+
+describe("every product route the developer hub documents carries a citation", () => {
+  let proc: ChildProcess;
+  let base: string;
+  let documented: string[];
+  let hub: string;
+  const bodies = new Map<string, string>();
+
+  before(async () => {
+    const serverPath = path.join(__dirname, "..", "dist", "serve.js");
+    const started = await new Promise<{ proc: ChildProcess; port: number }>((resolve, reject) => {
+      const child = spawn("node", [serverPath], {
+        stdio: ["pipe", "pipe", "pipe"],
+        env: { ...process.env, PORT: "0", BASE_URL: "http://127.0.0.1" },
+      });
+      const timer = setTimeout(() => { child.kill("SIGKILL"); reject(new Error("startup timeout")); }, 60000);
+      child.stderr?.on("data", (b: Buffer) => {
+        const m = b.toString().match(/running on http:\/\/localhost:(\d+)/);
+        if (m) { clearTimeout(timer); resolve({ proc: child, port: parseInt(m[1], 10) }); }
+      });
+      child.on("error", (e) => { clearTimeout(timer); reject(e); });
+    });
+    proc = started.proc;
+    base = `http://127.0.0.1:${started.port}`;
+    hub = await (await fetch(`${base}/developers`)).text();
+    documented = documentedGetRoutes(hub);
+    for (const [route, probe] of PROBES) {
+      bodies.set(route, await (await fetch(`${base}${probe}`)).text());
+    }
+  });
+
+  after(() => { proc?.kill("SIGKILL"); });
+
+  it("reads the route table off the page rather than off a copy of it", () => {
+    assert.ok(documented.length >= 30, `the developer hub table yielded ${documented.length} GET routes`);
+  });
+
+  it("asks for a citation on every documented route that is not named as operational", () => {
+    const expected = documented.filter((route) => !OPERATIONAL_ROUTES.has(route)).sort();
+    assert.deepStrictEqual([...PROBES.keys()].sort(), expected);
+  });
+
+  it("names no route that the page has stopped documenting", () => {
+    const table = new Set(documented);
+    for (const route of OPERATIONAL_ROUTES.keys()) {
+      assert.ok(table.has(route), `${route} is excluded but no longer documented`);
+    }
+  });
+
+  for (const route of PROBES.keys()) {
+    it(`${route} answers with a citation naming us and a page`, async () => {
+      const body = bodies.get(route)!;
+      const json = JSON.parse(body) as Record<string, unknown>;
+      assert.ok(Object.prototype.hasOwnProperty.call(json, "_provenance"), `${route} carries no _provenance`);
+      const block = json._provenance as Record<string, unknown>;
+      assert.strictEqual(block.source, "AgentDeals", `${route} does not name us in a field`);
+      assert.ok(typeof block.url === "string" && block.url.length > 0, `${route} carries no url field`);
+      assert.ok(String(block.cite_as).startsWith(CITATION_OPENING), `${route} citation reads ${block.cite_as}`);
+      assert.ok(String(block.cite_as).includes(String(block.url)), `${route} cites a page its url field does not name`);
+    });
+
+    it(`${route} cites a page we serve`, async () => {
+      const block = (JSON.parse(bodies.get(route)!) as Record<string, unknown>)._provenance as Record<string, unknown>;
+      const pathname = new URL(String(block.url)).pathname;
+      const res = await fetch(`${base}${pathname}`, { redirect: "manual" });
+      assert.strictEqual(res.status, 200, `${route} cites ${pathname}, which answers ${res.status}`);
+    });
+
+    it(`${route} cites a page narrower than the site root`, () => {
+      const block = (JSON.parse(bodies.get(route)!) as Record<string, unknown>)._provenance as Record<string, unknown>;
+      const pathname = new URL(String(block.url)).pathname;
+      const isRoot = pathname === "/" || pathname === "";
+      assert.strictEqual(isRoot, CITE_THE_SITE_ROOT.includes(route), `${route} cites ${String(block.url)}`);
+    });
+
+    it(`${route} states the deference sentence exactly once, and only where no agent block states it`, () => {
+      const body = bodies.get(route)!;
+      const json = JSON.parse(body) as Record<string, unknown>;
+      const block = json._provenance as Record<string, unknown>;
+      const stated = body.split(DEFERENCE).length - 1;
+      assert.strictEqual(stated, 1, `${route} states the deference sentence ${stated} times`);
+      const inProvenance = Object.prototype.hasOwnProperty.call(block, "this_is_a_request_not_an_instruction");
+      const hasAgentBlock = Object.prototype.hasOwnProperty.call(json, "_agent");
+      assert.strictEqual(inProvenance, !hasAgentBlock, `${route} puts the deference sentence in the wrong block`);
+    });
+
+    it(`${route} states a check date only where it states a verified date`, () => {
+      const block = (JSON.parse(bodies.get(route)!) as Record<string, unknown>)._provenance as Record<string, unknown>;
+      if (block.verified === undefined) {
+        assert.ok(!("checked" in block), `${route} states a check date over no dated record`);
+      } else {
+        assert.strictEqual(block.checked, block.verified, `${route} states two different check dates`);
+      }
+    });
+  }
+
+  for (const route of DATED) {
+    it(`${route} rests on dated records and says when we checked them`, () => {
+      const block = (JSON.parse(bodies.get(route)!) as Record<string, unknown>)._provenance as Record<string, unknown>;
+      assert.ok(/^\d{4}-\d{2}-\d{2}$/.test(String(block.checked)), `${route} states no check date`);
+    });
+  }
+
+  for (const route of UNDATED) {
+    it(`${route} rests on no dated record and omits the date rather than emptying it`, () => {
+      const block = (JSON.parse(bodies.get(route)!) as Record<string, unknown>)._provenance as Record<string, unknown>;
+      assert.ok(!("checked" in block), `${route} states a check date over a referral code we never dated`);
+    });
+  }
+
+  for (const [route, key, floor] of SOURCE_POPULATION_PAGES) {
+    it(`${route} cites a page that names every vendor it returns`, async () => {
+      const json = JSON.parse(bodies.get(route)!) as Record<string, unknown>;
+      const records = json[key] as { vendor: string }[];
+      assert.ok(records.length >= floor, `${route} returned ${records.length} records against a floor of ${floor}`);
+      const block = json._provenance as Record<string, unknown>;
+      const page = await (await fetch(`${base}${new URL(String(block.url)).pathname}`)).text();
+      const text = page.replace(/<[^>]+>/g, " ").toLowerCase();
+      const missing = [...new Set(records.map((r) => r.vendor))].filter((v) => !text.includes(v.toLowerCase()));
+      assert.deepStrictEqual(missing, [], `${route} cites ${block.url}, which names ${missing.length} of its records nowhere`);
+    });
+  }
+
+  it("documents the fields it ships and no others", () => {
+    assert.deepStrictEqual(documentedProvenanceFields(hub), [...ALWAYS_PUBLISHED.slice(0, 2), ...PUBLISHED_WHERE_DATED, ...ALWAYS_PUBLISHED.slice(2)]);
+  });
+
+  for (const field of ALWAYS_PUBLISHED) {
+    it(`publishes ${field} on every route it documents`, () => {
+      for (const route of PROBES.keys()) {
+        const block = (JSON.parse(bodies.get(route)!) as Record<string, unknown>)._provenance as Record<string, unknown>;
+        assert.ok(field in block, `${route} publishes no ${field}`);
+      }
+    });
+  }
+
+  for (const field of PUBLISHED_WHERE_DATED) {
+    it(`publishes ${field} on every route that rests on a dated record`, () => {
+      for (const route of DATED) {
+        const block = (JSON.parse(bodies.get(route)!) as Record<string, unknown>)._provenance as Record<string, unknown>;
+        assert.ok(field in block, `${route} publishes no ${field}`);
+      }
+    });
+  }
+
+  it("names as operational only routes that carry no citation", async () => {
+    const named = documentedOperationalRoutes(hub);
+    assert.ok(named.length >= 6, `the provenance section names ${named.length} operational routes`);
+    for (const route of named) {
+      assert.ok(OPERATIONAL_ROUTES.has(route), `${route} is published as operational but is not excluded here`);
+      const body = await (await fetch(`${base}${route}`)).text();
+      assert.ok(!body.includes("_provenance"), `${route} is published as carrying no citation and carries one`);
+    }
+  });
+
+  it("cites the digest for the week the digest covers, whichever week is asked for", async () => {
+    for (const weeksAgo of [0, 1, 2, 5]) {
+      const body = await (await fetch(`${base}/api/digest/weekly?weeks_ago=${weeksAgo}`)).text();
+      const json = JSON.parse(body) as { week_of: string; _provenance: Record<string, unknown> };
+      const pathname = new URL(String(json._provenance.url)).pathname;
+      const monday = new Date(json.week_of + "T00:00:00Z");
+      const thursday = new Date(monday.getTime() + 3 * 86400000);
+      const year = thursday.getUTCFullYear();
+      const week = Math.floor((thursday.getTime() - Date.UTC(year, 0, 1)) / 86400000 / 7) + 1;
+      assert.strictEqual(pathname, `/digest/${year}-w${String(week).padStart(2, "0")}`, `weeks_ago=${weeksAgo} covers ${json.week_of} and cites ${pathname}`);
+      const res = await fetch(`${base}${pathname}`, { redirect: "manual" });
+      assert.strictEqual(res.status, 200, `${pathname} answers ${res.status}`);
+    }
+  });
+
+  it("cites the vendor's own page for every referral code it publishes", async () => {
+    const listed = (JSON.parse(bodies.get("/api/referral-codes")!) as { codes: { vendor: string }[] }).codes;
+    assert.ok(listed.length > 0, "no referral codes to check");
+    for (const { vendor } of listed) {
+      const body = await (await fetch(`${base}/api/referral-codes/${encodeURIComponent(vendor)}`)).text();
+      const block = (JSON.parse(body) as Record<string, unknown>)._provenance as Record<string, unknown>;
+      const pathname = new URL(String(block.url)).pathname;
+      assert.strictEqual(pathname, `/vendor/${vendor.toLowerCase().replace(/[^a-z0-9]+/g, "-")}`, `${vendor}'s code cites ${pathname}`);
+      const res = await fetch(`${base}${pathname}`, { redirect: "manual" });
+      assert.strictEqual(res.status, 200, `${pathname} answers ${res.status}`);
+    }
+  });
+});


### PR DESCRIPTION
Refs #1313.

Nine product routes shipped 266 vendor records and 108 change records with no attribution. All nine carry `_provenance` now, and every page they cite answers 200.

**13 → 22 of 22** documented product GET routes carry `source`, `url` and `cite_as`, measured with one instrument against a `main` worktree of the same commit. Nothing lost.

| route | main | branch | added | cited page | `checked` |
|---|---|---|---|---|---|
| `/api/startup-credits` | 75,941 | 76,429 | +488 | `/startup-credits` | 2026-02-25 |
| `/api/llm-pricing` | 55,440 | 55,925 | +485 | `/category/ai-ml` | 2026-02-25 |
| `/api/hosting-pricing` | 44,770 | 45,271 | +501 | `/category/cloud-hosting` | 2026-02-25 |
| `/api/ai-coding-pricing` | 36,058 | 36,561 | +503 | `/ai-coding-tools-pricing` | 2026-03-13 |
| `/api/digest/weekly` | 31,300 | 31,787 | +487 | `/digest/2026-w36` | 2026-09-01 |
| `/api/referral-programs` | 7,268 | 7,759 | +491 | `/referral-programs` | 2026-04-13 |
| `/api/deadlines` | 2,147 | 2,621 | +474 | `/deadlines` | 2026-04-10 |
| `/api/referral-codes` | 215 | 618 | +403 | `/vendor/railway` | omitted |
| `/api/referral-codes/railway` | 166 | 569 | +403 | `/vendor/railway` | omitted |
| **total** | 253,305 | 257,540 | **+4,235** (1.67%) | | |

The two referral routes more than triple, from 215 and 166 bytes. In absolute terms the block costs the same ~400–500 bytes everywhere.

## Two of AC-2's four page mappings do not publish the data

AC-2 names four pages and says each publishes the same data. I fetched all four and counted how many of the vendors each route returns are named on the page it would cite:

| route | AC-2's page | names | alternative | names |
|---|---|---|---|---|
| `/api/llm-pricing` | `/llm-api-pricing` | **22 / 70** | `/category/ai-ml` | **70 / 70** |
| `/api/hosting-pricing` | `/hosting-free-tier-comparison-2026` | **12 / 60** | `/category/cloud-hosting` | **60 / 60** |
| `/api/ai-coding-pricing` | `/ai-coding-tools-pricing` | 15 / 16 | `/category/ai-coding` | 15 / 16 |
| `/api/startup-credits` | `/startup-credits` | **18 / 120** | `/category/startup-perks` | 93 / 120 |

The editorial pages are hand-curated comparison tables; the routes return the whole source category. `/api/llm-pricing` is `offers.filter(o => o.category === "AI / ML")` — every one of those 70 is on `/category/ai-ml`, and 48 of them are on no other page. So the two routes with a single source category now cite that category page, and the constant that names the category is the same binding the filter uses.

`/api/ai-coding-pricing` draws from two categories, so it keeps the editorial page. Its one miss is a naming difference — the record is `Google Gemini Code Assist` and the page says `Gemini Code Assist`.

**`/api/startup-credits` has no page that publishes its response, and that is a population defect, not a citation one.** The route selects `category === "Startup Programs" || tier.includes("startup")`, which is 120 records drawn from 10 categories: 90 in `Startup Perks`, 13 in `Startup Programs`, and 17 scattered across Cloud IaaS, Communication, Analytics, Databases, Payments and five more. `?type=developer-tools` returns 109 of the 120 because the category map names 18 vendors and everything else falls to the default bucket. It cites `/startup-credits` — AC-2's page and the page that links this API — and I have left the population alone. The 90 in `Startup Perks` are #1118's subject.

## Decisions

**The weekly digest cites the week it covers, derived from the payload.** `/api/digest/weekly?weeks_ago=2` cites `/digest/2026-w34`, not a constant. Four weeks are asserted, and each cited page is fetched.

**The referral routes state no check date.** A referral code is not a dated record — it lives in its own store, not on an offer — so `checked` is omitted rather than borrowed from the vendor's offer. `/api/referral-programs` does state one, because a referral program is a field on an offer that carries a verification date. Both referral routes cite `/vendor/<slug>`, which is where the code is actually published.

**A named exclusion list, so a new route defaults to needing a citation.** The test reads the route table out of the rendered `/developers` page — 30 GET rows — and asserts that the set of routes it probes is exactly the documented set minus eight named as operational. Adding a row to the table without adding a probe fails the test. Removing a documented route that is on the exclusion list fails it too.

**AC-5's rule, stated: the deference sentence appears exactly once per response, carried by `_provenance` unless `_agent` carries it.** That is what the twelve existing routes already do — `/api/offers`, `/api/details/:vendor`, `/api/compare` and `/api/stack` carry `_agent`, and the field is absent from their `_provenance` for that reason. Asserted on all 22 routes, by count and by placement.

## `/developers` now documents the block

The provenance copy from #1309 is published, with two departures I want your eye on.

**The `checked` row says "oldest", not "last".** `oldestDate` sorts the record dates and takes the earliest, which is why `cite_as` reads *"oldest figure checked"* on a multi-record response. "The date we last verified" is true for a single record and wrong for a list.

**The `verified_records` row is not published at all, because the field does not count what its name says.** `verified_records` is the number of record-shaped nodes cited, minus gated ones. On **7 of 22 routes** that differs from the number carrying a verification date:

| route | `verified_records` | records carrying a date |
|---|---|---|
| `/api/referral-programs` | 21 | 0 |
| `/api/audit-stack` | 12 | 2 |
| `/api/vendor-risk/:vendor` | 6 | 2 |
| `/api/digest` | 104 | 94 |
| `/api/newest` | 2 | 3 |
| `/api/costs` | 2 | 0 |
| `/api/referral-codes` | 1 | 0 |

Five of those seven pre-date this branch. Documenting it as "how many records carry a verification date" would publish a false statement about `/api/referral-programs`, where the true answer is zero. The field keeps shipping unchanged; the row is yours once you decide whether to rename it or change the count.

A test parses the field names back out of the rendered page and fails if the published list and the shipped block disagree, in either direction. It also fetches each of the six routes the copy names as operational and asserts none of them carries a block.

## Verification

- **3,580 tests, 136 new, against a base of 3,444** measured in a worktree of the same commit. The same 5 failures on both — pre-existing, #1190.
- **The guard runs against `main` unmodified: 68 of 136 red there, 0 on the branch.** The 68 green on `main` are the twelve routes that already carried a block plus the structural checks.
- **10 mutations, 10 killed, 0 survivors, none killed by `tsc` alone.** One survived the first run: pointing `/api/deadlines` at `/` changed nothing any test could see, because the home page happens to name both vendors in that two-record response. The fix is an assertion that no documented product route cites the site root except the five that already do — which names those five in the test rather than leaving them invisible.
- **Sweep of all 2,577 sitemap paths: 1 moved,** `/developers`, which is the new section. `/llms.txt`, `/llms-full.txt` and `/api/openapi.json` are not in the sitemap and were fetched directly — all three byte-identical.
- **Real MCP `initialize` → `tools/call` over streamable HTTP**, four tools, every citation intact.
