### PR TITLE
Run the suite before a scheduled data commit reaches main (#1317)

### DIFF
--- a/.github/workflows/analytics-rollup.yml
+++ b/.github/workflows/analytics-rollup.yml
@@ -25,7 +25,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "24.20.0"
           cache: "npm"
 
       - name: Install dependencies
@@ -48,16 +48,11 @@ jobs:
           WRITTEN=$(grep -oE '^Rolled up: [0-9]+' /tmp/rollup.log | grep -oE '[0-9]+$' || echo 0)
           echo "written=$WRITTEN" >> "$GITHUB_OUTPUT"
 
-      - name: Commit and push if changed
+      - name: Run the suite, then push to main only if it is green
         env:
           WRITTEN: ${{ steps.rollup.outputs.written }}
         run: |
-          if [ -z "$(git status --porcelain -- data/analytics)" ]; then
-            echo "No change under data/analytics — skipping commit."
-            exit 0
-          fi
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add data/analytics
-          git commit -m "data(auto): analytics rollup — ${WRITTEN} day(s)"
-          git push origin HEAD:main
+          bash scripts/gate-data-push.sh \
+            data-quarantine/analytics-rollup \
+            "data(auto): analytics rollup — ${WRITTEN} day(s)" \
+            data/analytics

--- a/.github/workflows/liveness.yml
+++ b/.github/workflows/liveness.yml
@@ -20,7 +20,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "24.20.0"
           cache: "npm"
 
       - name: Install dependencies
@@ -39,17 +39,12 @@ jobs:
           echo "unreachable=$UNREACHABLE" >> "$GITHUB_OUTPUT"
           echo "unknown=$UNKNOWN" >> "$GITHUB_OUTPUT"
 
-      - name: Commit and push if changed
+      - name: Run the suite, then push to main only if it is green
         env:
           UNREACHABLE: ${{ steps.liveness.outputs.unreachable }}
           UNKNOWN: ${{ steps.liveness.outputs.unknown }}
         run: |
-          if git diff --quiet -- data/link_health.json; then
-            echo "No change to data/link_health.json — skipping commit."
-            exit 0
-          fi
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add data/link_health.json
-          git commit -m "data(auto): link liveness — ${UNREACHABLE} unreachable, ${UNKNOWN} could not be checked"
-          git push origin HEAD:main
+          bash scripts/gate-data-push.sh \
+            data-quarantine/link-liveness \
+            "data(auto): link liveness — ${UNREACHABLE} unreachable, ${UNKNOWN} could not be checked" \
+            data/link_health.json

--- a/.github/workflows/reverify.yml
+++ b/.github/workflows/reverify.yml
@@ -53,7 +53,7 @@ jobs:
           echo "retried=$RETRIED" >> "$GITHUB_OUTPUT"
           echo "repicked=$REPICKED" >> "$GITHUB_OUTPUT"
 
-      - name: Commit and push if changed
+      - name: Run the suite, then push to main only if it is green
         env:
           VERIFIED: ${{ steps.reverify.outputs.verified }}
           FLAGGED: ${{ steps.reverify.outputs.flagged }}
@@ -62,16 +62,10 @@ jobs:
           RETRIED: ${{ steps.reverify.outputs.retried }}
           REPICKED: ${{ steps.reverify.outputs.repicked }}
         run: |
-          TRACKED="data/index.json data/deal_changes.json data/change_refusals.json data/verification_state.json"
-          if git diff --quiet -- $TRACKED; then
-            echo "No changes to $TRACKED — skipping commit."
-            exit 0
-          fi
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add $TRACKED
-          git commit -m "data(auto): rolling re-verification — ${VERIFIED} verified, ${FLAGGED} flagged, ${RECORDED} changes recorded, ${RETRIED} retried from quarantine, ${QUARANTINED} in quarantine, ${REPICKED} to be checked again"
-          git push origin HEAD:main
+          bash scripts/gate-data-push.sh \
+            data-quarantine/rolling-reverification \
+            "data(auto): rolling re-verification — ${VERIFIED} verified, ${FLAGGED} flagged, ${RECORDED} changes recorded, ${RETRIED} retried from quarantine, ${QUARANTINED} in quarantine, ${REPICKED} to be checked again" \
+            data/index.json data/deal_changes.json data/change_refusals.json data/verification_state.json
 
       - name: Check the change log is still being written to
         id: staleness

--- a/data/index.json
+++ b/data/index.json
@@ -2618,7 +2618,7 @@
       "source_check": {
         "checked": "2026-09-03",
         "outcome": "states_no_amount",
-        "detail": "the page names jsDelivr and says \"free API\" but states no amount, rate or price we can read, and the 1 structured-data block in its markup state no price"
+        "detail": "the page names jsDelivr and says \"free API\" but states no amount, rate or price we can read, and the 1 structured-data block in its markup states no price"
       }
     },
     {
@@ -32561,7 +32561,7 @@
       "source_check": {
         "checked": "2026-09-03",
         "outcome": "states_no_amount",
-        "detail": "the page names LastPass and says \"Business Plans\" but states no amount, rate or price we can read, and the 1 structured-data block in its markup state no price"
+        "detail": "the page names LastPass and says \"Business Plans\" but states no amount, rate or price we can read, and the 1 structured-data block in its markup states no price"
       }
     },
     {

--- a/scripts/gate-data-push.sh
+++ b/scripts/gate-data-push.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ "$#" -lt 3 ]; then
+  echo "usage: gate-data-push.sh <quarantine-branch> <commit-message> <path>..." >&2
+  exit 2
+fi
+
+QUARANTINE_BRANCH="$1"
+MESSAGE="$2"
+shift 2
+
+if [ -z "$(git status --porcelain -- "$@")" ]; then
+  echo "No change under $* — nothing to commit or push."
+  exit 0
+fi
+
+git config user.name "github-actions[bot]"
+git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+git add -- "$@"
+git commit -q -m "$MESSAGE"
+COMMIT="$(git rev-parse --short HEAD)"
+
+LOG="$(mktemp)"
+trap 'rm -f "$LOG"' EXIT
+
+if npm run build >"$LOG" 2>&1 && npm test >>"$LOG" 2>&1; then
+  grep -E '(tests|pass|fail) [0-9]+$' "$LOG" | tail -3 || true
+  git push origin HEAD:main
+  echo "Suite green — $COMMIT is on main."
+  exit 0
+fi
+
+grep -E '(tests|pass|fail) [0-9]+$' "$LOG" | tail -3 || true
+if grep -q 'failing tests:' "$LOG"; then
+  sed -n '/failing tests:/,$p' "$LOG"
+else
+  tail -n 60 "$LOG"
+fi
+
+git push --force origin "HEAD:refs/heads/$QUARANTINE_BRANCH"
+echo "Suite red — $COMMIT is held on $QUARANTINE_BRANCH and main is unchanged."
+exit 1

--- a/scripts/structured-prices.js
+++ b/scripts/structured-prices.js
@@ -121,7 +121,8 @@ export function structuredDetail(structured) {
   if (!structured) return null;
   if (structured.blocks === 0) return NO_STRUCTURED_DATA;
   if (structured.prices.length === 0) {
-    return `the ${structured.blocks} structured-data block${structured.blocks === 1 ? "" : "s"} in its markup state no price`;
+    const many = structured.blocks !== 1;
+    return `the ${structured.blocks} structured-data block${many ? "s" : ""} in its markup ${many ? "state" : "states"} no price`;
   }
   return `its markup states ${priceList(structured.prices)}`;
 }

--- a/test/data-push-gate.test.ts
+++ b/test/data-push-gate.test.ts
@@ -1,0 +1,221 @@
+import { describe, it, before, after } from "node:test";
+import assert from "node:assert";
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, mkdirSync, readFileSync, readdirSync, rmSync, writeFileSync, existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REPO = join(__dirname, "..");
+const WORKFLOWS = join(REPO, ".github", "workflows");
+const GATE = join(REPO, "scripts", "gate-data-push.sh");
+
+const GATED_WORKFLOWS = ["reverify.yml", "liveness.yml", "analytics-rollup.yml"];
+
+function workflowFiles(): string[] {
+  return readdirSync(WORKFLOWS).filter((f) => /\.ya?ml$/.test(f)).sort();
+}
+
+function source(file: string): string {
+  return readFileSync(join(WORKFLOWS, file), "utf8");
+}
+
+function nodeVersionsOf(text: string): string[] {
+  return [...text.matchAll(/node-version:\s*"?([0-9][0-9.]*)"?/g)].map((m) => m[1]!);
+}
+
+function quarantineBranchOf(text: string): string | null {
+  return text.match(/gate-data-push\.sh\s*\\?\s*\n?\s*([A-Za-z0-9/_.-]+)/)?.[1] ?? null;
+}
+
+describe("#1317 the suite sees every commit that reaches main", () => {
+  it("reads the workflows, so the assertions below have subjects", () => {
+    const files = workflowFiles();
+    assert.ok(files.length >= 6, `this test needs the workflows to check, found ${files.length}`);
+    for (const file of GATED_WORKFLOWS) {
+      assert.ok(files.includes(file), `${file} is not among ${files.join(", ")}`);
+    }
+  });
+
+  it("pushes to main from one place only, and that place runs the suite first", () => {
+    const offenders: string[] = [];
+    for (const file of workflowFiles()) {
+      for (const line of source(file).split("\n")) {
+        if (/git\s+push/.test(line) && /\bmain\b/.test(line)) offenders.push(`${file}: ${line.trim()}`);
+      }
+    }
+    assert.deepStrictEqual(
+      offenders,
+      [],
+      `a workflow pushes to main without the gate, so its commit reaches main untested: ${offenders.join("; ")}`,
+    );
+
+    const gate = readFileSync(GATE, "utf8");
+    const pushes = gate.split("\n").filter((l) => /git push/.test(l) && /\bmain\b/.test(l));
+    assert.strictEqual(pushes.length, 1, `the gate should hold exactly one push to main, holds ${pushes.length}`);
+    assert.ok(
+      gate.indexOf("npm test") < gate.indexOf("HEAD:main"),
+      "the gate pushes to main before it runs the suite",
+    );
+  });
+
+  it("routes every scheduled data writer through the gate, each with its own quarantine branch", () => {
+    const branches = new Map<string, string>();
+    for (const file of GATED_WORKFLOWS) {
+      const text = source(file);
+      assert.match(text, /bash scripts\/gate-data-push\.sh/, `${file} does not invoke the gate`);
+      const branch = quarantineBranchOf(text);
+      assert.ok(branch?.startsWith("data-quarantine/"), `${file} names no quarantine branch, got ${branch}`);
+      assert.ok(!branches.has(branch!), `${file} shares the quarantine branch ${branch} with ${branches.get(branch!)}`);
+      branches.set(branch!, file);
+    }
+    assert.strictEqual(branches.size, GATED_WORKFLOWS.length);
+  });
+
+  it("runs the gate on the Node the suite is pinned to, so the suite can load its own test files", () => {
+    const pinned = nodeVersionsOf(source("tests.yml"));
+    assert.strictEqual(pinned.length, 1, `tests.yml should pin one Node version, pins ${pinned.join(", ")}`);
+    for (const file of GATED_WORKFLOWS) {
+      assert.deepStrictEqual(
+        nodeVersionsOf(source(file)),
+        pinned,
+        `${file} runs the suite on a different Node than tests.yml pins (${pinned[0]})`,
+      );
+    }
+  });
+});
+
+const SUITE = `const red = process.env.GATE_FIXTURE_TESTS === "red";
+console.log("\\u2139 tests 2");
+console.log("\\u2139 pass " + (red ? 1 : 2));
+console.log("\\u2139 fail " + (red ? 1 : 0));
+if (red) {
+  console.log("\\u2716 failing tests:");
+  console.log("the fixture assertion the data broke");
+  process.exit(1);
+}
+`;
+
+const PACKAGE = JSON.stringify(
+  { name: "gate-fixture", version: "1.0.0", private: true, scripts: { build: "node --version", test: "node suite.js" } },
+  null,
+  2,
+);
+
+let scratch: string;
+
+function git(cwd: string, ...args: string[]): string {
+  const run = spawnSync("git", args, { cwd, encoding: "utf8" });
+  assert.strictEqual(run.status, 0, `git ${args.join(" ")} -> ${run.status}: ${run.stderr}`);
+  return run.stdout.trim();
+}
+
+function fixtureRepo(): { work: string; origin: string } {
+  const root = mkdtempSync(join(scratch, "repo-"));
+  const origin = join(root, "origin.git");
+  const work = join(root, "work");
+  spawnSync("git", ["init", "--bare", "--initial-branch=main", origin], { encoding: "utf8" });
+  git(root, "clone", origin, work);
+  git(work, "config", "user.email", "fixture@example.com");
+  git(work, "config", "user.name", "fixture");
+  mkdirSync(join(work, "data"), { recursive: true });
+  writeFileSync(join(work, "package.json"), PACKAGE);
+  writeFileSync(join(work, "suite.js"), SUITE);
+  writeFileSync(join(work, "data", "health.json"), '{"checked":1}\n');
+  writeFileSync(join(work, "untracked-by-the-gate.txt"), "before\n");
+  git(work, "add", "-A");
+  git(work, "commit", "-m", "fixture");
+  git(work, "push", "origin", "HEAD:main");
+  return { work, origin };
+}
+
+function runGate(work: string, red: boolean, ...args: string[]) {
+  return spawnSync("bash", [GATE, ...args], {
+    cwd: work,
+    encoding: "utf8",
+    env: { ...process.env, GATE_FIXTURE_TESTS: red ? "red" : "green" },
+  });
+}
+
+function mainSha(origin: string): string {
+  return git(origin, "rev-parse", "main");
+}
+
+function branchExists(origin: string, branch: string): boolean {
+  return spawnSync("git", ["rev-parse", "--verify", branch], { cwd: origin, encoding: "utf8" }).status === 0;
+}
+
+describe("#1317 the gate, run against a repository", () => {
+  before(() => {
+    scratch = mkdtempSync(join(tmpdir(), "gate-data-push-"));
+  });
+
+  after(() => {
+    if (scratch && existsSync(scratch)) rmSync(scratch, { recursive: true, force: true });
+  });
+
+  it("stops a data change the suite refuses, and holds it on the quarantine branch", () => {
+    const { work, origin } = fixtureRepo();
+    const before = mainSha(origin);
+    writeFileSync(join(work, "data", "health.json"), '{"checked":2}\n');
+
+    const run = runGate(work, true, "data-quarantine/fixture", "data(auto): fixture", "data/health.json");
+
+    assert.strictEqual(run.status, 1, `the gate let a red suite through: ${run.stdout}${run.stderr}`);
+    assert.strictEqual(mainSha(origin), before, "main moved on a commit the suite refused");
+    assert.ok(branchExists(origin, "data-quarantine/fixture"), "the refused commit was not held anywhere");
+    assert.strictEqual(
+      git(origin, "show", "data-quarantine/fixture:data/health.json"),
+      '{"checked":2}',
+      "the quarantine branch does not carry the data the run produced",
+    );
+    assert.match(run.stdout, /the fixture assertion the data broke/, "the failing test is not named in the log");
+    assert.match(run.stdout, /main is unchanged/);
+  });
+
+  it("pushes a data change the suite accepts", () => {
+    const { work, origin } = fixtureRepo();
+    const before = mainSha(origin);
+    writeFileSync(join(work, "data", "health.json"), '{"checked":3}\n');
+
+    const run = runGate(work, false, "data-quarantine/fixture", "data(auto): fixture", "data/health.json");
+
+    assert.strictEqual(run.status, 0, `the gate refused a green suite: ${run.stdout}${run.stderr}`);
+    assert.notStrictEqual(mainSha(origin), before);
+    assert.strictEqual(git(origin, "show", "main:data/health.json"), '{"checked":3}');
+    assert.strictEqual(git(origin, "log", "-1", "--format=%s", "main"), "data(auto): fixture");
+    assert.ok(!branchExists(origin, "data-quarantine/fixture"), "a green run opened a quarantine branch");
+  });
+
+  it("commits nothing when the run produced no data change, and leaves the suite unrun", () => {
+    const { work, origin } = fixtureRepo();
+    const before = mainSha(origin);
+
+    const run = runGate(work, true, "data-quarantine/fixture", "data(auto): fixture", "data/health.json");
+
+    assert.strictEqual(run.status, 0, run.stdout + run.stderr);
+    assert.strictEqual(mainSha(origin), before);
+    assert.match(run.stdout, /nothing to commit or push/);
+    assert.doesNotMatch(run.stdout, /tests 2/, "the gate ran the suite with nothing to push");
+  });
+
+  it("commits only the paths it was given, so an unrelated file cannot ride along", () => {
+    const { work, origin } = fixtureRepo();
+    writeFileSync(join(work, "data", "health.json"), '{"checked":4}\n');
+    writeFileSync(join(work, "untracked-by-the-gate.txt"), "after\n");
+
+    const run = runGate(work, false, "data-quarantine/fixture", "data(auto): fixture", "data/health.json");
+
+    assert.strictEqual(run.status, 0, run.stdout + run.stderr);
+    assert.strictEqual(git(origin, "show", "main:untracked-by-the-gate.txt"), "before");
+    assert.strictEqual(git(work, "diff", "--name-only"), "untracked-by-the-gate.txt");
+  });
+
+  it("refuses to run without a quarantine branch, a message and a path", () => {
+    const { work } = fixtureRepo();
+    const run = runGate(work, false, "data-quarantine/fixture", "data(auto): fixture");
+    assert.strictEqual(run.status, 2);
+    assert.match(run.stderr, /usage: gate-data-push\.sh/);
+  });
+});

--- a/test/no-private-context.test.ts
+++ b/test/no-private-context.test.ts
@@ -102,9 +102,11 @@ describe("no private operational context in tracked source", () => {
   it("scans a meaningful number of files", () => {
     assert.ok(files.length > 50, `only ${files.length} files scanned — the walk is broken`);
     const rel = files.map((f) => relative(REPO, f));
-    for (const expected of ["src/serve.ts", "src/stats.ts", "README.md"]) {
+    for (const expected of ["src/serve.ts", "src/stats.ts", "README.md", join(".github", "workflows", "tests.yml")]) {
       assert.ok(rel.includes(expected), `${expected} was not scanned`);
     }
+    const shell = rel.filter((f) => f.endsWith(".sh"));
+    assert.ok(shell.length > 0, "no shell script was scanned, and the repository ships them");
   });
 
   for (const rule of RULES) {

--- a/test/no-private-context.test.ts
+++ b/test/no-private-context.test.ts
@@ -7,8 +7,8 @@ import { fileURLToPath } from "node:url";
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const REPO = join(__dirname, "..");
 
-const ROOTS = ["src", "test", "scripts", "docs"];
-const EXTENSIONS = [".ts", ".js", ".mjs", ".md", ".json"];
+const ROOTS = ["src", "test", "scripts", "docs", join(".github", "workflows")];
+const EXTENSIONS = [".ts", ".js", ".mjs", ".md", ".json", ".sh", ".yml", ".yaml"];
 const SKIP_DIRS = new Set(["node_modules", "dist", ".git", "data", "coverage"]);
 
 const SELF = relative(REPO, fileURLToPath(import.meta.url));

--- a/test/price-evidence-grade.test.ts
+++ b/test/price-evidence-grade.test.ts
@@ -20,6 +20,7 @@ const INDEX_PATH = path.join(__dirname, "..", "data", "index.json");
 const { priceSignals, numericPriceSignals } = await import("../scripts/change-gate.js");
 const { classifySource, holdsVerifiedDate, statesAnAmount, SOURCE_CHECK_NO_AMOUNT } =
   await import("../scripts/vendor-naming.js");
+const { structuredDetail, NO_STRUCTURED_DATA } = await import("../scripts/structured-prices.js");
 
 const OFFER = {
   vendor: "Widgetson",
@@ -209,8 +210,36 @@ describe("the catalog after the grade was applied", () => {
     for (const offer of graded) {
       assert.match(
         offer.source_check!.detail,
-        /^the page names .+ and says ".+" but states no amount, rate or price we can read$/,
+        /^the page names .+ and says ".+" but states no amount, rate or price we can read(, and .+)?$/,
         `${offer.vendor} carries a detail the grade did not write`
+      );
+    }
+  });
+
+  it("closes a markup clause with the phrase the writer composes, not one an older shape allowed", () => {
+    const clauses = graded
+      .map((o) => ({
+        vendor: o.vendor,
+        clause: o.source_check!.detail.match(/ but states no amount, rate or price we can read, and (.+)$/)?.[1],
+      }))
+      .filter((c): c is { vendor: string; clause: string } => Boolean(c.clause));
+    assert.ok(clauses.length > 0, "no graded record carries a markup clause, so this assertion has no subject");
+
+    for (const { vendor, clause } of clauses) {
+      if (clause === NO_STRUCTURED_DATA) continue;
+      const blocks = Number(clause.match(/^the (\d+) structured-data blocks? in its markup states? no price$/)?.[1]);
+      if (Number.isInteger(blocks)) {
+        assert.strictEqual(
+          clause,
+          structuredDetail({ blocks, parsed: blocks, prices: [] }),
+          `${vendor} carries a clause the writer would compose differently`
+        );
+        continue;
+      }
+      assert.match(
+        clause,
+        /^its markup states \d+ typed prices? \(.+\)$/,
+        `${vendor} carries a clause structuredDetail does not compose: ${clause}`
       );
     }
   });

--- a/test/risk-badge.test.ts
+++ b/test/risk-badge.test.ts
@@ -79,18 +79,33 @@ describe("#1038 — the level is earned", () => {
     }
   });
 
-  it("a vendor whose only history is limits_increased renders stable, live", async () => {
-    const { loadDealChanges } = await import("../dist/data.js");
-    const railway = changesByVendor(loadDealChanges()).get("railway") ?? [];
-    assert.ok(railway.length > 0, "expected Railway to still hold change records");
+  it("every vendor whose only history is limits_increased renders stable, live", async () => {
+    const { loadDealChanges, loadOffers } = await import("../dist/data.js");
+    const changes = loadDealChanges() as Change[];
+    const subjects = new Map<string, string>();
+    for (const offer of loadOffers()) {
+      const own = changes.filter((c) => c.vendor.toLowerCase() === offer.vendor.toLowerCase());
+      if (own.length > 0 && own.every((c) => c.change_type === "limits_increased")) {
+        subjects.set(toSlug(offer.vendor), offer.vendor);
+      }
+    }
     assert.ok(
-      railway.every((c) => c.change_type === "limits_increased"),
-      "this test is anchored on Railway holding only limits_increased; its records have changed, re-anchor it",
+      subjects.size > 0,
+      "no vendor in the catalog holds a limits_increased-only history, so this assertion has no subject",
     );
-    const { text } = await get("/vendor/railway");
-    const h1 = text.match(/<h1>[\s\S]*?<\/h1>/)?.[0] ?? "";
-    assert.ok(h1.length > 0, "no <h1> on /vendor/railway");
-    assert.ok(!/caution|risky/.test(h1), `Railway's <h1> still carries a warning: ${h1}`);
+
+    const warned: string[] = [];
+    for (const [slug, vendor] of subjects) {
+      const { status, text } = await get(`/vendor/${slug}`);
+      if (status !== 200) {
+        warned.push(`${vendor} has a favourable-only history and no page at /vendor/${slug} (${status})`);
+        continue;
+      }
+      const h1 = text.match(/<h1>[\s\S]*?<\/h1>/)?.[0] ?? "";
+      if (h1.length === 0) warned.push(`no <h1> on /vendor/${slug}`);
+      else if (/caution|risky/.test(h1)) warned.push(`${vendor}: ${h1.replace(/\s+/g, " ")}`);
+    }
+    assert.deepStrictEqual(warned, [], `a favourable-only history earned a warning on ${warned.length} of ${subjects.size} pages`);
   });
 
   it("the count of records we hold does not move the level", async () => {

--- a/test/search-recording-wiring.test.ts
+++ b/test/search-recording-wiring.test.ts
@@ -63,6 +63,11 @@ function countFor(list: { query: string; count: number }[], query: string): numb
 async function categoryThatEmpties(query: string): Promise<string> {
   const covered = await get(`/api/offers?q=${query}&limit=2000`);
   assert.ok(covered.total > 0, `${query} matches nothing in the catalog, so it is no longer a covered query`);
+  assert.strictEqual(
+    covered.offers.length,
+    covered.total,
+    `the route returned ${covered.offers.length} of ${covered.total} matches, so the categories below are only part of what "${query}" covers`,
+  );
   const matched = new Set<string>(covered.offers.map((o: { category: string }) => o.category.toLowerCase()));
   const catalog = await get("/api/offers?limit=2000");
   const outside = catalog.offers

--- a/test/search-recording-wiring.test.ts
+++ b/test/search-recording-wiring.test.ts
@@ -16,6 +16,7 @@ let movedAside = false;
 
 const GAP_QUERY = `wiring-gap-${process.pid}`;
 const COVERED_QUERY = "database";
+let emptyingCategory = "";
 
 before(async () => {
   if (existsSync(telemetryPath)) {
@@ -35,6 +36,8 @@ before(async () => {
     });
     proc.on("error", (err) => { clearTimeout(timeout); reject(err); });
   });
+
+  emptyingCategory = await categoryThatEmpties(COVERED_QUERY);
 });
 
 after(() => {
@@ -57,14 +60,33 @@ function countFor(list: { query: string; count: number }[], query: string): numb
   return list.find(e => e.query === query.toLowerCase())?.count ?? 0;
 }
 
+async function categoryThatEmpties(query: string): Promise<string> {
+  const covered = await get(`/api/offers?q=${query}&limit=2000`);
+  assert.ok(covered.total > 0, `${query} matches nothing in the catalog, so it is no longer a covered query`);
+  const matched = new Set<string>(covered.offers.map((o: { category: string }) => o.category.toLowerCase()));
+  const catalog = await get("/api/offers?limit=2000");
+  const outside = catalog.offers
+    .map((o: { category: string }) => o.category)
+    .find((c: string) => !matched.has(c.toLowerCase()));
+  assert.ok(
+    outside,
+    `every one of the catalog's categories now holds a match for "${query}", so no filter can narrow it to zero`,
+  );
+  return outside;
+}
+
 describe("search recording wiring (#1018 Defect C)", () => {
   it("a filter that empties a covered query is not recorded as a catalog gap", async () => {
     const covered = await get(`/api/offers?q=${COVERED_QUERY}&limit=1`);
     assert.ok(covered.total > 0, `${COVERED_QUERY} should match offers; got ${covered.total}`);
 
     const before = await analytics();
-    const filtered = await get(`/api/offers?q=${COVERED_QUERY}&stability=volatile&payment_protocol=x402&limit=1`);
-    assert.strictEqual(filtered.total, 0, "this filter combination should empty the result set");
+    const filtered = await get(`/api/offers?q=${COVERED_QUERY}&category=${encodeURIComponent(emptyingCategory)}&limit=1`);
+    assert.strictEqual(
+      filtered.total,
+      0,
+      `no offer in ${emptyingCategory} matched "${COVERED_QUERY}" when the category was chosen; the catalog now holds ${filtered.total} that do`,
+    );
     const after = await analytics();
 
     assert.strictEqual(
@@ -102,8 +124,12 @@ describe("search recording wiring (#1018 Defect C)", () => {
     const sessionId = await mcpInitialize();
 
     const before = await analytics();
-    const filtered = await mcpSearch(sessionId, { query: COVERED_QUERY, payment_protocol: "x402", stability: "volatile" });
-    assert.strictEqual(filtered.total, 0, "this filter combination should empty the result set");
+    const filtered = await mcpSearch(sessionId, { query: COVERED_QUERY, category: emptyingCategory });
+    assert.strictEqual(
+      filtered.total,
+      0,
+      `no offer in ${emptyingCategory} matched "${COVERED_QUERY}" when the category was chosen; the catalog now holds ${filtered.total} that do`,
+    );
     const mid = await analytics();
 
     assert.strictEqual(

--- a/test/typed-price-read.test.ts
+++ b/test/typed-price-read.test.ts
@@ -217,10 +217,15 @@ describe("a malformed block does not cost us the page", () => {
     assert.match(gradeOf(none).detail, /carries no structured data/);
 
     const priceless = await readWith(page(`<p>${PROSE}</p>`) + ldBlock({ "@type": "Organization", name: "Widgetson" }));
-    assert.match(structuredDetail(priceless.structured) ?? "", /1 structured-data block .* state no price/);
-    assert.match(gradeOf(priceless).detail, /state no price/);
+    assert.strictEqual(structuredDetail(priceless.structured), "the 1 structured-data block in its markup states no price");
+    assert.match(gradeOf(priceless).detail, /states no price/);
 
     assert.strictEqual(structuredDetail(null), null);
+  });
+
+  it("agrees the verb with the number of blocks it counted", () => {
+    assert.strictEqual(structuredDetail({ blocks: 1, parsed: 1, prices: [] }), "the 1 structured-data block in its markup states no price");
+    assert.strictEqual(structuredDetail({ blocks: 2, parsed: 2, prices: [] }), "the 2 structured-data blocks in its markup state no price");
   });
 
   it("leaves a page read without a markup pass described as it was", () => {


### PR DESCRIPTION
Refs #1317.

Three scheduled workflows push to `main` with `GITHUB_TOKEN`, which cannot trigger `tests.yml`, so the commits that rewrite the corpus the suite asserts over are the only commits on `main` the suite never sees. All three now run the suite before the push, and a commit the suite refuses is held on a quarantine branch instead of reaching `main`.

`main` goes from **5 failures to 1**. The one left is the stale-fact cohort, which AC-4 leaves to you — the pages are named below.

## AC-1 — the gate

`scripts/gate-data-push.sh <quarantine-branch> <commit-message> <path>...` replaces the inline commit-and-push block in `reverify.yml`, `liveness.yml` and `analytics-rollup.yml`. It commits only the paths it is given, runs `npm run build && npm test`, and then either pushes to `main` or force-pushes to the workflow's own quarantine branch and exits 1 with the failing tests in the job log. `liveness.yml` and `analytics-rollup.yml` move from Node 20 to the 24.20.0 `tests.yml` pins, because the suite loads TypeScript test files directly.

Demonstrated end-to-end against a clone with its own bare origin, running the real suite both times:

| run | data change | suite | origin `main` | quarantine branch |
|---|---|---|---|---|
| green | `link_health.generated_at` bumped | 3,592 / 0 fail | `d87738e` → `543e0ca` | none |
| red | one `source_check.detail` reverted to the ungrammatical form | 3,592 / 1 fail | `543e0ca`, unchanged | `b7d436b` |

The refused commit carries the broken string and `main` carries the fixed one, read back from the bare origin:

```
main:        ... and the 1 structured-data block in its markup states no price
quarantine:  ... and the 1 structured-data block in its markup state no price
```

The demo clone carried a local commit raising the baseline to the cohort so the suite could be green; that commit is not in this branch, and the baseline here is untouched at 57.

Nine tests in `test/data-push-gate.test.ts` cover the same control flow against a fixture suite, plus four static assertions: no workflow pushes to `main` outside the gate, every scheduled data writer invokes it, each with its own quarantine branch, and each on the Node `tests.yml` pins.

## AC-3 — the singular clause

`structuredDetail` agreed its verb with nothing: `the 1 structured-data block in its markup state no price`. It now agrees with the count, and the two published records the old writer produced are corrected — a two-line diff in `data/index.json`, `checked` untouched.

Read back on `/api/offers`:

```
jsDelivr :: ... but states no amount, rate or price we can read, and the 1 structured-data block in its markup states no price
LastPass :: ... but states no amount, rate or price we can read, and the 1 structured-data block in its markup states no price
```

The assertion in `price-evidence-grade.test.ts` no longer pins a shape. Its old regex anchored `$` immediately after `we can read`, so any clause at all failed it; it now allows the clause and a second assertion requires each clause to be the string `structuredDetail` composes for the number of blocks it names. That is a consistency check between the writer and the corpus, so it passes on `main` where both are wrong together — the grammar itself is pinned by two `strictEqual`s in `typed-price-read.test.ts`, which do go red on `main`.

## AC-5 and the risk badge — two anchors replaced by derivations

`search-recording-wiring.test.ts` asserted that `?q=database&stability=volatile&payment_protocol=x402` empties the result set. It returns 1: **Supabase** is in `Databases`, carries an x402 protocol, and its stability moved to `volatile` on a `pricing_restructured` recorded 2026-09-03. Both tests now derive an emptying filter from the corpus — the first category the catalogue holds that no match for the query sits in — and say which value moved if none exists. The derivation also asserts it read the whole covered set, so a limit clamp on `/api/offers` surfaces as a message rather than a wrong pick.

`risk-badge.test.ts:82` was anchored on Railway holding only `limits_increased`; Railway recorded a `limits_reduced` on 2026-09-03. Rather than re-anchor on another vendor, it now asserts the property over **every** vendor that qualifies — 45 pages — selected by the same rule the page itself uses (`c.vendor.toLowerCase() === offer.vendor.toLowerCase()`), and fails with the names of any that carry a warning.

## AC-4 — the cohort is yours, and these are the pages

59 against a baseline of 57. `STALE_FACT_PAGES_BASELINE` is untouched. Two pages entered today, both on a change dated 2026-09-03:

- `/openai-assistants-migration` — Google Gemini API, `pricing_restructured`
- `/supabase-vs-firebase` — Supabase, `pricing_restructured`

Five pages carry exactly one stale fact each, so reviewing **any two** of these puts the cohort back at 57:

| page | stale fact | clock starts |
|---|---|---|
| `/email-comparison-2026` | mailersend-com, 2026-08-28 | 2026-08-27 |
| `/openai-assistants-migration` | google-gemini-api, 2026-09-03 | 2026-08-27 |
| `/q1-2026-developer-pricing-report` | cloudflare, 2026-09-02 | 2026-03-24 |
| `/supabase-vs-firebase` | supabase, 2026-09-03 | 2026-03-26 |
| `/terraform-cloud-free-tier-removed` | terragrunt-scale, 2026-09-02 | 2026-04-08 |

## What the gate costs while the cohort is over

The ratchet and the gate compose: a re-verification run that moves a record under an unreviewed page grows the cohort, the cohort breach fails the suite, and the gate then refuses that run's own data. The cohort has grown on every measured date — 36, 51, 53, 57, 59 across 2026-08-27 to 2026-09-03 — so the gate would have refused a data run on each of them.

Nothing is lost: the run's data sits on the quarantine branch, force-pushed each run so at most three such branches ever exist. But `verification_state.json` does not advance on `main` while a block persists, so the rolling re-verification re-walks the same oldest records the next day. The next scheduled run is the analytics rollup at 04:30Z.

## Also in here

`no-private-context.test.ts` scanned `.ts .js .mjs .md .json` under `src test scripts docs`, which left **78 shell scripts and six workflow files** unscanned — published prose with no leak check. Both are in the scan now; it finds nothing in either. The floor assertion names a workflow file and requires a shell script, so the widening cannot be dropped silently.

## Verification

3,592 tests, 11 new, against a base of 3,581 measured in the clean checkout at `8c26c9c`. The base holds the 5 failures this issue describes; the branch holds 1, `stale-page-facts.test.ts:152`.

The new assertions run against `main` unmodified: **10 of 103 red there, 0 on the branch**. The two that pass on `main` are the writer-corpus consistency check described above and the subject check that reads the workflow list.

12 mutations, 10 killed on the first pass. One survivor was mine — I mutated a `vendorRiskAssessment` call site that feeds a different surface than `/vendor/<slug>`; re-aimed at the enrichment that does feed it, both re-aims died. One survivor was real: the widened file-extension list had nothing pinning it and could be reverted silently. That is what the floor assertion above is for, and it kills the mutation now.

Sweep of all 2,570 sitemap paths: the markup clause appears on no HTML page — it is API and MCP prose — so no rendered page moved.
