### PR TITLE
Scope a vendor page's source-check assertion to the vendor it is about (#1190)

### DIFF
--- a/test/source-check-pages.test.ts
+++ b/test/source-check-pages.test.ts
@@ -5,6 +5,8 @@ import { writeFileSync, mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import { LEVEL_WITHHOLDING_OUTCOMES, levelWithheldReason, withheldLevelClause } from "../dist/source-check.js";
+import type { LevelWithheldReason } from "../src/source-check.ts";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const REPO = path.join(__dirname, "..");
@@ -131,26 +133,29 @@ function aboutThisVendor({ body }: { body: string }): string {
   return [verdict, history, ...answers].join("\n");
 }
 
+function saidOfTheSubject(body: string): string {
+  const ownRow = body.match(/<tr class="current-vendor-row">[\s\S]*?<\/tr>/)?.[0];
+  assert.ok(ownRow, "the page must carry its own row in the comparison table");
+  const scope = [aboutThisVendor({ body }), ownRow, faqAnswers(body).join("\n")].join("\n");
+  const rows = scope.match(/<tr[ >]/g) ?? [];
+  assert.equal(rows.length, 1, "the scope holds the subject's row and no other vendor's");
+  assert.ok(scope.length < body.length, "the scope is narrower than the document it comes from");
+  return scope;
+}
+
+const FIXTURES = [
+  SOURCED_FROM_A_MARKETPLACE,
+  SOURCED_FROM_ITS_OWN_PAGE,
+  SOURCED_FROM_A_PAGE_WE_COULD_NOT_READ,
+  SOURCED_FROM_A_PAGE_STATING_NO_FIGURES,
+  SOURCED_FROM_A_PAGE_NAMING_ONLY_A_PLAN,
+  QUOTED_FROM_THE_PAGE_IT_CITES,
+];
+
 before(async () => {
   fixtureDir = mkdtempSync(path.join(tmpdir(), "source-check-"));
   const indexPath = path.join(fixtureDir, "index.json");
-  writeFileSync(
-    indexPath,
-    JSON.stringify(
-      {
-        offers: [
-          SOURCED_FROM_A_MARKETPLACE,
-          SOURCED_FROM_ITS_OWN_PAGE,
-          SOURCED_FROM_A_PAGE_WE_COULD_NOT_READ,
-          SOURCED_FROM_A_PAGE_STATING_NO_FIGURES,
-          SOURCED_FROM_A_PAGE_NAMING_ONLY_A_PLAN,
-          QUOTED_FROM_THE_PAGE_IT_CITES,
-        ],
-      },
-      null,
-      2
-    )
-  );
+  writeFileSync(indexPath, JSON.stringify({ offers: FIXTURES }, null, 2));
   proc = await startServer(indexPath);
 });
 
@@ -416,12 +421,32 @@ describe("a page we quote from is not also a page we say we can read nothing on"
 
   it("does not also say that page states no terms it can read", async () => {
     const { body } = await get("/vendor/longcorp");
-    assert.doesNotMatch(body, /states no terms we can read/);
+    assert.doesNotMatch(saidOfTheSubject(body), /states no terms we can read/);
   });
 
   it("keeps saying so where the quote comes from a different page", async () => {
     const { body } = await get("/vendor/prosecorp");
     assert.match(body, /dealmarket\.example\/offers<\/a>, where it says:/);
-    assert.match(body, /states no terms we can read/);
+    assert.match(saidOfTheSubject(body), /states no terms we can read/);
+  });
+
+  for (const subject of FIXTURES) {
+    const withheld = levelWithheldReason(subject, null);
+    it(`states of ${subject.vendor} only the withheld-source clause its own check earns`, async () => {
+      const { body } = await get(`/vendor/${subject.vendor.toLowerCase()}`);
+      const scope = saidOfTheSubject(body);
+      for (const reason of LEVEL_WITHHOLDING_OUTCOMES as LevelWithheldReason[]) {
+        const clause = withheldLevelClause(reason, "");
+        const pattern = new RegExp(clause.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"), "i");
+        if (reason === withheld) assert.match(scope, pattern);
+        else assert.doesNotMatch(scope, pattern);
+      }
+    });
+  }
+
+  it("holds a fixture for every outcome that withholds a level, and one that withholds none", () => {
+    const outcomes = new Set(FIXTURES.map(f => f.source_check.outcome));
+    for (const reason of LEVEL_WITHHOLDING_OUTCOMES) assert.ok(outcomes.has(reason), reason);
+    assert.ok(FIXTURES.some(f => levelWithheldReason(f, null) === null));
   });
 });


### PR DESCRIPTION
Refs #1190, #1317, #1321

`test/source-check-pages.test.ts:417` asserted `doesNotMatch(body, /states no terms we can read/)` over the whole `/vendor/longcorp` document. The phrase belongs to `Prosecorp`, a sibling fixture, and it reaches the page through a `title` attribute on Prosecorp's row in Longcorp's mini-compare table — correct output about a different vendor. The assertion cannot tell the two apart.

## It is a daily reshuffle, not a window

`rankForListing` gives tied candidates a `seededShuffle` keyed on `sha256(utcDate | queryKey | band)`. All five alternatives tie, the vendor page renders `alternatives.slice(0, 3)`, and so which three siblings appear in Longcorp's table changes every day.

Measured over 365 days with `alternatives:Databases:Longcorp`: **Prosecorp lands in the top three on 221 of them — 60.5%.**

Confirmed end to end by running the suite at fixed clocks, `Date` replaced through `NODE_OPTIONS`. Old assertion against new, same six dates:

| date | old | new |
|---|---|---|
| 2026-09-02 | 43 pass / 0 fail | 50 / 0 |
| 2026-09-03 | 43 / 0 | 50 / 0 |
| 2026-09-04 | 42 / **1** | 50 / 0 |
| 2026-09-05 | 42 / **1** | 50 / 0 |
| 2026-09-06 | 43 / 0 | 50 / 0 |
| 2026-09-10 | 42 / **1** | 50 / 0 |

The red days are exactly the ones the shuffle predicts. The assertion landed 2026-09-02 in `22c65e2` and passed twice by luck before its first red day.

Nothing in #1319 moved it — that PR is on the same side of the flip as `8c26c9c`. The clock is the only input that changed between the two runs.

The new test is green at all fourteen simulated dates I ran, including 2026-10-01 and 2026-11-15.

## The change

`saidOfTheSubject(body)` returns what the page states about its own subject: the verdict, the change-history paragraph, the rendered answers, the FAQPage answers, and the subject's own row. It asserts the scope holds exactly one `<tr>` and is shorter than the document, so it cannot be widened back to the whole page without going red.

Both assertions in that block now read the scope rather than the document — the negative one so a sibling's notice cannot fail it, the positive one so a sibling's notice cannot pass it.

Added on top, a loop over all six fixtures: for each of the three outcomes that withhold a level, the clause `withheldLevelClause` composes appears in a vendor's own scope if and only if that outcome is the vendor's own. The clause strings come from `dist/source-check.js`, so the test cannot drift from the code, and a floor assertion requires the fixture set to keep covering every withholding outcome plus one that withholds none. Two vendors covered before; six now.

## Verification

- **3,599 tests, 0 failures** on the branch. Base at `4af0b62` is 3,592 with the one red. **`main` goes to green** — this was the second of the two failures #1317 is being held open for, and https://github.com/robhunter/agentdeals/pull/1320 cleared the first.
- 6 mutations, 6 killed: the row tooltip forced to one clause (2 red), `states_no_terms` withholding nothing (7), the `unreadable` clause reworded to the `states_no_terms` one (2), the verdict clause forced to `unreadable` (4), the scope widened back to the document (8), the own row's withheld cell removed (3).
- 7 new tests, no source change.
