### PR TITLE
Record Hetzner's June 15 adjustment and stop attributing a rename to it (#1181)

### DIFF
--- a/data/deal_changes.json
+++ b/data/deal_changes.json
@@ -638,7 +638,7 @@
       "vendor": "Hetzner",
       "change_type": "pricing_restructured",
       "date": "2026-04-01",
-      "summary": "Cloud & dedicated server prices increasing 30-50%. Entry-level CX23: €2.99→€3.99/mo (+33%). Applies to new and existing customers. Driven by DRAM (+171% YoY) and NVMe SSD cost surges from AI infrastructure demand. Superseded 2026-06-15: Hetzner ran a second adjustment across all cloud and dedicated lines, applying to new orders and rescales only, and renamed the lineup. Read from hetzner.com on 2026-09-03: CX23 is €5.99 and is marked \"not available\", as is every other shared-vCPU plan, and the cheapest orderable plan is CPX12 at €11.99/mo.",
+      "summary": "Cloud & dedicated server prices increasing 30-50%. Entry-level CX23: €2.99→€3.99/mo (+33%). Applies to new and existing customers. Driven by DRAM (+171% YoY) and NVMe SSD cost surges from AI infrastructure demand. Superseded 2026-06-15: Hetzner ran a second adjustment across all cloud and dedicated lines, applying to new orders and rescales only. Read from hetzner.com on 2026-09-03: CX23 is €5.99 and is marked \"not available\", as is every other shared-vCPU plan, and the cheapest orderable plan is CPX12 at €11.99/mo.",
       "previous_state": "Lower cloud server pricing across Germany, Finland, US, and Singapore data centers (e.g., CX23 at €2.99/mo)",
       "current_state": "30-37% increase on cloud servers, up to 50% on select dedicated/storage products. All regions and all customers (new and existing) affected. Announced Feb 23, 2026",
       "impact": "high",
@@ -650,6 +650,24 @@
         "OVHcloud"
       ],
       "recorded_date": "2026-02-26",
+      "date_source": "hand_written"
+    },
+    {
+      "vendor": "Hetzner",
+      "change_type": "pricing_restructured",
+      "date": "2026-06-15",
+      "summary": "Hetzner's second 2026 adjustment, effective 15 June, moved the two cloud lines at very different rates: shared-vCPU plans rose 30-38% (CX23 €3.99→€5.49, CAX11 €4.49→€5.99) and dedicated-vCPU plans rose 113-175% (CPX22 €7.99→€19.49, CCX13 €15.99→€42.99, CCX53 €249.99→€533.49). EU figures, taken from Hetzner's own old/new table and excluding the €0.50/mo primary IPv4 that hetzner.com's plan cards include in their displayed price. Scope: all dedicated servers and cloud plans at all locations, for new orders and rescales only — existing contracts keep their terms. Excluded: web hosting, managed servers, Server Auction, IPs, storage products, Load Balancers, Volumes, Snapshots and Object Storage. Setup fees on most dedicated servers were cut at the same time. Read on 2026-09-04: every Cost-Optimized plan (CX23-CX53, CAX11-CAX41) is marked \"not available\" on hetzner.com, so the line that rose least is the line nobody can order.",
+      "previous_state": "Post-April 2026 EU prices excluding IPv4: CX23 €3.99/mo, CX33 €6.49, CX43 €11.99, CX53 €22.49, CAX11 €4.49, CPX22 €7.99, CPX62 €50.49, CCX13 €15.99, CCX63 €374.49. Both the shared-vCPU and dedicated-vCPU lines orderable.",
+      "current_state": "EU prices excluding IPv4 from 2026-06-15: CX23 €5.49 (+37.6%), CX33 €8.49 (+30.8%), CX43 €15.99 (+33.4%), CX53 €29.49 (+31.1%), CAX11 €5.99 (+33.4%), CPX22 €19.49 (+143.9%), CPX62 €129.99 (+157.5%), CCX13 €42.99 (+168.9%), CCX63 €853.49 (+127.9%). US and Singapore moved by comparable multiples on the plans offered there. Applies to new orders and rescales; servers already running keep their contract terms.",
+      "impact": "high",
+      "source_url": "https://docs.hetzner.com/general/infrastructure-and-availability/price-adjustment/",
+      "category": "Cloud Hosting",
+      "alternatives": [
+        "DigitalOcean",
+        "Vultr",
+        "OVHcloud"
+      ],
+      "recorded_date": "2026-09-04",
       "date_source": "hand_written"
     },
     {

--- a/data/index.json
+++ b/data/index.json
@@ -2468,7 +2468,7 @@
     {
       "vendor": "Hetzner",
       "category": "Infrastructure",
-      "description": "Budget cloud VMs, no free tier. As of 2026-09-03 hetzner.com marks every shared-vCPU plan — CX23, CX33, CX43, CX53 and the Arm CAX11–CAX41 — \"not available\". The cheapest orderable plan is CPX12 at €11.99/month (1 vCPU AMD, 2 GB RAM, 40 GB NVMe, 0.5 TB traffic); CPX22 is €19.99 (2 vCPU, 4 GB, 80 GB, 20 TB traffic). Dedicated-vCPU CCX13 is €43.49/month in the EU and $51.59 in the US. Two 2026 increases: April 1 across all lines, then June 15, which applies to new orders and rescales only — existing contracts keep their terms. The June round also renamed the lineup, so the CX22/CX32/CX42 names no longer exist. Server Auction, IPs, storage, Load Balancers, Volumes, Snapshots and Object Storage were excluded from the June round.",
+      "description": "Budget cloud VMs, no free tier. As of 2026-09-04 hetzner.com marks every shared-vCPU plan — CX23, CX33, CX43, CX53 and the Arm CAX11–CAX41 — \"not available\". The cheapest orderable plan is CPX12 at €11.99/month (1 vCPU AMD, 2 GB RAM, 40 GB NVMe, 0.5 TB traffic); CPX22 is €19.99 (2 vCPU, 4 GB, 80 GB, 20 TB traffic). Dedicated-vCPU CCX13 is €43.49/month in the EU and $51.59 in the US. These are hetzner.com's displayed prices and include the €0.50/month primary IPv4. Two 2026 increases: April 1 across all lines, then June 15, which applies to new orders and rescales only — existing contracts keep their terms. The June standardization renamed dedicated server models (-1, -2 and -3 suffixes, plus a -1-Ltd limited line) and left the cloud plan names unchanged; the older CX22/CX32/CX42 names went before it. Server Auction, IPs, storage, Load Balancers, Volumes, Snapshots and Object Storage were excluded from the June round.",
       "tier": "Paid",
       "url": "https://www.hetzner.com/cloud/",
       "tags": [
@@ -2480,7 +2480,7 @@
         "eu",
         "price-increase-2026"
       ],
-      "verifiedDate": "2026-09-03",
+      "verifiedDate": "2026-09-04",
       "referral_program": {
         "available": true,
         "referrer_benefit": "€10 credit",


### PR DESCRIPTION
Refs #1181, criterion 4.

The June 15 adjustment had no record. Both of us declined to hand-write one — I asked for a detector to emit it, the Coder said the same on https://github.com/robhunter/agentdeals/pull/1323. A detector cannot emit a dated historical event it never saw, so the hole was permanent. Writing it, `date_source: hand_written`, which 289 of the 525 records already carry.

## Hetzner publishes the whole adjustment as a table

`https://docs.hetzner.com/general/infrastructure-and-availability/price-adjustment/` gives old and new monthly prices for every cloud plan in every region, and the table is in the raw HTML. Linked from the press release we already cite. It is a better source than the price API for a historical event, because it carries the before as well as the after.

**The June round moved the two cloud lines at completely different rates.**

| line | example | before | after | change |
|---|---|---|---|---|
| shared vCPU | CX23 | €3.99 | €5.49 | +37.6% |
| shared vCPU | CAX41 | €31.49 | €40.99 | +30.2% |
| dedicated vCPU | CPX22 | €7.99 | €19.49 | +143.9% |
| dedicated vCPU | CCX13 | €15.99 | €42.99 | +168.9% |
| dedicated vCPU | CCX53 | €249.99 | €533.49 | +113.4% |

Shared-vCPU rose 30–38% across all eight plans; dedicated-vCPU rose 113–175% across all eleven. The line that rose least is the line hetzner.com now marks "not available", which is why the page's entry price moved from €4.49 to €11.99 — not because the cheap plan got expensive, but because it became unbuyable and the next line up had nearly tripled.

CCX13 at €15.99 → €42.99 is exactly what #1181 estimated from secondary reporting.

## Two corrections in the same change, both to records I wrote

**1. June did not rename the cloud plans.** #1286 and #1287 both say it did. The press release standardizes *dedicated server* models — new `-1`, `-2`, `-3` suffixes and a `-1-Ltd` limited line — and Hetzner's own June table lists `CX23`, `CAX11`, `CPX22` and `CCX13` in its **old** price column as well as its new one. So those names predate June. CX22/CX32/CX42 are indeed gone from the lineup; that happened earlier.

The claim is also in the render source, at `serve.ts:5058` and in section 4 of `/hetzner-pricing-2026`. Reported on #1181 rather than fixed here.

**2. Our prices include a €0.50 IPv4 and we do not say so.** We read `CLOUD_nnn+CLOUD_21`; `CLOUD_21` alone is €0.50/month at every location, and hetzner.com labels its own matrix "Price incl. IPv4". Every one of our 25 rows is exactly €0.50 above Hetzner's published plan price. Matching hetzner.com's display is the right default, so this is a missing qualifier rather than a wrong number — the offer record now carries it.

The offer's `verifiedDate` moves to 2026-09-04, which is when I read the vendor.

## Checks

- `npm run validate` — 1580 offers, 525 deal changes, clean.
- `node scripts/lint-duplicates.js` — no candidates.
- **Stale-fact cohort is unchanged at 57, and it is the same 57 paths.** This record is the newest Hetzner change, so `newestChangeBySlug` moves from 2026-04-01 to 2026-06-15 and could have pulled pages reviewed in between into the cohort. Diffed the sorted cohort against `main`'s: identical. The ratchet in #1321 is not touched.
- Rendered `/vendor/hetzner`, `/hetzner-pricing-2026`, `/hetzner-alternatives`, `/hosting-alternatives`, `/category/infrastructure`, `/alternative-to/hetzner` and `/changes` locally and applied `hetzner-pricing-page.test.ts`'s two page assertions by hand: no page offers an unorderable plan as an entry price, and every "cheapest orderable plan" clause is followed by CPX12 at €11.99. The new prices do not reach `/hetzner-pricing-2026`, so its stray-price check is unaffected.

Data only — no `src/`, no `test/`.
