### PR TITLE
Move the quality budgets into data and split what a red suite holds back (#1321)

### DIFF
--- a/.github/workflows/analytics-rollup.yml
+++ b/.github/workflows/analytics-rollup.yml
@@ -12,6 +12,7 @@ on:
 
 permissions:
   contents: write
+  issues: write
 
 concurrency:
   group: analytics-rollup
@@ -49,6 +50,7 @@ jobs:
           echo "written=$WRITTEN" >> "$GITHUB_OUTPUT"
 
       - name: Run the suite, then push to main only if it is green
+        id: gate
         env:
           WRITTEN: ${{ steps.rollup.outputs.written }}
         run: |
@@ -56,3 +58,17 @@ jobs:
             data-quarantine/analytics-rollup \
             "data(auto): analytics rollup — ${WRITTEN} day(s)" \
             data/analytics
+
+      - name: Say where it can be seen what the gate did with this run's data
+        if: always() && (steps.gate.outputs.quarantined == 'true' || steps.gate.outputs.pushed_over_failures == 'true')
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          QUARANTINED: ${{ steps.gate.outputs.quarantined }}
+          QUARANTINE_REF: ${{ steps.gate.outputs.quarantine_ref }}
+          NON_BLOCKING_FILES: ${{ steps.gate.outputs.non_blocking_files }}
+        run: |
+          if [ "$QUARANTINED" = "true" ]; then
+            bash scripts/report-data-push-outcome.sh "Analytics rollup" refused "$QUARANTINE_REF"
+          else
+            bash scripts/report-data-push-outcome.sh "Analytics rollup" shipped-over-failures "$NON_BLOCKING_FILES"
+          fi

--- a/.github/workflows/liveness.yml
+++ b/.github/workflows/liveness.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: write
+  issues: write
 
 concurrency:
   group: link-liveness
@@ -40,6 +41,7 @@ jobs:
           echo "unknown=$UNKNOWN" >> "$GITHUB_OUTPUT"
 
       - name: Run the suite, then push to main only if it is green
+        id: gate
         env:
           UNREACHABLE: ${{ steps.liveness.outputs.unreachable }}
           UNKNOWN: ${{ steps.liveness.outputs.unknown }}
@@ -48,3 +50,17 @@ jobs:
             data-quarantine/link-liveness \
             "data(auto): link liveness — ${UNREACHABLE} unreachable, ${UNKNOWN} could not be checked" \
             data/link_health.json
+
+      - name: Say where it can be seen what the gate did with this run's data
+        if: always() && (steps.gate.outputs.quarantined == 'true' || steps.gate.outputs.pushed_over_failures == 'true')
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          QUARANTINED: ${{ steps.gate.outputs.quarantined }}
+          QUARANTINE_REF: ${{ steps.gate.outputs.quarantine_ref }}
+          NON_BLOCKING_FILES: ${{ steps.gate.outputs.non_blocking_files }}
+        run: |
+          if [ "$QUARANTINED" = "true" ]; then
+            bash scripts/report-data-push-outcome.sh "Link liveness" refused "$QUARANTINE_REF"
+          else
+            bash scripts/report-data-push-outcome.sh "Link liveness" shipped-over-failures "$NON_BLOCKING_FILES"
+          fi

--- a/.github/workflows/reverify.yml
+++ b/.github/workflows/reverify.yml
@@ -53,7 +53,13 @@ jobs:
           echo "retried=$RETRIED" >> "$GITHUB_OUTPUT"
           echo "repicked=$REPICKED" >> "$GITHUB_OUTPUT"
 
+      - name: Lower any quality budget this run's data has earned
+        run: |
+          npm run build
+          node scripts/ratchet-quality-budgets.js --lower
+
       - name: Run the suite, then push to main only if it is green
+        id: gate
         env:
           VERIFIED: ${{ steps.reverify.outputs.verified }}
           FLAGGED: ${{ steps.reverify.outputs.flagged }}
@@ -65,12 +71,28 @@ jobs:
           bash scripts/gate-data-push.sh \
             data-quarantine/rolling-reverification \
             "data(auto): rolling re-verification — ${VERIFIED} verified, ${FLAGGED} flagged, ${RECORDED} changes recorded, ${RETRIED} retried from quarantine, ${QUARANTINED} in quarantine, ${REPICKED} to be checked again" \
-            data/index.json data/deal_changes.json data/change_refusals.json data/verification_state.json
+            data/index.json data/deal_changes.json data/change_refusals.json data/verification_state.json data/quality_budgets.json
+
+      - name: Say where it can be seen what the gate did with this run's data
+        if: always() && (steps.gate.outputs.quarantined == 'true' || steps.gate.outputs.pushed_over_failures == 'true')
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          QUARANTINED: ${{ steps.gate.outputs.quarantined }}
+          QUARANTINE_REF: ${{ steps.gate.outputs.quarantine_ref }}
+          NON_BLOCKING_FILES: ${{ steps.gate.outputs.non_blocking_files }}
+        run: |
+          if [ "$QUARANTINED" = "true" ]; then
+            bash scripts/report-data-push-outcome.sh "Daily rolling re-verification" refused "$QUARANTINE_REF"
+          else
+            bash scripts/report-data-push-outcome.sh "Daily rolling re-verification" shipped-over-failures "$NON_BLOCKING_FILES"
+          fi
 
       - name: Check the change log is still being written to
         id: staleness
         if: always()
-        run: node scripts/check-change-log-staleness.js
+        run: |
+          git fetch origin main
+          node scripts/check-change-log-staleness.js --from-ref origin/main
 
       - name: Signal that no change detector is scheduled
         if: always() && steps.staleness.outputs.open_absence_issue == 'true'

--- a/data/quality_budgets.json
+++ b/data/quality_budgets.json
@@ -1,0 +1,10 @@
+{
+  "version": 1,
+  "budgets": {
+    "stale_fact_pages": 57,
+    "unsourced_tier_a": 43,
+    "faq_answers": 166,
+    "faq_answers_stating_a_figure": 77,
+    "faq_answers_with_a_digit_but_no_figure": 40
+  }
+}

--- a/package.json
+++ b/package.json
@@ -32,6 +32,8 @@
     "serve": "node dist/serve.js",
     "dev": "ts-node src/index.ts",
     "test": "node --test --test-concurrency 1 test/**/*.test.ts",
+    "test:gated": "node --test --test-concurrency 1 --test-reporter=spec --test-reporter-destination=stdout --test-reporter=./scripts/reporters/failing-test-files.js --test-reporter-destination=$GATE_FAILING_FILES test/**/*.test.ts",
+    "ratchet:budgets": "node scripts/ratchet-quality-budgets.js --lower",
     "lint": "tsc --noEmit",
     "check:staleness": "node scripts/check-staleness.js",
     "check:liveness": "node scripts/check-liveness.js",

--- a/scripts/check-change-log-staleness.js
+++ b/scripts/check-change-log-staleness.js
@@ -1,13 +1,33 @@
 #!/usr/bin/env node
 
 import { appendFileSync, readFileSync } from "node:fs";
-import { resolve, dirname } from "node:path";
+import { resolve, dirname, relative } from "node:path";
 import { fileURLToPath } from "node:url";
+import { spawnSync } from "node:child_process";
 import { readChangeLog, changeLogFreshness, CHANGES_PATH } from "./change-log.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
 export const DEFAULT_THRESHOLD_DAYS = 14;
+
+export const REPO = resolve(__dirname, "..");
+
+export function changeLogAtRef(ref, path = CHANGES_PATH, repo = REPO) {
+  const tracked = relative(repo, path).split("\\").join("/");
+  const show = spawnSync("git", ["show", `${ref}:${tracked}`], {
+    cwd: repo,
+    encoding: "utf-8",
+    maxBuffer: 256 * 1024 * 1024,
+  });
+  if (show.status !== 0) {
+    throw new Error(
+      `Cannot read ${tracked} at ${ref}: ${(show.stderr || show.error?.message || "git failed").toString().trim()}`
+    );
+  }
+  const data = JSON.parse(show.stdout);
+  if (!Array.isArray(data.changes)) throw new Error(`${tracked} at ${ref} has no changes array`);
+  return data;
+}
 
 export const WORKFLOW_PATH =
   process.env.AGENTDEALS_REVERIFY_WORKFLOW_PATH ||
@@ -197,13 +217,25 @@ function main() {
     process.exit(2);
   }
 
+  const refIdx = args.indexOf("--from-ref");
+  const ref = refIdx !== -1 ? args[refIdx + 1] : null;
+  if (refIdx !== -1 && !ref) {
+    console.error("--from-ref needs a git ref, so the check knows which tree it is reading.");
+    process.exit(2);
+  }
+
   let data;
   try {
-    data = readChangeLog(CHANGES_PATH);
+    data = ref ? changeLogAtRef(ref) : readChangeLog(CHANGES_PATH);
   } catch (err) {
     console.error(`Failed to read change log: ${err.message}`);
     process.exit(2);
   }
+  console.log(
+    ref
+      ? `Reading the change log as it stands at ${ref}, not as this run left it on disk.`
+      : "Reading the change log from this checkout."
+  );
 
   let workflowYaml;
   try {

--- a/scripts/gate-data-push.sh
+++ b/scripts/gate-data-push.sh
@@ -2,13 +2,16 @@
 set -euo pipefail
 
 if [ "$#" -lt 3 ]; then
-  echo "usage: gate-data-push.sh <quarantine-branch> <commit-message> <path>..." >&2
+  echo "usage: gate-data-push.sh <quarantine-prefix> <commit-message> <path>..." >&2
   exit 2
 fi
 
-QUARANTINE_BRANCH="$1"
+QUARANTINE_PREFIX="$1"
 MESSAGE="$2"
 shift 2
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+OUTPUT="${GITHUB_OUTPUT:-/dev/null}"
 
 if [ -z "$(git status --porcelain -- "$@")" ]; then
   echo "No change under $* — nothing to commit or push."
@@ -22,22 +25,65 @@ git commit -q -m "$MESSAGE"
 COMMIT="$(git rev-parse --short HEAD)"
 
 LOG="$(mktemp)"
-trap 'rm -f "$LOG"' EXIT
+VERDICT="$(mktemp)"
+GATE_FAILING_FILES="$(mktemp)"
+export GATE_FAILING_FILES
+trap 'rm -f "$LOG" "$VERDICT" "$GATE_FAILING_FILES"' EXIT
 
-if npm run build >"$LOG" 2>&1 && npm test >>"$LOG" 2>&1; then
-  grep -E '(tests|pass|fail) [0-9]+$' "$LOG" | tail -3 || true
+push_to_main() {
   git push origin HEAD:main
+}
+
+quarantine() {
+  local ref="${QUARANTINE_PREFIX}-$(date -u +%Y%m%dT%H%M%SZ)-${COMMIT}"
+  {
+    echo "quarantined=true"
+    echo "quarantine_ref=$ref"
+    echo "quarantined_commit=$COMMIT"
+  } >>"$OUTPUT"
+  if git push origin "HEAD:refs/heads/$ref"; then
+    echo "Suite red — $COMMIT is held on $ref and main is unchanged."
+  else
+    echo "Suite red — $COMMIT could not be held on $ref and main is unchanged. This run's data exists only in its own workspace."
+  fi
+  exit 1
+}
+
+summarize() {
+  grep -E '(tests|pass|fail) [0-9]+$' "$LOG" | tail -3 || true
+}
+
+if ! npm run build >"$LOG" 2>&1; then
+  tail -n 60 "$LOG"
+  echo "The build failed, and no test-file allowance covers code that does not compile."
+  quarantine
+fi
+
+if npm run test:gated >>"$LOG" 2>&1; then
+  summarize
+  push_to_main
   echo "Suite green — $COMMIT is on main."
   exit 0
 fi
 
-grep -E '(tests|pass|fail) [0-9]+$' "$LOG" | tail -3 || true
+summarize
 if grep -q 'failing tests:' "$LOG"; then
   sed -n '/failing tests:/,$p' "$LOG"
 else
   tail -n 60 "$LOG"
 fi
 
-git push --force origin "HEAD:refs/heads/$QUARANTINE_BRANCH"
-echo "Suite red — $COMMIT is held on $QUARANTINE_BRANCH and main is unchanged."
-exit 1
+if node "$SCRIPT_DIR/gate-verdict.js" "$GATE_FAILING_FILES" >"$VERDICT" 2>&1; then
+  cat "$VERDICT"
+  {
+    echo "quarantined=false"
+    echo "pushed_over_failures=true"
+    echo "non_blocking_files=$(tr '\n' ' ' <"$GATE_FAILING_FILES")"
+  } >>"$OUTPUT"
+  push_to_main
+  echo "Suite red — $COMMIT is on main anyway. Every failing file above measures how current our own reading is; none of them says this data is wrong."
+  exit 0
+fi
+
+cat "$VERDICT"
+quarantine

--- a/scripts/gate-non-blocking-tests.json
+++ b/scripts/gate-non-blocking-tests.json
@@ -1,0 +1,14 @@
+{
+  "version": 1,
+  "rule": "A test belongs here only when everything it fires on is a statement about how current our own editorial reading is, and nothing it fires on is a statement that the catalogue we are about to publish is wrong. Everything else holds the commit. This file is under scripts/, so no scheduled job can add to it — widening the gate takes a pull request.",
+  "tests": [
+    {
+      "file": "test/stale-page-facts.test.ts",
+      "reason": "counts the pages stating a vendor fact whose record has moved since the page was last read. Every pair it names is unread, not incorrect, and the count rises whenever the catalogue is re-verified."
+    },
+    {
+      "file": "test/page-data-provenance.test.ts",
+      "reason": "holds the register's declaration of where each page's numbers come from against what the page renders. A catalogue change can move a page from one class to the other, which means the register is behind, not that the catalogue is wrong."
+    }
+  ]
+}

--- a/scripts/gate-verdict.js
+++ b/scripts/gate-verdict.js
@@ -1,0 +1,26 @@
+import { gateVerdict, readFailingFiles, readNonBlockingTests } from "../dist/data-push-gate.js";
+
+const HELP = `Decide whether a red suite holds a scheduled data commit back from main.
+
+Reads the list of test files that failed, written by scripts/reporters/failing-test-files.js,
+and subtracts the files listed in scripts/gate-non-blocking-tests.json. Anything left holds
+the commit. Nothing left means every failure reported on how current our own reading is
+rather than on whether the data is right, so the data goes to main and the failures are
+printed for a person to read.
+
+Usage: node scripts/gate-verdict.js <failing-files-list>
+
+Exit status: 0 push, 1 quarantine, 2 the arguments were wrong.
+`;
+
+const [list] = process.argv.slice(2);
+if (!list || list === "--help" || list === "-h") {
+  console.log(HELP);
+  process.exit(list ? 0 : 2);
+}
+
+const verdict = gateVerdict(readFailingFiles(list), readNonBlockingTests());
+
+for (const t of verdict.excused) console.log(`Not held by ${t.file} — ${t.reason}`);
+console.log(verdict.reason);
+process.exit(verdict.decision === "push" ? 0 : 1);

--- a/scripts/ratchet-quality-budgets.js
+++ b/scripts/ratchet-quality-budgets.js
@@ -1,0 +1,126 @@
+import { readFileSync, writeFileSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  QUALITY_BUDGET_NAMES, newestChangeBySlug, pageReviewsPath, parsePageReviews, qualityBudgetsPath,
+  readQualityBudgets, serializeQualityBudgets, staleFactPages, unsourcedTierAPaths,
+} from "../dist/page-reviews.js";
+import { toSlug } from "../dist/vendor-slug.js";
+
+const REPO = join(dirname(fileURLToPath(import.meta.url)), "..");
+
+const HELP = `Keep data/quality_budgets.json in step with what the shipped data measures.
+
+Each budget is a ratchet: the count it caps may fall and the budget follows it down, but
+neither may rise without a person deciding to allow it. The budgets used to be constants in
+src/, which the scheduled data jobs and data-only pull requests cannot write — so clearing
+a page was a breaking change for whoever cleared it. They are data now, and this lowers
+them in the same commit as the improvement that earned it.
+
+A budget above its measurement is lowered. A budget below its measurement is left alone and
+reported: raising it is a decision, and the suite is what fails until someone makes it. The FAQ
+budgets are measured by booting a server, which this does not do, so it reports them and leaves
+them to be edited by hand from the number the suite prints.
+
+Usage: node scripts/ratchet-quality-budgets.js [options]
+
+  --lower         Write the lowered budgets (default: report only)
+  --date <date>   Day to measure, YYYY-MM-DD (default: today, UTC)
+  --json          Emit the measurement as JSON
+  --help          This text
+
+Exit status is 0 whenever the measurement was taken, including when a budget is below it.
+`;
+
+function parseArgs(argv) {
+  const opts = { lower: false, date: new Date().toISOString().slice(0, 10), json: false };
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === "--help" || arg === "-h") return { help: true };
+    else if (arg === "--lower") opts.lower = true;
+    else if (arg === "--json") opts.json = true;
+    else if (arg === "--date") opts.date = argv[++i];
+    else {
+      console.error(`Unknown argument: ${arg}`);
+      return { help: true, invalid: true };
+    }
+  }
+  return opts;
+}
+
+export function measureBudgets(date) {
+  const index = parsePageReviews(readFileSync(pageReviewsPath(), "utf-8"));
+  const changes = JSON.parse(readFileSync(join(REPO, "data", "deal_changes.json"), "utf-8")).changes;
+  const newest = newestChangeBySlug(changes, date, toSlug);
+  const stale = staleFactPages(index.pages, date, slug => newest.get(slug) ?? null);
+  return {
+    stale_fact_pages: stale.length,
+    unsourced_tier_a: unsourcedTierAPaths(index.pages).length,
+  };
+}
+
+export function ratchet(budgets, measured) {
+  const lowered = [];
+  const over = [];
+  const unmeasured = [];
+  const next = { ...budgets };
+  for (const name of QUALITY_BUDGET_NAMES) {
+    const was = budgets[name];
+    const is = measured[name];
+    if (typeof is !== "number") {
+      unmeasured.push(name);
+    } else if (is < was) {
+      next[name] = is;
+      lowered.push({ name, from: was, to: is });
+    } else if (is > was) {
+      over.push({ name, budget: was, measured: is });
+    }
+  }
+  return { next, lowered, over, unmeasured };
+}
+
+function main() {
+  const opts = parseArgs(process.argv.slice(2));
+  if (opts.help) {
+    console.log(HELP);
+    process.exit(opts.invalid ? 1 : 0);
+  }
+
+  const file = readQualityBudgets();
+  const measured = measureBudgets(opts.date);
+  const { next, lowered, over, unmeasured } = ratchet(file.budgets, measured);
+
+  if (opts.json) {
+    console.log(JSON.stringify({ measured_for: opts.date, budgets: file.budgets, measured, lowered, over, unmeasured }, null, 2));
+  } else {
+    console.log(`── Quality budgets, measured for ${opts.date} ──`);
+    for (const name of QUALITY_BUDGET_NAMES) {
+      const was = file.budgets[name];
+      const is = measured[name];
+      if (typeof is !== "number") {
+        console.log(`${name}: budget ${was}, measured only by the suite — this cannot lower it`);
+        continue;
+      }
+      const verdict = is === was ? "at budget" : is < was ? `${was - is} below budget` : `${is - was} OVER BUDGET`;
+      console.log(`${name}: budget ${was}, measured ${is} — ${verdict}`);
+    }
+  }
+
+  if (lowered.length > 0 && opts.lower) {
+    writeFileSync(qualityBudgetsPath(), serializeQualityBudgets({ version: file.version, budgets: next }));
+    for (const l of lowered) console.log(`Lowered ${l.name} ${l.from} → ${l.to} in ${qualityBudgetsPath()}`);
+  } else if (lowered.length > 0) {
+    for (const l of lowered) console.log(`Would lower ${l.name} ${l.from} → ${l.to} — pass --lower to write it`);
+  }
+
+  for (const o of over) {
+    console.log(
+      `${o.name} is ${o.measured - o.budget} over its budget of ${o.budget}. A budget does not rise here: ` +
+        `clear the entries that put it over, or raise it deliberately in ${qualityBudgetsPath()}.`
+    );
+  }
+}
+
+const isMainModule =
+  process.argv[1] && resolve(process.argv[1]) === resolve(fileURLToPath(import.meta.url));
+if (isMainModule) main();

--- a/scripts/report-data-push-outcome.sh
+++ b/scripts/report-data-push-outcome.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ "$#" -lt 2 ]; then
+  echo "usage: report-data-push-outcome.sh <job-name> refused|shipped-over-failures [detail]" >&2
+  exit 2
+fi
+
+JOB="$1"
+OUTCOME="$2"
+DETAIL="${3:-}"
+SERVER="${GITHUB_SERVER_URL:-https://github.com}"
+REPO="${GITHUB_REPOSITORY:-robhunter/agentdeals}"
+RUN_URL="$SERVER/$REPO/actions/runs/${GITHUB_RUN_ID:-unknown}"
+
+BODY="$(mktemp)"
+trap 'rm -f "$BODY"' EXIT
+
+case "$OUTCOME" in
+  refused)
+    MARKER="data-push-refused"
+    TITLE="A scheduled data push was refused — the catalogue is not advancing"
+    LABEL="priority/high"
+    COMMENT_EVERY_TIME="yes"
+    {
+      echo "\`$JOB\` produced data the suite refused, so \`main\` did not move and the catalogue did not advance."
+      echo
+      if [ -n "$DETAIL" ]; then
+        echo "The refused commit is held on [\`$DETAIL\`]($SERVER/$REPO/tree/$DETAIL). Each refusal gets its own ref, so this one is not overwritten by the next."
+      else
+        echo "The refused commit could not be pushed anywhere. This run's data exists only in the run's workspace and goes when it expires."
+      fi
+      echo
+      echo "The run: $RUN_URL"
+      echo
+      echo "Until this clears, the queue does not advance: the next run picks the same entries, finds the same things, and is refused again."
+      echo
+      echo "What to do: read the failing tests in the run, fix them on \`main\`, then merge the quarantined data or let the next scheduled run redo it."
+    } >"$BODY"
+    ;;
+  shipped-over-failures)
+    MARKER="data-push-over-failures"
+    TITLE="main is red on a test that measures our own reading, and the data shipped anyway"
+    LABEL="priority/medium"
+    COMMENT_EVERY_TIME="no"
+    {
+      echo "\`$JOB\` met a red suite, and every failing file was one whose failures do not hold a data commit — they measure how current our own editorial reading is, not whether the catalogue is right. The data is on \`main\`."
+      echo
+      echo "The files that were red: \`${DETAIL:-none recorded}\`"
+      echo
+      echo "The run: $RUN_URL"
+      echo
+      echo "\`main\` is red until somebody clears these. Nothing is blocked, which is why this needs saying out loud: a scheduled push carries no \`tests.yml\` run behind it, so this is the only place the redness shows."
+      echo
+      echo "What to do: clear the entries that put the measurement over its budget, then \`npm run ratchet:budgets\`."
+    } >"$BODY"
+    ;;
+  *)
+    echo "Unknown outcome: $OUTCOME" >&2
+    exit 2
+    ;;
+esac
+
+{
+  echo
+  echo "<!-- $MARKER -->"
+} >>"$BODY"
+
+EXISTING="$(gh issue list --state open --search "$MARKER in:body" --json number --jq '.[0].number // empty')"
+if [ -n "$EXISTING" ]; then
+  if [ "$COMMENT_EVERY_TIME" = "yes" ]; then
+    gh issue comment "$EXISTING" --body-file "$BODY"
+    echo "Reported on issue #$EXISTING."
+  else
+    echo "Already signalled by issue #$EXISTING — not opening or commenting on another."
+  fi
+  exit 0
+fi
+
+gh issue create --title "$TITLE" --label "$LABEL" --label "type: bug" --body-file "$BODY"

--- a/scripts/reporters/failing-test-files.js
+++ b/scripts/reporters/failing-test-files.js
@@ -1,0 +1,11 @@
+import { relative } from "node:path";
+
+export default async function* failingTestFiles(source) {
+  const files = new Set();
+  for await (const event of source) {
+    if (event.type !== "test:fail") continue;
+    const file = event.data?.file;
+    if (typeof file === "string" && file.length > 0) files.add(relative(process.cwd(), file));
+  }
+  yield [...files].sort().map(f => `${f}\n`).join("");
+}

--- a/scripts/stale-page-facts.js
+++ b/scripts/stale-page-facts.js
@@ -16,8 +16,8 @@ vendor, or one of its tables puts a number beside it. Either is a published clai
 either counts. A record dated after the page was last read means nobody has checked the
 claim against the record since the record moved — the pair is reported, not judged.
 
-The count of such pages is budgeted by STALE_FACT_PAGES_BASELINE and the budget does not
-rise. Run this when that budget refuses a build, to see which page entered.
+The count of such pages is budgeted by stale_fact_pages in data/quality_budgets.json and the
+budget does not rise. Run this when that budget refuses a build, to see which page entered.
 
 Usage: node scripts/stale-page-facts.js [options]
 
@@ -68,7 +68,7 @@ const tableOnlyPages = stale.filter(p => p.facts.every(f => f.surface === "table
 
 console.log(`${stale.length} of ${index.pages.length} pages state a vendor fact a record has moved under, on ${opts.date}`);
 console.log(`${pairs} page-vendor pairs, of which ${tableOnlyPairs} are named only by a table; ${tableOnlyPages} pages are in the cohort on a table alone`);
-console.log(`budget ${STALE_FACT_PAGES_BASELINE}`);
+console.log(`budget ${STALE_FACT_PAGES_BASELINE} (stale_fact_pages in data/quality_budgets.json)`);
 console.log("");
 
 for (const p of stale) {

--- a/src/data-push-gate.ts
+++ b/src/data-push-gate.ts
@@ -1,0 +1,108 @@
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+export interface NonBlockingTest {
+  file: string;
+  reason: string;
+}
+
+export interface NonBlockingTests {
+  version: number;
+  rule: string;
+  tests: NonBlockingTest[];
+}
+
+export function nonBlockingTestsPath(): string {
+  return (
+    process.env.AGENTDEALS_NON_BLOCKING_TESTS_PATH ||
+    path.join(__dirname, "..", "scripts", "gate-non-blocking-tests.json")
+  );
+}
+
+export function normalizeTestPath(file: string): string {
+  return file.trim().replace(/^\.\//, "").replace(/\\/g, "/");
+}
+
+export function parseNonBlockingTests(text: string, source: string): NonBlockingTests {
+  let raw: unknown;
+  try {
+    raw = JSON.parse(text);
+  } catch (err) {
+    throw new Error(`${source} is not valid JSON: ${(err as Error).message}`);
+  }
+  const file = raw as { version?: unknown; rule?: unknown; tests?: unknown };
+  if (file.version !== 1) throw new Error(`${source} has version ${String(file.version)}, expected 1`);
+  if (typeof file.rule !== "string" || file.rule.length === 0) {
+    throw new Error(`${source} states no rule for what may be listed in it`);
+  }
+  if (!Array.isArray(file.tests)) throw new Error(`${source} has no tests array`);
+  const tests: NonBlockingTest[] = [];
+  for (const entry of file.tests) {
+    const e = entry as { file?: unknown; reason?: unknown };
+    if (typeof e.file !== "string" || !e.file.startsWith("test/")) {
+      throw new Error(`${source} lists ${JSON.stringify(e.file)}, which is not a path under test/`);
+    }
+    if (typeof e.reason !== "string" || e.reason.length === 0) {
+      throw new Error(`${source} lists ${e.file} with no reason`);
+    }
+    tests.push({ file: normalizeTestPath(e.file), reason: e.reason });
+  }
+  const seen = new Set<string>();
+  for (const t of tests) {
+    if (seen.has(t.file)) throw new Error(`${source} lists ${t.file} twice`);
+    seen.add(t.file);
+  }
+  return { version: 1, rule: file.rule, tests };
+}
+
+export function readNonBlockingTests(file: string = nonBlockingTestsPath()): NonBlockingTests {
+  return parseNonBlockingTests(fs.readFileSync(file, "utf-8"), file);
+}
+
+export type GateDecision = "push" | "quarantine";
+
+export interface GateVerdict {
+  decision: GateDecision;
+  blocking: string[];
+  excused: NonBlockingTest[];
+  reason: string;
+}
+
+export function gateVerdict(failingFiles: string[], allowed: NonBlockingTests): GateVerdict {
+  const failing = [...new Set(failingFiles.map(normalizeTestPath).filter(f => f.length > 0))].sort();
+  if (failing.length === 0) {
+    return {
+      decision: "quarantine",
+      blocking: [],
+      excused: [],
+      reason: "the suite is red and named no test file, so what failed is unknown",
+    };
+  }
+  const byFile = new Map(allowed.tests.map(t => [t.file, t]));
+  const blocking = failing.filter(f => !byFile.has(f));
+  const excused = failing.filter(f => byFile.has(f)).map(f => byFile.get(f)!);
+  if (blocking.length > 0) {
+    return {
+      decision: "quarantine",
+      blocking,
+      excused,
+      reason: `${blocking.length} failing test file(s) hold the commit: ${blocking.join(", ")}`,
+    };
+  }
+  return {
+    decision: "push",
+    blocking,
+    excused,
+    reason: `every failing test file reports on how current our own reading is, not on whether the data is right: ${excused
+      .map(t => t.file)
+      .join(", ")}`,
+  };
+}
+
+export function readFailingFiles(file: string): string[] {
+  if (!fs.existsSync(file)) return [];
+  return fs.readFileSync(file, "utf-8").split("\n").map(normalizeTestPath).filter(f => f.length > 0);
+}

--- a/src/faq-provenance.ts
+++ b/src/faq-provenance.ts
@@ -1,4 +1,4 @@
-import { compiledNotice, getPageReview, reviewStatus, utcToday, type PageReviewRecord } from "./page-reviews.js";
+import { compiledNotice, getPageReview, qualityBudget, reviewStatus, utcToday, type PageReviewRecord } from "./page-reviews.js";
 
 export interface FaqItem {
   q: string;
@@ -6,9 +6,9 @@ export interface FaqItem {
 }
 
 export const FAQ_BASELINE = {
-  answers: 166,
-  stating_a_figure: 77,
-  a_digit_but_no_figure: 40,
+  answers: qualityBudget("faq_answers"),
+  stating_a_figure: qualityBudget("faq_answers_stating_a_figure"),
+  a_digit_but_no_figure: qualityBudget("faq_answers_with_a_digit_but_no_figure"),
 };
 
 const CURRENCY_AMOUNT = /[$€£¢]\s?\d|\d\s?¢|\b\d[\d,.]*\s?(?:USD|EUR|GBP)\b/;

--- a/src/page-reviews.ts
+++ b/src/page-reviews.ts
@@ -8,6 +8,78 @@ export function pageReviewsPath(): string {
   return process.env.AGENTDEALS_PAGE_REVIEWS_PATH || path.join(__dirname, "..", "data", "page-reviews.json");
 }
 
+export const QUALITY_BUDGET_NAMES = [
+  "stale_fact_pages",
+  "unsourced_tier_a",
+  "faq_answers",
+  "faq_answers_stating_a_figure",
+  "faq_answers_with_a_digit_but_no_figure",
+] as const;
+
+export type QualityBudgetName = (typeof QUALITY_BUDGET_NAMES)[number];
+
+export interface QualityBudgets {
+  version: number;
+  budgets: Record<QualityBudgetName, number>;
+}
+
+export function qualityBudgetsPath(): string {
+  return (
+    process.env.AGENTDEALS_QUALITY_BUDGETS_PATH ||
+    path.join(__dirname, "..", "data", "quality_budgets.json")
+  );
+}
+
+export function parseQualityBudgets(text: string, source: string): QualityBudgets {
+  let raw: unknown;
+  try {
+    raw = JSON.parse(text);
+  } catch (err) {
+    throw new Error(`${source} is not valid JSON: ${(err as Error).message}`);
+  }
+  if (typeof raw !== "object" || raw === null) throw new Error(`${source} is not an object`);
+  const file = raw as { version?: unknown; budgets?: unknown };
+  if (file.version !== 1) throw new Error(`${source} has version ${String(file.version)}, expected 1`);
+  if (typeof file.budgets !== "object" || file.budgets === null) {
+    throw new Error(`${source} carries no budgets object`);
+  }
+  const budgets = file.budgets as Record<string, unknown>;
+  const known = new Set<string>(QUALITY_BUDGET_NAMES);
+  const unread = Object.keys(budgets).filter(name => !known.has(name)).sort();
+  if (unread.length > 0) {
+    throw new Error(`${source} names ${unread.join(", ")}, which no budget in the code reads`);
+  }
+  const out = {} as Record<QualityBudgetName, number>;
+  for (const name of QUALITY_BUDGET_NAMES) {
+    const value = budgets[name];
+    if (typeof value !== "number" || !Number.isInteger(value) || value < 0) {
+      throw new Error(`${source} gives ${name} as ${JSON.stringify(value)}, expected a whole number`);
+    }
+    out[name] = value;
+  }
+  return { version: 1, budgets: out };
+}
+
+export function readQualityBudgets(file: string = qualityBudgetsPath()): QualityBudgets {
+  let text: string;
+  try {
+    text = fs.readFileSync(file, "utf-8");
+  } catch (err) {
+    throw new Error(`Cannot read the quality budgets at ${file}: ${(err as Error).message}`);
+  }
+  return parseQualityBudgets(text, file);
+}
+
+export function qualityBudget(name: QualityBudgetName): number {
+  return readQualityBudgets().budgets[name];
+}
+
+export function serializeQualityBudgets(budgets: QualityBudgets): string {
+  const ordered = {} as Record<QualityBudgetName, number>;
+  for (const name of QUALITY_BUDGET_NAMES) ordered[name] = budgets.budgets[name];
+  return `${JSON.stringify({ version: budgets.version, budgets: ordered }, null, 2)}\n`;
+}
+
 export type ReviewTier = "A" | "B";
 
 export const SLA_DAYS: Record<ReviewTier, number> = { A: 30, B: 90 };
@@ -35,9 +107,14 @@ export const PAGE_DATA_SOURCE_RULE: Record<PageDataSource, string> = {
   unsourced: "asserts vendor facts that are literals in the page and reach no record",
 };
 
-export const UNSOURCED_TIER_A_BASELINE = 43;
+export const UNSOURCED_TIER_A_BASELINE = qualityBudget("unsourced_tier_a");
 
-export const STALE_FACT_PAGES_BASELINE = 57;
+export const STALE_FACT_PAGES_BASELINE = qualityBudget("stale_fact_pages");
+
+export function lowerBudgetInstruction(name: string, to: number): string {
+  const file = qualityBudgetsPath().split(path.sep).slice(-2).join("/");
+  return `set ${name} to ${to} in ${file} — run npm run ratchet:budgets — so the slot cannot be reused`;
+}
 
 export interface PageReviewRecord {
   path: string;
@@ -359,7 +436,7 @@ export function staleFactViolations(
   const direction =
     stale.length > budget
       ? `${stale.length - budget} more than the budget allows, and the budget does not rise. The cohort is ${stale.map(p => p.path).sort().join(", ")}`
-      : `lower STALE_FACT_PAGES_BASELINE to ${stale.length} so the slot cannot be reused`;
+      : lowerBudgetInstruction("stale_fact_pages", stale.length);
   return [{
     path: "",
     problem: `${stale.length} pages state a vendor fact whose record moved after the page was last read — ${direction}`,
@@ -732,7 +809,7 @@ export function pageSourceViolations(
     const direction =
       unsourced.length > tierABudget
         ? `${unsourced.length - tierABudget} more than the budget allows, and the budget does not rise`
-        : `${tierABudget - unsourced.length} fewer than the budget; lower UNSOURCED_TIER_A_BASELINE to ${unsourced.length} so the slot cannot be reused`;
+        : `${tierABudget - unsourced.length} fewer than the budget; ${lowerBudgetInstruction("unsourced_tier_a", unsourced.length)}`;
     violations.push({
       path: "",
       problem: `${unsourced.length} tier-A pages assert vendor facts and read no catalogue record — ${direction}`,

--- a/test/change-log-writer.test.ts
+++ b/test/change-log-writer.test.ts
@@ -26,7 +26,7 @@ const {
 
 const { runUrlMode, runAiMode, summaryLines, repickWindowDays, regradeRefusals } = await import("../scripts/reverify-rolling.js");
 const { firstSeenDates } = await import("../scripts/backfill-change-recorded-dates.js");
-const { report, DEFAULT_THRESHOLD_DAYS, detectorSchedule, flagTokens, DETECTOR_CLI_OPTIONS, WORKFLOW_PATH } = await import("../scripts/check-change-log-staleness.js");
+const { report, DEFAULT_THRESHOLD_DAYS, detectorSchedule, flagTokens, DETECTOR_CLI_OPTIONS, WORKFLOW_PATH, changeLogAtRef } = await import("../scripts/check-change-log-staleness.js");
 const { VERIFIER_API_KEY_ENV, VERIFIER_MODEL } = await import("../scripts/verify-freshness.js");
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -1025,5 +1025,79 @@ describe("the change log's age reaches the surfaces that publish freshness", () 
     const html = await res.text();
     assert.match(html, /class="log-freshness"/);
     assert.match(html, /We last added an entry to this log/);
+  });
+});
+
+describe("#1321 the alarm on a frozen change log reads what main holds", () => {
+  let repo: string;
+
+  const entry = (detected: string) => ({
+    changes: [
+      {
+        vendor: "Fixture Vendor",
+        change_type: "limits_reduced",
+        effective_date: detected,
+        recorded_date: detected,
+        detected_by: DETECTED_BY_AI,
+        summary: "a fixture entry",
+      },
+    ],
+  });
+
+  const gitIn = (...args: string[]) => {
+    const run = spawnSync("git", args, { cwd: repo, encoding: "utf-8" });
+    assert.strictEqual(run.status, 0, `git ${args.join(" ")}: ${run.stderr}`);
+  };
+
+  before(() => {
+    repo = mkdtempSync(path.join(tmpdir(), "change-log-ref-"));
+    spawnSync("git", ["init", "--initial-branch=main", repo], { encoding: "utf-8" });
+    gitIn("config", "user.email", "fixture@example.com");
+    gitIn("config", "user.name", "fixture");
+    spawnSync("mkdir", ["-p", path.join(repo, "data")], { encoding: "utf-8" });
+    writeFileSync(path.join(repo, "data", "deal_changes.json"), JSON.stringify(entry("2026-01-01"), null, 2));
+    gitIn("add", "-A");
+    gitIn("commit", "-m", "what main holds");
+    writeFileSync(path.join(repo, "data", "deal_changes.json"), JSON.stringify(entry("2026-08-27"), null, 2));
+  });
+
+  after(() => {
+    if (repo) rmSync(repo, { recursive: true, force: true });
+  });
+
+  it("reads the committed log, not the one this run just wrote to disk", () => {
+    const onDisk = JSON.parse(readFileSync(path.join(repo, "data", "deal_changes.json"), "utf-8"));
+    const onRef = changeLogAtRef("main", path.join(repo, "data", "deal_changes.json"), repo);
+    assert.strictEqual(onDisk.changes[0].recorded_date, "2026-08-27");
+    assert.strictEqual(onRef.changes[0].recorded_date, "2026-01-01");
+  });
+
+  it("calls the log stale from the ref on the same run that calls it fresh from disk", () => {
+    const scheduled = { known: true, scheduled: true, reason: null };
+    const fromDisk = report(
+      changeLogFreshness(JSON.parse(readFileSync(path.join(repo, "data", "deal_changes.json"), "utf-8")).changes, NOW),
+      DEFAULT_THRESHOLD_DAYS,
+      scheduled
+    );
+    const fromRef = report(
+      changeLogFreshness(changeLogAtRef("main", path.join(repo, "data", "deal_changes.json"), repo).changes, NOW),
+      DEFAULT_THRESHOLD_DAYS,
+      scheduled
+    );
+    assert.strictEqual(fromDisk.failJob, false, "the run's own write already looked stale, so the pair proves nothing");
+    assert.strictEqual(fromRef.failJob, true, "a log frozen on main since January is still reported as fresh");
+  });
+
+  it("refuses to guess when the ref cannot be read", () => {
+    assert.throws(
+      () => changeLogAtRef("no-such-ref", path.join(repo, "data", "deal_changes.json"), repo),
+      /Cannot read data\/deal_changes\.json at no-such-ref/
+    );
+  });
+
+  it("is what the daily job runs, so the alarm cannot go back to reading its own checkout", () => {
+    const workflow = readFileSync(WORKFLOW_PATH, "utf-8");
+    assert.match(workflow, /check-change-log-staleness\.js --from-ref origin\/main/);
+    assert.match(workflow, /git fetch origin main/);
   });
 });

--- a/test/data-push-gate.test.ts
+++ b/test/data-push-gate.test.ts
@@ -6,6 +6,10 @@ import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
+import {
+  gateVerdict, parseNonBlockingTests, readNonBlockingTests,
+} from "../src/data-push-gate.ts";
+
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const REPO = join(__dirname, "..");
 const WORKFLOWS = join(REPO, ".github", "workflows");
@@ -54,10 +58,57 @@ describe("#1317 the suite sees every commit that reaches main", () => {
     const gate = readFileSync(GATE, "utf8");
     const pushes = gate.split("\n").filter((l) => /git push/.test(l) && /\bmain\b/.test(l));
     assert.strictEqual(pushes.length, 1, `the gate should hold exactly one push to main, holds ${pushes.length}`);
-    assert.ok(
-      gate.indexOf("npm test") < gate.indexOf("HEAD:main"),
-      "the gate pushes to main before it runs the suite",
+    assert.match(gate, /npm run test:gated/, "the gate does not run the suite");
+  });
+
+  it("runs the same test files under the gate as tests.yml runs on main", () => {
+    const scripts = JSON.parse(readFileSync(join(REPO, "package.json"), "utf8")).scripts;
+    const stripReporters = (cmd: string) =>
+      cmd.replace(/--test-reporter(-destination)?=\S+\s*/g, "").replace(/\s+/g, " ").trim();
+    assert.strictEqual(
+      stripReporters(scripts["test:gated"]),
+      stripReporters(scripts.test),
+      "the gate's suite and the suite main runs differ by more than which reporters they load",
     );
+    assert.match(
+      scripts["test:gated"],
+      /--test-reporter=\.\/scripts\/reporters\/failing-test-files\.js/,
+      "the gate's suite does not record which files failed, so it cannot tell what held the commit",
+    );
+  });
+
+  it("holds the refused data on a ref of its own each time, so yesterday's is still there tomorrow", () => {
+    const gate = readFileSync(GATE, "utf8");
+    assert.doesNotMatch(gate, /git push --force/, "a forced push to a fixed ref overwrites the last refusal");
+    assert.match(gate, /date -u \+/, "the quarantine ref carries no timestamp, so two refusals collide");
+  });
+
+  it("says what the gate did somewhere a person will see without opening the run", () => {
+    for (const file of GATED_WORKFLOWS) {
+      const text = source(file);
+      assert.match(
+        text,
+        /bash scripts\/report-data-push-outcome\.sh "[^"]+" refused/,
+        `${file} refuses a commit without saying so anywhere but its own log`,
+      );
+      assert.match(
+        text,
+        /bash scripts\/report-data-push-outcome\.sh "[^"]+" shipped-over-failures/,
+        `${file} can leave main red and say so nowhere — a scheduled push carries no tests run behind it`,
+      );
+      assert.match(
+        text,
+        /steps\.gate\.outputs\.quarantined == 'true' \|\| steps\.gate\.outputs\.pushed_over_failures == 'true'/,
+        `${file} does not report on both of the outcomes the gate can reach`,
+      );
+      assert.match(text, /issues: write/, `${file} cannot open the issue it is told to open`);
+    }
+  });
+
+  it("gives the two outcomes different markers, so neither buries the other", () => {
+    const reporter = readFileSync(join(REPO, "scripts", "report-data-push-outcome.sh"), "utf8");
+    const markers = [...reporter.matchAll(/MARKER="([a-z-]+)"/g)].map((m) => m[1]!);
+    assert.deepStrictEqual(markers, ["data-push-refused", "data-push-over-failures"]);
   });
 
   it("routes every scheduled data writer through the gate, each with its own quarantine branch", () => {
@@ -86,19 +137,59 @@ describe("#1317 the suite sees every commit that reaches main", () => {
   });
 });
 
-const SUITE = `const red = process.env.GATE_FIXTURE_TESTS === "red";
+const FAILING_BY_MODE: Record<string, string[]> = {
+  green: [],
+  red: ["test/the-data-this-run-wrote-is-wrong.test.ts"],
+  excused: ["test/how-current-our-reading-is.test.ts"],
+  mixed: ["test/how-current-our-reading-is.test.ts", "test/the-data-this-run-wrote-is-wrong.test.ts"],
+  crashed: [],
+};
+
+const SUITE = `import { writeFileSync } from "node:fs";
+const modes = ${JSON.stringify(FAILING_BY_MODE)};
+const mode = process.env.GATE_FIXTURE_TESTS || "green";
+const failing = modes[mode];
+writeFileSync(process.env.GATE_FAILING_FILES, failing.map((f) => f + "\\n").join(""));
 console.log("\\u2139 tests 2");
-console.log("\\u2139 pass " + (red ? 1 : 2));
-console.log("\\u2139 fail " + (red ? 1 : 0));
-if (red) {
+console.log("\\u2139 pass " + (mode === "green" ? 2 : 1));
+console.log("\\u2139 fail " + (mode === "green" ? 0 : 1));
+if (mode !== "green") {
   console.log("\\u2716 failing tests:");
-  console.log("the fixture assertion the data broke");
+  for (const f of failing) console.log("the fixture assertion in " + f);
+  if (mode === "crashed") console.log("the suite died before it named a file");
   process.exit(1);
 }
 `;
 
+const BUILD = `if (process.env.GATE_FIXTURE_BUILD === "fail") {
+  console.log("the fixture build does not compile");
+  process.exit(1);
+}
+`;
+
+const ALLOWLIST = JSON.stringify(
+  {
+    version: 1,
+    rule: "the fixture stands in for the shipped list, so the behaviour under test does not move when that list does",
+    tests: [
+      {
+        file: "test/how-current-our-reading-is.test.ts",
+        reason: "everything it fires on is unread rather than incorrect",
+      },
+    ],
+  },
+  null,
+  2,
+);
+
 const PACKAGE = JSON.stringify(
-  { name: "gate-fixture", version: "1.0.0", private: true, scripts: { build: "node --version", test: "node suite.js" } },
+  {
+    name: "gate-fixture",
+    version: "1.0.0",
+    private: true,
+    type: "module",
+    scripts: { build: "node build.js", "test:gated": "node suite.js" },
+  },
   null,
   2,
 );
@@ -122,6 +213,8 @@ function fixtureRepo(): { work: string; origin: string } {
   mkdirSync(join(work, "data"), { recursive: true });
   writeFileSync(join(work, "package.json"), PACKAGE);
   writeFileSync(join(work, "suite.js"), SUITE);
+  writeFileSync(join(work, "build.js"), BUILD);
+  writeFileSync(join(work, "allowlist.json"), ALLOWLIST);
   writeFileSync(join(work, "data", "health.json"), '{"checked":1}\n');
   writeFileSync(join(work, "untracked-by-the-gate.txt"), "before\n");
   git(work, "add", "-A");
@@ -130,21 +223,37 @@ function fixtureRepo(): { work: string; origin: string } {
   return { work, origin };
 }
 
-function runGate(work: string, red: boolean, ...args: string[]) {
-  return spawnSync("bash", [GATE, ...args], {
+type GateMode = keyof typeof FAILING_BY_MODE;
+
+function runGate(work: string, mode: GateMode | { mode: GateMode; build: "fail" }, ...args: string[]) {
+  const tests = typeof mode === "string" ? mode : mode.mode;
+  const build = typeof mode === "string" ? "ok" : mode.build;
+  const outputs = join(work, "step-outputs.txt");
+  const run = spawnSync("bash", [GATE, ...args], {
     cwd: work,
     encoding: "utf8",
-    env: { ...process.env, GATE_FIXTURE_TESTS: red ? "red" : "green" },
+    env: {
+      ...process.env,
+      GATE_FIXTURE_TESTS: tests,
+      GATE_FIXTURE_BUILD: build,
+      GITHUB_OUTPUT: outputs,
+      AGENTDEALS_NON_BLOCKING_TESTS_PATH: join(work, "allowlist.json"),
+    },
   });
+  return { ...run, outputs: existsSync(outputs) ? readFileSync(outputs, "utf8") : "" };
 }
 
 function mainSha(origin: string): string {
   return git(origin, "rev-parse", "main");
 }
 
-function branchExists(origin: string, branch: string): boolean {
-  return spawnSync("git", ["rev-parse", "--verify", branch], { cwd: origin, encoding: "utf8" }).status === 0;
+function quarantineRefs(origin: string, prefix: string): string[] {
+  return git(origin, "for-each-ref", "--format=%(refname:short)", `refs/heads/${prefix}*`)
+    .split("\n")
+    .filter((r) => r.length > 0)
+    .sort();
 }
+
 
 describe("#1317 the gate, run against a repository", () => {
   before(() => {
@@ -155,23 +264,26 @@ describe("#1317 the gate, run against a repository", () => {
     if (scratch && existsSync(scratch)) rmSync(scratch, { recursive: true, force: true });
   });
 
-  it("stops a data change the suite refuses, and holds it on the quarantine branch", () => {
+  it("stops a data change the suite refuses, and holds it on a quarantine ref", () => {
     const { work, origin } = fixtureRepo();
     const before = mainSha(origin);
     writeFileSync(join(work, "data", "health.json"), '{"checked":2}\n');
 
-    const run = runGate(work, true, "data-quarantine/fixture", "data(auto): fixture", "data/health.json");
+    const run = runGate(work, "red", "data-quarantine/fixture", "data(auto): fixture", "data/health.json");
 
     assert.strictEqual(run.status, 1, `the gate let a red suite through: ${run.stdout}${run.stderr}`);
     assert.strictEqual(mainSha(origin), before, "main moved on a commit the suite refused");
-    assert.ok(branchExists(origin, "data-quarantine/fixture"), "the refused commit was not held anywhere");
+    const refs = quarantineRefs(origin, "data-quarantine/fixture");
+    assert.strictEqual(refs.length, 1, `the refused commit was not held anywhere: ${refs.join(", ")}`);
     assert.strictEqual(
-      git(origin, "show", "data-quarantine/fixture:data/health.json"),
+      git(origin, "show", `${refs[0]}:data/health.json`),
       '{"checked":2}',
-      "the quarantine branch does not carry the data the run produced",
+      "the quarantine ref does not carry the data the run produced",
     );
-    assert.match(run.stdout, /the fixture assertion the data broke/, "the failing test is not named in the log");
+    assert.match(run.stdout, /the-data-this-run-wrote-is-wrong/, "the failing test is not named in the log");
     assert.match(run.stdout, /main is unchanged/);
+    assert.match(run.outputs, /quarantined=true/);
+    assert.match(run.outputs, new RegExp(`quarantine_ref=${refs[0]}`));
   });
 
   it("pushes a data change the suite accepts", () => {
@@ -179,20 +291,20 @@ describe("#1317 the gate, run against a repository", () => {
     const before = mainSha(origin);
     writeFileSync(join(work, "data", "health.json"), '{"checked":3}\n');
 
-    const run = runGate(work, false, "data-quarantine/fixture", "data(auto): fixture", "data/health.json");
+    const run = runGate(work, "green", "data-quarantine/fixture", "data(auto): fixture", "data/health.json");
 
     assert.strictEqual(run.status, 0, `the gate refused a green suite: ${run.stdout}${run.stderr}`);
     assert.notStrictEqual(mainSha(origin), before);
     assert.strictEqual(git(origin, "show", "main:data/health.json"), '{"checked":3}');
     assert.strictEqual(git(origin, "log", "-1", "--format=%s", "main"), "data(auto): fixture");
-    assert.ok(!branchExists(origin, "data-quarantine/fixture"), "a green run opened a quarantine branch");
+    assert.deepStrictEqual(quarantineRefs(origin, "data-quarantine/fixture"), [], "a green run quarantined something");
   });
 
   it("commits nothing when the run produced no data change, and leaves the suite unrun", () => {
     const { work, origin } = fixtureRepo();
     const before = mainSha(origin);
 
-    const run = runGate(work, true, "data-quarantine/fixture", "data(auto): fixture", "data/health.json");
+    const run = runGate(work, "red", "data-quarantine/fixture", "data(auto): fixture", "data/health.json");
 
     assert.strictEqual(run.status, 0, run.stdout + run.stderr);
     assert.strictEqual(mainSha(origin), before);
@@ -205,7 +317,7 @@ describe("#1317 the gate, run against a repository", () => {
     writeFileSync(join(work, "data", "health.json"), '{"checked":4}\n');
     writeFileSync(join(work, "untracked-by-the-gate.txt"), "after\n");
 
-    const run = runGate(work, false, "data-quarantine/fixture", "data(auto): fixture", "data/health.json");
+    const run = runGate(work, "green", "data-quarantine/fixture", "data(auto): fixture", "data/health.json");
 
     assert.strictEqual(run.status, 0, run.stdout + run.stderr);
     assert.strictEqual(git(origin, "show", "main:untracked-by-the-gate.txt"), "before");
@@ -214,8 +326,168 @@ describe("#1317 the gate, run against a repository", () => {
 
   it("refuses to run without a quarantine branch, a message and a path", () => {
     const { work } = fixtureRepo();
-    const run = runGate(work, false, "data-quarantine/fixture", "data(auto): fixture");
+    const run = runGate(work, "green", "data-quarantine/fixture", "data(auto): fixture");
     assert.strictEqual(run.status, 2);
     assert.match(run.stderr, /usage: gate-data-push\.sh/);
+  });
+});
+
+describe("#1321 a measurement of our own reading does not stop the catalogue advancing", () => {
+  before(() => {
+    scratch = mkdtempSync(join(tmpdir(), "gate-split-"));
+  });
+
+  after(() => {
+    if (scratch && existsSync(scratch)) rmSync(scratch, { recursive: true, force: true });
+  });
+
+  it("puts the data on main when the only red test measures how current our reading is", () => {
+    const { work, origin } = fixtureRepo();
+    const before = mainSha(origin);
+    writeFileSync(join(work, "data", "health.json"), '{"checked":5}\n');
+
+    const run = runGate(work, "excused", "data-quarantine/fixture", "data(auto): fixture", "data/health.json");
+
+    assert.strictEqual(run.status, 0, `the gate held the data back: ${run.stdout}${run.stderr}`);
+    assert.notStrictEqual(mainSha(origin), before, "the data did not reach main");
+    assert.strictEqual(git(origin, "show", "main:data/health.json"), '{"checked":5}');
+    assert.deepStrictEqual(quarantineRefs(origin, "data-quarantine/fixture"), []);
+    assert.match(run.stdout, /how-current-our-reading-is/, "the failure that did not hold the commit is not named");
+    assert.match(run.stdout, /none of them says this data is wrong/);
+    assert.match(run.outputs, /pushed_over_failures=true/);
+  });
+
+  it("still holds the data back when a test says the data itself is wrong", () => {
+    const { work, origin } = fixtureRepo();
+    const before = mainSha(origin);
+    writeFileSync(join(work, "data", "health.json"), '{"checked":6}\n');
+
+    const run = runGate(work, "red", "data-quarantine/fixture", "data(auto): fixture", "data/health.json");
+
+    assert.strictEqual(run.status, 1, "a data-validity failure no longer holds the commit");
+    assert.strictEqual(mainSha(origin), before);
+    assert.match(run.stdout, /hold the commit/);
+  });
+
+  it("holds the data back when one excused failure arrives beside one that is not", () => {
+    const { work, origin } = fixtureRepo();
+    const before = mainSha(origin);
+    writeFileSync(join(work, "data", "health.json"), '{"checked":7}\n');
+
+    const run = runGate(work, "mixed", "data-quarantine/fixture", "data(auto): fixture", "data/health.json");
+
+    assert.strictEqual(run.status, 1, "an excused failure carried a real one onto main with it");
+    assert.strictEqual(mainSha(origin), before);
+    assert.match(run.stdout, /the-data-this-run-wrote-is-wrong/);
+  });
+
+  it("holds the data back when the suite is red and names no file", () => {
+    const { work, origin } = fixtureRepo();
+    const before = mainSha(origin);
+    writeFileSync(join(work, "data", "health.json"), '{"checked":8}\n');
+
+    const run = runGate(work, "crashed", "data-quarantine/fixture", "data(auto): fixture", "data/health.json");
+
+    assert.strictEqual(run.status, 1, "a suite that failed without naming a file was treated as excused");
+    assert.strictEqual(mainSha(origin), before);
+    assert.match(run.stdout, /named no test file/);
+  });
+
+  it("holds the data back when the build does not compile, whatever the allowlist says", () => {
+    const { work, origin } = fixtureRepo();
+    const before = mainSha(origin);
+    writeFileSync(join(work, "data", "health.json"), '{"checked":9}\n');
+
+    const run = runGate(
+      work,
+      { mode: "excused", build: "fail" },
+      "data-quarantine/fixture",
+      "data(auto): fixture",
+      "data/health.json",
+    );
+
+    assert.strictEqual(run.status, 1, "a build failure reached main");
+    assert.strictEqual(mainSha(origin), before);
+    assert.match(run.stdout, /does not compile/);
+  });
+
+  it("leaves each refusal its own ref, so the second does not overwrite the first", () => {
+    const { work, origin } = fixtureRepo();
+    writeFileSync(join(work, "data", "health.json"), '{"checked":10}\n');
+    const first = runGate(work, "red", "data-quarantine/fixture", "data(auto): day one", "data/health.json");
+    assert.strictEqual(first.status, 1, first.stdout + first.stderr);
+
+    writeFileSync(join(work, "data", "health.json"), '{"checked":11}\n');
+    const second = runGate(work, "red", "data-quarantine/fixture", "data(auto): day two", "data/health.json");
+    assert.strictEqual(second.status, 1, second.stdout + second.stderr);
+
+    const refs = quarantineRefs(origin, "data-quarantine/fixture");
+    assert.strictEqual(refs.length, 2, `two refusals left ${refs.length} refs: ${refs.join(", ")}`);
+    const held = refs.map((r) => git(origin, "show", `${r}:data/health.json`)).sort();
+    assert.deepStrictEqual(held, ['{"checked":10}', '{"checked":11}'], "a day's findings were overwritten");
+  });
+});
+
+describe("#1321 which failures are allowed not to hold a data commit", () => {
+  const shipped = readNonBlockingTests();
+
+  it("names test files that exist, so a rename cannot silently widen the gate", () => {
+    for (const t of shipped.tests) {
+      assert.ok(existsSync(join(REPO, t.file)), `${t.file} is excused from holding a data commit and does not exist`);
+    }
+  });
+
+  it("keeps the list short enough to read, and gives a reason for every entry", () => {
+    assert.ok(shipped.tests.length > 0, "nothing is excused, so the split has no subject");
+    assert.ok(shipped.tests.length <= 5, `${shipped.tests.length} files are excused; the list is meant to be read`);
+    for (const t of shipped.tests) {
+      assert.ok(t.reason.length > 40, `${t.file} is excused with ${t.reason.length} characters of reason`);
+    }
+  });
+
+  it("lives where no scheduled job can write it, so widening the gate takes a pull request", () => {
+    assert.match(readFileSync(join(REPO, "src", "data-push-gate.ts"), "utf8"), /"scripts", "gate-non-blocking-tests\.json"/);
+    for (const file of GATED_WORKFLOWS) {
+      const gated = source(file).match(/gate-data-push\.sh[\s\S]*?\n\n/)?.[0] ?? "";
+      assert.doesNotMatch(gated, /\bscripts\//, `${file} hands the gate a path under scripts/, which it could then commit`);
+    }
+  });
+
+  it("holds the commit for a file nobody excused", () => {
+    const verdict = gateVerdict(["test/somewhere-else.test.ts"], shipped);
+    assert.strictEqual(verdict.decision, "quarantine");
+    assert.deepStrictEqual(verdict.blocking, ["test/somewhere-else.test.ts"]);
+  });
+
+  it("lets the commit through when every failing file is excused", () => {
+    const verdict = gateVerdict(shipped.tests.map((t) => t.file), shipped);
+    assert.strictEqual(verdict.decision, "push");
+    assert.deepStrictEqual(verdict.blocking, []);
+  });
+
+  it("holds the commit when the suite failed and named nothing", () => {
+    const verdict = gateVerdict([], shipped);
+    assert.strictEqual(verdict.decision, "quarantine");
+    assert.match(verdict.reason, /named no test file/);
+  });
+
+  it("refuses a list that excuses something outside test/", () => {
+    assert.throws(
+      () => parseNonBlockingTests(JSON.stringify({ version: 1, rule: "r", tests: [{ file: "src/serve.ts", reason: "x" }] }), "fixture"),
+      /not a path under test\//,
+    );
+  });
+
+  it("refuses a list that excuses a file with no reason", () => {
+    assert.throws(
+      () => parseNonBlockingTests(JSON.stringify({ version: 1, rule: "r", tests: [{ file: "test/a.test.ts" }] }), "fixture"),
+      /with no reason/,
+    );
+  });
+
+  it("counts the two ratchets the scheduled jobs can trip among the excused files", () => {
+    const excused = new Set(shipped.tests.map((t) => t.file));
+    assert.ok(excused.has("test/stale-page-facts.test.ts"), "the cohort this issue is about still holds the commit");
+    assert.ok(excused.has("test/page-data-provenance.test.ts"));
   });
 });

--- a/test/page-source-ratchet.test.ts
+++ b/test/page-source-ratchet.test.ts
@@ -110,7 +110,10 @@ describe("the number of tier-A pages asserting vendor facts from nowhere only go
   it("refuses a budget left above what the register now holds, so a freed slot cannot be reused", () => {
     const pages = filled(3);
     const problems = problemsFor(pages, measurementsFor(pages), 4);
-    assert.ok(problems.some(p => p.includes("lower UNSOURCED_TIER_A_BASELINE to 3")), problems.join(" | "));
+    assert.ok(
+      problems.some(p => p.includes("set unsourced_tier_a to 3 in data/quality_budgets.json")),
+      problems.join(" | ")
+    );
   });
 
   it("counts only tier A, because the budget is a claim about pages that state a verdict", () => {

--- a/test/stale-page-facts.test.ts
+++ b/test/stale-page-facts.test.ts
@@ -4,8 +4,10 @@ import { readFileSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import {
-  STALE_FACT_PAGES_BASELINE, factsOutdatedBy, newestChangeBySlug, parsePageReviews, reviewStatus,
-  staleFactPages, staleFactViolations, utcToday, vendorsStatedBy,
+  QUALITY_BUDGET_NAMES, STALE_FACT_PAGES_BASELINE, UNSOURCED_TIER_A_BASELINE, factsOutdatedBy,
+  newestChangeBySlug, parsePageReviews, parseQualityBudgets, qualityBudgetsPath, readQualityBudgets,
+  reviewStatus, serializeQualityBudgets, staleFactPages, staleFactViolations, unsourcedTierAPaths,
+  utcToday, vendorsStatedBy,
   type PageReviewRecord,
 } from "../src/page-reviews.ts";
 import { toSlug } from "../dist/vendor-slug.js";
@@ -124,7 +126,18 @@ describe("the number of pages resting on a record that has moved under them only
     const pages = [page({ path: "/a", vendors_asserted: ["neon"] })];
     const problems = staleFactViolations(pages, "2026-09-02", moved, 4).map(v => v.problem);
     assert.strictEqual(problems.length, 1);
-    assert.match(problems[0]!, /lower STALE_FACT_PAGES_BASELINE to 1/);
+    assert.match(problems[0]!, /set stale_fact_pages to 1 in data\/quality_budgets\.json/);
+  });
+
+  it("sends whoever lowers the budget to a data file, so a data-only change can carry the improvement", () => {
+    const problem = staleFactViolations(
+      [page({ path: "/a", vendors_asserted: ["neon"] })],
+      "2026-09-02",
+      moved,
+      4
+    )[0]!.problem;
+    assert.doesNotMatch(problem, /src\//, "the instruction sends a data-only author into src");
+    assert.match(problem, /npm run ratchet:budgets/);
   });
 
   it("is silent when the cohort is exactly the budget", () => {
@@ -220,5 +233,111 @@ describe("a reviewer's note survives a regeneration of what is derived", () => {
   it("claims no note from a review the register dates in the future", () => {
     const ahead = page({ path: "/p", reviewed_at: "2026-12-01", review_outcome: "fail", review_note: "found a stale row" });
     assert.strictEqual(reviewStatus(ahead, "2026-09-02").review_note, null);
+  });
+});
+
+describe("#1321 the budgets live where whoever earns a lower one can write them", () => {
+  const BUDGETS = path.join(REPO, "data", "quality_budgets.json");
+
+  it("is read from data, not compiled into the code the scheduled jobs cannot write", () => {
+    assert.strictEqual(qualityBudgetsPath(), BUDGETS);
+    const shipped = readQualityBudgets();
+    assert.strictEqual(STALE_FACT_PAGES_BASELINE, shipped.budgets.stale_fact_pages);
+    assert.strictEqual(UNSOURCED_TIER_A_BASELINE, shipped.budgets.unsourced_tier_a);
+    for (const file of ["page-reviews.ts", "faq-provenance.ts"]) {
+      assert.doesNotMatch(
+        readFileSync(path.join(REPO, "src", file), "utf-8"),
+        /BASELINE = \d+|: \d+,\n};/,
+        `a budget is still a literal in src/${file}`,
+      );
+    }
+  });
+
+  it("carries a number for every budget the code reads, and nothing else", () => {
+    const shipped = readQualityBudgets();
+    assert.deepStrictEqual(Object.keys(shipped.budgets).sort(), [...QUALITY_BUDGET_NAMES].sort());
+    for (const name of QUALITY_BUDGET_NAMES) assert.ok(Number.isInteger(shipped.budgets[name]));
+  });
+
+  it("refuses a budget name nothing reads, so a typo cannot sit unused", () => {
+    const budgets = Object.fromEntries(QUALITY_BUDGET_NAMES.map(n => [n, 1]));
+    assert.throws(
+      () => parseQualityBudgets(JSON.stringify({ version: 1, budgets: { ...budgets, stale_fact_pgaes: 1 } }), "fixture"),
+      /stale_fact_pgaes/,
+    );
+  });
+
+  it("refuses a budget that is missing, rather than treating it as zero", () => {
+    assert.throws(
+      () => parseQualityBudgets(JSON.stringify({ version: 1, budgets: { stale_fact_pages: 1 } }), "fixture"),
+      /unsourced_tier_a as undefined/,
+    );
+  });
+
+  it("writes back what it read, so lowering one budget cannot reorder or drop another", () => {
+    const shipped = readQualityBudgets();
+    assert.strictEqual(serializeQualityBudgets(shipped), readFileSync(BUDGETS, "utf-8"));
+  });
+
+  it("measures both budgets against the register the site ships", () => {
+    assert.strictEqual(staleFactPages(REGISTRY.pages, TODAY, changeDateFor).length, STALE_FACT_PAGES_BASELINE);
+    assert.strictEqual(unsourcedTierAPaths(REGISTRY.pages).length, UNSOURCED_TIER_A_BASELINE);
+  });
+});
+
+describe("#1321 a budget follows its measurement down and never up", () => {
+  const at = (stale: number, unsourced: number) => ({ stale_fact_pages: stale, unsourced_tier_a: unsourced });
+
+  it("lowers a budget the data has fallen below", async () => {
+    const { ratchet } = await import("../scripts/ratchet-quality-budgets.js");
+    const { next, lowered, over } = ratchet(at(57, 43), at(56, 43));
+    assert.deepStrictEqual(next, at(56, 43));
+    assert.deepStrictEqual(lowered, [{ name: "stale_fact_pages", from: 57, to: 56 }]);
+    assert.deepStrictEqual(over, []);
+  });
+
+  it("leaves a budget the data has risen above, and says which one", async () => {
+    const { ratchet } = await import("../scripts/ratchet-quality-budgets.js");
+    const { next, lowered, over } = ratchet(at(57, 43), at(58, 43));
+    assert.deepStrictEqual(next, at(57, 43), "a budget rose to meet the data");
+    assert.deepStrictEqual(lowered, []);
+    assert.deepStrictEqual(over, [{ name: "stale_fact_pages", budget: 57, measured: 58 }]);
+  });
+
+  it("moves each budget on its own measurement", async () => {
+    const { ratchet } = await import("../scripts/ratchet-quality-budgets.js");
+    const { next, lowered, over } = ratchet(at(57, 43), at(50, 44));
+    assert.deepStrictEqual(next, at(50, 43));
+    assert.deepStrictEqual(lowered.map(l => l.name), ["stale_fact_pages"]);
+    assert.deepStrictEqual(over.map(o => o.name), ["unsourced_tier_a"]);
+  });
+
+  it("measures what the shipped budgets already hold, so a run at rest writes nothing", async () => {
+    const { ratchet, measureBudgets } = await import("../scripts/ratchet-quality-budgets.js");
+    const { lowered, over } = ratchet(readQualityBudgets().budgets, measureBudgets(TODAY));
+    assert.deepStrictEqual(lowered, []);
+    assert.deepStrictEqual(over, []);
+  });
+});
+
+describe("#1321 the FAQ counts are budgets too, and they live in the same file", () => {
+  it("reads all three from data rather than from the code", async () => {
+    const { FAQ_BASELINE } = await import("../dist/faq-provenance.js");
+    const shipped = readQualityBudgets().budgets;
+    assert.strictEqual(FAQ_BASELINE.answers, shipped.faq_answers);
+    assert.strictEqual(FAQ_BASELINE.stating_a_figure, shipped.faq_answers_stating_a_figure);
+    assert.strictEqual(FAQ_BASELINE.a_digit_but_no_figure, shipped.faq_answers_with_a_digit_but_no_figure);
+  });
+
+  it("says plainly that the ratchet cannot lower a budget it does not measure", async () => {
+    const { ratchet } = await import("../scripts/ratchet-quality-budgets.js");
+    const { unmeasured, lowered, over } = ratchet(readQualityBudgets().budgets, { stale_fact_pages: 57, unsourced_tier_a: 43 });
+    assert.deepStrictEqual(unmeasured, [
+      "faq_answers",
+      "faq_answers_stating_a_figure",
+      "faq_answers_with_a_digit_but_no_figure",
+    ]);
+    assert.deepStrictEqual(lowered, []);
+    assert.deepStrictEqual(over, []);
   });
 });


### PR DESCRIPTION
Refs #1321

The gate from #1317 is right and stays. This changes what it sits on top of, following the ruling on the issue: **the budget moves into data, the gate blocks on wrong and reports on unreviewed, and the alarm reads `main`.**

## The budget is data now

`data/quality_budgets.json` holds all five ratchet numbers — `stale_fact_pages: 57`, `unsourced_tier_a: 43` and the three FAQ counts. `src/page-reviews.ts` and `src/faq-provenance.ts` read them; the literals are gone. The failure message changed with them — it used to say "lower `STALE_FACT_PAGES_BASELINE`", a constant in `src/`, and now says "set `stale_fact_pages` to 56 in `data/quality_budgets.json` — run `npm run ratchet:budgets`".

That is the whole of the problem this issue opened on. Both actors who can lower the number — the scheduled jobs and data-only pull requests — can write `data/`. Neither can write `src/`. #1323 and #1324 each corrected facts on `/hetzner-pricing-2026` and neither could record the review; either could now.

`npm run ratchet:budgets` measures both cohorts and lowers any budget above its measurement. It never raises one: a budget below its measurement is reported and left, and the suite is what fails until a person decides. The daily re-verification runs it before the gate and commits the result with its data, so an improvement the job earns is banked in the same commit.

**Named rather than hidden:** the job lowering the budget automatically means a transient data fault that shrinks the cohort ratchets the budget down with it, and the correction that restores the data then needs a deliberate raise. That raise is a one-line data edit rather than a `src/` change, which is the trade the ruling asked for — but it is a real edge and it is worth knowing about before it happens.

## Block on wrong, report on unreviewed

`npm run test:gated` runs the same test files as `npm test` with one extra reporter, `scripts/reporters/failing-test-files.js`, which writes the file of every failure. The gate subtracts `scripts/gate-non-blocking-tests.json` from that list. Anything left holds the commit; nothing left and the data reaches `main` with the failures printed.

Two files are on the list:

- `test/stale-page-facts.test.ts` — the cohort this issue is about.
- `test/page-data-provenance.test.ts` — holds the register's declaration of where each page's numbers come from against what the page renders.

The rule for admission is in the file: everything the test fires on has to be a statement about how current our own reading is, and nothing it fires on may be a statement that the catalogue is wrong. The list lives under `scripts/`, which no gated workflow hands to the gate, so widening it takes a pull request. A test asserts that.

Three things still hold the commit whatever the list says, each with a test: a failure in a file nobody excused, a red suite that named no file at all, and a build that does not compile.

## A refusal is visible, and survives the next one

The quarantine ref is `<prefix>-<UTC timestamp>-<short sha>` and the push is not forced. Two refusals leave two refs; a genuine price correction found on day one is no longer overwritten by day two. Tested by refusing twice and reading both.

When the gate quarantines, it writes `quarantined=true` and the ref to `$GITHUB_OUTPUT`, and each of the three workflows opens or comments on a single issue carrying the marker `data-push-refused`. That is criterion 3: the freeze is visible without opening a workflow log.

**The report path needed the same treatment, for a reason that only shows up once you put the two halves together.** "Report and go red on `main` where a human sees them" does not work by itself here: a scheduled push is made with `GITHUB_TOKEN`, which cannot trigger `tests.yml` — that is the finding #1317 shipped for. So a data run that ships over an excused failure would leave `main` red with no run behind it to say so. `scripts/report-data-push-outcome.sh` therefore has two outcomes and two markers. A refusal comments every time, because each one is a distinct event holding a distinct ref. A shipped-over-failures notice opens one issue and then stays quiet, because it recurs daily until somebody clears the budget.

## The alarm reads main

`check-change-log-staleness.js` gains `--from-ref`, and `reverify.yml` passes `origin/main` after fetching it. It read `data/deal_changes.json` from the workflow's own checkout, where the run had just written it, so it reported the log fresh whether or not the commit reached `main`.

The test builds a repository whose committed log is eight months stale and whose working tree is fresh, and asserts the two readings disagree — `failJob: false` from disk, `failJob: true` from the ref. That is the defect, reproduced.

## Criterion 5 — the other ratchets

I looked for every constant in `src/` that pins a count over the corpus. There are three, holding five numbers, and **all five are in `data/quality_budgets.json` now** — the class, not the instance.

| constant | reachable by scheduled-job data | lowered by |
|---|---|---|
| `STALE_FACT_PAGES_BASELINE` | yes, through `data/deal_changes.json` | `npm run ratchet:budgets`, and the daily job |
| `UNSOURCED_TIER_A_BASELINE` | no — it reads only the register | `npm run ratchet:budgets` |
| `FAQ_BASELINE` — three counts | yes, through `data/index.json` | by hand, from the number the suite prints |

`UNSOURCED_TIER_A_BASELINE` cannot be moved by the jobs, but the test file holding it can: the other half of `pageSourceViolations` reads rendered pages, and those read `data/index.json`. That is why the file is on the non-blocking list and the constant is in the budgets file anyway.

`FAQ_BASELINE` is the interesting one, and the evidence that it is reachable is already in the suite: `test/faq-provenance.test.ts` boots a server against a perturbed catalogue and asserts that **more than five FAQ answers move with it**. `stating_a_figure` is pinned twice — once as a count of answers, once as the number of dated answers the catalogue *cannot* move — so a re-verification that rewrites an offer's description can break either. Its three numbers are in the budgets file, but measuring them needs a running server, so `ratchet:budgets` reports them as "measured only by the suite" and does not touch them. That is honest rather than clever: the file it lives in is now writable by whoever earns a lower number, which was the whole complaint.

**A second answer to criterion 5, which the ruling asked for:** any red test blocks the gate, not only a ratchet. `source-check-pages.test.ts:417` was red on 60% of days for a date-seeded tie-break, measured on #1190. Nothing here excuses a flaky test — the answer to that class is criteria 3 and 4, which turn a flake from a silent freeze into a visible, recoverable quarantine, plus fixing the flakes on #1190.

## What the cohort can actually do

Measured on the shipped register today: **0 slugs can raise the cohort today, 28 from tomorrow.** The two pages #1320 cleared were cleared today, so a change recorded today does not beat their clock; from tomorrow it does. That agrees with the ~1.9 days on the issue and puts a date on it.

## Verification

The gate's own behaviour is proved against a real repository with its own bare origin, one test per branch: an excused-only red run pushes, a data-wrong red run quarantines, a mixed run quarantines, a run that failed without naming a file quarantines, a failed build quarantines, and two refusals leave two refs carrying two different days of data.

The last local run went through `npm run test:gated` rather than `npm test` — **3,648 tests, 0 failures** — so the reporter the gate depends on is exercised on all 165 real test files and not only on the fixture. It wrote an empty failing-files list, which is the green path.
