### PR TITLE
Record the Copilot Business signup pause and drop a false claim about it (#1183)

### DIFF
--- a/data/deal_changes.json
+++ b/data/deal_changes.json
@@ -4573,7 +4573,7 @@
       "date": "2026-04-20",
       "summary": "GitHub paused new signups for Copilot Pro, Pro+, and Copilot Student plans citing infrastructure strain from agentic AI workflows (long-running, parallelized sessions overwhelming capacity). Existing users are unaffected. Free tier signups remain open. Same announcement also removed Claude Opus from Pro (now Pro+ only) and tightened usage limits on individual plans.",
       "previous_state": "Pro ($10/mo), Pro+ ($39/mo), and Copilot Student plans accepting new signups. Claude Opus available on Pro. Standard individual-plan usage limits.",
-      "current_state": "Reversed. GitHub's changelog post for this change is marked Retired, and its plans documentation offers Copilot Pro, Pro+, Max and Copilot Student to new users today (verified 2026-09-02). The pause that remains in force is a separate one dated 2026-04-22 on self-serve purchase of Copilot Business and Copilot Enterprise. Free tier was unaffected throughout.",
+      "current_state": "Reversed. GitHub's changelog post for this change is marked Retired, and its plans documentation offers Copilot Pro, Pro+, Max and Copilot Student to new users today (verified 2026-09-02). A separate pause dated 2026-04-22 covered new self-serve signups for Copilot Business by organizations on GitHub Free and GitHub Team plans, and did not cover Copilot Enterprise; GitHub reenabled signups for new Copilot Business and Copilot Enterprise customers paying by credit card or PayPal from 2026-09-01. Free tier was unaffected throughout.",
       "impact": "high",
       "source_url": "https://github.blog/changelog/2026-04-20-changes-to-github-copilot-plans-for-individuals/",
       "category": "AI Coding",
@@ -4589,8 +4589,33 @@
       "resolution": {
         "state": "reversed",
         "date": "2026-09-02",
-        "detail": "Reversed: GitHub's changelog post for this change is marked Retired, and its plans documentation offers Copilot Pro, Pro+, Max and Copilot Student to new users, verified 2026-09-02. The only pause still on that page is a separate one dated 2026-04-22 on self-serve purchases of Copilot Business and Copilot Enterprise.",
+        "detail": "Reversed: GitHub's changelog post for this change is marked Retired, and its plans documentation offers Copilot Pro, Pro+, Max and Copilot Student to new users, verified 2026-09-02. A separate pause dated 2026-04-22 covered new self-serve signups for Copilot Business by organizations on GitHub Free and GitHub Team plans, and did not cover Copilot Enterprise; GitHub reenabled signups for new Copilot Business and Copilot Enterprise customers paying by credit card or PayPal from 2026-09-01.",
         "source_url": "https://docs.github.com/en/copilot/get-started/plans"
+      }
+    },
+    {
+      "vendor": "GitHub Copilot",
+      "change_type": "restriction",
+      "date": "2026-04-22",
+      "summary": "GitHub paused new self-serve signups for Copilot Business by organizations on GitHub Free and GitHub Team plans, two days after the pause on individual plans. Existing Copilot Business customers were unaffected and could keep adding seats. Copilot Enterprise was not named in the announcement.",
+      "previous_state": "Organizations on GitHub Free and GitHub Team could buy Copilot Business ($19/user/month) self-serve.",
+      "current_state": "Reversed. GitHub's changelog post for this pause is marked Retired, and its 2026-08-28 billing announcement says signups for new Copilot Business and Copilot Enterprise customers paying by credit card or PayPal were reenabled from 2026-09-01. The same announcement adds an upfront per-seat charge on assignment, reaching existing Business and Enterprise customers on those payment methods from 2026-10-01.",
+      "impact": "high",
+      "source_url": "https://github.blog/changelog/2026-04-22-pausing-new-self-serve-signups-for-github-copilot-business/",
+      "category": "AI Coding",
+      "alternatives": [
+        "Cursor",
+        "Windsurf",
+        "Gemini Code Assist",
+        "Claude Code"
+      ],
+      "recorded_date": "2026-09-04",
+      "date_source": "hand_written",
+      "resolution": {
+        "state": "reversed",
+        "date": "2026-09-01",
+        "detail": "Reversed: GitHub's 2026-08-28 changelog states \"Starting September 1, 2026, GitHub will start reenabling sign-ups for new Copilot Business and Copilot Enterprise customers paying by credit card or PayPal.\" The pause announcement is marked Retired.",
+        "source_url": "https://github.blog/changelog/2026-08-28-upcoming-changes-to-github-copilot-policies-and-billing/"
       }
     },
     {


### PR DESCRIPTION
Refs #1183

`/ai-coding-tools-pricing` is our most-read standalone page over the last ten days — 307 of 3,041 route-classified views in `data/analytics`, ahead of `/hetzner-pricing-2026` at 276. Its review on 2026-08-27 failed, and one of the two things it failed on was that the page recommends Copilot Business to enterprise readers while the restriction that would have stopped them buying it is not in our change log.

## The false claim

The 2026-04-20 record says, in `current_state` and again in `resolution.detail`:

> The pause that remains in force is a separate one dated 2026-04-22 on self-serve purchase of Copilot Business and Copilot Enterprise.

Both halves are wrong against GitHub's own changelog.

- **Scope.** [The 2026-04-22 post](https://github.blog/changelog/2026-04-22-pausing-new-self-serve-signups-for-github-copilot-business/) is titled "Pausing new self-serve signups for GitHub Copilot Business" and applies to "organizations on GitHub Free and GitHub Team plans." Copilot Enterprise is not in it.
- **Status.** [GitHub's 2026-08-28 billing post](https://github.blog/changelog/2026-08-28-upcoming-changes-to-github-copilot-policies-and-billing/) says "Starting September 1, 2026, GitHub will start reenabling sign-ups for new Copilot Business and Copilot Enterprise customers paying by credit card or PayPal." That was published five days before the 2026-09-02 verification that wrote the claim, and the source that verification cites — GitHub's plans documentation — contains no pause language at all, so it could not have supported it either way.

## The missing record

There was no record for the 2026-04-22 pause. It existed only as a clause inside another vendor's record, which is why the review found the page recommending Copilot Business with nothing in the log beside it. Added as its own record, `impact: high`, resolved `reversed` on 2026-09-01 with the reopening post as its source. The pause announcement itself is marked Retired on github.blog.

Its `current_state` also carries the part of the 2026-08-28 announcement that is still ahead of us: an upfront per-seat charge on assignment, reaching existing Business and Enterprise customers paying by card or PayPal from 2026-10-01. I have not filed that as its own record — future-dated fields are what #1267 is about and I would rather not add an instance while that is open.

## Checks

- `npm run validate` — 1,580 offers, 526 deal changes.
- `node scripts/lint-duplicates.js` — clean.
- Stale-fact ratchet measured before and after against `origin/main`: **57 before, 57 after, same 57 paths**, budget 57. GitHub Copilot's newest change is already 2026-08-28, so a record dated 2026-04-22 does not move `newestChangeBySlug`.
- Data only. No `src/`, no `test/`.
