### PR TITLE
Lower the budget inside the gate, where a failure holds the day's data instead of destroying it (#1326)

### DIFF
--- a/.github/workflows/analytics-rollup.yml
+++ b/.github/workflows/analytics-rollup.yml
@@ -65,10 +65,11 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           QUARANTINED: ${{ steps.gate.outputs.quarantined }}
           QUARANTINE_REF: ${{ steps.gate.outputs.quarantine_ref }}
+          QUARANTINE_REASON: ${{ steps.gate.outputs.quarantine_reason }}
           NON_BLOCKING_FILES: ${{ steps.gate.outputs.non_blocking_files }}
         run: |
           if [ "$QUARANTINED" = "true" ]; then
-            bash scripts/report-data-push-outcome.sh "Analytics rollup" refused "$QUARANTINE_REF"
+            bash scripts/report-data-push-outcome.sh "Analytics rollup" refused "$QUARANTINE_REF" "$QUARANTINE_REASON"
           else
             bash scripts/report-data-push-outcome.sh "Analytics rollup" shipped-over-failures "$NON_BLOCKING_FILES"
           fi

--- a/.github/workflows/liveness.yml
+++ b/.github/workflows/liveness.yml
@@ -57,10 +57,11 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           QUARANTINED: ${{ steps.gate.outputs.quarantined }}
           QUARANTINE_REF: ${{ steps.gate.outputs.quarantine_ref }}
+          QUARANTINE_REASON: ${{ steps.gate.outputs.quarantine_reason }}
           NON_BLOCKING_FILES: ${{ steps.gate.outputs.non_blocking_files }}
         run: |
           if [ "$QUARANTINED" = "true" ]; then
-            bash scripts/report-data-push-outcome.sh "Link liveness" refused "$QUARANTINE_REF"
+            bash scripts/report-data-push-outcome.sh "Link liveness" refused "$QUARANTINE_REF" "$QUARANTINE_REASON"
           else
             bash scripts/report-data-push-outcome.sh "Link liveness" shipped-over-failures "$NON_BLOCKING_FILES"
           fi

--- a/.github/workflows/reverify.yml
+++ b/.github/workflows/reverify.yml
@@ -75,10 +75,11 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           QUARANTINED: ${{ steps.gate.outputs.quarantined }}
           QUARANTINE_REF: ${{ steps.gate.outputs.quarantine_ref }}
+          QUARANTINE_REASON: ${{ steps.gate.outputs.quarantine_reason }}
           NON_BLOCKING_FILES: ${{ steps.gate.outputs.non_blocking_files }}
         run: |
           if [ "$QUARANTINED" = "true" ]; then
-            bash scripts/report-data-push-outcome.sh "Daily rolling re-verification" refused "$QUARANTINE_REF"
+            bash scripts/report-data-push-outcome.sh "Daily rolling re-verification" refused "$QUARANTINE_REF" "$QUARANTINE_REASON"
           else
             bash scripts/report-data-push-outcome.sh "Daily rolling re-verification" shipped-over-failures "$NON_BLOCKING_FILES"
           fi

--- a/.github/workflows/reverify.yml
+++ b/.github/workflows/reverify.yml
@@ -53,14 +53,10 @@ jobs:
           echo "retried=$RETRIED" >> "$GITHUB_OUTPUT"
           echo "repicked=$REPICKED" >> "$GITHUB_OUTPUT"
 
-      - name: Lower any quality budget this run's data has earned
-        run: |
-          npm run build
-          node scripts/ratchet-quality-budgets.js --lower
-
       - name: Run the suite, then push to main only if it is green
         id: gate
         env:
+          GATE_RATCHET_BUDGETS: "1"
           VERIFIED: ${{ steps.reverify.outputs.verified }}
           FLAGGED: ${{ steps.reverify.outputs.flagged }}
           RECORDED: ${{ steps.reverify.outputs.recorded }}

--- a/scripts/gate-data-push.sh
+++ b/scripts/gate-data-push.sh
@@ -54,11 +54,12 @@ quarantine() {
     echo "quarantined=true"
     echo "quarantine_ref=$ref"
     echo "quarantined_commit=$COMMIT"
+    echo "quarantine_reason=$why"
   } >>"$OUTPUT"
   if git push origin "HEAD:refs/heads/$ref"; then
-    echo "$why — $COMMIT is held on $ref and main is unchanged."
+    echo "Held back because $why — $COMMIT is on $ref and main is unchanged."
   else
-    echo "$why — $COMMIT could not be held on $ref and main is unchanged. This run's data exists only in its own workspace."
+    echo "Held back because $why — $COMMIT could not be pushed to $ref and main is unchanged. This run's data exists only in its own workspace."
   fi
   exit 1
 }
@@ -70,14 +71,14 @@ summarize() {
 if ! npm run build >"$LOG" 2>&1; then
   tail -n 60 "$LOG"
   echo "The build failed, and no test-file allowance covers code that does not compile."
-  quarantine "Build red"
+  quarantine "the build does not compile"
 fi
 
 if [ -n "$RATCHET_BUDGETS" ]; then
   echo "── Lowering any quality budget this run's data has earned ──"
   if ! npm run ratchet:budgets; then
     echo "The budgets could not be measured. That decides nothing about whether this run's data is right, so the data is held rather than discarded."
-    quarantine "Budget ratchet red"
+    quarantine "the quality budgets could not be measured"
   fi
   if [ -n "$(git status --porcelain -- "$@")" ]; then
     git add -- "$@"
@@ -114,4 +115,4 @@ if node "$SCRIPT_DIR/gate-verdict.js" "$GATE_FAILING_FILES" >"$VERDICT" 2>&1; th
 fi
 
 cat "$VERDICT"
-quarantine "Suite red"
+quarantine "the suite refused it"

--- a/scripts/gate-data-push.sh
+++ b/scripts/gate-data-push.sh
@@ -12,6 +12,19 @@ shift 2
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 OUTPUT="${GITHUB_OUTPUT:-/dev/null}"
+RATCHET_BUDGETS="${GATE_RATCHET_BUDGETS:-}"
+BUDGETS_PATH="data/quality_budgets.json"
+
+if [ -n "$RATCHET_BUDGETS" ]; then
+  BUDGETS_COMMITTABLE=""
+  for path in "$@"; do
+    case "$BUDGETS_PATH" in "$path"|"$path"/*) BUDGETS_COMMITTABLE="yes" ;; esac
+  done
+  if [ -z "$BUDGETS_COMMITTABLE" ]; then
+    echo "usage: GATE_RATCHET_BUDGETS is set but $BUDGETS_PATH is not among the paths this run may commit ($*), so a budget lowered here would be left behind in the workspace." >&2
+    exit 2
+  fi
+fi
 
 if [ -z "$(git status --porcelain -- "$@")" ]; then
   echo "No change under $* — nothing to commit or push."
@@ -35,6 +48,7 @@ push_to_main() {
 }
 
 quarantine() {
+  local why="$1"
   local ref="${QUARANTINE_PREFIX}-$(date -u +%Y%m%dT%H%M%SZ)-${COMMIT}"
   {
     echo "quarantined=true"
@@ -42,9 +56,9 @@ quarantine() {
     echo "quarantined_commit=$COMMIT"
   } >>"$OUTPUT"
   if git push origin "HEAD:refs/heads/$ref"; then
-    echo "Suite red — $COMMIT is held on $ref and main is unchanged."
+    echo "$why — $COMMIT is held on $ref and main is unchanged."
   else
-    echo "Suite red — $COMMIT could not be held on $ref and main is unchanged. This run's data exists only in its own workspace."
+    echo "$why — $COMMIT could not be held on $ref and main is unchanged. This run's data exists only in its own workspace."
   fi
   exit 1
 }
@@ -56,7 +70,21 @@ summarize() {
 if ! npm run build >"$LOG" 2>&1; then
   tail -n 60 "$LOG"
   echo "The build failed, and no test-file allowance covers code that does not compile."
-  quarantine
+  quarantine "Build red"
+fi
+
+if [ -n "$RATCHET_BUDGETS" ]; then
+  echo "── Lowering any quality budget this run's data has earned ──"
+  if ! npm run ratchet:budgets; then
+    echo "The budgets could not be measured. That decides nothing about whether this run's data is right, so the data is held rather than discarded."
+    quarantine "Budget ratchet red"
+  fi
+  if [ -n "$(git status --porcelain -- "$@")" ]; then
+    git add -- "$@"
+    git commit -q --amend --no-edit
+    COMMIT="$(git rev-parse --short HEAD)"
+    echo "A budget fell to what this run's data measures, in the same commit as the data that earned it."
+  fi
 fi
 
 if npm run test:gated >>"$LOG" 2>&1; then
@@ -86,4 +114,4 @@ if node "$SCRIPT_DIR/gate-verdict.js" "$GATE_FAILING_FILES" >"$VERDICT" 2>&1; th
 fi
 
 cat "$VERDICT"
-quarantine
+quarantine "Suite red"

--- a/scripts/gate-data-push.sh
+++ b/scripts/gate-data-push.sh
@@ -40,8 +40,10 @@ COMMIT="$(git rev-parse --short HEAD)"
 LOG="$(mktemp)"
 VERDICT="$(mktemp)"
 GATE_FAILING_FILES="$(mktemp)"
+SUBPROCESS_OUTPUT="$(mktemp)"
 export GATE_FAILING_FILES
-trap 'rm -f "$LOG" "$VERDICT" "$GATE_FAILING_FILES"' EXIT
+export GITHUB_OUTPUT="$SUBPROCESS_OUTPUT"
+trap 'rm -f "$LOG" "$VERDICT" "$GATE_FAILING_FILES" "$SUBPROCESS_OUTPUT"' EXIT
 
 push_to_main() {
   git push origin HEAD:main

--- a/scripts/report-data-push-outcome.sh
+++ b/scripts/report-data-push-outcome.sh
@@ -2,13 +2,14 @@
 set -euo pipefail
 
 if [ "$#" -lt 2 ]; then
-  echo "usage: report-data-push-outcome.sh <job-name> refused|shipped-over-failures [detail]" >&2
+  echo "usage: report-data-push-outcome.sh <job-name> refused|shipped-over-failures [detail] [reason]" >&2
   exit 2
 fi
 
 JOB="$1"
 OUTCOME="$2"
 DETAIL="${3:-}"
+REASON="${4:-the suite refused it}"
 SERVER="${GITHUB_SERVER_URL:-https://github.com}"
 REPO="${GITHUB_REPOSITORY:-robhunter/agentdeals}"
 RUN_URL="$SERVER/$REPO/actions/runs/${GITHUB_RUN_ID:-unknown}"
@@ -23,7 +24,7 @@ case "$OUTCOME" in
     LABEL="priority/high"
     COMMENT_EVERY_TIME="yes"
     {
-      echo "\`$JOB\` produced data the suite refused, so \`main\` did not move and the catalogue did not advance."
+      echo "\`$JOB\` produced data that did not reach \`main\`, because $REASON. The catalogue did not advance."
       echo
       if [ -n "$DETAIL" ]; then
         echo "The refused commit is held on [\`$DETAIL\`]($SERVER/$REPO/tree/$DETAIL). Each refusal gets its own ref, so this one is not overwritten by the next."
@@ -35,7 +36,7 @@ case "$OUTCOME" in
       echo
       echo "Until this clears, the queue does not advance: the next run picks the same entries, finds the same things, and is refused again."
       echo
-      echo "What to do: read the failing tests in the run, fix them on \`main\`, then merge the quarantined data or let the next scheduled run redo it."
+      echo "What to do: read the run for what went red, fix it on \`main\`, then merge the quarantined data or let the next scheduled run redo it."
     } >"$BODY"
     ;;
   shipped-over-failures)

--- a/test/data-push-gate.test.ts
+++ b/test/data-push-gate.test.ts
@@ -3,12 +3,13 @@ import assert from "node:assert";
 import { spawnSync } from "node:child_process";
 import { mkdtempSync, mkdirSync, readFileSync, readdirSync, rmSync, writeFileSync, existsSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { dirname, join } from "node:path";
+import { dirname, join, relative, sep } from "node:path";
 import { fileURLToPath } from "node:url";
 
 import {
   gateVerdict, parseNonBlockingTests, readNonBlockingTests,
 } from "../src/data-push-gate.ts";
+import { qualityBudgetsPath } from "../src/page-reviews.ts";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const REPO = join(__dirname, "..");
@@ -16,6 +17,27 @@ const WORKFLOWS = join(REPO, ".github", "workflows");
 const GATE = join(REPO, "scripts", "gate-data-push.sh");
 
 const GATED_WORKFLOWS = ["reverify.yml", "liveness.yml", "analytics-rollup.yml"];
+
+interface WorkflowStep {
+  name: string;
+  body: string;
+}
+
+function stepsOf(text: string): WorkflowStep[] {
+  const out: WorkflowStep[] = [];
+  for (const line of text.split("\n")) {
+    const start = line.match(/^ {6}- (?:name|uses):\s*(.+)$/);
+    if (start) out.push({ name: start[1]!.trim(), body: `${line}\n` });
+    else if (out.length > 0) out[out.length - 1]!.body += `${line}\n`;
+  }
+  return out;
+}
+
+function gateStepOf(file: string): WorkflowStep {
+  const step = stepsOf(source(file)).find((s) => /gate-data-push\.sh/.test(s.body));
+  assert.ok(step, `${file} has no step that invokes the gate`);
+  return step;
+}
 
 function workflowFiles(): string[] {
   return readdirSync(WORKFLOWS).filter((f) => /\.ya?ml$/.test(f)).sort();
@@ -167,6 +189,21 @@ const BUILD = `if (process.env.GATE_FIXTURE_BUILD === "fail") {
 }
 `;
 
+const BUDGETS_BEFORE = `${JSON.stringify({ version: 1, budgets: { fixture_pages: 57 } }, null, 2)}\n`;
+const BUDGETS_AFTER = `${JSON.stringify({ version: 1, budgets: { fixture_pages: 56 } }, null, 2)}\n`;
+
+const RATCHET = `import { writeFileSync } from "node:fs";
+const mode = process.env.GATE_FIXTURE_RATCHET || "lower";
+if (mode === "throw") {
+  console.log("the fixture ratchet could not read the data it measures");
+  process.exit(1);
+}
+if (mode === "lower") {
+  writeFileSync("data/quality_budgets.json", ${JSON.stringify(BUDGETS_AFTER)});
+  console.log("Lowered fixture_pages 57 -> 56");
+}
+`;
+
 const ALLOWLIST = JSON.stringify(
   {
     version: 1,
@@ -188,7 +225,11 @@ const PACKAGE = JSON.stringify(
     version: "1.0.0",
     private: true,
     type: "module",
-    scripts: { build: "node build.js", "test:gated": "node suite.js" },
+    scripts: {
+      build: "node build.js",
+      "test:gated": "node suite.js",
+      "ratchet:budgets": "node ratchet.js",
+    },
   },
   null,
   2,
@@ -214,8 +255,10 @@ function fixtureRepo(): { work: string; origin: string } {
   writeFileSync(join(work, "package.json"), PACKAGE);
   writeFileSync(join(work, "suite.js"), SUITE);
   writeFileSync(join(work, "build.js"), BUILD);
+  writeFileSync(join(work, "ratchet.js"), RATCHET);
   writeFileSync(join(work, "allowlist.json"), ALLOWLIST);
   writeFileSync(join(work, "data", "health.json"), '{"checked":1}\n');
+  writeFileSync(join(work, "data", "quality_budgets.json"), BUDGETS_BEFORE);
   writeFileSync(join(work, "untracked-by-the-gate.txt"), "before\n");
   git(work, "add", "-A");
   git(work, "commit", "-m", "fixture");
@@ -225,17 +268,26 @@ function fixtureRepo(): { work: string; origin: string } {
 
 type GateMode = keyof typeof FAILING_BY_MODE;
 
-function runGate(work: string, mode: GateMode | { mode: GateMode; build: "fail" }, ...args: string[]) {
-  const tests = typeof mode === "string" ? mode : mode.mode;
-  const build = typeof mode === "string" ? "ok" : mode.build;
+type RatchetMode = "lower" | "throw";
+
+interface GateRun {
+  mode: GateMode;
+  build?: "fail";
+  ratchet?: RatchetMode;
+}
+
+function runGate(work: string, mode: GateMode | GateRun, ...args: string[]) {
+  const opts: GateRun = typeof mode === "string" ? { mode } : mode;
   const outputs = join(work, "step-outputs.txt");
   const run = spawnSync("bash", [GATE, ...args], {
     cwd: work,
     encoding: "utf8",
     env: {
       ...process.env,
-      GATE_FIXTURE_TESTS: tests,
-      GATE_FIXTURE_BUILD: build,
+      GATE_FIXTURE_TESTS: opts.mode,
+      GATE_FIXTURE_BUILD: opts.build ?? "ok",
+      GATE_FIXTURE_RATCHET: opts.ratchet ?? "lower",
+      GATE_RATCHET_BUDGETS: opts.ratchet === undefined ? "" : "1",
       GITHUB_OUTPUT: outputs,
       AGENTDEALS_NON_BLOCKING_TESTS_PATH: join(work, "allowlist.json"),
     },
@@ -425,6 +477,161 @@ describe("#1321 a measurement of our own reading does not stop the catalogue adv
     assert.strictEqual(refs.length, 2, `two refusals left ${refs.length} refs: ${refs.join(", ")}`);
     const held = refs.map((r) => git(origin, "show", `${r}:data/health.json`)).sort();
     assert.deepStrictEqual(held, ['{"checked":10}', '{"checked":11}'], "a day's findings were overwritten");
+  });
+});
+
+describe("#1326 nothing that can fail stands between the day's data and the gate", () => {
+  it("runs the gate as the next step after the one that produced the data", () => {
+    for (const file of GATED_WORKFLOWS) {
+      const steps = stepsOf(source(file));
+      const gate = steps.findIndex((s) => /gate-data-push\.sh/.test(s.body));
+      assert.ok(gate > 0, `${file} has no gate step, or the gate is its first step`);
+      let producer = -1;
+      for (let i = 0; i < gate; i++) if (/\$GITHUB_OUTPUT/.test(steps[i]!.body)) producer = i;
+      assert.ok(producer >= 0, `${file} reaches its gate without a step that produced anything`);
+      assert.strictEqual(
+        gate,
+        producer + 1,
+        `${file} runs ${steps.slice(producer + 1, gate).map((s) => s.name).join(", ")} after producing the day's data ` +
+          `and before the gate that holds it — a failure there takes the data with the runner`,
+      );
+    }
+  });
+
+  it("lowers the daily run's budgets from inside the gate, where a failure is quarantined", () => {
+    const gate = gateStepOf("reverify.yml");
+    assert.match(gate.body, /GATE_RATCHET_BUDGETS: "1"/, "the daily run no longer banks the improvement its data earned");
+    assert.match(gate.body, /data\/quality_budgets\.json/, "the gate may lower a budget it is not allowed to commit");
+    assert.doesNotMatch(
+      source("reverify.yml"),
+      /ratchet-quality-budgets/,
+      "the ratchet still runs in a step of its own, upstream of every failure path the gate provides",
+    );
+  });
+
+  it("asks for the ratchet only where a budget is in the paths being committed", () => {
+    for (const file of GATED_WORKFLOWS) {
+      const gate = gateStepOf(file);
+      if (!/GATE_RATCHET_BUDGETS/.test(gate.body)) continue;
+      assert.match(gate.body, /data\/quality_budgets\.json/, `${file} lowers a budget it then leaves in the workspace`);
+    }
+  });
+
+  it("names the budgets file the code reads, so the shell and the code cannot drift", () => {
+    const declared = readFileSync(GATE, "utf8").match(/^BUDGETS_PATH="([^"]+)"$/m)?.[1];
+    assert.strictEqual(declared, relative(REPO, qualityBudgetsPath()).split(sep).join("/"));
+  });
+});
+
+describe("#1326 the gate, asked to lower a budget", () => {
+  before(() => {
+    scratch = mkdtempSync(join(tmpdir(), "gate-ratchet-"));
+  });
+
+  after(() => {
+    if (scratch && existsSync(scratch)) rmSync(scratch, { recursive: true, force: true });
+  });
+
+  const PATHS = ["data-quarantine/fixture", "data(auto): fixture", "data/health.json", "data/quality_budgets.json"];
+
+  it("puts the budget it lowers in the same commit as the data that earned it", () => {
+    const { work, origin } = fixtureRepo();
+    const before = mainSha(origin);
+    writeFileSync(join(work, "data", "health.json"), '{"checked":12}\n');
+
+    const run = runGate(work, { mode: "green", ratchet: "lower" }, ...PATHS);
+
+    assert.strictEqual(run.status, 0, `the gate refused a green run: ${run.stdout}${run.stderr}`);
+    assert.strictEqual(
+      git(origin, "rev-list", "--count", `${before}..main`),
+      "1",
+      "the lowered budget arrived as a commit of its own rather than with the data",
+    );
+    assert.deepStrictEqual(
+      git(origin, "show", "--name-only", "--format=", "main").split("\n").filter(Boolean).sort(),
+      ["data/health.json", "data/quality_budgets.json"],
+    );
+    assert.strictEqual(git(origin, "show", "main:data/quality_budgets.json"), BUDGETS_AFTER.trim());
+    assert.strictEqual(
+      git(origin, "log", "-1", "--format=%s", "main"),
+      "data(auto): fixture",
+      "amending the commit lost the message the run wrote",
+    );
+  });
+
+  it("holds the day's data on a ref of its own when the build the ratchet needs does not compile", () => {
+    const { work, origin } = fixtureRepo();
+    const before = mainSha(origin);
+    writeFileSync(join(work, "data", "health.json"), '{"checked":13}\n');
+
+    const run = runGate(work, { mode: "green", build: "fail", ratchet: "lower" }, ...PATHS);
+
+    assert.strictEqual(run.status, 1, `a build failure reached main: ${run.stdout}${run.stderr}`);
+    assert.strictEqual(mainSha(origin), before);
+    const refs = quarantineRefs(origin, "data-quarantine/fixture");
+    assert.strictEqual(refs.length, 1, `the day's data was discarded rather than held: ${refs.join(", ")}`);
+    assert.strictEqual(
+      git(origin, "show", `${refs[0]}:data/health.json`),
+      '{"checked":13}',
+      "the quarantine ref does not carry the data the run produced",
+    );
+    assert.match(run.stdout, /does not compile/);
+    assert.match(run.outputs, /quarantined=true/, "nothing downstream can report a refusal it is not told of");
+    assert.match(run.outputs, new RegExp(`quarantine_ref=${refs[0]}`));
+  });
+
+  it("holds the day's data on a ref of its own when the ratchet itself fails", () => {
+    const { work, origin } = fixtureRepo();
+    const before = mainSha(origin);
+    writeFileSync(join(work, "data", "health.json"), '{"checked":14}\n');
+
+    const run = runGate(work, { mode: "green", ratchet: "throw" }, ...PATHS);
+
+    assert.strictEqual(run.status, 1, `a run that could not measure a budget pushed anyway: ${run.stdout}${run.stderr}`);
+    assert.strictEqual(mainSha(origin), before);
+    const refs = quarantineRefs(origin, "data-quarantine/fixture");
+    assert.strictEqual(refs.length, 1, `failing to measure a budget cost the day's catalogue data: ${refs.join(", ")}`);
+    assert.strictEqual(git(origin, "show", `${refs[0]}:data/health.json`), '{"checked":14}');
+    assert.strictEqual(
+      git(origin, "show", `${refs[0]}:data/quality_budgets.json`),
+      BUDGETS_BEFORE.trim(),
+      "a ratchet that failed still moved a budget",
+    );
+    assert.match(run.stdout, /budgets could not be measured/);
+    assert.match(run.outputs, /quarantined=true/);
+    assert.match(run.outputs, new RegExp(`quarantine_ref=${refs[0]}`));
+  });
+
+  it("refuses to lower a budget it has not been given permission to commit", () => {
+    const { work, origin } = fixtureRepo();
+    const before = mainSha(origin);
+    writeFileSync(join(work, "data", "health.json"), '{"checked":15}\n');
+
+    const run = runGate(
+      work,
+      { mode: "green", ratchet: "lower" },
+      "data-quarantine/fixture",
+      "data(auto): fixture",
+      "data/health.json",
+    );
+
+    assert.strictEqual(run.status, 2, `${run.stdout}${run.stderr}`);
+    assert.match(run.stderr, /not among the paths this run may commit/);
+    assert.strictEqual(mainSha(origin), before);
+  });
+
+  it("leaves the budgets where they are on a run that did not ask for the ratchet", () => {
+    const { work, origin } = fixtureRepo();
+    writeFileSync(join(work, "data", "health.json"), '{"checked":16}\n');
+
+    const run = runGate(work, "green", ...PATHS);
+
+    assert.strictEqual(run.status, 0, `${run.stdout}${run.stderr}`);
+    assert.strictEqual(
+      git(origin, "show", "main:data/quality_budgets.json"),
+      BUDGETS_BEFORE.trim(),
+      "the gate lowered a budget for a job that never asked it to",
+    );
   });
 });
 

--- a/test/data-push-gate.test.ts
+++ b/test/data-push-gate.test.ts
@@ -167,11 +167,12 @@ const FAILING_BY_MODE: Record<string, string[]> = {
   crashed: [],
 };
 
-const SUITE = `import { writeFileSync } from "node:fs";
+const SUITE = `import { appendFileSync, writeFileSync } from "node:fs";
 const modes = ${JSON.stringify(FAILING_BY_MODE)};
 const mode = process.env.GATE_FIXTURE_TESTS || "green";
 const failing = modes[mode];
 writeFileSync(process.env.GATE_FAILING_FILES, failing.map((f) => f + "\\n").join(""));
+appendFileSync(process.env.GITHUB_OUTPUT, "a_test_spawned_a_script_that_wrote_this=yes\\n");
 console.log("\\u2139 tests 2");
 console.log("\\u2139 pass " + (mode === "green" ? 2 : 1));
 console.log("\\u2139 fail " + (mode === "green" ? 0 : 1));
@@ -643,6 +644,23 @@ describe("#1326 the gate, asked to lower a budget", () => {
     assert.strictEqual(run.status, 2, `${run.stdout}${run.stderr}`);
     assert.match(run.stderr, /not among the paths this run may commit/);
     assert.strictEqual(mainSha(origin), before);
+  });
+
+  it("keeps the suite's own writes out of the step outputs the reporting step reads", () => {
+    const { work, origin } = fixtureRepo();
+    const before = mainSha(origin);
+    writeFileSync(join(work, "data", "health.json"), '{"checked":17}\n');
+
+    const run = runGate(work, { mode: "red", ratchet: "lower" }, ...PATHS);
+
+    assert.strictEqual(run.status, 1, `${run.stdout}${run.stderr}`);
+    assert.strictEqual(mainSha(origin), before);
+    assert.match(run.outputs, /quarantined=true/, "the gate's own outputs went missing with the redirect");
+    assert.doesNotMatch(
+      run.outputs,
+      /a_test_spawned_a_script_that_wrote_this/,
+      "a test in the suite can write a step output on the gate step's behalf, including one the gate sets itself",
+    );
   });
 
   it("leaves the budgets where they are on a run that did not ask for the ratchet", () => {

--- a/test/data-push-gate.test.ts
+++ b/test/data-push-gate.test.ts
@@ -521,6 +521,29 @@ describe("#1326 nothing that can fail stands between the day's data and the gate
     const declared = readFileSync(GATE, "utf8").match(/^BUDGETS_PATH="([^"]+)"$/m)?.[1];
     assert.strictEqual(declared, relative(REPO, qualityBudgetsPath()).split(sep).join("/"));
   });
+
+  it("tells the refusal issue which of the three things went wrong, not just that something did", () => {
+    const gate = readFileSync(GATE, "utf8");
+    const reasons = [...gate.matchAll(/^\s*quarantine "([^"]+)"$/gm)].map((m) => m[1]!);
+    assert.deepStrictEqual(
+      reasons.sort(),
+      ["the build does not compile", "the quality budgets could not be measured", "the suite refused it"],
+      "the gate can hold a commit for a reason the issue it opens cannot name",
+    );
+    assert.match(gate, /echo "quarantine_reason=\$why"/, "the reason never reaches the step output");
+    for (const file of GATED_WORKFLOWS) {
+      assert.match(
+        source(file),
+        /report-data-push-outcome\.sh "[^"]+" refused "\$QUARANTINE_REF" "\$QUARANTINE_REASON"/,
+        `${file} opens an issue that tells a reader to look for failing tests whatever went wrong`,
+      );
+    }
+    assert.doesNotMatch(
+      readFileSync(join(REPO, "scripts", "report-data-push-outcome.sh"), "utf8"),
+      /read the failing tests in the run/,
+      "the refusal issue still sends a reader to failing tests when the build is what broke",
+    );
+  });
 });
 
 describe("#1326 the gate, asked to lower a budget", () => {
@@ -578,6 +601,7 @@ describe("#1326 the gate, asked to lower a budget", () => {
     assert.match(run.stdout, /does not compile/);
     assert.match(run.outputs, /quarantined=true/, "nothing downstream can report a refusal it is not told of");
     assert.match(run.outputs, new RegExp(`quarantine_ref=${refs[0]}`));
+    assert.match(run.outputs, /quarantine_reason=the build does not compile/);
   });
 
   it("holds the day's data on a ref of its own when the ratchet itself fails", () => {
@@ -600,6 +624,7 @@ describe("#1326 the gate, asked to lower a budget", () => {
     assert.match(run.stdout, /budgets could not be measured/);
     assert.match(run.outputs, /quarantined=true/);
     assert.match(run.outputs, new RegExp(`quarantine_ref=${refs[0]}`));
+    assert.match(run.outputs, /quarantine_reason=the quality budgets could not be measured/);
   });
 
   it("refuses to lower a budget it has not been given permission to commit", () => {


### PR DESCRIPTION
Refs #1326

#1325 put a step in `reverify.yml` that runs after the day's re-verification and before the gate. It has no failure path, so a broken build stops the job there: the gate never runs, no `data-quarantine/*` ref is written, the reporting step is skipped by its own `if:`, and ~75 entries plus the price corrections found in them are destroyed with the runner. That is the opposite of what it shipped for.

## The ratchet moves inside the gate

Criterion 4 asks whether the lowered budget still lands in the same commit as the data that earned it, and says to move the ratchet into `gate-data-push.sh` rather than work around it if that is what keeping both properties takes. It is, and it does.

The gate now runs, in order: commit the paths it was given, build, lower any budget the data has earned, amend that into the same commit, run the suite, push or quarantine. Every step after the commit has the same failure path, because by then the day's data is already a commit that a quarantine ref can hold.

- **The budget still lands with the data.** `git commit --amend --no-edit` folds `data/quality_budgets.json` into the commit the run already made, keeping its message. A test asserts one commit reaches `main` carrying both files.
- **A build failure is quarantined.** The gate's own "the build failed, and no test-file allowance covers code that does not compile" branch is reachable again for the case it was written for.
- **A ratchet failure is quarantined too.** Failing to measure a budget says nothing about whether the day's data is right, so the data is held rather than discarded. It is worth being conservative here rather than carrying on: the likeliest reason the ratchet throws is that the data it just read does not parse, which is a reason to hold that data, not to publish it.

`GATE_RATCHET_BUDGETS` opts a job in — only the daily re-verification sets it, as before. If it is set and `data/quality_budgets.json` is not among the paths the run may commit, the gate exits 2 rather than lowering a budget it would then leave behind in the workspace.

## The invariant, so this shape cannot come back

A gated workflow may run nothing between the step that produces the day's data and the gate that protects it. A test reads the three workflows, finds the gate step and the last step before it that writes `$GITHUB_OUTPUT`, and asserts they are adjacent. Restoring the step this issue is about fails it by name.

`liveness.yml` and `analytics-rollup.yml` each have a `Build` step of their own, and both are fine — the build runs *before* their producer, so a failure there costs nothing that exists yet. The rule is about order, not about which commands appear.

## The refusal issue says which of the three things went wrong

The gate can now hold a commit for three reasons, and the issue it opens said "produced data the suite refused" and "read the failing tests in the run" for all of them. `quarantine_reason` reaches `$GITHUB_OUTPUT`, all three workflows forward it, and the body names it.

## Verification

Two failure paths, run against a real clone of this repository with its own bare origin, with the real `ratchet-quality-budgets.js`:

- A genuine type error in `src/page-reviews.ts` — gate exit 1, `main` unchanged, the day's marker readable at `<ref>:data/verification_state.json`, `quarantined=true` and `quarantine_reason=the build does not compile` on the step output.
- A half-written line appended to `data/deal_changes.json`, so the ratchet throws where it parses — gate exit 1, `main` unchanged, the day's data on its own ref, the budget on that ref untouched at 57.

Under the shipped code both of those runs end at the standalone step with nothing pushed anywhere.

Then the success path: `stale_fact_pages` raised to 58 on the clone's `main`, a data change made, the gate run — the ratchet lowers it to 57 before the suite loads it, and `main` gains one commit carrying the data and the budget together.

3,659 tests, 11 new. 7 mutations, 7 killed.

## Found while running it

The gate exported its own `$GITHUB_OUTPUT` to every subprocess, so `npm run test:gated` inherited it. `test/change-log-writer.test.ts` spawns `check-change-log-staleness.js` with the ambient environment, and that script writes `detector_scheduled` and `open_absence_issue` — both landed in the gate step's outputs during the verification run above. Nothing collided this time, but any test in the suite could set a key the gate sets itself, including `quarantined`. Subprocesses now get a scratch file; the gate writes its own outputs to the file the step was given.
