### PR TITLE
Refuse a free tier removal whose own record describes a free plan on offer (#1336)

### DIFF
--- a/data/deal_changes.json
+++ b/data/deal_changes.json
@@ -6285,10 +6285,10 @@
     },
     {
       "vendor": "Formbricks",
-      "change_type": "free_tier_removed",
+      "change_type": "limits_reduced",
       "date": "2026-08-28",
       "date_source": "discovered",
-      "summary": "The Community/Free tier with unlimited surveys and responses no longer exists. The free tier, 'Hobby', offers 250 responses per month and core survey features.",
+      "summary": "The free tier on Formbricks Cloud is now 'Hobby' — 1 Workspace and 250 responses per month, where the Community Edition carried unlimited seats, surveys and responses. Self-hosting is still offered free.",
       "previous_state": "Open-source survey platform — Community Edition (self-hosted): unlimited seats, unlimited surveys, unlimited responses, all question types, advanced logic, custom styling, API access, all SDKs and integrations (MPL 2.0)",
       "current_state": "The Hobby plan is free and includes 1 Workspace, 250 responses per month, and core survey features like all question types, conditional logic, and full API access.",
       "impact": "high",
@@ -8068,7 +8068,13 @@
       "category": "Communication & Messaging",
       "alternatives": [],
       "detected_by": "reverify-ai",
-      "recorded_date": "2026-09-03"
+      "recorded_date": "2026-09-03",
+      "resolution": {
+        "state": "retracted",
+        "date": "2026-09-04",
+        "detail": "Retracted 2026-09-04: no free tier was removed. Microsoft Teams (free) is still offered, with 1:1 calls up to 30 hours and group meetings up to 60 minutes. The page this row was read from compares the paid business plans and does not carry the free version. This row was our error.",
+        "source_url": "https://www.microsoft.com/en-us/microsoft-teams/free"
+      }
     },
     {
       "vendor": "CircleCI",
@@ -8102,10 +8108,10 @@
     },
     {
       "vendor": "Mistral AI",
-      "change_type": "free_tier_removed",
+      "change_type": "pricing_restructured",
       "date": "2026-09-03",
       "date_source": "discovered",
-      "summary": "Previously 2 RPM and 1B tokens/month with no credit card required. The free tier now provides limited access to Vibe, including chat, search, creation, and Vibe for code, with limited messages, web searches, and image generations. It also includes access to Mistral Studio. There is a $10/month API credit option.",
+      "summary": "The free tier is no longer an API allowance of 2 RPM and 1B tokens a month across all models. It now carries limited messages, web searches and image generations in Vibe, plus access to Mistral Studio. $10 a month in API credits is sold separately.",
       "previous_state": "Access to all Mistral models including Large, Codestral, Pixtral — 2 RPM, 1B tokens/month. No credit card required",
       "current_state": "The free plan provides limited access to Vibe, including chat, search, creation, and Vibe for code. It includes limited messages, web searches, and image generations, and access to Mistral Studio. $10 /mo in API credits is also available.",
       "impact": "high",

--- a/scripts/change-gate.js
+++ b/scripts/change-gate.js
@@ -13,6 +13,7 @@ export const REJECT_NO_REMOVAL_EVIDENCE = "no_removal_evidence";
 export const REJECT_REMOVAL_READ_FROM_ROOT = "removal_read_from_root";
 export const REJECT_REMOVAL_READ_FROM_REDIRECT = "removal_read_from_redirect";
 export const REJECT_FREE_TIER_STILL_OFFERED = "free_tier_still_offered";
+export const REJECT_FREE_PLAN_STILL_DESCRIBED = "free_plan_still_described";
 export const REJECT_NO_BASELINE = "no_baseline";
 export const REJECT_DANGLING_REFERENCE = "dangling_reference";
 export const REJECT_MEASURES_NO_CHANGE = "measures_no_change";
@@ -32,6 +33,7 @@ export const GATE_REASONS = [
   REJECT_REMOVAL_READ_FROM_ROOT,
   REJECT_REMOVAL_READ_FROM_REDIRECT,
   REJECT_FREE_TIER_STILL_OFFERED,
+  REJECT_FREE_PLAN_STILL_DESCRIBED,
   REJECT_NO_BASELINE,
   REJECT_DANGLING_REFERENCE,
   REJECT_MEASURES_NO_CHANGE,
@@ -773,6 +775,42 @@ export function reportsSomethingStillFree(summary) {
   return FREE_STILL_OFFERED.some((pattern) => pattern.test(withoutTrials));
 }
 
+const A_PLAN_ASSERTED_FREE = [
+  /\b(?:the\s+)?['"‘“]?[\w.+-]+['"’”]?\s+plan\s+is\s+free\b/i,
+  /\bfree\s+(?:plan|tier)\s+(?:now\s+)?(?:provides?|offers?|includes?|gives?)\b/i,
+  /\bthe\s+free\s+(?:plan|tier),?\s*['"‘“]?[\w .+-]{0,24}['"’”]?,?\s+(?:offers?|includes?|provides?)\b/i,
+  /\bis\s+\$0\s*(?:\/|\s+per\s+)\s*(?:month|mo|year|yr)\b/i,
+  /\$0\s*(?:\/|\s+per\s+)\s*(?:month|mo|year|yr)\s+forever\b/i,
+];
+
+const REPLACED_BY_SOMETHING_TEMPORARY =
+  /(?:\b\d+[- ]?(?:day|days|week|weeks|month|months)\b[^.;]{0,20}\b(?:trial|free)\b|\bfree\s+trial\b|\btrial\b[^.;]{0,20}\b(?:with|of|includes?)\b)/i;
+const TAKEN_AWAY =
+  /\b(?:no\s+longer|removing|removed|discontinu\w*|retir\w*|does\s+not\s+(?:offer|include)|ended|eliminat\w*|is\s+gone)\b/i;
+const QUALIFIER_WINDOW = 40;
+
+function sentences(text) {
+  return String(text ?? "").split(/(?<=[.;])\s+/).filter(Boolean);
+}
+
+export function clauseStatingAPlanIsStillFree(record) {
+  const stated = [record?.summary, record?.current_state].filter((f) => typeof f === "string");
+  for (const sentence of sentences(stated.join(" "))) {
+    if (TAKEN_AWAY.test(sentence)) continue;
+    for (const pattern of A_PLAN_ASSERTED_FREE) {
+      const found = pattern.exec(sentence);
+      if (!found) continue;
+      const around = sentence.slice(
+        Math.max(0, found.index - QUALIFIER_WINDOW),
+        found.index + found[0].length + QUALIFIER_WINDOW
+      );
+      if (REPLACED_BY_SOMETHING_TEMPORARY.test(around)) continue;
+      return sentence.trim();
+    }
+  }
+  return null;
+}
+
 const ONLY_THE_WORDING_MOVED = [
   /\b(?:description|wording|phrasing)\s+is\s+(?:now\s+)?less\s+(?:specific|detailed|explicit)\b/i,
   /\bonly\s+the\s+(?:description|wording|phrasing)\s+(?:has\s+)?changed\b/i,
@@ -1272,6 +1310,13 @@ export function auditRecord(record, context = {}) {
       return refuse(
         REJECT_FREE_TIER_STILL_OFFERED,
         `a free tier was recorded as removed by a summary that reports the page still offering one`
+      );
+    }
+    const stillFree = clauseStatingAPlanIsStillFree(record);
+    if (stillFree) {
+      return refuse(
+        REJECT_FREE_PLAN_STILL_DESCRIBED,
+        `a free tier was recorded as removed by a record that describes a free plan on offer now — "${stillFree}". A free tier on different limits has been narrowed, not removed`
       );
     }
     if (!evidenced && isDomainRoot(record?.source_url)) {

--- a/scripts/mutate-1336.sh
+++ b/scripts/mutate-1336.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+set -uo pipefail
+
+cd "$(dirname "$0")/.."
+
+GATE=scripts/change-gate.js
+TESTS="test/free-tier-removal-evidence.test.ts"
+
+killed=0
+total=0
+
+run() {
+  local name="$1"
+  total=$((total + 1))
+  if git diff --quiet $GATE; then
+    echo "NOT APPLIED  $name"
+    git checkout -- $GATE
+    return
+  fi
+  if npx tsx --test $TESTS > /tmp/mutant-1336.log 2>&1; then
+    echo "SURVIVED  $name"
+  else
+    killed=$((killed + 1))
+    echo "killed    $name  ($(grep -c '^  *✖' /tmp/mutant-1336.log) failing)"
+  fi
+  git checkout -- $GATE
+}
+
+echo "== mutating $GATE =="
+
+perl -0pi -e 's/if \(TAKEN_AWAY\.test\(sentence\)\) continue;/if (false) continue;/' $GATE
+run "a clause that says the plan was taken away no longer suppresses the match"
+
+perl -0pi -e 's/if \(REPLACED_BY_SOMETHING_TEMPORARY\.test\(around\)\) continue;/if (false) continue;/' $GATE
+run "a trial replacing the free plan no longer suppresses the match"
+
+perl -0pi -e 's/const QUALIFIER_WINDOW = 40;/const QUALIFIER_WINDOW = 400;/' $GATE
+run "the trial qualifier may sit anywhere in the sentence"
+
+perl -0pi -e 's{/\\bis\\s\+\\\$0\\s\*\(\?:\\/\|\\s\+per\\s\+\)\\s\*\(\?:month\|mo\|year\|yr\)\\b/i}{/\\bis\\s+\\\$0/i}' $GATE
+run "a price of zero needs no period unit after it"
+
+perl -0pi -e 's/const stated = \[record\?\.summary, record\?\.current_state\]/const stated = [record?.summary]/' $GATE
+run "the rule reads the summary and not the current state"
+
+perl -0pi -e 's/    const stillFree = clauseStatingAPlanIsStillFree\(record\);/    const stillFree = null;/' $GATE
+run "the gate never consults the rule"
+
+echo ""
+echo "$killed of $total mutations killed"
+[ "$killed" = "$total" ]

--- a/test/free-tier-removal-evidence.test.ts
+++ b/test/free-tier-removal-evidence.test.ts
@@ -1,0 +1,189 @@
+import { describe, it } from "node:test";
+import assert from "node:assert";
+import { readFileSync, mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+process.env.AGENTDEALS_REFUSALS_PATH = path.join(
+  mkdtempSync(path.join(tmpdir(), "refusals-free-tier-removal-")),
+  "change_refusals.json"
+);
+
+const {
+  clauseStatingAPlanIsStillFree,
+  describesChange,
+  FREE_TIER_REMOVED,
+  REJECT_FREE_PLAN_STILL_DESCRIBED,
+} = await import("../scripts/change-gate.js");
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+const FORMBRICKS = {
+  vendor: "Formbricks",
+  change_type: FREE_TIER_REMOVED,
+  date: "2026-08-28",
+  summary:
+    "The Community/Free tier with unlimited surveys and responses no longer exists. The free tier, 'Hobby', offers 250 responses per month and core survey features.",
+  previous_state:
+    "Community Edition (self-hosted): unlimited seats, unlimited surveys, unlimited responses, all question types",
+  current_state:
+    "The Hobby plan is free and includes 1 Workspace, 250 responses per month, and core survey features like all question types, conditional logic, and full API access.",
+  impact: "high",
+  source_url: "https://formbricks.com/pricing",
+};
+
+const MISTRAL = {
+  vendor: "Mistral AI",
+  change_type: FREE_TIER_REMOVED,
+  date: "2026-09-03",
+  summary:
+    "Previously 2 RPM and 1B tokens/month with no credit card required. The free tier now provides limited access to Vibe, including chat, search, creation, and Vibe for code.",
+  previous_state: "Access to all Mistral models — 2 RPM, 1B tokens/month. No credit card required",
+  current_state:
+    "The free plan provides limited access to Vibe, including chat, search, creation, and Vibe for code. $10 /mo in API credits is also available.",
+  impact: "high",
+  source_url: "https://mistral.ai/pricing",
+};
+
+const HIGHLIGHT = {
+  vendor: "Highlight.io",
+  change_type: FREE_TIER_REMOVED,
+  date: "2026-08-28",
+  summary: "Highlight.io's own page now redirects to launchdarkly.com.",
+  previous_state: "500 sessions, 1K errors, 1M logs, 25M traces/month",
+  current_state:
+    "LaunchDarkly's Developer plan is $0/month forever and includes 5,000 session replays and 5,000 errors a month, 1 project and 3 environments, with 14-day data retention.",
+  impact: "high",
+  source_url: "https://www.highlight.io/pricing",
+};
+
+const A_TRIAL_REPLACED_THE_FREE_PLAN = {
+  vendor: "Middleware.io",
+  change_type: FREE_TIER_REMOVED,
+  date: "2026-08-28",
+  summary:
+    "The free tier has been replaced by a 14 days free trial with unlimited data ingestion and full platform access.",
+  previous_state: "Free forever tier with 1 GB of logs a month",
+  current_state: "14 days free trial with unlimited data ingestion, then paid plans from $0.30 per GB.",
+  impact: "high",
+  source_url: "https://middleware.io/pricing",
+};
+
+const THE_ONLY_FREE_PLAN_IS_THE_ONE_TAKEN_AWAY = {
+  vendor: "bonsai.io",
+  change_type: FREE_TIER_REMOVED,
+  date: "2026-09-04",
+  summary:
+    "The free tier no longer exists. The lowest tier is now a 'Staging' plan at $15/month with 1 GB storage and 256 MB memory.",
+  previous_state: "Free Sandbox plan with 35 MB storage",
+  current_state:
+    "The lowest available plan is 'Staging' at $15/month, offering 1 GB storage, 256 MB memory, and 100k documents.",
+  impact: "high",
+  source_url: "https://bonsai.io/pricing",
+};
+
+const A_METERED_RATE_OF_A_CENT = {
+  vendor: "Momento",
+  change_type: FREE_TIER_REMOVED,
+  date: "2026-09-04",
+  summary:
+    "Momento Cache Flex starts at $13 per GB-month. Pub/sub Topics are priced at $1 per 1M operations. Data transfer is $0.01 per GB for Valkey Router.",
+  previous_state: "5 GB per month free, then $0.15 per GB",
+  current_state: "Momento Cache Flex from $13 per GB-month. Valkey Router $0.01 per GB of data transfer.",
+  impact: "high",
+  source_url: "https://www.gomomento.com/pricing",
+};
+
+describe("a free tier a record still describes has not been removed", () => {
+  describe("the rule reads the record's own account of what is on offer", () => {
+    it("flags a removal whose current state names a plan it calls free", () => {
+      assert.strictEqual(
+        clauseStatingAPlanIsStillFree(FORMBRICKS),
+        "The free tier, 'Hobby', offers 250 responses per month and core survey features."
+      );
+    });
+
+    it("flags a removal whose summary says the free tier provides something now", () => {
+      assert.match(String(clauseStatingAPlanIsStillFree(MISTRAL)), /^The free tier now provides limited access/);
+    });
+
+    it("flags a removal that prices a plan at zero a month", () => {
+      assert.match(String(clauseStatingAPlanIsStillFree(HIGHLIGHT)), /\$0\/month forever/);
+    });
+
+    it("keeps a removal whose replacement is a trial of a stated length", () => {
+      assert.strictEqual(clauseStatingAPlanIsStillFree(A_TRIAL_REPLACED_THE_FREE_PLAN), null);
+    });
+
+    it("keeps a removal whose only free plan is the one it says is gone", () => {
+      assert.strictEqual(clauseStatingAPlanIsStillFree(THE_ONLY_FREE_PLAN_IS_THE_ONE_TAKEN_AWAY), null);
+    });
+
+    it("reads a rate of a cent per gigabyte as a price rather than as a plan costing nothing", () => {
+      assert.strictEqual(clauseStatingAPlanIsStillFree(A_METERED_RATE_OF_A_CENT), null);
+    });
+
+    it("requires a trial qualifier to sit beside the free claim, not merely in the same sentence", () => {
+      const retentionWindowIsNotATrial = {
+        ...HIGHLIGHT,
+        current_state:
+          "The Developer plan is $0/month forever and includes 5,000 session replays, with 14-day data retention.",
+      };
+      assert.ok(
+        clauseStatingAPlanIsStillFree(retentionWindowIsNotATrial),
+        "a retention window elsewhere in the sentence was read as the free plan being temporary"
+      );
+    });
+
+    it("reads no plan on offer in a record that states neither summary nor current state", () => {
+      assert.strictEqual(clauseStatingAPlanIsStillFree({ change_type: FREE_TIER_REMOVED }), null);
+    });
+  });
+
+  describe("the gate refuses such a record when it is written", () => {
+    it("refuses a removal that describes a free plan on offer now", () => {
+      const verdict = describesChange(FORMBRICKS);
+      assert.strictEqual(verdict.ok, false);
+      assert.strictEqual(verdict.reason, REJECT_FREE_PLAN_STILL_DESCRIBED);
+    });
+
+    it("names the clause it refused so the reading can be checked", () => {
+      assert.match(String(describesChange(MISTRAL).detail), /The free tier now provides limited access/);
+    });
+
+    it("admits a removal that states what stands where the free tier was", () => {
+      assert.notStrictEqual(
+        describesChange(THE_ONLY_FREE_PLAN_IS_THE_ONE_TAKEN_AWAY).reason,
+        REJECT_FREE_PLAN_STILL_DESCRIBED
+      );
+    });
+  });
+
+  describe("every free tier removal we have stored survives its own rule", () => {
+    const stored = JSON.parse(
+      readFileSync(path.join(__dirname, "..", "data", "deal_changes.json"), "utf-8")
+    ).changes as Array<Record<string, any>>;
+    const removals = stored.filter(c => c.change_type === FREE_TIER_REMOVED);
+
+    it("holds no removal still in force that describes a free plan on offer", () => {
+      const failing = removals
+        .filter(c => !c.resolution)
+        .map(c => ({ record: c, clause: clauseStatingAPlanIsStillFree(c) }))
+        .filter(({ clause }) => clause)
+        .map(({ record, clause }) => `${record.vendor} ${record.date}: ${clause}`);
+      assert.deepStrictEqual(failing, [], `stored removals describing a free plan:\n${failing.join("\n")}`);
+    });
+
+    it("still holds the removals the control set names", () => {
+      const kept = new Set(removals.filter(c => !c.resolution).map(c => c.vendor));
+      for (const vendor of ["Middleware.io", "Survicate", "ScraperAPI", "Burnermail"]) {
+        assert.ok(kept.has(vendor), `${vendor} keeps its free tier removal record`);
+      }
+    });
+
+    it("checks more than a handful of records", () => {
+      assert.ok(removals.length >= 80, `only ${removals.length} free tier removal records were checked`);
+    });
+  });
+});

--- a/test/free-tier-removal-evidence.test.ts
+++ b/test/free-tier-removal-evidence.test.ts
@@ -125,15 +125,26 @@ describe("a free tier a record still describes has not been removed", () => {
     });
 
     it("requires a trial qualifier to sit beside the free claim, not merely in the same sentence", () => {
-      const retentionWindowIsNotATrial = {
-        ...HIGHLIGHT,
+      const theTrialIsOnADifferentPlan = {
+        ...FORMBRICKS,
+        summary: "",
         current_state:
-          "The Developer plan is $0/month forever and includes 5,000 session replays, with 14-day data retention.",
+          "The Hobby plan is free and includes 1 Workspace and 250 responses per month, and the Pro tier can be evaluated with a 14-day free trial.",
       };
       assert.ok(
-        clauseStatingAPlanIsStillFree(retentionWindowIsNotATrial),
-        "a retention window elsewhere in the sentence was read as the free plan being temporary"
+        clauseStatingAPlanIsStillFree(theTrialIsOnADifferentPlan),
+        "a trial offered on another plan was read as the free plan itself being temporary"
       );
+    });
+
+    it("keeps a removal a vendor announced while still describing the plan going away", () => {
+      const announcedButNotYetGone = {
+        ...FORMBRICKS,
+        summary: "",
+        current_state:
+          "The free plan offers 500 MB of storage and is being removed for all workspaces on 1 October.",
+      };
+      assert.strictEqual(clauseStatingAPlanIsStillFree(announcedButNotYetGone), null);
     });
 
     it("reads no plan on offer in a record that states neither summary nor current state", () => {


### PR DESCRIPTION
Refs #1336.

A `free_tier_removed` record whose own summary or current state describes a free plan on offer now is refused when it is written, and fails CI if it is already stored. Three records that failed it are reclassified or retracted, so no vendor page still carries a `risky` badge for a removal that did not happen.

## The rule

`clauseStatingAPlanIsStillFree` splits `summary` and `current_state` into sentences, drops any that says the plan was taken away, and looks in the rest for a named plan asserted to be free right now — `<name> plan is free`, `the free plan/tier provides|offers|includes`, `$0/month`. A match is ignored when a trial qualifier sits within 40 characters of it, because a trial replacing a free plan is a real removal.

Two things the guards exist for, both covered by tests:

- **Proximity, not sentence membership.** A trial offered on a different plan in the same sentence must not suppress the free claim. Highlight.io's real record — `$0/month forever … with 14-day data retention` — was suppressed by an earlier draft that skipped any sentence containing a duration.
- **`$0` needs a period unit after it.** Momento's `Data transfer is $0.01 per GB` matched a bare `$0` and produced a false positive on a correct record.

The gate refuses on `free_plan_still_described` and names the offending sentence. CI holds the same rule over every stored removal that is still in force.

## Controls

All nine the issue names come out right, and across all 87 stored `free_tier_removed` records the rule flags exactly three — no false positives elsewhere in the corpus.

| fails | passes |
|---|---|
| Formbricks, Mistral AI, Highlight.io | Middleware.io, Survicate, ScraperAPI, Burnermail, Momento, bonsai.io |

Momento and bonsai.io still classify as `free_tier_removed`, so AC-4 holds.

## The three records

Each was checked against the vendor before it was touched.

- **Formbricks** → `limits_reduced`. `formbricks.com/pricing` still carries a free Hobby plan at 1 Workspace and 250 responses a month, and `formbricks.com/docs/self-hosting/overview` still offers self-hosting free.
- **Mistral AI** → `pricing_restructured`. `mistral.ai/pricing` answers "Does Mistral have a free plan? Yes." `limits_reduced` is not available: the gate refuses it as `unquantified_limit`, because the current state names no quantity for anything the stored state measured.
- **Microsoft Teams** → retracted. Teams (free) is live at `microsoft.com/en-us/microsoft-teams/free` with 1:1 calls up to 30 hours. The page the row was read from redirects to a comparison of the paid business plans.

Highlight.io was already retracted on 2026-09-03 and needs nothing.

## Verified

Rendered from a running server, with `BASE_URL` pointed at it — every non-API path 301s to production otherwise, and the first read of these pages was production's.

| page | before | after |
|---|---|---|
| `/vendor/formbricks` | risky — one recorded free tier removal | caution — one recorded limit reduction |
| `/vendor/mistral-ai` | risky — one recorded free tier removal | caution — one recorded pricing restructure |
| `/vendor/microsoft-teams` | risky — one recorded free tier removal | stable — the one change we have recorded did not narrow the terms |

3,679 tests, 15 new, 0 failing. 6 mutations against the rule, 6 killed — every guard in it is load-bearing.

AC-2 is not in this branch; the measurement that stops it is on the issue.
