### PR TITLE
Refuse a free tier removal for an offer whose free tier is the product (#1340)

### DIFF
--- a/data/index.json
+++ b/data/index.json
@@ -4747,7 +4747,8 @@
         "checked": "2026-08-28",
         "outcome": "ok",
         "detail": "text"
-      }
+      },
+      "free_tier_is_the_product": true
     },
     {
       "vendor": "Slack API",
@@ -32607,7 +32608,7 @@
       "category": "Communication & Messaging",
       "description": "Unlimited servers, channels, messages. Voice/video calls (up to 25 in DM groups). Screen sharing (720p/30fps). Go Live streaming (720p/30fps). 25 MB file upload limit. No HD streaming or animated avatars on free.",
       "tier": "Free",
-      "url": "https://discord.com/nitro",
+      "url": "https://discord.com/",
       "tags": [
         "messaging",
         "voice-chat",
@@ -32617,11 +32618,7 @@
         "free-tier"
       ],
       "verifiedDate": "2026-08-22",
-      "source_check": {
-        "checked": "2026-08-28",
-        "outcome": "ok",
-        "detail": "text"
-      }
+      "free_tier_is_the_product": true
     },
     {
       "vendor": "Zoom",
@@ -32647,7 +32644,7 @@
       "category": "Communication & Messaging",
       "description": "1-hour group meetings (up to 100 participants). Unlimited 1-on-1 calls (24-hour limit). Screen sharing. Real-time captions. Background effects. No recording or breakout rooms on free.",
       "tier": "Free",
-      "url": "https://apps.google.com/meet/pricing/",
+      "url": "https://workspace.google.com/products/meet/",
       "tags": [
         "video-conferencing",
         "meetings",
@@ -32655,30 +32652,21 @@
         "free-tier"
       ],
       "verifiedDate": "2026-08-21",
-      "source_check": {
-        "checked": "2026-08-28",
-        "outcome": "ok",
-        "detail": "url"
-      }
+      "free_tier_is_the_product": true
     },
     {
       "vendor": "Microsoft Teams",
       "category": "Communication & Messaging",
       "description": "Unlimited chat messages and search. Group meetings up to 60 minutes, up to 100 participants. 5 GB per user file storage. Screen sharing. No meeting recording or webinars on free.",
       "tier": "Free",
-      "url": "https://www.microsoft.com/en-us/microsoft-teams/compare-microsoft-teams-options",
+      "url": "https://www.microsoft.com/en-us/microsoft-teams/free",
       "tags": [
         "video-conferencing",
         "messaging",
         "consumer",
         "free-tier"
       ],
-      "verifiedDate": "2026-08-19",
-      "source_check": {
-        "checked": "2026-09-03",
-        "outcome": "ok",
-        "detail": "text"
-      }
+      "verifiedDate": "2026-08-19"
     },
     {
       "vendor": "Signal",
@@ -32699,7 +32687,8 @@
         "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names Signal but states no amount, tier or rate we can read"
-      }
+      },
+      "free_tier_is_the_product": true
     },
     {
       "vendor": "Telegram",
@@ -32718,7 +32707,8 @@
         "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names Telegram but states no amount, tier or rate we can read"
-      }
+      },
+      "free_tier_is_the_product": true
     },
     {
       "vendor": "WhatsApp",
@@ -32737,7 +32727,8 @@
         "checked": "2026-09-02",
         "outcome": "states_no_terms",
         "detail": "the page names WhatsApp but states no amount, tier or rate we can read"
-      }
+      },
+      "free_tier_is_the_product": true
     },
     {
       "vendor": "Photopea",
@@ -32950,7 +32941,7 @@
       "category": "Fitness & Health",
       "description": "Fully free health data aggregation on iOS. Steps, distance, flights climbed, sleep, heart rate, cycle tracking, medications, medical ID, health records. Data sharing with doctors. Third-party app integration hub.",
       "tier": "Free",
-      "url": "https://www.apple.com/ios/health/",
+      "url": "https://www.apple.com/health/",
       "tags": [
         "fitness",
         "health",
@@ -32959,11 +32950,7 @@
         "free"
       ],
       "verifiedDate": "2026-08-21",
-      "source_check": {
-        "checked": "2026-08-28",
-        "outcome": "ok",
-        "detail": "text"
-      }
+      "free_tier_is_the_product": true
     },
     {
       "vendor": "Proton VPN",

--- a/scripts/change-gate.js
+++ b/scripts/change-gate.js
@@ -14,6 +14,7 @@ export const REJECT_REMOVAL_READ_FROM_ROOT = "removal_read_from_root";
 export const REJECT_REMOVAL_READ_FROM_REDIRECT = "removal_read_from_redirect";
 export const REJECT_FREE_TIER_STILL_OFFERED = "free_tier_still_offered";
 export const REJECT_FREE_PLAN_STILL_DESCRIBED = "free_plan_still_described";
+export const REJECT_FREE_TIER_IS_THE_PRODUCT = "free_tier_is_the_product";
 export const REJECT_NO_BASELINE = "no_baseline";
 export const REJECT_DANGLING_REFERENCE = "dangling_reference";
 export const REJECT_MEASURES_NO_CHANGE = "measures_no_change";
@@ -34,6 +35,7 @@ export const GATE_REASONS = [
   REJECT_REMOVAL_READ_FROM_REDIRECT,
   REJECT_FREE_TIER_STILL_OFFERED,
   REJECT_FREE_PLAN_STILL_DESCRIBED,
+  REJECT_FREE_TIER_IS_THE_PRODUCT,
   REJECT_NO_BASELINE,
   REJECT_DANGLING_REFERENCE,
   REJECT_MEASURES_NO_CHANGE,
@@ -44,6 +46,16 @@ export const GATE_REASONS = [
 
 export const FREE_TIER_REMOVED = "free_tier_removed";
 export const RESTRICTION = "restriction";
+
+export const FREE_TIER_IS_THE_PRODUCT_FIELD = "free_tier_is_the_product";
+
+export function marksFreeTierAsTheProduct(offer) {
+  return offer?.[FREE_TIER_IS_THE_PRODUCT_FIELD] === true;
+}
+
+export function vendorsWhoseFreeTierIsTheProduct(offers = []) {
+  return new Set(offers.filter(marksFreeTierAsTheProduct).map((offer) => offer?.vendor));
+}
 
 const QUANTITY_CHANGE_TYPES = ["limits_reduced", "limits_increased"];
 
@@ -1073,6 +1085,7 @@ export async function gateCandidates(candidates, options = {}) {
   const pageTextFor = options.pageTextFor ?? (() => undefined);
   const pageCompleteFor = options.pageCompleteFor ?? (() => false);
   const finalUrlFor = options.finalUrlFor ?? (() => undefined);
+  const productIsTheFreeTier = vendorsWhoseFreeTierIsTheProduct(options.offers);
   const accepted = [];
   const rejected = [];
   const unchecked = [];
@@ -1085,6 +1098,7 @@ export async function gateCandidates(candidates, options = {}) {
       pageText: pageTextFor(original),
       pageComplete: pageCompleteFor(original),
       finalUrl: finalUrlFor(original),
+      freeTierIsTheProduct: productIsTheFreeTier.has(original?.vendor),
     });
     if (!verdict.ok) {
       rejected.push({ candidate: original, reason: verdict.reason, detail: verdict.detail });
@@ -1306,6 +1320,12 @@ export function auditRecord(record, context = {}) {
 
   if (record?.change_type === FREE_TIER_REMOVED) {
     const evidenced = statesARemoval(rewritten);
+    if (context.freeTierIsTheProduct === true) {
+      return refuse(
+        REJECT_FREE_TIER_IS_THE_PRODUCT,
+        `${record.vendor}'s free tier is the product itself, so the vendor publishes no plan with a free row anywhere — a page that names only the paid add-on states what it charges for, not that the product stopped being free`
+      );
+    }
     if (reportsSomethingStillFree(record?.summary)) {
       return refuse(
         REJECT_FREE_TIER_STILL_OFFERED,

--- a/scripts/gate-report.js
+++ b/scripts/gate-report.js
@@ -1,10 +1,23 @@
 #!/usr/bin/env node
 
+import { readFileSync } from "node:fs";
 import { resolve, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 import { readChangeLog, CHANGES_PATH, DETECTED_BY_AI } from "./change-log.js";
 import { gateCandidates, confirmDescribesChange } from "./change-gate.js";
 import { createVerifierClient, VERIFIER_MODEL, fetchPageText } from "./verify-freshness.js";
+
+const INDEX_PATH =
+  process.env.AGENTDEALS_INDEX_PATH ||
+  resolve(dirname(fileURLToPath(import.meta.url)), "..", "data", "index.json");
+
+export function readOffers(path = INDEX_PATH) {
+  try {
+    return JSON.parse(readFileSync(path, "utf-8")).offers ?? [];
+  } catch {
+    return [];
+  }
+}
 
 export async function readSourcePages(candidates, fetchFn = fetchPageText) {
   const pages = new Map();
@@ -77,6 +90,7 @@ async function main() {
   const pages = fetchPages ? await readSourcePages(candidates) : new Map();
   const result = await gateCandidates(candidates, {
     confirmFn,
+    offers: readOffers(),
     pageTextFor: (candidate) => pages.get(candidate),
   });
   for (const line of reportLines({ candidates, ...result })) console.log(line);

--- a/scripts/reverify-rolling.js
+++ b/scripts/reverify-rolling.js
@@ -288,6 +288,7 @@ export async function runAiMode(picked, data, dryRun, now, options = {}) {
 
   const { accepted, rejected, unchecked, reclassified, rewritten, overruled } = await gateCandidates(changes, {
     confirmFn,
+    offers: data.offers,
     pageTextFor: (candidate) => pageTexts.get(candidate),
     pageCompleteFor: (candidate) => wholePages.has(candidate),
     finalUrlFor: (candidate) => finalUrls.get(candidate),

--- a/src/types.ts
+++ b/src/types.ts
@@ -76,6 +76,7 @@ export interface Offer {
   product_role?: ProductRole;
   product_subtypes?: ProductSubtypes;
   source_check?: SourceCheck;
+  free_tier_is_the_product?: true;
 }
 
 export type SourceCheckOutcome =

--- a/test/free-tier-is-the-product.test.ts
+++ b/test/free-tier-is-the-product.test.ts
@@ -1,0 +1,232 @@
+import { describe, it } from "node:test";
+import assert from "node:assert";
+import { readFileSync, mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+process.env.AGENTDEALS_REFUSALS_PATH = path.join(
+  mkdtempSync(path.join(tmpdir(), "refusals-free-tier-is-the-product-")),
+  "change_refusals.json"
+);
+
+const {
+  describesChange,
+  gateCandidates,
+  marksFreeTierAsTheProduct,
+  vendorsWhoseFreeTierIsTheProduct,
+  FREE_TIER_IS_THE_PRODUCT_FIELD,
+  FREE_TIER_REMOVED,
+  GATE_REASONS,
+  REJECT_FREE_TIER_IS_THE_PRODUCT,
+} = await import("../scripts/change-gate.js");
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const dataFile = (name: string) =>
+  JSON.parse(readFileSync(path.join(__dirname, "..", "data", name), "utf-8"));
+
+const OFFERS = dataFile("index.json").offers as Array<Record<string, any>>;
+const STORED = dataFile("deal_changes.json").changes as Array<Record<string, any>>;
+
+const DISCORD = {
+  vendor: "Discord",
+  change_type: FREE_TIER_REMOVED,
+  date: "2026-09-04",
+  summary:
+    "Discord no longer offers a completely free tier with unlimited servers and messages. While core functionality remains accessible, features like custom emojis, larger file uploads (50MB for Nitro Basic, 500MB for Nitro), HD streaming, and more are now part of paid Nitro subscriptions ($2.99/month for Basic, $9.99/month for full Nitro).",
+  previous_state:
+    "Unlimited servers, channels, messages. Voice/video calls (up to 25 in DM groups). Screen sharing (720p/30fps). Go Live streaming (720p/30fps). 25 MB file upload limit. No HD streaming or animated avatars on free.",
+  current_state:
+    "Nitro Basic costs $2.99/month and includes 50MB uploads, custom emojis, and custom app icons. Nitro costs $9.99/month and includes 500MB uploads, HD streaming, and more.",
+  impact: "high",
+  source_url: "https://discord.com/nitro",
+};
+
+const GOOGLE_MEET = {
+  vendor: "Google Meet",
+  change_type: FREE_TIER_REMOVED,
+  date: "2026-09-04",
+  summary:
+    "Google Meet's own page now redirects to workspace.google.com. The free tier information is no longer directly presented. The lowest tier is 'Starter' at $5.60/user/month (with a discount) or $7.00/user/month. The page details features available in paid tiers, including video meetings with up to 1000 participants and recording capabilities.",
+  previous_state:
+    "1-hour group meetings (up to 100 participants). Unlimited 1-on-1 calls (24-hour limit). Screen sharing. Real-time captions. Background effects. No recording or breakout rooms on free.",
+  current_state:
+    "The lowest available plan is 'Starter' at $5.60/user/month (with a discount) or $7.00/user/month. Features like recording and more than 100 participants require paid plans.",
+  impact: "high",
+  source_url: "https://apps.google.com/meet/pricing/",
+};
+
+const MOMENTO = {
+  vendor: "Momento",
+  change_type: FREE_TIER_REMOVED,
+  date: "2026-09-04",
+  summary:
+    "Momento Cache Flex starts at $13 per GB-month. Pub/sub Topics are priced at $1 per 1M operations. Data transfer is $0.01 per GB for Valkey Router and $0.05/GiB for ingress/egress.",
+  previous_state:
+    "Serverless cache and pub/sub — 5 GB data transfer/month free, sub-millisecond latency, no infrastructure to manage",
+  current_state:
+    "Momento Cache Flex from $13 per GB-month. Pub / sub Topics from $1 per 1M operations. Valkey Router $0.01 per GB of data transfer. Data Transfer Ingress + Egress 200 GiB included per month $0.05 GiB",
+  impact: "high",
+  source_url: "https://www.gomomento.com/pricing",
+};
+
+const BONSAI = {
+  vendor: "bonsai.io",
+  change_type: FREE_TIER_REMOVED,
+  date: "2026-09-04",
+  summary:
+    "The free tier no longer exists. The lowest tier is now a 'Staging' plan at $15/month with 1 GB storage and 256 MB memory.",
+  previous_state:
+    "Free Sandbox plan: 125 MB memory, 125 MB storage, 35K documents. Free forever. Managed Elasticsearch.",
+  current_state:
+    "The lowest available plan is 'Staging' at $15/month, offering 1 GB storage, 256 MB memory, and 100k documents.",
+  impact: "high",
+  source_url: "https://bonsai.io/pricing",
+};
+
+const DISCORD_RAISED_ITS_UPLOAD_LIMIT = {
+  vendor: "Discord",
+  change_type: "limits_increased",
+  date: "2026-09-04",
+  summary: "The free upload limit is now 50 MB, up from 25 MB.",
+  previous_state: "25 MB file upload limit",
+  current_state: "50 MB file upload limit",
+  impact: "low",
+  source_url: "https://discord.com/",
+};
+
+const DISCORD_SHUT_A_PRODUCT_DOWN = {
+  vendor: "Discord",
+  change_type: "product_deprecated",
+  date: "2026-09-04",
+  summary: "Discord is retiring its Go Live streaming feature on 2026-12-01.",
+  previous_state: "Go Live streaming (720p/30fps)",
+  current_state: "Go Live streaming is retired on 2026-12-01.",
+  impact: "high",
+  source_url: "https://discord.com/",
+};
+
+const withoutMarkers = (offers: Array<Record<string, any>>) =>
+  offers.map(({ [FREE_TIER_IS_THE_PRODUCT_FIELD]: _marker, ...rest }) => rest);
+
+const gate = (candidates: Array<Record<string, any>>, offers = OFFERS) =>
+  gateCandidates(candidates, { offers });
+
+describe("a free tier that is the product cannot be evidenced by a plan page (#1340)", () => {
+  describe("the marker", () => {
+    it("is carried by the offer, so the vendors it covers are named in the catalogue", () => {
+      const marked = OFFERS.filter(marksFreeTierAsTheProduct).map(o => o.vendor);
+      for (const vendor of ["Discord", "Google Meet", "Signal", "Telegram", "WhatsApp"]) {
+        assert.ok(marked.includes(vendor), `${vendor} is marked as a free tier that is the product`);
+      }
+    });
+
+    it("holds one value, so an offer either carries the claim or does not make it", () => {
+      const other = OFFERS.filter(
+        o => FREE_TIER_IS_THE_PRODUCT_FIELD in o && o[FREE_TIER_IS_THE_PRODUCT_FIELD] !== true
+      ).map(o => `${o.vendor}: ${JSON.stringify(o[FREE_TIER_IS_THE_PRODUCT_FIELD])}`);
+      assert.deepStrictEqual(other, [], `offers carrying a value other than true:\n${other.join("\n")}`);
+    });
+
+    it("is not read from a vendor that does not carry it", () => {
+      assert.strictEqual(marksFreeTierAsTheProduct({ vendor: "Slack" }), false);
+      assert.strictEqual(marksFreeTierAsTheProduct(undefined), false);
+    });
+
+    it("resolves a candidate to the offer it was read from by the name the record carries", () => {
+      const vendors = vendorsWhoseFreeTierIsTheProduct(OFFERS);
+      assert.ok(vendors.has("Discord"));
+      assert.ok(!vendors.has("Slack"));
+      assert.strictEqual(vendorsWhoseFreeTierIsTheProduct().size, 0);
+    });
+  });
+
+  describe("the gate refuses a removal for a marked offer when it is written", () => {
+    it("refuses both records the 2026-09-04 batch holds for a marked vendor", async () => {
+      const { accepted, rejected } = await gate([DISCORD, GOOGLE_MEET]);
+      assert.deepStrictEqual(accepted, []);
+      assert.deepStrictEqual(
+        rejected.map(r => [r.candidate.vendor, r.reason]),
+        [
+          ["Discord", REJECT_FREE_TIER_IS_THE_PRODUCT],
+          ["Google Meet", REJECT_FREE_TIER_IS_THE_PRODUCT],
+        ]
+      );
+    });
+
+    it("records the same two when the offer makes no such claim, so the marker is what refused them", async () => {
+      const { accepted, rejected } = await gate([DISCORD, GOOGLE_MEET], withoutMarkers(OFFERS));
+      assert.deepStrictEqual(rejected, []);
+      assert.deepStrictEqual(accepted.map(c => c.vendor), ["Discord", "Google Meet"]);
+    });
+
+    it("states which product the page was about, so the refusal can be checked", async () => {
+      const { rejected } = await gate([DISCORD]);
+      assert.match(String(rejected[0].detail), /Discord's free tier is the product itself/);
+    });
+
+    it("keeps the removals of vendors that do publish a plan", async () => {
+      const { accepted, rejected } = await gate([MOMENTO, BONSAI]);
+      assert.deepStrictEqual(rejected, []);
+      assert.deepStrictEqual(accepted.map(c => c.vendor), ["Momento", "bonsai.io"]);
+    });
+
+    it("names its own reason among the reasons the gate reports", () => {
+      assert.ok(GATE_REASONS.includes(REJECT_FREE_TIER_IS_THE_PRODUCT));
+    });
+  });
+
+  describe("a marked offer is still re-verified for every other change type", () => {
+    it("records a limit that moved on a marked vendor", async () => {
+      const { accepted, rejected } = await gate([DISCORD_RAISED_ITS_UPLOAD_LIMIT]);
+      assert.deepStrictEqual(rejected, []);
+      assert.deepStrictEqual(accepted.map(c => c.change_type), ["limits_increased"]);
+    });
+
+    it("records a product the vendor is shutting down", async () => {
+      const { accepted, rejected } = await gate([DISCORD_SHUT_A_PRODUCT_DOWN]);
+      assert.deepStrictEqual(rejected, []);
+      assert.deepStrictEqual(accepted.map(c => c.change_type), ["product_deprecated"]);
+    });
+
+    it("exempts one conclusion rather than the vendor", () => {
+      const marked = { freeTierIsTheProduct: true };
+      for (const change_type of ["limits_reduced", "pricing_restructured", "restriction", "new_tier"]) {
+        const verdict = describesChange({ ...DISCORD, change_type }, marked);
+        assert.notStrictEqual(
+          verdict.reason,
+          REJECT_FREE_TIER_IS_THE_PRODUCT,
+          `${change_type} is not refused for being a product that is free`
+        );
+      }
+    });
+  });
+
+  describe("what the catalogue publishes about a marked offer", () => {
+    const marked = OFFERS.filter(marksFreeTierAsTheProduct);
+
+    it("sends the reader to a page about the free product, not the paid one beside it", () => {
+      const paidProductPath = /\/(nitro|premium|plus|pro|upgrade|subscribe|buy|business)(\/|$)/i;
+      const upsells = marked
+        .filter(o => paidProductPath.test(new URL(o.url).pathname))
+        .map(o => `${o.vendor}: ${o.url}`);
+      assert.deepStrictEqual(upsells, [], `marked offers linking to a paid product page:\n${upsells.join("\n")}`);
+    });
+
+    it("holds no removal still in force for a marked vendor", () => {
+      const vendors = vendorsWhoseFreeTierIsTheProduct(OFFERS);
+      const standing = STORED.filter(
+        c => c.change_type === FREE_TIER_REMOVED && !c.resolution && vendors.has(c.vendor)
+      ).map(c => `${c.vendor} ${c.date}: ${c.summary}`);
+      assert.deepStrictEqual(standing, [], `standing removals for a marked vendor:\n${standing.join("\n")}`);
+    });
+
+    it("covers vendors outside the one category the class was found in", () => {
+      const elsewhere = marked.filter(o => o.category !== "Communication & Messaging");
+      assert.ok(
+        elsewhere.length > 0,
+        "the marker is carried by at least one offer outside Communication & Messaging"
+      );
+    });
+  });
+});


### PR DESCRIPTION
Refs #1340.

Six vendors in Communication & Messaging publish no plan table with a free row, because their free tier is the product. Re-verification reads "does this page show a free tier?", gets no, and records a removal — on every pass. Discord and Google Meet sit in the 2026-09-04 quarantined batch and reach `main` on the next scheduled run.

## The field

`free_tier_is_the_product`, on an offer in `data/index.json`. The only accepted value is `true`; the field is absent otherwise. `src/types.ts` types it `?: true`, so `false` does not compile, and a test refuses any other value in the data.

It states a fact about the vendor, not a confidence level: the free tier is the product, so the vendor publishes no plan with a free row anywhere and no page can evidence the tier either way.

## The rule

`free_tier_removed` is refused for a marked offer under `free_tier_is_the_product`. Nothing else is exempt — the marker is read only inside the removal branch, so a marked vendor is still re-verified for every other change type.

The marker travels the same path at both ends: `gateCandidates` resolves it from the offers it is given, so the pipeline and a check over stored records run the same code.

## On the 2026-09-04 batch

Gating the 29 machine-detected candidates from the quarantined batch against this branch:

| | free_tier_removed reaching main |
|---|---|
| without the marker | Google Meet, Discord, Momento, bonsai.io |
| with it | Momento, bonsai.io |

The two correct removals still go in. Formbricks, Mistral AI and Windscribe stay refused by the rule from #1336.

Across all 85 stored removals the new rule refuses 0. Middleware.io, Survicate, ScraperAPI and Burnermail are untouched.

## Microsoft Teams is not in this class

The issue names it as a third negative control. Read with the pipeline's own fetcher, `microsoft.com/en-us/microsoft-teams/free` returns 6,462 characters and 14 price signals, says "get everything in the free version", and grades `ok` — four reads, stable. Teams publishes a real free plan on a page we can read, so marking it would suppress a genuine future removal.

What was wrong was the pointer: the offer cited the compare page, which redirects to a comparison of the paid business plans. It now cites `/microsoft-teams/free`, the page the 2026-09-03 retraction already named as its own source.

## Outbound links

Three marked or re-pointed offers linked readers to a paid product page from a page headed "<vendor> Free Tier 2026":

- Discord `discord.com/nitro` → `discord.com/`
- Google Meet `apps.google.com/meet/pricing/` → `workspace.google.com/products/meet/`
- Microsoft Teams the compare page → `microsoft.com/en-us/microsoft-teams/free`

A test refuses a marked offer whose URL path names a paid product line. All three verified on the rendered pages from a running server: each links to the free-product page and renders `stable`.

## Marked offers

Seven, two of them outside Communication & Messaging:

| vendor | category |
|---|---|
| Discord, Google Meet, Signal, Telegram, WhatsApp | Communication & Messaging |
| Discord API | Communication |
| Apple Health | Fitness & Health |

## Verification

3,694 tests, 15 new, base 3,679. 8 mutations, 8 killed — including a rule that never fires, a rule that always fires, a marker never read from the offer, a marker never passed by `gateCandidates`, a marker stored as something other than `true`, Discord pointed back at `/nitro`, and a rule widened to every directional claim.
