### PR TITLE
Record that Gemini 2.5 Pro is on the free tier (#1348)

### DIFF
--- a/data/index.json
+++ b/data/index.json
@@ -2922,7 +2922,7 @@
     {
       "vendor": "Google Gemini API",
       "category": "AI / ML",
-      "description": "Free tier is Flash-tier only: Gemini 2.5 Flash (10 RPM), Gemini 2.5 Flash-Lite (15 RPM), Gemini 3.0 Flash Preview, Gemini 3.1 Flash-Lite Preview, Gemini Embedding, and Gemma 4. 2.5 Pro and 3.1 Pro Preview are paid-only. Per-model paid pricing: Gemini 3.1 Pro Preview $2/$12 per MTok (≤200K ctx, doubles above), Gemini 3.0 Flash Preview $0.50/$3, Gemini 3.1 Flash-Lite Preview $0.25/$1.50, Gemini 2.5 Pro $1.25/$10 (≤200K, doubles above), Gemini 2.5 Flash $0.30/$2.50. Gemini 2.0 Flash and 2.0 Flash-Lite deprecated June 1, 2026 — migrate to 2.5 Flash or 3.x Flash. All models support Batch/Flex at 50% discount. Mandatory spend caps enforced since April 1, 2026.",
+      "description": "Free tier covers Gemini 2.5 Pro plus the Flash-tier models: Gemini 2.5 Flash (10 RPM), Gemini 2.5 Flash-Lite (15 RPM), Gemini 3.0 Flash Preview, Gemini 3.1 Flash-Lite Preview, Gemini Embedding, and Gemma 4. 3.1 Pro Preview is paid-only. Per-model paid pricing: Gemini 3.1 Pro Preview $2/$12 per MTok (≤200K ctx, doubles above), Gemini 3.0 Flash Preview $0.50/$3, Gemini 3.1 Flash-Lite Preview $0.25/$1.50, Gemini 2.5 Pro $1.25/$10 (≤200K, doubles above), Gemini 2.5 Flash $0.30/$2.50. Gemini 2.0 Flash and 2.0 Flash-Lite deprecated June 1, 2026 — migrate to 2.5 Flash or 3.x Flash. All models support Batch/Flex at 50% discount. Mandatory spend caps enforced since April 1, 2026.",
       "tier": "Free (Reduced)",
       "url": "https://ai.google.dev/pricing",
       "tags": [


### PR DESCRIPTION
Data-only. One sentence in one record.

`data/index.json`, vendor `Google Gemini API`, said:

> Free tier is Flash-tier only: … **2.5 Pro and 3.1 Pro Preview are paid-only.**

Google's pricing page gives **Gemini 2.5 Pro** a Free Tier of "Free of charge" for input and output, and "Yes" under "Used to improve our products" — the rows a paid-only model does not have. **Gemini 3.1 Pro Preview** reads "Not available" in the same column, which is what paid-only looks like there.

Read 2026-09-05 at `https://ai.google.dev/gemini-api/docs/pricing`.

Now reads:

> Free tier covers Gemini 2.5 Pro plus the Flash-tier models: … **3.1 Pro Preview is paid-only.**

Quality budgets unchanged before and after: `stale_fact_pages` 57, `unsourced_tier_a` 43, nothing lowered, nothing over.

The same error is published on seven rendered surfaces in `src/serve.ts`. That half is https://github.com/robhunter/agentdeals/issues/1348 and is not touched here.
