### PR TITLE
Withdraw the Clarifai and xAI removals, cite the Logz.io and SwaggerHub ones (#1352)

### DIFF
--- a/data/deal_changes.json
+++ b/data/deal_changes.json
@@ -3486,7 +3486,12 @@
       "category": "AI / ML",
       "alternatives": [],
       "recorded_date": "2026-04-13",
-      "date_source": "hand_written"
+      "date_source": "hand_written",
+      "resolution": {
+        "state": "reversed",
+        "date": "2026-09-05",
+        "detail": "No longer in force as of 2026-09-05. This record cites nothing and xAI does not publish its sign-up credit terms on a page we can read, so it cannot be retracted on evidence; it is withdrawn because the claim it makes is contradicted by our own later record. Our xAI offer, verified 2026-08-14 and re-checked 2026-09-02, reads \"Sign-up gives $25 in free API credits\". Recorded separately: the URL that offer cites, docs.x.ai/developers/models, contains no occurrence of \"free\", \"credit\" or \"$25\" in its 5,452 characters of visible text, so that claim is also uncited and needs a source of its own."
+      }
     },
     {
       "vendor": "Clarifai",
@@ -3500,7 +3505,13 @@
       "category": "AI / ML",
       "alternatives": [],
       "recorded_date": "2026-04-13",
-      "date_source": "hand_written"
+      "date_source": "hand_written",
+      "resolution": {
+        "state": "retracted",
+        "date": "2026-09-05",
+        "detail": "Retracted 2026-09-05: Clarifai's Community plan was not replaced by a trial. The Internet Archive's 2026-03-04 capture of clarifai.com/pricing, five weeks before this record, and its 2026-04-17 capture, four days after it, both carry the same Compare Plans ladder: \"Community | Get Community | Essential | Get Essential | Professional | Get Professional | Hybrid AI Enterprise | Contact Us | Private AI Enterprise | Contact Us\", with \"Monthly requests: Limited\" and \"Requests per second: 1\" in the Community column. Community is an orderable plan on both sides of this record's date. The 14-day trial named here is the hero banner above that table - \"Benchmark your models on the world's fastest inference engine with a free 14-day trial\" - which offers a trial of the Reasoning Engine, not a replacement for the plan ladder. Our own offer record, verified 2026-07-15, reads \"Community tier: 1,000 API calls/month\".",
+        "source_url": "https://web.archive.org/web/20260304155253/https://www.clarifai.com/pricing"
+      }
     },
     {
       "vendor": "Typeform",
@@ -3538,7 +3549,7 @@
       "previous_state": "",
       "current_state": "Free community plan replaced by trial only",
       "impact": "low",
-      "source_url": "",
+      "source_url": "https://swagger.io/product/pricing/",
       "category": "API Development",
       "alternatives": [],
       "recorded_date": "2026-04-13",
@@ -3930,7 +3941,7 @@
       "previous_state": "",
       "current_state": "No free tier, pay-as-you-go only ($0.92/GB/day)",
       "impact": "low",
-      "source_url": "",
+      "source_url": "https://logz.io/pricing/",
       "category": "Logging",
       "alternatives": [],
       "recorded_date": "2026-04-13",


### PR DESCRIPTION
Four of the 97 uncited change records from 2026-04-12/13, triaged against the vendors' own pages. Data only, one file. Ratchet unchanged: `stale_fact_pages` 57, `unsourced_tier_a` 43 before and after.

Two of the four records are right and two are wrong, so this is not a batch retraction.

## Clarifai — retracted

The record says "Free tier replaced by 14-day trial for Reasoning Engine". Two Wayback captures bracket its date and disagree with it:

- [2026-03-04](https://web.archive.org/web/20260304155253/https://www.clarifai.com/pricing), five weeks before
- [2026-04-17](https://web.archive.org/web/20260417032811/https://www.clarifai.com/pricing), four days after

Both carry the same Compare Plans ladder — "Community | Get Community | Essential | Get Essential | Professional | Get Professional | Hybrid AI Enterprise | Contact Us | Private AI Enterprise | Contact Us" — with "Monthly requests: Limited" and "Requests per second: 1" in the Community column. Community was an orderable plan on both sides of the record's date.

The trial the record names is the hero banner above that table: "Benchmark your models on the world's fastest inference engine with a free 14-day trial." That is a trial of the Reasoning Engine offered on top of the plan ladder.

This is the third record in a week written by reading a hero banner instead of the plan table beneath it, after Storyblok (#1352) and the Gemini page (#1348).

## xAI — reversed, not retracted

Uncitable in both directions. The record cites nothing. The offer that contradicts it — verified 2026-08-14, re-checked 2026-09-02 — cites `docs.x.ai/developers/models`, and that page contains no occurrence of "free", "credit" or "$25" in its 5,452 characters of visible text. `x.ai/api` and `console.x.ai` return 749 characters to every client I have. `docs.x.ai/docs/overview` says "Purchase credits".

So the demotion is withdrawn as `reversed` — our own later record contradicts it and the demoting record has no evidence at all — but I cannot retract it, because I cannot show the credits exist from a page xAI publishes. The offer's citation gap is recorded in the resolution detail and belongs to the issue below.

## Logz.io and SwaggerHub — correct, now cited

`logz.io/pricing` lists Pro and Enterprise only, with "Completely free for 14 days, no strings attached". The record's "no free tier, pay-as-you-go only" is right; it just had nowhere to be re-read from. `source_url` added.

`swagger.io/tools/swaggerhub/pricing/` 301s to `swagger.io/product/pricing/`, which renders Individual $19, Team $29 and Enterprise $49 per user per month, with "Try Free" as a trial CTA on each. No free plan, no Community plan, and the word "SwaggerHub" appears zero times in 11,445 rendered characters. The record is right.

Our own SwaggerHub **offer** still reads `tier: "Free"`, "free tier: 1 designer seat", verified 2026-07-30 with `source_check.outcome: "ok"`. That is a live false free-tier claim and it is filed separately, not fixed here.
