### PR TITLE
Retire the BackgroundStyler.com offer — the domain now serves a slot casino (#1355)

### DIFF
--- a/data/index.json
+++ b/data/index.json
@@ -26675,8 +26675,8 @@
     {
       "vendor": "BackgroundStyler.com",
       "category": "Dev Utilities",
-      "description": "Create aesthetic screenshots of your code, text or images to share on social media.",
-      "tier": "Free",
+      "description": "There is no free tier: backgroundstyler.com no longer serves the product. Checked 2026-09-05, the domain returns HTTP 200 with no redirect and its title is \"Langit77 : Pusat Situs Resmi Online Slot Pasti Menang\" - an Indonesian online slot-gambling site, which names \"Langit77\" 43 times and never names BackgroundStyler. The expired domain has been taken over by an unrelated party. The former offer was aesthetic screenshots of code, text or images for sharing on social media.",
+      "tier": "Retired",
       "url": "https://backgroundstyler.com",
       "tags": [
         "developer-tools",


### PR DESCRIPTION
`backgroundstyler.com` returns HTTP 200 **from its own domain with no redirect**. Its `<title>` is "Langit77 : Pusat Situs Resmi Online Slot Pasti Menang". "Langit77" appears 43 times in the body, "slot" 16, "gacor" 3; "BackgroundStyler" appears zero times.

We published it as `tier: "Free"` in Dev Utilities with `source_check.outcome: "ok"` recorded 2026-09-03, and https://agentdeals.dev/vendor/backgroundstyler-com — titled "BackgroundStyler.com Free Tier 2026: Limits, Pricing & What Changed" — carries two outbound links to it. It is also linked from `/category/dev-utilities`.

Retired using the same record shape as Supportivekoala and Oaysus, which document the same takeover. Data only, one file, ratchet unchanged (`stale_fact_pages` 57, `unsourced_tier_a` 43).

This removes the live link. It does not fix the check that passed it — that is https://github.com/robhunter/agentdeals/issues/1355, where BackgroundStyler is one of 34 offers graded `ok` with no evidence read.