### PR TITLE
Read the page, not the URL, before passing a source check (#1355)

### DIFF
--- a/data/index.json
+++ b/data/index.json
@@ -1279,9 +1279,9 @@
         "notes": "Channel partner program for resellers. No individual referral program."
       },
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-05",
         "outcome": "ok",
-        "detail": "url"
+        "detail": "the page names GitLab CI as \"gitlab ci\" and states \"$ 0\""
       }
     },
     {
@@ -2937,9 +2937,9 @@
       ],
       "verifiedDate": "2026-08-18",
       "source_check": {
-        "checked": "2026-09-03",
+        "checked": "2026-09-05",
         "outcome": "ok",
-        "detail": "url"
+        "detail": "the page writes \"google\", the domain we cite Google Gemini API from, and states \"$0.75\""
       },
       "product_subtypes": {
         "taxonomy": "AI / ML",
@@ -3620,9 +3620,9 @@
       },
       "expires_date": "2026-08-31",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-05",
         "outcome": "ok",
-        "detail": "url"
+        "detail": "the page names SVB (Silicon Valley Bank) as \"silicon\" and states \"$1\""
       }
     },
     {
@@ -4765,9 +4765,9 @@
       ],
       "verifiedDate": "2026-08-26",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-05",
         "outcome": "ok",
-        "detail": "url"
+        "detail": "the page writes \"slack\", the domain we cite Slack API from, and states \"$0\""
       }
     },
     {
@@ -6179,9 +6179,9 @@
       ],
       "verifiedDate": "2026-07-29",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-05",
         "outcome": "ok",
-        "detail": "url"
+        "detail": "the page writes \"amazon\", the domain we cite Amazon ECR Public from, and states \"$200\""
       }
     },
     {
@@ -8454,9 +8454,9 @@
       ],
       "verifiedDate": "2026-07-31",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-05",
         "outcome": "ok",
-        "detail": "url"
+        "detail": "the page names Comet ML as \"comet ml\" and states \"$0\""
       },
       "product_subtypes": {
         "taxonomy": "AI / ML",
@@ -8606,9 +8606,9 @@
       ],
       "verifiedDate": "2026-07-30",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-05",
         "outcome": "ok",
-        "detail": "url"
+        "detail": "the page writes \"swagger\", the domain we cite SwaggerHub from, and states \"2600 EUR\""
       }
     },
     {
@@ -9195,9 +9195,9 @@
       ],
       "verifiedDate": "2026-07-08",
       "source_check": {
-        "checked": "2026-08-28",
-        "outcome": "ok",
-        "detail": "url"
+        "checked": "2026-09-05",
+        "outcome": "does_not_name_vendor",
+        "detail": "the page never names Codefresh, on a domain that carries its name"
       }
     },
     {
@@ -11689,9 +11689,9 @@
       ],
       "verifiedDate": "2026-07-14",
       "source_check": {
-        "checked": "2026-08-28",
-        "outcome": "ok",
-        "detail": "url"
+        "checked": "2026-09-05",
+        "outcome": "does_not_name_vendor",
+        "detail": "the page never names Supportivekoala, on a domain that carries its name"
       }
     },
     {
@@ -11715,9 +11715,9 @@
         }
       ],
       "source_check": {
-        "checked": "2026-09-02",
+        "checked": "2026-09-05",
         "outcome": "ok",
-        "detail": "url"
+        "detail": "the page writes \"tavily\", the domain we cite Tavily AI from, and states \"$0.008\""
       },
       "product_subtypes": {
         "taxonomy": "AI / ML",
@@ -12774,9 +12774,9 @@
       ],
       "verifiedDate": "2026-07-08",
       "source_check": {
-        "checked": "2026-08-28",
-        "outcome": "ok",
-        "detail": "url"
+        "checked": "2026-09-05",
+        "outcome": "does_not_name_vendor",
+        "detail": "the page never names StreamBackdrops, on a domain that carries its name"
       }
     },
     {
@@ -14704,9 +14704,9 @@
       ],
       "verifiedDate": "2026-08-27",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-05",
         "outcome": "ok",
-        "detail": "url"
+        "detail": "the page writes \"letsencrypt\", the domain we cite letsencrypt.org from, and states \"2025 Annual R\""
       }
     },
     {
@@ -15292,9 +15292,9 @@
       ],
       "verifiedDate": "2026-08-26",
       "source_check": {
-        "checked": "2026-08-28",
-        "outcome": "ok",
-        "detail": "url"
+        "checked": "2026-09-05",
+        "outcome": "does_not_name_vendor",
+        "detail": "the page never names GetUpdraft, on a domain that carries its name"
       }
     },
     {
@@ -15791,9 +15791,9 @@
       ],
       "verifiedDate": "2026-08-25",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-05",
         "outcome": "ok",
-        "detail": "url"
+        "detail": "the page writes \"betterstack\", the domain we cite Better Stack Logs from, and states \"$0\""
       }
     },
     {
@@ -19234,9 +19234,9 @@
       ],
       "verifiedDate": "2026-08-31",
       "source_check": {
-        "checked": "2026-09-01",
-        "outcome": "ok",
-        "detail": "url"
+        "checked": "2026-09-05",
+        "outcome": "does_not_name_vendor",
+        "detail": "the page never names weserv, on a domain that carries its name"
       }
     },
     {
@@ -20342,9 +20342,9 @@
       ],
       "verifiedDate": "2026-07-16",
       "source_check": {
-        "checked": "2026-08-28",
-        "outcome": "ok",
-        "detail": "url"
+        "checked": "2026-09-05",
+        "outcome": "does_not_name_vendor",
+        "detail": "the page never names Oaysus, on a domain that carries its name"
       }
     },
     {
@@ -20810,9 +20810,9 @@
       ],
       "verifiedDate": "2026-09-01",
       "source_check": {
-        "checked": "2026-09-01",
+        "checked": "2026-09-05",
         "outcome": "ok",
-        "detail": "url"
+        "detail": "the page names noip as \"noip\" and states \"$24.95\""
       }
     },
     {
@@ -22685,9 +22685,9 @@
         }
       ],
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-05",
         "outcome": "ok",
-        "detail": "url"
+        "detail": "the page writes \"pinata\", the domain we cite Pinata IPFS from, and states \"1 Gateway Total 10G Bandwidth Per month\""
       }
     },
     {
@@ -26684,9 +26684,9 @@
       ],
       "verifiedDate": "2026-07-21",
       "source_check": {
-        "checked": "2026-09-03",
-        "outcome": "ok",
-        "detail": "url",
+        "checked": "2026-09-05",
+        "outcome": "does_not_name_vendor",
+        "detail": "the page never names BackgroundStyler.com, on a domain that carries its name",
         "unrendered_prices": [
           "IDR 1399000"
         ]
@@ -30611,9 +30611,9 @@
       ],
       "verifiedDate": "2026-08-17",
       "source_check": {
-        "checked": "2026-09-03",
+        "checked": "2026-09-05",
         "outcome": "ok",
-        "detail": "url"
+        "detail": "the page writes \"gcore\", the domain we cite Gcore DNS from, and states \"€0\""
       }
     },
     {
@@ -30761,9 +30761,9 @@
         }
       ],
       "source_check": {
-        "checked": "2026-09-02",
-        "outcome": "ok",
-        "detail": "url"
+        "checked": "2026-09-05",
+        "outcome": "does_not_name_vendor",
+        "detail": "the page never names xAI, on a domain that carries its name"
       },
       "product_subtypes": {
         "taxonomy": "AI / ML",
@@ -30812,9 +30812,9 @@
       ],
       "verifiedDate": "2026-08-26",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-05",
         "outcome": "ok",
-        "detail": "url"
+        "detail": "the page writes \"bolt\", the domain we cite Bolt.new from, and states \"$100\""
       }
     },
     {
@@ -31066,9 +31066,9 @@
         "notes": "No public affiliate/referral program."
       },
       "source_check": {
-        "checked": "2026-08-30",
+        "checked": "2026-09-05",
         "outcome": "ok",
-        "detail": "url"
+        "detail": "the page writes \"openai\", the domain we cite OpenAI Codex from, and states \"$0\""
       }
     },
     {
@@ -31195,9 +31195,9 @@
       ],
       "verifiedDate": "2026-08-18",
       "source_check": {
-        "checked": "2026-09-03",
+        "checked": "2026-09-05",
         "outcome": "ok",
-        "detail": "url"
+        "detail": "the page writes \"google\", the domain we cite Google Cloud Run from, and states \"$0.000018\""
       },
       "product_subtypes": {
         "taxonomy": "Cloud Hosting",
@@ -31268,9 +31268,9 @@
       ],
       "verifiedDate": "2026-08-17",
       "source_check": {
-        "checked": "2026-09-03",
+        "checked": "2026-09-05",
         "outcome": "ok",
-        "detail": "url"
+        "detail": "the page writes \"google\", the domain we cite Google Cloud Pub/Sub from, and states \"$169\""
       }
     },
     {
@@ -31288,9 +31288,9 @@
       ],
       "verifiedDate": "2026-09-02",
       "source_check": {
-        "checked": "2026-09-03",
+        "checked": "2026-09-05",
         "outcome": "ok",
-        "detail": "url"
+        "detail": "the page writes \"google\", the domain we cite Google Cloud Build from, and states \"$0.006\""
       }
     },
     {
@@ -31516,9 +31516,9 @@
       ],
       "verifiedDate": "2026-08-19",
       "source_check": {
-        "checked": "2026-09-03",
+        "checked": "2026-09-05",
         "outcome": "ok",
-        "detail": "url"
+        "detail": "the page writes \"ollama\", the domain we cite Ollama Cloud from, and states \"$0\""
       },
       "product_subtypes": {
         "taxonomy": "AI / ML",
@@ -31549,9 +31549,9 @@
       ],
       "verifiedDate": "2026-08-27",
       "source_check": {
-        "checked": "2026-09-02",
-        "outcome": "ok",
-        "detail": "url"
+        "checked": "2026-09-05",
+        "outcome": "does_not_name_vendor",
+        "detail": "the page never names Google Gemini Code Assist and is not served from its domain"
       }
     },
     {
@@ -32142,9 +32142,9 @@
       ],
       "verifiedDate": "2026-08-16",
       "source_check": {
-        "checked": "2026-09-03",
+        "checked": "2026-09-05",
         "outcome": "ok",
-        "detail": "url"
+        "detail": "the page writes \"apple\", the domain we cite Apple Notes from, and states \"$0.99\""
       }
     },
     {
@@ -32300,9 +32300,9 @@
       ],
       "verifiedDate": "2026-08-23",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-05",
         "outcome": "ok",
-        "detail": "url"
+        "detail": "the page writes \"google\", the domain we cite Google Drive from, and states \"$1.99\""
       }
     },
     {
@@ -32319,9 +32319,9 @@
       ],
       "verifiedDate": "2026-08-22",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-05",
         "outcome": "ok",
-        "detail": "text"
+        "detail": "the page names Google Photos as \"google photos\" and states \"$1.99\""
       }
     },
     {
@@ -32338,9 +32338,9 @@
       ],
       "verifiedDate": "2026-08-19",
       "source_check": {
-        "checked": "2026-09-03",
+        "checked": "2026-09-05",
         "outcome": "ok",
-        "detail": "text"
+        "detail": "the page names iCloud as \"icloud\" and states \"$0.99\""
       }
     },
     {
@@ -32598,9 +32598,9 @@
       ],
       "verifiedDate": "2026-08-18",
       "source_check": {
-        "checked": "2026-09-03",
+        "checked": "2026-09-05",
         "outcome": "ok",
-        "detail": "text"
+        "detail": "the page names Slack as \"slack\" and states \"$0\""
       }
     },
     {
@@ -33327,9 +33327,9 @@
       ],
       "verifiedDate": "2026-08-23",
       "source_check": {
-        "checked": "2026-08-28",
+        "checked": "2026-09-05",
         "outcome": "ok",
-        "detail": "host"
+        "detail": "the page writes \"tuta\", the domain we cite Tutanota from, and states \"€3\""
       }
     },
     {
@@ -33444,9 +33444,9 @@
       ],
       "verifiedDate": "2026-08-23",
       "source_check": {
-        "checked": "2026-09-02",
-        "outcome": "ok",
-        "detail": "url"
+        "checked": "2026-09-05",
+        "outcome": "does_not_name_vendor",
+        "detail": "the page never names Mint (Credit Karma) and is not served from its domain"
       }
     },
     {
@@ -33525,9 +33525,9 @@
       ],
       "verifiedDate": "2026-08-18",
       "source_check": {
-        "checked": "2026-09-03",
+        "checked": "2026-09-05",
         "outcome": "ok",
-        "detail": "url"
+        "detail": "the page writes \"kiro\", the domain we cite Amazon Kiro from, and states \"$20\""
       }
     },
     {
@@ -33815,9 +33815,9 @@
       ],
       "verifiedDate": "2026-08-15",
       "source_check": {
-        "checked": "2026-09-02",
-        "outcome": "ok",
-        "detail": "url"
+        "checked": "2026-09-05",
+        "outcome": "states_no_terms",
+        "detail": "the page names Google Vector Search 2.0 but states no amount, tier or rate we can read, and the 2 structured-data blocks in its markup state no price"
       },
       "product_subtypes": {
         "taxonomy": "AI / ML",
@@ -33847,9 +33847,9 @@
       ],
       "verifiedDate": "2026-08-19",
       "source_check": {
-        "checked": "2026-09-02",
+        "checked": "2026-09-05",
         "outcome": "ok",
-        "detail": "url"
+        "detail": "the page writes \"google\", the domain we cite Google GLM 5 from, and states \"10 frames per second\""
       },
       "product_subtypes": {
         "taxonomy": "AI / ML",

--- a/data/quality_budgets.json
+++ b/data/quality_budgets.json
@@ -3,7 +3,7 @@
   "budgets": {
     "stale_fact_pages": 57,
     "unsourced_tier_a": 43,
-    "uncited_change_records": 97,
+    "uncited_change_records": 95,
     "source_checks_ok_without_quoted_evidence": 666,
     "faq_answers": 166,
     "faq_answers_stating_a_figure": 77,

--- a/data/quality_budgets.json
+++ b/data/quality_budgets.json
@@ -4,6 +4,7 @@
     "stale_fact_pages": 57,
     "unsourced_tier_a": 43,
     "uncited_change_records": 97,
+    "source_checks_ok_without_quoted_evidence": 666,
     "faq_answers": 166,
     "faq_answers_stating_a_figure": 77,
     "faq_answers_with_a_digit_but_no_figure": 40

--- a/scripts/ratchet-quality-budgets.js
+++ b/scripts/ratchet-quality-budgets.js
@@ -7,6 +7,7 @@ import {
 } from "../dist/page-reviews.js";
 import { toSlug } from "../dist/vendor-slug.js";
 import { uncitedChanges } from "../dist/change-citation.js";
+import { passedWithoutQuotingThePage } from "../dist/source-check.js";
 
 const REPO = join(dirname(fileURLToPath(import.meta.url)), "..");
 
@@ -54,10 +55,12 @@ export function measureBudgets(date) {
   const changes = JSON.parse(readFileSync(join(REPO, "data", "deal_changes.json"), "utf-8")).changes;
   const newest = newestChangeBySlug(changes, date, toSlug);
   const stale = staleFactPages(index.pages, date, slug => newest.get(slug) ?? null);
+  const offers = JSON.parse(readFileSync(join(REPO, "data", "index.json"), "utf-8")).offers ?? [];
   return {
     stale_fact_pages: stale.length,
     unsourced_tier_a: unsourcedTierAPaths(index.pages).length,
     uncited_change_records: uncitedChanges(changes).length,
+    source_checks_ok_without_quoted_evidence: offers.filter(passedWithoutQuotingThePage).length,
   };
 }
 

--- a/scripts/source-naming-audit.js
+++ b/scripts/source-naming-audit.js
@@ -57,7 +57,9 @@ async function main() {
       page = JSON.parse(readFileSync(cachePath(url), "utf-8"));
     } else {
       const fetched = await fetchPageText(url);
-      page = fetched.ok ? { ok: true, text: fetched.text } : { ok: false, error: fetched.error };
+      page = fetched.ok
+        ? { ok: true, text: fetched.text, structured: fetched.structured ?? null }
+        : { ok: false, error: fetched.error };
       if (cacheDir) writeFileSync(cachePath(url), JSON.stringify(page));
     }
     done++;

--- a/scripts/vendor-naming.js
+++ b/scripts/vendor-naming.js
@@ -91,19 +91,6 @@ export function vendorNameForms(vendor, extra = []) {
   return [...forms];
 }
 
-export function vendorUrlForms(vendor, extra = []) {
-  const forms = new Set(vendorNameForms(vendor, extra));
-  for (const raw of names(vendor, extra)) {
-    const words = normalizeForMatch(raw).trim().split(" ").filter(Boolean);
-    if (words.length < 2) continue;
-    for (const word of words) {
-      if (NAME_QUALIFIERS.has(word)) continue;
-      if (word.length >= MIN_FORM_LENGTH) forms.add(word);
-    }
-  }
-  return [...forms];
-}
-
 function shortNameForms(vendor, extra = []) {
   const forms = new Set();
   for (const raw of names(vendor, extra)) {
@@ -125,16 +112,24 @@ export function hostLabels(url) {
   }
 }
 
-export function urlText(url) {
-  try {
-    const parsed = new URL(url);
-    return `${parsed.hostname} ${parsed.pathname}`;
-  } catch {
-    return "";
+const MIN_HOST_PREFIX = 4;
+
+export const NAMED_IN_PAGE_TEXT = "text";
+export const NAMED_BY_A_HOST_THE_PAGE_WRITES = "host_in_text";
+
+function hostLabelMatchesVendor(label, vendor, aliases) {
+  for (const form of shortNameForms(vendor, aliases)) {
+    if (label === form) return true;
+    if (label.length >= MIN_HOST_PREFIX && form.startsWith(label)) return true;
   }
+  return false;
 }
 
-const MIN_HOST_PREFIX = 4;
+export function servedFromTheVendorsDomain(offer, aliases = []) {
+  return hostLabels(offer?.url ?? "")
+    .slice(0, -1)
+    .some((label) => hostLabelMatchesVendor(label, offer?.vendor ?? "", aliases));
+}
 
 export function pageNamesVendor(pageText, vendor, options = {}) {
   const aliases = options.aliases ?? [];
@@ -144,22 +139,14 @@ export function pageNamesVendor(pageText, vendor, options = {}) {
 
   const haystack = normalizeForMatch(pageText);
   for (const form of forms) {
-    if (haystack.includes(` ${form} `)) return result(true, "text", form);
+    if (haystack.includes(` ${form} `)) return result(true, NAMED_IN_PAGE_TEXT, form);
   }
 
-  const url = options.url ?? "";
-  const flatUrl = normalizeForMatch(urlText(url)).replace(/ /g, "");
-  for (const form of vendorUrlForms(vendor, aliases)) {
-    const flat = form.replace(/ /g, "");
-    if (flat.length >= MIN_FORM_LENGTH && flatUrl.includes(flat)) return result(true, "url", form);
-  }
-
-  const labels = hostLabels(url).slice(0, -1);
-  const short = shortNameForms(vendor, aliases);
-  for (const label of labels) {
-    for (const form of short) {
-      if (label === form) return result(true, "host", form);
-      if (label.length >= MIN_HOST_PREFIX && form.startsWith(label)) return result(true, "host", form);
+  const written = haystack.replace(/ /g, "");
+  for (const label of hostLabels(options.url ?? "").slice(0, -1).reverse()) {
+    if (label.length < MIN_FORM_LENGTH || !written.includes(label)) continue;
+    if (hostLabelMatchesVendor(label, vendor, aliases)) {
+      return result(true, NAMED_BY_A_HOST_THE_PAGE_WRITES, label);
     }
   }
 
@@ -173,6 +160,12 @@ function markupClause(structured) {
   return detail ? `, and ${detail}` : "";
 }
 
+function namedClause(vendor, naming) {
+  return naming.via === NAMED_BY_A_HOST_THE_PAGE_WRITES
+    ? `the page writes "${naming.form}", the domain we cite ${vendor} from,`
+    : `the page names ${vendor} as "${naming.form}"`;
+}
+
 export function classifySource(offer, page, signals) {
   if (!page || !page.ok) {
     return { outcome: SOURCE_CHECK_UNREADABLE, detail: page?.error ?? "not fetched" };
@@ -181,7 +174,9 @@ export function classifySource(offer, page, signals) {
   if (!naming.named) {
     return {
       outcome: SOURCE_CHECK_NOT_NAMED,
-      detail: `the page never names ${offer.vendor} and is not served from its domain`,
+      detail: servedFromTheVendorsDomain(offer)
+        ? `the page never names ${offer.vendor}, on a domain that carries its name`
+        : `the page never names ${offer.vendor} and is not served from its domain`,
     };
   }
   const structured = page.structured ?? null;
@@ -207,7 +202,7 @@ export function classifySource(offer, page, signals) {
       detail: `the page names ${offer.vendor} and says "${found[0]}" but states no amount, rate or price we can read${markupClause(structured)}`,
     };
   }
-  return { outcome: SOURCE_CHECK_OK, detail: naming.via };
+  return { outcome: SOURCE_CHECK_OK, detail: `${namedClause(offer.vendor, naming)} and states "${found[0]}"` };
 }
 
 export const MAX_UNRENDERED_PRICES_RECORDED = 6;

--- a/src/openapi.ts
+++ b/src/openapi.ts
@@ -953,13 +953,13 @@ export const openapiSpec = {
             description: [
               "ok — the page names the vendor and states at least one amount, rate or price, either in figures the page renders or as a typed price in its schema.org markup (#1279).",
               "states_no_amount — the page names the vendor and names a plan or tier, but every price signal on it is a phrase such as \"Enterprise plan\" or \"Free forever\" and none is a figure (#1268). The quantities in description come from our own entry, not from that page. risk_level is still published and the summary says so, rather than being withheld.",
-              "does_not_name_vendor — the page never names the vendor and is not served from its domain.",
+              "does_not_name_vendor — the page we read never writes the vendor's name. The URL we asked for is not evidence for this check, so a domain that keeps the vendor's name and loses its product reaches this outcome too (#1355).",
               "states_no_terms — the page names the vendor but carries no price signal of any kind.",
               "unreadable — the fetch produced no body we could read.",
               "The last three withhold a favourable risk_level; the first two do not."
             ].join(" ")
           },
-          detail: { type: "string", description: "What the check found, in its own words: for ok, how the page named the vendor, or what its markup states when the rendered page states no amount; for states_no_amount, the phrase that was the page's entire price evidence; otherwise why the page cannot confirm the record. Where the page was read for schema.org markup, the detail says whether that markup was absent, present and priceless, or priced." },
+          detail: { type: "string", description: "What the check found, in its own words: for ok, the name the page writes for the vendor and the price evidence quoted from it, or what its markup states when the rendered page states no amount; for states_no_amount, the phrase that was the page's entire price evidence; otherwise why the page cannot confirm the record. Where the page was read for schema.org markup, the detail says whether that markup was absent, present and priceless, or priced." },
           read: { type: "string", enum: ["markup"], description: "Present when the ok grade rests on typed prices in the page's schema.org markup rather than on a figure the page renders (#1279)." },
           unrendered_prices: {
             type: "array",

--- a/src/page-reviews.ts
+++ b/src/page-reviews.ts
@@ -12,6 +12,7 @@ export const QUALITY_BUDGET_NAMES = [
   "stale_fact_pages",
   "unsourced_tier_a",
   "uncited_change_records",
+  "source_checks_ok_without_quoted_evidence",
   "faq_answers",
   "faq_answers_stating_a_figure",
   "faq_answers_with_a_digit_but_no_figure",

--- a/src/source-check.ts
+++ b/src/source-check.ts
@@ -46,6 +46,23 @@ export function withheldLevelSentence(
   return WITHHELD_LEVEL_SENTENCES[reason](subject, since);
 }
 
+export const NAMING_TOKENS_RECORDED_INSTEAD_OF_EVIDENCE = ["text", "url", "host"];
+
+export const NAMING_TOKENS_TAKEN_FROM_THE_URL_WE_ASKED_FOR = ["url", "host"];
+
+function passedOnDetail(offer: Pick<Offer, "source_check">, tokens: string[]): boolean {
+  const check = offer.source_check;
+  return check?.outcome === "ok" && tokens.includes(check.detail ?? "");
+}
+
+export function passedWithoutQuotingThePage(offer: Pick<Offer, "source_check">): boolean {
+  return passedOnDetail(offer, NAMING_TOKENS_RECORDED_INSTEAD_OF_EVIDENCE);
+}
+
+export function passedOnTheUrlWeAskedFor(offer: Pick<Offer, "source_check">): boolean {
+  return passedOnDetail(offer, NAMING_TOKENS_TAKEN_FROM_THE_URL_WE_ASKED_FOR);
+}
+
 export function sourceDoesNotNameVendor(offer: Pick<Offer, "source_check">): boolean {
   return offer.source_check?.outcome === "does_not_name_vendor";
 }

--- a/test/change-gate.test.ts
+++ b/test/change-gate.test.ts
@@ -1085,7 +1085,7 @@ describe("the run does not write a change the gate refused", () => {
     verifiedDate: "2026-01-01",
   };
   const picked = [{ index: 0, offer }];
-  const fetchFn = async () => ({ ok: true, text: SAME_TERMS_EITHER_SIDE.current_state });
+  const fetchFn = async () => ({ ok: true, text: `Abby pricing — ${SAME_TERMS_EITHER_SIDE.current_state}` });
   const detection = {
     status: "changed",
     summary: SAME_TERMS_EITHER_SIDE.summary,
@@ -1223,7 +1223,7 @@ describe("the run does not write a change the gate refused", () => {
     const file = tempLog([]);
     const data = { offers: [{ ...movedOffer }] };
     const result = await runAiMode([{ index: 0, offer: movedOffer }], data, false, NOW, {
-      fetchFn: async () => ({ ok: true, text: A_LIMIT_ACTUALLY_MOVED.current_state }),
+      fetchFn: async () => ({ ok: true, text: `Deno Deploy pricing — ${A_LIMIT_ACTUALLY_MOVED.current_state}` }),
       verifyFn: async () => ({
         status: "changed",
         summary: A_LIMIT_ACTUALLY_MOVED.summary,

--- a/test/change-log-writer.test.ts
+++ b/test/change-log-writer.test.ts
@@ -470,7 +470,7 @@ describe("change log writer", () => {
 
   describe("AI mode is the only mode that can write a change", () => {
     const picked = [{ index: 0, offer: { ...OFFER, verifiedDate: "2026-01-01" } }];
-    const fetchFn = async () => ({ ok: true, text: "500 MB for 14 days, then $19/month" });
+    const fetchFn = async () => ({ ok: true, text: "Examplebase pricing — 500 MB for 14 days, then $19/month" });
 
     it("writes the detected change to the log", async () => {
       const file = tempLog([]);

--- a/test/stale-page-facts.test.ts
+++ b/test/stale-page-facts.test.ts
@@ -336,6 +336,7 @@ describe("#1321 the FAQ counts are budgets too, and they live in the same file",
       stale_fact_pages: 57,
       unsourced_tier_a: 43,
       uncited_change_records: budgets.uncited_change_records,
+      source_checks_ok_without_quoted_evidence: budgets.source_checks_ok_without_quoted_evidence,
     });
     assert.deepStrictEqual(unmeasured, [
       "faq_answers",

--- a/test/uncited-change-records.test.ts
+++ b/test/uncited-change-records.test.ts
@@ -29,6 +29,15 @@ import type { DealChange } from "../dist/types.js";
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const REPO = path.join(__dirname, "..");
 
+function withEntitiesDecoded(html: string): string {
+  return html
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&amp;/g, "&");
+}
+
 const NOW = Date.parse("2026-09-05T00:00:00Z");
 
 const record = (over: Partial<DealChange> = {}): DealChange => ({
@@ -281,7 +290,7 @@ describe("the vendor page, for a vendor whose records cite no source", () => {
       const uncitedHere = changes.filter(c =>
         c.vendor.toLowerCase() === offer.vendor.toLowerCase() && changeIsUncited(c));
       for (const c of uncitedHere) {
-        assert.ok(html.includes(c.summary), `${offer.vendor} does not render ${c.date}`);
+        assert.ok(withEntitiesDecoded(html).includes(c.summary), `${offer.vendor} does not render ${c.date}`);
       }
       const marked = [...html.matchAll(/class="change-item[^"]*"/g)].filter(m => m[0].includes("change-unsourced"));
       assert.strictEqual(marked.length, uncitedHere.length, `${offer.vendor} marks the wrong number of records`);

--- a/test/vendor-naming.test.ts
+++ b/test/vendor-naming.test.ts
@@ -10,6 +10,9 @@ import {
   SOURCE_CHECK_UNREADABLE,
 } from "../scripts/vendor-naming.js";
 import { priceSignals, MIN_PRICE_SIGNALS } from "../scripts/change-gate.js";
+import { passedOnTheUrlWeAskedFor, passedWithoutQuotingThePage } from "../dist/source-check.js";
+import { qualityBudget } from "../dist/page-reviews.js";
+import { loadOffers } from "../dist/data.js";
 import { JOINSECRET_OFFERS_PAGE, BREX_REWARDS_PAGE } from "./vendor-page-fixture.ts";
 
 describe("does the page state terms about THIS vendor", () => {
@@ -71,41 +74,70 @@ describe("does the page state terms about THIS vendor", () => {
     });
   });
 
-  describe("evidence outside the page text", () => {
-    it("accepts a page served from the vendor's own domain", () => {
+  describe("the page is the only thing this check reads", () => {
+    it("refuses a page served from the vendor's own domain that never writes its name", () => {
       const result = pageNamesVendor("Sign in to continue", "PrefectCloud", {
         url: "https://www.prefect.io/",
       });
-      assert.strictEqual(result.named, true);
-      assert.strictEqual(result.via, "host");
+      assert.strictEqual(result.named, false);
     });
 
-    it("accepts a name too short to search prose for when the host is exactly it", () => {
-      const result = pageNamesVendor("Enable JavaScript to continue", "v0.dev", {
-        url: "https://v0.app/",
-      });
-      assert.strictEqual(result.named, true);
-      assert.strictEqual(result.via, "host");
-    });
-
-    it("accepts a host label that opens the stored name", () => {
-      const result = pageNamesVendor("Secure email, calendar and contacts", "Tutanota", {
-        url: "https://tuta.com/pricing",
-      });
-      assert.strictEqual(result.named, true);
-      assert.strictEqual(result.via, "host");
-    });
-
-    it("accepts a vendor the URL path names", () => {
+    it("refuses a URL path that names the vendor when the page does not", () => {
       const result = pageNamesVendor("Loading…", "SwaggerHub", {
         url: "https://swagger.io/tools/swaggerhub/pricing/",
       });
+      assert.strictEqual(result.named, false);
+    });
+
+    it("refuses a page whose content belongs to somebody else, on a domain that still carries the name", () => {
+      const result = pageNamesVendor(
+        "Langit77 Pusat Situs Resmi Online Slot Pasti Menang. Daftar sekarang.",
+        "BackgroundStyler.com",
+        { url: "https://backgroundstyler.com" }
+      );
+      assert.strictEqual(result.named, false);
+    });
+
+    it("accepts a host label the page itself writes", () => {
+      const result = pageNamesVendor("Tuta — secure email, calendar and contacts", "Tutanota", {
+        url: "https://tuta.com/pricing",
+      });
       assert.strictEqual(result.named, true);
-      assert.strictEqual(result.via, "url");
+      assert.strictEqual(result.via, "host_in_text");
+      assert.strictEqual(result.form, "tuta");
+    });
+
+    it("records the domain rather than the subdomain when the page writes both", () => {
+      const result = pageNamesVendor("Cloud Run pricing, from Google", "Google Cloud Run", {
+        url: "https://cloud.google.com/run/pricing",
+      });
+      assert.strictEqual(result.via, "host_in_text");
+      assert.strictEqual(result.form, "google");
+    });
+
+    it("will not take a host label off a page about a different company", () => {
+      const result = pageNamesVendor("joinsecret offers for founders", "Cloudways", {
+        url: "https://www.joinsecret.com/offers",
+      });
+      assert.strictEqual(result.named, false);
+    });
+
+    it("refuses a host label too short to mean anything where the page happens to carry it", () => {
+      const result = pageNamesVendor("Grok models and pricing from SpaceXAI Docs", "xAI", {
+        url: "https://docs.x.ai/developers/models",
+      });
+      assert.strictEqual(result.named, false);
+    });
+
+    it("refuses a host too short to be worth finding in prose", () => {
+      const result = pageNamesVendor("Enable JavaScript to continue", "v0.dev", {
+        url: "https://v0.app/",
+      });
+      assert.strictEqual(result.named, false);
     });
 
     it("refuses a host that merely shares a prefix with the stored name", () => {
-      const result = pageNamesVendor("Free currency conversion API", "CurrencyScoop", {
+      const result = pageNamesVendor("Free currency conversion from currencybeacon", "CurrencyScoop", {
         url: "https://currencybeacon.com/",
       });
       assert.strictEqual(result.named, false);
@@ -184,5 +216,57 @@ describe("what a re-verification learned about the cited page", () => {
       priceSignals("Vercel Hobby plan, free forever. Pro is $20/month.")
     );
     assert.strictEqual(result.outcome, SOURCE_CHECK_OK);
+  });
+
+  it("says what it read on the page it passed, rather than which layer matched", () => {
+    const text = "Vercel Hobby plan, free forever. Pro is $20/month.";
+    const result = classifySource({ vendor: "Vercel", url: "https://vercel.com/pricing" }, { ok: true, text }, priceSignals(text));
+    assert.strictEqual(passedWithoutQuotingThePage({ source_check: result }), false, result.detail);
+    assert.match(result.detail, /names Vercel/);
+    assert.match(result.detail, /\$20/);
+  });
+
+  it("does not claim a page named the vendor when all it wrote was the domain", () => {
+    const text = "Tuta — secure email, calendar and contacts. Legend from €3/month.";
+    const result = classifySource({ vendor: "Tutanota", url: "https://tuta.com/pricing" }, { ok: true, text }, priceSignals(text));
+    assert.strictEqual(result.outcome, SOURCE_CHECK_OK);
+    assert.match(result.detail, /the page writes "tuta", the domain we cite Tutanota from/);
+    assert.doesNotMatch(result.detail, /names Tutanota/);
+  });
+
+  it("refuses a takeover of the vendor's own domain and says the domain is still theirs", () => {
+    const text = "Langit77 Pusat Situs Resmi Online Slot. Bonus $107.50 setiap hari.";
+    const result = classifySource(
+      { vendor: "BackgroundStyler.com", url: "https://backgroundstyler.com" },
+      { ok: true, text },
+      priceSignals(text)
+    );
+    assert.strictEqual(result.outcome, SOURCE_CHECK_NOT_NAMED);
+    assert.match(result.detail, /on a domain that carries its name/);
+  });
+
+  it("keeps saying so when the page is somebody else's domain as well as somebody else's page", () => {
+    const result = classifySource(offer, { ok: true, text: JOINSECRET_OFFERS_PAGE }, priceSignals(JOINSECRET_OFFERS_PAGE));
+    assert.match(result.detail, /is not served from its domain/);
+  });
+});
+
+describe("what data/index.json publishes as a passed source check", () => {
+  const offers = loadOffers();
+
+  it("passes nothing on evidence that is only the URL we asked for", () => {
+    assert.deepStrictEqual(
+      offers.filter(passedOnTheUrlWeAskedFor).map((offer) => `${offer.vendor} — ${offer.url}`),
+      [],
+    );
+  });
+
+  it("holds no more passes that quote nothing from the page than the budget allows", () => {
+    const budget = qualityBudget("source_checks_ok_without_quoted_evidence");
+    const measured = offers.filter(passedWithoutQuotingThePage).length;
+    assert.ok(
+      measured <= budget,
+      `${measured} offers pass a source check without quoting the page, over the budget of ${budget} in data/quality_budgets.json`,
+    );
   });
 });


### PR DESCRIPTION
Refs #1355.

## What was wrong

`pageNamesVendor` answered "does this page name the vendor?" in three layers: the page text, then the URL string, then the host. The second and third read `offer.url` — a value we supply. **The answer cannot change when the page changes**, so for any offer whose URL contains its own name, that question could not fail.

`backgroundstyler.com` is the clean case. No redirect, HTTP 200 from its own domain, `<title>` "Langit77 : Pusat Situs Resmi Online Slot Pasti Menang", the string "BackgroundStyler" nowhere on it. The check said *named — via url*, found a rupiah price, and graded `ok`.

## What changed

The page is the only haystack. The URL still supplies candidate names, and the host must still plausibly be the vendor's — same relation as before — but **the page must write one of them**. A passed check now records what it read (`the page names Vercel as "vercel" and states "$0"`) rather than which layer matched, so an `ok` cannot rest on a naming token again.

`does_not_name_vendor` gained a second sentence. Its old one — *"the page never names X and is not served from its domain"* — is false for exactly the class this fixes, so a takeover of the vendor's own domain now records *"the page never names X, on a domain that carries its name"*.

## Measured, not assumed

Every one of the 1,580 cited pages was fetched and classified under both the old code and the new one.

| | issue | measured |
|---|---|---|
| named by the URL alone | 34 | **63** |
| `ok` grades in the catalogue | 603 | **775** |
| `ok` details that quote what was read | 569 | **71** |

The issue counted only the branch that stores the bare token. 25 records change outcome; **11 stop publishing a level**:

| record | cited page today |
|---|---|
| Codefresh | `codefresh.io/pricing/` 302s to `octopus.com/pricing/overview` — Octopus Deploy, $4,330/yr |
| StreamBackdrops | `streambackdrops.com` serves `meetbackdrops.com`. We already hold a change record saying so, dated 2026-08-28 |
| Supportivekoala | `lasertiquemedspa.com`, a slot site |
| Oaysus | `mirin.com` |
| BackgroundStyler.com | the casino, own domain |
| weserv | `images.weserv.nl` serves `wsrv.nl` — the same service, renamed. Our name is stale |
| xAI | `docs.x.ai` never writes "xAI" as a token |
| Google Gemini Code Assist, GetUpdraft | our stored name is longer than the one the page writes |
| DhiWise, paraio.com | were `states_no_amount`, which does not withhold |

38 records are **kept** by the host leg reading the page — Google Cloud Run, Slack API, Apple Notes, Google Drive, Tutanota, Pinata and the rest. Nothing correct was condemned to make the five wrong ones fail.

The cheap version of this — *"a host label that appears in the page text"*, without the vendor relation — was measured and rejected: it names 91 of the 92 records we already refuse, because every site writes its own name.

## The two acceptance criteria this closes

- **No `ok` rests on `detail: "url"`.** The guard fails on today's data before the fix, naming all 35 (the `host` case the issue does not mention is included). The 35 are re-checked against their live pages here by `source-naming-audit.js --write`, the same writer the pipeline uses.
- **An `ok` detail says what was read.** True for every check written from now on. 666 stored records still carry a bare token from an older run; that is a new ratcheted budget rather than a mass rewrite of 45% of the catalogue, so re-verification drains it and the slot cannot be reused.

## Also

`change-gate.js` shares this predicate, so a change record can no longer be written from a page that never names the vendor.

3,767 tests, 13 new. 9 mutations, 9 killed. Verified on a running server: `/api/vendor-risk/Codefresh` publishes `risk_level: null`, Google Cloud Run and Tutanota still publish `stable`, and an MCP `initialize` → `compare_vendors` returns the new outcome.

## Not in this PR

**SwaggerHub keeps `tier: "Free"`.** `swagger.io/product/pricing` is the vendor's own pricing page and writes "Swagger", so the check passes it — correctly. The defect there is the stored tier, and PR #1354 already cites the change record that contradicts it.
