### PR TITLE
Turn main green: re-ratchet the uncited budget, quote three retractions typographically

### DIFF
--- a/data/deal_changes.json
+++ b/data/deal_changes.json
@@ -3490,7 +3490,7 @@
       "resolution": {
         "state": "reversed",
         "date": "2026-09-05",
-        "detail": "No longer in force as of 2026-09-05. This record cites nothing and xAI does not publish its sign-up credit terms on a page we can read, so it cannot be retracted on evidence; it is withdrawn because the claim it makes is contradicted by our own later record. Our xAI offer, verified 2026-08-14 and re-checked 2026-09-02, reads \"Sign-up gives $25 in free API credits\". Recorded separately: the URL that offer cites, docs.x.ai/developers/models, contains no occurrence of \"free\", \"credit\" or \"$25\" in its 5,452 characters of visible text, so that claim is also uncited and needs a source of its own."
+        "detail": "No longer in force as of 2026-09-05. This record cites nothing and xAI does not publish its sign-up credit terms on a page we can read, so it cannot be retracted on evidence; it is withdrawn because the claim it makes is contradicted by our own later record. Our xAI offer, verified 2026-08-14 and re-checked 2026-09-02, reads “Sign-up gives $25 in free API credits”. Recorded separately: the URL that offer cites, docs.x.ai/developers/models, contains no occurrence of “free”, “credit” or “$25” in its 5,452 characters of visible text, so that claim is also uncited and needs a source of its own."
       }
     },
     {
@@ -3509,7 +3509,7 @@
       "resolution": {
         "state": "retracted",
         "date": "2026-09-05",
-        "detail": "Retracted 2026-09-05: Clarifai's Community plan was not replaced by a trial. The Internet Archive's 2026-03-04 capture of clarifai.com/pricing, five weeks before this record, and its 2026-04-17 capture, four days after it, both carry the same Compare Plans ladder: \"Community | Get Community | Essential | Get Essential | Professional | Get Professional | Hybrid AI Enterprise | Contact Us | Private AI Enterprise | Contact Us\", with \"Monthly requests: Limited\" and \"Requests per second: 1\" in the Community column. Community is an orderable plan on both sides of this record's date. The 14-day trial named here is the hero banner above that table - \"Benchmark your models on the world's fastest inference engine with a free 14-day trial\" - which offers a trial of the Reasoning Engine, not a replacement for the plan ladder. Our own offer record, verified 2026-07-15, reads \"Community tier: 1,000 API calls/month\".",
+        "detail": "Retracted 2026-09-05: Clarifai's Community plan was not replaced by a trial. The Internet Archive's 2026-03-04 capture of clarifai.com/pricing, five weeks before this record, and its 2026-04-17 capture, four days after it, both carry the same Compare Plans ladder: “Community | Get Community | Essential | Get Essential | Professional | Get Professional | Hybrid AI Enterprise | Contact Us | Private AI Enterprise | Contact Us”, with “Monthly requests: Limited” and “Requests per second: 1” in the Community column. Community is an orderable plan on both sides of this record's date. The 14-day trial named here is the hero banner above that table - “Benchmark your models on the world's fastest inference engine with a free 14-day trial” - which offers a trial of the Reasoning Engine, not a replacement for the plan ladder. Our own offer record, verified 2026-07-15, reads “Community tier: 1,000 API calls/month”.",
         "source_url": "https://web.archive.org/web/20260304155253/https://www.clarifai.com/pricing"
       }
     },
@@ -4019,7 +4019,7 @@
       "resolution": {
         "state": "retracted",
         "date": "2026-09-05",
-        "detail": "Retracted 2026-09-05: Storyblok's Starter plan is free and was free when this row was written. The Internet Archive's 2026-04-11 capture of storyblok.com/pricing - two days before this record's date - lists \"Starter ... Monthly price if billed monthly: Free\", and the live page reads the same today. The 45-day free trial named here is a trial of the paid Growth Plus plan offered on top of the free Starter plan, not a replacement for it. This row was our error, not a change Storyblok made.",
+        "detail": "Retracted 2026-09-05: Storyblok's Starter plan is free and was free when this row was written. The Internet Archive's 2026-04-11 capture of storyblok.com/pricing - two days before this record's date - lists “Starter ... Monthly price if billed monthly: Free”, and the live page reads the same today. The 45-day free trial named here is a trial of the paid Growth Plus plan offered on top of the free Starter plan, not a replacement for it. This row was our error, not a change Storyblok made.",
         "source_url": "https://www.storyblok.com/pricing",
         "resolved_by": {
           "vendor": "Storyblok",


### PR DESCRIPTION
`test/uncited-change-records.test.ts:284` asserts `html.includes(c.summary)`, where `c.summary` carries the composed `resolutionTag + summary + resolution.detail` and the page renders it through `escHtmlServer`. Three resolution details quote the vendor's page with straight double quotes, which render as `&quot;`, so the assertion fails on records the page renders correctly.

main has been red on this since c617a53. `test/uncited-change-records.test.ts` is not in `scripts/gate-non-blocking-tests.json`, so it holds the daily data commit — and the catalogue has not advanced on main since 2026-09-03T10:46Z.

This swaps the three straight quotes for typographic ones, which are not escaped. Every quotation is preserved character for character; only the glyph changes. Clarifai, Storyblok and xAI are the only affected records — the other eight resolved records contain no double quote.

That is an unblock, not the fix. The assertion compares unescaped text against escaped HTML and will fail again on the next retraction that quotes a page, which is how a retraction is evidenced. Filed as https://github.com/robhunter/agentdeals/issues/1359, high.

The budget half of this branch is dropped — #1357 re-ratcheted `uncited_change_records` to 95 first.

Verified against a local `src/serve.ts` on this branch: all 25 subjects the test iterates render every one of their uncited records, mark exactly the right number, and carry the unsourced note. `scripts/ratchet-quality-budgets.js --json` reports nothing to lower and nothing over.
