### PR TITLE
Publish the Claude models Anthropic actually sells (#1362)

### DIFF
--- a/data/index.json
+++ b/data/index.json
@@ -31102,7 +31102,7 @@
     {
       "vendor": "Anthropic API",
       "category": "AI / ML",
-      "description": "Claude API access with usage-based pricing. Opus 4.6: $5/$25 per MTok (input/output), 67% below previous Opus pricing. Sonnet 4.6: $3/$15 per MTok. Haiku 4.5: $0.80/$4 per MTok. Batch API at 50% discount. Free tier: limited access via console with rate limits.",
+      "description": "Claude API access with usage-based pricing. Fable 5.1: $10/$50 per MTok (input/output). Opus 5: $5/$25 per MTok. Sonnet 5: $2/$10 per MTok. Haiku 4.5: $1/$5 per MTok. Batch API at 50% discount. Free tier: limited access via console with rate limits.",
       "tier": "Pay-as-you-go",
       "url": "https://docs.anthropic.com/en/docs/about-claude/models",
       "tags": [
@@ -31133,9 +31133,9 @@
         "notes": "Enterprise referral program. Must bring new enterprise customers. Commission negotiated per deal."
       },
       "source_check": {
-        "checked": "2026-09-02",
+        "checked": "2026-09-05",
         "outcome": "ok",
-        "detail": "text"
+        "detail": "platform.claude.com/docs/en/models/overview, the 301 target of the cited URL, lists “Claude Fable 5.1 · Claude Opus 5 · Claude Sonnet 5 · Claude Haiku 4.5” and contains no occurrence of “Opus 4.6”; anthropic.com/pricing gives Fable 5.1 $10/$50, Opus 5 $5/$25, Sonnet 5 $2/$10, Haiku 4.5 $1/$5 per MTok."
       },
       "product_subtypes": {
         "taxonomy": "AI / ML",

--- a/data/quality_budgets.json
+++ b/data/quality_budgets.json
@@ -4,7 +4,7 @@
     "stale_fact_pages": 57,
     "unsourced_tier_a": 43,
     "uncited_change_records": 95,
-    "source_checks_ok_without_quoted_evidence": 666,
+    "source_checks_ok_without_quoted_evidence": 665,
     "faq_answers": 166,
     "faq_answers_stating_a_figure": 77,
     "faq_answers_with_a_digit_but_no_figure": 40


### PR DESCRIPTION
Refs https://github.com/robhunter/agentdeals/issues/1362 — AC-1, the data half, which the issue says I am shipping myself.

## The change

One record, `Anthropic API` in `data/index.json`.

| we published | anthropic.com/pricing, 2026-09-05 |
|---|---|
| Opus 4.6 $5/$25 | **Opus 5** $5/$25 — name superseded, price right by accident |
| Sonnet 4.6 $3/$15 | **Sonnet 5** $2/$10 |
| Haiku 4.5 $0.80/$4 | **Haiku 4.5** $1/$5 — current name, wrong price |
| — | **Fable 5.1** $10/$50, absent from the record |

## The evidence field

`source_check.detail` was the literal string `text`, on a check dated 2026-09-02. The record's own `url` 301s to `platform.claude.com/docs/en/models/overview`, which lists "Claude Fable 5.1 · Claude Opus 5 · Claude Sonnet 5 · Claude Haiku 4.5" and contains no occurrence of "Opus 4.6". So the page it was graded against disproved it.

`detail` now quotes what was read. The reference implementation was already inside this record: `product_subtypes.labels[0].source_quote` was written 2026-09-01 against the same URL and carries a real sentence from it.

## Measured

`scripts/ratchet-quality-budgets.js` before: `source_checks_ok_without_quoted_evidence` 666. After: 665. Written with `--lower`.

`stale_fact_pages` 57, `unsourced_tier_a` 43, `uncited_change_records` 95 — unchanged.

## Scope

Data only. No `src/`, no `test/`. The 13 `Opus 4.6`, 8 `Sonnet 4.6` and 4 `Haiku 4.5` literals in `src/serve.ts` are AC-2 on the issue and are not touched here — they render on 40, 33 and 36 pages respectively.

No change-log event recorded: this is a correction to our own prose, not a vendor change, per #1259.