### PR TITLE
Stop the gate's own configuration reaching the suite it runs (#1335)

### DIFF
--- a/scripts/gate-data-push.sh
+++ b/scripts/gate-data-push.sh
@@ -114,7 +114,7 @@ if [ -n "$UPDATE_PAGE_LASTMOD" ]; then
   fi
 fi
 
-if npm run test:gated >>"$LOG" 2>&1; then
+if env -u GATE_RATCHET_BUDGETS -u GATE_UPDATE_PAGE_LASTMOD npm run test:gated >>"$LOG" 2>&1; then
   summarize
   push_to_main
   echo "Suite green — $COMMIT is on main."

--- a/test/data-push-gate.test.ts
+++ b/test/data-push-gate.test.ts
@@ -167,11 +167,17 @@ const FAILING_BY_MODE: Record<string, string[]> = {
   crashed: [],
 };
 
+const GATE_CONFIGURATION = ["GATE_RATCHET_BUDGETS", "GATE_UPDATE_PAGE_LASTMOD"];
+
 const SUITE = `import { appendFileSync, writeFileSync } from "node:fs";
 const modes = ${JSON.stringify(FAILING_BY_MODE)};
 const mode = process.env.GATE_FIXTURE_TESTS || "green";
 const failing = modes[mode];
 writeFileSync(process.env.GATE_FAILING_FILES, failing.map((f) => f + "\\n").join(""));
+writeFileSync(
+  process.env.GATE_FIXTURE_ENV_REPORT,
+  ${JSON.stringify(GATE_CONFIGURATION)}.filter((name) => process.env[name]).join(","),
+);
 appendFileSync(process.env.GITHUB_OUTPUT, "a_test_spawned_a_script_that_wrote_this=yes\\n");
 console.log("\\u2139 tests 2");
 console.log("\\u2139 pass " + (mode === "green" ? 2 : 1));
@@ -260,6 +266,7 @@ function fixtureRepo(): { work: string; origin: string } {
   writeFileSync(join(work, "allowlist.json"), ALLOWLIST);
   writeFileSync(join(work, "data", "health.json"), '{"checked":1}\n');
   writeFileSync(join(work, "data", "quality_budgets.json"), BUDGETS_BEFORE);
+  writeFileSync(join(work, "data", "page-lastmod.json"), '{"version":1,"pages":{}}\n');
   writeFileSync(join(work, "untracked-by-the-gate.txt"), "before\n");
   git(work, "add", "-A");
   git(work, "commit", "-m", "fixture");
@@ -275,11 +282,13 @@ interface GateRun {
   mode: GateMode;
   build?: "fail";
   ratchet?: RatchetMode;
+  lastmod?: true;
 }
 
 function runGate(work: string, mode: GateMode | GateRun, ...args: string[]) {
   const opts: GateRun = typeof mode === "string" ? { mode } : mode;
   const outputs = join(work, "step-outputs.txt");
+  const envReport = join(work, "the-environment-the-suite-ran-in.txt");
   const run = spawnSync("bash", [GATE, ...args], {
     cwd: work,
     encoding: "utf8",
@@ -288,12 +297,19 @@ function runGate(work: string, mode: GateMode | GateRun, ...args: string[]) {
       GATE_FIXTURE_TESTS: opts.mode,
       GATE_FIXTURE_BUILD: opts.build ?? "ok",
       GATE_FIXTURE_RATCHET: opts.ratchet ?? "lower",
+      GATE_FIXTURE_ENV_REPORT: envReport,
       GATE_RATCHET_BUDGETS: opts.ratchet === undefined ? "" : "1",
+      GATE_UPDATE_PAGE_LASTMOD: opts.lastmod ? "1" : "",
       GITHUB_OUTPUT: outputs,
       AGENTDEALS_NON_BLOCKING_TESTS_PATH: join(work, "allowlist.json"),
+      AGENTDEALS_PAGE_LASTMOD_PATH: join(work, "data", "page-lastmod.json"),
     },
   });
-  return { ...run, outputs: existsSync(outputs) ? readFileSync(outputs, "utf8") : "" };
+  return {
+    ...run,
+    outputs: existsSync(outputs) ? readFileSync(outputs, "utf8") : "",
+    suiteSawGateConfig: existsSync(envReport) ? readFileSync(envReport, "utf8") : null,
+  };
 }
 
 function mainSha(origin: string): string {
@@ -544,6 +560,50 @@ describe("#1326 nothing that can fail stands between the day's data and the gate
       /read the failing tests in the run/,
       "the refusal issue still sends a reader to failing tests when the build is what broke",
     );
+  });
+});
+
+describe("#1335 the gate's own configuration does not configure the suite it runs", () => {
+  before(() => {
+    scratch = mkdtempSync(join(tmpdir(), "gate-config-"));
+  });
+
+  after(() => {
+    if (scratch && existsSync(scratch)) rmSync(scratch, { recursive: true, force: true });
+  });
+
+  const PATHS = [
+    "data-quarantine/fixture",
+    "data(auto): fixture",
+    "data/health.json",
+    "data/quality_budgets.json",
+    "data/page-lastmod.json",
+  ];
+
+  it("hands the suite neither variable, so a nested run reads its own arguments", () => {
+    const { work } = fixtureRepo();
+    writeFileSync(join(work, "data", "health.json"), '{"checked":21}\n');
+
+    const run = runGate(work, { mode: "green", ratchet: "lower", lastmod: true }, ...PATHS);
+
+    assert.notStrictEqual(run.suiteSawGateConfig, null, "the suite did not run, so this asserts nothing about what it saw");
+    assert.strictEqual(
+      run.suiteSawGateConfig,
+      "",
+      `the suite ran with ${run.suiteSawGateConfig} still set, so anything it starts is configured by this run rather than its own arguments`,
+    );
+  });
+
+  it("still acts on both variables itself", () => {
+    const { work, origin } = fixtureRepo();
+    writeFileSync(join(work, "data", "health.json"), '{"checked":22}\n');
+
+    const run = runGate(work, { mode: "green", ratchet: "lower", lastmod: true }, ...PATHS);
+
+    assert.strictEqual(run.status, 0, run.stdout + run.stderr);
+    assert.match(run.stdout, /Lowering any quality budget/, "the gate no longer lowers the budget its data earned");
+    assert.match(run.stdout, /Reading every page this run renders/, "the gate no longer dates the pages this run moved");
+    assert.notStrictEqual(mainSha(origin), "", "the fixture origin has no main");
   });
 });
 


### PR DESCRIPTION
Refs #1335.

## What refuses every scheduled data push

The 2026-09-05 run is refused on the same shape as the 2026-09-04 one, and it is not the data. Run `33959373966` failed 18 tests, all of them in `test/data-push-gate.test.ts`, all with one message:

> `usage: GATE_UPDATE_PAGE_LASTMOD is set but data/page-lastmod.json is not among the paths this run may commit (data/health.json), so the days read here would be left behind in the workspace.`

`reverify.yml` sets `GATE_UPDATE_PAGE_LASTMOD: "1"` on the gate step. The gate runs the suite as a child of that step, so the variable is still in the environment when the suite reaches its own gate tests. Those tests invoke `gate-data-push.sh` with fixture paths — `data/health.json` — and the guard added for #1347 correctly refuses that combination. The guard is right; what is wrong is that a nested invocation is configured by the outer one.

Reproduces on `main` in one line:

```
GATE_UPDATE_PAGE_LASTMOD=1 node --test --test-concurrency 1 test/data-push-gate.test.ts
```

18 fail. With this change, 41 pass with both `GATE_UPDATE_PAGE_LASTMOD=1` and `GATE_RATCHET_BUDGETS=1` set.

`GATE_RATCHET_BUDGETS` was already handled — `runGate` overrides it explicitly — so this is the second variable of the pair to leak and the first to reach a scheduled run. The fix is at the choke point rather than the surface: the gate removes both before running the suite, since they configure this invocation and nothing nested. The harness also sets them per run rather than inheriting, so the two are independent.

## A fixture run was writing the real repository's data

Adding a fixture that exercises the page-lastmod branch surfaced a second thing: `pageLastmodPath()` resolves from the module directory rather than the working directory, so `update-page-lastmod.js`, invoked by a gate running against a temporary fixture repo, read and rewrote the checked-out `data/page-lastmod.json` — 516 lines of it, in my working tree. The fixture now names its own path through `AGENTDEALS_PAGE_LASTMOD_PATH`.

## What this does not do

It does not recover the two quarantined batches. `data-quarantine/rolling-reverification-20260904T105424Z-0c2754c` and `data-quarantine/rolling-reverification-20260905T100944Z-7e7c93d` still have no path back, which is #1321. The next scheduled run will re-walk those records rather than recover the commits, so the data returns a day late rather than being lost.

Reviewing the batches before they land is still needed: the 09-04 comment on this issue records that three of its five `free_tier_removed` records are false, which is #1336.

## Tests

2 new, 3,792 passing. The first fails without the one-line change to the gate and passes with it; the second holds the gate still acting on both variables itself, so removing them from the suite cannot be achieved by ignoring them.
