### PR TITLE
Retire SwaggerHub's free tier — SmartBear sells a trial (#1355)

### DIFF
--- a/data/index.json
+++ b/data/index.json
@@ -8594,8 +8594,8 @@
     {
       "vendor": "SwaggerHub",
       "category": "API Development",
-      "description": "API design and documentation platform (SmartBear) — free tier: 1 designer seat for individual/personal use. OpenAPI editor, API mocking, code generation. Limited API definitions on free plan",
-      "tier": "Free",
+      "description": "API design and documentation platform (SmartBear) — no permanent free tier. Swagger's own pricing FAQ, read 2026-09-05: \"You can get started with Swagger with a free trial, no credit card required, then choose the plan that best fits your usage and requirements.\" The same FAQ puts the free Swagger tools on the open-source side — Swagger Editor, Swagger UI and Swagger Codegen, run locally — and SwaggerHub among the commercial products. Plan prices are client-rendered and were not read.",
+      "tier": "Trial",
       "url": "https://swagger.io/tools/swaggerhub/pricing/",
       "tags": [
         "api-design",


### PR DESCRIPTION
Refs #1355. Data only — one record in `data/index.json`, 2 insertions, 2 deletions.

## What the vendor says

`swagger.io/tools/swaggerhub/pricing/` renders its plan table client-side; the curl view is 1,296 visible characters and carries no plan and no price. The page's own FAQ content is in the served HTML, and answers both questions:

> **How much does Swagger cost?** "You can get started with Swagger with a free trial, no credit card required, then choose the plan that best fits your usage and requirements."

> **What's the difference between free Swagger tools and commercial Swagger products?** "Open-source Swagger tools provide the foundation for the enterprise Swagger products. Swagger Editor and Swagger UI support API authoring and documentation locally, Swagger Codegen generates client SDKs and provider stubs… Swagger's commercial products bring these capabilities together with enterprise features…"

A trial, and the free things are the open-source tools you run locally. SwaggerHub is on the commercial side of the vendor's own line.

## Our own change log said so in April

`data/deal_changes.json` holds a `free_tier_removed` record for SwaggerHub dated **2026-04-13**, summary "Free community plan replaced by trial only". It has sat there for five months while the offer read `tier: Free`.

## The change

`tier` `Free` → `Trial`, matching the five existing `Trial` records (Logz.io, imgix, ImageEngine, everystep-automation.com), and a description carrying the FAQ quote.

I did **not** set a price. The plan table is client-rendered and I could not read it, so the description says so rather than guessing.

## Budgets

`scripts/ratchet-quality-budgets.js --json` before and after: `stale_fact_pages` 57, `unsourced_tier_a` 43, `uncited_change_records` 95, `source_checks_ok_without_quoted_evidence` 665. Unchanged, nothing over.
