### PR TITLE
Publish the monitoring and hosting free tiers the vendors sell today (#1183)

### DIFF
--- a/src/serve.ts
+++ b/src/serve.ts
@@ -22374,7 +22374,6 @@ function buildFreeTierRiskPage(): string {
     { vendor: "Neon", risk: "medium", category: "Databases", reasoning: "Pricing restructured Jan 2026 post-Databricks acquisition. Free tier preserved (0.5 GB/project, 100 projects) but acquisition creates uncertainty about long-term free tier commitment.", lastChange: "2026-01-15", changeType: "pricing_restructured" },
     { vendor: "Railway", risk: "medium", category: "Hosting/PaaS", reasoning: "Free tier expanded with $100M Series B (Oct 2025). Currently generous ($5 credit, no sleep). But VC-funded PaaS companies have a history of removing free tiers (see: Heroku). Watch burn rate.", lastChange: "2025-10-01", changeType: "limits_increased" },
     { vendor: "Render", risk: "medium", category: "Hosting/PaaS", reasoning: "Sleep time reduced (Sep 2025) — 15-min spin-down is aggressive. Free PostgreSQL limited to 256 MB with 30-day expiry. Signals tightening, though core free tier intact.", lastChange: "2025-09-01", changeType: "limits_reduced" },
-    { vendor: "Fly.io", risk: "medium", category: "Hosting", reasoning: "Pricing restructured Jan 2026. Free tier narrowed — credit-card-required, 3 shared VMs. Still usable but not as generous as before. Startup funding means free tier may be temporary.", lastChange: "2026-01-01", changeType: "pricing_restructured" },
     { vendor: "Stripe", risk: "medium", category: "Payments", reasoning: "Processing fees restructured Feb 2026 (2.7% + 5¢ domestic card). No free tier per se — pay-per-transaction model. Risk is in rate changes, not tier removal.", lastChange: "2026-02-01", changeType: "pricing_restructured" },
     { vendor: "Firebase", risk: "medium", category: "BaaS", reasoning: "Multiple changes in 2026: Cloud Storage limits reduced (Feb), Realtime Database EOL announced (Mar), restrictions tightened (Feb). Google consolidating around Firestore. Migration advisable for RTDB users.", lastChange: "2026-03-19", changeType: "product_deprecated" },
     { vendor: "Docker Hub", risk: "medium", category: "Containers", reasoning: "Rate limits tightened (Dec 2024) — 100 pulls/6h anonymous, 200 authenticated. Docker Desktop commercial license required for large orgs ($5/user/mo+). Free for small teams but trending paid.", lastChange: "2024-12-10", changeType: "pricing_restructured" },
@@ -22382,6 +22381,7 @@ function buildFreeTierRiskPage(): string {
     { vendor: "Google Gemini API", risk: "medium", category: "AI/ML", reasoning: "Free tier rate limits slashed 50-80% (Dec 2025). The flagship Gemini 3.1 Pro is paid-only, though Gemini 2.5 Pro is still free. A Google PM admitted generous limits were only for a promotional weekend. Still has free tier but heavily restricted.", lastChange: "2025-12-15", changeType: "limits_reduced" },
 
     { vendor: "Heroku", risk: "high", category: "Hosting/PaaS", reasoning: "Free tier removed Nov 2022. Now in 'sustaining mode' under Salesforce — minimal investment, no innovation. The canonical cautionary tale for relying on free tiers.", lastChange: "2022-11-28", changeType: "free_tier_removed" },
+    { vendor: "Fly.io", risk: "high", category: "Hosting", reasoning: "Free tier removed for new accounts in October 2024. New signups get a trial of 2 hours runtime or 7 days, whichever comes first, then pay-as-you-go from the first machine — the smallest is $2.02/month. Only legacy Hobby/Launch/Scale accounts still carry 3 shared-cpu-1x VMs, 3 GB volume storage and 100 GB transfer. Volume snapshots became billable in January 2026.", lastChange: "2024-10-01", changeType: "free_tier_removed" },
     { vendor: "Postman", risk: "high", category: "API Testing", reasoning: "Team collaboration removed from free tier (Mar 2026). Aggressive monetization of previously-free features. Pattern suggests further restrictions ahead.", lastChange: "2026-03-01", changeType: "restriction" },
     { vendor: "OpenAI", risk: "high", category: "AI/ML", reasoning: "Multiple free tier reductions: limits cut Jun 2025, further reduced Feb 2026. GPT-4 free access removed. Market leader extracting value — expect continued tightening.", lastChange: "2026-02-09", changeType: "limits_reduced" },
     { vendor: "HCP Terraform", risk: "high", category: "Infrastructure", reasoning: "Legacy tier EOL March 31, 2026. HashiCorp BSL license change (Aug 2023) already fractured community. IBM acquisition adds enterprise pricing pressure. Migrate to OpenTofu.", lastChange: "2026-03-31", changeType: "pricing_restructured" },
@@ -40133,22 +40133,22 @@ ${mcpCtaCss()}
       </tr>
       <tr>
         <td class="provider-col">BetterStack</td>
-        <td>1GB logs</td>
+        <td>3 GB logs</td>
         <td>3 days</td>
         <td>3 days</td>
         <td>10 monitors</td>
         <td>Unlimited</td>
         <td class="check">&#10003;</td>
         <td class="check">&#10003;</td>
-        <td class="cross">&#10007;</td>
+        <td class="check">&#10003; 3GB traces</td>
         <td class="cross">&#10007;</td>
         <td><span style="color:#3fb950">Low</span></td>
       </tr>
       <tr>
         <td class="provider-col">Sentry</td>
-        <td>5K errors/mo + 10K replays</td>
+        <td>5K errors/mo + 50 replays</td>
         <td>N/A</td>
-        <td>90 days</td>
+        <td>30 days</td>
         <td>Unlimited</td>
         <td>1 user</td>
         <td class="check">&#10003;</td>
@@ -40417,7 +40417,7 @@ ${mcpCtaCss()}
 
   <div class="diff-card">
     <h3>Sentry <span class="winner-badge">BEST ERROR TRACKING</span></h3>
-    <div class="diff-desc"><strong>Free tier (Developer):</strong> 5,000 errors/month, 10,000 session replays, 10,000 performance units, 1 user. 90-day retention. Supports 30+ platforms. Source map support, breadcrumbs, and issue grouping included. The de facto standard for error tracking. Self-hosted option available for unlimited scale.</div>
+    <div class="diff-desc"><strong>Free tier (Developer):</strong> 5,000 errors/month, 50 session replays, 5M spans/month, 5 GB logs, 1 user. 30 days retention &mdash; the 90-day lookback is the Team plan. Supports 30+ platforms. Source map support, breadcrumbs, and issue grouping included. The de facto standard for error tracking. Self-hosted option available for unlimited scale.</div>
   </div>
 
   <div class="diff-card">
@@ -45983,12 +45983,12 @@ const STACK_TEMPLATES: StackTemplate[] = [
   {
     slug: "api-first",
     title: "Best Free Stack for an API-First Product — Build APIs for $0/Month in 2026",
-    metaDesc: "Build API products on free tiers. Neon, Fly.io, Auth0, New Relic, Mailgun, GitHub Actions — verified limits, cost at scale, stability ratings. Updated April 2026.",
+    metaDesc: "Build API products on free tiers. Neon, Cloudflare Workers, Auth0, New Relic, Mailgun, GitHub Actions — verified limits, cost at scale, stability ratings. Updated September 2026.",
     heroSubtitle: "Purpose-built for API products. Low latency, strong auth, and excellent observability.",
-    description: "API-first products need low-latency hosting, robust authentication with API keys and OAuth, and deep observability into request patterns. This stack pairs Fly.io's edge compute with Auth0's enterprise-grade auth and New Relic's generous free APM — giving you production-ready API infrastructure at $0/month.",
+    description: "API-first products need low-latency hosting, robust authentication with API keys and OAuth, and deep observability into request patterns. This stack pairs Cloudflare Workers' edge compute with Auth0's enterprise-grade auth and New Relic's generous free APM — giving you production-ready API infrastructure at $0/month. Fly.io held this row until September 2026 and was replaced because it has had no free tier for new accounts since October 2024.",
     services: [
       { category: "Database", vendor: "Neon", slug: "neon", estimatorCategory: "database", freeTier: "0.5 GB storage, 100 CU-hours", whyChosen: "Serverless Postgres scales to zero between requests. Connection pooling handles concurrent API clients.", starter: 19, growth: 69, scale: 350 },
-      { category: "Hosting", vendor: "Fly.io", slug: "fly-io", estimatorCategory: "hosting", freeTier: "3 shared VMs, 160 GB transfer", whyChosen: "Edge compute in 30+ regions. Low latency for API consumers worldwide.", starter: 0, growth: 15, scale: 75 },
+      { category: "Hosting", vendor: "Cloudflare Workers", slug: "cloudflare-workers", estimatorCategory: "hosting", freeTier: "100K requests/day", whyChosen: "Edge compute in 300+ locations with 10 ms CPU time per invocation. Low latency for API consumers worldwide, and the free allowance is permanent.", starter: 5, growth: 5, scale: 5 },
       { category: "Auth", vendor: "Auth0", slug: "auth0", estimatorCategory: "auth", freeTier: "25K MAU", whyChosen: "Enterprise-grade OAuth2/OIDC. API key management, rate limiting, and machine-to-machine tokens.", starter: 0, growth: 35, scale: 240 },
       { category: "Monitoring", vendor: "New Relic", slug: "new-relic", estimatorCategory: "monitoring", freeTier: "100 GB ingest/mo", whyChosen: "100 GB free ingest with APM — see every API request, latency distribution, and error rate.", starter: 0, growth: 0, scale: 49 },
       { category: "Email", vendor: "Mailgun", slug: "mailgun", estimatorCategory: "email", freeTier: "100 emails/day", whyChosen: "Reliable transactional email with detailed delivery analytics. Good for API key notifications and alerts.", starter: 0, growth: 35, scale: 90 },
@@ -46034,13 +46034,18 @@ function buildStackTemplatePage(slug: string): string | null {
   const costClass = (amount: number) => amount === 0 ? "cost-free" : amount <= 25 ? "cost-low" : amount <= 100 ? "cost-mid" : "cost-high";
   const formatCost = (amount: number) => amount === 0 ? "$0" : `$${amount.toLocaleString()}`;
 
+  const vendorLabel = (s: StackService) =>
+    vendorSlugMap.has(s.slug)
+      ? `<a href="/vendor/${escHtmlServer(s.slug)}">${escHtmlServer(s.vendor)}</a>`
+      : escHtmlServer(s.vendor);
+
   const tableRows = template.services.map(s => {
     const stability = stabilityMap.get(s.slug) ?? "stable";
     const sColor = stabilityColors[stability] ?? stabilityColors.stable;
     const sLabel = stabilityLabels[stability] ?? "Stable";
     return `<tr>
       <td>${escHtmlServer(s.category)}</td>
-      <td class="vendor-name"><a href="/vendor/${escHtmlServer(s.slug)}">${escHtmlServer(s.vendor)}</a><span class="free-tier-info">${escHtmlServer(s.freeTier)}</span></td>
+      <td class="vendor-name">${vendorLabel(s)}<span class="free-tier-info">${escHtmlServer(s.freeTier)}</span></td>
       <td><span class="stability-dot" style="background:${sColor}" title="${sLabel}"></span> ${sLabel}</td>
       <td class="cost-free">$0</td>
       <td class="${costClass(s.starter)}">${formatCost(s.starter)}</td>
@@ -46055,7 +46060,7 @@ function buildStackTemplatePage(slug: string): string | null {
     const sLabel = stabilityLabels[stability] ?? "Stable";
     return `<div class="why-card">
       <div class="why-card-header">
-        <strong>${escHtmlServer(s.category)}: <a href="/vendor/${escHtmlServer(s.slug)}">${escHtmlServer(s.vendor)}</a></strong>
+        <strong>${escHtmlServer(s.category)}: ${vendorLabel(s)}</strong>
         <span class="stability-badge" style="background:${sColor}20;color:${sColor};border:1px solid ${sColor}40">${sLabel}</span>
       </div>
       <p>${escHtmlServer(s.whyChosen)}</p>
@@ -46417,7 +46422,7 @@ function buildEstimatorData(): EstimatorCategory[] {
         { slug: "railway", name: "Railway", free: "$5 one-time credit", starter: 5, growth: 20, scale: 100, notes: "Hobby $5/mo, usage-based" },
         { slug: "render", name: "Render", free: "512 MB RAM, 0.1 CPU", starter: 7, growth: 25, scale: 85, notes: "Starter $7/mo per service" },
         { slug: "netlify", name: "Netlify", free: "300 credits/mo", starter: 19, growth: 19, scale: 99, notes: "Pro $19/mo, overages billed" },
-        { slug: "fly-io", name: "Fly.io", free: "3 shared VMs, 160 GB transfer", starter: 0, growth: 15, scale: 75, notes: "Pay-as-you-go after free tier" },
+        { slug: "fly-io", name: "Fly.io", free: "None — 2 hrs or 7-day trial", starter: 2, growth: 15, scale: 75, notes: "No free tier since Oct 2024; smallest machine $2.02/mo" },
         { slug: "cloudflare-workers", name: "Cloudflare Workers", free: "100K req/day", starter: 5, growth: 5, scale: 5, notes: "Paid $5/mo, 10M req included" },
         { slug: "cloudflare-pages", name: "Cloudflare Pages", free: "Unlimited bandwidth, 500 builds", starter: 0, growth: 0, scale: 0, notes: "Free for most use cases" },
       ],
@@ -46466,7 +46471,7 @@ function buildEstimatorData(): EstimatorCategory[] {
         { slug: "sendgrid", name: "SendGrid", free: "100 emails/day", starter: 0, growth: 20, scale: 50, notes: "Essentials $20/mo (50K emails)" },
         { slug: "mailgun", name: "Mailgun", free: "100 emails/day", starter: 0, growth: 35, scale: 90, notes: "Foundation $35/mo (50K emails)" },
         { slug: "brevo", name: "Brevo", free: "300 emails/day", starter: 0, growth: 25, scale: 65, notes: "Starter $25/mo (20K emails)" },
-        { slug: "amazon-ses", name: "Amazon SES", free: "3K messages/mo (from EC2)", starter: 0, growth: 10, scale: 100, notes: "$0.10/1K emails" },
+        { slug: "amazon-ses", name: "Amazon SES", free: "None — $200 in expiring credits", starter: 0, growth: 10, scale: 100, notes: "$0.10/1K emails; credits expire 12 months after signup" },
       ],
     },
     {

--- a/test/hosting-free-tier-figures.test.ts
+++ b/test/hosting-free-tier-figures.test.ts
@@ -113,9 +113,27 @@ const RETIRED_FIGURES: Retired[] = [
   },
   {
     what: "a Fly.io free tier for new accounts",
-    pattern: /Fly\.io(?:'s)?[^.]{0,70}(?:free tier includes|gives 3 shared|3 shared-cpu VMs)|3 shared-cpu-1x VMs, 160 ?GB|3 shared VMs free/i,
+    pattern: /Fly\.io(?:'s)?[^.]{0,70}(?:free tier includes|gives 3 shared|3 shared-cpu VMs)|3 shared-cpu-1x VMs, 160 ?GB|3 shared VMs free|3 shared VMs, 160 ?GB/i,
     replacedBy: /no free tier for new accounts|2 hrs? runtime|2 hours runtime|7-day trial/i,
     vendorRecord: () => recordFor("Fly.io", "Cloud Hosting").description,
+  },
+  {
+    what: "a Sentry free session-replay allowance of 10K",
+    pattern: /10K replays|10,000 (?:session )?replays/i,
+    replacedBy: /50 (?:session )?replays/i,
+    vendorRecord: () => recordFor("Sentry", "Monitoring").description,
+  },
+  {
+    what: "Sentry's free data retention as 90 days",
+    pattern: /Sentry[^.|]{0,60}90 days|90 days[^.|]{0,60}Sentry/i,
+    replacedBy: /30 days/i,
+    vendorRecord: () => recordFor("Sentry", "Monitoring").description,
+  },
+  {
+    what: "a Better Stack free log allowance of 1 GB",
+    pattern: /BetterStack[^.|]{0,40}1 ?GB logs|1 ?GB logs[^.|]{0,40}BetterStack/i,
+    replacedBy: /3 ?GB logs/i,
+    vendorRecord: () => recordFor("BetterStack", "Monitoring").description,
   },
   {
     what: "Railway's $5 Hobby credit described as free",
@@ -213,7 +231,10 @@ describe("hosting pages publish the free-tier figures our records hold (#1183)",
       "Deno Deploy free CPU allowance of 15 hours": ["/hosting-free-tier-comparison-2026", "/serverless-free-tier-comparison-2026", "/heroku-alternatives"],
       "a Koyeb free web service": ["/hosting-free-tier-comparison-2026", "/free-fastapi-stack"],
       "Supabase free egress of 2 GB": ["/database-free-tier-comparison-2026"],
-      "a Fly.io free tier for new accounts": ["/hetzner-pricing-2026", "/free-django-stack", "/railway-vs-render", "/aws-app-runner-migration"],
+      "a Fly.io free tier for new accounts": ["/hetzner-pricing-2026", "/free-django-stack", "/railway-vs-render", "/aws-app-runner-migration", "/free-tier-risk"],
+      "a Sentry free session-replay allowance of 10K": ["/monitoring-comparison-2026"],
+      "Sentry's free data retention as 90 days": ["/monitoring-comparison-2026"],
+      "a Better Stack free log allowance of 1 GB": ["/monitoring-comparison-2026"],
       "Railway's $5 Hobby credit described as free": ["/hetzner-pricing-2026", "/hosting-pricing", "/hosting-alternatives"],
     };
     const missing: string[] = [];

--- a/test/stack-template-free-tiers.test.ts
+++ b/test/stack-template-free-tiers.test.ts
@@ -1,0 +1,131 @@
+import { describe, it, before, after } from "node:test";
+import assert from "node:assert";
+import { spawn, type ChildProcess } from "node:child_process";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { classifyTier } from "../dist/ranking.js";
+import { toSlug } from "../dist/vendor-slug.js";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const root = path.join(__dirname, "..");
+
+const offers = JSON.parse(readFileSync(path.join(root, "data", "index.json"), "utf-8")).offers as Array<Record<string, any>>;
+
+const recordsBySlug = new Map<string, Array<Record<string, any>>>();
+for (const offer of offers) {
+  if (!offer.vendor) continue;
+  const slug = toSlug(offer.vendor);
+  if (!recordsBySlug.has(slug)) recordsBySlug.set(slug, []);
+  recordsBySlug.get(slug)!.push(offer);
+}
+
+const tierClassesFor = (slug: string) =>
+  (recordsBySlug.get(slug) ?? []).map((o) => classifyTier(o.tier ?? "").class);
+
+let server: ChildProcess;
+let base = "";
+
+function startServer(): Promise<ChildProcess> {
+  return new Promise((resolve, reject) => {
+    const proc = spawn("node", [path.join(root, "dist", "serve.js")], {
+      stdio: ["pipe", "pipe", "pipe"],
+      env: { ...process.env, PORT: "0", BASE_URL: "http://localhost", TZ: "UTC" },
+    });
+    const timeout = setTimeout(() => { proc.kill(); reject(new Error("Server startup timeout")); }, 20000);
+    proc.stderr!.on("data", (data: Buffer) => {
+      const match = data.toString().match(/running on http:\/\/localhost:(\d+)/);
+      if (match) { base = `http://localhost:${match[1]}`; clearTimeout(timeout); resolve(proc); }
+    });
+    proc.on("error", (err) => { clearTimeout(timeout); reject(err); });
+  });
+}
+
+type StackRow = { stack: string; vendor: string; slug: string; freeTier: string };
+
+const rows: StackRow[] = [];
+const stackPaths: string[] = [];
+const estimatorVendors: Array<{ slug: string; name: string; free: string }> = [];
+
+describe("a stack that totals $0 names no vendor our catalogue says is paid (#1183 row ten)", () => {
+  before(async () => {
+    server = await startServer();
+
+    const index = await (await fetch(`${base}/stacks`)).text();
+    for (const m of index.matchAll(/href="(\/stacks\/[a-z0-9-]+)"/g)) {
+      if (!stackPaths.includes(m[1])) stackPaths.push(m[1]);
+    }
+
+    for (const stack of stackPaths) {
+      const html = await (await fetch(`${base}${stack}`)).text();
+      for (const m of html.matchAll(
+        /<td class="vendor-name">(?:<a href="\/vendor\/([a-z0-9.-]+)">)?([^<]+)(?:<\/a>)?<span class="free-tier-info">([^<]*)<\/span>/g,
+      )) {
+        rows.push({ stack, vendor: m[2], slug: m[1] ?? toSlug(m[2]), freeTier: m[3] });
+      }
+    }
+
+    const estimate = await (await fetch(`${base}/estimate`)).text();
+    const embedded = estimate.match(/var EST_DATA = (\[[\s\S]*?\]);\n/);
+    assert.ok(embedded, "the estimator no longer embeds its vendor table");
+    for (const category of JSON.parse(embedded![1]) as Array<{ vendors: Array<{ slug: string; name: string; free: string }> }>) {
+      estimatorVendors.push(...category.vendors);
+    }
+  });
+
+  after(() => { server?.kill(); });
+
+  it("reads every stack template, not the one the issue named", () => {
+    assert.ok(stackPaths.length >= 5, `expected the whole stack index, got ${stackPaths.length}`);
+    assert.ok(rows.length >= 30, `expected every service row, got ${rows.length}`);
+  });
+
+  it("puts no vendor in a stack whose own record classifies its tier as anything but free", () => {
+    const paid = rows
+      .filter((r) => {
+        const classes = tierClassesFor(r.slug);
+        return classes.length > 0 && !classes.includes("free");
+      })
+      .map((r) => `${r.stack} totals $0/mo on ${r.vendor}, whose record is ${tierClassesFor(r.slug).join("/")}`);
+    assert.deepStrictEqual(paid.sort(), []);
+  });
+
+  it("states the free tier the vendor's own record states, or says there is none", () => {
+    const silent = rows
+      .filter((r) => !r.freeTier.trim())
+      .map((r) => `${r.stack} states no free tier for ${r.vendor}`);
+    assert.deepStrictEqual(silent, []);
+  });
+
+  it("links no service to a vendor page we do not publish", async () => {
+    const dead: string[] = [];
+    for (const row of rows) {
+      if (!row.slug || !recordsBySlug.has(row.slug)) continue;
+      const res = await fetch(`${base}/vendor/${row.slug}`);
+      if (res.status !== 200) dead.push(`${row.stack} links ${row.vendor} to /vendor/${row.slug} (${res.status})`);
+    }
+    assert.deepStrictEqual(dead.sort(), []);
+  });
+
+  it("leaves a service we hold no record for unlinked rather than pointing at a 404", async () => {
+    const unheld = rows.filter((r) => !recordsBySlug.has(r.slug));
+    for (const row of unheld) {
+      const html = await (await fetch(`${base}${row.stack}`)).text();
+      assert.ok(
+        !html.includes(`href="/vendor/${row.slug}"`),
+        `${row.stack} links ${row.vendor} to a vendor page we do not publish`,
+      );
+    }
+  });
+
+  it("does not offer the cost estimator a free tier for a vendor whose record has none", () => {
+    const wrong = estimatorVendors
+      .filter((v) => {
+        const classes = tierClassesFor(v.slug);
+        if (classes.length === 0 || classes.includes("free")) return false;
+        return !/^(?:None|No free tier)\b/i.test(v.free);
+      })
+      .map((v) => `the estimator offers ${v.name} a free tier of "${v.free}" on a ${tierClassesFor(v.slug).join("/")} record`);
+    assert.deepStrictEqual(wrong.sort(), []);
+  });
+});


### PR DESCRIPTION
Rows ten, eleven and twelve. Every figure below was read at the vendor with `AgentDeals-Reverify/1.0` today, not taken from the issue.

## Rows eleven and twelve — `/monitoring-comparison-2026`

| we published | `sentry.io/pricing` / `betterstack.com/pricing`, 2026-09-05 |
|---|---|
| Sentry `5K errors/mo + 10K replays` | Session Replay, developer column: **50 replays** |
| Sentry log retention `90 days` | Data retention, developer column: **30-day lookback**. `Up to 90-day lookback` is the team column |
| Better Stack `1GB logs` | **3 GB logs retained for 3 days** |
| Better Stack APM / Tracing `✗` | Free includes **3 GB traces retained for 3 days** |

**The sweep found a fourth surface on the same page that the issue did not list.** The Sentry section below the table read *"Free tier (Developer): 5,000 errors/month, 10,000 session replays, 10,000 performance units, 1 user. 90-day retention."* — the same two defects again plus a third: Sentry bills spans, not performance units, and our own record has said `5M spans/month` since August. The site-wide guard is what caught it; a targeted fix to the table row alone would have left it.

The tracing cell was the one the issue was unsure about. `betterstack.com/pricing` lists *Integrated distributed tracing* as a product and the Free plan includes `3 GB traces retained for 3 days`, which is the same thing Grafana Cloud's cell already claims a check for at `50GB traces`. Changed on the vendor's line; our record still does not mention traces, which is a separate gap.

## Row ten — four surfaces, and only one of them was readable

`/stacks/api-first` sold *"production-ready API infrastructure at $0/month"* with `Hosting | Fly.io | 3 shared VMs, 160 GB transfer | $0 | $0 | $15 | $75`. Three things are wrong at once: Fly.io has had **no free tier for new accounts since October 2024**, `fly.io/pricing` is 3,000 characters and contains "free" zero times, and even the legacy allowance is **100 GB transfer**, not 160.

**The hosting row is now Cloudflare Workers.** The alternative was to keep Fly.io and retitle a page whose whole job is to name a stack you can run for nothing. Cloudflare Workers keeps the row's actual argument — edge compute, low latency for API consumers — with a permanent 100K requests/day free allowance and a record that classifies as free. Totals move to $24 / $148 / $755. The page says in its own description that Fly.io held the row until today and why it does not any more.

**`/estimate` and `/budget-builder` shipped the claim inside `<script>`.** No text sweep can see it — my own site-wide sweep reported those two pages clean, the same failure mode as https://github.com/robhunter/agentdeals/issues/1348. The new check parses `EST_DATA` out of the page and compares each vendor's free string against `classifyTier` of that vendor's record.

**That check found one I had not read for.** The estimator offered **Amazon SES** a free tier of `3K messages/mo (from EC2)`, on a record whose own description opens *"No perpetual free tier"*. `/email-comparison-2026` has been saying so for months. Corrected to the $200 of expiring credits.

Fly.io's estimator starter cost is now **$2**, not $0 — `fly.io/docs/about/pricing/` prices `shared-cpu-1x 256MB` at **$2.02/month**, which is the cheapest thing Fly.io sells. Fly.io bills an always-on machine, so unlike SES its cost at zero users is not zero.

`/free-tier-risk` rated Fly.io **medium**, reasoning *"Free tier narrowed — credit-card-required, 3 shared VMs. Still usable"*, dated 2026-01-01. It is a removal, not a narrowing, so it sits at high beside Heroku, dated 2024-10-01. The 2026-01-01 date belongs to the volume-snapshot change we hold a record for, which the new reasoning states separately.

## One live defect found while doing this

**`/stacks/api-first` linked Mailgun to `/vendor/mailgun`, which 404s.** Mailgun is the only one of 30 stack services across all five templates with no catalogue record. Its free plan is real and current — `mailgun.com/pricing` reads `Free — Test us out for $0/mo, 100 emails/day included`, so the row's figure holds — but we publish no profile for it. The renderer now emits the name unlinked when we hold no record, so a recommendation cannot point at a 404. **A Mailgun record is a data gap, not mine to author.**

## What the new check enforces

`test/stack-template-free-tiers.test.ts`, six assertions over all five stacks and all 30 rows:

- no stack that totals $0/mo names a vendor whose record classifies as anything but `free`
- no stack row states an empty free tier
- every linked service resolves to a vendor page
- a service we hold no record for is not linked
- the estimator offers no free tier for a vendor whose record has none

Three mutations, three killed: putting Fly.io back in `api-first`, restoring the estimator's `3 shared VMs, 160 GB transfer`, and making the renderer link unconditionally. Two more against the monitoring literals, both killed. The fourth Sentry surface is the live evidence that the sweep bites — the file did not go green until it was fixed.

## Two things reported, not fixed

- **`/budget-builder` labels Fly.io `risk_level: "stable"`** in the same JSON that now says it has no free tier, because that field comes from the catalogue's risk assessment rather than from `/free-tier-risk`. Two surfaces, one vendor, opposite verdicts — the https://github.com/robhunter/agentdeals/issues/1260 class.
- **The `Free` column of every stack and of the budget builder is a literal `$0`, not a sum.** `totals.free` is computed and never read. It is right today for all five stacks, and it was right for `api-first` yesterday too, which is the point.

## Verification

3,818 tests, 6 new, 0 failures. Sweep of all 2,571 published URLs — text, `<meta content>` and JSON-LD: `160 GB` now appears on no route, `10K replays` on none, Sentry's 90 days only where the Team plan is named.

Refs #1183