### PR TITLE
Refuse a demotion that grants zero of a resource (#1371)

### DIFF
--- a/scripts/change-gate.js
+++ b/scripts/change-gate.js
@@ -21,6 +21,7 @@ export const REJECT_MEASURES_NO_CHANGE = "measures_no_change";
 export const REJECT_MEASURES_THE_OPPOSITE = "measures_the_opposite";
 export const REJECT_STATES_NO_NARROWING = "states_no_narrowing";
 export const REJECT_NO_TERMS_TO_NARROW = "no_terms_to_narrow";
+export const REJECT_ZERO_ALLOWANCE = "zero_allowance";
 
 export const GATE_REASONS = [
   REJECT_NULL_COMPARISON,
@@ -42,6 +43,7 @@ export const GATE_REASONS = [
   REJECT_MEASURES_THE_OPPOSITE,
   REJECT_STATES_NO_NARROWING,
   REJECT_NO_TERMS_TO_NARROW,
+  REJECT_ZERO_ALLOWANCE,
 ];
 
 export const FREE_TIER_REMOVED = "free_tier_removed";
@@ -58,6 +60,7 @@ export function vendorsWhoseFreeTierIsTheProduct(offers = []) {
 }
 
 const QUANTITY_CHANGE_TYPES = ["limits_reduced", "limits_increased"];
+const DEMOTING_QUANTITY_TYPES = ["limits_reduced", "free_tier_removed"];
 
 export const RECLASSIFIED_AS_RESTRUCTURE = "pricing_restructured";
 export const RECLASSIFIED_AS_CORRECTION = "record_corrected";
@@ -258,7 +261,7 @@ export function readQuantities(text) {
       spanOf(durationMatch ? durationMatch[1] : null) ??
       1;
     const period = rate?.period ?? null;
-    read.push({ value: match[0], words, unit, scale, period, spellsAPeriod: match.index < readThrough });
+    read.push({ value: match[0], words, unit, scale, period, at: match.index, spellsAPeriod: match.index < readThrough });
     if (rate) readThrough = start + rate.ends;
   }
   return read;
@@ -266,6 +269,44 @@ export function readQuantities(text) {
 
 export function quantifiedAttributes(text) {
   return readQuantities(text).filter(({ words, spellsAPeriod }) => words.length > 0 && !spellsAPeriod);
+}
+
+export const ALLOWANCE_NOUNS = new Set([
+  "user", "seat", "member", "collaborator", "device", "session",
+  "request", "call", "query", "lookup", "operation", "invocation", "execution",
+  "project", "site", "app", "application", "workspace", "environment", "vault",
+  "repository", "repo", "database", "table", "dataset", "bucket", "container",
+  "instance", "node", "sandbox", "machine", "worker", "runner",
+  "build", "deployment", "deploy", "job", "run", "pipeline", "check", "monitor",
+  "minute", "hour", "credit", "token", "message", "email", "notification",
+  "contact", "subscriber", "record", "row", "document", "image", "video",
+  "domain", "location", "region", "alias", "key", "form", "submission",
+  "event", "replay", "span", "log", "trace", "metric", "view", "page",
+]);
+
+function namedAllowance(quantity) {
+  if (quantity.words.includes(PRICE_ATTRIBUTE)) return null;
+  if (quantity.unit && BYTE_UNITS.has(quantity.unit)) return quantity.unit;
+  return quantity.words.find((word) => ALLOWANCE_NOUNS.has(word)) ?? null;
+}
+
+function labelFor(text, quantity) {
+  const from = text.slice(quantity.at, quantity.at + ATTRIBUTE_WINDOW);
+  const named = namedAllowance(quantity);
+  const beside = from.slice(quantity.value.length);
+  const stops = [beside.search(A_FIGURE), beside.search(CLAUSE_ENDS), beside.search(A_SCOPE)];
+  const fallback = Math.min(...stops.filter((at) => at !== -1), beside.length);
+  const spelled = named ? beside.match(new RegExp(`\\b${named}\\w*`, "i")) : null;
+  const ends = spelled ? Math.min(spelled.index + spelled[0].length, fallback) : fallback;
+  return from.slice(0, quantity.value.length + ends).trim();
+}
+
+export function zeroedAllowances(text) {
+  if (typeof text !== "string") return [];
+  return quantifiedAttributes(text)
+    .filter((quantity) => Number(String(quantity.value).replace(/,/g, "")) === 0)
+    .filter((quantity) => namedAllowance(quantity) !== null)
+    .map((quantity) => ({ ...quantity, label: labelFor(text, quantity) }));
 }
 
 function isAMeasureWord(word) {
@@ -1018,6 +1059,19 @@ export function describesChange(entry, context = {}) {
   }
 
   if (refusedByAudit) return refusedByAudit;
+
+  if (DEMOTING_QUANTITY_TYPES.includes(entry?.change_type)) {
+    const zeroed = zeroedAllowances(entry?.current_state);
+    if (zeroed.length > 0) {
+      const read = zeroed.map(({ label }) => `"${label}"`).join(", ");
+      return {
+        ok: false,
+        reason: REJECT_ZERO_ALLOWANCE,
+        detail: `${entry.change_type} claimed on a state that grants zero of a resource — ${read}. A vendor states a withdrawn allowance by dropping the row, not by publishing a zero, so a literal zero reads as a widget or plan configurator that had not populated when the page was fetched`,
+      };
+    }
+  }
+
   return { ok: true, rewriteSummary: audit.summary ?? undefined };
 }
 

--- a/test/zero-allowance-gate.test.ts
+++ b/test/zero-allowance-gate.test.ts
@@ -1,0 +1,228 @@
+import { describe, it } from "node:test";
+import assert from "node:assert";
+import { readFileSync, mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+process.env.AGENTDEALS_REFUSALS_PATH = path.join(
+  mkdtempSync(path.join(tmpdir(), "refusals-zero-")),
+  "change_refusals.json"
+);
+
+const {
+  describesChange,
+  zeroedAllowances,
+  gateCandidates,
+  GATE_REASONS,
+  REJECT_ZERO_ALLOWANCE,
+} = await import("../scripts/change-gate.js");
+
+const { buildRefusalEntry } = await import("../scripts/change-refusals.js");
+
+const REPO = path.join(import.meta.dirname, "..");
+
+const RECORDED = JSON.parse(
+  readFileSync(path.join(REPO, "data", "deal_changes.json"), "utf-8")
+).changes as Array<Record<string, any>>;
+
+const THE_BATCH_THAT_WAS_REVIEWED = "2026-09-05";
+
+const A_PLAN_CONFIGURATOR_AT_ITS_ZERO_POSITION = {
+  vendor: "Windscribe",
+  change_type: "limits_reduced",
+  date: THE_BATCH_THAT_WAS_REVIEWED,
+  date_source: "discovered",
+  summary:
+    "The free tier now offers 0 GB/month and requires purchasing additional data via location-based subscriptions (10GB per location at $1/month).",
+  previous_state:
+    "10 GB/month free data. 11 server locations. Ad/tracker blocker (R.O.B.E.R.T.). Firewall (kill switch). WireGuard, IKEv2, OpenVPN. Browser extension included. Additional 5 GB for tweeting about them.",
+  current_state: "0 GB/Month 0 Location(s)",
+  impact: "high",
+  source_url: "https://windscribe.com/upgrade",
+  category: "VPN & Privacy",
+};
+
+const A_COUNTER_THAT_NEVER_RESOLVED = {
+  vendor: "Proton Pass",
+  change_type: "limits_reduced",
+  date: THE_BATCH_THAT_WAS_REVIEWED,
+  date_source: "discovered",
+  summary:
+    "The free tier now has limits on vaults (0 vaults) and secure sharing (0 others). The free tier also includes password health alerts and dark web monitoring.",
+  previous_state:
+    "Unlimited logins, notes, and devices. 10 hide-my-email aliases. Integrated 2FA/TOTP. Passkey support. Vault sharing. End-to-end encrypted. Web, browser extension, mobile, and desktop apps. No credit card storage or unlimited aliases on free.",
+  current_state:
+    "Proton Free includes unlimited logins, notes and credit cards, unlimited devices, browser, mobile, and desktop apps, password generator, 10 hide-my-email aliases, alerts for weak and reused passwords, passkeys supported on all devices, and easy password import. It also includes 0 vaults and the ability to share with 0 others.",
+  impact: "medium",
+  source_url: "https://proton.me/pass/pricing",
+  category: "Password Managers",
+};
+
+const AN_UNRENDERED_TEMPLATE_VARIABLE_BESIDE_A_TRUE_CLAIM = {
+  vendor: "MEGA",
+  change_type: "pricing_restructured",
+  date: THE_BATCH_THAT_WAS_REVIEWED,
+  date_source: "discovered",
+  summary: "The transfer quota is now 'Limited' instead of 1 GB replenishing.",
+  previous_state:
+    "20 GB permanent storage. End-to-end encrypted. MEGA Chat. File sharing with encryption. Desktop and mobile sync. 1 GB transfer quota that replenishes. Up to 5 GB additional via achievements (temporary).",
+  current_state: "The free plan offers !{freePlanStorage} storage and limited transfer for €0 forever.",
+  impact: "high",
+  source_url: "https://mega.io/pricing",
+  category: "Cloud Storage",
+};
+
+const A_FEATURE_THAT_MOVED_BEHIND_THE_PAID_PLAN = {
+  vendor: "Phase Two",
+  change_type: "limits_reduced",
+  date: "2026-04-12",
+  date_source: "discovered",
+  summary:
+    "Free tier significantly reduced: users from 1,000 to 100, SSO connections from 10 to 0 (now requires paid Premium tier)",
+  previous_state: "1,000 users, 10 SSO connections",
+  current_state: "100 users, 0 SSO connections (SSO requires $749/month Premium)",
+  impact: "medium",
+  source_url: "https://phasetwo.io/pricing",
+  category: "Authentication",
+};
+
+const WINDSCRIBE_UPGRADE_PAGE = `Windscribe — Build a Plan
+Choose your locations and data. 0 GB/Month 0 Location(s)
+? Unlimited Data + R.O.B.E.R.T
+Build a plan from $1/month per location, or go Pro for $9/month.
+Your old subscription will be cancelled and a partial refund will be applied.`;
+
+describe("a demoting record that grants zero of a resource", () => {
+  it("is refused under a reason the refusals file can carry", () => {
+    assert.ok(GATE_REASONS.includes(REJECT_ZERO_ALLOWANCE));
+  });
+
+  it("refuses the plan configurator read at its zero position, naming the quantity it read", () => {
+    const verdict = describesChange(A_PLAN_CONFIGURATOR_AT_ITS_ZERO_POSITION, {});
+    assert.strictEqual(verdict.ok, false);
+    assert.strictEqual(verdict.reason, REJECT_ZERO_ALLOWANCE);
+    assert.match(verdict.detail, /"0 GB"/);
+    assert.match(verdict.detail, /"0 Location"/);
+  });
+
+  it("refuses the plan table whose counters had not resolved, naming the quantity it read", () => {
+    const verdict = describesChange(A_COUNTER_THAT_NEVER_RESOLVED, {});
+    assert.strictEqual(verdict.ok, false);
+    assert.strictEqual(verdict.reason, REJECT_ZERO_ALLOWANCE);
+    assert.match(verdict.detail, /"0 vaults"/);
+  });
+
+  it("still refuses when the page itself was read and states terms", () => {
+    const verdict = describesChange(A_PLAN_CONFIGURATOR_AT_ITS_ZERO_POSITION, {
+      pageText: WINDSCRIBE_UPGRADE_PAGE,
+      pageComplete: true,
+    });
+    assert.strictEqual(verdict.ok, false);
+    assert.strictEqual(verdict.reason, REJECT_ZERO_ALLOWANCE);
+  });
+
+  it("refuses a withdrawal recorded the same way", () => {
+    const withdrawn = {
+      ...A_PLAN_CONFIGURATOR_AT_ITS_ZERO_POSITION,
+      change_type: "free_tier_removed",
+      summary: "Free data is no longer offered — the page now sells data by location only.",
+    };
+    const verdict = describesChange(withdrawn, {});
+    assert.strictEqual(verdict.ok, false);
+    assert.strictEqual(verdict.reason, REJECT_ZERO_ALLOWANCE);
+  });
+
+  it("writes the refusal where the next reader can check it without re-running the job", async () => {
+    const result = await gateCandidates([A_PLAN_CONFIGURATOR_AT_ITS_ZERO_POSITION]);
+    assert.strictEqual(result.accepted.length, 0);
+    assert.strictEqual(result.rejected.length, 1);
+    const entry = buildRefusalEntry(result.rejected[0], { now: new Date("2026-09-05T14:00:00Z") });
+    assert.strictEqual(entry.vendor, "Windscribe");
+    assert.strictEqual(entry.reason, REJECT_ZERO_ALLOWANCE);
+    assert.strictEqual(entry.current_state, "0 GB/Month 0 Location(s)");
+    assert.strictEqual(entry.source_url, "https://windscribe.com/upgrade");
+    assert.match(entry.detail, /"0 GB"/);
+  });
+});
+
+describe("what the zero rule must not refuse", () => {
+  it("accepts a quantified claim carried beside an unrendered template variable", () => {
+    const verdict = describesChange(AN_UNRENDERED_TEMPLATE_VARIABLE_BESIDE_A_TRUE_CLAIM, {});
+    assert.strictEqual(verdict.ok, true, JSON.stringify(verdict));
+    assert.deepStrictEqual(
+      zeroedAllowances(AN_UNRENDERED_TEMPLATE_VARIABLE_BESIDE_A_TRUE_CLAIM.current_state),
+      []
+    );
+  });
+
+  it("reads a zero price as the point of a free tier rather than an allowance", () => {
+    assert.deepStrictEqual(zeroedAllowances("Free forever. $0/month for 5 users."), []);
+    assert.deepStrictEqual(zeroedAllowances("The free plan costs €0 and includes 3 projects."), []);
+  });
+
+  it("accepts a feature moved behind the paid plan beside an allowance that still stands", () => {
+    const verdict = describesChange(A_FEATURE_THAT_MOVED_BEHIND_THE_PAID_PLAN, {});
+    assert.strictEqual(verdict.ok, true, JSON.stringify(verdict));
+    assert.deepStrictEqual(
+      zeroedAllowances(A_FEATURE_THAT_MOVED_BEHIND_THE_PAID_PLAN.current_state),
+      []
+    );
+  });
+
+  it("leaves a clock reading alone", () => {
+    assert.deepStrictEqual(
+      zeroedAllowances("100,000 reads/day and 1 GB stored. All limits reset daily at 00:00 UTC."),
+      []
+    );
+  });
+
+  it("says nothing about a record that is not demoting", () => {
+    const increased = { ...A_PLAN_CONFIGURATOR_AT_ITS_ZERO_POSITION, change_type: "limits_increased" };
+    assert.notStrictEqual(describesChange(increased, {}).reason, REJECT_ZERO_ALLOWANCE);
+  });
+});
+
+describe("the batch this rule was written against", () => {
+  const batch = RECORDED.filter((change) => change.date === THE_BATCH_THAT_WAS_REVIEWED);
+
+  it("holds the records the rule was measured over", () => {
+    assert.ok(batch.length >= 26, `${batch.length} records dated ${THE_BATCH_THAT_WAS_REVIEWED}`);
+  });
+
+  it("refuses the two read from a page that had not rendered and nothing else in the batch", () => {
+    const refused = batch
+      .filter((change) => describesChange(change, {}).reason === REJECT_ZERO_ALLOWANCE)
+      .map((change) => change.vendor)
+      .sort();
+    assert.deepStrictEqual(refused, ["Proton Pass", "Windscribe"]);
+  });
+
+  it("leaves every other verdict in the batch as it found it", () => {
+    const refusals: Record<string, string> = {};
+    for (const change of batch) {
+      const verdict = describesChange(change, {});
+      if (!verdict.ok) refusals[change.vendor] = verdict.reason;
+    }
+    assert.deepStrictEqual(refusals, {
+      MEGA: "states_no_terms",
+      "Proton Pass": REJECT_ZERO_ALLOWANCE,
+      Windscribe: REJECT_ZERO_ALLOWANCE,
+    });
+    assert.strictEqual(
+      batch.filter((change) => describesChange(change, {}).ok).length,
+      batch.length - 3
+    );
+  });
+});
+
+describe("the published change log", () => {
+  it("carries no standing record this rule would refuse", () => {
+    const standing = RECORDED.filter((change) => change.resolution?.state !== "retracted").filter(
+      (change) => describesChange(change, {}).reason === REJECT_ZERO_ALLOWANCE
+    );
+    assert.deepStrictEqual(
+      standing.map((change) => `${change.vendor} ${change.date}`),
+      []
+    );
+  });
+});


### PR DESCRIPTION
Refs #1371.

Three of the 26 changes recorded on 2026-09-05 demoted a vendor on text the vendor's page never rendered. The data was retracted in #1370; this is the gate gap.

## What the gate does now

`scripts/change-gate.js` refuses a `limits_reduced` or `free_tier_removed` record whose `current_state` grants zero of a resource, under a new reason code `zero_allowance`, quoting the quantity it read:

```
✗ Windscribe (limits_reduced) describes no change [zero_allowance]:
  limits_reduced claimed on a state that grants zero of a resource — "0 GB", "0 Location".
  A vendor states a withdrawn allowance by dropping the row, not by publishing a zero, so a
  literal zero reads as a widget or plan configurator that had not populated when the page
  was fetched
```

It is built on the gate's own `readQuantities` parser rather than a standalone regex, so notation, magnitude and rate handling stay shared with the rest of the gate. A quantity counts as an allowance when its unit is a byte unit or one of its attribute words is an allowance noun. The price attribute is excluded — `$0` is what a free plan costs, and 26 of the 28 zeros the parser finds in demoting records are exactly that.

## Zero alone is not the discriminator

The issue proposes the rule on the reasoning that "a free tier that offers literally zero of a resource is a free tier that was removed". A record in the corpus contradicts that.

**Phase Two**, `limits_reduced`, 2026-04-12:

- previous: `1,000 users, 10 SSO connections`
- current: `100 users, 0 SSO connections (SSO requires $749/month Premium)`

That is a correct, coherent, quantified record. A feature moved behind the paid plan; the tier's own allowance still stands at 100 users. It is structurally identical to Windscribe — a dimension the stored state quantified as non-zero now reads zero — so no rule keyed on the shape of the comparison separates them. The issue's regex misses it only because `connections` is not in its unit list.

What separates them is what the zero is *of*: a consumable allowance, or a feature. That is a vocabulary judgement and this PR makes it explicit rather than incidental. **Phase Two is pinned as a fixture that must be accepted**, so widening the vocabulary to feature nouns turns the suite red — the same protective role MEGA plays for artifact tokens. `connection` is deliberately absent for that reason.

## Measurement

Over all 553 records in `data/deal_changes.json`, applying the rule to every record regardless of type:

| detector | matches |
|---|---|
| any zero quantified attribute | 28 — 26 of them `$0` |
| minus the price attribute | 8, incl. `00:00 UTC` on Cloudflare KV |
| zero of a named allowance (this PR) | **2 — Windscribe and Proton Pass** |

Two mechanistic alternatives were tested and rejected: requiring two or more zeroed allowances catches Windscribe but not Proton Pass (`0 others` is dropped by the parser's stopwords, leaving one zero); requiring the zero to have no non-zero baseline catches Proton Pass but not Windscribe, whose stored state does carry `10 GB/month`.

## Tests

`test/zero-allowance-gate.test.ts`, 15 tests:

- Windscribe and Proton Pass replayed as fixtures, each refused under the code, each detail naming the quantity read as zero
- MEGA replayed **as the gate saw it before #1370 repaired the field** — `!{freePlanStorage}` and `€0` intact — and asserted accepted, with `zeroedAllowances` empty on it
- Phase Two asserted accepted
- a `free_tier_removed` record with the same evidence asserted refused
- the full 2026-09-05 batch read out of `data/deal_changes.json`: the set refused under this code is exactly `["Proton Pass", "Windscribe"]`, and the batch's whole vendor→reason map is asserted, so any collateral change to the other records fails
- an invariant over the published log: no standing (non-retracted) record may be one this rule would refuse
- `$0`, `€0` and `00:00 UTC` asserted not to be allowances

3,833 tests pass locally, 15 new. 13 mutations, 12 killed; the survivor swaps `quantifiedAttributes` for `readQuantities`, which I measured as producing identical output on all 1,659 record fields — `namedAllowance` already subsumes the filter, so it is redundancy rather than an untested guard.

## Verified end to end

Ran the real `runAiMode` path against a Windscribe page fixture with the recorded detection. No entry reaches `deal_changes.json`; the refusal is written to `change_refusals.json` with the same fields as the existing twelve including `refused_date`, and the run summary reports `refused as zero_allowance: Windscribe`.

## Notes

- The 2026-09-05 batch holds **27** records, not 26 — `Storyblok` (`record_corrected`) is in it.
- AC-5, ipinfo.io, is answered on the issue with its own measurement.