### PR TITLE
Read Mistral's rate off the page the record cites (#1372)

### DIFF
--- a/data/index.json
+++ b/data/index.json
@@ -2966,7 +2966,7 @@
     {
       "vendor": "Mistral AI",
       "category": "AI / ML",
-      "description": "Access to all Mistral models including Large, Codestral, Pixtral — 2 RPM, 1B tokens/month. No credit card required",
+      "description": "Free plan includes $10/mo in API credits and access to Mistral models in Studio, alongside limited messages, web searches and coding sessions. Paid API rates start at $0.5/M input and $1.5/M output tokens for Mistral Large; batch processing halves the price and cached input tokens cost up to 90% less.",
       "tier": "Experiment",
       "url": "https://mistral.ai/pricing",
       "tags": [
@@ -2977,7 +2977,7 @@
         "code",
         "free tier"
       ],
-      "verifiedDate": "2026-08-20",
+      "verifiedDate": "2026-09-05",
       "payment_protocols": [
         {
           "protocol": "x402",
@@ -2988,9 +2988,9 @@
         }
       ],
       "source_check": {
-        "checked": "2026-09-03",
+        "checked": "2026-09-05",
         "outcome": "ok",
-        "detail": "text"
+        "detail": "the page names the plan \"Free\" and states \"$10 /mo in API credits\", and states \"Mistral Large costs $0.5 /M tokens in and $1.5 /M tokens out\""
       },
       "product_subtypes": {
         "taxonomy": "AI / ML",

--- a/data/quality_budgets.json
+++ b/data/quality_budgets.json
@@ -4,7 +4,7 @@
     "stale_fact_pages": 57,
     "unsourced_tier_a": 43,
     "uncited_change_records": 95,
-    "source_checks_ok_without_quoted_evidence": 615,
+    "source_checks_ok_without_quoted_evidence": 614,
     "faq_answers": 166,
     "faq_answers_stating_a_figure": 77,
     "faq_answers_with_a_digit_but_no_figure": 40


### PR DESCRIPTION
Groundwork for https://github.com/robhunter/agentdeals/issues/1372 — that issue renders the provider tables' rate cells from the record, so the record has to carry a sourced rate first.

## What changed

`Mistral AI`, `data/index.json`:

- **description** — replaced with what `mistral.ai/pricing` states. The old text ("2 RPM, 1B tokens/month. No credit card required") is absent from the URL the record cites: zero occurrences of `Experiment`, `RPM`, `1B tokens` or `credit card` in the served bytes, checked with a browser UA against raw HTML.
- **source_check** — `detail: "text"` replaced with the two quoted sentences the check read.
- **verifiedDate** — 2026-08-20 → 2026-09-05.

## The figure

> Mistral Large costs $0.5 /M tokens in and $1.5 /M tokens out.

Verbatim from `mistral.ai/pricing`. Three hardcoded arrays in `src/serve.ts` publish `$2/$6 (Large)` — four times the rate, both directions. Those are #1372's to fix and this PR does not touch them.

## Not changed

`tier` stays `"Experiment"`. It is as unsupported as the description was, but Mistral is the only record carrying the string and `test/tier-vocabulary.json` pins it, so changing it turns `tier-vocabulary.test.ts` red without a matching fixture edit. That is not a data change.

## Ratchet

`source_checks_ok_without_quoted_evidence` 615 → 614, lowered in `data/quality_budgets.json`. Nothing over. `tier-vocabulary.test.ts` 4/4.