### PR TITLE
Render the AI provider tables from the record their slug names (#1372)

### DIFF
--- a/data/index.json
+++ b/data/index.json
@@ -2967,7 +2967,7 @@
       "vendor": "Mistral AI",
       "category": "AI / ML",
       "description": "Free plan includes $10/mo in API credits and access to Mistral models in Studio, alongside limited messages, web searches and coding sessions. Paid API rates start at $0.5/M input and $1.5/M output tokens for Mistral Large; batch processing halves the price and cached input tokens cost up to 90% less.",
-      "tier": "Experiment",
+      "tier": "Free",
       "url": "https://mistral.ai/pricing",
       "tags": [
         "ai",

--- a/data/page-reviews.json
+++ b/data/page-reviews.json
@@ -1623,9 +1623,9 @@
       "reviewer": null,
       "review_outcome": null,
       "review_note": null,
-      "reads_index": false,
+      "reads_index": true,
       "reads_changes": true,
-      "data_source": "unsourced",
+      "data_source": "catalogue",
       "data_source_reason": null
     },
     {
@@ -1673,9 +1673,9 @@
       "reviewer": null,
       "review_outcome": null,
       "review_note": null,
-      "reads_index": false,
+      "reads_index": true,
       "reads_changes": true,
-      "data_source": "unsourced",
+      "data_source": "catalogue",
       "data_source_reason": null
     },
     {

--- a/data/quality_budgets.json
+++ b/data/quality_budgets.json
@@ -2,7 +2,7 @@
   "version": 1,
   "budgets": {
     "stale_fact_pages": 57,
-    "unsourced_tier_a": 43,
+    "unsourced_tier_a": 41,
     "uncited_change_records": 95,
     "source_checks_ok_without_quoted_evidence": 614,
     "faq_answers": 166,

--- a/scripts/mutate-1372.sh
+++ b/scripts/mutate-1372.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+set -uo pipefail
+cd "$(dirname "$0")/.."
+
+TESTS="test/model-rates.test.ts test/assistants-provider-tables.test.ts"
+KILLED=0
+SURVIVED=0
+
+run_mutation() {
+  local label="$1" file="$2" from="$3" to="$4"
+  cp "$file" /tmp/mutate-1372-backup
+  python3 - "$file" "$from" "$to" <<'PY'
+import sys
+path, frm, to = sys.argv[1], sys.argv[2], sys.argv[3]
+s = open(path, encoding="utf-8").read()
+n = s.count(frm)
+if n != 1:
+    print(f"SKIP: pattern appears {n} times", file=sys.stderr)
+    sys.exit(3)
+open(path, "w", encoding="utf-8").write(s.replace(frm, to))
+PY
+  local applied=$?
+  if [ $applied -ne 0 ]; then
+    cp /tmp/mutate-1372-backup "$file"
+    printf '  %-58s NOT APPLIED\n' "$label"
+    return
+  fi
+  ./node_modules/.bin/tsc > /tmp/mutate-1372-tsc 2>&1
+  if [ $? -ne 0 ]; then
+    printf '  %-58s killed (does not compile)\n' "$label"
+    KILLED=$((KILLED + 1))
+  else
+    node --test --test-concurrency 1 $TESTS > /tmp/mutate-1372-out 2>&1
+    if [ $? -ne 0 ]; then
+      printf '  %-58s killed by %s\n' "$label" "$(grep -oE '^  ✖ .*\(' /tmp/mutate-1372-out | head -1 | sed 's/^  ✖ //; s/ ($//')"
+      KILLED=$((KILLED + 1))
+    else
+      printf '  %-58s SURVIVED\n' "$label"
+      SURVIVED=$((SURVIVED + 1))
+    fi
+  fi
+  cp /tmp/mutate-1372-backup "$file"
+  ./node_modules/.bin/tsc > /dev/null 2>&1
+}
+
+echo "── mutations of the provider-table rendering ──"
+
+run_mutation "retired row keeps its stability rating" src/serve.ts \
+  'stability: retired ? ENDED_BADGE_LABEL : stability,' \
+  'stability: stability,'
+
+run_mutation "tier cell reverts to a literal" src/serve.ts \
+  'tier: record ? record.tier : "Not in our index",' \
+  'tier: "Free (rate-limited)",'
+
+run_mutation "a rate literal returns to a row array" src/serve.ts \
+  '{ name: "Anthropic Claude", slug: "anthropic-api", toolUse: "Native tool use", codeExec: "Computer use, code execution", bestFor: "Best reasoning, long context" },' \
+  '{ name: "Anthropic Claude", slug: "anthropic-api", toolUse: "Native tool use", codeExec: "Computer use, code execution", bestFor: "Best reasoning, $3/$15 (Sonnet)" },'
+
+run_mutation "rate cell prints a figure of its own" src/serve.ts \
+  'rateCell: span ? escHtmlServer(`${span} per MTok`) : pricingLink,' \
+  'rateCell: escHtmlServer("$3/$15 per MTok"),'
+
+run_mutation "a retired record is still asked for rates" src/model-rates.ts \
+  'if (!offer || offerRetired(offer)) return [];' \
+  'if (!offer) return [];'
+
+run_mutation "the free-tier count stops reading the tier class" src/serve.ts \
+  'const tierClass = classifyTier(record.tier).class;
+    return tierClass === "free" || tierClass === "time_limited";' \
+  'return true;'
+
+run_mutation "an input-only rate is published as a pair" src/model-rates.ts \
+  'return rate.model ? `${rate.input} (${rate.model}, input only)` : `${rate.input} (input only)`;' \
+  'return rate.model ? `${rate.input}/${rate.input} (${rate.model})` : `${rate.input}/${rate.input}`;'
+
+echo "── mutations of the rate reader ──"
+
+run_mutation "split input/output clauses stop being read" src/model-rates.ts \
+  '  scan(SPLIT, m => ({ input: `$${m[1]}`, output: `$${m[2]}` }));' \
+  '  void SPLIT;'
+
+run_mutation "a span never reaches its dearest end" src/model-rates.ts \
+  '  return [cheapest, dearest];' \
+  '  return [cheapest];'
+
+run_mutation "the amount swallows trailing punctuation" src/model-rates.ts \
+  'const AMOUNT = String.raw`\$(\d{1,3}(?:,\d{3})*(?:\.\d+)?)`;' \
+  'const AMOUNT = String.raw`\$(\d[\d.,]*)`;'
+
+run_mutation "a version dot ends a trailing model name" src/model-rates.ts \
+  '(?=\.(?!\d)|[,;:)]|\s*$)' \
+  '(?=[.,;:)]|\s*$)'
+
+run_mutation "the monthly bill drops the output tokens" src/model-rates.ts \
+  'return amountValue(rate.input) * millionsIn + amountValue(rate.output) * millionsOut;' \
+  'return amountValue(rate.input) * millionsIn;'
+
+run_mutation "cheapest and dearest swap" src/model-rates.ts \
+  'return amountValue(a.input) - amountValue(b.input);' \
+  'return amountValue(b.input) - amountValue(a.input);'
+
+run_mutation "a name is taken without checking it is one" src/model-rates.ts \
+  '  return acceptableName(afterLastClauseBreak(stripTail(prefix)));' \
+  '  return afterLastClauseBreak(stripTail(prefix)) || null;'
+
+run_mutation "an ambiguous slug resolves to its first record" src/model-rates.ts \
+  '  return matches.length === 1 ? matches[0] : null;' \
+  '  return matches[0] ?? null;'
+
+run_mutation "a retired offer's tier stops being consulted" src/model-rates.ts \
+  'export function publishableRates(offer: Pick<Offer, "tier" | "description"> | null): ModelRate[] {' \
+  'export function publishableRates(offer: Pick<Offer, "description"> | null): ModelRate[] {'
+
+echo
+echo "killed ${KILLED}, survived ${SURVIVED}"

--- a/src/model-rates.ts
+++ b/src/model-rates.ts
@@ -1,0 +1,168 @@
+import { loadOffers } from "./data.js";
+import { toSlug } from "./slug.js";
+import { offerRetired } from "./retirement.js";
+import type { Offer } from "./types.js";
+
+export interface ModelRate {
+  model: string | null;
+  input: string;
+  output: string | null;
+}
+
+const AMOUNT = String.raw`\$(\d{1,3}(?:,\d{3})*(?:\.\d+)?)`;
+const PAIRED = new RegExp(`${AMOUNT}\\s*/\\s*${AMOUNT}`, "g");
+const SPLIT = new RegExp(`${AMOUNT}\\s*/\\s*1?M\\s+input[^.$]{0,40}?${AMOUNT}\\s*/\\s*1?M\\s+output`, "g");
+const INPUT_ONLY = new RegExp(`${AMOUNT}\\s*/\\s*1?M\\s+input`, "g");
+
+const CONNECTORS = new Set([
+  "at", "from", "is", "are", "was", "costs", "cost", "start", "starts", "starting",
+  "of", "for", "to", "priced", "and", "or", "then", "up", "only", "about", "around",
+  "roughly", "approximately", "remains", "stays", "in",
+]);
+
+const NOT_A_MODEL = new Set([
+  "rate", "rates", "price", "prices", "pricing", "tier", "tiers", "api", "apis",
+  "token", "tokens", "cost", "costs", "model", "models", "plan", "plans", "access",
+  "use", "usage", "paid", "free", "batch", "context", "discount", "credits", "credit",
+  "inference", "platform", "limits", "month", "lineup", "tools", "tool",
+]);
+
+const CLAUSE_BREAKS = [". ", ", ", "; ", ": ", " — ", " – ", " (", ") "];
+
+function stripTail(text: string): string {
+  let s = text.replace(/\s+$/, "");
+  for (;;) {
+    const before = s;
+    s = s.replace(/\([^()]*\)$/, "").replace(/[\s:\u2014\u2013\-=,]+$/, "");
+    const word = s.match(/([A-Za-z]+)$/);
+    if (word && CONNECTORS.has(word[1].toLowerCase())) s = s.slice(0, s.length - word[1].length);
+    if (s === before) return s;
+  }
+}
+
+function afterLastClauseBreak(text: string): string {
+  let cut = 0;
+  for (const brk of CLAUSE_BREAKS) {
+    const at = text.lastIndexOf(brk);
+    if (at >= 0) cut = Math.max(cut, at + brk.length);
+  }
+  return text.slice(cut);
+}
+
+function acceptableName(candidate: string): string | null {
+  let name = candidate.replace(/^[\s"'\u201c]+|[\s"'\u201d]+$/g, "");
+  for (;;) {
+    const word = name.match(/([A-Za-z]+)$/);
+    if (!word || !NOT_A_MODEL.has(word[1].toLowerCase())) break;
+    name = name.slice(0, name.length - word[1].length).replace(/[\s\-:]+$/, "");
+  }
+  if (!name || name.length > 44) return null;
+  if (!/^[A-Za-z0-9]/.test(name)) return null;
+  if (!/[A-Za-z]/.test(name)) return null;
+  if (/[$%]/.test(name)) return null;
+  return name;
+}
+
+function nameBefore(prefix: string): string | null {
+  return acceptableName(afterLastClauseBreak(stripTail(prefix)));
+}
+
+function nameAfter(suffix: string): string | null {
+  const named = suffix.match(/^\s*(?:tokens?\s+)?for\s+([A-Za-z0-9][A-Za-z0-9.\- ]*?)(?=\.(?!\d)|[,;:)]|\s*$)/);
+  return named ? acceptableName(named[1]) : null;
+}
+
+export function readModelRates(description: string | null | undefined): ModelRate[] {
+  if (!description) return [];
+  const claimed: Array<[number, number]> = [];
+  const found: Array<ModelRate & { at: number }> = [];
+
+  const scan = (re: RegExp, toRate: (m: RegExpExecArray) => { input: string; output: string | null }) => {
+    re.lastIndex = 0;
+    let m: RegExpExecArray | null;
+    while ((m = re.exec(description)) !== null) {
+      const start = m.index;
+      const end = start + m[0].length;
+      if (claimed.some(([s, e]) => start < e && end > s)) continue;
+      claimed.push([start, end]);
+      const model = nameAfter(description.slice(end, end + 60)) ?? nameBefore(description.slice(0, start));
+      found.push({ model, at: start, ...toRate(m) });
+    }
+  };
+
+  scan(SPLIT, m => ({ input: `$${m[1]}`, output: `$${m[2]}` }));
+  scan(PAIRED, m => ({ input: `$${m[1]}`, output: `$${m[2]}` }));
+  scan(INPUT_ONLY, m => ({ input: `$${m[1]}`, output: null }));
+
+  return found
+    .sort((a, b) => a.at - b.at)
+    .map(({ model, input, output }) => ({ model, input, output }));
+}
+
+export function amountValue(amount: string): number {
+  return Number(amount.replace(/[$,]/g, ""));
+}
+
+export function soleMatch<T extends { vendor: string }>(offers: T[], slug: string): T | null {
+  const matches = offers.filter(o => toSlug(o.vendor) === slug);
+  return matches.length === 1 ? matches[0] : null;
+}
+
+export function offerForSlug(slug: string): Offer | null {
+  return soleMatch(loadOffers(), slug);
+}
+
+export function publishableRates(offer: Pick<Offer, "tier" | "description"> | null): ModelRate[] {
+  if (!offer || offerRetired(offer)) return [];
+  return readModelRates(offer.description);
+}
+
+export function vendorRates(slug: string): ModelRate[] {
+  return publishableRates(offerForSlug(slug));
+}
+
+function byInputRate(a: ModelRate, b: ModelRate): number {
+  return amountValue(a.input) - amountValue(b.input);
+}
+
+export function cheapestRate(rates: ModelRate[]): ModelRate | null {
+  return rates.length ? [...rates].sort(byInputRate)[0] : null;
+}
+
+export function dearestRate(rates: ModelRate[]): ModelRate | null {
+  return rates.length ? [...rates].sort(byInputRate)[rates.length - 1] : null;
+}
+
+export function spanOfRates(rates: ModelRate[]): ModelRate[] {
+  const cheapest = cheapestRate(rates);
+  const dearest = dearestRate(rates);
+  if (!cheapest) return [];
+  if (!dearest || sameFigures(cheapest, dearest)) return [cheapest];
+  return [cheapest, dearest];
+}
+
+export function sameFigures(a: ModelRate, b: ModelRate): boolean {
+  return a.input === b.input && a.output === b.output;
+}
+
+export function formatRate(rate: ModelRate): string {
+  if (rate.output === null) {
+    return rate.model ? `${rate.input} (${rate.model}, input only)` : `${rate.input} (input only)`;
+  }
+  return rate.model ? `${rate.input}/${rate.output} (${rate.model})` : `${rate.input}/${rate.output}`;
+}
+
+export function formatRateSpan(rates: ModelRate[]): string | null {
+  const span = spanOfRates(rates);
+  if (!span.length) return null;
+  return span.map(formatRate).join(" – ");
+}
+
+export function monthlyTokenCost(rate: ModelRate, millionsIn: number, millionsOut: number): number | null {
+  if (rate.output === null) return null;
+  return amountValue(rate.input) * millionsIn + amountValue(rate.output) * millionsOut;
+}
+
+export function formatDollars(value: number): string {
+  return `$${Math.round(value).toLocaleString("en-US")}`;
+}

--- a/src/serve.ts
+++ b/src/serve.ts
@@ -43,19 +43,20 @@ import { configureDurableBackend, hydrateDurableStores, persistDurableStores, id
 import { addFriend, removeFriend, getFriends, getFriendCodesForVendors } from "./friends.js";
 import { subscribe as watchlistSubscribe, getSubscription as getWatchlistSubscription, unsubscribe as watchlistUnsubscribe, listSubscriptions as listWatchlistSubscriptions } from "./watchlist.js";
 import { toSlug, vendorSlugMap, resolveVendorSlug, namedVendorSlug } from "./vendor-slug.js";
+import { offerForSlug, vendorRates, cheapestRate, dearestRate, spanOfRates, formatRate, formatRateSpan, monthlyTokenCost, formatDollars, type ModelRate } from "./model-rates.js";
 import { STALE_FACT_PAGES_BASELINE, factsOutdatedBy, linkifyVerdictBlocks, newestChangeBySlug, overdueReport, pageCompiledClause, pageDataProvenance, pageDateModified, pageFreshness, pageFreshnessSentence, utcToday, verdictsOutdatedBy } from "./page-reviews.js";
 import { faqPageJsonLd, type FaqItem } from "./faq-provenance.js";
 import { SSE_KEEPALIVE_FRAME, keepaliveIntervalMs, sessionRecoveryBody } from "./mcp-stream.js";
 import { ASSISTANTS_API_SHUTDOWN } from "./assistants-shutdown.js";
 import { discontinuedOnOrBefore, PRODUCT_DEPRECATED } from "./product-deprecation.js";
-import { rankOffers, rankForListing, rotateListing, utcDate, gateFor, notAFreeOfferGateFor, descriptionDeniesFreeTier, CRITERIA_PATH, DEMOTE_ONLY_POLICY, DISCLOSURE_RATIONALE, TIE_BREAK_ALGORITHM, GATE_TABLE, DEMERIT_TABLE, NOT_FREE_TIER_RULES, TIME_LIMITED_TIER_RULES, type TieBreak, type Gate } from "./ranking.js";
+import { rankOffers, rankForListing, rotateListing, utcDate, gateFor, notAFreeOfferGateFor, descriptionDeniesFreeTier, classifyTier, CRITERIA_PATH, DEMOTE_ONLY_POLICY, DISCLOSURE_RATIONALE, TIE_BREAK_ALGORITHM, GATE_TABLE, DEMERIT_TABLE, NOT_FREE_TIER_RULES, TIME_LIMITED_TIER_RULES, type TieBreak, type Gate } from "./ranking.js";
 import type { RankedEntry, RankingResult } from "./ranking.js";
 import { eligibilityGateAsPublished, gatedShareDescriptionClause, gatedShareLede, publishableEligibilityConditions } from "./eligibility.js";
 import { gateDisclosureFor } from "./gate-disclosure.js";
 import { verificationLedger, QUARANTINE_AFTER_FAILURES } from "./verification-state.js";
 import { partitionAlternatives, partitionSubstitutes, type SubstitutesPartition, productRoleSentence, MEMBERSHIP_GATE_RULES, MEMBERSHIP_GATE_ORDER, MEMBERSHIP_GATE_SYMMETRY, MEMBERSHIP_GATE_SCOPE, MEMBERSHIP_GATE_CORRECTIONS, SUBTYPE_TAXONOMIES, SUBTYPE_MEMBERSHIP_RULE, SUBTYPE_MEMBERSHIP_GROUP_SCOPE, CURATED_SUBTYPE_EXEMPTION, membershipGroupsFor, subtypeDefinition } from "./product-role.js";
 import { resolveCuratedAlternatives, curatedAlternativesFor, addCuratedToPool } from "./curated-alternatives.js";
-import type { Agent, ChangeDateSource, DealChange, RiskCause, RatingWithheld, LinkUnreachable, Offer } from "./types.js";
+import type { Agent, ChangeDateSource, DealChange, RiskCause, RatingWithheld, LinkUnreachable, Offer, StabilityClass } from "./types.js";
 import { changeDateLabel, changeDateClause, changeDatePublished, changeEventStartDate, capListSections, latestEventDate, offerExpiryAfter, feedEntryUpdated, undatedGroupHeading, firstReadHeading, discoveryBatchNote, isoWeekOf, DISCOVERED_DATE_PREFIX, UNDATED_GROUP_NOTE } from "./change-dates.js";
 import { FEED_CORRECTIONS, correctionEntriesXml } from "./feed-corrections.js";
 import { buildDay, emptyPageLastmod, fallbackDay, httpDate, lastmodFor, newestLastmod, readPageLastmod, type PageLastmodLedger } from "./page-lastmod.js";
@@ -18780,7 +18781,7 @@ function buildGoogleDeveloperProgram2026Page(): string {
     { vendor: "Groq", free: "30 RPM, 100K-500K tokens/day", models: "Llama 3, Mixtral, Gemma", link: "/vendor/groq" },
     { vendor: "OpenRouter", free: "Free models available", models: "100+ models aggregated", link: "/vendor/openrouter" },
     { vendor: "Cerebras", free: "Free tier available", models: "Llama 3, fast inference", link: "/vendor/cerebras" },
-    { vendor: "Mistral AI", free: "Experiment tier", models: "Mistral, Mixtral, Codestral", link: "/vendor/mistral-ai" },
+    { vendor: "Mistral AI", free: "Free plan, $10/mo API credits", models: "Mistral, Mixtral, Codestral", link: "/vendor/mistral-ai" },
     { vendor: "GitHub Models", free: "Free for GitHub users", models: "GPT-4o, Llama, Phi, Mistral", link: "/vendor/github-models" },
     { vendor: "Cohere", free: "Trial key available", models: "Command, Embed, Rerank", link: "/vendor/cohere" },
   ];
@@ -23174,6 +23175,47 @@ ${mcpCtaCss()}
 </html>`;
 }
 
+function joinWithAnd(items: string[]): string {
+  if (items.length <= 1) return items[0] ?? "";
+  return `${items.slice(0, -1).join(", ")} and ${items[items.length - 1]}`;
+}
+
+const RECORD_ENDED_COLOR = "#8b949e";
+const RESPONSES_TOOL_PRICES_URL = "https://developers.openai.com/api/docs/pricing";
+const RESPONSES_TOOL_PRICES_READ = "2026-09-05";
+
+interface ProviderRecordCells {
+  tier: string;
+  tierColor: string;
+  stability: string;
+  stabilityColor: string;
+  rateCell: string;
+  rates: ModelRate[];
+  retired: boolean;
+}
+
+function providerRecordCells(slug: string, stabilityMap: Map<string, StabilityClass>): ProviderRecordCells {
+  const record = offerForSlug(slug);
+  const retired = offerRetired(record);
+  const rates = vendorRates(slug);
+  const span = formatRateSpan(rates);
+  const stability = stabilityMap.get(slug) ?? "stable";
+  const pricingLink = record && !retired
+    ? `&mdash; <a href="${escHtmlServer(record.url)}" target="_blank" rel="noopener nofollow">vendor pricing</a>`
+    : "&mdash;";
+  return {
+    tier: record ? record.tier : "Not in our index",
+    tierColor: retired ? RECORD_ENDED_COLOR : /free/i.test(record?.tier ?? "") ? "#3fb950" : "var(--accent)",
+    stability: retired ? ENDED_BADGE_LABEL : stability,
+    stabilityColor: retired
+      ? RECORD_ENDED_COLOR
+      : stability === "volatile" ? "#f85149" : stability === "watch" ? "#d29922" : stability === "improving" ? "#3fb950" : "var(--text-dim)",
+    rateCell: span ? escHtmlServer(`${span} per MTok`) : pricingLink,
+    rates,
+    retired,
+  };
+}
+
 function buildOpenaiAssistantsAlternativesPage(): string {
   const title = "OpenAI Assistants API Sunset: Free Alternatives & Migration Guide for AI Agent Builders";
   const metaDesc = "OpenAI Assistants API shuts down August 26, 2026. Compare migration paths: Responses API, Claude, Gemini, open-source frameworks. Free tier comparison for 10+ AI API providers with stability ratings.";
@@ -23195,7 +23237,6 @@ function buildOpenaiAssistantsAlternativesPage(): string {
   interface AiProvider {
     name: string;
     slug: string;
-    freeTier: string;
     toolUse: string;
     codeExec: string;
     fileHandling: string;
@@ -23203,18 +23244,18 @@ function buildOpenaiAssistantsAlternativesPage(): string {
   }
 
   const providers: AiProvider[] = [
-    { name: "OpenAI (Responses API)", slug: "openai", freeTier: "Pay-per-use only", toolUse: "Native (function calling)", codeExec: "Code interpreter tool", fileHandling: "File search tool", bestFor: "Direct migration — least code changes" },
-    { name: "Anthropic Claude API", slug: "anthropic-api", freeTier: "Pay-per-use ($5/$25 MTok)", toolUse: "Native (tool use)", codeExec: "Computer use, code execution", fileHandling: "PDF + document processing", bestFor: "Best reasoning, long context (200K)" },
-    { name: "Google Gemini API", slug: "google-gemini-api", freeTier: "Free tier (rate-limited)", toolUse: "Native (function calling)", codeExec: "Code execution tool", fileHandling: "Multimodal (images, audio, video)", bestFor: "Free tier available, multimodal input" },
-    { name: "GitHub Models", slug: "github-models", freeTier: "Free (rate-limited)", toolUse: "Via hosted models", codeExec: "No built-in", fileHandling: "Model-dependent", bestFor: "Free access to multiple models" },
-    { name: "OpenRouter", slug: "openrouter", freeTier: "Free models available", toolUse: "Model-dependent", codeExec: "Model-dependent", fileHandling: "Model-dependent", bestFor: "Multi-provider abstraction, price comparison" },
-    { name: "Cohere", slug: "cohere", freeTier: "Trial key (rate-limited)", toolUse: "Native (tool use)", codeExec: "No built-in", fileHandling: "Document parsing", bestFor: "RAG and enterprise search" },
-    { name: "Groq", slug: "groq", freeTier: "Free (rate-limited)", toolUse: "Native (function calling)", codeExec: "No built-in", fileHandling: "No built-in", bestFor: "Fastest inference, open-source models" },
-    { name: "Fireworks AI", slug: "fireworks-ai", freeTier: "Free credits", toolUse: "Native (function calling)", codeExec: "No built-in", fileHandling: "No built-in", bestFor: "Fast open-source model hosting" },
-    { name: "Together AI", slug: "together-ai", freeTier: "Free credits", toolUse: "Native (function calling)", codeExec: "No built-in", fileHandling: "No built-in", bestFor: "Open-source fine-tuning + inference" },
-    { name: "Mistral AI", slug: "mistral-ai", freeTier: "Experiment tier (free)", toolUse: "Native (function calling)", codeExec: "No built-in", fileHandling: "Document understanding", bestFor: "European hosting, code generation" },
-    { name: "DeepSeek API", slug: "deepseek-api", freeTier: "Free credits + pay-as-you-go", toolUse: "Native (function calling)", codeExec: "No built-in", fileHandling: "No built-in", bestFor: "Cheapest frontier-class reasoning" },
-    { name: "Cerebras", slug: "cerebras", freeTier: "Free (rate-limited)", toolUse: "Via Llama models", codeExec: "No built-in", fileHandling: "No built-in", bestFor: "Ultra-fast inference (custom silicon)" },
+    { name: "OpenAI (Responses API)", slug: "openai", toolUse: "Native (function calling)", codeExec: "Code interpreter tool", fileHandling: "File search tool", bestFor: "Direct migration — least code changes" },
+    { name: "Anthropic Claude API", slug: "anthropic-api", toolUse: "Native (tool use)", codeExec: "Computer use, code execution", fileHandling: "PDF + document processing", bestFor: "Best reasoning, long context" },
+    { name: "Google Gemini API", slug: "google-gemini-api", toolUse: "Native (function calling)", codeExec: "Code execution tool", fileHandling: "Multimodal (images, audio, video)", bestFor: "Free tier available, multimodal input" },
+    { name: "GitHub Models", slug: "github-models", toolUse: "Via hosted models", codeExec: "No built-in", fileHandling: "Model-dependent", bestFor: "Free access to multiple models" },
+    { name: "OpenRouter", slug: "openrouter", toolUse: "Model-dependent", codeExec: "Model-dependent", fileHandling: "Model-dependent", bestFor: "Multi-provider abstraction, price comparison" },
+    { name: "Cohere", slug: "cohere", toolUse: "Native (tool use)", codeExec: "No built-in", fileHandling: "Document parsing", bestFor: "RAG and enterprise search" },
+    { name: "Groq", slug: "groq", toolUse: "Native (function calling)", codeExec: "No built-in", fileHandling: "No built-in", bestFor: "Fastest inference, open-source models" },
+    { name: "Fireworks AI", slug: "fireworks-ai", toolUse: "Native (function calling)", codeExec: "No built-in", fileHandling: "No built-in", bestFor: "Fast open-source model hosting" },
+    { name: "Together AI", slug: "together-ai", toolUse: "Native (function calling)", codeExec: "No built-in", fileHandling: "No built-in", bestFor: "Open-source fine-tuning + inference" },
+    { name: "Mistral AI", slug: "mistral-ai", toolUse: "Native (function calling)", codeExec: "No built-in", fileHandling: "Document understanding", bestFor: "European hosting, code generation" },
+    { name: "DeepSeek API", slug: "deepseek-api", toolUse: "Native (function calling)", codeExec: "No built-in", fileHandling: "No built-in", bestFor: "Cheapest frontier-class reasoning" },
+    { name: "Cerebras", slug: "cerebras", toolUse: "Via Llama models", codeExec: "No built-in", fileHandling: "No built-in", bestFor: "Ultra-fast inference (custom silicon)" },
   ];
 
   const openaiStability = stabilityMap.get("openai") ?? "stable";
@@ -23225,17 +23266,49 @@ function buildOpenaiAssistantsAlternativesPage(): string {
   const daysLeft = Math.max(0, Math.ceil((shutdownDate.getTime() - today.getTime()) / (1000 * 60 * 60 * 24)));
 
   const providerTableRows = providers.map(p => {
-    const stability = stabilityMap.get(p.slug) ?? "stable";
-    const stabColor = stability === "volatile" ? "#f85149" : stability === "watch" ? "#d29922" : stability === "improving" ? "#3fb950" : "var(--text-dim)";
-    const freeColor = p.freeTier.includes("Free") || p.freeTier.includes("free") ? "#3fb950" : "var(--accent)";
+    const cells = providerRecordCells(p.slug, stabilityMap);
     return `<tr>
       <td style="font-weight:600"><a href="/vendor/${p.slug}" style="color:var(--text)">${escHtmlServer(p.name)}</a></td>
-      <td style="font-family:var(--mono);font-size:.8rem;color:${freeColor}">${escHtmlServer(p.freeTier)}</td>
+      <td style="font-family:var(--mono);font-size:.8rem;color:${cells.tierColor}">${escHtmlServer(cells.tier)}</td>
+      <td style="font-family:var(--mono);font-size:.8rem">${cells.rateCell}</td>
       <td style="font-size:.8rem">${escHtmlServer(p.toolUse)}</td>
       <td style="font-size:.8rem">${escHtmlServer(p.codeExec)}</td>
-      <td><span style="color:${stabColor};font-size:.8rem;font-weight:600;text-transform:uppercase">${escHtmlServer(stability)}</span></td>
+      <td><span style="color:${cells.stabilityColor};font-size:.8rem;font-weight:600;text-transform:uppercase">${escHtmlServer(cells.stability)}</span></td>
     </tr>`;
   }).join("\n        ");
+
+  const monthlyAtScale = providers
+    .flatMap(p => spanOfRates(vendorRates(p.slug)).map(rate => ({ name: p.name, rate, monthly: monthlyTokenCost(rate, 100, 100) })))
+    .filter((x): x is { name: string; rate: ModelRate; monthly: number } => x.monthly !== null)
+    .sort((a, b) => a.monthly - b.monthly);
+  const cheapestAtScale = monthlyAtScale[0] ?? null;
+  const dearestAtScale = monthlyAtScale[monthlyAtScale.length - 1] ?? null;
+
+  const freeWithinLimits = providers
+    .filter(p => !formatRateSpan(vendorRates(p.slug)) && !offerRetired(offerForSlug(p.slug)))
+    .map(p => p.name.replace(/\s*\(.*\)$/, ""));
+
+  const claudeFlagship = dearestRate(vendorRates("anthropic-api"));
+  const cheapestNamed = providers
+    .map(p => ({ provider: p, rate: cheapestRate(vendorRates(p.slug)) }))
+    .filter((p): p is { provider: AiProvider; rate: ModelRate } => p.rate !== null && p.rate.output !== null)
+    .sort((a, b) => (monthlyTokenCost(a.rate, 1, 1) ?? 0) - (monthlyTokenCost(b.rate, 1, 1) ?? 0))[0] ?? null;
+  const openaiRate = cheapestRate(vendorRates("openai"));
+  const openaiMonthly = openaiRate ? monthlyTokenCost(openaiRate, 100, 100) : null;
+  const cheapestMonthly = cheapestNamed ? monthlyTokenCost(cheapestNamed.rate, 100, 100) : null;
+  const cheapestMultipleClause = openaiMonthly && cheapestMonthly
+    ? ` That is ${Math.round(openaiMonthly / cheapestMonthly)}× cheaper than ${openaiRate!.model} at the same volume.`
+    : "";
+
+  const githubModelsRecord = offerForSlug("github-models");
+  const openrouterRecord = offerForSlug("openrouter");
+
+  const startableWithoutPaying = providers.filter(p => {
+    const record = offerForSlug(p.slug);
+    if (!record) return false;
+    const tierClass = classifyTier(record.tier).class;
+    return tierClass === "free" || tierClass === "time_limited";
+  });
 
   const changeTimelineRows = openaiChanges.map(c => {
     const dateStr = new Date(c.date).toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" });
@@ -23363,7 +23436,7 @@ ${mcpCtaCss()}
   <div class="summary-stats">
     <div class="stat-card"><div class="stat-number red">${daysLeft}</div><div class="stat-label">Days Remaining</div></div>
     <div class="stat-card"><div class="stat-number">${providers.length}</div><div class="stat-label">Alternatives Compared</div></div>
-    <div class="stat-card"><div class="stat-number green">${providers.filter(p => p.freeTier.includes("Free") || p.freeTier.includes("free")).length}</div><div class="stat-label">With Free Tiers</div></div>
+    <div class="stat-card"><div class="stat-number green">${startableWithoutPaying.length}</div><div class="stat-label">Free or Trial Tiers</div></div>
     <div class="stat-card"><div class="stat-number">4</div><div class="stat-label">Migration Paths</div></div>
   </div>
 
@@ -23447,7 +23520,7 @@ ${mcpCtaCss()}
     </div>
     <div class="decision-path" style="border-left:3px solid #8b5cf6">
       <h3>Path 2: Diversify to Another AI API</h3>
-      <p>Claude (best reasoning, 200K context), Gemini (free tier, multimodal), Cohere (RAG/enterprise search). Each has native tool use/function calling. Requires API integration changes but not architectural rewrites.</p>
+      <p>Claude (best reasoning, long context), Gemini (free tier, multimodal), Cohere (RAG/enterprise search). Each has native tool use/function calling. Requires API integration changes but not architectural rewrites.</p>
       <p class="best-for">Best for: Teams wanting to reduce single-vendor dependency, those needing specific capabilities (long context, multimodal, search)</p>
     </div>
     <div class="decision-path" style="border-left:3px solid #3fb950">
@@ -23463,14 +23536,15 @@ ${mcpCtaCss()}
   </div>
 
   <h2 id="comparison-table">Free Tier Comparison Table</h2>
-  <p class="section-intro">All ${providers.length} alternative AI API providers compared. Free tier details from our index, stability ratings from our <a href="/stability">stability dashboard</a>. Click provider names for full vendor profiles.</p>
+  <p class="section-intro">All ${providers.length} alternative AI API providers compared. The tier and paid-rate columns are read from each provider's record in our index at request time, and the stability ratings come from our <a href="/stability">stability dashboard</a>. A dash means the record carries no paid rate; the link goes to the vendor's own pricing page. Click provider names for full vendor profiles.</p>
 
   <div style="overflow-x:auto">
-  <table class="pricing-table">
+  <table class="pricing-table" data-figures="index">
     <thead>
       <tr>
         <th>Provider</th>
-        <th>Free Tier</th>
+        <th>Recorded Tier</th>
+        <th>Paid Rate</th>
         <th>Tool Use</th>
         <th>Code Execution</th>
         <th>Stability</th>
@@ -23487,7 +23561,7 @@ ${mcpCtaCss()}
   </div>
 
   <div class="context-box">
-    <strong>Cost comparison at scale:</strong> OpenAI GPT-4o costs $2.50/$10 per MTok (input/output). Claude Opus 5 is $5/$25 but with stronger reasoning. Gemini 2.5 Pro has a free tier up to rate limits, then $1.25/$10 per MTok. DeepSeek V3 is ~$0.27/$1.10 per MTok \u2014 cheapest overall. Open-source models via Groq or Cerebras are free within rate limits.
+    <strong>Cost comparison at scale:</strong> ${cheapestAtScale && dearestAtScale && cheapestAtScale !== dearestAtScale ? `At 100M input and 100M output tokens a month, the cheapest rate our index holds for the providers above is ${escHtmlServer(cheapestAtScale.rate.model ?? cheapestAtScale.name)} at ${escHtmlServer(formatDollars(cheapestAtScale.monthly))}, and the dearest is ${escHtmlServer(dearestAtScale.rate.model ?? dearestAtScale.name)} at ${escHtmlServer(formatDollars(dearestAtScale.monthly))}.` : ""} ${escHtmlServer(joinWithAnd(freeWithinLimits))} carry no paid rate in our index &mdash; their records describe rate-limited free access only, so what you pay above the free tier is on the vendor's own page.
   </div>
 
   <h2 id="openai-timeline">OpenAI Pricing Change Timeline</h2>
@@ -23518,19 +23592,19 @@ ${mcpCtaCss()}
     </div>
     <div class="verdict-item">
       <strong>Best reasoning &amp; long context:</strong>
-      <p>Anthropic Claude API \u2014 Opus 5 at $5/$25 MTok with 1M context. Best for complex multi-step agent workflows that need strong reasoning.</p>
+      <p>Anthropic Claude API${claudeFlagship ? ` \u2014 ${escHtmlServer(formatRate(claudeFlagship))} per MTok at the top of the lineup our record holds` : ""}. Best for complex multi-step agent workflows that need strong reasoning.</p>
     </div>
     <div class="verdict-item">
       <strong>Free tier available:</strong>
       <p>Google Gemini API \u2014 free tier with rate limits, multimodal input (images, audio, video). Best for prototyping and low-volume production.</p>
     </div>
     <div class="verdict-item">
-      <strong>Multi-model access (free):</strong>
-      <p>GitHub Models \u2014 free access to GPT-4o, Llama, Mistral, and more. Rate-limited but $0 cost. Good for experimentation.</p>
+      <strong>Multi-model access:</strong>
+      <p>GitHub Models is recorded as ${escHtmlServer(githubModelsRecord?.tier ?? "not in our index")} \u2014 GitHub ended it, so it is no longer a way to reach several models for free. ${openrouterRecord ? `OpenRouter is the multi-model route still open in our index, recorded as ${escHtmlServer(openrouterRecord.tier)}.` : ""}</p>
     </div>
     <div class="verdict-item">
       <strong>Cheapest at scale:</strong>
-      <p>DeepSeek API \u2014 frontier-class reasoning at ~$0.27/$1.10 per MTok. 10\u00d7 cheaper than GPT-4o for comparable quality on many tasks.</p>
+      <p>${cheapestNamed ? `${escHtmlServer(cheapestNamed.provider.name)} \u2014 ${escHtmlServer(formatRate(cheapestNamed.rate))} per MTok, the lowest paid rate our index carries for any provider on this page.${escHtmlServer(cheapestMultipleClause)}` : "No provider on this page carries a paid rate in our index."}</p>
     </div>
     <div class="verdict-item">
       <strong>Fastest inference:</strong>
@@ -23612,20 +23686,18 @@ function buildOpenaiAssistantsMigration2026Page(): string {
   interface ApiProvider {
     name: string;
     slug: string;
-    freeTier: string;
     toolUse: string;
     codeExec: string;
-    pricing: string;
     bestFor: string;
   }
 
   const apiProviders: ApiProvider[] = [
-    { name: "OpenAI (Responses API)", slug: "openai", freeTier: "Pay-per-use only", toolUse: "Native function calling + MCP", codeExec: "Code interpreter tool", pricing: "$2.50/$10 per MTok (GPT-4o)", bestFor: "Direct migration, least code changes" },
-    { name: "Anthropic Claude", slug: "anthropic-api", freeTier: "Pay-per-use ($5/$25 MTok)", toolUse: "Native tool use", codeExec: "Computer use, code execution", pricing: "$3/$15 (Sonnet), $5/$25 (Opus)", bestFor: "Best reasoning, 200K context" },
-    { name: "Google Gemini", slug: "google-gemini-api", freeTier: "Free tier (rate-limited)", toolUse: "Native function calling", codeExec: "Code execution tool", pricing: "Free → $1.25/$5 (2.5 Pro)", bestFor: "Free tier, multimodal" },
-    { name: "DeepSeek", slug: "deepseek-api", freeTier: "Free credits + pay-as-you-go", toolUse: "Native function calling", codeExec: "No built-in", pricing: "~$0.27/$1.10 per MTok", bestFor: "Cheapest frontier reasoning" },
-    { name: "Mistral AI", slug: "mistral-ai", freeTier: "Experiment tier (free)", toolUse: "Native function calling", codeExec: "No built-in", pricing: "$2/$6 (Large), free (Small)", bestFor: "European hosting, code generation" },
-    { name: "Meta Llama (via Groq)", slug: "groq", freeTier: "Free (rate-limited)", toolUse: "Via Llama models", codeExec: "No built-in", pricing: "Free within rate limits", bestFor: "Fastest inference, open-source" },
+    { name: "OpenAI (Responses API)", slug: "openai", toolUse: "Native function calling + MCP", codeExec: "Code interpreter tool", bestFor: "Direct migration, least code changes" },
+    { name: "Anthropic Claude", slug: "anthropic-api", toolUse: "Native tool use", codeExec: "Computer use, code execution", bestFor: "Best reasoning, long context" },
+    { name: "Google Gemini", slug: "google-gemini-api", toolUse: "Native function calling", codeExec: "Code execution tool", bestFor: "Free tier, multimodal" },
+    { name: "DeepSeek", slug: "deepseek-api", toolUse: "Native function calling", codeExec: "No built-in", bestFor: "Cheapest frontier reasoning" },
+    { name: "Mistral AI", slug: "mistral-ai", toolUse: "Native function calling", codeExec: "No built-in", bestFor: "European hosting, code generation" },
+    { name: "Meta Llama (via Groq)", slug: "groq", toolUse: "Via Llama models", codeExec: "No built-in", bestFor: "Fastest inference, open-source" },
   ];
 
   interface AgentFramework {
@@ -23658,20 +23730,14 @@ function buildOpenaiAssistantsMigration2026Page(): string {
   ];
 
   interface CostRow {
-    operation: string;
-    responsesApi: string;
-    claude: string;
-    gemini: string;
-    deepseek: string;
+    provider: string;
+    slug: string;
+    rate: ModelRate;
   }
 
-  const costRows: CostRow[] = [
-    { operation: "Input tokens (per MTok)", responsesApi: "$2.50", claude: "$3.00 (Sonnet)", gemini: "Free → $1.25", deepseek: "$0.27" },
-    { operation: "Output tokens (per MTok)", responsesApi: "$10.00", claude: "$15.00 (Sonnet)", gemini: "Free → $5.00", deepseek: "$1.10" },
-    { operation: "File search (per GB/day)", responsesApi: "$0.10", claude: "N/A (PDF native)", gemini: "N/A (multimodal)", deepseek: "N/A" },
-    { operation: "Code interpreter (per call)", responsesApi: "$0.03", claude: "N/A", gemini: "Included", deepseek: "N/A" },
-    { operation: "Web search (per 1K calls)", responsesApi: "$25.00–$50.00", claude: "N/A", gemini: "Included (grounding)", deepseek: "N/A" },
-  ];
+  const costRows: CostRow[] = apiProviders.flatMap(p =>
+    spanOfRates(vendorRates(p.slug)).map(rate => ({ provider: p.name, slug: p.slug, rate })),
+  );
 
   const featureRows = featureMappings.map(f => {
     const compColor = f.complexity === "Low" ? "#3fb950" : f.complexity === "Medium" ? "#d29922" : f.complexity === "High" ? "#f85149" : "var(--text-dim)";
@@ -23684,15 +23750,13 @@ function buildOpenaiAssistantsMigration2026Page(): string {
   }).join("\n        ");
 
   const providerRows = apiProviders.map(p => {
-    const stability = stabilityMap.get(p.slug) ?? "stable";
-    const stabColor = stability === "volatile" ? "#f85149" : stability === "watch" ? "#d29922" : stability === "improving" ? "#3fb950" : "var(--text-dim)";
-    const freeColor = p.freeTier.includes("Free") || p.freeTier.includes("free") ? "#3fb950" : "var(--accent)";
+    const cells = providerRecordCells(p.slug, stabilityMap);
     return `<tr>
       <td style="font-weight:600"><a href="/vendor/${p.slug}" style="color:var(--text)">${escHtmlServer(p.name)}</a></td>
-      <td style="font-family:var(--mono);font-size:.8rem;color:${freeColor}">${escHtmlServer(p.freeTier)}</td>
+      <td style="font-family:var(--mono);font-size:.8rem;color:${cells.tierColor}">${escHtmlServer(cells.tier)}</td>
       <td style="font-size:.8rem">${escHtmlServer(p.toolUse)}</td>
-      <td style="font-size:.8rem">${escHtmlServer(p.pricing)}</td>
-      <td><span style="color:${stabColor};font-size:.8rem;font-weight:600;text-transform:uppercase">${escHtmlServer(stability)}</span></td>
+      <td style="font-family:var(--mono);font-size:.8rem">${cells.rateCell}</td>
+      <td><span style="color:${cells.stabilityColor};font-size:.8rem;font-weight:600;text-transform:uppercase">${escHtmlServer(cells.stability)}</span></td>
     </tr>`;
   }).join("\n        ");
 
@@ -23716,15 +23780,29 @@ function buildOpenaiAssistantsMigration2026Page(): string {
     </tr>`;
   }).join("\n        ");
 
-  const costTableRows = costRows.map(c =>
-    `<tr>
-      <td style="font-weight:600;font-size:.85rem">${escHtmlServer(c.operation)}</td>
-      <td style="font-family:var(--mono);font-size:.85rem">${escHtmlServer(c.responsesApi)}</td>
-      <td style="font-family:var(--mono);font-size:.85rem">${escHtmlServer(c.claude)}</td>
-      <td style="font-family:var(--mono);font-size:.85rem">${escHtmlServer(c.gemini)}</td>
-      <td style="font-family:var(--mono);font-size:.85rem">${escHtmlServer(c.deepseek)}</td>
-    </tr>`
-  ).join("\n        ");
+  const monthlyByRow = costRows
+    .map(c => ({ c, monthly: monthlyTokenCost(c.rate, 100, 100) }))
+    .filter((x): x is { c: CostRow; monthly: number } => x.monthly !== null)
+    .sort((a, b) => a.monthly - b.monthly);
+  const cheapestMonth = monthlyByRow[0] ?? null;
+  const dearestMonth = monthlyByRow[monthlyByRow.length - 1] ?? null;
+  const migrationClaudeFlagship = dearestRate(vendorRates("anthropic-api"));
+  const scaleEconomicsBox = cheapestMonth && dearestMonth && cheapestMonth !== dearestMonth
+    ? `<div class="context-box">
+    <strong>Scale economics:</strong> at 100M input and 100M output tokens a month, the cheapest rate our index holds for these providers is ${escHtmlServer(cheapestMonth.c.rate.model ?? cheapestMonth.c.provider)} at ${escHtmlServer(formatDollars(cheapestMonth.monthly))}, and the dearest is ${escHtmlServer(dearestMonth.c.rate.model ?? dearestMonth.c.provider)} at ${escHtmlServer(formatDollars(dearestMonth.monthly))} &mdash; ${Math.round(dearestMonth.monthly / cheapestMonth.monthly)}&times; the bill for the same traffic. Capability differs with it; the spread is the reason to measure your own workload rather than pick on price alone.
+  </div>`
+    : "";
+
+  const costTableRows = costRows.map(c => {
+    const monthly = monthlyTokenCost(c.rate, 100, 100);
+    return `<tr>
+      <td style="font-weight:600;font-size:.85rem"><a href="/vendor/${c.slug}" style="color:var(--text)">${escHtmlServer(c.provider)}</a></td>
+      <td style="font-size:.85rem">${escHtmlServer(c.rate.model ?? "Not named in the record")}</td>
+      <td style="font-family:var(--mono);font-size:.85rem">${escHtmlServer(c.rate.input)}</td>
+      <td style="font-family:var(--mono);font-size:.85rem">${c.rate.output === null ? "&mdash;" : escHtmlServer(c.rate.output)}</td>
+      <td style="font-family:var(--mono);font-size:.85rem">${monthly === null ? "&mdash;" : escHtmlServer(formatDollars(monthly))}</td>
+    </tr>`;
+  }).join("\n        ");
 
   const changeTimelineRows = openaiChanges.map(c => {
     const dateStr = new Date(c.date).toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" });
@@ -23886,7 +23964,7 @@ ${mcpCtaCss()}
       <li><a href="#complexity">Migration Complexity Assessment</a></li>
       <li><a href="#decision">Decision Framework: Migrate vs. Leave</a></li>
       <li><a href="#alternatives">Alternatives: APIs, Frameworks &amp; Bridges</a></li>
-      <li><a href="#cost">Cost Comparison</a></li>
+      <li><a href="#cost">Token Cost Comparison</a></li>
       <li><a href="#openai-changes">OpenAI Pricing Change Timeline</a></li>
       <li><a href="#methodology">Methodology</a></li>
     </ol>
@@ -23981,7 +24059,7 @@ ${mcpCtaCss()}
     </div>
     <div class="decision-path" style="border-left:3px solid #8b5cf6">
       <h3>\ud83d\udd00 Path 2: Switch to Another AI API Provider</h3>
-      <p>Claude (best reasoning, 200K context), Gemini (free tier, multimodal), DeepSeek (cheapest frontier reasoning), Mistral (European hosting). Each has native tool use/function calling. Requires API integration changes but not architectural rewrites.</p>
+      <p>Claude (best reasoning, long context), Gemini (free tier, multimodal), DeepSeek (cheapest frontier reasoning), Mistral (European hosting). Each has native tool use/function calling. Requires API integration changes but not architectural rewrites.</p>
       <p><strong>Choose this when:</strong> You want to reduce single-vendor dependency, need specific capabilities (long context, multimodal, EU hosting), or were already considering alternatives after repeated OpenAI API changes.</p>
       <p><strong>Watch out for:</strong> Different API shapes require code changes. Some features (code interpreter, web search) may not have direct equivalents. Evaluate each provider\u2019s tool use implementation carefully.</p>
       <p class="best-for">Effort: Medium &middot; Cost: Varies (often cheaper) &middot; Lock-in: Medium</p>
@@ -23998,16 +24076,16 @@ ${mcpCtaCss()}
   <h2 id="alternatives">5. Alternatives</h2>
 
   <h3>Direct API Alternatives</h3>
-  <p class="section-intro">${apiProviders.length} AI API providers compared. Free tier details from our index, stability ratings from our <a href="/stability">stability dashboard</a>.</p>
+  <p class="section-intro">${apiProviders.length} AI API providers compared. The tier and paid-rate columns are read from each provider's record in our index at request time, and the stability ratings come from our <a href="/stability">stability dashboard</a>. A dash means the record carries no paid rate; the link goes to the vendor's own pricing page.</p>
 
   <div style="overflow-x:auto">
-  <table class="pricing-table">
+  <table class="pricing-table" data-figures="index">
     <thead>
       <tr>
         <th>Provider</th>
-        <th>Free Tier</th>
+        <th>Recorded Tier</th>
         <th>Tool Use</th>
-        <th>Pricing</th>
+        <th>Paid Rate</th>
         <th>Stability</th>
       </tr>
     </thead>
@@ -24060,18 +24138,18 @@ ${mcpCtaCss()}
     <strong>Wire-compatible bridges explained:</strong> These services implement the same HTTP endpoints and request/response shapes as the Assistants API, so your existing client code works with just a base URL change. <strong>Ragwalla</strong> proxies to OpenAI\u2019s Responses API under the hood, preserving the familiar Assistants interface. <strong>DataStax astra-assistants-api</strong> is open-source and backs the API with Astra DB, letting you swap in any LLM provider. Both are useful as interim solutions while you plan a full migration.
   </div>
 
-  <h2 id="cost">6. Cost Comparison</h2>
-  <p class="section-intro">Responses API introduces per-tool pricing (file search, code interpreter, web search) on top of token costs. Here\u2019s how it compares to alternatives.</p>
+  <h2 id="cost">6. Token Cost Comparison</h2>
+  <p class="section-intro">Every figure below is read from the provider's record in our index at request time \u2014 the model name included. Each provider contributes the cheapest and the dearest model its record carries a rate for. The last column prices 100M input plus 100M output tokens in a month at that rate. Per-tool charges are separate and are covered under the table.</p>
 
   <div style="overflow-x:auto">
-  <table class="pricing-table">
+  <table class="pricing-table" data-figures="index">
     <thead>
       <tr>
-        <th>Operation</th>
-        <th>OpenAI Responses</th>
-        <th>Claude (Sonnet)</th>
-        <th>Gemini 2.5</th>
-        <th>DeepSeek</th>
+        <th>Provider</th>
+        <th>Model</th>
+        <th>Input (per MTok)</th>
+        <th>Output (per MTok)</th>
+        <th>100M in + 100M out</th>
       </tr>
     </thead>
     <tbody>
@@ -24081,12 +24159,10 @@ ${mcpCtaCss()}
   </div>
 
   <div class="context-box">
-    <strong>The hidden cost of Responses API tools:</strong> File search at $0.10/GB/day and web search at $25\u2013$50 per 1K calls add up quickly. A RAG app processing 10 GB of documents costs $1/day in file search alone \u2014 $30/month before any token costs. Compare: Claude processes PDFs natively with no per-file charge, and Gemini includes grounding (web search) in the base token price.
+    <strong>The hidden cost of Responses API tools:</strong> token rates are not the whole bill. From <a href="${RESPONSES_TOOL_PRICES_URL}" target="_blank" rel="noopener nofollow">OpenAI\u2019s pricing documentation</a>, read on ${RESPONSES_TOOL_PRICES_READ}: file search storage is $0.10 per GB per day with the first GB free, and the file search tool call is billed separately at $2.50 per 1,000 calls. Hosted Shell and Code Interpreter run on containers charged per 20-minute session, from $0.03 at 1 GB to $1.92 at 64 GB, with a five-minute minimum. Web search is $10.00 per 1,000 calls, or $25.00 for the preview tool on non-reasoning models, and retrieved content is billed as input tokens at the model\u2019s own rate. We hold no record for any of these, so nothing re-verifies them \u2014 that date is when we read them. Claude processes PDFs with no per-file charge and Gemini includes grounding in the base token price.
   </div>
 
-  <div class="context-box">
-    <strong>Scale economics:</strong> At 100M tokens/month (a moderately busy production app): OpenAI GPT-4o costs ~$1,250. Claude Sonnet costs ~$1,800 but with stronger reasoning. Gemini 2.5 Pro costs ~$625 (cheapest frontier after free tier). DeepSeek V3 costs ~$137 \u2014 10\u00d7 cheaper than GPT-4o for comparable quality on many benchmarks.
-  </div>
+  ${scaleEconomicsBox}
 
   <h2 id="openai-changes">7. OpenAI Pricing Change Timeline</h2>
   <p class="section-intro">OpenAI\u2019s stability rating is <strong style="color:${stabilityColor}">${openaiStability}</strong>. We\u2019ve tracked ${openaiChanges.length} changes. Pattern: repeated free tier erosion and API paradigm shifts.</p>
@@ -24120,7 +24196,7 @@ ${mcpCtaCss()}
     </div>
     <div class="verdict-item">
       <strong>Best reasoning &amp; long context:</strong>
-      <p>Anthropic Claude \u2014 Opus 5 with 1M context. Best for complex multi-step agent workflows.</p>
+      <p>Anthropic Claude${migrationClaudeFlagship ? ` \u2014 ${escHtmlServer(formatRate(migrationClaudeFlagship))} per MTok at the top of the lineup our record holds` : ""}. Best for complex multi-step agent workflows.</p>
     </div>
     <div class="verdict-item">
       <strong>Free tier available:</strong>
@@ -24128,7 +24204,7 @@ ${mcpCtaCss()}
     </div>
     <div class="verdict-item">
       <strong>Cheapest at scale:</strong>
-      <p>DeepSeek \u2014 frontier reasoning at ~$0.27/$1.10 per MTok. 10\u00d7 cheaper than GPT-4o.</p>
+      <p>${cheapestMonth ? `${escHtmlServer(cheapestMonth.c.provider)} \u2014 ${escHtmlServer(formatRate(cheapestMonth.c.rate))} per MTok, the lowest paid rate our index carries for any provider on this page.` : "No provider on this page carries a paid rate in our index."}</p>
     </div>
     <div class="verdict-item">
       <strong>Future-proof against deprecations:</strong>

--- a/test/assistants-provider-tables.test.ts
+++ b/test/assistants-provider-tables.test.ts
@@ -1,0 +1,212 @@
+import { describe, it, before, after } from "node:test";
+import assert from "node:assert";
+import { spawn, type ChildProcess } from "node:child_process";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { readModelRates, cheapestRate, vendorRates } from "../dist/model-rates.js";
+import { offerRetired } from "../dist/retirement.js";
+import { toSlug } from "../dist/slug.js";
+import { classifyTier } from "../dist/ranking.js";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const root = path.join(__dirname, "..");
+
+const PAGES = ["/openai-assistants-alternatives", "/openai-assistants-migration-2026"];
+
+const COMPARED_SLUGS = [
+  "openai", "anthropic-api", "google-gemini-api", "github-models", "openrouter",
+  "cohere", "groq", "fireworks-ai", "together-ai", "mistral-ai", "deepseek-api", "cerebras",
+];
+
+interface IndexedOffer {
+  vendor: string;
+  tier: string;
+  description: string;
+  url: string;
+}
+
+const offers: IndexedOffer[] = JSON.parse(
+  readFileSync(path.join(root, "data", "index.json"), "utf8"),
+).offers;
+
+function recordFor(slug: string): IndexedOffer {
+  const matches = offers.filter(o => toSlug(o.vendor) === slug);
+  assert.equal(matches.length, 1, `${slug} resolves to exactly one record`);
+  return matches[0];
+}
+
+let server: ChildProcess;
+let base = "";
+const html = new Map<string, string>();
+
+function startServer(): Promise<ChildProcess> {
+  return new Promise((resolve, reject) => {
+    const proc = spawn("node", [path.join(root, "dist", "serve.js")], {
+      stdio: ["pipe", "pipe", "pipe"],
+      env: { ...process.env, PORT: "0", BASE_URL: "http://localhost", TZ: "UTC" },
+    });
+    const timeout = setTimeout(() => {
+      proc.kill();
+      reject(new Error("Server startup timeout"));
+    }, 20000);
+    proc.stderr!.on("data", (data: Buffer) => {
+      const match = data.toString().match(/running on http:\/\/localhost:(\d+)/);
+      if (match) {
+        base = `http://localhost:${match[1]}`;
+        clearTimeout(timeout);
+        resolve(proc);
+      }
+    });
+    proc.on("error", err => {
+      clearTimeout(timeout);
+      reject(err);
+    });
+  });
+}
+
+const ENTITIES: Record<string, string> = {
+  "&mdash;": "—", "&ndash;": "–", "&amp;": "&", "&quot;": '"', "&#39;": "'",
+  "&nbsp;": " ", "&lt;": "<", "&gt;": ">", "&rarr;": "→", "&times;": "×",
+};
+
+function decode(text: string): string {
+  return text.replace(/&[a-z#0-9]+;/gi, e => ENTITIES[e] ?? e).replace(/\s+/g, " ").trim();
+}
+
+function readableText(source: string): string {
+  return decode(source.replace(/<(script|style|svg)\b[\s\S]*?<\/\1>/gi, " ").replace(/<[^>]+>/g, " "));
+}
+
+function indexBackedTables(page: string): string[] {
+  return [...(html.get(page) ?? "").matchAll(/<table\b[^>]*data-figures="index"[^>]*>[\s\S]*?<\/table>/gi)].map(m => m[0]);
+}
+
+function rowFor(page: string, vendorName: string): string {
+  const rows = [...(html.get(page) ?? "").matchAll(/<tr>[\s\S]*?<\/tr>/gi)].map(m => m[0]);
+  const match = rows.find(r => readableText(r).includes(vendorName));
+  assert.ok(match, `${page} has a table row for ${vendorName}`);
+  return match!;
+}
+
+function functionBody(source: string, name: string): string {
+  const start = source.indexOf(`function ${name}(`);
+  assert.ok(start >= 0, `src/serve.ts declares ${name}`);
+  const end = source.indexOf("\n}\n", start);
+  assert.ok(end > start, `${name} has a body`);
+  return source.slice(start, end);
+}
+
+function ratePairsIn(text: string): string[] {
+  return [...text.matchAll(/\$\d[\d.,]*\s*\/\s*\$\d[\d.,]*/g)].map(m => m[0].replace(/\s+/g, ""));
+}
+
+function indexedRatePairs(): Set<string> {
+  const pairs = new Set<string>();
+  for (const offer of offers) {
+    for (const rate of readModelRates(offer.description)) {
+      if (rate.output !== null) pairs.add(`${rate.input}/${rate.output}`);
+    }
+  }
+  return pairs;
+}
+
+describe("AI provider tables on the Assistants API pages", () => {
+  before(async () => {
+    server = await startServer();
+    for (const page of PAGES) {
+      const res = await fetch(`${base}${page}`);
+      assert.equal(res.status, 200, `${page} responds 200`);
+      html.set(page, await res.text());
+    }
+  });
+
+  after(() => {
+    server?.kill();
+  });
+
+  it("states each provider's free tier as the index records it", () => {
+    for (const page of PAGES) {
+      for (const slug of COMPARED_SLUGS) {
+        const record = recordFor(slug);
+        const row = [...(html.get(page) ?? "").matchAll(/<tr>[\s\S]*?<\/tr>/gi)]
+          .map(m => m[0])
+          .find(r => r.includes(`/vendor/${slug}"`));
+        if (!row) continue;
+        assert.ok(
+          readableText(row).includes(record.tier),
+          `${page} row for ${record.vendor} states the recorded tier "${record.tier}"`,
+        );
+      }
+    }
+  });
+
+  it("does not offer a retired tier as available, or rate it stable", () => {
+    const retiredSlugs = COMPARED_SLUGS.filter(slug => offerRetired(recordFor(slug)));
+    assert.ok(retiredSlugs.length > 0, "at least one compared provider is recorded as retired");
+    for (const page of PAGES) {
+      for (const slug of retiredSlugs) {
+        const record = recordFor(slug);
+        const pageHtml = html.get(page) ?? "";
+        if (!pageHtml.includes(`/vendor/${slug}"`)) continue;
+        const row = rowFor(page, record.vendor);
+        const rowText = readableText(row);
+        assert.ok(rowText.includes(record.tier), `${page} row for ${record.vendor} states "${record.tier}"`);
+        assert.ok(!/\bstable\b/i.test(rowText), `${page} row for ${record.vendor} carries no stability rating`);
+        assert.ok(
+          !/\bfree\b/i.test(rowText),
+          `${page} row for ${record.vendor} does not call the ended offer free`,
+        );
+      }
+    }
+  });
+
+  it("prices every index-backed table cell at a rate a record carries", () => {
+    const known = indexedRatePairs();
+    assert.ok(known.size > 0, "the index carries at least one model rate");
+    let checked = 0;
+    for (const page of PAGES) {
+      const tables = indexBackedTables(page);
+      assert.ok(tables.length > 0, `${page} marks its index-backed tables`);
+      for (const table of tables) {
+        for (const pair of ratePairsIn(readableText(table))) {
+          checked++;
+          assert.ok(known.has(pair), `${page} prices a row at ${pair}, which no record carries`);
+        }
+      }
+    }
+    assert.ok(checked > 0, "at least one rate pair is rendered from the index");
+  });
+
+  it("keeps token rates out of the page source", () => {
+    const source = readFileSync(path.join(root, "src", "serve.ts"), "utf8");
+    for (const builder of ["buildOpenaiAssistantsAlternativesPage", "buildOpenaiAssistantsMigration2026Page"]) {
+      const pairs = ratePairsIn(functionBody(source, builder));
+      assert.deepEqual(pairs, [], `${builder} states no token rate of its own`);
+    }
+  });
+
+  it("counts a provider among the free tiers only while the record still offers one", () => {
+    const startable = COMPARED_SLUGS.filter(slug => {
+      const tierClass = classifyTier(recordFor(slug).tier).class;
+      return tierClass === "free" || tierClass === "time_limited";
+    });
+    assert.ok(startable.length < COMPARED_SLUGS.length, "not every compared provider offers a free or trial tier");
+    const page = html.get("/openai-assistants-alternatives") ?? "";
+    const counted = page.match(/<div class="stat-number green">(\d+)<\/div>/);
+    assert.ok(counted, "the page publishes a count of free or trial tiers");
+    assert.equal(Number(counted![1]), startable.length);
+  });
+
+  it("names the model the record names when it quotes that model's rate", () => {
+    const cheapest = cheapestRate(vendorRates("deepseek-api"));
+    assert.ok(cheapest?.model, "the DeepSeek record names a model with a rate");
+    for (const page of PAGES) {
+      const text = readableText(html.get(page) ?? "");
+      assert.ok(
+        text.includes(cheapest!.model!),
+        `${page} names ${cheapest!.model} where it quotes that provider's rate`,
+      );
+    }
+  });
+});

--- a/test/model-rates.test.ts
+++ b/test/model-rates.test.ts
@@ -1,0 +1,161 @@
+import { describe, it } from "node:test";
+import assert from "node:assert";
+import {
+  readModelRates,
+  cheapestRate,
+  dearestRate,
+  spanOfRates,
+  formatRate,
+  formatRateSpan,
+  monthlyTokenCost,
+  formatDollars,
+  amountValue,
+  publishableRates,
+  soleMatch,
+} from "../dist/model-rates.js";
+
+describe("reading model rates out of a record description", () => {
+  it("reads a colon-introduced pair and keeps the model name", () => {
+    const rates = readModelRates("Claude API access with usage-based pricing. Sonnet 5: $2/$10 per MTok.");
+    assert.deepEqual(rates, [{ model: "Sonnet 5", input: "$2", output: "$10" }]);
+  });
+
+  it("reads several pairs from one sentence run and keeps each name", () => {
+    const rates = readModelRates(
+      "Fable 5.1: $10/$50 per MTok (input/output). Opus 5: $5/$25 per MTok. Haiku 4.5: $1/$5 per MTok.",
+    );
+    assert.deepEqual(rates.map(r => r.model), ["Fable 5.1", "Opus 5", "Haiku 4.5"]);
+    assert.deepEqual(rates.map(r => `${r.input}/${r.output}`), ["$10/$50", "$5/$25", "$1/$5"]);
+  });
+
+  it("does not read a version dot as the end of a sentence", () => {
+    const rates = readModelRates("Per-model paid pricing: Gemini 2.5 Pro $1.25/$10 (≤200K, doubles above).");
+    assert.deepEqual(rates, [{ model: "Gemini 2.5 Pro", input: "$1.25", output: "$10" }]);
+  });
+
+  it("does not swallow a trailing comma or full stop into the amount", () => {
+    const rates = readModelRates("Gemini 3.0 Flash Preview $0.50/$3, Gemini 2.5 Flash $0.30/$2.50.");
+    assert.deepEqual(rates.map(r => r.output), ["$3", "$2.50"]);
+  });
+
+  it("reads a rate split across input and output clauses", () => {
+    const rates = readModelRates("DeepSeek V3.2 (deepseek-chat): $0.28/M input, $0.42/M output (1M context).");
+    assert.deepEqual(rates, [{ model: "DeepSeek V3.2", input: "$0.28", output: "$0.42" }]);
+  });
+
+  it("takes the model name from after the rate when the sentence puts it there", () => {
+    const rates = readModelRates("Paid API rates start at $0.5/M input and $1.5/M output tokens for Mistral Large.");
+    assert.deepEqual(rates, [{ model: "Mistral Large", input: "$0.5", output: "$1.5" }]);
+  });
+
+  it("keeps a version number in a name that follows the rate", () => {
+    const rates = readModelRates("Starting at $0.20/M input tokens, $0.50/M output tokens for Grok 4.1 Fast.");
+    assert.equal(rates[0].model, "Grok 4.1 Fast");
+  });
+
+  it("reads an input rate with no stated output rate rather than inventing one", () => {
+    const rates = readModelRates("Paid tiers use token-based pricing: GPT-4o from $2.50/1M input tokens.");
+    assert.deepEqual(rates, [{ model: "GPT-4o", input: "$2.50", output: null }]);
+  });
+
+  it("reads no rate out of a description that states none", () => {
+    assert.deepEqual(readModelRates("Free tier: 30 RPM, 100K-500K tokens/day depending on model."), []);
+    assert.deepEqual(readModelRates(""), []);
+    assert.deepEqual(readModelRates(undefined), []);
+  });
+
+  it("does not report a price of the plan itself as a model rate", () => {
+    assert.deepEqual(readModelRates("Pro plan ($20/seat/mo) with 100 GB/month transfer."), []);
+  });
+
+  it("does not claim a name it cannot find", () => {
+    const rates = readModelRates("Token pricing is $1/$4 per MTok.");
+    assert.equal(rates.length, 1);
+    assert.equal(rates[0].model, null);
+  });
+});
+
+describe("choosing and formatting a rate to publish", () => {
+  const lineup = readModelRates("Fable 5.1: $10/$50 per MTok. Opus 5: $5/$25 per MTok. Haiku 4.5: $1/$5 per MTok.");
+
+  it("orders by the input rate, not by the order the record states them in", () => {
+    assert.equal(cheapestRate(lineup)?.model, "Haiku 4.5");
+    assert.equal(dearestRate(lineup)?.model, "Fable 5.1");
+  });
+
+  it("spans from cheapest to dearest", () => {
+    assert.deepEqual(spanOfRates(lineup).map(r => r.model), ["Haiku 4.5", "Fable 5.1"]);
+  });
+
+  it("collapses a span whose ends carry the same figures", () => {
+    const twins = readModelRates("DeepSeek V3.2: $0.28/M input, $0.42/M output. DeepSeek V3.2 Thinking: $0.28/M input, $0.42/M output.");
+    assert.equal(twins.length, 2);
+    assert.deepEqual(spanOfRates(twins).map(r => r.model), ["DeepSeek V3.2"]);
+  });
+
+  it("has nothing to span when the record carries no rate", () => {
+    assert.deepEqual(spanOfRates([]), []);
+    assert.equal(formatRateSpan([]), null);
+    assert.equal(cheapestRate([]), null);
+  });
+
+  it("marks a rate that states only an input price", () => {
+    assert.equal(formatRate({ model: "GPT-4o", input: "$2.50", output: null }), "$2.50 (GPT-4o, input only)");
+  });
+
+  it("names the model beside the figures", () => {
+    assert.equal(formatRateSpan(lineup), "$1/$5 (Haiku 4.5) – $10/$50 (Fable 5.1)");
+  });
+});
+
+describe("pricing a month of traffic at a recorded rate", () => {
+  it("bills input and output separately", () => {
+    assert.equal(monthlyTokenCost({ model: "Sonnet 5", input: "$2", output: "$10" }, 100, 100), 1200);
+  });
+
+  it("declines to price a rate with no output figure", () => {
+    assert.equal(monthlyTokenCost({ model: "GPT-4o", input: "$2.50", output: null }, 100, 100), null);
+  });
+
+  it("reads an amount written with thousands separators", () => {
+    assert.equal(amountValue("$1,250.50"), 1250.5);
+  });
+
+  it("writes a whole-dollar figure with separators", () => {
+    assert.equal(formatDollars(6000), "$6,000");
+    assert.equal(formatDollars(69.6), "$70");
+  });
+});
+
+describe("deciding which of a record's rates may be published", () => {
+  const priced = { tier: "Pay-as-you-go", description: "Sonnet 5: $2/$10 per MTok." };
+
+  it("publishes the rates of an offer that is still on sale", () => {
+    assert.deepEqual(publishableRates(priced), [{ model: "Sonnet 5", input: "$2", output: "$10" }]);
+  });
+
+  it("publishes no rate for an offer the record says has ended", () => {
+    assert.deepEqual(publishableRates({ ...priced, tier: "Retired" }), []);
+    assert.deepEqual(publishableRates({ ...priced, tier: "Discontinued" }), []);
+  });
+
+  it("publishes no rate when there is no record", () => {
+    assert.deepEqual(publishableRates(null), []);
+  });
+});
+
+describe("resolving a slug to one record", () => {
+  const arize = [{ vendor: "Arize AI" }, { vendor: "Arize Ax" }, { vendor: "Groq" }];
+
+  it("returns the record when exactly one vendor takes the slug", () => {
+    assert.deepEqual(soleMatch(arize, "groq"), { vendor: "Groq" });
+  });
+
+  it("returns nothing when two vendors take the same slug", () => {
+    assert.equal(soleMatch([{ vendor: "Arize AI" }, { vendor: "Arize.ai" }], "arize-ai"), null);
+  });
+
+  it("returns nothing when no vendor takes the slug", () => {
+    assert.equal(soleMatch(arize, "cerebras"), null);
+  });
+});

--- a/test/page-source-ratchet.test.ts
+++ b/test/page-source-ratchet.test.ts
@@ -122,7 +122,7 @@ describe("the number of tier-A pages asserting vendor facts from nowhere only go
   });
 
   it("is the number the shipped register holds", () => {
-    assert.strictEqual(UNSOURCED_TIER_A_BASELINE, 43);
+    assert.strictEqual(UNSOURCED_TIER_A_BASELINE, 41);
   });
 });
 

--- a/test/stale-page-facts.test.ts
+++ b/test/stale-page-facts.test.ts
@@ -334,7 +334,7 @@ describe("#1321 the FAQ counts are budgets too, and they live in the same file",
     const budgets = readQualityBudgets().budgets;
     const { unmeasured, lowered, over } = ratchet(budgets, {
       stale_fact_pages: 57,
-      unsourced_tier_a: 43,
+      unsourced_tier_a: 41,
       uncited_change_records: budgets.uncited_change_records,
       source_checks_ok_without_quoted_evidence: budgets.source_checks_ok_without_quoted_evidence,
     });

--- a/test/tier-vocabulary.json
+++ b/test/tier-vocabulary.json
@@ -12,7 +12,6 @@
   "Community (Self-hosted)",
   "Community / HCP Free",
   "Developer",
-  "Experiment",
   "Flamethrower",
   "Founder Perks",
   "Free",


### PR DESCRIPTION
Refs https://github.com/robhunter/agentdeals/issues/1372

Three hardcoded arrays across two pages now render their tier and rate cells from the record each row's `slug` resolves to. No literal token rate survives in either page's source.

## The mechanism

`src/model-rates.ts` reads model rates out of a record's `description` and returns `{ model, input, output }`. It handles the two shapes our records use — `Sonnet 5: $2/$10 per MTok` and `$0.28/M input, $0.42/M output` — and takes the model name from whichever side of the figures the sentence puts it on. Where a record states an input rate and no output rate, it says so rather than inventing one.

Measured against all 1,580 records: **8 carry a model rate, 17 rates in total, and every one is named.** Two of those eight are not on these pages and read correctly too (xAI `Grok 4.1 Fast`, MiniMax `MiniMax-M2.7 text`).

Each provider row now renders:

| cell | source |
|---|---|
| tier | `record.tier` |
| paid rate | cheapest and dearest model the record carries a rate for; an em dash linking to the vendor's pricing page when it carries none |
| stability | the stability dashboard, or `retired` when the record says the offer has ended |

## What changed on the pages

**GitHub Models.** Row reads `Retired`, no rate, no `stable`. The verdict block that recommended it as free multi-model access now states the retirement and names OpenRouter, from OpenRouter's own record.

**Every rate the issue listed is gone**, along with three the census did not cover:

| was published | the record says |
|---|---|
| `$3/$15 (Sonnet)` — in `apiProviders` **and** `costRows` | `$2/$10` |
| `$1.25/$5 (2.5 Pro)` | `$1.25/$10`, which the page's own prose already said |
| `$2/$6 (Large)` | `$0.5/$1.5`, sourced in https://github.com/robhunter/agentdeals/pull/1375 |
| `~$0.27/$1.10` — table and two prose sentences | `$0.28/$0.42` |
| `Pay-per-use ($5/$25 MTok)` in the **free-tier** column | `Pay-as-you-go` |
| `Best reasoning, long context (200K)` beside a verdict box saying `1M context` | neither figure is in the record; both removed |
| `With Free Tiers: 9` — a count of strings containing "free", which counted GitHub Models | 10, from `classifyTier` |

`DeepSeek V3` in prose is now `DeepSeek V3.2`, from the record.

## The cost table

`costRows` was five hardcoded rows: two token-rate rows and three Responses API tool prices. The token rows are now one row per provider per recorded model rate, with a column pricing 100M input + 100M output a month. `Scale economics` is computed from those rows instead of restating them.

**The three tool rows are removed, because no record can hold them and all three were wrong.** Read from `developers.openai.com/api/docs/pricing` on 2026-09-05:

- web search is `$10.00 / 1k calls`, or `$25.00` for the preview tool on non-reasoning models. The page published `$25.00–$50.00`. **`$50` appears nowhere on OpenAI's page.**
- code interpreter is `1 GB $0.03 … per 20-minute session per container`, five-minute minimum. The page published `$0.03` **per call**.
- file search storage is `$0.10 / GB per day (1 GB free)` and there is a separate `$2.50 / 1k calls` tool charge. The page published the storage rate alone — understating the cost, in a box about hidden costs.

They now live in the `hidden cost of Responses API tools` box, corrected, with the source linked and the read date shown, and a sentence saying plainly that we hold no record for them so nothing re-verifies them.

## Two data changes

`Mistral AI`, `tier`: `Experiment` → `Free`. `mistral.ai/pricing` has **zero occurrences of `Experiment`** and asks and answers `Does Mistral have a free plan? Yes, Mistral's Free plan…`, with `$10 /mo in API credits` in that plan's own bullet list. Read from raw bytes with a browser UA. `test/tier-vocabulary.json` drops `Experiment` in the same commit; `classifyTier` puts both strings in the same class, so nothing moves in the rankings.

`data/page-reviews.json`: both pages move from `reads_index: false` / `data_source: unsourced` to `true` / `catalogue`. **This was not a choice — the suite made it.** `page-data-provenance.test.ts` measures readership by perturbing the catalogue and diffing the render, and it went red against the register the moment the lookup landed. `unsourced_tier_a` ratchets **43 → 41**.

## Verification

Six page assertions were written first and **checked red against `9000c46` before any fix**, including the one the issue asked for:

```
✖ does not offer a retired tier as available, or rate it stable
  /openai-assistants-alternatives row for GitHub Models states "Retired"
✖ keeps token rates out of the page source
  actual: [ '$5/$25', '$2.50/$10', '$5/$25', '$1.25/$10', '$0.27/$1.10', '$5/$25', '$0.27/$1.10' ]
```

`prices every index-backed table cell at a rate a record carries` collects every `$A/$B` pair rendered inside a `data-figures="index"` table and requires each to be a pair some record carries. A future edit cannot satisfy it by adding a constant to `src/serve.ts` — the constant would have to be in `data/index.json`.

**3,866 tests, 33 new, none red.** 16 mutations in `scripts/mutate-1372.sh`, **16 killed**. The two that survived the first run were guards no record in the corpus exercises — a retired record with a paid rate, and an ambiguous slug — so they moved into `publishableRates` and `soleMatch` where a fixture can reach them, rather than staying unfalsifiable.

End to end on a real server, changing only `data/index.json`:

```
BEFORE  Anthropic Claude API | Pay-as-you-go | $1/$5 (Haiku 4.5) – $10/$50 (Fable 5.1)
        GitHub Models | Retired | — | retired

AFTER   Anthropic Claude API | Pay-as-you-go | $0.40/$2 (Sonnet 5 Mini) – $10/$50 (Fable 5.1)
        GitHub Models | Free | — vendor pricing | stable
```

Adding a cheaper model to one record moved the cheap end of the span; un-retiring another restored its tier, its pricing link and its stability rating. No code changed between those two renders.

## Found and not fixed

- **`openai.com/api/pricing/` is no longer a token-pricing page.** The OpenAI record cites it; in 738 KB of raw bytes it contains **zero occurrences of `gpt-4o` or `GPT-4o`** and no per-token rate at all — it now sells seats at `$20 / month` and `$100 / month`. Our own check already reads it as `unreadable / HTTP 403`. So the record's `GPT-4o from $2.50/1M input tokens`, its `3 requests/minute` free-tier claim and its `tier: "Free"` are all unsourceable from the URL beside them. The output rate is `$10.00` on `developers.openai.com/api/docs/pricing`, which is why the cell reads `$2.50 (GPT-4o, input only)` — the mechanism is showing you the hole rather than filling it from a page the record does not cite.
- **A fourth hardcoded provider table**, `llmAlternatives` at `src/serve.ts:18780` on `/google-developer-program-2026`, publishes `GitHub Models | Free for GitHub users`. Sibling arrays sit around it (`firebaseAlternatives` and others), so converting it is its own piece of work. I changed only the Mistral cell there, because the tier change above made it stale.
- **`/llm-api-pricing` carries the same two claims** — `Experiment tier: 2 RPM, 1 billion tokens/month` at `:31193` and a FAQ answer recommending `GitHub Models gives free access to 100+ models` at `:31500`. That page is https://github.com/robhunter/agentdeals/issues/1374 and I left it alone.
- **`/openai-assistants-alternatives` still counts down to a date that has passed** — `0 days until Assistants API shutdown`, and the meta description still says `shuts down August 26, 2026` in the future tense.
- **`OpenRouter — unified API across 100+ models`** is a figure in a verdict block that reaches no record; the record says `~30 free models`.
