### PR TITLE
Retire Momento's free tier, which its own pricing page no longer sells

### DIFF
--- a/data/index.json
+++ b/data/index.json
@@ -3205,8 +3205,8 @@
     {
       "vendor": "Momento",
       "category": "Databases",
-      "description": "Serverless cache and pub/sub — 5 GB data transfer/month free, sub-millisecond latency, no infrastructure to manage",
-      "tier": "Free",
+      "description": "Managed Valkey cache, cluster and pub/sub, formerly a serverless cache with a free tier. No free tier. gomomento.com/pricing, read 2026-09-05, prices every plan: Momento Cache Flex from $13 per GB-month, Momento Cache Cluster from $0.0105 per instance-hour, Pub/sub Topics from $1 per 1M operations, Valkey Router $0.01 per GB of data transfer. The only $0 on the page is the Starter Basic Support plan, which is a support level and not a product allowance.",
+      "tier": "Retired",
       "url": "https://www.gomomento.com/pricing",
       "tags": [
         "database",
@@ -3216,11 +3216,11 @@
         "free tier",
         "redis-alternative"
       ],
-      "verifiedDate": "2026-08-23",
+      "verifiedDate": "2026-09-05",
       "source_check": {
         "checked": "2026-09-05",
         "outcome": "ok",
-        "detail": "the page names Momento as \"momento\" and states \"$13\""
+        "detail": "the page states \"Momento Cache Flex from $13 per GB-month\" and \"Pub / sub Topics from $1 per 1M operations\"; the string \"free\" occurs once in 6,635 characters of visible text, in \"freeing up your team\""
       },
       "product_subtypes": {
         "taxonomy": "Databases",

--- a/data/quality_budgets.json
+++ b/data/quality_budgets.json
@@ -8,8 +8,8 @@
     "faq_answers": 166,
     "faq_answers_stating_a_figure": 77,
     "faq_answers_with_a_digit_but_no_figure": 40,
-    "records_with_superseded_terms": 176,
-    "vendor_pages_withholding_superseded_terms": 175,
-    "ungated_pages_withholding_superseded_terms": 166
+    "records_with_superseded_terms": 175,
+    "vendor_pages_withholding_superseded_terms": 174,
+    "ungated_pages_withholding_superseded_terms": 165
   }
 }


### PR DESCRIPTION
Retire Momento's free tier, which its own pricing page no longer sells

gomomento.com/pricing was read on 2026-09-04 and again on 2026-09-05. Its
6,635 characters of visible text contain the string "free" once, in
"freeing up your team". Every plan on the page carries a price: Momento
Cache Flex from $13 per GB-month, Momento Cache Cluster from $0.0105 per
instance-hour, Pub/sub Topics from $1 per 1M operations, Valkey Router
$0.01 per GB of data transfer.

Our record still read tier Free with "5 GB data transfer/month free",
verified 2026-08-23, while our own free_tier_removed change record dated
2026-09-05 says the opposite and cites the same URL.

The one $0 on that page is the Starter Basic Support plan. That is a
support level, not a product allowance, and the description now says so
in case a later pass reads it as a free tier.

The source_check detail was "the page names Momento as \"momento\" and
states \"$13\"" — a pass written off a bare price string. It now quotes the
two sentences that establish the claim.

Derived-set diff, local server against production: the route set is
unchanged at 483 pages and 1,573 vendors; Momento drops out of
/best/free-databases entirely, /vendor/momento renders the retired badge
and answers "there is no free tier here to run in production", and
/category/databases lists it as Retired.

Ratchet unchanged: 57 / 43 / 95 / 614.
