### PR TITLE
Withhold stored terms our own change log quotes as the previous ones (#1103)

### DIFF
--- a/scripts/mutate-1103.sh
+++ b/scripts/mutate-1103.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+set -uo pipefail
+cd "$(dirname "$0")/.."
+
+TESTS="test/superseded-terms.test.ts"
+KILLED=0
+SURVIVED=0
+
+run_mutation() {
+  local label="$1" file="$2" from="$3" to="$4"
+  cp "$file" /tmp/mutate-1103-backup
+  python3 - "$file" "$from" "$to" <<'PY'
+import sys
+path, frm, to = sys.argv[1], sys.argv[2], sys.argv[3]
+s = open(path, encoding="utf-8").read()
+n = s.count(frm)
+if n != 1:
+    print(f"SKIP: pattern appears {n} times", file=sys.stderr)
+    sys.exit(3)
+open(path, "w", encoding="utf-8").write(s.replace(frm, to))
+PY
+  local applied=$?
+  if [ $applied -ne 0 ]; then
+    cp /tmp/mutate-1103-backup "$file"
+    printf '  %-58s NOT APPLIED\n' "$label"
+    return
+  fi
+  ./node_modules/.bin/tsc > /tmp/mutate-1103-tsc 2>&1
+  if [ $? -ne 0 ]; then
+    printf '  %-58s killed (does not compile)\n' "$label"
+    KILLED=$((KILLED + 1))
+  else
+    node --test --test-concurrency 1 $TESTS > /tmp/mutate-1103-out 2>&1
+    if [ $? -ne 0 ]; then
+      printf '  %-58s killed by %s\n' "$label" "$(grep -oE '^  ✖ .*\(' /tmp/mutate-1103-out | head -1 | sed 's/^  ✖ //; s/ ($//')"
+      KILLED=$((KILLED + 1))
+    else
+      printf '  %-58s SURVIVED\n' "$label"
+      SURVIVED=$((SURVIVED + 1))
+    fi
+  fi
+  cp /tmp/mutate-1103-backup "$file"
+  ./node_modules/.bin/tsc > /dev/null 2>&1
+}
+
+echo "── mutations of the predicate ──"
+
+run_mutation "a change with no previous state quotes the terms" src/superseded-description.ts \
+  'return quoted !== "" && quoted === comparableTerms(description);' \
+  'return quoted === comparableTerms(description);'
+
+run_mutation "the comparison stops reflowing whitespace" src/superseded-description.ts \
+  'return (text ?? "").replace(/\s+/g, " ").trim().toLowerCase();' \
+  'return (text ?? "").trim().toLowerCase();'
+
+run_mutation "the comparison starts reading case" src/superseded-description.ts \
+  'return (text ?? "").replace(/\s+/g, " ").trim().toLowerCase();' \
+  'return (text ?? "").replace(/\s+/g, " ").trim();'
+
+run_mutation "a resolved change still supersedes the terms" src/superseded-description.ts \
+  '    if (isNoLongerInForce(change)) continue;' \
+  '    if (false) continue;'
+
+run_mutation "the oldest quoting change wins" src/superseded-description.ts \
+  '    if (!newest || change.date > newest.date) newest = change;' \
+  '    if (!newest || change.date < newest.date) newest = change;'
+
+run_mutation "the terms match a substring rather than the whole" src/superseded-description.ts \
+  'return quoted !== "" && quoted === comparableTerms(description);' \
+  'return quoted !== "" && comparableTerms(description).includes(quoted);'
+
+echo "── mutations of the vendor page ──"
+
+run_mutation "the page keeps publishing the superseded terms" src/serve.ts \
+  '  const publishableTerms = termsSuperseded ? "" : primary.description;' \
+  '  const publishableTerms = primary.description;'
+
+run_mutation "the description block prints them anyway" src/serve.ts \
+  '      : `<p class="desc-text">${escHtmlServer(primary.description)}</p>`}' \
+  '      : ``}${`<p class="desc-text">${escHtmlServer(primary.description)}</p>`}'
+
+run_mutation "the structured description keeps the stored terms" src/serve.ts \
+  '      description: termsSuperseded ? supersededTermsNotice(vendorName, termsSuperseded) : primary.description,' \
+  '      description: primary.description,'
+
+run_mutation "a zero-price Offer is published over withheld terms" src/serve.ts \
+  '      ...(primaryGate || termsSuperseded' \
+  '      ...(primaryGate'
+
+run_mutation "the free-tier answer opens with yes again" src/serve.ts \
+  '  const faqFreeAnswer = termsSuperseded
+    ? `${gateSentencesBeforeTheTerms}${supersededTermsAnswer(vendorName, termsSuperseded)}`
+    : retiredSentence' \
+  '  const faqFreeAnswer = retiredSentence'
+
+run_mutation "the tier answer restates the figures" src/serve.ts \
+  '  const faqTierAnswer = termsSuperseded
+    ? `${eligibilityGateSentence}${vendorName}'"'"'s free tier is called "${primary.tier}". ${supersededTermsNotice(vendorName, termsSuperseded)}`
+    : retiredSentence' \
+  '  const faqTierAnswer = retiredSentence'
+
+run_mutation "the meta description reverts to the stored limits" src/serve.ts \
+  '  const metaDesc = eligibilityGateSentence + (termsSuperseded
+    ? `${supersededTermsMetaSentence(vendorName, termsSuperseded)} See the recorded change history${alternatives.length > 0 ? ` and ${alternatives.length} alternatives in ${primary.category}` : ""}.`
+    : hasFree' \
+  '  const metaDesc = eligibilityGateSentence + (hasFree'
+
+echo
+echo "killed ${KILLED}, survived ${SURVIVED}"

--- a/src/serve.ts
+++ b/src/serve.ts
@@ -20,6 +20,7 @@ import { openapiSpec } from "./openapi.js";
 import { LINK_GRACE_DAYS, unreachableNoticeForUrl } from "./link-health.js";
 import { offerEnded, offerRetired, recordedTierSentence, endedHeadline, endedHistorySentence, endedReliabilitySentence, endedEmptyChangeHistorySentence, ENDED_BADGE_LABEL, ENDED_SINCE_CHANGES_SENTENCE, type OfferTierAndUrl } from "./retirement.js";
 import { amountUnstatedSentence, levelWithheldReason, sourceStatesNoAmount, withheldLevelClause, withheldLevelSentence } from "./source-check.js";
+import { SUPERSEDED_TERMS_LABEL, supersededTermsAnswer, supersededTermsMetaSentence, supersededTermsNotice, supersededTermsVerdictSentence, supersedingChange } from "./superseded-description.js";
 import { buildComparisonMap, comparisonSlug } from "./comparison-pairs.js";
 import { stabilityFaqAnswer, stabilityVerdictClause, type ComparisonSide, type StabilityRating } from "./comparison-verdict.js";
 import { publishedVendorLevel, vendorVerdictSentence, vendorBadge, statesRiskCause, narrowingSentence, changeKindNoun, type VendorVerdictInput } from "./vendor-verdict.js";
@@ -3751,6 +3752,9 @@ function buildVendorPage(slug: string): string | null {
     .filter(c => c.vendor.toLowerCase() === vendorName.toLowerCase())
     .sort((a, b) => b.date.localeCompare(a.date));
 
+  const termsSuperseded = supersedingChange(primary, vendorChanges);
+  const publishableTerms = termsSuperseded ? "" : primary.description;
+
   const riskColors: Record<string, string> = { stable: "#3fb950", caution: "#d29922", risky: "#f85149" };
   const riskCause = enriched.risk_cause;
   const riskLevel = publishedVendorLevel(enriched.risk_level ?? null, riskCause);
@@ -3876,17 +3880,19 @@ function buildVendorPage(slug: string): string | null {
   const title = hasFree
     ? `${freeTierHeadline}: Limits, Pricing & What Changed | AgentDeals`
     : `${pricingHeadline}: Plans, Costs & Free Alternatives | AgentDeals`;
-  const descLimits = primary.description.slice(0, 100).replace(/\.\s.*$/, "");
+  const descLimits = publishableTerms.slice(0, 100).replace(/\.\s.*$/, "");
   const verifiedMonth = (() => { const d = primary.verifiedDate.split("-"); const months = ["January","February","March","April","May","June","July","August","September","October","November","December"]; return `${months[parseInt(d[1],10)-1]} ${d[0]}`; })();
   const verifiedSentence = discontinuedOn
     ? ` Discontinued ${discontinuedOn}.`
     : enriched.link_unreachable ? "" : ` Verified ${verifiedMonth}.`;
   const eligibilityGateSentence = primaryEligibilityGate ? `${primaryEligibilityGate.reason} ` : "";
-  const metaDesc = eligibilityGateSentence + (hasFree
+  const metaDesc = eligibilityGateSentence + (termsSuperseded
+    ? `${supersededTermsMetaSentence(vendorName, termsSuperseded)} See the recorded change history${alternatives.length > 0 ? ` and ${alternatives.length} alternatives in ${primary.category}` : ""}.`
+    : hasFree
     ? `${vendorName} free tier includes ${descLimits}.${verifiedSentence}${alternatives.length > 0 ? ` Compare with ${alternatives.length} alternatives in ${primary.category}.` : ""}`
     : `${vendorName} pricing details${alternatives.length > 0 ? ` and ${alternatives.length} free alternatives in ${primary.category}` : ""}.${verifiedSentence}`);
 
-  const keyLimit = primary.description.slice(0, 120).replace(/\.\s.*$/, "");
+  const keyLimit = publishableTerms.slice(0, 120).replace(/\.\s.*$/, "");
   const verdictLine2 = vendorVerdictSentence(verdictInput);
   const verdictLine3 = discontinuedOn
     ? `${vendorName} was discontinued on ${discontinuedOn}, so it is not a current option${alternatives.length > 0 ? ` — the ${alternatives.length} alternatives below are replacements` : ""}.`
@@ -3894,9 +3900,12 @@ function buildVendorPage(slug: string): string | null {
     ? `Best for ${primary.category.toLowerCase()} workloads${alternatives.length >= 5 ? ` — ${alternatives.length} alternatives available` : ""}.`
     : "";
   const verdictSubject = primaryGate ? primaryGate.reason : retiredSentence;
+  const verdictTerms = termsSuperseded
+    ? escHtmlServer(supersededTermsVerdictSentence(vendorName, termsSuperseded))
+    : "";
   const verdictOpening = verdictSubject
-    ? `${escHtmlServer(verdictSubject)} ${escHtmlServer(keyLimit)}.`
-    : `${escHtmlServer(vendorName)}'s free tier offers ${escHtmlServer(keyLimit)}.`;
+    ? `${escHtmlServer(verdictSubject)} ${verdictTerms || `${escHtmlServer(keyLimit)}.`}`
+    : verdictTerms || `${escHtmlServer(vendorName)}'s free tier offers ${escHtmlServer(keyLimit)}.`;
   const quickVerdictHtml = `
   <div class="quick-verdict">
     <p>${verdictOpening} ${verdictLine2}${verdictLine3 ? " " + verdictLine3 : ""}</p>
@@ -3915,15 +3924,15 @@ function buildVendorPage(slug: string): string | null {
   </div>`;
 
   const growthBullets: string[] = [];
-  for (const phrase of growthLimitPhrases(primary.description)) {
+  for (const phrase of growthLimitPhrases(publishableTerms)) {
     growthBullets.push(levelWithheld
       ? `We record ${phrase} as the limit, but ${withheldClause}, so we cannot confirm that threshold today.`
       : `At ${phrase}, you'll need to upgrade.`);
   }
-  if (growthBullets.length === 0 && hasFree) {
+  if (growthBullets.length === 0 && hasFree && !termsSuperseded) {
     growthBullets.push(`When your usage exceeds the free tier limits, you'll need to upgrade.`);
   }
-  if (alternatives.length > 2) {
+  if (alternatives.length > 2 && !termsSuperseded) {
     const topAlt = alternatives[0];
     growthBullets.push(`At that point, consider <a href="/vendor/${toSlug(topAlt.vendor)}">${escHtmlServer(topAlt.vendor)}</a> which offers ${escHtmlServer(topAlt.tier)} in the same category.`);
   }
@@ -4175,10 +4184,10 @@ ${allCompareLinks.join("\n")}
     mainEntity: {
       "@type": "SoftwareApplication",
       name: vendorName,
-      description: primary.description,
+      description: termsSuperseded ? supersededTermsNotice(vendorName, termsSuperseded) : primary.description,
       applicationCategory: primary.category,
       ...(offerRetired(primary) ? {} : { url: primary.url }),
-      ...(primaryGate
+      ...(primaryGate || termsSuperseded
         ? {}
         : {
             offers: {
@@ -4204,7 +4213,10 @@ ${allCompareLinks.join("\n")}
   const eligibilityConditionsSentence = primaryEligibilityConditions.length > 0
     ? ` Eligibility: ${primaryEligibilityConditions.join("; ")}.`
     : "";
-  const faqFreeAnswer = retiredSentence
+  const gateSentencesBeforeTheTerms = `${eligibilityGateSentence}${primaryGateBeyondEligibility ? `${primaryGateBeyondEligibility.reason} ` : ""}`;
+  const faqFreeAnswer = termsSuperseded
+    ? `${gateSentencesBeforeTheTerms}${supersededTermsAnswer(vendorName, termsSuperseded)}`
+    : retiredSentence
     ? `${retiredSentence} ${storedTerms}`
     : primaryGateBeyondEligibility
     ? `${eligibilityGateSentence}${primaryGateBeyondEligibility.reason} ${levelWithheld ? `${unconfirmedTermsPreamble}${withUnconfirmedTermsCaveat(storedTerms)}` : storedTerms}${eligibilityConditionsSentence}`
@@ -4213,7 +4225,9 @@ ${allCompareLinks.join("\n")}
     : primaryEligibilityGate
     ? `${eligibilityGateSentence}${vendorName} offers a free tier: ${primary.tier}. ${storedTerms}${eligibilityConditionsSentence}`
     : `Yes, ${vendorName} offers a free tier: ${primary.tier}. ${storedTerms}`;
-  const faqTierAnswer = retiredSentence
+  const faqTierAnswer = termsSuperseded
+    ? `${eligibilityGateSentence}${vendorName}'s free tier is called "${primary.tier}". ${supersededTermsNotice(vendorName, termsSuperseded)}`
+    : retiredSentence
     ? `${retiredSentence} ${primary.description}`
     : eligibilityGateSentence + (levelWithheld
     ? `${unconfirmedTermsPreamble}Our stored record calls ${vendorName}'s free tier "${primary.tier}". ${withUnconfirmedTermsCaveat(primary.description)}`
@@ -4231,6 +4245,8 @@ ${allCompareLinks.join("\n")}
 
   const faqProductionAnswer = productionGate
     ? `${productionGate.reason} ${NO_FREE_TIER_FOR_PRODUCTION}`
+    : termsSuperseded
+    ? `${eligibilityGateSentence}${supersededTermsVerdictSentence(vendorName, termsSuperseded)} Until we have re-read the page we cannot say what capacity ${vendorName} gives you, so we are not recommending it for production on figures we have already superseded.`
     : eligibilityGateSentence + (levelWithheld
     ? `${withheldLevelSentence(levelWithheld, vendorName, unconfirmableSince)} We cannot confirm what this offer provides today, so we are not recommending it for production or for anything else until we can.`
     : hasFree
@@ -4410,7 +4426,9 @@ ${referralCalloutHtml}
 
   <div class="desc-block">
     <h2>Free Tier Details</h2>
-    <p class="desc-text">${escHtmlServer(primary.description)}</p>
+    ${termsSuperseded
+      ? `<p class="terms-superseded-text"><strong>${SUPERSEDED_TERMS_LABEL}:</strong> ${escHtmlServer(supersededTermsNotice(vendorName, termsSuperseded))} <a href="#changes">Read what we recorded &darr;</a></p>`
+      : `<p class="desc-text">${escHtmlServer(primary.description)}</p>`}
   </div>
 ${compareTableHtml}
 ${growthPathHtml}

--- a/src/superseded-description.ts
+++ b/src/superseded-description.ts
@@ -1,0 +1,76 @@
+import { changeDateClause } from "./change-dates.js";
+import { isNoLongerInForce } from "./change-resolution.js";
+import type { ChangeResolution, DealChange } from "./types.js";
+
+export interface QuotingChange extends Pick<DealChange, "date" | "date_source"> {
+  summary: string;
+  previous_state?: string | null;
+  resolution?: ChangeResolution | null;
+}
+
+export interface StoredTerms {
+  vendor: string;
+  description: string;
+}
+
+function comparableTerms(text: string | null | undefined): string {
+  return (text ?? "").replace(/\s+/g, " ").trim().toLowerCase();
+}
+
+export function quotesTheStoredTermsAsPrevious(change: QuotingChange, description: string): boolean {
+  const quoted = comparableTerms(change.previous_state);
+  return quoted !== "" && quoted === comparableTerms(description);
+}
+
+export function supersedingChange<T extends QuotingChange>(
+  offer: Pick<StoredTerms, "description">,
+  vendorChanges: readonly T[],
+): T | null {
+  let newest: T | null = null;
+  for (const change of vendorChanges) {
+    if (isNoLongerInForce(change)) continue;
+    if (!quotesTheStoredTermsAsPrevious(change, offer.description)) continue;
+    if (!newest || change.date > newest.date) newest = change;
+  }
+  return newest;
+}
+
+export function storedTermsAreSuperseded(
+  offer: Pick<StoredTerms, "description">,
+  vendorChanges: readonly QuotingChange[],
+): boolean {
+  return supersedingChange(offer, vendorChanges) !== null;
+}
+
+export const SUPERSEDED_TERMS_LABEL = "Superseded";
+
+export function supersededTermsNotice(vendor: string, change: QuotingChange): string {
+  return (
+    `The terms we store for ${vendor} are the ones our own pricing change record, ` +
+    `${changeDateClause(change)}, names as the previous ones. We have not re-read ${vendor}'s ` +
+    `pricing page since that record, so we are not publishing them as current.`
+  );
+}
+
+export function supersededTermsAnswer(vendor: string, change: QuotingChange): string {
+  return (
+    `We are not answering that from our stored terms today. Our pricing change record, ` +
+    `${changeDateClause(change)}, names them as the previous terms: ${change.summary} ` +
+    `We have not re-read ${vendor}'s pricing page since, so the recorded change is what we stand behind, ` +
+    `not the figures it replaces.`
+  );
+}
+
+export function supersededTermsMetaSentence(vendor: string, change: QuotingChange): string {
+  return (
+    `Our stored ${vendor} free-tier terms are superseded by a pricing change we recorded on ` +
+    `${change.date} and have not re-read since.`
+  );
+}
+
+export function supersededTermsVerdictSentence(vendor: string, change: QuotingChange): string {
+  return (
+    `We are not publishing ${vendor}'s stored free-tier figures — our pricing change record, ` +
+    `${changeDateClause(change)}, names them as the previous ones.`
+  );
+}

--- a/test/eligibility-disclosure.test.ts
+++ b/test/eligibility-disclosure.test.ts
@@ -8,13 +8,26 @@ import { fileURLToPath } from "node:url";
 const { eligibilityGate, eligibilityGateAsPublished, publishableEligibilityConditions, CONDITION_RECORDING_AN_UNREAD_PROGRAM } =
   await import("../dist/eligibility.js");
 const { gateFor, notAFreeOfferGateFor, utcDate } = await import("../dist/ranking.js");
+const { supersededTermsNotice, supersedingChange } = await import("../dist/superseded-description.js");
 
 type Offer = import("../src/types.ts").Offer;
+type DealChange = import("../src/types.ts").DealChange;
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const REPO = path.join(__dirname, "..");
 
 const offers: Offer[] = JSON.parse(readFileSync(path.join(REPO, "data", "index.json"), "utf-8")).offers;
+const dealChanges: DealChange[] = JSON.parse(
+  readFileSync(path.join(REPO, "data", "deal_changes.json"), "utf-8"),
+).changes;
+
+function publishedDescriptionOf(offer: Offer): string {
+  const superseding = supersedingChange(
+    offer,
+    dealChanges.filter(c => c.vendor.toLowerCase() === offer.vendor.toLowerCase()),
+  );
+  return superseding ? supersededTermsNotice(offer.vendor, superseding) : offer.description;
+}
 
 function slugOf(vendor: string): string {
   return vendor.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "");
@@ -78,7 +91,7 @@ function renderedOffer(html: string): Offer | undefined {
   const vendor = webPage?.mainEntity?.name;
   const description = webPage?.mainEntity?.description;
   if (typeof vendor !== "string" || typeof description !== "string") return undefined;
-  return offers.find(o => o.vendor === vendor && o.description === description);
+  return offers.find(o => o.vendor === vendor && publishedDescriptionOf(o) === description);
 }
 
 type RenderedPage = { vendor: string; slug: string; html: string; offer: Offer };

--- a/test/gated-vendor-answers.test.ts
+++ b/test/gated-vendor-answers.test.ts
@@ -8,15 +8,34 @@ import { fileURLToPath } from "node:url";
 const { gateFor, utcDate } = await import("../dist/ranking.js");
 const { vendorSlugMap } = await import("../dist/vendor-slug.js");
 const { offerEnded } = await import("../dist/retirement.js");
+const { supersededTermsNotice, supersedingChange } = await import("../dist/superseded-description.js");
 
 type Offer = import("../src/types.ts").Offer;
+type DealChange = import("../src/types.ts").DealChange;
 type Gate = { code: string; reason: string };
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const REPO = path.join(__dirname, "..");
 
 const offers: Offer[] = JSON.parse(readFileSync(path.join(REPO, "data", "index.json"), "utf-8")).offers;
+const dealChanges: DealChange[] = JSON.parse(
+  readFileSync(path.join(REPO, "data", "deal_changes.json"), "utf-8"),
+).changes;
 const TODAY = utcDate();
+
+const supersededBy = new Map<Offer, DealChange>();
+for (const offer of offers) {
+  const superseding = supersedingChange(
+    offer,
+    dealChanges.filter(c => c.vendor.toLowerCase() === offer.vendor.toLowerCase()),
+  );
+  if (superseding) supersededBy.set(offer, superseding);
+}
+
+function publishedDescriptionOf(offer: Offer): string {
+  const superseding = supersededBy.get(offer);
+  return superseding ? supersededTermsNotice(offer.vendor, superseding) : offer.description;
+}
 
 const PAY_AS_YOU_GO_REASON = 'Tier "Pay-as-you-go" is usage-billed from the first request.';
 const DIGITALOCEAN_EXPIRY_REASON = "Offer expired on 2026-06-30.";
@@ -24,8 +43,9 @@ const NO_FREE_TIER_FOR_PRODUCTION = "There is no free tier here to run in produc
 const STABLE_RATING_CLAUSE = "We rate it stable and";
 const RECOMMENDATION_CLAUSE = "so it's a reasonable starting point";
 
-const UNGATED_PAGES_ANSWERING_YES = 745;
-const UNGATED_PAGES_RECOMMENDING = 582;
+const UNGATED_PAGES_ANSWERING_YES = 588;
+const UNGATED_PAGES_RECOMMENDING = 559;
+const UNGATED_PAGES_WITHHOLDING_SUPERSEDED_TERMS = 222;
 
 let port = 0;
 let proc: ChildProcess | null = null;
@@ -138,6 +158,8 @@ after(() => { proc?.kill(); });
 
 const gated = () => rendered.filter(p => p.gate);
 const ungated = () => rendered.filter(p => !p.gate);
+const supersededTerms = (p: VendorPage) => supersededBy.has(p.primary);
+const publishingItsTerms = () => ungated().filter(p => !supersededTerms(p));
 const freeAnswer = (p: VendorPage) => faqAnswer(p.html, `Is ${p.vendor} free?`);
 const productionAnswer = (p: VendorPage) => faqAnswer(p.html, `Is ${p.vendor}'s free tier good for production?`);
 
@@ -147,7 +169,7 @@ describe("the page a gated record renders does not answer the free-tier question
     for (const p of rendered) {
       assert.strictEqual(
         blockOfType(p.html, "WebPage")?.mainEntity?.description,
-        p.primary.description,
+        publishedDescriptionOf(p.primary),
         `/vendor/${p.slug} renders a record other than the first this vendor holds`,
       );
     }
@@ -178,13 +200,29 @@ describe("the page a gated record renders does not answer the free-tier question
   });
 
   it("states the terms the record does hold after that sentence", () => {
-    for (const p of gated().filter(x => x.gate!.code !== "eligibility_restricted" && !offerEnded(x.primary))) {
+    const subjects = gated().filter(
+      x => x.gate!.code !== "eligibility_restricted" && !offerEnded(x.primary) && !supersededTerms(x),
+    );
+    assert.ok(subjects.length > 0, "no gated record still publishes its stored terms, so this assertion has no subject");
+    for (const p of subjects) {
       const answer = freeAnswer(p);
       const opening = p.primary.description.slice(0, 60);
       assert.ok(
         answer.includes(opening),
         `/vendor/${p.slug} drops the stored terms: ${answer.slice(0, 120)}`,
       );
+    }
+  });
+
+  it("says why it withholds them where the change log supersedes them instead", () => {
+    const subjects = gated().filter(
+      x => x.gate!.code !== "eligibility_restricted" && !offerEnded(x.primary) && supersededTerms(x),
+    );
+    assert.ok(subjects.length > 0, "no gated record has superseded terms, so this assertion has no subject");
+    for (const p of subjects) {
+      const answer = freeAnswer(p);
+      assert.ok(!answer.includes(p.primary.description.slice(0, 60)), `/vendor/${p.slug} still states them: ${answer.slice(0, 120)}`);
+      assert.ok(answer.includes("names them as the previous terms"), `/vendor/${p.slug}: ${answer.slice(0, 160)}`);
     }
   });
 
@@ -228,7 +266,7 @@ describe("the page a gated record renders does not answer the free-tier question
 
 describe("the ungated pages keep the answer they had", () => {
   it("answers yes on every ungated record nothing else withholds", () => {
-    const plainlyFree = ungated().filter(
+    const plainlyFree = publishingItsTerms().filter(
       p => p.primary.source_check?.outcome === "ok"
         && p.primary.tier.toLowerCase() !== "none"
         && !p.primary.description.toLowerCase().includes("no free tier"),
@@ -236,6 +274,12 @@ describe("the ungated pages keep the answer they had", () => {
     assert.ok(plainlyFree.length > 100, `only ${plainlyFree.length} ungated pages are plainly free`);
     const quiet = plainlyFree.filter(p => !freeAnswer(p).startsWith("Yes")).map(p => p.slug);
     assert.deepStrictEqual(quiet, []);
+  });
+
+  it("counts the ungated pages that withhold their terms, so the drop below is accounted for", () => {
+    const withholding = ungated().filter(supersededTerms).length;
+    assert.strictEqual(withholding, UNGATED_PAGES_WITHHOLDING_SUPERSEDED_TERMS);
+    assert.deepStrictEqual(ungated().filter(p => supersededTerms(p) && freeAnswer(p).startsWith("Yes")).map(p => p.slug), []);
   });
 
   it("counts at least as many ungated pages answering yes as the census found", () => {
@@ -606,11 +650,22 @@ describe("the same page an ungated record renders is unchanged", () => {
   });
 
   it("still opens its verdict on the free tier", () => {
-    const notOpening = ungated().filter(p => !pageProse(p).includes(`${p.vendor}'s free tier offers `)).map(p => p.slug);
+    const notOpening = publishingItsTerms().filter(p => !pageProse(p).includes(`${p.vendor}'s free tier offers `)).map(p => p.slug);
     assert.ok(
-      notOpening.length < ungated().length * 0.01,
+      notOpening.length < publishingItsTerms().length * 0.01,
       `${notOpening.length} ungated verdicts do not open on the free tier: ${notOpening.slice(0, 20).join(", ")}`,
     );
+  });
+
+  it("opens the verdict on the supersession where the change log holds one", () => {
+    const subjects = ungated().filter(supersededTerms);
+    assert.ok(subjects.length > 100, `only ${subjects.length} ungated pages withhold superseded terms`);
+    const opening = subjects.filter(p => pageProse(p).includes(`${p.vendor}'s free tier offers `)).map(p => p.slug);
+    assert.deepStrictEqual(opening.slice(0, 20), [], "verdicts still opening on figures the change log supersedes");
+    const silent = subjects
+      .filter(p => !pageProse(p).includes(`names them as the previous ones`))
+      .map(p => p.slug);
+    assert.deepStrictEqual(silent.slice(0, 20), [], "verdicts that withhold the figures without saying why");
   });
 
   it("still rates the free tier in its reliability answer", () => {
@@ -630,7 +685,12 @@ describe("the same page an ungated record renders is unchanged", () => {
   });
 
   it("still publishes a zero-price Offer", () => {
-    const missing = ungated().filter(p => offerBlock(p)?.price !== "0").map(p => p.slug);
+    const missing = publishingItsTerms().filter(p => offerBlock(p)?.price !== "0").map(p => p.slug);
     assert.deepStrictEqual(missing.slice(0, 20), [], "ungated pages that stopped publishing a zero-price Offer");
+  });
+
+  it("publishes none where the change log supersedes the terms behind it", () => {
+    const offering = ungated().filter(p => supersededTerms(p) && offerBlock(p) !== undefined).map(p => p.slug);
+    assert.deepStrictEqual(offering.slice(0, 20), [], "pages offering a price of zero for terms we withhold");
   });
 });

--- a/test/http.test.ts
+++ b/test/http.test.ts
@@ -1438,7 +1438,7 @@ describe("HTTP transport", () => {
   it("GET /vendor/:slug includes enriched JSON-LD with dateModified", async () => {
     proc = await startHttpServer();
 
-    const response = await fetch(`http://localhost:${serverPort}/vendor/railway`);
+    const response = await fetch(`http://localhost:${serverPort}/vendor/vercel`);
     const html = await response.text();
     assert.ok(html.includes("dateModified"), "JSON-LD should include dateModified");
     assert.ok(html.includes('"@type":"Offer"'), "JSON-LD should include an Offer");

--- a/test/superseded-terms.test.ts
+++ b/test/superseded-terms.test.ts
@@ -1,0 +1,397 @@
+import { describe, it, before, after } from "node:test";
+import assert from "node:assert";
+import { spawn, type ChildProcess } from "node:child_process";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const {
+  quotesTheStoredTermsAsPrevious,
+  supersedingChange,
+  storedTermsAreSuperseded,
+} = await import("../dist/superseded-description.js");
+const { toSlug } = await import("../dist/slug.js");
+
+type Offer = import("../src/types.ts").Offer;
+type DealChange = import("../src/types.ts").DealChange;
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO = path.join(__dirname, "..");
+
+const offers: Offer[] = JSON.parse(readFileSync(path.join(REPO, "data", "index.json"), "utf-8")).offers;
+const changes: DealChange[] = JSON.parse(
+  readFileSync(path.join(REPO, "data", "deal_changes.json"), "utf-8"),
+).changes;
+
+const RECORDS_WHOSE_STORED_TERMS_ARE_SUPERSEDED = 237;
+const VENDOR_PAGES_RENDERING_ONE_OF_THEM = 235;
+
+const changesByVendor = new Map<string, DealChange[]>();
+for (const change of changes) {
+  const key = change.vendor.toLowerCase();
+  const held = changesByVendor.get(key);
+  if (held) held.push(change);
+  else changesByVendor.set(key, [change]);
+}
+
+function changesFor(vendor: string): DealChange[] {
+  return changesByVendor.get(vendor.toLowerCase()) ?? [];
+}
+
+function supersededRecords(): { offer: Offer; change: DealChange }[] {
+  const found: { offer: Offer; change: DealChange }[] = [];
+  for (const offer of offers) {
+    const change = supersedingChange(offer, changesFor(offer.vendor));
+    if (change) found.push({ offer, change });
+  }
+  return found;
+}
+
+function firstRecordFor(vendor: string): Offer {
+  return offers.find((o) => o.vendor === vendor)!;
+}
+
+function supersededPagesRender(): { offer: Offer; change: DealChange }[] {
+  return supersededRecords().filter(({ offer }) => firstRecordFor(offer.vendor) === offer);
+}
+
+const A_RECORD = {
+  vendor: "Quotacorp",
+  category: "Cloud Hosting",
+  description: "Free plan: 100 GB egress, 1 GiB storage, 5 projects",
+  tier: "Free",
+  url: "https://quotacorp.example/pricing",
+  tags: ["hosting"],
+  verifiedDate: "2026-08-01",
+};
+
+const A_CHANGE_QUOTING_IT = {
+  vendor: "Quotacorp",
+  change_type: "limits_reduced",
+  date: "2026-08-28",
+  date_source: "discovered",
+  summary: "Egress on the free plan is now 20 GiB, down from 100 GB.",
+  previous_state: A_RECORD.description,
+  current_state: "Free plan: 20 GiB egress, 1 GiB storage, 5 projects",
+  impact: "high",
+  source_url: "https://quotacorp.example/pricing",
+  category: "Cloud Hosting",
+  alternatives: [],
+};
+
+describe("#1103 a change record that quotes our stored terms as the previous ones", () => {
+  it("recognises the quote", () => {
+    assert.strictEqual(quotesTheStoredTermsAsPrevious(A_CHANGE_QUOTING_IT, A_RECORD.description), true);
+  });
+
+  it("reads through whitespace and case, which the detector does not preserve", () => {
+    const reflowed = { ...A_CHANGE_QUOTING_IT, previous_state: "  free plan: 100 GB egress,\n 1 GiB storage,  5 projects " };
+    assert.strictEqual(quotesTheStoredTermsAsPrevious(reflowed, A_RECORD.description), true);
+  });
+
+  it("does not fire on a change that quotes nothing", () => {
+    for (const empty of [undefined, null, "", "   "]) {
+      assert.strictEqual(
+        quotesTheStoredTermsAsPrevious({ ...A_CHANGE_QUOTING_IT, previous_state: empty }, A_RECORD.description),
+        false,
+        `previous_state ${JSON.stringify(empty)} must not match`,
+      );
+    }
+  });
+
+  it("does not let a record with no stored terms be superseded by a change that quotes none", () => {
+    const blank = { ...A_RECORD, description: "   " };
+    const quotingNothing = { ...A_CHANGE_QUOTING_IT, previous_state: "" };
+    assert.strictEqual(storedTermsAreSuperseded(blank, [quotingNothing]), false);
+    assert.ok(
+      changes.filter((c) => !(c.previous_state ?? "").trim()).length > 50,
+      "too few changes quote nothing for that guard to be worth holding",
+    );
+  });
+
+  it("does not fire on a change that quotes part of the stored terms", () => {
+    const head = A_RECORD.description.slice(0, 30);
+    assert.ok(head.length > 20 && A_RECORD.description.startsWith(head));
+    assert.strictEqual(storedTermsAreSuperseded(A_RECORD, [{ ...A_CHANGE_QUOTING_IT, previous_state: head }]), false);
+    const extended = { ...A_RECORD, description: `${A_RECORD.description}, 2 seats` };
+    assert.strictEqual(storedTermsAreSuperseded(extended, [A_CHANGE_QUOTING_IT]), false);
+  });
+
+  it("does not fire once the record carries what the change says replaced the terms", () => {
+    const applied = { ...A_RECORD, description: A_CHANGE_QUOTING_IT.current_state };
+    assert.strictEqual(storedTermsAreSuperseded(applied, [A_CHANGE_QUOTING_IT]), false);
+  });
+
+  it("stops firing when the change is resolved, which is the way back", () => {
+    const retracted = {
+      ...A_CHANGE_QUOTING_IT,
+      resolution: { state: "retracted", date: "2026-09-05", detail: "The plan table still lists 100 GB." },
+    };
+    assert.strictEqual(storedTermsAreSuperseded(A_RECORD, [retracted]), false);
+  });
+
+  it("takes the newest of several", () => {
+    const older = { ...A_CHANGE_QUOTING_IT, date: "2026-08-02" };
+    const newer = { ...A_CHANGE_QUOTING_IT, date: "2026-09-04" };
+    assert.strictEqual(supersedingChange(A_RECORD, [newer, older])?.date, "2026-09-04");
+    assert.strictEqual(supersedingChange(A_RECORD, [older, newer])?.date, "2026-09-04");
+  });
+});
+
+describe("#1103 the catalogue population", () => {
+  it("holds the count, so a new one has to be looked at", () => {
+    assert.strictEqual(supersededRecords().length, RECORDS_WHOSE_STORED_TERMS_ARE_SUPERSEDED);
+  });
+
+  it("holds the count a vendor page renders, which is smaller where the vendor has a second record", () => {
+    assert.strictEqual(supersededPagesRender().length, VENDOR_PAGES_RENDERING_ONE_OF_THEM);
+  });
+
+  it("finds one superseding change per record, so no page has to choose between two", () => {
+    for (const offer of offers) {
+      const quoting = changesFor(offer.vendor).filter(
+        (c) => !c.resolution && quotesTheStoredTermsAsPrevious(c, offer.description),
+      );
+      assert.ok(quoting.length <= 1, `${offer.vendor} has ${quoting.length} changes quoting its stored terms`);
+    }
+  });
+});
+
+const FIXTURE_VENDOR = "Deno Deploy";
+const FIXTURE_SLUG = toSlug(FIXTURE_VENDOR);
+
+function fixtureFrom(withResolution: boolean) {
+  const record = JSON.parse(JSON.stringify(offers.find((o) => o.vendor === FIXTURE_VENDOR)));
+  const change = JSON.parse(JSON.stringify(changes.find((c) => c.vendor === FIXTURE_VENDOR)));
+  assert.ok(record && change, "the fixture is built from the record and change this issue names");
+  record.description = change.previous_state;
+  if (withResolution) {
+    change.resolution = { state: "reversed", date: "2026-09-04", detail: "The vendor restored the earlier limits." };
+  }
+  return { record, change };
+}
+
+function writeFixture(dir: string, name: string, withResolution: boolean) {
+  const { record, change } = fixtureFrom(withResolution);
+  writeFileSync(path.join(dir, `${name}-index.json`), JSON.stringify({ offers: [record, ...offers.filter((o) => o.vendor !== FIXTURE_VENDOR)] }));
+  writeFileSync(path.join(dir, `${name}-changes.json`), JSON.stringify({ changes: [change] }));
+  return { record, change };
+}
+
+function startServer(env: Record<string, string>): Promise<{ proc: ChildProcess; port: number }> {
+  return new Promise((resolve, reject) => {
+    const child = spawn("node", [path.join(REPO, "dist", "serve.js")], {
+      stdio: ["pipe", "pipe", "pipe"],
+      env: { ...process.env, PORT: "0", BASE_URL: "http://localhost", TZ: "UTC", ...env },
+    });
+    const timeout = setTimeout(() => { child.kill(); reject(new Error("Server startup timeout")); }, 60000);
+    child.stderr!.on("data", (data: Buffer) => {
+      const m = data.toString().match(/running on http:\/\/localhost:(\d+)/);
+      if (m) { clearTimeout(timeout); resolve({ proc: child, port: parseInt(m[1], 10) }); }
+    });
+    child.on("error", (err) => { clearTimeout(timeout); reject(err); });
+  });
+}
+
+function jsonLdOfType(html: string, type: string): Record<string, any> | undefined {
+  for (const m of html.matchAll(/<script type="application\/ld\+json">([\s\S]*?)<\/script>/g)) {
+    try {
+      const parsed = JSON.parse(m[1]);
+      if (parsed["@type"] === type) return parsed;
+    } catch { continue; }
+  }
+  return undefined;
+}
+
+function metaDescriptionOf(html: string): string {
+  return /<meta name="description" content="([^"]*)"/.exec(html)?.[1] ?? "";
+}
+
+function descriptionBlockOf(html: string): string {
+  return /<div class="desc-block">[\s\S]*?<\/div>/.exec(html)?.[0] ?? "";
+}
+
+function faqAnswersOf(html: string): { question: string; answer: string }[] {
+  const faq = jsonLdOfType(html, "FAQPage");
+  return (faq?.mainEntity ?? []).map((item: { name: string; acceptedAnswer: { text: string } }) => ({
+    question: item.name,
+    answer: item.acceptedAnswer.text,
+  }));
+}
+
+function unescaped(html: string): string {
+  return html.replace(/&#39;/g, "'").replace(/&quot;/g, '"').replace(/&amp;/g, "&");
+}
+
+describe("#1103 a page whose stored terms its own change log quotes as previous", () => {
+  let dir = "";
+  let superseded: { proc: ChildProcess; port: number } | null = null;
+  let resolved: { proc: ChildProcess; port: number } | null = null;
+  let supersededPage = "";
+  let resolvedPage = "";
+  let storedTerms = "";
+
+  before(async () => {
+    dir = mkdtempSync(path.join(tmpdir(), "superseded-terms-"));
+    const built = writeFixture(dir, "superseded", false);
+    writeFixture(dir, "resolved", true);
+    storedTerms = built.record.description;
+    [superseded, resolved] = await Promise.all([
+      startServer({
+        AGENTDEALS_INDEX_PATH: path.join(dir, "superseded-index.json"),
+        AGENTDEALS_CHANGES_PATH: path.join(dir, "superseded-changes.json"),
+      }),
+      startServer({
+        AGENTDEALS_INDEX_PATH: path.join(dir, "resolved-index.json"),
+        AGENTDEALS_CHANGES_PATH: path.join(dir, "resolved-changes.json"),
+      }),
+    ]);
+    supersededPage = await fetch(`http://localhost:${superseded.port}/vendor/${FIXTURE_SLUG}`).then((r) => r.text());
+    resolvedPage = await fetch(`http://localhost:${resolved.port}/vendor/${FIXTURE_SLUG}`).then((r) => r.text());
+  });
+
+  after(() => {
+    superseded?.proc.kill();
+    resolved?.proc.kill();
+    if (dir) rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("builds a fixture whose stored terms are the change's previous_state", () => {
+    const { record, change } = fixtureFrom(false);
+    assert.strictEqual(record.description, change.previous_state);
+    assert.notStrictEqual(change.previous_state, change.current_state);
+    assert.ok(storedTerms.length > 60, "the stored terms must be long enough for the assertions below to bite");
+  });
+
+  it("does not state the stored terms in the description block", () => {
+    assert.ok(!unescaped(descriptionBlockOf(supersededPage)).includes(storedTerms));
+  });
+
+  it("does not state the stored terms in the meta description", () => {
+    const meta = unescaped(metaDescriptionOf(supersededPage));
+    assert.ok(!meta.includes(storedTerms.slice(0, 60)), meta);
+    assert.ok(meta.includes("superseded by a pricing change we recorded on"), meta);
+  });
+
+  it("offers no upgrade threshold read off terms it will not publish", () => {
+    assert.ok(!supersededPage.includes(`class="section growth-section"`), "the page still tells the reader when they outgrow figures it withholds");
+    assert.ok(resolvedPage.includes(`class="section growth-section"`), "the same page without the supersession must carry one, or the assertion above is vacuous");
+  });
+
+  it("does not state the stored terms in the structured description a machine reads", () => {
+    const page = jsonLdOfType(supersededPage, "WebPage");
+    assert.ok(page, "the page must ship WebPage structured data for the assertion to mean anything");
+    assert.ok(!page!.mainEntity.description.includes(storedTerms));
+    assert.ok(!String(page!.description).includes(storedTerms.slice(0, 60)));
+  });
+
+  it("does not state the stored terms in any structured answer", () => {
+    const stating = faqAnswersOf(supersededPage).filter((pair) => pair.answer.includes(storedTerms.slice(0, 60)));
+    assert.deepStrictEqual(stating.map((pair) => pair.question), []);
+  });
+
+  it("does not answer that the vendor offers the tier we can no longer stand behind", () => {
+    const answers = faqAnswersOf(supersededPage);
+    const isFree = answers.find((pair) => pair.question === `Is ${FIXTURE_VENDOR} free?`);
+    assert.ok(isFree, "the page must still ask whether the vendor is free");
+    assert.ok(!isFree!.answer.startsWith("Yes,"), isFree!.answer);
+    assert.ok(isFree!.answer.includes("previous terms"), isFree!.answer);
+  });
+
+  it("still names the tier while withholding the figures behind it", () => {
+    const tier = faqAnswersOf(supersededPage).find(
+      (pair) => pair.question === `What is ${FIXTURE_VENDOR}'s free tier?`,
+    );
+    assert.ok(tier, "the page must still answer what the tier is called");
+    assert.ok(tier!.answer.includes(`is called "Free"`), tier!.answer);
+    assert.ok(!tier!.answer.includes(storedTerms.slice(0, 60)), tier!.answer);
+  });
+
+  it("does not offer a price of zero to a machine reading the record", () => {
+    const page = jsonLdOfType(supersededPage, "WebPage");
+    assert.ok(!("offers" in page!.mainEntity), JSON.stringify(page!.mainEntity.offers ?? null));
+  });
+
+  it("keeps the terms on the page as what the change record replaced", () => {
+    assert.ok(unescaped(supersededPage).includes(storedTerms));
+    assert.ok(supersededPage.includes("Before:"));
+  });
+
+  it("publishes the same terms as current once the change is resolved", () => {
+    assert.ok(unescaped(descriptionBlockOf(resolvedPage)).includes(storedTerms));
+    const isFree = faqAnswersOf(resolvedPage).find((pair) => pair.question === `Is ${FIXTURE_VENDOR} free?`);
+    assert.ok(isFree!.answer.startsWith("Yes,"), isFree!.answer);
+    assert.ok("offers" in jsonLdOfType(resolvedPage, "WebPage")!.mainEntity);
+  });
+});
+
+describe("#1103 every catalogue record whose stored terms are superseded", () => {
+  let server: { proc: ChildProcess; port: number } | null = null;
+  const bodies = new Map<string, string>();
+  const population = supersededPagesRender();
+
+  before(async () => {
+    server = await startServer({});
+    const queue = population.map(({ offer }) => `/vendor/${toSlug(offer.vendor)}`);
+    let next = 0;
+    await Promise.all(
+      Array.from({ length: 12 }, async () => {
+        while (next < queue.length) {
+          const pathname = queue[next++];
+          bodies.set(pathname, await fetch(`http://localhost:${server!.port}${pathname}`).then((r) => r.text()));
+        }
+      }),
+    );
+  });
+
+  after(() => { server?.proc.kill(); });
+
+  it("renders a page for every one of them", () => {
+    assert.strictEqual(bodies.size, population.length);
+  });
+
+  it("states the stored terms in no description block", () => {
+    const stating = population.filter(({ offer }) =>
+      unescaped(descriptionBlockOf(bodies.get(`/vendor/${toSlug(offer.vendor)}`)!)).includes(offer.description),
+    );
+    assert.deepStrictEqual(stating.map(({ offer }) => offer.vendor), []);
+  });
+
+  it("states the stored terms in no structured answer and no structured description", () => {
+    const stating: string[] = [];
+    for (const { offer, change } of population) {
+      const html = bodies.get(`/vendor/${toSlug(offer.vendor)}`)!;
+      const opening = offer.description.slice(0, 60);
+      const withoutWhatTheChangeItselfSays = (text: string) => text.split(change.summary).join(" ");
+      const page = jsonLdOfType(html, "WebPage");
+      if (page && String(page.mainEntity?.description ?? "").includes(opening)) stating.push(`${offer.vendor} :: mainEntity`);
+      if (page && String(page.description ?? "").includes(opening)) stating.push(`${offer.vendor} :: WebPage`);
+      for (const pair of faqAnswersOf(html)) {
+        if (withoutWhatTheChangeItselfSays(pair.answer).includes(opening)) stating.push(`${offer.vendor} :: ${pair.question}`);
+      }
+    }
+    assert.deepStrictEqual(stating, []);
+  });
+
+  it("offers a price of zero to none of them", () => {
+    const offering = population.filter(({ offer }) =>
+      "offers" in (jsonLdOfType(bodies.get(`/vendor/${toSlug(offer.vendor)}`)!, "WebPage")?.mainEntity ?? {}),
+    );
+    assert.deepStrictEqual(offering.map(({ offer }) => offer.vendor), []);
+  });
+
+  it("names an upgrade threshold on none of them", () => {
+    const telling = population
+      .filter(({ offer }) => bodies.get(`/vendor/${toSlug(offer.vendor)}`)!.includes(`class="section growth-section"`))
+      .map(({ offer }) => offer.vendor);
+    assert.deepStrictEqual(telling.slice(0, 20), []);
+  });
+
+  it("says in the meta description of every one why the terms are withheld", () => {
+    const silent = population
+      .filter(({ offer }) => !metaDescriptionOf(bodies.get(`/vendor/${toSlug(offer.vendor)}`)!).includes("superseded by a pricing change we recorded on"))
+      .map(({ offer }) => offer.vendor);
+    assert.deepStrictEqual(silent.slice(0, 20), []);
+  });
+});


### PR DESCRIPTION
`/vendor/*` publishes a description that our own change log names as the *previous* state, with the record saying so a few inches below it. 237 records are in that position today.

Refs #1103 — AC-1's second branch, per the ruling on the issue: the page stops presenting the description rather than the record being overwritten from a `current_state` that survived only five hand checks in seven.

## The rule

A change supersedes the stored terms when its `previous_state`, whitespace- and case-normalised, **is** the record's `description`, and the change is still in force. No change type is read and no judgement is made about whether the vendor really did what the record says — our own log has already named that exact text as superseded.

Measured against the shipped data: 237 records, 237 distinct vendors, exactly one such change each, none with `current_state` equal to the description, none re-verified on or after the change date. 235 of the 237 are the first record their vendor holds, so 235 vendor pages change.

The rule also reaches 28 of the 29 records the type-shaped alternative finds (a free-tier removal in force over a record still classed free). The 29th is OpenAI, whose two `free_tier_removed` records are about the Assistants API and DALL-E — other products of the same vendor, not the tier we describe.

## What changes on those pages

The stored figures no longer appear in the `Free Tier Details` block, the meta description, the `WebPage` and `SoftwareApplication` JSON-LD descriptions, the quick verdict, or any `FAQPage` answer. The zero-price `Offer` node is not emitted. Where a gate is also in force its sentence still opens the answer.

The terms stay on the page in one place — the change history, behind the `Before:` label. `$50,000` appeared 18 times on `/vendor/segment` when the issue was filed and appears 9 times now, every one of them inside *"no longer listed"* or behind `Before:`.

## The way back

The predicate reads `isNoLongerInForce`, so marking a change `reversed` or `retracted` restores the page with no code change. A paired fixture renders the same record and change withheld without a resolution and normally with one.

## Tests

`test/superseded-terms.test.ts`, 28 tests. AC-3's fixture is `deno-deploy`: an index whose record `description` is that change's `previous_state` — the state the record was in on 2026-08-28 — served and asserted against. Plus a census over all 235 rendered pages.

`scripts/mutate-1103.sh`: 13 mutations of the predicate and the render, 13 killed.

Three existing files widened rather than exempted: an ungated page that withholds superseded terms is a third state, so the invariants now name it and assert the counterpart. `UNGATED_PAGES_ANSWERING_YES` drops 745 → 588 and the drop is pinned to the 222 ungated pages that withhold.
