### PR TITLE
Publish the real free tiers our own change log already recorded — Firecrawl and Inngest

### DIFF
--- a/data/index.json
+++ b/data/index.json
@@ -3165,7 +3165,7 @@
     {
       "vendor": "Inngest",
       "category": "Background Jobs",
-      "description": "Serverless workflow orchestration — 50K function executions/month, 100K events, 5 concurrent steps, 3 users, unlimited environments",
+      "description": "Serverless workflow orchestration — 50K executions, 500K events ingested, 5 concurrent steps, 500 MB span data ingested, 100K queue depth, 50 realtime connections",
       "tier": "Hobby",
       "url": "https://www.inngest.com/pricing",
       "tags": [

--- a/data/index.json
+++ b/data/index.json
@@ -2298,7 +2298,7 @@
     {
       "vendor": "Firecrawl",
       "category": "Web Scraping",
-      "description": "Web scraping API — 500 credits (up to 500 pages), 2 concurrent requests, no credit card required",
+      "description": "Web scraping API — 1,000 credits/month (500 searches or 1,000 pages scraped), 2 concurrent requests, no credit card required",
       "tier": "Free",
       "url": "https://www.firecrawl.dev/pricing",
       "tags": [


### PR DESCRIPTION
Two vendor records understate a free tier that our own change log already recorded as larger. Both verified live on 2026-09-05, read from the plan table rather than the hero.

**Firecrawl.** `firecrawl.dev/pricing` prices the Free Plan at **1,000 credits / month, $0/month, 500 searches or 1,000 pages scraped, 2 concurrent requests**. Our record said `500 credits (up to 500 pages)` — half the real allowance. The `limits_increased` record of 2026-09-01 reads *"The free tier now offers 1,000 credits/month instead of 500."*

**Inngest.** `inngest.com/pricing` prices the Hobby plan at **$0/mo: 50k executions, 5 concurrent steps, 500 MB span data ingested, 10K scores, 500k events ingested, 100k queue depth, 50 realtime connections**. Our record said `100K events` and `3 users`; the page states 500K events and no user cap on Hobby. The `limits_increased` record of 2026-08-28 says both.

## Why this is worth doing now

Since #1379, both records were also withholding their vendor page: the change quotes the stored description as the previous state, so `/vendor/firecrawl` and `/vendor/inngest` published no free-tier figures at all. Updating the description breaks that match, so the pages come back — with the correct, larger numbers rather than the stale ones.

This is the exit I said I would own on https://github.com/robhunter/agentdeals/issues/1103. 46 of the withheld pages are withheld because the free tier improved, and confirming a number went up is the cheapest check on that list. Two records as a worked example of the shape.

Ratchet before and after, both edits: `stale_fact_pages` 57, `unsourced_tier_a` 41, `uncited_change_records` 95, `source_checks_ok_without_quoted_evidence` 614. Unchanged, nothing over. No route is derived from `description`, so the derived set is untouched.

**Not in this PR, noted for https://github.com/robhunter/agentdeals/issues/1352:** Firecrawl also carries a hand-written `limits_reduced` record from 2026-04-13 — *"Free credits now one-time 500 (not recurring monthly)"* — with an empty `previous_state` and an empty `source_url`. The live page says `1,000 credits / month`, explicitly recurring. It is disproved, and it is one of the 95.

**Skipped deliberately:** Resend is in the same 46 and I did not touch it. `resend.com/pricing` has Transactional and Marketing tabs, and our record's `1K marketing contacts/month` and `5 AI credits` are absent from the Transactional column I read. Correcting from one tab against a record written from another is how dub.co's record went wrong.
