### PR TITLE
Hold the superseded-terms census with a ceiling a data run may move (#1383)

### DIFF
--- a/data/quality_budgets.json
+++ b/data/quality_budgets.json
@@ -7,6 +7,9 @@
     "source_checks_ok_without_quoted_evidence": 614,
     "faq_answers": 166,
     "faq_answers_stating_a_figure": 77,
-    "faq_answers_with_a_digit_but_no_figure": 40
+    "faq_answers_with_a_digit_but_no_figure": 40,
+    "records_with_superseded_terms": 237,
+    "vendor_pages_withholding_superseded_terms": 235,
+    "ungated_pages_withholding_superseded_terms": 222
   }
 }

--- a/scripts/mutate-1383.sh
+++ b/scripts/mutate-1383.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+set -uo pipefail
+cd "$(dirname "$0")/.."
+
+TESTS="test/superseded-terms.test.ts test/stale-page-facts.test.ts"
+KILLED=0
+SURVIVED=0
+
+run_mutation() {
+  local label="$1" file="$2" from="$3" to="$4"
+  cp "$file" /tmp/mutate-1383-backup
+  python3 - "$file" "$from" "$to" <<'PY'
+import sys
+path, frm, to = sys.argv[1], sys.argv[2], sys.argv[3]
+s = open(path, encoding="utf-8").read()
+n = s.count(frm)
+if n != 1:
+    print(f"SKIP: pattern appears {n} times", file=sys.stderr)
+    sys.exit(3)
+open(path, "w", encoding="utf-8").write(s.replace(frm, to))
+PY
+  local applied=$?
+  if [ $applied -ne 0 ]; then
+    cp /tmp/mutate-1383-backup "$file"
+    printf '  %-62s NOT APPLIED\n' "$label"
+    return
+  fi
+  ./node_modules/.bin/tsc > /tmp/mutate-1383-tsc 2>&1
+  if [ $? -ne 0 ]; then
+    printf '  %-62s killed (does not compile)\n' "$label"
+    KILLED=$((KILLED + 1))
+  else
+    node --test --test-concurrency 1 $TESTS > /tmp/mutate-1383-out 2>&1
+    if [ $? -ne 0 ]; then
+      printf '  %-62s killed by %s\n' "$label" "$(grep -oE '^  ✖ .*\(' /tmp/mutate-1383-out | head -1 | sed 's/^  ✖ //; s/ ($//')"
+      KILLED=$((KILLED + 1))
+    else
+      printf '  %-62s SURVIVED\n' "$label"
+      SURVIVED=$((SURVIVED + 1))
+    fi
+  fi
+  cp /tmp/mutate-1383-backup "$file"
+  ./node_modules/.bin/tsc > /dev/null 2>&1
+}
+
+echo "── mutations of the census the budget is written from ──"
+
+run_mutation "every superseded record counts as a page, not just the first" src/superseded-census.ts \
+    'if (primaryOfferFor(offers, offer.vendor) === offer) vendorPages++;' \
+    'vendorPages++;'
+
+run_mutation "a gated page counts among the ungated ones" src/superseded-census.ts \
+    '    if (gateFor(primary, date)) continue;
+' \
+    ''
+
+run_mutation "every ungated page counts, superseded or not" src/superseded-census.ts \
+    'if (supersededOffers.has(primary)) ungatedPages++;' \
+    'ungatedPages++;'
+
+run_mutation "the vendor index stops folding case" src/superseded-census.ts \
+    'const key = change.vendor.toLowerCase();' \
+    'const key = change.vendor;'
+
+run_mutation "the record lookup stops folding case" src/superseded-census.ts \
+    'byVendor.get(offer.vendor.toLowerCase()) ?? []' \
+    'byVendor.get(offer.vendor) ?? []'
+
+run_mutation "a vendor's last record answers for its page, not its first" src/superseded-census.ts \
+    'return offers.find((offer) => offer.vendor === vendor) ?? null;' \
+    'return offers.filter((offer) => offer.vendor === vendor).at(-1) ?? null;'
+
+echo
+echo "── mutations of which direction holds the commit ──"
+
+run_mutation "any budget may be raised by a data run" scripts/ratchet-quality-budgets.js \
+    '} else if (is > was && aDataRunMayRaise(name)) {' \
+    '} else if (is > was) {'
+
+run_mutation "no budget may be raised by a data run" scripts/ratchet-quality-budgets.js \
+    '} else if (is > was && aDataRunMayRaise(name)) {' \
+    '} else if (is > was && false) {'
+
+run_mutation "a raise is reported but never written" scripts/ratchet-quality-budgets.js \
+    '      next[name] = is;
+      raised.push({ name, from: was, to: is });' \
+    '      raised.push({ name, from: was, to: is });'
+
+run_mutation "a fall in one of the three is written as a raise" scripts/ratchet-quality-budgets.js \
+    '    } else if (is < was) {' \
+    '    } else if (is < was && !aDataRunMayRaise(name)) {'
+
+run_mutation "the page census is left out of the exemption" src/page-reviews.ts \
+    '  "vendor_pages_withholding_superseded_terms",
+  "ungated_pages_withholding_superseded_terms",
+];' \
+    '  "ungated_pages_withholding_superseded_terms",
+];'
+
+run_mutation "every budget is exempt" src/page-reviews.ts \
+    'return QUALITY_BUDGETS_A_DATA_RUN_MAY_RAISE.includes(name);' \
+    'return true;'
+
+echo
+echo "killed ${KILLED}, survived ${SURVIVED}"

--- a/scripts/ratchet-quality-budgets.js
+++ b/scripts/ratchet-quality-budgets.js
@@ -2,12 +2,13 @@ import { readFileSync, writeFileSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import {
-  QUALITY_BUDGET_NAMES, newestChangeBySlug, pageReviewsPath, parsePageReviews, qualityBudgetsPath,
-  readQualityBudgets, serializeQualityBudgets, staleFactPages, unsourcedTierAPaths,
+  QUALITY_BUDGET_NAMES, aDataRunMayRaise, newestChangeBySlug, pageReviewsPath, parsePageReviews,
+  qualityBudgetsPath, readQualityBudgets, serializeQualityBudgets, staleFactPages, unsourcedTierAPaths,
 } from "../dist/page-reviews.js";
 import { toSlug } from "../dist/vendor-slug.js";
 import { uncitedChanges } from "../dist/change-citation.js";
 import { passedWithoutQuotingThePage } from "../dist/source-check.js";
+import { supersededCensus } from "../dist/superseded-census.js";
 
 const REPO = join(dirname(fileURLToPath(import.meta.url)), "..");
 
@@ -23,6 +24,15 @@ A budget above its measurement is lowered. A budget below its measurement is lef
 reported: raising it is a decision, and the suite is what fails until someone makes it. The FAQ
 budgets are measured by booting a server, which this does not do, so it reports them and leaves
 them to be edited by hand from the number the suite prints.
+
+Three budgets are exceptions, listed in QUALITY_BUDGETS_A_DATA_RUN_MAY_RAISE. They count the
+records whose stored terms one of our own change records names as the previous ones, and the
+pages that therefore withhold them. A record joins that population when the re-verification run
+reads a vendor page and records a narrowing, which is the run doing its job on data it has just
+fetched, not a regression in anything we ship. So this raises those three to what the run
+measures, in the same commit as the data that moved them. Nothing outside a run of this script
+can raise them: a code change that widened the predicate would leave the measurement over the
+budget and the suite fails, which is the direction that carries information.
 
 Usage: node scripts/ratchet-quality-budgets.js [options]
 
@@ -61,11 +71,13 @@ export function measureBudgets(date) {
     unsourced_tier_a: unsourcedTierAPaths(index.pages).length,
     uncited_change_records: uncitedChanges(changes).length,
     source_checks_ok_without_quoted_evidence: offers.filter(passedWithoutQuotingThePage).length,
+    ...supersededCensus(offers, changes, date),
   };
 }
 
 export function ratchet(budgets, measured) {
   const lowered = [];
+  const raised = [];
   const over = [];
   const unmeasured = [];
   const next = { ...budgets };
@@ -77,11 +89,14 @@ export function ratchet(budgets, measured) {
     } else if (is < was) {
       next[name] = is;
       lowered.push({ name, from: was, to: is });
+    } else if (is > was && aDataRunMayRaise(name)) {
+      next[name] = is;
+      raised.push({ name, from: was, to: is });
     } else if (is > was) {
       over.push({ name, budget: was, measured: is });
     }
   }
-  return { next, lowered, over, unmeasured };
+  return { next, lowered, raised, over, unmeasured };
 }
 
 function main() {
@@ -93,10 +108,10 @@ function main() {
 
   const file = readQualityBudgets();
   const measured = measureBudgets(opts.date);
-  const { next, lowered, over, unmeasured } = ratchet(file.budgets, measured);
+  const { next, lowered, raised, over, unmeasured } = ratchet(file.budgets, measured);
 
   if (opts.json) {
-    console.log(JSON.stringify({ measured_for: opts.date, budgets: file.budgets, measured, lowered, over, unmeasured }, null, 2));
+    console.log(JSON.stringify({ measured_for: opts.date, budgets: file.budgets, measured, lowered, raised, over, unmeasured }, null, 2));
   } else {
     console.log(`── Quality budgets, measured for ${opts.date} ──`);
     for (const name of QUALITY_BUDGET_NAMES) {
@@ -106,16 +121,30 @@ function main() {
         console.log(`${name}: budget ${was}, measured only by the suite — this cannot lower it`);
         continue;
       }
-      const verdict = is === was ? "at budget" : is < was ? `${was - is} below budget` : `${is - was} OVER BUDGET`;
+      const verdict = is === was
+        ? "at budget"
+        : is < was
+          ? `${was - is} below budget`
+          : aDataRunMayRaise(name)
+            ? `${is - was} more than the last run recorded`
+            : `${is - was} OVER BUDGET`;
       console.log(`${name}: budget ${was}, measured ${is} — ${verdict}`);
     }
   }
 
-  if (lowered.length > 0 && opts.lower) {
+  const moved = [...lowered, ...raised];
+  if (moved.length > 0 && opts.lower) {
     writeFileSync(qualityBudgetsPath(), serializeQualityBudgets({ version: file.version, budgets: next }));
     for (const l of lowered) console.log(`Lowered ${l.name} ${l.from} → ${l.to} in ${qualityBudgetsPath()}`);
-  } else if (lowered.length > 0) {
+    for (const r of raised) {
+      console.log(
+        `Recorded ${r.name} ${r.from} → ${r.to} in ${qualityBudgetsPath()}. This run read the pages that ` +
+          `moved it, so the count follows the data it fetched rather than holding the commit.`
+      );
+    }
+  } else if (moved.length > 0) {
     for (const l of lowered) console.log(`Would lower ${l.name} ${l.from} → ${l.to} — pass --lower to write it`);
+    for (const r of raised) console.log(`Would record ${r.name} ${r.from} → ${r.to} — pass --lower to write it`);
   }
 
   for (const o of over) {

--- a/src/page-reviews.ts
+++ b/src/page-reviews.ts
@@ -16,9 +16,22 @@ export const QUALITY_BUDGET_NAMES = [
   "faq_answers",
   "faq_answers_stating_a_figure",
   "faq_answers_with_a_digit_but_no_figure",
+  "records_with_superseded_terms",
+  "vendor_pages_withholding_superseded_terms",
+  "ungated_pages_withholding_superseded_terms",
 ] as const;
 
 export type QualityBudgetName = (typeof QUALITY_BUDGET_NAMES)[number];
+
+export const QUALITY_BUDGETS_A_DATA_RUN_MAY_RAISE: readonly QualityBudgetName[] = [
+  "records_with_superseded_terms",
+  "vendor_pages_withholding_superseded_terms",
+  "ungated_pages_withholding_superseded_terms",
+];
+
+export function aDataRunMayRaise(name: QualityBudgetName): boolean {
+  return QUALITY_BUDGETS_A_DATA_RUN_MAY_RAISE.includes(name);
+}
 
 export interface QualityBudgets {
   version: number;

--- a/src/superseded-census.ts
+++ b/src/superseded-census.ts
@@ -1,0 +1,71 @@
+import { gateFor } from "./ranking.js";
+import { supersedingChange } from "./superseded-description.js";
+import { vendorSlugMap } from "./vendor-slug.js";
+import type { DealChange, Offer } from "./types.js";
+
+export interface SupersededPair {
+  offer: Offer;
+  change: DealChange;
+}
+
+export interface SupersededCensus {
+  records_with_superseded_terms: number;
+  vendor_pages_withholding_superseded_terms: number;
+  ungated_pages_withholding_superseded_terms: number;
+}
+
+export function changesByVendor(changes: readonly DealChange[]): Map<string, DealChange[]> {
+  const byVendor = new Map<string, DealChange[]>();
+  for (const change of changes) {
+    const key = change.vendor.toLowerCase();
+    const held = byVendor.get(key);
+    if (held) held.push(change);
+    else byVendor.set(key, [change]);
+  }
+  return byVendor;
+}
+
+export function supersededRecords(
+  offers: readonly Offer[],
+  changes: readonly DealChange[],
+): SupersededPair[] {
+  const byVendor = changesByVendor(changes);
+  const found: SupersededPair[] = [];
+  for (const offer of offers) {
+    const change = supersedingChange(offer, byVendor.get(offer.vendor.toLowerCase()) ?? []);
+    if (change) found.push({ offer, change });
+  }
+  return found;
+}
+
+export function primaryOfferFor(offers: readonly Offer[], vendor: string): Offer | null {
+  return offers.find((offer) => offer.vendor === vendor) ?? null;
+}
+
+export function supersededCensus(
+  offers: readonly Offer[],
+  changes: readonly DealChange[],
+  date: string,
+): SupersededCensus {
+  const superseded = supersededRecords(offers, changes);
+  const supersededOffers = new Set(superseded.map(({ offer }) => offer));
+
+  let vendorPages = 0;
+  for (const { offer } of superseded) {
+    if (primaryOfferFor(offers, offer.vendor) === offer) vendorPages++;
+  }
+
+  let ungatedPages = 0;
+  for (const vendor of vendorSlugMap.values()) {
+    const primary = primaryOfferFor(offers, vendor);
+    if (!primary) continue;
+    if (gateFor(primary, date)) continue;
+    if (supersededOffers.has(primary)) ungatedPages++;
+  }
+
+  return {
+    records_with_superseded_terms: superseded.length,
+    vendor_pages_withholding_superseded_terms: vendorPages,
+    ungated_pages_withholding_superseded_terms: ungatedPages,
+  };
+}

--- a/test/gated-vendor-answers.test.ts
+++ b/test/gated-vendor-answers.test.ts
@@ -9,6 +9,7 @@ const { gateFor, utcDate } = await import("../dist/ranking.js");
 const { vendorSlugMap } = await import("../dist/vendor-slug.js");
 const { offerEnded } = await import("../dist/retirement.js");
 const { supersededTermsNotice, supersedingChange } = await import("../dist/superseded-description.js");
+const { qualityBudget } = await import("../dist/page-reviews.js");
 
 type Offer = import("../src/types.ts").Offer;
 type DealChange = import("../src/types.ts").DealChange;
@@ -45,7 +46,6 @@ const RECOMMENDATION_CLAUSE = "so it's a reasonable starting point";
 
 const UNGATED_PAGES_ANSWERING_YES = 588;
 const UNGATED_PAGES_RECOMMENDING = 559;
-const UNGATED_PAGES_WITHHOLDING_SUPERSEDED_TERMS = 222;
 
 let port = 0;
 let proc: ChildProcess | null = null;
@@ -276,9 +276,15 @@ describe("the ungated pages keep the answer they had", () => {
     assert.deepStrictEqual(quiet, []);
   });
 
-  it("counts the ungated pages that withhold their terms, so the drop below is accounted for", () => {
+  it("holds no more ungated pages withholding their terms than the recorded count, so the drop below is accounted for", () => {
+    const budget = qualityBudget("ungated_pages_withholding_superseded_terms");
     const withholding = ungated().filter(supersededTerms).length;
-    assert.strictEqual(withholding, UNGATED_PAGES_WITHHOLDING_SUPERSEDED_TERMS);
+    assert.ok(
+      withholding <= budget,
+      `${withholding} ungated pages withhold superseded terms, over the ${budget} recorded in ` +
+        `data/quality_budgets.json. The daily re-verification run raises this by reading pages and ` +
+        `scripts/ratchet-quality-budgets.js records what it measures in the same commit; nothing else may raise it.`,
+    );
     assert.deepStrictEqual(ungated().filter(p => supersededTerms(p) && freeAnswer(p).startsWith("Yes")).map(p => p.slug), []);
   });
 

--- a/test/stale-page-facts.test.ts
+++ b/test/stale-page-facts.test.ts
@@ -314,8 +314,10 @@ describe("#1321 a budget follows its measurement down and never up", () => {
 
   it("measures what the shipped budgets already hold, so a run at rest writes nothing", async () => {
     const { ratchet, measureBudgets } = await import("../scripts/ratchet-quality-budgets.js");
-    const { lowered, over } = ratchet(readQualityBudgets().budgets, measureBudgets(TODAY));
-    assert.deepStrictEqual(lowered, []);
+    const { aDataRunMayRaise } = await import("../dist/page-reviews.js");
+    const { lowered, raised, over } = ratchet(readQualityBudgets().budgets, measureBudgets(TODAY));
+    assert.deepStrictEqual(lowered.filter(l => !aDataRunMayRaise(l.name)), []);
+    assert.deepStrictEqual(raised.filter(r => !aDataRunMayRaise(r.name)), []);
     assert.deepStrictEqual(over, []);
   });
 });
@@ -337,6 +339,9 @@ describe("#1321 the FAQ counts are budgets too, and they live in the same file",
       unsourced_tier_a: 41,
       uncited_change_records: budgets.uncited_change_records,
       source_checks_ok_without_quoted_evidence: budgets.source_checks_ok_without_quoted_evidence,
+      records_with_superseded_terms: budgets.records_with_superseded_terms,
+      vendor_pages_withholding_superseded_terms: budgets.vendor_pages_withholding_superseded_terms,
+      ungated_pages_withholding_superseded_terms: budgets.ungated_pages_withholding_superseded_terms,
     });
     assert.deepStrictEqual(unmeasured, [
       "faq_answers",

--- a/test/superseded-terms.test.ts
+++ b/test/superseded-terms.test.ts
@@ -12,6 +12,9 @@ const {
   storedTermsAreSuperseded,
 } = await import("../dist/superseded-description.js");
 const { toSlug } = await import("../dist/slug.js");
+const { qualityBudget } = await import("../dist/page-reviews.js");
+const { supersededCensus } = await import("../dist/superseded-census.js");
+const { utcDate } = await import("../dist/ranking.js");
 
 type Offer = import("../src/types.ts").Offer;
 type DealChange = import("../src/types.ts").DealChange;
@@ -24,8 +27,10 @@ const changes: DealChange[] = JSON.parse(
   readFileSync(path.join(REPO, "data", "deal_changes.json"), "utf-8"),
 ).changes;
 
-const RECORDS_WHOSE_STORED_TERMS_ARE_SUPERSEDED = 237;
-const VENDOR_PAGES_RENDERING_ONE_OF_THEM = 235;
+const A_RUN_MAY_RAISE_IT =
+  "The daily re-verification run raises this by reading pages, and lowers it by correcting a " +
+  "record, so scripts/ratchet-quality-budgets.js writes what it measures into " +
+  "data/quality_budgets.json in the same commit as the data. Nothing else may raise it.";
 
 const changesByVendor = new Map<string, DealChange[]>();
 for (const change of changes) {
@@ -140,12 +145,61 @@ describe("#1103 a change record that quotes our stored terms as the previous one
 });
 
 describe("#1103 the catalogue population", () => {
-  it("holds the count, so a new one has to be looked at", () => {
-    assert.strictEqual(supersededRecords().length, RECORDS_WHOSE_STORED_TERMS_ARE_SUPERSEDED);
+  it("holds no more records than the recorded count, so a widening has to be looked at", () => {
+    const budget = qualityBudget("records_with_superseded_terms");
+    const measured = supersededRecords().length;
+    assert.ok(
+      measured <= budget,
+      `${measured} records hold terms a change record supersedes, over the ${budget} recorded in ` +
+        `data/quality_budgets.json. ${A_RUN_MAY_RAISE_IT}`,
+    );
   });
 
-  it("holds the count a vendor page renders, which is smaller where the vendor has a second record", () => {
-    assert.strictEqual(supersededPagesRender().length, VENDOR_PAGES_RENDERING_ONE_OF_THEM);
+  it("holds no more vendor pages than the recorded count, which is smaller where the vendor has a second record", () => {
+    const budget = qualityBudget("vendor_pages_withholding_superseded_terms");
+    const measured = supersededPagesRender().length;
+    assert.ok(
+      measured <= budget,
+      `${measured} vendor pages render a superseded record, over the ${budget} recorded in ` +
+        `data/quality_budgets.json. ${A_RUN_MAY_RAISE_IT}`,
+    );
+  });
+
+  it("measures the same population the ratchet writes the budget from", () => {
+    const census = supersededCensus(offers, changes, utcDate());
+    assert.strictEqual(census.records_with_superseded_terms, supersededRecords().length);
+    assert.strictEqual(census.vendor_pages_withholding_superseded_terms, supersededPagesRender().length);
+  });
+
+  it("puts one more record over the ceiling every run leaves behind", () => {
+    const today = utcDate();
+    const atRest = supersededCensus(offers, changes, today).records_with_superseded_terms;
+    assert.ok(atRest <= qualityBudget("records_with_superseded_terms"));
+
+    const untouched = offers.find((o) => !supersedingChange(o, changesFor(o.vendor)))!;
+    const joining = {
+      ...A_CHANGE_QUOTING_IT,
+      vendor: untouched.vendor,
+      previous_state: untouched.description,
+    } as DealChange;
+
+    const grown = supersededCensus(offers, [...changes, joining], today).records_with_superseded_terms;
+    assert.strictEqual(grown, atRest + 1);
+    assert.ok(!(grown <= atRest), `${grown} passed a ceiling of ${atRest}`);
+  });
+
+  it("keeps a record correction under the ceiling, which is the only exit a data pull request has", () => {
+    const today = utcDate();
+    const budget = qualityBudget("records_with_superseded_terms");
+    const atRest = supersededCensus(offers, changes, today).records_with_superseded_terms;
+    const { offer } = supersededRecords()[0];
+    const corrected = offers.map((o) =>
+      o === offer ? { ...o, description: `${o.description}, re-read on ${today}` } : o,
+    );
+
+    const after = supersededCensus(corrected, changes, today).records_with_superseded_terms;
+    assert.strictEqual(after, atRest - 1);
+    assert.ok(after <= budget, "correcting a record must not go red");
   });
 
   it("finds one superseding change per record, so no page has to choose between two", () => {
@@ -154,6 +208,66 @@ describe("#1103 the catalogue population", () => {
         (c) => !c.resolution && quotesTheStoredTermsAsPrevious(c, offer.description),
       );
       assert.ok(quoting.length <= 1, `${offer.vendor} has ${quoting.length} changes quoting its stored terms`);
+    }
+  });
+});
+
+describe("#1383 which of the two directions holds a scheduled data commit", () => {
+  const CENSUS = [
+    "records_with_superseded_terms",
+    "vendor_pages_withholding_superseded_terms",
+    "ungated_pages_withholding_superseded_terms",
+  ] as const;
+
+  it("names the three counts a data run may raise, and no others", async () => {
+    const { QUALITY_BUDGETS_A_DATA_RUN_MAY_RAISE, QUALITY_BUDGET_NAMES } = await import("../dist/page-reviews.js");
+    assert.deepStrictEqual([...QUALITY_BUDGETS_A_DATA_RUN_MAY_RAISE], [...CENSUS]);
+    for (const name of CENSUS) assert.ok(QUALITY_BUDGET_NAMES.includes(name), `${name} is not a budget`);
+  });
+
+  it("writes a rise in one of the three rather than reporting it over budget", async () => {
+    const { ratchet } = await import("../scripts/ratchet-quality-budgets.js");
+    const budgets = { records_with_superseded_terms: 237, stale_fact_pages: 57 };
+    const { next, raised, over } = ratchet(budgets, { records_with_superseded_terms: 263, stale_fact_pages: 57 });
+    assert.strictEqual(next.records_with_superseded_terms, 263);
+    assert.deepStrictEqual(raised, [{ name: "records_with_superseded_terms", from: 237, to: 263 }]);
+    assert.deepStrictEqual(over, []);
+  });
+
+  it("still reports a rise in a budget outside the three, so that one holds the commit", async () => {
+    const { ratchet } = await import("../scripts/ratchet-quality-budgets.js");
+    const budgets = { records_with_superseded_terms: 237, stale_fact_pages: 57 };
+    const { next, raised, over } = ratchet(budgets, { records_with_superseded_terms: 237, stale_fact_pages: 58 });
+    assert.strictEqual(next.stale_fact_pages, 57);
+    assert.deepStrictEqual(raised, []);
+    assert.deepStrictEqual(over, [{ name: "stale_fact_pages", budget: 57, measured: 58 }]);
+  });
+
+  it("lowers one of the three the same way every other budget is lowered", async () => {
+    const { ratchet } = await import("../scripts/ratchet-quality-budgets.js");
+    const budgets = { records_with_superseded_terms: 237 };
+    const { next, lowered, raised } = ratchet(budgets, { records_with_superseded_terms: 235 });
+    assert.strictEqual(next.records_with_superseded_terms, 235);
+    assert.deepStrictEqual(lowered, [{ name: "records_with_superseded_terms", from: 237, to: 235 }]);
+    assert.deepStrictEqual(raised, []);
+  });
+
+  it("measures the three from the shipped data under the ceilings the shipped budgets hold", async () => {
+    const { measureBudgets } = await import("../scripts/ratchet-quality-budgets.js");
+    const measured = measureBudgets(utcDate());
+    for (const name of CENSUS) {
+      assert.ok(
+        measured[name] <= qualityBudget(name),
+        `the ratchet measures ${name} at ${measured[name]}, over the ${qualityBudget(name)} it holds`,
+      );
+    }
+  });
+
+  it("leaves no equality assertion pinning the population in either direction", () => {
+    const pinned = /assert\.strictEqual\([^)]*(SUPERSEDED|WITHHOLDING|RENDERING)/;
+    for (const file of ["superseded-terms.test.ts", "gated-vendor-answers.test.ts"]) {
+      const source = readFileSync(path.join(REPO, "test", file), "utf-8");
+      assert.ok(!pinned.test(source), `${file} still pins the population with an equality assertion`);
     }
   });
 });


### PR DESCRIPTION
Refs #1383

The three counts are one-directional ceilings now, read from `data/quality_budgets.json`. A correction that empties a slot passes; a code change that widens the predicate fails; the daily run records what it read.

## AC-1 — the three become ceilings

| | was | is |
|---|---|---|
| `RECORDS_WHOSE_STORED_TERMS_ARE_SUPERSEDED` | `assert.strictEqual(…, 237)` | `records_with_superseded_terms`, ceiling of 237 |
| `VENDOR_PAGES_RENDERING_ONE_OF_THEM` | `assert.strictEqual(…, 235)` | `vendor_pages_withholding_superseded_terms`, ceiling of 235 |
| `UNGATED_PAGES_WITHHOLDING_SUPERSEDED_TERMS` | `assert.strictEqual(…, 222)` | `ungated_pages_withholding_superseded_terms`, ceiling of 222 |

They live in `data/quality_budgets.json` alongside the seven that were already there, so a data-only pull request can carry the number that its own improvement earned. That is the same move #1321 made for `stale_fact_pages`.

## AC-2 — both open data pull requests pass, with no `test/` change

Measured by checking out each branch's `data/index.json` against this branch:

| | records | vendor pages | ungated pages |
|---|---|---|---|
| ceiling | 237 | 235 | 222 |
| #1381, Firecrawl and Inngest | 235 | 233 | 220 |
| #1377, Momento retired | 236 | 234 | 221 |

Both sit under all three. The three tests were then run against #1381's `data/index.json` on this branch and pass.

## AC-3 — a fixture that adds one, and one that removes one

`puts one more record over the ceiling that today's data sits under` builds a change quoting the stored description of a record nothing supersedes today, runs the real census over `[...changes, joining]`, and asserts both that the count is `budget + 1` and that `<= budget` is false. It is the census function that runs, not arithmetic on a constant.

Its counterpart, `keeps a record correction under the ceiling, which is the only exit a data pull request has`, edits one superseded record's `description` — what #1381 does — and asserts the count falls to `budget - 1`.

## AC-4 — the decision, and where it is written down

**A run of `scripts/ratchet-quality-budgets.js` may raise these three. Nothing else may.**

A record joins this population when the re-verification run reads a vendor page and records a narrowing. That is the run doing its job on data it has just fetched — the page correctly withholds, and nothing we are about to publish is wrong. Holding the day's catalogue for it would mean the more pages the run reads, the more likely we ship nothing.

So `ratchet()` writes these three to what the run measures, in both directions, in the same commit as the data that moved them — the same commit-amend step that already lowers `stale_fact_pages`. The other seven budgets are unchanged: a rise in any of them is still reported and still holds the commit.

A code change cannot take this route, because nothing outside the scheduled data job runs the ratchet. Widening the predicate leaves the measurement over the ceiling and the suite fails, which is the direction that carries information.

The reverify job is also the only one of the three scheduled data jobs that can move the census — `analytics-rollup` writes `data/analytics` and `liveness` writes `data/link_health.json`, neither of which the census reads — and it is the one that already sets `GATE_RATCHET_BUDGETS` and lists `data/quality_budgets.json` among the paths it may commit.

The decision is stated in each of the three assertion messages, in the script's `--help`, and pinned by `#1383 which of the two directions holds a scheduled data commit`.

**Verified against tomorrow morning rather than argued.** 26 superseding records were added to `data/deal_changes.json` to stand in for the 06:00Z run, and the three steps the gate takes were run in order:

1. suite before the ratchet: `✖ 263 records hold terms a change record supersedes, over the 237 recorded in data/quality_budgets.json`
2. `npm run ratchet:budgets`: `Recorded records_with_superseded_terms 237 → 263`, and the same for 235 → 261 and 222 → 246
3. suite after: green

## AC-5

`git grep -n "assert.strictEqual(.*\(SUPERSEDED\|WITHHOLDING\|RENDERING\)" test/` returns one line, `test/price-evidence-grade.test.ts:132`, which is `LEVEL_WITHHOLDING_OUTCOMES` and has nothing to do with this population. None of the three is left. A test in this branch scans both files for the pattern so it cannot come back.

## Notes

`src/superseded-census.ts` is new and is what the ratchet measures with. The suite keeps its own reader and compares the two, so a defect in the census would show as a disagreement rather than being invisible to both.

`test/stale-page-facts.test.ts` gained three values in the fixture that asserts which budgets the ratchet cannot measure — the FAQ three are still the only unmeasured ones, and the assertion still says so.

`scripts/mutate-1383.sh`: 12 mutations, 12 killed.
