### PR TITLE
Withhold the stored terms only where the recorded change narrowed them (#1103)

### DIFF
--- a/data/quality_budgets.json
+++ b/data/quality_budgets.json
@@ -8,8 +8,8 @@
     "faq_answers": 166,
     "faq_answers_stating_a_figure": 77,
     "faq_answers_with_a_digit_but_no_figure": 40,
-    "records_with_superseded_terms": 237,
-    "vendor_pages_withholding_superseded_terms": 235,
-    "ungated_pages_withholding_superseded_terms": 222
+    "records_with_superseded_terms": 183,
+    "vendor_pages_withholding_superseded_terms": 182,
+    "ungated_pages_withholding_superseded_terms": 173
   }
 }

--- a/scripts/mutate-1103b.sh
+++ b/scripts/mutate-1103b.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+set -uo pipefail
+cd "$(dirname "$0")/.."
+
+TESTS="test/superseded-terms.test.ts"
+KILLED=0
+SURVIVED=0
+
+run_mutation() {
+  local label="$1" file="$2" from="$3" to="$4"
+  cp "$file" /tmp/mutate-1103b-backup
+  python3 - "$file" "$from" "$to" <<'PY'
+import sys
+path, frm, to = sys.argv[1], sys.argv[2], sys.argv[3]
+s = open(path, encoding="utf-8").read()
+n = s.count(frm)
+if n != 1:
+    print(f"SKIP: pattern appears {n} times", file=sys.stderr)
+    sys.exit(3)
+open(path, "w", encoding="utf-8").write(s.replace(frm, to))
+PY
+  local applied=$?
+  if [ $applied -ne 0 ]; then
+    cp /tmp/mutate-1103b-backup "$file"
+    printf '  %-62s NOT APPLIED\n' "$label"
+    return
+  fi
+  ./node_modules/.bin/tsc > /tmp/mutate-1103b-tsc 2>&1
+  if [ $? -ne 0 ]; then
+    printf '  %-62s killed (does not compile)\n' "$label"
+    KILLED=$((KILLED + 1))
+  else
+    node --test --test-concurrency 1 $TESTS > /tmp/mutate-1103b-out 2>&1
+    if [ $? -ne 0 ]; then
+      printf '  %-62s killed by %s\n' "$label" "$(grep -oE '^  ✖ .*\(' /tmp/mutate-1103b-out | head -1 | sed 's/^  ✖ //; s/ ($//')"
+      KILLED=$((KILLED + 1))
+    else
+      printf '  %-62s SURVIVED\n' "$label"
+      SURVIVED=$((SURVIVED + 1))
+    fi
+  fi
+  cp /tmp/mutate-1103b-backup "$file"
+  ./node_modules/.bin/tsc > /dev/null 2>&1
+}
+
+echo "── mutations of which direction withholds ──"
+
+run_mutation "every quoting change withholds again" src/superseded-description.ts \
+    '  if (!narrowsTheStoredTerms(change.change_type)) return false;
+' \
+    ''
+
+run_mutation "a widening change withholds and a narrowing one does not" src/change-direction.ts \
+    '  return direction === null || direction === "negative";' \
+    '  return direction !== null && direction !== "negative";'
+
+run_mutation "an unrecognised change type publishes the stored terms" src/change-direction.ts \
+    '  return direction === null || direction === "negative";' \
+    '  return direction === "negative";'
+
+run_mutation "a neutral change withholds alongside the negative ones" src/change-direction.ts \
+    '  return direction === null || direction === "negative";' \
+    '  return direction !== "positive";'
+
+run_mutation "a resolved narrowing change withholds again" src/superseded-description.ts \
+    '  if (isNoLongerInForce(change)) return false;
+' \
+    ''
+
+run_mutation "a change that quotes nothing withholds" src/superseded-description.ts \
+    '  return quotesTheStoredTermsAsPrevious(change, description);' \
+    '  return true;'
+
+echo
+echo "── mutations of the classification itself ──"
+
+run_mutation "a limit increase is read as adverse" src/change-direction.ts \
+    '  limits_increased: "positive",' \
+    '  limits_increased: "negative",'
+
+run_mutation "a restriction is read as harmless" src/change-direction.ts \
+    '  restriction: "negative",' \
+    '  restriction: "positive",'
+
+run_mutation "a rebrand is read as adverse" src/change-direction.ts \
+    '  rebranded: "neutral",' \
+    '  rebranded: "negative",'
+
+run_mutation "a price restructure is read as harmless" src/change-direction.ts \
+    '  pricing_restructured: "negative",' \
+    '  pricing_restructured: "neutral",'
+
+run_mutation "a deprecation is read as harmless" src/change-direction.ts \
+    '  product_deprecated: "negative",' \
+    '  product_deprecated: "neutral",'
+
+run_mutation "a new free tier is read as adverse" src/change-direction.ts \
+    '  new_free_tier: "positive",' \
+    '  new_free_tier: "negative",'
+
+echo
+echo "killed ${KILLED}, survived ${SURVIVED}"

--- a/src/change-direction.ts
+++ b/src/change-direction.ts
@@ -1,0 +1,29 @@
+import type { DealChange } from "./types.js";
+
+export type ChangeDirection = "negative" | "positive" | "neutral";
+
+export const CHANGE_DIRECTION: Record<DealChange["change_type"], ChangeDirection> = {
+  free_tier_removed: "negative",
+  open_source_killed: "negative",
+  product_deprecated: "negative",
+  limits_reduced: "negative",
+  restriction: "negative",
+  pricing_restructured: "negative",
+  pricing_model_change: "negative",
+  limits_increased: "positive",
+  new_free_tier: "positive",
+  new_tier: "positive",
+  startup_program_expanded: "positive",
+  pricing_postponed: "positive",
+  rebranded: "neutral",
+  record_corrected: "neutral",
+};
+
+export function directionOfChange(changeType: string): ChangeDirection | null {
+  return CHANGE_DIRECTION[changeType as DealChange["change_type"]] ?? null;
+}
+
+export function narrowsTheStoredTerms(changeType: string): boolean {
+  const direction = directionOfChange(changeType);
+  return direction === null || direction === "negative";
+}

--- a/src/data.ts
+++ b/src/data.ts
@@ -3,6 +3,7 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 import type { Offer, EnrichedOffer, OfferIndex, DealChange, DealChangesIndex, ChangeDateSource, StabilityClass, Referral, RiskCause, RatingWithheld, LinkUnreachable, SourceCheck } from "./types.js";
 import { isUrlSuspended } from "./referral-health.js";
+import { CHANGE_DIRECTION, type ChangeDirection } from "./change-direction.js";
 import { rankForListing, gateFor, utcDate, type TieBreak, type Gate, type GateCode } from "./ranking.js";
 import { unreachableNoticeForUrl, resetLinkHealthCache } from "./link-health.js";
 import { quarantineSummary, resetVerificationStateCache, type QuarantineSummary } from "./verification-state.js";
@@ -267,22 +268,7 @@ export function searchOffers(
   return results;
 }
 
-export const CHANGE_DIRECTION: Record<DealChange["change_type"], "negative" | "positive" | "neutral"> = {
-  free_tier_removed: "negative",
-  open_source_killed: "negative",
-  product_deprecated: "negative",
-  limits_reduced: "negative",
-  restriction: "negative",
-  pricing_restructured: "negative",
-  pricing_model_change: "negative",
-  limits_increased: "positive",
-  new_free_tier: "positive",
-  new_tier: "positive",
-  startup_program_expanded: "positive",
-  pricing_postponed: "positive",
-  rebranded: "neutral",
-  record_corrected: "neutral",
-};
+export { CHANGE_DIRECTION, narrowsTheStoredTerms } from "./change-direction.js";
 
 export const CORRECTION_TO_OUR_OWN_RECORD = "record_corrected";
 
@@ -290,7 +276,7 @@ export function isACorrectionToOurOwnRecord(change: Pick<DealChange, "change_typ
   return change.change_type === CORRECTION_TO_OUR_OWN_RECORD;
 }
 
-const directionSet = (d: "negative" | "positive" | "neutral") =>
+const directionSet = (d: ChangeDirection) =>
   new Set(Object.entries(CHANGE_DIRECTION).filter(([, v]) => v === d).map(([k]) => k));
 
 export const NEGATIVE_CHANGE_TYPES = directionSet("negative");

--- a/src/superseded-description.ts
+++ b/src/superseded-description.ts
@@ -1,8 +1,9 @@
 import { changeDateClause } from "./change-dates.js";
+import { narrowsTheStoredTerms } from "./change-direction.js";
 import { isNoLongerInForce } from "./change-resolution.js";
 import type { ChangeResolution, DealChange } from "./types.js";
 
-export interface QuotingChange extends Pick<DealChange, "date" | "date_source"> {
+export interface QuotingChange extends Pick<DealChange, "date" | "date_source" | "change_type"> {
   summary: string;
   previous_state?: string | null;
   resolution?: ChangeResolution | null;
@@ -22,14 +23,19 @@ export function quotesTheStoredTermsAsPrevious(change: QuotingChange, descriptio
   return quoted !== "" && quoted === comparableTerms(description);
 }
 
+export function supersedesTheStoredTerms(change: QuotingChange, description: string): boolean {
+  if (isNoLongerInForce(change)) return false;
+  if (!narrowsTheStoredTerms(change.change_type)) return false;
+  return quotesTheStoredTermsAsPrevious(change, description);
+}
+
 export function supersedingChange<T extends QuotingChange>(
   offer: Pick<StoredTerms, "description">,
   vendorChanges: readonly T[],
 ): T | null {
   let newest: T | null = null;
   for (const change of vendorChanges) {
-    if (isNoLongerInForce(change)) continue;
-    if (!quotesTheStoredTermsAsPrevious(change, offer.description)) continue;
+    if (!supersedesTheStoredTerms(change, offer.description)) continue;
     if (!newest || change.date > newest.date) newest = change;
   }
   return newest;

--- a/test/superseded-terms.test.ts
+++ b/test/superseded-terms.test.ts
@@ -212,6 +212,74 @@ describe("#1103 the catalogue population", () => {
   });
 });
 
+describe("#1103 which recorded changes make the stored terms unpublishable", () => {
+  const NARROWS = [
+    "free_tier_removed",
+    "limits_reduced",
+    "restriction",
+    "product_deprecated",
+    "open_source_killed",
+    "pricing_restructured",
+    "pricing_model_change",
+  ];
+  const LEAVES_THE_STORED_FIGURE_CONSERVATIVE = [
+    "limits_increased",
+    "new_free_tier",
+    "new_tier",
+    "rebranded",
+    "startup_program_expanded",
+    "pricing_postponed",
+    "record_corrected",
+  ];
+
+  it("withholds on a change that narrows the terms and publishes on one that does not", async () => {
+    const { narrowsTheStoredTerms } = await import("../dist/change-direction.js");
+    for (const type of NARROWS) assert.strictEqual(narrowsTheStoredTerms(type), true, type);
+    for (const type of LEAVES_THE_STORED_FIGURE_CONSERVATIVE) {
+      assert.strictEqual(narrowsTheStoredTerms(type), false, type);
+    }
+  });
+
+  it("classifies every change type the data model declares, and nothing is left over", async () => {
+    const { CHANGE_DIRECTION } = await import("../dist/change-direction.js");
+    const declared = Object.keys(CHANGE_DIRECTION).sort();
+    assert.deepStrictEqual([...NARROWS, ...LEAVES_THE_STORED_FIGURE_CONSERVATIVE].sort(), declared);
+  });
+
+  it("withholds on a change type it does not recognise, which is the safe direction", async () => {
+    const { narrowsTheStoredTerms, directionOfChange } = await import("../dist/change-direction.js");
+    assert.strictEqual(directionOfChange("terms_rewritten_by_a_type_we_have_not_met"), null);
+    assert.strictEqual(narrowsTheStoredTerms("terms_rewritten_by_a_type_we_have_not_met"), true);
+    assert.strictEqual(narrowsTheStoredTerms(undefined as unknown as string), true);
+  });
+
+  it("does not supersede the terms on a quoting change that widened them", () => {
+    const widening = { ...A_CHANGE_QUOTING_IT, change_type: "limits_increased" };
+    assert.strictEqual(quotesTheStoredTermsAsPrevious(widening, A_RECORD.description), true);
+    assert.strictEqual(storedTermsAreSuperseded(A_RECORD, [widening]), false);
+    assert.strictEqual(storedTermsAreSuperseded(A_RECORD, [A_CHANGE_QUOTING_IT]), true);
+  });
+
+  it("takes the newest narrowing change and passes over a newer widening one", () => {
+    const olderNarrowing = { ...A_CHANGE_QUOTING_IT, date: "2026-08-02" };
+    const newerWidening = { ...A_CHANGE_QUOTING_IT, date: "2026-09-04", change_type: "limits_increased" };
+    assert.strictEqual(supersedingChange(A_RECORD, [olderNarrowing, newerWidening])?.date, "2026-08-02");
+  });
+
+  it("leaves every record the change log only ever widened publishing its terms", () => {
+    const widenedOnly = offers.filter((offer) => {
+      const quoting = changesFor(offer.vendor).filter(
+        (c) => !c.resolution && quotesTheStoredTermsAsPrevious(c, offer.description),
+      );
+      return quoting.length > 0 && !supersedingChange(offer, changesFor(offer.vendor));
+    });
+    assert.ok(widenedOnly.length > 0, "no record in the shipped data exercises this, so the assertion is vacuous");
+    for (const offer of widenedOnly) {
+      assert.strictEqual(supersedingChange(offer, changesFor(offer.vendor)), null, offer.vendor);
+    }
+  });
+});
+
 describe("#1383 which of the two directions holds a scheduled data commit", () => {
   const CENSUS = [
     "records_with_superseded_terms",
@@ -275,19 +343,20 @@ describe("#1383 which of the two directions holds a scheduled data commit", () =
 const FIXTURE_VENDOR = "Deno Deploy";
 const FIXTURE_SLUG = toSlug(FIXTURE_VENDOR);
 
-function fixtureFrom(withResolution: boolean) {
+function fixtureFrom(withResolution: boolean, changeType?: string) {
   const record = JSON.parse(JSON.stringify(offers.find((o) => o.vendor === FIXTURE_VENDOR)));
   const change = JSON.parse(JSON.stringify(changes.find((c) => c.vendor === FIXTURE_VENDOR)));
   assert.ok(record && change, "the fixture is built from the record and change this issue names");
   record.description = change.previous_state;
+  if (changeType) change.change_type = changeType;
   if (withResolution) {
     change.resolution = { state: "reversed", date: "2026-09-04", detail: "The vendor restored the earlier limits." };
   }
   return { record, change };
 }
 
-function writeFixture(dir: string, name: string, withResolution: boolean) {
-  const { record, change } = fixtureFrom(withResolution);
+function writeFixture(dir: string, name: string, withResolution: boolean, changeType?: string) {
+  const { record, change } = fixtureFrom(withResolution, changeType);
   writeFileSync(path.join(dir, `${name}-index.json`), JSON.stringify({ offers: [record, ...offers.filter((o) => o.vendor !== FIXTURE_VENDOR)] }));
   writeFileSync(path.join(dir, `${name}-changes.json`), JSON.stringify({ changes: [change] }));
   return { record, change };
@@ -342,16 +411,19 @@ describe("#1103 a page whose stored terms its own change log quotes as previous"
   let dir = "";
   let superseded: { proc: ChildProcess; port: number } | null = null;
   let resolved: { proc: ChildProcess; port: number } | null = null;
+  let improved: { proc: ChildProcess; port: number } | null = null;
   let supersededPage = "";
   let resolvedPage = "";
+  let improvedPage = "";
   let storedTerms = "";
 
   before(async () => {
     dir = mkdtempSync(path.join(tmpdir(), "superseded-terms-"));
     const built = writeFixture(dir, "superseded", false);
     writeFixture(dir, "resolved", true);
+    writeFixture(dir, "improved", false, "limits_increased");
     storedTerms = built.record.description;
-    [superseded, resolved] = await Promise.all([
+    [superseded, resolved, improved] = await Promise.all([
       startServer({
         AGENTDEALS_INDEX_PATH: path.join(dir, "superseded-index.json"),
         AGENTDEALS_CHANGES_PATH: path.join(dir, "superseded-changes.json"),
@@ -360,14 +432,20 @@ describe("#1103 a page whose stored terms its own change log quotes as previous"
         AGENTDEALS_INDEX_PATH: path.join(dir, "resolved-index.json"),
         AGENTDEALS_CHANGES_PATH: path.join(dir, "resolved-changes.json"),
       }),
+      startServer({
+        AGENTDEALS_INDEX_PATH: path.join(dir, "improved-index.json"),
+        AGENTDEALS_CHANGES_PATH: path.join(dir, "improved-changes.json"),
+      }),
     ]);
     supersededPage = await fetch(`http://localhost:${superseded.port}/vendor/${FIXTURE_SLUG}`).then((r) => r.text());
     resolvedPage = await fetch(`http://localhost:${resolved.port}/vendor/${FIXTURE_SLUG}`).then((r) => r.text());
+    improvedPage = await fetch(`http://localhost:${improved.port}/vendor/${FIXTURE_SLUG}`).then((r) => r.text());
   });
 
   after(() => {
     superseded?.proc.kill();
     resolved?.proc.kill();
+    improved?.proc.kill();
     if (dir) rmSync(dir, { recursive: true, force: true });
   });
 
@@ -430,6 +508,16 @@ describe("#1103 a page whose stored terms its own change log quotes as previous"
   it("keeps the terms on the page as what the change record replaced", () => {
     assert.ok(unescaped(supersededPage).includes(storedTerms));
     assert.ok(supersededPage.includes("Before:"));
+  });
+
+  it("publishes the same terms as current where the recorded change widened them", () => {
+    const { change } = fixtureFrom(false, "limits_increased");
+    assert.strictEqual(change.previous_state, fixtureFrom(false).record.description);
+    assert.ok(unescaped(descriptionBlockOf(improvedPage)).includes(storedTerms));
+    const isFree = faqAnswersOf(improvedPage).find((pair) => pair.question === `Is ${FIXTURE_VENDOR} free?`);
+    assert.ok(isFree!.answer.startsWith("Yes,"), isFree!.answer);
+    assert.ok("offers" in jsonLdOfType(improvedPage, "WebPage")!.mainEntity);
+    assert.ok(!improvedPage.includes(`class="terms-superseded-text"`), "the page withheld terms a widening replaced");
   });
 
   it("publishes the same terms as current once the change is resolved", () => {


### PR DESCRIPTION
Refs #1103

Point 1 of the ruling. The withhold now asks which direction the recorded change went, and fires only on the ones that narrow the terms.

## The predicate

`supersedingChange` was: in force, and quotes the stored description as `previous_state`. It is now: in force, **narrows the terms**, and quotes the stored description as `previous_state`.

There is no new list of change types. `CHANGE_DIRECTION` already classifies all fourteen, is already what `vendor-verdict.ts` reads to decide whether a change counts against a vendor, and is an exhaustive `Record<DealChange["change_type"], …>`, so TypeScript refuses to compile a new change type that nobody has classified. It moves to `src/change-direction.ts` and `data.ts` re-exports it, because pulling all of `data.ts` into `superseded-description.ts` for one constant would be the wrong dependency. Every existing import is unchanged.

`narrowsTheStoredTerms` is `direction === "negative"`, and **an unrecognised type narrows**. Withholding is the safe answer when we do not know which way a change went, and defaulting the other way is how `classifyTier` came to return `free` for any tier string it does not recognise.

That lands on the ruling's ten types exactly:

| ruling | direction | withholds |
|---|---|---|
| `limits_reduced`, `free_tier_removed`, `restriction`, `product_deprecated`, `pricing_restructured`, `pricing_model_change` | negative | yes |
| `limits_increased`, `new_free_tier`, `new_tier`, `rebranded` | positive / neutral | no |

and answers the four the ruling did not name: `open_source_killed` negative and withholds, `startup_program_expanded` and `pricing_postponed` positive and do not, `record_corrected` neutral and does not.

**`record_corrected` is the one worth a second look and I have flagged it on the issue** rather than special-casing it here. Its four records are hand-written, none is in the population today, and none can enter it while a correction actually lands — but if one ever did, it would mean our own correction had not been applied to the description, which is a different defect with a different owner.

## What moves

| | was | is | restored |
|---|---|---|---|
| records | 237 | 183 | 54 |
| vendor pages | 235 | 182 | 53 |
| ungated pages | 222 | 173 | 49 |

The 54 restored, by the type that was withholding them: `limits_increased` 41, `new_tier` 5, `new_free_tier` 5, `rebranded` 3. That is the ruling's table.

`/vendor/instapaper`, `/vendor/firecrawl` and `/vendor/inngest` publish their figures again. `/vendor/railway` — `limits_reduced` — still withholds.

The three budgets were lowered by `npm run ratchet:budgets`, which is the mechanism #1384 shipped yesterday doing what it was built for: an improvement lowers the ceiling in the same commit.

## Tests

`writeFixture` takes a change type, so the same `deno-deploy` record and change render on a third server with `change_type: limits_increased`. That page publishes its description block, answers `Yes,`, emits the zero-price `Offer`, and carries no superseded notice — the exact counterpart of the eleven assertions the withheld fixture already makes.

`classifies every change type the data model declares, and nothing is left over` asserts the two lists partition `CHANGE_DIRECTION` exactly, so adding a change type without deciding its side turns the suite red rather than defaulting quietly.

`leaves every record the change log only ever widened publishing its terms` runs over the shipped catalogue and refuses to be vacuous — it asserts the population it checks is non-empty first.

`scripts/mutate-1103b.sh`: 12 mutations, 12 killed. Six of the predicate, six of the classification — flipping any one of the six types the ruling names is caught.

## Seen working

Four pages fetched from a build of this branch on a real server:

| | superseded notice | meta description | zero-price `Offer` |
|---|---|---|---|
| `/vendor/instapaper` | none | the stored terms | emitted |
| `/vendor/firecrawl` | none | the stored terms | emitted |
| `/vendor/inngest` | none | the stored terms | emitted |
| `/vendor/railway` | one | `superseded by a pricing change we recorded on 2026-09-03` | withheld |
