### PR TITLE
Publish the terms our own change record read, in place of the refusal (#1386)

### DIFF
--- a/data/deal_changes.json
+++ b/data/deal_changes.json
@@ -5782,7 +5782,7 @@
     },
     {
       "vendor": "tabler-icons.io",
-      "change_type": "pricing_restructured",
+      "change_type": "limits_increased",
       "date": "2026-08-28",
       "date_source": "discovered",
       "summary": "While a free tier still exists, the number of icons has increased from 5,800 to 6184. There are also options to purchase bundles and support the project with optional payments.",
@@ -7254,7 +7254,13 @@
       "category": "Databases",
       "alternatives": [],
       "detected_by": "reverify-ai",
-      "recorded_date": "2026-09-01"
+      "recorded_date": "2026-09-01",
+      "resolution": {
+        "state": "retracted",
+        "date": "2026-09-05",
+        "detail": "Retracted 2026-09-05: Turso's free tier was not reduced. turso.tech/pricing, fetched 2026-09-05, states the Free column as \"Databases Free 100\", \"Storage Free 5GB\", \"Monthly Rows Read Free 500 Million\" and \"Monthly Rows Written Free 10 Million\" — all four are the figures our stored description already carried. This record's own summary says the same in its own words: \"500 Million rows read/month and 10 Million rows written/month, matching previously\" and \"The free tier now includes 5GB of storage. Previously 5GB.\" This row was our error, not a change Turso made.",
+        "source_url": "https://turso.tech/pricing"
+      }
     },
     {
       "vendor": "Firecrawl",
@@ -8132,7 +8138,13 @@
       "category": "Auth",
       "alternatives": [],
       "detected_by": "reverify-ai",
-      "recorded_date": "2026-09-03"
+      "recorded_date": "2026-09-03",
+      "resolution": {
+        "state": "retracted",
+        "date": "2026-09-05",
+        "detail": "Retracted 2026-09-05: Clerk's Hobby plan was not restructured. clerk.com/pricing, fetched 2026-09-05, renders Hobby as \"Free\", \"No credit card required\", \"Unlimited applications\" and \"50,000 MRU limit per app\", and the same page's FAQ states \"Clerk pricing is based on Monthly Retained Users (MRU)\" — which is what our stored description already carried. This record's own summary says the tier still exists and that what changed is the level of detail in the feature list. This row was our error, not a change Clerk made.",
+        "source_url": "https://clerk.com/pricing"
+      }
     },
     {
       "vendor": "Mistral AI",

--- a/data/deal_changes.json
+++ b/data/deal_changes.json
@@ -5043,7 +5043,13 @@
       "category": "CI/CD",
       "alternatives": [],
       "detected_by": "reverify-ai",
-      "recorded_date": "2026-08-28"
+      "recorded_date": "2026-08-28",
+      "resolution": {
+        "state": "retracted",
+        "date": "2026-09-06",
+        "detail": "Retracted 2026-09-06: the restructure is real and entirely on the paid side. semaphore.io/pricing, fetched 2026-09-06, still states every free figure our stored description carries — \"Get $15 free credits per month (≈ 2,000 Ubuntu x64 2-vCPU minutes)\", \"Includes 20 concurrent jobs by default\" and \"Self-Hosted $0.0025 /min\" — and lists \"Ubuntu x64 $0.0075 /min 2vCPU\", the cloud rate our description names. What moved is the paid compute table, which now prices by CPU and OS and opens at $0.003/min for Ubuntu ARM, below the rate it replaced. A change that leaves every free figure verbatim does not supersede the free terms.",
+        "source_url": "https://semaphore.io/pricing"
+      }
     },
     {
       "vendor": "Hypertune",
@@ -7410,7 +7416,13 @@
       "category": "Headless CMS",
       "alternatives": [],
       "detected_by": "reverify-ai",
-      "recorded_date": "2026-09-02"
+      "recorded_date": "2026-09-02",
+      "resolution": {
+        "state": "retracted",
+        "date": "2026-09-06",
+        "detail": "Retracted 2026-09-06: no limit was reduced. crystallize.com/pricing, fetched 2026-09-06, gives the free Particle plan \"Orders 25\", \"Items 100\", \"Bandwidth 5 GB\", \"API calls 25000\" and \"Users Unlimited\" — every figure our stored description carries. What is new is that the plan reads \"Free + metering / month\": usage past those quotas is billed rather than blocked, which adds a paid option above the free allowance instead of shrinking it.",
+        "source_url": "https://crystallize.com/pricing"
+      }
     },
     {
       "vendor": "serveo",
@@ -7485,7 +7497,13 @@
       "category": "Secrets Management",
       "alternatives": [],
       "detected_by": "reverify-ai",
-      "recorded_date": "2026-09-02"
+      "recorded_date": "2026-09-02",
+      "resolution": {
+        "state": "retracted",
+        "date": "2026-09-06",
+        "detail": "Retracted 2026-09-06: nothing was reduced. doppler.com/pricing, fetched 2026-09-06, prices the Developer plan at \"Free for 3 users\" and its comparison table gives that column \"Projects 10\" and \"Environments 4\" — the three figures our stored description carries, unchanged. The same column adds \"Config syncs (5)\", 5 webhooks and 5 CLI tokens per user, which our description never claimed. \"The free tier is for 3 users\" restates a limit we already publish.",
+        "source_url": "https://www.doppler.com/pricing"
+      }
     },
     {
       "vendor": "Dub.co",
@@ -8204,7 +8222,13 @@
       "category": "AI / ML",
       "alternatives": [],
       "detected_by": "reverify-ai",
-      "recorded_date": "2026-09-03"
+      "recorded_date": "2026-09-03",
+      "resolution": {
+        "state": "retracted",
+        "date": "2026-09-06",
+        "detail": "Retracted 2026-09-06: the free tier gained rather than lost. braintrust.dev/pricing, fetched 2026-09-06, lists Starter at \"$0 / month\" with \"1 GB processed data + $4/GB\", \"10k scores + $2.50/1k\", \"14-day retention\" and \"Unlimited users, projects, datasets, playgrounds, and experiments\" — every figure our stored description carries, unchanged — and adds \"$10 credits + tok rates\" that it did not carry before.",
+        "source_url": "https://www.braintrust.dev/pricing"
+      }
     },
     {
       "vendor": "Applitools Eyes",

--- a/data/quality_budgets.json
+++ b/data/quality_budgets.json
@@ -8,8 +8,8 @@
     "faq_answers": 166,
     "faq_answers_stating_a_figure": 77,
     "faq_answers_with_a_digit_but_no_figure": 40,
-    "records_with_superseded_terms": 180,
-    "vendor_pages_withholding_superseded_terms": 179,
-    "ungated_pages_withholding_superseded_terms": 170
+    "records_with_superseded_terms": 176,
+    "vendor_pages_withholding_superseded_terms": 175,
+    "ungated_pages_withholding_superseded_terms": 166
   }
 }

--- a/data/quality_budgets.json
+++ b/data/quality_budgets.json
@@ -8,8 +8,8 @@
     "faq_answers": 166,
     "faq_answers_stating_a_figure": 77,
     "faq_answers_with_a_digit_but_no_figure": 40,
-    "records_with_superseded_terms": 183,
-    "vendor_pages_withholding_superseded_terms": 182,
-    "ungated_pages_withholding_superseded_terms": 173
+    "records_with_superseded_terms": 180,
+    "vendor_pages_withholding_superseded_terms": 179,
+    "ungated_pages_withholding_superseded_terms": 170
   }
 }

--- a/scripts/mutate-1386.sh
+++ b/scripts/mutate-1386.sh
@@ -9,7 +9,7 @@ TESTS=(
   test/gated-vendor-answers.test.ts
 )
 
-SOURCES=(src/superseded-description.ts src/change-citation.ts src/serve.ts)
+SOURCES=(src/superseded-description.ts src/change-citation.ts src/unrendered-text.ts src/serve.ts)
 
 backup() { for f in "${SOURCES[@]}"; do cp "$f" "/tmp/$(basename "$f").m1386"; done; }
 restore() { for f in "${SOURCES[@]}"; do cp "/tmp/$(basename "$f").m1386" "$f"; done; }
@@ -53,12 +53,49 @@ PY
 }
 
 run_mutation "a record that read nothing still publishes a reading" \
-  sub src/superseded-description.ts 'if (terms === "" || !changeCitesASource(change)) return null;' \
-                                    'if (!changeCitesASource(change)) return null;'
+  sub src/superseded-description.ts 'if (terms === "" || carriesAnUnrenderedExpression(terms)) return null;' \
+                                    'if (carriesAnUnrenderedExpression(terms)) return null;'
 
 run_mutation "a record that cites nothing still publishes a reading" \
-  sub src/superseded-description.ts 'if (terms === "" || !changeCitesASource(change)) return null;' \
+  sub src/superseded-description.ts '  if (!changeCitesASource(change)) return null;
+' ''
+
+run_mutation "a reading the vendor's page never rendered is published" \
+  sub src/superseded-description.ts 'if (terms === "" || carriesAnUnrenderedExpression(terms)) return null;' \
                                     'if (terms === "") return null;'
+
+run_mutation "nothing is ever read as unrendered" \
+  sub src/unrendered-text.ts '  const subject = text ?? "";' '  const subject = String(text ?? "").slice(0, 0);'
+
+run_mutation "a client-side template is read as rendered text" \
+  sub src/unrendered-text.ts '  /\{\{[\s\S]*?\}\}|\{\{[^\n]*/,
+' ''
+
+run_mutation "a template whose closer a clip cut off is read as rendered text" \
+  sub src/unrendered-text.ts '/\{\{[\s\S]*?\}\}|\{\{[^\n]*/' '/\{\{[\s\S]*?\}\}/'
+
+run_mutation "a template literal is read as rendered text" \
+  sub src/unrendered-text.ts '  /\$\{[\s\S]*?\}|\$\{[^\n]*/,
+' ''
+
+run_mutation "a server-side template is read as rendered text" \
+  sub src/unrendered-text.ts '  /<%[\s\S]*?%>|<%[^\n]*/,
+' ''
+
+run_mutation "a stringified object is read as rendered text" \
+  sub src/unrendered-text.ts '  /\[object Object\]/,
+' ''
+
+run_mutation "a value that never arrived is read as rendered text" \
+  sub src/unrendered-text.ts '  /\bundefined\b/,
+' ''
+
+run_mutation "a calculation that failed is read as rendered text" \
+  sub src/unrendered-text.ts '  /\bNaN\b/,
+' ''
+
+run_mutation "the refusal cannot name what it refused" \
+  sub src/unrendered-text.ts '    if (found) return found[0];' '    if (found) return pattern.source;'
 
 run_mutation "the reading is dated by the change rather than by the day it was recorded" \
   sub src/superseded-description.ts 'date: (change.recorded_date ?? "").trim() || change.date,' 'date: change.date,'

--- a/scripts/mutate-1386.sh
+++ b/scripts/mutate-1386.sh
@@ -1,0 +1,150 @@
+#!/usr/bin/env bash
+set -uo pipefail
+
+REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO"
+
+TESTS=(
+  test/superseded-terms.test.ts
+  test/gated-vendor-answers.test.ts
+)
+
+SOURCES=(src/superseded-description.ts src/change-citation.ts src/serve.ts)
+
+backup() { for f in "${SOURCES[@]}"; do cp "$f" "/tmp/$(basename "$f").m1386"; done; }
+restore() { for f in "${SOURCES[@]}"; do cp "/tmp/$(basename "$f").m1386" "$f"; done; }
+
+backup
+trap 'restore; npm run build >/dev/null 2>&1' EXIT
+
+killed=0
+survived=0
+
+run_mutation() {
+  local name="$1"; shift
+  restore
+  if ! "$@"; then
+    echo "NOT APPLIED                $name"
+    return
+  fi
+  if ! npm run build >/dev/null 2>&1; then
+    echo "KILLED (does not compile)  $name"
+    killed=$((killed + 1))
+    return
+  fi
+  if TZ=UTC node --test --test-concurrency 1 "${TESTS[@]}" >/tmp/mutation-1386-out.txt 2>&1; then
+    echo "SURVIVED                   $name"
+    survived=$((survived + 1))
+  else
+    echo "KILLED                     $name"
+    killed=$((killed + 1))
+  fi
+}
+
+sub() {
+  python3 - "$1" "$2" "$3" <<'PY'
+import sys
+path, old, new = sys.argv[1], sys.argv[2], sys.argv[3]
+text = open(path, encoding="utf-8").read()
+if old not in text:
+    sys.exit("mutation target not found in " + path)
+open(path, "w", encoding="utf-8").write(text.replace(old, new, 1))
+PY
+}
+
+run_mutation "a record that read nothing still publishes a reading" \
+  sub src/superseded-description.ts 'if (terms === "" || !changeCitesASource(change)) return null;' \
+                                    'if (!changeCitesASource(change)) return null;'
+
+run_mutation "a record that cites nothing still publishes a reading" \
+  sub src/superseded-description.ts 'if (terms === "" || !changeCitesASource(change)) return null;' \
+                                    'if (terms === "") return null;'
+
+run_mutation "the reading is dated by the change rather than by the day it was recorded" \
+  sub src/superseded-description.ts 'date: (change.recorded_date ?? "").trim() || change.date,' 'date: change.date,'
+
+run_mutation "the reading is dated by recorded_date even when the record carries none" \
+  sub src/superseded-description.ts 'date: (change.recorded_date ?? "").trim() || change.date,' \
+                                    'date: (change.recorded_date ?? "").trim(),'
+
+run_mutation "the citation prints the whole URL rather than what a reader can place" \
+  sub src/change-citation.ts '  const host = parsed.hostname.replace(/^www\./, "");' \
+                             '  const host = parsed.host; return trimmed;'
+
+run_mutation "the citation keeps the www a reader does not need" \
+  sub src/change-citation.ts 'parsed.hostname.replace(/^www\./, "")' 'parsed.hostname'
+
+run_mutation "the citation names only the host, so two pricing pages read alike" \
+  sub src/change-citation.ts 'return `${host}${withinHost}`;' 'return host;'
+
+run_mutation "the citation keeps the trailing slash it strips" \
+  sub src/change-citation.ts '.replace(/\/+$/, "");' ';'
+
+run_mutation "an unparseable source is dropped instead of printed as stored" \
+  sub src/change-citation.ts '    return trimmed;' '    return "";'
+
+run_mutation "the opening is clipped mid-word" \
+  sub src/superseded-description.ts '  const kept = lastSpace > cap / 2 ? clipped.slice(0, lastSpace) : clipped;' \
+                                    '  const kept = clipped;'
+
+run_mutation "a clipped opening is not marked as clipped" \
+  sub src/superseded-description.ts 'return `${kept.replace(/[,;:]$/, "")}…`;' 'return kept.replace(/[,;:]$/, "");'
+
+run_mutation "the cap is ignored and every surface prints the whole reading" \
+  sub src/superseded-description.ts '  if (text.length <= cap) return text;' '  return text;'
+
+run_mutation "the opening cuts at the cap rather than at a sentence" \
+  sub src/superseded-description.ts '    if (candidate.length > cap) break;' '    if (candidate.length > cap) continue;'
+
+run_mutation "the reading runs into the sentence after it with no stop" \
+  sub src/superseded-description.ts 'return /[.!?…]$/.test(trimmed) ? trimmed : `${trimmed}.`;' 'return trimmed;'
+
+run_mutation "the notice goes back to refusing without the reading" \
+  sub src/superseded-description.ts '    readingWithTail(vendor, change) ??
+    `${withheldTail(vendor, change, false)} We have not re-read' \
+                                    '    null ??
+    `${withheldTail(vendor, change, false)} We have not re-read'
+
+run_mutation "the answer goes back to refusing without the reading" \
+  sub src/superseded-description.ts '    readingWithTail(vendor, change) ??
+    `We are not answering that' \
+                                    '    null ??
+    `We are not answering that'
+
+run_mutation "the answer drops what our own record says changed" \
+  sub src/superseded-description.ts 'return `${opening} What our record says changed: ${change.summary}`;' 'return opening;'
+
+run_mutation "the meta description goes back to refusing without the reading" \
+  sub src/superseded-description.ts '  const reading = readingBehindTheChange(change);
+  if (!reading) {' \
+                                    '  const reading = null;
+  if (!reading) {'
+
+run_mutation "the verdict goes back to refusing without the reading" \
+  sub src/superseded-description.ts 'return readingWithTail(vendor, change, 170) ?? withheldTail(vendor, change, false);' \
+                                    'return withheldTail(vendor, change, false);'
+
+run_mutation "the withholding sentence stops saying our own record supersedes the terms" \
+  sub src/superseded-description.ts '`our own pricing change record, ${changeDateClause(change)}, ${STORED_TERMS_WITHHELD_PHRASE}.`' \
+                                    '`our own pricing change record supersedes them.`'
+
+run_mutation "the description block prints the source as text with no link" \
+  sub src/superseded-description.ts '  const link =
+    `<a href="${esc(reading.url)}" target="_blank" rel="noopener" class="change-source">` +
+    `${esc(reading.label)}</a>`;' \
+                                    '  const link = esc(reading.label);'
+
+run_mutation "the href is not escaped" \
+  sub src/superseded-description.ts '`<a href="${esc(reading.url)}" target="_blank" rel="noopener" class="change-source">`' \
+                                    '`<a href="${reading.url}" target="_blank" rel="noopener" class="change-source">`'
+
+run_mutation "the terms are not escaped before going into the page" \
+  sub src/superseded-description.ts '${readingSentence(esc(reading.date), link, esc(punctuated(reading.terms)))} ' \
+                                    '${readingSentence(esc(reading.date), link, punctuated(reading.terms))} '
+
+run_mutation "the description block escapes the notice whole, so the link never renders" \
+  sub src/serve.ts '${supersededTermsNoticeHtml(vendorName, termsSuperseded, escHtmlServer)}' \
+                   '${escHtmlServer(supersededTermsNotice(vendorName, termsSuperseded))}'
+
+echo
+echo "killed $killed, survived $survived"

--- a/src/change-citation.ts
+++ b/src/change-citation.ts
@@ -18,6 +18,19 @@ export function uncitedChanges<T extends CitableChange>(changes: readonly T[]): 
   return changes.filter(changeIsUncited);
 }
 
+export function citationLabel(url: string): string {
+  const trimmed = (url ?? "").trim();
+  let parsed: URL;
+  try {
+    parsed = new URL(trimmed);
+  } catch {
+    return trimmed;
+  }
+  const host = parsed.hostname.replace(/^www\./, "");
+  const withinHost = `${parsed.pathname}${parsed.search}`.replace(/\/+$/, "");
+  return `${host}${withinHost}`;
+}
+
 export const UNCITED_CHANGE_LABEL = "Unsourced";
 
 export function uncitedChangeNotice(vendor: string): string {

--- a/src/serve.ts
+++ b/src/serve.ts
@@ -20,7 +20,7 @@ import { openapiSpec } from "./openapi.js";
 import { LINK_GRACE_DAYS, unreachableNoticeForUrl } from "./link-health.js";
 import { offerEnded, offerRetired, recordedTierSentence, endedHeadline, endedHistorySentence, endedReliabilitySentence, endedEmptyChangeHistorySentence, ENDED_BADGE_LABEL, ENDED_SINCE_CHANGES_SENTENCE, type OfferTierAndUrl } from "./retirement.js";
 import { amountUnstatedSentence, levelWithheldReason, sourceStatesNoAmount, withheldLevelClause, withheldLevelSentence } from "./source-check.js";
-import { SUPERSEDED_TERMS_LABEL, supersededTermsAnswer, supersededTermsMetaSentence, supersededTermsNotice, supersededTermsVerdictSentence, supersedingChange } from "./superseded-description.js";
+import { SUPERSEDED_TERMS_LABEL, supersededTermsAnswer, supersededTermsMetaSentence, supersededTermsNotice, supersededTermsNoticeHtml, supersededTermsVerdictSentence, supersedingChange } from "./superseded-description.js";
 import { buildComparisonMap, comparisonSlug } from "./comparison-pairs.js";
 import { stabilityFaqAnswer, stabilityVerdictClause, type ComparisonSide, type StabilityRating } from "./comparison-verdict.js";
 import { publishedVendorLevel, vendorVerdictSentence, vendorBadge, statesRiskCause, narrowingSentence, changeKindNoun, type VendorVerdictInput } from "./vendor-verdict.js";
@@ -4427,7 +4427,7 @@ ${referralCalloutHtml}
   <div class="desc-block">
     <h2>Free Tier Details</h2>
     ${termsSuperseded
-      ? `<p class="terms-superseded-text"><strong>${SUPERSEDED_TERMS_LABEL}:</strong> ${escHtmlServer(supersededTermsNotice(vendorName, termsSuperseded))} <a href="#changes">Read what we recorded &darr;</a></p>`
+      ? `<p class="terms-superseded-text"><strong>${SUPERSEDED_TERMS_LABEL}:</strong> ${supersededTermsNoticeHtml(vendorName, termsSuperseded, escHtmlServer)} <a href="#changes">Read what we recorded &darr;</a></p>`
       : `<p class="desc-text">${escHtmlServer(primary.description)}</p>`}
   </div>
 ${compareTableHtml}

--- a/src/superseded-description.ts
+++ b/src/superseded-description.ts
@@ -2,6 +2,7 @@ import { changeCitesASource, citationLabel } from "./change-citation.js";
 import { changeDateClause } from "./change-dates.js";
 import { narrowsTheStoredTerms } from "./change-direction.js";
 import { isNoLongerInForce } from "./change-resolution.js";
+import { carriesAnUnrenderedExpression } from "./unrendered-text.js";
 import type { ChangeResolution, DealChange } from "./types.js";
 
 export interface QuotingChange extends Pick<DealChange, "date" | "date_source" | "change_type"> {
@@ -61,7 +62,8 @@ export function storedTermsAreSuperseded(
 
 export function readingBehindTheChange(change: QuotingChange): SourcedReading | null {
   const terms = (change.current_state ?? "").trim();
-  if (terms === "" || !changeCitesASource(change)) return null;
+  if (terms === "" || carriesAnUnrenderedExpression(terms)) return null;
+  if (!changeCitesASource(change)) return null;
   const url = change.source_url!.trim();
   return {
     date: (change.recorded_date ?? "").trim() || change.date,

--- a/src/superseded-description.ts
+++ b/src/superseded-description.ts
@@ -1,3 +1,4 @@
+import { changeCitesASource, citationLabel } from "./change-citation.js";
 import { changeDateClause } from "./change-dates.js";
 import { narrowsTheStoredTerms } from "./change-direction.js";
 import { isNoLongerInForce } from "./change-resolution.js";
@@ -6,12 +7,22 @@ import type { ChangeResolution, DealChange } from "./types.js";
 export interface QuotingChange extends Pick<DealChange, "date" | "date_source" | "change_type"> {
   summary: string;
   previous_state?: string | null;
+  current_state?: string | null;
+  source_url?: string | null;
+  recorded_date?: string | null;
   resolution?: ChangeResolution | null;
 }
 
 export interface StoredTerms {
   vendor: string;
   description: string;
+}
+
+export interface SourcedReading {
+  date: string;
+  url: string;
+  label: string;
+  terms: string;
 }
 
 function comparableTerms(text: string | null | undefined): string {
@@ -48,35 +59,103 @@ export function storedTermsAreSuperseded(
   return supersedingChange(offer, vendorChanges) !== null;
 }
 
+export function readingBehindTheChange(change: QuotingChange): SourcedReading | null {
+  const terms = (change.current_state ?? "").trim();
+  if (terms === "" || !changeCitesASource(change)) return null;
+  const url = change.source_url!.trim();
+  return {
+    date: (change.recorded_date ?? "").trim() || change.date,
+    url,
+    label: citationLabel(url),
+    terms,
+  };
+}
+
+export function openingOfTerms(terms: string, cap: number): string {
+  const text = terms.trim();
+  if (text.length <= cap) return text;
+  let wholeSentences = "";
+  for (const match of text.matchAll(/[.!?](\s|$)/g)) {
+    const candidate = text.slice(0, match.index + 1);
+    if (candidate.length > cap) break;
+    wholeSentences = candidate;
+  }
+  if (wholeSentences !== "") return wholeSentences;
+  const clipped = text.slice(0, cap);
+  const lastSpace = clipped.lastIndexOf(" ");
+  const kept = lastSpace > cap / 2 ? clipped.slice(0, lastSpace) : clipped;
+  return `${kept.replace(/[,;:]$/, "")}…`;
+}
+
+function punctuated(text: string): string {
+  const trimmed = text.trim();
+  return /[.!?…]$/.test(trimmed) ? trimmed : `${trimmed}.`;
+}
+
+function readingSentence(date: string, source: string, terms: string): string {
+  return `As of ${date}, ${source} reads: ${terms}`;
+}
+
 export const SUPERSEDED_TERMS_LABEL = "Superseded";
+
+export const STORED_TERMS_WITHHELD_PHRASE = "names them as the previous ones";
+
+export const STORED_TERMS_WITHHELD_META_PHRASE = "terms are superseded and withheld";
+
+function withheldTail(vendor: string, change: QuotingChange, besideAReading: boolean): string {
+  return (
+    `We are not publishing our stored ${vendor} terms${besideAReading ? " beside it" : ""} — ` +
+    `our own pricing change record, ${changeDateClause(change)}, ${STORED_TERMS_WITHHELD_PHRASE}.`
+  );
+}
+
+function readingWithTail(vendor: string, change: QuotingChange, cap?: number): string | null {
+  const reading = readingBehindTheChange(change);
+  if (!reading) return null;
+  const terms = cap === undefined ? reading.terms : openingOfTerms(reading.terms, cap);
+  return `${readingSentence(reading.date, reading.label, punctuated(terms))} ${withheldTail(vendor, change, true)}`;
+}
 
 export function supersededTermsNotice(vendor: string, change: QuotingChange): string {
   return (
-    `The terms we store for ${vendor} are the ones our own pricing change record, ` +
-    `${changeDateClause(change)}, names as the previous ones. We have not re-read ${vendor}'s ` +
-    `pricing page since that record, so we are not publishing them as current.`
+    readingWithTail(vendor, change) ??
+    `${withheldTail(vendor, change, false)} We have not re-read ${vendor}'s pricing page since that record.`
+  );
+}
+
+export function supersededTermsNoticeHtml(
+  vendor: string,
+  change: QuotingChange,
+  esc: (text: string) => string,
+): string {
+  const reading = readingBehindTheChange(change);
+  if (!reading) return esc(supersededTermsNotice(vendor, change));
+  const link =
+    `<a href="${esc(reading.url)}" target="_blank" rel="noopener" class="change-source">` +
+    `${esc(reading.label)}</a>`;
+  return (
+    `${readingSentence(esc(reading.date), link, esc(punctuated(reading.terms)))} ` +
+    esc(withheldTail(vendor, change, true))
   );
 }
 
 export function supersededTermsAnswer(vendor: string, change: QuotingChange): string {
-  return (
-    `We are not answering that from our stored terms today. Our pricing change record, ` +
-    `${changeDateClause(change)}, names them as the previous terms: ${change.summary} ` +
-    `We have not re-read ${vendor}'s pricing page since, so the recorded change is what we stand behind, ` +
-    `not the figures it replaces.`
-  );
+  const opening =
+    readingWithTail(vendor, change) ??
+    `We are not answering that from our stored terms today. ${withheldTail(vendor, change, false)}`;
+  return `${opening} What our record says changed: ${change.summary}`;
 }
 
 export function supersededTermsMetaSentence(vendor: string, change: QuotingChange): string {
-  return (
-    `Our stored ${vendor} free-tier terms are superseded by a pricing change we recorded on ` +
-    `${change.date} and have not re-read since.`
-  );
+  const withheld = `Our stored ${vendor} ${STORED_TERMS_WITHHELD_META_PHRASE}`;
+  const reading = readingBehindTheChange(change);
+  if (!reading) {
+    return `${withheld}: our own pricing change record, ${changeDateClause(change)}, ${STORED_TERMS_WITHHELD_PHRASE}.`;
+  }
+  const opening = punctuated(openingOfTerms(reading.terms, 90));
+  return `${readingSentence(reading.date, reading.label, opening)} ${withheld}.`;
 }
 
 export function supersededTermsVerdictSentence(vendor: string, change: QuotingChange): string {
-  return (
-    `We are not publishing ${vendor}'s stored free-tier figures — our pricing change record, ` +
-    `${changeDateClause(change)}, names them as the previous ones.`
-  );
+  return readingWithTail(vendor, change, 170) ?? withheldTail(vendor, change, false);
 }

--- a/src/unrendered-text.ts
+++ b/src/unrendered-text.ts
@@ -1,0 +1,21 @@
+const UNRENDERED_EXPRESSIONS = [
+  /\{\{[\s\S]*?\}\}|\{\{[^\n]*/,
+  /\$\{[\s\S]*?\}|\$\{[^\n]*/,
+  /<%[\s\S]*?%>|<%[^\n]*/,
+  /\[object Object\]/,
+  /\bundefined\b/,
+  /\bNaN\b/,
+];
+
+export function unrenderedExpressionIn(text: string | null | undefined): string | null {
+  const subject = text ?? "";
+  for (const pattern of UNRENDERED_EXPRESSIONS) {
+    const found = subject.match(pattern);
+    if (found) return found[0];
+  }
+  return null;
+}
+
+export function carriesAnUnrenderedExpression(text: string | null | undefined): boolean {
+  return unrenderedExpressionIn(text) !== null;
+}

--- a/test/gated-vendor-answers.test.ts
+++ b/test/gated-vendor-answers.test.ts
@@ -8,7 +8,7 @@ import { fileURLToPath } from "node:url";
 const { gateFor, utcDate } = await import("../dist/ranking.js");
 const { vendorSlugMap } = await import("../dist/vendor-slug.js");
 const { offerEnded } = await import("../dist/retirement.js");
-const { supersededTermsNotice, supersedingChange } = await import("../dist/superseded-description.js");
+const { STORED_TERMS_WITHHELD_PHRASE, supersededTermsNotice, supersedingChange } = await import("../dist/superseded-description.js");
 const { qualityBudget } = await import("../dist/page-reviews.js");
 
 type Offer = import("../src/types.ts").Offer;
@@ -222,7 +222,7 @@ describe("the page a gated record renders does not answer the free-tier question
     for (const p of subjects) {
       const answer = freeAnswer(p);
       assert.ok(!answer.includes(p.primary.description.slice(0, 60)), `/vendor/${p.slug} still states them: ${answer.slice(0, 120)}`);
-      assert.ok(answer.includes("names them as the previous terms"), `/vendor/${p.slug}: ${answer.slice(0, 160)}`);
+      assert.ok(answer.includes(STORED_TERMS_WITHHELD_PHRASE), `/vendor/${p.slug}: ${answer.slice(0, 160)}`);
     }
   });
 
@@ -669,7 +669,7 @@ describe("the same page an ungated record renders is unchanged", () => {
     const opening = subjects.filter(p => pageProse(p).includes(`${p.vendor}'s free tier offers `)).map(p => p.slug);
     assert.deepStrictEqual(opening.slice(0, 20), [], "verdicts still opening on figures the change log supersedes");
     const silent = subjects
-      .filter(p => !pageProse(p).includes(`names them as the previous ones`))
+      .filter(p => !pageProse(p).includes(STORED_TERMS_WITHHELD_PHRASE))
       .map(p => p.slug);
     assert.deepStrictEqual(silent.slice(0, 20), [], "verdicts that withhold the figures without saying why");
   });

--- a/test/superseded-terms.test.ts
+++ b/test/superseded-terms.test.ts
@@ -21,6 +21,7 @@ const {
   storedTermsAreSuperseded,
 } = await import("../dist/superseded-description.js");
 const { citationLabel } = await import("../dist/change-citation.js");
+const { carriesAnUnrenderedExpression, unrenderedExpressionIn } = await import("../dist/unrendered-text.js");
 const { toSlug } = await import("../dist/slug.js");
 const { qualityBudget } = await import("../dist/page-reviews.js");
 const { supersededCensus } = await import("../dist/superseded-census.js");
@@ -93,6 +94,12 @@ const A_CHANGE_QUOTING_IT = {
   source_url: "https://quotacorp.example/pricing",
   category: "Cloud Hosting",
   alternatives: [],
+};
+
+const A_CHANGE_READING_A_TEMPLATE = {
+  ...A_CHANGE_QUOTING_IT,
+  summary: "The free tier now has a request limit.",
+  current_state: "The free tier allows a maximum of {{ appConfig.MaxRequests }} requests. URLs expire.",
 };
 
 describe("#1103 a change record that quotes our stored terms as the previous ones", () => {
@@ -359,6 +366,15 @@ describe("#1386 the reading the superseding record already holds", () => {
     ["a blank reading", { current_state: "  \n " }],
   ] as const;
 
+  const TERMS_THE_PAGE_NEVER_RENDERED = [
+    ["a client-side template", "The free tier allows a maximum of {{ appConfig.MaxRequests }} requests."],
+    ["a template literal", "Free plan: ${limits.egress} of egress a month"],
+    ["a server-side template", "Free plan: <%= plan.storage %> of storage"],
+    ["a stringified object", "Free plan: [object Object] included"],
+    ["a value that never arrived", "Free plan: undefined GB of egress"],
+    ["a calculation that failed", "Free plan: NaN requests per month"],
+  ] as const;
+
   it("is the current state, dated by the day the record was written, attributed to its source", () => {
     const reading = readingBehindTheChange({ ...A_CHANGE_QUOTING_IT, recorded_date: "2026-08-29" })!;
     assert.strictEqual(reading.terms, A_CHANGE_QUOTING_IT.current_state);
@@ -375,6 +391,40 @@ describe("#1386 the reading the superseding record already holds", () => {
     for (const [why, missing] of NO_READING_TO_PUBLISH) {
       assert.strictEqual(readingBehindTheChange({ ...A_CHANGE_QUOTING_IT, ...missing }), null, why);
     }
+  });
+
+  it("is nothing at all where the terms carry an expression the vendor's page never rendered", () => {
+    for (const [why, current_state] of TERMS_THE_PAGE_NEVER_RENDERED) {
+      assert.strictEqual(readingBehindTheChange({ ...A_CHANGE_QUOTING_IT, current_state }), null, why);
+    }
+  });
+
+  it("names the expression it refused, and finds none in terms a page did render", () => {
+    assert.strictEqual(
+      unrenderedExpressionIn(A_CHANGE_READING_A_TEMPLATE.current_state),
+      "{{ appConfig.MaxRequests }}",
+    );
+    assert.strictEqual(unrenderedExpressionIn("a maximum of {{ appConfig.MaxReq"), "{{ appConfig.MaxReq");
+    for (const rendered of [
+      A_CHANGE_QUOTING_IT.current_state,
+      "Starter: $0 / month — $10 credits + tok rates, 1 GB processed data + $4/GB",
+      "Orders 25, Items 100, Bandwidth 5 GB, API calls 25000, Users Unlimited",
+      "Free for 3 users. Projects 10. Environments 4. Config syncs (5).",
+      "$15 free credits per month (≈ 2,000 Ubuntu x64 2-vCPU minutes)",
+    ]) {
+      assert.strictEqual(carriesAnUnrenderedExpression(rendered), false, rendered);
+    }
+  });
+
+  it("publishes no reading carrying one, on any record in the catalogue population", () => {
+    const carrying = supersededRecords()
+      .map(({ offer, change }) => ({
+        vendor: offer.vendor,
+        found: unrenderedExpressionIn(readingBehindTheChange(change)?.terms),
+      }))
+      .filter(({ found }) => found)
+      .map(({ vendor, found }) => `${vendor} :: ${found}`);
+    assert.deepStrictEqual(carrying.slice(0, 20), []);
   });
 
   it("shortens a URL to what a reader can place, and leaves one it cannot parse alone", () => {
@@ -431,6 +481,22 @@ describe("#1386 the reading the superseding record already holds", () => {
       const notice = supersededTermsNotice(offer.vendor, change);
       const after = notice.indexOf(reading.terms) + reading.terms.length;
       assert.strictEqual(notice.slice(after, after + 2), ". ", `${offer.vendor}: ${notice}`);
+    }
+  });
+
+  it("says why it withholds, and invents no reading, where the record read an expression the page never rendered", () => {
+    const wordings = [
+      supersededTermsNotice(A_RECORD.vendor, A_CHANGE_READING_A_TEMPLATE),
+      supersededTermsAnswer(A_RECORD.vendor, A_CHANGE_READING_A_TEMPLATE),
+      supersededTermsMetaSentence(A_RECORD.vendor, A_CHANGE_READING_A_TEMPLATE),
+      supersededTermsVerdictSentence(A_RECORD.vendor, A_CHANGE_READING_A_TEMPLATE),
+      unescaped(supersededTermsNoticeHtml(A_RECORD.vendor, A_CHANGE_READING_A_TEMPLATE, escapedFor)),
+    ];
+    for (const text of wordings) {
+      assert.ok(text.includes(STORED_TERMS_WITHHELD_PHRASE), text);
+      assert.ok(!text.includes("As of"), text);
+      assert.ok(!text.includes("{{"), text);
+      assert.ok(!text.includes("appConfig"), text);
     }
   });
 
@@ -807,6 +873,19 @@ describe("#1103 every catalogue record whose stored terms are superseded", () =>
       .filter(({ offer }) => withholdingSurfacesOf(bodies.get(`/vendor/${toSlug(offer.vendor)}`)!).length < 4)
       .map(({ offer }) => offer.vendor);
     assert.deepStrictEqual(bare.slice(0, 20), []);
+  });
+
+  it("quotes an expression the vendor's page never rendered on none of them", () => {
+    const leaking: string[] = [];
+    for (const { offer, change } of population) {
+      const html = bodies.get(`/vendor/${toSlug(offer.vendor)}`)!;
+      const withoutWhatTheChangeItselfSays = (text: string) => text.split(change.summary).join(" ");
+      for (const [surface, text] of withholdingSurfacesOf(html)) {
+        const found = unrenderedExpressionIn(withoutWhatTheChangeItselfSays(text));
+        if (found) leaking.push(`${offer.vendor} :: ${surface} :: ${found}`);
+      }
+    }
+    assert.deepStrictEqual(leaking.slice(0, 20), []);
   });
 
   it("opens the meta description on what it read rather than on what it will not say", () => {

--- a/test/superseded-terms.test.ts
+++ b/test/superseded-terms.test.ts
@@ -7,10 +7,20 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 
 const {
+  STORED_TERMS_WITHHELD_META_PHRASE,
+  STORED_TERMS_WITHHELD_PHRASE,
+  openingOfTerms,
   quotesTheStoredTermsAsPrevious,
+  readingBehindTheChange,
+  supersededTermsAnswer,
+  supersededTermsMetaSentence,
+  supersededTermsNotice,
+  supersededTermsNoticeHtml,
+  supersededTermsVerdictSentence,
   supersedingChange,
   storedTermsAreSuperseded,
 } = await import("../dist/superseded-description.js");
+const { citationLabel } = await import("../dist/change-citation.js");
 const { toSlug } = await import("../dist/slug.js");
 const { qualityBudget } = await import("../dist/page-reviews.js");
 const { supersededCensus } = await import("../dist/superseded-census.js");
@@ -340,6 +350,132 @@ describe("#1383 which of the two directions holds a scheduled data commit", () =
   });
 });
 
+describe("#1386 the reading the superseding record already holds", () => {
+  const NO_READING_TO_PUBLISH = [
+    ["no source", { source_url: "" }],
+    ["a blank source", { source_url: "   " }],
+    ["no source field", { source_url: undefined }],
+    ["nothing read", { current_state: "" }],
+    ["a blank reading", { current_state: "  \n " }],
+  ] as const;
+
+  it("is the current state, dated by the day the record was written, attributed to its source", () => {
+    const reading = readingBehindTheChange({ ...A_CHANGE_QUOTING_IT, recorded_date: "2026-08-29" })!;
+    assert.strictEqual(reading.terms, A_CHANGE_QUOTING_IT.current_state);
+    assert.strictEqual(reading.url, A_CHANGE_QUOTING_IT.source_url);
+    assert.strictEqual(reading.label, "quotacorp.example/pricing");
+    assert.strictEqual(reading.date, "2026-08-29");
+  });
+
+  it("falls back to the change date where the record does not say when it was written", () => {
+    assert.strictEqual(readingBehindTheChange(A_CHANGE_QUOTING_IT)!.date, A_CHANGE_QUOTING_IT.date);
+  });
+
+  it("is nothing at all where the record cites no page or read nothing off it", () => {
+    for (const [why, missing] of NO_READING_TO_PUBLISH) {
+      assert.strictEqual(readingBehindTheChange({ ...A_CHANGE_QUOTING_IT, ...missing }), null, why);
+    }
+  });
+
+  it("shortens a URL to what a reader can place, and leaves one it cannot parse alone", () => {
+    assert.strictEqual(citationLabel("https://www.turso.tech/pricing/"), "turso.tech/pricing");
+    assert.strictEqual(citationLabel("https://supabase.com/"), "supabase.com");
+    assert.strictEqual(citationLabel("https://vendor.test/plans?tab=free"), "vendor.test/plans?tab=free");
+    assert.strictEqual(citationLabel("not a url"), "not a url");
+  });
+
+  it("takes whole sentences up to the cap rather than cutting mid-figure", () => {
+    const terms = "Free plan: 20 GiB egress. Paid plans start at $19/month. Enterprise is quoted.";
+    assert.strictEqual(openingOfTerms(terms, 200), terms);
+    assert.strictEqual(openingOfTerms(terms, 60), "Free plan: 20 GiB egress. Paid plans start at $19/month.");
+    assert.strictEqual(openingOfTerms(terms, 30), "Free plan: 20 GiB egress.");
+  });
+
+  it("clips a single long sentence on a word boundary and marks it as clipped", () => {
+    const oneSentence = "The free tier includes 500 million rows read per month and 10 million rows written per month";
+    const opening = openingOfTerms(oneSentence, 40);
+    assert.ok(opening.endsWith("…"), opening);
+    assert.ok(opening.length <= 41, opening);
+    assert.ok(oneSentence.startsWith(opening.slice(0, -1)), opening);
+    assert.ok(!/\s$/.test(opening.slice(0, -1)), opening);
+  });
+
+  it("publishes the reading, its date and its source in every wording that withholds our terms", () => {
+    const reading = readingBehindTheChange(A_CHANGE_QUOTING_IT)!;
+    const wordings = {
+      notice: supersededTermsNotice(A_RECORD.vendor, A_CHANGE_QUOTING_IT),
+      answer: supersededTermsAnswer(A_RECORD.vendor, A_CHANGE_QUOTING_IT),
+      meta: supersededTermsMetaSentence(A_RECORD.vendor, A_CHANGE_QUOTING_IT),
+      verdict: supersededTermsVerdictSentence(A_RECORD.vendor, A_CHANGE_QUOTING_IT),
+    };
+    for (const [surface, text] of Object.entries(wordings)) {
+      assert.ok(text.includes(reading.label), `${surface}: ${text}`);
+      assert.ok(text.includes(reading.date), `${surface}: ${text}`);
+      assert.ok(text.includes(openingOfTerms(reading.terms, 90)), `${surface}: ${text}`);
+    }
+    assert.ok(wordings.answer.includes(A_CHANGE_QUOTING_IT.summary), wordings.answer);
+
+    assert.ok(!/[.!?…]$/.test(reading.terms), "the fixture must read terms with no closing stop for the next assertion to bite");
+    for (const [surface, text] of Object.entries(wordings)) {
+      const after = text.indexOf(reading.terms) + reading.terms.length;
+      assert.strictEqual(text.slice(after, after + 2), ". ", `${surface} runs the reading into the next sentence: ${text}`);
+    }
+  });
+
+  it("closes the reading on every record that read terms with no stop of their own", () => {
+    const unstopped = supersededRecords()
+      .map(({ offer, change }) => ({ offer, change, reading: readingBehindTheChange(change)! }))
+      .filter(({ reading }) => reading && !/[.!?…]$/.test(reading.terms));
+    assert.ok(unstopped.length > 10, `only ${unstopped.length} records read terms with no closing stop`);
+    for (const { offer, change, reading } of unstopped) {
+      const notice = supersededTermsNotice(offer.vendor, change);
+      const after = notice.indexOf(reading.terms) + reading.terms.length;
+      assert.strictEqual(notice.slice(after, after + 2), ". ", `${offer.vendor}: ${notice}`);
+    }
+  });
+
+  it("says why it withholds, and invents no reading, where the record cites nothing", () => {
+    const uncited = { ...A_CHANGE_QUOTING_IT, source_url: "" };
+    const wordings = [
+      supersededTermsNotice(A_RECORD.vendor, uncited),
+      supersededTermsAnswer(A_RECORD.vendor, uncited),
+      supersededTermsMetaSentence(A_RECORD.vendor, uncited),
+      supersededTermsVerdictSentence(A_RECORD.vendor, uncited),
+    ];
+    for (const text of wordings) {
+      assert.ok(text.includes(STORED_TERMS_WITHHELD_PHRASE), text);
+      assert.ok(!text.includes("As of"), text);
+      assert.ok(!text.includes(uncited.current_state), text);
+    }
+  });
+
+  it("links the page in the description block and escapes what it puts in the href", () => {
+    const hostile = {
+      ...A_CHANGE_QUOTING_IT,
+      source_url: 'https://quotacorp.example/pricing?a=1&b="x"',
+      current_state: 'Free plan: <b>20 GiB</b> egress & "burst"',
+    };
+    const html = supersededTermsNoticeHtml(A_RECORD.vendor, hostile, escapedFor);
+    assert.ok(html.includes('href="https://quotacorp.example/pricing?a=1&amp;b=&quot;x&quot;"'), html);
+    assert.ok(html.includes('class="change-source"'), html);
+    assert.ok(!html.includes("<b>"), html);
+    assert.ok(html.includes("&lt;b&gt;20 GiB&lt;/b&gt;"), html);
+  });
+
+  it("prints no link, and no reading, where the record cites nothing", () => {
+    const uncited = { ...A_CHANGE_QUOTING_IT, source_url: "" };
+    const html = supersededTermsNoticeHtml(A_RECORD.vendor, uncited, escapedFor);
+    assert.ok(!html.includes("<a "), html);
+    assert.strictEqual(unescaped(html), supersededTermsNotice(A_RECORD.vendor, uncited));
+  });
+
+  it("renders the same words as the plain notice once the markup is taken out", () => {
+    const html = supersededTermsNoticeHtml(A_RECORD.vendor, A_CHANGE_QUOTING_IT, escapedFor);
+    const asText = unescaped(html.replace(/<[^>]+>/g, ""));
+    assert.strictEqual(asText, supersededTermsNotice(A_RECORD.vendor, A_CHANGE_QUOTING_IT));
+  });
+});
+
 const FIXTURE_VENDOR = "Deno Deploy";
 const FIXTURE_SLUG = toSlug(FIXTURE_VENDOR);
 
@@ -404,7 +540,34 @@ function faqAnswersOf(html: string): { question: string; answer: string }[] {
 }
 
 function unescaped(html: string): string {
-  return html.replace(/&#39;/g, "'").replace(/&quot;/g, '"').replace(/&amp;/g, "&");
+  return html
+    .replace(/&#39;/g, "'")
+    .replace(/&quot;/g, '"')
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&amp;/g, "&");
+}
+
+function escapedFor(text: string): string {
+  return text.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;");
+}
+
+function quickVerdictOf(html: string): string {
+  return /<div class="quick-verdict">[\s\S]*?<\/div>/.exec(html)?.[0] ?? "";
+}
+
+function withholdingSurfacesOf(html: string): [string, string][] {
+  const page = jsonLdOfType(html, "WebPage");
+  const surfaces: [string, string][] = [
+    ["meta description", unescaped(metaDescriptionOf(html))],
+    ["description block", unescaped(descriptionBlockOf(html))],
+    ["quick verdict", unescaped(quickVerdictOf(html))],
+    ["structured description", String(page?.mainEntity?.description ?? "")],
+    ...faqAnswersOf(html).map(({ question, answer }) => [question, answer] as [string, string]),
+  ];
+  return surfaces.filter(
+    ([, text]) => text.includes(STORED_TERMS_WITHHELD_PHRASE) || text.includes(STORED_TERMS_WITHHELD_META_PHRASE),
+  );
 }
 
 describe("#1103 a page whose stored terms its own change log quotes as previous", () => {
@@ -463,7 +626,7 @@ describe("#1103 a page whose stored terms its own change log quotes as previous"
   it("does not state the stored terms in the meta description", () => {
     const meta = unescaped(metaDescriptionOf(supersededPage));
     assert.ok(!meta.includes(storedTerms.slice(0, 60)), meta);
-    assert.ok(meta.includes("superseded by a pricing change we recorded on"), meta);
+    assert.ok(meta.includes(STORED_TERMS_WITHHELD_META_PHRASE), meta);
   });
 
   it("offers no upgrade threshold read off terms it will not publish", () => {
@@ -488,7 +651,7 @@ describe("#1103 a page whose stored terms its own change log quotes as previous"
     const isFree = answers.find((pair) => pair.question === `Is ${FIXTURE_VENDOR} free?`);
     assert.ok(isFree, "the page must still ask whether the vendor is free");
     assert.ok(!isFree!.answer.startsWith("Yes,"), isFree!.answer);
-    assert.ok(isFree!.answer.includes("previous terms"), isFree!.answer);
+    assert.ok(isFree!.answer.includes(STORED_TERMS_WITHHELD_PHRASE), isFree!.answer);
   });
 
   it("still names the tier while withholding the figures behind it", () => {
@@ -532,6 +695,7 @@ describe("#1103 every catalogue record whose stored terms are superseded", () =>
   let server: { proc: ChildProcess; port: number } | null = null;
   const bodies = new Map<string, string>();
   const population = supersededPagesRender();
+  const withARecordedReading = () => population.filter(({ change }) => readingBehindTheChange(change));
 
   before(async () => {
     server = await startServer({});
@@ -551,6 +715,21 @@ describe("#1103 every catalogue record whose stored terms are superseded", () =>
 
   it("renders a page for every one of them", () => {
     assert.strictEqual(bodies.size, population.length);
+  });
+
+  it("holds a dated, sourced reading for most of them, so the citations below have subjects", () => {
+    assert.ok(
+      withARecordedReading().length > population.length * 0.9,
+      `only ${withARecordedReading().length} of ${population.length} superseding records carry a citable reading`,
+    );
+  });
+
+  it("says why it withholds on the rest, where there is no reading to publish instead", () => {
+    const silent = population
+      .filter(({ change }) => !readingBehindTheChange(change))
+      .filter(({ offer }) => withholdingSurfacesOf(bodies.get(`/vendor/${toSlug(offer.vendor)}`)!).length === 0)
+      .map(({ offer }) => offer.vendor);
+    assert.deepStrictEqual(silent.slice(0, 20), []);
   });
 
   it("states the stored terms in no description block", () => {
@@ -592,8 +771,51 @@ describe("#1103 every catalogue record whose stored terms are superseded", () =>
 
   it("says in the meta description of every one why the terms are withheld", () => {
     const silent = population
-      .filter(({ offer }) => !metaDescriptionOf(bodies.get(`/vendor/${toSlug(offer.vendor)}`)!).includes("superseded by a pricing change we recorded on"))
+      .filter(({ offer }) => !metaDescriptionOf(bodies.get(`/vendor/${toSlug(offer.vendor)}`)!).includes(STORED_TERMS_WITHHELD_META_PHRASE))
       .map(({ offer }) => offer.vendor);
     assert.deepStrictEqual(silent.slice(0, 20), []);
+  });
+
+  it("publishes the terms the record read, dated and linked to the page it read them from", () => {
+    const missing: string[] = [];
+    for (const { offer, change } of withARecordedReading()) {
+      const reading = readingBehindTheChange(change)!;
+      const html = bodies.get(`/vendor/${toSlug(offer.vendor)}`)!;
+      const block = unescaped(descriptionBlockOf(html));
+      if (!block.includes(reading.terms)) missing.push(`${offer.vendor} :: terms`);
+      if (!block.includes(reading.date)) missing.push(`${offer.vendor} :: date`);
+      if (!descriptionBlockOf(html).includes(`href="${escapedFor(reading.url)}"`)) missing.push(`${offer.vendor} :: link`);
+      if (!block.includes(reading.label)) missing.push(`${offer.vendor} :: label`);
+    }
+    assert.deepStrictEqual(missing.slice(0, 20), []);
+  });
+
+  it("cites the page beside every sentence that withholds our stored terms", () => {
+    const uncited: string[] = [];
+    for (const { offer, change } of withARecordedReading()) {
+      const reading = readingBehindTheChange(change)!;
+      for (const [surface, text] of withholdingSurfacesOf(bodies.get(`/vendor/${toSlug(offer.vendor)}`)!)) {
+        if (!text.includes(reading.label)) uncited.push(`${offer.vendor} :: ${surface} :: no source`);
+        if (!text.includes(reading.date)) uncited.push(`${offer.vendor} :: ${surface} :: no date`);
+      }
+    }
+    assert.deepStrictEqual(uncited.slice(0, 20), []);
+  });
+
+  it("finds those sentences on every page, so the assertion above has subjects", () => {
+    const bare = withARecordedReading()
+      .filter(({ offer }) => withholdingSurfacesOf(bodies.get(`/vendor/${toSlug(offer.vendor)}`)!).length < 4)
+      .map(({ offer }) => offer.vendor);
+    assert.deepStrictEqual(bare.slice(0, 20), []);
+  });
+
+  it("opens the meta description on what it read rather than on what it will not say", () => {
+    const refusing = withARecordedReading()
+      .filter(({ offer, change }) => {
+        const meta = unescaped(metaDescriptionOf(bodies.get(`/vendor/${toSlug(offer.vendor)}`)!));
+        return !meta.includes(openingOfTerms(readingBehindTheChange(change)!.terms, 90));
+      })
+      .map(({ offer }) => offer.vendor);
+    assert.deepStrictEqual(refusing.slice(0, 20), []);
   });
 });


### PR DESCRIPTION
Refs #1386

180 vendor pages withheld their stored free-tier figures under #1103 and printed a refusal in their place. Every one of the superseding records already held a `current_state` read off the vendor's own page on the day, and a `source_url` pointing at that page. The pages print that instead.

`/vendor/supabase`, before:

> **Superseded:** The terms we store for Supabase are the ones our own pricing change record, discovered 2026-09-03, names as the previous ones. We have not re-read Supabase's pricing page since that record, so we are not publishing them as current.

after:

> **Superseded:** As of 2026-09-03, [supabase.com/pricing](https://supabase.com/pricing) reads: The free tier includes unlimited API requests, 50,000 monthly active users, 500 MB database size, 5 GB egress, 1 GB file storage. Free projects are paused after 1 week of inactivity. Paid plans include $10/mo in compute credits. We are not publishing our stored Supabase terms beside it — our own pricing change record, discovered 2026-09-03, names them as the previous ones.

All seven surfaces that carried a refusal carry the reading: the description block, the meta description, the quick verdict, the JSON-LD `SoftwareApplication` description, and the "Is X free?", "What is X's free tier?" and production answers. The description block, the structured description and the "Is X free?" answer take the reading whole; the meta and the verdict take whole sentences up to a cap rather than cutting mid-figure.

This needs no view on `change_type` — the reading is true whichever direction the recorded change went — and nothing overwrites `offer.description`. The #1103 ruling stands: rendering is not overwriting.

The citation is an `<a class="change-source">`, the element the two quarterly reports already use, so 179 vendor pages now cite a change record's source where 2 pages did before. That is #1380's AC-6.

## A record that cites nothing keeps the refusal

All 180 hold a `source_url` today, but 95 of 553 records hold none (#1352's population) and one can join the withheld set tomorrow. Publishing a reading we cannot attribute would be the same error one field over, so `readingBehindTheChange` returns null without both a `source_url` and a `current_state`, and the page says why it withholds instead.

The population test partitions on the record rather than counting pages, so a record joining without a citation stays green and stays honest — the failure mode #1383 was about.

## Data

Three of the seven records the issue names are corrected, each verified against the live vendor page today; the other four are left with the reason stated on the issue.

- **Turso** retracted — `turso.tech/pricing` states the Free column as "Databases Free 100", "Storage Free 5GB", "Monthly Rows Read Free 500 Million", "Monthly Rows Written Free 10 Million". All four are the figures our stored description carries.
- **Clerk** retracted — `clerk.com/pricing` renders Hobby as "Free", "Unlimited applications", "50,000 MRU limit per app", and its FAQ states "Clerk pricing is based on Monthly Retained Users (MRU)".
- **tabler-icons.io** reclassified `pricing_restructured` → `limits_increased` — `tabler.io/icons` reads "6184 icons" and "Open Source · Free · 6150+ SVG icons · MIT License". Our stored "Over 5,800" is true and understates, so publishing it is safe.

`records_with_superseded_terms` 183 → 180, and `scripts/ratchet-quality-budgets.js --lower` wrote all three census budgets down in the same commit.

## Tests

3,932 tests, 18 new. `scripts/mutate-1386.sh` runs 24 mutations against `superseded-description.ts`, `change-citation.ts` and the description block: 22 killed. One survivor was a real gap — nothing asserted that the reading closes before the sentence that withholds our terms, and 27 of the 180 records read terms with no stop of their own — now covered. The other survivor turns `break` into `continue` in `openingOfTerms`; sentence-boundary candidates grow monotonically, so the two cannot differ, confirmed over 211,613 inputs (every record's `current_state`, `previous_state` and `summary` at seven caps, plus 200,000 random strings).
