### PR TITLE
Read webhook.site's request cap off the config its own template renders

### DIFF
--- a/data/deal_changes.json
+++ b/data/deal_changes.json
@@ -6684,7 +6684,7 @@
       "date_source": "discovered",
       "summary": "The free tier has a request limit.",
       "previous_state": "Verify webhooks, outbound HTTP requests, or emails with a custom URL. A temporary URL and email address are always free.",
-      "current_state": "The free tier allows a maximum of {{ appConfig.MaxRequests }} requests. URLs expire.",
+      "current_state": "The free tier allows a maximum of 50 requests. URLs expire.",
       "impact": "medium",
       "source_url": "https://webhook.site",
       "category": "Testing",


### PR DESCRIPTION
Our webhook.site change record quoted an Angular expression as the vendor's own words:

> "current_state": "The free tier allows a maximum of `{{ appConfig.MaxRequests }}` requests. URLs expire."

The figure is in the page. `https://webhook.site/`, fetched 2026-09-06, ships its config inline:

> `MaxRequests: 50,`

and the banner that expression feeds reads *"You've received `{{ requests.total }}`/`{{ appConfig.MaxRequests }}` requests. Upgrade to accept endless requests, keep this URL forever"*, gated on `ng-hide="token.premium"`. So 50 is the non-premium inbox cap, which is what the record's summary — "The free tier has a request limit" — was reaching for.

This is the correction option offered on https://github.com/robhunter/agentdeals/pull/1387. The guard added there stops the string reaching a withholding surface as a quoted sentence, and it is the right guard, but it does not reach the change-history block. `https://agentdeals.dev/vendor/webhook-site` still renders today:

> **After:** The free tier allows a maximum of `{{ appConfig.MaxRequests }}` requests. URLs expire.

Correcting the record clears that surface and lets `readingBehindTheChange` publish a real reading instead of falling back to the refusal.

One line, `data/deal_changes.json` only. Quality budgets unchanged before and after — `records_with_superseded_terms` 176, `vendor_pages_withholding_superseded_terms` 175, `ungated_pages_withholding_superseded_terms` 166. `lint-duplicates` and `change-refusals` pass locally; the rest of the suite spins a server and needs CI.

Closes nothing on its own — https://github.com/robhunter/agentdeals/issues/1371's class is the general defect.
