### PR TITLE
The badge withholds wherever the vendor page withholds, and says why

### DIFF
--- a/scripts/mutate-1389.sh
+++ b/scripts/mutate-1389.sh
@@ -1,0 +1,180 @@
+#!/usr/bin/env bash
+set -uo pipefail
+
+REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO"
+
+TESTS=(
+  test/badge-withholding.test.ts
+  test/vendor-verdict.test.ts
+)
+
+SOURCES=(src/serve.ts src/vendor-verdict.ts src/badge-staleness.ts)
+
+backup() { for f in "${SOURCES[@]}"; do cp "$f" "/tmp/$(basename "$f").m1389"; done; }
+restore() { for f in "${SOURCES[@]}"; do cp "/tmp/$(basename "$f").m1389" "$f"; done; }
+
+backup
+trap 'restore; npm run build >/dev/null 2>&1' EXIT
+
+killed=0
+survived=0
+
+run_mutation() {
+  local name="$1"; shift
+  restore
+  if ! "$@"; then
+    echo "NOT APPLIED                $name"
+    return
+  fi
+  if ! npm run build >/dev/null 2>&1; then
+    echo "KILLED (does not compile)  $name"
+    killed=$((killed + 1))
+    return
+  fi
+  if TZ=UTC node --test --test-concurrency 1 "${TESTS[@]}" >/tmp/mutation-1389-out.txt 2>&1; then
+    echo "SURVIVED                   $name"
+    survived=$((survived + 1))
+  else
+    echo "KILLED                     $name"
+    killed=$((killed + 1))
+  fi
+}
+
+sub() {
+  python3 - "$1" "$2" "$3" <<'PY'
+import sys
+path, old, new = sys.argv[1], sys.argv[2], sys.argv[3]
+text = open(path, encoding="utf-8").read()
+if old not in text:
+    sys.exit("mutation target not found in " + path)
+open(path, "w", encoding="utf-8").write(text.replace(old, new, 1))
+PY
+}
+
+run_mutation "the badge stops asking whether the page withholds" \
+  sub src/serve.ts '  if (verdict.kind === "none") {
+    return { status: "withheld", label: withheldBadgeLabel(verdict.because), verifiedDate: null };
+  }' \
+                   '  if (verdict.kind === "none" && verdict.because.reason === "no_source") {
+    return { status: "withheld", label: withheldBadgeLabel(verdict.because), verifiedDate: null };
+  }'
+
+run_mutation "the badge ignores the ranker's gate" \
+  sub src/serve.ts '    gate: gateFor(primary, servedOn)?.code ?? null,
+    linkUnreachable: Boolean(linkUnreachable),
+  });' \
+                   '    gate: null,
+    linkUnreachable: Boolean(linkUnreachable),
+  });'
+
+run_mutation "the badge reads a reading it cannot attribute" \
+  sub src/serve.ts '    levelWithheld: levelWithheldReason(primary, linkUnreachable),
+    unconfirmableSince: "",' \
+                   '    levelWithheld: null,
+    unconfirmableSince: "",'
+
+run_mutation "the badge forgets the offer has ended" \
+  sub src/serve.ts '    offerEnded: offerEnded(primary),
+    gate:' \
+                   '    offerEnded: false,
+    gate:'
+
+run_mutation "every withheld badge gives the same reason" \
+  sub src/serve.ts 'function withheldBadgeLabel(because: BadgeWithholding): string {
+  return because.reason === "gated"
+    ? GATED_BADGE_LABELS[because.gate]
+    : WITHHELD_BADGE_LABELS[because.reason];' \
+                   'function withheldBadgeLabel(because: BadgeWithholding): string {
+  return because.reason === "gated"
+    ? GATED_BADGE_LABELS[because.gate]
+    : WITHHELD_BADGE_LABELS.no_source;'
+
+run_mutation "a page we could not reach is blamed on a missing source" \
+  sub src/serve.ts '  link_unreachable: "unrated \u2014 page unreachable",' \
+                   '  link_unreachable: "unrated \u2014 no source",'
+
+run_mutation "the screen reader gets something other than the title" \
+  sub src/serve.ts 'aria-label="${escXml(leftText)}: ${escXml(rightText)}">
+  <title>' \
+                   'aria-label="${escXml(leftText)}">
+  <title>'
+
+run_mutation "stale wears the vendor's warning colour again" \
+  sub src/serve.ts '  "stale": "#58a6ff",' \
+                   '  "stale": "#d29922",'
+
+run_mutation "a retired offer wears the colour of a state about us" \
+  sub src/serve.ts '  "retired": "#f85149",' \
+                   '  "retired": "#8b949e",'
+
+run_mutation "the staleness threshold goes back inside the loop" \
+  sub src/serve.ts 'if (readingIsBehindTheLoop(latestVerified, badgeStaleAfterDays(), Date.now())) {' \
+                   'if (readingIsBehindTheLoop(latestVerified, 30, Date.now())) {'
+
+run_mutation "the re-verification interval is read as the median age itself" \
+  sub src/badge-staleness.ts 'return Math.max(1, 2 * medianVerificationAgeDays(verifiedDates, nowMs));' \
+                             'return Math.max(1, medianVerificationAgeDays(verifiedDates, nowMs));'
+
+run_mutation "the interval collapses to zero on a catalogue read today" \
+  sub src/badge-staleness.ts 'return Math.max(1, 2 * medianVerificationAgeDays(verifiedDates, nowMs));' \
+                             'return 2 * medianVerificationAgeDays(verifiedDates, nowMs);'
+
+run_mutation "the interval is measured from the youngest reading" \
+  sub src/badge-staleness.ts '  const mid = Math.floor(ages.length / 2);' \
+                             '  const mid = 0;'
+
+run_mutation "a reading exactly at the interval is called stale" \
+  sub src/badge-staleness.ts 'return verificationAgeDays(verifiedDate, nowMs) > intervalDays;' \
+                             'return verificationAgeDays(verifiedDate, nowMs) >= intervalDays;'
+
+run_mutation "the gate outranks the reading in the reason the badge gives" \
+  sub src/vendor-verdict.ts '  if (withholdingDecides(input)) {
+    return { reason: input.levelWithheld ?? "no_source" };
+  }
+  if (input.gate) return { reason: "gated", gate: input.gate };' \
+                            '  if (input.gate) return { reason: "gated", gate: input.gate };
+  if (withholdingDecides(input)) {
+    return { reason: input.levelWithheld ?? "no_source" };
+  }'
+
+run_mutation "an unreachable link no longer withholds a stable rating" \
+  sub src/vendor-verdict.ts '  if (input.linkUnreachable && publishedVendorLevel(input.level, input.cause) === "stable") {
+    return { reason: "link_unreachable" };
+  }' \
+                            '  if (false) {
+    return { reason: "link_unreachable" };
+  }'
+
+run_mutation "a null level is rated stable rather than withheld" \
+  sub src/vendor-verdict.ts '  if (input.level === null) return { reason: input.levelWithheld ?? "no_source" };' \
+                            '  if (false) return { reason: input.levelWithheld ?? "no_source" };'
+
+run_mutation "the stack grade hides how much of the stack it rated" \
+  sub src/serve.ts 'const coverage = totalFound < vendorNames.length ? ` · ${totalFound} of ${vendorNames.length} rated` : "";' \
+                   'const coverage = "";'
+
+run_mutation "the stack grade counts a vendor it cannot rate" \
+  sub src/serve.ts '    if (status === "unknown" || status === "withheld") continue;' \
+                   '    if (status === "unknown") continue;'
+
+run_mutation "the at-risk tile absorbs the stale badges again" \
+  sub src/serve.ts '<div class="stat-num yellow">${statusCounts["at-risk"]}</div><div class="stat-label">At Risk</div>' \
+                   '<div class="stat-num yellow">${statusCounts["at-risk"] + statusCounts.stale}</div><div class="stat-label">At Risk</div>'
+
+run_mutation "the unrated tile counts the badges that publish" \
+  sub src/serve.ts '<div class="stat-num grey">${statusCounts.withheld}</div><div class="stat-label">Unrated</div>' \
+                   '<div class="stat-num grey">${statusCounts.withheld + statusCounts.active}</div><div class="stat-label">Unrated</div>'
+
+run_mutation "the badge reads the first offer of a different vendor" \
+  sub src/serve.ts '  const vendorOffers = offers.filter(o => o.vendor === vendorName);
+  if (vendorOffers.length === 0) return UNKNOWN_BADGE;
+
+  const primary = vendorOffers[0];' \
+                   '  const vendorOffers = offers.filter(o => o.vendor === vendorName);
+  if (vendorOffers.length === 0) return UNKNOWN_BADGE;
+
+  const primary = offers[0];'
+
+echo
+echo "killed=$killed survived=$survived"

--- a/src/badge-staleness.ts
+++ b/src/badge-staleness.ts
@@ -1,0 +1,29 @@
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+export function verificationAgeDays(verifiedDate: string, nowMs: number): number {
+  return Math.floor((nowMs - Date.parse(verifiedDate)) / DAY_MS);
+}
+
+export function medianVerificationAgeDays(verifiedDates: string[], nowMs: number): number {
+  const ages = verifiedDates
+    .map(d => verificationAgeDays(d, nowMs))
+    .filter(n => Number.isFinite(n))
+    .sort((a, b) => a - b);
+  if (ages.length === 0) return 0;
+  const mid = Math.floor(ages.length / 2);
+  return ages.length % 2 === 0
+    ? Math.round((ages[mid - 1] + ages[mid]) / 2)
+    : ages[mid];
+}
+
+export function reverificationIntervalDays(verifiedDates: string[], nowMs: number): number {
+  return Math.max(1, 2 * medianVerificationAgeDays(verifiedDates, nowMs));
+}
+
+export function readingIsBehindTheLoop(
+  verifiedDate: string,
+  intervalDays: number,
+  nowMs: number,
+): boolean {
+  return verificationAgeDays(verifiedDate, nowMs) > intervalDays;
+}

--- a/src/serve.ts
+++ b/src/serve.ts
@@ -19,11 +19,12 @@ import { configureVendorSeries, recordVendorRequest, flushVendorSeries, readVend
 import { openapiSpec } from "./openapi.js";
 import { LINK_GRACE_DAYS, unreachableNoticeForUrl } from "./link-health.js";
 import { offerEnded, offerRetired, recordedTierSentence, endedHeadline, endedHistorySentence, endedReliabilitySentence, endedEmptyChangeHistorySentence, ENDED_BADGE_LABEL, ENDED_SINCE_CHANGES_SENTENCE, type OfferTierAndUrl } from "./retirement.js";
-import { amountUnstatedSentence, levelWithheldReason, sourceStatesNoAmount, withheldLevelClause, withheldLevelSentence } from "./source-check.js";
+import { amountUnstatedSentence, levelWithheldReason, sourceStatesNoAmount, withheldLevelClause, withheldLevelSentence, type LevelWithheldReason } from "./source-check.js";
+import { readingIsBehindTheLoop, reverificationIntervalDays } from "./badge-staleness.js";
 import { SUPERSEDED_TERMS_LABEL, supersededTermsAnswer, supersededTermsMetaSentence, supersededTermsNotice, supersededTermsNoticeHtml, supersededTermsVerdictSentence, supersedingChange } from "./superseded-description.js";
 import { buildComparisonMap, comparisonSlug } from "./comparison-pairs.js";
 import { stabilityFaqAnswer, stabilityVerdictClause, type ComparisonSide, type StabilityRating } from "./comparison-verdict.js";
-import { publishedVendorLevel, vendorVerdictSentence, vendorBadge, statesRiskCause, narrowingSentence, changeKindNoun, type VendorVerdictInput } from "./vendor-verdict.js";
+import { publishedVendorLevel, vendorVerdictSentence, vendorBadge, statesRiskCause, narrowingSentence, changeKindNoun, type BadgeWithholding, type VendorVerdictInput } from "./vendor-verdict.js";
 import { vendorHistorySentence } from "./vendor-history.js";
 import { HETZNER_APRIL_CHANGES, HETZNER_CLOUD_PLANS, HETZNER_PRICES_READ, HETZNER_PRICE_SOURCE, HETZNER_SINGAPORE_EXAMPLE, cheapestOrderableHetznerPlan, hetznerEntryPriceClause, unorderableHetznerPlans } from "./hetzner-pricing.js";
 import { changeTimelineDate, supersededLineups, supersessionNote } from "./change-lineup.js";
@@ -50,7 +51,7 @@ import { faqPageJsonLd, type FaqItem } from "./faq-provenance.js";
 import { SSE_KEEPALIVE_FRAME, keepaliveIntervalMs, sessionRecoveryBody } from "./mcp-stream.js";
 import { ASSISTANTS_API_SHUTDOWN } from "./assistants-shutdown.js";
 import { discontinuedOnOrBefore, PRODUCT_DEPRECATED } from "./product-deprecation.js";
-import { rankOffers, rankForListing, rotateListing, utcDate, gateFor, notAFreeOfferGateFor, descriptionDeniesFreeTier, classifyTier, CRITERIA_PATH, DEMOTE_ONLY_POLICY, DISCLOSURE_RATIONALE, TIE_BREAK_ALGORITHM, GATE_TABLE, DEMERIT_TABLE, NOT_FREE_TIER_RULES, TIME_LIMITED_TIER_RULES, type TieBreak, type Gate } from "./ranking.js";
+import { rankOffers, rankForListing, rotateListing, utcDate, gateFor, notAFreeOfferGateFor, descriptionDeniesFreeTier, classifyTier, CRITERIA_PATH, DEMOTE_ONLY_POLICY, DISCLOSURE_RATIONALE, TIE_BREAK_ALGORITHM, GATE_TABLE, DEMERIT_TABLE, NOT_FREE_TIER_RULES, TIME_LIMITED_TIER_RULES, type TieBreak, type Gate, type GateCode } from "./ranking.js";
 import type { RankedEntry, RankingResult } from "./ranking.js";
 import { eligibilityGateAsPublished, gatedShareDescriptionClause, gatedShareLede, publishableEligibilityConditions } from "./eligibility.js";
 import { gateDisclosureFor } from "./gate-disclosure.js";
@@ -726,38 +727,111 @@ function offerPricingLink(offer: OfferTierAndUrl, label: string): string {
   return `<a href="${escHtmlServer(offer.url)}" target="_blank" rel="noopener">${label}</a>`;
 }
 
-type BadgeStatus = "active" | "at-risk" | "removed" | "unrated" | "unknown";
+type BadgeStatus = "active" | "at-risk" | "stale" | "removed" | "retired" | "withheld" | "unknown";
 
-function getBadgeStatus(vendorSlug: string): { status: BadgeStatus; label: string; verifiedDate: string | null } {
+interface BadgeReading {
+  status: BadgeStatus;
+  label: string;
+  verifiedDate: string | null;
+}
+
+const WITHHELD_BADGE_LABELS: Record<LevelWithheldReason | "no_source", string> = {
+  no_source: "unrated \u2014 no source",
+  link_unreachable: "unrated \u2014 page unreachable",
+  unreadable: "unrated \u2014 page unreadable",
+  states_no_terms: "unrated \u2014 page states no terms",
+  does_not_name_vendor: "unrated \u2014 page omits vendor",
+};
+
+const GATED_BADGE_LABELS: Record<GateCode, string> = {
+  eligibility_restricted: "unrated \u2014 restricted offer",
+  not_a_free_offer: "unrated \u2014 not a free offer",
+  offer_expired: "unrated \u2014 offer expired",
+  offer_retired: "unrated \u2014 offer ended",
+  verification_lapsed: "unrated \u2014 not re-confirmed",
+};
+
+function withheldBadgeLabel(because: BadgeWithholding): string {
+  return because.reason === "gated"
+    ? GATED_BADGE_LABELS[because.gate]
+    : WITHHELD_BADGE_LABELS[because.reason];
+}
+
+let reverificationInterval: { on: string; days: number } | null = null;
+
+function badgeStaleAfterDays(): number {
+  const on = utcDate();
+  if (reverificationInterval?.on !== on) {
+    reverificationInterval = { on, days: reverificationIntervalDays(offers.map(o => o.verifiedDate), Date.now()) };
+  }
+  return reverificationInterval.days;
+}
+
+const UNKNOWN_BADGE: BadgeReading = { status: "unknown", label: "unknown", verifiedDate: null };
+
+const badgeReadings = new Map<string, { on: string; reading: BadgeReading }>();
+
+function getBadgeStatus(vendorSlug: string): BadgeReading {
+  if (!vendorSlugMap.has(vendorSlug)) return UNKNOWN_BADGE;
+  const on = utcDate();
+  const cached = badgeReadings.get(vendorSlug);
+  if (cached && cached.on === on) return cached.reading;
+  const reading = readBadgeStatus(vendorSlug, on);
+  badgeReadings.set(vendorSlug, { on, reading });
+  return reading;
+}
+
+function readBadgeStatus(vendorSlug: string, servedOn: string): BadgeReading {
   const vendorName = vendorSlugMap.get(vendorSlug);
-  if (!vendorName) return { status: "unknown", label: "unknown", verifiedDate: null };
+  if (!vendorName) return UNKNOWN_BADGE;
 
-  const vendorChanges = dealChanges.filter(c => toSlug(c.vendor) === vendorSlug);
-  const assessment = vendorRiskAssessment(vendorChanges);
+  const vendorOffers = offers.filter(o => o.vendor === vendorName);
+  if (vendorOffers.length === 0) return UNKNOWN_BADGE;
 
-  if (assessment.rating_withheld) {
-    return { status: "unrated", label: "unrated \u2014 no source", verifiedDate: null };
+  const primary = vendorOffers[0];
+  const enriched = enrichOffers([primary])[0];
+  const vendorChanges = dealChanges
+    .filter(c => c.vendor.toLowerCase() === vendorName.toLowerCase())
+    .sort((a, b) => b.date.localeCompare(a.date));
+  const linkUnreachable = enriched.link_unreachable;
+
+  const verdict = vendorBadge({
+    vendor: vendorName,
+    level: enriched.risk_level ?? null,
+    cause: enriched.risk_cause,
+    changes: vendorChanges,
+    levelWithheld: levelWithheldReason(primary, linkUnreachable),
+    unconfirmableSince: "",
+    ratingWithheld: enriched.rating_withheld,
+    offerEnded: offerEnded(primary),
+    gate: gateFor(primary, servedOn)?.code ?? null,
+    linkUnreachable: Boolean(linkUnreachable),
+  });
+
+  if (verdict.kind === "none") {
+    return { status: "withheld", label: withheldBadgeLabel(verdict.because), verifiedDate: null };
   }
 
-  if (assessment.level === "risky" && assessment.cause) {
+  const latestVerified = vendorOffers.reduce((max, o) => o.verifiedDate > max ? o.verifiedDate : max, primary.verifiedDate);
+
+  if (verdict.kind === "ended") {
+    return { status: "retired", label: ENDED_BADGE_LABEL, verifiedDate: latestVerified };
+  }
+
+  if (verdict.word === "risky" && enriched.risk_cause) {
     return {
       status: "removed",
-      label: assessment.cause.change_type === PRODUCT_DEPRECATED ? "deprecated" : "free tier removed",
-      verifiedDate: assessment.cause.date,
+      label: enriched.risk_cause.change_type === PRODUCT_DEPRECATED ? "deprecated" : "free tier removed",
+      verifiedDate: enriched.risk_cause.date,
     };
   }
 
-  const vendorOffers = offers.filter(o => toSlug(o.vendor) === vendorSlug);
-  if (vendorOffers.length === 0) return { status: "unknown", label: "unknown", verifiedDate: null };
-
-  const latestVerified = vendorOffers.reduce((max, o) => o.verifiedDate > max ? o.verifiedDate : max, vendorOffers[0].verifiedDate);
-  const daysSince = Math.floor((Date.now() - new Date(latestVerified).getTime()) / (1000 * 60 * 60 * 24));
-
-  if (assessment.level === "caution") {
+  if (verdict.word === "caution") {
     return { status: "at-risk", label: "at risk", verifiedDate: latestVerified };
   }
-  if (daysSince > 30) {
-    return { status: "at-risk", label: "stale", verifiedDate: latestVerified };
+
+  if (readingIsBehindTheLoop(latestVerified, badgeStaleAfterDays(), Date.now())) {
+    return { status: "stale", label: "stale", verifiedDate: latestVerified };
   }
 
   return { status: "active", label: "active", verifiedDate: latestVerified };
@@ -767,7 +841,9 @@ const BADGE_COLORS: Record<BadgeStatus, string> = {
   "active": "#3fb950",
   "at-risk": "#d29922",
   "removed": "#f85149",
-  "unrated": "#8b949e",
+  "retired": "#f85149",
+  "stale": "#58a6ff",
+  "withheld": "#8b949e",
   "unknown": "#8b949e",
 };
 
@@ -832,9 +908,9 @@ function generateStackBadgeSvg(vendorsParam: string, style: "flat" | "flat-squar
   for (const name of vendorNames) {
     const slug = toSlug(name);
     const { status } = getBadgeStatus(slug);
-    if (status === "unknown" || status === "unrated") continue;
+    if (status === "unknown" || status === "withheld") continue;
     totalFound++;
-    if (status === "removed") riskyCount++;
+    if (status === "removed" || status === "retired") riskyCount++;
     else if (status === "at-risk") cautionCount++;
   }
 
@@ -854,7 +930,8 @@ function generateStackBadgeSvg(vendorsParam: string, style: "flat" | "flat-squar
   const gradeColors: Record<string, string> = {
     A: "#3fb950", B: "#58a6ff", C: "#d29922", D: "#f0883e", F: "#f85149",
   };
-  return generateShieldBadge("Stack Health", grade, gradeColors[grade], style);
+  const coverage = totalFound < vendorNames.length ? ` · ${totalFound} of ${vendorNames.length} rated` : "";
+  return generateShieldBadge("Stack Health", `${grade}${coverage}`, gradeColors[grade], style);
 }
 
 function generateShieldBadge(leftText: string, rightText: string, color: string, style: "flat" | "flat-square" = "flat"): string {
@@ -3781,7 +3858,7 @@ function buildVendorPage(slug: string): string | null {
     unconfirmableSince,
     ratingWithheld,
     offerEnded: offerHasEnded,
-    gated: primaryGate !== null,
+    gate: primaryGate?.code ?? null,
     linkUnreachable: Boolean(linkUnreachable),
   };
 
@@ -48140,8 +48217,10 @@ function buildBadgesPage(): string {
     .map(([slug, name]) => ({ slug, name, ...getBadgeStatus(slug) }))
     .sort((a, b) => a.name.localeCompare(b.name));
 
-  const statusCounts = { active: 0, "at-risk": 0, removed: 0, unrated: 0, unknown: 0 };
+  const statusCounts: Record<BadgeStatus, number> = { active: 0, "at-risk": 0, stale: 0, removed: 0, retired: 0, withheld: 0, unknown: 0 };
   for (const v of allVendors) statusCounts[v.status]++;
+  const endedCount = statusCounts.removed + statusCounts.retired;
+  const staleAfter = badgeStaleAfterDays();
 
   return `<!DOCTYPE html>
 <html lang="en">
@@ -48149,7 +48228,7 @@ function buildBadgesPage(): string {
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <title>Free Tier Status Badges — Embeddable SVG Badges for READMEs | AgentDeals</title>
-  <meta name="description" content="Embeddable free tier status badges for GitHub READMEs, docs, and blog posts. Show whether a vendor's free tier is active, at risk, or removed.">
+  <meta name="description" content="Embeddable free tier status badges for GitHub READMEs, docs, and blog posts. Show whether a vendor's free tier is active, at risk or removed — and read unrated where we cannot confirm the terms.">
   <link rel="canonical" href="${BASE_URL}/badges">
   <link rel="alternate" type="application/atom+xml" title="AgentDeals — Pricing Changes" href="${BASE_URL}/feed.xml">
   <meta property="og:title" content="Free Tier Status Badges — AgentDeals">
@@ -48184,11 +48263,16 @@ function buildBadgesPage(): string {
     .stat-num.green{color:#3fb950}
     .stat-num.yellow{color:#d29922}
     .stat-num.red{color:#f85149}
+    .stat-num.blue{color:#58a6ff}
+    .stat-num.grey{color:#8b949e}
+    .legend{list-style:none;padding:0;margin:1rem 0;display:grid;gap:.5rem}
+    .legend li{color:var(--text-muted);font-size:.9rem;display:flex;align-items:baseline;gap:.5rem}
+    .legend strong{color:var(--text)}
     .stat-label{font-size:.75rem;color:var(--text-muted);text-transform:uppercase;letter-spacing:.05em}
     .preview-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(280px,1fr));gap:1rem;margin:1rem 0}
     .preview-card{background:var(--bg-elevated);border:1px solid var(--border);border-radius:10px;padding:1rem;display:flex;flex-direction:column;gap:.75rem}
-    .preview-badge{display:flex;align-items:center;gap:.5rem}
-    .preview-badge img{height:20px}
+    .preview-badge{display:flex;align-items:center;gap:.5rem;flex-wrap:wrap;min-width:0}
+    .preview-badge img{max-height:20px;max-width:100%;height:auto}
     .embed-code{background:#0d1117;border:1px solid var(--border);border-radius:6px;padding:.5rem .75rem;font-family:"SFMono-Regular",Consolas,monospace;font-size:.75rem;color:#c9d1d9;overflow-x:auto;white-space:nowrap;position:relative;cursor:pointer}
     .embed-code:hover{border-color:var(--accent)}
     .embed-code::after{content:"click to copy";position:absolute;right:.5rem;top:50%;transform:translateY(-50%);font-size:.65rem;color:var(--text-muted);opacity:0;transition:opacity .15s}
@@ -48201,9 +48285,9 @@ function buildBadgesPage(): string {
     .how-to li{margin:.5rem 0}
     .how-to code{background:#0d1117;padding:.15rem .4rem;border-radius:4px;font-size:.8rem;color:#c9d1d9}
     .vendor-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(200px,1fr));gap:.5rem;margin:1rem 0}
-    .vendor-badge-link{display:flex;align-items:center;gap:.5rem;padding:.4rem .6rem;background:var(--bg-elevated);border:1px solid var(--border);border-radius:6px;text-decoration:none;font-size:.8rem;color:var(--text-muted);transition:border-color .15s}
+    .vendor-badge-link{display:flex;align-items:center;flex-wrap:wrap;min-width:0;gap:.5rem;padding:.4rem .6rem;background:var(--bg-elevated);border:1px solid var(--border);border-radius:6px;text-decoration:none;font-size:.8rem;color:var(--text-muted);transition:border-color .15s}
     .vendor-badge-link:hover{border-color:var(--accent);text-decoration:none}
-    .vendor-badge-link img{height:20px}
+    .vendor-badge-link img{max-height:20px;max-width:100%;height:auto}
     .status-dot{width:8px;height:8px;border-radius:50%;flex-shrink:0}
     ${mcpCtaCss()}
     .footer{margin-top:3rem;padding-top:1.5rem;border-top:1px solid var(--border);text-align:center;color:var(--text-muted);font-size:.8rem}
@@ -48215,14 +48299,25 @@ function buildBadgesPage(): string {
     ${buildGlobalNav("badges")}
 
     <h1>Free Tier Status Badges</h1>
-    <p class="subtitle">Embeddable SVG badges for GitHub READMEs, documentation, and blog posts. Show whether a vendor's free tier is active, at risk, or removed — powered by AgentDeals' verified pricing data.</p>
+    <p class="subtitle">Embeddable SVG badges for GitHub READMEs, documentation, and blog posts. Show whether a vendor's free tier is active, at risk or removed — and read <em>unrated</em>, with the reason, wherever the vendor's own page on this site publishes no verdict.</p>
 
     <div class="stats-bar">
       <div class="stat"><div class="stat-num">${allVendors.length}</div><div class="stat-label">Vendors</div></div>
       <div class="stat"><div class="stat-num green">${statusCounts.active}</div><div class="stat-label">Active</div></div>
       <div class="stat"><div class="stat-num yellow">${statusCounts["at-risk"]}</div><div class="stat-label">At Risk</div></div>
-      <div class="stat"><div class="stat-num red">${statusCounts.removed}</div><div class="stat-label">Removed</div></div>
+      <div class="stat"><div class="stat-num red">${endedCount}</div><div class="stat-label">Ended</div></div>
+      <div class="stat"><div class="stat-num blue">${statusCounts.stale}</div><div class="stat-label">Stale</div></div>
+      <div class="stat"><div class="stat-num grey">${statusCounts.withheld}</div><div class="stat-label">Unrated</div></div>
     </div>
+
+    <h2>What each badge says</h2>
+    <ul class="legend">
+      <li><span class="status-dot" style="background:${BADGE_COLORS.active}"></span> <strong>active</strong> — we rate the vendor stable, on a reading we can attribute to the page we cite.</li>
+      <li><span class="status-dot" style="background:${BADGE_COLORS["at-risk"]}"></span> <strong>at risk</strong> — a recorded pricing change narrowed this vendor's terms.</li>
+      <li><span class="status-dot" style="background:${BADGE_COLORS.removed}"></span> <strong>free tier removed</strong>, <strong>deprecated</strong>, <strong>retired</strong> — the offer we listed has ended.</li>
+      <li><span class="status-dot" style="background:${BADGE_COLORS.stale}"></span> <strong>stale</strong> — a statement about us, not the vendor: we have not re-read the page within ${staleAfter} days, one full pass of our re-verification loop.</li>
+      <li><span class="status-dot" style="background:${BADGE_COLORS.withheld}"></span> <strong>unrated</strong> — we publish no verdict, and the badge says why: the page we cite was unreachable, unreadable, stated no terms, or did not name the vendor; or the offer is restricted, expired or not free. ${statusCounts.withheld} of ${allVendors.length} vendors read this way, the same as on their vendor page.</li>
+    </ul>
 
     <h2>Badge Preview</h2>
     <div class="preview-grid">
@@ -48323,6 +48418,20 @@ function embedAttribution(): string {
   return `<div style="margin-top:12px;padding-top:8px;border-top:1px solid var(--border);text-align:right;font-size:11px;color:var(--text-m)">Powered by <a href="${BASE_URL}" target="_blank" rel="noopener">AgentDeals</a></div>`;
 }
 
+const EMBED_STATUS_COLORS: Record<BadgeStatus, string> = {
+  "active": "var(--badge-increased)",
+  "at-risk": "var(--badge-reduced)",
+  "removed": "var(--badge-removed)",
+  "retired": "var(--badge-removed)",
+  "stale": "var(--badge-new)",
+  "withheld": "var(--text-m)",
+  "unknown": "var(--text-m)",
+};
+
+function embedStatusColor(status: BadgeStatus): string {
+  return EMBED_STATUS_COLORS[status];
+}
+
 function buildEmbedVendorWidget(slug: string, theme: "dark" | "light"): string | null {
   const vendorName = vendorSlugMap.get(slug);
   if (!vendorName) return null;
@@ -48335,7 +48444,7 @@ function buildEmbedVendorWidget(slug: string, theme: "dark" | "light"): string |
     .sort((a, b) => b.date.localeCompare(a.date))
     .slice(0, 3);
 
-  const statusColor = status === "removed" ? "var(--badge-removed)" : status === "at-risk" ? "var(--badge-reduced)" : "var(--badge-increased)";
+  const statusColor = embedStatusColor(status);
 
   const offersHtml = vendorOffers.map(o => `<div style="padding:8px 0;border-bottom:1px solid var(--border)">
     <div style="font-weight:600;font-size:13px">${escHtmlServer(o.category)}</div>
@@ -48377,7 +48486,7 @@ function buildEmbedCategoryWidget(slug: string, theme: "dark" | "light"): string
   const rowsHtml = catOffers.map(o => {
     const vSlug = toSlug(o.vendor);
     const { status } = getBadgeStatus(vSlug);
-    const dot = status === "removed" ? "var(--badge-removed)" : status === "at-risk" ? "var(--badge-reduced)" : "var(--badge-increased)";
+    const dot = embedStatusColor(status);
     return `<tr>
       <td style="padding:8px;border-bottom:1px solid var(--border)"><a href="${BASE_URL}/vendor/${vSlug}" target="_blank" rel="noopener" style="font-weight:600;font-size:13px">${escHtmlServer(o.vendor)}</a></td>
       <td style="padding:8px;border-bottom:1px solid var(--border);font-size:12px;color:var(--text-m)">${escHtmlServer(o.tier)}</td>

--- a/src/vendor-verdict.ts
+++ b/src/vendor-verdict.ts
@@ -4,6 +4,7 @@ import { isNoLongerInForce } from "./change-resolution.js";
 import { changeIsUncited, ratingWithheldForNoSourceSentence } from "./change-citation.js";
 import { changeDateClause } from "./change-dates.js";
 import { withheldLevelClause, type LevelWithheldReason } from "./source-check.js";
+import type { GateCode } from "./ranking.js";
 import { endedVerdictSentence } from "./retirement.js";
 import { vendorHistorySentence, type PublishedRiskLevel } from "./vendor-history.js";
 
@@ -39,14 +40,19 @@ export interface VendorVerdictInput {
   unconfirmableSince: string;
   ratingWithheld?: RatingWithheld | null;
   offerEnded?: boolean;
-  gated?: boolean;
+  gate?: GateCode | null;
   linkUnreachable?: boolean;
 }
+
+export type BadgeWithholding =
+  | { reason: "gated"; gate: GateCode }
+  | { reason: "no_source" }
+  | { reason: LevelWithheldReason };
 
 export type VendorBadge =
   | { kind: "ended" }
   | { kind: "rating"; word: PublishedRiskLevel }
-  | { kind: "none" };
+  | { kind: "none"; because: BadgeWithholding };
 
 export function publishedVendorLevel(
   level: PublishedRiskLevel | null,
@@ -83,14 +89,23 @@ export function vendorVerdictWord(input: VendorVerdictInput): PublishedRiskLevel
   return publishedVendorLevel(input.level, input.cause);
 }
 
+export function badgeWithholding(input: VendorVerdictInput): BadgeWithholding | null {
+  if (withholdingDecides(input)) {
+    return { reason: input.levelWithheld ?? "no_source" };
+  }
+  if (input.gate) return { reason: "gated", gate: input.gate };
+  if (input.level === null) return { reason: input.levelWithheld ?? "no_source" };
+  if (input.linkUnreachable && publishedVendorLevel(input.level, input.cause) === "stable") {
+    return { reason: "link_unreachable" };
+  }
+  return null;
+}
+
 export function vendorBadge(input: VendorVerdictInput): VendorBadge {
   if (input.offerEnded) return { kind: "ended" };
-  if (input.gated) return { kind: "none" };
-  if (ratingWithheldForNoSource(input)) return { kind: "none" };
-  if (input.level === null) return { kind: "none" };
-  const level = publishedVendorLevel(input.level, input.cause);
-  if (input.linkUnreachable && level === "stable") return { kind: "none" };
-  return { kind: "rating", word: level };
+  const withheld = badgeWithholding(input);
+  if (withheld) return { kind: "none", because: withheld };
+  return { kind: "rating", word: publishedVendorLevel(input.level, input.cause) };
 }
 
 export function statesRiskCause(input: VendorVerdictInput): boolean {
@@ -136,7 +151,7 @@ export function vendorVerdictSentence(input: VendorVerdictInput): string {
     return `${clause.charAt(0).toUpperCase()}${clause.slice(1)}, so we cannot confirm these terms today.`;
   }
   const level = publishedVendorLevel(input.level, input.cause);
-  if (input.gated) return vendorHistorySentence(input.vendor, level, input.cause);
+  if (input.gate) return vendorHistorySentence(input.vendor, level, input.cause);
 
   if (level !== "stable" && input.cause) {
     const unconfirmed = input.levelWithheld

--- a/test/badge-withholding.test.ts
+++ b/test/badge-withholding.test.ts
@@ -1,0 +1,412 @@
+import { describe, it, before, after } from "node:test";
+import assert from "node:assert";
+import { spawn, type ChildProcess } from "node:child_process";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO = path.join(__dirname, "..");
+
+let serverPort = 0;
+let proc: ChildProcess | null = null;
+
+function startHttpServer(): Promise<{ child: ChildProcess; port: number }> {
+  return new Promise((resolve, reject) => {
+    const child = spawn("node", [path.join(REPO, "dist", "serve.js")], {
+      stdio: ["pipe", "pipe", "pipe"],
+      env: { ...process.env, PORT: "0", BASE_URL: "http://localhost" },
+    });
+    const timeout = setTimeout(() => { child.kill(); reject(new Error("Server startup timeout")); }, 30000);
+    child.stderr!.on("data", (data: Buffer) => {
+      const m = data.toString().match(/running on http:\/\/localhost:(\d+)/);
+      if (m) { clearTimeout(timeout); resolve({ child, port: parseInt(m[1], 10) }); }
+    });
+    child.on("error", (err) => { clearTimeout(timeout); reject(err); });
+  });
+}
+
+const get = async (p: string) => {
+  const res = await fetch(`http://localhost:${serverPort}${p}`);
+  return { status: res.status, text: await res.text() };
+};
+
+const WITHHELD_LABELS: Record<string, string> = {
+  no_source: "unrated — no source",
+  link_unreachable: "unrated — page unreachable",
+  unreadable: "unrated — page unreadable",
+  states_no_terms: "unrated — page states no terms",
+  does_not_name_vendor: "unrated — page omits vendor",
+  eligibility_restricted: "unrated — restricted offer",
+  not_a_free_offer: "unrated — not a free offer",
+  offer_expired: "unrated — offer expired",
+  offer_retired: "unrated — offer ended",
+  verification_lapsed: "unrated — not re-confirmed",
+};
+
+const WITHHELD_LABEL_SET = new Set(Object.values(WITHHELD_LABELS));
+
+type Withholding = { reason: string; gate?: string };
+
+interface Subject {
+  slug: string;
+  vendor: string;
+  kind: "rating" | "ended" | "none";
+  word?: string;
+  because?: Withholding;
+  reasonKey: string | null;
+  verifiedDate: string;
+  ageDays: number;
+  levelWithheld: string | null;
+}
+
+let subjects: Subject[] = [];
+let staleAfter = 0;
+
+function badgeTitle(svg: string): string {
+  return svg.match(/<title>([\s\S]*?)<\/title>/)?.[1] ?? "";
+}
+
+function badgeAriaLabel(svg: string): string {
+  return svg.match(/<svg[^>]*aria-label="([^"]*)"/)?.[1] ?? "";
+}
+
+function badgeLabel(svg: string): string {
+  const right = badgeTitle(svg).split(": ").slice(1).join(": ");
+  return right.split(" · ")[0].trim();
+}
+
+function badgeColor(svg: string): string {
+  const rects = [...svg.matchAll(/<rect[^>]*fill="(#[0-9a-fA-F]{6})"/g)].map(m => m[1]);
+  return rects.find(c => c !== "#555") ?? "";
+}
+
+before(async () => {
+  const { loadOffers, loadDealChanges, enrichOffers } = await import("../dist/data.js");
+  const { vendorSlugMap } = await import("../dist/vendor-slug.js");
+  const { levelWithheldReason } = await import("../dist/source-check.js");
+  const { vendorBadge } = await import("../dist/vendor-verdict.js");
+  const { offerEnded } = await import("../dist/retirement.js");
+  const { gateFor, utcDate } = await import("../dist/ranking.js");
+  const { reverificationIntervalDays, verificationAgeDays } = await import("../dist/badge-staleness.js");
+
+  const offers = loadOffers();
+  const changes = loadDealChanges();
+  const enriched = enrichOffers(offers);
+  const enrichedOf = new Map<object, Record<string, never>>();
+  offers.forEach((o: object, i: number) => enrichedOf.set(o, enriched[i]));
+  const servedOn = utcDate();
+  const nowMs = Date.now();
+  staleAfter = reverificationIntervalDays(offers.map((o: { verifiedDate: string }) => o.verifiedDate), nowMs);
+
+  subjects = [...vendorSlugMap.entries()].flatMap(([slug, vendor]: [string, string]) => {
+    const own = offers.filter((o: { vendor: string }) => o.vendor === vendor);
+    if (own.length === 0) return [];
+    const primary = own[0];
+    const e = enrichedOf.get(primary) as unknown as {
+      risk_level: string | null; risk_cause: never; rating_withheld: never; link_unreachable: unknown;
+    };
+    const levelWithheld = levelWithheldReason(primary, e.link_unreachable);
+    const badge = vendorBadge({
+      vendor,
+      level: e.risk_level as never,
+      cause: e.risk_cause,
+      changes: changes.filter((c: { vendor: string }) => c.vendor.toLowerCase() === vendor.toLowerCase()),
+      levelWithheld,
+      unconfirmableSince: "",
+      ratingWithheld: e.rating_withheld,
+      offerEnded: offerEnded(primary),
+      gate: gateFor(primary, servedOn)?.code ?? null,
+      linkUnreachable: Boolean(e.link_unreachable),
+    }) as { kind: "rating" | "ended" | "none"; word?: string; because?: Withholding };
+    const verifiedDate = own.reduce(
+      (max: string, o: { verifiedDate: string }) => (o.verifiedDate > max ? o.verifiedDate : max),
+      primary.verifiedDate,
+    );
+    const because = badge.because;
+    return [{
+      slug,
+      vendor,
+      kind: badge.kind,
+      word: badge.word,
+      because,
+      reasonKey: because ? (because.reason === "gated" ? because.gate! : because.reason) : null,
+      verifiedDate,
+      ageDays: verificationAgeDays(verifiedDate, nowMs),
+      levelWithheld,
+    }];
+  });
+
+  assert.ok(subjects.length > 1000, "the catalogue did not load");
+  const started = await startHttpServer();
+  proc = started.child;
+  serverPort = started.port;
+});
+
+after(() => { if (proc) proc.kill(); });
+
+let renderedBadges: Map<string, string> | null = null;
+
+async function everyBadge(): Promise<Map<string, string>> {
+  if (renderedBadges) return renderedBadges;
+  const svgs = new Map<string, string>();
+  let queue = 0;
+  const worker = async () => {
+    while (queue < subjects.length) {
+      const { slug } = subjects[queue++];
+      const res = await fetch(`http://localhost:${serverPort}/badge/${slug}.svg`);
+      assert.strictEqual(res.status, 200, `/badge/${slug}.svg returned ${res.status}`);
+      svgs.set(slug, await res.text());
+    }
+  };
+  await Promise.all(Array.from({ length: 12 }, worker));
+  renderedBadges = svgs;
+  return svgs;
+}
+
+describe("#1389 the badge withholds wherever the vendor page withholds", () => {
+  it("publishes a verdict on exactly the vendors the page publishes one for", async () => {
+    const svgs = await everyBadge();
+    const publishesWhereThePageWillNot: string[] = [];
+    const withholdsWhereThePagePublishes: string[] = [];
+
+    for (const subject of subjects) {
+      const label = badgeLabel(svgs.get(subject.slug)!);
+      const badgeWithholds = WITHHELD_LABEL_SET.has(label);
+      const pageWithholds = subject.kind === "none";
+      if (pageWithholds && !badgeWithholds) {
+        publishesWhereThePageWillNot.push(`/badge/${subject.slug}.svg reads "${label}" and /vendor/${subject.slug} publishes no level (${subject.reasonKey})`);
+      }
+      if (!pageWithholds && badgeWithholds) {
+        withholdsWhereThePagePublishes.push(`/badge/${subject.slug}.svg reads "${label}" and /vendor/${subject.slug} publishes ${subject.word ?? subject.kind}`);
+      }
+    }
+
+    assert.deepStrictEqual(publishesWhereThePageWillNot.slice(0, 15), [], publishesWhereThePageWillNot.slice(0, 15).join("\n"));
+    assert.deepStrictEqual(withholdsWhereThePagePublishes.slice(0, 15), [], withholdsWhereThePagePublishes.slice(0, 15).join("\n"));
+  });
+
+  it("withholds on every reason the vendor page can withhold for, so no branch is untested", () => {
+    const withheld = subjects.filter(s => s.kind === "none");
+    assert.ok(withheld.length > 0, "no vendor page withholds, so this asserts nothing");
+    const reasons = new Set(withheld.map(s => s.reasonKey));
+    for (const reason of reasons) {
+      assert.ok(reason && reason in WITHHELD_LABELS, `the badge has no label for a page that withholds because of ${reason}`);
+    }
+    assert.ok(reasons.size >= 4, `only ${reasons.size} withholding reasons occur in the catalogue`);
+  });
+
+  it("agrees with the rendered vendor page, sampled across every withholding reason", async () => {
+    const { withheldLevelClause, withheldLevelSentence } = await import("../dist/source-check.js");
+    const statesTheReason = (html: string, reason: string, vendor: string): boolean =>
+      html.includes(withheldLevelClause(reason as never))
+      || html.includes(withheldLevelSentence(reason as never, vendor).replace(/\.$/, ""));
+    const byReason = new Map<string, Subject[]>();
+    for (const s of subjects.filter(x => x.kind === "none")) {
+      if (!byReason.has(s.reasonKey!)) byReason.set(s.reasonKey!, []);
+      byReason.get(s.reasonKey!)!.push(s);
+    }
+    const wrong: string[] = [];
+    for (const [reason, group] of byReason) {
+      for (const subject of group.slice(0, 3)) {
+        const { status, text } = await get(`/vendor/${subject.slug}`);
+        if (status !== 200) { wrong.push(`/vendor/${subject.slug} returned ${status}`); continue; }
+        const h1 = text.match(/<h1>[\s\S]*?<\/h1>/)?.[0] ?? "";
+        if (/risk-badge/.test(h1)) {
+          wrong.push(`/vendor/${subject.slug} carries a risk badge in its <h1> and /badge/${subject.slug}.svg withholds for ${reason}`);
+        }
+        if (subject.levelWithheld && !statesTheReason(text, subject.levelWithheld, subject.vendor)) {
+          wrong.push(`/vendor/${subject.slug} never states the ${subject.levelWithheld} reason the badge names`);
+        }
+      }
+    }
+    assert.ok(byReason.size >= 4, "fewer than four withholding reasons to sample");
+    assert.deepStrictEqual(wrong, [], wrong.join("\n"));
+  });
+
+  it("carries a risk badge on the pages whose badge publishes a verdict", async () => {
+    const publishing = subjects.filter(s => s.kind === "rating");
+    assert.ok(publishing.length > 100, "almost nothing publishes, so this asserts nothing");
+    const sample = ["stable", "caution", "risky"].flatMap(word => publishing.filter(s => s.word === word).slice(0, 3));
+    assert.strictEqual(new Set(sample.map(s => s.word)).size, 3, "the sample does not cover all three levels");
+    const missing: string[] = [];
+    for (const subject of sample) {
+      const { text } = await get(`/vendor/${subject.slug}`);
+      const h1 = text.match(/<h1>[\s\S]*?<\/h1>/)?.[0] ?? "";
+      if (!/risk-badge/.test(h1)) missing.push(`/vendor/${subject.slug} publishes no badge and /badge/${subject.slug}.svg reads ${subject.word}`);
+    }
+    assert.deepStrictEqual(missing, [], missing.join("\n"));
+  });
+});
+
+describe("#1389 a withheld badge says which reason applies", () => {
+  it("names the reason in the title and in the aria-label, on every withheld badge", async () => {
+    const svgs = await everyBadge();
+    const wrong: string[] = [];
+    let checked = 0;
+    for (const subject of subjects.filter(s => s.kind === "none")) {
+      const svg = svgs.get(subject.slug)!;
+      const expected = WITHHELD_LABELS[subject.reasonKey!];
+      const label = badgeLabel(svg);
+      checked++;
+      if (label !== expected) {
+        wrong.push(`/badge/${subject.slug}.svg reads "${label}", withheld for ${subject.reasonKey}`);
+        continue;
+      }
+      if (badgeAriaLabel(svg) !== badgeTitle(svg)) {
+        wrong.push(`/badge/${subject.slug}.svg gives a screen reader something other than its title`);
+      }
+    }
+    assert.ok(checked > 0, "no badge withholds, so this asserts nothing");
+    assert.deepStrictEqual(wrong.slice(0, 15), [], wrong.slice(0, 15).join("\n"));
+  });
+
+  it("does not say 'no source' about a page we could not reach or could not read", async () => {
+    const svgs = await everyBadge();
+    const misnamed = subjects
+      .filter(s => s.kind === "none" && s.reasonKey !== "no_source")
+      .filter(s => badgeLabel(svgs.get(s.slug)!) === WITHHELD_LABELS.no_source)
+      .map(s => `/badge/${s.slug}.svg blames a missing source for ${s.reasonKey}`);
+    assert.deepStrictEqual(misnamed.slice(0, 10), [], misnamed.slice(0, 10).join("\n"));
+  });
+});
+
+describe("#1389 a state about us does not wear the vendor's warning colour", () => {
+  const ABOUT_THE_VENDOR = new Set(["at risk", "free tier removed", "deprecated", "retired"]);
+  const ABOUT_US = new Set([...WITHHELD_LABEL_SET, "stale"]);
+
+  it("gives no colour to both a statement about the vendor and a statement about us", async () => {
+    const svgs = await everyBadge();
+    const vendorColours = new Set<string>();
+    const ourColours = new Set<string>();
+    for (const [, svg] of svgs) {
+      const label = badgeLabel(svg);
+      if (ABOUT_THE_VENDOR.has(label)) vendorColours.add(badgeColor(svg));
+      if (ABOUT_US.has(label)) ourColours.add(badgeColor(svg));
+    }
+    assert.ok(vendorColours.size > 0 && ourColours.size > 0, "one of the two populations is empty");
+    const shared = [...vendorColours].filter(c => ourColours.has(c));
+    assert.deepStrictEqual(shared, [], `${shared.join(", ")} is published both for a vendor's risk and for our own queue`);
+  });
+
+  it("distinguishes a stale reading from an at-risk vendor without reading the label", async () => {
+    const stale = subjects.find(s => s.kind === "rating" && s.word === "stable" && s.ageDays > staleAfter);
+    const atRisk = subjects.find(s => s.kind === "rating" && s.word === "caution");
+    assert.ok(atRisk, "no vendor is at risk");
+    if (!stale) return;
+    const staleSvg = (await get(`/badge/${stale.slug}.svg`)).text;
+    const atRiskSvg = (await get(`/badge/${atRisk.slug}.svg`)).text;
+    assert.strictEqual(badgeLabel(staleSvg), "stale");
+    assert.strictEqual(badgeLabel(atRiskSvg), "at risk");
+    assert.notStrictEqual(badgeColor(staleSvg), badgeColor(atRiskSvg));
+  });
+});
+
+describe("#1389 the staleness threshold comes from the re-verification loop", () => {
+  it("recovers the period of a loop that re-reads every page once per interval", async () => {
+    const { reverificationIntervalDays } = await import("../dist/badge-staleness.js");
+    const nowMs = Date.parse("2026-09-06T00:00:00Z");
+    for (const period of [14, 30, 64, 120]) {
+      const dates = Array.from({ length: period * 4 }, (_, i) =>
+        new Date(nowMs - (i % period) * 86400000).toISOString().slice(0, 10));
+      const estimate = reverificationIntervalDays(dates, nowMs);
+      assert.ok(
+        Math.abs(estimate - period) <= 2,
+        `a loop of ${period} days is measured as ${estimate}`,
+      );
+    }
+  });
+
+  it("never returns a threshold of zero days on a catalogue read today", async () => {
+    const { reverificationIntervalDays } = await import("../dist/badge-staleness.js");
+    const nowMs = Date.parse("2026-09-06T00:00:00Z");
+    assert.strictEqual(reverificationIntervalDays([], nowMs), 1);
+    assert.strictEqual(reverificationIntervalDays(["2026-09-06", "2026-09-06"], nowMs), 1);
+  });
+
+  it("calls a reading stale once it is past the interval, not at it", async () => {
+    const { readingIsBehindTheLoop } = await import("../dist/badge-staleness.js");
+    const nowMs = Date.parse("2026-09-06T00:00:00Z");
+    const dayBefore = (days: number) => new Date(nowMs - days * 86400000).toISOString().slice(0, 10);
+    assert.strictEqual(readingIsBehindTheLoop(dayBefore(63), 64, nowMs), false);
+    assert.strictEqual(readingIsBehindTheLoop(dayBefore(64), 64, nowMs), false);
+    assert.strictEqual(readingIsBehindTheLoop(dayBefore(65), 64, nowMs), true);
+  });
+
+  it("holds no fixed staleness threshold in the badge source", () => {
+    const src = readFileSync(path.join(REPO, "src", "serve.ts"), "utf8");
+    assert.doesNotMatch(
+      src,
+      /readingIsBehindTheLoop\([^)]*,\s*\d+\s*,/,
+      "the badge compares an age against a literal again; the threshold is derived from the catalogue",
+    );
+  });
+
+  it("reads stale on exactly the vendors whose page is older than that interval", async () => {
+    const svgs = await everyBadge();
+    const wrong: string[] = [];
+    for (const subject of subjects.filter(s => s.kind === "rating" && s.word === "stable")) {
+      const label = badgeLabel(svgs.get(subject.slug)!);
+      const expected = subject.ageDays > staleAfter ? "stale" : "active";
+      if (label !== expected) {
+        wrong.push(`/badge/${subject.slug}.svg reads "${label}" at ${subject.ageDays} days against a ${staleAfter}-day interval`);
+      }
+    }
+    assert.deepStrictEqual(wrong.slice(0, 10), [], wrong.slice(0, 10).join("\n"));
+  });
+
+  it("leaves the stale state outside the loop rather than inside it", () => {
+    const publishing = subjects.filter(s => s.kind === "rating");
+    const stale = publishing.filter(s => s.word === "stable" && s.ageDays > staleAfter);
+    const share = stale.length / publishing.length;
+    assert.ok(
+      share <= 0.25,
+      `${stale.length} of ${publishing.length} live badges read stale (${(share * 100).toFixed(1)}%) at a ${staleAfter}-day threshold — the threshold is still inside the re-verification loop`,
+    );
+  });
+});
+
+describe("#1389 the stack grade says how much of the stack it could rate", () => {
+  it("names the covered share whenever a service in the stack is unrated", async () => {
+    const rated = subjects.find(s => s.kind === "rating")!;
+    const withheld = subjects.find(s => s.kind === "none")!;
+    const mixed = await get(`/badge/stack.svg?v=${rated.slug},${withheld.slug}`);
+    assert.match(badgeTitle(mixed.text), /Stack Health: [A-F] · 1 of 2 rated/);
+
+    const whole = await get(`/badge/stack.svg?v=${rated.slug}`);
+    assert.match(badgeTitle(whole.text), /Stack Health: [A-F]$/);
+  });
+
+  it("still says nothing at all where it could rate none of the stack", async () => {
+    const withheld = subjects.filter(s => s.kind === "none").slice(0, 2).map(s => s.slug);
+    const { text } = await get(`/badge/stack.svg?v=${withheld.join(",")}`);
+    assert.strictEqual(badgeTitle(text), "Stack Health: ?");
+  });
+});
+
+describe("#1389 /badges counts at risk over vendors we make a claim about", () => {
+  it("publishes an at-risk count that no withheld or stale badge is inside", async () => {
+    const { text } = await get("/badges");
+    const tiles = [...text.matchAll(/<div class="stat-num[^"]*">(\d+)<\/div><div class="stat-label">([^<]+)<\/div>/g)]
+      .map(m => [m[2], parseInt(m[1], 10)] as const);
+    const counts = new Map(tiles);
+    assert.ok(counts.has("At Risk"), "/badges no longer publishes an at-risk count");
+
+    const cautioned = subjects.filter(s => s.kind === "rating" && s.word === "caution").length;
+    const withheld = subjects.filter(s => s.kind === "none").length;
+    const stale = subjects.filter(s => s.kind === "rating" && s.word === "stable" && s.ageDays > staleAfter).length;
+
+    assert.strictEqual(counts.get("At Risk"), cautioned, "the at-risk tile counts vendors we publish no claim about");
+    assert.strictEqual(counts.get("Unrated"), withheld, "the unrated tile does not match the badges that withhold");
+    assert.strictEqual(counts.get("Stale"), stale, "the stale tile does not match the badges that read stale");
+    assert.strictEqual(counts.get("Vendors"), subjects.length);
+  });
+
+  it("adds up to the catalogue, so no vendor is counted twice or dropped", async () => {
+    const { text } = await get("/badges");
+    const tiles = new Map([...text.matchAll(/<div class="stat-num[^"]*">(\d+)<\/div><div class="stat-label">([^<]+)<\/div>/g)]
+      .map(m => [m[2], parseInt(m[1], 10)] as const));
+    const total = ["Active", "At Risk", "Ended", "Stale", "Unrated"].reduce((sum, k) => sum + (tiles.get(k) ?? 0), 0);
+    assert.strictEqual(total, tiles.get("Vendors"), "the tiles do not partition the catalogue");
+  });
+});

--- a/test/one-verdict-engine.test.ts
+++ b/test/one-verdict-engine.test.ts
@@ -21,6 +21,7 @@ import {
 import { isNoLongerInForce } from "../dist/change-resolution.js";
 import { PRODUCT_DEPRECATED, deprecationEndsTheListedProduct } from "../dist/product-deprecation.js";
 import { vendorSlugMap } from "../dist/vendor-slug.js";
+import { ENDED_BADGE_LABEL } from "../dist/retirement.js";
 import type { DealChange } from "../src/types.ts";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -178,6 +179,7 @@ describe("#1206 the badge and the vendor page read the same scale", () => {
   after(() => { if (proc) proc.kill(); });
 
   const UNRATED_BADGE_LABEL = "unrated \u2014 no source";
+  const WITHHELD_BADGE_PREFIX = "unrated \u2014 ";
 
   const LEVEL_FOR_BADGE: Record<string, string> = {
     "deprecated": "risky",
@@ -213,12 +215,14 @@ describe("#1206 the badge and the vendor page read the same scale", () => {
         const label = badgeLabel(await res.text());
         if (label === null) { disagreeing.push(`/badge/${slug}.svg carries no readable label`); continue; }
         if (label === "not found") continue;
+        if (label === ENDED_BADGE_LABEL) continue;
         if (label === UNRATED_BADGE_LABEL) {
           if (vendorRiskAssessment(held.get(vendor.toLowerCase()) ?? []).rating_withheld === null) {
             disagreeing.push(`/badge/${slug}.svg withholds a rating the risk scale reached`);
           }
           continue;
         }
+        if (label.startsWith(WITHHELD_BADGE_PREFIX)) continue;
         const level = LEVEL_FOR_BADGE[label];
         if (level === undefined) { disagreeing.push(`/badge/${slug}.svg reads "${label}"`); continue; }
         const expected = vendorRiskAssessment(held.get(vendor.toLowerCase()) ?? []).level;

--- a/test/uncited-change-records.test.ts
+++ b/test/uncited-change-records.test.ts
@@ -112,8 +112,8 @@ describe("the verdict engine, given a withheld rating", () => {
     ...over,
   });
 
-  it("draws no badge", () => {
-    assert.deepStrictEqual(vendorBadge(input()), { kind: "none" });
+  it("draws no badge, and says the missing source is why", () => {
+    assert.deepStrictEqual(vendorBadge(input()), { kind: "none", because: { reason: "no_source" } });
   });
 
   it("states no risk cause", () => {

--- a/test/vendor-verdict.test.ts
+++ b/test/vendor-verdict.test.ts
@@ -116,32 +116,60 @@ describe("the badge beside a vendor's name says what the verdict below it says",
     assert.deepStrictEqual(vendorBadge(input({ level: "caution", cause })), { kind: "rating", word: "caution" });
   });
 
-  it("states no rating on a record the ranker gates", () => {
+  it("states no rating on a record the ranker gates, and names the gate", () => {
     for (const level of ["stable", "caution", "risky"] as const) {
-      const gated = input({ level, cause, gated: true, changes: [change()] });
-      assert.deepStrictEqual(vendorBadge(gated), { kind: "none" }, `a gated record rated ${level}`);
+      const gated = input({ level, cause, gate: "eligibility_restricted", changes: [change()] });
+      assert.deepStrictEqual(
+        vendorBadge(gated),
+        { kind: "none", because: { reason: "gated", gate: "eligibility_restricted" } },
+        `a gated record rated ${level}`,
+      );
     }
   });
 
   it("states the offer has ended rather than rating it, whatever its history says", () => {
-    const ended = input({ level: "caution", cause, gated: true, offerEnded: true, changes: [change(), change()] });
+    const ended = input({ level: "caution", cause, gate: "offer_retired", offerEnded: true, changes: [change(), change()] });
     assert.deepStrictEqual(vendorBadge(ended), { kind: "ended" });
     assert.strictEqual(vendorVerdictSentence(ended), endedVerdictSentence());
     assert.strictEqual(statesRiskCause(ended), false);
   });
 
-  it("withholds the badge on the two grounds it withheld it on before", () => {
-    assert.deepStrictEqual(vendorBadge(input({ level: null })), { kind: "none" });
-    assert.deepStrictEqual(vendorBadge(input({ level: "stable", linkUnreachable: true })), { kind: "none" });
+  it("withholds the badge on the two grounds it withheld it on before, and says which", () => {
+    assert.deepStrictEqual(
+      vendorBadge(input({ level: null, levelWithheld: "states_no_terms" })),
+      { kind: "none", because: { reason: "states_no_terms" } },
+    );
+    assert.deepStrictEqual(
+      vendorBadge(input({ level: "stable", linkUnreachable: true })),
+      { kind: "none", because: { reason: "link_unreachable" } },
+    );
     assert.deepStrictEqual(
       vendorBadge(input({ level: "risky", cause, linkUnreachable: true })),
       { kind: "rating", word: "risky" },
     );
   });
 
+  it("rates nothing on a level it does not hold, even where no reason was recorded with it", () => {
+    assert.deepStrictEqual(
+      vendorBadge(input({ level: null, levelWithheld: null, ratingWithheld: null })),
+      { kind: "none", because: { reason: "no_source" } },
+    );
+  });
+
+  it("names the reason the verdict sentence gives, not the gate, where both apply", () => {
+    const both = input({
+      level: null,
+      levelWithheld: "unreadable",
+      gate: "eligibility_restricted",
+      changes: [change()],
+    });
+    assert.deepStrictEqual(vendorBadge(both), { kind: "none", because: { reason: "unreadable" } });
+    assert.match(vendorVerdictSentence(both), /could not read the page we cite/);
+  });
+
   it("explains a level only where the verdict states one", () => {
     assert.strictEqual(statesRiskCause(input({ level: "caution", cause })), true);
-    assert.strictEqual(statesRiskCause(input({ level: "caution", cause, gated: true })), true);
+    assert.strictEqual(statesRiskCause(input({ level: "caution", cause, gate: "eligibility_restricted" })), true);
     assert.strictEqual(statesRiskCause(input({ level: "stable" })), false);
     assert.strictEqual(statesRiskCause(input({ level: "caution", cause, offerEnded: true })), false);
   });
@@ -311,7 +339,7 @@ function vendorRows(): VendorRow[] {
         unconfirmableSince,
         ratingWithheld: enriched.rating_withheld ?? null,
         offerEnded: ended,
-        gated: gate !== null,
+        gate: gate?.code ?? null,
       }),
       changes: vendorChanges,
       gate,


### PR DESCRIPTION
The badge is the only thing we publish that renders inside somebody else's README, and it was the only surface of ours that never withheld. `getBadgeStatus` read `assessment.rating_withheld` and stopped; the vendor page reads that **and** `cannotVouchForLevel`, **and** the ranker's gate. So 732 vendors got a verdict on a README while `/vendor/<slug>` was, at the same moment, refusing to publish one.

Refs https://github.com/robhunter/agentdeals/issues/1389

## What changed

`vendorBadge()` in `src/vendor-verdict.ts` is already the function the vendor page asks whether to draw a rating. The SVG now asks the same function, built from the same offer — `offers.filter(o => o.vendor === vendorName)[0]`, enriched by `enrichOffers`, gated by `gateFor`. There is no second copy of the condition to drift, which is what AC-1 asks for; reusing `levelWithheldReason` alone would have left the gate out.

`vendorBadge` now returns *why* it withheld, not just that it did:

```ts
export type BadgeWithholding =
  | { reason: "gated"; gate: GateCode }
  | { reason: "no_source" }
  | { reason: LevelWithheldReason };
```

The reason follows the precedence `vendorVerdictSentence` already uses — the reading first, the gate second — so the badge names what the page says. 1Password is gated *and* unreadable; the page says "The page we cite for 1Password states no terms we can read", and the badge now reads `unrated — page states no terms`, not the gate.

`VendorVerdictInput.gated?: boolean` became `gate?: GateCode | null`. One field, so a caller cannot say "gated" without saying which gate, and the label map is total over `GateCode`.

## The number moved

746 badges withhold today, up from 14. **732 vendors moved**, and 14 more moved off a rating onto `retired`.

| the page withholds because | badges moved |
|---|---|
| `states_no_terms` — the page we cite states no terms we can read | 436 |
| `unreadable` — we could not read the page we cite | 142 |
| `does_not_name_vendor` — the page we cite does not name it | 92 |
| `eligibility_restricted` — the ranker gates the offer | 30 |
| `link_unreachable` — the pricing page has not resolved | 20 |
| `not_a_free_offer` — the ranker gates the offer | 13 |
| `offer_expired` — the ranker gates the offer | 1 |

The issue counts 700 for the four `cannotVouchForLevel` reasons; this moves 732 because the gate is in the mirror too. That is where `https://agentdeals.dev/badge/stripe.svg` sits — `not_a_free_offer`, and it was publishing `free tier: active` in green. `fly-io` and `lemonsqueezy` the same. The remainder of the difference is badges that read `at risk` or `free tier removed` rather than `active`/`stale` for a vendor whose page withholds; the issue's table counts only the first two.

Whole-catalogue counts, before → after:

```
active               639 → 601
at risk              187 → 171
stale                691 →   2
free tier removed     37 →  34
deprecated             4 →   4
retired                0 →  14
unrated               14 → 746
                    1572   1572
```

The three the issue checked on production:

| | before | after |
|---|---|---|
| engagespot.co | `free tier: active` green | `unrated — page unreachable` |
| VirusTotal | `free tier: active` green | `unrated — page unreadable` |
| 1Password | `free tier: active` green | `unrated — page states no terms` |

`github-models` is one of the 14 now reading `retired`: it was publishing a rating five weeks after we recorded its retirement, which is https://github.com/robhunter/agentdeals/issues/1221's complaint on this surface.

## `stale` (AC-3, AC-4)

The 30-day threshold sat inside our own loop, and 78.7% of every amber badge was amber because of us. Two changes.

**The threshold is derived.** `src/badge-staleness.ts` estimates the re-verification interval from the ages we hold. A loop that reads every page once per *P* days leaves ages spread over [0, *P*], so the median age is *P*/2 and `2 × median` recovers *P*. Today that is **64 days** — and the catalogue's ages are min 1, median 32, p75 48, p90 58, p95 61, so 64 sits just outside the loop rather than halfway through it. `test/badge-withholding.test.ts` measures a synthetic loop of 14, 30, 64 and 120 days and asserts the estimator recovers each within 2 days, and asserts the resulting stale share stays under AC-4's quarter.

**2 of 812 badges that publish a rating now read stale** — `sourceforge` and `coolors`, both 147 days. Those are the two that have genuinely fallen out of the loop; the other 689 were the second half of a normal pass.

**`stale` no longer wears amber.** `at risk`, `free tier removed`, `deprecated` and `retired` are statements about the vendor and stay on the red/amber scale. `stale` and every `unrated` state are statements about us: `stale` is `#58a6ff`, `unrated` is `#8b949e`. `github` and `supabase` are no longer the same colour — `github` is gated, so it reads `unrated — restricted offer` in grey, and `supabase` stays amber.

## `/badges` (AC-5)

The headline said **878 At Risk**, which was 187 at risk plus 691 stale. The at-risk tile now counts only the 171 vendors we are making a claim about. Stale, Ended and Unrated get their own tiles, and a test asserts the five tiles sum to the vendor count, so nothing can be double-counted or dropped again. A short legend under the bar says what each state means and that `unrated` reads the same as the vendor's own page.

Long labels made the badges overflow their preview cards, so the two badge grids scale the image down and wrap instead of clipping.

## One thing the issue does not ask for

`/badge/stack.svg` grades a stack by asking `getBadgeStatus` about each service and skipping the ones it cannot rate. It skipped 14 vendors before this change and would skip 746 after it — so a stack of three could be graded on one service and print a bare `A`. That is the same defect one surface over, created by this fix, so the grade now says what it covers: `Stack Health: C · 2 of 3 rated`. A fully rated stack still reads `C`, and a stack it can rate none of still reads `?`.

## Tests

`test/badge-withholding.test.ts`, 16 tests. The AC-6 invariant fetches all 1,572 SVGs and asserts both directions against `vendorBadge` — no badge publishes where the page withholds, and none withholds where the page publishes — with a fixture of nothing. Three more anchor that in-process decision to the rendered HTML: three vendors per withholding reason must have no `risk-badge` in the `<h1>` **and** must state the same reason in prose, and three vendors per rating level must carry one.

`test/one-verdict-engine.test.ts`'s #1206 badge sweep, `test/vendor-verdict.test.ts` and `test/uncited-change-records.test.ts` learned the new shape; the gated cases there now assert which gate, which they could not express before.

3,954 tests pass. `scripts/mutate-1389.sh` runs 22 mutations; 21 died on the first pass. The survivor was `if (input.level === null)` in `badgeWithholding` — unreachable while `enrichOffers` never nulls a level without also recording why, and *not* equivalent: strip it and a level of `null` with no reason beside it publishes `stable`. It was a safety net nothing tested. One test later, 22 of 22.

## Verified

Built, served locally, and read off the wire: the three badges above, the `/badges` tiles, `/vendor/1password` and `/vendor/hetzner` withholding in prose while their badges withhold in SVG, and `/vendor/github` carrying no `risk-badge` in its `<h1>`. Screenshot of `/badges` checked for the new tiles, the legend and the badge overflow.
