### PR TITLE
Answer the free-tier question on /compare the way the rest of the site answers it

### DIFF
--- a/scripts/mutate-1393.sh
+++ b/scripts/mutate-1393.sh
@@ -1,0 +1,149 @@
+#!/usr/bin/env bash
+set -uo pipefail
+
+REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO"
+
+TESTS=(
+  test/compare-free-tier-claim.test.ts
+  test/comparison-verdict.test.ts
+  test/badge-withholding.test.ts
+)
+
+SOURCES=(src/serve.ts src/vendor-verdict.ts src/comparison-verdict.ts)
+
+backup() { for f in "${SOURCES[@]}"; do cp "$f" "/tmp/$(basename "$f").m1393"; done; }
+restore() { for f in "${SOURCES[@]}"; do cp "/tmp/$(basename "$f").m1393" "$f"; done; }
+
+backup
+trap 'restore; npm run build >/dev/null 2>&1' EXIT
+
+killed=0
+survived=0
+
+run_mutation() {
+  local name="$1"; shift
+  restore
+  if ! "$@"; then
+    echo "NOT APPLIED                $name"
+    return
+  fi
+  if ! npm run build >/dev/null 2>&1; then
+    echo "KILLED (does not compile)  $name"
+    killed=$((killed + 1))
+    return
+  fi
+  if TZ=UTC node --test --test-concurrency 1 "${TESTS[@]}" >/tmp/mutation-1393-out.txt 2>&1; then
+    echo "SURVIVED                   $name"
+    survived=$((survived + 1))
+  else
+    echo "KILLED                     $name"
+    killed=$((killed + 1))
+  fi
+}
+
+sub() {
+  python3 - "$1" "$2" "$3" <<'PY'
+import sys
+path, old, new = sys.argv[1], sys.argv[2], sys.argv[3]
+text = open(path, encoding="utf-8").read()
+if old not in text:
+    sys.exit("mutation target not found in " + path)
+open(path, "w", encoding="utf-8").write(text.replace(old, new, 1))
+PY
+}
+
+run_mutation "the comparison decides the free tier by searching the description again" \
+  sub src/serve.ts '  const freeSideA = freeTierSideOf(a.vendor, a.tier, contextA);
+  const freeSideB = freeTierSideOf(b.vendor, b.tier, contextB);' \
+                   '  const freeSideA: FreeTierSide = { vendor: a.vendor, free: a.tier.toLowerCase() !== "none" && !a.description.toLowerCase().includes("no free tier") ? { states: "offered", tier: a.tier } : { states: "ended" } };
+  const freeSideB: FreeTierSide = { vendor: b.vendor, free: b.tier.toLowerCase() !== "none" && !b.description.toLowerCase().includes("no free tier") ? { states: "offered", tier: b.tier } : { states: "ended" } };'
+
+run_mutation "a withheld verdict is read as a free tier" \
+  sub src/vendor-verdict.ts '  if (badge.kind === "none") return { states: "unconfirmed", because: badge.because };' \
+                            '  if (badge.kind === "none") return { states: "offered", level: "stable" };'
+
+run_mutation "a recorded removal no longer ends the free tier" \
+  sub src/vendor-verdict.ts '  if (badge.word === "risky" && input.cause) return { states: "ended", how: "removed", cause: input.cause };' \
+                            '  if (false && input.cause) return { states: "ended", how: "removed", cause: input.cause };'
+
+run_mutation "an ended offer is read as a rated one" \
+  sub src/vendor-verdict.ts '  if (badge.kind === "ended") return { states: "ended", how: "retired" };' \
+                            '  if (false) return { states: "ended", how: "retired" };'
+
+run_mutation "an at-risk rating stops counting as a free tier" \
+  sub src/vendor-verdict.ts '  return { states: "offered", level: badge.word };' \
+                            '  return badge.word === "caution" ? { states: "ended", how: "retired" } : { states: "offered", level: badge.word };'
+
+run_mutation "the comparison publishes terms our own record supersedes" \
+  sub src/serve.ts '  const descBlockHtml = (vendor: string, description: string, superseded: typeof supersededA) =>
+    superseded' \
+                   '  const descBlockHtml = (vendor: string, description: string, superseded: typeof supersededA) =>
+    false && superseded'
+
+run_mutation "the structured data keeps the superseded description" \
+  sub src/serve.ts '          description: superseded ? supersededTermsNotice(v.vendor, superseded) : v.description,' \
+                   '          description: v.description,'
+
+run_mutation "every side gets a zero-priced Offer again" \
+  sub src/serve.ts '          ...(free.states === "offered" && !superseded
+            ? { offers: { "@type": "Offer", price: "0", priceCurrency: "USD", description: v.tier } }
+            : {}),' \
+                   '          offers: { "@type": "Offer", price: "0", priceCurrency: "USD", description: v.tier },'
+
+run_mutation "no side gets an Offer at all" \
+  sub src/serve.ts '          ...(free.states === "offered" && !superseded
+            ? { offers: { "@type": "Offer", price: "0", priceCurrency: "USD", description: v.tier } }
+            : {}),' \
+                   '          ...({}),'
+
+run_mutation "a superseded side still publishes a zero price" \
+  sub src/serve.ts '          ...(free.states === "offered" && !superseded' \
+                   '          ...(free.states === "offered"'
+
+run_mutation "the FAQ takes its provenance from the bare slug again" \
+  sub src/serve.ts '  const faqJsonLd = faqPageJsonLd("/compare/" + slug, faqItems);' \
+                   '  const faqJsonLd = faqPageJsonLd("/" + slug, faqItems);'
+
+run_mutation "a side we do not rate is announced as offering a free tier" \
+  sub src/comparison-verdict.ts '      `We are not publishing a free-tier verdict for ${unsettled.vendor}.`,' \
+                                '      `${unsettled.vendor} offers a free tier ("Free").`,'
+
+run_mutation "the withheld side is named but its reason is dropped" \
+  sub src/comparison-verdict.ts '      settledSideOpening(settled),
+      `We are not publishing a free-tier verdict for ${unsettled.vendor}.`,
+      whyUnconfirmed(unsettled),' \
+                                '      settledSideOpening(settled),
+      `We are not publishing a free-tier verdict for ${unsettled.vendor}.`,
+      "",'
+
+run_mutation "the sentence names the ended side as the one offering a free tier" \
+  sub src/comparison-verdict.ts '  if (a.free.states === "offered") return [oneOffersSentence(a, b, forFaq)];
+  if (b.free.states === "offered") return [oneOffersSentence(b, a, forFaq)];' \
+                                '  if (a.free.states === "offered") return [oneOffersSentence(b, a, forFaq)];
+  if (b.free.states === "offered") return [oneOffersSentence(a, b, forFaq)];'
+
+run_mutation "two ended sides are announced as offering free tiers" \
+  sub src/comparison-verdict.ts '  return [neitherOffersSentence(a, b, forFaq)];' \
+                                '  return [bothOfferSentence(a, b, forFaq)];'
+
+run_mutation "a reason both clauses reach is printed twice" \
+  sub src/comparison-verdict.ts '    if (sentence === "" || said.has(sentence)) continue;' \
+                                '    if (sentence === "") continue;'
+
+run_mutation "the gate stops explaining itself" \
+  sub src/serve.ts '  if (because.reason === "gated") return context.gate?.reason ?? "";' \
+                   '  if (because.reason === "gated") return "";'
+
+run_mutation "the comparison reads the first offer of a different vendor" \
+  sub src/serve.ts '  const vendorOffers = offers.filter(o => o.vendor === vendorName);
+  if (vendorOffers.length === 0) return null;
+
+  const primary = vendorOffers[0];' \
+                   '  const vendorOffers = offers.filter(o => o.vendor === vendorName);
+  if (vendorOffers.length === 0) return null;
+
+  const primary = offers[0];'
+
+echo
+echo "killed=$killed survived=$survived"

--- a/src/comparison-verdict.ts
+++ b/src/comparison-verdict.ts
@@ -33,15 +33,117 @@ function whyWithheld(side: ComparisonSide): string {
     : `We are not publishing a stability rating for ${side.vendor}.`;
 }
 
-export function stabilityVerdictClause(a: ComparisonSide, b: ComparisonSide): string {
+export function stabilitySentences(a: ComparisonSide, b: ComparisonSide): string[] {
   const withheld = [a, b].filter(ratingIsWithheld);
   if (withheld.length > 0) {
-    return `${withheld.map(whyWithheld).join(" ")} We are not comparing the two pricing histories.`;
+    return [...withheld.map(whyWithheld), "We are not comparing the two pricing histories."];
   }
   const stabler = moreStableSide(a, b);
-  if (!stabler) return "";
+  if (!stabler) return [];
   const other = stabler === a ? b : a;
-  return `${stabler.vendor} has a more stable pricing history (${recordedChangesPhrase(stabler.recordedChanges)} vs ${other.recordedChanges}).`;
+  return [`${stabler.vendor} has a more stable pricing history (${recordedChangesPhrase(stabler.recordedChanges)} vs ${other.recordedChanges}).`];
+}
+
+export function stabilityVerdictClause(a: ComparisonSide, b: ComparisonSide): string {
+  return stabilitySentences(a, b).join(" ");
+}
+
+export type SideFreeTier =
+  | { states: "offered"; tier: string }
+  | { states: "ended" }
+  | { states: "unconfirmed"; why: string };
+
+export interface FreeTierSide {
+  vendor: string;
+  free: SideFreeTier;
+}
+
+function offeredTier(side: FreeTierSide): string {
+  return side.free.states === "offered" ? side.free.tier : "";
+}
+
+function bothOfferSentence(a: FreeTierSide, b: FreeTierSide, forFaq: boolean): string {
+  return forFaq
+    ? `Both offer free tiers. ${a.vendor} provides "${offeredTier(a)}" and ${b.vendor} offers "${offeredTier(b)}". Compare the specific limits above to determine which fits your usage.`
+    : `Both ${a.vendor} and ${b.vendor} offer free tiers. ${a.vendor} provides "${offeredTier(a)}" while ${b.vendor} offers "${offeredTier(b)}".`;
+}
+
+function oneOffersSentence(offering: FreeTierSide, ended: FreeTierSide, forFaq: boolean): string {
+  const tail = forFaq ? `${ended.vendor} does not` : `${ended.vendor} does not currently have a free tier`;
+  return `${offering.vendor} offers a free tier ("${offeredTier(offering)}") while ${tail}.`;
+}
+
+function neitherOffersSentence(a: FreeTierSide, b: FreeTierSide, forFaq: boolean): string {
+  return forFaq
+    ? `Neither currently offers a free tier.`
+    : `Neither ${a.vendor} nor ${b.vendor} currently offers a free tier.`;
+}
+
+function settledSideOpening(side: FreeTierSide): string {
+  return side.free.states === "offered"
+    ? `${side.vendor} offers a free tier ("${side.free.tier}").`
+    : `${side.vendor} does not currently have a free tier.`;
+}
+
+function whyUnconfirmed(side: FreeTierSide): string {
+  return side.free.states === "unconfirmed" ? side.free.why : "";
+}
+
+function freeTierSentences(a: FreeTierSide, b: FreeTierSide, forFaq: boolean): string[] {
+  const aUnconfirmed = a.free.states === "unconfirmed";
+  const bUnconfirmed = b.free.states === "unconfirmed";
+
+  if (aUnconfirmed && bUnconfirmed) {
+    return [
+      `We are not publishing a free-tier verdict for either ${a.vendor} or ${b.vendor}.`,
+      whyUnconfirmed(a),
+      whyUnconfirmed(b),
+    ];
+  }
+  if (aUnconfirmed || bUnconfirmed) {
+    const unsettled = aUnconfirmed ? a : b;
+    const settled = aUnconfirmed ? b : a;
+    return [
+      settledSideOpening(settled),
+      `We are not publishing a free-tier verdict for ${unsettled.vendor}.`,
+      whyUnconfirmed(unsettled),
+    ];
+  }
+  if (a.free.states === "offered" && b.free.states === "offered") return [bothOfferSentence(a, b, forFaq)];
+  if (a.free.states === "offered") return [oneOffersSentence(a, b, forFaq)];
+  if (b.free.states === "offered") return [oneOffersSentence(b, a, forFaq)];
+  return [neitherOffersSentence(a, b, forFaq)];
+}
+
+function joinOnce(sentences: string[]): string {
+  const said = new Set<string>();
+  const kept: string[] = [];
+  for (const sentence of sentences) {
+    if (sentence === "" || said.has(sentence)) continue;
+    said.add(sentence);
+    kept.push(sentence);
+  }
+  return kept.join(" ");
+}
+
+export function freeTierVerdictSentence(a: FreeTierSide, b: FreeTierSide): string {
+  return joinOnce(freeTierSentences(a, b, false));
+}
+
+export function freeTierFaqAnswer(a: FreeTierSide, b: FreeTierSide): string {
+  return joinOnce(freeTierSentences(a, b, true));
+}
+
+export function comparisonVerdictText(
+  freeA: FreeTierSide,
+  freeB: FreeTierSide,
+  stabilityA: ComparisonSide,
+  stabilityB: ComparisonSide,
+): string {
+  return joinOnce([
+    ...freeTierSentences(freeA, freeB, false),
+    ...stabilitySentences(stabilityA, stabilityB),
+  ]);
 }
 
 export function stabilityFaqAnswer(a: ComparisonSide, b: ComparisonSide): string {

--- a/src/ranking.ts
+++ b/src/ranking.ts
@@ -24,7 +24,7 @@ export const RETIRED_TIER_NOTE = "an offer the vendor has ended";
 
 export const NOT_FREE_TIER_RULES: { pattern: RegExp; note: string }[] = [
   { pattern: /^paid$/i, note: "no free offer at all" },
-  { pattern: /^freemium$/i, note: "paid product with a trial-shaped entry point, not a stated free tier" },
+  { pattern: /^freemium$/i, note: "a paid product with a trial-shaped entry point, not a stated free tier" },
   { pattern: /^pay[-\s]?as[-\s]?you[-\s]?go$/i, note: "usage-billed from the first request" },
   { pattern: /^pay[-\s]?per[-\s]?use\b/i, note: "usage-billed from the first request" },
   { pattern: /^legacy free$/i, note: "a free tier closed to new accounts" },

--- a/src/serve.ts
+++ b/src/serve.ts
@@ -23,8 +23,8 @@ import { amountUnstatedSentence, levelWithheldReason, sourceStatesNoAmount, with
 import { readingIsBehindTheLoop, reverificationIntervalDays } from "./badge-staleness.js";
 import { SUPERSEDED_TERMS_LABEL, supersededTermsAnswer, supersededTermsMetaSentence, supersededTermsNotice, supersededTermsNoticeHtml, supersededTermsVerdictSentence, supersedingChange } from "./superseded-description.js";
 import { buildComparisonMap, comparisonSlug } from "./comparison-pairs.js";
-import { stabilityFaqAnswer, stabilityVerdictClause, type ComparisonSide, type StabilityRating } from "./comparison-verdict.js";
-import { publishedVendorLevel, vendorVerdictSentence, vendorBadge, statesRiskCause, narrowingSentence, changeKindNoun, type BadgeWithholding, type VendorVerdictInput } from "./vendor-verdict.js";
+import { comparisonVerdictText, freeTierFaqAnswer, stabilityFaqAnswer, type ComparisonSide, type FreeTierSide, type SideFreeTier, type StabilityRating } from "./comparison-verdict.js";
+import { publishedVendorLevel, vendorVerdictSentence, vendorBadge, freeTierClaim, statesRiskCause, narrowingSentence, changeKindNoun, type BadgeWithholding, type VendorVerdictInput } from "./vendor-verdict.js";
 import { vendorHistorySentence } from "./vendor-history.js";
 import { HETZNER_APRIL_CHANGES, HETZNER_CLOUD_PLANS, HETZNER_PRICES_READ, HETZNER_PRICE_SOURCE, HETZNER_SINGAPORE_EXAMPLE, cheapestOrderableHetznerPlan, hetznerEntryPriceClause, unorderableHetznerPlans } from "./hetzner-pricing.js";
 import { changeTimelineDate, supersededLineups, supersessionNote } from "./change-lineup.js";
@@ -781,12 +781,20 @@ function getBadgeStatus(vendorSlug: string): BadgeReading {
   return reading;
 }
 
-function readBadgeStatus(vendorSlug: string, servedOn: string): BadgeReading {
-  const vendorName = vendorSlugMap.get(vendorSlug);
-  if (!vendorName) return UNKNOWN_BADGE;
+interface VendorVerdictContext {
+  vendorOffers: Offer[];
+  primary: Offer;
+  enriched: EnrichedOfferRow;
+  vendorChanges: DealChange[];
+  gate: Gate | null;
+  levelWithheld: LevelWithheldReason | null;
+  unconfirmableSince: string;
+  input: VendorVerdictInput;
+}
 
+function vendorVerdictContext(vendorName: string, servedOn: string): VendorVerdictContext | null {
   const vendorOffers = offers.filter(o => o.vendor === vendorName);
-  if (vendorOffers.length === 0) return UNKNOWN_BADGE;
+  if (vendorOffers.length === 0) return null;
 
   const primary = vendorOffers[0];
   const enriched = enrichOffers([primary])[0];
@@ -794,39 +802,74 @@ function readBadgeStatus(vendorSlug: string, servedOn: string): BadgeReading {
     .filter(c => c.vendor.toLowerCase() === vendorName.toLowerCase())
     .sort((a, b) => b.date.localeCompare(a.date));
   const linkUnreachable = enriched.link_unreachable;
+  const levelWithheld = levelWithheldReason(primary, linkUnreachable);
+  const unconfirmableSince = linkUnreachable?.last_reachable ? ` since ${linkUnreachable.last_reachable}` : "";
+  const gate = gateFor(primary, servedOn);
 
-  const verdict = vendorBadge({
-    vendor: vendorName,
-    level: enriched.risk_level ?? null,
-    cause: enriched.risk_cause,
-    changes: vendorChanges,
-    levelWithheld: levelWithheldReason(primary, linkUnreachable),
-    unconfirmableSince: "",
-    ratingWithheld: enriched.rating_withheld,
-    offerEnded: offerEnded(primary),
-    gate: gateFor(primary, servedOn)?.code ?? null,
-    linkUnreachable: Boolean(linkUnreachable),
-  });
+  return {
+    vendorOffers,
+    primary,
+    enriched,
+    vendorChanges,
+    gate,
+    levelWithheld,
+    unconfirmableSince,
+    input: {
+      vendor: vendorName,
+      level: enriched.risk_level ?? null,
+      cause: enriched.risk_cause,
+      changes: vendorChanges,
+      levelWithheld,
+      unconfirmableSince,
+      ratingWithheld: enriched.rating_withheld,
+      offerEnded: offerEnded(primary),
+      gate: gate?.code ?? null,
+      linkUnreachable: Boolean(linkUnreachable),
+    },
+  };
+}
 
-  if (verdict.kind === "none") {
-    return { status: "withheld", label: withheldBadgeLabel(verdict.because), verifiedDate: null };
+function unconfirmedFreeTierSentence(vendor: string, because: BadgeWithholding, context: VendorVerdictContext): string {
+  if (because.reason === "gated") return context.gate?.reason ?? "";
+  if (because.reason === "no_source") return ratingWithheldForNoSourceSentence(vendor);
+  return withheldLevelSentence(because.reason, vendor, context.unconfirmableSince);
+}
+
+function freeTierSideOf(vendor: string, tier: string, context: VendorVerdictContext): FreeTierSide {
+  const claim = freeTierClaim(context.input);
+  const free: SideFreeTier =
+    claim.states === "offered" ? { states: "offered", tier }
+    : claim.states === "ended" ? { states: "ended" }
+    : { states: "unconfirmed", why: unconfirmedFreeTierSentence(vendor, claim.because, context) };
+  return { vendor, free };
+}
+
+function readBadgeStatus(vendorSlug: string, servedOn: string): BadgeReading {
+  const vendorName = vendorSlugMap.get(vendorSlug);
+  if (!vendorName) return UNKNOWN_BADGE;
+
+  const context = vendorVerdictContext(vendorName, servedOn);
+  if (!context) return UNKNOWN_BADGE;
+
+  const { vendorOffers, primary } = context;
+  const claim = freeTierClaim(context.input);
+
+  if (claim.states === "unconfirmed") {
+    return { status: "withheld", label: withheldBadgeLabel(claim.because), verifiedDate: null };
   }
 
   const latestVerified = vendorOffers.reduce((max, o) => o.verifiedDate > max ? o.verifiedDate : max, primary.verifiedDate);
 
-  if (verdict.kind === "ended") {
-    return { status: "retired", label: ENDED_BADGE_LABEL, verifiedDate: latestVerified };
-  }
-
-  if (verdict.word === "risky" && enriched.risk_cause) {
+  if (claim.states === "ended") {
+    if (claim.how === "retired") return { status: "retired", label: ENDED_BADGE_LABEL, verifiedDate: latestVerified };
     return {
       status: "removed",
-      label: enriched.risk_cause.change_type === PRODUCT_DEPRECATED ? "deprecated" : "free tier removed",
-      verifiedDate: enriched.risk_cause.date,
+      label: claim.cause.change_type === PRODUCT_DEPRECATED ? "deprecated" : "free tier removed",
+      verifiedDate: claim.cause.date,
     };
   }
 
-  if (verdict.word === "caution") {
+  if (claim.level === "caution") {
     return { status: "at-risk", label: "at risk", verifiedDate: latestVerified };
   }
 
@@ -2371,10 +2414,22 @@ function buildComparisonPage(slug: string): string | null {
   const title = `${a.vendor} vs ${b.vendor} Free Tier Comparison — AgentDeals`;
   const metaDesc = `Compare ${a.vendor} and ${b.vendor} free tiers side by side. Pricing, limits, change history, and risk assessment for developers.`;
 
-  const riskA = enrichOffers([offers.find(o => o.vendor === a.vendor)!])[0];
-  const riskB = enrichOffers([offers.find(o => o.vendor === b.vendor)!])[0];
+  const servedOn = utcDate();
+  const contextA = vendorVerdictContext(a.vendor, servedOn);
+  const contextB = vendorVerdictContext(b.vendor, servedOn);
+  if (!contextA || !contextB) return null;
+
+  const riskA = contextA.enriched;
+  const riskB = contextB.enriched;
+  const supersededA = supersedingChange(contextA.primary, contextA.vendorChanges);
+  const supersededB = supersedingChange(contextB.primary, contextB.vendorChanges);
 
   const riskBadge = (o: { risk_level: string | null; risk_cause: RiskCause | null }) => riskBadgeHtml(o.risk_level, o.risk_cause, { margin: false });
+
+  const descBlockHtml = (vendor: string, description: string, superseded: typeof supersededA) =>
+    superseded
+      ? `<div class="desc-block terms-superseded-text"><strong>${SUPERSEDED_TERMS_LABEL}:</strong> ${supersededTermsNoticeHtml(vendor, superseded, escHtmlServer)} <a href="#changes">Read what we recorded &darr;</a></div>`
+      : `<div class="desc-block">${escHtmlServer(description)}</div>`;
 
   const changesHtml = (changes: typeof a.deal_changes, vendor: string) => {
     if (changes.length === 0) return `<p style="color:var(--text-dim);font-size:.85rem">No recorded pricing changes for ${escHtmlServer(vendor)}.</p>`;
@@ -2406,10 +2461,8 @@ function buildComparisonPage(slug: string): string | null {
     <a href="/category/${catSlug}">${catOthersCount} other ${escHtmlServer(primaryCategory.toLowerCase())} option${catOthersCount !== 1 ? "s" : ""} &rarr;</a>
   </div>` : "";
 
-  const tierA = a.tier.toLowerCase();
-  const tierB = b.tier.toLowerCase();
-  const hasFreeA = tierA !== "none" && !a.description.toLowerCase().includes("no free tier");
-  const hasFreeB = tierB !== "none" && !b.description.toLowerCase().includes("no free tier");
+  const freeSideA = freeTierSideOf(a.vendor, a.tier, contextA);
+  const freeSideB = freeTierSideOf(b.vendor, b.tier, contextB);
   const comparisonSide = (
     vendor: string,
     risk: typeof riskA,
@@ -2426,19 +2479,8 @@ function buildComparisonPage(slug: string): string | null {
   };
   const sideA = comparisonSide(a.vendor, riskA, a.deal_changes.length);
   const sideB = comparisonSide(b.vendor, riskB, b.deal_changes.length);
-  const stabilityClause = stabilityVerdictClause(sideA, sideB);
 
-  let verdictText = "";
-  if (hasFreeA && hasFreeB) {
-    verdictText = `Both ${a.vendor} and ${b.vendor} offer free tiers. ${a.vendor} provides "${a.tier}" while ${b.vendor} offers "${b.tier}".`;
-  } else if (hasFreeA && !hasFreeB) {
-    verdictText = `${a.vendor} offers a free tier ("${a.tier}") while ${b.vendor} does not currently have a free tier.`;
-  } else if (!hasFreeA && hasFreeB) {
-    verdictText = `${b.vendor} offers a free tier ("${b.tier}") while ${a.vendor} does not currently have a free tier.`;
-  } else {
-    verdictText = `Neither ${a.vendor} nor ${b.vendor} currently offers a free tier.`;
-  }
-  if (stabilityClause) verdictText += ` ${stabilityClause}`;
+  const verdictText = comparisonVerdictText(freeSideA, freeSideB, sideA, sideB);
 
   const verdictHtml = `
   <div class="verdict-section">
@@ -2462,7 +2504,7 @@ function buildComparisonPage(slug: string): string | null {
   </div>`;
 
   const faqItems = [
-    { q: `Which is cheaper, ${a.vendor} or ${b.vendor}?`, a: hasFreeA && hasFreeB ? `Both offer free tiers. ${a.vendor} provides "${a.tier}" and ${b.vendor} offers "${b.tier}". Compare the specific limits above to determine which fits your usage.` : hasFreeA ? `${a.vendor} offers a free tier ("${a.tier}") while ${b.vendor} does not.` : hasFreeB ? `${b.vendor} offers a free tier ("${b.tier}") while ${a.vendor} does not.` : `Neither currently offers a free tier.` },
+    { q: `Which is cheaper, ${a.vendor} or ${b.vendor}?`, a: freeTierFaqAnswer(freeSideA, freeSideB) },
     { q: `Is ${a.vendor} or ${b.vendor} more stable?`, a: stabilityFaqAnswer(sideA, sideB) },
     { q: `Can I use ${a.vendor} and ${b.vendor} together?`, a: sameCategory ? `While both are in the ${primaryCategory} category, some teams use both for different workloads. Check each vendor's free tier limits to see if they complement your stack.` : `Yes — ${a.vendor} (${a.category}) and ${b.vendor} (${b.category}) serve different purposes and can work well together.` },
   ];
@@ -2476,22 +2518,27 @@ function buildComparisonPage(slug: string): string | null {
     mainEntity: {
       "@type": "ItemList",
       numberOfItems: 2,
-      itemListElement: [a, b].map((v, i) => ({
+      itemListElement: [
+        { offer: a, free: freeSideA.free, superseded: supersededA },
+        { offer: b, free: freeSideB.free, superseded: supersededB },
+      ].map(({ offer: v, free, superseded }, i) => ({
         "@type": "ListItem",
         position: i + 1,
         item: {
           "@type": "SoftwareApplication",
           name: v.vendor,
-          description: v.description,
+          description: superseded ? supersededTermsNotice(v.vendor, superseded) : v.description,
           applicationCategory: v.category,
-          offers: { "@type": "Offer", price: "0", priceCurrency: "USD", description: v.tier },
+          ...(free.states === "offered" && !superseded
+            ? { offers: { "@type": "Offer", price: "0", priceCurrency: "USD", description: v.tier } }
+            : {}),
           url: v.url,
         },
       })),
     },
   };
 
-  const faqJsonLd = faqPageJsonLd("/" + slug, faqItems);
+  const faqJsonLd = faqPageJsonLd("/compare/" + slug, faqItems);
 
   const relatedComparisons = Array.from(comparisonMap.entries())
     .filter(([s, [ra, rb]]) => s !== slug && (ra === vendorA || ra === vendorB || rb === vendorA || rb === vendorB))
@@ -2580,7 +2627,7 @@ ${verdictHtml}
       <div class="detail-row"><span class="detail-label">Tier</span><span class="detail-value" style="color:var(--accent)">${escHtmlServer(a.tier)}</span></div>
       <div class="detail-row"><span class="detail-label">Verified</span><span class="detail-value">${escHtmlServer(a.verifiedDate)}</span></div>
       <div class="detail-row"><span class="detail-label">Changes</span><span class="detail-value">${a.deal_changes.length} recorded</span></div>
-      <div class="desc-block">${escHtmlServer(a.description)}</div>
+      ${descBlockHtml(a.vendor, a.description, supersededA)}
       ${a.referral ? `<div style="margin-top:.75rem;padding:.5rem .75rem;border:1px solid #3fb95040;border-left:3px solid #3fb950;border-radius:0 6px 6px 0;background:#3fb95010;font-size:.8rem">\ud83d\udd17 <a href="${escHtmlServer(a.referral.url)}" rel="noopener sponsored" target="_blank">Referral link</a>: ${escHtmlServer(a.referral.referee_value ?? "Save with our referral link")} <a href="/disclosure" style="font-size:.7rem;color:var(--text-dim)">(disclosure)</a></div>` : ""}
     </div>
     <div class="vendor-col">
@@ -2589,13 +2636,13 @@ ${verdictHtml}
       <div class="detail-row"><span class="detail-label">Tier</span><span class="detail-value" style="color:var(--accent)">${escHtmlServer(b.tier)}</span></div>
       <div class="detail-row"><span class="detail-label">Verified</span><span class="detail-value">${escHtmlServer(b.verifiedDate)}</span></div>
       <div class="detail-row"><span class="detail-label">Changes</span><span class="detail-value">${b.deal_changes.length} recorded</span></div>
-      <div class="desc-block">${escHtmlServer(b.description)}</div>
+      ${descBlockHtml(b.vendor, b.description, supersededB)}
       ${b.referral ? `<div style="margin-top:.75rem;padding:.5rem .75rem;border:1px solid #3fb95040;border-left:3px solid #3fb950;border-radius:0 6px 6px 0;background:#3fb95010;font-size:.8rem">\ud83d\udd17 <a href="${escHtmlServer(b.referral.url)}" rel="noopener sponsored" target="_blank">Referral link</a>: ${escHtmlServer(b.referral.referee_value ?? "Save with our referral link")} <a href="/disclosure" style="font-size:.7rem;color:var(--text-dim)">(disclosure)</a></div>` : ""}
     </div>
   </div>
 
   <div class="changes-section">
-    <h2>Pricing Change History</h2>
+    <h2 id="changes">Pricing Change History</h2>
     <div class="changes-cols">
       <div class="changes-col">
         <h3>${escHtmlServer(a.vendor)}</h3>
@@ -3817,17 +3864,13 @@ function buildVendorPage(slug: string): string | null {
   const vendorName = vendorSlugMap.get(slug);
   if (!vendorName) return null;
 
-  const vendorOffers = offers.filter(o => o.vendor === vendorName);
-  if (vendorOffers.length === 0) return null;
+  const servedOn = new Date().toISOString().slice(0, 10);
+  const context = vendorVerdictContext(vendorName, servedOn);
+  if (!context) return null;
 
-  const primary = vendorOffers[0];
-  const enriched = enrichOffers([primary])[0];
+  const { vendorOffers, primary, enriched, vendorChanges, levelWithheld, unconfirmableSince } = context;
+  const verdictInput = context.input;
   const allCategories = [...new Set(vendorOffers.map(o => o.category))];
-
-  const allChanges = loadDealChanges();
-  const vendorChanges = allChanges
-    .filter(c => c.vendor.toLowerCase() === vendorName.toLowerCase())
-    .sort((a, b) => b.date.localeCompare(a.date));
 
   const termsSuperseded = supersedingChange(primary, vendorChanges);
   const publishableTerms = termsSuperseded ? "" : primary.description;
@@ -3837,30 +3880,13 @@ function buildVendorPage(slug: string): string | null {
   const riskLevel = publishedVendorLevel(enriched.risk_level ?? null, riskCause);
   const riskColor = riskColors[riskLevel] ?? "#8b949e";
 
-  const servedOn = new Date().toISOString().slice(0, 10);
   const discontinuedOn = discontinuedOnOrBefore(vendorChanges, servedOn);
 
   const linkUnreachable = enriched.link_unreachable;
   const offerHasEnded = offerEnded(primary);
-  const primaryGate = gateFor(primary, servedOn);
-  const unconfirmableSince = linkUnreachable
-    ? (linkUnreachable.last_reachable ? ` since ${linkUnreachable.last_reachable}` : "")
-    : "";
-  const levelWithheld = levelWithheldReason(primary, linkUnreachable);
+  const primaryGate = context.gate;
   const withheldClause = levelWithheld ? withheldLevelClause(levelWithheld, unconfirmableSince) : "";
   const ratingWithheld = enriched.rating_withheld;
-  const verdictInput: VendorVerdictInput = {
-    vendor: vendorName,
-    level: enriched.risk_level ?? null,
-    cause: riskCause,
-    changes: vendorChanges,
-    levelWithheld,
-    unconfirmableSince,
-    ratingWithheld,
-    offerEnded: offerHasEnded,
-    gate: primaryGate?.code ?? null,
-    linkUnreachable: Boolean(linkUnreachable),
-  };
 
   const riskCauseLine = statesRiskCause(verdictInput) && riskCause
     ? `  <p class="risk-cause-line" style="margin:.4rem 0 .6rem;font-size:.9rem;color:var(--text-muted)"><strong style="color:${riskColor}">Why ${riskLevel}:</strong> <span class="risk-cause-date" style="font-family:var(--mono)">${escHtmlServer(changeDateLabel(riskCause))}</span> &mdash; ${escHtmlServer(riskCause.summary)} <a href="#changes" style="white-space:nowrap">Full history &darr;</a></p>`
@@ -3936,7 +3962,7 @@ function buildVendorPage(slug: string): string | null {
   const alternatives = alternativesRanking.entries.slice(0, 12).map(e => e.offer);
 
   const curatedVendorRanking = (() => {
-    const kept = curatedAlternativesFor(vendorName, allChanges, offers, vendorOffers).kept;
+    const kept = curatedAlternativesFor(vendorName, dealChanges, offers, vendorOffers).kept;
     if (kept.length === 0) return null;
     return rankForListing(kept, {
       queryKey: `curated-alternatives:${vendorName}`,

--- a/src/vendor-verdict.ts
+++ b/src/vendor-verdict.ts
@@ -108,6 +108,20 @@ export function vendorBadge(input: VendorVerdictInput): VendorBadge {
   return { kind: "rating", word: publishedVendorLevel(input.level, input.cause) };
 }
 
+export type FreeTierClaim =
+  | { states: "offered"; level: PublishedRiskLevel }
+  | { states: "ended"; how: "retired" }
+  | { states: "ended"; how: "removed"; cause: RiskCause }
+  | { states: "unconfirmed"; because: BadgeWithholding };
+
+export function freeTierClaim(input: VendorVerdictInput): FreeTierClaim {
+  const badge = vendorBadge(input);
+  if (badge.kind === "ended") return { states: "ended", how: "retired" };
+  if (badge.kind === "none") return { states: "unconfirmed", because: badge.because };
+  if (badge.word === "risky" && input.cause) return { states: "ended", how: "removed", cause: input.cause };
+  return { states: "offered", level: badge.word };
+}
+
 export function statesRiskCause(input: VendorVerdictInput): boolean {
   const word = vendorVerdictWord(input);
   return word !== null && word !== "stable" && input.cause !== null;

--- a/test/compare-free-tier-claim.test.ts
+++ b/test/compare-free-tier-claim.test.ts
@@ -1,0 +1,343 @@
+import { describe, it, before, after } from "node:test";
+import assert from "node:assert";
+import { spawn, type ChildProcess } from "node:child_process";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO = path.join(__dirname, "..");
+
+let serverPort = 0;
+let proc: ChildProcess | null = null;
+
+function startHttpServer(): Promise<{ child: ChildProcess; port: number }> {
+  return new Promise((resolve, reject) => {
+    const child = spawn("node", [path.join(REPO, "dist", "serve.js")], {
+      stdio: ["pipe", "pipe", "pipe"],
+      env: { ...process.env, PORT: "0", BASE_URL: "http://localhost" },
+    });
+    const timeout = setTimeout(() => { child.kill(); reject(new Error("Server startup timeout")); }, 30000);
+    child.stderr!.on("data", (data: Buffer) => {
+      const m = data.toString().match(/running on http:\/\/localhost:(\d+)/);
+      if (m) { clearTimeout(timeout); resolve({ child, port: parseInt(m[1], 10) }); }
+    });
+    child.on("error", (err) => { clearTimeout(timeout); reject(err); });
+  });
+}
+
+type SiteVerdict = "offered" | "ended" | "unconfirmed";
+
+const BADGE_VERDICT: Record<string, SiteVerdict> = {
+  "active": "offered",
+  "at risk": "offered",
+  "stale": "offered",
+  "free tier removed": "ended",
+  "deprecated": "ended",
+  "retired": "ended",
+};
+
+interface Pair {
+  slug: string;
+  a: string;
+  b: string;
+}
+
+interface Side {
+  vendor: string;
+  slug: string;
+  verdict: SiteVerdict;
+  tier: string;
+  description: string;
+  superseded: boolean;
+  reasonsItCouldGive: string[];
+}
+
+let pairs: Pair[] = [];
+const sides = new Map<string, Side>();
+
+function escHtml(s: string): string {
+  return s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;");
+}
+
+function unescHtml(s: string): string {
+  return s.replace(/&amp;/g, "&").replace(/&lt;/g, "<").replace(/&gt;/g, ">").replace(/&quot;/g, '"')
+    .replace(/&mdash;/g, "—").replace(/&rsquo;/g, "’").replace(/&hellip;/g, "…")
+    .replace(/&#39;/g, "'").replace(/&darr;/g, "↓").replace(/&rarr;/g, "→");
+}
+
+function badgeLabel(svg: string): string {
+  const title = svg.match(/<title>([\s\S]*?)<\/title>/)?.[1] ?? "";
+  return title.split(": ").slice(1).join(": ").split(" · ")[0].trim();
+}
+
+async function fetchAll<T>(items: T[], worker: (item: T) => Promise<void>, lanes = 12): Promise<void> {
+  let queue = 0;
+  await Promise.all(Array.from({ length: lanes }, async () => {
+    while (queue < items.length) await worker(items[queue++]);
+  }));
+}
+
+before(async () => {
+  const { buildComparisonMap } = await import("../dist/comparison-pairs.js");
+  const { enrichOffers, loadOffers, loadDealChanges } = await import("../dist/data.js");
+  const { toSlug } = await import("../dist/vendor-slug.js");
+  const { supersedingChange } = await import("../dist/superseded-description.js");
+  const { gateFor, utcDate } = await import("../dist/ranking.js");
+  const { levelWithheldReason, withheldLevelSentence } = await import("../dist/source-check.js");
+  const { ratingWithheldForNoSourceSentence } = await import("../dist/change-citation.js");
+
+  const offers = loadOffers();
+  const changes = loadDealChanges();
+  const servedOn = utcDate();
+  pairs = [...buildComparisonMap().entries()].map(([slug, [a, b]]: [string, [string, string]]) => ({ slug, a, b }));
+  assert.ok(pairs.length > 300, "the comparison set did not load");
+
+  const started = await startHttpServer();
+  proc = started.child;
+  serverPort = started.port;
+
+  const vendors = [...new Set(pairs.flatMap(p => [p.a, p.b]))];
+  await fetchAll(vendors, async (vendor) => {
+    const primary = offers.find((o: { vendor: string }) => o.vendor === vendor)!;
+    const slug = toSlug(vendor);
+    const res = await fetch(`http://localhost:${serverPort}/badge/${slug}.svg`);
+    assert.strictEqual(res.status, 200, `/badge/${slug}.svg returned ${res.status}`);
+    const label = badgeLabel(await res.text());
+    const verdict = BADGE_VERDICT[label] ?? "unconfirmed";
+    if (!BADGE_VERDICT[label]) {
+      assert.match(label, /^unrated/, `${vendor} carries an unrecognised badge label "${label}"`);
+    }
+    const enriched = enrichOffers([primary])[0];
+    const unreachable = enriched.link_unreachable;
+    const withheld = levelWithheldReason(primary, unreachable);
+    const since = unreachable?.last_reachable ? ` since ${unreachable.last_reachable}` : "";
+    const reasonsItCouldGive = [
+      gateFor(primary, servedOn)?.reason,
+      withheld ? withheldLevelSentence(withheld, vendor, since) : null,
+      ratingWithheldForNoSourceSentence(vendor),
+    ].filter((r): r is string => typeof r === "string" && r !== "");
+
+    sides.set(vendor, {
+      vendor,
+      slug,
+      verdict,
+      tier: primary.tier,
+      description: primary.description,
+      superseded: supersedingChange(
+        primary,
+        changes.filter((c: { vendor: string }) => c.vendor.toLowerCase() === vendor.toLowerCase()),
+      ) !== null,
+      reasonsItCouldGive,
+    });
+  });
+});
+
+after(() => { if (proc) proc.kill(); });
+
+let renderedPages: Map<string, string> | null = null;
+
+async function everyComparisonPage(): Promise<Map<string, string>> {
+  if (renderedPages) return renderedPages;
+  const html = new Map<string, string>();
+  await fetchAll(pairs, async ({ slug }) => {
+    const res = await fetch(`http://localhost:${serverPort}/compare/${slug}`);
+    assert.strictEqual(res.status, 200, `/compare/${slug} returned ${res.status}`);
+    html.set(slug, await res.text());
+  });
+  renderedPages = html;
+  return html;
+}
+
+function verdictOf(html: string): string {
+  const section = html.match(/class="verdict-section">([\s\S]*?)<\/div>/)?.[1] ?? "";
+  return unescHtml(section.match(/<p>([\s\S]*?)<\/p>/)?.[1] ?? "").trim();
+}
+
+function jsonLdBlocks(html: string): Record<string, unknown>[] {
+  return [...html.matchAll(/<script type="application\/ld\+json">([\s\S]*?)<\/script>/g)]
+    .map(m => JSON.parse(m[1]) as Record<string, unknown>);
+}
+
+function itemListOf(html: string): { name: string; description: string; offers?: { price?: string } }[] {
+  const page = jsonLdBlocks(html).find(b => b["@type"] === "WebPage") as
+    { mainEntity: { itemListElement: { item: { name: string; description: string; offers?: { price?: string } } }[] } };
+  return page.mainEntity.itemListElement.map(e => e.item);
+}
+
+function faqAnswers(html: string): string[] {
+  const faq = jsonLdBlocks(html).find(b => b["@type"] === "FAQPage") as
+    { mainEntity: { acceptedAnswer: { text: string } }[] };
+  return faq.mainEntity.map(q => q.acceptedAnswer.text);
+}
+
+function assertsAFreeTier(verdict: string, side: Side, other: Side): boolean {
+  const both = `Both ${side.vendor} and ${other.vendor} offer free tiers.`;
+  const bothReversed = `Both ${other.vendor} and ${side.vendor} offer free tiers.`;
+  if (verdict.startsWith(both) || verdict.startsWith(bothReversed)) return true;
+  return verdict.includes(`${side.vendor} offers a free tier ("`);
+}
+
+describe("#1393 the comparison page answers the free-tier question the way the rest of the site answers it", () => {
+  it("asserts a free tier for exactly the vendors the badge rates one for, on every page", async () => {
+    const pages = await everyComparisonPage();
+    const assertsWhatTheSiteWillNot: string[] = [];
+    const withholdsWhereTheSitePublishes: string[] = [];
+    let asserted = 0;
+
+    for (const pair of pairs) {
+      const verdict = verdictOf(pages.get(pair.slug)!);
+      assert.notStrictEqual(verdict, "", `/compare/${pair.slug} publishes no verdict`);
+      for (const [vendor, otherVendor] of [[pair.a, pair.b], [pair.b, pair.a]]) {
+        const side = sides.get(vendor)!;
+        const other = sides.get(otherVendor)!;
+        const asserts = assertsAFreeTier(verdict, side, other);
+        if (asserts) asserted++;
+        if (asserts && side.verdict !== "offered") {
+          assertsWhatTheSiteWillNot.push(`/compare/${pair.slug} — ${vendor} is ${side.verdict}`);
+        }
+        if (!asserts && side.verdict === "offered") {
+          withholdsWhereTheSitePublishes.push(`/compare/${pair.slug} — ${vendor}`);
+        }
+      }
+    }
+
+    assert.deepStrictEqual(assertsWhatTheSiteWillNot, [], "a comparison asserts a free tier the badge does not rate");
+    assert.deepStrictEqual(withholdsWhereTheSitePublishes, [], "a comparison withholds a free tier the badge rates");
+    assert.ok(asserted > 300, `only ${asserted} slots assert a free tier`);
+  });
+
+  it("states why it is withholding, on every slot the site does not rate", async () => {
+    const pages = await everyComparisonPage();
+    const silent: string[] = [];
+    const unreasoned: string[] = [];
+    let withholdingSlots = 0;
+
+    for (const pair of pairs) {
+      const verdict = verdictOf(pages.get(pair.slug)!);
+      for (const vendor of [pair.a, pair.b]) {
+        const side = sides.get(vendor)!;
+        if (side.verdict !== "unconfirmed") continue;
+        withholdingSlots++;
+        if (!verdict.includes(`free-tier verdict for ${vendor}.`) && !verdict.includes(`free-tier verdict for either `)) {
+          silent.push(`/compare/${pair.slug} — ${vendor}`);
+        }
+        if (!side.reasonsItCouldGive.some(reason => verdict.includes(reason))) {
+          unreasoned.push(`/compare/${pair.slug} — ${vendor}`);
+        }
+      }
+    }
+
+    assert.deepStrictEqual(silent, [], "a comparison withholds without saying so in the claim");
+    assert.deepStrictEqual(unreasoned, [], "a comparison withholds without naming a reason we hold");
+    assert.ok(withholdingSlots > 100, `only ${withholdingSlots} slots withhold`);
+  });
+
+  it("never publishes stored terms a change record supersedes", async () => {
+    const pages = await everyComparisonPage();
+    const republished: string[] = [];
+    let withheld = 0;
+
+    for (const pair of pairs) {
+      const html = pages.get(pair.slug)!;
+      for (const vendor of [pair.a, pair.b]) {
+        const side = sides.get(vendor)!;
+        if (!side.superseded) continue;
+        withheld++;
+        if (html.includes(escHtml(side.description))) republished.push(`/compare/${pair.slug} — ${vendor}`);
+        if (!html.includes("Superseded:")) republished.push(`/compare/${pair.slug} — ${vendor} states no supersession`);
+      }
+    }
+
+    assert.deepStrictEqual(republished, [], "a comparison publishes terms our own record supersedes");
+    assert.ok(withheld > 0, "no superseded side was exercised");
+  });
+
+  it("keeps the stored terms of every side no record supersedes", async () => {
+    const pages = await everyComparisonPage();
+    const dropped: string[] = [];
+
+    for (const pair of pairs) {
+      const html = pages.get(pair.slug)!;
+      for (const vendor of [pair.a, pair.b]) {
+        const side = sides.get(vendor)!;
+        if (side.superseded) continue;
+        if (!html.includes(escHtml(side.description))) dropped.push(`/compare/${pair.slug} — ${vendor}`);
+      }
+    }
+
+    assert.deepStrictEqual(dropped, [], "a comparison dropped terms nothing supersedes");
+  });
+
+  it("prices an Offer at zero only where it says in prose that the free tier exists", async () => {
+    const pages = await everyComparisonPage();
+    const priced: string[] = [];
+    const missing: string[] = [];
+    let offerBlocks = 0;
+
+    for (const pair of pairs) {
+      const items = itemListOf(pages.get(pair.slug)!);
+      for (const item of items) {
+        const side = sides.get(item.name)!;
+        const publishable = side.verdict === "offered" && !side.superseded;
+        if (item.offers) {
+          offerBlocks++;
+          assert.strictEqual(item.offers.price, "0", `${item.name} publishes a non-zero Offer`);
+          if (!publishable) priced.push(`/compare/${pair.slug} — ${item.name} is ${side.verdict}`);
+        } else if (publishable) {
+          missing.push(`/compare/${pair.slug} — ${item.name}`);
+        }
+      }
+    }
+
+    assert.deepStrictEqual(priced, [], "a machine-readable Offer prices a free tier the page will not vouch for");
+    assert.deepStrictEqual(missing, [], "a rated free tier lost its Offer block");
+    assert.ok(offerBlocks > 0, "no Offer block was exercised");
+  });
+
+  it("takes its FAQ provenance from its own route, not from a page whose path its slug happens to match", async () => {
+    const { faqPageJsonLd, pageFaqProvenanceClause } = await import("../dist/faq-provenance.js");
+    const pages = await everyComparisonPage();
+    const borrowed: string[] = [];
+    let collisions = 0;
+
+    for (const pair of pairs) {
+      const foreign = pageFaqProvenanceClause(`/${pair.slug}`);
+      const own = pageFaqProvenanceClause(`/compare/${pair.slug}`);
+      if (foreign === "" || foreign === own) continue;
+      collisions++;
+
+      const statesAFigure = [{ q: `What does ${pair.a} include?`, a: `The free tier includes 100 GB of bandwidth.` }];
+      const asItsOwnRoute = JSON.stringify(faqPageJsonLd(`/compare/${pair.slug}`, statesAFigure));
+      const asTheOtherPage = JSON.stringify(faqPageJsonLd(`/${pair.slug}`, statesAFigure));
+      assert.notStrictEqual(asItsOwnRoute, asTheOtherPage, `/compare/${pair.slug} cannot tell the two routes apart`);
+      assert.ok(asTheOtherPage.includes(foreign), `/${pair.slug} stopped carrying its own clause`);
+      assert.ok(!asItsOwnRoute.includes(foreign), `/compare/${pair.slug} inherits another page's clause`);
+
+      for (const answer of faqAnswers(pages.get(pair.slug)!)) {
+        if (answer.includes(foreign)) borrowed.push(`/compare/${pair.slug}`);
+      }
+    }
+
+    assert.deepStrictEqual(borrowed, [], "a comparison page carries another page's provenance clause");
+    assert.ok(collisions > 0, "no slug collision was exercised");
+  });
+
+  it("leaves a page reading as it did where the site rates both free tiers", async () => {
+    const pages = await everyComparisonPage();
+    const changed: string[] = [];
+    let bothRated = 0;
+
+    for (const pair of pairs) {
+      const a = sides.get(pair.a)!;
+      const b = sides.get(pair.b)!;
+      if (a.verdict !== "offered" || b.verdict !== "offered") continue;
+      bothRated++;
+      const verdict = verdictOf(pages.get(pair.slug)!);
+      const expected = `Both ${a.vendor} and ${b.vendor} offer free tiers. ${a.vendor} provides "${a.tier}" while ${b.vendor} offers "${b.tier}".`;
+      if (!verdict.startsWith(expected)) changed.push(`/compare/${pair.slug}`);
+    }
+
+    assert.deepStrictEqual(changed, [], "a page the site rates on both sides stopped reading the way it did");
+    assert.ok(bothRated > 50, `only ${bothRated} pages rate both sides`);
+  });
+});

--- a/test/comparison-verdict.test.ts
+++ b/test/comparison-verdict.test.ts
@@ -4,12 +4,17 @@ import { spawn, type ChildProcess } from "node:child_process";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import {
+  comparisonVerdictText,
+  freeTierFaqAnswer,
+  freeTierVerdictSentence,
   moreStableSide,
   ratingIsWithheld,
   recordedChangesPhrase,
   stabilityFaqAnswer,
+  stabilitySentences,
   stabilityVerdictClause,
   type ComparisonSide,
+  type FreeTierSide,
 } from "../dist/comparison-verdict.js";
 import { buildComparisonMap } from "../dist/comparison-pairs.js";
 import { enrichOffers, loadDealChanges, loadOffers } from "../dist/data.js";
@@ -30,6 +35,84 @@ function side(over: Partial<ComparisonSide> = {}): ComparisonSide {
     ...over,
   };
 }
+
+const offering = (vendor: string, tier: string): FreeTierSide => ({ vendor, free: { states: "offered", tier } });
+const ended = (vendor: string): FreeTierSide => ({ vendor, free: { states: "ended" } });
+const unconfirmed = (vendor: string, why: string): FreeTierSide => ({ vendor, free: { states: "unconfirmed", why } });
+
+describe("comparison verdict — the free-tier claim carries its own reservation", () => {
+  it("states both free tiers only when both sides are rated", () => {
+    assert.strictEqual(
+      freeTierVerdictSentence(offering("Neon", "Free"), offering("Supabase", "Free")),
+      `Both Neon and Supabase offer free tiers. Neon provides "Free" while Supabase offers "Free".`,
+    );
+    assert.strictEqual(
+      freeTierFaqAnswer(offering("Neon", "Free"), offering("Supabase", "Free")),
+      `Both offer free tiers. Neon provides "Free" and Supabase offers "Free". Compare the specific limits above to determine which fits your usage.`,
+    );
+  });
+
+  it("names the one rated side when the other has ended", () => {
+    assert.strictEqual(
+      freeTierVerdictSentence(offering("Neon", "Free"), ended("Hypertune")),
+      `Neon offers a free tier ("Free") while Hypertune does not currently have a free tier.`,
+    );
+    assert.strictEqual(
+      freeTierVerdictSentence(ended("Hypertune"), offering("Neon", "Free")),
+      `Neon offers a free tier ("Free") while Hypertune does not currently have a free tier.`,
+    );
+    assert.strictEqual(
+      freeTierVerdictSentence(ended("Hypertune"), ended("ETLR")),
+      `Neither Hypertune nor ETLR currently offers a free tier.`,
+    );
+  });
+
+  it("never says a side offers a free tier when the site publishes no verdict for it", () => {
+    const why = "The page we cite for BrowserStack states no terms we can read.";
+    const one = freeTierVerdictSentence(offering("Applitools Eyes", "Free"), unconfirmed("BrowserStack", why));
+    assert.ok(!one.includes("BrowserStack offers a free tier"), one);
+    assert.ok(one.includes("We are not publishing a free-tier verdict for BrowserStack."), one);
+    assert.ok(one.endsWith(why), one);
+
+    const both = freeTierVerdictSentence(
+      unconfirmed("Claude Code", `Tier "Paid" is no free offer at all.`),
+      unconfirmed("OpenAI Codex", `Tier "Freemium" is a paid product.`),
+    );
+    assert.ok(!both.includes("offers a free tier"), both);
+    assert.strictEqual(
+      both,
+      `We are not publishing a free-tier verdict for either Claude Code or OpenAI Codex. Tier "Paid" is no free offer at all. Tier "Freemium" is a paid product.`,
+    );
+  });
+
+  it("states a withheld reason once when the free-tier claim and the stability clause share it", () => {
+    const why = "The page we cite for BrowserStack states no terms we can read.";
+    const stableSide = side({ vendor: "Applitools Eyes", recordedChanges: 1, rating: "stable" });
+    const withheldSide = side({
+      vendor: "BrowserStack",
+      recordedChanges: 0,
+      rating: null,
+      ratingWithheldBecause: "states_no_terms",
+    });
+    const text = comparisonVerdictText(
+      ended("Applitools Eyes"),
+      unconfirmed("BrowserStack", why),
+      stableSide,
+      withheldSide,
+    );
+    assert.strictEqual(text.split(why).length - 1, 1, text);
+    assert.ok(text.endsWith("We are not comparing the two pricing histories."), text);
+  });
+
+  it("keeps the stability clause when nothing in the free-tier claim repeats it", () => {
+    const a = side({ vendor: "Neon", recordedChanges: 1, rating: "stable" });
+    const b = side({ vendor: "Supabase", recordedChanges: 2, rating: "caution" });
+    assert.strictEqual(
+      comparisonVerdictText(offering("Neon", "Free"), offering("Supabase", "Free"), a, b),
+      `Both Neon and Supabase offer free tiers. Neon provides "Free" while Supabase offers "Free". ${stabilityVerdictClause(a, b)}`,
+    );
+  });
+});
 
 describe("comparison verdict — the stability clause is derived from the counts the page prints", () => {
   it("names no winner when both sides have the same recorded-change count", () => {
@@ -314,7 +397,9 @@ describe("comparison verdict — as rendered", () => {
     const verdict = renderedVerdict(html);
     const answer = renderedStabilityAnswer(html, sides);
     if (clause) {
-      assert.ok(verdict.includes(escaped(clause)), `${slug} verdict does not render "${clause}"`);
+      for (const sentence of stabilitySentences(sides[0], sides[1])) {
+        assert.ok(verdict.includes(escaped(sentence)), `${slug} verdict does not render "${sentence}"`);
+      }
       assert.ok(answer.includes(clause), `${slug} structured data does not carry "${clause}"`);
     } else {
       assert.doesNotMatch(verdict, /has a more stable pricing history/, `${slug} verdict names a winner the rule does not`);
@@ -332,7 +417,9 @@ describe("comparison verdict — as rendered", () => {
       const clause = stabilityVerdictClause(sides[0], sides[1]);
       const verdict = renderedVerdict(html);
       const answer = renderedStabilityAnswer(html, sides);
-      if (clause && !verdict.includes(escaped(clause))) wrong.push(`${slug}: the verdict does not render "${clause}"`);
+      for (const sentence of stabilitySentences(sides[0], sides[1])) {
+        if (!verdict.includes(escaped(sentence))) wrong.push(`${slug}: the verdict does not render "${sentence}"`);
+      }
       if (clause && !answer.includes(clause)) wrong.push(`${slug}: the structured data does not carry "${clause}"`);
       if (!clause && /has a more stable pricing history/.test(verdict)) wrong.push(`${slug}: the verdict names a winner the counts do not support`);
       if (!clause && /has a more stable pricing history/.test(answer)) wrong.push(`${slug}: the structured data names a winner the counts do not support`);


### PR DESCRIPTION
Refs #1393.

`/compare/:slug` answered "does this vendor have a free tier" with a substring search over the stored description. It now asks the same function `/vendor/:slug` and `/badge/:slug.svg` ask, so the three surfaces cannot disagree about the same vendor at the same moment.

## The choke point

`vendorBadge()` already decides whether the site publishes a verdict for a vendor. The new `freeTierClaim()` sits directly on it and turns that verdict into the three answers a comparison needs — `offered`, `ended`, `unconfirmed` — and `readBadgeStatus` now derives the badge from the same function rather than repeating the classification. The three call sites also built the `VendorVerdictInput` three separate ways; there is now one `vendorVerdictContext(vendor, servedOn)` and the vendor page, the badge and the comparison all read it.

## Population moved, on all 353 pages and 706 slots

| | before | after |
|---|---|---|
| slots asserting a free tier | 705 | **369** |
| slots naming a withheld reason instead | 0 | **300** |
| slots stating the offer has ended | 1 | **37** |
| slots publishing stored terms a change record supersedes | 92 | **0** |
| JSON-LD `Offer` blocks priced `"0"` | 706 | **306** |

The 369 that still assert one are exactly the slots the badge rates — 268 active, 98 at risk, 3 stale. Their verdict sentence is unchanged, character for character (AC-7).

The 336 slots that stopped asserting break down as 36 the site records as removed or deprecated, 1 retired, and 299 it cannot confirm: `states_no_terms` 201, `unreadable` 49, `does_not_name_vendor` 20, `not_a_free_offer` 11, `eligibility_restricted` 6, `no_source` 5, `offer_expired` 3, `link_unreachable` 5.

## What each acceptance criterion did

**AC-1** `hasFreeA`/`hasFreeB` are gone. `freeTierSideOf` reads `freeTierClaim(context.input)`.

**AC-2** The reservation is in the claim, not appended to it. `/compare/applitools-eyes-vs-browserstack` opened with "Both Applitools Eyes and BrowserStack offer free tiers" and now opens:

> Applitools Eyes does not currently have a free tier. We are not publishing a free-tier verdict for BrowserStack. The page we cite for BrowserStack states no terms we can read. We are not comparing the two pricing histories.

The reason a withheld side gives is the sentence the rest of the site gives — the ranker's `gate.reason` for a gated side, `withheldLevelSentence` for a source check, `ratingWithheldForNoSourceSentence` for an uncited rating. Where the free-tier claim and the stability clause reach for the same sentence it is printed once.

**AC-3** `supersedingChange` now runs on the comparison too. The visible block carries the vendor page's `Superseded:` notice, with the change record's own reading and `source_url`, and the JSON-LD description carries `supersededTermsNotice`. `/compare/firebase-vs-supabase` no longer publishes the Supabase terms `/vendor/supabase` withholds.

**AC-4** The `offers` key is emitted only where the page says in prose that the free tier exists and no record supersedes the terms. 400 blocks are gone; none of the 306 that remain sits beside a claim the page will not make.

**AC-5** `faqPageJsonLd("/compare/" + slug, …)`. `neon-vs-supabase` and `railway-vs-render` collided with registered page paths, and `getPageReview` was resolving the hand-written vs-page's record.

**AC-6** `test/compare-free-tier-claim.test.ts` renders all 353 pages and asserts both directions against `/badge/:slug.svg` — the site's own published verdict, not a re-implementation of it — for every one of the 706 slots. Four of its seven checks fail on `main`.

## Verification

3,969 tests, 15 new, whole suite green. 18 mutations, 17 killed.

The one survivor is AC-5. `answerWithProvenance` appends the clause only to an answer that states a vendor figure, and 0 of the 1,059 FAQ answers across the 353 pages state one — so the misattribution is latent and no rendered page carries a clause today, before or after. The test pins that the two routes resolve to different records and which one the page must use; it cannot observe the call site until an answer states a figure.

To check the shared `vendorVerdictContext` changed nothing on the surfaces that already used it, I rendered 120 vendor pages, 120 badge SVGs, `/badges`, `/` and `/compare` on `main` and on this branch: 243 of 243 byte-identical.

Also here: the note `classifyTier` gives for a `Freemium` tier read "is paid product with a…" and now reads "is a paid product with a…". This change puts that note in front of readers on 353 more pages.

## Not fixed, noted

`/compare/applitools-eyes-vs-browserstack` prints `Tier — Free` in the details column beside a verdict saying the free tier has ended. `/vendor/applitools-eyes` prints the same `Tier — Free`, so the comparison is consistent with the rest of the site; the record's `tier` field disagrees with its own change record. That is a data correction, not a rendering one.
