### PR TITLE
Publish the superseded-terms answer on every surface that renders an offer description

### DIFF
--- a/data/page-reviews.json
+++ b/data/page-reviews.json
@@ -72,7 +72,7 @@
       "review_outcome": null,
       "review_note": null,
       "reads_index": true,
-      "reads_changes": false,
+      "reads_changes": true,
       "data_source": "catalogue",
       "data_source_reason": null
     },
@@ -88,7 +88,7 @@
       "review_outcome": null,
       "review_note": null,
       "reads_index": true,
-      "reads_changes": false,
+      "reads_changes": true,
       "data_source": "catalogue",
       "data_source_reason": null
     },
@@ -674,7 +674,7 @@
       "review_outcome": null,
       "review_note": null,
       "reads_index": true,
-      "reads_changes": false,
+      "reads_changes": true,
       "data_source": "catalogue",
       "data_source_reason": null
     },
@@ -2219,7 +2219,7 @@
       "review_outcome": null,
       "review_note": null,
       "reads_index": true,
-      "reads_changes": false,
+      "reads_changes": true,
       "data_source": "catalogue",
       "data_source_reason": null
     }

--- a/scripts/mutate-1395.sh
+++ b/scripts/mutate-1395.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+set -uo pipefail
+
+REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO"
+
+TESTS=(
+  test/superseded-terms-listings.test.ts
+  test/superseded-terms.test.ts
+)
+
+SOURCES=(src/serve.ts src/data.ts src/provenance.ts src/superseded-description.ts)
+
+backup() { for f in "${SOURCES[@]}"; do cp "$f" "/tmp/$(basename "$f").m1395"; done; }
+restore() { for f in "${SOURCES[@]}"; do cp "/tmp/$(basename "$f").m1395" "$f"; done; }
+
+backup
+trap 'restore; npm run build >/dev/null 2>&1' EXIT
+
+killed=0
+survived=0
+
+run_mutation() {
+  local name="$1"; shift
+  restore
+  if ! "$@"; then
+    echo "NOT APPLIED                $name"
+    return
+  fi
+  if ! npm run build >/dev/null 2>&1; then
+    echo "KILLED (does not compile)  $name"
+    killed=$((killed + 1))
+    return
+  fi
+  if TZ=UTC node --test --test-concurrency 1 "${TESTS[@]}" >/tmp/mutation-1395-out.txt 2>&1; then
+    echo "SURVIVED                   $name"
+    survived=$((survived + 1))
+  else
+    echo "KILLED                     $name"
+    killed=$((killed + 1))
+  fi
+}
+
+sub() {
+  python3 - "$1" "$2" "$3" <<'PY'
+import sys
+path, old, new = sys.argv[1], sys.argv[2], sys.argv[3]
+text = open(path, encoding="utf-8").read()
+if old not in text:
+    sys.exit("mutation target not found in " + path)
+open(path, "w", encoding="utf-8").write(text.replace(old, new, 1))
+PY
+}
+
+run_mutation "a listing cell publishes the stored terms again" \
+  sub src/serve.ts '  return superseded
+    ? supersededTermsListingHtml(offer.vendor, superseded)
+    : escHtmlServer(offer.description);' \
+                   '  return escHtmlServer(offer.description);'
+
+run_mutation "structured data publishes the stored terms again" \
+  sub src/serve.ts '  return superseded ? supersededTermsNotice(offer.vendor, superseded) : offer.description;' \
+                   '  return offer.description;'
+
+run_mutation "a short slot truncates the stored terms instead of withholding them" \
+  sub src/serve.ts '  if (superseded) return supersededTermsMetaSentence(offer.vendor, superseded);
+  return offer.description.length > cap ? `${offer.description.slice(0, cap)}...` : offer.description;' \
+                   '  return offer.description.length > cap ? `${offer.description.slice(0, cap)}...` : offer.description;'
+
+run_mutation "an opening sentence comes from the stored terms again" \
+  sub src/serve.ts '  if (superseded) return supersededTermsMetaSentence(offer.vendor, superseded);
+  const opening = offer.description.split(". ").slice(0, sentences).join(". ");' \
+                   '  const opening = offer.description.split(". ").slice(0, sentences).join(". ");'
+
+run_mutation "the vendor FAQ answers from the stored terms again" \
+  sub src/serve.ts '  if (superseded) return supersededTermsVerdictSentence(offer.vendor, superseded);
+  return `${offer.description.slice(0, 200)}${offer.description.length > 200 ? "..." : ""}`;' \
+                   '  return `${offer.description.slice(0, 200)}${offer.description.length > 200 ? "..." : ""}`;'
+
+run_mutation "the change index answers for no vendor" \
+  sub src/serve.ts '  return changesByVendorName.get(vendorName.toLowerCase()) ?? [];' \
+                   '  return [];'
+
+run_mutation "the offer listing stops marking the superseded record" \
+  sub src/data.ts '    const terms_superseded = supersededTermsRecordFor(offer, vendorAllChangesList.get(key) ?? []);' \
+                   '    const terms_superseded = null;'
+
+run_mutation "the single-vendor endpoint returns the raw stored record again" \
+  sub src/data.ts '      ...enrichOffers([match])[0],' \
+                   '      ...withLinkHealth(match), gate: gateForOffer(match), recent_change: null, expires_soon: null, risk_level: null, risk_cause: null, rating_withheld: null, stability: null, days_since_verified: 0, terms_superseded: null,'
+
+run_mutation "the alternatives beside a vendor go back to the raw stored record" \
+  sub src/data.ts '      result.alternatives = enrichOffers(sameCategoryOffers).map(o => stripReferrerValue(o));' \
+                   '      result.alternatives = sameCategoryOffers.map(o => stripReferrerValue({ ...withLinkHealth(o), gate: gateForOffer(o) })) as unknown as EnrichedOffer[];'
+
+run_mutation "the citation counts only gated records as withheld" \
+  sub src/provenance.ts '  return isGated(node) || termsAreWithheld(node) || levelIsWithheld(node);' \
+                   '  return isGated(node);'
+
+run_mutation "the citation ignores a withheld set of terms" \
+  sub src/provenance.ts '  return isGated(node) || termsAreWithheld(node) || levelIsWithheld(node);' \
+                   '  return isGated(node) || levelIsWithheld(node);'
+
+run_mutation "the citation ignores a withheld level" \
+  sub src/provenance.ts '  return isGated(node) || termsAreWithheld(node) || levelIsWithheld(node);' \
+                   '  return isGated(node) || termsAreWithheld(node);'
+
+run_mutation "the citation reads a withheld level only from the rating field" \
+  sub src/provenance.ts '  if (node.rating_withheld !== undefined && node.rating_withheld !== null) return true;
+  return "risk_level" in node && node.risk_level === null;' \
+                   '  return node.rating_withheld !== undefined && node.rating_withheld !== null;'
+
+run_mutation "the marked record drops the reading behind the change" \
+  sub src/superseded-description.ts '    reading: readingBehindTheChange(change),' \
+                   '    reading: null,'
+
+run_mutation "the marked record drops the sentence the vendor page prints" \
+  sub src/superseded-description.ts '    notice: supersededTermsNotice(vendor, change),' \
+                   '    notice: "",'
+
+run_mutation "the category row keeps its lede figure from a superseded record" \
+  sub src/serve.ts '  const topVendor = catOffers.find((o, i) => catGates[i] === null && !supersedingChangeFor(o));' \
+                   '  const topVendor = catOffers.find((_, i) => catGates[i] === null);'
+
+echo
+echo "killed=$killed survived=$survived"

--- a/src/data.ts
+++ b/src/data.ts
@@ -15,6 +15,7 @@ import {
   withheldLevelSentence,
 } from "./source-check.js";
 import { substitutesFor } from "./product-role.js";
+import { supersededTermsRecordFor, type SupersededTermsRecord } from "./superseded-description.js";
 import { isSubSlug, toSlug } from "./slug.js";
 import { DATE_SOURCES, isEventDated, changeDateClause, isoWeekWindow, changesInWindow, discoveryBatchNote, firstReadHeading, type DateWindow } from "./change-dates.js";
 import { PRODUCT_DEPRECATED, deprecationEndsTheListedProduct } from "./product-deprecation.js";
@@ -119,7 +120,7 @@ export function withLinkHealth<T extends Offer>(offer: T): T & { link_unreachabl
 export function getOfferDetails(
   vendorName: string,
   includeAlternatives: boolean = false
-): { offer: OfferWithLinkHealth & { gate: Gate | null; relatedVendors: string[]; alternatives?: Array<OfferWithLinkHealth & { gate: Gate | null }>; tie_break: TieBreak } } | { error: string; suggestions: string[] } {
+): { offer: EnrichedOffer & { relatedVendors: string[]; alternatives?: EnrichedOffer[]; tie_break: TieBreak } } | { error: string; suggestions: string[] } {
   const offers = loadOffers();
   const lowerName = vendorName.toLowerCase();
   const match = offers.find((o) => o.vendor.toLowerCase() === lowerName);
@@ -131,14 +132,13 @@ export function getOfferDetails(
     );
     const sameCategoryOffers = relatedRanking.entries.slice(0, 5).map((e) => e.offer);
     const relatedVendors = sameCategoryOffers.map((o) => o.vendor);
-    const result: OfferWithLinkHealth & { gate: Gate | null; relatedVendors: string[]; alternatives?: Array<OfferWithLinkHealth & { gate: Gate | null }>; tie_break: TieBreak } = {
-      ...withLinkHealth(match),
-      gate: gateForOffer(match),
+    const result: EnrichedOffer & { relatedVendors: string[]; alternatives?: EnrichedOffer[]; tie_break: TieBreak } = {
+      ...enrichOffers([match])[0],
       relatedVendors,
       tie_break: relatedRanking.tie_break,
     };
     if (includeAlternatives) {
-      result.alternatives = sameCategoryOffers.map(o => stripReferrerValue({ ...withLinkHealth(o), gate: gateForOffer(o) }));
+      result.alternatives = enrichOffers(sameCategoryOffers).map(o => stripReferrerValue(o));
     }
     return { offer: stripReferrerValue(result) };
   }
@@ -452,7 +452,9 @@ export function enrichOffers(offers: Offer[]): EnrichedOffer[] {
       (now.getTime() - new Date(offer.verifiedDate).getTime()) / (24 * 60 * 60 * 1000)
     );
 
-    const enriched = { ...offer, recent_change, expires_soon, risk_level, risk_cause, rating_withheld, stability, days_since_verified, link_unreachable, gate: gateFor(offer, servedOn) };
+    const terms_superseded = supersededTermsRecordFor(offer, vendorAllChangesList.get(key) ?? []);
+
+    const enriched = { ...offer, recent_change, expires_soon, risk_level, risk_cause, rating_withheld, stability, days_since_verified, link_unreachable, gate: gateFor(offer, servedOn), terms_superseded };
     return stripReferrerValue(enriched);
   });
 }
@@ -988,7 +990,7 @@ export interface AuditServiceResult {
 
 export interface AuditGap {
   category: string;
-  recommendation: { vendor: string; tier: string; description: string };
+  recommendation: { vendor: string; tier: string; description: string; terms_superseded: SupersededTermsRecord | null };
 }
 
 export interface AuditResult {
@@ -1078,6 +1080,7 @@ export function auditStack(serviceNames: string[]): AuditResult {
             vendor: topFree[0].vendor,
             tier: topFree[0].tier,
             description: topFree[0].description,
+            terms_superseded: supersededTermsRecordFor(topFree[0], loadDealChanges().filter((c) => c.vendor.toLowerCase() === topFree[0].vendor.toLowerCase())),
           },
         });
       }

--- a/src/provenance.ts
+++ b/src/provenance.ts
@@ -33,9 +33,22 @@ function isRecord(node: Record<string, unknown>): boolean {
   return RECORD_FIELDS.some((field) => node[field] !== undefined && node[field] !== null);
 }
 
-function isWithheld(node: Record<string, unknown>): boolean {
+function isGated(node: Record<string, unknown>): boolean {
   const gate = node.gate;
   return typeof gate === "object" && gate !== null && typeof (gate as { code?: unknown }).code === "string";
+}
+
+function termsAreWithheld(node: Record<string, unknown>): boolean {
+  return typeof node.terms_superseded === "object" && node.terms_superseded !== null;
+}
+
+function levelIsWithheld(node: Record<string, unknown>): boolean {
+  if (node.rating_withheld !== undefined && node.rating_withheld !== null) return true;
+  return "risk_level" in node && node.risk_level === null;
+}
+
+function isWithheld(node: Record<string, unknown>): boolean {
+  return isGated(node) || termsAreWithheld(node) || levelIsWithheld(node);
 }
 
 export function citedRecords(payload: unknown): CitedRecord[] {

--- a/src/serve.ts
+++ b/src/serve.ts
@@ -21,7 +21,8 @@ import { LINK_GRACE_DAYS, unreachableNoticeForUrl } from "./link-health.js";
 import { offerEnded, offerRetired, recordedTierSentence, endedHeadline, endedHistorySentence, endedReliabilitySentence, endedEmptyChangeHistorySentence, ENDED_BADGE_LABEL, ENDED_SINCE_CHANGES_SENTENCE, type OfferTierAndUrl } from "./retirement.js";
 import { amountUnstatedSentence, levelWithheldReason, sourceStatesNoAmount, withheldLevelClause, withheldLevelSentence, type LevelWithheldReason } from "./source-check.js";
 import { readingIsBehindTheLoop, reverificationIntervalDays } from "./badge-staleness.js";
-import { SUPERSEDED_TERMS_LABEL, supersededTermsAnswer, supersededTermsMetaSentence, supersededTermsNotice, supersededTermsNoticeHtml, supersededTermsVerdictSentence, supersedingChange } from "./superseded-description.js";
+import { SUPERSEDED_TERMS_LABEL, supersededTermsAnswer, supersededTermsMetaSentence, supersededTermsNotice, supersededTermsNoticeHtml, supersededTermsRecord, supersededTermsVerdictSentence, supersedingChange, type SupersededTermsRecord } from "./superseded-description.js";
+import { changesByVendor } from "./superseded-census.js";
 import { buildComparisonMap, comparisonSlug } from "./comparison-pairs.js";
 import { comparisonVerdictText, freeTierFaqAnswer, stabilityFaqAnswer, type ComparisonSide, type FreeTierSide, type SideFreeTier, type StabilityRating } from "./comparison-verdict.js";
 import { publishedVendorLevel, vendorVerdictSentence, vendorBadge, freeTierClaim, statesRiskCause, narrowingSentence, changeKindNoun, type BadgeWithholding, type VendorVerdictInput } from "./vendor-verdict.js";
@@ -446,6 +447,58 @@ const registrationLimiter = createRegistrationLimiter();
 const offers = loadOffers();
 const categories = getCategories();
 const dealChanges = loadDealChanges();
+
+const changesByVendorName = (() => {
+  const byVendor = changesByVendor(dealChanges);
+  for (const held of byVendor.values()) held.sort((a, b) => b.date.localeCompare(a.date));
+  return byVendor;
+})();
+
+function changesFor(vendorName: string): DealChange[] {
+  return changesByVendorName.get(vendorName.toLowerCase()) ?? [];
+}
+
+type StoredTermsOf = Pick<Offer, "vendor" | "description">;
+
+function supersedingChangeFor(offer: StoredTermsOf): DealChange | null {
+  return supersedingChange(offer, changesFor(offer.vendor));
+}
+
+function publishedTermsText(offer: StoredTermsOf): string {
+  const superseded = supersedingChangeFor(offer);
+  return superseded ? supersededTermsNotice(offer.vendor, superseded) : offer.description;
+}
+
+function supersededTermsListingHtml(vendor: string, change: DealChange): string {
+  return `<strong>${SUPERSEDED_TERMS_LABEL}:</strong> ${supersededTermsNoticeHtml(vendor, change, escHtmlServer)}` +
+    ` <a href="/vendor/${toSlug(vendor)}#changes">Read what we recorded &darr;</a>`;
+}
+
+function publishedTermsHtml(offer: StoredTermsOf): string {
+  const superseded = supersedingChangeFor(offer);
+  return superseded
+    ? supersededTermsListingHtml(offer.vendor, superseded)
+    : escHtmlServer(offer.description);
+}
+
+function publishedTermsSummary(offer: StoredTermsOf, cap: number): string {
+  const superseded = supersedingChangeFor(offer);
+  if (superseded) return supersededTermsMetaSentence(offer.vendor, superseded);
+  return offer.description.length > cap ? `${offer.description.slice(0, cap)}...` : offer.description;
+}
+
+function publishedTermsOpening(offer: StoredTermsOf, sentences: number, cap?: number): string {
+  const superseded = supersedingChangeFor(offer);
+  if (superseded) return supersededTermsMetaSentence(offer.vendor, superseded);
+  const opening = offer.description.split(". ").slice(0, sentences).join(". ");
+  return cap === undefined ? opening : opening.substring(0, cap);
+}
+
+function supersededTermsField(offer: StoredTermsOf): { terms_superseded?: SupersededTermsRecord } {
+  const superseded = supersedingChangeFor(offer);
+  return superseded ? { terms_superseded: supersededTermsRecord(offer.vendor, superseded) } : {};
+}
+
 const stats = {
   offers: offers.length,
   categories: categories.length,
@@ -798,9 +851,7 @@ function vendorVerdictContext(vendorName: string, servedOn: string): VendorVerdi
 
   const primary = vendorOffers[0];
   const enriched = enrichOffers([primary])[0];
-  const vendorChanges = dealChanges
-    .filter(c => c.vendor.toLowerCase() === vendorName.toLowerCase())
-    .sort((a, b) => b.date.localeCompare(a.date));
+  const vendorChanges = changesFor(vendorName);
   const linkUnreachable = enriched.link_unreachable;
   const levelWithheld = levelWithheldReason(primary, linkUnreachable);
   const unconfirmableSince = linkUnreachable?.last_reachable ? ` since ${linkUnreachable.last_reachable}` : "";
@@ -1269,7 +1320,7 @@ function buildCategoryPage(slug: string): string | null {
   const offersHtml = catOffers.map((o) => `        <tr>
           <td style="font-weight:600;color:var(--text);white-space:nowrap"><a href="/vendor/${toSlug(o.vendor)}" style="color:var(--text)">${escHtmlServer(o.vendor)}</a></td>
           <td style="font-family:var(--mono);color:var(--accent);white-space:nowrap">${escHtmlServer(o.tier)}</td>
-          <td style="color:var(--text-muted)">${escHtmlServer(o.description)}${listingEligibilityNoticeHtml(o)}${listingUnreachableNoticeHtml(o)}</td>
+          <td style="color:var(--text-muted)">${publishedTermsHtml(o)}${listingEligibilityNoticeHtml(o)}${listingUnreachableNoticeHtml(o)}</td>
           <td style="font-family:var(--mono);color:var(--text-dim);white-space:nowrap">${escHtmlServer(o.verifiedDate)}</td>
         </tr>`).join("\n");
 
@@ -1303,7 +1354,7 @@ function buildCategoryPage(slug: string): string | null {
     ? `This category has been relatively stable &mdash; only ${catChangeCount} pricing changes recorded across all vendors.`
     : `This category has seen some movement &mdash; ${catChangeCount} pricing changes recorded across vendors.`;
 
-  const topVendor = catOffers.find((_, i) => catGates[i] === null);
+  const topVendor = catOffers.find((o, i) => catGates[i] === null && !supersedingChangeFor(o));
   const keyLimitMatch = topVendor?.description.match(/(\d[\d,]*\s*(?:GB|GiB|MB|TB|requests?|calls?|MAU|users?|emails?|messages?|builds?|minutes?|hours?|projects?|repos?|sites?|apps?|databases?|invocations?|events?))/i);
   const keyLimit = keyLimitMatch ? keyLimitMatch[1] : "a generous free tier";
 
@@ -1403,7 +1454,7 @@ function buildCategoryPage(slug: string): string | null {
       item: {
         "@type": "SoftwareApplication",
         name: o.vendor,
-        description: o.description,
+        description: publishedTermsText(o),
         applicationCategory: categoryName,
         offers: { "@type": "Offer", price: "0", priceCurrency: "USD", description: o.tier },
         ...(offerRetired(o) ? {} : { url: o.url }),
@@ -1636,6 +1687,13 @@ function rankCategory(categoryName: string, date = utcDate()): RankingResult<Enr
 }
 
 function buildBestOfMiniReview(offer: ReturnType<typeof enrichOffers>[number]): string {
+  const caveatFor = (o: ReturnType<typeof enrichOffers>[number]): string =>
+    o.risk_level !== "stable" && o.risk_cause
+      ? ` Note — ${changeDateLabel(o.risk_cause)}: ${escHtmlServer(o.risk_cause.summary)}`
+      : "";
+  const superseded = supersedingChangeFor(offer);
+  if (superseded) return `${supersededTermsListingHtml(offer.vendor, superseded)}${caveatFor(offer)}`;
+
   const bestFor: string[] = [];
   const desc = offer.description.toLowerCase();
   if (desc.includes("hobby") || desc.includes("personal")) bestFor.push("personal projects");
@@ -1644,10 +1702,7 @@ function buildBestOfMiniReview(offer: ReturnType<typeof enrichOffers>[number]): 
   if (desc.includes("student") || desc.includes("education")) bestFor.push("students");
   if (desc.includes("unlimited") || desc.includes("no limit")) bestFor.push("unlimited usage needs");
   const bestForText = bestFor.length > 0 ? ` Best for ${bestFor.join(" and ")}.` : "";
-  const caveat = offer.risk_level !== "stable" && offer.risk_cause
-    ? ` Note — ${changeDateLabel(offer.risk_cause)}: ${escHtmlServer(offer.risk_cause.summary)}`
-    : "";
-  return `${escHtmlServer(offer.description)}${bestForText}${caveat}`;
+  return `${escHtmlServer(offer.description)}${bestForText}${caveatFor(offer)}`;
 }
 
 function renderDisclosures(entry: RankedEntry<EnrichedOfferRow>): string {
@@ -1748,7 +1803,7 @@ function buildBestOfPage(slug: string): string | null {
     return `        <tr>
           <td style="font-weight:600"><a href="/vendor/${toSlug(o.vendor)}" style="color:var(--text)">${escHtmlServer(o.vendor)}</a></td>
           <td style="font-family:var(--mono);color:var(--accent)">${escHtmlServer(o.tier)}</td>
-          <td style="color:var(--text-muted);max-width:300px">${escHtmlServer(o.description.slice(0, 120))}${o.description.length > 120 ? "..." : ""}</td>
+          <td style="color:var(--text-muted);max-width:300px">${escHtmlServer(publishedTermsSummary(o, 120))}</td>
           <td>${riskCellHtml(o.risk_level, o.risk_cause)}</td>
           <td style="font-family:var(--mono);color:var(--text-dim)">${escHtmlServer(o.verifiedDate)}</td>
         </tr>`;
@@ -1766,7 +1821,7 @@ function buildBestOfPage(slug: string): string | null {
       item: {
         "@type": "SoftwareApplication",
         name: e.offer.vendor,
-        description: e.offer.description,
+        description: publishedTermsText(e.offer),
         applicationCategory: categoryName,
         offers: { "@type": "Offer", price: "0", priceCurrency: "USD", description: e.offer.tier },
         ...(offerRetired(e.offer) ? {} : { url: e.offer.url }),
@@ -2998,8 +3053,8 @@ ${editorialVs.map(p => `      <a href="/${p.slug}" class="related-card">${escHtm
 
   const faqItems = [
     { q: `Is ${a.vendor} or ${b.vendor} better for free tier?`, a: config.verdict },
-    { q: `What is ${a.vendor}'s free tier?`, a: `${a.vendor} offers a ${a.tier} plan: ${a.description.substring(0, 200)}${a.description.length > 200 ? "..." : ""}` },
-    { q: `What is ${b.vendor}'s free tier?`, a: `${b.vendor} offers a ${b.tier} plan: ${b.description.substring(0, 200)}${b.description.length > 200 ? "..." : ""}` },
+    { q: `What is ${a.vendor}'s free tier?`, a: `${a.vendor} offers a ${a.tier} plan: ${storedTermsOf(a)}` },
+    { q: `What is ${b.vendor}'s free tier?`, a: `${b.vendor} offers a ${b.tier} plan: ${storedTermsOf(b)}` },
     { q: `Should I choose ${a.vendor} or ${b.vendor}?`, a: config.recommendation.replace(/<[^>]*>/g, " ").replace(/\s+/g, " ").trim() },
   ];
 
@@ -3100,7 +3155,7 @@ ${globalNavCss()}
       <div class="detail-row"><span class="detail-label">Verified</span><span class="detail-value">${escHtmlServer(a.verifiedDate)}</span></div>
       <div class="detail-row"><span class="detail-label">Stability</span><span class="detail-value">${escHtmlServer(riskA.stability ?? "stable")}</span></div>
       <div class="detail-row"><span class="detail-label">Changes</span><span class="detail-value">${a.deal_changes.length} recorded</span></div>
-      <div class="desc-block">${escHtmlServer(a.description)}</div>
+      <div class="desc-block">${publishedTermsHtml(a)}</div>
     </div>
     <div class="vendor-col">
       <h3><a href="/vendor/${toSlug(b.vendor)}">${escHtmlServer(b.vendor)}</a> ${riskBadge(riskB)} ${stabilityBadge(riskB.stability ?? "stable")}</h3>
@@ -3109,7 +3164,7 @@ ${globalNavCss()}
       <div class="detail-row"><span class="detail-label">Verified</span><span class="detail-value">${escHtmlServer(b.verifiedDate)}</span></div>
       <div class="detail-row"><span class="detail-label">Stability</span><span class="detail-value">${escHtmlServer(riskB.stability ?? "stable")}</span></div>
       <div class="detail-row"><span class="detail-label">Changes</span><span class="detail-value">${b.deal_changes.length} recorded</span></div>
-      <div class="desc-block">${escHtmlServer(b.description)}</div>
+      <div class="desc-block">${publishedTermsHtml(b)}</div>
     </div>
   </div>
 
@@ -3856,7 +3911,9 @@ function curatedAltsNote(vendorName: string): string {
   return `These alternatives were identified from ${escHtmlServer(vendorName)}&rsquo;s pricing changes as recommended replacements.`;
 }
 
-function storedTermsOf(offer: Pick<Offer, "description">): string {
+function storedTermsOf(offer: StoredTermsOf): string {
+  const superseded = supersedingChangeFor(offer);
+  if (superseded) return supersededTermsVerdictSentence(offer.vendor, superseded);
   return `${offer.description.slice(0, 200)}${offer.description.length > 200 ? "..." : ""}`;
 }
 
@@ -4759,7 +4816,7 @@ ${renderAuditBlock(altRanking.tie_break)}
       item: {
         "@type": "SoftwareApplication",
         name: a.vendor,
-        description: a.description,
+        description: publishedTermsText(a),
         applicationCategory: a.category,
         url: a.url,
         offers: { "@type": "Offer", price: "0", priceCurrency: "USD", description: a.tier },
@@ -7087,7 +7144,7 @@ function buildTimelyAlternativesPage(slug: string): string | null {
           <span class="alt-card-tier">${escHtmlServer(o.tier)}</span>
           ${riskBadge}
         </div>
-        <p class="alt-card-desc">${escHtmlServer(o.description)}</p>
+        <p class="alt-card-desc">${publishedTermsHtml(o)}</p>
         <div class="alt-card-links">
           <a href="/vendor/${toSlug(o.vendor)}">Full profile</a>
           <a href="/alternative-to/${toSlug(o.vendor)}">More alternatives</a>
@@ -7108,7 +7165,7 @@ function buildTimelyAlternativesPage(slug: string): string | null {
           <span class="alt-card-tier">${escHtmlServer(o.tier)}</span>
           ${riskBadge}
         </div>
-        <p class="alt-card-desc">${escHtmlServer(o.description)}</p>
+        <p class="alt-card-desc">${publishedTermsHtml(o)}</p>
         <div class="alt-card-links">
           <a href="/vendor/${toSlug(o.vendor)}">Full profile</a>
           ${offerPricingLink(o, "Pricing page &nearr;")}
@@ -7121,7 +7178,7 @@ function buildTimelyAlternativesPage(slug: string): string | null {
   const tableRows = allAlts.map((o) => `        <tr>
           <td style="font-weight:600"><a href="/vendor/${toSlug(o.vendor)}" style="color:var(--text)">${escHtmlServer(o.vendor)}</a></td>
           <td style="font-family:var(--mono);color:var(--accent)">${escHtmlServer(o.tier)}</td>
-          <td style="color:var(--text-muted);max-width:300px">${escHtmlServer(o.description.slice(0, 120))}${o.description.length > 120 ? "..." : ""}</td>
+          <td style="color:var(--text-muted);max-width:300px">${escHtmlServer(publishedTermsSummary(o, 120))}</td>
           <td>${riskCellHtml(o.risk_level, o.risk_cause)}</td>
         </tr>`).join("\n");
 
@@ -7137,7 +7194,7 @@ function buildTimelyAlternativesPage(slug: string): string | null {
       item: {
         "@type": "SoftwareApplication",
         name: o.vendor,
-        description: o.description,
+        description: publishedTermsText(o),
         offers: { "@type": "Offer", price: "0", priceCurrency: "USD", description: o.tier },
         ...(offerRetired(o) ? {} : { url: o.url }),
       },
@@ -8204,7 +8261,7 @@ function buildEventPage(slug: string): string | null {
       return '<tr>'
         + '<td><a href="/vendor/' + vendorSlug + '">' + escHtmlServer(o.vendor) + '</a></td>'
         + '<td>' + escHtmlServer(o.tier) + '</td>'
-        + '<td>' + escHtmlServer(o.description.slice(0, 100)) + (o.description.length > 100 ? "..." : "") + '</td>'
+        + '<td>' + escHtmlServer(publishedTermsSummary(o, 100)) + '</td>'
         + '<td>' + riskCellHtml(o.risk_level, o.risk_cause) + '</td>'
         + '<td>' + o.verifiedDate + '</td>'
         + '</tr>';
@@ -8828,7 +8885,7 @@ function buildAiFreeTiersPage(): string {
           <span class="alt-card-tier">${escHtmlServer(o.tier)}</span>
           ${riskBadge}
         </div>
-        <p class="alt-card-desc">${escHtmlServer(o.description)}</p>
+        <p class="alt-card-desc">${publishedTermsHtml(o)}</p>
         <div class="alt-card-links">
           <a href="/vendor/${toSlug(o.vendor)}">Full profile</a>
           <a href="/alternative-to/${toSlug(o.vendor)}">Alternatives</a>
@@ -8863,7 +8920,7 @@ function buildAiFreeTiersPage(): string {
       item: {
         "@type": "SoftwareApplication",
         name: o.vendor,
-        description: o.description,
+        description: publishedTermsText(o),
         offers: { "@type": "Offer", price: "0", priceCurrency: "USD", description: o.tier },
         ...(offerRetired(o) ? {} : { url: o.url }),
       },
@@ -9085,7 +9142,7 @@ function buildHostingAlternativesPage(): string {
           <span class="alt-card-tier">${escHtmlServer(o.tier)}</span>
           ${riskBadge}
         </div>
-        <p class="alt-card-desc">${escHtmlServer(o.description)}</p>
+        <p class="alt-card-desc">${publishedTermsHtml(o)}</p>
         <div class="alt-card-links">
           <a href="/vendor/${toSlug(o.vendor)}">Full profile</a>
           <a href="/alternative-to/${toSlug(o.vendor)}">Alternatives</a>
@@ -9118,7 +9175,7 @@ function buildHostingAlternativesPage(): string {
       item: {
         "@type": "SoftwareApplication",
         name: o.vendor,
-        description: o.description,
+        description: publishedTermsText(o),
         offers: { "@type": "Offer", price: "0", priceCurrency: "USD", description: o.tier },
         ...(offerRetired(o) ? {} : { url: o.url }),
       },
@@ -9423,7 +9480,7 @@ function buildDatabaseAlternativesPage(): string {
           <span class="alt-card-tier">${escHtmlServer(o.tier)}</span>
           ${riskBadge}
         </div>
-        <p class="alt-card-desc">${escHtmlServer(o.description)}</p>
+        <p class="alt-card-desc">${publishedTermsHtml(o)}</p>
         <div class="alt-card-links">
           <a href="/vendor/${toSlug(o.vendor)}">Full profile</a>
           <a href="/alternative-to/${toSlug(o.vendor)}">Alternatives</a>
@@ -9456,7 +9513,7 @@ function buildDatabaseAlternativesPage(): string {
       item: {
         "@type": "SoftwareApplication",
         name: o.vendor,
-        description: o.description,
+        description: publishedTermsText(o),
         offers: { "@type": "Offer", price: "0", priceCurrency: "USD", description: o.tier },
         ...(offerRetired(o) ? {} : { url: o.url }),
       },
@@ -9762,7 +9819,7 @@ function buildMonitoringAlternativesPage(): string {
           <span class="alt-card-tier">${escHtmlServer(o.tier)}</span>
           ${riskBadge}
         </div>
-        <p class="alt-card-desc">${escHtmlServer(o.description)}</p>
+        <p class="alt-card-desc">${publishedTermsHtml(o)}</p>
         <div class="alt-card-links">
           <a href="/vendor/${toSlug(o.vendor)}">Full profile</a>
           <a href="/alternative-to/${toSlug(o.vendor)}">Alternatives</a>
@@ -9795,7 +9852,7 @@ function buildMonitoringAlternativesPage(): string {
       item: {
         "@type": "SoftwareApplication",
         name: o.vendor,
-        description: o.description,
+        description: publishedTermsText(o),
         offers: { "@type": "Offer", price: "0", priceCurrency: "USD", description: o.tier },
         ...(offerRetired(o) ? {} : { url: o.url }),
       },
@@ -10090,7 +10147,7 @@ function buildCiCdAlternativesPage(): string {
           <span class="alt-card-tier">${escHtmlServer(o.tier)}</span>
           ${riskBadge}
         </div>
-        <p class="alt-card-desc">${escHtmlServer(o.description)}</p>
+        <p class="alt-card-desc">${publishedTermsHtml(o)}</p>
         <div class="alt-card-links">
           <a href="/vendor/${toSlug(o.vendor)}">Full profile</a>
           <a href="/alternative-to/${toSlug(o.vendor)}">Alternatives</a>
@@ -10123,7 +10180,7 @@ function buildCiCdAlternativesPage(): string {
       item: {
         "@type": "SoftwareApplication",
         name: o.vendor,
-        description: o.description,
+        description: publishedTermsText(o),
         offers: { "@type": "Offer", price: "0", priceCurrency: "USD", description: o.tier },
         ...(offerRetired(o) ? {} : { url: o.url }),
       },
@@ -10412,7 +10469,7 @@ function buildSecurityAlternativesPage(): string {
           <span class="alt-card-tier">${escHtmlServer(o.tier)}</span>
           ${riskBadge}
         </div>
-        <p class="alt-card-desc">${escHtmlServer(o.description)}</p>
+        <p class="alt-card-desc">${publishedTermsHtml(o)}</p>
         <div class="alt-card-links">
           <a href="/vendor/${toSlug(o.vendor)}">Full profile</a>
           <a href="/alternative-to/${toSlug(o.vendor)}">Alternatives</a>
@@ -10445,7 +10502,7 @@ function buildSecurityAlternativesPage(): string {
       item: {
         "@type": "SoftwareApplication",
         name: o.vendor,
-        description: o.description,
+        description: publishedTermsText(o),
         offers: { "@type": "Offer", price: "0", priceCurrency: "USD", description: o.tier },
         ...(offerRetired(o) ? {} : { url: o.url }),
       },
@@ -10749,7 +10806,7 @@ function buildTestingAlternativesPage(): string {
           <span class="alt-card-tier">${escHtmlServer(o.tier)}</span>
           ${riskBadge}
         </div>
-        <p class="alt-card-desc">${escHtmlServer(o.description)}</p>
+        <p class="alt-card-desc">${publishedTermsHtml(o)}</p>
         <div class="alt-card-links">
           <a href="/vendor/${toSlug(o.vendor)}">Full profile</a>
           <a href="/alternative-to/${toSlug(o.vendor)}">Alternatives</a>
@@ -10782,7 +10839,7 @@ function buildTestingAlternativesPage(): string {
       item: {
         "@type": "SoftwareApplication",
         name: o.vendor,
-        description: o.description,
+        description: publishedTermsText(o),
         offers: { "@type": "Offer", price: "0", priceCurrency: "USD", description: o.tier },
         ...(offerRetired(o) ? {} : { url: o.url }),
       },
@@ -11070,7 +11127,7 @@ function buildStorageAlternativesPage(): string {
           <span class="alt-card-tier">${escHtmlServer(o.tier)}</span>
           ${riskBadge}
         </div>
-        <p class="alt-card-desc">${escHtmlServer(o.description)}</p>
+        <p class="alt-card-desc">${publishedTermsHtml(o)}</p>
         <div class="alt-card-links">
           <a href="/vendor/${toSlug(o.vendor)}">Full profile</a>
           <a href="/alternative-to/${toSlug(o.vendor)}">Alternatives</a>
@@ -11103,7 +11160,7 @@ function buildStorageAlternativesPage(): string {
       item: {
         "@type": "SoftwareApplication",
         name: o.vendor,
-        description: o.description,
+        description: publishedTermsText(o),
         offers: { "@type": "Offer", price: "0", priceCurrency: "USD", description: o.tier },
         ...(offerRetired(o) ? {} : { url: o.url }),
       },
@@ -11382,7 +11439,7 @@ function buildAnalyticsAlternativesPage(): string {
           <span class="alt-card-tier">${escHtmlServer(o.tier)}</span>
           ${riskBadge}
         </div>
-        <p class="alt-card-desc">${escHtmlServer(o.description)}</p>
+        <p class="alt-card-desc">${publishedTermsHtml(o)}</p>
         <div class="alt-card-links">
           <a href="/vendor/${toSlug(o.vendor)}">Full profile</a>
           <a href="/alternative-to/${toSlug(o.vendor)}">Alternatives</a>
@@ -11415,7 +11472,7 @@ function buildAnalyticsAlternativesPage(): string {
       item: {
         "@type": "SoftwareApplication",
         name: o.vendor,
-        description: o.description,
+        description: publishedTermsText(o),
         offers: { "@type": "Offer", price: "0", priceCurrency: "USD", description: o.tier },
         ...(offerRetired(o) ? {} : { url: o.url }),
       },
@@ -11698,7 +11755,7 @@ function buildAiMlAlternativesPage(): string {
           <span class="alt-card-tier">${escHtmlServer(o.tier)}</span>
           ${riskBadge}
         </div>
-        <p class="alt-card-desc">${escHtmlServer(o.description)}</p>
+        <p class="alt-card-desc">${publishedTermsHtml(o)}</p>
         <div class="alt-card-links">
           <a href="/vendor/${toSlug(o.vendor)}">Full profile</a>
           <a href="/alternative-to/${toSlug(o.vendor)}">Alternatives</a>
@@ -11731,7 +11788,7 @@ function buildAiMlAlternativesPage(): string {
       item: {
         "@type": "SoftwareApplication",
         name: o.vendor,
-        description: o.description,
+        description: publishedTermsText(o),
         offers: { "@type": "Offer", price: "0", priceCurrency: "USD", description: o.tier },
         ...(offerRetired(o) ? {} : { url: o.url }),
       },
@@ -12020,7 +12077,7 @@ function buildEmailAlternativesPage(): string {
           <span class="alt-card-tier">${escHtmlServer(o.tier)}</span>
           ${riskBadge}
         </div>
-        <p class="alt-card-desc">${escHtmlServer(o.description)}</p>
+        <p class="alt-card-desc">${publishedTermsHtml(o)}</p>
         <div class="alt-card-links">
           <a href="/vendor/${toSlug(o.vendor)}">Full profile</a>
           <a href="/alternative-to/${toSlug(o.vendor)}">Alternatives</a>
@@ -12053,7 +12110,7 @@ function buildEmailAlternativesPage(): string {
       item: {
         "@type": "SoftwareApplication",
         name: o.vendor,
-        description: o.description,
+        description: publishedTermsText(o),
         offers: { "@type": "Offer", price: "0", priceCurrency: "USD", description: o.tier },
         ...(offerRetired(o) ? {} : { url: o.url }),
       },
@@ -12353,7 +12410,7 @@ function buildDesignAlternativesPage(): string {
           <span class="alt-card-tier">${escHtmlServer(o.tier)}</span>
           ${riskBadge}
         </div>
-        <p class="alt-card-desc">${escHtmlServer(o.description)}</p>
+        <p class="alt-card-desc">${publishedTermsHtml(o)}</p>
         <div class="alt-card-links">
           <a href="/vendor/${toSlug(o.vendor)}">Full profile</a>
           <a href="/alternative-to/${toSlug(o.vendor)}">Alternatives</a>
@@ -12386,7 +12443,7 @@ function buildDesignAlternativesPage(): string {
       item: {
         "@type": "SoftwareApplication",
         name: o.vendor,
-        description: o.description,
+        description: publishedTermsText(o),
         offers: { "@type": "Offer", price: "0", priceCurrency: "USD", description: o.tier },
         ...(offerRetired(o) ? {} : { url: o.url }),
       },
@@ -12690,7 +12747,7 @@ function buildProjectManagementAlternativesPage(): string {
           <span class="alt-card-tier">${escHtmlServer(o.tier)}</span>
           ${riskBadge}
         </div>
-        <p class="alt-card-desc">${escHtmlServer(o.description)}</p>
+        <p class="alt-card-desc">${publishedTermsHtml(o)}</p>
         <div class="alt-card-links">
           <a href="/vendor/${toSlug(o.vendor)}">Full profile</a>
           <a href="/alternative-to/${toSlug(o.vendor)}">Alternatives</a>
@@ -12723,7 +12780,7 @@ function buildProjectManagementAlternativesPage(): string {
       item: {
         "@type": "SoftwareApplication",
         name: o.vendor,
-        description: o.description,
+        description: publishedTermsText(o),
         offers: { "@type": "Offer", price: "0", priceCurrency: "USD", description: o.tier },
         ...(offerRetired(o) ? {} : { url: o.url }),
       },
@@ -13018,7 +13075,7 @@ function buildIdeCodeEditorsAlternativesPage(): string {
           <span class="alt-card-tier">${escHtmlServer(o.tier)}</span>
           ${riskBadge}
         </div>
-        <p class="alt-card-desc">${escHtmlServer(o.description)}</p>
+        <p class="alt-card-desc">${publishedTermsHtml(o)}</p>
         <div class="alt-card-links">
           <a href="/vendor/${toSlug(o.vendor)}">Full profile</a>
           <a href="/alternative-to/${toSlug(o.vendor)}">Alternatives</a>
@@ -13051,7 +13108,7 @@ function buildIdeCodeEditorsAlternativesPage(): string {
       item: {
         "@type": "SoftwareApplication",
         name: o.vendor,
-        description: o.description,
+        description: publishedTermsText(o),
         offers: { "@type": "Offer", price: "0", priceCurrency: "USD", description: o.tier },
         ...(offerRetired(o) ? {} : { url: o.url }),
       },
@@ -13327,7 +13384,7 @@ function buildFreeLlmApisPage(): string {
           <span class="alt-card-tier">${escHtmlServer(o.tier)}</span>
           ${riskBadge}
         </div>
-        <p class="alt-card-desc">${escHtmlServer(o.description)}</p>
+        <p class="alt-card-desc">${publishedTermsHtml(o)}</p>
         <div class="alt-card-links">
           <a href="/vendor/${toSlug(o.vendor)}">Full profile</a>
           <a href="/alternative-to/${toSlug(o.vendor)}">Alternatives</a>
@@ -13360,7 +13417,7 @@ function buildFreeLlmApisPage(): string {
       item: {
         "@type": "SoftwareApplication",
         name: o.vendor,
-        description: o.description,
+        description: publishedTermsText(o),
         offers: { "@type": "Offer", price: "0", priceCurrency: "USD", description: o.tier },
         ...(offerRetired(o) ? {} : { url: o.url }),
       },
@@ -13645,7 +13702,7 @@ function buildApiDevelopmentAlternativesPage(): string {
           <span class="alt-card-tier">${escHtmlServer(o.tier)}</span>
           ${riskBadge}
         </div>
-        <p class="alt-card-desc">${escHtmlServer(o.description)}</p>
+        <p class="alt-card-desc">${publishedTermsHtml(o)}</p>
         <div class="alt-card-links">
           <a href="/vendor/${toSlug(o.vendor)}">Full profile</a>
           <a href="/alternative-to/${toSlug(o.vendor)}">Alternatives</a>
@@ -13678,7 +13735,7 @@ function buildApiDevelopmentAlternativesPage(): string {
       item: {
         "@type": "SoftwareApplication",
         name: o.vendor,
-        description: o.description,
+        description: publishedTermsText(o),
         offers: { "@type": "Offer", price: "0", priceCurrency: "USD", description: o.tier },
         ...(offerRetired(o) ? {} : { url: o.url }),
       },
@@ -13960,7 +14017,7 @@ function buildTeamCollaborationAlternativesPage(): string {
           <span class="alt-card-tier">${escHtmlServer(o.tier)}</span>
           ${riskBadge}
         </div>
-        <p class="alt-card-desc">${escHtmlServer(o.description)}</p>
+        <p class="alt-card-desc">${publishedTermsHtml(o)}</p>
         <div class="alt-card-links">
           <a href="/vendor/${toSlug(o.vendor)}">Full profile</a>
           <a href="/alternative-to/${toSlug(o.vendor)}">Alternatives</a>
@@ -13993,7 +14050,7 @@ function buildTeamCollaborationAlternativesPage(): string {
       item: {
         "@type": "SoftwareApplication",
         name: o.vendor,
-        description: o.description,
+        description: publishedTermsText(o),
         offers: { "@type": "Offer", price: "0", priceCurrency: "USD", description: o.tier },
         ...(offerRetired(o) ? {} : { url: o.url }),
       },
@@ -14364,7 +14421,7 @@ function buildFreeStartupStackPage(): string {
           ${riskBadgeHtml(rec.risk_level, rec.risk_cause, { compact: true, margin: false })}
         </div>
         <p class="pick-why">${escHtmlServer(cat.recommended.why)}</p>
-        <p class="pick-limits">${escHtmlServer(rec.description.split(". ").slice(0, 2).join(". "))}</p>
+        <p class="pick-limits">${escHtmlServer(publishedTermsOpening(rec, 2))}</p>
         <div class="pick-links">
           <a href="/vendor/${toSlug(rec.vendor)}">Full profile</a>
           <a href="/alternative-to/${toSlug(rec.vendor)}">Alternatives</a>
@@ -14413,7 +14470,7 @@ function buildFreeStartupStackPage(): string {
 
   const tableRows = stackCategories.map(cat => {
     const rec = resolveVendor(cat.recommended.vendor);
-    const limits = rec ? rec.description.split(". ")[0].substring(0, 80) : "—";
+    const limits = rec ? publishedTermsOpening(rec, 1, 80) : "—";
     const riskBadge = rec ? riskCellHtml(rec.risk_level, rec.risk_cause) : riskCellHtml("stable", null);
     return `      <tr>
         <td style="font-weight:600">${cat.icon} ${escHtmlServer(cat.name)}</td>
@@ -14677,7 +14734,7 @@ function buildFreeAiStackPage(): string {
           ${riskBadgeHtml(rec.risk_level, rec.risk_cause, { compact: true, margin: false })}
         </div>
         <p class="pick-why">${escHtmlServer(cat.recommended.why)}</p>
-        <p class="pick-limits">${escHtmlServer(rec.description.split(". ").slice(0, 2).join(". "))}</p>
+        <p class="pick-limits">${escHtmlServer(publishedTermsOpening(rec, 2))}</p>
         <div class="pick-links">
           <a href="/vendor/${toSlug(rec.vendor)}">Full profile</a>
           <a href="/alternative-to/${toSlug(rec.vendor)}">Alternatives</a>
@@ -14726,7 +14783,7 @@ function buildFreeAiStackPage(): string {
 
   const tableRows = stackCategories.map(cat => {
     const rec = resolveVendor(cat.recommended.vendor);
-    const limits = rec ? rec.description.split(". ")[0].substring(0, 80) : "—";
+    const limits = rec ? publishedTermsOpening(rec, 1, 80) : "—";
     const riskBadge = rec ? riskCellHtml(rec.risk_level, rec.risk_cause) : riskCellHtml("stable", null);
     return `      <tr>
         <td style="font-weight:600">${cat.icon} ${escHtmlServer(cat.name)}</td>
@@ -15027,7 +15084,7 @@ function buildFreeDevopsStackPage(): string {
           ${riskBadgeHtml(rec.risk_level, rec.risk_cause, { compact: true, margin: false })}
         </div>
         <p class="pick-why">${escHtmlServer(cat.recommended.why)}</p>
-        <p class="pick-limits">${escHtmlServer(rec.description.split(". ").slice(0, 2).join(". "))}</p>
+        <p class="pick-limits">${escHtmlServer(publishedTermsOpening(rec, 2))}</p>
         <div class="pick-links">
           <a href="/vendor/${toSlug(rec.vendor)}">Full profile</a>
           <a href="/alternative-to/${toSlug(rec.vendor)}">Alternatives</a>
@@ -15076,7 +15133,7 @@ function buildFreeDevopsStackPage(): string {
 
   const tableRows = stackCategories.map(cat => {
     const rec = resolveVendor(cat.recommended.vendor);
-    const limits = rec ? rec.description.split(". ")[0].substring(0, 80) : "—";
+    const limits = rec ? publishedTermsOpening(rec, 1, 80) : "—";
     const riskBadge = rec ? riskCellHtml(rec.risk_level, rec.risk_cause) : riskCellHtml("stable", null);
     return `      <tr>
         <td style="font-weight:600">${cat.icon} ${escHtmlServer(cat.name)}</td>
@@ -15378,7 +15435,7 @@ function buildFreeFrontendStackPage(): string {
           ${riskBadgeHtml(rec.risk_level, rec.risk_cause, { compact: true, margin: false })}
         </div>
         <p class="pick-why">${escHtmlServer(cat.recommended.why)}</p>
-        <p class="pick-limits">${escHtmlServer(rec.description.split(". ").slice(0, 2).join(". "))}</p>
+        <p class="pick-limits">${escHtmlServer(publishedTermsOpening(rec, 2))}</p>
         <div class="pick-links">
           <a href="/vendor/${toSlug(rec.vendor)}">Full profile</a>
           <a href="/alternative-to/${toSlug(rec.vendor)}">Alternatives</a>
@@ -15427,7 +15484,7 @@ function buildFreeFrontendStackPage(): string {
 
   const tableRows = stackCategories.map(cat => {
     const rec = resolveVendor(cat.recommended.vendor);
-    const limits = rec ? rec.description.split(". ")[0].substring(0, 80) : "—";
+    const limits = rec ? publishedTermsOpening(rec, 1, 80) : "—";
     const riskBadge = rec ? riskCellHtml(rec.risk_level, rec.risk_cause) : riskCellHtml("stable", null);
     return `      <tr>
         <td style="font-weight:600">${cat.icon} ${escHtmlServer(cat.name)}</td>
@@ -15746,7 +15803,7 @@ function buildFreeNextjsStackPage(): string {
           ${riskBadgeHtml(rec.risk_level, rec.risk_cause, { compact: true, margin: false })}
         </div>
         <p class="pick-why">${escHtmlServer(cat.recommended.why)}</p>
-        <p class="pick-limits">${escHtmlServer(rec.description.split(". ").slice(0, 2).join(". "))}</p>
+        <p class="pick-limits">${escHtmlServer(publishedTermsOpening(rec, 2))}</p>
         <div class="pick-links">
           <a href="/vendor/${toSlug(rec.vendor)}">Full profile</a>
           <a href="/alternative-to/${toSlug(rec.vendor)}">Alternatives</a>
@@ -15801,7 +15858,7 @@ function buildFreeNextjsStackPage(): string {
 
   const tableRows = stackCategories.map(cat => {
     const rec = resolveVendor(cat.recommended.vendor);
-    const limits = rec ? rec.description.split(". ")[0].substring(0, 80) : "—";
+    const limits = rec ? publishedTermsOpening(rec, 1, 80) : "—";
     const riskBadge = rec ? riskCellHtml(rec.risk_level, rec.risk_cause) : riskCellHtml("stable", null);
     return `      <tr>
         <td style="font-weight:600">${cat.icon} ${escHtmlServer(cat.name)}</td>
@@ -16142,7 +16199,7 @@ function buildFreeDjangoStackPage(): string {
           ${riskBadgeHtml(rec.risk_level, rec.risk_cause, { compact: true, margin: false })}
         </div>
         <p class="pick-why">${escHtmlServer(cat.recommended.why)}</p>
-        <p class="pick-limits">${escHtmlServer(rec.description.split(". ").slice(0, 2).join(". "))}</p>
+        <p class="pick-limits">${escHtmlServer(publishedTermsOpening(rec, 2))}</p>
         <div class="pick-links">
           <a href="/vendor/${toSlug(rec.vendor)}">Full profile</a>
           <a href="/alternative-to/${toSlug(rec.vendor)}">Alternatives</a>
@@ -16216,7 +16273,7 @@ function buildFreeDjangoStackPage(): string {
   const tableRows = stackCategories.map(cat => {
     const rec = resolveVendor(cat.recommended.vendor);
     const vendorName = cat.recommended.vendor;
-    const limits = rec ? rec.description.split(". ")[0].substring(0, 80) : vendorName === "Django Built-in Auth" ? "Unlimited — included in Django" : "—";
+    const limits = rec ? publishedTermsOpening(rec, 1, 80) : vendorName === "Django Built-in Auth" ? "Unlimited — included in Django" : "—";
     const riskBadge = rec ? riskCellHtml(rec.risk_level, rec.risk_cause) : riskCellHtml("stable", null);
     const vendorLink = rec ? `<a href="/vendor/${toSlug(rec.vendor)}" style="color:var(--text);font-weight:600">${escHtmlServer(vendorName)}</a>` : `<span style="font-weight:600">${escHtmlServer(vendorName)}</span>`;
     return `      <tr>
@@ -16578,7 +16635,7 @@ function buildFreeFastapiStackPage(): string {
           ${riskBadgeHtml(rec.risk_level, rec.risk_cause, { compact: true, margin: false })}
         </div>
         <p class="pick-why">${escHtmlServer(cat.recommended.why)}</p>
-        <p class="pick-limits">${escHtmlServer(rec.description.split(". ").slice(0, 2).join(". "))}</p>
+        <p class="pick-limits">${escHtmlServer(publishedTermsOpening(rec, 2))}</p>
         <div class="pick-links">
           <a href="/vendor/${toSlug(rec.vendor)}">Full profile</a>
           <a href="/alternative-to/${toSlug(rec.vendor)}">Alternatives</a>
@@ -16652,7 +16709,7 @@ function buildFreeFastapiStackPage(): string {
   const tableRows = stackCategories.map(cat => {
     const rec = resolveVendor(cat.recommended.vendor);
     const vendorName = cat.recommended.vendor;
-    const limits = rec ? rec.description.split(". ")[0].substring(0, 80) : vendorName === "FastAPI Built-in" ? "Unlimited — built into FastAPI" : "—";
+    const limits = rec ? publishedTermsOpening(rec, 1, 80) : vendorName === "FastAPI Built-in" ? "Unlimited — built into FastAPI" : "—";
     const riskBadge = rec ? riskCellHtml(rec.risk_level, rec.risk_cause) : riskCellHtml("stable", null);
     const vendorLink = rec ? `<a href="/vendor/${toSlug(rec.vendor)}" style="color:var(--text);font-weight:600">${escHtmlServer(vendorName)}</a>` : `<span style="font-weight:600">${escHtmlServer(vendorName)}</span>`;
     return `      <tr>
@@ -17031,7 +17088,7 @@ function buildFreeGoStackPage(): string {
           ${riskBadgeHtml(rec.risk_level, rec.risk_cause, { compact: true, margin: false })}
         </div>
         <p class="pick-why">${escHtmlServer(cat.recommended.why)}</p>
-        <p class="pick-limits">${escHtmlServer(rec.description.split(". ").slice(0, 2).join(". "))}</p>
+        <p class="pick-limits">${escHtmlServer(publishedTermsOpening(rec, 2))}</p>
         <div class="pick-links">
           <a href="/vendor/${toSlug(rec.vendor)}">Full profile</a>
           <a href="/alternative-to/${toSlug(rec.vendor)}">Alternatives</a>
@@ -17105,7 +17162,7 @@ function buildFreeGoStackPage(): string {
   const tableRows = stackCategories.map(cat => {
     const rec = resolveVendor(cat.recommended.vendor);
     const vendorName = cat.recommended.vendor;
-    const limits = rec ? rec.description.split(". ")[0].substring(0, 80) : (vendorName === "Go Goroutines" ? "Unlimited — built into Go runtime" : vendorName === "swaggo/swag" ? "Open source — generates from comments" : "—");
+    const limits = rec ? publishedTermsOpening(rec, 1, 80) : (vendorName === "Go Goroutines" ? "Unlimited — built into Go runtime" : vendorName === "swaggo/swag" ? "Open source — generates from comments" : "—");
     const riskBadge = rec ? riskCellHtml(rec.risk_level, rec.risk_cause) : riskCellHtml("stable", null);
     const vendorLink = rec ? `<a href="/vendor/${toSlug(rec.vendor)}" style="color:var(--text);font-weight:600">${escHtmlServer(vendorName)}</a>` : `<span style="font-weight:600">${escHtmlServer(vendorName)}</span>`;
     return `      <tr>
@@ -17518,7 +17575,7 @@ function buildFreeSaasStackPage(): string {
           ${riskBadgeHtml(rec.risk_level, rec.risk_cause, { compact: true, margin: false })}
         </div>
         <p class="pick-why">${escHtmlServer(cat.recommended.why)}</p>
-        <p class="pick-limits">${escHtmlServer(rec.description.split(". ").slice(0, 2).join(". "))}</p>
+        <p class="pick-limits">${escHtmlServer(publishedTermsOpening(rec, 2))}</p>
         <div class="pick-links">
           <a href="/vendor/${toSlug(rec.vendor)}">Full profile</a>
           <a href="/alternative-to/${toSlug(rec.vendor)}">Alternatives</a>
@@ -17592,7 +17649,7 @@ function buildFreeSaasStackPage(): string {
   const tableRows = stackCategories.filter(c => !c.isFrameworkSection).map(cat => {
     const rec = resolveVendor(cat.recommended.vendor);
     const vendorName = cat.recommended.vendor;
-    const limits = rec ? rec.description.split(". ")[0].substring(0, 80) : (vendorName === "Stripe" ? "No monthly fee \u2014 2.9% + 30\u00a2/txn" : "\u2014");
+    const limits = rec ? publishedTermsOpening(rec, 1, 80) : (vendorName === "Stripe" ? "No monthly fee \u2014 2.9% + 30\u00a2/txn" : "\u2014");
     const riskBadge = rec ? riskCellHtml(rec.risk_level, rec.risk_cause) : riskCellHtml("stable", null);
     const vendorLink = rec ? `<a href="/vendor/${toSlug(rec.vendor)}" style="color:var(--text);font-weight:600">${escHtmlServer(vendorName)}</a>` : `<span style="font-weight:600">${escHtmlServer(vendorName)}</span>`;
     return `      <tr>
@@ -19321,7 +19378,7 @@ function buildSupabaseVsFirebasePage(): string {
     return `<tr>
       <td style="font-weight:600"><a href="/vendor/${vendorSlug}" style="color:var(--text)">${escHtmlServer(o.vendor)}</a></td>
       <td style="font-family:var(--mono);color:var(--accent);font-size:.85rem">${escHtmlServer(o.tier)}</td>
-      <td style="color:var(--text-muted);font-size:.85rem">${escHtmlServer(o.description)}</td>
+      <td style="color:var(--text-muted);font-size:.85rem">${publishedTermsHtml(o)}</td>
     </tr>`;
   }).join("\n        ");
 
@@ -19465,8 +19522,8 @@ ${mcpCtaCss()}
       </tbody>
     </table>
   </div>
-  ${supabaseOffer ? `<div class="context-box"><strong>Supabase verified data:</strong> ${escHtmlServer(supabaseOffer.description)} <br>Verified: ${escHtmlServer(supabaseOffer.verifiedDate)} &middot; <a href="/vendor/supabase">Full profile →</a></div>` : ""}
-  ${firebaseOffer ? `<div class="context-box"><strong>Firebase verified data:</strong> ${escHtmlServer(firebaseOffer.description)} <br>Verified: ${escHtmlServer(firebaseOffer.verifiedDate)} &middot; <a href="/vendor/firebase">Full profile →</a></div>` : ""}
+  ${supabaseOffer ? `<div class="context-box"><strong>Supabase verified data:</strong> ${publishedTermsHtml(supabaseOffer)} <br>Verified: ${escHtmlServer(supabaseOffer.verifiedDate)} &middot; <a href="/vendor/supabase">Full profile →</a></div>` : ""}
+  ${firebaseOffer ? `<div class="context-box"><strong>Firebase verified data:</strong> ${publishedTermsHtml(firebaseOffer)} <br>Verified: ${escHtmlServer(firebaseOffer.verifiedDate)} &middot; <a href="/vendor/firebase">Full profile →</a></div>` : ""}
 
   <h2 id="differences">2. Key Differences</h2>
   <p class="section-intro">Beyond the raw numbers, these architectural differences matter for your long-term stack choice.</p>
@@ -19643,7 +19700,7 @@ function buildVercelVsNetlifyPage(): string {
     return `<tr>
       <td style="font-weight:600"><a href="/vendor/${vendorSlug}" style="color:var(--text)">${escHtmlServer(o.vendor)}</a></td>
       <td style="font-family:var(--mono);color:var(--accent);font-size:.85rem">${escHtmlServer(o.tier)}</td>
-      <td style="color:var(--text-muted);font-size:.85rem">${escHtmlServer(o.description)}</td>
+      <td style="color:var(--text-muted);font-size:.85rem">${publishedTermsHtml(o)}</td>
     </tr>`;
   }).join("\n        ");
 
@@ -19787,8 +19844,8 @@ ${mcpCtaCss()}
       </tbody>
     </table>
   </div>
-  ${vercelOffer ? `<div class="context-box"><strong>Vercel verified data:</strong> ${escHtmlServer(vercelOffer.description)} <br>Verified: ${escHtmlServer(vercelOffer.verifiedDate)} &middot; <a href="/vendor/vercel">Full profile &rarr;</a></div>` : ""}
-  ${netlifyOffer ? `<div class="context-box"><strong>Netlify verified data:</strong> ${escHtmlServer(netlifyOffer.description)} <br>Verified: ${escHtmlServer(netlifyOffer.verifiedDate)} &middot; <a href="/vendor/netlify">Full profile &rarr;</a></div>` : ""}
+  ${vercelOffer ? `<div class="context-box"><strong>Vercel verified data:</strong> ${publishedTermsHtml(vercelOffer)} <br>Verified: ${escHtmlServer(vercelOffer.verifiedDate)} &middot; <a href="/vendor/vercel">Full profile &rarr;</a></div>` : ""}
+  ${netlifyOffer ? `<div class="context-box"><strong>Netlify verified data:</strong> ${publishedTermsHtml(netlifyOffer)} <br>Verified: ${escHtmlServer(netlifyOffer.verifiedDate)} &middot; <a href="/vendor/netlify">Full profile &rarr;</a></div>` : ""}
 
   <h2 id="differences">2. Key Differences</h2>
   <p class="section-intro">Beyond the raw numbers, these structural differences matter for your hosting choice.</p>
@@ -19962,7 +20019,7 @@ function buildNeonVsSupabasePage(): string {
     return `<tr>
       <td style="font-weight:600"><a href="/vendor/${vendorSlug}" style="color:var(--text)">${escHtmlServer(o.vendor)}</a></td>
       <td style="font-family:var(--mono);color:var(--accent);font-size:.85rem">${escHtmlServer(o.tier)}</td>
-      <td style="color:var(--text-muted);font-size:.85rem">${escHtmlServer(o.description)}</td>
+      <td style="color:var(--text-muted);font-size:.85rem">${publishedTermsHtml(o)}</td>
     </tr>`;
   }).join("\n        ");
 
@@ -20106,8 +20163,8 @@ ${mcpCtaCss()}
       </tbody>
     </table>
   </div>
-  ${neonOffer ? `<div class="context-box"><strong>Neon verified data:</strong> ${escHtmlServer(neonOffer.description)} <br>Verified: ${escHtmlServer(neonOffer.verifiedDate)} &middot; <a href="/vendor/neon">Full profile &rarr;</a></div>` : ""}
-  ${supabaseOffer ? `<div class="context-box"><strong>Supabase verified data:</strong> ${escHtmlServer(supabaseOffer.description)} <br>Verified: ${escHtmlServer(supabaseOffer.verifiedDate)} &middot; <a href="/vendor/supabase">Full profile &rarr;</a></div>` : ""}
+  ${neonOffer ? `<div class="context-box"><strong>Neon verified data:</strong> ${publishedTermsHtml(neonOffer)} <br>Verified: ${escHtmlServer(neonOffer.verifiedDate)} &middot; <a href="/vendor/neon">Full profile &rarr;</a></div>` : ""}
+  ${supabaseOffer ? `<div class="context-box"><strong>Supabase verified data:</strong> ${publishedTermsHtml(supabaseOffer)} <br>Verified: ${escHtmlServer(supabaseOffer.verifiedDate)} &middot; <a href="/vendor/supabase">Full profile &rarr;</a></div>` : ""}
 
   <h2 id="differences">2. Key Differences</h2>
   <p class="section-intro">Beyond the raw numbers, these architectural differences shape which platform fits your use case.</p>
@@ -20283,7 +20340,7 @@ function buildRailwayVsRenderPage(): string {
     return `<tr>
       <td style="font-weight:600"><a href="/vendor/${vendorSlug}" style="color:var(--text)">${escHtmlServer(o.vendor)}</a></td>
       <td style="font-family:var(--mono);color:var(--accent);font-size:.85rem">${escHtmlServer(o.tier)}</td>
-      <td style="color:var(--text-muted);font-size:.85rem">${escHtmlServer(o.description)}</td>
+      <td style="color:var(--text-muted);font-size:.85rem">${publishedTermsHtml(o)}</td>
     </tr>`;
   }).join("\n        ");
 
@@ -20427,8 +20484,8 @@ ${mcpCtaCss()}
       </tbody>
     </table>
   </div>
-  ${railwayOffer ? `<div class="context-box"><strong>Railway verified data:</strong> ${escHtmlServer(railwayOffer.description)} <br>Verified: ${escHtmlServer(railwayOffer.verifiedDate)} &middot; <a href="/vendor/railway">Full profile &rarr;</a></div>` : ""}
-  ${renderOffer ? `<div class="context-box"><strong>Render verified data:</strong> ${escHtmlServer(renderOffer.description)} <br>Verified: ${escHtmlServer(renderOffer.verifiedDate)} &middot; <a href="/vendor/render">Full profile &rarr;</a></div>` : ""}
+  ${railwayOffer ? `<div class="context-box"><strong>Railway verified data:</strong> ${publishedTermsHtml(railwayOffer)} <br>Verified: ${escHtmlServer(railwayOffer.verifiedDate)} &middot; <a href="/vendor/railway">Full profile &rarr;</a></div>` : ""}
+  ${renderOffer ? `<div class="context-box"><strong>Render verified data:</strong> ${publishedTermsHtml(renderOffer)} <br>Verified: ${escHtmlServer(renderOffer.verifiedDate)} &middot; <a href="/vendor/render">Full profile &rarr;</a></div>` : ""}
 
   <h2 id="differences">2. Key Differences</h2>
   <p class="section-intro">Beyond the raw numbers, these structural differences define the Railway vs Render choice.</p>
@@ -20604,7 +20661,7 @@ function buildDatadogVsNewRelicPage(): string {
     return `<tr>
       <td style="font-weight:600"><a href="/vendor/${vendorSlug}" style="color:var(--text)">${escHtmlServer(o.vendor)}</a></td>
       <td style="font-family:var(--mono);color:var(--accent);font-size:.85rem">${escHtmlServer(o.tier)}</td>
-      <td style="color:var(--text-muted);font-size:.85rem">${escHtmlServer(o.description)}</td>
+      <td style="color:var(--text-muted);font-size:.85rem">${publishedTermsHtml(o)}</td>
     </tr>`;
   }).join("\n        ");
 
@@ -20748,8 +20805,8 @@ ${mcpCtaCss()}
       </tbody>
     </table>
   </div>
-  ${datadogOffer ? `<div class="context-box"><strong>Datadog verified data:</strong> ${escHtmlServer(datadogOffer.description)} <br>Verified: ${escHtmlServer(datadogOffer.verifiedDate)} &middot; <a href="/vendor/datadog">Full profile &rarr;</a></div>` : ""}
-  ${newRelicOffer ? `<div class="context-box"><strong>New Relic verified data:</strong> ${escHtmlServer(newRelicOffer.description)} <br>Verified: ${escHtmlServer(newRelicOffer.verifiedDate)} &middot; <a href="/vendor/new-relic">Full profile &rarr;</a></div>` : ""}
+  ${datadogOffer ? `<div class="context-box"><strong>Datadog verified data:</strong> ${publishedTermsHtml(datadogOffer)} <br>Verified: ${escHtmlServer(datadogOffer.verifiedDate)} &middot; <a href="/vendor/datadog">Full profile &rarr;</a></div>` : ""}
+  ${newRelicOffer ? `<div class="context-box"><strong>New Relic verified data:</strong> ${publishedTermsHtml(newRelicOffer)} <br>Verified: ${escHtmlServer(newRelicOffer.verifiedDate)} &middot; <a href="/vendor/new-relic">Full profile &rarr;</a></div>` : ""}
 
   <h2 id="differences">2. Key Differences</h2>
   <p class="section-intro">Beyond the raw numbers, these structural differences define the Datadog vs New Relic choice.</p>
@@ -32016,7 +32073,7 @@ function buildAgentPaymentsPage(): string {
 
   const serviceRows = allPaymentOffers.map(o => {
     const vendorSlug = toSlug(o.vendor);
-    const shortDesc = o.description.split(". ")[0].substring(0, 120);
+    const shortDesc = publishedTermsOpening(o, 1, 120);
     const badges = (o.payment_protocols ?? []).map(p =>
       `<span class="proto-badge ${p.protocol === "stripe-mpp" ? "stripe-mpp" : "x402"}">${p.protocol === "stripe-mpp" ? "Stripe MPP" : "x402"}</span>`
     ).join(" ");
@@ -32040,7 +32097,7 @@ function buildAgentPaymentsPage(): string {
     const catSlug = toSlug(cat);
     const serviceList = catOffers.map(o => {
       const vendorSlug = toSlug(o.vendor);
-      const shortDesc = o.description.split(". ")[0].substring(0, 100);
+      const shortDesc = publishedTermsOpening(o, 1, 100);
       const badges = (o.payment_protocols ?? []).map(p =>
         `<span class="proto-badge ${p.protocol === "stripe-mpp" ? "stripe-mpp" : "x402"}">${p.protocol === "stripe-mpp" ? "Stripe MPP" : "x402"}</span>`
       ).join(" ");
@@ -32289,7 +32346,7 @@ function buildX402ServicesPage(): string {
 
   const serviceRows = x402Offers.map(o => {
     const vendorSlug = toSlug(o.vendor);
-    const shortDesc = o.description.split(". ")[0].substring(0, 120);
+    const shortDesc = publishedTermsOpening(o, 1, 120);
     const proto = o.payment_protocols?.find(p => p.protocol === "x402");
     const cost = proto?.example_cost || "varies";
     const chain = proto?.chain || "Base";
@@ -32307,7 +32364,7 @@ function buildX402ServicesPage(): string {
     const catSlug = toSlug(cat);
     const serviceList = catOffers.map(o => {
       const vendorSlug = toSlug(o.vendor);
-      const shortDesc = o.description.split(". ")[0].substring(0, 100);
+      const shortDesc = publishedTermsOpening(o, 1, 100);
       const proto = o.payment_protocols?.find(p => p.protocol === "x402");
       const cost = proto?.example_cost || "varies";
       return `<div class="service-card">
@@ -46713,7 +46770,7 @@ function buildStackCheckPage(): string {
     vendorLookup[slug] = {
       vendor: offer.vendor,
       category: offer.category,
-      description: offer.description,
+      description: publishedTermsText(offer),
       tier: offer.tier,
       slug,
       risk_level: assessment.level,
@@ -47083,7 +47140,7 @@ function buildStackCheckPage(): string {
         for (var i = 0; i < data.gaps.length; i++) {
           var g = data.gaps[i];
           gapsHtml += '<div class="gap-item"><span class="gap-cat">' + esc(g.category) + '</span>';
-          gapsHtml += '<span class="gap-rec">Try <a href="/vendor/' + esc(toSlug(g.recommendation.vendor)) + '">' + esc(g.recommendation.vendor) + '</a> — ' + esc(g.recommendation.description) + '</span></div>';
+          gapsHtml += '<span class="gap-rec">Try <a href="/vendor/' + esc(toSlug(g.recommendation.vendor)) + '">' + esc(g.recommendation.vendor) + '</a> — ' + esc(g.recommendation.terms_superseded ? g.recommendation.terms_superseded.notice : g.recommendation.description) + '</span></div>';
         }
         document.getElementById('gaps-list').innerHTML = gapsHtml;
       } else {
@@ -47405,7 +47462,7 @@ ${globalNavCss()}
     var html = '<div class="vendor-card">';
     html += '<h3><a href="/vendor/' + slug + '">' + escHtml(v.vendor) + '</a></h3>';
     html += '<span class="badge badge-category">' + escHtml(v.category) + '</span> ' + riskBadge(risk, riskCause);
-    html += '<div class="vendor-desc">' + escHtml(v.description) + '</div>';
+    html += '<div class="vendor-desc">' + escHtml(v.terms_superseded ? v.terms_superseded.notice : v.description) + '</div>';
     html += '<div class="vendor-meta">Tier: ' + escHtml(v.tier) + ' &middot; Verified: ' + escHtml(v.verifiedDate || v.verified_date || '') + '</div>';
     html += '<div class="vendor-links">';
     html += '<a href="/vendor/' + slug + '">Details</a>';
@@ -47512,7 +47569,7 @@ function buildEstimatePage(): string {
     for (const v of cat.vendors) {
       const offer = allOffers.find(o => toSlug(o.vendor) === v.slug || o.vendor.toLowerCase() === v.name.toLowerCase());
       if (offer) {
-        vendorInfo[v.slug] = { description: offer.description, url: offer.url, category: offer.category };
+        vendorInfo[v.slug] = { description: publishedTermsText(offer), url: offer.url, category: offer.category };
       }
     }
   }
@@ -50591,7 +50648,7 @@ function buildAgentStackPage(): string {
   const bundleHtml = resolvedBundles.map((bundle) => {
     const serviceRows = bundle.resolvedServices.map((svc) => {
       const limits = svc.description;
-      const shortLimits = limits.split(". ")[0].substring(0, 140);
+      const shortLimits = publishedTermsOpening({ vendor: svc.vendorName, description: limits }, 1, 140);
       return `          <tr>
             <td class="role-cell">${escHtmlServer(svc.role)}</td>
             <td><a href="/vendor/${svc.slug}" class="vendor-link">${escHtmlServer(svc.vendorName)}</a> <span class="tier-badge">${escHtmlServer(svc.tier)}</span></td>
@@ -51754,7 +51811,7 @@ function buildSearchPage(query: string, categoryFilter: string, typeFilter: stri
       + '<span class="result-cat">' + escHtmlServer(r.category) + '</span>'
       + '</div>'
       + '<div class="result-tier">' + escHtmlServer(r.tier) + '</div>'
-      + '<div class="result-desc">' + escHtmlServer((r.description ?? "").slice(0, 120)) + (r.description && r.description.length > 120 ? "..." : "") + '</div>'
+      + '<div class="result-desc">' + escHtmlServer(publishedTermsSummary(r, 120)) + '</div>'
       + '<div class="result-meta">Verified ' + r.verifiedDate
       + (r.recent_change ? ' &middot; <span style="color:#d29922">' + escHtmlServer(r.recent_change) + '</span>' : '')
       + (r.expires_soon ? ' &middot; <span style="color:#f85149">' + escHtmlServer(r.expires_soon) + '</span>' : '')
@@ -53874,6 +53931,7 @@ const httpServer = createHttpServer(async (req, res) => {
           category: o.category,
           tier: o.tier,
           description: o.description,
+          ...supersededTermsField(o),
           url: o.url,
           payment_protocols: o.payment_protocols,
           stability: o.stability,
@@ -53896,6 +53954,7 @@ const httpServer = createHttpServer(async (req, res) => {
         category: o.category,
         tier: o.tier,
         description: o.description,
+        ...supersededTermsField(o),
         url: o.url,
         payment_protocols: o.payment_protocols,
         stability: o.stability,
@@ -53994,6 +54053,7 @@ const httpServer = createHttpServer(async (req, res) => {
         vendor: o.vendor,
         category: toolCategory,
         description: o.description,
+        ...supersededTermsField(o),
         tier: o.tier,
         url: o.url,
         tags: o.tags,
@@ -54027,6 +54087,7 @@ const httpServer = createHttpServer(async (req, res) => {
         vendor: o.vendor,
         category: toolCat,
         description: o.description,
+        ...supersededTermsField(o),
         tier: o.tier,
         url: o.url,
         tags: o.tags,
@@ -54061,6 +54122,7 @@ const httpServer = createHttpServer(async (req, res) => {
         vendor: o.vendor,
         category: provCat,
         description: o.description,
+        ...supersededTermsField(o),
         tier: o.tier,
         url: o.url,
         tags: o.tags,
@@ -54097,6 +54159,7 @@ const httpServer = createHttpServer(async (req, res) => {
         vendor: o.vendor,
         category: progCat,
         description: o.description,
+        ...supersededTermsField(o),
         tier: o.tier,
         url: o.url,
         tags: o.tags,

--- a/src/superseded-description.ts
+++ b/src/superseded-description.ts
@@ -161,3 +161,29 @@ export function supersededTermsMetaSentence(vendor: string, change: QuotingChang
 export function supersededTermsVerdictSentence(vendor: string, change: QuotingChange): string {
   return readingWithTail(vendor, change, 170) ?? withheldTail(vendor, change, false);
 }
+
+export interface SupersededTermsRecord {
+  change_date: string;
+  change_type: string;
+  summary: string;
+  reading: SourcedReading | null;
+  notice: string;
+}
+
+export function supersededTermsRecord(vendor: string, change: QuotingChange): SupersededTermsRecord {
+  return {
+    change_date: change.date,
+    change_type: change.change_type,
+    summary: change.summary,
+    reading: readingBehindTheChange(change),
+    notice: supersededTermsNotice(vendor, change),
+  };
+}
+
+export function supersededTermsRecordFor(
+  offer: StoredTerms,
+  vendorChanges: readonly QuotingChange[],
+): SupersededTermsRecord | null {
+  const change = supersedingChange(offer, vendorChanges);
+  return change ? supersededTermsRecord(offer.vendor, change) : null;
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -144,6 +144,7 @@ export interface EnrichedOffer extends Offer {
   days_since_verified: number;
   link_unreachable: LinkUnreachable | null;
   gate: import("./ranking.js").Gate | null;
+  terms_superseded: import("./superseded-description.js").SupersededTermsRecord | null;
 }
 
 export interface OfferIndex {

--- a/test/superseded-terms-listings.test.ts
+++ b/test/superseded-terms-listings.test.ts
@@ -1,0 +1,361 @@
+import { describe, it, before, after } from "node:test";
+import assert from "node:assert";
+import { spawn, type ChildProcess } from "node:child_process";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const {
+  STORED_TERMS_WITHHELD_PHRASE,
+  STORED_TERMS_WITHHELD_META_PHRASE,
+  supersedingChange,
+  supersededTermsRecord,
+} = await import("../dist/superseded-description.js");
+const { toSlug } = await import("../dist/slug.js");
+const { citedRecords } = await import("../dist/provenance.js");
+const { getOfferDetails } = await import("../dist/data.js");
+
+type Offer = import("../src/types.ts").Offer;
+type DealChange = import("../src/types.ts").DealChange;
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO = path.join(__dirname, "..");
+
+const offers: Offer[] = JSON.parse(readFileSync(path.join(REPO, "data", "index.json"), "utf-8")).offers;
+const changes: DealChange[] = JSON.parse(
+  readFileSync(path.join(REPO, "data", "deal_changes.json"), "utf-8"),
+).changes;
+
+const byVendor = new Map<string, DealChange[]>();
+for (const change of changes) {
+  const key = change.vendor.toLowerCase();
+  const held = byVendor.get(key);
+  if (held) held.push(change);
+  else byVendor.set(key, [change]);
+}
+const changesFor = (vendor: string): DealChange[] => byVendor.get(vendor.toLowerCase()) ?? [];
+const supersedingFor = (offer: Offer): DealChange | null => supersedingChange(offer, changesFor(offer.vendor));
+
+const superseded = offers.filter((o) => supersedingFor(o) !== null);
+const notSuperseded = offers.filter((o) => supersedingFor(o) === null);
+
+const HEAD = 45;
+const squash = (text: string): string => text.replace(/\s+/g, " ").trim();
+const decodeEntities = (text: string): string =>
+  text
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+    .replace(/&mdash;/g, "—")
+    .replace(/&ldquo;/g, "“")
+    .replace(/&rdquo;/g, "”")
+    .replace(/&hellip;/g, "…")
+    .replace(/&amp;/g, "&");
+const withoutTags = (markup: string): string => decodeEntities(squash(markup.replace(/<[^>]*>/g, " ")));
+
+const headOf = (offer: Offer): string => squash(offer.description).slice(0, HEAD);
+
+function publishesStoredTerms(slot: string, offer: Offer): boolean {
+  const shown = squash(slot).replace(/(\.\.\.|…)$/, "");
+  const stored = squash(offer.description);
+  if (shown.length < 25) return false;
+  if (stored.startsWith(shown.slice(0, HEAD))) return true;
+  return stored.length >= HEAD && shown.includes(stored.slice(0, HEAD));
+}
+
+const STACK_AND_TABLE_PAGES = [
+  "/free-saas-stack", "/free-go-stack", "/free-fastapi-stack", "/free-django-stack",
+  "/free-nextjs-stack", "/free-frontend-stack", "/free-devops-stack", "/free-ai-stack",
+  "/free-startup-stack", "/x402-services", "/agent-payments", "/agent-stack",
+  "/events/google-io-2026", "/events/microsoft-build-2026", "/events/google-cloud-next-2026",
+  "/cloudinary-vs-imagekit", "/github-actions-vs-gitlab-ci", "/circleci-vs-github-actions",
+  "/datadog-vs-grafana-cloud", "/datadog-vs-new-relic", "/vercel-vs-netlify",
+  "/redis-alternatives", "/auth0-alternatives", "/vercel-alternatives", "/ai-free-tiers",
+];
+
+const SLOT_PATTERNS: RegExp[] = [
+  /<td[^>]*>([\s\S]*?)<\/td>/g,
+  /<td style="color:var\(--text-muted\)">([\s\S]*?)<\/td>/g,
+  /<td style="color:var\(--text-muted\);max-width:300px">([\s\S]*?)<\/td>/g,
+  /<td style="color:var\(--text-muted\);font-size:\.85rem">([\s\S]*?)<\/td>/g,
+  /<p class="alt-card-desc">([\s\S]*?)<\/p>/g,
+  /<p class="best-pick-review">([\s\S]*?)<\/p>/g,
+  /<p class="pick-limits">([\s\S]*?)<\/p>/g,
+  /<div class="result-desc">([\s\S]*?)<\/div>/g,
+  /<div class="desc-block">([\s\S]*?)<\/div>/g,
+  /<div class="faq-a">([\s\S]*?)<\/div>/g,
+];
+
+function visibleTermSlots(html: string): string[] {
+  const withoutStructuredData = html.replace(/<script type="application\/ld\+json">[\s\S]*?<\/script>/g, "");
+  const slots: string[] = [];
+  for (const pattern of SLOT_PATTERNS) {
+    for (const match of withoutStructuredData.matchAll(pattern)) slots.push(withoutTags(match[1]));
+  }
+  return slots;
+}
+
+function structuredDescriptions(html: string): string[] {
+  const found: string[] = [];
+  const visit = (node: unknown): void => {
+    if (!node || typeof node !== "object") return;
+    if (Array.isArray(node)) { node.forEach(visit); return; }
+    const record = node as Record<string, unknown>;
+    if (typeof record.description === "string") found.push(record.description);
+    Object.values(record).forEach(visit);
+  };
+  for (const match of html.matchAll(/<script type="application\/ld\+json">([\s\S]*?)<\/script>/g)) {
+    try { visit(JSON.parse(match[1])); } catch { continue; }
+  }
+  return found;
+}
+
+function startServer(): Promise<{ proc: ChildProcess; port: number }> {
+  return new Promise((resolve, reject) => {
+    const child = spawn("node", [path.join(REPO, "dist", "serve.js")], {
+      stdio: ["pipe", "pipe", "pipe"],
+      env: { ...process.env, PORT: "0", BASE_URL: "http://localhost", TZ: "UTC" },
+    });
+    const timeout = setTimeout(() => { child.kill(); reject(new Error("Server startup timeout")); }, 60000);
+    child.stderr!.on("data", (data: Buffer) => {
+      const m = data.toString().match(/running on http:\/\/localhost:(\d+)/);
+      if (m) { clearTimeout(timeout); resolve({ proc: child, port: parseInt(m[1], 10) }); }
+    });
+    child.on("error", (err) => { clearTimeout(timeout); reject(err); });
+  });
+}
+
+describe("#1395 the listing surfaces answer the stored-terms question the way the vendor page answers it", () => {
+  let server: { proc: ChildProcess; port: number } | null = null;
+  const pages = new Map<string, string>();
+  let base = "";
+
+  const categoryPaths = [...new Set(offers.map((o) => `/category/${toSlug(o.category)}`))];
+  const searchPaths = superseded.slice(0, 40).map((o) => `/search?q=${encodeURIComponent(o.vendor)}`);
+  const alternativePaths = [...new Set(superseded.map((o) => `/alternative-to/${toSlug(o.vendor)}`))];
+
+  before(async () => {
+    server = await startServer();
+    base = `http://localhost:${server.port}`;
+    const queue = [
+      ...categoryPaths,
+      ...searchPaths,
+      ...alternativePaths,
+      ...STACK_AND_TABLE_PAGES,
+      "/best/free-testing",
+      "/best/free-monitoring",
+    ];
+    let next = 0;
+    await Promise.all(
+      Array.from({ length: 12 }, async () => {
+        while (next < queue.length) {
+          const pathname = queue[next++];
+          const response = await fetch(base + pathname);
+          if (response.ok) pages.set(pathname, await response.text());
+        }
+      }),
+    );
+  });
+
+  after(() => { server?.proc.kill(); });
+
+  it("has records on both sides of the question, so neither direction below is vacuous", () => {
+    assert.ok(superseded.length > 100, `only ${superseded.length} records carry superseded stored terms`);
+    assert.ok(notSuperseded.length > 1000, `only ${notSuperseded.length} records carry current stored terms`);
+    assert.strictEqual(
+      pages.size,
+      categoryPaths.length + searchPaths.length + alternativePaths.length + STACK_AND_TABLE_PAGES.length + 2,
+    );
+  });
+
+  it("publishes no superseded stored terms in a visible listing slot", () => {
+    const published: string[] = [];
+    for (const [pathname, html] of pages) {
+      const slots = visibleTermSlots(html);
+      for (const offer of superseded) {
+        if (slots.some((slot) => publishesStoredTerms(slot, offer))) published.push(`${pathname} ${offer.vendor}`);
+      }
+    }
+    assert.deepStrictEqual(published.slice(0, 25), []);
+  });
+
+  it("publishes no superseded stored terms in structured data either", () => {
+    const published: string[] = [];
+    for (const [pathname, html] of pages) {
+      const descriptions = structuredDescriptions(html).map(decodeEntities);
+      for (const offer of superseded) {
+        if (descriptions.some((description) => publishesStoredTerms(description, offer))) {
+          published.push(`${pathname} ${offer.vendor}`);
+        }
+      }
+    }
+    assert.deepStrictEqual(published.slice(0, 25), []);
+  });
+
+  it("still publishes the stored terms of the records the vendor page publishes", () => {
+    let publishing = 0;
+    for (const html of pages.values()) {
+      const slots = visibleTermSlots(html);
+      for (const offer of notSuperseded) {
+        if (slots.some((slot) => publishesStoredTerms(slot, offer))) publishing++;
+      }
+    }
+    assert.ok(publishing > 300, `only ${publishing} listing slots publish stored terms that are current`);
+  });
+
+  it("names the change that superseded the terms wherever a category row withholds them", () => {
+    const silent: string[] = [];
+    for (const offer of superseded) {
+      const html = pages.get(`/category/${toSlug(offer.category)}`);
+      if (!html) continue;
+      const row = new RegExp(
+        `<td[^>]*><a href="/vendor/${toSlug(offer.vendor)}"[\\s\\S]*?</tr>`,
+      ).exec(html)?.[0];
+      if (!row) continue;
+      const text = withoutTags(row);
+      if (!text.includes(STORED_TERMS_WITHHELD_PHRASE)) silent.push(offer.vendor);
+    }
+    assert.deepStrictEqual(silent.slice(0, 25), []);
+  });
+
+  it("keeps the category table cell and its structured description saying the same thing", () => {
+    const disagreeing: string[] = [];
+    for (const offer of superseded) {
+      const html = pages.get(`/category/${toSlug(offer.category)}`);
+      if (!html) continue;
+      const named = structuredDescriptions(html)
+        .filter((description) => description.includes(offer.vendor))
+        .map(decodeEntities);
+      if (named.some((description) => publishesStoredTerms(description, offer))) disagreeing.push(offer.vendor);
+    }
+    assert.deepStrictEqual(disagreeing.slice(0, 25), []);
+  });
+
+  it("shortens the withholding rather than the stored terms in a search result", async () => {
+    const withStoredTerms: string[] = [];
+    for (const offer of superseded.slice(0, 40)) {
+      const html = pages.get(`/search?q=${encodeURIComponent(offer.vendor)}`);
+      if (!html) continue;
+      const slots = [...html.matchAll(/<div class="result-desc">([\s\S]*?)<\/div>/g)].map((m) => withoutTags(m[1]));
+      if (slots.some((slot) => publishesStoredTerms(slot, offer))) withStoredTerms.push(offer.vendor);
+      assert.ok(
+        slots.some((slot) => slot.includes(STORED_TERMS_WITHHELD_META_PHRASE) || slot.includes(STORED_TERMS_WITHHELD_PHRASE)),
+        `no search result for ${offer.vendor} says the stored terms are superseded`,
+      );
+    }
+    assert.deepStrictEqual(withStoredTerms, []);
+  });
+
+  it("marks the superseded record on every offer the API returns", async () => {
+    const payload = await (await fetch(`${base}/api/offers?limit=2000`)).json();
+    const rows: Record<string, any>[] = payload.offers;
+    assert.strictEqual(rows.length, offers.length);
+
+    const unmarked = rows
+      .filter((row) => superseded.some((o) => o.vendor === row.vendor && o.category === row.category))
+      .filter((row) => !row.terms_superseded)
+      .map((row) => row.vendor);
+    assert.deepStrictEqual(unmarked.slice(0, 25), []);
+
+    const wronglyMarked = rows
+      .filter((row) => notSuperseded.some((o) => o.vendor === row.vendor && o.category === row.category))
+      .filter((row) => row.terms_superseded)
+      .map((row) => row.vendor);
+    assert.deepStrictEqual(wronglyMarked.slice(0, 25), []);
+  });
+
+  it("carries the reading behind the change and the sentence the vendor page prints", async () => {
+    const offer = superseded.find((o) => {
+      const change = supersedingFor(o)!;
+      return change.source_url && change.current_state;
+    })!;
+    const change = supersedingFor(offer)!;
+    const payload = await (await fetch(`${base}/api/details/${encodeURIComponent(offer.vendor)}`)).json();
+    const marked = payload.offer.terms_superseded;
+    assert.deepStrictEqual(marked, supersededTermsRecord(offer.vendor, change));
+    assert.strictEqual(marked.change_date, change.date);
+    assert.strictEqual(marked.summary, change.summary);
+    assert.strictEqual(marked.reading.url, change.source_url);
+    assert.strictEqual(marked.reading.terms, change.current_state!.trim());
+    assert.ok(marked.notice.includes(change.current_state!.trim().slice(0, 40)));
+    assert.ok(marked.notice.includes(STORED_TERMS_WITHHELD_PHRASE));
+  });
+
+  it("counts a reading on nearly every marked record, so the field above is not an exception", async () => {
+    const payload = await (await fetch(`${base}/api/offers?limit=2000`)).json();
+    const marked: Record<string, any>[] = payload.offers.filter((row: any) => row.terms_superseded);
+    const withAReading = marked.filter((row) => row.terms_superseded.reading);
+    assert.ok(
+      withAReading.length > marked.length * 0.9,
+      `only ${withAReading.length} of ${marked.length} marked records carry the reading behind the change`,
+    );
+  });
+
+  it("does not lead a category on a record whose terms it withholds", () => {
+    const leading: string[] = [];
+    for (const [pathname, html] of pages) {
+      if (!pathname.startsWith("/category/")) continue;
+      const intro = /<div class="cat-intro">([\s\S]*?)<\/div>/.exec(html)?.[1] ?? "";
+      const text = withoutTags(intro);
+      for (const offer of superseded) {
+        if (text.includes(`${offer.vendor} leads with`)) leading.push(`${pathname} ${offer.vendor}`);
+      }
+    }
+    assert.deepStrictEqual(leading, []);
+  });
+
+  it("returns the verdict fields on a single vendor that the listing endpoint returns", async () => {
+    const fields = ["risk_level", "risk_cause", "rating_withheld", "recent_change", "stability", "terms_superseded"];
+    const missing: string[] = [];
+    for (const offer of offers.slice(0, 40)) {
+      const payload = await (await fetch(`${base}/api/details/${encodeURIComponent(offer.vendor)}`)).json();
+      if (!payload.offer) continue;
+      for (const field of fields) {
+        if (!(field in payload.offer)) missing.push(`${offer.vendor}.${field}`);
+      }
+    }
+    assert.deepStrictEqual(missing.slice(0, 25), []);
+  });
+
+  it("gives the vendor tool the same fields the endpoint gives", () => {
+    const offer = superseded[0];
+    const result = getOfferDetails(offer.vendor, true) as { offer: Record<string, unknown> };
+    for (const field of ["risk_level", "risk_cause", "rating_withheld", "recent_change", "stability", "terms_superseded"]) {
+      assert.ok(field in result.offer, `getOfferDetails omits ${field}`);
+    }
+    assert.ok(result.offer.terms_superseded);
+    assert.ok((result.offer.alternatives as Record<string, unknown>[]).every((a) => "risk_level" in a));
+  });
+
+  it("counts a record as withheld when the site declines to publish its terms", () => {
+    const stored = { vendor: "Quotacorp", verifiedDate: "2026-08-01", category: "Cloud Hosting" };
+    assert.strictEqual(citedRecords({ offer: { ...stored } })[0].withheld, false);
+    assert.strictEqual(
+      citedRecords({ offer: { ...stored, terms_superseded: { notice: "..." } } })[0].withheld,
+      true,
+    );
+    assert.strictEqual(citedRecords({ offer: { ...stored, risk_level: null } })[0].withheld, true);
+    assert.strictEqual(
+      citedRecords({ offer: { ...stored, rating_withheld: { reason: "no_source", records: 1 } } })[0].withheld,
+      true,
+    );
+    assert.strictEqual(citedRecords({ offer: { ...stored, risk_level: "stable" } })[0].withheld, false);
+  });
+
+  it("counts fewer records as verified than it holds, on the endpoint that returns them all", async () => {
+    const payload = await (await fetch(`${base}/api/offers?limit=2000`)).json();
+    const provenance = payload._provenance;
+    const rows: Record<string, any>[] = payload.offers;
+    const withheld = rows.filter(
+      (row) =>
+        (row.gate && typeof row.gate.code === "string") ||
+        row.terms_superseded ||
+        row.rating_withheld ||
+        row.risk_level === null,
+    );
+    assert.strictEqual(provenance.withheld_records, withheld.length);
+    assert.strictEqual(provenance.verified_records, rows.length - withheld.length);
+    assert.ok(provenance.verified_records < 1413, `verified_records is ${provenance.verified_records}`);
+  });
+});


### PR DESCRIPTION
Refs #1395

`/vendor/:slug` stopped publishing our stored terms for the records a change log entry
supersedes when #1387 shipped, and `/compare/:slug` stopped when #1394 shipped. Every other
surface that renders `offer.description` still published them as the current offer. This
makes those surfaces ask the same question through the same function.

## The population

**176 catalogue records** hold stored terms that a change record quotes as the previous
ones. 175 of them are the first record for their vendor, which is the 175 the issue counts
from `/vendor/:slug`; the 176th is a second record for a vendor whose first record is not
superseded, so no vendor page withholds it and `/api/details` never returns it.

## What the site published, measured on a build of `b9bbf4c`

| surface | before | after |
|---|---|---|
| `/category/:slug` table cell | 176 of 176, on 53 pages | **0** |
| `/category/:slug` JSON-LD `SoftwareApplication.description` | 163 of 176 | **0** |
| `/search?q=` `result-desc` | 176 of 176 | **0** |
| `/api/offers` `description` | 176 of 176, unmarked | 176 marked with `terms_superseded` |
| `/api/details/{vendor}` and `search_deals({vendor})` | 175, unmarked | 175 marked |
| `/api/details` verdict fields present | 0 of 5 | 6 of 6 |
| `_provenance.verified_records` on `?limit=2000` | 1413 | **646** |

The issue's figures were floors — it matched a 50-character prefix against the rendered
cell, so a truncated cell read as absent. Matching the cell against the stored string finds
every one of the 176 on both HTML surfaces.

## The issue named five surfaces; the site had thirteen

Fetching all 2,572 paths in the sitemap and reading the enclosing tag of every occurrence
of a stored description found **500 pages** publishing superseded terms, not 53 + a search
page:

| slot | pages before | after |
|---|---|---|
| JSON-LD `description` | 295 — `/alternative-to/:slug` (164), `/category/:slug` (52), `/best/:slug` (45), 30 hub pages | 0 |
| listing table cells | 125 — `/category/:slug`, `/best/:slug`, the stack pages, the event pages | 0 |
| `p.best-pick-review` | 48 | 0 |
| `p.alt-card-desc` | 30 | 0 |
| `p.pick-limits` | 9 | 0 |
| `div.faq-a` | 6 — `/alternative-to/:slug` and four comparison pages | 0 |
| `div.desc-block`, `p.service-desc`, `td.desc-cell`, `td.limits-cell` | 7 | 0 |
| `/stack-check` and `/estimate` client-side data | 2 | 0 |
| the change log's own `previous_state` renders | 177 | 177 — correct, they say *previous* |

`/alternative-to/:slug` is the largest of these and carries more traffic than every surface
the issue names put together. Its visible rows render no description at all, which is why a
census of the rendered text reads 0 there — but its `ItemList` JSON-LD carries the stored
description for every alternative it lists, on 164 pages.

**Two pages still publish one of these strings and are not fixed here.** `/ci-cd-pricing`
holds Buildkite's terms as a hardcoded `freeDetails` string and `/startup-credits` holds
Mercury's in hardcoded prose. Neither reads `offer.description`, so neither is reachable
from this change; they belong with #1374.

## The shape of the fix

One decision function, four renderings of it, no new sentences:

- `supersedingChangeFor(offer)` is the single call, backed by one `changesByVendor` index
  built once. `vendorVerdictContext` now reads that index too, so the vendor page, the
  comparison page, the badge and every listing sort the same vendor's changes the same way.
- `publishedTermsHtml` for a block slot — the `Superseded:` prefix, `supersededTermsNoticeHtml`
  and a link to the vendor page's change log, the same three parts `/vendor/:slug` and
  `/compare/:slug` already render.
- `publishedTermsText` for JSON-LD — `supersededTermsNotice`, which is what the vendor page
  and the comparison page already put in their structured data.
- `publishedTermsSummary` and `publishedTermsOpening` for the short slots —
  `supersededTermsMetaSentence`, the site's existing 90-character form. These slots used to
  truncate; a truncated withholding sentence would have published the reading with its
  reservation cut off, so they publish the whole sentence instead.
- `storedTermsOf` answers the free-tier FAQ, and now withholds where the vendor page does.
  It is only reached on `/vendor/:slug` when the terms are current, so that page does not move.

`/category/:slug` also chose the vendor for its opening sentence — *"X leads with 20 GB"* —
by taking the first ungated record and pattern-matching a figure out of its description.
On **7 categories** that record's terms are superseded. It now takes the first ungated
record whose terms are current.

### The API keeps `description` and gains a field

AC-3 asked for an explicit field rather than a rewritten string, so `description` is
untouched and `terms_superseded` sits beside it, carrying the change date, its type, its
summary, the dated and sourced reading behind it, and the sentence the vendor page prints:

```json
"terms_superseded": {
  "change_date": "2026-09-03",
  "change_type": "limits_reduced",
  "summary": "The free tier now has a $1/month minimum after the trial…",
  "reading": { "date": "2026-09-03", "url": "https://railway.com/pricing",
               "label": "railway.com/pricing", "terms": "Free $0 per month…" },
  "notice": "As of 2026-09-03, railway.com/pricing reads: … We are not publishing our stored Railway terms beside it — our own pricing change record, discovered 2026-09-03, names them as the previous ones."
}
```

It is built in `enrichOffers`, so `/api/offers` and the five hand-rolled pricing endpoints
carry it, and `getOfferDetails` now calls `enrichOffers` instead of `withLinkHealth` — which
is also AC-4: `/api/details/{vendor}` and `search_deals({vendor})` return `risk_level`,
`risk_cause`, `rating_withheld`, `recent_change` and `stability`, none of which they carried
before, and their `alternatives` array is enriched too. The two client-side renderers that
draw from these endpoints (`/compare-tool`, `/stack-check`) read `terms_superseded.notice`
when it is there.

### `isWithheld` counts what the site declines to publish

It tested one thing: whether `gate.code` is a string. It now also counts a record whose
terms the site withholds and a record whose level it withholds.

**`verified_records` on `/api/offers?limit=2000` falls from 1,413 to 646.** The 934 withheld
partition exactly: **167** gated, as before; **601** more whose `risk_level` is null and were
not gated — the population #1260 is about, which `/api/vendor-risk` already refuses to rate;
and **166** more whose terms are superseded and which were not caught by either of the other
two.

## Verification

**The surfaces that already withheld did not move.** 1,925 of 1,925 `/vendor/:slug` and
`/compare/:slug` pages byte-identical against a `main` build, which is what says pulling the
change index into shared code changed nothing where it already ran. `/compare/:slug` holds
the 369 asserting slots #1393 verified.

**Whole site.** 2,572 paths fetched from both builds: 2,249 identical, **323 moved, 0 status
changes, 0 line-count changes**. The moved set was predicted independently from the sweep
rather than read off the diff, and matches: the only apparent extra is `/this-week`, whose
difference is the percent-encoded base URL in its share links and which diffs clean when the
encoding is normalised; the only two predicted pages that did not move are the two hardcoded
strings above.

**End to end.** A real MCP `initialize` → `tools/call` for `search_deals({vendor: "Railway"})`
over streamable HTTP returns all six fields and the notice.

**3,984 tests, 15 new.** The new file fails 11 of 13 against a `main` build; the two that pass
there are the non-vacuity premise and the positive control, which is their job.

**16 mutations.** `data/page-reviews.json` moves four pages to `reads_changes: true` because
they now do.
