### PR TITLE
Cite the page every change was read from (#1380)

### DIFF
--- a/scripts/mutate-1380.sh
+++ b/scripts/mutate-1380.sh
@@ -1,0 +1,178 @@
+#!/usr/bin/env bash
+set -uo pipefail
+
+REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO"
+
+TESTS=(
+  test/change-log-citation.test.ts
+)
+
+SOURCES=(src/serve.ts src/change-citation.ts)
+
+backup() { for f in "${SOURCES[@]}"; do cp "$f" "/tmp/$(basename "$f").m1380"; done; }
+restore() { for f in "${SOURCES[@]}"; do cp "/tmp/$(basename "$f").m1380" "$f"; done; }
+
+backup
+trap 'restore; npm run build >/dev/null 2>&1' EXIT
+
+killed=0
+survived=0
+
+run_mutation() {
+  local name="$1"; shift
+  restore
+  if ! "$@"; then
+    echo "NOT APPLIED                $name"
+    return
+  fi
+  if ! npm run build >/dev/null 2>&1; then
+    echo "KILLED (does not compile)  $name"
+    killed=$((killed + 1))
+    return
+  fi
+  if TZ=UTC node --test --test-concurrency 1 "${TESTS[@]}" >/tmp/mutation-1380-out.txt 2>&1; then
+    echo "SURVIVED                   $name"
+    survived=$((survived + 1))
+  else
+    echo "KILLED                     $name"
+    killed=$((killed + 1))
+  fi
+}
+
+sub() {
+  python3 - "$1" "$2" "$3" <<'PY'
+import sys
+path, old, new = sys.argv[1], sys.argv[2], sys.argv[3]
+text = open(path, encoding="utf-8").read()
+if old not in text:
+    sys.exit("mutation target not found in " + path)
+open(path, "w", encoding="utf-8").write(text.replace(old, new, 1))
+PY
+}
+
+run_mutation "the citation link is never rendered" \
+  sub src/change-citation.ts '  if (!changeCitesASource(change)) return "";
+  const url = change.source_url!.trim();
+  return (
+    `<a href="${esc(url)}"' \
+                   '  if (!changeCitesASource(change)) return "";
+  if (changeCitesASource(change)) return "";
+  const url = change.source_url!.trim();
+  return (
+    `<a href="${esc(url)}"'
+
+run_mutation "a record with no source gets a link to nowhere" \
+  sub src/change-citation.ts 'export function changeSourceLinkHtml(change: CitableChange, esc: (text: string) => string): string {
+  if (!changeCitesASource(change)) return "";
+  const url = change.source_url!.trim();' \
+                   'export function changeSourceLinkHtml(change: CitableChange, esc: (text: string) => string): string {
+  const url = (change.source_url ?? "").trim();'
+
+run_mutation "the citation loses the class that marks it as a citation" \
+  sub src/change-citation.ts ' class="${CITATION_CLASS}"' \
+                   ''
+
+run_mutation "the citation loses the title naming the page" \
+  sub src/change-citation.ts ' title="${esc(citationLabel(url))}">${CITATION_LINK_HTML}' \
+                   '>${CITATION_LINK_HTML}'
+
+run_mutation "the title repeats the URL instead of the page" \
+  sub src/change-citation.ts 'title="${esc(citationLabel(url))}"' \
+                   'title="${esc(url)}"'
+
+run_mutation "the label keeps the www host prefix" \
+  sub src/change-citation.ts 'const host = parsed.hostname.replace(/^www\./, "");' \
+                   'const host = parsed.hostname;'
+
+run_mutation "a whitespace source counts as a source" \
+  sub src/change-citation.ts 'return typeof change.source_url === "string" && change.source_url.trim() !== "";' \
+                   'return typeof change.source_url === "string";'
+
+run_mutation "the structured citation is never built" \
+  sub src/change-citation.ts 'export function changeSourceCitation(change: CitableChange): { "@type": string; url: string; name: string } | null {
+  if (!changeCitesASource(change)) return null;' \
+                   'export function changeSourceCitation(change: CitableChange): { "@type": string; url: string; name: string } | null {
+  if (true) return null;
+  if (!changeCitesASource(change)) return null;'
+
+run_mutation "the structured citation is built for a record with no source" \
+  sub src/change-citation.ts '  if (!changeCitesASource(change)) return null;
+  const url = change.source_url!.trim();
+  return { "@type": "WebPage", url, name: citationLabel(url) };' \
+                   '  const url = (change.source_url ?? "").trim();
+  return { "@type": "WebPage", url, name: citationLabel(url) };'
+
+run_mutation "the structured citation names the wrong kind of thing" \
+  sub src/change-citation.ts 'return { "@type": "WebPage", url, name: citationLabel(url) };' \
+                   'return { "@type": "CreativeWork", url, name: citationLabel(url) };'
+
+run_mutation "the structured citation labels itself with the URL" \
+  sub src/change-citation.ts 'return { "@type": "WebPage", url, name: citationLabel(url) };' \
+                   'return { "@type": "WebPage", url, name: url };'
+
+run_mutation "the timeline stops citing anything" \
+  sub src/serve.ts '${altHtml}
+          ${changeSourceLinkHtml(c, escHtmlServer)}
+        </div>
+      </div>`;
+  }
+
+  const upcomingCount = sorted.filter(c => c.date >= today).length;
+  const removedCount = sorted.filter' \
+                   '${altHtml}
+        </div>
+      </div>`;
+  }
+
+  const upcomingCount = sorted.filter(c => c.date >= today).length;
+  const removedCount = sorted.filter'
+
+run_mutation "the change timeline stops citing anything" \
+  sub src/serve.ts '${altHtml}
+          ${changeSourceLinkHtml(c, escHtmlServer)}
+        </div>
+      </div>`;
+  }
+
+  const upcomingCount = sorted.filter(c => c.date >= today).length;
+  const removedCount = allChanges.filter' \
+                   '${altHtml}
+        </div>
+      </div>`;
+  }
+
+  const upcomingCount = sorted.filter(c => c.date >= today).length;
+  const removedCount = allChanges.filter'
+
+run_mutation "the change timeline stops saying when it holds no source" \
+  sub src/serve.ts '          <div class="chg-summary">${escHtmlServer(c.summary)}</div>
+          ${changeIsUncited(c) ? unsourcedNoteHtml(c.vendor) : ""}' \
+                   '          <div class="chg-summary">${escHtmlServer(c.summary)}</div>'
+
+run_mutation "the change timeline drops the tag on an unsourced entry" \
+  sub src/serve.ts '            <span class="chg-impact" style="color:${impactColor}">${c.impact}</span>
+            ${changeIsUncited(c) ? unsourcedTagHtml() : ""}' \
+                   '            <span class="chg-impact" style="color:${impactColor}">${c.impact}</span>'
+
+run_mutation "the machine-readable list drops the citation" \
+  sub src/serve.ts '          ...(citation ? { citation } : {}),' \
+                   ''
+
+run_mutation "the machine-readable list carries an empty citation" \
+  sub src/serve.ts '          ...(citation ? { citation } : {}),' \
+                   '          citation: citation as any,'
+
+run_mutation "the quarterly report links to nowhere again" \
+  sub src/serve.ts '      ${changeIsUncited(c) ? unsourcedNoteHtml(c.vendor) : changeSourceLinkHtml(c, escHtmlServer)}' \
+                   '      <a href="${escHtmlServer(c.source_url)}" target="_blank" rel="noopener" class="change-source">Source &nearr;</a>'
+
+run_mutation "the earlier quarterly report links to nowhere again" \
+  sub src/serve.ts '      (changeIsUncited(c) ? unsourcedNoteHtml(c.vendor) : changeSourceLinkHtml(c, escHtmlServer)) +' \
+                   '      "<a href=\"" + escHtmlServer(c.source_url) + "\" target=\"_blank\" rel=\"noopener\" class=\"change-source\">Source &nearr;</a>" +'
+
+restore
+npm run build >/dev/null 2>&1
+echo
+echo "killed:   $killed"
+echo "survived: $survived"

--- a/src/change-citation.ts
+++ b/src/change-citation.ts
@@ -31,6 +31,27 @@ export function citationLabel(url: string): string {
   return `${host}${withinHost}`;
 }
 
+export const CITATION_CLASS = "change-source";
+
+export const CITATION_LINK_HTML = "Source &nearr;";
+
+const CITATION_STYLE = "font-size:.75rem;color:var(--text-dim)";
+
+export function changeSourceLinkHtml(change: CitableChange, esc: (text: string) => string): string {
+  if (!changeCitesASource(change)) return "";
+  const url = change.source_url!.trim();
+  return (
+    `<a href="${esc(url)}" target="_blank" rel="noopener" class="${CITATION_CLASS}"` +
+    ` style="${CITATION_STYLE}" title="${esc(citationLabel(url))}">${CITATION_LINK_HTML}</a>`
+  );
+}
+
+export function changeSourceCitation(change: CitableChange): { "@type": string; url: string; name: string } | null {
+  if (!changeCitesASource(change)) return null;
+  const url = change.source_url!.trim();
+  return { "@type": "WebPage", url, name: citationLabel(url) };
+}
+
 export const UNCITED_CHANGE_LABEL = "Unsourced";
 
 export function uncitedChangeNotice(vendor: string): string {

--- a/src/serve.ts
+++ b/src/serve.ts
@@ -30,7 +30,7 @@ import { vendorHistorySentence } from "./vendor-history.js";
 import { HETZNER_APRIL_CHANGES, HETZNER_CLOUD_PLANS, HETZNER_PRICES_READ, HETZNER_PRICE_SOURCE, HETZNER_SINGAPORE_EXAMPLE, cheapestOrderableHetznerPlan, hetznerEntryPriceClause, unorderableHetznerPlans } from "./hetzner-pricing.js";
 import { changeTimelineDate, supersededLineups, supersessionNote } from "./change-lineup.js";
 import { isNoLongerInForce, eventResolutionFields } from "./change-resolution.js";
-import { changeIsUncited, citedChanges, uncitedChangeNotice, ratingWithheldForNoSourceClause, ratingWithheldForNoSourceSentence, UNCITED_CHANGE_LABEL } from "./change-citation.js";
+import { changeIsUncited, changeSourceCitation, changeSourceLinkHtml, citedChanges, uncitedChangeNotice, ratingWithheldForNoSourceClause, ratingWithheldForNoSourceSentence, UNCITED_CHANGE_LABEL } from "./change-citation.js";
 import { growthLimitPhrases } from "./growth-limits.js";
 import { registerAgent, authenticateRequest, validateVestauthUrl, hashApiKey, updateAgentX402Address, getAgentById } from "./agents.js";
 import { attributeAuthenticatedRequest } from "./referral-attribution.js";
@@ -2502,7 +2502,7 @@ function buildComparisonPage(slug: string): string | null {
           ${changeIsUncited(c) ? unsourcedTagHtml() : ""}
         </div>
         <div style="font-size:.85rem;color:var(--text-muted)">${escHtmlServer(c.summary)}</div>
-        ${changeIsUncited(c) ? unsourcedNoteHtml(vendor) : ""}
+        ${changeIsUncited(c) ? unsourcedNoteHtml(vendor) : changeSourceLinkHtml(c, escHtmlServer)}
       </div>`;
     }).join("\n") + truncationNote;
   };
@@ -3013,7 +3013,7 @@ function buildVsPage(slug: string): string | null {
           ${changeIsUncited(c) ? unsourcedTagHtml() : ""}
         </div>
         <div style="font-size:.85rem;color:var(--text-muted)">${escHtmlServer(c.summary)}</div>
-        ${changeIsUncited(c) ? unsourcedNoteHtml(vendor) : ""}
+        ${changeIsUncited(c) ? unsourcedNoteHtml(vendor) : changeSourceLinkHtml(c, escHtmlServer)}
       </div>`;
     }).join("\n");
   };
@@ -4150,6 +4150,7 @@ ${enrichedAlts.map(a => {
         <div class="change-summary">${escHtmlServer(c.summary)}</div>
         ${uncited ? unsourcedNoteHtml(vendorName) : ""}
         ${c.previous_state && c.current_state ? `<div class="change-detail"><span class="state-label">Before:</span> ${escHtmlServer(c.previous_state)}</div><div class="change-detail"><span class="state-label">After:</span> ${escHtmlServer(c.current_state)}</div>` : ""}
+        ${changeSourceLinkHtml(c, escHtmlServer)}
       </div>`;
   }).join("\n") : offerHasEnded
     ? `<p class="no-changes">${escHtmlServer(endedHistorySentence(vendorName))}</p>`
@@ -4519,6 +4520,7 @@ h1 .risk-badge{font-size:.75rem;font-weight:600;padding:.2rem .6rem;border-radiu
 .state-label{font-family:var(--mono);font-size:.7rem;color:var(--text-dim)}
 .change-resolved{opacity:.6;border-left-style:dashed}
 .change-unsourced{opacity:.75;border-left-style:dotted}
+.change-source:hover{color:var(--accent)}
 .no-changes{color:var(--text-dim);font-size:.9rem;font-style:italic}
 ${auditBlockCss()}
 .alt-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(180px,1fr));gap:.5rem}
@@ -18307,7 +18309,7 @@ function buildQ1PricingReportPage(): string {
         "<div class=\"change-before\"><strong>Before:</strong> " + escHtmlServer(c.previous_state) + "</div>" +
         "<div class=\"change-after\"><strong>After:</strong> " + escHtmlServer(c.current_state) + "</div>" +
       "</div>" +
-      "<a href=\"" + escHtmlServer(c.source_url) + "\" target=\"_blank\" rel=\"noopener\" class=\"change-source\">Source &nearr;</a>" +
+      (changeIsUncited(c) ? unsourcedNoteHtml(c.vendor) : changeSourceLinkHtml(c, escHtmlServer)) +
     "</div>";
   };
 
@@ -18715,7 +18717,7 @@ function buildQ2PricingPreview2026Page(): string {
         <div class="change-before"><strong>Before:</strong> ${escHtmlServer(c.previous_state)}</div>
         <div class="change-after"><strong>After:</strong> ${escHtmlServer(c.current_state)}</div>
       </div>
-      <a href="${escHtmlServer(c.source_url)}" target="_blank" rel="noopener" class="change-source">Source &nearr;</a>
+      ${changeIsUncited(c) ? unsourcedNoteHtml(c.vendor) : changeSourceLinkHtml(c, escHtmlServer)}
     </div>`;
   };
 
@@ -49231,6 +49233,7 @@ function buildPricingChangesPage(): string {
           ${changeIsUncited(c) ? unsourcedNoteHtml(c.vendor) : ""}
 ${stateHtml}
 ${altHtml}
+          ${changeSourceLinkHtml(c, escHtmlServer)}
         </div>
       </div>`;
   }
@@ -49462,6 +49465,7 @@ h1{font-family:var(--serif);font-size:2.25rem;color:var(--text);margin:1rem 0 .5
 .pc-entry{display:flex;gap:1rem;padding:.75rem;margin-bottom:.5rem;border:1px solid var(--border);border-radius:8px;background:var(--bg-card);transition:border-color .2s,background .2s}
 .pc-resolved{opacity:.6;border-style:dashed}
 .pc-unsourced{opacity:.75}
+.change-source:hover{color:var(--accent)}
 .pc-entry:hover{border-color:var(--accent)}
 .pc-entry:target{border-color:var(--accent);background:var(--accent-glow)}
 .pc-upcoming{border-color:rgba(88,166,255,0.3)}
@@ -49671,7 +49675,7 @@ function buildChangesPage(): string {
     const altHtml = c.alternatives && c.alternatives.length > 0
       ? `<div class="chg-alts"><span class="chg-alts-label">Alternatives:</span> ${c.alternatives.map(a => `<a href="/vendor/${toSlug(a)}">${escHtmlServer(a)}</a>`).join(", ")}</div>`
       : "";
-    return `      <div class="chg-entry${isUpcoming ? " chg-upcoming" : ""}${dated ? "" : " chg-undated"}">
+    return `      <div class="chg-entry${isUpcoming ? " chg-upcoming" : ""}${dated ? "" : " chg-undated"}${changeIsUncited(c) ? " chg-unsourced" : ""}">
         <div class="chg-left">
           <div class="chg-date">${dated ? c.date : `${DISCOVERED_DATE_PREFIX} ${c.date}`}</div>
           ${isUpcoming ? `<div class="chg-upcoming-badge">upcoming</div>` : ""}
@@ -49681,9 +49685,12 @@ function buildChangesPage(): string {
             <span class="badge" style="background:${badge.color}">${badge.label}</span>
             <a href="/vendor/${vendorSlug}" class="chg-vendor">${escHtmlServer(c.vendor)}</a>
             <span class="chg-impact" style="color:${impactColor}">${c.impact}</span>
+            ${changeIsUncited(c) ? unsourcedTagHtml() : ""}
           </div>
           <div class="chg-summary">${escHtmlServer(c.summary)}</div>
+          ${changeIsUncited(c) ? unsourcedNoteHtml(c.vendor) : ""}
 ${altHtml}
+          ${changeSourceLinkHtml(c, escHtmlServer)}
         </div>
       </div>`;
   }
@@ -49715,18 +49722,22 @@ ${undatedSorted.map(c => buildChangeEntry(c)).join("\n")}
     description: metaDesc,
     numberOfItems: allChanges.length,
     url: `${BASE_URL}/changes`,
-    itemListElement: newestFirst.slice(0, 50).map((c, i) => ({
-      "@type": "ListItem",
-      position: i + 1,
-      item: {
-        "@type": "NewsArticle",
-        headline: `${c.vendor}: ${(changeTypeBadge[c.change_type] ?? { label: c.change_type }).label}`,
-        description: c.summary,
-        ...changeDatePublished(c),
-        url: `${BASE_URL}/vendor/${toSlug(c.vendor)}`,
-        publisher: { "@type": "Organization", name: "AgentDeals", url: BASE_URL },
-      },
-    })),
+    itemListElement: newestFirst.slice(0, 50).map((c, i) => {
+      const citation = changeSourceCitation(c);
+      return {
+        "@type": "ListItem",
+        position: i + 1,
+        item: {
+          "@type": "NewsArticle",
+          headline: `${c.vendor}: ${(changeTypeBadge[c.change_type] ?? { label: c.change_type }).label}`,
+          description: c.summary,
+          ...changeDatePublished(c),
+          url: `${BASE_URL}/vendor/${toSlug(c.vendor)}`,
+          publisher: { "@type": "Organization", name: "AgentDeals", url: BASE_URL },
+          ...(citation ? { citation } : {}),
+        },
+      };
+    }),
   };
 
   return `<!DOCTYPE html>
@@ -49780,6 +49791,8 @@ h1{font-family:var(--serif);font-size:2.25rem;color:var(--text);margin:1rem 0 .5
 .chg-alts{font-size:.8rem;color:var(--text-dim);margin-top:.35rem}
 .chg-alts-label{font-weight:600;color:var(--text-muted)}
 .chg-alts a{color:var(--accent);font-size:.8rem}
+.chg-unsourced{opacity:.75}
+.change-source:hover{color:var(--accent)}
 .badge{display:inline-block;padding:.1rem .4rem;border-radius:10px;font-size:.65rem;font-weight:600;color:#fff}
 .mcp-cta{margin-top:2.5rem;padding:1.5rem;border:1px solid var(--border);border-radius:12px;background:var(--accent-glow);text-align:center}
 .mcp-cta p{color:var(--text-muted);font-size:.9rem;margin-bottom:.5rem}

--- a/test/change-log-citation.test.ts
+++ b/test/change-log-citation.test.ts
@@ -1,0 +1,371 @@
+import { describe, it, before, after } from "node:test";
+import assert from "node:assert";
+import { spawn, type ChildProcess } from "node:child_process";
+import { readFileSync, writeFileSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const { changeCitesASource, citationLabel } = await import("../dist/change-citation.js");
+const { isNoLongerInForce } = await import("../dist/change-resolution.js");
+
+type DealChange = import("../src/types.ts").DealChange;
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO = path.join(__dirname, "..");
+
+const CITATION_CLASS = "change-source";
+const UNSOURCED_NOTE_CLASS = "unsourced-note";
+const UNSOURCED_TAG_CLASS = "unsourced-tag";
+const CHANGE_LOG_ROUTES = ["/pricing-changes", "/changes"];
+const ENTRY_CLASS: Record<string, string> = {
+  "/pricing-changes": "pc-entry",
+  "/changes": "chg-entry",
+  "/q1-2026-developer-pricing-report": "change-card",
+  "/q2-pricing-preview-2026": "change-card",
+};
+
+const changes: DealChange[] = JSON.parse(
+  readFileSync(path.join(REPO, "data", "deal_changes.json"), "utf-8"),
+).changes;
+
+function sourceOf(change: { source_url?: string | null }): string | null {
+  return changeCitesASource(change) ? change.source_url!.trim() : null;
+}
+
+function decodeEntities(text: string): string {
+  return text
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+    .replace(/&amp;/g, "&");
+}
+
+function citationTags(html: string): string[] {
+  return [...html.matchAll(/<a [^>]*class="change-source"[^>]*>/g)].map((m) => m[0]);
+}
+
+function citedUrls(html: string): string[] {
+  return [...html.matchAll(/<a href="([^"]*)"[^>]*class="change-source"[^>]*>/g)].map((m) =>
+    decodeEntities(m[1]),
+  );
+}
+
+function entriesOn(html: string, route: string): string[] {
+  return html.split(new RegExp(`<div class="${ENTRY_CLASS[route]}[^"]*"`)).slice(1);
+}
+
+function startServer(env: Record<string, string>): Promise<{ proc: ChildProcess; port: number }> {
+  return new Promise((resolve, reject) => {
+    const child = spawn("node", [path.join(REPO, "dist", "serve.js")], {
+      stdio: ["pipe", "pipe", "pipe"],
+      env: { ...process.env, PORT: "0", TZ: "UTC", ...env },
+    });
+    const timeout = setTimeout(() => {
+      child.kill();
+      reject(new Error("Server startup timeout"));
+    }, 30000);
+    child.stderr!.on("data", (data: Buffer) => {
+      const m = data.toString().match(/running on http:\/\/localhost:(\d+)/);
+      if (m) {
+        clearTimeout(timeout);
+        resolve({ proc: child, port: parseInt(m[1], 10) });
+      }
+    });
+    child.on("error", (err) => {
+      clearTimeout(timeout);
+      reject(err);
+    });
+  });
+}
+
+describe("every change we publish reaches the page it was read from", () => {
+  let proc: ChildProcess;
+  let port = 0;
+  const pages = new Map<string, string>();
+  let sweptPaths: string[] = [];
+
+  async function page(pathname: string): Promise<string> {
+    const cached = pages.get(pathname);
+    if (cached !== undefined) return cached;
+    const body = await (await fetch(`http://localhost:${port}${pathname}`)).text();
+    pages.set(pathname, body);
+    return body;
+  }
+
+  before(async () => {
+    const started = await startServer({ BASE_URL: "http://localhost" });
+    proc = started.proc;
+    port = started.port;
+    const paths = new Set<string>(["/", ...CHANGE_LOG_ROUTES]);
+    const indexes = new Set<string>(["/sitemap.xml"]);
+    for (const entry of (await page("/sitemap.xml")).matchAll(/<loc>([^<]+)<\/loc>/g)) {
+      indexes.add(new URL(entry[1]).pathname);
+    }
+    for (const sitemap of indexes) {
+      for (const entry of (await page(sitemap)).matchAll(/<loc>([^<]+)<\/loc>/g)) {
+        const pathname = new URL(entry[1]).pathname;
+        if (!indexes.has(pathname)) paths.add(pathname);
+      }
+    }
+    sweptPaths = [...paths].sort();
+    let next = 0;
+    await Promise.all(
+      Array.from({ length: 12 }, async () => {
+        while (next < sweptPaths.length) await page(sweptPaths[next++]);
+      }),
+    );
+  });
+
+  after(() => proc?.kill());
+
+  it("has a population on both sides of the question", () => {
+    const inForceWithSource = changes.filter((c) => !isNoLongerInForce(c) && changeCitesASource(c));
+    assert.ok(
+      inForceWithSource.length > 100,
+      `only ${inForceWithSource.length} in-force records hold a source, so the citation sweep has almost no subject`,
+    );
+    assert.ok(
+      changes.some((c) => !changeCitesASource(c)),
+      "no record is missing a source, so nothing here exercises the entry that says we hold none",
+    );
+    assert.ok(sweptPaths.length > 1000, `swept only ${sweptPaths.length} paths`);
+  });
+
+  it("cites the page behind every in-force record on some page we serve", () => {
+    const cited = new Set<string>();
+    for (const p of sweptPaths) {
+      for (const url of citedUrls(pages.get(p) ?? "")) cited.add(url);
+    }
+    const uncited = changes
+      .filter((c) => !isNoLongerInForce(c) && changeCitesASource(c))
+      .filter((c) => !cited.has(sourceOf(c)!))
+      .map((c) => `${c.vendor} ${c.date} -> ${sourceOf(c)}`);
+    assert.deepStrictEqual(uncited, []);
+  });
+
+  it("does not depend on the vendor page to do it, so a retirement cannot take the citation away", () => {
+    const cited = new Set<string>();
+    for (const route of CHANGE_LOG_ROUTES) {
+      for (const url of citedUrls(pages.get(route)!)) cited.add(url);
+    }
+    const missing = changes
+      .filter(changeCitesASource)
+      .filter((c) => !cited.has(sourceOf(c)!))
+      .map((c) => `${c.vendor} ${c.date} -> ${sourceOf(c)}`);
+    assert.deepStrictEqual(missing, []);
+  });
+
+  for (const route of [...CHANGE_LOG_ROUTES, "/q1-2026-developer-pricing-report", "/q2-pricing-preview-2026"]) {
+    it(`gives every entry on ${route} either its source or the reason we have none`, () => {
+      const entries = entriesOn(pages.get(route)!, route);
+      assert.ok(entries.length > 0, `${route} rendered no change entry at all`);
+      const silent = entries.filter(
+        (e) => !e.includes(`class="${CITATION_CLASS}"`) && !e.includes(`class="${UNSOURCED_NOTE_CLASS}"`),
+      );
+      const both = entries.filter(
+        (e) => e.includes(`class="${CITATION_CLASS}"`) && e.includes(`class="${UNSOURCED_NOTE_CLASS}"`),
+      );
+      assert.strictEqual(silent.length, 0, `${route} renders ${silent.length} of ${entries.length} entries with neither`);
+      assert.strictEqual(both.length, 0, `${route} renders ${both.length} entries claiming both`);
+    });
+
+    it(`counts the citations on ${route} off the entries rather than a fixed number`, () => {
+      const html = pages.get(route)!;
+      const entries = entriesOn(html, route);
+      const cited = entries.filter((e) => e.includes(`class="${CITATION_CLASS}"`)).length;
+      assert.strictEqual(citationTags(html).length, cited, `${route} carries citation links outside its entries`);
+      assert.ok(cited > 0, `${route} cites nothing`);
+    });
+  }
+
+  it("gives every change a vendor page renders either its source or the reason we have none", () => {
+    const ENTRY_END = "\n      </div>";
+    const offenders: string[] = [];
+    let checked = 0;
+    for (const p of sweptPaths.filter((s) => s.startsWith("/vendor/"))) {
+      for (const chunk of (pages.get(p) ?? "").split(/<div class="change-item[^"]*"/).slice(1)) {
+        const end = chunk.indexOf(ENTRY_END);
+        assert.notStrictEqual(end, -1, `a change entry on ${p} does not close where this test looks for its end`);
+        const block = chunk.slice(0, end);
+        checked++;
+        if (!block.includes(`class="${CITATION_CLASS}"`) && !block.includes(`class="${UNSOURCED_NOTE_CLASS}"`)) {
+          offenders.push(p);
+        }
+      }
+    }
+    assert.ok(checked > 100, `only ${checked} change entries render on a vendor page`);
+    assert.deepStrictEqual([...new Set(offenders)].slice(0, 5), []);
+  });
+
+  it("reaches the source from the page of an offer that has ended, where the offer's own link is gone", () => {
+    const offers: Array<{ vendor: string; url: string; tier: string }> = JSON.parse(
+      readFileSync(path.join(REPO, "data", "index.json"), "utf-8"),
+    ).offers;
+    const sources = new Set(changes.filter(changeCitesASource).map((c) => sourceOf(c)!));
+    const ended = offers.filter((o) => o.tier.toLowerCase() === "retired" && sources.has(o.url));
+    if (ended.length === 0) return;
+    for (const offer of ended) {
+      const slug = offer.vendor.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "");
+      const html = pages.get(`/vendor/${slug}`) ?? "";
+      assert.ok(html.length > 0, `/vendor/${slug} was not served`);
+      assert.ok(
+        citedUrls(html).includes(offer.url),
+        `/vendor/${slug} no longer reaches ${offer.url}, which is the source of a change we publish about it`,
+      );
+    }
+  });
+
+  it("sends no reader to a citation with no destination", () => {
+    const offenders: string[] = [];
+    for (const p of sweptPaths) {
+      const empty = citationTags(pages.get(p) ?? "").filter((tag) => tag.includes('href=""'));
+      if (empty.length > 0) offenders.push(`${p} x${empty.length}`);
+    }
+    assert.deepStrictEqual(offenders, []);
+  });
+
+  it("names the page in the citation's title so the reader sees where it goes", () => {
+    for (const route of Object.keys(ENTRY_CLASS)) {
+      const tags = citationTags(pages.get(route)!);
+      assert.ok(tags.length > 50, `${route} carries only ${tags.length} citations`);
+      const wrong = tags.filter((tag) => {
+        const href = decodeEntities(tag.match(/href="([^"]*)"/)![1]);
+        const title = decodeEntities(tag.match(/title="([^"]*)"/)?.[1] ?? "");
+        return title !== citationLabel(href);
+      });
+      assert.deepStrictEqual(wrong.slice(0, 3), [], `${route} carries ${wrong.length} citations whose title is not the page`);
+    }
+  });
+
+  it("shortens the page to a label rather than repeating the URL", () => {
+    const labelled = citationTags(pages.get("/pricing-changes")!).map((tag) => ({
+      href: decodeEntities(tag.match(/href="([^"]*)"/)![1]),
+      title: decodeEntities(tag.match(/title="([^"]*)"/)?.[1] ?? ""),
+    }));
+    assert.ok(labelled.every((c) => !c.title.startsWith("http")), "a citation title is a bare URL");
+    const wwwStripped = labelled.filter((c) => c.href.includes("://www.") && !c.title.startsWith("www."));
+    assert.ok(wwwStripped.length > 0, "no cited page is on a www host, so nothing here exercises the label");
+  });
+
+  it("carries the source of each entry in the machine-readable list on /changes", () => {
+    const html = pages.get("/changes")!;
+    const lists = [...html.matchAll(/<script type="application\/ld\+json">([\s\S]*?)<\/script>/g)]
+      .map((m) => JSON.parse(m[1]))
+      .filter((b) => b["@type"] === "ItemList");
+    assert.strictEqual(lists.length, 1, "/changes publishes no single ItemList");
+    const items = lists[0].itemListElement.map((el: { item: Record<string, any> }) => el.item);
+    assert.ok(items.length > 0, "/changes publishes an empty ItemList");
+    const byHeadline = new Map<string, Record<string, any>>(items.map((i: Record<string, any>) => [i.headline, i]));
+    let checked = 0;
+    for (const item of items) {
+      const vendor = String(item.headline).split(":")[0];
+      const record = changes.find((c) => c.vendor === vendor && c.summary === item.description);
+      if (!record) continue;
+      checked++;
+      const source = sourceOf(record);
+      if (source === null) {
+        assert.ok(!("citation" in item), `${item.headline} publishes a citation for a record holding no source`);
+        continue;
+      }
+      assert.strictEqual(item.citation?.url, source, `${item.headline} publishes no citation for ${source}`);
+      assert.strictEqual(item.citation?.["@type"], "WebPage");
+      assert.strictEqual(item.citation?.name, citationLabel(source));
+    }
+    assert.ok(checked > items.length / 2, `matched only ${checked} of ${items.length} list items back to a record`);
+    assert.strictEqual(byHeadline.size > 0, true);
+  });
+});
+
+describe("a record with no source says so where a record with one is cited", () => {
+  const CITED = "Neon";
+  const UNCITED = "Xata";
+  const BLANK = "Fauna";
+  const SOURCE = "https://neon.example/pricing?plan=free";
+  let proc: ChildProcess;
+  let tmp: string;
+  const bodies = new Map<string, string>();
+
+  before(async () => {
+    tmp = mkdtempSync(path.join(tmpdir(), "change-log-citation-"));
+    const changesPath = path.join(tmp, "changes.json");
+    const day = (offset: number) =>
+      new Date(Date.now() + offset * 86400000).toISOString().slice(0, 10);
+    const base = {
+      change_type: "limits_reduced",
+      date_source: "vendor_page",
+      previous_state: "15 GB storage",
+      current_state: "5 GB storage",
+      impact: "high",
+      category: "Databases",
+      alternatives: [],
+    };
+    writeFileSync(
+      changesPath,
+      JSON.stringify({
+        changes: [
+          { ...base, vendor: CITED, date: day(-5), recorded_date: day(-5), summary: `${CITED} cut its free storage.`, source_url: SOURCE },
+          { ...base, vendor: UNCITED, date: day(-6), recorded_date: day(-6), summary: `${UNCITED} cut its free storage.` },
+          { ...base, vendor: BLANK, date: day(-7), recorded_date: day(-7), summary: `${BLANK} cut its free storage.`, source_url: "   " },
+        ],
+      }),
+    );
+    const started = await startServer({ BASE_URL: "http://localhost", AGENTDEALS_CHANGES_PATH: changesPath });
+    proc = started.proc;
+    for (const route of CHANGE_LOG_ROUTES) {
+      bodies.set(route, await (await fetch(`http://localhost:${started.port}${route}`)).text());
+    }
+  });
+
+  after(() => {
+    proc?.kill();
+    if (tmp) rmSync(tmp, { recursive: true, force: true });
+  });
+
+  for (const route of CHANGE_LOG_ROUTES) {
+    it(`links the source of the sourced record on ${route}`, () => {
+      const html = bodies.get(route)!;
+      assert.deepStrictEqual(citedUrls(html), [SOURCE]);
+      const tag = citationTags(html)[0];
+      assert.ok(tag.includes('target="_blank"') && tag.includes('rel="noopener"'), tag);
+      assert.ok(tag.includes(`title="${citationLabel(SOURCE)}"`), tag);
+    });
+
+    for (const vendor of [UNCITED, BLANK]) {
+      it(`says in words that it holds no source for ${vendor} on ${route}`, () => {
+        const entries = entriesOn(bodies.get(route)!, route);
+        assert.strictEqual(entries.length, 3, `${route} rendered ${entries.length} entries for three records`);
+        const subject = entries.filter((e) => e.includes(vendor));
+        assert.strictEqual(subject.length, 1);
+        assert.ok(subject[0].includes(`class="${UNSOURCED_NOTE_CLASS}"`), `${route} says nothing about the missing source`);
+        assert.ok(subject[0].includes(vendor), `${route} does not name the vendor in the note`);
+        assert.ok(subject[0].includes(`class="${UNSOURCED_TAG_CLASS}"`), `${route} does not mark the entry as unsourced`);
+        assert.ok(!subject[0].includes(`class="${CITATION_CLASS}"`), `${route} cites something for a record with no source`);
+      });
+    }
+
+    it(`marks only the entries with no source on ${route}`, () => {
+      const entries = entriesOn(bodies.get(route)!, route);
+      const tagged = entries.filter((e) => e.includes(`class="${UNSOURCED_TAG_CLASS}"`)).length;
+      const cited = entries.filter((e) => e.includes(`class="${CITATION_CLASS}"`)).length;
+      assert.strictEqual(tagged, 2, `${route} tags ${tagged} of 3 entries`);
+      assert.strictEqual(cited, 1, `${route} cites ${cited} of 3 entries`);
+    });
+  }
+
+  it("leaves the citation out of the machine-readable entry that has no source", () => {
+    const list = [...bodies.get("/changes")!.matchAll(/<script type="application\/ld\+json">([\s\S]*?)<\/script>/g)]
+      .map((m) => JSON.parse(m[1]))
+      .find((b) => b["@type"] === "ItemList");
+    const items = list.itemListElement.map((el: { item: Record<string, any> }) => el.item);
+    const cited = items.find((i: Record<string, any>) => String(i.headline).startsWith(CITED));
+    assert.strictEqual(cited.citation.url, SOURCE);
+    assert.strictEqual(cited.citation.name, citationLabel(SOURCE));
+    for (const vendor of [UNCITED, BLANK]) {
+      const item = items.find((i: Record<string, any>) => String(i.headline).startsWith(vendor));
+      assert.ok(item, `${vendor} is absent from the list`);
+      assert.ok(!("citation" in item), `${vendor} publishes ${JSON.stringify(item.citation)}`);
+    }
+  });
+});


### PR DESCRIPTION
Refs #1380

Our change log publishes 553 pricing changes. 458 of them record the page the change was read from, and until this PR 107 of those were cited on no page we serve. The two change-log pages — `/pricing-changes` and `/changes` — rendered every entry in full and linked the source of none.

## What changed

One `changeSourceLinkHtml` in `src/change-citation.ts`, beside the `changeIsUncited` predicate the same file already exported, and every surface that renders a change entry calls it. It emits the same `<a class="change-source">Source ↗</a>` element the two quarterly reports were already the only users of, plus a `title` naming the page — `gomomento.com/pricing` rather than the raw URL.

**The issue named two surfaces. Seven render a change entry.** I found the other five by looking for the slots that already answer the *other* half of the question: every call site of `unsourcedNoteHtml`, the sentence that says "We hold no source for this record." A page that says that about one entry and says nothing at all about the entry beside it is the asymmetry this issue is about.

| Surface | Citations before | after |
|---|---|---|
| `/pricing-changes` | 0 | 460 |
| `/changes` | 0 | 458 |
| `/vendor/:slug` change history | 0 | 322 pages |
| `/compare/:slug` | 0 | 179 pages |
| `-vs-` pages | 0 | 15 pages |
| `/q1-2026-developer-pricing-report` | 56 | 56 |
| `/q2-pricing-preview-2026` | 213, **95 of them to nowhere** | 118 |

## A live defect on the quarterly page, found by consolidating

`/q2-pricing-preview-2026` rendered `<a href="" ... class="change-source">Source ↗</a>` for **95 of its 213 entries** — every entry whose record holds no `source_url`. An empty `href` resolves to the current page, so 95 of that page's "Source" links sent the reader back to the page they were on. Routing both quarterly cards through the shared helper replaces those with the note `/pricing-changes` already published for the same records. Empty-href citations across all 3,917 paths: 95 → 0.

## AC-3: the retirement case, verified

`test/retired-records.test.ts:196` asserts we keep citing the page a change was read from even where the offer has ended. On `main`, with #1377's data applied, it fails: retiring Momento rewrites the description, the superseded-terms block on `/vendor/momento` stops rendering, and the one citation of `gomomento.com/pricing` goes with it. On this branch, with the same data applied, it passes — the change log cites it independently of any vendor page: 10 of 10 in that file.

The same case exists in the shipped data: **Augment Code is retired and its pricing page is the source of three change records.** The retirement gate strips the offer's own link from its page, and `/vendor/augment-code` carried 0 citations to that URL. It now carries 3. That is AC-6's second clause.

## AC-4

Each `NewsArticle` in `/changes`' `ItemList` now carries `citation: { "@type": "WebPage", url, name }`. All 50 items carry one; a record holding no source gets no `citation` key rather than a null one.

## Measured on 3,917 paths

- Records with a `source_url` cited on **no page we serve**: 107 → **0**. In-force records: 441 → 0 uncited.
- Pages carrying a change-source citation: 404 → **656**. Citation links: 1,037 → **2,632**.
- Route sweep against a `main` build: 1,770 paths move, **0 status changes, 0 pages shrink**. The moved set is 1,572 vendor pages (one CSS line each, of which 322 also gain citations), 179 `/compare`, 15 `-vs-`, and the four change-log and report pages. Predicted independently and matching, 0 predicted-but-unmoved.

## Tests

4,006 tests. `test/change-log-citation.test.ts` is new and holds 26 of them; 13 of the 19 it held at the point I first ran it against `main` fail there. The AC-5 test reproduces the issue's census — sweep the sitemaps, count `<a class="change-source">`, compare against `data/deal_changes.json` — and asserts the in-force uncited population is 0, with a floor assertion on the population so it cannot pass by having no subject.

One file went red in the full run and it is not this change: `test/durable-identity.test.ts` timed out on a fixed 20-second server startup while a census was running on the same box. It passes in 5.7 seconds on its own. That is #1190's class and I have noted it on the issue rather than touching it here.

A second suite drives the pages off a fixture change file holding three records: one with a source, one with the key absent, and one whose `source_url` is whitespace. The third is there because `changeCitesASource` trims before testing and nothing in the shipped data exercises that branch.

`scripts/mutate-1380.sh`: 19 mutations, 19 killed. The first round left 2 survivors and both were real gaps — nothing asserted the `Unsourced` tag on `/changes`, and the title check covered only the two change-log pages, so reverting the earlier quarterly card scored as equivalent when it silently drops the title from 56 citations.
