### PR TITLE
Give every stack recommendation the verdict its own badge publishes (#1400)

### DIFF
--- a/data/page-reviews.json
+++ b/data/page-reviews.json
@@ -79,7 +79,7 @@
     {
       "path": "/agent-stack",
       "published": "2026-03-19",
-      "tier": "B",
+      "tier": "A",
       "vendors_asserted": [],
       "vendors_tabulated": [],
       "badge_subjects_unresolved": [],
@@ -749,9 +749,7 @@
         "emailvalidation-io",
         "loops",
         "mailchimp",
-        "mailerlite-com",
         "maileroo",
-        "mailersend-com",
         "mailjet",
         "plunk",
         "postmark",
@@ -785,7 +783,6 @@
       ],
       "vendors_tabulated": [
         "codesandbox",
-        "cursor",
         "github-codespaces",
         "gitpod",
         "lovable",
@@ -945,6 +942,7 @@
         "railway",
         "resend",
         "sentry",
+        "swaggo-swag",
         "upstash"
       ],
       "vendors_tabulated": [],
@@ -998,7 +996,8 @@
         "posthog",
         "railway",
         "resend",
-        "sentry"
+        "sentry",
+        "stripe"
       ],
       "vendors_tabulated": [],
       "badge_subjects_unresolved": [],
@@ -1293,6 +1292,7 @@
         "google-ai-pro-ultra",
         "google-cloud-run",
         "groq",
+        "mistral-ai",
         "openrouter",
         "oracle-cloud",
         "railway",
@@ -1343,7 +1343,6 @@
       "published": "2026-03-25",
       "tier": "A",
       "vendors_asserted": [
-        "digitalocean",
         "ovhcloud"
       ],
       "vendors_tabulated": [
@@ -1616,7 +1615,13 @@
         "openrouter"
       ],
       "vendors_tabulated": [
-        "anthropic-api"
+        "anthropic-api",
+        "deepseek-api",
+        "fireworks-ai",
+        "google-gemini-api",
+        "mistral-ai",
+        "openai",
+        "together-ai"
       ],
       "badge_subjects_unresolved": [],
       "reviewed_at": null,
@@ -1876,6 +1881,96 @@
       "tier": "B",
       "vendors_asserted": [],
       "vendors_tabulated": [],
+      "badge_subjects_unresolved": [],
+      "reviewed_at": null,
+      "reviewer": null,
+      "review_outcome": null,
+      "review_note": null,
+      "reads_index": true,
+      "reads_changes": true,
+      "data_source": "catalogue",
+      "data_source_reason": null
+    },
+    {
+      "path": "/stacks/ai-startup",
+      "published": "2026-04-04",
+      "tier": "A",
+      "vendors_asserted": [],
+      "vendors_tabulated": [
+        "hosting-checker"
+      ],
+      "badge_subjects_unresolved": [],
+      "reviewed_at": null,
+      "reviewer": null,
+      "review_outcome": null,
+      "review_note": null,
+      "reads_index": true,
+      "reads_changes": true,
+      "data_source": "catalogue",
+      "data_source_reason": null
+    },
+    {
+      "path": "/stacks/api-first",
+      "published": "2026-04-04",
+      "tier": "A",
+      "vendors_asserted": [],
+      "vendors_tabulated": [
+        "hosting-checker"
+      ],
+      "badge_subjects_unresolved": [],
+      "reviewed_at": null,
+      "reviewer": null,
+      "review_outcome": null,
+      "review_note": null,
+      "reads_index": true,
+      "reads_changes": true,
+      "data_source": "catalogue",
+      "data_source_reason": null
+    },
+    {
+      "path": "/stacks/open-source",
+      "published": "2026-04-01",
+      "tier": "A",
+      "vendors_asserted": [],
+      "vendors_tabulated": [
+        "hosting-checker"
+      ],
+      "badge_subjects_unresolved": [],
+      "reviewed_at": null,
+      "reviewer": null,
+      "review_outcome": null,
+      "review_note": null,
+      "reads_index": true,
+      "reads_changes": true,
+      "data_source": "catalogue",
+      "data_source_reason": null
+    },
+    {
+      "path": "/stacks/saas-mvp",
+      "published": "2026-04-04",
+      "tier": "A",
+      "vendors_asserted": [],
+      "vendors_tabulated": [
+        "hosting-checker"
+      ],
+      "badge_subjects_unresolved": [],
+      "reviewed_at": null,
+      "reviewer": null,
+      "review_outcome": null,
+      "review_note": null,
+      "reads_index": true,
+      "reads_changes": true,
+      "data_source": "catalogue",
+      "data_source_reason": null
+    },
+    {
+      "path": "/stacks/side-project",
+      "published": "2026-04-04",
+      "tier": "A",
+      "vendors_asserted": [],
+      "vendors_tabulated": [
+        "hosting-checker"
+      ],
       "badge_subjects_unresolved": [],
       "reviewed_at": null,
       "reviewer": null,

--- a/scripts/mutate-1400.sh
+++ b/scripts/mutate-1400.sh
@@ -1,0 +1,228 @@
+#!/usr/bin/env bash
+set -uo pipefail
+
+REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO"
+
+TESTS=(
+  test/stack-page-verdicts.test.ts
+)
+
+SOURCES=(src/serve.ts src/stack-claim.ts)
+
+backup() { for f in "${SOURCES[@]}"; do cp "$f" "/tmp/$(basename "$f").m1400"; done; }
+restore() { for f in "${SOURCES[@]}"; do cp "/tmp/$(basename "$f").m1400" "$f"; done; }
+
+backup
+trap 'restore; npm run build >/dev/null 2>&1' EXIT
+
+killed=0
+survived=0
+
+run_mutation() {
+  local name="$1"; shift
+  restore
+  if ! "$@"; then
+    echo "NOT APPLIED                $name"
+    return
+  fi
+  if ! npm run build >/dev/null 2>&1; then
+    echo "KILLED (does not compile)  $name"
+    killed=$((killed + 1))
+    return
+  fi
+  if TZ=UTC node --test --test-concurrency 1 "${TESTS[@]}" >/tmp/mutation-1400-out.txt 2>&1; then
+    echo "SURVIVED                   $name"
+    survived=$((survived + 1))
+  else
+    echo "KILLED                     $name"
+    killed=$((killed + 1))
+  fi
+}
+
+sub() {
+  python3 - "$1" "$2" "$3" <<'PY'
+import sys
+path, old, new = sys.argv[1], sys.argv[2], sys.argv[3]
+text = open(path, encoding="utf-8").read()
+if old not in text:
+    sys.exit("mutation target not found in " + path)
+open(path, "w", encoding="utf-8").write(text.replace(old, new, 1))
+PY
+}
+
+run_mutation "a removed free tier is recommendable again" \
+  sub src/stack-claim.ts 'export function mayRecommendAsFree(status: StackBadgeStatus): boolean {
+  return !freeTierHasEnded(status);
+}' \
+                         'export function mayRecommendAsFree(_status: StackBadgeStatus): boolean {
+  return true;
+}'
+
+run_mutation "a retired offer counts as recommendable" \
+  sub src/stack-claim.ts '  return status === "removed" || status === "retired";' \
+                         '  return status === "removed";'
+
+run_mutation "the chip states our rating rather than what the badge publishes" \
+  sub src/serve.ts '    verdict: badge.label,' \
+                   '    verdict: publishedVendorLevel(context.enriched.risk_level ?? null, context.enriched.risk_cause),'
+
+run_mutation "the chip always reads active" \
+  sub src/serve.ts '    verdict: badge.label,' \
+                   '    verdict: "active",'
+
+run_mutation "the table row states no verdict" \
+  sub src/serve.ts '    verdict: stackVerdictChipHtml(reading),
+  };' \
+                   '    verdict: "",
+  };'
+
+run_mutation "the pick card states no verdict" \
+  sub src/serve.ts '          ${stackVerdictChipHtml(reading, { compact: true })}
+        </div>
+        <p class="pick-why">${escHtmlServer(reading.recommendable ? why : reading.why)}</p>
+        <p class="pick-limits">${stackKeyLimitHtml(reading, 220)}</p>' \
+                   '        </div>
+        <p class="pick-why">${escHtmlServer(reading.recommendable ? why : reading.why)}</p>
+        <p class="pick-limits">${stackKeyLimitHtml(reading, 220)}</p>'
+
+run_mutation "the also-consider chips keep a pick whose free tier has ended" \
+  sub src/serve.ts '  const kept = readings.filter(r => r.reading === null || r.reading.recommendable);' \
+                   '  const kept = readings;'
+
+run_mutation "the limit column publishes the superseded stored terms again" \
+  sub src/serve.ts '  const superseded = supersedingChangeFor(offer);
+  if (!superseded) return limitCellText(offer.description, cap);
+  const reading = readingBehindTheChange(superseded);
+  return reading ? limitCellText(reading.terms, cap) : null;' \
+                   '  return limitCellText(offer.description, cap);'
+
+run_mutation "the limit column publishes the withholding notice instead of withholding a figure" \
+  sub src/serve.ts '  return reading ? limitCellText(reading.terms, cap) : null;' \
+                   '  return reading ? limitCellText(reading.terms, cap) : supersededTermsMetaSentence(offer.vendor, superseded);'
+
+run_mutation "the limit cell truncates on a sentence boundary again" \
+  sub src/serve.ts '  if (!superseded) return limitCellText(offer.description, cap);' \
+                   '  if (!superseded) return openingOfTerms(offer.description, cap);'
+
+run_mutation "the limit cell clips terms with no mark that it clipped them" \
+  sub src/stack-claim.ts '  return `${kept.replace(/[,;:.]$/, "")}…`;' \
+                         '  return kept.replace(/[,;:.]$/, "");'
+
+run_mutation "the freshness statement reports only the newest reading" \
+  sub src/stack-claim.ts '  return oldest === newest
+    ? `${subject} read from vendor pricing pages on ${newest}.`
+    : `${subject} read from vendor pricing pages between ${oldest} and ${newest}.`;' \
+                         '  return `${subject} read from vendor pricing pages on ${newest}.`;'
+
+run_mutation "the freshness statement says nothing" \
+  sub src/serve.ts 'function stackFreshnessNote(readings: readonly StackPickReading[]): string {
+  return escHtmlServer(stackFreshnessStatement(readings.map(r => r.verifiedDate)));
+}' \
+                   'function stackFreshnessNote(_readings: readonly StackPickReading[]): string {
+  return "";
+}'
+
+run_mutation "the \$0 headline carries no caveat" \
+  sub src/stack-claim.ts '  const unconfirmed = picks.filter(p => !p.readsActive);' \
+                         '  const unconfirmed: CostHeadlinePick[] = [];'
+
+run_mutation "the caveat counts a pick our badge will not call active as covered" \
+  sub src/serve.ts '    readsActive: readsActive(r.status),' \
+                   '    readsActive: r.status !== "removed",'
+
+run_mutation "the prose keeps the sentence selling a dropped pick" \
+  sub src/stack-claim.ts '  return prose
+    .split(/(?<=[.!?])\s+/)
+    .filter(sentence => !names.some(name => sentence.includes(name)))
+    .join(" ");' \
+                         '  return prose;'
+
+run_mutation "the confidence scale reads an ended offer as unrated" \
+  sub src/stack-claim.ts '  if (holds(text, ENDED_PHRASES)) return 0;' \
+                         '  if (holds(text, ENDED_PHRASES)) return 1;'
+
+run_mutation "the confidence scale ranks a withheld rating as confident" \
+  sub src/stack-claim.ts '  if (holds(text, WITHHELD_PHRASES)) return 1;' \
+                         '  if (holds(text, WITHHELD_PHRASES)) return 3;'
+
+run_mutation "the comparison accepts a page more confident than the badge" \
+  sub src/stack-claim.ts '    if (pageConfidence > badgeConfidence) over.push({ ...pick, badgeConfidence, pageConfidence });' \
+                         '    if (pageConfidence > badgeConfidence + 3) over.push({ ...pick, badgeConfidence, pageConfidence });'
+
+run_mutation "an unrankable verdict passes silently" \
+  sub src/stack-claim.ts '    if (verdictConfidence(pick.badgeVerdict) === null) unreadable.push({ ...pick, side: "badge" });
+    else if (verdictConfidence(pick.pageVerdict) === null) unreadable.push({ ...pick, side: "page" });' \
+                         '    if (false) unreadable.push({ ...pick, side: "badge" });'
+
+run_mutation "a slot stating no verdict goes unreported" \
+  sub src/stack-claim.ts '    if (/class="[^"]*\bstack-verdict\b/.test(slot)) continue;
+    missing.push(link[1]);' \
+                         '    continue;'
+
+run_mutation "the older stability cell stops counting as a published verdict" \
+  sub src/stack-claim.ts '|class="stability-dot"[^>]*><\/span>\s*(?:<span[^>]*>)?([A-Za-z][A-Za-z ]*)/g;' \
+                         '/g;'
+
+run_mutation "a verdict is read against the wrong vendor" \
+  sub src/stack-claim.ts '    if (verdict !== "") published.push({ slug: subject, verdict });' \
+                         '    if (verdict !== "") published.push({ slug: "neon", verdict });'
+
+run_mutation "a limit is read against the vendor named in the row before it" \
+  sub src/stack-claim.ts '    if (m[1] !== undefined) {
+      subject = null;
+      continue;
+    }
+    if (m[2] !== undefined) {' \
+                         '    if (m[1] !== undefined) {
+      continue;
+    }
+    if (m[2] !== undefined) {'
+
+run_mutation "a named pick states hard-coded limits beside a record that says otherwise" \
+  sub src/serve.ts '        <p class="pick-why">${escHtmlServer(reading.recommendable ? why : reading.why)}</p>
+        <p class="pick-limits">${stackKeyLimitHtml(reading, 220)}</p>
+      </div>`;
+}
+
+function stackAltPicksHtml' \
+                   '        <p class="pick-why">${escHtmlServer(reading.recommendable ? why : reading.why)}</p>${limitsLine}
+      </div>`;
+}
+
+function stackAltPicksHtml'
+
+run_mutation "the stacks template reads its verdict from the name instead of the linked slug" \
+  sub src/serve.ts '    const reading = stackReadingForSlug(s.slug);
+    if (reading) templateReadings.set(s.slug, reading);' \
+                   '    const reading = stackPickReading(s.vendor);
+    if (reading) templateReadings.set(s.slug, reading);'
+
+run_mutation "the stacks template states its own stability word again" \
+  sub src/serve.ts '    return reading ? stackVerdictChipHtml(reading) : `<span style="color:var(--text-dim)">&mdash;</span>`;
+  };
+  const serviceLimitHtml' \
+                   '    return `<span class="stability-dot" style="background:#3fb950" title="Stable"></span> Stable${reading ? "" : ""}`;
+  };
+  const serviceLimitHtml'
+
+run_mutation "the agent stack drops its verdict column" \
+  sub src/serve.ts '      const verdict = reading ? stackVerdictChipHtml(reading) : `<span style="color:var(--text-dim)">&mdash;</span>`;' \
+                   '      const verdict = "";'
+
+run_mutation "the agent stack keeps a pick whose free tier has ended" \
+  sub src/serve.ts '    const recommended = readings.filter(r => r.reading === null || r.reading.recommendable);' \
+                   '    const recommended = readings;'
+
+run_mutation "the limit cell states a superseded reading with no citation" \
+  sub src/serve.ts '  return `<span class="stack-limit-read" title="${escHtmlServer(`Our stored ${reading.vendor} terms are superseded. This is what ${source.label} read on ${source.date}.`)}">${escHtmlServer(limit)}</span>` +
+    ` <a href="/vendor/${reading.slug}#changes" class="stack-limit-source" style="font-size:.7rem;color:var(--text-dim)">read ${escHtmlServer(source.date)}</a>`;' \
+                   '  return escHtmlServer(limit);'
+
+run_mutation "the citation link is read as part of the limit claim" \
+  sub src/stack-claim.ts '    .replace(CITATION_LINK, "")
+    .replace(/<[^>]*>/g, "")' \
+                         '    .replace(/<[^>]*>/g, "")'
+
+echo
+echo "killed=$killed survived=$survived"

--- a/scripts/sync-page-reviews.js
+++ b/scripts/sync-page-reviews.js
@@ -59,7 +59,9 @@ const EDITORIAL_PAGES = [
   "/openai-assistants-migration", "/openai-assistants-migration-2026",
   "/openai-realtime-migration", "/q1-2026-developer-pricing-report", "/q2-pricing-preview-2026",
   "/railway-vs-render", "/security-free-tier-comparison-2026",
-  "/serverless-free-tier-comparison-2026", "/shutdowns", "/stack-check", "/startup-credits",
+  "/serverless-free-tier-comparison-2026", "/shutdowns", "/stack-check",
+  "/stacks/ai-startup", "/stacks/api-first", "/stacks/open-source", "/stacks/saas-mvp",
+  "/stacks/side-project", "/startup-credits",
   "/state-of-free-tiers", "/storage-comparison-2026", "/supabase-vs-firebase",
   "/tenor-alternatives", "/terraform-cloud-free-tier-removed",
   "/testing-free-tier-comparison-2026", "/vector-database-pricing", "/vercel-vs-netlify",
@@ -81,9 +83,9 @@ function parseArgs(argv) {
   return opts;
 }
 
-function routeFirstServed(route) {
+function firstCommitHolding(literal) {
   try {
-    const log = execFileSync("git", ["log", "--reverse", "-S", `"${route}"`, "--format=%cs", "--", "src/serve.ts"], {
+    const log = execFileSync("git", ["log", "--reverse", "-S", `"${literal}"`, "--format=%cs", "--", "src/serve.ts"], {
       cwd: REPO, encoding: "utf-8", maxBuffer: 8 * 1024 * 1024,
     });
     const first = log.split("\n").find(l => /^\d{4}-\d{2}-\d{2}$/.test(l.trim()));
@@ -91,6 +93,13 @@ function routeFirstServed(route) {
   } catch {
     return null;
   }
+}
+
+function routeFirstServed(route) {
+  const whole = firstCommitHolding(route);
+  if (whole) return whole;
+  const segment = route.slice(route.lastIndexOf("/") + 1);
+  return segment && segment !== route.slice(1) ? firstCommitHolding(segment) : null;
 }
 
 function startServer(env = {}) {

--- a/src/page-reviews.ts
+++ b/src/page-reviews.ts
@@ -495,7 +495,7 @@ export function overdueReport(today: string, index: PageReviewIndex = loadPageRe
 }
 
 const VERDICT_BLOCK_CLASSES = ["summary-stats", "executive-summary", "verdict-box", "pick-header"];
-const VERDICT_INLINE_CLASSES = ["winner-badge", "pick-badge"];
+const VERDICT_INLINE_CLASSES = ["winner-badge", "pick-badge", "stack-verdict"];
 
 export function verdictBlocks(html: string): string[] {
   const blocks: string[] = [];

--- a/src/serve.ts
+++ b/src/serve.ts
@@ -21,7 +21,8 @@ import { LINK_GRACE_DAYS, unreachableNoticeForUrl } from "./link-health.js";
 import { offerEnded, offerRetired, recordedTierSentence, endedHeadline, endedHistorySentence, endedReliabilitySentence, endedEmptyChangeHistorySentence, ENDED_BADGE_LABEL, ENDED_SINCE_CHANGES_SENTENCE, type OfferTierAndUrl } from "./retirement.js";
 import { amountUnstatedSentence, levelWithheldReason, sourceStatesNoAmount, withheldLevelClause, withheldLevelSentence, type LevelWithheldReason } from "./source-check.js";
 import { readingIsBehindTheLoop, reverificationIntervalDays } from "./badge-staleness.js";
-import { SUPERSEDED_TERMS_LABEL, supersededTermsAnswer, supersededTermsMetaSentence, supersededTermsNotice, supersededTermsNoticeHtml, supersededTermsRecord, supersededTermsVerdictSentence, supersedingChange, type SupersededTermsRecord } from "./superseded-description.js";
+import { SUPERSEDED_TERMS_LABEL, openingOfTerms, readingBehindTheChange, supersededTermsAnswer, supersededTermsMetaSentence, supersededTermsNotice, supersededTermsNoticeHtml, supersededTermsRecord, supersededTermsVerdictSentence, supersedingChange, type SupersededTermsRecord } from "./superseded-description.js";
+import { NO_CURRENT_FIGURE, costHeadlineCaveat, limitCellText, mayRecommendAsFree, proseWithoutNames, readsActive, stackFreshnessStatement } from "./stack-claim.js";
 import { changesByVendor } from "./superseded-census.js";
 import { buildComparisonMap, comparisonSlug } from "./comparison-pairs.js";
 import { comparisonVerdictText, freeTierFaqAnswer, stabilityFaqAnswer, type ComparisonSide, type FreeTierSide, type SideFreeTier, type StabilityRating } from "./comparison-verdict.js";
@@ -940,6 +941,193 @@ const BADGE_COLORS: Record<BadgeStatus, string> = {
   "withheld": "#8b949e",
   "unknown": "#8b949e",
 };
+
+interface StackPickReading {
+  slug: string;
+  vendor: string;
+  tier: string;
+  status: BadgeStatus;
+  verdict: string;
+  why: string;
+  recommendable: boolean;
+  verifiedDate: string;
+  primary: Offer;
+}
+
+function stackPickReading(vendorName: string): StackPickReading | null {
+  return stackReadingForSlug(toSlug(vendorName));
+}
+
+function stackReadingForSlug(slug: string): StackPickReading | null {
+  const canonical = vendorSlugMap.get(slug);
+  if (!canonical) return null;
+  const context = vendorVerdictContext(canonical, utcDate());
+  if (!context) return null;
+  const badge = getBadgeStatus(slug);
+  return {
+    slug,
+    vendor: canonical,
+    tier: context.primary.tier,
+    status: badge.status,
+    verdict: badge.label,
+    why: vendorVerdictSentence(context.input),
+    recommendable: mayRecommendAsFree(badge.status),
+    verifiedDate: context.primary.verifiedDate,
+    primary: context.primary,
+  };
+}
+
+function stackKeyLimit(offer: StoredTermsOf, cap: number): string | null {
+  const superseded = supersedingChangeFor(offer);
+  if (!superseded) return limitCellText(offer.description, cap);
+  const reading = readingBehindTheChange(superseded);
+  return reading ? limitCellText(reading.terms, cap) : null;
+}
+
+function stackKeyLimitHtml(reading: StackPickReading, cap: number): string {
+  const limit = stackKeyLimit(reading.primary, cap);
+  if (limit === null) {
+    return `<span class="stack-no-figure" style="color:var(--text-dim)" title="${escHtmlServer(reading.why)}">${escHtmlServer(NO_CURRENT_FIGURE)}</span>`;
+  }
+  const superseded = supersedingChangeFor(reading.primary);
+  const source = superseded ? readingBehindTheChange(superseded) : null;
+  if (!source) return escHtmlServer(limit);
+  return `<span class="stack-limit-read" title="${escHtmlServer(`Our stored ${reading.vendor} terms are superseded. This is what ${source.label} read on ${source.date}.`)}">${escHtmlServer(limit)}</span>` +
+    ` <a href="/vendor/${reading.slug}#changes" class="stack-limit-source" style="font-size:.7rem;color:var(--text-dim)">read ${escHtmlServer(source.date)}</a>`;
+}
+
+function stackVerdictChipHtml(reading: StackPickReading, opts: { compact?: boolean } = {}): string {
+  const color = BADGE_COLORS[reading.status];
+  const size = opts.compact ? ".65rem" : ".7rem";
+  return `<span class="stack-verdict" style="display:inline-block;font-size:${size};padding:.15rem .5rem;border-radius:10px;background:${color}22;color:${color};font-weight:600" title="${escHtmlServer(reading.why)}">${escHtmlServer(reading.verdict)}</span>`;
+}
+
+function stackPickCostCaveat(readings: readonly StackPickReading[]): string {
+  const caveat = costHeadlineCaveat(readings.map(r => ({
+    vendor: r.vendor,
+    verdict: r.verdict,
+    readsActive: readsActive(r.status),
+  })));
+  if (caveat === "") return "";
+  return `\n    <div class="cost-caveat" style="margin-top:.75rem;font-size:.8rem;color:var(--text-muted);line-height:1.5">${escHtmlServer(caveat)}</div>`;
+}
+
+function stackFreshnessNote(readings: readonly StackPickReading[]): string {
+  return escHtmlServer(stackFreshnessStatement(readings.map(r => r.verifiedDate)));
+}
+
+function stackRecCardHtml(rec: EnrichedOfferRow, why: string): string {
+  const reading = stackPickReading(rec.vendor);
+  if (!reading) {
+    return `
+      <div class="stack-pick">
+        <div class="pick-header">
+          <span class="pick-badge">Recommended</span>
+          <a href="/vendor/${toSlug(rec.vendor)}" class="pick-name">${escHtmlServer(rec.vendor)}</a>
+          <span class="pick-tier">${escHtmlServer(rec.tier)}</span>
+        </div>
+        <p class="pick-why">${escHtmlServer(why)}</p>
+        <p class="pick-limits">${escHtmlServer(publishedTermsOpening(rec, 2))}</p>
+      </div>`;
+  }
+  const tier = reading.recommendable ? `\n          <span class="pick-tier">${escHtmlServer(reading.tier)}</span>` : "";
+  return `
+      <div class="stack-pick">
+        <div class="pick-header">
+          <span class="pick-badge">${reading.recommendable ? "Recommended" : "No longer a free-tier pick"}</span>
+          <a href="/vendor/${reading.slug}" class="pick-name">${escHtmlServer(reading.vendor)}</a>${tier}
+          ${stackVerdictChipHtml(reading, { compact: true })}
+        </div>
+        <p class="pick-why">${escHtmlServer(reading.recommendable ? why : reading.why)}</p>
+        <p class="pick-limits">${stackKeyLimitHtml(reading, 220)}</p>
+        <div class="pick-links">
+          <a href="/vendor/${reading.slug}">Full profile</a>
+          <a href="/alternative-to/${reading.slug}">Alternatives</a>
+          ${offerPricingLink(reading.primary, "Pricing &nearr;")}
+        </div>
+      </div>`;
+}
+
+function stackProseHtml(prose: string, names: readonly string[]): string {
+  const ended = names.filter(name => {
+    const reading = stackPickReading(name);
+    return reading !== null && !reading.recommendable;
+  });
+  return escHtmlServer(proseWithoutNames(prose, ended));
+}
+
+function stackPrimaryReadings(cats: readonly { recommended: { vendor: string } }[]): StackPickReading[] {
+  const seen = new Set<string>();
+  const readings: StackPickReading[] = [];
+  for (const cat of cats) {
+    const reading = stackPickReading(cat.recommended.vendor);
+    if (!reading || seen.has(reading.slug)) continue;
+    seen.add(reading.slug);
+    readings.push(reading);
+  }
+  return readings;
+}
+
+function stackTableCellsHtml(vendorName: string, fallbackLimit: string): { vendorLink: string; limits: string; verdict: string } {
+  const reading = stackPickReading(vendorName);
+  if (!reading) {
+    return {
+      vendorLink: `<span style="font-weight:600">${escHtmlServer(vendorName)}</span>`,
+      limits: escHtmlServer(fallbackLimit),
+      verdict: `<span style="color:var(--text-dim)">&mdash;</span>`,
+    };
+  }
+  return {
+    vendorLink: `<a href="/vendor/${reading.slug}" style="color:var(--text);font-weight:600">${escHtmlServer(vendorName)}</a>`,
+    limits: stackKeyLimitHtml(reading, 110),
+    verdict: stackVerdictChipHtml(reading),
+  };
+}
+
+function stackNamedPickHtml(vendorName: string, why: string, tier: string, limits: string): string {
+  const reading = stackPickReading(vendorName);
+  const limitsLine = limits === "" ? "" : `\n        <p class="pick-limits">${escHtmlServer(limits)}</p>`;
+  if (!reading) {
+    return `
+      <div class="stack-pick">
+        <div class="pick-header">
+          <span class="pick-badge">Recommended</span>
+          <span class="pick-name">${escHtmlServer(vendorName)}</span>
+          <span class="pick-tier">${escHtmlServer(tier)}</span>
+        </div>
+        <p class="pick-why">${escHtmlServer(why)}</p>${limitsLine}
+      </div>`;
+  }
+  return `
+      <div class="stack-pick">
+        <div class="pick-header">
+          <span class="pick-badge">${reading.recommendable ? "Recommended" : "No longer a free-tier pick"}</span>
+          <a href="/vendor/${reading.slug}" class="pick-name">${escHtmlServer(vendorName)}</a>
+          <span class="pick-tier">${escHtmlServer(tier)}</span>
+          ${stackVerdictChipHtml(reading, { compact: true })}
+        </div>
+        <p class="pick-why">${escHtmlServer(reading.recommendable ? why : reading.why)}</p>
+        <p class="pick-limits">${stackKeyLimitHtml(reading, 220)}</p>
+      </div>`;
+}
+
+function stackAltPicksHtml(altVendors: readonly EnrichedOfferRow[]): string {
+  if (altVendors.length === 0) return "";
+  const readings = altVendors.map(a => ({ offer: a, reading: stackPickReading(a.vendor) }));
+  const kept = readings.filter(r => r.reading === null || r.reading.recommendable);
+  const ended = readings.flatMap(r => (r.reading !== null && !r.reading.recommendable) ? [r.reading] : []);
+
+  const chips = kept.length === 0 ? "" : `
+      <div class="alt-picks">
+        <p class="alt-label">Also consider:</p>
+        ${kept.map(({ offer, reading }) => `<a href="/vendor/${toSlug(offer.vendor)}" class="alt-chip">${escHtmlServer(offer.vendor)} <span class="chip-tier">${escHtmlServer(offer.tier)}</span>${reading ? ` ${stackVerdictChipHtml(reading, { compact: true })}` : ""}</a>`).join(" ")}
+      </div>`;
+
+  const dropped = ended.length === 0 ? "" : `
+      <p class="alt-ended" style="font-size:.8rem;color:var(--text-muted);margin-top:.5rem">No longer a free-tier pick: ${ended.map(r => `<a href="/vendor/${r.slug}">${escHtmlServer(r.vendor)}</a> — ${escHtmlServer(r.verdict)}`).join("; ")}.</p>`;
+
+  return `${chips}${dropped}`;
+}
 
 function escXml(s: string): string {
   return s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;").replace(/'/g, "&apos;");
@@ -6559,7 +6747,7 @@ const ALTERNATIVES_PAGES: AlternativesPageConfig[] = [
   {
     slug: "free-startup-stack",
     title: "The Complete Free Startup Stack for 2026 — $0/Month SaaS Infrastructure Guide",
-    metaDesc: "Build a complete SaaS startup on free tiers. 10 infrastructure categories with recommended picks, exact limits, scaling guidance, and stability notes. Updated March 2026.",
+    metaDesc: "Build a complete SaaS startup on free tiers. 10 infrastructure categories with recommended picks, exact limits, scaling guidance, and stability notes.",
     contextHtml: "",
     tag: "startup-stack-guide",
     primaryVendor: "Vercel",
@@ -6568,7 +6756,7 @@ const ALTERNATIVES_PAGES: AlternativesPageConfig[] = [
   {
     slug: "free-ai-stack",
     title: "The Complete Free AI/ML Stack for 2026 — $0/Month AI Development Infrastructure",
-    metaDesc: "Build AI apps on free tiers. 10 AI/ML infrastructure categories — LLM APIs, vector databases, experiment tracking, observability, and more. Exact limits, scaling guidance. Updated March 2026.",
+    metaDesc: "Build AI apps on free tiers. 10 AI/ML infrastructure categories — LLM APIs, vector databases, experiment tracking, observability, and more. Exact limits, scaling guidance.",
     contextHtml: "",
     tag: "ai-stack-guide",
     primaryVendor: "Groq",
@@ -6577,7 +6765,7 @@ const ALTERNATIVES_PAGES: AlternativesPageConfig[] = [
   {
     slug: "free-devops-stack",
     title: "The Complete Free DevOps Stack for 2026 — $0/Month Infrastructure Ops",
-    metaDesc: "Build and run infrastructure on free tiers. 10 DevOps categories — CI/CD, monitoring, logging, container registries, secrets management, and more. Exact limits, scaling guidance. Updated March 2026.",
+    metaDesc: "Build and run infrastructure on free tiers. 10 DevOps categories — CI/CD, monitoring, logging, container registries, secrets management, and more. Exact limits, scaling guidance.",
     contextHtml: "",
     tag: "devops-stack-guide",
     primaryVendor: "GitHub Actions",
@@ -6586,7 +6774,7 @@ const ALTERNATIVES_PAGES: AlternativesPageConfig[] = [
   {
     slug: "free-frontend-stack",
     title: "The Complete Free Frontend Stack for 2026 — $0/Month Jamstack & Web Development",
-    metaDesc: "Build and ship frontend projects on free tiers. 10 categories — hosting, CDN, CMS, forms, analytics, error tracking, image optimization, and more. Exact limits, scaling guidance. Updated March 2026.",
+    metaDesc: "Build and ship frontend projects on free tiers. 10 categories — hosting, CDN, CMS, forms, analytics, error tracking, image optimization, and more. Exact limits, scaling guidance.",
     contextHtml: "",
     tag: "frontend-stack-guide",
     primaryVendor: "Cloudflare Pages",
@@ -6595,7 +6783,7 @@ const ALTERNATIVES_PAGES: AlternativesPageConfig[] = [
   {
     slug: "free-nextjs-stack",
     title: "The Complete Free Next.js Stack for 2026 — $0/Month Full-Stack Infrastructure",
-    metaDesc: "Build a complete Next.js app on free tiers. 10 infrastructure layers — hosting, database, auth, storage, email, monitoring, CI/CD, analytics, search, and background jobs. Exact limits, growth costs. Updated April 2026.",
+    metaDesc: "Build a complete Next.js app on free tiers. 10 infrastructure layers — hosting, database, auth, storage, email, monitoring, CI/CD, analytics, search, and background jobs. Exact limits, growth costs.",
     contextHtml: "",
     tag: "nextjs-stack-guide",
     primaryVendor: "Vercel",
@@ -6604,7 +6792,7 @@ const ALTERNATIVES_PAGES: AlternativesPageConfig[] = [
   {
     slug: "free-django-stack",
     title: "The Complete Free Django/Python Stack for 2026 — $0/Month Full-Stack Infrastructure",
-    metaDesc: "Build a complete Django app on free tiers. 10 infrastructure layers — WSGI hosting, Postgres, Redis/cache, auth, storage, email, monitoring, CI/CD, task queue, and search. Exact limits, growth costs. Updated April 2026.",
+    metaDesc: "Build a complete Django app on free tiers. 10 infrastructure layers — WSGI hosting, Postgres, Redis/cache, auth, storage, email, monitoring, CI/CD, task queue, and search. Exact limits, growth costs.",
     contextHtml: "",
     tag: "django-stack-guide",
     primaryVendor: "Railway",
@@ -6613,7 +6801,7 @@ const ALTERNATIVES_PAGES: AlternativesPageConfig[] = [
   {
     slug: "free-fastapi-stack",
     title: "The Complete Free FastAPI/Python Stack for 2026 — $0/Month Full-Stack Infrastructure",
-    metaDesc: "Build a complete FastAPI app on free tiers. 10 infrastructure layers — ASGI hosting, async Postgres, Redis, auth, storage, email, monitoring, CI/CD, background tasks, and API docs. Exact limits, growth costs. Updated April 2026.",
+    metaDesc: "Build a complete FastAPI app on free tiers. 10 infrastructure layers — ASGI hosting, async Postgres, Redis, auth, storage, email, monitoring, CI/CD, background tasks, and API docs. Exact limits, growth costs.",
     contextHtml: "",
     tag: "fastapi-stack-guide",
     primaryVendor: "Railway",
@@ -6622,7 +6810,7 @@ const ALTERNATIVES_PAGES: AlternativesPageConfig[] = [
   {
     slug: "free-go-stack",
     title: "The Complete Free Go/Golang Stack for 2026 — $0/Month Full-Stack Infrastructure",
-    metaDesc: "Build a complete Go app on free tiers. 10 infrastructure layers — single binary hosting, Postgres via pgx, Redis, auth, storage, email, monitoring, CI/CD, background jobs, and API docs. Exact limits, growth costs. Updated April 2026.",
+    metaDesc: "Build a complete Go app on free tiers. 10 infrastructure layers — single binary hosting, Postgres via pgx, Redis, auth, storage, email, monitoring, CI/CD, background jobs, and API docs. Exact limits, growth costs.",
     contextHtml: "",
     tag: "go-stack-guide",
     primaryVendor: "Railway",
@@ -6631,7 +6819,7 @@ const ALTERNATIVES_PAGES: AlternativesPageConfig[] = [
   {
     slug: "free-saas-stack",
     title: "The Complete Free SaaS Starter Stack for 2026 — Build and Launch for $0/Month",
-    metaDesc: "Build a complete SaaS product on free tiers. 12 infrastructure categories — hosting, database, auth, payments, email, storage, monitoring, CI/CD, analytics. Exact limits, growth costs at 1K/10K/100K users. Updated April 2026.",
+    metaDesc: "Build a complete SaaS product on free tiers. 12 infrastructure categories — hosting, database, auth, payments, email, storage, monitoring, CI/CD, analytics. Exact limits, growth costs at 1K/10K/100K users.",
     contextHtml: "",
     tag: "saas-stack-guide",
     primaryVendor: "Neon",
@@ -14301,10 +14489,8 @@ ${buildCards(other)}
 
 function buildFreeStartupStackPage(): string {
   const title = "The Complete Free Startup Stack for 2026 — $0/Month SaaS Infrastructure Guide";
-  const metaDesc = "Build a complete SaaS startup on free tiers. 10 infrastructure categories with recommended picks, exact limits, scaling guidance, and stability notes. Updated March 2026.";
+  const metaDesc = "Build a complete SaaS startup on free tiers. 10 infrastructure categories with recommended picks, exact limits, scaling guidance, and stability notes.";
   const slug = "free-startup-stack";
-
-  const riskColors: Record<string, string> = { stable: "#3fb950", caution: "#d29922", risky: "#f85149" };
 
   const stackCategories = [
     {
@@ -14410,32 +14596,14 @@ function buildFreeStartupStackPage(): string {
     author: { "@type": "Organization", name: "AgentDeals", url: BASE_URL },
   };
 
+  const pageReadings = stackPrimaryReadings(stackCategories);
   const categorySections = stackCategories.map(cat => {
     const rec = resolveVendor(cat.recommended.vendor);
     const altVendors = cat.alternatives.filter(v => v !== cat.recommended.vendor).map(v => resolveVendor(v)).filter(Boolean) as ReturnType<typeof enrichOffers>;
 
-    const recCard = rec ? `
-      <div class="stack-pick">
-        <div class="pick-header">
-          <span class="pick-badge">Recommended</span>
-          <a href="/vendor/${toSlug(rec.vendor)}" class="pick-name">${escHtmlServer(rec.vendor)}</a>
-          <span class="pick-tier">${escHtmlServer(rec.tier)}</span>
-          ${riskBadgeHtml(rec.risk_level, rec.risk_cause, { compact: true, margin: false })}
-        </div>
-        <p class="pick-why">${escHtmlServer(cat.recommended.why)}</p>
-        <p class="pick-limits">${escHtmlServer(publishedTermsOpening(rec, 2))}</p>
-        <div class="pick-links">
-          <a href="/vendor/${toSlug(rec.vendor)}">Full profile</a>
-          <a href="/alternative-to/${toSlug(rec.vendor)}">Alternatives</a>
-          ${offerPricingLink(rec, "Pricing &nearr;")}
-        </div>
-      </div>` : "";
+    const recCard = rec ? stackRecCardHtml(rec, cat.recommended.why) : "";
 
-    const altCards = altVendors.length > 0 ? `
-      <div class="alt-picks">
-        <p class="alt-label">Also consider:</p>
-        ${altVendors.map(a => `<a href="/vendor/${toSlug(a.vendor)}" class="alt-chip">${escHtmlServer(a.vendor)} <span class="chip-tier">${escHtmlServer(a.tier)}</span></a>`).join(" ")}
-      </div>` : "";
+    const altCards = stackAltPicksHtml(altVendors);
 
     const relatedLink = cat.relatedPage ? `<a href="${cat.relatedPage}" class="related-link">Full comparison guide &rarr;</a>` : "";
 
@@ -14445,7 +14613,7 @@ function buildFreeStartupStackPage(): string {
       ${recCard}
       ${altCards}
       <div class="outgrow-box">
-        <strong>When you'll outgrow it:</strong> ${escHtmlServer(cat.outgrow)}
+        <strong>When you'll outgrow it:</strong> ${stackProseHtml(cat.outgrow, [cat.recommended.vendor, ...cat.alternatives])}
       </div>
       ${relatedLink}
     </div>`;
@@ -14471,14 +14639,12 @@ function buildFreeStartupStackPage(): string {
   <p style="margin-top:1rem;font-size:.85rem"><a href="/changes">View all ${dealChanges.length} pricing changes &rarr;</a></p>` : "";
 
   const tableRows = stackCategories.map(cat => {
-    const rec = resolveVendor(cat.recommended.vendor);
-    const limits = rec ? publishedTermsOpening(rec, 1, 80) : "—";
-    const riskBadge = rec ? riskCellHtml(rec.risk_level, rec.risk_cause) : riskCellHtml("stable", null);
+    const cells = stackTableCellsHtml(cat.recommended.vendor, "—");
     return `      <tr>
         <td style="font-weight:600">${cat.icon} ${escHtmlServer(cat.name)}</td>
-        <td><a href="/vendor/${toSlug(cat.recommended.vendor)}" style="color:var(--text);font-weight:600">${escHtmlServer(cat.recommended.vendor)}</a></td>
-        <td style="font-family:var(--mono);font-size:.8rem;color:var(--accent)">${escHtmlServer(limits)}</td>
-        <td>${riskBadge}</td>
+        <td>${cells.vendorLink}</td>
+        <td style="font-family:var(--mono);font-size:.8rem;color:var(--accent)">${cells.limits}</td>
+        <td>${cells.verdict}</td>
       </tr>`;
   }).join("\n");
 
@@ -14557,12 +14723,12 @@ ${mcpCtaCss()}
 
   <div class="context">
     <p>You can build and launch a complete SaaS product without spending a dollar on infrastructure. This guide recommends the best free tier for each layer of a typical startup stack — <strong>10 categories</strong> from hosting to analytics — with exact limits pulled from our index of ${offers.length.toLocaleString()}+ verified developer tools.</p>
-    <p>Each recommendation includes alternatives, a "when you'll outgrow it" guide, and stability notes based on our tracking of ${dealChanges.length} real pricing changes. All limits verified against live pricing pages, March 2026.</p>
+    <p>Each recommendation includes alternatives, a "when you'll outgrow it" guide, and stability notes based on our tracking of ${dealChanges.length} real pricing changes. ${stackFreshnessNote(pageReadings)}</p>
   </div>
 
   <div class="cost-banner">
     <div class="cost-amount">$0<span style="font-size:1rem;color:var(--text-muted)">/month</span></div>
-    <div class="cost-label">Total estimated monthly cost for the complete stack below</div>
+    <div class="cost-label">Total estimated monthly cost for the complete stack below</div>${stackPickCostCaveat(pageReadings)}
   </div>
 
   <h2>Stack Overview</h2>
@@ -14615,10 +14781,8 @@ ${stabilityNotes}
 
 function buildFreeAiStackPage(): string {
   const title = "The Complete Free AI/ML Stack for 2026 — $0/Month AI Development Infrastructure";
-  const metaDesc = "Build AI apps on free tiers. 10 AI/ML infrastructure categories — LLM APIs, vector databases, experiment tracking, observability, and more. Exact limits, scaling guidance. Updated March 2026.";
+  const metaDesc = "Build AI apps on free tiers. 10 AI/ML infrastructure categories — LLM APIs, vector databases, experiment tracking, observability, and more. Exact limits, scaling guidance.";
   const slug = "free-ai-stack";
-
-  const riskColors: Record<string, string> = { stable: "#3fb950", caution: "#d29922", risky: "#f85149" };
 
   const stackCategories = [
     {
@@ -14723,32 +14887,14 @@ function buildFreeAiStackPage(): string {
     author: { "@type": "Organization", name: "AgentDeals", url: BASE_URL },
   };
 
+  const pageReadings = stackPrimaryReadings(stackCategories);
   const categorySections = stackCategories.map(cat => {
     const rec = resolveVendor(cat.recommended.vendor);
     const altVendors = cat.alternatives.filter(v => v !== cat.recommended.vendor).map(v => resolveVendor(v)).filter(Boolean) as ReturnType<typeof enrichOffers>;
 
-    const recCard = rec ? `
-      <div class="stack-pick">
-        <div class="pick-header">
-          <span class="pick-badge">Recommended</span>
-          <a href="/vendor/${toSlug(rec.vendor)}" class="pick-name">${escHtmlServer(rec.vendor)}</a>
-          <span class="pick-tier">${escHtmlServer(rec.tier)}</span>
-          ${riskBadgeHtml(rec.risk_level, rec.risk_cause, { compact: true, margin: false })}
-        </div>
-        <p class="pick-why">${escHtmlServer(cat.recommended.why)}</p>
-        <p class="pick-limits">${escHtmlServer(publishedTermsOpening(rec, 2))}</p>
-        <div class="pick-links">
-          <a href="/vendor/${toSlug(rec.vendor)}">Full profile</a>
-          <a href="/alternative-to/${toSlug(rec.vendor)}">Alternatives</a>
-          ${offerPricingLink(rec, "Pricing &nearr;")}
-        </div>
-      </div>` : "";
+    const recCard = rec ? stackRecCardHtml(rec, cat.recommended.why) : "";
 
-    const altCards = altVendors.length > 0 ? `
-      <div class="alt-picks">
-        <p class="alt-label">Also consider:</p>
-        ${altVendors.map(a => `<a href="/vendor/${toSlug(a.vendor)}" class="alt-chip">${escHtmlServer(a.vendor)} <span class="chip-tier">${escHtmlServer(a.tier)}</span></a>`).join(" ")}
-      </div>` : "";
+    const altCards = stackAltPicksHtml(altVendors);
 
     const relatedLink = cat.relatedPage ? `<a href="${cat.relatedPage}" class="related-link">Full comparison guide &rarr;</a>` : "";
 
@@ -14758,7 +14904,7 @@ function buildFreeAiStackPage(): string {
       ${recCard}
       ${altCards}
       <div class="outgrow-box">
-        <strong>When you'll outgrow it:</strong> ${escHtmlServer(cat.outgrow)}
+        <strong>When you'll outgrow it:</strong> ${stackProseHtml(cat.outgrow, [cat.recommended.vendor, ...cat.alternatives])}
       </div>
       ${relatedLink}
     </div>`;
@@ -14784,14 +14930,12 @@ function buildFreeAiStackPage(): string {
   <p style="margin-top:1rem;font-size:.85rem"><a href="/changes">View all ${dealChanges.length} pricing changes &rarr;</a></p>` : "";
 
   const tableRows = stackCategories.map(cat => {
-    const rec = resolveVendor(cat.recommended.vendor);
-    const limits = rec ? publishedTermsOpening(rec, 1, 80) : "—";
-    const riskBadge = rec ? riskCellHtml(rec.risk_level, rec.risk_cause) : riskCellHtml("stable", null);
+    const cells = stackTableCellsHtml(cat.recommended.vendor, "—");
     return `      <tr>
         <td style="font-weight:600">${cat.icon} ${escHtmlServer(cat.name)}</td>
-        <td><a href="/vendor/${toSlug(cat.recommended.vendor)}" style="color:var(--text);font-weight:600">${escHtmlServer(cat.recommended.vendor)}</a></td>
-        <td style="font-family:var(--mono);font-size:.8rem;color:var(--accent)">${escHtmlServer(limits)}</td>
-        <td>${riskBadge}</td>
+        <td>${cells.vendorLink}</td>
+        <td style="font-family:var(--mono);font-size:.8rem;color:var(--accent)">${cells.limits}</td>
+        <td>${cells.verdict}</td>
       </tr>`;
   }).join("\n");
 
@@ -14886,12 +15030,12 @@ ${mcpCtaCss()}
 
   <div class="context">
     <p>Everything you need to build, train, and deploy AI applications — without spending a dollar. This guide recommends the best free tier for each layer of an AI/ML development stack — <strong>10 categories</strong> from LLM APIs to speech AI — with exact limits pulled from our index of ${offers.length.toLocaleString()}+ verified developer tools.</p>
-    <p>Designed for solo AI developers, indie hackers, and startup teams prototyping AI features. Each recommendation includes alternatives, a "when you'll outgrow it" guide, and stability notes based on our tracking of ${dealChanges.length} real pricing changes. All limits verified March 2026.</p>
+    <p>Designed for solo AI developers, indie hackers, and startup teams prototyping AI features. Each recommendation includes alternatives, a "when you'll outgrow it" guide, and stability notes based on our tracking of ${dealChanges.length} real pricing changes. ${stackFreshnessNote(pageReadings)}</p>
   </div>
 
   <div class="cost-banner">
     <div class="cost-amount">$0<span style="font-size:1rem;color:var(--text-muted)">/month</span></div>
-    <div class="cost-label">Total estimated monthly cost for prototyping and experimentation</div>
+    <div class="cost-label">Total estimated monthly cost for prototyping and experimentation</div>${stackPickCostCaveat(pageReadings)}
   </div>
 
   <h2>Stack Overview</h2>
@@ -14965,10 +15109,8 @@ ${ossAlternatives.map(oss => `      <tr>
 
 function buildFreeDevopsStackPage(): string {
   const title = "The Complete Free DevOps Stack for 2026 — $0/Month Infrastructure Ops";
-  const metaDesc = "Build and run infrastructure on free tiers. 10 DevOps categories — CI/CD, monitoring, logging, container registries, secrets management, and more. Exact limits, scaling guidance. Updated March 2026.";
+  const metaDesc = "Build and run infrastructure on free tiers. 10 DevOps categories — CI/CD, monitoring, logging, container registries, secrets management, and more. Exact limits, scaling guidance.";
   const slug = "free-devops-stack";
-
-  const riskColors: Record<string, string> = { stable: "#3fb950", caution: "#d29922", risky: "#f85149" };
 
   const stackCategories = [
     {
@@ -15073,32 +15215,14 @@ function buildFreeDevopsStackPage(): string {
     author: { "@type": "Organization", name: "AgentDeals", url: BASE_URL },
   };
 
+  const pageReadings = stackPrimaryReadings(stackCategories);
   const categorySections = stackCategories.map(cat => {
     const rec = resolveVendor(cat.recommended.vendor);
     const altVendors = cat.alternatives.filter(v => v !== cat.recommended.vendor).map(v => resolveVendor(v)).filter(Boolean) as ReturnType<typeof enrichOffers>;
 
-    const recCard = rec ? `
-      <div class="stack-pick">
-        <div class="pick-header">
-          <span class="pick-badge">Recommended</span>
-          <a href="/vendor/${toSlug(rec.vendor)}" class="pick-name">${escHtmlServer(rec.vendor)}</a>
-          <span class="pick-tier">${escHtmlServer(rec.tier)}</span>
-          ${riskBadgeHtml(rec.risk_level, rec.risk_cause, { compact: true, margin: false })}
-        </div>
-        <p class="pick-why">${escHtmlServer(cat.recommended.why)}</p>
-        <p class="pick-limits">${escHtmlServer(publishedTermsOpening(rec, 2))}</p>
-        <div class="pick-links">
-          <a href="/vendor/${toSlug(rec.vendor)}">Full profile</a>
-          <a href="/alternative-to/${toSlug(rec.vendor)}">Alternatives</a>
-          ${offerPricingLink(rec, "Pricing &nearr;")}
-        </div>
-      </div>` : "";
+    const recCard = rec ? stackRecCardHtml(rec, cat.recommended.why) : "";
 
-    const altCards = altVendors.length > 0 ? `
-      <div class="alt-picks">
-        <p class="alt-label">Also consider:</p>
-        ${altVendors.map(a => `<a href="/vendor/${toSlug(a.vendor)}" class="alt-chip">${escHtmlServer(a.vendor)} <span class="chip-tier">${escHtmlServer(a.tier)}</span></a>`).join(" ")}
-      </div>` : "";
+    const altCards = stackAltPicksHtml(altVendors);
 
     const relatedLink = cat.relatedPage ? `<a href="${cat.relatedPage}" class="related-link">Full comparison guide &rarr;</a>` : "";
 
@@ -15108,7 +15232,7 @@ function buildFreeDevopsStackPage(): string {
       ${recCard}
       ${altCards}
       <div class="outgrow-box">
-        <strong>When you'll outgrow it:</strong> ${escHtmlServer(cat.outgrow)}
+        <strong>When you'll outgrow it:</strong> ${stackProseHtml(cat.outgrow, [cat.recommended.vendor, ...cat.alternatives])}
       </div>
       ${relatedLink}
     </div>`;
@@ -15134,14 +15258,12 @@ function buildFreeDevopsStackPage(): string {
   <p style="margin-top:1rem;font-size:.85rem"><a href="/changes">View all ${dealChanges.length} pricing changes &rarr;</a></p>` : "";
 
   const tableRows = stackCategories.map(cat => {
-    const rec = resolveVendor(cat.recommended.vendor);
-    const limits = rec ? publishedTermsOpening(rec, 1, 80) : "—";
-    const riskBadge = rec ? riskCellHtml(rec.risk_level, rec.risk_cause) : riskCellHtml("stable", null);
+    const cells = stackTableCellsHtml(cat.recommended.vendor, "—");
     return `      <tr>
         <td style="font-weight:600">${cat.icon} ${escHtmlServer(cat.name)}</td>
-        <td><a href="/vendor/${toSlug(cat.recommended.vendor)}" style="color:var(--text);font-weight:600">${escHtmlServer(cat.recommended.vendor)}</a></td>
-        <td style="font-family:var(--mono);font-size:.8rem;color:var(--accent)">${escHtmlServer(limits)}</td>
-        <td>${riskBadge}</td>
+        <td>${cells.vendorLink}</td>
+        <td style="font-family:var(--mono);font-size:.8rem;color:var(--accent)">${cells.limits}</td>
+        <td>${cells.verdict}</td>
       </tr>`;
   }).join("\n");
 
@@ -15237,12 +15359,12 @@ ${mcpCtaCss()}
 
   <div class="context">
     <p>Everything you need to build, deploy, and operate software infrastructure — without spending a dollar. This guide recommends the best free tier for each layer of a DevOps stack — <strong>10 categories</strong> from CI/CD pipelines to secrets management — with exact limits pulled from our index of ${offers.length.toLocaleString()}+ verified developer tools.</p>
-    <p>Designed for solo developers, small teams, and startups setting up their first production infrastructure. Each recommendation includes alternatives, a "when you'll outgrow it" guide, and stability notes based on our tracking of ${dealChanges.length} real pricing changes. All limits verified March 2026.</p>
+    <p>Designed for solo developers, small teams, and startups setting up their first production infrastructure. Each recommendation includes alternatives, a "when you'll outgrow it" guide, and stability notes based on our tracking of ${dealChanges.length} real pricing changes. ${stackFreshnessNote(pageReadings)}</p>
   </div>
 
   <div class="cost-banner">
     <div class="cost-amount">$0<span style="font-size:1rem;color:var(--text-muted)">/month</span></div>
-    <div class="cost-label">Total estimated monthly cost for a solo developer or small team</div>
+    <div class="cost-label">Total estimated monthly cost for a solo developer or small team</div>${stackPickCostCaveat(pageReadings)}
   </div>
 
   <h2>Stack Overview</h2>
@@ -15316,10 +15438,8 @@ ${ossAlternatives.map(oss => `      <tr>
 
 function buildFreeFrontendStackPage(): string {
   const title = "The Complete Free Frontend Stack for 2026 — $0/Month Jamstack & Web Development";
-  const metaDesc = "Build and ship frontend projects on free tiers. 10 categories — hosting, CDN, CMS, forms, analytics, error tracking, image optimization, and more. Exact limits, scaling guidance. Updated March 2026.";
+  const metaDesc = "Build and ship frontend projects on free tiers. 10 categories — hosting, CDN, CMS, forms, analytics, error tracking, image optimization, and more. Exact limits, scaling guidance.";
   const slug = "free-frontend-stack";
-
-  const riskColors: Record<string, string> = { stable: "#3fb950", caution: "#d29922", risky: "#f85149" };
 
   const stackCategories = [
     {
@@ -15424,32 +15544,14 @@ function buildFreeFrontendStackPage(): string {
     author: { "@type": "Organization", name: "AgentDeals", url: BASE_URL },
   };
 
+  const pageReadings = stackPrimaryReadings(stackCategories);
   const categorySections = stackCategories.map(cat => {
     const rec = resolveVendor(cat.recommended.vendor);
     const altVendors = cat.alternatives.filter(v => v !== cat.recommended.vendor).map(v => resolveVendor(v)).filter(Boolean) as ReturnType<typeof enrichOffers>;
 
-    const recCard = rec ? `
-      <div class="stack-pick">
-        <div class="pick-header">
-          <span class="pick-badge">Recommended</span>
-          <a href="/vendor/${toSlug(rec.vendor)}" class="pick-name">${escHtmlServer(rec.vendor)}</a>
-          <span class="pick-tier">${escHtmlServer(rec.tier)}</span>
-          ${riskBadgeHtml(rec.risk_level, rec.risk_cause, { compact: true, margin: false })}
-        </div>
-        <p class="pick-why">${escHtmlServer(cat.recommended.why)}</p>
-        <p class="pick-limits">${escHtmlServer(publishedTermsOpening(rec, 2))}</p>
-        <div class="pick-links">
-          <a href="/vendor/${toSlug(rec.vendor)}">Full profile</a>
-          <a href="/alternative-to/${toSlug(rec.vendor)}">Alternatives</a>
-          ${offerPricingLink(rec, "Pricing &nearr;")}
-        </div>
-      </div>` : "";
+    const recCard = rec ? stackRecCardHtml(rec, cat.recommended.why) : "";
 
-    const altCards = altVendors.length > 0 ? `
-      <div class="alt-picks">
-        <p class="alt-label">Also consider:</p>
-        ${altVendors.map(a => `<a href="/vendor/${toSlug(a.vendor)}" class="alt-chip">${escHtmlServer(a.vendor)} <span class="chip-tier">${escHtmlServer(a.tier)}</span></a>`).join(" ")}
-      </div>` : "";
+    const altCards = stackAltPicksHtml(altVendors);
 
     const relatedLink = cat.relatedPage ? `<a href="${cat.relatedPage}" class="related-link">Full comparison guide &rarr;</a>` : "";
 
@@ -15459,7 +15561,7 @@ function buildFreeFrontendStackPage(): string {
       ${recCard}
       ${altCards}
       <div class="outgrow-box">
-        <strong>When you'll outgrow it:</strong> ${escHtmlServer(cat.outgrow)}
+        <strong>When you'll outgrow it:</strong> ${stackProseHtml(cat.outgrow, [cat.recommended.vendor, ...cat.alternatives])}
       </div>
       ${relatedLink}
     </div>`;
@@ -15485,14 +15587,12 @@ function buildFreeFrontendStackPage(): string {
   <p style="margin-top:1rem;font-size:.85rem"><a href="/changes">View all ${dealChanges.length} pricing changes &rarr;</a></p>` : "";
 
   const tableRows = stackCategories.map(cat => {
-    const rec = resolveVendor(cat.recommended.vendor);
-    const limits = rec ? publishedTermsOpening(rec, 1, 80) : "—";
-    const riskBadge = rec ? riskCellHtml(rec.risk_level, rec.risk_cause) : riskCellHtml("stable", null);
+    const cells = stackTableCellsHtml(cat.recommended.vendor, "—");
     return `      <tr>
         <td style="font-weight:600">${cat.icon} ${escHtmlServer(cat.name)}</td>
-        <td><a href="/vendor/${toSlug(cat.recommended.vendor)}" style="color:var(--text);font-weight:600">${escHtmlServer(cat.recommended.vendor)}</a></td>
-        <td style="font-family:var(--mono);font-size:.8rem;color:var(--accent)">${escHtmlServer(limits)}</td>
-        <td>${riskBadge}</td>
+        <td>${cells.vendorLink}</td>
+        <td style="font-family:var(--mono);font-size:.8rem;color:var(--accent)">${cells.limits}</td>
+        <td>${cells.verdict}</td>
       </tr>`;
   }).join("\n");
 
@@ -15588,12 +15688,12 @@ ${mcpCtaCss()}
 
   <div class="context">
     <p>Everything you need to build, deploy, and ship frontend projects — without spending a dollar. This guide recommends the best free tier for each layer of a frontend/Jamstack stack — <strong>10 categories</strong> from static hosting to feature flags — with exact limits pulled from our index of ${offers.length.toLocaleString()}+ verified developer tools.</p>
-    <p>Designed for solo developers, freelancers, and small teams building websites, web apps, and Jamstack projects. Each recommendation includes alternatives, a "when you'll outgrow it" guide, and stability notes based on our tracking of ${dealChanges.length} real pricing changes. All limits verified March 2026.</p>
+    <p>Designed for solo developers, freelancers, and small teams building websites, web apps, and Jamstack projects. Each recommendation includes alternatives, a "when you'll outgrow it" guide, and stability notes based on our tracking of ${dealChanges.length} real pricing changes. ${stackFreshnessNote(pageReadings)}</p>
   </div>
 
   <div class="cost-banner">
     <div class="cost-amount">$0<span style="font-size:1rem;color:var(--text-muted)">/month</span></div>
-    <div class="cost-label">Total estimated monthly cost for a personal site or small project</div>
+    <div class="cost-label">Total estimated monthly cost for a personal site or small project</div>${stackPickCostCaveat(pageReadings)}
   </div>
 
   <h2>Stack Overview</h2>
@@ -15667,10 +15767,8 @@ ${ossAlternatives.map(oss => `      <tr>
 
 function buildFreeNextjsStackPage(): string {
   const title = "The Complete Free Next.js Stack for 2026 — $0/Month Full-Stack Infrastructure";
-  const metaDesc = "Build a complete Next.js app on free tiers. 10 infrastructure layers — hosting, database, auth, storage, email, monitoring, CI/CD, analytics, search, and background jobs. Exact limits, growth costs. Updated April 2026.";
+  const metaDesc = "Build a complete Next.js app on free tiers. 10 infrastructure layers — hosting, database, auth, storage, email, monitoring, CI/CD, analytics, search, and background jobs. Exact limits, growth costs.";
   const slug = "free-nextjs-stack";
-
-  const riskColors: Record<string, string> = { stable: "#3fb950", caution: "#d29922", risky: "#f85149" };
 
   const stackCategories = [
     {
@@ -15792,36 +15890,18 @@ function buildFreeNextjsStackPage(): string {
     { q: "What's the first thing to spend money on when scaling a Next.js app?", a: "Database. Neon's 0.5 GiB free storage is the tightest limit in the stack. The Neon Launch plan at $19/month gets you 10 GiB storage, 300 compute hours, and autoscaling. After that, hosting: Vercel Pro at $20/month unlocks commercial use, 1 TB bandwidth, and faster builds. Everything else (auth, email, monitoring, analytics) scales to meaningful traffic on free tiers." },
   ]);
 
+  const pageReadings = stackPrimaryReadings(stackCategories);
   const categorySections = stackCategories.map(cat => {
     const rec = resolveVendor(cat.recommended.vendor);
     const altVendors = cat.alternatives.filter(v => v !== cat.recommended.vendor).map(v => resolveVendor(v)).filter(Boolean) as ReturnType<typeof enrichOffers>;
 
-    const recCard = rec ? `
-      <div class="stack-pick">
-        <div class="pick-header">
-          <span class="pick-badge">Recommended</span>
-          <a href="/vendor/${toSlug(rec.vendor)}" class="pick-name">${escHtmlServer(rec.vendor)}</a>
-          <span class="pick-tier">${escHtmlServer(rec.tier)}</span>
-          ${riskBadgeHtml(rec.risk_level, rec.risk_cause, { compact: true, margin: false })}
-        </div>
-        <p class="pick-why">${escHtmlServer(cat.recommended.why)}</p>
-        <p class="pick-limits">${escHtmlServer(publishedTermsOpening(rec, 2))}</p>
-        <div class="pick-links">
-          <a href="/vendor/${toSlug(rec.vendor)}">Full profile</a>
-          <a href="/alternative-to/${toSlug(rec.vendor)}">Alternatives</a>
-          ${offerPricingLink(rec, "Pricing &nearr;")}
-        </div>
-      </div>` : "";
+    const recCard = rec ? stackRecCardHtml(rec, cat.recommended.why) : "";
 
-    const altCards = altVendors.length > 0 ? `
-      <div class="alt-picks">
-        <p class="alt-label">Also consider:</p>
-        ${altVendors.map(a => `<a href="/vendor/${toSlug(a.vendor)}" class="alt-chip">${escHtmlServer(a.vendor)} <span class="chip-tier">${escHtmlServer(a.tier)}</span></a>`).join(" ")}
-      </div>` : "";
+    const altCards = stackAltPicksHtml(altVendors);
 
     const whyNotBox = cat.whyNot ? `
       <div class="whynot-box">
-        <strong>⚠️ ${escHtmlServer(cat.whyNot)}</strong>
+        <strong>⚠️ ${stackProseHtml(cat.whyNot, [cat.recommended.vendor, ...cat.alternatives])}</strong>
       </div>` : "";
 
     const relatedLink = cat.relatedPage ? `<a href="${cat.relatedPage}" class="related-link">Full comparison guide &rarr;</a>` : "";
@@ -15832,7 +15912,7 @@ function buildFreeNextjsStackPage(): string {
       ${recCard}
       ${altCards}
       <div class="outgrow-box">
-        <strong>When you'll outgrow it:</strong> ${escHtmlServer(cat.outgrow)}
+        <strong>When you'll outgrow it:</strong> ${stackProseHtml(cat.outgrow, [cat.recommended.vendor, ...cat.alternatives])}
       </div>
       ${whyNotBox}
       ${relatedLink}
@@ -15859,14 +15939,12 @@ function buildFreeNextjsStackPage(): string {
   <p style="margin-top:1rem;font-size:.85rem"><a href="/changes">View all ${dealChanges.length} pricing changes &rarr;</a></p>` : "";
 
   const tableRows = stackCategories.map(cat => {
-    const rec = resolveVendor(cat.recommended.vendor);
-    const limits = rec ? publishedTermsOpening(rec, 1, 80) : "—";
-    const riskBadge = rec ? riskCellHtml(rec.risk_level, rec.risk_cause) : riskCellHtml("stable", null);
+    const cells = stackTableCellsHtml(cat.recommended.vendor, "—");
     return `      <tr>
         <td style="font-weight:600">${cat.icon} ${escHtmlServer(cat.name)}</td>
-        <td><a href="/vendor/${toSlug(cat.recommended.vendor)}" style="color:var(--text);font-weight:600">${escHtmlServer(cat.recommended.vendor)}</a></td>
-        <td style="font-family:var(--mono);font-size:.8rem;color:var(--accent)">${escHtmlServer(limits)}</td>
-        <td>${riskBadge}</td>
+        <td>${cells.vendorLink}</td>
+        <td style="font-family:var(--mono);font-size:.8rem;color:var(--accent)">${cells.limits}</td>
+        <td>${cells.verdict}</td>
       </tr>`;
   }).join("\n");
 
@@ -15966,12 +16044,12 @@ ${mcpCtaCss()}
 
   <div class="context">
     <p>Everything you need to build and ship a Next.js app — without spending a dollar. This guide recommends the best free tier for each layer of your Next.js infrastructure — <strong>10 layers</strong> from hosting to background jobs — with exact limits pulled from our index of ${offers.length.toLocaleString()}+ verified developer tools.</p>
-    <p>Designed for solo developers, indie hackers, and small teams building SaaS products, side projects, or MVPs with Next.js. Each recommendation includes alternatives, a "when you'll outgrow it" guide, "why not X" callouts for popular-but-not-recommended options, and stability notes based on our tracking of ${dealChanges.length} real pricing changes. All limits verified April 2026.</p>
+    <p>Designed for solo developers, indie hackers, and small teams building SaaS products, side projects, or MVPs with Next.js. Each recommendation includes alternatives, a "when you'll outgrow it" guide, "why not X" callouts for popular-but-not-recommended options, and stability notes based on our tracking of ${dealChanges.length} real pricing changes. ${stackFreshnessNote(pageReadings)}</p>
   </div>
 
   <div class="cost-banner">
     <div class="cost-amount">$0<span style="font-size:1rem;color:var(--text-muted)">/month</span></div>
-    <div class="cost-label">Total infrastructure cost for a Next.js SaaS on free tiers</div>
+    <div class="cost-label">Total infrastructure cost for a Next.js SaaS on free tiers</div>${stackPickCostCaveat(pageReadings)}
   </div>
 
   <h2>Stack Overview</h2>
@@ -16052,10 +16130,8 @@ GitHub → GitHub Actions (CI: tests + lint) → Vercel (CD: auto-deploy)</div>
 
 function buildFreeDjangoStackPage(): string {
   const title = "The Complete Free Django/Python Stack for 2026 — $0/Month Full-Stack Infrastructure";
-  const metaDesc = "Build a complete Django app on free tiers. 10 infrastructure layers — WSGI hosting, Postgres, Redis/cache, auth, storage, email, monitoring, CI/CD, task queue, and search. Exact limits, growth costs. Updated April 2026.";
+  const metaDesc = "Build a complete Django app on free tiers. 10 infrastructure layers — WSGI hosting, Postgres, Redis/cache, auth, storage, email, monitoring, CI/CD, task queue, and search. Exact limits, growth costs.";
   const slug = "free-django-stack";
-
-  const riskColors: Record<string, string> = { stable: "#3fb950", caution: "#d29922", risky: "#f85149" };
 
   const stackCategories = [
     {
@@ -16188,36 +16264,17 @@ function buildFreeDjangoStackPage(): string {
     { q: "PythonAnywhere vs Railway vs Render for Django?", a: "Railway is the best overall — a 30-day $5 trial credit then a $1/month minimum, no sleep timer, managed Postgres, and auto-deploy from GitHub. PythonAnywhere is great for learning (free WSGI hosting, built-in console) but limits you to one web app with no custom domain on free tier. Render has a free tier but your app sleeps after 15 minutes, causing 30-60 second cold starts that hurt user experience. For production Django apps, Railway or Fly.io." },
   ]);
 
+  const pageReadings = stackPrimaryReadings(stackCategories);
   const categorySections = stackCategories.map(cat => {
     const rec = resolveVendor(cat.recommended.vendor);
     const altVendors = cat.alternatives.filter(v => v !== cat.recommended.vendor).map(v => resolveVendor(v)).filter(Boolean) as ReturnType<typeof enrichOffers>;
 
-    const recCard = rec ? `
-      <div class="stack-pick">
-        <div class="pick-header">
-          <span class="pick-badge">Recommended</span>
-          <a href="/vendor/${toSlug(rec.vendor)}" class="pick-name">${escHtmlServer(rec.vendor)}</a>
-          <span class="pick-tier">${escHtmlServer(rec.tier)}</span>
-          ${riskBadgeHtml(rec.risk_level, rec.risk_cause, { compact: true, margin: false })}
-        </div>
-        <p class="pick-why">${escHtmlServer(cat.recommended.why)}</p>
-        <p class="pick-limits">${escHtmlServer(publishedTermsOpening(rec, 2))}</p>
-        <div class="pick-links">
-          <a href="/vendor/${toSlug(rec.vendor)}">Full profile</a>
-          <a href="/alternative-to/${toSlug(rec.vendor)}">Alternatives</a>
-          ${offerPricingLink(rec, "Pricing &nearr;")}
-        </div>
-      </div>` : cat.recommended.vendor === "Django Built-in Auth" ? `
-      <div class="stack-pick">
-        <div class="pick-header">
-          <span class="pick-badge">Recommended</span>
-          <span class="pick-name">Django Built-in Auth</span>
-          <span class="pick-tier">Free (included)</span>
-          <span style="display:inline-block;font-size:.65rem;padding:.1rem .4rem;border-radius:10px;background:${riskColors.stable}22;color:${riskColors.stable};font-weight:600">stable</span>
-        </div>
-        <p class="pick-why">${escHtmlServer(cat.recommended.why)}</p>
-        <p class="pick-limits">django.contrib.auth — unlimited users, sessions, permissions, groups. Add django-allauth for social login.</p>
-      </div>` : `
+    const recCard = rec ? stackRecCardHtml(rec, cat.recommended.why) : cat.recommended.vendor === "Django Built-in Auth" ? stackNamedPickHtml(
+      "Django Built-in Auth",
+      cat.recommended.why,
+      "Free (included)",
+      "django.contrib.auth — unlimited users, sessions, permissions, groups. Add django-allauth for social login.",
+    ) : `
       <div class="stack-pick">
         <div class="pick-header">
           <span class="pick-badge">Recommended</span>
@@ -16227,15 +16284,11 @@ function buildFreeDjangoStackPage(): string {
         <p class="pick-why">${escHtmlServer(cat.recommended.why)}</p>
       </div>`;
 
-    const altCards = altVendors.length > 0 ? `
-      <div class="alt-picks">
-        <p class="alt-label">Also consider:</p>
-        ${altVendors.map(a => `<a href="/vendor/${toSlug(a.vendor)}" class="alt-chip">${escHtmlServer(a.vendor)} <span class="chip-tier">${escHtmlServer(a.tier)}</span></a>`).join(" ")}
-      </div>` : "";
+    const altCards = stackAltPicksHtml(altVendors);
 
     const whyNotBox = cat.whyNot ? `
       <div class="whynot-box">
-        <strong>⚠️ ${escHtmlServer(cat.whyNot)}</strong>
+        <strong>⚠️ ${stackProseHtml(cat.whyNot, [cat.recommended.vendor, ...cat.alternatives])}</strong>
       </div>` : "";
 
     const relatedLink = cat.relatedPage ? `<a href="${cat.relatedPage}" class="related-link">Full comparison guide &rarr;</a>` : "";
@@ -16246,7 +16299,7 @@ function buildFreeDjangoStackPage(): string {
       ${recCard}
       ${altCards}
       <div class="outgrow-box">
-        <strong>When you'll outgrow it:</strong> ${escHtmlServer(cat.outgrow)}
+        <strong>When you'll outgrow it:</strong> ${stackProseHtml(cat.outgrow, [cat.recommended.vendor, ...cat.alternatives])}
       </div>
       ${whyNotBox}
       ${relatedLink}
@@ -16273,16 +16326,13 @@ function buildFreeDjangoStackPage(): string {
   <p style="margin-top:1rem;font-size:.85rem"><a href="/changes">View all ${dealChanges.length} pricing changes &rarr;</a></p>` : "";
 
   const tableRows = stackCategories.map(cat => {
-    const rec = resolveVendor(cat.recommended.vendor);
     const vendorName = cat.recommended.vendor;
-    const limits = rec ? publishedTermsOpening(rec, 1, 80) : vendorName === "Django Built-in Auth" ? "Unlimited — included in Django" : "—";
-    const riskBadge = rec ? riskCellHtml(rec.risk_level, rec.risk_cause) : riskCellHtml("stable", null);
-    const vendorLink = rec ? `<a href="/vendor/${toSlug(rec.vendor)}" style="color:var(--text);font-weight:600">${escHtmlServer(vendorName)}</a>` : `<span style="font-weight:600">${escHtmlServer(vendorName)}</span>`;
+    const cells = stackTableCellsHtml(vendorName, vendorName === "Django Built-in Auth" ? "Unlimited — included in Django" : "—");
     return `      <tr>
         <td style="font-weight:600">${cat.icon} ${escHtmlServer(cat.name)}</td>
-        <td>${vendorLink}</td>
-        <td style="font-family:var(--mono);font-size:.8rem;color:var(--accent)">${escHtmlServer(limits)}</td>
-        <td>${riskBadge}</td>
+        <td>${cells.vendorLink}</td>
+        <td style="font-family:var(--mono);font-size:.8rem;color:var(--accent)">${cells.limits}</td>
+        <td>${cells.verdict}</td>
       </tr>`;
   }).join("\n");
 
@@ -16386,12 +16436,12 @@ ${mcpCtaCss()}
 
   <div class="context">
     <p>Everything you need to build and ship a Django app — without spending a dollar. This guide recommends the best free tier for each layer of your Django infrastructure — <strong>10 layers</strong> from hosting to search — with exact limits pulled from our index of ${offers.length.toLocaleString()}+ verified developer tools.</p>
-    <p>Designed for Python developers building SaaS products, AI/ML applications, APIs, and side projects with Django. Each recommendation includes alternatives, a "when you'll outgrow it" guide, "why not X" callouts for popular-but-not-recommended options, and stability notes based on our tracking of ${dealChanges.length} real pricing changes. All limits verified April 2026.</p>
+    <p>Designed for Python developers building SaaS products, AI/ML applications, APIs, and side projects with Django. Each recommendation includes alternatives, a "when you'll outgrow it" guide, "why not X" callouts for popular-but-not-recommended options, and stability notes based on our tracking of ${dealChanges.length} real pricing changes. ${stackFreshnessNote(pageReadings)}</p>
   </div>
 
   <div class="cost-banner">
     <div class="cost-amount">$0<span style="font-size:1rem;color:var(--text-muted)">/month</span></div>
-    <div class="cost-label">Total infrastructure cost for a Django SaaS on free tiers</div>
+    <div class="cost-label">Total infrastructure cost for a Django SaaS on free tiers</div>${stackPickCostCaveat(pageReadings)}
   </div>
 
   <div class="batteries-box">
@@ -16490,10 +16540,8 @@ GitHub → GitHub Actions (CI: pytest + ruff) → Railway (CD: auto-deploy)</div
 
 function buildFreeFastapiStackPage(): string {
   const title = "The Complete Free FastAPI/Python Stack for 2026 — $0/Month Full-Stack Infrastructure";
-  const metaDesc = "Build a complete FastAPI app on free tiers. 10 infrastructure layers — ASGI hosting, async Postgres, Redis, auth, storage, email, monitoring, CI/CD, background tasks, and API docs. Exact limits, growth costs. Updated April 2026.";
+  const metaDesc = "Build a complete FastAPI app on free tiers. 10 infrastructure layers — ASGI hosting, async Postgres, Redis, auth, storage, email, monitoring, CI/CD, background tasks, and API docs. Exact limits, growth costs.";
   const slug = "free-fastapi-stack";
-
-  const riskColors: Record<string, string> = { stable: "#3fb950", caution: "#d29922", risky: "#f85149" };
 
   const stackCategories = [
     {
@@ -16624,36 +16672,17 @@ function buildFreeFastapiStackPage(): string {
     { q: "FastAPI vs Django for free hosting?", a: "FastAPI is lighter weight and async-native — ideal for APIs, microservices, and AI/ML serving. Django is batteries-included with built-in ORM, admin, auth, and forms — better for full web applications. Both host free on Railway ($5 credit) or Render. FastAPI needs you to choose every component (ORM, auth, admin) separately. Django includes them. If you're building a REST/GraphQL API or serving ML models, FastAPI. If you're building a web app with admin panel and user accounts, Django." },
   ]);
 
+  const pageReadings = stackPrimaryReadings(stackCategories);
   const categorySections = stackCategories.map(cat => {
     const rec = resolveVendor(cat.recommended.vendor);
     const altVendors = cat.alternatives.filter(v => v !== cat.recommended.vendor).map(v => resolveVendor(v)).filter(Boolean) as ReturnType<typeof enrichOffers>;
 
-    const recCard = rec ? `
-      <div class="stack-pick">
-        <div class="pick-header">
-          <span class="pick-badge">Recommended</span>
-          <a href="/vendor/${toSlug(rec.vendor)}" class="pick-name">${escHtmlServer(rec.vendor)}</a>
-          <span class="pick-tier">${escHtmlServer(rec.tier)}</span>
-          ${riskBadgeHtml(rec.risk_level, rec.risk_cause, { compact: true, margin: false })}
-        </div>
-        <p class="pick-why">${escHtmlServer(cat.recommended.why)}</p>
-        <p class="pick-limits">${escHtmlServer(publishedTermsOpening(rec, 2))}</p>
-        <div class="pick-links">
-          <a href="/vendor/${toSlug(rec.vendor)}">Full profile</a>
-          <a href="/alternative-to/${toSlug(rec.vendor)}">Alternatives</a>
-          ${offerPricingLink(rec, "Pricing &nearr;")}
-        </div>
-      </div>` : cat.recommended.vendor === "FastAPI Built-in" ? `
-      <div class="stack-pick">
-        <div class="pick-header">
-          <span class="pick-badge">Recommended</span>
-          <span class="pick-name">FastAPI Built-in</span>
-          <span class="pick-tier">Free (included)</span>
-          <span style="display:inline-block;font-size:.65rem;padding:.1rem .4rem;border-radius:10px;background:${riskColors.stable}22;color:${riskColors.stable};font-weight:600">stable</span>
-        </div>
-        <p class="pick-why">${escHtmlServer(cat.recommended.why)}</p>
-        <p class="pick-limits">Automatic Swagger UI + ReDoc from type hints. Zero config, zero cost.</p>
-      </div>` : `
+    const recCard = rec ? stackRecCardHtml(rec, cat.recommended.why) : cat.recommended.vendor === "FastAPI Built-in" ? stackNamedPickHtml(
+      "FastAPI Built-in",
+      cat.recommended.why,
+      "Free (included)",
+      "Automatic Swagger UI + ReDoc from type hints. Zero config, zero cost.",
+    ) : `
       <div class="stack-pick">
         <div class="pick-header">
           <span class="pick-badge">Recommended</span>
@@ -16663,15 +16692,11 @@ function buildFreeFastapiStackPage(): string {
         <p class="pick-why">${escHtmlServer(cat.recommended.why)}</p>
       </div>`;
 
-    const altCards = altVendors.length > 0 ? `
-      <div class="alt-picks">
-        <p class="alt-label">Also consider:</p>
-        ${altVendors.map(a => `<a href="/vendor/${toSlug(a.vendor)}" class="alt-chip">${escHtmlServer(a.vendor)} <span class="chip-tier">${escHtmlServer(a.tier)}</span></a>`).join(" ")}
-      </div>` : "";
+    const altCards = stackAltPicksHtml(altVendors);
 
     const whyNotBox = cat.whyNot ? `
       <div class="whynot-box">
-        <strong>⚠️ ${escHtmlServer(cat.whyNot)}</strong>
+        <strong>⚠️ ${stackProseHtml(cat.whyNot, [cat.recommended.vendor, ...cat.alternatives])}</strong>
       </div>` : "";
 
     const relatedLink = cat.relatedPage ? `<a href="${cat.relatedPage}" class="related-link">Full comparison guide &rarr;</a>` : "";
@@ -16682,7 +16707,7 @@ function buildFreeFastapiStackPage(): string {
       ${recCard}
       ${altCards}
       <div class="outgrow-box">
-        <strong>When you'll outgrow it:</strong> ${escHtmlServer(cat.outgrow)}
+        <strong>When you'll outgrow it:</strong> ${stackProseHtml(cat.outgrow, [cat.recommended.vendor, ...cat.alternatives])}
       </div>
       ${whyNotBox}
       ${relatedLink}
@@ -16709,16 +16734,13 @@ function buildFreeFastapiStackPage(): string {
   <p style="margin-top:1rem;font-size:.85rem"><a href="/changes">View all ${dealChanges.length} pricing changes &rarr;</a></p>` : "";
 
   const tableRows = stackCategories.map(cat => {
-    const rec = resolveVendor(cat.recommended.vendor);
     const vendorName = cat.recommended.vendor;
-    const limits = rec ? publishedTermsOpening(rec, 1, 80) : vendorName === "FastAPI Built-in" ? "Unlimited — built into FastAPI" : "—";
-    const riskBadge = rec ? riskCellHtml(rec.risk_level, rec.risk_cause) : riskCellHtml("stable", null);
-    const vendorLink = rec ? `<a href="/vendor/${toSlug(rec.vendor)}" style="color:var(--text);font-weight:600">${escHtmlServer(vendorName)}</a>` : `<span style="font-weight:600">${escHtmlServer(vendorName)}</span>`;
+    const cells = stackTableCellsHtml(vendorName, vendorName === "FastAPI Built-in" ? "Unlimited — built into FastAPI" : "—");
     return `      <tr>
         <td style="font-weight:600">${cat.icon} ${escHtmlServer(cat.name)}</td>
-        <td>${vendorLink}</td>
-        <td style="font-family:var(--mono);font-size:.8rem;color:var(--accent)">${escHtmlServer(limits)}</td>
-        <td>${riskBadge}</td>
+        <td>${cells.vendorLink}</td>
+        <td style="font-family:var(--mono);font-size:.8rem;color:var(--accent)">${cells.limits}</td>
+        <td>${cells.verdict}</td>
       </tr>`;
   }).join("\n");
 
@@ -16826,12 +16848,12 @@ ${mcpCtaCss()}
 
   <div class="context">
     <p>Everything you need to build and ship a FastAPI app — without spending a dollar. This guide recommends the best free tier for each layer of your FastAPI infrastructure — <strong>10 layers</strong> from ASGI hosting to API documentation — with exact limits pulled from our index of ${offers.length.toLocaleString()}+ verified developer tools.</p>
-    <p>Designed for Python developers building REST APIs, AI/ML serving endpoints, microservices, and async backend services with FastAPI. Each recommendation includes alternatives, a "when you'll outgrow it" guide, "why not X" callouts for popular-but-not-recommended options, and stability notes based on our tracking of ${dealChanges.length} real pricing changes. All limits verified April 2026.</p>
+    <p>Designed for Python developers building REST APIs, AI/ML serving endpoints, microservices, and async backend services with FastAPI. Each recommendation includes alternatives, a "when you'll outgrow it" guide, "why not X" callouts for popular-but-not-recommended options, and stability notes based on our tracking of ${dealChanges.length} real pricing changes. ${stackFreshnessNote(pageReadings)}</p>
   </div>
 
   <div class="cost-banner">
     <div class="cost-amount">$0<span style="font-size:1rem;color:var(--text-muted)">/month</span></div>
-    <div class="cost-label">Total infrastructure cost for a FastAPI service on free tiers</div>
+    <div class="cost-label">Total infrastructure cost for a FastAPI service on free tiers</div>${stackPickCostCaveat(pageReadings)}
   </div>
 
   <div class="choose-box">
@@ -16943,10 +16965,8 @@ GitHub → GitHub Actions (CI: pytest + ruff) → Railway (CD: auto-deploy)</div
 
 function buildFreeGoStackPage(): string {
   const title = "The Complete Free Go/Golang Stack for 2026 — $0/Month Full-Stack Infrastructure";
-  const metaDesc = "Build a complete Go app on free tiers. 10 infrastructure layers — single binary hosting, Postgres via pgx, Redis, auth, storage, email, monitoring, CI/CD, background jobs, and API docs. Exact limits, growth costs. Updated April 2026.";
+  const metaDesc = "Build a complete Go app on free tiers. 10 infrastructure layers — single binary hosting, Postgres via pgx, Redis, auth, storage, email, monitoring, CI/CD, background jobs, and API docs. Exact limits, growth costs.";
   const slug = "free-go-stack";
-
-  const riskColors: Record<string, string> = { stable: "#3fb950", caution: "#d29922", risky: "#f85149" };
 
   const stackCategories = [
     {
@@ -17077,36 +17097,17 @@ function buildFreeGoStackPage(): string {
     { q: "Do I need a framework for Go web apps?", a: "No. Go's net/http standard library is production-ready — it powers many of the world's largest services. Add a router (chi or gorilla/mux) for path parameters and middleware chaining. Frameworks like Gin, Echo, and Fiber add convenience (binding, validation, structured logging) but aren't required. The stdlib-first approach means fewer dependencies, smaller binaries, and no framework lock-in." },
   ]);
 
+  const pageReadings = stackPrimaryReadings(stackCategories);
   const categorySections = stackCategories.map(cat => {
     const rec = resolveVendor(cat.recommended.vendor);
     const altVendors = cat.alternatives.filter(v => v !== cat.recommended.vendor).map(v => resolveVendor(v)).filter(Boolean) as ReturnType<typeof enrichOffers>;
 
-    const recCard = rec ? `
-      <div class="stack-pick">
-        <div class="pick-header">
-          <span class="pick-badge">Recommended</span>
-          <a href="/vendor/${toSlug(rec.vendor)}" class="pick-name">${escHtmlServer(rec.vendor)}</a>
-          <span class="pick-tier">${escHtmlServer(rec.tier)}</span>
-          ${riskBadgeHtml(rec.risk_level, rec.risk_cause, { compact: true, margin: false })}
-        </div>
-        <p class="pick-why">${escHtmlServer(cat.recommended.why)}</p>
-        <p class="pick-limits">${escHtmlServer(publishedTermsOpening(rec, 2))}</p>
-        <div class="pick-links">
-          <a href="/vendor/${toSlug(rec.vendor)}">Full profile</a>
-          <a href="/alternative-to/${toSlug(rec.vendor)}">Alternatives</a>
-          ${offerPricingLink(rec, "Pricing &nearr;")}
-        </div>
-      </div>` : (cat.recommended.vendor === "Go Goroutines" || cat.recommended.vendor === "swaggo/swag") ? `
-      <div class="stack-pick">
-        <div class="pick-header">
-          <span class="pick-badge">Recommended</span>
-          <span class="pick-name">${escHtmlServer(cat.recommended.vendor)}</span>
-          <span class="pick-tier">Free (${cat.recommended.vendor === "Go Goroutines" ? "built into Go" : "open source"})</span>
-          <span style="display:inline-block;font-size:.65rem;padding:.1rem .4rem;border-radius:10px;background:${riskColors.stable}22;color:${riskColors.stable};font-weight:600">stable</span>
-        </div>
-        <p class="pick-why">${escHtmlServer(cat.recommended.why)}</p>
-        <p class="pick-limits">${cat.recommended.vendor === "Go Goroutines" ? "Unlimited — goroutines cost ~2 KB each, millions per process" : "OpenAPI generation from Go comments — Swagger UI included"}</p>
-      </div>` : `
+    const recCard = rec ? stackRecCardHtml(rec, cat.recommended.why) : (cat.recommended.vendor === "Go Goroutines" || cat.recommended.vendor === "swaggo/swag") ? stackNamedPickHtml(
+      cat.recommended.vendor,
+      cat.recommended.why,
+      `Free (${cat.recommended.vendor === "Go Goroutines" ? "built into Go" : "open source"})`,
+      cat.recommended.vendor === "Go Goroutines" ? "Unlimited — goroutines cost ~2 KB each, millions per process" : "OpenAPI generation from Go comments — Swagger UI included",
+    ) : `
       <div class="stack-pick">
         <div class="pick-header">
           <span class="pick-badge">Recommended</span>
@@ -17116,15 +17117,11 @@ function buildFreeGoStackPage(): string {
         <p class="pick-why">${escHtmlServer(cat.recommended.why)}</p>
       </div>`;
 
-    const altCards = altVendors.length > 0 ? `
-      <div class="alt-picks">
-        <p class="alt-label">Also consider:</p>
-        ${altVendors.map(a => `<a href="/vendor/${toSlug(a.vendor)}" class="alt-chip">${escHtmlServer(a.vendor)} <span class="chip-tier">${escHtmlServer(a.tier)}</span></a>`).join(" ")}
-      </div>` : "";
+    const altCards = stackAltPicksHtml(altVendors);
 
     const whyNotBox = cat.whyNot ? `
       <div class="whynot-box">
-        <strong>⚠️ ${escHtmlServer(cat.whyNot)}</strong>
+        <strong>⚠️ ${stackProseHtml(cat.whyNot, [cat.recommended.vendor, ...cat.alternatives])}</strong>
       </div>` : "";
 
     const relatedLink = cat.relatedPage ? `<a href="${cat.relatedPage}" class="related-link">Full comparison guide &rarr;</a>` : "";
@@ -17135,7 +17132,7 @@ function buildFreeGoStackPage(): string {
       ${recCard}
       ${altCards}
       <div class="outgrow-box">
-        <strong>When you'll outgrow it:</strong> ${escHtmlServer(cat.outgrow)}
+        <strong>When you'll outgrow it:</strong> ${stackProseHtml(cat.outgrow, [cat.recommended.vendor, ...cat.alternatives])}
       </div>
       ${whyNotBox}
       ${relatedLink}
@@ -17162,16 +17159,13 @@ function buildFreeGoStackPage(): string {
   <p style="margin-top:1rem;font-size:.85rem"><a href="/changes">View all ${dealChanges.length} pricing changes &rarr;</a></p>` : "";
 
   const tableRows = stackCategories.map(cat => {
-    const rec = resolveVendor(cat.recommended.vendor);
     const vendorName = cat.recommended.vendor;
-    const limits = rec ? publishedTermsOpening(rec, 1, 80) : (vendorName === "Go Goroutines" ? "Unlimited — built into Go runtime" : vendorName === "swaggo/swag" ? "Open source — generates from comments" : "—");
-    const riskBadge = rec ? riskCellHtml(rec.risk_level, rec.risk_cause) : riskCellHtml("stable", null);
-    const vendorLink = rec ? `<a href="/vendor/${toSlug(rec.vendor)}" style="color:var(--text);font-weight:600">${escHtmlServer(vendorName)}</a>` : `<span style="font-weight:600">${escHtmlServer(vendorName)}</span>`;
+    const cells = stackTableCellsHtml(vendorName, (vendorName === "Go Goroutines" ? "Unlimited — built into Go runtime" : vendorName === "swaggo/swag" ? "Open source — generates from comments" : "—"));
     return `      <tr>
         <td style="font-weight:600">${cat.icon} ${escHtmlServer(cat.name)}</td>
-        <td>${vendorLink}</td>
-        <td style="font-family:var(--mono);font-size:.8rem;color:var(--accent)">${escHtmlServer(limits)}</td>
-        <td>${riskBadge}</td>
+        <td>${cells.vendorLink}</td>
+        <td style="font-family:var(--mono);font-size:.8rem;color:var(--accent)">${cells.limits}</td>
+        <td>${cells.verdict}</td>
       </tr>`;
   }).join("\n");
 
@@ -17278,12 +17272,12 @@ ${mcpCtaCss()}
 
   <div class="context">
     <p>Everything you need to build and ship a Go service — without spending a dollar. This guide recommends the best free tier for each layer of your Go infrastructure — <strong>10 layers</strong> from single-binary hosting to API documentation — with exact limits pulled from our index of ${offers.length.toLocaleString()}+ verified developer tools.</p>
-    <p>Designed for developers building REST APIs, CLI tools, microservices, DevOps tooling, and cloud-native infrastructure with Go. Each recommendation includes alternatives, a "when you'll outgrow it" guide, "why not X" callouts for popular-but-not-recommended options, and stability notes based on our tracking of ${dealChanges.length} real pricing changes. All limits verified April 2026.</p>
+    <p>Designed for developers building REST APIs, CLI tools, microservices, DevOps tooling, and cloud-native infrastructure with Go. Each recommendation includes alternatives, a "when you'll outgrow it" guide, "why not X" callouts for popular-but-not-recommended options, and stability notes based on our tracking of ${dealChanges.length} real pricing changes. ${stackFreshnessNote(pageReadings)}</p>
   </div>
 
   <div class="cost-banner">
     <div class="cost-amount">$0<span style="font-size:1rem;color:var(--text-muted)">/month</span></div>
-    <div class="cost-label">Total infrastructure cost for a Go service on free tiers</div>
+    <div class="cost-label">Total infrastructure cost for a Go service on free tiers</div>${stackPickCostCaveat(pageReadings)}
   </div>
 
   <div class="binary-box">
@@ -17387,7 +17381,7 @@ GitHub → GitHub Actions (CI: go test + golangci-lint) → Railway (CD: auto-de
 
 function buildFreeSaasStackPage(): string {
   const title = "The Complete Free SaaS Starter Stack for 2026 — Build and Launch for $0/Month";
-  const metaDesc = "Build a complete SaaS product on free tiers. 12 infrastructure categories — hosting, database, auth, payments, email, storage, monitoring, CI/CD, analytics. Exact limits, growth costs at 1K/10K/100K users. Updated April 2026.";
+  const metaDesc = "Build a complete SaaS product on free tiers. 12 infrastructure categories — hosting, database, auth, payments, email, storage, monitoring, CI/CD, analytics. Exact limits, growth costs at 1K/10K/100K users.";
   const slug = "free-saas-stack";
 
   const riskColors: Record<string, string> = { stable: "#3fb950", caution: "#d29922", risky: "#f85149" };
@@ -17536,6 +17530,7 @@ function buildFreeSaasStackPage(): string {
     { q: "When should I start paying for infrastructure?", a: "Most SaaS products can run entirely on free tiers through their first 1,000-5,000 users. Database storage (Neon 0.5 GiB) is typically the first limit you'll hit, followed by email volume (Resend 3K/month) and hosting compute. The jump from free to first paid tier is $19-25/month. By the time you need to pay, you should have paying customers. Plan your growth path: at 10K users expect ~$150-300/month total infrastructure, at 100K users ~$1,500-3,000/month." },
   ]);
 
+  const pageReadings = stackPrimaryReadings(stackCategories);
   const categorySections = stackCategories.map(cat => {
     if (cat.isFrameworkSection) {
       return `
@@ -17568,32 +17563,12 @@ function buildFreeSaasStackPage(): string {
     const rec = resolveVendor(cat.recommended.vendor);
     const altVendors = cat.alternatives.filter(v => v !== cat.recommended.vendor).map(v => resolveVendor(v)).filter(Boolean) as ReturnType<typeof enrichOffers>;
 
-    const recCard = rec ? `
-      <div class="stack-pick">
-        <div class="pick-header">
-          <span class="pick-badge">Recommended</span>
-          <a href="/vendor/${toSlug(rec.vendor)}" class="pick-name">${escHtmlServer(rec.vendor)}</a>
-          <span class="pick-tier">${escHtmlServer(rec.tier)}</span>
-          ${riskBadgeHtml(rec.risk_level, rec.risk_cause, { compact: true, margin: false })}
-        </div>
-        <p class="pick-why">${escHtmlServer(cat.recommended.why)}</p>
-        <p class="pick-limits">${escHtmlServer(publishedTermsOpening(rec, 2))}</p>
-        <div class="pick-links">
-          <a href="/vendor/${toSlug(rec.vendor)}">Full profile</a>
-          <a href="/alternative-to/${toSlug(rec.vendor)}">Alternatives</a>
-          ${offerPricingLink(rec, "Pricing &nearr;")}
-        </div>
-      </div>` : (cat.recommended.vendor === "Stripe") ? `
-      <div class="stack-pick">
-        <div class="pick-header">
-          <span class="pick-badge">Recommended</span>
-          <span class="pick-name">Stripe</span>
-          <span class="pick-tier">No monthly fee \u2014 2.9% + 30\u00a2/txn</span>
-          <span style="display:inline-block;font-size:.65rem;padding:.1rem .4rem;border-radius:10px;background:${riskColors.stable}22;color:${riskColors.stable};font-weight:600">stable</span>
-        </div>
-        <p class="pick-why">${escHtmlServer(cat.recommended.why)}</p>
-        <p class="pick-limits">No monthly fee. Pay-per-transaction only. Subscriptions, invoicing, tax, customer portal included.</p>
-      </div>` : `
+    const recCard = rec ? stackRecCardHtml(rec, cat.recommended.why) : (cat.recommended.vendor === "Stripe") ? stackNamedPickHtml(
+      "Stripe",
+      cat.recommended.why,
+      "No monthly fee \u2014 2.9% + 30\u00a2/txn",
+      "No monthly fee. Pay-per-transaction only. Subscriptions, invoicing, tax, customer portal included.",
+    ) : `
       <div class="stack-pick">
         <div class="pick-header">
           <span class="pick-badge">Recommended</span>
@@ -17603,15 +17578,11 @@ function buildFreeSaasStackPage(): string {
         <p class="pick-why">${escHtmlServer(cat.recommended.why)}</p>
       </div>`;
 
-    const altCards = altVendors.length > 0 ? `
-      <div class="alt-picks">
-        <p class="alt-label">Also consider:</p>
-        ${altVendors.map(a => `<a href="/vendor/${toSlug(a.vendor)}" class="alt-chip">${escHtmlServer(a.vendor)} <span class="chip-tier">${escHtmlServer(a.tier)}</span></a>`).join(" ")}
-      </div>` : "";
+    const altCards = stackAltPicksHtml(altVendors);
 
     const whyNotBox = cat.whyNot ? `
       <div class="whynot-box">
-        <strong>\u26A0\uFE0F ${escHtmlServer(cat.whyNot)}</strong>
+        <strong>\u26A0\uFE0F ${stackProseHtml(cat.whyNot, [cat.recommended.vendor, ...cat.alternatives])}</strong>
       </div>` : "";
 
     const relatedLink = cat.relatedPage ? `<a href="${cat.relatedPage}" class="related-link">Full comparison guide &rarr;</a>` : "";
@@ -17622,7 +17593,7 @@ function buildFreeSaasStackPage(): string {
       ${recCard}
       ${altCards}
       <div class="outgrow-box">
-        <strong>When you'll outgrow it:</strong> ${escHtmlServer(cat.outgrow)}
+        <strong>When you'll outgrow it:</strong> ${stackProseHtml(cat.outgrow, [cat.recommended.vendor, ...cat.alternatives])}
       </div>
       ${whyNotBox}
       ${relatedLink}
@@ -17649,16 +17620,13 @@ function buildFreeSaasStackPage(): string {
   <p style="margin-top:1rem;font-size:.85rem"><a href="/changes">View all ${dealChanges.length} pricing changes &rarr;</a></p>` : "";
 
   const tableRows = stackCategories.filter(c => !c.isFrameworkSection).map(cat => {
-    const rec = resolveVendor(cat.recommended.vendor);
     const vendorName = cat.recommended.vendor;
-    const limits = rec ? publishedTermsOpening(rec, 1, 80) : (vendorName === "Stripe" ? "No monthly fee \u2014 2.9% + 30\u00a2/txn" : "\u2014");
-    const riskBadge = rec ? riskCellHtml(rec.risk_level, rec.risk_cause) : riskCellHtml("stable", null);
-    const vendorLink = rec ? `<a href="/vendor/${toSlug(rec.vendor)}" style="color:var(--text);font-weight:600">${escHtmlServer(vendorName)}</a>` : `<span style="font-weight:600">${escHtmlServer(vendorName)}</span>`;
+    const cells = stackTableCellsHtml(vendorName, (vendorName === "Stripe" ? "No monthly fee \u2014 2.9% + 30\u00a2/txn" : "\u2014"));
     return `      <tr>
         <td style="font-weight:600">${cat.icon} ${escHtmlServer(cat.name)}</td>
-        <td>${vendorLink}</td>
-        <td style="font-family:var(--mono);font-size:.8rem;color:var(--accent)">${escHtmlServer(limits)}</td>
-        <td>${riskBadge}</td>
+        <td>${cells.vendorLink}</td>
+        <td style="font-family:var(--mono);font-size:.8rem;color:var(--accent)">${cells.limits}</td>
+        <td>${cells.verdict}</td>
       </tr>`;
   }).join("\n");
 
@@ -17844,7 +17812,7 @@ ${mcpCtaCss()}
 
   <div class="context">
     <p>You can build and launch a complete SaaS product without spending a dollar on infrastructure. This guide gives you the <strong>opinionated "just tell me what to use" answer</strong> \u2014 the best free tier for each layer of a SaaS stack, with exact limits pulled from our index of ${offers.length.toLocaleString()}+ verified developer tools.</p>
-    <p>Every recommendation includes alternatives, "when you'll outgrow it" guidance, "why not X" callouts for popular-but-not-recommended options, and stability notes based on our tracking of ${dealChanges.length} real pricing changes. All limits verified April 2026.</p>
+    <p>Every recommendation includes alternatives, "when you'll outgrow it" guidance, "why not X" callouts for popular-but-not-recommended options, and stability notes based on our tracking of ${dealChanges.length} real pricing changes. ${stackFreshnessNote(pageReadings)}</p>
   </div>
 
   <div class="tldr-box">
@@ -17866,7 +17834,7 @@ ${mcpCtaCss()}
 
   <div class="cost-banner">
     <div class="cost-amount">$0<span style="font-size:1rem;color:var(--text-muted)">/month</span></div>
-    <div class="cost-label">Total infrastructure cost at launch (Stripe charges per-transaction only)</div>
+    <div class="cost-label">Total infrastructure cost at launch (Stripe charges per-transaction only)</div>${stackPickCostCaveat(pageReadings)}
     <div class="cost-scale">
       <div class="cost-scale-item"><div class="scale-users">1K users</div><div class="scale-cost" style="color:#d29922">~$40-80</div></div>
       <div class="cost-scale-item"><div class="scale-users">10K users</div><div class="scale-cost" style="color:#d29922">~$150-300</div></div>
@@ -46128,7 +46096,7 @@ const STACK_TEMPLATES: StackTemplate[] = [
   {
     slug: "saas-mvp",
     title: "Best Free Stack for a SaaS MVP — Ship for $0/Month in 2026",
-    metaDesc: "Build and launch a SaaS MVP on free tiers. Supabase, Vercel, Clerk, Sentry, Resend, GitHub Actions — verified limits, cost at scale, stability ratings. Updated April 2026.",
+    metaDesc: "Build and launch a SaaS MVP on free tiers. Supabase, Vercel, Clerk, Sentry, Resend, GitHub Actions — verified limits, cost at scale, stability ratings.",
     heroSubtitle: "Everything you need to build and launch a SaaS product without spending a dollar.",
     description: "The SaaS MVP stack prioritizes developer experience and speed-to-market. Every service here has a generous free tier that covers development through early traction. You can have a production-ready app with auth, database, email, monitoring, and CI/CD — all for $0/month until you have paying customers.",
     services: [
@@ -46156,7 +46124,7 @@ const STACK_TEMPLATES: StackTemplate[] = [
   {
     slug: "side-project",
     title: "Best Free Stack for a Side Project — Zero Cost, Zero Hassle in 2026",
-    metaDesc: "Build side projects on completely free tiers. Turso, Render, Firebase Auth, BetterStack, GitHub Actions — verified limits, cost at scale, stability ratings. Updated April 2026.",
+    metaDesc: "Build side projects on completely free tiers. Turso, Render, Firebase Auth, BetterStack, GitHub Actions — verified limits, cost at scale, stability ratings.",
     heroSubtitle: "Build your side project without worrying about costs. Every service here stays free for hobby use.",
     description: "Side projects need services that stay free forever — not free trials that expire. This stack uses genuinely free tiers with no credit card required. Optimized for solo developers who want to ship fast and keep costs at exactly $0 for as long as possible.",
     services: [
@@ -46184,7 +46152,7 @@ const STACK_TEMPLATES: StackTemplate[] = [
   {
     slug: "ai-startup",
     title: "Best Free Stack for an AI Startup — Build AI Products for $0/Month in 2026",
-    metaDesc: "Build AI products on free tiers. Neon, Railway, Supabase Auth, Grafana Cloud, Postmark, CircleCI — verified limits, cost at scale, stability ratings. Updated April 2026.",
+    metaDesc: "Build AI products on free tiers. Neon, Railway, Supabase Auth, Grafana Cloud, Postmark, CircleCI — verified limits, cost at scale, stability ratings.",
     heroSubtitle: "Infrastructure for AI startups that need fast iteration and reliable observability.",
     description: "AI startups burn through compute budgets fast — save infrastructure costs by using free tiers for everything except your model API. This stack pairs a serverless Postgres database (great for embeddings and vector search via pgvector) with Railway for flexible container hosting and Grafana Cloud for the observability you need when debugging model behavior.",
     services: [
@@ -46212,7 +46180,7 @@ const STACK_TEMPLATES: StackTemplate[] = [
   {
     slug: "open-source",
     title: "Best Free Stack for an Open-Source Project — CI, Hosting, and Community for $0 in 2026",
-    metaDesc: "Run open-source projects on free tiers. CockroachDB, Netlify, GitHub OAuth, BetterStack, GitHub Actions, Codecov — verified limits, cost at scale, stability ratings. Updated April 2026.",
+    metaDesc: "Run open-source projects on free tiers. CockroachDB, Netlify, GitHub OAuth, BetterStack, GitHub Actions, Codecov — verified limits, cost at scale, stability ratings.",
     heroSubtitle: "Free infrastructure for open-source maintainers. Focus on your code, not your cloud bill.",
     description: "Open-source projects get special treatment from most cloud providers — free tiers are more generous and often unlimited for public repos. This stack leverages those OSS advantages with services that have stable, long-standing free tiers and strong community support.",
     services: [
@@ -46239,7 +46207,7 @@ const STACK_TEMPLATES: StackTemplate[] = [
   {
     slug: "api-first",
     title: "Best Free Stack for an API-First Product — Build APIs for $0/Month in 2026",
-    metaDesc: "Build API products on free tiers. Neon, Cloudflare Workers, Auth0, New Relic, Mailgun, GitHub Actions — verified limits, cost at scale, stability ratings. Updated September 2026.",
+    metaDesc: "Build API products on free tiers. Neon, Cloudflare Workers, Auth0, New Relic, Mailgun, GitHub Actions — verified limits, cost at scale, stability ratings.",
     heroSubtitle: "Purpose-built for API products. Low latency, strong auth, and excellent observability.",
     description: "API-first products need low-latency hosting, robust authentication with API keys and OAuth, and deep observability into request patterns. This stack pairs Cloudflare Workers' edge compute with Auth0's enterprise-grade auth and New Relic's generous free APM — giving you production-ready API infrastructure at $0/month. Fly.io held this row until September 2026 and was replaced because it has had no free tier for new accounts since October 2024.",
     services: [
@@ -46273,7 +46241,19 @@ function buildStackTemplatePage(slug: string): string | null {
   const template = stackTemplateMap.get(slug);
   if (!template) return null;
 
-  const stabilityMap = getStabilityMap();
+  const templateReadings = new Map<string, StackPickReading>();
+  for (const s of template.services) {
+    const reading = stackReadingForSlug(s.slug);
+    if (reading) templateReadings.set(s.slug, reading);
+  }
+  const serviceVerdictHtml = (s: StackService) => {
+    const reading = templateReadings.get(s.slug);
+    return reading ? stackVerdictChipHtml(reading) : `<span style="color:var(--text-dim)">&mdash;</span>`;
+  };
+  const serviceLimitHtml = (s: StackService, cap: number) => {
+    const reading = templateReadings.get(s.slug);
+    return reading ? stackKeyLimitHtml(reading, cap) : escHtmlServer(s.freeTier);
+  };
 
   const totals = { free: 0, starter: 0, growth: 0, scale: 0 };
   for (const s of template.services) {
@@ -46284,9 +46264,6 @@ function buildStackTemplatePage(slug: string): string | null {
 
   const estimatorParams = template.services.map(s => `${encodeURIComponent(s.estimatorCategory)}=${encodeURIComponent(s.slug)}`).join("&");
 
-  const stabilityColors: Record<string, string> = { stable: "#3fb950", watch: "#d29922", volatile: "#f85149", improving: "#58a6ff" };
-  const stabilityLabels: Record<string, string> = { stable: "Stable", watch: "Watch", volatile: "Volatile", improving: "Improving" };
-
   const costClass = (amount: number) => amount === 0 ? "cost-free" : amount <= 25 ? "cost-low" : amount <= 100 ? "cost-mid" : "cost-high";
   const formatCost = (amount: number) => amount === 0 ? "$0" : `$${amount.toLocaleString()}`;
 
@@ -46296,13 +46273,10 @@ function buildStackTemplatePage(slug: string): string | null {
       : escHtmlServer(s.vendor);
 
   const tableRows = template.services.map(s => {
-    const stability = stabilityMap.get(s.slug) ?? "stable";
-    const sColor = stabilityColors[stability] ?? stabilityColors.stable;
-    const sLabel = stabilityLabels[stability] ?? "Stable";
     return `<tr>
       <td>${escHtmlServer(s.category)}</td>
-      <td class="vendor-name">${vendorLabel(s)}<span class="free-tier-info">${escHtmlServer(s.freeTier)}</span></td>
-      <td><span class="stability-dot" style="background:${sColor}" title="${sLabel}"></span> ${sLabel}</td>
+      <td class="vendor-name">${vendorLabel(s)}<span class="free-tier-info">${serviceLimitHtml(s, 90)}</span></td>
+      <td>${serviceVerdictHtml(s)}</td>
       <td class="cost-free">$0</td>
       <td class="${costClass(s.starter)}">${formatCost(s.starter)}</td>
       <td class="${costClass(s.growth)}">${formatCost(s.growth)}</td>
@@ -46311,25 +46285,24 @@ function buildStackTemplatePage(slug: string): string | null {
   }).join("\n");
 
   const whyCards = template.services.map(s => {
-    const stability = stabilityMap.get(s.slug) ?? "stable";
-    const sColor = stabilityColors[stability] ?? stabilityColors.stable;
-    const sLabel = stabilityLabels[stability] ?? "Stable";
+    const reading = templateReadings.get(s.slug);
     return `<div class="why-card">
       <div class="why-card-header">
         <strong>${escHtmlServer(s.category)}: ${vendorLabel(s)}</strong>
-        <span class="stability-badge" style="background:${sColor}20;color:${sColor};border:1px solid ${sColor}40">${sLabel}</span>
+        ${serviceVerdictHtml(s)}
       </div>
-      <p>${escHtmlServer(s.whyChosen)}</p>
-      <p class="why-free">${escHtmlServer(s.freeTier)}</p>
+      <p>${escHtmlServer(reading && !reading.recommendable ? reading.why : s.whyChosen)}</p>
+      <p class="why-free">${serviceLimitHtml(s, 150)}</p>
     </div>`;
   }).join("\n");
 
-  const swapsHtml = template.swaps.map(sw =>
-    `<div class="swap-card">
-      <strong>Swap ${escHtmlServer(sw.from)} for <a href="/vendor/${escHtmlServer(sw.toSlug)}">${escHtmlServer(sw.to)}</a></strong>
-      <p>${escHtmlServer(sw.saving)}</p>
-    </div>`
-  ).join("\n");
+  const swapsHtml = template.swaps.map(sw => {
+    const reading = stackReadingForSlug(sw.toSlug);
+    return `<div class="swap-card">
+      <strong>Swap ${escHtmlServer(sw.from)} for <a href="/vendor/${escHtmlServer(sw.toSlug)}">${escHtmlServer(sw.to)}</a></strong> ${reading ? stackVerdictChipHtml(reading) : ""}
+      <p>${escHtmlServer(reading && !reading.recommendable ? reading.why : sw.saving)}</p>
+    </div>`;
+  }).join("\n");
 
   const comparisonLinks = template.relatedComparisons.map(c => `<a href="${c.href}" class="related-link">${escHtmlServer(c.label)}</a>`).join("");
   const guideLinks = template.relatedGuides.map(g => `<a href="${g.href}" class="related-link">${escHtmlServer(g.label)}</a>`).join("");
@@ -46463,7 +46436,7 @@ function buildStackTemplatePage(slug: string): string | null {
       <div class="cost-tier"><span class="tier-label">Starter</span><span class="tier-amount ${costClass(totals.starter)}">${formatCost(totals.starter)}/mo</span><span class="tier-users">~1K MAU</span></div>
       <div class="cost-tier"><span class="tier-label">Growth</span><span class="tier-amount ${costClass(totals.growth)}">${formatCost(totals.growth)}/mo</span><span class="tier-users">~10K MAU</span></div>
       <div class="cost-tier"><span class="tier-label">Scale</span><span class="tier-amount ${costClass(totals.scale)}">${formatCost(totals.scale)}/mo</span><span class="tier-users">~100K MAU</span></div>
-    </div>
+    </div>${stackPickCostCaveat([...templateReadings.values()])}
 
     <a href="/estimate?${estimatorParams}" class="customize-cta">Customize in Cost Estimator &rarr;</a>
 
@@ -46505,7 +46478,7 @@ function buildStackTemplatePage(slug: string): string | null {
     ${buildMcpCta("Use <code>plan_stack</code> to get AI-powered stack recommendations tailored to your specific use case.")}
 
     <div class="footer">
-      <p>All pricing data verified from vendor pages as of April 2026. Stability ratings based on <a href="/stability">tracked pricing changes</a>.</p>
+      <p>${stackFreshnessNote([...templateReadings.values()])} Stability ratings based on <a href="/stability">tracked pricing changes</a>.</p>
       <p style="margin-top:.5rem"><a href="/stacks">All Stack Templates</a> &middot; <a href="/estimate">Cost Estimator</a> &middot; <a href="/guides">Guides</a> &middot; <a href="/privacy">Privacy</a></p>
     </div>
   </div>
@@ -46630,7 +46603,7 @@ function buildStacksIndexPage(): string {
     ${buildMcpCta("Use <code>plan_stack</code> to get AI-powered stack recommendations tailored to your specific use case.")}
 
     <div class="footer">
-      <p>All pricing data verified from vendor pages as of April 2026. Stability ratings based on <a href="/stability">tracked pricing changes</a>.</p>
+      <p>${stackFreshnessNote(stackPrimaryReadings(STACK_TEMPLATES.flatMap(t => t.services.map(s => ({ recommended: { vendor: s.vendor } })))))} Stability ratings based on <a href="/stability">tracked pricing changes</a>.</p>
       <p style="margin-top:.5rem"><a href="/">AgentDeals</a> &middot; <a href="/estimate">Cost Estimator</a> &middot; <a href="/guides">Guides</a> &middot; <a href="/privacy">Privacy</a></p>
     </div>
   </div>
@@ -50658,17 +50631,31 @@ function buildAgentStackPage(): string {
     author: { "@type": "Organization", name: "AgentDeals", url: BASE_URL },
   };
 
+  const pageReadings = stackPrimaryReadings(
+    resolvedBundles.flatMap(b => b.resolvedServices.map(s => ({ recommended: { vendor: s.vendorName } }))),
+  );
+
   const bundleHtml = resolvedBundles.map((bundle) => {
-    const serviceRows = bundle.resolvedServices.map((svc) => {
-      const limits = svc.description;
-      const shortLimits = publishedTermsOpening({ vendor: svc.vendorName, description: limits }, 1, 140);
+    const readings = bundle.resolvedServices.map((svc) => ({ svc, reading: stackPickReading(svc.vendorName) }));
+    const recommended = readings.filter(r => r.reading === null || r.reading.recommendable);
+    const ended = readings.flatMap(r => (r.reading !== null && !r.reading.recommendable) ? [r.reading] : []);
+
+    const serviceRows = recommended.map(({ svc, reading }) => {
+      const shortLimits = reading
+        ? stackKeyLimitHtml(reading, 140)
+        : escHtmlServer(publishedTermsOpening({ vendor: svc.vendorName, description: svc.description }, 1, 140));
+      const verdict = reading ? stackVerdictChipHtml(reading) : `<span style="color:var(--text-dim)">&mdash;</span>`;
       return `          <tr>
             <td class="role-cell">${escHtmlServer(svc.role)}</td>
             <td><a href="/vendor/${svc.slug}" class="vendor-link">${escHtmlServer(svc.vendorName)}</a> <span class="tier-badge">${escHtmlServer(svc.tier)}</span></td>
-            <td class="limits-cell">${escHtmlServer(shortLimits)}</td>
+            <td class="limits-cell">${shortLimits}</td>
+            <td class="verdict-cell">${verdict}</td>
             <td class="link-cell">${offerPricingLink(svc, "Pricing →")}</td>
           </tr>`;
     }).join("\n");
+
+    const bundleReadings = recommended.flatMap(r => r.reading ? [r.reading] : []);
+    const endedNote = ended.length === 0 ? "" : `\n        <p class="bundle-ended" style="font-size:.8rem;color:var(--text-muted);margin-top:.5rem">No longer a free-tier pick: ${ended.map(r => `<a href="/vendor/${r.slug}">${escHtmlServer(r.vendor)}</a> \u2014 ${escHtmlServer(r.verdict)}`).join("; ")}.</p>`;
 
     return `      <div class="stack-bundle" id="${bundle.id}">
         <div class="bundle-header">
@@ -50678,13 +50665,13 @@ function buildAgentStackPage(): string {
             <p class="bundle-desc">${escHtmlServer(bundle.description)}</p>
           </div>
         </div>
-        <div class="bundle-cost">Total: <strong>$0/month</strong></div>
+        <div class="bundle-cost">Total: <strong>$0/month</strong></div>${stackPickCostCaveat(bundleReadings)}
         <table>
-          <thead><tr><th>Role</th><th>Service</th><th>Free Tier</th><th></th></tr></thead>
+          <thead><tr><th>Role</th><th>Service</th><th>Free Tier</th><th>Our verdict</th><th></th></tr></thead>
           <tbody>
 ${serviceRows}
           </tbody>
-        </table>
+        </table>${endedNote}
       </div>`;
   }).join("\n\n");
 
@@ -50747,7 +50734,7 @@ ${globalNavCss()}
   ${buildGlobalNav("best")}
   <div class="breadcrumb"><a href="/">AgentDeals</a> &rsaquo; <a href="/best">Best Of</a> &rsaquo; Agent Stack Guide</div>
   <h1>AI Agent Builder\u2019s Free Stack Guide</h1>
-  <p class="page-intro">Curated free-tier infrastructure stacks for common AI agent patterns. Every service below has a real free tier \u2014 start building for $0/month.</p>
+  <p class="page-intro">Curated free-tier infrastructure stacks for common AI agent patterns. Each service carries the same verdict our own vendor page gives it. ${stackFreshnessNote(pageReadings)}</p>
 
 ${bundleHtml}
 

--- a/src/stack-claim.ts
+++ b/src/stack-claim.ts
@@ -1,0 +1,242 @@
+export type StackVerdictConfidence = 0 | 1 | 2 | 3;
+
+export interface PublishedPick {
+  vendor: string;
+  badgeVerdict: string;
+  pageVerdict: string;
+}
+
+export interface OverconfidentPick extends PublishedPick {
+  badgeConfidence: StackVerdictConfidence;
+  pageConfidence: StackVerdictConfidence;
+}
+
+export interface UnreadablePick extends PublishedPick {
+  side: "badge" | "page";
+}
+
+const ENDED_PHRASES = [
+  "free tier removed",
+  "offer ended",
+  "no longer free",
+  "deprecated",
+  "retired",
+  "shut down",
+  "sunset",
+];
+
+const WITHHELD_PHRASES = [
+  "unrated",
+  "unknown",
+  "not found",
+  "no source",
+  "withheld",
+  "unconfirmed",
+  "cannot confirm",
+  "risky",
+  "volatile",
+];
+
+const QUALIFIED_PHRASES = [
+  "at risk",
+  "stale",
+  "caution",
+  "watch",
+];
+
+const CONFIDENT_PHRASES = [
+  "active",
+  "stable",
+  "improving",
+  "free",
+];
+
+function normalise(text: string): string {
+  return text
+    .replace(/[—–‒]/g, "-")
+    .replace(/\s+/g, " ")
+    .trim()
+    .toLowerCase();
+}
+
+function holds(text: string, phrases: string[]): boolean {
+  return phrases.some(p => text.includes(p));
+}
+
+export function verdictConfidence(verdict: string): StackVerdictConfidence | null {
+  const text = normalise(verdict);
+  if (text === "") return null;
+  if (holds(text, ENDED_PHRASES)) return 0;
+  if (holds(text, WITHHELD_PHRASES)) return 1;
+  if (holds(text, QUALIFIED_PHRASES)) return 2;
+  if (holds(text, CONFIDENT_PHRASES)) return 3;
+  return null;
+}
+
+export function overconfidentPicks(picks: readonly PublishedPick[]): OverconfidentPick[] {
+  const over: OverconfidentPick[] = [];
+  for (const pick of picks) {
+    const badgeConfidence = verdictConfidence(pick.badgeVerdict);
+    const pageConfidence = verdictConfidence(pick.pageVerdict);
+    if (badgeConfidence === null || pageConfidence === null) continue;
+    if (pageConfidence > badgeConfidence) over.push({ ...pick, badgeConfidence, pageConfidence });
+  }
+  return over;
+}
+
+export function unreadablePicks(picks: readonly PublishedPick[]): UnreadablePick[] {
+  const unreadable: UnreadablePick[] = [];
+  for (const pick of picks) {
+    if (verdictConfidence(pick.badgeVerdict) === null) unreadable.push({ ...pick, side: "badge" });
+    else if (verdictConfidence(pick.pageVerdict) === null) unreadable.push({ ...pick, side: "page" });
+  }
+  return unreadable;
+}
+
+export interface PublishedVerdict {
+  slug: string;
+  verdict: string;
+}
+
+const VENDOR_LINK_OR_VERDICT = /href="\/vendor\/([a-z0-9][a-z0-9-]*)"|<span[^>]*class="[^"]*\bstack-verdict\b[^"]*"[^>]*>([^<]*)<\/span>|class="stability-dot"[^>]*><\/span>\s*(?:<span[^>]*>)?([A-Za-z][A-Za-z ]*)/g;
+
+export function verdictsPublishedOn(html: string): PublishedVerdict[] {
+  const published: PublishedVerdict[] = [];
+  const scan = new RegExp(VENDOR_LINK_OR_VERDICT.source, "g");
+  let subject: string | null = null;
+  let m: RegExpExecArray | null;
+  while ((m = scan.exec(html)) !== null) {
+    if (m[1] !== undefined) {
+      subject = m[1];
+      continue;
+    }
+    if (subject === null) continue;
+    const verdict = (m[2] ?? m[3] ?? "").replace(/&mdash;/g, "—").trim();
+    if (verdict !== "") published.push({ slug: subject, verdict });
+  }
+  return published;
+}
+
+export interface PublishedLimit {
+  slug: string;
+  limit: string;
+}
+
+const LIMIT_SCAN = /(<tr\b|<div class="stack-pick">|<div class="why-card">)|href="\/vendor\/([a-z0-9][a-z0-9-]*)"|<(?:td|p|span)[^>]*class="(?:pick-limits|limits-cell|why-free|free-tier-info)"[^>]*>([\s\S]*?)<\/(?:td|p|span)>|<td style="font-family:var\(--mono\);font-size:\.8rem;color:var\(--accent\)">([\s\S]*?)<\/td>/g;
+
+const CITATION_LINK = /<a\b[^>]*class="[^"]*\bstack-limit-source\b[^"]*"[^>]*>[\s\S]*?<\/a>/g;
+
+function textOf(html: string): string {
+  return html
+    .replace(CITATION_LINK, "")
+    .replace(/<[^>]*>/g, "")
+    .replace(/&amp;/g, "&").replace(/&lt;/g, "<").replace(/&gt;/g, ">")
+    .replace(/&quot;/g, '"').replace(/&#39;/g, "'").replace(/&mdash;/g, "—").replace(/&nbsp;/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+export function limitsPublishedOn(html: string): PublishedLimit[] {
+  const published: PublishedLimit[] = [];
+  const scan = new RegExp(LIMIT_SCAN.source, "g");
+  let subject: string | null = null;
+  let m: RegExpExecArray | null;
+  while ((m = scan.exec(html)) !== null) {
+    if (m[1] !== undefined) {
+      subject = null;
+      continue;
+    }
+    if (m[2] !== undefined) {
+      subject = m[2];
+      continue;
+    }
+    if (subject === null) continue;
+    const limit = textOf(m[3] ?? m[4] ?? "");
+    if (limit !== "") published.push({ slug: subject, limit });
+  }
+  return published;
+}
+
+const RECOMMENDATION_SLOT =/<tr\b[^>]*>[\s\S]*?<\/tr>|<a\b[^>]*class="[^"]*\balt-chip\b[^"]*"[^>]*>[\s\S]*?<\/a>|<div\b[^>]*class="[^"]*\bpick-header\b[^"]*"[^>]*>[\s\S]*?<\/div>/g;
+
+export function slotsMissingAVerdict(html: string): string[] {
+  const missing: string[] = [];
+  const scan = new RegExp(RECOMMENDATION_SLOT.source, "g");
+  let m: RegExpExecArray | null;
+  while ((m = scan.exec(html)) !== null) {
+    const slot = m[0];
+    const link = slot.match(/href="\/vendor\/([a-z0-9][a-z0-9-]*)"/);
+    if (!link) continue;
+    if (/class="[^"]*\bstack-verdict\b/.test(slot)) continue;
+    missing.push(link[1]);
+  }
+  return missing;
+}
+
+export type StackBadgeStatus =
+  | "active"
+  | "at-risk"
+  | "stale"
+  | "removed"
+  | "retired"
+  | "withheld"
+  | "unknown";
+
+export function freeTierHasEnded(status: StackBadgeStatus): boolean {
+  return status === "removed" || status === "retired";
+}
+
+export function mayRecommendAsFree(status: StackBadgeStatus): boolean {
+  return !freeTierHasEnded(status);
+}
+
+export function readsActive(status: StackBadgeStatus): boolean {
+  return status === "active";
+}
+
+export function proseWithoutNames(prose: string, names: readonly string[]): string {
+  if (names.length === 0) return prose;
+  return prose
+    .split(/(?<=[.!?])\s+/)
+    .filter(sentence => !names.some(name => sentence.includes(name)))
+    .join(" ");
+}
+
+export const NO_CURRENT_FIGURE = "No current figure";
+
+export function limitCellText(terms: string, cap: number): string {
+  const text = terms.replace(/\s+/g, " ").trim();
+  if (text.length <= cap) return text;
+  const clipped = text.slice(0, cap);
+  const lastSpace = clipped.lastIndexOf(" ");
+  const kept = lastSpace > cap / 2 ? clipped.slice(0, lastSpace) : clipped;
+  return `${kept.replace(/[,;:.]$/, "")}…`;
+}
+
+export function stackFreshnessStatement(verifiedDates: readonly string[]): string {
+  const dates = verifiedDates.filter(d => /^\d{4}-\d{2}-\d{2}$/.test(d)).slice().sort();
+  if (dates.length === 0) return "";
+  const oldest = dates[0];
+  const newest = dates[dates.length - 1];
+  const subject = dates.length === 1 ? "The limit on this page was" : "The limits on this page were";
+  return oldest === newest
+    ? `${subject} read from vendor pricing pages on ${newest}.`
+    : `${subject} read from vendor pricing pages between ${oldest} and ${newest}.`;
+}
+
+export interface CostHeadlinePick {
+  vendor: string;
+  verdict: string;
+  readsActive: boolean;
+}
+
+export function costHeadlineCaveat(picks: readonly CostHeadlinePick[]): string {
+  const total = picks.length;
+  if (total === 0) return "";
+  const unconfirmed = picks.filter(p => !p.readsActive);
+  if (unconfirmed.length === 0) return "";
+  const named = unconfirmed.map(p => `${p.vendor} (${p.verdict})`).join(", ");
+  const confirmed = total - unconfirmed.length;
+  const noun = total === 1 ? "pick" : "picks";
+  return `$0 covers the ${confirmed} of ${total} ${noun} whose free tier our own badge still reads as active. It does not cover ${named}.`;
+}

--- a/test/stack-page-verdicts.test.ts
+++ b/test/stack-page-verdicts.test.ts
@@ -1,0 +1,398 @@
+import { describe, it, before, after } from "node:test";
+import assert from "node:assert";
+import { spawn, type ChildProcess } from "node:child_process";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  costHeadlineCaveat,
+  limitCellText,
+  limitsPublishedOn,
+  mayRecommendAsFree,
+  NO_CURRENT_FIGURE,
+  overconfidentPicks,
+  proseWithoutNames,
+  slotsMissingAVerdict,
+  stackFreshnessStatement,
+  unreadablePicks,
+  verdictConfidence,
+  verdictsPublishedOn,
+  type PublishedPick,
+} from "../dist/stack-claim.js";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO = path.join(__dirname, "..");
+
+const STACK_PAGES = [
+  "/free-ai-stack",
+  "/free-devops-stack",
+  "/free-django-stack",
+  "/free-fastapi-stack",
+  "/free-frontend-stack",
+  "/free-go-stack",
+  "/free-nextjs-stack",
+  "/free-saas-stack",
+  "/free-startup-stack",
+  "/agent-stack",
+  "/stacks/ai-startup",
+  "/stacks/api-first",
+  "/stacks/open-source",
+  "/stacks/saas-mvp",
+  "/stacks/side-project",
+];
+
+let proc: ChildProcess | null = null;
+let port = 0;
+
+function startHttpServer(): Promise<{ child: ChildProcess; port: number }> {
+  return new Promise((resolve, reject) => {
+    const child = spawn("node", [path.join(REPO, "dist", "serve.js")], {
+      stdio: ["pipe", "pipe", "pipe"],
+      env: { ...process.env, PORT: "0", BASE_URL: "http://localhost" },
+    });
+    const timeout = setTimeout(() => { child.kill(); reject(new Error("Server startup timeout")); }, 30000);
+    child.stderr!.on("data", (data: Buffer) => {
+      const m = data.toString().match(/running on http:\/\/localhost:(\d+)/);
+      if (m) { clearTimeout(timeout); resolve({ child, port: parseInt(m[1], 10) }); }
+    });
+    child.on("error", (err) => { clearTimeout(timeout); reject(err); });
+  });
+}
+
+async function get(route: string): Promise<string> {
+  const res = await fetch(`http://localhost:${port}${route}`);
+  assert.strictEqual(res.status, 200, `${route} returned ${res.status}`);
+  return res.text();
+}
+
+const badges = new Map<string, string>();
+
+async function badgeVerdict(slug: string): Promise<string> {
+  const held = badges.get(slug);
+  if (held !== undefined) return held;
+  const svg = await get(`/badge/${slug}.svg`);
+  const texts = [...svg.matchAll(/<text[^>]*>(.*?)<\/text>/gs)].map(m => m[1].replace(/<[^>]+>/g, "").trim());
+  const verdict = texts.length > 0 ? texts[texts.length - 1] : "";
+  badges.set(slug, verdict);
+  return verdict;
+}
+
+interface StoredOffer {
+  description: string;
+  terms_superseded: { reading: { terms: string } | null } | null;
+}
+
+const records = new Map<string, StoredOffer | null>();
+
+async function offerRecord(slug: string): Promise<StoredOffer | null> {
+  const held = records.get(slug);
+  if (held !== undefined) return held;
+  const res = await fetch(`http://localhost:${port}/api/details/${slug}`);
+  const offer = res.status === 200 ? ((await res.json()) as { offer?: StoredOffer }).offer ?? null : null;
+  records.set(slug, offer);
+  return offer;
+}
+
+const pages = new Map<string, string>();
+
+before(async () => {
+  const started = await startHttpServer();
+  proc = started.child;
+  port = started.port;
+  for (const route of STACK_PAGES) pages.set(route, await get(route));
+});
+
+after(() => { proc?.kill(); });
+
+describe("stack pages do not out-claim the badge", () => {
+  it("publishes a verdict for every vendor a recommendation slot links", () => {
+    const missing: string[] = [];
+    for (const route of STACK_PAGES) {
+      for (const slug of slotsMissingAVerdict(pages.get(route)!)) missing.push(`${route} ${slug}`);
+    }
+    assert.deepStrictEqual(missing, [], `recommendation slots stating no verdict:\n${missing.join("\n")}`);
+  });
+
+  it("states no verdict stronger than the one the badge publishes", async () => {
+    const over: string[] = [];
+    const unparsed: string[] = [];
+    let compared = 0;
+    for (const route of STACK_PAGES) {
+      const picks: PublishedPick[] = [];
+      for (const { slug, verdict } of verdictsPublishedOn(pages.get(route)!)) {
+        picks.push({ vendor: slug, badgeVerdict: await badgeVerdict(slug), pageVerdict: verdict });
+      }
+      compared += picks.length;
+      for (const p of overconfidentPicks(picks)) {
+        over.push(`${route} ${p.vendor}: page "${p.pageVerdict}" over badge "${p.badgeVerdict}"`);
+      }
+      for (const p of unreadablePicks(picks)) {
+        unparsed.push(`${route} ${p.vendor}: unreadable ${p.side} verdict "${p.side === "badge" ? p.badgeVerdict : p.pageVerdict}"`);
+      }
+    }
+    assert.ok(compared >= 400, `only ${compared} published verdicts compared across ${STACK_PAGES.length} pages`);
+    assert.deepStrictEqual(unparsed, [], `verdicts neither side could be ranked from:\n${unparsed.join("\n")}`);
+    assert.deepStrictEqual(over, [], `pages stating a stronger verdict than the badge:\n${over.join("\n")}`);
+  });
+
+  it("recommends no vendor whose badge says the free tier has ended", async () => {
+    const recommended: string[] = [];
+    for (const route of STACK_PAGES) {
+      const html = pages.get(route)!;
+      for (const { slug, verdict } of verdictsPublishedOn(html)) {
+        if (verdictConfidence(verdict) !== 0) continue;
+        const inChip = new RegExp(`href="/vendor/${slug}"[^>]*class="[^"]*alt-chip`).test(html);
+        const badged = new RegExp(`<span class="pick-badge">Recommended</span>\\s*<a href="/vendor/${slug}"`).test(html);
+        if (inChip || badged) recommended.push(`${route} ${slug}: ${await badgeVerdict(slug)}`);
+      }
+    }
+    assert.deepStrictEqual(recommended, [], `ended offers still recommended:\n${recommended.join("\n")}`);
+  });
+
+  it("states no hard-coded freshness month", () => {
+    const hardcoded: string[] = [];
+    for (const route of STACK_PAGES) {
+      const found = pages.get(route)!.match(/(?:verified|updated)[^.<]{0,60}?(January|February|March|April|May|June|July|August|September|October|November|December)\s+20\d\d/gi);
+      if (found) hardcoded.push(`${route}: ${[...new Set(found)].join(" | ")}`);
+    }
+    assert.deepStrictEqual(hardcoded, [], `hard-coded freshness claims:\n${hardcoded.join("\n")}`);
+  });
+
+  it("dates its freshness statement from the picks it recommends", () => {
+    const undated: string[] = [];
+    for (const route of STACK_PAGES) {
+      if (!/read from vendor pricing pages (on|between) \d{4}-\d{2}-\d{2}/.test(pages.get(route)!)) undated.push(route);
+    }
+    assert.deepStrictEqual(undated, [], `pages with no derived freshness statement:\n${undated.join("\n")}`);
+  });
+
+  it("keeps the withholding notice out of the limit column", () => {
+    const misplaced: string[] = [];
+    for (const route of STACK_PAGES) {
+      const html = pages.get(route)!;
+      for (const cell of html.match(/<td[^>]*color:var\(--accent\)[^>]*>([^<]*)</g) ?? []) {
+        if (/terms are superseded and withheld|names them as the previous ones/.test(cell)) misplaced.push(`${route}: ${cell}`);
+      }
+      for (const cell of html.match(/class="(pick-limits|limits-cell)"[^>]*>([^<]*)</g) ?? []) {
+        if (/terms are superseded and withheld|names them as the previous ones/.test(cell)) misplaced.push(`${route}: ${cell}`);
+      }
+    }
+    assert.deepStrictEqual(misplaced, [], `withholding notices in a limit slot:\n${misplaced.join("\n")}`);
+  });
+
+  it("states a limit our own record still stands behind", async () => {
+    const wrong: string[] = [];
+    let checked = 0;
+    for (const route of STACK_PAGES) {
+      for (const { slug, limit } of limitsPublishedOn(pages.get(route)!)) {
+        const offer = await offerRecord(slug);
+        if (!offer) continue;
+        const superseded = offer.terms_superseded;
+        const source = superseded ? (superseded.reading?.terms ?? null) : offer.description;
+        checked += 1;
+        if (source === null) {
+          if (limit !== NO_CURRENT_FIGURE) wrong.push(`${route} ${slug}: states "${limit}" where our record holds no readable figure`);
+          continue;
+        }
+        const whole = source.replace(/\s+/g, " ").trim();
+        if (limit === whole) continue;
+        if (!limit.endsWith("\u2026")) {
+          wrong.push(`${route} ${slug}: states "${limit}" as a finished claim, but our record reads "${whole.slice(0, 90)}"`);
+          continue;
+        }
+        if (!whole.startsWith(limit.slice(0, -1))) {
+          wrong.push(`${route} ${slug}: states "${limit}", which does not open our record "${whole.slice(0, 90)}"`);
+        }
+      }
+    }
+    assert.ok(checked >= 100, `only ${checked} limit slots checked against a record`);
+    assert.deepStrictEqual(wrong, [], `limit slots our record does not support:\n${wrong.join("\n")}`);
+  });
+
+  it("cites the reading behind a limit our stored terms no longer supply", async () => {
+    const uncited: string[] = [];
+    let cited = 0;
+    for (const route of STACK_PAGES) {
+      const html = pages.get(route)!;
+      let fromAReading = 0;
+      for (const { slug } of limitsPublishedOn(html)) {
+        const offer = await offerRecord(slug);
+        if (offer?.terms_superseded?.reading) fromAReading += 1;
+      }
+      const citations = (html.match(/class="stack-limit-source"/g) ?? []).length;
+      cited += citations;
+      if (citations !== fromAReading) uncited.push(`${route}: ${fromAReading} limits read from a change record, ${citations} of them cited`);
+    }
+    assert.ok(cited > 0, "no limit on any stack page is served from a change record, so nothing was checked");
+    assert.deepStrictEqual(uncited, [], `limits published without the reading behind them:\n${uncited.join("\n")}`);
+  });
+
+  it("keeps a dropped pick out of the prose that recommended it", () => {
+    const offending: string[] = [];
+    for (const route of STACK_PAGES) {
+      const html = pages.get(route)!;
+      const dropped = [...html.matchAll(/class="alt-ended"[^>]*>No longer a free-tier pick: ([\s\S]*?)<\/p>/g)]
+        .flatMap(m => [...m[1].matchAll(/<a href="\/vendor\/[a-z0-9-]+">([^<]+)<\/a>/g)].map(a => a[1]));
+      if (dropped.length === 0) continue;
+      for (const box of html.match(/<div class="(?:outgrow-box|whynot-box)">[\s\S]*?<\/div>/g) ?? []) {
+        for (const name of dropped) if (box.includes(name)) offending.push(`${route}: ${name}`);
+      }
+    }
+    assert.deepStrictEqual(offending, [], `prose still selling a dropped pick:\n${offending.join("\n")}`);
+  });
+
+  it("qualifies a $0 headline it cannot stand behind", async () => {
+    const unqualified: string[] = [];
+    for (const route of STACK_PAGES) {
+      const html = pages.get(route)!;
+      if (!/\$0<span[^>]*>\/month|tier-amount cost-free">\$0\/mo|Total: <strong>\$0\/month/.test(html)) continue;
+      const weak: string[] = [];
+      for (const { slug, verdict } of verdictsPublishedOn(html)) {
+        if (verdictConfidence(verdict) !== 3) weak.push(slug);
+      }
+      if (weak.length > 0 && !html.includes("class=\"cost-caveat\"")) unqualified.push(`${route}: ${[...new Set(weak)].join(", ")}`);
+    }
+    assert.deepStrictEqual(unqualified, [], `unqualified $0 headlines:\n${unqualified.join("\n")}`);
+  });
+});
+
+describe("the verdict comparison itself", () => {
+  it("fails a recommendation whose badge reads free tier removed", () => {
+    const over = overconfidentPicks([
+      { vendor: "logrocket", badgeVerdict: "free tier removed · Aug 2026", pageVerdict: "Free Forever" },
+    ]);
+    assert.strictEqual(over.length, 1);
+    assert.strictEqual(over[0].badgeConfidence, 0);
+    assert.strictEqual(over[0].pageConfidence, 3);
+  });
+
+  it("passes a recommendation that repeats the badge", () => {
+    assert.deepStrictEqual(overconfidentPicks([
+      { vendor: "railway", badgeVerdict: "at risk · Aug 2026", pageVerdict: "at risk" },
+      { vendor: "neon", badgeVerdict: "active · Sep 2026", pageVerdict: "active" },
+      { vendor: "stripe", badgeVerdict: "unrated — not a free offer", pageVerdict: "unrated — not a free offer" },
+    ]), []);
+  });
+
+  it("reports a verdict neither side can be ranked from", () => {
+    const unreadable = unreadablePicks([
+      { vendor: "neon", badgeVerdict: "active", pageVerdict: "active" },
+      { vendor: "turso", badgeVerdict: "active", pageVerdict: "5 GB" },
+      { vendor: "orama", badgeVerdict: "???", pageVerdict: "active" },
+    ]);
+    assert.deepStrictEqual(unreadable.map(u => [u.vendor, u.side]), [["turso", "page"], ["orama", "badge"]]);
+  });
+
+  it("passes a page more cautious than the badge", () => {
+    assert.deepStrictEqual(overconfidentPicks([
+      { vendor: "neon", badgeVerdict: "active · Sep 2026", pageVerdict: "at risk" },
+    ]), []);
+  });
+
+  it("ranks the vocabulary both surfaces publish", () => {
+    assert.strictEqual(verdictConfidence("active · Sep 2026"), 3);
+    assert.strictEqual(verdictConfidence("Stable"), 3);
+    assert.strictEqual(verdictConfidence("at risk · Aug 2026"), 2);
+    assert.strictEqual(verdictConfidence("Watch"), 2);
+    assert.strictEqual(verdictConfidence("unrated — page unreadable"), 1);
+    assert.strictEqual(verdictConfidence("Volatile"), 1);
+    assert.strictEqual(verdictConfidence("free tier removed · Aug 2026"), 0);
+    assert.strictEqual(verdictConfidence("retired"), 0);
+    assert.strictEqual(verdictConfidence(""), null);
+  });
+
+  it("reads a verdict as belonging to the vendor last linked before it", () => {
+    const html =
+      `<a href="/vendor/vercel" class="alt-chip">Vercel <span class="stack-verdict">active</span></a>` +
+      `<a href="/vendor/railway" class="alt-chip">Railway <span class="stack-verdict">at risk</span></a>`;
+    assert.deepStrictEqual(verdictsPublishedOn(html), [
+      { slug: "vercel", verdict: "active" },
+      { slug: "railway", verdict: "at risk" },
+    ]);
+  });
+
+  it("reads the older stability cell as a verdict too", () => {
+    const html = `<td><a href="/vendor/github-actions">GitHub Actions</a></td><td><span class="stability-dot" style="background:#3fb950" title="Stable"></span> Stable</td>`;
+    assert.deepStrictEqual(verdictsPublishedOn(html), [{ slug: "github-actions", verdict: "Stable" }]);
+  });
+
+  it("names a recommendation slot that states no verdict", () => {
+    const row = `<tr><td><a href="/vendor/turso">Turso</a></td><td>5 GB</td></tr>`;
+    assert.deepStrictEqual(slotsMissingAVerdict(row), ["turso"]);
+    assert.deepStrictEqual(slotsMissingAVerdict(row.replace("5 GB", `<span class="stack-verdict">active</span>`)), []);
+  });
+
+  it("refuses to recommend a removed or retired offer as free", () => {
+    assert.strictEqual(mayRecommendAsFree("removed"), false);
+    assert.strictEqual(mayRecommendAsFree("retired"), false);
+    assert.strictEqual(mayRecommendAsFree("at-risk"), true);
+    assert.strictEqual(mayRecommendAsFree("withheld"), true);
+  });
+});
+
+describe("prose that names a pick we have dropped", () => {
+  it("drops the sentence rather than the whole paragraph", () => {
+    const prose = "Highlight.io offers 500 sessions bundled. LogRocket gives 1K sessions/month. Sentry is the default.";
+    assert.strictEqual(
+      proseWithoutNames(prose, ["LogRocket"]),
+      "Highlight.io offers 500 sessions bundled. Sentry is the default.",
+    );
+  });
+
+  it("leaves prose naming nothing we dropped alone", () => {
+    const prose = "Highlight.io offers 500 sessions bundled. Sentry is the default.";
+    assert.strictEqual(proseWithoutNames(prose, []), prose);
+    assert.strictEqual(proseWithoutNames(prose, ["LogRocket"]), prose);
+  });
+});
+
+describe("the derived freshness statement", () => {
+  it("spans the oldest and newest reading", () => {
+    assert.strictEqual(
+      stackFreshnessStatement(["2026-09-04", "2026-07-24", "2026-08-11"]),
+      "The limits on this page were read from vendor pricing pages between 2026-07-24 and 2026-09-04.",
+    );
+  });
+
+  it("states one date when every reading shares it", () => {
+    assert.strictEqual(
+      stackFreshnessStatement(["2026-09-04", "2026-09-04"]),
+      "The limits on this page were read from vendor pricing pages on 2026-09-04.",
+    );
+  });
+
+  it("says nothing when it holds no reading", () => {
+    assert.strictEqual(stackFreshnessStatement([]), "");
+    assert.strictEqual(stackFreshnessStatement(["not a date"]), "");
+  });
+});
+
+describe("the $0 caveat", () => {
+  it("names every pick the headline does not cover", () => {
+    assert.strictEqual(
+      costHeadlineCaveat([
+        { vendor: "Neon", verdict: "active", readsActive: true },
+        { vendor: "Railway", verdict: "at risk", readsActive: false },
+        { vendor: "Stripe", verdict: "unrated — not a free offer", readsActive: false },
+      ]),
+      "$0 covers the 1 of 3 picks whose free tier our own badge still reads as active. " +
+      "It does not cover Railway (at risk), Stripe (unrated — not a free offer).",
+    );
+  });
+
+  it("says nothing when every pick reads active", () => {
+    assert.strictEqual(costHeadlineCaveat([{ vendor: "Neon", verdict: "active", readsActive: true }]), "");
+  });
+});
+
+describe("the limit cell", () => {
+  it("never truncates into a sentence that reads complete", () => {
+    const railway = "Free $0 per month. Start with a 30-day free trial with $5 credits, then $1 per month.";
+    const cell = limitCellText(railway, 60);
+    assert.ok(cell.endsWith("…"), `truncated cell reads as a finished claim: ${cell}`);
+    assert.ok(!/^Free \$0 per month\.$/.test(cell));
+  });
+
+  it("passes terms through whole when they fit", () => {
+    assert.strictEqual(limitCellText("10 GB storage, zero egress", 60), "10 GB storage, zero egress");
+  });
+});

--- a/test/stack-template-free-tiers.test.ts
+++ b/test/stack-template-free-tiers.test.ts
@@ -6,6 +6,7 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { classifyTier } from "../dist/ranking.js";
 import { toSlug } from "../dist/vendor-slug.js";
+import { limitsPublishedOn } from "../dist/stack-claim.js";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const root = path.join(__dirname, "..");
@@ -59,9 +60,9 @@ describe("a stack that totals $0 names no vendor our catalogue says is paid (#11
     for (const stack of stackPaths) {
       const html = await (await fetch(`${base}${stack}`)).text();
       for (const m of html.matchAll(
-        /<td class="vendor-name">(?:<a href="\/vendor\/([a-z0-9.-]+)">)?([^<]+)(?:<\/a>)?<span class="free-tier-info">([^<]*)<\/span>/g,
+        /<td class="vendor-name">(?:<a href="\/vendor\/([a-z0-9.-]+)">)?([^<]+)(?:<\/a>)?<span class="free-tier-info">([\s\S]*?)<\/span><\/td>/g,
       )) {
-        rows.push({ stack, vendor: m[2], slug: m[1] ?? toSlug(m[2]), freeTier: m[3] });
+        rows.push({ stack, vendor: m[2], slug: m[1] ?? toSlug(m[2]), freeTier: limitsPublishedOn(`<tr><a href="/vendor/x"></a><span class="free-tier-info">${m[3]}</span></tr>`)[0]?.limit ?? "" });
       }
     }
 


### PR DESCRIPTION
Refs #1400

The 15 stack pages are the ones models cite, and none of them had ever stated a verdict about a vendor it recommends. **412 recommendation slots stated no verdict at all**; the 30 that did came from a map keyed by vendor name and queried by slug, so `github-actions` and `grafana-cloud` missed the lookup and read **`Stable` beside a badge reading `at risk`** on all five `/stacks/*` pages.

## The choke point

`stackPickReading(slug)` resolves the vendor from **the slug the page links**, builds the same `vendorVerdictContext` the badge builds, and returns the badge's own label plus the vendor page's own sentence. Every recommendation slot on all 15 pages renders from it — the nine `free-*-stack` pick cards, also-consider chips and overview tables; `/agent-stack`'s bundle rows; `/stacks/*`'s table, why-cards and swap cards.

Keying on the slug rather than the name matters: `/stacks/ai-startup` names its auth pick "Supabase Auth" and links `/vendor/supabase`. Reading the verdict from the name returns nothing; reading it from the link returns what the reader will see if they follow it.

## Populations, measured on both builds

| | main | branch |
|---|---|---|
| verdicts published across the 15 pages | 30 | **454** |
| recommendation slots stating no verdict | 412 | **0** |
| slots more confident than the badge | 5 | **0** |
| withholding notices in a limit slot | 49 | **0** |
| hard-coded "verified/updated \<month\> \<year\>" | 56 | **0** |
| pages dating their freshness from their own picks | 0 of 15 | **15 of 15** |
| `$0` headlines carrying a derived caveat | 0 | 18 |
| vendors linked (not active / ended) | 122 (52 / 1) | 124 (54 / 1) |

## Against each criterion

**AC-1.** LogRocket is out of `/free-frontend-stack`'s "Also consider" and into a `No longer a free-tier pick: LogRocket — free tier removed.` line. The filter is on the badge status, not on a name, so it self-heals. The category's hand-written outgrow prose also said *"LogRocket gives 1K sessions/month with full session replay"* — a sentence naming a dropped pick is now removed rather than left selling it.

**AC-2.** Each recommendation carries the badge's own words, coloured by the badge's own status, with the vendor page's verdict sentence in the title. The page cannot be more confident than `/vendor/<slug>` because it is reading the same function.

**AC-3.** The Key Limit column states the terms our change record read, clipped and **cited with the date it was read** (`read 2026-09-03` → `/vendor/<slug>#changes`). Where the superseding change has no readable reading the cell says we have no current figure and puts the explanation in the title, not in the limit slot.

Worth naming: routing Railway's cell through `openingOfTerms` truncated it at a sentence boundary to **`"Free $0 per month."`** — exactly the claim the record corrects. Truncation now always marks itself with an ellipsis, so a clipped cell can never read as a finished claim.

**AC-4.** `$0` is qualified by the picks it does not cover, derived from the badges: on `/free-saas-stack`, *"$0 covers the 7 of 10 picks whose free tier our own badge still reads as active. It does not cover Railway (at risk), Stripe (unrated — not a free offer), GitHub Actions (at risk)."* Stripe's card previously rendered a hard-coded green `stable` chip; it now reads what `/badge/stripe.svg` reads. Django Built-in Auth, FastAPI Built-in, Go Goroutines and swaggo/swag did the same — we hold no record for the first three, so they now state no verdict rather than a fabricated one.

**AC-5.** Nine body literals and fourteen meta-description literals are replaced by a statement derived from the `verifiedDate` of the picks the page recommends. `/free-saas-stack` now reads *"The limits on this page were read from vendor pricing pages between 2026-07-24 and 2026-09-04"* — the min and max the issue predicted. `/stacks/api-first` was claiming "Updated September 2026" against an April page; `test/page-freshness.test.ts` caught that as soon as the page entered the register.

**AC-6.** `test/stack-page-verdicts.test.ts` fetches all 15 pages and every `/badge/<slug>.svg`, attributes each published verdict to the vendor last linked before it, and ranks both sides on one scale. It asserts 0 overconfident and 0 slots without a verdict, over ≥400 compared pairs. Both halves fail on main (5 and 412). The ranking comparison is unit-tested against the fixture the criterion names — a badge reading `free tier removed` beside a page reading `Free Forever`.

The limit cells get their own oracle: for each one, `/api/details/<slug>` is asked what our record holds, and the cell must be that text whole, or an opening of it ending in an ellipsis, or the no-figure marker.

**AC-7.** All 15 are in `data/page-reviews.json` as **tier A reading the catalogue**, on the 30-day SLA. Rather than hand-writing the tier, `stack-verdict` joins the classes `deriveTier` recognises, the five `/stacks/*` routes join `EDITORIAL_PAGES`, and the register is regenerated. Unsourced tier-A pages stay at the budget of 41 — the `/stacks/*` pages now genuinely read the catalogue because their free-tier cells state the record. `routeFirstServed` falls back to the last path segment, so those five date from April 2026 rather than today.

## Verification

- **Route sweep**, 2,572 sitemap paths plus 31 non-sitemap routes, main build vs branch: **16 moved, 0 status changes, 0 shrank**. The moved set is exactly the 15 pages plus `/stacks`. `/this-week` reads as moved until `BASE_URL` and its percent-encoded form are normalised, then it is byte-identical.
- **4,038 tests, 28 new.** `test/stack-template-free-tiers.test.ts` parsed its rows with `[^<]*` and silently dropped to 19 of 30 once a limit cell carried a citation; its extractor now shares the one this PR added.
- **31 mutations, 29 killed.** The two survivors are latent rather than covered: no vendor recommended on these pages has superseded terms whose change carries no readable reading (so `stackKeyLimit`'s null branch never fires today), and no `/agent-stack` service currently reads ended (so filtering it is a no-op). Reported as such rather than dressed up. The first mutation round left 6 survivors and 4 of them were real gaps — the also-consider filter, the stored-terms fallback, the sentence-boundary truncation and the unranked-verdict report all had no assertion behind them.

## Left for the PM

- **`/stacks/*` rows still carry a hand-written `freeTier` string in the estimator and swap copy.** The visible cell now states the record, but `s.freeTier` is still the fallback and still the source for `/estimate`. That is #1374's population, not this one.
- **`scripts/check-mutation-targets.mjs` still checks nothing for the `sub`-based mutation scripts** — now 34 of 90, including this one — and prints a line that reads as a pass. Reported on #1380; unchanged.
