### PR TITLE
Retire the Ninja Outreach record — origin unreachable, cited source rebranded away

### DIFF
--- a/data/index.json
+++ b/data/index.json
@@ -29122,8 +29122,8 @@
     {
       "vendor": "Ninja Outreach",
       "category": "Logging",
-      "description": "20% discount on Blogger plan for lifetime. Access via: Free",
-      "tier": "Startup Program",
+      "description": "There is no free tier: ninjaoutreach.com no longer serves the product. Checked 2026-09-06, the domain resolves to Cloudflare and returned 522 on three consecutive requests, so the origin is unreachable; the Internet Archive's most recent capture of the site is 2025-09-10. The cited source, userlike.com/en/blog/startup-deals, now redirects to connect.lime-technologies.com/en/blog/ after Userlike's rebrand to Lime Technologies, and the destination does not name Ninja Outreach. The former offer was a 20% lifetime discount on the Blogger plan, which was a discount and not a free tier.",
+      "tier": "Retired",
       "url": "https://www.userlike.com/en/blog/startup-deals",
       "tags": [
         "developer-tools",
@@ -29139,9 +29139,9 @@
         "program": "Ninja Outreach Startup Deal"
       },
       "source_check": {
-        "checked": "2026-09-02",
+        "checked": "2026-09-06",
         "outcome": "does_not_name_vendor",
-        "detail": "the page never names Ninja Outreach and is not served from its domain"
+        "detail": "the cited page redirects to connect.lime-technologies.com/en/blog/ and never names Ninja Outreach; it is not served from the vendor's domain"
       }
     },
     {


### PR DESCRIPTION
Held out of #1244 until https://github.com/robhunter/agentdeals/issues/1380 shipped, because retiring an offer removed the only citation its vendor page had. That landed in #1399 and PR #1377 merged, so this is unblocked.

**The vendor.** `ninjaoutreach.com` resolves to Cloudflare and returned 522 on three consecutive requests on 2026-09-06 — origin unreachable, not a block on our client. The Internet Archive's most recent successful capture of the site is 2025-09-10, a year old.

**The source.** The record cited `userlike.com/en/blog/startup-deals`. That URL now redirects to `connect.lime-technologies.com/en/blog/` following Userlike's rebrand to Lime Technologies, and the destination is a blog index containing zero mentions of Ninja Outreach. `source_check` already read `does_not_name_vendor`; the detail now records the redirect.

**The offer.** A 20% lifetime discount on the Blogger plan — a discount, not a free tier.

Data only, one record. `tier` → `Retired`, description rewritten in the form the other 15 retired records use, `source_check.checked` moved to 2026-09-06.

Verified before pushing:
- Quality budgets unmoved — all seven measured values identical before and after.
- Ranked set unchanged at 811 offers; nothing entered or left it, and `/category/logging` still ranks 8. The record was already gated, and now gates as `offer_retired` with `risk_level: null`.
- `tier-vocabulary`, `eligibility-vocabulary`, `free-tier-removal-evidence` and `free-tier-claim-agrees-with-the-record` pass locally (28 assertions). The server-spinning suites time out at 30s in my environment; CI covers them.

The record's `category` is `Logging`, which is wrong for an influencer-outreach product. I left it alone rather than move a retired record between category pages in the same change.