### PR TITLE
Count only free tiers the site can vouch for on the report and every category lede

### DIFF
--- a/scripts/mutate-1407.mjs
+++ b/scripts/mutate-1407.mjs
@@ -1,0 +1,104 @@
+import { readFileSync, writeFileSync } from "node:fs";
+import { execFileSync } from "node:child_process";
+
+const SUITE = [
+  "test/free-tier-vouched-share.test.ts",
+  "test/category-gate-lede.test.ts",
+];
+
+const MUTANTS = [
+  ["tier-rule-drops-the-classifier", "src/free-tier-record.ts",
+    `  if (classifyTier(tier).class !== "free") return false;`,
+    `  if (false) return false;`],
+  ["tier-rule-drops-the-labels", "src/free-tier-record.ts",
+    `  return label.includes("free") || RECORDED_FREE_TIER_LABELS.has(label);`,
+    `  return label.includes("free");`],
+  ["tier-rule-accepts-anything", "src/free-tier-record.ts",
+    `  return label.includes("free") || RECORDED_FREE_TIER_LABELS.has(label);`,
+    `  return true;`],
+  ["census-counts-an-ended-free-tier", "src/serve.ts",
+    `    if (claim?.states === "ended") {
+      census.ended++;
+      continue;
+    }`,
+    `    if (claim?.states === "ended") {
+      census.ended++;
+    }`],
+  ["census-vouches-for-the-unconfirmed", "src/serve.ts",
+    `    if (claim?.states === "offered") census.vouched++;
+    else census.unconfirmed++;`,
+    `    census.vouched++;`],
+  ["census-never-reports-an-ending", "src/serve.ts",
+    `      census.ended++;`,
+    `      census.ended += 0;`],
+  ["claim-is-never-read", "src/serve.ts",
+    `  const context = vendorVerdictContext(vendorName, servedOn);
+  return context ? freeTierClaim(context.input) : null;`,
+    `  return null;`],
+  ["category-keeps-the-ended-record", "src/serve.ts",
+    `  const catStanding = catOffers.filter((o) => !catEnded.includes(o));`,
+    `  const catStanding = catOffers;`],
+  ["category-finds-no-ending", "src/serve.ts",
+    `  return population.filter(o => freeTierClaimFor(o.vendor, servedOn)?.states === "ended");`,
+    `  return population.filter(o => freeTierClaimFor(o.vendor, servedOn)?.states === "offered" && false);`],
+  ["intro-counts-the-ended-record", "src/serve.ts",
+    `    <p>We track <strong>${"$"}{catStandingCount}</strong> ${"$"}{categoryName.toLowerCase()} services with free tiers.`,
+    `    <p>We track <strong>${"$"}{catCount}</strong> ${"$"}{categoryName.toLowerCase()} services with free tiers.`],
+  ["snippet-counts-the-ended-record", "src/serve.ts",
+    `  const metaDesc = \`Compare ${"$"}{catStandingCount} free`,
+    `  const metaDesc = \`Compare ${"$"}{catCount} free`],
+  ["lede-says-nothing-about-an-ending", "src/eligibility.ts",
+    `  if (ended <= 0) return "";`,
+    `  return "";`],
+  ["lede-loses-the-plural", "src/eligibility.ts",
+    `  return \` We also track ${"$"}{ended} whose free tiers have ended.\`;`,
+    `  return " We also track one whose free tier has ended.";`],
+  ["lede-drops-the-clause-when-gated", "src/eligibility.ts",
+    `  return \`${"$"}{counted}. ${"$"}{gateDisclosureSentence("them", total, codes)}${"$"}{alsoEnded}\`;`,
+    `  return \`${"$"}{counted}. ${"$"}{gateDisclosureSentence("them", total, codes)}\`;`],
+  ["report-leads-with-the-recorded-share", "src/serve.ts",
+    `    <li><strong>${"$"}{vouchedPct}% of tracked services offer a free tier we can vouch for today</strong>`,
+    `    <li><strong>${"$"}{recordedPct}% of tracked services offer a free tier we can vouch for today</strong>`],
+  ["landscape-ranks-by-the-recorded-share", "src/serve.ts",
+    `    b.vouchedPct - a.vouchedPct
+    || b.census.vouched - a.census.vouched
+    || b.census.total - a.census.total`,
+    `    b.recordedPct - a.recordedPct
+    || b.census.total - a.census.total`],
+  ["landscape-drops-the-vouched-share", "src/serve.ts",
+    `      <td style="text-align:right;color:var(--text);font-weight:600">${"$"}{c.vouchedPct}%</td>`,
+    `      <td style="text-align:right;color:var(--text);font-weight:600">${"$"}{c.recordedPct}%</td>`],
+  ["cards-keep-the-ended-vendor", "src/serve.ts",
+    `      if (freeTierClaimFor(canonical, reportServedOn)?.states === "ended") {`,
+    `      if (freeTierClaimFor(canonical, reportServedOn) === null) {`],
+  ["cards-stop-resolving-the-slug", "src/serve.ts",
+    `      const slug = resolution.type === "exact" || resolution.type === "redirect" ? resolution.slug : null;`,
+    `      const slug = toSlug(name);`],
+];
+
+function run(cmd, args) {
+  try {
+    execFileSync(cmd, args, { stdio: "pipe", encoding: "utf-8" });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+const survivors = [];
+for (const [name, file, from, to] of MUTANTS) {
+  const original = readFileSync(file, "utf-8");
+  if (!original.includes(from)) {
+    console.log(`SKIP  ${name} — the line it mutates is not in ${file}`);
+    continue;
+  }
+  writeFileSync(file, original.replace(from, to));
+  const built = run("npm", ["run", "build"]);
+  const green = built && run("node", ["--test", "--test-concurrency", "1", ...SUITE]);
+  writeFileSync(file, original);
+  console.log(`${green ? "SURVIVED" : built ? "killed  " : "killed (did not compile)"}  ${name}`);
+  if (green) survivors.push(name);
+}
+run("npm", ["run", "build"]);
+console.log(`\n${MUTANTS.length - survivors.length}/${MUTANTS.length} killed`);
+if (survivors.length > 0) console.log("survivors:", survivors.join(", "));

--- a/src/eligibility.ts
+++ b/src/eligibility.ts
@@ -22,14 +22,21 @@ function eligibilityAccountsForEveryOffer(codes: GateCode[], total: number): boo
   return codes.length >= total && codes.every((code) => code === "eligibility_restricted");
 }
 
-export function gatedShareLede(total: number, gates: (Gate | null)[]): string {
+export function endedFreeTierClause(ended: number): string {
+  if (ended <= 0) return "";
+  if (ended === 1) return " We also track one whose free tier has ended.";
+  return ` We also track ${ended} whose free tiers have ended.`;
+}
+
+export function gatedShareLede(total: number, gates: (Gate | null)[], ended = 0): string {
   const counted = `${total} verified free tiers and developer deals`;
   const codes = gatedCodes(gates);
-  if (codes.length === 0) return `${counted}.`;
+  const alsoEnded = endedFreeTierClause(ended);
+  if (codes.length === 0) return `${counted}.${alsoEnded}`;
   if (eligibilityAccountsForEveryOffer(codes, total)) {
-    return `${counted}, none of them generally available — each requires an application or qualification.`;
+    return `${counted}, none of them generally available — each requires an application or qualification.${alsoEnded}`;
   }
-  return `${counted}. ${gateDisclosureSentence("them", total, codes)}`;
+  return `${counted}. ${gateDisclosureSentence("them", total, codes)}${alsoEnded}`;
 }
 
 export function gatedShareDescriptionClause(total: number, gates: (Gate | null)[]): string {

--- a/src/free-tier-record.ts
+++ b/src/free-tier-record.ts
@@ -1,0 +1,16 @@
+import { classifyTier } from "./ranking.js";
+
+export const RECORDED_FREE_TIER_LABELS = new Set([
+  "hobby",
+  "starter",
+  "personal",
+  "developer",
+  "community",
+  "open source",
+]);
+
+export function tierRecordsAFreeTier(tier: string): boolean {
+  if (classifyTier(tier).class !== "free") return false;
+  const label = tier.toLowerCase();
+  return label.includes("free") || RECORDED_FREE_TIER_LABELS.has(label);
+}

--- a/src/serve.ts
+++ b/src/serve.ts
@@ -26,7 +26,8 @@ import { NO_CURRENT_FIGURE, costHeadlineCaveat, limitCellText, mayRecommendAsFre
 import { changesByVendor } from "./superseded-census.js";
 import { buildComparisonMap, comparisonSlug } from "./comparison-pairs.js";
 import { comparisonVerdictText, freeTierFaqAnswer, stabilityFaqAnswer, type ComparisonSide, type FreeTierSide, type SideFreeTier, type StabilityRating } from "./comparison-verdict.js";
-import { publishedVendorLevel, vendorVerdictSentence, vendorBadge, freeTierClaim, statesRiskCause, narrowingSentence, changeKindNoun, type BadgeWithholding, type VendorVerdictInput } from "./vendor-verdict.js";
+import { publishedVendorLevel, vendorVerdictSentence, vendorBadge, freeTierClaim, statesRiskCause, narrowingSentence, changeKindNoun, type BadgeWithholding, type FreeTierClaim, type VendorVerdictInput } from "./vendor-verdict.js";
+import { tierRecordsAFreeTier } from "./free-tier-record.js";
 import { vendorHistorySentence } from "./vendor-history.js";
 import { HETZNER_APRIL_CHANGES, HETZNER_CLOUD_PLANS, HETZNER_PRICES_READ, HETZNER_PRICE_SOURCE, HETZNER_SINGAPORE_EXAMPLE, cheapestOrderableHetznerPlan, hetznerEntryPriceClause, unorderableHetznerPlans } from "./hetzner-pricing.js";
 import { changeTimelineDate, supersededLineups, supersessionNote } from "./change-lineup.js";
@@ -846,7 +847,17 @@ interface VendorVerdictContext {
   input: VendorVerdictInput;
 }
 
+const verdictContexts = new Map<string, { on: string; context: VendorVerdictContext | null }>();
+
 function vendorVerdictContext(vendorName: string, servedOn: string): VendorVerdictContext | null {
+  const cached = verdictContexts.get(vendorName);
+  if (cached && cached.on === servedOn) return cached.context;
+  const context = buildVendorVerdictContext(vendorName, servedOn);
+  verdictContexts.set(vendorName, { on: servedOn, context });
+  return context;
+}
+
+function buildVendorVerdictContext(vendorName: string, servedOn: string): VendorVerdictContext | null {
   const vendorOffers = offers.filter(o => o.vendor === vendorName);
   if (vendorOffers.length === 0) return null;
 
@@ -879,6 +890,43 @@ function vendorVerdictContext(vendorName: string, servedOn: string): VendorVerdi
       linkUnreachable: Boolean(linkUnreachable),
     },
   };
+}
+
+function freeTierClaimFor(vendorName: string, servedOn: string): FreeTierClaim | null {
+  const context = vendorVerdictContext(vendorName, servedOn);
+  return context ? freeTierClaim(context.input) : null;
+}
+
+interface FreeTierCensus {
+  total: number;
+  recorded: number;
+  vouched: number;
+  ended: number;
+  unconfirmed: number;
+}
+
+function freeTierCensus(population: readonly Offer[], servedOn: string): FreeTierCensus {
+  const census: FreeTierCensus = { total: population.length, recorded: 0, vouched: 0, ended: 0, unconfirmed: 0 };
+  for (const offer of population) {
+    const claim = freeTierClaimFor(offer.vendor, servedOn);
+    if (claim?.states === "ended") {
+      census.ended++;
+      continue;
+    }
+    if (!tierRecordsAFreeTier(offer.tier)) continue;
+    census.recorded++;
+    if (claim?.states === "offered") census.vouched++;
+    else census.unconfirmed++;
+  }
+  return census;
+}
+
+function sharePct(part: number, whole: number): number {
+  return whole === 0 ? 0 : Math.round((part / whole) * 100);
+}
+
+function endedFreeTiersIn(population: readonly Offer[], servedOn: string): Offer[] {
+  return population.filter(o => freeTierClaimFor(o.vendor, servedOn)?.states === "ended");
 }
 
 function unconfirmedFreeTierSentence(vendor: string, because: BadgeWithholding, context: VendorVerdictContext): string {
@@ -1500,10 +1548,13 @@ function buildCategoryPage(slug: string): string | null {
   const catOffers = offers.filter((o) => o.category === categoryName);
   const catCount = catOffers.length;
   const catServedOn = utcDate();
-  const catGates = catOffers.map((o) => gateFor(o, catServedOn));
-  const catGatedClause = gatedShareDescriptionClause(catCount, catGates);
+  const catEnded = endedFreeTiersIn(catOffers, catServedOn);
+  const catStanding = catOffers.filter((o) => !catEnded.includes(o));
+  const catStandingCount = catStanding.length;
+  const catGates = catStanding.map((o) => gateFor(o, catServedOn));
+  const catGatedClause = gatedShareDescriptionClause(catStandingCount, catGates);
   const title = `Free ${categoryName} Tools & Deals (${catCount} offers) — AgentDeals`;
-  const metaDesc = `Compare ${catCount} free ${categoryName.toLowerCase()} tools, free tiers, and developer deals.${catGatedClause ? ` ${catGatedClause}` : ""} Verified pricing for ${catOffers.slice(0, 5).map(o => o.vendor).join(", ")}${catCount > 5 ? " and more" : ""}.`;
+  const metaDesc = `Compare ${catStandingCount} free ${categoryName.toLowerCase()} tools, free tiers, and developer deals.${catGatedClause ? ` ${catGatedClause}` : ""} Verified pricing for ${catStanding.slice(0, 5).map(o => o.vendor).join(", ")}${catStandingCount > 5 ? " and more" : ""}.`;
 
   const offersHtml = catOffers.map((o) => `        <tr>
           <td style="font-weight:600;color:var(--text);white-space:nowrap"><a href="/vendor/${toSlug(o.vendor)}" style="color:var(--text)">${escHtmlServer(o.vendor)}</a></td>
@@ -1542,12 +1593,12 @@ function buildCategoryPage(slug: string): string | null {
     ? `This category has been relatively stable &mdash; only ${catChangeCount} pricing changes recorded across all vendors.`
     : `This category has seen some movement &mdash; ${catChangeCount} pricing changes recorded across vendors.`;
 
-  const topVendor = catOffers.find((o, i) => catGates[i] === null && !supersedingChangeFor(o));
+  const topVendor = catStanding.find((o, i) => catGates[i] === null && !supersedingChangeFor(o));
   const keyLimitMatch = topVendor?.description.match(/(\d[\d,]*\s*(?:GB|GiB|MB|TB|requests?|calls?|MAU|users?|emails?|messages?|builds?|minutes?|hours?|projects?|repos?|sites?|apps?|databases?|invocations?|events?))/i);
   const keyLimit = keyLimitMatch ? keyLimitMatch[1] : "a generous free tier";
 
   const introHtml = `<div class="cat-intro">
-    <p>We track <strong>${catCount}</strong> ${categoryName.toLowerCase()} services with free tiers.${topVendor ? ` ${escHtmlServer(topVendor.vendor)} leads with ${escHtmlServer(keyLimit)}.` : ""} ${stabilitySummary}</p>
+    <p>We track <strong>${catStandingCount}</strong> ${categoryName.toLowerCase()} services with free tiers.${topVendor ? ` ${escHtmlServer(topVendor.vendor)} leads with ${escHtmlServer(keyLimit)}.` : ""} ${stabilitySummary}</p>
   </div>`;
 
   const analysisCta = catMapping?.comparison
@@ -1610,7 +1661,7 @@ function buildCategoryPage(slug: string): string | null {
     },
     {
       q: `How many free ${categoryName.toLowerCase()} tools are there?`,
-      a: `We track ${catCount} ${categoryName.toLowerCase()} services with free tiers on AgentDeals. These range from generous always-free tiers to limited trial periods. Each listing is verified with the actual pricing page.`,
+      a: `We track ${catStandingCount} ${categoryName.toLowerCase()} services with free tiers on AgentDeals. These range from generous always-free tiers to limited trial periods. Each listing is verified with the actual pricing page.`,
     },
     {
       q: `How stable are ${categoryName.toLowerCase()} free tiers?`,
@@ -1719,7 +1770,7 @@ ${mcpCtaCss()}
   ${buildGlobalNav("categories")}
   <div class="breadcrumb"><a href="/">AgentDeals</a> &rsaquo; ${escHtmlServer(categoryName)}</div>
   <h1>Free ${escHtmlServer(categoryName)} Tools</h1>
-  <p class="cat-meta">${gatedShareLede(catCount, catGates)}${dataVerifiedSegment(catOffers)}</p>
+  <p class="cat-meta">${gatedShareLede(catStandingCount, catGates, catEnded.length)}${dataVerifiedSegment(catOffers)}</p>
 
   ${introHtml}
   ${analysisCta}
@@ -45158,16 +45209,33 @@ ${mcpCtaCss()}
 </html>`;
 }
 
+const STRUCTURALLY_FREE_CARDS = [
+  {
+    heading: "Cloud Provider Loss Leaders",
+    blurb: "Free tiers subsidized by the larger platform &mdash; they exist to acquire users into the paid ecosystem.",
+    vendors: ["Cloudflare", "Vercel", "Netlify", "Railway", "AWS", "Google Cloud", "Azure"],
+  },
+  {
+    heading: "Developer-First Companies",
+    blurb: "Companies whose business model depends on developer adoption &mdash; the free tier IS the product.",
+    vendors: ["Supabase", "Neon", "Resend", "PostHog", "Sentry", "Grafana Cloud", "Upstash"],
+  },
+  {
+    heading: "Open Source Safety Net",
+    blurb: "Self-hostable alternatives that can&rsquo;t remove free tiers by definition. Always have an exit strategy.",
+    vendors: ["GitLab", "Gitea", "Plausible", "Umami", "n8n", "Meilisearch", "MinIO"],
+  },
+];
+
 function buildStateOfFreeTiersPage(): string {
   const title = "State of Developer Free Tiers (2026) — Data from " + offers.length.toLocaleString() + "+ Tools | AgentDeals";
   const metaDesc = `${dealChanges.length} pricing changes tracked across ${offers.length.toLocaleString()} developer tools. ${categories.length} categories analyzed. The authoritative data on developer free tier trends, erosion patterns, and which vendors are still expanding.`;
   const now = new Date().toISOString().split("T")[0];
 
-  const freeTierOffers = offers.filter(o => {
-    const t = o.tier.toLowerCase();
-    return t.includes("free") || t === "hobby" || t === "starter" || t === "personal" || t === "developer" || t === "community" || t === "open source";
-  });
-  const freePct = Math.round((freeTierOffers.length / offers.length) * 100);
+  const reportServedOn = utcDate();
+  const freeTiers = freeTierCensus(offers, reportServedOn);
+  const recordedPct = sharePct(freeTiers.recorded, freeTiers.total);
+  const vouchedPct = sharePct(freeTiers.vouched, freeTiers.total);
 
   const eligibilityOffers = offers.filter(o => o.eligibility);
   const startupOffers = offers.filter(o => o.tier.toLowerCase().includes("startup") || (o.eligibility && JSON.stringify(o.eligibility).toLowerCase().includes("startup")));
@@ -45207,30 +45275,45 @@ function buildStateOfFreeTiersPage(): string {
     .sort((a, b) => b[1].negative - a[1].negative)
     .slice(0, 15);
 
-  const catCounts = new Map<string, number>();
-  const catFreeCounts = new Map<string, number>();
-  for (const o of offers) {
-    catCounts.set(o.category, (catCounts.get(o.category) ?? 0) + 1);
-    const t = o.tier.toLowerCase();
-    if (t.includes("free") || t === "hobby" || t === "starter" || t === "personal" || t === "developer" || t === "community" || t === "open source") {
-      catFreeCounts.set(o.category, (catFreeCounts.get(o.category) ?? 0) + 1);
-    }
-  }
-  const sortedCats = [...catCounts.entries()].sort((a, b) => b[1] - a[1]);
-
   const negativeChanges = dealChanges.filter(c => negativeTypes.has(c.change_type)).sort((a, b) => b.date.localeCompare(a.date));
   const positiveChanges = dealChanges.filter(c => positiveTypes.has(c.change_type)).sort((a, b) => b.date.localeCompare(a.date));
 
-  const topFreeCategories = [...catFreeCounts.entries()]
-    .sort((a, b) => b[1] - a[1])
-    .slice(0, 12);
+  const categoryShares = categories.map(c => {
+    const census = freeTierCensus(offers.filter(o => o.category === c.name), reportServedOn);
+    return {
+      category: c.name,
+      census,
+      recordedPct: sharePct(census.recorded, census.total),
+      vouchedPct: sharePct(census.vouched, census.total),
+    };
+  }).sort((a, b) =>
+    b.vouchedPct - a.vouchedPct
+    || b.census.vouched - a.census.vouched
+    || b.census.total - a.census.total
+  );
 
-  const catFreePercentage = sortedCats.map(([cat, total]) => ({
-    category: cat,
-    total,
-    free: catFreeCounts.get(cat) ?? 0,
-    pct: Math.round(((catFreeCounts.get(cat) ?? 0) / total) * 100),
-  })).sort((a, b) => b.pct - a.pct);
+  const rankableShares = categoryShares.filter(c => c.census.total >= 8);
+  const widestGap = rankableShares
+    .slice()
+    .sort((a, b) => (b.recordedPct - b.vouchedPct) - (a.recordedPct - a.vouchedPct) || b.census.total - a.census.total)[0]
+    ?? categoryShares[0];
+
+  const countOnDropped: string[] = [];
+  const countOnCards = STRUCTURALLY_FREE_CARDS.map(card => ({
+    heading: card.heading,
+    blurb: card.blurb,
+    vendors: card.vendors.flatMap(name => {
+      const resolution = resolveVendorSlug(toSlug(name));
+      const slug = resolution.type === "exact" || resolution.type === "redirect" ? resolution.slug : null;
+      const canonical = slug ? vendorSlugMap.get(slug) : undefined;
+      if (!slug || !canonical) return [];
+      if (freeTierClaimFor(canonical, reportServedOn)?.states === "ended") {
+        countOnDropped.push(canonical);
+        return [];
+      }
+      return [{ slug, name: canonical }];
+    }),
+  }));
 
   const changeTypeBadgeMap: Record<string, { label: string; color: string }> = {
     free_tier_removed: { label: "Removed", color: "#f85149" },
@@ -45272,13 +45355,15 @@ function buildStateOfFreeTiersPage(): string {
     </div>`;
   }).join("\n");
 
-  const categoryTableRows = catFreePercentage.slice(0, 20).map(c => {
-    const barWidth = Math.max(c.pct, 2);
+  const categoryTableRows = categoryShares.slice(0, 20).map(c => {
+    const barWidth = Math.max(c.vouchedPct, 2);
     return `<tr>
       <td><a href="/category/${toSlug(c.category)}">${escHtmlServer(c.category)}</a></td>
-      <td style="text-align:right">${c.total}</td>
-      <td style="text-align:right">${c.free}</td>
-      <td style="text-align:right">${c.pct}%</td>
+      <td style="text-align:right">${c.census.total}</td>
+      <td style="text-align:right">${c.census.recorded}</td>
+      <td style="text-align:right">${c.recordedPct}%</td>
+      <td style="text-align:right;color:var(--text)">${c.census.vouched}</td>
+      <td style="text-align:right;color:var(--text);font-weight:600">${c.vouchedPct}%</td>
       <td style="width:120px"><div style="background:var(--accent-glow);border-radius:4px;height:16px;width:100%"><div style="background:var(--accent);border-radius:4px;height:100%;width:${barWidth}%"></div></div></td>
     </tr>`;
   }).join("\n");
@@ -45374,7 +45459,9 @@ ${globalNavCss()}
   <h2>Executive Summary</h2>
   <p class="section-desc">We analyzed ${offers.length.toLocaleString()} developer tool offerings across ${categories.length} categories, tracking ${dealChanges.length} pricing changes over 2024&ndash;2026. Here&rsquo;s what the data shows:</p>
   <ul class="key-takeaways">
-    <li><strong>${freePct}% of tracked services offer free tiers</strong> &mdash; the developer-friendly ecosystem remains strong, but the trend is tightening.</li>
+    <li><strong>${vouchedPct}% of tracked services offer a free tier we can vouch for today</strong> &mdash; we hold a free-tier record for ${recordedPct}% of them, and can confirm ${freeTiers.vouched.toLocaleString()} of those ${freeTiers.recorded.toLocaleString()} against a source we have read.</li>
+    <li><strong>${freeTiers.unconfirmed.toLocaleString()} recorded free tiers we cannot confirm today</strong> &mdash; the record stands, but the page we hold for it states no terms, cannot be read, or does not name the vendor. Unconfirmed is not the same as gone.</li>
+    <li><strong>${freeTiers.ended} free tiers we have recorded as ended</strong> &mdash; excluded from every count above, and from every category total on this site.</li>
     <li><strong>${negativeChanges.length} negative pricing changes vs ${positiveChanges.length} positive</strong> &mdash; free tier removals and restrictions outpace expansions ${Math.round(negativeChanges.length / Math.max(positiveChanges.length, 1))}:1.</li>
     <li><strong>${changeTypeCounts.get("free_tier_removed") ?? 0} free tiers completely removed</strong> &mdash; Heroku, PlanetScale, SendGrid, Brave Search API, X API, and more. Once removed, none have returned.</li>
     <li><strong>Egress and overage are the real costs</strong> &mdash; storage at $0.023/GB vs egress at $0.09/GB. Cloudflare R2&rsquo;s zero-egress model is 60x cheaper than S3 at scale.</li>
@@ -45385,13 +45472,15 @@ ${globalNavCss()}
   <div class="stat-grid">
     <div class="stat-card"><span class="stat-number">${offers.length.toLocaleString()}</span><span class="stat-label">Offers Tracked</span></div>
     <div class="stat-card"><span class="stat-number">${categories.length}</span><span class="stat-label">Categories</span></div>
-    <div class="stat-card"><span class="stat-number">${freeTierOffers.length.toLocaleString()}</span><span class="stat-label">Free Tier Offers</span></div>
-    <div class="stat-card"><span class="stat-number">${freePct}%</span><span class="stat-label">Free Tier Rate</span></div>
+    <div class="stat-card"><span class="stat-number">${freeTiers.recorded.toLocaleString()}</span><span class="stat-label">Free Tiers Recorded &mdash; ${recordedPct}%</span></div>
+    <div class="stat-card"><span class="stat-number">${freeTiers.vouched.toLocaleString()}</span><span class="stat-label">Vouched Today &mdash; ${vouchedPct}%</span></div>
+    <div class="stat-card"><span class="stat-number">${freeTiers.unconfirmed.toLocaleString()}</span><span class="stat-label">Recorded, Unconfirmed</span></div>
+    <div class="stat-card"><span class="stat-number">${freeTiers.ended}</span><span class="stat-label">Recorded as Ended</span></div>
     <div class="stat-card"><span class="stat-number">${dealChanges.length}</span><span class="stat-label">Pricing Changes</span></div>
     <div class="stat-card"><span class="stat-number">${eligibilityOffers.length}</span><span class="stat-label">With Eligibility Rules</span></div>
   </div>
   <div class="callout">
-    <strong>How to read this data:</strong> We track publicly available developer tool free tiers, startup programs, and OSS eligibility across ${categories.length} categories. Every offer is manually verified against pricing pages. &ldquo;Free tier&rdquo; includes perpetual free plans, generous hobby tiers, and always-free offerings &mdash; not limited trials.
+    <strong>How to read this data:</strong> We track publicly available developer tool free tiers, startup programs, and OSS eligibility across ${categories.length} categories. &ldquo;Free tier&rdquo; includes perpetual free plans, generous hobby tiers, and always-free offerings &mdash; not limited trials. Three separate numbers follow from that: <strong>recorded</strong> is what the offer we hold says, <strong>vouched</strong> is what we can still confirm against a source we have read, and <strong>ended</strong> is a free tier our own change log says is gone. ${freeTiers.recorded.toLocaleString()} recorded, ${freeTiers.vouched.toLocaleString()} vouched, ${freeTiers.ended} ended &mdash; and the ${freeTiers.ended} are counted in no free-tier total on this site. Each figure is the answer the vendor&rsquo;s own page and status badge give, not a separate reading taken here.
   </div>
 
   <h2>Monthly Pricing Change Trend</h2>
@@ -45475,23 +45564,13 @@ ${globalNavCss()}
   </div>
 
   <h2>Still Free: Vendors You Can Count On</h2>
-  <p class="section-desc">Not everything is eroding. These vendors have strong structural commitment to free tiers &mdash; through open-source foundations, developer-first business models, or cloud provider loss-leader strategies. They represent the safe bets for long-term architecture decisions.</p>
+  <p class="section-desc">Not everything is eroding. These vendors have strong structural commitment to free tiers &mdash; through open-source foundations, developer-first business models, or cloud provider loss-leader strategies. They represent the safe bets for long-term architecture decisions. A vendor drops out of these lists as soon as our change log records its free tier ending${countOnDropped.length > 0 ? `, which is why ${escHtmlServer(joinWithAnd(countOnDropped))} ${countOnDropped.length === 1 ? "is" : "are"} not here` : ""}.</p>
   <div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(250px,1fr));gap:1rem;margin:1.5rem 0">
-    <div style="padding:1rem;border:1px solid #3fb950;border-radius:8px;background:rgba(63,185,80,0.06)">
-      <h3 style="margin:0 0 .5rem;font-size:.95rem;color:#3fb950">Cloud Provider Loss Leaders</h3>
-      <p style="font-size:.85rem;color:var(--text-muted);margin:0 0 .5rem">Free tiers subsidized by the larger platform &mdash; they exist to acquire users into the paid ecosystem.</p>
-      <div style="display:flex;flex-wrap:wrap;gap:.3rem">${["Cloudflare", "Vercel", "Netlify", "Railway", "AWS", "Google Cloud", "Azure"].map(v => `<a href="/vendor/${toSlug(v)}" style="display:inline-block;padding:.15rem .5rem;border:1px solid var(--border);border-radius:12px;font-size:.75rem;color:var(--text-muted)">${v}</a>`).join("")}</div>
-    </div>
-    <div style="padding:1rem;border:1px solid #3fb950;border-radius:8px;background:rgba(63,185,80,0.06)">
-      <h3 style="margin:0 0 .5rem;font-size:.95rem;color:#3fb950">Developer-First Companies</h3>
-      <p style="font-size:.85rem;color:var(--text-muted);margin:0 0 .5rem">Companies whose business model depends on developer adoption &mdash; the free tier IS the product.</p>
-      <div style="display:flex;flex-wrap:wrap;gap:.3rem">${["Supabase", "Neon", "Resend", "PostHog", "Sentry", "Grafana Cloud", "Upstash"].map(v => `<a href="/vendor/${toSlug(v)}" style="display:inline-block;padding:.15rem .5rem;border:1px solid var(--border);border-radius:12px;font-size:.75rem;color:var(--text-muted)">${v}</a>`).join("")}</div>
-    </div>
-    <div style="padding:1rem;border:1px solid #3fb950;border-radius:8px;background:rgba(63,185,80,0.06)">
-      <h3 style="margin:0 0 .5rem;font-size:.95rem;color:#3fb950">Open Source Safety Net</h3>
-      <p style="font-size:.85rem;color:var(--text-muted);margin:0 0 .5rem">Self-hostable alternatives that can&rsquo;t remove free tiers by definition. Always have an exit strategy.</p>
-      <div style="display:flex;flex-wrap:wrap;gap:.3rem">${["GitLab", "Gitea", "Plausible", "Umami", "n8n", "Meilisearch", "MinIO"].map(v => `<a href="/vendor/${toSlug(v)}" style="display:inline-block;padding:.15rem .5rem;border:1px solid var(--border);border-radius:12px;font-size:.75rem;color:var(--text-muted)">${v}</a>`).join("")}</div>
-    </div>
+    ${countOnCards.map(card => `<div style="padding:1rem;border:1px solid #3fb950;border-radius:8px;background:rgba(63,185,80,0.06)">
+      <h3 style="margin:0 0 .5rem;font-size:.95rem;color:#3fb950">${escHtmlServer(card.heading)}</h3>
+      <p style="font-size:.85rem;color:var(--text-muted);margin:0 0 .5rem">${card.blurb}</p>
+      <div style="display:flex;flex-wrap:wrap;gap:.3rem">${card.vendors.map(v => `<a href="/vendor/${v.slug}" style="display:inline-block;padding:.15rem .5rem;border:1px solid var(--border);border-radius:12px;font-size:.75rem;color:var(--text-muted)">${escHtmlServer(v.name)}</a>`).join("")}</div>
+    </div>`).join("\n    ")}
   </div>
   <div class="callout callout-good">
     <strong>Architecture advice:</strong> For each critical infrastructure component, ensure at least one of your shortlisted vendors is either open-source or a cloud-provider loss leader. When a vendor like PlanetScale or Heroku removes their free tier, you want an exit plan that doesn&rsquo;t require rewriting your stack.
@@ -45516,10 +45595,10 @@ ${globalNavCss()}
   <p style="color:var(--text-dim);font-size:.85rem;margin-top:.5rem">See our full <a href="/startup-credits">startup credits directory</a> for 19 programs across 3 tiers.</p>
 
   <h2>Category Landscape</h2>
-  <p class="section-desc">Which categories have the most free tier options? The table below shows our top 20 categories ranked by free tier density.</p>
+  <p class="section-desc">Which categories have the most free tier options? The table below shows our top 20 categories ranked by the share we can vouch for today. <strong>Recorded</strong> counts the free tiers our offers describe; <strong>Vouched</strong> counts the ones whose vendor page still states a verdict rather than withholding one. ${categoryShares.filter(c => c.recordedPct === 100).length} of ${categoryShares.length} categories record a free tier for every service they list, which is why the recorded share cannot rank them. The two shares diverge most in ${escHtmlServer(widestGap.category)}: ${widestGap.census.recorded} of ${widestGap.census.total} recorded, ${widestGap.census.vouched} vouched.</p>
   <div class="cost-table">
   <table>
-    <thead><tr><th>Category</th><th style="text-align:right">Total</th><th style="text-align:right">Free</th><th style="text-align:right">Free %</th><th>Density</th></tr></thead>
+    <thead><tr><th>Category</th><th style="text-align:right">Total</th><th style="text-align:right">Recorded</th><th style="text-align:right">Recorded %</th><th style="text-align:right">Vouched</th><th style="text-align:right">Vouched %</th><th>Vouched Density</th></tr></thead>
     <tbody>
       ${categoryTableRows}
     </tbody>
@@ -45563,7 +45642,7 @@ ${globalNavCss()}
   <h2>Methodology</h2>
   <p class="section-desc">How we built this dataset:</p>
   <ul style="color:var(--text-muted);font-size:.9rem;padding-left:1.25rem;margin-bottom:1rem">
-    <li style="margin-bottom:.4rem"><strong>Verification:</strong> Every offer is verified against the vendor&rsquo;s public pricing page. We record the verification date and source URL.</li>
+    <li style="margin-bottom:.4rem"><strong>Verification:</strong> Every offer records the date we read the vendor&rsquo;s public pricing page and the URL we read it from. That is not the same as being able to vouch for it today: ${freeTiers.unconfirmed.toLocaleString()} of the ${freeTiers.recorded.toLocaleString()} recorded free tiers have a source that states no terms, cannot be read, or does not name the vendor, and those are the ones counted as unconfirmed above.</li>
     <li style="margin-bottom:.4rem"><strong>Change tracking:</strong> ${dealChanges.length} pricing changes tracked with date, previous state, current state, impact level, and source documentation.</li>
     <li style="margin-bottom:.4rem"><strong>Definition of &ldquo;free tier&rdquo;:</strong> Perpetual free plans, always-free offerings, and generous hobby/starter tiers without time limits. We exclude limited trials (e.g., 14-day, 30-day) and one-time credits.</li>
     <li style="margin-bottom:.4rem"><strong>Update frequency:</strong> Continuous. Our <a href="/freshness">data freshness dashboard</a> shows verification recency by category.</li>

--- a/test/badge-verdicts.ts
+++ b/test/badge-verdicts.ts
@@ -1,0 +1,29 @@
+export type SiteFreeTierVerdict = "offered" | "ended" | "unconfirmed";
+
+const VERDICT_BY_BADGE_STATUS: Record<string, SiteFreeTierVerdict> = {
+  "active": "offered",
+  "at-risk": "offered",
+  "stale": "offered",
+  "removed": "ended",
+  "retired": "ended",
+  "withheld": "unconfirmed",
+  "unknown": "unconfirmed",
+};
+
+export function verdictForBadgeStatus(status: string): SiteFreeTierVerdict | null {
+  return VERDICT_BY_BADGE_STATUS[status] ?? null;
+}
+
+export function badgeVerdictsFromBadgesPage(html: string): Map<string, SiteFreeTierVerdict> {
+  const verdicts = new Map<string, SiteFreeTierVerdict>();
+  for (const m of html.matchAll(/<a href="\/vendor\/([a-z0-9-]+)" class="vendor-badge-link" title="[^"]*? — ([a-z-]+)"/g)) {
+    const verdict = verdictForBadgeStatus(m[2]);
+    if (verdict) verdicts.set(m[1], verdict);
+  }
+  return verdicts;
+}
+
+export async function fetchBadgeVerdicts(port: number): Promise<Map<string, SiteFreeTierVerdict>> {
+  const html = await (await fetch(`http://localhost:${port}/badges`)).text();
+  return badgeVerdictsFromBadgesPage(html);
+}

--- a/test/category-gate-lede.test.ts
+++ b/test/category-gate-lede.test.ts
@@ -5,8 +5,11 @@ import { readFileSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
+import { fetchBadgeVerdicts, type SiteFreeTierVerdict } from "./badge-verdicts.ts";
+
 const { gateFor, utcDate } = await import("../dist/ranking.js");
 const { gatedShareLede } = await import("../dist/eligibility.js");
+const { toSlug } = await import("../dist/vendor-slug.js");
 
 type Offer = import("../src/types.ts").Offer;
 type Gate = { code: string; reason: string } | null;
@@ -47,16 +50,23 @@ function eligibilityAccountsForAll(c: { codes: string[]; total: number }): boole
   return c.codes.length >= c.total && c.codes.every((code) => code === "eligibility_restricted");
 }
 
-function expectedLede(total: number, codes: string[]): string {
+function endedClause(ended: number): string {
+  if (ended <= 0) return "";
+  if (ended === 1) return " We also track one whose free tier has ended.";
+  return ` We also track ${ended} whose free tiers have ended.`;
+}
+
+function expectedLede(total: number, codes: string[], ended = 0): string {
   const counted = `${total} verified free tiers and developer deals`;
-  if (codes.length === 0) return `${counted}.`;
+  const alsoEnded = endedClause(ended);
+  if (codes.length === 0) return `${counted}.${alsoEnded}`;
   if (eligibilityAccountsForAll({ codes, total })) {
-    return `${counted}, ${ALL_GATED_ELIGIBILITY_LEDE}`;
+    return `${counted}, ${ALL_GATED_ELIGIBILITY_LEDE}${alsoEnded}`;
   }
   const clauses = clausesFor(codes);
-  if (codes.length >= total && total > 1) return `${counted}. None of them are on our ranked list — ${clauses}.`;
-  if (codes.length === 1) return `${counted}. One of them is not on our ranked list — ${clauses}.`;
-  return `${counted}. ${codes.length} of them are not on our ranked list — ${clauses}.`;
+  if (codes.length >= total && total > 1) return `${counted}. None of them are on our ranked list — ${clauses}.${alsoEnded}`;
+  if (codes.length === 1) return `${counted}. One of them is not on our ranked list — ${clauses}.${alsoEnded}`;
+  return `${counted}. ${codes.length} of them are not on our ranked list — ${clauses}.${alsoEnded}`;
 }
 
 function slugOf(name: string): string {
@@ -71,21 +81,30 @@ interface CategoryCensus {
   codes: string[];
   total: number;
   gated: number;
+  ended: number;
 }
 
-const census: CategoryCensus[] = [...new Set(offers.map((o) => o.category))].sort().map((name) => {
-  const records = offers.filter((o) => o.category === name);
-  const gates: Gate[] = records.map((o) => gateFor(o, TODAY));
-  return {
-    name,
-    slug: slugOf(name),
-    records,
-    gates,
-    codes: gates.filter((g): g is NonNullable<Gate> => g !== null).map((g) => g.code),
-    total: records.length,
-    gated: gates.filter((g) => g !== null).length,
-  };
-});
+const categoryNames = [...new Set(offers.map((o) => o.category))].sort();
+
+let census: CategoryCensus[] = [];
+
+function buildCensus(verdicts: Map<string, SiteFreeTierVerdict>): CategoryCensus[] {
+  return categoryNames.map((name) => {
+    const held = offers.filter((o) => o.category === name);
+    const records = held.filter((o) => verdicts.get(toSlug(o.vendor)) !== "ended");
+    const gates: Gate[] = records.map((o) => gateFor(o, TODAY));
+    return {
+      name,
+      slug: slugOf(name),
+      records,
+      gates,
+      codes: gates.filter((g): g is NonNullable<Gate> => g !== null).map((g) => g.code),
+      total: records.length,
+      gated: gates.filter((g) => g !== null).length,
+      ended: held.length - records.length,
+    };
+  });
+}
 
 let port = 0;
 let proc: ChildProcess | null = null;
@@ -154,9 +173,14 @@ function disclosedCountIn(lede: string, total: number): number | null {
   return named ? parseInt(named[1].replace(/,/g, ""), 10) : null;
 }
 
+before(async () => {
+  proc = await startServer();
+  census = buildCensus(await fetchBadgeVerdicts(port));
+});
+
+after(() => { proc?.kill(); });
+
 describe("a category page discloses every gated record, not eligibility alone", () => {
-  before(async () => { proc = await startServer(); });
-  after(() => { proc?.kill(); });
 
   it("holds the four populations the sentence forms are written for", () => {
     assert.ok(census.some((c) => c.gated === 0), "no category is free of gated records");
@@ -176,7 +200,7 @@ describe("a category page discloses every gated record, not eligibility alone", 
   it("states the sentence its own records compose", async () => {
     for (const c of census) {
       const lede = ledeOf(await page(`/category/${c.slug}`));
-      const expected = expectedLede(c.total, c.codes);
+      const expected = expectedLede(c.total, c.codes, c.ended);
       assert.ok(
         lede.startsWith(expected),
         `/category/${c.slug} (${c.gated} of ${c.total})\n  reads: ${lede}\n  should: ${expected}`,
@@ -286,8 +310,6 @@ describe("a category page discloses every gated record, not eligibility alone", 
 });
 
 describe("the record a category page puts forward is one the ranker lists", () => {
-  before(async () => { proc = proc ?? await startServer(); });
-  after(() => { proc?.kill(); });
 
   it("names no record the ranker gates", async () => {
     let named = 0;
@@ -366,10 +388,10 @@ describe("the record a category page puts forward is one the ranker lists", () =
 
 const GATE_CODES = ["eligibility_restricted", "not_a_free_offer", "offer_expired", "offer_retired", "verification_lapsed"];
 
-function population(total: number, codes: string[]): { total: number; codes: string[]; gates: Gate[] } {
+function population(total: number, codes: string[], ended = 0): { total: number; codes: string[]; gates: Gate[]; ended: number } {
   const gates: Gate[] = codes.map((code) => ({ code, reason: "" }));
   while (gates.length < total) gates.push(null as unknown as Gate);
-  return { total, codes, gates };
+  return { total, codes, gates, ended };
 }
 
 const FORMS = [
@@ -382,32 +404,44 @@ const FORMS = [
   { name: "all gated, no eligibility", ...population(3, ["not_a_free_offer", "offer_expired", "offer_retired"]) },
   { name: "the only record gated", ...population(1, ["offer_retired"]) },
   { name: "every code at once", ...population(9, [...GATE_CODES, ...GATE_CODES.slice(0, 4)]) },
+  { name: "one ended, nothing gated", ...population(12, [], 1) },
+  { name: "four ended, nothing gated", ...population(12, [], 4) },
+  { name: "ended alongside a gate", ...population(12, ["not_a_free_offer"], 3) },
+  { name: "ended alongside every record gated by eligibility", ...population(12, Array(12).fill("eligibility_restricted"), 2) },
+  { name: "ended alongside a mixed clause list", ...population(9, [...GATE_CODES], 5) },
 ];
 
 describe("the sentence forms hold whether or not a category exercises them today", () => {
   it("covers every form the composer can reach", () => {
-    const composed = FORMS.map((f) => gatedShareLede(f.total, f.gates));
-    for (const shape of ["none of them generally available", "None of them are on our ranked list", "One of them is not on our ranked list", "of them are not on our ranked list"]) {
+    const composed = FORMS.map((f) => gatedShareLede(f.total, f.gates, f.ended));
+    for (const shape of ["none of them generally available", "None of them are on our ranked list", "One of them is not on our ranked list", "of them are not on our ranked list", "We also track one whose free tier has ended.", "whose free tiers have ended."]) {
       assert.ok(composed.some((lede) => lede.includes(shape)), `no population above composes "${shape}"`);
     }
     for (const code of GATE_CODES) {
       assert.ok(FORMS.some((f) => f.codes.includes(code)), `no population above holds a ${code} record`);
     }
+    assert.ok(FORMS.some((f) => f.ended === 0), "no population above is free of ended records");
+    assert.ok(FORMS.some((f) => f.ended === 1), "no population above holds exactly one ended record");
+    assert.ok(FORMS.some((f) => f.ended > 1), "no population above holds more than one ended record");
+    assert.ok(
+      composed.filter((lede) => lede.includes("free tier")).length > FORMS.filter((f) => f.ended > 0).length,
+      "the ended clause is the only place the composer names a free tier",
+    );
   });
 
   it("composes the sentence this test asserts on the page", () => {
     for (const form of FORMS) {
       assert.strictEqual(
-        gatedShareLede(form.total, form.gates),
-        expectedLede(form.total, form.codes),
-        `${form.name} (${form.codes.length} of ${form.total})`,
+        gatedShareLede(form.total, form.gates, form.ended),
+        expectedLede(form.total, form.codes, form.ended),
+        `${form.name} (${form.codes.length} of ${form.total}, ${form.ended} ended)`,
       );
     }
   });
 
   it("reads its own count back out of every one of them", () => {
     for (const form of FORMS) {
-      const lede = gatedShareLede(form.total, form.gates);
+      const lede = gatedShareLede(form.total, form.gates, form.ended);
       assert.strictEqual(
         disclosedCountIn(lede, form.total),
         form.codes.length === 0 ? null : form.codes.length,

--- a/test/eligibility-disclosure.test.ts
+++ b/test/eligibility-disclosure.test.ts
@@ -5,6 +5,8 @@ import { readFileSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
+import { fetchBadgeVerdicts, type SiteFreeTierVerdict } from "./badge-verdicts.ts";
+
 const { eligibilityGate, eligibilityGateAsPublished, publishableEligibilityConditions, CONDITION_RECORDING_AN_UNREAD_PROGRAM } =
   await import("../dist/eligibility.js");
 const { gateFor, notAFreeOfferGateFor, utcDate } = await import("../dist/ranking.js");
@@ -98,8 +100,11 @@ type RenderedPage = { vendor: string; slug: string; html: string; offer: Offer }
 
 let rendered: RenderedPage[] = [];
 
+let verdicts = new Map<string, SiteFreeTierVerdict>();
+
 before(async () => {
   proc = await startServer();
+  verdicts = await fetchBadgeVerdicts(port);
   for (const vendor of vendorsHoldingAGatedRecord) {
     const slug = slugOf(vendor);
     const html = await page(`/vendor/${slug}`);
@@ -235,11 +240,13 @@ describe("the category page a gated offer is sent to states the restriction", ()
 describe("a category page does not count a gated offer as a plain free tier", () => {
   const categoryNames = [...new Set(offers.map(o => o.category))].sort();
   const censusOf = (category: string) => {
-    const inCategory = offers.filter(o => o.category === category);
+    const held = offers.filter(o => o.category === category);
+    const inCategory = held.filter(o => verdicts.get(slugOf(o.vendor)) !== "ended");
     return {
       total: inCategory.length,
       restricted: inCategory.filter(publishesARestriction).length,
       gated: inCategory.filter(o => gateFor(o, utcDate())).length,
+      ended: held.length - inCategory.length,
     };
   };
   const ledeOf = (html: string) => html.match(/<p class="cat-meta">([\s\S]*?)<\/p>/)?.[1] ?? "";
@@ -301,7 +308,8 @@ describe("a category page does not count a gated offer as a plain free tier", ()
       const { total, restricted, gated } = censusOf(category);
       const html = await page(`/category/${slugOf(category)}`);
       const lede = ledeOf(html);
-      assert.strictEqual(restrictedRows(html), restricted, `/category/${slugOf(category)} restricted rows`);
+      const rowsCarryingARestriction = offers.filter(o => o.category === category).filter(publishesARestriction).length;
+      assert.strictEqual(restrictedRows(html), rowsCarryingARestriction, `/category/${slugOf(category)} restricted rows`);
       if (gated > 1 && gated < total) {
         assert.ok(lede.includes(`${gated} of them`), `/category/${slugOf(category)} lede is ${lede}`);
       }

--- a/test/free-tier-vouched-share.test.ts
+++ b/test/free-tier-vouched-share.test.ts
@@ -1,0 +1,368 @@
+import { describe, it, before, after } from "node:test";
+import assert from "node:assert";
+import { spawn, type ChildProcess } from "node:child_process";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { fetchBadgeVerdicts, type SiteFreeTierVerdict } from "./badge-verdicts.ts";
+
+const { tierRecordsAFreeTier } = await import("../dist/free-tier-record.js");
+const { toSlug } = await import("../dist/vendor-slug.js");
+
+type Offer = import("../src/types.ts").Offer;
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO = path.join(__dirname, "..");
+
+const offers: Offer[] = JSON.parse(readFileSync(path.join(REPO, "data", "index.json"), "utf-8")).offers;
+const categoryNames = [...new Set(offers.map((o) => o.category))].sort();
+
+let port = 0;
+let proc: ChildProcess | null = null;
+let verdicts = new Map<string, SiteFreeTierVerdict>();
+const fetched = new Map<string, string>();
+
+function startServer(): Promise<ChildProcess> {
+  return new Promise((resolve, reject) => {
+    const child = spawn("node", [path.join(REPO, "dist", "serve.js")], {
+      stdio: ["pipe", "pipe", "pipe"],
+      env: { ...process.env, PORT: "0", BASE_URL: "http://localhost", TZ: "UTC" },
+    });
+    const timeout = setTimeout(() => { child.kill(); reject(new Error("Server startup timeout")); }, 60000);
+    child.stderr!.on("data", (data: Buffer) => {
+      const m = data.toString().match(/running on http:\/\/localhost:(\d+)/);
+      if (m) { port = parseInt(m[1], 10); clearTimeout(timeout); resolve(child); }
+    });
+    child.on("error", (e) => { clearTimeout(timeout); reject(e); });
+  });
+}
+
+async function page(pathname: string): Promise<string> {
+  const cached = fetched.get(pathname);
+  if (cached !== undefined) return cached;
+  const body = await (await fetch(`http://localhost:${port}${pathname}`)).text();
+  fetched.set(pathname, body);
+  return body;
+}
+
+function verdictFor(offer: Offer): SiteFreeTierVerdict {
+  return verdicts.get(toSlug(offer.vendor)) ?? "unconfirmed";
+}
+
+interface Census {
+  total: number;
+  recorded: number;
+  vouched: number;
+  ended: number;
+  unconfirmed: number;
+}
+
+function censusOf(population: Offer[]): Census {
+  const census: Census = { total: population.length, recorded: 0, vouched: 0, ended: 0, unconfirmed: 0 };
+  for (const offer of population) {
+    if (verdictFor(offer) === "ended") { census.ended++; continue; }
+    if (!tierRecordsAFreeTier(offer.tier)) continue;
+    census.recorded++;
+    if (verdictFor(offer) === "offered") census.vouched++;
+    else census.unconfirmed++;
+  }
+  return census;
+}
+
+function statCards(html: string): Map<string, string> {
+  const cards = new Map<string, string>();
+  for (const m of html.matchAll(/<span class="stat-number">([^<]*)<\/span><span class="stat-label">([^<]*)<\/span>/g)) {
+    cards.set(m[2].replace(/&mdash;/g, "—").trim(), m[1].trim());
+  }
+  return cards;
+}
+
+function statNumber(cards: Map<string, string>, labelPrefix: string): number {
+  const entry = [...cards.entries()].find(([label]) => label.startsWith(labelPrefix));
+  assert.ok(entry, `no stat card whose label starts with ${JSON.stringify(labelPrefix)} — labels: ${[...cards.keys()].join(" | ")}`);
+  return parseInt(entry![1].replace(/[,%]/g, ""), 10);
+}
+
+interface LandscapeRow {
+  slug: string;
+  category: string;
+  total: number;
+  recorded: number;
+  recordedPct: number;
+  vouched: number;
+  vouchedPct: number;
+}
+
+function landscapeRows(html: string): LandscapeRow[] {
+  const section = html.split("<h2>Category Landscape</h2>")[1]?.split("</table>")[0] ?? "";
+  return [...section.matchAll(
+    /<tr>\s*<td><a href="\/category\/([a-z0-9-]+)">([^<]*)<\/a><\/td>\s*<td[^>]*>(\d+)<\/td>\s*<td[^>]*>(\d+)<\/td>\s*<td[^>]*>(\d+)%<\/td>\s*<td[^>]*>(\d+)<\/td>\s*<td[^>]*>(\d+)%<\/td>/g,
+  )].map((m) => ({
+    slug: m[1],
+    category: m[2],
+    total: Number(m[3]),
+    recorded: Number(m[4]),
+    recordedPct: Number(m[5]),
+    vouched: Number(m[6]),
+    vouchedPct: Number(m[7]),
+  }));
+}
+
+function textOf(fragment: string): string {
+  return fragment.replace(/<[^>]+>/g, "").replace(/&mdash;/g, "—").replace(/&amp;/g, "&").replace(/&rsquo;/g, "’").trim();
+}
+
+function ledeOf(html: string): string {
+  return textOf(html.match(/<p class="cat-meta">([\s\S]*?)<\/p>/)?.[1] ?? "");
+}
+
+function countOnVendors(html: string): { name: string; slug: string }[] {
+  const section = html.split("<h2>Still Free: Vendors You Can Count On</h2>")[1]?.split('<div class="callout callout-good">')[0] ?? "";
+  return [...section.matchAll(/href="\/vendor\/([a-z0-9-]+)"[^>]*>([^<]*)<\/a>/g)].map((m) => ({ slug: m[1], name: m[2] }));
+}
+
+function slugOf(name: string): string {
+  return name.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "");
+}
+
+before(async () => {
+  proc = await startServer();
+  verdicts = await fetchBadgeVerdicts(port);
+});
+
+after(() => { proc?.kill(); });
+
+describe("the free tier report counts what the site is prepared to vouch for", () => {
+  it("reads a verdict for every vendor in the catalogue", () => {
+    assert.ok(verdicts.size >= 1500, `only ${verdicts.size} vendors publish a badge verdict`);
+    const missing = offers.filter((o) => !verdicts.has(toSlug(o.vendor)));
+    assert.deepStrictEqual(missing.map((o) => o.vendor), [], "offers whose vendor publishes no badge verdict");
+  });
+
+  it("holds the three populations the report is written for", () => {
+    const census = censusOf(offers);
+    assert.ok(census.ended >= 20, `only ${census.ended} offers are recorded as ended`);
+    assert.ok(census.vouched >= 300, `only ${census.vouched} offers are vouched`);
+    assert.ok(census.unconfirmed >= 100, `only ${census.unconfirmed} recorded offers are unconfirmed`);
+    assert.ok(
+      censusOf(offers.filter((o) => tierRecordsAFreeTier(o.tier))).ended >= 20,
+      "no offer whose tier records a free tier is also recorded as ended, so the exclusion is untested",
+    );
+  });
+
+  it("publishes recorded, vouched, ended and unconfirmed as four separate numbers", async () => {
+    const cards = statCards(await page("/state-of-free-tiers"));
+    const census = censusOf(offers);
+    assert.strictEqual(statNumber(cards, "Free Tiers Recorded"), census.recorded);
+    assert.strictEqual(statNumber(cards, "Vouched Today"), census.vouched);
+    assert.strictEqual(statNumber(cards, "Recorded, Unconfirmed"), census.unconfirmed);
+    assert.strictEqual(statNumber(cards, "Recorded as Ended"), census.ended);
+    assert.strictEqual(
+      census.recorded,
+      census.vouched + census.unconfirmed,
+      "the recorded population is not the vouched and unconfirmed populations together",
+    );
+  });
+
+  it("states the vouched share in the opening summary and derives it from the same data", async () => {
+    const html = await page("/state-of-free-tiers");
+    const census = censusOf(offers);
+    const vouchedPct = Math.round((census.vouched / census.total) * 100);
+    const recordedPct = Math.round((census.recorded / census.total) * 100);
+    assert.ok(
+      html.includes(`<strong>${vouchedPct}% of tracked services offer a free tier we can vouch for today</strong>`),
+      `the summary does not open on ${vouchedPct}%`,
+    );
+    assert.ok(html.includes(`we hold a free-tier record for ${recordedPct}% of them`), `the summary does not state ${recordedPct}% recorded`);
+    assert.ok(html.includes(`<strong>${census.ended} free tiers we have recorded as ended</strong>`), "the summary does not state the ended count");
+    assert.ok(!/\d+% of tracked services offer free tiers/.test(html), "the report still publishes a free tier rate that counts ended free tiers");
+  });
+
+  it("counts no offer the site says has ended toward any total on the report", async () => {
+    const html = await page("/state-of-free-tiers");
+    const cards = statCards(html);
+    const ended = offers.filter((o) => verdictFor(o) === "ended");
+    assert.ok(ended.length >= 20, `only ${ended.length} offers are recorded as ended`);
+    const recordedIfEndedCounted = censusOf(offers).recorded + ended.filter((o) => tierRecordsAFreeTier(o.tier)).length;
+    assert.notStrictEqual(
+      statNumber(cards, "Free Tiers Recorded"),
+      recordedIfEndedCounted,
+      "the recorded total is the same whether or not ended free tiers are counted, so nothing is excluded",
+    );
+    for (const row of landscapeRows(html)) {
+      const category = categoryNames.find((c) => slugOf(c) === row.slug);
+      assert.ok(category, `the landscape table names /category/${row.slug}, which is no category we hold`);
+      const census = censusOf(offers.filter((o) => o.category === category));
+      assert.strictEqual(row.recorded, census.recorded, `${row.category} recorded`);
+      assert.strictEqual(row.vouched, census.vouched, `${row.category} vouched`);
+      assert.strictEqual(row.total, census.total, `${row.category} total`);
+    }
+  });
+
+  it("ranks the category landscape by the share it can vouch for and publishes both shares", async () => {
+    const rows = landscapeRows(await page("/state-of-free-tiers"));
+    assert.ok(rows.length >= 15, `the landscape table renders ${rows.length} rows`);
+    for (let i = 1; i < rows.length; i++) {
+      assert.ok(
+        rows[i - 1].vouchedPct >= rows[i].vouchedPct,
+        `${rows[i - 1].category} (${rows[i - 1].vouchedPct}%) is ranked above ${rows[i].category} (${rows[i].vouchedPct}%)`,
+      );
+    }
+    assert.ok(
+      new Set(rows.map((r) => r.vouchedPct)).size > 1,
+      "every row in the landscape table reads the same vouched share, so the column ranks nothing",
+    );
+    for (const row of rows) {
+      assert.ok(row.recordedPct >= row.vouchedPct, `${row.category} vouches for more than it records`);
+      assert.strictEqual(row.recordedPct, Math.round((row.recorded / row.total) * 100), `${row.category} recorded share`);
+      assert.strictEqual(row.vouchedPct, Math.round((row.vouched / row.total) * 100), `${row.category} vouched share`);
+    }
+    assert.ok(
+      rows.some((r) => r.recordedPct - r.vouchedPct >= 20),
+      "no row in the landscape table shows a gap between the two shares",
+    );
+  });
+
+  it("recommends no vendor on the report whose free tier the site says has ended", async () => {
+    const html = await page("/state-of-free-tiers");
+    const named = countOnVendors(html);
+    assert.ok(named.length >= 12, `the structural-commitment cards name ${named.length} vendors`);
+    for (const vendor of named) {
+      assert.notStrictEqual(
+        verdicts.get(vendor.slug),
+        "ended",
+        `the report puts ${vendor.name} forward as a vendor you can count on`,
+      );
+      assert.ok(verdicts.has(vendor.slug), `the report links /vendor/${vendor.slug}, which publishes no badge verdict`);
+      const res = await fetch(`http://localhost:${port}/vendor/${vendor.slug}`, { redirect: "manual" });
+      assert.strictEqual(res.status, 200, `/vendor/${vendor.slug} answers ${res.status}`);
+    }
+    assert.ok(
+      html.includes("A vendor drops out of these lists as soon as our change log records its free tier ending"),
+      "the report does not say the lists are filtered",
+    );
+
+    const dropped = (textOf(html).match(/which is why (.+?) (?:is|are) not here/)?.[1] ?? "")
+      .split(/,\s*|\s+and\s+/)
+      .filter(Boolean);
+    assert.ok(dropped.length > 0, "the report names no vendor it dropped, so the sentence is untested");
+    for (const name of dropped) {
+      assert.strictEqual(
+        verdicts.get(toSlug(name)),
+        "ended",
+        `the report says it dropped ${name}, whose badge does not read ended`,
+      );
+    }
+    assert.ok(
+      named.length + dropped.length >= 20,
+      `the cards account for ${named.length} vendors published and ${dropped.length} dropped — a name in these lists resolves to no vendor page at all`,
+    );
+  });
+});
+
+describe("a category lede counts no free tier the site says has ended", () => {
+  it("holds categories on both sides of the exclusion", () => {
+    const withEnded = categoryNames.filter((c) => censusOf(offers.filter((o) => o.category === c)).ended > 0);
+    assert.ok(withEnded.length >= 15, `only ${withEnded.length} categories hold an ended free tier`);
+    assert.ok(withEnded.length < categoryNames.length, "every category holds an ended free tier");
+    assert.ok(
+      categoryNames.some((c) => censusOf(offers.filter((o) => o.category === c)).ended > 1),
+      "no category holds more than one ended free tier, so the plural form is untested",
+    );
+  });
+
+  it("subtracts them from the count and names them", async () => {
+    let naming = 0;
+    for (const category of categoryNames) {
+      const population = offers.filter((o) => o.category === category);
+      const ended = censusOf(population).ended;
+      const lede = ledeOf(await page(`/category/${slugOf(category)}`));
+      assert.ok(
+        lede.startsWith(`${population.length - ended} verified free tiers and developer deals`),
+        `/category/${slugOf(category)} counts ${population.length} less ${ended} ended as: ${lede}`,
+      );
+      if (ended === 0) {
+        assert.ok(!lede.includes("whose free tier"), `/category/${slugOf(category)} names an ended free tier it does not hold: ${lede}`);
+        continue;
+      }
+      naming++;
+      const clause = ended === 1
+        ? "We also track one whose free tier has ended."
+        : `We also track ${ended} whose free tiers have ended.`;
+      assert.ok(lede.includes(clause), `/category/${slugOf(category)} lede is: ${lede}`);
+    }
+    assert.ok(naming >= 15, `only ${naming} categories name an ended free tier`);
+  });
+
+  it("keeps the count out of the intro and the search snippet as well", async () => {
+    for (const category of categoryNames) {
+      const population = offers.filter((o) => o.category === category);
+      const standing = population.length - censusOf(population).ended;
+      const html = await page(`/category/${slugOf(category)}`);
+      const intro = textOf(html.match(/<div class="cat-intro">\s*<p>([\s\S]*?)<\/p>/)?.[1] ?? "");
+      assert.ok(
+        intro.startsWith(`We track ${standing} ${category.toLowerCase()} services with free tiers.`),
+        `/category/${slugOf(category)} intro is: ${intro}`,
+      );
+      const description = (html.match(/<meta name="description" content="([^"]*)"/)?.[1] ?? "").replace(/&amp;/g, "&");
+      assert.ok(
+        description.startsWith(`Compare ${standing} free ${category.toLowerCase()} tools`),
+        `/category/${slugOf(category)} description is: ${description}`,
+      );
+    }
+  });
+
+  it("agrees with the vendor page about a free tier that has ended", async () => {
+    const ended = offers.filter((o) => verdictFor(o) === "ended");
+    assert.ok(ended.length >= 20, `only ${ended.length} offers are recorded as ended`);
+    let checked = 0;
+    let retired = 0;
+    for (const offer of ended.slice(0, 20)) {
+      const slug = toSlug(offer.vendor);
+      const vendorPage = textOf(await page(`/vendor/${slug}`));
+      const saysRetired = vendorPage.includes(`${offer.vendor} — free tier retired`);
+      if (saysRetired) retired++;
+      assert.ok(
+        saysRetired || vendorPage.includes("Why risky:"),
+        `/vendor/${slug} publishes neither a retirement nor a cause, but its badge reads ended`,
+      );
+      const lede = ledeOf(await page(`/category/${slugOf(offer.category)}`));
+      const population = offers.filter((o) => o.category === offer.category);
+      const standing = population.length - censusOf(population).ended;
+      assert.ok(
+        lede.startsWith(`${standing} verified free tiers`),
+        `/category/${slugOf(offer.category)} still counts ${offer.vendor}: ${lede}`,
+      );
+      checked++;
+    }
+    assert.ok(checked >= 20, `only ${checked} ended free tiers were checked against their vendor page`);
+    assert.ok(retired > 0 && retired < checked, `${retired} of ${checked} pages publish a retirement, so one of the two forms is untested`);
+  });
+});
+
+describe("the report answers the free tier question with the rule the rest of the site uses", () => {
+  it("keeps no tier substring test inside the report builder", () => {
+    const source = readFileSync(path.join(REPO, "src", "serve.ts"), "utf-8");
+    const start = source.indexOf("function buildStateOfFreeTiersPage(");
+    assert.ok(start > 0, "buildStateOfFreeTiersPage is no longer in src/serve.ts");
+    const next = source.indexOf("\nfunction ", start + 1);
+    const body = source.slice(start, next > 0 ? next : undefined);
+    assert.ok(!body.includes('t.includes("free")'), "the report still classifies a tier by substring");
+    assert.ok(!body.includes('=== "hobby"'), "the report still holds its own list of free tier labels");
+    assert.ok(body.includes("freeTierCensus("), "the report does not ask the shared census for its populations");
+  });
+
+  it("reads a tier the same way wherever the question is asked", () => {
+    assert.strictEqual(tierRecordsAFreeTier("Free"), true);
+    assert.strictEqual(tierRecordsAFreeTier("Hobby"), true);
+    assert.strictEqual(tierRecordsAFreeTier("Open Source"), true);
+    assert.strictEqual(tierRecordsAFreeTier("Pro"), false);
+    assert.strictEqual(tierRecordsAFreeTier("Free Credits"), false);
+    assert.strictEqual(tierRecordsAFreeTier("Free Trial"), false);
+    assert.strictEqual(tierRecordsAFreeTier("Discontinued"), false);
+    assert.ok(
+      offers.some((o) => /free/i.test(o.tier) && !tierRecordsAFreeTier(o.tier)),
+      "no offer in the catalogue names free in a tier that does not record an ongoing free tier",
+    );
+  });
+});


### PR DESCRIPTION
Refs #1407

`/state-of-free-tiers` decided whether a vendor had a free tier by looking for the substring `free` in the stored tier label. Everywhere else on the site that question is answered by `freeTierClaim`. The report never called it, and 31 of the 1,389 free tiers it counted are ones our own badge says have been removed — Peacock, Dub.co, Unkey, LogRocket, Circum Icons and 26 more.

## What the page publishes now

The report's populations come from `freeTierCensus`, which asks `freeTierClaim` — the same function `/vendor/<slug>` and `/badge/<slug>.svg` ask — for every offer, and reads the stored tier through one shared rule rather than an inline substring test.

| | before | after |
|---|---|---|
| hero | `88% of tracked services offer free tiers` | `47% of tracked services offer a free tier we can vouch for today` |
| Free Tier Offers / Rate | 1,389 / 88% | Free Tiers Recorded **1,344 — 85%** |
| — | — | Vouched Today **747 — 47%** |
| — | — | Recorded, Unconfirmed **597** |
| — | — | Recorded as Ended **52** |

`recorded = vouched + unconfirmed` is an identity the suite asserts, and no offer whose claim states `ended` is counted in any of them.

## Category Landscape

Every one of the 20 rows read `100%`, because 32 of 66 categories tied at the maximum — the column ranked nothing. The table now publishes both shares on every row and is ranked by the one that can rank: Cloud Storage leads at 100% recorded / 89% vouched, and the section names the widest divergence (Streaming & Media: 11 of 12 recorded, 1 vouched).

## Category ledes

`gatedShareLede` called all 1,580 offers verified free tiers. 27 of 66 categories counted at least one ended free tier among them.

- `/category/streaming-media` — `12 verified free tiers and developer deals.` → `11 verified free tiers and developer deals. We also track one whose free tier has ended.`
- The same exclusion applies to the intro sentence, the search snippet and the vendor sample, which made the identical claim one field over.
- The gate disclosure now runs over the standing records only, so the 15 `offer_retired` gates that read "N have ended" are stated once, in the ended clause, rather than in two places.

## Two things found on the way

**The "Vendors You Can Count On" cards recommended three vendors whose free tiers our change log says are gone** — Plausible Analytics, n8n and MinIO, in a card headed "Open Source Safety Net". The three lists are now filtered by the same claim and the page names who dropped out. Two of the names also linked through a 301 (`/vendor/gitlab` → `/vendor/gitlab-ci`); they resolve directly now.

**The Methodology section said "Every offer is verified against the vendor's public pricing page"** on a page that now reports 597 recorded free tiers it cannot confirm. It states what a verification date actually means instead.

## Verification

- 13 new tests in `test/free-tier-vouched-share.test.ts`. They take the site's own `/badges` page as the oracle — a surface none of the pages under test builds — and assert the report's four numbers, the landscape table's two columns and ranking, and every one of the 66 category ledes against it. 9 of the 13 fail on `main`.
- 5 new sentence forms in `test/category-gate-lede.test.ts`, whose census now partitions the same way the page does.
- `scripts/mutate-1407.mjs`: 19 mutations, 19 killed, no survivors.

## Reported, not fixed

`auditStack` in `src/data.ts` holds two more private definitions of "has a free tier" (`o.tier.toLowerCase().includes("free")`, lines 1039 and 1074). Its eligible pool is 1,334 offers, 30 of which have an ended free tier; today that makes Dub.co the fallback `cheaper_alternative` for Dev Utilities. Details on the issue.
