### PR TITLE
Join the nine comparison tables to the records that supersede them (#1409)

### DIFF
--- a/data/deal_changes.json
+++ b/data/deal_changes.json
@@ -4430,7 +4430,7 @@
       "summary": "Free tier reduced from 1,000 to 100 daily requests. Full access now requires Coding Plan Pro ($50/month).",
       "previous_state": "1,000 requests/day free",
       "current_state": "100 requests/day free, full access $50/month",
-      "impact": "negative",
+      "impact": "high",
       "source_url": "https://tech.yahoo.com/ai/gemini/articles/free-qwen-dead-alibaba-shuts-190159063.html",
       "category": "AI / ML",
       "alternatives": [
@@ -4467,7 +4467,7 @@
       "summary": "SendGrid Accelerate startup program discontinued. sendgrid.com now redirects to twilio.com. Twilio explicitly states they do not offer additional credits to startups at this time.",
       "previous_state": "12 months of product credit, mentoring, and networking for startups",
       "current_state": "Program discontinued — no startup credits available",
-      "impact": "negative",
+      "impact": "high",
       "source_url": "https://www.twilio.com/en-us/startups",
       "category": "Email",
       "alternatives": [
@@ -4485,7 +4485,7 @@
       "summary": "Prospect.io startup deal via JoinSecret removed. joinsecret.com returns 403 errors and Prospect.io's own pricing page 404s.",
       "previous_state": "50% on Starter plan for 6 months + 1000 email credits via JoinSecret",
       "current_state": "Product and deal page both inaccessible — removed from index",
-      "impact": "negative",
+      "impact": "low",
       "source_url": "",
       "category": "Email",
       "alternatives": [
@@ -4503,7 +4503,7 @@
       "summary": "Kluster AI removed from index. Public pricing page shows a code review product ($30/month), not batch LLM inference. The $5 free credits for open-source model inference cannot be verified from any public page.",
       "previous_state": "$5 free credits for open-source model inference (DeepSeek-R1, Llama 3.3/3.1, Gemma 3)",
       "current_state": "Free credits offer unverifiable — removed from index",
-      "impact": "negative",
+      "impact": "low",
       "source_url": "https://kluster.ai/pricing",
       "category": "AI / ML",
       "alternatives": [
@@ -4521,7 +4521,7 @@
       "summary": "Homepage returns HTTP 502. Removed from index.",
       "previous_state": "Free 2 indices and 20 MB storage (hosted Elasticsearch)",
       "current_state": "Site unreachable (HTTP 502), service appears discontinued — removed from index",
-      "impact": "negative",
+      "impact": "low",
       "source_url": "",
       "category": "Search",
       "alternatives": [

--- a/data/page-reviews.json
+++ b/data/page-reviews.json
@@ -1402,9 +1402,9 @@
       "reviewer": null,
       "review_outcome": null,
       "review_note": null,
-      "reads_index": false,
+      "reads_index": true,
       "reads_changes": true,
-      "data_source": "unsourced",
+      "data_source": "catalogue",
       "data_source_reason": null
     },
     {

--- a/data/quality_budgets.json
+++ b/data/quality_budgets.json
@@ -2,7 +2,7 @@
   "version": 1,
   "budgets": {
     "stale_fact_pages": 57,
-    "unsourced_tier_a": 41,
+    "unsourced_tier_a": 40,
     "uncited_change_records": 98,
     "source_checks_ok_without_quoted_evidence": 614,
     "faq_answers": 166,

--- a/scripts/mutate-1409.mjs
+++ b/scripts/mutate-1409.mjs
@@ -1,0 +1,131 @@
+import { readFileSync, writeFileSync } from "node:fs";
+import { execFileSync } from "node:child_process";
+
+const SUITE = [
+  "test/compiled-comparison-figures.test.ts",
+];
+
+const MUTANTS = [
+  ["join-ignores-the-compile-date", "src/compiled-figures.ts",
+    `    .filter(change => change.date > compiledOn && change.date <= servedOn)`,
+    `    .filter(change => change.date <= servedOn)`],
+  ["join-admits-a-record-not-yet-in-force", "src/compiled-figures.ts",
+    `    .filter(change => change.date > compiledOn && change.date <= servedOn)`,
+    `    .filter(change => change.date > compiledOn)`],
+  ["join-orders-the-records-oldest-first", "src/compiled-figures.ts",
+    `    .sort((a, b) => b.date.localeCompare(a.date));`,
+    `    .sort((a, b) => a.date.localeCompare(b.date));`],
+  ["marker-is-never-drawn", "src/compiled-figures.ts",
+    `    if (!verdict.freeTierEnded && verdict.since.length === 0) continue;`,
+    `    if (!verdict.freeTierEnded || verdict.since.length >= 0) continue;`],
+  ["marker-is-drawn-on-every-slot", "src/compiled-figures.ts",
+    `    if (!verdict.freeTierEnded && verdict.since.length === 0) continue;`,
+    `    if (false) continue;`],
+  ["ended-row-keeps-its-figures", "src/compiled-figures.ts",
+    `        verdict.freeTierEnded && !slot.alreadyStatesRemoval
+          ? withEndedRowCells(withProvider, cellEndInRow + shift)
+          : withProvider,`,
+    `        withProvider,`],
+  ["ended-card-quotes-the-newest-record-rather-than-the-ending", "src/compiled-figures.ts",
+    `  const ending = verdict.endedBy;`,
+    `  const ending = verdict.since[0] ?? null;`],
+  ["ending-record-is-never-passed", "src/serve.ts",
+    `    endedBy: ending
+      ? { date: ending.date, summary: ending.summary, dateClause: changeDateClause(ending) }
+      : null,`,
+    `    endedBy: null,`],
+  ["ended-card-keeps-the-free-tier-it-states", "src/compiled-figures.ts",
+    `      if (!verdict.freeTierEnded || slot.alreadyStatesRemoval) continue;`,
+    `      if (verdict.since.length >= 0) continue;`],
+  ["ended-slot-reads-as-a-change-rather-than-an-ending", "src/compiled-figures.ts",
+    `    const badge = verdict.freeTierEnded
+      ? endedBadgeHtml(verdict)
+      : recordedSinceBadgeHtml(verdict, options);`,
+    `    const badge = verdict.freeTierEnded && verdict.since.length === 0
+      ? endedBadgeHtml(verdict)
+      : recordedSinceBadgeHtml(verdict, options);`],
+  ["marker-is-drawn-below-the-timeline-heading-too", "src/compiled-figures.ts",
+    `  const timeline = TIMELINE_HEADING.exec(html);
+  return timeline ? html.slice(0, timeline.index) : html;`,
+    `  return html;`],
+  ["card-subject-keeps-its-tagline", "src/compiled-figures.ts",
+    `  const withoutTagline = heading.split(SUBJECT_TAGLINE)[0]!.trim();`,
+    `  const withoutTagline = heading.trim();`],
+  ["card-subject-keeps-its-qualifier", "src/compiled-figures.ts",
+    `  const qualified = withoutTagline.match(TRAILING_QUALIFIER);
+  return (qualified ? qualified[1]! : withoutTagline).trim();`,
+    `  return withoutTagline.trim();`],
+  ["compared-services-counts-a-repeat-twice", "src/compiled-figures.ts",
+    `    if (slot.label !== "") named.add(slot.label);`,
+    `    if (slot.label !== "") named.add(slot.label + String(named.size));`],
+  ["compared-services-counts-the-cards-too", "src/compiled-figures.ts",
+    `    if (slot.kind !== "row") continue;`,
+    `    if (slot.kind === "card" && false) continue;`],
+  ["impact-scale-admits-any-string", "src/change-impact.ts",
+    `  return typeof impact === "string" && (CHANGE_IMPACT_LEVELS as readonly string[]).includes(impact);`,
+    `  return typeof impact === "string";`],
+  ["ungraded-impact-takes-the-lowest-grade-colour", "src/change-impact.ts",
+    `  return isChangeImpactLevel(impact) ? IMPACT_COLOR[impact] : UNGRADED_IMPACT_COLOR;`,
+    `  return isChangeImpactLevel(impact) ? IMPACT_COLOR[impact] : IMPACT_COLOR.low;`],
+  ["ungraded-impact-prints-itself-as-a-grade", "src/change-impact.ts",
+    `  return isChangeImpactLevel(impact) ? impact.toUpperCase() : UNGRADED_IMPACT_LABEL;`,
+    `  return String(impact ?? "").toUpperCase();`],
+  ["card-heading-resolves-through-a-generalisation", "src/compiled-figures.ts",
+    `  if (resolution.type === "redirect" && resolution.slug.startsWith(slug + "-")) return resolution.slug;`,
+    `  if (resolution.type === "redirect") return resolution.slug;`],
+  ["subject-never-resolves-from-the-link-the-page-carries", "src/compiled-figures.ts",
+    `  if (subject.linkedSlug && vendorSlugMap.has(subject.linkedSlug)) return subject.linkedSlug;`,
+    `  if (subject.linkedSlug && false) return subject.linkedSlug;`],
+  ["subject-trusts-a-link-the-catalogue-does-not-hold", "src/compiled-figures.ts",
+    `  if (subject.linkedSlug && vendorSlugMap.has(subject.linkedSlug)) return subject.linkedSlug;`,
+    `  if (subject.linkedSlug) return subject.linkedSlug;`],
+  ["subject-reads-a-card-heading-as-loosely-as-a-row", "src/compiled-figures.ts",
+    `  if (subject.kind === "card") return slugNamedByHeading(subject.label);`,
+    `  if (subject.kind === "card" && false) return slugNamedByHeading(subject.label);`],
+  ["timeline-drops-the-vendors-the-page-names", "src/compiled-figures.ts",
+    `  for (const subject of subjects) {
+    const vendor = vendorNameForSubject(subject);
+    if (!vendor) continue;
+    for (const change of changesForVendor(vendor)) timeline.add(change);
+  }`,
+    `  for (const subject of subjects) void subject;`],
+  ["timeline-forgets-the-scope-the-page-declares", "src/compiled-figures.ts",
+    `  const timeline = new Set<T>(declaredScope);`,
+    `  const timeline = new Set<T>();`],
+  ["timeline-takes-the-oldest-records", "src/compiled-figures.ts",
+    `  return [...timeline].sort((a, b) => b.date.localeCompare(a.date)).slice(0, limit);`,
+    `  return [...timeline].sort((a, b) => a.date.localeCompare(b.date)).slice(0, limit);`],
+  ["timeline-ignores-its-row-limit", "src/compiled-figures.ts",
+    `  return [...timeline].sort((a, b) => b.date.localeCompare(a.date)).slice(0, limit);`,
+    `  return [...timeline].sort((a, b) => b.date.localeCompare(a.date));`],
+  ["services-compared-is-never-filled-in", "src/compiled-figures.ts",
+    `  if (!html.includes(COMPARED_SERVICES_PLACEHOLDER)) return html;`,
+    `  return html;`],
+];
+
+function run(cmd, args) {
+  try {
+    execFileSync(cmd, args, { stdio: "pipe", encoding: "utf-8" });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+const survivors = [];
+for (const [name, file, from, to] of MUTANTS) {
+  const original = readFileSync(file, "utf-8");
+  if (!original.includes(from)) {
+    console.log(`SKIP  ${name} — the line it mutates is not in ${file}`);
+    continue;
+  }
+  writeFileSync(file, original.replace(from, to));
+  const built = run("npm", ["run", "build"]);
+  const green = built && run("node", ["--test", "--test-concurrency", "1", ...SUITE]);
+  writeFileSync(file, original);
+  console.log(`${green ? "SURVIVED" : built ? "killed  " : "killed (did not compile)"}  ${name}`);
+  if (green) survivors.push(name);
+}
+run("npm", ["run", "build"]);
+console.log(`\n${MUTANTS.length - survivors.length}/${MUTANTS.length} killed`);
+if (survivors.length > 0) console.log("survivors:", survivors.join(", "));

--- a/scripts/validate-data.ts
+++ b/scripts/validate-data.ts
@@ -4,6 +4,7 @@ import { readFileSync } from "fs";
 import { resolve, dirname } from "path";
 import { fileURLToPath } from "url";
 import { summaryCallsItsSourceUnreadable } from "../dist/change-citation.js";
+import { CHANGE_IMPACT_LEVELS, isChangeImpactLevel } from "../dist/change-impact.js";
 import {
   CHANGE_REPORT_RULE,
   CHANGE_REPORT_SUBJECTS,
@@ -288,6 +289,19 @@ function validateDealChanges(changes: DealChange[]): ValidationError[] {
         vendor,
         field: "date_source",
         message: `Unknown date_source "${change.date_source}". Valid: ${VALID_DATE_SOURCES.join(", ")}`,
+      });
+    }
+
+    if (change.impact !== undefined && change.impact !== null && !isChangeImpactLevel(change.impact)) {
+      errors.push({
+        file: "data/deal_changes.json",
+        index: i,
+        vendor,
+        field: "impact",
+        message:
+          `Unknown impact "${change.impact}". Valid: ${CHANGE_IMPACT_LEVELS.join(", ")}. ` +
+          `Every surface that colours a change reads impact as a severity grade, and a value outside ` +
+          `this set renders as no grade at all.`,
       });
     }
 

--- a/src/change-impact.ts
+++ b/src/change-impact.ts
@@ -1,0 +1,38 @@
+export const CHANGE_IMPACT_LEVELS = ["high", "medium", "low"] as const;
+
+export type ChangeImpactLevel = (typeof CHANGE_IMPACT_LEVELS)[number];
+
+const IMPACT_COLOR: Record<ChangeImpactLevel, string> = {
+  high: "#f85149",
+  medium: "#d29922",
+  low: "#3fb950",
+};
+
+export const UNGRADED_IMPACT_COLOR = "#8b949e";
+
+export const UNGRADED_IMPACT_LABEL = "UNGRADED";
+
+export function isChangeImpactLevel(impact: unknown): impact is ChangeImpactLevel {
+  return typeof impact === "string" && (CHANGE_IMPACT_LEVELS as readonly string[]).includes(impact);
+}
+
+export function changeImpactColor(impact: unknown): string {
+  return isChangeImpactLevel(impact) ? IMPACT_COLOR[impact] : UNGRADED_IMPACT_COLOR;
+}
+
+export function changeImpactLabel(impact: unknown): string {
+  return isChangeImpactLevel(impact) ? impact.toUpperCase() : UNGRADED_IMPACT_LABEL;
+}
+
+export function changeImpactWord(impact: unknown): string {
+  return isChangeImpactLevel(impact) ? impact : UNGRADED_IMPACT_LABEL.toLowerCase();
+}
+
+export function ungradedImpactValues(changes: readonly { impact?: unknown }[]): string[] {
+  const seen = new Set<string>();
+  for (const change of changes) {
+    if (isChangeImpactLevel(change.impact)) continue;
+    seen.add(change.impact === undefined || change.impact === null ? "" : String(change.impact));
+  }
+  return [...seen].sort();
+}

--- a/src/compiled-figures.ts
+++ b/src/compiled-figures.ts
@@ -1,0 +1,339 @@
+import { assertedVendorSlugs, isNonVendorSubject, resolveVendorSlug, toSlug, vendorSlugMap } from "./vendor-slug.js";
+
+export interface CompiledPageRecord {
+  date: string;
+  summary: string;
+  dateClause?: string;
+}
+
+function recordDateClause(record: CompiledPageRecord): string {
+  return record.dateClause ?? `on ${record.date}`;
+}
+
+export function recordsSinceCompiled<T extends { date: string }>(
+  vendorChanges: readonly T[],
+  compiledOn: string,
+  servedOn: string,
+): T[] {
+  return vendorChanges
+    .filter(change => change.date > compiledOn && change.date <= servedOn)
+    .sort((a, b) => b.date.localeCompare(a.date));
+}
+
+export interface CompiledFigureSubject {
+  kind: "row" | "card";
+  label: string;
+  linkedSlug: string | null;
+}
+
+export interface CompiledFigureVerdict {
+  slug: string;
+  vendor: string;
+  freeTierEnded: boolean;
+  endedBy: CompiledPageRecord | null;
+  since: readonly CompiledPageRecord[];
+}
+
+export type CompiledFigureLookup = (subject: CompiledFigureSubject) => CompiledFigureVerdict | null;
+
+export interface CompiledFigureMarkupOptions {
+  compiledOn: string;
+  esc: (text: string) => string;
+  shortDate: (isoDate: string) => string;
+}
+
+const TIMELINE_HEADING = /<h2\b[^>]*\bid="changes"/;
+const PROVIDER_CELL = /<td\b[^>]*class="[^"]*\bprovider-col\b[^"]*"[^>]*>([\s\S]*?)<\/td>/g;
+const CARD_HEADING = /<div\b[^>]*class="[^"]*\bdiff-card\b[^"]*"[^>]*>\s*<h3\b[^>]*>([\s\S]*?)<\/h3>/g;
+const CARD_DESCRIPTION = /<(div|p)\b[^>]*class="[^"]*\bdiff-desc\b[^"]*"[^>]*>[\s\S]*?<\/\1>/;
+const VENDOR_LINK = /href="\/vendor\/([a-z0-9][a-z0-9-]*)"/;
+const DECORATION_SPAN = /<span\b[^>]*class="[^"]*\b(?:winner|caution|removed|pick)-badge\b[^"]*"[^>]*>[\s\S]*?<\/span>/g;
+const ROW_CELL = /<td\b[^>]*>[\s\S]*?<\/td>/g;
+const REMOVED_BADGE = /class="[^"]*\bremoved-badge\b[^"]*"/;
+const RECORD_MARKER = /<a\b[^>]*href="\/vendor\/[a-z0-9-]+#changes"[^>]*>[\s\S]*?<\/a>/g;
+const TRAILING_QUALIFIER = /^(.+?)\s*\([^()]*\)$/;
+const SUBJECT_TAGLINE = /\s+[—–:]\s+/;
+const TIMELINE_BODY = /(<h2\b[^>]*\bid="changes"(?:(?!<\/table>)[\s\S])*?<tbody>)([\s\S]*?)(<\/tbody>)/;
+
+export function staticHalfOf(html: string): string {
+  const timeline = TIMELINE_HEADING.exec(html);
+  return timeline ? html.slice(0, timeline.index) : html;
+}
+
+function undecorated(fragment: string): string {
+  return fragment.replace(RECORD_MARKER, " ").replace(DECORATION_SPAN, " ");
+}
+
+function plainText(fragment: string): string {
+  return fragment
+    .replace(/<[^>]*>/g, " ")
+    .replace(/&amp;/g, "&")
+    .replace(/&rsquo;|&#8217;/g, "’")
+    .replace(/&mdash;/g, "—")
+    .replace(/&[a-z]+;/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+export function subjectOfCardHeading(heading: string): string {
+  const withoutTagline = heading.split(SUBJECT_TAGLINE)[0]!.trim();
+  const qualified = withoutTagline.match(TRAILING_QUALIFIER);
+  return (qualified ? qualified[1]! : withoutTagline).trim();
+}
+
+function subjectOfProviderCell(cell: string): string {
+  const qualified = cell.match(TRAILING_QUALIFIER);
+  return (qualified ? qualified[1]! : cell).trim();
+}
+
+interface DiscoveredSlot extends CompiledFigureSubject {
+  start: number;
+  end: number;
+  inner: string;
+  innerStart: number;
+  alreadyStatesRemoval: boolean;
+}
+
+function discoverSlots(staticHtml: string): DiscoveredSlot[] {
+  const slots: DiscoveredSlot[] = [];
+
+  const cells = new RegExp(PROVIDER_CELL.source, "g");
+  let cell: RegExpExecArray | null;
+  while ((cell = cells.exec(staticHtml)) !== null) {
+    const inner = cell[1]!;
+    const linked = inner.match(VENDOR_LINK);
+    slots.push({
+      kind: "row",
+      label: subjectOfProviderCell(plainText(undecorated(inner))),
+      linkedSlug: linked ? linked[1]! : null,
+      start: cell.index,
+      end: cell.index + cell[0].length,
+      inner,
+      innerStart: cell.index + cell[0].indexOf(inner),
+      alreadyStatesRemoval: REMOVED_BADGE.test(inner.replace(RECORD_MARKER, "")),
+    });
+  }
+
+  const headings = new RegExp(CARD_HEADING.source, "g");
+  let heading: RegExpExecArray | null;
+  while ((heading = headings.exec(staticHtml)) !== null) {
+    const inner = heading[1]!;
+    const linked = inner.match(VENDOR_LINK);
+    slots.push({
+      kind: "card",
+      label: subjectOfCardHeading(plainText(undecorated(inner))),
+      linkedSlug: linked ? linked[1]! : null,
+      start: heading.index,
+      end: heading.index + heading[0].length,
+      inner,
+      innerStart: heading.index + heading[0].indexOf(inner),
+      alreadyStatesRemoval: REMOVED_BADGE.test(inner.replace(RECORD_MARKER, "")),
+    });
+  }
+
+  return slots.sort((a, b) => a.start - b.start);
+}
+
+export interface CompiledFigureSlot extends CompiledFigureSubject {
+  markup: string;
+}
+
+export function compiledFigureSlots(html: string): CompiledFigureSlot[] {
+  return discoverSlots(staticHalfOf(html)).map(({ kind, label, linkedSlug, inner }) => ({
+    kind,
+    label,
+    linkedSlug,
+    markup: inner,
+  }));
+}
+
+export function vendorSubjectsOnCompiledPage(html: string): CompiledFigureSubject[] {
+  return compiledFigureSlots(html).map(({ kind, label, linkedSlug }) => ({ kind, label, linkedSlug }));
+}
+
+const FREE_TIER_REMOVED_LABEL = "FREE REMOVED";
+
+function endedBadgeHtml(verdict: CompiledFigureVerdict): string {
+  return (
+    ` <a href="/vendor/${verdict.slug}#changes" class="removed-badge"` +
+    ` title="Our own change log records that the ${verdict.vendor} free tier has ended.">` +
+    `${FREE_TIER_REMOVED_LABEL}</a>`
+  );
+}
+
+const RECORDED_SINCE_STYLE =
+  "display:inline-block;background:rgba(210,153,34,0.15);color:#d29922;font-size:.65rem;" +
+  "font-weight:700;padding:.1rem .35rem;border-radius:4px;margin-left:.35rem;letter-spacing:.03em";
+
+function recordedSinceBadgeHtml(
+  verdict: CompiledFigureVerdict,
+  options: CompiledFigureMarkupOptions,
+): string {
+  const latest = verdict.since[0]!;
+  const count = verdict.since.length;
+  const title =
+    `We recorded ${count === 1 ? "a pricing change" : `${count} pricing changes`} for ${verdict.vendor} ` +
+    `after this table was compiled on ${options.compiledOn}. The most recent, ${recordDateClause(latest)}: ${latest.summary}`;
+  return (
+    ` <a href="/vendor/${verdict.slug}#changes" style="${RECORDED_SINCE_STYLE}"` +
+    ` title="${options.esc(title)}">CHANGED ${options.esc(options.shortDate(latest.date).toUpperCase())}</a>`
+  );
+}
+
+const STRUCK_STYLE = "color:var(--text-dim);text-decoration:line-through";
+
+function struck(inner: string): string {
+  return `<span style="${STRUCK_STYLE}">${inner}</span>`;
+}
+
+function withEndedRowCells(row: string, providerCellEnd: number): string {
+  const rest = row.slice(providerCellEnd);
+  const cells = new RegExp(ROW_CELL.source, "g");
+  return (
+    row.slice(0, providerCellEnd) +
+    rest.replace(cells, whole => {
+      const openEnd = whole.indexOf(">") + 1;
+      const closeStart = whole.lastIndexOf("</td>");
+      const inner = whole.slice(openEnd, closeStart);
+      if (inner.trim() === "") return whole;
+      return `${whole.slice(0, openEnd)}${struck(inner)}${whole.slice(closeStart)}`;
+    })
+  );
+}
+
+function endedCardDescriptionHtml(
+  verdict: CompiledFigureVerdict,
+  options: CompiledFigureMarkupOptions,
+  tag: string,
+): string {
+  const ending = verdict.endedBy;
+  const recorded = ending
+    ? `Our own pricing change record, ${options.esc(recordDateClause(ending))}, says: ${options.esc(ending.summary)}`
+    : `Our own change log records that the ${options.esc(verdict.vendor)} free tier has ended.`;
+  return (
+    `<${tag} class="diff-desc"><strong>Free tier:</strong> none. ${recorded} ` +
+    `<a href="/vendor/${verdict.slug}#changes">Read what we recorded &rarr;</a></${tag}>`
+  );
+}
+
+export function markCompiledFigures(
+  html: string,
+  lookup: CompiledFigureLookup,
+  options: CompiledFigureMarkupOptions,
+): string {
+  const staticHtml = staticHalfOf(html);
+  const edits: Array<{ start: number; end: number; text: string }> = [];
+
+  for (const slot of discoverSlots(staticHtml)) {
+    const verdict = lookup({ kind: slot.kind, label: slot.label, linkedSlug: slot.linkedSlug });
+    if (!verdict) continue;
+    if (!verdict.freeTierEnded && verdict.since.length === 0) continue;
+
+    const badge = verdict.freeTierEnded
+      ? endedBadgeHtml(verdict)
+      : recordedSinceBadgeHtml(verdict, options);
+
+    if (slot.kind === "card") {
+      edits.push({ start: slot.innerStart + slot.inner.length, end: slot.innerStart + slot.inner.length, text: badge });
+      if (!verdict.freeTierEnded || slot.alreadyStatesRemoval) continue;
+      const description = CARD_DESCRIPTION.exec(staticHtml.slice(slot.end, slot.end + 6000));
+      if (!description) continue;
+      edits.push({
+        start: slot.end + description.index,
+        end: slot.end + description.index + description[0].length,
+        text: endedCardDescriptionHtml(verdict, options, description[1]!),
+      });
+      continue;
+    }
+
+    const rowStart = staticHtml.lastIndexOf("<tr", slot.start);
+    const rowEnd = staticHtml.indexOf("</tr>", slot.end);
+    if (rowStart < 0 || rowEnd < 0) continue;
+    const row = staticHtml.slice(rowStart, rowEnd + "</tr>".length);
+    const cellEndInRow = slot.end - rowStart;
+    const inner = slot.inner;
+    const markedProvider = verdict.freeTierEnded
+      ? struck(inner.replace(DECORATION_SPAN, "")) + badge
+      : inner + badge;
+    const withProvider =
+      row.slice(0, slot.innerStart - rowStart) + markedProvider + row.slice(slot.innerStart - rowStart + inner.length);
+    const shift = withProvider.length - row.length;
+    edits.push({
+      start: rowStart,
+      end: rowEnd + "</tr>".length,
+      text:
+        verdict.freeTierEnded && !slot.alreadyStatesRemoval
+          ? withEndedRowCells(withProvider, cellEndInRow + shift)
+          : withProvider,
+    });
+  }
+
+  edits.sort((a, b) => a.start - b.start);
+  let out = "";
+  let cursor = 0;
+  for (const edit of edits) {
+    if (edit.start < cursor) continue;
+    out += html.slice(cursor, edit.start) + edit.text;
+    cursor = edit.end;
+  }
+  return out + html.slice(cursor);
+}
+
+export function vendorSlugForSubject(subject: CompiledFigureSubject): string | null {
+  if (subject.linkedSlug && vendorSlugMap.has(subject.linkedSlug)) return subject.linkedSlug;
+  if (isNonVendorSubject(subject.label)) return null;
+  if (subject.kind === "card") return slugNamedByHeading(subject.label);
+  const asserted = assertedVendorSlugs(subject.label);
+  return asserted.length === 1 ? asserted[0]! : null;
+}
+
+function slugNamedByHeading(label: string): string | null {
+  const slug = toSlug(label);
+  if (!slug) return null;
+  const resolution = resolveVendorSlug(slug);
+  if (resolution.type === "exact") return resolution.slug;
+  if (resolution.type === "redirect" && resolution.slug.startsWith(slug + "-")) return resolution.slug;
+  return null;
+}
+
+export function vendorNameForSubject(subject: CompiledFigureSubject): string | null {
+  const slug = vendorSlugForSubject(subject);
+  return slug ? vendorSlugMap.get(slug) ?? null : null;
+}
+
+export function timelineRecordsFor<T extends { date: string }>(
+  declaredScope: readonly T[],
+  subjects: readonly CompiledFigureSubject[],
+  changesForVendor: (vendor: string) => readonly T[],
+  limit: number,
+): T[] {
+  const timeline = new Set<T>(declaredScope);
+  for (const subject of subjects) {
+    const vendor = vendorNameForSubject(subject);
+    if (!vendor) continue;
+    for (const change of changesForVendor(vendor)) timeline.add(change);
+  }
+  return [...timeline].sort((a, b) => b.date.localeCompare(a.date)).slice(0, limit);
+}
+
+export const COMPARED_SERVICES_PLACEHOLDER = '<span data-compared-services=""></span>';
+
+export function comparedServicesOn(html: string): string[] {
+  const named = new Set<string>();
+  for (const slot of discoverSlots(staticHalfOf(html))) {
+    if (slot.kind !== "row") continue;
+    if (slot.label !== "") named.add(slot.label);
+  }
+  return [...named].sort();
+}
+
+export function fillComparedServicesCount(html: string): string {
+  if (!html.includes(COMPARED_SERVICES_PLACEHOLDER)) return html;
+  return html.split(COMPARED_SERVICES_PLACEHOLDER).join(String(comparedServicesOn(html).length));
+}
+
+export function replaceTimelineRows(html: string, rowsHtml: string): string {
+  return html.replace(TIMELINE_BODY, (whole, open: string, _body: string, close: string) =>
+    rowsHtml.trim() === "" ? whole : `${open}\n        ${rowsHtml}\n      ${close}`,
+  );
+}

--- a/src/serve.ts
+++ b/src/serve.ts
@@ -28,6 +28,8 @@ import { buildComparisonMap, comparisonSlug } from "./comparison-pairs.js";
 import { comparisonVerdictText, freeTierFaqAnswer, stabilityFaqAnswer, type ComparisonSide, type FreeTierSide, type SideFreeTier, type StabilityRating } from "./comparison-verdict.js";
 import { publishedVendorLevel, vendorVerdictSentence, vendorBadge, freeTierClaim, statesRiskCause, narrowingSentence, changeKindNoun, type BadgeWithholding, type FreeTierClaim, type VendorVerdictInput } from "./vendor-verdict.js";
 import { tierRecordsAFreeTier } from "./free-tier-record.js";
+import { UNGRADED_IMPACT_COLOR, changeImpactColor, changeImpactLabel, changeImpactWord, isChangeImpactLevel } from "./change-impact.js";
+import { COMPARED_SERVICES_PLACEHOLDER, fillComparedServicesCount, markCompiledFigures, recordsSinceCompiled, replaceTimelineRows, timelineRecordsFor, vendorSlugForSubject, vendorSubjectsOnCompiledPage, type CompiledFigureSubject, type CompiledFigureVerdict } from "./compiled-figures.js";
 import { vendorHistorySentence } from "./vendor-history.js";
 import { HETZNER_APRIL_CHANGES, HETZNER_CLOUD_PLANS, HETZNER_PRICES_READ, HETZNER_PRICE_SOURCE, HETZNER_SINGAPORE_EXAMPLE, cheapestOrderableHetznerPlan, hetznerEntryPriceClause, unorderableHetznerPlans } from "./hetzner-pricing.js";
 import { changeTimelineDate, supersededLineups, supersessionNote } from "./change-lineup.js";
@@ -637,7 +639,7 @@ function buildDeadlinesHtml(): string {
     const daysLeft = Math.ceil((deadlineDate.getTime() - todayDate.getTime()) / 86400000);
     const urgentClass = daysLeft <= 14 ? " deadline-urgent" : "";
     const daysLabel = daysLeft === 1 ? "1 day" : `${daysLeft} days`;
-    const impactColor = c.impact === "high" ? "#f85149" : c.impact === "medium" ? "#d29922" : "#8b949e";
+    const impactColor = changeImpactColor(c.impact);
     return `      <div class="deadline-item${urgentClass}">
         <div class="deadline-left">
           <div class="deadline-countdown" style="border-color:${impactColor}"><span class="deadline-days">${daysLeft}</span><span class="deadline-unit">${daysLeft === 1 ? "day" : "days"}</span></div>
@@ -895,6 +897,73 @@ function buildVendorVerdictContext(vendorName: string, servedOn: string): Vendor
 function freeTierClaimFor(vendorName: string, servedOn: string): FreeTierClaim | null {
   const context = vendorVerdictContext(vendorName, servedOn);
   return context ? freeTierClaim(context.input) : null;
+}
+
+function recordsSinceCompiledFor(vendorName: string, compiledOn: string): DealChange[] {
+  return recordsSinceCompiled(changesFor(vendorName), compiledOn, today);
+}
+
+function compiledFigureVerdictFor(
+  subject: CompiledFigureSubject,
+  compiledOn: string,
+): CompiledFigureVerdict | null {
+  const slug = vendorSlugForSubject(subject);
+  if (!slug) return null;
+  const vendor = vendorSlugMap.get(slug);
+  if (!vendor) return null;
+  const claim = freeTierClaimFor(vendor, today);
+  const ending = claim?.states === "ended" && claim.how === "removed" ? claim.cause : null;
+  return {
+    slug,
+    vendor,
+    freeTierEnded: claim?.states === "ended",
+    endedBy: ending
+      ? { date: ending.date, summary: ending.summary, dateClause: changeDateClause(ending) }
+      : null,
+    since: recordsSinceCompiledFor(vendor, compiledOn).map(c => ({
+      date: c.date,
+      summary: c.summary,
+      dateClause: changeDateClause(c),
+    })),
+  };
+}
+
+function changeTimelineRowsHtml(changes: readonly DealChange[]): string {
+  return changes.map(c => {
+    const dateStr = new Date(c.date).toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" });
+    return `<tr>
+      <td style="font-family:var(--mono);font-size:.8rem;white-space:nowrap">${escHtmlServer(dateStr)}</td>
+      <td style="font-weight:600">${escHtmlServer(c.vendor)}</td>
+      <td style="font-size:.85rem">${escHtmlServer(c.summary)}</td>
+      <td><span style="color:${changeImpactColor(c.impact)};font-size:.8rem;font-weight:600">${escHtmlServer(changeImpactLabel(c.impact))}</span></td>
+    </tr>`;
+  }).join("\n        ");
+}
+
+const TIMELINE_ROW_LIMIT = 12;
+
+function shortChangeDate(isoDate: string): string {
+  return new Date(isoDate).toLocaleDateString("en-US", { month: "short", day: "numeric", timeZone: "UTC" });
+}
+
+function comparisonPageWithLiveRecords(
+  html: string,
+  compiledOn: string,
+  declaredScope: readonly DealChange[],
+): string {
+  const marked = markCompiledFigures(html, subject => compiledFigureVerdictFor(subject, compiledOn), {
+    compiledOn,
+    esc: escHtmlServer,
+    shortDate: shortChangeDate,
+  });
+
+  const rows = timelineRecordsFor(
+    declaredScope,
+    vendorSubjectsOnCompiledPage(html),
+    changesFor,
+    TIMELINE_ROW_LIMIT,
+  );
+  return fillComparedServicesCount(replaceTimelineRows(marked, changeTimelineRowsHtml(rows)));
 }
 
 interface FreeTierCensus {
@@ -2737,7 +2806,7 @@ function buildComparisonPage(slug: string): string | null {
         <div style="display:flex;align-items:center;gap:.5rem;margin-bottom:.25rem">
           <span style="display:inline-block;padding:.1rem .4rem;border-radius:10px;font-size:.65rem;font-weight:600;background:${badge.color};color:#fff">${badge.label}</span>
           <span style="font-family:var(--mono);font-size:.75rem;color:var(--text-dim)">${changeDateLabel(c)}</span>
-          <span style="font-size:.7rem;color:${c.impact === "high" ? "#f85149" : c.impact === "medium" ? "#d29922" : "#8b949e"}">${c.impact} impact</span>
+          <span style="font-size:.7rem;color:${changeImpactColor(c.impact)}">${c.impact} impact</span>
           ${changeIsUncited(c) ? unsourcedTagHtml() : ""}
         </div>
         <div style="font-size:.85rem;color:var(--text-muted)">${escHtmlServer(c.summary)}</div>
@@ -3248,7 +3317,7 @@ function buildVsPage(slug: string): string | null {
         <div style="display:flex;align-items:center;gap:.5rem;margin-bottom:.25rem">
           <span style="display:inline-block;padding:.1rem .4rem;border-radius:10px;font-size:.65rem;font-weight:600;background:${badge.color};color:#fff">${badge.label}</span>
           <span style="font-family:var(--mono);font-size:.75rem;color:var(--text-dim)">${changeDateLabel(c)}</span>
-          <span style="font-size:.7rem;color:${c.impact === "high" ? "#f85149" : c.impact === "medium" ? "#d29922" : "#8b949e"}">${c.impact} impact</span>
+          <span style="font-size:.7rem;color:${changeImpactColor(c.impact)}">${c.impact} impact</span>
           ${changeIsUncited(c) ? unsourcedTagHtml() : ""}
         </div>
         <div style="font-size:.85rem;color:var(--text-muted)">${escHtmlServer(c.summary)}</div>
@@ -3569,13 +3638,13 @@ function buildDigestPage(weekKey: string): string | null {
     <div class="stat-pill"><strong>0</strong> changes</div>${discoveryPill}
   </div>` : "");
 
-  const byImpact: Record<string, typeof changes> = { high: [], medium: [], low: [] };
+  const byImpact: Record<string, typeof changes> = { high: [], medium: [], low: [], ungraded: [] };
   for (const c of changes) {
-    (byImpact[c.impact] ?? byImpact.low).push(c);
+    byImpact[isChangeImpactLevel(c.impact) ? c.impact : "ungraded"].push(c);
   }
 
-  const impactColors = { high: "#f85149", medium: "#d29922", low: "#8b949e" };
-  const impactLabels = { high: "High Impact", medium: "Medium Impact", low: "Low Impact" };
+  const impactColors = { high: "#f85149", medium: "#d29922", low: "#8b949e", ungraded: UNGRADED_IMPACT_COLOR };
+  const impactLabels = { high: "High Impact", medium: "Medium Impact", low: "Low Impact", ungraded: "Impact Not Graded" };
 
   function digestEntry(c: typeof weekRecords[0], borderColor: string): string {
     const badge = changeTypeBadge[c.change_type] ?? { label: c.change_type, color: "#8b949e" };
@@ -3591,7 +3660,7 @@ function buildDigestPage(weekKey: string): string | null {
   }
 
   const changesHtml = changes.length > 0
-    ? (["high", "medium", "low"] as const).filter(level => byImpact[level].length > 0).map(level => `
+    ? (["high", "medium", "low", "ungraded"] as const).filter(level => byImpact[level].length > 0).map(level => `
   <div class="impact-section">
     <h2><span class="impact-dot" style="background:${impactColors[level]}"></span> ${impactLabels[level]} (${byImpact[level].length})</h2>
     ${byImpact[level].sort((a, b) => b.date.localeCompare(a.date)).map(c => digestEntry(c, impactColors[level])).join("\n    ")}
@@ -4383,7 +4452,7 @@ ${enrichedAlts.map(a => {
         <div class="change-head">
           <span class="badge" style="background:${badge.color}">${badge.label}</span>
           <span class="change-date"><a href="/pricing-changes#${anchor}" style="color:var(--text-dim);text-decoration:none">${changeDateLabel(c)}</a></span>
-          <span class="impact impact-${c.impact}">${c.impact} impact</span>
+          <span class="impact impact-${changeImpactWord(c.impact)}">${changeImpactWord(c.impact)} impact</span>
           ${uncited ? unsourcedTagHtml() : ""}
         </div>
         <div class="change-summary">${escHtmlServer(c.summary)}</div>
@@ -4753,7 +4822,7 @@ h1 .risk-badge{font-size:.75rem;font-weight:600;padding:.2rem .6rem;border-radiu
 .change-head{display:flex;align-items:center;gap:.5rem;margin-bottom:.3rem;flex-wrap:wrap}
 .badge{display:inline-block;padding:.1rem .4rem;border-radius:10px;font-size:.65rem;font-weight:600;color:#fff}
 .change-date{font-family:var(--mono);font-size:.75rem;color:var(--text-dim)}
-.impact{font-size:.7rem}.impact-high{color:#f85149}.impact-medium{color:#d29922}.impact-low{color:#8b949e}
+.impact{font-size:.7rem}.impact-high{color:#f85149}.impact-medium{color:#d29922}.impact-low{color:#8b949e}.impact-ungraded{color:#8b949e;font-style:italic}
 .change-summary{font-size:.85rem;color:var(--text-muted)}
 .change-detail{font-size:.8rem;color:var(--text-dim);margin-top:.25rem}
 .state-label{font-family:var(--mono);font-size:.7rem;color:var(--text-dim)}
@@ -4981,7 +5050,7 @@ function buildAlternativesPage(slug: string): string | null {
           <div class="change-head">
             <span class="badge" style="background:${badge.color}">${badge.label}</span>
             <span class="change-date">${changeDateLabel(c)}</span>
-            <span class="impact impact-${c.impact}">${c.impact} impact</span>
+            <span class="impact impact-${changeImpactWord(c.impact)}">${changeImpactWord(c.impact)} impact</span>
           </div>
           <div class="change-summary">${escHtmlServer(c.summary)}</div>
         </div>`;
@@ -5149,7 +5218,7 @@ h3{font-family:var(--serif);font-size:1rem;color:var(--text);margin-bottom:.5rem
 .change-head{display:flex;align-items:center;gap:.5rem;margin-bottom:.2rem;flex-wrap:wrap}
 .badge{display:inline-block;padding:.1rem .4rem;border-radius:10px;font-size:.65rem;font-weight:600;color:#fff}
 .change-date{font-family:var(--mono);font-size:.75rem;color:var(--text-dim)}
-.impact{font-size:.7rem}.impact-high{color:#f85149}.impact-medium{color:#d29922}.impact-low{color:#8b949e}
+.impact{font-size:.7rem}.impact-high{color:#f85149}.impact-medium{color:#d29922}.impact-low{color:#8b949e}.impact-ungraded{color:#8b949e;font-style:italic}
 .change-summary{font-size:.85rem;color:var(--text-muted)}
 .more-link{font-size:.85rem;margin-top:.5rem}
 .section{margin-bottom:2rem;padding-top:1.5rem;border-top:1px solid var(--border)}
@@ -8485,7 +8554,7 @@ function buildEventPage(slug: string): string | null {
           + '<span class="badge" style="background:' + badge.color + '">' + badge.label + '</span>'
           + '<strong>' + escHtmlServer(c.vendor) + '</strong>'
           + '<span class="update-date">' + c.date + '</span>'
-          + '<span class="impact impact-' + c.impact + '">' + c.impact + ' impact</span>'
+          + '<span class="impact impact-' + changeImpactWord(c.impact) + '">' + changeImpactWord(c.impact) + ' impact</span>'
           + '</div>'
           + '<div class="update-summary">' + escHtmlServer(c.summary) + '</div>'
           + '</div>';
@@ -8609,7 +8678,7 @@ function buildEventPage(slug: string): string | null {
     + '.update-summary{font-size:.85rem;color:var(--text-muted)}\n'
     + '.badge{font-size:.65rem;padding:.15rem .4rem;border-radius:3px;color:#fff;font-weight:600;text-transform:uppercase}\n'
     + '.impact{font-size:.7rem;padding:.1rem .3rem;border-radius:3px}\n'
-    + '.impact-high{background:#f8514920;color:#f85149}.impact-medium{background:#d2992220;color:#d29922}.impact-low{background:#3fb95020;color:#3fb950}\n'
+    + '.impact-high{background:#f8514920;color:#f85149}.impact-medium{background:#d2992220;color:#d29922}.impact-low{background:#3fb95020;color:#3fb950}.impact-ungraded{background:#8b949e20;color:#8b949e;font-style:italic}\n'
     + '.comparison-grid{display:flex;flex-wrap:wrap;gap:.5rem}\n'
     + '.comparison-link{font-size:.85rem;padding:.4rem .75rem;border:1px solid var(--border);border-radius:6px;color:var(--text-muted);text-decoration:none;transition:all .15s}\n'
     + '.comparison-link:hover{color:var(--accent);border-color:var(--accent);text-decoration:none}\n'
@@ -22536,6 +22605,58 @@ function buildGeminiApiPricingChangesPage(): string {
     + '</body>\n</html>';
 }
 
+interface RiskEntry {
+  vendor: string;
+  risk: "low" | "medium" | "high" | "dead";
+  category: string;
+  reasoning: string;
+  lastChange?: string;
+  changeType?: string;
+}
+
+const riskEntries: RiskEntry[] = [
+  { vendor: "Cloudflare", risk: "low", category: "Cloud/CDN", reasoning: "Actively expanding free tiers (Workers, Pages, Queues added free Feb 2026). Profitable, no VC subsidy pressure. Free tier is a strategic funnel — core business is paid enterprise CDN.", lastChange: "2026-02-04", changeType: "new_free_tier" },
+  { vendor: "GitHub", risk: "low", category: "Version Control", reasoning: "Microsoft-backed, free tier stable since 2019. Actions self-hosted runner fee was proposed then postponed after backlash (Jan 2026). Track record of expanding, not contracting.", lastChange: "2026-01-01", changeType: "pricing_postponed" },
+  { vendor: "Grafana Cloud", risk: "low", category: "Monitoring", reasoning: "Open-source core (Prometheus, Loki, Tempo). Free tier includes 10K metrics, 50 GB logs, 50 GB traces. Company profitable, recent IPO path. Open-source foundation means community forks prevent lock-in." },
+  { vendor: "CockroachDB", risk: "low", category: "Databases", reasoning: "10 GB free storage, multi-region support. Backed by $633M funding. Free tier is strategic acquisition tool. Serverless model scales naturally." },
+  { vendor: "Auth0", risk: "low", category: "Authentication", reasoning: "Okta-owned (enterprise backing). Limits increased Nov 2025 (25K MAU → expanded). Free tier is developer funnel for enterprise IAM.", lastChange: "2025-11-01", changeType: "limits_increased" },
+  { vendor: "Sentry", risk: "low", category: "Error Tracking", reasoning: "Open-source core. Pricing restructured Aug 2025 but free tier preserved (5K errors/mo). Community edition available as fallback.", lastChange: "2025-08-15", changeType: "pricing_restructured" },
+  { vendor: "Google Cloud (Always Free)", risk: "low", category: "Cloud IaaS", reasoning: "Google Always Free tier unchanged for years — f1-micro VM, 5 GB Cloud Storage, BigQuery 1 TB/mo. Separate from promotional credits. Backed by Alphabet's cloud growth strategy.", lastChange: "2026-01-01", changeType: "limits_increased" },
+  { vendor: "AWS Free Tier", risk: "low", category: "Cloud IaaS", reasoning: "12-month free tier + always-free services (Lambda 1M requests, DynamoDB 25 GB). AWS is the market leader — free tier is a training/onboarding tool, not a cost center. Restructured Jan 2026 but expanded.", lastChange: "2026-01-04", changeType: "pricing_restructured" },
+  { vendor: "GitHub Copilot Free", risk: "low", category: "AI Coding", reasoning: "New free tier launched Dec 2025 (2K completions + 50 chat/mo). Microsoft strategic investment in AI developer tools. Competitive pressure from Cursor/Claude ensures free tier stays.", lastChange: "2025-12-18", changeType: "new_free_tier" },
+  { vendor: "Anthropic", risk: "low", category: "AI/ML APIs", reasoning: "Limits increased Feb 2026 and Mar 2026. Currently in growth mode, well-funded ($7.3B raised). Free API tier is competitive necessity against OpenAI/Google.", lastChange: "2026-03-13", changeType: "limits_increased" },
+
+  { vendor: "Supabase", risk: "medium", category: "Databases/BaaS", reasoning: "Project pause tightened to 1 week inactivity (Feb 2026). Core free tier preserved but signals efficiency pressure. Post-Series C ($80M) — profitable path unclear.", lastChange: "2026-02-01", changeType: "limits_reduced" },
+  { vendor: "Vercel", risk: "medium", category: "Hosting", reasoning: "Restructured to credit-based model (Jan 2026). Free tier still generous for personal projects but commercial use restricted (Hobby plan). Watch for further tightening.", lastChange: "2026-01-01", changeType: "pricing_restructured" },
+  { vendor: "Netlify", risk: "medium", category: "Hosting", reasoning: "Restructured to credit-based pricing (Sep 2025) — sites pause on exhaustion. 300 credits/month is sufficient for small sites but represents a philosophical shift toward metered billing.", lastChange: "2025-09-04", changeType: "pricing_restructured" },
+  { vendor: "Neon", risk: "medium", category: "Databases", reasoning: "Pricing restructured Jan 2026 post-Databricks acquisition. Free tier preserved (0.5 GB/project, 100 projects) but acquisition creates uncertainty about long-term free tier commitment.", lastChange: "2026-01-15", changeType: "pricing_restructured" },
+  { vendor: "Railway", risk: "medium", category: "Hosting/PaaS", reasoning: "Free tier expanded with $100M Series B (Oct 2025). Currently generous ($5 credit, no sleep). But VC-funded PaaS companies have a history of removing free tiers (see: Heroku). Watch burn rate.", lastChange: "2025-10-01", changeType: "limits_increased" },
+  { vendor: "Render", risk: "medium", category: "Hosting/PaaS", reasoning: "Sleep time reduced (Sep 2025) — 15-min spin-down is aggressive. Free PostgreSQL limited to 256 MB with 30-day expiry. Signals tightening, though core free tier intact.", lastChange: "2025-09-01", changeType: "limits_reduced" },
+  { vendor: "Stripe", risk: "medium", category: "Payments", reasoning: "Processing fees restructured Feb 2026 (2.7% + 5¢ domestic card). No free tier per se — pay-per-transaction model. Risk is in rate changes, not tier removal.", lastChange: "2026-02-01", changeType: "pricing_restructured" },
+  { vendor: "Firebase", risk: "medium", category: "BaaS", reasoning: "Multiple changes in 2026: Cloud Storage limits reduced (Feb), Realtime Database EOL announced (Mar), restrictions tightened (Feb). Google consolidating around Firestore. Migration advisable for RTDB users.", lastChange: "2026-03-19", changeType: "product_deprecated" },
+  { vendor: "Docker Hub", risk: "medium", category: "Containers", reasoning: "Rate limits tightened (Dec 2024) — 100 pulls/6h anonymous, 200 authenticated. Docker Desktop commercial license required for large orgs ($5/user/mo+). Free for small teams but trending paid.", lastChange: "2024-12-10", changeType: "pricing_restructured" },
+  { vendor: "Dub.co", risk: "medium", category: "Dev Utilities", reasoning: "Free tier limits reduced sharply (Mar 2026). Link shortener with declining free allowance signals monetization pressure.", lastChange: "2026-03-22", changeType: "limits_reduced" },
+  { vendor: "Google Gemini API", risk: "medium", category: "AI/ML", reasoning: "Free tier rate limits slashed 50-80% (Dec 2025). The flagship Gemini 3.1 Pro is paid-only, though Gemini 2.5 Pro is still free. A Google PM admitted generous limits were only for a promotional weekend. Still has free tier but heavily restricted.", lastChange: "2025-12-15", changeType: "limits_reduced" },
+
+  { vendor: "Heroku", risk: "high", category: "Hosting/PaaS", reasoning: "Free tier removed Nov 2022. Now in 'sustaining mode' under Salesforce — minimal investment, no innovation. The canonical cautionary tale for relying on free tiers.", lastChange: "2022-11-28", changeType: "free_tier_removed" },
+  { vendor: "Fly.io", risk: "high", category: "Hosting", reasoning: "Free tier removed for new accounts in October 2024. New signups get a trial of 2 hours runtime or 7 days, whichever comes first, then pay-as-you-go from the first machine — the smallest is $2.02/month. Only legacy Hobby/Launch/Scale accounts still carry 3 shared-cpu-1x VMs, 3 GB volume storage and 100 GB transfer. Volume snapshots became billable in January 2026.", lastChange: "2024-10-01", changeType: "free_tier_removed" },
+  { vendor: "Postman", risk: "high", category: "API Testing", reasoning: "Team collaboration removed from free tier (Mar 2026). Aggressive monetization of previously-free features. Pattern suggests further restrictions ahead.", lastChange: "2026-03-01", changeType: "restriction" },
+  { vendor: "OpenAI", risk: "high", category: "AI/ML", reasoning: "Multiple free tier reductions: limits cut Jun 2025, further reduced Feb 2026. GPT-4 free access removed. Market leader extracting value — expect continued tightening.", lastChange: "2026-02-09", changeType: "limits_reduced" },
+  { vendor: "HCP Terraform", risk: "high", category: "Infrastructure", reasoning: "Legacy tier EOL March 31, 2026. HashiCorp BSL license change (Aug 2023) already fractured community. IBM acquisition adds enterprise pricing pressure. Migrate to OpenTofu.", lastChange: "2026-03-31", changeType: "pricing_restructured" },
+  { vendor: "LocalStack", risk: "high", category: "Testing", reasoning: "Community Edition shut down March 23, 2026. Complete removal of free/OSS option. Migrate to Moto, aws-sdk-mock, or Testcontainers.", lastChange: "2026-03-23", changeType: "free_tier_removed" },
+  { vendor: "X API (Twitter)", risk: "high", category: "APIs", reasoning: "Free tier removed twice in 2026 (Feb 1 + Feb 9). Pay-per-use only with $10 one-time credit. Unpredictable management. Do not build on this API without paid plan budget.", lastChange: "2026-02-09", changeType: "free_tier_removed" },
+  { vendor: "Brave Search API", risk: "high", category: "Search", reasoning: "Free plan (5K queries/mo) replaced with metered billing Feb 2026. No spending cap — credit cards actively charged. Complete removal of free access.", lastChange: "2026-02-12", changeType: "free_tier_removed" },
+  { vendor: "Spotify API", risk: "high", category: "APIs", reasoning: "Premium subscription now required for dev mode (Feb 2026). Test users cut from 25 to 5. Multiple endpoints deprecated. Hostile to free developers.", lastChange: "2026-02-11", changeType: "limits_reduced" },
+  { vendor: "Amazon SP-API", risk: "high", category: "APIs", reasoning: "Free access ended after 10+ years — now $1,400/year + per-call fees (Apr 2026). Zero warning. Shows even long-stable APIs can go paid overnight.", lastChange: "2026-01-31", changeType: "pricing_restructured" },
+
+  { vendor: "PlanetScale", risk: "dead", category: "Databases", reasoning: "Free tier removed April 2024. Hobby plan eliminated entirely. Migrate to Neon, Turso, or CockroachDB.", lastChange: "2024-04-08", changeType: "free_tier_removed" },
+  { vendor: "Fauna", risk: "dead", category: "Databases", reasoning: "Product deprecated May 2025. Entire service shutting down. Migrate immediately to MongoDB Atlas, CockroachDB, or Supabase.", lastChange: "2025-05-30", changeType: "product_deprecated" },
+  { vendor: "MinIO (OSS)", risk: "dead", category: "Storage", reasoning: "Open-source version killed Feb 2026 (GNU AGPL → proprietary). Self-hosted MinIO is no longer free for production. Use S3-compatible alternatives.", lastChange: "2026-02-12", changeType: "open_source_killed" },
+  { vendor: "SendGrid", risk: "dead", category: "Email", reasoning: "Free tier removed May 2025 under Twilio ownership. Use Resend (3K emails/mo free) or Maileroo (3K/mo); Mailgun and Amazon SES have since dropped their free tiers too.", lastChange: "2025-05-27", changeType: "free_tier_removed" },
+  { vendor: "Logz.io", risk: "dead", category: "Logging", reasoning: "Free tier removed Mar 2026. Use Grafana Cloud (50 GB logs free), Axiom (500 GB/mo), or self-hosted ELK.", lastChange: "2026-03-02", changeType: "free_tier_removed" },
+  { vendor: "Freshping", risk: "dead", category: "Monitoring", reasoning: "Free tier removed Mar 2026. Use BetterStack (10 monitors free), UptimeRobot (50 monitors), or Grafana Cloud synthetics.", lastChange: "2026-03-06", changeType: "free_tier_removed" },
+];
+
 function buildFreeTierRiskPage(): string {
   const title = "Free Tier Risk Index — Predictive Analysis of Which Free Tiers May Disappear Next";
   const metaDesc = "Predictive risk scores for 38 developer tool free tiers — which will disappear next? Category heatmap, pattern analysis from 80 tracked pricing changes, counter-trends, and actionable protection strategies. Updated April 2026.";
@@ -22547,57 +22668,6 @@ function buildFreeTierRiskPage(): string {
   const negativeChanges = dealChanges.filter(c => negativeTypes.includes(c.change_type));
   const positiveChanges = dealChanges.filter(c => positiveTypes.includes(c.change_type));
 
-  interface RiskEntry {
-    vendor: string;
-    risk: "low" | "medium" | "high" | "dead";
-    category: string;
-    reasoning: string;
-    lastChange?: string;
-    changeType?: string;
-  }
-
-  const riskEntries: RiskEntry[] = [
-    { vendor: "Cloudflare", risk: "low", category: "Cloud/CDN", reasoning: "Actively expanding free tiers (Workers, Pages, Queues added free Feb 2026). Profitable, no VC subsidy pressure. Free tier is a strategic funnel — core business is paid enterprise CDN.", lastChange: "2026-02-04", changeType: "new_free_tier" },
-    { vendor: "GitHub", risk: "low", category: "Version Control", reasoning: "Microsoft-backed, free tier stable since 2019. Actions self-hosted runner fee was proposed then postponed after backlash (Jan 2026). Track record of expanding, not contracting.", lastChange: "2026-01-01", changeType: "pricing_postponed" },
-    { vendor: "Grafana Cloud", risk: "low", category: "Monitoring", reasoning: "Open-source core (Prometheus, Loki, Tempo). Free tier includes 10K metrics, 50 GB logs, 50 GB traces. Company profitable, recent IPO path. Open-source foundation means community forks prevent lock-in." },
-    { vendor: "CockroachDB", risk: "low", category: "Databases", reasoning: "10 GB free storage, multi-region support. Backed by $633M funding. Free tier is strategic acquisition tool. Serverless model scales naturally." },
-    { vendor: "Auth0", risk: "low", category: "Authentication", reasoning: "Okta-owned (enterprise backing). Limits increased Nov 2025 (25K MAU → expanded). Free tier is developer funnel for enterprise IAM.", lastChange: "2025-11-01", changeType: "limits_increased" },
-    { vendor: "Sentry", risk: "low", category: "Error Tracking", reasoning: "Open-source core. Pricing restructured Aug 2025 but free tier preserved (5K errors/mo). Community edition available as fallback.", lastChange: "2025-08-15", changeType: "pricing_restructured" },
-    { vendor: "Google Cloud (Always Free)", risk: "low", category: "Cloud IaaS", reasoning: "Google Always Free tier unchanged for years — f1-micro VM, 5 GB Cloud Storage, BigQuery 1 TB/mo. Separate from promotional credits. Backed by Alphabet's cloud growth strategy.", lastChange: "2026-01-01", changeType: "limits_increased" },
-    { vendor: "AWS Free Tier", risk: "low", category: "Cloud IaaS", reasoning: "12-month free tier + always-free services (Lambda 1M requests, DynamoDB 25 GB). AWS is the market leader — free tier is a training/onboarding tool, not a cost center. Restructured Jan 2026 but expanded.", lastChange: "2026-01-04", changeType: "pricing_restructured" },
-    { vendor: "GitHub Copilot Free", risk: "low", category: "AI Coding", reasoning: "New free tier launched Dec 2025 (2K completions + 50 chat/mo). Microsoft strategic investment in AI developer tools. Competitive pressure from Cursor/Claude ensures free tier stays.", lastChange: "2025-12-18", changeType: "new_free_tier" },
-    { vendor: "Anthropic", risk: "low", category: "AI/ML APIs", reasoning: "Limits increased Feb 2026 and Mar 2026. Currently in growth mode, well-funded ($7.3B raised). Free API tier is competitive necessity against OpenAI/Google.", lastChange: "2026-03-13", changeType: "limits_increased" },
-
-    { vendor: "Supabase", risk: "medium", category: "Databases/BaaS", reasoning: "Project pause tightened to 1 week inactivity (Feb 2026). Core free tier preserved but signals efficiency pressure. Post-Series C ($80M) — profitable path unclear.", lastChange: "2026-02-01", changeType: "limits_reduced" },
-    { vendor: "Vercel", risk: "medium", category: "Hosting", reasoning: "Restructured to credit-based model (Jan 2026). Free tier still generous for personal projects but commercial use restricted (Hobby plan). Watch for further tightening.", lastChange: "2026-01-01", changeType: "pricing_restructured" },
-    { vendor: "Netlify", risk: "medium", category: "Hosting", reasoning: "Restructured to credit-based pricing (Sep 2025) — sites pause on exhaustion. 300 credits/month is sufficient for small sites but represents a philosophical shift toward metered billing.", lastChange: "2025-09-04", changeType: "pricing_restructured" },
-    { vendor: "Neon", risk: "medium", category: "Databases", reasoning: "Pricing restructured Jan 2026 post-Databricks acquisition. Free tier preserved (0.5 GB/project, 100 projects) but acquisition creates uncertainty about long-term free tier commitment.", lastChange: "2026-01-15", changeType: "pricing_restructured" },
-    { vendor: "Railway", risk: "medium", category: "Hosting/PaaS", reasoning: "Free tier expanded with $100M Series B (Oct 2025). Currently generous ($5 credit, no sleep). But VC-funded PaaS companies have a history of removing free tiers (see: Heroku). Watch burn rate.", lastChange: "2025-10-01", changeType: "limits_increased" },
-    { vendor: "Render", risk: "medium", category: "Hosting/PaaS", reasoning: "Sleep time reduced (Sep 2025) — 15-min spin-down is aggressive. Free PostgreSQL limited to 256 MB with 30-day expiry. Signals tightening, though core free tier intact.", lastChange: "2025-09-01", changeType: "limits_reduced" },
-    { vendor: "Stripe", risk: "medium", category: "Payments", reasoning: "Processing fees restructured Feb 2026 (2.7% + 5¢ domestic card). No free tier per se — pay-per-transaction model. Risk is in rate changes, not tier removal.", lastChange: "2026-02-01", changeType: "pricing_restructured" },
-    { vendor: "Firebase", risk: "medium", category: "BaaS", reasoning: "Multiple changes in 2026: Cloud Storage limits reduced (Feb), Realtime Database EOL announced (Mar), restrictions tightened (Feb). Google consolidating around Firestore. Migration advisable for RTDB users.", lastChange: "2026-03-19", changeType: "product_deprecated" },
-    { vendor: "Docker Hub", risk: "medium", category: "Containers", reasoning: "Rate limits tightened (Dec 2024) — 100 pulls/6h anonymous, 200 authenticated. Docker Desktop commercial license required for large orgs ($5/user/mo+). Free for small teams but trending paid.", lastChange: "2024-12-10", changeType: "pricing_restructured" },
-    { vendor: "Dub.co", risk: "medium", category: "Dev Utilities", reasoning: "Free tier limits reduced sharply (Mar 2026). Link shortener with declining free allowance signals monetization pressure.", lastChange: "2026-03-22", changeType: "limits_reduced" },
-    { vendor: "Google Gemini API", risk: "medium", category: "AI/ML", reasoning: "Free tier rate limits slashed 50-80% (Dec 2025). The flagship Gemini 3.1 Pro is paid-only, though Gemini 2.5 Pro is still free. A Google PM admitted generous limits were only for a promotional weekend. Still has free tier but heavily restricted.", lastChange: "2025-12-15", changeType: "limits_reduced" },
-
-    { vendor: "Heroku", risk: "high", category: "Hosting/PaaS", reasoning: "Free tier removed Nov 2022. Now in 'sustaining mode' under Salesforce — minimal investment, no innovation. The canonical cautionary tale for relying on free tiers.", lastChange: "2022-11-28", changeType: "free_tier_removed" },
-    { vendor: "Fly.io", risk: "high", category: "Hosting", reasoning: "Free tier removed for new accounts in October 2024. New signups get a trial of 2 hours runtime or 7 days, whichever comes first, then pay-as-you-go from the first machine — the smallest is $2.02/month. Only legacy Hobby/Launch/Scale accounts still carry 3 shared-cpu-1x VMs, 3 GB volume storage and 100 GB transfer. Volume snapshots became billable in January 2026.", lastChange: "2024-10-01", changeType: "free_tier_removed" },
-    { vendor: "Postman", risk: "high", category: "API Testing", reasoning: "Team collaboration removed from free tier (Mar 2026). Aggressive monetization of previously-free features. Pattern suggests further restrictions ahead.", lastChange: "2026-03-01", changeType: "restriction" },
-    { vendor: "OpenAI", risk: "high", category: "AI/ML", reasoning: "Multiple free tier reductions: limits cut Jun 2025, further reduced Feb 2026. GPT-4 free access removed. Market leader extracting value — expect continued tightening.", lastChange: "2026-02-09", changeType: "limits_reduced" },
-    { vendor: "HCP Terraform", risk: "high", category: "Infrastructure", reasoning: "Legacy tier EOL March 31, 2026. HashiCorp BSL license change (Aug 2023) already fractured community. IBM acquisition adds enterprise pricing pressure. Migrate to OpenTofu.", lastChange: "2026-03-31", changeType: "pricing_restructured" },
-    { vendor: "LocalStack", risk: "high", category: "Testing", reasoning: "Community Edition shut down March 23, 2026. Complete removal of free/OSS option. Migrate to Moto, aws-sdk-mock, or Testcontainers.", lastChange: "2026-03-23", changeType: "free_tier_removed" },
-    { vendor: "X API (Twitter)", risk: "high", category: "APIs", reasoning: "Free tier removed twice in 2026 (Feb 1 + Feb 9). Pay-per-use only with $10 one-time credit. Unpredictable management. Do not build on this API without paid plan budget.", lastChange: "2026-02-09", changeType: "free_tier_removed" },
-    { vendor: "Brave Search API", risk: "high", category: "Search", reasoning: "Free plan (5K queries/mo) replaced with metered billing Feb 2026. No spending cap — credit cards actively charged. Complete removal of free access.", lastChange: "2026-02-12", changeType: "free_tier_removed" },
-    { vendor: "Spotify API", risk: "high", category: "APIs", reasoning: "Premium subscription now required for dev mode (Feb 2026). Test users cut from 25 to 5. Multiple endpoints deprecated. Hostile to free developers.", lastChange: "2026-02-11", changeType: "limits_reduced" },
-    { vendor: "Amazon SP-API", risk: "high", category: "APIs", reasoning: "Free access ended after 10+ years — now $1,400/year + per-call fees (Apr 2026). Zero warning. Shows even long-stable APIs can go paid overnight.", lastChange: "2026-01-31", changeType: "pricing_restructured" },
-
-    { vendor: "PlanetScale", risk: "dead", category: "Databases", reasoning: "Free tier removed April 2024. Hobby plan eliminated entirely. Migrate to Neon, Turso, or CockroachDB.", lastChange: "2024-04-08", changeType: "free_tier_removed" },
-    { vendor: "Fauna", risk: "dead", category: "Databases", reasoning: "Product deprecated May 2025. Entire service shutting down. Migrate immediately to MongoDB Atlas, CockroachDB, or Supabase.", lastChange: "2025-05-30", changeType: "product_deprecated" },
-    { vendor: "MinIO (OSS)", risk: "dead", category: "Storage", reasoning: "Open-source version killed Feb 2026 (GNU AGPL → proprietary). Self-hosted MinIO is no longer free for production. Use S3-compatible alternatives.", lastChange: "2026-02-12", changeType: "open_source_killed" },
-    { vendor: "SendGrid", risk: "dead", category: "Email", reasoning: "Free tier removed May 2025 under Twilio ownership. Use Resend (3K emails/mo free) or Maileroo (3K/mo); Mailgun and Amazon SES have since dropped their free tiers too.", lastChange: "2025-05-27", changeType: "free_tier_removed" },
-    { vendor: "Logz.io", risk: "dead", category: "Logging", reasoning: "Free tier removed Mar 2026. Use Grafana Cloud (50 GB logs free), Axiom (500 GB/mo), or self-hosted ELK.", lastChange: "2026-03-02", changeType: "free_tier_removed" },
-    { vendor: "Freshping", risk: "dead", category: "Monitoring", reasoning: "Free tier removed Mar 2026. Use BetterStack (10 monitors free), UptimeRobot (50 monitors), or Grafana Cloud synthetics.", lastChange: "2026-03-06", changeType: "free_tier_removed" },
-  ];
 
   const lowRisk = riskEntries.filter(e => e.risk === "low");
   const medRisk = riskEntries.filter(e => e.risk === "medium");
@@ -23511,11 +23581,11 @@ function buildOpenaiAssistantsAlternativesPage(): string {
 
   const changeTimelineRows = openaiChanges.map(c => {
     const dateStr = new Date(c.date).toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" });
-    const impactColor = c.impact === "high" ? "#f85149" : c.impact === "medium" ? "#d29922" : "#3fb950";
+    const impactColor = changeImpactColor(c.impact);
     return `<tr>
       <td style="font-family:var(--mono);font-size:.8rem;white-space:nowrap">${escHtmlServer(dateStr)}</td>
       <td style="font-size:.85rem">${escHtmlServer(c.summary)}</td>
-      <td><span style="color:${impactColor};font-size:.8rem;font-weight:600">${escHtmlServer(c.impact?.toUpperCase() ?? "N/A")}</span></td>
+      <td><span style="color:${impactColor};font-size:.8rem;font-weight:600">${escHtmlServer(changeImpactLabel(c.impact))}</span></td>
     </tr>`;
   }).join("\n        ");
 
@@ -24005,11 +24075,11 @@ function buildOpenaiAssistantsMigration2026Page(): string {
 
   const changeTimelineRows = openaiChanges.map(c => {
     const dateStr = new Date(c.date).toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" });
-    const impactColor = c.impact === "high" ? "#f85149" : c.impact === "medium" ? "#d29922" : "#3fb950";
+    const impactColor = changeImpactColor(c.impact);
     return `<tr>
       <td style="font-family:var(--mono);font-size:.8rem;white-space:nowrap">${escHtmlServer(dateStr)}</td>
       <td style="font-size:.85rem">${escHtmlServer(c.summary)}</td>
-      <td><span style="color:${impactColor};font-size:.8rem;font-weight:600">${escHtmlServer(c.impact?.toUpperCase() ?? "N/A")}</span></td>
+      <td><span style="color:${impactColor};font-size:.8rem;font-weight:600">${escHtmlServer(changeImpactLabel(c.impact))}</span></td>
     </tr>`;
   }).join("\n        ");
 
@@ -24494,11 +24564,11 @@ function buildTenorAlternativesPage(): string {
 
   const changeTimelineRows = tenorChanges.map(c => {
     const dateStr = new Date(c.date).toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" });
-    const impactColor = c.impact === "high" ? "#f85149" : c.impact === "medium" ? "#d29922" : "#3fb950";
+    const impactColor = changeImpactColor(c.impact);
     return `<tr>
       <td style="font-family:var(--mono);font-size:.8rem;white-space:nowrap">${escHtmlServer(dateStr)}</td>
       <td style="font-size:.85rem">${escHtmlServer(c.summary)}</td>
-      <td><span style="color:${impactColor};font-size:.8rem;font-weight:600">${escHtmlServer(c.impact?.toUpperCase() ?? "N/A")}</span></td>
+      <td><span style="color:${impactColor};font-size:.8rem;font-weight:600">${escHtmlServer(changeImpactLabel(c.impact))}</span></td>
     </tr>`;
   }).join("\n        ");
 
@@ -24954,11 +25024,11 @@ function buildFirebaseStudioShutdownPage(): string {
 
   const changeTimelineRows = firebaseChanges.slice(0, 10).map(c => {
     const dateStr = new Date(c.date).toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" });
-    const impactColor = c.impact === "high" ? "#f85149" : c.impact === "medium" ? "#d29922" : "#3fb950";
+    const impactColor = changeImpactColor(c.impact);
     return `<tr>
       <td style="font-family:var(--mono);font-size:.8rem;white-space:nowrap">${escHtmlServer(dateStr)}</td>
       <td style="font-size:.85rem">${escHtmlServer(c.summary)}</td>
-      <td><span style="color:${impactColor};font-size:.8rem;font-weight:600">${escHtmlServer(c.impact?.toUpperCase() ?? "N/A")}</span></td>
+      <td><span style="color:${impactColor};font-size:.8rem;font-weight:600">${escHtmlServer(changeImpactLabel(c.impact))}</span></td>
     </tr>`;
   }).join("\n        ");
 
@@ -25519,17 +25589,17 @@ function buildOpenAIAssistantsMigrationPage(): string {
     return '<tr>' +
       '<td style="font-family:var(--mono);font-size:.85rem;white-space:nowrap">' + escHtmlServer(e.date) + '</td>' +
       '<td style="font-size:.9rem">' + escHtmlServer(e.event) + '</td>' +
-      '<td><span style="color:' + impactColor + ';font-size:.8rem;font-weight:600">' + escHtmlServer(e.impact.toUpperCase()) + '</span></td>' +
+      '<td><span style="color:' + impactColor + ';font-size:.8rem;font-weight:600">' + escHtmlServer(changeImpactLabel(e.impact)) + '</span></td>' +
       '</tr>';
   }).join("\n        ");
 
   const changeTimelineRows = openaiChanges.slice(0, 10).map(c => {
     const dateStr = new Date(c.date).toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" });
-    const impactColor = c.impact === "high" ? "#f85149" : c.impact === "medium" ? "#d29922" : "#3fb950";
+    const impactColor = changeImpactColor(c.impact);
     return '<tr>' +
       '<td style="font-family:var(--mono);font-size:.8rem;white-space:nowrap">' + escHtmlServer(dateStr) + '</td>' +
       '<td style="font-size:.85rem">' + escHtmlServer(c.summary) + '</td>' +
-      '<td><span style="color:' + impactColor + ';font-size:.8rem;font-weight:600">' + escHtmlServer(c.impact?.toUpperCase() ?? "N/A") + '</span></td>' +
+      '<td><span style="color:' + impactColor + ';font-size:.8rem;font-weight:600">' + escHtmlServer(changeImpactLabel(c.impact)) + '</span></td>' +
       '</tr>';
   }).join("\n        ");
 
@@ -26250,12 +26320,12 @@ ${buildGlobalNav("guides")}
     <tbody>
       ${relevantChanges.map(c => {
         const dateStr = new Date(c.date).toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" });
-        const impactColor = c.impact === "high" ? "#f85149" : c.impact === "medium" ? "#d29922" : "#3fb950";
+        const impactColor = changeImpactColor(c.impact);
         return `<tr>
           <td style="font-family:var(--mono);font-size:.8rem;white-space:nowrap">${escHtmlServer(dateStr)}</td>
           <td><a href="/vendor/${toSlug(c.vendor)}" style="color:var(--text)">${escHtmlServer(c.vendor)}</a></td>
           <td style="font-size:.85rem">${escHtmlServer(c.summary)}</td>
-          <td><span style="color:${impactColor};font-size:.8rem;font-weight:600">${escHtmlServer(c.impact?.toUpperCase() ?? "N/A")}</span></td>
+          <td><span style="color:${impactColor};font-size:.8rem;font-weight:600">${escHtmlServer(changeImpactLabel(c.impact))}</span></td>
         </tr>`;
       }).join("\n      ")}
     </tbody>
@@ -26854,12 +26924,12 @@ function buildStartupCreditsPage(): string {
 
   const changeTimelineRows = startupChanges.map(c => {
     const dateStr = new Date(c.date).toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" });
-    const impactColor = c.impact === "high" ? "#f85149" : c.impact === "medium" ? "#d29922" : "#3fb950";
+    const impactColor = changeImpactColor(c.impact);
     return '<tr>' +
       '<td style="font-family:var(--mono);font-size:.8rem;white-space:nowrap">' + escHtmlServer(dateStr) + '</td>' +
       '<td style="font-weight:600">' + escHtmlServer(c.vendor) + '</td>' +
       '<td style="font-size:.85rem">' + escHtmlServer(c.summary) + '</td>' +
-      '<td><span style="color:' + impactColor + ';font-size:.8rem;font-weight:600">' + escHtmlServer(c.impact?.toUpperCase() ?? "N/A") + '</span></td>' +
+      '<td><span style="color:' + impactColor + ';font-size:.8rem;font-weight:600">' + escHtmlServer(changeImpactLabel(c.impact)) + '</span></td>' +
       '</tr>';
   }).join("\n        ");
 
@@ -27282,7 +27352,7 @@ function buildAiCodingPricing2026Page(): string {
 
   const changeTimelineRows = aiCodingChanges.map(c => {
     const dateStr = changeTimelineDate(c.date);
-    const impactColor = c.impact === "high" ? "#f85149" : c.impact === "medium" ? "#d29922" : "#3fb950";
+    const impactColor = changeImpactColor(c.impact);
     const newest = supersededAiCodingLineups.get(c);
     const historyNote = newest
       ? `<div class="superseded-note">${escHtmlServer(supersessionNote(newest, changeTimelineDate))}</div>`
@@ -27291,7 +27361,7 @@ function buildAiCodingPricing2026Page(): string {
       <td style="font-family:var(--mono);font-size:.8rem;white-space:nowrap">${escHtmlServer(dateStr)}</td>
       <td style="font-weight:600">${escHtmlServer(c.vendor)}</td>
       <td style="font-size:.85rem">${escHtmlServer(c.summary)}${historyNote}</td>
-      <td><span style="color:${impactColor};font-size:.8rem;font-weight:600">${escHtmlServer(c.impact?.toUpperCase() ?? "N/A")}</span></td>
+      <td><span style="color:${impactColor};font-size:.8rem;font-weight:600">${escHtmlServer(changeImpactLabel(c.impact))}</span></td>
     </tr>`;
   }).join("\n        ");
 
@@ -27897,7 +27967,7 @@ function buildAiCodingToolsPricingPage(): string {
 
   const changeTimelineRows = aiCodingChanges.map((c: any) => {
     const dateStr = changeTimelineDate(c.date);
-    const impactColor = c.impact === "high" ? "#f85149" : c.impact === "medium" ? "#d29922" : "#3fb950";
+    const impactColor = changeImpactColor(c.impact);
     const newest = supersededAiCodingLineups.get(c);
     const historyNote = newest
       ? '<div class="superseded-note">' + escHtmlServer(supersessionNote(newest, changeTimelineDate)) + '</div>'
@@ -27906,7 +27976,7 @@ function buildAiCodingToolsPricingPage(): string {
       '<td style="font-family:var(--mono);font-size:.8rem;white-space:nowrap">' + escHtmlServer(dateStr) + '</td>' +
       '<td style="font-weight:600">' + escHtmlServer(c.vendor) + '</td>' +
       '<td style="font-size:.85rem">' + escHtmlServer(c.summary) + historyNote + '</td>' +
-      '<td><span style="color:' + impactColor + ';font-size:.8rem;font-weight:600">' + escHtmlServer(c.impact?.toUpperCase() ?? "N/A") + '</span></td>' +
+      '<td><span style="color:' + impactColor + ';font-size:.8rem;font-weight:600">' + escHtmlServer(changeImpactLabel(c.impact)) + '</span></td>' +
       '</tr>';
   }).join("\n        ");
 
@@ -28655,12 +28725,12 @@ function buildCiCdPricingPage(): string {
 
   const changeTimelineRows = cicdChanges.map(c => {
     const dateStr = new Date(c.date).toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" });
-    const impactColor = c.impact === "high" ? "#f85149" : c.impact === "medium" ? "#d29922" : "#3fb950";
+    const impactColor = changeImpactColor(c.impact);
     return '<tr>' +
       '<td style="font-family:var(--mono);font-size:.8rem;white-space:nowrap">' + escHtmlServer(dateStr) + '</td>' +
       '<td style="font-weight:600">' + escHtmlServer(c.vendor) + '</td>' +
       '<td style="font-size:.85rem">' + escHtmlServer(c.summary) + '</td>' +
-      '<td><span style="color:' + impactColor + ';font-size:.8rem;font-weight:600">' + escHtmlServer(c.impact?.toUpperCase() ?? "N/A") + '</span></td>' +
+      '<td><span style="color:' + impactColor + ';font-size:.8rem;font-weight:600">' + escHtmlServer(changeImpactLabel(c.impact)) + '</span></td>' +
       '</tr>';
   }).join("\n        ");
 
@@ -29539,12 +29609,12 @@ function buildDatabasePricingPage(): string {
 
   const changeTimelineRows = dbChanges.map(c => {
     const dateStr = new Date(c.date).toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" });
-    const impactColor = c.impact === "high" ? "#f85149" : c.impact === "medium" ? "#d29922" : "#3fb950";
+    const impactColor = changeImpactColor(c.impact);
     return '<tr>' +
       '<td style="font-family:var(--mono);font-size:.8rem;white-space:nowrap">' + escHtmlServer(dateStr) + '</td>' +
       '<td style="font-weight:600">' + escHtmlServer(c.vendor) + '</td>' +
       '<td style="font-size:.85rem">' + escHtmlServer(c.summary) + '</td>' +
-      '<td><span style="color:' + impactColor + ';font-size:.8rem;font-weight:600">' + escHtmlServer(c.impact?.toUpperCase() ?? "N/A") + '</span></td>' +
+      '<td><span style="color:' + impactColor + ';font-size:.8rem;font-weight:600">' + escHtmlServer(changeImpactLabel(c.impact)) + '</span></td>' +
       '</tr>';
   }).join("\n        ");
 
@@ -30910,12 +30980,12 @@ function buildHostingPricingPage(): string {
 
   const changeTimelineRows = hostingChanges.map(c => {
     const dateStr = new Date(c.date).toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" });
-    const impactColor = c.impact === "high" ? "#f85149" : c.impact === "medium" ? "#d29922" : "#3fb950";
+    const impactColor = changeImpactColor(c.impact);
     return '<tr>' +
       '<td style="font-family:var(--mono);font-size:.8rem;white-space:nowrap">' + escHtmlServer(dateStr) + '</td>' +
       '<td style="font-weight:600">' + escHtmlServer(c.vendor) + '</td>' +
       '<td style="font-size:.85rem">' + escHtmlServer(c.summary) + '</td>' +
-      '<td><span style="color:' + impactColor + ';font-size:.8rem;font-weight:600">' + escHtmlServer(c.impact?.toUpperCase() ?? "N/A") + '</span></td>' +
+      '<td><span style="color:' + impactColor + ';font-size:.8rem;font-weight:600">' + escHtmlServer(changeImpactLabel(c.impact)) + '</span></td>' +
       '</tr>';
   }).join("\n        ");
 
@@ -31682,12 +31752,12 @@ function buildLlmApiPricingPage(): string {
 
   const changeTimelineRows = llmChanges.slice(0, 20).map(c => {
     const dateStr = new Date(c.date).toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" });
-    const impactColor = c.impact === "high" ? "#f85149" : c.impact === "medium" ? "#d29922" : "#3fb950";
+    const impactColor = changeImpactColor(c.impact);
     return '<tr>' +
       '<td style="font-family:var(--mono);font-size:.8rem;white-space:nowrap">' + escHtmlServer(dateStr) + '</td>' +
       '<td style="font-weight:600">' + escHtmlServer(c.vendor) + '</td>' +
       '<td style="font-size:.85rem">' + escHtmlServer(c.summary) + '</td>' +
-      '<td><span style="color:' + impactColor + ';font-size:.8rem;font-weight:600">' + escHtmlServer(c.impact?.toUpperCase() ?? "N/A") + '</span></td>' +
+      '<td><span style="color:' + impactColor + ';font-size:.8rem;font-weight:600">' + escHtmlServer(changeImpactLabel(c.impact)) + '</span></td>' +
       '</tr>';
   }).join("\n        ");
 
@@ -32618,11 +32688,11 @@ function buildDallEShutdownPage(): string {
 
   const changeTimelineRows = dalleChanges.slice(0, 10).map(c => {
     const dateStr = new Date(c.date).toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" });
-    const impactColor = c.impact === "high" ? "#f85149" : c.impact === "medium" ? "#d29922" : "#3fb950";
+    const impactColor = changeImpactColor(c.impact);
     return `<tr>
       <td style="font-family:var(--mono);font-size:.8rem;white-space:nowrap">${escHtmlServer(dateStr)}</td>
       <td style="font-size:.85rem">${escHtmlServer(c.summary)}</td>
-      <td><span style="color:${impactColor};font-size:.8rem;font-weight:600">${escHtmlServer(c.impact?.toUpperCase() ?? "N/A")}</span></td>
+      <td><span style="color:${impactColor};font-size:.8rem;font-weight:600">${escHtmlServer(changeImpactLabel(c.impact))}</span></td>
     </tr>`;
   }).join("\n        ");
 
@@ -33125,8 +33195,8 @@ function buildOpenAIRealtimeMigrationPage(): string {
 
   const changeTimelineRows = relevantChanges.slice(0, 10).map(c => {
     const dateStr = new Date(c.date).toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" });
-    const impactColor = c.impact === "high" ? "#f85149" : c.impact === "medium" ? "#d29922" : "#3fb950";
-    return '<tr>\n      <td style="font-family:var(--mono);font-size:.8rem;white-space:nowrap">' + escHtmlServer(dateStr) + '</td>\n      <td style="font-size:.85rem">' + escHtmlServer(c.summary) + '</td>\n      <td><span style="color:' + impactColor + ';font-size:.8rem;font-weight:600">' + escHtmlServer(c.impact?.toUpperCase() ?? "N/A") + "</span></td>\n    </tr>";
+    const impactColor = changeImpactColor(c.impact);
+    return '<tr>\n      <td style="font-family:var(--mono);font-size:.8rem;white-space:nowrap">' + escHtmlServer(dateStr) + '</td>\n      <td style="font-size:.85rem">' + escHtmlServer(c.summary) + '</td>\n      <td><span style="color:' + impactColor + ';font-size:.8rem;font-weight:600">' + escHtmlServer(changeImpactLabel(c.impact)) + "</span></td>\n    </tr>";
   }).join("\n        ");
 
   const relatedPages = ALTERNATIVES_PAGES.filter(p =>
@@ -33247,11 +33317,11 @@ function buildAppRunnerMigrationPage(): string {
 
   const changeTimelineRows = awsChanges.slice(0, 10).map(c => {
     const dateStr = new Date(c.date).toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" });
-    const impactColor = c.impact === "high" ? "#f85149" : c.impact === "medium" ? "#d29922" : "#3fb950";
+    const impactColor = changeImpactColor(c.impact);
     return `<tr>
       <td style="font-family:var(--mono);font-size:.8rem;white-space:nowrap">${escHtmlServer(dateStr)}</td>
       <td style="font-size:.85rem">${escHtmlServer(c.summary)}</td>
-      <td><span style="color:${impactColor};font-size:.8rem;font-weight:600">${escHtmlServer(c.impact?.toUpperCase() ?? "N/A")}</span></td>
+      <td><span style="color:${impactColor};font-size:.8rem;font-weight:600">${escHtmlServer(changeImpactLabel(c.impact))}</span></td>
     </tr>`;
   }).join("\n        ");
 
@@ -33858,12 +33928,12 @@ function buildAwsFreeTier2026Page(): string {
 
   const changeTimelineRows = awsChanges.slice(0, 10).map((c: any) => {
     const dateStr = new Date(c.date).toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" });
-    const impactColor = c.impact === "high" ? "#f85149" : c.impact === "medium" ? "#d29922" : "#3fb950";
+    const impactColor = changeImpactColor(c.impact);
     return `<tr>
       <td style="font-family:var(--mono);font-size:.8rem;white-space:nowrap">${escHtmlServer(dateStr)}</td>
       <td style="font-weight:600">${escHtmlServer(c.vendor)}</td>
       <td style="font-size:.85rem">${escHtmlServer(c.summary)}</td>
-      <td><span style="color:${impactColor};font-size:.8rem;font-weight:600">${escHtmlServer(c.impact?.toUpperCase() ?? "N/A")}</span></td>
+      <td><span style="color:${impactColor};font-size:.8rem;font-weight:600">${escHtmlServer(changeImpactLabel(c.impact))}</span></td>
     </tr>`;
   }).join("\n        ");
 
@@ -34296,12 +34366,12 @@ function buildGcpFreeTier2026Page(): string {
 
   const changeTimelineRows = gcpChanges.slice(0, 12).map((c: any) => {
     const dateStr = new Date(c.date).toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" });
-    const impactColor = c.impact === "high" ? "#f85149" : c.impact === "medium" ? "#d29922" : "#3fb950";
+    const impactColor = changeImpactColor(c.impact);
     return `<tr>
       <td style="font-family:var(--mono);font-size:.8rem;white-space:nowrap">${escHtmlServer(dateStr)}</td>
       <td style="font-weight:600">${escHtmlServer(c.vendor)}</td>
       <td style="font-size:.85rem">${escHtmlServer(c.summary)}</td>
-      <td><span style="color:${impactColor};font-size:.8rem;font-weight:600">${escHtmlServer(c.impact?.toUpperCase() ?? "N/A")}</span></td>
+      <td><span style="color:${impactColor};font-size:.8rem;font-weight:600">${escHtmlServer(changeImpactLabel(c.impact))}</span></td>
     </tr>`;
   }).join("\n        ");
 
@@ -34715,12 +34785,12 @@ function buildAzureFreeTier2026Page(): string {
 
   const changeTimelineRows = azureChanges.slice(0, 10).map((c: any) => {
     const dateStr = new Date(c.date).toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" });
-    const impactColor = c.impact === "high" ? "#f85149" : c.impact === "medium" ? "#d29922" : "#3fb950";
+    const impactColor = changeImpactColor(c.impact);
     return `<tr>
       <td style="font-family:var(--mono);font-size:.8rem;white-space:nowrap">${escHtmlServer(dateStr)}</td>
       <td style="font-weight:600">${escHtmlServer(c.vendor)}</td>
       <td style="font-size:.85rem">${escHtmlServer(c.summary)}</td>
-      <td><span style="color:${impactColor};font-size:.8rem;font-weight:600">${escHtmlServer(c.impact?.toUpperCase() ?? "N/A")}</span></td>
+      <td><span style="color:${impactColor};font-size:.8rem;font-weight:600">${escHtmlServer(changeImpactLabel(c.impact))}</span></td>
     </tr>`;
   }).join("\n        ");
 
@@ -35160,12 +35230,12 @@ function buildDigitalOceanFreeTier2026Page(): string {
 
   const changeTimelineRows = doChanges.slice(0, 10).map((c: any) => {
     const dateStr = new Date(c.date).toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" });
-    const impactColor = c.impact === "high" ? "#f85149" : c.impact === "medium" ? "#d29922" : "#3fb950";
+    const impactColor = changeImpactColor(c.impact);
     return `<tr>
       <td style="font-family:var(--mono);font-size:.8rem;white-space:nowrap">${escHtmlServer(dateStr)}</td>
       <td style="font-weight:600">${escHtmlServer(c.vendor)}</td>
       <td style="font-size:.85rem">${escHtmlServer(c.summary)}</td>
-      <td><span style="color:${impactColor};font-size:.8rem;font-weight:600">${escHtmlServer(c.impact?.toUpperCase() ?? "N/A")}</span></td>
+      <td><span style="color:${impactColor};font-size:.8rem;font-weight:600">${escHtmlServer(changeImpactLabel(c.impact))}</span></td>
     </tr>`;
   }).join("\n        ");
 
@@ -35620,12 +35690,12 @@ function buildCloudFreeTierComparison2026Page(): string {
 
   const changeTimelineRows = cloudChanges.slice(0, 12).map((c: any) => {
     const dateStr = new Date(c.date).toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" });
-    const impactColor = c.impact === "high" ? "#f85149" : c.impact === "medium" ? "#d29922" : "#3fb950";
+    const impactColor = changeImpactColor(c.impact);
     return `<tr>
       <td style="font-family:var(--mono);font-size:.8rem;white-space:nowrap">${escHtmlServer(dateStr)}</td>
       <td style="font-weight:600">${escHtmlServer(c.vendor)}</td>
       <td style="font-size:.85rem">${escHtmlServer(c.summary)}</td>
-      <td><span style="color:${impactColor};font-size:.8rem;font-weight:600">${escHtmlServer(c.impact?.toUpperCase() ?? "N/A")}</span></td>
+      <td><span style="color:${impactColor};font-size:.8rem;font-weight:600">${escHtmlServer(changeImpactLabel(c.impact))}</span></td>
     </tr>`;
   }).join("\n        ");
 
@@ -35645,7 +35715,7 @@ function buildCloudFreeTierComparison2026Page(): string {
     mainEntityOfPage: { "@type": "WebPage", "@id": `${BASE_URL}/${slug}` },
   };
 
-  return `<!DOCTYPE html>
+  return comparisonPageWithLiveRecords(`<!DOCTYPE html>
 <html lang="en">
 <head>
 <meta charset="utf-8">
@@ -36205,7 +36275,7 @@ ${mcpCtaCss()}
 </footer>
 <script>${mcpCtaScript()}</script>
 </body>
-</html>`;
+</html>`, pubDate, cloudChanges);
 }
 
 function buildDatabaseFreeTierComparison2026Page(): string {
@@ -36216,17 +36286,17 @@ function buildDatabaseFreeTierComparison2026Page(): string {
 
   const dbVendorKeywords = ["Supabase", "Neon", "Firebase", "Turso", "PlanetScale", "MongoDB", "CockroachDB", "Upstash", "Cloudflare D1", "Redis", "Appwrite", "Convex", "Weaviate", "Zilliz", "Aiven", "Aurora", "Neo4j", "Hasura"];
   const dbChanges = dealChanges.filter((c: any) =>
-    dbVendorKeywords.some(v => c.vendor === v || c.vendor.startsWith(v + " ") || c.vendor.includes(v))
+    dbVendorKeywords.some(v => c.vendor === v || c.vendor.startsWith(v + " ") || c.vendor.includes(v)) || c.category === "Databases"
   ).sort((a: any, b: any) => new Date(b.date).getTime() - new Date(a.date).getTime());
 
   const changeTimelineRows = dbChanges.slice(0, 12).map((c: any) => {
     const dateStr = new Date(c.date).toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" });
-    const impactColor = c.impact === "high" ? "#f85149" : c.impact === "medium" ? "#d29922" : "#3fb950";
+    const impactColor = changeImpactColor(c.impact);
     return `<tr>
       <td style="font-family:var(--mono);font-size:.8rem;white-space:nowrap">${escHtmlServer(dateStr)}</td>
       <td style="font-weight:600">${escHtmlServer(c.vendor)}</td>
       <td style="font-size:.85rem">${escHtmlServer(c.summary)}</td>
-      <td><span style="color:${impactColor};font-size:.8rem;font-weight:600">${escHtmlServer(c.impact?.toUpperCase() ?? "N/A")}</span></td>
+      <td><span style="color:${impactColor};font-size:.8rem;font-weight:600">${escHtmlServer(changeImpactLabel(c.impact))}</span></td>
     </tr>`;
   }).join("\n        ");
 
@@ -36267,7 +36337,7 @@ function buildDatabaseFreeTierComparison2026Page(): string {
     mainEntityOfPage: { "@type": "WebPage", "@id": `${BASE_URL}/${slug}` },
   };
 
-  return `<!DOCTYPE html>
+  return comparisonPageWithLiveRecords(`<!DOCTYPE html>
 <html lang="en">
 <head>
 <meta charset="utf-8">
@@ -36356,7 +36426,7 @@ ${mcpCtaCss()}
   ${buildGlobalNav("guides")}
   <div class="breadcrumb"><a href="/">AgentDeals</a> &rsaquo; <a href="/category/databases">Databases</a> &rsaquo; Database Free Tier Comparison</div>
   <h1>Database Free Tier Comparison 2026</h1>
-  <p class="pub-date">Published ${pubDate}${pageFreshness("/database-free-tier-comparison-2026")} &middot; ${pageDataProvenance("/database-free-tier-comparison-2026", offers.length)} &middot; 44 database services compared</p>
+  <p class="pub-date">Published ${pubDate}${pageFreshness("/database-free-tier-comparison-2026")} &middot; ${pageDataProvenance("/database-free-tier-comparison-2026", offers.length)} &middot; ${COMPARED_SERVICES_PLACEHOLDER} database services compared</p>
 
   ${buildComparisonCategoryBackLink(slug)}
 
@@ -36613,7 +36683,7 @@ ${mcpCtaCss()}
       <tr>
         <td class="provider-col">Appwrite Cloud</td>
         <td>Document-based</td>
-        <td style="font-family:var(--mono)">2 GB</td>
+        <td style="font-family:var(--mono)">2 GB across 2 projects</td>
         <td class="check">75K MAU</td>
         <td class="check">750K executions/mo</td>
         <td class="check">Yes</td>
@@ -36633,7 +36703,7 @@ ${mcpCtaCss()}
   </div>
 
   <div class="context-box">
-    <strong>Firebase had major free tier changes in early 2026:</strong> Cloud Storage was removed from the Spark (free) plan in February 2026, and Firebase Studio (formerly Project IDX) was discontinued in March. If you're starting new, <strong>Supabase</strong> gives you a similar feature set on standard Postgres with no lock-in. <strong>Appwrite</strong> has the most generous free tier (75K MAU) and is fully open-source. See our <a href="/supabase-vs-firebase">Supabase vs Firebase comparison</a>.
+    <strong>Firebase had major free tier changes in early 2026:</strong> Cloud Storage was removed from the Spark (free) plan in February 2026, and Firebase Studio (formerly Project IDX) was discontinued in March. If you're starting new, <strong>Supabase</strong> gives you a similar feature set on standard Postgres with no lock-in. <strong>Appwrite</strong> has the most generous free tier (75K MAU) and is fully open-source, with two constraints its plan card states and this table does not: the free plan is limited to 2 projects, and a free project is paused after 1 week of inactivity. See our <a href="/supabase-vs-firebase">Supabase vs Firebase comparison</a>.
   </div>
 
   <h2 id="edge">Edge / Embedded Databases</h2>
@@ -36757,9 +36827,9 @@ ${mcpCtaCss()}
     <tbody>
       <tr>
         <td class="provider-col">Weaviate</td>
-        <td>Unlimited (self-hosted)</td>
-        <td>Unlimited (self-hosted)</td>
-        <td>OSS: free. Cloud: 14-day sandbox</td>
+        <td>Unlimited self-hosted. Cloud: 100,000 objects</td>
+        <td>Unlimited self-hosted. Cloud: 1 GB memory, 10 GB disk</td>
+        <td>OSS: free. Cloud: Free Forever, 1 cluster, 1 collection</td>
         <td>Self-hosted vector search</td>
       </tr>
       <tr>
@@ -36778,9 +36848,9 @@ ${mcpCtaCss()}
       </tr>
       <tr>
         <td class="provider-col">Upstash Vector</td>
-        <td style="font-family:var(--mono)">10K vectors</td>
-        <td>1536 dimensions</td>
-        <td>Serverless, no credit card</td>
+        <td style="font-family:var(--mono)">200M vectors &times; dimensions</td>
+        <td>1 GB, up to 1,536 dimensions</td>
+        <td>Serverless, no credit card. 10K queries or updates a day</td>
         <td>Lightweight RAG, serverless apps</td>
       </tr>
     </tbody>
@@ -36788,7 +36858,7 @@ ${mcpCtaCss()}
   </div>
 
   <div class="context-box">
-    <strong>For self-hosted:</strong> Weaviate and LanceDB are both fully open-source with no limits. <strong>For managed:</strong> Zilliz Cloud has the most generous free tier (5 GB storage, 5 collections). Upstash Vector is the simplest to set up (serverless, 10K vectors free) but limited for production workloads. If you're building RAG pipelines, Zilliz or self-hosted Weaviate are the strongest options.
+    <strong>For self-hosted:</strong> Weaviate and LanceDB are both fully open-source with no limits when you run them yourself &mdash; Weaviate Cloud's Free Forever tier is a separate, bounded offer (1 cluster, 100,000 objects, 1 collection). <strong>For managed:</strong> Zilliz Cloud has the most generous free tier (5 GB storage, 5 collections). Upstash Vector is the simplest to set up (serverless, 200M vectors &times; dimensions free) but its 10K daily query and update cap is what limits it for production workloads. If you're building RAG pipelines, Zilliz or self-hosted Weaviate are the strongest options.
   </div>
 
   <h2 id="best-for">Best for Each Use Case</h2>
@@ -36843,7 +36913,7 @@ ${mcpCtaCss()}
   <div class="diff-card" style="border-left-color:#3fb950">
     <h3>Lessons for choosing a database</h3>
     <p class="diff-desc"><strong>1. Prefer standard Postgres.</strong> If you use standard SQL, migration is straightforward. PlanetScale's Vitess-based MySQL with custom branching was harder to migrate from.<br>
-    <strong>2. Check our <a href="/free-tier-risk">Free Tier Risk Index</a></strong> — we score 38 vendors by free tier sustainability risk.<br>
+    <strong>2. Check our <a href="/free-tier-risk">Free Tier Risk Index</a></strong> — we score ${riskEntries.length} vendors by free tier sustainability risk.<br>
     <strong>3. Have a migration plan.</strong> Export your schema and data regularly. Test imports on your backup database provider.<br>
     <strong>4. Watch for signals:</strong> funding changes, pricing restructuring, reduced limits. We track all of these in our <a href="/changes">pricing changes timeline</a>.</p>
   </div>
@@ -36886,7 +36956,7 @@ ${mcpCtaCss()}
 </footer>
 <script>${mcpCtaScript()}</script>
 </body>
-</html>`;
+</html>`, pubDate, dbChanges);
 }
 
 function buildCicdFreeTierComparison2026Page(): string {
@@ -36902,12 +36972,12 @@ function buildCicdFreeTierComparison2026Page(): string {
 
   const changeTimelineRows = cicdChanges.slice(0, 12).map((c: any) => {
     const dateStr = new Date(c.date).toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" });
-    const impactColor = c.impact === "high" ? "#f85149" : c.impact === "medium" ? "#d29922" : "#3fb950";
+    const impactColor = changeImpactColor(c.impact);
     return `<tr>
       <td style="font-family:var(--mono);font-size:.8rem;white-space:nowrap">${escHtmlServer(dateStr)}</td>
       <td style="font-weight:600">${escHtmlServer(c.vendor)}</td>
       <td style="font-size:.85rem">${escHtmlServer(c.summary)}</td>
-      <td><span style="color:${impactColor};font-size:.8rem;font-weight:600">${escHtmlServer(c.impact?.toUpperCase() ?? "N/A")}</span></td>
+      <td><span style="color:${impactColor};font-size:.8rem;font-weight:600">${escHtmlServer(changeImpactLabel(c.impact))}</span></td>
     </tr>`;
   }).join("\n        ");
 
@@ -36948,7 +37018,7 @@ function buildCicdFreeTierComparison2026Page(): string {
     mainEntityOfPage: { "@type": "WebPage", "@id": `${BASE_URL}/${slug}` },
   };
 
-  return `<!DOCTYPE html>
+  return comparisonPageWithLiveRecords(`<!DOCTYPE html>
 <html lang="en">
 <head>
 <meta charset="utf-8">
@@ -37554,7 +37624,7 @@ ${mcpCtaCss()}
 </footer>
 <script>${mcpCtaScript()}</script>
 </body>
-</html>`;
+</html>`, pubDate, cicdChanges);
 }
 
 function buildServerlessFreeTierComparison2026Page(): string {
@@ -37565,18 +37635,17 @@ function buildServerlessFreeTierComparison2026Page(): string {
 
   const serverlessVendorKeywords = ["Vercel", "Cloudflare Workers", "Cloudflare Durable Objects", "Cloudflare Queues", "Deno Deploy", "Val Town", "Google Cloud", "AWS", "Azure", "Cloud Run", "Lambda", "Cloud Functions", "Azure Functions", "DBOS", "Inngest", "Trigger.dev"];
   const serverlessChanges = dealChanges.filter((c: any) =>
-    serverlessVendorKeywords.some(v => c.vendor === v || c.vendor.startsWith(v + " ") || c.vendor.includes(v)) ||
-    (c.summary && (c.summary.toLowerCase().includes("serverless") || c.summary.toLowerCase().includes("function") || c.summary.toLowerCase().includes("lambda") || c.summary.toLowerCase().includes("worker")))
+    serverlessVendorKeywords.some(v => c.vendor === v || c.vendor.startsWith(v + " ") || c.vendor.includes(v))
   ).sort((a: any, b: any) => new Date(b.date).getTime() - new Date(a.date).getTime());
 
   const changeTimelineRows = serverlessChanges.slice(0, 12).map((c: any) => {
     const dateStr = new Date(c.date).toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" });
-    const impactColor = c.impact === "high" ? "#f85149" : c.impact === "medium" ? "#d29922" : "#3fb950";
+    const impactColor = changeImpactColor(c.impact);
     return `<tr>
       <td style="font-family:var(--mono);font-size:.8rem;white-space:nowrap">${escHtmlServer(dateStr)}</td>
       <td style="font-weight:600">${escHtmlServer(c.vendor)}</td>
       <td style="font-size:.85rem">${escHtmlServer(c.summary)}</td>
-      <td><span style="color:${impactColor};font-size:.8rem;font-weight:600">${escHtmlServer(c.impact?.toUpperCase() ?? "N/A")}</span></td>
+      <td><span style="color:${impactColor};font-size:.8rem;font-weight:600">${escHtmlServer(changeImpactLabel(c.impact))}</span></td>
     </tr>`;
   }).join("\n        ");
 
@@ -37617,7 +37686,7 @@ function buildServerlessFreeTierComparison2026Page(): string {
     mainEntityOfPage: { "@type": "WebPage", "@id": `${BASE_URL}/${slug}` },
   };
 
-  return `<!DOCTYPE html>
+  return comparisonPageWithLiveRecords(`<!DOCTYPE html>
 <html lang="en">
 <head>
 <meta charset="utf-8">
@@ -38200,7 +38269,7 @@ ${mcpCtaCss()}
 </footer>
 <script>${mcpCtaScript()}</script>
 </body>
-</html>`;
+</html>`, pubDate, serverlessChanges);
 }
 
 function buildAuthComparison2026Page(): string {
@@ -38217,12 +38286,12 @@ function buildAuthComparison2026Page(): string {
 
   const changeTimelineRows = authChanges.slice(0, 12).map((c: any) => {
     const dateStr = new Date(c.date).toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" });
-    const impactColor = c.impact === "high" ? "#f85149" : c.impact === "medium" ? "#d29922" : "#3fb950";
+    const impactColor = changeImpactColor(c.impact);
     return `<tr>
       <td style="font-family:var(--mono);font-size:.8rem;white-space:nowrap">${escHtmlServer(dateStr)}</td>
       <td style="font-weight:600">${escHtmlServer(c.vendor)}</td>
       <td style="font-size:.85rem">${escHtmlServer(c.summary)}</td>
-      <td><span style="color:${impactColor};font-size:.8rem;font-weight:600">${escHtmlServer(c.impact?.toUpperCase() ?? "N/A")}</span></td>
+      <td><span style="color:${impactColor};font-size:.8rem;font-weight:600">${escHtmlServer(changeImpactLabel(c.impact))}</span></td>
     </tr>`;
   }).join("\n        ");
 
@@ -39158,12 +39227,12 @@ function buildEmailComparison2026Page(): string {
 
   const changeTimelineRows = emailChanges.slice(0, 12).map((c: any) => {
     const dateStr = new Date(c.date).toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" });
-    const impactColor = c.impact === "high" ? "#f85149" : c.impact === "medium" ? "#d29922" : "#3fb950";
+    const impactColor = changeImpactColor(c.impact);
     return `<tr>
       <td style="font-family:var(--mono);font-size:.8rem;white-space:nowrap">${escHtmlServer(dateStr)}</td>
       <td style="font-weight:600">${escHtmlServer(c.vendor)}</td>
       <td style="font-size:.85rem">${escHtmlServer(c.summary)}</td>
-      <td><span style="color:${impactColor};font-size:.8rem;font-weight:600">${escHtmlServer(c.impact?.toUpperCase() ?? "N/A")}</span></td>
+      <td><span style="color:${impactColor};font-size:.8rem;font-weight:600">${escHtmlServer(changeImpactLabel(c.impact))}</span></td>
     </tr>`;
   }).join("\n        ");
 
@@ -40132,12 +40201,12 @@ function buildMonitoringComparison2026Page(): string {
 
   const changeTimelineRows = monitoringChanges.slice(0, 12).map((c: any) => {
     const dateStr = new Date(c.date).toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" });
-    const impactColor = c.impact === "high" ? "#f85149" : c.impact === "medium" ? "#d29922" : "#3fb950";
+    const impactColor = changeImpactColor(c.impact);
     return `<tr>
       <td style="font-family:var(--mono);font-size:.8rem;white-space:nowrap">${escHtmlServer(dateStr)}</td>
       <td style="font-weight:600">${escHtmlServer(c.vendor)}</td>
       <td style="font-size:.85rem">${escHtmlServer(c.summary)}</td>
-      <td><span style="color:${impactColor};font-size:.8rem;font-weight:600">${escHtmlServer(c.impact?.toUpperCase() ?? "N/A")}</span></td>
+      <td><span style="color:${impactColor};font-size:.8rem;font-weight:600">${escHtmlServer(changeImpactLabel(c.impact))}</span></td>
     </tr>`;
   }).join("\n        ");
 
@@ -41129,12 +41198,12 @@ function buildStorageComparison2026Page(): string {
 
   const changeTimelineRows = storageChanges.slice(0, 12).map((c: any) => {
     const dateStr = new Date(c.date).toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" });
-    const impactColor = c.impact === "high" ? "#f85149" : c.impact === "medium" ? "#d29922" : "#3fb950";
+    const impactColor = changeImpactColor(c.impact);
     return `<tr>
       <td style="font-family:var(--mono);font-size:.8rem;white-space:nowrap">${escHtmlServer(dateStr)}</td>
       <td style="font-weight:600">${escHtmlServer(c.vendor)}</td>
       <td style="font-size:.85rem">${escHtmlServer(c.summary)}</td>
-      <td><span style="color:${impactColor};font-size:.8rem;font-weight:600">${escHtmlServer(c.impact?.toUpperCase() ?? "N/A")}</span></td>
+      <td><span style="color:${impactColor};font-size:.8rem;font-weight:600">${escHtmlServer(changeImpactLabel(c.impact))}</span></td>
     </tr>`;
   }).join("\n        ");
 
@@ -41927,18 +41996,17 @@ function buildTestingFreeTierComparison2026Page(): string {
 
   const testingVendorKeywords = ["Cypress", "Playwright", "BrowserStack", "Checkly", "Chromatic", "Codecov", "Postman", "LocalStack", "Testcontainers", "Percy", "Katalon", "Selenium", "Sauce Labs", "LambdaTest", "Applitools", "k6", "Grafana k6", "Artillery", "Gatling", "Locust", "BlazeMeter", "Argos", "BugBug", "Bencher"];
   const testingChanges = dealChanges.filter((c: any) =>
-    testingVendorKeywords.some(v => c.vendor === v || c.vendor.startsWith(v + " ") || c.vendor.includes(v)) ||
-    (c.summary && (c.summary.toLowerCase().includes("testing") || c.summary.toLowerCase().includes("test result") || c.summary.toLowerCase().includes("browser automation")))
+    testingVendorKeywords.some(v => c.vendor === v || c.vendor.startsWith(v + " ") || c.vendor.includes(v)) || c.category === "Testing"
   ).sort((a: any, b: any) => new Date(b.date).getTime() - new Date(a.date).getTime());
 
   const changeTimelineRows = testingChanges.slice(0, 12).map((c: any) => {
     const dateStr = new Date(c.date).toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" });
-    const impactColor = c.impact === "high" ? "#f85149" : c.impact === "medium" ? "#d29922" : "#3fb950";
+    const impactColor = changeImpactColor(c.impact);
     return `<tr>
       <td style="font-family:var(--mono);font-size:.8rem;white-space:nowrap">${escHtmlServer(dateStr)}</td>
       <td style="font-weight:600">${escHtmlServer(c.vendor)}</td>
       <td style="font-size:.85rem">${escHtmlServer(c.summary)}</td>
-      <td><span style="color:${impactColor};font-size:.8rem;font-weight:600">${escHtmlServer(c.impact?.toUpperCase() ?? "N/A")}</span></td>
+      <td><span style="color:${impactColor};font-size:.8rem;font-weight:600">${escHtmlServer(changeImpactLabel(c.impact))}</span></td>
     </tr>`;
   }).join("\n        ");
 
@@ -41979,7 +42047,7 @@ function buildTestingFreeTierComparison2026Page(): string {
     mainEntityOfPage: { "@type": "WebPage", "@id": `${BASE_URL}/${slug}` },
   };
 
-  return `<!DOCTYPE html>
+  return comparisonPageWithLiveRecords(`<!DOCTYPE html>
 <html lang="en">
 <head>
 <meta charset="utf-8">
@@ -42585,7 +42653,7 @@ ${mcpCtaCss()}
 </footer>
 <script>${mcpCtaScript()}</script>
 </body>
-</html>`;
+</html>`, pubDate, testingChanges);
 }
 
 function buildAnalyticsFreeTierComparison2026Page(): string {
@@ -42596,18 +42664,17 @@ function buildAnalyticsFreeTierComparison2026Page(): string {
 
   const analyticsVendorKeywords = ["PostHog", "Mixpanel", "Amplitude", "Plausible", "Google Analytics", "Umami", "Matomo", "Heap", "June", "Countly", "Fathom", "Simple Analytics", "Pirsch", "Pendo"];
   const analyticsChanges = dealChanges.filter((c: any) =>
-    analyticsVendorKeywords.some(v => c.vendor === v || c.vendor.startsWith(v + " ") || c.vendor.includes(v)) ||
-    (c.summary && (c.summary.toLowerCase().includes("analytics") || c.summary.toLowerCase().includes("event tracking") || c.summary.toLowerCase().includes("session replay")))
+    analyticsVendorKeywords.some(v => c.vendor === v || c.vendor.startsWith(v + " ") || c.vendor.includes(v)) || c.category === "Analytics"
   ).sort((a: any, b: any) => new Date(b.date).getTime() - new Date(a.date).getTime());
 
   const changeTimelineRows = analyticsChanges.slice(0, 12).map((c: any) => {
     const dateStr = new Date(c.date).toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" });
-    const impactColor = c.impact === "high" ? "#f85149" : c.impact === "medium" ? "#d29922" : "#3fb950";
+    const impactColor = changeImpactColor(c.impact);
     return `<tr>
       <td style="font-family:var(--mono);font-size:.8rem;white-space:nowrap">${escHtmlServer(dateStr)}</td>
       <td style="font-weight:600">${escHtmlServer(c.vendor)}</td>
       <td style="font-size:.85rem">${escHtmlServer(c.summary)}</td>
-      <td><span style="color:${impactColor};font-size:.8rem;font-weight:600">${escHtmlServer(c.impact?.toUpperCase() ?? "N/A")}</span></td>
+      <td><span style="color:${impactColor};font-size:.8rem;font-weight:600">${escHtmlServer(changeImpactLabel(c.impact))}</span></td>
     </tr>`;
   }).join("\n        ");
 
@@ -42648,7 +42715,7 @@ function buildAnalyticsFreeTierComparison2026Page(): string {
     mainEntityOfPage: { "@type": "WebPage", "@id": `${BASE_URL}/${slug}` },
   };
 
-  return `<!DOCTYPE html>
+  return comparisonPageWithLiveRecords(`<!DOCTYPE html>
 <html lang="en">
 <head>
 <meta charset="utf-8">
@@ -43268,7 +43335,7 @@ ${mcpCtaCss()}
 </footer>
 <script>${mcpCtaScript()}</script>
 </body>
-</html>`;
+</html>`, pubDate, analyticsChanges);
 }
 
 function buildApiDevelopmentFreeTierComparison2026Page(): string {
@@ -43279,18 +43346,17 @@ function buildApiDevelopmentFreeTierComparison2026Page(): string {
 
   const apiDevVendorKeywords = ["Postman", "Bruno", "Hoppscotch", "Insomnia", "Thunder Client", "Apidog", "HTTPie", "RapidAPI", "Paw", "Stoplight", "Swagger", "Scalar", "Mockoon", "Yaak"];
   const apiDevChanges = dealChanges.filter((c: any) =>
-    apiDevVendorKeywords.some(v => c.vendor === v || c.vendor.startsWith(v + " ") || c.vendor.includes(v)) ||
-    (c.summary && (c.summary.toLowerCase().includes("api client") || c.summary.toLowerCase().includes("api testing") || c.summary.toLowerCase().includes("postman")))
+    apiDevVendorKeywords.some(v => c.vendor === v || c.vendor.startsWith(v + " ") || c.vendor.includes(v)) || c.category === "API Development"
   ).sort((a: any, b: any) => new Date(b.date).getTime() - new Date(a.date).getTime());
 
   const changeTimelineRows = apiDevChanges.slice(0, 12).map((c: any) => {
     const dateStr = new Date(c.date).toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" });
-    const impactColor = c.impact === "high" ? "#f85149" : c.impact === "medium" ? "#d29922" : "#3fb950";
+    const impactColor = changeImpactColor(c.impact);
     return `<tr>
       <td style="font-family:var(--mono);font-size:.8rem;white-space:nowrap">${escHtmlServer(dateStr)}</td>
       <td style="font-weight:600">${escHtmlServer(c.vendor)}</td>
       <td style="font-size:.85rem">${escHtmlServer(c.summary)}</td>
-      <td><span style="color:${impactColor};font-size:.8rem;font-weight:600">${escHtmlServer(c.impact?.toUpperCase() ?? "N/A")}</span></td>
+      <td><span style="color:${impactColor};font-size:.8rem;font-weight:600">${escHtmlServer(changeImpactLabel(c.impact))}</span></td>
     </tr>`;
   }).join("\n        ");
 
@@ -43331,7 +43397,7 @@ function buildApiDevelopmentFreeTierComparison2026Page(): string {
     mainEntityOfPage: { "@type": "WebPage", "@id": `${BASE_URL}/${slug}` },
   };
 
-  return `<!DOCTYPE html>
+  return comparisonPageWithLiveRecords(`<!DOCTYPE html>
 <html lang="en">
 <head>
 <meta charset="utf-8">
@@ -43865,7 +43931,7 @@ ${mcpCtaCss()}
 </footer>
 <script>${mcpCtaScript()}</script>
 </body>
-</html>`;
+</html>`, pubDate, apiDevChanges);
 }
 
 function buildSecurityFreeTierComparison2026Page(): string {
@@ -43876,18 +43942,17 @@ function buildSecurityFreeTierComparison2026Page(): string {
 
   const secVendorKeywords = ["Snyk", "SonarCloud", "GitGuardian", "Semgrep", "Trivy", "OWASP ZAP", "Nuclei", "CodeQL", "Dependabot", "Renovate", "FOSSA", "Socket", "Tailscale", "Twingate", "1Password", "Checkov", "Grype", "Falco", "StackHawk", "Probely", "Gitleaks", "TruffleHog", "aikido", "SOOS"];
   const secChanges = dealChanges.filter((c: any) =>
-    secVendorKeywords.some(v => c.vendor === v || c.vendor.startsWith(v + " ") || c.vendor.includes(v)) ||
-    (c.summary && (c.summary.toLowerCase().includes("security") || c.summary.toLowerCase().includes("vulnerability") || c.summary.toLowerCase().includes("secret")))
+    secVendorKeywords.some(v => c.vendor === v || c.vendor.startsWith(v + " ") || c.vendor.includes(v)) || c.category === "Security" || c.category === "Code Quality"
   ).sort((a: any, b: any) => new Date(b.date).getTime() - new Date(a.date).getTime());
 
   const changeTimelineRows = secChanges.slice(0, 12).map((c: any) => {
     const dateStr = new Date(c.date).toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" });
-    const impactColor = c.impact === "high" ? "#f85149" : c.impact === "medium" ? "#d29922" : "#3fb950";
+    const impactColor = changeImpactColor(c.impact);
     return `<tr>
       <td style="font-family:var(--mono);font-size:.8rem;white-space:nowrap">${escHtmlServer(dateStr)}</td>
       <td style="font-weight:600">${escHtmlServer(c.vendor)}</td>
       <td style="font-size:.85rem">${escHtmlServer(c.summary)}</td>
-      <td><span style="color:${impactColor};font-size:.8rem;font-weight:600">${escHtmlServer(c.impact?.toUpperCase() ?? "N/A")}</span></td>
+      <td><span style="color:${impactColor};font-size:.8rem;font-weight:600">${escHtmlServer(changeImpactLabel(c.impact))}</span></td>
     </tr>`;
   }).join("\n        ");
 
@@ -43928,7 +43993,7 @@ function buildSecurityFreeTierComparison2026Page(): string {
     mainEntityOfPage: { "@type": "WebPage", "@id": `${BASE_URL}/${slug}` },
   };
 
-  return `<!DOCTYPE html>
+  return comparisonPageWithLiveRecords(`<!DOCTYPE html>
 <html lang="en">
 <head>
 <meta charset="utf-8">
@@ -44583,7 +44648,7 @@ ${mcpCtaCss()}
 </footer>
 <script>${mcpCtaScript()}</script>
 </body>
-</html>`;
+</html>`, pubDate, secChanges);
 }
 
 function buildHostingFreeTierComparison2026Page(): string {
@@ -44594,18 +44659,17 @@ function buildHostingFreeTierComparison2026Page(): string {
 
   const hostingVendorKeywords = ["Vercel", "Netlify", "Render", "Railway", "Fly.io", "Cloudflare Pages", "Cloudflare Workers", "Koyeb", "Deno Deploy", "GitHub Pages", "PythonAnywhere", "Hetzner", "Heroku", "Clever Cloud"];
   const hostingChanges = dealChanges.filter((c: any) =>
-    hostingVendorKeywords.some(v => c.vendor === v || c.vendor.startsWith(v + " ") || c.vendor.includes(v)) ||
-    (c.summary && (c.summary.toLowerCase().includes("hosting") || c.summary.toLowerCase().includes("deploy") || c.summary.toLowerCase().includes("paas")))
+    hostingVendorKeywords.some(v => c.vendor === v || c.vendor.startsWith(v + " ") || c.vendor.includes(v)) || c.category === "Cloud Hosting" || c.category === "Hosting"
   ).sort((a: any, b: any) => new Date(b.date).getTime() - new Date(a.date).getTime());
 
   const changeTimelineRows = hostingChanges.slice(0, 15).map((c: any) => {
     const dateStr = new Date(c.date).toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" });
-    const impactColor = c.impact === "high" ? "#f85149" : c.impact === "medium" ? "#d29922" : "#3fb950";
+    const impactColor = changeImpactColor(c.impact);
     return `<tr>
       <td style="font-family:var(--mono);font-size:.8rem;white-space:nowrap">${escHtmlServer(dateStr)}</td>
       <td style="font-weight:600">${escHtmlServer(c.vendor)}</td>
       <td style="font-size:.85rem">${escHtmlServer(c.summary)}</td>
-      <td><span style="color:${impactColor};font-size:.8rem;font-weight:600">${escHtmlServer(c.impact?.toUpperCase() ?? "N/A")}</span></td>
+      <td><span style="color:${impactColor};font-size:.8rem;font-weight:600">${escHtmlServer(changeImpactLabel(c.impact))}</span></td>
     </tr>`;
   }).join("\n        ");
 
@@ -44646,7 +44710,7 @@ function buildHostingFreeTierComparison2026Page(): string {
     mainEntityOfPage: { "@type": "WebPage", "@id": `${BASE_URL}/${slug}` },
   };
 
-  return `<!DOCTYPE html>
+  return comparisonPageWithLiveRecords(`<!DOCTYPE html>
 <html lang="en">
 <head>
 <meta charset="utf-8">
@@ -45206,7 +45270,7 @@ ${mcpCtaCss()}
 </footer>
 <script>${mcpCtaScript()}</script>
 </body>
-</html>`;
+</html>`, pubDate, hostingChanges);
 }
 
 const STRUCTURALLY_FREE_CARDS = [
@@ -45331,7 +45395,7 @@ function buildStateOfFreeTiersPage(): string {
 
   const squeezeHtml = negativeChanges.slice(0, 15).map(c => {
     const badge = changeTypeBadgeMap[c.change_type] ?? { label: c.change_type, color: "#8b949e" };
-    const impactColor = c.impact === "high" ? "#f85149" : c.impact === "medium" ? "#d29922" : "#8b949e";
+    const impactColor = changeImpactColor(c.impact);
     return `<div style="margin-bottom:.75rem;padding:.75rem 1rem;border-left:3px solid ${badge.color};background:var(--bg-card);border-radius:0 8px 8px 0">
       <div style="display:flex;align-items:center;gap:.5rem;margin-bottom:.3rem;flex-wrap:wrap">
         <span style="display:inline-block;padding:.1rem .5rem;border-radius:10px;font-size:.65rem;font-weight:600;background:${badge.color};color:#fff">${badge.label}</span>
@@ -49252,7 +49316,7 @@ function buildPricingChangesPage(): string {
 
   function buildChangeEntry(c: typeof allChanges[0]): string {
     const badge = changeTypeBadge[c.change_type] ?? { label: c.change_type, color: "#8b949e" };
-    const impactColor = c.impact === "high" ? "#f85149" : c.impact === "medium" ? "#d29922" : "#8b949e";
+    const impactColor = changeImpactColor(c.impact);
     const vendorSlug = toSlug(c.vendor);
     const dated = isEventDated(c);
     const isUpcoming = dated && c.date >= today;
@@ -49720,7 +49784,7 @@ function buildChangesPage(): string {
 
   function buildChangeEntry(c: typeof allChanges[0]): string {
     const badge = changeTypeBadge[c.change_type] ?? { label: c.change_type, color: "#8b949e" };
-    const impactColor = c.impact === "high" ? "#f85149" : c.impact === "medium" ? "#d29922" : "#8b949e";
+    const impactColor = changeImpactColor(c.impact);
     const vendorSlug = toSlug(c.vendor);
     const dated = isEventDated(c);
     const isUpcoming = dated && c.date >= today;
@@ -49941,7 +50005,7 @@ function buildExpiringPage(): string {
 
   function buildEntry(c: typeof allChanges[0], showCountdown: boolean): string {
     const badge = changeTypeBadge[c.change_type] ?? { label: c.change_type, color: "#8b949e" };
-    const impactColor = c.impact === "high" ? "#f85149" : c.impact === "medium" ? "#d29922" : "#8b949e";
+    const impactColor = changeImpactColor(c.impact);
     const vendorSlug = toSlug(c.vendor);
     const dated = isEventDated(c);
     const countdown = showCountdown && dated ? countdownLabel(c.date) : null;
@@ -52302,7 +52366,7 @@ h1{font-family:var(--serif);font-size:2.25rem;color:var(--text);margin:1rem 0 .5
 .timeline-head{display:flex;align-items:center;gap:.5rem;margin-bottom:.25rem;flex-wrap:wrap}
 .timeline-vendor{color:var(--text);font-weight:600;font-size:.85rem}
 .timeline-date{font-family:var(--mono);font-size:.75rem;color:var(--text-dim)}
-.impact{font-size:.7rem}.impact-high{color:#f85149}.impact-medium{color:#d29922}.impact-low{color:#8b949e}
+.impact{font-size:.7rem}.impact-high{color:#f85149}.impact-medium{color:#d29922}.impact-low{color:#8b949e}.impact-ungraded{color:#8b949e;font-style:italic}
 .timeline-summary{font-size:.85rem;color:var(--text-muted)}
 .no-data{color:var(--text-dim);font-size:.9rem;font-style:italic}
 .vendor-list{display:flex;flex-direction:column;gap:.4rem}

--- a/test/compiled-comparison-figures.test.ts
+++ b/test/compiled-comparison-figures.test.ts
@@ -1,0 +1,477 @@
+import { describe, it, before, after } from "node:test";
+import assert from "node:assert";
+import { spawn, type ChildProcess } from "node:child_process";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { fetchBadgeVerdicts, type SiteFreeTierVerdict } from "./badge-verdicts.ts";
+
+const {
+  comparedServicesOn,
+  compiledFigureSlots,
+  markCompiledFigures,
+  recordsSinceCompiled,
+  staticHalfOf,
+  subjectOfCardHeading,
+  timelineRecordsFor,
+  vendorSlugForSubject,
+} = await import("../dist/compiled-figures.js");
+const { CHANGE_IMPACT_LEVELS, changeImpactColor, changeImpactLabel, isChangeImpactLevel } =
+  await import("../dist/change-impact.js");
+const { vendorSlugMap } = await import("../dist/vendor-slug.js");
+
+type DealChange = import("../src/types.ts").DealChange;
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO = path.join(__dirname, "..");
+
+const changes: DealChange[] = JSON.parse(
+  readFileSync(path.join(REPO, "data", "deal_changes.json"), "utf-8"),
+).changes;
+
+const COMPILED_ON: Record<string, string> = {
+  analytics: "2026-04-01",
+  "api-development": "2026-04-01",
+  cicd: "2026-03-31",
+  cloud: "2026-03-31",
+  database: "2026-03-31",
+  hosting: "2026-04-03",
+  security: "2026-04-01",
+  serverless: "2026-03-31",
+  testing: "2026-04-01",
+};
+const SLUGS = Object.keys(COMPILED_ON);
+
+const ESCAPE: Record<string, string> = { "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;" };
+const esc = (text: string) => text.replace(/[&<>"]/g, c => ESCAPE[c]!);
+const shortDate = (iso: string) =>
+  new Date(iso).toLocaleDateString("en-US", { month: "short", day: "numeric", timeZone: "UTC" });
+const markup = { compiledOn: "2026-04-01", esc, shortDate };
+
+const FREE_TIER_FIGURE = /<strong>Free tier:<\/strong>(?!\s*none\.)/;
+const TODAY = new Date().toISOString().slice(0, 10);
+
+function cardBody(html: string, headingMarkup: string): string {
+  const at = html.indexOf(headingMarkup);
+  if (at < 0) return "";
+  const rest = html.slice(at + headingMarkup.length);
+  const close = rest.indexOf("</div>");
+  return close < 0 ? rest.slice(0, 1500) : rest.slice(0, close);
+}
+
+let port = 0;
+let proc: ChildProcess | null = null;
+let verdicts = new Map<string, SiteFreeTierVerdict>();
+const pages = new Map<string, string>();
+
+function startServer(): Promise<ChildProcess> {
+  return new Promise((resolve, reject) => {
+    const child = spawn("node", [path.join(REPO, "dist", "serve.js")], {
+      stdio: ["pipe", "pipe", "pipe"],
+      env: { ...process.env, PORT: "0", BASE_URL: "http://localhost", TZ: "UTC" },
+    });
+    const timeout = setTimeout(() => { child.kill(); reject(new Error("Server startup timeout")); }, 60000);
+    child.stderr!.on("data", (data: Buffer) => {
+      const m = data.toString().match(/running on http:\/\/localhost:(\d+)/);
+      if (m) { port = parseInt(m[1], 10); clearTimeout(timeout); resolve(child); }
+    });
+    child.on("error", (e) => { clearTimeout(timeout); reject(e); });
+  });
+}
+
+async function page(pathname: string): Promise<string> {
+  const cached = pages.get(pathname);
+  if (cached !== undefined) return cached;
+  const body = await (await fetch(`http://localhost:${port}${pathname}`)).text();
+  pages.set(pathname, body);
+  return body;
+}
+
+function comparisonPage(slug: string): Promise<string> {
+  return page(`/${slug}-free-tier-comparison-2026`);
+}
+
+function timelineHalf(html: string): string {
+  const at = html.indexOf('<h2 id="changes"');
+  return at < 0 ? "" : html.slice(at);
+}
+
+const subjectSlug = vendorSlugForSubject;
+
+function changesForSlug(slug: string): DealChange[] {
+  const vendor = vendorSlugMap.get(slug);
+  if (!vendor) return [];
+  return changes.filter(c => c.vendor.toLowerCase() === vendor.toLowerCase());
+}
+
+describe("the join between a compiled figure and the records that postdate it", () => {
+  const vendorChanges = [
+    { date: "2026-03-01", summary: "before" },
+    { date: "2026-04-02", summary: "after" },
+    { date: "2026-09-09", summary: "not yet in force" },
+  ];
+
+  it("returns only records dated after the compile date and no later than the served day", () => {
+    const since = recordsSinceCompiled(vendorChanges, "2026-04-01", "2026-09-06");
+    assert.deepStrictEqual(since.map(c => c.summary), ["after"]);
+  });
+
+  it("returns nothing when every record predates the compile date", () => {
+    assert.deepStrictEqual(recordsSinceCompiled(vendorChanges, "2026-12-31", "2027-01-01"), []);
+  });
+
+  it("orders the records newest first", () => {
+    const since = recordsSinceCompiled(vendorChanges, "2026-01-01", "2026-12-31");
+    assert.deepStrictEqual(since.map(c => c.date), ["2026-09-09", "2026-04-02", "2026-03-01"]);
+  });
+});
+
+describe("reading the subject a comparison card is about", () => {
+  it("takes the name before an em-dash tagline", () => {
+    assert.strictEqual(subjectOfCardHeading("Semgrep — best free SAST for teams"), "Semgrep");
+  });
+
+  it("drops a trailing parenthetical qualifier", () => {
+    assert.strictEqual(subjectOfCardHeading("Heap (Contentsquare)"), "Heap");
+  });
+
+  it("leaves a sentence heading whole so it resolves to no vendor", () => {
+    assert.strictEqual(
+      subjectOfCardHeading("Vercel Hobby plan bans commercial use"),
+      "Vercel Hobby plan bans commercial use",
+    );
+  });
+});
+
+describe("resolving the vendor a compiled figure is about", () => {
+  it("takes the vendor the page links before anything the label says", () => {
+    const slug = vendorSlugForSubject({ kind: "row", label: "Neon", linkedSlug: "supabase" });
+    assert.strictEqual(slug, "supabase");
+  });
+
+  it("reads the label when the page links no vendor", () => {
+    assert.strictEqual(vendorSlugForSubject({ kind: "row", label: "Supabase", linkedSlug: null }), "supabase");
+  });
+
+  it("ignores a link to a vendor the catalogue does not hold", () => {
+    const slug = vendorSlugForSubject({ kind: "row", label: "Supabase", linkedSlug: "a-vendor-we-do-not-track" });
+    assert.strictEqual(slug, "supabase");
+  });
+
+  it("refuses a card heading that only mentions a vendor in passing", () => {
+    const slug = vendorSlugForSubject({
+      kind: "card",
+      label: "Vercel Hobby plan bans commercial use",
+      linkedSlug: null,
+    });
+    assert.strictEqual(slug, null);
+  });
+});
+
+describe("the timeline population a compiled page draws on", () => {
+  const declared = [{ date: "2026-05-01", vendor: "Declared" }];
+  const held: Record<string, { date: string; vendor: string }[]> = {
+    Supabase: [{ date: "2026-09-03", vendor: "Supabase" }],
+  };
+
+  it("adds the records of a vendor the page prices and the declared scope misses", () => {
+    const rows = timelineRecordsFor(
+      declared,
+      [{ kind: "row", label: "Supabase", linkedSlug: null }],
+      (vendor: string) => held[vendor] ?? [],
+      12,
+    );
+    assert.deepStrictEqual(rows.map(r => r.vendor), ["Supabase", "Declared"]);
+  });
+
+  it("keeps the declared scope when the page names no vendor it can resolve", () => {
+    const rows = timelineRecordsFor(
+      declared,
+      [{ kind: "card", label: "Egress charges", linkedSlug: null }],
+      (vendor: string) => held[vendor] ?? [],
+      12,
+    );
+    assert.deepStrictEqual(rows.map(r => r.vendor), ["Declared"]);
+  });
+
+  it("holds the row limit and takes the newest records", () => {
+    const many = Array.from({ length: 20 }, (_, i) => ({ date: `2026-01-${String(i + 1).padStart(2, "0")}`, vendor: `v${i}` }));
+    const rows = timelineRecordsFor(many, [], () => [], 12);
+    assert.strictEqual(rows.length, 12);
+    assert.strictEqual(rows[0]!.date, "2026-01-20");
+  });
+});
+
+describe("marking a compiled figure whose vendor has moved since", () => {
+  const row =
+    '<table class="comp-table"><tbody><tr><td class="provider-col">Acme</td>' +
+    "<td>500 MB</td><td>Yes</td></tr></tbody></table>" +
+    '<h2 id="changes">Pricing Change Timeline</h2><tbody></tbody>';
+
+  it("flags a row whose vendor holds a record dated after the compile date", () => {
+    const marked = markCompiledFigures(row, () => ({
+      slug: "acme",
+      vendor: "Acme",
+      freeTierEnded: false,
+      endedBy: null,
+      since: [{ date: "2026-09-03", summary: "Storage cut to 100 MB" }],
+    }), markup);
+    assert.match(marked, /CHANGED SEP 3/);
+    assert.match(marked, /href="\/vendor\/acme#changes"/);
+    assert.doesNotMatch(marked, /line-through/);
+  });
+
+  it("leaves a row alone when nothing has been recorded since it was compiled", () => {
+    const marked = markCompiledFigures(row, () => ({
+      slug: "acme", vendor: "Acme", freeTierEnded: false, endedBy: null, since: [],
+    }), markup);
+    assert.strictEqual(marked, row);
+  });
+
+  it("strikes the figures in a row whose free tier the change log says has ended", () => {
+    const marked = markCompiledFigures(row, () => ({
+      slug: "acme",
+      vendor: "Acme",
+      freeTierEnded: true,
+      endedBy: { date: "2026-09-03", summary: "Free tier removed" },
+      since: [{ date: "2026-09-03", summary: "Free tier removed" }],
+    }), markup);
+    assert.match(marked, />FREE REMOVED</);
+    assert.match(marked, /line-through">500 MB<\/span>/);
+  });
+
+  it("does not strike a row that already declares the removal itself", () => {
+    const declared = row.replace(
+      '<td class="provider-col">Acme</td>',
+      '<td class="provider-col">Acme<span class="removed-badge">FREE REMOVED</span></td>',
+    );
+    const marked = markCompiledFigures(declared, () => ({
+      slug: "acme", vendor: "Acme", freeTierEnded: true, endedBy: null, since: [],
+    }), markup);
+    assert.match(marked, />FREE REMOVED</);
+    assert.doesNotMatch(marked, /line-through">500 MB/);
+  });
+
+  it("replaces the stated free tier on a card whose vendor no longer offers one", () => {
+    const card =
+      '<div class="diff-card"><h3>Acme</h3>' +
+      '<div class="diff-desc"><strong>Free tier:</strong> 50 units/month, unlimited users.</div></div>' +
+      '<h2 id="changes">Pricing Change Timeline</h2>';
+    const marked = markCompiledFigures(card, () => ({
+      slug: "acme",
+      vendor: "Acme",
+      freeTierEnded: true,
+      endedBy: { date: "2026-09-03", summary: "The free tier no longer exists." },
+      since: [{ date: "2026-09-03", summary: "The free tier no longer exists." }],
+    }), markup);
+    assert.doesNotMatch(marked, /50 units\/month/);
+    assert.match(marked, /<strong>Free tier:<\/strong> none\./);
+    assert.match(marked, /The free tier no longer exists\./);
+  });
+
+  it("quotes the record that ended the free tier, not whichever record is newest", () => {
+    const card =
+      '<div class="diff-card"><h3>Acme</h3>' +
+      '<div class="diff-desc"><strong>Free tier:</strong> 50 units/month.</div></div>' +
+      '<h2 id="changes">Pricing Change Timeline</h2>';
+    const marked = markCompiledFigures(card, () => ({
+      slug: "acme",
+      vendor: "Acme",
+      freeTierEnded: true,
+      endedBy: { date: "2026-03-23", summary: "Free tier replaced with a paid plan." },
+      since: [
+        { date: "2026-09-01", summary: "Seat pricing rearranged." },
+        { date: "2026-03-23", summary: "Free tier replaced with a paid plan." },
+      ],
+    }), markup);
+    assert.match(marked, /Free tier replaced with a paid plan\./);
+    assert.doesNotMatch(marked, /Seat pricing rearranged/);
+  });
+
+  it("marks nothing below the timeline heading", () => {
+    const below =
+      '<h2 id="changes">Pricing Change Timeline</h2>' +
+      '<table class="comp-table"><tr><td class="provider-col">Acme</td><td>500 MB</td></tr></table>';
+    const marked = markCompiledFigures(below, () => ({
+      slug: "acme", vendor: "Acme", freeTierEnded: true, endedBy: null, since: [],
+    }), markup);
+    assert.strictEqual(marked, below);
+  });
+});
+
+describe("grading the severity of a pricing change", () => {
+  it("gives each level its own colour", () => {
+    const colors = CHANGE_IMPACT_LEVELS.map(changeImpactColor);
+    assert.strictEqual(new Set(colors).size, CHANGE_IMPACT_LEVELS.length);
+  });
+
+  it("does not give a value outside the scale any level's colour", () => {
+    const scale = new Set(CHANGE_IMPACT_LEVELS.map(changeImpactColor));
+    for (const outside of ["negative", "", "HIGH", "critical"]) {
+      assert.ok(!scale.has(changeImpactColor(outside)), `${outside} took a colour reserved for a grade`);
+    }
+    assert.ok(!scale.has(changeImpactColor(undefined)));
+  });
+
+  it("labels a value outside the scale as ungraded rather than printing it as one", () => {
+    assert.strictEqual(changeImpactLabel("negative"), "UNGRADED");
+    assert.strictEqual(changeImpactLabel(undefined), "UNGRADED");
+    assert.strictEqual(changeImpactLabel("high"), "HIGH");
+  });
+
+  it("holds every stored record to the scale", () => {
+    const outside = changes.filter(c => !isChangeImpactLevel(c.impact));
+    assert.deepStrictEqual(outside.map(c => `${c.vendor}: ${c.impact}`), []);
+    assert.ok(changes.length >= 500, `only ${changes.length} records read`);
+  });
+});
+
+describe("the nine compiled comparison pages against the site's own verdicts", () => {
+  before(async () => {
+    proc = await startServer();
+    verdicts = await fetchBadgeVerdicts(port);
+  });
+
+  after(() => { proc?.kill(); });
+
+  it("reads a verdict for every vendor the site publishes a badge for", () => {
+    assert.ok(verdicts.size >= 1500, `only ${verdicts.size} badge verdicts read`);
+  });
+
+  it("states no free tier for a vendor whose free tier the site says has ended", async () => {
+    const stating: string[] = [];
+    let ended = 0;
+    for (const slug of SLUGS) {
+      const html = staticHalfOf(await comparisonPage(slug));
+      for (const slot of compiledFigureSlots(html)) {
+        const vendorSlug = subjectSlug(slot);
+        if (!vendorSlug || verdicts.get(vendorSlug) !== "ended") continue;
+        ended++;
+        if (!slot.markup.includes("FREE REMOVED")) stating.push(`${slug}: ${slot.label}`);
+        if (slot.kind === "card" && FREE_TIER_FIGURE.test(cardBody(html, slot.markup))) {
+          stating.push(`${slug}: ${slot.label} still prints a free tier figure`);
+        }
+      }
+    }
+    assert.deepStrictEqual(stating, []);
+    assert.ok(ended >= 6, `only ${ended} ended subjects found across the nine pages`);
+  });
+
+  it("marks every figure whose vendor holds a record dated after the page was compiled", async () => {
+    const unmarked: string[] = [];
+    let marked = 0;
+    for (const slug of SLUGS) {
+      const html = staticHalfOf(await comparisonPage(slug));
+      for (const slot of compiledFigureSlots(html)) {
+        const vendorSlug = subjectSlug(slot);
+        if (!vendorSlug) continue;
+        const since = recordsSinceCompiled(changesForSlug(vendorSlug), COMPILED_ON[slug]!, TODAY);
+        if (since.length === 0) continue;
+        marked++;
+        if (!/CHANGED [A-Z]{3} \d+|FREE REMOVED/.test(slot.markup)) unmarked.push(`${slug}: ${slot.label}`);
+      }
+    }
+    assert.deepStrictEqual(unmarked, []);
+    assert.ok(marked >= 60, `only ${marked} superseded figures found across the nine pages`);
+  });
+
+  it("links every marker to the record it rests on", async () => {
+    let links = 0;
+    for (const slug of SLUGS) {
+      const html = staticHalfOf(await comparisonPage(slug));
+      for (const m of html.matchAll(/<a href="\/vendor\/([a-z0-9-]+)#changes"[^>]*>(CHANGED [A-Z]{3} \d+|FREE REMOVED)</g)) {
+        assert.ok(vendorSlugMap.has(m[1]!), `${slug} links /vendor/${m[1]} and no such vendor exists`);
+        links++;
+      }
+    }
+    assert.ok(links >= 60, `only ${links} markers carry a link`);
+  });
+
+  it("marks only a slot whose heading names the vendor and nothing longer", async () => {
+    const overreaching: string[] = [];
+    let named = 0;
+    for (const slug of SLUGS) {
+      const html = staticHalfOf(await comparisonPage(slug));
+      for (const slot of compiledFigureSlots(html)) {
+        if (!/CHANGED [A-Z]{3} \d+|FREE REMOVED/.test(slot.markup)) continue;
+        named++;
+        const vendorSlug = subjectSlug(slot)!;
+        const vendor = vendorSlugMap.get(vendorSlug)!;
+        const label = slot.label.toLowerCase();
+        const name = vendor.toLowerCase();
+        if (!label.startsWith(name) && !name.startsWith(label)) {
+          overreaching.push(`${slug}: ${slot.label} marked as ${vendor}`);
+        }
+        if (slot.label.split(/\s+/).length > 4) {
+          overreaching.push(`${slug}: ${slot.label} is a sentence, not a vendor`);
+        }
+      }
+    }
+    assert.deepStrictEqual(overreaching, []);
+    assert.ok(named >= 60, `only ${named} marked slots read`);
+  });
+
+  it("selects the security timeline by vendor rather than by searching the summaries", async () => {
+    const timeline = timelineHalf(await comparisonPage("security"));
+    assert.doesNotMatch(timeline, /Prospect\.io/);
+    assert.ok(timeline.includes("<tbody>"), "the security page renders no timeline");
+  });
+
+  it("prints no timeline row whose severity is outside the scale", async () => {
+    let rows = 0;
+    for (const slug of SLUGS) {
+      const timeline = timelineHalf(await comparisonPage(slug));
+      for (const m of timeline.matchAll(/<span style="color:(#[0-9a-f]{6});font-size:\.8rem;font-weight:600">([A-Z]+)</g)) {
+        assert.ok(CHANGE_IMPACT_LEVELS.map(l => l.toUpperCase()).includes(m[2]!), `${slug} renders ${m[2]}`);
+        assert.strictEqual(changeImpactColor(m[2]!.toLowerCase()), m[1], `${slug} colours ${m[2]} off the scale`);
+        rows++;
+      }
+    }
+    assert.ok(rows >= 90, `only ${rows} timeline rows read`);
+  });
+
+  it("counts the services its own tables name", async () => {
+    const html = await comparisonPage("database");
+    const byline = html.match(/&middot; (\d+) database services compared/);
+    assert.ok(byline, "the database page prints no service count");
+    const inTables = new Set<string>();
+    for (const m of staticHalfOf(html).matchAll(/<td class="provider-col">([\s\S]*?)<\/td>/g)) {
+      const name = m[1]!
+        .replace(/<a href="\/vendor\/[a-z0-9-]+#changes"[\s\S]*?<\/a>/g, "")
+        .replace(/<span[^>]*class="[^"]*-badge[^"]*"[^>]*>[\s\S]*?<\/span>/g, "")
+        .replace(/<[^>]+>/g, "")
+        .replace(/\s+/g, " ")
+        .trim();
+      if (name) inTables.add(name);
+    }
+    assert.strictEqual(parseInt(byline[1]!, 10), inTables.size);
+    assert.deepStrictEqual(comparedServicesOn(html), [...inTables].sort());
+    assert.ok(inTables.size >= 15, `only ${inTables.size} services named`);
+  });
+
+  it("quotes the risk index at the size the risk index publishes", async () => {
+    const database = await comparisonPage("database");
+    const index = await page("/free-tier-risk");
+    const quoted = database.match(/we score (\d+) vendors/);
+    const published = index.match(/This index scores (\d+) major developer tools/);
+    assert.ok(quoted && published, "one of the two pages prints no count");
+    assert.strictEqual(quoted[1], published[1]);
+  });
+
+  it("prices Upstash Vector, Weaviate and Appwrite at what their own pages state", async () => {
+    const html = await comparisonPage("database");
+    assert.match(html, /200M vectors &times; dimensions/);
+    assert.match(html, /10K queries or updates a day/);
+    assert.doesNotMatch(html, /10K vectors free/);
+    assert.match(html, /Cloud: Free Forever/);
+    assert.doesNotMatch(html, /Cloud: 14-day sandbox/);
+    assert.match(html, /2 GB across 2 projects/);
+    assert.match(html, /paused after 1 week of inactivity/);
+  });
+
+  it("no longer sells the Applitools free tier its own record retired", async () => {
+    const html = await comparisonPage("testing");
+    assert.doesNotMatch(html, /Free tier:<\/strong> 50 Test Units/);
+    assert.match(html, /applitools-eyes#changes/);
+  });
+});

--- a/test/page-source-ratchet.test.ts
+++ b/test/page-source-ratchet.test.ts
@@ -1,5 +1,6 @@
 import { describe, it } from "node:test";
 import assert from "node:assert";
+import { readFileSync } from "node:fs";
 import {
   CATALOGUE_TEXT_FIELDS, PERTURBATION_SENTINEL, UNSOURCED_TIER_A_BASELINE,
   compiledClause, compiledNotice, dataProvenanceFor, freshnessSegmentFor, pageSourceViolations,
@@ -122,7 +123,11 @@ describe("the number of tier-A pages asserting vendor facts from nowhere only go
   });
 
   it("is the number the shipped register holds", () => {
-    assert.strictEqual(UNSOURCED_TIER_A_BASELINE, 41);
+    const shipped = parsePageReviews(
+      readFileSync(new URL("../data/page-reviews.json", import.meta.url), "utf-8"),
+    ).pages;
+    assert.strictEqual(UNSOURCED_TIER_A_BASELINE, unsourcedTierAPaths(shipped).length);
+    assert.ok(shipped.length > 60, `only ${shipped.length} pages on the register`);
   });
 });
 

--- a/test/stale-page-facts.test.ts
+++ b/test/stale-page-facts.test.ts
@@ -336,7 +336,7 @@ describe("#1321 the FAQ counts are budgets too, and they live in the same file",
     const budgets = readQualityBudgets().budgets;
     const { unmeasured, lowered, over } = ratchet(budgets, {
       stale_fact_pages: 57,
-      unsourced_tier_a: 41,
+      unsourced_tier_a: budgets.unsourced_tier_a,
       uncited_change_records: budgets.uncited_change_records,
       source_checks_ok_without_quoted_evidence: budgets.source_checks_ok_without_quoted_evidence,
       records_with_superseded_terms: budgets.records_with_superseded_terms,


### PR DESCRIPTION
Refs #1409.

The nine `-free-tier-comparison-2026` pages each held a table compiled in March or April and, further down the same page, a live timeline of our own records saying those figures had moved. Neither half knew the other existed. This joins them at the cell.

## The join is one helper, not nine copies

`src/compiled-figures.ts` holds the whole mechanism:

- `recordsSinceCompiled(vendorChanges, compiledOn, servedOn)` — AC-3's join. Given a vendor's records and a compile date it returns the ones that postdate it, newest first, excluding anything not yet in force.
- `compiledFigureSlots(html)` / `markCompiledFigures(html, lookup, options)` — **discovers** the slots rather than reading a list. It walks the page's static half for `<td class="provider-col">` cells and `<div class="diff-card"><h3>` headings, resolves each to a catalogue vendor through `assertedVendorSlugs` and the `/vendor/` link the page already carries, and marks what the join returns.
- `replaceTimelineRows` / `fillComparedServicesCount` — the timeline population and the service count, both derived from the same discovery.

Each of the nine pages is now one call: `comparisonPageWithLiveRecords(html, pubDate, declaredScope)`. The next hardcoded editorial array is a call site.

Discovery is why this found subjects the issue did not name. **Plausible Analytics** carries a `BEST PRIVACY` badge on `/analytics-free-tier-comparison-2026` and sold a free tier; our record says its plans start at $9/mo with a trial. **DBOS** is priced on `/serverless-free-tier-comparison-2026` and its cloud free tier went in April.

## What moved

Measured against production (2,572 sitemap paths, 0 status changes, 0 5xx):

| | before | after |
|---|---|---|
| figures marked as superseded on the nine pages | 0 | 77 |
| free tiers stated for a vendor whose free tier has ended | 6 | 0 |
| ended vendors flagged at the cell | 1, hand-written | 9, derived and linked |
| change records graded outside high/medium/low | 5 | 0 |
| timeline rows rendering an ungraded severity in a grade's colour | 1 | 0 |
| `/security-free-tier-comparison-2026` rows selected by searching summary prose | 4 of 8 | 0 |
| `/database-free-tier-comparison-2026` byline | "44 database services" | 20, counted from its own tables |
| the same page's risk-index reference | "we score 38 vendors" | 37, read from `/free-tier-risk` |

107 routes moved. 9 are the comparison pages; the rest render one of the five re-graded records or a `low` severity label, whose colour is discussed below.

## AC-4 — the four figures, checked against the vendors' own pages today

- **Applitools Eyes** — `applitools.com/pricing` redirects to `/platform-pricing/`; lowest plan Starter, $667/mo paid annually. No free tier. The card now states none and cites the record.
- **Upstash Vector** — Free plan is **200 Million** max vectors × dimensions, 1,536 max dimensions, **10K daily query/update limit**, 1 GB. The table had taken the daily query cap as the capacity, and the verdict that it is "limited for production workloads" rested on it.
- **Weaviate** — `weaviate.io/pricing` sells **Free Forever, $0/mo**, always free: 1 cluster, 100,000 objects, 1 GB memory, 10 GB disk, 1 collection, 3 tenants. Not a 14-day sandbox.
- **Appwrite** — figures were right; the plan card's two constraints were missing. Free is capped at **2 projects** and a free project is **paused after 1 week of inactivity**.

## AC-5 — severity is validated, and an unknown value is not a grade

`src/change-impact.ts` is now the single scale. All 45 render sites read it, `scripts/validate-data.ts` refuses a value outside `high|medium|low`, and the weekly digest gets an "Impact Not Graded" section rather than silently bucketing an unknown value as low.

The five `negative` records are graded on their merits rather than blanket-high, calibrated against how the corpus already grades this: **Alibaba Cloud Qwen Code** (free tier cut 1,000 → 100 daily requests) and **SendGrid Accelerate** (programme discontinued) are `high`; **Prospect.io**, **Kluster AI** and **searchly.com** are index removals of niche listings, which the 36 other `free_tier_removed low` records are too.

One deliberate consequence: three render sites used `#8b949e` for `low` and for everything unrecognised. Once an unknown value must be visibly not-a-grade, those two cannot share a colour, so `low` takes the same green the other 42 sites give it. That is the `low` label on `/changes`, the `low impact` line on vendor and compare pages, and the `/deadlines` countdown border.

## AC-6 — vendor membership, not pattern-matching the copy

Six of the nine selected timeline rows with `summary.toLowerCase().includes(...)`. Each now selects on the page's category instead, and the shared pass adds every vendor the page's own tables name — which is what puts **Momento** on the database timeline, a vendor the 18-name keyword list could not see while the table above recommended it.

## Verification

- 4,109 tests, 0 failures, 34 new.
- 20 mutations of the join, the marker, the scale and the resolver.
- Route sweep of 2,572 sitemap paths against production: 107 moved, 0 status changes, 0 5xx.
- The new tests take `/badges` — one fetch, 1,572 vendors, a page none of the nine builds — as the oracle for what the site says about a free tier, rather than recomputing the claim.

`/hosting-free-tier-comparison-2026` now measures as reading the catalogue under the perturbation harness, so its register entry moves to `catalogue` and the `unsourced_tier_a` budget ratchets 41 → 40. The other eight resolve their verdicts from change records, so a catalogue text perturbation leaves them byte-identical.
