### PR TITLE
Withhold the verification claim from the meta description where the source check failed (#1412)

### DIFF
--- a/scripts/mutate-1412.mjs
+++ b/scripts/mutate-1412.mjs
@@ -1,0 +1,98 @@
+import { readFileSync, writeFileSync } from "node:fs";
+import { execFileSync } from "node:child_process";
+
+const SUITE = [
+  "test/meta-description-withholding.test.ts",
+];
+
+const MUTANTS = [
+  ["meta-never-reads-the-source-check", "src/serve.ts",
+    `  const metaVerifiedSentence = termsUnconfirmed && !discontinuedOn
+    ? \` \${unconfirmedTermsMetaSentence(termsUnconfirmed)}\`
+    : verifiedSentence;`,
+    `  const metaVerifiedSentence = verifiedSentence;`],
+  ["meta-withholds-on-every-vendor", "src/serve.ts",
+    `  const metaVerifiedSentence = termsUnconfirmed && !discontinuedOn
+    ? \` \${unconfirmedTermsMetaSentence(termsUnconfirmed)}\`
+    : verifiedSentence;`,
+    `  const metaVerifiedSentence = \` \${unconfirmedTermsMetaSentence(termsUnconfirmed ?? "unreadable")}\`;`],
+  ["meta-states-nothing-about-verification", "src/serve.ts",
+    `  const metaVerifiedSentence = termsUnconfirmed && !discontinuedOn
+    ? \` \${unconfirmedTermsMetaSentence(termsUnconfirmed)}\`
+    : verifiedSentence;`,
+    `  const metaVerifiedSentence = "";`],
+  ["discontinuation-loses-its-place-to-the-withholding", "src/serve.ts",
+    `  const metaVerifiedSentence = termsUnconfirmed && !discontinuedOn`,
+    `  const metaVerifiedSentence = termsUnconfirmed`],
+  ["the-source-check-never-reaches-the-verdict-input", "src/serve.ts",
+    `      sourceCheck: primary.source_check?.outcome ?? null,`,
+    `      sourceCheck: null,`],
+  ["the-body-stops-sharing-the-predicate", "src/serve.ts",
+    `  const amountUnstatedLine = !levelWithheld && termsUnconfirmed === "states_no_amount"`,
+    `  const amountUnstatedLine = !levelWithheld && termsUnconfirmed === "unreadable"`],
+  ["predicate-passes-every-outcome", "src/source-check.ts",
+    `  return outcome && outcome !== "ok" ? outcome : null;`,
+    `  return null;`],
+  ["predicate-fails-every-outcome", "src/source-check.ts",
+    `  return outcome && outcome !== "ok" ? outcome : null;`,
+    `  return outcome ? (outcome as TermsUnconfirmedReason) : null;`],
+  ["predicate-forgets-that-a-plan-without-an-amount-is-unconfirmed", "src/source-check.ts",
+    `  return outcome && outcome !== "ok" ? outcome : null;`,
+    `  return outcome && outcome !== "ok" && outcome !== "states_no_amount" ? outcome : null;`],
+  ["predicate-forgets-the-unreadable-page", "src/source-check.ts",
+    `  return outcome && outcome !== "ok" ? outcome : null;`,
+    `  return outcome && outcome !== "ok" && outcome !== "unreadable" ? outcome : null;`],
+  ["meta-clause-stops-quoting-the-body", "src/source-check.ts",
+    `  does_not_name_vendor: WITHHELD_LEVEL_CLAUSES.does_not_name_vendor(""),
+  states_no_terms: WITHHELD_LEVEL_CLAUSES.states_no_terms(""),
+  unreadable: WITHHELD_LEVEL_CLAUSES.unreadable(""),`,
+    `  does_not_name_vendor: "we cannot confirm this",
+  states_no_terms: "we cannot confirm this",
+  unreadable: "we cannot confirm this",`],
+  ["every-outcome-reads-the-same-to-a-reader", "src/source-check.ts",
+    `export function unconfirmedTermsClause(reason: TermsUnconfirmedReason): string {
+  return UNCONFIRMED_TERMS_CLAUSES[reason];
+}`,
+    `export function unconfirmedTermsClause(reason: TermsUnconfirmedReason): string {
+  return UNCONFIRMED_TERMS_CLAUSES[reason] && UNCONFIRMED_TERMS_CLAUSES.unreadable;
+}`],
+  ["a-plan-without-an-amount-reads-as-an-unreadable-page", "src/source-check.ts",
+    `  states_no_amount: \`the page we cite for this offer names a plan but states no amount\`,`,
+    `  states_no_amount: WITHHELD_LEVEL_CLAUSES.unreadable(""),`],
+  ["the-withholding-sentence-says-nothing", "src/vendor-verdict.ts",
+    `  return \`Not verified — \${unconfirmedTermsClause(reason)}.\`;`,
+    `  return "";`],
+  ["the-withholding-sentence-keeps-the-verification-word", "src/vendor-verdict.ts",
+    `  return \`Not verified — \${unconfirmedTermsClause(reason)}.\`;`,
+    `  return \`Verified August 2026 — \${unconfirmedTermsClause(reason)}.\`;`],
+  ["the-withholding-sentence-drops-its-cause", "src/vendor-verdict.ts",
+    `  return \`Not verified — \${unconfirmedTermsClause(reason)}.\`;`,
+    `  return "Not verified.";`],
+];
+
+function run(cmd, args) {
+  try {
+    execFileSync(cmd, args, { stdio: "pipe", encoding: "utf-8" });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+const survivors = [];
+for (const [name, file, from, to] of MUTANTS) {
+  const original = readFileSync(file, "utf-8");
+  if (!original.includes(from)) {
+    console.log(`SKIP  ${name} — the line it mutates is not in ${file}`);
+    continue;
+  }
+  writeFileSync(file, original.replace(from, to));
+  const built = run("npm", ["run", "build"]);
+  const green = built && run("node", ["--test", "--test-concurrency", "1", ...SUITE]);
+  writeFileSync(file, original);
+  console.log(`${green ? "SURVIVED" : built ? "killed  " : "killed (did not compile)"}  ${name}`);
+  if (green) survivors.push(name);
+}
+run("npm", ["run", "build"]);
+console.log(`\n${MUTANTS.length - survivors.length}/${MUTANTS.length} killed`);
+if (survivors.length > 0) console.log("survivors:", survivors.join(", "));

--- a/src/serve.ts
+++ b/src/serve.ts
@@ -19,14 +19,14 @@ import { configureVendorSeries, recordVendorRequest, flushVendorSeries, readVend
 import { openapiSpec } from "./openapi.js";
 import { LINK_GRACE_DAYS, unreachableNoticeForUrl } from "./link-health.js";
 import { offerEnded, offerRetired, recordedTierSentence, endedHeadline, endedHistorySentence, endedReliabilitySentence, endedEmptyChangeHistorySentence, ENDED_BADGE_LABEL, ENDED_SINCE_CHANGES_SENTENCE, type OfferTierAndUrl } from "./retirement.js";
-import { amountUnstatedSentence, levelWithheldReason, sourceStatesNoAmount, withheldLevelClause, withheldLevelSentence, type LevelWithheldReason } from "./source-check.js";
+import { amountUnstatedSentence, levelWithheldReason, withheldLevelClause, withheldLevelSentence, type LevelWithheldReason } from "./source-check.js";
 import { readingIsBehindTheLoop, reverificationIntervalDays } from "./badge-staleness.js";
 import { SUPERSEDED_TERMS_LABEL, openingOfTerms, readingBehindTheChange, supersededTermsAnswer, supersededTermsMetaSentence, supersededTermsNotice, supersededTermsNoticeHtml, supersededTermsRecord, supersededTermsVerdictSentence, supersedingChange, type SupersededTermsRecord } from "./superseded-description.js";
 import { NO_CURRENT_FIGURE, costHeadlineCaveat, limitCellText, mayRecommendAsFree, proseWithoutNames, readsActive, stackFreshnessStatement } from "./stack-claim.js";
 import { changesByVendor } from "./superseded-census.js";
 import { buildComparisonMap, comparisonSlug } from "./comparison-pairs.js";
 import { comparisonVerdictText, freeTierFaqAnswer, stabilityFaqAnswer, type ComparisonSide, type FreeTierSide, type SideFreeTier, type StabilityRating } from "./comparison-verdict.js";
-import { publishedVendorLevel, vendorVerdictSentence, vendorBadge, freeTierClaim, statesRiskCause, narrowingSentence, changeKindNoun, type BadgeWithholding, type FreeTierClaim, type VendorVerdictInput } from "./vendor-verdict.js";
+import { publishedVendorLevel, vendorVerdictSentence, vendorBadge, freeTierClaim, statesRiskCause, narrowingSentence, changeKindNoun, termsUnconfirmedBySource, unconfirmedTermsMetaSentence, type BadgeWithholding, type FreeTierClaim, type VendorVerdictInput } from "./vendor-verdict.js";
 import { tierRecordsAFreeTier } from "./free-tier-record.js";
 import { UNGRADED_IMPACT_COLOR, changeImpactColor, changeImpactLabel, changeImpactWord, isChangeImpactLevel } from "./change-impact.js";
 import { COMPARED_SERVICES_PLACEHOLDER, fillComparedServicesCount, markCompiledFigures, recordsSinceCompiled, replaceTimelineRows, timelineRecordsFor, vendorSlugForSubject, vendorSubjectsOnCompiledPage, type CompiledFigureSubject, type CompiledFigureVerdict } from "./compiled-figures.js";
@@ -890,6 +890,7 @@ function buildVendorVerdictContext(vendorName: string, servedOn: string): Vendor
       offerEnded: offerEnded(primary),
       gate: gate?.code ?? null,
       linkUnreachable: Boolean(linkUnreachable),
+      sourceCheck: primary.source_check?.outcome ?? null,
     },
   };
 }
@@ -4268,7 +4269,9 @@ function buildVendorPage(slug: string): string | null {
     ? `  <p class="link-unreachable-line" style="margin:.4rem 0 .6rem;font-size:.9rem;color:var(--text-muted)"><strong style="color:#f85149">Link unreachable:</strong> ${escHtmlServer(primary.url)} did not resolve on our check of <span class="link-checked-date" style="font-family:var(--mono)">${escHtmlServer(linkUnreachable.checked)}</span>. ${linkUnreachable.last_reachable ? `Last reachable <span class="link-last-reachable" style="font-family:var(--mono)">${escHtmlServer(linkUnreachable.last_reachable)}</span>.` : "We have no date on which it was reachable."}</p>`
     : "";
 
-  const amountUnstatedLine = !levelWithheld && sourceStatesNoAmount(primary)
+  const termsUnconfirmed = termsUnconfirmedBySource(verdictInput);
+
+  const amountUnstatedLine = !levelWithheld && termsUnconfirmed === "states_no_amount"
     ? `\n  <p class="amount-unstated-line" style="margin:.4rem 0 .6rem;font-size:.9rem;color:var(--text-muted)"><strong style="color:#d29922">Source states no amount:</strong> ${escHtmlServer(amountUnstatedSentence(vendorName))}</p>`
     : "";
 
@@ -4353,12 +4356,15 @@ function buildVendorPage(slug: string): string | null {
   const verifiedSentence = discontinuedOn
     ? ` Discontinued ${discontinuedOn}.`
     : enriched.link_unreachable ? "" : ` Verified ${verifiedMonth}.`;
+  const metaVerifiedSentence = termsUnconfirmed && !discontinuedOn
+    ? ` ${unconfirmedTermsMetaSentence(termsUnconfirmed)}`
+    : verifiedSentence;
   const eligibilityGateSentence = primaryEligibilityGate ? `${primaryEligibilityGate.reason} ` : "";
   const metaDesc = eligibilityGateSentence + (termsSuperseded
     ? `${supersededTermsMetaSentence(vendorName, termsSuperseded)} See the recorded change history${alternatives.length > 0 ? ` and ${alternatives.length} alternatives in ${primary.category}` : ""}.`
     : hasFree
-    ? `${vendorName} free tier includes ${descLimits}.${verifiedSentence}${alternatives.length > 0 ? ` Compare with ${alternatives.length} alternatives in ${primary.category}.` : ""}`
-    : `${vendorName} pricing details${alternatives.length > 0 ? ` and ${alternatives.length} free alternatives in ${primary.category}` : ""}.${verifiedSentence}`);
+    ? `${vendorName} free tier includes ${descLimits}.${metaVerifiedSentence}${alternatives.length > 0 ? ` Compare with ${alternatives.length} alternatives in ${primary.category}.` : ""}`
+    : `${vendorName} pricing details${alternatives.length > 0 ? ` and ${alternatives.length} free alternatives in ${primary.category}` : ""}.${metaVerifiedSentence}`);
 
   const keyLimit = publishableTerms.slice(0, 120).replace(/\.\s.*$/, "");
   const verdictLine2 = vendorVerdictSentence(verdictInput);

--- a/src/source-check.ts
+++ b/src/source-check.ts
@@ -46,6 +46,25 @@ export function withheldLevelSentence(
   return WITHHELD_LEVEL_SENTENCES[reason](subject, since);
 }
 
+export type TermsUnconfirmedReason = Exclude<SourceCheckOutcome, "ok">;
+
+const UNCONFIRMED_TERMS_CLAUSES: Record<TermsUnconfirmedReason, string> = {
+  does_not_name_vendor: WITHHELD_LEVEL_CLAUSES.does_not_name_vendor(""),
+  states_no_terms: WITHHELD_LEVEL_CLAUSES.states_no_terms(""),
+  unreadable: WITHHELD_LEVEL_CLAUSES.unreadable(""),
+  states_no_amount: `the page we cite for this offer names a plan but states no amount`,
+};
+
+export function unconfirmedTermsClause(reason: TermsUnconfirmedReason): string {
+  return UNCONFIRMED_TERMS_CLAUSES[reason];
+}
+
+export function termsUnconfirmedOutcome(
+  outcome: SourceCheckOutcome | null | undefined,
+): TermsUnconfirmedReason | null {
+  return outcome && outcome !== "ok" ? outcome : null;
+}
+
 export const NAMING_TOKENS_RECORDED_INSTEAD_OF_EVIDENCE = ["text", "url", "host"];
 
 export const NAMING_TOKENS_TAKEN_FROM_THE_URL_WE_ASKED_FOR = ["url", "host"];

--- a/src/vendor-verdict.ts
+++ b/src/vendor-verdict.ts
@@ -1,9 +1,15 @@
-import type { DealChange, RatingWithheld, RiskCause } from "./types.js";
+import type { DealChange, RatingWithheld, RiskCause, SourceCheckOutcome } from "./types.js";
 import { CHANGE_DIRECTION, isACorrectionToOurOwnRecord } from "./data.js";
 import { isNoLongerInForce } from "./change-resolution.js";
 import { changeIsUncited, ratingWithheldForNoSourceSentence } from "./change-citation.js";
 import { changeDateClause } from "./change-dates.js";
-import { withheldLevelClause, type LevelWithheldReason } from "./source-check.js";
+import {
+  termsUnconfirmedOutcome,
+  unconfirmedTermsClause,
+  withheldLevelClause,
+  type LevelWithheldReason,
+  type TermsUnconfirmedReason,
+} from "./source-check.js";
 import type { GateCode } from "./ranking.js";
 import { endedVerdictSentence } from "./retirement.js";
 import { vendorHistorySentence, type PublishedRiskLevel } from "./vendor-history.js";
@@ -42,6 +48,7 @@ export interface VendorVerdictInput {
   offerEnded?: boolean;
   gate?: GateCode | null;
   linkUnreachable?: boolean;
+  sourceCheck?: SourceCheckOutcome | null;
 }
 
 export type BadgeWithholding =
@@ -76,6 +83,14 @@ function narrowingChanges(
 
 export function ratingWithheldForNoSource(input: VendorVerdictInput): boolean {
   return Boolean(input.ratingWithheld) && publishedVendorLevel(input.level, input.cause) === "stable";
+}
+
+export function termsUnconfirmedBySource(input: VendorVerdictInput): TermsUnconfirmedReason | null {
+  return termsUnconfirmedOutcome(input.sourceCheck);
+}
+
+export function unconfirmedTermsMetaSentence(reason: TermsUnconfirmedReason): string {
+  return `Not verified — ${unconfirmedTermsClause(reason)}.`;
 }
 
 export function withholdingDecides(input: VendorVerdictInput): boolean {

--- a/test/meta-description-withholding.test.ts
+++ b/test/meta-description-withholding.test.ts
@@ -1,0 +1,252 @@
+import { describe, it, before, after } from "node:test";
+import assert from "node:assert";
+import { spawn, type ChildProcess } from "node:child_process";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO = path.join(__dirname, "..");
+
+const { loadOffers, loadDealChanges } = await import("../dist/data.js");
+const { vendorSlugMap } = await import("../dist/vendor-slug.js");
+const { supersedingChange } = await import("../dist/superseded-description.js");
+const { discontinuedOnOrBefore } = await import("../dist/product-deprecation.js");
+const { utcDate } = await import("../dist/ranking.js");
+const { unconfirmedTermsClause, withheldLevelClause } = await import("../dist/source-check.js");
+const { termsUnconfirmedBySource, unconfirmedTermsMetaSentence } = await import("../dist/vendor-verdict.js");
+
+type Outcome = "ok" | "states_no_amount" | "does_not_name_vendor" | "states_no_terms" | "unreadable";
+
+interface Subject {
+  slug: string;
+  vendor: string;
+  outcome: Outcome | null;
+  verifiedMonth: string;
+  termsSuperseded: boolean;
+  discontinuedOn: string | null;
+}
+
+const MONTHS = [
+  "January", "February", "March", "April", "May", "June",
+  "July", "August", "September", "October", "November", "December",
+];
+
+function monthLabel(isoDate: string): string {
+  const [year, month] = isoDate.split("-");
+  return `${MONTHS[parseInt(month, 10) - 1]} ${year}`;
+}
+
+const VERIFIED_ASSERTION = new RegExp(`Verified (?:${MONTHS.join("|")}) \\d{4}`);
+
+function capitalise(text: string): string {
+  return `${text.charAt(0).toUpperCase()}${text.slice(1)}`;
+}
+
+function assertedMonth(text: string): string | null {
+  const m = text.match(VERIFIED_ASSERTION);
+  return m ? m[0].replace("Verified ", "") : null;
+}
+
+let subjects: Subject[] = [];
+let serverPort = 0;
+let proc: ChildProcess | null = null;
+
+function startHttpServer(): Promise<{ child: ChildProcess; port: number }> {
+  return new Promise((resolve, reject) => {
+    const child = spawn("node", [path.join(REPO, "dist", "serve.js")], {
+      stdio: ["pipe", "pipe", "pipe"],
+      env: { ...process.env, PORT: "0", BASE_URL: "http://localhost", TZ: "UTC" },
+    });
+    const timeout = setTimeout(() => { child.kill(); reject(new Error("Server startup timeout")); }, 60000);
+    child.stderr!.on("data", (data: Buffer) => {
+      const m = data.toString().match(/running on http:\/\/localhost:(\d+)/);
+      if (m) { clearTimeout(timeout); resolve({ child, port: parseInt(m[1], 10) }); }
+    });
+    child.on("error", (err) => { clearTimeout(timeout); reject(err); });
+  });
+}
+
+before(async () => {
+  const offers = loadOffers();
+  const changesByVendor = new Map<string, Array<{ vendor: string }>>();
+  for (const change of loadDealChanges() as Array<{ vendor: string }>) {
+    const key = change.vendor.toLowerCase();
+    const held = changesByVendor.get(key);
+    if (held) held.push(change);
+    else changesByVendor.set(key, [change]);
+  }
+
+  const servedOn = utcDate();
+  subjects = [...vendorSlugMap.entries()].flatMap(([slug, vendor]: [string, string]) => {
+    const primary = offers.find((o: { vendor: string }) => o.vendor === vendor);
+    if (!primary) return [];
+    const vendorChanges = changesByVendor.get(vendor.toLowerCase()) ?? [];
+    return [{
+      slug,
+      vendor,
+      outcome: (primary.source_check?.outcome ?? null) as Outcome | null,
+      verifiedMonth: monthLabel(primary.verifiedDate),
+      termsSuperseded: supersedingChange(primary, vendorChanges) !== null,
+      discontinuedOn: discontinuedOnOrBefore(vendorChanges, servedOn),
+    }];
+  });
+
+  assert.ok(subjects.length > 1000, `the catalogue did not load: ${subjects.length} vendors`);
+  const started = await startHttpServer();
+  proc = started.child;
+  serverPort = started.port;
+});
+
+after(() => { if (proc) proc.kill(); });
+
+interface Rendered {
+  meta: string;
+  byline: string;
+  verdict: string;
+  amountLine: string;
+}
+
+let rendered: Map<string, Rendered> | null = null;
+
+function extract(html: string): Rendered {
+  return {
+    meta: html.match(/<meta name="description" content="([^"]*)"/)?.[1] ?? "",
+    byline: html.match(/<p class="page-meta">([\s\S]*?)<\/p>/)?.[1] ?? "",
+    verdict: html.match(/<div class="quick-verdict">\s*<p>([\s\S]*?)<\/p>/)?.[1] ?? "",
+    amountLine: html.match(/<p class="amount-unstated-line"[^>]*>([\s\S]*?)<\/p>/)?.[1] ?? "",
+  };
+}
+
+async function everyVendorPage(): Promise<Map<string, Rendered>> {
+  if (rendered) return rendered;
+  const pages = new Map<string, Rendered>();
+  let queue = 0;
+  const worker = async () => {
+    while (queue < subjects.length) {
+      const { slug } = subjects[queue++];
+      const res = await fetch(`http://localhost:${serverPort}/vendor/${slug}`);
+      assert.strictEqual(res.status, 200, `/vendor/${slug} returned ${res.status}`);
+      pages.set(slug, extract(await res.text()));
+    }
+  };
+  await Promise.all(Array.from({ length: 12 }, worker));
+  rendered = pages;
+  return pages;
+}
+
+const sourceCheckFailed = (s: Subject) => s.outcome !== null && s.outcome !== "ok";
+
+describe("#1412 the meta description withholds wherever the source check failed", () => {
+  it("asserts a verification on no vendor whose cited page did not confirm the terms", async () => {
+    const pages = await everyVendorPage();
+    const population = subjects.filter(sourceCheckFailed);
+    assert.ok(population.length > 700, `only ${population.length} records have a failed source check`);
+
+    const claiming = population.filter(s => assertedMonth(pages.get(s.slug)!.meta) !== null);
+    assert.deepStrictEqual(
+      claiming.map(s => `${s.slug} [${s.outcome}]`).slice(0, 20),
+      [],
+      `${claiming.length} of ${population.length} meta descriptions assert a verification the source check did not make`,
+    );
+  });
+
+  it("publishes in the meta the same withholding the page body publishes", async () => {
+    const pages = await everyVendorPage();
+    const population = subjects
+      .filter(sourceCheckFailed)
+      .filter(s => !s.termsSuperseded && s.discontinuedOn === null);
+    assert.ok(population.length > 700, `only ${population.length} records to compare surfaces on`);
+
+    const disagreeing: string[] = [];
+    let compared = 0;
+    for (const subject of population) {
+      const page = pages.get(subject.slug)!;
+      const clause = unconfirmedTermsClause(subject.outcome as Exclude<Outcome, "ok">);
+      const aboutThisVendor = clause.replace("this offer", subject.vendor);
+      const body = `${page.verdict} ${page.amountLine}`;
+      const forms = [clause, capitalise(clause), aboutThisVendor, capitalise(aboutThisVendor)];
+      if (!forms.some(form => body.includes(form))) continue;
+      compared++;
+      if (!page.meta.includes(clause)) disagreeing.push(`${subject.slug} [${subject.outcome}]`);
+    }
+
+    assert.ok(compared > 700, `only ${compared} pages state the withholding in the body`);
+    assert.deepStrictEqual(
+      disagreeing.slice(0, 20),
+      [],
+      `${disagreeing.length} of ${compared} meta descriptions omit a withholding the body states`,
+    );
+  });
+
+  it("says a product has been discontinued rather than that its terms are unconfirmed", async () => {
+    const pages = await everyVendorPage();
+    const population = subjects.filter(sourceCheckFailed).filter(s => s.discontinuedOn !== null);
+    assert.ok(population.length > 0, "no discontinued record has a failed source check");
+
+    const wrong: string[] = [];
+    for (const subject of population) {
+      const meta = pages.get(subject.slug)!.meta;
+      if (!meta.includes(`Discontinued ${subject.discontinuedOn}.`)) wrong.push(`${subject.slug}: no discontinuation date`);
+      if (meta.includes("Not verified")) wrong.push(`${subject.slug}: withholds as well as discontinues`);
+    }
+    assert.deepStrictEqual(wrong.slice(0, 20), [], `${wrong.length} of ${population.length} discontinued records`);
+  });
+
+  it("leaves the verification claim standing wherever the source check passed", async () => {
+    const pages = await everyVendorPage();
+    const population = subjects.filter(s => s.outcome === "ok" && !s.termsSuperseded);
+    assert.ok(population.length > 600, `only ${population.length} records passed their source check`);
+
+    const wrongMonth: string[] = [];
+    const droppedFromTheMeta: string[] = [];
+    const withheldWithoutCause: string[] = [];
+    let asserting = 0;
+    for (const subject of population) {
+      const page = pages.get(subject.slug)!;
+      const inMeta = assertedMonth(page.meta);
+      const inByline = assertedMonth(page.byline);
+      if (page.meta.includes("Not verified")) withheldWithoutCause.push(subject.slug);
+      if (inByline !== null && inMeta === null) droppedFromTheMeta.push(subject.slug);
+      if (inMeta === null) continue;
+      asserting++;
+      if (inMeta !== subject.verifiedMonth) {
+        wrongMonth.push(`${subject.slug}: meta says ${inMeta}, the record says ${subject.verifiedMonth}`);
+      }
+    }
+
+    assert.ok(asserting > 550, `only ${asserting} passing records still carry a verification month`);
+    assert.deepStrictEqual(withheldWithoutCause.slice(0, 20), [], `${withheldWithoutCause.length} passing records withhold`);
+    assert.deepStrictEqual(droppedFromTheMeta.slice(0, 20), [], `${droppedFromTheMeta.length} meta descriptions dropped a month the byline still states`);
+    assert.deepStrictEqual(wrongMonth.slice(0, 20), [], `${wrongMonth.length} meta descriptions state a month the record does not`);
+  });
+});
+
+describe("#1412 the withholding predicate is the one the badge and the body read", () => {
+  it("answers only for the outcomes that leave the terms unconfirmed", () => {
+    const base = { vendor: "Example", level: null, cause: null, changes: [], levelWithheld: null, unconfirmableSince: "" };
+    assert.strictEqual(termsUnconfirmedBySource({ ...base, sourceCheck: "ok" }), null);
+    assert.strictEqual(termsUnconfirmedBySource({ ...base, sourceCheck: null }), null);
+    assert.strictEqual(termsUnconfirmedBySource(base), null);
+    for (const outcome of ["states_no_amount", "does_not_name_vendor", "states_no_terms", "unreadable"] as const) {
+      assert.strictEqual(termsUnconfirmedBySource({ ...base, sourceCheck: outcome }), outcome);
+    }
+  });
+
+  it("quotes the body's own clause for every outcome the level rules also cover", () => {
+    for (const reason of ["does_not_name_vendor", "states_no_terms", "unreadable"] as const) {
+      assert.strictEqual(unconfirmedTermsClause(reason), withheldLevelClause(reason));
+    }
+  });
+
+  it("gives each outcome a sentence a reader can tell apart from the others", () => {
+    const outcomes = ["states_no_amount", "does_not_name_vendor", "states_no_terms", "unreadable"] as const;
+    const sentences = outcomes.map(o => unconfirmedTermsMetaSentence(o));
+    assert.strictEqual(new Set(sentences).size, outcomes.length);
+    for (const sentence of sentences) {
+      assert.ok(sentence.startsWith("Not verified"), sentence);
+      assert.ok(sentence.endsWith("."), sentence);
+      assert.strictEqual(assertedMonth(sentence), null, sentence);
+      assert.ok(sentence.length <= 90, `${sentence.length} characters: ${sentence}`);
+    }
+  });
+});


### PR DESCRIPTION
The `<meta name="description">` on a vendor page was the only surface that
answered "can we confirm these terms?" by not asking. The badge withheld, the
page body withheld, and the meta stated the terms and stamped them Verified.

774 of the 810 vendor pages whose primary record failed its source check
asserted `Verified <Month> <Year>`, and 0 of the 810 carried any hedge. 757 of
them hedged in the body and asserted verification in the meta on the same page —
`/vendor/contentful` read "We could not read the page we cite for this offer" in
the body and "Verified July 2026" to an extractor.

## The predicate

`src/vendor-verdict.ts` gains `termsUnconfirmedBySource`, which reads the
`sourceCheck` outcome now carried on `VendorVerdictInput` beside the
`levelWithheld` the badge and the body already read. The meta calls it and so
does the body's amount-unstated line, so the two surfaces cannot drift.

The clause is the body's own. `unconfirmedTermsClause` composes
`WITHHELD_LEVEL_CLAUSES` for the three outcomes the level rules already cover —
a test pins that by identity — and adds one for `states_no_amount`, the only
non-`ok` outcome that withholds no rating.

A discontinuation still displaces it: `/vendor/google-content-api-for-shopping`
reads `Discontinued 2026-08-18.` rather than that its terms are unconfirmed.

## Measured over the whole catalogue

| | before | after |
|---|---|---|
| failed source check, meta asserts `Verified <Month> <Year>` | 774 of 810 | **0 of 810** |
| failed source check, meta carries the withholding | 0 | **794** |
| body hedges and the meta asserts verification | 757 | **0** |
| passed source check, meta asserts `Verified <Month> <Year>` | 603 | **603** |

The 16 non-`ok` pages that carry no clause publish something stronger in its
place: 15 quote the source reading that supersedes the stored terms, and one is
the discontinuation above.

`og:description` and the WebPage JSON-LD `description` are built from the same
string, so all three extractor-facing surfaces move together.

The clause lands before character 155 on 763 of the 794 pages that carry it, so
it survives a snippet clip; the median description length goes 139 to 166.

## Verification

4,124 tests, 0 failures, 7 new. 16 mutants in `scripts/mutate-1412.mjs`, 16
killed, none of them by a compile failure. Route sweep of 2,578 paths: 794
moved, 0 status changes, 0 5xx — and the moved set is exactly the pages with a
failed source check, minus the 16 above. 0 pages with a passing source check
moved.

Refs #1412
