### PR TITLE
Mark a comparison slot whose vendor the catalogue does not list (#1415)

### DIFF
--- a/data/deal_changes.json
+++ b/data/deal_changes.json
@@ -1436,7 +1436,13 @@
         "AWS S3"
       ],
       "recorded_date": "2026-03-22",
-      "date_source": "hand_written"
+      "date_source": "hand_written",
+      "resolution": {
+        "state": "reversed",
+        "date": "2026-09-06",
+        "source_url": "https://uploadthing.com/pricing",
+        "detail": "No longer in force as of 2026-09-06: uploadthing.com/pricing, the page this record cites, opens its plan ladder with \"2GB App - Everything you need to start uploading! - $0 /month\", listing 2GB of storage shared between all apps, 7 days of audit log retention and unlimited uploads and downloads. The $25/month usage-based plan named here is the third rung of that ladder, above a $10/month 100GB App, not the entry point. We hold no evidence either way about the state on 2025-01-15, so this is recorded as no longer in force rather than retracted."
+      }
     },
     {
       "vendor": "Neo4j AuraDB",

--- a/scripts/mutate-1415.mjs
+++ b/scripts/mutate-1415.mjs
@@ -8,18 +8,20 @@ const SUITE = [
 
 const MUTANTS = [
   ["subject-is-only-ever-read-from-the-catalogue", "src/compiled-figures.ts",
-    `  const named = vendorWeHoldRecordsFor(subject.label);
-  if (named) {`,
-    `  const named = vendorSlugMap.get(toSlug(subject.label)) ?? null;
-  if (named) {`],
-  ["subject-prefers-a-longer-catalogue-entry-to-the-name-it-reads", "src/compiled-figures.ts",
-    `  const named = vendorWeHoldRecordsFor(subject.label);
-  if (named) {`,
-    `  const named = vendorSlugForSubject(subject) ? null : vendorWeHoldRecordsFor(subject.label);
-  if (named) {`],
+    `  const named = changeLogVendorNamed(subject.label);`,
+    `  const named: string | null = null;`],
+  ["subject-prefers-the-change-log-to-the-vendor-s-own-page", "src/compiled-figures.ts",
+    `  if (slug) return { slug, vendor: vendorSlugMap.get(slug)! };`,
+    `  if (slug && !changeLogVendorNamed(subject.label)) return { slug, vendor: vendorSlugMap.get(slug)! };`],
   ["subject-with-no-page-is-given-one-anyway", "src/compiled-figures.ts",
-    `    return { slug: vendorSlugMap.has(slug) ? slug : null, vendor: named };`,
-    `    return { slug, vendor: named };`],
+    `  return named ? { slug: null, vendor: named } : null;`,
+    `  return named ? { slug: toSlug(named), vendor: named } : null;`],
+  ["subject-records-are-read-under-one-spelling-only", "src/serve.ts",
+    `  const names = new Set([named.vendor, ...(changeLogNamesBySubject.get(named.slug) ?? [])]);`,
+    `  const names = new Set([named.vendor]);`],
+  ["change-log-names-reach-no-subject", "src/serve.ts",
+    `    const subject = vendorSlugMap.has(slug) ? slug : namedVendorSlug(vendor);`,
+    `    const subject = vendorSlugMap.has(slug) ? slug : null;`],
   ["a-subject-that-is-not-a-vendor-is-named-anyway", "src/vendor-slug.ts",
     `  return NON_VENDOR_SUBJECTS.some(s => toSlug(s) === toSlug(phrase));`,
     `  return false;`],
@@ -48,13 +50,13 @@ const MUTANTS = [
     `    .filter(c => SEVERE_CHANGE_TYPES.has(c.change_type))`,
     `    .filter(c => Boolean(c.change_type))`],
   ["subject-with-no-page-is-never-called-ended", "src/serve.ts",
-    `    const ending = freeTierEndingRecord(changesFor(named.vendor));
+    `    const ending = freeTierEndingRecord(changesForSubject(named));
     return { ended: ending !== null, endedBy: ending };`,
     `    return { ended: false, endedBy: null };`],
   ["subject-with-no-page-is-always-called-ended", "src/serve.ts",
-    `    const ending = freeTierEndingRecord(changesFor(named.vendor));
+    `    const ending = freeTierEndingRecord(changesForSubject(named));
     return { ended: ending !== null, endedBy: ending };`,
-    `    const ending = freeTierEndingRecord(changesFor(named.vendor));
+    `    const ending = freeTierEndingRecord(changesForSubject(named));
     return { ended: true, endedBy: ending };`],
   ["change-log-anchors-every-record-it-prints", "src/serve.ts",
     `    const anchorAttr = anchor && anchorHolder.get(anchor) === c ? \` id="\${anchor}"\` : "";`,

--- a/scripts/mutate-1415.mjs
+++ b/scripts/mutate-1415.mjs
@@ -1,0 +1,120 @@
+import { readFileSync, writeFileSync } from "node:fs";
+import { execFileSync } from "node:child_process";
+
+const SUITE = [
+  "test/change-log-only-vendors.test.ts",
+  "test/compiled-comparison-figures.test.ts",
+];
+
+const MUTANTS = [
+  ["subject-is-only-ever-read-from-the-catalogue", "src/compiled-figures.ts",
+    `  const named = vendorWeHoldRecordsFor(subject.label);
+  if (named) {`,
+    `  const named = vendorSlugMap.get(toSlug(subject.label)) ?? null;
+  if (named) {`],
+  ["subject-prefers-a-longer-catalogue-entry-to-the-name-it-reads", "src/compiled-figures.ts",
+    `  const named = vendorWeHoldRecordsFor(subject.label);
+  if (named) {`,
+    `  const named = vendorSlugForSubject(subject) ? null : vendorWeHoldRecordsFor(subject.label);
+  if (named) {`],
+  ["subject-with-no-page-is-given-one-anyway", "src/compiled-figures.ts",
+    `    return { slug: vendorSlugMap.has(slug) ? slug : null, vendor: named };`,
+    `    return { slug, vendor: named };`],
+  ["a-subject-that-is-not-a-vendor-is-named-anyway", "src/vendor-slug.ts",
+    `  return NON_VENDOR_SUBJECTS.some(s => toSlug(s) === toSlug(phrase));`,
+    `  return false;`],
+  ["marker-always-points-at-a-vendor-page", "src/compiled-figures.ts",
+    `  if (verdict.slug) return \`/vendor/\${verdict.slug}#changes\`;`,
+    `  return \`/vendor/\${verdict.slug ?? toSlug(verdict.vendor)}#changes\`;`],
+  ["marker-always-points-at-the-change-log", "src/compiled-figures.ts",
+    `  if (verdict.slug) return \`/vendor/\${verdict.slug}#changes\`;`,
+    ``],
+  ["marker-points-at-the-change-log-with-no-anchor", "src/compiled-figures.ts",
+    `  return anchor ? \`\${CHANGE_LOG_PATH}#\${anchor}\` : CHANGE_LOG_PATH;`,
+    `  return anchor ? CHANGE_LOG_PATH : CHANGE_LOG_PATH;`],
+  ["ending-record-ignores-a-resolution", "src/data.ts",
+    `  const inForce = vendorChanges.filter(c => !isNoLongerInForce(c));`,
+    `  const inForce = vendorChanges.filter(c => Boolean(c));`],
+  ["ending-record-ignores-a-later-restoration", "src/data.ts",
+    `  const restored = inForce.some(c => c.change_type === "new_free_tier" && c.date > ending.date);`,
+    `  const restored = false;`],
+  ["ending-record-lets-an-earlier-restoration-clear-it", "src/data.ts",
+    `  const restored = inForce.some(c => c.change_type === "new_free_tier" && c.date > ending.date);`,
+    `  const restored = inForce.some(c => c.change_type === "new_free_tier");`],
+  ["ending-record-takes-the-oldest-ending", "src/data.ts",
+    `    .sort((a, b) => b.date.localeCompare(a.date))[0];`,
+    `    .sort((a, b) => a.date.localeCompare(b.date))[0];`],
+  ["ending-record-reads-an-ending-out-of-any-change", "src/data.ts",
+    `    .filter(c => SEVERE_CHANGE_TYPES.has(c.change_type))`,
+    `    .filter(c => Boolean(c.change_type))`],
+  ["subject-with-no-page-is-never-called-ended", "src/serve.ts",
+    `    const ending = freeTierEndingRecord(changesFor(named.vendor));
+    return { ended: ending !== null, endedBy: ending };`,
+    `    return { ended: false, endedBy: null };`],
+  ["subject-with-no-page-is-always-called-ended", "src/serve.ts",
+    `    const ending = freeTierEndingRecord(changesFor(named.vendor));
+    return { ended: ending !== null, endedBy: ending };`,
+    `    const ending = freeTierEndingRecord(changesFor(named.vendor));
+    return { ended: true, endedBy: ending };`],
+  ["change-log-anchors-every-record-it-prints", "src/serve.ts",
+    `    const anchorAttr = anchor && anchorHolder.get(anchor) === c ? \` id="\${anchor}"\` : "";`,
+    `    const anchorAttr = anchor ? \` id="\${anchor}"\` : "";`],
+  ["change-log-anchors-nothing", "src/serve.ts",
+    `    const anchorAttr = anchor && anchorHolder.get(anchor) === c ? \` id="\${anchor}"\` : "";`,
+    `    const anchorAttr = "";`],
+  ["ended-cell-is-struck-a-second-time", "src/compiled-figures.ts",
+    `  if (slot.alreadyStruck) return inner;`,
+    ``],
+  ["ended-cell-drops-the-badge-the-page-wrote", "src/compiled-figures.ts",
+    `  if (!slot.alreadyStatesRemoval) return strickenName;
+  return strickenName + (inner.match(DECORATION_SPAN) ?? []).join("");`,
+    `  return strickenName;`],
+  ["a-slot-the-page-badged-is-badged-again", "src/compiled-figures.ts",
+    `      ? (slot.alreadyStatesRemoval ? "" : endedBadgeHtml(verdict))`,
+    `      ? endedBadgeHtml(verdict)`],
+  ["a-marker-the-join-drew-does-not-count-as-a-marker", "src/compiled-figures.ts",
+    `  return { alreadyStatesRemoval: REMOVED_BADGE.test(inner), alreadyStruck: STRUCK_SUBJECT.test(inner) };`,
+    `  const written = inner.replace(RECORD_MARKER, "");
+  return { alreadyStatesRemoval: REMOVED_BADGE.test(written), alreadyStruck: STRUCK_SUBJECT.test(written) };`],
+  ["change-log-names-are-read-off-the-catalogue", "src/vendor-slug.ts",
+    `  for (const change of loadDealChanges()) {
+    const slug = toSlug(change.vendor);`,
+    `  for (const change of loadOffers()) {
+    const slug = toSlug(change.vendor);`],
+  ["marker-text-is-not-read-back-off-the-page", "src/compiled-figures.ts",
+    `  /<a\\b[^>]*href="(?:\\/vendor\\/[a-z0-9-]+#changes|\\/changes#vendor-[a-z0-9-]+)"[^>]*>[\\s\\S]*?<\\/a>/g;`,
+    `  /<a\\b[^>]*href="\\/vendor\\/[a-z0-9-]+#changes"[^>]*>[\\s\\S]*?<\\/a>/g;`],
+  ["change-log-anchor-is-shared-by-every-vendor", "src/vendor-slug.ts",
+    `  return slug ? \`vendor-\${slug}\` : null;`,
+    `  return slug ? "vendor" : null;`],
+];
+
+function run(cmd, args) {
+  try {
+    execFileSync(cmd, args, { stdio: "pipe", encoding: "utf-8" });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+const survivors = [];
+const uncompiled = [];
+for (const [name, file, from, to] of MUTANTS) {
+  const original = readFileSync(file, "utf-8");
+  if (!original.includes(from)) {
+    console.log(`SKIP  ${name} — the line it mutates is not in ${file}`);
+    continue;
+  }
+  writeFileSync(file, original.replace(from, to));
+  const built = run("npm", ["run", "build"]);
+  const green = built && run("node", ["--test", "--test-concurrency", "1", ...SUITE]);
+  writeFileSync(file, original);
+  if (!built) uncompiled.push(name);
+  console.log(`${green ? "SURVIVED" : built ? "killed  " : "DID NOT COMPILE"}  ${name}`);
+  if (green) survivors.push(name);
+}
+run("npm", ["run", "build"]);
+console.log(`\n${MUTANTS.length - survivors.length - uncompiled.length}/${MUTANTS.length} killed`);
+if (survivors.length > 0) console.log("survivors:", survivors.join(", "));
+if (uncompiled.length > 0) console.log("did not compile:", uncompiled.join(", "));

--- a/src/compiled-figures.ts
+++ b/src/compiled-figures.ts
@@ -1,4 +1,4 @@
-import { assertedVendorSlugs, changeLogAnchorFor, isNonVendorSubject, resolveVendorSlug, toSlug, vendorSlugMap, vendorWeHoldRecordsFor } from "./vendor-slug.js";
+import { assertedVendorSlugs, changeLogAnchorFor, changeLogVendorNamed, isNonVendorSubject, resolveVendorSlug, toSlug, vendorSlugMap } from "./vendor-slug.js";
 
 export interface CompiledPageRecord {
   date: string;
@@ -331,13 +331,10 @@ export function vendorForSubject(subject: CompiledFigureSubject): CompiledFigure
     return { slug: subject.linkedSlug, vendor: vendorSlugMap.get(subject.linkedSlug)! };
   }
   if (isNonVendorSubject(subject.label)) return null;
-  const named = vendorWeHoldRecordsFor(subject.label);
-  if (named) {
-    const slug = toSlug(named);
-    return { slug: vendorSlugMap.has(slug) ? slug : null, vendor: named };
-  }
   const slug = vendorSlugForSubject(subject);
-  return slug ? { slug, vendor: vendorSlugMap.get(slug)! } : null;
+  if (slug) return { slug, vendor: vendorSlugMap.get(slug)! };
+  const named = changeLogVendorNamed(subject.label);
+  return named ? { slug: null, vendor: named } : null;
 }
 
 export function vendorNameForSubject(subject: CompiledFigureSubject): string | null {

--- a/src/compiled-figures.ts
+++ b/src/compiled-figures.ts
@@ -1,4 +1,4 @@
-import { assertedVendorSlugs, isNonVendorSubject, resolveVendorSlug, toSlug, vendorSlugMap } from "./vendor-slug.js";
+import { assertedVendorSlugs, changeLogAnchorFor, isNonVendorSubject, resolveVendorSlug, toSlug, vendorSlugMap, vendorWeHoldRecordsFor } from "./vendor-slug.js";
 
 export interface CompiledPageRecord {
   date: string;
@@ -27,11 +27,19 @@ export interface CompiledFigureSubject {
 }
 
 export interface CompiledFigureVerdict {
-  slug: string;
+  slug: string | null;
   vendor: string;
   freeTierEnded: boolean;
   endedBy: CompiledPageRecord | null;
   since: readonly CompiledPageRecord[];
+}
+
+export const CHANGE_LOG_PATH = "/changes";
+
+export function recordsHrefFor(verdict: Pick<CompiledFigureVerdict, "slug" | "vendor">): string {
+  if (verdict.slug) return `/vendor/${verdict.slug}#changes`;
+  const anchor = changeLogAnchorFor(verdict.vendor);
+  return anchor ? `${CHANGE_LOG_PATH}#${anchor}` : CHANGE_LOG_PATH;
 }
 
 export type CompiledFigureLookup = (subject: CompiledFigureSubject) => CompiledFigureVerdict | null;
@@ -50,7 +58,9 @@ const VENDOR_LINK = /href="\/vendor\/([a-z0-9][a-z0-9-]*)"/;
 const DECORATION_SPAN = /<span\b[^>]*class="[^"]*\b(?:winner|caution|removed|pick)-badge\b[^"]*"[^>]*>[\s\S]*?<\/span>/g;
 const ROW_CELL = /<td\b[^>]*>[\s\S]*?<\/td>/g;
 const REMOVED_BADGE = /class="[^"]*\bremoved-badge\b[^"]*"/;
-const RECORD_MARKER = /<a\b[^>]*href="\/vendor\/[a-z0-9-]+#changes"[^>]*>[\s\S]*?<\/a>/g;
+const RECORD_MARKER =
+  /<a\b[^>]*href="(?:\/vendor\/[a-z0-9-]+#changes|\/changes#vendor-[a-z0-9-]+)"[^>]*>[\s\S]*?<\/a>/g;
+const STRUCK_SUBJECT = /<span\b[^>]*style="[^"]*text-decoration:\s*line-through[^"]*"/;
 const TRAILING_QUALIFIER = /^(.+?)\s*\([^()]*\)$/;
 const SUBJECT_TAGLINE = /\s+[—–:]\s+/;
 const TIMELINE_BODY = /(<h2\b[^>]*\bid="changes"(?:(?!<\/table>)[\s\S])*?<tbody>)([\s\S]*?)(<\/tbody>)/;
@@ -92,6 +102,12 @@ interface DiscoveredSlot extends CompiledFigureSubject {
   inner: string;
   innerStart: number;
   alreadyStatesRemoval: boolean;
+  alreadyStruck: boolean;
+}
+
+function removalTheSlotAlreadyCarries(inner: string): Pick<DiscoveredSlot, "alreadyStatesRemoval" | "alreadyStruck"> {
+  const written = inner.replace(RECORD_MARKER, "");
+  return { alreadyStatesRemoval: REMOVED_BADGE.test(written), alreadyStruck: STRUCK_SUBJECT.test(written) };
 }
 
 function discoverSlots(staticHtml: string): DiscoveredSlot[] {
@@ -110,7 +126,7 @@ function discoverSlots(staticHtml: string): DiscoveredSlot[] {
       end: cell.index + cell[0].length,
       inner,
       innerStart: cell.index + cell[0].indexOf(inner),
-      alreadyStatesRemoval: REMOVED_BADGE.test(inner.replace(RECORD_MARKER, "")),
+      ...removalTheSlotAlreadyCarries(inner),
     });
   }
 
@@ -127,7 +143,7 @@ function discoverSlots(staticHtml: string): DiscoveredSlot[] {
       end: heading.index + heading[0].length,
       inner,
       innerStart: heading.index + heading[0].indexOf(inner),
-      alreadyStatesRemoval: REMOVED_BADGE.test(inner.replace(RECORD_MARKER, "")),
+      ...removalTheSlotAlreadyCarries(inner),
     });
   }
 
@@ -155,7 +171,7 @@ const FREE_TIER_REMOVED_LABEL = "FREE REMOVED";
 
 function endedBadgeHtml(verdict: CompiledFigureVerdict): string {
   return (
-    ` <a href="/vendor/${verdict.slug}#changes" class="removed-badge"` +
+    ` <a href="${recordsHrefFor(verdict)}" class="removed-badge"` +
     ` title="Our own change log records that the ${verdict.vendor} free tier has ended.">` +
     `${FREE_TIER_REMOVED_LABEL}</a>`
   );
@@ -175,7 +191,7 @@ function recordedSinceBadgeHtml(
     `We recorded ${count === 1 ? "a pricing change" : `${count} pricing changes`} for ${verdict.vendor} ` +
     `after this table was compiled on ${options.compiledOn}. The most recent, ${recordDateClause(latest)}: ${latest.summary}`;
   return (
-    ` <a href="/vendor/${verdict.slug}#changes" style="${RECORDED_SINCE_STYLE}"` +
+    ` <a href="${recordsHrefFor(verdict)}" style="${RECORDED_SINCE_STYLE}"` +
     ` title="${options.esc(title)}">CHANGED ${options.esc(options.shortDate(latest.date).toUpperCase())}</a>`
   );
 }
@@ -184,6 +200,16 @@ const STRUCK_STYLE = "color:var(--text-dim);text-decoration:line-through";
 
 function struck(inner: string): string {
   return `<span style="${STRUCK_STYLE}">${inner}</span>`;
+}
+
+function endedProviderCell(
+  inner: string,
+  slot: Pick<DiscoveredSlot, "alreadyStatesRemoval" | "alreadyStruck">,
+): string {
+  if (slot.alreadyStruck) return inner;
+  const strickenName = struck(inner.replace(DECORATION_SPAN, ""));
+  if (!slot.alreadyStatesRemoval) return strickenName;
+  return strickenName + (inner.match(DECORATION_SPAN) ?? []).join("");
 }
 
 function withEndedRowCells(row: string, providerCellEnd: number): string {
@@ -212,7 +238,7 @@ function endedCardDescriptionHtml(
     : `Our own change log records that the ${options.esc(verdict.vendor)} free tier has ended.`;
   return (
     `<${tag} class="diff-desc"><strong>Free tier:</strong> none. ${recorded} ` +
-    `<a href="/vendor/${verdict.slug}#changes">Read what we recorded &rarr;</a></${tag}>`
+    `<a href="${recordsHrefFor(verdict)}">Read what we recorded &rarr;</a></${tag}>`
   );
 }
 
@@ -230,7 +256,7 @@ export function markCompiledFigures(
     if (!verdict.freeTierEnded && verdict.since.length === 0) continue;
 
     const badge = verdict.freeTierEnded
-      ? endedBadgeHtml(verdict)
+      ? (slot.alreadyStatesRemoval ? "" : endedBadgeHtml(verdict))
       : recordedSinceBadgeHtml(verdict, options);
 
     if (slot.kind === "card") {
@@ -253,7 +279,7 @@ export function markCompiledFigures(
     const cellEndInRow = slot.end - rowStart;
     const inner = slot.inner;
     const markedProvider = verdict.freeTierEnded
-      ? struck(inner.replace(DECORATION_SPAN, "")) + badge
+      ? endedProviderCell(inner, slot) + badge
       : inner + badge;
     const withProvider =
       row.slice(0, slot.innerStart - rowStart) + markedProvider + row.slice(slot.innerStart - rowStart + inner.length);
@@ -296,9 +322,27 @@ function slugNamedByHeading(label: string): string | null {
   return null;
 }
 
-export function vendorNameForSubject(subject: CompiledFigureSubject): string | null {
+export interface CompiledFigureVendor {
+  slug: string | null;
+  vendor: string;
+}
+
+export function vendorForSubject(subject: CompiledFigureSubject): CompiledFigureVendor | null {
+  if (subject.linkedSlug && vendorSlugMap.has(subject.linkedSlug)) {
+    return { slug: subject.linkedSlug, vendor: vendorSlugMap.get(subject.linkedSlug)! };
+  }
+  if (isNonVendorSubject(subject.label)) return null;
+  const named = vendorWeHoldRecordsFor(subject.label);
+  if (named) {
+    const slug = toSlug(named);
+    return { slug: vendorSlugMap.has(slug) ? slug : null, vendor: named };
+  }
   const slug = vendorSlugForSubject(subject);
-  return slug ? vendorSlugMap.get(slug) ?? null : null;
+  return slug ? { slug, vendor: vendorSlugMap.get(slug)! } : null;
+}
+
+export function vendorNameForSubject(subject: CompiledFigureSubject): string | null {
+  return vendorForSubject(subject)?.vendor ?? null;
 }
 
 export function timelineRecordsFor<T extends { date: string }>(

--- a/src/compiled-figures.ts
+++ b/src/compiled-figures.ts
@@ -106,8 +106,7 @@ interface DiscoveredSlot extends CompiledFigureSubject {
 }
 
 function removalTheSlotAlreadyCarries(inner: string): Pick<DiscoveredSlot, "alreadyStatesRemoval" | "alreadyStruck"> {
-  const written = inner.replace(RECORD_MARKER, "");
-  return { alreadyStatesRemoval: REMOVED_BADGE.test(written), alreadyStruck: STRUCK_SUBJECT.test(written) };
+  return { alreadyStatesRemoval: REMOVED_BADGE.test(inner), alreadyStruck: STRUCK_SUBJECT.test(inner) };
 }
 
 function discoverSlots(staticHtml: string): DiscoveredSlot[] {

--- a/src/data.ts
+++ b/src/data.ts
@@ -327,6 +327,18 @@ export function isSevereChange(
 
 export const SEVERE_CHANGE_TYPES = new Set(["free_tier_removed", "open_source_killed"]);
 
+type EndingCandidate = Pick<DealChange, "change_type" | "date"> & { resolution?: DealChange["resolution"] };
+
+export function freeTierEndingRecord<T extends EndingCandidate>(vendorChanges: readonly T[]): T | null {
+  const inForce = vendorChanges.filter(c => !isNoLongerInForce(c));
+  const ending = inForce
+    .filter(c => SEVERE_CHANGE_TYPES.has(c.change_type))
+    .sort((a, b) => b.date.localeCompare(a.date))[0];
+  if (!ending) return null;
+  const restored = inForce.some(c => c.change_type === "new_free_tier" && c.date > ending.date);
+  return restored ? null : ending;
+}
+
 const NEGATIVE_STABILITY_TYPES = NEGATIVE_CHANGE_TYPES;
 const POSITIVE_STABILITY_TYPES = POSITIVE_CHANGE_TYPES;
 

--- a/src/serve.ts
+++ b/src/serve.ts
@@ -5,7 +5,7 @@ import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
 import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
 import { createServer, getServerCard } from "./server.js";
-import { oldestVerifiedDateForSlug, vendorRiskAssessment, NEGATIVE_CHANGE_TYPES, POSITIVE_CHANGE_TYPES, SEVERE_CHANGE_TYPES, loadOffers, getCategories, getNewOffers, getNewestDeals, searchOffers, enrichOffers, gateForOffer, loadDealChanges, getDealChanges, changeContext, DEFAULT_CHANGE_WINDOW_DAYS, getOfferDetails, compareServices, checkVendorRisk, auditStack, getExpiringDeals, getWeeklyDigest, getFormattedWeeklyDigest, getFreshnessMetrics, getStabilityMap, getVendorReferral, sanitizeQuery, getChangeLogFreshness, isEventDated, partitionByDateProvenance } from "./data.js";
+import { oldestVerifiedDateForSlug, vendorRiskAssessment, freeTierEndingRecord, NEGATIVE_CHANGE_TYPES, POSITIVE_CHANGE_TYPES, SEVERE_CHANGE_TYPES, loadOffers, getCategories, getNewOffers, getNewestDeals, searchOffers, enrichOffers, gateForOffer, loadDealChanges, getDealChanges, changeContext, DEFAULT_CHANGE_WINDOW_DAYS, getOfferDetails, compareServices, checkVendorRisk, auditStack, getExpiringDeals, getWeeklyDigest, getFormattedWeeklyDigest, getFreshnessMetrics, getStabilityMap, getVendorReferral, sanitizeQuery, getChangeLogFreshness, isEventDated, partitionByDateProvenance } from "./data.js";
 import { getStackRecommendation } from "./stacks.js";
 import { estimateCosts } from "./costs.js";
 import { classifyRequest } from "./client-class.js";
@@ -29,7 +29,7 @@ import { comparisonVerdictText, freeTierFaqAnswer, stabilityFaqAnswer, type Comp
 import { publishedVendorLevel, vendorVerdictSentence, vendorBadge, freeTierClaim, statesRiskCause, narrowingSentence, changeKindNoun, termsUnconfirmedBySource, unconfirmedTermsMetaSentence, type BadgeWithholding, type FreeTierClaim, type VendorVerdictInput } from "./vendor-verdict.js";
 import { tierRecordsAFreeTier } from "./free-tier-record.js";
 import { UNGRADED_IMPACT_COLOR, changeImpactColor, changeImpactLabel, changeImpactWord, isChangeImpactLevel } from "./change-impact.js";
-import { COMPARED_SERVICES_PLACEHOLDER, fillComparedServicesCount, markCompiledFigures, recordsSinceCompiled, replaceTimelineRows, timelineRecordsFor, vendorSlugForSubject, vendorSubjectsOnCompiledPage, type CompiledFigureSubject, type CompiledFigureVerdict } from "./compiled-figures.js";
+import { COMPARED_SERVICES_PLACEHOLDER, fillComparedServicesCount, markCompiledFigures, recordsSinceCompiled, replaceTimelineRows, timelineRecordsFor, vendorForSubject, vendorSubjectsOnCompiledPage, type CompiledFigureSubject, type CompiledFigureVendor, type CompiledFigureVerdict } from "./compiled-figures.js";
 import { vendorHistorySentence } from "./vendor-history.js";
 import { HETZNER_APRIL_CHANGES, HETZNER_CLOUD_PLANS, HETZNER_PRICES_READ, HETZNER_PRICE_SOURCE, HETZNER_SINGAPORE_EXAMPLE, cheapestOrderableHetznerPlan, hetznerEntryPriceClause, unorderableHetznerPlans } from "./hetzner-pricing.js";
 import { changeTimelineDate, supersededLineups, supersessionNote } from "./change-lineup.js";
@@ -49,7 +49,7 @@ import { runHealthCheck, getLastReport, startPeriodicChecks } from "./referral-h
 import { configureDurableBackend, hydrateDurableStores, persistDurableStores, identityStorageReport } from "./durable-store.js";
 import { addFriend, removeFriend, getFriends, getFriendCodesForVendors } from "./friends.js";
 import { subscribe as watchlistSubscribe, getSubscription as getWatchlistSubscription, unsubscribe as watchlistUnsubscribe, listSubscriptions as listWatchlistSubscriptions } from "./watchlist.js";
-import { toSlug, vendorSlugMap, resolveVendorSlug, namedVendorSlug } from "./vendor-slug.js";
+import { changeLogAnchorFor, toSlug, vendorSlugMap, resolveVendorSlug, namedVendorSlug } from "./vendor-slug.js";
 import { offerForSlug, vendorRates, cheapestRate, dearestRate, spanOfRates, formatRate, formatRateSpan, monthlyTokenCost, formatDollars, type ModelRate } from "./model-rates.js";
 import { STALE_FACT_PAGES_BASELINE, factsOutdatedBy, linkifyVerdictBlocks, newestChangeBySlug, overdueReport, pageCompiledClause, pageDataProvenance, pageDateModified, pageFreshness, pageFreshnessSentence, utcToday, verdictsOutdatedBy } from "./page-reviews.js";
 import { faqPageJsonLd, type FaqItem } from "./faq-provenance.js";
@@ -904,24 +904,38 @@ function recordsSinceCompiledFor(vendorName: string, compiledOn: string): DealCh
   return recordsSinceCompiled(changesFor(vendorName), compiledOn, today);
 }
 
+interface SubjectFreeTier {
+  ended: boolean;
+  endedBy: (Pick<DealChange, "date" | "summary"> & { date_source?: ChangeDateSource }) | null;
+}
+
+function freeTierForSubject(named: CompiledFigureVendor): SubjectFreeTier {
+  if (named.slug === null) {
+    const ending = freeTierEndingRecord(changesFor(named.vendor));
+    return { ended: ending !== null, endedBy: ending };
+  }
+  const claim = freeTierClaimFor(named.vendor, today);
+  return {
+    ended: claim?.states === "ended",
+    endedBy: claim?.states === "ended" && claim.how === "removed" ? claim.cause : null,
+  };
+}
+
 function compiledFigureVerdictFor(
   subject: CompiledFigureSubject,
   compiledOn: string,
 ): CompiledFigureVerdict | null {
-  const slug = vendorSlugForSubject(subject);
-  if (!slug) return null;
-  const vendor = vendorSlugMap.get(slug);
-  if (!vendor) return null;
-  const claim = freeTierClaimFor(vendor, today);
-  const ending = claim?.states === "ended" && claim.how === "removed" ? claim.cause : null;
+  const named = vendorForSubject(subject);
+  if (!named) return null;
+  const { ended, endedBy } = freeTierForSubject(named);
   return {
-    slug,
-    vendor,
-    freeTierEnded: claim?.states === "ended",
-    endedBy: ending
-      ? { date: ending.date, summary: ending.summary, dateClause: changeDateClause(ending) }
+    slug: named.slug,
+    vendor: named.vendor,
+    freeTierEnded: ended,
+    endedBy: endedBy
+      ? { date: endedBy.date, summary: endedBy.summary, dateClause: changeDateClause(endedBy) }
       : null,
-    since: recordsSinceCompiledFor(vendor, compiledOn).map(c => ({
+    since: recordsSinceCompiledFor(named.vendor, compiledOn).map(c => ({
       date: c.date,
       summary: c.summary,
       dateClause: changeDateClause(c),
@@ -39279,7 +39293,7 @@ function buildEmailComparison2026Page(): string {
     mainEntityOfPage: { "@type": "WebPage", "@id": `${BASE_URL}/${slug}` },
   };
 
-  return `<!DOCTYPE html>
+  return comparisonPageWithLiveRecords(`<!DOCTYPE html>
 <html lang="en">
 <head>
 <meta charset="utf-8">
@@ -40190,7 +40204,7 @@ ${mcpCtaCss()}
 </footer>
 <script>${mcpCtaScript()}</script>
 </body>
-</html>`;
+</html>`, pubDate, emailChanges);
 }
 
 function buildMonitoringComparison2026Page(): string {
@@ -40253,7 +40267,7 @@ function buildMonitoringComparison2026Page(): string {
     mainEntityOfPage: { "@type": "WebPage", "@id": `${BASE_URL}/${slug}` },
   };
 
-  return `<!DOCTYPE html>
+  return comparisonPageWithLiveRecords(`<!DOCTYPE html>
 <html lang="en">
 <head>
 <meta charset="utf-8">
@@ -41187,7 +41201,7 @@ ${mcpCtaCss()}
 </footer>
 <script>${mcpCtaScript()}</script>
 </body>
-</html>`;
+</html>`, pubDate, monitoringChanges);
 }
 
 function buildStorageComparison2026Page(): string {
@@ -41250,7 +41264,7 @@ function buildStorageComparison2026Page(): string {
     mainEntityOfPage: { "@type": "WebPage", "@id": `${BASE_URL}/${slug}` },
   };
 
-  return `<!DOCTYPE html>
+  return comparisonPageWithLiveRecords(`<!DOCTYPE html>
 <html lang="en">
 <head>
 <meta charset="utf-8">
@@ -41991,7 +42005,7 @@ ${mcpCtaCss()}
 </footer>
 <script>${mcpCtaScript()}</script>
 </body>
-</html>`;
+</html>`, pubDate, storageChanges);
 }
 
 function buildTestingFreeTierComparison2026Page(): string {
@@ -49788,16 +49802,24 @@ function buildChangesPage(): string {
     return `${monthNames[parseInt(m, 10) - 1]} ${y}`;
   }
 
+  const anchorHolder = new Map<string, typeof allChanges[0]>();
+  for (const c of newestFirst) {
+    const anchor = changeLogAnchorFor(c.vendor);
+    if (anchor && !anchorHolder.has(anchor)) anchorHolder.set(anchor, c);
+  }
+
   function buildChangeEntry(c: typeof allChanges[0]): string {
     const badge = changeTypeBadge[c.change_type] ?? { label: c.change_type, color: "#8b949e" };
     const impactColor = changeImpactColor(c.impact);
     const vendorSlug = toSlug(c.vendor);
     const dated = isEventDated(c);
     const isUpcoming = dated && c.date >= today;
+    const anchor = changeLogAnchorFor(c.vendor);
+    const anchorAttr = anchor && anchorHolder.get(anchor) === c ? ` id="${anchor}"` : "";
     const altHtml = c.alternatives && c.alternatives.length > 0
       ? `<div class="chg-alts"><span class="chg-alts-label">Alternatives:</span> ${c.alternatives.map(a => `<a href="/vendor/${toSlug(a)}">${escHtmlServer(a)}</a>`).join(", ")}</div>`
       : "";
-    return `      <div class="chg-entry${isUpcoming ? " chg-upcoming" : ""}${dated ? "" : " chg-undated"}${changeIsUncited(c) ? " chg-unsourced" : ""}">
+    return `      <div${anchorAttr} class="chg-entry${isUpcoming ? " chg-upcoming" : ""}${dated ? "" : " chg-undated"}${changeIsUncited(c) ? " chg-unsourced" : ""}">
         <div class="chg-left">
           <div class="chg-date">${dated ? c.date : `${DISCOVERED_DATE_PREFIX} ${c.date}`}</div>
           ${isUpcoming ? `<div class="chg-upcoming-badge">upcoming</div>` : ""}

--- a/src/serve.ts
+++ b/src/serve.ts
@@ -49,7 +49,7 @@ import { runHealthCheck, getLastReport, startPeriodicChecks } from "./referral-h
 import { configureDurableBackend, hydrateDurableStores, persistDurableStores, identityStorageReport } from "./durable-store.js";
 import { addFriend, removeFriend, getFriends, getFriendCodesForVendors } from "./friends.js";
 import { subscribe as watchlistSubscribe, getSubscription as getWatchlistSubscription, unsubscribe as watchlistUnsubscribe, listSubscriptions as listWatchlistSubscriptions } from "./watchlist.js";
-import { changeLogAnchorFor, toSlug, vendorSlugMap, resolveVendorSlug, namedVendorSlug } from "./vendor-slug.js";
+import { changeLogAnchorFor, changeLogVendorMap, toSlug, vendorSlugMap, resolveVendorSlug, namedVendorSlug } from "./vendor-slug.js";
 import { offerForSlug, vendorRates, cheapestRate, dearestRate, spanOfRates, formatRate, formatRateSpan, monthlyTokenCost, formatDollars, type ModelRate } from "./model-rates.js";
 import { STALE_FACT_PAGES_BASELINE, factsOutdatedBy, linkifyVerdictBlocks, newestChangeBySlug, overdueReport, pageCompiledClause, pageDataProvenance, pageDateModified, pageFreshness, pageFreshnessSentence, utcToday, verdictsOutdatedBy } from "./page-reviews.js";
 import { faqPageJsonLd, type FaqItem } from "./faq-provenance.js";
@@ -900,8 +900,22 @@ function freeTierClaimFor(vendorName: string, servedOn: string): FreeTierClaim |
   return context ? freeTierClaim(context.input) : null;
 }
 
-function recordsSinceCompiledFor(vendorName: string, compiledOn: string): DealChange[] {
-  return recordsSinceCompiled(changesFor(vendorName), compiledOn, today);
+const changeLogNamesBySubject = (() => {
+  const bySubject = new Map<string, string[]>();
+  for (const [slug, vendor] of changeLogVendorMap) {
+    const subject = vendorSlugMap.has(slug) ? slug : namedVendorSlug(vendor);
+    if (!subject) continue;
+    const held = bySubject.get(subject);
+    if (held) held.push(vendor);
+    else bySubject.set(subject, [vendor]);
+  }
+  return bySubject;
+})();
+
+function changesForSubject(named: CompiledFigureVendor): DealChange[] {
+  if (named.slug === null) return changesFor(named.vendor);
+  const names = new Set([named.vendor, ...(changeLogNamesBySubject.get(named.slug) ?? [])]);
+  return [...names].flatMap(changesFor);
 }
 
 interface SubjectFreeTier {
@@ -911,7 +925,7 @@ interface SubjectFreeTier {
 
 function freeTierForSubject(named: CompiledFigureVendor): SubjectFreeTier {
   if (named.slug === null) {
-    const ending = freeTierEndingRecord(changesFor(named.vendor));
+    const ending = freeTierEndingRecord(changesForSubject(named));
     return { ended: ending !== null, endedBy: ending };
   }
   const claim = freeTierClaimFor(named.vendor, today);
@@ -935,7 +949,7 @@ function compiledFigureVerdictFor(
     endedBy: endedBy
       ? { date: endedBy.date, summary: endedBy.summary, dateClause: changeDateClause(endedBy) }
       : null,
-    since: recordsSinceCompiledFor(named.vendor, compiledOn).map(c => ({
+    since: recordsSinceCompiled(changesForSubject(named), compiledOn, today).map(c => ({
       date: c.date,
       summary: c.summary,
       dateClause: changeDateClause(c),
@@ -49819,7 +49833,7 @@ function buildChangesPage(): string {
     const altHtml = c.alternatives && c.alternatives.length > 0
       ? `<div class="chg-alts"><span class="chg-alts-label">Alternatives:</span> ${c.alternatives.map(a => `<a href="/vendor/${toSlug(a)}">${escHtmlServer(a)}</a>`).join(", ")}</div>`
       : "";
-    return `      <div${anchorAttr} class="chg-entry${isUpcoming ? " chg-upcoming" : ""}${dated ? "" : " chg-undated"}${changeIsUncited(c) ? " chg-unsourced" : ""}">
+    return `      <div class="chg-entry${isUpcoming ? " chg-upcoming" : ""}${dated ? "" : " chg-undated"}${changeIsUncited(c) ? " chg-unsourced" : ""}"${anchorAttr}>
         <div class="chg-left">
           <div class="chg-date">${dated ? c.date : `${DISCOVERED_DATE_PREFIX} ${c.date}`}</div>
           ${isUpcoming ? `<div class="chg-upcoming-badge">upcoming</div>` : ""}

--- a/src/vendor-slug.ts
+++ b/src/vendor-slug.ts
@@ -28,10 +28,9 @@ function buildChangeLogVendorMap(): Map<string, string> {
 
 export const changeLogVendorMap: Map<string, string> = buildChangeLogVendorMap();
 
-export function vendorWeHoldRecordsFor(phrase: string): string | null {
+export function changeLogVendorNamed(phrase: string): string | null {
   const slug = toSlug(phrase);
-  if (!slug) return null;
-  return vendorSlugMap.get(slug) ?? changeLogVendorMap.get(slug) ?? null;
+  return slug ? changeLogVendorMap.get(slug) ?? null : null;
 }
 
 export function changeLogAnchorFor(vendor: string): string | null {

--- a/src/vendor-slug.ts
+++ b/src/vendor-slug.ts
@@ -1,4 +1,4 @@
-import { loadOffers } from "./data.js";
+import { loadDealChanges, loadOffers } from "./data.js";
 import { isSubSlug, toSlug } from "./slug.js";
 
 export { isSubSlug, toSlug };
@@ -15,6 +15,29 @@ function buildVendorSlugMap(): Map<string, string> {
 }
 
 export const vendorSlugMap: Map<string, string> = buildVendorSlugMap();
+
+function buildChangeLogVendorMap(): Map<string, string> {
+  const map = new Map<string, string>();
+  for (const change of loadDealChanges()) {
+    const slug = toSlug(change.vendor);
+    if (!slug || map.has(slug)) continue;
+    map.set(slug, change.vendor);
+  }
+  return map;
+}
+
+export const changeLogVendorMap: Map<string, string> = buildChangeLogVendorMap();
+
+export function vendorWeHoldRecordsFor(phrase: string): string | null {
+  const slug = toSlug(phrase);
+  if (!slug) return null;
+  return vendorSlugMap.get(slug) ?? changeLogVendorMap.get(slug) ?? null;
+}
+
+export function changeLogAnchorFor(vendor: string): string | null {
+  const slug = toSlug(vendor);
+  return slug ? `vendor-${slug}` : null;
+}
 
 export type VendorSlugResolution =
   | { type: "exact"; slug: string }

--- a/test/change-log-only-vendors.test.ts
+++ b/test/change-log-only-vendors.test.ts
@@ -1,0 +1,195 @@
+import { describe, it, before, after } from "node:test";
+import assert from "node:assert";
+import { spawn, type ChildProcess } from "node:child_process";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { badgeVerdictsFromBadgesPage, type SiteFreeTierVerdict } from "./badge-verdicts.ts";
+
+const { compiledFigureSlots, staticHalfOf } = await import("../dist/compiled-figures.js");
+const { toSlug, vendorSlugMap } = await import("../dist/vendor-slug.js");
+
+type DealChange = import("../src/types.ts").DealChange;
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO = path.join(__dirname, "..");
+
+const changes: DealChange[] = JSON.parse(
+  readFileSync(path.join(REPO, "data", "deal_changes.json"), "utf-8"),
+).changes;
+
+const ENDS_THE_FREE_TIER = new Set(["free_tier_removed", "open_source_killed"]);
+const REMOVAL_MARKER = /class="[^"]*\bremoved-badge\b[^"]*"/;
+
+function recordsByVendorSlug(): Map<string, DealChange[]> {
+  const byVendor = new Map<string, DealChange[]>();
+  for (const change of changes) {
+    const slug = toSlug(change.vendor);
+    if (!slug) continue;
+    const held = byVendor.get(slug);
+    if (held) held.push(change);
+    else byVendor.set(slug, [change]);
+  }
+  return byVendor;
+}
+
+function endingRecordIn(vendorChanges: DealChange[]): DealChange | null {
+  const standing = vendorChanges.filter(c => !c.resolution);
+  const ending = standing
+    .filter(c => ENDS_THE_FREE_TIER.has(c.change_type))
+    .sort((a, b) => b.date.localeCompare(a.date))[0];
+  if (!ending) return null;
+  return standing.some(c => c.change_type === "new_free_tier" && c.date > ending.date) ? null : ending;
+}
+
+const recordsFor = recordsByVendorSlug();
+const endedByTheLog = new Map<string, DealChange>();
+for (const [slug, held] of recordsFor) {
+  const ending = endingRecordIn(held);
+  if (ending) endedByTheLog.set(slug, ending);
+}
+const outsideTheCatalogue = (slug: string) => !vendorSlugMap.has(slug);
+
+let proc: ChildProcess | null = null;
+let base = "";
+const pages = new Map<string, string>();
+let verdicts = new Map<string, SiteFreeTierVerdict>();
+
+function startServer(): Promise<ChildProcess> {
+  return new Promise((resolve, reject) => {
+    const child = spawn("node", [path.join(REPO, "dist", "serve.js")], {
+      stdio: ["pipe", "pipe", "pipe"],
+      env: { ...process.env, PORT: "0", BASE_URL: "http://localhost", TZ: "UTC" },
+    });
+    const timeout = setTimeout(() => { child.kill(); reject(new Error("Server startup timeout")); }, 60000);
+    child.stderr!.on("data", (data: Buffer) => {
+      const m = data.toString().match(/running on http:\/\/localhost:(\d+)/);
+      if (m) { base = `http://localhost:${m[1]}`; clearTimeout(timeout); resolve(child); }
+    });
+    child.on("error", (e) => { clearTimeout(timeout); reject(e); });
+  });
+}
+
+async function fetchEveryPublishedPage(): Promise<void> {
+  const sitemap = await (await fetch(`${base}/sitemap-pages.xml`)).text();
+  const queue = [...sitemap.matchAll(/<loc>([^<]+)<\/loc>/g)].map(m => new URL(m[1]).pathname);
+  await Promise.all(Array.from({ length: 8 }, async () => {
+    for (let next = queue.pop(); next; next = queue.pop()) {
+      const res = await fetch(`${base}${next}`);
+      if (res.ok) pages.set(next, await res.text());
+    }
+  }));
+}
+
+interface SweptSlot {
+  path: string;
+  kind: "row" | "card";
+  label: string;
+  slug: string;
+  markup: string;
+}
+
+function everySlotOnEveryPage(): SweptSlot[] {
+  const found: SweptSlot[] = [];
+  for (const [pathname, html] of pages) {
+    for (const slot of compiledFigureSlots(staticHalfOf(html))) {
+      const slug = toSlug(slot.label);
+      if (!slug) continue;
+      found.push({ path: pathname, kind: slot.kind, label: slot.label, slug, markup: slot.markup });
+    }
+  }
+  return found;
+}
+
+describe("marking a comparison slot whose vendor has no catalogue entry", () => {
+  before(async () => {
+    proc = await startServer();
+    await fetchEveryPublishedPage();
+    verdicts = badgeVerdictsFromBadgesPage(await (await fetch(`${base}/badges`)).text());
+  });
+
+  after(() => { proc?.kill(); });
+
+  it("reads every page the sitemap publishes", () => {
+    assert.ok(pages.size >= 400, `only ${pages.size} pages read`);
+    assert.ok(verdicts.size >= 1500, `only ${verdicts.size} badge verdicts read`);
+  });
+
+  it("holds ended records for vendors the catalogue has no entry for", () => {
+    const orphaned = [...endedByTheLog.keys()].filter(outsideTheCatalogue);
+    assert.ok(orphaned.length >= 20, `only ${orphaned.length} ended vendors are absent from the catalogue`);
+  });
+
+  it("marks every slot naming an uncatalogued vendor whose free tier the change log ended", () => {
+    const named = everySlotOnEveryPage().filter(
+      slot => outsideTheCatalogue(slot.slug) && endedByTheLog.has(slot.slug),
+    );
+    const unmarked = named
+      .filter(slot => !REMOVAL_MARKER.test(slot.markup))
+      .map(slot => `${slot.path}: ${slot.kind} ${slot.label}`);
+    assert.deepStrictEqual(unmarked, []);
+    assert.ok(named.length >= 3, `only ${named.length} slots name an uncatalogued ended vendor`);
+  });
+
+  it("marks every slot the site's own badge says has lost its free tier", () => {
+    const named = everySlotOnEveryPage().filter(slot => verdicts.get(slot.slug) === "ended");
+    const unmarked = named
+      .filter(slot => !REMOVAL_MARKER.test(slot.markup))
+      .map(slot => `${slot.path}: ${slot.kind} ${slot.label}`);
+    assert.deepStrictEqual(unmarked, []);
+    assert.ok(named.length >= 8, `only ${named.length} slots name a vendor the badge calls ended`);
+  });
+
+  it("sends no marker to a vendor page that does not exist", () => {
+    const dead: string[] = [];
+    for (const slot of everySlotOnEveryPage()) {
+      for (const href of slot.markup.matchAll(/href="\/vendor\/([a-z0-9-]+)#changes"/g)) {
+        if (!vendorSlugMap.has(href[1]!)) dead.push(`${slot.path}: ${slot.label} -> /vendor/${href[1]}`);
+      }
+    }
+    assert.deepStrictEqual(dead, []);
+  });
+
+  it("lands every change-log marker on the record it rests on", () => {
+    const log = pages.get("/changes");
+    assert.ok(log, "the change log did not render");
+    let landed = 0;
+    for (const slot of everySlotOnEveryPage()) {
+      for (const href of slot.markup.matchAll(/href="\/changes#(vendor-[a-z0-9-]+)"/g)) {
+        assert.ok(log!.includes(` id="${href[1]}"`), `${slot.path}: ${slot.label} points at a missing ${href[1]}`);
+        landed++;
+      }
+    }
+    assert.ok(landed >= 3, `only ${landed} markers point at the change log`);
+  });
+
+  it("gives the change log one anchor per vendor and no more", () => {
+    const ids = [...pages.get("/changes")!.matchAll(/ id="(vendor-[a-z0-9-]+)"/g)].map(m => m[1]!);
+    assert.deepStrictEqual(ids.filter((id, at) => ids.indexOf(id) !== at), []);
+    assert.ok(ids.length >= 400, `only ${ids.length} vendors are addressable in the change log`);
+  });
+
+  it("leaves a slot the page itself wrote as removed exactly as the page wrote it", () => {
+    const written = everySlotOnEveryPage().filter(slot => REMOVAL_MARKER.test(slot.markup));
+    const twiceBadged = written
+      .filter(slot => (slot.markup.match(/removed-badge/g) ?? []).length > 1)
+      .map(slot => `${slot.path}: ${slot.label}`);
+    assert.deepStrictEqual(twiceBadged, []);
+    const twiceStruck = written
+      .filter(slot => /line-through[\s\S]*line-through/.test(slot.markup.split("removed-badge")[0]!))
+      .map(slot => `${slot.path}: ${slot.label}`);
+    assert.deepStrictEqual(twiceStruck, []);
+    assert.ok(written.length >= 10, `only ${written.length} slots carry a removal marker`);
+  });
+
+  it("stops calling a free tier ended once the record that ended it no longer stands", () => {
+    const standingDown = [...recordsFor.entries()]
+      .filter(([slug, held]) => held.some(c => ENDS_THE_FREE_TIER.has(c.change_type)) && !endedByTheLog.has(slug))
+      .map(([slug]) => slug);
+    assert.ok(standingDown.length >= 1, "no ended record has been reversed, retracted or superseded");
+    const marked = everySlotOnEveryPage()
+      .filter(slot => standingDown.includes(slot.slug) && REMOVAL_MARKER.test(slot.markup))
+      .map(slot => `${slot.path}: ${slot.label}`);
+    assert.deepStrictEqual(marked, []);
+  });
+});

--- a/test/change-log-only-vendors.test.ts
+++ b/test/change-log-only-vendors.test.ts
@@ -7,7 +7,7 @@ import { fileURLToPath } from "node:url";
 import { badgeVerdictsFromBadgesPage, type SiteFreeTierVerdict } from "./badge-verdicts.ts";
 
 const { compiledFigureSlots, staticHalfOf } = await import("../dist/compiled-figures.js");
-const { toSlug, vendorSlugMap } = await import("../dist/vendor-slug.js");
+const { namedVendorSlug, toSlug, vendorSlugMap } = await import("../dist/vendor-slug.js");
 
 type DealChange = import("../src/types.ts").DealChange;
 
@@ -20,6 +20,8 @@ const changes: DealChange[] = JSON.parse(
 
 const ENDS_THE_FREE_TIER = new Set(["free_tier_removed", "open_source_killed"]);
 const REMOVAL_MARKER = /class="[^"]*\bremoved-badge\b[^"]*"/;
+const PAGE_OWN_REMOVAL = /<span\b[^>]*class="[^"]*\bremoved-badge\b/;
+const JOIN_MARKER = /<a\b[^>]*href="(?:\/vendor\/[a-z0-9-]+#changes|\/changes#vendor-[a-z0-9-]+)"[^>]*>(?:CHANGED [A-Z]{3} \d+|FREE REMOVED)</;
 
 function recordsByVendorSlug(): Map<string, DealChange[]> {
   const byVendor = new Map<string, DealChange[]>();
@@ -48,7 +50,7 @@ for (const [slug, held] of recordsFor) {
   const ending = endingRecordIn(held);
   if (ending) endedByTheLog.set(slug, ending);
 }
-const outsideTheCatalogue = (slug: string) => !vendorSlugMap.has(slug);
+const outsideTheCatalogue = (label: string) => namedVendorSlug(label) === null;
 
 let proc: ChildProcess | null = null;
 let base = "";
@@ -116,19 +118,37 @@ describe("marking a comparison slot whose vendor has no catalogue entry", () => 
   });
 
   it("holds ended records for vendors the catalogue has no entry for", () => {
-    const orphaned = [...endedByTheLog.keys()].filter(outsideTheCatalogue);
+    const orphaned = [...endedByTheLog.values()].filter(c => outsideTheCatalogue(c.vendor));
     assert.ok(orphaned.length >= 20, `only ${orphaned.length} ended vendors are absent from the catalogue`);
   });
 
   it("marks every slot naming an uncatalogued vendor whose free tier the change log ended", () => {
     const named = everySlotOnEveryPage().filter(
-      slot => outsideTheCatalogue(slot.slug) && endedByTheLog.has(slot.slug),
+      slot => outsideTheCatalogue(slot.label) && endedByTheLog.has(slot.slug),
     );
     const unmarked = named
       .filter(slot => !REMOVAL_MARKER.test(slot.markup))
       .map(slot => `${slot.path}: ${slot.kind} ${slot.label}`);
     assert.deepStrictEqual(unmarked, []);
     assert.ok(named.length >= 3, `only ${named.length} slots name an uncatalogued ended vendor`);
+  });
+
+  it("reaches a vendor's records through the name its own page is filed under", () => {
+    const crossSpelled = everySlotOnEveryPage().filter(slot => {
+      const page = namedVendorSlug(slot.label);
+      if (page === null || page === slot.slug) return false;
+      if (PAGE_OWN_REMOVAL.test(slot.markup)) return false;
+      const heldUnderTheLabel = recordsFor.get(slot.slug) ?? [];
+      return heldUnderTheLabel.length > 0 && (recordsFor.get(page) ?? []).length === 0;
+    });
+    assert.ok(crossSpelled.length >= 2, `only ${crossSpelled.length} slots name a vendor the two stores spell differently`);
+    for (const slot of crossSpelled) {
+      assert.match(
+        slot.markup,
+        new RegExp(`<a [^>]*href="/vendor/${namedVendorSlug(slot.label)}#changes"`),
+        `${slot.path}: ${slot.label} reaches no record through its own page`,
+      );
+    }
   });
 
   it("marks every slot the site's own badge says has lost its free tier", () => {
@@ -160,7 +180,7 @@ describe("marking a comparison slot whose vendor has no catalogue entry", () => 
         landed++;
       }
     }
-    assert.ok(landed >= 3, `only ${landed} markers point at the change log`);
+    assert.ok(landed >= 2, `only ${landed} markers point at the change log`);
   });
 
   it("gives the change log one anchor per vendor and no more", () => {

--- a/test/compiled-comparison-figures.test.ts
+++ b/test/compiled-comparison-figures.test.ts
@@ -351,6 +351,19 @@ describe("marking a compiled figure whose vendor has moved since", () => {
     assert.doesNotMatch(marked, /Seat pricing rearranged/);
   });
 
+  it("adds nothing a second time to a page it has already marked", () => {
+    const ended = () => ({
+      slug: null,
+      vendor: "Acme",
+      freeTierEnded: true,
+      endedBy: { date: "2026-05-01", summary: "Free tier withdrawn" },
+      since: [],
+    });
+    const once = markCompiledFigures(row, ended, markup);
+    assert.match(once, /removed-badge/);
+    assert.strictEqual(markCompiledFigures(once, ended, markup), once);
+  });
+
   it("marks nothing below the timeline heading", () => {
     const below =
       '<h2 id="changes">Pricing Change Timeline</h2>' +

--- a/test/compiled-comparison-figures.test.ts
+++ b/test/compiled-comparison-figures.test.ts
@@ -171,14 +171,17 @@ describe("resolving the vendor a compiled figure is about", () => {
   });
 
   it("names a vendor the change log holds and the catalogue does not", () => {
-    const named = vendorForSubject({ kind: "row", label: "Heroku", linkedSlug: null });
-    assert.deepStrictEqual(named, { slug: null, vendor: "Heroku" });
-    assert.ok(!vendorSlugMap.has("heroku"), "Heroku has gained a catalogue entry");
+    const named = vendorForSubject({ kind: "row", label: "StackHawk", linkedSlug: null });
+    assert.deepStrictEqual(named, { slug: null, vendor: "StackHawk" });
+    assert.strictEqual(vendorSlugForSubject({ kind: "row", label: "StackHawk", linkedSlug: null }), null);
   });
 
-  it("prefers the name the change log holds over a longer catalogue entry that starts with it", () => {
-    assert.strictEqual(vendorSlugForSubject({ kind: "row", label: "Heroku", linkedSlug: null }), "heroku-for-startups-program");
-    assert.strictEqual(vendorForSubject({ kind: "row", label: "Heroku", linkedSlug: null })!.vendor, "Heroku");
+  it("keeps a vendor's own page when the catalogue holds it under a longer name", () => {
+    assert.ok(!vendorSlugMap.has("katalon"), "Katalon is now catalogued under its bare name");
+    assert.deepStrictEqual(
+      vendorForSubject({ kind: "card", label: "Katalon", linkedSlug: null }),
+      { slug: "katalon-com", vendor: vendorSlugMap.get("katalon-com") },
+    );
   });
 
   it("keeps the catalogue entry for a vendor that has one", () => {

--- a/test/compiled-comparison-figures.test.ts
+++ b/test/compiled-comparison-figures.test.ts
@@ -10,12 +10,15 @@ const {
   comparedServicesOn,
   compiledFigureSlots,
   markCompiledFigures,
+  recordsHrefFor,
   recordsSinceCompiled,
   staticHalfOf,
   subjectOfCardHeading,
   timelineRecordsFor,
+  vendorForSubject,
   vendorSlugForSubject,
 } = await import("../dist/compiled-figures.js");
+const { freeTierEndingRecord } = await import("../dist/data.js");
 const { CHANGE_IMPACT_LEVELS, changeImpactColor, changeImpactLabel, isChangeImpactLevel } =
   await import("../dist/change-impact.js");
 const { vendorSlugMap } = await import("../dist/vendor-slug.js");
@@ -165,6 +168,66 @@ describe("resolving the vendor a compiled figure is about", () => {
       linkedSlug: null,
     });
     assert.strictEqual(slug, null);
+  });
+
+  it("names a vendor the change log holds and the catalogue does not", () => {
+    const named = vendorForSubject({ kind: "row", label: "Heroku", linkedSlug: null });
+    assert.deepStrictEqual(named, { slug: null, vendor: "Heroku" });
+    assert.ok(!vendorSlugMap.has("heroku"), "Heroku has gained a catalogue entry");
+  });
+
+  it("prefers the name the change log holds over a longer catalogue entry that starts with it", () => {
+    assert.strictEqual(vendorSlugForSubject({ kind: "row", label: "Heroku", linkedSlug: null }), "heroku-for-startups-program");
+    assert.strictEqual(vendorForSubject({ kind: "row", label: "Heroku", linkedSlug: null })!.vendor, "Heroku");
+  });
+
+  it("keeps the catalogue entry for a vendor that has one", () => {
+    assert.deepStrictEqual(
+      vendorForSubject({ kind: "row", label: "Supabase", linkedSlug: null }),
+      { slug: "supabase", vendor: vendorSlugMap.get("supabase") },
+    );
+  });
+
+  it("names nothing for a subject that is not a vendor", () => {
+    assert.strictEqual(vendorForSubject({ kind: "row", label: "Go Goroutines", linkedSlug: null }), null);
+  });
+});
+
+describe("where a marker sends a reader for the record it rests on", () => {
+  it("sends a catalogued vendor to its own page", () => {
+    assert.strictEqual(recordsHrefFor({ slug: "supabase", vendor: "Supabase" }), "/vendor/supabase#changes");
+  });
+
+  it("sends a vendor with no page to its own place in the change log", () => {
+    assert.strictEqual(recordsHrefFor({ slug: null, vendor: "Uploadthing" }), "/changes#vendor-uploadthing");
+  });
+});
+
+describe("reading an ending out of a vendor's records", () => {
+  const removed = { change_type: "free_tier_removed", date: "2026-04-13" };
+
+  it("takes the newest record that ends the free tier", () => {
+    const older = { change_type: "open_source_killed", date: "2025-01-01" };
+    assert.strictEqual(freeTierEndingRecord([older, removed]), removed);
+  });
+
+  it("reads no ending from a record that is no longer in force", () => {
+    const reversed = { ...removed, resolution: { state: "reversed", date: "2026-09-06" } };
+    assert.strictEqual(freeTierEndingRecord([reversed]), null);
+  });
+
+  it("reads no ending once a later record opens a free tier again", () => {
+    const restored = { change_type: "new_free_tier", date: "2026-06-01" };
+    assert.strictEqual(freeTierEndingRecord([removed, restored]), null);
+  });
+
+  it("keeps the ending when the record opening a free tier came first", () => {
+    const earlier = { change_type: "new_free_tier", date: "2026-01-01" };
+    assert.strictEqual(freeTierEndingRecord([removed, earlier]), removed);
+  });
+
+  it("reads no ending from records that only narrow the terms", () => {
+    assert.strictEqual(freeTierEndingRecord([{ change_type: "limits_reduced", date: "2026-05-01" }]), null);
   });
 });
 
@@ -395,8 +458,7 @@ describe("the nine compiled comparison pages against the site's own verdicts", (
       for (const slot of compiledFigureSlots(html)) {
         if (!/CHANGED [A-Z]{3} \d+|FREE REMOVED/.test(slot.markup)) continue;
         named++;
-        const vendorSlug = subjectSlug(slot)!;
-        const vendor = vendorSlugMap.get(vendorSlug)!;
+        const vendor = vendorForSubject(slot)!.vendor;
         const label = slot.label.toLowerCase();
         const name = vendor.toLowerCase();
         if (!label.startsWith(name) && !name.startsWith(label)) {


### PR DESCRIPTION
Refs https://github.com/robhunter/agentdeals/issues/1415

## What the join was doing

Every comparison slot resolved through `resolveVendorSlug`, and a subject that resolved to nothing was skipped. 37 of the 140 vendors named only by the change log carry a record ending their free tier, and their slots could never be marked.

Resolution was only half of it. Two other things kept records away from their slots:

- **`/storage-comparison-2026`, `/email-comparison-2026` and `/monitoring-comparison-2026` were not joined at all.** They now are, alongside the nine that already were. `/storage-comparison-2026` is where AC-1's Uploadthing row lives.
- **A subject asked the change log for records under its own catalogue name only.** Where the two stores spell a vendor differently the records never arrived: the catalogue holds `katalon.com`, `mailtrap.io`, `mailersend.com` and `mailerlite.com`; the change log holds `Katalon`, `Mailtrap`, `MailerSend` and `MailerLite`. A subject now gathers records filed under any name that resolves to it.

## What changed

- `vendorForSubject` names a subject from the catalogue first and falls back to the change log. The catalogue keeps precedence so a vendor with a page of its own is never marked through the change log instead — that would have cost `/email-comparison-2026` six correct `/vendor/` links.
- A subject with no page of its own is marked with a link into the change log, where every vendor now carries an anchor. No marker points at a page that does not exist.
- `freeTierEndingRecord` in `src/data.ts` answers, for a subject with no offer, whether the change log ends its free tier: the newest severe record still in force, unless a later record opens a free tier again. A subject with a page keeps using the claim, which is the site's answer for a vendor whose terms we publish. The two populations are asked different questions because only one of them has terms to reconcile.
- Marking is idempotent per decoration. A slot the page itself struck and badged is left exactly as the page wrote it; a slot the page badged but did not strike keeps its own badge and gains the strike. Applying the join to a page it has already marked now adds nothing — it used to add a second badge and strike the figures twice.

## AC-5: read against the vendors, and one of the three inverts

**StackHawk** — `stackhawk.com/pricing` sells Wingman at $10/user/mo with a 14-day trial and Scale at "Talk to us". No free tier. Our record is right; the row and card are now struck and badged.

**Katalon** — `katalon.com/pricing` opens at $180/seat/month monthly, $84/seat/month annual for the first three seats, every entry point "Buy now" or "Start free trial". No `$0` anywhere on the page. Our record is right.

**Uploadthing — our record is the stale one, and the row is correct.** `uploadthing.com/pricing` opens its plan ladder with **"2GB App — Everything you need to start uploading! — $0 /month"**, listing 2GB of storage shared between all apps, 7 days of audit log retention and unlimited uploads and downloads. The $25/month usage-based plan our record names is the third rung, above a $10/month 100GB App. The row's "2 GB storage" matches the vendor's own page exactly.

The 2025-01-15 record is recorded as **no longer in force** rather than retracted — we hold no evidence either way about January 2025 — which is the idiom the xAI and Google Gemini API records already use. Marking that row `FREE REMOVED` would have published a claim the vendor's own page contradicts.

## Verification

- 4,146 tests, 0 failures, 21 new. Every new test fails on `main`.
- 25 mutants, 24 killed. The survivor removes the non-vendor-subject guard, which has no live subject: none of `Django Built-in Auth`, `FastAPI Built-in` or `Go Goroutines` appears as a slot on any published page.
- Route sweep of all 483 paths in `sitemap-pages.xml`: 10 moved, 0 status changes, 0 5xx. Across those 483 pages, slots carrying a removal marker 14 → 20, slots carrying a superseded-figure marker 77 → 111, markers pointing at a vendor page that does not exist 0 → 0.
- `/pricing-changes`, `/budget-builder` and `/stability` moved because of the Uploadthing resolution alone: the entry is tagged as no longer in force, the row drops its risk cause, and the volatile count falls 71 → 70.
- The two control slots read the same. `/database-free-tier-comparison-2026`'s PlanetScale cell is byte-identical. `/hosting-free-tier-comparison-2026`'s Heroku cell keeps its strike and its `FREE REMOVED`.

## Found, not fixed

- **`/vendor/katalon-com` publishes `Tier — Free` while our change log records the Community Edition removed.** The cross-spelling fix here is scoped to the join; the site's shared record lookup is still keyed on the exact catalogue name, so the vendor page, its badge and its risk level never see the `Katalon` records. Same shape for `mailtrap.io`, `mailerlite.com` and `mailersend.com` — and the change log already holds `MailerSend` **and** `MailerSend.com`, so someone has hit this before. This is why Katalon's card carries `CHANGED APR 13` rather than `FREE REMOVED`: the comparison page will not overrule the vendor page.
- **`/hosting-free-tier-comparison-2026`'s Heroku row is the only reason that page reads the catalogue at all.** Its `FREE REMOVED` came from the claim for `Heroku for Startups Program`, a different product; `Heroku` itself has no catalogue entry. The row is left exactly as it was, so nothing moves, but the page's `data_source: catalogue` in `data/page-reviews.json` rests on a misattribution. Its twelve sibling comparison pages are all `reads_index: false`.
- **`/security-free-tier-comparison-2026` sells StackHawk's free tier in four places the join cannot see** — the quick verdict's list of "hosted platforms with generous free tiers", the `$0 (StackHawk, 1 app)` cell in the cost-trap table, the "Best free DAST" verdict item, and a whole gotcha card about the 1-app limit. Swept every marked vendor against its own page's prose across all 483 paths: StackHawk on this page is the only one where a marker and the prose disagree. Every other hit is prose *about* a removal, which is correct writing.
- **`/vendor/heroku` and the change log's Heroku entries** resolve through a redirect to a different product's page.
