### PR TITLE
Retract the Dub.co removal: it read the Dub Partners tab of a two-product pricing page

### DIFF
--- a/data/deal_changes.json
+++ b/data/deal_changes.json
@@ -7541,21 +7541,6 @@
       }
     },
     {
-      "vendor": "Dub.co",
-      "change_type": "free_tier_removed",
-      "date": "2026-09-02",
-      "date_source": "discovered",
-      "summary": "The free tier no longer exists. The lowest tier is $90/month.",
-      "previous_state": "Open-source link management — 25 new links/month, 1,000 tracked events/month, 3 custom domains, 1 user, 30-day analytics retention, API with native SDKs. No credit card required",
-      "current_state": "The lowest tier is $90/month and includes 10K new links/month, unlimited tags, 20 folders, custom QR codes, UTM builder + templates, custom link previews, deep links, link cloaking, link expiration, password protection, device targeting, geo targeting, A/B testing, automated global payouts, $2.5K partner payouts/month, 5% payout fees, tax compliance, basic partner rewards, dual-sided incentives, AI landing page generator, 500 partners, 3 partner groups, 10 partner tags, embedded referral dashboard, partner referral rewards, messaging center, email campaigns, social metrics bounties, risk monitoring, advanced analytics, 250K tracked events/month, 3-year retention, conversion tracking, customer insights, real-time events stream, 100 custom domains, SSL certificates, free .link domain, API Access, Native SDKs, 1,200/min rate limit, event webhooks, 10 users, role-based access control, and email support.",
-      "impact": "high",
-      "source_url": "https://dub.co/pricing",
-      "category": "Dev Utilities",
-      "alternatives": [],
-      "detected_by": "reverify-ai",
-      "recorded_date": "2026-09-02"
-    },
-    {
       "vendor": "StatusCake",
       "change_type": "limits_increased",
       "date": "2026-09-02",

--- a/data/index.json
+++ b/data/index.json
@@ -5593,7 +5593,7 @@
       "category": "Dev Utilities",
       "description": "Open-source link management — 25 new links/month, 1,000 tracked events/month, 3 custom domains, 1 user, 30-day analytics retention, API with native SDKs. No credit card required",
       "tier": "Free",
-      "url": "https://dub.co/pricing",
+      "url": "https://dub.co/pricing/links",
       "tags": [
         "links",
         "url shortener",


### PR DESCRIPTION
`dub.co/pricing` sells two products behind a tab control. It opens on **Dub Partners**, whose lowest plan is $90/month. The free tier is on the other tab, **Dub Links**, at `dub.co/pricing/links`, which today reads:

> **Free $0** free forever – the most generous free plan on the market
> 25 new links/mo · 1K tracked events/mo · 1 user · 3 custom domains · 30-day analytics retention · API access · QR codes · link tags · UTM templates

That is our stored description verbatim, down to every figure.

The `free_tier_removed` record dated 2026-09-02 compared Dub Links' free plan (`previous_state`) against Dub Partners' $90 Business plan (`current_state`) and read the difference as a removal — its `current_state` lists partner payouts, referral dashboards, bounties and partner groups, none of which is a link-management feature. `/badge/dub-co.svg` publishes **"free tier removed · Sep 2026"** right now on a vendor whose own page calls its free plan the most generous on the market.

**Two changes.** The record comes out. The offer's `url` moves from `dub.co/pricing` to `dub.co/pricing/links`, so the next re-verification reads the tab that holds the plan we describe.

**The class.** This is the wrong-row family (#1371) one level up: not the wrong row of a table, the wrong product on a page that sells more than one. A liveness check passes, a text read passes, and the terms belong to something else. Worth a sweep of records whose stored URL serves a product toggle; I will scope that separately rather than widen this.
