### PR TITLE
Derive every page's lede from the description it already publishes (#1343)

### DIFF
--- a/scripts/mutate-1343.mjs
+++ b/scripts/mutate-1343.mjs
@@ -1,0 +1,84 @@
+import { readFileSync, writeFileSync } from "node:fs";
+import { execFileSync } from "node:child_process";
+
+const SUITE = [
+  "test/page-lede.test.ts",
+];
+
+const MUTANTS = [
+  ["no-page-is-given-a-lede", "src/page-lede.ts",
+    `  const headAt = html.indexOf(PAGE_HEAD_OPEN);
+  if (headAt === -1) return html;`,
+    `  const headAt = html.indexOf(PAGE_HEAD_OPEN);
+  if (headAt === -1 || headAt !== -1) return html;`],
+  ["lede-is-placed-after-the-menu", "src/page-lede.ts",
+    `  return html.slice(0, insertAt)
+    + PAGE_CLAIM_OPEN + description + PAGE_CLAIM_CLOSE
+    + html.slice(insertAt);`,
+    `  const closeAt = html.indexOf("</div>", insertAt);
+  return html.slice(0, closeAt)
+    + PAGE_CLAIM_OPEN + description + PAGE_CLAIM_CLOSE
+    + html.slice(closeAt);`],
+  ["lede-is-read-from-the-title", "src/page-lede.ts",
+    `  return html.match(/<meta name="description" content="([^"]*)"/i)?.[1] ?? "";`,
+    `  return html.match(/<title>([^<]*)<\\/title>/i)?.[1] ?? "";`],
+  ["lede-is-read-from-any-tag-that-has-content", "src/page-lede.ts",
+    `  return html.match(/<meta name="description" content="([^"]*)"/i)?.[1] ?? "";`,
+    `  return html.match(/content="([^"]*)"/i)?.[1] ?? "";`],
+  ["lede-is-clipped-to-the-width-of-a-search-result", "src/page-lede.ts",
+    `    + PAGE_CLAIM_OPEN + description + PAGE_CLAIM_CLOSE`,
+    `    + PAGE_CLAIM_OPEN + description.slice(0, 80) + PAGE_CLAIM_CLOSE`],
+  ["lede-is-escaped-a-second-time", "src/page-lede.ts",
+    `    + PAGE_CLAIM_OPEN + description + PAGE_CLAIM_CLOSE`,
+    `    + PAGE_CLAIM_OPEN + description.replace(/&/g, "&amp;") + PAGE_CLAIM_CLOSE`],
+  ["a-page-that-already-states-its-claim-is-given-a-second-one", "src/page-lede.ts",
+    `  if (html.startsWith(PAGE_CLAIM_OPEN, insertAt)) return html;`,
+    ``],
+  ["a-page-with-no-description-states-an-empty-claim", "src/page-lede.ts",
+    `  if (!description.trim()) return html;`,
+    ``],
+  ["the-menu-is-not-wrapped-for-a-lede", "src/serve.ts",
+    `  return PAGE_HEAD_OPEN + nav + '</div>' + '<script>' + globalNavJs() + '</script>';`,
+    `  return nav + '<script>' + globalNavJs() + '</script>';`],
+  ["html-responses-are-served-without-a-lede", "src/serve.ts",
+    `    if (typeof args[0] === "string" && /^text\\/html/.test(servedContentType)) {`,
+    `    if (typeof args[0] === "string" && /^application\\/json/.test(servedContentType)) {`],
+  ["the-served-content-type-is-never-recorded", "src/serve.ts",
+    `    servedContentType = String(
+      headers?.["Content-Type"] ?? headers?.["content-type"] ?? res.getHeader("Content-Type") ?? "",
+    );`,
+    `    servedContentType = String(
+      headers?.["Content-Type"] ?? headers?.["content-type"] ?? "",
+    );
+    servedContentType = "";`],
+];
+
+function run(cmd, args) {
+  try {
+    execFileSync(cmd, args, { stdio: "pipe", encoding: "utf-8" });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+const survivors = [];
+const uncompiled = [];
+for (const [name, file, from, to] of MUTANTS) {
+  const original = readFileSync(file, "utf-8");
+  if (!original.includes(from)) {
+    console.log(`SKIP  ${name} — the line it mutates is not in ${file}`);
+    continue;
+  }
+  writeFileSync(file, original.replace(from, to));
+  const built = run("npm", ["run", "build"]);
+  const green = built && run("node", ["--test", "--test-concurrency", "1", ...SUITE]);
+  writeFileSync(file, original);
+  if (!built) uncompiled.push(name);
+  console.log(`${green ? "SURVIVED" : built ? "killed  " : "DID NOT COMPILE"}  ${name}`);
+  if (green) survivors.push(name);
+}
+run("npm", ["run", "build"]);
+console.log(`\n${MUTANTS.length - survivors.length - uncompiled.length}/${MUTANTS.length} killed`);
+if (survivors.length > 0) console.log("survivors:", survivors.join(", "));
+if (uncompiled.length > 0) console.log("did not compile:", uncompiled.join(", "));

--- a/src/page-lede.ts
+++ b/src/page-lede.ts
@@ -1,0 +1,30 @@
+export const PAGE_HEAD_OPEN = '<div class="page-head">';
+export const PAGE_CLAIM_OPEN = '<p class="page-claim">';
+const PAGE_CLAIM_CLOSE = "</p>";
+
+export function metaDescriptionOf(html: string): string {
+  return html.match(/<meta name="description" content="([^"]*)"/i)?.[1] ?? "";
+}
+
+export function pageClaimOf(html: string): string | null {
+  const claimAt = html.indexOf(PAGE_CLAIM_OPEN);
+  if (claimAt === -1) return null;
+  const from = claimAt + PAGE_CLAIM_OPEN.length;
+  const to = html.indexOf(PAGE_CLAIM_CLOSE, from);
+  return to === -1 ? null : html.slice(from, to);
+}
+
+export function withLedeBeforeNav(html: string): string {
+  const headAt = html.indexOf(PAGE_HEAD_OPEN);
+  if (headAt === -1) return html;
+
+  const insertAt = headAt + PAGE_HEAD_OPEN.length;
+  if (html.startsWith(PAGE_CLAIM_OPEN, insertAt)) return html;
+
+  const description = metaDescriptionOf(html);
+  if (!description.trim()) return html;
+
+  return html.slice(0, insertAt)
+    + PAGE_CLAIM_OPEN + description + PAGE_CLAIM_CLOSE
+    + html.slice(insertAt);
+}

--- a/src/serve.ts
+++ b/src/serve.ts
@@ -28,6 +28,7 @@ import { buildComparisonMap, comparisonSlug } from "./comparison-pairs.js";
 import { comparisonVerdictText, freeTierFaqAnswer, stabilityFaqAnswer, type ComparisonSide, type FreeTierSide, type SideFreeTier, type StabilityRating } from "./comparison-verdict.js";
 import { publishedVendorLevel, vendorVerdictSentence, vendorBadge, freeTierClaim, statesRiskCause, narrowingSentence, changeKindNoun, termsUnconfirmedBySource, unconfirmedTermsMetaSentence, type BadgeWithholding, type FreeTierClaim, type VendorVerdictInput } from "./vendor-verdict.js";
 import { tierRecordsAFreeTier } from "./free-tier-record.js";
+import { PAGE_HEAD_OPEN, withLedeBeforeNav } from "./page-lede.js";
 import { UNGRADED_IMPACT_COLOR, changeImpactColor, changeImpactLabel, changeImpactWord, isChangeImpactLevel } from "./change-impact.js";
 import { COMPARED_SERVICES_PLACEHOLDER, fillComparedServicesCount, markCompiledFigures, recordsSinceCompiled, replaceTimelineRows, timelineRecordsFor, vendorForSubject, vendorSubjectsOnCompiledPage, type CompiledFigureSubject, type CompiledFigureVendor, type CompiledFigureVerdict } from "./compiled-figures.js";
 import { vendorHistorySentence } from "./vendor-history.js";
@@ -1435,7 +1436,7 @@ function globalNavCss(): string {
 @media(max-width:768px){.nav-hamburger{display:block}.nav-items{display:none;position:absolute;top:100%;left:0;right:0;background:var(--bg-elevated);border:1px solid var(--border);border-radius:0 0 8px 8px;padding:.5rem;flex-direction:column;align-items:stretch;gap:0;z-index:99;box-shadow:0 4px 12px rgba(0,0,0,.1)}.nav-items.open{display:flex}.global-nav{flex-wrap:wrap;position:relative}.nav-group{width:100%}.nav-group-toggle{width:100%;justify-content:space-between;padding:.5rem .75rem}.nav-dropdown{position:static;box-shadow:none;border:none;padding:0 0 0 1rem;background:transparent;min-width:auto}.nav-group:hover .nav-dropdown{display:none}.nav-group.open .nav-dropdown{display:block}.nav-link{padding:.4rem .75rem}.nav-link.standalone{padding:.5rem .75rem}}`;
 }
 
-function buildGlobalNav(active: NavSection, pageClaim?: string): string {
+function buildGlobalNav(active: NavSection): string {
   type NavLink = { href: string; label: string; section: NavSection };
   type NavGroup = { label: string; items: NavLink[] };
 
@@ -1496,11 +1497,7 @@ function buildGlobalNav(active: NavSection, pageClaim?: string): string {
     + '<div class="nav-items">' + searchLink + groupsHtml + '</div>'
     + '</nav>';
 
-  const head = pageClaim
-    ? '<div class="page-head"><p class="page-claim">' + escHtmlServer(pageClaim) + '</p>' + nav + '</div>'
-    : nav;
-
-  return head + '<script>' + globalNavJs() + '</script>';
+  return PAGE_HEAD_OPEN + nav + '</div>' + '<script>' + globalNavJs() + '</script>';
 }
 
 function globalNavJs(): string {
@@ -5427,11 +5424,9 @@ ${vendorListHtml}
 
 const MONITORING_COMPARISON_TITLE = "Free Tiers for Error Tracking, Monitoring & Observability 2026 — Datadog vs Grafana Cloud vs New Relic vs Better Stack vs Sentry";
 const MONITORING_COMPARISON_META_DESC = "Which error tracking, application monitoring and observability services still have a genuinely free tier in 2026. 25+ compared — Datadog, Grafana Cloud, New Relic, Better Stack, Sentry, Checkly, SigNoz, HyperDX, Elastic — free data ingest, retention and APM limits, and what monitoring costs at 10/50/100/500 hosts.";
-const MONITORING_COMPARISON_CLAIM = "Free tiers for error tracking, application monitoring and observability: what Datadog, Grafana Cloud, New Relic, Better Stack and Sentry give away, and what monitoring costs once you outgrow it.";
 
 const LLM_API_PRICING_TITLE = "LLM API Free Tiers & Free Credits 2026 — LLM API Pricing Comparison: Token Costs, Rate Limits & Hidden Limits";
 const LLM_API_PRICING_META_DESC = "Which LLM APIs have a genuinely free tier or free credits in 2026, and what tokens cost once you exceed it. OpenAI, Anthropic, Google Gemini, Mistral, Groq, DeepSeek, Cerebras, OpenRouter, Cohere and xAI compared — free tier limits, rate limits, context windows and per-token pricing.";
-const LLM_API_PRICING_CLAIM = "Which LLM APIs have a genuinely free tier or free credits, and which only sell tokens: free limits, rate limits and per-token cost for OpenAI, Anthropic, Google Gemini, Groq, DeepSeek and more.";
 
 interface AlternativesPageConfig {
   slug: string;
@@ -31916,7 +31911,7 @@ function buildLlmApiPricingPage(): string {
     mcpCtaCss() + '\n' +
     '</style>\n</head>\n<body>\n' +
     '<div class="container">\n' +
-    '  ' + buildGlobalNav("changes", LLM_API_PRICING_CLAIM) + '\n' +
+    '  ' + buildGlobalNav("changes") + '\n' +
     '  <div class="breadcrumb"><a href="/">AgentDeals</a> &rsaquo; <a href="/ai-ml-alternatives">AI / ML</a> &rsaquo; LLM API Pricing</div>\n' +
     '  <h1>LLM API Free Tiers and Free Credits &mdash; The 2026 Comparison</h1>\n' +
     '  <p class="pub-date">Published ' + pubDate + pageFreshness("/llm-api-pricing") + ' &middot; ' + providers.length + ' providers compared &middot; ' + pageDataProvenance("/llm-api-pricing", offers.length) + ' &middot; ' + llmChanges.length + ' pricing changes tracked</p>\n' +
@@ -40373,7 +40368,7 @@ ${mcpCtaCss()}
 </head>
 <body>
 <div class="container">
-  ${buildGlobalNav("guides", MONITORING_COMPARISON_CLAIM)}
+  ${buildGlobalNav("guides")}
   <div class="breadcrumb"><a href="/">AgentDeals</a> &rsaquo; <a href="/category/monitoring">Monitoring</a> &rsaquo; Monitoring &amp; Observability Comparison</div>
   <h1>Free Tiers for Error Tracking, Monitoring &amp; Observability 2026</h1>
   <p class="pub-date">Published ${pubDate}${pageFreshness("/monitoring-comparison-2026")} &middot; ${pageDataProvenance("/monitoring-comparison-2026", offers.length)} &middot; 25+ monitoring services compared</p>
@@ -53433,24 +53428,33 @@ const httpServer = createHttpServer(async (req, res) => {
     });
   }
 
+  let servedContentType = "";
   const rawWriteHead = res.writeHead.bind(res);
   res.writeHead = ((status: number, ...rest: unknown[]) => {
+    const headers = rest.find(a => a && typeof a === "object") as Record<string, string> | undefined;
+    servedContentType = String(
+      headers?.["Content-Type"] ?? headers?.["content-type"] ?? res.getHeader("Content-Type") ?? "",
+    );
     if (status >= 200 && status < 300) {
-      const headers = rest.find(a => a && typeof a === "object") as Record<string, string> | undefined;
-      const contentType = String(
-        headers?.["Content-Type"] ?? headers?.["content-type"] ?? res.getHeader("Content-Type") ?? "",
-      );
-      if (/^(text\/html|application\/json)/.test(contentType) && !res.hasHeader(SIGNAL_HEADER_NAME)) {
+      if (/^(text\/html|application\/json)/.test(servedContentType) && !res.hasHeader(SIGNAL_HEADER_NAME)) {
         const slug = singleVendorSlug(url.pathname);
         res.setHeader(SIGNAL_HEADER_NAME, signalHeaderValue(BASE_URL, slug));
       }
-      if (/^text\/html/.test(contentType) && !res.hasHeader("Last-Modified")) {
+      if (/^text\/html/.test(servedContentType) && !res.hasHeader("Last-Modified")) {
         const changed = pageLastmodHeader(url.pathname);
         if (changed) res.setHeader("Last-Modified", changed);
       }
     }
     return rawWriteHead(status as never, ...(rest as never[]));
   }) as typeof res.writeHead;
+
+  const rawEnd = res.end.bind(res);
+  res.end = ((...args: unknown[]) => {
+    if (typeof args[0] === "string" && /^text\/html/.test(servedContentType)) {
+      args[0] = withLedeBeforeNav(args[0]);
+    }
+    return rawEnd(...(args as never[]));
+  }) as typeof res.end;
 
   if (url.pathname === SIGNAL_PATH) {
     if (req.method !== "POST" && !isGetOrHead) {

--- a/test/page-lede.test.ts
+++ b/test/page-lede.test.ts
@@ -5,6 +5,7 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { extractTextContent } from "../scripts/monitor-pricing.js";
 import { getGuideList } from "../dist/guides.js";
+import { metaDescriptionOf, withLedeBeforeNav } from "../dist/page-lede.js";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -38,6 +39,8 @@ function startServer(): Promise<ChildProcess> {
 }
 
 const LEDE_WINDOW = 200;
+const SWEPT_PATHS_FLOOR = 300;
+const PAGES_WITH_MENU_FLOOR = 300;
 
 const NAV_LABELS = [
   "Categories", "Best Of", "Alternatives", "Agent Stacks",
@@ -170,20 +173,26 @@ describe("Page lede", () => {
     });
   }
 
-  it("no page renders its claim below the site menu", async () => {
+  it("every page that renders the site menu states its own claim first", async () => {
     const paths = [...await sitemapPaths("/sitemap-pages.xml"), ...await sitemapPaths("/sitemap-misc.xml")];
-    const withClaim: string[] = [];
+    assert.ok(
+      paths.length >= SWEPT_PATHS_FLOOR,
+      `swept ${paths.length} paths, too few to stand as a site-wide check`,
+    );
+
+    const withMenu: string[] = [];
+    const withoutClaim: string[] = [];
 
     for (const pathname of paths) {
       const response = await fetch(base + pathname);
       if (response.status !== 200) continue;
       const html = await response.text();
-      const claimAt = html.indexOf('<p class="page-claim">');
-      if (claimAt === -1) continue;
-      withClaim.push(pathname);
-
       const navAt = html.indexOf('<nav class="global-nav">');
-      assert.ok(navAt !== -1, `${pathname} renders a claim and no site menu`);
+      if (navAt === -1) continue;
+      withMenu.push(pathname);
+
+      const claimAt = html.indexOf('<p class="page-claim">');
+      if (claimAt === -1) { withoutClaim.push(pathname); continue; }
       assert.ok(
         claimAt < navAt,
         `${pathname} renders its claim after the site menu, so extraction still opens with navigation`,
@@ -197,11 +206,71 @@ describe("Page lede", () => {
       );
     }
 
-    for (const page of CLAIM_PAGES) {
-      assert.ok(
-        withClaim.includes(page.path),
-        `${page.path} no longer renders a claim`,
-      );
+    assert.ok(
+      withMenu.length >= PAGES_WITH_MENU_FLOOR,
+      `only ${withMenu.length} of ${paths.length} swept paths render the site menu`,
+    );
+    assert.deepStrictEqual(
+      withoutClaim,
+      [],
+      `${withoutClaim.length} of ${withMenu.length} pages render the site menu with no claim before it`,
+    );
+  });
+
+  it("every claim is the page's own meta description, so no page carries a second copy to keep in step", async () => {
+    const paths = [...await sitemapPaths("/sitemap-pages.xml"), ...await sitemapPaths("/sitemap-misc.xml")];
+    const disagreeing: string[] = [];
+    let checked = 0;
+
+    for (const pathname of paths) {
+      const response = await fetch(base + pathname);
+      if (response.status !== 200) continue;
+      const html = await response.text();
+      const claim = html.match(/<p class="page-claim">([\s\S]*?)<\/p>/)?.[1];
+      if (claim === undefined) continue;
+      checked++;
+      const metaDesc = html.match(/<meta name="description" content="([^"]*)"/i)?.[1] ?? "";
+      if (claim !== metaDesc) disagreeing.push(`${pathname}: claim "${claim}" against description "${metaDesc}"`);
     }
+
+    assert.ok(checked >= PAGES_WITH_MENU_FLOOR, `only ${checked} pages carry a claim`);
+    assert.deepStrictEqual(disagreeing, [], "a page states a claim that is not its meta description");
+  });
+});
+
+describe("Lede derivation", () => {
+  const NAV = '<div class="page-head"><nav class="global-nav"><a href="/">AgentDeals</a></nav></div>';
+  const page = (description: string) =>
+    `<!DOCTYPE html><html><head><meta name="description" content="${description}"></head><body>${NAV}<h1>Untouched</h1></body></html>`;
+
+  it("gives a page nobody edited the description it already publishes", () => {
+    const html = withLedeBeforeNav(page("What this page answers, in the words a reader asks it."));
+    assert.ok(
+      html.includes('<div class="page-head"><p class="page-claim">What this page answers, in the words a reader asks it.</p><nav'),
+      `derived no claim: ${html}`,
+    );
+    assert.ok(extractTextContent(html).startsWith("What this page answers"), "the claim does not open the extracted text");
+  });
+
+  it("reads the description the page serves rather than a second store", () => {
+    assert.strictEqual(metaDescriptionOf(page("A stated claim.")), "A stated claim.");
+    assert.strictEqual(metaDescriptionOf("<html><head></head><body></body></html>"), "");
+  });
+
+  it("adds one claim however many times it runs", () => {
+    const once = withLedeBeforeNav(page("A stated claim."));
+    assert.strictEqual(withLedeBeforeNav(once), once);
+    assert.strictEqual(once.split('<p class="page-claim">').length - 1, 1);
+  });
+
+  it("leaves a page with no description and a page with no menu alone", () => {
+    const noDescription = `<!DOCTYPE html><html><head></head><body>${NAV}</body></html>`;
+    assert.strictEqual(withLedeBeforeNav(noDescription), noDescription);
+
+    const blankDescription = page("   ");
+    assert.strictEqual(withLedeBeforeNav(blankDescription), blankDescription);
+
+    const noMenu = '<!DOCTYPE html><html><head><meta name="description" content="A stated claim."></head><body><h1>Standalone</h1></body></html>';
+    assert.strictEqual(withLedeBeforeNav(noMenu), noMenu);
   });
 });


### PR DESCRIPTION
Refs #1343 — acceptance criteria 5 and 6.

## What AC-3 left behind

AC-3 asked that the first 200 characters of extracted text state the page's own claim rather than the site menu, and said to do it in the template. It shipped as a hand-written claim on the two pages the issue names.

Measured over `sitemap-pages.xml` on `main`: **481 of 483 URLs render the site menu, and 2 of those 481 state a claim before it.** On the median page the first menu label lands at character 25, so the text a retriever weights opens `AgentDeals Search Browse Categories Best Of Alternatives Compare Guides…` before the page says anything about itself.

## The claim every page already publishes

Each page carries a `<meta name="description">` — one paragraph, written by whoever wrote the page, saying what it answers. All 481 have one; the shortest is 84 characters and the median 135. Nothing has to be authored for a new page to have a lede, which is AC-6.

`src/page-lede.ts` puts that description in front of the menu. It is applied at the one point every HTML body passes through — the response wrapper in `createHttpServer`, beside the two cross-cutting concerns already applied to every HTML response there (the `Signal` header and `Last-Modified`) rather than at 144 route handlers. `buildGlobalNav` now always emits the `.page-head` wrapper, which is the insertion point; its existing CSS keeps the menu visually first while the claim comes first in the DOM.

**Both hand-written claims are deleted.** `/monitoring-comparison-2026` and `/llm-api-pricing` take their meta descriptions, which carry every word AC-1's test looks for — `error tracking`, `monitoring`, `free tier`, `free credits` — and name four more vendors than the claims did. Two strings stating one page's claim is the two-store shape behind most of the divergences on the board, so the suite now asserts site-wide that no page states a claim that is not its own description.

## AC-5, over the 483 rather than a sample

| | main | this branch |
|---|---|---|
| `sitemap-pages.xml` URLs rendering the site menu | 481 of 483 | 481 of 483 |
| …stating their own claim before it | **2** | **481** |
| …whose extracted text opens with that claim | 2 | 481 |
| first menu label, median character | 25 | 171 |
| `sitemap-misc.xml` | 0 of 71 | 71 of 71 |
| whole site, all five sitemaps | 2 of 2,570 | **2,570 of 2,570** |

The two `sitemap-pages.xml` URLs outside the population render no site menu: `/feed.xml` is an Atom feed, and `/api/docs` is a Swagger UI shell that publishes no meta description at all and 18 characters of extracted text.

**The 200-character window is not cleared everywhere, and I am not claiming it is.** 168 of 481 pages carry no menu label in their first 200 characters, against 2 before. On the rest the claim opens the text and the menu follows inside the window, because the median description is 135 characters. Closing that gap needs either longer descriptions or the menu out of the top of the document, and neither is this change.

## AC-6 — a page nobody edits

`test/page-lede.test.ts` builds a page with a description, a menu and nothing else and asserts it comes back with the description as its lede. Three more cover the edges: applying the lede twice adds one claim, a page with no description is returned untouched, and a page with no menu is returned untouched.

## Verification

- 4,151 tests, 5 new, 0 failures. The two site-wide assertions and the four derivation tests fail on `main`.
- 11 mutants, 11 killed — `scripts/mutate-1343.mjs`. The first mutant makes `withLedeBeforeNav` return the page unchanged, which is `main`'s behaviour, and the suite goes red.
- Swept all five sitemaps against the running server: 2,570 of 2,570 pages that render the menu state their claim first, and every one of those claims is character-for-character the page's own meta description.
- `initialize` → `tools/call` over streamable-http on `/mcp` returns results, and the JSON API, the SVG badges, the sitemaps, `llms.txt` and `feed.xml` are byte-unchanged — the wrapper only touches `text/html`.
- Screenshots of `/category/databases`, `/budget-builder` and `/monitoring-comparison-2026`: the lede renders as a standfirst above the breadcrumb, in the treatment #1344 already shipped.

## Reported, not fixed

- **6 of 627 editorial pages now state their lede twice** — `/budget-builder`, `/this-week`, `/reports` and three `/best/` pages repeat the description verbatim below the fold. The fix is to differentiate the copy, not the mechanism.
- **`/api/docs` publishes no meta description** and renders 18 characters of extracted text. It is in `sitemap-pages.xml`. Same family as AC-7's `/compare-tool`.
- **AC-7 is only half-touched.** `/compare-tool` now opens with its own claim instead of the menu, but the comparison its client-side tool makes is still not in the server-rendered HTML. That is the separable half.
- `data/page-lastmod.json` will move for every page on the next `data(auto)` run, because every page's rendered body changed. That is a crawl signal, and the indexed titles this issue is waiting on are stale.
