### PR TITLE
Give every vendor lede one truncation rule that marks what it cut (#1421)

### DIFF
--- a/scripts/census-1421-lede-truncation.mjs
+++ b/scripts/census-1421-lede-truncation.mjs
@@ -1,0 +1,173 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+const args = process.argv.slice(2);
+const base = args[args.indexOf("--base") + 1] ?? "http://127.0.0.1:8791";
+const repo = path.resolve(args[args.indexOf("--repo") + 1] ?? ".");
+const limit = args.includes("--limit") ? Number(args[args.indexOf("--limit") + 1]) : Infinity;
+
+const { offers } = JSON.parse(readFileSync(path.join(repo, "data", "index.json"), "utf8"));
+
+const storedTerms = new Set(offers.map(o => o.description.trim()));
+
+async function get(url) {
+  for (let attempt = 0; attempt < 3; attempt++) {
+    try {
+      const res = await fetch(url, { redirect: "follow", headers: { "user-agent": "agentdeals-census" } });
+      if (!res.ok) return null;
+      return await res.text();
+    } catch {
+      await new Promise(r => setTimeout(r, 400));
+    }
+  }
+  return null;
+}
+
+function decodeEntities(text) {
+  return text
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&amp;/g, "&");
+}
+
+function metaDescription(html) {
+  const m = html.match(/<meta name="description" content="([^"]*)"/);
+  return m ? decodeEntities(m[1]) : null;
+}
+
+const WITHHELD = "terms are superseded and withheld";
+const INCLUDES = " free tier includes ";
+
+function termsClause(desc) {
+  const at = desc.indexOf(INCLUDES);
+  if (at === -1) return null;
+  const rest = desc.slice(at + INCLUDES.length);
+  const stop = rest.search(/\.(\s|$)/);
+  return stop === -1 ? rest : rest.slice(0, stop);
+}
+
+function matchesAStoredRecord(clause) {
+  for (const terms of storedTerms) if (terms.startsWith(clause)) return terms;
+  return null;
+}
+
+function cutInsideAWord(clause, full) {
+  if (!full || full.length <= clause.length) return false;
+  const next = full[clause.length];
+  const last = clause[clause.length - 1];
+  return /[A-Za-z0-9]/.test(next) && /[A-Za-z0-9]/.test(last);
+}
+
+function seversANumberFromItsUnit(clause, full) {
+  if (!full || full.length <= clause.length) return false;
+  if (/\d[\d,.]*\s*$/.test(clause)) return true;
+  const tail = clause.match(/(\d[\d,.]*)\s*([A-Za-z-]*)$/);
+  if (!tail) return false;
+  return cutInsideAWord(clause, full) && tail[2] !== "";
+}
+
+function opensABracketItDoesNotClose(text) {
+  let depth = 0;
+  for (const ch of text) {
+    if (ch === "(") depth++;
+    else if (ch === ")") depth--;
+  }
+  return depth !== 0;
+}
+
+const sitemap = await get(`${base}/sitemap-vendors.xml`);
+if (!sitemap) throw new Error("sitemap-vendors.xml unreachable");
+const urls = [...sitemap.matchAll(/<loc>([^<]+)<\/loc>/g)]
+  .map(m => m[1].replace(/^https?:\/\/[^/]+/, base))
+  .slice(0, limit);
+
+const report = {
+  base,
+  vendor_urls: urls.length,
+  unreachable: [],
+  no_description: [],
+  branch: { superseded: 0, has_free: 0, other: 0 },
+  has_free: {
+    pages: 0,
+    matched_to_a_record: 0,
+    clause_shorter_than_the_record: 0,
+    cut_at_exactly_100: 0,
+    cut_inside_a_word: 0,
+    severs_a_number_from_its_unit: 0,
+    unclosed_bracket: 0,
+    marked_as_clipped: 0,
+    unmarked_clip: 0,
+  },
+  superseded: { pages: 0, ending_mid_word: 0, unclosed_bracket: 0 },
+  double_period: 0,
+  samples: { cut_inside_a_word: [], unmarked_clip: [], double_period: [] },
+  by_url: {},
+};
+
+const CONCURRENCY = 8;
+let cursor = 0;
+async function worker() {
+  while (cursor < urls.length) {
+    const url = urls[cursor++];
+    const html = await get(url);
+    const route = url.slice(base.length);
+    if (html === null) {
+      report.unreachable.push(route);
+      continue;
+    }
+    const desc = metaDescription(html);
+    if (desc === null) {
+      report.no_description.push(route);
+      continue;
+    }
+    if (desc.includes("..")) {
+      report.double_period++;
+      if (report.samples.double_period.length < 6) report.samples.double_period.push({ route, desc });
+    }
+    if (desc.includes(WITHHELD)) {
+      report.branch.superseded++;
+      report.superseded.pages++;
+      report.by_url[route] = { branch: "superseded", desc };
+      continue;
+    }
+    const clause = termsClause(desc);
+    if (clause === null) {
+      report.branch.other++;
+      continue;
+    }
+    report.branch.has_free++;
+    report.has_free.pages++;
+    const bare = clause.replace(/…$/, "").trim();
+    const full = matchesAStoredRecord(bare);
+    if (full) report.has_free.matched_to_a_record++;
+    const clipped = Boolean(full) && full.length > bare.length;
+    if (clipped) report.has_free.clause_shorter_than_the_record++;
+    if (bare.length === 100) report.has_free.cut_at_exactly_100++;
+    if (cutInsideAWord(bare, full)) {
+      report.has_free.cut_inside_a_word++;
+      if (report.samples.cut_inside_a_word.length < 8) report.samples.cut_inside_a_word.push({ route, clause });
+    }
+    if (seversANumberFromItsUnit(bare, full)) report.has_free.severs_a_number_from_its_unit++;
+    if (opensABracketItDoesNotClose(clause)) report.has_free.unclosed_bracket++;
+    if (clipped && clause.endsWith("…")) report.has_free.marked_as_clipped++;
+    if (clipped && !clause.endsWith("…")) {
+      report.has_free.unmarked_clip++;
+      if (report.samples.unmarked_clip.length < 8) report.samples.unmarked_clip.push({ route, clause, full });
+    }
+    report.by_url[route] = { branch: "has_free", desc, clause };
+  }
+}
+await Promise.all(Array.from({ length: CONCURRENCY }, worker));
+
+for (const [route, row] of Object.entries(report.by_url)) {
+  if (row.branch !== "superseded") continue;
+  const sentence = row.desc.split(/(?<=[.…])\s/)[0] ?? "";
+  if (/[A-Za-z0-9]$/.test(sentence.replace(/[.…]$/, "")) && sentence.endsWith(".") && !sentence.endsWith("….")) continue;
+  if (opensABracketItDoesNotClose(sentence)) report.superseded.unclosed_bracket++;
+}
+
+report.unreachable = report.unreachable.slice(0, 20);
+delete report.by_url;
+console.log(JSON.stringify(report, null, 2));

--- a/scripts/census-1421-lede-truncation.mjs
+++ b/scripts/census-1421-lede-truncation.mjs
@@ -4,11 +4,20 @@ import path from "node:path";
 const args = process.argv.slice(2);
 const base = args[args.indexOf("--base") + 1] ?? "http://127.0.0.1:8791";
 const repo = path.resolve(args[args.indexOf("--repo") + 1] ?? ".");
-const limit = args.includes("--limit") ? Number(args[args.indexOf("--limit") + 1]) : Infinity;
 
 const { offers } = JSON.parse(readFileSync(path.join(repo, "data", "index.json"), "utf8"));
+const { toSlug } = await import(path.join(repo, "dist", "slug.js"));
 
-const storedTerms = new Set(offers.map(o => o.description.trim()));
+const recordsBySlug = new Map();
+for (const offer of offers) {
+  const slug = toSlug(offer.vendor);
+  if (!recordsBySlug.has(slug)) recordsBySlug.set(slug, []);
+  recordsBySlug.get(slug).push(offer.description.trim());
+}
+
+const CLIP_MARKER = "…";
+const WITHHELD = "terms are superseded and withheld";
+const INCLUDES = " free tier includes ";
 
 async function get(url) {
   for (let attempt = 0; attempt < 3; attempt++) {
@@ -37,51 +46,39 @@ function metaDescription(html) {
   return m ? decodeEntities(m[1]) : null;
 }
 
-const WITHHELD = "terms are superseded and withheld";
-const INCLUDES = " free tier includes ";
-
-function termsClause(desc) {
-  const at = desc.indexOf(INCLUDES);
-  if (at === -1) return null;
-  const rest = desc.slice(at + INCLUDES.length);
-  const stop = rest.search(/\.(\s|$)/);
-  return stop === -1 ? rest : rest.slice(0, stop);
+function sharedPrefixLength(published, stored) {
+  let i = 0;
+  while (i < published.length && i < stored.length && published[i] === stored[i]) i++;
+  return i;
 }
 
-function matchesAStoredRecord(clause) {
-  for (const terms of storedTerms) if (terms.startsWith(clause)) return terms;
-  return null;
-}
-
-function cutInsideAWord(clause, full) {
-  if (!full || full.length <= clause.length) return false;
-  const next = full[clause.length];
-  const last = clause[clause.length - 1];
-  return /[A-Za-z0-9]/.test(next) && /[A-Za-z0-9]/.test(last);
-}
-
-function seversANumberFromItsUnit(clause, full) {
-  if (!full || full.length <= clause.length) return false;
-  if (/\d[\d,.]*\s*$/.test(clause)) return true;
-  const tail = clause.match(/(\d[\d,.]*)\s*([A-Za-z-]*)$/);
-  if (!tail) return false;
-  return cutInsideAWord(clause, full) && tail[2] !== "";
-}
-
-function opensABracketItDoesNotClose(text) {
-  let depth = 0;
-  for (const ch of text) {
-    if (ch === "(") depth++;
-    else if (ch === ")") depth--;
+function quotationAgainst(published, candidates) {
+  let best = null;
+  for (const stored of candidates) {
+    const shared = sharedPrefixLength(published, stored);
+    const quotation = {
+      stored,
+      opening: published.slice(0, shared),
+      marked: published.slice(shared).startsWith(CLIP_MARKER),
+      continues: stored.slice(shared),
+    };
+    if (best === null || quotation.opening.length > best.opening.length) best = quotation;
   }
-  return depth !== 0;
+  return best;
+}
+
+function unclosedBrackets(text) {
+  let open = 0;
+  for (const character of text) {
+    if (character === "(") open++;
+    else if (character === ")" && open > 0) open--;
+  }
+  return open;
 }
 
 const sitemap = await get(`${base}/sitemap-vendors.xml`);
 if (!sitemap) throw new Error("sitemap-vendors.xml unreachable");
-const urls = [...sitemap.matchAll(/<loc>([^<]+)<\/loc>/g)]
-  .map(m => m[1].replace(/^https?:\/\/[^/]+/, base))
-  .slice(0, limit);
+const urls = [...sitemap.matchAll(/<loc>([^<]+)<\/loc>/g)].map(m => m[1].replace(/^https?:\/\/[^/]+/, base));
 
 const report = {
   base,
@@ -89,85 +86,73 @@ const report = {
   unreachable: [],
   no_description: [],
   branch: { superseded: 0, has_free: 0, other: 0 },
-  has_free: {
+  free_tier_branch: {
     pages: 0,
-    matched_to_a_record: 0,
-    clause_shorter_than_the_record: 0,
-    cut_at_exactly_100: 0,
+    resolved_to_a_record: 0,
+    shorter_than_the_record: 0,
+    marked_as_clipped: 0,
+    clipped_without_saying_so: 0,
     cut_inside_a_word: 0,
     severs_a_number_from_its_unit: 0,
-    unclosed_bracket: 0,
-    marked_as_clipped: 0,
-    unmarked_clip: 0,
   },
-  superseded: { pages: 0, ending_mid_word: 0, unclosed_bracket: 0 },
-  double_period: 0,
-  samples: { cut_inside_a_word: [], unmarked_clip: [], double_period: [] },
-  by_url: {},
+  ledes_with_an_unclosed_bracket: 0,
+  ledes_containing_a_repeated_full_stop: 0,
+  lede_length: { median: 0, max: 0 },
+  samples: { cut_inside_a_word: [], clipped_without_saying_so: [] },
 };
 
+const lengths = [];
 const CONCURRENCY = 8;
 let cursor = 0;
 async function worker() {
   while (cursor < urls.length) {
     const url = urls[cursor++];
-    const html = await get(url);
     const route = url.slice(base.length);
-    if (html === null) {
-      report.unreachable.push(route);
-      continue;
-    }
+    const html = await get(url);
+    if (html === null) { report.unreachable.push(route); continue; }
     const desc = metaDescription(html);
-    if (desc === null) {
-      report.no_description.push(route);
-      continue;
-    }
-    if (desc.includes("..")) {
-      report.double_period++;
-      if (report.samples.double_period.length < 6) report.samples.double_period.push({ route, desc });
-    }
-    if (desc.includes(WITHHELD)) {
-      report.branch.superseded++;
-      report.superseded.pages++;
-      report.by_url[route] = { branch: "superseded", desc };
-      continue;
-    }
-    const clause = termsClause(desc);
-    if (clause === null) {
-      report.branch.other++;
-      continue;
-    }
+    if (desc === null) { report.no_description.push(route); continue; }
+
+    lengths.push(desc.length);
+    if (unclosedBrackets(desc) > 0) report.ledes_with_an_unclosed_bracket++;
+    if (desc.includes("..")) report.ledes_containing_a_repeated_full_stop++;
+
+    if (desc.includes(WITHHELD)) { report.branch.superseded++; continue; }
+    const includesAt = desc.indexOf(INCLUDES);
+    if (includesAt === -1) { report.branch.other++; continue; }
     report.branch.has_free++;
-    report.has_free.pages++;
-    const bare = clause.replace(/…$/, "").trim();
-    const full = matchesAStoredRecord(bare);
-    if (full) report.has_free.matched_to_a_record++;
-    const clipped = Boolean(full) && full.length > bare.length;
-    if (clipped) report.has_free.clause_shorter_than_the_record++;
-    if (bare.length === 100) report.has_free.cut_at_exactly_100++;
-    if (cutInsideAWord(bare, full)) {
-      report.has_free.cut_inside_a_word++;
-      if (report.samples.cut_inside_a_word.length < 8) report.samples.cut_inside_a_word.push({ route, clause });
+    report.free_tier_branch.pages++;
+
+    const slug = route.replace("/vendor/", "");
+    const records = recordsBySlug.get(slug);
+    if (!records) continue;
+    report.free_tier_branch.resolved_to_a_record++;
+
+    const quotation = quotationAgainst(desc.slice(includesAt + INCLUDES.length), records);
+    if (quotation.continues === "") continue;
+    report.free_tier_branch.shorter_than_the_record++;
+    if (quotation.marked) report.free_tier_branch.marked_as_clipped++;
+    else {
+      report.free_tier_branch.clipped_without_saying_so++;
+      if (report.samples.clipped_without_saying_so.length < 6) {
+        report.samples.clipped_without_saying_so.push({ route, opening: quotation.opening.slice(-60) });
+      }
     }
-    if (seversANumberFromItsUnit(bare, full)) report.has_free.severs_a_number_from_its_unit++;
-    if (opensABracketItDoesNotClose(clause)) report.has_free.unclosed_bracket++;
-    if (clipped && clause.endsWith("…")) report.has_free.marked_as_clipped++;
-    if (clipped && !clause.endsWith("…")) {
-      report.has_free.unmarked_clip++;
-      if (report.samples.unmarked_clip.length < 8) report.samples.unmarked_clip.push({ route, clause, full });
+    if (/[A-Za-z0-9]$/.test(quotation.opening) && /^[A-Za-z0-9]/.test(quotation.continues)) {
+      report.free_tier_branch.cut_inside_a_word++;
+      if (report.samples.cut_inside_a_word.length < 6) {
+        report.samples.cut_inside_a_word.push({ route, opening: quotation.opening.slice(-50), continues: quotation.continues.slice(0, 20) });
+      }
     }
-    report.by_url[route] = { branch: "has_free", desc, clause };
+    if (/\d$/.test(quotation.opening) && /^\s*[A-Za-z]/.test(quotation.continues)) {
+      report.free_tier_branch.severs_a_number_from_its_unit++;
+    }
   }
 }
 await Promise.all(Array.from({ length: CONCURRENCY }, worker));
 
-for (const [route, row] of Object.entries(report.by_url)) {
-  if (row.branch !== "superseded") continue;
-  const sentence = row.desc.split(/(?<=[.…])\s/)[0] ?? "";
-  if (/[A-Za-z0-9]$/.test(sentence.replace(/[.…]$/, "")) && sentence.endsWith(".") && !sentence.endsWith("….")) continue;
-  if (opensABracketItDoesNotClose(sentence)) report.superseded.unclosed_bracket++;
-}
-
+lengths.sort((a, b) => a - b);
+report.lede_length.median = lengths[Math.floor(lengths.length / 2)] ?? 0;
+report.lede_length.max = lengths[lengths.length - 1] ?? 0;
 report.unreachable = report.unreachable.slice(0, 20);
-delete report.by_url;
 console.log(JSON.stringify(report, null, 2));

--- a/scripts/mutate-1421.sh
+++ b/scripts/mutate-1421.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+set -uo pipefail
+
+REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO"
+
+TESTS=(
+  test/vendor-lede-truncation.test.ts
+  test/superseded-terms.test.ts
+  test/stack-page-verdicts.test.ts
+)
+
+SOURCES=(src/serve.ts src/terms-opening.ts src/stack-claim.ts src/superseded-description.ts)
+
+backup() { for f in "${SOURCES[@]}"; do cp "$f" "/tmp/$(basename "$f").m1421"; done; }
+restore() { for f in "${SOURCES[@]}"; do cp "/tmp/$(basename "$f").m1421" "$f"; done; }
+
+backup
+trap 'restore; npm run build >/dev/null 2>&1' EXIT
+
+killed=0
+survived=0
+
+run_mutation() {
+  local name="$1"; shift
+  restore
+  if ! "$@"; then
+    echo "NOT APPLIED                $name"
+    return
+  fi
+  if ! npm run build >/dev/null 2>&1; then
+    echo "KILLED (does not compile)  $name"
+    killed=$((killed + 1))
+    return
+  fi
+  if TZ=UTC node --test --test-concurrency 1 "${TESTS[@]}" >/tmp/mutation-1421-out.txt 2>&1; then
+    echo "SURVIVED                   $name"
+    survived=$((survived + 1))
+  else
+    echo "KILLED                     $name"
+    killed=$((killed + 1))
+  fi
+}
+
+sub() {
+  python3 - "$1" "$2" "$3" <<'PY'
+import sys
+path, old, new = sys.argv[1], sys.argv[2], sys.argv[3]
+text = open(path, encoding="utf-8").read()
+if old not in text:
+    sys.exit("mutation target not found in " + path)
+open(path, "w", encoding="utf-8").write(text.replace(old, new, 1))
+PY
+}
+
+run_mutation "the free-tier lede goes back to a raw slice" \
+  sub src/serve.ts '  const descLimits = punctuatedOpeningOfTerms(publishableTerms, 100);' \
+                   '  const descLimits = publishableTerms.slice(0, 100).replace(/\.\s.*$/, "") + ".";'
+
+run_mutation "the verdict goes back to a raw slice" \
+  sub src/serve.ts '  const keyLimit = openingOfTerms(publishableTerms, 120);' \
+                   '  const keyLimit = publishableTerms.slice(0, 120).replace(/\.\s.*$/, "");'
+
+run_mutation "a clip at a sentence boundary is published unmarked" \
+  sub src/terms-opening.ts '  const opening = sentences !== ""
+    ? withoutTrailingSeparators(sentences.replace(/[.!?]+$/, ""))
+    : withoutASeveredNumber(withoutTrailingSeparators(wordBoundary));
+  return markedAsClipped(opening === "" ? wordBoundary : opening);' \
+                           '  if (sentences !== "") return sentences;
+  const opening = withoutASeveredNumber(withoutTrailingSeparators(wordBoundary));
+  return markedAsClipped(opening === "" ? wordBoundary : opening);'
+
+run_mutation "no clip is marked at all" \
+  sub src/terms-opening.ts 'function markedAsClipped(text: string): string {
+  return `${text}${CLIPPED_TERMS_MARKER}${")".repeat(unclosedBrackets(text))}`;
+}' \
+                           'function markedAsClipped(text: string): string {
+  return `${text}${")".repeat(unclosedBrackets(text))}`;
+}'
+
+run_mutation "a clip may leave its bracket open" \
+  sub src/terms-opening.ts '  return `${text}${CLIPPED_TERMS_MARKER}${")".repeat(unclosedBrackets(text))}`;' \
+                           '  return `${text}${CLIPPED_TERMS_MARKER}`;'
+
+run_mutation "a clip may end on a figure whose unit follows" \
+  sub src/terms-opening.ts '    : withoutASeveredNumber(withoutTrailingSeparators(wordBoundary));' \
+                           '    : withoutTrailingSeparators(wordBoundary);'
+
+run_mutation "the clip cuts at the cap rather than a word boundary" \
+  sub src/terms-opening.ts '  const lastSpace = clipped.lastIndexOf(" ");
+  return lastSpace > cap / 2 ? clipped.slice(0, lastSpace) : clipped;' \
+                           '  return clipped;'
+
+run_mutation "the opening keeps a trailing comma before the marker" \
+  sub src/terms-opening.ts 'function withoutTrailingSeparators(text: string): string {
+  return text.replace(/[\s,;:—–-]+$/, "");
+}' \
+                           'function withoutTrailingSeparators(text: string): string {
+  return text;
+}'
+
+run_mutation "a second full stop is added to terms that end with one" \
+  sub src/terms-opening.ts '  return /[.!?…]$/.test(trimmed) ? trimmed : `${trimmed}.`;' \
+                           '  return `${trimmed}.`;'
+
+run_mutation "an unmatched closing bracket counts as an open one" \
+  sub src/terms-opening.ts '    else if (character === ")" && open > 0) open--;' \
+                           '    else if (character === ")") open--;'
+
+run_mutation "the sentence branch takes one sentence too many" \
+  sub src/terms-opening.ts '    if (candidate.length > cap) break;
+    longest = candidate;' \
+                           '    longest = candidate;
+    if (candidate.length > cap) break;'
+
+run_mutation "the terms are never returned whole" \
+  sub src/terms-opening.ts '  if (text.length <= cap) return text;' \
+                           '  if (text.length < cap / 2) return text;'
+
+run_mutation "the withheld reading stops publishing what it clipped" \
+  sub src/superseded-description.ts '  const opening = punctuatedOpeningOfTerms(reading.terms, 90);' \
+                                    '  const opening = punctuated(openingOfTerms(reading.terms, 90).replace(/…\)*$/, ""));'
+
+echo
+echo "killed:   $killed"
+echo "survived: $survived"

--- a/src/serve.ts
+++ b/src/serve.ts
@@ -4752,7 +4752,7 @@ ${allCompareLinks.join("\n")}
     ? `${withheldLevelSentence(levelWithheld, vendorName, unconfirmableSince)} We cannot confirm what this offer provides today, so we are not recommending it for production or for anything else until we can.`
     : hasFree
     ? (riskLevel === "stable"
-      ? `${vendorName}'s free tier can be suitable for small production workloads and side projects. ${primaryGate ? "It" : "We rate it stable and it"} is a reasonable starting point, offering ${escHtmlServer(punctuated(keyLimit))}${vendorChanges.length > 0 ? ` ${narrowingSentence(vendorChanges)}` : ""} Monitor your usage against the limits and have an upgrade plan ready.`
+      ? `${vendorName}'s free tier can be suitable for small production workloads and side projects. ${primaryGate ? "It" : "We rate it stable and it"} offers ${escHtmlServer(keyLimit)}, so it's a reasonable starting point.${vendorChanges.length > 0 ? ` ${narrowingSentence(vendorChanges)}` : ""} Monitor your usage against the limits and have an upgrade plan ready.`
       : primaryGate
       ? `${vendorName}'s free tier is usable for prototyping and development. ${vendorHistorySentence(vendorName, riskLevel, riskCause)}`
       : `${vendorName}'s free tier is usable for prototyping and development, but we rate it ${riskLevel}${riskCause ? ` because of one recorded ${changeKindNoun(riskCause.change_type)}, ${changeDateClause(riskCause)}` : ""}. Consider alternatives with more stable pricing for critical services.`)

--- a/src/serve.ts
+++ b/src/serve.ts
@@ -21,7 +21,8 @@ import { LINK_GRACE_DAYS, unreachableNoticeForUrl } from "./link-health.js";
 import { offerEnded, offerRetired, recordedTierSentence, endedHeadline, endedHistorySentence, endedReliabilitySentence, endedEmptyChangeHistorySentence, ENDED_BADGE_LABEL, ENDED_SINCE_CHANGES_SENTENCE, type OfferTierAndUrl } from "./retirement.js";
 import { amountUnstatedSentence, levelWithheldReason, withheldLevelClause, withheldLevelSentence, type LevelWithheldReason } from "./source-check.js";
 import { readingIsBehindTheLoop, reverificationIntervalDays } from "./badge-staleness.js";
-import { SUPERSEDED_TERMS_LABEL, openingOfTerms, readingBehindTheChange, supersededTermsAnswer, supersededTermsMetaSentence, supersededTermsNotice, supersededTermsNoticeHtml, supersededTermsRecord, supersededTermsVerdictSentence, supersedingChange, type SupersededTermsRecord } from "./superseded-description.js";
+import { SUPERSEDED_TERMS_LABEL, readingBehindTheChange, supersededTermsAnswer, supersededTermsMetaSentence, supersededTermsNotice, supersededTermsNoticeHtml, supersededTermsRecord, supersededTermsVerdictSentence, supersedingChange, type SupersededTermsRecord } from "./superseded-description.js";
+import { openingOfTerms, punctuated, punctuatedOpeningOfTerms } from "./terms-opening.js";
 import { NO_CURRENT_FIGURE, costHeadlineCaveat, limitCellText, mayRecommendAsFree, proseWithoutNames, readsActive, stackFreshnessStatement } from "./stack-claim.js";
 import { changesByVendor } from "./superseded-census.js";
 import { buildComparisonMap, comparisonSlug } from "./comparison-pairs.js";
@@ -4376,7 +4377,7 @@ function buildVendorPage(slug: string): string | null {
   const title = hasFree
     ? `${freeTierHeadline}: Limits, Pricing & What Changed | AgentDeals`
     : `${pricingHeadline}: Plans, Costs & Free Alternatives | AgentDeals`;
-  const descLimits = publishableTerms.slice(0, 100).replace(/\.\s.*$/, "");
+  const descLimits = punctuatedOpeningOfTerms(publishableTerms, 100);
   const verifiedMonth = (() => { const d = primary.verifiedDate.split("-"); const months = ["January","February","March","April","May","June","July","August","September","October","November","December"]; return `${months[parseInt(d[1],10)-1]} ${d[0]}`; })();
   const verifiedSentence = discontinuedOn
     ? ` Discontinued ${discontinuedOn}.`
@@ -4388,10 +4389,10 @@ function buildVendorPage(slug: string): string | null {
   const metaDesc = eligibilityGateSentence + (termsSuperseded
     ? `${supersededTermsMetaSentence(vendorName, termsSuperseded)} See the recorded change history${alternatives.length > 0 ? ` and ${alternatives.length} alternatives in ${primary.category}` : ""}.`
     : hasFree
-    ? `${vendorName} free tier includes ${descLimits}.${metaVerifiedSentence}${alternatives.length > 0 ? ` Compare with ${alternatives.length} alternatives in ${primary.category}.` : ""}`
+    ? `${vendorName} free tier includes ${descLimits}${metaVerifiedSentence}${alternatives.length > 0 ? ` Compare with ${alternatives.length} alternatives in ${primary.category}.` : ""}`
     : `${vendorName} pricing details${alternatives.length > 0 ? ` and ${alternatives.length} free alternatives in ${primary.category}` : ""}.${metaVerifiedSentence}`);
 
-  const keyLimit = publishableTerms.slice(0, 120).replace(/\.\s.*$/, "");
+  const keyLimit = openingOfTerms(publishableTerms, 120);
   const verdictLine2 = vendorVerdictSentence(verdictInput);
   const verdictLine3 = discontinuedOn
     ? `${vendorName} was discontinued on ${discontinuedOn}, so it is not a current option${alternatives.length > 0 ? ` — the ${alternatives.length} alternatives below are replacements` : ""}.`
@@ -4403,8 +4404,8 @@ function buildVendorPage(slug: string): string | null {
     ? escHtmlServer(supersededTermsVerdictSentence(vendorName, termsSuperseded))
     : "";
   const verdictOpening = verdictSubject
-    ? `${escHtmlServer(verdictSubject)} ${verdictTerms || `${escHtmlServer(keyLimit)}.`}`
-    : verdictTerms || `${escHtmlServer(vendorName)}'s free tier offers ${escHtmlServer(keyLimit)}.`;
+    ? `${escHtmlServer(verdictSubject)} ${verdictTerms || escHtmlServer(punctuated(keyLimit))}`
+    : verdictTerms || `${escHtmlServer(vendorName)}'s free tier offers ${escHtmlServer(punctuated(keyLimit))}`;
   const quickVerdictHtml = `
   <div class="quick-verdict">
     <p>${verdictOpening} ${verdictLine2}${verdictLine3 ? " " + verdictLine3 : ""}</p>
@@ -4751,7 +4752,7 @@ ${allCompareLinks.join("\n")}
     ? `${withheldLevelSentence(levelWithheld, vendorName, unconfirmableSince)} We cannot confirm what this offer provides today, so we are not recommending it for production or for anything else until we can.`
     : hasFree
     ? (riskLevel === "stable"
-      ? `${vendorName}'s free tier can be suitable for small production workloads and side projects. ${primaryGate ? "It" : "We rate it stable and it"} offers ${escHtmlServer(keyLimit)}, so it's a reasonable starting point.${vendorChanges.length > 0 ? ` ${narrowingSentence(vendorChanges)}` : ""} Monitor your usage against the limits and have an upgrade plan ready.`
+      ? `${vendorName}'s free tier can be suitable for small production workloads and side projects. ${primaryGate ? "It" : "We rate it stable and it"} is a reasonable starting point, offering ${escHtmlServer(punctuated(keyLimit))}${vendorChanges.length > 0 ? ` ${narrowingSentence(vendorChanges)}` : ""} Monitor your usage against the limits and have an upgrade plan ready.`
       : primaryGate
       ? `${vendorName}'s free tier is usable for prototyping and development. ${vendorHistorySentence(vendorName, riskLevel, riskCause)}`
       : `${vendorName}'s free tier is usable for prototyping and development, but we rate it ${riskLevel}${riskCause ? ` because of one recorded ${changeKindNoun(riskCause.change_type)}, ${changeDateClause(riskCause)}` : ""}. Consider alternatives with more stable pricing for critical services.`)

--- a/src/superseded-description.ts
+++ b/src/superseded-description.ts
@@ -2,6 +2,7 @@ import { changeCitesASource, citationLabel } from "./change-citation.js";
 import { changeDateClause } from "./change-dates.js";
 import { narrowsTheStoredTerms } from "./change-direction.js";
 import { isNoLongerInForce } from "./change-resolution.js";
+import { openingOfTerms, punctuated, punctuatedOpeningOfTerms } from "./terms-opening.js";
 import { carriesAnUnrenderedExpression } from "./unrendered-text.js";
 import type { ChangeResolution, DealChange } from "./types.js";
 
@@ -73,27 +74,6 @@ export function readingBehindTheChange(change: QuotingChange): SourcedReading | 
   };
 }
 
-export function openingOfTerms(terms: string, cap: number): string {
-  const text = terms.trim();
-  if (text.length <= cap) return text;
-  let wholeSentences = "";
-  for (const match of text.matchAll(/[.!?](\s|$)/g)) {
-    const candidate = text.slice(0, match.index + 1);
-    if (candidate.length > cap) break;
-    wholeSentences = candidate;
-  }
-  if (wholeSentences !== "") return wholeSentences;
-  const clipped = text.slice(0, cap);
-  const lastSpace = clipped.lastIndexOf(" ");
-  const kept = lastSpace > cap / 2 ? clipped.slice(0, lastSpace) : clipped;
-  return `${kept.replace(/[,;:]$/, "")}…`;
-}
-
-function punctuated(text: string): string {
-  const trimmed = text.trim();
-  return /[.!?…]$/.test(trimmed) ? trimmed : `${trimmed}.`;
-}
-
 function readingSentence(date: string, source: string, terms: string): string {
   return `As of ${date}, ${source} reads: ${terms}`;
 }
@@ -154,7 +134,7 @@ export function supersededTermsMetaSentence(vendor: string, change: QuotingChang
   if (!reading) {
     return `${withheld}: our own pricing change record, ${changeDateClause(change)}, ${STORED_TERMS_WITHHELD_PHRASE}.`;
   }
-  const opening = punctuated(openingOfTerms(reading.terms, 90));
+  const opening = punctuatedOpeningOfTerms(reading.terms, 90);
   return `${readingSentence(reading.date, reading.label, opening)} ${withheld}.`;
 }
 

--- a/src/terms-opening.ts
+++ b/src/terms-opening.ts
@@ -1,0 +1,69 @@
+export const CLIPPED_TERMS_MARKER = "…";
+
+function withoutTrailingSeparators(text: string): string {
+  return text.replace(/[\s,;:—–-]+$/, "");
+}
+
+export function unclosedBrackets(text: string): number {
+  let open = 0;
+  for (const character of text) {
+    if (character === "(") open++;
+    else if (character === ")" && open > 0) open--;
+  }
+  return open;
+}
+
+function markedAsClipped(text: string): string {
+  return `${text}${CLIPPED_TERMS_MARKER}${")".repeat(unclosedBrackets(text))}`;
+}
+
+function withoutASeveredNumber(text: string): string {
+  let kept = text;
+  while (/\d$/.test(kept)) {
+    const lastSpace = kept.lastIndexOf(" ");
+    if (lastSpace <= 0) break;
+    kept = withoutTrailingSeparators(kept.slice(0, lastSpace));
+  }
+  return kept;
+}
+
+function wholeSentencesWithin(text: string, cap: number): string {
+  let longest = "";
+  for (const match of text.matchAll(/[.!?](\s|$)/g)) {
+    const candidate = text.slice(0, match.index + 1);
+    if (candidate.length > cap) break;
+    longest = candidate;
+  }
+  return longest;
+}
+
+function upToAWordBoundary(text: string, cap: number): string {
+  const clipped = text.slice(0, cap);
+  const lastSpace = clipped.lastIndexOf(" ");
+  return lastSpace > cap / 2 ? clipped.slice(0, lastSpace) : clipped;
+}
+
+export function openingOfTerms(terms: string, cap: number): string {
+  const text = terms.trim();
+  if (text.length <= cap) return text;
+  const sentences = wholeSentencesWithin(text, cap);
+  const wordBoundary = upToAWordBoundary(text, cap);
+  const opening = sentences !== ""
+    ? withoutTrailingSeparators(sentences.replace(/[.!?]+$/, ""))
+    : withoutASeveredNumber(withoutTrailingSeparators(wordBoundary));
+  return markedAsClipped(opening === "" ? wordBoundary : opening);
+}
+
+export function punctuated(text: string): string {
+  const trimmed = text.trim();
+  if (trimmed === "") return "";
+  return /[.!?…]$/.test(trimmed) ? trimmed : `${trimmed}.`;
+}
+
+export function punctuatedOpeningOfTerms(terms: string, cap: number): string {
+  return punctuated(openingOfTerms(terms, cap));
+}
+
+export function termsWereClipped(opening: string): boolean {
+  return opening.replace(/\)+$/, "").endsWith(CLIPPED_TERMS_MARKER);
+}

--- a/test/stack-page-verdicts.test.ts
+++ b/test/stack-page-verdicts.test.ts
@@ -389,7 +389,8 @@ describe("the limit cell", () => {
     const railway = "Free $0 per month. Start with a 30-day free trial with $5 credits, then $1 per month.";
     const cell = limitCellText(railway, 60);
     assert.ok(cell.endsWith("…"), `truncated cell reads as a finished claim: ${cell}`);
-    assert.ok(!/^Free \$0 per month\.$/.test(cell));
+    assert.ok(!/^Free \$0 per month[.…]$/.test(cell), `the cell stopped at the first full stop: ${cell}`);
+    assert.ok(cell.includes("30-day free trial"), `the cell left the width it was given unused: ${cell}`);
   });
 
   it("passes terms through whole when they fit", () => {

--- a/test/superseded-terms.test.ts
+++ b/test/superseded-terms.test.ts
@@ -9,7 +9,6 @@ import { fileURLToPath } from "node:url";
 const {
   STORED_TERMS_WITHHELD_META_PHRASE,
   STORED_TERMS_WITHHELD_PHRASE,
-  openingOfTerms,
   quotesTheStoredTermsAsPrevious,
   readingBehindTheChange,
   supersededTermsAnswer,
@@ -20,6 +19,7 @@ const {
   supersedingChange,
   storedTermsAreSuperseded,
 } = await import("../dist/superseded-description.js");
+const { openingOfTerms } = await import("../dist/terms-opening.js");
 const { citationLabel } = await import("../dist/change-citation.js");
 const { carriesAnUnrenderedExpression, unrenderedExpressionIn } = await import("../dist/unrendered-text.js");
 const { toSlug } = await import("../dist/slug.js");
@@ -434,11 +434,11 @@ describe("#1386 the reading the superseding record already holds", () => {
     assert.strictEqual(citationLabel("not a url"), "not a url");
   });
 
-  it("takes whole sentences up to the cap rather than cutting mid-figure", () => {
+  it("takes whole sentences up to the cap rather than cutting mid-figure, and marks that it stopped early", () => {
     const terms = "Free plan: 20 GiB egress. Paid plans start at $19/month. Enterprise is quoted.";
     assert.strictEqual(openingOfTerms(terms, 200), terms);
-    assert.strictEqual(openingOfTerms(terms, 60), "Free plan: 20 GiB egress. Paid plans start at $19/month.");
-    assert.strictEqual(openingOfTerms(terms, 30), "Free plan: 20 GiB egress.");
+    assert.strictEqual(openingOfTerms(terms, 60), "Free plan: 20 GiB egress. Paid plans start at $19/month…");
+    assert.strictEqual(openingOfTerms(terms, 30), "Free plan: 20 GiB egress…");
   });
 
   it("clips a single long sentence on a word boundary and marks it as clipped", () => {

--- a/test/vendor-lede-truncation.test.ts
+++ b/test/vendor-lede-truncation.test.ts
@@ -1,0 +1,342 @@
+import { describe, it, before, after } from "node:test";
+import assert from "node:assert";
+import { spawn, type ChildProcess } from "node:child_process";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO = path.join(__dirname, "..");
+
+const { openingOfTerms, punctuatedOpeningOfTerms, termsWereClipped, unclosedBrackets } =
+  await import("../dist/terms-opening.js");
+const { readingBehindTheChange, supersedingChange } = await import("../dist/superseded-description.js");
+const { toSlug } = await import("../dist/slug.js");
+
+interface Offer { vendor: string; description: string }
+
+const { offers } = JSON.parse(readFileSync(path.join(REPO, "data", "index.json"), "utf8")) as { offers: Offer[] };
+const { changes: dealChanges } = JSON.parse(readFileSync(path.join(REPO, "data", "deal_changes.json"), "utf8")) as
+  { changes: { vendor: string }[] };
+
+const changesByVendorName = new Map<string, { vendor: string }[]>();
+for (const change of dealChanges) {
+  const key = (change.vendor ?? "").toLowerCase();
+  if (!changesByVendorName.has(key)) changesByVendorName.set(key, []);
+  changesByVendorName.get(key)!.push(change);
+}
+
+const recordsBySlug = new Map<string, Offer[]>();
+for (const offer of offers) {
+  const slug = toSlug(offer.vendor);
+  if (!recordsBySlug.has(slug)) recordsBySlug.set(slug, []);
+  recordsBySlug.get(slug)!.push(offer);
+}
+
+const readingsBySlug = new Map<string, string[]>();
+for (const offer of offers) {
+  const superseding = supersedingChange(offer, changesByVendorName.get(offer.vendor.toLowerCase()) ?? []);
+  if (!superseding) continue;
+  const reading = readingBehindTheChange(superseding);
+  if (!reading) continue;
+  const slug = toSlug(offer.vendor);
+  if (!readingsBySlug.has(slug)) readingsBySlug.set(slug, []);
+  readingsBySlug.get(slug)!.push(reading.terms.trim());
+}
+
+let server: ChildProcess;
+let base = "";
+
+function startServer(): Promise<ChildProcess> {
+  return new Promise((resolve, reject) => {
+    const proc = spawn("node", [path.join(REPO, "dist", "serve.js")], {
+      stdio: ["pipe", "pipe", "pipe"],
+      env: { ...process.env, PORT: "0", BASE_URL: "http://localhost" },
+    });
+    const timeout = setTimeout(() => {
+      proc.kill();
+      reject(new Error("Server startup timeout"));
+    }, 30000);
+    proc.stderr!.on("data", (data: Buffer) => {
+      const match = data.toString().match(/running on http:\/\/localhost:(\d+)/);
+      if (match) {
+        base = `http://localhost:${match[1]}`;
+        clearTimeout(timeout);
+        resolve(proc);
+      }
+    });
+    proc.on("error", (err) => {
+      clearTimeout(timeout);
+      reject(err);
+    });
+  });
+}
+
+const SWEPT_PAGES_VACUITY_GUARD = 200;
+const WITHHOLDING_PHRASE = "terms are superseded and withheld";
+const INCLUDES_PHRASE = " free tier includes ";
+const READING_PHRASE = " reads: ";
+const CLIP_MARKER = "…";
+
+function decodeEntities(text: string): string {
+  return text
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&amp;/g, "&");
+}
+
+function metaDescriptionOf(html: string): string | null {
+  const match = html.match(/<meta name="description" content="([^"]*)"/);
+  return match ? decodeEntities(match[1]) : null;
+}
+
+function sharedPrefixLength(published: string, stored: string): number {
+  let i = 0;
+  while (i < published.length && i < stored.length && published[i] === stored[i]) i++;
+  return i;
+}
+
+interface Quotation {
+  route: string;
+  stored: string;
+  opening: string;
+  marked: boolean;
+  continues: string;
+}
+
+function quotationAgainst(route: string, published: string, candidates: readonly string[]): Quotation | null {
+  let best: Quotation | null = null;
+  for (const stored of candidates) {
+    const shared = sharedPrefixLength(published, stored);
+    const opening = published.slice(0, shared);
+    const quotation: Quotation = {
+      route,
+      stored,
+      opening,
+      marked: published.slice(shared).startsWith(CLIP_MARKER),
+      continues: stored.slice(shared),
+    };
+    if (best === null || quotation.opening.length > best.opening.length) best = quotation;
+  }
+  return best;
+}
+
+interface Swept {
+  route: string;
+  slug: string;
+  description: string;
+  branch: "superseded" | "has_free" | "other";
+  quoted: string | null;
+}
+
+const swept: Swept[] = [];
+const unreachable: string[] = [];
+
+async function sweepVendorPages(): Promise<void> {
+  const xml = await (await fetch(`${base}/sitemap-vendors.xml`)).text();
+  const routes = [...xml.matchAll(/<loc>([^<]+)<\/loc>/g)].map(m => new URL(m[1]).pathname);
+  let cursor = 0;
+  const worker = async (): Promise<void> => {
+    while (cursor < routes.length) {
+      const route = routes[cursor++];
+      const response = await fetch(base + route);
+      if (response.status !== 200) { unreachable.push(route); continue; }
+      const description = metaDescriptionOf(await response.text());
+      if (description === null) { unreachable.push(route); continue; }
+      const withheld = description.includes(WITHHOLDING_PHRASE);
+      const includesAt = description.indexOf(INCLUDES_PHRASE);
+      const readsAt = description.indexOf(READING_PHRASE);
+      swept.push({
+        route,
+        slug: route.replace("/vendor/", ""),
+        description,
+        branch: withheld ? "superseded" : includesAt === -1 ? "other" : "has_free",
+        quoted: withheld
+          ? (readsAt === -1 ? null : description.slice(readsAt + READING_PHRASE.length))
+          : includesAt === -1
+          ? null
+          : description.slice(includesAt + INCLUDES_PHRASE.length),
+      });
+    }
+  };
+  await Promise.all(Array.from({ length: 8 }, worker));
+}
+
+function statedTerms(): Quotation[] {
+  const out: Quotation[] = [];
+  for (const page of swept) {
+    if (page.branch !== "has_free" || page.quoted === null) continue;
+    const records = recordsBySlug.get(page.slug);
+    if (!records) continue;
+    const quotation = quotationAgainst(page.route, page.quoted, records.map(r => r.description.trim()));
+    if (quotation) out.push(quotation);
+  }
+  return out;
+}
+
+function clippedStatedTerms(): Quotation[] {
+  return statedTerms().filter(q => q.continues !== "");
+}
+
+describe("the vendor page lede", () => {
+  before(async () => {
+    server = await startServer();
+    await sweepVendorPages();
+  });
+
+  after(() => {
+    server?.kill();
+  });
+
+  it("answers on every vendor page, and states terms a record of that vendor begins with", () => {
+    assert.deepStrictEqual(unreachable, [], "vendor pages that published no description");
+    assert.ok(
+      swept.length > SWEPT_PAGES_VACUITY_GUARD,
+      `swept ${swept.length} vendor pages, too few to stand as a site-wide check`,
+    );
+    const quoted = statedTerms();
+    assert.strictEqual(
+      quoted.length,
+      swept.filter(p => p.branch === "has_free").length,
+      "free-tier ledes whose vendor has no record in the index",
+    );
+    const strangers = quoted.filter(q => q.opening.length < 8).map(q => `${q.route}: ${q.opening}`);
+    assert.deepStrictEqual(strangers, [], "ledes sharing almost nothing with their own record");
+  });
+
+  it("never ends inside a word", () => {
+    const midWord = clippedStatedTerms()
+      .filter(q => /[A-Za-z0-9]$/.test(q.opening) && /^[A-Za-z0-9]/.test(q.continues))
+      .map(q => `${q.route}: …${q.opening.slice(-40)} | record continues ${q.continues.slice(0, 20)}`);
+    assert.deepStrictEqual(midWord, [], "ledes cut inside a word");
+  });
+
+  it("marks every lede that stops short of its record, so a clip cannot read as a finished claim", () => {
+    const silent = clippedStatedTerms()
+      .filter(q => !q.marked)
+      .map(q => `${q.route}: …${q.opening.slice(-40)} | record continues ${q.continues.slice(0, 30)}`);
+    assert.deepStrictEqual(silent, [], "ledes shorter than their record that do not say so");
+  });
+
+  it("never separates a number from its unit", () => {
+    const severed = clippedStatedTerms()
+      .filter(q => /\d$/.test(q.opening) && /^\s*[A-Za-z]/.test(q.continues))
+      .map(q => `${q.route}: …${q.opening.slice(-40)} | record continues ${q.continues.slice(0, 20)}`);
+    assert.deepStrictEqual(severed, [], "ledes that end on a figure whose unit follows in the record");
+  });
+
+  it("never opens a bracket it does not close", () => {
+    const unbalanced = swept
+      .filter(p => unclosedBrackets(p.description) > 0)
+      .map(p => `${p.route}: ${p.description}`);
+    assert.deepStrictEqual(unbalanced, [], "ledes with an unclosed bracket");
+  });
+
+  it("repeats a full stop only where its own record does", () => {
+    const invented = swept
+      .filter(p => p.description.includes(".."))
+      .filter(p => ![
+        ...(recordsBySlug.get(p.slug) ?? []).map(r => r.description),
+        ...(readingsBySlug.get(p.slug) ?? []),
+      ].some(stored => stored.includes("..")))
+      .map(p => `${p.route}: ${p.description}`);
+    assert.deepStrictEqual(invented, [], "ledes whose repeated full stop the render invented");
+  });
+
+  it("derives every branch of the description from the one truncation rule", () => {
+    const source = readFileSync(path.join(REPO, "src", "serve.ts"), "utf8");
+    const rawClips = [...source.matchAll(/publishableTerms\.slice\([^)]*\)/g)].map(m => m[0]);
+    assert.deepStrictEqual(rawClips, [], "description branches that clip the stored terms without the shared rule");
+    assert.ok(
+      source.includes("punctuatedOpeningOfTerms(publishableTerms, 100)"),
+      "the free-tier branch no longer takes its opening from the shared rule",
+    );
+    assert.ok(
+      source.includes("openingOfTerms(publishableTerms, 120)"),
+      "the verdict no longer takes its opening from the shared rule",
+    );
+  });
+
+  it("leaves the superseded branch quoting the reading behind its record, verbatim and marked", () => {
+    const withheld = swept.filter(p => p.branch === "superseded" && p.quoted !== null);
+    assert.ok(withheld.length > 20, `only ${withheld.length} pages withhold superseded terms`);
+
+    const notAPrefix: string[] = [];
+    const silent: string[] = [];
+    for (const page of withheld) {
+      const readings = readingsBySlug.get(page.slug);
+      if (!readings) continue;
+      const quotation = quotationAgainst(page.route, page.quoted!, readings);
+      if (!quotation || quotation.opening.length < 8) {
+        notAPrefix.push(`${page.route}: ${page.quoted!.slice(0, 60)}`);
+        continue;
+      }
+      if (quotation.continues !== "" && !quotation.marked) {
+        silent.push(`${page.route}: …${quotation.opening.slice(-40)} | reading continues ${quotation.continues.slice(0, 30)}`);
+      }
+    }
+    assert.deepStrictEqual(notAPrefix, [], "withheld pages quoting words the reading behind them does not contain");
+    assert.deepStrictEqual(silent, [], "withheld pages quoting less than the reading without saying so");
+  });
+});
+
+describe("the truncation rule", () => {
+  it("returns the terms untouched when they fit", () => {
+    assert.strictEqual(openingOfTerms("10 GB storage, zero egress", 60), "10 GB storage, zero egress");
+    assert.strictEqual(punctuatedOpeningOfTerms("10 GB storage, zero egress", 60), "10 GB storage, zero egress.");
+  });
+
+  it("stops on a word and says that it stopped", () => {
+    const terms = "Hobby plan with 100 GB/month Fast Data Transfer, 1M function invocations, 4 hrs Active CPU, 360 GB-hrs Provisioned Memory";
+    const opening = openingOfTerms(terms, 100);
+    assert.ok(termsWereClipped(opening), opening);
+    assert.ok(terms.startsWith(opening.replace(/…$/, "")), opening);
+    assert.ok(!/GB-h…$/.test(opening), `the opening severed a unit: ${opening}`);
+  });
+
+  it("marks a stop at a sentence boundary too, because a full stop reads as the whole claim", () => {
+    const terms = "Edge compute with 100K requests/day, 10ms CPU time per invocation. KV: 1 GB storage, 100K reads/day.";
+    const opening = openingOfTerms(terms, 70);
+    assert.strictEqual(opening, "Edge compute with 100K requests/day, 10ms CPU time per invocation…");
+    assert.ok(termsWereClipped(opening));
+  });
+
+  it("does not leave a figure without the unit that follows it", () => {
+    const terms = "Team plan with 25 seats, 100 GB storage, 5000 build minutes and 12 concurrent jobs per account";
+    for (let cap = 20; cap <= 90; cap++) {
+      const opening = openingOfTerms(terms, cap);
+      assert.ok(!/\d$/.test(opening.replace(/…\)*$/, "")), `cap ${cap} ended on a figure: ${opening}`);
+    }
+  });
+
+  it("closes a bracket the clip would have left open, without dropping the terms inside it", () => {
+    const terms = "300 credits/month (deploys at 15 credits each, bandwidth at 20 credits/GB, compute at 10 credits/GB-hour, web requests at 2 credits/10K)";
+    const opening = openingOfTerms(terms, 100);
+    assert.strictEqual(unclosedBrackets(opening), 0, opening);
+    assert.ok(termsWereClipped(opening), opening);
+    assert.ok(opening.includes("deploys at 15 credits each"), `closing the bracket dropped the terms: ${opening}`);
+  });
+
+  it("adds no second full stop to terms that end with one", () => {
+    assert.strictEqual(punctuatedOpeningOfTerms("Event gateway — 10K events/month.", 100), "Event gateway — 10K events/month.");
+    const clipped = punctuatedOpeningOfTerms("Edge compute with 100K requests/day, 10ms CPU time per invocation. KV: 1 GB storage.", 70);
+    assert.ok(!clipped.includes(".."), clipped);
+  });
+
+  it("is either the record word for word or an opening that says it is one", () => {
+    for (const offer of offers) {
+      const terms = offer.description.trim();
+      for (const cap of [90, 100, 120, 170]) {
+        const opening = openingOfTerms(terms, cap);
+        if (opening === terms) continue;
+        assert.ok(termsWereClipped(opening), `${offer.vendor} at ${cap}: ${opening}`);
+        assert.ok(
+          terms.startsWith(opening.replace(/…\)*$/, "")),
+          `${offer.vendor} at ${cap} publishes words its record does not: ${opening}`,
+        );
+      }
+    }
+  });
+});

--- a/test/vendor-lede-truncation.test.ts
+++ b/test/vendor-lede-truncation.test.ts
@@ -227,6 +227,13 @@ describe("the vendor page lede", () => {
     assert.deepStrictEqual(severed, [], "ledes that end on a figure whose unit follows in the record");
   });
 
+  it("leaves no separator hanging in front of the marker", () => {
+    const hanging = clippedStatedTerms()
+      .filter(q => /[\s,;:—–-]$/.test(q.opening))
+      .map(q => `${q.route}: …${q.opening.slice(-40)}`);
+    assert.deepStrictEqual(hanging, [], "ledes whose clip marker follows a separator");
+  });
+
   it("never opens a bracket it does not close", () => {
     const unbalanced = swept
       .filter(p => unclosedBrackets(p.description) > 0)
@@ -303,12 +310,24 @@ describe("the truncation rule", () => {
     assert.ok(termsWereClipped(opening));
   });
 
-  it("does not leave a figure without the unit that follows it", () => {
+  it("does not leave a figure, or the separator after it, without what followed", () => {
     const terms = "Team plan with 25 seats, 100 GB storage, 5000 build minutes and 12 concurrent jobs per account";
     for (let cap = 20; cap <= 90; cap++) {
-      const opening = openingOfTerms(terms, cap);
-      assert.ok(!/\d$/.test(opening.replace(/…\)*$/, "")), `cap ${cap} ended on a figure: ${opening}`);
+      const bare = openingOfTerms(terms, cap).replace(/…\)*$/, "");
+      assert.ok(!/\d$/.test(bare), `cap ${cap} ended on a figure: ${bare}…`);
+      assert.ok(!/[\s,;:—–-]$/.test(bare), `cap ${cap} left a separator in front of the marker: ${bare}…`);
     }
+  });
+
+  it("leaves no separator in front of the marker anywhere in the catalogue", () => {
+    const hanging: string[] = [];
+    for (const offer of offers) {
+      for (const cap of [90, 100, 120, 170]) {
+        const bare = openingOfTerms(offer.description.trim(), cap).replace(/…\)*$/, "");
+        if (/[\s,;:—–-]$/.test(bare)) hanging.push(`${offer.vendor} at ${cap}: …${bare.slice(-40)}`);
+      }
+    }
+    assert.deepStrictEqual(hanging, [], "openings whose clip marker follows a separator");
   });
 
   it("closes a bracket the clip would have left open, without dropping the terms inside it", () => {


### PR DESCRIPTION
Refs #1421.

The free-tier branch of the vendor description took `publishableTerms.slice(0, 100)`, dropped everything after the first full stop, and appended a period. Since #1420 made the description the page's opening sentence, that cut is the first thing an extractor reads on 1,362 of 1,573 vendor pages.

`openingOfTerms` — the truncator the `termsSuperseded` branch already used — moves to `src/terms-opening.ts` and now serves all three branches of the description and the quick verdict. Four rules, one implementation:

- stop on a whole sentence if one fits the cap, otherwise on a word;
- never end on a figure whose unit follows, or on the separator before it;
- close a bracket the clip would have left open, rather than dropping what is inside it;
- **mark every clip**, including one that lands on a full stop.

`punctuated` moves with it, so the template no longer appends a period of its own.

## Measured over every URL in `sitemap-vendors.xml`

Each page's published terms are matched against its own record by longest common prefix, so the numbers do not depend on parsing sentence boundaries out of the rendered text and hold for both spellings.

| | production | this branch |
|---|---|---|
| vendor pages swept | 1,573 | 1,573 |
| …on the free-tier branch | 1,362 | 1,362 |
| ledes cut inside a word | **246** | **0** |
| ledes shorter than their record | 1,149 | 975 |
| …that say so | **0** | **975** |
| ledes ending on a figure whose unit follows | 4 | 0 |
| ledes with an unclosed bracket | 38 | 0 |
| ledes containing `..` | 129 | 2 |

`/vendor/vercel` ends `…4 hrs Active CPU…` instead of `…4 hrs Active CPU, 360 GB-h.`; `/vendor/netlify` ends `…bandwidth at 20 credits/GB, compute at…).` instead of `…compute at 10 credits/GB-.`; `/vendor/cloudflare-workers` ends `…10ms CPU time per invocation…` where it used to state one of six sub-quotas as if it were the whole tier.

The quick verdict took the same raw slice at 120 characters and is now derived the same way, so the sentence two lines under the lede no longer stops mid-word either.

## The two open questions

**A trailing `…` is still a cut.** The `<meta>` tag and the body lede stay the same sentence — splitting them would put a page's claim in two places, which is what #1343's AC-6 exists to prevent. Nothing is withheld by keeping one: the complete stored terms are already on the same page, in the **Free Tier Details** block, and now the lede says it is shorter than them.

**The 165-page control moved on 69 of its 173 pages, and only additively.** 104 are byte-identical. 57 differ by one character — a full stop became the clip marker, because that branch stops on a sentence boundary too and `/vendor/github-actions` was publishing 76 characters of a 387-character reading with a full stop after it. 12 more gained the marker in place of an exclamation mark, or the closing bracket the clip had dropped. No page on that branch publishes a different word than before. Marking a clip that was silent is the same defect being fixed, not a regression in the reference; the tests below assert the property rather than the bytes, so they catch a real regression at any catalogue size.

## Tests

`test/vendor-lede-truncation.test.ts` sweeps all 1,573 vendor URLs at concurrency 8 in 1.6 seconds and asserts one acceptance criterion each: no cut inside a word, every short lede marked, no severed figure, no hanging separator, no unclosed bracket, no invented `..`, one implementation, and the withheld branch quoting its reading verbatim. Every assertion is a `deepStrictEqual` against an empty offender list with a vacuity guard well under the live population, so none of them measures whether the catalogue has shrunk. All eight fail on `main`.

The rule's own tests cover the whole catalogue at four caps: an opening is either the record word for word or an opening that says it is one.

4,166 tests, 0 failures from this change. 13 mutants, 13 killed — including both raw slices restored, the marker removed, the sentence branch left unmarked, the bracket left open and the severed-figure guard removed.

`test/stack-page-verdicts.test.ts` gains one assertion: the limit cell must fill the width it is given. Its existing check that the cell "never truncates into a sentence that reads complete" passed once `openingOfTerms` began marking sentence stops, which would have let the limit column quietly fall back to it.

## Not fixed here

- `/vendor/google-ads` and `/vendor/mockaroo` publish `..` because their stored record and its change reading contain one. The render invents none.
- `src/stack-claim.ts` holds a third truncator, `limitCellText`. It deliberately skips the sentence preference; now that every clip is marked, the reason for that difference is weaker, but converging them is a separate change.
- The median description is 176 characters, up from 163, because a clip now keeps the bracketed detail it used to drop.
