### PR TITLE
Repoint 14 offers from the vendor homepage to the pricing page that states their terms

### DIFF
--- a/data/index.json
+++ b/data/index.json
@@ -9366,7 +9366,7 @@
       "category": "Productivity & Notes",
       "description": "Free for 5 users with 1 GB upload limit & 5GB storage. Zoho Office Suite (Writer, Sheets & Show) comes bundled.",
       "tier": "Free",
-      "url": "https://zoho.com/docs",
+      "url": "https://www.zoho.com/workdrive/pricing.html",
       "tags": [
         "productivity",
         "free-for-dev"
@@ -10586,7 +10586,7 @@
       "category": "Dev Utilities",
       "description": "Stock market and financial data API. Free plan allows 300 requests per day.",
       "tier": "Free",
-      "url": "https://financialdata.net/",
+      "url": "https://financialdata.net/pricing",
       "tags": [
         "developer-tools",
         "free-for-dev"
@@ -11404,7 +11404,7 @@
       "category": "Notebooks & Data Science",
       "description": "A complete platform for dataflow automation. Free plan includes 5 deployed workflows and 500 minutes of serverless compute credits per month.",
       "tier": "Free",
-      "url": "https://www.prefect.io/cloud/",
+      "url": "https://www.prefect.io/pricing",
       "tags": [
         "developer-tools",
         "free-for-dev"
@@ -12887,7 +12887,7 @@
       "category": "Storage",
       "description": "simplest, fastest and safest interface to transfer and share files. Send photos, videos and other large files without a manditory subscription.",
       "tier": "Free",
-      "url": "https://www.transfernow.net/",
+      "url": "https://www.transfernow.net/en/prices",
       "tags": [
         "developer-tools",
         "free-for-dev"
@@ -13398,7 +13398,7 @@
     {
       "vendor": "beanstalkapp.com",
       "category": "Source Control",
-      "description": "A complete workflow to write, review, and deploy code), a free account for one user, and one repository with 100 MB of storage",
+      "description": "A complete workflow to write, review, and deploy code, a free account for one user, and one repository with 100 MB of storage",
       "tier": "Free",
       "url": "https://beanstalkapp.com/",
       "tags": [
@@ -14049,7 +14049,7 @@
       "category": "CI/CD",
       "description": "GitOps-first Terraform automation with pull request-driven workflows, project isolation via self-hosted runners, and layered runs for ordered operations. Free for unlimited users with unlimited runs and runners.",
       "tier": "Free",
-      "url": "https://terrateam.io",
+      "url": "https://terrateam.io/pricing",
       "tags": [
         "ci",
         "cd",
@@ -14455,7 +14455,7 @@
       "category": "Testing",
       "description": "Build scalable UIs in Java or TypeScript, and use the integrated tooling, components, and design system to iterate faster, design better, and simplify the development process. Unlimited Projects with five years of free maintenance.",
       "tier": "Free",
-      "url": "https://vaadin.com",
+      "url": "https://vaadin.com/pricing",
       "tags": [
         "testing",
         "qa",
@@ -15404,7 +15404,7 @@
       "category": "Server Management",
       "description": "Server management tool to easily manage and deploy your servers & sites. Free for one server.",
       "tier": "Free",
-      "url": "https://ploi.io/",
+      "url": "https://ploi.io/pricing",
       "tags": [
         "developer-tools",
         "free-for-dev"
@@ -15837,7 +15837,7 @@
       "category": "Logging",
       "description": "Self-hosted Enterprise free up to 50 GB/day ingestion; open-source self-hosted free with no usage limits",
       "tier": "Free",
-      "url": "https://openobserve.ai/",
+      "url": "https://openobserve.ai/pricing",
       "tags": [
         "logging",
         "log-management",
@@ -15924,7 +15924,7 @@
       "category": "Localization",
       "description": "Free for 1000 source language strings, unlimited languages, unlimited contributors, startup and open source deals",
       "tier": "Free",
-      "url": "https://localazy.com",
+      "url": "https://localazy.com/pricing",
       "tags": [
         "developer-tools",
         "free-for-dev"
@@ -16729,7 +16729,7 @@
       "category": "Monitoring",
       "description": "Powerful server monitoring in a unified platform for metrics and logs, with no setup complexity. Free for one server.",
       "tier": "Free",
-      "url": "https://simpleobservability.com",
+      "url": "https://simpleobservability.com/pricing",
       "tags": [
         "monitoring",
         "observability",
@@ -22650,7 +22650,7 @@
       "category": "Storage",
       "description": "Hosted Package Repositories for YUM, APT, RubyGem and PyPI. Limited free plans and open-source plans are available via request",
       "tier": "Free",
-      "url": "https://packagecloud.io/",
+      "url": "https://packagecloud.io/pricing",
       "tags": [
         "storage",
         "media",
@@ -22668,7 +22668,7 @@
       "category": "Storage",
       "description": "Pinata is the simplest way to upload and manage files on IPFS. Our friendly user interface and IPFS API make Pinata the easiest IPFS pinning service for platforms, creators, and collectors. 1 GB storage free, along with access to API.",
       "tier": "Free",
-      "url": "https://pinata.cloud",
+      "url": "https://pinata.cloud/pricing",
       "tags": [
         "storage",
         "media",
@@ -24262,7 +24262,7 @@
       "category": "Design",
       "description": "Low-code Front-end Design & Development Platform. TeleportHQ is the collaborative front-end platform to instantly create and publish headless static websites. Three free projects, unlimited collaborators, and free code export.",
       "tier": "Free",
-      "url": "https://teleporthq.io/",
+      "url": "https://teleporthq.io/pricing",
       "tags": [
         "design",
         "ui",
@@ -24785,7 +24785,7 @@
       "category": "Maps/Geolocation",
       "description": "Free geocoding for global places and coordinates. 25,000 Requests per month for personal use.",
       "tier": "Free",
-      "url": "https://positionstack.com/",
+      "url": "https://positionstack.com/pricing",
       "tags": [
         "maps",
         "geolocation",
@@ -28737,7 +28737,7 @@
     {
       "vendor": "GOOGLE ADS",
       "category": "Startup Perks",
-      "description": "Up to $150 in Google Ads credit.. Access via: Free for Brex customers",
+      "description": "Up to $150 in Google Ads credit. Access via: Free for Brex customers",
       "tier": "Startup Program",
       "url": "https://brex.com/rewards/",
       "tags": [


### PR DESCRIPTION
Fourteen offers whose stored source URL is the vendor's homepage, repointed to the pricing page that states their terms. Plus two one-character description fixes found while closing #1421.

Part of https://github.com/robhunter/agentdeals/issues/1110. Eight were repointed in PR #1227; this is the second batch.

## What changed

`data/index.json` only. Fourteen `url` values and two `description` values. No `verifiedDate` moved — per #1110 AC-4, the URL changed and nobody re-read the terms, so the next detector run is what establishes the fact.

| vendor | was | now | what the new page states |
|---|---|---|---|
| Financial Data | `financialdata.net/` | `/pricing` | `Free $0/month — 300 Requests/Day` |
| Simple Observability | `simpleobservability.com` | `/pricing` | `Free plan for one server` |
| ploi.io | `ploi.io/` | `/pricing` | `Free €0 $0/mo` |
| Terrateam | `terrateam.io` | `/pricing` | `Free $0/mo — 50 runs/month, 3 users, 1 private runner` |
| packagecloud.io | `packagecloud.io/` | `/pricing` | `Free Plan — 10 GB bandwidth, 2 GB storage` |
| Pinata IPFS | `pinata.cloud` | `/pricing` | `Free $0/month — 1GB storage, 1 gateway` |
| PrefectCloud | `prefect.io/cloud/` | `/pricing` | `Hobby — Free forever, 2 users, 5 deployments, 500 min` |
| Vaadin | `vaadin.com` | `/pricing` | `Free — Free forever, Apache 2.0` |
| openobserve.ai | `openobserve.ai/` | `/pricing` | `Self-Hosted Enterprise free up to 50 GB/day` |
| localazy.com | `localazy.com` | `/pricing` | `Small project = free plan` |
| transfernow | `transfernow.net/` | `/en/prices` | names the free plan alongside the trial |
| Zoho Docs | `zoho.com/docs` | `zoho.com/workdrive/pricing.html` | `Free Plan — 5 GB` |
| positionstack | `positionstack.com/` | `/pricing` | `Free — $0/month, 100 Requests` |
| TeleportHQ | `teleporthq.io/` | `/pricing` | `Trial — $0, 7 days from account activation` |

Every one was fetched and read before the edit, per #1110 AC-2. Each candidate names its vendor (AC-3), with one caveat below.

## Two of these will produce a change record on the first run, and should

I am repointing them rather than hand-correcting the record, because a detector run against the right page is the evidence, and my reading is not.

**positionstack.** We store `25,000 Requests per month for personal use`. `/pricing` sells `Free — Personal use, $0 per month, 100 Requests`. The string `25,000` does not appear on the page. The detector already caught this from the homepage on 2026-09-01 and filed `limits_reduced`, high impact, so the reduction is not news — but the record still stores the old figure and the new source makes it checkable.

**TeleportHQ.** The `$0` plan on `/pricing` is named `Trial`: *"7 days from account activation"*, *"Downloading the code is not available during the free trial"*, *"No project backups… during the trial period"*. We hold the record at `tier: Free`. From the homepage the detector read *"promotes starting for free with no explicit project limits mentioned"* and filed `limits_reduced` — a softer verdict than the pricing page supports.

## Caveat on Zoho Docs

`zoho.com/docs` redirects to WorkDrive; Zoho Docs was folded into it. The candidate page names WorkDrive, not Zoho Docs, so it does not literally satisfy #1110 AC-3. I am including it because the redirect target is the vendor's own choice of successor page, and the record's name being stale is a separate problem — it belongs to the rename family on #1402 / #1245, where I have noted it.

## The two description fixes

Both surfaced closing #1421 as the only defects its render fix could not reach, because the render was quoting the record faithfully.

- `beanstalkapp.com` stored `…and deploy code), a free account…` — a `)` with no opener, the only unbalanced description in 1,580 records.
- `GOOGLE ADS` stored `Up to $150 in Google Ads credit.. Access via:…` — the `..` on `/vendor/google-ads`.

## Checks

`node scripts/validate-data.ts` → `All data valid. 1580 offers, 552 deal changes.`
`test/source-check.test.ts`, `test/source-check-pages.test.ts`, `test/data-push-gate.test.ts` → 112 pass, 0 fail.

Catalogue size is unchanged at 1,580, so none of the #1417 floors are in play.
