### PR TITLE
Date a week we recorded nothing in, so an empty digest is not a missing one (#1425)

### DIFF
--- a/src/provenance.ts
+++ b/src/provenance.ts
@@ -131,6 +131,7 @@ export interface ProvenanceOptions {
   listingPath?: string;
   deference?: boolean;
   dateForSlug?: (slug: string) => string | null;
+  dateOfTheLogConsulted?: string | null;
 }
 
 export function provenanceBlock(
@@ -146,12 +147,12 @@ export function provenanceBlock(
   const ranked = records.filter((r) => !r.withheld);
   const withheld = records.length - ranked.length;
   const dated = ranked.length > 0 ? ranked : records;
-  const date = oldestDate(dated);
+  const date = oldestDate(dated) ?? options.dateOfTheLogConsulted ?? null;
   const derived = options.path ?? narrowestPath(records);
   const path = derived === "/" ? options.listingPath ?? "/" : derived;
 
   const block: Record<string, unknown> = {
-    ...citation(baseUrl, path, date, dated.length === 1),
+    ...citation(baseUrl, path, date, dated.length <= 1),
     ...(date ? { verified: date } : {}),
     verified_records: ranked.length,
     ...(withheld > 0 ? { withheld_records: withheld } : {}),

--- a/src/serve.ts
+++ b/src/serve.ts
@@ -53352,6 +53352,17 @@ function citedAt<T extends object>(payload: T, path: string): T & { _provenance:
   };
 }
 
+function citedAgainstTheChangeLog<T extends object>(payload: T, path: string): T & { _provenance: Record<string, unknown> } {
+  return {
+    ...payload,
+    _provenance: provenanceBlock(BASE_URL, payload, {
+      path,
+      dateForSlug: oldestVerifiedDateForSlug,
+      dateOfTheLogConsulted: getChangeLogFreshness().last_recorded_date,
+    }),
+  };
+}
+
 function withAgentBlock<T extends object>(payload: T, slug?: string | null): T & { _agent: Record<string, unknown>; _provenance: Record<string, unknown> } {
   return {
     ...payload,
@@ -54496,7 +54507,7 @@ const httpServer = createHttpServer(async (req, res) => {
       res.end(digest.digest_html);
     } else {
       res.writeHead(200, { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*", "Cache-Control": "public, max-age=3600" });
-      res.end(JSON.stringify(citedAt(digest, digestWeekPath(digest.week_of))));
+      res.end(JSON.stringify(citedAgainstTheChangeLog(digest, digestWeekPath(digest.week_of))));
     }
   } else if (url.pathname === "/api/digest" && isGetOrHead) {
     recordApiHit("/api/digest");

--- a/test/documented-route-citation.test.ts
+++ b/test/documented-route-citation.test.ts
@@ -4,6 +4,7 @@ import { spawn, type ChildProcess } from "node:child_process";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { DEFERENCE } from "../dist/signal-copy.js";
+import { getChangeLogFreshness, loadDealChanges } from "../dist/data.js";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -68,6 +69,18 @@ const SOURCE_POPULATION_PAGES: [string, string, number][] = [
 
 const ALWAYS_PUBLISHED = ["source", "url", "cite_as", "note"];
 const PUBLISHED_WHERE_DATED = ["checked", "verified"];
+
+function lastRecordedDate(): string | null {
+  return getChangeLogFreshness().last_recorded_date;
+}
+
+function weeksBackToBeforeTheFirstRecord(): number {
+  const dates = loadDealChanges().flatMap((c: { date?: string; recorded_date?: string }) => [c.date, c.recorded_date])
+    .filter((d): d is string => typeof d === "string" && d !== "")
+    .sort();
+  const oldest = Date.parse(dates[0] + "T00:00:00Z");
+  return Math.ceil((Date.now() - oldest) / (7 * 86400000)) + 1;
+}
 
 function documentedProvenanceFields(html: string): string[] {
   const section = html.slice(html.indexOf("<h2>Provenance</h2>"), html.indexOf("<h2>Rate Limits</h2>"));
@@ -254,6 +267,20 @@ describe("every product route the developer hub documents carries a citation", (
       const res = await fetch(`${base}${pathname}`, { redirect: "manual" });
       assert.strictEqual(res.status, 200, `${pathname} answers ${res.status}`);
     }
+  });
+
+  it("dates a week it recorded nothing in, so an empty week reads differently from a stopped feed", async () => {
+    const weeksAgo = weeksBackToBeforeTheFirstRecord();
+    const body = await (await fetch(`${base}/api/digest/weekly?weeks_ago=${weeksAgo}`)).text();
+    const json = JSON.parse(body) as { week_of: string; changes_in_week: number; discovered_in_week: number; _provenance: Record<string, unknown> };
+    assert.strictEqual(json.changes_in_week, 0, `the week of ${json.week_of} precedes every record and holds ${json.changes_in_week} changes`);
+    assert.strictEqual(json.discovered_in_week, 0, `the week of ${json.week_of} precedes every record and holds ${json.discovered_in_week} discoveries`);
+    for (const field of PUBLISHED_WHERE_DATED) {
+      assert.ok(field in json._provenance, `a week with no changes publishes no ${field}`);
+    }
+    assert.strictEqual(json._provenance.checked, lastRecordedDate(), "an empty week is dated something other than the day the change log last grew");
+    assert.strictEqual(json._provenance.verified, lastRecordedDate());
+    assert.match(String(json._provenance.cite_as), /, checked \d{4}-\d{2}-\d{2}\)$/);
   });
 
   it("cites the vendor's own page for every referral code it publishes", async () => {


### PR DESCRIPTION
Refs #1425

## What was wrong

`/api/digest/weekly` derived its citation date from the dated records inside its own payload. A week that has had no changes yet contains none, so the route published no `checked` and no `verified` — and the three assertions in `test/documented-route-citation.test.ts` that require every dated route to carry them went red. It recurs at every ISO week boundary and heals itself when the week's first change lands, which is why it kept coming back.

## Which answer I picked

The issue offered two. I took the second: **an empty digest still carries a check date.** A route reporting zero changes for a week that had zero changes is answering correctly, and excusing it from the assertion would have made "this route rests on a dated record" a property of the calendar rather than of the route.

The date it cites is **the day the change log it consulted last grew** — `last_recorded_date`, the same field `/changes` already publishes in prose. That is the date we last looked, it is a date we know, and it satisfies AC-2 directly: a feed that has stopped moving publishes a check date that has stopped moving with it, so `checked 2026-09-05, 0 changes this week` reads differently from `checked 2026-06-01, 0 changes this week`.

```
GET /api/digest/weekly
{"week_of":"2026-09-07","changes_in_week":0,
 "_provenance":{"checked":"2026-09-05","verified":"2026-09-05",
   "cite_as":"Source: AgentDeals (https://agentdeals.dev/digest/2026-w37, checked 2026-09-05)"}}
```

The clause reads `checked D`, not `oldest figure checked D`, when there is no figure to be the oldest one.

## Scope

`dateOfTheLogConsulted` is passed by one route. Every other route reaches `provenanceBlock` with the option absent and is byte-identical — the only behaviour that changed for them would be a payload with zero cited records *and* a date, which cannot happen without the option. AC-3 holds: `/api/deadlines`, `/api/ai-coding-pricing`, `/api/hosting-pricing`, `/api/llm-pricing`, `/api/startup-credits` and `/api/referral-programs` publish what they published before, and a non-empty digest week still reads `oldest figure checked`.

## Verification

- **4,169 tests, 0 failures.** The three assertions this fixes fail on `main` at `afbc329` and pass here.
- **New test** asks for the week that precedes every record in the log, computed from the log itself, so it reaches the empty-week branch on any day it is run rather than only during the hours the bug is live.
- **3 mutants, 3 killed** — dropping the fallback date, keeping the plural citation clause, and pinning the date to a constant each fail at least one assertion.
- Probed on a running server: `weeks_ago=0` (empty, now dated), `weeks_ago=1` and `weeks_ago=2` (populated, unchanged).

AC-4: `#1367` is untouched.