### PR TITLE
A superseding reading has to price a plan before it can replace one (#1424)

### DIFF
--- a/data/quality_budgets.json
+++ b/data/quality_budgets.json
@@ -8,9 +8,9 @@
     "faq_answers": 166,
     "faq_answers_stating_a_figure": 77,
     "faq_answers_with_a_digit_but_no_figure": 40,
-    "records_with_superseded_terms": 175,
-    "vendor_pages_withholding_superseded_terms": 174,
-    "ungated_pages_withholding_superseded_terms": 165
+    "records_with_superseded_terms": 165,
+    "vendor_pages_withholding_superseded_terms": 164,
+    "ungated_pages_withholding_superseded_terms": 155
   },
   "raised_because": {
     "uncited_change_records": "95 to 98 on 2026-09-06. stathat.com, searchly.com and Prospect.io each cited the page their own summary reports as unreadable, and dropping that citation is the honest fix rather than repointing it at a page that would pass a liveness check. The 35 records that report our own index lost a citation in the same change and are outside this count rather than spending slots in it."

--- a/scripts/census-1424-superseding-readings.mjs
+++ b/scripts/census-1424-superseding-readings.mjs
@@ -1,0 +1,148 @@
+import { readFileSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const { quotesTheStoredTermsAsPrevious, readingBehindTheChange } = await import(`${root}/dist/superseded-description.js`);
+const { narrowsTheStoredTerms } = await import(`${root}/dist/change-direction.js`);
+const { isNoLongerInForce } = await import(`${root}/dist/change-resolution.js`);
+const { tierRecordsAFreeTier } = await import(`${root}/dist/free-tier-record.js`);
+const { openingOfTerms, punctuated } = await import(`${root}/dist/terms-opening.js`);
+const { describesOnlyATrial, mentionsSomethingFree, namesAFreePlan, openingOfAReading, sentencesOf } =
+  await import(`${root}/dist/superseding-reading.js`);
+
+const LEDE_CAP = 90;
+const CONCURRENCY = 6;
+const TIMEOUT_MS = 25000;
+
+const offers = JSON.parse(readFileSync(`${root}/data/index.json`, "utf8")).offers;
+const changes = JSON.parse(readFileSync(`${root}/data/deal_changes.json`, "utf8")).changes;
+
+const byVendor = new Map();
+for (const change of changes) {
+  const key = change.vendor.toLowerCase();
+  if (!byVendor.has(key)) byVendor.set(key, []);
+  byVendor.get(key).push(change);
+}
+
+function everySupersedingChange(offer) {
+  let newest = null;
+  for (const change of byVendor.get(offer.vendor.toLowerCase()) ?? []) {
+    if (isNoLongerInForce(change)) continue;
+    if (!narrowsTheStoredTerms(change.change_type)) continue;
+    if (!quotesTheStoredTermsAsPrevious(change, offer.description)) continue;
+    if (!newest || change.date > newest.date) newest = change;
+  }
+  return newest;
+}
+
+const population = [];
+for (const offer of offers) {
+  const change = everySupersedingChange(offer);
+  if (!change) continue;
+  const reading = readingBehindTheChange(change);
+  if (!reading) continue;
+  population.push({ offer, change, reading });
+}
+
+function visibleText(html) {
+  return html
+    .replace(/<script[\s\S]*?<\/script>/gi, " ")
+    .replace(/<style[\s\S]*?<\/style>/gi, " ")
+    .replace(/<noscript[\s\S]*?<\/noscript>/gi, " ")
+    .replace(/<[^>]+>/g, " ")
+    .replace(/&nbsp;|&#160;/g, " ")
+    .replace(/&amp;/g, "&")
+    .replace(/&#36;/g, "$")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+async function readThePage(url) {
+  for (let attempt = 0; attempt < 2; attempt++) {
+    try {
+      const res = await fetch(url, {
+        redirect: "follow",
+        headers: { "user-agent": "Mozilla/5.0 (compatible; AgentDeals-census/1.0)" },
+        signal: AbortSignal.timeout(TIMEOUT_MS),
+      });
+      if (!res.ok) return { status: res.status, text: null };
+      return { status: res.status, text: visibleText(await res.text()) };
+    } catch (error) {
+      if (attempt === 1) return { status: 0, text: null, error: String(error).slice(0, 120) };
+    }
+  }
+  return { status: 0, text: null };
+}
+
+function whereThePageNamesAFreePlan(text) {
+  for (const sentence of sentencesOf(text)) {
+    if (sentence.text.length > 400) continue;
+    if (namesAFreePlan(sentence.text)) return sentence.text.trim().slice(0, 180);
+  }
+  return null;
+}
+
+const rows = [];
+let done = 0;
+async function work(queue) {
+  while (queue.length > 0) {
+    const item = queue.shift();
+    const page = await readThePage(item.change.source_url);
+    const before = punctuated(openingOfTerms(item.reading.terms, LEDE_CAP));
+    const after = punctuated(openingOfAReading(item.reading.terms, LEDE_CAP));
+    const freeRecord = tierRecordsAFreeTier(item.offer.tier ?? "");
+    const withdrawn = freeRecord && describesOnlyATrial(item.reading.terms);
+    rows.push({
+      vendor: item.offer.vendor,
+      tier: item.offer.tier,
+      free_tier_record: freeRecord,
+      url: item.change.source_url,
+      has_a_path: new URL(item.change.source_url).pathname.replace(/\/+$/, "") !== "",
+      change_type: item.change.change_type,
+      status: page.status,
+      page_names_a_free_plan: page.text ? whereThePageNamesAFreePlan(page.text) : null,
+      reading: item.reading.terms,
+      lede_before: before,
+      lede_after: withdrawn ? null : after,
+      stops_superseding: withdrawn,
+      stored: item.offer.description,
+    });
+    done++;
+    if (done % 20 === 0) process.stderr.write(`  read ${done} of ${population.length}\n`);
+  }
+}
+
+const queue = [...population];
+await Promise.all(Array.from({ length: CONCURRENCY }, () => work(queue)));
+rows.sort((a, b) => a.vendor.localeCompare(b.vendor));
+
+const reachable = rows.filter((r) => r.status >= 200 && r.status < 400 && r.page_names_a_free_plan !== null || r.status >= 200 && r.status < 400);
+const statesOne = rows.filter((r) => r.page_names_a_free_plan !== null);
+const silentBefore = statesOne.filter((r) => !mentionsSomethingFree(r.lede_before));
+const silentAfter = statesOne.filter((r) => r.lede_after !== null && !mentionsSomethingFree(r.lede_after));
+
+const summary = {
+  superseded_records: rows.length,
+  cited_page_read: reachable.length,
+  cited_page_names_a_free_plan: statesOne.length,
+  published_lede_says_nothing_free_before: silentBefore.length,
+  published_lede_says_nothing_free_after: silentAfter.length,
+  records_that_stop_superseding: rows.filter((r) => r.stops_superseding).length,
+  ledes_re_anchored: rows.filter((r) => !r.stops_superseding && r.lede_after !== r.lede_before).length,
+};
+
+writeFileSync(`${root}/../census-1424.json`, JSON.stringify({ summary, rows }, null, 1));
+console.log(JSON.stringify(summary, null, 1));
+console.log("\nstops superseding:");
+for (const r of rows.filter((x) => x.stops_superseding)) {
+  console.log(`  ${r.vendor} [${r.tier}] ${r.url} (${r.status}) page names a free plan: ${r.page_names_a_free_plan ? "yes" : "no"}`);
+}
+console.log("\nlede re-anchored:");
+for (const r of rows.filter((x) => !x.stops_superseding && x.lede_after !== x.lede_before)) {
+  console.log(`  ${r.vendor} ${r.url} (${r.status})\n    before: ${r.lede_before}\n    after:  ${r.lede_after}`);
+}
+console.log("\nlede still says nothing free while the cited page names a free plan:");
+for (const r of silentAfter) {
+  console.log(`  ${r.vendor} ${r.url}\n    page:  ${r.page_names_a_free_plan}\n    lede:  ${r.lede_after}`);
+}

--- a/scripts/mutate-1424.sh
+++ b/scripts/mutate-1424.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+set -uo pipefail
+
+REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO"
+
+TESTS=(
+  test/superseded-terms.test.ts
+  test/superseded-terms-listings.test.ts
+)
+
+SOURCES=(src/superseding-reading.ts src/superseded-description.ts)
+
+backup() { for f in "${SOURCES[@]}"; do cp "$f" "/tmp/$(basename "$f").m1424"; done; }
+restore() { for f in "${SOURCES[@]}"; do cp "/tmp/$(basename "$f").m1424" "$f"; done; }
+
+backup
+trap 'restore; npm run build >/dev/null 2>&1' EXIT
+
+killed=0
+survived=0
+
+run_mutation() {
+  local name="$1"; shift
+  restore
+  if ! "$@"; then
+    echo "NOT APPLIED                $name"
+    return
+  fi
+  if ! npm run build >/dev/null 2>&1; then
+    echo "KILLED (does not compile)  $name"
+    killed=$((killed + 1))
+    return
+  fi
+  if TZ=UTC node --test --test-concurrency 1 "${TESTS[@]}" >/tmp/mutation-1424-out.txt 2>&1; then
+    echo "SURVIVED                   $name"
+    survived=$((survived + 1))
+  else
+    echo "KILLED                     $name"
+    killed=$((killed + 1))
+  fi
+}
+
+sub() {
+  python3 - "$1" "$2" "$3" <<'PY'
+import sys
+path, old, new = sys.argv[1], sys.argv[2], sys.argv[3]
+text = open(path, encoding="utf-8").read()
+if old not in text:
+    sys.exit("mutation target not found in " + path)
+open(path, "w", encoding="utf-8").write(text.replace(old, new, 1))
+PY
+}
+
+run_mutation "the opening never moves to the sentence that names the free plan" \
+  sub src/superseding-reading.ts '  if (at <= 0) return opening;' \
+                                 '  if (at >= 0) return opening;'
+
+run_mutation "the meta sentence takes a raw slice again" \
+  sub src/superseded-description.ts '  const opening = punctuated(openingOfAReading(reading.terms, 90));' \
+                                    '  const opening = punctuated(reading.terms.slice(0, 90));'
+
+run_mutation "a trial-only reading goes on withholding our terms" \
+  sub src/superseded-description.ts '    if (readingPricesNothingButATrial(change, offer)) continue;' \
+                                    '    if (false) continue;'
+
+run_mutation "the withholding is lifted whatever the record's tier says" \
+  sub src/superseded-description.ts '  if (!tierRecordsAFreeTier(offer.tier ?? "")) return false;' \
+                                    '  if (false) return false;'
+
+run_mutation "a trial reading counts as a plan reading" \
+  sub src/superseding-reading.ts '  if (!A_TRIAL.test(reading)) return false;' \
+                                 '  if (true) return false;'
+
+run_mutation "a priced reading counts as a trial" \
+  sub src/superseding-reading.ts '  if (A_PLAN_PRICE.test(reading)) return false;' \
+                                 '  if (false) return false;'
+
+run_mutation "a free price inside a trial clause counts as a free plan" \
+  sub src/superseding-reading.ts '    if (!isQualifiedAway(text, match.index, match[0].length)) return match.index;' \
+                                 '    return match.index;'
+
+run_mutation "a sentence denying the free plan counts as naming one" \
+  sub src/superseding-reading.ts '  return !DENIES_A_FREE_PLAN.test(clauseAround(sentence, at).text);' \
+                                 '  return true;'
+
+run_mutation "the moved opening is published unmarked" \
+  sub src/superseding-reading.ts '  return `${CLIPPED_TERMS_MARKER}${openingOfTerms(reading.slice(at), cap - CLIPPED_TERMS_MARKER.length)}`;' \
+                                 '  return openingOfTerms(reading.slice(at), cap);'
+
+run_mutation "the opening moves even where it already says something is free" \
+  sub src/superseding-reading.ts '  if (mentionsSomethingFree(opening)) return opening;' \
+                                 '  if (false) return opening;'
+
+echo
+echo "killed $killed, survived $survived"
+[ "$survived" -eq 0 ]

--- a/src/serve.ts
+++ b/src/serve.ts
@@ -464,7 +464,7 @@ function changesFor(vendorName: string): DealChange[] {
   return changesByVendorName.get(vendorName.toLowerCase()) ?? [];
 }
 
-type StoredTermsOf = Pick<Offer, "vendor" | "description">;
+type StoredTermsOf = Pick<Offer, "vendor" | "description" | "tier">;
 
 function supersedingChangeFor(offer: StoredTermsOf): DealChange | null {
   return supersedingChange(offer, changesFor(offer.vendor));
@@ -50824,7 +50824,7 @@ function buildAgentStackPage(): string {
     const serviceRows = recommended.map(({ svc, reading }) => {
       const shortLimits = reading
         ? stackKeyLimitHtml(reading, 140)
-        : escHtmlServer(publishedTermsOpening({ vendor: svc.vendorName, description: svc.description }, 1, 140));
+        : escHtmlServer(publishedTermsOpening({ vendor: svc.vendorName, description: svc.description, tier: svc.tier }, 1, 140));
       const verdict = reading ? stackVerdictChipHtml(reading) : `<span style="color:var(--text-dim)">&mdash;</span>`;
       return `          <tr>
             <td class="role-cell">${escHtmlServer(svc.role)}</td>

--- a/src/superseded-description.ts
+++ b/src/superseded-description.ts
@@ -2,7 +2,9 @@ import { changeCitesASource, citationLabel } from "./change-citation.js";
 import { changeDateClause } from "./change-dates.js";
 import { narrowsTheStoredTerms } from "./change-direction.js";
 import { isNoLongerInForce } from "./change-resolution.js";
-import { openingOfTerms, punctuated, punctuatedOpeningOfTerms } from "./terms-opening.js";
+import { tierRecordsAFreeTier } from "./free-tier-record.js";
+import { describesOnlyATrial, openingOfAReading } from "./superseding-reading.js";
+import { punctuated } from "./terms-opening.js";
 import { carriesAnUnrenderedExpression } from "./unrendered-text.js";
 import type { ChangeResolution, DealChange } from "./types.js";
 
@@ -18,6 +20,7 @@ export interface QuotingChange extends Pick<DealChange, "date" | "date_source" |
 export interface StoredTerms {
   vendor: string;
   description: string;
+  tier?: string;
 }
 
 export interface SourcedReading {
@@ -42,20 +45,30 @@ export function supersedesTheStoredTerms(change: QuotingChange, description: str
   return quotesTheStoredTermsAsPrevious(change, description);
 }
 
+export function readingPricesNothingButATrial(
+  change: QuotingChange,
+  offer: Pick<StoredTerms, "tier">,
+): boolean {
+  if (!tierRecordsAFreeTier(offer.tier ?? "")) return false;
+  const reading = readingBehindTheChange(change);
+  return reading !== null && describesOnlyATrial(reading.terms);
+}
+
 export function supersedingChange<T extends QuotingChange>(
-  offer: Pick<StoredTerms, "description">,
+  offer: Pick<StoredTerms, "description" | "tier">,
   vendorChanges: readonly T[],
 ): T | null {
   let newest: T | null = null;
   for (const change of vendorChanges) {
     if (!supersedesTheStoredTerms(change, offer.description)) continue;
+    if (readingPricesNothingButATrial(change, offer)) continue;
     if (!newest || change.date > newest.date) newest = change;
   }
   return newest;
 }
 
 export function storedTermsAreSuperseded(
-  offer: Pick<StoredTerms, "description">,
+  offer: Pick<StoredTerms, "description" | "tier">,
   vendorChanges: readonly QuotingChange[],
 ): boolean {
   return supersedingChange(offer, vendorChanges) !== null;
@@ -94,7 +107,7 @@ function withheldTail(vendor: string, change: QuotingChange, besideAReading: boo
 function readingWithTail(vendor: string, change: QuotingChange, cap?: number): string | null {
   const reading = readingBehindTheChange(change);
   if (!reading) return null;
-  const terms = cap === undefined ? reading.terms : openingOfTerms(reading.terms, cap);
+  const terms = cap === undefined ? reading.terms : openingOfAReading(reading.terms, cap);
   return `${readingSentence(reading.date, reading.label, punctuated(terms))} ${withheldTail(vendor, change, true)}`;
 }
 
@@ -134,7 +147,7 @@ export function supersededTermsMetaSentence(vendor: string, change: QuotingChang
   if (!reading) {
     return `${withheld}: our own pricing change record, ${changeDateClause(change)}, ${STORED_TERMS_WITHHELD_PHRASE}.`;
   }
-  const opening = punctuatedOpeningOfTerms(reading.terms, 90);
+  const opening = punctuated(openingOfAReading(reading.terms, 90));
   return `${readingSentence(reading.date, reading.label, opening)} ${withheld}.`;
 }
 
@@ -161,7 +174,7 @@ export function supersededTermsRecord(vendor: string, change: QuotingChange): Su
 }
 
 export function supersededTermsRecordFor(
-  offer: StoredTerms,
+  offer: Pick<StoredTerms, "vendor" | "description" | "tier">,
   vendorChanges: readonly QuotingChange[],
 ): SupersededTermsRecord | null {
   const change = supersedingChange(offer, vendorChanges);

--- a/src/superseding-reading.ts
+++ b/src/superseding-reading.ts
@@ -1,0 +1,94 @@
+import { CLIPPED_TERMS_MARKER, openingOfTerms } from "./terms-opening.js";
+
+export const A_FREE_PLAN =
+  /\b(?:always\s+free|free\s+forever|forever\s+free)\b|\bfree[\s'"’-]{0,3}(?:plans?|tiers?|editions?|versions?|accounts?|keys?|api)\b|\b(?:plans?|tiers?|editions?|versions?|accounts?)\b[^.!?]{0,24}?\bis\s+free\b|\bfree\s+for(?:ever)?\b(?!\s+(?:\d|a\s+(?:limited|month|year)|the\s+first))|[$€£]\s?0(?:\.00)?\s*(?:\/\s*|per\s+)(?:mo|month|user|seat|year|yr)\b|\bfree\b\s*[:=]\s*[$€£]\s?0\b/i;
+
+export const A_FREE_PRICE = /\bfree\b|[$€£]\s?0\b/i;
+
+export const A_TRIAL_A_CREDIT_OR_A_DISCOUNT =
+  /\btrials?\b|[$€£]\s?[\d,.]+\s*[km]?\s*(?:in\s+)?(?:free\s+)?credits?\b|\bcredits?\s+(?:of|worth|for\s+new)\b|\bfree\s+credits?\b|\bcoupons?\b|\bdiscounts?\b|\b\d+\s*%\s*off\b|\bvouchers?\b/i;
+
+export const A_TRIAL = /\btrials?\b|\bfree\s+for\s+\d+\s+(?:days?|weeks?|months?)\b/i;
+
+export const A_PLAN_PRICE = /[$€£]\s?[\d,]+(?:\.\d+)?|\b[\d,]+(?:\.\d+)?\s*(?:USD|EUR|GBP)\b/i;
+
+export const DENIES_A_FREE_PLAN =
+  /\b(?:does\s+not|doesn['’]t|do\s+not|no\s+longer|not\s+available|only\s+available|is\s+not|are\s+not|remov(?:e|es|ed|ing|al)|sunset(?:s|ting|ted)?|shutting\s+down|shut\s+down|deprecat(?:e|ed|ing|ion)|discontinu(?:e|ed|ing))\b/i;
+
+const CLAUSE_BREAK = /[;:|]|,(?=\s)|\s+[-–—]\s+/g;
+
+const SENTENCE_BREAK = /(?<=[.!?])\s+/;
+
+const WORDS_EITHER_SIDE = 24;
+
+function clauseAround(text: string, index: number): { at: number; text: string } {
+  let start = 0;
+  let end = text.length;
+  for (const match of text.matchAll(CLAUSE_BREAK)) {
+    if (match.index < index) start = match.index + match[0].length;
+    else {
+      end = match.index;
+      break;
+    }
+  }
+  return { at: start, text: text.slice(start, end) };
+}
+
+function isQualifiedAway(text: string, index: number, length: number): boolean {
+  const clause = clauseAround(text, index);
+  const from = index - clause.at - WORDS_EITHER_SIDE;
+  const to = index - clause.at + length + WORDS_EITHER_SIDE;
+  for (const match of clause.text.matchAll(new RegExp(A_TRIAL_A_CREDIT_OR_A_DISCOUNT.source, "gi"))) {
+    if (match.index < to && match.index + match[0].length > from) return true;
+  }
+  return false;
+}
+
+function whereItIsOfferedOutrightIn(text: string, pattern: RegExp): number {
+  for (const match of text.matchAll(new RegExp(pattern.source, "gi"))) {
+    if (!isQualifiedAway(text, match.index, match[0].length)) return match.index;
+  }
+  return -1;
+}
+
+export function namesAFreePlan(sentence: string): boolean {
+  const at = whereItIsOfferedOutrightIn(sentence, A_FREE_PLAN);
+  if (at < 0) return false;
+  return !DENIES_A_FREE_PLAN.test(clauseAround(sentence, at).text);
+}
+
+export function mentionsSomethingFree(text: string): boolean {
+  return whereItIsOfferedOutrightIn(text, A_FREE_PRICE) >= 0;
+}
+
+export function sentencesOf(text: string): { at: number; text: string }[] {
+  const found: { at: number; text: string }[] = [];
+  let from = 0;
+  for (const part of text.split(SENTENCE_BREAK)) {
+    const at = text.indexOf(part, from);
+    if (part.trim() !== "") found.push({ at, text: part });
+    from = at + part.length;
+  }
+  return found;
+}
+
+export function whereAFreePlanIsNamed(reading: string): number {
+  for (const sentence of sentencesOf(reading)) {
+    if (namesAFreePlan(sentence.text)) return sentence.at;
+  }
+  return -1;
+}
+
+export function describesOnlyATrial(reading: string): boolean {
+  if (!A_TRIAL.test(reading)) return false;
+  if (A_PLAN_PRICE.test(reading)) return false;
+  return whereAFreePlanIsNamed(reading) === -1;
+}
+
+export function openingOfAReading(reading: string, cap: number): string {
+  const opening = openingOfTerms(reading, cap);
+  if (mentionsSomethingFree(opening)) return opening;
+  const at = whereAFreePlanIsNamed(reading);
+  if (at <= 0) return opening;
+  return `${CLIPPED_TERMS_MARKER}${openingOfTerms(reading.slice(at), cap - CLIPPED_TERMS_MARKER.length)}`;
+}

--- a/test/superseded-terms.test.ts
+++ b/test/superseded-terms.test.ts
@@ -26,6 +26,14 @@ const { toSlug } = await import("../dist/slug.js");
 const { qualityBudget } = await import("../dist/page-reviews.js");
 const { supersededCensus } = await import("../dist/superseded-census.js");
 const { utcDate } = await import("../dist/ranking.js");
+const { tierRecordsAFreeTier } = await import("../dist/free-tier-record.js");
+const {
+  describesOnlyATrial,
+  mentionsSomethingFree,
+  namesAFreePlan,
+  openingOfAReading,
+  whereAFreePlanIsNamed,
+} = await import("../dist/superseding-reading.js");
 
 type Offer = import("../src/types.ts").Offer;
 type DealChange = import("../src/types.ts").DealChange;
@@ -354,6 +362,131 @@ describe("#1383 which of the two directions holds a scheduled data commit", () =
       const source = readFileSync(path.join(REPO, "test", file), "utf-8");
       assert.ok(!pinned.test(source), `${file} still pins the population with an equality assertion`);
     }
+  });
+});
+
+describe("#1424 whether a superseding reading prices a plan or describes a trial", () => {
+  const A_TRIAL_AND_NOTHING_ELSE = [
+    ["a trial in place of a free forever plan", "We provide 14 days free trial with unlimited data ingestion."],
+    ["a trial in place of a free plan", "A 7-day trial is available with 5,000 API credits and no credit card required."],
+    [
+      "a trial banner in place of a free plan",
+      "Free 10-day trial No card required Explore all features Give Survicate a test drive with the following features: " +
+        "Collect up to 25 survey responses Research Hub with 100 data points 25+ integrations available",
+    ],
+    ["a trial with no plan beside it", "Offers a 7-day free trial, no credit card required."],
+  ] as const;
+
+  const A_PLAN = [
+    [
+      "a free price beside a paid one",
+      "Send 100 monthly geocode requests for free — in case you ever need more, premium geocoding subscriptions start at just USD $9.99 per month.",
+    ],
+    ["a paid plan and its limits", "Starter plan includes 10 users, 500 test results / month, and 100 prompt execs / month."],
+    ["prices per period", "DBOS Pro is $99/month (2 user seats, 3 apps, 1M checkpoints)."],
+    ["prices per token", "Grok 4.6: Input $2.00 / 1M tokens, Output $6.00 / 1M tokens"],
+  ] as const;
+
+  const NAMES_A_FREE_PLAN = [
+    "The free tier includes unlimited API requests, 50,000 monthly active users, 500 MB database size.",
+    "Always Free services include HeatWave AMD-based Compute and Object Storage.",
+    "Free Forever $0 Free Up to 25 infrastructure units",
+    "The Free plan costs $0 per month and includes 50 AI credits.",
+    "The Community plan is free and includes unlimited users.",
+  ];
+
+  const NAMES_NO_FREE_PLAN = [
+    "The page offers a free trial with up to 1,000 MAU and 6-month message retention.",
+    "Start with a free credit of $40.",
+    "It does not mention a permanently free tier for up to 5 servers.",
+    'It states "Why We are Removing Burner Mail\'s Free Plan Read more".',
+    "Brevo 50% off Starter and Standard Plans Save up to $2,574",
+    "Free plan trial: 14 days, then $19 a month.",
+  ];
+
+  const OFFERS_NOTHING_FREE_OUTRIGHT = [
+    "Start for free with $50 in credit for new signups.",
+    "There is a free 7-day trial, then $10 a month for the Developer plan.",
+    "Brevo 50% off Starter and Standard Plans Save up to $2,574",
+  ];
+
+  const OFFERS_SOMETHING_FREE_OUTRIGHT = [
+    "KIRO FREE $0 per month 50 credits.",
+    "The Free plan costs $0 per month and includes 50 AI credits.",
+    "Leiga is free forever with no credit card required.",
+  ];
+
+  for (const sentence of OFFERS_NOTHING_FREE_OUTRIGHT) {
+    it(`reads nothing as offered free outright in "${sentence.slice(0, 40)}"`, () => {
+      assert.strictEqual(mentionsSomethingFree(sentence), false);
+    });
+  }
+
+  for (const sentence of OFFERS_SOMETHING_FREE_OUTRIGHT) {
+    it(`reads something as offered free outright in "${sentence.slice(0, 40)}"`, () => {
+      assert.strictEqual(mentionsSomethingFree(sentence), true);
+    });
+  }
+
+  for (const [shape, reading] of A_TRIAL_AND_NOTHING_ELSE) {
+    it(`reads ${shape} as no reading of the plan table`, () => {
+      assert.strictEqual(describesOnlyATrial(reading), true, reading);
+    });
+  }
+
+  for (const [shape, reading] of A_PLAN) {
+    it(`reads ${shape} as a reading of the plan table`, () => {
+      assert.strictEqual(describesOnlyATrial(reading), false, reading);
+    });
+  }
+
+  for (const sentence of NAMES_A_FREE_PLAN) {
+    it(`finds the free plan in "${sentence.slice(0, 44)}"`, () => {
+      assert.strictEqual(namesAFreePlan(sentence), true);
+    });
+  }
+
+  for (const sentence of NAMES_NO_FREE_PLAN) {
+    it(`finds no free plan in "${sentence.slice(0, 44)}"`, () => {
+      assert.strictEqual(namesAFreePlan(sentence), false);
+    });
+  }
+
+  it("opens on the sentence that names the free plan when the first one does not", () => {
+    const reading =
+      "Test Manager Premium is $49 /month billed annually. KaneAI Starter is $17 /month billed annually. " +
+      "A free forever plan for Test Manager exists with unlimited projects and 24x7 support.";
+    assert.strictEqual(openingOfTerms(reading, 90), "Test Manager Premium is $49 /month billed annually…");
+    assert.strictEqual(
+      openingOfAReading(reading, 90),
+      "…A free forever plan for Test Manager exists with unlimited projects and 24x7 support.",
+    );
+  });
+
+  it("opens where it always did when the first sentence already says something is free", () => {
+    const reading = "The free tier includes 10K search requests a month and 50K records. Paid plans start at $50.";
+    assert.strictEqual(openingOfAReading(reading, 60), openingOfTerms(reading, 60));
+  });
+
+  it("opens where it always did when no sentence names a free plan", () => {
+    const reading = "Starter plan includes 10 users, 500 test results / month, and 100 prompt execs / month.";
+    assert.strictEqual(openingOfAReading(reading, 40), openingOfTerms(reading, 40));
+  });
+
+  it("marks the opening it moved, so a reader can see it began later than the reading did", () => {
+    const reading = "Pricing starts at $76 a month for 1K sessions. The free tier covers 1,000 sessions a month.";
+    assert.ok(openingOfAReading(reading, 60).startsWith("…"));
+  });
+
+  it("keeps the withholding wherever the record is not a free-tier one", () => {
+    const trialOnly = { ...A_CHANGE_QUOTING_IT, current_state: "Offers a 7-day free trial, no credit card required." };
+    assert.strictEqual(supersedingChange({ ...A_RECORD, tier: "Startup Program" }, [trialOnly]), trialOnly);
+    assert.strictEqual(supersedingChange({ ...A_RECORD, tier: "Free" }, [trialOnly]), null);
+  });
+
+  it("keeps the withholding wherever the reading prices a plan", () => {
+    const priced = { ...A_CHANGE_QUOTING_IT, current_state: "After the trial, plans start at $349 per month." };
+    assert.strictEqual(supersedingChange({ ...A_RECORD, tier: "Free" }, [priced]), priced);
   });
 });
 
@@ -892,9 +1025,48 @@ describe("#1103 every catalogue record whose stored terms are superseded", () =>
     const refusing = withARecordedReading()
       .filter(({ offer, change }) => {
         const meta = unescaped(metaDescriptionOf(bodies.get(`/vendor/${toSlug(offer.vendor)}`)!));
-        return !meta.includes(openingOfTerms(readingBehindTheChange(change)!.terms, 90));
+        return !meta.includes(openingOfAReading(readingBehindTheChange(change)!.terms, 90));
       })
       .map(({ offer }) => offer.vendor);
     assert.deepStrictEqual(refusing.slice(0, 20), []);
+  });
+
+  const readingNamesAFreePlanLaterOn = () =>
+    withARecordedReading().filter(({ change }) => {
+      const terms = readingBehindTheChange(change)!.terms;
+      return whereAFreePlanIsNamed(terms) > 0 && !mentionsSomethingFree(openingOfTerms(terms, 90));
+    });
+
+  it("names the free plan in the meta description wherever the reading names one the opening would miss", () => {
+    const silent = readingNamesAFreePlanLaterOn()
+      .filter(({ offer }) => !mentionsSomethingFree(unescaped(metaDescriptionOf(bodies.get(`/vendor/${toSlug(offer.vendor)}`)!))))
+      .map(({ offer }) => offer.vendor);
+    assert.deepStrictEqual(silent.slice(0, 20), []);
+  });
+
+  it("finds readings that name one, so the assertion above has subjects", () => {
+    assert.ok(readingNamesAFreePlanLaterOn().length >= 4, `${readingNamesAFreePlanLaterOn().length} readings name a free plan the opening would miss`);
+  });
+
+  it("leaves the opening alone wherever it already says something is free", () => {
+    const moved: string[] = [];
+    for (const { offer, change } of withARecordedReading()) {
+      const terms = readingBehindTheChange(change)!.terms;
+      const asBefore = openingOfTerms(terms, 90);
+      if (!mentionsSomethingFree(asBefore)) continue;
+      if (openingOfAReading(terms, 90) !== asBefore) moved.push(offer.vendor);
+    }
+    assert.deepStrictEqual(moved, []);
+  });
+
+  it("withholds our free-tier terms behind no reading that is only a trial", () => {
+    const banners = population
+      .filter(({ offer }) => tierRecordsAFreeTier(offer.tier ?? ""))
+      .filter(({ change }) => {
+        const reading = readingBehindTheChange(change);
+        return reading !== null && describesOnlyATrial(reading.terms);
+      })
+      .map(({ offer }) => offer.vendor);
+    assert.deepStrictEqual(banners.slice(0, 20), []);
   });
 });

--- a/test/vendor-lede-truncation.test.ts
+++ b/test/vendor-lede-truncation.test.ts
@@ -107,16 +107,19 @@ interface Quotation {
 }
 
 function quotationAgainst(route: string, published: string, candidates: readonly string[]): Quotation | null {
+  const excerpted = published.startsWith(CLIP_MARKER);
+  const body = excerpted ? published.slice(CLIP_MARKER.length) : published;
   let best: Quotation | null = null;
   for (const stored of candidates) {
-    const shared = sharedPrefixLength(published, stored);
-    const opening = published.slice(0, shared);
+    const from = excerpted ? stored.indexOf(body.slice(0, 24)) : 0;
+    const rest = from < 0 ? "" : stored.slice(from);
+    const shared = sharedPrefixLength(body, rest);
     const quotation: Quotation = {
       route,
       stored,
-      opening,
-      marked: published.slice(shared).startsWith(CLIP_MARKER),
-      continues: stored.slice(shared),
+      opening: body.slice(0, shared),
+      marked: body.slice(shared).startsWith(CLIP_MARKER),
+      continues: rest.slice(shared),
     };
     if (best === null || quotation.opening.length > best.opening.length) best = quotation;
   }


### PR DESCRIPTION
Refs #1424

## The rule, stated (AC-5)

`src/superseding-reading.ts` holds it, and nothing else in the tree decides this:

- **A sentence names a free plan** when a free price — `free`, `$0`, `€0` — attaches to a plan: `always free`, `free forever`, `free plan / tier / edition / version / account / key / API`, `<plan> is free`, `free for …`, or a zero price per period (`$0 per month`, `Free: $0`).
- **A free price does not count** when a trial, credit, coupon, discount or voucher word sits within 24 characters of it **in the same clause**. `Start for free with $50 in credit for new signups` prices nothing; `KIRO FREE $0 per month 50 credits` prices a plan, because the credits are the allowance rather than the offer.
- **It does not count** when its own clause denies it: `does not`, `no longer`, `only available`, `removing`, `sunsetting`, `deprecated`.
- **A reading describes only a trial** when it names a trial and names neither a free plan nor any plan price.

**Where it will be wrong.** The 24-character window is a judgement, not a law: a sentence that offers a free plan and a trial in the same breath more than 24 characters apart will read as offering the plan, and one that offers them closer together will read as offering neither. The denial list is a word list and will miss a denial phrased another way. Both failures are visible in the census below, which is why it prints every instance rather than a count.

## What changed

**The opening moves to the sentence that names the free plan, where the one we publish names none.** `/vendor/lambdatest` opened `Test Manager Premium is $49 /month billed annually…`; the same reading goes on to say a free forever plan exists. It now opens `…A free forever plan for Test Manager exists with unlimited projects…`, marked at the front so a reader can see it began later than the reading did. **Seven pages move.** Where the opening already says something is free, it is byte-identical — that is AC-3 and there is a test for it.

**A reading that prices nothing but a trial stops superseding a free-tier record.** `/vendor/middleware-io` published `We provide 14 days free trial with unlimited data ingestion` while `middleware.io/pricing`, fetched today, sells `Free Forever $0 — Up to 100GB Data, Up to 1k RUM Sessions, Up to 20k Synthetic Checks`. Figure for figure that is the record we were suppressing. **Nine records stop superseding** and publish their own terms again. The change record is not hidden: the page still carries the `risky` badge, `Why risky: discovered 2026-08-28 — the free tier now offers a 14-day free trial…`, and the full history.

The gate is on the record's own tier — we decline to withhold only where what is being withheld is a free-tier record. A startup-credits record whose reading is a credits reading is untouched.

## Verified by re-reading the cited pages (AC-1)

`scripts/census-1424-superseding-readings.mjs` fetches all 174 cited URLs and classifies the live page, not the stored reading. All 174 answered 200.

| | before | after |
|---|---|---|
| cited page names a free plan | 90 | 90 |
| …and the lede we publish says nothing free | **19** | **12** |
| records superseding | 174 | 165 |

The mechanical count over-reads in both directions, so here are the 12 by hand. **Eight are real and need the record re-read, which no render rule can do**: Apollo GraphOS (the lede sells a $50 credit; the page says `Forever Free`), Cypress Cloud (`any organization you create will be automatically placed on our Free plan`), DBOS (`the open source DBOS Transact library, free forever`), InfluxDB Cloud (`Free Forever Self-managed`), MailerSend (`Free — 500 emails /month`), Rybbit (`Free $0 /mo`), Sematext (`each App can have a different plan, including the free plan`), Sendbird — the one instance in the issue I could not reach, because its reading calls our stored Developer plan a trial and names no free plan anywhere in itself.

**One is a different mechanism and worth its own look**: `/vendor/google-cloud-pub-sub`. Its reading's *first* sentence says the first 10 GiB a month is free, and that sentence is 130 characters long, so the 90-character opening stops before the word. Re-anchoring cannot help — there is nowhere later to go. It needs a longer opening or a clip that reaches for the operative clause.

**Three are the census misreading the page, not us**: Burnermail (the page headline it matched is `Why We're Removing Burner Mail's Free Plan`), LogRocket (`2,000 free API / MCP credits` on the Enterprise tier), Mercury (a perks record, and the page's `$0/month` is business banking).

## The nine that stop superseding (AC-4)

165 of 174 still supersede. Named, with what the cited page says today:

- **Cited page names a free plan** — `Middleware.io`, `ScraperAPI`, `Survicate`, `Tencent RTC`. Restoring the stored terms is what the page supports.
- **Cited page carries free wording that supports the record** — `Coursera` (`courses that you can preview for free`, against a stored `Free audit mode`), `SimplePDF.eu` (`On the free editor, the document stays in your browser`).
- **Cited source is a bare homepage that states no plan at all** — `localazy.com`, `ploi.io`, `Webvizio`. These are `#1110`'s shape as well as this one: the reading is a trial banner and the URL is a homepage. Restoring the record leaves the dated change fully rendered.

`/vendor/positionstack`, the issue's positive control, is unchanged.

## Verification

- **4,204 tests, 0 failures**, 35 new. `main` at `6f2de33` is green, so nothing here is standing red.
- **10 mutants, 10 killed** — `scripts/mutate-1424.sh`.
- Four site-wide properties over the real catalogue rather than over fixtures: no free-tier record withheld behind a trial-only reading; the meta description names the free plan wherever the reading names one the opening would miss; the opening is byte-identical wherever it already said something was free; and the existing `#1421` assertion that a published quotation is a contiguous, marked passage of its reading, widened from prefix to passage so an excerpt still has to be found in the reading it claims.
- Rendered and read on a running server: `/vendor/middleware-io`, `/vendor/scraperapi`, `/vendor/survicate` (terms restored), `/vendor/lambdatest`, `/vendor/terragrunt-scale`, `/vendor/tyk` (opening moved), `/vendor/positionstack` (control). Screenshot checked.
- `data/quality_budgets.json` lowered by the ratchet in this commit: 175→165, 174→164, 165→155.