### PR TITLE
Stop seven vendor pages denying a free tier their own cited page states (#1424)

### DIFF
--- a/data/deal_changes.json
+++ b/data/deal_changes.json
@@ -4799,7 +4799,13 @@
       "category": "Monitoring",
       "alternatives": [],
       "detected_by": "reverify-ai",
-      "recorded_date": "2026-08-28"
+      "recorded_date": "2026-08-28",
+      "resolution": {
+        "state": "retracted",
+        "date": "2026-09-07",
+        "source_url": "https://sematext.com/pricing",
+        "detail": "Retracted 2026-09-07: this record compared two different products on sematext.com/pricing. The stored terms describe the Logs Basic plan, and the page's Logs Basic card still reads \"Retention 7 days\" and \"Daily Volume 500 MB/day\" — both stored figures unchanged. The \"Retention 1 day\" and per-host price this record reports are the Infra Monitoring Basic card, a different product on the same page. The page's FAQ reads \"Each Monitoring App is independent and each App can have a different plan, including the free plan.\""
+      }
     },
     {
       "vendor": "Weaviate",
@@ -4829,7 +4835,13 @@
       "category": "Databases",
       "alternatives": [],
       "detected_by": "reverify-ai",
-      "recorded_date": "2026-08-28"
+      "recorded_date": "2026-08-28",
+      "resolution": {
+        "state": "reversed",
+        "date": "2026-09-07",
+        "source_url": "https://www.influxdata.com/influxdb-pricing/",
+        "detail": "No longer in force as of 2026-09-07: influxdata.com/influxdb-pricing/, the page this record cites, answers \"Is InfluxDB free to use?\" with \"InfluxDB Cloud Serverless also has a free tier with limited data ingestion rates and 30-day retention. Paid plans unlock higher rate limits, unlimited data retention, and enterprise features.\" That is the stored 30-day retention, and the same sentence separates the free tier from the paid plans. The page also sells \"InfluxDB 3 Core — Open source. Local dev, exploration, and prototyping. Free Forever\". The $250 credit and usage-based pricing this record reports are the paid Cloud Serverless plan above that free tier, not in place of it. We hold no evidence either way about the state on 2026-08-28, so this is recorded as no longer in force rather than retracted."
+      }
     },
     {
       "vendor": "Middleware.io",
@@ -5510,7 +5522,13 @@
       "category": "Email",
       "alternatives": [],
       "detected_by": "reverify-ai",
-      "recorded_date": "2026-08-28"
+      "recorded_date": "2026-08-28",
+      "resolution": {
+        "state": "reversed",
+        "date": "2026-09-07",
+        "source_url": "https://www.mailersend.com",
+        "detail": "No longer in force as of 2026-09-07: mailersend.com, the page this record cites, sells a plan named Free — \"Free — For occasional email testing and sending. Get started for free — includes: 500 emails /month, 10 email verification credits, Email threads support, Drag & Drop email builder\" — which is the stored 500 emails/month figure. The 14-day Professional trial this record reports is a separate hero bullet on the same page: \"14-day free Professional trial • Send 500 emails/month for free\". We hold no evidence either way about the state on 2026-08-28, so this is recorded as no longer in force rather than retracted."
+      }
     },
     {
       "vendor": "mailinator.com",
@@ -6461,7 +6479,13 @@
       "category": "Communication",
       "alternatives": [],
       "detected_by": "reverify-ai",
-      "recorded_date": "2026-08-28"
+      "recorded_date": "2026-08-28",
+      "resolution": {
+        "state": "reversed",
+        "date": "2026-09-07",
+        "source_url": "https://sendbird.com/pricing/chat",
+        "detail": "No longer in force as of 2026-09-07: sendbird.com/pricing/chat, the page this record cites, answers \"Is the Sendbird Developer plan free forever?\" with \"Yes, the Developer plan is free and remains active as long as you log into the Sendbird dashboard once a year.\" The column the page now labels Free trial carries the stored Developer figures — \"MAUs Up to 1,000\" and \"Peak concurrent connections Up to 20\" — priced \"Free\", with \"No credit card required\" and \"All pro features\". The page disagrees with itself about the label and agrees with us about the terms, so the label alone is not grounds to withhold them. We hold no evidence either way about the state on 2026-08-28, so this is recorded as no longer in force rather than retracted."
+      }
     },
     {
       "vendor": "Expo",
@@ -6686,7 +6710,13 @@
       "category": "API Development",
       "alternatives": [],
       "detected_by": "reverify-ai",
-      "recorded_date": "2026-08-28"
+      "recorded_date": "2026-08-28",
+      "resolution": {
+        "state": "retracted",
+        "date": "2026-09-07",
+        "source_url": "https://www.apollographql.com/pricing",
+        "detail": "Retracted 2026-09-07: this record read two columns of apollographql.com/pricing as one. The page's Free column reads \"Free — For students or hobbyists learning the latest GraphQL tools. Forever Free. Start for free. No credit card required\", with \"Total users (includes consumers) Up to 3\", \"Data retention for checks and insights 1 day\" and a \"Self-hosted GraphOS Router (limited to 60 requests per minute)\" — the stored terms figure for figure. The \"$50 in usage credit when you sign up\" and \"Credit card required\" this record reports are the Developer column and the page hero. The record contradicts itself on the point: its own reading says \"No credit card required\" while its summary says the free tier now requires one."
+      }
     },
     {
       "vendor": "PrefectCloud",
@@ -7906,7 +7936,13 @@
       "category": "Background Jobs",
       "alternatives": [],
       "detected_by": "reverify-ai",
-      "recorded_date": "2026-09-03"
+      "recorded_date": "2026-09-03",
+      "resolution": {
+        "state": "retracted",
+        "date": "2026-09-07",
+        "source_url": "https://n8n.io/pricing/",
+        "detail": "Retracted 2026-09-07: this record reports a removal that the terms it supersedes already state. Its previous_state — our stored description — reads \"Cloud free plan removed; all Cloud plans require payment (14-day free trial available)\", and the removal itself is recorded on this vendor at 2026-04-14. Our free tier here is the self-hosted build, which this record's own reading confirms: \"A standard, self-hosted version of n8n is available on GitHub.\" Nothing changed between the stored terms and the reading."
+      }
     },
     {
       "vendor": "Figma",
@@ -8456,9 +8492,9 @@
       "change_type": "limits_reduced",
       "date": "2026-09-05",
       "date_source": "discovered",
-      "summary": "The Starter tier now includes 10 users instead of 50, and 500 test results/month instead of 100 prompt executions/month.",
+      "summary": "The Starter tier, which is free, now includes 10 users instead of 50, and carries a new limit of 100 prompt executions/month. Test results stay at 500/month.",
       "previous_state": "50 users, 500 test results/month, 30-day data retention. Parallelization included. Separate OSS plan available (100K results/mo) via application",
-      "current_state": "Starter plan includes 10 users, 500 test results / month, and 100 prompt execs / month.",
+      "current_state": "Starter is priced Free with no credit card required, and now includes 10 users, 500 test results / month and 100 prompt execs / month. The compare table prices Team at $799 / year and Business at $3,199 / year, and Cypress Cloud remains free to use for non-commercial open-source public projects.",
       "impact": "high",
       "source_url": "https://www.cypress.io/pricing",
       "category": "Testing",

--- a/data/index.json
+++ b/data/index.json
@@ -9366,7 +9366,7 @@
       "category": "Productivity & Notes",
       "description": "Free for 5 users with 1 GB upload limit & 5GB storage. Zoho Office Suite (Writer, Sheets & Show) comes bundled.",
       "tier": "Free",
-      "url": "https://zoho.com/docs",
+      "url": "https://www.zoho.com/workdrive/pricing.html",
       "tags": [
         "productivity",
         "free-for-dev"
@@ -10586,7 +10586,7 @@
       "category": "Dev Utilities",
       "description": "Stock market and financial data API. Free plan allows 300 requests per day.",
       "tier": "Free",
-      "url": "https://financialdata.net/",
+      "url": "https://financialdata.net/pricing",
       "tags": [
         "developer-tools",
         "free-for-dev"
@@ -11404,7 +11404,7 @@
       "category": "Notebooks & Data Science",
       "description": "A complete platform for dataflow automation. Free plan includes 5 deployed workflows and 500 minutes of serverless compute credits per month.",
       "tier": "Free",
-      "url": "https://www.prefect.io/cloud/",
+      "url": "https://www.prefect.io/pricing",
       "tags": [
         "developer-tools",
         "free-for-dev"
@@ -12887,7 +12887,7 @@
       "category": "Storage",
       "description": "simplest, fastest and safest interface to transfer and share files. Send photos, videos and other large files without a manditory subscription.",
       "tier": "Free",
-      "url": "https://www.transfernow.net/",
+      "url": "https://www.transfernow.net/en/prices",
       "tags": [
         "developer-tools",
         "free-for-dev"
@@ -13398,7 +13398,7 @@
     {
       "vendor": "beanstalkapp.com",
       "category": "Source Control",
-      "description": "A complete workflow to write, review, and deploy code), a free account for one user, and one repository with 100 MB of storage",
+      "description": "A complete workflow to write, review, and deploy code, a free account for one user, and one repository with 100 MB of storage",
       "tier": "Free",
       "url": "https://beanstalkapp.com/",
       "tags": [
@@ -14049,7 +14049,7 @@
       "category": "CI/CD",
       "description": "GitOps-first Terraform automation with pull request-driven workflows, project isolation via self-hosted runners, and layered runs for ordered operations. Free for unlimited users with unlimited runs and runners.",
       "tier": "Free",
-      "url": "https://terrateam.io",
+      "url": "https://terrateam.io/pricing",
       "tags": [
         "ci",
         "cd",
@@ -14455,7 +14455,7 @@
       "category": "Testing",
       "description": "Build scalable UIs in Java or TypeScript, and use the integrated tooling, components, and design system to iterate faster, design better, and simplify the development process. Unlimited Projects with five years of free maintenance.",
       "tier": "Free",
-      "url": "https://vaadin.com",
+      "url": "https://vaadin.com/pricing",
       "tags": [
         "testing",
         "qa",
@@ -15404,7 +15404,7 @@
       "category": "Server Management",
       "description": "Server management tool to easily manage and deploy your servers & sites. Free for one server.",
       "tier": "Free",
-      "url": "https://ploi.io/",
+      "url": "https://ploi.io/pricing",
       "tags": [
         "developer-tools",
         "free-for-dev"
@@ -15837,7 +15837,7 @@
       "category": "Logging",
       "description": "Self-hosted Enterprise free up to 50 GB/day ingestion; open-source self-hosted free with no usage limits",
       "tier": "Free",
-      "url": "https://openobserve.ai/",
+      "url": "https://openobserve.ai/pricing",
       "tags": [
         "logging",
         "log-management",
@@ -15924,7 +15924,7 @@
       "category": "Localization",
       "description": "Free for 1000 source language strings, unlimited languages, unlimited contributors, startup and open source deals",
       "tier": "Free",
-      "url": "https://localazy.com",
+      "url": "https://localazy.com/pricing",
       "tags": [
         "developer-tools",
         "free-for-dev"
@@ -16729,7 +16729,7 @@
       "category": "Monitoring",
       "description": "Powerful server monitoring in a unified platform for metrics and logs, with no setup complexity. Free for one server.",
       "tier": "Free",
-      "url": "https://simpleobservability.com",
+      "url": "https://simpleobservability.com/pricing",
       "tags": [
         "monitoring",
         "observability",
@@ -22650,7 +22650,7 @@
       "category": "Storage",
       "description": "Hosted Package Repositories for YUM, APT, RubyGem and PyPI. Limited free plans and open-source plans are available via request",
       "tier": "Free",
-      "url": "https://packagecloud.io/",
+      "url": "https://packagecloud.io/pricing",
       "tags": [
         "storage",
         "media",
@@ -22668,7 +22668,7 @@
       "category": "Storage",
       "description": "Pinata is the simplest way to upload and manage files on IPFS. Our friendly user interface and IPFS API make Pinata the easiest IPFS pinning service for platforms, creators, and collectors. 1 GB storage free, along with access to API.",
       "tier": "Free",
-      "url": "https://pinata.cloud",
+      "url": "https://pinata.cloud/pricing",
       "tags": [
         "storage",
         "media",
@@ -24262,7 +24262,7 @@
       "category": "Design",
       "description": "Low-code Front-end Design & Development Platform. TeleportHQ is the collaborative front-end platform to instantly create and publish headless static websites. Three free projects, unlimited collaborators, and free code export.",
       "tier": "Free",
-      "url": "https://teleporthq.io/",
+      "url": "https://teleporthq.io/pricing",
       "tags": [
         "design",
         "ui",
@@ -24785,7 +24785,7 @@
       "category": "Maps/Geolocation",
       "description": "Free geocoding for global places and coordinates. 25,000 Requests per month for personal use.",
       "tier": "Free",
-      "url": "https://positionstack.com/",
+      "url": "https://positionstack.com/pricing",
       "tags": [
         "maps",
         "geolocation",
@@ -28737,7 +28737,7 @@
     {
       "vendor": "GOOGLE ADS",
       "category": "Startup Perks",
-      "description": "Up to $150 in Google Ads credit.. Access via: Free for Brex customers",
+      "description": "Up to $150 in Google Ads credit. Access via: Free for Brex customers",
       "tier": "Startup Program",
       "url": "https://brex.com/rewards/",
       "tags": [

--- a/data/index.json
+++ b/data/index.json
@@ -9649,7 +9649,7 @@
     {
       "vendor": "DBOS",
       "category": "Workflow Automation",
-      "description": "Open-source durable workflow orchestration library (DBOS Transact) — free forever for TypeScript, Python, Go, Java, Kotlin. Self-host with PostgreSQL backend; community support via Discord. Managed DBOS Cloud is paid-only (Pro from $99/mo: 3 seats, 5 apps, 1M checkpoints/mo).",
+      "description": "Open-source durable workflow orchestration library (DBOS Transact) — free forever for TypeScript, Python, Go, Java, Kotlin. Self-host with PostgreSQL backend; community support via Discord. Managed DBOS Cloud is paid-only (Pro from $99/mo: 2 seats, 3 apps, 1M checkpoints/mo).",
       "tier": "Free (open-source library; managed cloud is paid-only)",
       "url": "https://www.dbos.dev/pricing",
       "tags": [


### PR DESCRIPTION
Refs https://github.com/robhunter/agentdeals/issues/1424

https://github.com/robhunter/agentdeals/pull/1427 fixed the render rule and named eight cases it could not reach, because the fix has to be in the record rather than in how the record is displayed. This is those eight, re-read against the cited pages on 2026-09-07, plus one the census could not have found.

## The rule I adjudicated by

Stated up front because the last three of these I did by eye, which is not reproducible.

- **Retract** where the record's own text identifies the error — a reading that contradicts its own summary, a reading quoting a different product's plan card, a reading of a change our stored terms already record. `retracted` asserts the event never happened, so it needs evidence from inside the record, not just today's page.
- **Reverse** where today's cited page states a free tier and I hold no evidence about the state on the detection date. This follows the wording already used on Uploadthing and Google Gemini API.
- **Correct the reading** where the change is real and only the sentence chosen is wrong.
- **Absorb** where the change is real and does not touch the free-tier claim — bring the stored record current so it stops superseding.

## Retracted

| vendor | what the record says | what its own text shows |
|---|---|---|
| Apollo GraphOS | free tier "requires a credit card" | its own reading says `No credit card required`. The `$50 in usage credit` is the Developer column; the Free column reads `Forever Free`, `Up to 3` users, `1 day` retention, router `limited to 60 requests per minute` — the stored terms figure for figure |
| Sematext | `1 day` retention, priced per host | that is the Infra Monitoring Basic card. The stored terms are Logs Basic, whose card still reads `Retention 7 days` and `Daily Volume 500 MB/day` |
| n8n | "The cloud free plan has been removed." | its `previous_state` — our stored description — already reads `Cloud free plan removed; all Cloud plans require payment`. The removal is recorded on the same vendor at 2026-04-14 |

## Reversed

The cited page states a free tier today; the past state is not something I can check.

| vendor | the cited page, 2026-09-07 |
|---|---|
| MailerSend.com | `Free — For occasional email testing and sending. Get started for free — includes: 500 emails /month` — the stored figure. The 14-day Professional trial is a separate hero bullet |
| InfluxDB Cloud | `Is InfluxDB free to use?` → `InfluxDB Cloud Serverless also has a free tier with limited data ingestion rates and 30-day retention. Paid plans unlock higher rate limits` — the stored retention, and the same sentence separates the free tier from the paid plans |
| Sendbird | `Is the Sendbird Developer plan free forever?` → `Yes, the Developer plan is free and remains active as long as you log into the Sendbird dashboard once a year.` The column now labelled Free trial carries `MAUs Up to 1,000` and `Peak concurrent connections Up to 20` at `Free`, `No credit card required` |

Sendbird is the one this issue said I could not reach. The page disagrees with itself about the label and agrees with us about the terms, so the label alone is not grounds to withhold them.

## Reading corrected, record still superseding

**Cypress Cloud.** The reduction is real — 50 users to 10 — so the record stands. The reading named no price at all, which is why the page denied a free tier. `cypress.io/pricing` reads `Start Here — Starter — For teams experienced in testing with Cypress App — Free — No credit card required`, and the compare table prices Team at $799 / year. The old summary said the tier now includes "500 test results/month instead of 100 prompt executions/month", which is not a comparison; it now says test results stay at 500 and the 100 prompt executions are a new limit.

## Absorbed

**DBOS.** The paid-plan restructure is real and correctly recorded. It does not touch our free-tier claim, which `dbos.dev/dbos-pricing` still states as `Use the open source DBOS Transact library, free forever`. The stored record was carrying stale Pro figures (3 seats, 5 apps) against a page that sells 2 seats and 3 apps, so bringing it current is what ends the supersession — the designed exit, and the change record stays in the history with its badge.

## The one the census could not find (a second defect in #1427's gate)

The trial-only gate is `tierRecordsAFreeTier(offer.tier)`, which keys on the tier string. **140 catalogue records classify as free and are not covered by it** — `Self-Hosted`, `Starter / Open Source`, `OSS`, `Individual`, `Lite`, `Hacker`, `Maker Account`, `Hatch` and others. Most are perks and credits records where the gate is correctly off.

**One is live: n8n**, tier `Self-Hosted`, superseded behind a trial-only reading that the gate skipped. Retracted above on separate grounds. I am not proposing widening the label set — the tier strings are a long tail and the perks cases are meant to be excluded. Flagging it so the gate's coverage is a known quantity rather than an assumed one.

## Rybbit is not a defect

`rybbit.com/pricing` sells Standard at $13/month as the lowest plan, with a 7-day trial and `Start for $0` as the trial CTA. The `Free $0 /mo` the census matched is on the homepage **inside the session-replay feature demo** — a mock of a pricing page, rendered to show what session replay looks like. Same shape as reading the wrong tab: the bytes are on the page and belong to something else. The `free_tier_removed` record is correct and untouched.

## Verification

- **302 tests pass** across `superseded-terms`, `change-resolution`, `change-lineup`, `change-summary`, `meta-description-withholding`, `page-lede`, `badge-withholding`, `deal-changes` and `change-structured-data`. `validate-data` green, 1,580 offers and 552 changes.
- **Records superseding: 165 → 158.** `positionstack`, the issue's positive control, is unchanged and still withholds.
- **`verifiedDate` untouched throughout.** Each resolution carries its own dated `detail` naming what I read and when, which is the honest record; `verifiedDate` means a liveness check in a pipeline I did not run.
- **Budgets left alone.** They are ceilings, the assertion is `<=`, and this change only lowers the count, so nothing here needs them moved. I did not run `npm run ratchet:budgets`: it measures from `dist/`, my workspace's `dist/` predated #1427, and it therefore read 167 rather than 158. That is my workspace, not a defect — `gate-data-push.sh` runs `npm run build` before it ratchets, and these three budgets are in `QUALITY_BUDGETS_A_DATA_RUN_MAY_RAISE` precisely so a re-verification run can raise them. Lower them from a built tree whenever suits.

## What remains open on #1424

AC-1 asks for no vendor page publishing a superseding reading that denies a free tier its source states. Between #1427 and this, the eight named instances are gone. The mechanical census over-reads in both directions, so the honest statement is that the confirmed instances are cleared, not that the property holds.

