### PR TITLE
Price Backblaze B2 at the rate it publishes, including the 3x free egress allowance (#1430)

### DIFF
--- a/src/serve.ts
+++ b/src/serve.ts
@@ -34,6 +34,7 @@ import { UNGRADED_IMPACT_COLOR, changeImpactColor, changeImpactLabel, changeImpa
 import { COMPARED_SERVICES_PLACEHOLDER, fillComparedServicesCount, markCompiledFigures, recordsSinceCompiled, replaceTimelineRows, timelineRecordsFor, vendorForSubject, vendorSubjectsOnCompiledPage, type CompiledFigureSubject, type CompiledFigureVendor, type CompiledFigureVerdict } from "./compiled-figures.js";
 import { vendorHistorySentence } from "./vendor-history.js";
 import { HETZNER_APRIL_CHANGES, HETZNER_CLOUD_PLANS, HETZNER_PRICES_READ, HETZNER_PRICE_SOURCE, HETZNER_SINGAPORE_EXAMPLE, cheapestOrderableHetznerPlan, hetznerEntryPriceClause, unorderableHetznerPlans } from "./hetzner-pricing.js";
+import { HUNDRED_TB_SCENARIO, ONE_TO_ONE_SCENARIO, STORAGE_RATES_READ, STORAGE_SCALE_WORKLOADS, TEN_TO_ONE_SCENARIO, cheapestProviderAt, costliestProviderAt, egressAllowanceSentence, egressBillOnceOverAllowance, egressRatioWhereCostsMatch, fixedMonthlyGrantsSentence, monthlyStorageCost, providersWithScalingEgressAllowance, rateCardFor, scaleCostFor } from "./storage-cost-model.js";
 import { changeTimelineDate, supersededLineups, supersessionNote } from "./change-lineup.js";
 import { isNoLongerInForce, eventResolutionFields } from "./change-resolution.js";
 import { changeIsUncited, changeSourceCitation, changeSourceLinkHtml, citedChanges, uncitedChangeNotice, ratingWithheldForNoSourceClause, ratingWithheldForNoSourceSentence, UNCITED_CHANGE_LABEL } from "./change-citation.js";
@@ -3224,15 +3225,15 @@ const VS_PAGES: VsPageConfig[] = [
   {
     vendorA: "Backblaze B2", vendorB: "Cloudflare R2",
     category: "Storage",
-    verdict: "Cloudflare R2 is the clear winner for most use cases: zero egress fees make it dramatically cheaper at scale. Backblaze B2 offers free egress through Cloudflare CDN but requires extra setup. Both offer 10 GB free storage with S3 compatibility.",
+    verdict: `Which one is cheaper depends on how much you read relative to what you store. Backblaze B2 stores at ${rateCardFor("Backblaze B2").publishedStorageRate} and gives every account free egress up to 3x its average monthly storage, so a workload inside that ratio pays ${scaleCostFor("Backblaze B2", ONE_TO_ONE_SCENARIO)} per TB against Cloudflare R2's ${scaleCostFor("Cloudflare R2", ONE_TO_ONE_SCENARIO)} — no CDN required. Past roughly ${b2CrossoverRatio()}x egress-to-storage, R2's flat zero-egress rate wins and keeps winning. Both offer 10 GB free storage with S3 compatibility.`,
     keyDifferences: `<ul>
-      <li><strong>Egress:</strong> R2 has zero egress fees — always. B2 charges for egress ($0.01/GB) but offers free egress through Cloudflare CDN via the Bandwidth Alliance. R2's zero-egress is simpler and more predictable.</li>
-      <li><strong>Free tier:</strong> Both offer 10 GB free storage. R2 includes 1M writes and 10M reads/month. B2's allowances are similar but structured differently.</li>
-      <li><strong>At scale:</strong> At 1 TB stored + 10 TB egress, R2 costs ~$15/month vs B2 at ~$60/month (without CDN) or ~$15/month (with Cloudflare CDN). R2 is cheaper out of the box.</li>
+      <li><strong>Egress:</strong> R2 has zero egress fees — always, at every ratio. B2's egress is free up to 3x average monthly storage, $0.01/GB above that, and unmetered through a partner CDN (Cloudflare, Fastly, bunny.net and others). R2's model is simpler to predict; B2's is cheaper until reads reach about ${b2CrossoverRatio()}x storage.</li>
+      <li><strong>Free tier:</strong> Both offer 10 GB free storage. R2 includes 1M writes and 10M reads/month. B2 makes Class A, B and C API calls free on pay-as-you-go.</li>
+      <li><strong>At scale:</strong> At 1 TB stored + 1 TB egress, B2 costs ${scaleCostFor("Backblaze B2", ONE_TO_ONE_SCENARIO)}/month against R2's ${scaleCostFor("Cloudflare R2", ONE_TO_ONE_SCENARIO)} — the read is inside B2's allowance and costs nothing to serve. Raise the read to 10 TB against the same 1 TB stored and it flips: B2 is ${scaleCostFor("Backblaze B2", TEN_TO_ONE_SCENARIO)} (3 TB free, 7 TB at $0.01/GB) against R2's unchanged ${scaleCostFor("Cloudflare R2", TEN_TO_ONE_SCENARIO)}.</li>
       <li><strong>Ecosystem:</strong> R2 integrates natively with Cloudflare Workers, Pages, and the broader Cloudflare ecosystem. B2 is a standalone storage service.</li>
     </ul>`,
-    recommendation: `<p><strong>Choose Cloudflare R2 if</strong> you want zero egress fees without any CDN configuration, are already in the Cloudflare ecosystem, or want the simplest S3-compatible storage pricing.</p>
-    <p><strong>Choose Backblaze B2 if</strong> you already use Backblaze for backups, need their B2 lifecycle rules, or prefer a storage-focused provider independent of CDN vendors.</p>`,
+    recommendation: `<p><strong>Choose Cloudflare R2 if</strong> your reads far outrun your storage — streaming, downloads, a viral static asset — or you are already in the Cloudflare ecosystem and want one rate to reason about at any ratio.</p>
+    <p><strong>Choose Backblaze B2 if</strong> your egress stays within a few multiples of what you store, which covers most archives, backups and application storage: it is less than half R2's price there. Also if you already use Backblaze for backups or need their B2 lifecycle rules.</p>`,
   },
   {
     vendorA: "Cloudinary", vendorB: "ImageKit",
@@ -11622,7 +11623,7 @@ ${buildCards(other)}
         <td style="font-weight:600"><a href="/vendor/backblaze-b2" style="color:var(--text)">Backblaze B2</a></td>
         <td>Object Storage</td>
         <td>10 GB</td>
-        <td>1 GB/day free</td>
+        <td>Free to 3x storage</td>
         <td>Affordable S3-compatible storage</td>
       </tr>
       <tr>
@@ -11698,7 +11699,7 @@ ${buildCards(other)}
     </tbody>
   </table>
   </div>
-  <p style="color:var(--text-dim);font-size:.8rem;margin-top:.5rem">Cloudflare R2 leads on value with 10 GB free and zero egress fees \u2014 a game-changer for read-heavy workloads. Backblaze B2 matches on storage but charges for egress beyond 1 GB/day. For media, Cloudinary and ImageKit both offer generous transformation pipelines. MinIO is the go-to for self-hosted S3-compatible storage. All limits verified against live pricing pages, March 2026.</p>
+  <p style="color:var(--text-dim);font-size:.8rem;margin-top:.5rem">Cloudflare R2 leads on value with 10 GB free and zero egress fees \u2014 a game-changer for read-heavy workloads. Backblaze B2 undercuts it on storage and serves up to 3x what you store for nothing, charging $0.01/GB only past that. For media, Cloudinary and ImageKit both offer generous transformation pipelines. MinIO is the go-to for self-hosted S3-compatible storage. All limits verified against live pricing pages, March 2026.</p>
 
   <h2>Which Free Storage Should I Use?</h2>
   <div class="decision-guide">
@@ -11707,7 +11708,7 @@ ${buildCards(other)}
       <dd><a href="/vendor/cloudflare-r2">Cloudflare R2</a> \u2014 10 GB free storage, 1M Class B reads/month, and zero egress fees. The best deal for read-heavy workloads like static assets, backups, or media serving.</dd>
 
       <dt>Want affordable S3-compatible storage?</dt>
-      <dd><a href="/vendor/backblaze-b2">Backblaze B2</a> \u2014 10 GB free, simple pricing at $6/TB beyond that. Pairs well with Cloudflare CDN (Bandwidth Alliance = free egress). <a href="/vendor/tigris">Tigris</a> is a newer S3-compatible option with global distribution.</dd>
+      <dd><a href="/vendor/backblaze-b2">Backblaze B2</a> \u2014 10 GB free, simple pricing at $6.95/TB beyond that, with egress free up to 3x what you store and unmetered through a partner CDN such as Cloudflare. <a href="/vendor/tigris">Tigris</a> is a newer S3-compatible option with global distribution.</dd>
 
       <dt>Building an image-heavy app?</dt>
       <dd><a href="/vendor/cloudinary">Cloudinary</a> for the most mature transformation pipeline (25 credits/month free). <a href="/vendor/imagekit">ImageKit</a> for 20 GB bandwidth/month. Both handle upload, resize, format conversion, and CDN delivery.</dd>
@@ -15953,7 +15954,7 @@ function buildFreeNextjsStackPage(): string {
       icon: "📦",
       recommended: { vendor: "Cloudflare R2", why: "Zero egress fees — the standout differentiator. 10 GB storage, 1 million Class A operations, 10 million Class B operations per month. S3-compatible API means any S3 SDK works. Perfect for Next.js image uploads, user files, and static assets that would cost a fortune on S3 egress." },
       alternatives: ["Backblaze B2", "Tigris", "Supabase"],
-      outgrow: "When you exceed 10 GB storage. At scale, R2 saves dramatically: 1 TB stored + 10 TB egress costs ~$15/month on R2 vs ~$925/month on S3 (the egress tax). Backblaze B2 offers 10 GB free with free egress via Cloudflare CDN. Tigris gives 5 GB with S3 compatibility and global distribution.",
+      outgrow: "When you exceed 10 GB storage. At scale, R2 saves dramatically: 1 TB stored + 10 TB egress costs ~$15/month on R2 vs ~$925/month on S3 (the egress tax). Backblaze B2 offers 10 GB free and free egress up to 3x what you store, no CDN required. Tigris gives 5 GB with S3 compatibility and global distribution.",
       whyNot: "Why not AWS S3: The 5 GB free tier expires after 12 months, then egress costs $0.09/GB. At 100 GB egress/month, that's $9/month just for bandwidth — R2 charges $0.",
       relatedPage: "/storage-comparison-2026",
     },
@@ -16325,7 +16326,7 @@ function buildFreeDjangoStackPage(): string {
       icon: "📦",
       recommended: { vendor: "Cloudflare R2", why: "Zero egress fees — the standout differentiator. 10 GB storage, 1 million Class A operations, 10 million Class B operations per month. S3-compatible API means django-storages works out of the box with the S3Boto3Storage backend. Perfect for Django file uploads (ImageField, FileField), static file hosting (collectstatic), and media storage." },
       alternatives: ["Backblaze B2", "Supabase", "Cloudflare"],
-      outgrow: "When you exceed 10 GB storage. At scale, R2 saves dramatically vs S3: 1 TB stored + 10 TB egress costs ~$15/month on R2 vs ~$925/month on S3. Backblaze B2 offers 10 GB free with free egress via Cloudflare CDN — also works with django-storages. Supabase Storage gives 1 GB free with image transformations.",
+      outgrow: "When you exceed 10 GB storage. At scale, R2 saves dramatically vs S3: 1 TB stored + 10 TB egress costs ~$15/month on R2 vs ~$925/month on S3. Backblaze B2 offers 10 GB free and free egress up to 3x what you store, no CDN required — also works with django-storages. Supabase Storage gives 1 GB free with image transformations.",
       whyNot: "Why not AWS S3: The 5 GB free tier expires after 12 months, then egress costs $0.09/GB. Django apps serving user-uploaded media can rack up egress costs quickly — R2 charges $0.",
       relatedPage: "/storage-comparison-2026",
     },
@@ -16735,7 +16736,7 @@ function buildFreeFastapiStackPage(): string {
       icon: "📦",
       recommended: { vendor: "Cloudflare R2", why: "Zero egress fees — the standout differentiator. 10 GB storage, 1 million Class A operations, 10 million Class B operations per month. S3-compatible API means boto3 and aioboto3 work directly. FastAPI's UploadFile with async streaming to R2 handles file uploads efficiently without buffering entire files in memory." },
       alternatives: ["Backblaze B2", "Supabase"],
-      outgrow: "When you exceed 10 GB storage. At scale, R2 saves dramatically vs S3: 1 TB stored + 10 TB egress costs ~$15/month on R2 vs ~$925/month on S3. Backblaze B2 offers 10 GB free with free egress via Cloudflare CDN. Supabase Storage gives 1 GB free with image transformations.",
+      outgrow: "When you exceed 10 GB storage. At scale, R2 saves dramatically vs S3: 1 TB stored + 10 TB egress costs ~$15/month on R2 vs ~$925/month on S3. Backblaze B2 offers 10 GB free and free egress up to 3x what you store, no CDN required. Supabase Storage gives 1 GB free with image transformations.",
       whyNot: "Why not AWS S3: The 5 GB free tier expires after 12 months, then egress costs $0.09/GB. API services returning pre-signed URLs for large files can rack up egress costs quickly — R2 charges $0.",
       relatedPage: "/storage-comparison-2026",
     },
@@ -17160,7 +17161,7 @@ function buildFreeGoStackPage(): string {
       icon: "📦",
       recommended: { vendor: "Cloudflare R2", why: "Zero egress fees — the standout differentiator. 10 GB storage, 1 million Class A operations, 10 million Class B operations per month. S3-compatible API via aws-sdk-go-v2. Go's io.Reader/io.Writer interfaces make streaming uploads and downloads natural — no buffering entire files in memory. Multipart uploads work out of the box with the AWS SDK." },
       alternatives: ["Backblaze B2", "Supabase"],
-      outgrow: "When you exceed 10 GB storage. At scale, R2 saves dramatically vs S3: 1 TB stored + 10 TB egress costs ~$15/month on R2 vs ~$925/month on S3. Backblaze B2 offers 10 GB free with free egress via Cloudflare CDN. Supabase Storage gives 1 GB free with image transformations.",
+      outgrow: "When you exceed 10 GB storage. At scale, R2 saves dramatically vs S3: 1 TB stored + 10 TB egress costs ~$15/month on R2 vs ~$925/month on S3. Backblaze B2 offers 10 GB free and free egress up to 3x what you store, no CDN required. Supabase Storage gives 1 GB free with image transformations.",
       whyNot: "Why not AWS S3: The 5 GB free tier expires after 12 months, then egress costs $0.09/GB. Go services returning pre-signed URLs for large files can rack up egress costs quickly — R2 charges $0.",
       relatedPage: "/storage-comparison-2026",
     },
@@ -17602,7 +17603,7 @@ function buildFreeSaasStackPage(): string {
       icon: "\u{1F4E6}",
       recommended: { vendor: "Cloudflare R2", why: "10 GB storage with zero egress fees \u2014 the only major storage provider that doesn't charge for bandwidth. S3-compatible API works with every SDK and library. For SaaS, this means user uploads (avatars, documents, images) cost nothing to serve, no matter how many times they're downloaded. No surprise bandwidth bills." },
       alternatives: ["Backblaze B2", "Supabase"],
-      outgrow: "When you exceed 10 GB storage or 1M Class A operations/month. R2's zero-egress model means the constraint is storage volume, not bandwidth \u2014 a SaaS serving 1 TB of user files still pays $0 in egress. At scale: 100 GB costs ~$1.50/mo on R2 vs ~$9/mo on S3 (plus $9/GB egress on S3). Backblaze B2 offers 10 GB free with free egress via Cloudflare CDN.",
+      outgrow: "When you exceed 10 GB storage or 1M Class A operations/month. R2's zero-egress model means the constraint is storage volume, not bandwidth \u2014 a SaaS serving 1 TB of user files still pays $0 in egress. At scale: 100 GB costs ~$1.50/mo on R2 vs ~$9/mo on S3 (plus $9/GB egress on S3). Backblaze B2 offers 10 GB free and free egress up to 3x what you store, no CDN required.",
       whyNot: "Why not AWS S3: The 5 GB free tier expires after 12 months, then egress costs $0.09/GB. A SaaS serving user-uploaded files can accumulate significant egress costs. R2 charges $0 for egress, forever. Why not Vercel Blob: 250 MB free \u2014 too small for most SaaS file storage needs.",
       relatedPage: "/storage-comparison-2026",
       isFrameworkSection: false,
@@ -41214,6 +41215,43 @@ ${mcpCtaCss()}
 </html>`, pubDate, monitoringChanges);
 }
 
+const STORAGE_SCALE_COLUMNS = ["Cloudflare R2", "AWS S3", "Backblaze B2", "Google Cloud Storage"];
+
+function b2CrossoverRatio(): number {
+  const crossover = egressRatioWhereCostsMatch(rateCardFor("Backblaze B2"), rateCardFor("Cloudflare R2"));
+  if (crossover === null) throw new Error("Backblaze B2 and Cloudflare R2 costs do not cross at any egress ratio");
+  return crossover;
+}
+
+function storageScaleTableRows(): string {
+  return STORAGE_SCALE_WORKLOADS.map(workload => {
+    const cheapest = cheapestProviderAt(workload);
+    const costliest = costliestProviderAt(workload);
+    const cells = STORAGE_SCALE_COLUMNS.map(provider => {
+      const emphasis = provider === cheapest ? ' class="cheapest"' : provider === costliest ? ' class="expensive"' : "";
+      return `        <td${emphasis}>${scaleCostFor(provider, workload)}</td>`;
+    }).join("\n");
+    return `      <tr>
+        <td><strong>${workload.label}</strong></td>
+${cells}
+        <td>${workload.selfHostedEstimate}</td>
+      </tr>`;
+  }).join("\n");
+}
+
+function storageScalingAllowanceSentence(): string {
+  const scaling = providersWithScalingEgressAllowance();
+  if (scaling.length === 0) return "No provider here publishes an egress allowance that scales with what you store.";
+  const named = scaling.map(card => egressAllowanceSentence(card)).join(" ");
+  return `${named} No other column has an allowance that scales, so their egress bills at the headline rate from the first byte.`;
+}
+
+function storageScaleSpreadClause(): string {
+  const costliest = monthlyStorageCost(rateCardFor(costliestProviderAt(HUNDRED_TB_SCENARIO)), HUNDRED_TB_SCENARIO);
+  const cheapest = monthlyStorageCost(rateCardFor(cheapestProviderAt(HUNDRED_TB_SCENARIO)), HUNDRED_TB_SCENARIO);
+  return `${Math.round(costliest / cheapest)}x gap`;
+}
+
 function buildStorageComparison2026Page(): string {
   const title = "Storage & CDN Comparison 2026 — S3 vs R2 vs B2 vs Supabase Storage vs Cloudinary";
   const metaDescStorage = "Comprehensive comparison of 15+ storage and CDN free tiers in 2026. AWS S3, Cloudflare R2, Backblaze B2, Tigris, Storj, Supabase Storage, Cloudinary, ImageKit, BunnyCDN, MinIO — storage limits, egress fees, S3 compatibility, CDN, and the S3 egress tax at scale.";
@@ -41381,7 +41419,7 @@ ${mcpCtaCss()}
   </div>
 
   <div class="executive-summary">
-    <p><strong>Quick verdict:</strong> <strong>Cloudflare R2</strong> is the standout choice for most developers &mdash; 10 GB storage with zero egress fees, S3-compatible API, and a permanent free tier. At scale, the savings are staggering: 5 TB stored + 50 TB egress costs $75/month on R2 vs $4,625/month on S3. <strong>Storj</strong> offers the largest starting capacity at 25 GB, but as a 30-day trial rather than a free tier &mdash; a $5 minimum monthly fee applies once it ends. <strong>Backblaze B2</strong> has the cheapest paid storage at $0.006/GB with free egress through Cloudflare CDN. For media: <strong>Cloudinary</strong> (25 credits/month) and <strong>BunnyCDN</strong> ($0.01/GB, 14-day trial) are best-in-class. For self-hosted: <strong>MinIO</strong> is the industry standard.</p>
+    <p><strong>Quick verdict:</strong> <strong>Cloudflare R2</strong> is the standout choice for most developers &mdash; 10 GB storage with zero egress fees, S3-compatible API, and a permanent free tier. At scale, the savings are staggering: 5 TB stored + 50 TB egress costs $75/month on R2 vs $4,625/month on S3. <strong>Storj</strong> offers the largest starting capacity at 25 GB, but as a 30-day trial rather than a free tier &mdash; a $5 minimum monthly fee applies once it ends. <strong>Backblaze B2</strong> has the cheapest paid storage at ${rateCardFor("Backblaze B2").publishedStorageRate} and gives every account free egress up to 3x what it stores, no CDN needed &mdash; which makes it the cheapest column in the scaling table below, not R2&rsquo;s equal. For media: <strong>Cloudinary</strong> (25 credits/month) and <strong>BunnyCDN</strong> ($0.01/GB, 14-day trial) are best-in-class. For self-hosted: <strong>MinIO</strong> is the industry standard.</p>
     <p><strong>The S3 egress tax is legendary.</strong> AWS S3 egress charges are the #1 developer bill shock story. S3 bills across 6 dimensions most developers don&rsquo;t know about: storage, egress, PUT requests, GET requests, lifecycle transitions, and the hidden NAT Gateway charge ($0.045/GB) that appears on your EC2 bill, not your S3 bill. At 1 TB/month egress, S3 costs $92 in bandwidth alone. R2 costs $0. This single difference has disrupted the entire cloud storage market.</p>
   </div>
 
@@ -41446,11 +41484,11 @@ ${mcpCtaCss()}
         <td class="provider-col">Backblaze B2</td>
         <td>Object</td>
         <td>10 GB</td>
-        <td>1 GB/day</td>
+        <td>3x storage</td>
         <td class="check">&#10003;</td>
         <td class="partial">CF partner</td>
         <td class="check">&#10003;</td>
-        <td>Free via CF CDN</td>
+        <td class="cheapest">Free to 3x</td>
       </tr>
       <tr>
         <td class="provider-col">Tigris (Fly.io)</td>
@@ -41620,8 +41658,8 @@ ${mcpCtaCss()}
   </div>
 
   <div class="diff-card">
-    <h3>Backblaze B2 + Cloudflare CDN</h3>
-    <div class="diff-desc"><strong>Free tier:</strong> 10 GB storage, 1 GB/day direct egress, 2,500 API calls/day. S3-compatible API. Key advantage: <strong>free egress through Cloudflare CDN</strong> via the Bandwidth Alliance &mdash; put Cloudflare in front of B2 and egress is free. Without CDN, paid egress is $0.01/GB (9x cheaper than S3). Storage is the cheapest in the industry at $0.006/GB. Long-standing indie company with a stable track record. Best for large file storage where you control the CDN layer.</div>
+    <h3>Backblaze B2</h3>
+    <div class="diff-desc"><strong>Free tier:</strong> 10 GB storage, always free. S3-compatible API. Key advantage: <strong>free egress up to 3x your average monthly storage</strong>, for every account, with no CDN required &mdash; store 10 GB and 30 GB/month leaves free. Egress beyond 3x is $0.01/GB, 9x cheaper than S3, and unmetered through a partner CDN (Cloudflare, Fastly, bunny.net, CacheFly and others). Class A, B and C API calls are free on pay-as-you-go. Storage is ${rateCardFor("Backblaze B2").publishedStorageRate}, the cheapest of the four majors here. Long-standing indie company with a stable track record. Best for large file storage, and cheapest of all when reads stay inside 3x.</div>
   </div>
 
   <div class="diff-card">
@@ -41823,44 +41861,21 @@ ${mcpCtaCss()}
       </tr>
     </thead>
     <tbody>
-      <tr>
-        <td><strong>100 GB + 100 GB egress</strong></td>
-        <td class="cheapest">$1.50</td>
-        <td class="expensive">$11.30</td>
-        <td>$1.50</td>
-        <td>$14.00</td>
-        <td>~$5 (infra)</td>
-      </tr>
-      <tr>
-        <td><strong>1 TB + 1 TB egress</strong></td>
-        <td class="cheapest">$15</td>
-        <td class="expensive">$115</td>
-        <td>$16</td>
-        <td>$140</td>
-        <td>~$20 (infra)</td>
-      </tr>
-      <tr>
-        <td><strong>10 TB + 10 TB egress</strong></td>
-        <td class="cheapest">$150</td>
-        <td class="expensive">$1,130</td>
-        <td>$160</td>
-        <td>$1,400</td>
-        <td>~$80 (infra)</td>
-      </tr>
-      <tr>
-        <td><strong>100 TB + 100 TB egress</strong></td>
-        <td class="cheapest">$1,500</td>
-        <td class="expensive">$11,300</td>
-        <td>$1,600</td>
-        <td>$14,000</td>
-        <td>~$500 (infra)</td>
-      </tr>
+      ${storageScaleTableRows()}
     </tbody>
   </table>
   </div>
 
+  <div class="methodology">
+    <strong>How to read this table:</strong> every column is that provider&rsquo;s published pay-as-you-go rate for the row&rsquo;s workload, read ${STORAGE_RATES_READ}, with each provider&rsquo;s own egress allowance applied. ${storageScalingAllowanceSentence()} Fixed monthly grants are not netted out of any column, so no provider is credited one the others do not get: ${fixedMonthlyGrantsSentence()} At the 100 GB row those grants are most of the bill; by 10 TB they are a rounding error. Volume discounts and committed-use pricing are excluded throughout.
+  </div>
+
   <div class="context-box">
-    <strong>The 60x gap at scale:</strong> At 100 TB stored + 100 TB egress/month, <strong>AWS S3 costs $11,300/month</strong> while <strong>Cloudflare R2 costs $1,500/month</strong>. Google Cloud Storage is even more expensive at $14,000/month due to higher egress rates ($0.12/GB vs S3&rsquo;s $0.09/GB). Backblaze B2 with Cloudflare CDN matches R2 pricing because egress goes through the Bandwidth Alliance at $0. The lesson: <strong>storage pricing is a rounding error; egress pricing is the entire bill.</strong>
+    <strong>The ${storageScaleSpreadClause()} at scale:</strong> at 100 TB stored + 100 TB egress/month the columns run from <strong>Backblaze B2 at ${scaleCostFor("Backblaze B2", HUNDRED_TB_SCENARIO)}/month</strong> to <strong>Google Cloud Storage at ${scaleCostFor("Google Cloud Storage", HUNDRED_TB_SCENARIO)}</strong>, with AWS S3 at ${scaleCostFor("AWS S3", HUNDRED_TB_SCENARIO)} and Cloudflare R2 at ${scaleCostFor("Cloudflare R2", HUNDRED_TB_SCENARIO)}. GCS and S3 are dear for the same reason &mdash; egress at $0.12/GB and $0.09/GB with no allowance against it. B2 is cheapest, and not because of a CDN: every row here egresses 1x what it stores, inside B2&rsquo;s 3x allowance, so it pays nothing to serve that with no partner in front of it. The lesson: <strong>storage pricing is a rounding error; egress pricing is the entire bill.</strong>
+  </div>
+
+  <div class="context-box">
+    <strong>Past 3x, B2 starts billing:</strong> the allowance is a multiple of what you store, so a read-heavy workload can leave it. ${egressBillOnceOverAllowance(rateCardFor("Backblaze B2"), TEN_TO_ONE_SCENARIO)} &mdash; past Cloudflare R2 at ${scaleCostFor("Cloudflare R2", TEN_TO_ONE_SCENARIO)}, which charges nothing for egress at any ratio. The two cross at about ${b2CrossoverRatio()}x egress-to-storage: below it B2 is cheaper, above it R2 is. Egress through Cloudflare, Fastly, bunny.net or another Backblaze partner CDN is unmetered, which removes the 3x ceiling entirely.
   </div>
 
   <div class="context-box">
@@ -41908,13 +41923,13 @@ ${mcpCtaCss()}
     </div>
 
     <div class="verdict-item">
-      <strong>Best for bandwidth-heavy apps &rarr; Cloudflare R2 or Backblaze B2 + Cloudflare CDN</strong>
-      <p>Streaming, downloads, media delivery: these workloads are 90% egress cost. R2 eliminates egress entirely. B2 + Cloudflare CDN achieves the same through the Bandwidth Alliance. At 50 TB/month egress, either saves $4,500+ vs S3.</p>
+      <strong>Best for bandwidth-heavy apps &rarr; Cloudflare R2</strong>
+      <p>Streaming, downloads, media delivery: these workloads are 90% egress cost, and they are the case where egress out-runs storage by a wide multiple. R2 eliminates egress entirely at any ratio, which is why it wins here rather than B2 &mdash; B2&rsquo;s allowance is 3x what you store, so a 100 GB library serving 50 TB/month is billed for 49.7 TB of it. Put a partner CDN in front of B2 and that goes away too, but R2 needs no such arrangement. At 50 TB/month egress, either saves $4,500+ vs S3.</p>
     </div>
 
     <div class="verdict-item">
       <strong>Best S3 drop-in replacement &rarr; Backblaze B2</strong>
-      <p>S3-compatible API, cheapest storage at $0.006/GB, free egress via Cloudflare CDN. Change the endpoint URL and credentials &mdash; your existing S3 code works unchanged. Stable indie company with a track record of not removing free tiers.</p>
+      <p>S3-compatible API, cheapest storage of the four majors at ${rateCardFor("Backblaze B2").publishedStorageRate}, and free egress up to 3x what you store with no CDN in the path. Change the endpoint URL and credentials &mdash; your existing S3 code works unchanged. At every scenario in the table above it is also the cheapest column outright, ${scaleCostFor("Backblaze B2", HUNDRED_TB_SCENARIO)}/month against R2&rsquo;s ${scaleCostFor("Cloudflare R2", HUNDRED_TB_SCENARIO)} at 100 TB. Stable indie company with a track record of not removing free tiers.</p>
     </div>
 
     <div class="verdict-item">
@@ -41961,8 +41976,8 @@ ${mcpCtaCss()}
   </div>
 
   <div class="diff-card">
-    <h3>Backblaze B2: free egress only via CDN partners</h3>
-    <div class="diff-desc">B2&rsquo;s 1 GB/day free direct egress is minimal. The unlimited free egress is specifically through Cloudflare, Fastly, and Bunny CDN via the Bandwidth Alliance. Direct API access beyond 1 GB/day costs $0.01/GB. If your architecture doesn&rsquo;t use a CDN partner, you don&rsquo;t get free egress at scale.</div>
+    <h3>Backblaze B2: free egress is capped at 3x what you store</h3>
+    <div class="diff-desc">The free direct allowance is a multiple of what you store, not a fixed daily cap: every B2 account gets free egress up to 3x its average monthly storage, and $0.01/GB after that. Store 1 TB and 3 TB/month leaves free with no CDN in front. A partner CDN &mdash; Cloudflare, Fastly, bunny.net, CacheFly and others &mdash; makes egress unmetered, which is an extension of that allowance rather than the only route to one. The workload this catches is read-heavy: a 100 GB archive serving 1 TB/month is at 10x and pays for 700 GB of it.</div>
   </div>
 
   <div class="diff-card">

--- a/src/storage-cost-model.ts
+++ b/src/storage-cost-model.ts
@@ -1,0 +1,159 @@
+export const STORAGE_RATES_READ = "2026-09-07";
+
+export interface StorageRateCard {
+  provider: string;
+  source: string;
+  publishedStorageRate: string;
+  storagePerGbMonth: number;
+  egressPerGb: number;
+  freeEgressMultipleOfStorage: number;
+  freeStorageGbPerMonth: number;
+  freeEgressGbPerMonth: number;
+}
+
+export interface StorageWorkload {
+  label: string;
+  storageGb: number;
+  egressGb: number;
+  selfHostedEstimate: string;
+}
+
+export const STORAGE_RATE_CARDS: readonly StorageRateCard[] = [
+  {
+    provider: "Cloudflare R2",
+    source: "https://developers.cloudflare.com/r2/pricing/",
+    publishedStorageRate: "$0.015/GB-month",
+    storagePerGbMonth: 0.015,
+    egressPerGb: 0,
+    freeEgressMultipleOfStorage: 0,
+    freeStorageGbPerMonth: 10,
+    freeEgressGbPerMonth: 0,
+  },
+  {
+    provider: "AWS S3",
+    source: "https://aws.amazon.com/s3/pricing/",
+    publishedStorageRate: "$0.023/GB-month",
+    storagePerGbMonth: 0.023,
+    egressPerGb: 0.09,
+    freeEgressMultipleOfStorage: 0,
+    freeStorageGbPerMonth: 0,
+    freeEgressGbPerMonth: 100,
+  },
+  {
+    provider: "Backblaze B2",
+    source: "https://www.backblaze.com/cloud-storage/pricing",
+    publishedStorageRate: "$6.95/TB/30-day",
+    storagePerGbMonth: 0.00695,
+    egressPerGb: 0.01,
+    freeEgressMultipleOfStorage: 3,
+    freeStorageGbPerMonth: 10,
+    freeEgressGbPerMonth: 0,
+  },
+  {
+    provider: "Google Cloud Storage",
+    source: "https://cloud.google.com/storage/pricing",
+    publishedStorageRate: "$0.02/GB-month",
+    storagePerGbMonth: 0.02,
+    egressPerGb: 0.12,
+    freeEgressMultipleOfStorage: 0,
+    freeStorageGbPerMonth: 5,
+    freeEgressGbPerMonth: 0,
+  },
+];
+
+export const STORAGE_SCALE_WORKLOADS: readonly StorageWorkload[] = [
+  { label: "100 GB + 100 GB egress", storageGb: 100, egressGb: 100, selfHostedEstimate: "~$5 (infra)" },
+  { label: "1 TB + 1 TB egress", storageGb: 1_000, egressGb: 1_000, selfHostedEstimate: "~$20 (infra)" },
+  { label: "10 TB + 10 TB egress", storageGb: 10_000, egressGb: 10_000, selfHostedEstimate: "~$80 (infra)" },
+  { label: "100 TB + 100 TB egress", storageGb: 100_000, egressGb: 100_000, selfHostedEstimate: "~$500 (infra)" },
+];
+
+export const HUNDRED_TB_SCENARIO = { storageGb: 100_000, egressGb: 100_000 };
+export const ONE_TO_ONE_SCENARIO = { storageGb: 1_000, egressGb: 1_000 };
+export const TEN_TO_ONE_SCENARIO = { storageGb: 1_000, egressGb: 10_000 };
+
+export function rateCardFor(provider: string): StorageRateCard {
+  const card = STORAGE_RATE_CARDS.find(c => c.provider === provider);
+  if (!card) throw new Error(`No published storage rate card for ${provider}`);
+  return card;
+}
+
+export function freeEgressAllowanceGb(card: StorageRateCard, workload: Pick<StorageWorkload, "storageGb">): number {
+  return card.freeEgressMultipleOfStorage * workload.storageGb;
+}
+
+export function billableEgressGb(card: StorageRateCard, workload: Pick<StorageWorkload, "storageGb" | "egressGb">): number {
+  return Math.max(0, workload.egressGb - freeEgressAllowanceGb(card, workload));
+}
+
+export function monthlyStorageCost(card: StorageRateCard, workload: Pick<StorageWorkload, "storageGb" | "egressGb">): number {
+  return workload.storageGb * card.storagePerGbMonth + billableEgressGb(card, workload) * card.egressPerGb;
+}
+
+export function formatMonthlyStorageCost(amount: number): string {
+  const rounded = Math.round(amount * 100) / 100;
+  const decimals = Number.isInteger(rounded) ? 0 : 2;
+  return `$${rounded.toLocaleString("en-US", { minimumFractionDigits: decimals, maximumFractionDigits: decimals })}`;
+}
+
+export function scaleCostFor(provider: string, workload: Pick<StorageWorkload, "storageGb" | "egressGb">): string {
+  return formatMonthlyStorageCost(monthlyStorageCost(rateCardFor(provider), workload));
+}
+
+export function rankedProvidersAt(workload: Pick<StorageWorkload, "storageGb" | "egressGb">): StorageRateCard[] {
+  return [...STORAGE_RATE_CARDS].sort((a, b) => monthlyStorageCost(a, workload) - monthlyStorageCost(b, workload));
+}
+
+export function cheapestProviderAt(workload: Pick<StorageWorkload, "storageGb" | "egressGb">): string {
+  return rankedProvidersAt(workload)[0].provider;
+}
+
+export function costliestProviderAt(workload: Pick<StorageWorkload, "storageGb" | "egressGb">): string {
+  const ranked = rankedProvidersAt(workload);
+  return ranked[ranked.length - 1].provider;
+}
+
+export function egressRatioWhereCostsMatch(cheapWhenIdle: StorageRateCard, flatRate: StorageRateCard, maxRatio = 100): number | null {
+  const storageGb = 1_000;
+  const costAtRatio = (card: StorageRateCard, ratio: number) =>
+    monthlyStorageCost(card, { storageGb, egressGb: storageGb * ratio });
+  if (costAtRatio(cheapWhenIdle, 0) >= costAtRatio(flatRate, 0)) return null;
+  if (costAtRatio(cheapWhenIdle, maxRatio) < costAtRatio(flatRate, maxRatio)) return null;
+  let low = 0;
+  let high = maxRatio;
+  for (let step = 0; step < 60; step++) {
+    const mid = (low + high) / 2;
+    if (costAtRatio(cheapWhenIdle, mid) < costAtRatio(flatRate, mid)) low = mid;
+    else high = mid;
+  }
+  return Math.round(((low + high) / 2) * 10) / 10;
+}
+
+export function providersWithScalingEgressAllowance(): StorageRateCard[] {
+  return STORAGE_RATE_CARDS.filter(c => c.freeEgressMultipleOfStorage > 0);
+}
+
+export function fixedMonthlyGrantClause(card: StorageRateCard): string | null {
+  const grants: string[] = [];
+  if (card.freeEgressGbPerMonth > 0) grants.push(`the first ${card.freeEgressGbPerMonth} GB of internet egress`);
+  if (card.freeStorageGbPerMonth > 0) grants.push(`${card.freeStorageGbPerMonth} GB of storage`);
+  if (grants.length === 0) return null;
+  return `${card.provider} gives every account ${grants.join(" and ")} free each month`;
+}
+
+export function fixedMonthlyGrantsSentence(): string {
+  const clauses = STORAGE_RATE_CARDS.map(fixedMonthlyGrantClause).filter((c): c is string => c !== null);
+  return `${clauses.join("; ")}.`;
+}
+
+export function egressAllowanceSentence(card: StorageRateCard): string {
+  if (card.freeEgressMultipleOfStorage === 0) return `${card.provider} publishes no egress allowance that scales with what you store.`;
+  return `${card.provider} egress is free up to ${card.freeEgressMultipleOfStorage}x average monthly storage, then $${card.egressPerGb.toFixed(2)}/GB.`;
+}
+
+export function egressBillOnceOverAllowance(card: StorageRateCard, workload: Pick<StorageWorkload, "storageGb" | "egressGb">): string {
+  const billable = billableEgressGb(card, workload);
+  const allowance = freeEgressAllowanceGb(card, workload);
+  const asTb = (gb: number) => (gb >= 1_000 ? `${gb / 1_000} TB` : `${gb} GB`);
+  return `${asTb(workload.egressGb)} egress against ${asTb(workload.storageGb)} stored: ${asTb(allowance)} free, ${asTb(billable)} billed at $${card.egressPerGb.toFixed(2)}/GB, ${formatMonthlyStorageCost(monthlyStorageCost(card, workload))}/month all in`;
+}

--- a/test/storage-cost-model.test.ts
+++ b/test/storage-cost-model.test.ts
@@ -1,0 +1,182 @@
+import { describe, it } from "node:test";
+import assert from "node:assert";
+
+const model = await import("../dist/storage-cost-model.js");
+
+const {
+  STORAGE_RATE_CARDS,
+  STORAGE_SCALE_WORKLOADS,
+  billableEgressGb,
+  cheapestProviderAt,
+  costliestProviderAt,
+  egressAllowanceSentence,
+  egressBillOnceOverAllowance,
+  fixedMonthlyGrantClause,
+  fixedMonthlyGrantsSentence,
+  formatMonthlyStorageCost,
+  freeEgressAllowanceGb,
+  monthlyStorageCost,
+  providersWithScalingEgressAllowance,
+  rateCardFor,
+  scaleCostFor,
+} = model;
+
+describe("published storage rate cards", () => {
+  it("prices every scenario for every provider in the scaling table", () => {
+    for (const workload of STORAGE_SCALE_WORKLOADS) {
+      for (const card of STORAGE_RATE_CARDS) {
+        const cost = monthlyStorageCost(card, workload);
+        assert.ok(Number.isFinite(cost) && cost > 0, `${card.provider} at ${workload.label} priced ${cost}`);
+      }
+    }
+  });
+
+  it("reproduces the three columns compiled from list rates without allowances", () => {
+    const expected: Record<string, string[]> = {
+      "Cloudflare R2": ["$1.50", "$15", "$150", "$1,500"],
+      "AWS S3": ["$11.30", "$113", "$1,130", "$11,300"],
+      "Google Cloud Storage": ["$14", "$140", "$1,400", "$14,000"],
+    };
+    for (const [provider, cells] of Object.entries(expected)) {
+      STORAGE_SCALE_WORKLOADS.forEach((workload, i) => {
+        assert.strictEqual(scaleCostFor(provider, workload), cells[i], `${provider} at ${workload.label}`);
+      });
+    }
+  });
+
+  it("charges Backblaze B2 nothing for egress inside its 3x allowance", () => {
+    const b2 = rateCardFor("Backblaze B2");
+    for (const workload of STORAGE_SCALE_WORKLOADS) {
+      assert.strictEqual(workload.egressGb, workload.storageGb, `${workload.label} is not a 1x egress scenario`);
+      assert.strictEqual(billableEgressGb(b2, workload), 0, `${workload.label} billed egress inside the allowance`);
+      assert.strictEqual(
+        monthlyStorageCost(b2, workload),
+        workload.storageGb * b2.storagePerGbMonth,
+        `${workload.label} charged more than storage`,
+      );
+    }
+    assert.deepStrictEqual(
+      STORAGE_SCALE_WORKLOADS.map(w => scaleCostFor("Backblaze B2", w)),
+      ["$0.70", "$6.95", "$69.50", "$695"],
+    );
+  });
+
+  it("bills Backblaze B2 for the excess once egress passes 3x storage", () => {
+    const b2 = rateCardFor("Backblaze B2");
+    const readHeavy = { storageGb: 1_000, egressGb: 10_000 };
+    assert.strictEqual(freeEgressAllowanceGb(b2, readHeavy), 3_000);
+    assert.strictEqual(billableEgressGb(b2, readHeavy), 7_000);
+    assert.strictEqual(monthlyStorageCost(b2, readHeavy), 6.95 + 70);
+    assert.match(egressBillOnceOverAllowance(b2, readHeavy), /3 TB free, 7 TB billed at \$0\.01\/GB/);
+  });
+
+  it("bills the whole egress at the headline rate for providers with no scaling allowance", () => {
+    const workload = { storageGb: 1_000, egressGb: 1_000 };
+    for (const card of STORAGE_RATE_CARDS) {
+      if (card.freeEgressMultipleOfStorage > 0) continue;
+      assert.strictEqual(freeEgressAllowanceGb(card, workload), 0, `${card.provider} was given an allowance`);
+      assert.strictEqual(billableEgressGb(card, workload), 1_000, `${card.provider} egress was discounted`);
+    }
+  });
+
+  it("names Backblaze B2 as the only provider whose egress allowance scales", () => {
+    assert.deepStrictEqual(providersWithScalingEgressAllowance().map(c => c.provider), ["Backblaze B2"]);
+  });
+
+  it("nets out no fixed monthly grant from any column", () => {
+    const withGrants = STORAGE_RATE_CARDS.filter(c => c.freeStorageGbPerMonth > 0 || c.freeEgressGbPerMonth > 0);
+    assert.ok(withGrants.length >= 3, "expected most providers to publish a fixed monthly grant");
+    const smallest = STORAGE_SCALE_WORKLOADS[0];
+    for (const card of withGrants) {
+      const billed = monthlyStorageCost(card, smallest);
+      const netted =
+        Math.max(0, smallest.storageGb - card.freeStorageGbPerMonth) * card.storagePerGbMonth +
+        Math.max(0, billableEgressGb(card, smallest) - card.freeEgressGbPerMonth) * card.egressPerGb;
+      assert.ok(billed >= netted, `${card.provider} priced below its own list rate`);
+      assert.strictEqual(
+        billed,
+        smallest.storageGb * card.storagePerGbMonth + billableEgressGb(card, smallest) * card.egressPerGb,
+        `${card.provider} had a fixed grant netted out`,
+      );
+    }
+  });
+
+  it("states every provider's fixed monthly grant so none is applied silently", () => {
+    const sentence = fixedMonthlyGrantsSentence();
+    for (const card of STORAGE_RATE_CARDS) {
+      const clause = fixedMonthlyGrantClause(card);
+      if (card.freeStorageGbPerMonth === 0 && card.freeEgressGbPerMonth === 0) {
+        assert.strictEqual(clause, null, `${card.provider} has no grant to state`);
+        continue;
+      }
+      assert.ok(clause, `${card.provider} publishes a grant with no clause`);
+      assert.ok(sentence.includes(clause), `${card.provider} grant missing from the stated assumption`);
+    }
+    assert.match(sentence, /AWS S3 gives every account the first 100 GB of internet egress free each month/);
+  });
+
+  it("states the allowance for every provider, including the ones that have none", () => {
+    for (const card of STORAGE_RATE_CARDS) {
+      const sentence = egressAllowanceSentence(card);
+      assert.ok(sentence.startsWith(card.provider), `${card.provider} sentence names another provider`);
+      if (card.freeEgressMultipleOfStorage > 0) {
+        assert.match(sentence, /free up to 3x average monthly storage, then \$0\.01\/GB/);
+      } else {
+        assert.match(sentence, /no egress allowance that scales/);
+      }
+    }
+  });
+
+  it("ranks Backblaze B2 cheapest and Google Cloud Storage dearest at every scenario in the table", () => {
+    for (const workload of STORAGE_SCALE_WORKLOADS) {
+      assert.strictEqual(cheapestProviderAt(workload), "Backblaze B2", `cheapest at ${workload.label}`);
+      assert.strictEqual(costliestProviderAt(workload), "Google Cloud Storage", `dearest at ${workload.label}`);
+      assert.ok(
+        monthlyStorageCost(rateCardFor("Backblaze B2"), workload) < monthlyStorageCost(rateCardFor("Cloudflare R2"), workload),
+        `B2 not below R2 at ${workload.label}`,
+      );
+    }
+  });
+
+  it("finds the egress ratio where B2 stops being cheaper than R2", () => {
+    const b2 = rateCardFor("Backblaze B2");
+    const r2 = rateCardFor("Cloudflare R2");
+    const crossover = model.egressRatioWhereCostsMatch(b2, r2);
+    assert.strictEqual(crossover, 3.8);
+    const below = { storageGb: 1_000, egressGb: 1_000 * (crossover! - 0.2) };
+    const above = { storageGb: 1_000, egressGb: 1_000 * (crossover! + 0.2) };
+    assert.ok(monthlyStorageCost(b2, below) < monthlyStorageCost(r2, below), "B2 not cheaper below the crossover");
+    assert.ok(monthlyStorageCost(b2, above) > monthlyStorageCost(r2, above), "B2 not dearer above the crossover");
+  });
+
+  it("reports no crossover for a provider that never starts out cheaper", () => {
+    assert.strictEqual(
+      model.egressRatioWhereCostsMatch(rateCardFor("Cloudflare R2"), rateCardFor("Backblaze B2")),
+      null,
+    );
+    assert.strictEqual(
+      model.egressRatioWhereCostsMatch(rateCardFor("Backblaze B2"), rateCardFor("AWS S3")),
+      null,
+    );
+  });
+
+  it("shows cents only where the amount has them", () => {
+    assert.strictEqual(formatMonthlyStorageCost(0.695), "$0.70");
+    assert.strictEqual(formatMonthlyStorageCost(15), "$15");
+    assert.strictEqual(formatMonthlyStorageCost(11.3), "$11.30");
+    assert.strictEqual(formatMonthlyStorageCost(11300), "$11,300");
+  });
+
+  it("refuses a provider it holds no published rate card for", () => {
+    assert.throws(() => rateCardFor("Wasabi"), /No published storage rate card for Wasabi/);
+  });
+
+  it("cites a source and a read date for every rate card", () => {
+    assert.match(model.STORAGE_RATES_READ, /^\d{4}-\d{2}-\d{2}$/);
+    for (const card of STORAGE_RATE_CARDS) {
+      assert.match(card.source, /^https:\/\//, `${card.provider} has no source URL`);
+      assert.ok(card.publishedStorageRate.includes("$"), `${card.provider} has no published storage rate`);
+      assert.ok(card.storagePerGbMonth > 0, `${card.provider} stores for nothing`);
+    }
+  });
+});

--- a/test/storage-scale-table.test.ts
+++ b/test/storage-scale-table.test.ts
@@ -1,0 +1,135 @@
+import { describe, it, before, after } from "node:test";
+import assert from "node:assert";
+import { spawn, type ChildProcess } from "node:child_process";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { STORAGE_SCALE_WORKLOADS, cheapestProviderAt, costliestProviderAt, monthlyStorageCost, rateCardFor, scaleCostFor } from "../dist/storage-cost-model.js";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO = path.join(__dirname, "..");
+const COLUMNS = ["Cloudflare R2", "AWS S3", "Backblaze B2", "Google Cloud Storage"];
+
+function startServer(): Promise<{ proc: ChildProcess; port: number }> {
+  return new Promise((resolve, reject) => {
+    const child = spawn("node", [path.join(REPO, "dist", "serve.js")], {
+      cwd: REPO,
+      stdio: ["ignore", "ignore", "pipe"],
+      env: { ...process.env, PORT: "0", BASE_URL: "http://localhost:3000" },
+    });
+    const timeout = setTimeout(() => {
+      child.kill();
+      reject(new Error("Server startup timeout"));
+    }, 30000);
+    child.stderr!.on("data", (data: Buffer) => {
+      const m = data.toString().match(/running on http:\/\/localhost:(\d+)/);
+      if (m) {
+        clearTimeout(timeout);
+        resolve({ proc: child, port: parseInt(m[1], 10) });
+      }
+    });
+    child.on("error", err => {
+      clearTimeout(timeout);
+      reject(err);
+    });
+  });
+}
+
+function growthTableCells(html: string): string[][] {
+  const table = html.match(/<table class="growth-table">([\s\S]*?)<\/table>/);
+  assert.ok(table, "the scaling table is not on the page");
+  const rows = [...table[1].matchAll(/<tr>([\s\S]*?)<\/tr>/g)].map(r => r[1]);
+  return rows
+    .filter(r => r.includes("<td"))
+    .map(r => [...r.matchAll(/<td[^>]*>([\s\S]*?)<\/td>/g)].map(c => c[1].replace(/<[^>]*>/g, "").trim()));
+}
+
+describe("the storage scaling table publishes its rate card", () => {
+  let proc: ChildProcess;
+  let port: number;
+  let html = "";
+
+  before(async () => {
+    ({ proc, port } = await startServer());
+    const response = await fetch(`http://localhost:${port}/storage-comparison-2026`);
+    assert.strictEqual(response.status, 200);
+    html = await response.text();
+  });
+
+  after(() => {
+    proc?.kill();
+  });
+
+  it("has one row per scenario and one column per provider", () => {
+    const cells = growthTableCells(html);
+    assert.strictEqual(cells.length, STORAGE_SCALE_WORKLOADS.length);
+    for (const row of cells) {
+      assert.strictEqual(row.length, COLUMNS.length + 2, `row has ${row.length} cells: ${row.join(" | ")}`);
+    }
+  });
+
+  it("prints each provider's computed cost in every scenario", () => {
+    const cells = growthTableCells(html);
+    STORAGE_SCALE_WORKLOADS.forEach((workload, rowIndex) => {
+      const row = cells[rowIndex];
+      assert.strictEqual(row[0], workload.label, `row ${rowIndex} is not ${workload.label}`);
+      COLUMNS.forEach((provider, columnIndex) => {
+        assert.strictEqual(
+          row[columnIndex + 1],
+          scaleCostFor(provider, workload),
+          `${provider} at ${workload.label}`,
+        );
+      });
+      assert.strictEqual(row[COLUMNS.length + 1], workload.selfHostedEstimate);
+    });
+  });
+
+  it("no longer bills Backblaze B2 for egress inside its allowance", () => {
+    const cells = growthTableCells(html);
+    const b2Column = cells.map(row => row[COLUMNS.indexOf("Backblaze B2") + 1]);
+    assert.deepStrictEqual(b2Column, ["$0.70", "$6.95", "$69.50", "$695"]);
+    for (const overstated of ["$1.50", "$16", "$160", "$1,600"]) {
+      assert.ok(
+        !b2Column.includes(overstated),
+        `the Backblaze column still prints ${overstated}`,
+      );
+    }
+  });
+
+  it("states the allowance rule and the grants it does not net out", () => {
+    assert.match(html, /every column is that provider&rsquo;s published pay-as-you-go rate/);
+    assert.match(html, /Backblaze B2 egress is free up to 3x average monthly storage, then \$0\.01\/GB/);
+    assert.match(html, /AWS S3 gives every account the first 100 GB of internet egress free each month/);
+    assert.match(html, /Fixed monthly grants are not netted out of any column/);
+  });
+
+  it("says what happens once egress passes the allowance", () => {
+    assert.match(html, /3 TB free, 7 TB billed at \$0\.01\/GB, \$76\.95\/month all in/);
+  });
+
+  it("does not repeat the retired daily cap or the rounded storage rate", () => {
+    const b2Rate = rateCardFor("Backblaze B2");
+    assert.ok(html.includes(b2Rate.publishedStorageRate), `page omits ${b2Rate.publishedStorageRate}`);
+    assert.ok(!html.includes("$0.006/GB"), "page still quotes Backblaze storage at $0.006/GB");
+    assert.ok(!/B2&rsquo;s 1 GB\/day free direct egress/.test(html), "page still describes a 1 GB/day Backblaze egress cap");
+    assert.ok(!html.includes("matches R2 pricing because egress goes through the Bandwidth Alliance"), "page still calls B2 R2's equal");
+  });
+
+  it("ranks B2 against R2 on the corrected numbers", () => {
+    const hundredTb = STORAGE_SCALE_WORKLOADS[STORAGE_SCALE_WORKLOADS.length - 1];
+    const b2 = scaleCostFor("Backblaze B2", hundredTb);
+    const r2 = scaleCostFor("Cloudflare R2", hundredTb);
+    assert.ok(html.includes(`<strong>Backblaze B2 at ${b2}/month</strong>`), "the verdict does not name B2 as cheapest");
+    assert.ok(html.includes(`${b2}/month against R2&rsquo;s ${r2} at 100 TB`), "the drop-in verdict does not compare B2 to R2");
+  });
+
+  it("headlines the spread between the two columns it names first", () => {
+    const hundredTb = STORAGE_SCALE_WORKLOADS[STORAGE_SCALE_WORKLOADS.length - 1];
+    const cheapest = monthlyStorageCost(rateCardFor(cheapestProviderAt(hundredTb)), hundredTb);
+    const dearest = monthlyStorageCost(rateCardFor(costliestProviderAt(hundredTb)), hundredTb);
+    const spread = Math.round(dearest / cheapest);
+    assert.strictEqual(spread, 20);
+    assert.ok(html.includes(`The ${spread}x gap at scale`), `page does not headline a ${spread}x gap`);
+    assert.ok(!html.includes("The 60x gap at scale"), "page still headlines the pre-correction 60x gap");
+  });
+});


### PR DESCRIPTION
Refs #1430

## What was wrong

`/storage-comparison-2026`'s scaling table billed Backblaze B2 for egress Backblaze gives free. **Every scenario in that table egresses exactly 1x what it stores**, and B2's allowance is 3x average monthly storage for every account — so all four rows were inside the allowance and all four overstated the bill by ~2.3x.

Verified against `backblaze.com/cloud-storage/pricing`, read 2026-09-07: `$6.95/TB/30-day` storage, "All B2 Cloud Storage users get free egress up to 3x their average monthly storage", `$0.01/GB` beyond, first 10 GB of storage always free, Class A/B/C API calls free on pay-as-you-go.

## What changed

New `src/storage-cost-model.ts` holds each provider's published rate card — storage rate, egress rate, scaling egress allowance, fixed monthly grants — with a source URL and a read date per provider. The table's four vendor columns are computed from it rather than hand-written.

| Scenario | R2 | S3 | **B2 was → is** | GCS |
|---|---|---|---|---|
| 100 GB + 100 GB | $1.50 | $11.30 | **$1.50 → $0.70** | $14 |
| 1 TB + 1 TB | $15 | $113 | **$16 → $6.95** | $140 |
| 10 TB + 10 TB | $150 | $1,130 | **$160 → $69.50** | $1,400 |
| 100 TB + 100 TB | $1,500 | $11,300 | **$1,600 → $695** | $14,000 |

**AC-5, and the two control cells that move.** 14 of the 16 previously published cells reproduce byte-for-byte from the rate card — that is the negative control, now mechanical rather than asserted. Two do not, and I did not special-case either:

- **AWS S3 at 1 TB: `$115` → `$113`.** `$115` matches no published rate. `$0.023 × 1000 + $0.09 × 1000 = $113`, which is the issue's own arithmetic in its negative-control section. Leaving one hand-written cell in a table whose point is that every cell is checkable preserves the defect class. **One line to revert if you disagree.**
- **GCS at 100 GB: `$14.00` → `$14`.** Formatting only, identical value: cents are shown where an amount has them.

**AC-2 — the stated assumption.** Under the table: every column is that provider's published pay-as-you-go rate for the row's workload, with each provider's own *scaling* allowance applied. **Fixed monthly grants are not netted out of any column**, and the page now names all of them rather than leaving them silent — including that **AWS gives every account the first 100 GB of internet egress free each month**, permanently, not as part of the 12-month tier. That grant is most of the S3 bill in the 100 GB row.

**This is where AC-2 and AC-5 pull against each other, and it is your call.** "Each vendor's own published allowance" applied without qualification would move S3's 100 GB row from `$11.30` to `$2.30` and the 1 TB row from `$113` to `$104` — a large move in a column AC-5 pins. I drew the line at *proportional* allowances (B2's 3x changes the answer at every scale) versus *fixed grants* (which wash out by 10 TB), applied that rule to all four columns, and disclosed the grants instead of netting them. If you want the grants netted too, say so and it is a one-field change in the rate card.

**AC-1** — nothing in the table exceeds 3x, so the page states the rule and works an example that does: 10 TB against 1 TB stored is 3 TB free, 7 TB at `$0.01/GB`, `$76.95`/month.

**AC-3** — the three prose statements now match the vendor page: the 3x direct allowance, partner CDNs as an extension of it rather than the only route, and `$6.95/TB/30-day` rather than `$0.006/GB`. The retired 1 GB/day figure is gone from the B2 rows and cards.

**AC-4** — the cheapest/dearest emphasis is computed, so it cannot drift from the numbers. B2 is now marked cheapest in all four rows and the verdicts follow: the "60x gap" headline is derived and reads 20x (GCS $14,000 to B2 $695); "Best S3 drop-in replacement" names B2 at $695 against R2's $1,500; "Best for bandwidth-heavy apps" is now R2 alone, with the reason stated — B2's allowance is a multiple of storage, so a 100 GB library serving 50 TB/month is billed for 49.7 TB of it.

## AC-6 — every other hardcoded B2 figure

**Fixed in this PR, because each stated something false or reversed:**

- `src/serve.ts:3228–3232`, the `/backblaze-b2-vs-cloudflare-r2` verdict. Called R2 "the clear winner", said B2's free egress "requires extra setup", and priced 1 TB + 10 TB at "~$60/month (without CDN) or ~$15/month (with Cloudflare CDN)" — the first matches no rate (it is $76.95), the second is $6.95. The verdict is now ratio-dependent, with the crossover derived rather than typed: **the two cross at 3.8x egress-to-storage**, below it B2 is cheaper, above it R2 is.
- `src/serve.ts:11626`, `/storage-alternatives` table cell: "1 GB/day free" → "Free to 3x storage".
- `src/serve.ts:11702`: "charges for egress beyond 1 GB/day" — retired cap.
- `src/serve.ts:11711`: "$6/TB" → `$6.95/TB`.
- Five `outgrow` strings (`:15957`, `:16329`, `:16739`, `:17164`, `:17606`), all one repeated phrase: "10 GB free with free egress via Cloudflare CDN" implied the CDN was the only route. Not false, but it is the exact belief this issue corrects, and it was five identical copies of it. Their S3 figures are right: 1 TB + 10 TB on S3 is `$923`, published as "~$925".

**Reported, not changed — the catalogue record, which is data:**

- `data/index.json`, the Backblaze B2 offer description: *"Object storage — first 10 GB always free, free egress via Cloudflare/CDN partners"*. Same omission, and it reaches further than the prose did — it is the `schema.org` `SoftwareApplication` description, the FAQ answer and the visible summary on `/backblaze-b2-vs-cloudflare-r2`, and the vendor page. Suggested: *"first 10 GB always free, free egress up to 3x average monthly storage, unmetered via CDN partners"*.
- `:17606`'s "plus $9/GB egress on S3" should be `$0.09/GB` — a units error, pre-existing, not B2's and not in scope here.

**Checked and correct, left alone:** the `1 GB/day` figures at `:19461` (Firestore), `:26501` (Logz.io) and `:41557`/`:41804` (Firebase Storage) belong to other vendors.

## Verification

- **4,227 tests, 23 new, 0 failures.** `tsc --noEmit` clean, `lint:duplicates` clean, `no-private-context` 9/9.
- **5 mutants, 5 killed**: B2 allowance 3→0 (7 tests fail), 3→1, storage rate `0.00695`→`0.006`, S3 egress `0.09`→`0.08`, AWS grant `100`→`0`.
- **Rendered against a running server**, not just asserted: the table, the four rewritten verdict blocks, `/storage-alternatives`, and `/backblaze-b2-vs-cloudflare-r2` in body copy, meta description and FAQ JSON-LD. Screenshotted the table to confirm the cheapest/dearest colouring follows the corrected numbers.
- Reading the rendered page caught an error in my own draft copy — I had written that B2 at 1 TB + 10 TB was "still under R2", which is backwards ($76.95 against $15). That sentence is now the crossover explanation.