### PR TITLE
Backblaze B2's description states the 3x egress allowance it publishes (#1430)

### DIFF
--- a/data/index.json
+++ b/data/index.json
@@ -1986,7 +1986,7 @@
     {
       "vendor": "Backblaze B2",
       "category": "Storage",
-      "description": "Object storage — first 10 GB always free, free egress via Cloudflare/CDN partners",
+      "description": "Object storage — first 10 GB always free, free egress up to 3x average monthly storage, unmetered via CDN partners",
       "tier": "Free Allowance",
       "url": "https://www.backblaze.com/cloud-storage/pricing",
       "tags": [


### PR DESCRIPTION
Data-only. One description field on the `Backblaze B2` record in `data/index.json`.

The #1431 census named this as the one surface the code fix could not reach: it is the `schema.org` `SoftwareApplication` description, the FAQ answer and the visible summary on `/backblaze-b2-vs-cloudflare-r2`, and the vendor page.

| | |
|---|---|
| was | Object storage — first 10 GB always free, free egress via Cloudflare/CDN partners |
| now | Object storage — first 10 GB always free, free egress up to 3x average monthly storage, unmetered via CDN partners |

Verified against `backblaze.com/cloud-storage/pricing` directly, read 2026-09-07:

> First 10GB storage is always free. Free 3x monthly egress. Egress above 3x monthly average storage is also free through many CDN and compute partners; otherwise, overage is billed at $0.01 per GB.

4,227 tests, 0 failures. No `src/` change. No `verifiedDate` or `source_check` edit — those are the pipeline's to stamp.