### PR TITLE
Measure a test floor against the population it reads (#1417)

### DIFF
--- a/test/alternatives-crawl-space.test.ts
+++ b/test/alternatives-crawl-space.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, before, after } from "node:test";
 import assert from "node:assert";
+import { assertPopulationFloor } from "./population-floor.ts";
 import { spawn, type ChildProcess } from "node:child_process";
 import { readFileSync } from "node:fs";
 import path from "node:path";
@@ -70,7 +71,7 @@ before(async () => {
   await renderAll(slugs);
   const sitemap = await (await fetch(`http://localhost:${serverPort}/sitemap-pages.xml`)).text();
   submitted = new Set([...sitemap.matchAll(/<loc>[^<]*\/alternative-to\/([^<]+)<\/loc>/g)].map(m => m[1]));
-  assert.ok(pages.size > 1000, `every vendor must have an alternatives page for this test to mean anything, rendered ${pages.size}`);
+  assertPopulationFloor(pages.size, 1001, "alternatives pages rendered");
   assert.ok(withSubstitutes().length > 0, "some page must name a substitute for this test to mean anything");
   assert.ok(withoutSubstitutes().length > 0, "some page must name none for this test to mean anything");
 });

--- a/test/alternatives-membership.test.ts
+++ b/test/alternatives-membership.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, before, after } from "node:test";
 import assert from "node:assert";
+import { assertPopulationFloor } from "./population-floor.ts";
 import { spawn, type ChildProcess } from "node:child_process";
 import { readFileSync } from "node:fs";
 import path from "node:path";
@@ -369,7 +370,7 @@ describe("#1032 a classification must not contradict what we already publish", (
         if (r.gate === "subtype_mismatch" || r.gate === "not_in_taxonomy") dropped.push(`${vendor} -> ${r.offer.vendor}`);
       }
     }
-    assert.ok(pairs > 100, `the change records must resolve to pairs for this test to mean anything, found ${pairs}`);
+    assertPopulationFloor(pairs, 101, "change records resolve to a comparison pair");
     assert.deepStrictEqual(dropped, [], `a curated pair is a stronger claim than a taxonomy match: ${dropped.join(", ")}`);
   });
 

--- a/test/badge-subjects-resolve.test.ts
+++ b/test/badge-subjects-resolve.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, before, after } from "node:test";
 import assert from "node:assert";
+import { assertPopulationFloor } from "./population-floor.ts";
 import { spawn, type ChildProcess } from "node:child_process";
 import { readFileSync, rmSync, writeFileSync } from "node:fs";
 import path from "node:path";
@@ -71,8 +72,8 @@ describe("#1063 an editorial badge names something we hold a record for", () => 
         subjects.add(`${subject}|${badge}`);
       }
     }
-    assert.ok(spans > 150, `expected the sweep to reach every badge on the site, reached ${spans}`);
-    assert.ok(subjects.size > 100, `expected over 100 distinct subject and badge pairs, found ${subjects.size}`);
+    assertPopulationFloor(spans, 80, "badges the sweep reached");
+    assertPopulationFloor(subjects.size, 60, "distinct subject and badge pairs");
   });
 
   it("carries a subject for every badge it enumerates", () => {

--- a/test/badge-verdicts.ts
+++ b/test/badge-verdicts.ts
@@ -23,7 +23,19 @@ export function badgeVerdictsFromBadgesPage(html: string): Map<string, SiteFreeT
   return verdicts;
 }
 
+export function badgeLinksOnBadgesPage(html: string): string[] {
+  return [...html.matchAll(/<a href="\/vendor\/([a-z0-9-]+)" class="vendor-badge-link"/g)].map(m => m[1]!);
+}
+
+export function badgesWithNoVerdict(html: string): string[] {
+  const verdicts = badgeVerdictsFromBadgesPage(html);
+  return badgeLinksOnBadgesPage(html).filter(slug => !verdicts.has(slug));
+}
+
+export async function fetchBadgesPage(port: number): Promise<string> {
+  return await (await fetch(`http://localhost:${port}/badges`)).text();
+}
+
 export async function fetchBadgeVerdicts(port: number): Promise<Map<string, SiteFreeTierVerdict>> {
-  const html = await (await fetch(`http://localhost:${port}/badges`)).text();
-  return badgeVerdictsFromBadgesPage(html);
+  return badgeVerdictsFromBadgesPage(await fetchBadgesPage(port));
 }

--- a/test/badge-withholding.test.ts
+++ b/test/badge-withholding.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, before, after } from "node:test";
 import assert from "node:assert";
+import { assertPopulationFloor } from "./population-floor.ts";
 import { spawn, type ChildProcess } from "node:child_process";
 import { readFileSync } from "node:fs";
 import path from "node:path";
@@ -137,7 +138,7 @@ before(async () => {
     }];
   });
 
-  assert.ok(subjects.length > 1000, "the catalogue did not load");
+  assertPopulationFloor(subjects.length, 1001, "vendors loaded from the catalogue");
   const started = await startHttpServer();
   proc = started.child;
   serverPort = started.port;
@@ -226,7 +227,7 @@ describe("#1389 the badge withholds wherever the vendor page withholds", () => {
 
   it("carries a risk badge on the pages whose badge publishes a verdict", async () => {
     const publishing = subjects.filter(s => s.kind === "rating");
-    assert.ok(publishing.length > 100, "almost nothing publishes, so this asserts nothing");
+    assertPopulationFloor(publishing.length, 101, "subjects publish a badge rather than withhold one");
     const sample = ["stable", "caution", "risky"].flatMap(word => publishing.filter(s => s.word === word).slice(0, 3));
     assert.strictEqual(new Set(sample.map(s => s.word)).size, 3, "the sample does not cover all three levels");
     const missing: string[] = [];

--- a/test/change-date-provenance.test.ts
+++ b/test/change-date-provenance.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, before, after } from "node:test";
 import assert from "node:assert";
+import { assertPopulationFloor } from "./population-floor.ts";
 import { spawn, type ChildProcess } from "node:child_process";
 import { readFileSync, writeFileSync, mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
@@ -164,7 +165,7 @@ describe("backfilling the entries written before the field existed", () => {
     const published = JSON.parse(readFileSync(path.join(REPO, "data", "deal_changes.json"), "utf-8")).changes;
     const freshness = changeLogFreshness(published, new Date());
     assert.strictEqual(freshness.entries_without_date_source, 0);
-    assert.ok(published.length > 100, `expected the real log, got ${published.length} entries`);
+    assertPopulationFloor(published.length, 101, "entries in the published log");
   });
 
   it("counts entries whose date is only a discovery", () => {

--- a/test/change-log-citation.test.ts
+++ b/test/change-log-citation.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, before, after } from "node:test";
 import assert from "node:assert";
+import { assertPopulationFloor } from "./population-floor.ts";
 import { spawn, type ChildProcess } from "node:child_process";
 import { readFileSync, writeFileSync, mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
@@ -122,15 +123,12 @@ describe("every change we publish reaches the page it was read from", () => {
 
   it("has a population on both sides of the question", () => {
     const inForceWithSource = changes.filter((c) => !isNoLongerInForce(c) && changeCitesASource(c));
-    assert.ok(
-      inForceWithSource.length > 100,
-      `only ${inForceWithSource.length} in-force records hold a source, so the citation sweep has almost no subject`,
-    );
+    assertPopulationFloor(inForceWithSource.length, 101, "in-force records hold a source for the citation sweep to read");
     assert.ok(
       changes.some((c) => !changeCitesASource(c)),
       "no record is missing a source, so nothing here exercises the entry that says we hold none",
     );
-    assert.ok(sweptPaths.length > 1000, `swept only ${sweptPaths.length} paths`);
+    assertPopulationFloor(sweptPaths.length, 1001, "paths swept");
   });
 
   it("cites the page behind every in-force record on some page we serve", () => {
@@ -158,7 +156,7 @@ describe("every change we publish reaches the page it was read from", () => {
       [],
       "a rendered Source link reaches a page no change record cites, so nothing can retract it",
     );
-    assert.ok(stillCited.size > 100, `only ${stillCited.size} distinct sources back the citations we render`);
+    assertPopulationFloor(stillCited.size, 101, "distinct sources back the citations we render");
   });
 
   it("does not depend on the vendor page to do it, so a retirement cannot take the citation away", () => {
@@ -211,7 +209,7 @@ describe("every change we publish reaches the page it was read from", () => {
         }
       }
     }
-    assert.ok(checked > 100, `only ${checked} change entries render on a vendor page`);
+    assertPopulationFloor(checked, 101, "change entries render on a vendor page");
     assert.deepStrictEqual([...new Set(offenders)].slice(0, 5), []);
   });
 

--- a/test/change-log-only-vendors.test.ts
+++ b/test/change-log-only-vendors.test.ts
@@ -1,10 +1,16 @@
 import { describe, it, before, after } from "node:test";
 import assert from "node:assert";
+import { assertPopulationFloor } from "./population-floor.ts";
 import { spawn, type ChildProcess } from "node:child_process";
 import { readFileSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { badgeVerdictsFromBadgesPage, type SiteFreeTierVerdict } from "./badge-verdicts.ts";
+import {
+  badgeLinksOnBadgesPage,
+  badgeVerdictsFromBadgesPage,
+  badgesWithNoVerdict,
+  type SiteFreeTierVerdict,
+} from "./badge-verdicts.ts";
 
 const { compiledFigureSlots, staticHalfOf } = await import("../dist/compiled-figures.js");
 const { namedVendorSlug, toSlug, vendorSlugMap } = await import("../dist/vendor-slug.js");
@@ -56,6 +62,8 @@ let proc: ChildProcess | null = null;
 let base = "";
 const pages = new Map<string, string>();
 let verdicts = new Map<string, SiteFreeTierVerdict>();
+let badges = "";
+let published = 0;
 
 function startServer(): Promise<ChildProcess> {
   return new Promise((resolve, reject) => {
@@ -72,15 +80,17 @@ function startServer(): Promise<ChildProcess> {
   });
 }
 
-async function fetchEveryPublishedPage(): Promise<void> {
+async function fetchEveryPublishedPage(): Promise<number> {
   const sitemap = await (await fetch(`${base}/sitemap-pages.xml`)).text();
-  const queue = [...sitemap.matchAll(/<loc>([^<]+)<\/loc>/g)].map(m => new URL(m[1]).pathname);
+  const paths = [...sitemap.matchAll(/<loc>([^<]+)<\/loc>/g)].map(m => new URL(m[1]).pathname);
+  const queue = [...paths];
   await Promise.all(Array.from({ length: 8 }, async () => {
     for (let next = queue.pop(); next; next = queue.pop()) {
       const res = await fetch(`${base}${next}`);
       if (res.ok) pages.set(next, await res.text());
     }
   }));
+  return paths.length;
 }
 
 interface SweptSlot {
@@ -106,15 +116,17 @@ function everySlotOnEveryPage(): SweptSlot[] {
 describe("marking a comparison slot whose vendor has no catalogue entry", () => {
   before(async () => {
     proc = await startServer();
-    await fetchEveryPublishedPage();
-    verdicts = badgeVerdictsFromBadgesPage(await (await fetch(`${base}/badges`)).text());
+    published = await fetchEveryPublishedPage();
+    badges = await (await fetch(`${base}/badges`)).text();
+    verdicts = badgeVerdictsFromBadgesPage(badges);
   });
 
   after(() => { proc?.kill(); });
 
   it("reads every page the sitemap publishes", () => {
-    assert.ok(pages.size >= 400, `only ${pages.size} pages read`);
-    assert.ok(verdicts.size >= 1500, `only ${verdicts.size} badge verdicts read`);
+    assert.strictEqual(pages.size, published, "the sitemap lists a page that did not answer");
+    assert.deepStrictEqual(badgesWithNoVerdict(badges), []);
+    assert.strictEqual(verdicts.size, badgeLinksOnBadgesPage(badges).length);
   });
 
   it("holds ended records for vendors the catalogue has no entry for", () => {
@@ -186,7 +198,7 @@ describe("marking a comparison slot whose vendor has no catalogue entry", () => 
   it("gives the change log one anchor per vendor and no more", () => {
     const ids = [...pages.get("/changes")!.matchAll(/ id="(vendor-[a-z0-9-]+)"/g)].map(m => m[1]!);
     assert.deepStrictEqual(ids.filter((id, at) => ids.indexOf(id) !== at), []);
-    assert.ok(ids.length >= 400, `only ${ids.length} vendors are addressable in the change log`);
+    assertPopulationFloor(ids.length, 200, "vendors are addressable in the change log");
   });
 
   it("leaves a slot the page itself wrote as removed exactly as the page wrote it", () => {

--- a/test/change-reporting.test.ts
+++ b/test/change-reporting.test.ts
@@ -1,5 +1,6 @@
 import { describe, it } from "node:test";
 import assert from "node:assert";
+import { assertPopulationFloor } from "./population-floor.ts";
 import { readFileSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -37,6 +38,9 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const REPO = path.join(__dirname, "..");
 
 const changes: DealChange[] = loadDealChanges();
+const shippedChanges: DealChange[] = JSON.parse(
+  readFileSync(path.join(REPO, "data", "deal_changes.json"), "utf-8"),
+).changes;
 
 const record = (over: Partial<DealChange> = {}): DealChange => ({
   vendor: "Fixture Vendor",
@@ -105,7 +109,7 @@ describe("a record whose summary says its own source cannot be read", () => {
       c => `${c.vendor} ${c.date} -> ${c.source_url} (${summaryCallsItsSourceUnreadable(c)})`,
     );
     assert.deepStrictEqual(offenders, []);
-    assert.ok(changes.length > 500, `only ${changes.length} records were checked`);
+    assert.strictEqual(changes.length, shippedChanges.length, "the sweep read fewer records than the repository ships");
   });
 
   it("no longer sends anyone to the startup-deals roundup that named none of its eight vendors", () => {
@@ -118,8 +122,7 @@ describe("a record whose summary says its own source cannot be read", () => {
 
 describe("what a change record reports", () => {
   it("is a field, so a reader of the data does not have to parse the summary to tell", () => {
-    const shipped = JSON.parse(readFileSync(path.join(REPO, "data", "deal_changes.json"), "utf-8")).changes;
-    const marked = shipped.filter((c: DealChange) => c.reports === "our_index");
+    const marked = shippedChanges.filter((c: DealChange) => c.reports === "our_index");
     assert.ok(marked.length > 0, "no shipped record says it reports our own index");
     assert.strictEqual(marked.length, ourIndexChanges(changes).length);
     for (const c of marked) {

--- a/test/compare-free-tier-claim.test.ts
+++ b/test/compare-free-tier-claim.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, before, after } from "node:test";
 import assert from "node:assert";
+import { assertPopulationFloor } from "./population-floor.ts";
 import { spawn, type ChildProcess } from "node:child_process";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -90,7 +91,7 @@ before(async () => {
   const changes = loadDealChanges();
   const servedOn = utcDate();
   pairs = [...buildComparisonMap().entries()].map(([slug, [a, b]]: [string, [string, string]]) => ({ slug, a, b }));
-  assert.ok(pairs.length > 300, "the comparison set did not load");
+  assertPopulationFloor(pairs.length, 200, "comparison pairs loaded");
 
   const started = await startHttpServer();
   proc = started.child;
@@ -203,7 +204,7 @@ describe("#1393 the comparison page answers the free-tier question the way the r
 
     assert.deepStrictEqual(assertsWhatTheSiteWillNot, [], "a comparison asserts a free tier the badge does not rate");
     assert.deepStrictEqual(withholdsWhereTheSitePublishes, [], "a comparison withholds a free tier the badge rates");
-    assert.ok(asserted > 300, `only ${asserted} slots assert a free tier`);
+    assertPopulationFloor(asserted, 200, "slots assert a free tier");
   });
 
   it("states why it is withholding, on every slot the site does not rate", async () => {
@@ -229,7 +230,7 @@ describe("#1393 the comparison page answers the free-tier question the way the r
 
     assert.deepStrictEqual(silent, [], "a comparison withholds without saying so in the claim");
     assert.deepStrictEqual(unreasoned, [], "a comparison withholds without naming a reason we hold");
-    assert.ok(withholdingSlots > 100, `only ${withholdingSlots} slots withhold`);
+    assertPopulationFloor(withholdingSlots, 101, "slots withhold");
   });
 
   it("never publishes stored terms a change record supersedes", async () => {

--- a/test/compiled-comparison-figures.test.ts
+++ b/test/compiled-comparison-figures.test.ts
@@ -1,10 +1,17 @@
 import { describe, it, before, after } from "node:test";
 import assert from "node:assert";
+import { assertPopulationFloor } from "./population-floor.ts";
 import { spawn, type ChildProcess } from "node:child_process";
 import { readFileSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { fetchBadgeVerdicts, type SiteFreeTierVerdict } from "./badge-verdicts.ts";
+import {
+  badgeLinksOnBadgesPage,
+  badgeVerdictsFromBadgesPage,
+  badgesWithNoVerdict,
+  fetchBadgesPage,
+  type SiteFreeTierVerdict,
+} from "./badge-verdicts.ts";
 
 const {
   comparedServicesOn,
@@ -65,6 +72,7 @@ function cardBody(html: string, headingMarkup: string): string {
 let port = 0;
 let proc: ChildProcess | null = null;
 let verdicts = new Map<string, SiteFreeTierVerdict>();
+let badges = "";
 const pages = new Map<string, string>();
 
 function startServer(): Promise<ChildProcess> {
@@ -401,20 +409,22 @@ describe("grading the severity of a pricing change", () => {
   it("holds every stored record to the scale", () => {
     const outside = changes.filter(c => !isChangeImpactLevel(c.impact));
     assert.deepStrictEqual(outside.map(c => `${c.vendor}: ${c.impact}`), []);
-    assert.ok(changes.length >= 500, `only ${changes.length} records read`);
+    assertPopulationFloor(changes.length, 300, "records read");
   });
 });
 
 describe("the nine compiled comparison pages against the site's own verdicts", () => {
   before(async () => {
     proc = await startServer();
-    verdicts = await fetchBadgeVerdicts(port);
+    badges = await fetchBadgesPage(port);
+    verdicts = badgeVerdictsFromBadgesPage(badges);
   });
 
   after(() => { proc?.kill(); });
 
   it("reads a verdict for every vendor the site publishes a badge for", () => {
-    assert.ok(verdicts.size >= 1500, `only ${verdicts.size} badge verdicts read`);
+    assert.deepStrictEqual(badgesWithNoVerdict(badges), []);
+    assert.strictEqual(verdicts.size, badgeLinksOnBadgesPage(badges).length);
   });
 
   it("states no free tier for a vendor whose free tier the site says has ended", async () => {

--- a/test/deal-changes.test.ts
+++ b/test/deal-changes.test.ts
@@ -1,5 +1,6 @@
 import { describe, it } from "node:test";
 import assert from "node:assert";
+import { assertPopulationFloor } from "./population-floor.ts";
 import { spawn } from "node:child_process";
 import path from "node:path";
 import fs from "node:fs";
@@ -78,7 +79,7 @@ describe("track_changes tool", () => {
     assert.ok(Array.isArray(body.changes));
     assert.strictEqual(body.total, body.changes.length);
     assert.strictEqual(body.total, onFile.length);
-    assert.ok(body.total > 200, `expected the whole change log, got ${body.total}`);
+    assertPopulationFloor(body.total, 201, "records in the change log");
     for (const c of body.changes) assert.ok(c.date >= since, `${c.vendor} predates the since date`);
   });
 

--- a/test/discovery-date-surfaces.test.ts
+++ b/test/discovery-date-surfaces.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, before, after } from "node:test";
 import assert from "node:assert";
+import { assertPopulationFloor } from "./population-floor.ts";
 import { spawn, type ChildProcess } from "node:child_process";
 import { writeFileSync, mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
@@ -192,7 +193,7 @@ describe("no published surface presents a discovery date as the date a vendor ch
   });
 
   it("reaches enough of the site for the sweep below to mean something", () => {
-    assert.ok(routes.length > 1000, `only enumerated ${routes.length} routes from the sitemap`);
+    assertPopulationFloor(routes.length, 1001, "routes enumerated from the sitemap");
     assert.ok(rendered.size > 40, `only ${rendered.size} routes rendered the entry at all`);
   });
 

--- a/test/faq-provenance.test.ts
+++ b/test/faq-provenance.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, before, after } from "node:test";
 import assert from "node:assert";
+import { assertPopulationFloor } from "./population-floor.ts";
 import { spawn, type ChildProcess } from "node:child_process";
 import { readFileSync, writeFileSync, mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
@@ -216,8 +217,8 @@ describe("#1086 every structured answer that states a vendor figure carries the 
     const changes = JSON.parse(readFileSync(path.join(REPO, "data", "deal_changes.json"), "utf-8"));
     const touchedChanges = perturbTextFields(changes.changes, CHANGE_LOG_TEXT_FIELDS);
     writeFileSync(path.join(tmp, "deal_changes.json"), JSON.stringify(changes));
-    assert.ok(touchedIndex > 1000, `perturbed only ${touchedIndex} catalogue fields, so the comparison below proves nothing`);
-    assert.ok(touchedChanges > 100, `perturbed only ${touchedChanges} change-log fields, so the comparison below proves nothing`);
+    assertPopulationFloor(touchedIndex, 1001, "catalogue fields perturbed for the comparison below");
+    assertPopulationFloor(touchedChanges, 101, "change-log fields perturbed for the comparison below");
 
     [real, perturbed] = await Promise.all([
       startServer({}),

--- a/test/free-tier-vouched-share.test.ts
+++ b/test/free-tier-vouched-share.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, before, after } from "node:test";
 import assert from "node:assert";
+import { assertPopulationFloor } from "./population-floor.ts";
 import { spawn, type ChildProcess } from "node:child_process";
 import { readFileSync } from "node:fs";
 import path from "node:path";
@@ -134,7 +135,6 @@ after(() => { proc?.kill(); });
 
 describe("the free tier report counts what the site is prepared to vouch for", () => {
   it("reads a verdict for every vendor in the catalogue", () => {
-    assert.ok(verdicts.size >= 1500, `only ${verdicts.size} vendors publish a badge verdict`);
     const missing = offers.filter((o) => !verdicts.has(toSlug(o.vendor)));
     assert.deepStrictEqual(missing.map((o) => o.vendor), [], "offers whose vendor publishes no badge verdict");
   });
@@ -142,8 +142,8 @@ describe("the free tier report counts what the site is prepared to vouch for", (
   it("holds the three populations the report is written for", () => {
     const census = censusOf(offers);
     assert.ok(census.ended >= 20, `only ${census.ended} offers are recorded as ended`);
-    assert.ok(census.vouched >= 300, `only ${census.vouched} offers are vouched`);
-    assert.ok(census.unconfirmed >= 100, `only ${census.unconfirmed} recorded offers are unconfirmed`);
+    assertPopulationFloor(census.vouched, 300, "offers are vouched");
+    assertPopulationFloor(census.unconfirmed, 100, "recorded offers are unconfirmed");
     assert.ok(
       censusOf(offers.filter((o) => tierRecordsAFreeTier(o.tier))).ended >= 20,
       "no offer whose tier records a free tier is also recorded as ended, so the exclusion is untested",

--- a/test/gated-vendor-answers.test.ts
+++ b/test/gated-vendor-answers.test.ts
@@ -339,7 +339,11 @@ describe("the production answer reads the same gate", () => {
 
   it("opens with whatever opens the free-tier answer on the same page", () => {
     const subjects = gated().filter(p => freeAnswer(p).startsWith(p.gate!.reason));
-    assertPopulationFloor(subjects.length, 101, "gated pages open the free-tier answer with the gate");
+    assertPopulationFloor(
+      subjects.length,
+      Math.floor(gated().length / 3),
+      `gated pages of ${gated().length} open the free-tier answer with the gate`,
+    );
     const contradicting = subjects
       .filter(p => !productionAnswer(p).startsWith(p.gate!.reason))
       .map(p => `${p.slug} (${p.gate!.code}): ${productionAnswer(p).slice(0, 60)}`);

--- a/test/gated-vendor-answers.test.ts
+++ b/test/gated-vendor-answers.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, before, after } from "node:test";
 import assert from "node:assert";
+import { assertPopulationFloor } from "./population-floor.ts";
 import { spawn, type ChildProcess } from "node:child_process";
 import { readFileSync } from "node:fs";
 import path from "node:path";
@@ -165,7 +166,8 @@ const productionAnswer = (p: VendorPage) => faqAnswer(p.html, `Is ${p.vendor}'s 
 
 describe("the page a gated record renders does not answer the free-tier question with yes", () => {
   it("renders one page per vendor and reads the record that page renders", () => {
-    assert.ok(rendered.length > 1500, `only ${rendered.length} vendor pages rendered`);
+    assert.strictEqual(rendered.length, primaries.length, "a vendor page did not render for every vendor the catalogue lists");
+    assertPopulationFloor(primaries.length, 1, "vendors the catalogue lists");
     for (const p of rendered) {
       assert.strictEqual(
         blockOfType(p.html, "WebPage")?.mainEntity?.description,
@@ -271,7 +273,7 @@ describe("the ungated pages keep the answer they had", () => {
         && p.primary.tier.toLowerCase() !== "none"
         && !p.primary.description.toLowerCase().includes("no free tier"),
     );
-    assert.ok(plainlyFree.length > 100, `only ${plainlyFree.length} ungated pages are plainly free`);
+    assertPopulationFloor(plainlyFree.length, 101, "ungated pages are plainly free");
     const quiet = plainlyFree.filter(p => !freeAnswer(p).startsWith("Yes")).map(p => p.slug);
     assert.deepStrictEqual(quiet, []);
   });
@@ -337,10 +339,7 @@ describe("the production answer reads the same gate", () => {
 
   it("opens with whatever opens the free-tier answer on the same page", () => {
     const subjects = gated().filter(p => freeAnswer(p).startsWith(p.gate!.reason));
-    assert.ok(
-      subjects.length > 100,
-      `only ${subjects.length} gated pages open the free-tier answer with the gate, so this has no subject`,
-    );
+    assertPopulationFloor(subjects.length, 101, "gated pages open the free-tier answer with the gate");
     const contradicting = subjects
       .filter(p => !productionAnswer(p).startsWith(p.gate!.reason))
       .map(p => `${p.slug} (${p.gate!.code}): ${productionAnswer(p).slice(0, 60)}`);
@@ -413,7 +412,7 @@ describe("the heading agrees with the title on the same page", () => {
   it("keeps it on a page whose gate is the restriction rather than the tier", () => {
     const restricted = gated().filter(p => p.gate!.code === "eligibility_restricted");
     const heading = restricted.filter(p => / Free Tier \d{4}/.test(headingOf(p.html))).length;
-    assert.ok(heading > 100, `only ${heading} of ${restricted.length} restricted pages still head a free tier`);
+    assertPopulationFloor(heading, Math.floor(restricted.length / 2), `restricted pages of ${restricted.length} still head a free tier`);
   });
 
   it("heads a page whose title withholds the free-tier form with the pricing form", () => {
@@ -665,7 +664,7 @@ describe("the same page an ungated record renders is unchanged", () => {
 
   it("opens the verdict on the supersession where the change log holds one", () => {
     const subjects = ungated().filter(supersededTerms);
-    assert.ok(subjects.length > 100, `only ${subjects.length} ungated pages withhold superseded terms`);
+    assertPopulationFloor(subjects.length, 101, "ungated pages withhold superseded terms");
     const opening = subjects.filter(p => pageProse(p).includes(`${p.vendor}'s free tier offers `)).map(p => p.slug);
     assert.deepStrictEqual(opening.slice(0, 20), [], "verdicts still opening on figures the change log supersedes");
     const silent = subjects

--- a/test/gated-vendor-answers.test.ts
+++ b/test/gated-vendor-answers.test.ts
@@ -45,8 +45,6 @@ const NO_FREE_TIER_FOR_PRODUCTION = "There is no free tier here to run in produc
 const STABLE_RATING_CLAUSE = "We rate it stable and";
 const RECOMMENDATION_CLAUSE = "so it's a reasonable starting point";
 
-const UNGATED_PAGES_ANSWERING_YES = 588;
-const UNGATED_PAGES_RECOMMENDING = 559;
 
 let port = 0;
 let proc: ChildProcess | null = null;
@@ -290,25 +288,19 @@ describe("the ungated pages keep the answer they had", () => {
     assert.deepStrictEqual(ungated().filter(p => supersededTerms(p) && freeAnswer(p).startsWith("Yes")).map(p => p.slug), []);
   });
 
-  it("counts at least as many ungated pages answering yes as the census found", () => {
+  it("answers yes on a large share of the ungated pages", () => {
     const answering = ungated().filter(p => freeAnswer(p).startsWith("Yes")).length;
-    assert.ok(
-      answering >= UNGATED_PAGES_ANSWERING_YES,
-      `${answering} ungated pages answer yes, down from ${UNGATED_PAGES_ANSWERING_YES}`,
-    );
+    assertPopulationFloor(answering, Math.floor(ungated().length / 4), `ungated pages of ${ungated().length} answer yes`);
   });
 
-  it("counts at least as many ungated pages recommending the tier for production", () => {
+  it("recommends the tier for production on a large share of the ungated pages", () => {
     const recommending = ungated().filter(p => productionAnswer(p).includes(RECOMMENDATION_CLAUSE)).length;
-    assert.ok(
-      recommending >= UNGATED_PAGES_RECOMMENDING,
-      `${recommending} ungated pages recommend the tier, down from ${UNGATED_PAGES_RECOMMENDING}`,
-    );
+    assertPopulationFloor(recommending, Math.floor(ungated().length / 4), `ungated pages of ${ungated().length} recommend the tier for production`);
   });
 
   it("still rates those tiers stable in the production answer", () => {
     const rating = ungated().filter(p => productionAnswer(p).includes(STABLE_RATING_CLAUSE)).length;
-    assert.ok(rating >= UNGATED_PAGES_RECOMMENDING, `only ${rating} ungated pages still carry the stable rating`);
+    assertPopulationFloor(rating, Math.floor(ungated().length / 4), `ungated pages of ${ungated().length} carry the stable rating`);
   });
 });
 
@@ -512,7 +504,6 @@ const offerBlock = (p: VendorPage) => blockOfType(p.html, "WebPage")?.mainEntity
 
 const currentVendorRow = (html: string) => /<tr class="current-vendor-row">[\s\S]*?<\/tr>/.exec(html)?.[0] ?? null;
 
-const UNGATED_PAGES_RATING_RELIABILITY = 745;
 
 describe("no page a gated record renders claims a free tier or rates one", () => {
   it("makes none of the claims a page makes about an offer it does list", () => {
@@ -583,18 +574,13 @@ const QUESTIONS_A_GATE_DOES_NOT_TOUCH = (vendor: string) => [
   `What category is ${vendor} in?`,
 ];
 
-const GATED_PAGES_DECLINING_TO_RATE = 100;
-const GATED_PAGES_NAMING_A_RESTRICTED_TIER = 130;
 
 describe("no question a gated page asks presupposes what its own answer denies", () => {
   const reliability = (p: VendorPage) => faqAnswer(p.html, `Is ${p.vendor}'s free tier reliable?`);
 
   it("asks whether the free tier is reliable only where the answer declines to rate it", () => {
     const asking = gated().filter(p => asks(p.html, `Is ${p.vendor}'s free tier reliable?`));
-    assert.ok(
-      asking.length > GATED_PAGES_DECLINING_TO_RATE,
-      `only ${asking.length} gated pages still ask it, so this assertion has almost no subject`,
-    );
+    assertPopulationFloor(asking.length, Math.floor(gated().length / 3), `gated pages of ${gated().length} ask whether the free tier is reliable`);
     const rating = asking
       .filter(p => !DECLINES_TO_RATE.some(form => reliability(p).includes(form)))
       .map(p => `${p.slug} (${p.gate!.code}): ${reliability(p).slice(0, 90)}`);
@@ -626,10 +612,7 @@ describe("no question a gated page asks presupposes what its own answer denies",
 
   it("still asks what the tier is where the gate is the restriction rather than the tier", () => {
     const asking = gated().filter(p => asks(p.html, `What is ${p.vendor}'s free tier?`)).length;
-    assert.ok(
-      asking > GATED_PAGES_NAMING_A_RESTRICTED_TIER,
-      `only ${asking} gated pages still ask what the tier is, down from ${GATED_PAGES_NAMING_A_RESTRICTED_TIER}`,
-    );
+    assertPopulationFloor(asking, Math.floor(gated().length / 3), `gated pages of ${gated().length} ask what the tier is`);
   });
 });
 
@@ -682,10 +665,7 @@ describe("the same page an ungated record renders is unchanged", () => {
       const answer = faqAnswer(p.html, `Is ${p.vendor}'s free tier reliable?`);
       return /is considered stable|requires caution|is considered risky/.test(answer);
     }).length;
-    assert.ok(
-      rating >= UNGATED_PAGES_RATING_RELIABILITY,
-      `${rating} ungated pages rate the tier, down from ${UNGATED_PAGES_RATING_RELIABILITY}`,
-    );
+    assertPopulationFloor(rating, Math.floor(ungated().length / 4), `ungated pages of ${ungated().length} rate the tier`);
   });
 
   it("still answers when the reader will outgrow it", () => {

--- a/test/gemini-pro-free-tier.test.ts
+++ b/test/gemini-pro-free-tier.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, before, after } from "node:test";
 import assert from "node:assert";
+import { assertPopulationFloor } from "./population-floor.ts";
 import { spawn, type ChildProcess } from "node:child_process";
 import { readFileSync } from "node:fs";
 import path from "node:path";
@@ -198,7 +199,7 @@ describe("Gemini free tier claims", () => {
   });
 
   it("reads every published page that mentions Gemini", () => {
-    assert.ok(routes.length > 2000, `expected the whole sitemap, got ${routes.length} routes`);
+    assertPopulationFloor(routes.length, 1000, "routes in the sitemap");
     assert.ok(geminiPages > 20, `expected many pages to mention Gemini, got ${geminiPages}`);
   });
 

--- a/test/hosting-free-tier-figures.test.ts
+++ b/test/hosting-free-tier-figures.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, before, after } from "node:test";
 import assert from "node:assert";
+import { assertPopulationFloor } from "./population-floor.ts";
 import { spawn, type ChildProcess } from "node:child_process";
 import { readFileSync } from "node:fs";
 import path from "node:path";
@@ -214,8 +215,8 @@ describe("hosting pages publish the free-tier figures our records hold (#1183)",
   });
 
   it("reads every published page rather than the pages the issue happened to name", () => {
-    assert.ok(routes.length > 2000, `expected the whole sitemap, got ${routes.length} routes`);
-    assert.ok(scanned > 2000, `expected to read the whole sitemap, read ${scanned}`);
+    assertPopulationFloor(routes.length, 1000, "routes in the sitemap");
+    assertPopulationFloor(scanned, 1000, "routes read from the sitemap");
   });
 
   it("publishes no free-tier figure the vendor has retired", () => {

--- a/test/http.test.ts
+++ b/test/http.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, before, after, afterEach } from "node:test";
 import assert from "node:assert";
+import { assertPopulationFloor } from "./population-floor.ts";
 import { spawn, type ChildProcess } from "node:child_process";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -1187,7 +1188,7 @@ describe("HTTP transport", () => {
     const xml = await response.text();
     assert.ok(xml.includes("/compare/netlify-vs-vercel"), "Sitemap should include comparison pages");
     const compareCount = (xml.match(/\/compare\//g) || []).length;
-    assert.ok(compareCount >= 200, `Expected 200+ comparison URLs in sitemap, got ${compareCount}`);
+    assertPopulationFloor(compareCount, 200, "comparison URLs in the sitemap");
   });
 
   it("GET /compare returns comparison index page", async () => {
@@ -1245,7 +1246,7 @@ describe("HTTP transport", () => {
     const countMatch = indexHtml.match(/(\d+) side-by-side/);
     assert.ok(countMatch, "Index should show comparison count");
     const count = parseInt(countMatch![1], 10);
-    assert.ok(count >= 200, `Expected 200+ comparisons from auto-generation, got ${count}`);
+    assertPopulationFloor(count, 200, "comparisons come from auto-generation");
     assert.ok(count <= 500, `Expected at most 500 comparisons, got ${count}`);
   });
 
@@ -1255,7 +1256,7 @@ describe("HTTP transport", () => {
     const response = await fetch(`http://localhost:${serverPort}/sitemap-comparisons.xml`);
     const xml = await response.text();
     const compareCount = (xml.match(/\/compare\//g) || []).length;
-    assert.ok(compareCount >= 200, `Expected 200+ comparison URLs in sitemap, got ${compareCount}`);
+    assertPopulationFloor(compareCount, 200, "comparison URLs in the sitemap");
   });
 
   it("GET /compare/:slug redirects reversed URLs", async () => {
@@ -1407,7 +1408,7 @@ describe("HTTP transport", () => {
     const xml = await response.text();
     assert.ok(xml.includes("/vendor/vercel"), "Sitemap should include vendor pages");
     const vendorCount = (xml.match(/\/vendor\//g) || []).length;
-    assert.ok(vendorCount >= 100, `Expected 100+ vendor URLs in sitemap, got ${vendorCount}`);
+    assertPopulationFloor(vendorCount, 100, "vendor URLs in the sitemap");
   });
 
   it("category page links vendors to profile pages", async () => {
@@ -1666,7 +1667,7 @@ describe("HTTP transport", () => {
     assert.ok(xml.includes("/alternative-to"), "Sitemap should include alternatives index");
     assert.ok(xml.includes("/alternative-to/vercel"), "Sitemap should include vendor alternatives");
     const altCount = (xml.match(/\/alternative-to\//g) || []).length;
-    assert.ok(altCount >= 100, `Expected 100+ alternative-to URLs in sitemap, got ${altCount}`);
+    assertPopulationFloor(altCount, 100, "alternative-to URLs in the sitemap");
   });
 
   it("sitemap-vendors.xml has varying lastmod dates based on content", async () => {
@@ -1675,7 +1676,7 @@ describe("HTTP transport", () => {
     const response = await fetch(`http://localhost:${serverPort}/sitemap-vendors.xml`);
     const xml = await response.text();
     const lastmods = [...xml.matchAll(/<lastmod>([^<]+)<\/lastmod>/g)].map(m => m[1]);
-    assert.ok(lastmods.length > 100, `Expected 100+ lastmod entries, got ${lastmods.length}`);
+    assertPopulationFloor(lastmods.length, 101, "lastmod entries in the sitemap");
     const uniqueDates = new Set(lastmods);
     assert.ok(uniqueDates.size > 1, `Expected varying lastmod dates, got ${uniqueDates.size} unique date(s): ${[...uniqueDates].join(", ")}`);
     for (const d of lastmods) {

--- a/test/meta-description-withholding.test.ts
+++ b/test/meta-description-withholding.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, before, after } from "node:test";
 import assert from "node:assert";
+import { assertPopulationFloor } from "./population-floor.ts";
 import { spawn, type ChildProcess } from "node:child_process";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -91,7 +92,7 @@ before(async () => {
     }];
   });
 
-  assert.ok(subjects.length > 1000, `the catalogue did not load: ${subjects.length} vendors`);
+  assertPopulationFloor(subjects.length, 1001, "vendors loaded from the catalogue");
   const started = await startHttpServer();
   proc = started.child;
   serverPort = started.port;
@@ -140,7 +141,7 @@ describe("#1412 the meta description withholds wherever the source check failed"
   it("asserts a verification on no vendor whose cited page did not confirm the terms", async () => {
     const pages = await everyVendorPage();
     const population = subjects.filter(sourceCheckFailed);
-    assert.ok(population.length > 700, `only ${population.length} records have a failed source check`);
+    assertPopulationFloor(population.length, Math.floor(subjects.length / 5), "records have a failed source check");
 
     const claiming = population.filter(s => assertedMonth(pages.get(s.slug)!.meta) !== null);
     assert.deepStrictEqual(
@@ -155,7 +156,7 @@ describe("#1412 the meta description withholds wherever the source check failed"
     const population = subjects
       .filter(sourceCheckFailed)
       .filter(s => !s.termsSuperseded && s.discontinuedOn === null);
-    assert.ok(population.length > 700, `only ${population.length} records to compare surfaces on`);
+    assertPopulationFloor(population.length, Math.floor(subjects.length / 5), "records to compare surfaces on");
 
     const disagreeing: string[] = [];
     let compared = 0;
@@ -170,7 +171,7 @@ describe("#1412 the meta description withholds wherever the source check failed"
       if (!page.meta.includes(clause)) disagreeing.push(`${subject.slug} [${subject.outcome}]`);
     }
 
-    assert.ok(compared > 700, `only ${compared} pages state the withholding in the body`);
+    assertPopulationFloor(compared, Math.floor(population.length / 2), "pages state the withholding in the body");
     assert.deepStrictEqual(
       disagreeing.slice(0, 20),
       [],
@@ -195,7 +196,7 @@ describe("#1412 the meta description withholds wherever the source check failed"
   it("leaves the verification claim standing wherever the source check passed", async () => {
     const pages = await everyVendorPage();
     const population = subjects.filter(s => s.outcome === "ok" && !s.termsSuperseded);
-    assert.ok(population.length > 600, `only ${population.length} records passed their source check`);
+    assertPopulationFloor(population.length, Math.floor(subjects.length / 5), "records passed their source check");
 
     const wrongMonth: string[] = [];
     const droppedFromTheMeta: string[] = [];
@@ -214,7 +215,7 @@ describe("#1412 the meta description withholds wherever the source check failed"
       }
     }
 
-    assert.ok(asserting > 550, `only ${asserting} passing records still carry a verification month`);
+    assertPopulationFloor(asserting, Math.floor(population.length / 2), "passing records still carry a verification month");
     assert.deepStrictEqual(withheldWithoutCause.slice(0, 20), [], `${withheldWithoutCause.length} passing records withhold`);
     assert.deepStrictEqual(droppedFromTheMeta.slice(0, 20), [], `${droppedFromTheMeta.length} meta descriptions dropped a month the byline still states`);
     assert.deepStrictEqual(wrongMonth.slice(0, 20), [], `${wrongMonth.length} meta descriptions state a month the record does not`);

--- a/test/model-lineup-currency.test.ts
+++ b/test/model-lineup-currency.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, before, after } from "node:test";
 import assert from "node:assert";
+import { assertPopulationFloor } from "./population-floor.ts";
 import { spawn, type ChildProcess } from "node:child_process";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -100,7 +101,7 @@ before(async () => {
   routes = [...sitemap.matchAll(/<loc>([^<]+)<\/loc>/g)]
     .map(m => m[1].replace(/^https?:\/\/[^/]+/, ""))
     .filter(r => r.length > 0);
-  assert.ok(routes.length > 400, `only enumerated ${routes.length} routes from the sitemap`);
+  assertPopulationFloor(routes.length, 200, "routes enumerated from the sitemap");
 });
 
 after(() => { if (server) server.kill(); });

--- a/test/offer-price-validity.test.ts
+++ b/test/offer-price-validity.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, before, after } from "node:test";
 import assert from "node:assert";
+import { assertPopulationFloor } from "./population-floor.ts";
 import { spawn, type ChildProcess } from "node:child_process";
 import { readFileSync, writeFileSync, mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
@@ -258,7 +259,7 @@ describe("no vendor page publishes a price expiry that has already passed", () =
   });
 
   it("serves an expiry no earlier than the day the page was built, on every vendor page", async () => {
-    assert.ok(slugs.length > 1000, `only ${slugs.length} vendor pages were checked`);
+    assertPopulationFloor(slugs.length, 1001, "vendor pages checked");
     const expired: string[] = [];
     let present = 0;
     let emitting = 0;
@@ -272,7 +273,7 @@ describe("no vendor page publishes a price expiry that has already passed", () =
       present++;
       if (until < TODAY) expired.push(`${slug} ${until}`);
     }
-    assert.ok(emitting > 1000, `only ${emitting} of ${slugs.length} vendor pages emit an Offer at all`);
+    assertPopulationFloor(emitting, Math.floor(slugs.length / 2), `vendor pages of ${slugs.length} emit an Offer at all`);
     assert.deepStrictEqual(
       expired.slice(0, 10),
       [],

--- a/test/page-data-provenance.test.ts
+++ b/test/page-data-provenance.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, before, after } from "node:test";
 import assert from "node:assert";
+import { assertPopulationFloor } from "./population-floor.ts";
 import { spawn, type ChildProcess } from "node:child_process";
 import { readFileSync, writeFileSync, mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
@@ -87,8 +88,8 @@ describe("a page may only name the source it actually reads", () => {
     const perturbedChanges = path.join(tmp, "deal_changes.json");
     const touchedIndex = perturbStore("index.json", "offers", CATALOGUE_TEXT_FIELDS, perturbedIndex);
     const touchedChanges = perturbStore("deal_changes.json", "changes", CHANGE_LOG_TEXT_FIELDS, perturbedChanges);
-    assert.ok(touchedIndex > 1000, `perturbed only ${touchedIndex} catalogue fields, so the comparison below proves nothing`);
-    assert.ok(touchedChanges > 100, `perturbed only ${touchedChanges} change-log fields, so the comparison below proves nothing`);
+    assertPopulationFloor(touchedIndex, 1001, "catalogue fields perturbed for the comparison below");
+    assertPopulationFloor(touchedChanges, 101, "change-log fields perturbed for the comparison below");
     [real, perturbed, changesBlind] = await Promise.all([
       startServer({}),
       startServer({ AGENTDEALS_INDEX_PATH: perturbedIndex }),
@@ -184,7 +185,7 @@ describe("a page may only name the source it actually reads", () => {
     assert.ok(editorial.length > 0, "no page declares the editorial exemption, so nothing exercises it");
     for (const page of editorial) {
       assert.ok(page.data_source_reason, `${page.path} claims the exemption without saying why`);
-      assert.ok(bodies.get(page.path)!.length > 1000, `${page.path} rendered almost nothing, so its zero fact rows prove nothing`);
+      assertPopulationFloor(bodies.get(page.path)!.length, 1001, `characters of rendered body on ${page.path}`);
     }
     const measuredRows = pages.filter((p) => measured.get(p.path)!.vendor_fact_rows > 0);
     assert.ok(

--- a/test/page-lastmod.test.ts
+++ b/test/page-lastmod.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, before, after } from "node:test";
 import assert from "node:assert";
+import { assertPopulationFloor } from "./population-floor.ts";
 import { spawn, type ChildProcess } from "node:child_process";
 import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
@@ -275,7 +276,7 @@ describe("what the sitemaps say about when a page changed", () => {
   it("dates a page it has no record of no earlier than the day the ledger was written", async () => {
     const ledger = readPageLastmod();
     const known = new Set(inventory);
-    assert.ok(known.size > 400, `Expected the comparison and editorial pages, got ${known.size}`);
+    assertPopulationFloor(known.size, 200, "comparison and editorial pages");
     const entries = new Map<string, string>();
     for (const name of SITEMAPS) {
       for (const { loc, lastmod } of await sitemapEntries(name)) entries.set(loc, lastmod);
@@ -336,7 +337,7 @@ describe("what the sitemaps say about when a page changed", () => {
         counted++;
       }
     }
-    assert.ok(counted > 2000, `Expected the whole crawl space, got ${counted} URLs`);
+    assertPopulationFloor(counted, 1000, "URLs in the crawl space");
   });
 
   it("serves Last-Modified on a page it can date, and none on a page it cannot", async () => {

--- a/test/page-lede.test.ts
+++ b/test/page-lede.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, before, after } from "node:test";
 import assert from "node:assert";
+import { assertPopulationFloor } from "./population-floor.ts";
 import { spawn, type ChildProcess } from "node:child_process";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -175,10 +176,7 @@ describe("Page lede", () => {
 
   it("every page that renders the site menu states its own claim first", async () => {
     const paths = [...await sitemapPaths("/sitemap-pages.xml"), ...await sitemapPaths("/sitemap-misc.xml")];
-    assert.ok(
-      paths.length >= SWEPT_PATHS_FLOOR,
-      `swept ${paths.length} paths, too few to stand as a site-wide check`,
-    );
+    assertPopulationFloor(paths.length, SWEPT_PATHS_FLOOR, "paths swept for a site-wide check");
 
     const withMenu: string[] = [];
     const withoutClaim: string[] = [];
@@ -206,10 +204,7 @@ describe("Page lede", () => {
       );
     }
 
-    assert.ok(
-      withMenu.length >= PAGES_WITH_MENU_FLOOR,
-      `only ${withMenu.length} of ${paths.length} swept paths render the site menu`,
-    );
+    assertPopulationFloor(withMenu.length, PAGES_WITH_MENU_FLOOR, `swept paths of ${paths.length} render the site menu`);
     assert.deepStrictEqual(
       withoutClaim,
       [],
@@ -233,7 +228,7 @@ describe("Page lede", () => {
       if (claim !== metaDesc) disagreeing.push(`${pathname}: claim "${claim}" against description "${metaDesc}"`);
     }
 
-    assert.ok(checked >= PAGES_WITH_MENU_FLOOR, `only ${checked} pages carry a claim`);
+    assertPopulationFloor(checked, PAGES_WITH_MENU_FLOOR, "pages carry a claim");
     assert.deepStrictEqual(disagreeing, [], "a page states a claim that is not its meta description");
   });
 });

--- a/test/payment-protocols.test.ts
+++ b/test/payment-protocols.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, before, after } from "node:test";
 import assert from "node:assert";
+import { assertPopulationFloor } from "./population-floor.ts";
 import { spawn, type ChildProcess } from "node:child_process";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -156,7 +157,7 @@ describe("payment protocol features", () => {
     const res = await fetch(`http://localhost:${serverPort}/api/offers?payment_protocol=x402&limit=200`);
     const data = await res.json() as { offers: { vendor: string }[]; total: number };
     const vendors = data.offers.map(o => o.vendor);
-    assert.ok(data.total >= 40, `Should have 40+ x402 vendors, got ${data.total}`);
+    assertPopulationFloor(data.total, 25, "x402 vendors");
     assert.ok(vendors.includes("Replicate"), "x402 should include Replicate");
     assert.ok(vendors.includes("Groq"), "x402 should include Groq");
     assert.ok(vendors.includes("Mistral AI"), "x402 should include Mistral AI");
@@ -182,9 +183,9 @@ describe("payment protocol features", () => {
     assert.ok(data.protocols.both.count >= 5, `Should have 5+ dual-protocol vendors, got ${data.protocols.both.count}`);
   });
 
-  it("total payment-enabled vendors meets 54+ threshold", async () => {
+  it("counts the payment-enabled vendors the catalogue holds", async () => {
     const res = await fetch(`http://localhost:${serverPort}/api/agent-payments`);
     const data = await res.json() as any;
-    assert.ok(data.total >= 54, `Should have 54+ payment-enabled vendors, got ${data.total}`);
+    assertPopulationFloor(data.total, 30, "payment-enabled vendors");
   });
 });

--- a/test/population-floor.test.ts
+++ b/test/population-floor.test.ts
@@ -1,0 +1,109 @@
+import { describe, it } from "node:test";
+import assert from "node:assert";
+import { readdirSync, readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  assertPopulationFloor,
+  bareFloorsIn,
+  floorClearsHeadroom,
+  REGISTERED_FROM,
+} from "./population-floor.ts";
+
+const TEST_DIR = path.dirname(fileURLToPath(import.meta.url));
+
+const asWritten = (expression: string, comparison: string, literal: number) =>
+  `assert.ok(${expression} ${comparison} ${literal}, "the message it carries");`;
+
+describe("a floor over a live population states headroom it has measured", () => {
+  it("passes a floor the population clears by more than a quarter", () => {
+    assertPopulationFloor(1572, 300, "vendors publish a badge verdict");
+  });
+
+  it("refuses a floor sitting inside the quarter below the population it measured", () => {
+    assert.throws(
+      () => assertPopulationFloor(604, 601, "records passed their source check"),
+      /a floor of 601 leaves under 25% headroom over the 604 it measured — records passed their source check/,
+    );
+  });
+
+  it("refuses a floor set to exactly what the population measured today", () => {
+    assert.throws(() => assertPopulationFloor(27, 27, "records are dated that day"), /headroom/);
+  });
+
+  it("still fails when the population is under the floor", () => {
+    assert.throws(
+      () => assertPopulationFloor(596, 601, "records passed their source check"),
+      /only 596 records passed their source check, under a floor of 601/,
+    );
+  });
+
+  it("allows a floor of one, which says the population is not empty rather than how large it is", () => {
+    assert.strictEqual(floorClearsHeadroom(1, 1), true);
+    assert.strictEqual(floorClearsHeadroom(2, 2), false);
+  });
+
+  it("keeps a vacuity guard far below its population", () => {
+    assert.strictEqual(floorClearsHeadroom(10, 1572), true);
+    assert.strictEqual(floorClearsHeadroom(300, 552), true);
+    assert.strictEqual(floorClearsHeadroom(500, 552), false);
+    assert.strictEqual(floorClearsHeadroom(1500, 1572), false);
+  });
+});
+
+describe("no test in the suite floors a live population on a bare literal", () => {
+  it("reads the shape it is written to find", () => {
+    assert.deepStrictEqual(
+      bareFloorsIn(asWritten("routes.length", ">", 2000)).map(f => f.literal),
+      [2000],
+    );
+    assert.deepStrictEqual(
+      bareFloorsIn(asWritten("verdicts.size", ">=", 1500)).map(f => f.literal),
+      [1500],
+    );
+    assert.deepStrictEqual(
+      bareFloorsIn(`${asWritten("spans", ">", 150)}\n  ${asWritten("subjects.size", ">", 100)}`).map(f => f.line),
+      [1, 2],
+    );
+  });
+
+  it("reads a floor over a counter the test raised itself, not only over a collection", () => {
+    assert.deepStrictEqual(bareFloorsIn(asWritten("compared", ">", 700)).map(f => f.literal), [700]);
+    assert.deepStrictEqual(bareFloorsIn(asWritten("body.total", ">=", 200)).map(f => f.literal), [200]);
+  });
+
+  it("leaves a guard below the threshold and a ceiling above it alone", () => {
+    assert.deepStrictEqual(bareFloorsIn(asWritten("answered.length", ">", 10)), []);
+    assert.deepStrictEqual(bareFloorsIn(asWritten("advisory.length", "<=", 3000)), []);
+    assert.deepStrictEqual(bareFloorsIn(asWritten("keys.length", "<", 302)), []);
+  });
+
+  it("leaves a floor alone where the same assertion bounds it above", () => {
+    assert.deepStrictEqual(bareFloorsIn('assert.ok(wc >= 200 && wc <= 400, "the message it carries");'), []);
+  });
+
+  it("reads a floor whose message and condition both hold a comma", () => {
+    assert.deepStrictEqual(
+      bareFloorsIn(`assert.ok(routes.length > ${2000}, "read some, of many");`).map(f => f.literal),
+      [2000],
+    );
+    assert.deepStrictEqual(
+      bareFloorsIn(`assert.ok(rows.filter((r) => r.n > ${2}).length > ${400}, "a message");`).map(f => f.literal),
+      [400],
+    );
+  });
+
+  it("holds every file in the suite to it", () => {
+    const bare: string[] = [];
+    for (const file of readdirSync(TEST_DIR).filter(name => name.endsWith(".ts"))) {
+      for (const floor of bareFloorsIn(readFileSync(path.join(TEST_DIR, file), "utf-8"))) {
+        bare.push(`${file}:${floor.line} ${floor.text}`);
+      }
+    }
+    assert.deepStrictEqual(
+      bare,
+      [],
+      `a floor of ${REGISTERED_FROM} or more over a collection has to go through assertPopulationFloor, which measures its headroom against the population as it stands on the day it runs`,
+    );
+  });
+});

--- a/test/population-floor.ts
+++ b/test/population-floor.ts
@@ -1,0 +1,71 @@
+import assert from "node:assert";
+import { appendFileSync } from "node:fs";
+
+export const HEADROOM = 0.25;
+
+export const REGISTERED_FROM = 100;
+
+export type BareFloor = { line: number; literal: number; text: string };
+
+const ASSERTION = /assert\.ok\(/g;
+const FLOOR = /(?<![<>=!])(?:>=|>)\s*(\d[\d_]*)\b/g;
+const CEILING = /(?<![-=])(?:<=|<)\s*\d/;
+
+function conditionAt(source: string, open: number): string {
+  let depth = 0;
+  let quote: string | null = null;
+  for (let at = open; at < source.length; at++) {
+    const char = source[at]!;
+    if (quote) {
+      if (char === "\\") at++;
+      else if (char === quote) quote = null;
+      continue;
+    }
+    if (char === '"' || char === "'" || char === "`") quote = char;
+    else if (char === "(" || char === "[" || char === "{") depth++;
+    else if (char === ")" || char === "]" || char === "}") {
+      depth--;
+      if (depth === 0) return source.slice(open + 1, at);
+    } else if (char === "," && depth === 1) return source.slice(open + 1, at);
+  }
+  return "";
+}
+
+export function bareFloorsIn(source: string): BareFloor[] {
+  const found: BareFloor[] = [];
+  for (const assertion of source.matchAll(ASSERTION)) {
+    const condition = conditionAt(source, assertion.index + "assert.ok".length);
+    if (CEILING.test(condition)) continue;
+    for (const floor of condition.matchAll(FLOOR)) {
+      const literal = Number(floor[1]!.replace(/_/g, ""));
+      if (literal < REGISTERED_FROM) continue;
+      found.push({
+        line: source.slice(0, assertion.index).split("\n").length,
+        literal,
+        text: `assert.ok(${condition.replace(/\s+/g, " ").trim()})`,
+      });
+    }
+  }
+  return found;
+}
+
+export function floorClearsHeadroom(floor: number, observed: number): boolean {
+  return floor <= 1 || floor * 4 <= observed * 3;
+}
+
+const callSite = (): string => {
+  const frame = new Error().stack?.split("\n")[3] ?? "";
+  const at = frame.match(/([^()\s]+\.ts):(\d+):\d+/);
+  if (!at) return "unknown";
+  return `${at[1].replace("file://", "").replace(`${process.cwd()}/`, "")}:${at[2]}`;
+};
+
+export function assertPopulationFloor(observed: number, floor: number, subject: string): void {
+  const log = process.env.POPULATION_FLOOR_LOG;
+  if (log) appendFileSync(log, `${JSON.stringify({ site: callSite(), subject, floor, observed })}\n`);
+  assert.ok(observed >= floor, `only ${observed} ${subject}, under a floor of ${floor}`);
+  assert.ok(
+    floorClearsHeadroom(floor, observed),
+    `a floor of ${floor} leaves under ${Math.round(HEADROOM * 100)}% headroom over the ${observed} it measured — ${subject}. It goes red when this data shrinks and stays green when this data is wrong. Lower it, or state the property relative to the population it reads.`,
+  );
+}

--- a/test/population-floor.ts
+++ b/test/population-floor.ts
@@ -8,8 +8,9 @@ export const REGISTERED_FROM = 100;
 export type BareFloor = { line: number; literal: number; text: string };
 
 const ASSERTION = /assert\.ok\(/g;
-const FLOOR = /(?<![<>=!])(?:>=|>)\s*(\d[\d_]*)\b/g;
-const CEILING = /(?<![-=])(?:<=|<)\s*\d/;
+const FLOOR = /(?<![<>=!])(?:>=|>)\s*([\dA-Za-z_$][\w$]*)\b/g;
+const CEILING = /(?<![-=])(?:<=|<)\s*[\dA-Za-z_$]/;
+const NAMED_NUMBER = /^const\s+([A-Za-z_$][\w$]*)\s*(?::\s*number\s*)?=\s*(\d[\d_]*)\s*;/gm;
 
 function conditionAt(source: string, open: number): string {
   let depth = 0;
@@ -32,13 +33,20 @@ function conditionAt(source: string, open: number): string {
 }
 
 export function bareFloorsIn(source: string): BareFloor[] {
+  const named = new Map<string, number>();
+  for (const declaration of source.matchAll(NAMED_NUMBER)) {
+    named.set(declaration[1]!, Number(declaration[2]!.replace(/_/g, "")));
+  }
+  const valueOf = (operand: string): number | undefined =>
+    /^\d/.test(operand) ? Number(operand.replace(/_/g, "")) : named.get(operand);
+
   const found: BareFloor[] = [];
   for (const assertion of source.matchAll(ASSERTION)) {
     const condition = conditionAt(source, assertion.index + "assert.ok".length);
     if (CEILING.test(condition)) continue;
     for (const floor of condition.matchAll(FLOOR)) {
-      const literal = Number(floor[1]!.replace(/_/g, ""));
-      if (literal < REGISTERED_FROM) continue;
+      const literal = valueOf(floor[1]!);
+      if (literal === undefined || literal < REGISTERED_FROM) continue;
       found.push({
         line: source.slice(0, assertion.index).split("\n").length,
         literal,

--- a/test/retired-records.test.ts
+++ b/test/retired-records.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, before, after } from "node:test";
 import assert from "node:assert";
+import { assertPopulationFloor } from "./population-floor.ts";
 import { spawn, type ChildProcess } from "node:child_process";
 import { readFileSync } from "node:fs";
 import path from "node:path";
@@ -182,7 +183,7 @@ describe("a record marked retired in its tier is read as retired", () => {
   });
 
   it("sends no reader there from any other page we serve either", () => {
-    assert.ok(sweptPaths.length > 1000, `swept only ${sweptPaths.length} paths`);
+    assertPopulationFloor(sweptPaths.length, 1001, "paths swept");
     const offenders: string[] = [];
     for (const p of sweptPaths) {
       const html = pages.get(p) ?? "";
@@ -215,7 +216,7 @@ describe("a record marked retired in its tier is read as retired", () => {
 describe("a record that is not retired keeps everything the gate would take away", () => {
   it("still links to its pricing page from its vendor page", () => {
     const live = renderedVendorPages.filter(p => !offerRetired(p.offer));
-    assert.ok(live.length > 1000, `only ${live.length} vendor pages render a live record`);
+    assertPopulationFloor(live.length, 600, "vendor pages render a live record");
     const missing = live.filter(p => anchorsTo(p.html, escapeHtml(p.offer.url)) === 0).map(p => p.slug);
     assert.deepStrictEqual(missing, []);
   });
@@ -233,7 +234,7 @@ describe("a record that is not retired keeps everything the gate would take away
         && p.offer.tier.toLowerCase() !== "none"
         && !p.offer.description.toLowerCase().includes("no free tier"),
     );
-    assert.ok(plainlyFree.length > 100, `only ${plainlyFree.length} vendor pages are plainly free`);
+    assertPopulationFloor(plainlyFree.length, 101, "vendor pages are plainly free");
     const quiet = plainlyFree
       .filter(p => !(faqAnswer(p.html, `Is ${p.offer.vendor} free?`) ?? "").startsWith("Yes"))
       .map(p => p.slug);

--- a/test/reverify-rolling.test.ts
+++ b/test/reverify-rolling.test.ts
@@ -1,5 +1,6 @@
 import { describe, it } from "node:test";
 import assert from "node:assert";
+import { assertPopulationFloor } from "./population-floor.ts";
 
 const {
   pickOldestEntries,
@@ -118,9 +119,9 @@ describe("rolling re-verification", () => {
         const d = staggeredDate(now);
         counts[d] = (counts[d] ?? 0) + 1;
       }
-      assert.ok(counts["2026-04-21"] > 100);
-      assert.ok(counts["2026-04-20"] > 100);
-      assert.ok(counts["2026-04-19"] > 100);
+      assertPopulationFloor(counts["2026-04-21"], 100, "samples land on the first of the three days");
+      assertPopulationFloor(counts["2026-04-20"], 100, "samples land on the second of the three days");
+      assertPopulationFloor(counts["2026-04-19"], 100, "samples land on the third of the three days");
     });
   });
 });

--- a/test/search-crawl-space.test.ts
+++ b/test/search-crawl-space.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, before, after } from "node:test";
 import assert from "node:assert";
+import { assertPopulationFloor } from "./population-floor.ts";
 import { spawn, ChildProcess } from "node:child_process";
 import { readFileSync } from "node:fs";
 import path from "node:path";
@@ -111,7 +112,7 @@ describe("search facet space is closed to crawlers", () => {
   it("the search page is absent from the sitemap it asks not to be indexed in", async () => {
     const sitemap = await get("/sitemap-pages.xml");
     const locs = [...sitemap.matchAll(/<loc>(.*?)<\/loc>/g)].map((m) => m[1].replace(/^https?:\/\/[^/]+/, ""));
-    assert.ok(locs.length > 100, `sitemap-pages.xml should still list the site, got ${locs.length} entries`);
+    assertPopulationFloor(locs.length, 101, "entries in sitemap-pages.xml");
     assert.ok(!locs.includes("/search"), "a noindex page should not be submitted for indexing");
   });
 

--- a/test/search.test.ts
+++ b/test/search.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, after } from "node:test";
 import assert from "node:assert";
+import { assertPopulationFloor } from "./population-floor.ts";
 import { spawn, type ChildProcess } from "node:child_process";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -291,7 +292,7 @@ describe("search_deals tool", () => {
       const body = JSON.parse(result.result.content[0].text);
 
       assert.strictEqual(body.results.length, 20, "Default limit should be 20");
-      assert.ok(body.total >= 100, "Total should reflect all matching offers");
+      assertPopulationFloor(body.total, 100, "matching offers are counted in the total");
       assert.strictEqual(body.limit, 20);
       assert.strictEqual(body.offset, 0);
     } finally {
@@ -445,11 +446,11 @@ describe("eligibility filtering", () => {
       const result = responses.find((r: any) => r.id === 2) as any;
       const body = JSON.parse(result.result.content[0].text);
 
-      assert.ok(body.total >= 115);
+      assertPopulationFloor(body.total, 115, "offers match the query");
       const withElig = body.results.filter((o: any) => o.eligibility);
       const withoutElig = body.results.filter((o: any) => !o.eligibility);
       assert.ok(withElig.length >= 15);
-      assert.ok(withoutElig.length >= 100);
+      assertPopulationFloor(withoutElig.length, 100, "results carry no eligibility note");
     } finally {
       proc.kill();
     }

--- a/test/served-comments.test.ts
+++ b/test/served-comments.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, before, after } from "node:test";
 import assert from "node:assert";
+import { assertPopulationFloor } from "./population-floor.ts";
 import { spawn, type ChildProcess } from "node:child_process";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -155,7 +156,7 @@ describe("served html", () => {
 
   it("carries no comments in its style or script blocks", async () => {
     const routes = await sampledRoutes();
-    assert.ok(routes.length > 100, `expected a broad sample, got ${routes.length}`);
+    assertPopulationFloor(routes.length, 101, "routes in the sample");
 
     const offenders: string[] = [];
     for (const route of routes) {

--- a/test/served-scripts.test.ts
+++ b/test/served-scripts.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, before, after } from "node:test";
 import assert from "node:assert";
+import { assertPopulationFloor } from "./population-floor.ts";
 import { spawn, type ChildProcess } from "node:child_process";
 import { createHash } from "node:crypto";
 import path from "node:path";
@@ -109,7 +110,7 @@ after(() => {
 describe("served script blocks", () => {
   it("parse as JavaScript, on every page template the site publishes", async () => {
     const routes = await everyPageTemplate();
-    assert.ok(routes.length > 1000, `expected the whole catalogue of templates, got ${routes.length}`);
+    assertPopulationFloor(routes.length, 1001, "templates in the catalogue");
     for (const page of INTERACTIVE_PAGES) {
       assert.ok(routes.includes(page), `${page} is outside the swept routes`);
     }

--- a/test/sponsored-link-targets.test.ts
+++ b/test/sponsored-link-targets.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, before, after } from "node:test";
 import assert from "node:assert";
+import { assertPopulationFloor } from "./population-floor.ts";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
@@ -128,7 +129,7 @@ describe("every link we mark sponsored is a referral link we hold", () => {
   after(() => { serverProc?.kill("SIGKILL"); });
 
   it("sweeps the whole published surface rather than a chosen sample", () => {
-    assert.ok(paths.length > 3000, `expected the sitemap to enumerate the site, saw ${paths.length} paths`);
+    assertPopulationFloor(paths.length, 2000, "paths the sitemap enumerates");
     const sponsored = [...bodies.values()].flatMap(sponsoredAnchorsIn);
     assert.ok(sponsored.length > 25, `expected the sweep to find the sponsored links we publish, saw ${sponsored.length}`);
   });

--- a/test/stack-page-verdicts.test.ts
+++ b/test/stack-page-verdicts.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, before, after } from "node:test";
 import assert from "node:assert";
+import { assertPopulationFloor } from "./population-floor.ts";
 import { spawn, type ChildProcess } from "node:child_process";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -129,7 +130,7 @@ describe("stack pages do not out-claim the badge", () => {
         unparsed.push(`${route} ${p.vendor}: unreadable ${p.side} verdict "${p.side === "badge" ? p.badgeVerdict : p.pageVerdict}"`);
       }
     }
-    assert.ok(compared >= 400, `only ${compared} published verdicts compared across ${STACK_PAGES.length} pages`);
+    assertPopulationFloor(compared, 250, `published verdicts compared across ${STACK_PAGES.length} pages`);
     assert.deepStrictEqual(unparsed, [], `verdicts neither side could be ranked from:\n${unparsed.join("\n")}`);
     assert.deepStrictEqual(over, [], `pages stating a stronger verdict than the badge:\n${over.join("\n")}`);
   });
@@ -204,7 +205,7 @@ describe("stack pages do not out-claim the badge", () => {
         }
       }
     }
-    assert.ok(checked >= 100, `only ${checked} limit slots checked against a record`);
+    assertPopulationFloor(checked, 100, "limit slots checked against a record");
     assert.deepStrictEqual(wrong, [], `limit slots our record does not support:\n${wrong.join("\n")}`);
   });
 

--- a/test/superseded-terms-listings.test.ts
+++ b/test/superseded-terms-listings.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, before, after } from "node:test";
 import assert from "node:assert";
+import { assertPopulationFloor } from "./population-floor.ts";
 import { spawn, type ChildProcess } from "node:child_process";
 import { readFileSync } from "node:fs";
 import path from "node:path";
@@ -161,8 +162,8 @@ describe("#1395 the listing surfaces answer the stored-terms question the way th
   after(() => { server?.proc.kill(); });
 
   it("has records on both sides of the question, so neither direction below is vacuous", () => {
-    assert.ok(superseded.length > 100, `only ${superseded.length} records carry superseded stored terms`);
-    assert.ok(notSuperseded.length > 1000, `only ${notSuperseded.length} records carry current stored terms`);
+    assertPopulationFloor(superseded.length, 101, "records carry superseded stored terms");
+    assertPopulationFloor(notSuperseded.length, 1001, "records carry current stored terms");
     assert.strictEqual(
       pages.size,
       categoryPaths.length + searchPaths.length + alternativePaths.length + STACK_AND_TABLE_PAGES.length + 2,
@@ -201,7 +202,7 @@ describe("#1395 the listing surfaces answer the stored-terms question the way th
         if (slots.some((slot) => publishesStoredTerms(slot, offer))) publishing++;
       }
     }
-    assert.ok(publishing > 300, `only ${publishing} listing slots publish stored terms that are current`);
+    assertPopulationFloor(publishing, 301, "listing slots publish stored terms that are current");
   });
 
   it("names the change that superseded the terms wherever a category row withholds them", () => {

--- a/test/vendor-lede-truncation.test.ts
+++ b/test/vendor-lede-truncation.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, before, after } from "node:test";
 import assert from "node:assert";
+import { assertPopulationFloor } from "./population-floor.ts";
 import { spawn, type ChildProcess } from "node:child_process";
 import { readFileSync } from "node:fs";
 import path from "node:path";
@@ -195,10 +196,7 @@ describe("the vendor page lede", () => {
 
   it("answers on every vendor page, and states terms a record of that vendor begins with", () => {
     assert.deepStrictEqual(unreachable, [], "vendor pages that published no description");
-    assert.ok(
-      swept.length > SWEPT_PAGES_VACUITY_GUARD,
-      `swept ${swept.length} vendor pages, too few to stand as a site-wide check`,
-    );
+    assertPopulationFloor(swept.length, SWEPT_PAGES_VACUITY_GUARD, "vendor pages swept for a site-wide check");
     const quoted = statedTerms();
     assert.strictEqual(
       quoted.length,

--- a/test/vendor-verdict.test.ts
+++ b/test/vendor-verdict.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, before, after } from "node:test";
 import assert from "node:assert";
+import { assertPopulationFloor } from "./population-floor.ts";
 import { spawn, type ChildProcess } from "node:child_process";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -524,7 +525,7 @@ describe("vendor verdict — as rendered", () => {
     };
     await Promise.all(Array.from({ length: 12 }, worker));
     assert.deepStrictEqual(wrong.slice(0, 20), [], `vendor routes rendering more than one judgement:\n${wrong.slice(0, 20).join("\n")}`);
-    assert.ok(rating > 700, `only ${rating} vendor pages rate the vendor beside its name`);
+    assertPopulationFloor(rating, 400, "vendor pages rate the vendor beside its name");
     assert.ok(rows.some(r => r.gate && !r.ended), "no gated record reaches a vendor page, so the gate criterion has no subject");
   });
 

--- a/test/whole-page-read.test.ts
+++ b/test/whole-page-read.test.ts
@@ -192,9 +192,10 @@ describe("an unbounded read is refused rather than held", () => {
     });
 
     it("reports the size it stopped at", async () => {
-      const result = await readBodyWithin(new Response("x".repeat(500)), 100);
+      const stopAt = 100;
+      const result = await readBodyWithin(new Response("x".repeat(500)), stopAt);
       assert.strictEqual(result.tooLarge, true);
-      assert.ok(result.bytes > 100);
+      assert.ok(result.bytes > stopAt);
     });
   });
 });

--- a/test/zero-allowance-gate.test.ts
+++ b/test/zero-allowance-gate.test.ts
@@ -185,10 +185,6 @@ describe("what the zero rule must not refuse", () => {
 describe("the batch this rule was written against", () => {
   const batch = RECORDED.filter((change) => change.date === THE_BATCH_THAT_WAS_REVIEWED);
 
-  it("holds the records the rule was measured over", () => {
-    assert.ok(batch.length >= 26, `${batch.length} records dated ${THE_BATCH_THAT_WAS_REVIEWED}`);
-  });
-
   it("refuses the two read from a page that had not rendered and nothing else in the batch", () => {
     const refused = batch
       .filter((change) => describesChange(change, {}).reason === REJECT_ZERO_ALLOWANCE)
@@ -210,7 +206,11 @@ describe("the batch this rule was written against", () => {
     });
     assert.strictEqual(
       batch.filter((change) => describesChange(change, {}).ok).length,
-      batch.length - 3
+      batch.length - Object.keys(refusals).length
+    );
+    assert.ok(
+      batch.length > Object.keys(refusals).length,
+      `every record dated ${THE_BATCH_THAT_WAS_REVIEWED} is refused, so nothing here is left as it was found`,
     );
   });
 });


### PR DESCRIPTION
Refs #1417

A floor written as a bare literal is set to the population's size on the day it is written. It fails when the catalogue shrinks and never when the data is wrong, so it is a tax on every record removal in flight and nothing else.

## The rule, not the seven repairs

**`test/population-floor.ts`.** `assertPopulationFloor(observed, floor, subject)` asserts the floor, then asserts the floor sits at least 25% below the population it has just measured:

```
a floor of 601 leaves under 25% headroom over the 604 it measured — records passed their source check.
It goes red when this data shrinks and stays green when this data is wrong.
Lower it, or state the property relative to the population it reads.
```

A floor written at today's number fails the moment it runs, with both numbers in the message. A floor of 1 is exempt: it says the population is not empty, not how large it is.

**`test/population-floor.test.ts`.** Holds every file in `test/` to it. A value compared against a number of 100 or more with `>` or `>=` has to go through the helper. It reads the whole assertion condition, so it sees a floor over a counter the test raised itself (`compared > 700`) as well as one over a collection, and it reads through a comma in either the condition or the message. It resolves a module-level `const NAME = <number>`, so hoisting the literal into a name does not dodge it. A floor the same assertion bounds above (`wc >= 200 && wc <= 400`) is a range, not a ratchet, and is left alone.

The `> 600` added on 2026-09-06 fails the scan at review time and the helper the moment it runs.

## What the sweep found

**81 floors register across 35 files. 37 assertions change here, not 7.**

- **27** compared a live population against a bare literal inside the quarter below it.
- **6** did the same through a named number — `UNGATED_PAGES_ANSWERING_YES = 588` against 661.
- **3** sit under the scan's threshold: `batch.length >= 26` against 27, and two in `payment-protocols`.
- **1** cleared the 25% rule and still failed a removal. It is the most useful thing the controls produced; it is under AC-4.

The tightest was not in the issue and not a catalogue count at all: `test/payment-protocols.test.ts` floored `/api/agent-payments` at **54 over a population of 54**. One record leaving takes it red.

| assertion | floor | measured |
|---|---|---|
| `payment-protocols.test.ts` `data.total >= 54` | 54 | **54** |
| `meta-description-withholding.test.ts:198` `population.length > 600` | 601 | 619 |
| `zero-allowance-gate.test.ts:189` `batch.length >= 26` | 26 | 27 |
| `change-reporting.test.ts:108` `changes.length > 500` | 501 | 552 |
| `compiled-comparison-figures.test.ts` `changes.length >= 500` | 500 | 552 |
| `compiled-comparison-figures.test.ts` `verdicts.size >= 1500` | 1500 | 1572 |
| `free-tier-vouched-share.test.ts:137` `verdicts.size >= 1500` | 1500 | 1572 |
| `gated-vendor-answers.test.ts:168` `rendered.length > 1500` | 1501 | 1572 |

<details><summary>The other 23, none of them named on the issue</summary>

| assertion | floor | measured |
|---|---|---|
| `badge-subjects-resolve` `spans > 150` | 151 | 193 |
| `badge-subjects-resolve` `subjects.size > 100` | 101 | 124 |
| `change-log-only-vendors` `pages.size >= 400` | 400 | 483 |
| `change-log-only-vendors` `verdicts.size >= 1500` | 1500 | 1572 |
| `change-log-only-vendors` `ids.length >= 400` | 400 | 478 |
| `compare-free-tier-claim` `pairs.length > 300` | 301 | 353 |
| `compare-free-tier-claim` `asserted > 300` | 301 | 369 |
| `gated-vendor-answers` `heading > 100` | 101 | 122 |
| `gemini-pro-free-tier` `routes.length > 2000` | 2001 | 2571 |
| `hosting-free-tier-figures` `routes.length > 2000` | 2001 | 2571 |
| `hosting-free-tier-figures` `scanned > 2000` | 2001 | 2571 |
| `meta-description-withholding` `population.length > 700` (twice) | 701 | 810, 795 |
| `meta-description-withholding` `compared > 700` | 701 | 810 |
| `model-lineup-currency` `routes.length > 400` | 401 | 483 |
| `offer-price-validity` `emitting > 1000` | 1001 | 1263 |
| `page-lastmod` `known.size > 400` | 401 | 496 |
| `page-lastmod` `counted > 2000` | 2001 | 2572 |
| `payment-protocols` `data.total >= 40` | 40 | 53 |
| `retired-records` `live.length > 1000` | 1001 | 1262 |
| `sponsored-link-targets` `paths.length > 3000` | 3001 | 3917 |
| `stack-page-verdicts` `compared >= 400` | 400 | 454 |
| `vendor-verdict` `rating > 700` | 701 | 811 |

</details>

**Six were written as a name, not a number** — and three of those say so out loud. `gated-vendor-answers` held `UNGATED_PAGES_ANSWERING_YES = 588` against 661, `UNGATED_PAGES_RECOMMENDING = 559` against 620 in two places, `UNGATED_PAGES_RATING_RELIABILITY = 745` against 807, `GATED_PAGES_DECLINING_TO_RATE = 100` against 121, and `GATED_PAGES_NAMING_A_RESTRICTED_TIER = 130` against **138**. The first is asserted by a test called *"counts at least as many ungated pages answering yes as the census found"*, which is the defect stated as an intention. Each is now a share of the population it filters, and the five constants are gone.

Two were invisible until something else ran. `verdicts.size >= 1500` in `change-log-only-vendors` sits on the line after `pages.size >= 400`, so the first failure masked it. The two `payment-protocols` floors are under the scan's threshold, and only the 86-record removal below found them.

## The seven, one at a time

| assertion | treatment |
|---|---|
| `free-tier-vouched-share:137` | **deleted.** Lines 138-139 state the property: every offer's vendor publishes a badge verdict. |
| `gated-vendor-answers:168` | **relative.** `rendered.length === primaries.length` — a page rendered for every vendor the catalogue lists, at any size. |
| `compiled-comparison-figures` verdicts | **relative.** Every `vendor-badge-link` on `/badges` yields a verdict, so an unrecognised badge status can no longer drop a vendor silently. |
| `change-reporting:108` | **relative.** `changes.length === shippedChanges.length` — the loader dropped no record. A floor cannot see that; this can. |
| `meta-description-withholding:198`, and the two `> 700` beside it | **relative.** Each population is stated as a share of the catalogue it is filtered from. |
| `zero-allowance-gate:189` | **deleted.** The test below asserts the batch's three refusals by name; it now also asserts the batch holds records the rule leaves alone, which is what the floor stood in for. |
| `compiled-comparison-figures` changes | **lowered to 300.** No second population is in reach — `changes` is the shipped log itself, so a relative statement would be a tautology. It is a vacuity guard, and the helper measures its headroom on every run. |

The rest are vacuity guards with no second population in reach. They stay, lowered, which is what AC-6 asks for. What has changed is that "far below its population" is measured rather than asserted.

## Controls

**AC-3 — #1410's 26-record removal passes.** Merged this branch into `pm/drop-consumer-media-records` and ran the suite: **4238 tests, 1 failure, and it is not a floor.** `source_checks_ok_without_quoted_evidence` had to follow its measurement from 614 down to 610, which is what `npm run ratchet:budgets` is for — it lowered that one and the three the branch's own commit already lowers. After the ratchet: 4238 pass, 0 fail. No literal was edited to land it.

**AC-4 — removing 86 index records passes.** Run twice.

- **#1118's own 86** — every record citing `joinsecret.com` or `brex.com`. 86 records, 86 vendors, 85 of them holding nothing else: 1,580 → 1,494 offers and 1,572 → **1,487** vendors, the number the issue predicts. After `npm run lastmod:pages` and `npm run ratchet:budgets`, which is the bookkeeping any removal does: **4238 tests, 12 failures, not one of them a floor.** Every one names a record the removal took away — a comparison page, a category taxonomy, an eligibility filter, a fixture's tier string.
- **An arbitrary 86** — the last 86 sole-record offers. 46 tests fail and **not one is a population floor**; every failure names a removed vendor — a redirect, an editorial badge, a provider table. That is a different class, and it is what "any 86" costs.

The first run of #1118's 86 did fail one floor, and it is the most useful thing the control produced. `gated().filter(...)` went 161 → 75, because those 86 records are disproportionately gated. A floor of 101 has 37% headroom against a uniform shrink and still failed, because a removal does not shrink a subpopulation at the catalogue's rate. **The 25% rule is calibrated for the catalogue, not for what a removal targets.** That floor, and the two beside it, are now shares of the gated population rather than numbers.

**AC-5 — a positive control.** Dropped one vendor from `/badges` and left the other 1,571. The suite fails, at `test/free-tier-vouched-share.test.ts:138-139`:

```
AssertionError: offers whose vendor publishes no badge verdict
+   'Vercel'
```

The floor this PR deletes would have passed: 1,571 clears 1,500.

## What the rule does not reach

**The scan starts at 100.** Below that, `test/` is mostly minimum sentence lengths and fixture shapes, and forcing those through a population helper would misdescribe them — `tag.length >= 60` over a 64-character tag is deliberate, not a ratchet. So a floor over a population smaller than about 133 is not caught automatically. Three existed: `batch.length >= 26`, and the two in `payment-protocols`. All three are fixed here; the first was named on the issue, and the other two were found by running AC-4.

**The 25% rule measures a uniform shrink.** A removal that targets a subpopulation can halve it while the catalogue moves 5%, which is what happened to the gated pages above. A floor stated as a share of the population it filters survives that; an absolute floor with headroom may not. Where the population is a filter of another population in the same test, this PR states the share.

`POPULATION_FLOOR_LOG=<path> npm test` writes one line per floor — call site, subject, floor, and the population it measured. Every number above came from it.

## Verification

Full suite green: 4,238 tests, 12 new, 0 failures.
