### PR TITLE
Publish what a category name holds and which names answer alongside it (#1436)

### DIFF
--- a/data/index.json
+++ b/data/index.json
@@ -3256,7 +3256,7 @@
     },
     {
       "vendor": "PostHog",
-      "category": "Startup Programs",
+      "category": "Startup Perks",
       "description": "$50,000/year in credits for Y Combinator companies — auto-renews annually. Covers product analytics, session replay, feature flags, and experimentation. Must have raised less than $25M",
       "tier": "YC Deal",
       "url": "https://posthog.com/pricing",
@@ -3286,7 +3286,7 @@
     },
     {
       "vendor": "Segment",
-      "category": "Analytics",
+      "category": "Startup Perks",
       "description": "$50,000 in credits toward monthly Team plan for up to 2 years. Includes access to $1M+ in partner deals (AWS, Google, Intercom) and Analytics Academy",
       "tier": "Startup Program",
       "url": "https://segment.com/docs/guides/usage-and-billing/discounts-for-startups-npos/",
@@ -3315,7 +3315,7 @@
     },
     {
       "vendor": "Amplitude",
-      "category": "Startup Programs",
+      "category": "Startup Perks",
       "description": "1 year free Growth plan — 200K MTUs or 100M events/month. All Growth features including Behavioral Cohorts, Pathfinder, experimentation, and predictive audiences. 96%+ approval rate",
       "tier": "Startup Scholarship",
       "url": "https://amplitude.com/startups",
@@ -3342,7 +3342,7 @@
     },
     {
       "vendor": "AWS Activate",
-      "category": "Cloud IaaS",
+      "category": "Startup Perks",
       "description": "Founders: $1,000 credits (self-funded startups). Portfolio: up to $100,000 credits (VC/accelerator-backed). Additional up to $300,000 in Trainium/Inferentia credits for AI startups building on AWS custom silicon (requires provider nomination). All credits usable on Bedrock models",
       "tier": "Portfolio",
       "url": "https://aws.amazon.com/activate/",
@@ -3440,7 +3440,7 @@
     },
     {
       "vendor": "Sentry",
-      "category": "Startup Programs",
+      "category": "Startup Perks",
       "description": "Free sponsored plan with Business features — 5M errors, 1B spans, 5,000 GB logs, 100K replays, 500 cron monitors, 25 uptime monitors, 3K continuous profile hours. No term limit",
       "tier": "OSS Sponsored",
       "url": "https://sentry.io/for/open-source/",
@@ -3477,7 +3477,7 @@
     },
     {
       "vendor": "Brex",
-      "category": "Startup Programs",
+      "category": "Startup Perks",
       "description": "$350,000+ in aggregate partner perks for Brex cardholders — includes $5K AWS credits, $2.5K OpenAI credits, $200K Google Cloud, 20 free GitHub Enterprise seats, 6mo free Notion, $500 Anthropic credits, and 30+ more partner discounts",
       "tier": "Partner Perks",
       "url": "https://www.brex.com/solutions/startups",
@@ -3507,7 +3507,7 @@
     },
     {
       "vendor": "Mercury",
-      "category": "Startup Programs",
+      "category": "Startup Perks",
       "description": "1 year free Datadog (up to $100K value), $5K AWS credits, up to $200K Google Cloud credits, and 30% off QuickBooks Online for Mercury banking customers",
       "tier": "Banking Perks",
       "url": "https://mercury.com/perks",
@@ -3537,7 +3537,7 @@
     },
     {
       "vendor": "Ramp",
-      "category": "Startup Programs",
+      "category": "Startup Perks",
       "description": "Up to $5,000 in AWS credits plus partner discounts on Notion, and other tools. Part of $350K+ total partner rewards program",
       "tier": "Partner Rewards",
       "url": "https://ramp.com/rewards/aws",
@@ -3565,7 +3565,7 @@
     },
     {
       "vendor": "Stripe Atlas",
-      "category": "Startup Programs",
+      "category": "Startup Perks",
       "description": "$500 one-time incorporation (Delaware filing and fees, tax ID, founder equity issuance, 83(b) filing, document templates, first year of registered agent), $100/year after. Includes $2,500 in Stripe product credits and access to over $50,000 in partner discounts.",
       "tier": "Founder Perks",
       "url": "https://stripe.com/atlas",
@@ -3598,7 +3598,7 @@
     },
     {
       "vendor": "SVB (Silicon Valley Bank)",
-      "category": "Startup Programs",
+      "category": "Startup Perks",
       "description": "$5K AWS credits, up to $100K Google Cloud credits (usage-based annual cap), $5K MongoDB credits, $9K off Slack, and $50K Segment credits for SVB startup banking customers. Now a division of First Citizens BancShares",
       "tier": "Banking Offers",
       "url": "https://www.svb.com/startup-banking/",
@@ -3664,7 +3664,7 @@
     },
     {
       "vendor": "Google Cloud",
-      "category": "Startup Programs",
+      "category": "Startup Perks",
       "description": "Scale: up to $200,000 over 2 years for equity-funded startups. Scale AI: up to $350,000 over 2 years ($250K Y1 + $100K Y2) for AI-first startups (pre-seed to Series A). Includes $10K Model Garden credits, $12K support credits, Google Workspace, and dedicated Startup Success Manager",
       "tier": "Startup Program",
       "url": "https://cloud.google.com/startup",
@@ -4482,7 +4482,7 @@
     },
     {
       "vendor": "DigitalOcean",
-      "category": "Startup Programs",
+      "category": "Startup Perks",
       "description": "Hatch startup program — up to $100K compute credits over 12 months. GPU Droplets at $1.90/GPU/hour for 12 months (H100 excluded from credits). 15 months Standard support. Partner perks from Cloudflare, Stripe, Retool, HubSpot. Must have raised $10M or less",
       "tier": "Hatch",
       "url": "https://www.digitalocean.com/startups",
@@ -4523,7 +4523,7 @@
     },
     {
       "vendor": "Atlassian",
-      "category": "Project Management",
+      "category": "Startup Perks",
       "description": "50 seats free for 12 months — Jira Premium, Confluence Premium, Loom Business + AI, Jira Product Discovery, Compass, Bitbucket Premium. Dedicated CSM and onboarding",
       "tier": "Startup Program",
       "url": "https://www.atlassian.com/software/startups",
@@ -4812,7 +4812,7 @@
     },
     {
       "vendor": "Microsoft Founders Hub",
-      "category": "Cloud IaaS",
+      "category": "Startup Perks",
       "description": "Up to $5,000 Azure credits (basic path, no investor required) or up to $150,000 (investor network path). Includes M365 Business Premium (50 seats), GitHub Enterprise (20 users), Visual Studio Enterprise (5 users), Power Apps (10 users)",
       "tier": "Startup Program",
       "url": "https://www.microsoft.com/en-us/startups",
@@ -5352,7 +5352,7 @@
     },
     {
       "vendor": "IBM Cloud",
-      "category": "Startup Programs",
+      "category": "Startup Perks",
       "description": "Builder tier: $1,000/month for 12 months ($12K total). Premium tier: $10,000/month for 12 months ($120K total, requires approved VC/accelerator affiliation). 170+ cloud products (AI, IoT, data, dev tools). No-cost, no-equity",
       "tier": "Startup Program",
       "url": "https://www.ibm.com/partners/startup",
@@ -5383,7 +5383,7 @@
     },
     {
       "vendor": "Cloudflare",
-      "category": "Startup Programs",
+      "category": "Startup Perks",
       "description": "Up to $250K in Cloudflare credits across 4 tiers: Bootstrapped ($5K), Up-and-Coming ($25K), Seed-Funded ($100K), High Growth ($250K). Covers Workers, R2, Workers AI, Stream, Durable Objects, and more. Credits expire within 1 year. Max $10K toward R2/Cache Reserve, up to $50K for Workers AI",
       "tier": "Startup Program",
       "url": "https://www.cloudflare.com/forstartups/",
@@ -5417,7 +5417,7 @@
     },
     {
       "vendor": "Amazon Kiro (AWS Startups)",
-      "category": "Startup Programs",
+      "category": "Startup Perks",
       "description": "Up to 1 year of free Kiro Pro+ (worth $480/year) through AWS Startups program. Three tiers: Starter (up to 2 users), Growth (up to 50 users), Scale (up to 100 users). Eligible: early-stage to Series B companies. Application via AWS Startups portal.",
       "tier": "Startup Program",
       "url": "https://aws.amazon.com/startups/",
@@ -27401,7 +27401,7 @@
     },
     {
       "vendor": "Microsoft for Startups",
-      "category": "Cloud IaaS",
+      "category": "Startup Perks",
       "description": "Get access to a wide range of benefits—from technical resources and free Azure cloud, to selling alongside Microsoft salespeople and partner channel.",
       "tier": "Startup Program",
       "url": "https://startups.microsoft.com/en-us/",
@@ -27427,7 +27427,7 @@
     },
     {
       "vendor": "Create@Alibaba Cloud",
-      "category": "Cloud IaaS",
+      "category": "Startup Perks",
       "description": "Create@Alibaba Cloud is a global program focused on accelerating business success for startups.",
       "tier": "Startup Program",
       "url": "https://www.alibabacloud.com/startup",
@@ -27453,7 +27453,7 @@
     },
     {
       "vendor": "Clever Bootstrap Program",
-      "category": "Cloud IaaS",
+      "category": "Startup Perks",
       "description": "Clever Cloud's startup programme is now called UP. It offers up to €10,000 in cloud credits for the first year, onboarding and training with Clever Cloud engineers, a monthly coaching session, premium support access, workshops and masterclasses for technical teams, mentoring, and access to Angel Start financial planning tools. Admission is by selection round; the page names the next as 16 September 2026.",
       "tier": "Startup Program",
       "url": "https://www.clever.cloud/up-program/",
@@ -27506,7 +27506,7 @@
     },
     {
       "vendor": "Scaleway Startup Program",
-      "category": "Cloud IaaS",
+      "category": "Startup Perks",
       "description": "Three tiers, all cloud credits: Founders gives up to €1,000 over one year; Early Stage gives €1,500/month for 6 months, up to €9,000; Growth gives €3,000/month for 12 months, up to €36,000. Applications are reviewed weekly by a committee. All tiers except Founders include a dedicated customer success manager.",
       "tier": "Startup Program",
       "url": "https://www.scaleway.com/en/startup-program/",
@@ -27534,7 +27534,7 @@
     },
     {
       "vendor": "ScaleGrid Startup Program",
-      "category": "Databases",
+      "category": "Startup Perks",
       "description": "ScaleGrid's startup offer is now called Startup Saver: up to 50% off for 12 months on managed MySQL, PostgreSQL, Redis and MongoDB. Bring Your Own Cloud plans get 50% off at medium size or larger; Dedicated Hosting gets 25% off at medium or larger. Small plan sizes get 50% off BYOC and 25% off Dedicated Hosting for 3 months.",
       "tier": "Startup Program",
       "url": "https://scalegrid.io/pricing/offers/startup-saver/",
@@ -27558,16 +27558,11 @@
         "checked": "2026-09-02",
         "outcome": "ok",
         "detail": "text"
-      },
-      "product_subtypes": {
-        "taxonomy": "Databases",
-        "labels": [],
-        "reviewed": "2026-08-31"
       }
     },
     {
       "vendor": "Knowlarity for Startups",
-      "category": "Communication",
+      "category": "Startup Perks",
       "description": "Unicorn dreams? Knowlarity is happy to offer free credits for its communications suite product—SuperReceptionist. Contact them for exclusive benefits.",
       "tier": "Startup Program",
       "url": "https://www.knowlarity.com/startups/",
@@ -27619,7 +27614,7 @@
     },
     {
       "vendor": "The Intercom Early Stage Program",
-      "category": "Communication",
+      "category": "Startup Perks",
       "description": "Intercom Early Stage pricing starts at $33/month, with 93% off in the first year, 50% off in the second and 25% off in the third. The first year includes 300 Fin outcomes and 15 Fin qualifications per month. The discount does not apply to additional outcomes or qualifications; phone, SMS and WhatsApp are charged at list price.",
       "tier": "Startup Program",
       "url": "https://www.intercom.com/early-stage",
@@ -27664,7 +27659,7 @@
     },
     {
       "vendor": "Zendesk for Startups",
-      "category": "Communication",
+      "category": "Startup Perks",
       "description": "Qualified startups get the Zendesk Resolution Platform free for up to 2 years for up to 50 agents, with the length depending on funding profile and partner. The baseline program length for all accepted startups is 6 months.",
       "tier": "Startup Program",
       "url": "https://www.zendesk.com/business/startups/",
@@ -27692,7 +27687,7 @@
     },
     {
       "vendor": "Help Scout for Startups",
-      "category": "Communication",
+      "category": "Startup Perks",
       "description": "Qualifying startups get 6 months of Help Scout free — the page states no charge for the first six months, not a discounted monthly rate.",
       "tier": "Startup Program",
       "url": "https://www.helpscout.com/startups/",
@@ -27762,7 +27757,7 @@
     },
     {
       "vendor": "Chargebee Launch Programme",
-      "category": "Payments",
+      "category": "Startup Perks",
       "description": "Chargebee's startup offer is now called Chargebee for Startups: Chargebee Billing is free until you have billed your first $1 million in cumulative revenue, not $50k. Cumulative billing is the total invoiced through Chargebee over time, not ARR or MRR. After $1M you move to a pay-as-you-go plan with no annual commitment.",
       "tier": "Startup Program",
       "url": "https://www.chargebee.com/startups/",
@@ -27817,7 +27812,7 @@
     },
     {
       "vendor": "Shotstack Startup Program",
-      "category": "Video",
+      "category": "Startup Perks",
       "description": "Qualifying startups get 80% off Shotstack's Professional plans for one year, applied as a discount code to a purchased plan. The page states no credit grant. Shotstack is a cloud video-editing API.",
       "tier": "Startup Program",
       "url": "https://shotstack.io/solutions/startups/",
@@ -30698,7 +30693,7 @@
     },
     {
       "vendor": "Vast.ai",
-      "category": "AI / ML",
+      "category": "Startup Perks",
       "description": "GPU marketplace — startup program offers $2,500 in free GPU credits. Access to A100s, H200s, and consumer cards. Up to 81% savings vs. major cloud GPU providers. 24/7 priority support during credit period. No long-term contracts",
       "tier": "Startup Program",
       "url": "https://vast.ai/startup",
@@ -30723,17 +30718,6 @@
         "checked": "2026-09-02",
         "outcome": "ok",
         "detail": "text"
-      },
-      "product_subtypes": {
-        "taxonomy": "AI / ML",
-        "labels": [
-          {
-            "subtype": "gpu_compute",
-            "source_url": "https://vast.ai/startup",
-            "source_quote": "From a single GPU to full clusters"
-          }
-        ],
-        "reviewed": "2026-09-01"
       }
     },
     {

--- a/data/page-lastmod.json
+++ b/data/page-lastmod.json
@@ -150,18 +150,6 @@
       "hash": "7ab265b2681856d4",
       "changed": "2026-09-05"
     },
-    "/compare/adapty-io-vs-chargebee-launch-programme": {
-      "hash": "246eba8f89d248c3",
-      "changed": "2026-09-05"
-    },
-    "/compare/adapty-io-vs-parityvend": {
-      "hash": "c7e34f98c4623c04",
-      "changed": "2026-09-05"
-    },
-    "/compare/adapty-io-vs-polar": {
-      "hash": "3b985b1c79ec203c",
-      "changed": "2026-09-05"
-    },
     "/compare/aider-vs-amazon-kiro": {
       "hash": "174ce50a2b885217",
       "changed": "2026-09-05"
@@ -190,17 +178,13 @@
       "hash": "b97cb21cd43edb60",
       "changed": "2026-09-05"
     },
-    "/compare/amplitude-vs-digitalocean": {
-      "hash": "756c4c5925564792",
-      "changed": "2026-09-05"
+    "/compare/amplitude-vs-heap-io": {
+      "hash": "d6a8d9355bfb6329",
+      "changed": "2026-09-07"
     },
-    "/compare/amplitude-vs-sentry": {
-      "hash": "877a8c391ab4df97",
-      "changed": "2026-09-05"
-    },
-    "/compare/amplitude-vs-svb-silicon-valley-bank": {
-      "hash": "2dc43e4d743a0df9",
-      "changed": "2026-09-05"
+    "/compare/amplitude-vs-smartlook-com": {
+      "hash": "3e76f98963c29b3d",
+      "changed": "2026-09-07"
     },
     "/compare/apple-health-vs-nike-training-club": {
       "hash": "c429606a628cc411",
@@ -268,18 +252,6 @@
     },
     "/compare/auth0-vs-clerk": {
       "hash": "7e1889712a285eba",
-      "changed": "2026-09-05"
-    },
-    "/compare/backlog-vs-meistertask": {
-      "hash": "ae8af3629dff8963",
-      "changed": "2026-09-05"
-    },
-    "/compare/backlog-vs-teleretro-com": {
-      "hash": "f97bd740958ee9e3",
-      "changed": "2026-09-05"
-    },
-    "/compare/backlog-vs-yodiz": {
-      "hash": "c8d27727090ff2e4",
       "changed": "2026-09-05"
     },
     "/compare/bitrise-vs-harness-ci": {
@@ -394,10 +366,6 @@
       "hash": "f8b972aaaf91d5ba",
       "changed": "2026-09-05"
     },
-    "/compare/chargebee-launch-programme-vs-polar": {
-      "hash": "daf121f3075d75df",
-      "changed": "2026-09-05"
-    },
     "/compare/checkov-vs-falco": {
       "hash": "9925326018b4ac69",
       "changed": "2026-09-05"
@@ -434,32 +402,8 @@
       "hash": "8862c6658ad3052b",
       "changed": "2026-09-05"
     },
-    "/compare/clicky-vs-heap-io": {
-      "hash": "300452b37216bb65",
-      "changed": "2026-09-05"
-    },
-    "/compare/clicky-vs-smartlook-com": {
-      "hash": "ab3a83031250e352",
-      "changed": "2026-09-05"
-    },
-    "/compare/clicky-vs-uxtweak-com": {
-      "hash": "4e094efac84d38bf",
-      "changed": "2026-09-05"
-    },
     "/compare/cline-vs-aider": {
       "hash": "3e617ecd3340f50e",
-      "changed": "2026-09-05"
-    },
-    "/compare/clouddev-vs-create-alibaba-cloud": {
-      "hash": "85153c6fa6747c26",
-      "changed": "2026-09-05"
-    },
-    "/compare/clouddev-vs-google-ai-pro-ultra": {
-      "hash": "ce44997b25bb1ffb",
-      "changed": "2026-09-05"
-    },
-    "/compare/clouddev-vs-oracle-cloud": {
-      "hash": "2c6234e86ebb2d6c",
       "changed": "2026-09-05"
     },
     "/compare/cloudflare-dynamic-workers-vs-daestro": {
@@ -542,6 +486,14 @@
       "hash": "a0b909818fba00fd",
       "changed": "2026-09-05"
     },
+    "/compare/cohere-vs-exa": {
+      "hash": "f1a5e7c6f0d8ba89",
+      "changed": "2026-09-07"
+    },
+    "/compare/cohere-vs-scale-ai": {
+      "hash": "7053dcf883814630",
+      "changed": "2026-09-07"
+    },
     "/compare/configcat-vs-harness-feature-flags": {
       "hash": "1a7f41f2ad6bc209",
       "changed": "2026-09-05"
@@ -566,18 +518,6 @@
       "hash": "fba914ed1c4b0571",
       "changed": "2026-09-05"
     },
-    "/compare/couchbase-capella-vs-neo4j-auradb": {
-      "hash": "af301eba78e2adae",
-      "changed": "2026-09-05"
-    },
-    "/compare/couchbase-capella-vs-nhost": {
-      "hash": "eccd60d797ed987b",
-      "changed": "2026-09-05"
-    },
-    "/compare/couchbase-capella-vs-redis-cloud": {
-      "hash": "d488dd4d5153c074",
-      "changed": "2026-09-05"
-    },
     "/compare/coupler-vs-cube": {
       "hash": "f28b31077b23d10a",
       "changed": "2026-09-05"
@@ -600,10 +540,6 @@
     },
     "/compare/craftmypdf-vs-versionfeeds": {
       "hash": "59242baa4c4d9605",
-      "changed": "2026-09-05"
-    },
-    "/compare/create-alibaba-cloud-vs-google-ai-pro-ultra": {
-      "hash": "380880a58cc39429",
       "changed": "2026-09-05"
     },
     "/compare/cron-job-org-vs-n8n": {
@@ -666,18 +602,6 @@
       "hash": "58e8f3e1260635f4",
       "changed": "2026-09-05"
     },
-    "/compare/daily-co-vs-mux": {
-      "hash": "d8964cb70ebb2abe",
-      "changed": "2026-09-05"
-    },
-    "/compare/daily-co-vs-shotstack-startup-program": {
-      "hash": "151da51c1ef93ab3",
-      "changed": "2026-09-05"
-    },
-    "/compare/daily-co-vs-zoho-meeting": {
-      "hash": "cc83bf1f93ae5148",
-      "changed": "2026-09-05"
-    },
     "/compare/datadog-vs-grafana-cloud": {
       "hash": "e7b26ec8d5610f80",
       "changed": "2026-09-05"
@@ -706,13 +630,25 @@
       "hash": "3e8886a2126ef3f5",
       "changed": "2026-09-05"
     },
-    "/compare/digitalocean-vs-sentry": {
-      "hash": "9436d5cdff209d98",
-      "changed": "2026-09-05"
+    "/compare/digitalocean-vs-google-compute-engine": {
+      "hash": "c6c0b7dc5ce91249",
+      "changed": "2026-09-07"
     },
-    "/compare/digitalocean-vs-svb-silicon-valley-bank": {
-      "hash": "0dff8195cc078f52",
-      "changed": "2026-09-05"
+    "/compare/digitalocean-vs-gorgias": {
+      "hash": "2304ff0822f7aea3",
+      "changed": "2026-09-07"
+    },
+    "/compare/digitalocean-vs-heroku-for-startups-program": {
+      "hash": "b795f22be175c467",
+      "changed": "2026-09-07"
+    },
+    "/compare/digitalocean-vs-startup-with-ibm": {
+      "hash": "8003f47175edd9e5",
+      "changed": "2026-09-07"
+    },
+    "/compare/digitalocean-vs-zoom": {
+      "hash": "6f8e076921475ae0",
+      "changed": "2026-09-07"
     },
     "/compare/digitalplat-vs-hurricane-electric-dns": {
       "hash": "19651e1f07e4546b",
@@ -770,6 +706,14 @@
       "hash": "0d9b6d3cf28033f9",
       "changed": "2026-09-05"
     },
+    "/compare/dynamodb-local-vs-nile": {
+      "hash": "8d60c6b64eff8445",
+      "changed": "2026-09-07"
+    },
+    "/compare/dynamodb-local-vs-turbopuffer": {
+      "hash": "2e079c5c476e50f0",
+      "changed": "2026-09-07"
+    },
     "/compare/element-io-vs-talky-io": {
       "hash": "0aea5f0d27177f3d",
       "changed": "2026-09-05"
@@ -781,6 +725,14 @@
     "/compare/emaillabs-io-vs-resend": {
       "hash": "c3048c37af51b75f",
       "changed": "2026-09-05"
+    },
+    "/compare/exa-vs-openai": {
+      "hash": "ae732bde9a8907a8",
+      "changed": "2026-09-07"
+    },
+    "/compare/exa-vs-scale-ai": {
+      "hash": "a06ae4deef6b8bb6",
+      "changed": "2026-09-07"
     },
     "/compare/expo-vs-loadly": {
       "hash": "515522da45dbc906",
@@ -826,6 +778,14 @@
       "hash": "fe09204e0b6ff0ac",
       "changed": "2026-09-05"
     },
+    "/compare/fivetran-activations-vs-heap-io": {
+      "hash": "386182794d85a5ea",
+      "changed": "2026-09-07"
+    },
+    "/compare/fivetran-activations-vs-smartlook-com": {
+      "hash": "b5b7da29c5dfde37",
+      "changed": "2026-09-07"
+    },
     "/compare/flickr-vs-icloud": {
       "hash": "efcf3c08c0a57d6e",
       "changed": "2026-09-05"
@@ -862,18 +822,6 @@
       "hash": "3c5e43f1645ec456",
       "changed": "2026-09-05"
     },
-    "/compare/forter-vs-findmassleads": {
-      "hash": "0253a4f960007b5e",
-      "changed": "2026-09-05"
-    },
-    "/compare/forter-vs-intercom": {
-      "hash": "18f206db81293e1d",
-      "changed": "2026-09-05"
-    },
-    "/compare/forter-vs-prospectin": {
-      "hash": "435e87ae161e4453",
-      "changed": "2026-09-05"
-    },
     "/compare/free-po-editor-vs-localit": {
       "hash": "28b8c353cbbcffd7",
       "changed": "2026-09-05"
@@ -881,6 +829,10 @@
     "/compare/free-po-editor-vs-transifex-com": {
       "hash": "366918fb7d168bab",
       "changed": "2026-09-05"
+    },
+    "/compare/freedcamp-com-vs-teleretro-com": {
+      "hash": "ce1f8e91c46653f2",
+      "changed": "2026-09-07"
     },
     "/compare/geekflare-api-vs-snapapi": {
       "hash": "9d5ade3331c764e1",
@@ -942,9 +894,9 @@
       "hash": "5618232b3d08d15d",
       "changed": "2026-09-05"
     },
-    "/compare/google-ai-pro-ultra-vs-oracle-cloud": {
-      "hash": "daa47c31735cfacb",
-      "changed": "2026-09-05"
+    "/compare/google-compute-engine-vs-heroku-for-startups-program": {
+      "hash": "15600b4cd9493b0c",
+      "changed": "2026-09-07"
     },
     "/compare/google-keep-vs-todoist": {
       "hash": "53d04672f81d9631",
@@ -974,6 +926,14 @@
       "hash": "ddc2a04a7ee62c1d",
       "changed": "2026-09-05"
     },
+    "/compare/gorgias-vs-hubspot-for-startups": {
+      "hash": "f6c0c8323520d286",
+      "changed": "2026-09-07"
+    },
+    "/compare/gorgias-vs-zoom": {
+      "hash": "304819e76ab315e4",
+      "changed": "2026-09-07"
+    },
     "/compare/grafana-cloud-vs-sentry": {
       "hash": "e37686cf9fb2120a",
       "changed": "2026-09-05"
@@ -989,6 +949,18 @@
     "/compare/grafana-loki-vs-smart-grow-logs": {
       "hash": "895e13b8e487da10",
       "changed": "2026-09-05"
+    },
+    "/compare/graphcomment-vs-intensedebate": {
+      "hash": "063052651ed57d88",
+      "changed": "2026-09-07"
+    },
+    "/compare/graphcomment-vs-sendbird": {
+      "hash": "2d1484487bde6b07",
+      "changed": "2026-09-07"
+    },
+    "/compare/graphcomment-vs-slack-api": {
+      "hash": "2837b063db247e24",
+      "changed": "2026-09-07"
     },
     "/compare/gtmetrix-com-vs-scrutinizer-ci-com": {
       "hash": "992693ca1d887251",
@@ -1038,6 +1010,10 @@
       "hash": "212d14e130e32411",
       "changed": "2026-09-05"
     },
+    "/compare/heroku-for-startups-program-vs-startup-with-ibm": {
+      "hash": "735baa072c6ab5aa",
+      "changed": "2026-09-07"
+    },
     "/compare/highlight-io-vs-logz-io": {
       "hash": "e6f0ebf56a0768d5",
       "changed": "2026-09-05"
@@ -1045,6 +1021,10 @@
     "/compare/highlight-io-vs-smart-grow-logs": {
       "hash": "06a4470daa3e371a",
       "changed": "2026-09-05"
+    },
+    "/compare/hubspot-for-startups-vs-zoom": {
+      "hash": "645ab70576cc208c",
+      "changed": "2026-09-07"
     },
     "/compare/hurricane-electric-dns-vs-luadns-com": {
       "hash": "963dbe813c6809ba",
@@ -1078,9 +1058,13 @@
       "hash": "f7e4fe0422b3b0af",
       "changed": "2026-09-05"
     },
-    "/compare/intercom-vs-findmassleads": {
-      "hash": "5e47c223770ec311",
-      "changed": "2026-09-05"
+    "/compare/intensedebate-vs-sendbird": {
+      "hash": "5f4a98f97a3ebdea",
+      "changed": "2026-09-07"
+    },
+    "/compare/intensedebate-vs-slack-api": {
+      "hash": "1005ab6bd0833ee8",
+      "changed": "2026-09-07"
     },
     "/compare/internxt-vs-icloud": {
       "hash": "87f13236e857ed2d",
@@ -1108,18 +1092,6 @@
     },
     "/compare/khan-academy-vs-mit-opencourseware": {
       "hash": "e05e06e7672a648a",
-      "changed": "2026-09-05"
-    },
-    "/compare/knowlarity-for-startups-vs-stream": {
-      "hash": "01c8120aa39a8ece",
-      "changed": "2026-09-05"
-    },
-    "/compare/knowlarity-for-startups-vs-tawk-to": {
-      "hash": "132928374766b4fb",
-      "changed": "2026-09-05"
-    },
-    "/compare/knowlarity-for-startups-vs-utterances": {
-      "hash": "140db03d624dabbb",
       "changed": "2026-09-05"
     },
     "/compare/kong-vs-unkey": {
@@ -1186,24 +1158,8 @@
       "hash": "228608493adb6644",
       "changed": "2026-09-05"
     },
-    "/compare/lumenfall-ai-vs-openai": {
-      "hash": "026497402f5b3bf9",
-      "changed": "2026-09-05"
-    },
-    "/compare/lumenfall-ai-vs-pollinations-ai": {
-      "hash": "50b6cb72f5578e0e",
-      "changed": "2026-09-05"
-    },
-    "/compare/lumenfall-ai-vs-replicate": {
-      "hash": "ac4a6fdf7ff21000",
-      "changed": "2026-09-05"
-    },
     "/compare/make-vs-zoho-sign": {
       "hash": "e7561216a13500ad",
-      "changed": "2026-09-05"
-    },
-    "/compare/meistertask-vs-teleretro-com": {
-      "hash": "6de0e22c15813326",
       "changed": "2026-09-05"
     },
     "/compare/microsoft-ajax-vs-bootstrapcdn-com": {
@@ -1242,16 +1198,16 @@
       "hash": "f815283fa8139b81",
       "changed": "2026-09-05"
     },
+    "/compare/mux-vs-whereby": {
+      "hash": "6c834f5aebb0dc97",
+      "changed": "2026-09-07"
+    },
+    "/compare/mux-vs-wistia-com": {
+      "hash": "73232a1c4066ac49",
+      "changed": "2026-09-07"
+    },
     "/compare/mux-vs-zoho-meeting": {
       "hash": "48df5517cc4af2c6",
-      "changed": "2026-09-05"
-    },
-    "/compare/neo4j-auradb-vs-nhost": {
-      "hash": "d3874c61a44c97e9",
-      "changed": "2026-09-05"
-    },
-    "/compare/neo4j-auradb-vs-redis-cloud": {
-      "hash": "7c2c7f76c1f203ea",
       "changed": "2026-09-05"
     },
     "/compare/neon-vs-supabase": {
@@ -1278,6 +1234,14 @@
       "hash": "703521d64c1c8d60",
       "changed": "2026-09-05"
     },
+    "/compare/nile-vs-codehooks-io": {
+      "hash": "cfa907af717042bc",
+      "changed": "2026-09-07"
+    },
+    "/compare/nile-vs-turbopuffer": {
+      "hash": "7da6988f22eacb9c",
+      "changed": "2026-09-07"
+    },
     "/compare/novu-vs-courier-com": {
       "hash": "f78389d8e62619dd",
       "changed": "2026-09-05"
@@ -1294,13 +1258,9 @@
       "hash": "6f7863b251c4941d",
       "changed": "2026-09-05"
     },
-    "/compare/openai-vs-pollinations-ai": {
-      "hash": "1999c5e54a5451e4",
-      "changed": "2026-09-05"
-    },
-    "/compare/openai-vs-replicate": {
-      "hash": "e77598d3fdf518dc",
-      "changed": "2026-09-05"
+    "/compare/openai-vs-scale-ai": {
+      "hash": "ea9738840588a76a",
+      "changed": "2026-09-07"
     },
     "/compare/opencagedata-com-vs-osmnames": {
       "hash": "81855c265440dd24",
@@ -1346,9 +1306,17 @@
       "hash": "0f7c66bbe35899a7",
       "changed": "2026-09-05"
     },
+    "/compare/parityvend-vs-currencylayer": {
+      "hash": "ede528ddb65953d8",
+      "changed": "2026-09-07"
+    },
     "/compare/parityvend-vs-polar": {
       "hash": "6fd84e7980618d89",
       "changed": "2026-09-05"
+    },
+    "/compare/parityvend-vs-qonversion": {
+      "hash": "e2d62eb21dccf90a",
+      "changed": "2026-09-07"
     },
     "/compare/payload-cms-vs-wpjack": {
       "hash": "5b084d2bc6b57607",
@@ -1361,6 +1329,18 @@
     "/compare/peacock-vs-pocket-casts": {
       "hash": "b4c0de40012f1748",
       "changed": "2026-09-05"
+    },
+    "/compare/pendulums-vs-freedcamp-com": {
+      "hash": "6e1a710821862bf0",
+      "changed": "2026-09-07"
+    },
+    "/compare/pendulums-vs-teleretro-com": {
+      "hash": "7e7623138bb5f09a",
+      "changed": "2026-09-07"
+    },
+    "/compare/pendulums-vs-timecamp": {
+      "hash": "43e9f5bb19433387",
+      "changed": "2026-09-07"
     },
     "/compare/phpsandbox-vs-cacher-io": {
       "hash": "fc0ebde4da78f1e3",
@@ -1382,16 +1362,20 @@
       "hash": "5ef4b9a8cc0a1f3e",
       "changed": "2026-09-05"
     },
+    "/compare/polar-vs-currencylayer": {
+      "hash": "4531bcf19c6d9d60",
+      "changed": "2026-09-07"
+    },
+    "/compare/polar-vs-qonversion": {
+      "hash": "c52a1a5b1b7957e2",
+      "changed": "2026-09-07"
+    },
     "/compare/propelauth-vs-supertokens": {
       "hash": "5d865c6b982925b0",
       "changed": "2026-09-05"
     },
     "/compare/propelauth-vs-zitadel-cloud": {
       "hash": "08470c20e0c83ed4",
-      "changed": "2026-09-05"
-    },
-    "/compare/prospectin-vs-findmassleads": {
-      "hash": "48abcd7094261cc9",
       "changed": "2026-09-05"
     },
     "/compare/proton-mail-vs-tutanota": {
@@ -1470,10 +1454,6 @@
       "hash": "1f86271c45484188",
       "changed": "2026-09-05"
     },
-    "/compare/shotstack-startup-program-vs-zoho-meeting": {
-      "hash": "0e036fea6462d676",
-      "changed": "2026-09-05"
-    },
     "/compare/simplelocalize-vs-transifex-com": {
       "hash": "225b4433871e1b97",
       "changed": "2026-09-05"
@@ -1486,17 +1466,13 @@
       "hash": "d1a0c301dcfbb796",
       "changed": "2026-09-05"
     },
-    "/compare/stream-vs-utterances": {
-      "hash": "513f47e9944924f9",
-      "changed": "2026-09-05"
-    },
     "/compare/supertokens-vs-zitadel-cloud": {
       "hash": "cce3681835e6ad73",
       "changed": "2026-09-05"
     },
-    "/compare/tawk-to-vs-utterances": {
-      "hash": "3d60ed8ef4afcad7",
-      "changed": "2026-09-05"
+    "/compare/timecamp-vs-teleretro-com": {
+      "hash": "67016849e2a3d62c",
+      "changed": "2026-09-07"
     },
     "/compare/todoist-vs-zoho-docs": {
       "hash": "68b6e0b53118cecb",
@@ -1510,16 +1486,16 @@
       "hash": "8c026ecc70904f9d",
       "changed": "2026-09-05"
     },
+    "/compare/turbopuffer-vs-codehooks-io": {
+      "hash": "c129e4b15d24f4d1",
+      "changed": "2026-09-07"
+    },
     "/compare/unkey-vs-x-twitter": {
       "hash": "83773f50c0e0995c",
       "changed": "2026-09-05"
     },
     "/compare/unkey-vs-zuplo": {
       "hash": "1a0675cbafd9b94c",
-      "changed": "2026-09-05"
-    },
-    "/compare/uxtweak-com-vs-smartlook-com": {
-      "hash": "25bad18ef3976d79",
       "changed": "2026-09-05"
     },
     "/compare/versionfeeds-vs-redirect-pizza": {
@@ -1534,9 +1510,9 @@
       "hash": "54a044101333a33b",
       "changed": "2026-09-05"
     },
-    "/compare/yodiz-vs-teleretro-com": {
-      "hash": "1552435dd687af7f",
-      "changed": "2026-09-05"
+    "/compare/whereby-vs-wistia-com": {
+      "hash": "06e224427d1403e0",
+      "changed": "2026-09-07"
     },
     "/compare/zoho-assist-vs-moss-sh": {
       "hash": "9fc25f69ad8617c7",
@@ -1553,6 +1529,10 @@
     "/compare/zoho-bookings-vs-zoho-sign": {
       "hash": "5ed7223f60c27bda",
       "changed": "2026-09-05"
+    },
+    "/compare/zoho-meeting-vs-wistia-com": {
+      "hash": "549913d89e9519a3",
+      "changed": "2026-09-07"
     },
     "/cursor-alternatives": {
       "hash": "f9e5d68f3cd70625",

--- a/scripts/refile-programme-records.mjs
+++ b/scripts/refile-programme-records.mjs
@@ -1,0 +1,27 @@
+import { readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+const indexPath = join(process.cwd(), "data", "index.json");
+const data = JSON.parse(readFileSync(indexPath, "utf8"));
+
+const PROGRAMME_TIERS = new Set(["Startup Program", "Portfolio"]);
+const PROGRAMME_CATEGORY = "Startup Perks";
+const MERGED_AWAY = "Startup Programs";
+
+const moved = [];
+for (const offer of data.offers) {
+  if (offer.category === MERGED_AWAY) {
+    moved.push({ vendor: offer.vendor, from: offer.category, tier: offer.tier, why: "merged" });
+    offer.category = PROGRAMME_CATEGORY;
+    continue;
+  }
+  if (PROGRAMME_TIERS.has(offer.tier) && offer.category !== PROGRAMME_CATEGORY) {
+    moved.push({ vendor: offer.vendor, from: offer.category, tier: offer.tier, why: "tier" });
+    offer.category = PROGRAMME_CATEGORY;
+  }
+}
+
+writeFileSync(indexPath, JSON.stringify(data, null, 2) + "\n");
+
+for (const m of moved) console.log(`${m.why}\t${m.from}\t${m.vendor}\t${m.tier}`);
+console.log(`moved ${moved.length} of ${data.offers.length} in ${indexPath}`);

--- a/src/category-scope.ts
+++ b/src/category-scope.ts
@@ -1,0 +1,444 @@
+import type { Offer } from "./types.js";
+import { offerEnded } from "./retirement.js";
+
+export type CategoryAudience = "developer" | "personal";
+
+export type CategoryHolds = "products" | "programmes";
+
+export interface CategoryScope {
+  answers: string[];
+  audience: CategoryAudience;
+  scope: string;
+  holds?: CategoryHolds;
+  names?: Record<string, string>;
+}
+
+export const PROGRAMME_TIERS: readonly string[] = ["Startup Program", "Portfolio"];
+
+export const CATEGORY_SCOPES: Record<string, CategoryScope> = {
+  "Storage": {
+    answers: ["where do my files live"],
+    audience: "developer",
+    scope: "Object storage, buckets and upload APIs an application writes to, plus the image and asset hosts built on them.",
+  },
+  "Cloud Storage": {
+    answers: ["where do my files live"],
+    audience: "personal",
+    scope: "Consumer file-sync drives a person keeps documents and photos in — not storage an application writes to.",
+  },
+  "CDN": {
+    answers: ["where do my files live"],
+    audience: "developer",
+    scope: "Edge caches and public script and asset CDNs that serve files stored somewhere else.",
+  },
+
+  "Cloud Hosting": {
+    answers: ["where do I run my code"],
+    audience: "developer",
+    scope: "Managed platforms that deploy an application from a repository — PaaS, serverless and static hosts.",
+  },
+  "Cloud IaaS": {
+    answers: ["where do I run my code"],
+    audience: "developer",
+    scope: "Cloud accounts that rent compute by the instance or by credit — the hyperscalers and the resellers on top of them, not a deploy pipeline.",
+  },
+  "Infrastructure": {
+    answers: ["where do I run my code"],
+    audience: "developer",
+    scope: "Infrastructure-as-code, provisioning and orchestration tools that stand a deployment up — and the bare-metal hosts they target, including Hetzner.",
+    names: { "Hetzner": "Infrastructure" },
+  },
+  "Server Management": {
+    answers: ["where do I run my code"],
+    audience: "developer",
+    scope: "Control panels that administer a server someone has already rented elsewhere.",
+  },
+
+  "Monitoring": {
+    answers: ["how do I find out it is broken"],
+    audience: "developer",
+    scope: "Uptime checks, metrics, tracing and the general-purpose observability suites — including Sentry and BetterStack, which also do the three names beside this one.",
+    names: { "Sentry": "Monitoring", "BetterStack": "Monitoring" },
+  },
+  "Logging": {
+    answers: ["how do I find out it is broken"],
+    audience: "developer",
+    scope: "Log shipping, retention and search, from tools that sell that alone.",
+  },
+  "Error Tracking": {
+    answers: ["how do I find out it is broken"],
+    audience: "developer",
+    scope: "Crash and exception aggregation from dedicated error trackers; the observability suites that also do it, Sentry among them, are filed under Monitoring.",
+    names: { "Sentry": "Monitoring" },
+  },
+  "Status Pages": {
+    answers: ["how do I find out it is broken"],
+    audience: "developer",
+    scope: "Public status and incident pages that tell your own users something is down.",
+  },
+
+  "Security": {
+    answers: ["who is allowed in, and where are the secrets kept"],
+    audience: "developer",
+    scope: "Code and dependency scanning, threat intel and network access control — the broad security suites, including 1Password.",
+    names: { "1Password": "Security" },
+  },
+  "Auth": {
+    answers: ["who is allowed in, and where are the secrets kept"],
+    audience: "developer",
+    scope: "Identity providers an application delegates sign-in to — hosted and self-hosted.",
+  },
+  "Secrets Management": {
+    answers: ["who is allowed in, and where are the secrets kept"],
+    audience: "developer",
+    scope: "Vaults an application reads its own credentials from at run time, not vaults a person logs into.",
+  },
+  "Password Managers": {
+    answers: ["who is allowed in, and where are the secrets kept"],
+    audience: "personal",
+    scope: "Vaults a person or a team logs into by hand; the suites that also sell one, including 1Password, are filed under Security.",
+    names: { "1Password": "Security" },
+  },
+
+  "Testing": {
+    answers: ["how do I check the code and the browser"],
+    audience: "developer",
+    scope: "Test runners, coverage, visual review and the hosted grids that execute a suite.",
+  },
+  "Browser Automation": {
+    answers: ["how do I check the code and the browser"],
+    audience: "developer",
+    scope: "Headless browsers driven by a script, sold as browser sessions rather than as a test suite.",
+  },
+  "Web Scraping": {
+    answers: ["how do I check the code and the browser"],
+    audience: "developer",
+    scope: "Extraction APIs that return a page as data — the same headless browsers, sold by the page.",
+  },
+  "Code Quality": {
+    answers: ["how do I check the code and the browser"],
+    audience: "developer",
+    scope: "Static analysis, review bots and coverage reporting that read the source without running the product.",
+  },
+
+  "Databases": {
+    answers: ["where do I put the data and query it"],
+    audience: "developer",
+    scope: "Hosted databases and the platforms sold around them — relational, document, key-value and vector.",
+  },
+  "Search": {
+    answers: ["where do I put the data and query it"],
+    audience: "developer",
+    scope: "Search indexes queried by relevance rather than by key.",
+  },
+  "Headless CMS": {
+    answers: ["where do I put the data and query it"],
+    audience: "developer",
+    scope: "Editorial stores with an authoring UI in front of them, read over an API.",
+  },
+
+  "Project Management": {
+    answers: ["how do people working together talk and track work"],
+    audience: "developer",
+    scope: "Issue trackers, boards and planning tools that hold the work itself.",
+  },
+  "Team Collaboration": {
+    answers: ["how do people working together talk and track work"],
+    audience: "developer",
+    scope: "Shared workspaces, scheduling and real-time editing around the work — not the chat clients and not the tracker.",
+  },
+  "Communication": {
+    answers: ["how do people working together talk and track work"],
+    audience: "developer",
+    scope: "Chat, voice, video and support-desk APIs an application embeds — not an app a team signs into.",
+  },
+  "Communication & Messaging": {
+    answers: ["how do people working together talk and track work"],
+    audience: "personal",
+    scope: "Chat and meeting apps a person signs into — Slack, Teams, Signal — not the APIs behind them.",
+    names: { "Slack": "Communication & Messaging", "Signal": "Communication & Messaging" },
+  },
+  "Messaging": {
+    answers: ["how do people working together talk and track work"],
+    audience: "developer",
+    scope: "Queues, pub/sub, webhooks and notification delivery between services, not between people.",
+  },
+  "Productivity & Notes": {
+    answers: ["how do people working together talk and track work"],
+    audience: "personal",
+    scope: "Personal note-taking, documents and to-do apps kept by one person.",
+  },
+
+  "Design": {
+    answers: ["what do I build the interface with"],
+    audience: "developer",
+    scope: "Interface and product design tools, asset libraries and generators used to build a screen.",
+  },
+  "Design & Creative": {
+    answers: ["what do I build the interface with"],
+    audience: "personal",
+    scope: "Desktop creative applications — raster, vector, 3D and video editors installed on a machine.",
+  },
+  "Diagramming": {
+    answers: ["what do I build the interface with"],
+    audience: "developer",
+    scope: "Whiteboards, flowcharts and architecture diagrams.",
+  },
+  "Low-Code Platforms": {
+    answers: ["what do I build the interface with"],
+    audience: "developer",
+    scope: "Builders that generate an internal tool or admin UI from a data source without a front-end codebase.",
+  },
+  "Forms": {
+    answers: ["what do I build the interface with"],
+    audience: "developer",
+    scope: "Form builders and form-submission back ends that collect a response.",
+  },
+
+  "API Development": {
+    answers: ["how do I build and publish an API"],
+    audience: "developer",
+    scope: "Clients, mocking, schema tooling and integration platforms used while building an API of your own.",
+  },
+  "API Gateway": {
+    answers: ["how do I build and publish an API"],
+    audience: "developer",
+    scope: "Gateways and proxies that sit in front of an API in production, doing routing, keys and rate limits.",
+  },
+  "Documentation": {
+    answers: ["how do I build and publish an API"],
+    audience: "developer",
+    scope: "Documentation site generators and hosted docs platforms.",
+  },
+
+  "AI / ML": {
+    answers: ["what runs the model"],
+    audience: "developer",
+    scope: "Model APIs, inference hosts, vector stores and training platforms called from your own code.",
+  },
+  "AI Coding": {
+    answers: ["what runs the model", "what do I write code in"],
+    audience: "developer",
+    scope: "Coding agents and completion assistants that write or edit source, standalone or inside an editor.",
+  },
+  "Notebooks & Data Science": {
+    answers: ["what runs the model"],
+    audience: "developer",
+    scope: "Hosted notebooks and analysis workspaces with compute attached.",
+  },
+  "IDE & Code Editors": {
+    answers: ["what do I write code in"],
+    audience: "developer",
+    scope: "Editors, IDEs and cloud development environments — the surface the code is typed into.",
+  },
+
+  "Email": {
+    answers: ["how does mail get sent and received"],
+    audience: "developer",
+    scope: "Transactional and bulk sending APIs, inbound parsing, deliverability and disposable-address services.",
+  },
+  "Consumer Email": {
+    answers: ["how does mail get sent and received"],
+    audience: "personal",
+    scope: "Mailboxes a person reads their own mail in.",
+  },
+
+  "Video": {
+    answers: ["where does video live"],
+    audience: "developer",
+    scope: "Video encoding, hosting and meeting-room APIs a product embeds.",
+  },
+  "Streaming & Media": {
+    answers: ["where does video live"],
+    audience: "personal",
+    scope: "Consumer streaming services a person watches or listens to.",
+  },
+
+  "Workflow Automation": {
+    answers: ["how do I run work in the background"],
+    audience: "developer",
+    scope: "Connector platforms that run a sequence of steps between products when something happens.",
+  },
+  "Background Jobs": {
+    answers: ["how do I run work in the background"],
+    audience: "developer",
+    scope: "Job queues, schedulers and durable execution called from your own code.",
+  },
+
+  "Payments": {
+    answers: ["where does the money go"],
+    audience: "developer",
+    scope: "Taking money from your customers — checkout, billing, merchant-of-record and the currency rates behind it.",
+  },
+  "Banking & Finance": {
+    answers: ["where does the money go"],
+    audience: "personal",
+    scope: "Personal banking, transfers and investing apps.",
+  },
+
+  "Startup Perks": {
+    answers: ["what does a company get for being a startup"],
+    audience: "developer",
+    scope: "Credit grants and discounted plans a company qualifies for by stage, accelerator or investor — not a free tier anyone can open.",
+    holds: "programmes",
+  },
+
+  "CI/CD": {
+    answers: [],
+    audience: "developer",
+    scope: "Pipelines that build, test and release on a push.",
+  },
+  "Source Control": {
+    answers: [],
+    audience: "developer",
+    scope: "Hosted repositories and code forges.",
+  },
+  "Container Registry": {
+    answers: [],
+    audience: "developer",
+    scope: "Registries that store and serve container images.",
+  },
+  "Analytics": {
+    answers: [],
+    audience: "developer",
+    scope: "Product and web analytics, session capture and the pipelines that move events into them.",
+  },
+  "Feature Flags": {
+    answers: [],
+    audience: "developer",
+    scope: "Flag and experiment services that switch behaviour without a deploy.",
+  },
+  "DNS & Domain Management": {
+    answers: [],
+    audience: "developer",
+    scope: "Authoritative DNS, dynamic DNS, resolvers and domain registration.",
+  },
+  "Tunneling & Networking": {
+    answers: [],
+    audience: "developer",
+    scope: "Tunnels and relays that expose a local port or join two networks.",
+  },
+  "Maps/Geolocation": {
+    answers: [],
+    audience: "developer",
+    scope: "Map tiles, geocoding, IP location and weather APIs.",
+  },
+  "Localization": {
+    answers: [],
+    audience: "developer",
+    scope: "Translation management and string catalogues for shipping a product in more than one language.",
+  },
+  "Mobile Development": {
+    answers: [],
+    audience: "developer",
+    scope: "Mobile build, distribution and device-management services.",
+  },
+  "Dev Utilities": {
+    answers: [],
+    audience: "developer",
+    scope: "Single-purpose APIs a product calls for one narrow thing — validation, conversion, enrichment, screenshots, reference data.",
+  },
+  "Education": {
+    answers: [],
+    audience: "personal",
+    scope: "Courses and learning platforms.",
+  },
+  "News & Reading": {
+    answers: [],
+    audience: "personal",
+    scope: "Read-later apps and feed readers.",
+  },
+  "VPN & Privacy": {
+    answers: [],
+    audience: "personal",
+    scope: "Consumer VPNs and private relays.",
+  },
+  "Fitness & Health": {
+    answers: [],
+    audience: "personal",
+    scope: "Activity, training and health-tracking apps.",
+  },
+  "Meditation & Wellness": {
+    answers: [],
+    audience: "personal",
+    scope: "Meditation and mental-wellbeing apps.",
+  },
+};
+
+export const CATEGORY_ALIASES: Record<string, string> = {
+  "Startup Programs": "Startup Perks",
+};
+
+export function resolveCategoryName(name: string): string {
+  return CATEGORY_ALIASES[name] ?? name;
+}
+
+export function scopeFor(name: string): CategoryScope | null {
+  return CATEGORY_SCOPES[resolveCategoryName(name)] ?? null;
+}
+
+export function categoryHolds(name: string): CategoryHolds {
+  return scopeFor(name)?.holds ?? "products";
+}
+
+export function familySiblings(name: string): string[] {
+  const scope = CATEGORY_SCOPES[resolveCategoryName(name)];
+  if (!scope) return [];
+  const questions = new Set(scope.answers);
+  if (questions.size === 0) return [];
+  return Object.entries(CATEGORY_SCOPES)
+    .filter(([other, s]) => other !== resolveCategoryName(name) && s.answers.some((a) => questions.has(a)))
+    .map(([other]) => other)
+    .sort();
+}
+
+export interface CategoryDirectoryEntry {
+  name: string;
+  slug: string;
+  count: number;
+  audience: CategoryAudience;
+  holds: CategoryHolds;
+  scope: string;
+  answers: string[];
+  also_answering: { name: string; slug: string; count: number }[];
+  example_members: string[];
+}
+
+export const EXAMPLE_MEMBER_COUNT = 3;
+
+export const EXAMPLE_MEMBERS_BASIS =
+  "The first members of the category as we list them, with offers the vendor has ended left out. Not a ranking and not a size ordering — no record carries a size.";
+
+export function buildCategoryDirectory(
+  categories: { name: string; count: number }[],
+  offers: Offer[],
+  toSlug: (value: string) => string,
+): CategoryDirectoryEntry[] {
+  const counts = new Map(categories.map((c) => [c.name, c.count]));
+  const membersByCategory = new Map<string, string[]>();
+  for (const offer of offers) {
+    if (offerEnded(offer)) continue;
+    const held = membersByCategory.get(offer.category);
+    if (held) {
+      if (held.length < EXAMPLE_MEMBER_COUNT) held.push(offer.vendor);
+    } else {
+      membersByCategory.set(offer.category, [offer.vendor]);
+    }
+  }
+
+  return categories.map((category) => {
+    const scope = scopeFor(category.name);
+    const siblings = familySiblings(category.name).filter((s) => counts.has(s));
+    return {
+      name: category.name,
+      slug: toSlug(category.name),
+      count: category.count,
+      audience: scope?.audience ?? "developer",
+      holds: scope?.holds ?? "products",
+      scope: scope?.scope ?? "",
+      answers: scope?.answers ?? [],
+      also_answering: siblings.map((s) => ({ name: s, slug: toSlug(s), count: counts.get(s) ?? 0 })),
+      example_members: membersByCategory.get(category.name) ?? [],
+    };
+  });
+}

--- a/src/data.ts
+++ b/src/data.ts
@@ -23,6 +23,7 @@ import { vendorHistorySentence } from "./vendor-history.js";
 import { isNoLongerInForce, withResolutionInSummary } from "./change-resolution.js";
 import { changeCitesASource, changeIsUncited, ratingWithheldForNoSourceSentence, type CitableChange } from "./change-citation.js";
 import { endedVerdictSentence } from "./retirement.js";
+import { resolveCategoryName } from "./category-scope.js";
 
 export function gateForOffer(offer: Offer): Gate | null {
   return gateFor(offer, utcDate());
@@ -203,7 +204,7 @@ export function searchOffers(
   let results = loadOffers();
 
   if (category) {
-    const lowerCategory = category.toLowerCase();
+    const lowerCategory = resolveCategoryName(category).toLowerCase();
     results = results.filter(
       (o) => o.category.toLowerCase() === lowerCategory
     );

--- a/src/openapi.ts
+++ b/src/openapi.ts
@@ -59,10 +59,10 @@ export const openapiSpec = {
     "/api/categories": {
       get: {
         summary: "List all categories",
-        description: "Returns all offer categories with the number of offers in each.",
+        description: "Returns all offer categories with the number of offers in each, the scope statement that says what the name holds, and the other category names that answer the same question. Several names answer one question and hold disjoint sets, so a count alone does not say whether a category is the whole answer: read `also_answering` before deciding a category is empty of what you want. Names in `retired_names` are accepted by `category=` filters and redirect on `/category/`.",
         responses: {
           "200": {
-            description: "List of categories with counts",
+            description: "List of categories with counts, scope statements and the names that answer alongside them",
             content: {
               "application/json": {
                 schema: {
@@ -74,17 +74,43 @@ export const openapiSpec = {
                         type: "object",
                         properties: {
                           name: { type: "string" },
-                          count: { type: "integer" }
+                          slug: { type: "string" },
+                          count: { type: "integer" },
+                          audience: { type: "string", enum: ["developer", "personal"], description: "Who the products under this name are sold to." },
+                          holds: { type: "string", enum: ["products", "programmes"], description: "`programmes` means every member is qualified-access — a startup or accelerator offer, not a free tier anyone can open." },
+                          scope: { type: "string", description: "One line saying what this name holds and what it does not." },
+                          answers: { type: "array", items: { type: "string" }, description: "The question or questions this name answers." },
+                          also_answering: {
+                            type: "array",
+                            description: "Other categories answering one of the same questions. Their sets are disjoint from this one.",
+                            items: { type: "object", properties: { name: { type: "string" }, slug: { type: "string" }, count: { type: "integer" } } }
+                          },
+                          example_members: { type: "array", items: { type: "string" } }
                         }
                       }
-                    }
+                    },
+                    example_members_basis: { type: "string" },
+                    retired_names: { type: "object", additionalProperties: { type: "string" }, description: "Category names no longer published, mapped to the name that replaced them." }
                   }
                 },
                 example: {
                   categories: [
-                    { name: "Cloud Hosting", count: 45 },
-                    { name: "Databases", count: 30 }
-                  ]
+                    {
+                      name: "Cloud Storage",
+                      slug: "cloud-storage",
+                      count: 9,
+                      audience: "personal",
+                      holds: "products",
+                      scope: "Consumer file-sync drives a person keeps documents and photos in — not storage an application writes to.",
+                      answers: ["where do my files live"],
+                      also_answering: [
+                        { name: "CDN", slug: "cdn", count: 19 },
+                        { name: "Storage", slug: "storage", count: 55 }
+                      ],
+                      example_members: ["Google Drive", "Google Photos", "iCloud"]
+                    }
+                  ],
+                  retired_names: { "Startup Programs": "Startup Perks" }
                 }
               }
             }

--- a/src/serve.ts
+++ b/src/serve.ts
@@ -17,6 +17,7 @@ import { recordApiHit, recordSessionConnect, recordSessionDisconnect, recordLand
 import { buildDailyRollup, readRollups, coverageOf, ROLLUP_DATE_PATTERN } from "./analytics-rollup.js";
 import { configureVendorSeries, recordVendorRequest, flushVendorSeries, readVendorSeries, vendorSeriesGauge, vendorExportAuthorized, isSeriesDate, seriesDateRange, VENDOR_SERIES_PATH, VENDOR_SERIES_RETENTION_DAYS, VENDOR_SERIES_NOTES } from "./vendor-series.js";
 import { openapiSpec } from "./openapi.js";
+import { CATEGORY_ALIASES, EXAMPLE_MEMBERS_BASIS, buildCategoryDirectory, categoryHolds, familySiblings, resolveCategoryName, scopeFor } from "./category-scope.js";
 import { LINK_GRACE_DAYS, unreachableNoticeForUrl } from "./link-health.js";
 import { offerEnded, offerRetired, recordedTierSentence, endedHeadline, endedHistorySentence, endedReliabilitySentence, endedEmptyChangeHistorySentence, ENDED_BADGE_LABEL, ENDED_SINCE_CHANGES_SENTENCE, type OfferTierAndUrl } from "./retirement.js";
 import { amountUnstatedSentence, levelWithheldReason, withheldLevelClause, withheldLevelSentence, type LevelWithheldReason } from "./source-check.js";
@@ -1615,8 +1616,7 @@ const relatedCategoriesMap: Record<string, string[]> = {
   "Tunneling & Networking": ["Cloud Hosting", "Infrastructure", "DNS & Domain Management"],
   "Diagramming": ["Design", "Documentation", "Project Management"],
   "Dev Utilities": ["API Development", "Testing", "IDE & Code Editors"],
-  "Startup Programs": ["Startup Perks", "Cloud Hosting", "Databases"],
-  "Startup Perks": ["Startup Programs", "Cloud Hosting", "AI / ML"],
+  "Startup Perks": ["Cloud IaaS", "Cloud Hosting", "AI / ML"],
   "Background Jobs": ["Workflow Automation", "Cloud Hosting", "CI/CD"],
   "API Gateway": ["API Development", "Cloud Hosting", "Security"],
 };
@@ -1694,7 +1694,19 @@ function buildCategoryPage(slug: string): string | null {
   const keyLimitMatch = topVendor?.description.match(/(\d[\d,]*\s*(?:GB|GiB|MB|TB|requests?|calls?|MAU|users?|emails?|messages?|builds?|minutes?|hours?|projects?|repos?|sites?|apps?|databases?|invocations?|events?))/i);
   const keyLimit = keyLimitMatch ? keyLimitMatch[1] : "a generous free tier";
 
-  const introHtml = `<div class="cat-intro">
+  const catScope = scopeFor(categoryName);
+  const catSiblings = familySiblings(categoryName).filter(s => categorySlugMap.has(toSlug(s)));
+  const siblingsHtml = catSiblings.length > 0 && catScope
+    ? `<p class="cat-scope-siblings">${catSiblings.length === 1 ? "One other name here answers" : `${catSiblings.length} other names here answer`} &ldquo;${escHtmlServer(catScope.answers[0])}&rdquo;, and each holds a different list: ${catSiblings.map(s => `<a href="/category/${toSlug(s)}">${escHtmlServer(s)}</a> (${categories.find(c => c.name === s)?.count ?? 0})`).join(", ")}.</p>`
+    : "";
+  const scopeHtml = catScope
+    ? `<div class="cat-scope">
+    <p><strong>What this name holds:</strong> ${escHtmlServer(catScope.scope)}</p>${siblingsHtml}
+  </div>`
+    : "";
+
+  const introHtml = `${scopeHtml}
+  <div class="cat-intro">
     <p>We track <strong>${catStandingCount}</strong> ${categoryName.toLowerCase()} services with free tiers.${topVendor ? ` ${escHtmlServer(topVendor.vendor)} leads with ${escHtmlServer(keyLimit)}.` : ""} ${stabilitySummary}</p>
   </div>`;
 
@@ -1735,7 +1747,8 @@ function buildCategoryPage(slug: string): string | null {
   </div>`
     : "";
 
-  const related = (relatedCategoriesMap[categoryName] ?? [])
+  const related = [...familySiblings(categoryName), ...(relatedCategoriesMap[categoryName] ?? [])]
+    .filter((rc, i, all) => all.indexOf(rc) === i)
     .filter(rc => categorySlugMap.has(toSlug(rc)));
   const relatedCatsHtml = related.length > 0
     ? `<div class="related-cats">
@@ -1827,6 +1840,10 @@ h1{font-family:var(--serif);font-size:2.25rem;color:var(--text);margin:1rem 0 .5
 .cat-meta{color:var(--text-muted);margin-bottom:1rem;font-size:.95rem}
 .cat-intro{margin-bottom:1.5rem;padding:1rem 1.25rem;background:var(--bg-card);border:1px solid var(--border);border-radius:8px;font-size:.95rem;color:var(--text-muted);line-height:1.7}
 .cat-intro strong{color:var(--text)}
+.cat-scope{margin-bottom:1rem;padding:.9rem 1.25rem;border-left:3px solid var(--accent);background:var(--bg-card);border-radius:0 8px 8px 0;font-size:.95rem;color:var(--text-muted);line-height:1.7}
+.cat-scope p{margin:0}
+.cat-scope strong{color:var(--text)}
+.cat-scope-siblings{margin-top:.5rem!important;font-size:.9rem;color:var(--text-dim)}
 .analysis-cta{margin-bottom:2rem}
 .analysis-cta a{display:flex;align-items:center;gap:.75rem;padding:1rem 1.25rem;background:linear-gradient(135deg,rgba(59,130,246,0.1),rgba(139,92,246,0.1));border:1px solid rgba(59,130,246,0.3);border-radius:10px;color:var(--text);text-decoration:none;transition:all .2s}
 .analysis-cta a:hover{border-color:var(--accent);background:linear-gradient(135deg,rgba(59,130,246,0.15),rgba(139,92,246,0.15));text-decoration:none}
@@ -4208,7 +4225,6 @@ const categoryComparisonMap: Record<string, { comparison?: string; hub?: string 
   "Tunneling & Networking": { hub: "/hosting-alternatives" },
   "Diagramming": { hub: "/design-alternatives" },
   "Dev Utilities": { hub: "/api-development-alternatives" },
-  "Startup Programs": { hub: "/startup-credits" },
   "Startup Perks": { hub: "/startup-credits" },
   "Background Jobs": { hub: "/hosting-alternatives" },
   "API Gateway": { hub: "/api-development-alternatives" },
@@ -48917,7 +48933,7 @@ function copyCode(btn){var block=btn.parentElement;var text=block.textContent.re
 function buildDeveloperHubPage(): string {
   const endpointTable = [
     { method: "GET", path: "/api/offers", desc: "Search and browse offers", params: "q, category, limit, offset" },
-    { method: "GET", path: "/api/categories", desc: "List all categories with counts", params: "" },
+    { method: "GET", path: "/api/categories", desc: "List all categories with counts, what each name holds, and the other names answering the same question", params: "" },
     { method: "GET", path: "/api/new", desc: "Recently added or updated offers", params: "days" },
     { method: "GET", path: "/api/newest", desc: "Newest deals by verification date", params: "limit" },
     { method: "GET", path: "/api/changes", desc: "Pricing and deal changes", params: "since, type, vendor, vendors, category, categories, limit, offset" },
@@ -54107,10 +54123,10 @@ const httpServer = createHttpServer(async (req, res) => {
     res.end(JSON.stringify(cited(dealsWithCodes)));
   } else if (url.pathname === "/api/categories" && isGetOrHead) {
     recordApiHit("/api/categories");
-    const cats = getCategories();
+    const cats = buildCategoryDirectory(getCategories(), loadOffers(), toSlug);
     logRequest({ ts: new Date().toISOString(), type: "api", endpoint: "/api/categories", params: {}, user_agent: req.headers["user-agent"] ?? "unknown", result_count: cats.length });
     res.writeHead(200, { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" });
-    res.end(JSON.stringify(cited({ categories: cats }, "/category")));
+    res.end(JSON.stringify(cited({ categories: cats, example_members_basis: EXAMPLE_MEMBERS_BASIS, retired_names: CATEGORY_ALIASES }, "/category")));
   } else if (url.pathname === "/api/agent-payments" && isGetOrHead) {
     recordApiHit("/api/agent-payments");
     const protocolFilter = url.searchParams.get("protocol") || undefined;
@@ -54352,7 +54368,7 @@ const httpServer = createHttpServer(async (req, res) => {
   } else if (url.pathname === "/api/startup-credits" && isGetOrHead) {
     recordApiHit("/api/startup-credits");
     const startupOffers = offers.filter(o =>
-      o.category === "Startup Programs" ||
+      categoryHolds(o.category) === "programmes" ||
       (o.tier && o.tier.toLowerCase().includes("startup"))
     );
     const startupCategoryMap: Record<string, string[]> = {
@@ -54727,7 +54743,7 @@ Parameters:
 ## REST API Endpoints
 
 - GET /api/offers — Search deals (params: q, category, eligibility_type, sort, limit, offset)
-- GET /api/categories — List all categories with counts
+- GET /api/categories — List all categories with counts, what each name holds, and the other names answering the same question
 - GET /api/changes — Pricing changes (params: since, type, vendor, vendors, category, categories, limit, offset)
 - GET /api/new — Recently added offers (params: days)
 - GET /api/newest — Newest deals (params: since, limit, category)
@@ -54950,6 +54966,12 @@ ${catList}
     res.end(buildCategoryIndexPage());
   } else if (url.pathname.startsWith("/category/") && isGetOrHead) {
     const slug = url.pathname.slice("/category/".length).replace(/\/$/, "");
+    const retiredName = Object.keys(CATEGORY_ALIASES).find(name => toSlug(name) === slug);
+    if (retiredName && !categorySlugMap.has(slug)) {
+      res.writeHead(301, { Location: `/category/${toSlug(CATEGORY_ALIASES[retiredName])}` });
+      res.end();
+      return;
+    }
     const html = buildCategoryPage(slug);
     if (html) {
       recordApiHit("/category/:slug");

--- a/test/best-of-ranking.test.ts
+++ b/test/best-of-ranking.test.ts
@@ -111,18 +111,28 @@ describe("/best/:slug shows the whole qualified band", () => {
 
 describe("/best/:slug is not a mirror of /category/:slug", () => {
   it("the gates remove offers the category page shows", async () => {
-    const best = await get("/best/free-ai-ml");
-    const category = await get("/category/ai-ml");
-    assert.strictEqual(best.status, 200);
-    assert.strictEqual(category.status, 200);
-    const bestVendors = new Set([...best.html.matchAll(/class="best-pick-name">([^<]+)</g)].map((m) => m[1]));
-    assert.ok(bestVendors.size > 0);
     const index = JSON.parse(readFileSync(path.join(__dirname, "..", "data", "index.json"), "utf8"));
-    const gatedOut = index.offers.filter((o: { category: string; eligibility?: unknown }) => o.category === "AI / ML" && o.eligibility);
-    assert.ok(gatedOut.length > 0, "fixture assumption: AI/ML has eligibility-gated offers");
-    for (const o of gatedOut) {
-      assert.ok(!bestVendors.has(o.vendor), `${o.vendor} is eligibility-restricted and must not be on a best-of page`);
+    const restricted = new Map<string, { vendor: string }[]>();
+    for (const o of index.offers as { vendor: string; category: string; eligibility?: unknown }[]) {
+      if (!o.eligibility) continue;
+      const held = restricted.get(o.category);
+      if (held) held.push(o);
+      else restricted.set(o.category, [o]);
     }
+    let checked = 0;
+    for (const [category, gatedOut] of restricted) {
+      const slug = category.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-|-$/g, "");
+      const best = await get(`/best/free-${slug}`);
+      if (best.status !== 200) continue;
+      assert.strictEqual((await get(`/category/${slug}`)).status, 200);
+      const bestVendors = new Set([...best.html.matchAll(/class="best-pick-name">([^<]+)</g)].map((m) => m[1]));
+      assert.ok(bestVendors.size > 0, `/best/free-${slug} puts no vendor forward`);
+      for (const o of gatedOut) {
+        assert.ok(!bestVendors.has(o.vendor), `${o.vendor} is eligibility-restricted and must not be on a best-of page`);
+      }
+      checked++;
+    }
+    assert.ok(checked > 0, "no category holds both an eligibility-gated record and a best-of page");
   });
 });
 

--- a/test/category-gate-lede.test.ts
+++ b/test/category-gate-lede.test.ts
@@ -6,6 +6,7 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 
 import { fetchBadgeVerdicts, type SiteFreeTierVerdict } from "./badge-verdicts.ts";
+import { assertPopulationFloor } from "./population-floor.ts";
 
 const { gateFor, utcDate } = await import("../dist/ranking.js");
 const { gatedShareLede } = await import("../dist/eligibility.js");
@@ -236,7 +237,7 @@ describe("a category page discloses every gated record, not eligibility alone", 
       disclosing++;
     }
     assert.strictEqual(disclosing, census.filter((c) => c.gated > 0).length);
-    assert.ok(disclosing > 20, `only ${disclosing} categories disclose a gated count`);
+    assertPopulationFloor(disclosing, Math.floor(census.length / 5), "of the categories on the site disclose a gated count");
   });
 
   it("keeps the eligibility wording on every category holding an eligibility record", async () => {
@@ -257,7 +258,8 @@ describe("a category page discloses every gated record, not eligibility alone", 
         : CLAUSE_FORMS.eligibility_restricted(restricted);
       assert.ok(lede.includes(clause), `/category/${c.slug} drops the eligibility clause: ${lede}`);
     }
-    assert.ok(carrying >= 13, `only ${carrying} categories carry the eligibility clause`);
+    assert.strictEqual(carrying, census.filter((c) => c.codes.includes("eligibility_restricted")).length);
+    assertPopulationFloor(carrying, Math.floor(census.length / 20), "of the categories on the site carry the eligibility clause");
   });
 
   it("leaves the pages eligibility gates entirely on the wording they already publish", async () => {

--- a/test/category-scope.test.ts
+++ b/test/category-scope.test.ts
@@ -1,0 +1,181 @@
+import { describe, it } from "node:test";
+import assert from "node:assert";
+import {
+  CATEGORY_ALIASES,
+  CATEGORY_SCOPES,
+  EXAMPLE_MEMBER_COUNT,
+  PROGRAMME_TIERS,
+  buildCategoryDirectory,
+  categoryHolds,
+  familySiblings,
+  resolveCategoryName,
+  scopeFor,
+} from "../dist/category-scope.js";
+import { getCategories, loadOffers } from "../dist/data.js";
+import { toSlug } from "../dist/slug.js";
+import { offerEnded } from "../dist/retirement.js";
+
+const categories = getCategories();
+const offers = loadOffers();
+const directory = buildCategoryDirectory(categories, offers, toSlug);
+
+describe("every published category says what it holds", () => {
+  it("gives a scope statement to every name /api/categories publishes", () => {
+    const silent = directory.filter((entry) => entry.scope.length === 0);
+    assert.deepStrictEqual(
+      silent.map((entry) => entry.name),
+      [],
+      `these category names publish a count and no scope statement: ${silent.map((e) => e.name).join(", ")}`,
+    );
+  });
+
+  it("declares no scope for a name no offer is filed under", () => {
+    const live = new Set(categories.map((c) => c.name));
+    const orphans = Object.keys(CATEGORY_SCOPES).filter((name) => !live.has(name));
+    assert.deepStrictEqual(orphans, [], `scope declared for names holding nothing: ${orphans.join(", ")}`);
+  });
+
+  it("names three members for every category holding three unended offers", () => {
+    const short = directory.filter((entry) => entry.count >= EXAMPLE_MEMBER_COUNT && entry.example_members.length < EXAMPLE_MEMBER_COUNT);
+    assert.deepStrictEqual(short.map((e) => e.name), []);
+  });
+
+  it("draws every example member from the category it illustrates", () => {
+    for (const entry of directory) {
+      for (const member of entry.example_members) {
+        const filedUnder = offers.filter((o) => o.vendor === member).map((o) => o.category);
+        assert.ok(
+          filedUnder.includes(entry.name),
+          `${member} illustrates ${entry.name} and is filed under ${filedUnder.join(", ")}`,
+        );
+      }
+    }
+  });
+});
+
+describe("no two names answer one question without saying how they differ", () => {
+  it("gives every category in a family a scope statement of its own", () => {
+    const seen = new Map<string, string>();
+    for (const [name, scope] of Object.entries(CATEGORY_SCOPES)) {
+      const duplicate = seen.get(scope.scope);
+      assert.strictEqual(duplicate, undefined, `${name} and ${duplicate} publish the same scope statement`);
+      seen.set(scope.scope, name);
+    }
+  });
+
+  it("has every member of a family point at every other", () => {
+    for (const entry of directory) {
+      for (const sibling of entry.also_answering) {
+        const back = directory.find((e) => e.name === sibling.name);
+        assert.ok(back, `${entry.name} points at ${sibling.name}, which is not published`);
+        assert.ok(
+          back.also_answering.some((s) => s.name === entry.name),
+          `${entry.name} names ${sibling.name} as answering alongside it and ${sibling.name} does not name ${entry.name}`,
+        );
+      }
+    }
+  });
+
+  it("publishes a count beside every name it sends a caller to", () => {
+    const counts = new Map(categories.map((c) => [c.name, c.count]));
+    for (const entry of directory) {
+      for (const sibling of entry.also_answering) {
+        assert.strictEqual(sibling.count, counts.get(sibling.name));
+        assert.strictEqual(sibling.slug, toSlug(sibling.name));
+      }
+    }
+  });
+
+  it("files every vendor a scope statement names where the statement says it is", () => {
+    for (const [name, scope] of Object.entries(CATEGORY_SCOPES)) {
+      for (const [vendor, claimed] of Object.entries(scope.names ?? {})) {
+        assert.ok(scope.scope.includes(vendor), `${name} claims ${vendor} and does not name it`);
+        const filedUnder = offers.filter((o) => o.vendor === vendor).map((o) => o.category);
+        assert.ok(filedUnder.length > 0, `${name}'s scope statement names ${vendor}, which the catalogue does not hold`);
+        assert.ok(
+          filedUnder.includes(claimed),
+          `${name}'s scope statement puts ${vendor} under ${claimed} and it is under ${filedUnder.join(", ")}`,
+        );
+      }
+    }
+  });
+
+  it("sends a caller only to a name that holds something", () => {
+    for (const entry of directory) {
+      for (const sibling of entry.also_answering) {
+        assert.ok(sibling.count > 0, `${entry.name} sends a caller to ${sibling.name}, which holds nothing`);
+      }
+    }
+  });
+});
+
+describe("the storage pair a caller cannot currently tell apart", () => {
+  const storage = directory.find((e) => e.name === "Storage")!;
+  const cloudStorage = directory.find((e) => e.name === "Cloud Storage")!;
+
+  it("answers 'free object storage for my app' under one name", () => {
+    assert.ok(storage.scope.includes("Object storage"));
+    assert.strictEqual(storage.audience, "developer");
+    assert.ok(storage.also_answering.some((s) => s.name === "Cloud Storage"));
+  });
+
+  it("answers 'free personal file sync' under the other", () => {
+    assert.ok(cloudStorage.scope.includes("file-sync"));
+    assert.strictEqual(cloudStorage.audience, "personal");
+    assert.ok(cloudStorage.also_answering.some((s) => s.name === "Storage"));
+  });
+
+  it("tells the two apart from the directory alone", () => {
+    assert.notStrictEqual(storage.audience, cloudStorage.audience);
+    assert.notStrictEqual(storage.scope, cloudStorage.scope);
+  });
+});
+
+describe("a tier that names a programme is not filed as a product", () => {
+  it("keeps every qualified-access record out of a product category", () => {
+    const misfiled = offers
+      .filter((o) => PROGRAMME_TIERS.includes(o.tier))
+      .filter((o) => categoryHolds(o.category) === "products")
+      .map((o) => `${o.vendor} (${o.category}, ${o.tier})`);
+    assert.deepStrictEqual(misfiled, [], `records whose tier says programme and whose category says product: ${misfiled.join("; ")}`);
+  });
+
+  it("holds nothing but qualified-access offers in a programme category", () => {
+    const programmeCategories = Object.entries(CATEGORY_SCOPES)
+      .filter(([, scope]) => scope.holds === "programmes")
+      .map(([name]) => name);
+    assert.ok(programmeCategories.length > 0);
+    for (const name of programmeCategories) {
+      const members = offers.filter((o) => o.category === name);
+      const openToAnyone = members.filter((o) => !o.eligibility && !offerEnded(o) && !/startup|founder|accelerator|partner|perks|portfolio|deal|scholarship|sponsor|hatch|banking|offers/i.test(o.tier));
+      assert.deepStrictEqual(openToAnyone.map((o) => `${o.vendor} (${o.tier})`), []);
+    }
+  });
+});
+
+describe("a name that stops being published keeps answering", () => {
+  it("maps every retired name to a name that is published", () => {
+    const live = new Set(categories.map((c) => c.name));
+    for (const [retired, replacement] of Object.entries(CATEGORY_ALIASES)) {
+      assert.ok(!live.has(retired), `${retired} is listed as retired and still holds offers`);
+      assert.ok(live.has(replacement), `${retired} points at ${replacement}, which holds nothing`);
+    }
+  });
+
+  it("resolves a retired name to the category that replaced it", () => {
+    for (const [retired, replacement] of Object.entries(CATEGORY_ALIASES)) {
+      assert.strictEqual(resolveCategoryName(retired), replacement);
+      assert.strictEqual(scopeFor(retired)?.scope, CATEGORY_SCOPES[replacement].scope);
+    }
+  });
+
+  it("leaves a live name alone", () => {
+    for (const category of categories) {
+      assert.strictEqual(resolveCategoryName(category.name), category.name);
+    }
+  });
+
+  it("reports no family for a name whose family is gone", () => {
+    assert.deepStrictEqual(familySiblings("Startup Perks"), []);
+  });
+});

--- a/test/category-url-stability.test.ts
+++ b/test/category-url-stability.test.ts
@@ -1,0 +1,138 @@
+import { describe, it, before, after } from "node:test";
+import assert from "node:assert";
+import { spawn, type ChildProcess } from "node:child_process";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO = path.join(__dirname, "..");
+
+const SLUGS_PUBLISHED_BEFORE_THE_SCOPE_REGISTRY = [
+  "ai-coding", "ai-ml", "analytics", "api-development", "api-gateway", "auth",
+  "background-jobs", "banking-finance", "browser-automation", "cdn", "ci-cd",
+  "cloud-hosting", "cloud-iaas", "cloud-storage", "code-quality", "communication",
+  "communication-messaging", "consumer-email", "container-registry", "databases",
+  "design", "design-creative", "dev-utilities", "diagramming", "dns-domain-management",
+  "documentation", "education", "email", "error-tracking", "feature-flags",
+  "fitness-health", "forms", "headless-cms", "ide-code-editors", "infrastructure",
+  "localization", "logging", "low-code-platforms", "maps-geolocation",
+  "meditation-wellness", "messaging", "mobile-development", "monitoring",
+  "news-reading", "notebooks-data-science", "password-managers", "payments",
+  "productivity-notes", "project-management", "search", "secrets-management",
+  "security", "server-management", "source-control", "startup-perks",
+  "startup-programs", "status-pages", "storage", "streaming-media",
+  "team-collaboration", "testing", "tunneling-networking", "video", "vpn-privacy",
+  "web-scraping", "workflow-automation",
+];
+
+let server: ChildProcess;
+let port = 0;
+
+function startServer(): Promise<ChildProcess> {
+  return new Promise((resolve, reject) => {
+    const child = spawn("node", [path.join(REPO, "dist", "serve.js")], {
+      stdio: ["pipe", "pipe", "pipe"],
+      env: { ...process.env, PORT: "0", BASE_URL: "http://localhost", TZ: "UTC" },
+    });
+    const timeout = setTimeout(() => { child.kill(); reject(new Error("Server startup timeout")); }, 60000);
+    child.stderr!.on("data", (data: Buffer) => {
+      const m = data.toString().match(/running on http:\/\/localhost:(\d+)/);
+      if (m) { port = parseInt(m[1], 10); clearTimeout(timeout); resolve(child); }
+    });
+    child.on("error", (e) => { clearTimeout(timeout); reject(e); });
+  });
+}
+
+before(async () => { server = await startServer(); });
+after(() => { server?.kill(); });
+
+describe("a category URL published once keeps resolving", () => {
+  it("answers every category path the site published before the scope registry", async () => {
+    const orphaned: string[] = [];
+    for (const slug of SLUGS_PUBLISHED_BEFORE_THE_SCOPE_REGISTRY) {
+      const res = await fetch(`http://localhost:${port}/category/${slug}`, { redirect: "manual" });
+      if (res.status === 200) continue;
+      if (res.status === 301) {
+        const followed = await fetch(`http://localhost:${port}${res.headers.get("location")}`, { redirect: "manual" });
+        if (followed.status === 200) continue;
+        orphaned.push(`${slug} -> ${res.headers.get("location")} -> ${followed.status}`);
+        continue;
+      }
+      orphaned.push(`${slug} -> ${res.status}`);
+    }
+    assert.deepStrictEqual(orphaned, [], `category paths that no longer resolve: ${orphaned.join(", ")}`);
+  });
+
+  it("redirects the merged name rather than serving it", async () => {
+    const res = await fetch(`http://localhost:${port}/category/startup-programs`, { redirect: "manual" });
+    assert.strictEqual(res.status, 301);
+    assert.strictEqual(res.headers.get("location"), "/category/startup-perks");
+  });
+
+  it("still filters offers by a name it no longer publishes", async () => {
+    const merged = await (await fetch(`http://localhost:${port}/api/offers?category=Startup%20Programs&limit=5`)).json() as { total: number; offers: { category: string }[] };
+    const surviving = await (await fetch(`http://localhost:${port}/api/offers?category=Startup%20Perks&limit=5`)).json() as { total: number };
+    assert.strictEqual(merged.total, surviving.total);
+    assert.ok(merged.total > 0);
+    for (const offer of merged.offers) assert.strictEqual(offer.category, "Startup Perks");
+  });
+});
+
+describe("the directory says what a name holds", () => {
+  it("publishes a scope statement and family for every category", async () => {
+    const body = await (await fetch(`http://localhost:${port}/api/categories`)).json() as {
+      categories: { name: string; slug: string; count: number; scope: string; audience: string; also_answering: { name: string }[]; example_members: string[] }[];
+      retired_names: Record<string, string>;
+    };
+    assert.ok(body.categories.length > 0);
+    for (const category of body.categories) {
+      assert.ok(category.scope.length > 0, `${category.name} publishes no scope statement`);
+      assert.ok(["developer", "personal"].includes(category.audience));
+      assert.ok(category.slug.length > 0);
+    }
+    assert.strictEqual(body.retired_names["Startup Programs"], "Startup Perks");
+  });
+
+  it("tells a caller asking for cloud storage that the object stores are under another name", async () => {
+    const body = await (await fetch(`http://localhost:${port}/api/categories`)).json() as {
+      categories: { name: string; audience: string; scope: string; also_answering: { name: string; count: number }[]; example_members: string[] }[];
+    };
+    const cloudStorage = body.categories.find((c) => c.name === "Cloud Storage")!;
+    assert.strictEqual(cloudStorage.audience, "personal");
+    const storage = cloudStorage.also_answering.find((s) => s.name === "Storage");
+    assert.ok(storage, "Cloud Storage does not send a caller to Storage");
+    assert.ok(storage.count > 0);
+    assert.ok(cloudStorage.example_members.includes("Google Drive"));
+  });
+
+  it("tells a caller asking for error tracking that the suites are under Monitoring", async () => {
+    const body = await (await fetch(`http://localhost:${port}/api/categories`)).json() as {
+      categories: { name: string; scope: string; also_answering: { name: string }[] }[];
+    };
+    const errorTracking = body.categories.find((c) => c.name === "Error Tracking")!;
+    assert.ok(errorTracking.scope.includes("Monitoring"));
+    assert.ok(errorTracking.also_answering.some((s) => s.name === "Monitoring"));
+  });
+});
+
+describe("a category page states its own scope", () => {
+  it("prints the same scope statement the directory publishes", async () => {
+    const body = await (await fetch(`http://localhost:${port}/api/categories`)).json() as {
+      categories: { name: string; slug: string; scope: string }[];
+    };
+    for (const name of ["Storage", "Cloud Storage", "Error Tracking", "Messaging", "Startup Perks"]) {
+      const category = body.categories.find((c) => c.name === name)!;
+      const html = await (await fetch(`http://localhost:${port}/category/${category.slug}`)).text();
+      const published = category.scope
+        .replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;")
+        .replace(/"/g, "&quot;").replace(/'/g, "&#39;");
+      assert.ok(html.includes(published), `/category/${category.slug} does not print its own scope statement`);
+    }
+  });
+
+  it("links a category to the names answering alongside it", async () => {
+    const html = await (await fetch(`http://localhost:${port}/category/cloud-storage`)).text();
+    assert.ok(html.includes("where do my files live"));
+    assert.ok(html.includes('href="/category/storage"'));
+  });
+});

--- a/test/comparison-verdict.test.ts
+++ b/test/comparison-verdict.test.ts
@@ -433,10 +433,10 @@ describe("comparison verdict — as rendered", () => {
   });
 
   it("no longer calls the vendor with more recorded changes the more stable of the two", async () => {
-    const pair = buildComparisonMap().get("digitalocean-vs-sentry");
-    assert.ok(pair, "digitalocean-vs-sentry is a linked comparison");
-    const sides = sidesFor(pair)!;
-    const html = await assertRendersItsClause("digitalocean-vs-sentry", sides);
+    const found = firstSlugWhere(([a, b]) => a.recordedChanges !== b.recordedChanges && !NAMES_A_WINNER.test(stabilityVerdictClause(a, b)));
+    assert.ok(found, "at least one linked comparison holds a change-count difference it refuses to call a winner");
+    const sides = found.sides;
+    const html = await assertRendersItsClause(found.slug, sides);
     const worse = sides[0].recordedChanges > sides[1].recordedChanges ? sides[0] : sides[1];
     assert.ok(!html.includes(`${worse.vendor} has a more stable pricing history`), `${worse.vendor} has the higher count`);
   });

--- a/test/ranking.test.ts
+++ b/test/ranking.test.ts
@@ -466,7 +466,7 @@ describe("the live index, ranked", () => {
     assert.strictEqual(uniqueTop, 0);
   });
 
-  it("Databases: Firebase is demoted on a recorded withdrawal, and the two gated offers stay gated", () => {
+  it("Databases: Firebase is demoted on a recorded withdrawal, and a tier that is not a free offer stays gated", () => {
     const offers = index.offers.filter((o) => o.category === "Databases");
     const r = rankOffers(offers, {
       queryKey: "best-of:Databases",
@@ -481,7 +481,6 @@ describe("the live index, ranked", () => {
     assert.ok(!vendorsOf(r.qualified).includes("Firebase"), "Firebase is demoted and must not also be in the qualified band");
     const gated = new Map(r.excluded.map((e) => [e.offer.vendor, e.gate.code]));
     assert.strictEqual(gated.get("Turbopuffer"), "not_a_free_offer");
-    assert.strictEqual(gated.get("ScaleGrid Startup Program"), "eligibility_restricted");
     assert.strictEqual(r.qualified.length, offers.length - r.demoted.length - r.excluded.length);
   });
 

--- a/test/search.test.ts
+++ b/test/search.test.ts
@@ -456,7 +456,7 @@ describe("eligibility filtering", () => {
     }
   });
 
-  it("combines eligibility_type with category filter", async () => {
+  it("combines eligibility_type with a category name the catalogue no longer publishes", async () => {
     const proc = startServer();
     try {
       const responses = (await sendMcpMessages(proc, [
@@ -479,7 +479,7 @@ describe("eligibility filtering", () => {
       assert.ok(offers.length >= 3);
       for (const offer of offers) {
         assert.strictEqual(offer.eligibility.type, "accelerator");
-        assert.strictEqual(offer.category, "Startup Programs");
+        assert.strictEqual(offer.category, "Startup Perks");
       }
     } finally {
       proc.kill();


### PR DESCRIPTION
`GET /api/categories` returned a name and a count. **Fifteen families of names answer one question and hold different lists**, so a caller filtering on the name that matches the question most literally gets a proper subset of the answer.

- `category=Cloud Storage` returns Flickr; `Storage` holds R2 and B2.
- `category=Error Tracking` returns 15 records and Sentry is not one of them.
- `category=Secrets Management` returns 4; 1Password is under Security and Bitwarden under Password Managers.

## The single declaration

`src/category-scope.ts` holds one entry per published name: a one-line scope statement, the `audience` it is sold to (`developer` or `personal`), whether it `holds` products or qualified-access programmes, and the question or questions it `answers`. Names sharing a question form a family, and every member publishes the others with their counts.

`/api/categories` and `/category/:slug` both read from it, so the page and the API cannot state different scopes — a test asserts the page prints the directory's own sentence character for character.

```
GET /api/categories
{
  "name": "Error Tracking", "slug": "error-tracking", "count": 15,
  "audience": "developer", "holds": "products",
  "answers": ["how do I find out it is broken"],
  "scope": "Crash and exception aggregation from dedicated error trackers; the observability suites that also do it, Sentry among them, are filed under Monitoring.",
  "also_answering": [
    {"name": "Logging", "slug": "logging", "count": 14},
    {"name": "Monitoring", "slug": "monitoring", "count": 59},
    {"name": "Status Pages", "slug": "status-pages", "count": 6}
  ],
  "example_members": ["Bugsnag", "Rollbar", "GlitchTip"]
}
```

**A scope statement that names a vendor declares where that vendor is filed, and a test reads the claim back off the catalogue.** Error Tracking's sentence stops being publishable the day Sentry moves. Six names carry such a claim.

## The one merge

`Startup Programs` (13) and `Startup Perks` (93) held the same thing under two names, and no scope statement could tell them apart, so `Startup Programs` is merged away. The retired name still filters offers — `/api/offers?category=Startup Programs` and `search_deals` both resolve it — and `/category/startup-programs` redirects. `retired_names` publishes the mapping. Every one of the 66 category paths live before this change still resolves, and a test holds all 66.

## The sixteen refiled records

Sixteen records whose `tier` reads `Startup Program` or `Portfolio` sat in a product category. In every one **the tier is right and the category was wrong** — each description states credits, a discount or free seats for a qualifying company:

| was | records |
|---|---|
| Cloud IaaS | AWS Activate, Microsoft Founders Hub, Microsoft for Startups, Create@Alibaba Cloud, Clever Bootstrap Program, Scaleway Startup Program |
| Communication | Knowlarity for Startups, The Intercom Early Stage Program, Zendesk for Startups, Help Scout for Startups |
| Analytics | Segment |
| Project Management | Atlassian |
| Databases | ScaleGrid Startup Program |
| Payments | Chargebee Launch Programme |
| Video | Shotstack Startup Program |
| AI / ML | Vast.ai |

A test now keeps a qualified-access tier out of any category declaring it holds products.

## Verification

- 4,264 tests, 26 new, 0 failures. `tsc --noEmit` clean.
- Read back off a running server: `/api/categories` publishes 65 scoped names; `/category/startup-programs` returns 301 to `/category/startup-perks`; `?category=Startup%20Programs` returns the same 122 records as `?category=Startup%20Perks`; MCP `initialize` → `tools/call` `search_deals` with the retired name returns records labelled `Startup Perks`.
- `/category/error-tracking` and `/category/cloud-storage` read on the rendered page.

## Where this leaves other tests

Nine tests were pinned to a record or a count the refiling moves. Each was restated over the property rather than the fixture: `/best/:slug` sweeps every category holding an eligibility record instead of assuming AI/ML has one; the comparison verdict finds a pair with differing change counts instead of naming one; two floors of 20 and 13 over a live population became shares of the category census, via the `assertPopulationFloor` helper.

`data/page-lastmod.json` loses 47 `/compare/` entries and gains 42: the comparison-pair generator rotates over each category's vendor list, so refiling 29 records changes which pages exist. Only those 89 entries are touched — every other page keeps its recorded date.

Refs #1436