### PR TITLE
State on every change entry whether its date is when the terms changed (#1440)

### DIFF
--- a/src/change-dates.ts
+++ b/src/change-dates.ts
@@ -7,6 +7,10 @@ type ExpiringChange = Pick<DealChange, "date" | "date_source" | "change_type" | 
 
 export const DISCOVERED_DATE_PREFIX = "discovered";
 
+export const EFFECTIVE_DATE_PREFIX = "effective";
+
+export const UNKNOWN_EFFECTIVE_DATE_MARKER = "effective date unknown";
+
 export const DATE_SOURCES: ChangeDateSource[] = ["vendor_page", "hand_written", "discovered"];
 
 export const EVENT_DATED_SOURCES: ChangeDateSource[] = ["vendor_page", "hand_written"];
@@ -73,12 +77,20 @@ export function discoveryBatchNote(count: number, when: string): string {
 export const UNDATED_GROUP_NOTE =
   "The vendor’s page states these terms but not when they took effect, so we can only tell you when we found them. They are listed by discovery date and are excluded from the monthly groups and the Last 30 Days count above, both of which count changes by the date they took effect.";
 
+export const UNDATED_TILE_LABEL = "Effective Date Unknown";
+
 export function undatedGroupHeading(count: number): string {
   return `Effective date unknown (${count} ${count === 1 ? "change" : "changes"})`;
 }
 
 export function changeDateLabel(c: DatedChange): string {
   return isEventDated(c) ? c.date : `${DISCOVERED_DATE_PREFIX} ${c.date}`;
+}
+
+export function changeEntryDateLabel(c: DatedChange): string {
+  return isEventDated(c)
+    ? `${EFFECTIVE_DATE_PREFIX} ${c.date}`
+    : `${DISCOVERED_DATE_PREFIX} ${c.date} · ${UNKNOWN_EFFECTIVE_DATE_MARKER}`;
 }
 
 export function changeDateClause(c: DatedChange): string {

--- a/src/serve.ts
+++ b/src/serve.ts
@@ -68,7 +68,7 @@ import { verificationLedger, QUARANTINE_AFTER_FAILURES } from "./verification-st
 import { partitionAlternatives, partitionSubstitutes, type SubstitutesPartition, productRoleSentence, MEMBERSHIP_GATE_RULES, MEMBERSHIP_GATE_ORDER, MEMBERSHIP_GATE_SYMMETRY, MEMBERSHIP_GATE_SCOPE, MEMBERSHIP_GATE_CORRECTIONS, SUBTYPE_TAXONOMIES, SUBTYPE_MEMBERSHIP_RULE, SUBTYPE_MEMBERSHIP_GROUP_SCOPE, CURATED_SUBTYPE_EXEMPTION, membershipGroupsFor, subtypeDefinition } from "./product-role.js";
 import { resolveCuratedAlternatives, curatedAlternativesFor, addCuratedToPool } from "./curated-alternatives.js";
 import type { Agent, ChangeDateSource, DealChange, RiskCause, RatingWithheld, LinkUnreachable, Offer, StabilityClass } from "./types.js";
-import { changeDateLabel, changeDateClause, changeDatePublished, changeEventStartDate, capListSections, latestEventDate, offerExpiryAfter, feedEntryUpdated, undatedGroupHeading, firstReadHeading, discoveryBatchNote, isoWeekOf, DISCOVERED_DATE_PREFIX, UNDATED_GROUP_NOTE } from "./change-dates.js";
+import { changeDateLabel, changeEntryDateLabel, changeDateClause, changeDatePublished, changeEventStartDate, capListSections, latestEventDate, offerExpiryAfter, feedEntryUpdated, undatedGroupHeading, UNDATED_TILE_LABEL, firstReadHeading, discoveryBatchNote, isoWeekOf, DISCOVERED_DATE_PREFIX, EFFECTIVE_DATE_PREFIX, EVENT_DATED_SOURCES, UNDATED_GROUP_NOTE, UNKNOWN_EFFECTIVE_DATE_MARKER } from "./change-dates.js";
 import { FEED_CORRECTIONS, correctionEntriesXml } from "./feed-corrections.js";
 import { buildDay, emptyPageLastmod, fallbackDay, httpDate, lastmodFor, newestLastmod, readPageLastmod, type PageLastmodLedger } from "./page-lastmod.js";
 import type { AgentBalance } from "./ledger.js";
@@ -627,7 +627,7 @@ function buildChangesHtml(): string {
         <div class="change-header">
           <span class="change-badge" style="background:${badge.color}">${badge.label}</span>
           <span class="change-vendor">${c.vendor}</span>
-          <span class="change-date">${changeDateLabel(c)}</span>
+          <span class="change-date">${changeEntryDateLabel(c)}</span>
         </div>
         <div class="change-summary">${c.summary}</div>
       </div>`;
@@ -652,7 +652,7 @@ function buildDeadlinesHtml(): string {
           <div class="deadline-header">
             <span class="change-badge" style="background:${badge.color}">${badge.label}</span>
             <span class="change-vendor">${c.vendor}</span>
-            <span class="deadline-date">${c.date}</span>
+            <span class="deadline-date">${changeEntryDateLabel(c)}</span>
           </div>
           <div class="change-summary">${c.summary}</div>
         </div>
@@ -704,7 +704,7 @@ function buildRecentChangesSection(): string {
         <div class="rc-head">
           <span class="change-badge" style="background:${badge.color}">${badge.label}</span>
           <a href="/vendor/${vendorSlug}" class="rc-vendor">${c.vendor}</a>
-          <span class="rc-date">${changeDateLabel(c)}</span>
+          <span class="rc-date">${changeEntryDateLabel(c)}</span>
         </div>
         <div class="rc-summary">${c.summary}</div>
       </div>`;
@@ -2061,7 +2061,7 @@ function buildBestOfMiniReview(offer: ReturnType<typeof enrichOffers>[number]): 
 function renderDisclosures(entry: RankedEntry<EnrichedOfferRow>): string {
   if (entry.disclosures.length === 0) return "";
   const items = entry.disclosures.map((d) =>
-    `<li><span style="font-family:var(--mono);color:var(--text-dim)">${escHtmlServer(changeDateLabel(d))}</span> &mdash; <strong>${escHtmlServer(d.code.replace(/_/g, " "))}</strong>: ${escHtmlServer(d.summary)}</li>`
+    `<li><span style="font-family:var(--mono);color:var(--text-dim)">${escHtmlServer(changeEntryDateLabel(d))}</span> &mdash; <strong>${escHtmlServer(d.code.replace(/_/g, " "))}</strong>: ${escHtmlServer(d.summary)}</li>`
   ).join("");
   return `<div class="best-disclosure"><span class="best-disclosure-label">Recorded, but does not affect rank:</span><ul>${items}</ul></div>`;
 }
@@ -2850,7 +2850,7 @@ function buildComparisonPage(slug: string): string | null {
       return `<div style="margin-bottom:.75rem;padding:.6rem .75rem;border-left:3px solid ${badge.color};background:var(--bg-card);border-radius:0 6px 6px 0">
         <div style="display:flex;align-items:center;gap:.5rem;margin-bottom:.25rem">
           <span style="display:inline-block;padding:.1rem .4rem;border-radius:10px;font-size:.65rem;font-weight:600;background:${badge.color};color:#fff">${badge.label}</span>
-          <span style="font-family:var(--mono);font-size:.75rem;color:var(--text-dim)">${changeDateLabel(c)}</span>
+          <span style="font-family:var(--mono);font-size:.75rem;color:var(--text-dim)">${changeEntryDateLabel(c)}</span>
           <span style="font-size:.7rem;color:${changeImpactColor(c.impact)}">${c.impact} impact</span>
           ${changeIsUncited(c) ? unsourcedTagHtml() : ""}
         </div>
@@ -3361,7 +3361,7 @@ function buildVsPage(slug: string): string | null {
       return `<div style="margin-bottom:.75rem;padding:.6rem .75rem;border-left:3px solid ${badge.color};background:var(--bg-card);border-radius:0 6px 6px 0">
         <div style="display:flex;align-items:center;gap:.5rem;margin-bottom:.25rem">
           <span style="display:inline-block;padding:.1rem .4rem;border-radius:10px;font-size:.65rem;font-weight:600;background:${badge.color};color:#fff">${badge.label}</span>
-          <span style="font-family:var(--mono);font-size:.75rem;color:var(--text-dim)">${changeDateLabel(c)}</span>
+          <span style="font-family:var(--mono);font-size:.75rem;color:var(--text-dim)">${changeEntryDateLabel(c)}</span>
           <span style="font-size:.7rem;color:${changeImpactColor(c.impact)}">${c.impact} impact</span>
           ${changeIsUncited(c) ? unsourcedTagHtml() : ""}
         </div>
@@ -3697,7 +3697,7 @@ function buildDigestPage(weekKey: string): string | null {
       <div class="change-header">
         <span class="change-badge" style="background:${badge.color}">${badge.label}</span>
         <span class="change-vendor">${escHtmlServer(c.vendor)}</span>
-        <span class="change-date">${changeDateLabel(c)}</span>
+        <span class="change-date">${changeEntryDateLabel(c)}</span>
         <span class="change-cat">${escHtmlServer(c.category)}</span>
       </div>
       <div class="change-summary">${escHtmlServer(c.summary)}</div>
@@ -3914,7 +3914,7 @@ function buildThisWeekPage(weeksAgo: number): string {
         <div class="change-header">
           <span class="change-badge" style="background:${badge.color}">${badge.label}</span>
           <a href="/vendor/${toSlug(c.vendor)}" class="change-vendor">${escHtmlServer(c.vendor)}</a>
-          <span class="change-cat" style="font-family:var(--mono)">${changeDateLabel(c)}</span>
+          <span class="change-cat" style="font-family:var(--mono)">${changeEntryDateLabel(c)}</span>
           <span class="change-cat">${escHtmlServer(c.category)}</span>
         </div>
         <div class="change-summary">${escHtmlServer(c.summary)}</div>
@@ -4298,7 +4298,7 @@ function buildVendorPage(slug: string): string | null {
   const ratingWithheld = enriched.rating_withheld;
 
   const riskCauseLine = statesRiskCause(verdictInput) && riskCause
-    ? `  <p class="risk-cause-line" style="margin:.4rem 0 .6rem;font-size:.9rem;color:var(--text-muted)"><strong style="color:${riskColor}">Why ${riskLevel}:</strong> <span class="risk-cause-date" style="font-family:var(--mono)">${escHtmlServer(changeDateLabel(riskCause))}</span> &mdash; ${escHtmlServer(riskCause.summary)} <a href="#changes" style="white-space:nowrap">Full history &darr;</a></p>`
+    ? `  <p class="risk-cause-line" style="margin:.4rem 0 .6rem;font-size:.9rem;color:var(--text-muted)"><strong style="color:${riskColor}">Why ${riskLevel}:</strong> <span class="risk-cause-date" style="font-family:var(--mono)">${escHtmlServer(changeEntryDateLabel(riskCause))}</span> &mdash; ${escHtmlServer(riskCause.summary)} <a href="#changes" style="white-space:nowrap">Full history &darr;</a></p>`
     : "";
 
   const retiredBadgeColor = "#8b949e";
@@ -4500,7 +4500,7 @@ ${enrichedAlts.map(a => {
     return `<div class="change-item${isNoLongerInForce(c) ? " change-resolved" : ""}${uncited ? " change-unsourced" : ""}">
         <div class="change-head">
           <span class="badge" style="background:${badge.color}">${badge.label}</span>
-          <span class="change-date"><a href="/pricing-changes#${anchor}" style="color:var(--text-dim);text-decoration:none">${changeDateLabel(c)}</a></span>
+          <span class="change-date"><a href="/pricing-changes#${anchor}" style="color:var(--text-dim);text-decoration:none">${changeEntryDateLabel(c)}</a></span>
           <span class="impact impact-${changeImpactWord(c.impact)}">${changeImpactWord(c.impact)} impact</span>
           ${uncited ? unsourcedTagHtml() : ""}
         </div>
@@ -4524,7 +4524,7 @@ ${enrichedAlts.map(a => {
     const badge = changeTypeBadge[latestChange.change_type] ?? { label: latestChange.change_type, color: "#8b949e" };
     const anchor = `${toSlug(latestChange.vendor)}-${latestChange.date}`;
     return `<div class="change-notice" style="margin:1rem 0;padding:.75rem 1rem;border:1px solid ${badge.color}40;border-left:3px solid ${badge.color};border-radius:0 8px 8px 0;background:${badge.color}10">
-      <span style="font-size:.85rem">\u26a0\ufe0f <strong>Pricing change:</strong> ${escHtmlServer(latestChange.summary)} (${latestChange.date})</span>
+      <span style="font-size:.85rem">\u26a0\ufe0f <strong>Pricing change:</strong> ${escHtmlServer(latestChange.summary)} (${escHtmlServer(changeEntryDateLabel(latestChange))})</span>
       <a href="/pricing-changes#${anchor}" style="display:block;font-size:.8rem;margin-top:.25rem">View in changelog &rarr;</a>
     </div>`;
   })() : "";
@@ -5085,7 +5085,7 @@ function buildAlternativesPage(slug: string): string | null {
       parts.push(`<div class="risk-row"><span class="risk-label">Why:</span> ${escHtmlServer(altWithheldSentence)} We are not publishing a stability judgement for it until that is fixed.</div>`);
     }
     if (riskLevel !== "stable" && riskCause) {
-      parts.push(`<div class="risk-row"><span class="risk-label">Why:</span> <span class="risk-cause-date" style="font-family:var(--mono)">${escHtmlServer(changeDateLabel(riskCause))}</span> &mdash; ${escHtmlServer(riskCause.summary)}</div>`);
+      parts.push(`<div class="risk-row"><span class="risk-label">Why:</span> <span class="risk-cause-date" style="font-family:var(--mono)">${escHtmlServer(changeEntryDateLabel(riskCause))}</span> &mdash; ${escHtmlServer(riskCause.summary)}</div>`);
     }
     parts.push(`<div class="risk-row"><span class="risk-label">Category:</span> ${vendorCategories.map(c => `<a href="/category/${toSlug(c)}" class="cat-pill">${escHtmlServer(c)}</a>`).join(" ")}</div>`);
     if (!offerRetired(primary)) {
@@ -5098,7 +5098,7 @@ function buildAlternativesPage(slug: string): string | null {
         return `<div class="change-item${isNoLongerInForce(c) ? " change-resolved" : ""}">
           <div class="change-head">
             <span class="badge" style="background:${badge.color}">${badge.label}</span>
-            <span class="change-date">${changeDateLabel(c)}</span>
+            <span class="change-date">${changeEntryDateLabel(c)}</span>
             <span class="impact impact-${changeImpactWord(c.impact)}">${changeImpactWord(c.impact)} impact</span>
           </div>
           <div class="change-summary">${escHtmlServer(c.summary)}</div>
@@ -8600,7 +8600,7 @@ function buildEventPage(slug: string): string | null {
           + '<div class="update-head">'
           + '<span class="badge" style="background:' + badge.color + '">' + badge.label + '</span>'
           + '<strong>' + escHtmlServer(c.vendor) + '</strong>'
-          + '<span class="update-date">' + c.date + '</span>'
+          + '<span class="update-date">' + escHtmlServer(changeEntryDateLabel(c)) + '</span>'
           + '<span class="impact impact-' + changeImpactWord(c.impact) + '">' + changeImpactWord(c.impact) + ' impact</span>'
           + '</div>'
           + '<div class="update-summary">' + escHtmlServer(c.summary) + '</div>'
@@ -18435,7 +18435,7 @@ function buildQ1PricingReportPage(): string {
     return "<div class=\"change-card\" style=\"border-left-color:" + impactColor + "\">" +
       "<div class=\"change-header\">" +
         "<a href=\"/vendor/" + vendorSlug + "\" class=\"change-vendor\">" + escHtmlServer(c.vendor) + "</a>" +
-        "<span class=\"change-date\">" + changeDateLabel(c) + "</span>" +
+        "<span class=\"change-date\">" + changeEntryDateLabel(c) + "</span>" +
         "<span class=\"change-impact\" style=\"color:" + impactColor + "\">" + c.impact + "</span>" +
       "</div>" +
       "<span class=\"change-type-badge\" style=\"background:" + impactColor + "22;color:" + impactColor + "\">" + typeLabel + "</span>" + editorialLink +
@@ -18843,7 +18843,7 @@ function buildQ2PricingPreview2026Page(): string {
     return `<div class="change-card" style="border-left-color:${impactColor}">
       <div class="change-header">
         <a href="/vendor/${vendorSlug}" class="change-vendor">${escHtmlServer(c.vendor)}</a>
-        <span class="change-date">${changeDateLabel(c)}</span>
+        <span class="change-date">${changeEntryDateLabel(c)}</span>
         <span class="change-impact" style="color:${impactColor}">${c.impact}</span>
       </div>
       <span class="change-type-badge" style="background:${impactColor}22;color:${impactColor}">${typeLabel}</span>${editorialLink}
@@ -18986,7 +18986,7 @@ ${mcpCtaCss()}
   ${timelineChanges.map(c => {
     const impactColor = impactColors[c.impact] ?? "#94a3b8";
     return `<div class="timeline-item">
-      <div class="timeline-date">${changeDateLabel(c)}</div>
+      <div class="timeline-date">${changeEntryDateLabel(c)}</div>
       <div class="timeline-content">
         <span class="timeline-vendor"><a href="/vendor/${toSlug(c.vendor)}" style="color:var(--text)">${escHtmlServer(c.vendor)}</a></span>
         <span class="timeline-impact" style="background:${impactColor}22;color:${impactColor}">${c.impact}</span>
@@ -21011,7 +21011,7 @@ ${mcpCtaCss()}
   <p class="section-intro">Pricing context from our deal change tracker. Monitoring is one of the most actively evolving pricing categories.</p>
   <div style="display:grid;gap:.75rem;margin:1rem 0">
     ${relatedChanges.length > 0 ? relatedChanges.map(c => `<div class="diff-card" style="border-left-color:#d29922">
-      <h3>${escHtmlServer(c.vendor)} — ${escHtmlServer(c.date)}</h3>
+      <h3>${escHtmlServer(c.vendor)} — ${escHtmlServer(changeEntryDateLabel(c))}</h3>
       <p class="diff-desc">${escHtmlServer(c.summary)}</p>
       <p style="font-size:.8rem;color:var(--text-dim);margin-top:.5rem">Impact: ${escHtmlServer(c.impact)} &middot; <a href="${escHtmlServer(c.source_url)}" target="_blank" rel="noopener">Source &rarr;</a></p>
     </div>`).join("\n    ") : `<div class="context-box">No recent pricing changes tracked for Datadog or New Relic. Both vendors have maintained stable free tier limits through early 2026. Check our <a href="/changes">full pricing timeline</a> for all vendor changes.</div>`}
@@ -23251,7 +23251,7 @@ function buildStabilityDashboardPage(): string {
       <p class="vendor-summary">${escHtmlServer(latestChange?.summary?.substring(0, 200) ?? "")}</p>
       <div class="vendor-meta">
         <span class="change-type">${escHtmlServer(changeTypeLabel)}</span>
-        <span class="change-date">${escHtmlServer(latestChange ? changeDateLabel(latestChange) : "")}</span>
+        <span class="change-date">${escHtmlServer(latestChange ? changeEntryDateLabel(latestChange) : "")}</span>
         ${entry.changes.length > 1 ? `<span class="change-count">${entry.changes.length} changes tracked</span>` : ""}
         ${editorialLink ? `<a href="/${editorialLink.slug}" class="alt-link">View alternatives &rarr;</a>` : ""}
       </div>
@@ -26656,7 +26656,7 @@ function buildFreeTierTrackerPage(): string {
     return `<tr>
       <td style="font-weight:600;white-space:nowrap"><a href="/vendor/${vendorSlug}" style="color:var(--text)">${escHtmlServer(c.vendor)}</a></td>
       <td style="white-space:nowrap"><span style="color:${color};font-weight:600;font-size:.8rem">${label}</span></td>
-      <td style="font-family:var(--mono);font-size:.8rem;color:var(--text-dim);white-space:nowrap">${escHtmlServer(c.date)}</td>
+      <td style="font-family:var(--mono);font-size:.8rem;color:var(--text-dim);white-space:nowrap">${escHtmlServer(changeEntryDateLabel(c))}</td>
       <td style="color:var(--text-muted);font-size:.8rem">${escHtmlServer(c.summary.length > 120 ? c.summary.slice(0, 117) + "..." : c.summary)}</td>
     </tr>`;
   };
@@ -30321,7 +30321,7 @@ function buildVectorDatabasePricingPage(): string {
 
   const changeTimelineRows = vectorChanges.slice(0, 15).map((c: any) =>
     '<tr>' +
-    '<td style="font-size:.85rem;white-space:nowrap">' + escHtmlServer(c.date) + '</td>' +
+    '<td style="font-size:.85rem;white-space:nowrap">' + escHtmlServer(changeEntryDateLabel(c)) + '</td>' +
     '<td style="font-weight:600;font-size:.85rem"><a href="/vendor/' + escHtmlServer(c.vendor.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/-+$/, "")) + '">' + escHtmlServer(c.vendor) + '</a></td>' +
     '<td style="font-size:.85rem">' + escHtmlServer(c.change_type || "update") + '</td>' +
     '<td style="font-size:.85rem;color:var(--text-muted)">' + escHtmlServer(c.description || c.summary || "") + '</td>' +
@@ -45460,7 +45460,7 @@ function buildStateOfFreeTiersPage(): string {
     return `<div style="margin-bottom:.75rem;padding:.75rem 1rem;border-left:3px solid ${badge.color};background:var(--bg-card);border-radius:0 8px 8px 0">
       <div style="display:flex;align-items:center;gap:.5rem;margin-bottom:.3rem;flex-wrap:wrap">
         <span style="display:inline-block;padding:.1rem .5rem;border-radius:10px;font-size:.65rem;font-weight:600;background:${badge.color};color:#fff">${badge.label}</span>
-        <span style="font-family:var(--mono);font-size:.75rem;color:var(--text-dim)">${changeDateLabel(c)}</span>
+        <span style="font-family:var(--mono);font-size:.75rem;color:var(--text-dim)">${changeEntryDateLabel(c)}</span>
         <span style="font-size:.7rem;color:${impactColor};font-weight:600">${c.impact} impact</span>
         <a href="/vendor/${toSlug(c.vendor)}" style="font-size:.8rem;font-weight:600;color:var(--text)">${escHtmlServer(c.vendor)}</a>
       </div>
@@ -45473,7 +45473,7 @@ function buildStateOfFreeTiersPage(): string {
     return `<div style="margin-bottom:.75rem;padding:.75rem 1rem;border-left:3px solid ${badge.color};background:var(--bg-card);border-radius:0 8px 8px 0">
       <div style="display:flex;align-items:center;gap:.5rem;margin-bottom:.3rem;flex-wrap:wrap">
         <span style="display:inline-block;padding:.1rem .5rem;border-radius:10px;font-size:.65rem;font-weight:600;background:${badge.color};color:#fff">${badge.label}</span>
-        <span style="font-family:var(--mono);font-size:.75rem;color:var(--text-dim)">${changeDateLabel(c)}</span>
+        <span style="font-family:var(--mono);font-size:.75rem;color:var(--text-dim)">${changeEntryDateLabel(c)}</span>
         <a href="/vendor/${toSlug(c.vendor)}" style="font-size:.8rem;font-weight:600;color:var(--text)">${escHtmlServer(c.vendor)}</a>
       </div>
       <div style="font-size:.85rem;color:var(--text-muted);line-height:1.4">${escHtmlServer(c.summary)}</div>
@@ -46957,7 +46957,7 @@ function buildStackCheckPage(): string {
         ? { date: changeDateLabel(assessment.cause), date_source: assessment.cause.date_source, change_type: assessment.cause.change_type, summary: assessment.cause.summary }
         : null,
       stability,
-      recent_changes: vendorChanges.map(c => ({ date: changeDateLabel(c), change_type: c.change_type, summary: c.summary, impact: c.impact, resolved: isNoLongerInForce(c) })),
+      recent_changes: vendorChanges.map(c => ({ date: changeEntryDateLabel(c), change_type: c.change_type, summary: c.summary, impact: c.impact, resolved: isNoLongerInForce(c) })),
     };
     vendorLookup[offer.vendor.toLowerCase()] = vendorLookup[slug];
   }
@@ -47546,6 +47546,15 @@ ${globalNavCss()}
   var PRESETS = ${JSON.stringify(presetMatchups)};
   var NEG_TYPES = ['free_tier_removed','limits_reduced','restriction','product_deprecated','open_source_killed','pricing_model_change','pricing_restructured'];
   var POS_TYPES = ['new_free_tier','limits_increased','startup_program_expanded','new_tier'];
+  var EVENT_DATED_SOURCES = ${JSON.stringify(EVENT_DATED_SOURCES)};
+  var EFFECTIVE_DATE_PREFIX = ${JSON.stringify(EFFECTIVE_DATE_PREFIX)};
+  var DISCOVERED_DATE_PREFIX = ${JSON.stringify(DISCOVERED_DATE_PREFIX)};
+  var UNKNOWN_EFFECTIVE_DATE_MARKER = ${JSON.stringify(UNKNOWN_EFFECTIVE_DATE_MARKER)};
+
+  function changeEntryDateLabel(c) {
+    if (EVENT_DATED_SOURCES.indexOf(c.date_source) !== -1) return EFFECTIVE_DATE_PREFIX + ' ' + c.date;
+    return DISCOVERED_DATE_PREFIX + ' ' + c.date + ' \u00b7 ' + UNKNOWN_EFFECTIVE_DATE_MARKER;
+  }
 
   function usePreset(a, b) {
     document.getElementById('vendor-a').value = a;
@@ -47650,7 +47659,7 @@ ${globalNavCss()}
     if (changes.length > 0) {
       html += '<div class="changes-timeline"><strong style="font-size:.85rem">Recent Changes</strong>';
       changes.slice(0, 5).forEach(function(c) {
-        html += '<div class="change-item' + (c.resolution ? ' change-resolved' : '') + '"><span class="change-date">' + escHtml(c.date) + '</span> ' + changeTypeBadge(c.change_type) + ' ' + escHtml(c.summary.length > 120 ? c.summary.slice(0, 120) + '...' : c.summary) + '</div>';
+        html += '<div class="change-item' + (c.resolution ? ' change-resolved' : '') + '"><span class="change-date">' + escHtml(changeEntryDateLabel(c)) + '</span> ' + changeTypeBadge(c.change_type) + ' ' + escHtml(c.summary.length > 120 ? c.summary.slice(0, 120) + '...' : c.summary) + '</div>';
       });
       html += '</div>';
     }
@@ -48721,7 +48730,7 @@ function buildEmbedVendorWidget(slug: string, theme: "dark" | "light"): string |
       return `<div style="padding:4px 0;font-size:12px;color:var(--text-m)">
         <span style="display:inline-block;padding:1px 6px;border-radius:3px;font-size:10px;font-weight:600;color:#fff;background:${badge.color}">${badge.label}</span>
         <span style="margin-left:4px">${escHtmlServer(c.summary)}</span>
-        <span style="opacity:.6;margin-left:4px">${c.date}</span>
+        <span style="opacity:.6;margin-left:4px">${escHtmlServer(changeEntryDateLabel(c))}</span>
       </div>`;
     }).join("")}
   </div>` : "";
@@ -48777,7 +48786,7 @@ function buildEmbedChangesWidget(theme: "dark" | "light"): string {
       <div>
         <a href="${BASE_URL}/vendor/${vSlug}" target="_blank" rel="noopener" style="font-weight:600;font-size:13px">${escHtmlServer(c.vendor)}</a>
         <div style="font-size:12px;color:var(--text-m);margin-top:1px">${escHtmlServer(c.summary)}</div>
-        <div style="font-size:11px;color:var(--text-m);opacity:.6;margin-top:1px">${c.date}</div>
+        <div style="font-size:11px;color:var(--text-m);opacity:.6;margin-top:1px">${escHtmlServer(changeEntryDateLabel(c))}</div>
       </div>
     </div>`;
   }).join("");
@@ -49335,6 +49344,14 @@ function buildDeveloperHubPage(): string {
     + "</html>";
 }
 
+function undatedTileHtml(count: number): string {
+  if (count === 0) return "";
+  return `    <div class="stat-card stat-card-undated">
+      <div class="stat-value">${count}</div>
+      <div class="stat-label">${UNDATED_TILE_LABEL}</div>
+    </div>`;
+}
+
 function buildPricingChangesPage(): string {
   const allChanges = loadDealChanges();
   const { dated: eventDated, discovered: undatedChanges } = partitionByDateProvenance(allChanges);
@@ -49395,7 +49412,7 @@ function buildPricingChangesPage(): string {
     const changeYear = dated ? c.date.slice(0, 4) : "";
     return `      <div class="pc-entry${isUpcoming ? " pc-upcoming" : ""}${dated ? "" : " pc-undated"}${isNoLongerInForce(c) ? " pc-resolved" : ""}${changeIsUncited(c) ? " pc-unsourced" : ""}" id="${changeAnchor(c)}" data-type="${escHtmlServer(c.change_type)}" data-impact="${escHtmlServer(c.impact)}" data-category="${category}" data-vendor-cat="${vendorCat}" data-year="${changeYear}">
         <div class="pc-left">
-          <div class="pc-date">${dated ? c.date : `${DISCOVERED_DATE_PREFIX} ${c.date}`}</div>
+          <div class="pc-date${dated ? "" : " pc-date-unknown"}">${changeEntryDateLabel(c)}</div>
           ${isUpcoming ? `<div class="pc-upcoming-badge">upcoming</div>` : ""}
           <a href="#${changeAnchor(c)}" class="pc-anchor" title="Link to this change">#</a>
         </div>
@@ -49649,6 +49666,8 @@ h1{font-family:var(--serif);font-size:2.25rem;color:var(--text);margin:1rem 0 .5
 .pc-undated{border-style:dashed}
 .pc-left{flex-shrink:0;min-width:100px;text-align:right;position:relative}
 .pc-date{font-family:var(--mono);font-size:.75rem;color:var(--text-muted)}
+.pc-date-unknown{color:#d29922;font-style:italic}
+.stat-card-undated .stat-value{color:#d29922}
 .pc-upcoming-badge{font-family:var(--mono);font-size:.65rem;color:#58a6ff;font-weight:600;text-transform:uppercase;letter-spacing:.05em}
 .pc-anchor{font-family:var(--mono);font-size:.7rem;color:var(--text-dim);opacity:0;transition:opacity .15s}
 .pc-entry:hover .pc-anchor{opacity:1}
@@ -49722,6 +49741,7 @@ ${globalNavCss()}
       <div class="stat-value">${removedCount}</div>
       <div class="stat-label">Removals</div>
     </div>
+${undatedTileHtml(undatedSorted.length)}
   </div>
 
   <div class="trend-summary">
@@ -49862,7 +49882,7 @@ function buildChangesPage(): string {
       : "";
     return `      <div class="chg-entry${isUpcoming ? " chg-upcoming" : ""}${dated ? "" : " chg-undated"}${changeIsUncited(c) ? " chg-unsourced" : ""}"${anchorAttr}>
         <div class="chg-left">
-          <div class="chg-date">${dated ? c.date : `${DISCOVERED_DATE_PREFIX} ${c.date}`}</div>
+          <div class="chg-date${dated ? "" : " chg-date-unknown"}">${changeEntryDateLabel(c)}</div>
           ${isUpcoming ? `<div class="chg-upcoming-badge">upcoming</div>` : ""}
         </div>
         <div class="chg-right">
@@ -49966,6 +49986,8 @@ h1{font-family:var(--serif);font-size:2.25rem;color:var(--text);margin:1rem 0 .5
 .chg-undated{border-style:dashed}
 .chg-left{flex-shrink:0;min-width:100px;text-align:right}
 .chg-date{font-family:var(--mono);font-size:.75rem;color:var(--text-muted)}
+.chg-date-unknown{color:#d29922;font-style:italic}
+.stat-card-undated .stat-value{color:#d29922}
 .chg-upcoming-badge{font-family:var(--mono);font-size:.65rem;color:#58a6ff;font-weight:600;text-transform:uppercase;letter-spacing:.05em}
 .chg-right{flex:1;min-width:0}
 .chg-head{display:flex;align-items:center;gap:.5rem;margin-bottom:.25rem;flex-wrap:wrap}
@@ -50017,10 +50039,7 @@ ${globalNavCss()}
       <div class="stat-value">${byMonth.size}</div>
       <div class="stat-label">Months Tracked</div>
     </div>
-${undatedSorted.length === 0 ? "" : `    <div class="stat-card">
-      <div class="stat-value">${undatedSorted.length}</div>
-      <div class="stat-label">Effective Date Unknown</div>
-    </div>`}
+${undatedTileHtml(undatedSorted.length)}
   </div>
 
 ${changeLogFreshnessNote()}
@@ -50082,7 +50101,7 @@ function buildExpiringPage(): string {
     return `      <div class="exp-entry${urgentClass}${dated ? "" : " exp-undated"}">
         <div class="exp-left">
           ${countdown ? `<div class="exp-countdown${countdown.urgent ? " exp-countdown-urgent" : ""}">${countdown.text}</div>` : ""}
-          <div class="exp-date">${dated ? c.date : `${DISCOVERED_DATE_PREFIX} ${c.date}`}</div>
+          <div class="exp-date${dated ? "" : " exp-date-unknown"}">${changeEntryDateLabel(c)}</div>
         </div>
         <div class="exp-right">
           <div class="exp-head">
@@ -50190,6 +50209,7 @@ h1{font-family:var(--serif);font-size:2.25rem;color:var(--text);margin:1rem 0 .5
 .recent-entries{display:none}
 .recent-entries.show{display:block}
 .exp-undated{border-style:dashed}
+.exp-date-unknown{color:#d29922;font-style:italic}
 .no-upcoming{color:var(--text-dim);font-style:italic;padding:2rem;text-align:center;border:1px dashed var(--border);border-radius:8px}
 .mcp-cta{margin-top:2.5rem;padding:1.5rem;border:1px solid var(--border);border-radius:12px;background:var(--accent-glow);text-align:center}
 .mcp-cta p{color:var(--text-muted);font-size:.9rem;margin-bottom:.5rem}
@@ -50568,7 +50588,7 @@ function buildDeadlinesPage(): string {
             <a href="/vendor/${vendorSlug}" class="dl-vendor">${escHtmlServer(c.vendor)}</a>
             <span class="dl-category">${escHtmlServer(c.category)}</span>
           </div>
-          <div class="dl-date">${c.date}</div>
+          <div class="dl-date">${escHtmlServer(changeEntryDateLabel(c))}</div>
           <div class="dl-summary">${escHtmlServer(c.summary)}</div>
 ${altHtml}${guideHtml}
         </div>
@@ -52348,7 +52368,7 @@ function buildTrendsPage(slug: string): string | null {
         <div class="timeline-head">
           <span class="badge" style="background:${badge.color}">${badge.label}</span>
           <a href="/vendor/${toSlug(c.vendor)}" class="timeline-vendor">${escHtmlServer(c.vendor)}</a>
-          <span class="timeline-date">${changeDateLabel(c)}</span>
+          <span class="timeline-date">${changeEntryDateLabel(c)}</span>
           <span class="impact impact-${c.impact}">${c.impact}</span>
         </div>
         <div class="timeline-summary">${escHtmlServer(c.summary)}</div>

--- a/test/change-entry-date-provenance.test.ts
+++ b/test/change-entry-date-provenance.test.ts
@@ -1,0 +1,331 @@
+import { describe, it, before, after } from "node:test";
+import assert from "node:assert";
+import { assertPopulationFloor } from "./population-floor.ts";
+import { spawn, type ChildProcess } from "node:child_process";
+import { readFileSync, writeFileSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  changeEntryDateLabel,
+  DISCOVERED_DATE_PREFIX,
+  EFFECTIVE_DATE_PREFIX,
+  UNDATED_TILE_LABEL,
+  UNKNOWN_EFFECTIVE_DATE_MARKER,
+} from "../dist/change-dates.js";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO = path.join(__dirname, "..");
+
+const TODAY = new Date().toISOString().slice(0, 10);
+const dayOffset = (days: number) =>
+  new Date(Date.parse(TODAY) + days * 86400000).toISOString().slice(0, 10);
+
+const SUBJECT = "Xata";
+const CONTROL = "Hyperping";
+const CONTROL_DATE = dayOffset(-10);
+const SUMMARY = "Free storage allowance cut from 15 GB to 5 GB.";
+const FIELD_SLACK = 20;
+
+function change(vendor: string, date: string, dateSource: string, summary: string) {
+  return {
+    vendor,
+    change_type: "limits_reduced",
+    date,
+    date_source: dateSource,
+    summary,
+    previous_state: "15 GB storage",
+    current_state: "5 GB storage",
+    impact: "high",
+    source_url: `https://example.com/${vendor.toLowerCase()}/pricing`,
+    category: "Databases",
+    alternatives: [],
+    recorded_date: TODAY,
+    ...(dateSource === "discovered" ? { detected_by: "reverify-ai" } : {}),
+  };
+}
+
+function visibleText(body: string): string {
+  return body
+    .replace(/<script[\s\S]*?<\/script>/gi, " ")
+    .replace(/<style[\s\S]*?<\/style>/gi, " ")
+    .replace(/<[^>]+>/g, " ")
+    .replace(/&mdash;/g, "—")
+    .replace(/&ndash;/g, "–")
+    .replace(/&nbsp;/g, " ")
+    .replace(/&#39;/g, "'")
+    .replace(/&quot;/g, '"')
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&amp;/g, "&")
+    .replace(/\s+/g, " ");
+}
+
+function isDateField(text: string, date: string): boolean {
+  const remainder = text
+    .replace(date, "")
+    .replace(UNKNOWN_EFFECTIVE_DATE_MARKER, "")
+    .replace(EFFECTIVE_DATE_PREFIX, "")
+    .replace(DISCOVERED_DATE_PREFIX, "")
+    .replace(/[·\u2014\u2013-]/g, "")
+    .trim();
+  return remainder.length <= FIELD_SLACK;
+}
+
+function dateFields(body: string, date: string): string[] {
+  const found: string[] = [];
+  const withoutScripts = body.replace(/<script[\s\S]*?<\/script>/gi, " ");
+  for (const node of withoutScripts.matchAll(/>([^<>]*)</g)) {
+    const text = node[1].trim();
+    if (!text.includes(date)) continue;
+    if (!isDateField(text, date)) continue;
+    found.push(text);
+  }
+  return found;
+}
+
+const BROWSER_ASSEMBLED = ["/compare-tool", "/stack-check"];
+
+const EXEMPT: Array<{ name: string; allows: (field: string) => boolean }> = [
+  {
+    name: "the risk chip beside a vendor's name, which rates the vendor rather than listing the change",
+    allows: (field) => /^(?:discovered )?\d{4}-\d{2}-\d{2} [a-z ]+$/.test(field),
+  },
+];
+
+function startServer(changesPath: string): Promise<{ proc: ChildProcess; port: number }> {
+  return new Promise((resolve, reject) => {
+    const child = spawn("node", [path.join(REPO, "dist", "serve.js")], {
+      stdio: ["pipe", "pipe", "pipe"],
+      env: {
+        ...process.env,
+        PORT: "0",
+        BASE_URL: "http://localhost:3000",
+        AGENTDEALS_CHANGES_PATH: changesPath,
+      },
+    });
+    const timeout = setTimeout(() => {
+      child.kill();
+      reject(new Error("Server startup timeout"));
+    }, 30000);
+    child.stderr!.on("data", (data: Buffer) => {
+      const m = data.toString().match(/running on http:\/\/localhost:(\d+)/);
+      if (m) {
+        clearTimeout(timeout);
+        resolve({ proc: child, port: parseInt(m[1], 10) });
+      }
+    });
+    child.on("error", (err) => {
+      clearTimeout(timeout);
+      reject(err);
+    });
+  });
+}
+
+describe("the label an entry carries beside its date", () => {
+  it("says an event date is the date the terms took effect", () => {
+    assert.strictEqual(
+      changeEntryDateLabel({ date: TODAY, date_source: "vendor_page" } as never),
+      `${EFFECTIVE_DATE_PREFIX} ${TODAY}`
+    );
+    assert.strictEqual(
+      changeEntryDateLabel({ date: TODAY, date_source: "hand_written" } as never),
+      `${EFFECTIVE_DATE_PREFIX} ${TODAY}`
+    );
+  });
+
+  it("says a discovery date is not one, in the entry rather than above it", () => {
+    const label = changeEntryDateLabel({ date: TODAY, date_source: "discovered" } as never);
+    assert.ok(label.startsWith(`${DISCOVERED_DATE_PREFIX} ${TODAY}`), label);
+    assert.ok(label.includes(UNKNOWN_EFFECTIVE_DATE_MARKER), label);
+  });
+
+  it("stays short enough to repeat on every entry", () => {
+    const label = changeEntryDateLabel({ date: TODAY, date_source: "discovered" } as never);
+    assert.ok(label.length <= 60, `${label.length} characters: ${label}`);
+  });
+});
+
+const NOT_A_CHANGE_RECORD: Array<{ expr: string; why: string }> = [
+  { expr: "escHtmlServer(tie.date)", why: "the UTC day the ranking permutation is seeded on" },
+  { expr: "escHtmlServer(p.date)", why: "the day a press mention was published" },
+  { expr: "escHtmlServer(e.date)", why: "a hand-written editorial timeline, which carries no record" },
+];
+
+describe("nothing renders a change date without saying which kind of date it is", () => {
+  const source = readFileSync(path.join(REPO, "src", "serve.ts"), "utf8").split("\n");
+  const LABELLED = /change(?:Entry)?DateLabel|changeDateClause|feedEntryUpdated|toISOString/;
+  const TEXT_NODE = />\s*(?:\$\{([^{}]*(?:\{[^{}]*\}[^{}]*)*)\}|'\s*\+\s*([^+]*?)\s*\+\s*')\s*</g;
+
+  const dateTextNodes = source.flatMap((line, i) =>
+    [...line.matchAll(TEXT_NODE)]
+      .map((m) => (m[1] ?? m[2] ?? "").trim())
+      .filter((expr) => /\.date\b/.test(expr) && !LABELLED.test(expr))
+      .map((expr) => ({ line: i + 1, expr }))
+  );
+
+  const unlabelled = (line: string) =>
+    [...line.matchAll(TEXT_NODE)]
+      .map((m) => (m[1] ?? m[2] ?? "").trim())
+      .filter((expr) => /\.date\b/.test(expr) && !LABELLED.test(expr));
+
+  it("finds the date fields it is meant to be scanning", () => {
+    const labelled = source.filter((line) => /change(?:Entry)?DateLabel\(/.test(line)).length;
+    assertPopulationFloor(labelled, 20, "lines rendering a change date through a labelling helper");
+  });
+
+  it("catches a change date put back into a text node unlabelled", () => {
+    assert.deepStrictEqual(unlabelled('<span class="d">${c.date}</span>'), ["c.date"]);
+    assert.deepStrictEqual(unlabelled("'<td>' + escHtmlServer(c.date) + '</td>'"), ["escHtmlServer(c.date)"]);
+    assert.deepStrictEqual(unlabelled('<span class="d">${changeEntryDateLabel(c)}</span>'), []);
+    assert.deepStrictEqual(unlabelled('<a href="#${toSlug(c.vendor)}-${c.date}">link</a>'), []);
+  });
+
+  it("routes every date a change record carries through a labelling helper", () => {
+    const offenders = dateTextNodes
+      .filter(({ expr }) => !NOT_A_CHANGE_RECORD.some((e) => e.expr === expr))
+      .map(({ line, expr }) => `src/serve.ts:${line}: ${expr}`);
+    assert.deepStrictEqual(offenders, []);
+  });
+
+  it("keeps every declared non-record date in use", () => {
+    const unused = NOT_A_CHANGE_RECORD.filter(
+      (e) => !dateTextNodes.some(({ expr }) => expr === e.expr)
+    );
+    assert.deepStrictEqual(unused.map((e) => `${e.expr} — ${e.why}`), []);
+  });
+});
+
+describe("an entry lifted out of its section still says what its date is", () => {
+  let tmp: string;
+  const servers: ChildProcess[] = [];
+  let routes: string[] = [];
+  let ENTRY_DATE = "";
+  let discoveredPort = 0;
+  const rendered = new Map<string, { discovered: string; dated: string }>();
+
+  before(async () => {
+    tmp = mkdtempSync(path.join(tmpdir(), "change-entry-provenance-"));
+    const write = (name: string, changes: unknown[]) => {
+      const p = path.join(tmp, name);
+      writeFileSync(p, JSON.stringify({ changes }));
+      return p;
+    };
+    const control = change(CONTROL, CONTROL_DATE, "vendor_page", "Monitor allowance cut.");
+    ENTRY_DATE = dayOffset(-3);
+
+    const discovered = await startServer(
+      write("discovered.json", [control, change(SUBJECT, ENTRY_DATE, "discovered", SUMMARY)])
+    );
+    const dated = await startServer(
+      write("dated.json", [control, change(SUBJECT, ENTRY_DATE, "vendor_page", SUMMARY)])
+    );
+    servers.push(discovered.proc, dated.proc);
+    discoveredPort = discovered.port;
+
+    const index = await (await fetch(`http://localhost:${discovered.port}/sitemap.xml`)).text();
+    const locs: string[] = [];
+    for (const m of index.matchAll(/<loc>([^<]+)<\/loc>/g)) {
+      const childPath = new URL(m[1]).pathname;
+      const xml = await (await fetch(`http://localhost:${discovered.port}${childPath}`)).text();
+      for (const inner of xml.matchAll(/<loc>([^<]+)<\/loc>/g)) locs.push(new URL(inner[1]).pathname);
+    }
+    routes = [...new Set([...locs, ...BROWSER_ASSEMBLED, `/vendor/${SUBJECT.toLowerCase()}`])];
+
+    const queue = [...routes];
+    async function worker() {
+      for (;;) {
+        const route = queue.shift();
+        if (!route) return;
+        try {
+          const [a, b] = await Promise.all([
+            fetch(`http://localhost:${discovered.port}${route}`),
+            fetch(`http://localhost:${dated.port}${route}`),
+          ]);
+          if (a.status !== 200 || b.status !== 200) continue;
+          const bodies = { discovered: await a.text(), dated: await b.text() };
+          if (bodies.discovered.includes(SUMMARY)) rendered.set(route, bodies);
+        } catch {
+          continue;
+        }
+      }
+    }
+    await Promise.all(Array.from({ length: 6 }, worker));
+  });
+
+  after(() => {
+    for (const proc of servers) proc.kill();
+    if (tmp) rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it("reaches enough of the site for the sweep below to mean something", () => {
+    assertPopulationFloor(routes.length, 1001, "routes enumerated from the sitemap");
+    assert.ok(rendered.size > 8, `only ${rendered.size} routes rendered the entry at all`);
+  });
+
+  it("would fail if a date field printed the date without saying which date it is", () => {
+    const seen = [...rendered].filter(([, b]) => dateFields(b.dated, ENTRY_DATE).length > 0);
+    assertPopulationFloor(seen.length, 6, "routes putting the entry's date in a field of its own");
+  });
+
+  it("declares an effective date as one in every field that prints it", () => {
+    const offenders: string[] = [];
+    for (const [route, b] of rendered) {
+      for (const field of dateFields(b.dated, ENTRY_DATE)) {
+        if (field.includes(`${EFFECTIVE_DATE_PREFIX} ${ENTRY_DATE}`)) continue;
+        if (EXEMPT.some((e) => e.allows(field))) continue;
+        offenders.push(`${route}: ${field}`);
+      }
+    }
+    assert.deepStrictEqual(offenders, []);
+  });
+
+  it("says the effective date is unknown in every field that prints a discovery date", () => {
+    const offenders: string[] = [];
+    for (const [route, b] of rendered) {
+      for (const field of dateFields(b.discovered, ENTRY_DATE)) {
+        if (
+          field.includes(`${DISCOVERED_DATE_PREFIX} ${ENTRY_DATE}`) &&
+          field.includes(UNKNOWN_EFFECTIVE_DATE_MARKER)
+        ) {
+          continue;
+        }
+        if (EXEMPT.some((e) => e.allows(field))) continue;
+        offenders.push(`${route}: ${field}`);
+      }
+    }
+    assert.deepStrictEqual(offenders, []);
+  });
+
+  it("keeps every declared exemption in use", () => {
+    const fires = (e: (typeof EXEMPT)[number]) =>
+      [...rendered.values()].some((b) =>
+        [...dateFields(b.discovered, ENTRY_DATE), ...dateFields(b.dated, ENTRY_DATE)].some((f) => e.allows(f))
+      );
+    assert.deepStrictEqual(EXEMPT.filter((e) => !fires(e)).map((e) => e.name), []);
+  });
+
+  it("ships the same wording to the pages that assemble an entry in the browser", async () => {
+    for (const route of BROWSER_ASSEMBLED) {
+      const body = await (await fetch(`http://localhost:${discoveredPort}${route}`)).text();
+      assert.ok(body.includes(UNKNOWN_EFFECTIVE_DATE_MARKER), `${route} ships no marker`);
+      assert.ok(body.includes(EFFECTIVE_DATE_PREFIX), `${route} ships no event-date prefix`);
+    }
+  });
+
+  it("agrees with itself and with the API on how many entries it cannot date", async () => {
+    const tile = (body: string): number => {
+      const m = body.match(
+        new RegExp(`<div class="stat-value">(\\d+)</div>\\s*<div class="stat-label">${UNDATED_TILE_LABEL}</div>`)
+      );
+      assert.ok(m, "no undated tile");
+      return parseInt(m![1], 10);
+    };
+    const get = async (route: string) =>
+      await (await fetch(`http://localhost:${discoveredPort}${route}`)).text();
+    const api = JSON.parse(await get("/api/changes?since=2000-01-01&limit=1000"));
+    assert.strictEqual(api.date_provenance.discovered, 1);
+    assert.strictEqual(tile(await get("/pricing-changes")), api.date_provenance.discovered);
+    assert.strictEqual(tile(await get("/changes")), api.date_provenance.discovered);
+  });
+});


### PR DESCRIPTION
Refs #1440

`/pricing-changes` renders 259 records whose date is the day we read the vendor's page, not the day the terms changed. The section header said so; no entry did. An entry lifted out of that section read `discovered 2026-09-02 # reduced Artillery medium impact The free tier now includes 30 reports/month instead of 100.` — a date, a change type and a summary, with nothing in it saying the date is not an effective date. The sentence that says so sat 132,000 characters earlier.

Every entry now carries its own provenance.

| | before | after |
|---|---|---|
| event-dated | `2026-08-26` | `effective 2026-08-26` |
| discovery-dated | `discovered 2026-09-02` | `discovered 2026-09-02 · effective date unknown` |

46 characters at most, so it survives extraction and can be repeated 259 times. The Artillery entry the issue quotes now opens `discovered 2026-09-02 · effective date unknown`.

One declaration produces both forms — `changeEntryDateLabel` in `src/change-dates.ts`. Nothing in the data model, `date_source`, `date_provenance` or any API response changed.

## AC-5: the routes that render a change entry

The issue names two. There are 25 route families, and ten of them were rendering a change's date with no prefix at all — not even the `discovered` marker the rest of the site already had.

| Route | The entry |
|---|---|
| `/pricing-changes` | `pc-date` in every `pc-entry` |
| `/changes` | `chg-date` in every `chg-entry` |
| `/expiring` | `exp-date` in every `exp-entry` |
| `/deadlines` | `dl-date` **(was bare)** |
| `/` | recent changes, upcoming deadlines **(deadline list was bare)** |
| `/vendor/:slug` | the change list, the `Why <risk>` line, the pricing-change notice **(the notice was bare)** |
| `/alternative-to/:slug` | the change list and the risk row |
| `/compare/:slug` | recent changes |
| `/<a>-vs-<b>` | recent changes |
| `/best/:slug` | the disclosure list |
| `/trends/:slug` | the timeline |
| `/this-week` | the week's changes |
| `/digest/:week` | the week's changes |
| `/stability` | the latest change on each vendor card |
| `/state-of-free-tiers` | both change lists |
| `/free-tier-tracker` | the change table **(was bare)** |
| `/q1-2026-developer-pricing-report` | change cards |
| `/q2-pricing-preview-2026` | change cards and the timeline |
| `/events/:slug` | Recent Updates **(was bare)** |
| `/vector-database-pricing` | the change timeline **(was bare)** |
| `/datadog-vs-new-relic` | Recent Deal Changes **(was bare)** |
| `/stack-check` | change items, assembled in the browser from a server-built label |
| `/compare-tool` | change items, assembled in the browser **(was bare)** |
| `/embed/vendor/:slug` | the widget's change list **(was bare)** |
| `/embed/changes` | the widget's change list **(was bare)** |

`/compare-tool` builds its entries in the browser from `/api/compare`, which already returns `date_source`. It now composes the same label client-side from the same exported constants, so the wording cannot drift from the server's.

## The tile (AC-3, AC-4)

`/pricing-changes` gains the `Effective Date Unknown` tile `/changes` already had. Both now render from one function, so they cannot disagree, and a test holds both against `date_provenance.discovered` from `/api/changes`. On today's data all three read **259**.

## How this is held

`test/change-entry-date-provenance.test.ts`, three parts.

**A source scan.** Every HTML text node in `src/serve.ts` that interpolates a record's `date` must go through a labelling helper. Three expressions are declared exempt with a reason — a ranking seed, a press mention's publication day, and a hand-written editorial timeline — and a test fails if a declared exemption stops firing. A mutation control asserts the matcher fires on `${c.date}` in a text node and stays quiet on the labelled form and on an anchor id. This scan is what found the ten bare sites; the two existing sweeps could not, because they only see the routes a fixture reaches.

**A route sweep.** Two servers, the same change record, one `discovered` and one `vendor_page`. Every route in the sitemap is fetched from both. A *date field* is a text node that is a date plus at most 20 other characters — that excludes prose, which states its date in a sentence. Every date field for the event-dated record must say `effective`; every date field for the discovery-dated record must say both `discovered` and `effective date unknown`. A negative control asserts the sweep saw the field in the first place, so a green run cannot mean the entry never rendered.

**The label itself**, in both directions, and a length bound.

## Judgement calls

**Prose was left alone.** `/vendor/xata` answers *"What changed in Xata's pricing?"* with `Most recently: <summary> (discovered 2026-09-02).` That is the compact form, and the sweep excludes it by construction. A sentence that says "discovered" reads as one; a 46-character marker inside it does not. Worth its own issue if the retrieval evidence says these answers are being extracted too — I did not widen this change to cover it.

**The risk chip is exempt, and the exemption is declared and exercised.** `caution 2026-09-02 reduced` beside a vendor's name on `/alternative-to/*` and `/best/*` rates the vendor rather than listing the change; it carries no summary of its own and links to the entry that does. Repeating a 46-character marker on thirteen chips a page is the cost AC-7 is warning about. One line to reverse if you disagree.

**`effective` rather than `took effect`.** Two records are dated in the future, and the neutral tense is correct for both those and the past.

**Amber italic for the undated date.** The entry already had a dashed border; the date cell was styled identically to an event date, which AC-2 asks to change. `#d29922` is the hue this site already uses for a qualified verdict, and the qualification here is real.

## Verification

4,278 tests, 14 new, 0 failures. `tsc --noEmit` clean. Read back on a running server: the `Effective Date Unknown` tile on both pages against `date_provenance.discovered` (259/259/259), the Artillery entry, `/expiring`'s 259 undated entries, and `/compare-tool` driven in a real browser — comparing Artillery against Vercel returns `discovered 2026-09-02 · effective date unknown limits reduced …` beside Vercel's `effective 2026-01-01` and `effective 2026-02-01` rows.