### PR TITLE
Label a change date wherever it is reformatted or handed to a browser (#1440)

### DIFF
--- a/src/change-dates.ts
+++ b/src/change-dates.ts
@@ -87,10 +87,24 @@ export function changeDateLabel(c: DatedChange): string {
   return isEventDated(c) ? c.date : `${DISCOVERED_DATE_PREFIX} ${c.date}`;
 }
 
-export function changeEntryDateLabel(c: DatedChange): string {
+export function changeEntryDateLabelFor(c: Pick<DealChange, "date_source">, rendered: string): string {
   return isEventDated(c)
-    ? `${EFFECTIVE_DATE_PREFIX} ${c.date}`
-    : `${DISCOVERED_DATE_PREFIX} ${c.date} · ${UNKNOWN_EFFECTIVE_DATE_MARKER}`;
+    ? `${EFFECTIVE_DATE_PREFIX} ${rendered}`
+    : `${DISCOVERED_DATE_PREFIX} ${rendered} · ${UNKNOWN_EFFECTIVE_DATE_MARKER}`;
+}
+
+export function changeEntryDateLabel(c: DatedChange): string {
+  return changeEntryDateLabelFor(c, c.date);
+}
+
+export function longDate(date: string): string {
+  return new Date(date)
+    .toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" })
+    .replace(/ /g, "\u00a0");
+}
+
+export function changeEntryLongDateLabel(c: DatedChange): string {
+  return changeEntryDateLabelFor(c, longDate(c.date));
 }
 
 export function changeDateClause(c: DatedChange): string {

--- a/src/change-lineup.ts
+++ b/src/change-lineup.ts
@@ -1,4 +1,5 @@
 import { theEventNeverHappened } from "./change-resolution.js";
+import { longDate } from "./change-dates.js";
 import type { ChangeResolution } from "./types.js";
 
 export interface LineupClaim {
@@ -44,7 +45,7 @@ export function supersededLineups<T extends LineupClaim>(changes: readonly T[]):
 }
 
 export function changeTimelineDate(iso: string): string {
-  return new Date(iso).toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" });
+  return longDate(iso);
 }
 
 export function supersessionNote(newest: LineupClaim, formatDate: (iso: string) => string): string {

--- a/src/serve.ts
+++ b/src/serve.ts
@@ -68,7 +68,7 @@ import { verificationLedger, QUARANTINE_AFTER_FAILURES } from "./verification-st
 import { partitionAlternatives, partitionSubstitutes, type SubstitutesPartition, productRoleSentence, MEMBERSHIP_GATE_RULES, MEMBERSHIP_GATE_ORDER, MEMBERSHIP_GATE_SYMMETRY, MEMBERSHIP_GATE_SCOPE, MEMBERSHIP_GATE_CORRECTIONS, SUBTYPE_TAXONOMIES, SUBTYPE_MEMBERSHIP_RULE, SUBTYPE_MEMBERSHIP_GROUP_SCOPE, CURATED_SUBTYPE_EXEMPTION, membershipGroupsFor, subtypeDefinition } from "./product-role.js";
 import { resolveCuratedAlternatives, curatedAlternativesFor, addCuratedToPool } from "./curated-alternatives.js";
 import type { Agent, ChangeDateSource, DealChange, RiskCause, RatingWithheld, LinkUnreachable, Offer, StabilityClass } from "./types.js";
-import { changeDateLabel, changeEntryDateLabel, changeDateClause, changeDatePublished, changeEventStartDate, capListSections, latestEventDate, offerExpiryAfter, feedEntryUpdated, undatedGroupHeading, UNDATED_TILE_LABEL, firstReadHeading, discoveryBatchNote, isoWeekOf, DISCOVERED_DATE_PREFIX, EFFECTIVE_DATE_PREFIX, EVENT_DATED_SOURCES, UNDATED_GROUP_NOTE, UNKNOWN_EFFECTIVE_DATE_MARKER } from "./change-dates.js";
+import { changeDateLabel, changeEntryDateLabel, changeEntryLongDateLabel, changeDateClause, changeDatePublished, changeEventStartDate, capListSections, latestEventDate, offerExpiryAfter, feedEntryUpdated, undatedGroupHeading, UNDATED_TILE_LABEL, firstReadHeading, discoveryBatchNote, isoWeekOf, DISCOVERED_DATE_PREFIX, EFFECTIVE_DATE_PREFIX, EVENT_DATED_SOURCES, UNDATED_GROUP_NOTE, UNKNOWN_EFFECTIVE_DATE_MARKER } from "./change-dates.js";
 import { FEED_CORRECTIONS, correctionEntriesXml } from "./feed-corrections.js";
 import { buildDay, emptyPageLastmod, fallbackDay, httpDate, lastmodFor, newestLastmod, readPageLastmod, type PageLastmodLedger } from "./page-lastmod.js";
 import type { AgentBalance } from "./ledger.js";
@@ -963,9 +963,9 @@ function compiledFigureVerdictFor(
 
 function changeTimelineRowsHtml(changes: readonly DealChange[]): string {
   return changes.map(c => {
-    const dateStr = new Date(c.date).toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" });
+    const dateStr = changeEntryLongDateLabel(c);
     return `<tr>
-      <td style="font-family:var(--mono);font-size:.8rem;white-space:nowrap">${escHtmlServer(dateStr)}</td>
+      <td style="font-family:var(--mono);font-size:.8rem">${escHtmlServer(dateStr)}</td>
       <td style="font-weight:600">${escHtmlServer(c.vendor)}</td>
       <td style="font-size:.85rem">${escHtmlServer(c.summary)}</td>
       <td><span style="color:${changeImpactColor(c.impact)};font-size:.8rem;font-weight:600">${escHtmlServer(changeImpactLabel(c.impact))}</span></td>
@@ -22608,7 +22608,7 @@ function buildGeminiApiPricingChangesPage(): string {
     + '    </div>\n'
     + '  </div>\n'
     + '\n'
-    + (geminiChanges.length > 0 ? '  <div class="context-box">\n    <strong>From our deal change tracker (' + geminiChanges.length + ' Gemini changes tracked):</strong>\n    <ul>\n' + geminiChanges.slice(0, 5).map(c => '      <li><strong>' + escHtmlServer(new Date(c.date).toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" })) + ':</strong> ' + escHtmlServer(c.summary) + '</li>\n').join("") + '    </ul>\n    <p>See the full timeline at <a href="/changes">Pricing Changes</a>.</p>\n  </div>\n' : "")
+    + (geminiChanges.length > 0 ? '  <div class="context-box">\n    <strong>From our deal change tracker (' + geminiChanges.length + ' Gemini changes tracked):</strong>\n    <ul>\n' + geminiChanges.slice(0, 5).map(c => '      <li><strong>' + escHtmlServer(changeEntryLongDateLabel(c)) + ':</strong> ' + escHtmlServer(c.summary) + '</li>\n').join("") + '    </ul>\n    <p>See the full timeline at <a href="/changes">Pricing Changes</a>.</p>\n  </div>\n' : "")
     + '\n'
     + '  <h2 id="faq">8. Frequently Asked Questions</h2>\n'
     + '  <div class="faq-section">\n'
@@ -23627,10 +23627,10 @@ function buildOpenaiAssistantsAlternativesPage(): string {
   });
 
   const changeTimelineRows = openaiChanges.map(c => {
-    const dateStr = new Date(c.date).toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" });
+    const dateStr = changeEntryLongDateLabel(c);
     const impactColor = changeImpactColor(c.impact);
     return `<tr>
-      <td style="font-family:var(--mono);font-size:.8rem;white-space:nowrap">${escHtmlServer(dateStr)}</td>
+      <td style="font-family:var(--mono);font-size:.8rem">${escHtmlServer(dateStr)}</td>
       <td style="font-size:.85rem">${escHtmlServer(c.summary)}</td>
       <td><span style="color:${impactColor};font-size:.8rem;font-weight:600">${escHtmlServer(changeImpactLabel(c.impact))}</span></td>
     </tr>`;
@@ -24121,10 +24121,10 @@ function buildOpenaiAssistantsMigration2026Page(): string {
   }).join("\n        ");
 
   const changeTimelineRows = openaiChanges.map(c => {
-    const dateStr = new Date(c.date).toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" });
+    const dateStr = changeEntryLongDateLabel(c);
     const impactColor = changeImpactColor(c.impact);
     return `<tr>
-      <td style="font-family:var(--mono);font-size:.8rem;white-space:nowrap">${escHtmlServer(dateStr)}</td>
+      <td style="font-family:var(--mono);font-size:.8rem">${escHtmlServer(dateStr)}</td>
       <td style="font-size:.85rem">${escHtmlServer(c.summary)}</td>
       <td><span style="color:${impactColor};font-size:.8rem;font-weight:600">${escHtmlServer(changeImpactLabel(c.impact))}</span></td>
     </tr>`;
@@ -24610,10 +24610,10 @@ function buildTenorAlternativesPage(): string {
   }).join("\n        ");
 
   const changeTimelineRows = tenorChanges.map(c => {
-    const dateStr = new Date(c.date).toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" });
+    const dateStr = changeEntryLongDateLabel(c);
     const impactColor = changeImpactColor(c.impact);
     return `<tr>
-      <td style="font-family:var(--mono);font-size:.8rem;white-space:nowrap">${escHtmlServer(dateStr)}</td>
+      <td style="font-family:var(--mono);font-size:.8rem">${escHtmlServer(dateStr)}</td>
       <td style="font-size:.85rem">${escHtmlServer(c.summary)}</td>
       <td><span style="color:${impactColor};font-size:.8rem;font-weight:600">${escHtmlServer(changeImpactLabel(c.impact))}</span></td>
     </tr>`;
@@ -25070,10 +25070,10 @@ function buildFirebaseStudioShutdownPage(): string {
   }
 
   const changeTimelineRows = firebaseChanges.slice(0, 10).map(c => {
-    const dateStr = new Date(c.date).toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" });
+    const dateStr = changeEntryLongDateLabel(c);
     const impactColor = changeImpactColor(c.impact);
     return `<tr>
-      <td style="font-family:var(--mono);font-size:.8rem;white-space:nowrap">${escHtmlServer(dateStr)}</td>
+      <td style="font-family:var(--mono);font-size:.8rem">${escHtmlServer(dateStr)}</td>
       <td style="font-size:.85rem">${escHtmlServer(c.summary)}</td>
       <td><span style="color:${impactColor};font-size:.8rem;font-weight:600">${escHtmlServer(changeImpactLabel(c.impact))}</span></td>
     </tr>`;
@@ -25641,10 +25641,10 @@ function buildOpenAIAssistantsMigrationPage(): string {
   }).join("\n        ");
 
   const changeTimelineRows = openaiChanges.slice(0, 10).map(c => {
-    const dateStr = new Date(c.date).toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" });
+    const dateStr = changeEntryLongDateLabel(c);
     const impactColor = changeImpactColor(c.impact);
     return '<tr>' +
-      '<td style="font-family:var(--mono);font-size:.8rem;white-space:nowrap">' + escHtmlServer(dateStr) + '</td>' +
+      '<td style="font-family:var(--mono);font-size:.8rem">' + escHtmlServer(dateStr) + '</td>' +
       '<td style="font-size:.85rem">' + escHtmlServer(c.summary) + '</td>' +
       '<td><span style="color:' + impactColor + ';font-size:.8rem;font-weight:600">' + escHtmlServer(changeImpactLabel(c.impact)) + '</span></td>' +
       '</tr>';
@@ -26366,10 +26366,10 @@ ${buildGlobalNav("guides")}
     <thead><tr><th>Date</th><th>Vendor</th><th>Change</th><th>Impact</th></tr></thead>
     <tbody>
       ${relevantChanges.map(c => {
-        const dateStr = new Date(c.date).toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" });
+        const dateStr = changeEntryLongDateLabel(c);
         const impactColor = changeImpactColor(c.impact);
         return `<tr>
-          <td style="font-family:var(--mono);font-size:.8rem;white-space:nowrap">${escHtmlServer(dateStr)}</td>
+          <td style="font-family:var(--mono);font-size:.8rem">${escHtmlServer(dateStr)}</td>
           <td><a href="/vendor/${toSlug(c.vendor)}" style="color:var(--text)">${escHtmlServer(c.vendor)}</a></td>
           <td style="font-size:.85rem">${escHtmlServer(c.summary)}</td>
           <td><span style="color:${impactColor};font-size:.8rem;font-weight:600">${escHtmlServer(changeImpactLabel(c.impact))}</span></td>
@@ -26970,10 +26970,10 @@ function buildStartupCreditsPage(): string {
   ];
 
   const changeTimelineRows = startupChanges.map(c => {
-    const dateStr = new Date(c.date).toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" });
+    const dateStr = changeEntryLongDateLabel(c);
     const impactColor = changeImpactColor(c.impact);
     return '<tr>' +
-      '<td style="font-family:var(--mono);font-size:.8rem;white-space:nowrap">' + escHtmlServer(dateStr) + '</td>' +
+      '<td style="font-family:var(--mono);font-size:.8rem">' + escHtmlServer(dateStr) + '</td>' +
       '<td style="font-weight:600">' + escHtmlServer(c.vendor) + '</td>' +
       '<td style="font-size:.85rem">' + escHtmlServer(c.summary) + '</td>' +
       '<td><span style="color:' + impactColor + ';font-size:.8rem;font-weight:600">' + escHtmlServer(changeImpactLabel(c.impact)) + '</span></td>' +
@@ -27398,14 +27398,14 @@ function buildAiCodingPricing2026Page(): string {
   const supersededAiCodingLineups = supersededLineups(aiCodingChanges);
 
   const changeTimelineRows = aiCodingChanges.map(c => {
-    const dateStr = changeTimelineDate(c.date);
+    const dateStr = changeEntryLongDateLabel(c);
     const impactColor = changeImpactColor(c.impact);
     const newest = supersededAiCodingLineups.get(c);
     const historyNote = newest
       ? `<div class="superseded-note">${escHtmlServer(supersessionNote(newest, changeTimelineDate))}</div>`
       : "";
     return `<tr${newest || isNoLongerInForce(c) ? ` class="superseded-row"` : ""}>
-      <td style="font-family:var(--mono);font-size:.8rem;white-space:nowrap">${escHtmlServer(dateStr)}</td>
+      <td style="font-family:var(--mono);font-size:.8rem">${escHtmlServer(dateStr)}</td>
       <td style="font-weight:600">${escHtmlServer(c.vendor)}</td>
       <td style="font-size:.85rem">${escHtmlServer(c.summary)}${historyNote}</td>
       <td><span style="color:${impactColor};font-size:.8rem;font-weight:600">${escHtmlServer(changeImpactLabel(c.impact))}</span></td>
@@ -28013,14 +28013,14 @@ function buildAiCodingToolsPricingPage(): string {
   const supersededAiCodingLineups = supersededLineups(aiCodingChanges);
 
   const changeTimelineRows = aiCodingChanges.map((c: any) => {
-    const dateStr = changeTimelineDate(c.date);
+    const dateStr = changeEntryLongDateLabel(c);
     const impactColor = changeImpactColor(c.impact);
     const newest = supersededAiCodingLineups.get(c);
     const historyNote = newest
       ? '<div class="superseded-note">' + escHtmlServer(supersessionNote(newest, changeTimelineDate)) + '</div>'
       : "";
     return '<tr' + (newest || isNoLongerInForce(c) ? ' class="superseded-row"' : "") + '>' +
-      '<td style="font-family:var(--mono);font-size:.8rem;white-space:nowrap">' + escHtmlServer(dateStr) + '</td>' +
+      '<td style="font-family:var(--mono);font-size:.8rem">' + escHtmlServer(dateStr) + '</td>' +
       '<td style="font-weight:600">' + escHtmlServer(c.vendor) + '</td>' +
       '<td style="font-size:.85rem">' + escHtmlServer(c.summary) + historyNote + '</td>' +
       '<td><span style="color:' + impactColor + ';font-size:.8rem;font-weight:600">' + escHtmlServer(changeImpactLabel(c.impact)) + '</span></td>' +
@@ -28771,10 +28771,10 @@ function buildCiCdPricingPage(): string {
   }).join("\n        ");
 
   const changeTimelineRows = cicdChanges.map(c => {
-    const dateStr = new Date(c.date).toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" });
+    const dateStr = changeEntryLongDateLabel(c);
     const impactColor = changeImpactColor(c.impact);
     return '<tr>' +
-      '<td style="font-family:var(--mono);font-size:.8rem;white-space:nowrap">' + escHtmlServer(dateStr) + '</td>' +
+      '<td style="font-family:var(--mono);font-size:.8rem">' + escHtmlServer(dateStr) + '</td>' +
       '<td style="font-weight:600">' + escHtmlServer(c.vendor) + '</td>' +
       '<td style="font-size:.85rem">' + escHtmlServer(c.summary) + '</td>' +
       '<td><span style="color:' + impactColor + ';font-size:.8rem;font-weight:600">' + escHtmlServer(changeImpactLabel(c.impact)) + '</span></td>' +
@@ -29655,10 +29655,10 @@ function buildDatabasePricingPage(): string {
   }).join("\n        ");
 
   const changeTimelineRows = dbChanges.map(c => {
-    const dateStr = new Date(c.date).toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" });
+    const dateStr = changeEntryLongDateLabel(c);
     const impactColor = changeImpactColor(c.impact);
     return '<tr>' +
-      '<td style="font-family:var(--mono);font-size:.8rem;white-space:nowrap">' + escHtmlServer(dateStr) + '</td>' +
+      '<td style="font-family:var(--mono);font-size:.8rem">' + escHtmlServer(dateStr) + '</td>' +
       '<td style="font-weight:600">' + escHtmlServer(c.vendor) + '</td>' +
       '<td style="font-size:.85rem">' + escHtmlServer(c.summary) + '</td>' +
       '<td><span style="color:' + impactColor + ';font-size:.8rem;font-weight:600">' + escHtmlServer(changeImpactLabel(c.impact)) + '</span></td>' +
@@ -31026,10 +31026,10 @@ function buildHostingPricingPage(): string {
   }).join("\n        ");
 
   const changeTimelineRows = hostingChanges.map(c => {
-    const dateStr = new Date(c.date).toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" });
+    const dateStr = changeEntryLongDateLabel(c);
     const impactColor = changeImpactColor(c.impact);
     return '<tr>' +
-      '<td style="font-family:var(--mono);font-size:.8rem;white-space:nowrap">' + escHtmlServer(dateStr) + '</td>' +
+      '<td style="font-family:var(--mono);font-size:.8rem">' + escHtmlServer(dateStr) + '</td>' +
       '<td style="font-weight:600">' + escHtmlServer(c.vendor) + '</td>' +
       '<td style="font-size:.85rem">' + escHtmlServer(c.summary) + '</td>' +
       '<td><span style="color:' + impactColor + ';font-size:.8rem;font-weight:600">' + escHtmlServer(changeImpactLabel(c.impact)) + '</span></td>' +
@@ -31798,10 +31798,10 @@ function buildLlmApiPricingPage(): string {
   }).join("\n\n  ");
 
   const changeTimelineRows = llmChanges.slice(0, 20).map(c => {
-    const dateStr = new Date(c.date).toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" });
+    const dateStr = changeEntryLongDateLabel(c);
     const impactColor = changeImpactColor(c.impact);
     return '<tr>' +
-      '<td style="font-family:var(--mono);font-size:.8rem;white-space:nowrap">' + escHtmlServer(dateStr) + '</td>' +
+      '<td style="font-family:var(--mono);font-size:.8rem">' + escHtmlServer(dateStr) + '</td>' +
       '<td style="font-weight:600">' + escHtmlServer(c.vendor) + '</td>' +
       '<td style="font-size:.85rem">' + escHtmlServer(c.summary) + '</td>' +
       '<td><span style="color:' + impactColor + ';font-size:.8rem;font-weight:600">' + escHtmlServer(changeImpactLabel(c.impact)) + '</span></td>' +
@@ -32734,10 +32734,10 @@ function buildDallEShutdownPage(): string {
     </tr>`).join("\n        ");
 
   const changeTimelineRows = dalleChanges.slice(0, 10).map(c => {
-    const dateStr = new Date(c.date).toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" });
+    const dateStr = changeEntryLongDateLabel(c);
     const impactColor = changeImpactColor(c.impact);
     return `<tr>
-      <td style="font-family:var(--mono);font-size:.8rem;white-space:nowrap">${escHtmlServer(dateStr)}</td>
+      <td style="font-family:var(--mono);font-size:.8rem">${escHtmlServer(dateStr)}</td>
       <td style="font-size:.85rem">${escHtmlServer(c.summary)}</td>
       <td><span style="color:${impactColor};font-size:.8rem;font-weight:600">${escHtmlServer(changeImpactLabel(c.impact))}</span></td>
     </tr>`;
@@ -33241,9 +33241,9 @@ function buildOpenAIRealtimeMigrationPage(): string {
   ].map(r => '<tr>\n      <td style="font-weight:600">' + escHtmlServer(r.name) + '</td>\n      <td style="font-family:var(--mono);font-size:.8rem;color:' + r.color + '">' + escHtmlServer(r.free) + '</td>\n      <td style="font-family:var(--mono);font-size:.8rem">' + escHtmlServer(r.cost) + '</td>\n      <td style="font-size:.8rem">' + escHtmlServer(r.features) + "</td>\n    </tr>").join("\n        ");
 
   const changeTimelineRows = relevantChanges.slice(0, 10).map(c => {
-    const dateStr = new Date(c.date).toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" });
+    const dateStr = changeEntryLongDateLabel(c);
     const impactColor = changeImpactColor(c.impact);
-    return '<tr>\n      <td style="font-family:var(--mono);font-size:.8rem;white-space:nowrap">' + escHtmlServer(dateStr) + '</td>\n      <td style="font-size:.85rem">' + escHtmlServer(c.summary) + '</td>\n      <td><span style="color:' + impactColor + ';font-size:.8rem;font-weight:600">' + escHtmlServer(changeImpactLabel(c.impact)) + "</span></td>\n    </tr>";
+    return '<tr>\n      <td style="font-family:var(--mono);font-size:.8rem">' + escHtmlServer(dateStr) + '</td>\n      <td style="font-size:.85rem">' + escHtmlServer(c.summary) + '</td>\n      <td><span style="color:' + impactColor + ';font-size:.8rem;font-weight:600">' + escHtmlServer(changeImpactLabel(c.impact)) + "</span></td>\n    </tr>";
   }).join("\n        ");
 
   const relatedPages = ALTERNATIVES_PAGES.filter(p =>
@@ -33363,10 +33363,10 @@ function buildAppRunnerMigrationPage(): string {
     </tr>`).join("\n        ");
 
   const changeTimelineRows = awsChanges.slice(0, 10).map(c => {
-    const dateStr = new Date(c.date).toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" });
+    const dateStr = changeEntryLongDateLabel(c);
     const impactColor = changeImpactColor(c.impact);
     return `<tr>
-      <td style="font-family:var(--mono);font-size:.8rem;white-space:nowrap">${escHtmlServer(dateStr)}</td>
+      <td style="font-family:var(--mono);font-size:.8rem">${escHtmlServer(dateStr)}</td>
       <td style="font-size:.85rem">${escHtmlServer(c.summary)}</td>
       <td><span style="color:${impactColor};font-size:.8rem;font-weight:600">${escHtmlServer(changeImpactLabel(c.impact))}</span></td>
     </tr>`;
@@ -33974,10 +33974,10 @@ function buildAwsFreeTier2026Page(): string {
     </tr>`).join("\n        ");
 
   const changeTimelineRows = awsChanges.slice(0, 10).map((c: any) => {
-    const dateStr = new Date(c.date).toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" });
+    const dateStr = changeEntryLongDateLabel(c);
     const impactColor = changeImpactColor(c.impact);
     return `<tr>
-      <td style="font-family:var(--mono);font-size:.8rem;white-space:nowrap">${escHtmlServer(dateStr)}</td>
+      <td style="font-family:var(--mono);font-size:.8rem">${escHtmlServer(dateStr)}</td>
       <td style="font-weight:600">${escHtmlServer(c.vendor)}</td>
       <td style="font-size:.85rem">${escHtmlServer(c.summary)}</td>
       <td><span style="color:${impactColor};font-size:.8rem;font-weight:600">${escHtmlServer(changeImpactLabel(c.impact))}</span></td>
@@ -34412,10 +34412,10 @@ function buildGcpFreeTier2026Page(): string {
     </tr>`).join("\n        ");
 
   const changeTimelineRows = gcpChanges.slice(0, 12).map((c: any) => {
-    const dateStr = new Date(c.date).toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" });
+    const dateStr = changeEntryLongDateLabel(c);
     const impactColor = changeImpactColor(c.impact);
     return `<tr>
-      <td style="font-family:var(--mono);font-size:.8rem;white-space:nowrap">${escHtmlServer(dateStr)}</td>
+      <td style="font-family:var(--mono);font-size:.8rem">${escHtmlServer(dateStr)}</td>
       <td style="font-weight:600">${escHtmlServer(c.vendor)}</td>
       <td style="font-size:.85rem">${escHtmlServer(c.summary)}</td>
       <td><span style="color:${impactColor};font-size:.8rem;font-weight:600">${escHtmlServer(changeImpactLabel(c.impact))}</span></td>
@@ -34831,10 +34831,10 @@ function buildAzureFreeTier2026Page(): string {
     </tr>`).join("\n        ");
 
   const changeTimelineRows = azureChanges.slice(0, 10).map((c: any) => {
-    const dateStr = new Date(c.date).toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" });
+    const dateStr = changeEntryLongDateLabel(c);
     const impactColor = changeImpactColor(c.impact);
     return `<tr>
-      <td style="font-family:var(--mono);font-size:.8rem;white-space:nowrap">${escHtmlServer(dateStr)}</td>
+      <td style="font-family:var(--mono);font-size:.8rem">${escHtmlServer(dateStr)}</td>
       <td style="font-weight:600">${escHtmlServer(c.vendor)}</td>
       <td style="font-size:.85rem">${escHtmlServer(c.summary)}</td>
       <td><span style="color:${impactColor};font-size:.8rem;font-weight:600">${escHtmlServer(changeImpactLabel(c.impact))}</span></td>
@@ -35276,10 +35276,10 @@ function buildDigitalOceanFreeTier2026Page(): string {
     </tr>`).join("\n        ");
 
   const changeTimelineRows = doChanges.slice(0, 10).map((c: any) => {
-    const dateStr = new Date(c.date).toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" });
+    const dateStr = changeEntryLongDateLabel(c);
     const impactColor = changeImpactColor(c.impact);
     return `<tr>
-      <td style="font-family:var(--mono);font-size:.8rem;white-space:nowrap">${escHtmlServer(dateStr)}</td>
+      <td style="font-family:var(--mono);font-size:.8rem">${escHtmlServer(dateStr)}</td>
       <td style="font-weight:600">${escHtmlServer(c.vendor)}</td>
       <td style="font-size:.85rem">${escHtmlServer(c.summary)}</td>
       <td><span style="color:${impactColor};font-size:.8rem;font-weight:600">${escHtmlServer(changeImpactLabel(c.impact))}</span></td>
@@ -35736,10 +35736,10 @@ function buildCloudFreeTierComparison2026Page(): string {
   ).sort((a: any, b: any) => new Date(b.date).getTime() - new Date(a.date).getTime());
 
   const changeTimelineRows = cloudChanges.slice(0, 12).map((c: any) => {
-    const dateStr = new Date(c.date).toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" });
+    const dateStr = changeEntryLongDateLabel(c);
     const impactColor = changeImpactColor(c.impact);
     return `<tr>
-      <td style="font-family:var(--mono);font-size:.8rem;white-space:nowrap">${escHtmlServer(dateStr)}</td>
+      <td style="font-family:var(--mono);font-size:.8rem">${escHtmlServer(dateStr)}</td>
       <td style="font-weight:600">${escHtmlServer(c.vendor)}</td>
       <td style="font-size:.85rem">${escHtmlServer(c.summary)}</td>
       <td><span style="color:${impactColor};font-size:.8rem;font-weight:600">${escHtmlServer(changeImpactLabel(c.impact))}</span></td>
@@ -36337,10 +36337,10 @@ function buildDatabaseFreeTierComparison2026Page(): string {
   ).sort((a: any, b: any) => new Date(b.date).getTime() - new Date(a.date).getTime());
 
   const changeTimelineRows = dbChanges.slice(0, 12).map((c: any) => {
-    const dateStr = new Date(c.date).toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" });
+    const dateStr = changeEntryLongDateLabel(c);
     const impactColor = changeImpactColor(c.impact);
     return `<tr>
-      <td style="font-family:var(--mono);font-size:.8rem;white-space:nowrap">${escHtmlServer(dateStr)}</td>
+      <td style="font-family:var(--mono);font-size:.8rem">${escHtmlServer(dateStr)}</td>
       <td style="font-weight:600">${escHtmlServer(c.vendor)}</td>
       <td style="font-size:.85rem">${escHtmlServer(c.summary)}</td>
       <td><span style="color:${impactColor};font-size:.8rem;font-weight:600">${escHtmlServer(changeImpactLabel(c.impact))}</span></td>
@@ -37018,10 +37018,10 @@ function buildCicdFreeTierComparison2026Page(): string {
   ).sort((a: any, b: any) => new Date(b.date).getTime() - new Date(a.date).getTime());
 
   const changeTimelineRows = cicdChanges.slice(0, 12).map((c: any) => {
-    const dateStr = new Date(c.date).toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" });
+    const dateStr = changeEntryLongDateLabel(c);
     const impactColor = changeImpactColor(c.impact);
     return `<tr>
-      <td style="font-family:var(--mono);font-size:.8rem;white-space:nowrap">${escHtmlServer(dateStr)}</td>
+      <td style="font-family:var(--mono);font-size:.8rem">${escHtmlServer(dateStr)}</td>
       <td style="font-weight:600">${escHtmlServer(c.vendor)}</td>
       <td style="font-size:.85rem">${escHtmlServer(c.summary)}</td>
       <td><span style="color:${impactColor};font-size:.8rem;font-weight:600">${escHtmlServer(changeImpactLabel(c.impact))}</span></td>
@@ -37686,10 +37686,10 @@ function buildServerlessFreeTierComparison2026Page(): string {
   ).sort((a: any, b: any) => new Date(b.date).getTime() - new Date(a.date).getTime());
 
   const changeTimelineRows = serverlessChanges.slice(0, 12).map((c: any) => {
-    const dateStr = new Date(c.date).toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" });
+    const dateStr = changeEntryLongDateLabel(c);
     const impactColor = changeImpactColor(c.impact);
     return `<tr>
-      <td style="font-family:var(--mono);font-size:.8rem;white-space:nowrap">${escHtmlServer(dateStr)}</td>
+      <td style="font-family:var(--mono);font-size:.8rem">${escHtmlServer(dateStr)}</td>
       <td style="font-weight:600">${escHtmlServer(c.vendor)}</td>
       <td style="font-size:.85rem">${escHtmlServer(c.summary)}</td>
       <td><span style="color:${impactColor};font-size:.8rem;font-weight:600">${escHtmlServer(changeImpactLabel(c.impact))}</span></td>
@@ -38332,10 +38332,10 @@ function buildAuthComparison2026Page(): string {
   ).sort((a: any, b: any) => new Date(b.date).getTime() - new Date(a.date).getTime());
 
   const changeTimelineRows = authChanges.slice(0, 12).map((c: any) => {
-    const dateStr = new Date(c.date).toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" });
+    const dateStr = changeEntryLongDateLabel(c);
     const impactColor = changeImpactColor(c.impact);
     return `<tr>
-      <td style="font-family:var(--mono);font-size:.8rem;white-space:nowrap">${escHtmlServer(dateStr)}</td>
+      <td style="font-family:var(--mono);font-size:.8rem">${escHtmlServer(dateStr)}</td>
       <td style="font-weight:600">${escHtmlServer(c.vendor)}</td>
       <td style="font-size:.85rem">${escHtmlServer(c.summary)}</td>
       <td><span style="color:${impactColor};font-size:.8rem;font-weight:600">${escHtmlServer(changeImpactLabel(c.impact))}</span></td>
@@ -39273,10 +39273,10 @@ function buildEmailComparison2026Page(): string {
   ).sort((a: any, b: any) => new Date(b.date).getTime() - new Date(a.date).getTime());
 
   const changeTimelineRows = emailChanges.slice(0, 12).map((c: any) => {
-    const dateStr = new Date(c.date).toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" });
+    const dateStr = changeEntryLongDateLabel(c);
     const impactColor = changeImpactColor(c.impact);
     return `<tr>
-      <td style="font-family:var(--mono);font-size:.8rem;white-space:nowrap">${escHtmlServer(dateStr)}</td>
+      <td style="font-family:var(--mono);font-size:.8rem">${escHtmlServer(dateStr)}</td>
       <td style="font-weight:600">${escHtmlServer(c.vendor)}</td>
       <td style="font-size:.85rem">${escHtmlServer(c.summary)}</td>
       <td><span style="color:${impactColor};font-size:.8rem;font-weight:600">${escHtmlServer(changeImpactLabel(c.impact))}</span></td>
@@ -40247,10 +40247,10 @@ function buildMonitoringComparison2026Page(): string {
   ).sort((a: any, b: any) => new Date(b.date).getTime() - new Date(a.date).getTime());
 
   const changeTimelineRows = monitoringChanges.slice(0, 12).map((c: any) => {
-    const dateStr = new Date(c.date).toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" });
+    const dateStr = changeEntryLongDateLabel(c);
     const impactColor = changeImpactColor(c.impact);
     return `<tr>
-      <td style="font-family:var(--mono);font-size:.8rem;white-space:nowrap">${escHtmlServer(dateStr)}</td>
+      <td style="font-family:var(--mono);font-size:.8rem">${escHtmlServer(dateStr)}</td>
       <td style="font-weight:600">${escHtmlServer(c.vendor)}</td>
       <td style="font-size:.85rem">${escHtmlServer(c.summary)}</td>
       <td><span style="color:${impactColor};font-size:.8rem;font-weight:600">${escHtmlServer(changeImpactLabel(c.impact))}</span></td>
@@ -41281,10 +41281,10 @@ function buildStorageComparison2026Page(): string {
   ).sort((a: any, b: any) => new Date(b.date).getTime() - new Date(a.date).getTime());
 
   const changeTimelineRows = storageChanges.slice(0, 12).map((c: any) => {
-    const dateStr = new Date(c.date).toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" });
+    const dateStr = changeEntryLongDateLabel(c);
     const impactColor = changeImpactColor(c.impact);
     return `<tr>
-      <td style="font-family:var(--mono);font-size:.8rem;white-space:nowrap">${escHtmlServer(dateStr)}</td>
+      <td style="font-family:var(--mono);font-size:.8rem">${escHtmlServer(dateStr)}</td>
       <td style="font-weight:600">${escHtmlServer(c.vendor)}</td>
       <td style="font-size:.85rem">${escHtmlServer(c.summary)}</td>
       <td><span style="color:${impactColor};font-size:.8rem;font-weight:600">${escHtmlServer(changeImpactLabel(c.impact))}</span></td>
@@ -42061,10 +42061,10 @@ function buildTestingFreeTierComparison2026Page(): string {
   ).sort((a: any, b: any) => new Date(b.date).getTime() - new Date(a.date).getTime());
 
   const changeTimelineRows = testingChanges.slice(0, 12).map((c: any) => {
-    const dateStr = new Date(c.date).toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" });
+    const dateStr = changeEntryLongDateLabel(c);
     const impactColor = changeImpactColor(c.impact);
     return `<tr>
-      <td style="font-family:var(--mono);font-size:.8rem;white-space:nowrap">${escHtmlServer(dateStr)}</td>
+      <td style="font-family:var(--mono);font-size:.8rem">${escHtmlServer(dateStr)}</td>
       <td style="font-weight:600">${escHtmlServer(c.vendor)}</td>
       <td style="font-size:.85rem">${escHtmlServer(c.summary)}</td>
       <td><span style="color:${impactColor};font-size:.8rem;font-weight:600">${escHtmlServer(changeImpactLabel(c.impact))}</span></td>
@@ -42729,10 +42729,10 @@ function buildAnalyticsFreeTierComparison2026Page(): string {
   ).sort((a: any, b: any) => new Date(b.date).getTime() - new Date(a.date).getTime());
 
   const changeTimelineRows = analyticsChanges.slice(0, 12).map((c: any) => {
-    const dateStr = new Date(c.date).toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" });
+    const dateStr = changeEntryLongDateLabel(c);
     const impactColor = changeImpactColor(c.impact);
     return `<tr>
-      <td style="font-family:var(--mono);font-size:.8rem;white-space:nowrap">${escHtmlServer(dateStr)}</td>
+      <td style="font-family:var(--mono);font-size:.8rem">${escHtmlServer(dateStr)}</td>
       <td style="font-weight:600">${escHtmlServer(c.vendor)}</td>
       <td style="font-size:.85rem">${escHtmlServer(c.summary)}</td>
       <td><span style="color:${impactColor};font-size:.8rem;font-weight:600">${escHtmlServer(changeImpactLabel(c.impact))}</span></td>
@@ -43411,10 +43411,10 @@ function buildApiDevelopmentFreeTierComparison2026Page(): string {
   ).sort((a: any, b: any) => new Date(b.date).getTime() - new Date(a.date).getTime());
 
   const changeTimelineRows = apiDevChanges.slice(0, 12).map((c: any) => {
-    const dateStr = new Date(c.date).toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" });
+    const dateStr = changeEntryLongDateLabel(c);
     const impactColor = changeImpactColor(c.impact);
     return `<tr>
-      <td style="font-family:var(--mono);font-size:.8rem;white-space:nowrap">${escHtmlServer(dateStr)}</td>
+      <td style="font-family:var(--mono);font-size:.8rem">${escHtmlServer(dateStr)}</td>
       <td style="font-weight:600">${escHtmlServer(c.vendor)}</td>
       <td style="font-size:.85rem">${escHtmlServer(c.summary)}</td>
       <td><span style="color:${impactColor};font-size:.8rem;font-weight:600">${escHtmlServer(changeImpactLabel(c.impact))}</span></td>
@@ -44007,10 +44007,10 @@ function buildSecurityFreeTierComparison2026Page(): string {
   ).sort((a: any, b: any) => new Date(b.date).getTime() - new Date(a.date).getTime());
 
   const changeTimelineRows = secChanges.slice(0, 12).map((c: any) => {
-    const dateStr = new Date(c.date).toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" });
+    const dateStr = changeEntryLongDateLabel(c);
     const impactColor = changeImpactColor(c.impact);
     return `<tr>
-      <td style="font-family:var(--mono);font-size:.8rem;white-space:nowrap">${escHtmlServer(dateStr)}</td>
+      <td style="font-family:var(--mono);font-size:.8rem">${escHtmlServer(dateStr)}</td>
       <td style="font-weight:600">${escHtmlServer(c.vendor)}</td>
       <td style="font-size:.85rem">${escHtmlServer(c.summary)}</td>
       <td><span style="color:${impactColor};font-size:.8rem;font-weight:600">${escHtmlServer(changeImpactLabel(c.impact))}</span></td>
@@ -44724,10 +44724,10 @@ function buildHostingFreeTierComparison2026Page(): string {
   ).sort((a: any, b: any) => new Date(b.date).getTime() - new Date(a.date).getTime());
 
   const changeTimelineRows = hostingChanges.slice(0, 15).map((c: any) => {
-    const dateStr = new Date(c.date).toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" });
+    const dateStr = changeEntryLongDateLabel(c);
     const impactColor = changeImpactColor(c.impact);
     return `<tr>
-      <td style="font-family:var(--mono);font-size:.8rem;white-space:nowrap">${escHtmlServer(dateStr)}</td>
+      <td style="font-family:var(--mono);font-size:.8rem">${escHtmlServer(dateStr)}</td>
       <td style="font-weight:600">${escHtmlServer(c.vendor)}</td>
       <td style="font-size:.85rem">${escHtmlServer(c.summary)}</td>
       <td><span style="color:${impactColor};font-size:.8rem;font-weight:600">${escHtmlServer(changeImpactLabel(c.impact))}</span></td>
@@ -46954,7 +46954,7 @@ function buildStackCheckPage(): string {
       slug,
       risk_level: assessment.level,
       risk_cause: assessment.cause
-        ? { date: changeDateLabel(assessment.cause), date_source: assessment.cause.date_source, change_type: assessment.cause.change_type, summary: assessment.cause.summary }
+        ? { date: changeEntryDateLabel(assessment.cause), date_source: assessment.cause.date_source, change_type: assessment.cause.change_type, summary: assessment.cause.summary }
         : null,
       stability,
       recent_changes: vendorChanges.map(c => ({ date: changeEntryDateLabel(c), change_type: c.change_type, summary: c.summary, impact: c.impact, resolved: isNoLongerInForce(c) })),
@@ -48064,7 +48064,7 @@ function buildBudgetBuilderPage(): string {
       const vendorChanges = allChanges.filter(c => toSlug(c.vendor) === v.slug || c.vendor.toLowerCase() === v.name.toLowerCase());
       const assessment = vendorRiskAssessment(vendorChanges);
       return { slug: v.slug, name: v.name, free: v.free, starter: v.starter, growth: v.growth, scale: v.scale, notes: v.notes, risk_level: assessment.level,
-        risk_cause: assessment.cause ? { date: assessment.cause.date, change_type: assessment.cause.change_type, summary: assessment.cause.summary } : null };
+        risk_cause: assessment.cause ? { date: changeEntryDateLabel(assessment.cause), change_type: assessment.cause.change_type, summary: assessment.cause.summary } : null };
     });
   }
 

--- a/test/change-entry-date-provenance.test.ts
+++ b/test/change-entry-date-provenance.test.ts
@@ -150,18 +150,34 @@ const NOT_A_CHANGE_RECORD: Array<{ expr: string; why: string }> = [
   { expr: "escHtmlServer(tie.date)", why: "the UTC day the ranking permutation is seeded on" },
   { expr: "escHtmlServer(p.date)", why: "the day a press mention was published" },
   { expr: "escHtmlServer(e.date)", why: "a hand-written editorial timeline, which carries no record" },
+  { expr: "date: r.date", why: "the day an analytics rollup covers" },
 ];
 
 describe("nothing renders a change date without saying which kind of date it is", () => {
   const source = readFileSync(path.join(REPO, "src", "serve.ts"), "utf8").split("\n");
-  const LABELLED = /change(?:Entry)?DateLabel|changeDateClause|feedEntryUpdated|toISOString/;
+  const LABELLED = /change(?:Entry)?DateLabel(?:For|Fn)?|changeEntryLongDateLabel|changeDateClause|feedEntryUpdated|toISOString/;
   const TEXT_NODE = />\s*(?:\$\{([^{}]*(?:\{[^{}]*\}[^{}]*)*)\}|'\s*\+\s*([^+]*?)\s*\+\s*')\s*</g;
+  const REFORMATTED = /new Date\(([A-Za-z_$][\w$.]*\.date)\)\.toLocale\w*\(/g;
+  const COPIED_RAW = /\bdate:\s*([A-Za-z_$][\w$.]*\.date)\b/g;
 
   const dateTextNodes = source.flatMap((line, i) =>
     [...line.matchAll(TEXT_NODE)]
       .map((m) => (m[1] ?? m[2] ?? "").trim())
       .filter((expr) => /\.date\b/.test(expr) && !LABELLED.test(expr))
       .map((expr) => ({ line: i + 1, expr }))
+  );
+
+  const reformatted = source.flatMap((line, i) =>
+    LABELLED.test(line) ? [] : [...line.matchAll(REFORMATTED)].map((m) => ({ line: i + 1, expr: m[0] }))
+  );
+
+  const travelsWithProvenance = (i: number) =>
+    source.slice(Math.max(0, i - 1), i + 3).some((l) => /dateClause|date_source/.test(l));
+
+  const copiedRaw = source.flatMap((line, i) =>
+    travelsWithProvenance(i) || LABELLED.test(line)
+      ? []
+      : [...line.matchAll(COPIED_RAW)].map((m) => ({ line: i + 1, expr: m[0] }))
   );
 
   const unlabelled = (line: string) =>
@@ -174,11 +190,37 @@ describe("nothing renders a change date without saying which kind of date it is"
     assertPopulationFloor(labelled, 20, "lines rendering a change date through a labelling helper");
   });
 
+  it("reformats a change date only through a labelling helper", () => {
+    const offenders = reformatted
+      .filter(({ expr }) => !expr.includes("r.date"))
+      .map(({ line, expr }) => `src/serve.ts:${line}: ${expr}`);
+    assert.deepStrictEqual(offenders, []);
+  });
+
+  it("never copies a change date into another object without its provenance", () => {
+    const offenders = copiedRaw
+      .filter(({ expr }) => !NOT_A_CHANGE_RECORD.some((e) => e.expr === expr))
+      .map(({ line, expr }) => `src/serve.ts:${line}: ${expr}`);
+    assert.deepStrictEqual(offenders, []);
+  });
+
   it("catches a change date put back into a text node unlabelled", () => {
     assert.deepStrictEqual(unlabelled('<span class="d">${c.date}</span>'), ["c.date"]);
     assert.deepStrictEqual(unlabelled("'<td>' + escHtmlServer(c.date) + '</td>'"), ["escHtmlServer(c.date)"]);
     assert.deepStrictEqual(unlabelled('<span class="d">${changeEntryDateLabel(c)}</span>'), []);
     assert.deepStrictEqual(unlabelled('<a href="#${toSlug(c.vendor)}-${c.date}">link</a>'), []);
+  });
+
+  it("catches a change date reformatted or handed to a browser unlabelled", () => {
+    const fires = (re: RegExp, line: string) => (LABELLED.test(line) ? [] : [...line.matchAll(re)].map((m) => m[0]));
+    assert.deepStrictEqual(fires(REFORMATTED, '  const s = new Date(c.date).toLocaleDateString("en-US", {});'), [
+      "new Date(c.date).toLocaleDateString(",
+    ]);
+    assert.deepStrictEqual(fires(REFORMATTED, "  const s = changeEntryLongDateLabel(c);"), []);
+    assert.deepStrictEqual(fires(COPIED_RAW, "    risk_cause: { date: cause.date, summary: cause.summary }"), [
+      "date: cause.date",
+    ]);
+    assert.deepStrictEqual(fires(COPIED_RAW, "    risk_cause: { date: changeEntryDateLabel(cause) }"), []);
   });
 
   it("routes every date a change record carries through a labelling helper", () => {
@@ -189,9 +231,8 @@ describe("nothing renders a change date without saying which kind of date it is"
   });
 
   it("keeps every declared non-record date in use", () => {
-    const unused = NOT_A_CHANGE_RECORD.filter(
-      (e) => !dateTextNodes.some(({ expr }) => expr === e.expr)
-    );
+    const scanned = [...dateTextNodes, ...copiedRaw];
+    const unused = NOT_A_CHANGE_RECORD.filter((e) => !scanned.some(({ expr }) => expr === e.expr));
     assert.deepStrictEqual(unused.map((e) => `${e.expr} — ${e.why}`), []);
   });
 });

--- a/test/change-lineup.test.ts
+++ b/test/change-lineup.test.ts
@@ -5,6 +5,7 @@ import { readFileSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import type { DealChange } from "../src/types.ts";
+import { DISCOVERED_DATE_PREFIX, EFFECTIVE_DATE_PREFIX } from "../dist/change-dates.js";
 import {
   changeTimelineDate,
   statedPrices,
@@ -175,7 +176,10 @@ function startServer(): Promise<ChildProcess> {
 const get = async (p: string) => (await fetch(`http://localhost:${serverPort}${p}`)).text();
 
 const rowsOf = (body: string) => body.match(/<tr[^>]*>[\s\S]*?<\/tr>/g) ?? [];
-const isChangeRow = (row: string) => /<td[^>]*>[A-Z][a-z]{2} \d{1,2}, \d{4}<\/td>/.test(row);
+const CHANGE_ROW_DATE = new RegExp(
+  `<td[^>]*>(?:${EFFECTIVE_DATE_PREFIX}|${DISCOVERED_DATE_PREFIX})[\\s\\u00a0]+[A-Z][a-z]{2}[\\s\\u00a0]+\\d{1,2},[\\s\\u00a0]+\\d{4}`
+);
+const isChangeRow = (row: string) => CHANGE_ROW_DATE.test(row);
 const withoutChangeRows = (body: string) =>
   rowsOf(body).filter(isChangeRow).reduce((rest, row) => rest.replace(row, ""), body);
 const AI_CODING_PAGES = ["/ai-coding-pricing-2026", "/ai-coding-tools-pricing"];

--- a/test/copilot-billing-unit.test.ts
+++ b/test/copilot-billing-unit.test.ts
@@ -4,6 +4,7 @@ import { spawn, type ChildProcess } from "node:child_process";
 import { readFileSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import { DISCOVERED_DATE_PREFIX, EFFECTIVE_DATE_PREFIX } from "../dist/change-dates.js";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const REPO = path.join(__dirname, "..");
@@ -32,7 +33,10 @@ function startServer(): Promise<ChildProcess> {
 const get = async (p: string) => (await fetch(`http://localhost:${serverPort}${p}`)).text();
 
 const rowsOf = (body: string) => body.match(/<tr[^>]*>[\s\S]*?<\/tr>/g) ?? [];
-const isChangeRow = (row: string) => /<td[^>]*>[A-Z][a-z]{2} \d{1,2}, \d{4}<\/td>/.test(row);
+const CHANGE_ROW_DATE = new RegExp(
+  `<td[^>]*>(?:${EFFECTIVE_DATE_PREFIX}|${DISCOVERED_DATE_PREFIX})[\\s\\u00a0]+[A-Z][a-z]{2}[\\s\\u00a0]+\\d{1,2},[\\s\\u00a0]+\\d{4}`
+);
+const isChangeRow = (row: string) => CHANGE_ROW_DATE.test(row);
 const withoutChangeRows = (body: string) =>
   rowsOf(body).filter(isChangeRow).reduce((rest, row) => rest.replace(row, ""), body);
 


### PR DESCRIPTION
Refs #1440

Follow-up to https://github.com/robhunter/agentdeals/pull/1441. Verifying that change on production, I found three more ways a change date reaches a reader, none of which the scan I shipped could see — it reads HTML text nodes, and none of these is one.

## 35 entries reformat the date first

33 page builders hold `new Date(c.date).toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" })` and render the result in a change row beside the vendor and the summary. `/storage-comparison-2026`, `/llm-api-pricing`, every `/*-free-tier-comparison-2026`, the four cloud free-tier pages, the migration and shutdown guides. Two more go through `changeTimelineDate` in `src/change-lineup.ts`.

None of the three sweeps we own could see them. The two behavioural ones search for the ISO date string, which never appears; the source scan matches `.date` in a text node, and these interpolate a local `dateStr`.

`changeEntryLongDateLabel` formats and labels in one call, so `Sep 2, 2026` becomes `effective Sep 2, 2026` or `discovered Sep 2, 2026 · effective date unknown`.

**The cell used `white-space:nowrap`, which a 46-character label turns into a 46-character-wide column.** The date joins with non-breaking spaces instead and the cell wraps normally — `Sep 2, 2026` still never breaks, and the marker now can. Measured on `/storage-comparison-2026`: the table is 912px inside a 1280px body and does not overflow.

## Two payloads handed to a browser

`/budget-builder` copied `assessment.cause.date` raw into the JSON its client script renders as `Why caution: 2026-09-02 — <summary>`. No marker of any kind, on nine records today, six of them discovery-dated.

`/stack-check` carried the compact `discovered 2026-08-28` in the identical slot the server-rendered risk-cause line publishes with the entry label. Both now use `changeEntryDateLabel`.

## The scan grew two rules

- **A reformatted date.** `new Date(<x>.date).toLocale*(` outside a labelling helper.
- **A date copied into another object.** `date: <x>.date`, allowed only where a `dateClause` or `date_source` travels beside it — which is how `compiledFigureVerdict` already hands its records to `src/compiled-figures.ts`. One non-record date is declared: the day an analytics rollup covers.

Each rule has a mutation control asserting it fires on the unlabelled form and stays quiet on the labelled one.

## Two test parsers were keyed on the old cell text

`isChangeRow` in `test/change-lineup.test.ts` and `test/copilot-billing-unit.test.ts` identified a change row by `<td>Sep 4, 2026</td>`. With the label in the cell they matched nothing, and three tests then read every change row as a current fact — a green-to-red that reported the opposite of what changed. Both now build their pattern from `EFFECTIVE_DATE_PREFIX` and `DISCOVERED_DATE_PREFIX`.

## Verification

4,281 tests, 3 new, 0 failures. `tsc --noEmit` clean. Read back on a running server: `/storage-comparison-2026` and `/llm-api-pricing` rendering the long form, `/budget-builder` and `/stack-check` carrying it in their payloads, and the timeline table screenshotted to confirm the date column wraps the marker without breaking a date or the table.
