### PR TITLE
Derive from the catalogue the three assertions a data run just froze (#1337)

### DIFF
--- a/test/deal-changes.test.ts
+++ b/test/deal-changes.test.ts
@@ -67,14 +67,25 @@ function startServer() {
   });
 }
 
+function changeLogOnFile(): { vendor: string; date: string }[] {
+  return JSON.parse(
+    fs.readFileSync(path.join(__dirname, "..", "data", "deal_changes.json"), "utf-8")
+  ).changes;
+}
+
+function namedInTheChangeLog(names: string[], since: string): { vendor: string; date: string }[] {
+  const wanted = names.map((n) => n.toLowerCase());
+  return changeLogOnFile().filter(
+    (c) => c.date >= since && wanted.some((n) => c.vendor.toLowerCase().includes(n))
+  );
+}
+
 describe("track_changes tool", () => {
   it("returns all changes when no filters (with broad since)", async () => {
     const { getDealChanges } = await import("../dist/data.js");
     const since = "2024-01-01";
     const body = getDealChanges(since);
-    const onFile = JSON.parse(
-      fs.readFileSync(path.join(__dirname, "..", "data", "deal_changes.json"), "utf-8")
-    ).changes.filter((c: { date: string }) => c.date >= since);
+    const onFile = changeLogOnFile().filter((c) => c.date >= since);
 
     assert.ok(Array.isArray(body.changes));
     assert.strictEqual(body.total, body.changes.length);
@@ -288,13 +299,21 @@ describe("track_changes tool", () => {
 
   it("getDealChanges filters by vendors (comma-separated)", async () => {
     const { getDealChanges } = await import("../dist/data.js");
+    const since = "2024-01-01";
 
-    const single = getDealChanges("2024-01-01", undefined, undefined, "Netlify");
-    assert.strictEqual(single.total, 4);
-    assert.strictEqual(single.changes[0].vendor, "Netlify");
+    const single = getDealChanges(since, undefined, undefined, "Netlify");
+    assert.strictEqual(single.total, namedInTheChangeLog(["Netlify"], since).length);
+    assert.ok(single.total > 0, "the change log names no Netlify record for the filter to return");
+    for (const change of single.changes) {
+      assert.ok(
+        change.vendor.toLowerCase().includes("netlify"),
+        `Unexpected vendor: ${change.vendor}`
+      );
+    }
 
-    const multi = getDealChanges("2024-01-01", undefined, undefined, "Netlify,OpenAI");
-    assert.ok(multi.total >= 2, `Expected at least 2 changes for Netlify+OpenAI, got ${multi.total}`);
+    const multi = getDealChanges(since, undefined, undefined, "Netlify,OpenAI");
+    assert.strictEqual(multi.total, namedInTheChangeLog(["Netlify", "OpenAI"], since).length);
+    assert.ok(multi.total >= single.total, "a second name returned fewer records than the first alone");
     for (const change of multi.changes) {
       const lower = change.vendor.toLowerCase();
       assert.ok(
@@ -303,7 +322,7 @@ describe("track_changes tool", () => {
       );
     }
 
-    const none = getDealChanges("2024-01-01", undefined, undefined, "nonexistent-xyz,also-fake");
+    const none = getDealChanges(since, undefined, undefined, "nonexistent-xyz,also-fake");
     assert.strictEqual(none.total, 0);
     assert.deepStrictEqual(none.changes, []);
 
@@ -315,9 +334,20 @@ describe("track_changes tool", () => {
 
   it("vendors takes precedence over vendor when both provided", async () => {
     const { getDealChanges } = await import("../dist/data.js");
-    const result = getDealChanges("2024-01-01", undefined, "OpenAI", "Netlify");
-    assert.strictEqual(result.total, 4);
-    assert.strictEqual(result.changes[0].vendor, "Netlify");
+    const since = "2024-01-01";
+
+    const both = getDealChanges(since, undefined, "OpenAI", "Netlify");
+    const vendorsAlone = getDealChanges(since, undefined, undefined, "Netlify");
+    const vendorAlone = getDealChanges(since, undefined, "OpenAI");
+
+    assert.ok(vendorAlone.total > 0, "the change log names no OpenAI record for vendor to have selected");
+    assert.deepStrictEqual(both.changes, vendorsAlone.changes);
+    for (const change of both.changes) {
+      assert.ok(
+        !change.vendor.toLowerCase().includes("openai"),
+        `vendor was not overridden: ${change.vendor}`
+      );
+    }
   });
 
   it("getDealChanges filters by categories (comma-separated)", async () => {

--- a/test/http.test.ts
+++ b/test/http.test.ts
@@ -2,11 +2,60 @@ import { describe, it, before, after, afterEach } from "node:test";
 import assert from "node:assert";
 import { assertPopulationFloor } from "./population-floor.ts";
 import { spawn, type ChildProcess } from "node:child_process";
+import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 let serverPort = 0;
+
+const { supersedingChange } = await import("../dist/superseded-description.js");
+const { vendorSlugMap } = await import("../dist/vendor-slug.js");
+
+type StoredRecord = { vendor: string; description: string; tier: string };
+
+const VENDOR_PAGES_TRIED_FOR_AN_OFFER = 12;
+
+const catalogue: StoredRecord[] = JSON.parse(
+  fs.readFileSync(path.join(__dirname, "..", "data", "index.json"), "utf-8"),
+).offers;
+
+const changeLogByVendor = new Map<string, { date: string; change_type: string }[]>();
+for (const change of JSON.parse(
+  fs.readFileSync(path.join(__dirname, "..", "data", "deal_changes.json"), "utf-8"),
+).changes) {
+  const key = change.vendor.toLowerCase();
+  const held = changeLogByVendor.get(key);
+  if (held) held.push(change);
+  else changeLogByVendor.set(key, [change]);
+}
+
+function primaryRecordOf(vendor: string): StoredRecord | undefined {
+  return catalogue.find((o) => o.vendor === vendor);
+}
+
+function slugsWhoseStoredTermsStand(): string[] {
+  const found: string[] = [];
+  for (const [slug, vendor] of vendorSlugMap) {
+    const primary = primaryRecordOf(vendor);
+    if (!primary) continue;
+    if (supersedingChange(primary, changeLogByVendor.get(vendor.toLowerCase()) ?? [])) continue;
+    found.push(slug);
+  }
+  return found;
+}
+
+function jsonLdWebPage(html: string): Record<string, any> | undefined {
+  for (const block of html.matchAll(/<script type="application\/ld\+json">([\s\S]*?)<\/script>/g)) {
+    try {
+      const parsed = JSON.parse(block[1]);
+      if (parsed["@type"] === "WebPage") return parsed;
+    } catch {
+      continue;
+    }
+  }
+  return undefined;
+}
 
 function startHttpServer(): Promise<ChildProcess> {
   return new Promise((resolve, reject) => {
@@ -1440,9 +1489,31 @@ describe("HTTP transport", () => {
     proc = await startHttpServer();
 
     const response = await fetch(`http://localhost:${serverPort}/vendor/vercel`);
-    const html = await response.text();
-    assert.ok(html.includes("dateModified"), "JSON-LD should include dateModified");
-    assert.ok(html.includes('"@type":"Offer"'), "JSON-LD should include an Offer");
+    const page = jsonLdWebPage(await response.text());
+    assert.ok(page, "JSON-LD should include a WebPage block");
+    assert.match(String(page.dateModified ?? ""), /^\d{4}-\d{2}-\d{2}/, "JSON-LD should include dateModified");
+  });
+
+  it("GET /vendor/:slug prices a record it still publishes as a free Offer", async () => {
+    proc = await startHttpServer();
+
+    const standing = slugsWhoseStoredTermsStand().slice(0, VENDOR_PAGES_TRIED_FOR_AN_OFFER);
+    assert.ok(standing.length > 0, "no record in the catalogue has terms no recorded change has superseded");
+
+    for (const slug of standing) {
+      const response = await fetch(`http://localhost:${serverPort}/vendor/${slug}`);
+      const page = jsonLdWebPage(await response.text());
+      const offer = page?.mainEntity?.offers;
+      if (!offer) continue;
+
+      assert.strictEqual(offer["@type"], "Offer");
+      assert.strictEqual(offer.price, "0");
+      assert.strictEqual(offer.priceCurrency, "USD");
+      assert.strictEqual(offer.description, primaryRecordOf(String(page.mainEntity.name))?.tier);
+      return;
+    }
+
+    assert.fail(`none of the first ${standing.length} vendor pages whose stored terms stand published an Offer`);
   });
 
   it("GET /vendor/:slug includes watchlist CTA", async () => {

--- a/test/superseded-terms.test.ts
+++ b/test/superseded-terms.test.ts
@@ -229,11 +229,50 @@ describe("#1103 the catalogue population", () => {
 
   it("finds one superseding change per record, so no page has to choose between two", () => {
     for (const offer of offers) {
-      const quoting = changesFor(offer.vendor).filter(
-        (c) => !c.resolution && quotesTheStoredTermsAsPrevious(c, offer.description),
+      const vendorChanges = changesFor(offer.vendor);
+      const chosen = supersedingChange(offer, vendorChanges);
+      if (!chosen) continue;
+      const readTheOtherWay = supersedingChange(offer, [...vendorChanges].reverse());
+      assert.strictEqual(
+        readTheOtherWay,
+        chosen,
+        `${offer.vendor} supersedes its stored terms with a different change when the same records are read in the opposite order, so the page quotes whichever the file happens to list first`,
       );
-      assert.ok(quoting.length <= 1, `${offer.vendor} has ${quoting.length} changes quoting its stored terms`);
     }
+  });
+
+  it("catches two superseding changes that share a date, which is the only way the order can decide it", () => {
+    const sameDay = [
+      { ...A_CHANGE_QUOTING_IT, summary: "Egress on the free plan is now 20 GiB." },
+      { ...A_CHANGE_QUOTING_IT, summary: "Storage on the free plan is now 500 MiB." },
+    ] as DealChange[];
+
+    assert.strictEqual(sameDay[0].date, sameDay[1].date);
+    assert.notStrictEqual(
+      supersedingChange(A_RECORD, sameDay),
+      supersedingChange(A_RECORD, [...sameDay].reverse()),
+    );
+  });
+
+  it("a later superseding change replaces an earlier one rather than competing with it", () => {
+    const earlier = { ...A_CHANGE_QUOTING_IT, date: "2026-08-28" } as DealChange;
+    const later = { ...A_CHANGE_QUOTING_IT, date: "2026-09-07" } as DealChange;
+
+    assert.strictEqual(supersedingChange(A_RECORD, [earlier, later]), later);
+    assert.strictEqual(supersedingChange(A_RECORD, [later, earlier]), later);
+  });
+
+  it("a change that widens the terms does not compete with the one that narrowed them", () => {
+    const narrowed = { ...A_CHANGE_QUOTING_IT, date: "2026-08-28" } as DealChange;
+    const widened = {
+      ...A_CHANGE_QUOTING_IT,
+      change_type: "limits_increased",
+      date: "2026-09-07",
+      summary: "Egress on the free plan is now 200 GB, up from 100 GB.",
+    } as DealChange;
+
+    assert.strictEqual(quotesTheStoredTermsAsPrevious(widened, A_RECORD.description), true);
+    assert.strictEqual(supersedingChange(A_RECORD, [narrowed, widened]), narrowed);
   });
 });
 


### PR DESCRIPTION
Refs #1337.

`Daily rolling re-verification` has shipped data on 6 of its last 14 attempts and the change log has not advanced since 2026-09-05. Today's run detected 25 changes and the suite refused all of them. Four assertions in three files held the commit; every one of them describes the catalogue as it stood when it was written rather than the property it means to hold.

## What each one was

**`test/deal-changes.test.ts:293` and `:319` — `assert.strictEqual(total, 4)` on Netlify.** The run recorded a fifth Netlify change, so the vendor filter returned 5. Neither test is about how many records Netlify has; they are about the filter selecting only the named vendor, and about `vendors` overriding `vendor`. The count now comes from `data/deal_changes.json` filtered the same way, and the precedence test asserts the property directly: the result equals what `vendors` alone returns, `vendor` names a vendor that does have records, and none of them come back.

**`test/superseded-terms.test.ts:235` — `quoting.length <= 1`.** It filtered on `quotesTheStoredTermsAsPrevious`, which was the definition of superseding until #1385 split the two. Since then a change supersedes the stored terms only if it also *narrows* them. transfernow has a `limits_reduced` dated 2026-08-28 and the run added a `limits_increased` dated 2026-09-07 quoting the same stored description; one supersedes and one does not, and the page had nothing to choose between. Four records carry two quoting changes; three carry two superseding ones, all with distinct dates.

The test now asserts what its name says: `supersedingChange` returns the same record when the vendor's changes are read in the opposite order. A tie on the newest date is the only way the file's ordering can decide it, and three new cases cover both directions — a same-day pair is caught, a later narrowing replaces an earlier one, and a widening change does not compete with the narrowing it follows.

**`test/http.test.ts:1445` — `/vendor/vercel` must carry an `Offer` in its JSON-LD.** The run recorded a change that supersedes Vercel's stored terms, so the page correctly stopped pricing them. The subject is now chosen from the catalogue — the first vendor whose stored terms no recorded change has superseded — and the assertion went from a substring match to the Offer's shape: `price`, `priceCurrency`, and a `description` equal to that record's own tier. `dateModified` stays on `vercel`, where it does not depend on the data. The withholding direction is already held over the whole population by `superseded-terms.test.ts`.

## Verified against the batch that was refused

Ran these three files on `data-quarantine/rolling-reverification-20260907T114926Z-dc52652`'s data applied to current `main`, reproducing all four failures first, then again with this branch's tests: 119 + 14 + 330 pass, 0 fail. On `main`'s data: the same 463 pass.

The only failures left on that batch are the three in `test/stale-page-facts.test.ts`, which `scripts/gate-non-blocking-tests.json` already excuses.

## One record in that batch is wrong, and none of these four caught it

Reported in full on #1337. Vercel's new record is typed `limits_reduced` and every allowance it compares is unchanged — all six of `1M function invocations`, `4 hrs Active CPU`, `360 GB-hrs`, `1M edge requests`, `1 GB Blob`, `5K image transformations` read `equal`. What changed is that overages are now itemised. The gate has a rule for exactly this, and it did not fire.

The hardcoded `vercel` in the JSON-LD test failed on that record, but by coincidence — the same defect on any other vendor would have shipped, and 24 correct records were discarded along with it.
