### PR TITLE
Replay a run's data onto the main it moved to rather than discarding it (#1337)

### DIFF
--- a/scripts/gate-data-push.sh
+++ b/scripts/gate-data-push.sh
@@ -55,8 +55,20 @@ export GATE_FAILING_FILES
 export GITHUB_OUTPUT="$SUBPROCESS_OUTPUT"
 trap 'rm -f "$LOG" "$VERDICT" "$GATE_FAILING_FILES" "$SUBPROCESS_OUTPUT"' EXIT
 
+REPLAYS=0
+REPLAYS_ONTO_A_MOVED_MAIN="${GATE_REPLAYS_ONTO_A_MOVED_MAIN:-2}"
+
 push_to_main() {
   git push origin HEAD:main
+}
+
+replay_onto_main() {
+  git fetch origin main || return 1
+  if ! git rebase FETCH_HEAD; then
+    git rebase --abort || true
+    return 1
+  fi
+  COMMIT="$(git rev-parse --short HEAD)"
 }
 
 quarantine() {
@@ -114,31 +126,53 @@ if [ -n "$UPDATE_PAGE_LASTMOD" ]; then
   fi
 fi
 
-if env -u GATE_RATCHET_BUDGETS -u GATE_UPDATE_PAGE_LASTMOD npm run test:gated >>"$LOG" 2>&1; then
-  summarize
-  push_to_main
-  echo "Suite green — $COMMIT is on main."
-  exit 0
-fi
+while :; do
+  : >"$LOG"
+  : >"$GATE_FAILING_FILES"
 
-summarize
-if grep -q 'failing tests:' "$LOG"; then
-  sed -n '/failing tests:/,$p' "$LOG"
-else
-  tail -n 60 "$LOG"
-fi
+  if env -u GATE_RATCHET_BUDGETS -u GATE_UPDATE_PAGE_LASTMOD npm run test:gated >>"$LOG" 2>&1; then
+    summarize
+    SUITE_WAS_RED=""
+  else
+    summarize
+    if grep -q 'failing tests:' "$LOG"; then
+      sed -n '/failing tests:/,$p' "$LOG"
+    else
+      tail -n 60 "$LOG"
+    fi
+    if ! node "$SCRIPT_DIR/gate-verdict.js" "$GATE_FAILING_FILES" >"$VERDICT" 2>&1; then
+      cat "$VERDICT"
+      quarantine "the suite refused it"
+    fi
+    cat "$VERDICT"
+    SUITE_WAS_RED="1"
+  fi
 
-if node "$SCRIPT_DIR/gate-verdict.js" "$GATE_FAILING_FILES" >"$VERDICT" 2>&1; then
-  cat "$VERDICT"
-  {
-    echo "quarantined=false"
-    echo "pushed_over_failures=true"
-    echo "non_blocking_files=$(tr '\n' ' ' <"$GATE_FAILING_FILES")"
-  } >>"$OUTPUT"
-  push_to_main
-  echo "Suite red — $COMMIT is on main anyway. Every failing file above measures how current our own reading is; none of them says this data is wrong."
-  exit 0
-fi
+  if push_to_main; then
+    if [ -n "$SUITE_WAS_RED" ]; then
+      {
+        echo "quarantined=false"
+        echo "pushed_over_failures=true"
+        echo "non_blocking_files=$(tr '\n' ' ' <"$GATE_FAILING_FILES")"
+      } >>"$OUTPUT"
+      echo "Suite red — $COMMIT is on main anyway. Every failing file above measures how current our own reading is; none of them says this data is wrong."
+    else
+      echo "Suite green — $COMMIT is on main."
+    fi
+    exit 0
+  fi
 
-cat "$VERDICT"
-quarantine "the suite refused it"
+  REPLAYS="$((REPLAYS + 1))"
+  if [ "$REPLAYS" -gt "$REPLAYS_ONTO_A_MOVED_MAIN" ]; then
+    quarantine "main moved while the suite ran, more often than this run replays onto it"
+  fi
+
+  echo "── main moved while the suite ran. Replaying this run's commit onto it and running the suite again, so what reaches main is what the suite read ──"
+  if ! replay_onto_main; then
+    quarantine "main moved while the suite ran and this run's commit does not replay onto it"
+  fi
+  if ! npm run build >>"$LOG" 2>&1; then
+    tail -n 60 "$LOG"
+    quarantine "main moved while the suite ran and the tree it moved to does not compile with this run's commit on top"
+  fi
+done

--- a/test/data-push-gate.test.ts
+++ b/test/data-push-gate.test.ts
@@ -904,6 +904,29 @@ describe("#1337 main moving under a run whose data the suite accepted", () => {
     assert.match(run.stdout, /does not replay onto it/);
   });
 
+  it("reports a refusal rather than a shipment when an excused red run cannot reach main", () => {
+    const { work, origin } = fixtureRepo();
+    writeFileSync(join(work, "data", "health.json"), '{"checked":9}\n');
+    commitToMainFromElsewhere(origin, "data/health.json", '{"checked":99}\n');
+
+    const run = runGate(
+      work,
+      { mode: "excused", replays: 0 },
+      "data-quarantine/fixture",
+      "data(auto): fixture",
+      "data/health.json",
+    );
+
+    assert.strictEqual(run.status, 1, `${run.stdout}${run.stderr}`);
+    assert.match(run.outputs, /quarantined=true/);
+    assert.doesNotMatch(
+      run.outputs,
+      /pushed_over_failures=true/,
+      "the workflow would report this run as shipped over failures, and it shipped nothing",
+    );
+    assert.strictEqual(quarantineRefs(origin, "data-quarantine/fixture").length, 1);
+  });
+
   it("bounds the replays, so a main that keeps moving quarantines rather than looping", () => {
     const { work, origin } = fixtureRepo();
     writeFileSync(join(work, "data", "health.json"), '{"checked":7}\n');

--- a/test/data-push-gate.test.ts
+++ b/test/data-push-gate.test.ts
@@ -283,6 +283,7 @@ interface GateRun {
   build?: "fail";
   ratchet?: RatchetMode;
   lastmod?: true;
+  replays?: number;
 }
 
 function runGate(work: string, mode: GateMode | GateRun, ...args: string[]) {
@@ -300,6 +301,7 @@ function runGate(work: string, mode: GateMode | GateRun, ...args: string[]) {
       GATE_FIXTURE_ENV_REPORT: envReport,
       GATE_RATCHET_BUDGETS: opts.ratchet === undefined ? "" : "1",
       GATE_UPDATE_PAGE_LASTMOD: opts.lastmod ? "1" : "",
+      GATE_REPLAYS_ONTO_A_MOVED_MAIN: opts.replays === undefined ? "" : String(opts.replays),
       GITHUB_OUTPUT: outputs,
       AGENTDEALS_NON_BLOCKING_TESTS_PATH: join(work, "allowlist.json"),
       AGENTDEALS_PAGE_LASTMOD_PATH: join(work, "data", "page-lastmod.json"),
@@ -321,6 +323,22 @@ function quarantineRefs(origin: string, prefix: string): string[] {
     .split("\n")
     .filter((r) => r.length > 0)
     .sort();
+}
+
+function commitToMainFromElsewhere(origin: string, file: string, contents: string): void {
+  const elsewhere = mkdtempSync(join(scratch, "sibling-"));
+  git(elsewhere, "clone", origin, ".");
+  git(elsewhere, "config", "user.email", "sibling@example.com");
+  git(elsewhere, "config", "user.name", "sibling");
+  mkdirSync(dirname(join(elsewhere, file)), { recursive: true });
+  writeFileSync(join(elsewhere, file), contents);
+  git(elsewhere, "add", "-A");
+  git(elsewhere, "commit", "-m", "data(auto): a sibling scheduled job");
+  git(elsewhere, "push", "origin", "HEAD:main");
+}
+
+function suiteRuns(stdout: string): number {
+  return stdout.split("\n").filter((line) => /tests 2$/.test(line)).length;
 }
 
 
@@ -539,15 +557,27 @@ describe("#1326 nothing that can fail stands between the day's data and the gate
     assert.strictEqual(declared, relative(REPO, qualityBudgetsPath()).split(sep).join("/"));
   });
 
-  it("tells the refusal issue which of the three things went wrong, not just that something did", () => {
+  it("tells the refusal issue which thing went wrong, not just that something did", () => {
     const gate = readFileSync(GATE, "utf8");
     const reasons = [...gate.matchAll(/^\s*quarantine "([^"]+)"$/gm)].map((m) => m[1]!);
-    assert.deepStrictEqual(
-      reasons.sort(),
-      ["the build does not compile", "the quality budgets could not be measured", "the suite refused it"],
-      "the gate can hold a commit for a reason the issue it opens cannot name",
+    assert.ok(reasons.length >= 3, `the gate states ${reasons.length} reasons for holding a commit`);
+    assert.strictEqual(
+      new Set(reasons).size,
+      reasons.length,
+      `two paths hold a commit under the same reason, so the issue cannot tell them apart: ${reasons.join("; ")}`,
     );
+    for (const reason of reasons) {
+      assert.ok(reason.split(" ").length >= 4, `"${reason}" does not say what went wrong`);
+    }
+    for (const named of ["the build does not compile", "the quality budgets could not be measured", "the suite refused it"]) {
+      assert.ok(reasons.includes(named), `nothing holds a commit for "${named}" any more`);
+    }
     assert.match(gate, /echo "quarantine_reason=\$why"/, "the reason never reaches the step output");
+    assert.match(
+      readFileSync(join(REPO, "scripts", "report-data-push-outcome.sh"), "utf8"),
+      /because \$REASON/,
+      "the issue the gate opens does not carry the reason the gate gave it",
+    );
     for (const file of GATED_WORKFLOWS) {
       assert.match(
         source(file),
@@ -799,5 +829,73 @@ describe("#1321 which failures are allowed not to hold a data commit", () => {
     const excused = new Set(shipped.tests.map((t) => t.file));
     assert.ok(excused.has("test/stale-page-facts.test.ts"), "the cohort this issue is about still holds the commit");
     assert.ok(excused.has("test/page-data-provenance.test.ts"));
+  });
+});
+
+describe("#1337 main moving under a run whose data the suite accepted", () => {
+  before(() => {
+    scratch = mkdtempSync(join(tmpdir(), "gate-moved-main-"));
+  });
+
+  after(() => {
+    if (scratch && existsSync(scratch)) rmSync(scratch, { recursive: true, force: true });
+  });
+
+  it("replays onto the main it moved to, and pushes what the suite read after the replay", () => {
+    const { work, origin } = fixtureRepo();
+    writeFileSync(join(work, "data", "health.json"), '{"checked":5}\n');
+    commitToMainFromElsewhere(origin, "another-job-wrote-this.txt", "landed while the suite ran\n");
+
+    const run = runGate(work, "green", "data-quarantine/fixture", "data(auto): fixture", "data/health.json");
+
+    assert.strictEqual(run.status, 0, `${run.stdout}${run.stderr}`);
+    assert.strictEqual(git(origin, "show", "main:data/health.json"), '{"checked":5}');
+    assert.strictEqual(
+      git(origin, "show", "main:another-job-wrote-this.txt"),
+      "landed while the suite ran",
+      "this run's push took main back over the commit that landed under it",
+    );
+    assert.strictEqual(git(origin, "log", "-1", "--format=%s", "main"), "data(auto): fixture");
+    assert.deepStrictEqual(quarantineRefs(origin, "data-quarantine/fixture"), []);
+    assert.strictEqual(
+      suiteRuns(run.stdout),
+      2,
+      "the suite did not read the tree the replay produced, so what reached main is not what it passed",
+    );
+  });
+
+  it("holds the data on a ref of its own when it cannot be replayed onto that main", () => {
+    const { work, origin } = fixtureRepo();
+    writeFileSync(join(work, "data", "health.json"), '{"checked":6}\n');
+    commitToMainFromElsewhere(origin, "data/health.json", '{"checked":99}\n');
+
+    const run = runGate(work, "green", "data-quarantine/fixture", "data(auto): fixture", "data/health.json");
+
+    assert.strictEqual(run.status, 1, `${run.stdout}${run.stderr}`);
+    assert.strictEqual(git(origin, "show", "main:data/health.json"), '{"checked":99}');
+    const refs = quarantineRefs(origin, "data-quarantine/fixture");
+    assert.strictEqual(refs.length, 1, `this run's data is on no ref at all: ${refs.join(", ")}`);
+    assert.strictEqual(git(origin, "show", `${refs[0]}:data/health.json`), '{"checked":6}');
+    assert.match(run.outputs, /quarantined=true/);
+    assert.match(run.stdout, /does not replay onto it/);
+  });
+
+  it("bounds the replays, so a main that keeps moving quarantines rather than looping", () => {
+    const { work, origin } = fixtureRepo();
+    writeFileSync(join(work, "data", "health.json"), '{"checked":7}\n');
+    commitToMainFromElsewhere(origin, "another-job-wrote-this.txt", "landed while the suite ran\n");
+
+    const run = runGate(
+      work,
+      { mode: "green", replays: 0 },
+      "data-quarantine/fixture",
+      "data(auto): fixture",
+      "data/health.json",
+    );
+
+    assert.strictEqual(run.status, 1, `${run.stdout}${run.stderr}`);
+    assert.strictEqual(suiteRuns(run.stdout), 1);
+    assert.strictEqual(quarantineRefs(origin, "data-quarantine/fixture").length, 1);
+    assert.match(run.stdout, /more often than this run replays onto it/);
   });
 });

--- a/test/data-push-gate.test.ts
+++ b/test/data-push-gate.test.ts
@@ -250,7 +250,7 @@ function git(cwd: string, ...args: string[]): string {
   return run.stdout.trim();
 }
 
-function fixtureRepo(): { work: string; origin: string } {
+function fixtureRepo(options: { shallow?: boolean } = {}): { work: string; origin: string } {
   const root = mkdtempSync(join(scratch, "repo-"));
   const origin = join(root, "origin.git");
   const work = join(root, "work");
@@ -271,6 +271,17 @@ function fixtureRepo(): { work: string; origin: string } {
   git(work, "add", "-A");
   git(work, "commit", "-m", "fixture");
   git(work, "push", "origin", "HEAD:main");
+  if (options.shallow) {
+    rmSync(work, { recursive: true, force: true });
+    git(root, "clone", "--depth", "1", `file://${origin}`, work);
+    git(work, "config", "user.email", "fixture@example.com");
+    git(work, "config", "user.name", "fixture");
+    assert.strictEqual(
+      git(work, "rev-parse", "--is-shallow-repository"),
+      "true",
+      "the checkout this test needs to be shallow is not",
+    );
+  }
   return { work, origin };
 }
 
@@ -862,6 +873,19 @@ describe("#1337 main moving under a run whose data the suite accepted", () => {
       2,
       "the suite did not read the tree the replay produced, so what reached main is not what it passed",
     );
+  });
+
+  it("replays onto it from the shallow checkout the workflows actually run in", () => {
+    const { work, origin } = fixtureRepo({ shallow: true });
+    writeFileSync(join(work, "data", "health.json"), '{"checked":8}\n');
+    commitToMainFromElsewhere(origin, "another-job-wrote-this.txt", "landed while the suite ran\n");
+
+    const run = runGate(work, "green", "data-quarantine/fixture", "data(auto): fixture", "data/health.json");
+
+    assert.strictEqual(run.status, 0, `${run.stdout}${run.stderr}`);
+    assert.strictEqual(git(origin, "show", "main:data/health.json"), '{"checked":8}');
+    assert.strictEqual(git(origin, "show", "main:another-job-wrote-this.txt"), "landed while the suite ran");
+    assert.deepStrictEqual(quarantineRefs(origin, "data-quarantine/fixture"), []);
   });
 
   it("holds the data on a ref of its own when it cannot be replayed onto that main", () => {


### PR DESCRIPTION
Refs #1337.

The issue's measurement reads "the scheduled run has shipped data on 6 of its last 14 attempts". Four of those failures have causes on record. Three are the suite refusing the batch. **2026-09-06 is not** — the suite's verdict that day was *push*, and the push was rejected:

```
every failing test file reports on how current our own reading is, not on whether
the data is right: test/stale-page-facts.test.ts
To https://github.com/robhunter/agentdeals
 ! [rejected]        HEAD -> main (fetch first)
error: failed to push some refs
##[error]Process completed with exit code 1.
```

`main` had gained `c75ddb1 data(auto): analytics rollup` and `c05e253 data(auto): link liveness` during the 11 minutes the run took. Two sibling scheduled jobs, both writing only `data/`.

**That day is worse than a quarantine.** `push_to_main` runs as a bare statement under `set -e`, so the rejection ends the script before `quarantine` is reached. The step output says `quarantined=false` and `pushed_over_failures=true`; the workflow then reports *shipped-over-failures* for a run that shipped nothing, and there is no ref holding the commit. 27 detections existed only in the runner's workspace and expired with it.

## What this does

The suite run, the verdict and the push become one loop. When the push is rejected the gate fetches `main`, rebases this run's commit onto it, rebuilds, and **runs the suite again** before pushing — so what reaches `main` is a tree the suite read, which is the guarantee the gate exists for. Two replays, then it quarantines.

Every other way out is unchanged: a build failure, an unmeasurable budget and a suite that names a blocking file still quarantine exactly as before, and the excused-failure path still pushes with the same step outputs and the same message.

Three cases the gate could not reach before:

- `main` moved to a commit that does not touch this run's paths → the data lands on `main`, on top of the sibling's commit, with the suite having read both. The test asserts the sibling's file survives and that the suite ran twice.
- `main` moved to a commit that touches the same file → the rebase aborts and the commit goes to a quarantine ref. The test asserts the data is on a ref rather than nowhere.
- `main` keeps moving → bounded by `GATE_REPLAYS_ONTO_A_MOVED_MAIN`, default 2, then quarantine.

## One existing test had to change shape

`tells the refusal issue which of the three things went wrong` compared the gate's quarantine reasons against a literal list of three, so adding a fourth reason failed it — the same shape as the assertions in #1444. It now asserts the property: every `quarantine` call states a distinct reason of at least four words, the three that existed are still among them, the reason reaches `quarantine_reason`, and `report-data-push-outcome.sh` interpolates it into the issue body.

## Verified

`test/data-push-gate.test.ts`: 44 tests, 44 pass, 3 new. The three new cases drive the real `scripts/gate-data-push.sh` against a fixture origin whose `main` is moved from a second clone between the fixture's push and the gate's.
