### PR TITLE
Bin a change into the month its terms took effect, not the month we read the page (#1442)

### DIFF
--- a/scripts/mutate-1442.mjs
+++ b/scripts/mutate-1442.mjs
@@ -1,0 +1,81 @@
+import { readFileSync, writeFileSync } from "node:fs";
+import { execFileSync } from "node:child_process";
+
+const SUITE = ["test/monthly-change-series.test.ts"];
+
+const MUTANTS = [
+  ["trend-chart-bins-every-record", "src/serve.ts",
+    `  const sortedMonths = tallyMonths(changeMonths.effective);`,
+    `  const sortedMonths = tallyMonths(monthlyChangeSeries(dealChanges.map(c => ({ ...c, date_source: "hand_written" as typeof c.date_source }))).effective);`],
+  ["risk-card-bins-every-record", "src/serve.ts",
+    `  const monthlyChanges = new Map([...changeMonths.effective].map(([month, records]) => [month, records.length]));`,
+    `  const monthlyChanges = new Map([...monthlyChangeSeries(dealChanges.map(c => ({ ...c, date_source: "hand_written" as typeof c.date_source }))).effective].map(([month, records]) => [month, records.length]));`],
+  ["quarter-report-bins-every-record", "src/serve.ts",
+    `  const q1Changes = changesInWindow(dealChanges, { start: "2026-01-01", end: "2026-03-31" }).dated;`,
+    `  const q1Changes = dealChanges.filter(c => c.date >= "2026-01-01" && c.date <= "2026-03-31");`],
+  ["quarter-report-bins-its-months-without-the-partition", "src/serve.ts",
+    `  const monthlyData = new Map([...monthlyChangeSeries(q1Changes).effective].map(([month, records]) => [month, {`,
+    `  const monthlyData = new Map([...monthlyChangeSeries(dealChanges.filter(c => c.date >= "2026-01-01" && c.date <= "2026-03-31").map(c => ({ ...c, date_source: "hand_written" as typeof c.date_source }))).effective].map(([month, records]) => [month, {`],
+  ["period-comparison-counts-every-record-in-the-window", "src/serve.ts",
+    `    [...changeMonths.effective.values()].flat().filter(c => c.date >= start && c.date <= end).length;`,
+    `    dealChanges.filter(c => c.date >= start && c.date <= end).length;`],
+  ["period-comparison-is-hardcoded", "src/serve.ts",
+    `    { label: "Q1 2026", count: countInWindow("2026-01-01", "2026-03-31") }`,
+    `    { label: "Q1 2026", count: 50 }`],
+  ["trend-chart-hides-the-discovery-series", "src/serve.ts",
+    `  \${discoveredTotal > 0 ? \`<h3>\${discoveryMonthSeriesHeading(discoveredTotal)}</h3>`,
+    `  \${false ? \`<h3>\${discoveryMonthSeriesHeading(discoveredTotal)}</h3>`],
+  ["risk-card-hides-the-discovery-series", "src/serve.ts",
+    `    \${discoveredTotal > 0 ? \`<p class="diff-desc"><strong>\${discoveryMonthSeriesHeading(discoveredTotal)}.</strong>`,
+    `    \${false ? \`<p class="diff-desc"><strong>\${discoveryMonthSeriesHeading(discoveredTotal)}.</strong>`],
+  ["discovery-series-does-not-say-when-we-read-the-page", "src/change-dates.ts",
+    `export const DISCOVERY_MONTH_SERIES_NOTE =
+  "These vendors’ pages state terms that differ from what we had stored and do not say when they changed. Each is counted in the month we read the page, so this series measures when we looked, not when the market moved. None of them are in the monthly figures above.";`,
+    `export const DISCOVERY_MONTH_SERIES_NOTE =
+  "These vendors’ pages state terms that differ from what we had stored.";`],
+  ["trend-caption-claims-an-acceleration", "src/serve.ts",
+    `  <p class="section-desc">\${EFFECTIVE_MONTH_SERIES_NOTE} Red bars = negative changes`,
+    `  <p class="section-desc">Pricing changes by month, showing the acceleration in 2026. Red bars = negative changes`],
+  ["risk-card-claims-the-pace-is-not-slowing", "src/serve.ts",
+    `\${quarterAgainstHalf}</p>`,
+    `\${quarterAgainstHalf} The pace isn't slowing.</p>`],
+  ["partition-calls-a-discovered-record-event-dated", "src/change-dates.ts",
+    `  for (const change of changes) (isEventDated(change) ? dated : discovered).push(change);`,
+    `  for (const change of changes) dated.push(change);`],
+  ["month-key-reads-the-day-as-well", "src/change-dates.ts",
+    `    const month = change.date.slice(0, 7);`,
+    `    const month = change.date.slice(0, 10);`],
+  ["months-come-back-in-the-order-the-records-are-stored", "src/change-dates.ts",
+    `  return new Map([...byMonth.entries()].sort((a, b) => a[0].localeCompare(b[0])));`,
+    `  return byMonth;`],
+];
+
+function run(cmd, args) {
+  try {
+    execFileSync(cmd, args, { stdio: "pipe", encoding: "utf-8" });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+const survivors = [];
+const uncompiled = [];
+for (const [name, file, from, to] of MUTANTS) {
+  const original = readFileSync(file, "utf-8");
+  if (!original.includes(from)) {
+    console.log(`SKIP  ${name} — the line it mutates is not in ${file}`);
+    continue;
+  }
+  writeFileSync(file, original.replace(from, to));
+  const built = run("npm", ["run", "build"]);
+  const green = built && run("node", ["--test", "--test-concurrency", "1", ...SUITE]);
+  writeFileSync(file, original);
+  if (!built) uncompiled.push(name);
+  console.log(`${green ? "SURVIVED" : built ? "killed  " : "DID NOT COMPILE"}  ${name}`);
+  if (green) survivors.push(name);
+}
+run("npm", ["run", "build"]);
+console.log(`\n${MUTANTS.length - survivors.length - uncompiled.length}/${MUTANTS.length} killed`);
+if (survivors.length > 0) console.log("survivors:", survivors.join(", "));
+if (uncompiled.length > 0) console.log("did not compile:", uncompiled.join(", "));

--- a/src/change-dates.ts
+++ b/src/change-dates.ts
@@ -28,6 +28,41 @@ export function partitionByDateProvenance<T extends Pick<DealChange, "date_sourc
   return { dated, discovered };
 }
 
+export function groupByMonth<T extends Pick<DealChange, "date">>(changes: T[]): Map<string, T[]> {
+  const byMonth = new Map<string, T[]>();
+  for (const change of changes) {
+    const month = change.date.slice(0, 7);
+    const bucket = byMonth.get(month);
+    if (bucket) bucket.push(change);
+    else byMonth.set(month, [change]);
+  }
+  return new Map([...byMonth.entries()].sort((a, b) => a[0].localeCompare(b[0])));
+}
+
+export function monthlyChangeSeries<T extends Pick<DealChange, "date" | "date_source">>(
+  changes: T[]
+): { effective: Map<string, T[]>; discovered: Map<string, T[]> } {
+  const { dated, discovered } = partitionByDateProvenance(changes);
+  return { effective: groupByMonth(dated), discovered: groupByMonth(discovered) };
+}
+
+export const EFFECTIVE_MONTH_SERIES_NOTE =
+  "Each change is counted in the month its terms took effect. A change read off a page that does not say when it changed is not counted here — those are below, by the month we read the page.";
+
+export function discoveryMonthSeriesHeading(count: number): string {
+  return `Changes Found by Reading a Page (${count})`;
+}
+
+export const DISCOVERY_MONTH_SERIES_NOTE =
+  "These vendors’ pages state terms that differ from what we had stored and do not say when they changed. Each is counted in the month we read the page, so this series measures when we looked, not when the market moved. None of them are in the monthly figures above.";
+
+export function periodComparisonSentence(
+  earlier: { label: string; count: number },
+  later: { label: string; count: number }
+): string {
+  return `${later.label} holds ${later.count} ${later.count === 1 ? "change" : "changes"} whose terms took effect in it, against ${earlier.count} in ${earlier.label}.`;
+}
+
 export interface DateWindow {
   start: string;
   end?: string;

--- a/src/serve.ts
+++ b/src/serve.ts
@@ -68,7 +68,7 @@ import { verificationLedger, QUARANTINE_AFTER_FAILURES } from "./verification-st
 import { partitionAlternatives, partitionSubstitutes, type SubstitutesPartition, productRoleSentence, MEMBERSHIP_GATE_RULES, MEMBERSHIP_GATE_ORDER, MEMBERSHIP_GATE_SYMMETRY, MEMBERSHIP_GATE_SCOPE, MEMBERSHIP_GATE_CORRECTIONS, SUBTYPE_TAXONOMIES, SUBTYPE_MEMBERSHIP_RULE, SUBTYPE_MEMBERSHIP_GROUP_SCOPE, CURATED_SUBTYPE_EXEMPTION, membershipGroupsFor, subtypeDefinition } from "./product-role.js";
 import { resolveCuratedAlternatives, curatedAlternativesFor, addCuratedToPool } from "./curated-alternatives.js";
 import type { Agent, ChangeDateSource, DealChange, RiskCause, RatingWithheld, LinkUnreachable, Offer, StabilityClass } from "./types.js";
-import { changeDateLabel, changeEntryDateLabel, changeEntryLongDateLabel, changeDateClause, changeDatePublished, changeEventStartDate, capListSections, latestEventDate, offerExpiryAfter, feedEntryUpdated, undatedGroupHeading, UNDATED_TILE_LABEL, firstReadHeading, discoveryBatchNote, isoWeekOf, DISCOVERED_DATE_PREFIX, EFFECTIVE_DATE_PREFIX, EVENT_DATED_SOURCES, UNDATED_GROUP_NOTE, UNKNOWN_EFFECTIVE_DATE_MARKER } from "./change-dates.js";
+import { changeDateLabel, changeEntryDateLabel, changeEntryLongDateLabel, changeDateClause, changeDatePublished, changeEventStartDate, capListSections, latestEventDate, offerExpiryAfter, feedEntryUpdated, undatedGroupHeading, UNDATED_TILE_LABEL, firstReadHeading, discoveryBatchNote, isoWeekOf, monthlyChangeSeries, changesInWindow, discoveryMonthSeriesHeading, periodComparisonSentence, DISCOVERED_DATE_PREFIX, EFFECTIVE_DATE_PREFIX, EVENT_DATED_SOURCES, UNDATED_GROUP_NOTE, UNKNOWN_EFFECTIVE_DATE_MARKER, EFFECTIVE_MONTH_SERIES_NOTE, DISCOVERY_MONTH_SERIES_NOTE } from "./change-dates.js";
 import { FEED_CORRECTIONS, correctionEntriesXml } from "./feed-corrections.js";
 import { buildDay, emptyPageLastmod, fallbackDay, httpDate, lastmodFor, newestLastmod, readPageLastmod, type PageLastmodLedger } from "./page-lastmod.js";
 import type { AgentBalance } from "./ledger.js";
@@ -18367,7 +18367,7 @@ ${mcpCtaCss()}
   </div>
 
   <div class="search-cta">
-    <p>This analysis covers Hetzner's April 1 and June 15, 2026 price adjustments and what its cloud plans cost today. For the full quarterly overview covering ${dealChanges.filter(c => c.date >= "2026-01-01" && c.date <= "2026-03-31").length} pricing changes across all developer tools, see the <a href="/q1-2026-developer-pricing-report">Q1 2026 Developer Pricing Report</a>. Browse all ${offers.length.toLocaleString()} developer tools at <a href="/search">/search</a>.</p>
+    <p>This analysis covers Hetzner's April 1 and June 15, 2026 price adjustments and what its cloud plans cost today. For the full quarterly overview covering ${changesInWindow(dealChanges, { start: "2026-01-01", end: "2026-03-31" }).dated.length} pricing changes across all developer tools, see the <a href="/q1-2026-developer-pricing-report">Q1 2026 Developer Pricing Report</a>. Browse all ${offers.length.toLocaleString()} developer tools at <a href="/search">/search</a>.</p>
   </div>
 
   ${buildMoreAlternativesGuides(slug)}
@@ -18386,7 +18386,7 @@ function buildQ1PricingReportPage(): string {
   const slug = "q1-2026-developer-pricing-report";
   const pubDate = "2026-03-24";
 
-  const q1Changes = dealChanges.filter(c => c.date >= "2026-01-01" && c.date <= "2026-03-31");
+  const q1Changes = changesInWindow(dealChanges, { start: "2026-01-01", end: "2026-03-31" }).dated;
 
   const negativeTypes = new Set(["free_tier_removed", "limits_reduced", "restriction", "open_source_killed", "product_deprecated"]);
   const positiveTypes = new Set(["limits_increased", "new_free_tier", "startup_program_expanded", "pricing_postponed"]);
@@ -18474,16 +18474,12 @@ function buildQ1PricingReportPage(): string {
   const sortedCategories = [...catChangeCounts.entries()].sort((a, b) => b[1].total - a[1].total);
   const maxCatTotal = Math.max(...sortedCategories.map(([, v]) => v.total), 1);
 
-  const monthlyData = new Map<string, { total: number; negative: number; positive: number; high: number }>();
-  for (const c of q1Changes) {
-    const month = c.date.slice(0, 7);
-    const entry = monthlyData.get(month) ?? { total: 0, negative: 0, positive: 0, high: 0 };
-    entry.total++;
-    if (negativeTypes.has(c.change_type)) entry.negative++;
-    if (positiveTypes.has(c.change_type)) entry.positive++;
-    if (c.impact === "high") entry.high++;
-    monthlyData.set(month, entry);
-  }
+  const monthlyData = new Map([...monthlyChangeSeries(q1Changes).effective].map(([month, records]) => [month, {
+    total: records.length,
+    negative: records.filter(c => negativeTypes.has(c.change_type)).length,
+    positive: records.filter(c => positiveTypes.has(c.change_type)).length,
+    high: records.filter(c => c.impact === "high").length,
+  }]));
   const monthNames: Record<string, string> = { "2026-01": "January", "2026-02": "February", "2026-03": "March" };
   const sortedMonths = [...monthlyData.entries()].sort((a, b) => a[0].localeCompare(b[0]));
   const maxMonthTotal = Math.max(...sortedMonths.map(([, v]) => v.total), 1);
@@ -18516,7 +18512,7 @@ function buildQ1PricingReportPage(): string {
     const negPct = data.total > 0 ? Math.round((data.negative / data.total) * 100) : 0;
     const posPct = data.total > 0 ? Math.round((data.positive / data.total) * 100) : 0;
     const neutralPct = 100 - negPct - posPct;
-    return "<div style=\"display:flex;align-items:center;gap:.75rem;margin-bottom:.6rem\">" +
+    return "<div class=\"q1-month\" data-series=\"effective\" data-month=\"" + month + "\" data-count=\"" + data.total + "\" style=\"display:flex;align-items:center;gap:.75rem;margin-bottom:.6rem\">" +
       "<span style=\"font-family:var(--mono);font-size:.8rem;color:var(--text-muted);min-width:6rem;text-align:right\">" + (monthNames[month] ?? month) + "</span>" +
       "<div style=\"flex:1;display:flex;height:28px;border-radius:4px;overflow:hidden;background:var(--bg-card);max-width:" + totalWidth + "%;min-width:40px\">" +
         (negPct > 0 ? "<div style=\"width:" + negPct + "%;background:#f85149\" title=\"" + data.negative + " negative\"></div>" : "") +
@@ -22764,16 +22760,17 @@ function buildFreeTierRiskPage(): string {
     .map(([cat, d]) => ({ category: cat, ...d, pctNeg: Math.round((d.negative / d.total) * 100) }))
     .sort((a, b) => b.total - a.total);
 
-  const monthlyChanges = new Map<string, number>();
-  const monthlyNeg = new Map<string, number>();
-  for (const dc of dealChanges) {
-    const month = dc.date.substring(0, 7);
-    monthlyChanges.set(month, (monthlyChanges.get(month) ?? 0) + 1);
-    if (negativeTypes.includes(dc.change_type)) {
-      monthlyNeg.set(month, (monthlyNeg.get(month) ?? 0) + 1);
-    }
-  }
+  const changeMonths = monthlyChangeSeries(dealChanges);
+  const monthlyChanges = new Map([...changeMonths.effective].map(([month, records]) => [month, records.length]));
+  const discoveryMonths = [...changeMonths.discovered].map(([month, records]) => [month, records.length] as const);
+  const discoveredTotal = discoveryMonths.reduce((sum, [, count]) => sum + count, 0);
   const sortedMonths = [...monthlyChanges.keys()].sort();
+  const countInWindow = (start: string, end: string) =>
+    [...changeMonths.effective.values()].flat().filter(c => c.date >= start && c.date <= end).length;
+  const quarterAgainstHalf = periodComparisonSentence(
+    { label: "the second half of 2025", count: countInWindow("2025-07-01", "2025-12-31") },
+    { label: "Q1 2026", count: countInWindow("2026-01-01", "2026-03-31") }
+  );
 
   const vendorChangeCount = new Map<string, number>();
   for (const dc of dealChanges) {
@@ -23054,8 +23051,9 @@ ${mcpCtaCss()}
   </div>
 
   <div class="diff-card" style="border-left-color:#d29922">
-    <h3>\u{1F4C8} Monthly Acceleration</h3>
-    <p class="diff-desc">Pricing changes are accelerating. Monthly change counts: ${sortedMonths.map(m => '<strong>' + m + '</strong>: ' + (monthlyChanges.get(m) ?? 0)).join(', ')}. Q1 2026 saw 50 changes — more than all of 2025 H2. The pace isn't slowing.</p>
+    <h3>\u{1F4C8} Changes by Month</h3>
+    <p class="diff-desc">${EFFECTIVE_MONTH_SERIES_NOTE} Monthly counts: ${sortedMonths.map(m => '<span class="ftr-month" data-series="effective" data-month="' + m + '" data-count="' + (monthlyChanges.get(m) ?? 0) + '"><strong>' + m + '</strong>: ' + (monthlyChanges.get(m) ?? 0) + '</span>').join(', ')}. ${quarterAgainstHalf}</p>
+    ${discoveredTotal > 0 ? `<p class="diff-desc"><strong>${discoveryMonthSeriesHeading(discoveredTotal)}.</strong> ${DISCOVERY_MONTH_SERIES_NOTE} Monthly counts: ${discoveryMonths.map(([m, count]) => '<span class="ftr-month" data-series="discovered" data-month="' + m + '" data-count="' + count + '"><strong>' + m + '</strong>: ' + count + '</span>').join(', ')}.</p>` : ""}
   </div>
 
   <div class="diff-card" style="border-left-color:#8b5cf6">
@@ -26412,7 +26410,7 @@ function buildFreeTierTrackerPage(): string {
 
   const q1Start = "2026-01-01";
   const q1End = "2026-03-31";
-  const q1Changes = dealChanges.filter(c => c.date >= q1Start && c.date <= q1End);
+  const q1Changes = changesInWindow(dealChanges, { start: q1Start, end: q1End }).dated;
 
   const negativeTypes = ["free_tier_removed", "limits_reduced", "restriction", "open_source_killed", "pricing_model_change", "pricing_restructured", "product_deprecated"];
   const positiveTypes = ["limits_increased", "new_free_tier", "startup_program_expanded", "pricing_postponed"];
@@ -45365,19 +45363,42 @@ function buildStateOfFreeTiersPage(): string {
   const eligibilityOffers = offers.filter(o => o.eligibility);
   const startupOffers = offers.filter(o => o.tier.toLowerCase().includes("startup") || (o.eligibility && JSON.stringify(o.eligibility).toLowerCase().includes("startup")));
 
-  const monthlyChanges = new Map<string, { total: number; negative: number; positive: number }>();
   const negativeTypes = new Set(["free_tier_removed", "limits_reduced", "restriction", "open_source_killed", "product_deprecated"]);
   const positiveTypes = new Set(["new_free_tier", "limits_increased", "startup_program_expanded"]);
-  for (const c of dealChanges) {
-    const month = c.date.slice(0, 7);
-    const entry = monthlyChanges.get(month) ?? { total: 0, negative: 0, positive: 0 };
-    entry.total++;
-    if (negativeTypes.has(c.change_type)) entry.negative++;
-    if (positiveTypes.has(c.change_type)) entry.positive++;
-    monthlyChanges.set(month, entry);
+  function tallyMonths(months: Map<string, typeof dealChanges>): Array<[string, { total: number; negative: number; positive: number }]> {
+    return [...months.entries()].map(([month, records]) => [month, {
+      total: records.length,
+      negative: records.filter(c => negativeTypes.has(c.change_type)).length,
+      positive: records.filter(c => positiveTypes.has(c.change_type)).length,
+    }]);
   }
-  const sortedMonths = [...monthlyChanges.entries()].sort((a, b) => a[0].localeCompare(b[0]));
-  const maxMonthTotal = Math.max(...sortedMonths.map(([, v]) => v.total), 1);
+  const changeMonths = monthlyChangeSeries(dealChanges);
+  const sortedMonths = tallyMonths(changeMonths.effective);
+  const discoveryMonths = tallyMonths(changeMonths.discovered);
+  const discoveredTotal = [...changeMonths.discovered.values()].reduce((sum, records) => sum + records.length, 0);
+  const maxMonthTotal = Math.max(...[...sortedMonths, ...discoveryMonths].map(([, v]) => v.total), 1);
+  function monthBarsHtml(series: string, months: typeof sortedMonths): string {
+    return months.map(([month, data]) => {
+      const totalWidth = Math.round((data.total / maxMonthTotal) * 100);
+      const negWidth = data.total > 0 ? Math.round((data.negative / data.total) * 100) : 0;
+      const posWidth = data.total > 0 ? Math.round((data.positive / data.total) * 100) : 0;
+      const neutralWidth = 100 - negWidth - posWidth;
+      return `<div class="sft-month" data-series="${series}" data-month="${month}" data-count="${data.total}" style="display:flex;align-items:center;gap:.75rem;margin-bottom:.4rem">
+        <span style="font-family:var(--mono);font-size:.75rem;color:var(--text-dim);min-width:5rem;text-align:right">${month}</span>
+        <div style="flex:1;display:flex;height:24px;border-radius:4px;overflow:hidden;background:var(--bg-card);max-width:${totalWidth}%;min-width:30px">
+          ${negWidth > 0 ? `<div style="width:${negWidth}%;background:#f85149" title="${data.negative} negative"></div>` : ""}
+          ${neutralWidth > 0 ? `<div style="width:${neutralWidth}%;background:#8b5cf6" title="${data.total - data.negative - data.positive} neutral"></div>` : ""}
+          ${posWidth > 0 ? `<div style="width:${posWidth}%;background:#3fb950" title="${data.positive} positive"></div>` : ""}
+        </div>
+        <span style="font-family:var(--mono);font-size:.75rem;color:var(--text-muted);min-width:1.5rem">${data.total}</span>
+      </div>`;
+    }).join("\n    ");
+  }
+  const changeBarLegendHtml = `<div style="display:flex;gap:1.5rem;margin-top:.75rem;font-size:.75rem;color:var(--text-dim)">
+      <span><span style="display:inline-block;width:10px;height:10px;border-radius:2px;background:#f85149;vertical-align:middle;margin-right:.25rem"></span> Negative (removals, reductions)</span>
+      <span><span style="display:inline-block;width:10px;height:10px;border-radius:2px;background:#8b5cf6;vertical-align:middle;margin-right:.25rem"></span> Restructured / Other</span>
+      <span><span style="display:inline-block;width:10px;height:10px;border-radius:2px;background:#3fb950;vertical-align:middle;margin-right:.25rem"></span> Positive (new tiers, expansions)</span>
+    </div>`;
 
   const changeTypeCounts = new Map<string, number>();
   for (const c of dealChanges) {
@@ -45609,29 +45630,18 @@ ${globalNavCss()}
   </div>
 
   <h2>Monthly Pricing Change Trend</h2>
-  <p class="section-desc">Pricing changes by month, showing the acceleration in 2026. Red bars = negative changes (removals, reductions, restrictions). Green bars = positive changes (new free tiers, expansions).</p>
+  <p class="section-desc">${EFFECTIVE_MONTH_SERIES_NOTE} Red bars = negative changes (removals, reductions, restrictions). Green bars = positive changes (new free tiers, expansions).</p>
   <div style="margin:1.5rem 0;overflow-x:auto">
-    ${sortedMonths.map(([month, data]) => {
-      const totalWidth = Math.round((data.total / maxMonthTotal) * 100);
-      const negWidth = data.total > 0 ? Math.round((data.negative / data.total) * 100) : 0;
-      const posWidth = data.total > 0 ? Math.round((data.positive / data.total) * 100) : 0;
-      const neutralWidth = 100 - negWidth - posWidth;
-      return `<div style="display:flex;align-items:center;gap:.75rem;margin-bottom:.4rem">
-        <span style="font-family:var(--mono);font-size:.75rem;color:var(--text-dim);min-width:5rem;text-align:right">${month}</span>
-        <div style="flex:1;display:flex;height:24px;border-radius:4px;overflow:hidden;background:var(--bg-card);max-width:${totalWidth}%;min-width:30px">
-          ${negWidth > 0 ? `<div style="width:${negWidth}%;background:#f85149" title="${data.negative} negative"></div>` : ""}
-          ${neutralWidth > 0 ? `<div style="width:${neutralWidth}%;background:#8b5cf6" title="${data.total - data.negative - data.positive} neutral"></div>` : ""}
-          ${posWidth > 0 ? `<div style="width:${posWidth}%;background:#3fb950" title="${data.positive} positive"></div>` : ""}
-        </div>
-        <span style="font-family:var(--mono);font-size:.75rem;color:var(--text-muted);min-width:1.5rem">${data.total}</span>
-      </div>`;
-    }).join("\n    ")}
-    <div style="display:flex;gap:1.5rem;margin-top:.75rem;font-size:.75rem;color:var(--text-dim)">
-      <span><span style="display:inline-block;width:10px;height:10px;border-radius:2px;background:#f85149;vertical-align:middle;margin-right:.25rem"></span> Negative (removals, reductions)</span>
-      <span><span style="display:inline-block;width:10px;height:10px;border-radius:2px;background:#8b5cf6;vertical-align:middle;margin-right:.25rem"></span> Restructured / Other</span>
-      <span><span style="display:inline-block;width:10px;height:10px;border-radius:2px;background:#3fb950;vertical-align:middle;margin-right:.25rem"></span> Positive (new tiers, expansions)</span>
-    </div>
+    ${monthBarsHtml("effective", sortedMonths)}
+    ${changeBarLegendHtml}
   </div>
+
+  ${discoveredTotal > 0 ? `<h3>${discoveryMonthSeriesHeading(discoveredTotal)}</h3>
+  <p class="section-desc">${DISCOVERY_MONTH_SERIES_NOTE} Bars are on the same scale as the trend above.</p>
+  <div style="margin:1.5rem 0;overflow-x:auto">
+    ${monthBarsHtml("discovered", discoveryMonths)}
+    ${changeBarLegendHtml}
+  </div>` : ""}
 
   <h2>Change Type Breakdown</h2>
   <p class="section-desc">What kinds of pricing changes are we seeing? The breakdown by change type reveals the dominant patterns.</p>

--- a/test/monthly-change-series.test.ts
+++ b/test/monthly-change-series.test.ts
@@ -1,0 +1,293 @@
+import { describe, it, before, after } from "node:test";
+import assert from "node:assert";
+import { assertPopulationFloor } from "./population-floor.ts";
+import { spawn, type ChildProcess } from "node:child_process";
+import { readFileSync, writeFileSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { monthlyChangeSeries, groupByMonth, discoveryMonthSeriesHeading } from "../dist/change-dates.js";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO = path.join(__dirname, "..");
+
+const EVENT_DATED = ["vendor_page", "hand_written"];
+
+const INJECTED_MONTH = "2026-02";
+const INJECTED_DATE = `${INJECTED_MONTH}-15`;
+const INJECTED_COUNT = 40;
+
+const MONTH_NAMES = ["January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December"];
+
+const DISCOVERY_SERIES_LEAD = discoveryMonthSeriesHeading(1).split(" (")[0];
+
+interface StoredChange {
+  vendor: string;
+  date: string;
+  date_source: string;
+  change_type: string;
+  impact: string;
+  summary: string;
+  category?: string;
+}
+
+function storedChanges(): StoredChange[] {
+  const raw = JSON.parse(readFileSync(path.join(REPO, "data", "deal_changes.json"), "utf8"));
+  return Array.isArray(raw) ? raw : raw.changes;
+}
+
+function injectedChange(n: number): StoredChange {
+  return {
+    vendor: `Fixture Vendor ${n}`,
+    change_type: "limits_reduced",
+    date: INJECTED_DATE,
+    date_source: "discovered",
+    summary: "Free storage allowance differs from what we had stored.",
+    impact: "low",
+    category: "Databases",
+    ...({ source_url: "https://example.com/pricing", alternatives: [], recorded_date: INJECTED_DATE, detected_by: "reverify-ai" } as Record<string, unknown>),
+  } as StoredChange;
+}
+
+function startServer(changesPath?: string): Promise<{ proc: ChildProcess; port: number }> {
+  return new Promise((resolve, reject) => {
+    const child = spawn("node", [path.join(REPO, "dist", "serve.js")], {
+      stdio: ["pipe", "pipe", "pipe"],
+      env: {
+        ...process.env,
+        PORT: "0",
+        BASE_URL: "http://localhost:3000",
+        ...(changesPath ? { AGENTDEALS_CHANGES_PATH: changesPath } : {}),
+      },
+    });
+    const timeout = setTimeout(() => {
+      child.kill();
+      reject(new Error("Server startup timeout"));
+    }, 60000);
+    child.stderr!.on("data", (data: Buffer) => {
+      const m = data.toString().match(/running on http:\/\/localhost:(\d+)/);
+      if (m) {
+        clearTimeout(timeout);
+        resolve({ proc: child, port: parseInt(m[1], 10) });
+      }
+    });
+    child.on("error", (err) => {
+      clearTimeout(timeout);
+      reject(err);
+    });
+  });
+}
+
+function monthKeyFromHeading(heading: string): string | null {
+  const m = heading.match(/^(\w+) (\d{4})$/);
+  if (!m) return null;
+  const index = MONTH_NAMES.indexOf(m[1]);
+  if (index < 0) return null;
+  return `${m[2]}-${String(index + 1).padStart(2, "0")}`;
+}
+
+function changeLogMonths(body: string): Map<string, number> {
+  const months = new Map<string, number>();
+  for (const group of body.split(/<h2 class="month-heading">/).slice(1)) {
+    const heading = group.slice(0, group.indexOf("<"));
+    const key = monthKeyFromHeading(heading);
+    if (!key) continue;
+    months.set(key, (group.match(/class="chg-vendor"/g) ?? []).length);
+  }
+  return months;
+}
+
+function renderedSeries(body: string, series: string): Map<string, number> {
+  const months = new Map<string, number>();
+  for (const element of body.matchAll(/<[a-z]+[^>]*\sdata-month="[^"]*"[^>]*>/g)) {
+    const tag = element[0];
+    const attribute = (name: string) => tag.match(new RegExp(`\\sdata-${name}="([^"]*)"`))?.[1];
+    if (attribute("series") !== series) continue;
+    months.set(attribute("month")!, parseInt(attribute("count")!, 10));
+  }
+  return months;
+}
+
+function sectionText(body: string, opening: string, closing: RegExp): string {
+  const start = body.indexOf(opening);
+  assert.notStrictEqual(start, -1, `section ${JSON.stringify(opening)} is not on the page`);
+  const rest = body.slice(start + opening.length);
+  const end = rest.search(closing);
+  return (end < 0 ? rest : rest.slice(0, end))
+    .replace(/<[^>]+>/g, " ")
+    .replace(/&mdash;/g, "—")
+    .replace(/&rsquo;/g, "’")
+    .replace(/\s+/g, " ");
+}
+
+const SURFACES = [
+  { route: "/state-of-free-tiers", name: "the Monthly Pricing Change Trend chart" },
+  { route: "/free-tier-risk", name: "the Changes by Month card" },
+];
+
+describe("the month a change is counted in", () => {
+  it("puts a record in the effective series only when its date is the date the terms changed", () => {
+    const changes = storedChanges();
+    const { effective, discovered } = monthlyChangeSeries(changes as never);
+
+    const expectedEffective = new Map<string, number>();
+    const expectedDiscovered = new Map<string, number>();
+    for (const c of changes) {
+      const bucket = EVENT_DATED.includes(c.date_source) ? expectedEffective : expectedDiscovered;
+      bucket.set(c.date.slice(0, 7), (bucket.get(c.date.slice(0, 7)) ?? 0) + 1);
+    }
+
+    assertPopulationFloor(expectedEffective.size, 12, "months holding a change dated by its own terms");
+    assertPopulationFloor(expectedDiscovered.size, 1, "months holding a change dated by discovery");
+
+    for (const [month, records] of effective) {
+      assert.strictEqual(records.length, expectedEffective.get(month) ?? 0, month);
+    }
+    for (const [month, records] of discovered) {
+      assert.strictEqual(records.length, expectedDiscovered.get(month) ?? 0, month);
+    }
+    assert.deepStrictEqual([...effective.keys()].sort(), [...expectedEffective.keys()].sort());
+    assert.deepStrictEqual([...discovered.keys()].sort(), [...expectedDiscovered.keys()].sort());
+  });
+
+  it("keeps the months in ascending order so a series reads left to right", () => {
+    const months = [...groupByMonth(storedChanges() as never).keys()];
+    assert.deepStrictEqual(months, [...months].sort());
+  });
+});
+
+describe("every surface that bins changes by month", () => {
+  const servers: ChildProcess[] = [];
+  let tmp = "";
+  let live = 0;
+  let injected = 0;
+
+  before(async () => {
+    tmp = mkdtempSync(path.join(tmpdir(), "monthly-change-series-"));
+    const withBatch = [
+      ...storedChanges(),
+      ...Array.from({ length: INJECTED_COUNT }, (_, i) => injectedChange(i)),
+    ];
+    const fixture = path.join(tmp, "with-discovery-batch.json");
+    writeFileSync(fixture, JSON.stringify({ changes: withBatch }));
+
+    const [a, b] = await Promise.all([startServer(), startServer(fixture)]);
+    servers.push(a.proc, b.proc);
+    live = a.port;
+    injected = b.port;
+  });
+
+  after(() => {
+    for (const proc of servers) proc.kill();
+    if (tmp) rmSync(tmp, { recursive: true, force: true });
+  });
+
+  async function body(port: number, route: string): Promise<string> {
+    const res = await fetch(`http://localhost:${port}${route}`);
+    assert.strictEqual(res.status, 200, route);
+    return res.text();
+  }
+
+  it("counts the same changes into a month as the change log does", async () => {
+    const expected = changeLogMonths(await body(live, "/changes"));
+    assertPopulationFloor(expected.size, 12, "months the change log groups by");
+    assertPopulationFloor(
+      [...expected.values()].reduce((a, b) => a + b, 0),
+      200,
+      "changes the change log groups into a month"
+    );
+
+    for (const surface of SURFACES) {
+      const rendered = renderedSeries(await body(live, surface.route), "effective");
+      assert.deepStrictEqual(
+        Object.fromEntries([...rendered].sort()),
+        Object.fromEntries([...expected].sort()),
+        `${surface.name} disagrees with the change log about which changes took effect in which month`
+      );
+    }
+  });
+
+  it("counts into a quarter report only the changes whose terms took effect in it", async () => {
+    const expected = changeLogMonths(await body(live, "/changes"));
+    const quarter = new Map([...expected].filter(([m]) => m >= "2026-01" && m <= "2026-03"));
+    assertPopulationFloor(quarter.size, 2, "months in the quarter the report covers");
+
+    const rendered = renderedSeries(await body(live, "/q1-2026-developer-pricing-report"), "effective");
+    assert.deepStrictEqual(Object.fromEntries([...rendered].sort()), Object.fromEntries([...quarter].sort()));
+  });
+
+  it("does not move a month when a batch of pages is read and none of them says when it changed", async () => {
+    const routes = [...SURFACES.map(s => s.route), "/q1-2026-developer-pricing-report", "/changes"];
+    for (const route of routes) {
+      const control = await body(live, route);
+      const after = await body(injected, route);
+      const [before, later] = route === "/changes"
+        ? [changeLogMonths(control), changeLogMonths(after)]
+        : [renderedSeries(control, "effective"), renderedSeries(after, "effective")];
+      assertPopulationFloor(before.size, 2, `months ${route} bins changes into`);
+      assert.deepStrictEqual(
+        Object.fromEntries([...later].sort()),
+        Object.fromEntries([...before].sort()),
+        `${route} counted a discovery batch into the month we read it`
+      );
+    }
+  });
+
+  it("shows the discovery batch under a label saying the date is when we read the page", async () => {
+    for (const surface of SURFACES) {
+      const control = renderedSeries(await body(live, surface.route), "discovered");
+      const after = renderedSeries(await body(injected, surface.route), "discovered");
+      assert.strictEqual(
+        (after.get(INJECTED_MONTH) ?? 0) - (control.get(INJECTED_MONTH) ?? 0),
+        INJECTED_COUNT,
+        `${surface.name} did not show the batch as pages read in ${INJECTED_MONTH}`
+      );
+
+      const page = await body(injected, surface.route);
+      const start = page.indexOf(DISCOVERY_SERIES_LEAD);
+      assert.notStrictEqual(start, -1, `${surface.name} does not head the batch as changes found by reading a page`);
+      const lead = page.slice(start, page.indexOf("data-series=\"discovered\"", start));
+      assert.ok(
+        /the month we read the page/.test(lead),
+        `${surface.name} shows a discovery month without saying the date is when we read the page: ${lead.replace(/<[^>]+>/g, " ")}`
+      );
+    }
+  });
+
+  it("states a period comparison in figures taken from the records", async () => {
+    const eventDated = storedChanges().filter(c => EVENT_DATED.includes(c.date_source));
+    const inWindow = (start: string, end: string) =>
+      eventDated.filter(c => c.date >= start && c.date <= end).length;
+    const quarter = inWindow("2026-01-01", "2026-03-31");
+    const half = inWindow("2025-07-01", "2025-12-31");
+    assertPopulationFloor(quarter, 10, "changes whose terms took effect in the quarter compared");
+
+    const text = sectionText(await body(live, "/free-tier-risk"), "Changes by Month", /<\/div>/);
+    assert.ok(
+      text.includes(`Q1 2026 holds ${quarter} `),
+      `the comparison does not state the ${quarter} the records hold: ${text.slice(-260)}`
+    );
+    assert.ok(
+      text.includes(`against ${half} in the second half of 2025`),
+      `the comparison does not state the ${half} the records hold: ${text.slice(-260)}`
+    );
+
+    const moved = sectionText(await body(injected, "/free-tier-risk"), "Changes by Month", /<\/div>/);
+    assert.ok(
+      moved.includes(`Q1 2026 holds ${quarter} `),
+      "a discovery batch dated inside the quarter moved the figure the comparison states"
+    );
+  });
+
+  it("claims no rate or direction over a month series", async () => {
+    const sections = [
+      { route: "/state-of-free-tiers", opening: "<h2>Monthly Pricing Change Trend</h2>", closing: /<h2/ },
+      { route: "/free-tier-risk", opening: "Changes by Month", closing: /<\/div>/ },
+    ];
+    for (const section of sections) {
+      const text = sectionText(await body(live, section.route), section.opening, section.closing);
+      assertPopulationFloor(text.length, 200, `characters of prose around the ${section.route} month series`);
+      assert.ok(!/accelerat|the pace/i.test(text), `${section.route} states a rate over a month series: ${text}`);
+    }
+  });
+});


### PR DESCRIPTION
Refs #1442

`/state-of-free-tiers` binned all 552 change records by `date`. 259 of those are `date_source: discovered` — the date is the day we read the vendor's page, not the day the terms changed. The Monthly Pricing Change Trend showed **150 changes in August and 114 in September** under a caption reading *"showing the acceleration in 2026"*. `/changes` publishes 2 and 3 for the same months. `/free-tier-risk` carried the same series in prose.

## What changed

`monthlyChangeSeries` in `src/change-dates.ts` partitions and bins in one call, beside the `partitionByDateProvenance` the five correct surfaces already use. Three sites now go through it:

| surface | before | after |
|---|---|---|
| `/state-of-free-tiers` trend | Aug 150, Sep 114 | Aug 2, Sep 3 |
| `/free-tier-risk` monthly counts | Aug 150, Sep 114 | Aug 2, Sep 3 |
| `/q1-2026-developer-pricing-report` | right by accident | right by rule |

Every month on all three now equals what `/changes` renders, exactly.

**The 259 are not dropped.** Both surfaces carry a second, distinctly labelled series — *Changes Found by Reading a Page (259)* — on the same scale as the trend, saying the date is the month we read the page. Reading 259 pricing pages in five weeks is the freshest thing we publish; the fix is to stop calling it a market trend, not to hide it.

**AC-3.** The caption's *"showing the acceleration in 2026"* and the card's *"Pricing changes are accelerating … The pace isn't slowing"* are gone. Neither surface asserts a rate or a direction over a month series.

**AC-4.** *"Q1 2026 saw 50 changes — more than all of 2025 H2"* was hardcoded. It now reads *"Q1 2026 holds 52 changes whose terms took effect in it, against 14 in the second half of 2025"*, both computed from the records.

**AC-6, and two siblings it shares a shape with.** `buildQ1PricingReportPage` selects its quarter through `changesInWindow` and bins its months through the same partition. `/free-tier-tracker` and the quarter count in `/hetzner-pricing-2026`'s prose hold the same window filter and would have disagreed with the report they link to, so both take the same one-line change. All three render **byte-identical to production today** — no discovered record falls in Q1 — and stay right when one does.

## Tests

`test/monthly-change-series.test.ts`, 8 tests. The oracle is `/changes`, an untouched surface that already made this distinction: for every month, the count each surface renders must equal the count `/changes` renders for it. Nothing is recomputed with the code under test.

The regression test injects 40 `discovered` records dated `2026-02-15` into a fixture catalogue and serves it from a second server. Every month on all four surfaces must be identical to the control's, and the discovery series must gain exactly 40 in `2026-02`. That is the shape of the defect: a discovery batch landing in a month it did not happen in — and 2026-02 is inside the quarter the report covers, so it drives the latent site too.

`scripts/mutate-1442.mjs` — 14 mutants, 14 killed.

Full suite: 4,298 tests, 4,298 pass.

## Not in this change

The April 2026 spike of 200 stays. Those records are `hand_written` and `/changes` bins them as dated too, so they are outside this rule — but they remain odd in the way the issue describes: 108 fall on 2026-04-12 and 54 on 2026-04-13, `date` equals `recorded_date` on all 162, and 131 carry no `source_url`.
