### PR TITLE
Read agent demand by what triggers the fetch, not by class alone (#1449)

### DIFF
--- a/scripts/mutate-1449.mjs
+++ b/scripts/mutate-1449.mjs
@@ -1,0 +1,83 @@
+import { readFileSync, writeFileSync } from "node:fs";
+import { execFileSync } from "node:child_process";
+
+const SUITE = ["test/client-class.test.ts", "test/traffic-attribution.test.ts"];
+
+const MUTANTS = [
+  ["a-coding-agent-is-filed-as-the-plain-user-family", "src/client-class.ts",
+    "  { pattern: /claude-code/i, client_class: \"ai_agent\", family: \"Claude-Code\", trigger: \"user_initiated\" },\n  { pattern: /Claude-User/i, client_class: \"ai_agent\", family: \"Claude-User\", trigger: \"user_initiated\" },",
+    "  { pattern: /Claude-User/i, client_class: \"ai_agent\", family: \"Claude-User\", trigger: \"user_initiated\" },\n  { pattern: /claude-code/i, client_class: \"ai_agent\", family: \"Claude-Code\", trigger: \"user_initiated\" },"],
+  ["a-broader-rule-above-an-existing-one-strands-it", "src/client-class.ts",
+    "  { pattern: /ChatGPT-User/i, client_class: \"ai_agent\", family: \"ChatGPT-User\", trigger: \"user_initiated\" },",
+    "  { pattern: /User/i, client_class: \"ai_agent\", family: \"ChatGPT-User\", trigger: \"user_initiated\" },"],
+  ["the-split-reports-what-it-attributed-as-the-total", "src/stats.ts",
+    "    total: agentHits,\n    user_initiated: perTrigger.user_initiated,",
+    "    total: attributed,\n    user_initiated: perTrigger.user_initiated,"],
+  ["hits-with-no-family-are-dropped-rather-than-named", "src/stats.ts",
+    "    unattributed: agentHits - attributed,",
+    "    unattributed: 0,"],
+  ["a-family-with-no-rule-is-guessed-as-ambiguous", "src/stats.ts",
+    "    const trigger = agentTriggerForFamily(family);\n    if (trigger === null) continue;",
+    "    const trigger = agentTriggerForFamily(family) ?? \"ambiguous\";"],
+  ["training-crawls-fall-out-of-the-automated-group", "src/stats.ts",
+    "    automated: perTrigger.search_index + perTrigger.training,",
+    "    automated: perTrigger.search_index,"],
+  ["the-search-and-training-detail-does-not-add-up", "src/stats.ts",
+    "    automated_by_kind: { search_index: perTrigger.search_index, training: perTrigger.training },",
+    "    automated_by_kind: { search_index: perTrigger.search_index, training: 0 },"],
+  ["every-agent-hit-reads-as-user-initiated", "src/client-class.ts",
+    "  return TRIGGER_BY_FAMILY.get(family) ?? null;",
+    "  return TRIGGER_BY_FAMILY.has(family) ? \"user_initiated\" : null;"],
+  ["a-crawler-family-is-sold-as-a-person-asking", "src/client-class.ts",
+    "  { pattern: /Amazonbot/i, client_class: \"ai_agent\", family: \"Amazonbot\", trigger: \"search_index\" },",
+    "  { pattern: /Amazonbot/i, client_class: \"ai_agent\", family: \"Amazonbot\", trigger: \"user_initiated\" },"],
+  ["the-coding-agent-family-is-filed-as-a-training-crawl", "src/client-class.ts",
+    "  { pattern: /claude-code/i, client_class: \"ai_agent\", family: \"Claude-Code\", trigger: \"user_initiated\" },",
+    "  { pattern: /claude-code/i, client_class: \"ai_agent\", family: \"Claude-Code\", trigger: \"training\" },"],
+  ["the-published-grouping-loses-a-family", "src/client-class.ts",
+    "  for (const [family, trigger] of TRIGGER_BY_FAMILY) out[trigger].push(family);",
+    "  for (const [family, trigger] of TRIGGER_BY_FAMILY) if (family !== \"Claude-Code\") out[trigger].push(family);"],
+  ["the-endpoint-still-promises-maintainer-traffic-cannot-reach-it", "src/stats.ts",
+    "  \"A maintainer running a bare `curl` against a normal page is indistinguishable from any other scripted client and is counted as `sdk_client`, not `internal`, so it inflates web_hits. Coding agents are not: `Claude-Code` and `agent-scraper` are agent tooling classified `ai_agent`, and the automation that maintains this project uses them, so its own requests are inside ai_agent_hits. Read those two families as an upper bound on outside demand rather than a measure of it.\",",
+    "  \"A maintainer running a bare `curl` against a normal page is indistinguishable from any other scripted client and is counted as `sdk_client`, not `internal`. It can therefore inflate web_hits but never ai_agent_hits.\","],
+  ["the-window-publishes-a-split-of-nothing", "src/stats.ts",
+    "  window.ai_agent_by_trigger = splitAgentHitsByTrigger(window.ai_agent_by_family, window.by_class[\"ai_agent\"] ?? 0);",
+    "  window.ai_agent_by_trigger = splitAgentHitsByTrigger({}, window.by_class[\"ai_agent\"] ?? 0);"],
+  ["the-grouping-is-published-from-somewhere-other-than-the-table", "src/stats.ts",
+    "    ai_agent_trigger_families: agentFamiliesByTrigger(),\n    notes: TRAFFIC_NOTES,\n    storage,\n  });\n\n  if (!useRedis()) return unavailable(\"redis-not-configured\");",
+    "    ai_agent_trigger_families: { user_initiated: [], search_index: [], training: [], ambiguous: [] },\n    notes: TRAFFIC_NOTES,\n    storage,\n  });\n\n  if (!useRedis()) return unavailable(\"redis-not-configured\");"],
+];
+
+function run(cmd, args) {
+  try {
+    execFileSync(cmd, args, { stdio: "pipe", encoding: "utf-8" });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+const survivors = [];
+const uncompiled = [];
+const skipped = [];
+for (const [name, file, from, to] of MUTANTS) {
+  const original = readFileSync(file, "utf-8");
+  if (!original.includes(from)) {
+    console.log(`SKIP  ${name} — the line it mutates is not in ${file}`);
+    skipped.push(name);
+    continue;
+  }
+  writeFileSync(file, original.replace(from, to));
+  const built = run("npm", ["run", "build"]);
+  const green = built && run("node", ["--test", "--test-concurrency", "1", ...SUITE]);
+  writeFileSync(file, original);
+  if (!built) uncompiled.push(name);
+  console.log(`${green ? "SURVIVED" : built ? "killed  " : "DID NOT COMPILE"}  ${name}`);
+  if (green) survivors.push(name);
+}
+run("npm", ["run", "build"]);
+const killed = MUTANTS.length - survivors.length - uncompiled.length - skipped.length;
+console.log(`\n${killed}/${MUTANTS.length} killed`);
+if (survivors.length > 0) console.log("survivors:", survivors.join(", "));
+if (uncompiled.length > 0) console.log("did not compile:", uncompiled.join(", "));
+if (skipped.length > 0) console.log("skipped — target string moved, so these scored nothing:", skipped.join(", "));

--- a/src/client-class.ts
+++ b/src/client-class.ts
@@ -26,37 +26,50 @@ export const CLIENT_CLASSES: readonly ClientClass[] = [
 
 export const UNKNOWN_FAMILY = "unknown";
 
-interface Rule {
+export type AgentTrigger = "user_initiated" | "search_index" | "training" | "ambiguous";
+
+export const AGENT_TRIGGERS: readonly AgentTrigger[] = ["user_initiated", "search_index", "training", "ambiguous"] as const;
+
+interface AgentRule {
   pattern: RegExp;
-  client_class: ClientClass;
+  client_class: "ai_agent";
+  family: string;
+  trigger: AgentTrigger;
+}
+
+interface NonAgentRule {
+  pattern: RegExp;
+  client_class: Exclude<ClientClass, "ai_agent">;
   family: string;
 }
+
+type Rule = AgentRule | NonAgentRule;
 
 const RULES: Rule[] = [
   { pattern: /agentdeals-internal|agentdeals-monitor/i, client_class: "internal", family: "agentdeals-internal" },
 
-  { pattern: /ChatGPT-User/i, client_class: "ai_agent", family: "ChatGPT-User" },
-  { pattern: /OAI-SearchBot/i, client_class: "ai_agent", family: "OAI-SearchBot" },
-  { pattern: /GPTBot/i, client_class: "ai_agent", family: "GPTBot" },
-  { pattern: /Claude-User/i, client_class: "ai_agent", family: "Claude-User" },
-  { pattern: /claude-code/i, client_class: "ai_agent", family: "Claude-Code" },
-  { pattern: /Claude-SearchBot/i, client_class: "ai_agent", family: "Claude-SearchBot" },
-  { pattern: /ClaudeBot|anthropic-ai/i, client_class: "ai_agent", family: "ClaudeBot" },
-  { pattern: /Perplexity-User/i, client_class: "ai_agent", family: "Perplexity-User" },
-  { pattern: /PerplexityBot/i, client_class: "ai_agent", family: "PerplexityBot" },
-  { pattern: /Google-Extended/i, client_class: "ai_agent", family: "Google-Extended" },
-  { pattern: /Gemini|Google-CloudVertexBot/i, client_class: "ai_agent", family: "Gemini" },
-  { pattern: /Applebot-Extended/i, client_class: "ai_agent", family: "Applebot-Extended" },
-  { pattern: /meta-externalagent|meta-externalfetcher/i, client_class: "ai_agent", family: "meta-externalagent" },
-  { pattern: /Bytespider/i, client_class: "ai_agent", family: "Bytespider" },
-  { pattern: /Amazonbot/i, client_class: "ai_agent", family: "Amazonbot" },
-  { pattern: /YouBot/i, client_class: "ai_agent", family: "YouBot" },
-  { pattern: /cohere-ai|cohere-training-data-crawler/i, client_class: "ai_agent", family: "cohere-ai" },
-  { pattern: /CCBot/i, client_class: "ai_agent", family: "CCBot" },
-  { pattern: /MistralAI-User/i, client_class: "ai_agent", family: "MistralAI-User" },
-  { pattern: /DuckAssistBot/i, client_class: "ai_agent", family: "DuckAssistBot" },
-  { pattern: /AI2Bot|Diffbot|Timpibot|ImagesiftBot|Omgilibot|Webzio-Extended|PanguBot|Kangaroo Bot|img2dataset/i, client_class: "ai_agent", family: "other-ai-crawler" },
-  { pattern: /Firecrawl|ScrapingBot|BrowserBase|Browserless/i, client_class: "ai_agent", family: "agent-scraper" },
+  { pattern: /ChatGPT-User/i, client_class: "ai_agent", family: "ChatGPT-User", trigger: "user_initiated" },
+  { pattern: /OAI-SearchBot/i, client_class: "ai_agent", family: "OAI-SearchBot", trigger: "search_index" },
+  { pattern: /GPTBot/i, client_class: "ai_agent", family: "GPTBot", trigger: "training" },
+  { pattern: /claude-code/i, client_class: "ai_agent", family: "Claude-Code", trigger: "user_initiated" },
+  { pattern: /Claude-User/i, client_class: "ai_agent", family: "Claude-User", trigger: "user_initiated" },
+  { pattern: /Claude-SearchBot/i, client_class: "ai_agent", family: "Claude-SearchBot", trigger: "search_index" },
+  { pattern: /ClaudeBot|anthropic-ai/i, client_class: "ai_agent", family: "ClaudeBot", trigger: "training" },
+  { pattern: /Perplexity-User/i, client_class: "ai_agent", family: "Perplexity-User", trigger: "user_initiated" },
+  { pattern: /PerplexityBot/i, client_class: "ai_agent", family: "PerplexityBot", trigger: "search_index" },
+  { pattern: /Google-Extended/i, client_class: "ai_agent", family: "Google-Extended", trigger: "training" },
+  { pattern: /Gemini|Google-CloudVertexBot/i, client_class: "ai_agent", family: "Gemini", trigger: "training" },
+  { pattern: /Applebot-Extended/i, client_class: "ai_agent", family: "Applebot-Extended", trigger: "training" },
+  { pattern: /meta-externalagent|meta-externalfetcher/i, client_class: "ai_agent", family: "meta-externalagent", trigger: "training" },
+  { pattern: /Bytespider/i, client_class: "ai_agent", family: "Bytespider", trigger: "training" },
+  { pattern: /Amazonbot/i, client_class: "ai_agent", family: "Amazonbot", trigger: "search_index" },
+  { pattern: /YouBot/i, client_class: "ai_agent", family: "YouBot", trigger: "search_index" },
+  { pattern: /cohere-ai|cohere-training-data-crawler/i, client_class: "ai_agent", family: "cohere-ai", trigger: "training" },
+  { pattern: /CCBot/i, client_class: "ai_agent", family: "CCBot", trigger: "training" },
+  { pattern: /MistralAI-User/i, client_class: "ai_agent", family: "MistralAI-User", trigger: "user_initiated" },
+  { pattern: /DuckAssistBot/i, client_class: "ai_agent", family: "DuckAssistBot", trigger: "ambiguous" },
+  { pattern: /AI2Bot|Diffbot|Timpibot|ImagesiftBot|Omgilibot|Webzio-Extended|PanguBot|Kangaroo Bot|img2dataset/i, client_class: "ai_agent", family: "other-ai-crawler", trigger: "training" },
+  { pattern: /Firecrawl|ScrapingBot|BrowserBase|Browserless/i, client_class: "ai_agent", family: "agent-scraper", trigger: "ambiguous" },
 
   { pattern: /Googlebot|Storebot-Google|GoogleOther|AdsBot-Google|Mediapartners-Google/i, client_class: "search_crawler", family: "Googlebot" },
   { pattern: /bingbot|adidxbot|BingPreview|msnbot/i, client_class: "search_crawler", family: "bingbot" },
@@ -104,6 +117,45 @@ const RULES: Rule[] = [
 ];
 
 const GENERIC_BOT = /\b(bot|crawler|spider|scraper|crawl)\b|bot\/|\+https?:\/\/[^\s)]*bot/i;
+
+function agentRules(): AgentRule[] {
+  return RULES.filter((rule): rule is AgentRule => rule.client_class === "ai_agent");
+}
+
+const TRIGGER_BY_FAMILY: ReadonlyMap<string, AgentTrigger> = new Map(
+  agentRules().map((rule) => [rule.family, rule.trigger]),
+);
+
+export function agentTriggerForFamily(family: string): AgentTrigger | null {
+  return TRIGGER_BY_FAMILY.get(family) ?? null;
+}
+
+export function agentFamiliesByTrigger(): Record<AgentTrigger, string[]> {
+  const out = Object.fromEntries(AGENT_TRIGGERS.map((t) => [t, [] as string[]])) as Record<AgentTrigger, string[]>;
+  for (const [family, trigger] of TRIGGER_BY_FAMILY) out[trigger].push(family);
+  for (const trigger of AGENT_TRIGGERS) out[trigger].sort();
+  return out;
+}
+
+export function agentFamilyRuleCount(): number {
+  return agentRules().length;
+}
+
+export interface RuleDescriptor {
+  pattern: RegExp;
+  client_class: ClientClass;
+  family: string;
+  trigger: AgentTrigger | null;
+}
+
+export function clientRuleTable(): RuleDescriptor[] {
+  return RULES.map((rule) => ({
+    pattern: rule.pattern,
+    client_class: rule.client_class,
+    family: rule.family,
+    trigger: rule.client_class === "ai_agent" ? rule.trigger : null,
+  }));
+}
 
 export function classifyClient(userAgent: string | undefined | null): ClientClassification {
   const ua = typeof userAgent === "string" ? userAgent.trim() : "";

--- a/src/stats.ts
+++ b/src/stats.ts
@@ -1,5 +1,6 @@
 import { readFileSync, writeFileSync, mkdirSync } from "node:fs";
 import { dirname } from "node:path";
+import { AGENT_TRIGGERS, agentFamiliesByTrigger, agentTriggerForFamily, type AgentTrigger } from "./client-class.js";
 
 const startedAt = Date.now();
 const serverStartedISO = new Date(startedAt).toISOString();
@@ -1880,6 +1881,15 @@ export function getPageViewsToday(): number {
   return pageViewsToday;
 }
 
+export interface AgentTriggerSplit {
+  total: number;
+  user_initiated: number;
+  automated: number;
+  ambiguous: number;
+  unattributed: number;
+  automated_by_kind: { search_index: number; training: number };
+}
+
 export interface TrafficWindow {
   days: number;
   from: string;
@@ -1891,6 +1901,7 @@ export interface TrafficWindow {
   hits_excluding_internal: number;
   by_class: Record<string, number>;
   ai_agent_by_family: Record<string, number>;
+  ai_agent_by_trigger: AgentTriggerSplit;
   top_routes_by_class: Record<string, { route: string; hits: number }[]>;
   not_found_total: number;
   not_found_by_class: Record<string, number>;
@@ -1920,6 +1931,7 @@ export interface TrafficReport {
   since_boot_redirects: number;
   not_found_sample: NotFoundSample[];
   sessions: SessionSeries;
+  ai_agent_trigger_families: Record<AgentTrigger, string[]>;
   notes: string[];
   storage: TelemetryHealth;
 }
@@ -1960,12 +1972,32 @@ function emptyWindow(days: number): TrafficWindow {
     hits_excluding_internal: 0,
     by_class: {},
     ai_agent_by_family: {},
+    ai_agent_by_trigger: splitAgentHitsByTrigger({}, 0),
     top_routes_by_class: {},
     not_found_total: 0,
     not_found_by_class: {},
     redirect_total: 0,
     redirects_by_class: {},
     pre_split_dates: [],
+  };
+}
+
+function splitAgentHitsByTrigger(byFamily: Record<string, number>, agentHits: number): AgentTriggerSplit {
+  const perTrigger = Object.fromEntries(AGENT_TRIGGERS.map((t) => [t, 0])) as Record<AgentTrigger, number>;
+  let attributed = 0;
+  for (const [family, count] of Object.entries(byFamily)) {
+    const trigger = agentTriggerForFamily(family);
+    if (trigger === null) continue;
+    perTrigger[trigger] += count;
+    attributed += count;
+  }
+  return {
+    total: agentHits,
+    user_initiated: perTrigger.user_initiated,
+    automated: perTrigger.search_index + perTrigger.training,
+    ambiguous: perTrigger.ambiguous,
+    unattributed: agentHits - attributed,
+    automated_by_kind: { search_index: perTrigger.search_index, training: perTrigger.training },
   };
 }
 
@@ -2057,6 +2089,7 @@ function buildWindow(view: PageViewSnapshot, days: number): TrafficWindow {
       .sort((a, b) => b.hits - a.hits)
       .slice(0, TOP_ROUTES_PER_CLASS);
   }
+  window.ai_agent_by_trigger = splitAgentHitsByTrigger(window.ai_agent_by_family, window.by_class["ai_agent"] ?? 0);
   return window;
 }
 
@@ -2082,7 +2115,8 @@ function buildWebVsMcp(view: PageViewSnapshot, window: TrafficWindow, days: numb
 
 const TRAFFIC_NOTES = [
   "`internal` covers requests to observability endpoints (/api/pageviews, /api/query-log, /api/traffic, /api/metrics, /health) plus anything carrying an agentdeals-internal user agent. Excluded from hits_excluding_internal and from web_vs_mcp.",
-  "A maintainer running a bare `curl` against a normal page is indistinguishable from any other scripted client and is counted as `sdk_client`, not `internal`. It can therefore inflate web_hits but never ai_agent_hits.",
+  "A maintainer running a bare `curl` against a normal page is indistinguishable from any other scripted client and is counted as `sdk_client`, not `internal`, so it inflates web_hits. Coding agents are not: `Claude-Code` and `agent-scraper` are agent tooling classified `ai_agent`, and the automation that maintains this project uses them, so its own requests are inside ai_agent_hits. Read those two families as an upper bound on outside demand rather than a measure of it.",
+  "ai_agent_by_trigger regroups the same ai_agent hits by what each vendor documents as the trigger for a fetch: user_initiated where a person's request causes it, automated for crawling on the vendor's own schedule, ambiguous where the vendor documents both. automated_by_kind splits automated into search_index and training. unattributed is the remainder — hits older than detail_days carry a class but no family, and a family with no rule cannot be assigned. The four groups sum to total, which is by_class.ai_agent, so a split that drops hits is arithmetically visible.",
   "`sdk_client` is deliberately not folded into `ai_agent`: undici/python-httpx traffic may be an agent or a scraper, and overclaiming it would make the headline number unquotable.",
   "These counters store only the class and a bounded family label from a fixed table: the user agent and the address a request arrived with are read to derive them and are not persisted into these counters. That is a statement about this endpoint, not about the site — /api/query-log persists and publishes the user agent string itself, and /privacy is the document that describes the whole service.",
   "Attribution starts from the deploy that introduced it — windows longer than that are short by however much history predates it, not wrong.",
@@ -2114,6 +2148,7 @@ export function getTrafficReport(): TrafficReport {
     since_boot_redirects: redirectsSinceBoot,
     not_found_sample: [...pendingPageViews.not_found_sample].reverse(),
     sessions: getSessionSeries(),
+    ai_agent_trigger_families: agentFamiliesByTrigger(),
     notes: TRAFFIC_NOTES,
     storage,
   });
@@ -2143,6 +2178,7 @@ export function getTrafficReport(): TrafficReport {
     since_boot_redirects: redirectsSinceBoot,
     not_found_sample: [...view.not_found_sample].reverse(),
     sessions: getSessionSeries(),
+    ai_agent_trigger_families: agentFamiliesByTrigger(),
     notes: TRAFFIC_NOTES,
     storage,
   };

--- a/test/analytics-rollup.test.ts
+++ b/test/analytics-rollup.test.ts
@@ -13,7 +13,7 @@ import {
   ROLLUP_EXCLUSIONS,
   ROLLUP_SCHEMA_VERSION,
 } from "../src/analytics-rollup.ts";
-import type { RollupDaySource } from "../src/stats.ts";
+import type { RollupDaySource } from "../dist/stats.js";
 
 function sourceFor(date: string, overrides: Partial<RollupDaySource> = {}): RollupDaySource {
   return {

--- a/test/api-analytics-persistence.test.ts
+++ b/test/api-analytics-persistence.test.ts
@@ -13,7 +13,7 @@ const {
   getApiHitsByEndpoint,
   getSearchAnalytics,
   resetCounters,
-} = await import("../src/stats.ts");
+} = await import("../dist/stats.js");
 
 describe("per-endpoint API analytics persistence (#965)", () => {
   beforeEach(() => {

--- a/test/client-class.test.ts
+++ b/test/client-class.test.ts
@@ -5,6 +5,11 @@ const {
   classifyRequest,
   isObservabilityPath,
   CLIENT_CLASSES,
+  AGENT_TRIGGERS,
+  agentFamiliesByTrigger,
+  agentFamilyRuleCount,
+  agentTriggerForFamily,
+  clientRuleTable,
 } = await import("../src/client-class.ts");
 type ClientClass = import("../src/client-class.ts").ClientClass;
 
@@ -40,8 +45,15 @@ const UA = {
   uptime: "Mozilla/5.0+(compatible; UptimeRobot/2.0; http://www.uptimerobot.com/)",
   unknownBot: "Mozilla/5.0 (compatible; SomeNewThingBot/1.0; +http://example.com/bot)",
   internal: "agentdeals-internal/1.0 (verification)",
+  claudeCodeReal: "Claude-User (claude-code/2.1.260; +https://support.anthropic.com/)",
   garbage: "\u0000\u0001 xyzzy",
 } as const;
+
+const REAL_CLAUDE_CODE_UAS = [
+  UA.claudeCodeReal,
+  "Claude-User (claude-code/2.1.255; +https://support.anthropic.com/)",
+  "Claude-User (claude-code/2.1.252; +https://support.anthropic.com/)",
+] as const;
 
 describe("classifyClient — AI agents", () => {
   const cases: [keyof typeof UA, string][] = [
@@ -83,6 +95,20 @@ describe("classifyClient — ordering traps", () => {
   it("Claude-User (agent mid-task) is distinguished from ClaudeBot (training crawler)", () => {
     assert.equal(classifyClient(UA.claudeUser).family, "Claude-User");
     assert.equal(classifyClient(UA.claudeBot).family, "ClaudeBot");
+  });
+
+  it("a coding-agent request carries both tokens and is not filed as the plain one", () => {
+    for (const ua of REAL_CLAUDE_CODE_UAS) {
+      assert.match(ua, /Claude-User/, "the observed strings carry both tokens — that is the whole trap");
+      assert.match(ua, /claude-code/);
+      const seen = classifyClient(ua);
+      assert.equal(seen.family, "Claude-Code", `${ua} must not be pooled into Claude-User`);
+      assert.equal(seen.client_class, "ai_agent");
+    }
+    const plain = classifyClient(UA.claudeUser);
+    assert.equal(plain.family, "Claude-User");
+    assert.equal(plain.client_class, "ai_agent");
+    assert.notEqual(classifyClient(REAL_CLAUDE_CODE_UAS[0]).family, plain.family);
   });
 
   it("OAI-SearchBot is an AI agent, not a search crawler, despite the name", () => {
@@ -205,5 +231,145 @@ describe("classifyRequest — internal attribution", () => {
     assert.equal(isObservabilityPath(""), false);
     assert.equal(isObservabilityPath("/api/pageviews/extra"), false);
     assert.equal(isObservabilityPath(undefined as unknown as string), false);
+  });
+});
+
+function expandBranch(source: string, from: number, stop: string): { candidates: string[]; next: number } {
+  let candidates = [""];
+  const branches: string[][] = [];
+  let i = from;
+  const flush = () => {
+    branches.push(candidates);
+    candidates = [""];
+  };
+  const append = (parts: string[]) => {
+    const out: string[] = [];
+    for (const head of candidates) for (const tail of parts) out.push(head + tail);
+    candidates = out;
+  };
+  while (i < source.length) {
+    const ch = source[i];
+    if (stop && ch === stop) break;
+    if (ch === "|") {
+      flush();
+      i++;
+      continue;
+    }
+    if (ch === "^" || ch === "$") {
+      i++;
+      continue;
+    }
+    if (ch === "\\") {
+      const esc = source[i + 1];
+      i += 2;
+      if (esc === "b" || esc === "B") continue;
+      if (esc === "d") append(["1"]);
+      else if (esc === "s") append([" "]);
+      else if (esc === "w") append(["a"]);
+      else append([esc]);
+      continue;
+    }
+    if (ch === "[") {
+      const close = source.indexOf("]", i + 1);
+      assert.ok(close > i, `unterminated character class in ${source}`);
+      const body = source.slice(i + 1, close);
+      assert.ok(!body.startsWith("^"), `negated character class is not expandable in ${source}`);
+      const first = body.startsWith("\\") ? body.slice(0, 2) : body.slice(0, 1);
+      append([first === "\\d" ? "1" : first === "\\w" ? "a" : first.replace("\\", "")]);
+      i = close + 1;
+      if (source[i] === "?") i++;
+      continue;
+    }
+    if (ch === "(") {
+      let start = i + 1;
+      if (source.startsWith("(?:", i)) start = i + 3;
+      const inner = expandBranch(source, start, ")");
+      assert.equal(source[inner.next], ")", `unterminated group in ${source}`);
+      i = inner.next + 1;
+      const optional = source[i] === "?";
+      if (optional) i++;
+      append(optional ? [...inner.candidates, ""] : inner.candidates);
+      continue;
+    }
+    assert.ok(!"*+{".includes(ch), `unsupported quantifier ${ch} in ${source} — widen the expander rather than skipping the rule`);
+    append([ch]);
+    i++;
+  }
+  flush();
+  return { candidates: branches.flat(), next: i };
+}
+
+function candidatesFor(pattern: RegExp): string[] {
+  const expanded = expandBranch(pattern.source, 0, "");
+  const usable = expanded.candidates.filter((c) => c.length > 0);
+  assert.ok(usable.length > 0, `no candidate string could be built from ${pattern}`);
+  for (const candidate of usable) {
+    assert.match(candidate, pattern, "a candidate that does not match its own rule would make this property vacuous");
+  }
+  return usable;
+}
+
+describe("the client rule table — every family it declares is reachable", () => {
+  const table = clientRuleTable();
+
+  it("builds a matching candidate string for every rule in the table", () => {
+    assert.ok(table.length > 50, `only ${table.length} rules read from the table`);
+    for (const rule of table) assert.ok(candidatesFor(rule.pattern).length > 0);
+  });
+
+  it("no rule is shadowed by an earlier one — a first-match table can strand a family silently", () => {
+    const stranded: string[] = [];
+    for (const rule of table) {
+      const reaches = candidatesFor(rule.pattern).some((candidate) => {
+        const seen = classifyClient(candidate);
+        return seen.family === rule.family && seen.client_class === rule.client_class;
+      });
+      if (!reaches) stranded.push(`${rule.client_class}/${rule.family} via ${rule.pattern}`);
+    }
+    assert.deepStrictEqual(stranded, []);
+  });
+
+  it("a rule inserted above an existing one is caught by that property", () => {
+    const claudeUser = table.find((r) => r.family === "Claude-User");
+    assert.ok(claudeUser, "the table must still declare Claude-User for this control to mean anything");
+    const shadow = /Claude/i;
+    const reaches = candidatesFor(claudeUser.pattern).some((candidate) => !shadow.test(candidate));
+    assert.equal(reaches, false, "a broader rule above this one would swallow every string that reaches it");
+  });
+});
+
+describe("the client rule table — one trigger per AI agent family", () => {
+  it("every ai_agent rule declares a trigger and no other rule does", () => {
+    for (const rule of clientRuleTable()) {
+      if (rule.client_class === "ai_agent") {
+        assert.ok(rule.trigger !== null, `${rule.family} is an AI agent family with no declared trigger`);
+        assert.ok(AGENT_TRIGGERS.includes(rule.trigger), `${rule.family} declares an unknown trigger ${rule.trigger}`);
+      } else {
+        assert.equal(rule.trigger, null, `${rule.family} is ${rule.client_class} and cannot carry an agent trigger`);
+      }
+    }
+  });
+
+  it("the grouping covers every family in the table exactly once", () => {
+    const grouped = agentFamiliesByTrigger();
+    const flat = AGENT_TRIGGERS.flatMap((trigger) => grouped[trigger]);
+    assert.equal(new Set(flat).size, flat.length, "a family in two groups would double-count its hits");
+    assert.equal(flat.length, agentFamilyRuleCount(), "every ai_agent rule contributes exactly one family to the grouping");
+    for (const rule of clientRuleTable()) {
+      if (rule.client_class !== "ai_agent") continue;
+      assert.ok(flat.includes(rule.family), `${rule.family} is in the table and absent from the grouping`);
+      assert.equal(agentTriggerForFamily(rule.family), rule.trigger);
+    }
+  });
+
+  it("a family with no rule has no trigger rather than a guessed one", () => {
+    assert.equal(agentTriggerForFamily("unknown"), null);
+    assert.equal(agentTriggerForFamily("SomeNewThingBot"), null);
+  });
+
+  it("the families that carry this project's own tooling are user_initiated and named as such", () => {
+    assert.equal(agentTriggerForFamily("Claude-Code"), "user_initiated");
+    assert.equal(agentTriggerForFamily("agent-scraper"), "ambiguous");
+    assert.equal(classifyClient(UA.claudeCodeReal).family, "Claude-Code");
   });
 });

--- a/test/query-log-redaction.test.ts
+++ b/test/query-log-redaction.test.ts
@@ -9,7 +9,7 @@ const REPO = path.join(path.dirname(fileURLToPath(import.meta.url)), "..");
 const {
   toPublicRequestLog,
   PUBLISHED_TEXT_MAX,
-} = await import("../src/stats.ts");
+} = await import("../dist/stats.js");
 
 type RawEntry = Parameters<typeof toPublicRequestLog>[0][number];
 

--- a/test/referral-marketplace-metrics.test.ts
+++ b/test/referral-marketplace-metrics.test.ts
@@ -17,7 +17,7 @@ const {
   loadTelemetry,
   flushTelemetry,
   resetCounters,
-} = await import("../src/stats.ts");
+} = await import("../dist/stats.js");
 
 describe("referral marketplace stats module", () => {
   beforeEach(() => {

--- a/test/rollup-day-source.test.ts
+++ b/test/rollup-day-source.test.ts
@@ -1,6 +1,6 @@
 import { describe, it } from "node:test";
 import assert from "node:assert";
-import { splitDayPageViews, splitSignalKeys, getRollupDaySource, getRollupDatesAvailable } from "../src/stats.ts";
+import { splitDayPageViews, splitSignalKeys, getRollupDaySource, getRollupDatesAvailable } from "../dist/stats.js";
 
 describe("splitting a stored day into rollup input", () => {
   it("counts served views from the route keys, never from the stored total", () => {

--- a/test/search-analytics.test.ts
+++ b/test/search-analytics.test.ts
@@ -5,7 +5,7 @@ const {
   recordSearchQuery,
   getSearchAnalytics,
   resetCounters,
-} = await import("../src/stats.ts");
+} = await import("../dist/stats.js");
 
 describe("search analytics", () => {
   beforeEach(() => {

--- a/test/session-classification.test.ts
+++ b/test/session-classification.test.ts
@@ -13,7 +13,7 @@ const {
   resetCounters,
   CRAWLER_CLIENT_PATTERNS,
   AGENT_CLIENT_NAMES,
-} = await import("../src/stats.ts");
+} = await import("../dist/stats.js");
 
 describe("classifyMcpClient heuristic", () => {
   it("classifies every documented crawler pattern as 'crawler'", () => {

--- a/test/telemetry.test.ts
+++ b/test/telemetry.test.ts
@@ -14,7 +14,7 @@ const {
   getStats,
   useRedis,
   resetCounters,
-} = await import("../src/stats.ts");
+} = await import("../dist/stats.js");
 
 describe("telemetry persistence", () => {
   const tmpDir = join(tmpdir(), `telemetry-test-${randomUUID()}`);
@@ -91,7 +91,7 @@ describe("telemetry persistence", () => {
     resetCounters();
     await loadTelemetry(filePath);
 
-    const { recordToolCall: rec, getConnectionStats: conn } = await import("../src/stats.ts");
+    const { recordToolCall: rec, getConnectionStats: conn } = await import("../dist/stats.js");
     rec("search_deals", "opencode");
     rec("search_deals", "opencode");
     rec("plan_stack", "cursor");
@@ -135,7 +135,7 @@ describe("telemetry persistence", () => {
     resetCounters();
     await loadTelemetry(filePath);
 
-    const { getConnectionStats: conn } = await import("../src/stats.ts");
+    const { getConnectionStats: conn } = await import("../dist/stats.js");
     const c = conn(0);
     assert.strictEqual(c.toolCallsByClient.unknown, 61);
     const sum = Object.values(c.toolCallsByClient).reduce((a: number, b: number) => a + b, 0);
@@ -152,7 +152,7 @@ describe("telemetry persistence", () => {
     resetCounters();
     await loadTelemetry(filePath);
 
-    const { recordToolCall: rec, getConnectionStats: conn } = await import("../src/stats.ts");
+    const { recordToolCall: rec, getConnectionStats: conn } = await import("../dist/stats.js");
     rec("search_deals", "opencode");
     rec("search_deals", "cursor");
     rec("plan_stack", "opencode");
@@ -198,7 +198,7 @@ describe("telemetry persistence", () => {
     resetCounters();
     await loadTelemetry(filePath);
 
-    const { getConnectionStats: conn } = await import("../src/stats.ts");
+    const { getConnectionStats: conn } = await import("../dist/stats.js");
     const c = conn(0);
     assert.strictEqual(c.toolCallsByName.unknown, 62);
     const sum = Object.values(c.toolCallsByName).reduce((a: number, b: number) => a + b, 0);

--- a/test/traffic-attribution.test.ts
+++ b/test/traffic-attribution.test.ts
@@ -21,7 +21,7 @@ const {
   OVERFLOW_PAGE_KEY,
   NOT_FOUND_KEY,
 } = await import("../dist/stats.js");
-const { classifyRequest, CLIENT_CLASSES } = await import("../dist/client-class.js");
+const { classifyRequest, CLIENT_CLASSES, agentFamiliesByTrigger } = await import("../dist/client-class.js");
 
 function recordTraffic(path: string, ua: string | undefined, status?: number): void {
   recordTrafficRaw(classifyRequest(path, ua), path, status);
@@ -418,5 +418,217 @@ describe("window honesty and storage bounds", () => {
 
     const bytes = JSON.stringify(snap).length;
     assert.ok(bytes < 400_000, `worst-case snapshot is ${(bytes / 1024).toFixed(0)}KB`);
+  });
+});
+
+describe("ai_agent hits split by what triggers the fetch (#1449)", () => {
+  beforeEach(async () => {
+    process.env.UPSTASH_REDIS_REST_URL = "https://stub.upstash.invalid";
+    process.env.UPSTASH_REDIS_REST_TOKEN = "stub-token";
+    redis = new FakeUpstash();
+    telemetryFile = join(tmpdir(), `trigger-${randomUUID()}.json`);
+    resetCounters();
+    resetTelemetryBuffers();
+    resetTelemetryHealth();
+    installFetchStub();
+  });
+
+  afterEach(() => {
+    globalThis.fetch = realFetch;
+    delete process.env.UPSTASH_REDIS_REST_URL;
+    delete process.env.UPSTASH_REDIS_REST_TOKEN;
+  });
+
+  const AGENT_UA = {
+    chatgptUser: UA.chatgpt,
+    claudeUser: UA.claude,
+    claudeCode: "Claude-User (claude-code/2.1.260; +https://support.anthropic.com/)",
+    amazonbot: "Mozilla/5.0 (compatible; Amazonbot/0.1; +https://developer.amazon.com/support/amazonbot)",
+    perplexityBot: "Mozilla/5.0 (compatible; PerplexityBot/1.0; +https://perplexity.ai/perplexitybot)",
+    bytespider: "Mozilla/5.0 (compatible; Bytespider; spider-feedback@bytedance.com)",
+    ccbot: "CCBot/2.0 (https://commoncrawl.org/faq/)",
+    duckAssist: "Mozilla/5.0 (compatible; DuckAssistBot/1.0; +https://duckduckgo.com/duckassistbot)",
+  };
+
+  function recordEach(entries: [string, number][]): void {
+    for (const [ua, times] of entries) {
+      for (let i = 0; i < times; i++) recordTraffic("/vendor/neon", ua, 200);
+    }
+  }
+
+  it("separates a fetch a person caused from crawling on the vendor's own schedule", async () => {
+    await boot();
+    recordEach([
+      [AGENT_UA.chatgptUser, 5],
+      [AGENT_UA.claudeUser, 3],
+      [AGENT_UA.amazonbot, 40],
+      [AGENT_UA.perplexityBot, 30],
+      [AGENT_UA.bytespider, 20],
+      [AGENT_UA.ccbot, 10],
+      [AGENT_UA.duckAssist, 2],
+    ]);
+
+    const window = getTrafficReport().today;
+    const split = window.ai_agent_by_trigger;
+    assert.equal(window.by_class.ai_agent, 110);
+    assert.equal(split.total, 110);
+    assert.equal(split.user_initiated, 8);
+    assert.equal(split.automated, 100);
+    assert.equal(split.ambiguous, 2);
+    assert.equal(split.unattributed, 0);
+    assert.deepStrictEqual(split.automated_by_kind, { search_index: 70, training: 30 });
+  });
+
+  it("the four groups sum to the ai_agent class total, so a dropped family is arithmetic", async () => {
+    await boot();
+    recordEach(Object.values(AGENT_UA).map((ua) => [ua, 7] as [string, number]));
+
+    const report = getTrafficReport();
+    for (const key of ["today", "last_7d", "last_30d"] as const) {
+      const window = report[key];
+      const split = window.ai_agent_by_trigger;
+      const total = window.by_class.ai_agent ?? 0;
+      assert.equal(split.total, total, `${key}: the split reports a total the class count disagrees with`);
+      assert.equal(
+        split.user_initiated + split.automated + split.ambiguous + split.unattributed,
+        total,
+        `${key}: the groups do not partition the class total`,
+      );
+      assert.equal(split.automated_by_kind.search_index + split.automated_by_kind.training, split.automated, key);
+      assert.ok(split.unattributed >= 0, `${key}: more family detail than class hits is a recording bug`);
+    }
+    assert.equal(report.web_vs_mcp.today.ai_agent_hits, report.today.ai_agent_by_trigger.total);
+  });
+
+  it("a coding agent is counted apart from the plain user family it shares a token with", async () => {
+    await boot();
+    recordEach([[AGENT_UA.claudeUser, 4], [AGENT_UA.claudeCode, 6]]);
+
+    const window = getTrafficReport().today;
+    assert.equal(window.ai_agent_by_family["Claude-Code"], 6, "the coding-agent family must be reachable in recorded data");
+    assert.equal(window.ai_agent_by_family["Claude-User"], 4);
+    assert.equal(window.by_class.ai_agent, 10);
+    assert.equal(window.ai_agent_by_trigger.user_initiated, 10, "both are user-initiated; the point is they are separable");
+  });
+
+  it("hits older than the family detail window are unattributed, not dropped and not guessed", async () => {
+    const day = (back: number) => new Date(Date.now() - back * 86400000).toISOString().slice(0, 10);
+    redis.values.set(
+      PAGE_VIEWS_KEY,
+      JSON.stringify({
+        days: {},
+        referrers: {},
+        all_time: {},
+        classes: { [day(0)]: { ai_agent: 30 }, [day(20)]: { ai_agent: 500 } },
+        families: { [day(0)]: { "ChatGPT-User": 10, Amazonbot: 20 } },
+        class_routes: {},
+        not_found: {},
+        redirects: {},
+        mcp: {},
+        updated_at: "",
+      }),
+    );
+    await boot();
+
+    const report = getTrafficReport();
+    assert.equal(report.last_7d.by_class.ai_agent, 30);
+    assert.equal(report.last_7d.ai_agent_by_trigger.unattributed, 0, "inside the detail window every hit has a family");
+
+    const long = report.last_30d;
+    assert.equal(long.by_class.ai_agent, 530);
+    assert.equal(long.ai_agent_by_trigger.total, 530);
+    assert.equal(long.ai_agent_by_trigger.user_initiated, 10);
+    assert.equal(long.ai_agent_by_trigger.automated, 20);
+    assert.equal(long.ai_agent_by_trigger.unattributed, 500, "the class-only days are named, not silently absent");
+    assert.ok(
+      long.detail_days < long.days,
+      "this window keeps class history longer than family history — that is what makes the remainder real",
+    );
+  });
+
+  it("a family carrying no rule is unattributed rather than folded into a group", async () => {
+    redis.values.set(
+      PAGE_VIEWS_KEY,
+      JSON.stringify({
+        days: {},
+        referrers: {},
+        all_time: {},
+        classes: { [today()]: { ai_agent: 12 } },
+        families: { [today()]: { "ChatGPT-User": 4, unknown: 8 } },
+        class_routes: {},
+        not_found: {},
+        redirects: {},
+        mcp: {},
+        updated_at: "",
+      }),
+    );
+    await boot();
+
+    const split = getTrafficReport().today.ai_agent_by_trigger;
+    assert.equal(split.user_initiated, 4);
+    assert.equal(split.automated, 0);
+    assert.equal(split.ambiguous, 0, "an overflow bucket is not evidence of an ambiguous trigger");
+    assert.equal(split.unattributed, 8);
+    assert.equal(split.user_initiated + split.automated + split.ambiguous + split.unattributed, split.total);
+  });
+
+  it("publishes which families are in which group, from the table the labels come from", async () => {
+    await boot();
+    const report = getTrafficReport();
+    const groups = report.ai_agent_trigger_families;
+    assert.ok(groups.user_initiated.includes("Claude-Code"));
+    assert.ok(groups.user_initiated.includes("Claude-User"));
+    assert.ok(groups.search_index.includes("Amazonbot") && groups.search_index.includes("PerplexityBot"));
+    assert.ok(groups.training.includes("Bytespider") && groups.training.includes("CCBot"));
+    assert.ok(groups.ambiguous.includes("DuckAssistBot"));
+
+    const flat = Object.values(groups).flat();
+    assert.equal(new Set(flat).size, flat.length, "a family in two groups would double-count");
+    for (const family of Object.keys(report.today.ai_agent_by_family)) {
+      assert.ok(flat.includes(family) || family === "unknown", `${family} was recorded and is in no published group`);
+    }
+  });
+
+  it("publishes the grouping even when the counters are unreadable — it describes the table, not the data", async () => {
+    redis.failWith = "ERR max requests limit exceeded";
+    await loadTelemetry(telemetryFile);
+    redis.reset();
+
+    const report = getTrafficReport();
+    assert.equal(report.available, false, "this is the branch a storage outage serves");
+    assert.deepStrictEqual(report.ai_agent_trigger_families, agentFamiliesByTrigger());
+    assert.ok(report.ai_agent_trigger_families.user_initiated.includes("Claude-Code"));
+    for (const key of ["today", "last_7d", "last_30d"] as const) {
+      const split = report[key].ai_agent_by_trigger;
+      assert.equal(split.total, 0, `${key}: no measurement is zero, not a guess`);
+      assert.equal(split.user_initiated + split.automated + split.ambiguous + split.unattributed, 0);
+    }
+  });
+
+  it("counts nothing differently — the class values and family labels are untouched", async () => {
+    await boot();
+    recordEach([[AGENT_UA.chatgptUser, 5], [AGENT_UA.amazonbot, 3], [UA.chrome, 9], [UA.curl, 2]]);
+
+    const window = getTrafficReport().today;
+    assert.equal(window.hits_total, 19);
+    assert.equal(window.by_class.ai_agent, 8);
+    assert.equal(window.by_class.browser, 9);
+    assert.equal(window.by_class.sdk_client, 2);
+    assert.deepStrictEqual(window.ai_agent_by_family, { "ChatGPT-User": 5, Amazonbot: 3 });
+  });
+
+  it("the notes stop bounding maintainer traffic out of ai_agent_hits and name the tooling families", async () => {
+    await boot();
+    const notes = getTrafficReport().notes;
+    const joined = notes.join("\n");
+    assert.ok(
+      !/never\s+ai_agent_hits/.test(joined),
+      "the endpoint used to promise maintainer traffic could not reach this counter, and coding agents break that promise",
+    );
+    assert.match(joined, /Claude-Code/);
+    assert.match(joined, /agent-scraper/);
+    assert.match(joined, /ai_agent_by_trigger/);
+    assert.match(joined, /unattributed/);
+    for (const note of notes) assert.ok(note.length > 40, `a note this short states nothing: ${note}`);
   });
 });


### PR DESCRIPTION
Refs #1449

## What was wrong

`src/client-class.ts` is first-match-wins, and `Claude-User` was tested before `claude-code`. Claude Code's real user agent carries **both** tokens:

```
Claude-User (claude-code/2.1.260; +https://support.anthropic.com/)
```

So every Claude Code request was filed as `Claude-User`, and `Claude-Code` could only ever fire for a string carrying `claude-code` *without* `Claude-User` — which is not a string Claude Code sends. `Claude-Code` read 3 for the week against `Claude-User`'s 997.

The existing test passed because its fixture was `claude-code/2.1.4 (external, cli)`, a synthetic string that carries only one of the two tokens. The new tests use the three observed strings from `/api/query-log`.

## What it publishes now

`/api/traffic` gains `ai_agent_by_trigger` per window and `ai_agent_trigger_families` once. Against production's snapshot as of 21:00Z:

| window | total | user_initiated | automated | ambiguous | unattributed |
|---|---|---|---|---|---|
| today | 2,372 | 316 | 2,055 (index 895 / training 1,160) | 1 | 0 |
| last_7d | 11,803 | 1,909 | 9,887 (index 7,626 / training 2,261) | 7 | 0 |
| last_30d | 19,345 | 1,909 | 9,887 | 7 | 7,542 |

The seven-day headline overstates user-initiated demand **6.2x**, reproducing the issue's 6.1x on a window a few hours further on.

## Three decisions worth naming

**The 30-day window could not sum, and that is now visible rather than hidden.** Class counts are retained 30 days, family detail 7 (`CLASS_DAY_RETENTION` vs `PAGE_VIEW_DAY_RETENTION`). So `ai_agent_by_family` sums to 11,803 while `by_class.ai_agent` reads 19,345 — a 39% shortfall that a naive split would have published as a total. `unattributed` carries that remainder by construction, so the four groups partition the class total exactly. A family with no rule lands there too, rather than being guessed into `ambiguous`.

**`Claude-Code` is grouped `user_initiated`, and the note says why that is an upper bound.** The issue's own table puts it there, and Claude Code is normally a person's tool. But this project's automation uses it, so the group is not a clean demand figure. AC-5 asked the `notes` to stop promising maintainer traffic can never reach `ai_agent_hits`; the replacement names `Claude-Code` and `agent-scraper` as the two families that carry agent tooling and says to read them as an upper bound. One field flips the grouping if you would rather it read `ambiguous`.

**AC-2's property does not catch AC-1's bug, and I did not stretch it to pretend otherwise.** Reachability builds a candidate string from each rule's own pattern and asserts it reaches that rule's family. `claude-code` alone does reach `Claude-Code` — the bug only appears in a composite string a vendor happens to send. So the property guards the general case (a broader rule inserted above an existing one) and a separate test pins the observed strings. The expander throws on any regex construct it does not understand, so a new rule cannot be silently skipped.

## Verification

- **4,338 tests.** 27 new. The 3 failures on this branch are the same 3 that fail on clean `main` at `e152fef` — `test/stale-page-facts.test.ts`, `stale_fact_pages` measured 58 against a budget of 57, from today's 20:01Z data push. Reported separately; no `Tests` run has executed against `e152fef` yet.
- **Mutation: 14/14 killed** (`scripts/mutate-1449.mjs`). One survived the first run — the Redis-unavailable branch published the grouping with no test on it, which is a real production state. Test added.
- **End to end over the wire**, not just unit tests: a server against a stub Upstash, 22 requests in 6 real agent user agents, read back through `GET /api/traffic`. `Claude-Code: 5` separated from `Claude-User: 3`, split `10 + 11 + 1 + 0 = 22 = by_class.ai_agent`, and `web_vs_mcp.ai_agent_hits` agrees with the split total.
- **Nothing is counted differently.** No `client_class` value, `hits_total` or family label moves. `by_class`, `hits_total` and `ai_agent_by_family` are asserted unchanged.

## Incidental

`src/stats.ts` had no local imports until now, so eight test files loaded it as `../src/stats.ts` and broke under type-stripping once it imported `./client-class.js`. They now load `../dist/stats.js`, which is what `test/traffic-attribution.test.ts` already did for the same module and what every other test does for a module with local imports.

## Reported, not fixed

`TikTokSpider` classifies as **`browser` / `safari`**. It matches the Safari rule, and the generic-bot fallback misses it because `\b(spider)\b` needs a word boundary the vendor did not leave — `TikTokSpider` and `ttspider-feedback` both glue it to the preceding token. `SleepBot/1.0` is caught only because `bot/` matches. That inflates `browser`, not `ai_agent`, so it is outside this issue's scope and outside AC-6 — a self-declared crawler counted as a human is worth its own issue.