### PR TITLE
Correct the Nhost storage figure our own record now contradicts (#1367)

### DIFF
--- a/data/index.json
+++ b/data/index.json
@@ -1128,7 +1128,7 @@
     {
       "vendor": "Nhost",
       "category": "Databases",
-      "description": "Open-source Firebase alternative with Postgres + Hasura GraphQL — 1 GB database, 5 GB storage, 5 GB bandwidth free",
+      "description": "Open-source Firebase alternative with Postgres + Hasura GraphQL — 1 GB database, 1 GB storage, 5 GB bandwidth free",
       "tier": "Free",
       "url": "https://nhost.io/pricing",
       "tags": [

--- a/data/page-reviews.json
+++ b/data/page-reviews.json
@@ -2092,10 +2092,10 @@
         "pocketbase"
       ],
       "badge_subjects_unresolved": [],
-      "reviewed_at": "2026-09-05",
+      "reviewed_at": "2026-09-07",
       "reviewer": "coder",
       "review_outcome": "pass",
-      "review_note": "Read against appwrite.io/pricing on 2026-09-05, after an Appwrite Cloud record dated 2026-09-05 moved under the 2026-09-04 review. The Free plan reads 5GB bandwidth, 2GB storage, 750K executions, 75K monthly active users, community support, 1 Database / 1 Bucket / 2 Functions per project, 15-minute builds, paused after 1 week of inactivity, and a limit of 2 projects. Every figure the Other BaaS Alternatives row already published holds; the two-project cap and the per-project database, bucket and function caps were absent, and that row renders the catalogue record, so the record was corrected rather than the prose. The Supabase and Firebase claims are unchanged since the 2026-09-04 reading and were not re-fetched.",
+      "review_note": "Read against nhost.io/pricing on 2026-09-07, after an Nhost record dated 2026-09-07 moved under the 2026-09-05 review. The Starter plan reads $0/month, a limit of 1 project, the project paused after 1 week of inactivity, 1 GB database, 1 GB storage and 5 GB egress. The comparison table gave Nhost 5 GB File Storage and the catalogue description said the same; the vendor gives 1 GB, so both were corrected. Database (1 GB) and Bandwidth (5 GB) already matched. The one-project limit and the inactivity pause are stated by neither surface and the table has no column for either. The Appwrite Cloud, Supabase, Firebase, PocketBase and Convex claims are unchanged since the 2026-09-05 reading and were not re-fetched.",
       "reads_index": true,
       "reads_changes": true,
       "data_source": "catalogue",

--- a/src/serve.ts
+++ b/src/serve.ts
@@ -5863,7 +5863,7 @@ const ALTERNATIVES_PAGES: AlternativesPageConfig[] = [
       </tr>
       <tr>
         <td style="font-weight:600"><a href="/vendor/nhost" style="color:var(--text)">Nhost</a></td>
-        <td>1 GB Postgres</td><td>5 GB</td><td>Included</td><td>Included</td><td>5 GB</td><td>\u2705 (GraphQL)</td>
+        <td>1 GB Postgres</td><td>1 GB</td><td>Included</td><td>Included</td><td>5 GB</td><td>\u2705 (GraphQL)</td>
         <td>MIT</td>
       </tr>
       <tr>

--- a/test/baas-comparison-figures.test.ts
+++ b/test/baas-comparison-figures.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, before, after } from "node:test";
+import assert from "node:assert";
+import { spawn, type ChildProcess } from "node:child_process";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const root = path.join(__dirname, "..");
+
+const offers = JSON.parse(readFileSync(path.join(root, "data", "index.json"), "utf-8")).offers as Array<Record<string, any>>;
+const changes = JSON.parse(readFileSync(path.join(root, "data", "deal_changes.json"), "utf-8")).changes as Array<Record<string, any>>;
+
+const recordFor = (vendor: string) => offers.find((o) => o.vendor === vendor)!;
+const newestChangeFor = (vendor: string) =>
+  changes.filter((c) => c.vendor === vendor).sort((a, b) => String(a.date).localeCompare(String(b.date))).at(-1);
+
+const ENTITIES: Record<string, string> = {
+  "&mdash;": "—", "&ndash;": "–", "&amp;": "&", "&quot;": '"', "&#39;": "'",
+  "&nbsp;": " ", "&lt;": "<", "&gt;": ">", "&rarr;": "→",
+};
+
+function readableText(html: string): string {
+  return html
+    .replace(/<(script|style|svg)\b[\s\S]*?<\/\1>/gi, " ")
+    .replace(/<[^>]+>/g, " ")
+    .replace(/&[a-z#0-9]+;/gi, (e) => ENTITIES[e] ?? e)
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function startServer(): Promise<ChildProcess> {
+  return new Promise((resolve, reject) => {
+    const proc = spawn("node", [path.join(root, "dist", "serve.js")], {
+      stdio: ["pipe", "pipe", "pipe"],
+      env: { ...process.env, PORT: "0", BASE_URL: "http://localhost", TZ: "UTC" },
+    });
+    const timeout = setTimeout(() => { proc.kill(); reject(new Error("Server startup timeout")); }, 20000);
+    proc.stderr!.on("data", (data: Buffer) => {
+      const match = data.toString().match(/running on http:\/\/localhost:(\d+)/);
+      if (match) { base = `http://localhost:${match[1]}`; clearTimeout(timeout); resolve(proc); }
+    });
+    proc.on("error", (err) => { clearTimeout(timeout); reject(err); });
+  });
+}
+
+let server: ChildProcess;
+let base = "";
+const pages: Record<string, string> = {};
+
+const NHOST_STORAGE_GB = () => {
+  const stated = recordFor("Nhost").description.match(/(\d+(?:\.\d+)?) GB storage/i);
+  assert.ok(stated, `the Nhost record no longer states a storage allowance: ${recordFor("Nhost").description}`);
+  return stated![1];
+};
+
+describe("the BaaS comparisons state the free limits our own record holds (#1367)", () => {
+  before(async () => {
+    server = await startServer();
+    for (const slug of ["firebase-alternatives", "supabase-vs-firebase"]) {
+      pages[slug] = readableText(await (await fetch(`${base}/${slug}`)).text());
+    }
+  });
+
+  after(() => { server?.kill(); });
+
+  it("gives Nhost the storage its record states in the hand-written comparison table", () => {
+    const row = pages["firebase-alternatives"].match(/Nhost (1 GB Postgres [^]{1,60}?) MIT/);
+    assert.ok(row, "the comparison table no longer carries an Nhost row");
+    assert.strictEqual(
+      row![1],
+      `1 GB Postgres ${NHOST_STORAGE_GB()} GB Included Included 5 GB ✅ (GraphQL)`,
+      "the hand-written row and the catalogue record state different free limits",
+    );
+  });
+
+  it("gives Nhost the same storage on the page that renders the record rather than a table", () => {
+    assert.match(pages["supabase-vs-firebase"], new RegExp(`Nhost Free [^]{0,120}?${NHOST_STORAGE_GB()} GB storage`));
+  });
+
+  it("keeps the record's figures in step with the newest change record we hold for that vendor", () => {
+    const record = recordFor("Nhost");
+    const change = newestChangeFor("Nhost");
+    assert.ok(change?.current_state, "no Nhost change record states a current tier");
+    for (const field of ["database", "storage"] as const) {
+      const inChange = String(change!.current_state).match(new RegExp(`(\\d+(?:\\.\\d+)?) GB ${field}`, "i"));
+      const inRecord = record.description.match(new RegExp(`(\\d+(?:\\.\\d+)?) GB ${field}`, "i"));
+      assert.ok(inChange && inRecord, `${field} is stated by only one of the two: ${change!.current_state} / ${record.description}`);
+      assert.strictEqual(
+        inRecord![1],
+        inChange![1],
+        `the catalogue gives Nhost ${inRecord![1]} GB ${field} and our own ${change!.date} record gives ${inChange![1]} GB`,
+      );
+    }
+  });
+
+  it("publishes the withdrawn storage figure on neither page", () => {
+    for (const [slug, text] of Object.entries(pages)) {
+      assert.doesNotMatch(text, /Nhost 1 GB Postgres 5 GB/, slug);
+      assert.doesNotMatch(text, /Nhost Free [^]{0,120}?5 GB storage/, slug);
+    }
+  });
+});


### PR DESCRIPTION
Refs #1367
Refs #1378

`main` is red. Today's 20:01Z data run pushed `e152fef`, which recorded an Nhost restriction, and `test/stale-page-facts.test.ts` went to **58 against a budget of 57**. No `Tests` run has executed against `e152fef` — a scheduled push carries no `tests.yml` run behind it — so this PR is the first place the redness surfaces. Confirmed on a clean worktree at `e152fef`: 3 failing tests, all in that file, before any change of mine.

## The entrant, and what it turned out to be

`/supabase-vs-firebase` entered the stale-fact cohort, on one fact: `nhost`, record dated 2026-09-07.

```
Nhost · restriction · 2026-09-07 · discovered
"The free tier now pauses projects after 1 week of inactivity."
current_state: Starter is free forever with a limit of 1 project. The project will be
paused after 1 week of inactivity. It includes 1 GB database, 1 GB storage, and 5 GB egress.
```

Read against `nhost.io/pricing` today, the vendor's own page says exactly that:

> **Starter** — $0/month — Limit of 1 project. Project paused after 1 week of inactivity. **1 GB database, 1 GB storage, 5 GB egress**

**Two of our surfaces said 5 GB storage.** The hand-written comparison table on `/firebase-alternatives` gave Nhost `1 GB Postgres | 5 GB | Included | Included | 5 GB`, and the catalogue description said `1 GB database, 5 GB storage, 5 GB bandwidth free` — which is the text `/supabase-vs-firebase` renders. Database and bandwidth already matched; storage was wrong by 5x on both. Both now read 1 GB.

## Two things worth naming

**The flagged page was not the page with the wrong table.** `/supabase-vs-firebase` renders the catalogue record, so correcting the record is what fixes it — the same shape as the Appwrite Cloud entry cleared in #1368. The 5 GB *table* lives on `/firebase-alternatives`, which the cohort did not flag. I found it because I went looking for every surface stating the figure rather than only the one the budget named. Fixing one and not the other would have left two of our own pages disagreeing about Nhost.

**I did not write the pause or the project cap onto either page.** The record states both; the table has no column for either and the description does not mention them. Adding them is new prose about a vendor, which is a copy decision rather than a figure correction, so it is flagged here rather than made.

## Verification

- `stale_fact_pages` measured **58 → 57**, against an unchanged budget of 57. No budget raised; `npm run ratchet:budgets` writes nothing.
- **Full suite 4,326 pass, 0 fail** on this branch rebased onto `e152fef`. The three failures that are on `main` right now are gone.
- New `test/baas-comparison-figures.test.ts` (4 tests) fetches both pages from a running server and asserts each Nhost figure against the catalogue record, and the record against the newest change record we hold for that vendor. Reverting either surface to 5 GB fails 2 of the 4 — checked, not assumed.
- `/supabase-vs-firebase` is recorded as read, with a note naming what was fetched, which figures held, and which claims were not re-fetched.