### PR TITLE
Publish how often a removed free tier came back, not that none ever has (#1453)

### DIFF
--- a/scripts/mutate-1453.mjs
+++ b/scripts/mutate-1453.mjs
@@ -1,0 +1,89 @@
+import { readFileSync, writeFileSync } from "node:fs";
+import { execFileSync } from "node:child_process";
+
+const SUITE = ["test/removal-durability.test.ts"];
+
+const MUTANTS = [
+  ["the-executive-summary-calls-every-removal-permanent-again", "src/serve.ts",
+    "${escHtmlServer(lastingExamples.map(e => e.vendor).join(\", \"))}, and more. ${escHtmlServer(removalReturnRateSentence(durability))}",
+    "Heroku, PlanetScale, SendGrid, Brave Search API, X API, and more. Once removed, none have returned."],
+  ["the-key-pattern-callout-calls-every-removal-permanent-again", "src/serve.ts",
+    "<strong>Key pattern:</strong> ${escHtmlServer(removalDurabilityPattern(durability, lastingExamples))} Plan your architecture",
+    "<strong>Key pattern:</strong> Once a free tier is removed, it never comes back. Heroku (2022), PlanetScale (2024), SendGrid (2025), Brave Search (2026), X API (2026) &mdash; all permanent. Plan your architecture"],
+  ["the-named-examples-are-written-out-rather-than-read-off-the-log", "src/serve.ts",
+    "  const lastingExamples = lastingRemovalExamplesFor(\"/state-of-free-tiers\", dealChanges);",
+    "  const lastingExamples = [\"Heroku\", \"PlanetScale\", \"SendGrid\", \"Brave Search API\", \"X API (Twitter)\"].map(vendor => ({ vendor, date: \"2022-11-28\", year: \"2022\" }));"],
+  ["the-key-pattern-names-no-example-at-all", "src/serve.ts",
+    "${escHtmlServer(removalDurabilityPattern(durability, lastingExamples))}",
+    "${escHtmlServer(removalDurabilityPattern(durability, []))}"],
+  ["a-reversal-recorded-in-the-resolution-field-is-not-a-return", "src/removal-durability.ts",
+    "  if (removal.resolution?.state === \"reversed\") {",
+    "  if (removal.resolution?.state === \"retracted\") {"],
+  ["a-return-only-our-own-later-record-shows-is-missed", "src/removal-durability.ts",
+    "      .filter(\n        (c) =>\n          c.vendor === removal.vendor &&",
+    "      .filter(\n        (c) =>\n          false &&\n          c.vendor === removal.vendor &&"],
+  ["a-retracted-record-is-counted-as-a-removal-that-came-back", "src/removal-durability.ts",
+    "  if (theEventNeverHappened(removal)) return null;\n  if (removal.resolution?.state === \"reversed\") {",
+    "  if (theEventNeverHappened(removal)) {\n    return { basis: \"resolution\", date: removal.resolution!.date, detail: null };\n  }\n  if (removal.resolution?.state === \"reversed\") {"],
+  ["a-record-we-retracted-still-counts-as-a-removal-we-stand-behind", "src/removal-durability.ts",
+    "  const weStandBehind = recorded.filter((r) => !theEventNeverHappened(r));",
+    "  const weStandBehind = recorded;"],
+  ["an-expansion-dated-before-the-removal-reads-as-a-return", "src/removal-durability.ts",
+    "          c.date > removal.date &&",
+    "          c.date !== removal.date &&"],
+  ["another-vendor-expanding-reads-as-this-vendor-returning", "src/removal-durability.ts",
+    "          c.vendor === removal.vendor &&\n          c.date > removal.date &&",
+    "          c.date > removal.date &&"],
+  ["a-later-cut-reads-as-a-return", "src/removal-durability.ts",
+    "          CHANGE_DIRECTION[c.change_type as DealChange[\"change_type\"]] === \"positive\",",
+    "          CHANGE_DIRECTION[c.change_type as DealChange[\"change_type\"]] !== \"neutral\","],
+  ["the-return-rate-is-published-without-naming-anyone", "src/removal-durability.ts",
+    "  return `${durability.cameBack.length} of the ${standBehind} removals we stand behind have since come back: ${vendorsThatCameBack(durability)}.${retractionClause(durability)}`;",
+    "  return `${durability.cameBack.length} of the ${standBehind} removals we stand behind have since come back.${retractionClause(durability)}`;"],
+  ["a-vendor-that-came-back-may-still-be-named-as-lasting", "src/removal-durability.ts",
+    "    (removal) => !theEventNeverHappened(removal) && !theFreeTierCameBackAfter(removal, log),",
+    "    (removal) => !theEventNeverHappened(removal),"],
+  ["only-a-vendors-first-removal-is-checked-before-naming-it", "src/removal-durability.ts",
+    "  const everyOneHeld = removals.every(",
+    "  const everyOneHeld = removals.slice(0, 1).every("],
+  ["the-scan-for-permanence-claims-sees-nothing", "src/removal-durability.ts",
+    "  return REMOVAL_PERMANENCE_ASSERTIONS.some((pattern) => pattern.test(text));",
+    "  return false;"],
+  ["the-scan-fires-on-any-use-of-the-word-permanent", "src/removal-durability.ts",
+    "const REMOVAL_PERMANENCE_ASSERTIONS = [",
+    "const REMOVAL_PERMANENCE_ASSERTIONS = [\n  /\\bpermanent\\b/i,"],
+];
+
+function run(cmd, args) {
+  try {
+    execFileSync(cmd, args, { stdio: "pipe", encoding: "utf-8" });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+const survivors = [];
+const uncompiled = [];
+const skipped = [];
+for (const [name, file, from, to] of MUTANTS) {
+  const original = readFileSync(file, "utf-8");
+  if (!original.includes(from)) {
+    console.log(`SKIP  ${name} — the line it mutates is not in ${file}`);
+    skipped.push(name);
+    continue;
+  }
+  writeFileSync(file, original.replace(from, to));
+  const built = run("npm", ["run", "build"]);
+  const green = built && run("node", ["--test", "--test-concurrency", "1", ...SUITE]);
+  writeFileSync(file, original);
+  if (!built) uncompiled.push(name);
+  console.log(`${green ? "SURVIVED" : built ? "killed  " : "DID NOT COMPILE"}  ${name}`);
+  if (green) survivors.push(name);
+}
+run("npm", ["run", "build"]);
+const killed = MUTANTS.length - survivors.length - uncompiled.length - skipped.length;
+console.log(`\n${killed}/${MUTANTS.length} killed`);
+if (survivors.length > 0) console.log("survivors:", survivors.join(", "));
+if (uncompiled.length > 0) console.log("did not compile:", uncompiled.join(", "));
+if (skipped.length > 0) console.log("skipped — target string moved, so these scored nothing:", skipped.join(", "));

--- a/src/removal-durability.ts
+++ b/src/removal-durability.ts
@@ -1,0 +1,189 @@
+import type { DealChange } from "./types.js";
+import { CHANGE_DIRECTION } from "./change-direction.js";
+import { theEventNeverHappened } from "./change-resolution.js";
+
+export const FREE_TIER_REMOVED = "free_tier_removed";
+
+export type RemovalCandidate = Pick<DealChange, "vendor" | "change_type" | "date"> & {
+  summary?: string;
+  resolution?: DealChange["resolution"];
+};
+
+export type ReturnEvidence =
+  | { basis: "resolution"; date: string; detail: string | null }
+  | { basis: "later_record"; date: string; changeType: string; summary: string };
+
+export interface ReturnedRemoval {
+  removal: RemovalCandidate;
+  evidence: ReturnEvidence;
+}
+
+export interface RemovalDurability {
+  recorded: RemovalCandidate[];
+  retracted: RemovalCandidate[];
+  weStandBehind: RemovalCandidate[];
+  cameBack: ReturnedRemoval[];
+  stillInForce: RemovalCandidate[];
+}
+
+export function isAFreeTierRemoval(change: Pick<DealChange, "change_type">): boolean {
+  return change.change_type === FREE_TIER_REMOVED;
+}
+
+function laterPositiveRecordForTheSameVendor<T extends RemovalCandidate>(
+  removal: RemovalCandidate,
+  log: readonly T[],
+): T | null {
+  return (
+    log
+      .filter(
+        (c) =>
+          c.vendor === removal.vendor &&
+          c.date > removal.date &&
+          CHANGE_DIRECTION[c.change_type as DealChange["change_type"]] === "positive",
+      )
+      .sort((a, b) => a.date.localeCompare(b.date))[0] ?? null
+  );
+}
+
+export function theFreeTierCameBackAfter<T extends RemovalCandidate>(
+  removal: RemovalCandidate,
+  log: readonly T[],
+): ReturnEvidence | null {
+  if (theEventNeverHappened(removal)) return null;
+  if (removal.resolution?.state === "reversed") {
+    return { basis: "resolution", date: removal.resolution.date, detail: removal.resolution.detail ?? null };
+  }
+  const later = laterPositiveRecordForTheSameVendor(removal, log);
+  if (!later) return null;
+  return { basis: "later_record", date: later.date, changeType: later.change_type, summary: later.summary ?? "" };
+}
+
+export function removalDurability<T extends RemovalCandidate>(log: readonly T[]): RemovalDurability {
+  const recorded = log.filter(isAFreeTierRemoval);
+  const retracted = recorded.filter(theEventNeverHappened);
+  const weStandBehind = recorded.filter((r) => !theEventNeverHappened(r));
+  const cameBack: ReturnedRemoval[] = [];
+  const stillInForce: RemovalCandidate[] = [];
+  for (const removal of weStandBehind) {
+    const evidence = theFreeTierCameBackAfter(removal, log);
+    if (evidence) cameBack.push({ removal, evidence });
+    else stillInForce.push(removal);
+  }
+  return { recorded, retracted, weStandBehind, cameBack, stillInForce };
+}
+
+export interface RemovalNamedAsLasting {
+  vendor: string;
+  route: string;
+}
+
+export const REMOVALS_PAGES_NAME_AS_LASTING: readonly RemovalNamedAsLasting[] = [
+  { vendor: "Heroku", route: "/state-of-free-tiers" },
+  { vendor: "PlanetScale", route: "/state-of-free-tiers" },
+  { vendor: "SendGrid", route: "/state-of-free-tiers" },
+  { vendor: "Brave Search API", route: "/state-of-free-tiers" },
+  { vendor: "X API (Twitter)", route: "/state-of-free-tiers" },
+  { vendor: "SendGrid", route: "/email-comparison-2026" },
+];
+
+export interface LastingRemovalExample {
+  vendor: string;
+  date: string;
+  year: string;
+}
+
+export function removalsRecordedFor<T extends RemovalCandidate>(vendor: string, log: readonly T[]): T[] {
+  return log
+    .filter((c) => isAFreeTierRemoval(c) && c.vendor === vendor)
+    .sort((a, b) => a.date.localeCompare(b.date));
+}
+
+export function removalNamedOn<T extends RemovalCandidate>(vendor: string, log: readonly T[]): T | null {
+  return removalsRecordedFor(vendor, log)[0] ?? null;
+}
+
+export function removalStillLasting<T extends RemovalCandidate>(
+  vendor: string,
+  log: readonly T[],
+): LastingRemovalExample | null {
+  const removals = removalsRecordedFor(vendor, log);
+  if (removals.length === 0) return null;
+  const everyOneHeld = removals.every(
+    (removal) => !theEventNeverHappened(removal) && !theFreeTierCameBackAfter(removal, log),
+  );
+  if (!everyOneHeld) return null;
+  const first = removals[0]!;
+  return { vendor: first.vendor, date: first.date, year: first.date.slice(0, 4) };
+}
+
+export function lastingRemovalExamplesFor<T extends RemovalCandidate>(
+  route: string,
+  log: readonly T[],
+): LastingRemovalExample[] {
+  return REMOVALS_PAGES_NAME_AS_LASTING.filter((named) => named.route === route)
+    .map((named) => removalStillLasting(named.vendor, log))
+    .filter((example): example is LastingRemovalExample => example !== null);
+}
+
+function namesInASentence(names: readonly string[]): string {
+  if (names.length <= 1) return names[0] ?? "";
+  return `${names.slice(0, -1).join(", ")} and ${names[names.length - 1]}`;
+}
+
+function vendorsThatCameBack(durability: RemovalDurability): string {
+  return namesInASentence([...new Set(durability.cameBack.map((r) => r.removal.vendor))].sort());
+}
+
+function retractionClause(durability: RemovalDurability): string {
+  const retracted = durability.retracted.length;
+  if (retracted === 0) return "";
+  const subject = retracted === 1 ? "record we have retracted" : "records we have retracted";
+  return ` The other ${retracted} of the ${durability.recorded.length} are ${subject} — removals we now say did not happen.`;
+}
+
+export function removalReturnRateSentence(durability: RemovalDurability): string {
+  const standBehind = durability.weStandBehind.length;
+  if (durability.cameBack.length === 0) {
+    return `None of the ${standBehind} removals we stand behind has come back so far.${retractionClause(durability)}`;
+  }
+  return `${durability.cameBack.length} of the ${standBehind} removals we stand behind have since come back: ${vendorsThatCameBack(durability)}.${retractionClause(durability)}`;
+}
+
+function spanOfExamples(examples: readonly LastingRemovalExample[]): string {
+  const years = examples.map((e) => e.year).sort();
+  const first = years[0];
+  const last = years[years.length - 1];
+  return first === last ? `recorded in ${first}` : `recorded from ${first} to ${last}`;
+}
+
+export function removalDurabilityPattern(
+  durability: RemovalDurability,
+  examples: readonly LastingRemovalExample[],
+): string {
+  const held = durability.stillInForce.length;
+  const standBehind = durability.weStandBehind.length;
+  const named =
+    examples.length > 0
+      ? `, including ${namesInASentence(examples.map((e) => e.vendor))} — ${spanOfExamples(examples)}`
+      : "";
+  if (durability.cameBack.length === 0) {
+    return `Removal has held on every one of the ${standBehind} removals we stand behind${named}.`;
+  }
+  return `Removal usually holds. ${held} of the ${standBehind} removals we stand behind are still in force${named}. It is a rate, not a rule — ${durability.cameBack.length} have come back: ${vendorsThatCameBack(durability)}.`;
+}
+
+const REMOVAL_PERMANENCE_ASSERTIONS = [
+  /\bonce (?:a free tier is )?removed\b[^.]*\bnever\b/i,
+  /\bnone (?:have|has) (?:ever )?returned\b/i,
+  /\bnever comes? back\b/i,
+  /\bnever (?:been )?(?:returned|reinstated|reversed|restored)\b/i,
+  /\ball permanent\b/i,
+  /\bremovals? (?:is|are) (?:always )?permanent\b/i,
+  /\bno (?:removed )?free tier (?:has|have) (?:ever )?(?:returned|come back)\b/i,
+];
+
+export function prosePutsRemovalBeyondReturn(text: string | null | undefined): boolean {
+  if (!text) return false;
+  return REMOVAL_PERMANENCE_ASSERTIONS.some((pattern) => pattern.test(text));
+}

--- a/src/serve.ts
+++ b/src/serve.ts
@@ -38,6 +38,7 @@ import { HETZNER_APRIL_CHANGES, HETZNER_CLOUD_PLANS, HETZNER_PRICES_READ, HETZNE
 import { HUNDRED_TB_SCENARIO, ONE_TO_ONE_SCENARIO, STORAGE_RATES_READ, STORAGE_SCALE_WORKLOADS, TEN_TO_ONE_SCENARIO, cheapestProviderAt, costliestProviderAt, egressAllowanceSentence, egressBillOnceOverAllowance, egressRatioWhereCostsMatch, fixedMonthlyGrantsSentence, monthlyStorageCost, providersWithScalingEgressAllowance, rateCardFor, scaleCostFor } from "./storage-cost-model.js";
 import { changeTimelineDate, supersededLineups, supersessionNote } from "./change-lineup.js";
 import { isNoLongerInForce, eventResolutionFields } from "./change-resolution.js";
+import { removalDurability, removalReturnRateSentence, removalDurabilityPattern, lastingRemovalExamplesFor } from "./removal-durability.js";
 import { changeIsUncited, changeSourceCitation, changeSourceLinkHtml, citedChanges, uncitedChangeNotice, ratingWithheldForNoSourceClause, ratingWithheldForNoSourceSentence, UNCITED_CHANGE_LABEL } from "./change-citation.js";
 import { growthLimitPhrases } from "./growth-limits.js";
 import { registerAgent, authenticateRequest, validateVestauthUrl, hashApiKey, updateAgentX402Address, getAgentById } from "./agents.js";
@@ -45427,6 +45428,9 @@ function buildStateOfFreeTiersPage(): string {
   const negativeChanges = dealChanges.filter(c => negativeTypes.has(c.change_type)).sort((a, b) => b.date.localeCompare(a.date));
   const positiveChanges = dealChanges.filter(c => positiveTypes.has(c.change_type)).sort((a, b) => b.date.localeCompare(a.date));
 
+  const durability = removalDurability(dealChanges);
+  const lastingExamples = lastingRemovalExamplesFor("/state-of-free-tiers", dealChanges);
+
   const categoryShares = categories.map(c => {
     const census = freeTierCensus(offers.filter(o => o.category === c.name), reportServedOn);
     return {
@@ -45612,7 +45616,7 @@ ${globalNavCss()}
     <li><strong>${freeTiers.unconfirmed.toLocaleString()} recorded free tiers we cannot confirm today</strong> &mdash; the record stands, but the page we hold for it states no terms, cannot be read, or does not name the vendor. Unconfirmed is not the same as gone.</li>
     <li><strong>${freeTiers.ended} free tiers we have recorded as ended</strong> &mdash; excluded from every count above, and from every category total on this site.</li>
     <li><strong>${negativeChanges.length} negative pricing changes vs ${positiveChanges.length} positive</strong> &mdash; free tier removals and restrictions outpace expansions ${Math.round(negativeChanges.length / Math.max(positiveChanges.length, 1))}:1.</li>
-    <li><strong>${changeTypeCounts.get("free_tier_removed") ?? 0} free tiers completely removed</strong> &mdash; Heroku, PlanetScale, SendGrid, Brave Search API, X API, and more. Once removed, none have returned.</li>
+    <li><strong>${changeTypeCounts.get("free_tier_removed") ?? 0} free tiers completely removed</strong> &mdash; ${escHtmlServer(lastingExamples.map(e => e.vendor).join(", "))}, and more. ${escHtmlServer(removalReturnRateSentence(durability))}</li>
     <li><strong>Egress and overage are the real costs</strong> &mdash; storage at $0.023/GB vs egress at $0.09/GB. Cloudflare R2&rsquo;s zero-egress model is 60x cheaper than S3 at scale.</li>
     <li><strong>Open source is the safety net</strong> &mdash; in security tools, a $0 OSS stack matches $23K&ndash;$73K/yr hosted alternatives on capability.</li>
   </ul>
@@ -45665,7 +45669,7 @@ ${globalNavCss()}
   <h2>The Free Tier Squeeze: Who&rsquo;s Cutting Back</h2>
   <p class="section-desc">Of ${dealChanges.length} tracked pricing changes, ${negativeChanges.length} (${Math.round((negativeChanges.length / dealChanges.length) * 100)}%) are negative for developers &mdash; free tier removals, limit reductions, and new restrictions. The pattern is clear: as companies mature, raise prices, or get acquired, free tiers shrink.</p>
   <div class="callout callout-warn">
-    <strong>Key pattern:</strong> Once a free tier is removed, it never comes back. Heroku (2022), PlanetScale (2024), SendGrid (2025), Brave Search (2026), X API (2026) &mdash; all permanent. Plan your architecture around services with structural commitment to free tiers (open-source alternatives, cloud provider loss leaders, or developer-first companies).
+    <strong>Key pattern:</strong> ${escHtmlServer(removalDurabilityPattern(durability, lastingExamples))} Plan your architecture around services with structural commitment to free tiers (open-source alternatives, cloud provider loss leaders, or developer-first companies).
   </div>
   ${squeezeHtml}
 

--- a/test/removal-durability.test.ts
+++ b/test/removal-durability.test.ts
@@ -1,0 +1,389 @@
+import { describe, it } from "node:test";
+import assert from "node:assert";
+import { spawn, type ChildProcess } from "node:child_process";
+import { readFileSync, writeFileSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { assertPopulationFloor } from "./population-floor.ts";
+import {
+  REMOVALS_PAGES_NAME_AS_LASTING,
+  lastingRemovalExamplesFor,
+  prosePutsRemovalBeyondReturn,
+  removalDurability,
+  removalDurabilityPattern,
+  removalNamedOn,
+  removalReturnRateSentence,
+  removalStillLasting,
+  theFreeTierCameBackAfter,
+} from "../dist/removal-durability.js";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO = path.join(__dirname, "..");
+
+type LogRecord = {
+  vendor: string;
+  change_type: string;
+  date: string;
+  summary?: string;
+  resolution?: { state: string; date: string; detail?: string } | null;
+};
+
+const LOG: LogRecord[] = JSON.parse(
+  readFileSync(path.join(REPO, "data", "deal_changes.json"), "utf8"),
+).changes;
+
+const removal = (vendor: string, date: string, resolution?: LogRecord["resolution"]): LogRecord => ({
+  vendor,
+  change_type: "free_tier_removed",
+  date,
+  summary: `${vendor} withdrew its free plan`,
+  ...(resolution ? { resolution } : {}),
+});
+
+const reversedOn = (date: string) => ({ state: "reversed", date, detail: "The plan ladder opens at $0 again." });
+const retractedOn = (date: string) => ({ state: "retracted", date, detail: "This row was our error." });
+
+const later = (vendor: string, date: string, changeType: string): LogRecord => ({
+  vendor,
+  change_type: changeType,
+  date,
+  summary: `${vendor} record dated ${date}`,
+});
+
+describe("what makes a recorded removal one that came back", () => {
+  it("reads the log's own reversal as a return", () => {
+    const subject = removal("Acme", "2025-01-15", reversedOn("2026-09-06"));
+    const evidence = theFreeTierCameBackAfter(subject, [subject]);
+    assert.strictEqual(evidence?.basis, "resolution");
+    assert.strictEqual(evidence?.date, "2026-09-06");
+  });
+
+  it("reads a later positive record on the same vendor as a return the resolution field never recorded", () => {
+    const subject = removal("Acme", "2026-03-23");
+    const log = [subject, later("Acme", "2026-04-12", "limits_increased")];
+    const evidence = theFreeTierCameBackAfter(subject, log);
+    assert.strictEqual(evidence?.basis, "later_record");
+    assert.strictEqual(evidence?.date, "2026-04-12");
+  });
+
+  it("does not read a later negative record as a return", () => {
+    const subject = removal("Acme", "2026-03-23");
+    const log = [subject, later("Acme", "2026-04-12", "limits_reduced")];
+    assert.strictEqual(theFreeTierCameBackAfter(subject, log), null);
+  });
+
+  it("does not read a positive record dated before the removal as a return", () => {
+    const subject = removal("Acme", "2026-03-23");
+    const log = [subject, later("Acme", "2026-01-02", "limits_increased")];
+    assert.strictEqual(theFreeTierCameBackAfter(subject, log), null);
+  });
+
+  it("does not read another vendor's expansion as a return", () => {
+    const subject = removal("Acme", "2026-03-23");
+    const log = [subject, later("Globex", "2026-04-12", "limits_increased")];
+    assert.strictEqual(theFreeTierCameBackAfter(subject, log), null);
+  });
+
+  it("counts a retracted record as neither a removal nor a return", () => {
+    const subject = removal("Acme", "2026-04-13", retractedOn("2026-09-05"));
+    const log = [subject, later("Acme", "2026-09-07", "limits_increased")];
+    assert.strictEqual(theFreeTierCameBackAfter(subject, log), null);
+    const durability = removalDurability(log);
+    assert.strictEqual(durability.recorded.length, 1);
+    assert.strictEqual(durability.retracted.length, 1);
+    assert.strictEqual(durability.weStandBehind.length, 0);
+    assert.strictEqual(durability.cameBack.length, 0);
+    assert.strictEqual(durability.stillInForce.length, 0);
+  });
+
+  it("partitions every recorded removal into exactly one of retracted, came back, still in force", () => {
+    const durability = removalDurability(LOG);
+    assert.strictEqual(
+      durability.retracted.length + durability.cameBack.length + durability.stillInForce.length,
+      durability.recorded.length,
+    );
+    assert.strictEqual(durability.weStandBehind.length, durability.cameBack.length + durability.stillInForce.length);
+  });
+});
+
+describe("the sentences the report builds from that partition", () => {
+  it("names every vendor whose removal came back", () => {
+    const durability = removalDurability(LOG);
+    assertPopulationFloor(durability.cameBack.length, 1, "recorded removals the log says came back");
+    const sentence = removalReturnRateSentence(durability);
+    for (const returned of durability.cameBack) {
+      assert.ok(sentence.includes(returned.removal.vendor), `${returned.removal.vendor} missing from: ${sentence}`);
+    }
+  });
+
+  it("states the count against the population it was counted in", () => {
+    const durability = removalDurability(LOG);
+    const sentence = removalReturnRateSentence(durability);
+    assert.ok(sentence.includes(String(durability.cameBack.length)), sentence);
+    assert.ok(sentence.includes(String(durability.weStandBehind.length)), sentence);
+  });
+
+  it("asserts no permanence, on today's log and on a log where nothing has come back", () => {
+    const durability = removalDurability(LOG);
+    const examples = lastingRemovalExamplesFor("/state-of-free-tiers", LOG);
+    assert.strictEqual(prosePutsRemovalBeyondReturn(removalReturnRateSentence(durability)), false);
+    assert.strictEqual(prosePutsRemovalBeyondReturn(removalDurabilityPattern(durability, examples)), false);
+
+    const nothingCameBack = removalDurability([removal("Acme", "2025-01-15")]);
+    assert.strictEqual(nothingCameBack.cameBack.length, 0);
+    assert.strictEqual(prosePutsRemovalBeyondReturn(removalReturnRateSentence(nothingCameBack)), false);
+    assert.strictEqual(prosePutsRemovalBeyondReturn(removalDurabilityPattern(nothingCameBack, [])), false);
+  });
+
+  it("reads the sentences this page published before as claims of permanence", () => {
+    assert.strictEqual(
+      prosePutsRemovalBeyondReturn(
+        "87 free tiers completely removed — Heroku, PlanetScale, SendGrid, Brave Search API, X API, and more. Once removed, none have returned.",
+      ),
+      true,
+    );
+    assert.strictEqual(
+      prosePutsRemovalBeyondReturn(
+        "Key pattern: Once a free tier is removed, it never comes back. Heroku (2022), PlanetScale (2024) — all permanent.",
+      ),
+      true,
+    );
+  });
+
+  it("does not read a vendor's own trial-versus-free wording as a claim of permanence", () => {
+    for (const stored of [
+      "No permanent free tier, 45-day trial only",
+      "Permanent free tier removed, only 7-day trial. Basic $15/month",
+      "Oracle Cloud's Always Free tier is permanently free (not time-limited)",
+      "SendGrid permanently removed its free tier on May 27, 2025",
+    ]) {
+      assert.strictEqual(prosePutsRemovalBeyondReturn(stored), false, stored);
+    }
+  });
+});
+
+describe("the vendors our pages name as removals that lasted", () => {
+  it("names at least one on each page that names any", () => {
+    const routes = [...new Set(REMOVALS_PAGES_NAME_AS_LASTING.map((named) => named.route))];
+    assertPopulationFloor(routes.length, 1, "pages naming a removal as lasting");
+    for (const route of routes) {
+      assert.ok(lastingRemovalExamplesFor(route, LOG).length > 0, `${route} has no example left to name`);
+    }
+  });
+
+  it("holds a removal record for every vendor it names", () => {
+    for (const named of REMOVALS_PAGES_NAME_AS_LASTING) {
+      assert.ok(removalNamedOn(named.vendor, LOG), `${named.route} names ${named.vendor}, which has no removal record`);
+    }
+  });
+
+  it("names no vendor carrying a resolution or a later positive record", () => {
+    const durability = removalDurability(LOG);
+    const cameBack = new Set(durability.cameBack.map((r) => r.removal.vendor));
+    const retracted = new Set(durability.retracted.map((r) => r.vendor));
+    for (const named of REMOVALS_PAGES_NAME_AS_LASTING) {
+      assert.ok(!cameBack.has(named.vendor), `${named.route} names ${named.vendor}, whose free tier came back`);
+      assert.ok(!retracted.has(named.vendor), `${named.route} names ${named.vendor}, whose removal we retracted`);
+    }
+  });
+
+  it("will not name a vendor whose second removal came back, however the first one ended", () => {
+    const log = [
+      removal("Acme", "2024-01-10"),
+      removal("Acme", "2026-04-13", reversedOn("2026-09-06")),
+    ];
+    assert.strictEqual(removalStillLasting("Acme", log), null);
+    assert.strictEqual(removalStillLasting("Acme", [log[0]!])?.year, "2024");
+  });
+
+  it("drops a named vendor from the report as soon as its removal is reversed", () => {
+    const named = REMOVALS_PAGES_NAME_AS_LASTING.find((n) => n.route === "/state-of-free-tiers")!;
+    const reversed = LOG.map((c) =>
+      c.vendor === named.vendor && c.change_type === "free_tier_removed"
+        ? { ...c, resolution: reversedOn("2026-09-08") }
+        : c,
+    );
+    const examples = lastingRemovalExamplesFor("/state-of-free-tiers", reversed);
+    assert.ok(!examples.some((e) => e.vendor === named.vendor), `${named.vendor} is still named as lasting`);
+    assert.ok(
+      removalReturnRateSentence(removalDurability(reversed)).includes(named.vendor),
+      `${named.vendor} is not named among the returns`,
+    );
+  });
+});
+
+function startServer(changesPath: string | null): Promise<{ proc: ChildProcess; port: number }> {
+  return new Promise((resolve, reject) => {
+    const child = spawn("node", [path.join(REPO, "dist", "serve.js")], {
+      stdio: ["pipe", "pipe", "pipe"],
+      env: {
+        ...process.env,
+        PORT: "0",
+        BASE_URL: "http://localhost:3000",
+        ...(changesPath ? { AGENTDEALS_CHANGES_PATH: changesPath } : {}),
+      },
+    });
+    const timeout = setTimeout(() => {
+      child.kill();
+      reject(new Error("Server startup timeout"));
+    }, 40000);
+    child.stderr!.on("data", (data: Buffer) => {
+      const m = data.toString().match(/running on http:\/\/localhost:(\d+)/);
+      if (m) {
+        clearTimeout(timeout);
+        resolve({ proc: child, port: parseInt(m[1], 10) });
+      }
+    });
+    child.on("error", (err) => {
+      clearTimeout(timeout);
+      reject(err);
+    });
+  });
+}
+
+function visibleText(body: string): string {
+  return body
+    .replace(/<script[\s\S]*?<\/script>/gi, " ")
+    .replace(/<style[\s\S]*?<\/style>/gi, " ")
+    .replace(/<[^>]+>/g, " ")
+    .replace(/&mdash;/g, "—")
+    .replace(/&ndash;/g, "–")
+    .replace(/&nbsp;/g, " ")
+    .replace(/&rsquo;/g, "'")
+    .replace(/&#39;/g, "'")
+    .replace(/&quot;/g, '"')
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&amp;/g, "&")
+    .replace(/\s+/g, " ");
+}
+
+async function routesInSitemap(base: string): Promise<string[]> {
+  const index = await (await fetch(`${base}/sitemap.xml`)).text();
+  const routes = new Set<string>();
+  for (const entry of index.matchAll(/<loc>([^<]+)<\/loc>/g)) {
+    const at = new URL(entry[1]).pathname;
+    if (!/sitemap.*\.xml$/.test(at)) {
+      routes.add(at);
+      continue;
+    }
+    const nested = await (await fetch(`${base}${at}`)).text();
+    for (const page of nested.matchAll(/<loc>([^<]+)<\/loc>/g)) routes.add(new URL(page[1]).pathname);
+  }
+  return [...routes].sort();
+}
+
+function sentences(text: string): string[] {
+  return text.split(/(?<=[.!?])\s+/);
+}
+
+function claimsOfPermanence(text: string): string[] {
+  return sentences(text).filter((sentence) => prosePutsRemovalBeyondReturn(sentence));
+}
+
+function sentenceStatingRemovalsHeld(text: string, held: number, standBehind: number): string {
+  const found = sentences(text).find((sentence) => sentence.includes(`${held} of the ${standBehind} removals`));
+  assert.ok(found, `no sentence states that ${held} of ${standBehind} removals are still in force`);
+  return found;
+}
+
+describe("no page tells a reader a removed free tier cannot return", () => {
+  it("finds none on any page in the sitemap, while the log holds removals that came back", async () => {
+    assertPopulationFloor(
+      removalDurability(LOG).cameBack.length,
+      1,
+      "removals in the published log that came back, without which this property is vacuous",
+    );
+    const { proc, port } = await startServer(null);
+    try {
+      const base = `http://localhost:${port}`;
+      const routes = await routesInSitemap(base);
+      assertPopulationFloor(routes.length, 400, "routes in the sitemap this scan reads");
+      const offenders: string[] = [];
+      for (const route of routes) {
+        const response = await fetch(`${base}${route}`);
+        if (!response.ok) continue;
+        for (const claim of claimsOfPermanence(visibleText(await response.text()))) {
+          offenders.push(`${route}: ${claim.slice(0, 200)}`);
+        }
+      }
+      assert.deepStrictEqual(offenders, []);
+
+      const durability = removalDurability(LOG);
+      const report = visibleText(await (await fetch(`${base}/state-of-free-tiers`)).text());
+      const held = sentenceStatingRemovalsHeld(report, durability.stillInForce.length, durability.weStandBehind.length);
+      for (const example of lastingRemovalExamplesFor("/state-of-free-tiers", LOG)) {
+        assert.ok(held.includes(example.vendor), `${example.vendor} lasted and the report does not name it: ${held}`);
+      }
+      for (const returned of durability.cameBack) {
+        assert.ok(report.includes(returned.removal.vendor), `${returned.removal.vendor} came back and the report is silent`);
+      }
+    } finally {
+      proc.kill();
+    }
+  });
+
+  it("finds none when a fifth removal is reversed, and moves the published figures with it", async () => {
+    const standing = removalDurability(LOG).stillInForce.find(
+      (r) => !REMOVALS_PAGES_NAME_AS_LASTING.some((named) => named.vendor === r.vendor),
+    )!;
+    const before = removalDurability(LOG);
+    const reversed = LOG.map((c) =>
+      c.vendor === standing.vendor && c.change_type === "free_tier_removed" && c.date === standing.date
+        ? { ...c, resolution: reversedOn("2026-09-08") }
+        : c,
+    );
+    const after = removalDurability(reversed);
+    assert.strictEqual(after.cameBack.length, before.cameBack.length + 1);
+
+    const dir = mkdtempSync(path.join(tmpdir(), "removal-durability-"));
+    const changesPath = path.join(dir, "deal_changes.json");
+    writeFileSync(changesPath, JSON.stringify({ changes: reversed }));
+    const { proc, port } = await startServer(changesPath);
+    try {
+      const body = await (await fetch(`http://localhost:${port}/state-of-free-tiers`)).text();
+      const text = visibleText(body);
+      assert.deepStrictEqual(claimsOfPermanence(text), []);
+      assert.ok(
+        text.includes(`${after.cameBack.length} of the ${after.weStandBehind.length} removals we stand behind`),
+        `the page did not publish ${after.cameBack.length} of ${after.weStandBehind.length}`,
+      );
+      assert.ok(text.includes(standing.vendor), `${standing.vendor} came back and the page does not say so`);
+      assert.ok(
+        !text.includes(`${before.cameBack.length} of the ${before.weStandBehind.length} removals we stand behind`),
+        "the page published the figure from before the reversal",
+      );
+    } finally {
+      proc.kill();
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("stops naming a vendor as a removal that lasted once the log says it came back", async () => {
+    const named = REMOVALS_PAGES_NAME_AS_LASTING.find((n) => n.route === "/state-of-free-tiers")!;
+    const reversed = LOG.map((c) =>
+      c.vendor === named.vendor && c.change_type === "free_tier_removed"
+        ? { ...c, resolution: reversedOn("2026-09-08") }
+        : c,
+    );
+    const after = removalDurability(reversed);
+
+    const dir = mkdtempSync(path.join(tmpdir(), "removal-durability-named-"));
+    const changesPath = path.join(dir, "deal_changes.json");
+    writeFileSync(changesPath, JSON.stringify({ changes: reversed }));
+    const { proc, port } = await startServer(changesPath);
+    try {
+      const text = visibleText(await (await fetch(`http://localhost:${port}/state-of-free-tiers`)).text());
+      assert.deepStrictEqual(claimsOfPermanence(text), []);
+      const held = sentenceStatingRemovalsHeld(text, after.stillInForce.length, after.weStandBehind.length);
+      assert.ok(!held.includes(named.vendor), `${named.vendor} came back and is still named as lasting: ${held}`);
+      for (const example of lastingRemovalExamplesFor("/state-of-free-tiers", reversed)) {
+        assert.ok(held.includes(example.vendor), `${example.vendor} lasted and the report does not name it: ${held}`);
+      }
+    } finally {
+      proc.kill();
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
Refs #1453.

`/state-of-free-tiers` told developers twice that a removed free tier never returns, and built its only architectural instruction on it. Our own log holds counterexamples on three paths that share no evidence, and `uploadthing.com` publishes the $0 plan today.

Both sentences are now computed from `data/deal_changes.json` at render time.

**Executive summary**

> 87 free tiers completely removed — Heroku, PlanetScale, SendGrid, Brave Search API, X API (Twitter), and more. 3 of the 82 removals we stand behind have since come back: LocalStack, Uploadthing and xAI. The other 5 of the 87 are records we have retracted — removals we now say did not happen.

**Key pattern**

> Removal usually holds. 79 of the 82 removals we stand behind are still in force, including Heroku, PlanetScale, SendGrid, Brave Search API and X API (Twitter) — recorded from 2022 to 2026. It is a rate, not a rule — 3 have come back: LocalStack, Uploadthing and xAI. Plan your architecture around services with structural commitment to free tiers.

## The denominator is not 87, and the sentence says why

87 records carry `change_type: free_tier_removed`. Five are `retracted` — records we have said were our own error — so they are not removals whose durability can be measured. Of the 82 that remain, 3 came back:

| vendor | removed | came back | how the log knows |
|---|---|---|---|
| Uploadthing | 2025-01-15 | 2026-09-06 | `resolution.state: reversed` |
| xAI | 2026-04-13 | 2026-09-05 | `resolution.state: reversed` |
| LocalStack | 2026-03-23 | 2026-04-12 | a later `limits_increased` on the same vendor, reading *"still available as open source despite earlier discontinuation announcement"* |

Storyblok is the issue's fourth counterexample and is deliberately not in that table. Its removal is `retracted`, so under this rule it is not a removal that came back — it is a removal that did not happen. Both readings forbid the universal, which is what AC-3 asks for; only one of them belongs in a return rate.

The `87` itself is untouched. #1452's AC-1 covers page-level counts that include resolved records, and this sentence names the gap between 87 and 82 rather than restating that issue one bullet early.

## AC-4, and one instance outside this page

`REMOVALS_PAGES_NAME_AS_LASTING` in `src/removal-durability.ts` is the declared list of vendors our pages name as removals that lasted. The report renders only the entries that still qualify, so a reversal drops a vendor from the sentence without anyone remembering it was there.

It carries a sixth entry from outside the report: `/email-comparison-2026` states *"SendGrid — the most widely-used transactional email API — permanently removed its free tier on May 27, 2025."* That is the same claim about the same vendor, one page over, and it is hand-written prose that cannot self-heal. Registering it means the test fails if SendGrid's removal is ever reversed, which is when someone needs to rewrite that paragraph. Drop the entry if you would rather it went unwatched.

## What the tests hold

`test/removal-durability.test.ts`, 20 tests:

- **A rendered sweep of all 2,565 routes in the sitemap** finds no sentence asserting that a removed free tier cannot return, guarded by a population floor on the removals that came back so the property cannot pass vacuously.
- **A fifth reversal, injected through `AGENTDEALS_CHANGES_PATH`,** moves the published figures with it and still yields no permanence claim.
- **Reversing a named example** removes it from the still-in-force sentence on the rendered page and adds it to the returns.
- The scanner is checked against the two sentences this page published before, so it is not looking for nothing, and against four vendor records using *permanent* in the trial-versus-perpetual sense, so it does not fire on the log's own prose.

`scripts/mutate-1453.mjs`: 15 mutants, 15 killed.

## Reported, not fixed

The page's byline reads `Not yet reviewed`. `scripts/review-page.js` would record it, but this issue is a review someone else performed and #1452 is still open against the same page, so recording a `pass` would be false and recording a `fail` publishes *corrections outstanding* on our most-cited report. That reads like your call rather than mine.
