### PR TITLE
Publish the Vultr code that pays the reader $300, with its conditions (#1158)

### DIFF
--- a/data/index.json
+++ b/data/index.json
@@ -30672,12 +30672,12 @@
       "verifiedDate": "2026-04-13",
       "referral_program": {
         "available": true,
-        "referrer_benefit": "Up to $100 cash per referral",
-        "referee_benefit": "$100 credit",
+        "referrer_benefit": "$100 cash per verified paid signup",
+        "referee_benefit": "$300 in credit",
         "program_url": "https://www.vultr.com/docs/vultr-referral-program/",
         "type": "self-service",
         "commission_type": "one-time",
-        "notes": "Referred user must be active 30+ days and spend $35+"
+        "notes": "Referred user must be active 30+ days and have paid $100+. Terms read from the referral dashboard on 2026-08-29."
       },
       "source_check": {
         "checked": "2026-08-28",

--- a/data/platform_codes.json
+++ b/data/platform_codes.json
@@ -11,6 +11,46 @@
       "source": "platform",
       "active": true,
       "added_at": "2026-04-12"
+    },
+    {
+      "vendor": "Vultr DNS",
+      "code": "9920277-9J",
+      "referral_url": "https://www.vultr.com/?ref=9920277-9J",
+      "referrer_benefit": "$100 cash per verified paid signup",
+      "referrer_compensation": "commission",
+      "referee_benefit": "$300 in credit",
+      "restrictions": [
+        "A valid credit card or PayPal must be linked to claim the credit",
+        "Unused credit expires 30 days after signup",
+        "Vultr states this promotion is available for a limited time"
+      ],
+      "limited_time": true,
+      "terms_verified": "2026-08-29",
+      "payout_qualification": {
+        "active_days": 30,
+        "min_payments_usd": 100
+      },
+      "source": "platform",
+      "active": true,
+      "added_at": "2026-08-29"
+    },
+    {
+      "vendor": "Vultr DNS",
+      "code": "9920276",
+      "referral_url": "https://www.vultr.com/?ref=9920276",
+      "referrer_benefit": "$10 cash per verified paid signup",
+      "referrer_compensation": "commission",
+      "referee_benefit": "",
+      "restrictions": [],
+      "limited_time": false,
+      "terms_verified": "2026-08-29",
+      "payout_qualification": {
+        "active_days": 30,
+        "min_payments_usd": 10
+      },
+      "source": "platform",
+      "active": false,
+      "added_at": "2026-08-29"
     }
   ]
 }

--- a/src/platform-codes.ts
+++ b/src/platform-codes.ts
@@ -10,6 +10,11 @@ export type ReferrerCompensation = "commission" | "credit" | "none";
 
 const REFERRER_COMPENSATIONS: readonly ReferrerCompensation[] = ["commission", "credit", "none"];
 
+export interface PayoutQualification {
+  active_days: number;
+  min_payments_usd: number;
+}
+
 export interface PlatformCode {
   vendor: string;
   code: string;
@@ -18,6 +23,9 @@ export interface PlatformCode {
   referrer_compensation: ReferrerCompensation;
   referee_benefit: string;
   restrictions: string[];
+  limited_time?: boolean;
+  terms_verified?: string;
+  payout_qualification?: PayoutQualification;
   source: "platform";
   active: boolean;
   added_at: string;

--- a/src/referral-surfaces.ts
+++ b/src/referral-surfaces.ts
@@ -1,7 +1,7 @@
 import { getAllPlatformCodes, getPlatformCodeForVendor, referrerCompensationOf, restrictionsOf } from "./platform-codes.js";
-import type { ReferrerCompensation } from "./platform-codes.js";
+import type { PlatformCode, ReferrerCompensation } from "./platform-codes.js";
 import { toSlug } from "./vendor-slug.js";
-import type { Offer } from "./types.js";
+import type { Offer, Referral } from "./types.js";
 
 export type OurReferralLinkSource = "platform_code" | "offer_referral";
 
@@ -48,6 +48,39 @@ export function ourReferralLinkFor(vendorName: string, offer?: Offer | null): Ou
   }
 
   return null;
+}
+
+export interface VendorReferralAnswer {
+  vendor: string;
+  referral: {
+    code?: string;
+    url: string;
+    referee_value: string;
+    type: Referral["type"];
+    restrictions?: string[];
+  };
+}
+
+export function referralTypeOfPlatformCode(code: PlatformCode): Referral["type"] {
+  const readerIsPaid = code.referee_benefit.trim().length > 0;
+  const weArePaid = referrerCompensationOf(code) !== "none";
+  if (readerIsPaid && weArePaid) return "dual-sided";
+  return readerIsPaid ? "referee-only" : "referrer-only";
+}
+
+export function platformCodeAsVendorReferral(vendorName: string): VendorReferralAnswer | null {
+  const code = getPlatformCodeForVendor(vendorName);
+  if (!code) return null;
+  return {
+    vendor: code.vendor,
+    referral: {
+      code: code.code,
+      url: code.referral_url,
+      referee_value: code.referee_benefit,
+      type: referralTypeOfPlatformCode(code),
+      restrictions: restrictionsOf(code),
+    },
+  };
 }
 
 export function referrerDisclosureSentence(compensation: ReferrerCompensation | null): string {

--- a/src/serve.ts
+++ b/src/serve.ts
@@ -50,7 +50,8 @@ import { createRegistrationLimiter, rateLimitHeaders } from "./rate-limit.js";
 import { validateX402Address, executeTransfer, generateCorrelationId, payoutsAvailable, PAYOUTS_UNAVAILABLE_REASON } from "./x402.js";
 import { submitReferralCode, getCodesByAgent, getCodeById, updateCode, revokeCode, calculateTrustTier, getDailySubmissionCount, getDailyLimit, getRankedCodesForVendor, calculateCodeScore } from "./referral-codes.js";
 import { getBestReferralCode, listAllReferralCodes } from "./platform-codes.js";
-import { REFERRAL_CONDITIONS_HEADING, allOurReferralLinks, heldReferralLinkForVendor, ourReferralLinkFor, referralLinkCountClause, referrerDisclosureSentence } from "./referral-surfaces.js";
+import { REFERRAL_CONDITIONS_HEADING, allOurReferralLinks, heldReferralLinkForVendor, ourReferralLinkFor, platformCodeAsVendorReferral, referralLinkCountClause, referrerDisclosureSentence } from "./referral-surfaces.js";
+import type { VendorReferralAnswer } from "./referral-surfaces.js";
 import { runHealthCheck, getLastReport, startPeriodicChecks } from "./referral-health.js";
 import { configureDurableBackend, hydrateDurableStores, persistDurableStores, identityStorageReport } from "./durable-store.js";
 import { addFriend, removeFriend, getFriends, getFriendCodesForVendors } from "./friends.js";
@@ -35241,7 +35242,7 @@ function buildDigitalOceanFreeTier2026Page(): string {
     { name: "GCP (Google Cloud)", slug: "google-cloud", freeTier: "Always Free: e2-micro VM, BigQuery 1 TiB, Cloud Run 2M req/mo", strength: "Free persistent VM, generous compute", bestFor: "Side projects needing always-free compute" },
     { name: "Azure", slug: "azure", freeTier: "Always Free: Functions 1M req/mo, Cosmos DB 25 GB, 65+ services", strength: "Best free database (Cosmos DB), enterprise identity", bestFor: ".NET apps, enterprise auth, Cosmos DB" },
     { name: "Hetzner", slug: "hetzner", freeTier: `No free tier — cheapest orderable plan is ${hetznerEntryPriceClause()}`, strength: "Strong price/performance above the entry tier", bestFor: "European hosting, raw compute power" },
-    { name: "Vultr", slug: "vultr", freeTier: "$250 free credit (30 days), cheapest VPS at $2.50/mo", strength: "Global locations, competitive pricing", bestFor: "Low-cost VPS, multiple regions" },
+    { name: "Vultr", slug: "vultr", freeTier: "Free DNS hosting on any account, cheapest VPS at $2.50/mo", strength: "Global locations, competitive pricing", bestFor: "Low-cost VPS, multiple regions" },
     { name: "Railway", slug: "railway", freeTier: "$5 free trial credit, usage-based pricing", strength: "Best DX, instant deploys from Git", bestFor: "Quick prototypes, hobby projects" },
     { name: "Render", slug: "render", freeTier: "Free web services (512 MB RAM), free PostgreSQL (90 days)", strength: "Simple PaaS, free hobby tier", bestFor: "Heroku replacement, small apps" },
     { name: "Cloudflare", slug: "cloudflare", freeTier: "Workers 100K req/day, R2 10 GB, D1 5 GB, Pages unlimited", strength: "Edge-first, zero egress on R2", bestFor: "Edge computing, static sites, storage" },
@@ -50990,7 +50991,7 @@ ${bundleHtml}
 
 function buildReferralProgramsPage(): string {
   const seen = new Set<string>();
-  const programVendors: { vendor: string; category: string; referrer_benefit: string; referee_benefit: string; program_url: string; type: string; commission_type?: string; hasCode: boolean; referralUrl?: string; refereeValue?: string }[] = [];
+  const programVendors: { vendor: string; category: string; referrer_benefit: string; referee_benefit: string; program_url: string; type: string; commission_type?: string; hasCode: boolean; referralUrl?: string; refereeValue?: string; restrictions: string[] }[] = [];
   for (const o of offers) {
     if (o.referral_program?.available && !seen.has(o.vendor)) {
       seen.add(o.vendor);
@@ -51006,6 +51007,7 @@ function buildReferralProgramsPage(): string {
         hasCode: ourLink !== null,
         referralUrl: ourLink?.url,
         refereeValue: ourLink?.refereeBenefit,
+        restrictions: ourLink?.restrictions ?? [],
       });
     }
   }
@@ -51071,10 +51073,13 @@ function buildReferralProgramsPage(): string {
       ? `<a href="${escHtmlServer(v.referralUrl!)}" rel="noopener sponsored" target="_blank" class="status-badge status-active">Use our code</a>`
       : `<span class="status-badge status-none">&mdash;</span>`;
     const linkHtml = `<a href="${escHtmlServer(v.program_url)}" rel="noopener" target="_blank" class="program-link">View</a>`;
+    const conditionsHtml = v.hasCode && v.restrictions.length > 0
+      ? `<div class="referral-conditions"><span class="referral-conditions-heading">${REFERRAL_CONDITIONS_HEADING}</span><ul>${v.restrictions.map(r => `<li>${escHtmlServer(r)}</li>`).join("")}</ul></div>`
+      : "";
     return `      <tr data-category="${escHtmlServer(v.category)}">
         <td><a href="/vendor/${vendorSlug}" class="vendor-link">${escHtmlServer(v.vendor)}</a></td>
         <td class="cat-cell">${escHtmlServer(v.category)}</td>
-        <td class="benefit-cell">${escHtmlServer(v.referee_benefit)}</td>
+        <td class="benefit-cell">${escHtmlServer(v.referee_benefit)}${conditionsHtml}</td>
         <td class="benefit-cell">${escHtmlServer(v.referrer_benefit)}</td>
         <td class="type-cell">${typeLabel(v.type)}</td>
         <td class="status-cell">${statusHtml}</td>
@@ -51136,6 +51141,10 @@ h1{font-family:var(--serif);font-size:2.25rem;color:var(--text);margin:1rem 0 .5
 .vendor-link{color:var(--text);font-weight:600}.vendor-link:hover{color:var(--accent)}
 .cat-cell{color:var(--text-muted);font-size:.8rem}
 .benefit-cell{font-size:.8rem;color:var(--text-muted)}
+.programs-table td{vertical-align:top}
+.referral-conditions{margin-top:.4rem;padding:.4rem .6rem;border-left:2px solid #d29922;border-radius:0 4px 4px 0;background:rgba(210,153,34,0.08)}
+.referral-conditions-heading{display:block;font-size:.65rem;text-transform:uppercase;letter-spacing:.08em;color:var(--text-dim);font-family:var(--mono);margin-bottom:.25rem}
+.referral-conditions ul{margin:0;padding-left:1rem;font-size:.75rem;color:var(--text);line-height:1.45}
 .type-cell{font-size:.75rem;color:var(--text-dim);font-family:var(--mono)}
 .status-cell{text-align:center}
 .link-cell{text-align:center}
@@ -55707,7 +55716,7 @@ ${catList}
       return;
     }
 
-    const referralData = getVendorReferral(vendor);
+    const referralData: VendorReferralAnswer | null = getVendorReferral(vendor) ?? platformCodeAsVendorReferral(vendor);
     if (!referralData) {
       res.writeHead(404, { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" });
       res.end(JSON.stringify({ error: `No referral found for vendor "${vendor}"` }));
@@ -55725,6 +55734,7 @@ ${catList}
       referral_code: referralData.referral.code ?? null,
       referral_url: referralData.referral.url,
       referee_value: referralData.referral.referee_value,
+      restrictions: referralData.referral.restrictions ?? [],
       type: referralData.referral.type,
       attributed: attribution.status === "attributed",
       attribution: attribution.status,

--- a/src/server.ts
+++ b/src/server.ts
@@ -13,6 +13,7 @@ import { persistDurableStores } from "./durable-store.js";
 import { getAgentBalance, getAgentLedgerEntries, recordPayout, MINIMUM_PAYOUT_AMOUNT, getLeaderboard } from "./ledger.js";
 import { submitReferralCode, getCodesByAgent, calculateTrustTier, getDailySubmissionCount, getDailyLimit, getRankedCodesForVendor, calculateCodeScore } from "./referral-codes.js";
 import { getBestReferralCode } from "./platform-codes.js";
+import { platformCodeAsVendorReferral, type VendorReferralAnswer } from "./referral-surfaces.js";
 import { validateX402Address, executeTransfer, generateCorrelationId, payoutsAvailable, PAYOUTS_UNAVAILABLE_REASON } from "./x402.js";
 import { addFriend, removeFriend, getFriends, getFriendCodesForVendors } from "./friends.js";
 import { getStackRecommendation } from "./stacks.js";
@@ -1048,7 +1049,7 @@ Suggested monitoring cadence: run this check weekly to catch pricing changes ear
       try {
         recordToolCall("get_referral_code", getClientName?.());
 
-        const referralData = getVendorReferral(vendor);
+        const referralData: VendorReferralAnswer | null = getVendorReferral(vendor) ?? platformCodeAsVendorReferral(vendor);
         if (!referralData) {
           return {
             isError: true,
@@ -1064,6 +1065,7 @@ Suggested monitoring cadence: run this check weekly to catch pricing changes ear
           referral_code: referralData.referral.code ?? null,
           referral_url: referralData.referral.url,
           referee_value: referralData.referral.referee_value,
+          restrictions: referralData.referral.restrictions ?? [],
           type: referralData.referral.type,
           attributed,
           attribution: outcome.status,

--- a/test/vultr-referral-code.test.ts
+++ b/test/vultr-referral-code.test.ts
@@ -1,0 +1,305 @@
+import { describe, it, before, after } from "node:test";
+import assert from "node:assert";
+import fs from "node:fs";
+import path from "node:path";
+import { spawn, type ChildProcess } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import { assertPopulationFloor } from "./population-floor.ts";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const PLATFORM_CODES_PATH = path.join(__dirname, "..", "data", "platform_codes.json");
+
+const { getBestReferralCode, getPlatformCodeForVendor, getAllPlatformCodes, listAllReferralCodes } = await import("../dist/platform-codes.js");
+const { ourReferralLinkFor, platformCodeAsVendorReferral, referralTypeOfPlatformCode } = await import("../dist/referral-surfaces.js");
+const { loadOffers } = await import("../dist/data.js");
+
+const VENDOR = "Vultr DNS";
+const SLUG = "vultr-dns";
+const PUBLISHED_CODE = "9920277-9J";
+const PUBLISHED_URL = "https://www.vultr.com/?ref=9920277-9J";
+const READER_BENEFIT = "$300 in credit";
+const FALLBACK_CODE = "9920276";
+const CONDITIONS = [
+  "A valid credit card or PayPal must be linked to claim the credit",
+  "Unused credit expires 30 days after signup",
+  "Vultr states this promotion is available for a limited time",
+];
+
+const store = JSON.parse(fs.readFileSync(PLATFORM_CODES_PATH, "utf-8"));
+const rowsFor = (vendor: string) => store.platform_codes.filter((c: any) => c.vendor === vendor);
+
+let serverProc: ChildProcess | null = null;
+let port = 0;
+
+function startServer(): Promise<{ proc: ChildProcess; port: number }> {
+  return new Promise((resolve, reject) => {
+    const serverPath = path.join(__dirname, "..", "dist", "serve.js");
+    const proc = spawn("node", [serverPath], {
+      stdio: ["pipe", "pipe", "pipe"],
+      env: { ...process.env, PORT: "0", BASE_URL: "http://localhost" },
+    });
+    const timeout = setTimeout(() => { proc.kill(); reject(new Error("Server startup timeout")); }, 15000);
+    proc.stderr!.on("data", (data: Buffer) => {
+      const match = data.toString().match(/running on http:\/\/localhost:(\d+)/);
+      if (match) {
+        clearTimeout(timeout);
+        resolve({ proc, port: parseInt(match[1], 10) });
+      }
+    });
+    proc.on("error", (err) => { clearTimeout(timeout); reject(err); });
+  });
+}
+
+async function sitemapPaths(): Promise<string[]> {
+  const indexRes = await fetch(`http://localhost:${port}/sitemap.xml`);
+  assert.strictEqual(indexRes.status, 200);
+  const children = [...(await indexRes.text()).matchAll(/<loc>([^<]+)<\/loc>/g)].map(m => m[1]);
+  assert.ok(children.length >= 4, `sitemap index listed ${children.length} sitemaps`);
+
+  const paths = new Set<string>(["/"]);
+  for (const child of children) {
+    const childPath = new URL(child, "http://localhost").pathname;
+    const res = await fetch(`http://localhost:${port}${childPath}`);
+    assert.strictEqual(res.status, 200, `${childPath} answered ${res.status}`);
+    for (const m of (await res.text()).matchAll(/<loc>([^<]+)<\/loc>/g)) {
+      paths.add(new URL(m[1], "http://localhost").pathname);
+    }
+  }
+  return [...paths];
+}
+
+function readableText(html: string): string {
+  return html
+    .replace(/<[^>]+>/g, " ")
+    .replace(/&amp;/g, "&")
+    .replace(/&nbsp;/g, " ")
+    .replace(/&mdash;/g, "—")
+    .replace(/\s+/g, " ");
+}
+
+const CREDIT_AFTER_VULTR = /Vultr[^$]{0,200}?\$([\d,]+(?:\.\d+)?)\s*(?:in\s+)?(?:free\s+)?credits?\b/gi;
+
+describe("the record carries the terms the reader is held to and the terms we are paid under", () => {
+  it("publishes one Vultr code and keeps the second stored but inactive", () => {
+    const rows = rowsFor(VENDOR);
+    assert.strictEqual(rows.length, 2, "both Vultr codes belong on the record");
+
+    const published = rows.filter((c: any) => c.active);
+    assert.strictEqual(published.length, 1, "exactly one Vultr code may be published");
+    assert.strictEqual(published[0].code, PUBLISHED_CODE);
+    assert.strictEqual(published[0].referee_benefit, READER_BENEFIT);
+
+    const fallback = rows.find((c: any) => c.code === FALLBACK_CODE);
+    assert.ok(fallback, `${FALLBACK_CODE} must stay on the record as the documented fallback`);
+    assert.strictEqual(fallback.active, false);
+    assert.strictEqual(fallback.referee_benefit, "", "the fallback pays the reader nothing, and the record should say so");
+  });
+
+  it("never offers a code that gives the reader nothing", () => {
+    for (const code of getAllPlatformCodes()) {
+      assert.ok(
+        code.referee_benefit.trim().length > 0,
+        `${code.vendor} ${code.code} is published with no reader benefit — a code that pays only us must not be active`
+      );
+    }
+  });
+
+  it("states each reader-facing condition where the reader is asked to act", () => {
+    const published = rowsFor(VENDOR).find((c: any) => c.active);
+    assert.deepStrictEqual(published.restrictions, CONDITIONS);
+  });
+
+  it("keeps the qualification we are paid under off the list the reader is asked to meet", () => {
+    const published = rowsFor(VENDOR).find((c: any) => c.active);
+    assert.deepStrictEqual(published.payout_qualification, { active_days: 30, min_payments_usd: 100 });
+    for (const restriction of published.restrictions) {
+      assert.ok(
+        !/verified sale|paid \$100|min_payments/i.test(restriction),
+        `a condition on our payout is not something the reader must do: ${restriction}`
+      );
+    }
+  });
+
+  it("says in the conditions themselves that the offer is time-limited", () => {
+    for (const code of getAllPlatformCodes()) {
+      if (!code.limited_time) continue;
+      assert.ok(
+        code.restrictions.some((r: string) => /limited time/i.test(r)),
+        `${code.vendor} is recorded as limited_time and the reader is told nothing about it`
+      );
+    }
+  });
+
+  it("dates the reading the terms came from", () => {
+    const published = rowsFor(VENDOR).find((c: any) => c.active);
+    assert.match(published.terms_verified, /^\d{4}-\d{2}-\d{2}$/);
+    assert.strictEqual(published.added_at, "2026-08-29");
+  });
+
+  it("reads a code that pays both sides as dual-sided", () => {
+    assert.strictEqual(referralTypeOfPlatformCode(getPlatformCodeForVendor(VENDOR)!), "dual-sided");
+    assert.strictEqual(
+      referralTypeOfPlatformCode({ referee_benefit: "", referrer_compensation: "commission" } as any),
+      "referrer-only"
+    );
+    assert.strictEqual(
+      referralTypeOfPlatformCode({ referee_benefit: "$5 in credit", referrer_compensation: "none" } as any),
+      "referee-only"
+    );
+  });
+});
+
+describe("the code resolves for the vendor whose page it renders on", () => {
+  it("is keyed to the name the offer index holds", () => {
+    const offer = loadOffers().find((o: any) => o.vendor === VENDOR);
+    assert.ok(offer, "the offer index must still hold the record this code renders on");
+
+    const resolved = getPlatformCodeForVendor(VENDOR);
+    assert.strictEqual(resolved!.code, PUBLISHED_CODE);
+    assert.strictEqual(getPlatformCodeForVendor("Vultr"), null, "a bare vendor name resolves to no page and must not resolve to a code");
+
+    const link = ourReferralLinkFor(VENDOR, offer);
+    assert.strictEqual(link!.url, PUBLISHED_URL);
+    assert.deepStrictEqual(link!.restrictions, CONDITIONS);
+  });
+
+  it("reaches the tool that answers for one vendor", () => {
+    const answer = platformCodeAsVendorReferral(VENDOR);
+    assert.strictEqual(answer!.referral.code, PUBLISHED_CODE);
+    assert.strictEqual(answer!.referral.url, PUBLISHED_URL);
+    assert.strictEqual(answer!.referral.referee_value, READER_BENEFIT);
+    assert.deepStrictEqual(answer!.referral.restrictions, CONDITIONS);
+    assert.strictEqual(platformCodeAsVendorReferral("Hetzner DNS"), null);
+  });
+
+  it("carries the conditions into the listing an agent prefetches", () => {
+    const best = getBestReferralCode(VENDOR);
+    assert.strictEqual(best!.code, PUBLISHED_CODE);
+    assert.deepStrictEqual(best!.restrictions, CONDITIONS);
+
+    const listed = listAllReferralCodes().find((c: any) => c.vendor === VENDOR);
+    assert.strictEqual(listed!.referee_benefit, READER_BENEFIT);
+    assert.deepStrictEqual(listed!.restrictions, CONDITIONS);
+    assert.ok(
+      !listAllReferralCodes().some((c: any) => c.code === FALLBACK_CODE),
+      "the fallback pays the reader nothing and must not be listed"
+    );
+  });
+
+  it("leaves the code we already published resolving as before", () => {
+    const railway = getBestReferralCode("Railway");
+    assert.strictEqual(railway!.code, "7RZL9q");
+    assert.strictEqual(railway!.referee_benefit, "$20 in credits");
+  });
+});
+
+describe("every surface that offers the code also states its conditions", () => {
+  let vendorPage = "";
+  let referralPrograms = "";
+  let disclosure = "";
+  let byVendor: any = null;
+  let referralEndpoint: any = null;
+
+  before(async () => {
+    const started = await startServer();
+    serverProc = started.proc;
+    port = started.port;
+    vendorPage = await (await fetch(`http://localhost:${port}/vendor/${SLUG}`)).text();
+    referralPrograms = await (await fetch(`http://localhost:${port}/referral-programs`)).text();
+    disclosure = await (await fetch(`http://localhost:${port}/disclosure`)).text();
+    byVendor = await (await fetch(`http://localhost:${port}/api/referral-codes/${encodeURIComponent(VENDOR)}`)).json();
+    referralEndpoint = await (await fetch(`http://localhost:${port}/api/referral/${encodeURIComponent(VENDOR)}`)).json();
+  });
+
+  after(() => { serverProc?.kill(); });
+
+  it("offers the reward and its conditions on the vendor page, conditions first", () => {
+    assert.ok(vendorPage.includes(`Sign up via our referral link and get ${READER_BENEFIT}`));
+    for (const condition of CONDITIONS) {
+      assert.ok(vendorPage.includes(condition), `/vendor/${SLUG} should state: ${condition}`);
+    }
+    const conditionAt = vendorPage.indexOf(CONDITIONS[0]);
+    const buttonAt = vendorPage.indexOf(`${PUBLISHED_URL}" rel="noopener sponsored"`);
+    assert.ok(conditionAt > -1 && buttonAt > -1, "the page must carry both the conditions and the button");
+    assert.ok(conditionAt < buttonAt, "the conditions must come before the button, not after it");
+  });
+
+  it("agrees with itself about what each side of the deal gets", () => {
+    const text = readableText(vendorPage);
+    assert.ok(text.includes("You Earn $100 cash per verified paid signup"), text.slice(text.indexOf("You Earn"), text.indexOf("You Earn") + 120));
+    assert.ok(text.includes(`They Get ${READER_BENEFIT}`), "the documented program block must not contradict the button above it");
+  });
+
+  it("states them on the listing page that links straight out to the code", () => {
+    const rowAt = referralPrograms.indexOf(`/vendor/${SLUG}" class="vendor-link"`);
+    assert.ok(rowAt > -1, "/referral-programs should list the vendor");
+    const row = referralPrograms.slice(rowAt, referralPrograms.indexOf("</tr>", rowAt));
+    assert.ok(row.includes(PUBLISHED_URL), "the row links straight out to the code");
+    for (const condition of CONDITIONS) {
+      assert.ok(row.includes(condition), `the row that links out should state: ${condition}`);
+    }
+  });
+
+  it("repeats them where we list who pays us", () => {
+    for (const condition of CONDITIONS) {
+      assert.ok(disclosure.includes(condition), `/disclosure should state: ${condition}`);
+    }
+  });
+
+  it("hands them to an agent asking for the code", () => {
+    assert.strictEqual(byVendor.code, PUBLISHED_CODE);
+    assert.strictEqual(byVendor.referee_benefit, READER_BENEFIT);
+    assert.deepStrictEqual(byVendor.restrictions, CONDITIONS);
+
+    assert.strictEqual(referralEndpoint.referral_code, PUBLISHED_CODE);
+    assert.strictEqual(referralEndpoint.referee_value, READER_BENEFIT);
+    assert.strictEqual(referralEndpoint.type, "dual-sided");
+    assert.deepStrictEqual(referralEndpoint.restrictions, CONDITIONS);
+  });
+
+  it("inlines the code on the offer an agent reads without asking twice", async () => {
+    const listing = await (await fetch(`http://localhost:${port}/api/offers?category=${encodeURIComponent("DNS & Domain Management")}&limit=100`)).json();
+    const vultr = listing.offers.find((o: any) => o.vendor === VENDOR);
+    assert.ok(vultr, "the category listing should hold the vendor");
+    assert.strictEqual(vultr.referral_code.code, PUBLISHED_CODE);
+    assert.deepStrictEqual(vultr.referral_code.restrictions, CONDITIONS);
+
+    const details = await (await fetch(`http://localhost:${port}/api/details/${encodeURIComponent(VENDOR)}`)).json();
+    assert.strictEqual(details.offer.referral_code.code, PUBLISHED_CODE);
+    assert.deepStrictEqual(details.offer.referral_code.restrictions, CONDITIONS);
+  });
+
+  it("publishes no Vultr credit figure that contradicts the record", async () => {
+    const paths = await sitemapPaths();
+    assertPopulationFloor(paths.length, 1900, "routes in the sitemap the sweep read");
+
+    const offenders: string[] = [];
+    let readerCreditMentions = 0;
+    for (const p of paths) {
+      const res = await fetch(`http://localhost:${port}${p}`);
+      assert.strictEqual(res.status, 200, `${p} answered ${res.status}`);
+      const text = readableText(await res.text());
+      for (const match of text.matchAll(CREDIT_AFTER_VULTR)) {
+        readerCreditMentions++;
+        if (match[1] !== "300") {
+          offenders.push(`${p}: ${match[0].trim().slice(0, 120)}`);
+        }
+      }
+    }
+    assert.ok(readerCreditMentions > 0, "the sweep found no Vultr credit figure at all, so it proves nothing");
+    assert.deepStrictEqual(offenders, [], `every Vultr credit figure must be the ${READER_BENEFIT} on the record\n\n${offenders.join("\n")}`);
+  });
+
+  it("publishes the fallback code nowhere at all", async () => {
+    const paths = await sitemapPaths();
+    const offenders: string[] = [];
+    for (const p of paths) {
+      const html = await (await fetch(`http://localhost:${port}${p}`)).text();
+      if (html.includes(FALLBACK_CODE)) offenders.push(p);
+    }
+    assert.deepStrictEqual(offenders, [], `${FALLBACK_CODE} pays the reader nothing and must not be published`);
+
+    const listing = await (await fetch(`http://localhost:${port}/api/referral-codes`)).json();
+    assert.ok(!JSON.stringify(listing).includes(FALLBACK_CODE), "the code listing must not carry the fallback either");
+  });
+});


### PR DESCRIPTION
Refs #1158

`/vendor/vultr-dns` published one Vultr referral link and it was `https://www.vultr.com/docs/vultr-referral-program/` — Vultr's own documentation, where a reader can enrol under anybody's code but ours. There was no `?ref=` anywhere on the site for Vultr.

## What ships

`9920277-9J` is published as a platform code. The reader gets **$300 in credit**; the code pays **$100 cash per verified paid signup**. Its three reader-facing conditions render between the headline and the button on `/vendor/vultr-dns`, using the mechanism #1151 shipped — a valid card or PayPal must be linked, unused credit expires after 30 days, and Vultr states the promotion is time-limited.

`9920276` — the $10 linking code with no reader benefit — is stored `active: false` as the documented fallback for when the promotion ends. It renders on no route and appears in no API response.

## Acceptance criteria

- **AC-1, AC-2** — the row is on `data/platform_codes.json`. The reader-facing conditions are `restrictions` (they have to render, and #1151's mechanism reads that field). The rest are structured: `limited_time: true`, `terms_verified: "2026-08-29"`, `payout_qualification: { active_days: 30, min_payments_usd: 100 }`. The payout qualification is deliberately not in `restrictions` — it gates our payment, not the reader's credit.
- **AC-3** — verified in the browser, conditions above the button, with a test that asserts the ordering rather than the presence.
- **AC-4** — the fallback is stored and unpublished, and a sweep of all 2,563 routes plus `/api/referral-codes` asserts it stays that way.
- **AC-5** — `get_referral_code` returns the $300 code, verified over a real MCP session (`initialize` → `tools/call`) rather than only in a unit test. `/api/referral-codes`, `/api/referral-codes/{vendor}`, `/api/referral/{vendor}`, `/api/offers`, and `/api/details/{vendor}` all carry it.
- **AC-6** — the `referral_program` block on the same record read *You Earn: Up to $100 cash per referral / They Get: $100 credit*, directly beside a button offering $300. It now reads $100 / $300, and its `notes` carry the $100 payment threshold rather than the stale $35.
- **AC-7** — `src/serve.ts` published *$250 free credit (30 days)* for Vultr on `/digitalocean-free-tier-2026`. That figure is a claim about what Vultr gives any new account and nothing we hold can source it, so it is dropped rather than re-awarded; the row now states the free DNS tier our own index records. A sweep of every route asserts no Vultr credit figure other than the $300 on the record. On `main` that sweep flags two routes.

## Two decisions worth naming

**`get_referral_code` reads the platform code rather than a second copy of it in the offer index.** Railway is stored three times — `platform_codes.json`, `offer.referral` and `offer.referral_program` — and the copies have already drifted ($20 in credits vs $20 in Railway credits). Adding an `offer.referral` block for Vultr would have been the established shape, but ~20 list and comparison surfaces render `referral.referee_value` as a bare chip with no conditions attached, so it would have published *$300 in credit* with nothing about the card or the 30-day expiry on every one of them. Instead `platformCodeAsVendorReferral` resolves the code for the two surfaces that answer per vendor, and both now return `restrictions` beside the benefit.

**The conditions also render on `/referral-programs`, which AC-3 does not name.** That page links straight out to `?ref=9920277-9J` under a "Use our code" badge and printed *$300 in credit* with no conditions — the same defect #1152 reports for DigitalOcean, on the first conditional code we have ever published. One line to reverse if you would rather it had stayed on the vendor page alone.

## Tests

`test/vultr-referral-code.test.ts` — 19 tests. Record invariants (a `limited_time` code must say so in its own conditions; no active code may offer the reader nothing), resolution (the code is keyed to `Vultr DNS`, and a bare `Vultr` resolves to nothing because `/vendor/vultr` 301s), and every surface that offers the code. Two sweeps read all 2,563 sitemap routes. On `main` 15 of the 19 fail, including both sweeps, so none of them can pass vacuously.
