### PR TITLE
Date every risk grade and publish how each band has held up (#1460)

### DIFF
--- a/data/page-reviews.json
+++ b/data/page-reviews.json
@@ -1096,9 +1096,9 @@
       "reviewer": "content revision",
       "review_outcome": null,
       "review_note": null,
-      "reads_index": false,
+      "reads_index": true,
       "reads_changes": false,
-      "data_source": "unsourced",
+      "data_source": "catalogue",
       "data_source_reason": null
     },
     {

--- a/data/quality_budgets.json
+++ b/data/quality_budgets.json
@@ -2,17 +2,19 @@
   "version": 1,
   "budgets": {
     "stale_fact_pages": 57,
-    "unsourced_tier_a": 40,
+    "unsourced_tier_a": 39,
     "uncited_change_records": 98,
     "source_checks_ok_without_quoted_evidence": 562,
-    "faq_answers": 166,
+    "faq_answers": 167,
     "faq_answers_stating_a_figure": 77,
-    "faq_answers_with_a_digit_but_no_figure": 40,
+    "faq_answers_with_a_digit_but_no_figure": 42,
     "records_with_superseded_terms": 171,
     "vendor_pages_withholding_superseded_terms": 170,
     "ungated_pages_withholding_superseded_terms": 161
   },
   "raised_because": {
-    "uncited_change_records": "95 to 98 on 2026-09-06. stathat.com, searchly.com and Prospect.io each cited the page their own summary reports as unreadable, and dropping that citation is the honest fix rather than repointing it at a page that would pass a liveness check. The 35 records that report our own index lost a citation in the same change and are outside this count rather than spending slots in it."
+    "uncited_change_records": "95 to 98 on 2026-09-06. stathat.com, searchly.com and Prospect.io each cited the page their own summary reports as unreadable, and dropping that citation is the honest fix rather than repointing it at a page that would pass a liveness check. The 35 records that report our own index lost a citation in the same change and are outside this count rather than spending slots in it.",
+    "faq_answers": "166 to 167 on 2026-09-08. /free-tier-risk gained one answer, publishing the hit rate of each risk band against the change log since the day that band was graded.",
+    "faq_answers_with_a_digit_but_no_figure": "40 to 42 on 2026-09-08. Both are on /free-tier-risk and both are grading dates rather than vendor figures: the new hit-rate answer, and the lowest-risk answer, which now dates the grade it names."
   }
 }

--- a/src/guides.ts
+++ b/src/guides.ts
@@ -1,3 +1,5 @@
+import { riskEntries } from "./risk-scorecard.js";
+
 export interface GuideMetadata {
   slug: string;
   title: string;
@@ -65,7 +67,7 @@ const GUIDE_ENTRIES: Array<{ slug: string; title: string; description: string }>
   { slug: "neon-vs-supabase", title: "Neon vs Supabase", description: "Free tier comparison — storage, compute, branching, auth, scale-to-zero" },
   { slug: "railway-vs-render", title: "Railway vs Render", description: "Free tier comparison — usage-based vs fixed pricing, managed databases, sleep behavior" },
   { slug: "datadog-vs-new-relic", title: "Datadog vs New Relic", description: "Free tier comparison — per-host vs per-GB pricing, APM, logs, synthetics, retention" },
-  { slug: "free-tier-risk", title: "Free Tier Risk Index", description: "Predictive risk scores for 38 developer tools — category heatmap, pattern analysis from 80 pricing changes, counter-trends, FAQ" },
+  { slug: "free-tier-risk", title: "Free Tier Risk Index", description: `Predictive risk scores for ${riskEntries.length} developer tools — every grade dated and scored against what our change log recorded next, category heatmap, pattern analysis, counter-trends, FAQ` },
   { slug: "hcp-terraform-migration", title: "HCP Terraform Migration Guide", description: "5 migration paths, decision matrix, step-by-step process for HCP Terraform EOL" },
   { slug: "terraform-cloud-free-tier-removed", title: "Terraform Cloud Free Tier Removed", description: "HCP Terraform free tier removal guide — cost analysis at 10-500 resources, 8 alternatives compared, migration paths" },
   { slug: "gemini-api-pricing-2026", title: "Gemini API Pricing 2026", description: "Gemini API billing guide — free tier changes, spend caps ($250-$100K+/mo), prepaid billing, 3.1 Pro paid-only, 8-provider comparison" },

--- a/src/risk-scorecard.ts
+++ b/src/risk-scorecard.ts
@@ -1,0 +1,237 @@
+import type { DealChange, Offer } from "./types.js";
+import { PRODUCT_DEPRECATED, deprecationEndsTheListedProduct } from "./product-deprecation.js";
+import { isNoLongerInForce } from "./change-resolution.js";
+import { tierRecordsAFreeTier } from "./free-tier-record.js";
+
+export type RiskGrade = "low" | "medium" | "high" | "dead";
+
+export interface RiskEntry {
+  vendor: string;
+  risk: RiskGrade;
+  category: string;
+  reasoning: string;
+  graded: string;
+  lastChange?: string;
+  changeType?: string;
+  changeLogNames?: string[];
+  catalogueVendor?: string;
+}
+
+export const RISK_GRADES: RiskGrade[] = ["low", "medium", "high", "dead"];
+
+export const FREE_TIER_NEGATIVE_TYPES = [
+  "free_tier_removed",
+  "limits_reduced",
+  "restriction",
+  PRODUCT_DEPRECATED,
+  "open_source_killed",
+];
+
+export const INDEX_SWEEP_STATE = "Removed from index";
+
+export type NotEvidenceReason = "no_longer_in_force" | "index_sweep" | "another_product";
+
+export const NOT_EVIDENCE_LABELS: Record<NotEvidenceReason, string> = {
+  no_longer_in_force: "reversed or retracted since we recorded it",
+  index_sweep: "an index sweep, not a vendor announcement",
+  another_product: "a deprecation of a different product by the same vendor",
+};
+
+type GradableChange = Pick<DealChange, "vendor" | "date" | "change_type" | "summary" | "current_state"> & {
+  resolution?: DealChange["resolution"];
+};
+
+export function changeLogNamesFor(entry: RiskEntry): string[] {
+  return entry.changeLogNames ?? [entry.vendor];
+}
+
+export function catalogueVendorFor(entry: RiskEntry): string {
+  return entry.catalogueVendor ?? entry.vendor;
+}
+
+export function whyNotEvidence(change: GradableChange): NotEvidenceReason | null {
+  if (isNoLongerInForce(change)) return "no_longer_in_force";
+  if (change.current_state === INDEX_SWEEP_STATE) return "index_sweep";
+  if (change.change_type === PRODUCT_DEPRECATED && !deprecationEndsTheListedProduct(change)) return "another_product";
+  return null;
+}
+
+export function assertsANegative(change: Pick<DealChange, "change_type">): boolean {
+  return FREE_TIER_NEGATIVE_TYPES.includes(change.change_type);
+}
+
+export interface TrackedRecord<T extends GradableChange = GradableChange> {
+  change: T;
+  negative: boolean;
+  notEvidence: NotEvidenceReason | null;
+}
+
+export function recordsFor<T extends GradableChange>(entry: RiskEntry, changes: readonly T[]): T[] {
+  const names = new Set(changeLogNamesFor(entry));
+  return changes.filter(c => names.has(c.vendor));
+}
+
+export function trackedSinceGrading<T extends GradableChange>(
+  entry: RiskEntry,
+  changes: readonly T[],
+): TrackedRecord<T>[] {
+  return recordsFor(entry, changes)
+    .filter(c => c.date > entry.graded)
+    .sort((a, b) => a.date.localeCompare(b.date))
+    .map(change => ({ change, negative: assertsANegative(change), notEvidence: whyNotEvidence(change) }));
+}
+
+export function negativesSinceGrading<T extends GradableChange>(
+  entry: RiskEntry,
+  changes: readonly T[],
+): T[] {
+  return trackedSinceGrading(entry, changes)
+    .filter(r => r.negative && r.notEvidence === null)
+    .map(r => r.change);
+}
+
+export function neverTracked(entry: RiskEntry, changes: readonly GradableChange[]): boolean {
+  return recordsFor(entry, changes).length === 0;
+}
+
+export const GRADE_FACTORS_WITHOUT_PRICING_HISTORY =
+  "financial signals, competitive pressure and free tier strategic value";
+
+export interface BandScore {
+  grade: RiskGrade;
+  vendors: number;
+  vendorsWithANegative: number;
+  vendorsWithNothingTracked: number;
+  negativeRecords: number;
+  rate: number;
+}
+
+export function scoreBand(
+  grade: RiskGrade,
+  entries: readonly RiskEntry[],
+  changes: readonly GradableChange[],
+): BandScore {
+  const band = entries.filter(e => e.risk === grade);
+  const negatives = band.map(e => negativesSinceGrading(e, changes));
+  const vendorsWithANegative = negatives.filter(n => n.length > 0).length;
+  return {
+    grade,
+    vendors: band.length,
+    vendorsWithANegative,
+    vendorsWithNothingTracked: band.filter(e => trackedSinceGrading(e, changes).length === 0).length,
+    negativeRecords: negatives.reduce((sum, n) => sum + n.length, 0),
+    rate: band.length === 0 ? 0 : Math.round((vendorsWithANegative / band.length) * 100),
+  };
+}
+
+export function scorecard(
+  entries: readonly RiskEntry[],
+  changes: readonly GradableChange[],
+): BandScore[] {
+  return RISK_GRADES.map(grade => scoreBand(grade, entries, changes));
+}
+
+export function gradesSetOn(entries: readonly RiskEntry[]): string[] {
+  return [...new Set(entries.map(e => e.graded))].sort();
+}
+
+export function gradesLastSet(entries: readonly RiskEntry[]): string {
+  const dates = gradesSetOn(entries);
+  return dates[dates.length - 1] ?? "";
+}
+
+export function gradesFirstSet(entries: readonly RiskEntry[]): string {
+  return gradesSetOn(entries)[0] ?? "";
+}
+
+export function gradingDatesClause(entries: readonly RiskEntry[]): string {
+  const first = gradesFirstSet(entries);
+  const last = gradesLastSet(entries);
+  if (first === last) return `Grades set ${last}`;
+  const revised = entries.filter(e => e.graded === last).length;
+  return `Grades set ${first}, ${revised === 1 ? "one revised" : `${revised} revised`} ${last}`;
+}
+
+export type FreeTierStanding = "still_listed" | "no_longer_free" | "not_in_catalogue";
+
+export const FREE_TIER_STANDING_LABELS: Record<FreeTierStanding, string> = {
+  still_listed: "free tier still listed",
+  no_longer_free: "no free tier in our catalogue",
+  not_in_catalogue: "no catalogue record",
+};
+
+export function freeTierStanding(
+  entry: RiskEntry,
+  offers: readonly Pick<Offer, "vendor" | "tier">[],
+): FreeTierStanding {
+  const name = catalogueVendorFor(entry);
+  const records = offers.filter(o => o.vendor === name);
+  if (records.length === 0) return "not_in_catalogue";
+  return records.some(o => tierRecordsAFreeTier(o.tier)) ? "still_listed" : "no_longer_free";
+}
+
+export function stillOffersAFreeTier(
+  entry: RiskEntry,
+  offers: readonly Pick<Offer, "vendor" | "tier">[],
+): boolean {
+  return freeTierStanding(entry, offers) === "still_listed";
+}
+
+export function splitByFreeTierStanding(
+  entries: readonly RiskEntry[],
+  offers: readonly Pick<Offer, "vendor" | "tier">[],
+): { stillFree: RiskEntry[]; alreadyGone: RiskEntry[] } {
+  return {
+    stillFree: entries.filter(e => stillOffersAFreeTier(e, offers)),
+    alreadyGone: entries.filter(e => !stillOffersAFreeTier(e, offers)),
+  };
+}
+
+export function citesAChangeOlderThanTheGrade(entry: RiskEntry): boolean {
+  return Boolean(entry.lastChange && entry.lastChange < entry.graded);
+}
+
+const FIRST_GRADING = "2026-03-26";
+
+export const riskEntries: RiskEntry[] = [
+  { vendor: "Cloudflare", risk: "low", category: "Cloud/CDN", reasoning: "Actively expanding free tiers (Workers, Pages, Queues added free Feb 2026). Profitable, no VC subsidy pressure. Free tier is a strategic funnel — core business is paid enterprise CDN.", graded: FIRST_GRADING, lastChange: "2026-02-04", changeType: "new_free_tier" },
+  { vendor: "GitHub", risk: "low", category: "Version Control", reasoning: "Microsoft-backed, free tier stable since 2019. Actions self-hosted runner fee was proposed then postponed after backlash (Jan 2026). Track record of expanding, not contracting.", graded: FIRST_GRADING, lastChange: "2026-01-01", changeType: "pricing_postponed", changeLogNames: ["GitHub", "GitHub Actions"] },
+  { vendor: "Grafana Cloud", risk: "low", category: "Monitoring", reasoning: "Open-source core (Prometheus, Loki, Tempo). Free tier includes 10K metrics, 50 GB logs, 50 GB traces. Company profitable, recent IPO path. Open-source foundation means community forks prevent lock-in.", graded: FIRST_GRADING },
+  { vendor: "CockroachDB", risk: "low", category: "Databases", reasoning: "10 GB free storage, multi-region support. Backed by $633M funding. Free tier is strategic acquisition tool. Serverless model scales naturally.", graded: FIRST_GRADING },
+  { vendor: "Auth0", risk: "low", category: "Authentication", reasoning: "Okta-owned (enterprise backing). Limits increased Nov 2025 (25K MAU → expanded). Free tier is developer funnel for enterprise IAM.", graded: FIRST_GRADING, lastChange: "2025-11-01", changeType: "limits_increased" },
+  { vendor: "Sentry", risk: "low", category: "Error Tracking", reasoning: "Open-source core. Pricing restructured Aug 2025 but free tier preserved (5K errors/mo). Community edition available as fallback.", graded: FIRST_GRADING, lastChange: "2025-08-15", changeType: "pricing_restructured" },
+  { vendor: "Google Cloud (Always Free)", risk: "low", category: "Cloud IaaS", reasoning: "Google Always Free tier unchanged for years — f1-micro VM, 5 GB Cloud Storage, BigQuery 1 TB/mo. Separate from promotional credits. Backed by Alphabet's cloud growth strategy.", graded: FIRST_GRADING, lastChange: "2026-01-01", changeType: "limits_increased", changeLogNames: ["Google Cloud"], catalogueVendor: "Google Cloud" },
+  { vendor: "AWS Free Tier", risk: "low", category: "Cloud IaaS", reasoning: "12-month free tier + always-free services (Lambda 1M requests, DynamoDB 25 GB). AWS is the market leader — free tier is a training/onboarding tool, not a cost center. Restructured Jan 2026 but expanded.", graded: FIRST_GRADING, lastChange: "2026-01-04", changeType: "pricing_restructured", changeLogNames: ["AWS"], catalogueVendor: "AWS" },
+  { vendor: "GitHub Copilot Free", risk: "low", category: "AI Coding", reasoning: "New free tier launched Dec 2025 (2K completions + 50 chat/mo). Microsoft strategic investment in AI developer tools. Competitive pressure from Cursor/Claude ensures free tier stays.", graded: FIRST_GRADING, lastChange: "2025-12-18", changeType: "new_free_tier", changeLogNames: ["GitHub Copilot"], catalogueVendor: "GitHub Copilot" },
+  { vendor: "Anthropic", risk: "low", category: "AI/ML APIs", reasoning: "Limits increased Feb 2026 and Mar 2026. Currently in growth mode, well-funded ($7.3B raised). Free API tier is competitive necessity against OpenAI/Google.", graded: FIRST_GRADING, lastChange: "2026-03-13", changeType: "limits_increased", changeLogNames: ["Anthropic", "Anthropic API", "Anthropic Claude"], catalogueVendor: "Anthropic API" },
+
+  { vendor: "Supabase", risk: "medium", category: "Databases/BaaS", reasoning: "Project pause tightened to 1 week inactivity (Feb 2026). Core free tier preserved but signals efficiency pressure. Post-Series C ($80M) — profitable path unclear.", graded: FIRST_GRADING, lastChange: "2026-02-01", changeType: "limits_reduced" },
+  { vendor: "Vercel", risk: "medium", category: "Hosting", reasoning: "Restructured to credit-based model (Jan 2026). Free tier still generous for personal projects but commercial use restricted (Hobby plan). Watch for further tightening.", graded: FIRST_GRADING, lastChange: "2026-01-01", changeType: "pricing_restructured" },
+  { vendor: "Netlify", risk: "medium", category: "Hosting", reasoning: "Restructured to credit-based pricing (Sep 2025) — sites pause on exhaustion. 300 credits/month is sufficient for small sites but represents a philosophical shift toward metered billing.", graded: FIRST_GRADING, lastChange: "2025-09-04", changeType: "pricing_restructured" },
+  { vendor: "Neon", risk: "medium", category: "Databases", reasoning: "Pricing restructured Jan 2026 post-Databricks acquisition. Free tier preserved (0.5 GB/project, 100 projects) but acquisition creates uncertainty about long-term free tier commitment.", graded: FIRST_GRADING, lastChange: "2026-01-15", changeType: "pricing_restructured" },
+  { vendor: "Railway", risk: "medium", category: "Hosting/PaaS", reasoning: "Free tier expanded with $100M Series B (Oct 2025). Currently generous ($5 credit, no sleep). But VC-funded PaaS companies have a history of removing free tiers (see: Heroku). Watch burn rate.", graded: FIRST_GRADING, lastChange: "2025-10-01", changeType: "limits_increased" },
+  { vendor: "Render", risk: "medium", category: "Hosting/PaaS", reasoning: "Sleep time reduced (Sep 2025) — 15-min spin-down is aggressive. Free PostgreSQL limited to 256 MB with 30-day expiry. Signals tightening, though core free tier intact.", graded: FIRST_GRADING, lastChange: "2025-09-01", changeType: "limits_reduced" },
+  { vendor: "Stripe", risk: "medium", category: "Payments", reasoning: "Processing fees restructured Feb 2026 (2.7% + 5¢ domestic card). No free tier per se — pay-per-transaction model. Risk is in rate changes, not tier removal.", graded: FIRST_GRADING, lastChange: "2026-02-01", changeType: "pricing_restructured" },
+  { vendor: "Firebase", risk: "medium", category: "BaaS", reasoning: "Multiple changes in 2026: Cloud Storage limits reduced (Feb), Realtime Database EOL announced (Mar), restrictions tightened (Feb). Google consolidating around Firestore. Migration advisable for RTDB users.", graded: FIRST_GRADING, lastChange: "2026-03-19", changeType: "product_deprecated" },
+  { vendor: "Docker Hub", risk: "medium", category: "Containers", reasoning: "Rate limits tightened (Dec 2024) — 100 pulls/6h anonymous, 200 authenticated. Docker Desktop commercial license required for large orgs ($5/user/mo+). Free for small teams but trending paid.", graded: FIRST_GRADING, lastChange: "2024-12-10", changeType: "pricing_restructured" },
+  { vendor: "Dub.co", risk: "medium", category: "Dev Utilities", reasoning: "Free tier limits reduced sharply (Mar 2026). Link shortener with declining free allowance signals monetization pressure.", graded: FIRST_GRADING, lastChange: "2026-03-22", changeType: "limits_reduced" },
+  { vendor: "Google Gemini API", risk: "medium", category: "AI/ML", reasoning: "Free tier rate limits slashed 50-80% (Dec 2025). The flagship Gemini 3.1 Pro is paid-only, though Gemini 2.5 Pro is still free. A Google PM admitted generous limits were only for a promotional weekend. Still has free tier but heavily restricted.", graded: FIRST_GRADING, lastChange: "2025-12-15", changeType: "limits_reduced", changeLogNames: ["Google Gemini API", "Google Gemini"] },
+
+  { vendor: "Heroku", risk: "high", category: "Hosting/PaaS", reasoning: "Free tier removed Nov 2022. Now in 'sustaining mode' under Salesforce — minimal investment, no innovation. The canonical cautionary tale for relying on free tiers.", graded: FIRST_GRADING, lastChange: "2022-11-28", changeType: "free_tier_removed" },
+  { vendor: "Fly.io", risk: "high", category: "Hosting", reasoning: "Free tier removed for new accounts in October 2024. New signups get a trial of 2 hours runtime or 7 days, whichever comes first, then pay-as-you-go from the first machine — the smallest is $2.02/month. Only legacy Hobby/Launch/Scale accounts still carry 3 shared-cpu-1x VMs, 3 GB volume storage and 100 GB transfer. Volume snapshots became billable in January 2026.", graded: "2026-09-05", lastChange: "2024-10-01", changeType: "free_tier_removed" },
+  { vendor: "Postman", risk: "high", category: "API Testing", reasoning: "Team collaboration removed from free tier (Mar 2026). Aggressive monetization of previously-free features. Pattern suggests further restrictions ahead.", graded: FIRST_GRADING, lastChange: "2026-03-01", changeType: "restriction" },
+  { vendor: "OpenAI", risk: "high", category: "AI/ML", reasoning: "Multiple free tier reductions: limits cut Jun 2025, further reduced Feb 2026. GPT-4 free access removed. Market leader extracting value — expect continued tightening.", graded: FIRST_GRADING, lastChange: "2026-02-09", changeType: "limits_reduced" },
+  { vendor: "HCP Terraform", risk: "high", category: "Infrastructure", reasoning: "Legacy tier EOL March 31, 2026. HashiCorp BSL license change (Aug 2023) already fractured community. IBM acquisition adds enterprise pricing pressure. Migrate to OpenTofu.", graded: FIRST_GRADING, lastChange: "2026-03-31", changeType: "pricing_restructured" },
+  { vendor: "LocalStack", risk: "high", category: "Testing", reasoning: "Community Edition shut down March 23, 2026. Complete removal of free/OSS option. Migrate to Moto, aws-sdk-mock, or Testcontainers.", graded: FIRST_GRADING, lastChange: "2026-03-23", changeType: "free_tier_removed" },
+  { vendor: "X API (Twitter)", risk: "high", category: "APIs", reasoning: "Free tier removed twice in 2026 (Feb 1 + Feb 9). Pay-per-use only with $10 one-time credit. Unpredictable management. Do not build on this API without paid plan budget.", graded: FIRST_GRADING, lastChange: "2026-02-09", changeType: "free_tier_removed", changeLogNames: ["X API (Twitter)", "X (Twitter)"], catalogueVendor: "X (Twitter)" },
+  { vendor: "Brave Search API", risk: "high", category: "Search", reasoning: "Free plan (5K queries/mo) replaced with metered billing Feb 2026. No spending cap — credit cards actively charged. Complete removal of free access.", graded: FIRST_GRADING, lastChange: "2026-02-12", changeType: "free_tier_removed" },
+  { vendor: "Spotify API", risk: "high", category: "APIs", reasoning: "Premium subscription now required for dev mode (Feb 2026). Test users cut from 25 to 5. Multiple endpoints deprecated. Hostile to free developers.", graded: FIRST_GRADING, lastChange: "2026-02-11", changeType: "limits_reduced" },
+  { vendor: "Amazon SP-API", risk: "high", category: "APIs", reasoning: "Free access ended after 10+ years — now $1,400/year + per-call fees (Apr 2026). Zero warning. Shows even long-stable APIs can go paid overnight.", graded: FIRST_GRADING, lastChange: "2026-01-31", changeType: "pricing_restructured" },
+
+  { vendor: "PlanetScale", risk: "dead", category: "Databases", reasoning: "Free tier removed April 2024. Hobby plan eliminated entirely. Migrate to Neon, Turso, or CockroachDB.", graded: FIRST_GRADING, lastChange: "2024-04-08", changeType: "free_tier_removed" },
+  { vendor: "Fauna", risk: "dead", category: "Databases", reasoning: "Product deprecated May 2025. Entire service shutting down. Migrate immediately to MongoDB Atlas, CockroachDB, or Supabase.", graded: FIRST_GRADING, lastChange: "2025-05-30", changeType: "product_deprecated" },
+  { vendor: "MinIO (OSS)", risk: "dead", category: "Storage", reasoning: "Open-source version killed Feb 2026 (GNU AGPL → proprietary). Self-hosted MinIO is no longer free for production. Use S3-compatible alternatives.", graded: FIRST_GRADING, lastChange: "2026-02-12", changeType: "open_source_killed", changeLogNames: ["MinIO"], catalogueVendor: "MinIO" },
+  { vendor: "SendGrid", risk: "dead", category: "Email", reasoning: "Free tier removed May 2025 under Twilio ownership. Use Resend (3K emails/mo free) or Maileroo (3K/mo); Mailgun and Amazon SES have since dropped their free tiers too.", graded: FIRST_GRADING, lastChange: "2025-05-27", changeType: "free_tier_removed" },
+  { vendor: "Logz.io", risk: "dead", category: "Logging", reasoning: "Free tier removed Mar 2026. Use Grafana Cloud (50 GB logs free), Axiom (500 GB/mo), or self-hosted ELK.", graded: FIRST_GRADING, lastChange: "2026-03-02", changeType: "free_tier_removed" },
+  { vendor: "Freshping", risk: "dead", category: "Monitoring", reasoning: "Free tier removed Mar 2026. Use BetterStack (10 monitors free), UptimeRobot (50 monitors), or Grafana Cloud synthetics.", graded: FIRST_GRADING, lastChange: "2026-03-06", changeType: "free_tier_removed" },
+];

--- a/src/serve.ts
+++ b/src/serve.ts
@@ -38,6 +38,7 @@ import { HETZNER_APRIL_CHANGES, HETZNER_CLOUD_PLANS, HETZNER_PRICES_READ, HETZNE
 import { HUNDRED_TB_SCENARIO, ONE_TO_ONE_SCENARIO, STORAGE_RATES_READ, STORAGE_SCALE_WORKLOADS, TEN_TO_ONE_SCENARIO, cheapestProviderAt, costliestProviderAt, egressAllowanceSentence, egressBillOnceOverAllowance, egressRatioWhereCostsMatch, fixedMonthlyGrantsSentence, monthlyStorageCost, providersWithScalingEgressAllowance, rateCardFor, scaleCostFor } from "./storage-cost-model.js";
 import { changeTimelineDate, supersededLineups, supersessionNote } from "./change-lineup.js";
 import { isNoLongerInForce, eventResolutionFields, recordsStillInForce } from "./change-resolution.js";
+import { FREE_TIER_STANDING_LABELS, GRADE_FACTORS_WITHOUT_PRICING_HISTORY, NOT_EVIDENCE_LABELS, citesAChangeOlderThanTheGrade, freeTierStanding, gradesFirstSet, gradesLastSet, gradingDatesClause, neverTracked, riskEntries, scorecard, splitByFreeTierStanding, trackedSinceGrading, type RiskEntry } from "./risk-scorecard.js";
 import { directionRatioLabel } from "./change-direction.js";
 import { removalDurability, removalReturnRateSentence, removalDurabilityPattern, lastingRemovalExamplesFor } from "./removal-durability.js";
 import { changeIsUncited, changeSourceCitation, changeSourceLinkHtml, citedChanges, uncitedChangeNotice, ratingWithheldForNoSourceClause, ratingWithheldForNoSourceSentence, UNCITED_CHANGE_LABEL } from "./change-citation.js";
@@ -7054,11 +7055,11 @@ const ALTERNATIVES_PAGES: AlternativesPageConfig[] = [
   {
     slug: "free-tier-risk",
     title: "Free Tier Risk Index — Predictive Analysis of Which Free Tiers May Disappear Next",
-    metaDesc: `Predictive risk scores for 38 developer tool free tiers — which will disappear next? Category heatmap, pattern analysis from ${trackedChangeCount} tracked pricing changes, counter-trends, and actionable protection strategies. Updated April 2026.`,
+    metaDesc: `Predictive risk scores for ${riskEntries.length} developer tool free tiers — which will disappear next? ${gradingDatesClause(riskEntries)}, scored against every change tracked since. Category heatmap, pattern analysis from ${trackedChangeCount} tracked pricing changes, counter-trends.`,
     contextHtml: "",
     tag: "free-tier-risk",
     primaryVendor: "AgentDeals",
-    hubDesc: "Predictive risk analysis for 38 developer free tiers — category heatmap, pattern analysis, counter-trends, protection strategies",
+    hubDesc: `Predictive risk analysis for ${riskEntries.length} developer free tiers — grades dated and scored against what happened next, category heatmap, pattern analysis, counter-trends`,
   },
   {
     slug: "stability",
@@ -22645,61 +22646,13 @@ function buildGeminiApiPricingChangesPage(): string {
     + '</body>\n</html>';
 }
 
-interface RiskEntry {
-  vendor: string;
-  risk: "low" | "medium" | "high" | "dead";
-  category: string;
-  reasoning: string;
-  lastChange?: string;
-  changeType?: string;
-}
-
-const riskEntries: RiskEntry[] = [
-  { vendor: "Cloudflare", risk: "low", category: "Cloud/CDN", reasoning: "Actively expanding free tiers (Workers, Pages, Queues added free Feb 2026). Profitable, no VC subsidy pressure. Free tier is a strategic funnel — core business is paid enterprise CDN.", lastChange: "2026-02-04", changeType: "new_free_tier" },
-  { vendor: "GitHub", risk: "low", category: "Version Control", reasoning: "Microsoft-backed, free tier stable since 2019. Actions self-hosted runner fee was proposed then postponed after backlash (Jan 2026). Track record of expanding, not contracting.", lastChange: "2026-01-01", changeType: "pricing_postponed" },
-  { vendor: "Grafana Cloud", risk: "low", category: "Monitoring", reasoning: "Open-source core (Prometheus, Loki, Tempo). Free tier includes 10K metrics, 50 GB logs, 50 GB traces. Company profitable, recent IPO path. Open-source foundation means community forks prevent lock-in." },
-  { vendor: "CockroachDB", risk: "low", category: "Databases", reasoning: "10 GB free storage, multi-region support. Backed by $633M funding. Free tier is strategic acquisition tool. Serverless model scales naturally." },
-  { vendor: "Auth0", risk: "low", category: "Authentication", reasoning: "Okta-owned (enterprise backing). Limits increased Nov 2025 (25K MAU → expanded). Free tier is developer funnel for enterprise IAM.", lastChange: "2025-11-01", changeType: "limits_increased" },
-  { vendor: "Sentry", risk: "low", category: "Error Tracking", reasoning: "Open-source core. Pricing restructured Aug 2025 but free tier preserved (5K errors/mo). Community edition available as fallback.", lastChange: "2025-08-15", changeType: "pricing_restructured" },
-  { vendor: "Google Cloud (Always Free)", risk: "low", category: "Cloud IaaS", reasoning: "Google Always Free tier unchanged for years — f1-micro VM, 5 GB Cloud Storage, BigQuery 1 TB/mo. Separate from promotional credits. Backed by Alphabet's cloud growth strategy.", lastChange: "2026-01-01", changeType: "limits_increased" },
-  { vendor: "AWS Free Tier", risk: "low", category: "Cloud IaaS", reasoning: "12-month free tier + always-free services (Lambda 1M requests, DynamoDB 25 GB). AWS is the market leader — free tier is a training/onboarding tool, not a cost center. Restructured Jan 2026 but expanded.", lastChange: "2026-01-04", changeType: "pricing_restructured" },
-  { vendor: "GitHub Copilot Free", risk: "low", category: "AI Coding", reasoning: "New free tier launched Dec 2025 (2K completions + 50 chat/mo). Microsoft strategic investment in AI developer tools. Competitive pressure from Cursor/Claude ensures free tier stays.", lastChange: "2025-12-18", changeType: "new_free_tier" },
-  { vendor: "Anthropic", risk: "low", category: "AI/ML APIs", reasoning: "Limits increased Feb 2026 and Mar 2026. Currently in growth mode, well-funded ($7.3B raised). Free API tier is competitive necessity against OpenAI/Google.", lastChange: "2026-03-13", changeType: "limits_increased" },
-
-  { vendor: "Supabase", risk: "medium", category: "Databases/BaaS", reasoning: "Project pause tightened to 1 week inactivity (Feb 2026). Core free tier preserved but signals efficiency pressure. Post-Series C ($80M) — profitable path unclear.", lastChange: "2026-02-01", changeType: "limits_reduced" },
-  { vendor: "Vercel", risk: "medium", category: "Hosting", reasoning: "Restructured to credit-based model (Jan 2026). Free tier still generous for personal projects but commercial use restricted (Hobby plan). Watch for further tightening.", lastChange: "2026-01-01", changeType: "pricing_restructured" },
-  { vendor: "Netlify", risk: "medium", category: "Hosting", reasoning: "Restructured to credit-based pricing (Sep 2025) — sites pause on exhaustion. 300 credits/month is sufficient for small sites but represents a philosophical shift toward metered billing.", lastChange: "2025-09-04", changeType: "pricing_restructured" },
-  { vendor: "Neon", risk: "medium", category: "Databases", reasoning: "Pricing restructured Jan 2026 post-Databricks acquisition. Free tier preserved (0.5 GB/project, 100 projects) but acquisition creates uncertainty about long-term free tier commitment.", lastChange: "2026-01-15", changeType: "pricing_restructured" },
-  { vendor: "Railway", risk: "medium", category: "Hosting/PaaS", reasoning: "Free tier expanded with $100M Series B (Oct 2025). Currently generous ($5 credit, no sleep). But VC-funded PaaS companies have a history of removing free tiers (see: Heroku). Watch burn rate.", lastChange: "2025-10-01", changeType: "limits_increased" },
-  { vendor: "Render", risk: "medium", category: "Hosting/PaaS", reasoning: "Sleep time reduced (Sep 2025) — 15-min spin-down is aggressive. Free PostgreSQL limited to 256 MB with 30-day expiry. Signals tightening, though core free tier intact.", lastChange: "2025-09-01", changeType: "limits_reduced" },
-  { vendor: "Stripe", risk: "medium", category: "Payments", reasoning: "Processing fees restructured Feb 2026 (2.7% + 5¢ domestic card). No free tier per se — pay-per-transaction model. Risk is in rate changes, not tier removal.", lastChange: "2026-02-01", changeType: "pricing_restructured" },
-  { vendor: "Firebase", risk: "medium", category: "BaaS", reasoning: "Multiple changes in 2026: Cloud Storage limits reduced (Feb), Realtime Database EOL announced (Mar), restrictions tightened (Feb). Google consolidating around Firestore. Migration advisable for RTDB users.", lastChange: "2026-03-19", changeType: "product_deprecated" },
-  { vendor: "Docker Hub", risk: "medium", category: "Containers", reasoning: "Rate limits tightened (Dec 2024) — 100 pulls/6h anonymous, 200 authenticated. Docker Desktop commercial license required for large orgs ($5/user/mo+). Free for small teams but trending paid.", lastChange: "2024-12-10", changeType: "pricing_restructured" },
-  { vendor: "Dub.co", risk: "medium", category: "Dev Utilities", reasoning: "Free tier limits reduced sharply (Mar 2026). Link shortener with declining free allowance signals monetization pressure.", lastChange: "2026-03-22", changeType: "limits_reduced" },
-  { vendor: "Google Gemini API", risk: "medium", category: "AI/ML", reasoning: "Free tier rate limits slashed 50-80% (Dec 2025). The flagship Gemini 3.1 Pro is paid-only, though Gemini 2.5 Pro is still free. A Google PM admitted generous limits were only for a promotional weekend. Still has free tier but heavily restricted.", lastChange: "2025-12-15", changeType: "limits_reduced" },
-
-  { vendor: "Heroku", risk: "high", category: "Hosting/PaaS", reasoning: "Free tier removed Nov 2022. Now in 'sustaining mode' under Salesforce — minimal investment, no innovation. The canonical cautionary tale for relying on free tiers.", lastChange: "2022-11-28", changeType: "free_tier_removed" },
-  { vendor: "Fly.io", risk: "high", category: "Hosting", reasoning: "Free tier removed for new accounts in October 2024. New signups get a trial of 2 hours runtime or 7 days, whichever comes first, then pay-as-you-go from the first machine — the smallest is $2.02/month. Only legacy Hobby/Launch/Scale accounts still carry 3 shared-cpu-1x VMs, 3 GB volume storage and 100 GB transfer. Volume snapshots became billable in January 2026.", lastChange: "2024-10-01", changeType: "free_tier_removed" },
-  { vendor: "Postman", risk: "high", category: "API Testing", reasoning: "Team collaboration removed from free tier (Mar 2026). Aggressive monetization of previously-free features. Pattern suggests further restrictions ahead.", lastChange: "2026-03-01", changeType: "restriction" },
-  { vendor: "OpenAI", risk: "high", category: "AI/ML", reasoning: "Multiple free tier reductions: limits cut Jun 2025, further reduced Feb 2026. GPT-4 free access removed. Market leader extracting value — expect continued tightening.", lastChange: "2026-02-09", changeType: "limits_reduced" },
-  { vendor: "HCP Terraform", risk: "high", category: "Infrastructure", reasoning: "Legacy tier EOL March 31, 2026. HashiCorp BSL license change (Aug 2023) already fractured community. IBM acquisition adds enterprise pricing pressure. Migrate to OpenTofu.", lastChange: "2026-03-31", changeType: "pricing_restructured" },
-  { vendor: "LocalStack", risk: "high", category: "Testing", reasoning: "Community Edition shut down March 23, 2026. Complete removal of free/OSS option. Migrate to Moto, aws-sdk-mock, or Testcontainers.", lastChange: "2026-03-23", changeType: "free_tier_removed" },
-  { vendor: "X API (Twitter)", risk: "high", category: "APIs", reasoning: "Free tier removed twice in 2026 (Feb 1 + Feb 9). Pay-per-use only with $10 one-time credit. Unpredictable management. Do not build on this API without paid plan budget.", lastChange: "2026-02-09", changeType: "free_tier_removed" },
-  { vendor: "Brave Search API", risk: "high", category: "Search", reasoning: "Free plan (5K queries/mo) replaced with metered billing Feb 2026. No spending cap — credit cards actively charged. Complete removal of free access.", lastChange: "2026-02-12", changeType: "free_tier_removed" },
-  { vendor: "Spotify API", risk: "high", category: "APIs", reasoning: "Premium subscription now required for dev mode (Feb 2026). Test users cut from 25 to 5. Multiple endpoints deprecated. Hostile to free developers.", lastChange: "2026-02-11", changeType: "limits_reduced" },
-  { vendor: "Amazon SP-API", risk: "high", category: "APIs", reasoning: "Free access ended after 10+ years — now $1,400/year + per-call fees (Apr 2026). Zero warning. Shows even long-stable APIs can go paid overnight.", lastChange: "2026-01-31", changeType: "pricing_restructured" },
-
-  { vendor: "PlanetScale", risk: "dead", category: "Databases", reasoning: "Free tier removed April 2024. Hobby plan eliminated entirely. Migrate to Neon, Turso, or CockroachDB.", lastChange: "2024-04-08", changeType: "free_tier_removed" },
-  { vendor: "Fauna", risk: "dead", category: "Databases", reasoning: "Product deprecated May 2025. Entire service shutting down. Migrate immediately to MongoDB Atlas, CockroachDB, or Supabase.", lastChange: "2025-05-30", changeType: "product_deprecated" },
-  { vendor: "MinIO (OSS)", risk: "dead", category: "Storage", reasoning: "Open-source version killed Feb 2026 (GNU AGPL → proprietary). Self-hosted MinIO is no longer free for production. Use S3-compatible alternatives.", lastChange: "2026-02-12", changeType: "open_source_killed" },
-  { vendor: "SendGrid", risk: "dead", category: "Email", reasoning: "Free tier removed May 2025 under Twilio ownership. Use Resend (3K emails/mo free) or Maileroo (3K/mo); Mailgun and Amazon SES have since dropped their free tiers too.", lastChange: "2025-05-27", changeType: "free_tier_removed" },
-  { vendor: "Logz.io", risk: "dead", category: "Logging", reasoning: "Free tier removed Mar 2026. Use Grafana Cloud (50 GB logs free), Axiom (500 GB/mo), or self-hosted ELK.", lastChange: "2026-03-02", changeType: "free_tier_removed" },
-  { vendor: "Freshping", risk: "dead", category: "Monitoring", reasoning: "Free tier removed Mar 2026. Use BetterStack (10 monitors free), UptimeRobot (50 monitors), or Grafana Cloud synthetics.", lastChange: "2026-03-06", changeType: "free_tier_removed" },
-];
-
 function buildFreeTierRiskPage(): string {
   const title = "Free Tier Risk Index — Predictive Analysis of Which Free Tiers May Disappear Next";
-  const metaDesc = `Predictive risk scores for 38 developer tool free tiers — which will disappear next? Category heatmap, pattern analysis from ${trackedChangeCount} tracked pricing changes, counter-trends, and actionable protection strategies. Updated April 2026.`;
+  const gradedFrom = gradesFirstSet(riskEntries);
+  const gradingDates = gradingDatesClause(riskEntries);
+  const safestPicks = ["Cloudflare", "GitHub", "Grafana Cloud", "AWS Free Tier", "Google Cloud (Always Free)"];
+  const safestPicksGraded = gradesLastSet(riskEntries.filter(e => safestPicks.includes(e.vendor)));
+  const metaDesc = `Predictive risk scores for ${riskEntries.length} developer tool free tiers — which will disappear next? ${gradingDates}, scored against every change tracked since. Category heatmap, pattern analysis from ${trackedChangeCount} tracked pricing changes, counter-trends.`;
   const slug = "free-tier-risk";
   const pubDate = "2026-03-26";
 
@@ -22715,22 +22668,48 @@ function buildFreeTierRiskPage(): string {
   const medRisk = riskEntries.filter(e => e.risk === "medium");
   const highRisk = riskEntries.filter(e => e.risk === "high");
   const deadEntries = riskEntries.filter(e => e.risk === "dead");
+  const highBand = splitByFreeTierStanding(highRisk, offers);
+  const bandScores = scorecard(riskEntries, dealChanges);
+  const gradedWithNoRecordAtAll = riskEntries.filter(e => neverTracked(e, dealChanges));
 
   const riskColors: Record<string, string> = { low: "#3fb950", medium: "#d29922", high: "#f85149", dead: "#8b949e" };
   const riskLabels: Record<string, string> = { low: "Low Risk", medium: "Medium Risk", high: "High Risk", dead: "Already Changed" };
   const riskEmoji: Record<string, string> = { low: "\u{1F7E2}", medium: "\u{1F7E1}", high: "\u{1F534}", dead: "\u26AB" };
 
+  const sinceGradedCell = (e: RiskEntry) => {
+    if (neverTracked(e, dealChanges)) {
+      return `No change has ever been tracked for ${escHtmlServer(e.vendor)}. This grade rests on ${GRADE_FACTORS_WITHOUT_PRICING_HISTORY} — not on our deal change data.`;
+    }
+    const tracked = trackedSinceGrading(e, dealChanges);
+    if (tracked.length === 0) return "Nothing tracked since it was graded.";
+    return tracked.map(t => {
+      const label = t.notEvidence
+        ? ` <span style="color:var(--text-dim)">not counted &mdash; ${escHtmlServer(NOT_EVIDENCE_LABELS[t.notEvidence])}</span>`
+        : t.negative
+          ? ` <span style="color:#f85149">counted against the grade</span>`
+          : ` <span style="color:var(--text-dim)">not a free tier negative</span>`;
+      return `<div style="margin-bottom:.5rem"><span style="font-family:var(--mono);color:var(--text-dim)">${escHtmlServer(changeEntryDateLabel(t.change))}</span><div>${escHtmlServer(t.change.change_type)}${label}</div></div>`;
+    }).join("");
+  };
+
   const buildRiskRow = (e: RiskEntry) => {
     const vendorSlug = e.vendor.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/-+$/, "");
     const color = riskColors[e.risk];
+    const beforeTheGrade = citesAChangeOlderThanTheGrade(e)
+      ? `<div style="color:var(--text-dim);font-family:var(--sans);font-size:.72rem">before the grade</div>`
+      : "";
     return `<tr>
       <td style="font-weight:600"><a href="/vendor/${vendorSlug}" style="color:var(--text)">${escHtmlServer(e.vendor)}</a></td>
-      <td style="color:${color};font-weight:600;font-size:.85rem">${riskEmoji[e.risk]} ${riskLabels[e.risk]}</td>
+      <td style="color:${color};font-weight:600;font-size:.85rem">${riskEmoji[e.risk]} ${riskLabels[e.risk]}<div style="color:var(--text-dim);font-weight:400;font-size:.72rem;font-family:var(--mono);white-space:nowrap">graded ${escHtmlServer(e.graded)}</div></td>
       <td style="color:var(--text-muted);font-size:.85rem">${escHtmlServer(e.category)}</td>
       <td style="color:var(--text-muted);font-size:.8rem">${escHtmlServer(e.reasoning)}</td>
-      <td style="font-family:var(--mono);font-size:.8rem;color:var(--text-dim);white-space:nowrap">${e.lastChange ? escHtmlServer(e.lastChange) : "—"}</td>
+      <td style="font-family:var(--mono);font-size:.8rem;color:var(--text-dim)">${e.lastChange ? `<div style="white-space:nowrap">${escHtmlServer(e.lastChange)}</div>${beforeTheGrade}` : "&mdash;"}</td>
+      <td style="color:var(--text-muted);font-size:.75rem;min-width:200px">${sinceGradedCell(e)}</td>
     </tr>`;
   };
+
+  const riskTableHead = (statusHeader: string, whatHeader: string, dateHeader: string) =>
+    `<tr><th>Vendor</th><th>${statusHeader}</th><th>Category</th><th>${whatHeader}</th><th>${dateHeader}</th><th>Tracked since graded</th></tr>`;
 
   const categoryMap = new Map<string, { total: number; negative: number; positive: number }>();
   const normCat = (c: string) => {
@@ -22780,10 +22759,11 @@ function buildFreeTierRiskPage(): string {
     .sort((a, b) => b[1] - a[1]);
 
   const faqs = [
-    { q: "How often is the Free Tier Risk Index updated?", a: "We update risk scores whenever a new pricing change is tracked. Our dataset currently includes " + changesInForce.length + " changes across " + offers.length.toLocaleString() + " developer tools, and we add new changes within 48 hours of announcement." },
-    { q: "Which free tiers are safest to build on in 2026?", a: "Cloudflare, GitHub, Grafana Cloud, AWS Always Free, and Google Cloud Always Free are our lowest-risk picks. They share three traits: backed by profitable companies, the free tier is a strategic acquisition funnel, and strong competitive pressure prevents removal." },
+    { q: "How often is the Free Tier Risk Index updated?", a: "The grades are editorial and do not move on their own. " + gradingDates + ", and every row on the page carries the date its own grade was set. What is recomputed on every request is the record beneath them — each vendor's tracked changes since the day it was graded, and the scorecard showing how each band has fared. Our change log currently holds " + changesInForce.length + " changes in force across " + offers.length.toLocaleString() + " developer tools, and we add new changes within 48 hours of announcement." },
+    { q: "Which free tiers are safest to build on in 2026?", a: "Cloudflare, GitHub, Grafana Cloud, AWS Always Free, and Google Cloud Always Free are our lowest-risk picks, graded " + safestPicksGraded + ". They share three traits: backed by profitable companies, the free tier is a strategic acquisition funnel, and strong competitive pressure prevents removal. Section 6 of this page publishes what has happened to each band since." },
     { q: "What are the warning signs that a free tier is about to be removed?", a: "Key signals: (1) acquisition or ownership change (HashiCorp/IBM, Neon/Databricks), (2) license change (MinIO AGPL to proprietary), (3) credit-based pricing transition (Vercel, Netlify), (4) two or more negative changes within 6 months, and (5) 'sustaining mode' language in announcements." },
-    { q: "How do you calculate risk scores?", a: "We weight four factors: pricing history (40%) — has the vendor changed before and how recently; financial signals (25%) — profitable vs VC-subsidized, recent acquisitions; competitive pressure (20%) — intense competition keeps free tiers alive; free tier strategic value (15%) — is the free tier a funnel or a cost center." },
+    { q: "How do you calculate risk scores?", a: "We weight four factors: pricing history (40%) — has the vendor changed before and how recently; financial signals (25%) — profitable vs VC-subsidized, recent acquisitions; competitive pressure (20%) — intense competition keeps free tiers alive; free tier strategic value (15%) — is the free tier a funnel or a cost center. " + gradedWithNoRecordAtAll.length + " of the " + riskEntries.length + " graded vendors have no record in our change log at all, so pricing history supplied nothing for them and their grade rests on the other three factors: " + gradedWithNoRecordAtAll.map(e => e.vendor).join(", ") + "." },
+    { q: "How accurate have the risk grades been?", a: gradingDates + ", and scored against every change tracked since: " + bandScores.map(b => riskLabels[b.grade].toLowerCase() + " " + b.vendorsWithANegative + " of " + b.vendors + " (" + b.rate + "%)").join(", ") + ". A vendor counts if our change log holds a record in force since its grading date that removed a free tier, cut limits, added a restriction, killed an open-source edition, or deprecated the graded product itself. Vendors with nothing tracked stay in the denominator rather than being dropped." },
     { q: "What should I do if a tool I depend on is rated high risk?", a: "Start planning your migration now. Use abstractions (ORMs, S3-compatible APIs, OpenTelemetry) to minimize switching cost. Identify 2-3 alternatives and test them in a staging environment. Subscribe to our pricing change feed at /feed.xml for early warning." },
     { q: "Are there any categories where free tiers are expanding?", a: "Yes — AI coding tools (GitHub Copilot Free, Anthropic increases, Windsurf launch) and cloud infrastructure (Cloudflare Queues, Workers expansion, AWS restructuring). Competition for developer mindshare drives expansion. See the Counter-Trends section for details." },
   ];
@@ -22887,7 +22867,7 @@ ${mcpCtaCss()}
   ${buildGlobalNav("changes")}
   <div class="breadcrumb"><a href="/">AgentDeals</a> &rsaquo; <a href="/alternatives">Guides</a> &rsaquo; Free Tier Risk Index</div>
   <h1>Free Tier Risk Index</h1>
-  <p class="pub-date">Published ${pubDate} &middot; Based on ${changesInForce.length} tracked pricing changes across ${offers.length.toLocaleString()} developer tools &middot; ${pageDataProvenance("/free-tier-risk", offers.length)}</p>
+  <p class="pub-date">Published ${pubDate} &middot; ${gradingDates} &middot; Scored against ${changesInForce.length} tracked pricing changes across ${offers.length.toLocaleString()} developer tools &middot; ${pageDataProvenance("/free-tier-risk", offers.length)}</p>
 
   <div class="summary-stats">
     <div class="stat-card"><div class="stat-number" style="color:#3fb950">${lowRisk.length}</div><div class="stat-label">Low Risk (Safe)</div></div>
@@ -22900,6 +22880,7 @@ ${mcpCtaCss()}
     <p><strong>The question developers should ask isn't "what's free?" — it's "what will still be free in a year?"</strong></p>
     <p>We track ${changesInForce.length} pricing changes across the developer tool ecosystem. The data shows a clear pattern: <strong>${negativeChanges.length} negative changes</strong> (free tier removals, limit reductions, restrictions) vs <strong>${positiveChanges.length} positive changes</strong> (expansions, new tiers). Free tier erosion is real, but not universal — some vendors are actively expanding.</p>
     <p>This index scores ${riskEntries.length} major developer tools by free tier sustainability, using our deal change data, company financial signals, and competitive dynamics. <strong>Build on the greens, watch the yellows, plan exits from the reds.</strong></p>
+    <p>The grades are editorial. ${gradingDates}, and each row below carries the date its own grade was set. They do not move on their own, so <a href="#scorecard">section 6 scores them</a> against every change we have tracked since — band by band, with the vendors that took nothing left in the denominator.</p>
   </div>
 
   <div class="toc">
@@ -22908,8 +22889,9 @@ ${mcpCtaCss()}
       <li><a href="#methodology">How We Score Risk</a></li>
       <li><a href="#low">Low Risk — Safe to Build On</a> (${lowRisk.length} vendors)</li>
       <li><a href="#medium">Medium Risk — Use with Caution</a> (${medRisk.length} vendors)</li>
-      <li><a href="#high">High Risk — Plan Your Exit</a> (${highRisk.length} vendors)</li>
-      <li><a href="#dead">Already Changed</a> (${deadEntries.length} vendors)</li>
+      <li><a href="#high">High Risk — Plan Your Exit</a> (${highBand.stillFree.length} vendors)</li>
+      <li><a href="#dead">Already Changed</a> (${deadEntries.length + highBand.alreadyGone.length} vendors)</li>
+      <li><a href="#scorecard">Scorecard — How the Grades Have Held Up</a></li>
       <li><a href="#scoring">Full Scoring Table</a></li>
       <li><a href="#heatmap">Category Risk Heatmap</a></li>
       <li><a href="#patterns">Pattern Analysis</a></li>
@@ -22924,7 +22906,7 @@ ${mcpCtaCss()}
   <div style="display:grid;gap:.75rem;margin:1rem 0">
     <div class="diff-card" style="border-left-color:#3b82f6">
       <h3>Pricing History (40% weight)</h3>
-      <p class="diff-desc">Has this vendor changed pricing before? How recently? What direction? A vendor with 2+ negative changes in 12 months is flagged high risk. Vendors actively expanding get a boost. Data source: our ${changesInForce.length} tracked deal changes.</p>
+      <p class="diff-desc">Has this vendor changed pricing before? How recently? What direction? A vendor with 2+ negative changes in 12 months is flagged high risk. Vendors actively expanding get a boost. Data source: our ${changesInForce.length} tracked deal changes. ${gradedWithNoRecordAtAll.length} of the ${riskEntries.length} graded vendors have no record in that log at all — ${gradedWithNoRecordAtAll.map(e => escHtmlServer(e.vendor)).join(", ")} — so this factor supplied nothing for them and their grade rests on ${GRADE_FACTORS_WITHOUT_PRICING_HISTORY}.</p>
     </div>
     <div class="diff-card" style="border-left-color:#8b5cf6">
       <h3>Financial Signals (25% weight)</h3>
@@ -22945,7 +22927,7 @@ ${mcpCtaCss()}
   <div style="overflow-x:auto">
     <table class="risk-table">
       <thead>
-        <tr><th>Vendor</th><th>Risk</th><th>Category</th><th>Reasoning</th><th>Last Change</th></tr>
+        ${riskTableHead("Risk", "Reasoning", "Last Change")}
       </thead>
       <tbody>
         ${lowRisk.map(buildRiskRow).join("\n        ")}
@@ -22961,7 +22943,7 @@ ${mcpCtaCss()}
   <div style="overflow-x:auto">
     <table class="risk-table">
       <thead>
-        <tr><th>Vendor</th><th>Risk</th><th>Category</th><th>Reasoning</th><th>Last Change</th></tr>
+        ${riskTableHead("Risk", "Reasoning", "Last Change")}
       </thead>
       <tbody>
         ${medRisk.map(buildRiskRow).join("\n        ")}
@@ -22973,40 +22955,66 @@ ${mcpCtaCss()}
   </div>
 
   <h2 id="high">4. \u{1F534} High Risk — Plan Your Exit</h2>
-  <p class="section-intro">Active degradation or removal of free tiers. If you're building on these, migrate soon or budget for paid plans.</p>
+  <p class="section-intro">${highRisk.length} vendors carry the high grade. ${highBand.stillFree.length} of them still have a free tier in our catalogue, so an exit is something you can still plan — those are the ones below. The other ${highBand.alreadyGone.length} have nothing left to exit from and are listed under <a href="#dead">Already Changed</a> instead, because a heading that says <em>plan your exit</em> is an instruction, and an instruction to leave a free tier that is already gone is not one a reader can act on.</p>
   <div style="overflow-x:auto">
     <table class="risk-table">
       <thead>
-        <tr><th>Vendor</th><th>Risk</th><th>Category</th><th>Reasoning</th><th>Last Change</th></tr>
+        ${riskTableHead("Risk", "Reasoning", "Last Change")}
       </thead>
       <tbody>
-        ${highRisk.map(buildRiskRow).join("\n        ")}
+        ${highBand.stillFree.map(buildRiskRow).join("\n        ")}
       </tbody>
     </table>
   </div>
   <div class="context-box">
     <strong>Pattern:</strong> High-risk vendors share traits: multiple negative changes in a short period (OpenAI, X/Twitter), hostile stance toward free users (Spotify, Amazon SP-API), or entering "sustaining mode" with no investment (Heroku). When you see a vendor make 2+ negative changes in 6 months, the third is coming.
   </div>
+  <div class="context-box">
+    <strong>How this band is split:</strong> the grade is editorial and unchanged; only where it renders is derived. A vendor appears above if our catalogue holds a free tier for it today. ${highBand.alreadyGone.length === 0 ? "Every vendor in this band still has one." : highBand.alreadyGone.map(e => `${escHtmlServer(e.vendor)} (${escHtmlServer(FREE_TIER_STANDING_LABELS[freeTierStanding(e, offers)])})`).join(", ")}${highBand.alreadyGone.length === 0 ? "" : " did not, so they moved down a section."}
+  </div>
 
   <h2 id="dead">5. \u26AB Already Changed — Lessons Learned</h2>
-  <p class="section-intro">Free tiers that no longer exist. Each one is a case study in what to watch for.</p>
+  <p class="section-intro">Free tiers that no longer exist. Each one is a case study in what to watch for. The ${highBand.alreadyGone.length} vendors carrying the high grade with no free tier left in our catalogue are listed here too, under their own grade.</p>
   <div style="overflow-x:auto">
     <table class="risk-table">
       <thead>
-        <tr><th>Vendor</th><th>Status</th><th>Category</th><th>What Happened</th><th>Date</th></tr>
+        ${riskTableHead("Status", "What Happened", "Date")}
       </thead>
       <tbody>
-        ${deadEntries.map(buildRiskRow).join("\n        ")}
+        ${[...deadEntries, ...highBand.alreadyGone].map(buildRiskRow).join("\n        ")}
       </tbody>
     </table>
   </div>
 
-  <h2 id="scoring">6. Full Scoring Table</h2>
-  <p class="section-intro">All ${riskEntries.length} vendors ranked by risk level. Sort mentally by color: green is safe, yellow needs watching, red needs action, gray is gone.</p>
+  <h2 id="scorecard">6. Scorecard — How the Grades Have Held Up</h2>
+  <p class="section-intro">A grade nobody scores is not a prediction. Every band below is counted on request against the change log as it stands right now: for the vendors we put in each band, how many have since taken a change that removed a free tier, cut its limits, added a restriction, killed an open-source edition, or deprecated the graded product itself. Vendors that took nothing stay in the denominator.</p>
   <div style="overflow-x:auto">
     <table class="risk-table">
       <thead>
-        <tr><th>Vendor</th><th>Risk</th><th>Category</th><th>Reasoning</th><th>Last Change</th></tr>
+        <tr><th>Band</th><th>Vendors graded</th><th>Took a free tier negative</th><th>Rate</th><th>Negative records</th><th>Nothing tracked since</th></tr>
+      </thead>
+      <tbody>
+        ${bandScores.map(b => `<tr>
+          <td style="font-weight:600;color:${riskColors[b.grade]}">${riskEmoji[b.grade]} ${riskLabels[b.grade]}</td>
+          <td style="font-family:var(--mono)">${b.vendors}</td>
+          <td style="font-family:var(--mono)">${b.vendorsWithANegative}</td>
+          <td style="font-family:var(--mono);font-weight:600">${b.rate}%</td>
+          <td style="font-family:var(--mono)">${b.negativeRecords}</td>
+          <td style="font-family:var(--mono)">${b.vendorsWithNothingTracked}</td>
+        </tr>`).join("\n        ")}
+      </tbody>
+    </table>
+  </div>
+  <div class="context-box">
+    <strong>What the scorecard does not count.</strong> A record is left out if it has since been reversed or retracted, if it came from an index sweep rather than a vendor announcement, or if it deprecates a different product the same vendor sells — an AWS Lambda runtime reaching end of life is not the AWS free tier narrowing. Each vendor's row in the tables above names every record tracked since it was graded and says which of these applied. ${bandScores.reduce((sum, b) => sum + b.vendorsWithNothingTracked, 0)} of the ${riskEntries.length} graded vendors have had nothing tracked at all since grading, which is the honest limit on how much any of these rates can carry.
+  </div>
+
+  <h2 id="scoring">7. Full Scoring Table</h2>
+  <p class="section-intro">All ${riskEntries.length} vendors ranked by risk level, each with the date its grade was set. Sort mentally by color: green is safe, yellow needs watching, red needs action, gray is gone.</p>
+  <div style="overflow-x:auto">
+    <table class="risk-table">
+      <thead>
+        ${riskTableHead("Risk", "Reasoning", "Last Change")}
       </thead>
       <tbody>
         ${riskEntries.map(buildRiskRow).join("\n        ")}
@@ -23014,7 +23022,7 @@ ${mcpCtaCss()}
     </table>
   </div>
 
-  <h2 id="heatmap">7. Category Risk Heatmap</h2>
+  <h2 id="heatmap">8. Category Risk Heatmap</h2>
   <p class="section-intro">Which categories face the most pricing pressure? Darker red = higher percentage of negative changes. Based on ${changesInForce.length} tracked changes across all categories.</p>
   <div style="display:grid;gap:.5rem;margin:1rem 0 2rem">
     ${heatmapData.map(h => {
@@ -23041,7 +23049,7 @@ ${mcpCtaCss()}
     <strong>Reading the heatmap:</strong> Red bars = negative changes (removals, reductions, restrictions). Green bars = positive changes (expansions, new tiers). Gray = neutral restructurings. Categories with 80%+ negative changes (APIs, Testing, Monitoring) are under the most pricing pressure. AI/ML shows a split — some vendors contracting while new entrants expand.
   </div>
 
-  <h2 id="patterns">8. Pattern Analysis — What ${changesInForce.length} Changes Tell Us</h2>
+  <h2 id="patterns">9. Pattern Analysis — What ${changesInForce.length} Changes Tell Us</h2>
   <p class="section-intro">Statistical patterns from our pricing change dataset that predict future free tier removals.</p>
 
   <div class="diff-card" style="border-left-color:#f85149">
@@ -23070,7 +23078,7 @@ ${mcpCtaCss()}
     <p class="diff-desc">Not all changes are negative. ${positiveChanges.length} of ${changesInForce.length} changes were positive (new tiers or expansions). Safe signals: profitable company with developer funnel business model (Cloudflare, GitHub), open-source core with commercial layer (Grafana, Sentry), and competitive market forcing free tier maintenance (AI coding tools, cloud providers).</p>
   </div>
 
-  <h2 id="counter">9. Counter-Trends — Who's Expanding Free Tiers</h2>
+  <h2 id="counter">10. Counter-Trends — Who's Expanding Free Tiers</h2>
   <p class="section-intro">While most pricing changes are negative (${negativeChanges.length} of ${changesInForce.length}), a meaningful minority of vendors are actively expanding. Understanding why reveals what makes a free tier durable.</p>
 
   <div class="verdict-box" style="border-color:#3fb950;background:linear-gradient(135deg,rgba(63,185,80,0.1),rgba(59,130,246,0.1))">
@@ -23104,7 +23112,7 @@ ${mcpCtaCss()}
     </div>
   </div>
 
-  <h2 id="advice">10. How to Protect Your Stack</h2>
+  <h2 id="advice">11. How to Protect Your Stack</h2>
   <div class="verdict-box">
     <h3>Practical Risk Mitigation</h3>
     <div class="verdict-item">
@@ -23129,7 +23137,7 @@ ${mcpCtaCss()}
     </div>
   </div>
 
-  <h2 id="faq">11. Frequently Asked Questions</h2>
+  <h2 id="faq">12. Frequently Asked Questions</h2>
   ${faqs.map(f => '<div class="diff-card" style="border-left-color:var(--accent);cursor:pointer" onclick="const a=this.querySelector(\'.diff-desc\');a.style.display=a.style.display===\'none\'?\'block\':\'none\'">'
     + '<h3 style="margin:0;display:flex;justify-content:space-between;align-items:center">' + escHtmlServer(f.q) + ' <span style="color:var(--text-dim);font-size:.8rem">&#9660;</span></h3>'
     + '<p class="diff-desc" style="margin-top:.5rem">' + escHtmlServer(f.a) + '</p>'
@@ -23157,7 +23165,7 @@ ${mcpCtaCss()}
   </div>
 
   <div class="search-cta">
-    <p>This risk index covers ${riskEntries.length} major developer tools as of April 2026. For full free tier details on any vendor, search all ${offers.length.toLocaleString()} tracked developer tools at <a href="/search">/search</a>. Track changes in real-time via our <a href="/feed.xml">Atom feed</a> or <a href="/setup">MCP server</a>.</p>
+    <p>This risk index covers ${riskEntries.length} major developer tools, graded from ${gradedFrom} and scored above against everything tracked since. For full free tier details on any vendor, search all ${offers.length.toLocaleString()} tracked developer tools at <a href="/search">/search</a>. Track changes in real-time via our <a href="/feed.xml">Atom feed</a> or <a href="/setup">MCP server</a>.</p>
   </div>
 
   ${buildMoreAlternativesGuides(slug)}
@@ -45833,7 +45841,7 @@ ${globalNavCss()}
   <div style="margin:2rem 0 1rem;padding:1.25rem;border:1px solid var(--border);border-radius:8px;background:var(--bg-card)">
     <h3 style="margin:0 0 .75rem;font-family:var(--serif);font-size:1rem;color:var(--text)">More Guides</h3>
     <ul style="list-style:none;padding:0;margin:0;display:flex;flex-direction:column;gap:.5rem">
-      <li><a href="/free-tier-risk">Free Tier Risk Index</a> <span style="color:var(--text-muted);font-size:.85rem">&mdash; sustainability risk scores for 38 vendors</span></li>
+      <li><a href="/free-tier-risk">Free Tier Risk Index</a> <span style="color:var(--text-muted);font-size:.85rem">&mdash; sustainability risk scores for ${riskEntries.length} vendors</span></li>
       <li><a href="/free-tier-tracker">Q1 2026 Free Tier Tracker</a> <span style="color:var(--text-muted);font-size:.85rem">&mdash; removals, expansions, and trends</span></li>
       <li><a href="/startup-credits">Startup Credits Directory</a> <span style="color:var(--text-muted);font-size:.85rem">&mdash; 19 programs, $1M+ combined credits</span></li>
       <li><a href="/free-startup-stack">Free Startup Stack</a> <span style="color:var(--text-muted);font-size:.85rem">&mdash; complete infrastructure on $0/month</span></li>

--- a/test/free-tier-risk-scorecard.test.ts
+++ b/test/free-tier-risk-scorecard.test.ts
@@ -1,0 +1,372 @@
+import { describe, it, before, after } from "node:test";
+import assert from "node:assert";
+import fs from "node:fs";
+import path from "node:path";
+import { spawn, type ChildProcess } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+const {
+  riskEntries,
+  scorecard,
+  gradesLastSet,
+  gradesFirstSet,
+  gradesSetOn,
+  gradingDatesClause,
+  trackedSinceGrading,
+  negativesSinceGrading,
+  neverTracked,
+  whyNotEvidence,
+  freeTierStanding,
+  splitByFreeTierStanding,
+  changeLogNamesFor,
+  FREE_TIER_NEGATIVE_TYPES,
+  GRADE_FACTORS_WITHOUT_PRICING_HISTORY,
+  INDEX_SWEEP_STATE,
+} = await import("../dist/risk-scorecard.js");
+const { CHANGE_DIRECTION } = await import("../dist/change-direction.js");
+const { changeEntryDateLabel } = await import("../dist/change-dates.js");
+const { loadOffers, loadDealChanges } = await import("../dist/data.js");
+
+const offers = loadOffers();
+const dealChanges = loadDealChanges();
+
+const ISO_DATE = /^\d{4}-\d{2}-\d{2}$/;
+const GRADED_COUNT = 37;
+const BANDS = ["low", "medium", "high", "dead"] as const;
+
+let serverProc: ChildProcess | null = null;
+let port = 0;
+let riskHtml = "";
+
+function startServer(): Promise<{ proc: ChildProcess; port: number }> {
+  return new Promise((resolve, reject) => {
+    const serverPath = path.join(__dirname, "..", "dist", "serve.js");
+    const proc = spawn("node", [serverPath], {
+      stdio: ["pipe", "pipe", "pipe"],
+      env: { ...process.env, PORT: "0", BASE_URL: "http://localhost" },
+    });
+    const timeout = setTimeout(() => { proc.kill(); reject(new Error("Server startup timeout")); }, 20000);
+    proc.stderr!.on("data", (data: Buffer) => {
+      const match = data.toString().match(/running on http:\/\/localhost:(\d+)/);
+      if (match) {
+        clearTimeout(timeout);
+        resolve({ proc, port: parseInt(match[1], 10) });
+      }
+    });
+    proc.on("error", (err) => { clearTimeout(timeout); reject(err); });
+  });
+}
+
+function sectionBetween(html: string, openId: string, closeId: string): string {
+  const from = html.indexOf(`id="${openId}"`);
+  const to = html.indexOf(`id="${closeId}"`);
+  assert.ok(from >= 0, `the page has no section anchored ${openId}`);
+  assert.ok(to > from, `the page has no section anchored ${closeId} after ${openId}`);
+  return html.slice(from, to);
+}
+
+before(async () => {
+  const started = await startServer();
+  serverProc = started.proc;
+  port = started.port;
+  const res = await fetch(`http://localhost:${port}/free-tier-risk`);
+  assert.strictEqual(res.status, 200);
+  riskHtml = await res.text();
+});
+
+after(() => {
+  if (serverProc) serverProc.kill();
+});
+
+describe("every risk grade carries the date it was set", () => {
+  it("dates all of them", () => {
+    assert.strictEqual(riskEntries.length, GRADED_COUNT);
+    for (const entry of riskEntries) {
+      assert.ok(ISO_DATE.test(entry.graded), `${entry.vendor} carries no grading date`);
+    }
+  });
+
+  it("reports the newest grading date as the date the grades were last set", () => {
+    const dates = gradesSetOn(riskEntries);
+    assert.deepStrictEqual(dates, [...dates].sort());
+    assert.strictEqual(gradesLastSet(riskEntries), dates[dates.length - 1]);
+  });
+
+  it("renders the grading date beside the grade for every vendor", () => {
+    for (const entry of riskEntries) {
+      assert.ok(
+        riskHtml.includes(`graded ${entry.graded}`),
+        `the page renders no grading date for ${entry.vendor}`,
+      );
+    }
+  });
+
+  it("states the dates the grades were set in the page byline and the meta description", () => {
+    const clause = gradingDatesClause(riskEntries);
+    assert.ok(clause.includes(gradesFirstSet(riskEntries)), "the byline clause hides the date the grades were first set");
+    assert.ok(clause.includes(gradesLastSet(riskEntries)), "the byline clause hides the date a grade was last revised");
+    assert.ok(riskHtml.includes(clause), `the byline does not date the grades: ${clause}`);
+    const meta = riskHtml.match(/<meta name="description" content="([^"]*)"/);
+    assert.ok(meta, "the page publishes no meta description");
+    assert.ok(meta![1].includes(clause), `the meta description does not date the grades: ${meta![1]}`);
+  });
+});
+
+describe("no surface claims the grades refresh on their own", () => {
+  it("answers the update-cadence question with the date the grades were set", () => {
+    const faq = riskHtml.match(/How often is the Free Tier Risk Index updated\?[^]*?(?=<\/div>|<h3)/);
+    assert.ok(faq, "the page no longer answers how often the index is updated");
+    assert.ok(
+      faq![0].includes(gradingDatesClause(riskEntries)),
+      "the update-cadence answer does not name the dates the grades were set",
+    );
+    assert.ok(
+      !/We update risk scores whenever a new pricing change is tracked/.test(riskHtml),
+      "the page still says the risk scores move with every tracked change",
+    );
+  });
+
+  it("carries the same answer in the structured data a machine reads", () => {
+    const blocks = [...riskHtml.matchAll(/<script type="application\/ld\+json">([^]*?)<\/script>/g)]
+      .map(m => JSON.parse(m[1]));
+    const faqBlock = blocks.find(b => b["@type"] === "FAQPage");
+    assert.ok(faqBlock, "the page ships no FAQ structured data");
+    const answers: string[] = faqBlock.mainEntity.map((q: any) => q.acceptedAnswer.text);
+    const cadence = answers.find(a => a.includes("editorial"));
+    assert.ok(cadence, "the structured data does not say the grades are editorial");
+    assert.ok(cadence!.includes(gradingDatesClause(riskEntries)), "the structured data does not date the grades");
+    const lowestRisk = answers.find(a => a.includes("lowest-risk picks"));
+    assert.ok(lowestRisk, "the structured data no longer names the lowest-risk picks");
+    const named = ["Cloudflare", "GitHub", "Grafana Cloud", "AWS Free Tier", "Google Cloud (Always Free)"];
+    const namedGradedOn = gradesLastSet(riskEntries.filter(e => named.includes(e.vendor)));
+    assert.ok(
+      lowestRisk!.includes(`graded ${namedGradedOn}`),
+      "the structured data names graded vendors without the date of their grade",
+    );
+  });
+});
+
+describe("the band that gives a forward instruction holds only free tiers that still exist", () => {
+  it("keeps a vendor out of Plan Your Exit unless our catalogue holds a free tier for it", () => {
+    const high = riskEntries.filter(e => e.risk === "high");
+    const split = splitByFreeTierStanding(high, offers);
+    assert.ok(split.alreadyGone.length > 0, "no high-grade vendor has lost its free tier, so the split proves nothing");
+    const section = sectionBetween(riskHtml, "high", "dead");
+    for (const entry of split.stillFree) {
+      assert.ok(section.includes(`>${entry.vendor}</a>`), `${entry.vendor} still has a free tier and is not listed under Plan Your Exit`);
+      assert.strictEqual(freeTierStanding(entry, offers), "still_listed");
+    }
+    for (const entry of split.alreadyGone) {
+      assert.ok(
+        !section.includes(`>${entry.vendor}</a>`),
+        `${entry.vendor} has no free tier left and is listed under a heading telling readers to plan an exit from it`,
+      );
+    }
+  });
+
+  it("lists the vendors it moved under Already Changed instead, still under their own grade", () => {
+    const high = riskEntries.filter(e => e.risk === "high");
+    const split = splitByFreeTierStanding(high, offers);
+    const section = sectionBetween(riskHtml, "dead", "scorecard");
+    for (const entry of split.alreadyGone) {
+      assert.ok(section.includes(`>${entry.vendor}</a>`), `${entry.vendor} was moved out of the forward band and lands nowhere`);
+    }
+    assert.ok(section.includes("High Risk"), "the moved vendors no longer show the grade they were given");
+  });
+
+  it("names why each moved vendor was moved", () => {
+    const split = splitByFreeTierStanding(riskEntries.filter(e => e.risk === "high"), offers);
+    for (const entry of split.alreadyGone) {
+      const standing = freeTierStanding(entry, offers);
+      assert.notStrictEqual(standing, "still_listed");
+      assert.ok(riskHtml.includes(entry.vendor), `${entry.vendor} is not named on the page`);
+    }
+    assert.ok(riskHtml.includes("no catalogue record") || riskHtml.includes("no free tier in our catalogue"),
+      "the page does not say on what basis a vendor left the forward band");
+  });
+});
+
+describe("no entry is silent about its own window", () => {
+  it("says what has been tracked for every vendor since it was graded", () => {
+    for (const entry of riskEntries) {
+      const tracked = trackedSinceGrading(entry, dealChanges);
+      if (neverTracked(entry, dealChanges)) continue;
+      if (tracked.length === 0) continue;
+      for (const record of tracked) {
+        assert.ok(
+          riskHtml.includes(`${changeEntryDateLabel(record.change)}</span><div>${record.change.change_type}`),
+          `${entry.vendor} does not publish the ${record.change.change_type} tracked on ${record.change.date}`,
+        );
+      }
+    }
+  });
+
+  it("says so out loud when nothing has been tracked", () => {
+    const quiet = riskEntries.filter(e => !neverTracked(e, dealChanges) && trackedSinceGrading(e, dealChanges).length === 0);
+    assert.ok(quiet.length > 0, "every graded vendor has moved since grading, so the empty case proves nothing");
+    assert.ok(riskHtml.includes("Nothing tracked since it was graded."), "an entry with nothing tracked says nothing at all");
+  });
+
+  it("marks a change it does not count, and says which rule kept it out", () => {
+    const notCounted = riskEntries.flatMap(e => trackedSinceGrading(e, dealChanges)).filter(t => t.notEvidence !== null);
+    assert.ok(notCounted.length > 0, "no tracked change was excluded, so the exclusions prove nothing");
+    for (const reason of new Set(notCounted.map(t => t.notEvidence))) {
+      assert.ok(riskHtml.includes(`not counted &mdash;`), "an excluded change is shown without saying it was excluded");
+      assert.ok(reason !== null);
+    }
+  });
+});
+
+describe("a grade with no pricing history behind it says so", () => {
+  it("names the vendors our change log has never held a record for", () => {
+    const untracked = riskEntries.filter(e => neverTracked(e, dealChanges));
+    assert.ok(untracked.length > 0, "every graded vendor has a tracked change, so the disclosure proves nothing");
+    for (const entry of untracked) {
+      assert.ok(
+        riskHtml.includes(`No change has ever been tracked for ${entry.vendor}.`),
+        `${entry.vendor} carries a grade with no record behind it and the page does not say so`,
+      );
+    }
+    assert.ok(
+      riskHtml.includes(GRADE_FACTORS_WITHOUT_PRICING_HISTORY),
+      "the page does not name which factors supplied a grade that pricing history could not",
+    );
+  });
+
+  it("does not attribute those grades to the change data in the methodology either", () => {
+    const untracked = riskEntries.filter(e => neverTracked(e, dealChanges));
+    const method = sectionBetween(riskHtml, "methodology", "low");
+    for (const entry of untracked) {
+      assert.ok(method.includes(entry.vendor), `the methodology claims change data behind ${entry.vendor}'s grade without exception`);
+    }
+  });
+});
+
+describe("the page publishes its own hit rate", () => {
+  it("scores every band and keeps the quiet vendors in the denominator", () => {
+    const section = sectionBetween(riskHtml, "scorecard", "scoring");
+    for (const band of scorecard(riskEntries, dealChanges)) {
+      const inBand = riskEntries.filter(e => e.risk === band.grade).length;
+      assert.strictEqual(band.vendors, inBand, `the ${band.grade} band scored ${band.vendors} of ${inBand} graded vendors`);
+      assert.ok(band.vendorsWithNothingTracked <= band.vendors);
+      assert.ok(section.includes(`>${band.rate}%<`), `the ${band.grade} band publishes no rate`);
+      assert.ok(section.includes(`>${band.vendors}<`), `the ${band.grade} band publishes no denominator`);
+    }
+    assert.ok(BANDS.every(b => section.includes(b === "dead" ? "Already Changed" : `${b[0].toUpperCase()}${b.slice(1)} Risk`)),
+      "the scorecard does not cover every band");
+  });
+
+  it("counts a vendor only for a record in force that names a free tier negative", () => {
+    for (const entry of riskEntries) {
+      for (const negative of negativesSinceGrading(entry, dealChanges)) {
+        assert.ok(FREE_TIER_NEGATIVE_TYPES.includes(negative.change_type), `${negative.change_type} counted against ${entry.vendor}`);
+        assert.strictEqual(whyNotEvidence(negative), null);
+        assert.ok(negative.date > entry.graded, `a change from before ${entry.vendor} was graded was counted against it`);
+      }
+    }
+  });
+
+  it("shows the same rate a reader recomputing it from the change log would get", () => {
+    const section = sectionBetween(riskHtml, "scorecard", "scoring");
+    for (const band of scorecard(riskEntries, dealChanges)) {
+      const expected = band.vendors === 0 ? 0 : Math.round((band.vendorsWithANegative / band.vendors) * 100);
+      assert.strictEqual(band.rate, expected);
+      assert.ok(section.includes(`>${band.negativeRecords}<`), `the ${band.grade} band publishes no record count`);
+    }
+  });
+});
+
+describe("the grading rules the page states are the rules it applies", () => {
+  it("does not count a record that has been reversed or retracted", () => {
+    const reversed = dealChanges.filter((c: any) => c.resolution);
+    assert.ok(reversed.length > 0, "no record carries a resolution, so the exclusion proves nothing");
+    for (const change of reversed) assert.strictEqual(whyNotEvidence(change), "no_longer_in_force");
+  });
+
+  it("does not count the index sweep", () => {
+    const swept = dealChanges.filter((c: any) => c.current_state === INDEX_SWEEP_STATE && !c.resolution);
+    assert.ok(swept.length > 0, "no record came from an index sweep, so the exclusion proves nothing");
+    for (const change of swept) assert.strictEqual(whyNotEvidence(change), "index_sweep");
+  });
+
+  it("does not count a deprecation of a different product the vendor sells", () => {
+    const excluded = riskEntries
+      .flatMap(e => trackedSinceGrading(e, dealChanges))
+      .filter(t => t.notEvidence === "another_product");
+    assert.ok(excluded.length > 0, "no deprecation named another product, so the exclusion proves nothing");
+    for (const record of excluded) assert.strictEqual(record.change.change_type, "product_deprecated");
+  });
+
+  it("keeps its negative set inside the direction map the rest of the site reads", () => {
+    for (const type of FREE_TIER_NEGATIVE_TYPES) {
+      assert.strictEqual(CHANGE_DIRECTION[type], "negative", `${type} is not negative in the shared direction map`);
+    }
+  });
+
+  it("looks up every graded vendor under a name the change log actually uses", () => {
+    const known = new Set(dealChanges.map((c: any) => c.vendor));
+    const unmatched = riskEntries.flatMap(e => changeLogNamesFor(e).filter((n: string) => !known.has(n)).map((n: string) => `${e.vendor} -> ${n}`));
+    const orphaned = riskEntries.filter(e => neverTracked(e, dealChanges)).map(e => e.vendor);
+    for (const miss of unmatched) {
+      const vendor = miss.split(" -> ")[0];
+      const entry = riskEntries.find(e => e.vendor === vendor)!;
+      const stillMatches = changeLogNamesFor(entry).some((n: string) => known.has(n));
+      assert.ok(
+        stillMatches || orphaned.includes(vendor),
+        `${miss} matches no vendor in the change log and is not published as an untracked grade`,
+      );
+    }
+  });
+});
+
+describe("the count in the body and the count in the metadata agree", () => {
+  it("publishes the graded population once", () => {
+    const meta = riskHtml.match(/<meta name="description" content="([^"]*)"/)![1];
+    assert.ok(meta.includes(`${riskEntries.length} developer tool free tiers`), `the meta description miscounts: ${meta}`);
+    assert.ok(riskHtml.includes(`All ${riskEntries.length} vendors ranked by risk level`), "the scoring table miscounts");
+    assert.ok(riskHtml.includes(`This index scores ${riskEntries.length} major developer tools`), "the summary miscounts");
+    assert.ok(riskHtml.includes(`This risk index covers ${riskEntries.length} major developer tools`), "the closing line miscounts");
+  });
+
+  it("counts the same on the guide hub and the guide directory", async () => {
+    for (const route of ["/alternatives", "/guides"]) {
+      const res = await fetch(`http://localhost:${port}${route}`);
+      if (res.status !== 200) continue;
+      const html = await res.text();
+      if (!html.includes("Free Tier Risk Index")) continue;
+      assert.ok(!/risk (?:scores|analysis) for 38\b/.test(html), `${route} still counts 38 graded vendors`);
+    }
+  });
+});
+
+describe("no route on the site states a stale count or a cadence the grades do not keep", () => {
+  it("sweeps every published route", async () => {
+    const indexRes = await fetch(`http://localhost:${port}/sitemap.xml`);
+    assert.strictEqual(indexRes.status, 200);
+    const children = [...(await indexRes.text()).matchAll(/<loc>([^<]+)<\/loc>/g)].map(m => m[1]);
+    const paths = new Set<string>(["/"]);
+    for (const child of children) {
+      const childRes = await fetch(child.replace(/^https?:\/\/[^/]+/, `http://localhost:${port}`));
+      if (childRes.status !== 200) continue;
+      for (const loc of (await childRes.text()).matchAll(/<loc>([^<]+)<\/loc>/g)) {
+        paths.add(new URL(loc[1]).pathname);
+      }
+    }
+    const ROUTE_FLOOR = 2000;
+    assert.ok(paths.size >= ROUTE_FLOOR, `swept only ${paths.size} routes`);
+
+    const offenders: string[] = [];
+    for (const route of paths) {
+      const res = await fetch(`http://localhost:${port}${route}`);
+      if (res.status !== 200) continue;
+      const html = await res.text();
+      if (/risk (?:scores|analysis) for 38\b/.test(html)) offenders.push(`${route} counts 38 graded vendors`);
+      if (/We update risk scores whenever a new pricing change is tracked/.test(html)) {
+        offenders.push(`${route} says the risk scores move with every tracked change`);
+      }
+    }
+    assert.deepStrictEqual(offenders, [], offenders.join("; "));
+  });
+});


### PR DESCRIPTION
Refs #1460

`/free-tier-risk` makes the only falsifiable forward claim on the site and had never been graded. Its FAQ told extractors *"We update risk scores whenever a new pricing change is tracked"* while the grades themselves had not moved since March, and its red band — headed **Plan Your Exit** — was largely a list of free tiers that were already gone.

## What the page does now

**Every grade carries the date it was set.** 36 read `2026-03-26`; Fly.io reads `2026-09-05`, because it was regraded medium → high by 455b411. The byline, the meta description and the FAQ read `Grades set 2026-03-26, one revised 2026-09-05` rather than a single date that would be wrong for one row or thirty-six.

**A scorecard, derived on request.** For the vendors in each band, how many have since taken a change that removed a free tier, cut limits, added a restriction, killed an open-source edition or deprecated the graded product itself — counting only records still in force, and keeping the vendors with nothing tracked in the denominator. Low 0/10, medium 3/11, high 2/10, dead 1/6.

**No entry is silent about its own window.** Each row lists every record tracked for that vendor since its grading date, dated through the same labelling helper the rest of the site uses, and marks each one as counted, not a free tier negative, or excluded with the rule that excluded it.

**The forward band holds only free tiers that still exist.** No grade changed. A vendor renders under *Plan Your Exit* only if our catalogue holds a free tier for it today; the other six keep the high grade and render under *Already Changed*, with the reason named.

**A grade with no pricing history behind it says so.** CockroachDB has no record in the change log at all. Its cell and the Pricing History methodology card both say the 40% factor supplied nothing for it.

**`38` is gone from all four places that published it** — none of them counted. They read the array length.

## How it is built

`src/risk-scorecard.ts` holds the 37 entries, the grading window, the exclusion rules and the band scoring. `serve.ts` and `guides.ts` both read it, so the count cannot drift between the page and the guide list an agent fetches over MCP.

The exclusions reuse existing predicates rather than restating them: `isNoLongerInForce` for reversed and retracted records, `deprecationEndsTheListedProduct` for a deprecation that names another of the vendor's products, and `tierRecordsAFreeTier` for whether a free tier still stands. A test holds the negative set inside the shared `CHANGE_DIRECTION` map so the two cannot drift apart.

## Tests

`test/free-tier-risk-scorecard.test.ts`, 25 tests. 17 fail against `main` with the module present, including a sweep of every published route for the stale count and for the cadence claim. Every empty-case assertion is floored on real data so none can pass vacuously.

Three existing guards caught this change and all three were followed rather than exempted: the change-date provenance scan, which is why every tracked record renders through `changeEntryDateLabel`; the FAQ figure register, whose two counts are raised in `data/quality_budgets.json` with the reason recorded; and the page data-source register, where `/free-tier-risk` was declaring `reads_index: false, data_source: unsourced` on a tier-A page that asserts vendor facts. Reading the catalogue for the band split makes that declaration false, so it now reads `reads_index: true, data_source: catalogue` and `unsourced_tier_a` ratchets 40 to 39.
