### PR TITLE
Cite the source of every free-tier figure on the compiled comparison pages

### DIFF
--- a/data/page-reviews.json
+++ b/data/page-reviews.json
@@ -119,9 +119,9 @@
       "reviewer": null,
       "review_outcome": null,
       "review_note": null,
-      "reads_index": false,
+      "reads_index": true,
       "reads_changes": true,
-      "data_source": "unsourced",
+      "data_source": "catalogue",
       "data_source_reason": null
     },
     {
@@ -195,9 +195,9 @@
       "reviewer": null,
       "review_outcome": null,
       "review_note": null,
-      "reads_index": false,
+      "reads_index": true,
       "reads_changes": true,
-      "data_source": "unsourced",
+      "data_source": "catalogue",
       "data_source_reason": null
     },
     {
@@ -226,9 +226,9 @@
       "reviewer": null,
       "review_outcome": null,
       "review_note": null,
-      "reads_index": false,
+      "reads_index": true,
       "reads_changes": true,
-      "data_source": "unsourced",
+      "data_source": "catalogue",
       "data_source_reason": null
     },
     {
@@ -276,9 +276,9 @@
       "reviewer": null,
       "review_outcome": null,
       "review_note": null,
-      "reads_index": false,
+      "reads_index": true,
       "reads_changes": true,
-      "data_source": "unsourced",
+      "data_source": "catalogue",
       "data_source_reason": null
     },
     {
@@ -344,9 +344,9 @@
       "reviewer": null,
       "review_outcome": null,
       "review_note": null,
-      "reads_index": false,
+      "reads_index": true,
       "reads_changes": true,
-      "data_source": "unsourced",
+      "data_source": "catalogue",
       "data_source_reason": null
     },
     {
@@ -373,9 +373,9 @@
       "reviewer": null,
       "review_outcome": null,
       "review_note": null,
-      "reads_index": false,
+      "reads_index": true,
       "reads_changes": true,
-      "data_source": "unsourced",
+      "data_source": "catalogue",
       "data_source_reason": null
     },
     {
@@ -479,9 +479,9 @@
       "reviewer": null,
       "review_outcome": null,
       "review_note": null,
-      "reads_index": false,
+      "reads_index": true,
       "reads_changes": true,
-      "data_source": "unsourced",
+      "data_source": "catalogue",
       "data_source_reason": null
     },
     {
@@ -504,9 +504,9 @@
       "reviewer": null,
       "review_outcome": null,
       "review_note": null,
-      "reads_index": false,
+      "reads_index": true,
       "reads_changes": true,
-      "data_source": "unsourced",
+      "data_source": "catalogue",
       "data_source_reason": null
     },
     {
@@ -592,9 +592,9 @@
       "reviewer": null,
       "review_outcome": null,
       "review_note": null,
-      "reads_index": false,
+      "reads_index": true,
       "reads_changes": true,
-      "data_source": "unsourced",
+      "data_source": "catalogue",
       "data_source_reason": null
     },
     {
@@ -704,9 +704,9 @@
       "reviewer": null,
       "review_outcome": null,
       "review_note": null,
-      "reads_index": false,
+      "reads_index": true,
       "reads_changes": true,
-      "data_source": "unsourced",
+      "data_source": "catalogue",
       "data_source_reason": null
     },
     {
@@ -764,9 +764,9 @@
       "reviewer": "coder",
       "review_outcome": "fail",
       "review_note": "Read against resend.com/pricing, mailersend.com/pricing and mailerlite.com/pricing on 2026-09-05, after a Resend record dated 2026-09-05 moved under the 2026-09-04 review. Resend: 3,000 emails/month and the 100/day cap hold; custom domains on Free is 3, not the 1 the page published, and the catalogue record carried the same 1. MailerSend: the Free plan is 500 emails/month with 1 domain, 10 templates, 5 seats, 1,000 daily API requests and 1-day activity retention, and the 14-day Professional trial carries the same 500 \u2014 so the 3,000 the page published on three surfaces was not the trial figure either. Hobby is $7.00/month monthly, $5.60 billed yearly, for 5,000 emails. MailerLite: the Free plan is 250 subscribers and 2,500 monthly emails, below both the 1,000/12,000 the page published and the 500/12,000 in our own record; the record is the stale side and no change record holds 250. Corrected on this page: the MailerSend table row, section and 3K cost-trap cell, the MailerLite table row and section, the Resend section, and the transactional-email answer on /email-service-alternatives. Not verified in this pass: Amazon SES, Brevo, Mailtrap, Loops, Mailjet, Postmark, Maileroo, EmailOctopus, Buttondown, Substack, SMTP2GO, EmailLabs.io and the 10K/50K/100K/500K rows of the cost-trap table.",
-      "reads_index": false,
+      "reads_index": true,
       "reads_changes": true,
-      "data_source": "unsourced",
+      "data_source": "catalogue",
       "data_source_reason": null
     },
     {
@@ -1204,9 +1204,9 @@
       "reviewer": null,
       "review_outcome": null,
       "review_note": null,
-      "reads_index": false,
+      "reads_index": true,
       "reads_changes": true,
-      "data_source": "unsourced",
+      "data_source": "catalogue",
       "data_source_reason": null
     },
     {
@@ -1552,9 +1552,9 @@
       "reviewer": "pm",
       "review_outcome": "fail",
       "review_note": null,
-      "reads_index": false,
+      "reads_index": true,
       "reads_changes": true,
-      "data_source": "unsourced",
+      "data_source": "catalogue",
       "data_source_reason": null
     },
     {
@@ -1799,9 +1799,9 @@
       "reviewer": null,
       "review_outcome": null,
       "review_note": null,
-      "reads_index": false,
+      "reads_index": true,
       "reads_changes": true,
-      "data_source": "unsourced",
+      "data_source": "catalogue",
       "data_source_reason": null
     },
     {
@@ -1838,9 +1838,9 @@
       "reviewer": null,
       "review_outcome": null,
       "review_note": null,
-      "reads_index": false,
+      "reads_index": true,
       "reads_changes": true,
-      "data_source": "unsourced",
+      "data_source": "catalogue",
       "data_source_reason": null
     },
     {
@@ -2054,9 +2054,9 @@
       "reviewer": "pm",
       "review_outcome": "fail",
       "review_note": null,
-      "reads_index": false,
+      "reads_index": true,
       "reads_changes": true,
-      "data_source": "unsourced",
+      "data_source": "catalogue",
       "data_source_reason": null
     },
     {
@@ -2161,9 +2161,9 @@
       "reviewer": null,
       "review_outcome": null,
       "review_note": null,
-      "reads_index": false,
+      "reads_index": true,
       "reads_changes": true,
-      "data_source": "unsourced",
+      "data_source": "catalogue",
       "data_source_reason": null
     },
     {

--- a/data/quality_budgets.json
+++ b/data/quality_budgets.json
@@ -2,7 +2,7 @@
   "version": 1,
   "budgets": {
     "stale_fact_pages": 57,
-    "unsourced_tier_a": 39,
+    "unsourced_tier_a": 22,
     "uncited_change_records": 98,
     "source_checks_ok_without_quoted_evidence": 562,
     "faq_answers": 167,

--- a/src/change-citation.ts
+++ b/src/change-citation.ts
@@ -37,7 +37,16 @@ export function citationLabel(url: string): string {
 
 export const CITATION_CLASS = "change-source";
 
+export const RECORD_SOURCE_CLASS = "record-source";
+
+export const UNCITED_TAG_CLASS = "unsourced-tag";
+
 export const CITATION_LINK_HTML = "Source &nearr;";
+
+export const SOURCE_MARKER_MARKUP = new RegExp(
+  `<(a|span)\\b[^>]*class="[^"]*\\b(?:${RECORD_SOURCE_CLASS}|${UNCITED_TAG_CLASS})\\b[^"]*"[^>]*>[\\s\\S]*?</\\1>`,
+  "g",
+);
 
 const CITATION_STYLE = "font-size:.75rem;color:var(--text-dim)";
 

--- a/src/compiled-figures.ts
+++ b/src/compiled-figures.ts
@@ -1,4 +1,5 @@
 import { assertedVendorSlugs, changeLogAnchorFor, changeLogVendorNamed, isNonVendorSubject, resolveVendorSlug, toSlug, vendorSlugMap } from "./vendor-slug.js";
+import { SOURCE_MARKER_MARKUP } from "./change-citation.js";
 
 export interface CompiledPageRecord {
   date: string;
@@ -71,7 +72,10 @@ export function staticHalfOf(html: string): string {
 }
 
 function undecorated(fragment: string): string {
-  return fragment.replace(RECORD_MARKER, " ").replace(DECORATION_SPAN, " ");
+  return fragment
+    .replace(new RegExp(SOURCE_MARKER_MARKUP.source, "g"), " ")
+    .replace(RECORD_MARKER, " ")
+    .replace(DECORATION_SPAN, " ");
 }
 
 function plainText(fragment: string): string {
@@ -164,6 +168,23 @@ export function compiledFigureSlots(html: string): CompiledFigureSlot[] {
 
 export function vendorSubjectsOnCompiledPage(html: string): CompiledFigureSubject[] {
   return compiledFigureSlots(html).map(({ kind, label, linkedSlug }) => ({ kind, label, linkedSlug }));
+}
+
+export type CompiledFigureMarkup = (subject: CompiledFigureSubject) => string;
+
+export function appendToCompiledFigureSlots(html: string, markupFor: CompiledFigureMarkup): string {
+  const staticHtml = staticHalfOf(html);
+  let out = "";
+  let cursor = 0;
+  for (const slot of discoverSlots(staticHtml)) {
+    const markup = markupFor({ kind: slot.kind, label: slot.label, linkedSlug: slot.linkedSlug });
+    if (markup === "") continue;
+    const at = slot.innerStart + slot.inner.length;
+    if (at < cursor) continue;
+    out += html.slice(cursor, at) + markup;
+    cursor = at;
+  }
+  return out + html.slice(cursor);
 }
 
 const FREE_TIER_REMOVED_LABEL = "FREE REMOVED";

--- a/src/page-reviews.ts
+++ b/src/page-reviews.ts
@@ -723,7 +723,7 @@ export function deriveTier(html: string): ReviewTier {
 }
 
 export const PERTURBATION_SENTINEL = "PMPERTURB";
-export const CATALOGUE_TEXT_FIELDS = ["description", "tier", "notes", "limits"];
+export const CATALOGUE_TEXT_FIELDS = ["description", "tier", "notes", "limits", "url"];
 export const CHANGE_LOG_TEXT_FIELDS = ["summary", "previous_state", "current_state"];
 
 export function perturbTextFields(records: any[], fields: string[]): number {
@@ -748,8 +748,12 @@ export interface VendorFactRow {
   slug: string;
 }
 
+export const SOURCE_MARKER_IN_A_CELL =
+  /<(a|span)\b[^>]*class="[^"]*\b(?:record-source|unsourced-tag)\b[^"]*"[^>]*>[\s\S]*?<\/\1>/g;
+
 function cellText(fragment: string): string {
   return fragment
+    .replace(new RegExp(SOURCE_MARKER_IN_A_CELL.source, "g"), " ")
     .replace(/<[^>]*>/g, " ")
     .replace(/&amp;/g, "&")
     .replace(/&[a-z]+;/g, " ")
@@ -757,19 +761,45 @@ function cellText(fragment: string): string {
     .trim();
 }
 
-export function vendorFactRows(html: string, slugFor: VendorSlugLookup): VendorFactRow[] {
-  const found: VendorFactRow[] = [];
-  for (const row of html.match(TABLE_ROW) ?? []) {
-    const cells = row.match(ROW_CELL) ?? [];
+export interface TabulatedSubject {
+  subject: string;
+  slug: string | null;
+}
+
+export interface TabulatedSubjectSlot extends TabulatedSubject {
+  cell: string;
+  cellEnd: number;
+}
+
+export function tabulatedSubjectSlots(html: string, slugFor: VendorSlugLookup): TabulatedSubjectSlot[] {
+  const found: TabulatedSubjectSlot[] = [];
+  const rows = new RegExp(TABLE_ROW.source, "g");
+  for (let row = rows.exec(html); row !== null; row = rows.exec(html)) {
+    const cells = row[0].match(ROW_CELL) ?? [];
     const first = cells[0];
     if (first === undefined) continue;
     if (!cells.slice(1).some(cell => /\d/.test(cellText(cell)))) continue;
     const subject = cellText(first);
     const linked = first.match(VENDOR_CELL_LINK);
-    const slug = linked ? linked[1]! : subject ? slugFor(subject) : null;
-    if (slug) found.push({ subject, slug });
+    const cellStart = row.index + row[0].indexOf(first);
+    found.push({
+      subject,
+      slug: linked ? linked[1]! : subject ? slugFor(subject) : null,
+      cell: first,
+      cellEnd: cellStart + first.length - "</td>".length,
+    });
   }
   return found;
+}
+
+export function tabulatedSubjects(html: string, slugFor: VendorSlugLookup): TabulatedSubject[] {
+  return tabulatedSubjectSlots(html, slugFor).map(({ subject, slug }) => ({ subject, slug }));
+}
+
+export function vendorFactRows(html: string, slugFor: VendorSlugLookup): VendorFactRow[] {
+  return tabulatedSubjects(html, slugFor).filter(
+    (row): row is VendorFactRow => row.slug !== null,
+  );
 }
 
 export interface PageSourceMeasurement {

--- a/src/serve.ts
+++ b/src/serve.ts
@@ -32,7 +32,8 @@ import { publishedVendorLevel, vendorVerdictSentence, vendorBadge, freeTierClaim
 import { tierRecordsAFreeTier } from "./free-tier-record.js";
 import { PAGE_HEAD_OPEN, withLedeBeforeNav } from "./page-lede.js";
 import { UNGRADED_IMPACT_COLOR, changeImpactColor, changeImpactLabel, changeImpactWord, isChangeImpactLevel } from "./change-impact.js";
-import { COMPARED_SERVICES_PLACEHOLDER, fillComparedServicesCount, markCompiledFigures, recordsSinceCompiled, replaceTimelineRows, timelineRecordsFor, vendorForSubject, vendorSubjectsOnCompiledPage, type CompiledFigureSubject, type CompiledFigureVendor, type CompiledFigureVerdict } from "./compiled-figures.js";
+import { COMPARED_SERVICES_PLACEHOLDER, appendToCompiledFigureSlots, fillComparedServicesCount, markCompiledFigures, recordsSinceCompiled, replaceTimelineRows, staticHalfOf, timelineRecordsFor, vendorForSubject, vendorSubjectsOnCompiledPage, type CompiledFigureSubject, type CompiledFigureVendor, type CompiledFigureVerdict } from "./compiled-figures.js";
+import { NO_CATALOGUE_RECORD, citedSourceLinkHtml, citedSourcesListHtml, freeTierSourceOf, readClauseHtml, sourceMarkerHtml, uncitedSourceLinkHtml, withCitedSources, type CitedService, type FreeTierSource } from "./source-citation.js";
 import { vendorHistorySentence } from "./vendor-history.js";
 import { HETZNER_APRIL_CHANGES, HETZNER_CLOUD_PLANS, HETZNER_PRICES_READ, HETZNER_PRICE_SOURCE, HETZNER_SINGAPORE_EXAMPLE, cheapestOrderableHetznerPlan, hetznerEntryPriceClause, unorderableHetznerPlans } from "./hetzner-pricing.js";
 import { HUNDRED_TB_SCENARIO, ONE_TO_ONE_SCENARIO, STORAGE_RATES_READ, STORAGE_SCALE_WORKLOADS, TEN_TO_ONE_SCENARIO, cheapestProviderAt, costliestProviderAt, egressAllowanceSentence, egressBillOnceOverAllowance, egressRatioWhereCostsMatch, fixedMonthlyGrantsSentence, monthlyStorageCost, providersWithScalingEgressAllowance, rateCardFor, scaleCostFor } from "./storage-cost-model.js";
@@ -59,7 +60,7 @@ import { addFriend, removeFriend, getFriends, getFriendCodesForVendors } from ".
 import { subscribe as watchlistSubscribe, getSubscription as getWatchlistSubscription, unsubscribe as watchlistUnsubscribe, listSubscriptions as listWatchlistSubscriptions } from "./watchlist.js";
 import { changeLogAnchorFor, changeLogVendorMap, toSlug, vendorSlugMap, resolveVendorSlug, namedVendorSlug } from "./vendor-slug.js";
 import { offerForSlug, vendorRates, cheapestRate, dearestRate, spanOfRates, formatRate, formatRateSpan, monthlyTokenCost, formatDollars, type ModelRate } from "./model-rates.js";
-import { STALE_FACT_PAGES_BASELINE, factsOutdatedBy, linkifyVerdictBlocks, newestChangeBySlug, overdueReport, pageCompiledClause, pageDataProvenance, pageDateModified, pageFreshness, pageFreshnessSentence, utcToday, verdictsOutdatedBy } from "./page-reviews.js";
+import { STALE_FACT_PAGES_BASELINE, factsOutdatedBy, linkifyVerdictBlocks, newestChangeBySlug, overdueReport, pageCompiledClause, pageDataProvenance, pageDateModified, pageFreshness, pageFreshnessSentence, tabulatedSubjectSlots, tabulatedSubjects, utcToday, verdictsOutdatedBy } from "./page-reviews.js";
 import { faqPageJsonLd, type FaqItem } from "./faq-provenance.js";
 import { SSE_KEEPALIVE_FRAME, keepaliveIntervalMs, sessionRecoveryBody } from "./mcp-stream.js";
 import { ASSISTANTS_API_SHUTDOWN } from "./assistants-shutdown.js";
@@ -1008,6 +1009,82 @@ function comparisonPageWithLiveRecords(
     TIMELINE_ROW_LIMIT,
   );
   return fillComparedServicesCount(replaceTimelineRows(marked, changeTimelineRowsHtml(rows)));
+}
+
+const SOURCE_READ_DATE_CLASS = "cited-source-read";
+
+function freeTierSourceForVendor(vendorName: string, servedOn: string): FreeTierSource {
+  return freeTierSourceOf(vendorVerdictContext(vendorName, servedOn)?.primary);
+}
+
+function vendorNamedBySlug(slug: string): string | undefined {
+  const direct = vendorSlugMap.get(slug);
+  if (direct) return direct;
+  const resolved = resolveVendorSlug(slug);
+  return resolved.type === "redirect" ? vendorSlugMap.get(resolved.slug) : undefined;
+}
+
+function citedServicesOn(html: string, servedOn: string): CitedService[] {
+  const found = new Map<string, CitedService>();
+  const add = (vendor: string, slug: string | null) => {
+    if (!found.has(vendor)) {
+      found.set(vendor, { vendor, slug, source: freeTierSourceForVendor(vendor, servedOn) });
+    }
+  };
+  for (const subject of vendorSubjectsOnCompiledPage(html)) {
+    const named = vendorForSubject(subject);
+    if (named) add(named.vendor, named.slug);
+  }
+  for (const row of tabulatedSubjects(html, namedVendorSlug)) {
+    const vendor = row.slug ? vendorNamedBySlug(row.slug) : undefined;
+    if (vendor) add(vendor, row.slug);
+  }
+  return [...found.values()].sort((a, b) => a.vendor.localeCompare(b.vendor));
+}
+
+function compiledPageCitingSources(html: string, servedOn = utcDate()): string {
+  const services = citedServicesOn(html, servedOn);
+  const byVendor = new Map(services.map(service => [service.vendor, service]));
+  const unresolvedRows = new Set(
+    tabulatedSubjects(html, namedVendorSlug)
+      .filter(row => row.slug === null && row.subject !== "")
+      .map(row => row.subject),
+  );
+
+  const marked = appendToCompiledFigureSlots(html, subject => {
+    const named = vendorForSubject(subject);
+    if (!named) {
+      return subject.kind === "row" && unresolvedRows.has(subject.label)
+        ? sourceMarkerHtml({ cited: false, clause: NO_CATALOGUE_RECORD }, escHtmlServer, UNCITED_CHANGE_LABEL)
+        : "";
+    }
+    const service = byVendor.get(named.vendor);
+    if (!service) return "";
+    return service.source.cited
+      ? citedSourceLinkHtml(service.source, escHtmlServer)
+      : uncitedSourceLinkHtml({ ...service, source: service.source }, escHtmlServer, UNCITED_CHANGE_LABEL);
+  });
+
+  const tabulated = markTabulatedRowSources(marked, byVendor);
+  return withCitedSources(tabulated, citedSourcesListHtml(services, escHtmlServer, SOURCE_READ_DATE_CLASS));
+}
+
+const ALREADY_MARKED = /class="(?:record-source|unsourced-tag)"/;
+
+function markTabulatedRowSources(html: string, byVendor: Map<string, CitedService>): string {
+  const staticHtml = staticHalfOf(html);
+  let out = "";
+  let cursor = 0;
+  for (const slot of tabulatedSubjectSlots(staticHtml, namedVendorSlug)) {
+    if (slot.slug === null || ALREADY_MARKED.test(slot.cell)) continue;
+    const vendor = vendorNamedBySlug(slot.slug);
+    const service = vendor ? byVendor.get(vendor) : undefined;
+    if (!service) continue;
+    if (slot.cellEnd < cursor) continue;
+    out += html.slice(cursor, slot.cellEnd) + sourceMarkerHtml(service.source, escHtmlServer, UNCITED_CHANGE_LABEL);
+    cursor = slot.cellEnd;
+  }
+  return out + html.slice(cursor);
 }
 
 interface FreeTierCensus {
@@ -4360,13 +4437,26 @@ function buildVendorPage(slug: string): string | null {
           .map(l => `<code>${escHtmlServer(l.subtype)}</code> &mdash; ${escHtmlServer(subtypeDefinition(classified.taxonomy, l.subtype) ?? "")}`)
           .join("; ") + ".";
     const sources = [...new Map(classified.labels.map(l => [l.source_url, l])).values()];
-    const provenance = sources
-      .map(l => `<a href="${escHtmlServer(l.source_url)}" rel="nofollow noopener">${escHtmlServer(l.source_url)}</a>, where it says: &ldquo;${escHtmlServer(l.source_quote)}&rdquo;`)
-      .join(" and from ");
-    const read = sources.length > 0
-      ? ` We read that on <span class="product-subtypes-reviewed" style="font-family:var(--mono)">${escHtmlServer(classified.reviewed)}</span> from ${provenance}`
-      : "";
-    return `\n  <p class="product-subtypes-line" style="margin:.4rem 0 .6rem;font-size:.9rem;color:var(--text-muted)"><strong>Subtypes in ${escHtmlServer(classified.taxonomy)}:</strong> ${body}${read} <a href="${CRITERIA_PATH}#subtypes">How we use this</a>.</p>`;
+    const read = readClauseHtml(
+      classified.reviewed,
+      sources.map(l => ({ url: l.source_url, quote: l.source_quote })),
+      escHtmlServer,
+      { dateClass: "product-subtypes-reviewed" },
+    );
+    const clause = read === "" ? "" : ` ${read}`;
+    return `\n  <p class="product-subtypes-line" style="margin:.4rem 0 .6rem;font-size:.9rem;color:var(--text-muted)"><strong>Subtypes in ${escHtmlServer(classified.taxonomy)}:</strong> ${body}${clause} <a href="${CRITERIA_PATH}#subtypes">How we use this</a>.</p>`;
+  })();
+
+  const freeTierSourceLine = (() => {
+    const source = freeTierSourceOf(primary);
+    if (!source.cited) return "";
+    const read = readClauseHtml(
+      source.readOn,
+      [{ url: source.url, quote: source.quote }],
+      escHtmlServer,
+      { dateClass: SOURCE_READ_DATE_CLASS },
+    );
+    return `\n    <p class="free-tier-source-line" style="margin:.5rem 0 0;font-size:.8rem;color:var(--text-dim)">${read}.</p>`;
   })();
 
   const alternativesMembership = partitionSubstitutes(
@@ -4945,7 +5035,7 @@ ${referralCalloutHtml}
     <h2>Free Tier Details</h2>
     ${termsSuperseded
       ? `<p class="terms-superseded-text"><strong>${SUPERSEDED_TERMS_LABEL}:</strong> ${supersededTermsNoticeHtml(vendorName, termsSuperseded, escHtmlServer)} <a href="#changes">Read what we recorded &darr;</a></p>`
-      : `<p class="desc-text">${escHtmlServer(primary.description)}</p>`}
+      : `<p class="desc-text">${escHtmlServer(primary.description)}</p>`}${freeTierSourceLine}
   </div>
 ${compareTableHtml}
 ${growthPathHtml}
@@ -55304,7 +55394,7 @@ ${catList}
     recordApiHit("/ai-coding-pricing-2026");
     logRequest({ ts: new Date().toISOString(), type: "api", endpoint: "/ai-coding-pricing-2026", params: {}, user_agent: req.headers["user-agent"] ?? "unknown", result_count: 1 });
     res.writeHead(200, { "Content-Type": "text/html; charset=utf-8", "Cache-Control": "public, max-age=3600" });
-    res.end(withVerdictLinks(buildAiCodingPricing2026Page()));
+    res.end(withVerdictLinks(compiledPageCitingSources(buildAiCodingPricing2026Page())));
   } else if (url.pathname === "/ai-coding-tools-pricing" && isGetOrHead) {
     recordApiHit("/ai-coding-tools-pricing");
     logRequest({ ts: new Date().toISOString(), type: "api", endpoint: "/ai-coding-tools-pricing", params: {}, user_agent: req.headers["user-agent"] ?? "unknown", result_count: 1 });
@@ -55364,57 +55454,57 @@ ${catList}
     recordApiHit("/aws-free-tier-2026");
     logRequest({ ts: new Date().toISOString(), type: "api", endpoint: "/aws-free-tier-2026", params: {}, user_agent: req.headers["user-agent"] ?? "unknown", result_count: 1 });
     res.writeHead(200, { "Content-Type": "text/html; charset=utf-8", "Cache-Control": "public, max-age=3600" });
-    res.end(withVerdictLinks(buildAwsFreeTier2026Page()));
+    res.end(withVerdictLinks(compiledPageCitingSources(buildAwsFreeTier2026Page())));
   } else if (url.pathname === "/gcp-free-tier-2026" && isGetOrHead) {
     recordApiHit("/gcp-free-tier-2026");
     logRequest({ ts: new Date().toISOString(), type: "api", endpoint: "/gcp-free-tier-2026", params: {}, user_agent: req.headers["user-agent"] ?? "unknown", result_count: 1 });
     res.writeHead(200, { "Content-Type": "text/html; charset=utf-8", "Cache-Control": "public, max-age=3600" });
-    res.end(withVerdictLinks(buildGcpFreeTier2026Page()));
+    res.end(withVerdictLinks(compiledPageCitingSources(buildGcpFreeTier2026Page())));
   } else if (url.pathname === "/azure-free-tier-2026" && isGetOrHead) {
     recordApiHit("/azure-free-tier-2026");
     logRequest({ ts: new Date().toISOString(), type: "api", endpoint: "/azure-free-tier-2026", params: {}, user_agent: req.headers["user-agent"] ?? "unknown", result_count: 1 });
     res.writeHead(200, { "Content-Type": "text/html; charset=utf-8", "Cache-Control": "public, max-age=3600" });
-    res.end(withVerdictLinks(buildAzureFreeTier2026Page()));
+    res.end(withVerdictLinks(compiledPageCitingSources(buildAzureFreeTier2026Page())));
   } else if (url.pathname === "/digitalocean-free-tier-2026" && isGetOrHead) {
     recordApiHit("/digitalocean-free-tier-2026");
     logRequest({ ts: new Date().toISOString(), type: "api", endpoint: "/digitalocean-free-tier-2026", params: {}, user_agent: req.headers["user-agent"] ?? "unknown", result_count: 1 });
     res.writeHead(200, { "Content-Type": "text/html; charset=utf-8", "Cache-Control": "public, max-age=3600" });
-    res.end(withVerdictLinks(buildDigitalOceanFreeTier2026Page()));
+    res.end(withVerdictLinks(compiledPageCitingSources(buildDigitalOceanFreeTier2026Page())));
   } else if (url.pathname === "/cicd-free-tier-comparison-2026" && isGetOrHead) {
     recordApiHit("/cicd-free-tier-comparison-2026");
     logRequest({ ts: new Date().toISOString(), type: "api", endpoint: "/cicd-free-tier-comparison-2026", params: {}, user_agent: req.headers["user-agent"] ?? "unknown", result_count: 1 });
     res.writeHead(200, { "Content-Type": "text/html; charset=utf-8", "Cache-Control": "public, max-age=3600" });
-    res.end(withVerdictLinks(buildCicdFreeTierComparison2026Page()));
+    res.end(withVerdictLinks(compiledPageCitingSources(buildCicdFreeTierComparison2026Page())));
   } else if (url.pathname === "/storage-comparison-2026" && isGetOrHead) {
     recordApiHit("/storage-comparison-2026");
     logRequest({ ts: new Date().toISOString(), type: "api", endpoint: "/storage-comparison-2026", params: {}, user_agent: req.headers["user-agent"] ?? "unknown", result_count: 1 });
     res.writeHead(200, { "Content-Type": "text/html; charset=utf-8", "Cache-Control": "public, max-age=3600" });
-    res.end(withVerdictLinks(buildStorageComparison2026Page()));
+    res.end(withVerdictLinks(compiledPageCitingSources(buildStorageComparison2026Page())));
   } else if (url.pathname === "/testing-free-tier-comparison-2026" && isGetOrHead) {
     recordApiHit("/testing-free-tier-comparison-2026");
     logRequest({ ts: new Date().toISOString(), type: "api", endpoint: "/testing-free-tier-comparison-2026", params: {}, user_agent: req.headers["user-agent"] ?? "unknown", result_count: 1 });
     res.writeHead(200, { "Content-Type": "text/html; charset=utf-8", "Cache-Control": "public, max-age=3600" });
-    res.end(withVerdictLinks(buildTestingFreeTierComparison2026Page()));
+    res.end(withVerdictLinks(compiledPageCitingSources(buildTestingFreeTierComparison2026Page())));
   } else if (url.pathname === "/analytics-free-tier-comparison-2026" && isGetOrHead) {
     recordApiHit("/analytics-free-tier-comparison-2026");
     logRequest({ ts: new Date().toISOString(), type: "api", endpoint: "/analytics-free-tier-comparison-2026", params: {}, user_agent: req.headers["user-agent"] ?? "unknown", result_count: 1 });
     res.writeHead(200, { "Content-Type": "text/html; charset=utf-8", "Cache-Control": "public, max-age=3600" });
-    res.end(withVerdictLinks(buildAnalyticsFreeTierComparison2026Page()));
+    res.end(withVerdictLinks(compiledPageCitingSources(buildAnalyticsFreeTierComparison2026Page())));
   } else if (url.pathname === "/api-development-free-tier-comparison-2026" && isGetOrHead) {
     recordApiHit("/api-development-free-tier-comparison-2026");
     logRequest({ ts: new Date().toISOString(), type: "api", endpoint: "/api-development-free-tier-comparison-2026", params: {}, user_agent: req.headers["user-agent"] ?? "unknown", result_count: 1 });
     res.writeHead(200, { "Content-Type": "text/html; charset=utf-8", "Cache-Control": "public, max-age=3600" });
-    res.end(withVerdictLinks(buildApiDevelopmentFreeTierComparison2026Page()));
+    res.end(withVerdictLinks(compiledPageCitingSources(buildApiDevelopmentFreeTierComparison2026Page())));
   } else if (url.pathname === "/security-free-tier-comparison-2026" && isGetOrHead) {
     recordApiHit("/security-free-tier-comparison-2026");
     logRequest({ ts: new Date().toISOString(), type: "api", endpoint: "/security-free-tier-comparison-2026", params: {}, user_agent: req.headers["user-agent"] ?? "unknown", result_count: 1 });
     res.writeHead(200, { "Content-Type": "text/html; charset=utf-8", "Cache-Control": "public, max-age=3600" });
-    res.end(withVerdictLinks(buildSecurityFreeTierComparison2026Page()));
+    res.end(withVerdictLinks(compiledPageCitingSources(buildSecurityFreeTierComparison2026Page())));
   } else if (url.pathname === "/hosting-free-tier-comparison-2026" && isGetOrHead) {
     recordApiHit("/hosting-free-tier-comparison-2026");
     logRequest({ ts: new Date().toISOString(), type: "api", endpoint: "/hosting-free-tier-comparison-2026", params: {}, user_agent: req.headers["user-agent"] ?? "unknown", result_count: 1 });
     res.writeHead(200, { "Content-Type": "text/html; charset=utf-8", "Cache-Control": "public, max-age=3600" });
-    res.end(withVerdictLinks(buildHostingFreeTierComparison2026Page()));
+    res.end(withVerdictLinks(compiledPageCitingSources(buildHostingFreeTierComparison2026Page())));
   } else if (url.pathname === "/state-of-free-tiers" && isGetOrHead) {
     recordApiHit("/state-of-free-tiers");
     logRequest({ ts: new Date().toISOString(), type: "api", endpoint: "/state-of-free-tiers", params: {}, user_agent: req.headers["user-agent"] ?? "unknown", result_count: 1 });
@@ -55424,32 +55514,32 @@ ${catList}
     recordApiHit("/email-comparison-2026");
     logRequest({ ts: new Date().toISOString(), type: "api", endpoint: "/email-comparison-2026", params: {}, user_agent: req.headers["user-agent"] ?? "unknown", result_count: 1 });
     res.writeHead(200, { "Content-Type": "text/html; charset=utf-8", "Cache-Control": "public, max-age=3600" });
-    res.end(withVerdictLinks(buildEmailComparison2026Page()));
+    res.end(withVerdictLinks(compiledPageCitingSources(buildEmailComparison2026Page())));
   } else if (url.pathname === "/monitoring-comparison-2026" && isGetOrHead) {
     recordApiHit("/monitoring-comparison-2026");
     logRequest({ ts: new Date().toISOString(), type: "api", endpoint: "/monitoring-comparison-2026", params: {}, user_agent: req.headers["user-agent"] ?? "unknown", result_count: 1 });
     res.writeHead(200, { "Content-Type": "text/html; charset=utf-8", "Cache-Control": "public, max-age=3600" });
-    res.end(withVerdictLinks(buildMonitoringComparison2026Page()));
+    res.end(withVerdictLinks(compiledPageCitingSources(buildMonitoringComparison2026Page())));
   } else if (url.pathname === "/auth-comparison-2026" && isGetOrHead) {
     recordApiHit("/auth-comparison-2026");
     logRequest({ ts: new Date().toISOString(), type: "api", endpoint: "/auth-comparison-2026", params: {}, user_agent: req.headers["user-agent"] ?? "unknown", result_count: 1 });
     res.writeHead(200, { "Content-Type": "text/html; charset=utf-8", "Cache-Control": "public, max-age=3600" });
-    res.end(withVerdictLinks(buildAuthComparison2026Page()));
+    res.end(withVerdictLinks(compiledPageCitingSources(buildAuthComparison2026Page())));
   } else if (url.pathname === "/serverless-free-tier-comparison-2026" && isGetOrHead) {
     recordApiHit("/serverless-free-tier-comparison-2026");
     logRequest({ ts: new Date().toISOString(), type: "api", endpoint: "/serverless-free-tier-comparison-2026", params: {}, user_agent: req.headers["user-agent"] ?? "unknown", result_count: 1 });
     res.writeHead(200, { "Content-Type": "text/html; charset=utf-8", "Cache-Control": "public, max-age=3600" });
-    res.end(withVerdictLinks(buildServerlessFreeTierComparison2026Page()));
+    res.end(withVerdictLinks(compiledPageCitingSources(buildServerlessFreeTierComparison2026Page())));
   } else if (url.pathname === "/database-free-tier-comparison-2026" && isGetOrHead) {
     recordApiHit("/database-free-tier-comparison-2026");
     logRequest({ ts: new Date().toISOString(), type: "api", endpoint: "/database-free-tier-comparison-2026", params: {}, user_agent: req.headers["user-agent"] ?? "unknown", result_count: 1 });
     res.writeHead(200, { "Content-Type": "text/html; charset=utf-8", "Cache-Control": "public, max-age=3600" });
-    res.end(withVerdictLinks(buildDatabaseFreeTierComparison2026Page()));
+    res.end(withVerdictLinks(compiledPageCitingSources(buildDatabaseFreeTierComparison2026Page())));
   } else if (url.pathname === "/cloud-free-tier-comparison-2026" && isGetOrHead) {
     recordApiHit("/cloud-free-tier-comparison-2026");
     logRequest({ ts: new Date().toISOString(), type: "api", endpoint: "/cloud-free-tier-comparison-2026", params: {}, user_agent: req.headers["user-agent"] ?? "unknown", result_count: 1 });
     res.writeHead(200, { "Content-Type": "text/html; charset=utf-8", "Cache-Control": "public, max-age=3600" });
-    res.end(withVerdictLinks(buildCloudFreeTierComparison2026Page()));
+    res.end(withVerdictLinks(compiledPageCitingSources(buildCloudFreeTierComparison2026Page())));
   } else if (url.pathname === "/openai-assistants-alternatives" && isGetOrHead) {
     recordApiHit("/openai-assistants-alternatives");
     logRequest({ ts: new Date().toISOString(), type: "api", endpoint: "/openai-assistants-alternatives", params: {}, user_agent: req.headers["user-agent"] ?? "unknown", result_count: 1 });

--- a/src/source-citation.ts
+++ b/src/source-citation.ts
@@ -5,6 +5,7 @@ import {
   termsUnconfirmedOutcome,
   unconfirmedTermsClause,
 } from "./source-check.js";
+import { ENDED_OFFER_CLAUSE, offerRetired } from "./retirement.js";
 import type { Offer } from "./types.js";
 
 export type Escaper = (text: string) => string;
@@ -59,10 +60,11 @@ export type FreeTierSource = SourceRead | SourceMissing;
 
 export const NO_CATALOGUE_RECORD = FREE_TIER_STANDING_LABELS.not_in_catalogue;
 
-export type SourcedOffer = Pick<Offer, "url" | "source_check" | "verifiedDate">;
+export type SourcedOffer = Pick<Offer, "url" | "tier" | "source_check" | "verifiedDate">;
 
 export function freeTierSourceOf(offer: SourcedOffer | null | undefined): FreeTierSource {
   if (!offer) return { cited: false, clause: NO_CATALOGUE_RECORD };
+  if (offerRetired(offer)) return { cited: false, clause: ENDED_OFFER_CLAUSE };
   const check = offer.source_check;
   const unconfirmed = termsUnconfirmedOutcome(check?.outcome);
   if (unconfirmed) return { cited: false, clause: unconfirmedTermsClause(unconfirmed) };

--- a/src/source-citation.ts
+++ b/src/source-citation.ts
@@ -1,0 +1,186 @@
+import { CITATION_LINK_HTML, RECORD_SOURCE_CLASS, UNCITED_TAG_CLASS, citationLabel } from "./change-citation.js";
+import { FREE_TIER_STANDING_LABELS } from "./risk-scorecard.js";
+import {
+  passedWithoutQuotingThePage,
+  termsUnconfirmedOutcome,
+  unconfirmedTermsClause,
+} from "./source-check.js";
+import type { Offer } from "./types.js";
+
+export type Escaper = (text: string) => string;
+
+export interface ReadSource {
+  url: string;
+  quote?: string | null;
+}
+
+export interface ReadClauseOptions {
+  dateClass: string;
+  rel?: string;
+  linkText?: (url: string) => string;
+}
+
+export function readClauseHtml(
+  readOn: string,
+  sources: readonly ReadSource[],
+  esc: Escaper,
+  options: ReadClauseOptions,
+): string {
+  if (sources.length === 0) return "";
+  const rel = options.rel ?? "nofollow noopener";
+  const linkText = options.linkText ?? ((url: string) => url);
+  const provenance = sources
+    .map(source => {
+      const link = `<a href="${esc(source.url)}" rel="${rel}">${esc(linkText(source.url))}</a>`;
+      return source.quote
+        ? `${link}, where it says: &ldquo;${esc(source.quote)}&rdquo;`
+        : link;
+    })
+    .join(" and from ");
+  return (
+    `We read that on <span class="${options.dateClass}" style="font-family:var(--mono)">${esc(readOn)}</span>` +
+    ` from ${provenance}`
+  );
+}
+
+export interface SourceRead {
+  cited: true;
+  url: string;
+  readOn: string;
+  quote: string | null;
+}
+
+export interface SourceMissing {
+  cited: false;
+  clause: string;
+}
+
+export type FreeTierSource = SourceRead | SourceMissing;
+
+export const NO_CATALOGUE_RECORD = FREE_TIER_STANDING_LABELS.not_in_catalogue;
+
+export type SourcedOffer = Pick<Offer, "url" | "source_check" | "verifiedDate">;
+
+export function freeTierSourceOf(offer: SourcedOffer | null | undefined): FreeTierSource {
+  if (!offer) return { cited: false, clause: NO_CATALOGUE_RECORD };
+  const check = offer.source_check;
+  const unconfirmed = termsUnconfirmedOutcome(check?.outcome);
+  if (unconfirmed) return { cited: false, clause: unconfirmedTermsClause(unconfirmed) };
+  const url = (offer.url ?? "").trim();
+  if (!check || !url) return { cited: false, clause: NO_CATALOGUE_RECORD };
+  return {
+    cited: true,
+    url,
+    readOn: check.checked,
+    quote: passedWithoutQuotingThePage(offer) ? null : check.detail,
+  };
+}
+
+export interface CitedService {
+  vendor: string;
+  slug: string | null;
+  source: FreeTierSource;
+}
+
+export function sourceAnchorId(service: Pick<CitedService, "vendor" | "slug">): string {
+  return `source-${service.slug ?? service.vendor.toLowerCase().replace(/[^a-z0-9]+/g, "-")}`;
+}
+
+const MARKER_STYLE = "font-size:.75rem;color:var(--text-dim);margin-left:.35rem";
+
+export function citedSourceLinkHtml(read: SourceRead, esc: Escaper): string {
+  const title = `${citationLabel(read.url)} — ${read.readOn}`;
+  return (
+    ` <a href="${esc(read.url)}" rel="nofollow noopener" class="${RECORD_SOURCE_CLASS}"` +
+    ` style="${MARKER_STYLE}" title="${esc(title)}">${CITATION_LINK_HTML}</a>`
+  );
+}
+
+const UNCITED_TAG_STYLE =
+  "display:inline-block;margin-left:.35rem;padding:.1rem .4rem;border-radius:10px;" +
+  "font-size:.65rem;font-weight:600;background:#8b949e22;color:#8b949e";
+
+export function uncitedSourceTagHtml(missing: SourceMissing, esc: Escaper, label: string): string {
+  return (
+    ` <span class="${UNCITED_TAG_CLASS}" style="${UNCITED_TAG_STYLE}"` +
+    ` title="${esc(missing.clause)}">${esc(label)}</span>`
+  );
+}
+
+export function uncitedSourceLinkHtml(
+  service: CitedService & { source: SourceMissing },
+  esc: Escaper,
+  label: string,
+): string {
+  return (
+    ` <a href="#${esc(sourceAnchorId(service))}" class="${UNCITED_TAG_CLASS}" style="${UNCITED_TAG_STYLE}"` +
+    ` title="${esc(service.source.clause)}">${esc(label)}</a>`
+  );
+}
+
+export function sourceMarkerHtml(
+  source: FreeTierSource,
+  esc: Escaper,
+  uncitedLabel: string,
+): string {
+  return source.cited
+    ? citedSourceLinkHtml(source, esc)
+    : uncitedSourceTagHtml(source, esc, uncitedLabel);
+}
+
+export const CITED_SOURCES_CLASS = "cited-sources";
+
+export function citedSourcesListHtml(
+  services: readonly CitedService[],
+  esc: Escaper,
+  dateClass: string,
+): string {
+  if (services.length === 0) return "";
+  const items = services
+    .map(service => {
+      const name = service.slug
+        ? `<a href="/vendor/${esc(service.slug)}">${esc(service.vendor)}</a>`
+        : esc(service.vendor);
+      const body = service.source.cited
+        ? readClauseHtml(
+            service.source.readOn,
+            [{ url: service.source.url, quote: service.source.quote }],
+            esc,
+            { dateClass, linkText: citationLabel },
+          )
+        : esc(service.source.clause);
+      return `<li id="${esc(sourceAnchorId(service))}">${name} &mdash; ${body}</li>`;
+    })
+    .join("\n      ");
+  return (
+    `<ul class="${CITED_SOURCES_CLASS}" style="margin:1rem 0 0 1.1rem;padding:0;font-size:.85rem;line-height:1.7">\n` +
+    `      ${items}\n    </ul>`
+  );
+}
+
+const METHODOLOGY_OPEN = /<div\b[^>]*class="[^"]*\bmethodology\b[^"]*"[^>]*>/;
+const DIV_TAG = /<div\b[^>]*>|<\/div>/g;
+const DATA_SOURCE_HEADING = /<h2\b[^>]*\bid="data-source"/;
+
+export function methodologyBlockEnd(html: string): number | null {
+  const heading = DATA_SOURCE_HEADING.exec(html);
+  const from = heading ? heading.index : 0;
+  const open = METHODOLOGY_OPEN.exec(html.slice(from));
+  if (!open) return null;
+  const openStart = from + open.index;
+  const tags = new RegExp(DIV_TAG.source, "g");
+  tags.lastIndex = openStart + open[0].length;
+  let depth = 1;
+  for (let tag = tags.exec(html); tag !== null; tag = tags.exec(html)) {
+    depth += tag[0] === "</div>" ? -1 : 1;
+    if (depth === 0) return tag.index;
+  }
+  return null;
+}
+
+export function withCitedSources(html: string, listHtml: string): string {
+  if (listHtml === "") return html;
+  const end = methodologyBlockEnd(html);
+  if (end === null) return html;
+  return `${html.slice(0, end)}\n    ${listHtml}${html.slice(end)}`;
+}

--- a/test/comparison-source-citation.test.ts
+++ b/test/comparison-source-citation.test.ts
@@ -1,0 +1,337 @@
+import { describe, it, before, after } from "node:test";
+import assert from "node:assert";
+import { assertPopulationFloor } from "./population-floor.ts";
+import { spawn, type ChildProcess } from "node:child_process";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const {
+  citedSourcesListHtml,
+  freeTierSourceOf,
+  methodologyBlockEnd,
+  readClauseHtml,
+  sourceAnchorId,
+  withCitedSources,
+  NO_CATALOGUE_RECORD,
+} = await import("../dist/source-citation.js");
+const { tabulatedSubjectSlots, vendorFactRows, SOURCE_MARKER_IN_A_CELL } = await import("../dist/page-reviews.js");
+const { SOURCE_MARKER_MARKUP } = await import("../dist/change-citation.js");
+const { namedVendorSlug, vendorSlugMap } = await import("../dist/vendor-slug.js");
+const { staticHalfOf } = await import("../dist/compiled-figures.js");
+
+type Offer = import("../src/types.ts").Offer;
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO = path.join(__dirname, "..");
+
+const offers: Offer[] = JSON.parse(
+  readFileSync(path.join(REPO, "data", "index.json"), "utf-8"),
+).offers;
+
+const primaryFor = new Map<string, Offer>();
+for (const offer of offers) if (!primaryFor.has(offer.vendor)) primaryFor.set(offer.vendor, offer);
+
+const COMPILED_PAGES = [
+  "/cloud-free-tier-comparison-2026",
+  "/database-free-tier-comparison-2026",
+  "/cicd-free-tier-comparison-2026",
+  "/serverless-free-tier-comparison-2026",
+  "/testing-free-tier-comparison-2026",
+  "/analytics-free-tier-comparison-2026",
+  "/api-development-free-tier-comparison-2026",
+  "/security-free-tier-comparison-2026",
+  "/hosting-free-tier-comparison-2026",
+  "/auth-comparison-2026",
+  "/email-comparison-2026",
+  "/storage-comparison-2026",
+  "/monitoring-comparison-2026",
+  "/aws-free-tier-2026",
+  "/gcp-free-tier-2026",
+  "/azure-free-tier-2026",
+  "/digitalocean-free-tier-2026",
+  "/ai-coding-pricing-2026",
+];
+
+const PAGES_THAT_ALREADY_LINKED_OUT = [
+  "/vercel-vs-netlify",
+  "/railway-vs-render",
+  "/neon-vs-supabase",
+  "/supabase-vs-firebase",
+  "/datadog-vs-new-relic",
+  "/hetzner-pricing-2026",
+  "/gemini-api-pricing-2026",
+  "/google-developer-program-2026",
+  "/openai-assistants-migration-2026",
+  "/q2-pricing-preview-2026",
+];
+
+const VENDOR_PAGE = "/vendor/upstash";
+
+const OURS = /localhost|agentdeals\.dev|fonts\.(?:googleapis|gstatic)\.com/;
+
+function outboundHosts(html: string): string[] {
+  const hrefs = html.match(/href="https?:\/\/[^"]+"/g) ?? [];
+  return [...new Set(hrefs.map(h => h.slice(6, -1)).filter(url => !OURS.test(url)))];
+}
+
+const CITED_SOURCE_LINK =
+  /<a href="(https?:\/\/[^"]+)" rel="nofollow noopener" class="record-source"[^>]*title="([^"]*)"/g;
+
+function citedSourceLinks(html: string): Array<{ url: string; title: string }> {
+  return [...html.matchAll(CITED_SOURCE_LINK)].map(m => ({ url: m[1]!, title: m[2]! }));
+}
+
+function startServer(): Promise<{ proc: ChildProcess; base: string }> {
+  return new Promise((resolve, reject) => {
+    const proc = spawn("node", [path.join(REPO, "dist", "serve.js")], {
+      cwd: REPO,
+      stdio: ["ignore", "ignore", "pipe"],
+      env: { ...process.env, PORT: "0", BASE_URL: "http://localhost", TZ: "UTC" },
+    });
+    const timeout = setTimeout(() => {
+      proc.kill();
+      reject(new Error("Server startup timeout"));
+    }, 30000);
+    proc.stderr!.on("data", (data: Buffer) => {
+      const m = data.toString().match(/running on http:\/\/localhost:(\d+)/);
+      if (m) {
+        clearTimeout(timeout);
+        resolve({ proc, base: `http://localhost:${m[1]}` });
+      }
+    });
+    proc.on("error", err => {
+      clearTimeout(timeout);
+      reject(err);
+    });
+  });
+}
+
+describe("what a record says about its source, without loading the catalogue", () => {
+  it("cites the page it read, the date it read it and what it found there", () => {
+    const source = freeTierSourceOf({
+      url: "https://example.com/pricing",
+      verifiedDate: "2026-08-01",
+      source_check: { checked: "2026-09-05", outcome: "ok", detail: 'the page names Example and states "$0"' },
+    });
+    assert.deepStrictEqual(source, {
+      cited: true,
+      url: "https://example.com/pricing",
+      readOn: "2026-09-05",
+      quote: 'the page names Example and states "$0"',
+    });
+  });
+
+  it("cites the page and the date without a quote when the check recorded no evidence from it", () => {
+    const source = freeTierSourceOf({
+      url: "https://example.com/pricing",
+      verifiedDate: "2026-08-01",
+      source_check: { checked: "2026-09-05", outcome: "ok", detail: "text" },
+    });
+    assert.deepStrictEqual(source, {
+      cited: true,
+      url: "https://example.com/pricing",
+      readOn: "2026-09-05",
+      quote: null,
+    });
+  });
+
+  for (const outcome of ["unreadable", "states_no_terms", "does_not_name_vendor", "states_no_amount"] as const) {
+    it(`declines to cite a source the check settled as ${outcome}, and says so`, () => {
+      const source = freeTierSourceOf({
+        url: "https://example.com/pricing",
+        verifiedDate: "2026-08-01",
+        source_check: { checked: "2026-09-05", outcome, detail: "" },
+      });
+      assert.strictEqual(source.cited, false);
+      assert.ok(!source.cited && source.clause.length > 0);
+    });
+  }
+
+  it("says a service we hold no record for has none, rather than citing nothing", () => {
+    const source = freeTierSourceOf(undefined);
+    assert.deepStrictEqual(source, { cited: false, clause: NO_CATALOGUE_RECORD });
+  });
+
+  it("renders the read as a link, a date and the quote, with a rel that endorses nobody", () => {
+    const html = readClauseHtml(
+      "2026-09-05",
+      [{ url: "https://example.com/pricing", quote: "free forever" }],
+      (t: string) => t,
+      { dateClass: "read-on" },
+    );
+    assert.match(html, /We read that on <span class="read-on"[^>]*>2026-09-05<\/span> from /);
+    assert.match(html, /<a href="https:\/\/example\.com\/pricing" rel="nofollow noopener">/);
+    assert.match(html, /where it says: &ldquo;free forever&rdquo;/);
+  });
+
+  it("drops the quote clause and keeps the link when there is nothing quoted", () => {
+    const html = readClauseHtml("2026-09-05", [{ url: "https://example.com/pricing" }], (t: string) => t, {
+      dateClass: "read-on",
+    });
+    assert.doesNotMatch(html, /where it says/);
+    assert.match(html, /<a href="https:\/\/example\.com\/pricing"/);
+  });
+
+  it("puts the list of sources inside the methodology block it belongs to", () => {
+    const page = '<h2 id="data-source">Data Source</h2>\n<div class="methodology">Compiled by hand. <div>x</div></div>\n<h2>Next</h2>';
+    const list = citedSourcesListHtml(
+      [{ vendor: "Example", slug: "example", source: { cited: false, clause: NO_CATALOGUE_RECORD } }],
+      (t: string) => t,
+      "read-on",
+    );
+    const out = withCitedSources(page, list);
+    assert.ok(methodologyBlockEnd(page) !== null);
+    assert.match(out, /<ul class="cited-sources"[\s\S]*<\/ul>\s*<\/div>\s*<h2>Next<\/h2>/);
+    assert.match(out, /<li id="source-example">/);
+  });
+
+  it("leaves a page with no methodology block untouched", () => {
+    const page = "<p>nothing to attach to</p>";
+    assert.strictEqual(withCitedSources(page, "<ul></ul>"), page);
+    assert.strictEqual(methodologyBlockEnd(page), null);
+  });
+
+  it("strips a source marker by the same pattern wherever a subject is read out of markup", () => {
+    assert.strictEqual(SOURCE_MARKER_IN_A_CELL.source, SOURCE_MARKER_MARKUP.source);
+  });
+
+  it("anchors a service on its slug so a row can reach its own entry", () => {
+    assert.strictEqual(sourceAnchorId({ vendor: "Fly.io", slug: "fly-io" }), "source-fly-io");
+    assert.strictEqual(sourceAnchorId({ vendor: "Dead Man's Snitch", slug: null }), "source-dead-man-s-snitch");
+  });
+});
+
+describe("every comparison page reaches the pages its figures were read from", () => {
+  let server: { proc: ChildProcess; base: string };
+  const rendered = new Map<string, string>();
+
+  before(async () => {
+    server = await startServer();
+    for (const page of [...COMPILED_PAGES, ...PAGES_THAT_ALREADY_LINKED_OUT, VENDOR_PAGE]) {
+      rendered.set(page, await fetch(`${server.base}${page}`).then(r => r.text()));
+    }
+  });
+
+  after(() => server?.proc.kill());
+
+  it("links out of every compiled comparison page", () => {
+    const silent = COMPILED_PAGES.filter(page => outboundHosts(rendered.get(page)!).length === 0);
+    assert.deepStrictEqual(silent, []);
+  });
+
+  it("lists the services it compares in the data source section of every one of them", () => {
+    const missing = COMPILED_PAGES.filter(page => !rendered.get(page)!.includes('<ul class="cited-sources"'));
+    assert.deepStrictEqual(missing, []);
+    const listed = COMPILED_PAGES.map(page => (rendered.get(page)!.match(/<li id="source-/g) ?? []).length);
+    assertPopulationFloor(
+      listed.reduce((a, b) => a + b, 0),
+      100,
+      "services listed with a source across the compiled comparison pages",
+    );
+  });
+
+  it("gives every cited link the url, the read date and the outcome its own record holds", () => {
+    const wrong: string[] = [];
+    let checked = 0;
+    const byUrl = new Map<string, Offer[]>();
+    for (const offer of offers) byUrl.set(offer.url, [...(byUrl.get(offer.url) ?? []), offer]);
+    for (const page of COMPILED_PAGES) {
+      for (const link of citedSourceLinks(rendered.get(page)!)) {
+        const records = byUrl.get(link.url) ?? [];
+        if (records.length === 0) {
+          wrong.push(`${page}: ${link.url} is on no record`);
+          continue;
+        }
+        checked += 1;
+        if (!records.some(r => r.source_check?.outcome === "ok")) {
+          wrong.push(`${page}: ${link.url} cited, and no record holding it passed its check`);
+        }
+        if (!records.some(r => link.title.includes(r.source_check?.checked ?? "\u0000"))) {
+          wrong.push(`${page}: ${link.url} dated ${link.title}, no record holding it was read then`);
+        }
+      }
+    }
+    assert.deepStrictEqual(wrong, []);
+    assertPopulationFloor(checked, 100, "cited source links checked against the record behind them");
+  });
+
+  it("marks a figure whose source we could not read rather than linking it as though we had", () => {
+    const wrong: string[] = [];
+    let marked = 0;
+    for (const page of COMPILED_PAGES) {
+      const html = rendered.get(page)!;
+      for (const entry of html.matchAll(/<li id="source-([a-z0-9-]+)">([\s\S]*?)<\/li>/g)) {
+        const vendor = vendorSlugMap.get(entry[1]!);
+        const record = vendor ? primaryFor.get(vendor) : undefined;
+        const outcome = record?.source_check?.outcome;
+        const claimsARead = entry[2]!.includes("We read that on");
+        if (outcome === "ok" && !claimsARead) wrong.push(`${page}: ${entry[1]} passed its check and cites nothing`);
+        if (outcome !== undefined && outcome !== "ok" && claimsARead) {
+          wrong.push(`${page}: ${entry[1]} is ${outcome} and claims a read`);
+        }
+        if (!claimsARead) marked += 1;
+      }
+    }
+    assert.deepStrictEqual(wrong, []);
+    assertPopulationFloor(marked, 20, "listed services that say what is missing instead of citing a source");
+  });
+
+  it("leaves no row that puts a number beside a service without a source or a reason", () => {
+    const bare: string[] = [];
+    let rows = 0;
+    for (const page of COMPILED_PAGES) {
+      const html = staticHalfOf(rendered.get(page)!);
+      for (const slot of tabulatedSubjectSlots(html, namedVendorSlug)) {
+        if (slot.slug === null) continue;
+        rows += 1;
+        if (!/class="(?:record-source|unsourced-tag)"/.test(slot.cell)) {
+          bare.push(`${page}: ${slot.subject}`);
+        }
+      }
+    }
+    assert.deepStrictEqual(bare, []);
+    assertPopulationFloor(rows, 100, "table rows naming a service we hold a record for");
+  });
+
+  it("counts the same rows the page register counts, once the markers are stripped", () => {
+    for (const page of COMPILED_PAGES) {
+      const html = rendered.get(page)!;
+      const named = vendorFactRows(html, namedVendorSlug);
+      assert.ok(
+        named.every(row => !row.subject.includes("Source")),
+        `${page} reads a source marker as part of a service name: ${JSON.stringify(named.slice(0, 3))}`,
+      );
+    }
+  });
+
+  it("endorses nobody it cites", () => {
+    const endorsing: string[] = [];
+    for (const page of COMPILED_PAGES) {
+      for (const link of rendered.get(page)!.matchAll(/<a href="(https?:\/\/[^"]+)"([^>]*)>/g)) {
+        if (OURS.test(link[1]!)) continue;
+        if (!/rel="[^"]*nofollow[^"]*"/.test(link[2]!)) endorsing.push(`${page}: ${link[1]}`);
+      }
+    }
+    assert.deepStrictEqual(endorsing, []);
+  });
+
+  it("keeps the outbound links on the pages that already had them", () => {
+    const lost = PAGES_THAT_ALREADY_LINKED_OUT.filter(page => outboundHosts(rendered.get(page)!).length === 0);
+    assert.deepStrictEqual(lost, []);
+  });
+
+  it("keeps the methodology block on the head-to-head page that already carried one", () => {
+    assert.match(rendered.get("/vercel-vs-netlify")!, /Free tier data sourced from our verified index/);
+    assert.match(rendered.get("/vercel-vs-netlify")!, /verified against/i);
+  });
+
+  it("reaches a vendor's own pricing page from the free tier it publishes", () => {
+    const html = rendered.get(VENDOR_PAGE)!;
+    const record = primaryFor.get("Upstash")!;
+    const block = html.slice(html.indexOf("Free Tier Details"));
+    const line = block.slice(0, block.indexOf("</div>"));
+    assert.match(line, new RegExp(`<a href="${record.url.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}" rel="nofollow noopener">`));
+    assert.ok(line.includes(record.source_check!.checked), `the free tier line omits ${record.source_check!.checked}`);
+  });
+});

--- a/test/comparison-source-citation.test.ts
+++ b/test/comparison-source-citation.test.ts
@@ -17,6 +17,7 @@ const {
 } = await import("../dist/source-citation.js");
 const { tabulatedSubjectSlots, vendorFactRows, SOURCE_MARKER_IN_A_CELL } = await import("../dist/page-reviews.js");
 const { SOURCE_MARKER_MARKUP } = await import("../dist/change-citation.js");
+const { ENDED_OFFER_CLAUSE, offerRetired } = await import("../dist/retirement.js");
 const { namedVendorSlug, vendorSlugMap } = await import("../dist/vendor-slug.js");
 const { staticHalfOf } = await import("../dist/compiled-figures.js");
 
@@ -111,6 +112,7 @@ describe("what a record says about its source, without loading the catalogue", (
   it("cites the page it read, the date it read it and what it found there", () => {
     const source = freeTierSourceOf({
       url: "https://example.com/pricing",
+      tier: "Free",
       verifiedDate: "2026-08-01",
       source_check: { checked: "2026-09-05", outcome: "ok", detail: 'the page names Example and states "$0"' },
     });
@@ -125,6 +127,7 @@ describe("what a record says about its source, without loading the catalogue", (
   it("cites the page and the date without a quote when the check recorded no evidence from it", () => {
     const source = freeTierSourceOf({
       url: "https://example.com/pricing",
+      tier: "Free",
       verifiedDate: "2026-08-01",
       source_check: { checked: "2026-09-05", outcome: "ok", detail: "text" },
     });
@@ -147,6 +150,17 @@ describe("what a record says about its source, without loading the catalogue", (
       assert.ok(!source.cited && source.clause.length > 0);
     });
   }
+
+  it("sends nobody to the pricing page of an offer our own tier records as ended", () => {
+    const source = freeTierSourceOf({
+      url: "https://example.com/pricing",
+      tier: "Retired",
+      verifiedDate: "2026-08-01",
+      source_check: { checked: "2026-09-05", outcome: "ok", detail: 'the page names Example and states "$0"' },
+    });
+    assert.strictEqual(source.cited, false);
+    assert.ok(!source.cited && source.clause === ENDED_OFFER_CLAUSE);
+  });
 
   it("says a service we hold no record for has none, rather than citing nothing", () => {
     const source = freeTierSourceOf(undefined);
@@ -265,11 +279,15 @@ describe("every comparison page reaches the pages its figures were read from", (
         const vendor = vendorSlugMap.get(entry[1]!);
         const record = vendor ? primaryFor.get(vendor) : undefined;
         const outcome = record?.source_check?.outcome;
+        const ended = record !== undefined && offerRetired(record);
         const claimsARead = entry[2]!.includes("We read that on");
-        if (outcome === "ok" && !claimsARead) wrong.push(`${page}: ${entry[1]} passed its check and cites nothing`);
+        if (outcome === "ok" && !ended && !claimsARead) {
+          wrong.push(`${page}: ${entry[1]} passed its check and cites nothing`);
+        }
         if (outcome !== undefined && outcome !== "ok" && claimsARead) {
           wrong.push(`${page}: ${entry[1]} is ${outcome} and claims a read`);
         }
+        if (ended && claimsARead) wrong.push(`${page}: ${entry[1]} has ended and claims a read`);
         if (!claimsARead) marked += 1;
       }
     }
@@ -303,6 +321,18 @@ describe("every comparison page reaches the pages its figures were read from", (
         `${page} reads a source marker as part of a service name: ${JSON.stringify(named.slice(0, 3))}`,
       );
     }
+  });
+
+  it("cites no page for an offer our own tier records as ended", () => {
+    const retired = new Set(offers.filter(offerRetired).map(o => o.url));
+    const offenders: string[] = [];
+    for (const page of COMPILED_PAGES) {
+      for (const link of citedSourceLinks(rendered.get(page)!)) {
+        if (retired.has(link.url)) offenders.push(`${page} -> ${link.url}`);
+      }
+    }
+    assert.deepStrictEqual(offenders, []);
+    assertPopulationFloor(retired.size, 12, "records whose tier says the offer has ended");
   });
 
   it("endorses nobody it cites", () => {

--- a/test/compiled-comparison-figures.test.ts
+++ b/test/compiled-comparison-figures.test.ts
@@ -29,6 +29,7 @@ const { freeTierEndingRecord } = await import("../dist/data.js");
 const { CHANGE_IMPACT_LEVELS, changeImpactColor, changeImpactLabel, isChangeImpactLevel } =
   await import("../dist/change-impact.js");
 const { vendorSlugMap } = await import("../dist/vendor-slug.js");
+const { SOURCE_MARKER_MARKUP } = await import("../dist/change-citation.js");
 
 type DealChange = import("../src/types.ts").DealChange;
 
@@ -525,6 +526,7 @@ describe("the nine compiled comparison pages against the site's own verdicts", (
     const inTables = new Set<string>();
     for (const m of staticHalfOf(html).matchAll(/<td class="provider-col">([\s\S]*?)<\/td>/g)) {
       const name = m[1]!
+        .replace(new RegExp(SOURCE_MARKER_MARKUP.source, "g"), "")
         .replace(/<a href="\/vendor\/[a-z0-9-]+#changes"[\s\S]*?<\/a>/g, "")
         .replace(/<span[^>]*class="[^"]*-badge[^"]*"[^>]*>[\s\S]*?<\/span>/g, "")
         .replace(/<[^>]+>/g, "")

--- a/test/page-data-provenance.test.ts
+++ b/test/page-data-provenance.test.ts
@@ -283,8 +283,8 @@ describe("a page may only name the source it actually reads", () => {
 });
 
 describe("a review that found defects reaches the reader", () => {
-  const SUBJECT = "/storage-comparison-2026";
-  const CONTROL = "/monitoring-comparison-2026";
+  const SUBJECT = "/database-pricing";
+  const CONTROL = "/vector-database-pricing";
   const REVIEWED_ON = "2026-08-26";
   let fixture: RegisterFixture;
   let server: { proc: ChildProcess; port: number };


### PR DESCRIPTION
Refs #1462

Eighteen compiled comparison pages published free-tier figures for fifteen to twenty services each and linked to none of them. Every one of those services already has a `url`, a `source_check.checked` date and a `source_check.detail` in `data/index.json`, and `/api/details/:slug` already returns all three. This renders them.

## What each of the eighteen pages now carries

**A source list in the Data Source section**, one entry per service the page tabulates or names in a compiled figure. Each entry either reads the sentence `/vendor/:slug` already uses for product subtypes — `We read that on <date> from <url>, where it says: "<quote>"` — or says what is missing instead.

**An inline marker beside every figure.** A row or card whose service passed its source check carries `Source ↗` linking straight to that service's own pricing page, with the host and the read date in its title. One whose check did not pass carries `Unsourced`, linking to its entry in the source list, with the reason in its title.

Counts, per page, of outbound links that are not ours: from 0 on all eighteen to between 4 and 24.

## What decides whether a figure is cited

`src/source-citation.ts` reads one record and returns either a citation or a reason, reusing the predicates in `src/source-check.ts` rather than restating them:

- `source_check.outcome` of `ok`, with a quoted detail — link, date and quote. 207 records.
- `ok`, with `detail` recording only which layer matched (`passedWithoutQuotingThePage`) — link and date, no quote clause. 562 records.
- Any other outcome — `unconfirmedTermsClause` says which one, and no outbound link is rendered. 811 records.
- No catalogue record for the service at all — `no catalogue record`, the label `src/risk-scorecard.ts` already uses for that state.

The read clause is one generator, shared with the product-subtypes line on `/vendor/:slug`, so the two cannot drift.

## The register moves with it

Seventeen of the eighteen pages now render catalogue fields, measured by perturbing the catalogue rather than declared: `reads_index` false → true and `data_source` unsourced → catalogue in `data/page-reviews.json`. `unsourced_tier_a` ratchets 39 → 22. `/hosting-free-tier-comparison-2026` already read the catalogue and is unchanged in the register.

Their `.pub-date` lines swap `Figures compiled …` for `Data verified from our index of 1,580 developer tools` on their own, through `dataProvenanceFor` — the two guards in `test/page-data-provenance.test.ts` that hold those two states apart both stay green.

`CATALOGUE_TEXT_FIELDS` gains `url`. The perturbation is the instrument that decides `reads_index`, and it did not cover the field these pages read. Measured before the change: adding `url` alone flips no page's measurement, so the instrument is wider without being looser.

`test/page-data-provenance.test.ts`'s failed-review fixture moves from `/storage-comparison-2026` and `/monitoring-comparison-2026` to `/database-pricing` and `/vector-database-pricing`. It exercises the compiled notice, which only renders on a page blind to the catalogue, and its two former subjects are no longer blind. Both replacements are tier A, unsourced and carry the notice.

## Tests

`test/comparison-source-citation.test.ts`, 23 tests. Twelve read the citation decision and its markup with no catalogue loaded; eleven sweep all eighteen pages, the ten that already linked out, and `/vendor/upstash`.

Checked against a `main` build with the new modules copied in: 6 of the 23 fail there, and they are the six behavioural ones.

Full suite green.

## The acceptance criteria

1. Every figure reaches its source as a link — inline on the row, and again in the source list.
2. The date is `source_check.checked`, the date of the read.
3. `source_check.detail` renders in the source list wherever it holds a quote.
4. A record whose check did not pass renders the reason, not a link.
5. All eighteen. A row naming a service we hold no record for says `no catalogue record`.
6. The ten pages that already linked out keep every link, and `/vercel-vs-netlify` keeps its Methodology block. Asserted.
7. `/vendor/upstash` reaches `https://upstash.com/pricing` from the free tier line, on the same generator as the product-subtypes line.
8. Every outbound source link carries `rel="nofollow noopener"`. Asserted across all eighteen pages, for every non-ours link.
