### PR TITLE
A category emptied by curation keeps its URL and states the date and the reason

### DIFF
--- a/src/category-retirement.ts
+++ b/src/category-retirement.ts
@@ -1,0 +1,35 @@
+import type { CategoryRetirement } from "./category-scope.js";
+
+export const RETIRED_CATEGORY_BADGE = "Retired category";
+
+export const RETIRED_CATEGORY_ONWARD_PATH = "/category";
+
+export function retiredCategoryTitle(name: string): string {
+  return `${name} — retired category — AgentDeals`;
+}
+
+export function retiredCategoryDescription(name: string): string {
+  return `${name} is a category AgentDeals no longer lists. Nothing is filed under this name, and the page stays here to say so rather than answer with a 404.`;
+}
+
+export function retiredCategoryHeadline(name: string): string {
+  return `${name} is no longer listed`;
+}
+
+export function retiredCategoryStatedOn(retirement: CategoryRetirement): string {
+  return `Retired on ${retirement.retired}.`;
+}
+
+export function retiredCategoryNoticeHtml(
+  name: string,
+  retirement: CategoryRetirement,
+  escape: (value: string) => string,
+): string {
+  return `<div class="retired-category">
+    <p class="retired-category-badge">${RETIRED_CATEGORY_BADGE}</p>
+    <h2 class="retired-category-headline">${escape(retiredCategoryHeadline(name))}</h2>
+    <p class="retired-category-date">${escape(retiredCategoryStatedOn(retirement))}</p>
+    <p class="retired-category-reason">${escape(retirement.reason)}</p>
+    <p class="retired-category-onward"><a href="${RETIRED_CATEGORY_ONWARD_PATH}">Browse the categories we do list</a>.</p>
+  </div>`;
+}

--- a/src/category-scope.ts
+++ b/src/category-scope.ts
@@ -369,12 +369,64 @@ export const CATEGORY_ALIASES: Record<string, string> = {
   "Startup Programs": "Startup Perks",
 };
 
+export interface CategoryRetirement {
+  retired: string;
+  reason: string;
+}
+
+export const CATEGORY_RETIREMENTS: Record<string, CategoryRetirement> = {
+  "Streaming & Media": {
+    retired: "2026-09-08",
+    reason: "Consumer streaming and listening services are not infrastructure anyone selects while building software. The records were not wrong — the free tiers they described are real — they were out of scope for this index.",
+  },
+  "Banking & Finance": {
+    retired: "2026-09-08",
+    reason: "Personal banking, transfer and investing apps are not infrastructure anyone selects while building software. The records were not wrong — the free tiers they described are real — they were out of scope for this index.",
+  },
+  "News & Reading": {
+    retired: "2026-09-08",
+    reason: "Read-later apps and feed readers are not infrastructure anyone selects while building software. The records were not wrong — the free tiers they described are real — they were out of scope for this index.",
+  },
+  "Fitness & Health": {
+    retired: "2026-09-08",
+    reason: "Activity and health-tracking apps are not infrastructure anyone selects while building software. The records were not wrong — the free tiers they described are real — they were out of scope for this index.",
+  },
+  "Meditation & Wellness": {
+    retired: "2026-09-08",
+    reason: "Meditation and mental-wellbeing apps are not infrastructure anyone selects while building software. The records were not wrong — the free tiers they described are real — they were out of scope for this index.",
+  },
+};
+
+export type CategoryState = "live" | "retired" | "absent";
+
 export function resolveCategoryName(name: string): string {
   return CATEGORY_ALIASES[name] ?? name;
 }
 
+export function categoryState(name: string, liveNames: ReadonlySet<string>): CategoryState {
+  const resolved = resolveCategoryName(name);
+  if (liveNames.has(resolved)) return "live";
+  if (CATEGORY_RETIREMENTS[resolved]) return "retired";
+  return "absent";
+}
+
+export function retirementFor(name: string, liveNames: ReadonlySet<string>): CategoryRetirement | null {
+  const resolved = resolveCategoryName(name);
+  return categoryState(resolved, liveNames) === "retired" ? CATEGORY_RETIREMENTS[resolved] : null;
+}
+
+export function retiredCategoryNames(liveNames: ReadonlySet<string>): string[] {
+  return Object.keys(CATEGORY_RETIREMENTS)
+    .filter((name) => categoryState(name, liveNames) === "retired")
+    .sort();
+}
+
 export function scopeFor(name: string): CategoryScope | null {
   return CATEGORY_SCOPES[resolveCategoryName(name)] ?? null;
+}
+
+export function publishedScopeFor(name: string, liveNames: ReadonlySet<string>): CategoryScope | null {
+  return categoryState(name, liveNames) === "retired" ? null : scopeFor(name);
 }
 
 export function categoryHolds(name: string): CategoryHolds {

--- a/src/mcp-instructions.ts
+++ b/src/mcp-instructions.ts
@@ -1,6 +1,14 @@
+import { getCategories, loadOffers } from "./data.js";
+
+export const CATALOGUE_CATEGORY_COUNT = getCategories().length;
+
+export const CATALOGUE_OFFER_FLOOR = Math.floor(loadOffers().length / 100) * 100;
+
+export const CATALOGUE_OFFER_FLOOR_LABEL = CATALOGUE_OFFER_FLOOR.toLocaleString("en-US");
+
 export const MCP_INSTRUCTIONS = `# AgentDeals — free tiers, credits, and pricing changes for developer tools
 
-AgentDeals is a curated, human-verified directory of 1,500+ free tiers, startup credits, and discounts across 66 developer-tool categories — databases, cloud hosting, CI/CD, monitoring, AI services, auth, observability, payments, email, and more. Every offer is fact-checked against the vendor's pricing page, and pricing changes (free tier removals, limit reductions, new tiers) are tracked over time.
+AgentDeals is a curated, human-verified directory of ${CATALOGUE_OFFER_FLOOR_LABEL}+ free tiers, startup credits, and discounts across ${CATALOGUE_CATEGORY_COUNT} developer-tool categories — databases, cloud hosting, CI/CD, monitoring, AI services, auth, observability, payments, email, and more. Every offer is fact-checked against the vendor's pricing page, and pricing changes (free tier removals, limit reductions, new tiers) are tracked over time.
 
 ## When to use this server
 

--- a/src/serve.ts
+++ b/src/serve.ts
@@ -17,7 +17,8 @@ import { recordApiHit, recordSessionConnect, recordSessionDisconnect, recordLand
 import { buildDailyRollup, readRollups, coverageOf, ROLLUP_DATE_PATTERN } from "./analytics-rollup.js";
 import { configureVendorSeries, recordVendorRequest, flushVendorSeries, readVendorSeries, vendorSeriesGauge, vendorExportAuthorized, isSeriesDate, seriesDateRange, VENDOR_SERIES_PATH, VENDOR_SERIES_RETENTION_DAYS, VENDOR_SERIES_NOTES } from "./vendor-series.js";
 import { openapiSpec } from "./openapi.js";
-import { CATEGORY_ALIASES, EXAMPLE_MEMBERS_BASIS, buildCategoryDirectory, categoryHolds, familySiblings, resolveCategoryName, scopeFor } from "./category-scope.js";
+import { CATEGORY_ALIASES, CATEGORY_RETIREMENTS, EXAMPLE_MEMBERS_BASIS, buildCategoryDirectory, categoryHolds, familySiblings, publishedScopeFor, resolveCategoryName, retiredCategoryNames, retirementFor, scopeFor } from "./category-scope.js";
+import { retiredCategoryDescription, retiredCategoryNoticeHtml, retiredCategoryTitle } from "./category-retirement.js";
 import { LINK_GRACE_DAYS, unreachableNoticeForUrl } from "./link-health.js";
 import { offerEnded, offerRetired, recordedTierSentence, endedHeadline, endedHistorySentence, endedReliabilitySentence, endedEmptyChangeHistorySentence, ENDED_BADGE_LABEL, ENDED_SINCE_CHANGES_SENTENCE, type OfferTierAndUrl } from "./retirement.js";
 import { amountUnstatedSentence, levelWithheldReason, withheldLevelClause, withheldLevelSentence, type LevelWithheldReason } from "./source-check.js";
@@ -758,6 +759,13 @@ ${entries}
 const categorySlugMap = new Map<string, string>();
 for (const cat of categories) {
   categorySlugMap.set(toSlug(cat.name), cat.name);
+}
+
+const liveCategoryNames: ReadonlySet<string> = new Set(categories.map((c) => c.name));
+
+const retiredCategorySlugMap = new Map<string, string>();
+for (const name of retiredCategoryNames(liveCategoryNames)) {
+  retiredCategorySlugMap.set(toSlug(name), name);
 }
 
 const vendorLastmod = new Map<string, string>();
@@ -1781,7 +1789,7 @@ function buildCategoryPage(slug: string): string | null {
   const keyLimitMatch = topVendor?.description.match(/(\d[\d,]*\s*(?:GB|GiB|MB|TB|requests?|calls?|MAU|users?|emails?|messages?|builds?|minutes?|hours?|projects?|repos?|sites?|apps?|databases?|invocations?|events?))/i);
   const keyLimit = keyLimitMatch ? keyLimitMatch[1] : "a generous free tier";
 
-  const catScope = scopeFor(categoryName);
+  const catScope = publishedScopeFor(categoryName, liveCategoryNames);
   const catSiblings = familySiblings(categoryName).filter(s => categorySlugMap.has(toSlug(s)));
   const siblingsHtml = catSiblings.length > 0 && catScope
     ? `<p class="cat-scope-siblings">${catSiblings.length === 1 ? "One other name here answers" : `${catSiblings.length} other names here answer`} &ldquo;${escHtmlServer(catScope.answers[0])}&rdquo;, and each holds a different list: ${catSiblings.map(s => `<a href="/category/${toSlug(s)}">${escHtmlServer(s)}</a> (${categories.find(c => c.name === s)?.count ?? 0})`).join(", ")}.</p>`
@@ -2099,6 +2107,61 @@ ${globalNavCss()}
   <div class="cat-index-grid">${catCardsHtml}
   </div>
 
+  <footer>AgentDeals &mdash; open source, built for agents | <a href="/privacy">Privacy</a> | <a href="/press">Press</a> | <a href="/disclosure">Affiliate Disclosure</a></footer>
+</div>
+</body>
+</html>`;
+}
+
+function buildRetiredCategoryPage(slug: string): string | null {
+  const categoryName = retiredCategorySlugMap.get(slug);
+  if (!categoryName) return null;
+  const retirement = retirementFor(categoryName, liveCategoryNames);
+  if (!retirement) return null;
+
+  const title = retiredCategoryTitle(categoryName);
+  const metaDesc = retiredCategoryDescription(categoryName);
+
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>${escHtmlServer(title)}</title>
+<meta name="description" content="${escHtmlServer(metaDesc)}">
+<link rel="canonical" href="${BASE_URL}/category/${slug}">
+<meta property="og:title" content="${escHtmlServer(title)}">
+<meta property="og:description" content="${escHtmlServer(metaDesc)}">
+<meta property="og:type" content="website">
+<meta property="og:url" content="${BASE_URL}/category/${slug}">
+${OG_IMAGE_META}${GOOGLE_VERIFICATION_META}<link rel="icon" type="image/png" href="/favicon.png">
+<link rel="preconnect" href="https://fonts.googleapis.com"><link rel="preconnect" href="https://fonts.gstatic.com" crossorigin><link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
+<style>
+*{margin:0;padding:0;box-sizing:border-box}
+:root{--bg:#0f172a;--bg-elevated:#1e293b;--bg-card:rgba(255,255,255,0.06);--border:#334155;--border-hover:#3b82f6;--text:#f1f5f9;--text-muted:#94a3b8;--text-dim:#64748b;--accent:#3b82f6;--accent-hover:#60a5fa;--accent-glow:rgba(59,130,246,0.15);--serif:'Inter',-apple-system,sans-serif;--sans:'Inter',-apple-system,sans-serif;--mono:'JetBrains Mono',SFMono-Regular,monospace}
+body{font-family:var(--sans);background:var(--bg);color:var(--text);line-height:1.6}
+a{color:var(--accent);text-decoration:none}a:hover{color:var(--accent-hover);text-decoration:underline}
+.container{max-width:760px;margin:0 auto;padding:0 1.5rem}
+.breadcrumb{padding:1.5rem 0 0;font-size:.8rem;color:var(--text-dim)}
+.breadcrumb a{color:var(--text-muted)}
+h1{font-family:var(--serif);font-size:2.25rem;color:var(--text);margin:1rem 0 .5rem;letter-spacing:-.02em}
+.retired-category{border:1px solid var(--border);border-radius:8px;background:var(--bg-card);padding:1.5rem;margin:1.5rem 0}
+.retired-category-badge{display:inline-block;font-family:var(--mono);font-size:.7rem;text-transform:uppercase;letter-spacing:.08em;color:var(--text-dim);border:1px solid var(--border);border-radius:4px;padding:.15rem .5rem;margin-bottom:.9rem}
+.retired-category-headline{font-size:1.2rem;color:var(--text);margin-bottom:.5rem}
+.retired-category-date{font-family:var(--mono);font-size:.85rem;color:var(--text-muted);margin-bottom:.75rem}
+.retired-category-reason{color:var(--text-muted);margin-bottom:.9rem}
+.retired-category-onward{color:var(--text-muted);font-size:.9rem}
+footer{text-align:center;color:var(--text-dim);font-size:.8rem;padding:3rem 0 2rem;border-top:1px solid var(--border);margin-top:3rem}
+@media(max-width:768px){h1{font-size:1.5rem}}
+${globalNavCss()}
+</style>
+</head>
+<body>
+<div class="container">
+  ${buildGlobalNav("categories")}
+  <div class="breadcrumb"><a href="/">AgentDeals</a> &rsaquo; <a href="/category">Categories</a> &rsaquo; ${escHtmlServer(categoryName)}</div>
+  <h1>${escHtmlServer(categoryName)}</h1>
+  ${retiredCategoryNoticeHtml(categoryName, retirement, escHtmlServer)}
   <footer>AgentDeals &mdash; open source, built for agents | <a href="/privacy">Privacy</a> | <a href="/press">Press</a> | <a href="/disclosure">Affiliate Disclosure</a></footer>
 </div>
 </body>
@@ -54044,7 +54107,13 @@ const httpServer = createHttpServer(async (req, res) => {
     const cats = buildCategoryDirectory(getCategories(), loadOffers(), toSlug);
     logRequest({ ts: new Date().toISOString(), type: "api", endpoint: "/api/categories", params: {}, user_agent: req.headers["user-agent"] ?? "unknown", result_count: cats.length });
     res.writeHead(200, { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" });
-    res.end(JSON.stringify(cited({ categories: cats, example_members_basis: EXAMPLE_MEMBERS_BASIS, retired_names: CATEGORY_ALIASES }, "/category")));
+    const retiredCategories = retiredCategoryNames(liveCategoryNames).map((name) => ({
+      name,
+      slug: toSlug(name),
+      retired: CATEGORY_RETIREMENTS[name].retired,
+      reason: CATEGORY_RETIREMENTS[name].reason,
+    }));
+    res.end(JSON.stringify(cited({ categories: cats, example_members_basis: EXAMPLE_MEMBERS_BASIS, retired_names: CATEGORY_ALIASES, retired_categories: retiredCategories }, "/category")));
   } else if (url.pathname === "/api/agent-payments" && isGetOrHead) {
     recordApiHit("/api/agent-payments");
     const protocolFilter = url.searchParams.get("protocol") || undefined;
@@ -54887,7 +54956,7 @@ ${catList}
       res.end();
       return;
     }
-    const html = buildCategoryPage(slug);
+    const html = buildCategoryPage(slug) ?? buildRetiredCategoryPage(slug);
     if (html) {
       recordApiHit("/category/:slug");
       logRequest({ ts: new Date().toISOString(), type: "api", endpoint: "/category/" + slug, params: {}, user_agent: req.headers["user-agent"] ?? "unknown", result_count: 1 });

--- a/src/server-remote.ts
+++ b/src/server-remote.ts
@@ -16,7 +16,7 @@ import {
 } from "./api-client.js";
 import { getGuideList, getGuideBySlug } from "./guides.js";
 import { registerMcpAppsResources, TOOL_UI_META } from "./mcp-apps.js";
-import { MCP_INSTRUCTIONS } from "./mcp-instructions.js";
+import { CATALOGUE_CATEGORY_COUNT, CATALOGUE_OFFER_FLOOR_LABEL, MCP_INSTRUCTIONS } from "./mcp-instructions.js";
 import { substitutesFor } from "./product-role.js";
 
 export const TRACK_CHANGES_LIMIT = 1000;
@@ -74,7 +74,7 @@ export function createServer(): McpServer {
     {
       name: "agentdeals",
       version: "0.1.0",
-      description: "Find free tiers, startup credits, and discounts for developer tools — databases, cloud hosting, CI/CD, monitoring, APIs, and more. 1,600+ verified offers across 67 categories with pricing change tracking.",
+      description: `Find free tiers, startup credits, and discounts for developer tools — databases, cloud hosting, CI/CD, monitoring, APIs, and more. ${CATALOGUE_OFFER_FLOOR_LABEL}+ verified offers across ${CATALOGUE_CATEGORY_COUNT} categories with pricing change tracking.`,
     },
     {
       instructions: MCP_INSTRUCTIONS,

--- a/src/server.ts
+++ b/src/server.ts
@@ -22,7 +22,7 @@ import { getGuideList, getGuideBySlug } from "./guides.js";
 import type { Offer, EnrichedOffer, DealChange } from "./types.js";
 import { substitutesFor } from "./product-role.js";
 import { registerMcpAppsResources, TOOL_UI_META } from "./mcp-apps.js";
-import { MCP_INSTRUCTIONS } from "./mcp-instructions.js";
+import { CATALOGUE_CATEGORY_COUNT, CATALOGUE_OFFER_FLOOR_LABEL, MCP_INSTRUCTIONS } from "./mcp-instructions.js";
 import { MCP_SIGNAL_FOOTER } from "./signal-copy.js";
 import { BASE_URL } from "./base-url.js";
 import { withProvenance } from "./provenance.js";
@@ -76,7 +76,7 @@ export function createServer(getSessionId?: () => string | undefined, getClientN
     {
       name: "agentdeals",
       version: PKG_VERSION,
-      description: "AgentDeals helps developers find free tiers, startup credits, and deals on developer infrastructure. Use these tools when a user is evaluating cloud providers, databases, hosting, CI/CD, monitoring, auth, AI services, or any developer service — especially when cost matters. 1,600+ verified offers across 67 categories with pricing change tracking.",
+      description: `AgentDeals helps developers find free tiers, startup credits, and deals on developer infrastructure. Use these tools when a user is evaluating cloud providers, databases, hosting, CI/CD, monitoring, auth, AI services, or any developer service — especially when cost matters. ${CATALOGUE_OFFER_FLOOR_LABEL}+ verified offers across ${CATALOGUE_CATEGORY_COUNT} categories with pricing change tracking.`,
     },
     {
       instructions: MCP_INSTRUCTIONS,

--- a/test/category-retirement.test.ts
+++ b/test/category-retirement.test.ts
@@ -1,0 +1,423 @@
+import { describe, it, before, after } from "node:test";
+import assert from "node:assert";
+import { spawn, type ChildProcess } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  CATEGORY_ALIASES,
+  CATEGORY_RETIREMENTS,
+  CATEGORY_SCOPES,
+  buildCategoryDirectory,
+  categoryState,
+  publishedScopeFor,
+  retiredCategoryNames,
+  retirementFor,
+  scopeFor,
+} from "../dist/category-scope.js";
+import {
+  RETIRED_CATEGORY_BADGE,
+  RETIRED_CATEGORY_ONWARD_PATH,
+  retiredCategoryDescription,
+  retiredCategoryNoticeHtml,
+  retiredCategoryStatedOn,
+  retiredCategoryTitle,
+} from "../dist/category-retirement.js";
+import { CATALOGUE_CATEGORY_COUNT } from "../dist/mcp-instructions.js";
+import { getCategories, loadOffers } from "../dist/data.js";
+import { toSlug } from "../dist/slug.js";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO = path.join(__dirname, "..");
+
+const categories = getCategories();
+const offers = loadOffers();
+const liveNames: ReadonlySet<string> = new Set(categories.map((c) => c.name));
+
+const SLUGS_PUBLISHED_BEFORE_THE_SCOPE_REGISTRY = [
+  "ai-coding", "ai-ml", "analytics", "api-development", "api-gateway", "auth",
+  "background-jobs", "banking-finance", "browser-automation", "cdn", "ci-cd",
+  "cloud-hosting", "cloud-iaas", "cloud-storage", "code-quality", "communication",
+  "communication-messaging", "consumer-email", "container-registry", "databases",
+  "design", "design-creative", "dev-utilities", "diagramming", "dns-domain-management",
+  "documentation", "education", "email", "error-tracking", "feature-flags",
+  "fitness-health", "forms", "headless-cms", "ide-code-editors", "infrastructure",
+  "localization", "logging", "low-code-platforms", "maps-geolocation",
+  "meditation-wellness", "messaging", "mobile-development", "monitoring",
+  "news-reading", "notebooks-data-science", "password-managers", "payments",
+  "productivity-notes", "project-management", "search", "secrets-management",
+  "security", "server-management", "source-control", "startup-perks",
+  "startup-programs", "status-pages", "storage", "streaming-media",
+  "team-collaboration", "testing", "tunneling-networking", "video", "vpn-privacy",
+  "web-scraping", "workflow-automation",
+];
+
+const withoutRetirementCandidates: ReadonlySet<string> = new Set(
+  [...liveNames].filter((name) => !CATEGORY_RETIREMENTS[name]),
+);
+
+const escapeForTest = (value: string) =>
+  value.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;").replace(/'/g, "&#39;");
+
+let server: ChildProcess;
+let port = 0;
+
+function startServer(env: NodeJS.ProcessEnv = {}): Promise<{ child: ChildProcess; port: number }> {
+  return new Promise((resolve, reject) => {
+    const child = spawn("node", [path.join(REPO, "dist", "serve.js")], {
+      stdio: ["pipe", "pipe", "pipe"],
+      env: { ...process.env, PORT: "0", BASE_URL: "http://localhost", TZ: "UTC", ...env },
+    });
+    const timeout = setTimeout(() => { child.kill(); reject(new Error("Server startup timeout")); }, 60000);
+    child.stderr!.on("data", (data: Buffer) => {
+      const m = data.toString().match(/running on http:\/\/localhost:(\d+)/);
+      if (m) { clearTimeout(timeout); resolve({ child, port: parseInt(m[1], 10) }); }
+    });
+    child.on("error", (e) => { clearTimeout(timeout); reject(e); });
+  });
+}
+
+before(async () => { ({ child: server, port } = await startServer()); });
+after(() => { server?.kill(); });
+
+describe("a name holding nothing is retired, not absent", () => {
+  it("keeps a name live while the catalogue still files offers under it", () => {
+    for (const name of Object.keys(CATEGORY_RETIREMENTS)) {
+      if (!liveNames.has(name)) continue;
+      assert.strictEqual(categoryState(name, liveNames), "live", `${name} holds offers and does not read as live`);
+      assert.strictEqual(retirementFor(name, liveNames), null, `${name} holds offers and publishes a retirement notice`);
+      assert.ok(publishedScopeFor(name, liveNames), `${name} holds offers and withholds its scope statement`);
+    }
+  });
+
+  it("reads a name carrying a notice and holding nothing as retired", () => {
+    for (const name of Object.keys(CATEGORY_RETIREMENTS)) {
+      assert.strictEqual(categoryState(name, withoutRetirementCandidates), "retired");
+      assert.strictEqual(retirementFor(name, withoutRetirementCandidates)?.retired, CATEGORY_RETIREMENTS[name].retired);
+    }
+    assert.deepStrictEqual(
+      retiredCategoryNames(withoutRetirementCandidates),
+      Object.keys(CATEGORY_RETIREMENTS).sort(),
+    );
+  });
+
+  it("reads a name holding nothing and carrying no notice as absent", () => {
+    assert.strictEqual(categoryState("Fax Machines", liveNames), "absent");
+    assert.strictEqual(categoryState("Fax Machines", withoutRetirementCandidates), "absent");
+    assert.strictEqual(retirementFor("Fax Machines", withoutRetirementCandidates), null);
+  });
+
+  it("withholds the scope statement of a retired name and keeps it in the registry", () => {
+    for (const name of Object.keys(CATEGORY_RETIREMENTS)) {
+      assert.strictEqual(publishedScopeFor(name, withoutRetirementCandidates), null, `${name} is retired and still publishes a scope statement`);
+      assert.ok(CATEGORY_SCOPES[name], `${name} is retired and has been dropped from the registry rather than kept`);
+      assert.ok(scopeFor(name), `${name} is retired and the registry no longer remembers what it held`);
+    }
+  });
+
+  it("resolves a renamed name before deciding its state", () => {
+    for (const [alias, replacement] of Object.entries(CATEGORY_ALIASES)) {
+      assert.strictEqual(categoryState(alias, liveNames), categoryState(replacement, liveNames));
+    }
+  });
+});
+
+describe("every retirement notice names a date and a reason", () => {
+  it("dates every notice", () => {
+    for (const [name, retirement] of Object.entries(CATEGORY_RETIREMENTS)) {
+      assert.match(retirement.retired, /^\d{4}-\d{2}-\d{2}$/, `${name} is retired on no readable date`);
+    }
+  });
+
+  it("gives a reason longer than the name it retires", () => {
+    for (const [name, retirement] of Object.entries(CATEGORY_RETIREMENTS)) {
+      assert.ok(retirement.reason.length > name.length + 40, `${name} is retired for no stated reason`);
+    }
+  });
+
+  it("retires only a name the site has published", () => {
+    const neverPublished = Object.keys(CATEGORY_RETIREMENTS)
+      .filter((name) => !SLUGS_PUBLISHED_BEFORE_THE_SCOPE_REGISTRY.includes(toSlug(name)));
+    assert.deepStrictEqual(neverPublished, [], `retirement notices for names the site never published: ${neverPublished.join(", ")}`);
+  });
+});
+
+describe("the notice states the date and the reason in place of a listing", () => {
+  const sample = { retired: "2026-01-31", reason: "The entries under this name were out of scope for an index of developer infrastructure." };
+
+  it("prints the date and the reason", () => {
+    const html = retiredCategoryNoticeHtml("Sample & Name", sample, escapeForTest);
+    assert.ok(html.includes("2026-01-31"), "the notice does not print the date");
+    assert.ok(html.includes(escapeForTest(sample.reason)), "the notice does not print the reason");
+    assert.ok(html.includes(RETIRED_CATEGORY_BADGE));
+    assert.ok(html.includes(`href="${RETIRED_CATEGORY_ONWARD_PATH}"`), "the notice offers no route onward");
+  });
+
+  it("escapes the name it was handed", () => {
+    const html = retiredCategoryNoticeHtml("Sample & Name", sample, escapeForTest);
+    assert.ok(html.includes("Sample &amp; Name"));
+    assert.ok(!html.includes("Sample & Name"));
+  });
+
+  it("names the category in the title and the description without restating the notice", () => {
+    assert.ok(retiredCategoryTitle("Sample").includes("Sample"));
+    assert.ok(retiredCategoryDescription("Sample").includes("Sample"));
+    assert.ok(!retiredCategoryDescription("Sample").includes(sample.reason), "the description restates the reason the notice already gives");
+    assert.ok(retiredCategoryStatedOn(sample).includes("2026-01-31"));
+  });
+});
+
+describe("a retired name reaches no surface that lists categories", () => {
+  it("leaves a retired name out of the directory it would otherwise appear in", () => {
+    const liveOnly = categories.filter((c) => !CATEGORY_RETIREMENTS[c.name]);
+    const directory = buildCategoryDirectory(liveOnly, offers, toSlug);
+    const surfaced = directory
+      .map((entry) => entry.name)
+      .filter((name) => retiredCategoryNames(withoutRetirementCandidates).includes(name));
+    assert.deepStrictEqual(surfaced, [], `retired names published by the directory: ${surfaced.join(", ")}`);
+  });
+
+  it("sends no caller from a live name to a retired one", () => {
+    const liveOnly = categories.filter((c) => !CATEGORY_RETIREMENTS[c.name]);
+    const directory = buildCategoryDirectory(liveOnly, offers, toSlug);
+    const retired = new Set(retiredCategoryNames(withoutRetirementCandidates));
+    for (const entry of directory) {
+      for (const sibling of entry.also_answering) {
+        assert.ok(!retired.has(sibling.name), `${entry.name} sends a caller to ${sibling.name}, which is retired`);
+      }
+    }
+  });
+
+  it("names only a live category on every surface that publishes a list of them", async () => {
+    const directory = await (await fetch(`http://localhost:${port}/api/categories`)).json() as {
+      categories: { name: string }[];
+    };
+    for (const entry of directory.categories) {
+      assert.ok(liveNames.has(entry.name), `/api/categories publishes ${entry.name}, which holds nothing`);
+    }
+
+    const sitemap = await (await fetch(`http://localhost:${port}/sitemap-pages.xml`)).text();
+    const sitemapSlugs = [...sitemap.matchAll(/\/category\/([a-z0-9-]+)</g)].map((m) => m[1]);
+    const liveSlugs = new Set([...liveNames].map(toSlug));
+    for (const slug of sitemapSlugs) {
+      assert.ok(liveSlugs.has(slug), `the sitemap lists /category/${slug}, which holds nothing`);
+    }
+
+    const llmsFull = await (await fetch(`http://localhost:${port}/llms-full.txt`)).text();
+    const listed = [...llmsFull.matchAll(/^- (.+?) \(\d+ offers\)$/gm)].map((m) => m[1]);
+    assert.ok(listed.length > 0, "llms-full.txt lists no categories at all");
+    for (const name of listed) {
+      assert.ok(liveNames.has(name), `llms-full.txt lists ${name}, which holds nothing`);
+    }
+  });
+
+  it("publishes the retired set beside the renamed set rather than folded into it", async () => {
+    const body = await (await fetch(`http://localhost:${port}/api/categories`)).json() as {
+      retired_names: Record<string, string>;
+      retired_categories: { name: string; slug: string; retired: string; reason: string }[];
+    };
+    assert.ok(Array.isArray(body.retired_categories));
+    assert.deepStrictEqual(
+      body.retired_categories.map((c) => c.name).sort(),
+      retiredCategoryNames(liveNames),
+    );
+    for (const entry of body.retired_categories) {
+      assert.strictEqual(entry.slug, toSlug(entry.name));
+      assert.match(entry.retired, /^\d{4}-\d{2}-\d{2}$/);
+      assert.ok(entry.reason.length > 0);
+      assert.ok(!(entry.name in body.retired_names), `${entry.name} is reported as renamed and as retired`);
+    }
+  });
+});
+
+describe("every category path the site published still answers", () => {
+  it("serves a retired path with a notice rather than a listing or a redirect", async () => {
+    for (const name of retiredCategoryNames(liveNames)) {
+      const retirement = CATEGORY_RETIREMENTS[name];
+      const res = await fetch(`http://localhost:${port}/category/${toSlug(name)}`, { redirect: "manual" });
+      assert.strictEqual(res.status, 200, `/category/${toSlug(name)} answers ${res.status}`);
+      const html = await res.text();
+      assert.ok(html.includes(retirement.retired), `/category/${toSlug(name)} does not print the date it was retired`);
+      assert.ok(html.includes(escapeForTest(retirement.reason)), `/category/${toSlug(name)} does not print why it was retired`);
+      assert.ok(!html.includes("<table"), `/category/${toSlug(name)} still renders a listing`);
+    }
+  });
+
+  it("answers every published path with a listing or a notice, never a 404", async () => {
+    const orphaned: string[] = [];
+    for (const slug of SLUGS_PUBLISHED_BEFORE_THE_SCOPE_REGISTRY) {
+      const res = await fetch(`http://localhost:${port}/category/${slug}`, { redirect: "manual" });
+      if (res.status === 200) continue;
+      if (res.status === 301) {
+        const followed = await fetch(`http://localhost:${port}${res.headers.get("location")}`, { redirect: "manual" });
+        if (followed.status === 200) continue;
+      }
+      orphaned.push(`${slug} -> ${res.status}`);
+    }
+    assert.deepStrictEqual(orphaned, [], `category paths that no longer resolve: ${orphaned.join(", ")}`);
+  });
+});
+
+describe("a catalogue that files nothing under a name retires it end to end", () => {
+  const retiredHere = Object.keys(CATEGORY_RETIREMENTS);
+  const emptiedIndex = path.join(os.tmpdir(), `catalogue-without-retired-categories-${process.pid}.json`);
+  let emptied: ChildProcess;
+  let emptiedPort = 0;
+  let survivors: { name: string; count: number }[] = [];
+
+  before(async () => {
+    const kept = offers.filter((o) => !retiredHere.includes(o.category));
+    assert.ok(retiredHere.length > 0, "no name carries a retirement notice, so nothing here is under test");
+    assert.ok(!kept.some((o) => retiredHere.includes(o.category)), "the catalogue under test still files offers under a retired name");
+    fs.mkdirSync(path.dirname(emptiedIndex), { recursive: true });
+    fs.writeFileSync(emptiedIndex, JSON.stringify({ offers: kept }));
+    const counts = new Map<string, number>();
+    for (const offer of kept) counts.set(offer.category, (counts.get(offer.category) ?? 0) + 1);
+    survivors = [...counts.entries()].map(([name, count]) => ({ name, count })).sort((a, b) => a.name.localeCompare(b.name));
+    ({ child: emptied, port: emptiedPort } = await startServer({ AGENTDEALS_INDEX_PATH: emptiedIndex }));
+  });
+
+  after(() => {
+    emptied?.kill();
+    fs.rmSync(emptiedIndex, { force: true });
+  });
+
+  it("answers every retired path with a dated, reasoned notice", async () => {
+    for (const name of retiredHere) {
+      const res = await fetch(`http://localhost:${emptiedPort}/category/${toSlug(name)}`, { redirect: "manual" });
+      assert.strictEqual(res.status, 200, `/category/${toSlug(name)} answers ${res.status} once the name holds nothing`);
+      const html = await res.text();
+      assert.ok(html.includes(CATEGORY_RETIREMENTS[name].retired), `/category/${toSlug(name)} does not print the date it was retired`);
+      assert.ok(html.includes(escapeForTest(CATEGORY_RETIREMENTS[name].reason)), `/category/${toSlug(name)} does not print why it was retired`);
+      assert.ok(html.includes(RETIRED_CATEGORY_BADGE));
+      assert.ok(!html.includes("<table"), `/category/${toSlug(name)} still renders a listing`);
+    }
+  });
+
+  it("states the reason once on the page rather than in the lede as well", async () => {
+    for (const name of retiredHere) {
+      const html = await (await fetch(`http://localhost:${emptiedPort}/category/${toSlug(name)}`)).text();
+      const reason = escapeForTest(CATEGORY_RETIREMENTS[name].reason);
+      const stated = html.split(reason).length - 1;
+      assert.strictEqual(stated, 1, `/category/${toSlug(name)} states why it was retired ${stated} times`);
+    }
+  });
+
+  it("answers every path the site published, retired names among them", async () => {
+    const orphaned: string[] = [];
+    for (const slug of SLUGS_PUBLISHED_BEFORE_THE_SCOPE_REGISTRY) {
+      const res = await fetch(`http://localhost:${emptiedPort}/category/${slug}`, { redirect: "manual" });
+      if (res.status === 200) continue;
+      if (res.status === 301) {
+        const followed = await fetch(`http://localhost:${emptiedPort}${res.headers.get("location")}`, { redirect: "manual" });
+        if (followed.status === 200) continue;
+      }
+      orphaned.push(`${slug} -> ${res.status}`);
+    }
+    assert.deepStrictEqual(orphaned, [], `category paths that no longer resolve: ${orphaned.join(", ")}`);
+  });
+
+  it("leaves a retired name out of every surface that lists categories", async () => {
+    const directory = await (await fetch(`http://localhost:${emptiedPort}/api/categories`)).json() as {
+      categories: { name: string }[];
+      retired_categories: { name: string; retired: string; reason: string }[];
+    };
+    for (const name of retiredHere) {
+      assert.ok(!directory.categories.some((c) => c.name === name), `/api/categories still publishes ${name}`);
+    }
+    assert.deepStrictEqual(directory.retired_categories.map((c) => c.name).sort(), [...retiredHere].sort());
+
+    const sitemap = await (await fetch(`http://localhost:${emptiedPort}/sitemap-pages.xml`)).text();
+    for (const name of retiredHere) {
+      assert.ok(!sitemap.includes(`/category/${toSlug(name)}<`), `the sitemap still lists /category/${toSlug(name)}`);
+    }
+
+    const llmsFull = await (await fetch(`http://localhost:${emptiedPort}/llms-full.txt`)).text();
+    for (const name of retiredHere) {
+      assert.ok(!llmsFull.includes(`- ${name} (`), `llms-full.txt still lists ${name}`);
+    }
+
+    const index = await (await fetch(`http://localhost:${emptiedPort}/category`)).text();
+    for (const name of retiredHere) {
+      assert.ok(!index.includes(`/category/${toSlug(name)}"`), `/category still cards ${name}`);
+    }
+  });
+
+  it("returns no offer under a retired name from any search", async () => {
+    for (const name of retiredHere) {
+      const byCategory = await (await fetch(`http://localhost:${emptiedPort}/api/offers?category=${encodeURIComponent(name)}&limit=5`)).json() as { total: number };
+      assert.strictEqual(byCategory.total, 0, `/api/offers still returns ${byCategory.total} offers under ${name}`);
+    }
+
+    const listed = await (await fetch(`http://localhost:${emptiedPort}/api/offers?limit=5000`)).json() as { total: number; offers: { vendor: string; category: string }[] };
+    assert.strictEqual(listed.offers.length, listed.total, "the sweep did not read every offer the API will serve");
+    assert.ok(listed.total > 0);
+    const reachable = listed.offers.filter((o) => retiredHere.includes(o.category));
+    assert.deepStrictEqual(reachable.map((o) => `${o.vendor} (${o.category})`), [], "offers filed under a retired name are still served");
+
+    const searchPage = await (await fetch(`http://localhost:${emptiedPort}/search`)).text();
+    for (const name of retiredHere) {
+      assert.ok(!searchPage.includes(`>${name}<`), `/search still offers ${name} as a filter`);
+    }
+  });
+
+  it("counts only the names that survived", async () => {
+    const live = survivors.length;
+    assert.strictEqual(live, categories.filter((c) => !retiredHere.includes(c.name)).length);
+    assert.ok(live > 0);
+
+    const home = await (await fetch(`http://localhost:${emptiedPort}/`)).text();
+    assert.ok(home.includes(`<div class="stat-num stat-purple">${live}</div>`), `the home page does not state ${live} categories`);
+
+    const llms = await (await fetch(`http://localhost:${emptiedPort}/llms.txt`)).text();
+    assert.ok(llms.includes(`across ${live} categories`), `llms.txt does not state ${live} categories`);
+
+    const index = await (await fetch(`http://localhost:${emptiedPort}/category`)).text();
+    assert.ok(index.includes(`All Categories (${live})`), `/category does not state ${live} categories`);
+  });
+});
+
+describe("the number of categories we publish is counted, not remembered", () => {
+  it("prints the live count on every surface that states one", async () => {
+    const live = categories.length;
+    assert.strictEqual(CATALOGUE_CATEGORY_COUNT, live, "the MCP instructions state a count of their own");
+
+    const home = await (await fetch(`http://localhost:${port}/`)).text();
+    assert.ok(home.includes(`<div class="stat-num stat-purple">${live}</div>`), `the home page does not state ${live} categories`);
+
+    const llms = await (await fetch(`http://localhost:${port}/llms.txt`)).text();
+    assert.ok(llms.includes(`across ${live} categories`), `llms.txt does not state ${live} categories`);
+
+    const llmsFull = await (await fetch(`http://localhost:${port}/llms-full.txt`)).text();
+    assert.ok(llmsFull.includes(`across ${live} categories`), `llms-full.txt does not state ${live} categories`);
+
+    const index = await (await fetch(`http://localhost:${port}/category`)).text();
+    assert.ok(index.includes(`All Categories (${live})`), `/category does not state ${live} categories`);
+  });
+
+  it("states the same count over MCP as it states over HTTP", async () => {
+    const init = await fetch(`http://localhost:${port}/mcp`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Accept: "application/json, text/event-stream" },
+      body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "initialize", params: { protocolVersion: "2025-06-18", capabilities: {}, clientInfo: { name: "test", version: "1" } } }),
+    });
+    const text = await init.text();
+    const payload = JSON.parse(text.startsWith("event:") ? text.split("data: ")[1] : text) as {
+      result: { instructions: string; serverInfo: { description?: string } };
+    };
+    assert.ok(payload.result.instructions.includes(`across ${categories.length} developer-tool categories`), "the MCP instructions state a count of their own");
+  });
+
+  it("writes no category count into a source file that a shrinking catalogue would falsify", () => {
+    const offenders: string[] = [];
+    for (const file of fs.readdirSync(path.join(REPO, "src")).filter((f) => f.endsWith(".ts"))) {
+      const source = fs.readFileSync(path.join(REPO, "src", file), "utf8");
+      for (const match of source.matchAll(/across [0-9,]+\+? (?:developer-tool )?categor|[0-9,]+\+? categories with pricing change tracking|Browse [0-9,]+ categories/g)) {
+        offenders.push(`src/${file}: ${match[0]}`);
+      }
+    }
+    assert.deepStrictEqual(offenders, [], `category counts written as literals: ${offenders.join("; ")}`);
+  });
+});

--- a/test/category-scope.test.ts
+++ b/test/category-scope.test.ts
@@ -7,7 +7,9 @@ import {
   PROGRAMME_TIERS,
   buildCategoryDirectory,
   categoryHolds,
+  categoryState,
   familySiblings,
+  publishedScopeFor,
   resolveCategoryName,
   scopeFor,
 } from "../dist/category-scope.js";
@@ -31,8 +33,16 @@ describe("every published category says what it holds", () => {
 
   it("declares no scope for a name no offer is filed under", () => {
     const live = new Set(categories.map((c) => c.name));
-    const orphans = Object.keys(CATEGORY_SCOPES).filter((name) => !live.has(name));
+    const orphans = Object.keys(CATEGORY_SCOPES).filter((name) => categoryState(name, live) === "absent");
     assert.deepStrictEqual(orphans, [], `scope declared for names holding nothing: ${orphans.join(", ")}`);
+  });
+
+  it("publishes no scope statement for a name it has retired", () => {
+    const live = new Set(categories.map((c) => c.name));
+    const speaking = Object.keys(CATEGORY_SCOPES)
+      .filter((name) => categoryState(name, live) === "retired")
+      .filter((name) => publishedScopeFor(name, live) !== null);
+    assert.deepStrictEqual(speaking, [], `retired names still publishing a scope statement: ${speaking.join(", ")}`);
   });
 
   it("names three members for every category holding three unended offers", () => {

--- a/test/mcp-instructions.test.ts
+++ b/test/mcp-instructions.test.ts
@@ -3,7 +3,8 @@ import assert from "node:assert";
 import { spawn, type ChildProcess } from "node:child_process";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { MCP_INSTRUCTIONS } from "../dist/mcp-instructions.js";
+import { CATALOGUE_CATEGORY_COUNT, CATALOGUE_OFFER_FLOOR_LABEL, MCP_INSTRUCTIONS } from "../dist/mcp-instructions.js";
+import { getCategories, loadOffers } from "../dist/data.js";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -15,14 +16,22 @@ describe("MCP_INSTRUCTIONS constant (issue #977)", () => {
 
   it("covers identity, trigger conditions, tool selection, and unique value", () => {
     assert.match(MCP_INSTRUCTIONS, /AgentDeals/);
-    assert.match(MCP_INSTRUCTIONS, /1,500\+/);
-    assert.match(MCP_INSTRUCTIONS, /66 .*categor/i);
+    assert.ok(MCP_INSTRUCTIONS.includes(`${CATALOGUE_OFFER_FLOOR_LABEL}+ free tiers`));
+    assert.ok(MCP_INSTRUCTIONS.includes(`across ${CATALOGUE_CATEGORY_COUNT} developer-tool categories`));
     assert.match(MCP_INSTRUCTIONS, /search_deals/);
     assert.match(MCP_INSTRUCTIONS, /plan_stack/);
     assert.match(MCP_INSTRUCTIONS, /compare_vendors/);
     assert.match(MCP_INSTRUCTIONS, /track_changes/);
     assert.match(MCP_INSTRUCTIONS, /verified/i);
     assert.match(MCP_INSTRUCTIONS, /pricing change/i);
+  });
+
+  it("counts the catalogue rather than remembering how big it once was", () => {
+    assert.strictEqual(CATALOGUE_CATEGORY_COUNT, getCategories().length);
+    const offers = loadOffers().length;
+    const floor = Number(CATALOGUE_OFFER_FLOOR_LABEL.replace(/,/g, ""));
+    assert.ok(floor <= offers, `the instructions claim ${floor}+ offers over a catalogue of ${offers}`);
+    assert.ok(offers - floor < 100, `the instructions round ${offers} offers down to ${floor}`);
   });
 });
 


### PR DESCRIPTION
Refs #1465

## What this does

The scope registry gains a third state. A name is **live** while the catalogue files an offer under it, **retired** when it holds nothing and carries a dated retirement notice, and **absent** otherwise. `categoryState(name, liveNames)` decides; the retired state is derived from the catalogue, not declared twice.

`/category/<slug>` for a retired name answers **200** with the date it was retired, the reason its entries left, and a route onward to `/category`. It is not a listing and not a redirect.

`/api/categories` gains `retired_categories` — name, slug, date, reason — beside the existing `retired_names`, which is the renamed-to map and a different thing. A test asserts no name appears in both.

## Verified against PR #1410's own catalogue

The two assertions blocking https://github.com/robhunter/agentdeals/pull/1410 pass on this branch when run against that branch's `data/index.json`:

```
AGENTDEALS_INDEX_PATH=<PR #1410's index.json> node --test \
  test/category-scope.test.ts test/category-url-stability.test.ts test/category-retirement.test.ts
  ✔ declares no scope for a name no offer is filed under
  ✔ answers every category path the site published before the scope registry
  ✔ publishes no scope statement for a name it has retired
  pass 52  fail 0
```

Neither assertion is exempted for these five names. The first now reads `categoryState(name, live) === "absent"` — a scoped name must hold offers **or be retired**, and retired is earned by carrying a dated, reasoned notice that the route actually serves. A name holding nothing without one still fails exactly as before.

PR #1410 also needs a data rebase — it currently conflicts with main in four `data/` files. That is separate from this and I have not touched it.

## Not vacuous on main

All five names are still live here, so a route test over "the retired set" would assert nothing. `test/category-retirement.test.ts` starts a second server against a catalogue with those categories emptied, via the existing `AGENTDEALS_INDEX_PATH` seam, and asserts against it: the five paths answer 200 with the notice, every path the site ever published still resolves, none of the five reaches `/api/categories`, the sitemap, `llms-full.txt`, `/category` or any search, and the counts drop to the survivors. The fixture is written to a temp dir; no repo data file is moved.

Mutation-tested, three mutations:

| mutation | killed by |
|---|---|
| route stops falling through to the retired page | 2 tests |
| `categoryState` never returns `retired` | 5 tests |
| a literal category count restored to `server.ts` | 1 test |

One assertion was vacuous when written — it queried `/api/search`, which does not exist, and read an empty result list as a pass. It now sweeps every offer `/api/offers` will serve and asserts none is filed under a retired name.

## Three MCP surfaces stated a count they no longer had

`mcp-instructions.ts` said 66 categories, `server.ts` and `server-remote.ts` said 67, and the catalogue holds 65. The same two sentences claimed 1,600+ offers over a catalogue of 1,580. Both numbers are now read from the catalogue, and a test fails on any source file that writes a category count as a literal — `test/mcp-instructions.test.ts` was itself pinned to `/66 .*categor/i` and is now pinned to the derived value.

`/` and `llms.txt` were already derived; the new test holds all six surfaces to the same number.

## One defect found and fixed on the branch

The first draft of the page stated its reason twice. `withLedeBeforeNav` injects the meta description into the body of every page, so a description carrying the reason repeated the notice a few lines below it. The description now states the fact and the notice states the reason, and a test asserts the reason appears exactly once on the page.

Verified in a browser at `/category/streaming-media` against the emptied catalogue.