### PR TITLE
Attribute a source check's finding to our check, not to the page it cites

### DIFF
--- a/scripts/ratchet-quality-budgets.js
+++ b/scripts/ratchet-quality-budgets.js
@@ -7,7 +7,7 @@ import {
 } from "../dist/page-reviews.js";
 import { toSlug } from "../dist/vendor-slug.js";
 import { uncitedChangesAgainstBudget } from "../dist/change-reporting.js";
-import { passedWithoutQuotingThePage } from "../dist/source-check.js";
+import { passedWithoutRecordingAFinding } from "../dist/source-check.js";
 import { supersededCensus } from "../dist/superseded-census.js";
 
 const REPO = join(dirname(fileURLToPath(import.meta.url)), "..");
@@ -70,7 +70,7 @@ export function measureBudgets(date) {
     stale_fact_pages: stale.length,
     unsourced_tier_a: unsourcedTierAPaths(index.pages).length,
     uncited_change_records: uncitedChangesAgainstBudget(changes).length,
-    source_checks_ok_without_quoted_evidence: offers.filter(passedWithoutQuotingThePage).length,
+    source_checks_ok_without_quoted_evidence: offers.filter(passedWithoutRecordingAFinding).length,
     ...supersededCensus(offers, changes, date),
   };
 }

--- a/src/openapi.ts
+++ b/src/openapi.ts
@@ -985,7 +985,7 @@ export const openapiSpec = {
               "The last three withhold a favourable risk_level; the first two do not."
             ].join(" ")
           },
-          detail: { type: "string", description: "What the check found, in its own words: for ok, the name the page writes for the vendor and the price evidence quoted from it, or what its markup states when the rendered page states no amount; for states_no_amount, the phrase that was the page's entire price evidence; otherwise why the page cannot confirm the record. Where the page was read for schema.org markup, the detail says whether that markup was absent, present and priceless, or priced." },
+          detail: { type: "string", description: "Our own sentence recording what the check found — never a quotation from the page, and not corroborable against it (#1467). For ok, the form of the vendor's name the check matched and the price signal it found, or what the markup states when the rendered page states no amount; for states_no_amount, the phrase that was the page's entire price evidence; otherwise why the page cannot confirm the record. Where the page was read for schema.org markup, the detail says whether that markup was absent, present and priceless, or priced. The fields carrying text taken from a page are product_role.source_quote and product_subtypes.labels[].source_quote." },
           read: { type: "string", enum: ["markup"], description: "Present when the ok grade rests on typed prices in the page's schema.org markup rather than on a figure the page renders (#1279)." },
           unrendered_prices: {
             type: "array",

--- a/src/serve.ts
+++ b/src/serve.ts
@@ -34,7 +34,7 @@ import { tierRecordsAFreeTier } from "./free-tier-record.js";
 import { PAGE_HEAD_OPEN, withLedeBeforeNav } from "./page-lede.js";
 import { UNGRADED_IMPACT_COLOR, changeImpactColor, changeImpactLabel, changeImpactWord, isChangeImpactLevel } from "./change-impact.js";
 import { COMPARED_SERVICES_PLACEHOLDER, appendToCompiledFigureSlots, fillComparedServicesCount, markCompiledFigures, recordsSinceCompiled, replaceTimelineRows, staticHalfOf, timelineRecordsFor, vendorForSubject, vendorSubjectsOnCompiledPage, type CompiledFigureSubject, type CompiledFigureVendor, type CompiledFigureVerdict } from "./compiled-figures.js";
-import { NO_CATALOGUE_RECORD, citedSourceLinkHtml, citedSourcesListHtml, freeTierSourceOf, readClauseHtml, sourceMarkerHtml, uncitedSourceLinkHtml, withCitedSources, type CitedService, type FreeTierSource } from "./source-citation.js";
+import { CHECK_ESTABLISHES, CHECK_SCOPE_CLASS, NO_CATALOGUE_RECORD, citedSourceLinkHtml, citedSourcesListHtml, freeTierSourceOf, pageQuoteHtml, readClauseHtml, sourceMarkerHtml, uncitedSourceLinkHtml, withCitedSources, type CitedService, type FreeTierSource } from "./source-citation.js";
 import { vendorHistorySentence } from "./vendor-history.js";
 import { HETZNER_APRIL_CHANGES, HETZNER_CLOUD_PLANS, HETZNER_PRICES_READ, HETZNER_PRICE_SOURCE, HETZNER_SINGAPORE_EXAMPLE, cheapestOrderableHetznerPlan, hetznerEntryPriceClause, unorderableHetznerPlans } from "./hetzner-pricing.js";
 import { HUNDRED_TB_SCENARIO, ONE_TO_ONE_SCENARIO, STORAGE_RATES_READ, STORAGE_SCALE_WORKLOADS, TEN_TO_ONE_SCENARIO, cheapestProviderAt, costliestProviderAt, egressAllowanceSentence, egressBillOnceOverAllowance, egressRatioWhereCostsMatch, fixedMonthlyGrantsSentence, monthlyStorageCost, providersWithScalingEgressAllowance, rateCardFor, scaleCostFor } from "./storage-cost-model.js";
@@ -4488,7 +4488,7 @@ function buildVendorPage(slug: string): string | null {
     const role = primary.product_role;
     const sentence = productRoleSentence(primary);
     if (!role || !sentence) return "";
-    return `  <p class="product-role-line" style="margin:.4rem 0 .6rem;font-size:.9rem;color:var(--text-muted)"><strong>Product role:</strong> ${escHtmlServer(sentence)} We read that from <a href="${escHtmlServer(role.source_url)}" rel="nofollow noopener">${escHtmlServer(role.source_url)}</a> on <span class="product-role-reviewed" style="font-family:var(--mono)">${escHtmlServer(role.reviewed)}</span>, where it says: &ldquo;${escHtmlServer(role.source_quote)}&rdquo; <a href="${CRITERIA_PATH}#membership">How we use this</a>.</p>`;
+    return `  <p class="product-role-line" style="margin:.4rem 0 .6rem;font-size:.9rem;color:var(--text-muted)"><strong>Product role:</strong> ${escHtmlServer(sentence)} We read that from <a href="${escHtmlServer(role.source_url)}" rel="nofollow noopener">${escHtmlServer(role.source_url)}</a> on <span class="product-role-reviewed" style="font-family:var(--mono)">${escHtmlServer(role.reviewed)}</span>, ${pageQuoteHtml(role.source_quote, escHtmlServer)} <a href="${CRITERIA_PATH}#membership">How we use this</a>.</p>`;
   })();
 
   const productSubtypesLine = (() => {
@@ -4515,11 +4515,11 @@ function buildVendorPage(slug: string): string | null {
     if (!source.cited) return "";
     const read = readClauseHtml(
       source.readOn,
-      [{ url: source.url, quote: source.quote }],
+      [{ url: source.url, finding: source.finding }],
       escHtmlServer,
       { dateClass: SOURCE_READ_DATE_CLASS },
     );
-    return `\n    <p class="free-tier-source-line" style="margin:.5rem 0 0;font-size:.8rem;color:var(--text-dim)">${read}.</p>`;
+    return `\n    <p class="free-tier-source-line" style="margin:.5rem 0 0;font-size:.8rem;color:var(--text-dim)">${read}. <span class="${CHECK_SCOPE_CLASS}">${escHtmlServer(CHECK_ESTABLISHES)}</span></p>`;
   })();
 
   const alternativesMembership = partitionSubstitutes(

--- a/src/source-check.ts
+++ b/src/source-check.ts
@@ -74,8 +74,16 @@ function passedOnDetail(offer: Pick<Offer, "source_check">, tokens: string[]): b
   return check?.outcome === "ok" && tokens.includes(check.detail ?? "");
 }
 
-export function passedWithoutQuotingThePage(offer: Pick<Offer, "source_check">): boolean {
+export function passedWithoutRecordingAFinding(offer: Pick<Offer, "source_check">): boolean {
   return passedOnDetail(offer, NAMING_TOKENS_RECORDED_INSTEAD_OF_EVIDENCE);
+}
+
+export function checkFinding(offer: Pick<Offer, "source_check">): string | null {
+  const check = offer.source_check;
+  if (check?.outcome !== "ok") return null;
+  const detail = (check.detail ?? "").trim();
+  if (detail === "" || NAMING_TOKENS_RECORDED_INSTEAD_OF_EVIDENCE.includes(detail)) return null;
+  return detail;
 }
 
 export function passedOnTheUrlWeAskedFor(offer: Pick<Offer, "source_check">): boolean {

--- a/src/source-citation.ts
+++ b/src/source-citation.ts
@@ -1,7 +1,7 @@
 import { CITATION_LINK_HTML, RECORD_SOURCE_CLASS, UNCITED_TAG_CLASS, citationLabel } from "./change-citation.js";
 import { FREE_TIER_STANDING_LABELS } from "./risk-scorecard.js";
 import {
-  passedWithoutQuotingThePage,
+  checkFinding,
   termsUnconfirmedOutcome,
   unconfirmedTermsClause,
 } from "./source-check.js";
@@ -10,15 +10,42 @@ import type { Offer } from "./types.js";
 
 export type Escaper = (text: string) => string;
 
+export const PAGE_QUOTE_CLASS = "page-quote";
+
+export const CHECK_FINDING_CLASS = "check-finding";
+
+export const CHECK_FINDING_LEAD = "our check recorded";
+
+export const CHECK_ESTABLISHES =
+  "A source check reads the cited page for the service's name and a price; the limits above are from our own record.";
+
+export const CHECK_ESTABLISHES_ON_A_LIST =
+  "A source check reads each cited page for that service's name and a price; the figures in the tables above are from our own records.";
+
+export function pageQuoteHtml(quote: string, esc: Escaper): string {
+  return `<span class="${PAGE_QUOTE_CLASS}">where it says: &ldquo;${esc(quote)}&rdquo;</span>`;
+}
+
+export function checkFindingHtml(finding: string, esc: Escaper): string {
+  return `<span class="${CHECK_FINDING_CLASS}">${CHECK_FINDING_LEAD}: ${esc(finding)}</span>`;
+}
+
 export interface ReadSource {
   url: string;
   quote?: string | null;
+  finding?: string | null;
 }
 
 export interface ReadClauseOptions {
   dateClass: string;
   rel?: string;
   linkText?: (url: string) => string;
+}
+
+function attributionHtml(source: ReadSource, esc: Escaper): string {
+  if (source.quote) return `, ${pageQuoteHtml(source.quote, esc)}`;
+  if (source.finding) return `, and ${checkFindingHtml(source.finding, esc)}`;
+  return "";
 }
 
 export function readClauseHtml(
@@ -33,9 +60,7 @@ export function readClauseHtml(
   const provenance = sources
     .map(source => {
       const link = `<a href="${esc(source.url)}" rel="${rel}">${esc(linkText(source.url))}</a>`;
-      return source.quote
-        ? `${link}, where it says: &ldquo;${esc(source.quote)}&rdquo;`
-        : link;
+      return `${link}${attributionHtml(source, esc)}`;
     })
     .join(" and from ");
   return (
@@ -48,7 +73,7 @@ export interface SourceRead {
   cited: true;
   url: string;
   readOn: string;
-  quote: string | null;
+  finding: string | null;
 }
 
 export interface SourceMissing {
@@ -74,7 +99,7 @@ export function freeTierSourceOf(offer: SourcedOffer | null | undefined): FreeTi
     cited: true,
     url,
     readOn: check.checked,
-    quote: passedWithoutQuotingThePage(offer) ? null : check.detail,
+    finding: checkFinding(offer),
   };
 }
 
@@ -132,6 +157,8 @@ export function sourceMarkerHtml(
 
 export const CITED_SOURCES_CLASS = "cited-sources";
 
+export const CHECK_SCOPE_CLASS = "check-scope";
+
 export function citedSourcesListHtml(
   services: readonly CitedService[],
   esc: Escaper,
@@ -146,7 +173,7 @@ export function citedSourcesListHtml(
       const body = service.source.cited
         ? readClauseHtml(
             service.source.readOn,
-            [{ url: service.source.url, quote: service.source.quote }],
+            [{ url: service.source.url, finding: service.source.finding }],
             esc,
             { dateClass, linkText: citationLabel },
           )
@@ -155,7 +182,8 @@ export function citedSourcesListHtml(
     })
     .join("\n      ");
   return (
-    `<ul class="${CITED_SOURCES_CLASS}" style="margin:1rem 0 0 1.1rem;padding:0;font-size:.85rem;line-height:1.7">\n` +
+    `<p class="${CHECK_SCOPE_CLASS}" style="margin:1rem 0 0;font-size:.8rem;color:var(--text-dim)">${esc(CHECK_ESTABLISHES_ON_A_LIST)}</p>\n` +
+    `    <ul class="${CITED_SOURCES_CLASS}" style="margin:.5rem 0 0 1.1rem;padding:0;font-size:.85rem;line-height:1.7">\n` +
     `      ${items}\n    </ul>`
   );
 }

--- a/test/check-finding-not-a-quotation.test.ts
+++ b/test/check-finding-not-a-quotation.test.ts
@@ -1,0 +1,282 @@
+import { describe, it, before, after } from "node:test";
+import assert from "node:assert";
+import { assertPopulationFloor } from "./population-floor.ts";
+import { spawn, type ChildProcess } from "node:child_process";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const {
+  CHECK_ESTABLISHES,
+  CHECK_ESTABLISHES_ON_A_LIST,
+  CHECK_FINDING_LEAD,
+  PAGE_QUOTE_CLASS,
+  freeTierSourceOf,
+  pageQuoteHtml,
+  readClauseHtml,
+} = await import("../dist/source-citation.js");
+const { NAMING_TOKENS_RECORDED_INSTEAD_OF_EVIDENCE, checkFinding } = await import("../dist/source-check.js");
+const { toSlug } = await import("../dist/vendor-slug.js");
+
+type Offer = import("../src/types.ts").Offer;
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO = path.join(__dirname, "..");
+
+const offers: Offer[] = JSON.parse(
+  readFileSync(path.join(REPO, "data", "index.json"), "utf-8"),
+).offers;
+
+const primaryFor = new Map<string, Offer>();
+for (const offer of offers) if (!primaryFor.has(offer.vendor)) primaryFor.set(offer.vendor, offer);
+const primaries = [...primaryFor.values()];
+
+const recordsWithAFinding = primaries.filter(
+  offer => checkFinding(offer) !== null && freeTierSourceOf(offer).cited,
+);
+
+const COMPILED_PAGES = [
+  "/cloud-free-tier-comparison-2026",
+  "/database-free-tier-comparison-2026",
+  "/cicd-free-tier-comparison-2026",
+  "/serverless-free-tier-comparison-2026",
+  "/testing-free-tier-comparison-2026",
+  "/analytics-free-tier-comparison-2026",
+  "/api-development-free-tier-comparison-2026",
+  "/security-free-tier-comparison-2026",
+  "/hosting-free-tier-comparison-2026",
+  "/auth-comparison-2026",
+  "/email-comparison-2026",
+  "/storage-comparison-2026",
+  "/monitoring-comparison-2026",
+  "/aws-free-tier-2026",
+  "/gcp-free-tier-2026",
+  "/azure-free-tier-2026",
+  "/digitalocean-free-tier-2026",
+  "/ai-coding-pricing-2026",
+];
+
+const QUOTED_AS_THE_PAGES_OWN_WORDS = new RegExp(
+  `<span class="${PAGE_QUOTE_CLASS}">where it says: &ldquo;([^<]*)&rdquo;</span>`,
+  "g",
+);
+
+function quotedAsPageText(html: string): string[] {
+  return [...html.matchAll(QUOTED_AS_THE_PAGES_OWN_WORDS)].map(m => m[1]!);
+}
+
+function unescapeEntities(text: string): string {
+  return text
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+    .replace(/&amp;/g, "&");
+}
+
+const pageTextWeHold = new Set<string>();
+for (const offer of offers) {
+  if (offer.product_role?.source_quote) pageTextWeHold.add(offer.product_role.source_quote);
+  for (const label of offer.product_subtypes?.labels ?? []) {
+    if (label.source_quote) pageTextWeHold.add(label.source_quote);
+  }
+}
+
+function startServer(): Promise<{ proc: ChildProcess; base: string }> {
+  return new Promise((resolve, reject) => {
+    const proc = spawn("node", [path.join(REPO, "dist", "serve.js")], {
+      cwd: REPO,
+      stdio: ["ignore", "ignore", "pipe"],
+      env: { ...process.env, PORT: "0", BASE_URL: "http://localhost", TZ: "UTC" },
+    });
+    const timeout = setTimeout(() => {
+      proc.kill();
+      reject(new Error("Server startup timeout"));
+    }, 30000);
+    proc.stderr!.on("data", (data: Buffer) => {
+      const m = data.toString().match(/running on http:\/\/localhost:(\d+)/);
+      if (m) {
+        clearTimeout(timeout);
+        resolve({ proc, base: `http://localhost:${m[1]}` });
+      }
+    });
+    proc.on("error", err => {
+      clearTimeout(timeout);
+      reject(err);
+    });
+  });
+}
+
+describe("a check result is our finding and never the vendor's words", () => {
+  it("publishes what the check found, attributed to the check", () => {
+    const detail = 'the page names Example as "example" and states "$0"';
+    const source = freeTierSourceOf({
+      url: "https://example.com/pricing",
+      tier: "Free",
+      verifiedDate: "2026-08-01",
+      source_check: { checked: "2026-09-05", outcome: "ok", detail },
+    });
+    assert.ok(source.cited);
+    assert.strictEqual(source.cited && source.finding, detail);
+    const html = readClauseHtml("2026-09-05", [{ url: "https://example.com/pricing", finding: detail }], (t: string) => t, {
+      dateClass: "read-on",
+    });
+    assert.ok(html.includes(`${CHECK_FINDING_LEAD}: ${detail}`), html);
+    assert.deepStrictEqual(quotedAsPageText(html), []);
+  });
+
+  it("keeps a detail template nobody has written yet out of the quotation slot", () => {
+    const novel = "the page renders a pricing widget we cannot read, and its markup states 3 typed prices";
+    const source = freeTierSourceOf({
+      url: "https://example.com/pricing",
+      tier: "Free",
+      verifiedDate: "2026-08-01",
+      source_check: { checked: "2026-09-05", outcome: "ok", detail: novel },
+    });
+    assert.strictEqual(source.cited && source.finding, novel);
+    const html = readClauseHtml("2026-09-05", [{ url: "https://example.com/pricing", finding: novel }], (t: string) => t, {
+      dateClass: "read-on",
+    });
+    assert.deepStrictEqual(quotedAsPageText(html), []);
+    assert.ok(html.includes(novel), html);
+  });
+
+  it("publishes nothing where the check recorded which layer matched rather than a finding", () => {
+    for (const token of NAMING_TOKENS_RECORDED_INSTEAD_OF_EVIDENCE) {
+      const offer = { source_check: { checked: "2026-09-05", outcome: "ok" as const, detail: token } };
+      assert.strictEqual(checkFinding(offer), null, token);
+    }
+  });
+
+  it("reaches the quotation slot only through text held as the page's own", () => {
+    const html = pageQuoteHtml("Serverless Redis, Vector and Search databases", (t: string) => t);
+    assert.deepStrictEqual(quotedAsPageText(html), ["Serverless Redis, Vector and Search databases"]);
+  });
+
+  it("holds a population of check results large enough for the sweeps below to mean something", () => {
+    assertPopulationFloor(recordsWithAFinding.length, 150, "records whose source check recorded a finding");
+  });
+});
+
+const CONTROL_VENDOR_PAGE = "/vendor/upstash";
+
+const FREE_TIER_SOURCE_LINE = /<p class="free-tier-source-line"[\s\S]*?<\/p>/;
+
+const vendorRoutes = [...new Set(primaries.map(offer => `/vendor/${toSlug(offer.vendor)}`))];
+
+interface Swept {
+  quotes: string[];
+  sourceLine: string;
+}
+
+describe("nothing we serve attributes our own sentence to the page it cites", () => {
+  let server: { proc: ChildProcess; base: string };
+  const swept = new Map<string, Swept>();
+  const rendered = new Map<string, string>();
+
+  before(async () => {
+    server = await startServer();
+    for (const route of [...COMPILED_PAGES, CONTROL_VENDOR_PAGE, ...vendorRoutes]) {
+      if (swept.has(route)) continue;
+      const res = await fetch(`${server.base}${route}`);
+      const html = await res.text();
+      if (res.status !== 200) continue;
+      swept.set(route, {
+        quotes: quotedAsPageText(html).map(unescapeEntities),
+        sourceLine: html.match(FREE_TIER_SOURCE_LINE)?.[0] ?? "",
+      });
+      if (COMPILED_PAGES.includes(route) || route === CONTROL_VENDOR_PAGE) rendered.set(route, html);
+    }
+  });
+
+  after(() => server?.proc.kill());
+
+  it("reads every vendor page and every compiled comparison page", () => {
+    assertPopulationFloor(swept.size, 1000, "pages read for the quotation sweep");
+    const unserved = [...COMPILED_PAGES, CONTROL_VENDOR_PAGE].filter(route => !swept.has(route));
+    assert.deepStrictEqual(unserved, []);
+  });
+
+  it("quotes only text our records hold as the page's own words", () => {
+    const attributed: Array<{ route: string; quote: string }> = [];
+    for (const [route, page] of swept) {
+      for (const quote of page.quotes) attributed.push({ route, quote });
+    }
+    const invented = attributed.filter(({ quote }) => !pageTextWeHold.has(quote));
+    assert.deepStrictEqual(
+      invented.slice(0, 10),
+      [],
+      `${invented.length} of ${attributed.length} quotations are text no record holds as the page's own`,
+    );
+    assertPopulationFloor(attributed.length, 150, "quotations swept across the served pages");
+  });
+
+  it("renders no source-check finding as something the cited page says", () => {
+    const misattributed: string[] = [];
+    for (const offer of recordsWithAFinding) {
+      const page = swept.get(`/vendor/${toSlug(offer.vendor)}`);
+      if (page?.quotes.includes(checkFinding(offer)!)) misattributed.push(offer.vendor);
+    }
+    assert.deepStrictEqual(misattributed.slice(0, 10), []);
+  });
+
+  it("tells the reader what the check found, and says it was our check", () => {
+    const silent: string[] = [];
+    let attributed = 0;
+    for (const offer of recordsWithAFinding) {
+      const page = swept.get(`/vendor/${toSlug(offer.vendor)}`);
+      if (!page || page.sourceLine === "") continue;
+      if (page.sourceLine.includes(`${CHECK_FINDING_LEAD}: `)) attributed++;
+      else silent.push(offer.vendor);
+    }
+    assert.deepStrictEqual(silent.slice(0, 10), []);
+    assertPopulationFloor(attributed, 150, "vendor pages attributing a finding to our check");
+  });
+
+  it("never publishes the name of the layer that matched as a thing we found", () => {
+    const leaked: string[] = [];
+    for (const [route, page] of swept) {
+      for (const token of NAMING_TOKENS_RECORDED_INSTEAD_OF_EVIDENCE) {
+        if (page.sourceLine.includes(`${CHECK_FINDING_LEAD}: ${token}<`)) leaked.push(`${route} — ${token}`);
+      }
+    }
+    assert.deepStrictEqual(leaked.slice(0, 10), []);
+  });
+
+  it("says on the page what a check establishes, wherever a citation sits beside the limits", () => {
+    const missing: string[] = [];
+    let stated = 0;
+    for (const [route, page] of swept) {
+      if (page.sourceLine === "") continue;
+      if (page.sourceLine.includes(CHECK_ESTABLISHES)) stated++;
+      else missing.push(route);
+    }
+    assert.deepStrictEqual(missing.slice(0, 10), []);
+    assertPopulationFloor(stated, 500, "vendor pages stating what their source check establishes");
+  });
+
+  it("says the same of the list of sources on every compiled comparison page", () => {
+    const missing = COMPILED_PAGES.filter(page => !rendered.get(page)!.includes(CHECK_ESTABLISHES_ON_A_LIST));
+    assert.deepStrictEqual(missing, []);
+  });
+
+  it("keeps quoting the page where a record holds the page's own words", () => {
+    const record = primaryFor.get("Upstash");
+    const held = record?.product_role?.source_quote ?? record?.product_subtypes?.labels[0]?.source_quote;
+    assert.ok(held, "the positive control needs a record holding page text");
+    assert.ok(swept.get(CONTROL_VENDOR_PAGE)?.quotes.includes(held!), "the quotation of held page text is gone");
+  });
+
+  it("keeps the source links and read dates the comparison pages ship", () => {
+    for (const page of COMPILED_PAGES) {
+      const html = rendered.get(page)!;
+      assert.ok(html.includes('<ul class="cited-sources"'), page);
+      assert.match(html, /class="cited-source-read"/, page);
+    }
+  });
+
+  it("keeps the note that says we could not read the page we cite", () => {
+    const carrying = COMPILED_PAGES.filter(page => rendered.get(page)!.includes("unsourced-tag"));
+    assertPopulationFloor(carrying.length, 10, "compiled pages still marking a service unsourced");
+  });
+});

--- a/test/comparison-source-citation.test.ts
+++ b/test/comparison-source-citation.test.ts
@@ -13,6 +13,7 @@ const {
   readClauseHtml,
   sourceAnchorId,
   withCitedSources,
+  CHECK_FINDING_LEAD,
   NO_CATALOGUE_RECORD,
 } = await import("../dist/source-citation.js");
 const { tabulatedSubjectSlots, vendorFactRows, SOURCE_MARKER_IN_A_CELL } = await import("../dist/page-reviews.js");
@@ -120,11 +121,11 @@ describe("what a record says about its source, without loading the catalogue", (
       cited: true,
       url: "https://example.com/pricing",
       readOn: "2026-09-05",
-      quote: 'the page names Example and states "$0"',
+      finding: 'the page names Example and states "$0"',
     });
   });
 
-  it("cites the page and the date without a quote when the check recorded no evidence from it", () => {
+  it("cites the page and the date alone where the check recorded which layer matched and no finding", () => {
     const source = freeTierSourceOf({
       url: "https://example.com/pricing",
       tier: "Free",
@@ -135,7 +136,7 @@ describe("what a record says about its source, without loading the catalogue", (
       cited: true,
       url: "https://example.com/pricing",
       readOn: "2026-09-05",
-      quote: null,
+      finding: null,
     });
   });
 
@@ -185,6 +186,15 @@ describe("what a record says about its source, without loading the catalogue", (
     });
     assert.doesNotMatch(html, /where it says/);
     assert.match(html, /<a href="https:\/\/example\.com\/pricing"/);
+  });
+
+  it("attributes a finding to our own check and never to the page", () => {
+    const finding = 'the page names Example as "example" and states "$0"';
+    const html = readClauseHtml("2026-09-05", [{ url: "https://example.com/pricing", finding }], (t: string) => t, {
+      dateClass: "read-on",
+    });
+    assert.doesNotMatch(html, /where it says/);
+    assert.ok(html.includes(`${CHECK_FINDING_LEAD}: ${finding}`), html);
   });
 
   it("puts the list of sources inside the methodology block it belongs to", () => {

--- a/test/source-check-pages.test.ts
+++ b/test/source-check-pages.test.ts
@@ -6,6 +6,7 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { LEVEL_WITHHOLDING_OUTCOMES, levelWithheldReason, withheldLevelClause } from "../dist/source-check.js";
+import { pageQuoteHtml } from "../dist/source-citation.js";
 import type { LevelWithheldReason } from "../src/source-check.ts";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -413,10 +414,8 @@ describe("a page we quote from is not also a page we say we can read nothing on"
 
   it("quotes the page it cites", async () => {
     const { body } = await get("/vendor/longcorp");
-    assert.match(
-      body,
-      /https:\/\/longcorp\.example\/pricing<\/a>, where it says: &ldquo;Standard Events and Metrics Up to 5 hosts&rdquo;/
-    );
+    const quoted = pageQuoteHtml("Standard Events and Metrics Up to 5 hosts", (t: string) => t);
+    assert.ok(body.includes(`https://longcorp.example/pricing</a>, ${quoted}`), quoted);
   });
 
   it("does not also say that page states no terms it can read", async () => {
@@ -426,7 +425,8 @@ describe("a page we quote from is not also a page we say we can read nothing on"
 
   it("keeps saying so where the quote comes from a different page", async () => {
     const { body } = await get("/vendor/prosecorp");
-    assert.match(body, /dealmarket\.example\/offers<\/a>, where it says:/);
+    const quoted = pageQuoteHtml("managed Postgres", (t: string) => t);
+    assert.ok(body.includes(`dealmarket.example/offers</a>, ${quoted}`), quoted);
     assert.match(saidOfTheSubject(body), /states no terms we can read/);
   });
 

--- a/test/vendor-naming.test.ts
+++ b/test/vendor-naming.test.ts
@@ -10,7 +10,7 @@ import {
   SOURCE_CHECK_UNREADABLE,
 } from "../scripts/vendor-naming.js";
 import { priceSignals, MIN_PRICE_SIGNALS } from "../scripts/change-gate.js";
-import { passedOnTheUrlWeAskedFor, passedWithoutQuotingThePage } from "../dist/source-check.js";
+import { passedOnTheUrlWeAskedFor, passedWithoutRecordingAFinding } from "../dist/source-check.js";
 import { qualityBudget } from "../dist/page-reviews.js";
 import { loadOffers } from "../dist/data.js";
 import { JOINSECRET_OFFERS_PAGE, BREX_REWARDS_PAGE } from "./vendor-page-fixture.ts";
@@ -221,7 +221,7 @@ describe("what a re-verification learned about the cited page", () => {
   it("says what it read on the page it passed, rather than which layer matched", () => {
     const text = "Vercel Hobby plan, free forever. Pro is $20/month.";
     const result = classifySource({ vendor: "Vercel", url: "https://vercel.com/pricing" }, { ok: true, text }, priceSignals(text));
-    assert.strictEqual(passedWithoutQuotingThePage({ source_check: result }), false, result.detail);
+    assert.strictEqual(passedWithoutRecordingAFinding({ source_check: result }), false, result.detail);
     assert.match(result.detail, /names Vercel/);
     assert.match(result.detail, /\$20/);
   });
@@ -263,7 +263,7 @@ describe("what data/index.json publishes as a passed source check", () => {
 
   it("holds no more passes that quote nothing from the page than the budget allows", () => {
     const budget = qualityBudget("source_checks_ok_without_quoted_evidence");
-    const measured = offers.filter(passedWithoutQuotingThePage).length;
+    const measured = offers.filter(passedWithoutRecordingAFinding).length;
     assert.ok(
       measured <= budget,
       `${measured} offers pass a source check without quoting the page, over the budget of ${budget} in data/quality_budgets.json`,


### PR DESCRIPTION
Refs #1467

Sixty-five citations on the eighteen comparison pages, and the vendor pages behind them, rendered `source_check.detail` — a sentence we generate — in the slot a verbatim quotation belongs in. The evidence behind each was real and on the page. The attribution was not.

## What changed

`SourceRead` carries a `finding`, not a `quote`, so `detail` has no path to the quotation slot at all. `/vendor/upstash` renders both shapes one after the other, and only the one holding page text says *where it says*:

> **Subtypes in Databases:** … We read that on 2026-08-31 from https://upstash.com/, where it says: “Serverless Redis, Vector and Search databases with low latency and pay-as-you-go pricing.”

> We read that on 2026-09-05 from https://upstash.com/pricing, and our check recorded: the page names Upstash as "upstash" and states "$0". A source check reads the cited page for the service's name and a price; the limits above are from our own record.

The quotation slot is now one generator, `pageQuoteHtml`, fed only by fields whose contract is page text — `product_role.source_quote` and `product_subtypes.labels[].source_quote`. That makes the distinction structural: a `detail` template added next cycle becomes a finding by construction, not by escaping a list of literals. `passedWithoutQuotingThePage`, which keyed on the three literals `text`, `url` and `host`, is now `passedWithoutRecordingAFinding` and decides only whether the note is publishable.

The second sentence answers the reading problem underneath: `states "$0"` sat beside a row publishing `500K commands/month`. A check establishes that the cited page names the service and states a price; it is not evidence of the limit next to it, and the page now says so.

`openapi.ts` draws the same line for the machine-readable surface and names the two fields that do hold page text.

## Measured

- Eighteen comparison pages: **65 findings** reattributed, **0 quotations** left on any of them. 401 source markers and 125 unsourced tags unchanged.
- Sweep of all **1,580 vendor pages** plus the eighteen: 202 quotations render, and every one is text a record holds as the page's own words.
- Reinstating the defect as a mutation puts **206 of 408** quotations back to text no record holds, and three assertions fire.

## Tests

15 new in `test/check-finding-not-a-quotation.test.ts`, including the negative control over every record that reaches a citation block and the positive control on `/vendor/upstash`. 7 mutants, 7 killed. Suite 4,484 pass.