### PR TITLE
Publish only what the homepage can serve (#1464)

### DIFF
--- a/data/deal_changes.json
+++ b/data/deal_changes.json
@@ -1847,7 +1847,7 @@
       "previous_state": "App Mesh: fully managed service mesh for ECS and EKS microservice networking",
       "current_state": "App Mesh: end of support September 30, complete service retirement",
       "impact": "medium",
-      "source_url": "https://docs.aws.amazon.com/app-mesh/",
+      "source_url": "https://docs.aws.amazon.com/app-mesh/latest/userguide/what-is-app-mesh.html",
       "category": "Cloud Hosting",
       "alternatives": [
         "Istio",
@@ -1855,7 +1855,12 @@
         "Amazon EKS native service mesh"
       ],
       "recorded_date": "2026-04-10",
-      "date_source": "hand_written"
+      "date_source": "hand_written",
+      "source_check": {
+        "checked": "2026-09-08",
+        "outcome": "ok",
+        "finding": "the page carries an End of support notice reading \"On September 30, 2026, AWS will discontinue support for AWS App Mesh\""
+      }
     },
     {
       "vendor": "AWS",
@@ -1865,7 +1870,7 @@
       "previous_state": "Proton: managed IaC provisioning with developer self-service templates",
       "current_state": "Proton: end of support October 7, complete service retirement",
       "impact": "medium",
-      "source_url": "https://docs.aws.amazon.com/proton/",
+      "source_url": "https://docs.aws.amazon.com/proton/latest/userguide/Welcome.html",
       "category": "DevOps",
       "alternatives": [
         "AWS CDK",
@@ -1873,7 +1878,12 @@
         "Pulumi"
       ],
       "recorded_date": "2026-04-10",
-      "date_source": "hand_written"
+      "date_source": "hand_written",
+      "source_check": {
+        "checked": "2026-09-08",
+        "outcome": "ok",
+        "finding": "the page carries an End of support notice reading \"On October 7, 2026, AWS will end support for AWS Proton\""
+      }
     },
     {
       "vendor": "Vercel",

--- a/data/index.json
+++ b/data/index.json
@@ -3343,7 +3343,7 @@
     {
       "vendor": "AWS Activate",
       "category": "Startup Perks",
-      "description": "Founders: $1,000 credits (self-funded startups). Portfolio: up to $100,000 credits (VC/accelerator-backed). Additional up to $300,000 in Trainium/Inferentia credits for AI startups building on AWS custom silicon (requires provider nomination). All credits usable on Bedrock models",
+      "description": "Founders: $1,000 credits (self-funded startups). Portfolio: up to $200,000 credits (VC/accelerator-backed). Additional up to $300,000 in Trainium/Inferentia credits for AI startups building on AWS custom silicon (requires provider nomination). All credits usable on Bedrock models",
       "tier": "Portfolio",
       "url": "https://aws.amazon.com/activate/",
       "tags": [

--- a/scripts/mutate-1464.mjs
+++ b/scripts/mutate-1464.mjs
@@ -1,0 +1,85 @@
+import { readFileSync, writeFileSync } from "node:fs";
+import { execSync } from "node:child_process";
+
+const SERVE = "src/serve.ts";
+const INVENTORY = "src/api-inventory.ts";
+const INDEX = "data/index.json";
+const CHANGES = "data/deal_changes.json";
+
+const MUTANTS = [
+  {
+    name: "a printed example names a vendor the catalogue does not hold",
+    file: INVENTORY,
+    from: '{ method: "GET", path: "/api/vendor-risk/:vendor", desc: "Check vendor pricing risk", params: "", group: "product", request: "/api/vendor-risk/{vendor}" }',
+    to: '{ method: "GET", path: "/api/vendor-risk/:vendor", desc: "Check vendor pricing risk", params: "", group: "product", request: "/api/vendor-risk/Heroku" }',
+  },
+  {
+    name: "the endpoint count is written as a literal again",
+    file: SERVE,
+    from: "Every one of the ${apiRequestsWePublish().length} read endpoints is listed below",
+    to: "Every one of the 18 read endpoints is listed below",
+  },
+  {
+    name: "the block prints fewer endpoints than the inventory publishes",
+    file: INVENTORY,
+    from: "export function readableRequestLines(groups: readonly ApiGroup[], subjects: ExampleSubjects): string[] {\n  return readableEndpoints(groups)",
+    to: "export function readableRequestLines(groups: readonly ApiGroup[], subjects: ExampleSubjects): string[] {\n  return readableEndpoints(groups).slice(0, 17)",
+  },
+  {
+    name: "a served route joins neither the inventory nor the unpublished register",
+    file: SERVE,
+    from: '  } else if (url.pathname === "/api/stats" && isGetOrHead) {',
+    to: '  } else if (url.pathname === "/api/not-in-any-inventory" && isGetOrHead) {\n    res.end();\n  } else if (url.pathname === "/api/stats" && isGetOrHead) {',
+  },
+  {
+    name: "the credit ceiling is hardcoded in the problem statement",
+    file: SERVE,
+    from: "<strong>${escHtmlServer(acceleratorCreditClause(acceleratorCreditCeiling()))}</strong>",
+    to: "<strong>your accelerator batch gets up to $100K in AWS credits</strong>",
+  },
+  {
+    name: "the record states a ceiling its own check contradicts",
+    file: INDEX,
+    from: "Portfolio: up to $200,000 credits (VC/accelerator-backed)",
+    to: "Portfolio: up to $100,000 credits (VC/accelerator-backed)",
+  },
+  {
+    name: "a change card names a vendor without linking it",
+    file: SERVE,
+    from: '          <span class="change-vendor">${homepageVendorLink(c.vendor)}</span>\n          <span class="change-date">',
+    to: '          <span class="change-vendor">${escHtmlServer(c.vendor)}</span>\n          <span class="change-date">',
+  },
+  {
+    name: "the App Mesh record cites the page that omits the date",
+    file: CHANGES,
+    from: '"finding": "the page carries an End of support notice reading \\"On September 30, 2026, AWS will discontinue support for AWS App Mesh\\""',
+    to: '"finding": "the page describes AWS App Mesh"',
+  },
+];
+
+const only = process.argv[2] ? Number(process.argv[2]) : null;
+
+for (const [i, mutant] of MUTANTS.entries()) {
+  if (only !== null && only !== i) continue;
+  const original = readFileSync(mutant.file, "utf8");
+  if (!original.includes(mutant.from)) {
+    console.log(`SKIP  ${i} ${mutant.name} — anchor not found in ${mutant.file}`);
+    continue;
+  }
+  writeFileSync(mutant.file, original.replace(mutant.from, mutant.to));
+  let killed = false;
+  let output = "";
+  try {
+    execSync("npx tsc", { stdio: "pipe" });
+    output = execSync("node --test --test-concurrency 1 test/homepage-cites-what-it-serves.test.ts", { stdio: "pipe" }).toString();
+  } catch (e) {
+    killed = true;
+    output = `${e.stdout ?? ""}${e.stderr ?? ""}`;
+  } finally {
+    writeFileSync(mutant.file, original);
+    execSync("npx tsc", { stdio: "pipe" });
+  }
+  const failing = [...output.matchAll(/^ {2}✖ (.+?) \(/gm)].map(([, name]) => name);
+  console.log(`${killed ? "KILLED" : "SURVIVED"}  ${i} ${mutant.name}`);
+  if (killed) console.log(`        by: ${failing.join("; ") || "(build or startup)"}`);
+}

--- a/src/api-inventory.ts
+++ b/src/api-inventory.ts
@@ -1,0 +1,124 @@
+export type ApiMethod = "GET" | "POST" | "DELETE";
+
+export type ApiGroup = "product" | "meta" | "referral";
+
+export interface ApiEndpoint {
+  method: ApiMethod;
+  path: string;
+  desc: string;
+  params: string;
+  group: ApiGroup;
+  request?: string;
+  requiresParams?: true;
+}
+
+export interface ExampleSubjects {
+  vendor: string;
+  otherVendor: string;
+  codedVendor: string;
+}
+
+export const API_ENDPOINTS: readonly ApiEndpoint[] = [
+  { method: "GET", path: "/api/offers", desc: "Search and browse offers", params: "q, category, limit, offset", group: "product", request: "/api/offers?q=database" },
+  { method: "GET", path: "/api/categories", desc: "List all categories with counts, what each name holds, and the other names answering the same question", params: "", group: "product" },
+  { method: "GET", path: "/api/new", desc: "Recently added or updated offers", params: "days", group: "product", request: "/api/new?days=7" },
+  { method: "GET", path: "/api/newest", desc: "Newest deals by verification date", params: "limit", group: "product", request: "/api/newest?limit=10" },
+  { method: "GET", path: "/api/changes", desc: "Pricing and deal changes", params: "since, type, vendor, vendors, category, categories, limit, offset", group: "product", request: "/api/changes?since=2025-01-01" },
+  { method: "GET", path: "/api/details/:vendor", desc: "Vendor detail with alternatives", params: "", group: "product", request: "/api/details/{vendor}" },
+  { method: "GET", path: "/api/compare", desc: "Compare two vendors side by side", params: "a, b", group: "product", request: "/api/compare?a={vendor}&b={otherVendor}" , requiresParams: true },
+  { method: "GET", path: "/api/audit-stack", desc: "Audit your infrastructure stack", params: "services", group: "product", request: "/api/audit-stack?services={vendor},{otherVendor}" , requiresParams: true },
+  { method: "GET", path: "/api/vendor-risk/:vendor", desc: "Check vendor pricing risk", params: "", group: "product", request: "/api/vendor-risk/{vendor}" },
+  { method: "GET", path: "/api/deadlines", desc: "Future-dated changes with countdown", params: "type", group: "product" },
+  { method: "GET", path: "/api/ai-coding-pricing", desc: "AI coding tools pricing comparison data", params: "type (ide, cli, cloud-agent, app-builder)", group: "product" },
+  { method: "GET", path: "/api/hosting-pricing", desc: "Cloud hosting & PaaS pricing comparison data", params: "type (traditional-paas, edge-serverless, full-featured, static-specialized)", group: "product" },
+  { method: "GET", path: "/api/llm-pricing", desc: "LLM API pricing comparison data", params: "type (frontier, inference, open-source-host, specialized)", group: "product" },
+  { method: "GET", path: "/api/startup-credits", desc: "Startup credits & programs comparison data", params: "type (cloud-infrastructure, fintech-banking, developer-tools, ai-tools)", group: "product" },
+  { method: "GET", path: "/api/referral-programs", desc: "Developer tools with referral/affiliate programs", params: "category", group: "product" },
+  { method: "GET", path: "/api/expiring", desc: "Get expiring deals", params: "days", group: "product", request: "/api/expiring?within_days=30" },
+  { method: "GET", path: "/api/freshness", desc: "Data freshness metrics", params: "", group: "product" },
+  { method: "GET", path: "/api/digest", desc: "Weekly pricing digest", params: "", group: "product" },
+  { method: "GET", path: "/api/digest/weekly", desc: "Formatted weekly digest with multiple output formats", params: "format (json|markdown|html), limit, weeks_ago", group: "product", request: "/api/digest/weekly?format=markdown&weeks_ago=1" },
+  { method: "GET", path: "/api/stack", desc: "Free-tier stack recommendation", params: "use_case, requirements", group: "product", request: "/api/stack?use_case=SaaS+app" , requiresParams: true },
+  { method: "GET", path: "/api/costs", desc: "Estimate infrastructure costs", params: "services, scale", group: "product", request: "/api/costs?services={vendor},{otherVendor}" , requiresParams: true },
+  { method: "GET", path: "/api/query-log", desc: "Recent request log", params: "limit", group: "product", request: "/api/query-log?limit=10" },
+  { method: "GET", path: "/api/pageviews", desc: "Page view analytics", params: "path, period", group: "product" },
+  { method: "GET", path: "/api/traffic", desc: "Traffic attributed by client class (AI agent / crawler / browser), with web-vs-MCP comparison", params: "", group: "product" },
+  { method: "GET", path: "/api/stats", desc: "Service statistics", params: "", group: "product" },
+  { method: "GET", path: "/api/feed", desc: "Atom feed of pricing changes", params: "", group: "product" },
+  { method: "GET", path: "/api/openapi.json", desc: "OpenAPI 3.0 description of this API", params: "", group: "meta" },
+  { method: "GET", path: "/api/docs", desc: "Browsable API reference", params: "", group: "meta" },
+  { method: "POST", path: "/api/watchlist", desc: "Subscribe to vendor pricing changes via webhook", params: "vendor, webhook_url (body)", group: "product" },
+  { method: "GET", path: "/api/watchlist", desc: "List active watchlist subscriptions", params: "webhook_url", group: "product" },
+  { method: "GET", path: "/api/watchlist/:id", desc: "Get subscription status", params: "", group: "product", request: "/api/watchlist/{watchlistId}" },
+  { method: "DELETE", path: "/api/watchlist/:id", desc: "Unsubscribe from vendor watch", params: "", group: "product" },
+  { method: "GET", path: "/api/referral-codes", desc: "List all active referral codes (platform + marketplace)", params: "source (platform|agent), category", group: "referral" },
+  { method: "GET", path: "/api/referral-codes/:vendor", desc: "Get best referral code for a specific vendor", params: "", group: "referral", request: "/api/referral-codes/{codedVendor}" },
+  { method: "POST", path: "/api/referral-codes", desc: "Submit a marketplace referral code (agents only, auth required)", params: "vendor, code, referral_url (body) — Authorization: Bearer <api-key>", group: "referral" },
+];
+
+export function endpointsInGroups(groups: readonly ApiGroup[]): ApiEndpoint[] {
+  return API_ENDPOINTS.filter((e) => groups.includes(e.group));
+}
+
+export function readableEndpoints(groups: readonly ApiGroup[]): ApiEndpoint[] {
+  return endpointsInGroups(groups).filter((e) => e.method === "GET");
+}
+
+export function pickSubject(available: readonly string[], preferred: readonly string[], exclude: readonly string[] = []): string {
+  const held = new Set(available);
+  const barred = new Set(exclude);
+  for (const name of preferred) {
+    if (held.has(name) && !barred.has(name)) return name;
+  }
+  for (const name of available) {
+    if (!barred.has(name)) return name;
+  }
+  return preferred[0] ?? "";
+}
+
+export const PREFERRED_EXAMPLE_VENDORS = ["Supabase", "Vercel", "Netlify", "Railway", "Render"] as const;
+
+export const PREFERRED_EXAMPLE_COMPARISONS = ["Neon", "Render", "Railway", "Fly.io", "Vercel"] as const;
+
+export function exampleSubjects(vendors: readonly string[], codedVendors: readonly string[]): ExampleSubjects {
+  const vendor = pickSubject(vendors, PREFERRED_EXAMPLE_VENDORS);
+  const otherVendor = pickSubject(vendors, PREFERRED_EXAMPLE_COMPARISONS, [vendor]);
+  const codedVendor = codedVendors.length > 0 ? pickSubject(codedVendors, PREFERRED_EXAMPLE_VENDORS) : vendor;
+  return { vendor, otherVendor, codedVendor };
+}
+
+export function exampleRequest(endpoint: ApiEndpoint, subjects: ExampleSubjects, watchlistId = "sub_example"): string {
+  const template = endpoint.request ?? endpoint.path;
+  return template
+    .replace(/\{vendor\}/g, encodeURIComponent(subjects.vendor))
+    .replace(/\{otherVendor\}/g, encodeURIComponent(subjects.otherVendor))
+    .replace(/\{codedVendor\}/g, encodeURIComponent(subjects.codedVendor))
+    .replace(/\{watchlistId\}/g, encodeURIComponent(watchlistId));
+}
+
+export function endpointHref(endpoint: ApiEndpoint, subjects: ExampleSubjects): string | null {
+  if (endpoint.method !== "GET") return null;
+  if (endpoint.path === "/api/watchlist/:id") return null;
+  return exampleRequest(endpoint, subjects);
+}
+
+export function endpointPathHref(endpoint: ApiEndpoint, subjects: ExampleSubjects): string | null {
+  if (endpointHref(endpoint, subjects) === null) return null;
+  if (endpoint.requiresParams) return exampleRequest(endpoint, subjects);
+  const codedRoute = endpoint.path === "/api/referral-codes/:vendor";
+  return endpoint.path.replace(/:vendor/, encodeURIComponent(codedRoute ? subjects.codedVendor : subjects.vendor));
+}
+
+export function readableRequestLines(groups: readonly ApiGroup[], subjects: ExampleSubjects): string[] {
+  return readableEndpoints(groups)
+    .filter((e) => endpointHref(e, subjects) !== null)
+    .map((e) => `GET ${exampleRequest(e, subjects)}`);
+}
+
+export function readableRequestCount(groups: readonly ApiGroup[], subjects: ExampleSubjects): number {
+  return readableRequestLines(groups, subjects).length;
+}
+
+export const HOMEPAGE_GROUPS: readonly ApiGroup[] = ["product", "meta"];
+
+export const DOCUMENTED_GROUPS: readonly ApiGroup[] = ["product", "referral"];

--- a/src/homepage-claims.ts
+++ b/src/homepage-claims.ts
@@ -1,0 +1,50 @@
+export interface ClaimRecord {
+  vendor: string;
+  description?: string | null;
+}
+
+export interface NamedVendor {
+  name: string;
+  slug: string;
+}
+
+const CEILING = /up to \$\s?([\d][\d,]*(?:\.\d+)?)\s?([KMB])?/i;
+
+export function programCeiling(record: ClaimRecord | undefined | null, program: string): string | null {
+  const description = record?.description ?? "";
+  const at = description.toLowerCase().indexOf(`${program.toLowerCase()}:`);
+  if (at === -1) return null;
+  const clause = description.slice(at, description.indexOf(".", at) === -1 ? undefined : description.indexOf(".", at));
+  const found = clause.match(CEILING);
+  if (!found) return null;
+  return `$${found[1]}${found[2] ?? ""}`;
+}
+
+export const ACCELERATOR_CREDIT_VENDOR = "AWS Activate";
+
+export const ACCELERATOR_CREDIT_PROGRAM = "Portfolio";
+
+export function acceleratorCreditClause(ceiling: string | null): string {
+  return ceiling === null
+    ? "your accelerator batch comes with cloud credits"
+    : `your accelerator batch gets up to ${ceiling} in AWS credits`;
+}
+
+const FIGURE = /\$\s?[\d][\d,]*(?:\.\d+)?\s?[KMB]?/g;
+
+export function figuresIn(text: string): string[] {
+  return [...text.matchAll(FIGURE)].map((m) => m[0]);
+}
+
+export function normaliseFigure(figure: string): string {
+  let digits = figure.replace(/[\s$,]/g, "").toUpperCase();
+  if (digits.endsWith("K")) digits = `${digits.slice(0, -1)}000`;
+  else if (digits.endsWith("M")) digits = `${digits.slice(0, -1)}000000`;
+  else if (digits.endsWith("B")) digits = `${digits.slice(0, -1)}000000000`;
+  return String(Number(digits));
+}
+
+export function figureIsHeldBy(figure: string, corpus: readonly string[]): boolean {
+  const wanted = normaliseFigure(figure);
+  return corpus.some((text) => figuresIn(text).some((held) => normaliseFigure(held) === wanted));
+}

--- a/src/serve.ts
+++ b/src/serve.ts
@@ -53,6 +53,8 @@ import { createRegistrationLimiter, rateLimitHeaders } from "./rate-limit.js";
 import { validateX402Address, executeTransfer, generateCorrelationId, payoutsAvailable, PAYOUTS_UNAVAILABLE_REASON } from "./x402.js";
 import { submitReferralCode, getCodesByAgent, getCodeById, updateCode, revokeCode, calculateTrustTier, getDailySubmissionCount, getDailyLimit, getRankedCodesForVendor, calculateCodeScore } from "./referral-codes.js";
 import { getBestReferralCode, listAllReferralCodes } from "./platform-codes.js";
+import { DOCUMENTED_GROUPS, HOMEPAGE_GROUPS, endpointHref, endpointPathHref, endpointsInGroups, exampleSubjects, readableRequestLines, type ApiEndpoint, type ExampleSubjects } from "./api-inventory.js";
+import { ACCELERATOR_CREDIT_PROGRAM, ACCELERATOR_CREDIT_VENDOR, acceleratorCreditClause, programCeiling } from "./homepage-claims.js";
 import { REFERRAL_CONDITIONS_HEADING, allOurReferralLinks, heldReferralLinkForVendor, ourReferralLinkFor, platformCodeAsVendorReferral, referralLinkCountClause, referrerDisclosureSentence } from "./referral-surfaces.js";
 import type { VendorReferralAnswer } from "./referral-surfaces.js";
 import { runHealthCheck, getLastReport, startPeriodicChecks } from "./referral-health.js";
@@ -465,6 +467,40 @@ const categories = getCategories();
 const dealChanges = loadDealChanges();
 const trackedChangeCount = recordsStillInForce(dealChanges).length;
 
+function apiExampleSubjects(): ExampleSubjects {
+  return exampleSubjects(
+    offers.map((o) => o.vendor),
+    listAllReferralCodes({}).map((c) => c.vendor),
+  );
+}
+
+function homepageVendorLink(name: string): string {
+  const slug = namedVendorSlug(name);
+  return slug === null
+    ? escHtmlServer(name)
+    : `<a href="/vendor/${slug}">${escHtmlServer(name)}</a>`;
+}
+
+function acceleratorCreditCeiling(): string | null {
+  return programCeiling(
+    offers.find((o) => o.vendor === ACCELERATOR_CREDIT_VENDOR),
+    ACCELERATOR_CREDIT_PROGRAM,
+  );
+}
+
+function documentedEndpointCount(): number {
+  return endpointsInGroups(DOCUMENTED_GROUPS).length;
+}
+
+let publishedApiRequests: string[] | null = null;
+
+function apiRequestsWePublish(): string[] {
+  if (publishedApiRequests === null) {
+    publishedApiRequests = readableRequestLines(HOMEPAGE_GROUPS, apiExampleSubjects());
+  }
+  return publishedApiRequests;
+}
+
 const changesByVendorName = (() => {
   const byVendor = changesByVendor(dealChanges);
   for (const held of byVendor.values()) held.sort((a, b) => b.date.localeCompare(a.date));
@@ -642,7 +678,7 @@ function buildChangesHtml(): string {
     return `      <div class="change-entry">
         <div class="change-header">
           <span class="change-badge" style="background:${badge.color}">${badge.label}</span>
-          <span class="change-vendor">${c.vendor}</span>
+          <span class="change-vendor">${homepageVendorLink(c.vendor)}</span>
           <span class="change-date">${changeEntryDateLabel(c)}</span>
         </div>
         <div class="change-summary">${changeSummaryHtml(c, escHtmlServer)}</div>
@@ -667,7 +703,7 @@ function buildDeadlinesHtml(): string {
         <div class="deadline-right">
           <div class="deadline-header">
             <span class="change-badge" style="background:${badge.color}">${badge.label}</span>
-            <span class="change-vendor">${c.vendor}</span>
+            <span class="change-vendor">${homepageVendorLink(c.vendor)}</span>
             <span class="deadline-date">${changeEntryDateLabel(c)}</span>
           </div>
           <div class="change-summary">${changeSummaryHtml(c, escHtmlServer)}</div>
@@ -46007,7 +46043,7 @@ ${globalNavCss()}
     <a href="/developers" style="display:block;padding:1rem;border:1px solid var(--border);border-radius:8px;background:var(--bg-card);text-decoration:none;transition:border-color .2s">
       <div style="font-size:1.5rem;margin-bottom:.5rem">&#128279;</div>
       <div style="font-weight:600;color:var(--text);margin-bottom:.25rem">REST API</div>
-      <div style="font-size:.8rem;color:var(--text-muted)">18 endpoints. Open data. No API key required.</div>
+      <div style="font-size:.8rem;color:var(--text-muted)">${documentedEndpointCount()} endpoints. Open data. No API key required.</div>
     </a>
     <a href="/stability" style="display:block;padding:1rem;border:1px solid var(--border);border-radius:8px;background:var(--bg-card);text-decoration:none;transition:border-color .2s">
       <div style="font-size:1.5rem;margin-bottom:.5rem">&#128202;</div>
@@ -49152,51 +49188,14 @@ function copyCode(btn){var block=btn.parentElement;var text=block.textContent.re
 }
 
 function buildDeveloperHubPage(): string {
-  const endpointTable = [
-    { method: "GET", path: "/api/offers", desc: "Search and browse offers", params: "q, category, limit, offset" },
-    { method: "GET", path: "/api/categories", desc: "List all categories with counts, what each name holds, and the other names answering the same question", params: "" },
-    { method: "GET", path: "/api/new", desc: "Recently added or updated offers", params: "days" },
-    { method: "GET", path: "/api/newest", desc: "Newest deals by verification date", params: "limit" },
-    { method: "GET", path: "/api/changes", desc: "Pricing and deal changes", params: "since, type, vendor, vendors, category, categories, limit, offset" },
-    { method: "GET", path: "/api/details/:vendor", desc: "Vendor detail with alternatives", params: "" },
-    { method: "GET", path: "/api/compare", desc: "Compare two vendors side by side", params: "a, b" },
-    { method: "GET", path: "/api/audit-stack", desc: "Audit your infrastructure stack", params: "services" },
-    { method: "GET", path: "/api/vendor-risk/:vendor", desc: "Check vendor pricing risk", params: "" },
-    { method: "GET", path: "/api/deadlines", desc: "Future-dated changes with countdown", params: "type" },
-    { method: "GET", path: "/api/ai-coding-pricing", desc: "AI coding tools pricing comparison data", params: "type (ide, cli, cloud-agent, app-builder)" },
-    { method: "GET", path: "/api/hosting-pricing", desc: "Cloud hosting & PaaS pricing comparison data", params: "type (traditional-paas, edge-serverless, full-featured, static-specialized)" },
-    { method: "GET", path: "/api/llm-pricing", desc: "LLM API pricing comparison data", params: "type (frontier, inference, open-source-host, specialized)" },
-    { method: "GET", path: "/api/startup-credits", desc: "Startup credits & programs comparison data", params: "type (cloud-infrastructure, fintech-banking, developer-tools, ai-tools)" },
-    { method: "GET", path: "/api/referral-programs", desc: "Developer tools with referral/affiliate programs", params: "category" },
-    { method: "GET", path: "/api/expiring", desc: "Get expiring deals", params: "days" },
-    { method: "GET", path: "/api/freshness", desc: "Data freshness metrics", params: "" },
-    { method: "GET", path: "/api/digest", desc: "Weekly pricing digest", params: "" },
-    { method: "GET", path: "/api/digest/weekly", desc: "Formatted weekly digest with multiple output formats", params: "format (json|markdown|html), limit, weeks_ago" },
-    { method: "GET", path: "/api/stack", desc: "Free-tier stack recommendation", params: "use_case, requirements" },
-    { method: "GET", path: "/api/costs", desc: "Estimate infrastructure costs", params: "services, scale" },
-    { method: "GET", path: "/api/query-log", desc: "Recent request log", params: "limit" },
-    { method: "GET", path: "/api/pageviews", desc: "Page view analytics", params: "path, period" },
-    { method: "GET", path: "/api/traffic", desc: "Traffic attributed by client class (AI agent / crawler / browser), with web-vs-MCP comparison", params: "" },
-    { method: "GET", path: "/api/stats", desc: "Service statistics", params: "" },
-    { method: "GET", path: "/api/feed", desc: "Atom feed of pricing changes", params: "" },
-    { method: "POST", path: "/api/watchlist", desc: "Subscribe to vendor pricing changes via webhook", params: "vendor, webhook_url (body)" },
-    { method: "GET", path: "/api/watchlist", desc: "List active watchlist subscriptions", params: "webhook_url" },
-    { method: "GET", path: "/api/watchlist/:id", desc: "Get subscription status", params: "" },
-    { method: "DELETE", path: "/api/watchlist/:id", desc: "Unsubscribe from vendor watch", params: "" },
-  ];
+  const subjects = apiExampleSubjects();
+  const endpointTable = endpointsInGroups(["product"]);
+  const referralEndpointTable = endpointsInGroups(["referral"]);
 
-  const referralEndpointTable = [
-    { method: "GET", path: "/api/referral-codes", desc: "List all active referral codes (platform + marketplace)", params: "source (platform|agent), category" },
-    { method: "GET", path: "/api/referral-codes/:vendor", desc: "Get best referral code for a specific vendor", params: "" },
-    { method: "POST", path: "/api/referral-codes", desc: "Submit a marketplace referral code (agents only, auth required)", params: "vendor, code, referral_url (body) — Authorization: Bearer <api-key>" },
-  ];
-
-  const referralEndpointRows = referralEndpointTable.map(function(e) {
-    const sampleHref = e.method === "GET"
-      ? BASE_URL + e.path.replace(/:vendor/, "railway")
-      : BASE_URL + e.path;
-    const cell = e.method === "GET"
-      ? "<a href=\"" + sampleHref + "\">" + escHtmlServer(e.path) + "</a>"
+  const endpointRow = function(e: ApiEndpoint): string {
+    const href = endpointPathHref(e, subjects);
+    const cell = href
+      ? "<a href=\"" + BASE_URL + escHtmlServer(href) + "\">" + escHtmlServer(e.path) + "</a>"
       : "<code>" + escHtmlServer(e.path) + "</code>";
     return "      <tr>"
       + "<td><code>" + e.method + "</code></td>"
@@ -49204,16 +49203,11 @@ function buildDeveloperHubPage(): string {
       + "<td>" + escHtmlServer(e.desc) + "</td>"
       + "<td>" + (e.params ? "<code>" + escHtmlServer(e.params) + "</code>" : "&mdash;") + "</td>"
       + "</tr>";
-  }).join("\n");
+  };
 
-  const endpointRows = endpointTable.map(function(e) {
-    return "      <tr>"
-      + "<td><code>" + e.method + "</code></td>"
-      + "<td><a href=\"" + BASE_URL + e.path.replace(/:vendor/, "supabase") + "\">" + escHtmlServer(e.path) + "</a></td>"
-      + "<td>" + escHtmlServer(e.desc) + "</td>"
-      + "<td>" + (e.params ? "<code>" + escHtmlServer(e.params) + "</code>" : "&mdash;") + "</td>"
-      + "</tr>";
-  }).join("\n");
+  const referralEndpointRows = referralEndpointTable.map(endpointRow).join("\n");
+
+  const endpointRows = endpointTable.map(endpointRow).join("\n");
 
   return "<!DOCTYPE html>\n"
     + "<html lang=\"en\">\n"
@@ -52626,7 +52620,7 @@ a:hover{color:var(--accent-hover);text-decoration:underline}
 .problem-text strong{color:var(--text)}
 
 .how-grid{display:grid;grid-template-columns:repeat(3,1fr);gap:1rem;margin-top:2rem}
-.how-card{background:var(--bg-card);backdrop-filter:blur(12px);border:1px solid var(--border);border-radius:12px;padding:1.5rem;transition:border-color .2s}
+.how-card{background:var(--bg-card);backdrop-filter:blur(12px);border:1px solid var(--border);border-radius:12px;padding:1.5rem;transition:border-color .2s;min-width:0}
 .how-card:hover{border-color:var(--accent)}
 .how-card-icon{font-family:var(--mono);font-size:.75rem;color:var(--accent);background:var(--accent-glow);display:inline-block;padding:.3rem .7rem;border-radius:6px;margin-bottom:.75rem;border:1px solid rgba(59,130,246,0.2)}
 .how-card h3{font-family:var(--sans);font-size:1.1rem;color:var(--text);margin-bottom:.5rem;font-weight:600}
@@ -52855,7 +52849,7 @@ ${buildDeadlinesHtml()}
 ` : ""}
   <div class="section">
     <div class="section-label">The Problem</div>
-    <p class="problem-text">When Claude Code recommends Railway, it doesn't know <strong>Render has a better free tier</strong>. When it suggests Supabase, it doesn't know <strong>your YC batch gets $100K in AWS credits</strong>.</p>
+    <p class="problem-text">When ${homepageVendorLink("Claude Code")} recommends ${homepageVendorLink("Railway")}, it doesn't know what ${homepageVendorLink("Render")} puts in its free tier. When it suggests ${homepageVendorLink("Supabase")}, it doesn't know <strong>${escHtmlServer(acceleratorCreditClause(acceleratorCreditCeiling()))}</strong> &mdash; ${homepageVendorLink(ACCELERATOR_CREDIT_VENDOR)}.</p>
     <p class="problem-text">AgentDeals gives your agent <strong>pricing context</strong> &mdash; free tiers, startup credits, and deal changes across ${stats.categories} categories of developer tools and consumer services.</p>
   </div>
 
@@ -52873,24 +52867,8 @@ ${buildDeadlinesHtml()}
       <div class="how-card">
         <div class="how-card-icon">02</div>
         <h3>REST API</h3>
-        <p>Query deals programmatically. 18 endpoints with search, filtering, risk analysis, and stack recommendations. <a href="/developers" style="color:var(--accent);text-decoration:underline">Developer Hub</a> &middot; <a href="/api/docs" style="color:var(--accent);text-decoration:underline">Swagger Docs</a></p>
-        <pre><code>GET /api/offers?q=database
-GET /api/categories
-GET /api/new?days=7
-GET /api/changes?since=2025-01-01
-GET /api/details/Supabase
-GET /api/stack?use_case=SaaS+app
-GET /api/costs?services=Vercel,Supabase
-GET /api/compare?a=Supabase&amp;b=Neon
-GET /api/vendor-risk/Heroku
-GET /api/audit-stack?services=Vercel,Supabase
-GET /api/expiring?within_days=30
-GET /api/digest
-GET /api/digest/weekly?format=markdown&amp;weeks_ago=1
-GET /api/feed
-GET /api/stats
-GET /api/openapi.json
-GET /api/docs</code></pre>
+        <p>Query deals programmatically. Every one of the ${apiRequestsWePublish().length} read endpoints is listed below, with a request you can issue as printed. <a href="/developers" style="color:var(--accent);text-decoration:underline">Developer Hub</a> &middot; <a href="/api/docs" style="color:var(--accent);text-decoration:underline">Swagger Docs</a></p>
+        <pre><code>${apiRequestsWePublish().map(escHtmlServer).join("\n")}</code></pre>
       </div>
       <div class="how-card">
         <div class="how-card-icon">03</div>

--- a/src/types.ts
+++ b/src/types.ts
@@ -171,6 +171,13 @@ export interface DealChange {
   recorded_date?: string;
   date_source?: ChangeDateSource;
   resolution?: ChangeResolution | null;
+  source_check?: ChangeSourceCheck | null;
+}
+
+export interface ChangeSourceCheck {
+  checked: string;
+  outcome: string;
+  finding: string;
 }
 
 export interface DealChangesIndex {

--- a/test/homepage-cites-what-it-serves.test.ts
+++ b/test/homepage-cites-what-it-serves.test.ts
@@ -1,0 +1,246 @@
+import { describe, it, before, after } from "node:test";
+import assert from "node:assert";
+import { spawn, type ChildProcess } from "node:child_process";
+import path from "node:path";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { API_ENDPOINTS, DOCUMENTED_GROUPS, HOMEPAGE_GROUPS, endpointHref, endpointsInGroups, exampleSubjects, readableEndpoints } from "../dist/api-inventory.js";
+import { ACCELERATOR_CREDIT_PROGRAM, ACCELERATOR_CREDIT_VENDOR, figureIsHeldBy, figuresIn, normaliseFigure, programCeiling } from "../dist/homepage-claims.js";
+import { loadDealChanges, loadOffers } from "../dist/data.js";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+const SERVE_SOURCE = path.join(__dirname, "..", "src", "serve.ts");
+
+const ROUTES_WE_DO_NOT_PUBLISH = new Map<string, string>([
+  ["/api/metrics", "our own service counters, read by the status page"],
+  ["/api/signals", "an inbox for agent-submitted signals"],
+  ["/api/page-reviews", "our editorial review register"],
+  ["/api/analytics/history", "our own analytics"],
+  ["/api/analytics/daily", "our own analytics"],
+  ["/api/agent-payments", "the retired marketplace ledger"],
+  ["/api/agents/register", "agent registration, not a read endpoint"],
+  ["/api/agents/me", "one caller's own registration"],
+  ["/api/referral/", "a redirect, not a JSON body"],
+  ["/api/conversions", "the retired marketplace ledger"],
+  ["/api/conversions/confirm", "the retired marketplace ledger"],
+  ["/api/conversions/clawback", "the retired marketplace ledger"],
+  ["/api/referral-codes/mine", "one caller's own submissions"],
+  ["/api/friends", "the agent friend graph"],
+  ["/api/friends/codes", "the agent friend graph"],
+  ["/api/leaderboard", "the retired marketplace ledger"],
+  ["/api/indexnow/status", "our own crawl plumbing"],
+  ["/api/referral-health", "our own link plumbing"],
+  ["/api/docs/", "an asset path under /api/docs"],
+  ["/api/watchlist/", "one caller's own subscription"],
+  ["/api/vendor-risk/", "published as /api/vendor-risk/:vendor"],
+  ["/api/details/", "published as /api/details/:vendor"],
+]);
+
+const NAMES_A_CLIENT_NOT_A_CLAIM = ["Cursor", "Cline", "Windsurf", "Claude Desktop"];
+
+const NAMES_AN_EXAMPLE_QUERY = ["Firebase"];
+
+function servedApiRoutes(): string[] {
+  const source = readFileSync(SERVE_SOURCE, "utf8");
+  const exact = [...source.matchAll(/url\.pathname === "(\/api\/[^"]+)"/g)].map(([, route]) => route);
+  const prefixed = [...source.matchAll(/url\.pathname\.startsWith\("(\/api\/[^"]+)"\)/g)].map(([, route]) => route);
+  return [...new Set([...exact, ...prefixed])].sort();
+}
+
+function requestsPrintedOnHome(html: string): string[] {
+  const blocks = [...html.matchAll(/<pre><code>([\s\S]*?)<\/code><\/pre>/g)].map(([, body]) => body);
+  return blocks
+    .flatMap((block) => block.split("\n"))
+    .filter((line) => line.startsWith("GET /api/"))
+    .map((line) => line.slice(4).replace(/&amp;/g, "&"));
+}
+
+function withoutMarkup(html: string): string {
+  const body = html.slice(html.indexOf("<body"));
+  const noScript = body.replace(/<script[\s\S]*?<\/script>/g, " ").replace(/<style[\s\S]*?<\/style>/g, " ");
+  return noScript.replace(/<pre[\s\S]*?<\/pre>/g, " ").replace(/<code[\s\S]*?<\/code>/g, " ");
+}
+
+function namedOutsideALink(prose: string, name: string): boolean {
+  const outside = prose.replace(/<a\b[^>]*>[\s\S]*?<\/a>/g, "   ").replace(/<[^>]*>/g, " ");
+  return mentions(outside, name);
+}
+
+function namedInsideALink(prose: string, name: string): boolean {
+  const linked = [...prose.matchAll(/<a\b[^>]*>([\s\S]*?)<\/a>/g)].map(([, text]) => text.replace(/<[^>]*>/g, "")).join(" | ");
+  return mentions(linked, name);
+}
+
+function mentions(corpus: string, name: string): boolean {
+  const escaped = name.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  return new RegExp(`(?<![\\w.-])${escaped}(?![\\w-])`).test(corpus);
+}
+
+describe("the homepage publishes only what it can serve", () => {
+  let proc: ChildProcess;
+  let base: string;
+  let home: string;
+  let printed: string[];
+
+  before(async () => {
+    const started = await new Promise<{ proc: ChildProcess; port: number }>((resolve, reject) => {
+      const child = spawn("node", [path.join(__dirname, "..", "dist", "serve.js")], {
+        stdio: ["pipe", "pipe", "pipe"],
+        env: { ...process.env, PORT: "0", BASE_URL: "http://127.0.0.1" },
+      });
+      const timer = setTimeout(() => { child.kill("SIGKILL"); reject(new Error("startup timeout")); }, 60000);
+      child.stderr?.on("data", (b: Buffer) => {
+        const m = b.toString().match(/running on http:\/\/localhost:(\d+)/);
+        if (m) { clearTimeout(timer); resolve({ proc: child, port: parseInt(m[1], 10) }); }
+      });
+      child.on("error", (e) => { clearTimeout(timer); reject(e); });
+    });
+    proc = started.proc;
+    base = `http://127.0.0.1:${started.port}`;
+    home = await (await fetch(`${base}/`)).text();
+    printed = requestsPrintedOnHome(home);
+  });
+
+  after(() => { proc?.kill("SIGKILL"); });
+
+  it("prints enough requests to be worth issuing", () => {
+    assert.ok(printed.length >= 20, `the homepage printed ${printed.length} API requests`);
+  });
+
+  it("issues every API request it prints and gets an answer", async () => {
+    const refused: string[] = [];
+    for (const request of printed) {
+      const res = await fetch(`${base}${request}`);
+      if (res.status >= 400) refused.push(`${request} -> ${res.status} ${(await res.text()).slice(0, 120)}`);
+    }
+    assert.deepStrictEqual(refused, [], `requests printed on / that the server refuses:\n${refused.join("\n")}`);
+  });
+
+  it("states an endpoint count equal to the number of requests it prints", () => {
+    const stated = [...withoutMarkup(home).matchAll(/(\d+)\s+read endpoints/g)].map(([, n]) => Number(n));
+    assert.ok(stated.length > 0, "the homepage states no endpoint count");
+    for (const count of stated) assert.strictEqual(count, printed.length);
+  });
+
+  it("prints every read endpoint the inventory publishes, and nothing it does not", () => {
+    const subjects = exampleSubjects(loadOffers().map((o) => o.vendor), []);
+    const expected = readableEndpoints(HOMEPAGE_GROUPS)
+      .map((e) => endpointHref(e, subjects))
+      .filter((href): href is string => href !== null);
+    assert.deepStrictEqual([...printed].sort(), [...expected].sort());
+  });
+
+  it("holds every /api route the server serves in one inventory or names why it is unpublished", () => {
+    const known = new Set(API_ENDPOINTS.map((e) => e.path.replace(/:[a-z]+$/i, "")));
+    const stray = servedApiRoutes().filter((route) => !known.has(route) && !ROUTES_WE_DO_NOT_PUBLISH.has(route));
+    assert.deepStrictEqual(stray, [], `served /api routes in neither the inventory nor the unpublished register: ${stray.join(", ")}`);
+  });
+
+  it("issues every API link the developer hub offers and gets an answer", async () => {
+    const hub = await (await fetch(`${base}/developers`)).text();
+    const links = [...new Set([...hub.matchAll(/<td><a href="([^"]*(\/api\/[^"]*))">/g)].map(([, , request]) => request.replace(/&amp;/g, "&")))];
+    assert.ok(links.length >= 25, `the developer hub offers ${links.length} API links`);
+    const refused: string[] = [];
+    for (const link of links) {
+      const res = await fetch(`${base}${link}`);
+      if (res.status >= 400) refused.push(`${link} -> ${res.status}`);
+    }
+    assert.deepStrictEqual(refused, [], `API links on /developers that the server refuses:\n${refused.join("\n")}`);
+  });
+
+  it("states one endpoint count wherever it states one", async () => {
+    const hub = await (await fetch(`${base}/developers`)).text();
+    const report = await (await fetch(`${base}/state-of-free-tiers`)).text();
+    const onHub = hub.match(/<div class="num">(\d+)<\/div><div class="label">Endpoints<\/div>/);
+    const onReport = report.match(/(\d+) endpoints\. Open data\./);
+    assert.ok(onHub, "/developers states no endpoint count");
+    assert.ok(onReport, "/state-of-free-tiers states no endpoint count");
+    assert.strictEqual(Number(onReport![1]), Number(onHub![1]));
+    assert.strictEqual(Number(onHub![1]), endpointsInGroups(DOCUMENTED_GROUPS).length);
+  });
+
+  it("writes no endpoint count as a literal in a source file", () => {
+    const source = readFileSync(SERVE_SOURCE, "utf8");
+    const literals = [...source.matchAll(/>(\d+) endpoints/g)].map(([match]) => match);
+    assert.deepStrictEqual(literals, []);
+  });
+
+  it("states no figure above the fold that no record of ours holds", () => {
+    const prose = withoutMarkup(home).replace(/<[^>]*>/g, " ");
+    const above = prose.slice(0, prose.indexOf("How It Works"));
+    const corpus = [
+      ...loadOffers().map((o) => `${o.description ?? ""} ${o.tier ?? ""}`),
+      ...loadDealChanges().flatMap((c) => [c.summary, c.previous_state, c.current_state]),
+    ];
+    const unheld = figuresIn(above).filter((figure) => !figureIsHeldBy(figure, corpus));
+    assert.deepStrictEqual([...new Set(unheld)], [], `figures published above the fold that no record holds: ${unheld.join(", ")}`);
+  });
+
+  it("takes the accelerator credit ceiling from the record rather than from prose", () => {
+    const record = loadOffers().find((o) => o.vendor === ACCELERATOR_CREDIT_VENDOR);
+    const ceiling = programCeiling(record, ACCELERATOR_CREDIT_PROGRAM);
+    assert.ok(ceiling, `no ${ACCELERATOR_CREDIT_PROGRAM} ceiling in the ${ACCELERATOR_CREDIT_VENDOR} record`);
+    const statements = [...home.matchAll(/<p class="problem-text">([\s\S]*?)<\/p>/g)].map(([, text]) => text);
+    const claiming = statements.filter((text) => /credits/i.test(text));
+    assert.ok(claiming.length > 0, "the problem statement makes no credit claim");
+    for (const claim of claiming) {
+      const stated = figuresIn(claim.replace(/<[^>]*>/g, " "));
+      assert.deepStrictEqual(
+        stated.map(normaliseFigure),
+        stated.map(() => normaliseFigure(ceiling!)),
+        `the problem statement says ${stated.join(", ")} where the record's ceiling is ${ceiling}`,
+      );
+    }
+  });
+
+  it("links the vendor on every change it puts on the page", () => {
+    const cells = [...home.matchAll(/<span class="change-vendor">([\s\S]*?)<\/span>/g)].map(([, cell]) => cell);
+    assert.ok(cells.length > 0, "the homepage renders no change cards");
+    const unlinked = cells.filter((cell) => !/<a\b/.test(cell)).map((cell) => cell.trim());
+    assert.deepStrictEqual(unlinked, [], `change cards naming a vendor with no link: ${unlinked.join(", ")}`);
+  });
+
+  it("reaches a page for every vendor it names in prose", () => {
+    const prose = withoutMarkup(home);
+    const excused = new Set([...NAMES_A_CLIENT_NOT_A_CLAIM, ...NAMES_AN_EXAMPLE_QUERY]);
+    const unreachable = loadOffers()
+      .map((o) => o.vendor)
+      .filter((vendor) => vendor.length >= 4 && !excused.has(vendor))
+      .filter((vendor) => namedOutsideALink(prose, vendor) && !namedInsideALink(prose, vendor));
+    assert.deepStrictEqual([...new Set(unreachable)], [], `vendors named on / that reach no page: ${unreachable.join(", ")}`);
+  });
+});
+
+describe("a record does not contradict its own source check", () => {
+  it("states the accelerator credit ceiling its own check read off the page", () => {
+    const record = loadOffers().find((o) => o.vendor === ACCELERATOR_CREDIT_VENDOR);
+    const detail = record?.source_check?.detail ?? "";
+    const quoted = [...detail.matchAll(/"(\$[^"]{1,20})"/g)].map(([, figure]) => figure);
+    assert.ok(quoted.length > 0, `the ${ACCELERATOR_CREDIT_VENDOR} check quotes no figure`);
+    const ceiling = programCeiling(record, ACCELERATOR_CREDIT_PROGRAM);
+    assert.ok(ceiling, `no ${ACCELERATOR_CREDIT_PROGRAM} ceiling in the ${ACCELERATOR_CREDIT_VENDOR} record`);
+    assert.ok(
+      quoted.some((figure) => normaliseFigure(figure) === normaliseFigure(ceiling!)),
+      `the record states ${ceiling} where its own check read ${quoted.join(", ")} off the page`,
+    );
+  });
+
+  it("carries the date it asserts inside the finding its citation is read from", () => {
+    const months = ["January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December"];
+    const mismatched = loadDealChanges()
+      .filter((change) => change.source_check)
+      .filter((change) => {
+        const [year, month, day] = change.date.split("-").map(Number);
+        const spelled = `${months[month - 1]} ${day}, ${year}`;
+        return !change.source_check!.finding.includes(spelled) && !change.source_check!.finding.includes(change.date);
+      })
+      .map((change) => `${change.vendor} ${change.date}: ${change.source_check!.finding}`);
+    assert.deepStrictEqual(mismatched, [], `records whose finding does not carry the date they assert:\n${mismatched.join("\n")}`);
+  });
+
+  it("checks a source on the deprecations the homepage leads with", () => {
+    const checked = loadDealChanges().filter((change) => change.source_check);
+    assert.ok(checked.length >= 2, `only ${checked.length} change records record what their source says`);
+  });
+});


### PR DESCRIPTION
Refs #1464

`/` is cited by 34 of ~104 public-repo path citations — more than the eighteen comparison pages #1462 covered, combined. It printed a copy-paste API block containing a request that 404s, four disagreeing inventories of our own API, a hero figure its own change feed contradicted two screens below, and vendor names a reader could not check.

I served the page and issued every request it prints rather than reading the strings. Numbers below are measured, not counted from source.

## 1. Every request the page prints, issued

`GET /api/vendor-risk/Heroku` returned `Vendor "Heroku" not found`. It was a literal that outlived the record it named — and six of the other sixteen examples embed a vendor name the same way, so any of them could rot next.

The example subjects are now drawn from the catalogue at render time (`exampleSubjects` in `src/api-inventory.ts`): a preference list intersected with the vendors we actually hold, falling back to the first vendor we hold. No printed request can name a vendor that is not in `data/index.json`.

**17 printed, 1 refused → 29 printed, 0 refused.** The test issues all 29 against a live server.

## 2. One inventory, and the count derived from it

Four inventories disagreed: 17 in the block, "18 endpoints" in the label beside it, 20 paths in `/api/openapi.json`, 30 rows on `/developers`.

`src/api-inventory.ts` is now the single registry — 35 entries, 30 product, 3 referral, 2 meta. `/developers` renders its two tables from it, the homepage block renders every GET entry that has a request you can issue, and the sentence beside the block counts the lines in the block. The card on `/state-of-free-tiers` that read "18 endpoints" and the Endpoints card on `/developers` both read the registry, so they now agree at 33.

The block was a subset before and did not say so. It now prints **all 29 read endpoints**, which is what fixes "an agent reading `/` gets neither an accurate count nor a complete list" — the count is accurate because the list is complete, not because the number was corrected.

Four tests hold it: the stated count equals the number of requests printed; the printed set equals the inventory's readable set; the two surfaces that state a bare "N endpoints" — the Developer Hub card and the one on `/state-of-free-tiers` — state the same 33; and every one of the 50 distinct `/api` route literals `src/serve.ts` serves is either in the registry or in a named register of 22 routes we do not publish, each with the reason. A route added later that joins neither fails the suite. A fifth test fails on any `>N endpoints` literal in the source.

The hub's own "try it" links went through the same check and four of them were 400s: `/api/compare`, `/api/audit-stack`, `/api/stack` and `/api/costs` all require a parameter and were linked bare. They carry `requiresParams` now and link a request that answers. **29 API links on `/developers`, 4 refused → 0 refused.** `/api/watchlist/:id` renders as `<code>` rather than as a link to a literal `:id`.

`/api/openapi.json` still holds its own 20 paths. That is #1318, which is filed and named in the working order; I did not fold it in here. The test asserts nothing about it, so nothing here blocks that fix.

## 3. The hero no longer contradicts the feed below it

The problem statement said **"your YC batch gets $100K in AWS credits"**. The change module on the same page said the AWS Activate programme now offers **$200,000**, up from $100,000, recorded 2026-09-07. The vendor's own page says $200,000 and our own `source_check.detail` on that record already read `states "$200,000"`.

The sentence now takes its ceiling from the record (`programCeiling`), so the two cannot disagree; if the record ever stops stating a ceiling, the sentence names none rather than inventing one.

A test extracts every `$` figure printed above "How It Works" and asserts each is held by some catalogue record or change record — comparing the page to the data, not to a fixture. Three figures qualify today ($200,000, $100,000, $15) and all three are held.

I also replaced "it doesn't know **Render has a better free tier**" with what Render puts in its free tier. That was an unearned superlative of exactly the kind #1471 shipped a check against, on the page that check does not cover.

## 4. Every vendor named in prose reaches a page

Five catalogue vendors were named on `/` and reachable from nowhere on it. The `Changing Soon` and `Act Now` modules rendered `<span class="change-vendor">AWS</span>` as plain text; the problem statement named four vendors flat.

All of them link now, through `namedVendorSlug`, which returns a slug only where the vendor page resolves — so a name we cannot serve renders as text rather than as a dead link. **0 dead internal links across the 43 the page carries.**

Four names are excused in the test, named in the file with the reason: `Cursor`, `Cline`, `Windsurf` and `Claude Desktop` are the labels on the MCP client picker — controls, not claims — and `Firebase` appears only inside "React + Firebase app", an example query typed into our own stack tool.

## 5. The two deprecations the page leads with cite a page that carries the date

`/` leads with AWS App Mesh (2026-09-30) and AWS Proton (2026-10-07). Both claims are right. Both cited `https://docs.aws.amazon.com/app-mesh/` and `.../proton/`, which describe the products in the present tense and state no end of support — I fetched both and they publish 546 and 505 characters of text with no notice in either.

The pages that carry the notice do exist, so I cited them rather than declaring the claim unsourced:

- `docs.aws.amazon.com/app-mesh/latest/userguide/what-is-app-mesh.html` — *"On September 30, 2026, AWS will discontinue support for AWS App Mesh"*
- `docs.aws.amazon.com/proton/latest/userguide/Welcome.html` — *"On October 7, 2026, AWS will end support for AWS Proton"*

Both records now carry a `source_check` recording what we found and when. Following #1467, the stored field is a `finding` attributed to our check, not a `quote`. A test asserts that any change record carrying a `source_check` has the date it asserts present inside that finding — so a citation cannot drift onto a page that does not carry the claim without the suite noticing.

## 6. The record no longer states a figure its own check contradicts

`AWS Activate`'s description read `Portfolio: up to $100,000 credits` beside a `source_check.detail` reading `states "$200,000"`. The description now states $200,000. The test compares the two fields of the record to each other, so it fails if either moves.

## Tests

15 new tests over the served page and the records; 8 mutants, 8 killed. Two survived the first pass and both were real gaps — asserting the recorded ceiling appeared *anywhere* on the page passed while the problem statement was hardcoded, because the change card below it states the same figure; and a page-wide "this vendor is reachable somewhere" rule let one of the two modules that render the same record go back to plain text. Both are now per-claim. Suite 4,520.

Verified by issuing every printed request against a live server, over a real MCP session (`search_deals` for AWS Activate returns the corrected ceiling), by screenshot, and by sweeping all 43 internal links on the page.

## Reported, not fixed

- **A sitewide version of AC-6 is not honest yet.** Across the catalogue, 6 records have both a quoted figure in `source_check.detail` and an `up to $N` ceiling in the description; 4 of those disagree legitimately — Ramp's `$5,000` against a page stating `$350,000` are different components of the same programme, not a contradiction. The general rule needs the check to record *which* claim its figure belongs to, which is the same gap #1467 named for quotations.
- **The AWS Activate description still carries `up to $300,000 in Trainium/Inferentia credits`,** which the 2026-09-07 change record says "is no longer present" on the page. Removing it is a data decision and outside AC-6, which names only the figure the check contradicts.
- **`.how-card` gained `min-width:0`.** Printing 29 requests instead of 17 made the code block the tallest element in the grid, and without it the `1fr` track was letting the block's longest line squeeze the Browse card to about a fifth of its share. The three columns are equal again and the block scrolls horizontally, which it was already styled to do.
