### PR TITLE
Name best-of pages after a product function, not half of one (#1476)

### DIFF
--- a/src/product-function.ts
+++ b/src/product-function.ts
@@ -1,0 +1,169 @@
+import { SUBTYPE_TAXONOMIES, subtypeDefinition } from "./product-role.js";
+import { toSlug } from "./slug.js";
+import type { SubtypeLabel } from "./types.js";
+
+export interface ProductFunction {
+  slug: string;
+  title: string;
+  categories: string[];
+  subtypes: string[];
+  taxonomies: string[];
+}
+
+export interface FunctionCarrier {
+  category: string;
+  product_subtypes?: { taxonomy: string; labels: SubtypeLabel[]; reviewed: string };
+}
+
+export const FUNCTION_NAMING_RULE =
+  "A page is named after a product function. A function is named by a category, by a subtype label, or by both — two names are the same function when their slugs match once a trailing plural is dropped, and by nothing weaker. Substring overlap is not a match: container_app is not the container registry category, host_metrics is not cloud hosting, and the document database subtype is not documentation.";
+
+export const FUNCTION_MEMBERSHIP_RULE =
+  "A record reaches a function page when its category names the function or when it carries a subtype label that names the function. Adding a label to a record publishes it here; removing one withdraws it. No page holds a list of vendors.";
+
+export const FUNCTION_SPLIT_RULE =
+  "They are listed under the function each is labelled with. An offer labelled with more than one is listed under each, with the words we read for that label; an offer we have not labelled is listed too, at the end.";
+
+export const FUNCTION_UNCLASSIFIED_RULE =
+  "These offers reach this page through their category and we have not read them against its subtypes yet. They are listed in full; what is missing is our reading, not their eligibility.";
+
+export const FUNCTION_NOT_IN_TAXONOMY_RULE =
+  "We have read these offers against this category's subtypes and none of them applies. They are listed in full: the category is what they were filed under, and this states what our labels do not cover rather than a finding about the products.";
+
+export function functionKey(slug: string): string {
+  return slug.replace(/s$/, "");
+}
+
+export function subtypeTitle(subtype: string): string {
+  return subtype
+    .split("_")
+    .map(word => (word === "llm" || word === "apm" || word === "api" || word === "gpu" ? word.toUpperCase() : word.charAt(0).toUpperCase() + word.slice(1)))
+    .join(" ");
+}
+
+export function buildProductFunctions(categoryNames: readonly string[]): ProductFunction[] {
+  const byKey = new Map<string, ProductFunction>();
+
+  for (const name of categoryNames) {
+    const slug = toSlug(name);
+    const key = functionKey(slug);
+    const held = byKey.get(key);
+    if (held) {
+      if (!held.categories.includes(name)) held.categories.push(name);
+      continue;
+    }
+    byKey.set(key, { slug, title: name, categories: [name], subtypes: [], taxonomies: [] });
+  }
+
+  for (const [taxonomy, entries] of Object.entries(SUBTYPE_TAXONOMIES)) {
+    for (const { subtype } of entries) {
+      const key = functionKey(toSlug(subtype));
+      const held = byKey.get(key);
+      if (held) {
+        if (!held.subtypes.includes(subtype)) held.subtypes.push(subtype);
+        if (!held.taxonomies.includes(taxonomy)) held.taxonomies.push(taxonomy);
+        continue;
+      }
+      byKey.set(key, { slug: toSlug(subtype), title: subtypeTitle(subtype), categories: [], subtypes: [subtype], taxonomies: [taxonomy] });
+    }
+  }
+
+  return [...byKey.values()];
+}
+
+export function functionDefinitions(fn: ProductFunction): string[] {
+  const definitions = new Set<string>();
+  for (const taxonomy of fn.taxonomies) {
+    for (const subtype of fn.subtypes) {
+      const definition = subtypeDefinition(taxonomy, subtype);
+      if (definition) definitions.add(definition);
+    }
+  }
+  return [...definitions];
+}
+
+export interface FunctionAdmission {
+  byCategory: boolean;
+  labels: SubtypeLabel[];
+}
+
+export function admissionFor(offer: FunctionCarrier, fn: ProductFunction): FunctionAdmission | null {
+  const byCategory = fn.categories.includes(offer.category);
+  const labels = (offer.product_subtypes?.labels ?? []).filter(l => fn.subtypes.includes(l.subtype));
+  if (!byCategory && labels.length === 0) return null;
+  return { byCategory, labels };
+}
+
+export function functionMembers<T extends FunctionCarrier>(offers: readonly T[], fn: ProductFunction): T[] {
+  return offers.filter(o => admissionFor(o, fn) !== null);
+}
+
+export function admittedByLabelAlone(offer: FunctionCarrier, fn: ProductFunction): boolean {
+  const admission = admissionFor(offer, fn);
+  return admission !== null && !admission.byCategory && admission.labels.length > 0;
+}
+
+export function functionSplits(fn: ProductFunction): boolean {
+  return fn.subtypes.length === 0;
+}
+
+export type FunctionResidue = "not_yet_classified" | "not_in_taxonomy";
+
+export interface FunctionGroup<T> {
+  subtype: string | null;
+  residue: FunctionResidue | null;
+  taxonomy: string | null;
+  definition: string | null;
+  title: string;
+  members: T[];
+}
+
+export const FUNCTION_RESIDUE_COPY: Record<FunctionResidue, { title: string; rule: string }> = {
+  not_yet_classified: { title: "Not read against this category's subtypes yet", rule: FUNCTION_UNCLASSIFIED_RULE },
+  not_in_taxonomy: { title: "None of this category's subtypes applies", rule: FUNCTION_NOT_IN_TAXONOMY_RULE },
+};
+
+export function splitByFunction<T extends FunctionCarrier>(members: readonly T[], fn: ProductFunction): FunctionGroup<T>[] | null {
+  if (!functionSplits(fn)) return null;
+  const labelled = new Map<string, FunctionGroup<T>>();
+  const residual = new Map<FunctionResidue, T[]>();
+  for (const member of members) {
+    const classified = member.product_subtypes;
+    const labels = classified?.labels ?? [];
+    if (labels.length === 0) {
+      const residue: FunctionResidue = classified ? "not_in_taxonomy" : "not_yet_classified";
+      const held = residual.get(residue);
+      if (held) held.push(member);
+      else residual.set(residue, [member]);
+      continue;
+    }
+    for (const label of labels) {
+      const taxonomy = classified!.taxonomy;
+      const held = labelled.get(label.subtype);
+      if (held) {
+        held.members.push(member);
+        continue;
+      }
+      labelled.set(label.subtype, {
+        subtype: label.subtype,
+        residue: null,
+        taxonomy,
+        definition: subtypeDefinition(taxonomy, label.subtype),
+        title: subtypeTitle(label.subtype),
+        members: [member],
+      });
+    }
+  }
+  if (labelled.size < 2) return null;
+  const groups = [...labelled.values()];
+  for (const residue of ["not_in_taxonomy", "not_yet_classified"] as FunctionResidue[]) {
+    const held = residual.get(residue);
+    if (!held) continue;
+    groups.push({ subtype: null, residue, taxonomy: null, definition: null, title: FUNCTION_RESIDUE_COPY[residue].title, members: held });
+  }
+  return groups;
+}
+
+export function labelsNaming(offer: FunctionCarrier, subtype: string): SubtypeLabel[] {
+  return (offer.product_subtypes?.labels ?? []).filter(l => l.subtype === subtype);
+}

--- a/src/serve.ts
+++ b/src/serve.ts
@@ -76,8 +76,9 @@ import { eligibilityGateAsPublished, gatedShareDescriptionClause, gatedShareLede
 import { gateDisclosureFor } from "./gate-disclosure.js";
 import { verificationLedger, QUARANTINE_AFTER_FAILURES } from "./verification-state.js";
 import { partitionAlternatives, partitionSubstitutes, type SubstitutesPartition, productRoleSentence, MEMBERSHIP_GATE_RULES, MEMBERSHIP_GATE_ORDER, MEMBERSHIP_GATE_SYMMETRY, MEMBERSHIP_GATE_SCOPE, MEMBERSHIP_GATE_CORRECTIONS, SUBTYPE_TAXONOMIES, SUBTYPE_MEMBERSHIP_RULE, SUBTYPE_MEMBERSHIP_GROUP_SCOPE, CURATED_SUBTYPE_EXEMPTION, membershipGroupsFor, subtypeDefinition } from "./product-role.js";
+import { buildProductFunctions, functionMembers, functionDefinitions, admissionFor, splitByFunction, labelsNaming, FUNCTION_RESIDUE_COPY, type ProductFunction, FUNCTION_MEMBERSHIP_RULE, FUNCTION_SPLIT_RULE, FUNCTION_NAMING_RULE } from "./product-function.js";
 import { resolveCuratedAlternatives, curatedAlternativesFor, addCuratedToPool } from "./curated-alternatives.js";
-import type { Agent, ChangeDateSource, DealChange, RiskCause, RatingWithheld, LinkUnreachable, Offer, StabilityClass } from "./types.js";
+import type { Agent, ChangeDateSource, DealChange, RiskCause, RatingWithheld, LinkUnreachable, Offer, StabilityClass, SubtypeLabel } from "./types.js";
 import { changeDateLabel, changeEntryDateLabel, changeEntryLongDateLabel, changeDateClause, changeDatePublished, changeEventStartDate, capListSections, latestEventDate, offerExpiryAfter, feedEntryUpdated, undatedGroupHeading, UNDATED_TILE_LABEL, firstReadHeading, discoveryBatchNote, isoWeekOf, monthlyChangeSeries, changesInWindow, discoveryMonthSeriesHeading, periodComparisonSentence, DISCOVERED_DATE_PREFIX, EFFECTIVE_DATE_PREFIX, EVENT_DATED_SOURCES, UNDATED_GROUP_NOTE, UNKNOWN_EFFECTIVE_DATE_MARKER, EFFECTIVE_MONTH_SERIES_NOTE, DISCOVERY_MONTH_SERIES_NOTE, weekRangeLabel } from "./change-dates.js";
 import { changeFeedEntries, feedEntryFields, feedUpdatedTimestamp, changeFeedProvenanceNote, CHANGE_FEED_ENTRY_LIMIT, CHANGE_FEED_DESCRIPTION, CHANGE_FEED_NAMESPACE, CHANGE_FEED_NAMESPACE_PREFIX, channelUpdatedTimestamp, WEEKLY_FEED_POPULATION_NOTE, feedLinkTag, feedEntrySourceXml, digestSourceXml, PER_CHANGE_FEED, WEEKLY_DIGEST_FEED } from "./change-feed.js";
 import { FEED_CORRECTIONS, correctionEntriesXml } from "./feed-corrections.js";
@@ -2221,19 +2222,25 @@ ${globalNavCss()}
 
 const BEST_OF_MIN_VENDORS = 5;
 
-const bestOfSlugMap = new Map<string, { categoryName: string }>();
-for (const cat of categories) {
-  const catOffers = offers.filter((o) => o.category === cat.name && !o.eligibility);
-  if (catOffers.length < BEST_OF_MIN_VENDORS) continue;
-  bestOfSlugMap.set(`free-${toSlug(cat.name)}`, { categoryName: cat.name });
+const productFunctions = buildProductFunctions(categories.map(c => c.name));
+
+const bestOfSlugMap = new Map<string, ProductFunction>();
+for (const fn of productFunctions) {
+  const generallyAvailable = functionMembers(offers, fn).filter((o) => !o.eligibility);
+  if (generallyAvailable.length < BEST_OF_MIN_VENDORS) continue;
+  bestOfSlugMap.set(`free-${fn.slug}`, fn);
+}
+
+function functionSubject(fn: ProductFunction): string {
+  return fn.categories[0] ?? fn.subtypes[0];
 }
 
 type EnrichedOfferRow = ReturnType<typeof enrichOffers>[number];
 
-function rankCategory(categoryName: string, date = utcDate()): RankingResult<EnrichedOfferRow> {
-  const catOffers = enrichOffers(offers.filter((o) => o.category === categoryName));
-  return rankOffers(catOffers, {
-    queryKey: `best-of:${categoryName}`,
+function rankFunction(fn: ProductFunction, date = utcDate()): RankingResult<EnrichedOfferRow> {
+  const members = enrichOffers(functionMembers(offers, fn));
+  return rankOffers(members, {
+    queryKey: `best-of:${functionSubject(fn)}`,
     changes: dealChanges,
     date,
     verificationLedger: verificationLedger(),
@@ -2298,29 +2305,57 @@ function renderAuditBlock(tie: TieBreak, listed?: { shown: number; total: number
   </div>`;
 }
 
+const FUNCTION_LABEL_DATE_CLASS = "function-label-reviewed";
+
+function functionEvidenceHtml(offer: EnrichedOfferRow, labels: SubtypeLabel[], fn: ProductFunction): string {
+  if (labels.length === 0) return "";
+  const reviewed = offer.product_subtypes?.reviewed;
+  if (!reviewed) return "";
+  const named = labels.map(l => `<code>${escHtmlServer(l.subtype)}</code>`).join(" and ");
+  const lead = fn.categories.includes(offer.category)
+    ? `Labelled ${named}.`
+    : `Listed in <a href="/category/${toSlug(offer.category)}">${escHtmlServer(offer.category)}</a>, and on this page because we labelled it ${named}.`;
+  const read = readClauseHtml(
+    reviewed,
+    [...new Map(labels.map(l => [l.source_url, l])).values()].map(l => ({ url: l.source_url, quote: l.source_quote })),
+    escHtmlServer,
+    { dateClass: FUNCTION_LABEL_DATE_CLASS },
+  );
+  const clause = read === "" ? "" : ` ${read}.`;
+  return `\n          <p class="function-evidence">${lead}${clause} <a href="${CRITERIA_PATH}#subtypes">How we use this</a></p>`;
+}
+
 function buildBestOfPage(slug: string): string | null {
-  const entry = bestOfSlugMap.get(slug);
-  if (!entry) return null;
-  const { categoryName } = entry;
-  const ranking = rankCategory(categoryName);
+  const fn = bestOfSlugMap.get(slug);
+  if (!fn) return null;
+  const categoryName = fn.title;
+  const ranking = rankFunction(fn);
   const qualified = ranking.qualified;
   const demoted = ranking.demoted;
   const tie = ranking.tie_break;
   const year = new Date().getFullYear();
   const pickCount = qualified.length;
+  const groups = splitByFunction(qualified.map(e => e.offer), fn);
+  const definition = fn.categories.length === 0 ? functionDefinitions(fn).join("; or when it ") || null : null;
   const title = `Best Free ${categoryName} Tools (${year}) — AgentDeals`;
-  const metaDesc = `Every free ${categoryName.toLowerCase()} tier that clears our bar in ${year}: ${pickCount} offers meet the criteria and ${demoted.length} are demoted with a named reason. Verified pricing, recorded changes, and a published ranking method.`;
+  const metaDesc = definition
+    ? `Every free ${categoryName.toLowerCase()} tier that clears our bar in ${year}: ${pickCount} offers meet the criteria and ${demoted.length} are demoted with a named reason. We list a product here when it ${definition}.`
+    : `Every free ${categoryName.toLowerCase()} tier that clears our bar in ${year}: ${pickCount} offers meet the criteria and ${demoted.length} are demoted with a named reason. Verified pricing, recorded changes, and a published ranking method.`;
 
   const riskColors: Record<string, string> = { stable: "#3fb950", caution: "#d29922", risky: "#f85149" };
+  const pageScope = fn.categories.length === 1 && fn.subtypes.length === 0 ? "for this category" : "on this page";
 
-  const tiePara = pickCount > 1
-    ? `<strong>${pickCount} offers meet our criteria for this category and none is distinguishable from the others under any signal we record.</strong> They are listed in an order that rotates daily; <a href="${CRITERIA_PATH}">here is how that order is derived</a>. There is no top slot here to sell.`
-    : `<strong>${pickCount} offer meets our criteria for this category.</strong> <a href="${CRITERIA_PATH}">Here is how we decide</a>.`;
+  const tiePara = groups
+    ? `<strong>${pickCount} offers meet our criteria here, and they are not all alternatives to one another &mdash; they carry ${groups.filter(g => g.subtype).length} different labelled functions.</strong> ${escHtmlServer(FUNCTION_SPLIT_RULE)} Both the sections and the offers inside them are listed in an order that rotates daily; <a href="${CRITERIA_PATH}">here is how that order is derived</a>. There is no top slot here to sell.`
+    : pickCount > 1
+      ? `<strong>${pickCount} offers meet our criteria ${pageScope} and none is distinguishable from the others under any signal we record.</strong> They are listed in an order that rotates daily; <a href="${CRITERIA_PATH}">here is how that order is derived</a>. There is no top slot here to sell.`
+      : `<strong>${pickCount} offer meets our criteria ${pageScope}.</strong> <a href="${CRITERIA_PATH}">Here is how we decide</a>.`;
 
-  const renderCard = (e: RankedEntry<EnrichedOfferRow>, i: number, demotedCard: boolean) => {
+  const renderCard = (e: RankedEntry<EnrichedOfferRow>, i: number, demotedCard: boolean, labels?: SubtypeLabel[]) => {
     const o = e.offer;
     const riskBadge = riskBadgeHtml(o.risk_level, o.risk_cause);
     const review = buildBestOfMiniReview(o);
+    const cited = labels ?? admissionFor(o, fn)?.labels ?? [];
     const relatedCompareLinks = Array.from(comparisonMap.entries())
       .filter(([, [a, b]]) => a === o.vendor || b === o.vendor)
       .slice(0, 2)
@@ -2334,7 +2369,7 @@ function buildBestOfPage(slug: string): string | null {
             ${riskBadge}
           </div>
           <div class="best-pick-tier">${escHtmlServer(o.tier)}</div>
-          <p class="best-pick-review">${review}</p>
+          <p class="best-pick-review">${review}</p>${functionEvidenceHtml(o, cited, fn)}
           ${renderDemerits(e)}
           ${renderDisclosures(e)}
           <div class="best-pick-links">
@@ -2347,9 +2382,29 @@ function buildBestOfPage(slug: string): string | null {
       </div>`;
   };
 
-  const reviewsHtml = qualified.map((e, i) => renderCard(e, i, false)).join("\n");
+  const entryFor = new Map<EnrichedOfferRow, RankedEntry<EnrichedOfferRow>>(qualified.map(e => [e.offer, e]));
+  const renderedGroups = groups
+    ? rotateListing(groups.filter(g => g.subtype), tie.query_key, tie.date).concat(groups.filter(g => !g.subtype))
+    : null;
+  const reviewsHtml = renderedGroups
+    ? renderedGroups
+        .map(group => {
+          const cards = group.members
+            .map(o => entryFor.get(o))
+            .filter((e): e is RankedEntry<EnrichedOfferRow> => e !== undefined)
+            .map((e, i) => renderCard(e, i, false, group.subtype ? labelsNaming(e.offer, group.subtype) : []))
+            .join("\n");
+          const scope = group.subtype
+            ? `${group.members.length === 1 ? "1 offer here is" : `${group.members.length} offers here are`} labelled <code>${escHtmlServer(group.subtype)}</code>${group.definition ? ` &mdash; ${escHtmlServer(group.definition)}` : ""}.${group.members.length > 1 ? " None is distinguishable from the others in this group under any signal we record." : ""}`
+            : escHtmlServer(FUNCTION_RESIDUE_COPY[group.residue!].rule);
+          return `  <h2 class="function-group-heading" id="function-${escHtmlServer(toSlug(group.subtype ?? group.residue!))}">${escHtmlServer(group.title)}</h2>
+  <p class="function-group-scope">${scope}</p>
+${cards}`;
+        })
+        .join("\n")
+    : qualified.map((e, i) => renderCard(e, i, false)).join("\n");
   const demotedHtml = demoted.length === 0
-    ? `      <p style="color:var(--text-muted);font-size:.9rem">Nothing in this category is demoted today &mdash; we hold no disqualifying record against any of these offers.</p>`
+    ? `      <p style="color:var(--text-muted);font-size:.9rem">Nothing on this page is demoted today &mdash; we hold no disqualifying record against any of these offers.</p>`
     : demoted.map((e, i) => renderCard(e, i, true)).join("\n");
 
   const tableRows = qualified.map((e) => {
@@ -2363,31 +2418,56 @@ function buildBestOfPage(slug: string): string | null {
         </tr>`;
   }).join("\n");
 
-  const jsonLd = {
-    "@context": "https://schema.org",
-    "@type": "ItemList",
-    name: `Best Free ${categoryName} Tools`,
-    description: metaDesc,
-    numberOfItems: pickCount,
-    itemListElement: qualified.map((e, i) => ({
-      "@type": "ListItem",
-      position: i + 1,
-      item: {
-        "@type": "SoftwareApplication",
-        name: e.offer.vendor,
-        description: publishedTermsText(e.offer),
-        applicationCategory: categoryName,
-        offers: { "@type": "Offer", price: "0", priceCurrency: "USD", description: e.offer.tier },
-        ...(offerRetired(e.offer) ? {} : { url: e.offer.url }),
-      },
-    })),
-  };
+  const applicationOf = (offer: EnrichedOfferRow) => ({
+    "@type": "SoftwareApplication",
+    name: offer.vendor,
+    description: publishedTermsText(offer),
+    applicationCategory: offer.category,
+    offers: { "@type": "Offer", price: "0", priceCurrency: "USD", description: offer.tier },
+    ...(offerRetired(offer) ? {} : { url: offer.url }),
+  });
+
+  const listOf = (members: EnrichedOfferRow[]) =>
+    members.map((offer, i) => ({ "@type": "ListItem", position: i + 1, item: applicationOf(offer) }));
+
+  const jsonLd = renderedGroups
+    ? {
+        "@context": "https://schema.org",
+        "@type": "ItemList",
+        name: `Best Free ${categoryName} Tools`,
+        description: metaDesc,
+        numberOfItems: renderedGroups.length,
+        itemListElement: renderedGroups.map((group, i) => ({
+          "@type": "ListItem",
+          position: i + 1,
+          item: {
+            "@type": "ItemList",
+            name: group.title,
+            ...(group.definition ? { description: group.definition } : {}),
+            numberOfItems: group.members.length,
+            itemListElement: listOf(group.members),
+          },
+        })),
+      }
+    : {
+        "@context": "https://schema.org",
+        "@type": "ItemList",
+        name: `Best Free ${categoryName} Tools`,
+        description: metaDesc,
+        numberOfItems: pickCount,
+        itemListElement: listOf(qualified.map(e => e.offer)),
+      };
+
+  const categoryBrowseLinks = [...new Set(functionMembers(offers, fn).map(o => o.category))]
+    .sort()
+    .map(c => `<a href="/category/${toSlug(c)}">See all ${offers.filter(o => o.category === c).length} ${escHtmlServer(c.toLowerCase())} offers &rarr;</a>`)
+    .join(" ");
 
   const otherBestOf = Array.from(bestOfSlugMap.entries())
     .filter(([s]) => s !== slug)
-    .sort((a, b) => offers.filter(o => o.category === b[1].categoryName).length - offers.filter(o => o.category === a[1].categoryName).length)
+    .sort((a, b) => functionMembers(offers, b[1]).length - functionMembers(offers, a[1]).length)
     .slice(0, 10)
-    .map(([s, v]) => `<a href="/best/${s}" style="display:inline-block;padding:.25rem .7rem;border-radius:20px;font-size:.75rem;color:var(--text-muted);border:1px solid var(--border);text-decoration:none;transition:all .2s">${escHtmlServer(v.categoryName)}</a>`)
+    .map(([s, v]) => `<a href="/best/${s}" style="display:inline-block;padding:.25rem .7rem;border-radius:20px;font-size:.75rem;color:var(--text-muted);border:1px solid var(--border);text-decoration:none;transition:all .2s">${escHtmlServer(v.title)}</a>`)
     .join("\n        ");
 
   return `<!DOCTYPE html>
@@ -2448,6 +2528,11 @@ h2{font-family:var(--serif);font-size:1.4rem;color:var(--text);margin:2.5rem 0 1
 .best-disclosure{margin:.5rem 0;font-size:.78rem;color:var(--text-dim)}
 .best-disclosure-label{text-transform:uppercase;letter-spacing:.04em;font-size:.68rem}
 .best-disclosure ul{margin:.25rem 0 0 1rem}
+.function-evidence{margin:.4rem 0 .5rem;font-size:.8rem;color:var(--text-dim);border-left:2px solid var(--border);padding-left:.6rem}
+.function-evidence code{font-family:var(--mono);color:var(--text-muted)}
+.function-group-heading{margin:2.5rem 0 .25rem}
+.function-group-scope{color:var(--text-muted);font-size:.9rem;margin-bottom:1rem}
+.function-group-scope code{font-family:var(--mono);color:var(--text)}
 ${auditBlockCss()}
 footer{text-align:center;color:var(--text-dim);font-size:.8rem;padding:3rem 0 2rem;border-top:1px solid var(--border);margin-top:3rem}
 @media(max-width:768px){h1{font-size:1.5rem}.best-pick{flex-direction:column;gap:.5rem}.best-pick-rank{text-align:left}.compare-table{font-size:.75rem}.compare-table th,.compare-table td{padding:.4rem .5rem}}
@@ -2460,18 +2545,18 @@ ${mcpCtaCss()}
   ${buildGlobalNav("best")}
   <div class="breadcrumb"><a href="/">AgentDeals</a> &rsaquo; <a href="/best">Best Of</a> &rsaquo; ${escHtmlServer(categoryName)}</div>
   <h1>Best Free ${escHtmlServer(categoryName)} Tools</h1>
-  <p class="page-meta">Every free ${escHtmlServer(categoryName.toLowerCase())} tier that clears our bar today. Updated ${tie.date}.</p>
+  <p class="page-meta">Every free ${escHtmlServer(categoryName.toLowerCase())} tier that clears our bar today. Updated ${tie.date}.${definition ? ` We list a product here when it ${escHtmlServer(definition)}.` : ""}</p>
 
   <div class="tie-note">${tiePara}</div>
 
   <div class="trust-note">
-    <strong>Why trust this data?</strong> Every free tier is verified against the vendor's pricing page with dates tracked. We monitor ${trackedChangeCount} pricing changes and flag vendors that have reduced or removed free tiers. ${escHtmlServer(DEMOTE_ONLY_POLICY)} <a href="/category/${toSlug(categoryName)}">See all ${offers.filter(o => o.category === categoryName).length} ${categoryName.toLowerCase()} offers &rarr;</a>
+    <strong>Why trust this data?</strong> Every free tier is verified against the vendor's pricing page with dates tracked. We monitor ${trackedChangeCount} pricing changes and flag vendors that have reduced or removed free tiers. ${escHtmlServer(DEMOTE_ONLY_POLICY)} ${escHtmlServer(FUNCTION_MEMBERSHIP_RULE)} ${categoryBrowseLinks}
   </div>
 
 ${reviewsHtml}
 
   <h2>Demoted &mdash; and exactly why</h2>
-  <p class="page-meta" style="margin-bottom:1rem">These offers are in this category but rank below the list above. Each one names the recorded fact behind it. ${escHtmlServer(DISCLOSURE_RATIONALE)}</p>
+  <p class="page-meta" style="margin-bottom:1rem">These offers reach this page too and rank below the list above. Each one names the recorded fact behind it. ${escHtmlServer(DISCLOSURE_RATIONALE)}</p>
 ${demotedHtml}
 
 ${renderAuditBlock(tie)}
@@ -2509,24 +2594,21 @@ ${tableRows}
 function buildBestOfIndexPage(): string {
   const year = new Date().getFullYear();
   const bestOfCount = bestOfSlugMap.size;
+  const categoryPageCount = [...bestOfSlugMap.values()].filter(fn => fn.categories.length > 0).length;
   const title = `Best Free Developer Tools (${year}) — AgentDeals`;
-  const metaDesc = `Every free tier that clears our bar, across ${bestOfCount} developer tool categories. Offers are never promoted — only demoted, on a named recorded fact. The method is published.`;
+  const metaDesc = `Every free tier that clears our bar, across ${bestOfCount} developer tool functions. Offers are never promoted — only demoted, on a named recorded fact. The method is published.`;
 
   const sortedEntries = Array.from(bestOfSlugMap.entries())
-    .sort((a, b) => {
-      const countA = offers.filter(o => o.category === a[1].categoryName).length;
-      const countB = offers.filter(o => o.category === b[1].categoryName).length;
-      return countB - countA;
-    });
+    .sort((a, b) => functionMembers(offers, b[1]).length - functionMembers(offers, a[1]).length);
 
-  const cardsHtml = sortedEntries.map(([slug, entry]) => {
-    const totalInCat = offers.filter(o => o.category === entry.categoryName).length;
-    const ranking = rankCategory(entry.categoryName);
+  const cardsHtml = sortedEntries.map(([slug, fn]) => {
+    const total = functionMembers(offers, fn).length;
+    const ranking = rankFunction(fn);
     const topVendors = ranking.qualified.slice(0, 3).map(e => e.offer.vendor).join(", ");
     return `
       <a href="/best/${slug}" class="best-index-card">
-        <span class="best-index-name">${escHtmlServer(entry.categoryName)}</span>
-        <span class="best-index-picks">${ranking.qualified.length} qualify of ${totalInCat}</span>
+        <span class="best-index-name">${escHtmlServer(fn.title)}</span>
+        <span class="best-index-picks">${ranking.qualified.length} qualify of ${total}</span>
         <span class="best-index-vendors">${escHtmlServer(topVendors)}</span>
       </a>`;
   }).join("");
@@ -2582,7 +2664,7 @@ ${globalNavCss()}
   ${buildGlobalNav("best")}
   <div class="breadcrumb"><a href="/">AgentDeals</a> &rsaquo; Best Of</div>
   <h1>Best Free Developer Tools</h1>
-  <p class="page-meta">${bestOfCount} categories. Every free tier that clears our bar, with the demoted ones listed underneath and the reason named. <a href="${CRITERIA_PATH}">How we rank &rarr;</a></p>
+  <p class="page-meta">${bestOfCount} product functions, ${categoryPageCount} of them named after a category and ${bestOfCount - categoryPageCount} after a subtype label. Every free tier that clears our bar, with the demoted ones listed underneath and the reason named. <a href="${CRITERIA_PATH}">How we rank &rarr;</a></p>
 
   <div class="best-index-grid">${cardsHtml}
   </div>
@@ -2595,6 +2677,7 @@ ${globalNavCss()}
 
 interface BestOfTieSummary {
   bestOfPageCount: number;
+  categoryPageCount: number;
   categoriesWithUniqueTop: string[];
   meanTie: string;
 }
@@ -2603,14 +2686,17 @@ function summariseBestOfTies(date = utcDate()): BestOfTieSummary {
   const categoriesWithUniqueTop: string[] = [];
   let tieSum = 0;
   let bestOfPageCount = 0;
-  for (const [, { categoryName }] of bestOfSlugMap) {
-    const r = rankCategory(categoryName, date);
+  let categoryPageCount = 0;
+  for (const [, fn] of bestOfSlugMap) {
+    const r = rankFunction(fn, date);
     bestOfPageCount++;
+    if (fn.categories.length > 0) categoryPageCount++;
     tieSum += r.tie_break.tie_count;
-    if (r.tie_break.tie_count === 1) categoriesWithUniqueTop.push(categoryName);
+    if (r.tie_break.tie_count === 1) categoriesWithUniqueTop.push(fn.title);
   }
   return {
     bestOfPageCount,
+    categoryPageCount,
     categoriesWithUniqueTop,
     meanTie: bestOfPageCount > 0 ? (tieSum / bestOfPageCount).toFixed(1) : "0",
   };
@@ -2618,7 +2704,7 @@ function summariseBestOfTies(date = utcDate()): BestOfTieSummary {
 
 function uniqueTopClause(s: BestOfTieSummary): string {
   const found = s.categoriesWithUniqueTop;
-  const scope = `of the ${s.bestOfPageCount} categories with a best-of page`;
+  const scope = `of the ${s.bestOfPageCount} product functions with a best-of page`;
   const named = found.length === 0 ? "" : ` (${found.join(", ")})`;
   return `${found.length} ${scope} ${found.length === 1 ? "has" : "have"} a unique number one${named}`;
 }
@@ -2765,8 +2851,9 @@ ${demeritRows}
   <div class="callout">
     <strong>${uniqueTopClause(tieSummary).replace(/^0 /, "Zero ")}.</strong> ${categoriesWithUniqueTop.length === 0
       ? "Under every criterion we currently record, there is no single best free database, no best free AI/ML tool, no best free anything."
-      : "Everywhere else, under every criterion we currently record, there is no single best free tier of anything."} On average ${meanTie} offers tie at the top of those categories. The site publishes ${categories.length} categories in all; the ${categories.length - bestOfPageCount} with fewer than ${BEST_OF_MIN_VENDORS} generally-available offers have no best-of page and are not counted here.
+      : "Everywhere else, under every criterion we currently record, there is no single best free tier of anything."} On average ${meanTie} offers tie at the top of those pages. A best-of page is named after a product function: ${tieSummary.categoryPageCount} of the ${bestOfPageCount} are named after a category and the site publishes ${categories.length} categories in all, so the ${categories.length - tieSummary.categoryPageCount} with fewer than ${BEST_OF_MIN_VENDORS} generally-available offers have no best-of page and are not counted here. The remaining ${bestOfPageCount - tieSummary.categoryPageCount} are named after a subtype label.
   </div>
+  <p id="functions">${escHtmlServer(FUNCTION_NAMING_RULE)} ${escHtmlServer(FUNCTION_MEMBERSHIP_RULE)}</p>
   <p>We think that is the honest answer and a better thing to publish than a manufactured winner. It is also the strongest form of &ldquo;our recommendations are not for sale&rdquo;: there is no top slot, so there is nothing to buy. A vendor cannot improve its position by talking to us &mdash; only by improving its offer, or by us being able to verify it.</p>
 
   <h3>The tie-break</h3>
@@ -54845,8 +54932,12 @@ ${catList}
       xml += '  <url>\n    <loc>' + BASE_URL + '/category/' + toSlug(c.name) + '</loc>\n    <lastmod>' + catLastmod + '</lastmod>\n    <changefreq>weekly</changefreq>\n    <priority>0.8</priority>\n  </url>\n';
     }
     xml += '  <url>\n    <loc>' + BASE_URL + '/best</loc>\n    <lastmod>' + latestVerified + '</lastmod>\n    <changefreq>weekly</changefreq>\n    <priority>0.8</priority>\n  </url>\n';
-    for (const [s, { categoryName }] of bestOfSlugMap.entries()) {
-      const bestLastmod = categoryLastmod.get(toSlug(categoryName)) || now;
+    for (const [s, fn] of bestOfSlugMap.entries()) {
+      const memberStamps = [...new Set(functionMembers(offers, fn).map(o => toSlug(o.category)))]
+        .map(c => categoryLastmod.get(c))
+        .filter((v): v is string => Boolean(v))
+        .sort();
+      const bestLastmod = memberStamps.at(-1) || now;
       xml += '  <url>\n    <loc>' + BASE_URL + '/best/' + s + '</loc>\n    <lastmod>' + bestLastmod + '</lastmod>\n    <changefreq>weekly</changefreq>\n    <priority>0.8</priority>\n  </url>\n';
     }
     xml += '  <url>\n    <loc>' + BASE_URL + '/guides</loc>\n    <lastmod>' + pageLastmod("/guides") + '</lastmod>\n    <changefreq>weekly</changefreq>\n    <priority>0.9</priority>\n  </url>\n';

--- a/test/best-of-ranking.test.ts
+++ b/test/best-of-ranking.test.ts
@@ -49,13 +49,27 @@ describe("/best/:slug shows the whole qualified band", () => {
     assert.ok(cards > 8, `expected the full band, got ${cards} cards`);
   });
 
-  it("states the tie in plain language, above the list", async () => {
-    const { html } = await get("/best/free-databases");
+  it("states the tie in plain language, above the list, where the whole page is one set of alternatives", async () => {
+    const { html } = await get("/best/free-search");
     const tieNote = html.indexOf("offers meet our criteria for this category");
     const firstCard = html.indexOf('class="best-pick"');
     assert.ok(tieNote > -1, "the tie must be stated");
     assert.ok(tieNote < firstCard, "the tie must be stated above the list, not below it");
     assert.match(html, /none is distinguishable from the others under any signal we record/);
+    assert.match(html, /rotates daily/);
+  });
+
+  it("states the split, not the tie, where the page spans several labelled functions", async () => {
+    const { html } = await get("/best/free-databases");
+    const split = html.indexOf("not all alternatives to one another");
+    const firstCard = html.indexOf('class="best-pick"');
+    assert.ok(split > -1, "a page spanning several labelled functions must say so");
+    assert.ok(split < firstCard, "the split must be stated above the list, not below it");
+    assert.ok(
+      !/none is distinguishable from the others under any signal we record/.test(html.slice(0, firstCard)),
+      "a page spanning several labelled functions must not claim its whole membership is one set",
+    );
+    assert.match(html, /None is distinguishable from the others in this group under any signal we record/);
     assert.match(html, /rotates daily/);
   });
 
@@ -91,8 +105,19 @@ describe("/best/:slug shows the whole qualified band", () => {
     assert.strictEqual(queryKey, "best-of:Databases");
     const recomputed = createHash("sha256").update(`${date}|${queryKey}|p0`).digest("hex");
     assert.strictEqual(seed, recomputed, "a third party must be able to recompute the published seed");
-    const cards = (html.match(/class="best-pick"/g) ?? []).length;
-    assert.strictEqual(Number(tieCount), cards, "tie_count must equal the number of qualified entries shown");
+    const qualifiedSection = html.slice(0, html.indexOf("Demoted &mdash; and exactly why"));
+    const shown = new Set([...qualifiedSection.matchAll(/class="best-pick-name">([^<]+)</g)].map(m => m[1]));
+    assert.strictEqual(Number(tieCount), shown.size, "tie_count must equal the number of qualified entries shown");
+  });
+
+  it("publishes the same seed on a page named after a subtype label", async () => {
+    const { html } = await get("/best/free-uptime-check");
+    const date = html.match(/<dt>date<\/dt><dd>(\d{4}-\d{2}-\d{2})<\/dd>/)?.[1];
+    const queryKey = html.match(/<dt>query_key<\/dt><dd>([^<]+)<\/dd>/)?.[1];
+    const seed = html.match(/<dt>seed<\/dt><dd>([0-9a-f]{64})<\/dd>/)?.[1];
+    assert.ok(date && queryKey && seed, "the audit block must publish all four fields");
+    assert.strictEqual(queryKey, "best-of:uptime_check");
+    assert.strictEqual(seed, createHash("sha256").update(`${date}|${queryKey}|p0`).digest("hex"));
   });
 
   it("links the published criteria from the page", async () => {
@@ -101,11 +126,26 @@ describe("/best/:slug shows the whole qualified band", () => {
   });
 
   it("keeps the structured data consistent with what is rendered", async () => {
-    const { html } = await get("/best/free-databases");
+    const { html } = await get("/best/free-search");
     const jsonLd = JSON.parse(html.match(/<script type="application\/ld\+json">(\{"@context":"https:\/\/schema\.org","@type":"ItemList".*?)<\/script>/s)![1]);
     const cards = (html.match(/class="best-pick"/g) ?? []).length;
     assert.strictEqual(jsonLd.numberOfItems, cards);
     assert.strictEqual(jsonLd.itemListElement.length, cards);
+  });
+
+  it("describes a split page as a list of function lists, matching what is rendered", async () => {
+    const { html } = await get("/best/free-databases");
+    const jsonLd = JSON.parse(html.match(/<script type="application\/ld\+json">(\{"@context":"https:\/\/schema\.org","@type":"ItemList".*?)<\/script>/s)![1]);
+    const headings = [...html.matchAll(/<h2 class="function-group-heading"[^>]*>([^<]+)<\/h2>/g)].map(m => m[1]);
+    assert.ok(headings.length > 1, "/best/free-databases must render more than one function section");
+    assert.strictEqual(jsonLd.numberOfItems, headings.length);
+    assert.deepStrictEqual(jsonLd.itemListElement.map((e: { item: { name: string } }) => e.item.name), headings);
+    const nested = jsonLd.itemListElement.reduce((n: number, e: { item: { itemListElement: unknown[] } }) => n + e.item.itemListElement.length, 0);
+    assert.strictEqual(nested, (html.match(/class="best-pick"/g) ?? []).length);
+    for (const element of jsonLd.itemListElement) {
+      assert.strictEqual(element.item["@type"], "ItemList");
+      assert.strictEqual(element.item.numberOfItems, element.item.itemListElement.length);
+    }
   });
 });
 
@@ -162,9 +202,13 @@ describe("/criteria publishes the method", () => {
 
   it("publishes the finding rather than hiding it, and says what it counted", async () => {
     const { html } = await get("/criteria");
-    assert.match(html, /Zero of the \d+ categories with a best-of page have a unique number one/);
-    assert.match(html, /The site publishes \d+ categories in all/);
+    const finding = /(Zero|\d+) of the (\d+) product functions with a best-of page (?:has|have) a unique number one/.exec(html);
+    assert.ok(finding, "the finding must state how many pages it counted");
+    assert.match(html, /the site publishes \d+ categories in all/);
     assert.ok(!/of 57 categories have/.test(html), "57 counts best-of pages, and the site publishes more categories than that");
+    if (finding[1] !== "Zero") {
+      assert.match(html, /have a unique number one \([^)]+\)/, "a page with a unique number one must be named, not just counted");
+    }
   });
 
   it("says what we do not model", async () => {

--- a/test/product-function-pages.test.ts
+++ b/test/product-function-pages.test.ts
@@ -1,0 +1,411 @@
+import { describe, it, before, after } from "node:test";
+import assert from "node:assert";
+import { spawn, type ChildProcess } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { enrichOffers, gateForOffer, getCategories, loadDealChanges, loadOffers } from "../dist/data.js";
+import { toSlug } from "../dist/slug.js";
+import { SUBTYPE_TAXONOMIES } from "../dist/product-role.js";
+import {
+  buildProductFunctions,
+  functionKey,
+  functionMembers,
+  splitByFunction,
+  type ProductFunction,
+} from "../dist/product-function.js";
+import { rankOffers, rotateListing, tieBreakSeed } from "../dist/ranking.js";
+import { verificationLedger } from "../dist/verification-state.js";
+import type { Offer } from "../dist/types.js";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO = path.join(__dirname, "..");
+
+const offers = loadOffers();
+const categories = getCategories();
+const functions = buildProductFunctions(categories.map(c => c.name));
+const MIN_VENDORS = Number(/const BEST_OF_MIN_VENDORS = (\d+);/.exec(fs.readFileSync(path.join(REPO, "src", "serve.ts"), "utf8"))?.[1]);
+
+const published = functions.filter(fn => functionMembers(offers, fn).filter(o => !o.eligibility).length >= MIN_VENDORS);
+
+function rankedFor(fn: ProductFunction, date: string) {
+  return rankOffers(enrichOffers(functionMembers(offers, fn)), {
+    queryKey: `best-of:${fn.categories[0] ?? fn.subtypes[0]}`,
+    changes: loadDealChanges(),
+    date,
+    verificationLedger: verificationLedger(),
+  });
+}
+
+function reachesAPage(offer: Offer): boolean {
+  return gateForOffer(offer) === null;
+}
+
+function startServer(env: NodeJS.ProcessEnv = {}): Promise<{ child: ChildProcess; port: number }> {
+  return new Promise((resolve, reject) => {
+    const child = spawn("node", [path.join(REPO, "dist", "serve.js")], {
+      stdio: ["pipe", "pipe", "pipe"],
+      env: { ...process.env, PORT: "0", BASE_URL: "http://localhost", TZ: "UTC", ...env },
+    });
+    const timeout = setTimeout(() => { child.kill(); reject(new Error("Server startup timeout")); }, 60000);
+    child.stderr!.on("data", (data: Buffer) => {
+      const m = data.toString().match(/running on http:\/\/localhost:(\d+)/);
+      if (m) { clearTimeout(timeout); resolve({ child, port: parseInt(m[1], 10) }); }
+    });
+    child.on("error", (e) => { clearTimeout(timeout); reject(e); });
+  });
+}
+
+let server: ChildProcess;
+let port = 0;
+
+before(async () => { ({ child: server, port } = await startServer()); });
+after(() => { server?.kill(); });
+
+async function page(pathname: string, atPort = port): Promise<{ status: number; html: string }> {
+  const res = await fetch(`http://localhost:${atPort}${pathname}`, { redirect: "error" });
+  return { status: res.status, html: await res.text() };
+}
+
+const unescapeForTest = (s: string) =>
+  s.replace(/&amp;/g, "&").replace(/&#39;/g, "'").replace(/&quot;/g, '"').replace(/&lt;/g, "<").replace(/&gt;/g, ">");
+
+function vendorsListed(html: string): string[] {
+  return [...html.matchAll(/class="best-pick-name">([^<]*)</g)].map(m => unescapeForTest(m[1]));
+}
+
+function groupBlocks(html: string): { subtype: string; body: string }[] {
+  const blocks: { subtype: string; body: string }[] = [];
+  const headings = [...html.matchAll(/<h2 class="function-group-heading" id="function-([a-z0-9-]+)">/g)];
+  for (let i = 0; i < headings.length; i++) {
+    const start = headings[i].index!;
+    const end = i + 1 < headings.length ? headings[i + 1].index! : html.indexOf("<h2>Demoted", start);
+    blocks.push({ subtype: headings[i][1], body: html.slice(start, end) });
+  }
+  return blocks;
+}
+
+const escapeForTest = (s: string) => s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;");
+
+describe("a page named after a product function draws on both encodings of it", () => {
+  it("the threshold this sweep uses is the one the site publishes with", () => {
+    assert.ok(Number.isInteger(MIN_VENDORS) && MIN_VENDORS > 0, "src/serve.ts must state a minimum these sweeps can read");
+    assert.ok(published.length > categories.length - 20, `only ${published.length} functions clear the threshold`);
+  });
+
+  it("lists Sentry on the error tracking page, quoting the page the label was read from", async () => {
+    const sentry = offers.find(o => o.vendor === "Sentry");
+    assert.ok(sentry, "the catalogue holds no Sentry record, so this test asserts nothing");
+    assert.notStrictEqual(sentry!.category, "Error Tracking", "Sentry is filed under Error Tracking, so nothing here is under test");
+    const label = sentry!.product_subtypes?.labels.find(l => l.subtype === "error_tracking");
+    assert.ok(label, "Sentry carries no error_tracking label, so nothing here is under test");
+
+    const { status, html } = await page("/best/free-error-tracking");
+    assert.strictEqual(status, 200);
+    assert.ok(vendorsListed(html).includes("Sentry"), "/best/free-error-tracking does not list Sentry");
+    assert.ok(html.includes(escapeForTest(label!.source_quote)), "Sentry is listed without the words we read the label from");
+    assert.ok(html.includes(`href="${label!.source_url}"`), "Sentry is listed without a link to the page the label was read from");
+    assert.ok(html.includes(escapeForTest(sentry!.product_subtypes!.reviewed)), "Sentry is listed without the date the label was read");
+    assert.match(html, /on this page because we labelled it/, "the page does not say why a record filed elsewhere is present");
+    assert.ok(html.includes(`href="/category/${toSlug(sentry!.category)}"`), "the page does not name the category Sentry is filed under");
+  });
+
+  it("no function page leaves out a record we labelled with its function", async () => {
+    const missing: string[] = [];
+    for (const fn of published) {
+      if (fn.subtypes.length === 0) continue;
+      const { html } = await page(`/best/free-${fn.slug}`);
+      const listed = new Set(vendorsListed(html));
+      for (const offer of offers) {
+        if (!(offer.product_subtypes?.labels ?? []).some(l => fn.subtypes.includes(l.subtype))) continue;
+        if (!reachesAPage(offer)) continue;
+        if (!listed.has(offer.vendor)) missing.push(`${offer.vendor} (${offer.category}) is labelled for /best/free-${fn.slug} and is not on it`);
+      }
+    }
+    assert.deepStrictEqual(missing, []);
+  });
+
+  it("keeps every record its category already reached on the page", async () => {
+    const dropped: string[] = [];
+    for (const fn of published) {
+      if (fn.categories.length === 0) continue;
+      const { html } = await page(`/best/free-${fn.slug}`);
+      const listed = new Set(vendorsListed(html));
+      for (const offer of offers) {
+        if (!fn.categories.includes(offer.category)) continue;
+        if (!reachesAPage(offer)) continue;
+        if (!listed.has(offer.vendor)) dropped.push(`${offer.vendor} is filed under ${offer.category} and is absent from /best/free-${fn.slug}`);
+      }
+    }
+    assert.deepStrictEqual(dropped, []);
+  });
+
+  it("carries no record that neither encoding admits", async () => {
+    const strangers: string[] = [];
+    for (const fn of published) {
+      const { html } = await page(`/best/free-${fn.slug}`);
+      const admitted = new Set(functionMembers(offers, fn).map(o => o.vendor));
+      for (const vendor of new Set(vendorsListed(html))) {
+        if (!admitted.has(vendor)) strangers.push(`${vendor} is on /best/free-${fn.slug} and neither its category nor a label puts it there`);
+      }
+    }
+    assert.deepStrictEqual(strangers, []);
+  });
+});
+
+describe("two names are the same function only when they name the same thing", () => {
+  it("merges a category and a subtype that differ only by a plural", () => {
+    const errorTracking = functions.find(f => f.slug === "error-tracking");
+    assert.ok(errorTracking, "no function is named error-tracking");
+    assert.deepStrictEqual(errorTracking!.categories, ["Error Tracking"]);
+    assert.deepStrictEqual(errorTracking!.subtypes, ["error_tracking"]);
+
+    const statusPages = functions.find(f => f.slug === "status-pages");
+    assert.ok(statusPages, "no function is named status-pages");
+    assert.deepStrictEqual(statusPages!.categories, ["Status Pages"]);
+    assert.deepStrictEqual(statusPages!.subtypes, ["status_page"]);
+  });
+
+  it("refuses the three substring overlaps that are not the same function", () => {
+    const notMerged: [string, string][] = [
+      ["container_app", "Container Registry"],
+      ["host_metrics", "Cloud Hosting"],
+      ["document", "Documentation"],
+    ];
+    for (const [subtype, category] of notMerged) {
+      assert.notStrictEqual(functionKey(toSlug(subtype)), functionKey(toSlug(category)), `${subtype} and ${category} resolve to one function`);
+      const fn = functions.find(f => f.subtypes.includes(subtype));
+      assert.ok(fn, `${subtype} names no function`);
+      assert.ok(!fn!.categories.includes(category), `${subtype} was folded into ${category}`);
+    }
+  });
+
+  it("gives every function slug one owner", () => {
+    const seen = new Map<string, ProductFunction>();
+    for (const fn of functions) {
+      assert.ok(!seen.has(fn.slug), `two functions publish /best/free-${fn.slug}`);
+      seen.set(fn.slug, fn);
+    }
+  });
+
+  it("never folds two published categories onto one URL", () => {
+    for (const fn of functions) {
+      assert.ok(fn.categories.length <= 1, `/best/free-${fn.slug} would serve both ${fn.categories.join(" and ")}`);
+    }
+    const withPages = published.filter(fn => fn.categories.length === 1).map(fn => fn.categories[0]);
+    assert.strictEqual(new Set(withPages).size, withPages.length, "a category lost its own best-of URL");
+  });
+});
+
+describe("every function with enough vendors to compare has a page", () => {
+  it("publishes one for every subtype that clears the threshold", async () => {
+    const bySubtype = new Map<string, Offer[]>();
+    for (const offer of offers) {
+      for (const label of offer.product_subtypes?.labels ?? []) {
+        const held = bySubtype.get(label.subtype);
+        if (held) held.push(offer);
+        else bySubtype.set(label.subtype, [offer]);
+      }
+    }
+    const owed = [...bySubtype.entries()].filter(([, list]) => list.filter(o => !o.eligibility).length >= MIN_VENDORS);
+    assert.ok(owed.length >= 20, `only ${owed.length} subtypes clear the threshold, so this sweep is not measuring the backlog`);
+    for (const [subtype] of owed) {
+      const fn = functions.find(f => f.subtypes.includes(subtype));
+      assert.ok(fn, `${subtype} names no function`);
+      const { status } = await page(`/best/free-${fn!.slug}`);
+      assert.strictEqual(status, 200, `/best/free-${fn!.slug} answers ${status} for a subtype with ${bySubtype.get(subtype)!.length} vendors`);
+    }
+  });
+
+  it("puts every one of them in the sitemap and on the index", async () => {
+    const map = await page("/sitemap-pages.xml");
+    const index = await page("/best");
+    for (const fn of published) {
+      assert.ok(map.html.includes(`/best/${`free-${fn.slug}`}<`), `/best/free-${fn.slug} is in no sitemap`);
+      assert.ok(index.html.includes(`href="/best/free-${fn.slug}"`), `/best/free-${fn.slug} is unreachable from /best`);
+    }
+  });
+
+  it("states, for every record a label put there, the URL and the date it was read from", async () => {
+    for (const fn of published.filter(f => f.categories.length === 0)) {
+      const { html } = await page(`/best/free-${fn.slug}`);
+      const blocks = [...html.matchAll(/<div class="best-pick">[\s\S]*?<\/div>\s*<\/div>/g)].map(m => m[0]);
+      assert.ok(blocks.length > 0, `/best/free-${fn.slug} renders no cards`);
+      for (const block of blocks) {
+        const vendor = /class="best-pick-name">([^<]*)</.exec(block)?.[1];
+        const offer = offers.find(o => o.vendor === vendor);
+        if (!offer) continue;
+        const label = (offer.product_subtypes?.labels ?? []).find(l => fn.subtypes.includes(l.subtype));
+        if (!label) continue;
+        assert.ok(block.includes(`href="${label.source_url}"`), `${vendor} on /best/free-${fn.slug} cites no source URL for its label`);
+        assert.ok(block.includes(escapeForTest(offer.product_subtypes!.reviewed)), `${vendor} on /best/free-${fn.slug} states no date for its label`);
+        assert.ok(block.includes(escapeForTest(label.source_quote)), `${vendor} on /best/free-${fn.slug} states no words read from the page`);
+      }
+    }
+  });
+});
+
+describe("a page whose members span several functions separates them", () => {
+  it("stops asserting that a whole mixed category is one set of alternatives", async () => {
+    const { html } = await page("/best/free-monitoring");
+    const tieNote = /<div class="tie-note">([\s\S]*?)<\/div>/.exec(html)?.[1] ?? "";
+    assert.ok(tieNote.length > 0, "/best/free-monitoring states no scope at all");
+    assert.ok(
+      !/none is distinguishable from the others under any signal we record/.test(tieNote),
+      "/best/free-monitoring still asserts its whole membership is indistinguishable",
+    );
+    assert.match(tieNote, /not all alternatives to one another/);
+  });
+
+  it("puts each record under every function it is labelled with, and under nothing else", async () => {
+    let split = 0;
+    for (const fn of published) {
+      const { html } = await page(`/best/free-${fn.slug}`);
+      const date = /<dt>date<\/dt><dd>([^<]+)<\/dd>/.exec(html)![1];
+      const qualified = rankedFor(fn, date).qualified.map(e => e.offer);
+      const groups = splitByFunction(qualified, fn);
+      const blocks = groupBlocks(html);
+      if (!groups) {
+        assert.strictEqual(blocks.length, 0, `/best/free-${fn.slug} splits by function and should not`);
+        continue;
+      }
+      split++;
+      assert.strictEqual(blocks.length, groups.length, `/best/free-${fn.slug} spans ${groups.length} functions and renders ${blocks.length} sections`);
+      for (const block of blocks) {
+        const subtype = SUBTYPE_TAXONOMIES[fn.categories[0]]?.find(t => toSlug(t.subtype) === block.subtype)?.subtype;
+        if (!subtype) continue;
+        const carrying = new Set(qualified.filter(o => (o.product_subtypes?.labels ?? []).some(l => l.subtype === subtype)).map(o => o.vendor));
+        assert.deepStrictEqual(
+          [...new Set(vendorsListed(block.body))].sort(),
+          [...carrying].sort(),
+          `the ${subtype} section of /best/free-${fn.slug} is not the set of records carrying that label`,
+        );
+      }
+    }
+    assert.ok(split >= 4, `only ${split} pages span more than one labelled function, so this sweep is not measuring the split`);
+  });
+
+  it("makes the equivalence claim inside a group rather than over the page", async () => {
+    const { html } = await page("/best/free-monitoring");
+    for (const block of groupBlocks(html)) {
+      const scope = /<p class="function-group-scope">([\s\S]*?)<\/p>/.exec(block.body)?.[1] ?? "";
+      const cards = vendorsListed(block.body).length;
+      if (cards > 1 && /labelled <code>/.test(scope)) {
+        assert.match(scope, /None is distinguishable from the others in this group/, `the ${block.subtype} group makes no scoped equivalence claim`);
+      }
+      if (cards === 1) {
+        assert.ok(!/None is distinguishable/.test(scope), `the ${block.subtype} group claims an equivalence over one offer`);
+      }
+    }
+  });
+
+  it("lists a record that carries no label rather than dropping it", async () => {
+    let checked = 0;
+    for (const fn of published) {
+      const unlabelled = functionMembers(offers, fn).filter(o => (o.product_subtypes?.labels ?? []).length === 0 && reachesAPage(o));
+      if (unlabelled.length === 0) continue;
+      const { html } = await page(`/best/free-${fn.slug}`);
+      const listed = new Set(vendorsListed(html));
+      for (const offer of unlabelled) {
+        checked++;
+        assert.ok(listed.has(offer.vendor), `${offer.vendor} carries no label and is absent from /best/free-${fn.slug}`);
+      }
+    }
+    assert.ok(checked > 50, `only ${checked} unlabelled records were reachable, so this sweep is not measuring the guarantee`);
+  });
+});
+
+describe("grouping is not a ranking", () => {
+  it("orders the groups by the published seed and nothing else", async () => {
+    const { html } = await page("/best/free-monitoring");
+    const date = /<dt>date<\/dt><dd>([^<]+)<\/dd>/.exec(html)?.[1];
+    const queryKey = /<dt>query_key<\/dt><dd>([^<]+)<\/dd>/.exec(html)?.[1];
+    assert.ok(date && queryKey, "/best/free-monitoring publishes no seed inputs");
+    const fn = functions.find(f => f.slug === "monitoring")!;
+    const groups = splitByFunction(rankedFor(fn, date!).qualified.map(e => e.offer), fn)!;
+    const expected = rotateListing(groups.filter(g => g.subtype), queryKey!, date!)
+      .map(g => toSlug(g.subtype!))
+      .concat(groups.filter(g => !g.subtype).map(g => toSlug(g.residue!)));
+    assert.deepStrictEqual(groupBlocks(html).map(b => b.subtype), expected);
+    assert.ok(tieBreakSeed(date!, queryKey!, 0).length > 0);
+  });
+
+  it("keeps the demote-only policy and adds no top slot", async () => {
+    for (const slug of ["free-monitoring", "free-uptime-check", "free-error-tracking"]) {
+      const { html } = await page(`/best/${slug}`);
+      assert.match(html, /Rankings start every offer at zero and can only demote/, `/best/${slug} drops the demote-only policy`);
+      assert.match(html, /There is no top slot here to sell/, `/best/${slug} drops the no-top-slot statement`);
+      assert.ok(!/\bbest pick\b|\bwinner\b|\bnumber one\b|\btop pick\b/i.test(html), `/best/${slug} crowns an entry`);
+    }
+  });
+
+  it("moves no offer between the qualified and demoted bands", async () => {
+    const { html } = await page("/best/free-monitoring");
+    const demotedAt = html.indexOf("<h2>Demoted");
+    const qualified = new Set(vendorsListed(html.slice(0, demotedAt)));
+    const flat = await page("/best/free-status-pages");
+    assert.ok(qualified.size > 0 && vendorsListed(flat.html).length > 0);
+    const demoted = vendorsListed(html.slice(demotedAt));
+    for (const vendor of demoted) {
+      assert.ok(!qualified.has(vendor), `${vendor} is rendered both qualified and demoted on /best/free-monitoring`);
+    }
+  });
+});
+
+describe("membership is derived from the record, not written down per page", () => {
+  const perturbed = path.join(os.tmpdir(), `catalogue-relabelled-${process.pid}.json`);
+  let child: ChildProcess;
+  let relabelledPort = 0;
+  let movedIn: Offer | undefined;
+
+  before(async () => {
+    const rewritten = offers.map(o =>
+      o.vendor === "Sentry" && o.product_subtypes
+        ? { ...o, product_subtypes: { ...o.product_subtypes, labels: o.product_subtypes.labels.filter(l => l.subtype !== "error_tracking") } }
+        : o,
+    );
+    movedIn = rewritten.find(o => o.category === "Databases" && (o.product_subtypes?.labels ?? []).length > 0 && !o.eligibility);
+    assert.ok(movedIn, "no Databases record carries a label, so this test cannot move one");
+    const withNewLabel = rewritten.map(o =>
+      o === movedIn
+        ? { ...o, product_subtypes: { ...o.product_subtypes!, labels: [...o.product_subtypes!.labels, { subtype: "error_tracking", source_url: o.url, source_quote: "moved for this test" }] } }
+        : o,
+    );
+    fs.writeFileSync(perturbed, JSON.stringify({ offers: withNewLabel }));
+    ({ child, port: relabelledPort } = await startServer({ AGENTDEALS_INDEX_PATH: perturbed }));
+  });
+
+  after(() => {
+    child?.kill();
+    fs.rmSync(perturbed, { force: true });
+  });
+
+  it("withdraws a record from the page when its label is removed", async () => {
+    const { html } = await page("/best/free-error-tracking", relabelledPort);
+    assert.ok(!vendorsListed(html).includes("Sentry"), "Sentry survives on /best/free-error-tracking with no error_tracking label");
+  });
+
+  it("publishes a record on the page when a label is added, whatever its category", async () => {
+    const { html } = await page("/best/free-error-tracking", relabelledPort);
+    assert.ok(vendorsListed(html).includes(movedIn!.vendor), `${movedIn!.vendor} carries an error_tracking label and is not on the page`);
+    assert.ok(html.includes("moved for this test"), "the page does not quote the added label's source");
+  });
+
+  it("publishes a whole page for a label that reaches the threshold, and withdraws it when it does not", async () => {
+    const live = await page("/best/free-uptime-check");
+    assert.strictEqual(live.status, 200);
+    const stripped = path.join(os.tmpdir(), `catalogue-unlabelled-${process.pid}.json`);
+    fs.writeFileSync(stripped, JSON.stringify({
+      offers: offers.map(o => o.product_subtypes ? { ...o, product_subtypes: { ...o.product_subtypes, labels: o.product_subtypes.labels.filter(l => l.subtype !== "uptime_check") } } : o),
+    }));
+    const { child: withoutLabel, port: strippedPort } = await startServer({ AGENTDEALS_INDEX_PATH: stripped });
+    try {
+      const gone = await page("/best/free-uptime-check", strippedPort).catch(() => ({ status: 0, html: "" }));
+      assert.notStrictEqual(gone.status, 200, "/best/free-uptime-check still answers 200 with no record carrying the label");
+    } finally {
+      withoutLabel.kill();
+      fs.rmSync(stripped, { force: true });
+    }
+  });
+});

--- a/test/ranked-surfaces.test.ts
+++ b/test/ranked-surfaces.test.ts
@@ -341,12 +341,12 @@ describe("every ranked surface publishes the seed that ordered it", () => {
 
     const { text: criteria } = await get("/criteria");
     const claim = criteria.match(/<div class="callout">([\s\S]*?)<\/div>/)![1];
-    assert.match(claim, new RegExp(`of the ${slugs.length} categories with a best-of page`), "the denominator must be the number of best-of pages");
+    assert.match(claim, new RegExp(`of the ${slugs.length} product functions with a best-of page`), "the denominator must be the number of best-of pages");
     assert.match(claim, new RegExp(`${uniqueTop === 0 ? "Zero" : String(uniqueTop)} of the`), `the page must publish the ${uniqueTop} its own best-of pages add up to`);
     assert.ok(claim.includes(`${meanTie} offers tie at the top`), `the mean must be ${meanTie}, the mean of the published tie counts`);
 
     const { text: llms } = await get("/llms.txt");
-    assert.match(llms, new RegExp(`${uniqueTop} of the ${slugs.length} categories with a best-of page`), "llms.txt must carry the same figure and the same scope");
+    assert.match(llms, new RegExp(`${uniqueTop} of the ${slugs.length} product functions with a best-of page`), "llms.txt must carry the same figure and the same scope");
   });
 
   it("the vendor page says how much of the ranked order it is showing", async () => {

--- a/test/retired-ranking.test.ts
+++ b/test/retired-ranking.test.ts
@@ -204,7 +204,14 @@ describe("the best-of pages count what they list", () => {
       const lede = /<div class="tie-note">.*?<strong>(\d+) offers? meets? our criteria/s.exec(html);
       assert.ok(lede, `${p} has no count in its lede`);
       const cards = [...html.matchAll(/<div class="best-pick">/g)].length;
-      assert.strictEqual(Number(lede![1]), cards, `${p} ledes ${lede![1]} and renders ${cards} picks`);
+      const qualifiedSection = html.slice(0, html.indexOf("Demoted &mdash; and exactly why"));
+      const shown = new Set([...qualifiedSection.matchAll(/class="best-pick-name">([^<]+)</g)].map(m => m[1]));
+      if (html.includes('class="function-group-heading"')) {
+        assert.strictEqual(Number(lede![1]), shown.size, `${p} ledes ${lede![1]} and renders ${shown.size} distinct picks`);
+        assert.ok(cards >= shown.size, `${p} renders ${cards} cards for ${shown.size} picks`);
+      } else {
+        assert.strictEqual(Number(lede![1]), cards, `${p} ledes ${lede![1]} and renders ${cards} picks`);
+      }
       checked++;
     }
     assert.ok(checked >= categoriesWithAnEndedRecord.length, `only ${checked} best-of pages were checked`);


### PR DESCRIPTION
Refs #1476

`/best/free-error-tracking` drew on `category == 'Error Tracking'` and could not list Sentry, whose record carries `subtype: error_tracking` cited to `sentry.io/pricing` quoting "Errors 50K $0.00". Product function was encoded twice and every page keyed on the half that misses it.

A best-of page is now named after a **product function**, and a function is named by a category, by a subtype label, or by both. `src/product-function.ts` derives the registry from the live category list and `SUBTYPE_TAXONOMIES`. A record reaches a page when its category names the function or when it carries a label that names it. No page holds a list of vendors.

**80 best-of pages, up from 58** — 58 named after a category, 22 after a subtype label. 234 record-page pairs that did not exist before.

**AC-1.** `/best/free-error-tracking` lists Sentry, 17 qualified where it was 12. Its card reads *"Listed in Monitoring, and on this page because we labelled it `error_tracking`. We read that on 2026-09-01 from https://sentry.io/pricing/, where it says: 'Errors 50K $0.00'."*

**AC-2.** Membership is measured rather than declared. A server started against a catalogue with Sentry's `error_tracking` label removed drops Sentry from the page; adding that label to a Databases record publishes it there, quoting the added source; stripping `uptime_check` from every record takes `/best/free-uptime-check` off the site entirely.

**AC-3.** Every subtype with at least `BEST_OF_MIN_VENDORS` generally-available members has a page — 24, two of which a category already named. Each card on a subtype page states the URL the label was read from, the date, and the words on the page, through the same generator the vendor pages use.

**AC-4.** `/best/free-monitoring` no longer says its 55 members are indistinguishable. It states that they carry 13 labelled functions and lists them under each, with the definition and the equivalence claim scoped to the group. The structured data follows: an `ItemList` of 13 `ItemList`s, matching the rendered headings.

**AC-5.** Sections are ordered by `rotateListing` on the seed the page already publishes, so the order rotates daily and no function holds a top slot. The demote-only policy, the gates and the qualified/demoted split are untouched.

**AC-6.** A record carrying no label is listed in full, under one of two named sections: read against the category's subtypes with none applying, or not read against them yet.

Two names are the same function only when their slugs match once a trailing plural is dropped. That merges `error_tracking` with Error Tracking and `status_page` with Status Pages, and refuses the three substring overlaps the issue names — `container_app` is not the container registry category, `host_metrics` is not cloud hosting, `document` is not documentation. A test holds all five.

The `/criteria` finding moved with the change and is published as it fell out: **2 of the 80 pages now have a unique number one** (Agent Sandbox, Embeddings API, each 5 members with 4 demoted on named records), where the figure was 0 of 58. The page names them; `llms.txt` carries the same figure and scope.

22 tests added. 9 mutants, 9 killed. Four existing tests failed on a premise this supersedes — the whole-page equivalence sentence, `tie_count == card count`, the flat `ItemList`, and the `categories with a best-of page` scope — and are inverted rather than deleted, each keeping its original assertion on a page that still does not split.
